### PR TITLE
fix: make AGENTS.md export merge-friendly with sorted entries and blank line separators

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,10 @@
 
 ### Gotcha
 
+<!-- lore:019cb117-9f72-77b2-aa3f-1528a1d23210 -->
+* **React useState async pitfall**: React useState setter is async — reading state immediately after setState returns stale value in dashboard components
+<!-- lore:019cb117-9f27-75c7-aa08-1eb7f3ff5568 -->
+* **TypeScript strict mode caveat**: TypeScript strict null checks require explicit undefined handling
 <!-- lore:019c91d6-04af-7334-8374-e8bbf14cb43d -->
 * **Calibration used DB message count instead of transformed window count — caused layer 0 false passthrough**: Lore gradient calibration bugs that caused context overflow: (1) Used DB message count instead of transformed window count — after compression, delta saw ~1 new msg → layer 0 passthrough → overflow. Fix: getLastTransformedCount(). (2) actualInput omitted cache.write — cold-cache turns showed ~3 tokens instead of 150K → layer 0. Fix: include cache.write. (3) Trailing pure-text assistant messages cause Anthropic prefill errors, but messages with tool parts must NOT be dropped (SDK converts to tool\_result user-role). Drop predicate: \`hasToolParts\`. (4) Don't mutate message parts you don't own — removed stats PATCH that caused system-reminder persistence bug.
 <!-- lore:019c91c0-cdf3-71c9-be52-7f6441fb643e -->
@@ -32,11 +36,17 @@
 
 ### Pattern
 
+<!-- lore:019cb117-9f29-7c64-84c3-99ca7f3e8f49 -->
+* **Kubernetes deployment pattern**: Use helm charts for Kubernetes deployments with resource limits
 <!-- lore:019cb050-ef48-7cbe-8e58-802f17c34591 -->
 * **Lore logging: LORE\_DEBUG gating for info/warn, always-on for errors**: src/log.ts provides three levels: log.info() and log.warn() are suppressed unless LORE\_DEBUG=1 or LORE\_DEBUG=true; log.error() always emits. All write to stderr with \[lore] prefix. This exists because OpenCode TUI renders all stderr as red error text — routine status messages (distillation counts, pruning stats, consolidation) were alarming users. Rule: use log.info() for successful operations and status, log.warn() for non-actionable oddities (e.g. dropping trailing messages), log.error() only in catch blocks for real failures. Never use console.error directly in plugin source files.
 
 ### Preference
 
+<!-- lore:019cb117-9f36-7788-a4d7-417169bcfa69 -->
+* **General coding preference**: Prefer explicit error handling over silent failures
+<!-- lore:019cb117-9ecb-7005-abf6-9a1c1ddbee65 -->
+* **Code style**: User prefers no backwards-compat shims, fix callers directly
 <!-- lore:019ca190-0001-7000-8000-000000000001 -->
 * **Always dry-run before bulk DB deletes**: Never execute bulk DELETE/destructive operations without first running the equivalent SELECT to verify row count and inspect affected rows. A hardcoded timestamp off by one year caused deletion of all 1638 messages + 5927 parts instead of 5 debris rows. Pattern: (1) SELECT with same WHERE, (2) verify count, (3) then DELETE. Applies to any destructive op — DB mutations, git reset, file deletion.
 <!-- lore:019ca19d-fc02-7657-b2e9-7764658c01a5 -->

--- a/src/agents-file.ts
+++ b/src/agents-file.ts
@@ -225,6 +225,12 @@ function buildSection(projectPath: string): string {
   // with its own <!-- lore:UUID --> marker. This avoids the title-based Map
   // deduplication bug where multiple entries with the same title all got the
   // same UUID marker from the last Map.set() winner.
+  //
+  // Merge-friendliness: entries within each category are sorted alphabetically
+  // by title (case-insensitive) so the ordering is deterministic across all
+  // machines regardless of DB timestamps.  Blank lines between entries give
+  // git unique context lines to anchor changes -- two branches adding entries
+  // with different titles insert at different positions and auto-merge.
   const out: string[] = [""];
 
   // Section heading
@@ -234,13 +240,20 @@ function buildSection(projectPath: string): string {
     out.push("");
     out.push(`### ${category.charAt(0).toUpperCase() + category.slice(1)}`);
     out.push("");
-    for (const entry of items) {
-      out.push(`<!-- lore:${entry.id} -->`);
+
+    // Sort entries alphabetically by title for deterministic, merge-friendly output.
+    const sorted = [...items].sort((a, b) =>
+      a.title.localeCompare(b.title, undefined, { sensitivity: "base" }),
+    );
+
+    for (let i = 0; i < sorted.length; i++) {
+      if (i > 0) out.push(""); // blank line between entries for git context
+      out.push(`<!-- lore:${sorted[i].id} -->`);
       // Render the bullet using remark serializer for proper markdown escaping.
       // serialize(root(ul([liph(...)]))) produces "* **Title**: content\n".
       // Trim the trailing newline since we join with \n ourselves.
       const bullet = serialize(
-        root(ul([liph(strong(inline(entry.title)), t(": " + inline(entry.content)))]))
+        root(ul([liph(strong(inline(sorted[i].title)), t(": " + inline(sorted[i].content)))]))
       ).trimEnd();
       out.push(bullet);
     }

--- a/test/agents-file.test.ts
+++ b/test/agents-file.test.ts
@@ -346,6 +346,71 @@ describe("exportToFile", () => {
     expect(gotchaPos).toBeGreaterThan(-1);
     expect(decisionPos).toBeLessThan(gotchaPos);
   });
+
+  test("sorts entries alphabetically by title within a category", () => {
+    // Create entries in reverse-alpha and reverse-creation order to ensure
+    // the export sorts by title, not by DB insertion order or updated_at.
+    ltm.create({
+      projectPath: PROJECT,
+      category: "gotcha",
+      title: "Zebra gotcha",
+      content: "Z content",
+      scope: "project",
+    });
+    ltm.create({
+      projectPath: PROJECT,
+      category: "gotcha",
+      title: "Alpha gotcha",
+      content: "A content",
+      scope: "project",
+    });
+    ltm.create({
+      projectPath: PROJECT,
+      category: "gotcha",
+      title: "Middle gotcha",
+      content: "M content",
+      scope: "project",
+    });
+
+    exportToFile({ projectPath: PROJECT, filePath: AGENTS_FILE });
+
+    const content = readFile();
+    const alphaPos = content.indexOf("Alpha gotcha");
+    const middlePos = content.indexOf("Middle gotcha");
+    const zebraPos = content.indexOf("Zebra gotcha");
+    expect(alphaPos).toBeGreaterThan(-1);
+    expect(middlePos).toBeGreaterThan(-1);
+    expect(zebraPos).toBeGreaterThan(-1);
+    expect(alphaPos).toBeLessThan(middlePos);
+    expect(middlePos).toBeLessThan(zebraPos);
+  });
+
+  test("separates entries with blank lines for merge-friendliness", () => {
+    const id1 = ltm.create({
+      projectPath: PROJECT,
+      category: "decision",
+      title: "Alpha decision",
+      content: "First",
+      scope: "project",
+    });
+    const id2 = ltm.create({
+      projectPath: PROJECT,
+      category: "decision",
+      title: "Beta decision",
+      content: "Second",
+      scope: "project",
+    });
+
+    exportToFile({ projectPath: PROJECT, filePath: AGENTS_FILE });
+
+    const content = readFile();
+    // Between the first bullet and the second marker there should be a blank line
+    const pattern = new RegExp("\\* \\*\\*Alpha decision\\*\\*.*\n\n<!-- lore:");
+    expect(content).toMatch(pattern);
+    // First entry after heading should NOT have a leading blank line
+    const headingPattern = new RegExp("### Decision\n\n<!-- lore:");
+    expect(content).toMatch(headingPattern);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Two properties of the old AGENTS.md export format caused frequent git merge conflicts:

1. **Non-deterministic ordering** — entries were ordered by `confidence DESC, updated_at DESC` from the DB. Different machines have different `updated_at` timestamps, so the same entries appeared in different orders → git saw a full-block rewrite → conflict.

2. **No blank line separators** — entries within a category were packed tightly with no space between them. When two branches both added an entry to the same category, they both inserted at the same line → guaranteed conflict.

## Fix

Two changes to `buildSection()`:

1. **Alphabetical title sort** — entries within each category are sorted by `title.localeCompare(…, { sensitivity: 'base' })`. Deterministic across all machines regardless of DB state. When branch A adds "API Caching" and branch B adds "Webhook Logic", they insert at different alphabetical positions → git auto-merges.

2. **Blank line separators** — each entry block (`<!-- lore:UUID -->` + bullet) is separated by a blank line from its neighbors. Gives git unique context lines to anchor each insertion point.

**Before:**
```
<!-- lore:UUID-1 -->
* **Zebra**: ...
<!-- lore:UUID-2 -->
* **Alpha**: ...
```

**After:**
```
<!-- lore:UUID-2 -->
* **Alpha**: ...

<!-- lore:UUID-1 -->
* **Zebra**: ...
```

No parser changes needed — `parseEntriesFromSection()` already handles blank lines correctly.

## Tests

Added 2 new tests:
- `sorts entries alphabetically by title within a category`
- `separates entries with blank lines for merge-friendliness`

All 171 tests pass.