### PR TITLE
release: 0.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-lore",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "type": "module",
   "license": "MIT",
   "description": "Three-tier memory architecture for OpenCode — distillation, not summarization",


### PR DESCRIPTION
Release 0.5.2 — fix: make AGENTS.md export merge-friendly with sorted entries and blank line separators (#28)