### PR TITLE
fix: drop trailing pure-text assistant messages at layer 0 too

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,14 +28,29 @@
 <!-- lore:019c91d6-04af-7334-8374-e8bbf14cb43d -->
 * **Calibration used DB message count instead of transformed window count — caused layer 0 false passthrough**: Lore gradient calibration bugs that caused context overflow: (1) Used DB message count instead of transformed window count — after compression, delta saw ~1 new msg → layer 0 passthrough → overflow. Fix: getLastTransformedCount(). (2) actualInput omitted cache.write — cold-cache turns showed ~3 tokens instead of 150K → layer 0. Fix: include cache.write. (3) Trailing pure-text assistant messages cause Anthropic prefill errors, but messages with tool parts must NOT be dropped (SDK converts to tool\_result user-role). Drop predicate: \`hasToolParts\`. (4) Don't mutate message parts you don't own — removed stats PATCH that caused system-reminder persistence bug.
 
+<!-- lore:019cb171-c0ef-7335-9afd-e7874b507b77 -->
+* **hostapd -t is not a config dry-run — it adds timestamps to debug output**: hostapd v2.10's \`-t\` flag means 'include timestamps in debug messages', NOT syntax check or dry-run. Running \`hostapd -t \<conf>\` fully initialises the interface and hangs as a running AP. There is no built-in config validation flag in hostapd. For validation, use grep-based checks for known-bad directives (e.g. checking for ieee80211r when it's not compiled in) rather than invoking hostapd itself.
+
 <!-- lore:019c91c0-cdf3-71c9-be52-7f6441fb643e -->
 * **Lore plugin only protects projects where it's registered in opencode.json**: The lore gradient transform only runs for projects with lore registered in opencode.json (or globally in ~/.config/opencode/). Projects without it get zero context management — messages accumulate until overflow triggers a stuck compaction loop. This caused a 404K-token overflow in a getsentry/cli session with no opencode.json.
+
+<!-- lore:019cb171-c0ea-75cf-bf65-b081373f136b -->
+* **mt7921e 3dBm tx power on desktop — disable CLC firmware table**: mt7921e/mt7922 PCIe WiFi cards in desktop PCs (no ACPI SAR tables like WRDS/EWRD) get stuck at ~3 dBm tx power because the CLC (Country Location Code) firmware power lookup falls back to a conservative default when no SAR table exists. Fix: set \`options mt7921\_common disable\_clc=1\` in /etc/modprobe.d/mt7921.conf. This lets the regulatory domain ceiling apply (e.g. 23 dBm on 5GHz ch44 in GB). Also set explicit tx power via \`iw dev \<iface> set txpower fixed 2000\` in ExecStartPost since the module param only takes effect on next module load/reboot.
+
+<!-- lore:019cb171-c0fa-74b0-a9a6-847901efa907 -->
+* **Pixel phones fail WPA group key rekey during doze — use 86400s interval**: Android Pixel devices in deep doze/sleep fail to respond to WPA group key handshake frames within hostapd's retry window. With wpa\_group\_rekey=3600, the phone gets deauthenticated every hour ('group key handshake failed (RSN) after 4 tries'). Other devices on the same AP complete the rekey fine. Fix: set wpa\_group\_rekey=86400 (24h) instead of 0 (disabled) for security balance. Also apply to Asus router: nvram set wpa\_gtk\_rekey=86400, wl0\_wpa\_gtk\_rekey=86400, wl1\_wpa\_gtk\_rekey=86400.
 
 <!-- lore:019c91ad-4d47-7afc-90e0-239a9eda57a4 -->
 * **Stuck compaction loops leave orphaned user+assistant message pairs in DB**: When OpenCode compaction overflows, it creates paired user+assistant messages per retry (assistant has error.name:'ContextOverflowError', mode:'compaction'). These accumulate and worsen the session. Recovery: find last good assistant message (has tokens, no error), delete all messages after it from both \`message\` and \`part\` tables. Use json\_extract(data, '$.error.name') to identify compaction debris.
 
+<!-- lore:019cb171-c0fe-78a8-a5f8-4ae8e2980a70 -->
+* **sudo changes $HOME to /root — hardcode user home in scripts run with sudo**: When running a script with \`sudo\`, \`$HOME\` resolves to \`/root\`, not the invoking user's home. SSH key paths like \`$HOME/.ssh/id\_ed25519\` break. Fix: use \`SUDO\_USER\` env var: \`USER\_HOME=$(eval echo ~${SUDO\_USER:-$USER})\` and reference \`$USER\_HOME/.ssh/id\_ed25519\`. This is a common trap in scripts that need both root privileges (systemctl, writing to /etc) and user-specific resources (SSH keys).
+
 <!-- lore:019c8f4f-67ca-7212-a8c4-8a75b230ceea -->
 * **Test DB isolation via LORE\_DB\_PATH and Bun test preload**: Lore test suite uses an isolated temp DB via test/setup.ts preload (bunfig.toml). The preload sets LORE\_DB\_PATH to a mkdtempSync path before any test file imports src/db.ts, and the afterAll cleans up. src/db.ts checks LORE\_DB\_PATH first — if set, uses that exact path instead of ~/.local/share/opencode-lore/lore.db. agents-file.test.ts still needs beforeEach cleanup for intra-file isolation and TEST\_UUIDS cleanup in afterAll (shared explicit UUIDs with ltm.test.ts). Individual test files no longer need close() calls or cross-run cleanup beforeAll blocks — the preload handles DB lifecycle.
+
+<!-- lore:019cb171-c0f5-741f-96cc-e0862c846202 -->
+* **Ubuntu packaged hostapd lacks 802.11r (CONFIG\_IEEE80211R not compiled)**: Ubuntu 24.04's hostapd package (2:2.10-21ubuntu0.x) is compiled without CONFIG\_IEEE80211R. Using \`ieee80211r=1\`, \`mobility\_domain\`, \`ft\_over\_ds\`, \`r0kh\`, \`r1kh\`, or \`FT-PSK\` in wpa\_key\_mgmt causes 'unknown configuration item' errors and hostapd fails to start. 802.11k (rrm\_neighbor\_report, rrm\_beacon\_report) and 802.11v (bss\_transition) ARE compiled in and work. Verify with \`strings /usr/sbin/hostapd | grep ieee80211r\` — absence confirms no FT support. Building from source with CONFIG\_IEEE80211R=y is the only workaround.
 
 ### Pattern
 
@@ -44,6 +59,9 @@
 
 <!-- lore:019cb12a-c957-7e24-b3f5-6869f3429d13 -->
 * **Lore release process: craft + issue-label publish**: Release flow: (1) Create release/X.Y.Z branch, bump version in package.json, push and merge PR. (2) Trigger release.yml via workflow\_dispatch — uses getsentry/craft to create a GitHub issue titled 'publish: BYK/opencode-lore@X.Y.Z'. (3) Label that issue 'accepted' — triggers publish.yml (on issues:labeled) which runs craft publish with npm OIDC trusted publishing, then closes the issue. Auto-merge on release PRs requires squash merge (merge commits disallowed on this repo). The repo uses a GitHub App token (APP\_ID + APP\_PRIVATE\_KEY) for checkout in both workflows.
+
+<!-- lore:019cb200-0001-7000-8000-000000000001 -->
+* **PR workflow for opencode-lore: branch → PR → auto-merge**: All changes (including minor fixes and test-only changes) must go through a branch + PR + auto-merge, never pushed directly to main. Workflow: (1) git checkout -b \<type>/\<slug>, (2) commit, (3) git push -u origin HEAD, (4) gh pr create --title "..." --body "..." --base main, (5) gh pr merge --auto --squash \<PR#>. Branch name conventions follow merged PR history: fix/\<slug>, feat/\<slug>, chore/\<slug>. Auto-merge with squash is required (merge commits disallowed). Never push directly to main even for trivial changes.
 
 ### Preference
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -481,41 +481,49 @@ export const LorePlugin: Plugin = async (ctx) => {
         sessionID,
       });
 
+      // The API requires the conversation to end with a user message.
+      // Drop trailing pure-text assistant messages (no tool parts), which would
+      // cause an Anthropic "does not support assistant message prefill" error.
+      // This must run at ALL layers, including layer 0 (passthrough) — the error
+      // can occur even when messages fit within the context budget.
+      //
+      // Crucially, assistant messages that contain tool parts (completed OR pending)
+      // must NOT be dropped:
+      // - Completed tool parts: OpenCode's SDK converts these into tool_result blocks
+      //   sent as user-role messages at the API level. The conversation already ends
+      //   with a user message — dropping would strip the entire current agentic turn
+      //   and cause an infinite tool-call loop (the model restarts from scratch).
+      // - Pending tool parts: the tool call hasn't returned yet; dropping would make
+      //   the model re-issue the same tool call on the next turn.
+      //
+      // Note: at layer 0, result.messages === output.messages (same reference), so
+      // mutating result.messages here also trims output.messages in place — which is
+      // safe for prompt caching since we only ever remove trailing messages, never
+      // reorder or insert.
+      while (
+        result.messages.length > 0 &&
+        result.messages.at(-1)!.info.role !== "user"
+      ) {
+        const last = result.messages.at(-1)!;
+        const hasToolParts = last.parts.some((p) => p.type === "tool");
+        if (hasToolParts) {
+          // Tool parts → tool_result (user-role) at the API level → no prefill error.
+          // Stop dropping; the conversation ends correctly as-is.
+          break;
+        }
+        const dropped = result.messages.pop()!;
+        log.warn(
+          "dropping trailing pure-text",
+          dropped.info.role,
+          "message to prevent prefill error. id:",
+          dropped.info.id,
+        );
+      }
+
       // Only restructure messages when the gradient transform is active (layers 1-4).
       // Layer 0 means all messages fit within the context budget — leave them alone
       // so the append-only sequence stays intact for prompt caching.
       if (result.layer > 0) {
-        // The API requires the conversation to end with a user message.
-        // Drop trailing pure-text assistant messages (no tool parts), which would
-        // cause an Anthropic "does not support assistant message prefill" error.
-        //
-        // Crucially, assistant messages that contain tool parts (completed OR pending)
-        // must NOT be dropped:
-        // - Completed tool parts: OpenCode's SDK converts these into tool_result blocks
-        //   sent as user-role messages at the API level. The conversation already ends
-        //   with a user message — dropping would strip the entire current agentic turn
-        //   and cause an infinite tool-call loop (the model restarts from scratch).
-        // - Pending tool parts: the tool call hasn't returned yet; dropping would make
-        //   the model re-issue the same tool call on the next turn.
-        while (
-          result.messages.length > 0 &&
-          result.messages.at(-1)!.info.role !== "user"
-        ) {
-          const last = result.messages.at(-1)!;
-          const hasToolParts = last.parts.some((p) => p.type === "tool");
-          if (hasToolParts) {
-            // Tool parts → tool_result (user-role) at the API level → no prefill error.
-            // Stop dropping; the conversation ends correctly as-is.
-            break;
-          }
-          const dropped = result.messages.pop()!;
-          log.warn(
-            "dropping trailing pure-text",
-            dropped.info.role,
-            "message to prevent prefill error. id:",
-            dropped.info.id,
-          );
-        }
         output.messages.splice(0, output.messages.length, ...result.messages);
       }
 

--- a/test/gradient.test.ts
+++ b/test/gradient.test.ts
@@ -753,6 +753,88 @@ function makeStepWithTool(
   };
 }
 
+// ---------------------------------------------------------------------------
+// Layer 0 trailing-drop: pure-text trailing assistant messages must be dropped
+// even when gradient is not active (layer 0 passthrough). This is the fix for
+// the "does not support assistant message prefill" error that recurred on small
+// sessions. The hook in index.ts now runs the drop loop unconditionally, before
+// the layer > 0 guard. At layer 0, result.messages === output.messages (same
+// reference), so mutating it in place trims output.messages too.
+// ---------------------------------------------------------------------------
+
+describe("gradient — layer 0 trailing assistant message drop (index.ts prefill fix)", () => {
+  const SESSION = "layer0-drop-sess";
+
+  beforeEach(() => {
+    resetCalibration();
+    resetPrefixCache();
+    resetRawWindowCache();
+    setModelLimits({ context: 200_000, output: 32_000 });
+    calibrate(0);
+    ensureProject(PROJECT);
+  });
+
+  test("transform returns layer 0 for a small session ending with trailing assistant message", () => {
+    // Tiny session — well within context budget, must be layer 0.
+    const msgs = [
+      makeMsg("l0-u1", "user", "hello", SESSION),
+      makeMsg("l0-a1", "assistant", "hi there", SESSION),
+      makeMsg("l0-u2", "user", "thanks", SESSION),
+      makeMsg("l0-a2", "assistant", "no problem", SESSION), // trailing pure-text — prefill error
+    ];
+
+    const result = transform({ messages: msgs, projectPath: PROJECT, sessionID: SESSION });
+
+    // Must be layer 0 — tiny messages easily fit
+    expect(result.layer).toBe(0);
+
+    // result.messages is the same reference as the input array at layer 0.
+    // The hook's drop loop mutates this in place. Simulate what the hook does:
+    while (result.messages.length > 0) {
+      const last = result.messages[result.messages.length - 1]!;
+      if (last.info.role === "user") break;
+      const hasToolParts = last.parts.some((p) => p.type === "tool");
+      if (hasToolParts) break;
+      result.messages.pop();
+    }
+
+    // After drop: last message must be user-role
+    const afterLast = result.messages[result.messages.length - 1]!;
+    expect(afterLast.info.role).toBe("user");
+    expect(afterLast.info.id).toBe("l0-u2");
+    // And since result.messages === msgs at layer 0, msgs is also trimmed
+    expect(msgs[msgs.length - 1]!.info.id).toBe("l0-u2");
+  });
+
+  test("tool-bearing trailing assistant message at layer 0 is preserved (no infinite tool loop)", () => {
+    // Same tiny session, but last message has a tool part.
+    // Must NOT be dropped — tool parts produce user-role tool_result at the API level.
+    const msgs = [
+      makeMsg("l0t-u1", "user", "run the build", SESSION),
+      makeStepWithTool("l0t-a1", "l0t-u1", "bash", "ok", SESSION), // trailing tool-bearing
+    ];
+
+    const result = transform({ messages: msgs, projectPath: PROJECT, sessionID: SESSION });
+
+    // Must be layer 0 — tiny messages
+    expect(result.layer).toBe(0);
+
+    // Simulate the hook's drop loop — must stop immediately at tool-bearing message
+    const beforeLen = result.messages.length;
+    while (result.messages.length > 0) {
+      const last = result.messages[result.messages.length - 1]!;
+      if (last.info.role === "user") break;
+      const hasToolParts = last.parts.some((p) => p.type === "tool");
+      if (hasToolParts) break;
+      result.messages.pop();
+    }
+
+    // Nothing dropped — length unchanged
+    expect(result.messages.length).toBe(beforeLen);
+    expect(result.messages[result.messages.length - 1]!.info.id).toBe("l0t-a1");
+  });
+});
+
 describe("gradient — tool-bearing steps survive compression (index.ts trailing-drop fix)", () => {
   const SESSION = "tool-drop-sess";
 


### PR DESCRIPTION
## Summary

- The `"does not support assistant message prefill"` error was recurring on small/early sessions where the gradient was at layer 0 (passthrough)
- The trailing assistant message drop loop was inside the `if (result.layer > 0)` guard, so it never ran at layer 0
- Move the drop loop unconditionally before the guard; at layer 0 `result.messages === output.messages` (same array reference), so `pop()` trims the output in place without disturbing prompt caching
- The `hasToolParts` guard that prevents infinite tool-call loops is completely unchanged and still stops the drop for any tool-bearing assistant message