### PR TITLE
fix: prevent EROFS crash when launched outside a git repo

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import type { Plugin, Hooks } from "@opencode-ai/plugin";
+import { join } from "path";
 import { load, config } from "./config";
 import { ensureProject, isFirstRun } from "./db";
 import * as temporal from "./temporal";
@@ -67,6 +68,14 @@ export function buildRecoveryMessage(
   ].join("\n");
 }
 
+/**
+ * Check whether a project path is valid for file operations (e.g. AGENTS.md export/import).
+ * Returns false for root ("/"), empty, or falsy paths to prevent writing to the filesystem root.
+ */
+export function isValidProjectPath(p: string): boolean {
+  return !!p && p !== "/";
+}
+
 export const LorePlugin: Plugin = async (ctx) => {
   const projectPath = ctx.worktree || ctx.directory;
   try {
@@ -88,8 +97,8 @@ export const LorePlugin: Plugin = async (ctx) => {
   // (hand-written entries, edits from other machines, or merge conflicts).
   {
     const cfg = config();
-    if (cfg.knowledge.enabled && cfg.agentsFile.enabled) {
-      const filePath = `${projectPath}/${cfg.agentsFile.path}`;
+    if (isValidProjectPath(projectPath) && cfg.knowledge.enabled && cfg.agentsFile.enabled) {
+      const filePath = join(projectPath, cfg.agentsFile.path);
       if (shouldImport({ projectPath, filePath })) {
         try {
           importFromFile({ projectPath, filePath });
@@ -424,8 +433,8 @@ export const LorePlugin: Plugin = async (ctx) => {
         // Export curated knowledge to AGENTS.md after distillation + curation.
         try {
           const agentsCfg = cfg.agentsFile;
-          if (cfg.knowledge.enabled && agentsCfg.enabled) {
-            const filePath = `${projectPath}/${agentsCfg.path}`;
+          if (isValidProjectPath(projectPath) && cfg.knowledge.enabled && agentsCfg.enabled) {
+            const filePath = join(projectPath, agentsCfg.path);
             exportToFile({ projectPath, filePath });
           }
         } catch (e) {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach } from "bun:test";
-import { isContextOverflow, buildRecoveryMessage, LorePlugin } from "../src/index";
+import { isContextOverflow, buildRecoveryMessage, LorePlugin, isValidProjectPath } from "../src/index";
 import * as ltm from "../src/ltm";
 import type { Plugin } from "@opencode-ai/plugin";
 
@@ -620,5 +620,47 @@ describe("LTM session cache", () => {
     } finally {
       cleanup();
     }
+  });
+});
+
+// ── isValidProjectPath tests ─────────────────────────────────────────
+
+describe("isValidProjectPath", () => {
+  test("returns false for root path '/'", () => {
+    expect(isValidProjectPath("/")).toBe(false);
+  });
+
+  test("returns false for empty string", () => {
+    expect(isValidProjectPath("")).toBe(false);
+  });
+
+  test("returns true for a normal project path", () => {
+    expect(isValidProjectPath("/home/user/project")).toBe(true);
+  });
+
+  test("returns true for a relative path", () => {
+    expect(isValidProjectPath("./my-project")).toBe(true);
+  });
+});
+
+// ── Plugin with invalid project path ─────────────────────────────────
+
+describe("LorePlugin — invalid project path", () => {
+  test("initializes without crashing when projectPath is '/'", async () => {
+    const { client } = createMockClient();
+
+    // Simulate launching outside a git repo: no worktree, directory is "/"
+    const hooks = await LorePlugin({
+      client,
+      project: { id: "test", path: "/" } as any,
+      directory: "/",
+      worktree: "",
+      serverUrl: new URL("http://localhost:0"),
+      $: {} as any,
+    });
+
+    // Plugin should return hooks without crashing
+    expect(hooks).toBeTruthy();
+    expect(hooks.event).toBeDefined();
   });
 });


### PR DESCRIPTION
Fixes #25

## Problem

When OpenCode is launched from a directory that is not a git repository (e.g. the user's home directory), the lore plugin crashes with an `EROFS: read-only file system` error trying to write to `//AGENTS.md`.

The root cause: `projectPath` resolves to `/` when there is no git worktree and `ctx.directory` is the filesystem root. The template literal `${projectPath}/${cfg.agentsFile.path}` then produces `//AGENTS.md`, and `mkdirSync(dirname("//AGENTS.md"))` attempts to write to the system root — which is read-only on macOS (EROFS).

## Fix

1. **Add `isValidProjectPath()` guard** — returns `false` for root (`/`), empty, or falsy paths. Guards both the import (startup) and export (session.idle) code paths to prevent any filesystem operations on invalid project paths.

2. **Use `path.join()` instead of template literal concatenation** — replaces `\`${projectPath}/${path}\`` with `join(projectPath, path)` for proper path construction. This is a defense-in-depth measure that normalizes paths correctly.

## Changes

- `src/index.ts`: Added `isValidProjectPath()` export, guarded both agents-file blocks, switched to `join()`
- `test/index.test.ts`: Added unit tests for `isValidProjectPath` and integration test verifying plugin initializes without crashing when `projectPath` is `/`