### PR TITLE
fix: switch publish workflow to Node 24, drop broken npm upgrade step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,12 +47,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
-
-      - name: Upgrade npm for OIDC trusted publishing
-        run: |
-          npm install -g npm@latest
-          npm --version
+          node-version: 24
 
       - name: Install Craft
         run: |


### PR DESCRIPTION
## Summary

- Switch `actions/setup-node` from Node 22 to Node 24
- Remove the `npm install -g npm@latest` step entirely

Node 24 bundles npm 11+ which has OIDC trusted publishing support built-in. The npm upgrade step was failing on every publish attempt due to a broken `promise-retry` module in the GitHub Actions Node 22.22.2 toolcache — this has blocked the 0.8.0 release.