### PR TITLE
build: rename opencode-lore to @loreai/opencode with legacy mirror

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -9,11 +9,22 @@ artifactProvider:
     artifacts:
       CI: npm-tarball
 targets:
-  # Discover all public workspace packages and publish each as its own npm
-  # target in dependency order (@loreai/core first, then opencode-lore + @loreai/pi
-  # which depend on it). Craft filters out the private monorepo root automatically.
+  # Publish the 3 workspace packages (@loreai/core, @loreai/opencode, @loreai/pi).
+  # Craft discovers these from the root package.json `workspaces` field and
+  # auto-generates per-package targets with `includeNames` set to the default
+  # artifact regex (e.g. `/^loreai-opencode-\d.*\.tgz$/`).
   - name: npm
     access: public
     oidc: true
     workspaces: true
+  # Mirror @loreai/opencode as the legacy `opencode-lore` package name.
+  # The CI pack step produces `opencode-lore-<version>.tgz` with identical
+  # content to `loreai-opencode-<version>.tgz` but a different `name` in
+  # package.json. This is a non-workspace target so Craft doesn't try to
+  # auto-discover it — we scope it with `includeNames`.
+  - name: npm
+    id: opencode-lore
+    access: public
+    oidc: true
+    includeNames: /^opencode-lore-\d.*\.tgz$/
   - name: github

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,12 +35,16 @@ jobs:
 
       # Pack each workspace package into its own tarball. Craft's npm target
       # with `workspaces: true` discovers all three and publishes them in
-      # dependency order (@loreai/core → opencode-lore + @loreai/pi).
+      # dependency order (@loreai/core → @loreai/opencode + @loreai/pi).
       #
       # We use `bun pm pack` (not `npm pack`) because Bun automatically rewrites
       # `workspace:*` dependency specifiers to the actual version being packed.
       # `npm pack` leaves the literal "workspace:*" in the tarball's
       # package.json which breaks installs.
+      #
+      # We also mirror @loreai/opencode → opencode-lore by repacking with the
+      # package name swapped. Both tarballs have identical content; the two
+      # names are published in parallel so existing users keep working.
       - name: Pack tarballs
         if: startsWith(github.ref, 'refs/heads/release/')
         run: |
@@ -49,7 +53,24 @@ jobs:
             echo "Packing $pkg"
             (cd "$pkg" && bun pm pack --destination ../../dist-tarballs)
           done
+
+          # Mirror @loreai/opencode as opencode-lore (legacy alias).
+          # Extract the tarball, swap the package name in package.json, repack.
+          version=$(jq -r '.version' packages/opencode/package.json)
+          mirror_dir=$(mktemp -d)
+          tar -xzf "dist-tarballs/loreai-opencode-${version}.tgz" -C "$mirror_dir"
+          jq '.name = "opencode-lore"' "$mirror_dir/package/package.json" > "$mirror_dir/package/package.json.tmp"
+          mv "$mirror_dir/package/package.json.tmp" "$mirror_dir/package/package.json"
+          (cd "$mirror_dir" && tar -czf "$GITHUB_WORKSPACE/dist-tarballs/opencode-lore-${version}.tgz" package)
+          rm -rf "$mirror_dir"
+
+          echo "--- Final tarballs: ---"
           ls -la dist-tarballs/
+          echo "--- Package name in each: ---"
+          for t in dist-tarballs/*.tgz; do
+            name=$(tar -xzOf "$t" package/package.json | jq -r '.name')
+            echo "$(basename "$t") → $name"
+          done
 
       - name: Upload tarballs
         if: startsWith(github.ref, 'refs/heads/release/')

--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ Lore is published as three packages, all sharing the same SQLite database at `~/
 
 | Package | For | Install |
 |---|---|---|
-| [`opencode-lore`](https://www.npmjs.com/package/opencode-lore) | [OpenCode](https://opencode.ai) plugin | Add to `opencode.json` `plugin` array |
+| [`@loreai/opencode`](https://www.npmjs.com/package/@loreai/opencode) | [OpenCode](https://opencode.ai) plugin | Add to `opencode.json` `plugin` array |
 | [`@loreai/pi`](https://www.npmjs.com/package/@loreai/pi) | [Pi coding-agent](https://github.com/badlogic/pi-mono) extension | `pi install npm:@loreai/pi` |
 | [`@loreai/core`](https://www.npmjs.com/package/@loreai/core) | Shared memory engine | Dependency of the host packages above |
+
+The OpenCode plugin is also published as [`opencode-lore`](https://www.npmjs.com/package/opencode-lore) (legacy alias). Both names contain identical code at every release — use whichever you prefer.
 
 Because all three share the same database, switching between OpenCode and Pi on the same project preserves the curated knowledge, distillations, and AGENTS.md sync.
 
@@ -94,17 +96,17 @@ This plugin was built in a few intense sessions. Some highlights:
 
 ### OpenCode
 
-Add `opencode-lore` to the `plugin` array in your project's `opencode.json`:
+Add `@loreai/opencode` to the `plugin` array in your project's `opencode.json`:
 
 ```json
 {
   "plugin": [
-    "opencode-lore"
+    "@loreai/opencode"
   ]
 }
 ```
 
-Restart OpenCode and the plugin will be installed automatically.
+Restart OpenCode and the plugin will be installed automatically. The legacy name `opencode-lore` still works if you have an existing setup.
 
 ### Pi
 

--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
       },
     },
     "packages/opencode": {
-      "name": "opencode-lore",
+      "name": "@loreai/opencode",
       "version": "0.9.1",
       "dependencies": {
         "@loreai/core": "workspace:*",
@@ -183,6 +183,8 @@
     "@google/genai": ["@google/genai@1.50.1", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-YbkX7H9+1Pt8wOt7DDREy8XSoiL6fRDzZQRyaVBarFf8MR3zHGqVdvM4cLbDXqPhxqvegZShgfxb8kw9C7YhAQ=="],
 
     "@loreai/core": ["@loreai/core@workspace:packages/core"],
+
+    "@loreai/opencode": ["@loreai/opencode@workspace:packages/opencode"],
 
     "@loreai/pi": ["@loreai/pi@workspace:packages/pi"],
 
@@ -593,8 +595,6 @@
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "openai": ["openai@6.26.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA=="],
-
-    "opencode-lore": ["opencode-lore@workspace:packages/opencode"],
 
     "p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -6,7 +6,7 @@ Shared memory engine for [Lore](https://github.com/BYK/opencode-lore) — three-
 
 This package is host-agnostic. It doesn't ship a user-facing extension on its own; it's consumed by adapter packages that wire it into a specific coding agent:
 
-- [`opencode-lore`](https://www.npmjs.com/package/opencode-lore) — [OpenCode](https://opencode.ai) plugin
+- [`@loreai/opencode`](https://www.npmjs.com/package/@loreai/opencode) — [OpenCode](https://opencode.ai) plugin (also published as [`opencode-lore`](https://www.npmjs.com/package/opencode-lore) legacy alias)
 - [`@loreai/pi`](https://www.npmjs.com/package/@loreai/pi) — [Pi coding-agent](https://github.com/badlogic/pi-mono) extension
 
 ## Install

--- a/packages/opencode/README.md
+++ b/packages/opencode/README.md
@@ -1,4 +1,4 @@
-# opencode-lore
+# @loreai/opencode
 
 > **Experimental** — Under active development. APIs, storage format, and behavior may change.
 
@@ -13,18 +13,20 @@ Add to your project's `opencode.json`:
 ```json
 {
   "plugin": [
-    "opencode-lore"
+    "@loreai/opencode"
   ]
 }
 ```
 
 Restart OpenCode and the plugin will be installed automatically.
 
+> This package is also published as [`opencode-lore`](https://www.npmjs.com/package/opencode-lore) (legacy alias). Both names ship identical code at every release — either works.
+
 ## Companion packages
 
 Lore ships as three packages sharing the same SQLite database at `~/.local/share/opencode-lore/lore.db`:
 
-- **`opencode-lore`** (you are here) — OpenCode plugin
+- **`@loreai/opencode`** (you are here) — OpenCode plugin
 - [`@loreai/pi`](https://www.npmjs.com/package/@loreai/pi) — [Pi coding-agent](https://github.com/badlogic/pi-mono) extension
 - [`@loreai/core`](https://www.npmjs.com/package/@loreai/core) — shared memory engine
 

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "opencode-lore",
+  "name": "@loreai/opencode",
   "version": "0.9.1",
   "type": "module",
   "license": "MIT",
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "build": "echo 'opencode-lore ships raw TS — no build step needed'"
+    "build": "echo '@loreai/opencode ships raw TS — no build step needed'"
   },
   "peerDependencies": {
     "@opencode-ai/plugin": ">=1.1.0"
@@ -39,6 +39,9 @@
     "type": "git",
     "url": "git+https://github.com/BYK/opencode-lore.git",
     "directory": "packages/opencode"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "keywords": [
     "opencode",

--- a/packages/pi/README.md
+++ b/packages/pi/README.md
@@ -23,7 +23,7 @@ Then run `pi install` once. The extension auto-loads on every Pi session.
 Lore ships as three packages sharing the same SQLite database at `~/.local/share/opencode-lore/lore.db`:
 
 - **`@loreai/pi`** (you are here) — Pi coding-agent extension
-- [`opencode-lore`](https://www.npmjs.com/package/opencode-lore) — [OpenCode](https://opencode.ai) plugin
+- [`@loreai/opencode`](https://www.npmjs.com/package/@loreai/opencode) — [OpenCode](https://opencode.ai) plugin (also published as [`opencode-lore`](https://www.npmjs.com/package/opencode-lore) legacy alias)
 - [`@loreai/core`](https://www.npmjs.com/package/@loreai/core) — shared memory engine
 
 Switching between OpenCode and Pi on the same project preserves the curated knowledge, distillations, and AGENTS.md sync.


### PR DESCRIPTION
## Summary

Your proposed approach: make `@loreai/opencode` canonical, keep publishing `opencode-lore` with identical content as a legacy alias.

## How it works

1. **Rename**: `packages/opencode/package.json` name → `@loreai/opencode`. Directory stays at `packages/opencode/` (npm only cares about `name`).

2. **Pack primary**: `bun pm pack` produces `loreai-opencode-<version>.tgz` with `workspace:*` deps rewritten to the actual version.

3. **Mirror**: CI extracts the tarball, swaps `"name": "@loreai/opencode"` → `"name": "opencode-lore"` in its `package.json`, repacks as `opencode-lore-<version>.tgz`. Everything else (code, deps, README, LICENSE) is identical.

4. **Publish**: `.craft.yml` has two `npm` targets:
   - Workspace target (auto-discovers `@loreai/{core,opencode,pi}`)
   - Non-workspace target scoped to `includeNames: /^opencode-lore-\d.*\.tgz$/`

   Each target's `includeNames` regex matches exactly one tarball, so craft routes them correctly without overlap.

## Verified locally

```
--- Final tarballs ---
loreai-core-0.9.1.tgz       → @loreai/core
loreai-opencode-0.9.1.tgz   → @loreai/opencode
loreai-pi-0.9.1.tgz         → @loreai/pi
opencode-lore-0.9.1.tgz     → opencode-lore
```

All have `workspace:*` deps rewritten to `0.9.1`. All include README + LICENSE. `bun test` → 350 pass. Typecheck clean for all 3 workspaces.

## Migration

- Existing `"plugin": ["opencode-lore"]` setups keep working — same content, same installer path, no action needed.
- New docs recommend `@loreai/opencode`.
- Both names are published in parallel at every release going forward.

## Follow-up

None — the rest of the release pipeline (OIDC auth, publish workflow, changelog) is already in place from PR #79.