### PR TITLE
fix(release): custom bump script to work around npm workspace:* incompatibility

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -3,6 +3,9 @@ changelog:
   policy: auto
 versioning:
   policy: auto
+# Custom version bump script — bypasses craft's built-in npm-based auto-bumping
+# which fails on our `workspace:*` deps. See scripts/bump-version.sh for details.
+preReleaseCommand: bash scripts/bump-version.sh
 artifactProvider:
   name: github
   config:

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Pre-release version bump for all three Lore workspace packages.
+#
+# Why this exists instead of letting craft auto-bump:
+#
+# Craft's built-in auto-bumping runs `npm version --workspaces --include-workspace-root`.
+# On our monorepo this succeeds in updating the version field in every package.json,
+# but then npm *also* validates dependency URLs during the version command and
+# errors out with EUNSUPPORTEDPROTOCOL on `workspace:*` specifiers. The exit
+# status propagates back to craft which treats the whole step as failed and
+# falls back to per-package bumping — which fails identically, because the
+# workspace deps are still there.
+#
+# We bypass npm entirely by editing package.json files with jq directly. The
+# `workspace:*` specifiers are rewritten to the concrete version at pack time
+# by `bun pm pack` (see .github/workflows/ci.yml), so we don't need to touch
+# them here.
+#
+# Craft passes the new version via CRAFT_NEW_VERSION. Command-line args are a
+# legacy fallback — prefer the env var.
+set -euo pipefail
+
+NEW_VERSION="${CRAFT_NEW_VERSION:-${2:-}}"
+if [ -z "$NEW_VERSION" ]; then
+  echo "error: CRAFT_NEW_VERSION not set and no positional version argument" >&2
+  exit 1
+fi
+
+echo "Bumping Lore workspace packages to ${NEW_VERSION}"
+
+for f in \
+  packages/core/package.json \
+  packages/opencode/package.json \
+  packages/pi/package.json; do
+  # Preserve trailing newline by piping through jq then appending.
+  tmp="$(mktemp)"
+  jq --arg v "$NEW_VERSION" '.version = $v' "$f" > "$tmp"
+  mv "$tmp" "$f"
+  name=$(jq -r '.name' "$f")
+  echo "  ✓ ${name} → ${NEW_VERSION}"
+done
+
+echo "Version bump complete."


### PR DESCRIPTION
## Problem

First attempt at cutting a release (run [24738145808](https://github.com/BYK/opencode-lore/actions/runs/24738145808)) failed with:

\`\`\`
[debug] Running: npm version 0.10.0 --no-git-tag-version --allow-same-version --workspaces --include-workspace-root (for workspaces)
[debug] npm --workspaces failed, falling back to individual package bumping
[debug] Bumping version for workspace package: @loreai/pi
[error] Automatic version bump failed for "npm" target: Process "npm" errored with code 1
STDERR: npm error code EUNSUPPORTEDPROTOCOL
npm error Unsupported URL Type "workspace:": workspace:*
\`\`\`

## Root cause

npm's \`version\` command validates dependency URLs even though it only updates the \`version\` field. \`workspace:\*\` is not a valid npm-consumable URL, so npm errors out with EUNSUPPORTEDPROTOCOL and exits 1 — **even though it successfully updated every package.json's version field first**.

Craft sees the non-zero exit, assumes failure, falls back to per-package bumps. Those fail identically for the same reason.

## Fix

Custom \`preReleaseCommand: bash scripts/bump-version.sh\` that edits \`packages/*/package.json\` version fields via \`jq\`. No npm involvement. The \`workspace:\*\` specifiers stay as-is and get rewritten to concrete versions at pack time by \`bun pm pack\` (see CI workflow).

Verified locally against a scratch copy of the monorepo:

\`\`\`
$ CRAFT_NEW_VERSION=0.10.0 bash scripts/bump-version.sh
Bumping Lore workspace packages to 0.10.0
  ✓ @loreai/core → 0.10.0
  ✓ @loreai/opencode → 0.10.0
  ✓ @loreai/pi → 0.10.0
Version bump complete.
\`\`\`

Root package.json stays untouched (no \`version\` field — it's a private monorepo root). jq is available in the craft Docker image (verified from craft's Dockerfile).