### PR TITLE
fix(publish): add registry-url to setup-node for npm OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,9 +45,14 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+      # `registry-url` is required for npm OIDC trusted publishing — without
+      # it, setup-node doesn't configure the authenticated .npmrc and
+      # `npm publish` errors with ENEEDAUTH even though the workflow has
+      # `id-token: write` permission.
       - uses: actions/setup-node@v4
         with:
           node-version: 24
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install Craft
         run: |


### PR DESCRIPTION
## Problem

First attempt at publishing 0.10.0 (run [24738458757](https://github.com/BYK/opencode-lore/actions/runs/24738458757)) failed with:

\`\`\`
npm: npm error code ENEEDAUTH
npm: npm error need auth This command requires you to be logged in to https://registry.npmjs.org/
\`\`\`

## Cause

\`actions/setup-node@v4\` without \`registry-url:\` doesn't configure the authenticated \`.npmrc\` file. npm OIDC requires setup-node to have written the registry config so it knows which registry to exchange the OIDC token against. Without it, npm falls back to checking for NPM_TOKEN, finds none, and errors.

The workflow already has \`id-token: write\` permission and \`.craft.yml\` has \`oidc: true\` — both necessary but not sufficient.

## Fix

Add \`registry-url: 'https://registry.npmjs.org'\` to the setup-node step in \`.github/workflows/publish.yml\`.

Publish workflow's failure step already cleaned up the \`accepted\` label on issue #84, so re-approval after this merges will re-trigger the publish workflow.