### PR TITLE
fix(release): patch bun.lock workspace versions during bump

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -11,10 +11,29 @@
 # falls back to per-package bumping — which fails identically, because the
 # workspace deps are still there.
 #
-# We bypass npm entirely by editing package.json files with jq directly. The
-# `workspace:*` specifiers are rewritten to the concrete version at pack time
-# by `bun pm pack` (see .github/workflows/ci.yml), so we don't need to touch
-# them here.
+# We bypass npm entirely by editing package.json files with jq directly.
+#
+# Why we also patch bun.lock:
+#
+# `bun pm pack` rewrites `workspace:*` dependency specifiers to a concrete
+# version at pack time. It reads that version from `bun.lock`, NOT from
+# `packages/<pkg>/package.json`. If the lockfile still records the OLD
+# version of a workspace package, pack will embed that stale version in the
+# tarball's `dependencies` field. We learned this the hard way with v0.10.0:
+# @loreai/opencode@0.10.0 and @loreai/pi@0.10.0 were published with a
+# @loreai/core@0.9.1 dependency (because 0.9.1 was the lockfile's recorded
+# workspace version), which was never published — npm install failed with
+# ETARGET "No matching version found for @loreai/core@0.9.1".
+#
+# Neither `bun install` nor `bun install --lockfile-only` updates the
+# `version` field of a workspace entry once it exists in the lockfile —
+# the lockfile is the source of truth and package.json edits are ignored.
+# We'd need `rm bun.lock && bun install --lockfile-only` to refresh it,
+# but bun isn't available in craft's Docker image (which runs this script
+# as preReleaseCommand). So we patch the three workspace version lines with
+# awk instead — same result, no bun required.
+#
+# Upstream tracking: https://github.com/getsentry/craft/issues/804
 #
 # Craft passes the new version via CRAFT_NEW_VERSION. Command-line args are a
 # legacy fallback — prefer the env var.
@@ -39,5 +58,38 @@ for f in \
   name=$(jq -r '.name' "$f")
   echo "  ✓ ${name} → ${NEW_VERSION}"
 done
+
+# Patch workspace version fields in bun.lock.
+#
+# The lockfile structure for each workspace is:
+#     "packages/<name>": {
+#       "name": "@loreai/<name>",
+#       "version": "<OLD_VERSION>",
+#       "dependencies": { ... },
+#       ...
+#     }
+#
+# The awk state machine below sets in_ws when it sees a workspace-path key,
+# then replaces the *next* "version": "..." line it encounters with NEW_VERSION.
+# Resets in_ws after the replacement so only the first "version" line after
+# the workspace header gets touched (not version pins inside "dependencies").
+#
+# Uses only POSIX-standard awk constructs so it works with gawk, mawk, etc.
+if [ -f bun.lock ]; then
+  echo "Patching bun.lock workspace versions..."
+  tmp="$(mktemp)"
+  awk -v new_ver="$NEW_VERSION" '
+    /^    "packages\/(core|opencode|pi)": \{$/ { in_ws = 1 }
+    in_ws && /^      "version": "[0-9]+\.[0-9]+\.[0-9]+",$/ {
+      sub(/"[0-9]+\.[0-9]+\.[0-9]+"/, "\"" new_ver "\"")
+      in_ws = 0
+    }
+    { print }
+  ' bun.lock > "$tmp"
+  mv "$tmp" bun.lock
+  echo "  ✓ bun.lock patched"
+else
+  echo "warning: bun.lock not found — skipping lockfile patch." >&2
+fi
 
 echo "Version bump complete."


### PR DESCRIPTION
## Why

v0.10.0 shipped broken tarballs. `@loreai/opencode@0.10.0` and `@loreai/pi@0.10.0` both have `@loreai/core: "0.9.1"` in their `dependencies` field — a version we never published. Every install attempt failed with:

```
npm error code ETARGET
npm error notarget No matching version found for @loreai/core@0.9.1
```

## Root cause

`bun pm pack` rewrites `workspace:*` specifiers to concrete versions at pack time, but **reads the version from `bun.lock`, not from the workspace `package.json`**. Our bump script (via `jq`) only updated `package.json` — the lockfile kept its stale `"version": "0.9.1"` workspace entries. Since `npm version` never touches `bun.lock` and `bun install --lockfile-only` on a stale lockfile leaves workspace versions untouched (lockfile is authoritative, not package.json), the lockfile stayed at 0.9.1 while everything else moved to 0.10.0. Pack produced tarballs pointing at the old version.

## Fix

`scripts/bump-version.sh` now also patches the three workspace `version` fields in `bun.lock` via an awk state machine:

- Matches `    "packages/{core,opencode,pi}": {` (the workspace path keys)
- Replaces the *first* `"version": "X.Y.Z",` line after each match
- Doesn't touch version pins inside `dependencies` blocks (the state machine resets after the first version line)

Uses only POSIX-standard awk — no bash/perl/bun dependency. Craft's Debian-based Docker image has awk by default.

## Upstream

Filed [getsentry/craft#804](https://github.com/getsentry/craft/issues/804) documenting both issues (the `EUNSUPPORTEDPROTOCOL` swallow and the bun.lock staleness). If craft lands proper workspace:* support, this script can go away.

## Verified

End-to-end on a scratch copy of the monorepo (baseline at 0.9.1 → bump to 0.11.0):

```
=== package.json ===
@loreai/core      → 0.11.0
@loreai/opencode  → 0.11.0
@loreai/pi        → 0.11.0

=== bun.lock workspace entries ===
packages/core:      "version": "0.11.0"
packages/opencode:  "version": "0.11.0"
packages/pi:        "version": "0.11.0"

=== tarball deps after bun pm pack ===
loreai-pi-0.11.0.tgz:       "@loreai/core": "0.11.0"  ✓
loreai-opencode-0.11.0.tgz: "@loreai/core": "0.11.0"  ✓
```

Idempotent: running the bump twice gives identical results. All 350 tests still pass.

## Next steps after merge

1. Cut 0.10.1 via release workflow
2. `npm deprecate` the broken 0.10.0 versions of `@loreai/opencode`, `@loreai/pi`, and `opencode-lore` (the legacy mirror is also affected — same broken tarball, different name)