### PR TITLE
fix(pi): add pi.extensions manifest and externalize pi ecosystem deps

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -42,10 +42,18 @@
       "version": "0.10.1",
       "dependencies": {
         "@loreai/core": "workspace:*",
+      },
+      "devDependencies": {
         "@mariozechner/pi-agent-core": "^0.68.0",
         "@mariozechner/pi-ai": "^0.68.0",
         "@mariozechner/pi-coding-agent": "^0.68.0",
         "@sinclair/typebox": "^0.34.41",
+      },
+      "peerDependencies": {
+        "@mariozechner/pi-agent-core": "*",
+        "@mariozechner/pi-ai": "*",
+        "@mariozechner/pi-coding-agent": "*",
+        "@sinclair/typebox": "*",
       },
     },
   },

--- a/packages/pi/package.json
+++ b/packages/pi/package.json
@@ -12,12 +12,31 @@
       "default": "./dist/index.js"
     }
   },
+  "pi": {
+    "extensions": [
+      "./dist/index.js"
+    ]
+  },
   "scripts": {
     "typecheck": "tsc --noEmit",
     "build": "bun run script/build.ts"
   },
   "dependencies": {
-    "@loreai/core": "workspace:*",
+    "@loreai/core": "workspace:*"
+  },
+  "peerDependencies": {
+    "@mariozechner/pi-agent-core": "*",
+    "@mariozechner/pi-ai": "*",
+    "@mariozechner/pi-coding-agent": "*",
+    "@sinclair/typebox": "*"
+  },
+  "peerDependenciesMeta": {
+    "@mariozechner/pi-agent-core": { "optional": true },
+    "@mariozechner/pi-ai": { "optional": true },
+    "@mariozechner/pi-coding-agent": { "optional": true },
+    "@sinclair/typebox": { "optional": true }
+  },
+  "devDependencies": {
     "@mariozechner/pi-agent-core": "^0.68.0",
     "@mariozechner/pi-ai": "^0.68.0",
     "@mariozechner/pi-coding-agent": "^0.68.0",

--- a/packages/pi/script/build.ts
+++ b/packages/pi/script/build.ts
@@ -4,9 +4,20 @@
  * Pi runs on Node exclusively (unlike OpenCode which is Bun), so we only
  * build one target with `node:sqlite` imports preserved via `conditions: ["node"]`.
  *
- * External: @mariozechner/* (peer-installed with Pi itself), @loreai/core
- * (published separately), and Node built-ins. Third-party pure-JS deps
- * (@sinclair/typebox) are bundled.
+ * External — all of these are resolved at consumer install time, NOT bundled:
+ *
+ * - `@loreai/core` — published separately; users picking up a new core
+ *   version (security/bug fix) automatically benefit without a pi republish.
+ * - `@mariozechner/*` — Pi bundles these internally and injects them via
+ *   jiti's virtualModules when loading extensions. Bundling our own copies
+ *   would break: jiti resolves imports to the virtual modules, but if we
+ *   inline a copy in our bundle, code that depends on module identity
+ *   (extension type checks, event bus registrations) sees two different
+ *   instances and silently fails to register.
+ * - `@sinclair/typebox` — Pi bundles this via the same virtualModules
+ *   mechanism. Pi's docs explicitly require pi-package authors to mark
+ *   it as a peerDependency. We inlined it previously, which is why our
+ *   v0.10.1 extension silently didn't register in real Pi installs.
  */
 import * as esbuild from "esbuild";
 import { rmSync, mkdirSync, cpSync, existsSync } from "node:fs";
@@ -21,15 +32,6 @@ const distDir = join(packageDir, "dist");
 rmSync(distDir, { recursive: true, force: true });
 mkdirSync(distDir, { recursive: true });
 
-// External — resolved at consumer install time, not bundled.
-//
-// `@loreai/core` stays external so users picking up a new core version
-// (security/bug fix) automatically benefit without a pi republish.
-//
-// `@mariozechner/*` stays external because Pi users already have those
-// packages in their environment — bundling them would duplicate every
-// pi-ai provider SDK (Anthropic, OpenAI, Google, etc.) and bloat the
-// extension several MB.
 const external = [
   "node:*",
   "@loreai/core",
@@ -37,6 +39,7 @@ const external = [
   "@mariozechner/pi-ai",
   "@mariozechner/pi-agent-core",
   "@mariozechner/pi-tui",
+  "@sinclair/typebox",
 ];
 
 await esbuild.build({


### PR DESCRIPTION
## Why

Your friend reported that \`pi install npm:@loreai/pi\` installs the package but the extension never activates — no \`recall\` tool, no DB writes. Reproduced locally. v0.10.0 and 0.10.1 are silently non-functional when installed via Pi's package manager.

## What

Three coupled fixes per [Pi's packages.md](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/packages.md):

1. **Add \`pi.extensions\` manifest** to \`package.json\` pointing at \`./dist/index.js\`. Pi's extension loader looks for either a \`pi\` field or a root-level \`index.ts\`/\`index.js\`. We had neither.

2. **Externalize \`@sinclair/typebox\`** in the esbuild bundle. Pi bundles its own typebox and injects it via jiti's virtualModules. Shipping our own copy creates module identity mismatches. Bundle shrank from 132KB → 16KB (113 inlined refs → 1 import).

3. **Move pi ecosystem deps to peerDependencies** with \`peerDependenciesMeta.optional: true\`. Prevents npm from installing duplicate copies under the extension's \`node_modules\`.

## Verification

- \`bun test\` → 350 pass
- Typecheck clean for all 3 workspaces
- Local-directory install (\`pi install /tmp/loreai-pi-installed\`) loads the extension correctly — \`recall\` appears in the tool list, DB writes happen, hooks fire

## What I haven't verified yet

The \`pi install npm:@loreai/pi\` path — the failure mode your friend saw. Can't fully test until this ships because pi reinstalls from npm on each startup, wiping any local patches. Will test against 0.10.2 on npm immediately after merge + release.

Shipping this rather than drilling further locally because:
- The three fixes are correct per Pi's documented guidance — they improve the package state regardless
- If \`pi install npm:\` still fails after this ships, we have a cleaner baseline to investigate against
- 0.10.0 and 0.10.1 are already broken, so this can't make things worse