### PR TITLE
feat(compact): adopt upstream SUMMARY_TEMPLATE for /compact prompt

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -81,6 +81,8 @@ export {
   CONSOLIDATION_SYSTEM,
   consolidationUser,
   QUERY_EXPANSION_SYSTEM,
+  COMPACT_SUMMARY_TEMPLATE,
+  buildCompactPrompt,
 } from "./prompt";
 export { shouldImport, importFromFile, exportToFile } from "./agents-file";
 export { workerSessionIDs, isWorkerSession } from "./worker";

--- a/packages/core/src/prompt.ts
+++ b/packages/core/src/prompt.ts
@@ -388,6 +388,81 @@ export function formatDistillations(
   return sections.join("\n\n");
 }
 
+// Strict Markdown skeleton for the /compact session summary. Task-oriented
+// sections so the next agent starting from the compacted context has a clear
+// "where am I, what's next, what's blocked" briefing. Derived from upstream
+// OpenCode's SUMMARY_TEMPLATE (session/compaction.ts in #23870) with a "(none)"
+// directive added for explicit empty sections and a closing "I'm ready to
+// continue." sentinel to preserve Lore's post-compact UX.
+export const COMPACT_SUMMARY_TEMPLATE = `Output exactly this Markdown structure. Keep every section in this order, even when empty (use "(none)").
+
+---
+## Goal
+- [single-sentence task summary]
+
+## Constraints & Preferences
+- [user constraints, preferences, specs, or "(none)"]
+
+## Progress
+### Done
+- [completed work or "(none)"]
+
+### In Progress
+- [current work or "(none)"]
+
+### Blocked
+- [blockers or "(none)"]
+
+## Key Decisions
+- [decision and why, or "(none)"]
+
+## Next Steps
+- [ordered next actions or "(none)"]
+
+## Critical Context
+- [important technical facts, errors, open questions, or "(none)"]
+
+## Relevant Files
+- [file or directory path: why it matters, or "(none)"]
+---
+
+Rules:
+- Keep every section, even when empty.
+- Use terse bullets, not prose paragraphs.
+- Preserve exact file paths, commands, error strings, and identifiers when known.
+- Do not mention the summary process or that context was compacted.
+- End with "I'm ready to continue." on its own line after the closing "---".`;
+
+// Build the user-facing prompt passed to the compaction agent during /compact.
+// Lore injects pre-computed distillations as context separately; this prompt
+// just tells the model how to render its summary.
+//
+// NOTE: Upstream's SUMMARY_TEMPLATE path also supports `<previous-summary>`
+// anchoring for repeat /compact invocations. Lore does not implement that yet —
+// see F1b follow-up for the persistence+retrieval needed to do it safely
+// (gen>0 meta-distillations are XML observation dumps, not prior /compact
+// output, so we can't reuse them as anchors).
+//
+// `hasDistillations` is a boolean rather than the full array because this
+// function only cares about presence — the distillation bodies are pushed into
+// `output.context` separately by the caller. Passing the array shape would be
+// misleading dead weight.
+export function buildCompactPrompt(input: {
+  hasDistillations: boolean;
+  knowledge?: string;
+}): string {
+  const distillSection = input.hasDistillations
+    ? "Lore has pre-computed chunked summaries of the session history (injected above as context). Use them as the authoritative source — do NOT re-read raw conversation messages that conflict with them.\n\n"
+    : "";
+
+  const knowledgeBlock = input.knowledge ? `\n${input.knowledge}\n` : "";
+
+  return `You are producing a compacted session summary for an AI coding agent. This summary will be the ONLY context available in the next part of the conversation.
+
+${distillSection}${COMPACT_SUMMARY_TEMPLATE}
+${knowledgeBlock}`;
+}
+
 // ~3 chars per token — validated as best heuristic against real API data.
 function estimateTokens(text: string): number {
   return Math.ceil(text.length / 3);

--- a/packages/core/test/prompt.test.ts
+++ b/packages/core/test/prompt.test.ts
@@ -1,0 +1,91 @@
+import { describe, test, expect } from "bun:test";
+import { buildCompactPrompt, COMPACT_SUMMARY_TEMPLATE } from "../src/prompt";
+
+// All required section headings emitted by COMPACT_SUMMARY_TEMPLATE. Pinning
+// this list keeps Lore's /compact output aligned with the upstream OpenCode
+// SUMMARY_TEMPLATE (see packages/core/src/prompt.ts commentary).
+const REQUIRED_SECTIONS = [
+  "## Goal",
+  "## Constraints & Preferences",
+  "## Progress",
+  "### Done",
+  "### In Progress",
+  "### Blocked",
+  "## Key Decisions",
+  "## Next Steps",
+  "## Critical Context",
+  "## Relevant Files",
+];
+
+describe("COMPACT_SUMMARY_TEMPLATE", () => {
+  test("contains every required section heading", () => {
+    for (const heading of REQUIRED_SECTIONS) {
+      expect(COMPACT_SUMMARY_TEMPLATE).toContain(heading);
+    }
+  });
+
+  test("instructs the model to close with 'I'm ready to continue.'", () => {
+    expect(COMPACT_SUMMARY_TEMPLATE).toContain("I'm ready to continue.");
+  });
+
+  test("sections appear in the upstream-canonical order", () => {
+    const positions = REQUIRED_SECTIONS.map((s) =>
+      COMPACT_SUMMARY_TEMPLATE.indexOf(s),
+    );
+    for (let i = 0; i < positions.length - 1; i++) {
+      expect(positions[i]).toBeLessThan(positions[i + 1]);
+    }
+  });
+});
+
+describe("buildCompactPrompt", () => {
+  test("no distillations, no knowledge — emits template only", () => {
+    const prompt = buildCompactPrompt({
+      hasDistillations: false,
+      knowledge: "",
+    });
+    // Template body present.
+    for (const heading of REQUIRED_SECTIONS) {
+      expect(prompt).toContain(heading);
+    }
+    // Distillation-reminder sentence absent when no distillations provided.
+    expect(prompt).not.toContain("Lore has pre-computed chunked summaries");
+    // No knowledge block.
+    expect(prompt).not.toContain("## Long-term Knowledge");
+  });
+
+  test("with distillations — injects the pre-computed summaries reminder", () => {
+    const prompt = buildCompactPrompt({ hasDistillations: true });
+    expect(prompt).toContain("Lore has pre-computed chunked summaries");
+  });
+
+  test("with knowledge block — appends knowledge after template", () => {
+    const knowledge = "## Long-term Knowledge\n### Pattern\n- **X**: Y";
+    const prompt = buildCompactPrompt({
+      hasDistillations: false,
+      knowledge,
+    });
+    expect(prompt).toContain(knowledge);
+  });
+
+  test("undefined knowledge is treated the same as empty string", () => {
+    const a = buildCompactPrompt({ hasDistillations: false, knowledge: undefined });
+    const b = buildCompactPrompt({ hasDistillations: false, knowledge: "" });
+    expect(a).toBe(b);
+    expect(a).not.toContain("## Long-term Knowledge");
+  });
+
+  test("block ordering: distill-reminder → template → knowledge", () => {
+    const prompt = buildCompactPrompt({
+      hasDistillations: true,
+      knowledge: "## Long-term Knowledge\n### Pattern\n- **X**: Y",
+    });
+    const reminderIdx = prompt.indexOf("Lore has pre-computed");
+    const templateIdx = prompt.indexOf("## Goal");
+    const knowledgeIdx = prompt.indexOf("## Long-term Knowledge");
+
+    expect(reminderIdx).toBeGreaterThan(-1);
+    expect(templateIdx).toBeGreaterThan(reminderIdx);
+    expect(knowledgeIdx).toBeGreaterThan(templateIdx);
+  });
+});

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -21,6 +21,7 @@ import {
   getLastTransformEstimate,
   formatKnowledge,
   formatDistillations,
+  buildCompactPrompt,
   shouldImport,
   importFromFile,
   exportToFile,
@@ -712,7 +713,10 @@ export const LorePlugin: Plugin = async (ctx) => {
     // Strategy: run chunked distillation first so all messages are captured in segments
     // that each fit within the model's context, then inject the pre-computed summaries
     // as context so the model consolidates them rather than re-reading all raw messages.
-    // This prevents the overflow→compaction→overflow stuck loop.
+    // Output format is the task-oriented SUMMARY_TEMPLATE from @loreai/core's
+    // buildCompactPrompt (Goal / Progress / Next Steps / Blocked / etc.), derived from
+    // upstream OpenCode's template so the next agent starting from the compacted
+    // context has a clear "where am I, what's next" briefing.
     "experimental.session.compacting": async (input, output) => {
       // Chunked distillation: split all undistilled messages into segments that each
       // fit within the model's context window and distill them independently.
@@ -755,21 +759,10 @@ export const LorePlugin: Plugin = async (ctx) => {
         );
       }
 
-      output.prompt = `You are creating a distilled memory summary for an AI coding agent. This summary will be the ONLY context available in the next part of the conversation.
-
-${distillations.length > 0 ? "Lore has pre-computed chunked summaries of the session history (injected above as context). Consolidate those summaries into a single coherent narrative. Do NOT re-read or re-summarize the raw conversation messages — trust the pre-computed summaries.\n\n" : ""}Structure your response as follows:
-
-## Session History
-
-For each major topic or task covered in the conversation, write:
-- A 1-3 sentence narrative of what happened (past tense, focus on outcomes)
-- A bullet list of specific, actionable facts (file paths, values, decisions, what failed and why)
-
-PRESERVE: file paths, specific values, decisions with rationale, user preferences, failed approaches with reasons, environment details.
-DROP: debugging back-and-forth, verbose tool output, pleasantries, redundant restatements.
-
-${knowledge ? `\n${knowledge}\n` : ""}
-End with "I'm ready to continue." so the agent knows to pick up where it left off.`;
+      output.prompt = buildCompactPrompt({
+        hasDistillations: distillations.length > 0,
+        knowledge,
+      });
     },
 
     // Register the recall tool

--- a/packages/opencode/test/index.test.ts
+++ b/packages/opencode/test/index.test.ts
@@ -1024,3 +1024,126 @@ describe("transform hook error handling", () => {
     }
   });
 });
+
+// ── experimental.session.compacting hook ────────────────────────────
+//
+// Wiring-level tests: the hook must populate output.prompt with the
+// SUMMARY_TEMPLATE body (via buildCompactPrompt) and push a distillations
+// context block into output.context when any distillations exist for the
+// session. These tests don't assert anything about the prompt-body shape
+// itself — that's covered by packages/core/test/prompt.test.ts.
+
+async function callCompacting(
+  hooks: Awaited<ReturnType<typeof LorePlugin>>,
+  input: { sessionID?: string },
+): Promise<{ prompt: string | undefined; context: string[] }> {
+  const hook = (hooks as Record<string, unknown>)[
+    "experimental.session.compacting"
+  ] as (
+    input: unknown,
+    output: { context: string[]; prompt: string | undefined },
+  ) => Promise<void>;
+  const output = { context: [] as string[], prompt: undefined as string | undefined };
+  await hook(input, output);
+  return output;
+}
+
+describe("experimental.session.compacting", () => {
+  test("sets output.prompt to the SUMMARY_TEMPLATE body", async () => {
+    const { hooks, cleanup } = await initPlugin();
+    try {
+      const { prompt, context } = await callCompacting(hooks!, {
+        sessionID: "ses_compact_template_001",
+      });
+      expect(prompt).toBeTruthy();
+      // Body contains template section headings.
+      expect(prompt).toContain("## Goal");
+      expect(prompt).toContain("## Progress");
+      expect(prompt).toContain("### Done");
+      expect(prompt).toContain("### In Progress");
+      expect(prompt).toContain("### Blocked");
+      expect(prompt).toContain("## Next Steps");
+      expect(prompt).toContain("## Critical Context");
+      expect(prompt).toContain("## Relevant Files");
+      expect(prompt).toContain("I'm ready to continue.");
+      // No distillations seeded, no context pushed.
+      expect(context).toHaveLength(0);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("pushes a Lore Pre-computed Session Summaries block into output.context when distillations exist", async () => {
+    const { hooks, tmpDir, cleanup } = await initPlugin();
+    try {
+      const sessionID = "ses_compact_context_001";
+      const pid = db()
+        .query("SELECT id FROM projects WHERE path = ?")
+        .get(tmpDir) as { id: string };
+      // Seed a gen-0 distillation directly so the hook sees it.
+      db()
+        .query(
+          `INSERT INTO distillations (id, project_id, session_id, narrative, facts, observations, source_ids, generation, token_count, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          crypto.randomUUID(),
+          pid.id,
+          sessionID,
+          "",
+          "[]",
+          "seeded distillation observation body",
+          "[]",
+          0,
+          10,
+          Date.now(),
+        );
+
+      const { prompt, context } = await callCompacting(hooks!, { sessionID });
+
+      // Context block pushed.
+      expect(context).toHaveLength(1);
+      expect(context[0]).toContain("Lore Pre-computed Session Summaries");
+      expect(context[0]).toContain("seeded distillation observation body");
+
+      // Prompt references that distillations are pre-computed.
+      expect(prompt).toContain("Lore has pre-computed chunked summaries");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("includes long-term knowledge in the prompt when knowledge entries exist", async () => {
+    const { hooks, tmpDir, cleanup } = await initPlugin();
+    try {
+      ltm.create({
+        projectPath: tmpDir,
+        category: "decision",
+        title: "Compact-hook knowledge entry",
+        content: "Entry that should appear in /compact prompt knowledge block",
+        scope: "project",
+      });
+
+      const { prompt } = await callCompacting(hooks!, {
+        sessionID: "ses_compact_knowledge_001",
+      });
+      expect(prompt).toContain("Long-term Knowledge");
+      expect(prompt).toContain("Compact-hook knowledge entry");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("works when input.sessionID is missing (no DB reads)", async () => {
+    const { hooks, cleanup } = await initPlugin();
+    try {
+      const { prompt, context } = await callCompacting(hooks!, {});
+      // Prompt still emitted with template body.
+      expect(prompt).toContain("## Goal");
+      // No distillations possible → no context block.
+      expect(context).toHaveLength(0);
+    } finally {
+      cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Rewrite the `experimental.session.compacting` hook's `output.prompt` to use a task-oriented `SUMMARY_TEMPLATE` derived from upstream OpenCode (#23870 `574b2c217`): strict Markdown skeleton with required sections `Goal / Constraints & Preferences / Progress (Done / In Progress / Blocked) / Key Decisions / Next Steps / Critical Context / Relevant Files`.
- Factor the prompt assembly into `@loreai/core`'s new `buildCompactPrompt` helper so the template can be reused by other hosts (Pi) later.
- Pin the template shape and hook wiring with tests.

## Why

When a user invokes `/compact`, the compaction agent's summary becomes the ONLY context for the next portion of the session. The prior prompt asked for a free-form `## Session History` with a narrative + bullet list per topic, which:
- Varied heavily run-to-run ("per major topic" is under-specified).
- Gave chronological recaps instead of action-oriented briefs.
- Missed the explicit `Goal / Next Steps / Blocked` framing users actually want ("where am I, what's next?").

Upstream's template is task-oriented, strictly structured (machine-parseable, cannot silently drop sections), and has been tuned on upstream's production traffic.

## Changes

| File | Change |
|------|--------|
| `packages/core/src/prompt.ts` | Add `COMPACT_SUMMARY_TEMPLATE` constant + `buildCompactPrompt({ hasDistillations, knowledge })` helper. |
| `packages/core/src/index.ts` | Re-export the two new symbols from the barrel. |
| `packages/opencode/src/index.ts` | Hook now calls `buildCompactPrompt` with a presence-only `hasDistillations` boolean; distillation bodies continue to flow through `output.context`. |
| `packages/core/test/prompt.test.ts` | New file — 8 tests: section coverage, ordering, empty/undefined knowledge equivalence, block order with all inputs. |
| `packages/opencode/test/index.test.ts` | New `describe("experimental.session.compacting")` block with 4 wiring tests: template emission, context-block push, knowledge inclusion, no-`sessionID` path. |

## Behavior change (user-visible)

`/compact` output format switches from the old `## Session History` narrative to the new structured template. Any downstream tooling that parsed the old heading will need updating. The pre-computed distillations block Lore pushes into `output.context` is unchanged.

## Verification

- `bun test`: 362 pass / 0 fail (4779 expect calls across 17 files).
- `bun --filter '*' typecheck`: all three packages exit 0.
- `bun --filter '*' build`: core and pi bundles emit cleanly; opencode ships raw TS.

## Deferred: `<previous-summary>` anchoring

Upstream's template path also supports anchored update-in-place on repeat `/compact` invocations (previous summary fed back via `<previous-summary>`, model updates rather than re-deriving). An initial draft of this PR wired that via a new `latestMetaSummary` helper, but review surfaced a semantic bug: gen>0 meta-distillations come from background `metaDistill()` with `RECURSIVE_SYSTEM` (XML observations), **not** from prior `/compact` invocations (Markdown summaries). Feeding XML into `<previous-summary>` and asking the model to "update in place" would mis-train the output.

The correct fix needs dedicated `/compact`-output persistence + retrieval. That's tracked in the follow-up plan `.opencode/plans/f1b-compact-anchor-persistence.md`. Shipping template adoption alone (the main user-visible win) in this PR.

## Review trail

Two subagent review passes; both cleared. The first caught the anchor semantic bug + a missing hook integration test — both addressed in subsequent commits-in-branch before this final squash.
