### PR TITLE
fix(opencode): robust context-overflow detection with upstream regex list

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -33,29 +33,100 @@ import {
 import { createRecallTool } from "./reflect";
 import { createOpenCodeLLMClient } from "./llm-adapter";
 
+// Mirrors upstream OpenCode's OVERFLOW_PATTERNS at
+// packages/opencode/src/provider/error.ts (commit be20f865a added the HTTP 413
+// regex; list otherwise tracks upstream's provider coverage). Keep this list
+// aligned with upstream when they add / change patterns — diff the arrays to
+// catch drift.
+// TODO(F10): add a contract test that diffs this array against upstream's
+// source file when available, so drift fails loudly instead of silently.
+const OVERFLOW_PATTERNS: RegExp[] = [
+  /prompt is too long/i, // Anthropic
+  /input is too long for requested model/i, // Amazon Bedrock
+  /exceeds the context window/i, // OpenAI
+  /input token count.*exceeds the maximum/i, // Google Gemini
+  /maximum prompt length is \d+/i, // xAI Grok
+  /reduce the length of the messages/i, // Groq
+  /maximum context length is \d+ tokens/i, // OpenRouter, DeepSeek, vLLM
+  /exceeds the limit of \d+/i, // GitHub Copilot
+  /exceeds the available context size/i, // llama.cpp
+  /greater than the context length/i, // LM Studio
+  /context window exceeds limit/i, // MiniMax
+  /exceeded model token limit/i, // Kimi / Moonshot
+  /context[_ ]length[_ ]exceeded/i, // Generic fallback
+  /request entity too large/i, // HTTP 413 (added upstream be20f865a)
+  /context length is only \d+ tokens/i, // vLLM
+  /input length.*exceeds.*context length/i, // vLLM
+  /prompt too long; exceeded (?:max )?context length/i, // Ollama
+  /too large for model with \d+ maximum context length/i, // Mistral
+  /model_context_window_exceeded/i, // z.ai
+  /^4(00|13)\s*(status code)?\s*\(no body\)/i, // Cerebras, Mistral no-body responses
+];
+
+// Patterns retained from Lore's historic detector that upstream doesn't
+// include. Kept for safety since the previous substring-based detector used
+// them. Remove only after (a) a user-report window goes quiet and (b) we've
+// confirmed the specific provider wordings they catch are covered by
+// OVERFLOW_PATTERNS above. Lore has no hit telemetry for these today.
+const LORE_LEGACY_PATTERNS: RegExp[] = [
+  /ContextWindowExceededError/i, // surfaces in some wrapped error messages
+  /too many tokens/i, // broad; catches non-standard wordings
+];
+
 /**
- * Detect whether an error from session.error is a context overflow ("prompt too long").
- * Matches by error name (ContextOverflowError — covers both API-level and OpenCode
- * compaction overflow) and by message text patterns for provider-specific strings.
+ * Detect context overflow from session.error payloads.
+ *
+ * Upstream ships errors to plugins via `namedSchemaError(...).toObject()`, so
+ * we receive one of these wire shapes:
+ *   - ContextOverflowError: { name: "ContextOverflowError", data: { message, responseBody? } }
+ *   - APIError:             { name: "APIError", data: { message, statusCode?, isRetryable?, ... } }
+ *   - Unknown:              { name: "Unknown", data: { message? } }
+ *
+ * Detection strategy (ordered, fail-open):
+ *   1. Structural tag: `error.name === "ContextOverflowError"` — upstream already
+ *      classified it as overflow.
+ *   2. HTTP 413 on APIError: `data.statusCode === 413` — belt-and-suspenders for
+ *      cases where upstream's `parseAPICallError` didn't fire (e.g. if the error
+ *      reached Lore before passing through `provider/error.ts`).
+ *   3. Regex match on `data.message` / `message` — mirrors upstream's
+ *      OVERFLOW_PATTERNS list for all provider wordings + legacy Lore patterns
+ *      for defensive coverage.
+ *
+ * When upstream revises OVERFLOW_PATTERNS, re-sync here. See
+ * `.opencode/plans/f8-context-overflow-detection-audit.md` for rationale and
+ * the ground-truth reference report.
  */
 export function isContextOverflow(rawError: unknown): boolean {
-  const error = rawError as
-    | { name?: string; message?: string; data?: { message?: string } }
-    | undefined;
+  if (!rawError || typeof rawError !== "object") return false;
 
-  // Match by error name — covers both API context overflow and OpenCode's
-  // compaction overflow ("Conversation history too large to compact").
-  if (error?.name === "ContextOverflowError") return true;
+  const error = rawError as {
+    name?: string;
+    message?: string;
+    data?: {
+      message?: string;
+      statusCode?: number;
+    };
+  };
 
-  const errorMessage = error?.data?.message ?? error?.message ?? "";
-  return (
-    typeof errorMessage === "string" &&
-    (errorMessage.includes("prompt is too long") ||
-      errorMessage.includes("context length exceeded") ||
-      errorMessage.includes("maximum context length") ||
-      errorMessage.includes("ContextWindowExceededError") ||
-      errorMessage.includes("too many tokens"))
-  );
+  // 1. Structural tag — upstream's already-classified overflow. Covers both
+  //    API-level overflow and OpenCode's compaction overflow ("Conversation
+  //    history too large to compact...").
+  if (error.name === "ContextOverflowError") return true;
+
+  // 2. HTTP 413 on APIError-shaped payloads. ContextOverflowError strips
+  //    statusCode in .toObject(), so this only matches non-classified leaks.
+  if (error.data?.statusCode === 413) return true;
+
+  // 3. Regex against message text (data.message preferred, top-level message
+  //    as fallback — the latter is dropped for named errors but may be
+  //    present for raw Error instances that somehow reach us).
+  const text = error.data?.message ?? error.message ?? "";
+  if (typeof text !== "string" || text.length === 0) return false;
+
+  if (OVERFLOW_PATTERNS.some((re) => re.test(text))) return true;
+  if (LORE_LEGACY_PATTERNS.some((re) => re.test(text))) return true;
+
+  return false;
 }
 
 /**

--- a/packages/opencode/test/index.test.ts
+++ b/packages/opencode/test/index.test.ts
@@ -78,6 +78,121 @@ describe("isContextOverflow", () => {
   });
 });
 
+// Provider-specific overflow wordings. These mirror upstream OpenCode's
+// OVERFLOW_PATTERNS list in packages/opencode/src/provider/error.ts. When
+// upstream adds or changes a pattern, add/update the corresponding case here.
+describe("isContextOverflow — provider-specific regex patterns", () => {
+  const cases: Array<[string, string]> = [
+    ["Anthropic", "prompt is too long: 250000 tokens > 200000 maximum"],
+    ["Amazon Bedrock", "Input is too long for requested model."],
+    ["OpenAI", "the request exceeds the context window for this model"],
+    [
+      "Google Gemini",
+      "Input token count 250000 exceeds the maximum number of tokens allowed (200000).",
+    ],
+    ["xAI Grok", "Maximum prompt length is 131072"],
+    ["Groq", "Please reduce the length of the messages or completion."],
+    ["OpenRouter", "maximum context length is 128000 tokens"],
+    ["GitHub Copilot", "Request exceeds the limit of 4096 tokens."],
+    ["llama.cpp", "Input exceeds the available context size"],
+    ["LM Studio", "Input is greater than the context length"],
+    ["MiniMax", "Context window exceeds limit."],
+    ["Kimi/Moonshot", "exceeded model token limit"],
+    ["Generic context_length_exceeded", "context_length_exceeded"],
+    ["Generic context length exceeded (spaced)", "context length exceeded"],
+    ["HTTP 413", "Request Entity Too Large"],
+    ["vLLM alt1", "context length is only 4096 tokens"],
+    [
+      "vLLM alt2",
+      "Input length 5000 tokens exceeds max context length 4096 tokens",
+    ],
+    ["Ollama", "prompt too long; exceeded max context length"],
+    [
+      "Mistral",
+      "Request is too large for model with 8192 maximum context length",
+    ],
+    ["z.ai", "model_context_window_exceeded"],
+    ["Cerebras 413 no-body", "413 (no body)"],
+    ["Cerebras 400 no-body", "400 status code (no body)"],
+  ];
+
+  for (const [provider, message] of cases) {
+    test(`detects ${provider}`, () => {
+      expect(
+        isContextOverflow({ name: "APIError", data: { message } }),
+      ).toBe(true);
+    });
+  }
+});
+
+// Wire-shape coverage. Upstream publishes errors via `namedSchemaError.toObject()`
+// — structural shape is { name, data: {...} } without top-level message or
+// statusCode. These tests pin the shapes we actually see in production.
+describe("isContextOverflow — wire shape coverage", () => {
+  test("APIError with data.statusCode === 413 matches even when message text doesn't", () => {
+    expect(
+      isContextOverflow({
+        name: "APIError",
+        data: { statusCode: 413, message: "whatever non-matching text" },
+      }),
+    ).toBe(true);
+  });
+
+  test("APIError with 413 wording in message but no statusCode", () => {
+    expect(
+      isContextOverflow({
+        name: "APIError",
+        data: { message: "HTTP 413 Request Entity Too Large" },
+      }),
+    ).toBe(true);
+  });
+
+  test("ContextOverflowError with responseBody (real upstream wire shape)", () => {
+    expect(
+      isContextOverflow({
+        name: "ContextOverflowError",
+        data: { message: "prompt is too long", responseBody: "{...}" },
+      }),
+    ).toBe(true);
+  });
+
+  test("rejects APIError with unrelated 4xx status codes", () => {
+    expect(
+      isContextOverflow({ name: "APIError", data: { statusCode: 400 } }),
+    ).toBe(false);
+    expect(
+      isContextOverflow({ name: "APIError", data: { statusCode: 429 } }),
+    ).toBe(false);
+  });
+
+  test("rejects non-object errors", () => {
+    expect(isContextOverflow("string error")).toBe(false);
+    expect(isContextOverflow(123)).toBe(false);
+    expect(isContextOverflow([])).toBe(false);
+  });
+
+  test("empty-string message does not crash or match", () => {
+    expect(
+      isContextOverflow({ name: "APIError", data: { message: "" } }),
+    ).toBe(false);
+  });
+});
+
+// Case-insensitivity regression guard. Real Anthropic errors have been seen
+// with Title Case wording; Lore's prior implementation used case-sensitive
+// `.includes()` and silently missed them.
+describe("isContextOverflow — case-insensitivity", () => {
+  test("matches Title Case wording", () => {
+    expect(isContextOverflow({ message: "Prompt Is Too Long" })).toBe(true);
+  });
+
+  test("matches UPPERCASE wording", () => {
+    expect(
+      isContextOverflow({ message: "CONTEXT_LENGTH_EXCEEDED" }),
+    ).toBe(true);
+  });
+});
+
 describe("buildRecoveryMessage", () => {
   test("includes distilled summaries when provided", () => {
     const msg = buildRecoveryMessage([


### PR DESCRIPTION
## Summary

- Replace `isContextOverflow`'s 5-substring case-sensitive detector with a regex-based detector that mirrors upstream OpenCode's `OVERFLOW_PATTERNS` list verbatim (19 provider-specific regexes + 1 for Cerebras/Mistral "no body" responses).
- Add defense-in-depth `data.statusCode === 413` check for APIError-shaped payloads that leak past upstream's `parseAPICallError` classification.
- Extend the existing test suite with 30 new cases covering all upstream providers, the real `.toObject()` wire shape, and case-insensitivity.

## Why

Lore's auto-recovery path hinges on this detector: a false negative means no `setForceMinLayer(2)`, no forced distillation, no synthetic recovery message — the user sees an unrecoverable error.

The prior implementation silently missed real overflows emitted by OpenAI, Gemini, Bedrock, xAI, Groq, Copilot, llama.cpp, LM Studio, MiniMax, Kimi, vLLM, Ollama, Mistral, z.ai, plus HTTP 413 wording and anything title-cased or uppercase (e.g. `"Prompt Is Too Long"` from real Anthropic errors).

Ground truth for the plugin-side error wire shape was verified against upstream source before implementation (see `.opencode/plans/f8-context-overflow-detection-audit.md`):

- Plugins receive `event.properties.error` as the `namedSchemaError.toObject()` wire form: `{ name: string, data: { ... } }`.
- `statusCode` is NOT present on `ContextOverflowError` — `.toObject()` strips it. It only survives on the `APIError` wire shape, which is what reaches us when upstream's classification didn't fire.

## Changes

| File | Change |
|------|--------|
| `packages/opencode/src/index.ts` | Add `OVERFLOW_PATTERNS` (mirrors upstream `provider/error.ts` L8–28) + `LORE_LEGACY_PATTERNS` module constants. Rewrite `isContextOverflow`: structural `name` check → `statusCode === 413` check → regex match on `data.message` / top-level `message`. Update JSDoc with the wire-shape reference and detection order. |
| `packages/opencode/test/index.test.ts` | Add 3 new `describe` blocks: provider-specific regex coverage (22 cases, one per upstream pattern), wire-shape coverage (6), case-insensitivity regression guard (2). |

## Detection order (new)

1. `error.name === "ContextOverflowError"` — upstream-classified overflow (covers API overflow + compaction-self overflow).
2. `error.data?.statusCode === 413` — HTTP 413 on APIError-shaped payloads. Fires only for non-classified leaks.
3. Regex match on `data.message` / `message` — `OVERFLOW_PATTERNS` (upstream-mirrored) then `LORE_LEGACY_PATTERNS` (historic Lore-only patterns).

## Behavior preserved

All 11 existing `isContextOverflow` tests still pass. Verified cases:
- `"prompt is too long: 250000 tokens"` → `/prompt is too long/i`
- `"maximum context length exceeded"` → `/context[_ ]length[_ ]exceeded/i`
- `"ContextWindowExceededError: too many tokens"` → `LORE_LEGACY_PATTERNS`
- `"Token refresh failed: 429"` and `"rate limit exceeded"` → still rejected.

## Deferred

- **Upstream-drift contract test** for the regex list tracked as F10 (already in `.opencode/plans/f10-hook-regression-test.md`). Marked inline with `TODO(F10)`.
- **Legacy-pattern removal criterion**: Lore has no hit telemetry for the 2 legacy patterns. Comment documents that removal waits on user-report quiet + confirmation the specific wordings are covered by `OVERFLOW_PATTERNS`.
- **Full upstream 413 replay path** (clone user turn, strip media, resubmit) — tracked as F9 `.opencode/plans/f9-media-aware-recovery.md`.

## Verification

- `bun test`: 392 pass / 0 fail (4854 expect calls across 17 files, +30 new tests).
- `bun --filter '*' typecheck`: all three packages exit 0.
- `bun --filter '*' build`: core + pi bundles clean, opencode ships raw TS.

## Review trail

Subagent review pass cleared as "YES merge" with only two minor comment tweaks applied (TODO marker for F10, corrected legacy-removal criterion wording). No blockers; no important issues introduced by this PR.
