### PR TITLE
feat(distill): truncate oversized tool outputs in distillation input

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -23,8 +23,18 @@ export const LoreConfig = z.object({
       minMessages: z.number().min(3).default(8),
       maxSegment: z.number().min(5).default(50),
       metaThreshold: z.number().min(3).default(10),
+      /** Max chars per tool output when rendering temporal messages for distillation input.
+       *  Outputs longer than this are replaced with a compact annotation preserving line
+       *  count, error signals, and file paths. Default: 2000 (matches upstream OpenCode's
+       *  TOOL_OUTPUT_MAX_CHARS during compaction). Set to 0 to disable. */
+      toolOutputMaxChars: z.number().min(0).default(2_000),
     })
-    .default({ minMessages: 8, maxSegment: 50, metaThreshold: 10 }),
+    .default({
+      minMessages: 8,
+      maxSegment: 50,
+      metaThreshold: 10,
+      toolOutputMaxChars: 2_000,
+    }),
   knowledge: z
     .object({
       /** Set to false to disable long-term knowledge storage and system-prompt injection.

--- a/packages/core/src/distillation.ts
+++ b/packages/core/src/distillation.ts
@@ -9,7 +9,7 @@ import {
   RECURSIVE_SYSTEM,
   recursiveUser,
 } from "./prompt";
-import { needsUrgentDistillation } from "./gradient";
+import { needsUrgentDistillation, toolStripAnnotation } from "./gradient";
 import { workerSessionIDs } from "./worker";
 import type { LLMClient } from "./types";
 
@@ -53,9 +53,110 @@ function formatTime(ms: number): string {
   return `${h}:${m}`;
 }
 
-function messagesToText(messages: TemporalMessage[]): string {
+// Chunk-boundary regex for content produced by temporal.partsToText (which
+// joins chunks with "\n"). A chunk boundary is the start of a new chunk we
+// can structurally identify: "[tool:<name>] " or "[reasoning] " at line start.
+//
+// Tool names are restricted to lowercase identifier-shaped strings so that
+// literal occurrences of `[tool:...]` inside tool payloads (e.g. when an
+// agent reads a file that documents this very serialization format) are
+// less likely to be mis-split into fabricated envelopes. Real tool names
+// in the OpenCode/Lore ecosystem are always lowercase alphanumeric with
+// `_` or `-` separators (`read`, `grep`, `read_file`, `query-expand`, ...).
+//
+// Two known ambiguity directions caused by the lossy serialization:
+//
+//   1. TRAILING-TEXT SWALLOW: plain text chunks have no structural prefix,
+//      so a text chunk that follows a tool chunk is indistinguishable from
+//      a continuation of the tool output. Such text is attributed to the
+//      preceding tool envelope's payload. This includes the case of a
+//      short tool output followed by a long assistant text reply — the
+//      text can push the combined chunk over the cap and get swallowed.
+//
+//   2. EMBEDDED-ENVELOPE FABRICATION: if a tool output legitimately
+//      contains `\n[tool:<identifier>] ` or `\n[reasoning] ` (e.g. reading
+//      AGENTS.md, this project's source, or any file that documents the
+//      format), the truncator will split on that literal occurrence and
+//      treat the remainder as if it were a separate envelope. The
+//      tightened identifier regex mitigates but doesn't eliminate this.
+//
+// Both limitations could be removed by changing partsToText in temporal.ts
+// to emit an unambiguous terminator plus a DB format bump. That's
+// disproportionate for a background-distill input renderer; the
+// distillation LLM's output is a summary, not a structural parse, so
+// occasional fabrication/swallow results in mildly noisy observations
+// rather than a user-visible bug.
+// TODO: if telemetry or user reports show this materially affects distill
+// quality, file a follow-up to add an unambiguous chunk terminator to
+// temporal.partsToText (DB format change — requires migration).
+const CHUNK_BOUNDARY_RE = /\n(?=\[(?:tool:[a-z][a-z0-9_-]*|reasoning)\] )/g;
+
+/**
+ * Truncate tool outputs within a pre-flattened `TemporalMessage.content` string
+ * (the format produced by `temporal.partsToText`). Plain text and `[reasoning]`
+ * chunks pass through untouched.
+ *
+ * Tool-output payloads longer than `maxChars` are replaced with
+ * `toolStripAnnotation(...)` — a compact marker preserving line count, error
+ * flag, and file paths. Matches the annotation style used by the runtime
+ * gradient so the distillation LLM sees the same affordance it sees during
+ * live turns.
+ *
+ * Exported primarily for tests. If future renderers need the same semantics
+ * (e.g. a recall-time preview), they can reuse this.
+ */
+export function truncateToolOutputsInContent(
+  content: string,
+  maxChars: number,
+): string {
+  if (maxChars <= 0 || content.length === 0) return content;
+
+  // Split on identifiable chunk boundaries. This correctly separates:
+  //   - leading text chunks from any subsequent [tool:*] / [reasoning] chunks
+  //   - consecutive [tool:*] / [reasoning] chunks from each other
+  // It does NOT separate a [tool:*] chunk from a trailing plain-text chunk
+  // (text has no structural prefix). That's documented in CHUNK_BOUNDARY_RE.
+  const chunks = content.split(CHUNK_BOUNDARY_RE);
+
+  // Return early if nothing in the content could be an oversized tool output.
+  let anyToolChunk = false;
+  for (const c of chunks) if (c.startsWith("[tool:")) { anyToolChunk = true; break; }
+  if (!anyToolChunk) return content;
+
+  const truncated = chunks.map((chunk) => {
+    if (!chunk.startsWith("[tool:")) return chunk; // plain text or [reasoning]
+    // Parse envelope: "[tool:<name>] <payload...>"
+    const closeBracket = chunk.indexOf("] ");
+    if (closeBracket < 0) return chunk; // malformed; leave alone
+    const toolName = chunk.slice(6, closeBracket); // 6 = "[tool:".length
+    const payload = chunk.slice(closeBracket + 2);
+    if (payload.length <= maxChars) return chunk;
+    return `[tool:${toolName}] ${toolStripAnnotation(toolName, payload)}`;
+  });
+
+  return truncated.join("\n");
+}
+
+/**
+ * Render a sequence of TemporalMessages as a single string for the distillation
+ * LLM. User messages pass through verbatim; assistant and tool messages have
+ * oversized tool outputs truncated via {@link truncateToolOutputsInContent}.
+ *
+ * Exported so tests can verify truncation on realistic message fixtures without
+ * spinning up a full distillSegment round trip.
+ */
+export function messagesToText(
+  messages: TemporalMessage[],
+  toolOutputMaxChars?: number,
+): string {
+  const cap = toolOutputMaxChars ?? config().distillation.toolOutputMaxChars;
   return messages
-    .map((m) => `[${m.role}] (${formatTime(m.created_at)}) ${m.content}`)
+    .map((m) => {
+      // User text is always signal — never truncate.
+      const body =
+        m.role === "user" ? m.content : truncateToolOutputsInContent(m.content, cap);
+      return `[${m.role}] (${formatTime(m.created_at)}) ${body}`;
+    })
     .join("\n\n");
 }
 

--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -320,20 +320,41 @@ function cleanParts(parts: LorePart[]): LorePart[] {
   return filtered.length > 0 ? filtered : parts;
 }
 
+// Upper bound on how much of the output the path-extraction regex scans.
+// Two mitigations for catastrophic backtracking in `PATH_RE`:
+//   1. Skip entirely if the input contains no '/' (a path requires at least
+//      one separator, so without one the regex has no possible match yet
+//      still backtracks O(n²) on long runs of [\w.-]).
+//   2. Cap the scanned slice at this limit so even crafted inputs with a
+//      '/' somewhere don't stall the worker. The annotation only needs a
+//      few representative paths — sampling the first 64KB is plenty.
+const ANNOTATION_PATH_SCAN_LIMIT = 64 * 1024;
+const PATH_RE = /(?:[\w.-]+\/)+[\w.-]+\.\w{1,5}/g;
+
 // Build a metadata annotation for a stripped tool output, preserving key signals
 // about what was lost without requiring an LLM call. Inspired by the per-token
 // scalar bias β from "Fast KV Compaction via Attention Matching" (Zweiger et al.,
 // 2025) — when tokens are removed, preserving metadata about the removed content
 // helps the model compensate for information loss and decide whether to recall.
 // Reference: https://arxiv.org/abs/2602.16284
-function toolStripAnnotation(toolName: string, output: string): string {
+export function toolStripAnnotation(toolName: string, output: string): string {
   const lines = output.split("\n").length;
-  const chars = output.length;
 
   // Detect key signals via lightweight heuristics — no LLM call
   const hasError = /\b(?:error|fail(?:ed|ure)?|exception|panic|traceback)\b/i.test(output);
-  const paths = output.match(/(?:[\w.-]+\/)+[\w.-]+\.\w{1,5}/g);
-  const uniquePaths = paths ? [...new Set(paths)].slice(0, 5) : [];
+
+  // Path extraction: skip entirely if no '/' is present (cheap O(n) check
+  // via indexOf) to avoid PATH_RE's O(n²) backtracking on long runs of
+  // [\w.-] without a separator. Otherwise sample the first N KB.
+  let uniquePaths: string[] = [];
+  if (output.indexOf("/") !== -1) {
+    const pathScan =
+      output.length > ANNOTATION_PATH_SCAN_LIMIT
+        ? output.slice(0, ANNOTATION_PATH_SCAN_LIMIT)
+        : output;
+    const paths = pathScan.match(PATH_RE);
+    if (paths) uniquePaths = [...new Set(paths)].slice(0, 5);
+  }
 
   let annotation = `[output omitted — ${toolName}: ${lines} lines`;
   if (hasError) annotation += ", contained errors";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -68,6 +68,7 @@ export {
   setForceMinLayer,
   getLastTransformedCount,
   getLastTransformEstimate,
+  toolStripAnnotation,
 } from "./gradient";
 export {
   formatKnowledge,

--- a/packages/core/test/distillation.test.ts
+++ b/packages/core/test/distillation.test.ts
@@ -1,0 +1,350 @@
+import { describe, test, expect } from "bun:test";
+import {
+  messagesToText,
+  truncateToolOutputsInContent,
+} from "../src/distillation";
+import type * as temporal from "../src/temporal";
+
+// Fixed timestamp so [hh:mm] prefixes are deterministic across runs.
+const T = new Date("2026-04-24T09:15:00Z").getTime();
+
+function msg(
+  role: "user" | "assistant" | "tool",
+  content: string,
+  overrides: Partial<temporal.TemporalMessage> = {},
+): temporal.TemporalMessage {
+  return {
+    id: `msg-${Math.random().toString(36).slice(2)}`,
+    project_id: "proj",
+    session_id: "sess",
+    role,
+    content,
+    tokens: Math.ceil(content.length / 3),
+    distilled: 0,
+    created_at: T,
+    metadata: "{}",
+    ...overrides,
+  };
+}
+
+// ─── truncateToolOutputsInContent ─────────────────────────────────────
+//
+// Operates on the flattened-content shape produced by temporal.partsToText
+// (see temporal.ts: chunks joined with "\n", tool outputs wrapped in
+// "[tool:<name>] ..."). Per-envelope truncation preserves plain text and
+// [reasoning] blocks untouched; only tool payloads above the cap are
+// replaced with a compact annotation.
+
+describe("truncateToolOutputsInContent", () => {
+  test("passthrough: content with no tool envelopes is unchanged", () => {
+    const plain = "User asked about auth.\n[reasoning] Thinking about flow";
+    expect(truncateToolOutputsInContent(plain, 2_000)).toBe(plain);
+  });
+
+  test("passthrough: short tool output below cap is unchanged", () => {
+    const content = "[tool:read] file contents are small";
+    expect(truncateToolOutputsInContent(content, 2_000)).toBe(content);
+  });
+
+  test("truncates oversized single tool envelope", () => {
+    const output = "x".repeat(5_000);
+    const content = `[tool:grep] ${output}`;
+    const result = truncateToolOutputsInContent(content, 2_000);
+    // Annotation replaces the payload wholesale.
+    expect(result).toContain("[tool:grep] [output omitted — grep:");
+    expect(result).toContain("lines");
+    expect(result.length).toBeLessThan(content.length);
+    // Original payload must not survive.
+    expect(result).not.toContain("xxxxxxxxxx"); // 10 x's would be in the body
+  });
+
+  test("preserves plain text BEFORE an oversized envelope", () => {
+    const output = "y".repeat(5_000);
+    const content = [
+      "I need to search for that symbol.",
+      `[tool:grep] ${output}`,
+    ].join("\n");
+    const result = truncateToolOutputsInContent(content, 2_000);
+    expect(result).toContain("I need to search for that symbol.");
+    expect(result).toContain("[output omitted — grep:");
+  });
+
+  test("known limitation (1a): plain text AFTER a tool chunk is attributed to the payload", () => {
+    // partsToText joins chunks with "\n" and plain text has no structural
+    // prefix, so a text chunk that follows a tool chunk is indistinguishable
+    // from a continuation of the tool output. The truncator attributes the
+    // trailing text to the tool payload. Acceptable trade-off — see
+    // CHUNK_BOUNDARY_RE comment in src/distillation.ts.
+    const output = "y".repeat(5_000);
+    const content = [
+      `[tool:grep] ${output}`,
+      "Follow-up text attributed to grep output.",
+    ].join("\n");
+    const result = truncateToolOutputsInContent(content, 2_000);
+    // Annotation is emitted; trailing text is swallowed into the annotation.
+    expect(result).toContain("[output omitted — grep:");
+    expect(result).not.toContain("Follow-up text attributed");
+  });
+
+  test("known limitation (1b): short tool + long trailing text gets the text swallowed", () => {
+    // Inverse of the above: a tool chunk with small output that's followed
+    // by a big assistant text-reply. The combined chunk exceeds the cap,
+    // so the trailing analysis disappears into the annotation. This is
+    // the same CHUNK_BOUNDARY_RE limitation (direction: long text after
+    // small tool) and is acceptable for background distill input — the
+    // summary-level observations still capture the interaction shape.
+    const longTrailingText = "This is a long analysis after the tool call. ".repeat(100);
+    const content = [
+      "[tool:grep] found 3 matches",
+      longTrailingText,
+    ].join("\n");
+    const result = truncateToolOutputsInContent(content, 2_000);
+    // Truncation fires because the combined chunk > cap.
+    expect(result).toContain("[output omitted — grep:");
+    // The trailing analysis is gone.
+    expect(result).not.toContain("long analysis after");
+  });
+
+  test("known limitation (2): embedded [tool:<name>] inside a payload fabricates a boundary", () => {
+    // If a tool output legitimately contains the literal sequence
+    // `\n[tool:<identifier>] ` (e.g. reading a file that documents this
+    // serialization format), the truncator splits on it. The tightened
+    // tool-name regex `[a-z][a-z0-9_-]*` reduces the surface (a literal
+    // `[tool:Fake]` inside a body won't split because of the uppercase F),
+    // but valid-identifier-shaped literals still fabricate a split. Pinning
+    // the behavior so it's not silently rediscovered.
+    const big = "x".repeat(3_000);
+    const content = [
+      `[tool:read] reading AGENTS.md`,
+      `File contents include the literal envelope prefix below:`,
+      `[tool:bash] this is a legitimate part of the read payload`,
+      big,
+    ].join("\n");
+    const result = truncateToolOutputsInContent(content, 2_000);
+    // The embedded `[tool:bash]` prefix creates a fabricated second chunk.
+    // The fabricated chunk contains the big payload and gets truncated as
+    // if it were a real bash call — producing an annotation that references
+    // "bash" even though no bash call occurred.
+    expect(result).toContain("[output omitted — bash:");
+    // The first read chunk body is short so it survives untruncated.
+    expect(result).toContain("[tool:read] reading AGENTS.md");
+  });
+
+  test("tightened regex: uppercase tool name inside a payload does NOT split", () => {
+    // Tool names with uppercase letters don't match the identifier regex,
+    // so literal `[tool:Fake]` occurrences in payloads stay inline.
+    const body = "first line\n[tool:Fake] mid-payload text with uppercase F\nmore data";
+    const content = `[tool:grep] ${body}`;
+    const result = truncateToolOutputsInContent(content, 2_000);
+    // Single chunk, under cap — passes through verbatim.
+    expect(result).toBe(content);
+  });
+
+  test("perf: 100KB single-letter payload without '/' annotates in <500ms", () => {
+    // Regression guard against catastrophic backtracking in the
+    // path-extraction regex inside toolStripAnnotation. Pathological
+    // inputs (minified JS, base64 blobs, binary dumps) used to stall
+    // the background worker for ~30s on this repro. The no-slash
+    // fast-exit in gradient.ts makes this O(n).
+    const pathological = "x".repeat(100_000);
+    const content = `[tool:grep] ${pathological}`;
+    const start = performance.now();
+    const result = truncateToolOutputsInContent(content, 2_000);
+    const elapsed = performance.now() - start;
+    expect(elapsed).toBeLessThan(500);
+    expect(result).toContain("[output omitted — grep:");
+  });
+
+  test("perf: 100KB payload WITH '/' still completes in <1s via scan limit", () => {
+    // Even with a single '/' present (so the no-slash fast-exit doesn't
+    // help), the 64KB scan cap on the path regex keeps runtime bounded.
+    // The fragment before '/' is only 64KB of `x`, which the slicing
+    // prevents from backtracking for too long.
+    const pathological = "x".repeat(50_000) + "/file.ts " + "y".repeat(50_000);
+    const content = `[tool:grep] ${pathological}`;
+    const start = performance.now();
+    const result = truncateToolOutputsInContent(content, 2_000);
+    const elapsed = performance.now() - start;
+    expect(elapsed).toBeLessThan(1000);
+    expect(result).toContain("[output omitted — grep:");
+  });
+
+  test("separates a tool chunk from a following [reasoning] chunk", () => {
+    // Unlike plain text, [reasoning] has a structural prefix so the
+    // boundary regex correctly separates it from a preceding tool chunk.
+    const output = "y".repeat(5_000);
+    const content = [
+      `[tool:grep] ${output}`,
+      "[reasoning] Post-search reasoning",
+    ].join("\n");
+    const result = truncateToolOutputsInContent(content, 2_000);
+    expect(result).toContain("[output omitted — grep:");
+    expect(result).toContain("[reasoning] Post-search reasoning");
+  });
+
+  test("truncates multiple oversized envelopes independently", () => {
+    const big = "z".repeat(5_000);
+    const content = [
+      "[tool:grep] " + big,
+      "[tool:read] " + big,
+    ].join("\n");
+    const result = truncateToolOutputsInContent(content, 2_000);
+    // Both envelopes replaced with separate annotations.
+    expect(result).toContain("[tool:grep] [output omitted — grep:");
+    expect(result).toContain("[tool:read] [output omitted — read:");
+    expect(result.length).toBeLessThan(content.length);
+  });
+
+  test("mixed sizes: only the oversized envelope is truncated", () => {
+    const big = "q".repeat(5_000);
+    const small = "small output lines";
+    const content = [
+      `[tool:grep] ${big}`,
+      `[tool:ls] ${small}`,
+    ].join("\n");
+    const result = truncateToolOutputsInContent(content, 2_000);
+    expect(result).toContain("[tool:grep] [output omitted — grep:");
+    // The small envelope survives verbatim.
+    expect(result).toContain(`[tool:ls] ${small}`);
+  });
+
+  test("line-start anchor: mid-line [tool:X] does not split the envelope", () => {
+    // A tool-call JSON or prose that mentions `[tool:grep]` as literal
+    // text *not at the start of a line* must not be mistaken for a new
+    // envelope. The boundary regex requires a preceding `\n`, so
+    // mid-line occurrences preceded by a space (as here) are preserved.
+    // The adjacent "known limitation (2)" test covers the
+    // newline-preceded-embedded-envelope path.
+    const body = "some text [tool:grep] mid-line, no split\nmore data";
+    const content = `[tool:read] ${body}`;
+    const result = truncateToolOutputsInContent(content, 2_000);
+    // Below threshold — full content passes through.
+    expect(result).toBe(content);
+  });
+
+  test("maxChars <= 0 disables truncation", () => {
+    const big = "a".repeat(10_000);
+    const content = `[tool:grep] ${big}`;
+    expect(truncateToolOutputsInContent(content, 0)).toBe(content);
+    expect(truncateToolOutputsInContent(content, -1)).toBe(content);
+  });
+
+  test("empty content is returned unchanged", () => {
+    expect(truncateToolOutputsInContent("", 2_000)).toBe("");
+  });
+
+  test("annotation includes error signal when payload mentions errors", () => {
+    const output = "x".repeat(3_000) + "\nError: connection refused\n" + "y".repeat(3_000);
+    const content = `[tool:grep] ${output}`;
+    const result = truncateToolOutputsInContent(content, 2_000);
+    expect(result).toContain("contained errors");
+  });
+
+  test("annotation includes file paths when payload contains them", () => {
+    const output =
+      "matched: src/foo.ts\nmatched: src/bar.ts\n" + "z".repeat(3_000);
+    const content = `[tool:grep] ${output}`;
+    const result = truncateToolOutputsInContent(content, 2_000);
+    expect(result).toContain("paths:");
+    expect(result).toContain("src/foo.ts");
+  });
+});
+
+// ─── messagesToText ────────────────────────────────────────────────────
+//
+// Wraps truncateToolOutputsInContent with role-aware routing. User messages
+// are never truncated (user text is always signal); assistant and tool
+// messages have oversized outputs trimmed.
+
+describe("messagesToText", () => {
+  test("preserves user messages regardless of size", () => {
+    const huge = "u".repeat(10_000);
+    const msgs = [msg("user", huge)];
+    const out = messagesToText(msgs, 2_000);
+    // Full user content present verbatim.
+    expect(out).toContain(huge);
+    expect(out).not.toContain("[output omitted —");
+  });
+
+  test("truncates oversized tool output on assistant messages", () => {
+    const big = "a".repeat(5_000);
+    const msgs = [msg("assistant", `[tool:grep] ${big}`)];
+    const out = messagesToText(msgs, 2_000);
+    expect(out).toContain("[output omitted — grep:");
+    expect(out).not.toContain("a".repeat(100));
+  });
+
+  test("truncates oversized tool output on tool-role messages", () => {
+    const big = "b".repeat(5_000);
+    const msgs = [msg("tool", `[tool:read] ${big}`)];
+    const out = messagesToText(msgs, 2_000);
+    expect(out).toContain("[output omitted — read:");
+  });
+
+  test("short assistant content passes through untouched", () => {
+    const content = "[tool:ls] small output";
+    const msgs = [msg("assistant", content)];
+    const out = messagesToText(msgs, 2_000);
+    expect(out).toContain(content);
+    expect(out).not.toContain("[output omitted —");
+  });
+
+  test("prefixes each message with [role] and a time stamp", () => {
+    const msgs = [
+      msg("user", "Hello there"),
+      msg("assistant", "Hi back"),
+    ];
+    const out = messagesToText(msgs, 2_000);
+    // Time format is HH:MM; content of the stamp varies by local TZ, so pin
+    // only the structural shape.
+    expect(out).toMatch(/\[user\] \(\d\d:\d\d\) Hello there/);
+    expect(out).toMatch(/\[assistant\] \(\d\d:\d\d\) Hi back/);
+  });
+
+  test("joins multiple messages with a blank line separator", () => {
+    const msgs = [msg("user", "first"), msg("user", "second")];
+    const out = messagesToText(msgs, 2_000);
+    // Exactly one blank line between the two `[user] (...) ...` lines.
+    const lines = out.split("\n\n");
+    expect(lines).toHaveLength(2);
+  });
+
+  test("explicit toolOutputMaxChars override wins over config default", () => {
+    const body = "c".repeat(1_000);
+    const msgs = [msg("assistant", `[tool:grep] ${body}`)];
+    // Cap of 100 forces truncation even though the body is only 1KB.
+    const out = messagesToText(msgs, 100);
+    expect(out).toContain("[output omitted — grep:");
+  });
+
+  test("cap of 0 disables truncation (large tool outputs survive verbatim)", () => {
+    const body = "d".repeat(10_000);
+    const msgs = [msg("assistant", `[tool:grep] ${body}`)];
+    const out = messagesToText(msgs, 0);
+    expect(out).toContain(body);
+    expect(out).not.toContain("[output omitted —");
+  });
+
+  test("handles mixed content: assistant text, reasoning, and tool output", () => {
+    // Chunks before the tool envelope survive because the boundary regex
+    // finds the [tool:grep] prefix. Trailing [reasoning] also survives
+    // because it has a structural prefix. See CHUNK_BOUNDARY_RE docs in
+    // src/distillation.ts for the plain-text-after-tool caveat.
+    const big = "e".repeat(5_000);
+    const content = [
+      "I'll search for that.",
+      "[reasoning] Planning the search",
+      `[tool:grep] ${big}`,
+      "[reasoning] Found what I needed.",
+    ].join("\n");
+    const msgs = [msg("assistant", content)];
+    const out = messagesToText(msgs, 2_000);
+    // Plain text and both reasoning chunks preserved.
+    expect(out).toContain("I'll search for that.");
+    expect(out).toContain("[reasoning] Planning the search");
+    expect(out).toContain("[reasoning] Found what I needed.");
+    // Tool body truncated.
+    expect(out).toContain("[output omitted — grep:");
+    expect(out).not.toContain("e".repeat(100));
+  });
+});


### PR DESCRIPTION
## Summary

Truncate oversized tool outputs in the distillation input path so background distill calls are token-cheap and quality isn't drowned by huge grep/file-read dumps. Mirrors upstream OpenCode's `TOOL_OUTPUT_MAX_CHARS = 2_000` behavior (#23870), applied to the same lossy-serialized `TemporalMessage.content` shape that `partsToText` already produces.

## Why

Before this PR, a 50KB `grep` output or a whole-file `read` dump was appended verbatim to every background distill prompt. Consequences:

- **Token cost**: one oversized tool output could double the segment tokens the distiller had to process.
- **Signal dilution**: `DISTILLATION_SYSTEM` is tuned for conversational observation; long tool dumps pulled the model toward summarizing the dump instead of the conversation.
- **Latency**: background distill calls ran slower, delaying LTM updates and `/compact` readiness.

The runtime gradient already handled this on chat windows via `stripToolOutputs`; the distillation input path had no equivalent.

## Changes

| File | Change |
|------|--------|
| `packages/core/src/config.ts` | Add `distillation.toolOutputMaxChars` knob (default `2_000`, min `0`; set to `0` to disable). |
| `packages/core/src/gradient.ts` | Export `toolStripAnnotation` for reuse. Add defensive mitigations against catastrophic backtracking in its path-extraction regex: no-slash fast-exit + 64KB scan cap. |
| `packages/core/src/distillation.ts` | Rewrite `messagesToText` with per-envelope truncation. Add new exported `truncateToolOutputsInContent` helper. Parse the `[tool:<name>] <payload>` envelopes produced by `temporal.partsToText` and replace over-cap payloads with `toolStripAnnotation(...)`. |
| `packages/core/src/index.ts` | Re-export `toolStripAnnotation` from the barrel. |
| `packages/core/test/distillation.test.ts` | New file — 27 tests. |

## Design

### Per-envelope truncation

`TemporalMessage.content` is a pre-flattened string built by `temporal.partsToText` (joins `[text]`, `[reasoning] ...`, and `[tool:<name>] ...` chunks with `\n`). The truncator:

1. Splits content on boundary pattern `\n(?=\[(?:tool:[a-z][a-z0-9_-]*|reasoning)\] )` — recognizes reasoning and tool-name-shaped chunk starts.
2. For each chunk starting with `[tool:`, parses the tool name and payload; if payload > cap, replaces with `[tool:<name>] <annotation>` where the annotation contains line count, error flag, and extracted file paths.
3. User messages are never truncated (user text is always signal).

### Honest limitations (documented + tested)

The `partsToText` serialization is lossy: chunks are joined with `\n` and plain text has no structural prefix, so two ambiguity directions exist:

1. **Trailing-text swallow**: plain text following a tool chunk is attributed to the tool payload. Includes the short-tool + long-text case.
2. **Embedded-envelope fabrication**: if a tool output legitimately contains `\n[tool:<identifier>] ` (e.g. reading AGENTS.md or this project's source), the truncator splits on it. Tool-name regex `[a-z][a-z0-9_-]*` reduces but doesn't eliminate this.

Both are pinned by tests and documented in the `CHUNK_BOUNDARY_RE` comment. Full fix would require changing `partsToText` to emit an unambiguous terminator + DB format bump — disproportionate for a background renderer; TODO'd in source.

### Performance hardening

`toolStripAnnotation`'s path-extraction regex `(?:[\w.-]+\/)+[\w.-]+\.\w{1,5}/g` backtracks catastrophically on long runs of `[\w.-]` without a separator (minified JS, base64 blobs). Previously it only ran on gradient-strip paths; this PR expands its blast radius to distillation input where a single pathological tool output could stall the background worker.

Two mitigations in `gradient.ts`:
- **No-slash fast-exit**: a path requires `/`, so if `output.indexOf("/") === -1` we skip the regex entirely.
- **64KB scan cap**: when `/` IS present, we slice the input before running the regex.

Verified on 100KB single-letter pathological input:
- Before: ~27s
- After: <500ms

## Verification

- `bun test`: 419 pass / 0 fail (4858 expect calls across 18 files, +27 new tests).
- `bun --filter '*' typecheck`: all three packages exit 0.
- `bun --filter '*' build`: core + pi bundles clean, opencode ships raw TS.
- Perf regression tests pin 100KB pathological inputs at <500ms (no slash) / <1s (one slash).

## Deferred

- Upstream-drift contract test for `OVERFLOW_PATTERNS` / envelope format (tracked as F10).
- Full unambiguous-terminator fix requires `partsToText` format change + DB migration (TODO-noted; would retire both known limitations at once).

## Review trail

Two subagent review passes. The first flagged three Important items — all addressed in subsequent commits-in-branch:
1. Embedded-envelope fabrication hazard → tightened regex + explicit documentation + two new tests (valid-identifier embed fabricates, uppercase doesn't).
2. Short-tool + long-text swallow → pinned by dedicated "known limitation (1b)" test.
3. `toolStripAnnotation` pathological-input stall → two defensive mitigations + two perf regression tests.

Second review cleared as "merge ready" with only two nits (both fixed): line-start-anchor test mislabeled, and a TODO pointer for the potential future DB format bump.
