### PR TITLE
feat(gradient): cold-cache idle-resume cache refresh

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -18,6 +18,24 @@ export const LoreConfig = z.object({
       ltm: z.number().min(0.02).max(0.3).default(0.10),
     })
     .default({ distilled: 0.25, raw: 0.4, output: 0.25, ltm: 0.10 }),
+  /**
+   * Cold-cache idle-resume handling.
+   *
+   * Anthropic's prompt cache evicts entries after ~5 min (default tier) /
+   * ~1 hour (extended tier). When a session resumes after the eviction window,
+   * Lore's byte-identity caches (distilled prefix, raw window pin, LTM block)
+   * are providing no value because the underlying provider cache is already
+   * cold. On detection, Lore refreshes those caches so the next turn can
+   * produce a better-fitting window without paying a cache cost it would
+   * otherwise be trying to preserve. Reasoning blocks are NOT touched —
+   * Anthropic's April 23 postmortem identified dropping reasoning blocks as
+   * the root cause of forgetfulness/repetition.
+   *
+   * `idleResumeMinutes` is the threshold in minutes. Default 60 — matches
+   * Anthropic's extended-cache eviction window, conservative across providers.
+   * Set to 0 to disable the feature.
+   */
+  idleResumeMinutes: z.number().min(0).max(24 * 60).default(60),
   distillation: z
     .object({
       minMessages: z.number().min(3).default(8),

--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -83,6 +83,25 @@ type SessionState = {
   prefixCache: PrefixCache | null;
   /** Raw window pin cache (Approach B) */
   rawWindowCache: RawWindowCache | null;
+  /**
+   * Wall-clock timestamp (epoch ms) of the most recent transform() call for this
+   * session. Used by onIdleResume() to detect cold-cache resumption — when the
+   * gap between turns exceeds Anthropic's prompt cache eviction window (5 min
+   * default / 1 hour extended), the byte-identity caching subsystems
+   * (prefixCache, rawWindowCache) are providing no value because the cache is
+   * already cold. Refreshing them on resume lets us produce a better-fitting
+   * window without paying a cache cost we'd otherwise be trying to preserve.
+   * 0 = never set (first turn).
+   */
+  lastTurnAt: number;
+  /**
+   * Set true by onIdleResume() when an idle-resume reset just fired; consumed
+   * (and cleared) by the LTM degraded-recovery branch in the OpenCode hook to
+   * skip the conversation-vs-LTM token comparison. After idle eviction the
+   * cache-bust cost is effectively zero, so we should always recover LTM on
+   * the post-idle turn regardless of conversation size.
+   */
+  cameOutOfIdle: boolean;
 };
 
 function makeSessionState(): SessionState {
@@ -97,6 +116,8 @@ function makeSessionState(): SessionState {
     lastTransformEstimate: 0,
     prefixCache: null,
     rawWindowCache: null,
+    lastTurnAt: 0,
+    cameOutOfIdle: false,
   };
 }
 
@@ -114,6 +135,65 @@ function getSessionState(sessionID: string): SessionState {
     sessionStates.set(sessionID, state);
   }
   return state;
+}
+
+/**
+ * Detect cold-cache resumption and refresh byte-identity caches.
+ *
+ * Anthropic's prompt cache evicts entries after ~5 minutes (default tier) /
+ * ~1 hour (extended tier). When a session resumes after the eviction window,
+ * the cache is provably cold — every prefix we've been carefully keeping
+ * byte-stable (`prefixCache`, `rawWindowCache`, plus the host's per-session
+ * LTM cache) provides no benefit on this turn. Worse, the LTM block was
+ * scored against the conversation context as it was on the previous turn,
+ * which may have drifted significantly in N hours.
+ *
+ * On resume after `thresholdMs`:
+ *   - reset the distilled prefix cache (next turn re-renders from scratch)
+ *   - reset the raw window pin cache (next turn picks a fresh cutoff)
+ *   - set `cameOutOfIdle` so the OpenCode host can also clear `ltmSessionCache`
+ *     and bypass the conversation-vs-LTM cost comparison in the LTM
+ *     degraded-recovery branch
+ *
+ * Importantly, this does NOT touch:
+ *   - reasoning blocks (Anthropic's April 23 postmortem identifies dropping
+ *     reasoning blocks as the root cause of forgetfulness/repetition; Lore
+ *     preserves reasoning by policy across all gradient layers)
+ *   - the gradient layer (cold cache doesn't change token budgets;
+ *     calibration's actualInput = input + cache.read + cache.write already
+ *     accounts for cache misses correctly)
+ *   - calibration state (`lastKnownInput`, overhead EMA, message-ID set) —
+ *     the next API response will refresh these via the normal calibrate() path
+ *
+ * Set `thresholdMs <= 0` to disable. Returns true if a reset fired so the
+ * caller can log/observe.
+ */
+export function onIdleResume(
+  sessionID: string,
+  thresholdMs: number,
+  now: number = Date.now(),
+): { triggered: false } | { triggered: true; idleMs: number } {
+  if (thresholdMs <= 0) return { triggered: false };
+  const state = getSessionState(sessionID);
+  if (state.lastTurnAt === 0) return { triggered: false }; // first turn — nothing to refresh
+  const idleMs = now - state.lastTurnAt;
+  if (idleMs < thresholdMs) return { triggered: false };
+  state.prefixCache = null;
+  state.rawWindowCache = null;
+  state.cameOutOfIdle = true;
+  return { triggered: true, idleMs };
+}
+
+/**
+ * Read-and-clear the cameOutOfIdle flag. The OpenCode host's LTM degraded-
+ * recovery branch consumes this to decide whether to bypass the
+ * conversation-vs-LTM token comparison on a post-idle turn.
+ */
+export function consumeCameOutOfIdle(sessionID: string): boolean {
+  const state = sessionStates.get(sessionID);
+  if (!state || !state.cameOutOfIdle) return false;
+  state.cameOutOfIdle = false;
+  return true;
 }
 
 // LTM tokens injected via system transform hook this turn.
@@ -249,6 +329,37 @@ export function resetCalibration(sessionID?: string) {
     }
     sessionStates.clear();
   }
+}
+
+/**
+ * For testing only — observe session-state cache fields without exposing the
+ * full type. Returns null when the session has no state. The boolean fields
+ * answer "does this cache hold something right now?" — sufficient for asserting
+ * that onIdleResume() reset them.
+ */
+export function inspectSessionState(sessionID: string): {
+  hasPrefixCache: boolean;
+  hasRawWindowCache: boolean;
+  cameOutOfIdle: boolean;
+  lastTurnAt: number;
+} | null {
+  const state = sessionStates.get(sessionID);
+  if (!state) return null;
+  return {
+    hasPrefixCache: state.prefixCache !== null,
+    hasRawWindowCache: state.rawWindowCache !== null,
+    cameOutOfIdle: state.cameOutOfIdle,
+    lastTurnAt: state.lastTurnAt,
+  };
+}
+
+/**
+ * For testing only — set the session's lastTurnAt field. Used to simulate
+ * idle gaps without sleeping. Creates the session state if not present so
+ * tests don't need to seed it via a transform() call.
+ */
+export function setLastTurnAtForTest(sessionID: string, ms: number): void {
+  getSessionState(sessionID).lastTurnAt = ms;
 }
 
 type Distillation = {
@@ -1303,6 +1414,10 @@ export function transform(input: {
     state.lastTransformEstimate = result.totalTokens;
     state.lastLayer = result.layer;
     state.lastWindowMessageIDs = new Set(result.messages.map((m) => m.info.id));
+    // Mark wall-clock for onIdleResume() — must record on every transform()
+    // so the next-turn idle check has an accurate baseline. Done after the
+    // result fields above so a thrown transformInner doesn't update it.
+    state.lastTurnAt = Date.now();
   }
   return result;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -69,6 +69,12 @@ export {
   getLastTransformedCount,
   getLastTransformEstimate,
   toolStripAnnotation,
+  onIdleResume,
+  consumeCameOutOfIdle,
+  // Test-only — exposed at the barrel so host-package tests can simulate idle
+  // gaps without sleeping. Not part of the public API.
+  setLastTurnAtForTest,
+  inspectSessionState,
 } from "./gradient";
 export {
   formatKnowledge,

--- a/packages/core/test/gradient.test.ts
+++ b/packages/core/test/gradient.test.ts
@@ -14,6 +14,10 @@ import {
   getLastLayer,
   estimateMessages,
   deduplicateToolOutputs,
+  onIdleResume,
+  consumeCameOutOfIdle,
+  inspectSessionState,
+  setLastTurnAtForTest,
 } from "../src/gradient";
 import type { LoreMessage, LorePart, LoreMessageWithParts } from "../src/types";
 import { isToolPart } from "../src/types";
@@ -1514,5 +1518,217 @@ describe("deduplicateToolOutputs", () => {
 
     // Third (latest) should be intact
     expect(getToolOutput(result[5].parts[0])).toBe(LARGE_CONTENT);
+  });
+});
+
+describe("onIdleResume", () => {
+  const SID = "idle-resume-sess";
+  const ONE_HOUR_MS = 60 * 60_000;
+
+  beforeEach(() => {
+    resetCalibration(SID);
+    setModelLimits({ context: 10_000, output: 2_000 });
+    calibrate(0);
+  });
+
+  test("first turn — no lastTurnAt yet, never triggers", () => {
+    const result = onIdleResume(SID, ONE_HOUR_MS);
+    expect(result.triggered).toBe(false);
+    const state = inspectSessionState(SID);
+    expect(state).not.toBeNull();
+    expect(state!.cameOutOfIdle).toBe(false);
+  });
+
+  test("under threshold — does not trigger or reset caches", () => {
+    // Seed a recent last-turn timestamp.
+    const now = 1_000_000_000_000; // arbitrary epoch ms
+    setLastTurnAtForTest(SID, now - 30 * 60_000); // 30 min ago
+    // Run a transform first to populate prefix/raw caches (best effort).
+    transform({
+      messages: [
+        {
+          info: {
+            id: "u1",
+            sessionID: SID,
+            role: "user",
+            time: { created: now },
+            agent: "build",
+            model: { providerID: "anthropic", modelID: "x" },
+          },
+          parts: [
+            {
+              id: "p1",
+              sessionID: SID,
+              messageID: "u1",
+              type: "text",
+              text: "hi",
+              time: { start: now, end: now },
+            },
+          ],
+        },
+      ],
+      projectPath: PROJECT,
+      sessionID: SID,
+    });
+    // Re-seed lastTurnAt (transform overwrote it to Date.now()).
+    setLastTurnAtForTest(SID, now - 30 * 60_000);
+
+    const result = onIdleResume(SID, ONE_HOUR_MS, now);
+    expect(result.triggered).toBe(false);
+    const state = inspectSessionState(SID);
+    expect(state!.cameOutOfIdle).toBe(false);
+  });
+
+  test("over threshold — triggers, resets caches, sets cameOutOfIdle", () => {
+    const now = 1_000_000_000_000;
+    setLastTurnAtForTest(SID, now - 2 * ONE_HOUR_MS); // 2 hours ago
+
+    // Force at least one cache to be populated so we can observe the reset.
+    // We use the testing inspector path: directly induce state by calling
+    // transform() so the prefix cache might populate. But for a deterministic
+    // assertion we just check the post-call state — onIdleResume itself sets
+    // them to null regardless of whether they were populated.
+    const result = onIdleResume(SID, ONE_HOUR_MS, now);
+    expect(result.triggered).toBe(true);
+    if (result.triggered) {
+      expect(result.idleMs).toBe(2 * ONE_HOUR_MS);
+    }
+    const state = inspectSessionState(SID);
+    expect(state!.hasPrefixCache).toBe(false);
+    expect(state!.hasRawWindowCache).toBe(false);
+    expect(state!.cameOutOfIdle).toBe(true);
+  });
+
+  test("threshold of 0 disables the feature entirely", () => {
+    const now = 1_000_000_000_000;
+    setLastTurnAtForTest(SID, now - 30 * 24 * 60 * 60_000); // 30 days ago
+    const result = onIdleResume(SID, 0, now);
+    expect(result.triggered).toBe(false);
+    const state = inspectSessionState(SID);
+    expect(state!.cameOutOfIdle).toBe(false);
+  });
+
+  test("consumeCameOutOfIdle is one-shot", () => {
+    const now = 1_000_000_000_000;
+    setLastTurnAtForTest(SID, now - 2 * ONE_HOUR_MS);
+    onIdleResume(SID, ONE_HOUR_MS, now);
+    expect(inspectSessionState(SID)!.cameOutOfIdle).toBe(true);
+
+    expect(consumeCameOutOfIdle(SID)).toBe(true);
+    expect(inspectSessionState(SID)!.cameOutOfIdle).toBe(false);
+
+    // Second call returns false — flag was cleared.
+    expect(consumeCameOutOfIdle(SID)).toBe(false);
+  });
+
+  test("consumeCameOutOfIdle on unknown session returns false", () => {
+    expect(consumeCameOutOfIdle("never-existed-session")).toBe(false);
+  });
+
+  test("transform() updates lastTurnAt — subsequent calls see no idle gap", () => {
+    const before = Date.now();
+    transform({
+      messages: [
+        {
+          info: {
+            id: "u1",
+            sessionID: SID,
+            role: "user",
+            time: { created: before },
+            agent: "build",
+            model: { providerID: "anthropic", modelID: "x" },
+          },
+          parts: [
+            {
+              id: "p1",
+              sessionID: SID,
+              messageID: "u1",
+              type: "text",
+              text: "hello world",
+              time: { start: before, end: before },
+            },
+          ],
+        },
+      ],
+      projectPath: PROJECT,
+      sessionID: SID,
+    });
+    const state = inspectSessionState(SID);
+    expect(state!.lastTurnAt).toBeGreaterThanOrEqual(before);
+    // Without a real idle gap, onIdleResume should not trigger.
+    const result = onIdleResume(SID, ONE_HOUR_MS);
+    expect(result.triggered).toBe(false);
+  });
+});
+
+describe("reasoning preservation (F-REASONING-AUDIT mini-pin)", () => {
+  // Fast structural check — full coverage lives in gradient-reasoning.test.ts.
+  // This guards against an accidental change to estimateParts/cleanParts that
+  // would silently drop reasoning blocks across all gradient layers.
+  test("layer 0 preserves reasoning parts unchanged", () => {
+    const SID = "reasoning-mini-sess";
+    resetCalibration(SID);
+    setModelLimits({ context: 100_000, output: 4_000 });
+    calibrate(0);
+
+    const messages: LoreMessageWithParts[] = [
+      makeMsg("rm-u1", "user", "Plan something."),
+      {
+        info: {
+          id: "rm-a1",
+          sessionID: SID,
+          role: "assistant",
+          time: { created: Date.now() },
+          parentID: "parent-rm-a1",
+          modelID: "claude-opus-4-7",
+          providerID: "anthropic",
+          mode: "build",
+          path: { cwd: "/test", root: "/test" },
+          cost: 0,
+          tokens: {
+            input: 100,
+            output: 50,
+            reasoning: 200,
+            cache: { read: 0, write: 0 },
+          },
+        },
+        parts: [
+          {
+            id: "rm-r1",
+            sessionID: SID,
+            messageID: "rm-a1",
+            type: "reasoning",
+            text: "I should consider the trade-offs carefully here.",
+            time: { start: Date.now(), end: Date.now() },
+          } as LorePart,
+          {
+            id: "rm-t1",
+            sessionID: SID,
+            messageID: "rm-a1",
+            type: "text",
+            text: "Here is my plan.",
+            time: { start: Date.now(), end: Date.now() },
+          },
+        ],
+      },
+    ];
+
+    const result = transform({
+      messages,
+      projectPath: PROJECT,
+      sessionID: SID,
+    });
+    expect(result.layer).toBe(0);
+    // Layer 0 returns the input array by reference
+    expect(result.messages).toBe(messages);
+    // Reasoning part still present, byte-identical
+    const assistantParts = result.messages[1].parts;
+    const reasoningPart = assistantParts.find((p) => p.type === "reasoning") as
+      | { type: "reasoning"; text: string }
+      | undefined;
+    expect(reasoningPart).toBeDefined();
+    expect(reasoningPart!.text).toBe(
+      "I should consider the trade-offs carefully here.",
+    );
   });
 });

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -19,6 +19,8 @@ import {
   setForceMinLayer,
   getLastTransformedCount,
   getLastTransformEstimate,
+  onIdleResume,
+  consumeCameOutOfIdle,
   formatKnowledge,
   formatDistillations,
   buildCompactPrompt,
@@ -602,6 +604,26 @@ export const LorePlugin: Plugin = async (ctx) => {
 
       const cfg = config();
 
+      // Cold-cache idle-resume: when the gap since this session's last turn
+      // exceeds the configured threshold, Anthropic's prompt cache has already
+      // evicted our prefix bytes. Refresh Lore's byte-identity caches before
+      // they're consulted on this turn. Reasoning blocks are NOT touched
+      // (Anthropic's April 23 postmortem identifies that as the root cause of
+      // forgetfulness/repetition). Wired into the system transform hook
+      // because (a) it always fires before the messages transform hook, so
+      // gradient.ts caches are reset before transform() consumes them, and
+      // (b) ltmSessionCache lives in this closure and is consulted below.
+      if (input.sessionID) {
+        const thresholdMs = cfg.idleResumeMinutes * 60_000;
+        const result = onIdleResume(input.sessionID, thresholdMs);
+        if (result.triggered) {
+          ltmSessionCache.delete(input.sessionID);
+          log.info(
+            `session idle ${Math.round(result.idleMs / 60_000)}min — refreshing caches on cold prompt cache`,
+          );
+        }
+      }
+
       // Knowledge injection — only when the knowledge system is enabled.
       // When disabled, LTM budget is zero and no knowledge is injected.
       //
@@ -635,20 +657,27 @@ export const LorePlugin: Plugin = async (ctx) => {
                 // switching to real LTM changes the system prompt prefix → busts the
                 // provider's read-token cache for the entire conversation after this point.
                 // Only recover if the cache invalidation cost is small relative to LTM benefit.
+                //
+                // Exception (F-CACHE-TTL): if onIdleResume() just fired for this session,
+                // the provider's prompt cache is already cold from the wall-clock gap, so
+                // the "cache bust cost" is effectively zero. Recover LTM unconditionally.
                 if (sessionID && ltmDegradedSessions.has(sessionID)) {
-                  const conversationTokens = getLastTransformEstimate(sessionID);
-                  if (conversationTokens > tokenCount) {
-                    // Conversation is larger than LTM — cache bust costs more than
-                    // LTM is worth. Keep the fallback note for this session.
-                    setLtmTokens(0);
-                    output.system.push(
-                      "[Lore plugin] Long-term memory is temporarily unavailable. " +
-                        "Use the recall tool to search for project knowledge, " +
-                        "past decisions, and prior session context when needed.",
-                    );
-                    return;
+                  const postIdle = consumeCameOutOfIdle(sessionID);
+                  if (!postIdle) {
+                    const conversationTokens = getLastTransformEstimate(sessionID);
+                    if (conversationTokens > tokenCount) {
+                      // Conversation is larger than LTM — cache bust costs more than
+                      // LTM is worth. Keep the fallback note for this session.
+                      setLtmTokens(0);
+                      output.system.push(
+                        "[Lore plugin] Long-term memory is temporarily unavailable. " +
+                          "Use the recall tool to search for project knowledge, " +
+                          "past decisions, and prior session context when needed.",
+                      );
+                      return;
+                    }
                   }
-                  // Conversation is small — LTM benefit outweighs cache cost. Recover.
+                  // Conversation is small (or post-idle) — LTM benefit outweighs cache cost. Recover.
                   ltmDegradedSessions.delete(sessionID);
                 }
 
@@ -673,9 +702,16 @@ export const LorePlugin: Plugin = async (ctx) => {
               "Use the recall tool to search for project knowledge, " +
               "past decisions, and prior session context when needed.",
           );
+        } finally {
+          // Hygiene: ensure cameOutOfIdle never lingers across turns. The flag
+          // is meaningful only for the post-idle turn's LTM-recovery decision;
+          // clear it unconditionally here so a healthy turn followed later by
+          // a degraded turn can't falsely bypass the cache-cost comparison.
+          if (sessionID) consumeCameOutOfIdle(sessionID);
         }
       } else {
         setLtmTokens(0);
+        if (input.sessionID) consumeCameOutOfIdle(input.sessionID);
       }
 
       // Remind the agent to include the agents file in commits.

--- a/packages/opencode/test/index.test.ts
+++ b/packages/opencode/test/index.test.ts
@@ -1,6 +1,14 @@
 import { describe, test, expect, beforeEach } from "bun:test";
 import { isContextOverflow, buildRecoveryMessage, LorePlugin, isValidProjectPath } from "../src/index";
-import { ltm, db, getLtmTokens, setModelLimits, calibrate, setLtmTokens } from "@loreai/core";
+import {
+  ltm,
+  db,
+  getLtmTokens,
+  setModelLimits,
+  calibrate,
+  setLtmTokens,
+  setLastTurnAtForTest,
+} from "@loreai/core";
 import type { Plugin } from "@opencode-ai/plugin";
 import type { Message, Part } from "@opencode-ai/sdk";
 
@@ -733,6 +741,103 @@ describe("LTM session cache", () => {
       // Should return an array (may or may not contain LTM depending on
       // cross-project entries from other tests — no assertion on content).
       expect(Array.isArray(result)).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+// ── Cold-cache idle-resume hook integration ─────────────────────────
+//
+// Validates that the system transform hook, on detecting a long idle gap,
+// (a) clears the per-session LTM cache so forSession() re-scores against
+// fresh conversation context on the post-idle turn, and (b) the gradient
+// state's prefix/raw window caches were reset by onIdleResume().
+
+describe("idle-resume hook integration", () => {
+  test("long idle gap clears LTM session cache — different bytes on resume", async () => {
+    const { hooks, tmpDir, cleanup } = await initPlugin();
+    try {
+      // Seed an entry so the cache populates.
+      ltm.create({
+        projectPath: tmpDir,
+        category: "decision",
+        title: "Idle resume test entry",
+        content: "Triggers cache population for idle test",
+        scope: "project",
+      });
+
+      const sessionID = "ses_idle_resume_001";
+      const first = await callSystemTransform(hooks!, sessionID);
+      const ltmBlock1 = first.find((s) => s.includes("Long-term Knowledge"));
+      expect(ltmBlock1).toBeTruthy();
+
+      // Simulate >60min gap by directly aging the gradient session state.
+      // callSystemTransform does NOT itself call transform(), so lastTurnAt
+      // wouldn't be set by the first call alone — seed it manually to a value
+      // older than the 60-minute default threshold.
+      setLastTurnAtForTest(sessionID, Date.now() - 2 * 60 * 60_000);
+
+      // Add a NEW entry so the post-resume LTM block has different content
+      // — this proves the cache was cleared (otherwise the cached bytes
+      // from the previous turn would be returned regardless).
+      ltm.create({
+        projectPath: tmpDir,
+        category: "decision",
+        title: "Idle resume new entry post-pause",
+        content: "Added during simulated idle gap — should appear after resume",
+        scope: "project",
+      });
+
+      const second = await callSystemTransform(hooks!, sessionID);
+      const ltmBlock2 = second.find((s) => s.includes("Long-term Knowledge"));
+      expect(ltmBlock2).toBeTruthy();
+      // The new entry was added during the gap, AND the cache was cleared,
+      // so the post-resume LTM block must include it.
+      expect(ltmBlock2).toContain("Idle resume new entry post-pause");
+      // Sanity: the bytes are NOT identical (which would indicate stale cache).
+      expect(ltmBlock2).not.toBe(ltmBlock1);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("short gap (under threshold) does NOT clear LTM cache", async () => {
+    const { hooks, tmpDir, cleanup } = await initPlugin();
+    try {
+      ltm.create({
+        projectPath: tmpDir,
+        category: "decision",
+        title: "Short gap cache test",
+        content: "This entry should be cached across short gaps",
+        scope: "project",
+      });
+
+      const sessionID = "ses_idle_resume_002";
+      const first = await callSystemTransform(hooks!, sessionID);
+      const ltmBlock1 = first.find((s) => s.includes("Long-term Knowledge"));
+      expect(ltmBlock1).toBeTruthy();
+
+      // Simulate a 5-minute gap — well under 60min threshold.
+      setLastTurnAtForTest(sessionID, Date.now() - 5 * 60_000);
+
+      // Add a new entry. If the cache was cleared, this would appear; if
+      // the cache survived, it would not.
+      ltm.create({
+        projectPath: tmpDir,
+        category: "decision",
+        title: "Should NOT appear post-short-gap",
+        content: "Cache should still be warm — this entry gets ignored",
+        scope: "project",
+      });
+
+      const second = await callSystemTransform(hooks!, sessionID);
+      const ltmBlock2 = second.find((s) => s.includes("Long-term Knowledge"));
+      expect(ltmBlock2).toBeTruthy();
+      // Cache was preserved — bytes are byte-identical.
+      expect(ltmBlock2).toBe(ltmBlock1);
+      // The new entry from during the short gap is NOT in the cached block.
+      expect(ltmBlock2).not.toContain("Should NOT appear post-short-gap");
     } finally {
       cleanup();
     }

--- a/packages/pi/src/index.ts
+++ b/packages/pi/src/index.ts
@@ -29,6 +29,7 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { Message as PiMessage } from "@mariozechner/pi-ai";
 import {
   config,
+  consumeCameOutOfIdle,
   curator,
   distillation,
   ensureProject,
@@ -41,6 +42,7 @@ import {
   log,
   ltm,
   latReader,
+  onIdleResume,
   setLtmTokens,
   setModelLimits,
   shouldImport,
@@ -214,6 +216,25 @@ export default function lorePiExtension(pi: ExtensionAPI): void {
         const outputReserved = ctx.model?.maxTokens ?? 16_384;
         setModelLimits({ context: contextLimit, output: outputReserved });
         const budget = getLtmBudget(cfg.budget.ltm);
+
+        // Cold-cache idle-resume: when the gap since this session's last turn
+        // exceeds the configured threshold, the provider's prompt cache has
+        // already evicted our prefix bytes. Refresh Lore's byte-identity caches
+        // (gradient prefix/raw window) and the per-session LTM cache before
+        // they're consulted on this turn. Reasoning blocks are NOT touched
+        // (Anthropic's April 23 postmortem identified that as the root cause
+        // of forgetfulness/repetition).
+        const thresholdMs = cfg.idleResumeMinutes * 60_000;
+        const idleResult = onIdleResume(currentSessionID, thresholdMs);
+        if (idleResult.triggered) {
+          ltmSessionCache.delete(currentSessionID);
+          log.info(
+            `pi: session idle ${Math.round(idleResult.idleMs / 60_000)}min — refreshing caches on cold prompt cache`,
+          );
+        }
+        // Pi has no LTM-degraded recovery branch (no fallback note path), so
+        // cameOutOfIdle isn't actionable here — clear it for hygiene.
+        consumeCameOutOfIdle(currentSessionID);
 
         // Per-session cache: reuse formatted string across turns for prompt caching.
         let formatted = ltmSessionCache.get(currentSessionID);


### PR DESCRIPTION
## Summary

Implements **F-IDLE + F-CACHE-TTL** from `.opencode/plans/1777128170203-quick-knight.md` — takeaways from [Anthropic's April 23 postmortem](https://www.anthropic.com/engineering/april-23-postmortem).

When a session resumes after a long idle gap (default 60 min), the provider's prompt cache has already evicted our prefix. Lore was still spending effort on byte-identity preservation (distilled prefix, raw window pin, per-session LTM block) for a cache that's provably cold — and the LTM block scored against the conversation context as it was N hours ago. Refresh those caches on resume so the post-idle turn produces a better-fitting window.

## What this is NOT

Anthropic's bug was clearing reasoning blocks on idle sessions and having that cleanup persist across all subsequent turns, causing the model to lose continuity (forgetfulness, repetition). **Lore preserves reasoning blocks across all gradient layers and this PR does not change that.** `onIdleResume()` only touches Lore's own byte-identity caches; it does not modify message content, drop reasoning, or change the gradient layer.

## Changes

- **`@loreai/core`**:
  - New fields on `SessionState`: `lastTurnAt` (epoch ms), `cameOutOfIdle` (boolean).
  - New exports: `onIdleResume(sessionID, thresholdMs, now?)` resets `prefixCache` + `rawWindowCache` and sets `cameOutOfIdle` when the gap exceeds threshold; `consumeCameOutOfIdle(sessionID)` is the one-shot reader.
  - `transform()` now records `lastTurnAt = Date.now()` at the end of every successful call.
  - New config: `idleResumeMinutes` (default 60, range 0–24×60; 0 disables).
  - Test-only helpers: `setLastTurnAtForTest()`, `inspectSessionState()` (used by host tests to simulate gaps without sleeping).

- **`opencode-lore`**:
  - Wires `onIdleResume()` into `experimental.chat.system.transform` so it runs before LTM lookup. On trigger, also clears `ltmSessionCache` and logs the idle minutes.
  - LTM degraded-recovery branch consumes `cameOutOfIdle` to skip the conversation-vs-LTM cost comparison: when the provider cache is already cold, the bust cost is zero so we should always recover LTM.
  - Hygiene `finally`-clause clears `cameOutOfIdle` regardless of branch so the flag never leaks across turns.

- **`@loreai/pi`**:
  - Mirrored wiring in `before_agent_start`. (Pi has no LTM-degraded recovery branch; the flag is consumed for hygiene only.)

## Tests

- `packages/core/test/gradient.test.ts` — 7 new cases under `describe("onIdleResume")`: first-turn no-op, under-threshold no-op, over-threshold trigger asserts cache reset + `cameOutOfIdle`, threshold=0 disables, `consumeCameOutOfIdle` is one-shot, unknown session returns false, `transform()` updates `lastTurnAt`. Plus a small `reasoning preservation` pin asserting layer 0 leaves reasoning blocks unchanged.
- `packages/opencode/test/index.test.ts` — 2 new cases under `describe("idle-resume hook integration")`: long gap clears LTM cache (different bytes post-resume); short gap preserves it (byte-identical, new entries during gap don't appear).

429 tests pass, 0 fail. `bun run typecheck` clean.

## Why default 60 min

Matches Anthropic's extended-cache eviction window — conservative across providers. 5-min default-tier matches Anthropic's standard cache, but most chat workflows have brief 5–10 min think-pauses that shouldn't trigger a refresh. Configurable for users who want either tier.

## Out of scope (per plan)

- F-REASONING-AUDIT (full reasoning preservation regression test) — separate PR.
- F-EVAL (prompt-change discipline docs) — separate PR.
