### PR TITLE
refactor(temporal): unambiguous chunk terminator in partsToText

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -2,7 +2,7 @@ import { Database } from "#db/driver";
 import { join, dirname } from "path";
 import { mkdirSync } from "fs";
 
-const SCHEMA_VERSION = 10;
+const SCHEMA_VERSION = 11;
 
 const MIGRATIONS: string[] = [
   `
@@ -280,6 +280,58 @@ const MIGRATIONS: string[] = [
     to_id TEXT NOT NULL REFERENCES knowledge(id) ON DELETE CASCADE,
     PRIMARY KEY (from_id, to_id)
   );
+  `,
+  `
+  -- Version 11: F3b -- unambiguous chunk terminator in temporal_messages.content.
+  --
+  -- Pre-F3b, partsToText joined chunks with a newline. Tool-output payloads
+  -- can contain newlines too, so the boundary between a tool envelope and a
+  -- following plain-text or [reasoning] chunk was structurally ambiguous.
+  -- This caused two known limitations in the F3 distill-input truncator:
+  -- trailing text could be swallowed into a tool payload, and embedded
+  -- literal envelope strings inside a payload (e.g. when reading AGENTS.md)
+  -- could fabricate fake boundaries.
+  --
+  -- F3b switches the chunk separator to newline plus ASCII Unit Separator
+  -- (char 31). The Unit Separator is non-word so FTS5's unicode61 tokenizer
+  -- ignores it (zero BM25 impact). New rows are written via the post-F3b
+  -- partsToText. Existing rows are rewritten in place by the UPDATE below,
+  -- which uses pure SQL replace() to inject the Unit Separator after every
+  -- legacy chunk-prefix sequence -- the same boundary patterns the legacy
+  -- F3 reader was already trying to recover.
+  --
+  -- Trade-off (acceptable): any embedded legacy chunk-prefix sequence
+  -- inside a tool payload becomes a structural boundary post-migration.
+  -- This matches what the legacy F3 reader did at read-time anyway, baked
+  -- into the row permanently. The migration runs once per machine.
+  --
+  -- Idempotent: a row that already contains the Unit Separator before a
+  -- chunk prefix no longer matches the search literal (the separator
+  -- interposes), so re-running the UPDATE is a no-op for migrated rows.
+  -- (Important: migrate() in db.ts runs each migration via database.exec()
+  -- with no explicit BEGIN/COMMIT around the whole loop. SQLite makes this
+  -- single UPDATE statement atomic per-statement, so partial progress on
+  -- crash is safe to retry thanks to the idempotency above.)
+  --
+  -- char(10) = newline, char(31) = Unit Separator. SQLite has no native
+  -- regex, but two nested replace() calls on the literal prefixes are
+  -- sufficient because both legacy chunk prefixes match at line-start.
+  --
+  -- Each row UPDATE fires the temporal_fts_update trigger once; because
+  -- the Unit Separator is a non-word character, the re-indexed content
+  -- tokenizes identically -- net no-op for FTS scoring.
+  UPDATE temporal_messages
+  SET content = replace(
+    replace(
+      content,
+      char(10) || '[tool:',
+      char(10) || char(31) || '[tool:'
+    ),
+    char(10) || '[reasoning] ',
+    char(10) || char(31) || '[reasoning] '
+  )
+  WHERE content LIKE '%' || char(10) || '[tool:%'
+     OR content LIKE '%' || char(10) || '[reasoning] %';
   `,
 ];
 

--- a/packages/core/src/distillation.ts
+++ b/packages/core/src/distillation.ts
@@ -1,6 +1,7 @@
 import { db, ensureProject } from "./db";
 import { config } from "./config";
 import * as temporal from "./temporal";
+import { CHUNK_TERMINATOR } from "./temporal";
 import * as embedding from "./embedding";
 import * as log from "./log";
 import {
@@ -53,57 +54,32 @@ function formatTime(ms: number): string {
   return `${h}:${m}`;
 }
 
-// Chunk-boundary regex for content produced by temporal.partsToText (which
-// joins chunks with "\n"). A chunk boundary is the start of a new chunk we
-// can structurally identify: "[tool:<name>] " or "[reasoning] " at line start.
+// Chunk separator written by `temporal.partsToText` and recovered by the
+// reader below. As of F3b, chunks are joined with `"\n" + CHUNK_TERMINATOR`
+// — the `\x1f` (Unit Separator) is non-word so FTS5 ignores it, and it
+// cannot legitimately appear in normal content, so the boundary is
+// unambiguous regardless of payload contents.
 //
-// Tool names are restricted to lowercase identifier-shaped strings so that
-// literal occurrences of `[tool:...]` inside tool payloads (e.g. when an
-// agent reads a file that documents this very serialization format) are
-// less likely to be mis-split into fabricated envelopes. Real tool names
-// in the OpenCode/Lore ecosystem are always lowercase alphanumeric with
-// `_` or `-` separators (`read`, `grep`, `read_file`, `query-expand`, ...).
-//
-// Two known ambiguity directions caused by the lossy serialization:
-//
-//   1. TRAILING-TEXT SWALLOW: plain text chunks have no structural prefix,
-//      so a text chunk that follows a tool chunk is indistinguishable from
-//      a continuation of the tool output. Such text is attributed to the
-//      preceding tool envelope's payload. This includes the case of a
-//      short tool output followed by a long assistant text reply — the
-//      text can push the combined chunk over the cap and get swallowed.
-//
-//   2. EMBEDDED-ENVELOPE FABRICATION: if a tool output legitimately
-//      contains `\n[tool:<identifier>] ` or `\n[reasoning] ` (e.g. reading
-//      AGENTS.md, this project's source, or any file that documents the
-//      format), the truncator will split on that literal occurrence and
-//      treat the remainder as if it were a separate envelope. The
-//      tightened identifier regex mitigates but doesn't eliminate this.
-//
-// Both limitations could be removed by changing partsToText in temporal.ts
-// to emit an unambiguous terminator plus a DB format bump. That's
-// disproportionate for a background-distill input renderer; the
-// distillation LLM's output is a summary, not a structural parse, so
-// occasional fabrication/swallow results in mildly noisy observations
-// rather than a user-visible bug.
-// TODO: if telemetry or user reports show this materially affects distill
-// quality, file a follow-up to add an unambiguous chunk terminator to
-// temporal.partsToText (DB format change — requires migration).
-const CHUNK_BOUNDARY_RE = /\n(?=\[(?:tool:[a-z][a-z0-9_-]*|reasoning)\] )/g;
+// The migration in db.ts (version 11) rewrote pre-F3b rows to the new
+// format, so every `temporal_messages.content` value now uses this
+// separator. Before F3b the structural parser used a heuristic regex
+// over `\n` boundaries which had two ambiguity directions
+// (trailing-text swallow + embedded-envelope fabrication); both are
+// gone for migrated and new rows.
+const CHUNK_SEPARATOR = "\n" + CHUNK_TERMINATOR;
 
 /**
- * Truncate tool outputs within a pre-flattened `TemporalMessage.content` string
- * (the format produced by `temporal.partsToText`). Plain text and `[reasoning]`
- * chunks pass through untouched.
+ * Truncate tool outputs within a `TemporalMessage.content` string (produced
+ * by `temporal.partsToText`). Plain text and `[reasoning]` chunks pass
+ * through untouched; only `[tool:<name>] <payload>` envelopes whose payload
+ * exceeds `maxChars` are replaced with a compact `toolStripAnnotation(...)`
+ * marker preserving line count, error flag, and file paths.
  *
- * Tool-output payloads longer than `maxChars` are replaced with
- * `toolStripAnnotation(...)` — a compact marker preserving line count, error
- * flag, and file paths. Matches the annotation style used by the runtime
- * gradient so the distillation LLM sees the same affordance it sees during
- * live turns.
+ * Annotation matches the style used by the runtime gradient so the
+ * distillation LLM sees the same affordance it sees during live turns.
  *
- * Exported primarily for tests. If future renderers need the same semantics
- * (e.g. a recall-time preview), they can reuse this.
+ * Exported primarily for tests. If future renderers need the same
+ * semantics (e.g. a recall-time preview), they can reuse this.
  */
 export function truncateToolOutputsInContent(
   content: string,
@@ -111,30 +87,41 @@ export function truncateToolOutputsInContent(
 ): string {
   if (maxChars <= 0 || content.length === 0) return content;
 
-  // Split on identifiable chunk boundaries. This correctly separates:
-  //   - leading text chunks from any subsequent [tool:*] / [reasoning] chunks
-  //   - consecutive [tool:*] / [reasoning] chunks from each other
-  // It does NOT separate a [tool:*] chunk from a trailing plain-text chunk
-  // (text has no structural prefix). That's documented in CHUNK_BOUNDARY_RE.
-  const chunks = content.split(CHUNK_BOUNDARY_RE);
+  // Fast path: a row with no chunk terminator is single-chunk content.
+  // (After the F3b migration, this only happens for messages with exactly
+  // one part — including all user messages, single-text assistant
+  // responses, and standalone tool outputs.) Truncate as one chunk if
+  // it's a tool envelope.
+  if (content.indexOf(CHUNK_TERMINATOR) === -1) {
+    return truncateSingleChunk(content, maxChars);
+  }
 
-  // Return early if nothing in the content could be an oversized tool output.
+  const chunks = content.split(CHUNK_SEPARATOR);
   let anyToolChunk = false;
-  for (const c of chunks) if (c.startsWith("[tool:")) { anyToolChunk = true; break; }
+  for (const c of chunks) {
+    if (c.startsWith("[tool:")) {
+      anyToolChunk = true;
+      break;
+    }
+  }
   if (!anyToolChunk) return content;
 
-  const truncated = chunks.map((chunk) => {
-    if (!chunk.startsWith("[tool:")) return chunk; // plain text or [reasoning]
-    // Parse envelope: "[tool:<name>] <payload...>"
-    const closeBracket = chunk.indexOf("] ");
-    if (closeBracket < 0) return chunk; // malformed; leave alone
-    const toolName = chunk.slice(6, closeBracket); // 6 = "[tool:".length
-    const payload = chunk.slice(closeBracket + 2);
-    if (payload.length <= maxChars) return chunk;
-    return `[tool:${toolName}] ${toolStripAnnotation(toolName, payload)}`;
-  });
+  const out = chunks.map((chunk) => truncateSingleChunk(chunk, maxChars));
+  return out.join(CHUNK_SEPARATOR);
+}
 
-  return truncated.join("\n");
+// Truncate a single chunk if it's an oversized [tool:<name>] envelope.
+// Returns the chunk unchanged if it's plain text, [reasoning], or a tool
+// chunk under the cap. Helper used by both the multi-chunk path and the
+// single-chunk fast path.
+function truncateSingleChunk(chunk: string, maxChars: number): string {
+  if (!chunk.startsWith("[tool:")) return chunk;
+  const closeBracket = chunk.indexOf("] ");
+  if (closeBracket < 0) return chunk; // malformed; leave alone
+  const toolName = chunk.slice(6, closeBracket); // 6 = "[tool:".length
+  const payload = chunk.slice(closeBracket + 2);
+  if (payload.length <= maxChars) return chunk;
+  return `[tool:${toolName}] ${toolStripAnnotation(toolName, payload)}`;
 }
 
 /**

--- a/packages/core/src/temporal.ts
+++ b/packages/core/src/temporal.ts
@@ -9,7 +9,38 @@ function estimate(text: string): number {
   return Math.ceil(text.length / 3);
 }
 
-function partsToText(parts: LorePart[]): string {
+/**
+ * Chunk-boundary terminator inserted between chunks by `partsToText`.
+ *
+ * `\x1f` is ASCII Unit Separator — a non-word control char that:
+ *   - cannot legitimately appear in normal chat or tool content (control
+ *     chars are vanishingly rare even in binary file dumps),
+ *   - is treated as a token separator by FTS5's `unicode61` tokenizer, so
+ *     it has zero effect on BM25 indexing or scoring,
+ *   - survives `sanitizeSurrogates()` (which only touches lone UTF-16
+ *     surrogates, never ASCII control chars).
+ *
+ * Placed AFTER the existing `\n` so display tools that split on `\n`
+ * still render correctly; the structural parser (in `distillation.ts`)
+ * splits on `"\n" + CHUNK_TERMINATOR` for unambiguous chunk recovery.
+ *
+ * Adopted in F3b. Pre-F3b rows are rewritten in-place by a SQL migration
+ * (see `db.ts`); after that migration runs, every `temporal_messages.content`
+ * value uses this format consistently.
+ */
+export const CHUNK_TERMINATOR = "\x1f";
+
+/**
+ * Serialize a list of message parts into a single content string for the
+ * `temporal_messages.content` column. Chunks are separated by
+ * `"\n" + CHUNK_TERMINATOR` so the structural parser can recover chunk
+ * boundaries unambiguously regardless of payload contents (including
+ * payloads that contain literal `[tool:...]` substrings — e.g. when the
+ * agent reads a file that documents this very format).
+ *
+ * Exported so tests can pin producer/consumer round-trip behavior.
+ */
+export function partsToText(parts: LorePart[]): string {
   const chunks: string[] = [];
   for (const part of parts) {
     if (isTextPart(part)) chunks.push(part.text);
@@ -21,7 +52,7 @@ function partsToText(parts: LorePart[]): string {
   // Sanitize unpaired surrogates from tool outputs and other raw text.
   // Without this, surrogates survive into the DB and later break JSON
   // serialization when included in recall tool responses.
-  return sanitizeSurrogates(chunks.join("\n"));
+  return sanitizeSurrogates(chunks.join("\n" + CHUNK_TERMINATOR));
 }
 
 function messageMetadata(info: LoreMessage, parts: LorePart[]): string {

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -21,7 +21,7 @@ describe("db", () => {
     const row = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(row.version).toBe(10);
+    expect(row.version).toBe(11);
   });
 
   test("distillation_fts virtual table exists", () => {

--- a/packages/core/test/distillation.test.ts
+++ b/packages/core/test/distillation.test.ts
@@ -3,10 +3,19 @@ import {
   messagesToText,
   truncateToolOutputsInContent,
 } from "../src/distillation";
-import type * as temporal from "../src/temporal";
+import * as temporal from "../src/temporal";
+import { CHUNK_TERMINATOR, partsToText } from "../src/temporal";
+import type { LorePart } from "../src/types";
 
 // Fixed timestamp so [hh:mm] prefixes are deterministic across runs.
 const T = new Date("2026-04-24T09:15:00Z").getTime();
+
+// Join chunks the way temporal.partsToText does (post-F3b): "\n\x1f"
+// between chunks. Tests use this to construct realistic content
+// fixtures without needing a full producer round trip every time.
+function seal(...chunks: string[]): string {
+  return chunks.join("\n" + CHUNK_TERMINATOR);
+}
 
 function msg(
   role: "user" | "assistant" | "tool",
@@ -29,197 +38,37 @@ function msg(
 
 // ─── truncateToolOutputsInContent ─────────────────────────────────────
 //
-// Operates on the flattened-content shape produced by temporal.partsToText
-// (see temporal.ts: chunks joined with "\n", tool outputs wrapped in
-// "[tool:<name>] ..."). Per-envelope truncation preserves plain text and
-// [reasoning] blocks untouched; only tool payloads above the cap are
-// replaced with a compact annotation.
+// Operates on the post-F3b chunk format produced by temporal.partsToText:
+// chunks separated by "\n\x1f" so the structural parser is unambiguous
+// regardless of payload contents. Single-chunk content (no \x1f) takes
+// a fast path that truncates the whole content as one chunk if it's an
+// oversized tool envelope. Multi-chunk content splits on the separator
+// and truncates each tool envelope independently.
 
-describe("truncateToolOutputsInContent", () => {
-  test("passthrough: content with no tool envelopes is unchanged", () => {
-    const plain = "User asked about auth.\n[reasoning] Thinking about flow";
+describe("truncateToolOutputsInContent — single-chunk fast path", () => {
+  test("plain text passes through unchanged", () => {
+    const plain = "Just a user message about auth.";
     expect(truncateToolOutputsInContent(plain, 2_000)).toBe(plain);
   });
 
-  test("passthrough: short tool output below cap is unchanged", () => {
+  test("short tool envelope below cap is unchanged", () => {
     const content = "[tool:read] file contents are small";
     expect(truncateToolOutputsInContent(content, 2_000)).toBe(content);
   });
 
-  test("truncates oversized single tool envelope", () => {
+  test("oversized single tool envelope is truncated", () => {
     const output = "x".repeat(5_000);
     const content = `[tool:grep] ${output}`;
     const result = truncateToolOutputsInContent(content, 2_000);
-    // Annotation replaces the payload wholesale.
     expect(result).toContain("[tool:grep] [output omitted — grep:");
     expect(result).toContain("lines");
     expect(result.length).toBeLessThan(content.length);
-    // Original payload must not survive.
-    expect(result).not.toContain("xxxxxxxxxx"); // 10 x's would be in the body
+    expect(result).not.toContain("xxxxxxxxxx");
   });
 
-  test("preserves plain text BEFORE an oversized envelope", () => {
-    const output = "y".repeat(5_000);
-    const content = [
-      "I need to search for that symbol.",
-      `[tool:grep] ${output}`,
-    ].join("\n");
-    const result = truncateToolOutputsInContent(content, 2_000);
-    expect(result).toContain("I need to search for that symbol.");
-    expect(result).toContain("[output omitted — grep:");
-  });
-
-  test("known limitation (1a): plain text AFTER a tool chunk is attributed to the payload", () => {
-    // partsToText joins chunks with "\n" and plain text has no structural
-    // prefix, so a text chunk that follows a tool chunk is indistinguishable
-    // from a continuation of the tool output. The truncator attributes the
-    // trailing text to the tool payload. Acceptable trade-off — see
-    // CHUNK_BOUNDARY_RE comment in src/distillation.ts.
-    const output = "y".repeat(5_000);
-    const content = [
-      `[tool:grep] ${output}`,
-      "Follow-up text attributed to grep output.",
-    ].join("\n");
-    const result = truncateToolOutputsInContent(content, 2_000);
-    // Annotation is emitted; trailing text is swallowed into the annotation.
-    expect(result).toContain("[output omitted — grep:");
-    expect(result).not.toContain("Follow-up text attributed");
-  });
-
-  test("known limitation (1b): short tool + long trailing text gets the text swallowed", () => {
-    // Inverse of the above: a tool chunk with small output that's followed
-    // by a big assistant text-reply. The combined chunk exceeds the cap,
-    // so the trailing analysis disappears into the annotation. This is
-    // the same CHUNK_BOUNDARY_RE limitation (direction: long text after
-    // small tool) and is acceptable for background distill input — the
-    // summary-level observations still capture the interaction shape.
-    const longTrailingText = "This is a long analysis after the tool call. ".repeat(100);
-    const content = [
-      "[tool:grep] found 3 matches",
-      longTrailingText,
-    ].join("\n");
-    const result = truncateToolOutputsInContent(content, 2_000);
-    // Truncation fires because the combined chunk > cap.
-    expect(result).toContain("[output omitted — grep:");
-    // The trailing analysis is gone.
-    expect(result).not.toContain("long analysis after");
-  });
-
-  test("known limitation (2): embedded [tool:<name>] inside a payload fabricates a boundary", () => {
-    // If a tool output legitimately contains the literal sequence
-    // `\n[tool:<identifier>] ` (e.g. reading a file that documents this
-    // serialization format), the truncator splits on it. The tightened
-    // tool-name regex `[a-z][a-z0-9_-]*` reduces the surface (a literal
-    // `[tool:Fake]` inside a body won't split because of the uppercase F),
-    // but valid-identifier-shaped literals still fabricate a split. Pinning
-    // the behavior so it's not silently rediscovered.
-    const big = "x".repeat(3_000);
-    const content = [
-      `[tool:read] reading AGENTS.md`,
-      `File contents include the literal envelope prefix below:`,
-      `[tool:bash] this is a legitimate part of the read payload`,
-      big,
-    ].join("\n");
-    const result = truncateToolOutputsInContent(content, 2_000);
-    // The embedded `[tool:bash]` prefix creates a fabricated second chunk.
-    // The fabricated chunk contains the big payload and gets truncated as
-    // if it were a real bash call — producing an annotation that references
-    // "bash" even though no bash call occurred.
-    expect(result).toContain("[output omitted — bash:");
-    // The first read chunk body is short so it survives untruncated.
-    expect(result).toContain("[tool:read] reading AGENTS.md");
-  });
-
-  test("tightened regex: uppercase tool name inside a payload does NOT split", () => {
-    // Tool names with uppercase letters don't match the identifier regex,
-    // so literal `[tool:Fake]` occurrences in payloads stay inline.
-    const body = "first line\n[tool:Fake] mid-payload text with uppercase F\nmore data";
-    const content = `[tool:grep] ${body}`;
-    const result = truncateToolOutputsInContent(content, 2_000);
-    // Single chunk, under cap — passes through verbatim.
-    expect(result).toBe(content);
-  });
-
-  test("perf: 100KB single-letter payload without '/' annotates in <500ms", () => {
-    // Regression guard against catastrophic backtracking in the
-    // path-extraction regex inside toolStripAnnotation. Pathological
-    // inputs (minified JS, base64 blobs, binary dumps) used to stall
-    // the background worker for ~30s on this repro. The no-slash
-    // fast-exit in gradient.ts makes this O(n).
-    const pathological = "x".repeat(100_000);
-    const content = `[tool:grep] ${pathological}`;
-    const start = performance.now();
-    const result = truncateToolOutputsInContent(content, 2_000);
-    const elapsed = performance.now() - start;
-    expect(elapsed).toBeLessThan(500);
-    expect(result).toContain("[output omitted — grep:");
-  });
-
-  test("perf: 100KB payload WITH '/' still completes in <1s via scan limit", () => {
-    // Even with a single '/' present (so the no-slash fast-exit doesn't
-    // help), the 64KB scan cap on the path regex keeps runtime bounded.
-    // The fragment before '/' is only 64KB of `x`, which the slicing
-    // prevents from backtracking for too long.
-    const pathological = "x".repeat(50_000) + "/file.ts " + "y".repeat(50_000);
-    const content = `[tool:grep] ${pathological}`;
-    const start = performance.now();
-    const result = truncateToolOutputsInContent(content, 2_000);
-    const elapsed = performance.now() - start;
-    expect(elapsed).toBeLessThan(1000);
-    expect(result).toContain("[output omitted — grep:");
-  });
-
-  test("separates a tool chunk from a following [reasoning] chunk", () => {
-    // Unlike plain text, [reasoning] has a structural prefix so the
-    // boundary regex correctly separates it from a preceding tool chunk.
-    const output = "y".repeat(5_000);
-    const content = [
-      `[tool:grep] ${output}`,
-      "[reasoning] Post-search reasoning",
-    ].join("\n");
-    const result = truncateToolOutputsInContent(content, 2_000);
-    expect(result).toContain("[output omitted — grep:");
-    expect(result).toContain("[reasoning] Post-search reasoning");
-  });
-
-  test("truncates multiple oversized envelopes independently", () => {
-    const big = "z".repeat(5_000);
-    const content = [
-      "[tool:grep] " + big,
-      "[tool:read] " + big,
-    ].join("\n");
-    const result = truncateToolOutputsInContent(content, 2_000);
-    // Both envelopes replaced with separate annotations.
-    expect(result).toContain("[tool:grep] [output omitted — grep:");
-    expect(result).toContain("[tool:read] [output omitted — read:");
-    expect(result.length).toBeLessThan(content.length);
-  });
-
-  test("mixed sizes: only the oversized envelope is truncated", () => {
-    const big = "q".repeat(5_000);
-    const small = "small output lines";
-    const content = [
-      `[tool:grep] ${big}`,
-      `[tool:ls] ${small}`,
-    ].join("\n");
-    const result = truncateToolOutputsInContent(content, 2_000);
-    expect(result).toContain("[tool:grep] [output omitted — grep:");
-    // The small envelope survives verbatim.
-    expect(result).toContain(`[tool:ls] ${small}`);
-  });
-
-  test("line-start anchor: mid-line [tool:X] does not split the envelope", () => {
-    // A tool-call JSON or prose that mentions `[tool:grep]` as literal
-    // text *not at the start of a line* must not be mistaken for a new
-    // envelope. The boundary regex requires a preceding `\n`, so
-    // mid-line occurrences preceded by a space (as here) are preserved.
-    // The adjacent "known limitation (2)" test covers the
-    // newline-preceded-embedded-envelope path.
-    const body = "some text [tool:grep] mid-line, no split\nmore data";
-    const content = `[tool:read] ${body}`;
-    const result = truncateToolOutputsInContent(content, 2_000);
-    // Below threshold — full content passes through.
-    expect(result).toBe(content);
+  test("malformed envelope (no `] ` close) is left alone", () => {
+    const content = "[tool:grep no close bracket text continues forever";
+    expect(truncateToolOutputsInContent(content, 2_000)).toBe(content);
   });
 
   test("maxChars <= 0 disables truncation", () => {
@@ -250,6 +99,131 @@ describe("truncateToolOutputsInContent", () => {
   });
 });
 
+describe("truncateToolOutputsInContent — multi-chunk path", () => {
+  test("plain text BEFORE an oversized envelope is preserved", () => {
+    const output = "y".repeat(5_000);
+    const content = seal("I need to search for that symbol.", `[tool:grep] ${output}`);
+    const result = truncateToolOutputsInContent(content, 2_000);
+    expect(result).toContain("I need to search for that symbol.");
+    expect(result).toContain("[output omitted — grep:");
+  });
+
+  test("plain text AFTER a tool chunk is preserved (former F3 known limitation 1a)", () => {
+    // Pre-F3b this test asserted the trailing text was SWALLOWED into the
+    // tool annotation. The new \x1f separator makes the boundary
+    // unambiguous, so the trailing text now survives untouched.
+    const output = "y".repeat(5_000);
+    const content = seal(`[tool:grep] ${output}`, "Follow-up text after the tool call.");
+    const result = truncateToolOutputsInContent(content, 2_000);
+    expect(result).toContain("[output omitted — grep:");
+    expect(result).toContain("Follow-up text after the tool call.");
+  });
+
+  test("short tool + long trailing text preserves both (former F3 known limitation 1b)", () => {
+    // Pre-F3b: short tool envelope + long trailing text resulted in the
+    // trailing text being swallowed into the annotation when the combined
+    // chunk exceeded the cap. With \x1f separators, the trailing text is
+    // its own chunk and is preserved verbatim regardless of size.
+    const longTrailingText = "Long analysis after the tool call. ".repeat(100);
+    const content = seal("[tool:grep] found 3 matches", longTrailingText);
+    const result = truncateToolOutputsInContent(content, 2_000);
+    // The short tool chunk survives; trailing text survives in full.
+    expect(result).toContain("[tool:grep] found 3 matches");
+    expect(result).toContain("Long analysis after the tool call.");
+    // No annotation emitted because no chunk exceeded the cap.
+    expect(result).not.toContain("[output omitted —");
+  });
+
+  test("embedded literal [tool:<id>] inside a payload does NOT fabricate a split (former F3 known limitation 2)", () => {
+    // Pre-F3b: a tool output that legitimately contained `\n[tool:bash] ...`
+    // (e.g. reading AGENTS.md or this project's source) was split on the
+    // literal occurrence, producing a fabricated [tool:bash] envelope the
+    // distill LLM would treat as a real tool call. With \x1f separators,
+    // the literal text inside a payload has no terminator after it, so no
+    // fabrication occurs.
+    const big = "x".repeat(3_000);
+    const toolPayload = [
+      "reading AGENTS.md",
+      "File contents include the literal envelope prefix below:",
+      "[tool:bash] this is a legitimate part of the read payload",
+      big,
+    ].join("\n");
+    const content = `[tool:read] ${toolPayload}`;
+    const result = truncateToolOutputsInContent(content, 2_000);
+    // The whole envelope is truncated as `read` (no fabricated `bash` annotation).
+    expect(result).toContain("[output omitted — read:");
+    expect(result).not.toContain("[output omitted — bash:");
+  });
+
+  test("multiple oversized envelopes are truncated independently", () => {
+    const big = "z".repeat(5_000);
+    const content = seal(`[tool:grep] ${big}`, `[tool:read] ${big}`);
+    const result = truncateToolOutputsInContent(content, 2_000);
+    expect(result).toContain("[tool:grep] [output omitted — grep:");
+    expect(result).toContain("[tool:read] [output omitted — read:");
+    expect(result.length).toBeLessThan(content.length);
+  });
+
+  test("only the oversized envelope is truncated; small siblings survive", () => {
+    const big = "q".repeat(5_000);
+    const small = "small output lines";
+    const content = seal(`[tool:grep] ${big}`, `[tool:ls] ${small}`);
+    const result = truncateToolOutputsInContent(content, 2_000);
+    expect(result).toContain("[tool:grep] [output omitted — grep:");
+    expect(result).toContain(`[tool:ls] ${small}`);
+  });
+
+  test("[reasoning] chunks pass through untouched", () => {
+    const big = "y".repeat(5_000);
+    const content = seal(`[tool:grep] ${big}`, "[reasoning] Post-search reasoning");
+    const result = truncateToolOutputsInContent(content, 2_000);
+    expect(result).toContain("[output omitted — grep:");
+    expect(result).toContain("[reasoning] Post-search reasoning");
+  });
+
+  test("text-only multi-chunk content (no tool envelopes) returns input unchanged", () => {
+    const content = seal("First text chunk.", "[reasoning] Some reasoning.");
+    expect(truncateToolOutputsInContent(content, 2_000)).toBe(content);
+  });
+
+  test("uppercase tool name inside a payload (e.g. JSON dump) is preserved verbatim", () => {
+    // Tool payloads containing arbitrary content — including text that
+    // looks like an envelope — are preserved as-is by the new format
+    // because only \x1f boundaries are structural.
+    const body = "first line\n[tool:Fake] mid-payload text\nmore data";
+    const content = `[tool:read] ${body}`;
+    const result = truncateToolOutputsInContent(content, 2_000);
+    expect(result).toBe(content);
+  });
+});
+
+describe("truncateToolOutputsInContent — perf regression guards", () => {
+  test("100KB single-letter payload without '/' annotates in <500ms", () => {
+    // Regression guard against catastrophic backtracking in the
+    // path-extraction regex inside toolStripAnnotation. Pathological
+    // inputs (minified JS, base64 blobs, binary dumps) used to stall
+    // the background worker for ~30s on this repro. The no-slash
+    // fast-exit in gradient.ts makes this O(n).
+    const pathological = "x".repeat(100_000);
+    const content = `[tool:grep] ${pathological}`;
+    const start = performance.now();
+    const result = truncateToolOutputsInContent(content, 2_000);
+    const elapsed = performance.now() - start;
+    expect(elapsed).toBeLessThan(500);
+    expect(result).toContain("[output omitted — grep:");
+  });
+
+  test("100KB payload WITH '/' completes in <1s via scan limit", () => {
+    const pathological = "x".repeat(50_000) + "/file.ts " + "y".repeat(50_000);
+    const content = `[tool:grep] ${pathological}`;
+    const start = performance.now();
+    const result = truncateToolOutputsInContent(content, 2_000);
+    const elapsed = performance.now() - start;
+    expect(elapsed).toBeLessThan(1000);
+    expect(result).toContain("[output omitted — grep:");
+  });
+});
+
 // ─── messagesToText ────────────────────────────────────────────────────
 //
 // Wraps truncateToolOutputsInContent with role-aware routing. User messages
@@ -261,7 +235,6 @@ describe("messagesToText", () => {
     const huge = "u".repeat(10_000);
     const msgs = [msg("user", huge)];
     const out = messagesToText(msgs, 2_000);
-    // Full user content present verbatim.
     expect(out).toContain(huge);
     expect(out).not.toContain("[output omitted —");
   });
@@ -290,13 +263,8 @@ describe("messagesToText", () => {
   });
 
   test("prefixes each message with [role] and a time stamp", () => {
-    const msgs = [
-      msg("user", "Hello there"),
-      msg("assistant", "Hi back"),
-    ];
+    const msgs = [msg("user", "Hello there"), msg("assistant", "Hi back")];
     const out = messagesToText(msgs, 2_000);
-    // Time format is HH:MM; content of the stamp varies by local TZ, so pin
-    // only the structural shape.
     expect(out).toMatch(/\[user\] \(\d\d:\d\d\) Hello there/);
     expect(out).toMatch(/\[assistant\] \(\d\d:\d\d\) Hi back/);
   });
@@ -304,7 +272,6 @@ describe("messagesToText", () => {
   test("joins multiple messages with a blank line separator", () => {
     const msgs = [msg("user", "first"), msg("user", "second")];
     const out = messagesToText(msgs, 2_000);
-    // Exactly one blank line between the two `[user] (...) ...` lines.
     const lines = out.split("\n\n");
     expect(lines).toHaveLength(2);
   });
@@ -312,7 +279,6 @@ describe("messagesToText", () => {
   test("explicit toolOutputMaxChars override wins over config default", () => {
     const body = "c".repeat(1_000);
     const msgs = [msg("assistant", `[tool:grep] ${body}`)];
-    // Cap of 100 forces truncation even though the body is only 1KB.
     const out = messagesToText(msgs, 100);
     expect(out).toContain("[output omitted — grep:");
   });
@@ -325,26 +291,104 @@ describe("messagesToText", () => {
     expect(out).not.toContain("[output omitted —");
   });
 
-  test("handles mixed content: assistant text, reasoning, and tool output", () => {
-    // Chunks before the tool envelope survive because the boundary regex
-    // finds the [tool:grep] prefix. Trailing [reasoning] also survives
-    // because it has a structural prefix. See CHUNK_BOUNDARY_RE docs in
-    // src/distillation.ts for the plain-text-after-tool caveat.
+  test("handles mixed content: assistant text, reasoning, tool, more text", () => {
+    // Multi-chunk content with all four chunk types in order. The new
+    // format preserves trailing plain text after a tool chunk (former
+    // F3 known limitation 1a, now a positive assertion).
     const big = "e".repeat(5_000);
-    const content = [
+    const content = seal(
       "I'll search for that.",
       "[reasoning] Planning the search",
       `[tool:grep] ${big}`,
-      "[reasoning] Found what I needed.",
-    ].join("\n");
+      "Found what I needed.",
+    );
     const msgs = [msg("assistant", content)];
     const out = messagesToText(msgs, 2_000);
-    // Plain text and both reasoning chunks preserved.
     expect(out).toContain("I'll search for that.");
     expect(out).toContain("[reasoning] Planning the search");
-    expect(out).toContain("[reasoning] Found what I needed.");
-    // Tool body truncated.
     expect(out).toContain("[output omitted — grep:");
+    // Trailing plain text survives.
+    expect(out).toContain("Found what I needed.");
     expect(out).not.toContain("e".repeat(100));
+  });
+});
+
+// ─── Round-trip via partsToText ────────────────────────────────────────
+//
+// Pin the producer/consumer contract end-to-end: a LorePart[] containing
+// arbitrary content (including payloads that look like envelopes) flows
+// through partsToText → truncateToolOutputsInContent without fabrication
+// or trailing-text loss. This is the F3b correctness guarantee.
+
+function textPart(text: string): LorePart {
+  return { type: "text", text } as LorePart;
+}
+function reasoningPart(text: string): LorePart {
+  return { type: "reasoning", text } as LorePart;
+}
+function toolPart(tool: string, output: string): LorePart {
+  return {
+    type: "tool",
+    tool,
+    state: { status: "completed", output },
+  } as unknown as LorePart;
+}
+
+describe("partsToText + truncateToolOutputsInContent round trip", () => {
+  test("produces \\n\\x1f boundaries between chunks", () => {
+    const content = partsToText([
+      textPart("first"),
+      reasoningPart("thinking"),
+      toolPart("grep", "results"),
+      textPart("last"),
+    ]);
+    // Expect exactly 3 separators for 4 chunks.
+    const separatorCount =
+      content.split("\n" + CHUNK_TERMINATOR).length - 1;
+    expect(separatorCount).toBe(3);
+  });
+
+  test("\\x1f appears ONLY at structural boundaries, not inside payloads", () => {
+    const adversarialOutput = [
+      "reading AGENTS.md",
+      "[tool:bash] this is INSIDE a tool payload, not a real envelope",
+      "still inside the read output",
+    ].join("\n");
+    const content = partsToText([
+      textPart("Searching for X"),
+      toolPart("read", adversarialOutput),
+      textPart("Found it."),
+    ]);
+    // Three chunks → two separators.
+    const separators = content.split("\n" + CHUNK_TERMINATOR);
+    expect(separators).toHaveLength(3);
+    // The middle chunk owns the entire adversarial payload — no \x1f leaks
+    // into it because partsToText only injects \x1f between chunks.
+    expect(separators[1]).toContain("[tool:read] reading AGENTS.md");
+    expect(separators[1]).toContain("[tool:bash] this is INSIDE");
+    expect(separators[1]).toContain("still inside the read output");
+    // Trailing text is its own chunk.
+    expect(separators[2]).toBe("Found it.");
+  });
+
+  test("truncating an adversarial round-trip preserves trailing text and rejects fabrication", () => {
+    const big = "x".repeat(3_000);
+    const adversarialOutput = [
+      "Reading repo source.",
+      "[tool:bash] embedded literal that could fabricate pre-F3b",
+      big,
+    ].join("\n");
+    const content = partsToText([
+      textPart("Looking up the format spec."),
+      toolPart("read", adversarialOutput),
+      textPart("Now I understand the chunk format."),
+    ]);
+    const result = truncateToolOutputsInContent(content, 2_000);
+    // Tool envelope is truncated as `read` (no fabricated `bash` envelope).
+    expect(result).toContain("[output omitted — read:");
+    expect(result).not.toContain("[output omitted — bash:");
+    // Both surrounding text chunks survive.
+    expect(result).toContain("Looking up the format spec.");
+    expect(result).toContain("Now I understand the chunk format.");
   });
 });


### PR DESCRIPTION
## Summary

Retire the two F3 "known limitations" (trailing-text swallow + embedded-envelope fabrication) by switching `temporal.partsToText`'s chunk separator from `"\n"` to `"\n\x1f"` (newline + ASCII Unit Separator). Pre-F3b legacy rows are rewritten in-place by a SQL migration (schema version 11); new rows are written with the unambiguous separator from the start.

The structural parser (`truncateToolOutputsInContent`) becomes a single-format reader — splits on `\n\x1f`, classifies chunks, truncates oversized `[tool:<name>]` envelopes. The F3 heuristic regex (`CHUNK_BOUNDARY_RE`) and its accompanying tightened tool-name regex are gone.

## Why now

F3 documented the two ambiguities honestly with tests and a TODO. Rather than build F9 (media-aware overflow recovery) on top of a known-shaky parser, retire the ambiguities first.

The exploration phase confirmed the surface area is small: 1 writer, 1 structural parser, 1 dependent helper, 1 test file. No host code parses `temporal_messages.content`. FTS5 is content-table-backed and `unicode61` already strips `[`, `]`, `:` as separators — adding a non-word terminator has zero BM25 impact.

## Why `\x1f` (ASCII Unit Separator, char 31)

- Non-word control character — cannot legitimately appear in chat or tool content (control chars are vanishingly rare even in binary file dumps).
- FTS5 `unicode61` tokenizer treats it as a separator, so BM25 indexing is byte-identical pre/post migration. **Verified empirically** on real SQLite — same row gets same BM25 rank for the same query.
- `sanitizeSurrogates()` only touches lone UTF-16 surrogates, so the Unit Separator passes through.
- Single byte on disk; cheaper than `\u241e` (3 bytes UTF-8).

## Why placed AFTER the existing `\n`

Display tools that split on `\n` still render correctly; the structural parser splits on `"\n" + CHUNK_TERMINATOR` for unambiguous recovery. Result: `chunk1\n\x1fchunk2\n\x1fchunk3` — backward-compatible at the display level, structurally unambiguous at parse time.

## Migration (schema version 11)

Pure SQL `UPDATE` with two nested `replace()` calls. Injects `\x1f` after every legacy `\n[tool:` and `\n[reasoning] ` boundary — the same patterns the legacy F3 reader was already trying to recover. Trade-off (acceptable per plan): any embedded `\n[tool:<id>] ` inside a tool payload becomes a structural boundary post-migration. Same direction as F3's known limitation #2 — baked into the row permanently. The migration runs once per machine.

**Idempotent**: re-running is a no-op for already-migrated rows because the WHERE-clause literal `\n[tool:` no longer matches `\n\x1f[tool:` (the separator interposes). Verified empirically.

**Crash-safe**: per-statement atomic in SQLite. If killed mid-UPDATE, retry resumes via idempotency.

**WHERE clause**: only touches rows that actually have legacy boundaries — plain user messages and single-chunk content are skipped, saving FTS reindex cost on text-heavy projects.

## Files changed

| File | Change |
|------|--------|
| `packages/core/src/temporal.ts` | Add `CHUNK_TERMINATOR = "\x1f"` constant + export. Switch `partsToText` join separator to `"\n" + CHUNK_TERMINATOR`. Export `partsToText` for tests. |
| `packages/core/src/db.ts` | Bump `SCHEMA_VERSION` to 11; add migration 11 with extensive doc comments. |
| `packages/core/src/distillation.ts` | Rewrite `truncateToolOutputsInContent` as single-format parser with single-chunk fast path. Remove `CHUNK_BOUNDARY_RE` heuristic regex and the F3 known-limitations doc block. Extract `truncateSingleChunk` helper. |
| `packages/core/test/distillation.test.ts` | Full rewrite: 31 tests in 5 describe blocks. Adds `seal()` helper, inverts the former known-limitation assertions into positive ones, adds end-to-end round-trip test through real `partsToText`. |
| `packages/core/test/db.test.ts` | Bump expected schema version assertion to 11. |

## Verification

- `bun test`: **433 pass / 0 fail** (4941 expect calls across 18 files).
- `bun --filter '*' typecheck`: all three packages exit 0.
- `bun --filter '*' build`: core + pi bundles clean, opencode ships raw TS.
- **Live migration smoke test** on synthetic legacy DB: confirms `\x1f` injected at every legacy boundary, schema version bumped to 11, FTS5 substring queries return identical hits pre/post migration.
- **FTS5 BM25 parity verified**: same row gets byte-identical BM25 rank for the same substring query before and after migration — confirming `\x1f` is fully ignored by the tokenizer.

## What this enables

F9 (media-aware overflow recovery) and any other distill-input or content-parsing work can now rely on unambiguous chunk boundaries without inheriting F3's documented hazards.

## Review trail

Subagent self-review pass cleared as **YES merge-ready**. Findings:
- One Important: migration runner doesn't wrap the whole loop in a transaction (pre-existing, not specific to F3b). Documented in the migration's SQL comments rather than fixed in this PR — addressing it would require touching `migrate()` for all migrations and is its own concern.
- 5 minor nits, all forward-compat or cosmetic; none affect correctness.
