### PR TITLE
feat(recovery): media-aware overflow recovery preserves user intent

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -134,6 +134,11 @@ export function isContextOverflow(rawError: unknown): boolean {
 /**
  * Build the synthetic recovery message injected after a context overflow.
  * Contains the distilled session history so the model can continue.
+ *
+ * For overflow paths where the failing user message contained media
+ * attachments (image/PDF), prefer `buildMediaAwareRecoveryMessage` —
+ * it preserves the user's text question and lists the dropped
+ * attachments so the model can acknowledge them.
  */
 export function buildRecoveryMessage(
   summaries: Array<{ observations: string; generation: number }>,
@@ -151,6 +156,154 @@ export function buildRecoveryMessage(
     historyText || "(No distilled history available — check recent messages for context.)",
     "</system-reminder>",
   ].join("\n");
+}
+
+/**
+ * Match upstream OpenCode's `isMedia` (`util/media.ts:7-9`) byte-for-byte:
+ * `mime.startsWith("image/") || mime === "application/pdf"`. Used to
+ * decide whether a file part qualifies as a "stripped attachment" worth
+ * surfacing in the media-aware recovery message.
+ */
+export function isMediaMime(mime: string): boolean {
+  return mime.startsWith("image/") || mime === "application/pdf";
+}
+
+/**
+ * Extract a "stripped attachment" descriptor from a `file` part, mirroring
+ * upstream OpenCode's replay stub at `compaction.ts:494` byte-for-byte:
+ * `[Attached <mime>: <filename or "file">]`. Returns undefined when the
+ * part isn't a media file part (so the caller can ignore it).
+ *
+ * Defensive: tolerates missing or non-string `mime`/`filename` fields
+ * since `LoreGenericPart` doesn't constrain shape.
+ */
+export function stripMediaPart(
+  part: { type?: unknown } & Record<string, unknown>,
+): string | undefined {
+  if (part.type !== "file") return undefined;
+  const mime = typeof part.mime === "string" ? part.mime : undefined;
+  if (!mime || !isMediaMime(mime)) return undefined;
+  const filename = typeof part.filename === "string" ? part.filename : "file";
+  return `[Attached ${mime}: ${filename}]`;
+}
+
+// Minimal interface of the OpenCode client surface F9 reads. Typed
+// loosely so tests can stub it without satisfying the full SDK shape.
+// Array elements are `unknown` because the SDK's element type is
+// non-null but real-world tests can pass nulls/malformed entries to
+// exercise the defensive shape-checks in `getLastRealUserMessage`.
+type SessionMessagesClient = {
+  session: {
+    messages: (opts: { path: { id: string } }) => Promise<{
+      data?: ReadonlyArray<unknown>;
+    }>;
+  };
+};
+
+/**
+ * Walk session messages newest-first to find the most recent user message
+ * that is NOT a Lore-injected synthetic recovery (i.e. its parts do not
+ * contain a text part with `synthetic: true`). Returns undefined when no
+ * real user message exists or the SDK call fails — the caller falls
+ * through to plain `buildRecoveryMessage` in either case.
+ *
+ * Uses `client.session.messages` (route `/session/{id}/message`,
+ * confirmed in `@opencode-ai/sdk` `sdk.gen.d.ts:170`). The endpoint
+ * returns all messages by default; F9 doesn't pass `limit` because
+ * recovery is not a hot path.
+ */
+export async function getLastRealUserMessage(
+  client: SessionMessagesClient,
+  sessionID: string,
+): Promise<
+  | { info: { role: string } & Record<string, unknown>; parts: Array<Record<string, unknown>> }
+  | undefined
+> {
+  let resp;
+  try {
+    resp = await client.session.messages({ path: { id: sessionID } });
+  } catch (e) {
+    log.warn(`getLastRealUserMessage: session.messages failed for ${sessionID.substring(0, 16)}:`, e);
+    return undefined;
+  }
+  const msgs = resp?.data ?? [];
+  for (let i = msgs.length - 1; i >= 0; i--) {
+    const raw = msgs[i];
+    if (!raw || typeof raw !== "object") continue;
+    const m = raw as { info?: unknown; parts?: unknown };
+    const info = m.info;
+    if (!info || typeof info !== "object") continue;
+    if ((info as { role?: unknown }).role !== "user") continue;
+    const partsRaw = m.parts;
+    const parts: Array<Record<string, unknown>> = Array.isArray(partsRaw)
+      ? (partsRaw as Array<Record<string, unknown>>)
+      : [];
+    const isSynthetic = parts.some(
+      (p) => p && typeof p === "object" && p.type === "text" && p.synthetic === true,
+    );
+    if (isSynthetic) continue;
+    return {
+      info: info as { role: string } & Record<string, unknown>,
+      parts,
+    };
+  }
+  return undefined;
+}
+
+/**
+ * Build a media-aware recovery message that extends the plain version with
+ * (a) a list of stripped attachments and (b) the user's original text from
+ * the failed turn. The plain `buildRecoveryMessage` should be preferred
+ * when no attachments were stripped — see the `session.error` handler.
+ *
+ * Sections (in order, with empty ones omitted):
+ *   - opening "previous turn failed" preamble
+ *   - stripped-attachments notice (only when present)
+ *   - distilled history block (or empty-history fallback)
+ *   - user's original text question (only when present)
+ *   - closing "review and continue" instruction
+ */
+export function buildMediaAwareRecoveryMessage(input: {
+  summaries: Array<{ observations: string; generation: number }>;
+  strippedAttachments: string[];
+  userText: string[];
+}): string {
+  const historyText =
+    input.summaries.length > 0 ? formatDistillations(input.summaries) : "";
+
+  const mediaNotice =
+    input.strippedAttachments.length > 0
+      ? [
+          "",
+          `The user's previous message included ${input.strippedAttachments.length} attachment(s) that were removed because they exceeded the context limit:`,
+          ...input.strippedAttachments.map((s) => `- ${s}`),
+          "If the user was asking about the attachments, acknowledge that they were too large to process and suggest smaller or fewer files.",
+          "",
+        ].join("\n")
+      : "";
+
+  const userQuestion =
+    input.userText.length > 0
+      ? [
+          "",
+          "The user's original question (with attachments removed):",
+          ...input.userText,
+          "",
+        ].join("\n")
+      : "";
+
+  return [
+    "<system-reminder>",
+    "The previous turn failed with a context overflow error (prompt too long).",
+    "Lore has automatically compressed the conversation history.",
+    mediaNotice,
+    historyText || "(No distilled history available — check recent messages for context.)",
+    userQuestion,
+    "Review the above and continue where you left off.",
+    "</system-reminder>",
+  ]
+    .filter((s) => s !== "")
+    .join("\n");
 }
 
 /**
@@ -443,13 +596,47 @@ export const LorePlugin: Plugin = async (ctx) => {
           //    continues where it left off — no user intervention needed.
           recoveringSessions.add(errorSessionID);
           try {
-            const summaries = distillation.loadForSession(projectPath, errorSessionID);
-            const recoveryText = buildRecoveryMessage(
-              summaries.map(s => ({ observations: s.observations, generation: s.generation })),
+            const summaries = distillation
+              .loadForSession(projectPath, errorSessionID)
+              .map((s) => ({
+                observations: s.observations,
+                generation: s.generation,
+              }));
+
+            // Walk back to the last real user message and check whether it
+            // carried media attachments. If yes, route through the
+            // media-aware recovery path so the user's text question + a
+            // list of dropped attachments survive into the synthetic
+            // recovery prompt. Failure of session.messages falls through
+            // to plain recovery.
+            const lastUser = await getLastRealUserMessage(
+              ctx.client,
+              errorSessionID,
             );
+            const strippedAttachments: string[] = [];
+            const userText: string[] = [];
+            if (lastUser) {
+              for (const part of lastUser.parts) {
+                if (part.type === "text" && typeof part.text === "string") {
+                  userText.push(part.text);
+                } else {
+                  const stub = stripMediaPart(part);
+                  if (stub) strippedAttachments.push(stub);
+                }
+              }
+            }
+
+            const recoveryText =
+              strippedAttachments.length > 0
+                ? buildMediaAwareRecoveryMessage({
+                    summaries,
+                    strippedAttachments,
+                    userText,
+                  })
+                : buildRecoveryMessage(summaries);
 
             log.info(
-              `sending auto-recovery message to session ${errorSessionID.substring(0, 16)}`,
+              `sending auto-recovery message to session ${errorSessionID.substring(0, 16)}${strippedAttachments.length > 0 ? ` (media-aware: ${strippedAttachments.length} attachment(s) stripped)` : ""}`,
             );
             await ctx.client.session.prompt({
               path: { id: errorSessionID },

--- a/packages/opencode/test/index.test.ts
+++ b/packages/opencode/test/index.test.ts
@@ -1,5 +1,14 @@
 import { describe, test, expect, beforeEach } from "bun:test";
-import { isContextOverflow, buildRecoveryMessage, LorePlugin, isValidProjectPath } from "../src/index";
+import {
+  isContextOverflow,
+  buildRecoveryMessage,
+  buildMediaAwareRecoveryMessage,
+  isMediaMime,
+  stripMediaPart,
+  getLastRealUserMessage,
+  LorePlugin,
+  isValidProjectPath,
+} from "../src/index";
 import {
   ltm,
   db,
@@ -217,6 +226,183 @@ describe("buildRecoveryMessage", () => {
   });
 });
 
+// ── F9 media-aware recovery — pure helper tests ──────────────────────
+
+describe("isMediaMime", () => {
+  test("accepts image/* mime types", () => {
+    expect(isMediaMime("image/png")).toBe(true);
+    expect(isMediaMime("image/jpeg")).toBe(true);
+    expect(isMediaMime("image/svg+xml")).toBe(true);
+    expect(isMediaMime("image/webp")).toBe(true);
+  });
+
+  test("accepts application/pdf", () => {
+    expect(isMediaMime("application/pdf")).toBe(true);
+  });
+
+  test("rejects non-media types", () => {
+    expect(isMediaMime("text/plain")).toBe(false);
+    expect(isMediaMime("application/json")).toBe(false);
+    expect(isMediaMime("application/x-directory")).toBe(false);
+    expect(isMediaMime("audio/mpeg")).toBe(false);
+    expect(isMediaMime("video/mp4")).toBe(false);
+  });
+
+  test("rejects empty string", () => {
+    expect(isMediaMime("")).toBe(false);
+  });
+});
+
+describe("stripMediaPart", () => {
+  test("formats image part with filename", () => {
+    expect(
+      stripMediaPart({
+        type: "file",
+        mime: "image/png",
+        filename: "screenshot.png",
+        url: "data:image/png;base64,abc",
+      }),
+    ).toBe("[Attached image/png: screenshot.png]");
+  });
+
+  test("falls back to literal 'file' when filename missing (upstream parity)", () => {
+    expect(
+      stripMediaPart({
+        type: "file",
+        mime: "image/png",
+        url: "data:image/png;base64,abc",
+      }),
+    ).toBe("[Attached image/png: file]");
+  });
+
+  test("formats PDF part", () => {
+    expect(
+      stripMediaPart({
+        type: "file",
+        mime: "application/pdf",
+        filename: "spec.pdf",
+        url: "file:///tmp/spec.pdf",
+      }),
+    ).toBe("[Attached application/pdf: spec.pdf]");
+  });
+
+  test("returns undefined for non-media file part", () => {
+    expect(
+      stripMediaPart({
+        type: "file",
+        mime: "text/plain",
+        filename: "notes.txt",
+        url: "file:///tmp/notes.txt",
+      }),
+    ).toBeUndefined();
+  });
+
+  test("returns undefined for non-file parts", () => {
+    expect(stripMediaPart({ type: "text", text: "hello" })).toBeUndefined();
+    expect(
+      stripMediaPart({ type: "tool", tool: "grep", state: { status: "completed", output: "" } }),
+    ).toBeUndefined();
+  });
+
+  test("returns undefined when mime is missing or non-string", () => {
+    expect(stripMediaPart({ type: "file" })).toBeUndefined();
+    expect(stripMediaPart({ type: "file", mime: 42 })).toBeUndefined();
+    expect(stripMediaPart({ type: "file", mime: null })).toBeUndefined();
+  });
+
+  test("uses 'file' fallback when filename is non-string", () => {
+    expect(
+      stripMediaPart({
+        type: "file",
+        mime: "image/png",
+        filename: 42,
+        url: "data:image/png;base64,abc",
+      }),
+    ).toBe("[Attached image/png: file]");
+  });
+});
+
+describe("buildMediaAwareRecoveryMessage", () => {
+  test("emits all sections when attachments + user text + summaries are present", () => {
+    const msg = buildMediaAwareRecoveryMessage({
+      summaries: [
+        { observations: "User fixed bug in auth.ts", generation: 0 },
+      ],
+      strippedAttachments: [
+        "[Attached image/png: screenshot.png]",
+        "[Attached application/pdf: spec.pdf]",
+      ],
+      userText: ["What does this image show?"],
+    });
+    // Opening preamble.
+    expect(msg).toContain("<system-reminder>");
+    expect(msg).toContain("context overflow error");
+    // Media notice with both attachments listed.
+    expect(msg).toContain("included 2 attachment(s) that were removed");
+    expect(msg).toContain("- [Attached image/png: screenshot.png]");
+    expect(msg).toContain("- [Attached application/pdf: spec.pdf]");
+    // Distilled history block.
+    expect(msg).toContain("auth.ts");
+    // User question block.
+    expect(msg).toContain("The user's original question");
+    expect(msg).toContain("What does this image show?");
+    // Closing instruction.
+    expect(msg).toContain("Review the above and continue");
+    expect(msg).toContain("</system-reminder>");
+  });
+
+  test("section order: notice → history → user question", () => {
+    const msg = buildMediaAwareRecoveryMessage({
+      summaries: [{ observations: "DISTILL_TOKEN", generation: 0 }],
+      strippedAttachments: ["[Attached image/png: a.png]"],
+      userText: ["USER_TOKEN"],
+    });
+    const noticeIdx = msg.indexOf("included 1 attachment");
+    const historyIdx = msg.indexOf("DISTILL_TOKEN");
+    const userIdx = msg.indexOf("USER_TOKEN");
+    expect(noticeIdx).toBeGreaterThan(-1);
+    expect(historyIdx).toBeGreaterThan(noticeIdx);
+    expect(userIdx).toBeGreaterThan(historyIdx);
+  });
+
+  test("omits media notice when no attachments stripped", () => {
+    const msg = buildMediaAwareRecoveryMessage({
+      summaries: [{ observations: "obs", generation: 0 }],
+      strippedAttachments: [],
+      userText: ["question"],
+    });
+    expect(msg).not.toContain("attachment(s) that were removed");
+  });
+
+  test("omits user-question block when userText is empty", () => {
+    const msg = buildMediaAwareRecoveryMessage({
+      summaries: [{ observations: "obs", generation: 0 }],
+      strippedAttachments: ["[Attached image/png: a.png]"],
+      userText: [],
+    });
+    expect(msg).not.toContain("The user's original question");
+  });
+
+  test("falls through to empty-history sentinel when summaries empty", () => {
+    const msg = buildMediaAwareRecoveryMessage({
+      summaries: [],
+      strippedAttachments: ["[Attached image/png: a.png]"],
+      userText: ["q"],
+    });
+    expect(msg).toContain("No distilled history available");
+  });
+
+  test("multiple user text parts are joined verbatim", () => {
+    const msg = buildMediaAwareRecoveryMessage({
+      summaries: [],
+      strippedAttachments: ["[Attached image/png: a.png]"],
+      userText: ["First sentence.", "Second sentence."],
+    });
+    expect(msg).toContain("First sentence.");
+    expect(msg).toContain("Second sentence.");
+  });
+});
+
 // ── Plugin integration tests ─────────────────────────────────────────
 
 /**
@@ -290,6 +476,40 @@ async function initPlugin() {
   return {
     hooks,
     calls,
+    tmpDir,
+    cleanup: () => rmSync(tmpDir, { recursive: true, force: true }),
+  };
+}
+
+/**
+ * Variant of `initPlugin` that lets tests customize the mock client BEFORE
+ * the plugin is initialized. The customizer receives the mock client and
+ * can override individual `session.*` methods (e.g. swap in a custom
+ * `session.messages` for F9 media-aware tests). Returns the initialized
+ * hooks + the call tracker + the customized client itself.
+ */
+async function initPluginCustomClient(
+  customize: (client: ReturnType<typeof createMockClient>["client"]) => void,
+) {
+  const { calls, client } = createMockClient();
+  customize(client);
+  const tmpDir = `${import.meta.dir}/__tmp_plugin_${Date.now()}_${Math.random().toString(36).slice(2)}__`;
+  const { mkdirSync, rmSync } = await import("fs");
+  mkdirSync(tmpDir, { recursive: true });
+
+  const hooks = await LorePlugin({
+    client,
+    project: { id: "test", path: tmpDir } as any,
+    directory: tmpDir,
+    worktree: tmpDir,
+    serverUrl: new URL("http://localhost:0"),
+    $: {} as any,
+  });
+
+  return {
+    hooks,
+    calls,
+    client,
     tmpDir,
     cleanup: () => rmSync(tmpDir, { recursive: true, force: true }),
   };
@@ -450,6 +670,307 @@ describe("auto-recovery re-entrancy guard", () => {
       await firstError;
     } finally {
       rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ── F9 media-aware recovery — getLastRealUserMessage + handler integration ──
+
+describe("getLastRealUserMessage", () => {
+  test("returns the most recent non-synthetic user message", async () => {
+    const client = {
+      session: {
+        messages: () =>
+          Promise.resolve({
+            data: [
+              {
+                info: { id: "m1", role: "user" },
+                parts: [{ type: "text", text: "first user question" }],
+              },
+              {
+                info: { id: "m2", role: "assistant" },
+                parts: [{ type: "text", text: "answer" }],
+              },
+              {
+                info: { id: "m3", role: "user" },
+                parts: [{ type: "text", text: "follow-up" }],
+              },
+            ],
+          }),
+      },
+    };
+    const result = await getLastRealUserMessage(client, "ses_test");
+    expect(result).toBeDefined();
+    // Most recent (m3), not the older one.
+    expect((result?.info as any).id).toBe("m3");
+    expect(result?.parts[0]).toMatchObject({ type: "text", text: "follow-up" });
+  });
+
+  test("skips synthetic user messages (Lore's own recovery injections)", async () => {
+    const client = {
+      session: {
+        messages: () =>
+          Promise.resolve({
+            data: [
+              {
+                info: { id: "m1", role: "user" },
+                parts: [{ type: "text", text: "real question" }],
+              },
+              {
+                info: { id: "m2", role: "assistant" },
+                parts: [{ type: "text", text: "answer" }],
+              },
+              {
+                info: { id: "m3", role: "user" },
+                parts: [
+                  {
+                    type: "text",
+                    text: "<system-reminder>...</system-reminder>",
+                    synthetic: true,
+                  },
+                ],
+              },
+            ],
+          }),
+      },
+    };
+    const result = await getLastRealUserMessage(client, "ses_test");
+    // Should skip m3 (synthetic) and return m1.
+    expect((result?.info as any).id).toBe("m1");
+  });
+
+  test("returns undefined when only synthetic user messages exist", async () => {
+    const client = {
+      session: {
+        messages: () =>
+          Promise.resolve({
+            data: [
+              {
+                info: { id: "m1", role: "user" },
+                parts: [{ type: "text", text: "synth", synthetic: true }],
+              },
+            ],
+          }),
+      },
+    };
+    expect(await getLastRealUserMessage(client, "ses_test")).toBeUndefined();
+  });
+
+  test("returns undefined for empty session", async () => {
+    const client = {
+      session: { messages: () => Promise.resolve({ data: [] }) },
+    };
+    expect(await getLastRealUserMessage(client, "ses_test")).toBeUndefined();
+  });
+
+  test("returns undefined when SDK call throws (logs warning, swallows)", async () => {
+    const client = {
+      session: {
+        messages: () => Promise.reject(new Error("network blip")),
+      },
+    };
+    // Must not throw out of the helper.
+    expect(await getLastRealUserMessage(client, "ses_test")).toBeUndefined();
+  });
+
+  test("tolerates missing `data` field on response", async () => {
+    const client = {
+      session: { messages: () => Promise.resolve({}) },
+    };
+    expect(await getLastRealUserMessage(client, "ses_test")).toBeUndefined();
+  });
+
+  test("tolerates messages with malformed shape", async () => {
+    const client = {
+      session: {
+        messages: () =>
+          Promise.resolve({
+            data: [
+              null,
+              { info: null, parts: [] },
+              { info: { role: "user" }, parts: [{ type: "text", text: "ok" }] },
+            ],
+          }),
+      },
+    };
+    const result = await getLastRealUserMessage(client, "ses_test");
+    expect(result?.parts[0]).toMatchObject({ type: "text", text: "ok" });
+  });
+});
+
+describe("auto-recovery — media-aware path (F9)", () => {
+  test("recovery prompt includes attachment list + user text when last user message has media", async () => {
+    const { hooks, calls, client, cleanup } = await initPluginCustomClient((c) => {
+      // Override session.messages to return a user message with an
+      // image attachment + text question.
+      (c.session as any).messages = () =>
+        Promise.resolve({
+          data: [
+            {
+              info: { id: "m1", role: "user" },
+              parts: [
+                { type: "text", text: "Explain this screenshot please." },
+                {
+                  type: "file",
+                  mime: "image/png",
+                  filename: "screenshot.png",
+                  url: "data:image/png;base64,abc",
+                },
+              ],
+            },
+          ],
+        });
+    });
+    try {
+      const sessionID = "ses_f9_media_001";
+      await hooks.event!({
+        event: {
+          type: "session.error",
+          properties: {
+            sessionID,
+            error: { message: "prompt is too long: 250000 tokens" },
+          },
+        } as any,
+      });
+      // Recovery prompt was sent.
+      expect(calls["session.prompt"]?.length ?? 0).toBeGreaterThanOrEqual(1);
+      // Inspect the body.
+      const promptArgs = calls["session.prompt"]![0]![0] as {
+        body: { parts: Array<{ text: string }> };
+      };
+      const text = promptArgs.body.parts[0]!.text;
+      expect(text).toContain("[Attached image/png: screenshot.png]");
+      expect(text).toContain("Explain this screenshot please.");
+      expect(text).toContain("compressed the conversation history");
+      expect(text).toContain("attachment(s) that were removed");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("recovery prompt falls back to plain buildRecoveryMessage when no media in last user message", async () => {
+    const { hooks, calls, cleanup } = await initPluginCustomClient((c) => {
+      // User message with text only — no media.
+      (c.session as any).messages = () =>
+        Promise.resolve({
+          data: [
+            {
+              info: { id: "m1", role: "user" },
+              parts: [{ type: "text", text: "ordinary text-only question" }],
+            },
+          ],
+        });
+    });
+    try {
+      const sessionID = "ses_f9_nomedia_001";
+      await hooks.event!({
+        event: {
+          type: "session.error",
+          properties: {
+            sessionID,
+            error: { message: "prompt is too long: 250000 tokens" },
+          },
+        } as any,
+      });
+      expect(calls["session.prompt"]?.length ?? 0).toBeGreaterThanOrEqual(1);
+      const promptArgs = calls["session.prompt"]![0]![0] as {
+        body: { parts: Array<{ text: string }> };
+      };
+      const text = promptArgs.body.parts[0]!.text;
+      // Plain recovery contract per F9 D4: byte-identical to today.
+      // We seed no distillations in this test (initPluginCustomClient
+      // creates an empty DB), so the expected payload is the
+      // "no summaries provided" fallback. Pin the full string so any
+      // accidental drift (e.g. an extra blank line, a section sneaking
+      // through the no-media path) is caught.
+      expect(text).toBe(buildRecoveryMessage([]));
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("recovery falls through to plain path when session.messages throws", async () => {
+    const { hooks, calls, cleanup } = await initPluginCustomClient((c) => {
+      (c.session as any).messages = () =>
+        Promise.reject(new Error("simulated SDK failure"));
+    });
+    try {
+      const sessionID = "ses_f9_sdk_fail_001";
+      await hooks.event!({
+        event: {
+          type: "session.error",
+          properties: {
+            sessionID,
+            error: { message: "prompt is too long: 250000 tokens" },
+          },
+        } as any,
+      });
+      // Recovery still happens — falls back to plain message.
+      expect(calls["session.prompt"]?.length ?? 0).toBeGreaterThanOrEqual(1);
+      const promptArgs = calls["session.prompt"]![0]![0] as {
+        body: { parts: Array<{ text: string }> };
+      };
+      const text = promptArgs.body.parts[0]!.text;
+      expect(text).not.toContain("attachment(s) that were removed");
+      expect(text).toContain("compressed the conversation history");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("multiple media attachments are all listed in the notice", async () => {
+    const { hooks, calls, cleanup } = await initPluginCustomClient((c) => {
+      (c.session as any).messages = () =>
+        Promise.resolve({
+          data: [
+            {
+              info: { id: "m1", role: "user" },
+              parts: [
+                { type: "text", text: "compare these" },
+                {
+                  type: "file",
+                  mime: "image/png",
+                  filename: "a.png",
+                  url: "data:image/png;base64,a",
+                },
+                {
+                  type: "file",
+                  mime: "image/jpeg",
+                  filename: "b.jpg",
+                  url: "data:image/jpeg;base64,b",
+                },
+                {
+                  type: "file",
+                  mime: "application/pdf",
+                  filename: "c.pdf",
+                  url: "file:///tmp/c.pdf",
+                },
+              ],
+            },
+          ],
+        });
+    });
+    try {
+      const sessionID = "ses_f9_multi_media";
+      await hooks.event!({
+        event: {
+          type: "session.error",
+          properties: {
+            sessionID,
+            error: { message: "prompt is too long: 250000 tokens" },
+          },
+        } as any,
+      });
+      const promptArgs = calls["session.prompt"]![0]![0] as {
+        body: { parts: Array<{ text: string }> };
+      };
+      const text = promptArgs.body.parts[0]!.text;
+      expect(text).toContain("3 attachment(s) that were removed");
+      expect(text).toContain("[Attached image/png: a.png]");
+      expect(text).toContain("[Attached image/jpeg: b.jpg]");
+      expect(text).toContain("[Attached application/pdf: c.pdf]");
+    } finally {
+      cleanup();
     }
   });
 });


### PR DESCRIPTION
## Summary

Close the last user-intent-preservation gap in Lore's overflow recovery path. When a session overflows because the user's most recent turn carried image/PDF attachments, the synthetic recovery message now preserves the user's text question AND lists the dropped attachments using upstream OpenCode's exact `[Attached <mime>: <filename or "file">]` stub format. When no media is present, the existing plain `buildRecoveryMessage` output is byte-identical to today.

## Why

Today's overflow recovery (`packages/opencode/src/index.ts:138-154` `buildRecoveryMessage`):
- Loads distillations, emits a fixed `<system-reminder>` block.
- For a user turn like "Explain this screenshot" with a 5MB PNG that caused a 413 → distillations don't capture the failed turn (it errored before completion). Model has zero idea what was asked.
- Media is silently dropped — user gets no acknowledgement.

Upstream's compaction replay path (`compaction.ts:357-380, 490-502`) reconstructs the user message and re-submits with media stripped. F9 borrows the **content preservation** but keeps Lore's simpler synthetic-text contract — Lore continues to inject a single synthetic text part, just with richer content.

## Design

### Detection (D1 in plan)
Walk back to the last real (non-synthetic) user message via `client.session.messages` (route `/session/{id}/message`). Use the media-aware path whenever any file part has an `isMedia(mime)` type — no size threshold. Simple, no estimation guesswork; the richer recovery message is strictly more informative than the plain version.

### Selector (D4 in plan)
- Has media parts → `buildMediaAwareRecoveryMessage` (notice + history + user text).
- No media OR SDK call fails → plain `buildRecoveryMessage` (byte-identical to today).

### Stub format byte-parity (D5 in plan)
`[Attached <mime>: <filename or "file">]` — exact byte match to `compaction.ts:494`. Note the fallback is the literal `"file"`, not `"attachment"`.

### Defensive shape-handling (D6 in plan)
`getLastRealUserMessage` tolerates: SDK throws, missing `data`, `null` array elements, missing `info`, non-string `role`, missing `parts`. All paths fall through to plain recovery. The recovery handler is wrapped in try/catch with `recoveringSessions.delete` in finally — F9 doesn't add new failure modes.

## Files changed

| File | Change |
|------|--------|
| `packages/opencode/src/index.ts` | Add `isMediaMime`, `stripMediaPart`, `getLastRealUserMessage`, `buildMediaAwareRecoveryMessage` (all exported). Wire into the `session.error` handler with `strippedAttachments.length > 0` selector. |
| `packages/opencode/test/index.test.ts` | Add 28 new tests across helper-level (17), `getLastRealUserMessage` shape-handling (7), and end-to-end handler integration (4). Add `initPluginCustomClient` test harness for pre-init mock overrides. |

## Stub format byte-parity confirmed

Verified against upstream:
- `[Attached image/png: screenshot.png]` (with filename)
- `[Attached image/png: file]` (filename missing — note the literal `"file"` fallback)
- `[Attached application/pdf: spec.pdf]` (PDF)

`isMediaMime`: `mime.startsWith("image/") || mime === "application/pdf"` — same set as upstream's `util/media.ts:7-9`.

## Plain-path regression guard

The "no media in last user message" test pins byte-equivalence:

```ts
expect(text).toBe(buildRecoveryMessage([]));
```

Any accidental drift in the no-media path (extra blank line, section sneaking through, etc.) will fail loudly.

## Verification

- `bun test`: 466 pass / 0 fail (4991 expect calls across 19 files, +28 new tests).
- `bun --filter '*' typecheck`: all three packages exit 0.
- `bun --filter '*' build`: core + pi bundles clean, opencode ships raw TS.

## Out of scope

- **Full upstream-style replay** (cloning user message info+parts as a fresh turn). Lore's recovery model is text-only synthetic; F9 enriches the content without changing the contract.
- **Walk-back length optimization**. `client.session.messages` returns all messages by default. Recovery is not a hot path; the round-trip is bounded by the re-entrancy guard. If telemetry shows long sessions causing latency spikes during recovery, add `query: { limit: 50 }` as a follow-up.
- **Pi extension parity**. Pi has a different overflow surface (`session_before_compact`); F9 lives in OpenCode.
- **Persisting stripped media** for later reference. Not a recovery concern.

## Review trail

Subagent self-review pass cleared as merge-ready with no code-correctness blockers. One suggested test tightening applied: pin byte-equivalence to `buildRecoveryMessage([])` in the no-media path so any accidental drift is caught.
