### PR TITLE
feat(compact): anchor /compact on prior summary via SDK live read

### DIFF
--- a/packages/core/src/prompt.ts
+++ b/packages/core/src/prompt.ts
@@ -437,29 +437,39 @@ Rules:
 // Lore injects pre-computed distillations as context separately; this prompt
 // just tells the model how to render its summary.
 //
-// NOTE: Upstream's SUMMARY_TEMPLATE path also supports `<previous-summary>`
-// anchoring for repeat /compact invocations. Lore does not implement that yet —
-// see F1b follow-up for the persistence+retrieval needed to do it safely
-// (gen>0 meta-distillations are XML observation dumps, not prior /compact
-// output, so we can't reuse them as anchors).
-//
 // `hasDistillations` is a boolean rather than the full array because this
 // function only cares about presence — the distillation bodies are pushed into
 // `output.context` separately by the caller. Passing the array shape would be
 // misleading dead weight.
+//
+// `previousSummary` is the prior `/compact` output text (typically from the
+// most recent assistant message with `info.summary === true`). When present,
+// the prompt asks the model to UPDATE the anchored summary in place rather
+// than re-derive from scratch — matching upstream OpenCode's behavior at
+// `compaction.ts:121-132` (`buildPrompt`). When absent, the prompt is
+// byte-identical to today's non-anchored output.
+//
+// F1b (this parameter) is OpenCode-specific: the retrieval path uses
+// `client.session.messages` to find the prior summary by `info.summary === true`.
+// See `findPreviousCompactSummary` in `packages/opencode/src/index.ts`.
 export function buildCompactPrompt(input: {
   hasDistillations: boolean;
   knowledge?: string;
+  previousSummary?: string;
 }): string {
   const distillSection = input.hasDistillations
     ? "Lore has pre-computed chunked summaries of the session history (injected above as context). Use them as the authoritative source — do NOT re-read raw conversation messages that conflict with them.\n\n"
+    : "";
+
+  const anchorBlock = input.previousSummary
+    ? `A prior compacted summary exists for this session. Update it using the conversation history above: preserve still-true details, remove stale details, and merge in new facts. Keep every section in place.\n\n<previous-summary>\n${input.previousSummary}\n</previous-summary>\n\n`
     : "";
 
   const knowledgeBlock = input.knowledge ? `\n${input.knowledge}\n` : "";
 
   return `You are producing a compacted session summary for an AI coding agent. This summary will be the ONLY context available in the next part of the conversation.
 
-${distillSection}${COMPACT_SUMMARY_TEMPLATE}
+${distillSection}${anchorBlock}${COMPACT_SUMMARY_TEMPLATE}
 ${knowledgeBlock}`;
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -35,6 +35,15 @@ export type LoreAssistantMessage = {
   modelID: string;
   providerID: string;
   mode: string;
+  /**
+   * Set to `true` by the OpenCode compaction agent on the assistant
+   * message that holds a `/compact` summary (see upstream
+   * `compaction.ts:435`). Lore reads this flag in F1b's
+   * `findPreviousCompactSummary` to anchor repeat `/compact`
+   * invocations to the prior summary. Always undefined for normal
+   * assistant turns.
+   */
+  summary?: boolean;
   path: { cwd: string; root: string };
   cost: number;
   tokens: {

--- a/packages/core/test/prompt.test.ts
+++ b/packages/core/test/prompt.test.ts
@@ -88,4 +88,62 @@ describe("buildCompactPrompt", () => {
     expect(templateIdx).toBeGreaterThan(reminderIdx);
     expect(knowledgeIdx).toBeGreaterThan(templateIdx);
   });
+
+  // F1b: anchor parameter
+  test("emits a <previous-summary> block when previousSummary is provided", () => {
+    const priorSummary = "## Goal\n- Refactor auth module\n## Progress\n### Done\n- Wrote tests";
+    const prompt = buildCompactPrompt({
+      hasDistillations: false,
+      previousSummary: priorSummary,
+    });
+    expect(prompt).toContain("<previous-summary>");
+    expect(prompt).toContain(priorSummary);
+    expect(prompt).toContain("</previous-summary>");
+    // Update-in-place instruction.
+    expect(prompt).toContain("Update it using the conversation history above");
+  });
+
+  test("no anchor block when previousSummary is undefined (byte-identical to pre-F1b)", () => {
+    const withParam = buildCompactPrompt({
+      hasDistillations: false,
+      previousSummary: undefined,
+    });
+    const withoutParam = buildCompactPrompt({
+      hasDistillations: false,
+    });
+    expect(withParam).toBe(withoutParam);
+    expect(withParam).not.toContain("<previous-summary>");
+    expect(withParam).not.toContain("Update it using the conversation history");
+  });
+
+  test("empty-string previousSummary is treated as absent", () => {
+    const withEmpty = buildCompactPrompt({
+      hasDistillations: false,
+      previousSummary: "",
+    });
+    const withoutParam = buildCompactPrompt({
+      hasDistillations: false,
+    });
+    expect(withEmpty).toBe(withoutParam);
+    expect(withEmpty).not.toContain("<previous-summary>");
+  });
+
+  test("anchor block placement: distill-reminder → anchor → template → knowledge", () => {
+    const prompt = buildCompactPrompt({
+      hasDistillations: true,
+      knowledge: "## Long-term Knowledge\n### Pattern\n- **X**: Y",
+      previousSummary: "PRIOR_SUMMARY_TOKEN",
+    });
+    const reminderIdx = prompt.indexOf("Lore has pre-computed");
+    const anchorIdx = prompt.indexOf("<previous-summary>");
+    const summaryBodyIdx = prompt.indexOf("PRIOR_SUMMARY_TOKEN");
+    const templateIdx = prompt.indexOf("## Goal");
+    const knowledgeIdx = prompt.indexOf("## Long-term Knowledge");
+
+    expect(reminderIdx).toBeGreaterThan(-1);
+    expect(anchorIdx).toBeGreaterThan(reminderIdx);
+    expect(summaryBodyIdx).toBeGreaterThan(anchorIdx);
+    expect(templateIdx).toBeGreaterThan(anchorIdx);
+    expect(knowledgeIdx).toBeGreaterThan(templateIdx);
+  });
 });

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -251,6 +251,69 @@ export async function getLastRealUserMessage(
 }
 
 /**
+ * Walk session messages newest-first to find the most recent prior `/compact`
+ * summary text. The compaction agent (upstream `compaction.ts:410-435`) emits
+ * an assistant message in the same session with `info.summary === true` and
+ * `info.mode === "compaction"` — this helper recovers the joined text-part
+ * content so the next `/compact` can anchor on it.
+ *
+ * Returns the joined text of the matched assistant message, or `undefined`
+ * when no prior summary exists or the SDK call fails. The caller falls
+ * through to non-anchored compaction in either case (byte-identical to the
+ * pre-F1b behavior).
+ *
+ * Approximates upstream's `completedCompactions` detection at
+ * `compaction.ts:104-118`. Upstream additionally checks `info.finish &&
+ * !info.error` and that the parent user message contains a `compaction` part;
+ * Lore relies on the upstream invariant that `summary` is only set on
+ * successfully completed compaction-agent assistant messages so the simpler
+ * `summary` check is sufficient in practice. Text-part assembly mirrors
+ * upstream's `summaryText` (`compaction.ts:93-101`): per-part trim, drop
+ * empties, join with paragraph breaks.
+ */
+export async function findPreviousCompactSummary(
+  client: SessionMessagesClient,
+  sessionID: string,
+): Promise<string | undefined> {
+  let resp;
+  try {
+    resp = await client.session.messages({ path: { id: sessionID } });
+  } catch (e) {
+    log.warn(`findPreviousCompactSummary: session.messages failed for ${sessionID.substring(0, 16)}:`, e);
+    return undefined;
+  }
+  const msgs = resp?.data ?? [];
+  for (let i = msgs.length - 1; i >= 0; i--) {
+    const raw = msgs[i];
+    if (!raw || typeof raw !== "object") continue;
+    const m = raw as { info?: unknown; parts?: unknown };
+    const info = m.info;
+    if (!info || typeof info !== "object") continue;
+    if ((info as { role?: unknown }).role !== "assistant") continue;
+    // Truthy check (matches upstream: `!msg.info.summary` rejects falsy).
+    // Production data only ever sets the flag to literal `true`; the looser
+    // check still rejects undefined / false / null / 0 / "" without
+    // false-positive matching string-typed truthy values from a
+    // hypothetical malformed SDK response.
+    if (!(info as { summary?: unknown }).summary) continue;
+    const partsRaw = m.parts;
+    const parts: Array<Record<string, unknown>> = Array.isArray(partsRaw)
+      ? (partsRaw as Array<Record<string, unknown>>)
+      : [];
+    const text = parts
+      .filter(
+        (p) =>
+          p && typeof p === "object" && p.type === "text" && typeof p.text === "string",
+      )
+      .map((p) => (p.text as string).trim())
+      .filter((s) => s.length > 0)
+      .join("\n\n");
+    if (text.length > 0) return text;
+  }
+  return undefined;
+}
+
+/**
  * Build a media-aware recovery message that extends the plain version with
  * (a) a list of stripped attachments and (b) the user's original text from
  * the failed turn. The plain `buildRecoveryMessage` should be preferred
@@ -1011,6 +1074,12 @@ export const LorePlugin: Plugin = async (ctx) => {
     // buildCompactPrompt (Goal / Progress / Next Steps / Blocked / etc.), derived from
     // upstream OpenCode's template so the next agent starting from the compacted
     // context has a clear "where am I, what's next" briefing.
+    //
+    // F1b: when a prior /compact summary exists in the session (assistant
+    // message with `info.summary === true`), retrieve it via
+    // `findPreviousCompactSummary` and pass as `previousSummary` so the
+    // model UPDATES the anchored summary rather than re-deriving from
+    // scratch. Mirrors upstream's `<previous-summary>` behavior.
     "experimental.session.compacting": async (input, output) => {
       // Chunked distillation: split all undistilled messages into segments that each
       // fit within the model's context window and distill them independently.
@@ -1024,6 +1093,13 @@ export const LorePlugin: Plugin = async (ctx) => {
       const distillations = input.sessionID
         ? distillation.loadForSession(projectPath, input.sessionID)
         : [];
+
+      // F1b anchor: find the prior /compact assistant summary (if any).
+      // SDK failure / no prior summary → undefined → byte-identical to
+      // pre-F1b prompt output.
+      const previousSummary = input.sessionID
+        ? await findPreviousCompactSummary(ctx.client, input.sessionID)
+        : undefined;
 
       const entries = config().knowledge.enabled
         ? ltm.forProject(projectPath, config().crossProject)
@@ -1056,6 +1132,7 @@ export const LorePlugin: Plugin = async (ctx) => {
       output.prompt = buildCompactPrompt({
         hasDistillations: distillations.length > 0,
         knowledge,
+        previousSummary,
       });
     },
 

--- a/packages/opencode/test/index.test.ts
+++ b/packages/opencode/test/index.test.ts
@@ -6,6 +6,7 @@ import {
   isMediaMime,
   stripMediaPart,
   getLastRealUserMessage,
+  findPreviousCompactSummary,
   LorePlugin,
   isValidProjectPath,
 } from "../src/index";
@@ -795,6 +796,214 @@ describe("getLastRealUserMessage", () => {
     };
     const result = await getLastRealUserMessage(client, "ses_test");
     expect(result?.parts[0]).toMatchObject({ type: "text", text: "ok" });
+  });
+});
+
+// ── F1b: findPreviousCompactSummary — pure helper tests ──────────────
+
+describe("findPreviousCompactSummary", () => {
+  test("returns the most recent assistant message text where info.summary is true", async () => {
+    const client = {
+      session: {
+        messages: () =>
+          Promise.resolve({
+            data: [
+              {
+                info: { id: "u1", role: "user" },
+                parts: [{ type: "text", text: "first user turn" }],
+              },
+              {
+                info: { id: "a1", role: "assistant", summary: true, mode: "compaction" },
+                parts: [
+                  { type: "text", text: "## Goal\n- prior session goal\n## Progress\n- step 1" },
+                ],
+              },
+              {
+                info: { id: "u2", role: "user" },
+                parts: [{ type: "text", text: "follow-up question" }],
+              },
+              {
+                info: { id: "a2", role: "assistant" },
+                parts: [{ type: "text", text: "regular assistant reply" }],
+              },
+            ],
+          }),
+      },
+    };
+    const result = await findPreviousCompactSummary(client, "ses_test");
+    expect(result).toBe("## Goal\n- prior session goal\n## Progress\n- step 1");
+  });
+
+  test("returns the MOST RECENT summary when multiple exist", async () => {
+    const client = {
+      session: {
+        messages: () =>
+          Promise.resolve({
+            data: [
+              {
+                info: { id: "a1", role: "assistant", summary: true },
+                parts: [{ type: "text", text: "older summary" }],
+              },
+              {
+                info: { id: "a2", role: "assistant", summary: true },
+                parts: [{ type: "text", text: "newer summary" }],
+              },
+            ],
+          }),
+      },
+    };
+    expect(await findPreviousCompactSummary(client, "ses_test")).toBe("newer summary");
+  });
+
+  test("returns undefined when no assistant has summary === true", async () => {
+    const client = {
+      session: {
+        messages: () =>
+          Promise.resolve({
+            data: [
+              {
+                info: { id: "a1", role: "assistant" },
+                parts: [{ type: "text", text: "regular reply" }],
+              },
+              {
+                info: { id: "a2", role: "assistant", summary: false },
+                parts: [{ type: "text", text: "explicitly-false flag" }],
+              },
+            ],
+          }),
+      },
+    };
+    expect(await findPreviousCompactSummary(client, "ses_test")).toBeUndefined();
+  });
+
+  test("returns undefined for empty session", async () => {
+    const client = {
+      session: { messages: () => Promise.resolve({ data: [] }) },
+    };
+    expect(await findPreviousCompactSummary(client, "ses_test")).toBeUndefined();
+  });
+
+  test("returns undefined when SDK call throws (logs warning, swallows)", async () => {
+    const client = {
+      session: {
+        messages: () => Promise.reject(new Error("network blip")),
+      },
+    };
+    expect(await findPreviousCompactSummary(client, "ses_test")).toBeUndefined();
+  });
+
+  test("joins multiple text parts with paragraph break (matches upstream summaryText)", async () => {
+    // Upstream's summaryText (compaction.ts:93-101) joins trimmed parts with
+    // "\n\n" after dropping empties. Lore mirrors that.
+    const client = {
+      session: {
+        messages: () =>
+          Promise.resolve({
+            data: [
+              {
+                info: { id: "a1", role: "assistant", summary: true },
+                parts: [
+                  { type: "text", text: "## Goal\n- ship F1b" },
+                  { type: "text", text: "  " }, // whitespace-only — dropped
+                  { type: "text", text: "## Progress\n- writing tests" },
+                ],
+              },
+            ],
+          }),
+      },
+    };
+    const result = await findPreviousCompactSummary(client, "ses_test");
+    expect(result).toBe("## Goal\n- ship F1b\n\n## Progress\n- writing tests");
+  });
+
+  test("ignores reasoning/tool parts on the matched message", async () => {
+    const client = {
+      session: {
+        messages: () =>
+          Promise.resolve({
+            data: [
+              {
+                info: { id: "a1", role: "assistant", summary: true },
+                parts: [
+                  { type: "reasoning", text: "internal thought" },
+                  { type: "text", text: "actual summary body" },
+                  { type: "tool", tool: "grep", state: { status: "completed", output: "x" } },
+                ],
+              },
+            ],
+          }),
+      },
+    };
+    expect(await findPreviousCompactSummary(client, "ses_test")).toBe("actual summary body");
+  });
+
+  test("skips assistants where summary is falsy (matches upstream's truthy check)", async () => {
+    // Upstream's completedCompactions uses `!msg.info.summary` (truthy check).
+    // Confirm Lore matches: false, null, 0, "" are all rejected; only the
+    // earlier "summary === true" case from the matching tests qualifies.
+    const client = {
+      session: {
+        messages: () =>
+          Promise.resolve({
+            data: [
+              {
+                info: { id: "a1", role: "assistant", summary: false },
+                parts: [{ type: "text", text: "explicit false" }],
+              },
+              {
+                info: { id: "a2", role: "assistant", summary: null },
+                parts: [{ type: "text", text: "explicit null" }],
+              },
+              {
+                info: { id: "a3", role: "assistant", summary: 0 },
+                parts: [{ type: "text", text: "numeric zero" }],
+              },
+              {
+                info: { id: "a4", role: "assistant", summary: "" },
+                parts: [{ type: "text", text: "empty string" }],
+              },
+            ],
+          }),
+      },
+    };
+    expect(await findPreviousCompactSummary(client, "ses_test")).toBeUndefined();
+  });
+
+  test("tolerates malformed entries (null, missing info, missing parts)", async () => {
+    const client = {
+      session: {
+        messages: () =>
+          Promise.resolve({
+            data: [
+              null,
+              { info: null, parts: [] },
+              { info: { role: "user" } },
+              {
+                info: { role: "assistant", summary: true },
+                parts: [{ type: "text", text: "valid summary" }],
+              },
+            ],
+          }),
+      },
+    };
+    expect(await findPreviousCompactSummary(client, "ses_test")).toBe("valid summary");
+  });
+
+  test("returns undefined when summary message has no non-empty text parts", async () => {
+    const client = {
+      session: {
+        messages: () =>
+          Promise.resolve({
+            data: [
+              {
+                info: { role: "assistant", summary: true },
+                parts: [{ type: "text", text: "   " }, { type: "reasoning", text: "thought" }],
+              },
+            ],
+          }),
+      },
+    };
+    expect(await findPreviousCompactSummary(client, "ses_test")).toBeUndefined();
   });
 });
 
@@ -1883,6 +2092,110 @@ describe("experimental.session.compacting", () => {
       expect(prompt).toContain("## Goal");
       // No distillations possible → no context block.
       expect(context).toHaveLength(0);
+    } finally {
+      cleanup();
+    }
+  });
+
+  // F1b: anchor on prior /compact summary
+
+  test("F1b: emits <previous-summary> anchor when a prior /compact summary exists in the session", async () => {
+    const priorSummaryText =
+      "## Goal\n- Refactor the auth module\n## Progress\n### Done\n- Added OAuth\n### In Progress\n- Token refresh\n## Next Steps\n- Write integration tests";
+    const { hooks, cleanup } = await initPluginCustomClient((c) => {
+      (c.session as any).messages = () =>
+        Promise.resolve({
+          data: [
+            {
+              info: { id: "u1", role: "user" },
+              parts: [{ type: "text", text: "first user turn" }],
+            },
+            {
+              info: { id: "a1", role: "assistant", summary: true, mode: "compaction" },
+              parts: [{ type: "text", text: priorSummaryText }],
+            },
+            {
+              info: { id: "u2", role: "user" },
+              parts: [{ type: "text", text: "more conversation after compact" }],
+            },
+          ],
+        });
+    });
+    try {
+      const { prompt } = await callCompacting(hooks!, {
+        sessionID: "ses_f1b_anchor_001",
+      });
+      expect(prompt).toContain("<previous-summary>");
+      expect(prompt).toContain(priorSummaryText);
+      expect(prompt).toContain("</previous-summary>");
+      expect(prompt).toContain("Update it using the conversation history above");
+      // Template body still emitted alongside.
+      expect(prompt).toContain("## Goal");
+      expect(prompt).toContain("## Next Steps");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("F1b: no anchor block when session has no prior /compact summary", async () => {
+    const { hooks, cleanup } = await initPluginCustomClient((c) => {
+      (c.session as any).messages = () =>
+        Promise.resolve({
+          data: [
+            {
+              info: { id: "u1", role: "user" },
+              parts: [{ type: "text", text: "first user turn" }],
+            },
+            {
+              info: { id: "a1", role: "assistant" },
+              parts: [{ type: "text", text: "regular assistant reply" }],
+            },
+          ],
+        });
+    });
+    try {
+      const { prompt } = await callCompacting(hooks!, {
+        sessionID: "ses_f1b_noanchor_001",
+      });
+      expect(prompt).not.toContain("<previous-summary>");
+      expect(prompt).not.toContain("Update it using the conversation history");
+      // Template body still emitted.
+      expect(prompt).toContain("## Goal");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("F1b: SDK failure on session.messages falls through to non-anchored prompt", async () => {
+    const { hooks, cleanup } = await initPluginCustomClient((c) => {
+      (c.session as any).messages = () =>
+        Promise.reject(new Error("simulated SDK failure"));
+    });
+    try {
+      const { prompt } = await callCompacting(hooks!, {
+        sessionID: "ses_f1b_sdkfail_001",
+      });
+      // Recovery: no anchor, but prompt still produced with template body.
+      expect(prompt).not.toContain("<previous-summary>");
+      expect(prompt).toContain("## Goal");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("F1b: missing input.sessionID skips anchor lookup entirely", async () => {
+    let messagesCalled = false;
+    const { hooks, cleanup } = await initPluginCustomClient((c) => {
+      (c.session as any).messages = () => {
+        messagesCalled = true;
+        return Promise.resolve({ data: [] });
+      };
+    });
+    try {
+      const { prompt } = await callCompacting(hooks!, {});
+      expect(messagesCalled).toBe(false);
+      expect(prompt).not.toContain("<previous-summary>");
+      expect(prompt).toContain("## Goal");
     } finally {
       cleanup();
     }


### PR DESCRIPTION
## Summary

Restore the `<previous-summary>` anchor to Lore's `/compact` override that was deferred from F1. When the user runs `/compact` a second time in the same session, the prior compaction-agent summary is retrieved via `client.session.messages` (filtering for `info.summary` per upstream's contract) and passed as `previousSummary` to `buildCompactPrompt`. The compaction agent is then asked to UPDATE the anchored summary in place rather than re-derive from scratch — matching upstream OpenCode's behavior at `compaction.ts:121-132`.

When no prior summary exists or the SDK call fails, the prompt is byte-identical to today's output (the F1 contract is preserved).

## Why deferred from F1

The F1 review caught that `gen>0` distillations come from `metaDistill()` (XML observation dumps from `RECURSIVE_SYSTEM`), NOT from `/compact` outputs. Feeding them into `<previous-summary>` and asking the model to "update it while preserving section order" would confuse the model and silently break on any session with background meta-distillations.

Ground truth (verified before implementation) confirms the OpenCode SDK exposes `AssistantMessage.summary?: boolean` and `AssistantMessage.mode: string` as first-class fields on `message.updated` events and via `client.session.messages`. Upstream sets both on the same-session assistant message bearing the compaction summary (`compaction.ts:410-435`), so it's not a child session — Lore's `shouldSkip` doesn't filter it.

## Files changed

| File | Change |
|------|--------|
| `packages/core/src/types.ts` | Add `summary?: boolean` to `LoreAssistantMessage`. The field flows through the host-abstraction `as unknown as` boundary at runtime but TypeScript couldn't see it; F1b makes it type-visible. |
| `packages/core/src/prompt.ts` | Re-add `previousSummary?: string` parameter to `buildCompactPrompt`. When present, emit a `<previous-summary>` block with update-in-place instructions. When absent or empty string, byte-identical to pre-F1b output. |
| `packages/opencode/src/index.ts` | Add exported `findPreviousCompactSummary(client, sessionID)` helper using F9's `SessionMessagesClient` interface. Wire into the `experimental.session.compacting` hook with `await findPreviousCompactSummary(ctx.client, input.sessionID)`. |
| `packages/core/test/prompt.test.ts` | 4 new tests on the anchor parameter (block emission, no-anchor byte-equivalence, empty-string-as-absent, ordering). |
| `packages/opencode/test/index.test.ts` | 14 new tests: 10 helper-level (most-recent, multi-summaries, no-summary, empty session, SDK throw, multi-text-parts, ignores reasoning/tool, falsy rejection, malformed entries, empty-text fallback) + 4 integration (anchor emitted, no-anchor passthrough, SDK failure fallback, missing sessionID). |

## Detection signal — approximates upstream's `completedCompactions`

Upstream's `completedCompactions` (`compaction.ts:104-118`) checks:
- `info.role === "assistant"`
- `info.summary && info.finish && !info.error`
- parent user message contains a `compaction` part

F1b uses the simpler `info.summary` truthy check, relying on the upstream invariant that the flag is only set on successfully completed compaction-agent assistant messages. JSDoc explicitly notes the divergence — Lore approximates rather than mirrors.

## Text-part assembly mirrors `summaryText`

Per-part trim, drop empties, join with `\n\n` — byte-identical to upstream's `summaryText` (`compaction.ts:93-101`). Pinned by:
```ts
expect(result).toBe("## Goal\n- ship F1b\n\n## Progress\n- writing tests");
```

## Defensive shape-handling

`findPreviousCompactSummary` tolerates: SDK throws (try/catch returns `undefined` + `log.warn`), missing `data`, `null` array elements, missing `info`, non-string `role`/`summary`, missing `parts`, non-array `parts`, non-string `text`. All paths fall through to plain compaction. The recovery handler is wrapped in try/catch with `recoveringSessions.delete` in finally — F1b doesn't add new failure modes.

## Verification

- `bun test`: 484 pass / 0 fail (5038 expect calls across 19 files, +18 new tests).
- `bun --filter '*' typecheck`: all three packages exit 0.
- `bun --filter '*' build`: core + pi bundles clean, opencode ships raw TS.

## Out of scope

- **Persisting prior `/compact` outputs in a dedicated DB table**. The SDK live-read is sufficient for a user-initiated command.
- **Pi parity**. Pi's `session_before_compact` returns the summary text directly with no LLM call — the anchor pattern doesn't apply. F1b is OpenCode-only. The core `LoreAssistantMessage.summary?: boolean` change is harmless to Pi.
- **Cross-session anchoring**. Same session only, matching upstream.

## Review trail

Subagent self-review pass cleared as merge-ready with three Important items, all addressed inline:
1. Detection signal: tightened from strict `=== true` to truthy match upstream's `!msg.info.summary` guard.
2. Text-part join: switched from `\n` to `\n\n` + per-part trim+filter to mirror upstream's `summaryText`.
3. JSDoc accuracy: softened "Mirrors upstream" to "Approximates upstream" with explicit notes on the divergences (drops `finish`/`!error`/parent-CompactionPart guards).
