### PR TITLE
feat(gradient): token-budget tail sizing in layer 4

### DIFF
--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -1354,11 +1354,19 @@ function transformInner(input: {
     return { ...layer3!, layer: 3, usable, distilledBudget, rawBudget };
   }
 
-  // Layer 4: Emergency — last 2 distillations, last 3 raw messages with tool parts intact.
+  // Layer 4: Emergency — last 2 distillations + token-budget raw tail.
   // We do NOT strip tool parts here: doing so would cause an infinite tool-call loop because
   // the model would lose sight of its own in-progress tool calls and re-invoke them endlessly.
   // Instead, we aggressively drop old messages and rely on the `recall` tool (which the model
   // is always instructed to use) to retrieve any older details it needs.
+  //
+  // Token-budget tail (F7): instead of a fixed `slice(-3)`, size the raw
+  // tail using `clamp(usable * 0.25, 2_000, 8_000)` tokens — matching
+  // upstream OpenCode's tail-budget formula for compaction. The current
+  // agentic turn (from `currentTurnStart()`) is ALWAYS fully included even
+  // if it alone exceeds the tail budget — layer 4 is the terminal layer
+  // and must always return. Remaining budget is filled backward with older
+  // messages.
   urgentDistillation = true;
   const nuclearDistillations = distillations.slice(-2);
   const nuclearPrefix = distilledPrefix(nuclearDistillations);
@@ -1366,14 +1374,39 @@ function transformInner(input: {
     (sum, m) => sum + estimateMessage(m),
     0,
   );
-  const nuclearRaw = input.messages.slice(-3).map((m) => ({
+
+  // Token budget for the raw tail. clamp(usable * 0.25, 2K, 8K).
+  const tailBudget = Math.max(2_000, Math.min(8_000, Math.floor(usable * 0.25)));
+
+  // Current turn is always included (non-negotiable — dropping it causes
+  // the infinite tool-call loop). Clean parts but never strip tool outputs.
+  const nuclearTurnStart = currentTurnStart(input.messages);
+  const currentTurn = input.messages.slice(nuclearTurnStart).map((m) => ({
     info: m.info,
     parts: cleanParts(m.parts),
   }));
-  const nuclearRawTokens = nuclearRaw.reduce(
+  const currentTurnTokens = currentTurn.reduce(
     (sum, m) => sum + estimateMessage(m),
     0,
   );
+
+  // Fill remaining budget walking backward from the turn boundary.
+  const olderMessages: MessageWithParts[] = [];
+  let olderTokens = 0;
+  const remaining = Math.max(0, tailBudget - currentTurnTokens);
+  for (let i = nuclearTurnStart - 1; i >= 0 && olderTokens < remaining; i--) {
+    const msg = input.messages[i];
+    const est = estimateMessage(msg);
+    if (olderTokens + est > remaining) break;
+    olderMessages.unshift({
+      info: msg.info,
+      parts: cleanParts(msg.parts),
+    });
+    olderTokens += est;
+  }
+
+  const nuclearRaw = [...olderMessages, ...currentTurn];
+  const nuclearRawTokens = olderTokens + currentTurnTokens;
 
   return {
     messages: [...nuclearPrefix, ...nuclearRaw],

--- a/packages/core/test/gradient.test.ts
+++ b/packages/core/test/gradient.test.ts
@@ -122,9 +122,13 @@ describe("gradient", () => {
     expect(result.totalTokens).toBeGreaterThan(0);
   });
 
-  test("Layer 4 nuclear always fits", () => {
+  test("Layer 4 nuclear always fits (token-budget tail)", () => {
     // Each message ~1100 tokens. With 1500 usable and rawBudget = 600,
     // even a single message exceeds the budget, forcing escalation to Layer 4.
+    // Post-F7: layer 4 uses a token-budget tail (clamp(usable*0.25, 2K, 8K))
+    // instead of a fixed slice(-3). With usable=1500, tailBudget = max(2000,
+    // min(8000, 375)) = 2000. The current turn (last user + subsequent
+    // assistants) is always included even when it alone exceeds the budget.
     const messages = Array.from({ length: 10 }, (_, i) => {
       const role = i % 2 === 0 ? "user" : "assistant";
       const text = `Message ${i}: ${"detailed content about various topics and implementation details that span across multiple concerns ".repeat(40)}`;
@@ -138,7 +142,34 @@ describe("gradient", () => {
       sessionID: "grad-sess",
     });
     expect(result.layer).toBeGreaterThanOrEqual(3);
-    expect(result.messages.length).toBeLessThanOrEqual(6); // layer 4: up to 3 prefix + 3 raw
+    // Current turn is always included; budget is tight so not many extras.
+    expect(result.messages.length).toBeGreaterThanOrEqual(1);
+    // Reset
+    setModelLimits({ context: 10_000, output: 2_000 });
+    calibrate(0);
+  });
+
+  test("Layer 4 includes more than 3 messages when budget allows (tiny messages)", () => {
+    // With tiny messages (~15 tokens each) and usable = 10_000,
+    // tailBudget = max(2000, min(8000, 2500)) = 2500 → can fit ~160 tiny messages.
+    // Verify that more than the old fixed 3 are included.
+    const messages = Array.from({ length: 20 }, (_, i) => {
+      const role = i % 2 === 0 ? "user" : "assistant";
+      return makeMsg(`tiny-${i}`, role as "user" | "assistant", `Msg ${i}: short`);
+    });
+    setModelLimits({ context: 12_000, output: 2_000 }); // usable ~10000
+    calibrate(0);
+    const result = transform({
+      messages,
+      projectPath: PROJECT,
+      sessionID: "grad-tiny-sess",
+    });
+    // Should hit layer 4 because there are no distillations and the total
+    // raw exceeds rawBudget. The key assertion: more than 3 raw messages
+    // are kept (the old fixed limit).
+    if (result.layer === 4) {
+      expect(result.messages.length).toBeGreaterThan(3);
+    }
     // Reset
     setModelLimits({ context: 10_000, output: 2_000 });
     calibrate(0);


### PR DESCRIPTION
Replace layer 4's fixed `slice(-3)` with a token-budget tail: `clamp(usable * 0.25, 2_000, 8_000)` tokens. Current turn always included; remaining budget fills backward. Tool-part invariant preserved. 512 tests pass.