### PR TITLE
fix: CROSS JOIN for FTS5 queries — prevent server freeze on recall

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -362,6 +362,10 @@ export function db(): Database {
   instance = new Database(path);
   instance.exec("PRAGMA journal_mode = WAL");
   instance.exec("PRAGMA foreign_keys = ON");
+  // Retry for up to 5s when another connection holds the write lock (e.g.
+  // backgroundDistill's BEGIN IMMEDIATE overlapping with a recall query).
+  // Default is 0ms which throws SQLITE_BUSY immediately.
+  instance.exec("PRAGMA busy_timeout = 5000");
   // Return freed pages to the OS incrementally on each transaction commit
   // instead of accumulating a free-page list that bloats the file.
   instance.exec("PRAGMA auto_vacuum = INCREMENTAL");

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -12,6 +12,11 @@ import { db } from "./db";
 import { config } from "./config";
 import * as log from "./log";
 
+/** Timeout for embedding API fetch calls (ms). Prevents a hanging API from
+ *  blocking the recall tool indefinitely. 10s is generous for typical 100-500ms
+ *  embedding calls but bounded enough to avoid minutes-long hangs. */
+const EMBED_TIMEOUT_MS = 10_000;
+
 // ---------------------------------------------------------------------------
 // Provider interface
 // ---------------------------------------------------------------------------
@@ -58,6 +63,7 @@ class VoyageProvider implements EmbeddingProvider {
         input_type: inputType,
         output_dimension: this.dimensions,
       }),
+      signal: AbortSignal.timeout(EMBED_TIMEOUT_MS),
     });
 
     if (!res.ok) {
@@ -112,6 +118,7 @@ class OpenAIProvider implements EmbeddingProvider {
         Authorization: `Bearer ${this.apiKey}`,
       },
       body: JSON.stringify(body),
+      signal: AbortSignal.timeout(EMBED_TIMEOUT_MS),
     });
 
     if (!res.ok) {

--- a/packages/core/src/lat-reader.ts
+++ b/packages/core/src/lat-reader.ts
@@ -290,8 +290,8 @@ export function searchScored(input: {
   const ftsSQL = `SELECT s.id, s.project_id, s.file, s.heading, s.depth, s.content,
          s.content_hash, s.first_paragraph, s.updated_at,
          bm25(lat_sections_fts, 6.0, 2.0) as rank
-       FROM lat_sections s
-       JOIN lat_sections_fts f ON s.rowid = f.rowid
+       FROM lat_sections_fts f
+       CROSS JOIN lat_sections s ON s.rowid = f.rowid
        WHERE lat_sections_fts MATCH ?
        AND s.project_id = ?
        ORDER BY rank LIMIT ?`;
@@ -335,8 +335,8 @@ export function scoreForSession(
         `SELECT s.id, s.project_id, s.file, s.heading, s.depth, s.content,
                 s.content_hash, s.first_paragraph, s.updated_at,
                 bm25(lat_sections_fts, 6.0, 2.0) as rank
-         FROM lat_sections s
-         JOIN lat_sections_fts f ON s.rowid = f.rowid
+         FROM lat_sections_fts f
+         CROSS JOIN lat_sections s ON s.rowid = f.rowid
          WHERE lat_sections_fts MATCH ?
          AND s.project_id = ?
          ORDER BY rank`,

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -215,11 +215,11 @@ function scoreEntriesFTS(sessionContext: string): Map<string, number> {
   try {
     const results = db()
       .query(
-        `SELECT k.id, bm25(knowledge_fts, ?, ?, ?) as rank
-         FROM knowledge k
-         JOIN knowledge_fts f ON k.rowid = f.rowid
-         WHERE knowledge_fts MATCH ?
-         AND k.confidence > 0.2`,
+         `SELECT k.id, bm25(knowledge_fts, ?, ?, ?) as rank
+          FROM knowledge_fts f
+          CROSS JOIN knowledge k ON k.rowid = f.rowid
+          WHERE knowledge_fts MATCH ?
+          AND k.confidence > 0.2`,
       )
       .all(title, content, category, q) as Array<{
       id: string;
@@ -460,14 +460,14 @@ export function search(input: {
   const pid = input.projectPath ? ensureProject(input.projectPath) : null;
 
   const ftsSQL = pid
-    ? `SELECT ${KNOWLEDGE_COLS_K} FROM knowledge k
-       JOIN knowledge_fts f ON k.rowid = f.rowid
+    ? `SELECT ${KNOWLEDGE_COLS_K} FROM knowledge_fts f
+       CROSS JOIN knowledge k ON k.rowid = f.rowid
        WHERE knowledge_fts MATCH ?
        AND (k.project_id = ? OR k.project_id IS NULL OR k.cross_project = 1)
        AND k.confidence > 0.2
        ORDER BY bm25(knowledge_fts, ?, ?, ?) LIMIT ?`
-    : `SELECT ${KNOWLEDGE_COLS_K} FROM knowledge k
-       JOIN knowledge_fts f ON k.rowid = f.rowid
+    : `SELECT ${KNOWLEDGE_COLS_K} FROM knowledge_fts f
+       CROSS JOIN knowledge k ON k.rowid = f.rowid
        WHERE knowledge_fts MATCH ?
        AND k.confidence > 0.2
        ORDER BY bm25(knowledge_fts, ?, ?, ?) LIMIT ?`;
@@ -517,14 +517,14 @@ export function searchScored(input: {
   const { title, content, category } = ftsWeights();
 
   const ftsSQL = pid
-    ? `SELECT ${KNOWLEDGE_COLS_K}, bm25(knowledge_fts, ?, ?, ?) as rank FROM knowledge k
-       JOIN knowledge_fts f ON k.rowid = f.rowid
+    ? `SELECT ${KNOWLEDGE_COLS_K}, bm25(knowledge_fts, ?, ?, ?) as rank FROM knowledge_fts f
+       CROSS JOIN knowledge k ON k.rowid = f.rowid
        WHERE knowledge_fts MATCH ?
        AND (k.project_id = ? OR k.project_id IS NULL OR k.cross_project = 1)
        AND k.confidence > 0.2
        ORDER BY rank LIMIT ?`
-    : `SELECT ${KNOWLEDGE_COLS_K}, bm25(knowledge_fts, ?, ?, ?) as rank FROM knowledge k
-       JOIN knowledge_fts f ON k.rowid = f.rowid
+    : `SELECT ${KNOWLEDGE_COLS_K}, bm25(knowledge_fts, ?, ?, ?) as rank FROM knowledge_fts f
+       CROSS JOIN knowledge k ON k.rowid = f.rowid
        WHERE knowledge_fts MATCH ?
        AND k.confidence > 0.2
        ORDER BY rank LIMIT ?`;
@@ -569,8 +569,8 @@ export function searchScoredOtherProjects(input: {
   // Find entries from other projects that are NOT cross-project (those are
   // already included in the normal search via the cross_project=1 filter).
   // Also exclude entries with no project_id (global) — already included.
-  const ftsSQL = `SELECT ${KNOWLEDGE_COLS_K}, bm25(knowledge_fts, ?, ?, ?) as rank FROM knowledge k
-     JOIN knowledge_fts f ON k.rowid = f.rowid
+  const ftsSQL = `SELECT ${KNOWLEDGE_COLS_K}, bm25(knowledge_fts, ?, ?, ?) as rank FROM knowledge_fts f
+     CROSS JOIN knowledge k ON k.rowid = f.rowid
      WHERE knowledge_fts MATCH ?
      AND k.project_id IS NOT NULL
      AND k.project_id != ?
@@ -819,8 +819,8 @@ export function check(projectPath: string): IntegrityIssue[] {
       const { title, content, category } = config().search.ftsWeights;
       const matches = db()
         .query(
-          `SELECT k.id, k.title FROM knowledge k
-           JOIN knowledge_fts f ON k.rowid = f.rowid
+          `SELECT k.id, k.title FROM knowledge_fts f
+           CROSS JOIN knowledge k ON k.rowid = f.rowid
            WHERE knowledge_fts MATCH ?
            AND k.id != ?
            AND k.confidence > 0.2

--- a/packages/core/src/recall.ts
+++ b/packages/core/src/recall.ts
@@ -116,14 +116,14 @@ function searchDistillationsScored(input: {
 
   const ftsSQL = input.sessionID
     ? `SELECT d.id, d.observations, d.generation, d.created_at, d.session_id, rank
-       FROM distillations d
-       JOIN distillation_fts f ON d.rowid = f.rowid
+       FROM distillation_fts f
+       CROSS JOIN distillations d ON d.rowid = f.rowid
        WHERE distillation_fts MATCH ?
        AND d.project_id = ? AND d.session_id = ?
        ORDER BY rank LIMIT ?`
     : `SELECT d.id, d.observations, d.generation, d.created_at, d.session_id, rank
-       FROM distillations d
-       JOIN distillation_fts f ON d.rowid = f.rowid
+       FROM distillation_fts f
+       CROSS JOIN distillations d ON d.rowid = f.rowid
        WHERE distillation_fts MATCH ?
        AND d.project_id = ?
        ORDER BY rank LIMIT ?`;

--- a/packages/core/src/temporal.ts
+++ b/packages/core/src/temporal.ts
@@ -198,12 +198,12 @@ export function search(input: {
   if (q === EMPTY_QUERY) return [];
 
   const ftsSQL = input.sessionID
-    ? `SELECT m.* FROM temporal_messages m
-       JOIN temporal_fts f ON m.rowid = f.rowid
+    ? `SELECT m.* FROM temporal_fts f
+       CROSS JOIN temporal_messages m ON m.rowid = f.rowid
        WHERE f.content MATCH ? AND m.project_id = ? AND m.session_id = ?
        ORDER BY rank LIMIT ?`
-    : `SELECT m.* FROM temporal_messages m
-       JOIN temporal_fts f ON m.rowid = f.rowid
+    : `SELECT m.* FROM temporal_fts f
+       CROSS JOIN temporal_messages m ON m.rowid = f.rowid
        WHERE f.content MATCH ? AND m.project_id = ?
        ORDER BY rank LIMIT ?`;
   const params = input.sessionID
@@ -253,12 +253,12 @@ export function searchScored(input: {
   if (q === EMPTY_QUERY) return [];
 
   const ftsSQL = input.sessionID
-    ? `SELECT m.*, rank FROM temporal_messages m
-       JOIN temporal_fts f ON m.rowid = f.rowid
+    ? `SELECT m.*, rank FROM temporal_fts f
+       CROSS JOIN temporal_messages m ON m.rowid = f.rowid
        WHERE f.content MATCH ? AND m.project_id = ? AND m.session_id = ?
        ORDER BY rank LIMIT ?`
-    : `SELECT m.*, rank FROM temporal_messages m
-       JOIN temporal_fts f ON m.rowid = f.rowid
+    : `SELECT m.*, rank FROM temporal_fts f
+       CROSS JOIN temporal_messages m ON m.rowid = f.rowid
        WHERE f.content MATCH ? AND m.project_id = ?
        ORDER BY rank LIMIT ?`;
   const params = input.sessionID


### PR DESCRIPTION
## Summary

- **Root cause**: SQLite's query planner chooses the wrong join order for FTS5 + content table JOINs when the content table has a matching index (e.g. `project_id`). Instead of letting FTS5 find matches (~60ms), it scans all project rows (~16K) and probes FTS5 for each — O(N × FTS5) nested loop taking **>2 minutes** on a real 318MB database
- **Fix**: `CROSS JOIN` forces FTS5 as the driving table. Same query drops from **>120s to 66ms**. Converted all 15 affected sites across `temporal.ts`, `recall.ts`, `ltm.ts`, and `lat-reader.ts`
- **Hardening**: Added `AbortSignal.timeout(10s)` to embedding `fetch()` calls (no timeout previously), and `PRAGMA busy_timeout=5000` to SQLite init (was 0ms default)

## Benchmarks (real 318MB production database, 81K temporal_messages)

```
-- Before (JOIN): >120,000ms (timed out after 2 minutes)
SELECT m.*, rank FROM temporal_messages m
  JOIN temporal_fts f ON m.rowid = f.rowid
  WHERE f.content MATCH 'state* OR handle* OR error*' AND m.project_id = ?
  ORDER BY rank LIMIT 10

-- After (CROSS JOIN): 66ms
SELECT m.*, rank FROM temporal_fts f
  CROSS JOIN temporal_messages m ON m.rowid = f.rowid
  WHERE f.content MATCH 'state* OR handle* OR error*' AND m.project_id = ?
  ORDER BY rank LIMIT 10
```

All 550 tests pass.