### PR TITLE
fix(db): prevent singleton poisoning when migrate() throws

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -359,17 +359,23 @@ export function db(): Database {
   // exist, so no special option is needed. (bun:sqlite's `{ create: true }`
   // exists only to opt INTO creation when you want readonly=false — which is
   // already the default for our case.)
-  instance = new Database(path);
-  instance.exec("PRAGMA journal_mode = WAL");
-  instance.exec("PRAGMA foreign_keys = ON");
+  //
+  // IMPORTANT: Do NOT assign to `instance` until migrate() succeeds. If
+  // migrate() throws (SQLITE_BUSY, partial prior run, disk error), the
+  // module-level singleton must remain undefined so the next db() call
+  // retries initialization instead of returning an un-migrated handle.
+  const database = new Database(path);
+  database.exec("PRAGMA journal_mode = WAL");
+  database.exec("PRAGMA foreign_keys = ON");
   // Retry for up to 5s when another connection holds the write lock (e.g.
   // backgroundDistill's BEGIN IMMEDIATE overlapping with a recall query).
   // Default is 0ms which throws SQLITE_BUSY immediately.
-  instance.exec("PRAGMA busy_timeout = 5000");
+  database.exec("PRAGMA busy_timeout = 5000");
   // Return freed pages to the OS incrementally on each transaction commit
   // instead of accumulating a free-page list that bloats the file.
-  instance.exec("PRAGMA auto_vacuum = INCREMENTAL");
-  migrate(instance);
+  database.exec("PRAGMA auto_vacuum = INCREMENTAL");
+  migrate(database);
+  instance = database;
   return instance;
 }
 

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { db, ensureProject, projectId, loadForceMinLayer, saveForceMinLayer } from "../src/db";
+import { db, close, ensureProject, projectId, loadForceMinLayer, saveForceMinLayer } from "../src/db";
 
 
 describe("db", () => {
@@ -102,5 +102,32 @@ describe("db", () => {
 
   test("loadForceMinLayer returns 0 for unknown session", () => {
     expect(loadForceMinLayer("nonexistent-session")).toBe(0);
+  });
+
+  test("kv_meta table exists (migration v8)", () => {
+    const tables = db()
+      .query("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+      .all() as Array<{ name: string }>;
+    expect(tables.map((t) => t.name)).toContain("kv_meta");
+  });
+
+  test("db() re-initializes after close()", () => {
+    // Ensure the singleton is populated
+    const first = db();
+    expect(first).toBeDefined();
+
+    // Close resets the singleton
+    close();
+
+    // Next call should re-create and re-migrate — not return a stale handle
+    const second = db();
+    expect(second).toBeDefined();
+
+    // Verify the new instance is fully migrated (kv_meta exists)
+    const row = second
+      .query("SELECT name FROM sqlite_master WHERE type='table' AND name='kv_meta'")
+      .get() as { name: string } | null;
+    expect(row).not.toBeNull();
+    expect(row!.name).toBe("kv_meta");
   });
 });


### PR DESCRIPTION
## Summary

- Fix `db()` singleton poisoning: the module-level `instance` was assigned **before** `migrate()` ran, so if migration threw (SQLITE_BUSY from lock contention, partial prior run with duplicate ALTER TABLE, disk error), every subsequent `db()` call returned the un-migrated handle — causing "no such table: kv_meta" errors for the rest of the process lifetime.
- The fix uses a local variable and only promotes it to the cached singleton after `migrate()` succeeds, so a failed init is retried on the next call.
- Added tests for `kv_meta` table existence and `db()` re-initialization after `close()`.

All 552 existing tests pass.