### PR TITLE
perf(gradient): batch distillation consumption at turn boundaries

### DIFF
--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -72,6 +72,13 @@ let calibratedOverhead: number | null = null;
 // response via UNCALIBRATED_SAFETY.
 // ---------------------------------------------------------------------------
 
+type DistillationSnapshot = {
+  /** Cached distillation rows from the most recent DB read */
+  rows: Distillation[];
+  /** ID of the last user message when this snapshot was taken */
+  lastUserMsgId: string | null;
+};
+
 type SessionState = {
   /** Exact input token count from the last successful API response */
   lastKnownInput: number;
@@ -116,6 +123,19 @@ type SessionState = {
   consecutiveHighLayer: number;
   /** Hash of the first message IDs in the last transform output — for cache-bust diagnostics. */
   lastPrefixHash: string;
+  /**
+   * Distillation row snapshot — cached to avoid hitting the DB on every
+   * transform() call. Refreshed only at turn boundaries (when a new user
+   * message appears) or on first call / idle resume. During autonomous
+   * tool-call chains this stays frozen, keeping the distilled prefix
+   * byte-identical across consecutive API calls and preserving the prompt
+   * cache.
+   *
+   * Cost context: each prefix refresh costs context_size × cache_write_price
+   * (~$1.88 per bust at 500K Sonnet). New distillations have near-zero
+   * marginal value mid-chain since the model already has raw messages.
+   */
+  distillationSnapshot: DistillationSnapshot | null;
 };
 
 function makeSessionState(): SessionState {
@@ -134,6 +154,7 @@ function makeSessionState(): SessionState {
     cameOutOfIdle: false,
     consecutiveHighLayer: 0,
     lastPrefixHash: "",
+    distillationSnapshot: null,
   };
 }
 
@@ -196,6 +217,7 @@ export function onIdleResume(
   if (idleMs < thresholdMs) return { triggered: false };
   state.prefixCache = null;
   state.rawWindowCache = null;
+  state.distillationSnapshot = null;
   state.cameOutOfIdle = true;
   return { triggered: true, idleMs };
 }
@@ -379,6 +401,7 @@ export function inspectSessionState(sessionID: string): {
   hasRawWindowCache: boolean;
   cameOutOfIdle: boolean;
   lastTurnAt: number;
+  distillationSnapshot: DistillationSnapshot | null;
 } | null {
   const state = sessionStates.get(sessionID);
   if (!state) return null;
@@ -387,6 +410,7 @@ export function inspectSessionState(sessionID: string): {
     hasRawWindowCache: state.rawWindowCache !== null,
     cameOutOfIdle: state.cameOutOfIdle,
     lastTurnAt: state.lastTurnAt,
+    distillationSnapshot: state.distillationSnapshot,
   };
 }
 
@@ -423,6 +447,46 @@ function loadDistillations(
   return db()
     .query(query)
     .all(...params) as Distillation[];
+}
+
+// Cached distillation loader — avoids hitting the DB on every transform() call.
+// Refreshed only at turn boundaries (when a new user message appears), on first
+// call (null snapshot), or after idle resume (snapshot cleared by onIdleResume).
+// During autonomous tool-call chains (consecutive assistant→tool→assistant with
+// the same last user message), returns the cached rows so the distilled prefix
+// stays byte-identical and preserves the Anthropic prompt cache.
+function loadDistillationsCached(
+  projectPath: string,
+  sessionID: string,
+  messages: MessageWithParts[],
+  sessState: SessionState,
+): Distillation[] {
+  // Find the last user message ID in the input
+  let lastUserMsgId: string | null = null;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].info.role === "user") {
+      lastUserMsgId = messages[i].info.id;
+      break;
+    }
+  }
+
+  const snapshot = sessState.distillationSnapshot;
+
+  // Cache hit: same user message = still in the same tool-call chain
+  if (snapshot && snapshot.lastUserMsgId === lastUserMsgId) {
+    return snapshot.rows;
+  }
+
+  // Cache miss: new user message (turn boundary), first call, or post-idle
+  const rows = loadDistillations(projectPath, sessionID);
+  sessState.distillationSnapshot = { rows, lastUserMsgId };
+
+  log.info(
+    `distillation refresh: ${rows.length} rows` +
+      ` (user msg ${lastUserMsgId?.substring(0, 16) ?? "none"})`,
+  );
+
+  return rows;
 }
 
 // Strip all <system-reminder>...</system-reminder> blocks from message text.
@@ -1147,6 +1211,16 @@ export function resetPrefixCache(sessionID?: string) {
   }
 }
 
+// For testing only — reset distillation snapshot for a specific session (or all)
+export function resetDistillationSnapshot(sessionID?: string) {
+  if (sessionID) {
+    const state = sessionStates.get(sessionID);
+    if (state) state.distillationSnapshot = null;
+  } else {
+    for (const state of sessionStates.values()) state.distillationSnapshot = null;
+  }
+}
+
 // --- Approach B: Lazy raw window eviction ---
 //
 // Tracks the ID of the first (oldest) message in the previous raw window.
@@ -1417,7 +1491,9 @@ function transformInner(input: {
   const dedupMessages = deduplicateToolOutputs(input.messages, turnStart);
 
 
-  const distillations = sid ? loadDistillations(input.projectPath, sid) : [];
+  const distillations = sid
+    ? loadDistillationsCached(input.projectPath, sid, input.messages, sessState)
+    : [];
 
   // Layer 1 uses the append-only cached prefix (Approach C) to keep the
   // distilled content byte-identical between distillation runs, preserving

--- a/packages/core/test/gradient.test.ts
+++ b/packages/core/test/gradient.test.ts
@@ -10,6 +10,7 @@ import {
   getLtmBudget,
   resetPrefixCache,
   resetRawWindowCache,
+  resetDistillationSnapshot,
   setForceMinLayer,
   getLastLayer,
   estimateMessages,
@@ -2009,5 +2010,174 @@ describe("reasoning preservation (F-REASONING-AUDIT mini-pin)", () => {
     expect(reasoningPart!.text).toBe(
       "I should consider the trade-offs carefully here.",
     );
+  });
+});
+
+describe("gradient — distillation snapshot caching", () => {
+  const SID = "distill-snapshot-sess";
+  const PID_KEY = "distill-snapshot-project";
+  let projectId: string;
+
+  function insertDistillation(opts: {
+    sessionID: string;
+    observations: string;
+    archived?: number;
+  }): string {
+    const id = crypto.randomUUID();
+    db()
+      .query(
+        `INSERT INTO distillations (id, project_id, session_id, narrative, facts, observations, source_ids, generation, token_count, archived, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        id,
+        projectId,
+        opts.sessionID,
+        "",
+        "[]",
+        opts.observations,
+        "[]",
+        0,
+        Math.ceil(opts.observations.length / 3),
+        opts.archived ?? 0,
+        Date.now(),
+      );
+    return id;
+  }
+
+  beforeAll(() => {
+    projectId = ensureProject(`/test/${PID_KEY}`);
+    // Small context to force gradient mode (layer 1+)
+    setModelLimits({ context: 5_000, output: 1_000 });
+    calibrate(0);
+  });
+
+  beforeEach(() => {
+    resetCalibration(SID);
+    resetPrefixCache(SID);
+    resetRawWindowCache(SID);
+    resetDistillationSnapshot(SID);
+    db().query("DELETE FROM distillations WHERE project_id = ?").run(projectId);
+  });
+
+  afterAll(() => {
+    setModelLimits({ context: 10_000, output: 2_000 });
+    calibrate(0);
+    db().query("DELETE FROM distillations WHERE project_id = ?").run(projectId);
+  });
+
+  test("consecutive transforms with same user message reuse cached distillation rows", () => {
+    // Insert a distillation row so the prefix has content
+    insertDistillation({
+      sessionID: SID,
+      observations: "- Initial observation about the task\n- Second observation",
+    });
+
+    // Build a conversation big enough to trigger gradient mode (layer 1+)
+    const messages = Array.from({ length: 16 }, (_, i) =>
+      makeMsg(`snap-${i}`, i % 2 === 0 ? "user" : "assistant", "X".repeat(1_000), SID),
+    );
+
+    const projectPath = `/test/${PID_KEY}`;
+    const result1 = transform({ messages, projectPath, sessionID: SID });
+    expect(result1.layer).toBeGreaterThanOrEqual(1);
+
+    // Insert a NEW distillation row between calls — simulates background distill arriving mid-chain
+    insertDistillation({
+      sessionID: SID,
+      observations: "- New observation that should NOT be consumed mid-chain",
+    });
+
+    // Same messages (same last user message) — should get cached snapshot
+    const result2 = transform({ messages, projectPath, sessionID: SID });
+    expect(result2.layer).toBeGreaterThanOrEqual(1);
+
+    // The distilled prefix should be identical (snapshot frozen)
+    // Find prefix messages (those without session ID = distilled)
+    const prefix1 = result1.messages.filter((m) => !m.info.sessionID || m.info.sessionID !== SID);
+    const prefix2 = result2.messages.filter((m) => !m.info.sessionID || m.info.sessionID !== SID);
+
+    // Prefix text should be byte-identical — the new row was NOT consumed
+    const text1 = prefix1.map((m) => m.parts.map((p) => ("text" in p ? p.text : "")).join()).join();
+    const text2 = prefix2.map((m) => m.parts.map((p) => ("text" in p ? p.text : "")).join()).join();
+    expect(text2).toBe(text1);
+    expect(text1).not.toContain("should NOT be consumed");
+  });
+
+  test("new user message triggers distillation refresh", () => {
+    insertDistillation({
+      sessionID: SID,
+      observations: "- First observation",
+    });
+
+    const projectPath = `/test/${PID_KEY}`;
+
+    // First call with user msg u-0
+    const messages1 = Array.from({ length: 16 }, (_, i) =>
+      makeMsg(`ref-${i}`, i % 2 === 0 ? "user" : "assistant", "X".repeat(1_000), SID),
+    );
+    const result1 = transform({ messages: messages1, projectPath, sessionID: SID });
+    expect(result1.layer).toBeGreaterThanOrEqual(1);
+
+    // Insert a new distillation row
+    insertDistillation({
+      sessionID: SID,
+      observations: "- Second observation after turn boundary",
+    });
+
+    // Append a NEW user message — this is a turn boundary, should refresh
+    const messages2 = [
+      ...messages1,
+      makeMsg("ref-new-user", "user", "New question from the user", SID),
+    ];
+    const result2 = transform({ messages: messages2, projectPath, sessionID: SID });
+    expect(result2.layer).toBeGreaterThanOrEqual(1);
+
+    // The prefix should now contain the new distillation
+    const allText = result2.messages
+      .map((m) => m.parts.map((p) => ("text" in p ? p.text : "")).join())
+      .join();
+    expect(allText).toContain("Second observation");
+  });
+
+  test("onIdleResume clears distillation snapshot", () => {
+    insertDistillation({
+      sessionID: SID,
+      observations: "- Pre-idle observation",
+    });
+
+    const projectPath = `/test/${PID_KEY}`;
+
+    // Build up state with a transform
+    const messages = Array.from({ length: 16 }, (_, i) =>
+      makeMsg(`idle-${i}`, i % 2 === 0 ? "user" : "assistant", "X".repeat(1_000), SID),
+    );
+    transform({ messages, projectPath, sessionID: SID });
+
+    // Verify snapshot exists via inspectSessionState
+    const state1 = inspectSessionState(SID);
+    expect(state1?.distillationSnapshot).not.toBeNull();
+
+    // Insert new distillation
+    insertDistillation({
+      sessionID: SID,
+      observations: "- Post-idle observation that should appear after resume",
+    });
+
+    // Simulate idle resume — sets lastTurnAt first so onIdleResume triggers
+    setLastTurnAtForTest(SID, Date.now() - 600_000); // 10 minutes ago
+    const idle = onIdleResume(SID, 60_000);
+    expect(idle.triggered).toBe(true);
+
+    // Verify snapshot was cleared
+    const state2 = inspectSessionState(SID);
+    expect(state2?.distillationSnapshot).toBeNull();
+
+    // Next transform should pick up the new distillation (same user messages — but snapshot was cleared)
+    const result = transform({ messages, projectPath, sessionID: SID });
+    const allText = result.messages
+      .map((m) => m.parts.map((p) => ("text" in p ? p.text : "")).join())
+      .join();
+    expect(allText).toContain("Post-idle observation");
   });
 });

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -707,8 +707,22 @@ export const LorePlugin: Plugin = async (ctx) => {
             activeSessions.add(msg.sessionID);
             if (msg.role === "user") turnsSinceCuration++;
 
-            // Incremental distillation: when undistilled messages accumulate past
-            // maxSegment, distill immediately instead of waiting for session.idle.
+            // Incremental distillation: only fire at turn boundaries (user message)
+            // to avoid producing distillation rows mid-chain that would change the
+            // distilled prefix and bust the prompt cache. The gradient's distillation
+            // snapshot is frozen during tool-call chains, so rows produced mid-chain
+            // can't be consumed until the next turn anyway — deferring to session.idle
+            // or next user message costs nothing but avoids DB churn and cache busts.
+            if (msg.role === "user") {
+              const pending = temporal.undistilledCount(projectPath, msg.sessionID);
+              if (pending >= config().distillation.maxSegment) {
+                log.info(
+                  `incremental distillation (turn boundary): ${pending} undistilled messages in ${msg.sessionID.substring(0, 16)}`,
+                );
+                backgroundDistill(msg.sessionID);
+              }
+            }
+
             if (
               msg.role === "assistant" &&
               msg.tokens &&
@@ -719,14 +733,6 @@ export const LorePlugin: Plugin = async (ctx) => {
               // to think only 3 tokens went in and passing the full session as layer 0.
               (msg.tokens.input > 0 || msg.tokens.cache.read > 0 || msg.tokens.cache.write > 0)
             ) {
-              const pending = temporal.undistilledCount(projectPath, msg.sessionID);
-              if (pending >= config().distillation.maxSegment) {
-                log.info(
-                  `incremental distillation: ${pending} undistilled messages in ${msg.sessionID.substring(0, 16)}`,
-                );
-                backgroundDistill(msg.sessionID);
-              }
-
               // Calibrate overhead using real token counts from the API response.
               // actualInput = all tokens the model processed (input + cache.read + cache.write).
               // The message estimate comes from the transform's own output (stored in


### PR DESCRIPTION
## Summary

- **Consumption side**: Cache loaded distillation rows per-session in `DistillationSnapshot`, refresh only when a new user message appears (turn boundary) or on idle resume. During autonomous tool-call chains, the snapshot stays frozen — keeping the distilled prefix byte-identical across consecutive API calls and preserving Anthropic's prompt cache.
- **Production side**: Gate `backgroundDistill()` on user messages instead of every assistant message in `message.updated`, deferring mid-chain distillation to `session.idle`. This reduces DB churn from distillation rows arriving mid-chain.

## Problem

Each new distillation row arriving between consecutive API calls changes the distilled prefix bytes. Anthropic invalidates the prompt cache from that point, rewriting 400–700K tokens (~$1.88/bust at 500K Sonnet context). In a 1,345-call session today, 189 distillation arrivals caused 314 cache busts costing $639 in cache writes alone.

## Expected Impact

- 1,345-call session: 314 busts → ~8 busts (one per user message)
- **~97% reduction** in cache write cost from distillation-related invalidation
- Autonomous tool-call chains become fully cache-stable