### PR TITLE
fix(db): use os.homedir() for cross-platform data directory resolution

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1,6 +1,7 @@
 import { Database } from "#db/driver";
 import { join, dirname } from "path";
 import { mkdirSync } from "fs";
+import { homedir } from "os";
 
 const SCHEMA_VERSION = 12;
 
@@ -353,7 +354,7 @@ const MIGRATIONS: string[] = [
 
 function dataDir() {
   const xdg = process.env.XDG_DATA_HOME;
-  const base = xdg || join(process.env.HOME || "~", ".local", "share");
+  const base = xdg || join(homedir(), ".local", "share");
   return join(base, "opencode-lore");
 }
 


### PR DESCRIPTION
## Summary

Fixes #121

- Replace `process.env.HOME || "~"` with `os.homedir()` in `dataDir()` to correctly resolve the home directory on Windows, where `HOME` is not set (Windows uses `USERPROFILE`)
- Without this fix, the database is created at `C:\Users\<user>\~\.local\share\opencode-lore` instead of `C:\Users\<user>\.local\share\opencode-lore`

## Details

Node's `path.join()` does not perform shell tilde expansion, so passing the literal string `"~"` as a fallback produces a broken path. `os.homedir()` is the correct cross-platform API — it checks `USERPROFILE` on Windows and `HOME` on Unix.

The `input.summaries.length` error reported in the issue could not be reproduced or traced to a specific init-time code path. It may be a secondary effect of the wrong DB path or a Bun-on-Windows module resolution issue. If it persists after this fix, a stack trace would be needed.