### PR TITLE
fix: reduce cache-bust cost with idle threshold, sticky layers, bust tracking, and meta-distill gating

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -50,11 +50,15 @@ export const LoreConfig = z.object({
    * Anthropic's April 23 postmortem identified dropping reasoning blocks as
    * the root cause of forgetfulness/repetition.
    *
-   * `idleResumeMinutes` is the threshold in minutes. Default 60 — matches
-   * Anthropic's extended-cache eviction window, conservative across providers.
+   * `idleResumeMinutes` is the threshold in minutes. Default 5 — matches
+   * Anthropic's default-tier prompt cache TTL. After 5 min of inactivity the
+   * upstream cache is cold, so preserving byte-identity wastes cache-write cost
+   * for no benefit. Refreshing the caches on resume produces a better-fitting
+   * window at the same cold-write price. Users on Anthropic's extended-cache
+   * tier (1 h TTL) should set this to 60 in `.lore.json`.
    * Set to 0 to disable the feature.
    */
-  idleResumeMinutes: z.number().min(0).max(24 * 60).default(60),
+  idleResumeMinutes: z.number().min(0).max(24 * 60).default(5),
   distillation: z
     .object({
       minMessages: z.number().min(3).default(5),

--- a/packages/core/src/distillation.ts
+++ b/packages/core/src/distillation.ts
@@ -526,6 +526,12 @@ export async function run(input: {
   model?: { providerID: string; modelID: string };
   /** Skip minMessages threshold check — distill whatever is pending */
   force?: boolean;
+  /** Skip meta-distillation even when gen-0 count exceeds the threshold.
+   *  Used when the upstream prompt cache is likely still warm — meta-distillation
+   *  rewrites distillation row IDs, which invalidates the distilled prefix cache
+   *  and causes a cache bust on the next turn. Callers should set this to true
+   *  when `Date.now() - getLastTurnAt(sessionID) < cacheTTL`. */
+  skipMeta?: boolean;
 }): Promise<{ rounds: number; distilled: number }> {
   // Reset orphaned messages (marked distilled by a deleted/migrated distillation)
   const orphans = resetOrphans(input.projectPath, input.sessionID);
@@ -567,8 +573,11 @@ export async function run(input: {
       }
     }
 
-    // Check if meta-distillation is needed
+    // Check if meta-distillation is needed (skip when cache is warm to avoid
+    // prefix cache invalidation — row IDs change after meta-distill, busting
+    // the prompt cache on the next turn).
     if (
+      !input.skipMeta &&
       gen0Count(input.projectPath, input.sessionID) >=
       cfg.distillation.metaThreshold
     ) {

--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -123,6 +123,10 @@ type SessionState = {
   consecutiveHighLayer: number;
   /** Hash of the first message IDs in the last transform output — for cache-bust diagnostics. */
   lastPrefixHash: string;
+  /** Cumulative cache-bust count for this session (prefix hash changed between turns). */
+  bustCount: number;
+  /** Total transform() calls for this session — used with bustCount for rate calculation. */
+  transformCount: number;
   /**
    * Distillation row snapshot — cached to avoid hitting the DB on every
    * transform() call. Refreshed only at turn boundaries (when a new user
@@ -154,6 +158,8 @@ function makeSessionState(): SessionState {
     cameOutOfIdle: false,
     consecutiveHighLayer: 0,
     lastPrefixHash: "",
+    bustCount: 0,
+    transformCount: 0,
     distillationSnapshot: null,
   };
 }
@@ -220,6 +226,16 @@ export function onIdleResume(
   state.distillationSnapshot = null;
   state.cameOutOfIdle = true;
   return { triggered: true, idleMs };
+}
+
+/**
+ * Return the wall-clock timestamp (epoch ms) of the most recent transform()
+ * call for this session. Returns 0 if the session has never been transformed.
+ * Used by callers (e.g. meta-distillation gating) to check whether the
+ * upstream prompt cache is likely still warm.
+ */
+export function getLastTurnAt(sessionID: string): number {
+  return sessionStates.get(sessionID)?.lastTurnAt ?? 0;
 }
 
 /**
@@ -1277,17 +1293,19 @@ function transformInner(input: {
   }
 
   // --- Sticky layer guard (Option C) ---
-  // After a compressed turn (layer >= 1), don't allow layer 0 re-entry until
+  // After a compressed turn (layer >= N), don't allow re-entry below N until
   // the session genuinely shrinks (e.g. after compaction deletes messages).
-  // Prevents the calibration oscillation: a compressed turn stores
-  // lastKnownInput=100K for a 50-message window, but the next turn's
-  // input.messages has 300 raw messages. The delta estimation treats the 250
-  // evicted messages as "new" and undercounts their tokens, producing an
-  // expectedInput that fits in layer 0 — but the actual tokens are ~190K.
+  // Prevents calibration oscillation AND layer-transition cache busts:
+  //   - 0→1→0: compressed turn stores lastKnownInput=100K for a 50-message
+  //     window, next turn's 300 raw messages produce an undercounted
+  //     expectedInput that "fits" in layer 0 but actually overflows.
+  //   - 1→2→1: layer 2 strips tool outputs (different bytes), bouncing back
+  //     to layer 1 restores them (different bytes again) → two busts.
+  // Pinning to the *actual* last layer prevents all downward oscillation.
   // Only applied when calibrated (same session, per-session state) to avoid
   // affecting other sessions including worker sessions.
   if (calibrated && sessState.lastLayer >= 1 && input.messages.length >= sessState.lastKnownMessageCount) {
-    effectiveMinLayer = Math.max(effectiveMinLayer, 1) as SafetyLayer;
+    effectiveMinLayer = Math.max(effectiveMinLayer, sessState.lastLayer) as SafetyLayer;
   }
 
   let expectedInput: number;
@@ -1536,19 +1554,29 @@ export function transform(input: {
     // result fields above so a thrown transformInner doesn't update it.
     state.lastTurnAt = Date.now();
 
-    // --- Cache-bust diagnostics (LORE_DEBUG only) ---
+    // --- Cache-bust diagnostics ---
     // Track byte-identity of the message prefix. When the prefix hash changes
     // between consecutive turns, it means Anthropic's prompt cache is invalidated
     // and the entire context is re-written (12.5× cache-read price). This helps
     // identify which code paths are breaking byte-identity.
     const prefixIds = result.messages.slice(0, 5).map((m) => m.info.id).join(",");
     const prefixHash = `${result.layer}:${prefixIds}`;
+    state.transformCount++;
     if (state.lastPrefixHash && state.lastPrefixHash !== prefixHash) {
+      state.bustCount++;
+      const rate = state.bustCount / state.transformCount;
       log.info(
-        `cache-bust detected: session=${sid} layer=${state.lastLayer}→${result.layer}` +
+        `cache-bust #${state.bustCount} (${(rate * 100).toFixed(0)}%): session=${sid}` +
+        ` layer=${state.lastLayer}→${result.layer}` +
         ` msgs=${state.lastTransformedCount}→${result.messages.length}` +
         ` prefix=${state.lastPrefixHash.slice(0, 30)}→${prefixHash.slice(0, 30)}`,
       );
+      if (state.transformCount >= 20 && rate > 0.5) {
+        log.warn(
+          `HIGH BUST RATE: session ${sid} has ${(rate * 100).toFixed(0)}% bust rate` +
+          ` (${state.bustCount}/${state.transformCount} transforms)`,
+        );
+      }
     }
     state.lastPrefixHash = prefixHash;
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -72,6 +72,7 @@ export {
   getLastTransformEstimate,
   toolStripAnnotation,
   onIdleResume,
+  getLastTurnAt,
   consumeCameOutOfIdle,
   // Test-only — exposed at the barrel so host-package tests can simulate idle
   // gaps without sleeping. Not part of the public API.

--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -16,6 +16,7 @@ import {
   latReader,
   log,
   config as loreConfig,
+  getLastTurnAt,
   exportToFile,
   exportLoreFile,
 } from "@loreai/core";
@@ -115,7 +116,11 @@ export function buildIdleWorkHandler(
     try {
       const pending = temporal.undistilledCount(projectPath, sessionID);
       if (pending >= cfg.distillation.minMessages) {
-        await distillation.run({ llm, projectPath, sessionID });
+        // Skip meta-distillation when the prompt cache is likely still warm.
+        const cacheTTLMs = cfg.idleResumeMinutes * 60_000;
+        const lastTurn = getLastTurnAt(sessionID);
+        const cacheWarm = lastTurn > 0 && (Date.now() - lastTurn) < cacheTTLMs;
+        await distillation.run({ llm, projectPath, sessionID, skipMeta: cacheWarm });
       }
     } catch (e) {
       log.error("idle distillation error:", e);

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -22,6 +22,7 @@ import {
   getLastTransformedCount,
   getLastTransformEstimate,
   onIdleResume,
+  getLastTurnAt,
   consumeCameOutOfIdle,
   formatKnowledge,
   formatDistillations,
@@ -750,12 +751,19 @@ export const LorePlugin: Plugin = async (ctx) => {
         pending >= cfg.distillation.minMessages ||
         needsUrgentDistillation()
       ) {
+        // Skip meta-distillation when the prompt cache is likely still warm.
+        // Meta-distill rewrites row IDs → invalidates distilled prefix cache →
+        // cache bust on the next turn. Defer until the cache is cold anyway.
+        const cacheTTLMs = cfg.idleResumeMinutes * 60_000;
+        const lastTurn = getLastTurnAt(sessionID);
+        const cacheWarm = lastTurn > 0 && (Date.now() - lastTurn) < cacheTTLMs;
         await distillation.run({
           llm: createOpenCodeLLMClient(ctx.client, sessionID),
           projectPath,
           sessionID,
           model: getWorkerModel(),
           force,
+          skipMeta: cacheWarm && !force,
         });
       }
     } catch (e) {

--- a/packages/opencode/test/index.test.ts
+++ b/packages/opencode/test/index.test.ts
@@ -1548,8 +1548,8 @@ describe("idle-resume hook integration", () => {
       const ltmBlock1 = first.find((s) => s.includes("Long-term Knowledge"));
       expect(ltmBlock1).toBeTruthy();
 
-      // Simulate a 5-minute gap — well under 60min threshold.
-      setLastTurnAtForTest(sessionID, Date.now() - 5 * 60_000);
+      // Simulate a 3-minute gap — well under 5min default threshold.
+      setLastTurnAtForTest(sessionID, Date.now() - 3 * 60_000);
 
       // Add a new entry. If the cache was cleared, this would appear; if
       // the cache survived, it would not.


### PR DESCRIPTION
## Summary

Four targeted fixes to reduce prompt cache-bust frequency and cost, building on top of the distillation consumption freeze (PR #123):

- **`idleResumeMinutes` 60→5**: Match Anthropic's default-tier 5m cache TTL. After 5m idle, the cache is cold — preserving byte-identity just pays write cost for no benefit. Extended-tier users can set 60 in `.lore.json`.
- **Generalized sticky-layer guard**: Pin at `sessState.lastLayer` instead of hardcoded `1`. Prevents 2→1→2 and 3→2→3 oscillation that causes repeated structural cache busts.
- **Bust-rate tracking**: `bustCount`/`transformCount` in SessionState with `log.warn()` when rate >50% after 20+ transforms. Runtime visibility into cache stability.
- **Meta-distillation gating on cache warmth**: `skipMeta` option on `distillation.run()`. When the prompt cache is likely warm (`timeSinceLastTurn < cacheTTL`), defer meta-distillation to avoid row ID rewrites that bust the prefix cache. Forced calls (compaction, overflow) always allow it.

## Cost impact

| Scenario | Before | After |
|----------|--------|-------|
| 10-min pause on default tier | Cache write at 1.25× (stale preservation) | Cache refresh with better content (same write cost) |
| Layer 2→1→2 oscillation | 2 busts per cycle (~$3.76 Sonnet) | 0 busts (pinned at layer 2) |
| Meta-distill during idle, user returns <5m | Prefix re-render → bust (~$1.88) | Deferred — bust-free |

## Files changed

- `packages/core/src/config.ts` — idle threshold default
- `packages/core/src/gradient.ts` — sticky guard, bust tracking, `getLastTurnAt()`
- `packages/core/src/distillation.ts` — `skipMeta` option
- `packages/core/src/index.ts` — barrel export
- `packages/gateway/src/idle.ts` — cache-warm gating
- `packages/opencode/src/index.ts` — cache-warm gating
- `packages/opencode/test/index.test.ts` — adjust test for new 5m default

744 tests pass, 0 failures.