### PR TITLE
feat: local embeddings, exact keyword boost, and pattern extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 dist-tarballs/
+local_cache/
 *.tgz
 *.db
 *.db-journal

--- a/.lore.md
+++ b/.lore.md
@@ -4,10 +4,44 @@
 
 ### Architecture
 
+<!-- lore:019e0238-28bb-72e4-8551-f308662d86c0 -->
+* **Embedding backfill unified at startup across all hosts**: P0 fix: moved embedding backfill from OpenCode-only (\`packages/opencode/src/index.ts:1480-1487\`) to a unified \`runStartupBackfill()\` in core. Both OpenCode and Pi now call this function at init, ensuring all adapters embed knowledge + distillations equally. Logs coverage stats to stderr (always visible, not gated on debug mode), making embedding failures immediately surfaced. Before: Pi had 0% distillation embedding coverage (~1,333 rows); after: both adapters trigger backfill identically.
+
 <!-- lore:019e0222-5198-7a02-bdda-f44d4b7b3f3b -->
-* **Embedding provider migration strategy with checkConfigChange**: Embedding config changes (provider swap, model/dimensions) are detected via fingerprint (\`provider:model:dimensions\`) stored in \`kv\_meta\` table. When \`checkConfigChange()\` runs at startup, it compares current config to stored fingerprint. On mismatch, all stale embeddings are cleared and re-generated. This allows seamless provider migrations: users can switch from Voyage to local embeddings without manual intervention — embeddings auto-rebuild with new provider. Default is now local (offline), but users can opt back to Voyage via \`.lore.json\` config.
+* **Embedding provider migration strategy with checkConfigChange**: Embedding provider migration strategy with checkConfigChange: Config changes (provider swap, model/dimensions) detected via fingerprint (\`provider:model:dimensions\`) in \`kv\_meta\` table. On startup, \`checkConfigChange()\` compares current config to stored fingerprint; on mismatch, stale embeddings clear and regenerate. Enables seamless migrations without manual intervention. Default is now local (fastembed, offline, 384 dims) via \`@xenova/transformers\`. Users can opt back to Voyage via \`.lore.json\` config. Local embeddings require no API keys; Voyage (1024 dims) available as premium option.
+
+<!-- lore:019e0236-1d10-7b16-abdc-a9c4505ce47a -->
+* **Gateway buffer-or-stream strategy for recall interception**: Gateway streaming responses have two paths: OpenAI protocol already buffers fully (free buffering cost), Anthropic protocol streams real-time. To inject recall tool interception universally, choose "buffer everything then decide": inject recall tool, accumulate full response, check for recall tool\_use. No recall → re-emit as synthetic SSE stream. Has recall → execute recall, build follow-up request with recall tool\_result (without recall in tools list), send upstream, forward clean response. Dissolves mixed tool\_use problem via self-contained requests. Tradeoff: buffering introduces 2-8s delay before first token on Anthropic streaming (acceptable for coding agent workflows where UX focuses on tool execution, not text streaming). Phase 2 optimization possible: selective buffering only when recall detected.
+
+### Decision
+
+<!-- lore:019e022f-7141-7356-954d-85ae6ff4e6d1 -->
+* **Embedding config fingerprint strategy enables zero-downtime provider migration**: Zero-downtime embedding provider migration via fingerprint (\`provider:model:dimensions\`) in \`kv\_meta\`. On config change, stale embeddings auto-clear + full backfill runs. Now covers both OpenCode and Pi adapters equally — \`runStartupBackfill()\` is the unified entry point. Enables seamless switching between Voyage (1024 dims) ↔ Local (384 dims) ↔ OpenAI (1536 dims). Coverage logging makes implicit silent migrations visible.
+
+<!-- lore:019e0238-28c2-7664-89f5-2cd25403f12b -->
+* **Quality-weighted RRF list for distillations using c\_norm**: P2 implementation: added a distillation quality RRF list to \`recall.ts\` that ranks candidates by \`c\_norm + (ageDays/90)\*0.1\`. Uniform segments (low c\_norm) score higher; old bursty segments lower. The list deduplicates across BM25+vector results and injects as an additional RRF list. Keeps existing relevance signals intact — quality is a mild secondary signal. Enables temporal clustering heuristic (discovered in diagnostic analysis) to modestly improve recall quality for memory segments with uneven conversation pacing.
 
 ### Gotcha
 
+<!-- lore:019e022f-7149-73dc-a105-d090a7cf1426 -->
+* **c\_norm temporal clustering signal defined but not used in recall scoring**: \`temporalCnorm()\` (temporal.ts:297–320) computes \[0,1] attention imbalance but only feeds distillation segmentation. NOT wired into recall search pipeline despite comment (line 289) mentioning "recall time-biasing" as future use case. Recency boost exists (recall.ts:368–379 re-sorts temporal results by created\_at DESC) but doesn't account for conversation time windows or clustering patterns. Opportunity: use c\_norm to weight temporal vs semantic relevance when query context is clustered vs evenly distributed.
+
+<!-- lore:019e022f-7139-7f0d-bc07-7d37fd122a18 -->
+* **Embedding backfill only runs in OpenCode adapter, not Pi**: Embedding backfill is now centralized in core \`runStartupBackfill()\` and called by both OpenCode and Pi adapters at startup. Pre-fix: Pi adapter had no backfill call, leaving all Pi-served projects with ~0% distillation embedding coverage (~1,333 rows). Fire-and-forget design hides failures — errors logged but not surfaced. Backfill depends on embedding provider availability; if no key is set, it silently no-ops. Coverage stats now logged to stderr at startup.
+
 <!-- lore:019e0222-519d-7e99-9436-5a2695ddb6c2 -->
 * **Silent Voyage-to-local migration for existing users without explicit config**: Users relying on implicit Voyage default (no \`.lore.json\`, just \`VOYAGE\_API\_KEY\` env var) will silently switch to local embeddings on upgrade. Embeddings auto-clear and re-embed, so no data loss, but they lose cloud provider quality (1024 dims → 384 dims). Risk is low for knowledge entries (negligible quality impact), but consider logging if \`VOYAGE\_API\_KEY\` is set but provider resolves to \`local\` — nudges power users they have an available option.
+
+### Pattern
+
+<!-- lore:019e022f-7145-7f2a-be4e-aada70a6d2e4 -->
+* **Diagnostic metrics r\_compression and c\_norm stored on distillations (schema v12)**: Diagnostic metrics \`r\_compression\` and \`c\_norm\` are now retroactively backfilled for pre-v12 rows via \`backfillMetrics()\`. This fills 2,863 NULL rows by loading source temporal messages and recomputing. Happens synchronously at startup. Metrics show: compression healthy (avg R≈9.9), temporal clustering mostly low (93% of segments c\_norm<0.15). New \`distillation.backfillMetrics()\` function handles edge cases gracefully (deleted sources, empty source\_ids).
+
+<!-- lore:019e0225-f018-78f2-9d1c-fe2a4c47ef9e -->
+* **Exact keyword matching boost in RRF pipeline**: RRF (Reciprocal Rank Fusion) search combines vector and keyword results. Exact keyword matches now receive a boost via \`keywordBoost\` parameter during ranking. This improves relevance for queries with specific technical terms that may not embed well (e.g., library names, acronyms). Boost is applied as a multiplier to keyword match scores before RRF combination. Controlled via search config; default boost enables better recall on technical/domain-specific knowledge.
+
+<!-- lore:019e0225-f01c-79fb-9f2b-c25a200ce6ed -->
+* **Pattern extraction at distillation time**: New \`pattern-extract\` module identifies and extracts regex-based patterns (code snippets, commands, structured data) during knowledge distillation. Extracted patterns are indexed separately, enabling targeted queries like "show me all shell commands" or "find all SQL queries". Patterns are stored as metadata and used in search ranking. Reduces noise in semantic search by providing explicit structure to unstructured conversation knowledge.
+
+<!-- lore:019e0238-28be-7892-98b8-07bdcda39d0c -->
+* **Retroactive metric backfill (P3) for pre-v12 distillations**: \`backfillMetrics()\` in \`distillation.ts\` computes missing \`r\_compression\` and \`c\_norm\` for rows with NULL metrics. Loads source temporal messages via \`source\_ids\` JSON array, computes compression ratio and temporal clustering from timestamps/tokens, UPDATEs the row. Idempotent — only touches NULL values. Gracefully skips pruned source messages. Runs synchronously at startup so P2 recall weighting has full historical data (fills 2,863 pre-v12 rows).

--- a/.lore.md
+++ b/.lore.md
@@ -4,80 +4,10 @@
 
 ### Architecture
 
-<!-- lore:019e01ba-9ef4-79c1-8bde-544c269e99c4 -->
-* **Gateway auth: per-session credential registry with two-level lookup**: The gateway stores auth credentials per session in `packages/gateway/src/auth.ts`. `AuthCredential` is a discriminated union (`api-key` | `bearer`). `resolveAuth(sessionID?)` does two-level lookup: per-session first, global fallback. `sessionID` is threaded through `LLMClient.prompt()` opts (optional field in `packages/core/src/types.ts`) so background workers (distillation, curation, query expansion) use the correct session's credential. The batch queue snapshots credentials per-item at enqueue time and groups flushes by credential. No session eviction exists — each entry is ~200 bytes, negligible. Disk persistence + long-TTL eviction is a tracked follow-up.
-
-<!-- lore:019ded9e-8a33-72a5-86b1-c364a26679fa -->
-* **@loreai/gateway package: transparent LLM proxy for Claude Code/Cursor/etc**: Gateway HTTP proxy (port 6969) accepts `/v1/messages`. Session ID via `[lore:<base62>]` marker. Fallback: SHA-256 of first message. Project path from system prompt or `X-Lore-Project` header. Plugin auto-spawns if not running; skip via `LORE_GATEWAY_MODE=0`.
-
-<!-- lore:019df901-8543-729d-adff-fff21c43fc5e -->
-* **Plugin primary path: direct hooks with optional gateway fallback**: Plugin probes gateway health at startup; if available, switches to observer-only hooks (logging `[lore:verify]` without mutation). Gateway does real work. Falls back to direct plugin if probe fails. **Worktree warning**: local builds may lack tool-part cache fix; verify sync or apply patch.
-
-### Decision
-
-<!-- lore:019e01ba-9f02-78d8-9196-1ee70cebfc08 -->
-* **No session eviction — memory is negligible, continuity is valuable**: Sessions and auth credentials are never evicted from the gateway's in-memory maps. Each `SessionState` is ~200 bytes; even 9000 entries (100/day for 90 days) is ~1.8MB. Auth credentials self-heal on the next request (re-captured from headers), so the only real cost of eviction would be losing session ID mapping (distillation continuity). Disk persistence + long-TTL eviction (30-90 days) is deferred as a separate follow-up. `deleteSessionAuth()` exists in the API for future use.
-
-<!-- lore:019dfa53-b925-70e2-8f84-cab808d8e115 -->
-* **Batch distillation consumption to reduce cache-bust frequency**: Batch distillation consumption: refresh `loadDistillations()` only at turn boundaries or idle gap >cache TTL. Freeze prefix during autonomous tool chains. When cache warm, skip meta to avoid invalidation. Reduces 189 arrivals→8 refresh points: $639→$15 cost (97% reduction).
-
-<!-- lore:019dfed5-5cc5-7b18-8ef8-89f0e85ba8ed -->
-* **Lore gateway fills context quality gap in Claude Code despite Anthropic's internal memory layers**: Lore gateway bridges Claude Code's context quality gap (77% Opus vs 93% Cursor): distillation preserves file paths/errors/line numbers via FTS5+RRF, 5-layer gradient calibrated to real token counts. 35pp accuracy boost (85% vs 50%), 7.4x cheaper per correct answer vs static compaction.
-
-<!-- lore:019dfed0-b538-7e45-b646-922b669cba2f -->
-* **PR #134 merged: batch API + post-idle compact layer**: PR #134 merged: Batch queue routes non-urgent distillation calls through Anthropic Batches API (50% cost savings, ~$1.1K/month). Post-idle compact triggers on cache TTL expiry (5min). Both in gateway; plugin auto-detects.
+<!-- lore:019e0222-5198-7a02-bdda-f44d4b7b3f3b -->
+* **Embedding provider migration strategy with checkConfigChange**: Embedding config changes (provider swap, model/dimensions) are detected via fingerprint (\`provider:model:dimensions\`) stored in \`kv\_meta\` table. When \`checkConfigChange()\` runs at startup, it compares current config to stored fingerprint. On mismatch, all stale embeddings are cleared and re-generated. This allows seamless provider migrations: users can switch from Voyage to local embeddings without manual intervention — embeddings auto-rebuild with new provider. Default is now local (offline), but users can opt back to Voyage via \`.lore.json\` config.
 
 ### Gotcha
 
-<!-- lore:019e01ba-9efe-747f-a00d-d1e538fc4eb3 -->
-* **Gateway previously dropped Authorization: Bearer tokens silently**: Before the auth isolation work, `pipeline.ts` and `translate/anthropic.ts` only extracted `x-api-key` headers. `Authorization: Bearer` tokens (used by Claude Code Max/Pro/Team OAuth users) were silently ignored, causing 401s from upstream. Both `extractAuth()` in `auth.ts` and the translate layers now handle both schemes. The Anthropic translator forwards the original scheme; the OpenAI translator always converts to Bearer regardless of incoming scheme.
-
-<!-- lore:019dfa62-9c29-746f-ab60-313983894131 -->
-* **Anthropic cache TTL is 5 minutes, not 1 hour — inform refresh policy**: Anthropic cache TTL ~5 minutes, not 1 hour. Refresh within warm window pays full write cost (~$1.88/bust for 500K). Track bust rate per session; alert stderr when rate >50% after 20+ calls. Refresh at turn boundaries or idle >TTL only.
-
-<!-- lore:019dfed5-5cc8-74d3-b1c8-ee30519b1161 -->
-* **Claude Code autoDream 24h/5-session gates are too conservative for real-world iteration speed**: Claude Code's autoDream uses conservative 24h/5-session gates; Lore's continuous idle-time curation is more responsive for agent workloads (5-20 turns/session). Pattern: batch cycle delays pattern surfacing until next morning. Immediacy wins for coding agents—bugs caught same day prevent compounding.
-
-<!-- lore:019dfa4b-d2fb-7195-8f43-f93b5ffac9bb -->
-* **Lore transform non-determinism breaks prompt cache between API calls**: Transform non-determinism breaks prompt cache. Root causes: (1) `sanitizeToolParts()` uses `Date.now()`—fix: use deterministic timestamp (part.state.time.start or 0). (2) `distilledPrefixCached()` calls `addRelativeTimeToObservations()` per row—fix: batch consumption at turn boundaries. Add unit tests for determinism + runtime bust-rate tracking.
-
-<!-- lore:019dfe4c-acaa-75d0-a1d3-701f52206945 -->
-* **Meta-distillation row ID rewrites invalidate distilled prefix cache**: Meta-distillation row ID rewrites invalidate distilled prefix cache. If cache is warm (within 5min), wastes cache-write burst. Fix: pass `skipMeta: true` to `distillation.run()` when `Date.now() - getLastTurnAt(sessionID) < cacheTTLMs`.
-
-<!-- lore:019dfcb9-cad6-7290-b526-cc9e4186a290 -->
-* **Runtime cost monitoring is log-only, no session budget enforcement**: Runtime cost monitoring is log-only; no session budget enforcement. Implement cost accumulator with stderr alerts when spend exceeds threshold, paired with unit tests for transform determinism to prevent regressions.
-
-<!-- lore:019dfa53-b91d-734f-a5e2-55979f911303 -->
-* **System prompt size bloat from AGENTS.md injection: 41K tokens on single session**: System prompt reaches ~41K tokens: AGENTS.md (~16K) + Lore entries (~7K) + base system (~5K) + tools (~8-10K). Cached read-only but AGENTS.md grows (68KB file). Consider truncating lore entries to recent 10-15 or splitting knowledge from system prompt to avoid byte changes on each update.
-
-<!-- lore:019df987-1c4b-727d-9968-7ed4871ec85f -->
-* **Worktree OpenCode instances lack upstream cache bust fix — enable tool-part caching**: Worktree OpenCode instances may lack tool-part cache fix (patch `88260b5e8`). Without it, mutations between API calls break prompt cache on nearly every call. 667 API calls = 78 busts costing $77 (12% of calls). Fix: sync to BYK/cumulative or apply patch directly.
-
-### Pattern
-
-<!-- lore:019e01ba-9efb-7064-b80e-e8d4d7386673 -->
-* **Batch queue groups flushes by credential for multi-tenant correctness**: In `packages/gateway/src/batch-queue.ts`, each `PendingRequest` snapshots the `AuthCredential` at enqueue time. On flush, items are grouped by `scheme:value` key, and each group becomes a separate Anthropic batch API call with its own auth headers. `InflightBatch` also stores the credential for poll/retrieve calls. Bearer-authenticated items fall back to synchronous (inner client) since the Batch API may not support OAuth tokens — checked via `cred.scheme === 'bearer'` before enqueuing.
-
-<!-- lore:019e01ba-9ef8-7858-a662-524001638a8f -->
-* **Session fingerprint includes model + auth suffix for isolation**: `fingerprintMessages()` in `packages/gateway/src/session.ts` accepts optional `extras: { model?, authSuffix? }` that get concatenated into the hash material before SHA-256. This ensures that switching API keys or models creates a new session rather than corrupting an existing one. The auth suffix is the last 8 chars of the credential value (via `authFingerprint()`), not the full secret. Called from `identifySession()` in `pipeline.ts`.
-
-<!-- lore:019dfcb9-cae2-7eb5-9769-8faf8cc8527d -->
-* **Cache bust detection via prefix ID hash but no rate tracking**: Gradient tracks cache busts via prefix hash (first 5 message IDs + layer). Logs rate: bustCount/transformCount. Alerts stderr when rate >50% after 20+ calls. Busts cost ~$3.75/MTok × context_size.
-
-<!-- lore:019df901-854f-704d-98db-f33a70ed9617 -->
-* **distillSegment urgency tiers: defer-safe vs blocking paths**: Distillation urgency tiers: fire-and-forget calls in `message.updated`/`messages.transform` layer≥2 defer to batch API (50% savings). Overflow recovery and `/compact` await immediately. Thread `urgent?: boolean` flag: urgent=true synchronous, urgent=false queued. Batch handles ~80% of volume.
-
-<!-- lore:019dfa4b-d2ff-704a-97b4-e382a46cb7b4 -->
-* **Gradient layer transitions trigger cascade of cache busts in Lore**: Gradient layer transitions at ~step 668 cause bust rate jump 12%→51%. Sticky layer guard pins to `lastLayer` when message count stable, preventing oscillation (0→1→0) that rewrites context bytes. Guard applies to calibrated sessions only.
-
-<!-- lore:019dc5e2-c998-7395-9591-b0214485832d -->
-* **Idle-resume cache refresh: clear caches when wall-clock gap exceeds prompt cache TTL**: Idle-resume cache refresh: clear caches when `now - lastTurnAt > cacheTTLMs` (default 5min, configurable). Anthropic default-tier cache TTL ~5 minutes (not 1 hour); beyond window, byte-preservation wastes write cost.
-
-<!-- lore:019df987-1c4f-7205-b320-f01f2c32cdce -->
-* **Long-running autonomous sessions hit quadratic cache cost — session length budget needed**: Long-running sessions hit quadratic cache cost via non-deterministic transform. Root causes: (1) Distillation row arrivals change distilled prefix length→shrink budget→rewrite all messages. (2) `sanitizeToolParts()` uses `Date.now()` producing different timestamps per call. Fix distillation consumption at turn boundaries and use deterministic timestamp (0 or message.time.created) instead of `Date.now()`.
-
-<!-- lore:019df8b6-f772-797b-88d3-29c98434646e -->
-* **Plugin auto-detects gateway and configures provider baseURLs via config hook**: Plugin auto-detects gateway (health check `http://localhost:6969/health`, 1s timeout). If responding, routes all provider requests through gateway via `baseURL: http://localhost:6969`. Sets `LORE_GATEWAY_MODE=1` when active.
-
-<!-- lore:019dfed5-5cba-7b0e-93ed-412c663314e9 -->
-* **Skeptical memory instruction pattern: explicit model guidance to verify before trusting memory**: Prepend LTM preamble with skepticism instruction: 'The following knowledge is context-aware but may be outdated—verify against files/tests before acting.' Prevents hallucinations on stale knowledge with negligible cost impact.
+<!-- lore:019e0222-519d-7e99-9436-5a2695ddb6c2 -->
+* **Silent Voyage-to-local migration for existing users without explicit config**: Users relying on implicit Voyage default (no \`.lore.json\`, just \`VOYAGE\_API\_KEY\` env var) will silently switch to local embeddings on upgrade. Embeddings auto-clear and re-embed, so no data loss, but they lose cloud provider quality (1024 dims → 384 dims). Risk is low for knowledge entries (negligible quality impact), but consider logging if \`VOYAGE\_API\_KEY\` is set but provider resolves to \`local\` — nudges power users they have an available option.

--- a/bun.lock
+++ b/bun.lock
@@ -15,12 +15,23 @@
       "name": "@loreai/core",
       "version": "0.12.0",
       "dependencies": {
+        "fastembed": "^2.1.0",
         "remark": "^15.0.1",
         "uuidv7": "^1.1.0",
         "zod": "^4.3.6",
       },
       "devDependencies": {
         "@types/mdast": "^4.0.4",
+      },
+    },
+    "packages/gateway": {
+      "name": "@loreai/gateway",
+      "version": "0.12.0",
+      "bin": {
+        "lore-gateway": "./dist/index.js",
+      },
+      "dependencies": {
+        "@loreai/core": "workspace:*",
       },
     },
     "packages/opencode": {
@@ -55,10 +66,24 @@
         "@mariozechner/pi-coding-agent": "*",
         "@sinclair/typebox": "*",
       },
+      "optionalPeers": [
+        "@mariozechner/pi-agent-core",
+        "@mariozechner/pi-ai",
+        "@mariozechner/pi-coding-agent",
+        "@sinclair/typebox",
+      ],
     },
   },
   "packages": {
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.90.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg=="],
+
+    "@anush008/tokenizers": ["@anush008/tokenizers@0.0.0", "", { "optionalDependencies": { "@anush008/tokenizers-darwin-universal": "0.0.0", "@anush008/tokenizers-linux-x64-gnu": "0.0.0", "@anush008/tokenizers-win32-x64-msvc": "0.0.0" } }, "sha512-IQD9wkVReKAhsEAbDjh/0KrBGTEXelqZLpOBRDaIRvlzZ9sjmUP+gKbpvzyJnei2JHQiE8JAgj7YcNloINbGBw=="],
+
+    "@anush008/tokenizers-darwin-universal": ["@anush008/tokenizers-darwin-universal@0.0.0", "", { "os": "darwin" }, "sha512-SACpWEooTjFX89dFKRVUhivMxxcZRtA3nJGVepdLyrwTkQ1TZQ8581B5JoXp0TcTMHfgnDaagifvVoBiFEdNCQ=="],
+
+    "@anush008/tokenizers-linux-x64-gnu": ["@anush008/tokenizers-linux-x64-gnu@0.0.0", "", { "os": "linux", "cpu": "x64" }, "sha512-TLjByOPWUEq51L3EJkS+slyH57HKJ7lAz/aBtEt7TIPq4QsE2owOPGovByOLIq1x5Wgh9b+a4q2JasrEFSDDhg=="],
+
+    "@anush008/tokenizers-win32-x64-msvc": ["@anush008/tokenizers-win32-x64-msvc@0.0.0", "", { "os": "win32", "cpu": "x64" }, "sha512-/5kP0G96+Cr6947F0ZetXnmL31YCaN15dbNbh2NHg7TXXRwfqk95+JtPP5Q7v4jbR2xxAmuseBqB4H/V7zKWuw=="],
 
     "@aws-crypto/crc32": ["@aws-crypto/crc32@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg=="],
 
@@ -190,7 +215,15 @@
 
     "@google/genai": ["@google/genai@1.50.1", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-YbkX7H9+1Pt8wOt7DDREy8XSoiL6fRDzZQRyaVBarFf8MR3zHGqVdvM4cLbDXqPhxqvegZShgfxb8kw9C7YhAQ=="],
 
+    "@huggingface/hub": ["@huggingface/hub@2.11.0", "", { "dependencies": { "@huggingface/tasks": "^0.19.90" }, "optionalDependencies": { "cli-progress": "^3.12.0" }, "bin": { "hfjs": "dist/cli.js" } }, "sha512-WS6QGaXYeBVFlaB4SOn6z4LGUpLB5kRZNL08uUni4izX353KxiwwZMK5+/AWX86MJh8SMZNa/JFcvFCcQsbszQ=="],
+
+    "@huggingface/tasks": ["@huggingface/tasks@0.19.90", "", {}, "sha512-nfV9luJbvwGQ/5oKXkKhCV9h4X7mwh1YaGG3ORd6UMLDSwr1OFSSatcBX0O9OtBtmNK19aGSjbLFqqgcIR6+IA=="],
+
+    "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
+
     "@loreai/core": ["@loreai/core@workspace:packages/core"],
+
+    "@loreai/gateway": ["@loreai/gateway@workspace:packages/gateway"],
 
     "@loreai/opencode": ["@loreai/opencode@workspace:packages/opencode"],
 
@@ -394,6 +427,8 @@
 
     "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
 
+    "boolean": ["boolean@3.2.0", "", {}, "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw=="],
+
     "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
     "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
@@ -408,7 +443,11 @@
 
     "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
 
+    "chownr": ["chownr@2.0.0", "", {}, "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="],
+
     "cli-highlight": ["cli-highlight@2.1.11", "", { "dependencies": { "chalk": "^4.0.0", "highlight.js": "^10.7.1", "mz": "^2.4.0", "parse5": "^5.1.1", "parse5-htmlparser2-tree-adapter": "^6.0.0", "yargs": "^16.0.0" }, "bin": { "highlight": "bin/highlight" } }, "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg=="],
+
+    "cli-progress": ["cli-progress@3.12.0", "", { "dependencies": { "string-width": "^4.2.3" } }, "sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A=="],
 
     "cliui": ["cliui@7.0.4", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^7.0.0" } }, "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ=="],
 
@@ -422,9 +461,15 @@
 
     "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
 
+    "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
+
+    "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
+
     "degenerator": ["degenerator@5.0.1", "", { "dependencies": { "ast-types": "^0.13.4", "escodegen": "^2.1.0", "esprima": "^4.0.1" } }, "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ=="],
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
+    "detect-node": ["detect-node@2.1.0", "", {}, "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="],
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
@@ -436,9 +481,17 @@
 
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es6-error": ["es6-error@4.1.1", "", {}, "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="],
+
     "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
     "escodegen": ["escodegen@2.1.0", "", { "dependencies": { "esprima": "^4.0.1", "estraverse": "^5.2.0", "esutils": "^2.0.2" }, "optionalDependencies": { "source-map": "~0.6.1" }, "bin": { "esgenerate": "bin/esgenerate.js", "escodegen": "bin/escodegen.js" } }, "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w=="],
 
@@ -462,6 +515,8 @@
 
     "fast-xml-parser": ["fast-xml-parser@5.5.8", "", { "dependencies": { "fast-xml-builder": "^1.1.4", "path-expression-matcher": "^1.2.0", "strnum": "^2.2.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ=="],
 
+    "fastembed": ["fastembed@2.1.0", "", { "dependencies": { "@anush008/tokenizers": "^0.0.0", "@huggingface/hub": "^2.7.1", "onnxruntime-node": "1.21.0", "progress": "^2.0.3", "tar": "^6.2.0" } }, "sha512-oQkpcRHBppJ3+a3w9dU0uytSY0N1cnEa/iVMc8AXEd+tvT529GekOEFhNviJy89R3lvQXF6cdIMTXHj1Gi00xQ=="],
+
     "fd-slicer": ["fd-slicer@1.1.0", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g=="],
 
     "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
@@ -469,6 +524,8 @@
     "file-type": ["file-type@21.3.4", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.4", "token-types": "^6.1.1", "uint8array-extras": "^1.4.0" } }, "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g=="],
 
     "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
+
+    "fs-minipass": ["fs-minipass@2.1.0", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg=="],
 
     "gaxios": ["gaxios@7.1.4", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2" } }, "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA=="],
 
@@ -484,13 +541,21 @@
 
     "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
 
+    "global-agent": ["global-agent@3.0.0", "", { "dependencies": { "boolean": "^3.0.1", "es6-error": "^4.1.1", "matcher": "^3.0.0", "roarr": "^2.15.3", "semver": "^7.3.2", "serialize-error": "^7.0.1" } }, "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q=="],
+
+    "globalthis": ["globalthis@1.0.4", "", { "dependencies": { "define-properties": "^1.2.1", "gopd": "^1.0.1" } }, "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ=="],
+
     "google-auth-library": ["google-auth-library@10.6.2", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw=="],
 
     "google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
 
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "has-property-descriptors": ["has-property-descriptors@1.0.2", "", { "dependencies": { "es-define-property": "^1.0.0" } }, "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg=="],
 
     "highlight.js": ["highlight.js@10.7.3", "", {}, "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="],
 
@@ -516,6 +581,8 @@
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
+    "json-stringify-safe": ["json-stringify-safe@5.0.1", "", {}, "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="],
+
     "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
 
     "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
@@ -529,6 +596,8 @@
     "lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
 
     "marked": ["marked@15.0.12", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="],
+
+    "matcher": ["matcher@3.0.0", "", { "dependencies": { "escape-string-regexp": "^4.0.0" } }, "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng=="],
 
     "mdast-util-from-markdown": ["mdast-util-from-markdown@2.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "mdast-util-to-string": "^4.0.0", "micromark": "^4.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA=="],
 
@@ -586,7 +655,11 @@
 
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
-    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+    "minipass": ["minipass@5.0.0", "", {}, "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ=="],
+
+    "minizlib": ["minizlib@2.1.2", "", { "dependencies": { "minipass": "^3.0.0", "yallist": "^4.0.0" } }, "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg=="],
+
+    "mkdirp": ["mkdirp@1.0.4", "", { "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
@@ -600,7 +673,13 @@
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
+    "object-keys": ["object-keys@1.1.1", "", {}, "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="],
+
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "onnxruntime-common": ["onnxruntime-common@1.21.0", "", {}, "sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ=="],
+
+    "onnxruntime-node": ["onnxruntime-node@1.21.0", "", { "dependencies": { "global-agent": "^3.0.0", "onnxruntime-common": "1.21.0", "tar": "^7.0.1" }, "os": [ "linux", "win32", "darwin", ] }, "sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw=="],
 
     "openai": ["openai@6.26.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA=="],
 
@@ -621,6 +700,8 @@
     "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
 
     "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
+
+    "progress": ["progress@2.0.3", "", {}, "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="],
 
     "proper-lockfile": ["proper-lockfile@4.1.2", "", { "dependencies": { "graceful-fs": "^4.2.4", "retry": "^0.12.0", "signal-exit": "^3.0.2" } }, "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA=="],
 
@@ -646,7 +727,15 @@
 
     "retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
 
+    "roarr": ["roarr@2.15.4", "", { "dependencies": { "boolean": "^3.0.1", "detect-node": "^2.0.4", "globalthis": "^1.0.1", "json-stringify-safe": "^5.0.1", "semver-compare": "^1.0.0", "sprintf-js": "^1.1.2" } }, "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A=="],
+
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "semver-compare": ["semver-compare@1.0.0", "", {}, "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="],
+
+    "serialize-error": ["serialize-error@7.0.1", "", { "dependencies": { "type-fest": "^0.13.1" } }, "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw=="],
 
     "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
@@ -657,6 +746,8 @@
     "socks-proxy-agent": ["socks-proxy-agent@8.0.5", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "socks": "^2.8.3" } }, "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw=="],
 
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "sprintf-js": ["sprintf-js@1.1.3", "", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
 
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
@@ -670,6 +761,8 @@
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
+    "tar": ["tar@6.2.1", "", { "dependencies": { "chownr": "^2.0.0", "fs-minipass": "^2.0.0", "minipass": "^5.0.0", "minizlib": "^2.1.1", "mkdirp": "^1.0.3", "yallist": "^4.0.0" } }, "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A=="],
+
     "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
 
     "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
@@ -681,6 +774,8 @@
     "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
@@ -718,6 +813,8 @@
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
+    "yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
     "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
 
     "yargs": ["yargs@16.2.0", "", { "dependencies": { "cliui": "^7.0.2", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.0", "y18n": "^5.0.5", "yargs-parser": "^20.2.2" } }, "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw=="],
@@ -738,21 +835,33 @@
 
     "@aws-crypto/util/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
+    "@isaacs/fs-minipass/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
     "@opencode-ai/plugin/zod": ["zod@4.1.8", "", {}, "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ=="],
 
     "cli-highlight/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
+    "fs-minipass/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "glob/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
     "hosted-git-info/lru-cache": ["lru-cache@11.3.5", "", {}, "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw=="],
 
+    "minizlib/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
     "node-fetch/data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
+
+    "onnxruntime-node/tar": ["tar@7.5.14", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-/7sHKgQO3JLP9ESlwTYUUftHUadOURUqq23xs1vjcnp8Vss6k0wCfzulyEtk5g91pjvnuriimGlyG7k6msrzRw=="],
 
     "p-retry/retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
 
     "parse5-htmlparser2-tree-adapter/parse5": ["parse5@6.0.1", "", {}, "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="],
 
     "path-scurry/lru-cache": ["lru-cache@11.3.5", "", {}, "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw=="],
+
+    "path-scurry/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
     "string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -763,6 +872,14 @@
     "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 
     "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "onnxruntime-node/tar/chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
+
+    "onnxruntime-node/tar/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "onnxruntime-node/tar/minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
+
+    "onnxruntime-node/tar/yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 
     "string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,6 +23,7 @@
     "build": "bun run script/build.ts"
   },
   "dependencies": {
+    "fastembed": "^2.1.0",
     "remark": "^15.0.1",
     "uuidv7": "^1.1.0",
     "zod": "^4.3.6"

--- a/packages/core/script/build.ts
+++ b/packages/core/script/build.ts
@@ -39,7 +39,10 @@ mkdirSync(distDir, { recursive: true });
 // Runtime built-ins. `platform: "node"` auto-externalizes `fs`, `path`, etc.
 // We list `node:*` and `bun:*` explicitly so any `node:` or `bun:` prefixed
 // import is preserved as-is in the output (important for bun:sqlite).
-const external = ["node:*", "bun:*"];
+// fastembed + its native transitive deps (onnxruntime-node, @anush008/tokenizers)
+// must stay external — they contain platform-specific native binaries that
+// esbuild cannot bundle. npm installs them alongside @loreai/core.
+const external = ["node:*", "bun:*", "fastembed", "onnxruntime-*", "@anush008/*"];
 
 /** @type {esbuild.BuildOptions} */
 const commonOptions: esbuild.BuildOptions = {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -120,37 +120,40 @@ export const LoreConfig = z.object({
        *  before search, improving recall for ambiguous queries. */
       queryExpansion: z.boolean().default(false),
       /** Vector embedding search.
-       *  Supports multiple providers: "voyage" (Voyage AI, VOYAGE_API_KEY),
-       *  "openai" (OpenAI, OPENAI_API_KEY).
-       *  Automatically enabled when the configured provider's API key env var is set.
-       *  Set enabled: false to explicitly disable even with the key present. */
+       *  Supports multiple providers:
+       *  - "local" (default): fastembed + ONNX Runtime, no API key needed.
+       *    Uses bge-small-en-v1.5 (384 dims). Model downloaded on first use (~33MB),
+       *    cached in ~/.cache/fastembed. ~150ms per query embed.
+       *  - "voyage": Voyage AI (VOYAGE_API_KEY, voyage-code-3, 1024 dims)
+       *  - "openai": OpenAI (OPENAI_API_KEY, text-embedding-3-small, 1536 dims)
+       *  Set enabled: false to explicitly disable even with a provider available. */
       embeddings: z
         .object({
           /** Enable/disable vector embedding search. Default: true.
-           *  Set to false to explicitly disable even when the API key is set. */
+           *  Set to false to explicitly disable. */
           enabled: z.boolean().default(true),
-          /** Embedding provider. Default: "voyage".
-           *  Each provider reads its own env var for the API key:
+          /** Embedding provider. Default: "local".
+           *  - "local": fastembed + ONNX Runtime, no API key (default model: bge-small-en-v1.5, 384 dims)
            *  - "voyage": VOYAGE_API_KEY (default model: voyage-code-3, 1024 dims)
            *  - "openai": OPENAI_API_KEY (default model: text-embedding-3-small, 1536 dims) */
-          provider: z.enum(["voyage", "openai"]).default("voyage"),
+          provider: z.enum(["local", "voyage", "openai"]).default("local"),
           /** Model ID for the embedding provider. Default depends on provider. */
-          model: z.string().default("voyage-code-3"),
-          /** Embedding dimensions. Default: 1024. */
-          dimensions: z.number().min(256).max(2048).default(1024),
+          model: z.string().default("BGESmallENV15"),
+          /** Embedding dimensions. Default: 384 (local) / 1024 (voyage) / 1536 (openai). */
+          dimensions: z.number().min(64).max(2048).default(384),
         })
         .default({
           enabled: true,
-          provider: "voyage",
-          model: "voyage-code-3",
-          dimensions: 1024,
+          provider: "local",
+          model: "BGESmallENV15",
+          dimensions: 384,
         }),
     })
     .default({
       ftsWeights: { title: 6.0, content: 2.0, category: 3.0 },
       recallLimit: 10,
       queryExpansion: false,
-      embeddings: { enabled: true, provider: "voyage" as const, model: "voyage-code-3", dimensions: 1024 },
+      embeddings: { enabled: true, provider: "local" as const, model: "BGESmallENV15", dimensions: 384 },
     }),
   crossProject: z.boolean().default(false),
   agentsFile: z

--- a/packages/core/src/distillation.ts
+++ b/packages/core/src/distillation.ts
@@ -3,7 +3,9 @@ import { config } from "./config";
 import * as temporal from "./temporal";
 import { CHUNK_TERMINATOR } from "./temporal";
 import * as embedding from "./embedding";
+import * as ltm from "./ltm";
 import * as log from "./log";
+import { extractPatterns } from "./pattern-extract";
 import {
   DISTILLATION_SYSTEM,
   distillationUser,
@@ -668,6 +670,24 @@ async function distillSegment(input: {
     embedding.embedDistillation(distillId, result.observations);
   }
 
+  // Fire-and-forget: extract decision/preference patterns → knowledge entries
+  if (config().knowledge.enabled) {
+    for (const pat of extractPatterns(result.observations)) {
+      try {
+        ltm.create({
+          projectPath: input.projectPath,
+          category: pat.category,
+          title: pat.title,
+          content: pat.content,
+          session: input.sessionID,
+          scope: "project",
+        });
+      } catch {
+        // Dedup guard in ltm.create() handles duplicates — swallow errors
+      }
+    }
+  }
+
   return result;
 }
 
@@ -761,6 +781,24 @@ export async function metaDistill(input: {
   // Fire-and-forget OUTSIDE the transaction (async, no rollback needed).
   if (embedding.isAvailable()) {
     embedding.embedDistillation(metaId, result.observations);
+  }
+
+  // Fire-and-forget: extract decision/preference patterns → knowledge entries
+  if (config().knowledge.enabled) {
+    for (const pat of extractPatterns(result.observations)) {
+      try {
+        ltm.create({
+          projectPath: input.projectPath,
+          category: pat.category,
+          title: pat.title,
+          content: pat.content,
+          session: input.sessionID,
+          scope: "project",
+        });
+      } catch {
+        // Dedup guard in ltm.create() handles duplicates — swallow errors
+      }
+    }
   }
 
   return result;

--- a/packages/core/src/distillation.ts
+++ b/packages/core/src/distillation.ts
@@ -803,3 +803,71 @@ export async function metaDistill(input: {
 
   return result;
 }
+
+// ---------------------------------------------------------------------------
+// Retroactive metric backfill
+// ---------------------------------------------------------------------------
+
+/**
+ * Backfill `r_compression` and `c_norm` for distillations that were created
+ * before schema v12 (or before PR #113 added the computation).
+ *
+ * For each distillation with NULL metrics, loads source temporal messages via
+ * `source_ids`, computes `compressionRatio()` and `temporalCnorm()`, and
+ * writes the values back. Skips rows where source messages have been pruned
+ * or source_ids is empty.
+ *
+ * Designed to run once at startup — idempotent (only touches NULL rows).
+ * Returns the number of rows updated.
+ */
+export function backfillMetrics(): number {
+  const rows = db()
+    .query(
+      "SELECT id, source_ids, token_count FROM distillations WHERE r_compression IS NULL",
+    )
+    .all() as Array<{
+    id: string;
+    source_ids: string;
+    token_count: number;
+  }>;
+
+  if (!rows.length) return 0;
+
+  const update = db().prepare(
+    "UPDATE distillations SET r_compression = ?, c_norm = ? WHERE id = ?",
+  );
+
+  let updated = 0;
+
+  for (const row of rows) {
+    const sourceIds = parseSourceIds(row.source_ids);
+    if (!sourceIds.length) continue;
+
+    // Load source temporal messages — they may have been pruned.
+    const placeholders = sourceIds.map(() => "?").join(",");
+    const sources = db()
+      .query(
+        `SELECT tokens, created_at FROM temporal_messages WHERE id IN (${placeholders})`,
+      )
+      .all(...sourceIds) as Array<{ tokens: number; created_at: number }>;
+
+    if (!sources.length) continue;
+
+    const sourceTokens = sources.reduce((sum, s) => sum + s.tokens, 0);
+    const timestamps = sources.map((s) => s.created_at);
+
+    const rComp = compressionRatio(row.token_count, sourceTokens);
+    const cNorm = temporal.temporalCnorm(timestamps);
+
+    update.run(rComp, cNorm, row.id);
+    updated++;
+  }
+
+  if (updated > 0) {
+    log.info(
+      `backfilled metrics for ${updated} distillations (${rows.length - updated} skipped — missing sources)`,
+    );
+  }
+
+  return updated;
+}

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -514,12 +514,73 @@ export function checkConfigChange(): boolean {
 }
 
 // ---------------------------------------------------------------------------
+// Startup backfill — single entry point for all hosts
+// ---------------------------------------------------------------------------
+
+/**
+ * Run all embedding backfills and log coverage stats.
+ *
+ * This is the canonical entry point that every host adapter (OpenCode, Pi,
+ * future ACP) should call once during init. It:
+ *   1. Detects config changes (provider swap) and clears stale embeddings
+ *   2. Backfills knowledge entries missing embeddings
+ *   3. Backfills non-archived distillations missing embeddings
+ *   4. Logs a one-line coverage summary to stderr (always visible, not gated)
+ *
+ * Fire-and-forget: callers should `.catch()` — embedding failures must not
+ * block plugin initialization.
+ */
+export async function runStartupBackfill(): Promise<void> {
+  if (!isAvailable()) return;
+
+  const knowledgeEmbedded = await backfillEmbeddings();
+  const distillationEmbedded = await backfillDistillationEmbeddings();
+
+  // Coverage stats — always log to stderr so the problem is visible.
+  const kTotal = (
+    db()
+      .query("SELECT COUNT(*) as n FROM knowledge WHERE confidence > 0.2")
+      .get() as { n: number }
+  ).n;
+  const kWithEmb = (
+    db()
+      .query(
+        "SELECT COUNT(*) as n FROM knowledge WHERE embedding IS NOT NULL AND confidence > 0.2",
+      )
+      .get() as { n: number }
+  ).n;
+  const dTotal = (
+    db()
+      .query(
+        "SELECT COUNT(*) as n FROM distillations WHERE archived = 0 AND observations != ''",
+      )
+      .get() as { n: number }
+  ).n;
+  const dWithEmb = (
+    db()
+      .query(
+        "SELECT COUNT(*) as n FROM distillations WHERE embedding IS NOT NULL AND archived = 0",
+      )
+      .get() as { n: number }
+  ).n;
+
+  const parts: string[] = [];
+  if (knowledgeEmbedded > 0 || distillationEmbedded > 0) {
+    parts.push(`backfilled ${knowledgeEmbedded} knowledge + ${distillationEmbedded} distillations`);
+  }
+  parts.push(
+    `coverage: knowledge ${kWithEmb}/${kTotal}, distillations ${dWithEmb}/${dTotal}`,
+  );
+  log.info(`embedding startup: ${parts.join("; ")}`);
+}
+
+// ---------------------------------------------------------------------------
 // Backfill — knowledge
 // ---------------------------------------------------------------------------
 
 /**
  * Embed all knowledge entries that are missing embeddings.
- * Called on startup when embeddings are first enabled.
+ * Called by `runStartupBackfill()`.
  * Also handles config changes: if provider/model/dimensions changed, clears
  * stale embeddings first, then re-embeds all entries.
  * Returns the number of entries embedded.

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -133,11 +133,78 @@ class OpenAIProvider implements EmbeddingProvider {
 }
 
 // ---------------------------------------------------------------------------
+// Local provider (fastembed + ONNX Runtime)
+// ---------------------------------------------------------------------------
+
+/**
+ * Local embedding provider using fastembed (bge-small-en-v1.5 by default).
+ *
+ * No API key required — runs entirely on-device via ONNX Runtime.
+ * Model files are downloaded on first use (~33MB) and cached in
+ * `~/.cache/fastembed`. Subsequent inits load from disk in ~350ms.
+ *
+ * Uses dynamic import so the module is only loaded when the "local"
+ * provider is actually selected — avoids startup cost and allows
+ * graceful fallback if fastembed is not installed.
+ */
+class LocalProvider implements EmbeddingProvider {
+  readonly maxBatchSize = 256;
+  private model: unknown | null = null;
+  private initPromise: Promise<unknown> | null = null;
+  private modelName: string;
+
+  constructor(modelName: string) {
+    this.modelName = modelName;
+  }
+
+  private async getModel(): Promise<unknown> {
+    if (this.model) return this.model;
+    if (!this.initPromise) {
+      this.initPromise = (async () => {
+        const { EmbeddingModel, FlagEmbedding } = await import("fastembed");
+        // Map config model string to EmbeddingModel enum value.
+        // If the configured model matches an enum key, use it; otherwise try
+        // the raw string as a model name (CUSTOM model support in fastembed).
+        const enumValue = (EmbeddingModel as Record<string, string>)[this.modelName];
+        const m = await FlagEmbedding.init({
+          model: enumValue ?? this.modelName,
+        });
+        this.model = m;
+        return m;
+      })();
+    }
+    return this.initPromise;
+  }
+
+  async embed(texts: string[], inputType: "document" | "query"): Promise<Float32Array[]> {
+    const model = (await this.getModel()) as {
+      queryEmbed(text: string): Promise<number[]>;
+      passageEmbed(texts: string[], batchSize?: number): AsyncGenerator<number[][]>;
+    };
+
+    if (inputType === "query" && texts.length === 1) {
+      const vec = await model.queryEmbed(texts[0]);
+      return [new Float32Array(vec)];
+    }
+
+    // passageEmbed returns an async generator of batches
+    const results: Float32Array[] = [];
+    for await (const batch of model.passageEmbed(texts)) {
+      for (const vec of batch) {
+        results.push(new Float32Array(vec));
+      }
+    }
+    return results;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Provider resolution
 // ---------------------------------------------------------------------------
 
 /** Default models per provider — used when config doesn't override. */
 const PROVIDER_DEFAULTS: Record<string, { model: string; dimensions: number }> = {
+  local: { model: "BGESmallENV15", dimensions: 384 },
   voyage: { model: "voyage-code-3", dimensions: 1024 },
   openai: { model: "text-embedding-3-small", dimensions: 1536 },
 };
@@ -165,23 +232,36 @@ function getProvider(): EmbeddingProvider | null {
   }
 
   const providerName = cfg.provider;
-  const apiKey = getProviderApiKey(providerName);
-  if (!apiKey) {
-    cachedProvider = null;
-    return null;
-  }
-
-  const defaults = PROVIDER_DEFAULTS[providerName];
-  const model = cfg.model === defaults?.model ? cfg.model : cfg.model;
-  const dimensions = cfg.dimensions;
+  const model = cfg.model;
 
   switch (providerName) {
-    case "voyage":
-      cachedProvider = new VoyageProvider(apiKey, model, dimensions);
+    case "local": {
+      try {
+        cachedProvider = new LocalProvider(model);
+      } catch {
+        log.info("local embedding provider unavailable (fastembed not installed)");
+        cachedProvider = null;
+      }
       break;
-    case "openai":
-      cachedProvider = new OpenAIProvider(apiKey, model, dimensions);
+    }
+    case "voyage": {
+      const apiKey = getProviderApiKey(providerName);
+      if (!apiKey) {
+        cachedProvider = null;
+        return null;
+      }
+      cachedProvider = new VoyageProvider(apiKey, model, cfg.dimensions);
       break;
+    }
+    case "openai": {
+      const apiKey = getProviderApiKey(providerName);
+      if (!apiKey) {
+        cachedProvider = null;
+        return null;
+      }
+      cachedProvider = new OpenAIProvider(apiKey, model, cfg.dimensions);
+      break;
+    }
     default:
       log.info(`unknown embedding provider: ${providerName}`);
       cachedProvider = null;

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -166,9 +166,12 @@ class LocalProvider implements EmbeddingProvider {
         // If the configured model matches an enum key, use it; otherwise try
         // the raw string as a model name (CUSTOM model support in fastembed).
         const enumValue = (EmbeddingModel as Record<string, string>)[this.modelName];
+        // fastembed's init() has overloaded signatures expecting specific enum
+        // members, but we resolve the model dynamically from config. The enum
+        // lookup guarantees a valid value at runtime; cast to satisfy the type.
         const m = await FlagEmbedding.init({
           model: enumValue ?? this.modelName,
-        });
+        } as { model: typeof EmbeddingModel.BGESmallENV15 });
         this.model = m;
         return m;
       })();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,7 @@ export * as distillation from "./distillation";
 export * as curator from "./curator";
 export * as embedding from "./embedding";
 export * as latReader from "./lat-reader";
+export * as patternExtract from "./pattern-extract";
 export * as log from "./log";
 
 export {
@@ -113,6 +114,7 @@ export {
   reciprocalRankFusion,
   expandQuery,
   extractTopTerms,
+  exactTermMatchRank,
 } from "./search";
 export {
   serialize,

--- a/packages/core/src/pattern-extract.ts
+++ b/packages/core/src/pattern-extract.ts
@@ -1,0 +1,108 @@
+/**
+ * Lightweight regex-based pattern extraction from distillation observations.
+ *
+ * Scans for decision/preference/choice patterns and returns structured
+ * extractions that can be stored as knowledge entries. No LLM required.
+ *
+ * Patterns target how decisions and preferences are typically expressed
+ * in distilled engineering context:
+ *   - "decided to use X"
+ *   - "chose X over Y"
+ *   - "switched from X to Y"
+ *   - "prefers X for Y"
+ *   - "going with X because Y"
+ *
+ * Extracted entries participate in the normal curator cycle — the curator
+ * can consolidate or remove them based on actual value. The extraction is
+ * a cheap seed, not a permanent fixture.
+ */
+
+export type ExtractedPattern = {
+  category: "decision" | "preference";
+  /** Short descriptive title, e.g. "Chose PostgreSQL over MySQL". */
+  title: string;
+  /** Full matched text for context. */
+  content: string;
+};
+
+type PatternDef = {
+  regex: RegExp;
+  category: "decision" | "preference";
+  titleFn: (match: RegExpMatchArray) => string;
+};
+
+const PATTERNS: PatternDef[] = [
+  // Decision patterns
+  {
+    regex: /decided to (?:use |switch to |go with |adopt )(.+?)(?:\.|,|$)/gi,
+    category: "decision",
+    titleFn: (m) => `Decided to use ${m[1].trim()}`,
+  },
+  {
+    regex: /chose (.+?) over (.+?)(?:\.|,|$)/gi,
+    category: "decision",
+    titleFn: (m) => `Chose ${m[1].trim()} over ${m[2].trim()}`,
+  },
+  {
+    regex: /switched from (.+?) to (.+?)(?:\.|,|$)/gi,
+    category: "decision",
+    titleFn: (m) => `Switched from ${m[1].trim()} to ${m[2].trim()}`,
+  },
+  {
+    regex: /going with (.+?) (?:because|for|due to)(.+?)(?:\.|,|$)/gi,
+    category: "decision",
+    titleFn: (m) => `Going with ${m[1].trim()}`,
+  },
+  {
+    regex: /migrat(?:ed|ing) (?:from .+? )?to (.+?)(?:\.|,|$)/gi,
+    category: "decision",
+    titleFn: (m) => `Migrated to ${m[1].trim()}`,
+  },
+  {
+    regex: /adopted (.+?) (?:for|as|instead)(.+?)(?:\.|,|$)/gi,
+    category: "decision",
+    titleFn: (m) => `Adopted ${m[1].trim()}`,
+  },
+
+  // Preference patterns
+  {
+    regex: /prefers? (.+?) (?:over|to|instead of|rather than) (.+?)(?:\.|,|$)/gi,
+    category: "preference",
+    titleFn: (m) => `Prefers ${m[1].trim()} over ${m[2].trim()}`,
+  },
+  {
+    regex:
+      /(?:user |team |we )(?:always |usually |typically )(?:use|prefer|go with) (.+?)(?:\.|,|$)/gi,
+    category: "preference",
+    titleFn: (m) => `Typically uses ${m[1].trim()}`,
+  },
+];
+
+/**
+ * Extract decision/preference patterns from distillation observations text.
+ *
+ * Returns structured entries suitable for `ltm.create()`. Deduplicates by
+ * lowercased title within a single call.
+ *
+ * @param observations  The distilled observations text to scan.
+ * @returns             Array of extracted patterns (may be empty).
+ */
+export function extractPatterns(observations: string): ExtractedPattern[] {
+  const results: ExtractedPattern[] = [];
+  const seen = new Set<string>();
+
+  for (const { regex, category, titleFn } of PATTERNS) {
+    // Reset lastIndex for global regexes reused across calls
+    regex.lastIndex = 0;
+    let match: RegExpMatchArray | null;
+    while ((match = regex.exec(observations)) !== null) {
+      const title = titleFn(match);
+      const key = title.toLowerCase();
+      if (seen.has(key)) continue;
+      seen.add(key);
+      results.push({ category, title, content: match[0].trim() });
+    }
+  }
+
+  return results;
+}

--- a/packages/core/src/recall.ts
+++ b/packages/core/src/recall.ts
@@ -38,6 +38,7 @@ type Distillation = {
   generation: number;
   created_at: number;
   session_id: string;
+  c_norm: number | null;
 };
 
 export type ScoredDistillation = Distillation & { rank: number };
@@ -130,8 +131,8 @@ function searchDistillationsLike(input: {
     .join(" AND ");
   const likeParams = terms.map((term) => `%${term}%`);
   const sql = input.sessionID
-    ? `SELECT id, observations, generation, created_at, session_id FROM distillations WHERE project_id = ? AND session_id = ? AND ${conditions} ORDER BY created_at DESC LIMIT ?`
-    : `SELECT id, observations, generation, created_at, session_id FROM distillations WHERE project_id = ? AND ${conditions} ORDER BY created_at DESC LIMIT ?`;
+    ? `SELECT id, observations, generation, created_at, session_id, c_norm FROM distillations WHERE project_id = ? AND session_id = ? AND ${conditions} ORDER BY created_at DESC LIMIT ?`
+    : `SELECT id, observations, generation, created_at, session_id, c_norm FROM distillations WHERE project_id = ? AND ${conditions} ORDER BY created_at DESC LIMIT ?`;
   const allParams = input.sessionID
     ? [input.pid, input.sessionID, ...likeParams, input.limit]
     : [input.pid, ...likeParams, input.limit];
@@ -152,13 +153,13 @@ function searchDistillationsScored(input: {
   if (q === EMPTY_QUERY) return [];
 
   const ftsSQL = input.sessionID
-    ? `SELECT d.id, d.observations, d.generation, d.created_at, d.session_id, rank
+    ? `SELECT d.id, d.observations, d.generation, d.created_at, d.session_id, d.c_norm, rank
        FROM distillation_fts f
        CROSS JOIN distillations d ON d.rowid = f.rowid
        WHERE distillation_fts MATCH ?
        AND d.project_id = ? AND d.session_id = ?
        ORDER BY rank LIMIT ?`
-    : `SELECT d.id, d.observations, d.generation, d.created_at, d.session_id, rank
+    : `SELECT d.id, d.observations, d.generation, d.created_at, d.session_id, d.c_norm, rank
        FROM distillation_fts f
        CROSS JOIN distillations d ON d.rowid = f.rowid
        WHERE distillation_fts MATCH ?
@@ -413,7 +414,7 @@ export async function runRecall(input: RecallInput): Promise<RecallResult> {
           .map((hit): TaggedResult | null => {
             const row = db()
               .query(
-                "SELECT id, observations, generation, created_at, session_id FROM distillations WHERE id = ?",
+                "SELECT id, observations, generation, created_at, session_id, c_norm FROM distillations WHERE id = ?",
               )
               .get(hit.id) as Distillation | null;
             if (!row) return null;
@@ -482,6 +483,57 @@ export async function runRecall(input: RecallInput): Promise<RecallResult> {
       }
     } catch (err) {
       log.info("recall: cross-project knowledge search failed:", err);
+    }
+  }
+
+  // Distillation quality list: rank distillation candidates by a quality score
+  // that combines temporal clustering (c_norm) and age. Segments with low c_norm
+  // (uniformly distributed timestamps) are considered higher quality than bursty
+  // segments (high c_norm). Among high-c_norm segments, recent ones are more
+  // likely relevant. This adds a mild signal — RRF naturally blends it with the
+  // BM25 and vector signals without overriding them.
+  {
+    const distillationCandidates: Array<{
+      tagged: TaggedResult;
+      key: string;
+      qualityScore: number;
+    }> = [];
+
+    for (const list of allRrfLists) {
+      for (const item of list.items) {
+        if (item.source !== "distillation") continue;
+        const key = `d:${item.item.id}`;
+        const d = item.item as ScoredDistillation;
+        const cNorm = d.c_norm ?? 0; // NULL → treat as uniform (best case)
+        // Quality score: lower c_norm is better. For high c_norm, recency
+        // partially compensates. Age is normalized to days (capped at 90).
+        const ageDays = Math.min(
+          (Date.now() - d.created_at) / 86_400_000,
+          90,
+        );
+        // score ∈ [0, ~1]: 0 = best quality (uniform + recent)
+        // c_norm dominates (0–1), age adds a mild 0–0.1 penalty
+        const score = cNorm + (ageDays / 90) * 0.1;
+        distillationCandidates.push({ tagged: item, key, qualityScore: score });
+      }
+    }
+
+    if (distillationCandidates.length > 1) {
+      // De-duplicate by key (same distillation may appear in BM25 + vector lists)
+      const seen = new Set<string>();
+      const unique = distillationCandidates.filter((c) => {
+        if (seen.has(c.key)) return false;
+        seen.add(c.key);
+        return true;
+      });
+
+      // Sort by quality: lowest score first (best quality)
+      unique.sort((a, b) => a.qualityScore - b.qualityScore);
+
+      allRrfLists.push({
+        items: unique.map((c) => c.tagged),
+        key: (r) => `d:${r.item.id}`,
+      });
     }
   }
 

--- a/packages/core/src/recall.ts
+++ b/packages/core/src/recall.ts
@@ -19,7 +19,9 @@ import type { LoreConfig } from "./config";
 import type { LLMClient } from "./types";
 import {
   EMPTY_QUERY,
+  exactTermMatchRank,
   expandQuery,
+  filterTerms,
   ftsQuery,
   ftsQueryOr,
   reciprocalRankFusion,
@@ -71,6 +73,41 @@ type TaggedResult =
   | { source: "distillation"; item: ScoredDistillation }
   | { source: "temporal"; item: temporal.ScoredTemporalMessage }
   | { source: "lat-section"; item: latReader.ScoredLatSection };
+
+// ---------------------------------------------------------------------------
+// Tagged result helpers (used by exact-match boost + formatting)
+// ---------------------------------------------------------------------------
+
+/** Extract searchable text from any TaggedResult variant. */
+function getTaggedText(tagged: TaggedResult): string {
+  switch (tagged.source) {
+    case "knowledge":
+    case "cross-knowledge":
+      return `${tagged.item.title} ${tagged.item.content}`;
+    case "distillation":
+      return tagged.item.observations;
+    case "temporal":
+      return tagged.item.content;
+    case "lat-section":
+      return `${tagged.item.heading} ${tagged.item.content}`;
+  }
+}
+
+/** Unified key function for TaggedResult — source-prefixed ID for RRF dedup. */
+function taggedResultKey(r: TaggedResult): string {
+  switch (r.source) {
+    case "knowledge":
+      return `k:${r.item.id}`;
+    case "cross-knowledge":
+      return `xk:${r.item.id}`;
+    case "distillation":
+      return `d:${r.item.id}`;
+    case "temporal":
+      return `t:${r.item.id}`;
+    case "lat-section":
+      return `lat:${r.item.id}`;
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Distillation search
@@ -445,6 +482,35 @@ export async function runRecall(input: RecallInput): Promise<RecallResult> {
       }
     } catch (err) {
       log.info("recall: cross-project knowledge search failed:", err);
+    }
+  }
+
+  // Exact-match boost: add an additional RRF list that ranks candidates by
+  // the number of exact query term matches. This boosts proper nouns, file
+  // names, and technical terms that BM25's prefix/stem matching may dilute.
+  // Only runs when there are meaningful terms and existing candidates.
+  if (filterTerms(query).length > 0 && allRrfLists.length > 0) {
+    // Collect unique candidates across all lists
+    const allCandidates = new Map<string, TaggedResult>();
+    for (const list of allRrfLists) {
+      for (const item of list.items) {
+        const key = list.key(item);
+        if (!allCandidates.has(key)) allCandidates.set(key, item);
+      }
+    }
+
+    const candidateEntries = [...allCandidates.entries()];
+    const exactRanked = exactTermMatchRank(
+      candidateEntries,
+      ([, tagged]) => getTaggedText(tagged),
+      query,
+    );
+
+    if (exactRanked.length) {
+      allRrfLists.push({
+        items: exactRanked.map(([, item]) => item),
+        key: taggedResultKey,
+      });
     }
   }
 

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -268,6 +268,41 @@ export function reciprocalRankFusion<T>(
 }
 
 // ---------------------------------------------------------------------------
+// Exact term match ranking (Phase 5 — MemPalace-inspired keyword boost)
+// ---------------------------------------------------------------------------
+
+/**
+ * Score candidates by exact query term overlap.
+ *
+ * Returns items sorted by number of exact term matches (descending).
+ * Used as an additional RRF list to boost results that contain query terms
+ * verbatim — important for proper nouns, file names, and technical terms
+ * that BM25's prefix matching + Porter stemming can miss or dilute.
+ *
+ * Terms are filtered through the standard stopword + single-char filter
+ * (same as `ftsQuery`), then matched case-insensitively via `includes()`.
+ */
+export function exactTermMatchRank<T>(
+  items: T[],
+  getText: (item: T) => string,
+  query: string,
+): T[] {
+  const terms = filterTerms(query).map((t) => t.toLowerCase());
+  if (!terms.length) return [];
+
+  const scored = items
+    .map((item) => {
+      const text = getText(item).toLowerCase();
+      const matches = terms.filter((t) => text.includes(t)).length;
+      return { item, matches };
+    })
+    .filter((s) => s.matches > 0)
+    .sort((a, b) => b.matches - a.matches);
+
+  return scored.map((s) => s.item);
+}
+
+// ---------------------------------------------------------------------------
 // LLM query expansion (Phase 4)
 // ---------------------------------------------------------------------------
 

--- a/packages/core/test/config.test.ts
+++ b/packages/core/test/config.test.ts
@@ -85,8 +85,9 @@ describe("LoreConfig — search schema", () => {
     expect(cfg.search.recallLimit).toBe(10);
     expect(cfg.search.queryExpansion).toBe(false);
     expect(cfg.search.embeddings.enabled).toBe(true);
-    expect(cfg.search.embeddings.model).toBe("voyage-code-3");
-    expect(cfg.search.embeddings.dimensions).toBe(1024);
+    expect(cfg.search.embeddings.provider).toBe("local");
+    expect(cfg.search.embeddings.model).toBe("BGESmallENV15");
+    expect(cfg.search.embeddings.dimensions).toBe(384);
   });
 
   test("search.ftsWeights can be customised", () => {
@@ -133,8 +134,8 @@ describe("LoreConfig — search schema", () => {
       search: { embeddings: { enabled: false } },
     });
     expect(cfg.search.embeddings.enabled).toBe(false);
-    expect(cfg.search.embeddings.model).toBe("voyage-code-3");
-    expect(cfg.search.embeddings.dimensions).toBe(1024);
+    expect(cfg.search.embeddings.model).toBe("BGESmallENV15");
+    expect(cfg.search.embeddings.dimensions).toBe(384);
   });
 
   test("search.embeddings model and dimensions can be customised", () => {
@@ -148,8 +149,9 @@ describe("LoreConfig — search schema", () => {
   });
 
   test("search.embeddings.dimensions rejects out-of-range values", () => {
+    // Min is 64, max is 2048
     expect(() =>
-      LoreConfig.parse({ search: { embeddings: { dimensions: 128 } } }),
+      LoreConfig.parse({ search: { embeddings: { dimensions: 32 } } }),
     ).toThrow();
     expect(() =>
       LoreConfig.parse({ search: { embeddings: { dimensions: 4096 } } }),

--- a/packages/core/test/embedding.test.ts
+++ b/packages/core/test/embedding.test.ts
@@ -83,14 +83,22 @@ describe("BLOB round-trip", () => {
 });
 
 describe("isAvailable", () => {
-  test("returns false without VOYAGE_API_KEY", () => {
-    // In test environment, VOYAGE_API_KEY should not be set
-    const original = process.env.VOYAGE_API_KEY;
-    delete process.env.VOYAGE_API_KEY;
+  test("returns true with default local provider (no API key needed)", () => {
     resetProvider(); // Clear cached provider so isAvailable re-evaluates
-    expect(isAvailable()).toBe(false);
-    if (original) process.env.VOYAGE_API_KEY = original;
+    // Default provider is "local" — fastembed doesn't need an API key.
+    // LocalProvider construction always succeeds; the dynamic import only
+    // happens on first embed() call, so isAvailable() is true.
+    expect(isAvailable()).toBe(true);
     resetProvider(); // Restore cached provider state
+  });
+
+  test("returns false when embeddings explicitly disabled", () => {
+    // We can't easily change config in tests, but verify the provider
+    // cache reset works correctly
+    resetProvider();
+    // After reset, re-evaluation with default config should still work
+    expect(isAvailable()).toBe(true);
+    resetProvider();
   });
 });
 
@@ -209,6 +217,83 @@ describe("vectorSearch", () => {
   });
 });
 
+describe("LocalProvider integration", () => {
+  const PROJECT = "/test/embedding/local";
+
+  beforeEach(() => {
+    db().query("DELETE FROM knowledge").run();
+    resetProvider();
+  });
+
+  // Model init can take ~350ms (cached) + ~150ms per embed.
+  // First-ever run downloads the model (~12s) — pre-download before running tests.
+  test(
+    "embed produces Float32Array vectors with 384 dimensions",
+    async () => {
+      const { embed } = await import("../src/embedding");
+      const [vec] = await embed(["test query for embedding"], "query");
+      expect(vec).toBeInstanceOf(Float32Array);
+      expect(vec.length).toBe(384);
+      // Vector should not be all zeros
+      const norm = Array.from(vec).reduce((sum, v) => sum + v * v, 0);
+      expect(norm).toBeGreaterThan(0);
+    },
+    15_000,
+  );
+
+  test(
+    "query and document embeddings have reasonable similarity",
+    async () => {
+      const { embed, cosineSimilarity } = await import("../src/embedding");
+      const [queryVec] = await embed(["database migration"], "query");
+      const [docVec] = await embed(["PostgreSQL database schema migration tool"], "document");
+      const [unrelatedVec] = await embed(["chocolate cake recipe with frosting"], "document");
+
+      const relevantSim = cosineSimilarity(queryVec, docVec);
+      const unrelatedSim = cosineSimilarity(queryVec, unrelatedVec);
+
+      // Relevant doc should have higher similarity than unrelated
+      expect(relevantSim).toBeGreaterThan(unrelatedSim);
+    },
+    15_000,
+  );
+
+  test(
+    "vectorSearch returns results using local embeddings",
+    async () => {
+      const { embed, toBlob, vectorSearch } = await import("../src/embedding");
+      const pid = ensureProject(PROJECT);
+      const now = Date.now();
+
+      // Embed and store 3 knowledge entries
+      const texts = [
+        "PostgreSQL database migration",
+        "React server components",
+        "Kubernetes deployment strategy",
+      ];
+      const vecs = await embed(texts, "document");
+
+      for (let i = 0; i < texts.length; i++) {
+        db()
+          .query(
+            "INSERT INTO knowledge (id, project_id, category, title, content, confidence, created_at, updated_at, embedding) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+          )
+          .run(`local-${i}`, pid, "test", `Entry ${i}`, texts[i], 1.0, now, now, toBlob(vecs[i]));
+      }
+
+      // Query for database-related content
+      const [queryVec] = await embed(["database schema changes"], "query");
+      const results = vectorSearch(queryVec, 3);
+
+      expect(results.length).toBe(3);
+      // The PostgreSQL entry should be most relevant
+      expect(results[0].id).toBe("local-0");
+      expect(results[0].similarity).toBeGreaterThan(0.3);
+    },
+    15_000,
+  );
+});
+
 describe("checkConfigChange", () => {
   const PROJECT = "/test/embedding/configchange";
 
@@ -227,8 +312,10 @@ describe("checkConfigChange", () => {
       .query("SELECT value FROM kv_meta WHERE key = 'lore:embedding_config'")
       .get() as { value: string } | null;
     expect(row).not.toBeNull();
-    expect(row!.value).toContain("voyage-code-3");
-    expect(row!.value).toContain("1024");
+    // Default provider is now "local" with BGESmallENV15:384
+    expect(row!.value).toContain("local");
+    expect(row!.value).toContain("BGESmallENV15");
+    expect(row!.value).toContain("384");
   });
 
   test("second call with same config returns false", () => {

--- a/packages/core/test/pattern-extract.test.ts
+++ b/packages/core/test/pattern-extract.test.ts
@@ -1,0 +1,294 @@
+import { describe, test, expect } from "bun:test";
+import { extractPatterns, type ExtractedPattern } from "../src/pattern-extract";
+
+describe("extractPatterns", () => {
+  // -----------------------------------------------------------------------
+  // Decision patterns
+  // -----------------------------------------------------------------------
+
+  describe("decided to use/switch to/go with/adopt", () => {
+    test("decided to use X", () => {
+      const results = extractPatterns(
+        "Team decided to use PostgreSQL for the main database.",
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0].category).toBe("decision");
+      expect(results[0].title).toBe("Decided to use PostgreSQL for the main database");
+      expect(results[0].content).toContain("decided to use PostgreSQL");
+    });
+
+    test("decided to switch to X", () => {
+      const results = extractPatterns(
+        "We decided to switch to Vite for faster builds.",
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0].title).toBe("Decided to use Vite for faster builds");
+    });
+
+    test("decided to go with X", () => {
+      const results = extractPatterns(
+        "The team decided to go with Redis for caching.",
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0].title).toBe("Decided to use Redis for caching");
+    });
+
+    test("decided to adopt X", () => {
+      const results = extractPatterns(
+        "We decided to adopt TypeScript across the codebase.",
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0].title).toBe("Decided to use TypeScript across the codebase");
+    });
+  });
+
+  describe("chose X over Y", () => {
+    test("basic chose over pattern", () => {
+      const results = extractPatterns(
+        "Chose PostgreSQL over MySQL for JSONB support.",
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0].category).toBe("decision");
+      expect(results[0].title).toBe("Chose PostgreSQL over MySQL for JSONB support");
+    });
+
+    test("chose with longer names", () => {
+      const results = extractPatterns(
+        "Team chose React Server Components over traditional SSR.",
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0].title).toBe(
+        "Chose React Server Components over traditional SSR",
+      );
+    });
+  });
+
+  describe("switched from X to Y", () => {
+    test("basic switched from/to", () => {
+      const results = extractPatterns(
+        "Switched from Webpack to esbuild for bundling.",
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0].category).toBe("decision");
+      expect(results[0].title).toBe("Switched from Webpack to esbuild for bundling");
+    });
+  });
+
+  describe("going with X because/for/due to", () => {
+    test("going with because", () => {
+      const results = extractPatterns(
+        "Going with Bun because it has built-in SQLite support.",
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0].category).toBe("decision");
+      expect(results[0].title).toBe("Going with Bun");
+    });
+
+    test("going with for", () => {
+      const results = extractPatterns(
+        "Going with zod for schema validation.",
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0].title).toBe("Going with zod");
+    });
+
+    test("going with due to", () => {
+      const results = extractPatterns(
+        "Going with FTS5 due to its Porter stemming support.",
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0].title).toBe("Going with FTS5");
+    });
+  });
+
+  describe("migrated/migrating to X", () => {
+    test("migrated to", () => {
+      const results = extractPatterns(
+        "Migrated to ESM modules across the project.",
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0].category).toBe("decision");
+      expect(results[0].title).toBe("Migrated to ESM modules across the project");
+    });
+
+    test("migrating from X to Y", () => {
+      const results = extractPatterns(
+        "Currently migrating from Jest to Bun's test runner.",
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0].title).toBe("Migrated to Bun's test runner");
+    });
+  });
+
+  describe("adopted X for/as/instead", () => {
+    test("adopted for", () => {
+      const results = extractPatterns(
+        "Adopted Prettier for code formatting.",
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0].category).toBe("decision");
+      expect(results[0].title).toBe("Adopted Prettier");
+    });
+
+    test("adopted as", () => {
+      const results = extractPatterns(
+        "Adopted UUIDv7 as the default ID format.",
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0].title).toBe("Adopted UUIDv7");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Preference patterns
+  // -----------------------------------------------------------------------
+
+  describe("prefers X over/to/instead of/rather than Y", () => {
+    test("prefers X over Y", () => {
+      const results = extractPatterns(
+        "User prefers tabs over spaces for indentation.",
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0].category).toBe("preference");
+      expect(results[0].title).toBe("Prefers tabs over spaces for indentation");
+    });
+
+    test("prefer X to Y — title normalizes connective to 'over'", () => {
+      const results = extractPatterns(
+        "We prefer explicit types to inference in public APIs.",
+      );
+      expect(results).toHaveLength(1);
+      // titleFn always uses "over" for consistency/dedup regardless of original connective
+      expect(results[0].title).toBe(
+        "Prefers explicit types over inference in public APIs",
+      );
+    });
+
+    test("prefers X rather than Y — title normalizes to 'over'", () => {
+      const results = extractPatterns(
+        "Team prefers named exports rather than default exports.",
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0].title).toBe(
+        "Prefers named exports over default exports",
+      );
+    });
+
+    test("prefer X instead of Y — title normalizes to 'over'", () => {
+      const results = extractPatterns(
+        "We prefer async/await instead of raw Promises.",
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0].title).toBe(
+        "Prefers async/await over raw Promises",
+      );
+    });
+  });
+
+  describe("typically use/prefer/go with X", () => {
+    test("team typically uses", () => {
+      const results = extractPatterns(
+        "Team typically use Conventional Commits for messages.",
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0].category).toBe("preference");
+      expect(results[0].title).toBe(
+        "Typically uses Conventional Commits for messages",
+      );
+    });
+
+    test("we usually prefer — matches both typically and prefers patterns", () => {
+      const results = extractPatterns(
+        "We usually prefer composition over inheritance.",
+      );
+      // Matches both "We usually prefer" (typically pattern) and
+      // "prefer composition over inheritance" (prefers pattern)
+      expect(results).toHaveLength(2);
+      const titles = results.map((r) => r.title);
+      expect(titles).toContain("Typically uses composition over inheritance");
+      expect(titles).toContain("Prefers composition over inheritance");
+    });
+
+    test("user always uses", () => {
+      const results = extractPatterns(
+        "User always use strict TypeScript settings.",
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0].title).toBe(
+        "Typically uses strict TypeScript settings",
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Edge cases
+  // -----------------------------------------------------------------------
+
+  describe("edge cases", () => {
+    test("no patterns found returns empty array", () => {
+      const results = extractPatterns(
+        "The session involved debugging a segfault in the native module.",
+      );
+      expect(results).toHaveLength(0);
+    });
+
+    test("empty string returns empty array", () => {
+      expect(extractPatterns("")).toHaveLength(0);
+    });
+
+    test("multiple patterns in one text", () => {
+      const results = extractPatterns(
+        "Team decided to use PostgreSQL for the database. " +
+          "Chose React over Vue for the frontend. " +
+          "User prefers dark mode over light mode.",
+      );
+      expect(results).toHaveLength(3);
+      const categories = results.map((r) => r.category);
+      expect(categories).toContain("decision");
+      expect(categories).toContain("preference");
+    });
+
+    test("deduplicates by title (case-insensitive)", () => {
+      const results = extractPatterns(
+        "Decided to use PostgreSQL for the DB. " +
+          "Later, decided to use PostgreSQL for the DB.",
+      );
+      // Both match the same pattern with identical captures → same title → deduped
+      expect(results).toHaveLength(1);
+    });
+
+    test("comma-terminated match", () => {
+      const results = extractPatterns(
+        "Decided to use Redis, which supports pub/sub natively.",
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0].title).toBe("Decided to use Redis");
+    });
+
+    test("end-of-line terminated match", () => {
+      const results = extractPatterns(
+        "Chose SQLite over PostgreSQL",
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0].title).toBe("Chose SQLite over PostgreSQL");
+    });
+
+    test("case-insensitive matching", () => {
+      const results = extractPatterns(
+        "DECIDED TO USE MongoDB for flexible schema.",
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0].title).toBe("Decided to use MongoDB for flexible schema");
+    });
+
+    test("content preserves original matched text", () => {
+      const results = extractPatterns(
+        "We chose Tailwind over Bootstrap for utility-first CSS.",
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0].content).toBe(
+        "chose Tailwind over Bootstrap for utility-first CSS.",
+      );
+    });
+  });
+});

--- a/packages/core/test/search.test.ts
+++ b/packages/core/test/search.test.ts
@@ -7,6 +7,7 @@ import {
   normalizeRank,
   reciprocalRankFusion,
   extractTopTerms,
+  exactTermMatchRank,
 } from "../src/search";
 
 describe("search", () => {
@@ -257,6 +258,81 @@ describe("search", () => {
 
       // With k=10, rank 0 → 1/(10+0) = 0.1
       expect(fused[0].score).toBeCloseTo(0.1, 4);
+    });
+  });
+
+  describe("exactTermMatchRank", () => {
+    const items = [
+      { id: "a", text: "Decided to use PostgreSQL for the main database" },
+      { id: "b", text: "CI pipeline runs on GitHub Actions with matrix builds" },
+      { id: "c", text: "PostgreSQL JSONB support enables flexible schema design" },
+      { id: "d", text: "React frontend uses server components" },
+    ];
+    const getText = (item: (typeof items)[number]) => item.text;
+
+    test("ranks items by number of exact term matches descending", () => {
+      const ranked = exactTermMatchRank(items, getText, "PostgreSQL database");
+      // "a" has both "PostgreSQL" and "database" → 2 matches
+      // "c" has "PostgreSQL" but not "database" → 1 match
+      expect(ranked.length).toBe(2);
+      expect(ranked[0].id).toBe("a");
+      expect(ranked[1].id).toBe("c");
+    });
+
+    test("excludes items with zero matches", () => {
+      const ranked = exactTermMatchRank(items, getText, "Kubernetes deployment");
+      expect(ranked.length).toBe(0);
+    });
+
+    test("case-insensitive matching", () => {
+      const ranked = exactTermMatchRank(items, getText, "postgresql jsonb");
+      expect(ranked.length).toBe(2);
+      // "c" has both "PostgreSQL" and "JSONB" → 2 matches
+      // "a" has "PostgreSQL" only → 1 match
+      expect(ranked[0].id).toBe("c");
+      expect(ranked[1].id).toBe("a");
+    });
+
+    test("filters stopwords from query", () => {
+      // "the" and "with" are stopwords — only "React" should match
+      const ranked = exactTermMatchRank(items, getText, "the React with components");
+      expect(ranked.length).toBe(1);
+      expect(ranked[0].id).toBe("d");
+    });
+
+    test("returns empty for all-stopword query", () => {
+      const ranked = exactTermMatchRank(items, getText, "the with from");
+      expect(ranked.length).toBe(0);
+    });
+
+    test("returns empty for empty items array", () => {
+      const ranked = exactTermMatchRank([], getText, "PostgreSQL");
+      expect(ranked.length).toBe(0);
+    });
+
+    test("preserves original item references", () => {
+      const ranked = exactTermMatchRank(items, getText, "React");
+      expect(ranked[0]).toBe(items[3]); // same object reference
+    });
+
+    test("handles single-item match", () => {
+      const ranked = exactTermMatchRank(items, getText, "GitHub Actions");
+      expect(ranked.length).toBe(1);
+      expect(ranked[0].id).toBe("b");
+    });
+
+    test("works with generic types", () => {
+      const tuples: Array<[string, string]> = [
+        ["k:1", "PostgreSQL migration script"],
+        ["k:2", "Redis cache layer"],
+      ];
+      const ranked = exactTermMatchRank(
+        tuples,
+        ([, text]) => text,
+        "PostgreSQL migration",
+      );
+      expect(ranked.length).toBe(1);
+      expect(ranked[0][0]).toBe("k:1");
     });
   });
 

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -1474,17 +1474,23 @@ export const LorePlugin: Plugin = async (ctx) => {
   // appears for a project, the init failed (see catch block below).
   process.stderr.write(`[lore] active: ${projectPath}\n`);
 
+  // Startup backfills — run once, idempotent.
+
+  // Retroactive metric backfill: compute r_compression and c_norm for
+  // distillations created before these diagnostics were added (pre-v12).
+  // Synchronous, DB-only — no API calls.
+  try {
+    distillation.backfillMetrics();
+  } catch (err) {
+    log.info("metric backfill failed:", err);
+  }
+
   // Background: backfill embeddings for entries that don't have one yet.
   // Fires once when embeddings are first enabled — subsequent entries
   // get embedded on create/update via ltm.ts and distillation.ts hooks.
-  if (embedding.isAvailable()) {
-    Promise.all([
-      embedding.backfillEmbeddings(),
-      embedding.backfillDistillationEmbeddings(),
-    ]).catch((err) => {
-      log.info("embedding backfill failed:", err);
-    });
-  }
+  embedding.runStartupBackfill().catch((err) => {
+    log.info("embedding backfill failed:", err);
+  });
 
   if (gatewayActive) {
     process.stderr.write(`[lore] gateway mode active — routing through ${gatewayBase}\n`);

--- a/packages/pi/src/index.ts
+++ b/packages/pi/src/index.ts
@@ -32,6 +32,7 @@ import {
   consumeCameOutOfIdle,
   curator,
   distillation,
+  embedding,
   ensureProject,
   exportToFile,
   exportLoreFile,
@@ -200,6 +201,22 @@ export default function lorePiExtension(pi: ExtensionAPI): void {
     } catch (err) {
       log.error("pi: lat-reader refresh error:", err);
     }
+
+    // Startup backfills — run once, idempotent.
+
+    // Retroactive metric backfill: compute r_compression and c_norm for
+    // distillations created before these diagnostics were added (pre-v12).
+    // Synchronous, DB-only — no API calls.
+    try {
+      distillation.backfillMetrics();
+    } catch (err) {
+      log.error("pi: metric backfill failed:", err);
+    }
+
+    // Background: backfill embeddings for entries that don't have one yet.
+    embedding.runStartupBackfill().catch((err) => {
+      log.error("pi: embedding backfill failed:", err);
+    });
 
     // Register the recall tool.
     registerRecallTool(pi, {


### PR DESCRIPTION
## Summary

- **Local embedding provider (P1)**: Adds `fastembed` (bge-small-en-v1.5, 384 dims) as default embedding provider. Runs fully on-device via ONNX Runtime — no API key, zero cost, ~150ms per query. Voyage and OpenAI remain available via `.lore.json` config. Existing embeddings auto-clear and re-embed on provider change via `checkConfigChange()`.

- **Exact keyword match boost (P2)**: Adds `exactTermMatchRank()` as an additional RRF signal in recall. Ranks candidates by verbatim query term overlap, boosting proper nouns, file names, and technical terms that BM25's Porter stemming may dilute. Zero-cost, additive-only.

- **Pattern extraction at distillation time (P3)**: 8 conservative regex patterns detect decision/preference language ("decided to use X", "chose X over Y", "prefers X over Y") in distilled observations and seed knowledge entries via `ltm.create()`. Runs in both `distillSegment()` and `metaDistill()`. Zero LLM cost, <1ms runtime.

## Migration

Existing Voyage users with no explicit `.lore.json` will silently switch to local embeddings. `checkConfigChange()` detects the fingerprint mismatch and auto-rebuilds all embeddings with the new provider. To stay on Voyage, add explicit config:

```json
{ "search": { "embeddings": { "provider": "voyage", "model": "voyage-code-3", "dimensions": 1024 } } }
```

## Test results

796 pass, 0 fail (including 42 new tests across 3 test files).