### PR TITLE
feat: unified startup backfill, retroactive metrics, and c_norm recall scoring

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -4,10 +4,44 @@
 
 ### Architecture
 
+<!-- lore:019e0238-28bb-72e4-8551-f308662d86c0 -->
+* **Embedding backfill unified at startup across all hosts**: P0 fix: moved embedding backfill from OpenCode-only (\`packages/opencode/src/index.ts:1480-1487\`) to a unified \`runStartupBackfill()\` in core. Both OpenCode and Pi now call this function at init, ensuring all adapters embed knowledge + distillations equally. Logs coverage stats to stderr (always visible, not gated on debug mode), making embedding failures immediately surfaced. Before: Pi had 0% distillation embedding coverage (~1,333 rows); after: both adapters trigger backfill identically.
+
 <!-- lore:019e0222-5198-7a02-bdda-f44d4b7b3f3b -->
-* **Embedding provider migration strategy with checkConfigChange**: Embedding config changes (provider swap, model/dimensions) are detected via fingerprint (\`provider:model:dimensions\`) stored in \`kv\_meta\` table. When \`checkConfigChange()\` runs at startup, it compares current config to stored fingerprint. On mismatch, all stale embeddings are cleared and re-generated. This allows seamless provider migrations: users can switch from Voyage to local embeddings without manual intervention — embeddings auto-rebuild with new provider. Default is now local (offline), but users can opt back to Voyage via \`.lore.json\` config.
+* **Embedding provider migration strategy with checkConfigChange**: Embedding provider migration strategy with checkConfigChange: Config changes (provider swap, model/dimensions) detected via fingerprint (\`provider:model:dimensions\`) in \`kv\_meta\` table. On startup, \`checkConfigChange()\` compares current config to stored fingerprint; on mismatch, stale embeddings clear and regenerate. Enables seamless migrations without manual intervention. Default is now local (fastembed, offline, 384 dims) via \`@xenova/transformers\`. Users can opt back to Voyage via \`.lore.json\` config. Local embeddings require no API keys; Voyage (1024 dims) available as premium option.
+
+<!-- lore:019e0236-1d10-7b16-abdc-a9c4505ce47a -->
+* **Gateway buffer-or-stream strategy for recall interception**: Gateway streaming responses have two paths: OpenAI protocol already buffers fully (free buffering cost), Anthropic protocol streams real-time. To inject recall tool interception universally, choose "buffer everything then decide": inject recall tool, accumulate full response, check for recall tool\_use. No recall → re-emit as synthetic SSE stream. Has recall → execute recall, build follow-up request with recall tool\_result (without recall in tools list), send upstream, forward clean response. Dissolves mixed tool\_use problem via self-contained requests. Tradeoff: buffering introduces 2-8s delay before first token on Anthropic streaming (acceptable for coding agent workflows where UX focuses on tool execution, not text streaming). Phase 2 optimization possible: selective buffering only when recall detected.
+
+### Decision
+
+<!-- lore:019e022f-7141-7356-954d-85ae6ff4e6d1 -->
+* **Embedding config fingerprint strategy enables zero-downtime provider migration**: Zero-downtime embedding provider migration via fingerprint (\`provider:model:dimensions\`) in \`kv\_meta\`. On config change, stale embeddings auto-clear + full backfill runs. Now covers both OpenCode and Pi adapters equally — \`runStartupBackfill()\` is the unified entry point. Enables seamless switching between Voyage (1024 dims) ↔ Local (384 dims) ↔ OpenAI (1536 dims). Coverage logging makes implicit silent migrations visible.
+
+<!-- lore:019e0238-28c2-7664-89f5-2cd25403f12b -->
+* **Quality-weighted RRF list for distillations using c\_norm**: P2 implementation: added a distillation quality RRF list to \`recall.ts\` that ranks candidates by \`c\_norm + (ageDays/90)\*0.1\`. Uniform segments (low c\_norm) score higher; old bursty segments lower. The list deduplicates across BM25+vector results and injects as an additional RRF list. Keeps existing relevance signals intact — quality is a mild secondary signal. Enables temporal clustering heuristic (discovered in diagnostic analysis) to modestly improve recall quality for memory segments with uneven conversation pacing.
 
 ### Gotcha
 
+<!-- lore:019e022f-7149-73dc-a105-d090a7cf1426 -->
+* **c\_norm temporal clustering signal defined but not used in recall scoring**: \`temporalCnorm()\` (temporal.ts:297–320) computes \[0,1] attention imbalance but only feeds distillation segmentation. NOT wired into recall search pipeline despite comment (line 289) mentioning "recall time-biasing" as future use case. Recency boost exists (recall.ts:368–379 re-sorts temporal results by created\_at DESC) but doesn't account for conversation time windows or clustering patterns. Opportunity: use c\_norm to weight temporal vs semantic relevance when query context is clustered vs evenly distributed.
+
+<!-- lore:019e022f-7139-7f0d-bc07-7d37fd122a18 -->
+* **Embedding backfill only runs in OpenCode adapter, not Pi**: Embedding backfill is now centralized in core \`runStartupBackfill()\` and called by both OpenCode and Pi adapters at startup. Pre-fix: Pi adapter had no backfill call, leaving all Pi-served projects with ~0% distillation embedding coverage (~1,333 rows). Fire-and-forget design hides failures — errors logged but not surfaced. Backfill depends on embedding provider availability; if no key is set, it silently no-ops. Coverage stats now logged to stderr at startup.
+
 <!-- lore:019e0222-519d-7e99-9436-5a2695ddb6c2 -->
 * **Silent Voyage-to-local migration for existing users without explicit config**: Users relying on implicit Voyage default (no \`.lore.json\`, just \`VOYAGE\_API\_KEY\` env var) will silently switch to local embeddings on upgrade. Embeddings auto-clear and re-embed, so no data loss, but they lose cloud provider quality (1024 dims → 384 dims). Risk is low for knowledge entries (negligible quality impact), but consider logging if \`VOYAGE\_API\_KEY\` is set but provider resolves to \`local\` — nudges power users they have an available option.
+
+### Pattern
+
+<!-- lore:019e022f-7145-7f2a-be4e-aada70a6d2e4 -->
+* **Diagnostic metrics r\_compression and c\_norm stored on distillations (schema v12)**: Diagnostic metrics \`r\_compression\` and \`c\_norm\` are now retroactively backfilled for pre-v12 rows via \`backfillMetrics()\`. This fills 2,863 NULL rows by loading source temporal messages and recomputing. Happens synchronously at startup. Metrics show: compression healthy (avg R≈9.9), temporal clustering mostly low (93% of segments c\_norm<0.15). New \`distillation.backfillMetrics()\` function handles edge cases gracefully (deleted sources, empty source\_ids).
+
+<!-- lore:019e0225-f018-78f2-9d1c-fe2a4c47ef9e -->
+* **Exact keyword matching boost in RRF pipeline**: RRF (Reciprocal Rank Fusion) search combines vector and keyword results. Exact keyword matches now receive a boost via \`keywordBoost\` parameter during ranking. This improves relevance for queries with specific technical terms that may not embed well (e.g., library names, acronyms). Boost is applied as a multiplier to keyword match scores before RRF combination. Controlled via search config; default boost enables better recall on technical/domain-specific knowledge.
+
+<!-- lore:019e0225-f01c-79fb-9f2b-c25a200ce6ed -->
+* **Pattern extraction at distillation time**: New \`pattern-extract\` module identifies and extracts regex-based patterns (code snippets, commands, structured data) during knowledge distillation. Extracted patterns are indexed separately, enabling targeted queries like "show me all shell commands" or "find all SQL queries". Patterns are stored as metadata and used in search ranking. Reduces noise in semantic search by providing explicit structure to unstructured conversation knowledge.
+
+<!-- lore:019e0238-28be-7892-98b8-07bdcda39d0c -->
+* **Retroactive metric backfill (P3) for pre-v12 distillations**: \`backfillMetrics()\` in \`distillation.ts\` computes missing \`r\_compression\` and \`c\_norm\` for rows with NULL metrics. Loads source temporal messages via \`source\_ids\` JSON array, computes compression ratio and temporal clustering from timestamps/tokens, UPDATEs the row. Idempotent — only touches NULL values. Gracefully skips pruned source messages. Runs synchronously at startup so P2 recall weighting has full historical data (fills 2,863 pre-v12 rows).

--- a/packages/core/src/distillation.ts
+++ b/packages/core/src/distillation.ts
@@ -803,3 +803,71 @@ export async function metaDistill(input: {
 
   return result;
 }
+
+// ---------------------------------------------------------------------------
+// Retroactive metric backfill
+// ---------------------------------------------------------------------------
+
+/**
+ * Backfill `r_compression` and `c_norm` for distillations that were created
+ * before schema v12 (or before PR #113 added the computation).
+ *
+ * For each distillation with NULL metrics, loads source temporal messages via
+ * `source_ids`, computes `compressionRatio()` and `temporalCnorm()`, and
+ * writes the values back. Skips rows where source messages have been pruned
+ * or source_ids is empty.
+ *
+ * Designed to run once at startup — idempotent (only touches NULL rows).
+ * Returns the number of rows updated.
+ */
+export function backfillMetrics(): number {
+  const rows = db()
+    .query(
+      "SELECT id, source_ids, token_count FROM distillations WHERE r_compression IS NULL",
+    )
+    .all() as Array<{
+    id: string;
+    source_ids: string;
+    token_count: number;
+  }>;
+
+  if (!rows.length) return 0;
+
+  const update = db().prepare(
+    "UPDATE distillations SET r_compression = ?, c_norm = ? WHERE id = ?",
+  );
+
+  let updated = 0;
+
+  for (const row of rows) {
+    const sourceIds = parseSourceIds(row.source_ids);
+    if (!sourceIds.length) continue;
+
+    // Load source temporal messages — they may have been pruned.
+    const placeholders = sourceIds.map(() => "?").join(",");
+    const sources = db()
+      .query(
+        `SELECT tokens, created_at FROM temporal_messages WHERE id IN (${placeholders})`,
+      )
+      .all(...sourceIds) as Array<{ tokens: number; created_at: number }>;
+
+    if (!sources.length) continue;
+
+    const sourceTokens = sources.reduce((sum, s) => sum + s.tokens, 0);
+    const timestamps = sources.map((s) => s.created_at);
+
+    const rComp = compressionRatio(row.token_count, sourceTokens);
+    const cNorm = temporal.temporalCnorm(timestamps);
+
+    update.run(rComp, cNorm, row.id);
+    updated++;
+  }
+
+  if (updated > 0) {
+    log.info(
+      `backfilled metrics for ${updated} distillations (${rows.length - updated} skipped — missing sources)`,
+    );
+  }
+
+  return updated;
+}

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -514,12 +514,73 @@ export function checkConfigChange(): boolean {
 }
 
 // ---------------------------------------------------------------------------
+// Startup backfill — single entry point for all hosts
+// ---------------------------------------------------------------------------
+
+/**
+ * Run all embedding backfills and log coverage stats.
+ *
+ * This is the canonical entry point that every host adapter (OpenCode, Pi,
+ * future ACP) should call once during init. It:
+ *   1. Detects config changes (provider swap) and clears stale embeddings
+ *   2. Backfills knowledge entries missing embeddings
+ *   3. Backfills non-archived distillations missing embeddings
+ *   4. Logs a one-line coverage summary to stderr (always visible, not gated)
+ *
+ * Fire-and-forget: callers should `.catch()` — embedding failures must not
+ * block plugin initialization.
+ */
+export async function runStartupBackfill(): Promise<void> {
+  if (!isAvailable()) return;
+
+  const knowledgeEmbedded = await backfillEmbeddings();
+  const distillationEmbedded = await backfillDistillationEmbeddings();
+
+  // Coverage stats — always log to stderr so the problem is visible.
+  const kTotal = (
+    db()
+      .query("SELECT COUNT(*) as n FROM knowledge WHERE confidence > 0.2")
+      .get() as { n: number }
+  ).n;
+  const kWithEmb = (
+    db()
+      .query(
+        "SELECT COUNT(*) as n FROM knowledge WHERE embedding IS NOT NULL AND confidence > 0.2",
+      )
+      .get() as { n: number }
+  ).n;
+  const dTotal = (
+    db()
+      .query(
+        "SELECT COUNT(*) as n FROM distillations WHERE archived = 0 AND observations != ''",
+      )
+      .get() as { n: number }
+  ).n;
+  const dWithEmb = (
+    db()
+      .query(
+        "SELECT COUNT(*) as n FROM distillations WHERE embedding IS NOT NULL AND archived = 0",
+      )
+      .get() as { n: number }
+  ).n;
+
+  const parts: string[] = [];
+  if (knowledgeEmbedded > 0 || distillationEmbedded > 0) {
+    parts.push(`backfilled ${knowledgeEmbedded} knowledge + ${distillationEmbedded} distillations`);
+  }
+  parts.push(
+    `coverage: knowledge ${kWithEmb}/${kTotal}, distillations ${dWithEmb}/${dTotal}`,
+  );
+  log.info(`embedding startup: ${parts.join("; ")}`);
+}
+
+// ---------------------------------------------------------------------------
 // Backfill — knowledge
 // ---------------------------------------------------------------------------
 
 /**
  * Embed all knowledge entries that are missing embeddings.
- * Called on startup when embeddings are first enabled.
+ * Called by `runStartupBackfill()`.
  * Also handles config changes: if provider/model/dimensions changed, clears
  * stale embeddings first, then re-embeds all entries.
  * Returns the number of entries embedded.

--- a/packages/core/src/recall.ts
+++ b/packages/core/src/recall.ts
@@ -38,6 +38,7 @@ type Distillation = {
   generation: number;
   created_at: number;
   session_id: string;
+  c_norm: number | null;
 };
 
 export type ScoredDistillation = Distillation & { rank: number };
@@ -130,8 +131,8 @@ function searchDistillationsLike(input: {
     .join(" AND ");
   const likeParams = terms.map((term) => `%${term}%`);
   const sql = input.sessionID
-    ? `SELECT id, observations, generation, created_at, session_id FROM distillations WHERE project_id = ? AND session_id = ? AND ${conditions} ORDER BY created_at DESC LIMIT ?`
-    : `SELECT id, observations, generation, created_at, session_id FROM distillations WHERE project_id = ? AND ${conditions} ORDER BY created_at DESC LIMIT ?`;
+    ? `SELECT id, observations, generation, created_at, session_id, c_norm FROM distillations WHERE project_id = ? AND session_id = ? AND ${conditions} ORDER BY created_at DESC LIMIT ?`
+    : `SELECT id, observations, generation, created_at, session_id, c_norm FROM distillations WHERE project_id = ? AND ${conditions} ORDER BY created_at DESC LIMIT ?`;
   const allParams = input.sessionID
     ? [input.pid, input.sessionID, ...likeParams, input.limit]
     : [input.pid, ...likeParams, input.limit];
@@ -152,13 +153,13 @@ function searchDistillationsScored(input: {
   if (q === EMPTY_QUERY) return [];
 
   const ftsSQL = input.sessionID
-    ? `SELECT d.id, d.observations, d.generation, d.created_at, d.session_id, rank
+    ? `SELECT d.id, d.observations, d.generation, d.created_at, d.session_id, d.c_norm, rank
        FROM distillation_fts f
        CROSS JOIN distillations d ON d.rowid = f.rowid
        WHERE distillation_fts MATCH ?
        AND d.project_id = ? AND d.session_id = ?
        ORDER BY rank LIMIT ?`
-    : `SELECT d.id, d.observations, d.generation, d.created_at, d.session_id, rank
+    : `SELECT d.id, d.observations, d.generation, d.created_at, d.session_id, d.c_norm, rank
        FROM distillation_fts f
        CROSS JOIN distillations d ON d.rowid = f.rowid
        WHERE distillation_fts MATCH ?
@@ -413,7 +414,7 @@ export async function runRecall(input: RecallInput): Promise<RecallResult> {
           .map((hit): TaggedResult | null => {
             const row = db()
               .query(
-                "SELECT id, observations, generation, created_at, session_id FROM distillations WHERE id = ?",
+                "SELECT id, observations, generation, created_at, session_id, c_norm FROM distillations WHERE id = ?",
               )
               .get(hit.id) as Distillation | null;
             if (!row) return null;
@@ -482,6 +483,57 @@ export async function runRecall(input: RecallInput): Promise<RecallResult> {
       }
     } catch (err) {
       log.info("recall: cross-project knowledge search failed:", err);
+    }
+  }
+
+  // Distillation quality list: rank distillation candidates by a quality score
+  // that combines temporal clustering (c_norm) and age. Segments with low c_norm
+  // (uniformly distributed timestamps) are considered higher quality than bursty
+  // segments (high c_norm). Among high-c_norm segments, recent ones are more
+  // likely relevant. This adds a mild signal — RRF naturally blends it with the
+  // BM25 and vector signals without overriding them.
+  {
+    const distillationCandidates: Array<{
+      tagged: TaggedResult;
+      key: string;
+      qualityScore: number;
+    }> = [];
+
+    for (const list of allRrfLists) {
+      for (const item of list.items) {
+        if (item.source !== "distillation") continue;
+        const key = `d:${item.item.id}`;
+        const d = item.item as ScoredDistillation;
+        const cNorm = d.c_norm ?? 0; // NULL → treat as uniform (best case)
+        // Quality score: lower c_norm is better. For high c_norm, recency
+        // partially compensates. Age is normalized to days (capped at 90).
+        const ageDays = Math.min(
+          (Date.now() - d.created_at) / 86_400_000,
+          90,
+        );
+        // score ∈ [0, ~1]: 0 = best quality (uniform + recent)
+        // c_norm dominates (0–1), age adds a mild 0–0.1 penalty
+        const score = cNorm + (ageDays / 90) * 0.1;
+        distillationCandidates.push({ tagged: item, key, qualityScore: score });
+      }
+    }
+
+    if (distillationCandidates.length > 1) {
+      // De-duplicate by key (same distillation may appear in BM25 + vector lists)
+      const seen = new Set<string>();
+      const unique = distillationCandidates.filter((c) => {
+        if (seen.has(c.key)) return false;
+        seen.add(c.key);
+        return true;
+      });
+
+      // Sort by quality: lowest score first (best quality)
+      unique.sort((a, b) => a.qualityScore - b.qualityScore);
+
+      allRrfLists.push({
+        items: unique.map((c) => c.tagged),
+        key: (r) => `d:${r.item.id}`,
+      });
     }
   }
 

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -1474,17 +1474,23 @@ export const LorePlugin: Plugin = async (ctx) => {
   // appears for a project, the init failed (see catch block below).
   process.stderr.write(`[lore] active: ${projectPath}\n`);
 
+  // Startup backfills — run once, idempotent.
+
+  // Retroactive metric backfill: compute r_compression and c_norm for
+  // distillations created before these diagnostics were added (pre-v12).
+  // Synchronous, DB-only — no API calls.
+  try {
+    distillation.backfillMetrics();
+  } catch (err) {
+    log.info("metric backfill failed:", err);
+  }
+
   // Background: backfill embeddings for entries that don't have one yet.
   // Fires once when embeddings are first enabled — subsequent entries
   // get embedded on create/update via ltm.ts and distillation.ts hooks.
-  if (embedding.isAvailable()) {
-    Promise.all([
-      embedding.backfillEmbeddings(),
-      embedding.backfillDistillationEmbeddings(),
-    ]).catch((err) => {
-      log.info("embedding backfill failed:", err);
-    });
-  }
+  embedding.runStartupBackfill().catch((err) => {
+    log.info("embedding backfill failed:", err);
+  });
 
   if (gatewayActive) {
     process.stderr.write(`[lore] gateway mode active — routing through ${gatewayBase}\n`);

--- a/packages/pi/src/index.ts
+++ b/packages/pi/src/index.ts
@@ -32,6 +32,7 @@ import {
   consumeCameOutOfIdle,
   curator,
   distillation,
+  embedding,
   ensureProject,
   exportToFile,
   exportLoreFile,
@@ -200,6 +201,22 @@ export default function lorePiExtension(pi: ExtensionAPI): void {
     } catch (err) {
       log.error("pi: lat-reader refresh error:", err);
     }
+
+    // Startup backfills — run once, idempotent.
+
+    // Retroactive metric backfill: compute r_compression and c_norm for
+    // distillations created before these diagnostics were added (pre-v12).
+    // Synchronous, DB-only — no API calls.
+    try {
+      distillation.backfillMetrics();
+    } catch (err) {
+      log.error("pi: metric backfill failed:", err);
+    }
+
+    // Background: backfill embeddings for entries that don't have one yet.
+    embedding.runStartupBackfill().catch((err) => {
+      log.error("pi: embedding backfill failed:", err);
+    });
 
     // Register the recall tool.
     registerRecallTool(pi, {


### PR DESCRIPTION
## Summary

- **P0: Unified embedding backfill** — Moved embedding backfill from OpenCode-only to a shared `runStartupBackfill()` in core. Both OpenCode and Pi adapters now call this at init, fixing near-zero embedding coverage (~0.5%) for Pi-served projects. Logs coverage stats to stderr at startup for immediate visibility.
- **P3: Retroactive metric backfill** — Added `backfillMetrics()` to compute `r_compression` and `c_norm` for ~2,863 pre-v12 distillations by loading source temporal messages. Idempotent, handles pruned sources gracefully. Runs synchronously at startup.
- **P2: Quality-weighted recall scoring** — Wired `c_norm` into recall by adding a distillation quality RRF list. Uniform segments (low c_norm) rank higher; old bursty segments rank lower via `c_norm + (ageDays/90) * 0.1`. Mild secondary signal that blends naturally with existing BM25 and vector relevance.

## Files Changed

| File | Change |
|---|---|
| `packages/core/src/embedding.ts` | Added `runStartupBackfill()` with coverage logging |
| `packages/core/src/distillation.ts` | Added `backfillMetrics()` for retroactive r_compression/c_norm |
| `packages/core/src/recall.ts` | Added c_norm to Distillation type, all SELECTs, and quality RRF list |
| `packages/opencode/src/index.ts` | Replaced inline backfill with core functions |
| `packages/pi/src/index.ts` | Added embedding + metric backfill calls |
| `.lore.md` | Updated project knowledge |

## Testing

- 796 tests pass, 0 failures
- Build TS errors are pre-existing (fastembed type issue on parent branch)