### PR TITLE
fix: pin @huggingface/hub@2.11.0 to avoid broken xetchunk-wasm workspace refs

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -27,7 +27,7 @@
 ### Gotcha
 
 <!-- lore:019e049c-b657-715d-99b2-9e055499008b -->
-* **Bun lockfile lacks overrides for transitive dependency fixes**: Bun doesn't support \`overrides\` field to force transitive dependency versions—but root \`package.json\` overrides DO work with \`bun install\`. Use overrides for transitive vulnerabilities that can't be fixed by bumping direct dependencies. Example: basic-ftp 5.3.1, tar 7.5.15, ip-address 10.2.0, fast-xml-parser 5.7.3. Major version bumps (tar 6→7) are low-risk if the direct dependent only uses stable APIs. Verify with \`bun audit\` after install.
+* **Bun lockfile lacks overrides for transitive dependency fixes**: Bun workspace transitive deps can't be overridden for build-only packages: Bun doesn't support \`overrides\` field to force transitive versions (unlike npm). Root \`package.json\` overrides work for direct deps but not nested chains. tar@6.2.1 vulnerability in fastembed@2.1.0 can't be patched without major version bump (7.x breaks API). Remaining 6 high-severity tar CVEs are accepted—fastembed doesn't extract untrusted archives in runtime. Transitive vulns in fastembed, onnxruntime-node chains require upstream package updates.
 
 <!-- lore:019e0490-cee2-7133-9657-0cd41dfa19fd -->
 * **Gateway system prompt changes don't directly bust cache but affect OpenCode budget**: System prompt changes don't directly bust cache but affect OpenCode budget: Gateway logs "system-prompt changed" when OpenCode modifies its system prompt. Gateway sessions show 0 busts despite prompt changes, but OpenCode sessions can bust indirectly when prompt size changes affect overhead calculations in \`tryFitStable\`. Large changes (8K+ shrinkage) can exceed 15% hysteresis buffer, triggering window rescans. System prompt changes are normal OpenCode behavior—monitor bust rates, not prompt change frequency.
@@ -40,6 +40,9 @@
 
 <!-- lore:019e0466-4b98-7135-a8f9-ad674552c503 -->
 * **OpenCode front-trims messages between turns causing pin-miss on absolute IDs**: OpenCode front-trims messages causing pin-miss on absolute IDs: Message array shifts between turns (compaction boundaries move, pruned outputs). Absolute message ID pinning fails when pinned ID disappears (\`pinnedIdx === -1\`). Fix: use offset-from-end pinning (\`pinnedRawCount + pinnedTotalCount\`), resilient to front-trimming.
+
+<!-- lore:019e04a5-77f0-742f-bb55-7b8393283d16 -->
+* **Published packages with jit workspace deps fail to install**: Published @loreai/opencode@0.13.3 includes fastembed@^2.1.0 as indirect dependency, which declares gearhash-jit@workspace:\* and @huggingface/blake3-jit@workspace:\*. These workspace refs can't resolve in npm/yarn consumers. The packages were created during a transitional phase where @mariozechner packages still had workspace deps. Updated versions (0.73.1+) should have resolved these, but published 0.13.3 is broken. Consumers must pin to working version or await next release.
 
 <!-- lore:019e0499-f66b-785d-b9b8-d15322b27947 -->
 * **Security vulnerabilities in esbuild and undici dependencies**: All 11 vulnerabilities (7 high, 4 moderate) resolved via: (1) Bumping @mariozechner/pi-ai and @mariozechner/pi-coding-agent to ^0.73.1 (fixes @anthropic-ai/sdk, uuid); (2) Adding root package.json overrides: basic-ftp→5.3.1, ip-address→10.2.0, fast-xml-parser→5.7.3, tar→7.5.15. GitHub Dependabot shows 0 alerts because it doesn't support bun.lock yet—use \`bun audit\` to verify locally. All 861 tests pass post-fix.

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
       "name": "@loreai/core",
       "version": "0.13.3",
       "dependencies": {
+        "@huggingface/hub": "2.11.0",
         "fastembed": "^2.1.0",
         "remark": "^15.0.1",
         "uuidv7": "^1.1.0",
@@ -75,6 +76,7 @@
     },
   },
   "overrides": {
+    "@huggingface/hub": "2.11.0",
     "basic-ftp": "5.3.1",
     "fast-xml-parser": "5.7.3",
     "ip-address": "10.2.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "overrides": {
     "basic-ftp": "5.3.1",
     "ip-address": "10.2.0",
-    "fast-xml-parser": "5.7.3"
+    "fast-xml-parser": "5.7.3",
+    "@huggingface/hub": "2.11.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,6 +23,7 @@
     "build": "bun run script/build.ts"
   },
   "dependencies": {
+    "@huggingface/hub": "2.11.0",
     "fastembed": "^2.1.0",
     "remark": "^15.0.1",
     "uuidv7": "^1.1.0",


### PR DESCRIPTION
## Summary

- **Pin `@huggingface/hub@2.11.0`** as a direct dependency of `@loreai/core` to prevent npm from resolving to `2.11.1`
- **Add root override** `@huggingface/hub: 2.11.0` for monorepo workspace

## Problem

`@huggingface/hub@2.11.1` added `@huggingface/xetchunk-wasm@0.0.4` as a dependency, which declares `gearhash-jit@workspace:*` and `@huggingface/blake3-jit@workspace:*` — unresolved workspace references accidentally published to npm. 

Since `fastembed@^2.1.0` (a dep of `@loreai/core`) depends on `@huggingface/hub@^2.7.1`, npm resolves to `2.11.1` and hits the broken workspace refs, making `@loreai/core` (and by extension `@loreai/opencode`) uninstallable for consumers.

## Fix

Pin `@huggingface/hub@2.11.0` directly in `@loreai/core`'s `package.json` so the constraint is **published** and consumers get the working version. `2.11.0` is the last version without `xetchunk-wasm`.

## Verification

| Check | Result |
|-------|--------|
| `bun test` | 861 pass, 0 fail |
| `bun run typecheck` | all 4 packages clean |
| `bun run build` | all 4 packages succeed |

## Note

This needs a new release to fix the published `@loreai/core@0.13.3`. The current published version remains broken until we cut a new version.