### PR TITLE
refactor(gateway): unified recall marker-and-expand strategy

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -4,79 +4,46 @@
 
 ### Architecture
 
-<!-- lore:019e049f-0178-7753-bd41-86b8974aeb27 -->
-* **Bun-first monorepo with 4-package workspace structure**: Monorepo uses Bun (>=1.2.0) as primary package manager with \`workspace: \["packages/\*"]\`. Four packages: @loreai/core (shared memory engine), @loreai/opencode (ships raw TS), @loreai/pi (Pi extension), @loreai/gateway (LLM proxy). Core is leaf dependency; others depend on core via \`workspace:\*\`. Uses \`bun.lock\` as canonical lockfile. Legacy \`pnpm-lock.yaml\` exists but is stale (missing workspace packages). CI uses \`bun --filter '\*'\` and \`bun pm pack\` for tarball generation.
-
-<!-- lore:019e0499-f65e-7ca8-bc7d-2b6a5104ebac -->
-* **Four-package workspace structure with pnpm**: Four-package workspace uses bun workspaces with four packages: \`packages/core\` (gradient system), \`packages/opencode\` (VS Code extension), \`packages/pi\` (terminal interface), \`packages/gateway\` (HTTP proxy). Lockfile is \`bun.lock\`. Dependencies declared with \`workspace:\*\` protocol. Bun overrides in root package.json control transitive vulnerabilities. GitHub Dependabot doesn't support bun.lock; use \`bun audit\` locally for vulnerability scanning.
-
-<!-- lore:019e049f-1486-7b73-8eb5-c48ec427b509 -->
-* **Monorepo structure with four workspace packages**: Four workspace packages: \`packages/core\` (core gradient library), \`packages/opencode\` (OpenCode AI assistant), \`packages/pi\` (personal intelligence), \`packages/gateway\` (API gateway). Uses pnpm workspace with lockfile v9. Root defines shared devDeps (TypeScript, esbuild, vitest). Each package has independent versions but shared build tooling. Package manager: pnpm v9.15.0, Node 18-22 supported.
-
-<!-- lore:019e049f-149c-7e61-ae3f-121a5b1b94c8 -->
-* **Monorepo uses pnpm workspaces with 4 core packages**: Monorepo structure: pnpm workspaces with 4 packages in \`packages/\` dir. Core packages: \`core\` (shared utilities), \`opencode\` (AI coding agent), \`pi\` (personal intelligence), \`gateway\` (API gateway). Uses pnpm 9.4+ (engines requirement) with Node 18+. Lockfile is \`pnpm-lock.yaml\` v9.0. All packages interdependent - core is foundation, others build layered functionality. Workspace pattern enables shared tooling while maintaining package boundaries.
-
-<!-- lore:019e049f-142f-7196-b036-cd5ef623f2df -->
-* **PNPM workspace with dual lockfiles for compatibility**: Uses pnpm as package manager with workspace pattern \`packages/\*\`. Maintains both pnpm-lock.yaml (primary) and package-lock.json (backup/compatibility). Root requires Node >=18.0.0, pnpm >=8.0.0. Workspace packages: core (types/utils), opencode (main agent), pi (planning), gateway (API). All packages use same TypeScript/build tooling versions for consistency.
+<!-- lore:019e0729-3187-7f8e-930b-e4f262e449d5 -->
+* **Recall marker round-trip pattern for cache-stable memory search**: Recall marker round-trip pattern for cache-stable memory search: Gateway recall uses 'Marker and Expand' pattern: response replaces tool\_use blocks with markers (\`📚 Searching \<scope> for "\<query>"…\`). Next request expands markers back to tool\_use + tool\_result pairs via \`expandRecallMarkers()\` using persistent \`RecallStore\` (Map keyed by \`scope:query\`). Keeps LLM view stable while client sees friendly text. For recall-only responses with follow-up, continuation content may be merged into same assistant message as marker, requiring message splitting during expansion to maintain valid tool call structure. Store has no TTL—cleaned when gradient evicts containing message.
 
 ### Decision
 
-<!-- lore:019e04a1-175f-769d-ac0c-020daa96d61e -->
-* **Switched from @sinclair/typebox@^0.34.41 to typebox@^1**: switched from @sinclair/typebox@^0.34.41 to typebox@^1.
+<!-- lore:019e04c0-e61b-79ca-b7e7-1a81ff6fa4ef -->
+* **Switched from \`@sinclair/typebox\` (v0.34.41) to new \`typebox\` package (v1**: Switched from \`@sinclair/typebox\` (v0.34.41) to new \`typebox\` package (v1.x) - old scoped package is deprecated.
 
 ### Gotcha
 
-<!-- lore:019e049c-b657-715d-99b2-9e055499008b -->
-* **Bun lockfile lacks overrides for transitive dependency fixes**: Bun workspace transitive deps can't be overridden for build-only packages: Bun doesn't support \`overrides\` field to force transitive versions (unlike npm). Root \`package.json\` overrides work for direct deps but not nested chains. tar@6.2.1 vulnerability in fastembed@2.1.0 can't be patched without major version bump (7.x breaks API). Remaining 6 high-severity tar CVEs are accepted—fastembed doesn't extract untrusted archives in runtime. Transitive vulns in fastembed, onnxruntime-node chains require upstream package updates.
+<!-- lore:019e0731-1637-7bad-ab1b-96322d445eea -->
+* **expandRecallMarkers must distinguish continuation text from mixed tool calls**: When splitting assistant messages containing markers, only split for continuation text after markers, not for tool\_use blocks from the same turn. Mixed-tools case: \`\[text, marker, tool\_use(Read), tool\_use(Bash)]\` should NOT split — the tool\_use blocks belong in the same assistant message. Recall-only continuation case: \`\[text, marker, continuation\_text]\` should split. The heuristic: check if content after the marker contains tool\_use blocks. If yes, it's mixed tools (no split). If only text/thinking content, it's follow-up continuation (split required).
 
-<!-- lore:019e0490-cee2-7133-9657-0cd41dfa19fd -->
-* **Gateway system prompt changes don't directly bust cache but affect OpenCode budget**: System prompt changes don't directly bust cache but affect OpenCode budget: Gateway logs "system-prompt changed" when OpenCode modifies its system prompt. Gateway sessions show 0 busts despite prompt changes, but OpenCode sessions can bust indirectly when prompt size changes affect overhead calculations in \`tryFitStable\`. Large changes (8K+ shrinkage) can exceed 15% hysteresis buffer, triggering window rescans. System prompt changes are normal OpenCode behavior—monitor bust rates, not prompt change frequency.
+<!-- lore:019e0730-9f84-744d-a367-9f3e34ee20da -->
+* **expandRecallMarkers split logic must distinguish continuation text from tool\_use blocks**: When expanding recall markers, only split assistant messages if content after marker is text/thinking blocks (continuation from follow-up), not tool\_use blocks (mixed tools case). Use \`hasNonToolContentAfter()\` to check - if content after marker contains tool\_use blocks, they belong in same assistant message. Only text content indicates recall-only follow-up continuation that needs splitting. Mixed tools case should preserve all tool\_use blocks in original assistant message.
 
-<!-- lore:019e0445-9ede-77ac-bf07-b4745feca17d -->
-* **Layer 0 cache busts are expected with OpenCode front-trimming**: Layer 0 cache busts expected with OpenCode front-trimming: At layer 0, gradient passes messages unchanged, so front message changes affect Anthropic cache. Distillation prefix appearing first-time causes one-time bust (won't repeat). Sessions escalate to layer 1 with \`maxLayer0Tokens\`, allowing \`tryFitStable\` to control window and eliminate busts. Observed 1.6% bust rate projected to 2% for 50-turn sessions.
+<!-- lore:019e0729-318f-7100-a8f0-7ad5ea5a3de2 -->
+* **Recall follow-up tool\_use/tool\_result pairing breaks on marker expansion**: Recall follow-up tool\_use/tool\_result pairing breaks when continuation text follows markers: In recall-only with follow-up, the client sees merged content: \`marker + continuation text\` as one assistant message. When \`expandRecallMarkers()\` expands the marker back to \`tool\_use\` and inserts \`tool\_result\`, the continuation text remains in the same assistant message after the tool\_use, violating Anthropic's expectation that tool\_use appears at message end. Fix: \`expandRecallMarkers()\` detects non-tool content after markers and splits the assistant message - one ending with tool\_use, one with continuation content, with synthetic tool\_result user message between them.
 
-<!-- lore:019e049f-0180-74b5-b8f4-6c42662fbcd1 -->
-* **Legacy pnpm-lock.yaml causes tool confusion**: Repo has both \`bun.lock\` (canonical) and stale \`pnpm-lock.yaml\` that only lists root importer, missing all workspace packages (core, opencode, pi, gateway). Security scanners or Dependabot may pick up wrong lockfile. The pnpm lockfile should be removed or kept in sync to avoid false dependency reports.
+<!-- lore:019e071a-608c-785d-9855-2b427b839fc5 -->
+* **SessionState recallStore must be initialized to new Map in constructor**: SessionState.recallStore must be explicitly initialized to \`new Map()\` in the constructor/factory. Without initialization, \`expandRecallMarkers()\` will fail when trying to call \`.get()\` on undefined recallStore. The store holds recall results keyed by \`${scope}:${query}\` format. Also add an upgrade guard for sessions created before the type change: \`if (!state.recallStore) state.recallStore = new Map()\` in \`getOrCreateSession()\`.
 
-<!-- lore:019e0466-4b98-7135-a8f9-ad674552c503 -->
-* **OpenCode front-trims messages between turns causing pin-miss on absolute IDs**: OpenCode front-trims messages causing pin-miss on absolute IDs: Message array shifts between turns (compaction boundaries move, pruned outputs). Absolute message ID pinning fails when pinned ID disappears (\`pinnedIdx === -1\`). Fix: use offset-from-end pinning (\`pinnedRawCount + pinnedTotalCount\`), resilient to front-trimming.
-
-<!-- lore:019e04a5-77f0-742f-bb55-7b8393283d16 -->
-* **Published packages with jit workspace deps fail to install**: Published @loreai/opencode@0.13.3 includes fastembed@^2.1.0 as indirect dependency, which declares gearhash-jit@workspace:\* and @huggingface/blake3-jit@workspace:\*. These workspace refs can't resolve in npm/yarn consumers. The packages were created during a transitional phase where @mariozechner packages still had workspace deps. Updated versions (0.73.1+) should have resolved these, but published 0.13.3 is broken. Consumers must pin to working version or await next release.
-
-<!-- lore:019e0499-f66b-785d-b9b8-d15322b27947 -->
-* **Security vulnerabilities in esbuild and undici dependencies**: All 11 vulnerabilities (7 high, 4 moderate) resolved via: (1) Bumping @mariozechner/pi-ai and @mariozechner/pi-coding-agent to ^0.73.1 (fixes @anthropic-ai/sdk, uuid); (2) Adding root package.json overrides: basic-ftp→5.3.1, ip-address→10.2.0, fast-xml-parser→5.7.3, tar→7.5.15. GitHub Dependabot shows 0 alerts because it doesn't support bun.lock yet—use \`bun audit\` to verify locally. All 861 tests pass post-fix.
-
-<!-- lore:019e049f-14a0-7b04-84ec-34da68cc7fe2 -->
-* **Security-flagged dependencies present: esbuild and undici**: Contains security-flagged packages: \`esbuild@0.23.1\` (bundler, commonly flagged), \`undici@5.28.4\` (HTTP client, frequent CVEs). Both are transitive deps via \`@hono/node-server\`. Also has \`cross-spawn@7.0.3\` (process spawning). Monitor these for security updates. Esbuild used for bundling, undici for HTTP in Hono server. Update Hono to get latest versions of these deps.
+<!-- lore:019e04c0-e6f1-7186-b13b-6dec842e693d -->
+* **Worker model validation rejects candidates with insufficient observation density**: Worker model validation rejects insufficiently thorough candidates: Worker model validation (\`packages/core/src/worker-model.ts:203\`) requires candidates to produce observations within ±50% of the reference model's line count. If a candidate (e.g., Haiku) produces too few lines, validation fails and clears the stored worker model entry, falling back to session model. Additionally, when all candidates fail, validation clears stale entries without logging which candidate was the reference or why—producing opaque errors. When debugging: check reference model observation\_count drift and candidate list completeness.
 
 ### Pattern
 
-<!-- lore:019e049c-410a-7dcc-b63b-5379acc378b8 -->
-* **Bun monorepo uses workspace protocol for internal deps**: Bun workspace uses \`workspace:\*\` protocol for internal package references, similar to pnpm. Root bunfig.toml configures workspace resolution. Packages reference each other (e.g. @loreai/pi depends on @loreai/core) using workspace protocol. External deps declared normally in each package's package.json. Bun.lock is text-based lockfile containing resolved versions and integrity hashes.
+<!-- lore:019e04c3-14db-7b73-90d9-550db7f85dfb -->
+* **C\_norm temporal clustering metric indicates message age distribution within distillation segments**: C\_norm temporal clustering metric: C\_norm (normalized variance of message existence weights) ranges 0–1, measuring timestamp distribution evenness within distillation segments. Computed at distillation.ts:649 via \`temporalCnorm()\`. Values near 0 indicate uniform age distribution (healthy segmentation). Non-zero values appear when segments contain messages with very different ages (e.g., idle-resume patterns). Used for time-gap segmentation quality assessment.
 
-<!-- lore:019e045f-2777-79f6-b22a-13431690182d -->
-* **Content-based cache fingerprinting matches Anthropic byte-identity behavior**: Content-based cache fingerprinting matches Anthropic byte-identity: Fingerprint uses \`role + text.slice(0, 30)\` instead of IDs. Function \`computeContentBasedFingerprint()\` extracts snippets from first 5 messages. Format: \`${layer}:${role}:${text.slice(0,30)}\` per message. Part text must be typed as \`string\` before \`.slice()\`. Reduces false positives from ~98% to ~7-9%; remaining busts are genuine window changes.
+<!-- lore:019e0731-8930-7f1a-8dfa-d675cddb16f2 -->
+* **expandRecallMarkers message splitting for valid conversation structure**: When expanding recall markers, \`expandRecallMarkers()\` detects assistant messages with non-tool content after markers (continuation from recall-only follow-up) and splits them to maintain valid Anthropic conversation structure. Split occurs when content after marker contains text/thinking blocks rather than tool\_use blocks. Result: assistant message truncated at marker with tool\_use, synthetic user message with tool\_result, new assistant message with continuation. Mixed-tools case (tool\_use blocks after marker) doesn't split - stays in same message.
 
-<!-- lore:019e049e-15de-7b80-8d2b-001640cf92ce -->
-* **Dependency updates via external package upgrades**: Workspace uses external @mariozechner packages that bundle their own dependencies. Security fixes require updating these packages rather than direct dependency updates. The pi-ai and pi-coding-agent packages control esbuild, undici, and basic-ftp versions. Monitor their releases for vulnerability patches. Direct \`pnpm audit --fix\` won't work for bundled deps—must update the wrapper packages.
-
-<!-- lore:019e049d-2ae0-7fcb-b04f-4d28cb4655d1 -->
-* **Four-package coordinated versioning and publishing**: All 4 packages must be version-bumped and published together: @loreai/core, @loreai/gateway, @loreai/opencode, @loreai/pi. They share the same version number (e.g. 0.13.3) and are published as a coordinated release. Use \`pnpm changeset\` to bump all packages simultaneously. Publishing pipeline expects all 4 packages to be available at the same version - missing any package breaks the release.
-
-<!-- lore:019e049d-2ad3-7008-adab-e7706a7c0556 -->
-* **Monorepo publishing workflow with pnpm**: All 4 workspace packages publish together at same version using \`pnpm publish -r\` from root. Packages auto-increment version in lockstep. Publishing workflow: run \`pnpm publish -r\`, verify all packages at target version with \`pnpm view\`, close GitHub issue. All packages (core, opencode, pi, gateway) maintain version parity across releases.
-
-<!-- lore:019e049f-0185-7eca-9bcc-85859145660b -->
-* **Node 22.5+ required, esbuild 0.25.12 dev-only**: Core/pi require Node >=22.5, opencode/gateway require Bun >=1.2.0. CI uses Node 24 + Bun latest. esbuild@0.25.12 is root devDependency only (used by \`script/build.ts\`), not shipped to consumers. Heavy transitive deps from fastembed→onnxruntime-node. undici@7.25.0 only via pi's dev deps (not shipped). All security-relevant packages (tar@6.2.1, semver@7.7.4, etc.) are patched versions.
-
-<!-- lore:019e0483-8a09-7626-80cd-f1f1f136b63a -->
-* **Projected stable cache bust rates after hysteresis tuning**: Projected stable cache bust rates with 15% hysteresis: Achieved 1.6% cache bust rate (1/63 turns) in testing with 15% hysteresis and offset-from-end pinning. Single bust from unavoidable one-time distillation prefix appearance. Pin-overflow events eliminated (0 vs 4 with 10% hysteresis). Projected 50-turn opus session: ~2% bust rate, ~$5.30 cost. Legitimate content changes don't repeat in same conversation.
-
-<!-- lore:019e0442-6979-7219-a153-0d39b4b92879 -->
-* **tryFit backward window scanning algorithm**: tryFit backward window scanning with hysteresis: \`tryFit()\` backward scans for layers 1-3. \`tryFitStable()\` uses offset-from-end pinning resilient to host front-trimming. Pin validity uses high-water mark budget with 15% hysteresis to absorb EMA overhead drift and dedup token changes. 15% hysteresis eliminated pin-overflow events (4→0 in testing).
+<!-- lore:019e070d-194a-7992-9a8e-727882ce8336 -->
+* **stripToolOutputs replaces verbose tool outputs with compact annotations**: Function at gradient.ts:908-920 operates on LorePart arrays, replacing completed tool output content with compact annotations via \`toolStripAnnotation()\`. Annotations include tool name, line count, error detection, and up to 5 file paths. Example: \`\[output omitted — read: 150 lines, paths: src/foo.ts — use recall for details]\`. Used by gradient layers 2-3 for token reduction while preserving tool call structure. Does NOT remove messages or affect any cache fingerprinting.
 
 ### Preference
 
-<!-- lore:019e0494-ed1c-7272-9628-f1f1811ca68e -->
-* **Prefers updates over creates**: prefer updates over creates,
+<!-- lore:019e04c1-7826-7356-8101-3b6260be6dc8 -->
+* **Prefers non-reasoning models over avoid wasted thinking tokens**: prefers non-reasoning models to avoid wasted thinking tokens.
+
+<!-- lore:019e072f-bbb5-7390-bae5-4646b40dce47 -->
+* **Prefers to always send tool call and result blocks (not marker text) over the Anthropic API to keep cache and context intact**: prefers to always send tool call and result blocks (not marker text) to the Anthropic API to keep cache and context intact.

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -100,10 +100,12 @@ import {
   hasRecallToolUse,
   hasOtherToolUse,
   clientHasRecallTool,
-  isPendingRecallValid,
-  injectPendingRecall,
   buildRecallFollowUp,
-  stripRecallFromResponse,
+  buildRecallMarker,
+  recallStoreKey,
+  expandRecallMarkers,
+  cleanupRecallStore,
+  replaceRecallWithMarker,
 } from "./recall";
 
 // ---------------------------------------------------------------------------
@@ -298,17 +300,15 @@ function getOrCreateSession(
       lastRequestTime: Date.now(),
       messageCount: 0,
       turnsSinceCuration: 0,
+      recallStore: new Map(),
     };
     sessions.set(sessionID, state);
   }
   state.lastRequestTime = Date.now();
 
-  // Lazy cleanup: discard expired pending recall on access
-  if (state.pendingRecall && !isPendingRecallValid(state.pendingRecall)) {
-    log.warn(
-      `lazy cleanup: discarding expired pending recall for session ${sessionID.slice(0, 16)}`,
-    );
-    state.pendingRecall = undefined;
+  // Ensure recallStore exists (upgrade from older session state)
+  if (!state.recallStore) {
+    state.recallStore = new Map();
   }
 
   return state;
@@ -483,44 +483,46 @@ function buildStreamingResponse(
               recallContext.sessionState.sessionID,
             );
 
+            const scope = input.scope ?? "all";
+
+            // Store recall result for marker round-trip expansion
+            const storeKey = recallStoreKey(input.query, scope);
+            const position = resp.content.indexOf(recallBlock);
+            recallContext.sessionState.recallStore.set(storeKey, {
+              toolUseId: recallBlock.id,
+              input,
+              position,
+              result,
+            });
+
+            // Emit marker text block in place of the suppressed recall block
+            const markerText = buildRecallMarker(input.query, scope);
+            const markerIdx = recallAccum.clientBlockCount();
+            const syntheticMarker = [
+              formatSSEEvent("content_block_start", JSON.stringify({
+                type: "content_block_start",
+                index: markerIdx,
+                content_block: { type: "text", text: "" },
+              })),
+              formatSSEEvent("content_block_delta", JSON.stringify({
+                type: "content_block_delta",
+                index: markerIdx,
+                delta: { type: "text_delta", text: markerText },
+              })),
+              formatSSEEvent("content_block_stop", JSON.stringify({
+                type: "content_block_stop",
+                index: markerIdx,
+              })),
+            ].join("");
+            controller.enqueue(encoder.encode(syntheticMarker));
+
             if (recallAccum.hasOtherTools()) {
-              // Case 2: mixed tools — store pending, forward held-back events
-              const position = resp.content.indexOf(recallBlock);
-              recallContext.sessionState.pendingRecall = {
-                toolUseId: recallBlock.id,
-                input,
-                position,
-                result,
-                timestamp: Date.now(),
-              };
+              // Forward held-back events, close stream
               log.info(
-                `recall (stream, mixed): stored pending result for session ` +
+                `recall (stream, mixed): stored result for session ` +
                   `${recallContext.sessionState.sessionID.slice(0, 16)}`,
               );
 
-              // Emit a synthetic "[Searching memory...]" text block after all
-              // other tool blocks. The accumulator already re-indexed other
-              // tools to fill the gap, so this goes at clientBlockCount.
-              const searchingIdx = recallAccum.clientBlockCount();
-              const syntheticCase2 = [
-                formatSSEEvent("content_block_start", JSON.stringify({
-                  type: "content_block_start",
-                  index: searchingIdx,
-                  content_block: { type: "text", text: "" },
-                })),
-                formatSSEEvent("content_block_delta", JSON.stringify({
-                  type: "content_block_delta",
-                  index: searchingIdx,
-                  delta: { type: "text_delta", text: "\n\n[Searching memory...]" },
-                })),
-                formatSSEEvent("content_block_stop", JSON.stringify({
-                  type: "content_block_stop",
-                  index: searchingIdx,
-                })),
-              ].join("");
-              controller.enqueue(encoder.encode(syntheticCase2));
-
-              // Forward the held-back message_delta + message_stop
               const heldBack = recallAccum.heldBackEvents();
               if (heldBack) {
                 controller.enqueue(encoder.encode(heldBack));
@@ -528,39 +530,17 @@ function buildStreamingResponse(
 
               controller.close();
 
-              // Post-stream: use stripped response for temporal storage
-              const cleanResp = stripRecallFromResponse(resp);
-              onComplete(cleanResp);
+              // Post-stream: store response with marker text (not raw tool_use)
+              const markerResp = replaceRecallWithMarker(resp);
+              onComplete(markerResp);
               return;
             }
 
-            // Case 1: recall-only — send follow-up, pipe continuation
+            // Recall-only — send follow-up, pipe continuation
             log.info(
               `recall (stream, only): executing follow-up for session ` +
                 `${recallContext.sessionState.sessionID.slice(0, 16)}`,
             );
-
-            // Emit a synthetic "[Searching memory...]" text block at the
-            // suppressed recall index so the client sees a natural indicator
-            // during the pause while the recall executes.
-            const searchingIndex = recallAccum.clientBlockCount();
-            const syntheticBlock = [
-              formatSSEEvent("content_block_start", JSON.stringify({
-                type: "content_block_start",
-                index: searchingIndex,
-                content_block: { type: "text", text: "" },
-              })),
-              formatSSEEvent("content_block_delta", JSON.stringify({
-                type: "content_block_delta",
-                index: searchingIndex,
-                delta: { type: "text_delta", text: "\n\n[Searching memory...]" },
-              })),
-              formatSSEEvent("content_block_stop", JSON.stringify({
-                type: "content_block_stop",
-                index: searchingIndex,
-              })),
-            ].join("");
-            controller.enqueue(encoder.encode(syntheticBlock));
 
             const followUp = buildRecallFollowUp(
               recallContext.modifiedReq,
@@ -568,11 +548,32 @@ function buildStreamingResponse(
               result,
               recallBlock,
             );
-            const followUpResponse = await forwardToUpstream(
-              followUp,
-              recallContext.config,
-              undefined,
-              recallContext.cacheOptions,
+            let followUpResponse: Response;
+            try {
+              followUpResponse = await forwardToUpstream(
+                followUp,
+                recallContext.config,
+                undefined,
+                recallContext.cacheOptions,
+              );
+            } catch (fetchErr) {
+              log.error(
+                `recall follow-up fetch error for session ${recallContext.sessionState.sessionID.slice(0, 16)}:`,
+                fetchErr,
+              );
+              const heldBack = recallAccum.heldBackEvents();
+              if (heldBack) {
+                controller.enqueue(encoder.encode(heldBack));
+              }
+              controller.close();
+              const markerResp = replaceRecallWithMarker(resp);
+              onComplete(markerResp);
+              return;
+            }
+
+            log.info(
+              `recall follow-up response: status=${followUpResponse.status} ` +
+                `hasBody=${!!followUpResponse.body} session=${recallContext.sessionState.sessionID.slice(0, 16)}`,
             );
 
             if (!followUpResponse.ok) {
@@ -586,22 +587,21 @@ function buildStreamingResponse(
                 controller.enqueue(encoder.encode(heldBack));
               }
               controller.close();
-              const cleanResp = stripRecallFromResponse(resp);
-              onComplete(cleanResp);
+              const markerResp = replaceRecallWithMarker(resp);
+              onComplete(markerResp);
               return;
             }
 
             // Pipe the continuation stream into the same HTTP response.
             // Suppress message_start (client already has one) and re-index
             // content blocks to continue from where the client left off.
-            // +1 accounts for the synthetic "[Searching memory...]" block.
-            // Use clientBlockCount (not recallBlockIndex) — this is the number
-            // of blocks the client has already seen, so continuation blocks
-            // start at clientBlockCount + 1 (for the synthetic block).
+            // +1 accounts for the synthetic marker block.
             const blockOffset = recallAccum.clientBlockCount() + 1;
             const contReader = followUpResponse.body!.getReader();
+            let contEventCount = 0;
 
             for await (const { event: contEvent, data: contData } of parseSSEStream(contReader)) {
+              contEventCount++;
               if (contEvent === "message_start") {
                 // Suppress — client already received one
                 continue;
@@ -634,19 +634,18 @@ function buildStreamingResponse(
               controller.enqueue(encoder.encode(forwarded));
             }
 
+            log.info(
+              `recall follow-up stream complete: ${contEventCount} events piped, ` +
+                `session=${recallContext.sessionState.sessionID.slice(0, 16)}`,
+            );
+
             controller.close();
 
-            // Post-stream: accumulate the continuation for temporal storage.
-            // We use resp (original) + continuation for a complete picture,
-            // but for simplicity just store the continuation response since
-            // it's what the model actually produced for the client.
-            // The continuation accumulator was not wired — use the original
-            // response's pre-recall content + continuation's content.
-            // For now, call onComplete with the original response so at least
-            // the pre-recall content is stored. The continuation's text is
-            // visible to the client but not separately stored — acceptable
-            // since temporal storage captures the full conversation on next turn.
-            onComplete(resp);
+            // Post-stream: store response with marker text for temporal storage.
+            // The marker replaces the raw tool_use, so future turns can
+            // round-trip the marker ↔ tool_use/tool_result correctly.
+            const markerResp = replaceRecallWithMarker(resp);
+            onComplete(markerResp);
             return;
           }
         }
@@ -1079,25 +1078,18 @@ async function handleConversationTurn(
   // Track session model for worker model discovery
   lastSeenSessionModel = req.model;
 
-  // --- Inject pending recall from previous turn (Case 2: mixed tools) ---
-  if (sessionState.pendingRecall) {
-    if (isPendingRecallValid(sessionState.pendingRecall)) {
-      const injected = injectPendingRecall(req, sessionState.pendingRecall);
-      if (injected) {
-        log.info(
-          `injected pending recall result into request for session ${sessionID.slice(0, 16)}`,
-        );
-      } else {
-        log.warn(
-          `failed to inject pending recall — conversation structure mismatch`,
-        );
-      }
-    } else {
-      log.warn(
-        `discarding expired pending recall for session ${sessionID.slice(0, 16)}`,
+  // --- Expand recall markers from previous turns ---
+  // Scan all assistant messages for marker text blocks and restore them
+  // to tool_use + tool_result pairs before forwarding upstream.
+  if (sessionState.recallStore.size > 0) {
+    const expanded = expandRecallMarkers(req, sessionState.recallStore);
+    if (expanded) {
+      log.info(
+        `expanded recall markers for session ${sessionID.slice(0, 16)}`,
       );
     }
-    sessionState.pendingRecall = undefined;
+    // Clean up orphaned store entries (markers evicted by gradient)
+    cleanupRecallStore(req, sessionState.recallStore);
   }
 
   log.info(
@@ -1292,30 +1284,33 @@ async function handleConversationTurn(
       sessionState.sessionID,
     );
 
+    // Store recall result for marker round-trip expansion
+    const storeKey = recallStoreKey(input.query, input.scope ?? "all");
+    const position = resp.content.indexOf(recallBlock);
+    sessionState.recallStore.set(storeKey, {
+      toolUseId: recallBlock.id,
+      input,
+      position,
+      result,
+    });
+
+    // Replace recall tool_use with marker text in the response
+    const markerResp = replaceRecallWithMarker(resp);
+
     if (hasOtherToolUse(resp)) {
-      // Case 2: recall + other tools — store pending, strip recall from response
-      const position = resp.content.indexOf(recallBlock);
-      sessionState.pendingRecall = {
-        toolUseId: recallBlock.id,
-        input,
-        position,
-        result,
-        timestamp: Date.now(),
-      };
+      // Mixed tools — return response with marker replacing recall tool_use
       log.info(
-        `recall (non-stream, mixed): stored pending result for session ${sessionState.sessionID.slice(0, 16)}`,
+        `recall (non-stream, mixed): stored result for session ${sessionState.sessionID.slice(0, 16)}`,
       );
-      const cleanResp = stripRecallFromResponse(resp);
-      postResponse(req, cleanResp, sessionState, config);
-      return nonStreamHttpResponse(cleanResp);
+      postResponse(req, markerResp, sessionState, config);
+      return nonStreamHttpResponse(markerResp);
     }
 
-    // Case 1: recall-only — send follow-up request
+    // Recall-only — send follow-up request for seamless UX
     log.info(
       `recall (non-stream, only): executing follow-up for session ${sessionState.sessionID.slice(0, 16)}`,
     );
     const followUp = buildRecallFollowUp(modifiedReq, resp, result, recallBlock);
-    // Strip recall from the follow-up tools (already done by buildRecallFollowUp)
     const followUpResponse = await forwardToUpstream(
       followUp,
       config,
@@ -1328,10 +1323,9 @@ async function handleConversationTurn(
       log.error(
         `recall follow-up upstream error: ${followUpResponse.status} ${errorBody.slice(0, 500)}`,
       );
-      // Fall back to the original response without recall
-      const cleanResp = stripRecallFromResponse(resp);
-      postResponse(req, cleanResp, sessionState, config);
-      return nonStreamHttpResponse(cleanResp);
+      // Fall back to response with marker (no continuation)
+      postResponse(req, markerResp, sessionState, config);
+      return nonStreamHttpResponse(markerResp);
     }
 
     const continuationResp = await accumulateNonStreamResponse(followUpResponse);

--- a/packages/gateway/src/recall.ts
+++ b/packages/gateway/src/recall.ts
@@ -1,15 +1,19 @@
 /**
  * Gateway recall interception — transparent memory search for any client.
  *
- * Injects a `recall` tool into upstream requests and handles the response
- * transparently. Two strategies based on whether recall is the only tool:
+ * Uses a unified "Marker and Expand" strategy:
  *
- *  - **Case 1 (recall-only)**: "Pause and Continue" — pause client stream,
- *    execute recall, send follow-up request, resume streaming in the same
- *    HTTP response.
- *  - **Case 2 (mixed tools)**: "Strip and Inject" — suppress recall blocks
- *    from the client stream, execute recall in background, inject the result
- *    into the next request from the client.
+ *  1. **On response (to client):** The recall `tool_use` block is replaced
+ *     with a human-readable marker text block
+ *     (`📚 Searching <scope> for "<query>"…`). The recall is executed
+ *     internally and the result is stored in session state.
+ *
+ *  2. **On request (from client):** Marker text blocks in the conversation
+ *     are expanded back into the original `tool_use` + `tool_result` pairs
+ *     before forwarding upstream.
+ *
+ *  For recall-only responses, a follow-up call is still made internally
+ *  so the model can continue in the same HTTP response (seamless UX).
  *
  * All recall execution delegates to `runRecall()` from `@loreai/core`.
  */
@@ -28,7 +32,7 @@ import type {
   GatewayResponse,
   GatewayToolUseBlock,
   GatewayMessage,
-  PendingRecall,
+  RecallStore,
 } from "./translate/types";
 
 // ---------------------------------------------------------------------------
@@ -59,15 +63,205 @@ export const RECALL_GATEWAY_TOOL: GatewayTool = {
 export const RECALL_TOOL_NAME = "recall";
 
 // ---------------------------------------------------------------------------
-// Pending recall state (cross-request, Case 2)
+// Marker utilities — human-readable text ↔ recall tool round-trip
 // ---------------------------------------------------------------------------
 
-/** TTL for pending recall results — discard after 60 seconds. */
-const PENDING_RECALL_TTL_MS = 60_000;
+/** Scope → human-readable label for marker text. */
+const SCOPE_LABELS: Record<string, string> = {
+  all: "all archives",
+  session: "session history",
+  project: "project archives",
+  knowledge: "knowledge base",
+};
 
-/** Check whether a pending recall is still valid (within TTL). */
-export function isPendingRecallValid(pending: PendingRecall): boolean {
-  return Date.now() - pending.timestamp < PENDING_RECALL_TTL_MS;
+/** Reverse: label → scope enum. */
+const LABEL_TO_SCOPE: Record<string, RecallScope> = Object.fromEntries(
+  Object.entries(SCOPE_LABELS).map(([k, v]) => [v, k as RecallScope]),
+);
+
+/** Map a recall scope to a human-readable label. */
+export function scopeToLabel(scope: string = "all"): string {
+  return SCOPE_LABELS[scope] ?? SCOPE_LABELS.all;
+}
+
+/** Map a human-readable label back to a scope enum value. */
+export function labelToScope(label: string): RecallScope {
+  return LABEL_TO_SCOPE[label] ?? "all";
+}
+
+/**
+ * Build a marker text string for a recall tool call.
+ *
+ * Format: `📚 Searching <scope-label> for "<query>"…`
+ */
+export function buildRecallMarker(query: string, scope: string = "all"): string {
+  return `📚 Searching ${scopeToLabel(scope)} for "${query}"…`;
+}
+
+/** Regex to parse a recall marker back into query + scope. */
+const MARKER_REGEX = /📚 Searching (.+?) for "(.+?)"…/;
+
+/**
+ * Parse a recall marker text block, returning query and scope if valid.
+ * Returns null if the text doesn't match the marker format.
+ */
+export function parseRecallMarker(
+  text: string,
+): { query: string; scope: RecallScope } | null {
+  const match = MARKER_REGEX.exec(text);
+  if (!match) return null;
+  return {
+    query: match[2],
+    scope: labelToScope(match[1]),
+  };
+}
+
+/** Derive a store key from query + scope. */
+export function recallStoreKey(query: string, scope: string = "all"): string {
+  return `${scope}:${query}`;
+}
+
+// ---------------------------------------------------------------------------
+// Marker expansion — restore tool_use + tool_result from markers on inbound
+// ---------------------------------------------------------------------------
+
+/**
+ * Find recall marker text blocks in the conversation and expand them
+ * back into tool_use + tool_result pairs for the upstream API.
+ *
+ * Scans ALL assistant messages (not just the last one) since markers
+ * persist across turns until gradient evicts the message.
+ *
+ * Mutates the request in-place. Returns true if any expansion was performed.
+ */
+export function expandRecallMarkers(
+  req: GatewayRequest,
+  store: RecallStore,
+): boolean {
+  let expanded = false;
+
+  // Iterate forward; when we splice messages the index is adjusted.
+  for (let i = 0; i < req.messages.length; i++) {
+    const msg = req.messages[i];
+    if (msg.role !== "assistant") continue;
+
+    // Find the first (should be only) recall marker in this message.
+    // We process one marker per assistant message per pass; the outer
+    // loop will revisit if there's more than one (rare).
+    let markerIdx = -1;
+    let parsed: { query: string; scope: RecallScope } | null = null;
+    for (let j = 0; j < msg.content.length; j++) {
+      const block = msg.content[j];
+      if (block.type !== "text") continue;
+      parsed = parseRecallMarker(block.text);
+      if (parsed) {
+        markerIdx = j;
+        break;
+      }
+    }
+
+    if (markerIdx < 0 || !parsed) continue;
+
+    const key = recallStoreKey(parsed.query, parsed.scope);
+    const stored = store.get(key);
+    if (!stored) continue; // No stored result — leave marker as-is
+
+    // Check if there's non-tool content AFTER the marker in this message.
+    // This happens when recall-only follow-up piped continuation content
+    // (text blocks) into the same assistant message. Tool_use blocks after
+    // the marker are from the same turn (mixed tools) and stay together.
+    const afterMarker = msg.content.slice(markerIdx + 1);
+    const hasContinuationAfter = afterMarker.length > 0 &&
+      afterMarker.some((b) => b.type !== "tool_use");
+
+    // Replace marker with tool_use
+    msg.content[markerIdx] = {
+      type: "tool_use",
+      id: stored.toolUseId,
+      name: RECALL_TOOL_NAME,
+      input: stored.input,
+    };
+
+    // Truncate assistant message at the tool_use (remove continuation)
+    if (hasContinuationAfter) {
+      msg.content.length = markerIdx + 1;
+    }
+
+    // Build synthetic tool_result user message
+    const toolResultMsg: GatewayMessage = {
+      role: "user",
+      content: [
+        {
+          type: "tool_result",
+          toolUseId: stored.toolUseId,
+          content: stored.result,
+        },
+      ],
+    };
+
+    if (hasContinuationAfter) {
+      // Split: insert tool_result user message + continuation assistant
+      // message after the current assistant message.
+      const continuationMsg: GatewayMessage = {
+        role: "assistant",
+        content: afterMarker,
+      };
+      req.messages.splice(i + 1, 0, toolResultMsg, continuationMsg);
+      // Skip past the two newly inserted messages
+      i += 2;
+    } else {
+      // No split needed — insert tool_result into the following user message.
+      // Prepend (unshift) so the recall result appears before existing
+      // tool_results — matching the tool_use order in the assistant message.
+      const nextMsg = req.messages[i + 1];
+      if (nextMsg?.role === "user") {
+        nextMsg.content.unshift({
+          type: "tool_result",
+          toolUseId: stored.toolUseId,
+          content: stored.result,
+        });
+      } else {
+        // No following user message — insert a synthetic one
+        req.messages.splice(i + 1, 0, toolResultMsg);
+        i += 1;
+      }
+    }
+
+    expanded = true;
+  }
+
+  return expanded;
+}
+
+/**
+ * Clean up orphaned recall store entries whose markers no longer
+ * appear in the conversation (e.g. gradient evicted the turn).
+ */
+export function cleanupRecallStore(
+  req: GatewayRequest,
+  store: RecallStore,
+): void {
+  if (store.size === 0) return;
+
+  // Collect all marker keys still present in assistant messages
+  const activeKeys = new Set<string>();
+  for (const msg of req.messages) {
+    if (msg.role !== "assistant") continue;
+    for (const block of msg.content) {
+      if (block.type !== "text") continue;
+      const parsed = parseRecallMarker(block.text);
+      if (parsed) {
+        activeKeys.add(recallStoreKey(parsed.query, parsed.scope));
+      }
+    }
+  }
+
+  // Remove entries not referenced by any current marker
+  for (const key of store.keys()) {
+    if (!activeKeys.has(key)) {
+      store.delete(key);
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -212,90 +406,28 @@ export function buildRecallFollowUp(
 }
 
 // ---------------------------------------------------------------------------
-// Pending recall injection (Case 2: next request enrichment)
+// Response content rewriting — replace recall tool_use with marker text
 // ---------------------------------------------------------------------------
 
 /**
- * Inject a pending recall result into the current request.
+ * Build a GatewayResponse with recall tool_use blocks replaced by marker text.
  *
- * Finds the last assistant message in `req.messages`, inserts the recall
- * tool_use block at the recorded position, and inserts a tool_result block
- * into the following user message.
- *
- * Mutates the request in-place for efficiency. Returns true if injection
- * was performed, false if the conversation structure didn't match
- * (e.g., no trailing assistant→user pair).
+ * Used for both recall-only and mixed-tools cases to produce a response
+ * where the client sees human-readable markers instead of tool call mechanics.
  */
-export function injectPendingRecall(
-  req: GatewayRequest,
-  pending: PendingRecall,
-): boolean {
-  const messages = req.messages;
-  if (messages.length < 2) return false;
-
-  // Find the last assistant message followed by a user message.
-  // The pending recall was from the previous turn's assistant response.
-  let assistantIdx = -1;
-  for (let i = messages.length - 2; i >= 0; i--) {
-    if (
-      messages[i].role === "assistant" &&
-      messages[i + 1]?.role === "user"
-    ) {
-      assistantIdx = i;
-      break;
-    }
-  }
-
-  if (assistantIdx < 0) {
-    log.warn("injectPendingRecall: no assistant→user pair found");
-    return false;
-  }
-
-  const assistantMsg = messages[assistantIdx];
-  const userMsg = messages[assistantIdx + 1];
-
-  // Insert recall tool_use into assistant message at the recorded position.
-  // Clamp to content length in case the message was modified by gradient.
-  const insertPos = Math.min(pending.position, assistantMsg.content.length);
-  const recallToolUse: GatewayToolUseBlock = {
-    type: "tool_use",
-    id: pending.toolUseId,
-    name: RECALL_TOOL_NAME,
-    input: pending.input,
-  };
-  assistantMsg.content.splice(insertPos, 0, recallToolUse);
-
-  // Insert recall tool_result into the user message.
-  // Add it at the beginning alongside any other tool_results.
-  userMsg.content.unshift({
-    type: "tool_result",
-    toolUseId: pending.toolUseId,
-    content: pending.result,
-  });
-
-  // Strip recall from tools list for this request
-  req.tools = req.tools.filter((t) => t.name !== RECALL_TOOL_NAME);
-
-  return true;
-}
-
-// ---------------------------------------------------------------------------
-// Response content stripping (Case 2: remove recall from response)
-// ---------------------------------------------------------------------------
-
-/**
- * Build a GatewayResponse with recall tool_use blocks removed.
- *
- * Used for Case 2 to produce a clean response for `postResponse` storage
- * that excludes the gateway-internal recall blocks.
- */
-export function stripRecallFromResponse(
+export function replaceRecallWithMarker(
   resp: GatewayResponse,
 ): GatewayResponse {
   return {
     ...resp,
-    content: resp.content.filter(
-      (b) => !(b.type === "tool_use" && b.name === RECALL_TOOL_NAME),
-    ),
+    content: resp.content.map((b) => {
+      if (b.type === "tool_use" && b.name === RECALL_TOOL_NAME) {
+        const input = b.input as Record<string, unknown>;
+        const query = typeof input.query === "string" ? input.query : "";
+        const scope = (input.scope as string) ?? "all";
+        return { type: "text" as const, text: buildRecallMarker(query, scope) };
+      }
+      return b;
+    }),
   };
 }

--- a/packages/gateway/src/translate/types.ts
+++ b/packages/gateway/src/translate/types.ts
@@ -139,22 +139,23 @@ export type GatewayResponse = {
 };
 
 // ---------------------------------------------------------------------------
-// Pending recall state (cross-request, gateway recall interception)
+// Recall store (cross-request, gateway recall interception)
 // ---------------------------------------------------------------------------
 
-/** Pending recall result stored between requests (Case 2: mixed tools). */
-export type PendingRecall = {
-  /** tool_use ID from the suppressed block. */
+/** Stored recall result for marker-based round-trip expansion. */
+export type StoredRecall = {
+  /** The tool_use ID to reconstruct in the upstream request. */
   toolUseId: string;
-  /** The original recall input (for conversation history reconstruction). */
+  /** Original recall input (query + scope). */
   input: { query: string; scope?: string };
   /** Position (content block index) in the original assistant message. */
   position: number;
   /** Executed recall result (formatted markdown). */
   result: string;
-  /** Timestamp for TTL-based cleanup. */
-  timestamp: number;
 };
+
+/** Map from marker key (`${scope}:${query}`) → stored recall data. */
+export type RecallStore = Map<string, StoredRecall>;
 
 // ---------------------------------------------------------------------------
 // Session state — per-session tracking for Lore pipeline integration
@@ -172,6 +173,6 @@ export type SessionState = {
   messageCount: number;
   /** Turns since last curation run — triggers background curation. */
   turnsSinceCuration: number;
-  /** Pending recall result from previous turn (Case 2: mixed tool interception). */
-  pendingRecall?: PendingRecall;
+  /** Stored recall results for marker-based round-trip expansion. */
+  recallStore: RecallStore;
 };

--- a/packages/gateway/test/recall-stream.test.ts
+++ b/packages/gateway/test/recall-stream.test.ts
@@ -15,10 +15,12 @@ import {
 } from "../src/stream/anthropic";
 import {
   findRecallToolUse,
-  injectPendingRecall,
-  stripRecallFromResponse,
+  replaceRecallWithMarker,
+  expandRecallMarkers,
+  recallStoreKey,
+  buildRecallMarker,
 } from "../src/recall";
-import type { GatewayRequest, GatewayToolUseBlock } from "../src/translate/types";
+import type { GatewayRequest, GatewayToolUseBlock, RecallStore } from "../src/translate/types";
 
 // ---------------------------------------------------------------------------
 // Helpers: build SSE events matching Anthropic's streaming format
@@ -661,25 +663,32 @@ describe("Case 2 integration — mixed tools end-to-end", () => {
     expect(recallBlock!.id).toBe("toolu_recall_1");
     expect(recallBlock!.name).toBe("recall");
 
-    // --- Step 4: Strip recall from response for post-processing ---
-    const cleanResp = stripRecallFromResponse(resp);
-    expect(cleanResp.content).toHaveLength(2); // text + Read only
-    expect(cleanResp.content.every((b) => {
+    // --- Step 4: Replace recall with marker in response for post-processing ---
+    const markerResp = replaceRecallWithMarker(resp);
+    expect(markerResp.content).toHaveLength(3); // text + marker text + Read
+    expect(markerResp.content[1].type).toBe("text");
+    expect((markerResp.content[1] as { text: string }).text).toBe(
+      buildRecallMarker("gateway architecture", "all"),
+    );
+    // No recall tool_use blocks remain
+    expect(markerResp.content.every((b) => {
       if (b.type === "tool_use") return (b as GatewayToolUseBlock).name !== "recall";
       return true;
     })).toBe(true);
 
-    // --- Step 5: Simulate pending recall storage ---
-    const pendingRecall = {
+    // --- Step 5: Store recall result in recallStore ---
+    const store: RecallStore = new Map();
+    const storeKey = recallStoreKey("gateway architecture", "all");
+    store.set(storeKey, {
       toolUseId: recallBlock!.id,
       input: { query: "gateway architecture" },
       position: accum.recallBlockIndex(),
       result: "Found: gateway uses Anthropic protocol, recall interception is transparent",
-      timestamp: Date.now(),
-    };
+    });
 
-    // --- Step 6: Inject into next request ---
-    // Simulate the next request: client sends tool_result for Read
+    // --- Step 6: Expand markers in next request ---
+    // Simulate the next request: client sends tool_result for Read,
+    // and the assistant message contains the marker text (not raw tool_use)
     const nextReq: GatewayRequest = {
       model: "claude-sonnet-4-20250514",
       protocol: "anthropic",
@@ -690,7 +699,8 @@ describe("Case 2 integration — mixed tools end-to-end", () => {
           role: "assistant",
           content: [
             { type: "text", text: "Let me search memory and read the file." },
-            // Client only saw Read at index 1 (recall was suppressed)
+            { type: "text", text: buildRecallMarker("gateway architecture", "all") },
+            // Client only saw Read at index 1 (recall was suppressed, marker emitted)
             { type: "tool_use", id: "toolu_read_1", name: "Read", input: { path: "/src/index.ts" } },
           ],
         },
@@ -711,10 +721,10 @@ describe("Case 2 integration — mixed tools end-to-end", () => {
       rawHeaders: {},
     };
 
-    const injected = injectPendingRecall(nextReq, pendingRecall);
-    expect(injected).toBe(true);
+    const expanded = expandRecallMarkers(nextReq, store);
+    expect(expanded).toBe(true);
 
-    // Assistant message should now have recall tool_use at position 1
+    // Assistant message should now have recall tool_use replacing the marker
     const assistantMsg = nextReq.messages[1];
     expect(assistantMsg.content).toHaveLength(3); // text + recall + Read
     expect(assistantMsg.content[0].type).toBe("text");
@@ -724,17 +734,13 @@ describe("Case 2 integration — mixed tools end-to-end", () => {
     expect(assistantMsg.content[2].type).toBe("tool_use");
     expect((assistantMsg.content[2] as GatewayToolUseBlock).name).toBe("Read");
 
-    // User message should have recall tool_result prepended before Read tool_result
+    // User message should have recall tool_result inserted before Read tool_result
     const userMsg = nextReq.messages[2];
     expect(userMsg.content).toHaveLength(2);
     expect(userMsg.content[0].type).toBe("tool_result");
     expect((userMsg.content[0] as { toolUseId: string }).toolUseId).toBe("toolu_recall_1");
     expect(userMsg.content[1].type).toBe("tool_result");
     expect((userMsg.content[1] as { toolUseId: string }).toolUseId).toBe("toolu_read_1");
-
-    // Recall tool should be stripped from tools list
-    expect(nextReq.tools).toHaveLength(1);
-    expect(nextReq.tools[0].name).toBe("Read");
   });
 
   test("pending recall with multiple other tools — correct injection order", () => {
@@ -771,20 +777,22 @@ describe("Case 2 integration — mixed tools end-to-end", () => {
     expect(blockStarts[1].data.index).toBe(1); // Read re-indexed from 2
     expect(blockStarts[2].data.index).toBe(2); // Bash re-indexed from 3
 
-    // Extract and build pending
+    // Extract recall and store result
     const resp = accum.getResponse();
     const recallBlock = findRecallToolUse(resp);
     expect(recallBlock).toBeDefined();
 
-    const pendingRecall = {
+    const store: RecallStore = new Map();
+    const storeKey = recallStoreKey("patterns", "all");
+    store.set(storeKey, {
       toolUseId: recallBlock!.id,
       input: { query: "patterns" },
       position: accum.recallBlockIndex(),
       result: "Found patterns info",
-      timestamp: Date.now(),
-    };
+    });
 
-    // Next request: client provides tool_results for Read and Bash
+    // Next request: client provides tool_results for Read and Bash,
+    // assistant message has marker text instead of recall tool_use
     const nextReq: GatewayRequest = {
       model: "claude-sonnet-4-20250514",
       protocol: "anthropic",
@@ -795,6 +803,7 @@ describe("Case 2 integration — mixed tools end-to-end", () => {
           role: "assistant",
           content: [
             { type: "text", text: "I'll search, read, and run." },
+            { type: "text", text: buildRecallMarker("patterns", "all") },
             { type: "tool_use", id: "toolu_read_2", name: "Read", input: {} },
             { type: "tool_use", id: "toolu_bash_1", name: "Bash", input: { command: "ls" } },
           ],
@@ -818,10 +827,10 @@ describe("Case 2 integration — mixed tools end-to-end", () => {
       rawHeaders: {},
     };
 
-    const injected = injectPendingRecall(nextReq, pendingRecall);
-    expect(injected).toBe(true);
+    const expanded = expandRecallMarkers(nextReq, store);
+    expect(expanded).toBe(true);
 
-    // Assistant: text + recall(inserted at position 1) + Read + Bash
+    // Assistant: text + recall(replacing marker) + Read + Bash
     const assistantMsg = nextReq.messages[1];
     expect(assistantMsg.content).toHaveLength(4);
     expect((assistantMsg.content[1] as GatewayToolUseBlock).name).toBe("recall");
@@ -834,9 +843,5 @@ describe("Case 2 integration — mixed tools end-to-end", () => {
     expect((userMsg.content[0] as { toolUseId: string }).toolUseId).toBe("toolu_recall_2");
     expect((userMsg.content[1] as { toolUseId: string }).toolUseId).toBe("toolu_read_2");
     expect((userMsg.content[2] as { toolUseId: string }).toolUseId).toBe("toolu_bash_1");
-
-    // recall stripped from tools
-    expect(nextReq.tools).toHaveLength(2);
-    expect(nextReq.tools.every((t) => t.name !== "recall")).toBe(true);
   });
 });

--- a/packages/gateway/test/recall.test.ts
+++ b/packages/gateway/test/recall.test.ts
@@ -16,16 +16,22 @@ import {
   hasRecallToolUse,
   hasOtherToolUse,
   clientHasRecallTool,
-  isPendingRecallValid,
   buildRecallFollowUp,
-  injectPendingRecall,
-  stripRecallFromResponse,
+  buildRecallMarker,
+  parseRecallMarker,
+  scopeToLabel,
+  labelToScope,
+  recallStoreKey,
+  expandRecallMarkers,
+  cleanupRecallStore,
+  replaceRecallWithMarker,
 } from "../src/recall";
 import type {
   GatewayResponse,
   GatewayRequest,
   GatewayToolUseBlock,
-  PendingRecall,
+  RecallStore,
+  StoredRecall,
 } from "../src/translate/types";
 
 // ---------------------------------------------------------------------------
@@ -75,15 +81,14 @@ function makeRecallToolUse(
   };
 }
 
-function makePendingRecall(
-  overrides: Partial<PendingRecall> = {},
-): PendingRecall {
+function makeStoredRecall(
+  overrides: Partial<StoredRecall> = {},
+): StoredRecall {
   return {
     toolUseId: "toolu_recall_1",
     input: { query: "test query", scope: "all" },
     position: 1,
     result: "## Recall Results\n* some result",
-    timestamp: Date.now(),
     ...overrides,
   };
 }
@@ -189,27 +194,89 @@ describe("clientHasRecallTool", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Pending recall TTL
+// Marker utilities
 // ---------------------------------------------------------------------------
 
-describe("isPendingRecallValid", () => {
-  test("returns true for fresh pending recall", () => {
-    const pending = makePendingRecall({ timestamp: Date.now() });
-    expect(isPendingRecallValid(pending)).toBe(true);
+describe("scopeToLabel / labelToScope", () => {
+  test("maps all scopes to labels", () => {
+    expect(scopeToLabel("all")).toBe("all archives");
+    expect(scopeToLabel("session")).toBe("session history");
+    expect(scopeToLabel("project")).toBe("project archives");
+    expect(scopeToLabel("knowledge")).toBe("knowledge base");
   });
 
-  test("returns false for expired pending recall", () => {
-    const pending = makePendingRecall({
-      timestamp: Date.now() - 120_000, // 2 minutes ago
-    });
-    expect(isPendingRecallValid(pending)).toBe(false);
+  test("defaults unknown scope to 'all archives'", () => {
+    expect(scopeToLabel("unknown")).toBe("all archives");
+    expect(scopeToLabel()).toBe("all archives");
   });
 
-  test("returns true for recall just within TTL", () => {
-    const pending = makePendingRecall({
-      timestamp: Date.now() - 50_000, // 50 seconds ago (TTL is 60s)
-    });
-    expect(isPendingRecallValid(pending)).toBe(true);
+  test("reverse maps labels back to scopes", () => {
+    expect(labelToScope("all archives")).toBe("all");
+    expect(labelToScope("session history")).toBe("session");
+    expect(labelToScope("project archives")).toBe("project");
+    expect(labelToScope("knowledge base")).toBe("knowledge");
+  });
+
+  test("defaults unknown label to 'all'", () => {
+    expect(labelToScope("unknown label")).toBe("all");
+  });
+});
+
+describe("buildRecallMarker", () => {
+  test("builds correct marker with default scope", () => {
+    expect(buildRecallMarker("test query")).toBe(
+      '📚 Searching all archives for "test query"…',
+    );
+  });
+
+  test("builds correct marker with explicit scope", () => {
+    expect(buildRecallMarker("auth flow", "session")).toBe(
+      '📚 Searching session history for "auth flow"…',
+    );
+    expect(buildRecallMarker("config", "project")).toBe(
+      '📚 Searching project archives for "config"…',
+    );
+    expect(buildRecallMarker("patterns", "knowledge")).toBe(
+      '📚 Searching knowledge base for "patterns"…',
+    );
+  });
+});
+
+describe("parseRecallMarker", () => {
+  test("parses a valid marker", () => {
+    const result = parseRecallMarker(
+      '📚 Searching all archives for "gradient cache"…',
+    );
+    expect(result).toEqual({ query: "gradient cache", scope: "all" });
+  });
+
+  test("parses markers with different scopes", () => {
+    expect(
+      parseRecallMarker('📚 Searching session history for "auth"…'),
+    ).toEqual({ query: "auth", scope: "session" });
+    expect(
+      parseRecallMarker('📚 Searching project archives for "config"…'),
+    ).toEqual({ query: "config", scope: "project" });
+    expect(
+      parseRecallMarker('📚 Searching knowledge base for "patterns"…'),
+    ).toEqual({ query: "patterns", scope: "knowledge" });
+  });
+
+  test("returns null for non-marker text", () => {
+    expect(parseRecallMarker("hello world")).toBeNull();
+    expect(parseRecallMarker("[Searching memory...]")).toBeNull();
+    expect(parseRecallMarker("")).toBeNull();
+  });
+});
+
+describe("recallStoreKey", () => {
+  test("creates key from query and scope", () => {
+    expect(recallStoreKey("test", "all")).toBe("all:test");
+    expect(recallStoreKey("test", "session")).toBe("session:test");
+  });
+
+  test("defaults scope to all", () => {
+    expect(recallStoreKey("test")).toBe("all:test");
   });
 });
 
@@ -280,17 +347,21 @@ describe("buildRecallFollowUp", () => {
 });
 
 // ---------------------------------------------------------------------------
-// injectPendingRecall
+// expandRecallMarkers
 // ---------------------------------------------------------------------------
 
-describe("injectPendingRecall", () => {
-  test("injects recall into assistant→user pair", () => {
+describe("expandRecallMarkers", () => {
+  test("expands marker in assistant message back to tool_use + tool_result", () => {
+    const store: RecallStore = new Map();
+    store.set(recallStoreKey("test query", "all"), makeStoredRecall());
+
     const req = makeRequest([
       { role: "user", content: [{ type: "text", text: "hello" }] },
       {
         role: "assistant",
         content: [
           { type: "text", text: "I'll read the file." },
+          { type: "text", text: buildRecallMarker("test query", "all") },
           { type: "tool_use", id: "toolu_1", name: "Read", input: { path: "/a" } },
         ],
       },
@@ -302,31 +373,44 @@ describe("injectPendingRecall", () => {
       },
     ]);
 
-    const pending = makePendingRecall({ position: 1 });
-    const result = injectPendingRecall(req, pending);
+    const result = expandRecallMarkers(req, store);
 
     expect(result).toBe(true);
 
-    // Assistant message should now have recall tool_use at position 1
+    // Assistant message should now have recall tool_use replacing the marker
     const assistant = req.messages[1];
     expect(assistant.content).toHaveLength(3);
     expect(assistant.content[1].type).toBe("tool_use");
     expect((assistant.content[1] as GatewayToolUseBlock).name).toBe("recall");
 
-    // User message should have recall tool_result prepended
+    // User message should have recall tool_result inserted
     const user = req.messages[2];
     expect(user.content).toHaveLength(2);
     expect(user.content[0].type).toBe("tool_result");
     expect((user.content[0] as { toolUseId: string }).toolUseId).toBe(
-      pending.toolUseId,
+      "toolu_recall_1",
     );
   });
 
-  test("clamps position to content length", () => {
+  test("returns false when no markers found", () => {
+    const store: RecallStore = new Map();
+    const req = makeRequest([
+      { role: "user", content: [{ type: "text", text: "hello" }] },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "just text" }],
+      },
+    ]);
+
+    expect(expandRecallMarkers(req, store)).toBe(false);
+  });
+
+  test("returns false when marker present but no store entry", () => {
+    const store: RecallStore = new Map(); // empty
     const req = makeRequest([
       {
         role: "assistant",
-        content: [{ type: "text", text: "hello" }],
+        content: [{ type: "text", text: buildRecallMarker("unknown", "all") }],
       },
       {
         role: "user",
@@ -334,73 +418,214 @@ describe("injectPendingRecall", () => {
       },
     ]);
 
-    const pending = makePendingRecall({ position: 99 }); // Way beyond content length
-    const result = injectPendingRecall(req, pending);
-
-    expect(result).toBe(true);
-    // Should be appended at the end
-    const assistant = req.messages[0];
-    expect(assistant.content).toHaveLength(2);
-    expect(assistant.content[1].type).toBe("tool_use");
+    expect(expandRecallMarkers(req, store)).toBe(false);
   });
 
-  test("returns false when no assistant→user pair", () => {
-    const req = makeRequest([
-      { role: "user", content: [{ type: "text", text: "hello" }] },
-    ]);
-    const pending = makePendingRecall();
-    expect(injectPendingRecall(req, pending)).toBe(false);
-  });
-
-  test("returns false with too few messages", () => {
+  test("returns false with empty messages", () => {
+    const store: RecallStore = new Map();
+    store.set(recallStoreKey("test", "all"), makeStoredRecall());
     const req = makeRequest([]);
-    const pending = makePendingRecall();
-    expect(injectPendingRecall(req, pending)).toBe(false);
+
+    expect(expandRecallMarkers(req, store)).toBe(false);
   });
 
-  test("strips recall from tools list", () => {
-    const req = makeRequest(
-      [
-        {
-          role: "assistant",
-          content: [{ type: "text", text: "hello" }],
-        },
-        {
-          role: "user",
-          content: [{ type: "text", text: "thanks" }],
-        },
-      ],
-      [
-        { name: "Read", description: "Read", inputSchema: {} },
-        { name: "recall", description: "Recall", inputSchema: {} },
-      ],
+  test("splits assistant message when continuation text follows marker (recall-only)", () => {
+    const store: RecallStore = new Map();
+    store.set(recallStoreKey("arch query", "all"), makeStoredRecall({
+      toolUseId: "toolu_recall_split",
+      input: { query: "arch query", scope: "all" },
+      result: "Found: architecture docs",
+    }));
+
+    // Simulate recall-only with follow-up: the client sees one assistant
+    // message with marker + continuation text from the follow-up.
+    const req = makeRequest([
+      { role: "user", content: [{ type: "text", text: "tell me about arch" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: buildRecallMarker("arch query", "all") },
+          { type: "text", text: "Based on the architecture docs, here's what I found..." },
+        ],
+      },
+      { role: "user", content: [{ type: "text", text: "thanks, tell me more" }] },
+    ]);
+
+    const result = expandRecallMarkers(req, store);
+    expect(result).toBe(true);
+
+    // Should split into: assistant[tool_use] → user[tool_result] → assistant[continuation] → user[next]
+    expect(req.messages).toHaveLength(5);
+
+    // Message 1: assistant with just the tool_use (truncated)
+    expect(req.messages[1].role).toBe("assistant");
+    expect(req.messages[1].content).toHaveLength(1);
+    expect(req.messages[1].content[0].type).toBe("tool_use");
+    expect((req.messages[1].content[0] as GatewayToolUseBlock).id).toBe("toolu_recall_split");
+
+    // Message 2: synthetic user with tool_result
+    expect(req.messages[2].role).toBe("user");
+    expect(req.messages[2].content).toHaveLength(1);
+    expect(req.messages[2].content[0].type).toBe("tool_result");
+    expect((req.messages[2].content[0] as { toolUseId: string }).toolUseId).toBe("toolu_recall_split");
+    expect((req.messages[2].content[0] as { content: string }).content).toBe("Found: architecture docs");
+
+    // Message 3: continuation assistant message
+    expect(req.messages[3].role).toBe("assistant");
+    expect(req.messages[3].content).toHaveLength(1);
+    expect((req.messages[3].content[0] as { text: string }).text).toBe(
+      "Based on the architecture docs, here's what I found...",
     );
 
-    const pending = makePendingRecall();
-    injectPendingRecall(req, pending);
+    // Message 4: original next user message (unchanged)
+    expect(req.messages[4].role).toBe("user");
+    expect((req.messages[4].content[0] as { text: string }).text).toBe("thanks, tell me more");
+  });
 
-    expect(req.tools).toHaveLength(1);
-    expect(req.tools[0].name).toBe("Read");
+  test("does NOT split when content after marker is only tool_use blocks (mixed tools)", () => {
+    const store: RecallStore = new Map();
+    store.set(recallStoreKey("mixed query", "all"), makeStoredRecall({
+      toolUseId: "toolu_recall_mixed",
+      input: { query: "mixed query", scope: "all" },
+    }));
+
+    const req = makeRequest([
+      { role: "user", content: [{ type: "text", text: "search and read" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "I'll search and read." },
+          { type: "text", text: buildRecallMarker("mixed query", "all") },
+          { type: "tool_use", id: "toolu_read_1", name: "Read", input: { path: "/a" } },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          { type: "tool_result", toolUseId: "toolu_read_1", content: "file content" },
+        ],
+      },
+    ]);
+
+    const result = expandRecallMarkers(req, store);
+    expect(result).toBe(true);
+
+    // Should NOT split — tool_use blocks stay in the same message
+    expect(req.messages).toHaveLength(3);
+
+    const assistant = req.messages[1];
+    expect(assistant.content).toHaveLength(3); // text + recall tool_use + Read tool_use
+    expect(assistant.content[1].type).toBe("tool_use");
+    expect((assistant.content[1] as GatewayToolUseBlock).name).toBe("recall");
+    expect(assistant.content[2].type).toBe("tool_use");
+    expect((assistant.content[2] as GatewayToolUseBlock).name).toBe("Read");
+
+    // User message has recall tool_result prepended
+    const user = req.messages[2];
+    expect(user.content).toHaveLength(2);
+    expect((user.content[0] as { toolUseId: string }).toolUseId).toBe("toolu_recall_mixed");
+    expect((user.content[1] as { toolUseId: string }).toolUseId).toBe("toolu_read_1");
+  });
+
+  test("expands markers across multiple assistant messages", () => {
+    const store: RecallStore = new Map();
+    store.set(recallStoreKey("query1", "all"), makeStoredRecall({
+      toolUseId: "toolu_recall_1",
+      input: { query: "query1", scope: "all" },
+    }));
+    store.set(recallStoreKey("query2", "session"), makeStoredRecall({
+      toolUseId: "toolu_recall_2",
+      input: { query: "query2", scope: "session" },
+    }));
+
+    const req = makeRequest([
+      { role: "user", content: [{ type: "text", text: "first" }] },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: buildRecallMarker("query1", "all") }],
+      },
+      { role: "user", content: [{ type: "text", text: "second" }] },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: buildRecallMarker("query2", "session") }],
+      },
+      { role: "user", content: [{ type: "text", text: "third" }] },
+    ]);
+
+    const result = expandRecallMarkers(req, store);
+    expect(result).toBe(true);
+
+    // Both assistant messages should have tool_use blocks
+    expect(req.messages[1].content[0].type).toBe("tool_use");
+    expect((req.messages[1].content[0] as GatewayToolUseBlock).id).toBe("toolu_recall_1");
+    expect(req.messages[3].content[0].type).toBe("tool_use");
+    expect((req.messages[3].content[0] as GatewayToolUseBlock).id).toBe("toolu_recall_2");
+
+    // Both following user messages should have tool_results inserted
+    expect(req.messages[2].content[0].type).toBe("tool_result");
+    expect((req.messages[2].content[0] as { toolUseId: string }).toolUseId).toBe("toolu_recall_1");
+    expect(req.messages[4].content[0].type).toBe("tool_result");
+    expect((req.messages[4].content[0] as { toolUseId: string }).toolUseId).toBe("toolu_recall_2");
   });
 });
 
 // ---------------------------------------------------------------------------
-// stripRecallFromResponse
+// cleanupRecallStore
 // ---------------------------------------------------------------------------
 
-describe("stripRecallFromResponse", () => {
-  test("removes recall tool_use blocks", () => {
+describe("cleanupRecallStore", () => {
+  test("removes orphaned entries", () => {
+    const store: RecallStore = new Map();
+    store.set(recallStoreKey("active", "all"), makeStoredRecall());
+    store.set(recallStoreKey("orphaned", "all"), makeStoredRecall());
+
+    const req = makeRequest([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: buildRecallMarker("active", "all") }],
+      },
+      { role: "user", content: [{ type: "text", text: "next" }] },
+    ]);
+
+    cleanupRecallStore(req, store);
+
+    expect(store.size).toBe(1);
+    expect(store.has(recallStoreKey("active", "all"))).toBe(true);
+    expect(store.has(recallStoreKey("orphaned", "all"))).toBe(false);
+  });
+
+  test("no-op on empty store", () => {
+    const store: RecallStore = new Map();
+    const req = makeRequest([
+      { role: "user", content: [{ type: "text", text: "hello" }] },
+    ]);
+
+    cleanupRecallStore(req, store);
+    expect(store.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// replaceRecallWithMarker
+// ---------------------------------------------------------------------------
+
+describe("replaceRecallWithMarker", () => {
+  test("replaces recall tool_use with marker text", () => {
     const resp = makeResponse([
       { type: "text", text: "hello" },
-      makeRecallToolUse(),
+      makeRecallToolUse("find config", "project"),
       { type: "tool_use", id: "toolu_1", name: "Read", input: {} },
     ]);
 
-    const stripped = stripRecallFromResponse(resp);
-    expect(stripped.content).toHaveLength(2);
-    expect(stripped.content[0].type).toBe("text");
-    expect(stripped.content[1].type).toBe("tool_use");
-    expect((stripped.content[1] as GatewayToolUseBlock).name).toBe("Read");
+    const replaced = replaceRecallWithMarker(resp);
+    expect(replaced.content).toHaveLength(3);
+    expect(replaced.content[0].type).toBe("text");
+    expect(replaced.content[1].type).toBe("text");
+    expect((replaced.content[1] as { text: string }).text).toBe(
+      buildRecallMarker("find config", "project"),
+    );
+    expect(replaced.content[2].type).toBe("tool_use");
+    expect((replaced.content[2] as GatewayToolUseBlock).name).toBe("Read");
   });
 
   test("returns same content when no recall present", () => {
@@ -409,27 +634,29 @@ describe("stripRecallFromResponse", () => {
       { type: "tool_use", id: "toolu_1", name: "Read", input: {} },
     ]);
 
-    const stripped = stripRecallFromResponse(resp);
-    expect(stripped.content).toHaveLength(2);
+    const replaced = replaceRecallWithMarker(resp);
+    expect(replaced.content).toHaveLength(2);
   });
 
   test("does not mutate original response", () => {
     const recallBlock = makeRecallToolUse();
     const resp = makeResponse([recallBlock]);
 
-    const stripped = stripRecallFromResponse(resp);
+    const replaced = replaceRecallWithMarker(resp);
     expect(resp.content).toHaveLength(1);
-    expect(stripped.content).toHaveLength(0);
+    expect(resp.content[0].type).toBe("tool_use");
+    expect(replaced.content).toHaveLength(1);
+    expect(replaced.content[0].type).toBe("text");
   });
 
   test("preserves non-content fields", () => {
     const resp = makeResponse([makeRecallToolUse()]);
     resp.usage.inputTokens = 999;
 
-    const stripped = stripRecallFromResponse(resp);
-    expect(stripped.id).toBe(resp.id);
-    expect(stripped.model).toBe(resp.model);
-    expect(stripped.stopReason).toBe(resp.stopReason);
-    expect(stripped.usage.inputTokens).toBe(999);
+    const replaced = replaceRecallWithMarker(resp);
+    expect(replaced.id).toBe(resp.id);
+    expect(replaced.model).toBe(resp.model);
+    expect(replaced.stopReason).toBe(resp.stopReason);
+    expect(replaced.usage.inputTokens).toBe(999);
   });
 });


### PR DESCRIPTION
## Summary

- Replace dual Case 1/Case 2 recall interception with a unified "Marker and Expand" pattern: responses emit `📚 Searching <scope> for "<query>"…` marker text, next request expands markers back to `tool_use` + `tool_result` pairs for the upstream API
- `expandRecallMarkers()` splits assistant messages when recall-only follow-up continuation text follows a marker, producing valid Anthropic conversation structure (`assistant[tool_use] → user[tool_result] → assistant[continuation]`)
- Replace `PendingRecall` (TTL-based, single-slot) with `RecallStore` (persistent Map, supports multiple concurrent markers across turns)

## Changes

- **types.ts**: `StoredRecall` + `RecallStore` replace `PendingRecall`; `SessionState.recallStore` replaces `pendingRecall`
- **recall.ts**: Add marker utilities (`buildRecallMarker`, `parseRecallMarker`, `expandRecallMarkers`, `cleanupRecallStore`, `replaceRecallWithMarker`); remove `isPendingRecallValid`, `injectPendingRecall`, `stripRecallFromResponse`
- **pipeline.ts**: Unified streaming path for both cases; inbound marker expansion with store cleanup; diagnostic logging for follow-up response status and event count
- **Tests**: 52 recall-specific tests (2 new for split behavior), 873 total pass