### PR TITLE
fix(gateway): cache analytics JSON path missing array index for first element

### DIFF
--- a/packages/gateway/src/cache-analytics.ts
+++ b/packages/gateway/src/cache-analytics.ts
@@ -68,13 +68,18 @@ export function mapOffsetToJsonPath(json: string, offset: number): string {
   if (offset >= json.length) return "<end>";
   if (offset === 0) return "<start>";
 
-  const path: (string | number)[] = [];
-  let depth = 0;
+  // Stack-based JSON path tracker. Each frame represents a nesting level.
+  // - object frames: { kind: "object", key: current key or "" }
+  // - array frames:  { kind: "array", index: current element index }
+  type Frame =
+    | { kind: "object"; key: string }
+    | { kind: "array"; index: number };
+
+  const stack: Frame[] = [];
   let inString = false;
   let escaped = false;
   let currentKey = "";
   let collectingKey = false;
-  let arrayIndex: number[] = []; // stack of array indices per depth
 
   for (let i = 0; i < json.length && i < offset; i++) {
     const ch = json[i];
@@ -92,10 +97,7 @@ export function mapOffsetToJsonPath(json: string, offset: number): string {
       }
       if (ch === '"') {
         inString = false;
-        if (collectingKey) {
-          collectingKey = false;
-          // Key will be pushed on the next ':'
-        }
+        collectingKey = false;
         continue;
       }
       if (collectingKey) currentKey += ch;
@@ -105,86 +107,66 @@ export function mapOffsetToJsonPath(json: string, offset: number): string {
     switch (ch) {
       case '"':
         inString = true;
-        // If we're in an object context and haven't seen ':' yet, start collecting key
-        if (i + 1 < json.length) {
-          // Look ahead to see if this is a key (followed eventually by ':')
-          // Simple heuristic: if we just saw '{' or ',' in object context, it's a key
-          collectingKey = isObjectContext(json, i);
-          if (collectingKey) currentKey = "";
-        }
+        // Determine if this quote starts a key (object context, key position)
+        collectingKey = isObjectKeyPosition(json, i);
+        if (collectingKey) currentKey = "";
         break;
 
       case "{":
-        depth++;
-        arrayIndex.push(-1); // -1 = object context
+        stack.push({ kind: "object", key: "" });
         break;
 
       case "[":
-        depth++;
-        arrayIndex.push(0); // array context, start at 0
+        stack.push({ kind: "array", index: 0 });
         break;
 
       case "}":
       case "]":
-        if (path.length > 0 && path.length >= depth) {
-          path.length = depth - 1;
-        }
-        depth--;
-        arrayIndex.pop();
+        stack.pop();
         break;
 
       case ":":
-        // Push the key we just collected
-        if (currentKey) {
-          // Trim path to current depth - 1, then push key
-          path.length = depth - 1;
-          path.push(currentKey);
+        // Assign the collected key to the current object frame
+        if (currentKey && stack.length > 0) {
+          const top = stack[stack.length - 1];
+          if (top.kind === "object") {
+            top.key = currentKey;
+          }
           currentKey = "";
         }
         break;
 
       case ",":
-        // In array context, increment index
-        if (arrayIndex.length > 0) {
-          const topIdx = arrayIndex.length - 1;
-          if (arrayIndex[topIdx] >= 0) {
-            arrayIndex[topIdx]++;
-            // Update path with new array index
-            path.length = depth - 1;
-            path.push(arrayIndex[topIdx]);
+        // In array context, advance to the next element
+        if (stack.length > 0) {
+          const top = stack[stack.length - 1];
+          if (top.kind === "array") {
+            top.index++;
           }
         }
         break;
     }
   }
 
-  // For arrays, also push the initial [0] element if we haven't yet
-  if (arrayIndex.length > 0) {
-    const topIdx = arrayIndex.length - 1;
-    if (arrayIndex[topIdx] >= 0 && (path.length < depth || typeof path[path.length - 1] !== "number")) {
-      path.length = depth - 1;
-      path.push(arrayIndex[topIdx]);
+  // Build path from the stack
+  const parts: string[] = [];
+  for (const frame of stack) {
+    if (frame.kind === "object" && frame.key) {
+      parts.push(parts.length === 0 ? frame.key : `.${frame.key}`);
+    } else if (frame.kind === "array") {
+      parts.push(`[${frame.index}]`);
     }
   }
 
-  if (path.length === 0) return "<root>";
-
-  return path
-    .map((p, i) =>
-      typeof p === "number"
-        ? `[${p}]`
-        : i === 0
-          ? p
-          : `.${p}`,
-    )
-    .join("");
+  return parts.length === 0 ? "<root>" : parts.join("");
 }
 
 /**
- * Simple heuristic: are we in an object context where a '"' starts a key?
- * Scans backwards from offset to find the last structural character.
+ * Determine if a '"' at `offset` starts an object key.
+ * Scans backwards to find the last structural character — if it's '{' or ','
+ * we're in key position (not value position).
  */
-function isObjectContext(json: string, offset: number): boolean {
+function isObjectKeyPosition(json: string, offset: number): boolean {
   for (let i = offset - 1; i >= 0; i--) {
     const ch = json[i];
     if (ch === " " || ch === "\n" || ch === "\r" || ch === "\t") continue;

--- a/packages/gateway/test/cache-analytics.test.ts
+++ b/packages/gateway/test/cache-analytics.test.ts
@@ -112,7 +112,7 @@ describe("mapOffsetToJsonPath", () => {
     expect(path).toBe("system");
   });
 
-  test("nested messages array", () => {
+  test("nested messages array — later element", () => {
     const json = JSON.stringify({
       model: "opus",
       messages: [
@@ -121,10 +121,47 @@ describe("mapOffsetToJsonPath", () => {
         { role: "user", content: "CHANGED" },
       ],
     });
-    // Find where "CHANGED" appears
     const offset = json.indexOf("CHANGED");
     const path = mapOffsetToJsonPath(json, offset);
     expect(path).toMatch(/messages\[2\]/);
+  });
+
+  test("nested messages array — first element (index 0)", () => {
+    const json = JSON.stringify({
+      model: "opus",
+      messages: [
+        { role: "user", content: "CHANGED" },
+        { role: "assistant", content: "second" },
+      ],
+    });
+    const offset = json.indexOf("CHANGED");
+    const path = mapOffsetToJsonPath(json, offset);
+    expect(path).toBe("messages[0].content");
+  });
+
+  test("system block array (Anthropic cache format)", () => {
+    const json = JSON.stringify({
+      model: "opus",
+      system: [{ type: "text", text: "CHANGED_HERE", cache_control: { type: "ephemeral" } }],
+      messages: [],
+    });
+    const offset = json.indexOf("CHANGED_HERE");
+    const path = mapOffsetToJsonPath(json, offset);
+    expect(path).toBe("system[0].text");
+  });
+
+  test("content block array within message", () => {
+    const json = JSON.stringify({
+      messages: [
+        { role: "user", content: [
+          { type: "text", text: "first block" },
+          { type: "text", text: "DIVERGED" },
+        ]},
+      ],
+    });
+    const offset = json.indexOf("DIVERGED");
+    const path = mapOffsetToJsonPath(json, offset);
+    expect(path).toBe("messages[0].content[1].text");
   });
 
   test("system prompt change", () => {


### PR DESCRIPTION
## Summary

- Fix `mapOffsetToJsonPath` producing `messages.content.text` instead of `messages[0].content.text` in production logs
- Rewrite from depth+path.length tracking to a clean stack-based approach where each nesting level is a typed frame (object with key, or array with index)
- Array indices are now tracked from element 0 and always appear in the output path

## Bug

The previous implementation only pushed array indices to the path on `,` (comma, advancing to the next element). The first element (index 0) was never recorded before entering deeper nesting, causing paths like `messages.content.text` instead of `messages[0].content.text`.

Observed in production logs:
```
divergence="messages.content.text" reason="changed at messages.content.text"  (6 occurrences)
```

## Tests

- 3 new regression tests: first array element, system block arrays, nested content block arrays
- 904 total tests pass, 0 fail