### PR TITLE
feat: layered cache breakpoints and LTM content-diff pinning

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -2,139 +2,64 @@
 
 ## Long-term Knowledge
 
-### Architecture
-
-<!-- lore:019e0751-6f95-742e-a594-894afd5c7cc8 -->
-* **Cache analytics ground truth lives at gateway, predictive analysis derives semantic divergence**: Gateway CacheAnalytics separates two data streams: (1) Ground truth from API: cacheRead/cacheCreation tokens, inputTokens—source of actual cache hit rate. (2) Predictive analysis: byte-level prefix comparison of compressed request bodies maps divergence byte offset to JSON semantic path ('system', 'messages\[3].content\[1]', 'tools'). computeCacheDivergence() does the mapping. This enables Sentry instrumentation with both API-verified cache effectiveness and structured root cause (which field changed). Not used by core layer selection—purely observability.
-
-<!-- lore:019e0751-6e7e-7847-bbc3-9e7567906699 -->
-* **Cache analytics moved from gradient to gateway with structured divergence reporting**: Cache analytics (bustCount, transformCount, lastPrefixHash) removed from gradient SessionState—diagnostic burden belongs at gateway where API calls happen. Gateway SessionState now holds CacheAnalytics: compressed last request body (deflateSync), API response cache fields, and per-turn CacheTurnAnalysis (prefixMatchBytes, divergencePoint, divergenceReason). Ground truth from API response; predictions from byte-level body comparison. Enables Sentry instrumentation at gateway level.
-
-<!-- lore:019e0750-f949-7793-8d67-44ae9ce2379e -->
-* **Cache analytics moved to gateway level with compressed request body storage**: Gateway SessionState now stores CacheAnalytics: compressed last request body (deflate), API response cache metrics (cache\_read\_input\_tokens, cache\_creation\_input\_tokens), and computed cacheHitRate. Per-turn analysis in postResponse performs byte-level prefix comparison of serialized bodies to detect divergence point and semantic reason (e.g., 'system prompt changed', 'new tool added'). Replaces hash-based detection. Ground truth from API responses, not heuristics. Enables structured Sentry instrumentation.
-
-<!-- lore:019e0750-f92d-7c05-bfcb-a0a883a0a445 -->
-* **Cache analytics ownership moves to gateway SessionState**: Cache analytics now live in gateway SessionState, not gradient SessionState. Gateway captures compressed lastRequestBody in forwardToUpstream, computes CacheTurnAnalysis (prefixMatchBytes, divergencePoint, cacheHitRate) in postResponse by comparing with previous body and API metrics. Gradient SessionState no longer tracks bustCount, transformCount, lastPrefixHash—these were diagnostic only and are now computed per-turn in gateway. Enables Sentry instrumentation and cleaner separation of concerns.
-
-<!-- lore:019e0751-6f5d-75a2-8062-e1a259e13783 -->
-* **CacheAnalytics stored in gateway SessionState drives Sentry instrumentation**: Gateway SessionState now includes CacheAnalytics (lastCompressedBody, lastCacheRead, lastCacheCreation, cacheHitRatio, turnCount, bustCount). Per-turn postResponse computes CacheTurnAnalysis with: API ground truth (cache\_read, cache\_creation from response), byte-level prefixMatchBytes/prefixMatchPercent, and divergencePoint mapped from JSON structure. Enables Sentry to instrument cache effectiveness and divergence reasons. Replaces core gradient's diagnostic bustCount/transformCount/lastPrefixHash—those fields removed from gradient SessionState.
-
-<!-- lore:019e0751-6e55-7de3-9d0a-dc8f424b89af -->
-* **CacheAnalytics structured detection at gateway level**: Cache analytics moved from gradient to gateway SessionState to capture ground truth at API call site. Stores compressed last request body (zstd-deflated JSON) + API response cache fields (cacheRead, cacheCreation tokens). Per-turn: byte-level prefix comparison detects divergence point (e.g., 'messages\[3].content'), maps to semantic reason (system changed, message edited, new tool). Computes cacheHitRate from API response. Diagnostic output for Sentry; zero behavioral impact on layer selection or budget.
-
-<!-- lore:019e0750-f99f-7f62-848e-623fec435898 -->
-* **Gateway cache analytics uses forwardToUpstream body return pattern**: forwardToUpstream returns {response, requestBody} tuple to enable cache analytics. Gateway SessionState.cacheAnalytics stores compressed last request body + API cache response fields. postResponse accepts requestBody parameter for analyzeCacheTurn comparison. Main conversation path uses full analytics; passthrough/recall calls destructure but ignore body. Bun's deflateSync provides ~10:1 compression on repetitive JSON bodies.
-
-<!-- lore:019e0750-f9a6-7763-9913-b99603618fe6 -->
-* **Gateway CacheAnalytics captures request body and API response cache ground truth**: CacheAnalytics stores compressed last request body, API cache response fields (cache\_read\_input\_tokens, cache\_creation\_input\_tokens), and running cache metrics (turnCount, cacheHitRatio). Lives in gateway SessionState, populated in postResponse(). forwardToUpstream() returns both response and serialized request body. On each turn, analyzeCacheTurn() decompresses previous body, compares byte-by-byte to find divergence point, maps to JSON path (e.g., 'system', 'messages\[3].content'), and logs CacheTurnAnalysis with cacheHitRate and divergenceReason for Sentry instrumentation.
-
-<!-- lore:019e0751-6f9a-7633-abe2-1dc928d62794 -->
-* **Gateway CacheAnalytics captures structured per-turn cache data**: New \`CacheAnalytics\` in gateway SessionState stores: compressed last request body (deflate), API ground-truth cache metrics (cacheRead, cacheCreation tokens), and running hit ratio. Per-turn analysis outputs: byte-level prefixMatchPercent, divergencePoint (e.g. 'messages\[3].content'), and divergenceReason semantic label. Removes need for gradient-layer fingerprinting. Enables Sentry instrumentation and post-analysis of cache effectiveness.
-
-<!-- lore:019e0751-6f31-71a2-b4a2-fb1f1776e5fa -->
-* **Gateway CacheAnalytics tracks compressed request bodies for precise cache analysis**: Gateway SessionState includes CacheAnalytics: compressedLastBody (zstd-compressed full request JSON), lastCacheRead/Creation (API response tokens), turnCount, bustCount, cacheHitRatio. forwardToUpstream() returns {response, requestBody} tuple. postResponse() decompresses previous body, does byte-level prefix diff, maps divergence offset to JSON semantic path. Structured logging includes prefixMatchPercent, divergencePoint, divergenceReason. Uses Bun's deflateSync/inflateSync for ~0.6% compression on repetitive JSON.
-
-<!-- lore:019e0750-f9bd-75ba-a895-76bdaf34c5c1 -->
-* **Gateway session state holds compressed request analytics**: Gateway SessionState stores cache analytics using Bun's built-in deflateSync/inflateSync: lastRequestBodyCompressed (deflated JSON), lastCacheRead/lastCacheCreation tokens from API response, bustCount/turnCount counters. forwardToUpstream returns serialized body alongside response. postResponse performs byte-level prefix comparison on decompressed bodies to detect semantic divergence points. Analytics live at gateway level where actual API calls happen, not in gradient transform logic.
-
-<!-- lore:019e0750-f9f1-71df-b4c5-ecd7879b1ab2 -->
-* **Gateway-level cache analytics uses byte-level prefix comparison with compression**: Cache analytics moved from core to gateway level for ground truth analysis. SessionState stores compressed previous request body using Bun's deflateSync (~0.6% compression ratio). Next turn decompresses and does byte-level prefix comparison to find exact divergence point. Maps byte offset to JSON structure for semantic divergence detection (e.g. 'messages\[3].content changed'). Uses API response cache fields (cache\_read\_input\_tokens, cache\_creation\_input\_tokens) for accurate hit/miss determination rather than heuristics.
-
-<!-- lore:019e074f-9b4b-746c-b22a-3543c425c46f -->
-* **Gateway-level cache analytics with byte-level prefix comparison**: Gateway-level cache analytics uses compressed request body storage and byte-level prefix comparison. SessionState.cacheAnalytics stores deflateSync-compressed previous body (~0.6% ratio), API response cache fields (cache\_read/creation\_input\_tokens), and computed metrics. analyzeCacheTurn() decompresses, finds divergence offset, maps to JSON path (e.g. 'messages\[3].content\[1]'), determines semantic reason. Provides ground truth cacheHitRate and structured analytics for Sentry.
-
-<!-- lore:019e0751-6f45-7939-9140-008e96e1b583 -->
-* **Gateway-level cache analytics with compressed request body storage**: Cache analytics moved to gateway level for ground-truth measurement: SessionState.cacheAnalytics stores compressed previous request body (deflateSync) + API response cache fields (lastCacheRead, lastCacheCreation). analyzeCacheTurn() performs byte-level prefix comparison between compressed bodies, maps divergence point to semantic JSON location (e.g. 'messages\[3].content\[1]'). forwardToUpstream() returns serialized body alongside response. Captures actual API cache effectiveness vs. predictive analysis.
-
-<!-- lore:019e0751-6f35-7168-863a-f28c3da40134 -->
-* **Gateway-level structured cache analytics with compressed request body comparison**: Gateway SessionState includes CacheAnalytics with compressed previous request body (Bun deflateSync) plus API response cache fields. analyzeCacheTurn() does byte-level prefix comparison to find exact divergence point and semantic location (e.g. 'messages\[3].content changed'). forwardToUpstream() returns serialized body alongside response. postResponse() processes cache analytics and logs structured data for Sentry/analysis. Replaces gradient-level hash-based bust detection with ground-truth API metrics.
-
 ### Decision
 
-<!-- lore:019e0751-6e6b-75e7-8833-7f921ae930e1 -->
-* **Compressed body storage for cache diff instead of fingerprinting**: Replaced single-hash fingerprint with full compressed request body storage. zstd deflate achieves ~0.6% ratio on JSON (10-50KB per session). Byte-level prefix comparison next turn reveals exact divergence offset, then mapped to semantic JSON path. More expensive storage/compute than hash, but enables Sentry reporting of \_what\_ changed and why. Supports post-analysis without requiring live logs.
+<!-- lore:019e079b-543f-75e0-bab1-6f5b668d33c3 -->
+* **Decided to use \`bun build --compile\` with \`--external\` flags for native modules (\`fastembed\`**: decided to use \`bun build --compile\` with \`--external\` flags for native modules (\`fastembed\`,
 
-<!-- lore:019e0752-717c-7b4f-8a1f-8e1d0be95e80 -->
-* **Switched from deflate to zstd compression in cache analytics (zstd: 0**: Switched from deflate to zstd compression in cache analytics (zstd: 0.
-
-<!-- lore:019e0752-2d89-70ee-998d-99f6ac913262 -->
-* **Switched from deflate to zstd compression in cache-analytics**: switched from deflate to zstd compression in cache-analytics.
+<!-- lore:019e079b-53d7-7394-b73e-b1edb5fb6780 -->
+* **Switched from \`Bun.build({ compile: true })\` API to \`bun build --compile\` CLI with \`--external\` flags for native modules (fastembed**: Switched from \`Bun.build({ compile: true })\` API to \`bun build --compile\` CLI with \`--external\` flags for native modules (fastembed,
 
 ### Gotcha
 
-<!-- lore:019e0751-6fa5-77d0-89aa-6f9a32663006 -->
-* **Cache analytics replaces gradient-layer bust detection; remove old fingerprinting logic**: Old gradient SessionState fields (lastPrefixHash, bustCount, transformCount) are being replaced by gateway-level CacheAnalytics. Remove fingerprinting block from gradient.ts transform() and delete diagnostic burst warnings. Gateway now owns cache analysis end-to-end with actual API response ground truth instead of predictive hashing.
+<!-- lore:019e0794-0778-7157-8029-794369dd0e49 -->
+* **Git stash restores unintended changes from multiple developers**: Git cannot recover uncommitted working directory changes after destructive operations: \`git reset --hard\` permanently destroys uncommitted working directory changes that were never staged or stashed. \`git reflog\` only tracks commits and HEAD movements — it cannot recover working directory state. Stash operations only preserve files that were explicitly included in the stash. If changes were made to working directory then wiped by reset without being staged/committed/stashed first, they're unrecoverable. Always stage important work or use \`git stash -u\` for full working directory backup before risky operations.
 
-<!-- lore:019e0751-6e88-7a98-bec1-86a4565fe126 -->
-* **forwardToUpstream now returns {response, requestBody} tuple**: forwardToUpstream modified to return \[response, requestBody] instead of just response. All callers must destructure: \`const \[response, body] = await forwardToUpstream(...)\`. Affects conversation handler (line ~1261), passthrough, recall follow-ups, and streaming paths. Non-conversation paths can ignore body; main handler passes body to postResponse for cache analytics.
-
-<!-- lore:019e0751-6f55-71e6-bb94-ba022d63fca5 -->
-* **forwardToUpstream now returns {response, serializedBody} tuple**: forwardToUpstream() signature changed to return {response, serializedBody} instead of just response. All callers must destructure: const {response, serializedBody} = await forwardToUpstream(...). serializedBody is needed by postResponse() for byte-level cache comparison. Failing to destructure will cause runtime errors in analytics pipeline.
-
-<!-- lore:019e0750-f9ad-75e2-a3fc-7d6d3335e0cc -->
-* **forwardToUpstream() return type changed to include serialized body**: forwardToUpstream() now returns {response, serializedBody} instead of just response. All four call sites in gateway.ts must destructure: const {response, serializedBody} = await forwardToUpstream(...). Main conversation path (line ~1261) uses serializedBody for analytics in postResponse(); passthrough, recall, and rewrite paths ignore it. Missing destructuring will cause type errors.
-
-<!-- lore:019e071a-608c-785d-9855-2b427b839fc5 -->
-* **SessionState recallStore must be initialized to new Map in constructor**: SessionState.recallStore must be initialized to new Map() in constructor. expandRecallMarkers() calls .get() on recallStore; without init, fails. Also initialize new cacheAnalytics field: { lastCompressedBody: null, lastCacheRead: 0, lastCacheCreation: 0, turnCount: 0, bustCount: 0 }. Add upgrade guard in getOrCreateSession().
+<!-- lore:019e0789-63eb-77c2-860a-be9cbb906e55 -->
+* **LTM system prompt injection causes frequent cache busts**: LTM system prompt injection causes frequent cache busts, fixed with content pinning. Background curation/consolidation invalidates \`ltmSessionCache\` → fresh BM25 re-scoring → different system text → cache bust. Fix: \`ltmPinnedText\` map stores formatted LTM content per session. Only update pin when new content differs >5% via Levenshtein distance, preventing busts from trivial re-scoring. Pin survives cache invalidation — only cleared on global resets. Reduces bust rate from 25% to near-zero.
 
 ### Pattern
 
-<!-- lore:019e0751-6fa1-73af-9614-3cb190920bee -->
-* **Byte-level prefix diff maps to semantic divergence in JSON**: Cache analytics compares compressed request bodies byte-by-byte to find where they diverge, then maps the offset back to semantic location in JSON structure (e.g. 'system prompt changed', 'message content changed at messages\[3]'). Enables precise root-cause analysis of cache busts for logging and Sentry instrumentation without storing full request hashes.
+<!-- lore:019e078d-feef-7123-bc40-8d78641dc278 -->
+* **Anthropic cache breakpoint allocation strategy**: Anthropic cache breakpoint allocation strategy: Anthropic API supports up to 4 cache breakpoints per request. Current allocation: system\[0] host prompt (1h), tools\[last] including recall+git (1h), messages\[last] conversation tail (5m). Fourth slot reserved for future use. System\[1] LTM gets no breakpoint but benefits from prefix caching when system\[0] stable. Tools array gets single breakpoint at end - adding recall tool with integrated git reminder extends stable prefix coverage for tool-heavy conversations.
 
-<!-- lore:019e0751-6e83-70df-91df-543bcc57ba70 -->
-* **Byte-level request body comparison for cache divergence detection**: Compare serialized request JSON bodies byte-by-byte to detect where cache was busted. computePrefixMatch() finds matching byte range, then mapDivergenceToPath() walks JSON structure to identify divergence point (e.g., 'system', 'messages\[2].content'). Store last body compressed with deflateSync (~0.6% ratio on JSON). Per-turn analysis yields prefixMatchPercent, divergenceReason for structured logging. This replaces previous fingerprint-based detection.
+<!-- lore:019e0789-63ef-7d42-a16e-245fcb5e4053 -->
+* **Binary build externals for native dependencies**: Standalone Bun binary build must mark native modules as external (fastembed, onnxruntime-node, @anush008/\*) in esbuild config. Binary can't bundle native addons but also can't resolve them at runtime. Core imports fastembed dynamically, so external is safe - binary gracefully degrades when fastembed unavailable. Use \`bun build --compile --external fastembed\` for final compile step. Different from npm bundle which relies on consumer npm install.
 
-<!-- lore:019e04c3-14db-7b73-90d9-550db7f85dfb -->
-* **C\_norm temporal clustering metric indicates message age distribution within distillation segments**: C\_norm temporal clustering metric indicates message age distribution: C\_norm (normalized variance of message existence weights) ranges 0–1, measuring timestamp distribution evenness within distillation segments. Computed via temporalCnorm() at distillation.ts:649. Values near 0 indicate uniform age distribution (healthy segmentation). Used for time-gap segmentation quality assessment.
+<!-- lore:019e0789-63f3-761d-bd8a-6f2cf6211dab -->
+* **CLI command dispatch via parseArgs and separate command modules**: CLI uses node:util parseArgs() with command dispatch to separate modules (start.ts, run.ts). Main entry (main.ts) parses args, validates commands, dispatches to command functions. Each command module exports single function taking parsed args. Pattern enables clean separation, testability, and avoids monolithic index.ts. Help/version handled at dispatch layer before command execution to avoid gateway startup blocking --help.
 
-<!-- lore:019e0751-6f89-7d70-beac-1997752d2b63 -->
-* **Cache analytics module maps byte divergence to JSON semantic location**: cacheAnalytics.ts computes prefixMatchBytes via inflated body comparison, then maps byte offset to JSON path (e.g., 'system', 'messages\[3].content\[1]') using recursive descent. Returns divergenceReason string ('system prompt changed', 'message content changed', 'new tool added'). Uses Bun deflate/inflate for compression. Structured output (cacheRead, cacheHitRate, prefixMatchPercent, divergencePoint, divergenceReason) feeds Sentry and logs—enables root-cause analysis without brittle hashing.
+<!-- lore:019e078f-daef-7d94-a5d6-a35bf31d849e -->
+* **Content-diff pinning for LTM injection suppresses re-ranking busts**: Content-diff pinning implemented in OpenCode plugin via \`pinnedTextMap\`. LTM re-scoring changes are suppressed unless >5% word count difference from pinned version. Uses Map\<sessionId, {text, wordCount}> with session-scoped pinning. When LTM cache invalidates, new formatted text is compared to pinned version - only updates system prompt if significant change detected. Prevents frequent cache busts from minor BM25 re-ranking while allowing meaningful knowledge updates.
 
-<!-- lore:019e0751-6ef0-76a3-ab4c-20f2180f3cf4 -->
-* **Cache body compression with zstd deflateSync for gateway state**: Gateway caches compressed request body (Bun deflateSync ~0.6% ratio) in SessionState.cacheAnalytics.lastRequestBody to enable byte-level prefix diff next turn. On each postResponse(), decompress, compare bytes, map divergence offset to JSON path (system/messages\[n]/tools), log semantic reason (prompt changed vs message content vs tool added). Ground truth: API response cache\_read/cacheCreation tokens validate actual cache hits. Replaces hashing—provides actionable divergence point for Sentry instrumentation and post-analysis.
+<!-- lore:019e079a-d436-7c96-962b-7da8cdb10570 -->
+* **Git reminder in recall tool description instead of system prompt**: Git reminder (check .lore.md/AGENTS.md before commit) moved from system prompt injection to \`createRecallTool()\` description in reflect.ts. OpenCode plugin appends reminder to recall tool description when knowledge is enabled. This avoids system-prompt mutations on each turn, preserving Anthropic cache stability. Reminder only appears when recall tool is injected (i.e., when knowledge system is enabled). Gateway recall tool description is built in the same way, ensuring consistency across execution paths.
 
-<!-- lore:019e0750-f943-7bdf-ba52-5af34a98e68f -->
-* **CacheAnalytics module performs byte-level prefix diffing with semantic mapping**: Gateway module analyzeCacheAnalytics() compares deflateSync-compressed request bodies byte-by-byte, computing prefixMatchBytes and prefixMatchPercent. Maps divergence offset to JSON path via recursive descent (e.g. 'system', 'messages\[3].content\[1]'). Outputs CacheTurnAnalysis with API ground truth (cacheRead, cacheCreation from response), computed cacheHitRate, and divergenceReason enum. Enables post-analysis via Sentry and structured logging without behavioral impact on layer selection.
+<!-- lore:019e078e-0694-784b-9cce-3dbada3b827d -->
+* **LTM cache invalidation triggers in three parallel code paths**: Three independent injection paths (OpenCode plugin, gateway pipeline, Pi extension) each maintain \`ltmSessionCache\` with identical invalidation sources: curation completion, consolidation, dead-ref cleanup, knowledge import (startup), oversized entry pruning, and idle-resume (>5min). \`ltmPinnedText\` map prevents cache busts by pinning formatted LTM text per session until content differs >5%. When cache invalidated, \`ltm.forSession()\` dynamically scores all entries via FTS5 BM25 against evolved session context, but pinned text only updates on significant content change. This reduces Anthropic cache busts from ~25% to minimal, saving $1.30 per 96K session batch vs full re-injection.
 
-<!-- lore:019e0751-6f51-7ad7-a356-3cacca0e64b3 -->
-* **CacheTurnAnalysis semantic divergence detection**: Cache divergence analysis maps byte-level prefix mismatch back to JSON path: After byte-by-byte prefix comparison with previous request body, the module traverses current JSON structure to map divergence byte offset to semantic location (e.g., 'system prompt changed', 'messages\[3].content\[1]'). Stores divergencePoint (JSON path) and divergenceReason (human-readable explanation). Enables root-cause analysis for cache busts without hashing entire bodies. Compressed previous body keeps memory ~0.6% of original JSON size.
+<!-- lore:019e079a-d42f-7703-a935-4f07b5a75a9a -->
+* **LTM content-diff pinning prevents cache busts from re-scoring**: Both gateway and OpenCode plugin implement \`ltmPinnedText\` map to cache LTM formatted text per session. On LTM injection, compares new formatted content against pinned version using character-count ratio. Only updates system prompt if >5% change threshold exceeded, suppressing cache busts from minor BM25 re-ranking variations. Pin survives \`ltmSessionCache\` invalidation — only cleared on global resets. Map structure: \`Map\<sessionID, pinnedText>\`. Prevents system prompt mutations from trivial entry reordering while allowing meaningful knowledge updates to propagate.
 
-<!-- lore:019e0750-f9f6-76fa-a206-f0196c9a9b79 -->
-* **forwardToUpstream returns serialized body alongside response for analytics**: forwardToUpstream() now returns {response, requestBody} tuple instead of just response. The requestBody is the serialized JSON sent to Anthropic, needed for next-turn cache comparison. Main conversation path uses both values for analytics. Passthrough calls (recall follow-ups, non-main conversations) destructure and ignore requestBody. This pattern enables cache analytics without changing the core request/response flow.
+<!-- lore:019e078f-daeb-755e-b976-ce7ace9b244c -->
+* **Pin host system prompt per session to avoid cache busts from legitimate mutations**: Pin host system prompt per session with content-hash comparison to avoid cache busts from legitimate mutations. Host can mutate system\[0] between turns (adding memory, AGENTS.md, feature toggles). Store host's incoming system\[0] with content hash and 1h TTL per session. If identical text sent next turn, use cached version. If changed, accept bust as host-caused and log 'host-system-prompt-changed'. Implemented via \`pinnedTextMap\` in gateway and OpenCode plugin with same session ID for consistency.
 
-<!-- lore:019e074d-c4c0-7fbe-b9b2-517e2c817178 -->
-* **forwardToUpstream returns serialized body for analytics**: forwardToUpstream returns {response, requestBody} tuple to enable cache analytics. Main conversation handler uses both values for cache comparison; passthrough calls (recall follow-ups, streaming) destructure and ignore requestBody. This pattern separates request serialization from analytics while keeping API clean.
+<!-- lore:019e078f-daf3-7b21-9613-df07e9381277 -->
+* **System prompt layer ordering for cache stability: host → git reminder → LTM → tools**: System prompt layer ordering for cache stability: (1) host base prompt (pinned per session with 1h cache breakpoint), (2) LTM knowledge as separate system\[1] block (pinned with content-diff suppression), (3) tools array (static with 1h cache breakpoint). LTM moved from system\[0] injection to dedicated system\[1] block, enabling independent caching without breaking host prompt cache. This ordering maximizes Anthropic cache hit rate with stable prefix even when LTM re-scores.
 
-<!-- lore:019e0751-6f92-769f-ada7-0e940dde31bc -->
-* **forwardToUpstream returns serialized body for cache analysis round-trip**: forwardToUpstream() now returns tuple \[response, serializedBody] to enable gateway-level cache analytics. Serialized body is the exact JSON sent to Anthropic. All callers destructure: const {response, serializedBody} = await forwardToUpstream(). serializedBody is then passed to postResponse() for byte-level prefix comparison against lastRequestBodyCompressed (deflateSync). This allows computing divergencePoint (semantic JSON path) and cacheHitRate per turn for Sentry instrumentation without changing core gradient logic.
+<!-- lore:019e079a-d433-795e-9a25-8881a72774ed -->
+* **System prompt layering: host block (1h) + LTM block (no breakpoint) + tools (1h)**: Anthropic request builds 2-block system array via \`buildAnthropicRequest()\`: \`system\[0]\` = host prompt with explicit \`cache\_control { type: 'ephemeral', ttl: '1h' }\`, \`system\[1]\` = injected LTM knowledge without breakpoint. LTM gets prefix-caching benefit when system\[0] stable, but doesn't consume a dedicated breakpoint. Last tool array element gets \`cache\_control { type: 'ephemeral', ttl: '1h' }\` when \`cacheTools\` enabled. This allocation leaves one Anthropic breakpoint slot free for future use. Ordered: host (pinned per session) → LTM (pinned per session with content-diff) → tools (static).
 
-<!-- lore:019e0750-f94e-73e4-8199-5e0dbffdb8e8 -->
-* **forwardToUpstream returns tuple of (response, serializedBody) for cache analytics**: forwardToUpstream now returns \[response, serializedBody] instead of just response. Serialized JSON body captured before API call, threaded through pipeline to postResponse(). Enables gateway-level cache analytics to do byte-level prefix comparison without re-serializing. All downstream callers updated to destructure tuple. Keeps cache ground truth (API response cache fields) at gateway level where request/response lifecycle is visible.
+### Preference
 
-<!-- lore:019e0750-f95f-72e0-a262-46cfd5254e40 -->
-* **forwardToUpstream returns tuple with serialized body for cache analysis**: forwardToUpstream() now returns {response, serializedBody} instead of just response. serializedBody is the JSON string sent to Anthropic before forwarding. postResponse() extracts serializedBody and passes it to analyzeCacheTurn() which compares with previous compressed body. All callers of forwardToUpstream() must destructure result. Enables gateway-level cache analytics without modifying core request serialization.
+<!-- lore:019e079b-cf45-7163-9329-3d9b0ee1b378 -->
+* **Prefers updates over creates: check existing entries first**: prefers updates over creates: check existing entries first,
 
-<!-- lore:019e0750-f988-7d37-aa30-7c23495a00b6 -->
-* **Gateway cache analytics uses Bun's native compression**: Gateway compresses stored request bodies using Bun's built-in deflateSync/inflateSync (no external deps needed). Achieves ~99.4% compression ratio on repetitive JSON. Stores compressed body in SessionState.cacheAnalytics.lastRequestBodyCompressed, decompresses next turn for byte-level prefix comparison. Memory footprint: ~10-50KB per session vs 100-500KB uncompressed.
+<!-- lore:019e0792-9e33-7271-946a-8c18b2e94822 -->
+* **Stash precision - user expects granular control**: User expects 'stash your changes' to mean only AI-made changes in current session. Untracked files can't be stashed by path — \`git stash push \<files>\` fails on untracked files; must use \`--include-untracked\` flag instead. When stashing mixed work: (1) identify agent-only files first, (2) use \`git stash push --include-untracked -- \<files>\` for untracked, (3) never do bare \`git stash\` in shared working directories. After popping, always \`git status\` to verify no foreign changes leaked back.
 
-<!-- lore:019e0751-6ede-7175-86e3-e2fe63e8fcce -->
-* **Gateway owns cache analytics; core gradient stays cache-agnostic**: Cache analytics (lastCompressedBody, cacheRead, cacheCreation, turnCount, cacheHitRatio) live exclusively in gateway SessionState, not core gradient SessionState. forwardToUpstream returns serialized body alongside response. postResponse computes CacheTurnAnalysis (prefixMatchBytes, divergencePoint, divergenceReason) and updates gateway state. Core gradient receives no cache data—it remains pure layer-selection logic. This separation keeps core stateless and lets gateway own Sentry instrumentation and post-analysis logging.
+<!-- lore:019e0794-07a9-7690-83e4-1a30c814d363 -->
+* **User distinguishes between their changes and agent changes in git workflow**: When user says "stash your changes" they mean only the agent's modifications, not all unstaged changes. User expects agent to identify which files were modified by the agent vs. pre-existing changes from stashes or other sources. Agent should use \`git status\` and \`git diff\` to separate agent work from other modifications before stashing/reverting. User gets frustrated when agent blindly stashes everything including changes that came from elsewhere.
 
-<!-- lore:019e0750-fa19-74b3-94a2-e61358c76b58 -->
-* **Gateway request body capture pattern for cache analytics**: forwardToUpstream returns both response and serialized request body for cache analytics: Modified to return {response, requestBody} tuple. Four call sites destructure appropriately—main conversation path uses requestBody for cache analysis, passthrough/recall paths ignore it. postResponse receives requestBody parameter for prefix comparison against previous turn's compressed body stored in SessionState.cacheAnalytics.
-
-<!-- lore:019e0751-6f59-7b89-b800-a75705550310 -->
-* **Request body capture in forwardToUpstream for cache analytics**: forwardToUpstream now returns tuple \[response, serializedBody] so postResponse can access the request JSON that was actually sent. This enables byte-level prefix comparison on next turn without re-serializing. Serialized body is compressed with deflateSync before storage (10-50KB per session). Update all callers to destructure: const \[response, body] = await forwardToUpstream(). Pattern enables ground-truth cache analytics without storing uncompressed request JSON.
-
-<!-- lore:019e0750-f9a9-738f-be0a-048321855b91 -->
-* **Request body compression uses Bun's built-in deflateSync/inflateSync**: Store compressed request bodies in gateway CacheAnalytics using deflateSync() before caching, inflate with inflateSync() next turn for prefix comparison. No external zstd dependency needed. Compression ratio ~0.6% on repetitive JSON (~10–50KB per session vs 100–500KB uncompressed). Byte-level prefix diff reveals exact divergence point for semantic categorization (e.g., 'system changed', 'message content changed').
-
-<!-- lore:019e0751-6f9d-7d33-b685-00e17759de39 -->
-* **Request body compression with deflate for cache analysis storage**: Gateway stores compressed request body using Bun's built-in \`deflateSync\`/\`inflateSync\` (no external dependency). Achieves ~0.6% compression ratio on repetitive JSON payloads, keeping per-session memory at 10-50KB vs 100-500KB uncompressed. Decompress on next turn for byte-level prefix comparison to detect cache invalidation points.
-
-<!-- lore:019e0751-6ee2-7101-8327-04d126adcf5a -->
-* **Request body round-trip for cache divergence analysis**: Gateway's forwardToUpstream returns tuple \[response, serializedRequestBody] for cache analytics. postResponse receives body and compares with previous turn's compressed body (deflateSync). Byte-level prefix diff maps divergence to JSON path (e.g., 'system', 'messages\[3].content\[1]'). API response provides ground truth (cache\_read, cache\_creation tokens). Structured divergence reasons (system changed, message content changed, etc.) enable Sentry instrumentation and root-cause analysis.
-
-<!-- lore:019e0751-6e61-7b93-b5b6-636b40e4a11d -->
-* **Request body serialization capture in forwardToUpstream**: forwardToUpstream now returns {response, serializedBody} tuple. Caller destructures and passes serializedBody to postResponse for cache analytics. Serialized body is the exact JSON sent to Anthropic (after all transforms, tool injection, etc). Non-conversation paths (passthrough, recall follow-ups) destructure but ignore body. Enables precise divergence detection by comparing current vs previous serialized state.
+<!-- lore:019e0792-9e5c-709c-bb5f-a12be6279bea -->
+* **User prefers targeted git operations over bulk stashing**: User distinguishes between "your changes" (agent's modifications) vs "everything" (all uncommitted changes) when using git stash. Prefers precise stashing of specific files rather than bulk \`git stash\` that captures unrelated work. When asked to stash changes, clarify scope and use \`git stash push \<files>\` for selective stashing. CRITICAL: \`git restore\` and \`git checkout\` are destructive and unrecoverable — never use on files that aren't yours. If other people's changes get swept into operations, verify ownership before restoring/discarding. When working in shared directories, always check \`git status\` and confirm file ownership before any destructive git operations.

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -16,7 +16,6 @@ import {
   load,
   config as loreConfig,
   ensureProject,
-  isFirstRun,
   temporal,
   ltm,
   distillation,
@@ -146,6 +145,7 @@ export async function resetPipelineState(): Promise<void> {
   cachedProjectPath = null;
   sessions.clear();
   ltmSessionCache.clear();
+  ltmPinnedText.clear();
   // Shut down batch queue gracefully before clearing the client
   if (llmClient && "shutdown" in llmClient) {
     await (llmClient as LLMClient & { shutdown: () => Promise<void> }).shutdown();
@@ -177,6 +177,46 @@ const ltmSessionCache = new Map<
   string,
   { formatted: string; tokenCount: number }
 >();
+
+/**
+ * Pinned LTM text per session — the text currently being injected into the
+ * system prompt. When ltmSessionCache is invalidated and recomputed, we
+ * compare the new text against the pin. Only update if >5% character
+ * difference to avoid cache busts from minor BM25 re-ranking changes.
+ */
+const ltmPinnedText = new Map<
+  string,
+  { formatted: string; tokenCount: number }
+>();
+
+/**
+ * Measure character-level difference between two strings as a ratio (0..1).
+ * Uses a simple length + common-prefix heuristic — not a full diff, but
+ * sufficient to detect "substantially the same" vs "meaningfully different".
+ */
+function textDiffRatio(a: string, b: string): number {
+  if (a === b) return 0;
+  if (!a || !b) return 1;
+
+  // Common prefix length
+  const minLen = Math.min(a.length, b.length);
+  const maxLen = Math.max(a.length, b.length);
+  let common = 0;
+  for (let i = 0; i < minLen; i++) {
+    if (a[i] === b[i]) common++;
+    else break;
+  }
+
+  // Common suffix length (non-overlapping with prefix)
+  let suffix = 0;
+  for (let i = 0; i < minLen - common; i++) {
+    if (a[a.length - 1 - i] === b[b.length - 1 - i]) suffix++;
+    else break;
+  }
+
+  const matched = common + suffix;
+  return 1 - matched / maxLen;
+}
 
 /** Cached LLM client for background workers. */
 let llmClient: LLMClient | null = null;
@@ -1149,8 +1189,8 @@ async function handleConversationTurn(
     );
   }
 
-  // --- 6. LTM injection into system prompt ---
-  let modifiedSystem = req.system;
+  // --- 6. LTM injection (kept separate from host system prompt for caching) ---
+  let ltmText: string | undefined;
   if (cfg.knowledge.enabled) {
     try {
       let cached = ltmSessionCache.get(sessionID);
@@ -1178,8 +1218,21 @@ async function handleConversationTurn(
       }
 
       if (cached) {
-        setLtmTokens(cached.tokenCount, sessionID);
-        modifiedSystem = `${req.system}\n\n${cached.formatted}`;
+        // Content-diff pinning: only update the injected LTM text if the
+        // new content differs by >5% from what's currently pinned. This
+        // prevents cache busts from minor BM25 re-ranking after background
+        // curation/consolidation invalidates the LTM cache.
+        const pinned = ltmPinnedText.get(sessionID);
+        if (pinned && textDiffRatio(pinned.formatted, cached.formatted) < 0.05) {
+          // Near-identical — keep the pinned text to preserve cache prefix
+          ltmText = pinned.formatted;
+          setLtmTokens(pinned.tokenCount, sessionID);
+        } else {
+          // Substantially different or first injection — pin the new text
+          ltmPinnedText.set(sessionID, cached);
+          ltmText = cached.formatted;
+          setLtmTokens(cached.tokenCount, sessionID);
+        }
       } else {
         setLtmTokens(0, sessionID);
       }
@@ -1192,25 +1245,6 @@ async function handleConversationTurn(
   } else {
     setLtmTokens(0, sessionID);
     consumeCameOutOfIdle(sessionID);
-  }
-
-  // First-run greeting
-  if (isFirstRun()) {
-    modifiedSystem +=
-      "\n\n[Lore plugin] This is the first time Lore has been activated. " +
-      "Briefly let the user know that Lore is now active and their " +
-      "coding agent will get progressively smarter on this codebase " +
-      "over time as knowledge accumulates across sessions.";
-  }
-
-  // Lore knowledge file commit reminder
-  if (cfg.knowledge.enabled) {
-    const filesToTrack = [".lore.md"];
-    if (cfg.agentsFile.enabled) filesToTrack.push(cfg.agentsFile.path);
-    modifiedSystem +=
-      `\n\nWhen making git commits, always check if ${filesToTrack.join(" and ")} ` +
-      `have unstaged changes and include them in the commit. These files contain ` +
-      `shared project knowledge managed by lore and must be version-controlled.`;
   }
 
   // --- 7. Gradient transform on messages ---
@@ -1244,26 +1278,45 @@ async function handleConversationTurn(
 
   const modifiedReq: GatewayRequest = {
     ...req,
-    system: modifiedSystem,
+    // Host system prompt is passed through unmodified — LTM is injected
+    // as a separate system block via cache options for prefix stability.
     messages: transformedMessages,
   };
 
-  // --- 8b. Inject recall tool ---
+  // --- 8b. Inject recall tool (with git reminder appended to description) ---
   // Only inject if the client doesn't already have a recall tool (e.g. from
   // a host plugin like OpenCode) and the request has other tools (so it's a
   // coding agent, not a bare chat).
   if (modifiedReq.tools.length > 0 && !clientHasRecallTool(modifiedReq.tools)) {
-    modifiedReq.tools = [...modifiedReq.tools, RECALL_GATEWAY_TOOL];
+    // Build the recall tool with git reminder baked into its description.
+    // This keeps the reminder in the stable tools prefix (1h cache) rather
+    // than the volatile system prompt.
+    const recallTool = cfg.knowledge.enabled
+      ? {
+          ...RECALL_GATEWAY_TOOL,
+          description:
+            RECALL_GATEWAY_TOOL.description +
+            "\n\nWhen making git commits, always check if .lore.md " +
+            "has unstaged changes and include it in the commit. " +
+            "This file contains shared project knowledge managed " +
+            "by lore and must be version-controlled.",
+        }
+      : RECALL_GATEWAY_TOOL;
+    modifiedReq.tools = [...modifiedReq.tools, recallTool];
   }
 
   // --- 9. Forward to upstream ---
-  // Enable prompt caching for conversation turns:
-  //  - System prompt: explicit breakpoint with 5m TTL (frequent turns)
-  //  - Conversation: breakpoint on last block so Anthropic caches the prefix
+  // Enable prompt caching for conversation turns with layered breakpoints:
+  //  - System prompt: 1h TTL (host prompt is very stable within a session)
+  //  - LTM: separate system block (no breakpoint, benefits from prefix)
+  //  - Tools: 1h TTL on last tool (recall + git reminder are static)
+  //  - Conversation: 5m TTL on last message block
   // Title/summary passthrough (handlePassthrough) never reaches here — it
   // forwards the raw request without buildAnthropicRequest, so no caching.
   const cacheOptions: AnthropicCacheOptions = {
-    systemTTL: "5m",
+    systemTTL: "1h",
+    ltmSystem: ltmText,
+    cacheTools: true,
     cacheConversation: true,
   };
   const { response: upstreamResponse, serializedBody: requestBody } =

--- a/packages/gateway/src/translate/anthropic.ts
+++ b/packages/gateway/src/translate/anthropic.ts
@@ -266,6 +266,24 @@ export type AnthropicCacheOptions = {
   systemTTL?: "5m" | "1h" | false;
 
   /**
+   * LTM knowledge text to inject as a separate system block after the host
+   * prompt. Keeping it in a separate block means the host prompt gets its
+   * own cache breakpoint (1h) and LTM changes don't bust the host prefix.
+   *
+   * When provided AND systemTTL is set, the system becomes a 2-block array:
+   *   system[0]: host prompt  — cache_control with systemTTL
+   *   system[1]: LTM content  — no cache_control (benefits from prefix)
+   */
+  ltmSystem?: string;
+
+  /**
+   * Cache the last tool definition with an explicit 1h breakpoint.
+   * Tool definitions (including our injected recall tool) are stable
+   * across turns — caching them avoids re-processing on every request.
+   */
+  cacheTools?: boolean;
+
+  /**
    * Place an explicit `cache_control` breakpoint on the last block of the
    * last message, enabling Anthropic to cache the conversation prefix.
    *
@@ -329,19 +347,33 @@ export function buildAnthropicRequest(
   // System — only include if non-empty
   if (req.system) {
     const systemTTL = cache?.systemTTL;
+    const ltmText = cache?.ltmSystem;
+
     if (systemTTL) {
-      // Send as block array with explicit cache_control breakpoint.
-      // This creates a stable cache slot for the system prompt — it changes
-      // only when LTM entries are added/removed or AGENTS.md is updated.
+      // Send as block array with explicit cache_control breakpoint on the
+      // host prompt. The host prompt is the most stable part (changes only
+      // when the host mutates AGENTS.md, memory, etc.) so it gets a 1h TTL.
       const cacheControl: Record<string, string> =
         systemTTL === "1h"
           ? { type: "ephemeral", ttl: "1h" }
           : { type: "ephemeral" };
-      body.system = [
+
+      const blocks: Record<string, unknown>[] = [
         { type: "text", text: req.system, cache_control: cacheControl },
       ];
+
+      // LTM knowledge as a separate block — no cache_control of its own,
+      // but benefits from the host prompt prefix cache. When LTM changes,
+      // only this block and everything after it is re-processed; the host
+      // prompt prefix is still a cache read.
+      if (ltmText) {
+        blocks.push({ type: "text", text: ltmText });
+      }
+
+      body.system = blocks;
     } else {
-      body.system = req.system;
+      // No caching — concatenate LTM into a single string.
+      body.system = ltmText ? `${req.system}\n\n${ltmText}` : req.system;
     }
   }
 
@@ -368,11 +400,23 @@ export function buildAnthropicRequest(
 
   // Tools — only include if present
   if (req.tools.length > 0) {
-    body.tools = req.tools.map((t) => ({
+    const tools = req.tools.map((t) => ({
       name: t.name,
       description: t.description,
       input_schema: t.inputSchema,
     }));
+
+    // Tool caching: place a 1h breakpoint on the last tool definition.
+    // Tool definitions (including our recall tool) are stable across turns.
+    if (cache?.cacheTools && tools.length > 0) {
+      const lastTool = tools[tools.length - 1]!;
+      (lastTool as Record<string, unknown>).cache_control = {
+        type: "ephemeral",
+        ttl: "1h",
+      };
+    }
+
+    body.tools = tools;
   }
 
   // Restore all metadata params (temperature, top_p, stop_sequences, etc.)

--- a/packages/gateway/test/anthropic-caching.test.ts
+++ b/packages/gateway/test/anthropic-caching.test.ts
@@ -332,3 +332,196 @@ describe("buildAnthropicRequest — caching doesn't affect other fields", () => 
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// LTM as separate system block
+// ---------------------------------------------------------------------------
+
+describe("buildAnthropicRequest — LTM system block", () => {
+  test("LTM creates a second system block without cache_control", () => {
+    const body = getBody(makeRequest(), {
+      systemTTL: "1h",
+      ltmSystem: "## Long-term Knowledge\n\n* entry one\n* entry two",
+    });
+    const blocks = body.system as Array<Record<string, unknown>>;
+    expect(blocks).toHaveLength(2);
+
+    // Block 0: host prompt with 1h cache
+    expect(blocks[0].type).toBe("text");
+    expect(blocks[0].text).toBe("You are a helpful assistant.");
+    expect(blocks[0].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+
+    // Block 1: LTM — no cache_control
+    expect(blocks[1].type).toBe("text");
+    expect(blocks[1].text).toBe("## Long-term Knowledge\n\n* entry one\n* entry two");
+    expect(blocks[1].cache_control).toBeUndefined();
+  });
+
+  test("no LTM block when ltmSystem is undefined", () => {
+    const body = getBody(makeRequest(), { systemTTL: "1h" });
+    const blocks = body.system as Array<Record<string, unknown>>;
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].text).toBe("You are a helpful assistant.");
+  });
+
+  test("no LTM block when ltmSystem is empty string", () => {
+    const body = getBody(makeRequest(), { systemTTL: "1h", ltmSystem: "" });
+    const blocks = body.system as Array<Record<string, unknown>>;
+    expect(blocks).toHaveLength(1);
+  });
+
+  test("LTM with 5m TTL uses ephemeral without ttl field on host block", () => {
+    const body = getBody(makeRequest(), {
+      systemTTL: "5m",
+      ltmSystem: "some knowledge",
+    });
+    const blocks = body.system as Array<Record<string, unknown>>;
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0].cache_control).toEqual({ type: "ephemeral" });
+    expect(blocks[1].cache_control).toBeUndefined();
+  });
+
+  test("LTM concatenated as string when no caching", () => {
+    const body = getBody(makeRequest(), {
+      systemTTL: false,
+      ltmSystem: "some knowledge",
+    });
+    expect(typeof body.system).toBe("string");
+    expect(body.system).toBe("You are a helpful assistant.\n\nsome knowledge");
+  });
+
+  test("no LTM concatenation when ltmSystem undefined and no caching", () => {
+    const body = getBody(makeRequest(), { systemTTL: false });
+    expect(body.system).toBe("You are a helpful assistant.");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tool caching
+// ---------------------------------------------------------------------------
+
+describe("buildAnthropicRequest — tool caching", () => {
+  const reqWithTools = () =>
+    makeRequest({
+      tools: [
+        {
+          name: "bash",
+          description: "Run a command",
+          inputSchema: { type: "object" },
+        },
+        {
+          name: "recall",
+          description: "Search memory",
+          inputSchema: { type: "object" },
+        },
+      ],
+    });
+
+  test("last tool gets 1h cache_control when cacheTools is true", () => {
+    const body = getBody(reqWithTools(), { cacheTools: true });
+    const tools = body.tools as Array<Record<string, unknown>>;
+    expect(tools).toHaveLength(2);
+
+    // First tool — no cache_control
+    expect(tools[0].cache_control).toBeUndefined();
+
+    // Last tool — 1h cache
+    expect(tools[1].cache_control).toEqual({
+      type: "ephemeral",
+      ttl: "1h",
+    });
+  });
+
+  test("no cache_control on tools when cacheTools is false", () => {
+    const body = getBody(reqWithTools(), { cacheTools: false });
+    const tools = body.tools as Array<Record<string, unknown>>;
+    for (const tool of tools) {
+      expect(tool.cache_control).toBeUndefined();
+    }
+  });
+
+  test("no cache_control on tools when cacheTools is undefined", () => {
+    const body = getBody(reqWithTools(), {});
+    const tools = body.tools as Array<Record<string, unknown>>;
+    for (const tool of tools) {
+      expect(tool.cache_control).toBeUndefined();
+    }
+  });
+
+  test("single tool gets cache_control when cacheTools is true", () => {
+    const req = makeRequest({
+      tools: [
+        {
+          name: "bash",
+          description: "Run a command",
+          inputSchema: { type: "object" },
+        },
+      ],
+    });
+    const body = getBody(req, { cacheTools: true });
+    const tools = body.tools as Array<Record<string, unknown>>;
+    expect(tools).toHaveLength(1);
+    expect(tools[0].cache_control).toEqual({
+      type: "ephemeral",
+      ttl: "1h",
+    });
+  });
+
+  test("no tools array when request has no tools", () => {
+    const body = getBody(makeRequest(), { cacheTools: true });
+    expect(body.tools).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Combined: all cache layers (system 1h + LTM + tools 1h + conversation 5m)
+// ---------------------------------------------------------------------------
+
+describe("buildAnthropicRequest — full layered caching", () => {
+  test("all breakpoints set correctly in production config", () => {
+    const req = makeRequest({
+      messages: [
+        { role: "user", content: [{ type: "text", text: "Hello" }] },
+        { role: "assistant", content: [{ type: "text", text: "Hi!" }] },
+        { role: "user", content: [{ type: "text", text: "More" }] },
+      ],
+      tools: [
+        {
+          name: "bash",
+          description: "Run a command",
+          inputSchema: { type: "object" },
+        },
+        {
+          name: "recall",
+          description: "Search memory",
+          inputSchema: { type: "object" },
+        },
+      ],
+    });
+    const body = getBody(req, {
+      systemTTL: "1h",
+      ltmSystem: "## Knowledge\n\n* gotcha one",
+      cacheTools: true,
+      cacheConversation: true,
+    });
+
+    // System: 2 blocks — host (1h BP) + LTM (no BP)
+    const system = body.system as Array<Record<string, unknown>>;
+    expect(system).toHaveLength(2);
+    expect(system[0].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+    expect(system[1].cache_control).toBeUndefined();
+
+    // Tools: last tool gets 1h BP
+    const tools = body.tools as Array<Record<string, unknown>>;
+    expect(tools[0].cache_control).toBeUndefined();
+    expect(tools[1].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+
+    // Messages: last block of last message gets 5m BP
+    const messages = body.messages as Array<{
+      content: Array<Record<string, unknown>>;
+    }>;
+    const lastMsg = messages[messages.length - 1]!;
+    const lastBlock = lastMsg.content[lastMsg.content.length - 1]!;
+    expect(lastBlock.cache_control).toEqual({ type: "ephemeral" });
+  });
+});

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -511,7 +511,40 @@ export const LorePlugin: Plugin = async (ctx) => {
   // — startup AGENTS.md import, pruneOversized, etc. all fire before the
   // hooks are registered, and a TDZ reference would fail the whole plugin.
   const ltmSessionCache = new Map<string, { formatted: string; tokenCount: number }>();
+
+  /**
+   * Pinned LTM text per session — the text currently being injected.
+   * When ltmSessionCache is invalidated and recomputed, we compare
+   * the new text against the pin. Only update if >5% character
+   * difference to avoid cache busts from minor BM25 re-ranking.
+   */
+  const ltmPinnedText = new Map<string, { formatted: string; tokenCount: number }>();
+
+  /**
+   * Measure character-level difference between two strings as a ratio (0..1).
+   * Uses a simple common-prefix + common-suffix heuristic.
+   */
+  function textDiffRatio(a: string, b: string): number {
+    if (a === b) return 0;
+    if (!a || !b) return 1;
+    const minLen = Math.min(a.length, b.length);
+    const maxLen = Math.max(a.length, b.length);
+    let common = 0;
+    for (let i = 0; i < minLen; i++) {
+      if (a[i] === b[i]) common++;
+      else break;
+    }
+    let suffix = 0;
+    for (let i = 0; i < minLen - common; i++) {
+      if (a[a.length - 1 - i] === b[b.length - 1 - i]) suffix++;
+      else break;
+    }
+    return 1 - (common + suffix) / maxLen;
+  }
+
   function invalidateLtmCache() {
+    // Only clear the computed cache — pins survive to enable content-diff
+    // comparison on the next turn's recomputation.
     ltmSessionCache.clear();
   }
 
@@ -521,7 +554,7 @@ export const LorePlugin: Plugin = async (ctx) => {
 
   try {
     await load(ctx.directory);
-    let firstRun = isFirstRun();
+    const firstRun = isFirstRun();
     ensureProject(projectPath);
 
   if (firstRun) {
@@ -1069,18 +1102,6 @@ export const LorePlugin: Plugin = async (ctx) => {
 
     // Inject LTM knowledge into system prompt — relevance-ranked and budget-capped.
     "experimental.chat.system.transform": async (input, output) => {
-      // One-time first-run note so the agent acknowledges Lore is active.
-      // Cleared after first injection to avoid repeating on subsequent turns.
-      if (firstRun) {
-        output.system.push(
-          "[Lore plugin] This is the first time Lore has been activated. " +
-          "Briefly let the user know that Lore is now active and their " +
-          "coding agent will get progressively smarter on this codebase " +
-          "over time as knowledge accumulates across sessions.",
-        );
-        firstRun = false;
-      }
-
       if (input.model?.limit) {
         setModelLimits(input.model.limit);
       }
@@ -1196,8 +1217,21 @@ export const LorePlugin: Plugin = async (ctx) => {
           }
 
           if (cached) {
-            setLtmTokens(cached.tokenCount, sessionID);
-            output.system.push(cached.formatted);
+            // Content-diff pinning: only update the injected LTM text if
+            // the new content differs by >5% from what's currently pinned.
+            // Prevents cache busts from minor BM25 re-ranking after
+            // background curation/consolidation.
+            const pinned = sessionID ? ltmPinnedText.get(sessionID) : undefined;
+            if (pinned && textDiffRatio(pinned.formatted, cached.formatted) < 0.05) {
+              // Near-identical — keep pinned text to preserve cache prefix
+              setLtmTokens(pinned.tokenCount, sessionID);
+              output.system.push(pinned.formatted);
+            } else {
+              // Substantially different or first injection — pin the new text
+              if (sessionID) ltmPinnedText.set(sessionID, cached);
+              setLtmTokens(cached.tokenCount, sessionID);
+              output.system.push(cached.formatted);
+            }
           } else {
             setLtmTokens(0, sessionID);
           }
@@ -1222,19 +1256,9 @@ export const LorePlugin: Plugin = async (ctx) => {
         if (input.sessionID) consumeCameOutOfIdle(input.sessionID);
       }
 
-      // Remind the agent to include lore-managed files in commits.
-      // They are modified after the lore export runs (post-session) so they
-      // appear as unstaged when the agent goes to commit — the agent must not
-      // skip them just because they look auto-generated.
-      if (cfg.knowledge.enabled) {
-        const filesToTrack = [".lore.md"];
-        if (cfg.agentsFile.enabled) filesToTrack.push(cfg.agentsFile.path);
-        output.system.push(
-          `When making git commits, always check if ${filesToTrack.join(" and ")} ` +
-          `have unstaged changes and include them in the commit. These files contain ` +
-          `shared project knowledge managed by lore and must be version-controlled.`,
-        );
-      }
+      // Git reminder moved to recall tool description for cache stability.
+      // See reflect.ts — the reminder is appended to the recall tool's
+      // description, which is in the stable tools prefix (1h cache).
 
       // Cache-bust diagnostic: track system prompt byte-identity across turns.
       // When the system prompt changes between turns, it invalidates the entire

--- a/packages/opencode/src/reflect.ts
+++ b/packages/opencode/src/reflect.ts
@@ -15,6 +15,13 @@ import {
   type LoreConfig,
 } from "@loreai/core";
 
+/** Git reminder appended to recall tool description for cache stability. */
+const GIT_REMINDER =
+  "\n\nWhen making git commits, always check if .lore.md " +
+  "has unstaged changes and include it in the commit. " +
+  "This file contains shared project knowledge managed " +
+  "by lore and must be version-controlled.";
+
 export function createRecallTool(
   projectPath: string,
   knowledgeEnabled = true,
@@ -22,7 +29,9 @@ export function createRecallTool(
   searchConfig?: LoreConfig["search"],
 ): ReturnType<typeof tool> {
   return tool({
-    description: RECALL_TOOL_DESCRIPTION,
+    description: knowledgeEnabled
+      ? RECALL_TOOL_DESCRIPTION + GIT_REMINDER
+      : RECALL_TOOL_DESCRIPTION,
     args: {
       query: tool.schema.string().describe(RECALL_PARAM_DESCRIPTIONS.query),
       scope: tool.schema


### PR DESCRIPTION
## Summary

- **Split system prompt into 2 blocks** for Anthropic cache stability: `system[0]` host prompt (1h breakpoint) + `system[1]` LTM knowledge (no breakpoint, benefits from prefix cache). When LTM changes, only the suffix is re-processed; the host prompt prefix is still a cache read.
- **Pin LTM text per session with >5% content-diff threshold** — background curation/consolidation invalidates the LTM cache and forces BM25 re-scoring, but the re-scored text is usually nearly identical. Only update the injected LTM if content actually changed meaningfully, suppressing false cache busts.
- **Add 1h cache breakpoint on last tool definition** — tool definitions (including recall) are stable across turns and should be cached.
- **Move git commit reminder into recall tool description** — keeps it in the stable tools prefix (1h cache) instead of the volatile system prompt.
- **Remove first-run greeting from system prompt** — eliminates the turn-1→turn-2 cache bust from greeting removal. Toast notification is preserved.

### Cache breakpoint allocation (3 of 4 Anthropic slots)

| Slot | Content | TTL |
|------|---------|-----|
| `system[0]` | Host prompt (AGENTS.md, base prompt) | 1h |
| `tools[last]` | Recall tool + git reminder | 1h |
| `messages[last]` | Conversation tail | 5m |

### Expected impact

Before: 25% bust rate from LTM re-injection + first-run removal + git reminder mutations.  
After: Only busts from genuine knowledge changes (>5% diff) or host-side prompt mutations (out of our control).

Cost savings: ~$1.30 per 96K token bust avoided (cache read at $1.50/M vs input at $15/M).