### PR TITLE
fix(gateway): preserve thinking block signature through Lore format round-trip

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -79,6 +79,8 @@ export type LoreReasoningPart = {
   messageID: string;
   type: "reasoning";
   text: string;
+  /** Anthropic extended-thinking signature; opaque, must be round-tripped. */
+  signature?: string;
 };
 
 export type LoreToolStatePending = {

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -1491,6 +1491,9 @@ export function loreMessagesToGateway(
           content.push({
             type: "thinking",
             thinking: (part as { text: string }).text ?? "",
+            ...((part as { signature?: string }).signature != null
+              ? { signature: (part as { signature?: string }).signature }
+              : undefined),
           });
           break;
         case "tool": {

--- a/packages/gateway/src/temporal-adapter.ts
+++ b/packages/gateway/src/temporal-adapter.ts
@@ -97,6 +97,9 @@ function contentBlockToPart(
         messageID,
         type: "reasoning",
         text: block.thinking,
+        ...(block.signature != null
+          ? { signature: block.signature }
+          : undefined),
       } satisfies LoreReasoningPart;
 
     case "tool_use":


### PR DESCRIPTION
## Summary

- Fixes `messages.1.content.0.thinking.signature: Field required` error on multi-turn Claude Code conversations through the gateway
- Adds optional `signature` field to `LoreReasoningPart` and threads it through the inbound (temporal-adapter) and outbound (pipeline) conversion paths

## Root Cause

The gateway converts Anthropic thinking blocks to internal `LoreReasoningPart` format, which lacked a `signature` field. On turn 2+, Claude Code sends conversation history containing previous assistant thinking blocks with signatures. The lossy round-trip (`GatewayThinkingBlock` → `LoreReasoningPart` → `GatewayThinkingBlock`) dropped the signature, causing Anthropic's API to reject the request.

## Changes (3 files, ~5 lines)

1. **`packages/core/src/types.ts`** — Add `signature?: string` to `LoreReasoningPart`
2. **`packages/gateway/src/temporal-adapter.ts`** — Carry signature when converting thinking → reasoning
3. **`packages/gateway/src/pipeline.ts`** — Reconstruct signature when converting reasoning → thinking