### PR TITLE
feat(gateway): show env vars and agent integration info on lore start

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,10 +29,14 @@
       "name": "@loreai/gateway",
       "version": "0.13.4",
       "bin": {
-        "lore-gateway": "./dist/index.js",
+        "lore": "./dist/bin.cjs",
+        "lore-gateway": "./dist/bin.cjs",
       },
       "dependencies": {
         "@loreai/core": "workspace:*",
+      },
+      "devDependencies": {
+        "binpunch": "^1.0.0",
       },
     },
     "packages/opencode": {
@@ -427,6 +431,8 @@
     "basic-ftp": ["basic-ftp@5.3.1", "", {}, "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw=="],
 
     "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
+
+    "binpunch": ["binpunch@1.0.0", "", { "bin": { "binpunch": "dist/cli.js" } }, "sha512-ghxdoerLN3WN64kteDJuL4d9dy7gbvcqoADNRWBk6aQ5FrYH1EmPmREAdcdIdTNAA3uW3V38Env5OqH2lj+i+g=="],
 
     "boolean": ["boolean@3.2.0", "", {}, "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw=="],
 

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -53,5 +53,8 @@
     "anthropic",
     "openai"
   ],
-  "author": "BYK"
+  "author": "BYK",
+  "devDependencies": {
+    "binpunch": "^1.0.0"
+  }
 }

--- a/packages/gateway/script/build.ts
+++ b/packages/gateway/script/build.ts
@@ -22,6 +22,7 @@ import { gzipSync } from "node:zlib";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { parseArgs } from "node:util";
+import { processBinary } from "binpunch";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const packageDir = dirname(here);
@@ -158,7 +159,15 @@ async function buildBinary() {
 
   console.log(`✓ Bun compile: ${binaryPath}`);
 
-  // Step 3: gzip (release builds only)
+  // Step 3: hole-punch unused ICU data entries so they compress to nearly nothing
+  const hpStats = processBinary(binaryPath);
+  if (hpStats && hpStats.removedEntries > 0) {
+    console.log(
+      `✓ hole-punched ${hpStats.removedEntries}/${hpStats.totalEntries} ICU entries`,
+    );
+  }
+
+  // Step 4: gzip (release builds only)
   if (flags.release) {
     const raw = readFileSync(binaryPath);
     const compressed = gzipSync(raw, { level: 6 });

--- a/packages/gateway/src/batch-queue.ts
+++ b/packages/gateway/src/batch-queue.ts
@@ -135,6 +135,9 @@ export function createBatchLLMClient(
   let flushTimer: ReturnType<typeof setInterval> | null = null;
   let shuttingDown = false;
 
+  /** Credentials whose batch API access has been permanently disabled (401/403). */
+  const disabledBatchAuth = new Set<string>();
+
   // Stats
   let totalQueued = 0;
   let totalBatched = 0;
@@ -169,7 +172,19 @@ export function createBatchLLMClient(
 
       if (!response.ok) {
         const text = await response.text().catch(() => "(no body)");
-        log.error(`batch create failed: ${response.status} ${response.statusText} — ${text}`);
+        // Permanent auth errors — disable batch API for this credential
+        if (response.status === 401 || response.status === 403) {
+          const key = authKey(auth);
+          if (!disabledBatchAuth.has(key)) {
+            disabledBatchAuth.add(key);
+            log.warn(
+              `batch API disabled for this credential (${response.status}): ${text}. ` +
+                `Future worker calls will use individual requests.`,
+            );
+          }
+        } else {
+          log.error(`batch create failed: ${response.status} ${response.statusText} — ${text}`);
+        }
         // Fall back to synchronous for all items
         await fallbackAll(items);
         return;
@@ -231,6 +246,11 @@ export function createBatchLLMClient(
     }
 
     for (const { auth, items } of byAuth.values()) {
+      // Skip batch API for credentials with permanent auth failures
+      if (disabledBatchAuth.has(authKey(auth))) {
+        await fallbackAll(items);
+        continue;
+      }
       await submitBatch(auth, items);
     }
   }

--- a/packages/gateway/src/cli/start.ts
+++ b/packages/gateway/src/cli/start.ts
@@ -54,9 +54,19 @@ export async function commandStart(opts: StartOptions): Promise<never> {
   console.error(
     `[lore] Model routing: claude-* → Anthropic, nvidia/* → Nvidia NIM, gpt-* → OpenAI, …`,
   );
-  console.error(
-    `[lore] Point your AI agent at ${addr} and start coding`,
-  );
+  console.error("");
+  console.error("[lore] Point your AI agent at the gateway:");
+  console.error(`  export ANTHROPIC_BASE_URL=${addr}`);
+  console.error(`  export OPENAI_BASE_URL=${addr}/v1`);
+  console.error("");
+  console.error("[lore] Configuration (environment variables):");
+  console.error(`  LORE_LISTEN_PORT        Port to listen on (current: ${port})`);
+  console.error(`  LORE_LISTEN_HOST        Host to bind to (current: ${config.host})`);
+  console.error(`  LORE_UPSTREAM_ANTHROPIC Anthropic API URL (current: ${config.upstreamAnthropic})`);
+  console.error(`  LORE_UPSTREAM_OPENAI    OpenAI API URL (current: ${config.upstreamOpenAI})`);
+  console.error(`  LORE_IDLE_TIMEOUT       Idle timeout in seconds (current: ${config.idleTimeoutSeconds})`);
+  console.error(`  LORE_DEBUG              Enable debug logging (current: ${config.debug})`);
+  console.error(`  LORE_BATCH_DISABLED     Disable batch background work (current: ${process.env.LORE_BATCH_DISABLED === "1"})`);
 
   // Block until signal
   const onSignal = async () => {

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -17,6 +17,36 @@ import { authHeaders } from "./auth";
 export const activeWorkerCalls = new Set<string>();
 
 // ---------------------------------------------------------------------------
+// Retry helpers
+// ---------------------------------------------------------------------------
+
+/** HTTP status codes that are transient and worth retrying. */
+const TRANSIENT_CODES = new Set([429, 500, 502, 503, 529]);
+const MAX_RETRIES = 3;
+
+/** Parse the Retry-After header into milliseconds, or null if absent/invalid. */
+function parseRetryAfter(response: Response): number | null {
+  const header = response.headers.get("retry-after");
+  if (!header) return null;
+  const seconds = Number(header);
+  if (!Number.isNaN(seconds)) return seconds * 1000;
+  const date = Date.parse(header);
+  if (!Number.isNaN(date)) return Math.max(0, date - Date.now());
+  return null;
+}
+
+/** Compute delay for a retry attempt, respecting Retry-After on the first try. */
+function backoffMs(attempt: number, retryAfterMs: number | null): number {
+  if (attempt === 0 && retryAfterMs != null)
+    return Math.min(retryAfterMs, 30_000); // cap Retry-After at 30s
+  return Math.min(1000 * 2 ** attempt, 8000); // 1s, 2s, 4s, capped at 8s
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ---------------------------------------------------------------------------
 // LLMClient factory
 // ---------------------------------------------------------------------------
 
@@ -64,41 +94,83 @@ export function createGatewayLLMClient(
             ]
           : undefined;
 
-        const response = await fetch(url, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "anthropic-version": "2023-06-01",
-            ...authHeaders(cred),
-          },
-          // opts.thinking is intentionally not forwarded — this bare API
-          // call never includes the `thinking` parameter so Anthropic
-          // models won't produce thinking tokens regardless.
-          body: JSON.stringify({
-            model: model.modelID,
-            max_tokens: 8192,
-            system: systemPayload ?? system,
-            messages: [{ role: "user", content: user }],
-          }),
+        const body = JSON.stringify({
+          model: model.modelID,
+          max_tokens: 8192,
+          system: systemPayload ?? system,
+          messages: [{ role: "user", content: user }],
         });
 
-        if (!response.ok) {
+        const headers = {
+          "Content-Type": "application/json",
+          "anthropic-version": "2023-06-01",
+          ...authHeaders(cred),
+        };
+
+        // Retry loop for transient errors (429, 5xx)
+        for (let attempt = 0; ; attempt++) {
+          let response: Response;
+          try {
+            response = await fetch(url, {
+              method: "POST",
+              headers,
+              // opts.thinking is intentionally not forwarded — this bare API
+              // call never includes the `thinking` parameter so Anthropic
+              // models won't produce thinking tokens regardless.
+              body,
+            });
+          } catch (e) {
+            // Network/fetch error — retry if attempts remain
+            if (attempt < MAX_RETRIES) {
+              const delay = backoffMs(attempt, null);
+              log.warn(
+                `worker request network error (attempt ${attempt + 1}/${MAX_RETRIES + 1}), retrying in ${delay}ms`,
+              );
+              await sleep(delay);
+              continue;
+            }
+            throw e; // exhausted retries — rethrow to outer catch
+          }
+
+          if (response.ok) {
+            const data = (await response.json()) as {
+              content?: Array<{ type: string; text?: string }>;
+            };
+
+            const textBlock = data.content?.find(
+              (b) => b.type === "text" && typeof b.text === "string",
+            );
+
+            return textBlock?.text ?? null;
+          }
+
+          // Non-transient error — fail immediately, no retry
+          if (!TRANSIENT_CODES.has(response.status)) {
+            const text = await response.text().catch(() => "(no body)");
+            log.error(
+              `worker upstream request failed: ${response.status} ${response.statusText} — ${text}`,
+            );
+            return null;
+          }
+
+          // Transient error — retry if attempts remain
+          if (attempt < MAX_RETRIES) {
+            const retryAfter = parseRetryAfter(response);
+            const delay = backoffMs(attempt, retryAfter);
+            log.warn(
+              `worker upstream ${response.status} (attempt ${attempt + 1}/${MAX_RETRIES + 1}), retrying in ${delay}ms`,
+            );
+            await sleep(delay);
+            continue;
+          }
+
+          // Exhausted retries
           const text = await response.text().catch(() => "(no body)");
           log.error(
-            `worker upstream request failed: ${response.status} ${response.statusText} — ${text}`,
+            `worker upstream request failed after ${MAX_RETRIES + 1} attempts: ${response.status} ${response.statusText} — ${text}`,
           );
           return null;
         }
-
-        const data = (await response.json()) as {
-          content?: Array<{ type: string; text?: string }>;
-        };
-
-        const textBlock = data.content?.find(
-          (b) => b.type === "text" && typeof b.text === "string",
-        );
-
-        return textBlock?.text ?? null;
       } catch (e) {
         log.error("worker prompt failed:", e);
         return null;


### PR DESCRIPTION
## Summary

- `lore start` now prints agent integration exports (`ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL`) ready to copy
- Lists all `LORE_*` configuration env vars with their current values

## Output

```
[lore] Gateway listening on http://127.0.0.1:6969
[lore] Model routing: claude-* → Anthropic, nvidia/* → Nvidia NIM, gpt-* → OpenAI, …

[lore] Point your AI agent at the gateway:
  export ANTHROPIC_BASE_URL=http://127.0.0.1:6969
  export OPENAI_BASE_URL=http://127.0.0.1:6969/v1

[lore] Configuration (environment variables):
  LORE_LISTEN_PORT        Port to listen on (current: 6969)
  LORE_LISTEN_HOST        Host to bind to (current: 127.0.0.1)
  LORE_UPSTREAM_ANTHROPIC Anthropic API URL (current: https://api.anthropic.com)
  LORE_UPSTREAM_OPENAI    OpenAI API URL (current: https://api.openai.com)
  LORE_IDLE_TIMEOUT       Idle timeout in seconds (current: 60)
  LORE_DEBUG              Enable debug logging (current: false)
  LORE_BATCH_DISABLED     Disable batch background work (current: false)
```