### PR TITLE
feat(gateway): implement delta-based self-upgrade system

### DIFF
--- a/packages/gateway/src/cli/help.ts
+++ b/packages/gateway/src/cli/help.ts
@@ -13,6 +13,7 @@ Commands:
   run [command...]    Start gateway and launch an AI agent (default)
   start               Start the gateway server only
   upgrade [version]   Update lore to the latest (or specified) version
+                      Flags: --check, --force, --offline, --channel <ch>
   help                Show this help text
 
 Options:
@@ -29,6 +30,12 @@ Examples:
   lore start                    # Start gateway only (set ANTHROPIC_BASE_URL yourself)
   lore start -p 8080            # Start gateway on a custom port
   lore upgrade                  # Upgrade to latest version
+  lore upgrade --check          # Check for updates without installing
+  lore upgrade --force          # Force re-download even if up to date
+  lore upgrade nightly          # Switch to nightly channel and update
+  lore upgrade stable           # Switch back to stable channel
+  lore upgrade 0.14.0           # Install a specific version
+  lore upgrade --offline        # Upgrade from cached patches (no network)
 
 Environment variables:
   LORE_LISTEN_PORT              Gateway port (overridden by --port)

--- a/packages/gateway/src/cli/lib/binary.ts
+++ b/packages/gateway/src/cli/lib/binary.ts
@@ -1,0 +1,353 @@
+/**
+ * Binary Management
+ *
+ * Shared utilities for installing, replacing, and managing the CLI binary.
+ * Adapted from Sentry CLI's binary.ts for the Lore upgrade system.
+ *
+ * Key differences from Sentry CLI:
+ * - No musl detection (Lore doesn't target Alpine)
+ * - Lore binary naming: `lore-{os}-{arch}[.exe]`
+ * - Install dirs: ~/.lore/bin, ~/.local/bin
+ * - No Sentry SDK telemetry
+ */
+
+import {
+  existsSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { chmod, mkdir, unlink } from "node:fs/promises";
+import { delimiter, join, resolve } from "node:path";
+import { VERSION } from "../version";
+import { stringifyUnknown, UpgradeError } from "./errors";
+
+/** GitHub owner/repo for Lore releases */
+const GITHUB_OWNER = "BYK";
+const GITHUB_REPO = "loreai";
+
+/** GitHub API base URL for releases */
+export const GITHUB_RELEASES_URL =
+  `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/releases`;
+
+/** Known directories where the curl installer may place the binary */
+export const KNOWN_CURL_DIRS = [".local/bin", "bin", ".lore/bin"];
+
+/**
+ * Build the platform-specific binary base name.
+ *
+ * Matches the naming convention used by GitHub Releases and GHCR:
+ * `lore-{os}-{arch}[.exe]`
+ */
+export function getPlatformBinaryName(): string {
+  let os: string;
+  if (process.platform === "darwin") {
+    os = "darwin";
+  } else if (process.platform === "win32") {
+    os = "windows";
+  } else {
+    os = "linux";
+  }
+  const arch = process.arch === "arm64" ? "arm64" : "x64";
+  const suffix = process.platform === "win32" ? ".exe" : "";
+  return `lore-${os}-${arch}${suffix}`;
+}
+
+/**
+ * Build the download URL for a platform-specific binary from GitHub releases.
+ */
+export function getBinaryDownloadUrl(version: string): string {
+  return `https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}/releases/download/${version}/${getPlatformBinaryName()}`;
+}
+
+/**
+ * Detect whether a version string identifies a nightly build.
+ *
+ * Nightlies use the format `X.Y.Z-dev.<unix-seconds>`.
+ */
+export function isNightlyVersion(version: string): boolean {
+  return version.includes("-dev.");
+}
+
+/**
+ * Compare two version strings and return their ordering.
+ *
+ * Uses `Bun.semver.order` which handles both stable (`X.Y.Z`) and
+ * nightly (`X.Y.Z-dev.<unix-seconds>`) versions correctly.
+ */
+export function compareVersions(a: string, b: string): -1 | 0 | 1 {
+  return Bun.semver.order(a, b);
+}
+
+/**
+ * Check whether moving from `current` to `target` is a downgrade.
+ */
+export function isDowngrade(current: string, target: string): boolean {
+  return compareVersions(current, target) === 1;
+}
+
+/**
+ * Get the binary filename for the current platform.
+ */
+export function getBinaryFilename(): string {
+  return process.platform === "win32" ? "lore.exe" : "lore";
+}
+
+/**
+ * Build paths object from an install path.
+ */
+export function getBinaryPaths(installPath: string): {
+  installPath: string;
+  tempPath: string;
+  oldPath: string;
+  lockPath: string;
+} {
+  return {
+    installPath,
+    tempPath: `${installPath}.download`,
+    oldPath: `${installPath}.old`,
+    lockPath: `${installPath}.lock`,
+  };
+}
+
+/**
+ * Determine the install directory for a curl-installed binary.
+ *
+ * Priority:
+ * 1. $LORE_INSTALL_DIR environment variable
+ * 2. ~/.local/bin (if exists AND in $PATH)
+ * 3. ~/bin (if exists AND in $PATH)
+ * 4. ~/.lore/bin (fallback)
+ */
+export function determineInstallDir(
+  homeDir: string,
+  env: NodeJS.ProcessEnv,
+): string {
+  const pathDirs = (env.PATH ?? "").split(delimiter);
+
+  if (env.LORE_INSTALL_DIR) {
+    return env.LORE_INSTALL_DIR;
+  }
+
+  const candidates = [join(homeDir, ".local", "bin"), join(homeDir, "bin")];
+
+  for (const dir of candidates) {
+    if (existsSync(dir) && pathDirs.includes(dir)) {
+      return dir;
+    }
+  }
+
+  return join(homeDir, ".lore", "bin");
+}
+
+/**
+ * Build headers for GitHub API requests.
+ */
+export function getGitHubHeaders(): Record<string, string> {
+  return {
+    Accept: "application/vnd.github.v3+json",
+    "User-Agent": getUserAgent(),
+  };
+}
+
+/**
+ * Generate the User-Agent string for API requests.
+ */
+export function getUserAgent(): string {
+  const runtime =
+    typeof process.versions.bun !== "undefined"
+      ? `bun/${process.versions.bun}`
+      : `node/${process.versions.node}`;
+  return `lore/${VERSION} (${process.platform}-${process.arch}) ${runtime}`;
+}
+
+/**
+ * Fetch wrapper that converts network errors to UpgradeError.
+ */
+export async function fetchWithUpgradeError(
+  url: string,
+  init: RequestInit,
+  serviceName: string,
+): Promise<Response> {
+  try {
+    return await fetch(url, init);
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      throw error;
+    }
+    const msg = stringifyUnknown(error);
+    throw new UpgradeError(
+      "network_error",
+      `Failed to connect to ${serviceName}: ${msg}`,
+    );
+  }
+}
+
+/**
+ * Replace the binary at the install path, handling platform differences.
+ *
+ * Intentionally synchronous: the multi-step rename sequence must be
+ * uninterruptible to avoid leaving the install path in a broken state.
+ *
+ * - Unix: Atomic rename overwrites the target
+ * - Windows: Rename old binary to .old first, then rename temp into place
+ */
+export function replaceBinarySync(tempPath: string, installPath: string): void {
+  if (process.platform === "win32") {
+    const oldPath = `${installPath}.old`;
+    try {
+      renameSync(installPath, oldPath);
+    } catch {
+      try {
+        unlinkSync(oldPath);
+        renameSync(installPath, oldPath);
+      } catch {
+        // Current binary might not exist — that's fine
+      }
+    }
+    renameSync(tempPath, installPath);
+  } else {
+    renameSync(tempPath, installPath);
+  }
+}
+
+/**
+ * Clean up leftover .old files from previous upgrades.
+ * Called on CLI startup. Fire-and-forget.
+ */
+export function cleanupOldBinary(oldPath: string): void {
+  unlink(oldPath).catch(() => {
+    // Intentionally ignore — file may not exist
+  });
+}
+
+// Lock Management
+
+/**
+ * Check if a process with the given PID is still running.
+ */
+export function isProcessRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "EPERM") {
+      return true;
+    }
+    return false;
+  }
+}
+
+/**
+ * Acquire an exclusive lock for binary installation/upgrade.
+ * Uses atomic file creation with 'wx' flag to prevent race conditions.
+ */
+export function acquireLock(lockPath: string): void {
+  try {
+    writeFileSync(lockPath, String(process.pid), { flag: "wx" });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+      throw error;
+    }
+    handleExistingLock(lockPath);
+  }
+}
+
+function handleExistingLock(lockPath: string): void {
+  let content: string;
+  try {
+    content = readFileSync(lockPath, "utf-8").trim();
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      acquireLock(lockPath);
+      return;
+    }
+    throw error;
+  }
+
+  const existingPid = Number.parseInt(content, 10);
+
+  if (!Number.isNaN(existingPid) && isProcessRunning(existingPid)) {
+    if (existingPid === process.ppid) {
+      writeFileSync(lockPath, String(process.pid));
+      return;
+    }
+    throw new UpgradeError(
+      "execution_failed",
+      "Another upgrade is already in progress",
+    );
+  }
+
+  // Stale lock from dead process — remove and retry
+  try {
+    unlinkSync(lockPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+  }
+
+  acquireLock(lockPath);
+}
+
+/**
+ * Release the binary lock.
+ */
+export function releaseLock(lockPath: string): void {
+  try {
+    unlinkSync(lockPath);
+  } catch {
+    // Ignore — file might already be gone
+  }
+}
+
+/**
+ * Install a binary to the target directory.
+ */
+export async function installBinary(
+  sourcePath: string,
+  installDir: string,
+): Promise<string> {
+  await mkdir(installDir, { recursive: true, mode: 0o755 });
+
+  const installPath = join(installDir, getBinaryFilename());
+  const { tempPath, lockPath } = getBinaryPaths(installPath);
+
+  acquireLock(lockPath);
+
+  try {
+    if (resolve(sourcePath) !== resolve(tempPath)) {
+      try {
+        await unlink(tempPath);
+      } catch {
+        // Ignore if doesn't exist
+      }
+
+      await Bun.write(tempPath, Bun.file(sourcePath));
+
+      if (process.platform !== "win32") {
+        await chmod(tempPath, 0o755);
+      }
+    }
+
+    replaceBinarySync(tempPath, installPath);
+  } finally {
+    releaseLock(lockPath);
+  }
+
+  return installPath;
+}
+
+/**
+ * Get the Lore config directory.
+ * Uses $LORE_CONFIG_DIR if set, otherwise ~/.lore
+ */
+export function getConfigDir(): string {
+  if (process.env.LORE_CONFIG_DIR) {
+    return process.env.LORE_CONFIG_DIR;
+  }
+  const home =
+    process.env.HOME ?? process.env.USERPROFILE ?? require("node:os").homedir();
+  return join(home, ".lore");
+}

--- a/packages/gateway/src/cli/lib/bspatch.ts
+++ b/packages/gateway/src/cli/lib/bspatch.ts
@@ -1,0 +1,306 @@
+/**
+ * Streaming TRDIFF10 Binary Patch Application
+ *
+ * Implements the bspatch algorithm for applying binary delta patches in the
+ * TRDIFF10 format (produced by zig-bsdiff with `--use-zstd`). Designed for
+ * minimal memory usage during CLI self-upgrades:
+ *
+ * - Old binary: copy-then-mmap for 0 JS heap (CoW on btrfs/xfs/APFS),
+ *   falling back to `arrayBuffer()` if copy/mmap fails
+ * - Diff/extra blocks: streamed via `DecompressionStream('zstd')`
+ * - Output: written incrementally to disk via `Bun.file().writer()`
+ * - Integrity: SHA-256 computed inline via `Bun.CryptoHasher`
+ *
+ * TRDIFF10 format (from zig-bsdiff):
+ * ```
+ * [0..8]   magic: "TRDIFF10"
+ * [8..16]  controlLen: i64 LE (compressed size of control block)
+ * [16..24] diffLen:    i64 LE (compressed size of diff block)
+ * [24..32] newSize:    i64 LE (expected output size)
+ * [32..]   zstd(control) | zstd(diff) | zstd(extra)
+ * ```
+ *
+ * Adapted from Sentry CLI's bspatch.ts — pure Bun, no external dependencies.
+ */
+
+import { constants, copyFileSync } from "node:fs";
+import { unlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/** TRDIFF10 header magic bytes */
+const TRDIFF10_MAGIC = "TRDIFF10";
+
+/** Header size in bytes (magic + 3 x i64) */
+const HEADER_SIZE = 32;
+
+/** Parsed TRDIFF10 header fields */
+export type PatchHeader = {
+  controlLen: number;
+  diffLen: number;
+  newSize: number;
+};
+
+/**
+ * Read a signed 64-bit little-endian integer using the zig-bsdiff encoding.
+ *
+ * The sign is stored in bit 7 of byte 7 (the MSB of the last byte).
+ * The magnitude is in the lower 63 bits, read as unsigned LE.
+ * This differs from standard two's complement — it uses sign-magnitude.
+ */
+export function offtin(buf: Uint8Array, offset: number): number {
+  const view = new DataView(buf.buffer, buf.byteOffset + offset, 8);
+  const lo = view.getUint32(0, true);
+  const hi = view.getUint32(4, true);
+
+  const magnitude = (hi % 0x80_00_00_00) * 0x1_00_00_00_00 + lo;
+
+  if (magnitude !== 0 && hi >= 0x80_00_00_00) {
+    return -magnitude;
+  }
+  return magnitude;
+}
+
+/**
+ * Parse and validate a TRDIFF10 patch header.
+ */
+export function parsePatchHeader(patch: Uint8Array): PatchHeader {
+  if (patch.byteLength < HEADER_SIZE) {
+    throw new Error(
+      `Patch too small: ${patch.byteLength} bytes (need at least ${HEADER_SIZE})`,
+    );
+  }
+
+  const magic = new TextDecoder().decode(patch.subarray(0, 8));
+  if (magic !== TRDIFF10_MAGIC) {
+    throw new Error(`Invalid patch format: expected TRDIFF10, got "${magic}"`);
+  }
+
+  const controlLen = offtin(patch, 8);
+  const diffLen = offtin(patch, 16);
+  const newSize = offtin(patch, 24);
+
+  if (controlLen < 0 || diffLen < 0 || newSize < 0) {
+    throw new Error("Corrupt patch: negative length in header");
+  }
+
+  const totalCompressed = HEADER_SIZE + controlLen + diffLen;
+  if (totalCompressed > patch.byteLength) {
+    throw new Error(
+      `Corrupt patch: header lengths (${totalCompressed}) exceed file size (${patch.byteLength})`,
+    );
+  }
+
+  return { controlLen, diffLen, newSize };
+}
+
+/**
+ * Buffered reader over a `ReadableStream` that serves exact byte counts.
+ */
+class BufferedStreamReader {
+  private readonly chunks: Uint8Array[] = [];
+  private buffered = 0;
+  private done = false;
+  private readonly reader: ReadableStreamDefaultReader<Uint8Array>;
+
+  constructor(reader: ReadableStreamDefaultReader<Uint8Array>) {
+    this.reader = reader;
+  }
+
+  async read(n: number): Promise<Uint8Array> {
+    while (this.buffered < n && !this.done) {
+      const result = await this.reader.read();
+      if (result.done) {
+        this.done = true;
+        break;
+      }
+      this.chunks.push(result.value);
+      this.buffered += result.value.byteLength;
+    }
+
+    if (this.buffered < n) {
+      throw new Error(
+        `Unexpected end of stream: needed ${n} bytes, have ${this.buffered}`,
+      );
+    }
+
+    const output = new Uint8Array(n);
+    let written = 0;
+
+    while (written < n) {
+      const front = this.chunks[0];
+      if (!front) break;
+      const needed = n - written;
+
+      if (front.byteLength <= needed) {
+        output.set(front, written);
+        written += front.byteLength;
+        this.buffered -= front.byteLength;
+        this.chunks.shift();
+      } else {
+        output.set(front.subarray(0, needed), written);
+        this.chunks[0] = front.subarray(needed);
+        this.buffered -= needed;
+        written = n;
+      }
+    }
+
+    return output;
+  }
+}
+
+/**
+ * Create a streaming zstd decompressor from a compressed buffer.
+ */
+function createZstdStreamReader(compressed: Uint8Array): BufferedStreamReader {
+  const input = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(compressed);
+      controller.close();
+    },
+  });
+
+  // Bun supports 'zstd' but the standard CompressionFormat type doesn't include it.
+  // The double cast works around TypeScript's strict WritableStream<BufferSource>
+  // vs WritableStream<Uint8Array> mismatch in DecompressionStream.
+  const decompressed = input.pipeThrough(
+    new DecompressionStream("zstd" as "deflate") as unknown as TransformStream<Uint8Array, Uint8Array>,
+  );
+
+  return new BufferedStreamReader(
+    decompressed.getReader() as ReadableStreamDefaultReader<Uint8Array>,
+  );
+}
+
+type OldFileHandle = {
+  data: Uint8Array;
+  cleanup: () => void | Promise<void>;
+};
+
+/**
+ * Load the old binary for read access during patching.
+ *
+ * Strategy: copy to temp file, then try mmap on the copy. Falls back to
+ * arrayBuffer() if copy or mmap fails.
+ */
+let loadCounter = 0;
+
+async function loadOldBinary(oldPath: string): Promise<OldFileHandle> {
+  loadCounter += 1;
+  const tempCopy = join(
+    tmpdir(),
+    `lore-patch-old-${process.pid}-${loadCounter}`,
+  );
+  try {
+    copyFileSync(oldPath, tempCopy, constants.COPYFILE_FICLONE);
+    const data = Bun.mmap(tempCopy, { shared: false });
+    return {
+      data,
+      cleanup: () =>
+        unlink(tempCopy).catch(() => {
+          /* Best-effort */
+        }),
+    };
+  } catch {
+    await unlink(tempCopy).catch(() => {
+      /* May not exist */
+    });
+    return {
+      data: new Uint8Array(await Bun.file(oldPath).arrayBuffer()),
+      cleanup: () => {},
+    };
+  }
+}
+
+/**
+ * Apply a TRDIFF10 binary patch with streaming I/O for minimal memory usage.
+ *
+ * @param oldPath - Path to the existing (old) binary file
+ * @param patchData - Complete TRDIFF10 patch file contents
+ * @param destPath - Path to write the patched (new) binary
+ * @returns SHA-256 hex digest of the written output
+ */
+export async function applyPatch(
+  oldPath: string,
+  patchData: Uint8Array,
+  destPath: string,
+): Promise<string> {
+  const { controlLen, diffLen, newSize } = parsePatchHeader(patchData);
+
+  const controlStart = HEADER_SIZE;
+  const diffStart = controlStart + controlLen;
+  const extraStart = diffStart + diffLen;
+
+  // Control block is tiny — decompress fully for random access
+  const controlBlock = Bun.zstdDecompressSync(
+    patchData.subarray(controlStart, diffStart),
+  );
+
+  // Diff and extra blocks are streamed
+  const diffReader = createZstdStreamReader(
+    patchData.subarray(diffStart, extraStart),
+  );
+  const extraReader = createZstdStreamReader(patchData.subarray(extraStart));
+
+  const { data: oldFile, cleanup: cleanupOldFile } =
+    await loadOldBinary(oldPath);
+
+  const writer = Bun.file(destPath).writer();
+  const hasher = new Bun.CryptoHasher("sha256");
+
+  let oldpos = 0;
+  let newpos = 0;
+
+  try {
+    for (
+      let controlPos = 0;
+      controlPos < controlBlock.byteLength;
+      controlPos += 24
+    ) {
+      const readDiffBy = offtin(controlBlock, controlPos);
+      const readExtraBy = offtin(controlBlock, controlPos + 8);
+      const seekBy = offtin(controlBlock, controlPos + 16);
+
+      // Step 1: Read diff bytes and add to old file bytes (wrapping u8 add)
+      if (readDiffBy > 0) {
+        const diffChunk = await diffReader.read(readDiffBy);
+        const outputChunk = new Uint8Array(readDiffBy);
+
+        for (let i = 0; i < readDiffBy; i++) {
+          outputChunk[i] =
+            ((oldFile[oldpos + i] ?? 0) + (diffChunk[i] ?? 0)) % 256;
+        }
+
+        writer.write(outputChunk);
+        hasher.update(outputChunk);
+        oldpos += readDiffBy;
+        newpos += readDiffBy;
+      }
+
+      // Step 2: Copy extra bytes directly to output
+      if (readExtraBy > 0) {
+        const extraChunk = await extraReader.read(readExtraBy);
+        writer.write(extraChunk);
+        hasher.update(extraChunk);
+        newpos += readExtraBy;
+      }
+
+      // Step 3: Seek old file position
+      oldpos += seekBy;
+    }
+  } finally {
+    try {
+      await writer.end();
+    } finally {
+      await cleanupOldFile();
+    }
+  }
+
+  if (newpos !== newSize) {
+    throw new Error(
+      `Output size mismatch: wrote ${newpos} bytes, expected ${newSize}`,
+    );
+  }
+
+  return hasher.digest("hex") as string;
+}

--- a/packages/gateway/src/cli/lib/delta-upgrade.ts
+++ b/packages/gateway/src/cli/lib/delta-upgrade.ts
@@ -1,0 +1,790 @@
+/**
+ * Delta Upgrade Module
+ *
+ * Discovers and applies binary delta patches for CLI self-upgrades.
+ * Instead of downloading the full ~30 MB gzipped binary, downloads
+ * tiny patches (50-500 KB) and applies them to the currently installed
+ * binary using the TRDIFF10 format (zig-bsdiff with zstd compression).
+ *
+ * Supports two channels:
+ * - **Stable**: patches stored as GitHub Release assets with predictable names
+ * - **Nightly**: patches stored in GHCR with `:patch-<version>` tags
+ *
+ * Falls back to full download when:
+ * - No patch is available (404)
+ * - Chain of patches exceeds 60% of the full download size
+ * - Chain exceeds the maximum depth (10 steps)
+ * - Any error occurs during patch download or application
+ *
+ * Adapted from Sentry CLI's delta-upgrade.ts for Lore.
+ * All Sentry SDK telemetry removed — uses plain logging.
+ */
+
+import { unlinkSync } from "node:fs";
+
+import {
+  GITHUB_RELEASES_URL,
+  getPlatformBinaryName,
+  getUserAgent,
+  isDowngrade,
+  isNightlyVersion,
+} from "./binary";
+import { applyPatch } from "./bspatch";
+import { VERSION } from "../version";
+import {
+  downloadLayerBlob,
+  fetchManifest,
+  getAnonymousToken,
+  listTags,
+  type OciManifest,
+} from "./ghcr";
+import { loadCachedChain, savePatchesToCache } from "./patch-cache";
+
+/** Maximum stable patches to chain before falling back to full download */
+const MAX_STABLE_CHAIN_DEPTH = 10;
+
+/**
+ * Maximum nightly patches to chain before falling back to full download.
+ */
+const MAX_NIGHTLY_CHAIN_DEPTH = 30;
+
+/**
+ * Maximum ratio of total patch chain size to full download size.
+ */
+const SIZE_THRESHOLD_RATIO = 0.6;
+
+const SHA256_DIGEST_PATTERN = /^sha256:([0-9a-f]+)$/i;
+
+/** A single link in the patch chain */
+type PatchLink = {
+  data: Uint8Array;
+  size: number;
+};
+
+/** A resolved chain of patches from current version to target version */
+export type PatchChain = {
+  patches: PatchLink[];
+  totalSize: number;
+  expectedSha256: string;
+  steps?: { fromVersion: string; toVersion: string }[];
+};
+
+/** Result of a successful delta upgrade */
+export type DeltaResult = {
+  sha256: string;
+  patchBytes: number;
+  chainLength: number;
+};
+
+// ---------------------------------------------------------------------------
+// Pre-flight check
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether delta upgrade can be attempted.
+ */
+export function canAttemptDelta(targetVersion: string): boolean {
+  if (VERSION === "dev" || VERSION === "0.0.0-dev") {
+    return false;
+  }
+
+  // Cross-channel upgrades are rare one-off operations; skip delta
+  if (isNightlyVersion(VERSION) !== isNightlyVersion(targetVersion)) {
+    return false;
+  }
+
+  if (isDowngrade(VERSION, targetVersion)) {
+    return false;
+  }
+
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Stable channel: GitHub Releases
+// ---------------------------------------------------------------------------
+
+export type GitHubAsset = {
+  name: string;
+  size: number;
+  digest?: string;
+  browser_download_url: string;
+};
+
+export type GitHubRelease = {
+  tag_name: string;
+  assets: GitHubAsset[];
+  body?: string;
+};
+
+/**
+ * Fetch recent releases from GitHub, ordered newest-first.
+ */
+export async function fetchRecentReleases(
+  signal?: AbortSignal,
+): Promise<GitHubRelease[]> {
+  const perPage = MAX_STABLE_CHAIN_DEPTH + 2;
+  let response: Response;
+  try {
+    response = await fetch(`${GITHUB_RELEASES_URL}?per_page=${perPage}`, {
+      headers: {
+        Accept: "application/vnd.github.v3+json",
+        "User-Agent": getUserAgent(),
+      },
+      signal,
+    });
+  } catch {
+    return [];
+  }
+  if (!response.ok) return [];
+  return (await response.json()) as GitHubRelease[];
+}
+
+/**
+ * Extract SHA-256 hex digest from a GitHub asset's digest field.
+ */
+export function extractSha256(asset: GitHubAsset): string | null {
+  if (!asset.digest) return null;
+  const match = SHA256_DIGEST_PATTERN.exec(asset.digest);
+  return match ? (match[1]?.toLowerCase() ?? null) : null;
+}
+
+/**
+ * Download a patch file from a GitHub Release asset URL.
+ */
+export async function downloadStablePatch(
+  url: string,
+  signal?: AbortSignal,
+): Promise<Uint8Array | null> {
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      headers: { "User-Agent": getUserAgent() },
+      signal,
+    });
+  } catch {
+    return null;
+  }
+  if (!response.ok) return null;
+  return new Uint8Array(await response.arrayBuffer());
+}
+
+/**
+ * Extract the target binary SHA-256 from a GitHub Release.
+ */
+export function getStableTargetSha256(
+  release: GitHubRelease,
+  binaryName: string,
+): string | null {
+  const binaryAsset = release.assets.find((a) => a.name === binaryName);
+  if (!binaryAsset) return null;
+  return extractSha256(binaryAsset);
+}
+
+export type ExtractStableChainOpts = {
+  releases: GitHubRelease[];
+  currentVersion: string;
+  targetVersion: string;
+  binaryName: string;
+  fullGzSize: number;
+};
+
+export type StableChainInfo = {
+  patchUrls: string[];
+  expectedSha256: string;
+  steps: { fromVersion: string; toVersion: string }[];
+};
+
+/**
+ * Extract the chain of patch URLs from an already-fetched release list.
+ * Pure computation — no HTTP calls.
+ */
+export function extractStableChain(
+  opts: ExtractStableChainOpts,
+): StableChainInfo | null {
+  const { releases, currentVersion, targetVersion, binaryName, fullGzSize } =
+    opts;
+  const patchAssetName = `${binaryName}.patch`;
+
+  const targetIdx = releases.findIndex((r) => r.tag_name === targetVersion);
+  const currentIdx = releases.findIndex((r) => r.tag_name === currentVersion);
+  if (targetIdx === -1 || currentIdx === -1 || targetIdx >= currentIdx) {
+    return null;
+  }
+
+  const chainReleases = releases.slice(targetIdx, currentIdx);
+  if (chainReleases.length > MAX_STABLE_CHAIN_DEPTH) {
+    return null;
+  }
+
+  const targetRelease = chainReleases[0];
+  if (!targetRelease) return null;
+  const expectedSha256 =
+    getStableTargetSha256(targetRelease, binaryName) ?? "";
+  if (!expectedSha256) return null;
+
+  const patchUrls: string[] = [];
+  let totalSize = 0;
+  for (const release of chainReleases) {
+    const patchAsset = release.assets.find((a) => a.name === patchAssetName);
+    if (!patchAsset) return null;
+    patchUrls.push(patchAsset.browser_download_url);
+    totalSize += patchAsset.size;
+    if (totalSize > fullGzSize * SIZE_THRESHOLD_RATIO) {
+      return null;
+    }
+  }
+
+  // Reverse to get apply order: oldest patch first
+  patchUrls.reverse();
+
+  const reversedReleases = [...chainReleases].reverse();
+  const steps: { fromVersion: string; toVersion: string }[] = [];
+  let prevVersion = currentVersion;
+  for (const release of reversedReleases) {
+    steps.push({ fromVersion: prevVersion, toVersion: release.tag_name });
+    prevVersion = release.tag_name;
+  }
+
+  return { patchUrls, expectedSha256, steps };
+}
+
+/**
+ * Resolve a chain of stable patches from current to target version.
+ */
+export async function resolveStableChain(
+  currentVersion: string,
+  targetVersion: string,
+  signal?: AbortSignal,
+): Promise<PatchChain | null> {
+  const binaryName = getPlatformBinaryName();
+  const releases = await fetchRecentReleases(signal);
+
+  const targetRelease = releases.find((r) => r.tag_name === targetVersion);
+  if (!targetRelease) return null;
+  const gzAsset = targetRelease.assets.find(
+    (a) => a.name === `${binaryName}.gz`,
+  );
+  if (!gzAsset) return null;
+
+  const chainInfo = extractStableChain({
+    releases,
+    currentVersion,
+    targetVersion,
+    binaryName,
+    fullGzSize: gzAsset.size,
+  });
+  if (!chainInfo) return null;
+
+  // Parallel patch download
+  const downloadResults = await Promise.all(
+    chainInfo.patchUrls.map((url) => downloadStablePatch(url, signal)),
+  );
+
+  const patches: PatchLink[] = [];
+  let totalSize = 0;
+  for (const data of downloadResults) {
+    if (!data) return null;
+    patches.push({ data, size: data.byteLength });
+    totalSize += data.byteLength;
+  }
+
+  return {
+    patches,
+    totalSize,
+    expectedSha256: chainInfo.expectedSha256,
+    steps: chainInfo.steps,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Nightly channel: GHCR
+// ---------------------------------------------------------------------------
+
+export function getPatchFromVersion(manifest: OciManifest): string | null {
+  return manifest.annotations?.["from-version"] ?? null;
+}
+
+export function getPatchTargetSha256(
+  manifest: OciManifest,
+  binaryName: string,
+): string | null {
+  return manifest.annotations?.[`sha256-${binaryName}`] ?? null;
+}
+
+export const PATCH_TAG_PREFIX = "patch-";
+
+/**
+ * Filter patch tags to only those in the upgrade chain, sorted in apply order.
+ */
+export function filterAndSortChainTags(
+  allTags: string[],
+  currentVersion: string,
+  targetVersion: string,
+): string[] {
+  const chainTags: { tag: string; version: string }[] = [];
+
+  for (const tag of allTags) {
+    const version = tag.slice(PATCH_TAG_PREFIX.length);
+    if (
+      Bun.semver.order(version, currentVersion) === 1 &&
+      Bun.semver.order(version, targetVersion) !== 1
+    ) {
+      chainTags.push({ tag, version });
+    }
+  }
+
+  chainTags.sort((a, b) => Bun.semver.order(a.version, b.version));
+  return chainTags.map((t) => t.tag);
+}
+
+type NightlyChainValidation = {
+  digests: string[];
+  totalSize: number;
+  expectedSha256: string;
+};
+
+type ValidateChainOpts = {
+  manifests: OciManifest[];
+  chainTags: string[];
+  currentVersion: string;
+  targetVersion: string;
+  patchLayerName: string;
+  binaryName: string;
+  fullGzSize: number;
+};
+
+type ChainStepResult =
+  | { ok: true; digest: string; size: number }
+  | { ok: false };
+
+export function validateChainStep(
+  manifest: OciManifest,
+  opts: { expectedFrom: string; patchLayerName: string; sizeLimit: number },
+): ChainStepResult {
+  const fromVersion = getPatchFromVersion(manifest);
+  if (fromVersion !== opts.expectedFrom) {
+    return { ok: false };
+  }
+
+  const layer = manifest.layers.find((l) => {
+    const title = l.annotations?.["org.opencontainers.image.title"];
+    return title === opts.patchLayerName;
+  });
+  if (!layer) return { ok: false };
+  if (layer.size > opts.sizeLimit) return { ok: false };
+
+  return { ok: true, digest: layer.digest, size: layer.size };
+}
+
+function validateNightlyChain(
+  opts: ValidateChainOpts,
+): NightlyChainValidation | null {
+  const {
+    manifests,
+    chainTags,
+    currentVersion,
+    targetVersion,
+    patchLayerName,
+    binaryName,
+    fullGzSize,
+  } = opts;
+  const digests: string[] = [];
+  let totalSize = 0;
+  let prevVersion = currentVersion;
+
+  for (let i = 0; i < manifests.length; i++) {
+    const manifest = manifests[i];
+    const tag = chainTags[i];
+    if (!(manifest && tag)) return null;
+
+    const remainingBudget = fullGzSize * SIZE_THRESHOLD_RATIO - totalSize;
+    const result = validateChainStep(manifest, {
+      expectedFrom: prevVersion,
+      patchLayerName,
+      sizeLimit: remainingBudget,
+    });
+    if (!result.ok) return null;
+
+    digests.push(result.digest);
+    totalSize += result.size;
+    prevVersion = tag.slice(PATCH_TAG_PREFIX.length);
+
+    if (i === manifests.length - 1) {
+      if (prevVersion !== targetVersion) return null;
+      const sha256 = getPatchTargetSha256(manifest, binaryName) ?? "";
+      if (!sha256) return null;
+      return { digests, totalSize, expectedSha256: sha256 };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Resolve a chain of nightly patches from current to target version.
+ */
+export async function resolveNightlyChain(opts: {
+  token: string;
+  currentVersion: string;
+  targetVersion: string;
+  fullGzSize: number;
+  preloadedTags?: string[];
+  signal?: AbortSignal;
+}): Promise<PatchChain | null> {
+  const {
+    token,
+    currentVersion,
+    targetVersion,
+    fullGzSize,
+    preloadedTags,
+    signal,
+  } = opts;
+  const binaryName = getPlatformBinaryName();
+  const patchLayerName = `${binaryName}.patch`;
+
+  const allTags =
+    preloadedTags ?? (await listTags(token, PATCH_TAG_PREFIX, signal));
+
+  const chainTags = filterAndSortChainTags(
+    allTags,
+    currentVersion,
+    targetVersion,
+  );
+  if (chainTags.length === 0 || chainTags.length > MAX_NIGHTLY_CHAIN_DEPTH) {
+    return null;
+  }
+
+  // Fetch manifests for chain tags
+  const fetchedManifests = new Map<string, OciManifest>();
+  const results = await Promise.all(
+    chainTags.map(async (tag) => {
+      try {
+        const manifest = await fetchManifest(token, tag, signal);
+        return { tag, manifest };
+      } catch {
+        return { tag, manifest: null };
+      }
+    }),
+  );
+
+  for (const { tag, manifest } of results) {
+    if (manifest) fetchedManifests.set(tag, manifest);
+  }
+
+  const manifests: (OciManifest | undefined)[] = chainTags.map((tag) =>
+    fetchedManifests.get(tag),
+  );
+  if (manifests.some((m) => !m)) return null;
+
+  const validation = validateNightlyChain({
+    manifests: manifests as OciManifest[],
+    chainTags,
+    currentVersion,
+    targetVersion,
+    patchLayerName,
+    binaryName,
+    fullGzSize,
+  });
+  if (!validation) return null;
+
+  // Parallel blob download
+  const downloadResults = await Promise.all(
+    validation.digests.map((digest) =>
+      downloadLayerBlob(token, digest, signal).then(
+        (buf) => new Uint8Array(buf),
+      ),
+    ),
+  );
+
+  const patches: PatchLink[] = [];
+  let downloadedSize = 0;
+  for (const data of downloadResults) {
+    patches.push({ data, size: data.byteLength });
+    downloadedSize += data.byteLength;
+  }
+
+  const steps: { fromVersion: string; toVersion: string }[] = [];
+  let prevVersion = currentVersion;
+  for (const tag of chainTags) {
+    const toVersion = tag.slice(PATCH_TAG_PREFIX.length);
+    steps.push({ fromVersion: prevVersion, toVersion });
+    prevVersion = toVersion;
+  }
+
+  return {
+    patches,
+    totalSize: downloadedSize,
+    expectedSha256: validation.expectedSha256,
+    steps,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point: attempt delta upgrade
+// ---------------------------------------------------------------------------
+
+/**
+ * Attempt to download and apply delta patches instead of a full binary.
+ *
+ * This is the main entry point called by `downloadBinaryToTemp()` in
+ * the upgrade module. Falls back gracefully to null on any failure.
+ */
+export async function attemptDeltaUpgrade(
+  targetVersion: string,
+  oldBinaryPath: string,
+  destPath: string,
+  offline?: boolean,
+): Promise<DeltaResult | null> {
+  if (!canAttemptDelta(targetVersion)) {
+    return null;
+  }
+
+  const channel = isNightlyVersion(targetVersion) ? "nightly" : "stable";
+
+  try {
+    const result =
+      channel === "nightly"
+        ? await resolveAndApplyDelta({
+            targetVersion,
+            oldBinaryPath,
+            destPath,
+            resolveFromNetwork: () =>
+              resolveNightlyChainWithContext(targetVersion),
+            channel: "nightly",
+            offline,
+          })
+        : await resolveAndApplyDelta({
+            targetVersion,
+            oldBinaryPath,
+            destPath,
+            resolveFromNetwork: () =>
+              resolveStableChain(VERSION, targetVersion),
+            channel: "stable",
+            offline,
+          });
+
+    return result;
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    console.error(
+      `[lore] Delta upgrade failed (${msg}), falling back to full download`,
+    );
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shared cache-first resolve + apply logic
+// ---------------------------------------------------------------------------
+
+type ResolveAndApplyOpts = {
+  targetVersion: string;
+  oldBinaryPath: string;
+  destPath: string;
+  resolveFromNetwork: () => Promise<PatchChain | null>;
+  channel: string;
+  offline?: boolean;
+};
+
+async function resolveAndApplyDelta(
+  opts: ResolveAndApplyOpts,
+): Promise<DeltaResult | null> {
+  const {
+    targetVersion,
+    oldBinaryPath,
+    destPath,
+    resolveFromNetwork,
+    channel,
+    offline,
+  } = opts;
+
+  // Check patch cache first — enables fully offline upgrades
+  const cached = await tryLoadCachedChain(VERSION, targetVersion);
+  if (cached) {
+    return await applyChainAndReturn(cached, oldBinaryPath, destPath);
+  }
+
+  if (offline) {
+    return null;
+  }
+
+  const chain = await resolveFromNetwork();
+  if (!chain) return null;
+
+  // Save to cache for future offline upgrades, then apply
+  if (chain.steps) {
+    savePatchesToCache(chain, chain.steps).catch(() => {});
+  }
+
+  return await applyChainAndReturn(chain, oldBinaryPath, destPath);
+}
+
+async function tryLoadCachedChain(
+  currentVersion: string,
+  targetVersion: string,
+): Promise<PatchChain | null> {
+  try {
+    return await loadCachedChain(currentVersion, targetVersion);
+  } catch {
+    return null;
+  }
+}
+
+async function applyChainAndReturn(
+  chain: PatchChain,
+  oldBinaryPath: string,
+  destPath: string,
+): Promise<DeltaResult> {
+  const sha256 = await applyPatchChain(chain, oldBinaryPath, destPath);
+  return {
+    sha256,
+    patchBytes: chain.totalSize,
+    chainLength: chain.patches.length,
+  };
+}
+
+/**
+ * Resolve a nightly chain with full context setup.
+ */
+async function resolveNightlyChainWithContext(
+  targetVersion: string,
+  signal?: AbortSignal,
+): Promise<PatchChain | null> {
+  const token = await getAnonymousToken(signal);
+
+  const binaryName = getPlatformBinaryName();
+  const targetTag = `nightly-${targetVersion}`;
+
+  const [nightlyManifest, patchTags] = await Promise.all([
+    fetchManifest(token, targetTag, signal),
+    listTags(token, PATCH_TAG_PREFIX, signal),
+  ]);
+
+  const gzLayer = nightlyManifest.layers.find((l) => {
+    const title = l.annotations?.["org.opencontainers.image.title"];
+    return title === `${binaryName}.gz`;
+  });
+  if (!gzLayer) return null;
+
+  return await resolveNightlyChain({
+    token,
+    currentVersion: VERSION,
+    targetVersion,
+    fullGzSize: gzLayer.size,
+    preloadedTags: patchTags,
+    signal,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Patch application
+// ---------------------------------------------------------------------------
+
+function cleanupIntermediates(destPath: string): void {
+  for (const suffix of [".patching.a", ".patching.b"]) {
+    try {
+      unlinkSync(`${destPath}${suffix}`);
+    } catch {
+      // Ignore cleanup errors
+    }
+  }
+}
+
+async function applyPatchesSequentially(
+  chain: PatchChain,
+  oldBinaryPath: string,
+  destPath: string,
+): Promise<string> {
+  let currentOldPath = oldBinaryPath;
+  let sha256 = "";
+
+  const intermediateA = `${destPath}.patching.a`;
+  const intermediateB = `${destPath}.patching.b`;
+
+  try {
+    for (let i = 0; i < chain.patches.length; i++) {
+      const patch = chain.patches[i];
+      if (!patch) throw new Error(`Missing patch at index ${i}`);
+      const isLast = i === chain.patches.length - 1;
+      const intermediate = i % 2 === 0 ? intermediateA : intermediateB;
+      const outputPath = isLast ? destPath : intermediate;
+
+      sha256 = await applyPatch(currentOldPath, patch.data, outputPath);
+
+      if (!isLast) {
+        currentOldPath = outputPath;
+      }
+    }
+  } finally {
+    if (chain.patches.length > 1) {
+      cleanupIntermediates(destPath);
+    }
+  }
+
+  return sha256;
+}
+
+/**
+ * Apply a resolved patch chain sequentially and verify the result.
+ */
+export async function applyPatchChain(
+  chain: PatchChain,
+  oldBinaryPath: string,
+  destPath: string,
+): Promise<string> {
+  const sha256 = await applyPatchesSequentially(chain, oldBinaryPath, destPath);
+
+  if (sha256 !== chain.expectedSha256) {
+    throw new Error(
+      `SHA-256 mismatch after patching: got ${sha256}, expected ${chain.expectedSha256}`,
+    );
+  }
+
+  return sha256;
+}
+
+// ---------------------------------------------------------------------------
+// Patch Pre-fetching (can be called during background version checks)
+// ---------------------------------------------------------------------------
+
+async function prefetchAndCache(
+  targetVersion: string,
+  signal: AbortSignal | undefined,
+  resolveChain: () => Promise<PatchChain | null>,
+): Promise<void> {
+  if (!canAttemptDelta(targetVersion) || signal?.aborted) {
+    return;
+  }
+
+  const chain = await resolveChain();
+  if (!chain?.steps || signal?.aborted) {
+    return;
+  }
+
+  await savePatchesToCache(chain, chain.steps);
+}
+
+/**
+ * Pre-fetch nightly delta patches for a future upgrade.
+ */
+export function prefetchNightlyPatches(
+  targetVersion: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  return prefetchAndCache(targetVersion, signal, () =>
+    resolveNightlyChainWithContext(targetVersion, signal),
+  );
+}
+
+/**
+ * Pre-fetch stable delta patches for a future upgrade.
+ */
+export function prefetchStablePatches(
+  targetVersion: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  return prefetchAndCache(targetVersion, signal, () =>
+    resolveStableChain(VERSION, targetVersion, signal),
+  );
+}

--- a/packages/gateway/src/cli/lib/errors.ts
+++ b/packages/gateway/src/cli/lib/errors.ts
@@ -1,0 +1,48 @@
+/**
+ * Upgrade Error Types
+ *
+ * Slim error hierarchy for the upgrade system. No Sentry SDK dependency,
+ * no complex exit code mapping — just typed reasons for programmatic handling.
+ */
+
+export type UpgradeErrorReason =
+  | "network_error"
+  | "execution_failed"
+  | "version_not_found"
+  | "offline_cache_miss";
+
+/**
+ * Upgrade-related errors with typed reasons for programmatic handling.
+ */
+export class UpgradeError extends Error {
+  readonly reason: UpgradeErrorReason;
+
+  constructor(reason: UpgradeErrorReason, message?: string) {
+    const defaultMessages: Record<UpgradeErrorReason, string> = {
+      network_error: "Failed to fetch version information.",
+      execution_failed: "Upgrade command failed.",
+      version_not_found: "The specified version was not found.",
+      offline_cache_miss:
+        "Cannot upgrade offline — no pre-downloaded update is available.",
+    };
+    super(message ?? defaultMessages[reason]);
+    this.name = "UpgradeError";
+    this.reason = reason;
+  }
+}
+
+/**
+ * Convert an unknown value to a human-readable string.
+ */
+export function stringifyUnknown(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value instanceof Error) return value.message;
+  if (value && typeof value === "object") {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return String(value);
+    }
+  }
+  return String(value);
+}

--- a/packages/gateway/src/cli/lib/ghcr.ts
+++ b/packages/gateway/src/cli/lib/ghcr.ts
@@ -1,0 +1,389 @@
+/**
+ * GHCR (GitHub Container Registry) Client
+ *
+ * Encapsulates the OCI download protocol for fetching nightly CLI binaries
+ * from ghcr.io/BYK/loreai. Nightly builds are pushed as OCI artifacts
+ * via ORAS with the version baked into the manifest annotation.
+ *
+ * Key design decisions:
+ * - Anonymous access: nightly package is public; no token needed beyond the
+ *   standard ghcr.io anonymous token exchange.
+ * - Version discovery from manifest annotation: `annotations.version` in the
+ *   OCI manifest holds the nightly version.
+ * - Redirect quirk: ghcr.io blob downloads return 307 to Azure Blob Storage.
+ *   Using `fetch` with `redirect: "follow"` would forward the Authorization
+ *   header to Azure, which returns 404. Must follow the redirect manually
+ *   without the auth header.
+ *
+ * Adapted from Sentry CLI's ghcr.ts for Lore.
+ */
+
+import { getUserAgent } from "./binary";
+import { UpgradeError } from "./errors";
+
+/** Default timeout for GHCR HTTP requests (10 seconds) */
+const GHCR_REQUEST_TIMEOUT = 10_000;
+
+/** Maximum number of retry attempts for transient failures */
+const GHCR_MAX_RETRIES = 1;
+
+/** Timeout for large blob downloads (30 seconds) */
+const GHCR_BLOB_TIMEOUT = 30_000;
+
+function isRetryableError(error: Error): boolean {
+  if (error.name === "TimeoutError" || error.name === "AbortError") {
+    return true;
+  }
+  const msg = error.message.toLowerCase();
+  return (
+    msg.includes("timeout") ||
+    msg.includes("econnreset") ||
+    msg.includes("econnrefused") ||
+    msg.includes("network") ||
+    msg.includes("fetch failed")
+  );
+}
+
+function buildSignal(
+  timeout: number,
+  externalSignal?: AbortSignal,
+): AbortSignal {
+  const timeoutSignal = AbortSignal.timeout(timeout);
+  return externalSignal
+    ? AbortSignal.any([timeoutSignal, externalSignal])
+    : timeoutSignal;
+}
+
+function isExternalAbort(error: Error, externalSignal?: AbortSignal): boolean {
+  return Boolean(externalSignal?.aborted && error.name === "AbortError");
+}
+
+type RetryOptions = {
+  timeout?: number;
+  signal?: AbortSignal;
+};
+
+async function fetchWithRetry(
+  url: string,
+  init: RequestInit,
+  context: string,
+  options?: RetryOptions,
+): Promise<Response> {
+  const timeout = options?.timeout ?? GHCR_REQUEST_TIMEOUT;
+  const externalSignal = options?.signal;
+  let lastError: Error | undefined;
+
+  for (let attempt = 0; attempt <= GHCR_MAX_RETRIES; attempt++) {
+    try {
+      const response = await fetch(url, {
+        ...init,
+        signal: buildSignal(timeout, externalSignal),
+      });
+      return response;
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+      if (isExternalAbort(lastError, externalSignal)) {
+        break;
+      }
+      if (attempt >= GHCR_MAX_RETRIES || !isRetryableError(lastError)) {
+        break;
+      }
+    }
+  }
+
+  throw new UpgradeError(
+    "network_error",
+    `${context}: ${lastError?.message ?? "unknown error"}`,
+  );
+}
+
+/** GHCR repository for Lore distribution */
+export const GHCR_REPO = "BYK/loreai";
+
+/** OCI tag for nightly builds */
+export const GHCR_TAG = "nightly";
+
+/** Base URL for GHCR registry API */
+const GHCR_REGISTRY = "https://ghcr.io";
+
+/** OCI manifest media type */
+const OCI_MANIFEST_TYPE = "application/vnd.oci.image.manifest.v1+json";
+
+/** A single layer entry from an OCI manifest. */
+export type OciLayer = {
+  digest: string;
+  mediaType: string;
+  size: number;
+  annotations?: Record<string, string>;
+};
+
+/** OCI image manifest returned by the registry. */
+export type OciManifest = {
+  schemaVersion: number;
+  mediaType?: string;
+  config?: OciLayer;
+  layers: OciLayer[];
+  annotations?: Record<string, string>;
+};
+
+/**
+ * Fetch a short-lived anonymous bearer token for read-only access to the
+ * public ghcr.io/BYK/loreai package.
+ */
+export async function getAnonymousToken(
+  signal?: AbortSignal,
+): Promise<string> {
+  const url = `${GHCR_REGISTRY}/token?scope=repository:${GHCR_REPO}:pull`;
+  const response = await fetchWithRetry(
+    url,
+    { headers: { "User-Agent": getUserAgent() } },
+    "Failed to connect to GHCR",
+    { signal },
+  );
+
+  if (!response.ok) {
+    throw new UpgradeError(
+      "network_error",
+      `GHCR token exchange failed: HTTP ${response.status}`,
+    );
+  }
+
+  const data = (await response.json()) as { token?: string };
+  if (!data.token) {
+    throw new UpgradeError(
+      "network_error",
+      "GHCR token exchange returned no token",
+    );
+  }
+
+  return data.token;
+}
+
+/**
+ * Fetch the OCI manifest for an arbitrary tag from GHCR.
+ */
+export async function fetchManifest(
+  token: string,
+  tag: string,
+  signal?: AbortSignal,
+): Promise<OciManifest> {
+  const url = `${GHCR_REGISTRY}/v2/${GHCR_REPO}/manifests/${tag}`;
+  const response = await fetchWithRetry(
+    url,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: OCI_MANIFEST_TYPE,
+        "User-Agent": getUserAgent(),
+      },
+    },
+    `Failed to fetch manifest for tag "${tag}"`,
+    { signal },
+  );
+
+  if (!response.ok) {
+    throw new UpgradeError(
+      "network_error",
+      `Failed to fetch manifest for tag "${tag}": HTTP ${response.status}`,
+    );
+  }
+
+  return (await response.json()) as OciManifest;
+}
+
+/**
+ * Fetch the OCI manifest for the `:nightly` tag.
+ */
+export async function fetchNightlyManifest(
+  token: string,
+): Promise<OciManifest> {
+  return await fetchManifest(token, GHCR_TAG);
+}
+
+/**
+ * Extract the nightly version string from a manifest's annotations.
+ */
+export function getNightlyVersion(manifest: OciManifest): string {
+  const version = manifest.annotations?.version;
+  if (!version) {
+    throw new UpgradeError(
+      "network_error",
+      "Nightly manifest has no version annotation",
+    );
+  }
+  return version;
+}
+
+/**
+ * Find the layer matching a given filename in an OCI manifest.
+ */
+export function findLayerByFilename(
+  manifest: OciManifest,
+  filename: string,
+): OciLayer {
+  const layer = manifest.layers.find(
+    (l) => l.annotations?.["org.opencontainers.image.title"] === filename,
+  );
+  if (!layer) {
+    throw new UpgradeError(
+      "version_not_found",
+      `No nightly build found for ${filename}`,
+    );
+  }
+  return layer;
+}
+
+/**
+ * Download a nightly binary blob from GHCR.
+ *
+ * The blob endpoint returns a 307 redirect to Azure Blob Storage.
+ * Must follow the redirect manually without the Authorization header.
+ */
+export async function downloadNightlyBlob(
+  token: string,
+  digest: string,
+  signal?: AbortSignal,
+): Promise<Response> {
+  const blobUrl = `${GHCR_REGISTRY}/v2/${GHCR_REPO}/blobs/${digest}`;
+
+  let blobResponse: Response;
+  try {
+    blobResponse = await fetch(blobUrl, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "User-Agent": getUserAgent(),
+      },
+      redirect: "manual",
+      signal: buildSignal(GHCR_BLOB_TIMEOUT, signal),
+    });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    throw new UpgradeError(
+      "network_error",
+      `Failed to connect to GHCR: ${msg}`,
+    );
+  }
+
+  if (blobResponse.status === 200) {
+    return blobResponse;
+  }
+
+  if (
+    blobResponse.status === 301 ||
+    blobResponse.status === 302 ||
+    blobResponse.status === 307 ||
+    blobResponse.status === 308
+  ) {
+    const redirectUrl = blobResponse.headers.get("location");
+    if (!redirectUrl) {
+      throw new UpgradeError(
+        "network_error",
+        `GHCR blob redirect (${blobResponse.status}) had no Location header`,
+      );
+    }
+
+    let redirectResponse: Response;
+    try {
+      redirectResponse = await fetch(redirectUrl, {
+        headers: { "User-Agent": getUserAgent() },
+        signal,
+      });
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      throw new UpgradeError(
+        "network_error",
+        `Failed to download from blob storage: ${msg}`,
+      );
+    }
+
+    if (!redirectResponse.ok) {
+      throw new UpgradeError(
+        "network_error",
+        `Blob storage download failed: HTTP ${redirectResponse.status}`,
+      );
+    }
+
+    return redirectResponse;
+  }
+
+  throw new UpgradeError(
+    "network_error",
+    `Unexpected GHCR blob response: HTTP ${blobResponse.status}`,
+  );
+}
+
+/** Page size for tag listing pagination */
+const TAGS_PAGE_SIZE = 100;
+
+async function fetchTagPage(
+  token: string,
+  lastTag?: string,
+  signal?: AbortSignal,
+): Promise<string[]> {
+  let url = `${GHCR_REGISTRY}/v2/${GHCR_REPO}/tags/list?n=${TAGS_PAGE_SIZE}`;
+  if (lastTag) {
+    url += `&last=${encodeURIComponent(lastTag)}`;
+  }
+
+  const response = await fetchWithRetry(
+    url,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "User-Agent": getUserAgent(),
+      },
+    },
+    "Failed to list GHCR tags",
+    { signal },
+  );
+
+  if (!response.ok) {
+    throw new UpgradeError(
+      "network_error",
+      `Failed to list GHCR tags: HTTP ${response.status}`,
+    );
+  }
+
+  const data = (await response.json()) as { tags?: string[] };
+  return data.tags ?? [];
+}
+
+/**
+ * List tags in the GHCR repository, optionally filtered by prefix.
+ */
+export async function listTags(
+  token: string,
+  prefix?: string,
+  signal?: AbortSignal,
+): Promise<string[]> {
+  const allTags: string[] = [];
+  let lastTag: string | undefined;
+
+  for (;;) {
+    const tags = await fetchTagPage(token, lastTag, signal);
+    if (tags.length === 0) break;
+
+    for (const tag of tags) {
+      if (!prefix || tag.startsWith(prefix)) {
+        allTags.push(tag);
+      }
+    }
+
+    if (tags.length < TAGS_PAGE_SIZE) break;
+    lastTag = tags.at(-1);
+  }
+
+  return allTags;
+}
+
+/**
+ * Download an OCI layer blob as an ArrayBuffer.
+ */
+export async function downloadLayerBlob(
+  token: string,
+  digest: string,
+  signal?: AbortSignal,
+): Promise<ArrayBuffer> {
+  const response = await downloadNightlyBlob(token, digest, signal);
+  return response.arrayBuffer();
+}

--- a/packages/gateway/src/cli/lib/patch-cache.ts
+++ b/packages/gateway/src/cli/lib/patch-cache.ts
@@ -1,0 +1,342 @@
+/**
+ * Patch Cache
+ *
+ * File-based cache for delta upgrade patches. Patches are downloaded
+ * during background version checks so that `lore upgrade` can apply
+ * them offline without any network calls.
+ *
+ * Cache location: <configDir>/patch-cache/
+ * - <fromVersion>-<toVersion>.patch — raw binary patch data
+ * - chain-<fromVersion>-<toVersion>.json — chain metadata
+ *
+ * Uses file-based storage to avoid bloating a DB with 50-80KB binary
+ * blobs. Channel-agnostic — the same version-based naming works for
+ * both nightly (GHCR) and stable (GitHub Releases) channels.
+ *
+ * Adapted from Sentry CLI's patch-cache.ts for Lore.
+ */
+
+import { mkdir, readdir, unlink } from "node:fs/promises";
+import { join } from "node:path";
+import { getConfigDir } from "./binary";
+
+const PATCH_CACHE_DIR = "patch-cache";
+
+/** 7-day TTL for cached patches (milliseconds) */
+const CACHE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** Maximum number of chain steps to prevent infinite loops */
+const MAX_CHAIN_WALK_DEPTH = 10;
+
+/** Metadata for a single patch step */
+export type PatchStepMeta = {
+  fromVersion: string;
+  toVersion: string;
+  size: number;
+};
+
+/** Chain metadata stored alongside patch files */
+export type ChainMeta = {
+  fromVersion: string;
+  toVersion: string;
+  expectedSha256: string;
+  cachedAt: number;
+  patches: PatchStepMeta[];
+};
+
+function getCacheDir(): string {
+  return join(getConfigDir(), PATCH_CACHE_DIR);
+}
+
+async function ensureCacheDir(): Promise<void> {
+  await mkdir(getCacheDir(), { recursive: true, mode: 0o700 });
+}
+
+/**
+ * Sanitize version strings for safe filenames.
+ */
+function sanitizeVersion(version: string): string {
+  return version.replace(/[^a-zA-Z0-9.-]/g, "_");
+}
+
+/** Build the filename for a patch file given a from->to version pair. */
+export function patchFileName(fromVersion: string, toVersion: string): string {
+  return `${sanitizeVersion(fromVersion)}-${sanitizeVersion(toVersion)}.patch`;
+}
+
+/** Build the filename for a chain metadata file. */
+export function chainFileName(fromVersion: string, toVersion: string): string {
+  return `chain-${sanitizeVersion(fromVersion)}-${sanitizeVersion(toVersion)}.json`;
+}
+
+function isNotFound(err: unknown): boolean {
+  return err instanceof Error && "code" in err && err.code === "ENOENT";
+}
+
+/**
+ * Save a patch file and its chain metadata to the cache.
+ */
+export async function savePatchesToCache(
+  chain: {
+    patches: { data: Uint8Array; size: number }[];
+    expectedSha256: string;
+  },
+  steps: { fromVersion: string; toVersion: string }[],
+): Promise<void> {
+  await ensureCacheDir();
+  const cacheDir = getCacheDir();
+
+  // Save all patch files in parallel
+  await Promise.all(
+    chain.patches.flatMap((patch, i) => {
+      const step = steps[i];
+      if (!(step && patch)) return [];
+      const filePath = join(
+        cacheDir,
+        patchFileName(step.fromVersion, step.toVersion),
+      );
+      return [Bun.write(filePath, patch.data)];
+    }),
+  );
+
+  // Save chain metadata
+  if (steps.length > 0) {
+    const firstStep = steps.at(0);
+    const lastStep = steps.at(-1);
+    if (firstStep && lastStep) {
+      const meta: ChainMeta = {
+        fromVersion: firstStep.fromVersion,
+        toVersion: lastStep.toVersion,
+        expectedSha256: chain.expectedSha256,
+        cachedAt: Date.now(),
+        patches: steps.map((s, i) => ({
+          fromVersion: s.fromVersion,
+          toVersion: s.toVersion,
+          size: chain.patches[i]?.size ?? 0,
+        })),
+      };
+      const metaPath = join(
+        cacheDir,
+        chainFileName(firstStep.fromVersion, lastStep.toVersion),
+      );
+      await Bun.write(metaPath, JSON.stringify(meta));
+    }
+  }
+}
+
+/**
+ * Load all chain metadata files from the cache directory.
+ */
+async function loadAllChainMetas(cacheDir: string): Promise<ChainMeta[]> {
+  let files: string[];
+  try {
+    files = await readdir(cacheDir);
+  } catch (err) {
+    if (isNotFound(err)) return [];
+    throw err;
+  }
+
+  const metaFiles = files.filter(
+    (f) => f.startsWith("chain-") && f.endsWith(".json"),
+  );
+
+  const results = await Promise.all(
+    metaFiles.map(async (file) => {
+      try {
+        return (await Bun.file(join(cacheDir, file)).json()) as ChainMeta;
+      } catch {
+        return null;
+      }
+    }),
+  );
+
+  return results.filter((m): m is ChainMeta => m !== null);
+}
+
+/**
+ * Build a step map from chain metadata: fromVersion -> { toVersion, size }.
+ */
+function buildStepMap(
+  chainMetas: ChainMeta[],
+): Map<string, { toVersion: string; size: number }> {
+  const stepMap = new Map<string, { toVersion: string; size: number }>();
+  for (const meta of chainMetas) {
+    for (const step of meta.patches) {
+      stepMap.set(step.fromVersion, {
+        toVersion: step.toVersion,
+        size: step.size,
+      });
+    }
+  }
+  return stepMap;
+}
+
+/**
+ * Walk from currentVersion toward targetVersion using the step map.
+ */
+function walkChainSteps(
+  stepMap: Map<string, { toVersion: string; size: number }>,
+  currentVersion: string,
+  targetVersion: string,
+): { fromVersion: string; toVersion: string }[] | null {
+  const steps: { fromVersion: string; toVersion: string }[] = [];
+  let version = currentVersion;
+  while (version !== targetVersion) {
+    const next = stepMap.get(version);
+    if (!next) return null;
+    steps.push({ fromVersion: version, toVersion: next.toVersion });
+    version = next.toVersion;
+
+    if (steps.length > MAX_CHAIN_WALK_DEPTH) return null;
+  }
+  return steps.length > 0 ? steps : null;
+}
+
+/**
+ * Try to load a complete patch chain from the cache.
+ */
+export async function loadCachedChain(
+  currentVersion: string,
+  targetVersion: string,
+): Promise<{
+  patches: { data: Uint8Array; size: number }[];
+  totalSize: number;
+  expectedSha256: string;
+} | null> {
+  const cacheDir = getCacheDir();
+
+  const chainMetas = await loadAllChainMetas(cacheDir);
+  if (chainMetas.length === 0) return null;
+
+  const stepMap = buildStepMap(chainMetas);
+  const steps = walkChainSteps(stepMap, currentVersion, targetVersion);
+  if (!steps) return null;
+
+  // Find the expectedSha256 from metadata
+  let expectedSha256 = "";
+  for (const meta of chainMetas) {
+    if (meta.toVersion === targetVersion && meta.expectedSha256) {
+      expectedSha256 = meta.expectedSha256;
+      break;
+    }
+  }
+  if (!expectedSha256) return null;
+
+  // Load all patch files in parallel
+  const loadResults = await Promise.all(
+    steps.map(async (step) => {
+      const filePath = join(
+        cacheDir,
+        patchFileName(step.fromVersion, step.toVersion),
+      );
+      try {
+        const data = new Uint8Array(await Bun.file(filePath).arrayBuffer());
+        return { data, size: data.byteLength };
+      } catch (err) {
+        if (isNotFound(err)) return null;
+        throw err;
+      }
+    }),
+  );
+
+  const patches: { data: Uint8Array; size: number }[] = [];
+  let totalSize = 0;
+  for (const result of loadResults) {
+    if (!result) return null;
+    patches.push(result);
+    totalSize += result.size;
+  }
+
+  return { patches, totalSize, expectedSha256 };
+}
+
+/**
+ * Remove expired chain entries and their exclusive patch files.
+ */
+async function removeExpiredEntries(
+  cacheDir: string,
+  files: string[],
+  now: number,
+): Promise<void> {
+  const expiredMetas: ChainMeta[] = [];
+  const livePatchFiles = new Set<string>();
+
+  const metaResults = await Promise.all(
+    files
+      .filter((f) => f.startsWith("chain-") && f.endsWith(".json"))
+      .map(async (file) => {
+        try {
+          const meta = (await Bun.file(
+            join(cacheDir, file),
+          ).json()) as ChainMeta;
+          return { file, meta };
+        } catch {
+          await unlink(join(cacheDir, file)).catch(() => {});
+          return null;
+        }
+      }),
+  );
+
+  for (const result of metaResults) {
+    if (!result) continue;
+    if (now - result.meta.cachedAt > CACHE_MAX_AGE_MS) {
+      expiredMetas.push(result.meta);
+    } else {
+      for (const step of result.meta.patches) {
+        livePatchFiles.add(patchFileName(step.fromVersion, step.toVersion));
+      }
+    }
+  }
+
+  const deletions: Promise<void>[] = [];
+  for (const meta of expiredMetas) {
+    for (const step of meta.patches) {
+      const name = patchFileName(step.fromVersion, step.toVersion);
+      if (!livePatchFiles.has(name)) {
+        deletions.push(unlink(join(cacheDir, name)).catch(() => {}));
+      }
+    }
+    deletions.push(
+      unlink(
+        join(cacheDir, chainFileName(meta.fromVersion, meta.toVersion)),
+      ).catch(() => {}),
+    );
+  }
+
+  await Promise.all(deletions);
+}
+
+/**
+ * Remove stale cache entries older than 7 days.
+ * Called opportunistically. Fire-and-forget.
+ */
+export async function cleanupPatchCache(): Promise<void> {
+  const cacheDir = getCacheDir();
+  let files: string[];
+  try {
+    files = await readdir(cacheDir);
+  } catch (err) {
+    if (isNotFound(err)) return;
+    throw err;
+  }
+  await removeExpiredEntries(cacheDir, files, Date.now());
+}
+
+/**
+ * Remove all cached patch files and chain metadata.
+ * Called after a successful upgrade.
+ */
+export async function clearPatchCache(): Promise<void> {
+  const cacheDir = getCacheDir();
+  let files: string[];
+  try {
+    files = await readdir(cacheDir);
+  } catch (err) {
+    if (isNotFound(err)) return;
+    throw err;
+  }
+
+  await Promise.all(
+    files.map((file) => unlink(join(cacheDir, file)).catch(() => {})),
+  );
+}

--- a/packages/gateway/src/cli/lib/upgrade.ts
+++ b/packages/gateway/src/cli/lib/upgrade.ts
@@ -1,0 +1,454 @@
+/**
+ * Upgrade Module
+ *
+ * Orchestrates binary self-upgrade: version fetching, delta patch
+ * application with full-download fallback, and binary replacement.
+ *
+ * Lore is distributed as a standalone binary only — no package manager
+ * detection or Homebrew support needed. The upgrade flow is:
+ *
+ * 1. Check latest version (GitHub Releases for stable, GHCR for nightly)
+ * 2. Try delta upgrade (tiny patches instead of full ~30MB binary)
+ * 3. Fall back to full .gz download if no patches available
+ * 4. Verify binary, set permissions, replace self atomically
+ *
+ * Adapted from Sentry CLI's upgrade.ts — stripped of brew/npm/pnpm/yarn
+ * detection, setup spawning, and Sentry SDK telemetry.
+ */
+
+import { chmodSync, statSync, unlinkSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+import {
+  acquireLock,
+  cleanupOldBinary,
+  fetchWithUpgradeError,
+  getBinaryFilename,
+  getBinaryPaths,
+  getConfigDir,
+  getGitHubHeaders,
+  getPlatformBinaryName,
+  GITHUB_RELEASES_URL,
+  getBinaryDownloadUrl,
+  isNightlyVersion,
+  KNOWN_CURL_DIRS,
+  releaseLock,
+  replaceBinarySync,
+} from "./binary";
+import { VERSION } from "../version";
+import { attemptDeltaUpgrade, type DeltaResult } from "./delta-upgrade";
+import { UpgradeError } from "./errors";
+import {
+  downloadNightlyBlob,
+  fetchManifest,
+  fetchNightlyManifest,
+  findLayerByFilename,
+  getAnonymousToken,
+  getNightlyVersion,
+} from "./ghcr";
+import { clearPatchCache } from "./patch-cache";
+
+/** Regex to strip 'v' prefix from version strings */
+export const VERSION_PREFIX_REGEX = /^v/;
+
+/** The git tag used for the rolling nightly GitHub release */
+export const NIGHTLY_TAG = "nightly";
+
+/** Release channel type */
+export type ReleaseChannel = "stable" | "nightly";
+
+/**
+ * How the current upgrade reached the offline code path.
+ */
+export type OfflineMode = false | "explicit" | "network-fallback";
+
+// ---------------------------------------------------------------------------
+// Channel persistence
+// ---------------------------------------------------------------------------
+
+const CHANNEL_FILE = "channel";
+
+/**
+ * Read the persisted release channel from ~/.lore/channel.
+ * Returns "stable" if not set or on any error.
+ */
+export function getReleaseChannel(): ReleaseChannel {
+  try {
+    const content = require("node:fs")
+      .readFileSync(join(getConfigDir(), CHANNEL_FILE), "utf-8")
+      .trim();
+    if (content === "nightly") return "nightly";
+  } catch {
+    // File doesn't exist or unreadable — default to stable
+  }
+  return "stable";
+}
+
+/**
+ * Persist the release channel to ~/.lore/channel.
+ */
+export function setReleaseChannel(channel: ReleaseChannel): void {
+  try {
+    const fs = require("node:fs");
+    const dir = getConfigDir();
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(join(dir, CHANNEL_FILE), channel, "utf-8");
+  } catch {
+    // Best-effort — don't fail the upgrade if persistence fails
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Install path resolution
+// ---------------------------------------------------------------------------
+
+const sep = require("node:path").sep;
+
+/**
+ * Known curl install paths, resolved at runtime against the user's home.
+ */
+const KNOWN_CURL_PATHS = KNOWN_CURL_DIRS.map(
+  (dir: string) => join(homedir(), dir) + sep,
+);
+
+/**
+ * Get file paths for the curl-installed binary.
+ */
+export function getCurlInstallPaths(): {
+  installPath: string;
+  tempPath: string;
+  oldPath: string;
+  lockPath: string;
+} {
+  // Check if we're running from a known curl install location
+  for (const dir of KNOWN_CURL_PATHS) {
+    if (process.execPath.startsWith(dir)) {
+      return getBinaryPaths(process.execPath);
+    }
+  }
+
+  // Fallback to default path
+  const defaultPath = join(homedir(), ".lore", "bin", getBinaryFilename());
+  return getBinaryPaths(defaultPath);
+}
+
+/**
+ * Start cleanup of .old binary. Called on CLI startup. Fire-and-forget.
+ */
+export function startCleanupOldBinary(): void {
+  const { oldPath } = getCurlInstallPaths();
+  cleanupOldBinary(oldPath);
+}
+
+// ---------------------------------------------------------------------------
+// Version Fetching
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch the latest stable version from GitHub releases.
+ */
+export async function fetchLatestFromGitHub(
+  signal?: AbortSignal,
+): Promise<string> {
+  const response = await fetchWithUpgradeError(
+    `${GITHUB_RELEASES_URL}/latest`,
+    { headers: getGitHubHeaders(), signal },
+    "GitHub",
+  );
+
+  if (!response.ok) {
+    throw new UpgradeError(
+      "network_error",
+      `Failed to fetch from GitHub: ${response.status}`,
+    );
+  }
+
+  const data = (await response.json()) as { tag_name?: string };
+
+  if (!data.tag_name) {
+    throw new UpgradeError(
+      "network_error",
+      "No version found in GitHub release",
+    );
+  }
+
+  return data.tag_name.replace(VERSION_PREFIX_REGEX, "");
+}
+
+/**
+ * Fetch the latest nightly version from GHCR.
+ */
+export async function fetchLatestNightlyVersion(
+  signal?: AbortSignal,
+): Promise<string> {
+  if (signal?.aborted) throw new Error("Aborted");
+
+  const token = await getAnonymousToken(signal);
+
+  if (signal?.aborted) throw new Error("Aborted");
+
+  const manifest = await fetchNightlyManifest(token);
+  return getNightlyVersion(manifest);
+}
+
+/**
+ * Fetch the latest available version based on channel.
+ */
+export function fetchLatestVersion(
+  channel: ReleaseChannel = "stable",
+  signal?: AbortSignal,
+): Promise<string> {
+  if (channel === "nightly") {
+    return fetchLatestNightlyVersion(signal);
+  }
+  return fetchLatestFromGitHub(signal);
+}
+
+/**
+ * Check if a specific version exists in the appropriate registry.
+ */
+export async function versionExists(
+  version: string,
+  channel: ReleaseChannel,
+): Promise<boolean> {
+  if (isNightlyVersion(version) || channel === "nightly") {
+    try {
+      const token = await getAnonymousToken();
+      await fetchManifest(token, `nightly-${version}`);
+      return true;
+    } catch (error) {
+      if (
+        error instanceof UpgradeError &&
+        (error.message.includes("HTTP 404") ||
+          error.message.includes("HTTP 403"))
+      ) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  const response = await fetchWithUpgradeError(
+    `${GITHUB_RELEASES_URL}/tags/${version}`,
+    { method: "HEAD", headers: getGitHubHeaders() },
+    "GitHub",
+  );
+  return response.ok;
+}
+
+// ---------------------------------------------------------------------------
+// Download
+// ---------------------------------------------------------------------------
+
+export type DownloadResult = {
+  tempBinaryPath: string;
+  lockPath: string;
+  patchBytes?: number;
+};
+
+/**
+ * Stream a response body through gzip decompression to disk.
+ */
+async function streamDecompressToFile(
+  body: ReadableStream<Uint8Array>,
+  destPath: string,
+): Promise<void> {
+  const stream = body.pipeThrough(
+    new DecompressionStream("gzip") as unknown as TransformStream<Uint8Array, Uint8Array>,
+  );
+  const writer = Bun.file(destPath).writer();
+  try {
+    for await (const chunk of stream) {
+      writer.write(chunk);
+    }
+  } finally {
+    await writer.end();
+  }
+}
+
+function getNightlyGzFilename(): string {
+  return `${getPlatformBinaryName()}.gz`;
+}
+
+/**
+ * Download a nightly binary from GHCR and decompress it.
+ */
+async function downloadNightlyToPath(
+  destPath: string,
+  version?: string,
+): Promise<void> {
+  const token = await getAnonymousToken();
+  const manifest = version
+    ? await fetchManifest(token, `nightly-${version}`)
+    : await fetchNightlyManifest(token);
+  const filename = getNightlyGzFilename();
+  const layer = findLayerByFilename(manifest, filename);
+  const response = await downloadNightlyBlob(token, layer.digest);
+
+  if (!response.body) {
+    throw new UpgradeError(
+      "execution_failed",
+      "GHCR blob response had no body",
+    );
+  }
+  await streamDecompressToFile(response.body, destPath);
+}
+
+/**
+ * Download a stable binary from GitHub Releases.
+ * Tries gzip first, falls back to raw binary.
+ */
+async function downloadStableToPath(
+  version: string,
+  destPath: string,
+): Promise<void> {
+  const url = getBinaryDownloadUrl(version);
+  const headers = getGitHubHeaders();
+
+  // Try gzip-compressed download first (~60% smaller)
+  try {
+    const gzResponse = await fetchWithUpgradeError(
+      `${url}.gz`,
+      { headers },
+      "GitHub",
+    );
+    if (gzResponse.ok && gzResponse.body) {
+      await streamDecompressToFile(gzResponse.body, destPath);
+      return;
+    }
+  } catch {
+    // Fall through to raw download
+  }
+
+  const response = await fetchWithUpgradeError(url, { headers }, "GitHub");
+
+  if (!response.ok) {
+    throw new UpgradeError(
+      "execution_failed",
+      `Failed to download binary: HTTP ${response.status}`,
+    );
+  }
+
+  const body = await response.arrayBuffer();
+  await Bun.write(destPath, body);
+}
+
+/** Max probe attempts before giving up */
+const VERIFY_MAX_ATTEMPTS = 6;
+const VERIFY_BASE_DELAY_MS = 100;
+
+function probeBinaryFile(path: string): number | null {
+  const stats = statSync(path, { throwIfNoEntry: false });
+  if (stats?.isFile() && stats.size > 0) return stats.size;
+  return null;
+}
+
+/**
+ * Wait for a freshly written binary to become visible by path.
+ * Handles Windows filesystem visibility race.
+ */
+async function waitForBinaryVisible(path: string): Promise<number> {
+  for (let attempt = 1; attempt <= VERIFY_MAX_ATTEMPTS; attempt++) {
+    const size = probeBinaryFile(path);
+    if (size !== null) return size;
+    if (attempt === VERIFY_MAX_ATTEMPTS) break;
+    const delay = VERIFY_BASE_DELAY_MS * 2 ** (attempt - 1);
+    await Bun.sleep(delay);
+  }
+  throw new UpgradeError(
+    "execution_failed",
+    `Downloaded binary is missing or empty at ${path}. ` +
+      "This is usually transient — rerun `lore upgrade` to retry.",
+  );
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/**
+ * Download the new binary to a temporary path and return its location.
+ *
+ * Tries delta upgrade first, falls back to full download.
+ * The lock is held on success so concurrent upgrades are blocked.
+ */
+export async function downloadBinaryToTemp(
+  version: string,
+  downloadTag?: string,
+  offline?: OfflineMode,
+): Promise<DownloadResult> {
+  const { tempPath, lockPath } = getCurlInstallPaths();
+
+  acquireLock(lockPath);
+
+  try {
+    // Clean up leftover temp file
+    try {
+      unlinkSync(tempPath);
+    } catch {
+      // Ignore
+    }
+
+    // Try delta upgrade first
+    const deltaResult = await attemptDeltaUpgrade(
+      version,
+      process.execPath,
+      tempPath,
+      !!offline,
+    );
+
+    let patchBytes: number | undefined;
+    if (deltaResult) {
+      patchBytes = deltaResult.patchBytes;
+    } else if (offline) {
+      throw new UpgradeError(
+        "offline_cache_miss",
+        offline === "explicit"
+          ? `Cannot upgrade to ${version} in offline mode — no pre-downloaded update is available. ` +
+              "Run `lore upgrade` without `--offline` to download the update directly."
+          : `Cannot upgrade to ${version} — the network is unavailable and no pre-downloaded update was found. ` +
+              "Check your internet connection and try again.",
+      );
+    } else {
+      // Full download
+      if (isNightlyVersion(version)) {
+        await downloadNightlyToPath(tempPath, version);
+      } else {
+        await downloadStableToPath(downloadTag ?? version, tempPath);
+      }
+    }
+
+    const verifiedSize = await waitForBinaryVisible(tempPath);
+    console.error(`[lore] Binary verified (${formatBytes(verifiedSize)})`);
+
+    // Clear consumed patch cache
+    clearPatchCache().catch(() => {});
+
+    // Set executable permission (Unix only)
+    if (process.platform !== "win32") {
+      chmodSync(tempPath, 0o755);
+    }
+
+    return { tempBinaryPath: tempPath, lockPath, patchBytes };
+  } catch (error) {
+    releaseLock(lockPath);
+    throw error;
+  }
+}
+
+/**
+ * Execute the full upgrade: download binary, replace self.
+ *
+ * Returns the download result with paths for the caller to
+ * handle lock release.
+ */
+export async function executeUpgrade(
+  version: string,
+  downloadTag?: string,
+  offline?: OfflineMode,
+): Promise<DownloadResult> {
+  return downloadBinaryToTemp(version, downloadTag, offline);
+}

--- a/packages/gateway/src/cli/upgrade.ts
+++ b/packages/gateway/src/cli/upgrade.ts
@@ -1,14 +1,311 @@
 /**
  * `lore upgrade [version]` — self-update command.
  *
- * Stub — full implementation in Step 8.
+ * Self-update the Lore CLI to the latest or a specific version.
+ * After upgrading, replaces the running binary atomically.
+ *
+ * Supports two release channels:
+ * - stable (default): tracks the latest GitHub release
+ * - nightly: tracks the rolling nightly prerelease from GHCR
+ *
+ * The channel can be set via --channel or by passing "nightly"/"stable"
+ * as the version argument. The choice is persisted in ~/.lore/channel.
+ *
+ * Flags:
+ *   --check    Check for updates without installing
+ *   --force    Force re-download even if up to date
+ *   --offline  Upgrade from cached patches (no network)
+ *   --channel  Set release channel (stable or nightly)
+ *
+ * Adapted from Sentry CLI's upgrade command — stripped of brew/npm
+ * detection, setup spawning, release notes, and Sentry SDK telemetry.
  */
+
+import { parseArgs } from "node:util";
+import { dirname } from "node:path";
 import { VERSION } from "./version";
+import {
+  isDowngrade,
+  installBinary,
+  determineInstallDir,
+  releaseLock,
+} from "./lib/binary";
+import { UpgradeError } from "./lib/errors";
+import {
+  executeUpgrade,
+  fetchLatestVersion,
+  getCurlInstallPaths,
+  getReleaseChannel,
+  NIGHTLY_TAG,
+  type OfflineMode,
+  type ReleaseChannel,
+  setReleaseChannel,
+  versionExists,
+  VERSION_PREFIX_REGEX,
+} from "./lib/upgrade";
+
+/** Special version strings that select a channel */
+const CHANNEL_VERSIONS = new Set(["nightly", "stable"]);
+
+// ---------------------------------------------------------------------------
+// Flag parsing
+// ---------------------------------------------------------------------------
+
+interface UpgradeFlags {
+  check: boolean;
+  force: boolean;
+  offline: boolean;
+  channel?: string;
+}
+
+function parseUpgradeFlags(args: string[]): {
+  flags: UpgradeFlags;
+  versionArg: string | undefined;
+} {
+  const { values, positionals } = parseArgs({
+    args,
+    options: {
+      check: { type: "boolean", default: false },
+      force: { type: "boolean", default: false },
+      offline: { type: "boolean", default: false },
+      channel: { type: "string" },
+    },
+    allowPositionals: true,
+    strict: false,
+  });
+
+  return {
+    flags: {
+      check: !!values.check,
+      force: !!values.force,
+      offline: !!values.offline,
+      channel: values.channel as string | undefined,
+    },
+    versionArg: positionals[0],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Channel + version resolution
+// ---------------------------------------------------------------------------
+
+function resolveChannelAndVersion(
+  versionArg: string | undefined,
+  channelFlag: string | undefined,
+): {
+  channel: ReleaseChannel;
+  cleanVersionArg: string | undefined;
+} {
+  // "nightly" and "stable" as positional args select the channel
+  const lower = versionArg?.toLowerCase();
+  if (lower === "nightly" || lower === "stable") {
+    return { channel: lower, cleanVersionArg: undefined };
+  }
+
+  // --channel flag overrides persisted channel
+  if (channelFlag === "nightly" || channelFlag === "stable") {
+    return { channel: channelFlag, cleanVersionArg: versionArg };
+  }
+
+  return {
+    channel: getReleaseChannel(),
+    cleanVersionArg: versionArg,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Cached version for offline mode
+// ---------------------------------------------------------------------------
+
+/** Simple file-based cache for last-known latest version */
+function getCachedLatestVersion(): string | null {
+  try {
+    const fs = require("node:fs");
+    const path = require("node:path");
+    const { getConfigDir } = require("./lib/binary");
+    const content = fs
+      .readFileSync(path.join(getConfigDir(), "latest-version"), "utf-8")
+      .trim();
+    return content || null;
+  } catch {
+    return null;
+  }
+}
+
+function setCachedLatestVersion(version: string): void {
+  try {
+    const fs = require("node:fs");
+    const path = require("node:path");
+    const { getConfigDir } = require("./lib/binary");
+    const dir = getConfigDir();
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "latest-version"), version, "utf-8");
+  } catch {
+    // Best-effort
+  }
+}
+
+function resolveOfflineTarget(versionArg: string | undefined): string {
+  if (versionArg) {
+    return versionArg.replace(VERSION_PREFIX_REGEX, "");
+  }
+  const cached = getCachedLatestVersion();
+  if (!cached) {
+    throw new UpgradeError(
+      "network_error",
+      "No cached version available. Run `lore upgrade` with network access first, then retry with --offline.",
+    );
+  }
+  return cached;
+}
+
+// ---------------------------------------------------------------------------
+// Main command
+// ---------------------------------------------------------------------------
 
 export async function commandUpgrade(args: string[]): Promise<void> {
-  const target = args[0] ?? "latest";
+  const { flags, versionArg: rawVersionArg } = parseUpgradeFlags(args);
+
+  const { channel, cleanVersionArg } = resolveChannelAndVersion(
+    rawVersionArg,
+    flags.channel,
+  );
+
+  const currentChannel = getReleaseChannel();
+  const channelChanged = channel !== currentChannel;
+
   console.error(`[lore] Current version: ${VERSION}`);
-  console.error(`[lore] Upgrade to "${target}" is not yet implemented.`);
-  console.error("[lore] For now, update via: npm update -g @loreai/gateway");
-  process.exit(1);
+  console.error(`[lore] Channel: ${channel}`);
+
+  // Resolve target version
+  let target: string;
+  let offline: OfflineMode = false;
+
+  if (flags.offline) {
+    // Read cached version BEFORE persisting channel
+    target = resolveOfflineTarget(cleanVersionArg);
+    offline = "explicit";
+    console.error(`[lore] Offline mode: using cached target ${target}`);
+  } else {
+    try {
+      const latest = await fetchLatestVersion(channel);
+      target = cleanVersionArg?.replace(VERSION_PREFIX_REGEX, "") ?? latest;
+
+      // Cache the latest version for future offline use
+      setCachedLatestVersion(latest);
+    } catch (error) {
+      // Try offline fallback
+      if (error instanceof UpgradeError && error.reason === "network_error") {
+        try {
+          target = resolveOfflineTarget(cleanVersionArg);
+          offline = "network-fallback";
+          console.error(
+            "[lore] Network unavailable, falling back to cached upgrade target",
+          );
+        } catch {
+          throw error; // Re-throw original network error
+        }
+      } else {
+        throw error;
+      }
+    }
+  }
+
+  // Persist channel preference
+  if (channelChanged || CHANNEL_VERSIONS.has(rawVersionArg ?? "")) {
+    setReleaseChannel(channel);
+  }
+
+  // --check: just report status
+  if (flags.check) {
+    if (VERSION === target) {
+      console.error(`[lore] Already up to date (${VERSION})`);
+    } else {
+      const direction = isDowngrade(VERSION, target)
+        ? "Downgrade"
+        : "Update";
+      console.error(`[lore] ${direction} available: ${VERSION} -> ${target}`);
+      console.error(`[lore] Run 'lore upgrade' to update.`);
+    }
+    if (offline) {
+      console.error("[lore] (resolved from cache — network unavailable)");
+    }
+    return;
+  }
+
+  // Already on target — unless forced or switching channels
+  if (VERSION === target && !flags.force && !channelChanged) {
+    console.error(`[lore] Already up to date (${VERSION})`);
+    return;
+  }
+
+  // Validate pinned version exists (skip for channel keywords)
+  if (
+    cleanVersionArg &&
+    !CHANNEL_VERSIONS.has(cleanVersionArg) &&
+    !offline
+  ) {
+    const exists = await versionExists(target, channel);
+    if (!exists) {
+      throw new UpgradeError(
+        "version_not_found",
+        `Version ${target} not found`,
+      );
+    }
+  }
+
+  const downgrade = isDowngrade(VERSION, target);
+  const verb = downgrade ? "Downgrading" : "Upgrading";
+  console.error(`[lore] ${verb} to ${target}...`);
+
+  // Use the rolling "nightly" tag only when upgrading to latest nightly
+  const downloadTag =
+    channel === "nightly" && !cleanVersionArg ? NIGHTLY_TAG : undefined;
+
+  // Download the new binary
+  const downloadResult = await executeUpgrade(target, downloadTag, offline);
+
+  if (downloadResult.patchBytes) {
+    console.error(
+      `[lore] Applied delta patch (${formatBytes(downloadResult.patchBytes)} downloaded)`,
+    );
+  }
+
+  // Install: replace the current binary atomically
+  try {
+    const currentInstallDir = dirname(getCurlInstallPaths().installPath);
+    const installDir = determineInstallDir(
+      require("node:os").homedir(),
+      process.env,
+    );
+    // Use current install dir if we're already in a known location
+    const targetDir = process.execPath.startsWith(currentInstallDir)
+      ? currentInstallDir
+      : installDir;
+
+    const installedPath = await installBinary(
+      downloadResult.tempBinaryPath,
+      targetDir,
+    );
+
+    console.error(
+      `[lore] ${downgrade ? "Downgraded" : "Upgraded"} successfully: ${VERSION} -> ${target}`,
+    );
+    console.error(`[lore] Binary installed at: ${installedPath}`);
+    if (offline) {
+      console.error("[lore] (upgraded from cached patches)");
+    }
+  } finally {
+    releaseLock(downloadResult.lockPath);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }


### PR DESCRIPTION
## Summary

Adapts Sentry CLI's upgrade architecture for the Lore CLI. Replaces the `lore upgrade` stub with a full self-update system featuring bandwidth-efficient delta patches.

### What's included

**7 new modules** in `packages/gateway/src/cli/lib/`:

| Module | Purpose |
|---|---|
| `errors.ts` | Typed `UpgradeError` with reasons for programmatic handling |
| `binary.ts` | Platform detection, install paths (`~/.lore/bin`), PID-based locking, atomic binary replacement |
| `bspatch.ts` | TRDIFF10 binary patch application — streaming zstd + bsdiff with SHA-256 verification |
| `ghcr.ts` | GHCR OCI client for nightly distribution — anonymous token, manifest fetch, blob download |
| `patch-cache.ts` | File-based delta cache (`~/.lore/patch-cache/`) with 7-day TTL for offline upgrades |
| `delta-upgrade.ts` | Stable chain (GitHub Releases) + nightly chain (GHCR) resolution and application |
| `upgrade.ts` | Download orchestration — delta-first with full `.gz` fallback, channel persistence |

**Rewritten** `cli/upgrade.ts` command handler with flags:
- `--check` — check for updates without installing
- `--force` — force re-download even if up to date
- `--offline` — upgrade from cached patches only
- `--channel <stable|nightly>` — set release channel

### Key design decisions

- **No new dependencies** — uses Bun built-ins (`Bun.semver`, `Bun.mmap`, `Bun.CryptoHasher`, `Bun.zstdDecompressSync`, `DecompressionStream`)
- **Curl-only distribution** — no brew/npm/pnpm/yarn detection
- **Delta patches reduce download ~80%** (50-500 KB patches vs 30 MB binary)
- **Nightly support included** but requires CI setup (GHCR push) before it's operational
- **Config stored in `~/.lore/`** — channel file, latest-version cache, patch-cache directory
- All Sentry SDK telemetry stripped; logging via `console.error("[lore]")`