### PR TITLE
chore: add dist-bin/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+dist-bin/
 dist-tarballs/
 local_cache/
 *.tgz


### PR DESCRIPTION
## Summary
- Add `dist-bin/` to `.gitignore` to prevent compiled standalone binaries from being committed