### PR TITLE
feat(gateway): debug ID source maps + zero runtime dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,8 @@ jobs:
       # -----------------------------------------------------------------
       - name: Build npm bundle (CJS)
         run: bun run --filter '@loreai/gateway' bundle
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
       - name: Smoke-test npm bundle under Node.js
         run: |
@@ -86,6 +88,8 @@ jobs:
 
       - name: Build linux-x64 binary
         run: bun run --filter '@loreai/gateway' build:binary
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
       - name: Smoke-test standalone binary
         run: |
@@ -168,6 +172,8 @@ jobs:
           done
           echo "--- Release binaries: ---"
           ls -la packages/gateway/dist-bin/
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
       - name: Upload tarballs
         if: startsWith(github.ref, 'refs/heads/release/')
@@ -228,6 +234,8 @@ jobs:
           done
           echo "--- Nightly binaries: ---"
           ls -la packages/gateway/dist-bin/
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
       - name: Upload compressed artifacts
         uses: actions/upload-artifact@v4

--- a/bun.lock
+++ b/bun.lock
@@ -32,11 +32,9 @@
         "lore": "./dist/bin.cjs",
         "lore-gateway": "./dist/bin.cjs",
       },
-      "dependencies": {
+      "devDependencies": {
         "@loreai/core": "workspace:*",
         "@sentry/bun": "^10.52.0",
-      },
-      "devDependencies": {
         "binpunch": "^1.0.0",
       },
     },

--- a/packages/gateway/instrument.ts
+++ b/packages/gateway/instrument.ts
@@ -17,6 +17,41 @@ import * as Sentry from "@sentry/bun";
 import { log } from "@loreai/core";
 import { VERSION } from "./src/cli/version";
 
+/**
+ * Build-time debug ID for sourcemap resolution, injected by esbuild.
+ *
+ * During the build, esbuild's `define` replaces this identifier with a
+ * placeholder UUID string literal. After esbuild finishes, the build
+ * script replaces the placeholder with the real debug ID (derived from
+ * the sourcemap content hash). The same-length swap keeps sourcemap
+ * character positions valid.
+ */
+declare const __SENTRY_DEBUG_ID__: string | undefined;
+
+/**
+ * Register the build-time debug ID with the Sentry SDK's native discovery.
+ *
+ * The SDK reads `globalThis._sentryDebugIds` (a map of Error.stack → debugId)
+ * during event processing to populate `debug_meta.images`, which the server
+ * uses to match uploaded sourcemaps.
+ *
+ * This is the ESM-safe alternative to prepending an IIFE snippet — placing
+ * the registration here (inside the module, after all imports) is valid ESM
+ * and feeds the SDK's existing mechanism directly.
+ */
+if (typeof __SENTRY_DEBUG_ID__ !== "undefined") {
+  try {
+    const stack = new Error().stack;
+    if (stack) {
+      const g = globalThis as any;
+      g._sentryDebugIds = g._sentryDebugIds || {};
+      g._sentryDebugIds[stack] = __SENTRY_DEBUG_ID__;
+    }
+  } catch (_) {
+    // Non-critical — sourcemap resolution degrades gracefully
+  }
+}
+
 if (VERSION !== "dev" && !Sentry.isInitialized()) {
   Sentry.init({
     dsn: "https://0282201d6a3df3bc46423e61012ae62b@o275100.ingest.us.sentry.io/4511355222622208",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -23,13 +23,11 @@
     "build:binary": "bun run script/build.ts --binary",
     "start": "bun run src/index.ts"
   },
-  "dependencies": {
-    "@loreai/core": "workspace:*",
-    "@sentry/bun": "^10.52.0"
-  },
+  "dependencies": {},
   "files": [
     "src/",
     "dist/",
+    "!dist/**/*.map",
     "README.md",
     "LICENSE"
   ],
@@ -56,6 +54,8 @@
   ],
   "author": "BYK",
   "devDependencies": {
+    "@loreai/core": "workspace:*",
+    "@sentry/bun": "^10.52.0",
     "binpunch": "^1.0.0"
   }
 }

--- a/packages/gateway/script/build.ts
+++ b/packages/gateway/script/build.ts
@@ -11,18 +11,34 @@
  *      Produces a standalone Bun binary for GitHub Releases.
  *      Everything is bundled (core, npm deps). Only bun:* stays external.
  *
+ *      Uses a two-step build to produce external sourcemaps for Sentry:
+ *      1. Bundle TS → single minified JS + external .map (esbuild)
+ *      2. Inject debug IDs + swap placeholder UUID → real content-hash UUID
+ *      3. Compile JS → native binary per platform (bun build --compile)
+ *         (sourcemap is backed up/restored around Bun compile)
+ *      4. Upload .map to Sentry for server-side stack trace resolution
+ *
  *      Targets are controlled via --target (default: current platform).
  *      Example: bun run script/build.ts --binary --target linux-x64
  *
  *      The --release flag enables gzip compression of the output.
  */
 import * as esbuild from "esbuild";
-import { rmSync, mkdirSync, readFileSync } from "node:fs";
+import {
+  rmSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  renameSync,
+  unlinkSync,
+} from "node:fs";
+import { execSync } from "node:child_process";
 import { gzipSync } from "node:zlib";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { parseArgs } from "node:util";
 import { processBinary } from "binpunch";
+import { PLACEHOLDER_DEBUG_ID, injectDebugId } from "./debug-id";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const packageDir = dirname(here);
@@ -110,6 +126,7 @@ async function buildBinary() {
 
   // Step 1: esbuild bundle — single ESM file with everything inlined
   const bundlePath = join(distBinDir, "bin.js");
+  const mapPath = join(distBinDir, "bin.js.map");
 
   await esbuild.build({
     entryPoints: [join(packageDir, "src/cli/bin.ts")],
@@ -122,27 +139,70 @@ async function buildBinary() {
     // platform-specific .node files that esbuild can't bundle)
     external: ["bun:*", "fastembed", "onnxruntime-*", "@anush008/*"],
     outfile: bundlePath,
+    // "linked" produces an external .map file with a //# sourceMappingURL=
+    // comment in the JS. This map is uploaded to Sentry (never shipped to users).
+    sourcemap: "linked",
     minify: true,
     logLevel: "info",
     legalComments: "none",
     define: {
       LORE_CLI_VERSION: JSON.stringify(pkg.version),
+      __SENTRY_DEBUG_ID__: JSON.stringify(PLACEHOLDER_DEBUG_ID),
     },
   });
 
   console.log(`✓ esbuild bundle: ${bundlePath}`);
 
-  // Step 2: bun build --compile — produce native binary
-  // We shell out because Bun.build({ compile }) tries to resolve externals
-  // at runtime, while the CLI --compile handles them correctly.
+  // Step 2: Inject debug IDs into the JS and sourcemap
+  // skipSnippet: true — the IIFE snippet breaks ESM (placed before import
+  // declarations). The debug ID is instead registered in instrument.ts via
+  // the build-time __SENTRY_DEBUG_ID__ constant.
+  let debugId: string | undefined;
+
+  try {
+    const result = await injectDebugId(bundlePath, mapPath, {
+      skipSnippet: true,
+    });
+    debugId = result.debugId;
+    console.log(`✓ Debug ID injected: ${debugId}`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`⚠ Debug ID injection failed: ${msg}`);
+  }
+
+  // Replace the placeholder UUID with the real debug ID in the JS bundle.
+  // Both are 36-char UUIDs so sourcemap character positions stay valid.
+  if (debugId) {
+    try {
+      const content = readFileSync(bundlePath, "utf-8");
+      writeFileSync(bundlePath, content.replaceAll(PLACEHOLDER_DEBUG_ID, debugId));
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`⚠ Debug ID placeholder replacement failed: ${msg}`);
+    }
+  }
+
+  // Step 3: bun build --compile — produce native binary
+  // Rename the esbuild map out of the way before Bun.build — when using
+  // sourcemap: "linked", Bun writes its own map to bin.js.map. The esbuild
+  // map (which maps back to original TS) is what we upload to Sentry.
+  // Bun's embedded map handles runtime Error.stack → esbuild-output mapping
+  // automatically, so the two compose: Bun runtime → esbuild positions →
+  // original TS (via Sentry's uploaded map).
+  const esbuildMapBackup = `${mapPath}.esbuild`;
+  renameSync(mapPath, esbuildMapBackup);
+
   const ext = target.startsWith("windows") ? ".exe" : "";
   const binaryName = `lore-${target}${ext}`;
   const binaryPath = join(distBinDir, binaryName);
 
-  const { execSync } = await import("node:child_process");
   const compileCmd = [
     "bun", "build", "--compile",
     "--target", `bun-${target}`,
+    // "linked" embeds a sourcemap in the binary. At runtime, Bun's engine
+    // auto-resolves Error.stack positions through this embedded map back to
+    // the esbuild output's coordinate space.
+    "--sourcemap=linked",
     "--external", "fastembed",
     "--external", "onnxruntime-*",
     "--external", "@anush008/*",
@@ -153,13 +213,18 @@ async function buildBinary() {
   try {
     execSync(compileCmd, { stdio: "inherit", cwd: packageDir });
   } catch {
+    // Restore the esbuild map even on failure
+    renameSync(esbuildMapBackup, mapPath);
     console.error("Bun compile failed");
     process.exit(1);
   }
 
+  // Restore the esbuild sourcemap (Bun.build wrote its own map)
+  renameSync(esbuildMapBackup, mapPath);
+
   console.log(`✓ Bun compile: ${binaryPath}`);
 
-  // Step 3: hole-punch unused ICU data entries so they compress to nearly nothing
+  // Step 4: hole-punch unused ICU data entries so they compress to nearly nothing
   const hpStats = processBinary(binaryPath);
   if (hpStats && hpStats.removedEntries > 0) {
     console.log(
@@ -167,18 +232,56 @@ async function buildBinary() {
     );
   }
 
-  // Step 4: gzip (release builds only)
+  // Step 5: gzip (release builds only)
   if (flags.release) {
     const raw = readFileSync(binaryPath);
     const compressed = gzipSync(raw, { level: 6 });
     const gzPath = `${binaryPath}.gz`;
-    const { writeFileSync } = await import("node:fs");
     writeFileSync(gzPath, compressed);
 
     const ratio = ((compressed.length / raw.length) * 100).toFixed(1);
     console.log(
       `✓ gzip: ${gzPath} (${(compressed.length / 1024 / 1024).toFixed(1)}MB, ${ratio}% of original)`,
     );
+  }
+
+  // Step 6: Upload sourcemap to Sentry
+  // The esbuild map (bin.js → original TS) is the one we upload. Bun's
+  // embedded map handles the binary → esbuild-output resolution at runtime.
+  let uploaded = false;
+
+  if (process.env.SENTRY_AUTH_TOKEN) {
+    console.log(`  Uploading sourcemap to Sentry (release: ${pkg.version})...`);
+    try {
+      execSync(
+        [
+          "npx", "sentry", "sourcemap", "upload", "dist-bin/",
+          "--release", pkg.version,
+          "--org", "byk",
+          "--project", "loreai-gateway",
+          "--url-prefix", "~/dist-bin/",
+        ].join(" "),
+        { cwd: packageDir, stdio: "inherit" },
+      );
+      uploaded = true;
+      console.log("✓ Sourcemap uploaded to Sentry");
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`⚠ Sourcemap upload failed: ${msg}`);
+    }
+  } else {
+    console.log("  No SENTRY_AUTH_TOKEN — skipping sourcemap upload");
+  }
+
+  // Clean up intermediate files (only the binary is the artifact)
+  try {
+    unlinkSync(bundlePath);
+    if (uploaded) {
+      unlinkSync(mapPath);
+      console.log("✓ Sourcemap deleted (uploaded to Sentry)");
+    }
+  } catch {
+    // Ignore
   }
 
   console.log(`\n✓ Binary build complete: ${binaryName} (v${pkg.version})`);

--- a/packages/gateway/script/bundle.ts
+++ b/packages/gateway/script/bundle.ts
@@ -11,11 +11,17 @@
  *
  * The Bun → Node.js polyfill layer (script/node-polyfills.ts) is injected at
  * bundle time so the source code stays Bun-native.
+ *
+ * Debug IDs are injected into the JS + sourcemap after bundling for Sentry
+ * source map resolution. When SENTRY_AUTH_TOKEN is set, sourcemaps are
+ * uploaded to Sentry and then deleted (they shouldn't ship to users).
  */
 import * as esbuild from "esbuild";
-import { rmSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { rmSync, mkdirSync, writeFileSync, readFileSync, unlinkSync } from "node:fs";
+import { execSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
+import { PLACEHOLDER_DEBUG_ID, injectDebugId } from "./debug-id";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const packageDir = dirname(here);
@@ -25,6 +31,9 @@ const distDir = join(packageDir, "dist");
 const pkg = JSON.parse(
   readFileSync(join(packageDir, "package.json"), "utf8"),
 ) as { version: string };
+
+const jsPath = join(distDir, "index.cjs");
+const mapPath = join(distDir, "index.cjs.map");
 
 // ---------------------------------------------------------------------------
 // Clean + create dist
@@ -54,7 +63,7 @@ await esbuild.build({
   // Resolve #db/driver → driver.node.ts (node:sqlite)
   conditions: ["node"],
   external,
-  outfile: join(distDir, "index.cjs"),
+  outfile: jsPath,
   sourcemap: true,
   minify: true,
   logLevel: "info",
@@ -64,8 +73,78 @@ await esbuild.build({
   // Build-time constants
   define: {
     LORE_CLI_VERSION: JSON.stringify(pkg.version),
+    __SENTRY_DEBUG_ID__: JSON.stringify(PLACEHOLDER_DEBUG_ID),
   },
 });
+
+// ---------------------------------------------------------------------------
+// Debug ID injection + sourcemap upload
+// ---------------------------------------------------------------------------
+
+// Inject debug IDs into the JS and sourcemap.
+// skipSnippet: true — the IIFE snippet breaks ESM/CJS mixed output. The
+// debug ID is instead registered in instrument.ts via the build-time
+// __SENTRY_DEBUG_ID__ constant.
+let debugId: string | undefined;
+
+try {
+  const result = await injectDebugId(jsPath, mapPath, { skipSnippet: true });
+  debugId = result.debugId;
+  console.log(`✓ Debug ID injected: ${debugId}`);
+} catch (err) {
+  const msg = err instanceof Error ? err.message : String(err);
+  console.warn(`⚠ Debug ID injection failed: ${msg}`);
+}
+
+// Replace the placeholder UUID with the real debug ID in the JS bundle.
+// Both are 36-char UUIDs so sourcemap character positions stay valid.
+if (debugId) {
+  try {
+    const content = readFileSync(jsPath, "utf-8");
+    writeFileSync(jsPath, content.replaceAll(PLACEHOLDER_DEBUG_ID, debugId));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`⚠ Debug ID placeholder replacement failed: ${msg}`);
+  }
+}
+
+// Upload sourcemaps to Sentry if auth token is available.
+// Gracefully skipped in local dev and fork PRs.
+let uploaded = false;
+
+if (process.env.SENTRY_AUTH_TOKEN) {
+  console.log(`  Uploading sourcemaps to Sentry (release: ${pkg.version})...`);
+  try {
+    execSync(
+      [
+        "npx", "sentry", "sourcemap", "upload", "dist/",
+        "--release", pkg.version,
+        "--org", "byk",
+        "--project", "loreai-gateway",
+        "--url-prefix", "~/",
+      ].join(" "),
+      { cwd: packageDir, stdio: "inherit" },
+    );
+    uploaded = true;
+    console.log("✓ Sourcemaps uploaded to Sentry");
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`⚠ Sourcemap upload failed: ${msg}`);
+  }
+} else {
+  console.log("  No SENTRY_AUTH_TOKEN — skipping sourcemap upload");
+}
+
+// Delete .map files after successful upload — they shouldn't ship to users.
+// Keep them on upload failure so a retry doesn't require a full rebuild.
+if (uploaded) {
+  try {
+    unlinkSync(mapPath);
+    console.log("✓ Sourcemap deleted (uploaded to Sentry)");
+  } catch {
+    // Ignore — file might already be gone
+  }
+}
 
 // ---------------------------------------------------------------------------
 // bin wrapper — dist/bin.cjs
@@ -102,6 +181,6 @@ require("./index.cjs")._cli().catch((e) => {
 
 writeFileSync(join(distDir, "bin.cjs"), binScript, { mode: 0o755 });
 
-console.log(`✓ @loreai/gateway npm bundle complete (v${pkg.version})`);
+console.log(`\n✓ @loreai/gateway npm bundle complete (v${pkg.version})`);
 console.log(`  dist/index.cjs — CJS bundle`);
 console.log(`  dist/bin.cjs   — CLI wrapper`);

--- a/packages/gateway/script/debug-id.ts
+++ b/packages/gateway/script/debug-id.ts
@@ -1,0 +1,157 @@
+/**
+ * Debug ID injection for JavaScript sourcemaps.
+ *
+ * Injects Sentry debug IDs into JavaScript files and their companion
+ * sourcemaps for reliable server-side stack trace resolution. Debug IDs
+ * replace fragile filename/release-based sourcemap matching with a
+ * deterministic UUID embedded in both the JS file and its sourcemap.
+ *
+ * The UUID algorithm and runtime snippet are byte-for-byte compatible
+ * with `@sentry/bundler-plugin-core`'s `stringToUUID` and
+ * `getDebugIdSnippet` — see ECMA-426 (Source Map Format) for the spec.
+ *
+ * Adapted from the Sentry CLI's own build pipeline
+ * (getsentry/sentry-cli src/lib/sourcemap/debug-id.ts).
+ */
+
+import { createHash } from "node:crypto";
+import { readFile, writeFile } from "node:fs/promises";
+
+/**
+ * Placeholder UUID used by esbuild's `define` for `__SENTRY_DEBUG_ID__`.
+ *
+ * After esbuild finishes and the real debug ID is computed from the
+ * sourcemap content hash, this placeholder is replaced in the JS output
+ * via `String.replaceAll`. The placeholder is exactly 36 characters
+ * (standard UUID length) so character positions in the sourcemap stay valid.
+ */
+export const PLACEHOLDER_DEBUG_ID = "deb00000-de60-4d00-a000-000000000000";
+
+/** Comment prefix used to identify an existing debug ID in a JS file. */
+const DEBUGID_COMMENT_PREFIX = "//# debugId=";
+
+/** Regex to extract an existing debug ID from a JS file. */
+const EXISTING_DEBUGID_RE = /\/\/# debugId=([0-9a-fA-F-]{36})/;
+
+/**
+ * Generate a deterministic debug ID (UUID v4 format) from content.
+ *
+ * Computes SHA-256 of the input, then formats the first 128 bits as a
+ * UUID v4 string. Matches `@sentry/bundler-plugin-core`'s `stringToUUID`
+ * exactly — position 12 is forced to `4` (version), and position 16 is
+ * forced to one of `8/9/a/b` (variant, RFC 4122 §4.4).
+ *
+ * @param content - File content (string or Buffer) to hash
+ * @returns UUID v4 string, e.g. `"a1b2c3d4-e5f6-4789-abcd-ef0123456789"`
+ */
+export function contentToDebugId(content: string | Buffer): string {
+  const hash = createHash("sha256").update(content).digest("hex");
+  // Position 16 (first char of 5th group in the hash) determines the
+  // variant nibble. charCodeAt(0) of a hex digit is deterministic.
+  const v4variant = ["8", "9", "a", "b"][
+    hash.substring(16, 17).charCodeAt(0) % 4
+  ];
+  return `${hash.substring(0, 8)}-${hash.substring(8, 12)}-4${hash.substring(13, 16)}-${v4variant}${hash.substring(17, 20)}-${hash.substring(20, 32)}`.toLowerCase();
+}
+
+/**
+ * Inject a Sentry debug ID into a JavaScript file and its companion
+ * sourcemap.
+ *
+ * Performs the following mutations:
+ * 1. Appends a `//# debugId=<uuid>` comment to the JS file
+ * 2. Adds `debug_id` and `debugId` fields to the sourcemap JSON
+ * 3. Normalizes Windows backslashes in sourcemap `sources` array
+ *
+ * When `options.skipSnippet` is `false` (default), it also:
+ * - Prepends the runtime IIFE snippet to the JS file (after any hashbang)
+ * - Prepends a `;` to the sourcemap `mappings` (offsets by one line)
+ *
+ * When `options.skipSnippet` is `true`, the IIFE and mappings offset are
+ * skipped. This is used by our build pipeline where the debug ID is
+ * registered in source code (`instrument.ts`) instead of via the IIFE.
+ *
+ * The operation is **idempotent** — files that already contain a
+ * `//# debugId=` comment are returned unchanged.
+ *
+ * @param jsPath - Path to the JavaScript file
+ * @param mapPath - Path to the companion `.map` file
+ * @param options - Optional settings
+ * @param options.skipSnippet - Skip the IIFE runtime snippet
+ * @returns The debug ID and whether it was newly injected
+ */
+export async function injectDebugId(
+  jsPath: string,
+  mapPath: string,
+  options?: { skipSnippet?: boolean },
+): Promise<{ debugId: string; wasInjected: boolean }> {
+  const [jsContent, mapContent] = await Promise.all([
+    readFile(jsPath, "utf-8"),
+    readFile(mapPath, "utf-8"),
+  ]);
+
+  // Idempotent: if the JS file already has a debug ID, extract and return it
+  const existingMatch = jsContent.match(EXISTING_DEBUGID_RE);
+  if (existingMatch?.[1]) {
+    return { debugId: existingMatch[1], wasInjected: false };
+  }
+
+  // Generate debug ID from the sourcemap content (deterministic)
+  const debugId = contentToDebugId(mapContent);
+  const skipSnippet = options?.skipSnippet ?? false;
+
+  // --- Mutate JS file ---
+  let newJs: string;
+  if (skipSnippet) {
+    // Metadata-only mode: just append the debugId comment, no IIFE snippet.
+    // Used by our build where the debug ID is registered in instrument.ts.
+    newJs = jsContent;
+  } else {
+    // Full mode: prepend the runtime IIFE snippet (for user-facing injection).
+    const snippet = `;!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof globalThis?globalThis:"undefined"!=typeof self?self:{},n=(new e.Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]="${debugId}",e._sentryDebugIdIdentifier="sentry-dbid-${debugId}")}catch(e){}}();`;
+    // Preserve hashbang if present, insert snippet after it
+    if (jsContent.startsWith("#!")) {
+      const newlineIdx = jsContent.indexOf("\n");
+      const splitAt = newlineIdx === -1 ? jsContent.length : newlineIdx + 1;
+      const hashbang = jsContent.slice(0, splitAt);
+      const rest = jsContent.slice(splitAt);
+      const sep = newlineIdx === -1 ? "\n" : "";
+      newJs = `${hashbang}${sep}${snippet}\n${rest}`;
+    } else {
+      newJs = `${snippet}\n${jsContent}`;
+    }
+  }
+  // Append debug ID comment at the end
+  newJs += `\n${DEBUGID_COMMENT_PREFIX}${debugId}\n`;
+
+  // --- Mutate sourcemap ---
+  const map = JSON.parse(mapContent) as {
+    mappings: string;
+    sources?: (string | null)[];
+    debug_id?: string;
+    debugId?: string;
+  };
+
+  // Normalize Windows backslashes in the sources array so uploaded
+  // sourcemaps have consistent forward-slash paths regardless of build
+  // platform.
+  if (map.sources) {
+    map.sources = map.sources.map((s) => (s ? s.replaceAll("\\", "/") : s));
+  }
+
+  if (!skipSnippet) {
+    // Prepend one `;` to mappings — tells decoders "no mappings for the
+    // first line" (the injected snippet line).
+    map.mappings = `;${map.mappings}`;
+  }
+  map.debug_id = debugId;
+  map.debugId = debugId;
+
+  // Write both files concurrently
+  await Promise.all([
+    writeFile(jsPath, newJs),
+    writeFile(mapPath, JSON.stringify(map)),
+  ]);
+
+  return { debugId, wasInjected: true };
+}


### PR DESCRIPTION
## Summary

- Inject deterministic debug IDs (SHA-256 → UUID v4) into JS bundles and source maps for Sentry error symbolication
- Upload source maps to Sentry via `npx sentry sourcemap upload` during CI (gated on `SENTRY_AUTH_TOKEN`)
- Eliminate all runtime dependencies — `@sentry/bun` and `@loreai/core` bundled inline by esbuild

## Approach

Follows the [Sentry CLI's own build pipeline](https://github.com/getsentry/sentry-cli/tree/master/script) pattern:

1. **Build-time placeholder**: esbuild `define` injects `PLACEHOLDER_DEBUG_ID` (`deb00000-de60-4d00-a000-000000000000`) for `__SENTRY_DEBUG_ID__`
2. **Post-build injection**: `injectDebugId()` computes real UUID from source map content hash, writes `debug_id`/`debugId` fields to `.map`, appends `//# debugId=` comment to JS
3. **Placeholder swap**: replace placeholder → real UUID in JS (same 36-char length preserves source map offsets)
4. **Runtime registration**: `instrument.ts` registers debug ID in `globalThis._sentryDebugIds` — ESM-safe alternative to IIFE snippet
5. **CI upload**: `npx sentry sourcemap upload` with org `byk` / project `loreai-gateway`; `.map` files deleted after successful upload

### Binary build specifics

The esbuild source map is backed up before `bun build --compile` (which overwrites it with its own map) and restored afterward. The esbuild map (TS → JS) is what gets uploaded to Sentry; Bun's embedded map handles binary → JS resolution at runtime.

## Changes

| File | Change |
|------|--------|
| `packages/gateway/script/debug-id.ts` | **New** — `contentToDebugId()`, `injectDebugId()`, `PLACEHOLDER_DEBUG_ID` |
| `packages/gateway/instrument.ts` | Debug ID registration via `_sentryDebugIds` before `Sentry.init()` |
| `packages/gateway/script/bundle.ts` | Debug ID define → inject → swap → upload → delete maps |
| `packages/gateway/script/build.ts` | Same flow + sourcemap backup/restore around `bun build --compile` |
| `packages/gateway/package.json` | `dependencies: {}` (zero runtime); `!dist/**/*.map` exclusion |
| `bun.lock` | Reflects dependency moves |
| `.github/workflows/ci.yml` | Pass `SENTRY_AUTH_TOKEN` to 4 build steps |

## Verification

- CJS bundle: debug ID injected, placeholder fully replaced, source map has `debug_id`/`debugId` fields, smoke test passes
- Binary: debug ID injected, map backup/restore works, binary runs correctly
- Tarball: `.map` files excluded from `bun pm pack` output
- Tests: 916 pass, 0 fail