### PR TITLE
fix: include binary and patch artifacts in Craft release workflow

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -10,7 +10,14 @@ artifactProvider:
   name: github
   config:
     artifacts:
-      CI: npm-tarball
+      # CI workflow uploads three artifact groups on release branches:
+      #   npm-tarball      — workspace .tgz files for npm publish
+      #   release-binaries — gzipped standalone CLI binaries per platform
+      #   release-patches  — delta patches from previous stable release
+      CI:
+        - npm-tarball
+        - release-binaries
+        - release-patches
 targets:
   # Publish the 4 workspace packages (@loreai/core, @loreai/opencode, @loreai/pi, @loreai/gateway).
   # Craft discovers these from the root package.json `workspaces` field and
@@ -30,4 +37,9 @@ targets:
     access: public
     oidc: true
     includeNames: /^opencode-lore-\d.*\.tgz$/
+  # Create GitHub Release with binaries and delta patches attached.
+  # The includeNames filter ensures only .gz binaries and .patch deltas
+  # are uploaded as release assets — npm tarballs are published via the
+  # npm targets above, not attached to the GitHub Release.
   - name: github
+    includeNames: /\.(gz|patch)$/


### PR DESCRIPTION
## Summary

- **Fix Craft artifact provider** to download all three CI artifact groups (`npm-tarball`, `release-binaries`, `release-patches`) instead of only `npm-tarball`
- **Scope the `github` target** with `includeNames: /\.(gz|patch)$/` so only binaries and delta patches are attached as GitHub Release assets — npm tarballs are published via the `npm` targets

## Problem

The `.craft.yml` artifact provider config was written before the binary build system existed. After the CLI skeleton (#159) and nightly builds (#167) changes, CI now uploads three artifact groups on release branches, but Craft was only told about one. This meant `craft publish` would create GitHub Releases with **no binary assets attached**.

## Verification

Traced the full release flow end-to-end:
1. `release.yml` → `craft prepare` creates release branch
2. `ci.yml` → builds tarballs, binaries, patches → uploads as `npm-tarball`, `release-binaries`, `release-patches`
3. `publish.yml` → `craft publish` downloads artifacts, publishes npm, creates GitHub Release

Confirmed `publish.yml` already has correct permissions (`id-token: write` for npm OIDC, `contents: write` for GitHub Releases, `registry-url` configured, Node.js 24).

Confirmed `release-patches` is conditionally uploaded (only when a previous stable release exists) — Craft handles missing artifacts gracefully.