### PR TITLE
feat: simplify worker model to session model, use live models.dev pricing

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -4,36 +4,44 @@
 
 ### Architecture
 
-<!-- lore:019e0c9f-a53c-789d-acf4-20723d88d5fe -->
-* **Release channel stored in metadata table, not file**: Release channel configuration migrated from file-based storage to database metadata table (kv\_meta). Eliminates file I/O dependency for release channel detection. Channel value retrieved via database query rather than filesystem read, improving reliability and consistency with other configuration storage patterns in the system.
+<!-- lore:019e0d03-7319-78e3-b087-1939edc15953 -->
+* **Live pricing from models.dev at startup**: Live pricing from models.dev at startup: Fetch MODEL\_SPECS (cost, limits) from models.dev once at server startup via \`fetchCostMap()\`. Gateway caches result in memory Map; sentry.ts and pipeline.ts consume it via \`getModelSpec()\` sync getter instead of hardcoded maps. Cache pre-warmed in \`initIfNeeded()\` to ensure availability during hot path (turn processing step 4). Response includes \`cost.input\`, \`cost.output\`, \`cost.cache\_read\` and context/output limits. When spreading models.dev entries into cache, use the API response key as \`id\` (don't double-set \`id\` from both entry and separate param). Fallback to hardcoded defaults if cache unpopulated.
 
-<!-- lore:019e0c94-32f5-7ee7-88ae-cad01bcee33e -->
-* **SQLite database layer: lazy singleton with WAL, FTS5 search, schema migrations**: SQLite database layer: lazy singleton with WAL, FTS5 search, schema migrations. Path: $LORE\_DB\_PATH (tests) or $XDG\_DATA\_HOME/opencode-lore/lore.db (default). PRAGMAs: WAL mode, foreign\_keys ON, 5s busy\_timeout, incremental auto\_vacuum. Runtime driver abstraction: bun:sqlite in Bun, wrapped node:sqlite in Node. Schema: 9 real tables (projects, temporal\_messages, distillations, knowledge, schema\_version, session\_state, kv\_meta, lat\_sections, knowledge\_refs) + 4 FTS5 virtual tables. Version: 12. Metadata table (kv\_meta) stores app-level config like release channel with file fallback for backward compatibility.
+<!-- lore:019e0d02-fef7-7d3e-b20e-43a890cf783c -->
+* **Worker model selection and fallback flow**: Worker model selection and fallback flow: Auto-selection in gateway via \`resolveWorkerModel()\` checks validated model or falls back to session model. Validation stored in \`validatedWorkerModels\` map with 24h TTL. Functions: \`selectWorkerModel\`, \`validateWorkerModel\`, \`getValidatedWorkerModel\`, \`storeValidatedWorkerModel\`. When no validated model exists, session model is used as fallback. Judge validation via LLM (scoring/quality assessment) cached with expiry. Gateway test suite validates this flow via mock validations and fallback chains.
+
+### Decision
+
+<!-- lore:019e0d0a-c6c8-7090-83a2-62d85addf809 -->
+* **Decided to use session model (Opus 4**: decided to use session model (Opus 4.
+
+<!-- lore:019e0d0c-276b-714c-ac6a-28ca971ff293 -->
+* **Decided to use sync path reading from in-memory cache (populated by \`fetchModelData\`)**: decided to use sync path reading from in-memory cache (populated by \`fetchModelData\`),
+
+<!-- lore:019e0d02-ff0e-7307-985d-61731b349db5 -->
+* **Hardcoded thinking:false in gateway LLM adapter**: Hardcoded thinking:false in gateway LLM adapter: Anthropic.messages.create() calls use hardcoded \`thinking:false\`. Extended thinking disabled at adapter layer, not configurable per request. Applies to all gateway-routed LLM calls including model validation and worker selection logic.
 
 ### Gotcha
 
-<!-- lore:019e0c9b-10e6-7407-b666-480e8b30c613 -->
-* **Git history rewrite affects branch age detection; use tree comparison for merge status**: After git-filter-repo history rewrite \[\[019e0c97-6770-7fc0-b897-348b6c158d52]], all branch commit dates show as rewrite date (2026-05-08), making date-based staleness detection unreliable. Use \`git rev-list --count branch..main\` to detect fully-merged branches (count=0) vs ahead branches (count>0). Tree comparison via \`git diff --quiet main branch\` also works. Only branches with identical trees to main are safe to delete as stale/merged.
+<!-- lore:019e0d08-09cd-72b3-92b2-4f7afd4d9986 -->
+* **getModelSpecSync fallback defaults don't auto-update after fetch completes**: Cache pre-warming in \`initIfNeeded()\` ensures models.dev data is available early, but if that init path is skipped or delayed, fallback defaults remain in place until cache is populated. Callers see hardcoded fallback (Opus: $3/$15 input/output per 1M) until first fetch completes. In tests, mock \`getModelSpecSync()\` or ensure \`fetchModelData()\` is called before testing cost calculations.
+
+<!-- lore:019e0d02-feef-759e-a6b6-2f64aaa7b5d5 -->
+* **Model parameter precedence in distillation pipeline**: opts.model parameter passed to distillation.run() ALWAYS overrides worker model selection when making LLM calls, bypassing validation in history. Flows: run() → \_distill() → \_callLLM() which directly uses provided model. Don't pass opts.model if worker model should be used.
+
+<!-- lore:019e0d02-fefe-732a-ab94-ab13703b4559 -->
+* **Worker model validation expires; no retroactive analysis possible**: Worker model validation results cached 24h TTL but not recorded per distillation run. Once cached and expired, impossible to retroactively determine which model produced which result. A/B testing with live validation required for model comparison.
 
 ### Pattern
 
-<!-- lore:019e0c9a-9c23-7dcf-9139-1a8e8d408763 -->
-* **Batch completion time tracking via enqueuedAt/resolvedAt timestamps**: Batch completion time tracking via enqueuedAt/resolvedAt timestamps: Track batch queue completion time as \`resolvedAt - enqueuedAt\` from PendingRequest timestamps. Emit as \`lore.batch\_queue\_ms\` span attribute to measure end-to-end batch processing time. Parse usage stats (input\_tokens, output\_tokens, cache\_hit\_tokens, cache\_creation\_tokens) from batch results via StreamParser and emit via \`gen\_ai.chat\` span in batch-queue.ts retry loop. Different from request duration — this measures Anthropic's batch infrastructure performance. Spans include model, cost\_usd (with 0.5x batch discount), and cache metrics for capacity planning.
+<!-- lore:019e0d06-a8ea-7591-babc-f6cbf7d90828 -->
+* **Sync cache getter for hot-path model specs**: Sync cache getter for hot-path model specs: Models.dev fetch happens async at startup, but pipeline.ts hot path (request processing step 4) needs sync access to MODEL\_SPECS. Solution: cache fetched data in memory (Map), expose sync \`getModelSpec()\` getter from worker-model.ts that reads cache directly. Pre-warm cache in \`initIfNeeded()\` to ensure population before requests start. Use response key directly when spreading (don't double-assign \`id\`); entry from models.dev may already have \`id\` field. Provide hardcoded fallback defaults for initialization window before async fetch completes.
 
-<!-- lore:019e0ca0-1c84-7567-b94d-60779dc98f69 -->
-* **Release channel persistence: metadata table with file fallback**: Release channel stored in kv\_meta table ('release\_channel' key) with ~/.lore/channel file fallback. Write path: update both table and file for redundancy. Read path: try table first, fallback to file if missing/error, default to 'stable'. Migration preserves existing file-based channels. Pattern enables gradual DB adoption while maintaining backward compatibility for existing installations.
+<!-- lore:019e0d07-9341-7bea-a518-636e42c83906 -->
+* **Sync cache pattern for async data in request hot path**: When async data (like models.dev pricing) is needed in the request hot path, pre-warm cache during \`initIfNeeded()\` and expose a sync getter with hardcoded fallback defaults. Pipeline.ts calls \`getModelSpecSync()\` to read pre-fetched cache without blocking. If cache empty, returns fallback constants. This pattern avoids async/await in critical path while ensuring data freshness at startup.
 
-<!-- lore:019e0ca0-1c6f-7b1d-8248-e366bf2ee31d -->
-* **Release channel storage migrated from file to metadata table with fallback**: Release channel persistence uses kv\_meta table with file fallback for compatibility. getCurrentChannel() checks metadata table first, falls back to .lore-channel file. setCurrentChannel() writes to both locations atomically. Migration preserves existing file-based channels during upgrade. This pattern allows gradual migration from file-based to database-based configuration while maintaining backward compatibility.
+<!-- lore:019e0d07-1fd5-700f-9517-fe260eb8fbb8 -->
+* **Sync cache pattern for models.dev data in hot paths**: Async fetch at startup (\`fetchModelData()\` in initIfNeeded) populates \`MODEL\_DATA\` map. Hot paths like pipeline.ts use sync \`getModelSpec()\` reader with hardcoded fallbacks, avoiding async bottleneck in request processing. Cache is pre-warmed before request handling, guaranteeing data availability. Fallback defaults ensure graceful degradation if fetch fails. Apply this pattern when runtime-fetched data must serve synchronous code paths.
 
-<!-- lore:019e0c9f-a546-7291-ad67-c05ef7ba02d0 -->
-* **Release channel stored in metadata table, not release.txt file**: Release channel now stored in metadata table with key 'release\_channel', replacing previous file-based storage at release.txt. Migration handles both upgrade (file → table) and downgrade (table → file) paths. Uses existing metadata KV infrastructure with proper JSON serialization. File-based approach removed as part of database-first configuration strategy.
-
-<!-- lore:019e0c9a-2652-76c7-9311-e6acf19f486a -->
-* **Sentry instrumentation hierarchy: llm-adapter retry loops + batch queue + cost metrics**: Sentry instrumentation hierarchy: llm-adapter + batch-queue + cost metrics at pipeline level: Gateway pipeline.ts integrates AI monitoring: (1) batch\_enabled tag set at handleRequest level; (2) enrichSentryScope() called after session auth binding to add session/project context; (3) upstream llm-adapter calls wrapped in gen\_ai.chat spans with model, usage, cache tokens; (4) batch-queue.ts retry loop emits per-resolved spans with parsed usage stats (input\_tokens, output\_tokens, cache\_hit\_tokens, cache\_creation\_tokens); (5) cost via Sentry.metrics.distribution() with model pricing + 0.5x batch discount; (6) spans include lore-specific attributes (worker\_id, batch\_queue\_ms). Scope enrichment provides session context for all downstream spans.
-
-<!-- lore:019e0c82-cd4c-7784-9263-ada1bea1bbdd -->
-* **Sourcemaps bundled via esbuild, debug ID injected post-compile, uploaded to Sentry during CI**: Sourcemaps bundled via esbuild with debug ID injection and Sentry upload. Pipeline: esbuild compiles → debug ID injection (SHA-256 → UUID v4 via placeholder swap + .map footer) → Bun compile (binary) → sentry sourcemaps upload during CI. Maps keyed by release version, deleted after upload. Maps registered via globalThis.\_sentryDebugIds (ESM-safe). Upload skips gracefully if SENTRY\_AUTH\_TOKEN absent. Maps excluded from npm tarball.
-
-<!-- lore:019e0c99-3c1f-75b9-a29d-fce64f7744c9 -->
-* **Worker instrumentation via LLMClient prompt() chokepoint for model stats and cache analytics**: Gateway pipeline instrumentation via Sentry gen\_ai.chat spans: All LLM calls flow through handleConversationTurn() pipeline, making it ideal for instrumentation. Wrap upstream forwarding in gen\_ai.chat spans with model, token counts, cache metrics from Anthropic responses. Use enrichScope() to set batch\_enabled tag early in pipeline. Extract usage via StreamParser for both streaming/non-streaming responses. Add cost metrics via Sentry.metrics.distribution with model pricing lookup and 0.5x batch discount. Both direct llm-adapter and batch-queue paths instrumented at pipeline level.
+<!-- lore:019e0d08-09c9-7ef1-a8e5-3036c7f40e2e -->
+* **Synchronous cache reads in request hot path for model pricing**: Model specs (pricing, context/output limits) fetched asynchronously from models.dev at gateway init, cached in-memory. Hot-path consumers (pipeline.ts:getModelSpec) use synchronous \`getModelSpecSync()\` read from cache to avoid async in request processing. Pre-warm cache via \`initIfNeeded()\` ensures data available before first request. Fallback defaults (per-model input/output costs) used if fetch not yet complete. This pattern avoids async complexity in request handling while keeping pricing data fresh.

--- a/packages/core/src/worker-model.ts
+++ b/packages/core/src/worker-model.ts
@@ -1,25 +1,22 @@
 /**
- * Dynamic worker model selection.
+ * Worker model resolution.
  *
- * Background workers (distillation, curation, query expansion) don't need
- * frontier reasoning. This module discovers cheaper models from the same
- * provider and validates their quality via a two-phase comparison:
- *   Phase 1: structural checks (parsability, observation count, token bounds)
- *   Phase 2: LLM judge (session model rates candidate output vs reference)
+ * Background workers (distillation, curation, query expansion) use the session
+ * model by default. An explicit `workerModel` config override is supported for
+ * cases where the user wants to pin background work to a specific model.
  *
- * Results are persisted in kv_meta and re-evaluated when the model landscape
- * changes (new models, session model switch, model deprecation).
+ * Previously this module contained dynamic worker model selection with
+ * candidate discovery, two-phase validation (structural check + LLM judge),
+ * and fingerprint-based staleness detection. That complexity was removed in
+ * favor of always using the session model — A/B testing showed the quality
+ * gap on complex conversations wasn't worth the infrastructure cost.
  */
 
-import { db } from "./db";
-import { sha256 } from "#db/driver";
-import * as log from "./log";
-
 // ---------------------------------------------------------------------------
-// Types
+// Types (kept for config compatibility)
 // ---------------------------------------------------------------------------
 
-/** Minimal model info needed for worker selection — provider-agnostic. */
+/** Minimal model info — kept for downstream consumers. */
 export type ModelInfo = {
   id: string;
   providerID: string;
@@ -32,369 +29,21 @@ export type ModelInfo = {
   };
 };
 
-/** Result of a worker model validation stored in kv_meta. */
-export type WorkerModelResult = {
-  modelID: string;
-  providerID: string;
-  fingerprint: string;
-  validatedAt: number;
-  judgeScore: number | null; // null = structural-only (no judge run yet)
-};
-
-const KV_PREFIX = "lore:worker_model:";
-
-// ---------------------------------------------------------------------------
-// Candidate selection
-// ---------------------------------------------------------------------------
-
-/**
- * Select worker model candidates from the available models.
- *
- * Returns up to 2 candidates: cheapest overall + one tier below the session
- * model. The session model itself is included (if it's the cheapest, the list
- * has 1 entry and no comparison is needed).
- */
-export function selectWorkerCandidates(
-  sessionModel: { id: string; providerID: string; cost: { input: number } },
-  providerModels: ModelInfo[],
-): ModelInfo[] {
-  // Filter: same provider, active, text-capable
-  const eligible = providerModels.filter(
-    (m) =>
-      m.providerID === sessionModel.providerID &&
-      m.status === "active" &&
-      m.capabilities.input.text,
-  );
-
-  if (eligible.length === 0) return [];
-
-  // Sort by cost ascending, then prefer non-reasoning models at equal cost.
-  // Non-reasoning models don't produce thinking tokens, avoiding wasted spend
-  // on tokens that background workers discard.
-  const sorted = [...eligible].sort((a, b) => {
-    const costDiff = a.cost.input - b.cost.input;
-    if (costDiff !== 0) return costDiff;
-    // At equal cost, non-reasoning (0) sorts before reasoning (1)
-    const aReasoning = a.capabilities.reasoning ? 1 : 0;
-    const bReasoning = b.capabilities.reasoning ? 1 : 0;
-    return aReasoning - bReasoning;
-  });
-
-  // Cheapest overall
-  const cheapest = sorted[0];
-
-  // One tier below session model: the most expensive model that's still
-  // cheaper than the session model. If session IS cheapest, this is undefined.
-  const belowSession = sorted
-    .filter((m) => m.cost.input < sessionModel.cost.input)
-    .pop(); // last = most expensive among cheaper ones
-
-  // Deduplicate
-  const candidates = new Map<string, ModelInfo>();
-  candidates.set(cheapest.id, cheapest);
-  if (belowSession && belowSession.id !== cheapest.id) {
-    candidates.set(belowSession.id, belowSession);
-  }
-
-  // If session model is the cheapest, return just it
-  if (cheapest.id === sessionModel.id || cheapest.cost.input >= sessionModel.cost.input) {
-    return [cheapest];
-  }
-
-  return [...candidates.values()];
-}
-
-// ---------------------------------------------------------------------------
-// Fingerprinting
-// ---------------------------------------------------------------------------
-
-/**
- * Compute a fingerprint from the model landscape. Changes when:
- * - Models are added or removed from the provider
- * - The session model changes
- */
-export function computeModelFingerprint(
-  providerID: string,
-  sessionModelID: string,
-  activeModelIDs: string[],
-): string {
-  const sorted = [...activeModelIDs].sort();
-  return sha256(
-    JSON.stringify({ providerID, sessionModelID, modelIDs: sorted }),
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Persistence
-// ---------------------------------------------------------------------------
-
-export function getValidatedWorkerModel(
-  providerID: string,
-): WorkerModelResult | null {
-  const row = db()
-    .query("SELECT value FROM kv_meta WHERE key = ?")
-    .get(`${KV_PREFIX}${providerID}`) as { value: string } | null;
-  if (!row) return null;
-  try {
-    return JSON.parse(row.value) as WorkerModelResult;
-  } catch {
-    return null;
-  }
-}
-
-export function storeValidatedWorkerModel(result: WorkerModelResult): void {
-  const key = `${KV_PREFIX}${result.providerID}`;
-  const value = JSON.stringify(result);
-  db()
-    .query(
-      "INSERT INTO kv_meta (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = ?",
-    )
-    .run(key, value, value);
-}
-
-/** Clear a stored worker model validation (e.g. when the model is deprecated). */
-export function clearValidatedWorkerModel(providerID: string): void {
-  db().query("DELETE FROM kv_meta WHERE key = ?").run(`${KV_PREFIX}${providerID}`);
-}
-
-/**
- * Check whether the stored validation is stale (fingerprint mismatch).
- */
-export function isValidationStale(
-  stored: WorkerModelResult | null,
-  currentFingerprint: string,
-): boolean {
-  if (!stored) return true;
-  return stored.fingerprint !== currentFingerprint;
-}
-
-// ---------------------------------------------------------------------------
-// Structural validation
-// ---------------------------------------------------------------------------
-
-export type StructuralCheckResult = {
-  passed: boolean;
-  observationCount: number;
-  tokenCount: number;
-  reason?: string;
-};
-
-/**
- * Structural quality check: does the candidate distillation output meet
- * minimum quality thresholds relative to the reference?
- */
-export function structuralCheck(
-  candidateObservations: string | null,
-  referenceObservations: string,
-): StructuralCheckResult {
-  if (candidateObservations == null || candidateObservations.length === 0) {
-    return { passed: false, observationCount: 0, tokenCount: 0, reason: candidateObservations === null ? "parse_failed" : "empty" };
-  }
-
-  // Count observation lines (non-empty lines starting with common markers)
-  const countObs = (text: string) =>
-    text.split("\n").filter((l) => l.trim().length > 0).length;
-
-  const refCount = countObs(referenceObservations);
-  const candCount = countObs(candidateObservations);
-  const candTokens = Math.ceil(candidateObservations.length / 3);
-
-  // Observation count within ±50% of reference
-  if (refCount > 0 && (candCount < refCount * 0.5 || candCount > refCount * 1.5)) {
-    return {
-      passed: false,
-      observationCount: candCount,
-      tokenCount: candTokens,
-      reason: `observation_count_${candCount}_vs_ref_${refCount}`,
-    };
-  }
-
-  // Not degenerate: not empty, not >3x reference size
-  const refTokens = Math.ceil(referenceObservations.length / 3);
-  if (candTokens === 0) {
-    return { passed: false, observationCount: candCount, tokenCount: candTokens, reason: "empty" };
-  }
-  if (refTokens > 0 && candTokens > refTokens * 3) {
-    return {
-      passed: false,
-      observationCount: candCount,
-      tokenCount: candTokens,
-      reason: `token_count_${candTokens}_vs_ref_${refTokens}_3x`,
-    };
-  }
-
-  return { passed: true, observationCount: candCount, tokenCount: candTokens };
-}
-
-// ---------------------------------------------------------------------------
-// Judge prompt
-// ---------------------------------------------------------------------------
-
-export const WORKER_JUDGE_SYSTEM = `You are evaluating distillation quality. You will be given a REFERENCE distillation (produced by a capable model) and a CANDIDATE distillation (produced by a cheaper model) of the same conversation segment.
-
-Rate the candidate on a scale of 1-5:
-5 = Captures all key facts and decisions, equivalent to reference
-4 = Captures most facts, minor omissions
-3 = Captures the essential facts, some detail loss acceptable
-2 = Missing important facts or technical details
-1 = Significantly incomplete or inaccurate
-
-Respond with ONLY a single digit (1-5).`;
-
-export function workerJudgeUser(
-  reference: string,
-  candidate: string,
-): string {
-  return `<reference>\n${reference}\n</reference>\n\n<candidate>\n${candidate}\n</candidate>`;
-}
-
-/** Parse the judge's score from a response. Returns null on parse failure. */
-export function parseJudgeScore(response: string): number | null {
-  const match = response.trim().match(/^([1-5])/);
-  if (!match) return null;
-  return parseInt(match[1], 10);
-}
-
-// ---------------------------------------------------------------------------
-// Validation orchestration
-// ---------------------------------------------------------------------------
-
-import { DISTILLATION_SYSTEM, distillationUser } from "./prompt";
-import type { LLMClient } from "./types";
-
-export type ValidationInput = {
-  llm: LLMClient;
-  providerID: string;
-  sessionModelID: string;
-  candidates: ModelInfo[];
-  /** Recent gen-0 distillation to use as reference (observations text). */
-  referenceObservations: string;
-  /** Source messages text for re-running distillation with candidates. */
-  sourceMessagesText: string;
-  /** Date string for the distillation prompt. */
-  date: string;
-};
-
-/**
- * Run the two-phase quality validation for worker model candidates.
- * Returns the cheapest passing candidate, or null if none pass.
- */
-export async function runValidation(
-  input: ValidationInput,
-): Promise<WorkerModelResult | null> {
-  const { llm, candidates, referenceObservations, sourceMessagesText, date } = input;
-
-  const userPrompt = distillationUser({
-    messages: sourceMessagesText,
-    date,
-  });
-
-  for (const candidate of candidates) {
-    // Skip the session model — it produced the reference, no need to test
-    if (candidate.id === input.sessionModelID) continue;
-
-    // Phase 1: run distillation with candidate model
-    let candidateObservations: string | null = null;
-    try {
-      const raw = await llm.prompt(DISTILLATION_SYSTEM, userPrompt, {
-        model: { providerID: candidate.providerID, modelID: candidate.id },
-        workerID: "lore-distill",
-        thinking: false,
-      });
-      if (raw) {
-        // Parse <observations>...</observations> block
-        const match = raw.match(/<observations>([\s\S]*?)<\/observations>/);
-        candidateObservations = match ? match[1].trim() : raw.trim();
-      }
-    } catch (e) {
-      log.warn(`worker model validation: candidate ${candidate.id} failed:`, e);
-      continue;
-    }
-
-    const structural = structuralCheck(candidateObservations, referenceObservations);
-    if (!structural.passed) {
-      log.info(
-        `worker model validation: ${candidate.id} failed structural check: ${structural.reason}`,
-      );
-      continue;
-    }
-
-    // Phase 2: LLM judge (using session model)
-    let judgeScore: number | null = null;
-    try {
-      const judgeResponse = await llm.prompt(
-        WORKER_JUDGE_SYSTEM,
-        workerJudgeUser(referenceObservations, candidateObservations!),
-        { workerID: "lore-distill", thinking: false }, // use session model (no model override)
-      );
-      if (judgeResponse) {
-        judgeScore = parseJudgeScore(judgeResponse);
-      }
-    } catch (e) {
-      log.warn(`worker model validation: judge call failed for ${candidate.id}:`, e);
-    }
-
-    if (judgeScore !== null && judgeScore < 3) {
-      log.info(
-        `worker model validation: ${candidate.id} failed judge (score=${judgeScore})`,
-      );
-      continue;
-    }
-
-    // Candidate passed both phases
-    const fingerprint = computeModelFingerprint(
-      input.providerID,
-      input.sessionModelID,
-      candidates.map((c) => c.id),
-    );
-
-    const result: WorkerModelResult = {
-      modelID: candidate.id,
-      providerID: candidate.providerID,
-      fingerprint,
-      validatedAt: Date.now(),
-      judgeScore,
-    };
-    storeValidatedWorkerModel(result);
-    log.info(
-      `worker model validated: ${candidate.id} (judge=${judgeScore}) for provider ${input.providerID}`,
-    );
-    return result;
-  }
-
-  // No candidate passed — clear any stale stored result so we don't keep
-  // routing worker calls to a potentially-deprecated model.
-  clearValidatedWorkerModel(input.providerID);
-  log.info(
-    `worker model validation: no candidate passed for ${input.providerID} — cleared stale entry`,
-  );
-  return null;
-}
-
 // ---------------------------------------------------------------------------
 // Effective worker model resolution
 // ---------------------------------------------------------------------------
 
 /**
  * Resolve the effective worker model for a given provider.
- * Priority: explicit config > validated auto-selection > session model (fallback).
+ * Priority: explicit config override > session model (fallback).
  */
 export function resolveWorkerModel(
-  providerID: string,
+  _providerID: string,
   configWorkerModel?: { providerID: string; modelID: string },
   configModel?: { providerID: string; modelID: string },
 ): { providerID: string; modelID: string } | undefined {
   // Explicit override wins
   if (configWorkerModel) return configWorkerModel;
-
-  // Check for validated auto-selection.
-  // Don't trust entries older than 24h — model may have been deprecated.
-  // Validation will re-run on next idle cycle and either re-confirm or clear.
-  const validated = getValidatedWorkerModel(providerID);
-  const MAX_AGE_MS = 24 * 60 * 60 * 1000;
-  if (validated && Date.now() - validated.validatedAt <= MAX_AGE_MS) {
-    return { providerID: validated.providerID, modelID: validated.modelID };
-  }
 
   // Fall back to the session model config (or undefined = host default)
   return configModel;

--- a/packages/core/test/worker-model.test.ts
+++ b/packages/core/test/worker-model.test.ts
@@ -1,259 +1,42 @@
 import { describe, test, expect } from "bun:test";
-import {
-  selectWorkerCandidates,
-  computeModelFingerprint,
-  structuralCheck,
-  parseJudgeScore,
-  type ModelInfo,
-} from "../src/worker-model";
+import { resolveWorkerModel } from "../src/worker-model";
 import { computeLayer0Cap } from "../src/gradient";
 
 // ---------------------------------------------------------------------------
-// selectWorkerCandidates
+// resolveWorkerModel
 // ---------------------------------------------------------------------------
 
-const mkModel = (
-  id: string,
-  provider: string,
-  costInput: number,
-  reasoning?: boolean,
-): ModelInfo => ({
-  id,
-  providerID: provider,
-  cost: { input: costInput },
-  status: "active",
-  capabilities: { input: { text: true }, reasoning },
-});
-
-describe("selectWorkerCandidates", () => {
-  const haiku = mkModel("claude-haiku-4-5", "anthropic", 1);
-  const sonnet = mkModel("claude-sonnet-4-6", "anthropic", 3);
-  const opus = mkModel("claude-opus-4-7", "anthropic", 5);
-  const gemini = mkModel("gemini-pro", "google", 2);
-
-  test("returns cheapest + one-below-session for Opus session", () => {
-    const candidates = selectWorkerCandidates(
-      { id: opus.id, providerID: "anthropic", cost: { input: 5 } },
-      [haiku, sonnet, opus, gemini],
+describe("resolveWorkerModel", () => {
+  test("returns explicit workerModel config when set", () => {
+    const result = resolveWorkerModel(
+      "anthropic",
+      { providerID: "anthropic", modelID: "claude-haiku-4-5" },
+      { providerID: "anthropic", modelID: "claude-opus-4-6" },
     );
-    // Should pick haiku (cheapest) and sonnet (one below opus)
-    expect(candidates.length).toBe(2);
-    expect(candidates[0].id).toBe("claude-haiku-4-5");
-    expect(candidates[1].id).toBe("claude-sonnet-4-6");
+    expect(result).toEqual({ providerID: "anthropic", modelID: "claude-haiku-4-5" });
   });
 
-  test("returns only cheapest when session is Sonnet (one-below = cheapest)", () => {
-    const candidates = selectWorkerCandidates(
-      { id: sonnet.id, providerID: "anthropic", cost: { input: 3 } },
-      [haiku, sonnet, opus],
+  test("falls back to config model when no workerModel override", () => {
+    const result = resolveWorkerModel(
+      "anthropic",
+      undefined,
+      { providerID: "anthropic", modelID: "claude-opus-4-6" },
     );
-    // Haiku is both cheapest and one-below-sonnet → deduplicated to 1
-    expect(candidates.length).toBe(1);
-    expect(candidates[0].id).toBe("claude-haiku-4-5");
+    expect(result).toEqual({ providerID: "anthropic", modelID: "claude-opus-4-6" });
   });
 
-  test("returns session model when it is the cheapest", () => {
-    const candidates = selectWorkerCandidates(
-      { id: haiku.id, providerID: "anthropic", cost: { input: 1 } },
-      [haiku, sonnet, opus],
+  test("returns undefined when no config at all", () => {
+    const result = resolveWorkerModel("anthropic", undefined, undefined);
+    expect(result).toBeUndefined();
+  });
+
+  test("workerModel takes priority over configModel", () => {
+    const result = resolveWorkerModel(
+      "anthropic",
+      { providerID: "anthropic", modelID: "claude-haiku-4-5" },
+      { providerID: "anthropic", modelID: "claude-opus-4-6" },
     );
-    expect(candidates.length).toBe(1);
-    expect(candidates[0].id).toBe("claude-haiku-4-5");
-  });
-
-  test("filters to same provider only", () => {
-    const candidates = selectWorkerCandidates(
-      { id: opus.id, providerID: "anthropic", cost: { input: 5 } },
-      [gemini], // only google models
-    );
-    expect(candidates.length).toBe(0);
-  });
-
-  test("filters out inactive models", () => {
-    const deprecated = { ...sonnet, status: "deprecated" };
-    const candidates = selectWorkerCandidates(
-      { id: opus.id, providerID: "anthropic", cost: { input: 5 } },
-      [deprecated, haiku, opus],
-    );
-    // Should still find haiku (active)
-    expect(candidates.some((c) => c.id === "claude-haiku-4-5")).toBe(true);
-    expect(candidates.some((c) => c.id === "claude-sonnet-4-6")).toBe(false);
-  });
-
-  test("returns empty array when no eligible models", () => {
-    const candidates = selectWorkerCandidates(
-      { id: opus.id, providerID: "anthropic", cost: { input: 5 } },
-      [],
-    );
-    expect(candidates.length).toBe(0);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// selectWorkerCandidates — reasoning preference
-// ---------------------------------------------------------------------------
-
-describe("selectWorkerCandidates — reasoning preference", () => {
-  test("prefers non-reasoning model at equal cost", () => {
-    const sonnetReasoning = mkModel("claude-sonnet-4-6-thinking", "anthropic", 3, true);
-    const sonnetPlain = mkModel("claude-sonnet-4-6", "anthropic", 3, false);
-    const opus = mkModel("claude-opus-4-7", "anthropic", 5, true);
-
-    const candidates = selectWorkerCandidates(
-      { id: opus.id, providerID: "anthropic", cost: { input: 5 } },
-      [sonnetReasoning, sonnetPlain, opus],
-    );
-
-    // Both are at cost 3: non-reasoning is cheapest (sorted first),
-    // reasoning is one-below-session (last among cost < 5).
-    // The non-reasoning model should come first in the candidates array.
-    expect(candidates.length).toBe(2);
-    expect(candidates[0].id).toBe("claude-sonnet-4-6"); // non-reasoning first
-    expect(candidates[1].id).toBe("claude-sonnet-4-6-thinking");
-  });
-
-  test("cheapest non-reasoning wins over costlier non-reasoning", () => {
-    const haiku = mkModel("claude-haiku-4-5", "anthropic", 1, false);
-    const sonnet = mkModel("claude-sonnet-4-6", "anthropic", 3, false);
-    const opus = mkModel("claude-opus-4-7", "anthropic", 5, true);
-
-    const candidates = selectWorkerCandidates(
-      { id: opus.id, providerID: "anthropic", cost: { input: 5 } },
-      [haiku, sonnet, opus],
-    );
-
-    expect(candidates.length).toBe(2);
-    expect(candidates[0].id).toBe("claude-haiku-4-5");
-    expect(candidates[1].id).toBe("claude-sonnet-4-6");
-  });
-
-  test("reasoning model still selected if it is the only cheaper option", () => {
-    const sonnetReasoning = mkModel("claude-sonnet-4-6-thinking", "anthropic", 3, true);
-    const opus = mkModel("claude-opus-4-7", "anthropic", 5, true);
-
-    const candidates = selectWorkerCandidates(
-      { id: opus.id, providerID: "anthropic", cost: { input: 5 } },
-      [sonnetReasoning, opus],
-    );
-
-    expect(candidates.length).toBe(1);
-    expect(candidates[0].id).toBe("claude-sonnet-4-6-thinking");
-  });
-
-  test("undefined reasoning is treated as non-reasoning (backwards compat)", () => {
-    const haikuNoFlag = mkModel("claude-haiku-4-5", "anthropic", 1); // reasoning=undefined
-    const haikuReasoning = mkModel("claude-haiku-4-5-thinking", "anthropic", 1, true);
-    const opus = mkModel("claude-opus-4-7", "anthropic", 5, true);
-
-    const candidates = selectWorkerCandidates(
-      { id: opus.id, providerID: "anthropic", cost: { input: 5 } },
-      [haikuReasoning, haikuNoFlag, opus],
-    );
-
-    // At equal cost, undefined reasoning (falsy) sorts before reasoning=true
-    expect(candidates[0].id).toBe("claude-haiku-4-5");
-  });
-});
-
-// ---------------------------------------------------------------------------
-// computeModelFingerprint
-// ---------------------------------------------------------------------------
-
-describe("computeModelFingerprint", () => {
-  test("is deterministic", () => {
-    const a = computeModelFingerprint("anthropic", "opus-4-7", ["haiku", "sonnet", "opus"]);
-    const b = computeModelFingerprint("anthropic", "opus-4-7", ["haiku", "sonnet", "opus"]);
-    expect(a).toBe(b);
-  });
-
-  test("changes when model list changes", () => {
-    const a = computeModelFingerprint("anthropic", "opus-4-7", ["haiku", "sonnet", "opus"]);
-    const b = computeModelFingerprint("anthropic", "opus-4-7", ["haiku", "sonnet", "opus", "haiku-new"]);
-    expect(a).not.toBe(b);
-  });
-
-  test("changes when session model changes", () => {
-    const a = computeModelFingerprint("anthropic", "opus-4-6", ["haiku", "sonnet", "opus"]);
-    const b = computeModelFingerprint("anthropic", "opus-4-7", ["haiku", "sonnet", "opus"]);
-    expect(a).not.toBe(b);
-  });
-
-  test("order-independent (sorts internally)", () => {
-    const a = computeModelFingerprint("anthropic", "opus", ["haiku", "sonnet"]);
-    const b = computeModelFingerprint("anthropic", "opus", ["sonnet", "haiku"]);
-    expect(a).toBe(b);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// structuralCheck
-// ---------------------------------------------------------------------------
-
-describe("structuralCheck", () => {
-  const reference = "Line 1: user asked about X\nLine 2: decided to do Y\nLine 3: implemented Z\n";
-
-  test("passes when candidate has similar structure", () => {
-    const candidate = "Obs 1: question about X\nObs 2: decision Y\nObs 3: did Z\n";
-    const result = structuralCheck(candidate, reference);
-    expect(result.passed).toBe(true);
-  });
-
-  test("fails when candidate is null (parse failure)", () => {
-    const result = structuralCheck(null, reference);
-    expect(result.passed).toBe(false);
-    expect(result.reason).toBe("parse_failed");
-  });
-
-  test("fails when candidate is empty", () => {
-    const result = structuralCheck("", reference);
-    expect(result.passed).toBe(false);
-    expect(result.reason).toBe("empty");
-  });
-
-  test("fails when observation count is too low", () => {
-    const candidate = "Just one line\n";
-    const result = structuralCheck(candidate, reference);
-    expect(result.passed).toBe(false);
-    expect(result.reason).toContain("observation_count");
-  });
-
-  test("fails when token count is >3x reference", () => {
-    // Same line count as reference but each line is 10x longer → token count way over 3x
-    const candidate = "Line 1: " + "x".repeat(500) + "\nLine 2: " + "x".repeat(500) + "\nLine 3: " + "x".repeat(500) + "\n";
-    const result = structuralCheck(candidate, reference);
-    expect(result.passed).toBe(false);
-    expect(result.reason).toContain("3x");
-  });
-});
-
-// ---------------------------------------------------------------------------
-// parseJudgeScore
-// ---------------------------------------------------------------------------
-
-describe("parseJudgeScore", () => {
-  test("parses single digit", () => {
-    expect(parseJudgeScore("4")).toBe(4);
-  });
-
-  test("parses digit with trailing text", () => {
-    expect(parseJudgeScore("3\nThe candidate captures most facts")).toBe(3);
-  });
-
-  test("parses with leading whitespace", () => {
-    expect(parseJudgeScore("  5")).toBe(5);
-  });
-
-  test("returns null for non-digit", () => {
-    expect(parseJudgeScore("The score is 4")).toBeNull();
-  });
-
-  test("returns null for out-of-range digit", () => {
-    expect(parseJudgeScore("0")).toBeNull();
-    expect(parseJudgeScore("6")).toBeNull();
-  });
-
-  test("returns null for empty string", () => {
-    expect(parseJudgeScore("")).toBeNull();
+    expect(result?.modelID).toBe("claude-haiku-4-5");
   });
 });
 

--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -23,8 +23,7 @@ import {
 import type { LLMClient } from "@loreai/core";
 import type { GatewayConfig } from "./config";
 import type { SessionState } from "./translate/types";
-import type { AuthCredential } from "./auth";
-import { maybeValidateWorkerModel, getWorkerModel } from "./worker-model";
+import { getWorkerModel } from "./worker-model";
 
 const POLL_INTERVAL_MS = 30_000;
 
@@ -103,38 +102,13 @@ export function touchSession(
  *
  * @param projectPath - Resolved project directory path
  * @param llm - LLM client for worker calls (distillation, curation)
- * @param upstreamUrl - Anthropic API base URL (for model discovery)
- * @param getAuth - Callback to resolve auth credentials
- * @param sessionModel - Model ID used for conversation (frontier model)
  */
 export function buildIdleWorkHandler(
   projectPath: string,
   llm: LLMClient,
-  upstreamUrl: string,
-  getAuth: () => AuthCredential | null,
-  sessionModel: string,
 ): (sessionID: string, state: SessionState) => Promise<void> {
   return async (sessionID: string, state: SessionState) => {
     const cfg = loreConfig();
-
-    // 0. Worker model validation — discover cheaper models for background work.
-    // Runs before distillation/curation so the resolved model is up-to-date.
-    try {
-      const cred = getAuth();
-      if (cred) {
-        await maybeValidateWorkerModel(
-          sessionModel,
-          upstreamUrl,
-          cred,
-          llm,
-          projectPath,
-          sessionID,
-        );
-      }
-    } catch (e) {
-      log.error("idle worker model validation error:", e);
-    }
-
     const model = getWorkerModel();
 
     // 1. Distillation — force-distill ALL pending messages on idle, even

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -90,7 +90,7 @@ import {
 } from "./auth";
 import type { UpstreamInterceptor } from "./recorder";
 import { startIdleScheduler, buildIdleWorkHandler } from "./idle";
-import { getWorkerModel, resetWorkerModelState } from "./worker-model";
+import { getWorkerModel, resetWorkerModelState, fetchModelData, getModelEntrySync } from "./worker-model";
 import * as Sentry from "@sentry/bun";
 import { analyzeCacheTurn } from "./cache-analytics";
 import {
@@ -237,33 +237,33 @@ let stopIdleScheduler: (() => void) | null = null;
 let lastSeenSessionModel: string | null = null;
 
 // ---------------------------------------------------------------------------
-// Model limits — hardcoded for known models, fallback for unknown
+// Model limits — fetched from models.dev, fallback for unknown
 // ---------------------------------------------------------------------------
 
 type ModelSpec = {
   context: number;
   output: number;
-  /** Cache-read cost per token in USD (Anthropic: 10% of input price). */
+  /** Cache-read cost per token in USD. */
   cacheReadCost?: number;
-};
-
-const MODEL_SPECS: Record<string, ModelSpec> = {
-  // Pricing: https://docs.anthropic.com/en/docs/about-claude/models
-  // Cache-read = input_price / 1_000_000 * 0.1 (10% of input for Anthropic)
-  "claude-opus-4":     { context: 200_000, output: 32_000, cacheReadCost: 15 / 1_000_000 * 0.1 },
-  "claude-sonnet-4":   { context: 200_000, output: 16_000, cacheReadCost: 3 / 1_000_000 * 0.1 },
-  "claude-sonnet-3-5": { context: 200_000, output: 8_192,  cacheReadCost: 3 / 1_000_000 * 0.1 },
-  "claude-haiku-3-5":  { context: 200_000, output: 8_192,  cacheReadCost: 0.80 / 1_000_000 * 0.1 },
 };
 
 const DEFAULT_MODEL_SPEC: ModelSpec = { context: 200_000, output: 8_192 };
 
+/**
+ * Look up model limits and cache-read cost from models.dev data.
+ *
+ * Uses the sync cache populated by `fetchModelData()` during init.
+ * Falls back to sensible defaults if the cache isn't warm yet.
+ */
 function getModelSpec(model: string): ModelSpec {
-  // Check for prefix matches: "claude-opus-4-20250514" → "claude-opus-4"
-  for (const [prefix, spec] of Object.entries(MODEL_SPECS)) {
-    if (model.startsWith(prefix)) return spec;
-  }
-  return DEFAULT_MODEL_SPEC;
+  const entry = getModelEntrySync(model);
+  return {
+    context: entry.limit?.context ?? DEFAULT_MODEL_SPEC.context,
+    output: entry.limit?.output ?? DEFAULT_MODEL_SPEC.output,
+    cacheReadCost: entry.cost?.cache_read != null
+      ? entry.cost.cache_read / 1_000_000  // models.dev is per-million, we need per-token
+      : undefined,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -282,18 +282,18 @@ async function initIfNeeded(projectPath: string, config?: GatewayConfig): Promis
   initialized = true;
   cachedProjectPath = projectPath;
 
+  // Pre-warm models.dev pricing/limits cache so synchronous lookups in the
+  // request hot path (getModelSpec, emitCostMetric) resolve from memory.
+  fetchModelData().catch((e) => log.warn("models.dev pre-warm failed:", e));
+
   // Start the idle scheduler for background work (distillation, curation,
   // pruning, AGENTS.md export). Uses a 30s poll interval and fires for any
   // session whose lastRequestTime exceeds the idle timeout.
   if (config && !stopIdleScheduler) {
     const llm = getLLMClient(config);
-    const sessionModelID = lastSeenSessionModel ?? (loreConfig().model?.modelID ?? "claude-sonnet-4-20250514");
     const idleHandler = buildIdleWorkHandler(
       projectPath,
       llm,
-      config.upstreamAnthropic,
-      () => resolveAuth(),
-      sessionModelID,
     );
     stopIdleScheduler = startIdleScheduler(config, sessions, idleHandler);
   }

--- a/packages/gateway/src/sentry.ts
+++ b/packages/gateway/src/sentry.ts
@@ -154,28 +154,20 @@ export function setGenAiUsageAttributes(
 // Cost estimation metrics
 // ---------------------------------------------------------------------------
 
-/**
- * Per-model pricing (USD per million tokens).
- * Source: https://docs.anthropic.com/en/docs/about-claude/models
- */
-type ModelPricing = { input: number; output: number };
+import { getModelEntry } from "./worker-model";
 
-const MODEL_PRICING: Record<string, ModelPricing> = {
-  "claude-opus-4": { input: 15, output: 75 },
-  "claude-sonnet-4": { input: 3, output: 15 },
-  "claude-sonnet-3-5": { input: 3, output: 15 },
-  "claude-haiku-3-5": { input: 0.80, output: 4 },
-};
+type ModelPricing = { input: number; output: number };
 
 const DEFAULT_PRICING: ModelPricing = { input: 3, output: 15 };
 
 /**
- * Look up pricing by model name, supporting prefix matches
- * (e.g. "claude-sonnet-4-20250514" → "claude-sonnet-4").
+ * Look up pricing for a model from models.dev (cached, fetched at startup).
+ * Falls back to sensible defaults if the fetch hasn't completed yet.
  */
-function getPricing(model: string): ModelPricing {
-  for (const [prefix, pricing] of Object.entries(MODEL_PRICING)) {
-    if (model.startsWith(prefix)) return pricing;
+async function getPricing(model: string): Promise<ModelPricing> {
+  const entry = await getModelEntry(model);
+  if (entry.cost?.input != null && entry.cost?.output != null) {
+    return { input: entry.cost.input, output: entry.cost.output };
   }
   return DEFAULT_PRICING;
 }
@@ -183,7 +175,8 @@ function getPricing(model: string): ModelPricing {
 /**
  * Emit a cost-estimate metric for an LLM call.
  *
- * Uses Anthropic's published pricing. Batch calls get 50% discount.
+ * Uses live pricing from models.dev (fetched at gateway startup, cached 1h).
+ * Batch calls get 50% discount.
  * Emits as a Sentry distribution metric (aggregatable/chartable).
  */
 export function emitCostMetric(
@@ -193,16 +186,22 @@ export function emitCostMetric(
 ): void {
   if (!Sentry.isInitialized()) return;
 
-  const pricing = getPricing(model);
-  const multiplier = callType === "batch" ? 0.5 : 1.0;
-  const inputCost =
-    ((usage.input_tokens ?? 0) / 1_000_000) * pricing.input * multiplier;
-  const outputCost =
-    ((usage.output_tokens ?? 0) / 1_000_000) * pricing.output * multiplier;
-  const totalCost = inputCost + outputCost;
+  // Fire-and-forget: pricing lookup is async but we don't want to block callers.
+  // The models.dev data is cached after first fetch, so subsequent calls resolve
+  // from memory without network I/O.
+  getPricing(model).then((pricing) => {
+    const multiplier = callType === "batch" ? 0.5 : 1.0;
+    const inputCost =
+      ((usage.input_tokens ?? 0) / 1_000_000) * pricing.input * multiplier;
+    const outputCost =
+      ((usage.output_tokens ?? 0) / 1_000_000) * pricing.output * multiplier;
+    const totalCost = inputCost + outputCost;
 
-  Sentry.metrics.distribution("lore.llm_cost_usd", totalCost, {
-    attributes: { model, call_type: callType },
-    unit: "dollar",
+    Sentry.metrics.distribution("lore.llm_cost_usd", totalCost, {
+      attributes: { model, call_type: callType },
+      unit: "dollar",
+    });
+  }).catch(() => {
+    // Silently ignore — cost metrics are best-effort, not critical path.
   });
 }

--- a/packages/gateway/src/worker-model.ts
+++ b/packages/gateway/src/worker-model.ts
@@ -1,75 +1,42 @@
 /**
- * Gateway worker model discovery and resolution.
+ * Gateway model pricing and resolution.
  *
- * Discovers available models from the upstream Anthropic `/v1/models` API,
- * fetches per-model pricing from models.dev (open-source model database),
- * and integrates with core's worker model validation/resolution pipeline.
+ * Fetches per-model pricing from models.dev (open-source model database)
+ * for cost estimation in Sentry metrics and gradient cost-aware capping.
  *
- * This replaces the OpenCode adapter's `getProviderModels()` +
- * `maybeValidateWorkerModel()` — the gateway is the universal path and
- * doesn't depend on the OpenCode SDK's model listing (which can report
- * deprecated models as "active").
+ * Worker model resolution delegates to core's simple chain:
+ *   explicit config override > session model fallback.
  */
 
 import {
   workerModel,
-  temporal,
-  distillation as distillationMod,
   config as loreConfig,
   log,
 } from "@loreai/core";
-import type { LLMClient } from "@loreai/core";
-import type { AuthCredential } from "./auth";
-import { authHeaders } from "./auth";
 
 // ---------------------------------------------------------------------------
-// Cost lookup — models.dev with hardcoded fallback
+// Cost lookup — models.dev
 // ---------------------------------------------------------------------------
 
 /**
  * models.dev JSON API endpoint — returns all providers/models with pricing.
  *
  * Single request replaces N individual TOML fetches. Response shape:
- *   { anthropic: { models: { "claude-sonnet-4-20250514": { cost: { input: 3 }, ... }, ... } } }
- * Cost values are per-million-token USD.
+ *   { anthropic: { models: { "claude-sonnet-4-20250514": { cost: { input: 3, output: 15, cache_read: 0.3 }, limit: { context: 200000, output: 64000 } }, ... } } }
+ * Cost values are per-million-token USD. Limit values are token counts.
  */
 const MODELS_DEV_API = "https://models.dev/api.json";
 
-/** Cached models.dev cost data: modelID → per-million-token input cost. */
-let cachedCostMap: Map<string, number> | null = null;
-let cachedCostMapAt = 0;
-const COST_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
-
-/**
- * Hardcoded fallback costs (per-input-token, USD) used when models.dev
- * API is unreachable. Prefix-matched against model IDs.
- *
- * These only serve as a safety net — runtime pricing from models.dev is
- * preferred and fetched on every discovery cycle (cached 1h).
- */
-const FALLBACK_COSTS: Array<{ prefix: string; inputCostPerToken: number }> = [
-  { prefix: "claude-opus-4", inputCostPerToken: 15 / 1_000_000 },
-  { prefix: "claude-sonnet-4", inputCostPerToken: 3 / 1_000_000 },
-  { prefix: "claude-haiku-4", inputCostPerToken: 1 / 1_000_000 },
-  { prefix: "claude-haiku-3-5", inputCostPerToken: 0.8 / 1_000_000 },
-  { prefix: "claude-sonnet-3-5", inputCostPerToken: 3 / 1_000_000 },
-  { prefix: "claude-3-haiku", inputCostPerToken: 0.25 / 1_000_000 },
-  { prefix: "claude-3-sonnet", inputCostPerToken: 3 / 1_000_000 },
-  { prefix: "claude-3-opus", inputCostPerToken: 15 / 1_000_000 },
-];
-
-function fallbackCost(modelID: string): number {
-  for (const { prefix, inputCostPerToken } of FALLBACK_COSTS) {
-    if (modelID.startsWith(prefix)) return inputCostPerToken;
-  }
-  // Unknown model — assume expensive so it doesn't get picked as a worker
-  return 100 / 1_000_000;
-}
+/** Cached models.dev data: full model entries for Anthropic. */
+let cachedModelData: Map<string, ModelsDevEntry> | null = null;
+let cachedModelDataAt = 0;
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
 
 /** Shape of a model entry in the models.dev JSON API. */
-type ModelsDevEntry = {
+export type ModelsDevEntry = {
   id: string;
-  cost?: { input?: number };
+  cost?: { input?: number; output?: number; cache_read?: number };
+  limit?: { context?: number; output?: number };
 };
 
 /** Shape of the models.dev JSON API response (subset we care about). */
@@ -80,15 +47,58 @@ type ModelsDevResponse = {
 };
 
 /**
- * Fetch the models.dev cost map for Anthropic models.
- *
- * Single HTTP request to the JSON API, cached for 1 hour.
- * Returns a map of modelID → per-million-token input cost.
+ * Hardcoded fallback costs (per-million-token, USD) used when models.dev
+ * API is unreachable. Prefix-matched against model IDs.
  */
-export async function fetchCostMap(): Promise<Map<string, number>> {
+const FALLBACK_PRICING: Array<{
+  prefix: string;
+  input: number;
+  output: number;
+  cache_read: number;
+  context: number;
+  outputLimit: number;
+}> = [
+  { prefix: "claude-opus-4-6", input: 5, output: 25, cache_read: 0.5, context: 1_000_000, outputLimit: 128_000 },
+  { prefix: "claude-opus-4-5", input: 5, output: 25, cache_read: 0.5, context: 200_000, outputLimit: 64_000 },
+  { prefix: "claude-opus-4", input: 15, output: 75, cache_read: 1.5, context: 200_000, outputLimit: 32_000 },
+  { prefix: "claude-sonnet-4-6", input: 3, output: 15, cache_read: 0.3, context: 1_000_000, outputLimit: 64_000 },
+  { prefix: "claude-sonnet-4", input: 3, output: 15, cache_read: 0.3, context: 200_000, outputLimit: 64_000 },
+  { prefix: "claude-haiku-4-5", input: 1, output: 5, cache_read: 0.1, context: 200_000, outputLimit: 64_000 },
+  { prefix: "claude-haiku-3-5", input: 0.8, output: 4, cache_read: 0.08, context: 200_000, outputLimit: 8_192 },
+  { prefix: "claude-sonnet-3-5", input: 3, output: 15, cache_read: 0.3, context: 200_000, outputLimit: 8_192 },
+  { prefix: "claude-3-haiku", input: 0.25, output: 1.25, cache_read: 0.03, context: 200_000, outputLimit: 4_096 },
+  { prefix: "claude-3-sonnet", input: 3, output: 15, cache_read: 0.3, context: 200_000, outputLimit: 4_096 },
+  { prefix: "claude-3-opus", input: 15, output: 75, cache_read: 1.5, context: 200_000, outputLimit: 4_096 },
+];
+
+function fallbackEntry(modelID: string): ModelsDevEntry {
+  for (const fb of FALLBACK_PRICING) {
+    if (modelID.startsWith(fb.prefix)) {
+      return {
+        id: modelID,
+        cost: { input: fb.input, output: fb.output, cache_read: fb.cache_read },
+        limit: { context: fb.context, output: fb.outputLimit },
+      };
+    }
+  }
+  // Unknown model — assume mid-range so metrics are roughly correct
+  return {
+    id: modelID,
+    cost: { input: 3, output: 15, cache_read: 0.3 },
+    limit: { context: 200_000, output: 8_192 },
+  };
+}
+
+/**
+ * Fetch model data from models.dev for Anthropic models.
+ *
+ * Single HTTP request, cached for 1 hour. Returns a map of
+ * modelID → entry with cost and limit data.
+ */
+export async function fetchModelData(): Promise<Map<string, ModelsDevEntry>> {
   // Return cache if fresh
-  if (cachedCostMap && Date.now() - cachedCostMapAt < COST_CACHE_TTL_MS) {
-    return cachedCostMap;
+  if (cachedModelData && Date.now() - cachedModelDataAt < CACHE_TTL_MS) {
+    return cachedModelData;
   }
 
   try {
@@ -100,283 +110,90 @@ export async function fetchCostMap(): Promise<Map<string, number>> {
 
     if (!response.ok) {
       log.warn(`models.dev API failed: ${response.status} ${response.statusText}`);
-      return cachedCostMap ?? new Map();
+      return cachedModelData ?? new Map();
     }
 
     const data = (await response.json()) as ModelsDevResponse;
     const anthropic = data.anthropic?.models;
     if (!anthropic) {
       log.warn("models.dev API: no anthropic provider found");
-      return cachedCostMap ?? new Map();
+      return cachedModelData ?? new Map();
     }
 
-    const costMap = new Map<string, number>();
+    const modelData = new Map<string, ModelsDevEntry>();
     for (const [modelId, entry] of Object.entries(anthropic)) {
-      if (entry.cost?.input != null) {
-        costMap.set(modelId, entry.cost.input);
-      }
+      modelData.set(modelId, { ...entry, id: modelId });
     }
 
-    cachedCostMap = costMap;
-    cachedCostMapAt = Date.now();
+    cachedModelData = modelData;
+    cachedModelDataAt = Date.now();
 
-    log.info(`models.dev: loaded costs for ${costMap.size} anthropic models`);
-    return costMap;
+    log.info(`models.dev: loaded data for ${modelData.size} anthropic models`);
+    return modelData;
   } catch (e) {
     log.warn("models.dev API error:", e);
-    return cachedCostMap ?? new Map();
+    return cachedModelData ?? new Map();
   }
-}
-
-/** Clear the cached cost map (for testing). */
-export function clearCostCache(): void {
-  cachedCostMap = null;
-  cachedCostMapAt = 0;
 }
 
 /**
- * Fetch per-model input cost from models.dev JSON API.
+ * Look up model data by ID, with prefix matching and fallback.
  *
- * Single HTTP request fetches all Anthropic model costs. Returns a map of
- * modelID → per-token cost. Models not found in models.dev get fallback costs.
+ * First tries exact match, then prefix match (e.g. "claude-opus-4-6-20260101"
+ * matches "claude-opus-4-6"), then falls back to hardcoded defaults.
  */
-export async function fetchModelCosts(
-  modelIDs: string[],
-): Promise<Map<string, number>> {
-  const costMap = await fetchCostMap();
-  const costs = new Map<string, number>();
+export async function getModelEntry(modelID: string): Promise<ModelsDevEntry> {
+  const data = await fetchModelData();
 
-  for (const id of modelIDs) {
-    const costPerMillion = costMap.get(id);
-    if (costPerMillion != null) {
-      costs.set(id, costPerMillion / 1_000_000);
-    } else {
-      costs.set(id, fallbackCost(id));
-    }
+  // Exact match
+  const exact = data.get(modelID);
+  if (exact) return exact;
+
+  // Prefix match: find the entry whose ID is a prefix of the requested model
+  for (const [id, entry] of data) {
+    if (modelID.startsWith(id)) return entry;
   }
 
-  return costs;
+  // Reverse prefix: find if the requested model is a prefix of any entry
+  for (const [id, entry] of data) {
+    if (id.startsWith(modelID)) return entry;
+  }
+
+  return fallbackEntry(modelID);
 }
-
-// ---------------------------------------------------------------------------
-// Anthropic /v1/models API types (subset we care about)
-// ---------------------------------------------------------------------------
-
-type AnthropicModelEntry = {
-  id: string;
-  display_name: string;
-  created_at: string;
-  capabilities?: {
-    thinking?: { supported: boolean };
-  };
-};
-
-type AnthropicModelsResponse = {
-  data: AnthropicModelEntry[];
-  has_more: boolean;
-  last_id?: string;
-};
-
-// ---------------------------------------------------------------------------
-// Model discovery — fetch from upstream /v1/models
-// ---------------------------------------------------------------------------
-
-/** Cached model list with TTL. */
-let cachedModels: workerModel.ModelInfo[] | null = null;
-let cachedModelsAt = 0;
-const MODEL_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
 
 /**
- * Fetch available Anthropic models from the upstream API.
+ * Synchronous model entry lookup — reads from the in-memory cache only.
  *
- * Results are cached for 1 hour — model listings change rarely and we
- * don't want to hit the API on every idle cycle.
- *
- * Unlike the OpenCode SDK's `provider.list()`, the Anthropic `/v1/models`
- * API only returns models that actually exist — deprecated models are
- * removed, so we never get stale entries like `claude-3-haiku-20240307`.
+ * Use this on the hot request path where async is impractical. Returns
+ * fallback defaults if the cache hasn't been populated yet (e.g. before
+ * the first `fetchModelData()` call completes). Pre-warm the cache by
+ * calling `fetchModelData()` during gateway init.
  */
-export async function discoverModels(
-  upstreamUrl: string,
-  cred: AuthCredential,
-): Promise<workerModel.ModelInfo[]> {
-  // Return cache if fresh
-  if (cachedModels && Date.now() - cachedModelsAt < MODEL_CACHE_TTL_MS) {
-    return cachedModels;
+export function getModelEntrySync(modelID: string): ModelsDevEntry {
+  if (!cachedModelData) return fallbackEntry(modelID);
+
+  // Exact match
+  const exact = cachedModelData.get(modelID);
+  if (exact) return exact;
+
+  // Prefix match
+  for (const [id, entry] of cachedModelData) {
+    if (modelID.startsWith(id)) return entry;
   }
 
-  try {
-    const entries: AnthropicModelEntry[] = [];
-    let afterId: string | undefined;
-
-    // Paginate through all models
-    do {
-      const url = new URL(`${upstreamUrl}/v1/models`);
-      url.searchParams.set("limit", "1000");
-      if (afterId) url.searchParams.set("after_id", afterId);
-
-      const response = await fetch(url.toString(), {
-        headers: {
-          "content-type": "application/json",
-          "anthropic-version": "2023-06-01",
-          ...authHeaders(cred),
-        },
-      });
-
-      if (!response.ok) {
-        const text = await response.text().catch(() => "(no body)");
-        log.warn(
-          `model discovery failed: ${response.status} ${response.statusText} — ${text}`,
-        );
-        return cachedModels ?? [];
-      }
-
-      const data = (await response.json()) as AnthropicModelsResponse;
-
-      for (const entry of data.data) {
-        entries.push(entry);
-      }
-
-      afterId = data.has_more ? data.last_id : undefined;
-    } while (afterId);
-
-    // Fetch costs from models.dev in parallel (with fallback to hardcoded)
-    const modelIDs = entries.map((e) => e.id);
-    const costs = await fetchModelCosts(modelIDs);
-
-    const models: workerModel.ModelInfo[] = entries.map((entry) => ({
-      id: entry.id,
-      providerID: "anthropic",
-      cost: { input: costs.get(entry.id) ?? fallbackCost(entry.id) },
-      status: "active", // Only active models are returned by the API
-      capabilities: {
-        input: { text: true }, // All Anthropic models accept text
-        reasoning: entry.capabilities?.thinking?.supported ?? false,
-      },
-    }));
-
-    cachedModels = models;
-    cachedModelsAt = Date.now();
-
-    log.info(
-      `model discovery: found ${models.length} models (${models.map((m) => m.id).join(", ")})`,
-    );
-
-    return models;
-  } catch (e) {
-    log.warn("model discovery error:", e);
-    return cachedModels ?? [];
+  // Reverse prefix
+  for (const [id, entry] of cachedModelData) {
+    if (id.startsWith(modelID)) return entry;
   }
+
+  return fallbackEntry(modelID);
 }
 
-/** Clear the cached model list (for testing). */
-export function clearModelCache(): void {
-  cachedModels = null;
-  cachedModelsAt = 0;
-}
-
-// ---------------------------------------------------------------------------
-// Worker model validation — gateway version of maybeValidateWorkerModel
-// ---------------------------------------------------------------------------
-
-/** Guard against concurrent validation runs. */
-let validating = false;
-
-/**
- * Run worker model validation if needed.
- *
- * Called on session idle — discovers available models, selects candidates,
- * checks if the stored validation is stale, and runs the two-phase
- * comparison (structural check + LLM judge) if needed.
- *
- * @param sessionModel  The model ID being used for conversation (frontier)
- * @param upstreamUrl   Anthropic API base URL
- * @param cred          Auth credential for API calls
- * @param llm           LLM client for validation prompts
- * @param projectPath   Project directory path
- * @param sessionID     Session ID for loading reference distillation data
- */
-export async function maybeValidateWorkerModel(
-  sessionModel: string,
-  upstreamUrl: string,
-  cred: AuthCredential,
-  llm: LLMClient,
-  projectPath: string,
-  sessionID: string,
-): Promise<void> {
-  if (validating) return;
-
-  const cfg = loreConfig();
-  if (cfg.workerModel) return; // explicit override — skip auto-selection
-
-  const models = await discoverModels(upstreamUrl, cred);
-  if (models.length === 0) return;
-
-  // Build the session model info for candidate selection.
-  // Use cost from discovered models if available, otherwise fallback.
-  const discoveredModel = models.find((m) => m.id === sessionModel);
-  const sessionModelInfo: Parameters<typeof workerModel.selectWorkerCandidates>[0] = {
-    id: sessionModel,
-    providerID: "anthropic",
-    cost: { input: discoveredModel?.cost.input ?? fallbackCost(sessionModel) },
-  };
-
-  const candidates = workerModel.selectWorkerCandidates(sessionModelInfo, models);
-  if (candidates.length === 0) return;
-  // If session model is already the cheapest, no comparison needed
-  if (candidates.length === 1 && candidates[0].id === sessionModel) return;
-
-  const fingerprint = workerModel.computeModelFingerprint(
-    "anthropic",
-    sessionModel,
-    models.filter((m) => m.providerID === "anthropic").map((m) => m.id),
-  );
-
-  const stored = workerModel.getValidatedWorkerModel("anthropic");
-  if (!workerModel.isValidationStale(stored, fingerprint)) return;
-
-  // Need reference distillation data
-  const distillations = distillationMod.loadForSession(projectPath, sessionID, true);
-  const gen0 = distillations.filter((d) => d.generation === 0);
-  if (gen0.length === 0) return;
-
-  const reference = gen0[gen0.length - 1]; // most recent gen-0
-  const sourceIds = reference.source_ids;
-  if (sourceIds.length === 0) return;
-
-  // Load source temporal messages
-  const allMessages = temporal.bySession(projectPath, sessionID);
-  const sourceSet = new Set(sourceIds);
-  const sourceMessages = allMessages.filter((m) => sourceSet.has(m.id));
-  if (sourceMessages.length === 0) return;
-
-  const messagesText = sourceMessages.map((m) => m.content).join("\n");
-  const date = new Date(sourceMessages[0].created_at).toLocaleDateString(
-    "en-US",
-    { year: "numeric", month: "long", day: "numeric" },
-  );
-
-  validating = true;
-  try {
-    const result = await workerModel.runValidation({
-      llm,
-      providerID: "anthropic",
-      sessionModelID: sessionModel,
-      candidates,
-      referenceObservations: reference.observations,
-      sourceMessagesText: messagesText,
-      date,
-    });
-    if (result) {
-      log.info(
-        `worker model validated: ${result.modelID} (judge=${result.judgeScore}) — saving 50%+ on worker calls`,
-      );
-    }
-  } catch (e) {
-    log.error("worker model validation error:", e);
-  } finally {
-    validating = false;
-  }
+/** Clear cached data (for testing). */
+export function clearModelDataCache(): void {
+  cachedModelData = null;
+  cachedModelDataAt = 0;
 }
 
 // ---------------------------------------------------------------------------
@@ -388,8 +205,7 @@ export async function maybeValidateWorkerModel(
  *
  * Checks (in order):
  *  1. Explicit config override (`workerModel` in lore config)
- *  2. Validated auto-selection from kv_meta (with 24h TTL)
- *  3. Config model fallback (frontier model)
+ *  2. Config model fallback (session model)
  */
 export function getWorkerModel(): { providerID: string; modelID: string } | undefined {
   const cfg = loreConfig();
@@ -402,7 +218,5 @@ export function getWorkerModel(): { providerID: string; modelID: string } | unde
 
 /** Reset module state (for testing). */
 export function resetWorkerModelState(): void {
-  clearModelCache();
-  clearCostCache();
-  validating = false;
+  clearModelDataCache();
 }

--- a/packages/gateway/test/worker-model.test.ts
+++ b/packages/gateway/test/worker-model.test.ts
@@ -1,112 +1,57 @@
 import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
 import {
-  discoverModels,
-  clearModelCache,
-  clearCostCache,
+  fetchModelData,
+  getModelEntry,
+  getModelEntrySync,
   getWorkerModel,
   resetWorkerModelState,
-  fetchModelCosts,
-  fetchCostMap,
+  clearModelDataCache,
+  type ModelsDevEntry,
 } from "../src/worker-model";
-import type { AuthCredential } from "../src/auth";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-const TEST_CRED: AuthCredential = { scheme: "api-key", value: "sk-test-key" };
-const UPSTREAM = "https://api.anthropic.com";
 const MODELS_DEV_API = "https://models.dev/api.json";
 
-/** Build a mock Anthropic /v1/models response. */
-function buildModelsResponse(
-  models: Array<{
-    id: string;
-    display_name?: string;
-    thinking_supported?: boolean;
-  }>,
-) {
-  return {
-    data: models.map((m) => ({
-      id: m.id,
-      type: "model" as const,
-      display_name: m.display_name ?? m.id,
-      created_at: "2025-01-01T00:00:00Z",
-      max_input_tokens: 200_000,
-      max_tokens: 8192,
-      capabilities: {
-        thinking: { supported: m.thinking_supported ?? false },
-      },
-    })),
-    has_more: false,
-    first_id: models[0]?.id ?? "",
-    last_id: models[models.length - 1]?.id ?? "",
-  };
-}
-
-/** Build a mock models.dev api.json response. */
+/** Build a mock models.dev api.json response with full cost+limit data. */
 function buildModelsDevResponse(
-  models: Record<string, number>,
-): { anthropic: { models: Record<string, { id: string; cost: { input: number } }> } } {
-  const entries: Record<string, { id: string; cost: { input: number } }> = {};
-  for (const [id, inputCost] of Object.entries(models)) {
-    entries[id] = { id, cost: { input: inputCost } };
+  models: Record<string, { cost: { input: number; output: number; cache_read: number }; limit: { context: number; output: number } }>,
+) {
+  const entries: Record<string, ModelsDevEntry> = {};
+  for (const [id, data] of Object.entries(models)) {
+    entries[id] = { id, cost: data.cost, limit: data.limit };
   }
   return { anthropic: { models: entries } };
 }
 
-/** Default models.dev cost data for tests. */
-const DEFAULT_COSTS: Record<string, number> = {
-  "claude-opus-4-20250514": 15.0,
-  "claude-sonnet-4-20250514": 3.0,
-  "claude-haiku-3-5-20241022": 0.8,
-  "claude-haiku-4-5-20251001": 1.0,
+/** Default models.dev data for tests. */
+const DEFAULT_MODELS = {
+  "claude-opus-4-6": {
+    cost: { input: 5, output: 25, cache_read: 0.5 },
+    limit: { context: 1_000_000, output: 128_000 },
+  },
+  "claude-sonnet-4-20250514": {
+    cost: { input: 3, output: 15, cache_read: 0.3 },
+    limit: { context: 200_000, output: 64_000 },
+  },
+  "claude-haiku-4-5": {
+    cost: { input: 1, output: 5, cache_read: 0.1 },
+    limit: { context: 200_000, output: 64_000 },
+  },
 };
 
-/**
- * Create a URL-aware fetch mock that handles both Anthropic API and
- * models.dev JSON API requests.
- */
-function createRoutedFetch(
-  anthropicResponse: unknown,
-  options?: {
-    modelsDevCosts?: Record<string, number>;
-    modelsDevOverride?: (url: string) => Response;
-    onAnthropicCall?: (url: string, init?: RequestInit) => void;
-  },
-) {
-  return mock((url: string | URL | Request, init?: RequestInit) => {
-    const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
-
-    // models.dev API request
-    if (urlStr === MODELS_DEV_API) {
-      if (options?.modelsDevOverride) {
-        return Promise.resolve(options.modelsDevOverride(urlStr));
-      }
-      const costs = options?.modelsDevCosts ?? DEFAULT_COSTS;
-      return Promise.resolve(
-        new Response(JSON.stringify(buildModelsDevResponse(costs)), { status: 200 }),
-      );
-    }
-
-    // Anthropic API requests
-    options?.onAnthropicCall?.(urlStr, init);
-    return Promise.resolve(
-      new Response(JSON.stringify(anthropicResponse), { status: 200 }),
-    );
-  }) as unknown as typeof fetch;
-}
-
 // ---------------------------------------------------------------------------
-// fetchCostMap
+// fetchModelData
 // ---------------------------------------------------------------------------
 
-describe("fetchCostMap", () => {
+describe("fetchModelData", () => {
   let originalFetch: typeof globalThis.fetch;
 
   beforeEach(() => {
     originalFetch = globalThis.fetch;
-    clearCostCache();
+    clearModelDataCache();
   });
 
   afterEach(() => {
@@ -114,19 +59,22 @@ describe("fetchCostMap", () => {
     resetWorkerModelState();
   });
 
-  test("fetches and parses costs from models.dev JSON API", async () => {
+  test("fetches and parses model data from models.dev JSON API", async () => {
     globalThis.fetch = mock(() =>
       Promise.resolve(
-        new Response(JSON.stringify(buildModelsDevResponse(DEFAULT_COSTS)), { status: 200 }),
+        new Response(JSON.stringify(buildModelsDevResponse(DEFAULT_MODELS)), { status: 200 }),
       ),
     ) as unknown as typeof fetch;
 
-    const costMap = await fetchCostMap();
+    const data = await fetchModelData();
 
-    expect(costMap.get("claude-opus-4-20250514")).toBe(15.0);
-    expect(costMap.get("claude-sonnet-4-20250514")).toBe(3.0);
-    expect(costMap.get("claude-haiku-3-5-20241022")).toBe(0.8);
-    expect(costMap.size).toBe(4);
+    expect(data.size).toBe(3);
+    const opus = data.get("claude-opus-4-6")!;
+    expect(opus.cost?.input).toBe(5);
+    expect(opus.cost?.output).toBe(25);
+    expect(opus.cost?.cache_read).toBe(0.5);
+    expect(opus.limit?.context).toBe(1_000_000);
+    expect(opus.limit?.output).toBe(128_000);
   });
 
   test("caches results and returns cache on subsequent calls", async () => {
@@ -134,12 +82,12 @@ describe("fetchCostMap", () => {
     globalThis.fetch = mock(() => {
       callCount++;
       return Promise.resolve(
-        new Response(JSON.stringify(buildModelsDevResponse(DEFAULT_COSTS)), { status: 200 }),
+        new Response(JSON.stringify(buildModelsDevResponse(DEFAULT_MODELS)), { status: 200 }),
       );
     }) as unknown as typeof fetch;
 
-    const first = await fetchCostMap();
-    const second = await fetchCostMap();
+    const first = await fetchModelData();
+    const second = await fetchModelData();
 
     expect(callCount).toBe(1);
     expect(first).toBe(second); // Same reference — cached
@@ -150,29 +98,8 @@ describe("fetchCostMap", () => {
       Promise.resolve(new Response("Server Error", { status: 500 })),
     ) as unknown as typeof fetch;
 
-    const costMap = await fetchCostMap();
-    expect(costMap.size).toBe(0);
-  });
-
-  test("returns stale cache on API error when cache exists", async () => {
-    // First call succeeds
-    globalThis.fetch = mock(() =>
-      Promise.resolve(
-        new Response(JSON.stringify(buildModelsDevResponse(DEFAULT_COSTS)), { status: 200 }),
-      ),
-    ) as unknown as typeof fetch;
-    const cached = await fetchCostMap();
-    expect(cached.size).toBe(4);
-
-    // Expire cache
-    clearCostCache();
-
-    // Second call fails — but stale cache was cleared
-    globalThis.fetch = mock(() =>
-      Promise.resolve(new Response("Server Error", { status: 500 })),
-    ) as unknown as typeof fetch;
-    const fallback = await fetchCostMap();
-    expect(fallback.size).toBe(0);
+    const data = await fetchModelData();
+    expect(data.size).toBe(0);
   });
 
   test("returns stale cache on network error", async () => {
@@ -180,8 +107,8 @@ describe("fetchCostMap", () => {
       Promise.reject(new Error("Network error")),
     ) as unknown as typeof fetch;
 
-    const costMap = await fetchCostMap();
-    expect(costMap.size).toBe(0);
+    const data = await fetchModelData();
+    expect(data.size).toBe(0);
   });
 
   test("handles missing anthropic provider gracefully", async () => {
@@ -191,21 +118,21 @@ describe("fetchCostMap", () => {
       ),
     ) as unknown as typeof fetch;
 
-    const costMap = await fetchCostMap();
-    expect(costMap.size).toBe(0);
+    const data = await fetchModelData();
+    expect(data.size).toBe(0);
   });
 });
 
 // ---------------------------------------------------------------------------
-// fetchModelCosts
+// getModelEntry (async)
 // ---------------------------------------------------------------------------
 
-describe("fetchModelCosts", () => {
+describe("getModelEntry", () => {
   let originalFetch: typeof globalThis.fetch;
 
   beforeEach(() => {
     originalFetch = globalThis.fetch;
-    clearCostCache();
+    clearModelDataCache();
   });
 
   afterEach(() => {
@@ -213,58 +140,56 @@ describe("fetchModelCosts", () => {
     resetWorkerModelState();
   });
 
-  test("maps model IDs to per-token costs from models.dev", async () => {
+  test("returns exact match from models.dev", async () => {
     globalThis.fetch = mock(() =>
       Promise.resolve(
-        new Response(JSON.stringify(buildModelsDevResponse(DEFAULT_COSTS)), { status: 200 }),
+        new Response(JSON.stringify(buildModelsDevResponse(DEFAULT_MODELS)), { status: 200 }),
       ),
     ) as unknown as typeof fetch;
 
-    const costs = await fetchModelCosts([
-      "claude-opus-4-20250514",
-      "claude-sonnet-4-20250514",
-      "claude-haiku-3-5-20241022",
-    ]);
-
-    expect(costs.get("claude-opus-4-20250514")).toBe(15 / 1_000_000);
-    expect(costs.get("claude-sonnet-4-20250514")).toBe(3 / 1_000_000);
-    expect(costs.get("claude-haiku-3-5-20241022")).toBe(0.8 / 1_000_000);
+    const entry = await getModelEntry("claude-opus-4-6");
+    expect(entry.cost?.input).toBe(5);
+    expect(entry.cost?.output).toBe(25);
+    expect(entry.limit?.context).toBe(1_000_000);
   });
 
-  test("falls back to hardcoded cost for unknown models", async () => {
+  test("returns prefix match for dated model IDs", async () => {
     globalThis.fetch = mock(() =>
       Promise.resolve(
-        new Response(JSON.stringify(buildModelsDevResponse(DEFAULT_COSTS)), { status: 200 }),
+        new Response(JSON.stringify(buildModelsDevResponse(DEFAULT_MODELS)), { status: 200 }),
       ),
     ) as unknown as typeof fetch;
 
-    const costs = await fetchModelCosts(["claude-future-model-2026"]);
-    // Unknown model — not in models.dev, fallback to high cost
-    expect(costs.get("claude-future-model-2026")).toBe(100 / 1_000_000);
+    const entry = await getModelEntry("claude-haiku-4-5-20251001");
+    expect(entry.cost?.input).toBe(1);
+    expect(entry.cost?.output).toBe(5);
   });
 
-  test("falls back to hardcoded cost when API fails", async () => {
+  test("returns fallback for unknown model", async () => {
     globalThis.fetch = mock(() =>
-      Promise.reject(new Error("Network error")),
+      Promise.resolve(
+        new Response(JSON.stringify(buildModelsDevResponse(DEFAULT_MODELS)), { status: 200 }),
+      ),
     ) as unknown as typeof fetch;
 
-    const costs = await fetchModelCosts(["claude-sonnet-4-20250514"]);
-    // Fallback cost for claude-sonnet-4 prefix
-    expect(costs.get("claude-sonnet-4-20250514")).toBe(3 / 1_000_000);
+    const entry = await getModelEntry("claude-future-model-2027");
+    // Fallback defaults
+    expect(entry.cost?.input).toBe(3);
+    expect(entry.cost?.output).toBe(15);
+    expect(entry.limit?.context).toBe(200_000);
   });
 });
 
 // ---------------------------------------------------------------------------
-// discoverModels
+// getModelEntrySync
 // ---------------------------------------------------------------------------
 
-describe("discoverModels", () => {
+describe("getModelEntrySync", () => {
   let originalFetch: typeof globalThis.fetch;
 
   beforeEach(() => {
     originalFetch = globalThis.fetch;
-    clearModelCache();
-    clearCostCache();
+    clearModelDataCache();
   });
 
   afterEach(() => {
@@ -272,298 +197,49 @@ describe("discoverModels", () => {
     resetWorkerModelState();
   });
 
-  test("discovers models from upstream API with costs from models.dev", async () => {
-    const response = buildModelsResponse([
-      { id: "claude-opus-4-20250514", thinking_supported: true },
-      { id: "claude-sonnet-4-20250514" },
-      { id: "claude-haiku-3-5-20241022" },
-    ]);
-
-    globalThis.fetch = createRoutedFetch(response);
-
-    const models = await discoverModels(UPSTREAM, TEST_CRED);
-
-    expect(models).toHaveLength(3);
-    expect(models.map((m) => m.id)).toEqual([
-      "claude-opus-4-20250514",
-      "claude-sonnet-4-20250514",
-      "claude-haiku-3-5-20241022",
-    ]);
+  test("returns fallback when cache is cold", () => {
+    const entry = getModelEntrySync("claude-opus-4-6");
+    // Should get fallback pricing for opus-4-6
+    expect(entry.cost?.input).toBe(5);
+    expect(entry.cost?.output).toBe(25);
+    expect(entry.limit?.context).toBe(1_000_000);
   });
 
-  test("maps model costs from models.dev correctly", async () => {
-    const response = buildModelsResponse([
-      { id: "claude-opus-4-20250514" },
-      { id: "claude-sonnet-4-20250514" },
-      { id: "claude-haiku-3-5-20241022" },
-    ]);
-
-    globalThis.fetch = createRoutedFetch(response);
-
-    const models = await discoverModels(UPSTREAM, TEST_CRED);
-
-    const opus = models.find((m) => m.id === "claude-opus-4-20250514")!;
-    const sonnet = models.find((m) => m.id === "claude-sonnet-4-20250514")!;
-    const haiku = models.find((m) => m.id === "claude-haiku-3-5-20241022")!;
-
-    // Relative ordering: opus > sonnet > haiku
-    expect(opus.cost.input).toBeGreaterThan(sonnet.cost.input);
-    expect(sonnet.cost.input).toBeGreaterThan(haiku.cost.input);
-
-    // Exact values from models.dev mock data
-    expect(opus.cost.input).toBe(15 / 1_000_000);
-    expect(sonnet.cost.input).toBe(3 / 1_000_000);
-    expect(haiku.cost.input).toBe(0.8 / 1_000_000);
-  });
-
-  test("detects reasoning capability from thinking.supported", async () => {
-    const response = buildModelsResponse([
-      { id: "claude-opus-4-20250514", thinking_supported: true },
-      { id: "claude-haiku-3-5-20241022", thinking_supported: false },
-    ]);
-
-    globalThis.fetch = createRoutedFetch(response);
-
-    const models = await discoverModels(UPSTREAM, TEST_CRED);
-
-    const opus = models.find((m) => m.id === "claude-opus-4-20250514")!;
-    const haiku = models.find((m) => m.id === "claude-haiku-3-5-20241022")!;
-
-    expect(opus.capabilities.reasoning).toBe(true);
-    expect(haiku.capabilities.reasoning).toBe(false);
-  });
-
-  test("all models are marked as active and text-capable", async () => {
-    const response = buildModelsResponse([
-      { id: "claude-sonnet-4-20250514" },
-    ]);
-
-    globalThis.fetch = createRoutedFetch(response);
-
-    const models = await discoverModels(UPSTREAM, TEST_CRED);
-
-    expect(models[0].status).toBe("active");
-    expect(models[0].capabilities.input.text).toBe(true);
-    expect(models[0].providerID).toBe("anthropic");
-  });
-
-  test("caches results and returns cache on subsequent calls", async () => {
-    const response = buildModelsResponse([
-      { id: "claude-sonnet-4-20250514" },
-    ]);
-
-    let anthropicCallCount = 0;
-    globalThis.fetch = createRoutedFetch(response, {
-      onAnthropicCall: () => { anthropicCallCount++; },
-    });
-
-    const first = await discoverModels(UPSTREAM, TEST_CRED);
-    const second = await discoverModels(UPSTREAM, TEST_CRED);
-
-    expect(anthropicCallCount).toBe(1);
-    expect(first).toBe(second); // Same reference — cached
-  });
-
-  test("returns empty array on API error with no cache", async () => {
+  test("returns cached data after fetchModelData populates cache", async () => {
     globalThis.fetch = mock(() =>
-      Promise.resolve(new Response("Unauthorized", { status: 401 })),
+      Promise.resolve(
+        new Response(JSON.stringify(buildModelsDevResponse(DEFAULT_MODELS)), { status: 200 }),
+      ),
     ) as unknown as typeof fetch;
 
-    const models = await discoverModels(UPSTREAM, TEST_CRED);
-    expect(models).toEqual([]);
+    // Warm the cache
+    await fetchModelData();
+
+    const entry = getModelEntrySync("claude-haiku-4-5");
+    expect(entry.cost?.input).toBe(1);
+    expect(entry.cost?.output).toBe(5);
+    expect(entry.limit?.output).toBe(64_000);
   });
 
-  test("returns stale cache on API error when cache exists", async () => {
-    const response = buildModelsResponse([
-      { id: "claude-sonnet-4-20250514" },
-    ]);
-
-    // First call succeeds and populates cache
-    globalThis.fetch = createRoutedFetch(response);
-
-    const cached = await discoverModels(UPSTREAM, TEST_CRED);
-    expect(cached).toHaveLength(1);
-
-    // Expire the cache manually
-    clearModelCache();
-
-    // Second call fails (Anthropic API error)
+  test("prefix matches work in sync mode", async () => {
     globalThis.fetch = mock(() =>
-      Promise.resolve(new Response("Server Error", { status: 500 })),
+      Promise.resolve(
+        new Response(JSON.stringify(buildModelsDevResponse(DEFAULT_MODELS)), { status: 200 }),
+      ),
     ) as unknown as typeof fetch;
 
-    // clearModelCache clears both cache and timestamp, so stale fallback
-    // returns empty since there's genuinely no cache
-    const fallback = await discoverModels(UPSTREAM, TEST_CRED);
-    expect(fallback).toEqual([]);
+    await fetchModelData();
+
+    const entry = getModelEntrySync("claude-sonnet-4-20250514-extended");
+    expect(entry.cost?.input).toBe(3);
   });
 
-  test("returns stale cache on network error", async () => {
-    const response = buildModelsResponse([
-      { id: "claude-sonnet-4-20250514" },
-    ]);
-
-    // First: populate cache
-    globalThis.fetch = createRoutedFetch(response);
-    await discoverModels(UPSTREAM, TEST_CRED);
-
-    clearModelCache();
-
-    // Network error on re-fetch
-    globalThis.fetch = mock(() =>
-      Promise.reject(new Error("Network error")),
-    ) as unknown as typeof fetch;
-
-    const models = await discoverModels(UPSTREAM, TEST_CRED);
-    // No cache available after clearModelCache
-    expect(models).toEqual([]);
-  });
-
-  test("sends correct auth headers with API key", async () => {
-    const response = buildModelsResponse([]);
-    let capturedHeaders: Record<string, string> = {};
-
-    globalThis.fetch = createRoutedFetch(response, {
-      onAnthropicCall: (_url, init) => {
-        capturedHeaders = init?.headers as Record<string, string>;
-      },
-    });
-
-    await discoverModels(UPSTREAM, TEST_CRED);
-
-    expect(capturedHeaders["x-api-key"]).toBe("sk-test-key");
-    expect(capturedHeaders["anthropic-version"]).toBe("2023-06-01");
-  });
-
-  test("sends correct auth headers with bearer token", async () => {
-    const response = buildModelsResponse([]);
-    let capturedHeaders: Record<string, string> = {};
-
-    globalThis.fetch = createRoutedFetch(response, {
-      onAnthropicCall: (_url, init) => {
-        capturedHeaders = init?.headers as Record<string, string>;
-      },
-    });
-
-    const bearerCred: AuthCredential = {
-      scheme: "bearer",
-      value: "token-abc",
-    };
-    await discoverModels(UPSTREAM, bearerCred);
-
-    expect(capturedHeaders["Authorization"]).toBe("Bearer token-abc");
-  });
-
-  test("deprecated models not returned by API are naturally excluded", async () => {
-    const response = buildModelsResponse([
-      { id: "claude-sonnet-4-20250514" },
-      { id: "claude-haiku-3-5-20241022" },
-    ]);
-
-    globalThis.fetch = createRoutedFetch(response);
-
-    const models = await discoverModels(UPSTREAM, TEST_CRED);
-
-    expect(models.map((m) => m.id)).not.toContain("claude-3-haiku-20240307");
-    expect(models).toHaveLength(2);
-  });
-
-  test("unknown model gets high cost when not in models.dev", async () => {
-    const response = buildModelsResponse([
-      { id: "claude-future-model-2026" },
-    ]);
-
-    globalThis.fetch = createRoutedFetch(response);
-
-    const models = await discoverModels(UPSTREAM, TEST_CRED);
-    const unknown = models[0];
-
-    // Not in models.dev → fallback to high cost
-    expect(unknown.cost.input).toBe(100 / 1_000_000);
-  });
-
-  test("falls back to hardcoded costs when models.dev is down", async () => {
-    const response = buildModelsResponse([
-      { id: "claude-sonnet-4-20250514" },
-      { id: "claude-haiku-3-5-20241022" },
-    ]);
-
-    globalThis.fetch = createRoutedFetch(response, {
-      modelsDevOverride: () => new Response("Service Unavailable", { status: 503 }),
-    });
-
-    const models = await discoverModels(UPSTREAM, TEST_CRED);
-
-    // Should still get models with fallback costs
-    expect(models).toHaveLength(2);
-    const sonnet = models.find((m) => m.id === "claude-sonnet-4-20250514")!;
-    const haiku = models.find((m) => m.id === "claude-haiku-3-5-20241022")!;
-
-    // Fallback costs maintain correct ordering
-    expect(sonnet.cost.input).toBeGreaterThan(haiku.cost.input);
-  });
-
-  test("paginates through multiple pages", async () => {
-    const page1 = {
-      data: [
-        {
-          id: "claude-opus-4-20250514",
-          type: "model",
-          display_name: "Claude Opus 4",
-          created_at: "2025-01-01T00:00:00Z",
-          max_input_tokens: 200_000,
-          max_tokens: 32_000,
-          capabilities: { thinking: { supported: true } },
-        },
-      ],
-      has_more: true,
-      first_id: "claude-opus-4-20250514",
-      last_id: "claude-opus-4-20250514",
-    };
-    const page2 = {
-      data: [
-        {
-          id: "claude-haiku-3-5-20241022",
-          type: "model",
-          display_name: "Claude Haiku 3.5",
-          created_at: "2025-01-01T00:00:00Z",
-          max_input_tokens: 200_000,
-          max_tokens: 8192,
-          capabilities: { thinking: { supported: false } },
-        },
-      ],
-      has_more: false,
-      first_id: "claude-haiku-3-5-20241022",
-      last_id: "claude-haiku-3-5-20241022",
-    };
-
-    let anthropicCallIndex = 0;
-    globalThis.fetch = mock((url: string | URL | Request, _init?: RequestInit) => {
-      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
-
-      // models.dev API request
-      if (urlStr === MODELS_DEV_API) {
-        return Promise.resolve(
-          new Response(JSON.stringify(buildModelsDevResponse(DEFAULT_COSTS)), { status: 200 }),
-        );
-      }
-
-      // Anthropic API — paginated
-      const page = anthropicCallIndex === 0 ? page1 : page2;
-      anthropicCallIndex++;
-      return Promise.resolve(
-        new Response(JSON.stringify(page), { status: 200 }),
-      );
-    }) as unknown as typeof fetch;
-
-    const models = await discoverModels(UPSTREAM, TEST_CRED);
-
-    expect(anthropicCallIndex).toBe(2);
-    expect(models).toHaveLength(2);
-    expect(models.map((m) => m.id)).toEqual([
-      "claude-opus-4-20250514",
-      "claude-haiku-3-5-20241022",
-    ]);
+  test("unknown model returns default fallback", () => {
+    const entry = getModelEntrySync("totally-unknown-model");
+    expect(entry.cost?.input).toBe(3);
+    expect(entry.cost?.output).toBe(15);
+    expect(entry.limit?.context).toBe(200_000);
+    expect(entry.limit?.output).toBe(8_192);
   });
 });
 
@@ -572,14 +248,14 @@ describe("discoverModels", () => {
 // ---------------------------------------------------------------------------
 
 describe("getWorkerModel", () => {
-  test("returns undefined when no validation has been stored", () => {
+  test("returns a model or undefined (depends on lore config)", () => {
     const result = getWorkerModel();
     expect(result === undefined || typeof result === "object").toBe(true);
   });
 });
 
 // ---------------------------------------------------------------------------
-// clearModelCache / resetWorkerModelState
+// resetWorkerModelState
 // ---------------------------------------------------------------------------
 
 describe("resetWorkerModelState", () => {
@@ -594,26 +270,25 @@ describe("resetWorkerModelState", () => {
     resetWorkerModelState();
   });
 
-  test("clears cache so next discoverModels re-fetches", async () => {
-    const response = buildModelsResponse([
-      { id: "claude-sonnet-4-20250514" },
-    ]);
+  test("clears cache so next fetchModelData re-fetches", async () => {
+    let callCount = 0;
+    globalThis.fetch = mock(() => {
+      callCount++;
+      return Promise.resolve(
+        new Response(JSON.stringify(buildModelsDevResponse(DEFAULT_MODELS)), { status: 200 }),
+      );
+    }) as unknown as typeof fetch;
 
-    let anthropicCallCount = 0;
-    globalThis.fetch = createRoutedFetch(response, {
-      onAnthropicCall: () => { anthropicCallCount++; },
-    });
-
-    await discoverModels(UPSTREAM, TEST_CRED);
-    expect(anthropicCallCount).toBe(1);
+    await fetchModelData();
+    expect(callCount).toBe(1);
 
     // Without reset, cached
-    await discoverModels(UPSTREAM, TEST_CRED);
-    expect(anthropicCallCount).toBe(1);
+    await fetchModelData();
+    expect(callCount).toBe(1);
 
     // After reset, re-fetches
     resetWorkerModelState();
-    await discoverModels(UPSTREAM, TEST_CRED);
-    expect(anthropicCallCount).toBe(2);
+    await fetchModelData();
+    expect(callCount).toBe(2);
   });
 });

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -670,9 +670,7 @@ export const LorePlugin: Plugin = async (ctx) => {
   /**
    * Resolve the model to use for background worker calls.
    *
-   * Worker model validation is now handled by the gateway (via /v1/models
-   * API discovery), which writes validated models to kv_meta. This function
-   * reads the validated result — no OpenCode-side validation needed.
+   * Priority: explicit config override > session model fallback.
    */
   function getWorkerModel(): { providerID: string; modelID: string } | undefined {
     const cfg = config();
@@ -797,10 +795,6 @@ export const LorePlugin: Plugin = async (ctx) => {
       } catch (e) {
         log.error("consolidation error:", e);
       }
-
-      // Worker model validation is now handled by the gateway (via /v1/models
-      // API discovery). The gateway writes validated models to kv_meta, and
-      // getWorkerModel() reads them — no OpenCode-side validation needed.
 
       // Prune temporal messages after distillation and curation have run.
       // Pass 1: TTL — remove distilled messages older than retention period.


### PR DESCRIPTION
## Summary

- **Remove dynamic worker model selection** — candidate discovery, two-phase validation (structural check + LLM judge), fingerprint staleness detection all removed. A/B testing showed the quality gap on complex conversations wasn't worth the infrastructure cost. Background work now always uses the session model (with explicit `workerModel` config override still supported).
- **Replace 3 hardcoded pricing maps with live models.dev data** — `MODEL_PRICING` (sentry.ts), `MODEL_SPECS` (pipeline.ts), and `FALLBACK_COSTS` (worker-model.ts) all replaced by a single `fetchModelData()` call to models.dev/api.json at gateway startup. New models automatically get correct pricing, context limits, and output limits without code changes.
- **Net: −1,104 lines** — core worker-model.ts (401→51), gateway worker-model.ts (408→222), tests rewritten. 889 tests pass, all packages typecheck clean.

## Changes

| File | What changed |
|------|-------------|
| `core/src/worker-model.ts` | Stripped to `resolveWorkerModel()` only (config override → session model fallback) |
| `gateway/src/worker-model.ts` | Kept `fetchModelData()` from models.dev, added `getModelEntrySync()` for hot path, removed all validation/discovery |
| `gateway/src/sentry.ts` | `emitCostMetric` uses live pricing via `getModelEntry()` |
| `gateway/src/pipeline.ts` | `getModelSpec` uses sync cache via `getModelEntrySync()`, pre-warm in `initIfNeeded()` |
| `gateway/src/idle.ts` | Removed validation step + unused params from `buildIdleWorkHandler` |
| `opencode/src/index.ts` | Updated comments, no functional change |
| Tests | Rewritten for new API surface |