### PR TITLE
fix: normalize Claude CLI cch= hash in cache analytics

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -5,49 +5,49 @@
 ### Architecture
 
 <!-- lore:019e0e5c-ab22-7d49-97ac-295ac0b39c08 -->
-* **GitHub Copilot as free tier model provider through OpenCode**: GitHub Copilot integration through OpenCode provides free access to premium models (gpt-4o, claude-3-5-sonnet, o1-preview, gemini-1.5-pro) for testing and development. Available models include OpenAI, Anthropic, Google, and other providers without direct API costs. Use for A/B testing model quality across providers and as fallback option for cost-sensitive operations.
+* **GitHub Copilot as free tier model provider through OpenCode**: GitHub Copilot provides free access to premium models (gpt-4o, claude-3-5-sonnet, o1-preview, gemini-1.5-pro) through OpenCode integration. Available without direct API costs for testing and A/B testing model quality. Other paid providers (xAI, Mistral) require separate API key configuration.
+
+### Decision
+
+<!-- lore:019e0e85-e0e6-7914-994d-c10798a247fc -->
+* **Switched from plan to build mode (read-only disabled**: switched from plan to build mode (read-only disabled,
 
 ### Gotcha
 
-<!-- lore:019e0e62-2936-7deb-8d99-1df5dd175465 -->
-* **OpenCode API paid provider authentication failures**: OpenCode SDK returns "(no text response)" for paid providers (xAI, Mistral) when API keys aren't configured or models require special handling. Only GitHub Copilot-provided models work reliably without additional auth setup. Use \`client.models.list()\` to verify provider availability before testing - disconnected providers show empty model lists.
+<!-- lore:019e0e7d-a1e6-76fc-a45a-9bb32fe775ac -->
+* **Claude CLI system prompt divergence causes 99.9% cache miss rate**: Claude CLI system prompt divergence at byte 168: System\[0] diverges at fixed position ~168 bytes (~75 characters) in every turn, suggesting dynamic content injection (timestamp, environment info). Appears as 0.1% prefix match on 150-266KB prompts but doesn't affect Anthropic's actual cache (98-100% hit rates observed). The CLI likely embeds turn-specific metadata early in system prompt. Our JSON.stringify comparison detects this as cache bust but Anthropic's token-level caching is unaffected.
 
-<!-- lore:019e0da9-6a78-75bb-9a43-056d34bd8c04 -->
-* **ReadableStream controller double-close in error handling**: (gotcha) ReadableStream controller double-close in error handling: Pipeline streaming closes controller in success path, but if \`onComplete()\` or subsequent work throws, catch handler calls \`controller.error(err)\` on already-closed controller causing TypeError. Fix: track closed state with boolean flag, guard error handler with \`if (!isClosed) controller.error(err)\`. Alternative: move \`controller.close()\` after all throwing work.
+<!-- lore:019e0e73-8f08-7093-bd66-734b2356192b -->
+* **FALLBACK\_PRICING maintenance burden vs offline resilience tradeoff**: FALLBACK\_PRICING as offline safety net: Contains only critical models (expensive session models like opus/gpt-4o and worker models like sonnet-4-6/gpt-4o-mini) when models.dev is unreachable. Trimmed from 22+ to ~4 entries to reduce maintenance burden. Unknown models use generic defaults. Balances offline functionality with reduced maintenance overhead.
 
-<!-- lore:019e0e67-a728-7d8c-844a-f57b2e47a5fa -->
-* **Test data setup for multi-provider model loading**: buildModelsDevResponse test helper only creates Anthropic models by default, but model loading now includes OpenAI. Tests expecting specific model counts or provider filtering must account for cross-provider loading. Update test data to include OpenAI models or use provider-specific filtering in assertions to avoid brittle counts.
+<!-- lore:019e0e82-acaa-7790-899b-de3ff46a6091 -->
+* **OAuth token batch API fallback triggers worker rate limits**: Claude CLI OAuth tokens lack batch API scope, forcing worker requests (distillation, curation) into synchronous fallback. These compete with main session for rate quota, causing 429s on worker calls. Batch fails with 403 'OAuth token does not meet scope requirement' - requires user:batch/developer or workspace:developer scopes. Consider more aggressive backoff or skipping non-critical work when rate-limited on shared credentials.
+
+<!-- lore:019e0e81-4cd5-75a7-9c7c-1a2c550e0434 -->
+* **Sentry span ends before cache analytics run, preventing span enrichment**: Sentry span ends before cache analytics run, preventing span enrichment: genAiSpan.end() called before cache analytics in postResponse. Cache divergence data (bust cause, prefix match, divergence snippets) can't reach Sentry traces. Fixed by reordering: run cache analytics first, set span attributes via setCacheTurnAttributes(), then end span. Helper extracts bust\_cause, prefix\_match\_percentage, divergence\_point\_byte, and optional before/after snippets from CacheTurnAnalysis.
+
+<!-- lore:019e0e78-98ea-7494-b86a-60725e8fc04a -->
+* **System prompt divergence uses JSON.stringify comparison**: System prompt divergence uses JSON.stringify: System prompt cache divergence uses JSON.stringify for comparison, sensitive to whitespace, property ordering, and structure changes. System prompts stored as array: system\[0] = host prompt, system\[1] = LTM context. divergenceAnalysis() compares each element separately - system\[0] changes log as "host system prompt changed". Byte-for-byte JSON identity required to avoid cache misses.
 
 ### Pattern
 
 <!-- lore:019e0d91-d623-7753-9867-8e728c6fac37 -->
-* **Auto-detected conversation TTL based on cold-cache turn progression**: Auto-detected conversation TTL by turn progression: TTL selection logic: 5m for turns 1-3, 1h for turn 4+. Gateway tracks coldCacheTurns incremented on cache misses. getTTLBasedOnTurns() determines TTL before cache construction. Prevents unnecessary long-term cache on quick interactions while preserving context for sustained conversations.
+* **Auto-detected conversation TTL based on cold-cache turn progression**: Auto-detected conversation TTL: TTL selection logic: 5m for turns 1-3, 1h for turn 4+. Gateway tracks coldCacheTurns incremented on cache misses. getTTLBasedOnTurns() determines TTL before cache construction. Prevents unnecessary long-term cache on quick interactions while preserving context for sustained conversations.
 
-<!-- lore:019e0d89-1f32-764a-ba85-e5b7018ac3fe -->
-* **Bust rate feedback loop in postResponse calibration**: Bust rate feedback loop in postResponse: Updates SessionState.gradient.burstFrequencyEMA via EMA (alpha ~0.3) after cache analytics. Tracks write:read ratio and break frequency per session for adaptive cap tightening. Calls calibrate() callback with recent metrics to update EMA for next turn's context cap calculation.
+<!-- lore:019e0e83-96dd-7fc2-9d58-c36f5e5b0844 -->
+* **Cache divergence snippets for debugging in CacheTurnAnalysis**: CacheTurnAnalysis includes optional snippet fields for debugging early cache divergences: prevSnippet and currSnippet capture 200-char windows around divergence point. Only populated when divergence occurs within first 500 chars (early divergence). enrichSpanWithCacheInfo() helper adds these snippets to Sentry spans as cache.prev\_snippet and cache.curr\_snippet attributes for debugging cache bust causes.
 
-<!-- lore:019e0d8c-cb2f-7834-8dba-670edf682fe4 -->
-* **Cache bust metric emission for observability and feedback**: Cache bust metric emission: Emit emitCacheBustMetric(sessionId, bustCause, context) in postResponse() after categorizing bust cause. Captures sessionId, bustCause enum, model, session duration, active layers. Uses Sentry metrics for dashboards tracking bust patterns. Data feeds back into calibrate() EMA feedback loop.
+<!-- lore:019e0e7a-de00-7436-a523-1b0e7f92c33d -->
+* **Compaction request interception for Claude Code**: Compaction request interception: Proxy detects Claude Code compaction requests via system prompt containing "anchored context summarization assistant", empty tools + user message with "anchored summary" patterns or \<previous-summary> tags, or \<template> tag with 4+ section headers. When detected, runs Lore's own distillation instead of forwarding upstream. Prevents expensive upstream compaction calls.
 
-<!-- lore:019e0d8a-0c17-7807-8c9c-854650d88535 -->
-* **Cache write cost per model in ModelSpec — derived from pricing + TTL**: ModelSpec cache write cost calculation: Pre-computed as cache\_write\_price \* base\_price / input\_price per model+TTL. Defaults: 1.25x (5m TTL), 2x (1h TTL). Exposed via getModelSpec() for context caps and curation decisions. Used by cost-aware worker defaults to select cheaper models when session model cacheWriteCost >= 2x.
+<!-- lore:019e0e83-21c8-7822-809f-c6cb133e77f5 -->
+* **Sentry span enrichment with cache analytics attributes**: enrichGenAiSpanWithCacheAnalysis() helper adds cache debugging context to Sentry spans: Sets cache.bust\_cause (miss/divergence/timeout), cache.prefix\_match (percentage), and cache.divergence\_point (byte position) attributes from CacheTurnAnalysis. Called after cache analytics run but before span.end() to ensure cache debugging data reaches distributed traces. Requires CacheTurnAnalysis object with cacheBustCause, cachePrefixMatch, and divergenceAnalysis fields.
 
-<!-- lore:019e0d8b-e42b-7cb5-a89c-9ebe0af8b4bb -->
-* **Cost-aware curation frequency scaling by model tier**: Cost-aware curation frequency scaling: Curation frequency scales by model cost via \`afterTurns \*= getModelSpec(model).cacheWriteCost\` in pipeline.ts. Expensive models (Opus ~2x) curate less frequently. LTM diff threshold scales inversely so expensive models need larger changes to trigger updates. Prevents costly model churn while maintaining quality.
+<!-- lore:019e0e82-acaf-79dd-8fff-cd78a7744c6a -->
+* **Sentry span timing for cache analytics integration**: Sentry genAiSpan ends before cache analytics run (span.end() at L913, analytics at L917-942). Cache divergence data unavailable for Sentry enrichment. Must reorder: run cache analytics first, set span attributes with divergence point/prefix match/bust cause, then end span. Enables customer debugging through Sentry traces when cache issues occur.
 
-<!-- lore:019e0d9c-97e5-76fa-a260-f094144a7763 -->
-* **Cost-aware default worker model selection**: Provider-aware worker model selection in gateway: getWorkerModel() maps providers to validated cheaper alternatives based on cfg.model.providerID. Anthropic sessions → claude-sonnet-4-6, OpenAI sessions → gpt-5.4-mini (70% cost savings, quality parity). All other providers → gpt-5.4-mini as general fallback (available through GitHub Copilot). Triggered when session model cacheWriteCost > 1.5. Resolution: explicit config → provider mapping → general fallback (gpt-5.4-mini) → host default.
-
-<!-- lore:019e0e5c-ab10-7281-9d1a-6340ea03a2b0 -->
-* **Multi-provider model equivalency mapping for worker model selection**: Provider-aware worker model mapping validated via A/B testing on 22-message conversation: GPT-5.4-mini achieves quality parity with GPT-5.4 (24/24, 22/24 across runs) at 70% cost savings. Anthropic Sonnet 4.6 matches Opus quality (25 vs 23 obs). Gemini 3 Flash underperforms Pro (-14% to -35% obs loss). xAI/Mistral return no responses via OpenCode API. getWorkerModel() maps: Anthropic→claude-sonnet-4-6, OpenAI→gpt-5.4-mini, GitHub Copilot detects provider via model ID prefix (claude-\*→sonnet, others→gpt-5.4-mini), unknown expensive providers→gpt-5.4-mini fallback. Only activates when session model cacheWriteCost > 1.5x.
+<!-- lore:019e0e7a-ddfb-7394-bf57-9fa3ea0fe024 -->
+* **Session correlation via fingerprint and message-count proximity**: Session correlation via fingerprint: Sessions identified using SHA-256 fingerprint of first user message + model + auth suffix (16 hex chars). Scans active sessions for matching fingerprint and selects closest message count within 20-message threshold. Fork detection: if message count drops >20, treats as new session. Stores fingerprint, messageCount, lastRequestTime in SessionState.
 
 <!-- lore:019e0da9-69ef-79d4-87e6-6206f11dcfb0 -->
-* **SSE streaming pipeline recall interception architecture**: (pattern) SSE streaming pipeline architecture: Pipeline streaming phases: 1) Parse upstream SSE via parseSSEStream(), forward through accumulator.processEvent() 2) Post-stream recall check - execute query and emit synthetic marker if detected 3) Branch by tool mix: mixed tools = forward held events + close, recall-only = follow-up API call + continuation stream, no recall = normal close. All branches use controller.enqueue(encoder.encode(sseText)).
-
-### Preference
-
-<!-- lore:019e0e5c-ab27-7be5-ac93-d63f08570b20 -->
-* **No direct pushes to main branch without explicit approval**: Never push directly to main branch unless explicitly instructed to do so. Always use pull requests for changes to maintain code review process and branch protection. This is a strict workflow requirement for all code modifications.
-
-<!-- lore:019e0e67-0533-7c17-a972-bd30642de7b4 -->
-* **Prefers newest models in their segments per user mandate (e.g., Gemini 3-flash over 2**: prefer newest models in their segments per user mandate (e.g., Gemini 3-flash over 2.
+* **SSE streaming pipeline recall interception architecture**: SSE streaming pipeline architecture: 1) Parse upstream SSE via parseSSEStream(), forward through accumulator.processEvent() 2) Post-stream recall check - execute query and emit synthetic marker if detected 3) Branch by tool mix: mixed tools = forward held events + close, recall-only = follow-up API call + continuation stream, no recall = normal close. All branches use controller.enqueue(encoder.encode(sseText)).

--- a/packages/gateway/src/cache-analytics.ts
+++ b/packages/gateway/src/cache-analytics.ts
@@ -36,6 +36,30 @@ export function decompressBody(compressed: Uint8Array): string {
 }
 
 // ---------------------------------------------------------------------------
+// Body normalization for stable comparison
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize a serialized request body for cache comparison by stripping
+ * volatile metadata that clients embed in the system prompt.
+ *
+ * Claude Code prepends `entrypoint=cli; cch=XXXXX;\n` to its system prompt
+ * where `cch` is a content-cache hash that changes every turn. This busts
+ * our byte-level prefix comparison even though the actual prompt content
+ * is stable (and Anthropic's token-level cache hits fine).
+ *
+ * We replace the volatile `cch=...;` segment with a fixed placeholder so
+ * the comparison sees the bodies as prefix-identical when only this hash
+ * changed. The upstream request is never modified — only our analytics copy.
+ */
+const CCH_PATTERN = /cch=[0-9a-fA-F]+;/g;
+const CCH_REPLACEMENT = "cch=__;";
+
+export function normalizeBodyForComparison(body: string): string {
+  return body.replace(CCH_PATTERN, CCH_REPLACEMENT);
+}
+
+// ---------------------------------------------------------------------------
 // Byte-level prefix comparison
 // ---------------------------------------------------------------------------
 
@@ -288,26 +312,49 @@ export function analyzeCacheTurn(
   let prefixMatchPercent = 0;
   let divergencePoint = "<first-turn>";
   let divergenceReason = "first turn — no previous request to compare";
+  let prevSnippet: string | undefined;
+  let currSnippet: string | undefined;
+
+  // Normalize the current body for comparison: strip volatile client metadata
+  // (e.g. Claude Code's per-turn `cch=XXXXX;` hash) so it doesn't pollute
+  // prefix comparison. The previous body was already normalized before storage.
+  const normalizedBody = normalizeBodyForComparison(currentBody);
 
   // Compare with previous body if available
   if (analytics.lastRequestBody !== null) {
     const prevBody = decompressBody(analytics.lastRequestBody);
     const prevLength = prevBody.length;
-    const currLength = currentBody.length;
+    const currLength = normalizedBody.length;
 
-    prefixMatchBytes = findDivergenceOffset(prevBody, currentBody);
+    prefixMatchBytes = findDivergenceOffset(prevBody, normalizedBody);
     const minLength = Math.min(prevLength, currLength);
     prefixMatchPercent = minLength > 0 ? prefixMatchBytes / minLength : 0;
 
     if (prefixMatchBytes < minLength) {
       // Actual divergence within the shared prefix
-      divergencePoint = mapOffsetToJsonPath(currentBody, prefixMatchBytes);
+      divergencePoint = mapOffsetToJsonPath(normalizedBody, prefixMatchBytes);
       divergenceReason = inferDivergenceReason(
         divergencePoint,
         prevLength,
         currLength,
         messageCount,
       );
+
+      // Capture and log diverging byte snippets for early divergences (< 5%
+      // prefix match) to help diagnose what the client is changing (e.g.
+      // timestamps, turn counters). Snippets are also stored on the result
+      // for Sentry span enrichment.
+      if (prefixMatchPercent < 0.05) {
+        const start = Math.max(0, prefixMatchBytes - 20);
+        const end = prefixMatchBytes + 80;
+        prevSnippet = prevBody.slice(start, Math.min(prevLength, end));
+        currSnippet = normalizedBody.slice(start, Math.min(currLength, end));
+        log.info(
+          `cache-analytics: early divergence at byte ${prefixMatchBytes}` +
+            `\n  prev: ${JSON.stringify(prevSnippet)}` +
+            `\n  curr: ${JSON.stringify(currSnippet)}`,
+        );
+      }
     } else if (prevLength !== currLength) {
       // One is a prefix of the other — new content appended/removed
       divergencePoint = "<end>";
@@ -321,9 +368,11 @@ export function analyzeCacheTurn(
     }
   }
 
-  // Store compressed body for next turn
-  analytics.lastRequestBody = compressBody(currentBody);
-  analytics.lastRequestBodyLength = currentBody.length;
+  // Store normalized + compressed body for next turn. We store the normalized
+  // version so the next turn's comparison is apples-to-apples (both sides
+  // have volatile metadata stripped).
+  analytics.lastRequestBody = compressBody(normalizedBody);
+  analytics.lastRequestBodyLength = normalizedBody.length;
   analytics.lastCacheRead = cacheRead;
   analytics.lastCacheCreation = cacheCreation;
 
@@ -337,6 +386,8 @@ export function analyzeCacheTurn(
     prefixMatchPercent,
     divergencePoint,
     divergenceReason,
+    prevSnippet,
+    currSnippet,
   };
 
   // Log structured analysis

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -97,13 +97,14 @@ import { getWorkerModel, resetWorkerModelState, fetchModelData, getModelEntrySyn
 import * as Sentry from "@sentry/bun";
 import { analyzeCacheTurn, categorizeBust } from "./cache-analytics";
 import {
-  setSentryRequestContext,
-  setSentryCacheContext,
-  setSentryLightContext,
-  setGenAiUsageAttributes,
-  emitCostMetric,
-  emitCacheBustMetric,
-  type AnthropicUsage,
+   setSentryRequestContext,
+   setSentryCacheContext,
+   setSentryLightContext,
+   setGenAiUsageAttributes,
+   setCacheAnalyticsAttributes,
+   emitCostMetric,
+   emitCacheBustMetric,
+   type AnthropicUsage,
 } from "./sentry";
 import {
   RECALL_GATEWAY_TOOL,
@@ -899,7 +900,7 @@ function postResponse(
       getLastTransformedCount(sessionID),
     );
 
-    // --- Sentry cache context + cost metric + span finalization ---
+    // --- Sentry cache context + cost metric ---
     setSentryCacheContext(resp.usage);
     const usageForSentry: AnthropicUsage = {
       input_tokens: resp.usage.inputTokens,
@@ -910,10 +911,11 @@ function postResponse(
     emitCostMetric(resp.model, usageForSentry, "conversation");
     if (genAiSpan) {
       setGenAiUsageAttributes(genAiSpan, usageForSentry, resp.model);
-      genAiSpan.end();
     }
 
     // --- Cache analytics + bust cause telemetry ---
+    // Run BEFORE genAiSpan.end() so we can enrich the span with
+    // divergence diagnostics (divergence point, prefix match, bust cause).
     if (requestBody) {
       const turnAnalysis = analyzeCacheTurn(
         sessionState.cacheAnalytics, requestBody, resp.usage, sessionID,
@@ -923,6 +925,12 @@ function postResponse(
         turnAnalysis,
         sessionState.lastTurnWasIdle ?? false,
       );
+      if (genAiSpan) {
+        setCacheAnalyticsAttributes(
+          genAiSpan, turnAnalysis, bustCause,
+          turnAnalysis.prevSnippet, turnAnalysis.currSnippet,
+        );
+      }
       emitCacheBustMetric(
         bustCause,
         resp.usage.cacheCreationInputTokens ?? 0,
@@ -939,6 +947,11 @@ function postResponse(
       if (sessionState.coldCacheWindow.length > 20) {
         sessionState.coldCacheWindow.shift();
       }
+    }
+
+    // --- Finalize gen_ai.chat span (after cache analytics enrichment) ---
+    if (genAiSpan) {
+      genAiSpan.end();
     }
 
     // --- Bust rate feedback for dynamic context cap ---

--- a/packages/gateway/src/sentry.ts
+++ b/packages/gateway/src/sentry.ts
@@ -151,8 +151,44 @@ export function setGenAiUsageAttributes(
 }
 
 // ---------------------------------------------------------------------------
-// Cost estimation metrics
+// Cache analytics span enrichment
 // ---------------------------------------------------------------------------
+
+import type { CacheTurnAnalysis } from "./translate/types.ts";
+
+/**
+ * Set cache analytics attributes on a gen_ai.chat span.
+ *
+ * Called after `analyzeCacheTurn()` returns — adds divergence diagnostics
+ * and prefix match data so cache busting issues are visible in Sentry traces
+ * without needing to grep server logs.
+ *
+ * For early divergences (< 5% prefix match), also includes short byte
+ * snippets around the divergence point for forensic debugging.
+ */
+export function setCacheAnalyticsAttributes(
+  span: Sentry.Span,
+  analysis: CacheTurnAnalysis,
+  bustCause: string,
+  prevSnippet?: string,
+  currSnippet?: string,
+): void {
+  span.setAttribute("lore.cache.turn", analysis.turn);
+  span.setAttribute("lore.cache.hit_rate", Math.round(analysis.cacheHitRate * 1000) / 1000);
+  span.setAttribute("lore.cache.prefix_match", Math.round(analysis.prefixMatchPercent * 1000) / 1000);
+  span.setAttribute("lore.cache.divergence_point", analysis.divergencePoint);
+  span.setAttribute("lore.cache.divergence_reason", analysis.divergenceReason);
+  span.setAttribute("lore.cache.bust_cause", bustCause);
+
+  // Include diverging byte snippets for early divergences — these are from the
+  // system prompt prefix (client env info), not user conversation content.
+  if (prevSnippet) {
+    span.setAttribute("lore.cache.divergence_prev_snippet", prevSnippet);
+  }
+  if (currSnippet) {
+    span.setAttribute("lore.cache.divergence_curr_snippet", currSnippet);
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Cache bust telemetry

--- a/packages/gateway/src/translate/types.ts
+++ b/packages/gateway/src/translate/types.ts
@@ -185,6 +185,12 @@ export type CacheTurnAnalysis = {
   divergencePoint: string;
   /** Human-readable reason (e.g. "system prompt changed", "new message appended"). */
   divergenceReason: string;
+
+  // --- Forensic snippets for early divergences (< 5% prefix match) ---
+  /** Short snippet of previous body around the divergence point. */
+  prevSnippet?: string;
+  /** Short snippet of current body around the divergence point. */
+  currSnippet?: string;
 };
 
 /** Per-session cache analytics state. */

--- a/packages/gateway/test/cache-analytics.test.ts
+++ b/packages/gateway/test/cache-analytics.test.ts
@@ -6,6 +6,7 @@ import {
   mapOffsetToJsonPath,
   inferDivergenceReason,
   analyzeCacheTurn,
+  normalizeBodyForComparison,
 } from "../src/cache-analytics";
 import type { CacheAnalytics, GatewayUsage } from "../src/translate/types";
 
@@ -439,5 +440,75 @@ describe("analyzeCacheTurn", () => {
 
     expect(result.divergencePoint).toMatch(/messages\[1\]/);
     expect(result.divergenceReason).toMatch(/message at position 1 content changed/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeBodyForComparison
+// ---------------------------------------------------------------------------
+
+describe("normalizeBodyForComparison", () => {
+  test("replaces cch= hex hash with fixed placeholder", () => {
+    const body = '{"system":[{"type":"text","text":"entrypoint=cli; cch=f0e67;\\nYou are Claude Code"}]}';
+    const normalized = normalizeBodyForComparison(body);
+    expect(normalized).toBe('{"system":[{"type":"text","text":"entrypoint=cli; cch=__;\\nYou are Claude Code"}]}');
+  });
+
+  test("handles varying cch lengths", () => {
+    expect(normalizeBodyForComparison("cch=abc;")).toBe("cch=__;");
+    expect(normalizeBodyForComparison("cch=abcdef0123;")).toBe("cch=__;");
+    expect(normalizeBodyForComparison("cch=A1B2C3;")).toBe("cch=__;");
+  });
+
+  test("does not modify bodies without cch=", () => {
+    const body = '{"model":"opus","system":"You are Claude"}';
+    expect(normalizeBodyForComparison(body)).toBe(body);
+  });
+
+  test("handles multiple cch= occurrences", () => {
+    const body = "cch=aaa; some text cch=bbb;";
+    expect(normalizeBodyForComparison(body)).toBe("cch=__; some text cch=__;");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// analyzeCacheTurn — cch= normalization
+// ---------------------------------------------------------------------------
+
+describe("analyzeCacheTurn — cch normalization", () => {
+  test("treats bodies differing only in cch= as identical", () => {
+    const analytics = makeCacheAnalytics();
+    const body1 = JSON.stringify({
+      system: [{ type: "text", text: "entrypoint=cli; cch=f0e67;\nYou are Claude Code" }],
+      messages: [{ role: "user", content: "hello" }],
+    });
+    const body2 = JSON.stringify({
+      system: [{ type: "text", text: "entrypoint=cli; cch=35c93;\nYou are Claude Code" }],
+      messages: [{ role: "user", content: "hello" }],
+    });
+
+    analyzeCacheTurn(analytics, body1, makeUsage());
+    const result = analyzeCacheTurn(analytics, body2, makeUsage());
+
+    expect(result.divergencePoint).toBe("<identical>");
+    expect(result.divergenceReason).toBe("request bodies are identical");
+  });
+
+  test("still detects real system prompt changes alongside cch=", () => {
+    const analytics = makeCacheAnalytics();
+    const body1 = JSON.stringify({
+      system: [{ type: "text", text: "entrypoint=cli; cch=f0e67;\nYou are Claude Code v1" }],
+      messages: [{ role: "user", content: "hello" }],
+    });
+    const body2 = JSON.stringify({
+      system: [{ type: "text", text: "entrypoint=cli; cch=35c93;\nYou are Claude Code v2" }],
+      messages: [{ role: "user", content: "hello" }],
+    });
+
+    analyzeCacheTurn(analytics, body1, makeUsage());
+    const result = analyzeCacheTurn(analytics, body2, makeUsage());
+
+    expect(result.divergencePoint).toMatch(/system/);
+    expect(result.prefixMatchPercent).toBeGreaterThan(0.5);
   });
 });


### PR DESCRIPTION
## Summary

- **Root cause**: Claude CLI embeds `entrypoint=cli; cch=XXXXX;\n` at the start of its system prompt with a content-cache hash that changes every turn, causing our byte-level cache analytics to report 0.1% prefix match on every turn
- **Fix**: Normalize the volatile `cch=` hash to a fixed placeholder before storing/comparing request bodies — only affects our analytics, upstream requests are untouched
- **Bonus**: Enrich Sentry `gen_ai.chat` spans with cache analytics attributes (`lore.cache.*`) so future cache issues are debuggable from Sentry traces without grepping logs

## Changes

| File | What |
|------|------|
| `packages/gateway/src/cache-analytics.ts` | `normalizeBodyForComparison()` strips `cch=XXXXX;` → `cch=__;`, debug logging for early divergences |
| `packages/gateway/src/sentry.ts` | New `setCacheAnalyticsAttributes()` helper for span enrichment |
| `packages/gateway/src/pipeline.ts` | Reorder `postResponse()`: cache analytics before `genAiSpan.end()`, wire up span attributes |
| `packages/gateway/src/translate/types.ts` | Optional `prevSnippet`/`currSnippet` fields on `CacheTurnAnalysis` |
| `packages/gateway/test/cache-analytics.test.ts` | 6 new tests for normalization and cch= handling |

## Verification

Before fix (every turn shows false divergence):
```
cache-analytics: session=13nZoO4J8o7E5bBx turn=5 prefixMatch=0.1% divergence="system[0].text" reason="host system prompt changed"
```

Debug logging revealed the cause:
```
prev: "entrypoint=cli; cch=f0e67;\nYou are Claude Code..."
curr: "entrypoint=cli; cch=35c93;\nYou are Claude Code..."
```

After fix: bodies differing only in `cch=` are treated as `<identical>`.