### PR TITLE
fix: handle client disconnect in streaming pipeline (LOREAI-GATEWAY-3)

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -7,15 +7,7 @@
 <!-- lore:019e0e5c-ab22-7d49-97ac-295ac0b39c08 -->
 * **GitHub Copilot as free tier model provider through OpenCode**: GitHub Copilot provides free access to premium models (gpt-4o, claude-3-5-sonnet, o1-preview, gemini-1.5-pro) through OpenCode integration. Available without direct API costs for testing and A/B testing model quality. Other paid providers (xAI, Mistral) require separate API key configuration.
 
-### Decision
-
-<!-- lore:019e0e85-e0e6-7914-994d-c10798a247fc -->
-* **Switched from plan to build mode (read-only disabled**: switched from plan to build mode (read-only disabled,
-
 ### Gotcha
-
-<!-- lore:019e0e7d-a1e6-76fc-a45a-9bb32fe775ac -->
-* **Claude CLI system prompt divergence causes 99.9% cache miss rate**: Claude CLI system prompt divergence at byte 168: System\[0] diverges at fixed position ~168 bytes (~75 characters) in every turn, suggesting dynamic content injection (timestamp, environment info). Appears as 0.1% prefix match on 150-266KB prompts but doesn't affect Anthropic's actual cache (98-100% hit rates observed). The CLI likely embeds turn-specific metadata early in system prompt. Our JSON.stringify comparison detects this as cache bust but Anthropic's token-level caching is unaffected.
 
 <!-- lore:019e0e73-8f08-7093-bd66-734b2356192b -->
 * **FALLBACK\_PRICING maintenance burden vs offline resilience tradeoff**: FALLBACK\_PRICING as offline safety net: Contains only critical models (expensive session models like opus/gpt-4o and worker models like sonnet-4-6/gpt-4o-mini) when models.dev is unreachable. Trimmed from 22+ to ~4 entries to reduce maintenance burden. Unknown models use generic defaults. Balances offline functionality with reduced maintenance overhead.
@@ -26,13 +18,13 @@
 <!-- lore:019e0e81-4cd5-75a7-9c7c-1a2c550e0434 -->
 * **Sentry span ends before cache analytics run, preventing span enrichment**: Sentry span ends before cache analytics run, preventing span enrichment: genAiSpan.end() called before cache analytics in postResponse. Cache divergence data (bust cause, prefix match, divergence snippets) can't reach Sentry traces. Fixed by reordering: run cache analytics first, set span attributes via setCacheTurnAttributes(), then end span. Helper extracts bust\_cause, prefix\_match\_percentage, divergence\_point\_byte, and optional before/after snippets from CacheTurnAnalysis.
 
-<!-- lore:019e0e78-98ea-7494-b86a-60725e8fc04a -->
-* **System prompt divergence uses JSON.stringify comparison**: System prompt divergence uses JSON.stringify: System prompt cache divergence uses JSON.stringify for comparison, sensitive to whitespace, property ordering, and structure changes. System prompts stored as array: system\[0] = host prompt, system\[1] = LTM context. divergenceAnalysis() compares each element separately - system\[0] changes log as "host system prompt changed". Byte-for-byte JSON identity required to avoid cache misses.
-
 ### Pattern
 
 <!-- lore:019e0d91-d623-7753-9867-8e728c6fac37 -->
 * **Auto-detected conversation TTL based on cold-cache turn progression**: Auto-detected conversation TTL: TTL selection logic: 5m for turns 1-3, 1h for turn 4+. Gateway tracks coldCacheTurns incremented on cache misses. getTTLBasedOnTurns() determines TTL before cache construction. Prevents unnecessary long-term cache on quick interactions while preserving context for sustained conversations.
+
+<!-- lore:019e0e8b-b440-7d32-a37d-9741e0fcf8e5 -->
+* **Cache analytics normalization for dynamic metadata prefixes**: Claude CLI metadata normalization for cache analytics: normalizeRequestBodyForCache() and normalizeSystemPromptForCache() strip dynamic \`cch=XXXXX;\` patterns that change per turn but don't affect upstream cache. Applied in analyzeCacheTurn() to both current body (before storage) and previous body (for comparison). Prevents false cache divergence detection - Claude CLI shows 99.9% miss rate in analytics while actual Anthropic cache hits 97-99%. Normalization only affects analytics accuracy, original requests forwarded unchanged.
 
 <!-- lore:019e0e83-96dd-7fc2-9d58-c36f5e5b0844 -->
 * **Cache divergence snippets for debugging in CacheTurnAnalysis**: CacheTurnAnalysis includes optional snippet fields for debugging early cache divergences: prevSnippet and currSnippet capture 200-char windows around divergence point. Only populated when divergence occurs within first 500 chars (early divergence). enrichSpanWithCacheInfo() helper adds these snippets to Sentry spans as cache.prev\_snippet and cache.curr\_snippet attributes for debugging cache bust causes.
@@ -48,6 +40,3 @@
 
 <!-- lore:019e0e7a-ddfb-7394-bf57-9fa3ea0fe024 -->
 * **Session correlation via fingerprint and message-count proximity**: Session correlation via fingerprint: Sessions identified using SHA-256 fingerprint of first user message + model + auth suffix (16 hex chars). Scans active sessions for matching fingerprint and selects closest message count within 20-message threshold. Fork detection: if message count drops >20, treats as new session. Stores fingerprint, messageCount, lastRequestTime in SessionState.
-
-<!-- lore:019e0da9-69ef-79d4-87e6-6206f11dcfb0 -->
-* **SSE streaming pipeline recall interception architecture**: SSE streaming pipeline architecture: 1) Parse upstream SSE via parseSSEStream(), forward through accumulator.processEvent() 2) Post-stream recall check - execute query and emit synthetic marker if detected 3) Branch by tool mix: mixed tools = forward held events + close, recall-only = follow-up API call + continuation stream, no recall = normal close. All branches use controller.enqueue(encoder.encode(sseText)).

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -544,15 +544,40 @@ function buildStreamingResponse(
   const accumulator: StreamAccumulator = recallAccum ?? createStreamAccumulator();
   const encoder = new TextEncoder();
 
+  // Client-disconnect detection: shared between start() and cancel()
+  let cancelled = false;
+  let activeReader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+
   const stream = new ReadableStream({
     async start(controller) {
+      // Guard helpers for client-disconnect safety
+      const safeEnqueue = (data: Uint8Array): boolean => {
+        if (cancelled) return false;
+        try {
+          controller.enqueue(data);
+          return true;
+        } catch {
+          cancelled = true;
+          return false;
+        }
+      };
+      const safeClose = (): void => {
+        if (cancelled) return;
+        try {
+          controller.close();
+        } catch {
+          // Already closed/cancelled
+        }
+      };
+
       try {
         // Parse and forward upstream SSE events
         const reader = upstreamResponse.body!.getReader();
+        activeReader = reader;
         for await (const { event, data } of parseSSEStream(reader)) {
           const forwarded = accumulator.processEvent(event, data);
           if (forwarded) {
-            controller.enqueue(encoder.encode(forwarded));
+            if (!safeEnqueue(encoder.encode(forwarded))) break;
           }
         }
 
@@ -599,7 +624,7 @@ function buildStreamingResponse(
                 index: markerIdx,
               })),
             ].join("");
-            controller.enqueue(encoder.encode(syntheticMarker));
+            if (!safeEnqueue(encoder.encode(syntheticMarker))) return;
 
             if (recallAccum.hasOtherTools()) {
               // Forward held-back events, close stream
@@ -610,13 +635,13 @@ function buildStreamingResponse(
 
               const heldBack = recallAccum.heldBackEvents();
               if (heldBack) {
-                controller.enqueue(encoder.encode(heldBack));
+                safeEnqueue(encoder.encode(heldBack));
               }
 
               // Post-stream: store response with marker text (not raw tool_use)
               const markerResp = replaceRecallWithMarker(resp);
               onComplete(markerResp);
-              controller.close();
+              safeClose();
               return;
             }
 
@@ -647,11 +672,11 @@ function buildStreamingResponse(
               );
               const heldBack = recallAccum.heldBackEvents();
               if (heldBack) {
-                controller.enqueue(encoder.encode(heldBack));
+                safeEnqueue(encoder.encode(heldBack));
               }
               const markerResp = replaceRecallWithMarker(resp);
               onComplete(markerResp);
-              controller.close();
+              safeClose();
               return;
             }
 
@@ -668,11 +693,11 @@ function buildStreamingResponse(
               // Forward the held-back events to close the stream gracefully
               const heldBack = recallAccum.heldBackEvents();
               if (heldBack) {
-                controller.enqueue(encoder.encode(heldBack));
+                safeEnqueue(encoder.encode(heldBack));
               }
               const markerResp = replaceRecallWithMarker(resp);
               onComplete(markerResp);
-              controller.close();
+              safeClose();
               return;
             }
 
@@ -682,6 +707,7 @@ function buildStreamingResponse(
             // +1 accounts for the synthetic marker block.
             const blockOffset = recallAccum.clientBlockCount() + 1;
             const contReader = followUpResponse.body!.getReader();
+            activeReader = contReader;
             let contEventCount = 0;
 
             for await (const { event: contEvent, data: contData } of parseSSEStream(contReader)) {
@@ -705,7 +731,7 @@ function buildStreamingResponse(
                       contEvent,
                       JSON.stringify(parsed),
                     );
-                    controller.enqueue(encoder.encode(adjusted));
+                    if (!safeEnqueue(encoder.encode(adjusted))) break;
                     continue;
                   }
                 } catch {
@@ -715,7 +741,7 @@ function buildStreamingResponse(
 
               // Forward message_delta, message_stop, and other events as-is
               const forwarded = formatSSEEvent(contEvent, contData);
-              controller.enqueue(encoder.encode(forwarded));
+              if (!safeEnqueue(encoder.encode(forwarded))) break;
             }
 
             log.info(
@@ -728,7 +754,7 @@ function buildStreamingResponse(
             // round-trip the marker ↔ tool_use/tool_result correctly.
             const markerResp = replaceRecallWithMarker(resp);
             onComplete(markerResp);
-            controller.close();
+            safeClose();
             return;
           }
         }
@@ -736,7 +762,7 @@ function buildStreamingResponse(
         // No recall — normal path
         const response = accumulator.getResponse();
         onComplete(response);
-        controller.close();
+        safeClose();
       } catch (err) {
         log.error("streaming pipeline error:", err);
         try {
@@ -745,6 +771,10 @@ function buildStreamingResponse(
           // Controller already closed or cancelled — error already logged above
         }
       }
+    },
+    cancel() {
+      cancelled = true;
+      try { activeReader?.cancel(); } catch { /* ignore */ }
     },
   });
 


### PR DESCRIPTION
## Summary

- Fix `TypeError: Invalid state: Controller is already closed` when the downstream HTTP client disconnects mid-stream (e.g., Claude CLI timeout/abort)
- Add `cancel()` handler with `safeEnqueue()`/`safeClose()` guards to `buildStreamingResponse()` in `pipeline.ts`
- Cancel upstream reader on client disconnect to stop wasting bandwidth

## Problem

When the client disconnects, the Bun runtime cancels the `ReadableStream` controller, but the `async start()` function continues consuming the upstream SSE stream. The next `controller.enqueue()` call throws a TypeError, which propagates as a socket closure error to the Claude CLI.

Sentry: https://byk.sentry.io/issues/7470287992/

## Changes

- `cancelled` flag + `activeReader` ref shared between `start()` and `cancel()`
- `safeEnqueue()` returns `false` on cancelled stream, allowing `break` from `for await` loops
- `safeClose()` is a no-op when already cancelled
- `cancel()` handler sets flag and aborts the active upstream reader
- All 7 `controller.enqueue()` and 5 `controller.close()` calls replaced with safe variants