### PR TITLE
fix: increase Bun.serve idleTimeout for LLM streaming responses

### DIFF
--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -197,6 +197,9 @@ export function startServer(config: GatewayConfig): {
   const server = Bun.serve({
     port: config.port,
     hostname: config.host,
+    // Bun defaults to 10s which is too short for LLM streaming responses.
+    // 255 is the maximum allowed by Bun.
+    idleTimeout: 255,
 
     async fetch(req: Request): Promise<Response> {
       const url = new URL(req.url);


### PR DESCRIPTION
## Summary

- Set `idleTimeout: 255` on `Bun.serve()` to prevent premature connection drops during LLM streaming
- Fixes `[Bun.serve]: request timed out after 10 seconds` errors that kill SSE streams mid-response

## Problem

Bun's default `idleTimeout` is 10 seconds. LLM streaming responses (especially with large context or complex reasoning) routinely take 30-120+ seconds. When there's a gap >10s between SSE chunks (e.g., during think time), Bun kills the connection. The client sees a socket closure error.

This was likely contributing to LOREAI-GATEWAY-3 alongside the controller close issue fixed in #188.

## Changes

One-line change in `packages/gateway/src/server.ts`: add `idleTimeout: 255` to the `Bun.serve()` options (255 is Bun's maximum allowed value).