### PR TITLE
fix(gateway): suppress verbose startup banner in embedded mode

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -7,7 +7,13 @@
 <!-- lore:019e0e5c-ab22-7d49-97ac-295ac0b39c08 -->
 * **GitHub Copilot as free tier model provider through OpenCode**: GitHub Copilot provides free access to premium models (gpt-4o, claude-3-5-sonnet, o1-preview, gemini-1.5-pro) through OpenCode integration. Available without direct API costs for testing and A/B testing model quality. Other paid providers (xAI, Mistral) require separate API key configuration.
 
+<!-- lore:019e0e9b-f550-720b-8fbb-930fd5aede4f -->
+* **Single Bun.serve() entry point in server.ts startServer()**: Single Bun.serve() entry point with dual startup paths: All HTTP servers use startServer() in /packages/gateway/src/server.ts line 193. Two entry paths exist: 1) CLI 'lore start' via commandStart() (verbose banner + env vars), 2) OpenCode plugin spawns via index.ts guard calling commandStart() directly. Both routes call same function but only CLI should show verbose output. OpenCode pipes child stderr to parent, leaking full banner. Node.js polyfill exists at script/node-polyfills.ts.
+
 ### Gotcha
+
+<!-- lore:019e0e9a-9575-7b78-a878-ce93a2cd307a -->
+* **Bun.serve() idleTimeout too short for LLM streaming responses**: Bun.serve() idleTimeout missing for LLM streaming: Bun.serve() in server.ts line 197 has NO idleTimeout configured, defaulting to 10 seconds. This causes 'request timed out' errors during LLM streaming responses that take 30-60+ seconds. Must add idleTimeout: 240 to Bun.serve() config object alongside existing port/hostname options. LORE\_IDLE\_TIMEOUT (60s default) is unrelated - it controls session background work scheduling, not HTTP connection timeouts.
 
 <!-- lore:019e0e73-8f08-7093-bd66-734b2356192b -->
 * **FALLBACK\_PRICING maintenance burden vs offline resilience tradeoff**: FALLBACK\_PRICING as offline safety net: Contains only critical models (expensive session models like opus/gpt-4o and worker models like sonnet-4-6/gpt-4o-mini) when models.dev is unreachable. Trimmed from 22+ to ~4 entries to reduce maintenance burden. Unknown models use generic defaults. Balances offline functionality with reduced maintenance overhead.
@@ -31,6 +37,9 @@
 
 <!-- lore:019e0e7a-de00-7436-a523-1b0e7f92c33d -->
 * **Compaction request interception for Claude Code**: Compaction request interception: Proxy detects Claude Code compaction requests via system prompt containing "anchored context summarization assistant", empty tools + user message with "anchored summary" patterns or \<previous-summary> tags, or \<template> tag with 4+ section headers. When detected, runs Lore's own distillation instead of forwarding upstream. Prevents expensive upstream compaction calls.
+
+<!-- lore:019e0ea3-4b77-7b56-94c0-6d11de99cb7a -->
+* **Gateway startup banner controlled by commandStart verbose output**: Gateway startup banner controlled by quiet flag in commandStart(): commandStart() prints verbose startup banner including env vars and routing info (Lines 49-69 in cli/start.ts) unless opts.quiet is true. commandRun() only prints listening line. The embedded entry point (packages/gateway/src/index.ts) calls commandStart({ quiet: true }) to suppress banner when spawned by OpenCode. CLI 'lore start' calls commandStart() without quiet flag to show full banner. Regression: commit e4104bd expanded commandStart() output without realizing it's also used by embedded mode.
 
 <!-- lore:019e0e83-21c8-7822-809f-c6cb133e77f5 -->
 * **Sentry span enrichment with cache analytics attributes**: enrichGenAiSpanWithCacheAnalysis() helper adds cache debugging context to Sentry spans: Sets cache.bust\_cause (miss/divergence/timeout), cache.prefix\_match (percentage), and cache.divergence\_point (byte position) attributes from CacheTurnAnalysis. Called after cache analytics run but before span.end() to ensure cache debugging data reaches distributed traces. Requires CacheTurnAnalysis object with cacheBustCause, cachePrefixMatch, and divergenceAnalysis fields.

--- a/packages/gateway/src/cli/start.ts
+++ b/packages/gateway/src/cli/start.ts
@@ -11,6 +11,8 @@ export interface StartOptions {
   port?: number;
   host?: string;
   debug?: boolean;
+  /** Suppress verbose banner (env vars, export hints). Used in embedded mode. */
+  quiet?: boolean;
 }
 
 /**
@@ -51,23 +53,25 @@ export async function commandStart(opts: StartOptions): Promise<never> {
 
   const addr = `http://${config.host}:${port}`;
   console.error(`[lore] Gateway listening on ${addr}`);
-  console.error(
-    `[lore] Model routing: claude-* → Anthropic, nvidia/* → Nvidia NIM, gpt-* → OpenAI, …`,
-  );
-  console.error("");
-  console.error("[lore] Point your AI agent at the gateway:");
-  console.error(`  export ANTHROPIC_BASE_URL=${addr}`);
-  console.error(`  export OPENAI_BASE_URL=${addr}/v1`);
-  console.error("");
-  console.error("[lore] Configuration (environment variables):");
-  console.error(`  LORE_LISTEN_PORT        Port to listen on (current: ${port})`);
-  console.error(`  LORE_LISTEN_HOST        Host to bind to (current: ${config.host})`);
-  console.error(`  LORE_UPSTREAM_ANTHROPIC Anthropic API URL (current: ${config.upstreamAnthropic})`);
-  console.error(`  LORE_UPSTREAM_OPENAI    OpenAI API URL (current: ${config.upstreamOpenAI})`);
-  console.error(`  LORE_IDLE_TIMEOUT       Idle timeout in seconds (current: ${config.idleTimeoutSeconds})`);
-  console.error(`  LORE_DEBUG              Enable debug logging (current: ${config.debug})`);
-  console.error(`  LORE_BATCH_DISABLED     Disable batch background work (current: ${process.env.LORE_BATCH_DISABLED === "1"})`);
 
+  if (!opts.quiet) {
+    console.error(
+      `[lore] Model routing: claude-* → Anthropic, nvidia/* → Nvidia NIM, gpt-* → OpenAI, …`,
+    );
+    console.error("");
+    console.error("[lore] Point your AI agent at the gateway:");
+    console.error(`  export ANTHROPIC_BASE_URL=${addr}`);
+    console.error(`  export OPENAI_BASE_URL=${addr}/v1`);
+    console.error("");
+    console.error("[lore] Configuration (environment variables):");
+    console.error(`  LORE_LISTEN_PORT        Port to listen on (current: ${port})`);
+    console.error(`  LORE_LISTEN_HOST        Host to bind to (current: ${config.host})`);
+    console.error(`  LORE_UPSTREAM_ANTHROPIC Anthropic API URL (current: ${config.upstreamAnthropic})`);
+    console.error(`  LORE_UPSTREAM_OPENAI    OpenAI API URL (current: ${config.upstreamOpenAI})`);
+    console.error(`  LORE_IDLE_TIMEOUT       Idle timeout in seconds (current: ${config.idleTimeoutSeconds})`);
+    console.error(`  LORE_DEBUG              Enable debug logging (current: ${config.debug})`);
+    console.error(`  LORE_BATCH_DISABLED     Disable batch background work (current: ${process.env.LORE_BATCH_DISABLED === "1"})`);
+  }
   // Block until signal
   const onSignal = async () => {
     await shutdown();

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -37,5 +37,5 @@ if (typeof Bun !== "undefined" && Bun.main === import.meta.path) {
   // no reason to auto-detect agents when launched as an embedded server.
   // esbuild CJS output drops import.meta to `{}` so the condition is
   // always false in the npm bundle — the await is dead-code-eliminated.
-  import("./cli/start").then(({ commandStart }) => commandStart({}));
+  import("./cli/start").then(({ commandStart }) => commandStart({ quiet: true }));
 }


### PR DESCRIPTION
## Summary

- Fixes regression where the full `lore start` env info banner (model routing, export hints, env var config) was printed to stderr when lore is spawned from OpenCode as an embedded gateway
- Adds `quiet` option to `StartOptions`; embedded entry point passes `quiet: true` so only the minimal `[lore] Gateway listening on ...` line is printed
- Standalone `lore start` CLI is unaffected — still shows full banner

## Root Cause

Commit `e4104bd` expanded `commandStart()` output with env vars and export hints, not realizing it's also the code path used when OpenCode spawns the gateway (`packages/gateway/src/index.ts:40`). The child's stderr is piped back to OpenCode, leaking the full banner.