### PR TITLE
fix(gateway): catch port-in-use errors and memoize gateway init (LOREAI-GATEWAY-2)

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -8,7 +8,12 @@
 * **GitHub Copilot as free tier model provider through OpenCode**: GitHub Copilot provides free access to premium models (gpt-4o, claude-3-5-sonnet, o1-preview, gemini-1.5-pro) through OpenCode integration. Available without direct API costs for testing and A/B testing model quality. Other paid providers (xAI, Mistral) require separate API key configuration.
 
 <!-- lore:019e0e9b-f550-720b-8fbb-930fd5aede4f -->
-* **Single Bun.serve() entry point in server.ts startServer()**: Single Bun.serve() entry point with dual startup paths: All HTTP servers use startServer() in /packages/gateway/src/server.ts line 193. Two entry paths exist: 1) CLI 'lore start' via commandStart() (verbose banner + env vars), 2) OpenCode plugin spawns via index.ts guard calling commandStart() directly. Both routes call same function but only CLI should show verbose output. OpenCode pipes child stderr to parent, leaking full banner. Node.js polyfill exists at script/node-polyfills.ts.
+* **Single Bun.serve() entry point in server.ts startServer()**: Single Bun.serve() entry point with dual startup paths: All HTTP servers use startServer() in packages/gateway/src/server.ts. Two entry paths: 1) CLI 'lore start' via commandStart(), 2) OpenCode plugin via spawnGateway() calling 'bun run packages/gateway/src/index.ts'. Child process stderr captured by parent for startup banner parsing. No error handling around Bun.serve() call itself - port conflicts bubble up as unhandled exceptions. Gateway startup uses process.exit(1) on Bun.serve() failures.
+
+### Decision
+
+<!-- lore:019e0eaa-020f-709c-93a6-2a592c39f703 -->
+* **Switched from plan to build mode**: switched from plan to build mode,
 
 ### Gotcha
 
@@ -18,11 +23,23 @@
 <!-- lore:019e0e73-8f08-7093-bd66-734b2356192b -->
 * **FALLBACK\_PRICING maintenance burden vs offline resilience tradeoff**: FALLBACK\_PRICING as offline safety net: Contains only critical models (expensive session models like opus/gpt-4o and worker models like sonnet-4-6/gpt-4o-mini) when models.dev is unreachable. Trimmed from 22+ to ~4 entries to reduce maintenance burden. Unknown models use generic defaults. Balances offline functionality with reduced maintenance overhead.
 
+<!-- lore:019e0ea9-17bb-75c3-929b-ed12c4c398a5 -->
+* **Lack of port conflict error handling in gateway startup**: Gateway startup lacks port conflict handling causing Sentry noise: Bun.serve() throws unhandled EADDRINUSE exceptions that bubble up as Sentry reports (LOREAI-GATEWAY-2). OpenCode's spawnGateway() probes port first but race window exists between probe and spawn where another process can bind the port. Fixed by wrapping Bun.serve() in try/catch in commandStart() - exit silently in quiet mode (parent handles fallback), show helpful message in CLI mode. Consider promise memoization to prevent multiple concurrent spawn attempts racing for same port.
+
+<!-- lore:019e0eaa-01fd-794f-a91c-0588d701ff97 -->
+* **LOREAI-GATEWAY-2 Sentry issue from unhandled port-in-use errors**: LOREAI-GATEWAY-2 is a Sentry issue fingerprint (not in codebase) triggered by unhandled exceptions when Bun.serve() fails due to port already in use. Occurs when multiple lore instances attempt to bind same port. Should catch Bun.serve() errors in startServer() and provide user-friendly message instead of letting exception reach Sentry. Common in development when previous instance didn't clean up or user runs multiple instances.
+
+<!-- lore:019e0eaa-01cd-7819-9eb1-e0e1c2e7a8e6 -->
+* **No port-in-use error handling causes silent 5s timeout in OpenCode plugin**: Gateway startup has no EADDRINUSE handling - Bun.serve() throws uncaught if port taken. OpenCode plugin's spawnGateway() catches all errors but can't distinguish port conflicts from other failures. Results in silent 5s timeout waiting for /health, then fallback to plugin mode. No retry with different ports. Probe-before-spawn (probeGateway()) handles existing gateway but not other processes on port. Race condition: process can bind port between probe and spawn.
+
 <!-- lore:019e0e82-acaa-7790-899b-de3ff46a6091 -->
 * **OAuth token batch API fallback triggers worker rate limits**: Claude CLI OAuth tokens lack batch API scope, forcing worker requests (distillation, curation) into synchronous fallback. These compete with main session for rate quota, causing 429s on worker calls. Batch fails with 403 'OAuth token does not meet scope requirement' - requires user:batch/developer or workspace:developer scopes. Consider more aggressive backoff or skipping non-critical work when rate-limited on shared credentials.
 
 <!-- lore:019e0e81-4cd5-75a7-9c7c-1a2c550e0434 -->
 * **Sentry span ends before cache analytics run, preventing span enrichment**: Sentry span ends before cache analytics run, preventing span enrichment: genAiSpan.end() called before cache analytics in postResponse. Cache divergence data (bust cause, prefix match, divergence snippets) can't reach Sentry traces. Fixed by reordering: run cache analytics first, set span attributes via setCacheTurnAttributes(), then end span. Helper extracts bust\_cause, prefix\_match\_percentage, divergence\_point\_byte, and optional before/after snippets from CacheTurnAnalysis.
+
+<!-- lore:019e0eaa-01f6-7247-9842-df6e7c6f792b -->
+* **Uncaught exceptions in gateway startup propagate without handling**: startServer() calls Bun.serve() with no try/catch wrapper at server.ts:197. commandStart(), startGateway(), commandRun() don't wrap startServer() calls. Direct execution via index.ts has no .catch() on import chain. Only OpenCode plugin's spawnGateway() has error handling - catches all and returns false after 5s timeout, making all startup failures appear identical.
 
 ### Pattern
 
@@ -38,8 +55,11 @@
 <!-- lore:019e0e7a-de00-7436-a523-1b0e7f92c33d -->
 * **Compaction request interception for Claude Code**: Compaction request interception: Proxy detects Claude Code compaction requests via system prompt containing "anchored context summarization assistant", empty tools + user message with "anchored summary" patterns or \<previous-summary> tags, or \<template> tag with 4+ section headers. When detected, runs Lore's own distillation instead of forwarding upstream. Prevents expensive upstream compaction calls.
 
-<!-- lore:019e0ea3-4b77-7b56-94c0-6d11de99cb7a -->
-* **Gateway startup banner controlled by commandStart verbose output**: Gateway startup banner controlled by quiet flag in commandStart(): commandStart() prints verbose startup banner including env vars and routing info (Lines 49-69 in cli/start.ts) unless opts.quiet is true. commandRun() only prints listening line. The embedded entry point (packages/gateway/src/index.ts) calls commandStart({ quiet: true }) to suppress banner when spawned by OpenCode. CLI 'lore start' calls commandStart() without quiet flag to show full banner. Regression: commit e4104bd expanded commandStart() output without realizing it's also used by embedded mode.
+<!-- lore:019e0ea9-17c2-7dfd-b065-947a1d5871ae -->
+* **Sentry error reporting with LOREAI-GATEWAY fingerprints**: Gateway uses Sentry.captureException() for error reporting with 'LOREAI-GATEWAY' fingerprint prefix. Error fingerprints follow pattern: 'LOREAI-GATEWAY-{N}' where N is error category number. Instrument.ts configures Sentry with beforeSend hook that adds gateway context. Errors captured include upstream API failures, cache issues, and request processing failures. All gateway errors automatically tagged for grouping in Sentry dashboard.
+
+<!-- lore:019e0eaa-01ed-7019-a9cf-e41643df517c -->
+* **Sentry integration only through log.registerSink() callback**: No direct Sentry.captureException() calls in gateway code. All error reporting flows through log.registerSink() callback in instrument.ts:88. Gateway uses Sentry for spans (genAi operations), metrics (cache\_bust, llm\_cost\_usd), tags (auth\_fingerprint, model, port), and cache analytics span attributes. No custom fingerprint arrays for error grouping - relies on Sentry's default grouping.
 
 <!-- lore:019e0e83-21c8-7822-809f-c6cb133e77f5 -->
 * **Sentry span enrichment with cache analytics attributes**: enrichGenAiSpanWithCacheAnalysis() helper adds cache debugging context to Sentry spans: Sets cache.bust\_cause (miss/divergence/timeout), cache.prefix\_match (percentage), and cache.divergence\_point (byte position) attributes from CacheTurnAnalysis. Called after cache analytics run but before span.end() to ensure cache debugging data reaches distributed traces. Requires CacheTurnAnalysis object with cacheBustCause, cachePrefixMatch, and divergenceAnalysis fields.

--- a/packages/gateway/src/cli/start.ts
+++ b/packages/gateway/src/cli/start.ts
@@ -49,7 +49,20 @@ export function startGateway(opts: StartOptions = {}): {
  * SIGINT/SIGTERM.
  */
 export async function commandStart(opts: StartOptions): Promise<never> {
-  const { config, port, shutdown } = startGateway(opts);
+  let result: ReturnType<typeof startGateway>;
+  try {
+    result = startGateway(opts);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (/port\b.*\bin use/i.test(msg) || /EADDRINUSE/i.test(msg)) {
+      if (!opts.quiet) {
+        console.error(`[lore] ${msg}`);
+      }
+      process.exit(1);
+    }
+    throw e;
+  }
+  const { config, port, shutdown } = result;
 
   const addr = `http://${config.host}:${port}`;
   console.error(`[lore] Gateway listening on ${addr}`);

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -467,6 +467,9 @@ let processInitDone = false;
 let processGatewayActive = false;
 let processGatewayBase = "";
 
+/** Memoized gateway init promise — ensures concurrent plugin calls don't race. */
+let gatewayInitPromise: Promise<boolean> | null = null;
+
 export const LorePlugin: Plugin = async (ctx) => {
   // Resolve the gateway base URL — explicit env var or default.
   const gatewayBase =
@@ -481,18 +484,23 @@ export const LorePlugin: Plugin = async (ctx) => {
       process.argv.some((a) => a.includes(".test."));
 
     if (process.env.LORE_GATEWAY_MODE !== "0" && !inTestEnv) {
-      if (await probeGateway(gatewayBase)) {
-        log.info(`gateway detected at ${gatewayBase}`);
-        gatewayActive = true;
-      } else {
-        log.info(`starting gateway at ${gatewayBase}…`);
-        if (await spawnGateway(gatewayBase)) {
-          log.info(`gateway started at ${gatewayBase}`);
-          gatewayActive = true;
-        } else {
+      // Memoize so concurrent LorePlugin calls don't race on probe→spawn.
+      if (!gatewayInitPromise) {
+        gatewayInitPromise = (async () => {
+          if (await probeGateway(gatewayBase)) {
+            log.info(`gateway detected at ${gatewayBase}`);
+            return true;
+          }
+          log.info(`starting gateway at ${gatewayBase}…`);
+          if (await spawnGateway(gatewayBase)) {
+            log.info(`gateway started at ${gatewayBase}`);
+            return true;
+          }
           log.info("gateway unavailable, running in plugin mode");
-        }
+          return false;
+        })();
       }
+      gatewayActive = await gatewayInitPromise;
     }
     processGatewayActive = gatewayActive;
     processGatewayBase = gatewayBase;


### PR DESCRIPTION
## Summary

- Catches `Bun.serve()` port-in-use errors in `commandStart()` so they exit cleanly instead of becoming unhandled rejections reported to Sentry as LOREAI-GATEWAY-2
- In embedded/quiet mode: exits silently (parent's health probe handles fallback)
- In CLI mode: prints a helpful `[lore] Failed to start server. Is port 6969 in use?` message
- Memoizes the gateway probe→spawn sequence in the OpenCode plugin so concurrent `LorePlugin` calls await the same promise instead of racing to bind the port

Fixes LOREAI-GATEWAY-2 (14 occurrences, escalating)