### PR TITLE
fix(core): make fastembed optional to survive CUDA 13 install failures

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -12,6 +12,9 @@
 
 ### Decision
 
+<!-- lore:019e0eb8-5704-732a-84fc-4bd5a99693e8 -->
+* **Chose hybrid approach for retry exhaustion - extend 429 retries to 5 attempts over 2-3 minutes (vs 4 attempts in ~7s currently)**: Chose hybrid approach for retry exhaustion - extend 429 retries to 5 attempts over 2-3 minutes (vs 4 attempts in ~7s currently),
+
 <!-- lore:019e0eaa-020f-709c-93a6-2a592c39f703 -->
 * **Switched from plan to build mode**: switched from plan to build mode,
 
@@ -23,23 +26,20 @@
 <!-- lore:019e0e73-8f08-7093-bd66-734b2356192b -->
 * **FALLBACK\_PRICING maintenance burden vs offline resilience tradeoff**: FALLBACK\_PRICING as offline safety net: Contains only critical models (expensive session models like opus/gpt-4o and worker models like sonnet-4-6/gpt-4o-mini) when models.dev is unreachable. Trimmed from 22+ to ~4 entries to reduce maintenance burden. Unknown models use generic defaults. Balances offline functionality with reduced maintenance overhead.
 
-<!-- lore:019e0ea9-17bb-75c3-929b-ed12c4c398a5 -->
-* **Lack of port conflict error handling in gateway startup**: Gateway startup lacks port conflict handling causing Sentry noise: Bun.serve() throws unhandled EADDRINUSE exceptions that bubble up as Sentry reports (LOREAI-GATEWAY-2). OpenCode's spawnGateway() probes port first but race window exists between probe and spawn where another process can bind the port. Fixed by wrapping Bun.serve() in try/catch in commandStart() - exit silently in quiet mode (parent handles fallback), show helpful message in CLI mode. Consider promise memoization to prevent multiple concurrent spawn attempts racing for same port.
-
 <!-- lore:019e0eaa-01fd-794f-a91c-0588d701ff97 -->
-* **LOREAI-GATEWAY-2 Sentry issue from unhandled port-in-use errors**: LOREAI-GATEWAY-2 is a Sentry issue fingerprint (not in codebase) triggered by unhandled exceptions when Bun.serve() fails due to port already in use. Occurs when multiple lore instances attempt to bind same port. Should catch Bun.serve() errors in startServer() and provide user-friendly message instead of letting exception reach Sentry. Common in development when previous instance didn't clean up or user runs multiple instances.
+* **LOREAI-GATEWAY-2 Sentry issue from unhandled port-in-use errors**: LOREAI-GATEWAY-2 Sentry issue from unhandled port-in-use errors: Fixed in PR #191. Gateway startup now catches EADDRINUSE from Bun.serve() and exits gracefully with user-friendly message instead of throwing unhandled exception to Sentry. Prevents noise from multiple lore instances attempting same port. Error handling added to startServer() function wrapping Bun.serve() call.
 
 <!-- lore:019e0eaa-01cd-7819-9eb1-e0e1c2e7a8e6 -->
 * **No port-in-use error handling causes silent 5s timeout in OpenCode plugin**: Gateway startup has no EADDRINUSE handling - Bun.serve() throws uncaught if port taken. OpenCode plugin's spawnGateway() catches all errors but can't distinguish port conflicts from other failures. Results in silent 5s timeout waiting for /health, then fallback to plugin mode. No retry with different ports. Probe-before-spawn (probeGateway()) handles existing gateway but not other processes on port. Race condition: process can bind port between probe and spawn.
 
 <!-- lore:019e0e82-acaa-7790-899b-de3ff46a6091 -->
-* **OAuth token batch API fallback triggers worker rate limits**: Claude CLI OAuth tokens lack batch API scope, forcing worker requests (distillation, curation) into synchronous fallback. These compete with main session for rate quota, causing 429s on worker calls. Batch fails with 403 'OAuth token does not meet scope requirement' - requires user:batch/developer or workspace:developer scopes. Consider more aggressive backoff or skipping non-critical work when rate-limited on shared credentials.
+* **OAuth token batch API fallback triggers worker rate limits**: Claude CLI OAuth tokens lack batch API scope, forcing worker requests (distillation, curation, consolidation) into synchronous fallback. These compete with main session for rate quota, causing 429s on worker calls. Batch fails with 403 'OAuth token does not meet scope requirement' - requires user:batch/developer or workspace:developer scopes. Worker requests are fire-and-forget background tasks called from scheduleBackgroundWork() and buildIdleWorkHandler(). Current retry logic honors Retry-After header only on attempt 0, then uses aggressive exponential backoff (1s, 2s, 4s) that burns through retry budget during active rate limit windows. Worker failures return null, silently losing distillation/curation results.
 
 <!-- lore:019e0e81-4cd5-75a7-9c7c-1a2c550e0434 -->
 * **Sentry span ends before cache analytics run, preventing span enrichment**: Sentry span ends before cache analytics run, preventing span enrichment: genAiSpan.end() called before cache analytics in postResponse. Cache divergence data (bust cause, prefix match, divergence snippets) can't reach Sentry traces. Fixed by reordering: run cache analytics first, set span attributes via setCacheTurnAttributes(), then end span. Helper extracts bust\_cause, prefix\_match\_percentage, divergence\_point\_byte, and optional before/after snippets from CacheTurnAnalysis.
 
 <!-- lore:019e0eaa-01f6-7247-9842-df6e7c6f792b -->
-* **Uncaught exceptions in gateway startup propagate without handling**: startServer() calls Bun.serve() with no try/catch wrapper at server.ts:197. commandStart(), startGateway(), commandRun() don't wrap startServer() calls. Direct execution via index.ts has no .catch() on import chain. Only OpenCode plugin's spawnGateway() has error handling - catches all and returns false after 5s timeout, making all startup failures appear identical.
+* **Uncaught exceptions in gateway startup propagate without handling**: OpenCode gateway initialization race condition: Fixed in PR #191. Multiple concurrent sessions calling LorePlugin saw processInitDone === false and triggered duplicate probe→spawn sequences. Second spawn failed with EADDRINUSE but errors were suppressed. Fixed by memoizing gateway initialization into single promise (gatewayInitPromise) that all sessions await. Promise created on first call, subsequent calls reuse same promise.
 
 ### Pattern
 
@@ -55,6 +55,12 @@
 <!-- lore:019e0e7a-de00-7436-a523-1b0e7f92c33d -->
 * **Compaction request interception for Claude Code**: Compaction request interception: Proxy detects Claude Code compaction requests via system prompt containing "anchored context summarization assistant", empty tools + user message with "anchored summary" patterns or \<previous-summary> tags, or \<template> tag with 4+ section headers. When detected, runs Lore's own distillation instead of forwarding upstream. Prevents expensive upstream compaction calls.
 
+<!-- lore:019e0eb6-d76c-75f6-9fdf-96d78eb5da41 -->
+* **Extended worker retry strategy for rate limits**: Worker requests (distillation, curation, consolidation) use differentiated retry strategy for 429s vs other errors. Rate limits get 5 retries with server-guided backoff: honor retry-after header (capped at 120s) or fallback to 15s→30s→45s→60s→60s progression. Non-429 errors keep aggressive 3-retry pattern (1s→2s→4s). Background workers can afford 2-3 minute waits since they're fire-and-forget. Silent failures trigger Sentry alerting on retry exhaustion. Idle scheduler naturally retries on next cycle if worker fails completely.
+
+<!-- lore:019e0eaf-7fd7-7e9f-b6e9-95ac4d2e8a99 -->
+* **Gateway embedded mode with quiet startup banner**: Gateway supports quiet mode for embedded contexts via \`quiet\` flag passed to startServer(). When enabled, suppresses verbose startup banner while preserving essential output. Implemented in PR #190 for cleaner OpenCode plugin integration. Flag controls banner visibility without affecting gateway functionality or health endpoint availability.
+
 <!-- lore:019e0ea9-17c2-7dfd-b065-947a1d5871ae -->
 * **Sentry error reporting with LOREAI-GATEWAY fingerprints**: Gateway uses Sentry.captureException() for error reporting with 'LOREAI-GATEWAY' fingerprint prefix. Error fingerprints follow pattern: 'LOREAI-GATEWAY-{N}' where N is error category number. Instrument.ts configures Sentry with beforeSend hook that adds gateway context. Errors captured include upstream API failures, cache issues, and request processing failures. All gateway errors automatically tagged for grouping in Sentry dashboard.
 
@@ -69,3 +75,9 @@
 
 <!-- lore:019e0e7a-ddfb-7394-bf57-9fa3ea0fe024 -->
 * **Session correlation via fingerprint and message-count proximity**: Session correlation via fingerprint: Sessions identified using SHA-256 fingerprint of first user message + model + auth suffix (16 hex chars). Scans active sessions for matching fingerprint and selects closest message count within 20-message threshold. Fork detection: if message count drops >20, treats as new session. Stores fingerprint, messageCount, lastRequestTime in SessionState.
+
+<!-- lore:019e0eb6-d762-7b50-ba43-d7fa25c03278 -->
+* **Worker calls are fire-and-forget background tasks with natural retry cycles**: All worker calls (distillation, curation, consolidation) are background fire-and-forget from scheduleBackgroundWork() and buildIdleWorkHandler(). Silent failures (return null) don't break sessions but degrade long-term memory quality. Natural retry mechanism: idle scheduler polls every 30s, so failed work gets retried on next cycle. Input context may go stale (conversation moves on) making disk persistence counterproductive. Better to extend retry windows for temporary failures and alert loudly on exhaustion.
+
+<!-- lore:019e0eb6-d74c-77b9-873e-904c986c1a83 -->
+* **Worker task resilience strategy for rate limit failures**: Background worker tasks (distillation, curation, consolidation) should use differentiated retry strategy: 5 retries for 429s with server-guided backoff (honor retry-after header, cap at 120s), vs 3 retries for 5xx with fast exponential backoff. Workers are fire-and-forget from idle timers - can afford 2-3min wait for rate limit windows to reset. Failed workers after exhaustion should alert via Sentry but not persist to disk (inputs go stale quickly). Idle scheduler naturally retries work on next 30s cycle.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -19,6 +19,10 @@ bun add @loreai/core
 
 You only need to install this directly if you're building a new adapter. End users install one of the host packages above.
 
+### Optional dependency: `fastembed`
+
+`fastembed` is declared as an `optionalDependencies` because its native `onnxruntime-node` bindings can fail to build on some hosts (e.g. CUDA 13 on Linux/x64 — [microsoft/onnxruntime#26586](https://github.com/microsoft/onnxruntime/discussions/26586)). Install always succeeds; if the optional install fails, recall falls back to FTS-only and the configured `voyage`/`openai` providers continue to work. To force a local-embeddings install on a CUDA-13 host, run with `ONNXRUNTIME_NODE_INSTALL_CUDA=skip` — the bundled CPU EP is sufficient for `bge-small-en-v1.5`.
+
 ## Documentation
 
 Full architecture, benchmarks, and rationale: **[github.com/BYK/loreai](https://github.com/BYK/loreai)**

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,10 +24,12 @@
   },
   "dependencies": {
     "@huggingface/hub": "2.11.0",
-    "fastembed": "^2.1.0",
     "remark": "^15.0.1",
     "uuidv7": "^1.1.0",
     "zod": "^4.3.6"
+  },
+  "optionalDependencies": {
+    "fastembed": "^2.1.0"
   },
   "devDependencies": {
     "@types/mdast": "^4.0.4"

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -137,6 +137,83 @@ class OpenAIProvider implements EmbeddingProvider {
 // ---------------------------------------------------------------------------
 
 /**
+ * Thrown when `LocalProvider` is requested but `fastembed` cannot be loaded.
+ * `fastembed` is an optionalDependency of `@loreai/core`: if its postinstall
+ * fails (e.g. CUDA 13 hits the upstream `onnxruntime-node` bug — see #185),
+ * the package install still succeeds but local embeddings are disabled.
+ * Callers in `recall.ts` / `ltm.ts` / `distillation.ts` already gate on
+ * `isAvailable()`, which flips to `false` after this error fires once.
+ */
+export class LocalProviderUnavailableError extends Error {
+  constructor(cause?: unknown) {
+    super(
+      "Local embedding provider unavailable: 'fastembed' is not installed. " +
+        "Configure search.embeddings.provider to 'voyage' or 'openai', or " +
+        "reinstall with ONNXRUNTIME_NODE_INSTALL_CUDA=skip to retry the optional fastembed install.",
+    );
+    this.name = "LocalProviderUnavailableError";
+    if (cause !== undefined) (this as Error & { cause?: unknown }).cause = cause;
+  }
+}
+
+/** Cache of the fastembed module-load probe.
+ *  null = not yet probed; module = imported successfully; false = import failed. */
+let fastembedModule: typeof import("fastembed") | null = null;
+let fastembedProbed: boolean = false;
+let fastembedAvailable: boolean = false;
+let fastembedLogged: boolean = false;
+
+/** For tests: reset the fastembed probe cache. */
+export function _resetFastembedProbe(): void {
+  fastembedModule = null;
+  fastembedProbed = false;
+  fastembedAvailable = false;
+  fastembedLogged = false;
+}
+
+/** For tests: simulate fastembed being unresolvable, without mocking the
+ *  dynamic import. After this call, `tryLoadFastembed()` short-circuits to
+ *  `null` and `isAvailable()` returns false for the local provider. */
+export function _markFastembedUnavailable(): void {
+  fastembedModule = null;
+  fastembedProbed = true;
+  fastembedAvailable = false;
+  fastembedLogged = true; // suppress the info log in tests
+}
+
+/**
+ * Probe `fastembed` once. Returns the module on success, `null` on failure.
+ * Logs an info-level note exactly once on the first failure so users know
+ * how to recover (switch provider, or reinstall with the CUDA env-var).
+ */
+async function tryLoadFastembed(): Promise<typeof import("fastembed") | null> {
+  if (fastembedProbed) return fastembedAvailable ? fastembedModule : null;
+  try {
+    fastembedModule = await import("fastembed");
+    fastembedAvailable = true;
+  } catch (err) {
+    fastembedAvailable = false;
+    if (!fastembedLogged) {
+      fastembedLogged = true;
+      const msg = err instanceof Error ? err.message : String(err);
+      log.info(
+        `local embedding provider unavailable (fastembed not installed: ${msg}) — ` +
+          `set search.embeddings.provider to 'voyage' or 'openai', or reinstall with ` +
+          `ONNXRUNTIME_NODE_INSTALL_CUDA=skip to retry the optional fastembed install`,
+      );
+    }
+  } finally {
+    fastembedProbed = true;
+  }
+  return fastembedAvailable ? fastembedModule : null;
+}
+
+/** True iff the fastembed probe has run and reported the module missing. */
+function fastembedKnownUnavailable(): boolean {
+  return fastembedProbed && !fastembedAvailable;
+}
+
+/**
  * Local embedding provider using fastembed (bge-small-en-v1.5 by default).
  *
  * No API key required — runs entirely on-device via ONNX Runtime.
@@ -145,7 +222,8 @@ class OpenAIProvider implements EmbeddingProvider {
  *
  * Uses dynamic import so the module is only loaded when the "local"
  * provider is actually selected — avoids startup cost and allows
- * graceful fallback if fastembed is not installed.
+ * graceful fallback when the optional `fastembed` peer isn't installed
+ * (its native onnxruntime-node may fail to build, e.g. on CUDA 13).
  */
 class LocalProvider implements EmbeddingProvider {
   readonly maxBatchSize = 256;
@@ -161,7 +239,9 @@ class LocalProvider implements EmbeddingProvider {
     if (this.model) return this.model;
     if (!this.initPromise) {
       this.initPromise = (async () => {
-        const { EmbeddingModel, FlagEmbedding } = await import("fastembed");
+        const fastembed = await tryLoadFastembed();
+        if (!fastembed) throw new LocalProviderUnavailableError();
+        const { EmbeddingModel, FlagEmbedding } = fastembed;
         // Map config model string to EmbeddingModel enum value.
         // If the configured model matches an enum key, use it; otherwise try
         // the raw string as a model name (CUSTOM model support in fastembed).
@@ -174,7 +254,13 @@ class LocalProvider implements EmbeddingProvider {
         } as { model: typeof EmbeddingModel.BGESmallENV15 });
         this.model = m;
         return m;
-      })();
+      })().catch((err) => {
+        // Don't cache a rejected init — let a later call retry if the user
+        // installs fastembed in-process. (For LocalProviderUnavailableError
+        // the probe cache short-circuits anyway, so retries are cheap.)
+        this.initPromise = null;
+        throw err;
+      });
     }
     return this.initPromise;
   }
@@ -239,12 +325,12 @@ function getProvider(): EmbeddingProvider | null {
 
   switch (providerName) {
     case "local": {
-      try {
-        cachedProvider = new LocalProvider(model);
-      } catch {
-        log.info("local embedding provider unavailable (fastembed not installed)");
-        cachedProvider = null;
-      }
+      // `fastembed` is an optionalDependency. We construct the provider
+      // optimistically here; the import + ONNX init happens lazily in
+      // `LocalProvider.getModel()`, which throws `LocalProviderUnavailableError`
+      // if the optional dep isn't installed. After that first failure
+      // `isAvailable()` short-circuits to false and callers fall back to FTS.
+      cachedProvider = new LocalProvider(model);
       break;
     }
     case "voyage": {
@@ -284,9 +370,16 @@ export function resetProvider(): void {
 
 /** Returns true if embedding is available.
  *  Active when the configured provider's API key is set, unless explicitly
- *  disabled via `search.embeddings.enabled: false` in .lore.json. */
+ *  disabled via `search.embeddings.enabled: false` in .lore.json.
+ *
+ *  For the `local` provider, also returns false once we've discovered the
+ *  optional `fastembed` peer is missing — callers (recall, ltm, distillation)
+ *  use this gate to skip embedding work and fall back to FTS-only search. */
 export function isAvailable(): boolean {
-  return getProvider() !== null;
+  const provider = getProvider();
+  if (!provider) return false;
+  if (provider instanceof LocalProvider && fastembedKnownUnavailable()) return false;
+  return true;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/test/embedding.test.ts
+++ b/packages/core/test/embedding.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach } from "bun:test";
+import { afterEach, describe, test, expect, beforeEach } from "bun:test";
 import { db, ensureProject } from "../src/db";
 import {
   cosineSimilarity,
@@ -8,6 +8,10 @@ import {
   vectorSearch,
   checkConfigChange,
   resetProvider,
+  embed,
+  LocalProviderUnavailableError,
+  _resetFastembedProbe,
+  _markFastembedUnavailable,
 } from "../src/embedding";
 
 describe("cosineSimilarity", () => {
@@ -99,6 +103,54 @@ describe("isAvailable", () => {
     // After reset, re-evaluation with default config should still work
     expect(isAvailable()).toBe(true);
     resetProvider();
+  });
+});
+
+describe("fastembed unavailable fallback (#185)", () => {
+  // Simulates the CUDA-13 install failure path: the optional `fastembed` peer
+  // isn't installed, so the local provider's dynamic import fails. Callers
+  // should see `isAvailable() === false` and never have to handle a thrown
+  // error from deep inside `embed()`.
+
+  afterEach(() => {
+    // Restore real probe state for subsequent tests (the LocalProvider
+    // integration suite below depends on fastembed actually loading).
+    _resetFastembedProbe();
+    resetProvider();
+  });
+
+  test("isAvailable() returns false once fastembed is known missing", () => {
+    resetProvider();
+    _resetFastembedProbe();
+    expect(isAvailable()).toBe(true); // optimistic before probe runs
+
+    _markFastembedUnavailable();
+    expect(isAvailable()).toBe(false);
+  });
+
+  test("embed() throws LocalProviderUnavailableError when fastembed is missing", async () => {
+    resetProvider();
+    _markFastembedUnavailable();
+
+    let caught: unknown;
+    try {
+      await embed(["test"], "query");
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(LocalProviderUnavailableError);
+    expect((caught as Error).message).toContain("fastembed");
+  });
+
+  test("isAvailable() flips to false after the first embed() failure", async () => {
+    resetProvider();
+    _markFastembedUnavailable();
+
+    // First embed call surfaces the error (callers like recall.ts wrap in try/catch).
+    await expect(embed(["test"], "query")).rejects.toBeInstanceOf(LocalProviderUnavailableError);
+
+    // Subsequent isAvailable() calls short-circuit so callers stop calling embed().
+    expect(isAvailable()).toBe(false);
   });
 });
 

--- a/packages/opencode/README.md
+++ b/packages/opencode/README.md
@@ -22,6 +22,10 @@ Restart OpenCode and the plugin will be installed automatically.
 
 > This package is also published as [`opencode-lore`](https://www.npmjs.com/package/opencode-lore) (legacy alias). Both names ship identical code at every release — either works.
 
+## Local embeddings (optional)
+
+Recall uses `fastembed` for on-device vector search by default. It's an `optionalDependencies` of `@loreai/core`: if its native `onnxruntime-node` postinstall fails (e.g. CUDA 13 on Linux/x64 — [microsoft/onnxruntime#26586](https://github.com/microsoft/onnxruntime/discussions/26586)), install still succeeds and recall falls back to FTS-only. To force a local-embeddings install on such a host, set `ONNXRUNTIME_NODE_INSTALL_CUDA=skip` before installing — or configure `search.embeddings.provider` to `"voyage"` / `"openai"` in `.lore.json`.
+
 ## Companion packages
 
 Lore ships as three packages sharing the same SQLite database at `~/.local/share/opencode-lore/lore.db`:

--- a/packages/pi/README.md
+++ b/packages/pi/README.md
@@ -18,6 +18,24 @@ Add to your `~/.pi/settings.json`:
 
 Then run `pi install` once. The extension auto-loads on every Pi session.
 
+## Local embeddings (optional)
+
+By default, recall uses `fastembed` (bge-small-en-v1.5, ~33MB) for on-device vector search — no API key required. `fastembed` ships native bindings via `onnxruntime-node`, which has known install issues on some configurations (e.g. CUDA 13 on Linux/x64 — see [microsoft/onnxruntime#26586](https://github.com/microsoft/onnxruntime/discussions/26586)). It's declared as an `optionalDependencies` of `@loreai/core`, so install will succeed regardless: if `fastembed` doesn't build, recall transparently falls back to FTS-only search.
+
+If you want local embeddings on a system where `fastembed`'s postinstall fails, skip the CUDA EP download — the bundled CPU EP is sufficient for `bge-small-en-v1.5`:
+
+```bash
+ONNXRUNTIME_NODE_INSTALL_CUDA=skip pi install
+```
+
+Or configure a hosted provider in `.lore.json`:
+
+```json
+{ "search": { "embeddings": { "provider": "voyage" } } }
+```
+
+(also supports `"openai"`; reads `VOYAGE_API_KEY` / `OPENAI_API_KEY` from env).
+
 ## Companion packages
 
 Lore ships as three packages sharing the same SQLite database at `~/.local/share/opencode-lore/lore.db`:


### PR DESCRIPTION
## Summary

- Move `fastembed` from `dependencies` to `optionalDependencies` in `@loreai/core` so its transitive `onnxruntime-node@1.21.0` postinstall failing on CUDA 13 (microsoft/onnxruntime#26586) no longer aborts `npm i @loreai/pi` / `npm i @loreai/opencode`.
- Repair the runtime fallback in `packages/core/src/embedding.ts`: a single `tryLoadFastembed()` probe with one-shot info log, a typed `LocalProviderUnavailableError`, and `isAvailable()` short-circuiting to `false` once the probe reports missing — so recall / ltm / distillation drop cleanly to FTS-only instead of throwing from deep inside `embed()`.
- README notes in `core`, `pi`, and `opencode` packages explain the optional dep + the `ONNXRUNTIME_NODE_INSTALL_CUDA=skip` escape hatch for users who specifically want local embeddings on CUDA 13.

Closes #185

## Test plan

- [ ] `bun --filter '@loreai/core' typecheck`
- [ ] `bun test packages/core/test/embedding.test.ts` — new `fastembed unavailable fallback (#185)` block covers `isAvailable()`, `embed()` throwing `LocalProviderUnavailableError`, and the post-failure flip
- [ ] `bun --filter '@loreai/gateway' build` (fastembed stays external, build is unaffected)
- [ ] `bun --filter '@loreai/gateway' bundle` (npm CJS bundle still external-marks fastembed)
- [ ] `bun --filter '@loreai/pi' build`
- [ ] **Repro** — on a CUDA-13 host (or `nvcc` mocked to `release 13`): before this PR `npm i @loreai/pi` errors out as in #185; after this PR install completes with an `npm WARN optional dep failed` line and `@loreai/core` is importable; recall transparently runs FTS-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
