### PR TITLE
fix: per-session urgentDistillation and layer 1 distillation trigger

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -31,9 +31,6 @@
 <!-- lore:019e132b-1b18-7723-9586-be04f1b16627 -->
 * **Temporal-distillation-knowledge data flow lifecycle**: Data flows through 4 stages: (1) Temporal messages - raw conversation with FTS5, TTL+size pruning; (2) Distillations gen-0 - LLM-compressed 5-30 message segments; (3) Distillations gen-1+ - meta-distillations consolidating gen-0, archive gen-0; (4) Knowledge (LTM) - curated entries from curator + pattern-extract. Knowledge exported to .lore.md for version control. Context transform injects distillation prefix + LTM entries into system prompt.
 
-<!-- lore:019e1323-ffdb-7556-9624-5fa69af1afec -->
-* **urgentDistillation singleton causes cross-session race conditions**: urgentDistillation is module-level singleton with consume-on-read pattern. Three async consumers (gateway, opencode, distillation service) race for the flag across all sessions. First caller gets true, others get false even if their session needs distillation. Requires per-session tracking to fix race condition.
-
 ### Gotcha
 
 <!-- lore:019e1352-4391-79d2-9cc8-1aa6e05afea8 -->
@@ -49,12 +46,24 @@
 * **Fingerprint must exclude model parameter to prevent session breaks**: Session fingerprint should exclude \`model\` parameter to prevent session fragmentation on model changes. Users frequently switch models mid-conversation expecting continuity. Fingerprint composition: \`firstUserContent + authSuffix\` only. Remove model from both fingerprint generation and all callers in pipeline.ts. Model changes should not break session continuity - session identity is about user context, not AI model choice.
 
 <!-- lore:019e1323-ffde-75c3-9af8-d52ac068fe87 -->
-* **OpenCode distillation threshold skips layer 1 entirely**: OpenCode plugin only triggers backgroundDistill() for result.layer >= 2, skipping layer 1 entirely. Combined with layer 1 not setting urgentDistillation flag, layer 1 contexts never get background knowledge extraction. Fix: change threshold to layer >= 1 and ensure layer 1 sets urgentDistillation flag.
+* **OpenCode distillation threshold skips layer 1 entirely**: OpenCode distillation threshold and urgentDistillation race condition: OpenCode plugin only triggers backgroundDistill() for result.layer >= 2, skipping layer 1 entirely. Combined with urgentDistillation singleton race conditions across sessions, layer 1 contexts never get background knowledge extraction. Three async consumers (gateway, opencode, distillation service) compete for singleton flag - first caller gets true, others false. Fix requires: (1) change threshold to layer >= 1, (2) implement per-session urgentDistillation tracking to eliminate race conditions.
+
+<!-- lore:019e138b-7ac9-783d-9b37-54cc35e747bf -->
+* **TypeScript resolution conflicts between bun and tsc with @loreai/core**: TypeScript compiler resolves \`@loreai/core\` via \`dist/node/index.d.ts\` (built types) while Bun uses \`src/index.ts\` (source). When changing core APIs, \`npx tsc\` shows errors until types are rebuilt, but \`bun typecheck\` works with source. Use \`bun --filter '\*' typecheck\` for proper per-package validation, not root \`tsc\`. Build core package after API changes to sync declaration files.
+
+<!-- lore:019e138b-7ac1-7771-9878-5b93645ef8cd -->
+* **TypeScript resolution differs between tsc and Bun for monorepo packages**: Root \`tsc\` resolves \`@loreai/core\` via \`dist/index.d.ts\` (built declarations) while Bun uses \`src/index.ts\` (source). This causes type mismatches during development. Per-package typechecks use \`paths\` mapping to resolve to source. Always run \`bun --filter '\*' typecheck\` for accurate validation, not root \`tsc\`. Root typecheck sees stale built types.
+
+<!-- lore:019e138b-7ad1-7b56-9f56-8ab061da85be -->
+* **TypeScript resolution mismatch between tsc and Bun runtime exports**: TypeScript compiler (tsc) resolves \`@loreai/core\` through package.json "types" field pointing to built declarations in dist/, while Bun runtime uses "bun" export condition pointing to src/ files. This causes type errors when source changes before rebuild - tsc sees stale built types while Bun sees fresh source. Solution: ensure package builds stay in sync with source changes, or use direct relative imports in development to bypass package resolution entirely.
 
 ### Pattern
 
 <!-- lore:019e135d-f964-7f2f-8439-e11a62f30dd2 -->
 * **Fingerprint excludes model parameter for session stability**: Session fingerprinting excludes \`model\` parameter to prevent session fragmentation during model switches. Fingerprint uses only \`firstUserContent + authSuffix\` for stable session identification across model changes and compaction events. Model parameter removed from \`createFingerprint()\` calls in pipeline - only auth context and initial user content determine session identity. Enables persistent sessions regardless of LLM model selection.
+
+<!-- lore:019e138b-055a-7ad6-934e-4a7ac5476a04 -->
+* **Gradient system uses layerMap for O(1) context lookup optimization**: Context gradient system optimized with \`layerMap\` for O(1) layer lookups instead of O(n) array searches. Map structure: \`layerMap.set(layer.id, layer)\` during initialization, then \`layerMap.get(contextId)\` for instant retrieval. Applied to layers 2, 3, 4 in gradient.ts. Eliminates performance bottleneck when searching contexts by ID during distillation and knowledge extraction workflows. Essential for scaling with large context histories.
 
 <!-- lore:019e132b-1b1f-798a-ae69-71a7f40bdeb0 -->
 * **Lore.md file managed via UUID-tracked markdown with import/export cycle**: \`.lore.md\` contains project knowledge as markdown bullets with \`\<!-- lore:UUID -->\` tracking markers. \`exportLoreFile()\` writes DB entries grouped by category. \`importLoreFile()\` parses bullets: known UUID updates content, unknown UUID creates with that ID, no UUID creates new UUIDv7. \`shouldImportLoreFile()\` detects changes via content hash. Enables cross-machine knowledge sync via git commits.
@@ -67,3 +76,6 @@
 
 <!-- lore:019e1351-cdc0-7416-af76-3f7fe16fb47d -->
 * **Multiple host binding requires spawning separate server instances**: Bun.serve() only accepts single hostname parameter. To bind to multiple IP addresses, spawn one server instance per host using Promise.all(). Return array of stop functions for cleanup. Pattern: parse comma-separated LORE\_LISTEN\_HOST env var into hosts array, accept multiple --host CLI flags, then map each host to separate Bun.serve() call with same port and handler.
+
+<!-- lore:019e138b-7acd-7d07-b3bf-2ab24bb2e128 -->
+* **urgentDistillation refactored from singleton to session map**: Replaced module-level urgentDistillation singleton with session-keyed Map to eliminate cross-session race conditions. New pattern: \`urgentDistillationMap.set(sessionId, true)\` to flag, \`consumeUrgentDistillation(sessionId)\` returns and deletes flag atomically. Fixes race where first consumer across all sessions would steal flag from other sessions needing distillation.

--- a/packages/core/src/distillation.ts
+++ b/packages/core/src/distillation.ts
@@ -12,7 +12,7 @@ import {
   RECURSIVE_SYSTEM,
   recursiveUser,
 } from "./prompt";
-import { needsUrgentDistillation, toolStripAnnotation } from "./gradient";
+import { toolStripAnnotation } from "./gradient";
 import { workerSessionIDs } from "./worker";
 import type { LLMClient } from "./types";
 
@@ -599,8 +599,10 @@ export async function run(input: {
       rounds++;
     }
 
-    // Check if we still need urgent distillation
-    if (!needsUrgentDistillation()) break;
+    // Continue looping only when explicitly forced (urgent/overflow recovery).
+    // Previously re-polled needsUrgentDistillation() here, but that consumed
+    // the per-session flag and raced with the caller that already checked it.
+    if (!input.force) break;
   }
 
   return { rounds, distilled };

--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -1429,11 +1429,13 @@ export type TransformResult = {
   rawBudget: number;
 };
 
-// Signal that we need urgent distillation
-let urgentDistillation = false;
-export function needsUrgentDistillation(): boolean {
-  const v = urgentDistillation;
-  urgentDistillation = false;
+// Per-session urgent distillation tracking.
+// Keyed by sessionID. Set by layer returns in transformInner(),
+// consumed (read + delete) by needsUrgentDistillation(sessionID).
+const urgentDistillationMap = new Map<string, boolean>();
+export function needsUrgentDistillation(sessionID: string): boolean {
+  const v = urgentDistillationMap.get(sessionID) ?? false;
+  urgentDistillationMap.delete(sessionID);
   return v;
 }
 
@@ -1650,7 +1652,12 @@ function transformInner(input: {
           rawBudget,
           strip: "none",
         });
-    if (fitsWithSafetyMargin(layer1)) return { ...layer1!, layer: 1, usable, distilledBudget, rawBudget };
+    if (fitsWithSafetyMargin(layer1)) {
+      if (cached.tokens === 0 && sid) {
+        urgentDistillationMap.set(sid, true);
+      }
+      return { ...layer1!, layer: 1, usable, distilledBudget, rawBudget };
+    }
   }
 
   // Layer 1 didn't fit (or was force-skipped) — reset the raw window cache.
@@ -1670,7 +1677,7 @@ function transformInner(input: {
       protectedTurns: 2,
     });
     if (fitsWithSafetyMargin(layer2)) {
-      urgentDistillation = true;
+      if (sid) urgentDistillationMap.set(sid, true);
       return { ...layer2!, layer: 2, usable, distilledBudget, rawBudget };
     }
   }
@@ -1691,7 +1698,7 @@ function transformInner(input: {
     strip: "all-tools",
   });
   if (fitsWithSafetyMargin(layer3)) {
-    urgentDistillation = true;
+    if (sid) urgentDistillationMap.set(sid, true);
     return { ...layer3!, layer: 3, usable, distilledBudget, rawBudget };
   }
 
@@ -1708,7 +1715,7 @@ function transformInner(input: {
   // if it alone exceeds the tail budget — layer 4 is the terminal layer
   // and must always return. Remaining budget is filled backward with older
   // messages.
-  urgentDistillation = true;
+  if (sid) urgentDistillationMap.set(sid, true);
   const nuclearDistillations = distillations.slice(-2);
   const nuclearPrefix = distilledPrefix(nuclearDistillations);
   const nuclearPrefixTokens = nuclearPrefix.reduce(

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -1139,7 +1139,7 @@ function scheduleBackgroundWork(
   // Check if urgent distillation is needed (gradient flagged it).
   // Mark urgent: true so these bypass the batch queue — the gradient is
   // in overflow and needs the result before the next user turn.
-  if (needsUrgentDistillation()) {
+  if (needsUrgentDistillation(sessionState.sessionID)) {
     distillation
       .run({
         llm,

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -700,7 +700,7 @@ export const LorePlugin: Plugin = async (ctx) => {
       if (
         force ||
         pending >= cfg.distillation.minMessages ||
-        needsUrgentDistillation()
+        needsUrgentDistillation(sessionID)
       ) {
         // Skip meta-distillation when the prompt cache is likely still warm.
         // Meta-distill rewrites row IDs → invalidates distilled prefix cache →
@@ -1250,7 +1250,7 @@ export const LorePlugin: Plugin = async (ctx) => {
           );
         }
 
-        if (result.layer >= 2 && sessionID) {
+        if (result.layer >= 1 && sessionID) {
           backgroundDistill(sessionID);
         }
       } catch (e) {


### PR DESCRIPTION
## Summary

Fixes #194 — distillation never triggers at gradient layer 1, causing `distilled=0` to persist indefinitely.

## Problem

Two interacting bugs:

1. **Layer 1 never signals urgency** — layers 2–4 all set `urgentDistillation = true`, but layer 1 returns without it. The OpenCode plugin also gates `backgroundDistill()` on `result.layer >= 2`, so layer 1 never triggers distillation.

2. **Global singleton with consume-on-read** — `urgentDistillation` was a module-level `let` shared across all concurrent sessions. Three consumers raced for it; the first caller got `true`, the rest got `false`. The distillation loop's re-check at line 603 always saw `false` because the caller already consumed it.

## Changes

- **`packages/core/src/gradient.ts`** — Replace module-level singleton with `Map<string, boolean>` keyed by sessionID. Signal urgency at layer 1 when `cached.tokens === 0` (no distilled prefix yet). Update layers 2–4 to use the map with `if (sid)` guard.
- **`packages/core/src/distillation.ts`** — Remove `needsUrgentDistillation` import. Replace loop re-check with `input.force` to eliminate the double-consume bug.
- **`packages/gateway/src/pipeline.ts`** — Pass `sessionState.sessionID` to `needsUrgentDistillation()`.
- **`packages/opencode/src/index.ts`** — Pass `sessionID` to `needsUrgentDistillation()`. Lower layer threshold from `>= 2` to `>= 1`.

## Verification

- `bun --filter '*' typecheck` passes on all 4 packages
- `rg "urgentDistillation|needsUrgentDistillation"` confirms no stale references