### PR TITLE
feat: prevent Claude Code auto-compaction with defense-in-depth

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -5,62 +5,70 @@
 ### Architecture
 
 <!-- lore:019e1349-63c2-72f1-8725-db0ee29efedd -->
-* **3-tier session identification with header learning**: 3-tier session identification with multiple headers: Uses hierarchy: (1) Known headers - \`x-claude-code-session-id\`, \`x-session-affinity\`, \`x-parent-session-id\`; (2) Learned headers - collect \`x-\` headers with ID-like values during fingerprint bootstrap; (3) Fingerprint fallback. \`identifySession()\` returns \`{sessionId, tier}\`. Uses \`headerToSessionMap\` for O(1) reverse lookup. Higher tiers override lower.
+* **3-tier session identification with header learning**: 3-tier session identification: (1) Known headers (x-claude-code-session-id, x-session-affinity, x-parent-session-id); (2) Learned x-\* headers with ID-like values; (3) Fingerprint fallback. identifySession() returns {sessionId, tier}. headerToSessionMap for O(1) lookup.
+
+<!-- lore:019e1405-1594-7e54-a90c-095bb0a2df12 -->
+* **Agent launcher injects environment variables per agent configuration**: Agent launcher in cli/agents.ts provides agent-specific config including binary paths, detection functions, and environment variables. envVars(url) function returns per-agent env setup. Environment merging: base env + agent envVars + explicit overrides. Claude Code agent gets DISABLE\_AUTO\_COMPACT=1 to prevent client-side compaction at 167K tokens, since gateway interception points can't catch all compaction paths (microcompact, session memory).
 
 <!-- lore:019e133c-1e2a-72b4-97c9-75965fe2d0f6 -->
-* **Claude Code sends persistent session ID in HTTP headers**: Claude Code sends persistent session ID in HTTP headers: Sends persistent \`X-Claude-Code-Session-Id\` header with UUID generated at startup. Session ID persists across compaction, model changes, and CLI session lifecycle. Header normalizes to lowercase: \`rawHeaders\["x-claude-code-session-id"]\`. Sub-agents share parent session ID, enabling direct identification without fragile fingerprinting.
+* **Claude Code sends persistent session ID in HTTP headers**: Claude Code session ID: Sends persistent X-Claude-Code-Session-Id header (UUID at startup). Persists across compaction, model changes. Normalizes to lowercase: rawHeaders\['x-claude-code-session-id']. Sub-agents share parent ID.
 
 <!-- lore:019e1330-a34e-7917-9802-35093f041a31 -->
-* **Data management pattern across CLI and web UI**: Unified data management across CLI and web UI: core/data.ts exports unified APIs (listProjects, clearProject, etc), CLI data.ts provides terminal interface, gateway ui.ts serves web forms. Clear operations regenerate .lore.md and warn to commit changes. Both CLI and web UI use same core APIs for consistency.
+* **Data management pattern across CLI and web UI**: Unified data management: core/data.ts exports APIs (listProjects, clearProject), CLI data.ts provides terminal interface, gateway ui.ts serves web forms. Both use same core APIs. Clear operations regenerate .lore.md and warn to commit.
 
 <!-- lore:019e1328-d565-7f53-bc81-915c48531370 -->
-* **Gateway HTTP server uses Bun.serve with manual routing**: Gateway HTTP server uses Bun.serve with manual routing: Implements HTTP server using Bun.serve() on port 6969. Manual routing via if/else chain in fetch() handler. Routes: POST /v1/messages (Anthropic), POST /v1/chat/completions (OpenAI), GET /v1/models, GET /health. Uses jsonResponse(), errorResponse() helpers. No web framework dependency.
+* **Gateway HTTP server uses Bun.serve with manual routing**: Gateway uses Bun.serve() on port 6969 with manual if/else routing in fetch() handler. Routes: POST /v1/messages (Anthropic), POST /v1/chat/completions (OpenAI), GET /v1/models, GET /health. Uses jsonResponse(), errorResponse() helpers for consistent response formatting.
 
 <!-- lore:019e13f6-44cf-7406-a618-2ef9b4faa99c -->
-* **Git-based project identification with 4-tier resolution hierarchy**: Git-based project identification with 4-tier resolution: Projects identified by git remote URL + filesystem path. \`ensureProject()\` uses 4-tier resolution: (1) exact path match; (2) path alias lookup; (3) git remote match (prefers upstream > origin); (4) create new project. Schema v14 adds git\_remote column. Prevents data fragmentation across worktrees, clones, directory renames.
+* **Git-based project identification with 4-tier resolution hierarchy**: Git-based project identification: 4-tier resolution via git remote + path. ensureProject() tries: (1) exact path; (2) path alias; (3) git remote (prefers upstream > origin); (4) create new. Schema v14 adds git\_remote. Prevents fragmentation across worktrees/clones.
 
-<!-- lore:019e13fe-4a09-709d-adc1-bfde8e54b642 -->
-* **Lore distillation system replaces compaction with hierarchical context layers**: Lore distillation system replaces compaction with hierarchical context preservation: Replaces free-code's lossy compaction with distillation that preserves context. Process: (1) Raw messages with FTS search; (2) Background LLM distills 5-30 message segments into gen-0 summaries; (3) gen-0s consolidated into gen-1+ meta-distillations; (4) Manual curation extracts knowledge entries. All layers inject into system prompt. Conversations grow richer context over time rather than losing history.
+<!-- lore:019e140a-9519-708c-9438-4a8f9d90c608 -->
+* **Gradient system context cap adaptation creates 67K unused window with auto-compact disabled**: Gradient system dynamic context scaling with cost-aware caps: Dynamic context cap tightens to MIN\_CONTEXT\_FLOOR=100K when bustRateEMA>0.8. Cost-aware cap = min(targetBustCost/cacheWriteCost, 100K floor). Default $1 targetBustCost: sonnet-4 uncapped (267K), opus-4-6 at 160K. With DISABLE\_AUTO\_COMPACT=1 and 167K auto-compact disabled, system uses only 65K (25% distilled + 40% raw) leaving 67K unused. Increase targetBustCost or set maxContextTokens override to utilize full window.
 
 <!-- lore:019e13fe-49f6-7107-b47e-c1c1f7e82306 -->
-* **Lore gradient system injects multi-layer context via system prompt prefixes**: Lore gradient system injects multi-layer context via system prompt: Builds hierarchical context from 4 layers: distillations (gen-0: segments, gen-1+: consolidated), LTM knowledge entries, context-specific data, current session. \`buildPromptPrefix()\` formats each layer with markdown headers, injects as system prompt prefix via \`systemPromptWithGradientContext()\`. Replaces compaction entirely - conversations accumulate richer background knowledge over time.
+* **Lore gradient system injects multi-layer context via system prompt prefixes**: Lore gradient system builds 4-layer hierarchical context via system prompt injection: Layers include distillations (gen-0/gen-1+), LTM knowledge, context-specific, and session data. buildPromptPrefix() formats with markdown headers, injects via systemPromptWithGradientContext(). Replaces compaction with progressive knowledge accumulation across conversation history.
 
 <!-- lore:019e1352-b81c-7997-8006-ab66063c4b32 -->
-* **Multiple host binding via Bun.serve instance spawning**: Multiple host binding via Bun.serve spawning: Gateway supports multiple IP addresses by spawning one \`Bun.serve()\` instance per host (Bun.serve only accepts single hostname). Parses comma-separated \`LORE\_HOST\` env var and multiple \`--host\` CLI flags into \`hosts: string\[]\`. Returns combined stop functions. Agent connections use first host (typically 127.0.0.1).
+* **Multiple host binding via Bun.serve instance spawning**: Multiple host binding via Bun.serve spawning: Gateway spawns one Bun.serve() instance per host (single hostname limit). Parses comma-separated LORE\_HOST and --host flags into hosts array. Returns combined stop functions. Agent connections use first host.
+
+<!-- lore:019e140a-9501-7342-a381-1c9a62ce9dd8 -->
+* **Session-state-based compaction detection before pattern matching**: Session-state compaction detection via O(1) headerSessionIndex lookup: handleRequest() restructured with Tier-1 session lookup before routing. Extract sessionId from x-claude-code-session-id header, check sessions\[sessionId].messageCount vs req.messages.length. Drop from 19→1-3 messages = structural compaction. More reliable than pattern matching since works regardless of prompt format. Use isStructuralCompaction(priorState, req) after cheap session lookup.
 
 <!-- lore:019e132b-8785-76e0-85b2-0b5903aa4087 -->
-* **SQLite schema with FTS5 search across messages, distillations, knowledge**: SQLite schema with FTS5 search: Schema at $XDG\_DATA\_HOME/opencode-lore/lore.db with 6 tables: \`projects\`, \`temporal\_messages\`, \`distillations\`, \`knowledge\`, \`lat\_sections\`, \`project\_path\_aliases\`. All content tables have FTS5 search and project\_id foreign key. Projects auto-created with git-remote awareness. WAL journal mode, foreign keys ON. Runtime drivers: bun:sqlite native, node:sqlite compatibility.
+* **SQLite schema with FTS5 search across messages, distillations, knowledge**: SQLite schema: $XDG\_DATA\_HOME/opencode-lore/lore.db with 6 tables: projects, temporal\_messages, distillations, knowledge, lat\_sections, project\_path\_aliases. FTS5 search on content tables. WAL journal, foreign keys ON. Drivers: bun:sqlite native, node:sqlite compat.
+
+<!-- lore:019e1417-dcb4-7332-a56b-3daccb9c4072 -->
+* **Stream accumulator dual-mode design for usage scaling**: createStreamAccumulator() supports optional client usage scaling via scaleClientUsage parameter. When enabled, processEvent() applies scaleUsageForClient() to message\_start/message\_delta events before forwarding, while internal accumulator.getResponse() retains real values. Used in 3 places: buildStreamingResponse() (with scaling), accumulateStreamResponse() (no scaling for internals), RecallAwareAccumulator (with scaling for forwarded events). Enables compaction prevention without affecting internal token tracking.
 
 <!-- lore:019e132b-1b18-7723-9586-be04f1b16627 -->
-* **Temporal-distillation-knowledge data flow lifecycle**: Temporal-distillation-knowledge data flow: Data flows through 4 stages: (1) Temporal messages - raw conversation with FTS5, TTL+size pruning; (2) Distillations gen-0 - LLM-compressed 5-30 message segments; (3) Distillations gen-1+ - meta-distillations consolidating gen-0; (4) Knowledge (LTM) - curated entries. Knowledge exported to .lore.md for version control. Context transform injects into system prompt.
+* **Temporal-distillation-knowledge data flow lifecycle**: Temporal-distillation-knowledge data flow: (1) Temporal messages with FTS5, TTL pruning; (2) Gen-0 distillations from 5-30 message segments; (3) Gen-1+ meta-distillations; (4) Knowledge (LTM) entries. Exports to .lore.md for version control. Context transform injects into system prompt via gradient system.
+
+<!-- lore:019e140f-9bb6-7241-a370-3eb591fefe0c -->
+* **Token count flow and interception points for compaction prevention**: Claude Code auto-compacts at 167K tokens via getTokenCountFromUsage() = input\_tokens + cache\_creation\_input\_tokens + cache\_read\_input\_tokens + output\_tokens. Gateway prevention: (1) DISABLE\_AUTO\_COMPACT=1 env var in agent launcher - prevents at source; (2) Structural detection - O(1) session lookup before routing, compaction if messageCount drops 19→1-3; (3) Proportional token scaling - scale all usage fields in client responses to ~90% threshold (~150K max) while preserving real values for internal calibrate(). Scaling applied via scaleUsageForClient() in both standard pipeline and recall-aware accumulator (message\_start/message\_delta forwarding paths); (4) Pattern matching fallback; (5) Anomaly detection. Key: postResponse() runs with real tokens for calibrate()/updateBustRate(), then scale response for client.
+
+### Decision
+
+<!-- lore:019e1418-c451-7e82-9812-ec3ab91d58b4 -->
+* **Switched from read-only plan mode to build mode**: switched from read-only plan mode to build mode,
 
 ### Gotcha
 
-<!-- lore:019e1322-eb6a-7660-8975-c1d2e91096cf -->
-* **fastembed ARM64 compatibility via tokenizers override**: fastembed ARM64 compatibility via tokenizers override: fastembed 2.1.0 pins \`@anush008/tokenizers\` to \`^0.0.0\`, breaking ARM64 which needs 0.5.0+. Fix: override with \`"@anush008/tokenizers": "^0.6.0"\` in package.json. Clear vendor cache after overrides: \`rm -rf /tmp/fastembed\_cache\`. 0.6.0+ includes ARM64 binaries.
-
-<!-- lore:019e135e-6e7e-7ea9-9410-df480e406058 -->
-* **Fingerprint must exclude model parameter to prevent session breaks**: Fingerprint must exclude model parameter to prevent session breaks: Session fingerprint should exclude \`model\` parameter to prevent session fragmentation on model changes. Users frequently switch models mid-conversation expecting continuity. Fingerprint composition: \`firstUserContent + authSuffix\` only. Model changes should not break session continuity - session identity is about user context, not AI model choice.
-
-<!-- lore:019e13fa-8d5b-732c-90a6-ac33f2242c27 -->
-* **free-code autoCompactThreshold uses percentages not absolute tokens**: free-code autoCompactThreshold uses percentages and token tracking: autoCompactThreshold is percentage-based (0.0-1.0, default 0.89 = 89% of context window). Model capabilities define contextWindowTokens (Claude-3.5: 200000). Token usage tracked via \`context\_management.input\_tokens\` from API responses. Calculation: \`tokensUsed / contextWindow >= threshold\`. UI shows 'X% until auto-compact' based on this ratio. Settings in \`~/.config/free-code/settings.json\`.
-
-<!-- lore:019e13fe-4a0e-7e12-8762-07ce562219e9 -->
-* **Lore gateway preserves Claude Code token tracking but blocks compaction execution**: OpenCode plugin blocks compaction while preserving token tracking UI: Plugin's PreCompact hook returns \`{block: true}\` to prevent all compaction execution. Gateway passes through all \`usage\` fields (\`input\_tokens\`, \`output\_tokens\`, \`cache\_\*\`) unmodified to preserve Claude Code's token tracking UI ("X% until auto-compact"). Users see normal token awareness but compaction never executes, enabling Lore's context preservation while maintaining client expectations.
-
-<!-- lore:019e138b-7ac9-783d-9b37-54cc35e747bf -->
-* **TypeScript resolution conflicts between bun and tsc with @loreai/core**: TypeScript resolution conflicts between bun and tsc with @loreai/core: TypeScript compiler resolves \`@loreai/core\` via built declarations in dist/ while Bun uses source in src/. When changing core APIs, \`npx tsc\` shows errors until types are rebuilt, but \`bun typecheck\` works with source. Always run \`bun --filter '\*' typecheck\` for accurate validation, not root \`tsc\`. Build core package after API changes to sync declaration files.
+<!-- lore:019e1403-b62a-7944-8d5e-f6d70ddc2801 -->
+* **Gradient layer resets indicate undetected Claude Code compaction events**: Claude Code compaction detection and prevention: Claude Code auto-compacts at ~167K via multiple paths: LLM summary (interceptable), session memory compact, and microcompact (client-side only). Gateway detection via gradient layer drops (4→0) with system prompt changes or message count drops (19→3). Use DISABLE\_AUTO\_COMPACT=1 for reliable prevention. Session-state detection more reliable than pattern matching since compaction bypasses API interception.
 
 ### Pattern
 
 <!-- lore:019e138b-055a-7ad6-934e-4a7ac5476a04 -->
-* **Gradient system uses layerMap for O(1) context lookup optimization**: Gradient system uses layerMap for O(1) context lookup optimization: Context gradient system optimized with \`layerMap\` for O(1) layer lookups instead of O(n) array searches. Map structure: \`layerMap.set(layer.id, layer)\` during initialization, then \`layerMap.get(contextId)\` for instant retrieval. Applied to layers 2, 3, 4 in gradient.ts. Eliminates performance bottleneck when searching contexts by ID during distillation and knowledge extraction workflows. Essential for scaling with large context histories.
+* **Gradient system uses layerMap for O(1) context lookup optimization**: Gradient layerMap optimization: O(1) context lookup via layerMap.set(layer.id, layer) during init, layerMap.get(contextId) for retrieval. Eliminates O(n) array searches in layers 2,3,4. Essential for scaling with large context histories.
 
 <!-- lore:019e132b-1b1f-798a-ae69-71a7f40bdeb0 -->
-* **Lore.md file managed via UUID-tracked markdown with import/export cycle**: Lore.md managed via UUID-tracked markdown: \`.lore.md\` contains project knowledge as markdown bullets with \`\<!-- lore:UUID -->\` markers. \`exportLoreFile()\` writes DB entries grouped by category. \`importLoreFile()\` parses: known UUID updates content, unknown UUID creates with that ID, no UUID creates new UUIDv7. \`shouldImportLoreFile()\` detects changes via content hash. Enables cross-machine sync via git.
+* **Lore.md file managed via UUID-tracked markdown with import/export cycle**: Lore.md UUID-tracked markdown: .lore.md contains knowledge as markdown with lore:UUID markers. exportLoreFile() writes DB entries by category. importLoreFile() parses: known UUID updates, unknown creates with ID, no UUID creates new UUIDv7. shouldImportLoreFile() detects changes via hash.
 
-<!-- lore:019e1359-6546-740a-b765-b43239a32be1 -->
-* **Lore.md merge conflict resolution via keeping all unique entries**: Lore.md merge conflict resolution via keeping all unique entries: When \`.lore.md\` has changes from lore system operations, include them in feature commits rather than creating separate commits. The lore system automatically exports knowledge to \`.lore.md\` during operations, so these changes are part of the feature work. Check git status before committing, include \`.lore.md\` changes with feature commits to maintain coherent history.
+<!-- lore:019e1417-dcb7-7e19-ba62-122854c393bc -->
+* **scaleUsageForClient utility for consistent token capping**: scaleUsageForClient() utility in compaction.ts applies 40% scaling factor to all usage fields: input\_tokens, cache\_creation\_input\_tokens, cache\_read\_input\_tokens, output\_tokens. Prevents Claude Code auto-compact by keeping reported usage below 167K threshold while preserving real values for internal tracking. Used in both streaming (via createStreamAccumulator) and non-streaming response paths for consistent client-side token capping.
+
+<!-- lore:019e1418-c3ca-767e-83ea-b46c0cf8e0af -->
+* **Token scaling in recall-aware accumulator requires manual forwarding**: Recall-aware accumulator in pipeline.ts builds independent forwarded events rather than using inner createStreamAccumulator() output. Must apply scaleUsageForClient() to message\_start/message\_delta events at 3 forwarding points: (1) message\_start fallthrough, (2) message\_delta/message\_stop fallthrough when not recall, (3) continuation stream message\_delta forwarding. Held-back events auto-scale via forwardEvent() helper but continuation stream needs explicit scaling. Use static import of scaleUsageForClient to avoid dynamic imports in hot loops.
 
 <!-- lore:019e138b-7acd-7d07-b3bf-2ab24bb2e128 -->
-* **urgentDistillation refactored from singleton to session map**: urgentDistillation refactored from singleton to session map: Replaced module-level urgentDistillation singleton with session-keyed Map to eliminate cross-session race conditions. New pattern: \`urgentDistillationMap.set(sessionId, true)\` to flag, \`consumeUrgentDistillation(sessionId)\` returns and deletes flag atomically. Fixes race where first consumer across all sessions would steal flag from other sessions needing distillation.
+* **urgentDistillation refactored from singleton to session map**: urgentDistillation session isolation: Replaced module singleton with session-keyed Map. Pattern: urgentDistillationMap.set(sessionId, true) to flag, consumeUrgentDistillation(sessionId) returns and deletes atomically. Fixes cross-session race conditions.

--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -62,7 +62,7 @@ const MIN_LAYER0_FLOOR = 40_000;
  *  0 = disabled (no cap). Set via setMaxContextTokens(). */
 let maxContextTokensCeiling = 0;
 
-const MIN_CONTEXT_FLOOR = 100_000;
+const MIN_CONTEXT_FLOOR = 130_000;
 
 /** Compute the context ceiling from a per-bust cost target and cache-write price per token. */
 export function computeContextCap(

--- a/packages/gateway/src/cli/agents.ts
+++ b/packages/gateway/src/cli/agents.ts
@@ -59,7 +59,10 @@ export const AGENTS: AgentDef[] = [
     displayName: "Claude Code",
     binary: "claude",
     detect: () => which("claude"),
-    envVars: (url) => ({ ANTHROPIC_BASE_URL: url }),
+    envVars: (url) => ({
+      ANTHROPIC_BASE_URL: url,
+      DISABLE_AUTO_COMPACT: "1",
+    }),
   },
   {
     name: "codex",

--- a/packages/gateway/src/cli/start.ts
+++ b/packages/gateway/src/cli/start.ts
@@ -85,6 +85,9 @@ export async function commandStart(opts: StartOptions): Promise<never> {
     console.error(`  LORE_IDLE_TIMEOUT       Idle timeout in seconds (current: ${config.idleTimeoutSeconds})`);
     console.error(`  LORE_DEBUG              Enable debug logging (current: ${config.debug})`);
     console.error(`  LORE_BATCH_DISABLED     Disable batch background work (current: ${process.env.LORE_BATCH_DISABLED === "1"})`);
+    console.error("");
+    console.error("[lore] When using Claude Code, also set:");
+    console.error("  export DISABLE_AUTO_COMPACT=1");
   }
   // Block until signal
   const onSignal = async () => {

--- a/packages/gateway/src/compaction.ts
+++ b/packages/gateway/src/compaction.ts
@@ -74,7 +74,87 @@ function estimateTokens(text: string): number {
 }
 
 // ---------------------------------------------------------------------------
-// isCompactionRequest
+// Usage scaling — prevent client auto-compaction in hosted gateway scenarios
+// ---------------------------------------------------------------------------
+
+/**
+ * Claude Code's auto-compact threshold for a 200K context model:
+ *   effectiveContextWindow = contextWindow - min(maxOutputTokens, 20_000)
+ *   autoCompactThreshold  = effectiveContextWindow - 13_000
+ *
+ * For 200K context → 167K.  We report at most TARGET_RATIO × 167K ≈ 150K
+ * so the client's "X% until auto-compact" UI grows naturally but never
+ * triggers the compaction.
+ */
+const AUTOCOMPACT_THRESHOLD = 167_000;
+const TARGET_RATIO = 0.9;
+const MAX_REPORTED_USAGE = Math.floor(AUTOCOMPACT_THRESHOLD * TARGET_RATIO);
+
+/**
+ * Scale usage fields proportionally so the client's total
+ * (`input_tokens + cache_creation + cache_read + output_tokens`) stays
+ * below `MAX_REPORTED_USAGE`.
+ *
+ * Returns the original usage unchanged when the total is already safe.
+ * Internal Lore systems (calibrate, bustRate) must use the **real** values
+ * — only the client-facing response should carry the scaled values.
+ */
+export function scaleUsageForClient(usage: {
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_input_tokens?: number;
+  cache_creation_input_tokens?: number;
+}): {
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_input_tokens?: number;
+  cache_creation_input_tokens?: number;
+} {
+  const total =
+    usage.input_tokens +
+    (usage.cache_read_input_tokens ?? 0) +
+    (usage.cache_creation_input_tokens ?? 0) +
+    usage.output_tokens;
+
+  if (total <= MAX_REPORTED_USAGE) return usage;
+
+  const scale = MAX_REPORTED_USAGE / total;
+  return {
+    input_tokens: Math.floor(usage.input_tokens * scale),
+    output_tokens: Math.floor(usage.output_tokens * scale),
+    ...(usage.cache_read_input_tokens != null
+      ? { cache_read_input_tokens: Math.floor(usage.cache_read_input_tokens * scale) }
+      : {}),
+    ...(usage.cache_creation_input_tokens != null
+      ? { cache_creation_input_tokens: Math.floor(usage.cache_creation_input_tokens * scale) }
+      : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// isStructuralCompaction — session-aware detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect compaction via structural session signals — no prompt pattern
+ * matching needed.  Works regardless of compaction prompt format changes.
+ *
+ * Signal: a known session previously had many messages (>10), but the
+ * current request has very few (≤3) — a >50 % drop.  This is the
+ * hallmark of Claude Code replacing its entire message history with a
+ * compaction summary.
+ */
+export function isStructuralCompaction(
+  req: GatewayRequest,
+  priorState?: { messageCount: number },
+): boolean {
+  if (!priorState || priorState.messageCount <= 10) return false;
+  const currCount = req.messages.length;
+  return currCount <= 3 && currCount < priorState.messageCount * 0.5;
+}
+
+// ---------------------------------------------------------------------------
+// isCompactionRequest — pattern-based detection (fallback)
 // ---------------------------------------------------------------------------
 
 /**

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -59,9 +59,11 @@ import {
 } from "./session";
 import {
   isCompactionRequest,
+  isStructuralCompaction,
   isTitleOrSummaryRequest,
   extractPreviousSummary,
   buildCompactionResponse,
+  scaleUsageForClient,
 } from "./compaction";
 import {
   buildAnthropicRequest,
@@ -631,9 +633,10 @@ function buildStreamingResponse(
   },
 ): Response {
   const recallAccum = recallContext
-    ? createRecallAwareAccumulator(RECALL_TOOL_NAME)
+    ? createRecallAwareAccumulator(RECALL_TOOL_NAME, { scaleClientUsage: true })
     : null;
-  const accumulator: StreamAccumulator = recallAccum ?? createStreamAccumulator();
+  const accumulator: StreamAccumulator =
+    recallAccum ?? createStreamAccumulator({ scaleClientUsage: true });
   const encoder = new TextEncoder();
 
   // Client-disconnect detection: shared between start() and cancel()
@@ -831,7 +834,29 @@ function buildStreamingResponse(
                 }
               }
 
-              // Forward message_delta, message_stop, and other events as-is
+              // Forward message_delta, message_stop, and other events.
+              // Scale usage in message_delta to prevent client auto-compaction.
+              if (contEvent === "message_delta") {
+                try {
+                  const parsed = JSON.parse(contData) as Record<string, unknown>;
+                  const deltaUsage = parsed.usage as Record<string, number> | undefined;
+                  if (deltaUsage && typeof deltaUsage.output_tokens === "number") {
+                    const innerResp = accumulator.getResponse();
+                    const scaled = scaleUsageForClient({
+                      input_tokens: innerResp.usage.inputTokens,
+                      output_tokens: deltaUsage.output_tokens,
+                      cache_read_input_tokens: innerResp.usage.cacheReadInputTokens,
+                      cache_creation_input_tokens: innerResp.usage.cacheCreationInputTokens,
+                    });
+                    parsed.usage = { ...deltaUsage, output_tokens: scaled.output_tokens };
+                    const adjusted = formatSSEEvent(contEvent, JSON.stringify(parsed));
+                    if (!safeEnqueue(encoder.encode(adjusted))) break;
+                    continue;
+                  }
+                } catch {
+                  // Fall through to forward as-is
+                }
+              }
               const forwarded = formatSSEEvent(contEvent, contData);
               if (!safeEnqueue(encoder.encode(forwarded))) break;
             }
@@ -956,9 +981,27 @@ async function accumulateStreamResponse(
 
 /**
  * Convert a GatewayResponse to a non-streaming HTTP Response.
+ * Scales usage fields to prevent client auto-compaction.
  */
 function nonStreamHttpResponse(resp: GatewayResponse): Response {
-  const body = buildAnthropicNonStreamResponse(resp);
+  // Scale usage so the client's token total stays below auto-compact threshold.
+  // postResponse() has already consumed the real values for calibration/bustRate.
+  const scaledUsage = scaleUsageForClient({
+    input_tokens: resp.usage.inputTokens,
+    output_tokens: resp.usage.outputTokens,
+    cache_read_input_tokens: resp.usage.cacheReadInputTokens,
+    cache_creation_input_tokens: resp.usage.cacheCreationInputTokens,
+  });
+  const scaledResp: GatewayResponse = {
+    ...resp,
+    usage: {
+      inputTokens: scaledUsage.input_tokens,
+      outputTokens: scaledUsage.output_tokens,
+      cacheReadInputTokens: scaledUsage.cache_read_input_tokens,
+      cacheCreationInputTokens: scaledUsage.cache_creation_input_tokens,
+    },
+  };
+  const body = buildAnthropicNonStreamResponse(scaledResp);
   return new Response(JSON.stringify(body), {
     status: 200,
     headers: { "content-type": "application/json" },
@@ -1374,8 +1417,21 @@ async function handleConversationTurn(
     }
   }
 
+  // --- Compaction anomaly detection ---
+  // If we reach here (normal turn) with a large message count drop, the client
+  // performed compaction that slipped past both structural and pattern detection.
+  const prevMsgCount = sessionState.messageCount;
+  const currMsgCount = req.messages.length;
+  if (prevMsgCount > 10 && currMsgCount < prevMsgCount * 0.5) {
+    log.warn(
+      `compaction anomaly: session=${sessionID.slice(0, 16)} ` +
+        `messages dropped ${prevMsgCount}→${currMsgCount}. ` +
+        `Client may have compacted outside gateway control.`,
+    );
+  }
+
   // Always update message count for proximity matching
-  sessionState.messageCount = req.messages.length;
+  sessionState.messageCount = currMsgCount;
 
   // Track session model for worker model discovery
   lastSeenSessionModel = req.model;
@@ -1984,8 +2040,22 @@ export async function handleRequest(
       setLastSeenAuth(earlyAuth);
     }
 
+    // --- Quick Tier-1 session lookup for structural compaction detection ---
+    // O(1) header + map lookup — lets us compare message counts before routing.
+    let priorState: SessionState | undefined;
+    const known = extractKnownSessionHeader(req.rawHeaders);
+    if (known) {
+      const indexKey = `${known.headerName}:${known.sessionId}`;
+      const sid = headerSessionIndex.get(indexKey);
+      if (sid) priorState = sessions.get(sid);
+    }
+
     // --- Case 1: Compaction request → intercept ---
-    if (isCompactionRequest(req)) {
+    // Structural detection (session-aware) first, pattern matching as fallback.
+    if (
+      isStructuralCompaction(req, priorState) ||
+      isCompactionRequest(req)
+    ) {
       return await handleCompaction(req, config);
     }
 

--- a/packages/gateway/src/stream/anthropic.ts
+++ b/packages/gateway/src/stream/anthropic.ts
@@ -16,6 +16,7 @@ import type {
   GatewayResponse,
   GatewayUsage,
 } from "../translate/types";
+import { scaleUsageForClient } from "../compaction";
 
 // ---------------------------------------------------------------------------
 // SSE formatting
@@ -119,7 +120,13 @@ export interface StreamAccumulator {
   isDone(): boolean;
 }
 
-export function createStreamAccumulator(): StreamAccumulator {
+export function createStreamAccumulator(options?: {
+  /** When true, scale usage fields in client-facing SSE events so Claude Code's
+   *  auto-compact threshold is never reached.  Internal accumulation is unaffected. */
+  scaleClientUsage?: boolean;
+}): StreamAccumulator {
+  const shouldScale = options?.scaleClientUsage ?? false;
+
   let id = "";
   let model = "";
   let stopReason = "";
@@ -137,18 +144,68 @@ export function createStreamAccumulator(): StreamAccumulator {
   /** Track which indices have been finalized. */
   const finalized = new Set<number>();
 
-  function processEvent(eventType: string, data: string): string {
-    // Forward the event as-is regardless of processing outcome
-    const forwarded = formatSSEEvent(eventType, data);
+  /**
+   * Rewrite usage fields in a `message_start` or `message_delta` SSE event
+   * payload so the client sees scaled token counts.  Returns the modified
+   * JSON string, or `null` if no rewrite was needed.
+   */
+  function rewriteUsage(parsed: Record<string, unknown>, eventType: string): string | null {
+    if (!shouldScale) return null;
 
-    // Parse the data payload — if it's not valid JSON, just forward
+    if (eventType === "message_start") {
+      const message = parsed.message as Record<string, unknown> | undefined;
+      const msgUsage = message?.usage as Record<string, number> | undefined;
+      if (!msgUsage) return null;
+
+      const scaled = scaleUsageForClient({
+        input_tokens: msgUsage.input_tokens ?? 0,
+        output_tokens: msgUsage.output_tokens ?? 0,
+        cache_read_input_tokens: msgUsage.cache_read_input_tokens,
+        cache_creation_input_tokens: msgUsage.cache_creation_input_tokens,
+      });
+      // Only rewrite if scaling actually changed something
+      if (scaled === msgUsage) return null;
+
+      const rewritten = {
+        ...parsed,
+        message: { ...message, usage: { ...msgUsage, ...scaled } },
+      };
+      return JSON.stringify(rewritten);
+    }
+
+    if (eventType === "message_delta") {
+      const deltaUsage = parsed.usage as Record<string, number> | undefined;
+      if (!deltaUsage || typeof deltaUsage.output_tokens !== "number") return null;
+
+      // For message_delta, the usage only carries output_tokens.  We need to
+      // scale based on the *total* accumulated so far (input from message_start
+      // + output from this delta) so the proportional scaling is consistent.
+      const scaled = scaleUsageForClient({
+        input_tokens: usage.inputTokens,
+        output_tokens: deltaUsage.output_tokens,
+        cache_read_input_tokens: usage.cacheReadInputTokens,
+        cache_creation_input_tokens: usage.cacheCreationInputTokens,
+      });
+      const rewritten = {
+        ...parsed,
+        usage: { ...deltaUsage, output_tokens: scaled.output_tokens },
+      };
+      return JSON.stringify(rewritten);
+    }
+
+    return null;
+  }
+
+  function processEvent(eventType: string, data: string): string {
+    // Parse the data payload — if it's not valid JSON, just forward as-is
     let parsed: Record<string, unknown>;
     try {
       parsed = JSON.parse(data) as Record<string, unknown>;
     } catch {
-      return forwarded;
+      return formatSSEEvent(eventType, data);
     }
 
+    // Accumulate real values internally (always unscaled)
     switch (eventType) {
       case "message_start":
         handleMessageStart(parsed);
@@ -171,7 +228,11 @@ export function createStreamAccumulator(): StreamAccumulator {
       // "ping" and unknown events — just forward
     }
 
-    return forwarded;
+    // Rewrite usage in client-facing events when scaling is active
+    const rewritten = rewriteUsage(parsed, eventType);
+    if (rewritten) return formatSSEEvent(eventType, rewritten);
+
+    return formatSSEEvent(eventType, data);
   }
 
   function handleMessageStart(parsed: Record<string, unknown>): void {
@@ -569,8 +630,10 @@ export interface RecallAwareAccumulator extends StreamAccumulator {
  */
 export function createRecallAwareAccumulator(
   recallToolName = "recall",
+  options?: { scaleClientUsage?: boolean },
 ): RecallAwareAccumulator {
-  // Delegate to the standard accumulator for actual accumulation
+  const shouldScale = options?.scaleClientUsage ?? false;
+  // Delegate to the standard accumulator for actual accumulation (never scales — internal only)
   const inner = createStreamAccumulator();
 
   /** Set of upstream block indices that are suppressed (recall). */
@@ -587,6 +650,56 @@ export function createRecallAwareAccumulator(
   let heldBack = "";
   /** Whether we've detected recall in this stream. */
   let recallDetected = false;
+
+  /** Scale usage in a parsed SSE event and return the rewritten JSON, or null if unchanged. */
+  function maybeScaleEvent(parsed: Record<string, unknown>, eventType: string): string | null {
+    if (!shouldScale) return null;
+
+    if (eventType === "message_start") {
+      const message = parsed.message as Record<string, unknown> | undefined;
+      const msgUsage = message?.usage as Record<string, number> | undefined;
+      if (!msgUsage) return null;
+      const scaled = scaleUsageForClient({
+        input_tokens: msgUsage.input_tokens ?? 0,
+        output_tokens: msgUsage.output_tokens ?? 0,
+        cache_read_input_tokens: msgUsage.cache_read_input_tokens,
+        cache_creation_input_tokens: msgUsage.cache_creation_input_tokens,
+      });
+      if (scaled === msgUsage) return null;
+      return JSON.stringify({
+        ...parsed,
+        message: { ...message, usage: { ...msgUsage, ...scaled } },
+      });
+    }
+
+    if (eventType === "message_delta") {
+      const deltaUsage = parsed.usage as Record<string, number> | undefined;
+      if (!deltaUsage || typeof deltaUsage.output_tokens !== "number") return null;
+      // Scale based on total accumulated in the inner accumulator
+      const innerResp = inner.getResponse();
+      const scaled = scaleUsageForClient({
+        input_tokens: innerResp.usage.inputTokens,
+        output_tokens: deltaUsage.output_tokens,
+        cache_read_input_tokens: innerResp.usage.cacheReadInputTokens,
+        cache_creation_input_tokens: innerResp.usage.cacheCreationInputTokens,
+      });
+      return JSON.stringify({
+        ...parsed,
+        usage: { ...deltaUsage, output_tokens: scaled.output_tokens },
+      });
+    }
+
+    return null;
+  }
+
+  /** Format an SSE event, applying usage scaling when active. */
+  function forwardEvent(eventType: string, data: string, parsed?: Record<string, unknown>): string {
+    if (parsed) {
+      const rewritten = maybeScaleEvent(parsed, eventType);
+      if (rewritten) return formatSSEEvent(eventType, rewritten);
+    }
+    return formatSSEEvent(eventType, data);
+  }
 
   function processEvent(eventType: string, data: string): string {
     // Always feed the inner accumulator (it tracks full state)
@@ -652,17 +765,18 @@ export function createRecallAwareAccumulator(
       case "message_delta":
       case "message_stop": {
         if (recallDetected) {
-          // Hold back — caller decides whether to forward or replace
-          heldBack += formatSSEEvent(eventType, data);
+          // Hold back — caller decides whether to forward or replace.
+          // Apply scaling to held-back events too (they may be forwarded later).
+          heldBack += forwardEvent(eventType, data, parsed);
           return "";
         }
         break;
       }
 
-      // message_start, ping, etc. — forward unchanged
+      // message_start, ping, etc. — forward with possible usage scaling
     }
 
-    return formatSSEEvent(eventType, data);
+    return forwardEvent(eventType, data, parsed);
   }
 
   return {


### PR DESCRIPTION
## Summary

Prevents Claude Code from destroying gradient-managed context via auto-compaction through 5 layers of defense. Triggered by a caught compaction event in session `0iOTTzwgLDf6KURW` where the gateway's pattern-based `isCompactionRequest()` missed the detection entirely.

## Changes

### 1. `DISABLE_AUTO_COMPACT=1` in agent launcher (primary defense)
- Injected when launching Claude Code via `lore run claude`
- Prevents auto-compact trigger at the source while keeping manual `/compact` and the "X% until auto-compact" UI
- `packages/gateway/src/cli/agents.ts`, `packages/gateway/src/cli/start.ts`

### 2. Session-aware structural compaction detection
- O(1) Tier-1 header lookup in `handleRequest()` before routing — compares prior vs current message count
- A known session dropping from 19 to 1-3 messages = compaction, regardless of prompt format
- Immune to Claude Code changing its compaction prompt patterns
- `packages/gateway/src/compaction.ts` (`isStructuralCompaction()`), `packages/gateway/src/pipeline.ts`

### 3. Proportional token scaling in API responses (hosted gateway support)
- Scales all usage fields proportionally so Claude Code's `getTokenCountFromUsage()` never exceeds ~90% of the 167K threshold (~150K max reported)
- Internal `calibrate()`, `updateBustRate()`, and all Lore systems see real unscaled values
- Covers all 4 client-facing paths: streaming (processEvent), recall-aware accumulator, continuation stream, and non-streaming responses
- `packages/gateway/src/stream/anthropic.ts`, `packages/gateway/src/pipeline.ts`, `packages/gateway/src/compaction.ts` (`scaleUsageForClient()`)

### 4. Compaction anomaly detection (safety net)
- Warns when message count drops >50% on a normal conversation turn
- Catches client-side compaction paths (session memory compact, microcompact) that make no API call
- `packages/gateway/src/pipeline.ts`

### 5. Raised `MIN_CONTEXT_FLOOR` from 100K to 130K
- With auto-compact disabled, the gradient system can safely use more context
- At default budgets: 84.5K content (32.5K distilled + 52K raw) vs 65K today — 30% more context
- Still well below 167K as a safety buffer
- `packages/core/src/gradient.ts`

## Testing
- `bun run typecheck` — all packages pass
- `bun test` — 1045 tests pass, 0 failures