### PR TITLE
feat: dynamic max_tokens sizing for workers and conversation passthrough

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -5,56 +5,42 @@
 ### Architecture
 
 <!-- lore:019e1349-63c2-72f1-8725-db0ee29efedd -->
-* **3-tier session identification with header learning**: 3-tier session identification: (1) Known headers (x-claude-code-session-id, x-session-affinity, x-parent-session-id); (2) Learned x-\* headers with ID-like values; (3) Fingerprint fallback. identifySession() returns {sessionId, tier}. headerToSessionMap for O(1) lookup.
+* **3-tier session identification with header learning**: 3-tier session identification: (1) Known headers (x-claude-code-session-id, x-session-affinity, x-parent-session-id); (2) Learned x-\* headers with ID-like values; (3) Fingerprint fallback. identifySession() returns {sessionId, tier}.
 
 <!-- lore:019e1405-1594-7e54-a90c-095bb0a2df12 -->
-* **Agent launcher injects environment variables per agent configuration**: Agent launcher in cli/agents.ts provides agent-specific config including binary paths, detection functions, and environment variables. envVars(url) function returns per-agent env setup. Environment merging: base env + agent envVars + explicit overrides. Claude Code agent gets DISABLE\_AUTO\_COMPACT=1 to prevent client-side compaction at 167K tokens, since gateway interception points can't catch all compaction paths (microcompact, session memory).
+* **Agent launcher injects environment variables per agent configuration**: Agent launcher provides agent-specific config including binary paths, detection functions, and environment variables. envVars(url) returns per-agent env setup. Claude Code agent gets DISABLE\_AUTO\_COMPACT=1 to prevent client-side compaction at 167K tokens.
+
+<!-- lore:019e1438-5ff0-77f3-abf8-5c815425f0ec -->
+* **CCH billing signature system for Claude Code request authentication**: CCH (Client-Computed Hash) system authenticates Claude Code requests via xxHash64(bodyBytes, versionSeed) & 0xFFFFF → 5-hex signatures. computeCch() computes hash, formatBillingHeader() creates header with suffix. Pipeline extracts/validates via extractBillingInfo(), resignBody() re-signs modified requests. Core files: gateway/cch.ts, gateway/pipeline.ts.
+
+<!-- lore:019e1430-1cca-7bd3-81a6-9d345b9cdd4b -->
+* **Claude Code seed extraction via brute-force binary scanning**: Claude Code seed extraction via binary scanning: Downloads platform binaries, scans 8-byte-aligned offsets as little-endian uint64. Validates via xxHash64(body, seed) & 0xFFFFF == cch using oracle request/response pairs. Requires 2+ pairs for collision elimination. ~8s scan time with 1-byte fallback. Oracle generation challenges: \`claude\` binary hangs on OAuth/auth flows, filesystem discovery can timeout before API calls. Use isolated temp directories and minimal environments to reduce initialization overhead.
 
 <!-- lore:019e133c-1e2a-72b4-97c9-75965fe2d0f6 -->
-* **Claude Code sends persistent session ID in HTTP headers**: Claude Code session ID: Sends persistent X-Claude-Code-Session-Id header (UUID at startup). Persists across compaction, model changes. Normalizes to lowercase: rawHeaders\['x-claude-code-session-id']. Sub-agents share parent ID.
+* **Claude Code sends persistent session ID in HTTP headers**: Claude Code sends persistent X-Claude-Code-Session-Id header (UUID at startup). Persists across compaction, model changes. Normalizes to lowercase: rawHeaders\['x-claude-code-session-id']. Sub-agents share parent ID.
 
 <!-- lore:019e1330-a34e-7917-9802-35093f041a31 -->
 * **Data management pattern across CLI and web UI**: Unified data management: core/data.ts exports APIs (listProjects, clearProject), CLI data.ts provides terminal interface, gateway ui.ts serves web forms. Both use same core APIs. Clear operations regenerate .lore.md and warn to commit.
 
 <!-- lore:019e1328-d565-7f53-bc81-915c48531370 -->
-* **Gateway HTTP server uses Bun.serve with manual routing**: Gateway uses Bun.serve() on port 6969 with manual if/else routing in fetch() handler. Routes: POST /v1/messages (Anthropic), POST /v1/chat/completions (OpenAI), GET /v1/models, GET /health. Uses jsonResponse(), errorResponse() helpers for consistent response formatting.
+* **Gateway HTTP server uses Bun.serve with manual routing**: Gateway uses Bun.serve() on port 6969 with manual if/else routing in fetch() handler. Routes: POST /v1/messages (Anthropic), POST /v1/chat/completions (OpenAI), GET /v1/models, GET /health. Uses jsonResponse(), errorResponse() helpers.
 
 <!-- lore:019e13f6-44cf-7406-a618-2ef9b4faa99c -->
 * **Git-based project identification with 4-tier resolution hierarchy**: Git-based project identification: 4-tier resolution via git remote + path. ensureProject() tries: (1) exact path; (2) path alias; (3) git remote (prefers upstream > origin); (4) create new. Schema v14 adds git\_remote. Prevents fragmentation across worktrees/clones.
 
-<!-- lore:019e140a-9519-708c-9438-4a8f9d90c608 -->
-* **Gradient system context cap adaptation creates 67K unused window with auto-compact disabled**: Gradient system dynamic context scaling with cost-aware caps: Dynamic context cap tightens to MIN\_CONTEXT\_FLOOR=100K when bustRateEMA>0.8. Cost-aware cap = min(targetBustCost/cacheWriteCost, 100K floor). Default $1 targetBustCost: sonnet-4 uncapped (267K), opus-4-6 at 160K. With DISABLE\_AUTO\_COMPACT=1 and 167K auto-compact disabled, system uses only 65K (25% distilled + 40% raw) leaving 67K unused. Increase targetBustCost or set maxContextTokens override to utilize full window.
-
 <!-- lore:019e13fe-49f6-7107-b47e-c1c1f7e82306 -->
-* **Lore gradient system injects multi-layer context via system prompt prefixes**: Lore gradient system builds 4-layer hierarchical context via system prompt injection: Layers include distillations (gen-0/gen-1+), LTM knowledge, context-specific, and session data. buildPromptPrefix() formats with markdown headers, injects via systemPromptWithGradientContext(). Replaces compaction with progressive knowledge accumulation across conversation history.
+* **Lore gradient system injects multi-layer context via system prompt prefixes**: Lore gradient system builds 4-layer hierarchical context via system prompt injection: distillations, LTM knowledge, context-specific, and session data. buildPromptPrefix() formats with markdown headers, injects via systemPromptWithGradientContext(). Replaces compaction with progressive knowledge accumulation.
 
 <!-- lore:019e1352-b81c-7997-8006-ab66063c4b32 -->
-* **Multiple host binding via Bun.serve instance spawning**: Multiple host binding via Bun.serve spawning: Gateway spawns one Bun.serve() instance per host (single hostname limit). Parses comma-separated LORE\_HOST and --host flags into hosts array. Returns combined stop functions. Agent connections use first host.
-
-<!-- lore:019e140a-9501-7342-a381-1c9a62ce9dd8 -->
-* **Session-state-based compaction detection before pattern matching**: Session-state compaction detection via O(1) headerSessionIndex lookup: handleRequest() restructured with Tier-1 session lookup before routing. Extract sessionId from x-claude-code-session-id header, check sessions\[sessionId].messageCount vs req.messages.length. Drop from 19→1-3 messages = structural compaction. More reliable than pattern matching since works regardless of prompt format. Use isStructuralCompaction(priorState, req) after cheap session lookup.
-
-<!-- lore:019e132b-8785-76e0-85b2-0b5903aa4087 -->
-* **SQLite schema with FTS5 search across messages, distillations, knowledge**: SQLite schema: $XDG\_DATA\_HOME/opencode-lore/lore.db with 6 tables: projects, temporal\_messages, distillations, knowledge, lat\_sections, project\_path\_aliases. FTS5 search on content tables. WAL journal, foreign keys ON. Drivers: bun:sqlite native, node:sqlite compat.
-
-<!-- lore:019e1417-dcb4-7332-a56b-3daccb9c4072 -->
-* **Stream accumulator dual-mode design for usage scaling**: createStreamAccumulator() supports optional client usage scaling via scaleClientUsage parameter. When enabled, processEvent() applies scaleUsageForClient() to message\_start/message\_delta events before forwarding, while internal accumulator.getResponse() retains real values. Used in 3 places: buildStreamingResponse() (with scaling), accumulateStreamResponse() (no scaling for internals), RecallAwareAccumulator (with scaling for forwarded events). Enables compaction prevention without affecting internal token tracking.
-
-<!-- lore:019e132b-1b18-7723-9586-be04f1b16627 -->
-* **Temporal-distillation-knowledge data flow lifecycle**: Temporal-distillation-knowledge data flow: (1) Temporal messages with FTS5, TTL pruning; (2) Gen-0 distillations from 5-30 message segments; (3) Gen-1+ meta-distillations; (4) Knowledge (LTM) entries. Exports to .lore.md for version control. Context transform injects into system prompt via gradient system.
-
-<!-- lore:019e140f-9bb6-7241-a370-3eb591fefe0c -->
-* **Token count flow and interception points for compaction prevention**: Claude Code auto-compacts at 167K tokens via getTokenCountFromUsage() = input\_tokens + cache\_creation\_input\_tokens + cache\_read\_input\_tokens + output\_tokens. Gateway prevention: (1) DISABLE\_AUTO\_COMPACT=1 env var in agent launcher - prevents at source; (2) Structural detection - O(1) session lookup before routing, compaction if messageCount drops 19→1-3; (3) Proportional token scaling - scale all usage fields in client responses to ~90% threshold (~150K max) while preserving real values for internal calibrate(). Scaling applied via scaleUsageForClient() in both standard pipeline and recall-aware accumulator (message\_start/message\_delta forwarding paths); (4) Pattern matching fallback; (5) Anomaly detection. Key: postResponse() runs with real tokens for calibrate()/updateBustRate(), then scale response for client.
-
-### Decision
-
-<!-- lore:019e1418-c451-7e82-9812-ec3ab91d58b4 -->
-* **Switched from read-only plan mode to build mode**: switched from read-only plan mode to build mode,
+* **Multiple host binding via Bun.serve instance spawning**: Gateway spawns one Bun.serve() instance per host (single hostname limit). Parses comma-separated LORE\_HOST and --host flags into hosts array. Returns combined stop functions. Agent connections use first host.
 
 ### Gotcha
 
+<!-- lore:019e143d-5bab-7d1a-b982-58ec976ae421 -->
+* **Claude Code binary requires proper filesystem context for API calls**: Claude Code binary performs extensive filesystem scanning before making API calls, causing timeouts in isolated environments. Binary initializes OAuth flows, scans project directories, and needs proper home/working directories. Attempts to capture network traffic via minimal environments (empty dirs, fake API keys) fail as binary never reaches network phase. Use established project directories with proper auth setup for successful API interaction.
+
 <!-- lore:019e1403-b62a-7944-8d5e-f6d70ddc2801 -->
-* **Gradient layer resets indicate undetected Claude Code compaction events**: Claude Code compaction detection and prevention: Claude Code auto-compacts at ~167K via multiple paths: LLM summary (interceptable), session memory compact, and microcompact (client-side only). Gateway detection via gradient layer drops (4→0) with system prompt changes or message count drops (19→3). Use DISABLE\_AUTO\_COMPACT=1 for reliable prevention. Session-state detection more reliable than pattern matching since compaction bypasses API interception.
+* **Gradient layer resets indicate undetected Claude Code compaction events**: Claude Code compaction detection via gradient layer resets: Auto-compacts through multiple paths. Gateway detects via gradient layer drops (4→0) with system prompt changes or message count drops (19→3). Session-state detection more reliable than pattern matching. Prevention: DISABLE\_AUTO\_COMPACT=1 env var or token scaling via scaleUsageForClient().
 
 ### Pattern
 
@@ -62,13 +48,13 @@
 * **Gradient system uses layerMap for O(1) context lookup optimization**: Gradient layerMap optimization: O(1) context lookup via layerMap.set(layer.id, layer) during init, layerMap.get(contextId) for retrieval. Eliminates O(n) array searches in layers 2,3,4. Essential for scaling with large context histories.
 
 <!-- lore:019e132b-1b1f-798a-ae69-71a7f40bdeb0 -->
-* **Lore.md file managed via UUID-tracked markdown with import/export cycle**: Lore.md UUID-tracked markdown: .lore.md contains knowledge as markdown with lore:UUID markers. exportLoreFile() writes DB entries by category. importLoreFile() parses: known UUID updates, unknown creates with ID, no UUID creates new UUIDv7. shouldImportLoreFile() detects changes via hash.
+* **Lore.md file managed via UUID-tracked markdown with import/export cycle**: .lore.md contains knowledge as markdown with lore:UUID markers. exportLoreFile() writes DB entries by category. importLoreFile() parses: known UUID updates, unknown creates with ID, no UUID creates new UUIDv7. shouldImportLoreFile() detects changes via hash.
 
 <!-- lore:019e1417-dcb7-7e19-ba62-122854c393bc -->
-* **scaleUsageForClient utility for consistent token capping**: scaleUsageForClient() utility in compaction.ts applies 40% scaling factor to all usage fields: input\_tokens, cache\_creation\_input\_tokens, cache\_read\_input\_tokens, output\_tokens. Prevents Claude Code auto-compact by keeping reported usage below 167K threshold while preserving real values for internal tracking. Used in both streaming (via createStreamAccumulator) and non-streaming response paths for consistent client-side token capping.
+* **scaleUsageForClient utility for consistent token capping**: scaleUsageForClient applies 40% scaling to all usage fields (input\_tokens, cache\_creation\_input\_tokens, cache\_read\_input\_tokens, output\_tokens) keeping reported usage below 167K threshold to prevent Claude Code auto-compact while preserving real values for internal tracking.
 
-<!-- lore:019e1418-c3ca-767e-83ea-b46c0cf8e0af -->
-* **Token scaling in recall-aware accumulator requires manual forwarding**: Recall-aware accumulator in pipeline.ts builds independent forwarded events rather than using inner createStreamAccumulator() output. Must apply scaleUsageForClient() to message\_start/message\_delta events at 3 forwarding points: (1) message\_start fallthrough, (2) message\_delta/message\_stop fallthrough when not recall, (3) continuation stream message\_delta forwarding. Held-back events auto-scale via forwardEvent() helper but continuation stream needs explicit scaling. Use static import of scaleUsageForClient to avoid dynamic imports in hot loops.
+<!-- lore:019e1439-4aa6-7313-a63f-c2409129b6d1 -->
+* **sessionNeedsBilling sticky flag prevents billing header loss across turns**: sessionNeedsBilling Map tracks bearer-token sessions requiring billing headers. captureBillingPrefix() sets sticky flag when x-anthropic-billing-header detected. Flag persists for session lifetime. buildBillingBlock() returns null for unflagged sessions.
 
-<!-- lore:019e138b-7acd-7d07-b3bf-2ab24bb2e128 -->
-* **urgentDistillation refactored from singleton to session map**: urgentDistillation session isolation: Replaced module singleton with session-keyed Map. Pattern: urgentDistillationMap.set(sessionId, true) to flag, consumeUrgentDistillation(sessionId) returns and deletes atomically. Fixes cross-session race conditions.
+<!-- lore:019e1439-c675-76be-8c0b-3e11b5390dd4 -->
+* **Version suffix computation uses message chars at indices 4,7,20**: cc\_version suffix format: MAJOR.MINOR.PATCH.XXX where XXX = sha256(WORKER\_SALT + chars + version)\[:3]. chars = user message characters at string indices 4, 7, 20 (pad with '0' if shorter). Makes billing header per-turn-unique for replay attack prevention.

--- a/packages/core/src/curator.ts
+++ b/packages/core/src/curator.ts
@@ -82,7 +82,7 @@ export async function run(input: {
   const responseText = await input.llm.prompt(
     CURATOR_SYSTEM,
     userContent,
-    { model, workerID: "lore-curator", thinking: false, sessionID: input.sessionID },
+    { model, workerID: "lore-curator", thinking: false, sessionID: input.sessionID, maxTokens: 2048 },
   );
   if (!responseText) return { created: 0, updated: 0, deleted: 0 };
 
@@ -185,7 +185,7 @@ export async function consolidate(input: {
   const responseText = await input.llm.prompt(
     CONSOLIDATION_SYSTEM,
     userContent,
-    { model, workerID: "lore-curator", thinking: false, sessionID: input.sessionID },
+    { model, workerID: "lore-curator", thinking: false, sessionID: input.sessionID, maxTokens: 4096 },
   );
   if (!responseText) return { updated: 0, deleted: 0 };
 

--- a/packages/core/src/distillation.ts
+++ b/packages/core/src/distillation.ts
@@ -61,6 +61,23 @@ export function detectSegments(
   return splitSegments(messages, maxSegment);
 }
 
+/**
+ * Compute the max_tokens budget for a worker LLM call.
+ *
+ * @param inputTokens  Estimated source token count
+ * @param ratio        Compression ratio (0.0–1.0) — output ≈ ratio × input
+ * @param floor        Minimum output tokens
+ * @param cap          Maximum output tokens
+ */
+export function workerTokenBudget(
+  inputTokens: number,
+  ratio: number,
+  floor: number,
+  cap: number,
+): number {
+  return Math.max(floor, Math.min(Math.ceil(inputTokens * ratio), cap));
+}
+
 /** Minimum segment size — segments smaller than this get merged. */
 const MIN_SEGMENT = 3;
 
@@ -634,10 +651,12 @@ async function distillSegment(input: {
   });
 
   const model = input.model ?? config().model;
+  const sourceTokens = input.messages.reduce((sum, m) => sum + m.tokens, 0);
+  const maxTokens = workerTokenBudget(sourceTokens, 0.25, 1024, 8192);
   const responseText = await input.llm.prompt(
     DISTILLATION_SYSTEM,
     userContent,
-    { model, workerID: "lore-distill", thinking: false, urgent: input.urgent, sessionID: input.sessionID },
+    { model, workerID: "lore-distill", thinking: false, urgent: input.urgent, sessionID: input.sessionID, maxTokens },
   );
   if (!responseText) return null;
 
@@ -646,7 +665,6 @@ async function distillSegment(input: {
 
   // Compute context health metrics before storing.
   const distilledTokens = Math.ceil(result.observations.length / 3);
-  const sourceTokens = input.messages.reduce((sum, m) => sum + m.tokens, 0);
   const rComp = compressionRatio(distilledTokens, sourceTokens);
   const cNorm = temporal.temporalCnorm(input.messages.map((m) => m.created_at));
 
@@ -731,10 +749,12 @@ export async function metaDistill(input: {
   const userContent = recursiveUser(existing, priorMeta?.observations);
 
   const model = input.model ?? config().model;
+  const inputTokens = Math.ceil(userContent.length / 3);
+  const maxTokens = workerTokenBudget(inputTokens, 0.25, 1024, 8192);
   const responseText = await input.llm.prompt(
     RECURSIVE_SYSTEM,
     userContent,
-    { model, workerID: "lore-distill", thinking: false, urgent: input.urgent, sessionID: input.sessionID },
+    { model, workerID: "lore-distill", thinking: false, urgent: input.urgent, sessionID: input.sessionID, maxTokens },
   );
   if (!responseText) return null;
 

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -335,7 +335,7 @@ export async function expandQuery(
       llm.prompt(
         QUERY_EXPANSION_SYSTEM,
         `Input: "${query}"`,
-        { model, workerID: "lore-query-expand", thinking: false, urgent: true, sessionID },
+        { model, workerID: "lore-query-expand", thinking: false, urgent: true, sessionID, maxTokens: 256 },
       ),
       new Promise<null>((resolve) => setTimeout(() => resolve(null), TIMEOUT_MS)),
     ]);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -245,6 +245,21 @@ export interface LLMClient {
        * auth through their own mechanisms.
        */
       sessionID?: string;
+      /**
+       * Maximum output tokens for this call. When absent, the adapter
+       * uses its built-in default (typically 8192).
+       *
+       * Worker call sites should set this explicitly based on expected
+       * output size to avoid wasting tokens on unnecessarily large
+       * output budgets.
+       *
+       * Adapter behavior:
+       * - Gateway: uses as `max_tokens` in the API request body
+       * - Pi: passes as `maxTokens` to `complete()`
+       * - OpenCode: cannot honor — SDK has no maxTokens on session.prompt();
+       *   the field is silently ignored
+       */
+      maxTokens?: number;
     },
   ): Promise<string | null>;
 }

--- a/packages/core/test/distillation.test.ts
+++ b/packages/core/test/distillation.test.ts
@@ -6,6 +6,7 @@ import {
   latestMetaObservations,
   metaDistill,
   detectSegments,
+  workerTokenBudget,
   type Distillation,
 } from "../src/distillation";
 import * as temporal from "../src/temporal";
@@ -978,5 +979,44 @@ describe("context health columns", () => {
     const valuedRow = rows.find((r) => r.r_compression !== null);
     expect(nullRow).toBeDefined();
     expect(valuedRow).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// workerTokenBudget
+// ---------------------------------------------------------------------------
+
+describe("workerTokenBudget", () => {
+  test("returns computed value within floor and cap", () => {
+    // 15000 * 0.25 = 3750 — between floor (1024) and cap (8192)
+    expect(workerTokenBudget(15000, 0.25, 1024, 8192)).toBe(3750);
+  });
+
+  test("returns floor when computed is below floor", () => {
+    // 100 * 0.25 = 25 — below floor
+    expect(workerTokenBudget(100, 0.25, 1024, 8192)).toBe(1024);
+  });
+
+  test("returns cap when computed exceeds cap", () => {
+    // 100000 * 0.25 = 25000 — above cap
+    expect(workerTokenBudget(100000, 0.25, 1024, 8192)).toBe(8192);
+  });
+
+  test("returns floor for zero input", () => {
+    expect(workerTokenBudget(0, 0.25, 1024, 8192)).toBe(1024);
+  });
+
+  test("returns floor for negative input", () => {
+    expect(workerTokenBudget(-500, 0.25, 1024, 8192)).toBe(1024);
+  });
+
+  test("handles ratio of 0.5 (compaction)", () => {
+    // 10000 * 0.5 = 5000
+    expect(workerTokenBudget(10000, 0.5, 2048, 20000)).toBe(5000);
+  });
+
+  test("ceil rounds up fractional tokens", () => {
+    // 10001 * 0.25 = 2500.25 → ceil = 2501
+    expect(workerTokenBudget(10001, 0.25, 1024, 8192)).toBe(2501);
   });
 });

--- a/packages/gateway/src/batch-queue.ts
+++ b/packages/gateway/src/batch-queue.ts
@@ -551,7 +551,7 @@ export function createBatchLLMClient(
           customId,
           params: {
             model: model.modelID,
-            max_tokens: 8192,
+            max_tokens: opts?.maxTokens ?? 8192,
             system: systemPayload ?? system,
             messages: [{ role: "user", content: user }],
           },

--- a/packages/gateway/src/cch.ts
+++ b/packages/gateway/src/cch.ts
@@ -168,6 +168,11 @@ export function resignBody(
 const BILLING_HEADER_RE =
   /^x-anthropic-billing-header:\s*cc_version=[^;]+;\s*cc_entrypoint=[^;]+;\s*cch=[0-9a-fA-F]+;/;
 
+/** Check if a system prompt contains the Claude Code billing header. */
+export function hasBillingHeader(system: string): boolean {
+  return BILLING_HEADER_RE.test(system);
+}
+
 /** Sessions that use bearer-token auth and need billing headers on workers. */
 const sessionNeedsBilling = new Map<string, boolean>();
 

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -174,7 +174,7 @@ export function createGatewayLLMClient(
         // Build body with cch=00000 placeholder, then sign if needed
         let body = JSON.stringify({
           model: model.modelID,
-          max_tokens: 8192,
+          max_tokens: opts?.maxTokens ?? 8192,
           system: systemPayload,
           messages: [{ role: "user", content: user }],
         });

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -100,7 +100,8 @@ import type { UpstreamInterceptor } from "./recorder";
 import { startIdleScheduler, buildIdleWorkHandler } from "./idle";
 import { getWorkerModel, resetWorkerModelState, fetchModelData, getModelEntrySync } from "./worker-model";
 import * as Sentry from "@sentry/bun";
-import { captureBillingPrefix, resignBody } from "./cch";
+import { captureBillingPrefix, hasBillingHeader, resignBody } from "./cch";
+import { detectClientType } from "./session";
 import { analyzeCacheTurn, categorizeBust } from "./cache-analytics";
 import {
    setSentryRequestContext,
@@ -294,6 +295,55 @@ function getModelSpec(model: string): ModelSpec {
         : undefined,
     inputCostPerMillion: entry.cost?.input ?? undefined,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Dynamic max_tokens sizing for non-Claude-Code clients
+// ---------------------------------------------------------------------------
+
+const MAX_TOKENS_FLOOR = 8192;
+const MAX_TOKENS_BUFFER = 1000;
+const MAX_TOKENS_EMA_MULTIPLIER = 3;
+
+/**
+ * Compute a right-sized `max_tokens` value for a conversation turn using
+ * a hybrid headroom + history approach.
+ *
+ * - Turn 1 (no history): returns `ceiling` (32K) — matches Claude Code.
+ * - Turns 2+: 3× output EMA, clamped by context headroom and ceiling.
+ * - After truncation (`stop_reason: "length"`): jumps back to ceiling.
+ *
+ * Exported for testing.
+ */
+export function computeMaxTokens(
+  modelOutput: number,
+  modelContext: number,
+  outputEMA: number | undefined,
+  lastStopReason: string | undefined,
+  lastInputTokens: number | undefined,
+): number {
+  const ceiling = Math.min(modelOutput, 32_000);
+
+  // Turn 1: no history — use ceiling (matches Claude Code default)
+  if (outputEMA == null) return ceiling;
+
+  // Headroom: how much output the context can afford given last known input
+  const estimatedInput = lastInputTokens ?? 0;
+  const headroom = Math.max(
+    MAX_TOKENS_FLOOR,
+    modelContext - estimatedInput - MAX_TOKENS_BUFFER,
+  );
+
+  // History: 3× recent output EMA — generous multiplier to absorb spikes
+  let adaptive = Math.max(MAX_TOKENS_FLOOR, MAX_TOKENS_EMA_MULTIPLIER * outputEMA);
+
+  // Safety: if last turn was truncated, jump to ceiling
+  if (lastStopReason === "length") {
+    adaptive = ceiling;
+  }
+
+  // Clamp: history within headroom, within ceiling
+  return Math.min(headroom, Math.max(adaptive, MAX_TOKENS_FLOOR), ceiling);
 }
 
 // ---------------------------------------------------------------------------
@@ -1160,6 +1210,24 @@ function postResponse(
     sessionState.turnsSinceCuration =
       (sessionState.turnsSinceCuration ?? 0) + 1;
 
+    // --- Output tracking for dynamic max_tokens sizing ---
+    sessionState.lastStopReason = resp.stopReason;
+    sessionState.lastInputTokens =
+      (resp.usage.inputTokens ?? 0) +
+      (resp.usage.cacheReadInputTokens ?? 0) +
+      (resp.usage.cacheCreationInputTokens ?? 0);
+    const outputTokens = resp.usage.outputTokens;
+    if (outputTokens > 0) {
+      const EMA_ALPHA = 0.3;
+      sessionState.outputTokensEMA =
+        sessionState.outputTokensEMA == null
+          ? outputTokens
+          : Math.round(
+              sessionState.outputTokensEMA * (1 - EMA_ALPHA) +
+                outputTokens * EMA_ALPHA,
+            );
+    }
+
     // --- Schedule background work (fire-and-forget) ---
     scheduleBackgroundWork(sessionState, config);
   } catch (e) {
@@ -1312,10 +1380,13 @@ async function handleCompaction(
     ? `${context}\n\n---\n\n${compactPrompt}`
     : compactPrompt;
 
+  const compactInputTokens = Math.ceil(userContent.length / 3);
+  const compactMaxTokens = Math.max(2048, Math.min(Math.ceil(compactInputTokens * 0.5), 20_000));
   const summaryText = await llm.prompt(compactPrompt, userContent, {
     model: cfg.model,
     workerID: "lore-compact",
     urgent: true, // Client is blocking on this response
+    maxTokens: compactMaxTokens,
   });
 
   const summary = summaryText ?? "(Compaction failed — no summary generated.)";
@@ -1490,6 +1561,31 @@ async function handleConversationTurn(
       cfg.budget.targetBustCost,
       modelSpec.cacheWriteCost,
     ));
+  }
+
+  // --- 4c. Dynamic max_tokens sizing for non-Claude-Code clients ---
+  // Claude Code manages its own max_tokens (32K for modern models). Non-CC
+  // clients (OpenCode, generic) often send low/missing values (defaults to
+  // 4096 in ingress parsing). Apply a hybrid headroom + history algorithm
+  // that tightens from the 32K ceiling based on actual output patterns.
+  const clientType = detectClientType(req.rawHeaders);
+  const isCC = clientType === "claude-code" || hasBillingHeader(req.system);
+  if (!isCC) {
+    const computed = computeMaxTokens(
+      modelSpec.output,
+      modelSpec.context,
+      sessionState.outputTokensEMA,
+      sessionState.lastStopReason,
+      sessionState.lastInputTokens,
+    );
+    if (req.maxTokens !== computed) {
+      log.info(
+        `max_tokens: ${req.maxTokens} → ${computed} ` +
+          `(client=${clientType}, ema=${sessionState.outputTokensEMA ?? "none"}, ` +
+          `lastStop=${sessionState.lastStopReason ?? "none"})`,
+      );
+      req.maxTokens = computed;
+    }
   }
 
   // --- 5. Cold-cache idle-resume ---

--- a/packages/gateway/src/session.ts
+++ b/packages/gateway/src/session.ts
@@ -224,6 +224,42 @@ export const MESSAGE_COUNT_PROXIMITY_THRESHOLD = 20;
 // Tier 1: Known session headers
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Client type detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Client type for behavioral decisions (e.g. max_tokens sizing).
+ *
+ * - "claude-code": manages its own max_tokens (32K for modern models)
+ * - "opencode": uses x-session-affinity, currently sends no max_tokens
+ * - "generic": unknown client
+ */
+export type ClientType = "claude-code" | "opencode" | "generic";
+
+/**
+ * Detect the client type from request headers.
+ *
+ * Detection hierarchy:
+ *  1. x-claude-code-session-id → "claude-code"
+ *  2. x-session-affinity → "opencode"
+ *  3. absence of all → "generic"
+ *
+ * For edge cases (Claude Code OAuth without session header), callers can
+ * additionally check hasBillingHeader() on the system prompt.
+ */
+export function detectClientType(
+  rawHeaders: Record<string, string>,
+): ClientType {
+  if (rawHeaders["x-claude-code-session-id"]) return "claude-code";
+  if (rawHeaders["x-session-affinity"]) return "opencode";
+  return "generic";
+}
+
+// ---------------------------------------------------------------------------
+// Session identification
+// ---------------------------------------------------------------------------
+
 /**
  * Well-known HTTP headers that carry a persistent, unique session ID.
  * Checked in order — first match wins.

--- a/packages/gateway/src/translate/types.ts
+++ b/packages/gateway/src/translate/types.ts
@@ -244,4 +244,13 @@ export type SessionState = {
   /** Candidate headers being tracked during the Tier 2 learning phase.
    *  Key: header name. Value: last seen value + consecutive stable turn count. */
   candidateHeaders?: Map<string, { value: string; seenCount: number }>;
+
+  // --- Dynamic max_tokens sizing ---
+
+  /** EMA of output tokens across recent turns (α=0.3). */
+  outputTokensEMA?: number;
+  /** Stop reason from the last completed turn (e.g. "end_turn", "tool_use", "length"). */
+  lastStopReason?: string;
+  /** Total input tokens from the last completed turn (for headroom calculation). */
+  lastInputTokens?: number;
 };

--- a/packages/gateway/test/max-tokens.test.ts
+++ b/packages/gateway/test/max-tokens.test.ts
@@ -1,0 +1,167 @@
+import { describe, test, expect } from "bun:test";
+import { computeMaxTokens } from "../src/pipeline";
+import { detectClientType } from "../src/session";
+import { hasBillingHeader } from "../src/cch";
+
+// ---------------------------------------------------------------------------
+// computeMaxTokens
+// ---------------------------------------------------------------------------
+
+describe("computeMaxTokens", () => {
+  const MODEL_OUTPUT = 128_000; // e.g. Opus 4.x
+  const MODEL_CONTEXT = 200_000;
+
+  test("returns ceiling (32K) on first turn with no history", () => {
+    expect(
+      computeMaxTokens(MODEL_OUTPUT, MODEL_CONTEXT, undefined, undefined, undefined),
+    ).toBe(32_000);
+  });
+
+  test("returns ceiling capped by model output limit", () => {
+    // Model with only 8192 max output → ceiling = 8192
+    expect(
+      computeMaxTokens(8192, 200_000, undefined, undefined, undefined),
+    ).toBe(8192);
+  });
+
+  test("uses 3× EMA when history is available", () => {
+    // EMA 3000 → 3 × 3000 = 9000, above floor (8192)
+    expect(
+      computeMaxTokens(MODEL_OUTPUT, MODEL_CONTEXT, 3000, "end_turn", 50_000),
+    ).toBe(9000);
+  });
+
+  test("returns floor when 3× EMA is below floor", () => {
+    // EMA 1000 → 3 × 1000 = 3000, below floor (8192)
+    expect(
+      computeMaxTokens(MODEL_OUTPUT, MODEL_CONTEXT, 1000, "end_turn", 50_000),
+    ).toBe(8192);
+  });
+
+  test("returns floor when EMA is zero", () => {
+    // EMA explicitly 0 (not undefined) → 3 × 0 = 0, below floor
+    // Note: EMA of 0 is distinct from undefined (no history)
+    expect(
+      computeMaxTokens(MODEL_OUTPUT, MODEL_CONTEXT, 0, "end_turn", 50_000),
+    ).toBe(8192);
+  });
+
+  test("jumps to ceiling after truncation (stop_reason=length)", () => {
+    // EMA 1000 would normally yield floor (8192), but truncation bumps to ceiling
+    expect(
+      computeMaxTokens(MODEL_OUTPUT, MODEL_CONTEXT, 1000, "length", 50_000),
+    ).toBe(32_000);
+  });
+
+  test("caps by headroom when context is nearly full", () => {
+    // Input 195_000 → headroom = 200_000 - 195_000 - 1000 = 4000 → clamped to floor 8192
+    // EMA 20_000 → 3 × 20_000 = 60_000 but headroom is 8192
+    expect(
+      computeMaxTokens(MODEL_OUTPUT, MODEL_CONTEXT, 20_000, "end_turn", 195_000),
+    ).toBe(8192);
+  });
+
+  test("headroom calculation with moderate input", () => {
+    // Input 170_000 → headroom = 200_000 - 170_000 - 1000 = 29_000
+    // EMA 15_000 → 3 × 15_000 = 45_000, clamped by headroom → 29_000
+    expect(
+      computeMaxTokens(MODEL_OUTPUT, MODEL_CONTEXT, 15_000, "end_turn", 170_000),
+    ).toBe(29_000);
+  });
+
+  test("adaptive stays within ceiling for large EMA", () => {
+    // EMA 20_000 → 3 × 20_000 = 60_000, but ceiling = 32_000
+    expect(
+      computeMaxTokens(MODEL_OUTPUT, MODEL_CONTEXT, 20_000, "end_turn", 50_000),
+    ).toBe(32_000);
+  });
+
+  test("handles missing lastInputTokens gracefully", () => {
+    // No last input → estimatedInput = 0 → headroom = context - 0 - buffer
+    // EMA 3000 → adaptive = 9000
+    expect(
+      computeMaxTokens(MODEL_OUTPUT, MODEL_CONTEXT, 3000, "end_turn", undefined),
+    ).toBe(9000);
+  });
+
+  test("tool_use stop reason does not trigger ceiling jump", () => {
+    // Only "length" triggers the safety bump
+    expect(
+      computeMaxTokens(MODEL_OUTPUT, MODEL_CONTEXT, 1000, "tool_use", 50_000),
+    ).toBe(8192);
+  });
+
+  test("end_turn stop reason does not trigger ceiling jump", () => {
+    expect(
+      computeMaxTokens(MODEL_OUTPUT, MODEL_CONTEXT, 1000, "end_turn", 50_000),
+    ).toBe(8192);
+  });
+
+  test("small model output limits ceiling accordingly", () => {
+    // Sonnet-like model with 16K output limit
+    // EMA 3000 → adaptive = 9000, ceiling = 16_000
+    expect(
+      computeMaxTokens(16_000, 200_000, 3000, "end_turn", 50_000),
+    ).toBe(9000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectClientType
+// ---------------------------------------------------------------------------
+
+describe("detectClientType", () => {
+  test("detects Claude Code via x-claude-code-session-id header", () => {
+    expect(
+      detectClientType({ "x-claude-code-session-id": "abc-123-uuid" }),
+    ).toBe("claude-code");
+  });
+
+  test("detects OpenCode via x-session-affinity header", () => {
+    expect(
+      detectClientType({ "x-session-affinity": "nano-id-value" }),
+    ).toBe("opencode");
+  });
+
+  test("returns generic when no known headers", () => {
+    expect(detectClientType({})).toBe("generic");
+    expect(detectClientType({ "x-custom-header": "value" })).toBe("generic");
+  });
+
+  test("Claude Code wins when both headers present", () => {
+    expect(
+      detectClientType({
+        "x-claude-code-session-id": "abc",
+        "x-session-affinity": "def",
+      }),
+    ).toBe("claude-code");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasBillingHeader
+// ---------------------------------------------------------------------------
+
+describe("hasBillingHeader", () => {
+  test("returns true for system prompt with billing header", () => {
+    const system =
+      "x-anthropic-billing-header: cc_version=2.1.37.abc; cc_entrypoint=cli; cch=a75d0;\n" +
+      "You are a helpful assistant.";
+    expect(hasBillingHeader(system)).toBe(true);
+  });
+
+  test("returns false for system prompt without billing header", () => {
+    expect(hasBillingHeader("You are a helpful assistant.")).toBe(false);
+  });
+
+  test("returns false for empty system prompt", () => {
+    expect(hasBillingHeader("")).toBe(false);
+  });
+
+  test("returns false when billing header is not at start", () => {
+    const system =
+      "You are a helpful assistant.\n" +
+      "x-anthropic-billing-header: cc_version=2.1.37.abc; cc_entrypoint=cli; cch=a75d0;";
+    expect(hasBillingHeader(system)).toBe(false);
+  });
+});

--- a/packages/pi/src/llm-adapter.ts
+++ b/packages/pi/src/llm-adapter.ts
@@ -36,6 +36,7 @@ export function createPiLLMClient(
         model?: { providerID: string; modelID: string };
         workerID?: string;
         thinking?: boolean;
+        maxTokens?: number;
       },
     ): Promise<string | null> {
       // Resolve the model: opts.model (per-call override) > defaultModel (session model)
@@ -82,7 +83,7 @@ export function createPiLLMClient(
           {
             apiKey: auth.apiKey,
             headers: auth.headers,
-            maxTokens: 8192,
+            maxTokens: opts?.maxTokens ?? 8192,
             // Surface the ctx.signal if it's defined — lets user abort
             // cancel pending worker LLM calls. Defined during active turns.
             signal: ctx.signal,


### PR DESCRIPTION
## Summary

- **Right-size `max_tokens` across all worker LLM calls** instead of the blanket 8192 default — distillation uses a compression-ratio formula, curation/query-expansion use fixed budgets, compaction cap raised to 20K matching Claude Code
- **Add dynamic per-turn `max_tokens` for non-Claude-Code conversation clients** using a hybrid headroom + history algorithm (3× output EMA, 8192 floor, 32K ceiling, automatic recovery after truncation)
- **Leave Claude Code clients untouched** — they manage their own values correctly

## Track 1: Worker max_tokens

Adds `maxTokens?: number` to `LLMClient.prompt()` opts, wired through all 3 adapters (gateway, batch queue, Pi).

New `workerTokenBudget()` utility computes `clamp(floor, ceil(input × ratio), cap)`.

| Worker | Before | After |
|--------|--------|-------|
| Gen-0 distillation | 8192 | `input × 0.25` (floor 1024, cap 8192) |
| Meta-distillation | 8192 | `input × 0.25` (floor 1024, cap 8192) |
| Curator extraction | 8192 | 2048 fixed |
| Curator consolidation | 8192 | 4096 fixed |
| Query expansion | 8192 | 256 fixed |
| Compaction summary | 8192 | `input × 0.5` (floor 2048, cap 20000) |

## Track 2: Dynamic conversation max_tokens

For non-Claude-Code clients (OpenCode, generic), applies a hybrid algorithm:

- **Turn 1**: 32K ceiling (matches Claude Code default)
- **Turns 2+**: `3 × outputEMA` — tightens based on actual usage patterns
- **After truncation** (`stop_reason: "length"`): immediately restores ceiling
- **Context pressure**: headroom cap prevents overflow as input grows
- **Floor**: 8192 minimum protects against output spikes in agentic flows

Detection via `x-claude-code-session-id` header + billing header check. Claude Code requests pass through unchanged.

New `SessionState` fields: `outputTokensEMA`, `lastStopReason`, `lastInputTokens` — tracked in `postResponse()`.

## Testing

- 7 `workerTokenBudget` unit tests
- 12 `computeMaxTokens` unit tests (ceiling, EMA, floor, headroom, truncation recovery)
- 4 `detectClientType` + 4 `hasBillingHeader` tests
- All 1073 existing tests pass, all 4 packages typecheck clean