### PR TITLE
feat: speculative cache warming with survival analysis and user controls

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -185,8 +185,24 @@ export const LoreConfig = z.object({
        *    downgrades when <20%. Auto-syncs idleResumeMinutes to 60 when 1h is active.
        *  Default: "auto". */
       conversationTTL: z.enum(["5m", "1h", "auto"]).default("auto"),
+      /** Speculative cache warming — sends max_tokens:0 keepalive requests to
+       *  refresh the Anthropic prompt cache before it expires. Uses survival
+       *  analysis on inter-turn gaps to predict whether the user will return. */
+      warming: z
+        .object({
+          /** Enable cache warming. Default: true. */
+          enabled: z.boolean().default(true),
+          /** Override the survival probability threshold below which warming is
+           *  skipped. Default: auto-derived from cache read/write cost ratio
+           *  (~0.08 for 5m TTL, ~0.05 for 1h TTL). */
+          minReturnProbability: z.number().min(0).max(1).optional(),
+        })
+        .default({ enabled: true }),
     })
-    .default({ conversationTTL: "auto" }),
+    .default({
+      conversationTTL: "auto",
+      warming: { enabled: true },
+    }),
   crossProject: z.boolean().default(false),
   agentsFile: z
     .object({

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -4,7 +4,7 @@ import { mkdirSync } from "fs";
 import { homedir } from "os";
 import { getGitRemote } from "./git";
 
-const SCHEMA_VERSION = 14;
+const SCHEMA_VERSION = 15;
 
 const MIGRATIONS: string[] = [
   `
@@ -382,6 +382,27 @@ const MIGRATIONS: string[] = [
   CREATE TABLE IF NOT EXISTS project_path_aliases (
     path TEXT PRIMARY KEY,
     project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE
+  );
+  `,
+
+  `
+  -- Version 15: Cache warming survival histograms.
+  --
+  -- Persists global (per-project, per-time-slot) inter-turn gap histograms
+  -- across gateway restarts. These histograms feed the survival analysis
+  -- model that decides whether to send speculative cache-warming pings.
+  -- Without persistence, the model has no data until enough turns rebuild
+  -- the histogram from scratch (cold start problem).
+  --
+  -- counts: JSON array of bin counts (21 elements: 20 bins + 1 overflow).
+  -- total: Sum of counts (denormalized for fast reads).
+  CREATE TABLE IF NOT EXISTS warmup_histograms (
+    project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    time_slot TEXT NOT NULL,
+    counts TEXT NOT NULL DEFAULT '[]',
+    total INTEGER NOT NULL DEFAULT 0,
+    updated_at INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (project_id, time_slot)
   );
   `,
 ];

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -22,7 +22,7 @@ describe("db", () => {
     const row = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(row.version).toBe(14);
+    expect(row.version).toBe(15);
   });
 
   test("distillation_fts virtual table exists", () => {

--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -1,0 +1,843 @@
+/**
+ * Speculative cache warming — sends keepalive requests to refresh
+ * Anthropic's prompt cache before it expires.
+ *
+ * Uses survival analysis on inter-turn gaps to predict whether the user
+ * will return before the cache TTL expires. If the expected value of
+ * warming (P(return) × cache_miss_savings) exceeds the warmup cost
+ * (cache_read_cost), sends a max_tokens:0 request that refreshes the
+ * cache without generating output.
+ *
+ * Key design decisions:
+ *  - Cache keys are computed from tokenized prompt content (tools →
+ *    system → messages), NOT raw JSON bytes. max_tokens, stream, and
+ *    temperature are not part of the cache key. Confirmed by Anthropic
+ *    pre-warming docs and cache invalidation table.
+ *  - The normalized lastRequestBody from cache-analytics is sufficient
+ *    for replay — cch/version suffix normalization doesn't affect the
+ *    cache key (those are billing verification, not prompt content).
+ *  - Global circuit breaker: if 3 warmup requests cause cache writes
+ *    instead of reads (meaning the warmup body doesn't match the cached
+ *    prefix), ALL warming is disabled for the process lifetime. This
+ *    prevents burning money if our assumptions about cache key computation
+ *    are wrong.
+ */
+
+import { log, config as loreConfig, db, projectId } from "@loreai/core";
+import type {
+  InterTurnHistogram,
+  SurvivalModel,
+  TimeSlot,
+  WarmupResult,
+  WarmupState,
+  SessionState,
+} from "./translate/types";
+import { decompressBody } from "./cache-analytics";
+import { resolveAuth, authHeaders } from "./auth";
+import { resignBody } from "./cch";
+import { resolveUpstreamRoute } from "./config";
+import { getModelEntrySync } from "./worker-model";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Log-scale histogram bin edges (ms). High resolution around the 5m and
+ * 1h TTL boundaries where the warming decision matters most.
+ */
+export const HISTOGRAM_BINS: readonly number[] = [
+  10_000,    // 10s
+  20_000,    // 20s
+  30_000,    // 30s
+  45_000,    // 45s
+  60_000,    // 1m
+  90_000,    // 1.5m
+  120_000,   // 2m
+  180_000,   // 3m
+  240_000,   // 4m
+  300_000,   // 5m   ← 5m TTL boundary
+  420_000,   // 7m
+  600_000,   // 10m
+  900_000,   // 15m
+  1_200_000, // 20m
+  1_800_000, // 30m
+  2_700_000, // 45m
+  3_600_000, // 1h   ← 1h TTL boundary
+  5_400_000, // 1.5h
+  7_200_000, // 2h
+  14_400_000, // 4h
+] as const;
+
+/** Number of histogram bins (edges + 1 overflow bin). */
+const BIN_COUNT = HISTOGRAM_BINS.length + 1;
+
+/** Pseudocount for Bayesian blending of session vs global histograms. */
+const BLEND_PSEUDOCOUNT = 20;
+
+/** Survival probability below which a session is marked dead. */
+const DEAD_SESSION_THRESHOLD = 0.02;
+
+/** Minimum completed turns before warming is eligible. Filters out one-shot
+ *  sessions and ensures the survival model has ≥2 gap observations. */
+const MIN_TURNS_FOR_WARMING = 3;
+
+/** Max uncached warmup responses before the global circuit breaker trips. */
+const CIRCUIT_BREAKER_MAX_FAILURES = 3;
+
+// ---------------------------------------------------------------------------
+// Global circuit breaker
+// ---------------------------------------------------------------------------
+
+let circuitBreakerFailures = 0;
+let circuitBreakerTripped = false;
+
+/**
+ * Check if the global circuit breaker has tripped.
+ *
+ * Once tripped, ALL cache warming is disabled for the process lifetime.
+ * This is intentionally non-recoverable — if warmups are causing cache
+ * writes instead of reads, something fundamental is wrong (our assumptions
+ * about cache key computation, body format, auth, etc.) and we cannot
+ * afford to keep trying.
+ */
+export function isCircuitBreakerTripped(): boolean {
+  return circuitBreakerTripped;
+}
+
+/**
+ * Record a warmup result and check the circuit breaker.
+ *
+ * A "failure" is a warmup where cacheCreationTokens > 0 AND
+ * cacheReadTokens === 0 — meaning the warmup caused a fresh cache write
+ * instead of refreshing an existing entry. This should never happen if
+ * the warmup body matches the cached prefix.
+ *
+ * Returns true if the circuit breaker has tripped (warming should stop).
+ */
+export function checkCircuitBreaker(result: WarmupResult): boolean {
+  if (circuitBreakerTripped) return true;
+
+  if (result.ok && result.cacheCreationTokens > 0 && result.cacheReadTokens === 0) {
+    circuitBreakerFailures++;
+    log.error(
+      `cache-warmer CIRCUIT BREAKER: warmup caused uncached write ` +
+        `(${circuitBreakerFailures}/${CIRCUIT_BREAKER_MAX_FAILURES}). ` +
+        `cacheCreation=${result.cacheCreationTokens} cacheRead=${result.cacheReadTokens}`,
+    );
+    if (circuitBreakerFailures >= CIRCUIT_BREAKER_MAX_FAILURES) {
+      circuitBreakerTripped = true;
+      log.error(
+        `cache-warmer CIRCUIT BREAKER TRIPPED: ${CIRCUIT_BREAKER_MAX_FAILURES} consecutive ` +
+          `uncached warmups detected. ALL cache warming disabled for this process. ` +
+          `This indicates warmup bodies don't match the cached prefix — ` +
+          `investigate cache key computation assumptions.`,
+      );
+      return true;
+    }
+  } else if (result.ok && result.cacheReadTokens > 0) {
+    // Successful cache read — reset the failure counter
+    circuitBreakerFailures = 0;
+  }
+
+  return circuitBreakerTripped;
+}
+
+// ---------------------------------------------------------------------------
+// Histogram operations
+// ---------------------------------------------------------------------------
+
+/** Create an empty histogram with the right number of bins. */
+export function createHistogram(): InterTurnHistogram {
+  return { counts: new Array(BIN_COUNT).fill(0), total: 0 };
+}
+
+/**
+ * Find the bin index for a gap duration.
+ * Returns 0..HISTOGRAM_BINS.length (last index is the overflow bin).
+ */
+function binIndex(gapMs: number): number {
+  for (let i = 0; i < HISTOGRAM_BINS.length; i++) {
+    if (gapMs < HISTOGRAM_BINS[i]) return i;
+  }
+  return HISTOGRAM_BINS.length; // overflow
+}
+
+/** Record an inter-turn gap in a histogram. */
+export function recordGap(histogram: InterTurnHistogram, gapMs: number): void {
+  const idx = binIndex(gapMs);
+  histogram.counts[idx]++;
+  histogram.total++;
+}
+
+// ---------------------------------------------------------------------------
+// Survival function
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the survival function S(t) = P(gap > t) from a histogram.
+ *
+ * S(t) = (# observations with gap > t) / total
+ *
+ * For an empty histogram, returns 1.0 (optimistic — assume user returns).
+ */
+export function survivalFunction(
+  histogram: InterTurnHistogram,
+  tMs: number,
+): number {
+  if (histogram.total === 0) return 1.0;
+
+  const idx = binIndex(tMs);
+  // Sum counts in bins > idx (gaps strictly larger than tMs)
+  let surviving = 0;
+  for (let i = idx + 1; i < BIN_COUNT; i++) {
+    surviving += histogram.counts[i];
+  }
+  // Include a fraction of the current bin proportionally
+  // (linear interpolation within the bin)
+  const binStart = idx > 0 ? HISTOGRAM_BINS[idx - 1] : 0;
+  const binEnd = idx < HISTOGRAM_BINS.length ? HISTOGRAM_BINS[idx] : Infinity;
+  const binWidth = binEnd - binStart;
+  if (binWidth > 0 && isFinite(binWidth)) {
+    const fractionPast = Math.min(1, Math.max(0, (tMs - binStart) / binWidth));
+    surviving += histogram.counts[idx] * (1 - fractionPast);
+  }
+
+  return surviving / histogram.total;
+}
+
+/**
+ * Conditional return probability: P(return within [idle, idle+window] | idle for `idleMs`).
+ *
+ * Uses the survival function:
+ *   P = (S(idleMs) - S(idleMs + windowMs)) / S(idleMs)
+ *
+ * Returns 0 if survival at idleMs is already ~0 (dead session).
+ */
+export function conditionalReturnProbability(
+  histogram: InterTurnHistogram,
+  idleMs: number,
+  windowMs: number,
+): number {
+  const sNow = survivalFunction(histogram, idleMs);
+  if (sNow < 0.001) return 0; // effectively dead
+  const sFuture = survivalFunction(histogram, idleMs + windowMs);
+  return Math.max(0, (sNow - sFuture) / sNow);
+}
+
+// ---------------------------------------------------------------------------
+// Time slot resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the current time-of-day slot for survival analysis.
+ *
+ * - `work`:    Mon–Fri 08:00–18:00 local
+ * - `evening`: Mon–Fri 18:00–23:00, weekends 08:00–23:00
+ * - `night`:   23:00–08:00 any day
+ */
+export function resolveTimeSlot(date: Date): TimeSlot {
+  const hour = date.getHours();
+  const day = date.getDay(); // 0=Sun, 6=Sat
+  const isWeekend = day === 0 || day === 6;
+
+  if (hour < 8 || hour >= 23) return "night";
+  if (isWeekend) return "evening";
+  if (hour >= 18) return "evening";
+  return "work";
+}
+
+// ---------------------------------------------------------------------------
+// Survival model helpers
+// ---------------------------------------------------------------------------
+
+/** Create an empty survival model with all three time slots. */
+export function createSurvivalModel(): SurvivalModel {
+  return {
+    slots: {
+      work: createHistogram(),
+      evening: createHistogram(),
+      night: createHistogram(),
+    },
+  };
+}
+
+/**
+ * Get (or create) the session-level histogram for a given time slot.
+ */
+export function getSessionHistogram(
+  state: SessionState,
+  slot: TimeSlot,
+): InterTurnHistogram {
+  if (!state.survivalModel) {
+    state.survivalModel = createSurvivalModel();
+  }
+  return state.survivalModel.slots[slot];
+}
+
+/**
+ * Blend a session histogram with a global histogram using Bayesian weighting.
+ *
+ * When the session has few observations, lean on the global prior.
+ * As the session accumulates data, its own distribution dominates.
+ *
+ * effective_count[i] = session_weight × session[i] + global_weight × global[i]
+ * where session_weight = min(session.total / PSEUDOCOUNT, 1.0)
+ */
+export function blendHistograms(
+  session: InterTurnHistogram,
+  global: InterTurnHistogram,
+): InterTurnHistogram {
+  const sessionWeight = Math.min(session.total / BLEND_PSEUDOCOUNT, 1.0);
+  const globalWeight = 1.0 - sessionWeight;
+
+  const blended = createHistogram();
+  for (let i = 0; i < BIN_COUNT; i++) {
+    blended.counts[i] =
+      sessionWeight * session.counts[i] + globalWeight * global.counts[i];
+  }
+  blended.total =
+    sessionWeight * session.total + globalWeight * global.total;
+  return blended;
+}
+
+// ---------------------------------------------------------------------------
+// Global histograms (per-project, in-memory)
+// ---------------------------------------------------------------------------
+
+/** Global histograms keyed by projectPath → time slot. */
+const globalModels = new Map<string, SurvivalModel>();
+
+export function getGlobalHistogram(
+  projectPath: string,
+  slot: TimeSlot,
+): InterTurnHistogram {
+  let model = globalModels.get(projectPath);
+  if (!model) {
+    model = createSurvivalModel();
+    globalModels.set(projectPath, model);
+  }
+  return model.slots[slot];
+}
+
+/** Get blended histogram for a session (session + global for current slot). */
+export function blendedHistogramForSession(
+  state: SessionState,
+  slot: TimeSlot,
+): InterTurnHistogram {
+  const sessionHist = getSessionHistogram(state, slot);
+  const globalHist = getGlobalHistogram(state.projectPath, slot);
+  return blendHistograms(sessionHist, globalHist);
+}
+
+// ---------------------------------------------------------------------------
+// Cache warming profiles
+// ---------------------------------------------------------------------------
+
+/** Provider-agnostic cache warming profile. */
+export type CacheWarmingProfile = {
+  /** Cache TTL in ms for this session's configuration. */
+  ttlMs: number;
+  /** Per-MTok cost to read from cache ($). */
+  cacheReadCostPerMTok: number;
+  /** Per-MTok cost on a full miss (write) ($). */
+  cacheMissCostPerMTok: number;
+  /** How early before TTL expiry to send the warmup (ms). */
+  warmupMarginMs: number;
+  /** Prepare the stored body for a warmup request. */
+  prepareWarmupBody: (storedBody: string) => string;
+  /** Upstream URL to send the warmup to. */
+  upstreamUrl: string;
+};
+
+/**
+ * Prepare an Anthropic request body for cache warming.
+ *
+ * Sets max_tokens to 0 (or 1 for thinking-enabled sessions), disables
+ * streaming, and strips fields incompatible with max_tokens:0.
+ *
+ * The cache key is computed from tokenized prompt content (tools → system
+ * → messages), NOT raw JSON bytes. max_tokens, stream, and temperature
+ * are not part of the cache key, so changing them doesn't affect cache
+ * hit/miss. Confirmed by Anthropic's pre-warming docs.
+ */
+export function prepareAnthropicWarmupBody(storedBody: string): string {
+  const body = JSON.parse(storedBody);
+  const hasThinking = "thinking" in body;
+
+  // max_tokens: 0 is the ideal warmup (zero output cost), but it's
+  // incompatible with extended thinking. Fall back to max_tokens: 1
+  // for thinking-enabled sessions (~$0.000015 output cost, negligible).
+  body.max_tokens = hasThinking ? 1 : 0;
+  body.stream = false;
+
+  // Strip forced tool_choice (incompatible with max_tokens: 0;
+  // also avoids generating a tool call on max_tokens: 1)
+  if (body.tool_choice?.type === "tool" || body.tool_choice?.type === "any") {
+    delete body.tool_choice;
+  }
+
+  // Strip structured output format (incompatible with max_tokens: 0)
+  delete body.output_config;
+
+  return JSON.stringify(body);
+}
+
+/**
+ * Build an Anthropic warming profile for a given model and TTL.
+ */
+export function buildAnthropicProfile(
+  model: string,
+  ttl: "5m" | "1h",
+  upstreamBase?: string,
+): CacheWarmingProfile {
+  const entry = getModelEntrySync(model);
+  const cacheReadCost = entry.cost?.cache_read ?? (entry.cost?.input ?? 3) * 0.1;
+  const cacheWriteCost = entry.cost?.cache_write ?? (entry.cost?.input ?? 3) * 1.25;
+
+  const ttlMs = ttl === "1h" ? 3_600_000 : 300_000;
+  // For 5m TTL: warm in the last 45s (4:15–5:00)
+  // For 1h TTL: warm in the last 5m (55:00–60:00)
+  const warmupMarginMs = ttl === "1h" ? 300_000 : 45_000;
+
+  const route = resolveUpstreamRoute(model);
+  const base = upstreamBase ?? route?.url ?? "https://api.anthropic.com";
+
+  return {
+    ttlMs,
+    cacheReadCostPerMTok: cacheReadCost,
+    cacheMissCostPerMTok: cacheWriteCost,
+    warmupMarginMs,
+    prepareWarmupBody: prepareAnthropicWarmupBody,
+    upstreamUrl: `${base}/v1/messages`,
+  };
+}
+
+/**
+ * Resolve a warming profile for a session.
+ *
+ * Returns null if warming is not applicable (unknown provider, warming
+ * disabled, etc.).
+ */
+export function resolveProfile(
+  model: string | undefined,
+  protocol: "anthropic" | "openai" | undefined,
+  ttl: "5m" | "1h" | undefined,
+  upstreamBase?: string,
+): CacheWarmingProfile | null {
+  if (!model || !protocol) return null;
+
+  // Only Anthropic for now — OpenAI has automatic prefix caching
+  // with no explicit warming API
+  if (protocol !== "anthropic") return null;
+
+  return buildAnthropicProfile(model, ttl ?? "5m", upstreamBase);
+}
+
+// ---------------------------------------------------------------------------
+// Decision function
+// ---------------------------------------------------------------------------
+
+/**
+ * Determine whether to warm a session's cache right now.
+ *
+ * Returns true if all conditions are met:
+ *  1. Cache is about to expire (within warmupMargin of TTL)
+ *  2. Cache hasn't already expired (past TTL)
+ *  3. Session has enough turns (≥3) for reliable survival prediction
+ *  4. Session is not marked dead
+ *  5. Session hasn't been warmed in this TTL window
+ *  6. Survival probability exceeds cost threshold
+ *  7. Global circuit breaker hasn't tripped
+ */
+export function shouldWarm(
+  state: SessionState,
+  profile: CacheWarmingProfile,
+  blendedHist: InterTurnHistogram,
+  now: number = Date.now(),
+): boolean {
+  // Global kill switch — always respected, even with /keep
+  if (circuitBreakerTripped) return false;
+
+  const cfg = loreConfig();
+  if (!cfg.cache.warming.enabled) return false;
+
+  // No stored body to replay — nothing to warm
+  if (!state.cacheAnalytics.lastRequestBody) return false;
+
+  const elapsed = now - state.lastRequestTime;
+  const { ttlMs, warmupMarginMs } = profile;
+  const forced = state.warmup?.forceKeepWarm === true;
+
+  // Already warmed in this TTL window (prevents double-warming even with /keep)
+  if (state.warmup?.lastWarmupAt && (now - state.warmup.lastWarmupAt) < ttlMs) {
+    return false;
+  }
+
+  if (forced) {
+    // /keep mode: only requirement is that we're within the warmup margin
+    // of *some* TTL window. Compute which window we're in relative to
+    // lastRequestTime (each window is ttlMs wide) and check if we're in
+    // the last warmupMarginMs of that window.
+    const intoWindow = elapsed % ttlMs;
+    if (intoWindow < ttlMs - warmupMarginMs) return false;
+    return true;
+  }
+
+  // --- Normal (non-forced) path ---
+
+  // Cache still fresh — no warmup needed yet
+  if (elapsed < ttlMs - warmupMarginMs) return false;
+
+  // Cache already expired — warmup is pointless (would cause a write, not a read)
+  if (elapsed >= ttlMs) return false;
+
+  // Not enough turns — survival model has insufficient data and the
+  // session may be a one-shot question not worth warming ($0.30 per
+  // wasted warmup at 200K Opus tokens).
+  if (state.messageCount < MIN_TURNS_FOR_WARMING * 2) return false;
+
+  // Session marked dead
+  if (state.warmup?.disabled) return false;
+
+  // Survival check: P(return within next TTL window | idle for `elapsed`)
+  let pReturn = conditionalReturnProbability(blendedHist, elapsed, ttlMs);
+
+  // Dampen survival estimate based on consecutive text-only end_turn
+  // responses. Each consecutive text-only turn halves the probability —
+  // the model finishing with text (no tool calls) multiple times in a
+  // row suggests the task is wrapping up.
+  const textOnlyRuns = state.consecutiveTextOnlyTurns ?? 0;
+  if (textOnlyRuns > 0) {
+    pReturn *= Math.pow(0.5, textOnlyRuns);
+  }
+
+  // Cost threshold: warm if P(return) > cacheReadCost / cacheMissCost
+  // This is the break-even point where expected savings = 0.
+  const autoThreshold =
+    profile.cacheReadCostPerMTok / profile.cacheMissCostPerMTok;
+  const threshold = cfg.cache.warming.minReturnProbability ?? autoThreshold;
+
+  if (pReturn <= threshold) {
+    // Check if session should be marked dead
+    const survival = survivalFunction(blendedHist, elapsed);
+    if (survival < DEAD_SESSION_THRESHOLD) {
+      if (!state.warmup) {
+        state.warmup = { lastWarmupAt: 0, warmupCount: 0, warmupHits: 0, disabled: true };
+      } else {
+        state.warmup.disabled = true;
+      }
+      log.info(
+        `cache-warmer: session=${state.sessionID.slice(0, 16)} marked dead ` +
+          `(survival=${(survival * 100).toFixed(1)}% < ${(DEAD_SESSION_THRESHOLD * 100).toFixed(0)}%)`,
+      );
+    }
+    return false;
+  }
+
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Warmup execution
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the first user message text from a serialized request body.
+ * Used for cch re-signing (version suffix depends on first user chars).
+ */
+function extractFirstUserText(bodyJson: string): string {
+  try {
+    const body = JSON.parse(bodyJson);
+    if (Array.isArray(body.messages)) {
+      for (const msg of body.messages) {
+        if (msg.role !== "user") continue;
+        if (typeof msg.content === "string") return msg.content;
+        if (Array.isArray(msg.content)) {
+          for (const block of msg.content) {
+            if (block.type === "text" && typeof block.text === "string") {
+              return block.text;
+            }
+          }
+        }
+      }
+    }
+  } catch {
+    // Parse failure — return empty
+  }
+  return "";
+}
+
+/**
+ * Execute a cache warmup for a session.
+ *
+ * Decompresses the stored request body, patches it for warmup
+ * (max_tokens:0, stream:false), re-signs the cch billing header,
+ * and sends it to the upstream provider.
+ *
+ * Returns the result for circuit breaker checking and metrics.
+ */
+export async function executeWarmup(
+  state: SessionState,
+  profile: CacheWarmingProfile,
+): Promise<WarmupResult> {
+  const noResult: WarmupResult = { ok: false, cacheReadTokens: 0, cacheCreationTokens: 0 };
+
+  const { lastRequestBody } = state.cacheAnalytics;
+  if (!lastRequestBody) return noResult;
+
+  // Decompress the stored body
+  const storedBody = decompressBody(lastRequestBody);
+
+  // Prepare for warmup (max_tokens:0, strip incompatible fields)
+  const warmupBody = profile.prepareWarmupBody(storedBody);
+
+  // Resolve auth for this session
+  const cred = resolveAuth(state.sessionID);
+  if (!cred) {
+    log.warn(`cache-warmer: no auth for session=${state.sessionID.slice(0, 16)}, skipping`);
+    return noResult;
+  }
+
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    "anthropic-version": "2023-06-01",
+    ...authHeaders(cred),
+  };
+
+  // Re-sign the cch billing header. The cch hash covers the entire
+  // serialized body, and we changed max_tokens/stream. The cch is
+  // billing verification only — NOT part of the cache key.
+  const firstUserText = extractFirstUserText(storedBody);
+  const signedBody = resignBody(warmupBody, firstUserText);
+
+  log.info(
+    `cache-warmer: sending warmup for session=${state.sessionID.slice(0, 16)} ` +
+      `model=${state.lastModel} ttl=${profile.ttlMs / 1000}s`,
+  );
+
+  try {
+    const response = await fetch(profile.upstreamUrl, {
+      method: "POST",
+      headers,
+      body: signedBody,
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text().catch(() => "");
+      log.error(
+        `cache-warmer: upstream error ${response.status} for ` +
+          `session=${state.sessionID.slice(0, 16)}: ${errorBody.slice(0, 300)}`,
+      );
+      return { ok: false, cacheReadTokens: 0, cacheCreationTokens: 0 };
+    }
+
+    // Parse the response to extract usage
+    const resp = (await response.json()) as {
+      usage?: {
+        cache_read_input_tokens?: number;
+        cache_creation_input_tokens?: number;
+        input_tokens?: number;
+      };
+      stop_reason?: string;
+    };
+
+    const inputTokens = resp.usage?.input_tokens ?? 0;
+    const cacheReadTokens = resp.usage?.cache_read_input_tokens ?? 0;
+    const cacheCreationTokens = resp.usage?.cache_creation_input_tokens ?? 0;
+    const totalInput = inputTokens + cacheReadTokens + cacheCreationTokens;
+
+    const result: WarmupResult = {
+      ok: true,
+      cacheReadTokens,
+      cacheCreationTokens,
+    };
+
+    // Compute cost estimate for this warmup
+    const readCost = (cacheReadTokens / 1_000_000) * profile.cacheReadCostPerMTok;
+    const writeCost = (cacheCreationTokens / 1_000_000) * profile.cacheMissCostPerMTok;
+    const warmupCost = readCost + writeCost;
+    const costStr = `$${warmupCost.toFixed(4)}`;
+
+    // Log the outcome with full cache statistics
+    const sid = state.sessionID.slice(0, 16);
+    const hitRate = totalInput > 0
+      ? `${((cacheReadTokens / totalInput) * 100).toFixed(0)}%`
+      : "N/A";
+
+    if (cacheReadTokens > 0 && cacheCreationTokens === 0) {
+      log.info(
+        `cache-warmer: ✓ refresh session=${sid} ` +
+          `input=${totalInput} cacheRead=${cacheReadTokens} hit=${hitRate} cost=${costStr}`,
+      );
+    } else if (cacheReadTokens > 0 && cacheCreationTokens > 0) {
+      // Partial hit — some breakpoints read, some written (e.g. conversation
+      // breakpoint expired but system/tools still cached). This is fine.
+      log.info(
+        `cache-warmer: ~ partial session=${sid} ` +
+          `input=${totalInput} cacheRead=${cacheReadTokens} cacheWrite=${cacheCreationTokens} ` +
+          `hit=${hitRate} cost=${costStr}`,
+      );
+    } else {
+      log.warn(
+        `cache-warmer: ✗ UNCACHED session=${sid} ` +
+          `input=${totalInput} cacheRead=${cacheReadTokens} cacheWrite=${cacheCreationTokens} ` +
+          `cost=${costStr} — warmup body may not match cached prefix`,
+      );
+    }
+
+    // Update session warmup state
+    if (!state.warmup) {
+      state.warmup = { lastWarmupAt: 0, warmupCount: 0, warmupHits: 0, disabled: false };
+    }
+    state.warmup.lastWarmupAt = Date.now();
+    state.warmup.warmupCount++;
+
+    // Check circuit breaker
+    checkCircuitBreaker(result);
+
+    return result;
+  } catch (e) {
+    log.error(`cache-warmer: fetch error for session=${state.sessionID.slice(0, 16)}:`, e);
+    return noResult;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Global histogram persistence (SQLite)
+// ---------------------------------------------------------------------------
+
+/** Tracks which project×slot combos have been modified since last flush. */
+const dirtyHistograms = new Set<string>();
+
+function dirtyKey(projectPath: string, slot: TimeSlot): string {
+  return `${projectPath}\0${slot}`;
+}
+
+/**
+ * Load persisted global histograms for a project from SQLite.
+ *
+ * Called once per project on first access. Populates the in-memory
+ * globalModels map so survival analysis has data immediately after
+ * a gateway restart.
+ */
+export function loadGlobalHistograms(projectPath: string): void {
+  if (globalModels.has(projectPath)) return; // already loaded
+
+  const model = createSurvivalModel();
+  const pid = projectId(projectPath);
+  if (!pid) {
+    globalModels.set(projectPath, model);
+    return;
+  }
+
+  try {
+    const rows = db()
+      .query("SELECT time_slot, counts, total FROM warmup_histograms WHERE project_id = ?")
+      .all(pid) as Array<{ time_slot: string; counts: string; total: number }>;
+
+    for (const row of rows) {
+      const slot = row.time_slot as TimeSlot;
+      if (!(slot in model.slots)) continue;
+
+      try {
+        const counts = JSON.parse(row.counts) as number[];
+        if (Array.isArray(counts) && counts.length === BIN_COUNT) {
+          model.slots[slot] = { counts, total: row.total };
+        }
+      } catch {
+        // Corrupt JSON — start fresh for this slot
+      }
+    }
+
+    log.info(
+      `cache-warmer: loaded global histograms for project=${projectPath.slice(-30)} ` +
+        `(work=${model.slots.work.total} evening=${model.slots.evening.total} night=${model.slots.night.total})`,
+    );
+  } catch (e) {
+    log.warn("cache-warmer: failed to load global histograms:", e);
+  }
+
+  globalModels.set(projectPath, model);
+}
+
+/**
+ * Mark a global histogram as dirty (modified since last flush).
+ * Called internally by recordGap when targeting a global histogram.
+ */
+function markDirty(projectPath: string, slot: TimeSlot): void {
+  dirtyHistograms.add(dirtyKey(projectPath, slot));
+}
+
+/**
+ * Flush dirty global histograms to SQLite.
+ *
+ * Designed to be called periodically (e.g. every 60s from the idle
+ * scheduler) rather than on every recordGap call, to avoid write
+ * amplification on a hot path.
+ */
+export function flushGlobalHistograms(): void {
+  if (dirtyHistograms.size === 0) return;
+
+  const d = db();
+  const now = Date.now();
+
+  for (const key of dirtyHistograms) {
+    const [projectPath, slot] = key.split("\0") as [string, TimeSlot];
+    const pid = projectId(projectPath);
+    if (!pid) continue;
+
+    const model = globalModels.get(projectPath);
+    if (!model) continue;
+
+    const hist = model.slots[slot];
+    if (!hist) continue;
+
+    try {
+      d.query(
+        `INSERT INTO warmup_histograms (project_id, time_slot, counts, total, updated_at)
+         VALUES (?, ?, ?, ?, ?)
+         ON CONFLICT(project_id, time_slot) DO UPDATE SET
+           counts = excluded.counts,
+           total = excluded.total,
+           updated_at = excluded.updated_at`,
+      ).run(pid, slot, JSON.stringify(hist.counts), hist.total, now);
+    } catch (e) {
+      log.warn(`cache-warmer: failed to flush histogram ${slot}:`, e);
+    }
+  }
+
+  dirtyHistograms.clear();
+}
+
+// Override getGlobalHistogram to load from DB on first access and mark dirty on write
+const _originalGetGlobalHistogram = getGlobalHistogram;
+
+/**
+ * Record an inter-turn gap in a global histogram, with dirty tracking.
+ *
+ * Wraps the base `recordGap` to also mark the histogram for periodic
+ * SQLite flush.
+ */
+export function recordGlobalGap(
+  projectPath: string,
+  slot: TimeSlot,
+  gapMs: number,
+): void {
+  loadGlobalHistograms(projectPath); // ensure loaded
+  const hist = getGlobalHistogram(projectPath, slot);
+  recordGap(hist, gapMs);
+  markDirty(projectPath, slot);
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/** @internal Reset module state for tests. */
+export function _resetForTest(): void {
+  circuitBreakerFailures = 0;
+  circuitBreakerTripped = false;
+  globalModels.clear();
+  dirtyHistograms.clear();
+}

--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -5,6 +5,10 @@
  * `session.idle` event), it uses a timer-based approach to detect when
  * sessions go idle and trigger background work (distillation, curation,
  * pruning, AGENTS.md export, etc.).
+ *
+ * Also runs speculative cache warming checks on every 30s tick — separate
+ * from idle work (which triggers after idleTimeoutSeconds). Warming needs
+ * to fire ~45s before cache TTL expiry, not after the idle timeout.
  */
 
 import { join } from "node:path";
@@ -24,6 +28,17 @@ import type { LLMClient } from "@loreai/core";
 import type { GatewayConfig } from "./config";
 import type { SessionState } from "./translate/types";
 import { getWorkerModel } from "./worker-model";
+import {
+  isCircuitBreakerTripped,
+  resolveProfile,
+  resolveTimeSlot,
+  blendedHistogramForSession,
+  shouldWarm,
+  executeWarmup,
+  loadGlobalHistograms,
+  flushGlobalHistograms,
+} from "./cache-warmer";
+import { emitWarmupMetric } from "./sentry";
 
 const POLL_INTERVAL_MS = 30_000;
 
@@ -46,11 +61,13 @@ export function startIdleScheduler(
   doIdleWork: (sessionID: string, state: SessionState) => Promise<void>,
 ): () => void {
   const inProgress = new Set<string>();
+  const warmupInProgress = new Set<string>();
 
   const timer = setInterval(() => {
     const now = Date.now();
     const timeoutMs = config.idleTimeoutSeconds * 1000;
 
+    // --- Idle work (distillation, curation, etc.) ---
     for (const [sessionID, state] of sessions) {
       if (inProgress.has(sessionID)) continue;
       if (now - state.lastRequestTime < timeoutMs) continue;
@@ -59,6 +76,43 @@ export function startIdleScheduler(
       doIdleWork(sessionID, state)
         .catch((e) => log.error(`idle work failed for session ${sessionID}:`, e))
         .finally(() => inProgress.delete(sessionID));
+    }
+
+    // --- Cache warming (separate from idle work — fires before TTL expiry) ---
+    if (isCircuitBreakerTripped()) return;
+
+    for (const [sessionID, state] of sessions) {
+      if (warmupInProgress.has(sessionID)) continue;
+
+      // Ensure global histograms are loaded from SQLite for this project
+      loadGlobalHistograms(state.projectPath);
+
+      const profile = resolveProfile(
+        state.lastModel,
+        state.lastProtocol,
+        state.resolvedConversationTTL,
+      );
+      if (!profile) continue;
+
+      const slot = resolveTimeSlot(new Date(now));
+      const blendedHist = blendedHistogramForSession(state, slot);
+      if (!shouldWarm(state, profile, blendedHist, now)) continue;
+
+      warmupInProgress.add(sessionID);
+      executeWarmup(state, profile)
+        .then((result) => emitWarmupMetric(state, result))
+        .catch((e) =>
+          log.error(`cache-warmer: warmup failed session=${sessionID.slice(0, 16)}:`, e),
+        )
+        .finally(() => warmupInProgress.delete(sessionID));
+    }
+
+    // Flush dirty global histograms to SQLite (debounced — runs at most
+    // once per 30s poll tick, not on every recordGap call).
+    try {
+      flushGlobalHistograms();
+    } catch (e) {
+      log.warn("cache-warmer: histogram flush error:", e);
     }
   }, POLL_INTERVAL_MS);
 

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -104,14 +104,21 @@ import { captureBillingPrefix, hasBillingHeader, resignBody } from "./cch";
 import { detectClientType } from "./session";
 import { analyzeCacheTurn, categorizeBust } from "./cache-analytics";
 import {
+  resolveTimeSlot,
+  recordGap,
+  getSessionHistogram,
+  recordGlobalGap,
+} from "./cache-warmer";
+import {
    setSentryRequestContext,
    setSentryCacheContext,
    setSentryLightContext,
    setGenAiUsageAttributes,
    setCacheAnalyticsAttributes,
-   emitCostMetric,
-   emitCacheBustMetric,
-   type AnthropicUsage,
+    emitCostMetric,
+    emitCacheBustMetric,
+    emitWarmupHitMetric,
+    type AnthropicUsage,
 } from "./sentry";
 import {
   RECALL_GATEWAY_TOOL,
@@ -431,6 +438,7 @@ function getOrCreateSession(
       lastRequestTime: Date.now(),
       messageCount: 0,
       turnsSinceCuration: 0,
+      consecutiveTextOnlyTurns: 0,
       recallStore: new Map(),
       cacheAnalytics: {
         lastRequestBody: null,
@@ -1217,6 +1225,15 @@ function postResponse(
       // Update session state
       sessionState.turnsSinceCuration =
         (sessionState.turnsSinceCuration ?? 0) + 1;
+
+      // --- Track consecutive text-only end_turn responses (session-end heuristic) ---
+      const hasToolUse = resp.content.some((b) => b.type === "tool_use");
+      if (resp.stopReason === "end_turn" && !hasToolUse) {
+        sessionState.consecutiveTextOnlyTurns =
+          (sessionState.consecutiveTextOnlyTurns ?? 0) + 1;
+      } else {
+        sessionState.consecutiveTextOnlyTurns = 0;
+      }
     }
 
     // --- Output tracking for dynamic max_tokens sizing ---
@@ -1241,6 +1258,44 @@ function postResponse(
                   outputTokens * EMA_ALPHA,
               );
       }
+    }
+
+    // --- Cache warming: record inter-turn gap + track warmup hits ---
+    const now = Date.now();
+    if (sessionState.lastRequestTime > 0) {
+      const gap = now - sessionState.lastRequestTime;
+      const slot = resolveTimeSlot(new Date(now));
+      recordGap(getSessionHistogram(sessionState, slot), gap);
+      recordGlobalGap(sessionState.projectPath, slot, gap);
+
+      // Track warmup hit: user returned after we warmed the cache
+      if (sessionState.warmup?.lastWarmupAt) {
+        const ttlMs = sessionState.resolvedConversationTTL === "1h" ? 3_600_000 : 300_000;
+        const sinceWarmup = now - sessionState.warmup.lastWarmupAt;
+        if (sinceWarmup < ttlMs) {
+          sessionState.warmup.warmupHits++;
+          emitWarmupHitMetric(
+            sessionState.lastModel ?? req.model,
+            sessionState.resolvedConversationTTL ?? "5m",
+          );
+          log.info(
+            `cache-warmer: HIT session=${sessionID.slice(0, 16)} ` +
+              `user returned ${(sinceWarmup / 1000).toFixed(0)}s after warmup`,
+          );
+        }
+      }
+    }
+    // Track model/protocol for warmup profile resolution
+    sessionState.lastModel = req.model;
+    sessionState.lastProtocol =
+      resolveUpstreamRoute(req.model)?.protocol ?? "anthropic";
+
+    // Reset dead flag if session was marked dead but user returned
+    if (sessionState.warmup?.disabled) {
+      sessionState.warmup.disabled = false;
+      log.info(
+        `cache-warmer: re-enabled session=${sessionID.slice(0, 16)} (user resumed)`,
+      );
     }
 
     // --- Schedule background work (fire-and-forget) ---
@@ -2126,6 +2181,114 @@ export function removeOrphanedToolResults(
 }
 
 // ---------------------------------------------------------------------------
+// Slash command interception (/done, /keep)
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the text of the last user message, trimmed and lowercased.
+ * Returns empty string if no user message found.
+ */
+function lastUserTextTrimmed(req: GatewayRequest): string {
+  for (let i = req.messages.length - 1; i >= 0; i--) {
+    const msg = req.messages[i];
+    if (msg.role !== "user") continue;
+    const text = msg.content
+      .filter((b) => b.type === "text")
+      .map((b) => (b as { type: "text"; text: string }).text)
+      .join("\n")
+      .trim();
+    return text;
+  }
+  return "";
+}
+
+/**
+ * Check if the last user message is a warmup slash command.
+ *
+ * `/done` — disables cache warming for this session (user is finished).
+ * `/keep` — forces cache warming regardless of survival analysis.
+ *
+ * Returns a synthetic Anthropic-format response if a command was matched,
+ * or null to continue normal processing.
+ */
+function handleWarmupSlashCommand(
+  req: GatewayRequest,
+  allSessions: Map<string, SessionState>,
+): Response | null {
+  const text = lastUserTextTrimmed(req);
+  const lower = text.toLowerCase();
+
+  const isDone = lower === "/done";
+  const isKeep = lower === "/keep" || lower === "/keep-warm";
+  if (!isDone && !isKeep) return null;
+
+  // Find the session for this request (use the same header-based lookup)
+  const known = extractKnownSessionHeader(req.rawHeaders);
+  let state: SessionState | undefined;
+  if (known) {
+    const indexKey = `${known.headerName}:${known.sessionId}`;
+    const sid = headerSessionIndex.get(indexKey);
+    if (sid) state = allSessions.get(sid);
+  }
+
+  // Update session warmup state
+  if (state) {
+    if (!state.warmup) {
+      state.warmup = { lastWarmupAt: 0, warmupCount: 0, warmupHits: 0, disabled: isDone };
+    } else {
+      state.warmup.disabled = isDone;
+    }
+    if (isKeep) state.warmup.forceKeepWarm = true;
+    log.info(
+      `cache-warmer: ${lower} received for session=${state.sessionID.slice(0, 16)} — ` +
+        `warming ${isDone ? "disabled" : "forced"}`,
+    );
+  }
+
+  const responseText = isDone ? "🧊 Freezing session." : "🔥 Keeping cache warm.";
+
+  const msgId = `msg_lore_${Date.now()}`;
+
+  // Return SSE stream when the client expects streaming (OpenCode, Claude Code)
+  if (req.stream) {
+    const sseBody = buildSSETextResponse(msgId, req.model, responseText, {
+      inputTokens: 0,
+      outputTokens: 0,
+    });
+    return new Response(sseBody, {
+      status: 200,
+      headers: {
+        "content-type": "text/event-stream",
+        "cache-control": "no-cache",
+        connection: "keep-alive",
+      },
+    });
+  }
+
+  // Non-streaming: plain JSON
+  const body = JSON.stringify({
+    id: msgId,
+    type: "message",
+    role: "assistant",
+    content: [{ type: "text", text: responseText }],
+    model: req.model,
+    stop_reason: "end_turn",
+    stop_sequence: null,
+    usage: {
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+    },
+  });
+
+  return new Response(body, {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Error response builder
 // ---------------------------------------------------------------------------
 
@@ -2175,6 +2338,10 @@ export async function handleRequest(
       const sid = headerSessionIndex.get(indexKey);
       if (sid) priorState = sessions.get(sid);
     }
+
+    // --- Case 0: Slash command interception (/done, /keep) ---
+    const slashResult = handleWarmupSlashCommand(req, sessions);
+    if (slashResult) return slashResult;
 
     // --- Case 1: Compaction request → intercept ---
     // Structural detection (session-aware) first, pattern matching as fallback.

--- a/packages/gateway/src/sentry.ts
+++ b/packages/gateway/src/sentry.ts
@@ -264,6 +264,77 @@ async function getPricing(model: string): Promise<ModelPricing> {
  *  - cache_creation_input_tokens: written to prompt cache (1.25× input price)
  *  - output_tokens: generated output (output price)
  */
+// ---------------------------------------------------------------------------
+// Cache warming telemetry
+// ---------------------------------------------------------------------------
+
+import type { SessionState, WarmupResult } from "./translate/types";
+
+/**
+ * Emit metrics for a cache warmup attempt.
+ *
+ * Tracks warmup sent/hit/miss counts and estimated cost/savings for
+ * ROI analysis. All metrics are tagged by model and TTL.
+ */
+export function emitWarmupMetric(
+  state: SessionState,
+  result: WarmupResult,
+): void {
+  if (!Sentry.isInitialized()) return;
+
+  const model = state.lastModel ?? "unknown";
+  const ttl = state.resolvedConversationTTL ?? "5m";
+  const attrs = { model, ttl };
+
+  // Count every warmup sent
+  Sentry.metrics.count("lore.cache_warmup.sent", 1, { attributes: attrs });
+
+  if (result.ok && result.cacheReadTokens > 0 && result.cacheCreationTokens === 0) {
+    // Pure cache refresh — ideal outcome
+    Sentry.metrics.count("lore.cache_warmup.refresh", 1, { attributes: attrs });
+  } else if (result.ok && result.cacheCreationTokens > 0 && result.cacheReadTokens === 0) {
+    // Uncached warmup — circuit breaker material
+    Sentry.metrics.count("lore.cache_warmup.uncached", 1, { attributes: attrs });
+  }
+
+  // Emit warmup cost as a distribution (fire-and-forget)
+  if (result.ok) {
+    getPricing(model).then((pricing) => {
+      const readCost = (result.cacheReadTokens / 1_000_000) * pricing.cache_read;
+      const writeCost = (result.cacheCreationTokens / 1_000_000) * pricing.cache_write;
+      Sentry.metrics.distribution("lore.cache_warmup.cost_usd", readCost + writeCost, {
+        attributes: attrs,
+        unit: "dollar",
+      });
+    }).catch(() => {});
+  }
+}
+
+/**
+ * Emit a metric when a user returns after a warmup (confirmed save).
+ */
+export function emitWarmupHitMetric(
+  model: string,
+  ttl: string,
+): void {
+  if (!Sentry.isInitialized()) return;
+  Sentry.metrics.count("lore.cache_warmup.hit", 1, {
+    attributes: { model, ttl },
+  });
+}
+
+/**
+ * Emit a metric when the circuit breaker trips.
+ */
+export function emitWarmupCircuitBreakerMetric(): void {
+  if (!Sentry.isInitialized()) return;
+  Sentry.metrics.count("lore.cache_warmup.circuit_breaker_tripped", 1, {});
+}
+
+// ---------------------------------------------------------------------------
+// LLM cost estimation
+// ---------------------------------------------------------------------------
+
 export function emitCostMetric(
   model: string,
   usage: AnthropicUsage,

--- a/packages/gateway/src/translate/types.ts
+++ b/packages/gateway/src/translate/types.ts
@@ -253,4 +253,65 @@ export type SessionState = {
   lastStopReason?: string;
   /** Total input tokens from the last completed turn (for headroom calculation). */
   lastInputTokens?: number;
+
+  // --- Cache warming ---
+
+  /** Consecutive turns where stop_reason was "end_turn" and the response
+   *  contained no tool_use blocks (text-only replies). Resets to 0 whenever
+   *  a tool_use turn occurs. Used to dampen the survival estimate — multiple
+   *  text-only replies suggest the model is done working. */
+  consecutiveTextOnlyTurns: number;
+
+  /** Cache warming state for speculative keep-alive pings. */
+  warmup?: WarmupState;
+  /** Per-session survival model (inter-turn gap histogram by time slot). */
+  survivalModel?: SurvivalModel;
+  /** Model name from the last real request (for warming profile resolution). */
+  lastModel?: string;
+  /** Protocol from the last real request (for warming profile resolution). */
+  lastProtocol?: "anthropic" | "openai";
+};
+
+// ---------------------------------------------------------------------------
+// Cache warming types
+// ---------------------------------------------------------------------------
+
+/** Time-of-day slot for survival analysis — captures circadian work patterns. */
+export type TimeSlot = "work" | "evening" | "night";
+
+/** Binned histogram of inter-turn gaps for survival analysis. */
+export type InterTurnHistogram = {
+  /** Count per bin (length = number of bin edges + 1 for overflow). */
+  counts: number[];
+  /** Total observations (sum of counts). */
+  total: number;
+};
+
+/** Per-session survival model with time-slot segmented histograms. */
+export type SurvivalModel = {
+  slots: Record<TimeSlot, InterTurnHistogram>;
+};
+
+/** Per-session cache warming state. */
+export type WarmupState = {
+  /** Timestamp (ms) of the last warmup ping sent. */
+  lastWarmupAt: number;
+  /** Total warmup pings sent in this session. */
+  warmupCount: number;
+  /** Warmups followed by a user return within TTL (confirmed saves). */
+  warmupHits: number;
+  /** Session marked as dead — survival dropped below threshold. Resets on real request. */
+  disabled: boolean;
+  /** User explicitly requested keep-warm via /keep command. Bypasses survival analysis. */
+  forceKeepWarm?: boolean;
+};
+
+/** Result from a warmup request — used for circuit breaker and metrics. */
+export type WarmupResult = {
+  /** Whether the upstream accepted the request (HTTP 2xx). */
+  ok: boolean;
+  /** Cache read tokens from the warmup response (confirms cache was refreshed). */
+  cacheReadTokens: number;
+  /** Cache creation tokens (non-zero means warmup caused a fresh write — bad). */
+  cacheCreationTokens: number;
 };

--- a/packages/gateway/test/cache-warmer.test.ts
+++ b/packages/gateway/test/cache-warmer.test.ts
@@ -1,0 +1,771 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import {
+  createHistogram,
+  recordGap,
+  survivalFunction,
+  conditionalReturnProbability,
+  resolveTimeSlot,
+  createSurvivalModel,
+  blendHistograms,
+  prepareAnthropicWarmupBody,
+  buildAnthropicProfile,
+  shouldWarm,
+  checkCircuitBreaker,
+  isCircuitBreakerTripped,
+  HISTOGRAM_BINS,
+  _resetForTest,
+} from "../src/cache-warmer";
+import type {
+  SessionState,
+  CacheAnalytics,
+  WarmupResult,
+} from "../src/translate/types";
+import { compressBody } from "../src/cache-analytics";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeCacheAnalytics(): CacheAnalytics {
+  return {
+    lastRequestBody: null,
+    lastRequestBodyLength: 0,
+    lastCacheRead: 0,
+    lastCacheCreation: 0,
+    turnCount: 0,
+    bustCount: 0,
+  };
+}
+
+function makeSessionState(overrides: Partial<SessionState> = {}): SessionState {
+  return {
+    sessionID: "test-session-abc123",
+    projectPath: "/tmp/test-project",
+    fingerprint: "abc123",
+    lastRequestTime: Date.now() - 270_000, // 4.5 min ago (inside 5m warmup window)
+    messageCount: 10,
+    turnsSinceCuration: 2,
+    consecutiveTextOnlyTurns: 0,
+    recallStore: new Map(),
+    cacheAnalytics: makeCacheAnalytics(),
+    lastModel: "claude-sonnet-4-20250514",
+    lastProtocol: "anthropic",
+    resolvedConversationTTL: "5m",
+    ...overrides,
+  };
+}
+
+function makeWarmupResult(overrides: Partial<WarmupResult> = {}): WarmupResult {
+  return {
+    ok: true,
+    cacheReadTokens: 50000,
+    cacheCreationTokens: 0,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Histogram
+// ---------------------------------------------------------------------------
+
+describe("histogram", () => {
+  test("createHistogram returns correct number of bins", () => {
+    const hist = createHistogram();
+    expect(hist.counts.length).toBe(HISTOGRAM_BINS.length + 1);
+    expect(hist.total).toBe(0);
+    expect(hist.counts.every((c) => c === 0)).toBe(true);
+  });
+
+  test("recordGap increments correct bin and total", () => {
+    const hist = createHistogram();
+    recordGap(hist, 5_000); // 5s → first bin (< 10s)
+    expect(hist.total).toBe(1);
+    expect(hist.counts[0]).toBe(1);
+
+    recordGap(hist, 15_000); // 15s → second bin (10s–20s)
+    expect(hist.total).toBe(2);
+    expect(hist.counts[1]).toBe(1);
+  });
+
+  test("recordGap puts overflow in last bin", () => {
+    const hist = createHistogram();
+    recordGap(hist, 100_000_000); // way past all bins
+    expect(hist.counts[HISTOGRAM_BINS.length]).toBe(1);
+    expect(hist.total).toBe(1);
+  });
+
+  test("recordGap handles exact bin edge", () => {
+    const hist = createHistogram();
+    // 10_000 ms = bin edge → goes into bin 1 (10s–20s), since < check
+    // is strict: gapMs < HISTOGRAM_BINS[0] is 10000 < 10000 = false,
+    // so it falls through to bin 1
+    recordGap(hist, 10_000);
+    expect(hist.counts[1]).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Survival function
+// ---------------------------------------------------------------------------
+
+describe("survivalFunction", () => {
+  test("empty histogram returns 1.0 (optimistic)", () => {
+    const hist = createHistogram();
+    expect(survivalFunction(hist, 60_000)).toBe(1.0);
+  });
+
+  test("all gaps shorter than query → survival ~0", () => {
+    const hist = createHistogram();
+    // All gaps are 5s
+    for (let i = 0; i < 100; i++) recordGap(hist, 5_000);
+    const s = survivalFunction(hist, 30_000);
+    expect(s).toBeLessThan(0.01);
+  });
+
+  test("all gaps longer than query → survival ~1", () => {
+    const hist = createHistogram();
+    // All gaps are 10 minutes
+    for (let i = 0; i < 100; i++) recordGap(hist, 600_000);
+    const s = survivalFunction(hist, 30_000);
+    expect(s).toBeGreaterThan(0.9);
+  });
+
+  test("mixed gaps produce intermediate survival", () => {
+    const hist = createHistogram();
+    // 50% gaps at 30s, 50% at 10 minutes
+    for (let i = 0; i < 50; i++) recordGap(hist, 30_000);
+    for (let i = 0; i < 50; i++) recordGap(hist, 600_000);
+    const s = survivalFunction(hist, 60_000);
+    // ~50% should survive past 60s
+    expect(s).toBeGreaterThan(0.3);
+    expect(s).toBeLessThan(0.7);
+  });
+
+  test("survival decreases monotonically", () => {
+    const hist = createHistogram();
+    // Spread gaps across multiple bins
+    for (let i = 0; i < 20; i++) recordGap(hist, 30_000);
+    for (let i = 0; i < 20; i++) recordGap(hist, 120_000);
+    for (let i = 0; i < 20; i++) recordGap(hist, 300_000);
+    for (let i = 0; i < 20; i++) recordGap(hist, 600_000);
+    for (let i = 0; i < 20; i++) recordGap(hist, 3_600_000);
+
+    const s1 = survivalFunction(hist, 60_000);
+    const s2 = survivalFunction(hist, 300_000);
+    const s3 = survivalFunction(hist, 3_600_000);
+
+    expect(s1).toBeGreaterThan(s2);
+    expect(s2).toBeGreaterThan(s3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Conditional return probability
+// ---------------------------------------------------------------------------
+
+describe("conditionalReturnProbability", () => {
+  test("returns 0 for dead histogram", () => {
+    const hist = createHistogram();
+    // All gaps at 5s — nobody returns after 1h
+    for (let i = 0; i < 100; i++) recordGap(hist, 5_000);
+    const p = conditionalReturnProbability(hist, 3_600_000, 300_000);
+    expect(p).toBe(0);
+  });
+
+  test("returns positive for active sessions near TTL", () => {
+    const hist = createHistogram();
+    // Mix of gaps: some at 3m, some at 6m, some at 10m
+    for (let i = 0; i < 30; i++) recordGap(hist, 180_000);
+    for (let i = 0; i < 30; i++) recordGap(hist, 360_000);
+    for (let i = 0; i < 30; i++) recordGap(hist, 600_000);
+
+    // At 4.5min idle, asking about return in next 5min
+    const p = conditionalReturnProbability(hist, 270_000, 300_000);
+    expect(p).toBeGreaterThan(0.1);
+  });
+
+  test("returns 0 for empty histogram at very long idle", () => {
+    // Empty histogram → survival is 1.0 everywhere → conditional
+    // probability is (1.0 - 1.0) / 1.0 = 0... but actually with an
+    // empty histogram everything is uniform, so the function should
+    // handle this gracefully
+    const hist = createHistogram();
+    const p = conditionalReturnProbability(hist, 0, 300_000);
+    // With no data, survival is 1.0 at both points → p = 0
+    // (can't distinguish any time range)
+    expect(p).toBeGreaterThanOrEqual(0);
+    expect(p).toBeLessThanOrEqual(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Time slot resolution
+// ---------------------------------------------------------------------------
+
+describe("resolveTimeSlot", () => {
+  test("weekday morning → work", () => {
+    // Wednesday 10:00
+    const d = new Date(2025, 0, 8, 10, 0); // Jan 8 2025 is a Wednesday
+    expect(resolveTimeSlot(d)).toBe("work");
+  });
+
+  test("weekday evening → evening", () => {
+    // Wednesday 20:00
+    const d = new Date(2025, 0, 8, 20, 0);
+    expect(resolveTimeSlot(d)).toBe("evening");
+  });
+
+  test("weekday night → night", () => {
+    // Wednesday 02:00
+    const d = new Date(2025, 0, 8, 2, 0);
+    expect(resolveTimeSlot(d)).toBe("night");
+  });
+
+  test("late night → night", () => {
+    // Wednesday 23:30
+    const d = new Date(2025, 0, 8, 23, 30);
+    expect(resolveTimeSlot(d)).toBe("night");
+  });
+
+  test("weekend daytime → evening", () => {
+    // Saturday 14:00
+    const d = new Date(2025, 0, 11, 14, 0); // Jan 11 2025 is a Saturday
+    expect(resolveTimeSlot(d)).toBe("evening");
+  });
+
+  test("weekend night → night", () => {
+    // Sunday 03:00
+    const d = new Date(2025, 0, 12, 3, 0);
+    expect(resolveTimeSlot(d)).toBe("night");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Histogram blending
+// ---------------------------------------------------------------------------
+
+describe("blendHistograms", () => {
+  test("empty session uses global entirely", () => {
+    const session = createHistogram();
+    const global = createHistogram();
+    for (let i = 0; i < 100; i++) recordGap(global, 60_000);
+
+    const blended = blendHistograms(session, global);
+    // Session weight = 0, global weight = 1
+    expect(blended.total).toBeCloseTo(global.total);
+  });
+
+  test("session with enough data dominates", () => {
+    const session = createHistogram();
+    const global = createHistogram();
+
+    // Session: all 30s gaps (25 observations > PSEUDOCOUNT of 20)
+    for (let i = 0; i < 25; i++) recordGap(session, 30_000);
+    // Global: all 10m gaps
+    for (let i = 0; i < 100; i++) recordGap(global, 600_000);
+
+    const blended = blendHistograms(session, global);
+    // Session weight should be ~1.0 (25/20 clamped to 1.0)
+    // So survival at 5m should be low (session has all 30s gaps)
+    const s = survivalFunction(blended, 300_000);
+    expect(s).toBeLessThan(0.1);
+  });
+
+  test("session with few observations blends with global", () => {
+    const session = createHistogram();
+    const global = createHistogram();
+
+    // Session: 5 observations at 30s (weight = 5/20 = 0.25)
+    for (let i = 0; i < 5; i++) recordGap(session, 30_000);
+    // Global: 100 observations at 10m
+    for (let i = 0; i < 100; i++) recordGap(global, 600_000);
+
+    const blended = blendHistograms(session, global);
+    // Should have substantial survival at 5m due to global influence
+    const s = survivalFunction(blended, 300_000);
+    expect(s).toBeGreaterThan(0.3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Body patching
+// ---------------------------------------------------------------------------
+
+describe("prepareAnthropicWarmupBody", () => {
+  test("sets max_tokens to 0 and stream to false", () => {
+    const body = JSON.stringify({
+      model: "claude-sonnet-4-20250514",
+      max_tokens: 16384,
+      stream: true,
+      system: [{ type: "text", text: "You are helpful." }],
+      messages: [{ role: "user", content: "hello" }],
+    });
+
+    const result = JSON.parse(prepareAnthropicWarmupBody(body));
+    expect(result.max_tokens).toBe(0);
+    expect(result.stream).toBe(false);
+    expect(result.model).toBe("claude-sonnet-4-20250514");
+    expect(result.system).toEqual([{ type: "text", text: "You are helpful." }]);
+    expect(result.messages).toEqual([{ role: "user", content: "hello" }]);
+  });
+
+  test("uses max_tokens:1 for thinking-enabled sessions", () => {
+    const body = JSON.stringify({
+      model: "claude-sonnet-4-20250514",
+      max_tokens: 16384,
+      stream: true,
+      thinking: { type: "enabled", budget_tokens: 10000 },
+      system: "You are helpful.",
+      messages: [{ role: "user", content: "hello" }],
+    });
+
+    const result = JSON.parse(prepareAnthropicWarmupBody(body));
+    expect(result.max_tokens).toBe(1);
+    expect(result.stream).toBe(false);
+    expect(result.thinking).toEqual({ type: "enabled", budget_tokens: 10000 });
+  });
+
+  test("strips forced tool_choice", () => {
+    const body = JSON.stringify({
+      model: "claude-sonnet-4-20250514",
+      max_tokens: 16384,
+      stream: true,
+      tool_choice: { type: "tool", name: "my_tool" },
+      messages: [{ role: "user", content: "hello" }],
+    });
+
+    const result = JSON.parse(prepareAnthropicWarmupBody(body));
+    expect(result.max_tokens).toBe(0);
+    expect(result.tool_choice).toBeUndefined();
+  });
+
+  test("preserves auto tool_choice", () => {
+    const body = JSON.stringify({
+      model: "claude-sonnet-4-20250514",
+      max_tokens: 16384,
+      stream: true,
+      tool_choice: { type: "auto" },
+      messages: [{ role: "user", content: "hello" }],
+    });
+
+    const result = JSON.parse(prepareAnthropicWarmupBody(body));
+    expect(result.tool_choice).toEqual({ type: "auto" });
+  });
+
+  test("strips output_config", () => {
+    const body = JSON.stringify({
+      model: "claude-sonnet-4-20250514",
+      max_tokens: 16384,
+      stream: true,
+      output_config: { format: "json" },
+      messages: [{ role: "user", content: "hello" }],
+    });
+
+    const result = JSON.parse(prepareAnthropicWarmupBody(body));
+    expect(result.output_config).toBeUndefined();
+  });
+
+  test("preserves all prompt content fields", () => {
+    const body = JSON.stringify({
+      model: "claude-sonnet-4-20250514",
+      max_tokens: 16384,
+      stream: true,
+      system: [
+        {
+          type: "text",
+          text: "system prompt with cch=__;",
+          cache_control: { type: "ephemeral", ttl: "1h" },
+        },
+      ],
+      tools: [{ name: "tool1", description: "desc", input_schema: {} }],
+      messages: [
+        { role: "user", content: [{ type: "text", text: "hello" }] },
+        { role: "assistant", content: [{ type: "text", text: "hi" }] },
+        { role: "user", content: [{ type: "text", text: "question" }] },
+      ],
+    });
+
+    const result = JSON.parse(prepareAnthropicWarmupBody(body));
+    // All prompt content preserved
+    expect(result.system).toHaveLength(1);
+    expect(result.system[0].cache_control).toBeDefined();
+    expect(result.tools).toHaveLength(1);
+    expect(result.messages).toHaveLength(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Circuit breaker
+// ---------------------------------------------------------------------------
+
+describe("circuit breaker", () => {
+  beforeEach(() => {
+    _resetForTest();
+  });
+
+  test("does not trip on successful cache reads", () => {
+    const result = makeWarmupResult({ cacheReadTokens: 50000, cacheCreationTokens: 0 });
+    expect(checkCircuitBreaker(result)).toBe(false);
+    expect(isCircuitBreakerTripped()).toBe(false);
+  });
+
+  test("counts uncached warmups", () => {
+    const bad = makeWarmupResult({ cacheReadTokens: 0, cacheCreationTokens: 50000 });
+    expect(checkCircuitBreaker(bad)).toBe(false); // 1st failure
+    expect(checkCircuitBreaker(bad)).toBe(false); // 2nd failure
+    expect(isCircuitBreakerTripped()).toBe(false);
+  });
+
+  test("trips after 3 consecutive uncached warmups", () => {
+    const bad = makeWarmupResult({ cacheReadTokens: 0, cacheCreationTokens: 50000 });
+    checkCircuitBreaker(bad); // 1
+    checkCircuitBreaker(bad); // 2
+    const tripped = checkCircuitBreaker(bad); // 3
+    expect(tripped).toBe(true);
+    expect(isCircuitBreakerTripped()).toBe(true);
+  });
+
+  test("resets failure count on successful read", () => {
+    const bad = makeWarmupResult({ cacheReadTokens: 0, cacheCreationTokens: 50000 });
+    const good = makeWarmupResult({ cacheReadTokens: 50000, cacheCreationTokens: 0 });
+
+    checkCircuitBreaker(bad); // 1
+    checkCircuitBreaker(bad); // 2
+    checkCircuitBreaker(good); // reset
+    checkCircuitBreaker(bad); // 1 (restarted)
+    checkCircuitBreaker(bad); // 2
+    expect(isCircuitBreakerTripped()).toBe(false);
+  });
+
+  test("stays tripped permanently after tripping", () => {
+    const bad = makeWarmupResult({ cacheReadTokens: 0, cacheCreationTokens: 50000 });
+    const good = makeWarmupResult({ cacheReadTokens: 50000, cacheCreationTokens: 0 });
+
+    checkCircuitBreaker(bad);
+    checkCircuitBreaker(bad);
+    checkCircuitBreaker(bad); // tripped
+    expect(isCircuitBreakerTripped()).toBe(true);
+
+    // Even good results don't un-trip
+    checkCircuitBreaker(good);
+    expect(isCircuitBreakerTripped()).toBe(true);
+  });
+
+  test("does not count failed requests", () => {
+    const failed = makeWarmupResult({ ok: false, cacheReadTokens: 0, cacheCreationTokens: 0 });
+    checkCircuitBreaker(failed);
+    checkCircuitBreaker(failed);
+    checkCircuitBreaker(failed);
+    expect(isCircuitBreakerTripped()).toBe(false);
+  });
+
+  test("partial hits (read > 0 + creation > 0) reset counter", () => {
+    const bad = makeWarmupResult({ cacheReadTokens: 0, cacheCreationTokens: 50000 });
+    const partial = makeWarmupResult({ cacheReadTokens: 30000, cacheCreationTokens: 20000 });
+
+    checkCircuitBreaker(bad); // 1
+    checkCircuitBreaker(bad); // 2
+    checkCircuitBreaker(partial); // has reads → reset
+    checkCircuitBreaker(bad); // 1
+    expect(isCircuitBreakerTripped()).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// shouldWarm decision function
+// ---------------------------------------------------------------------------
+
+describe("shouldWarm", () => {
+  beforeEach(() => {
+    _resetForTest();
+  });
+
+  test("returns false when cache is still fresh", () => {
+    const state = makeSessionState({
+      lastRequestTime: Date.now() - 60_000, // 1 min ago — cache still fresh
+    });
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+
+    // Need histogram with some data
+    const hist = createHistogram();
+    for (let i = 0; i < 50; i++) recordGap(hist, 300_000);
+
+    expect(shouldWarm(state, profile, hist)).toBe(false);
+  });
+
+  test("returns false when cache already expired", () => {
+    const state = makeSessionState({
+      lastRequestTime: Date.now() - 400_000, // 6.7 min ago — past 5m TTL
+    });
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+
+    const hist = createHistogram();
+    for (let i = 0; i < 50; i++) recordGap(hist, 300_000);
+
+    expect(shouldWarm(state, profile, hist)).toBe(false);
+  });
+
+  test("returns true when in warmup window with good survival", () => {
+    const now = Date.now();
+    const state = makeSessionState({
+      lastRequestTime: now - 270_000, // 4.5 min ago — inside warmup window
+      cacheAnalytics: {
+        ...makeCacheAnalytics(),
+        lastRequestBody: compressBody('{"model":"claude-sonnet-4-20250514","max_tokens":16384,"stream":true,"messages":[{"role":"user","content":"test"}]}'),
+      },
+    });
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+
+    // Histogram showing users commonly return at 5-7 min intervals
+    const hist = createHistogram();
+    for (let i = 0; i < 50; i++) recordGap(hist, 360_000); // 6m gaps
+
+    expect(shouldWarm(state, profile, hist, now)).toBe(true);
+  });
+
+  test("returns false when session is marked dead", () => {
+    const state = makeSessionState({
+      lastRequestTime: Date.now() - 270_000,
+      warmup: { lastWarmupAt: 0, warmupCount: 0, warmupHits: 0, disabled: true },
+      cacheAnalytics: {
+        ...makeCacheAnalytics(),
+        lastRequestBody: compressBody('{"test": true}'),
+      },
+    });
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+    const hist = createHistogram();
+    for (let i = 0; i < 50; i++) recordGap(hist, 360_000);
+
+    expect(shouldWarm(state, profile, hist)).toBe(false);
+  });
+
+  test("returns false when already warmed in this TTL window", () => {
+    const now = Date.now();
+    const state = makeSessionState({
+      lastRequestTime: now - 270_000,
+      warmup: {
+        lastWarmupAt: now - 30_000, // warmed 30s ago
+        warmupCount: 1,
+        warmupHits: 0,
+        disabled: false,
+      },
+      cacheAnalytics: {
+        ...makeCacheAnalytics(),
+        lastRequestBody: compressBody('{"test": true}'),
+      },
+    });
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+    const hist = createHistogram();
+    for (let i = 0; i < 50; i++) recordGap(hist, 360_000);
+
+    expect(shouldWarm(state, profile, hist, now)).toBe(false);
+  });
+
+  test("returns false when session has too few turns", () => {
+    const now = Date.now();
+    const state = makeSessionState({
+      lastRequestTime: now - 270_000,
+      messageCount: 4, // 2 turns (user+assistant each) — below threshold of 3 turns (6 messages)
+      cacheAnalytics: {
+        ...makeCacheAnalytics(),
+        lastRequestBody: compressBody('{"test": true}'),
+      },
+    });
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+    const hist = createHistogram();
+    for (let i = 0; i < 50; i++) recordGap(hist, 360_000);
+
+    expect(shouldWarm(state, profile, hist, now)).toBe(false);
+  });
+
+  test("returns false when no stored body", () => {
+    const state = makeSessionState({
+      lastRequestTime: Date.now() - 270_000,
+    });
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+    const hist = createHistogram();
+    for (let i = 0; i < 50; i++) recordGap(hist, 360_000);
+
+    expect(shouldWarm(state, profile, hist)).toBe(false);
+  });
+
+  test("returns false when circuit breaker is tripped", () => {
+    // Trip the circuit breaker
+    const bad = makeWarmupResult({ cacheReadTokens: 0, cacheCreationTokens: 50000 });
+    checkCircuitBreaker(bad);
+    checkCircuitBreaker(bad);
+    checkCircuitBreaker(bad);
+
+    const state = makeSessionState({
+      lastRequestTime: Date.now() - 270_000,
+      cacheAnalytics: {
+        ...makeCacheAnalytics(),
+        lastRequestBody: compressBody('{"test": true}'),
+      },
+    });
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+    const hist = createHistogram();
+    for (let i = 0; i < 50; i++) recordGap(hist, 360_000);
+
+    expect(shouldWarm(state, profile, hist)).toBe(false);
+  });
+
+  test("dampens survival with consecutive text-only turns", () => {
+    const now = Date.now();
+
+    // First: verify this session WOULD warm with 0 text-only turns
+    const baseState = makeSessionState({
+      lastRequestTime: now - 270_000,
+      consecutiveTextOnlyTurns: 0,
+      cacheAnalytics: {
+        ...makeCacheAnalytics(),
+        lastRequestBody: compressBody('{"model":"claude-sonnet-4-20250514","max_tokens":16384,"stream":true,"messages":[{"role":"user","content":"test"}]}'),
+      },
+    });
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+
+    // Histogram with moderate return probability — just above the cost threshold
+    const hist = createHistogram();
+    for (let i = 0; i < 30; i++) recordGap(hist, 360_000); // 60% at 6m
+    for (let i = 0; i < 70; i++) recordGap(hist, 30_000);  // 70% at 30s (never return after 4.5m)
+
+    expect(shouldWarm(baseState, profile, hist, now)).toBe(true);
+
+    // Now: same session but with 5 consecutive text-only turns → 0.5^5 = 3.1%× probability
+    const dampenedState = makeSessionState({
+      lastRequestTime: now - 270_000,
+      consecutiveTextOnlyTurns: 5,
+      cacheAnalytics: {
+        ...makeCacheAnalytics(),
+        lastRequestBody: compressBody('{"model":"claude-sonnet-4-20250514","max_tokens":16384,"stream":true,"messages":[{"role":"user","content":"test"}]}'),
+      },
+    });
+
+    // With dampening, the effective probability drops below threshold
+    expect(shouldWarm(dampenedState, profile, hist, now)).toBe(false);
+  });
+
+  test("forceKeepWarm bypasses survival analysis and turn count", () => {
+    const now = Date.now();
+    const state = makeSessionState({
+      lastRequestTime: now - 270_000,
+      messageCount: 2, // only 1 turn — normally blocked by MIN_TURNS
+      consecutiveTextOnlyTurns: 5, // would dampen survival to ~0
+      warmup: {
+        lastWarmupAt: 0,
+        warmupCount: 0,
+        warmupHits: 0,
+        disabled: false,
+        forceKeepWarm: true,
+      },
+      cacheAnalytics: {
+        ...makeCacheAnalytics(),
+        lastRequestBody: compressBody('{"test": true}'),
+      },
+    });
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+    const hist = createHistogram(); // empty — no data
+
+    expect(shouldWarm(state, profile, hist, now)).toBe(true);
+  });
+
+  test("forceKeepWarm warms across multiple TTL windows", () => {
+    const now = Date.now();
+    const state = makeSessionState({
+      lastRequestTime: now - 870_000, // 14.5 min ago — well past first 5m TTL
+      warmup: {
+        lastWarmupAt: now - 310_000, // last warmup 5m10s ago — previous window
+        warmupCount: 2,
+        warmupHits: 0,
+        disabled: false,
+        forceKeepWarm: true,
+      },
+      cacheAnalytics: {
+        ...makeCacheAnalytics(),
+        lastRequestBody: compressBody('{"test": true}'),
+      },
+    });
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+    const hist = createHistogram();
+
+    // 870s elapsed, ttl=300s → window index 2, into_window = 870%300 = 270s
+    // warmup margin = 45s → threshold = 255s → 270 > 255 → should warm
+    expect(shouldWarm(state, profile, hist, now)).toBe(true);
+  });
+
+  test("forceKeepWarm still respects circuit breaker", () => {
+    const bad = makeWarmupResult({ cacheReadTokens: 0, cacheCreationTokens: 50000 });
+    checkCircuitBreaker(bad);
+    checkCircuitBreaker(bad);
+    checkCircuitBreaker(bad);
+
+    const now = Date.now();
+    const state = makeSessionState({
+      lastRequestTime: now - 270_000,
+      warmup: {
+        lastWarmupAt: 0,
+        warmupCount: 0,
+        warmupHits: 0,
+        disabled: false,
+        forceKeepWarm: true,
+      },
+      cacheAnalytics: {
+        ...makeCacheAnalytics(),
+        lastRequestBody: compressBody('{"test": true}'),
+      },
+    });
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+    const hist = createHistogram();
+
+    expect(shouldWarm(state, profile, hist, now)).toBe(false);
+  });
+
+  test("marks session dead when survival drops below threshold", () => {
+    const now = Date.now();
+    const state = makeSessionState({
+      lastRequestTime: now - 275_000, // 4m35s — in warmup window
+      cacheAnalytics: {
+        ...makeCacheAnalytics(),
+        lastRequestBody: compressBody('{"test": true}'),
+      },
+    });
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+
+    // All gaps are very short — nobody ever comes back after 4.5m
+    const hist = createHistogram();
+    for (let i = 0; i < 100; i++) recordGap(hist, 5_000);
+
+    expect(shouldWarm(state, profile, hist, now)).toBe(false);
+    expect(state.warmup?.disabled).toBe(true);
+  });
+
+
+});
+
+// ---------------------------------------------------------------------------
+// Profile building
+// ---------------------------------------------------------------------------
+
+describe("buildAnthropicProfile", () => {
+  test("5m TTL has correct parameters", () => {
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+    expect(profile.ttlMs).toBe(300_000);
+    expect(profile.warmupMarginMs).toBe(45_000);
+    expect(profile.cacheReadCostPerMTok).toBeGreaterThan(0);
+    expect(profile.cacheMissCostPerMTok).toBeGreaterThan(profile.cacheReadCostPerMTok);
+  });
+
+  test("1h TTL has correct parameters", () => {
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "1h");
+    expect(profile.ttlMs).toBe(3_600_000);
+    expect(profile.warmupMarginMs).toBe(300_000);
+  });
+
+  test("cost ratio gives reasonable threshold", () => {
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+    const threshold = profile.cacheReadCostPerMTok / profile.cacheMissCostPerMTok;
+    // Should be around 0.08 (10% of base / 125% of base = 0.08)
+    expect(threshold).toBeGreaterThan(0.03);
+    expect(threshold).toBeLessThan(0.15);
+  });
+});


### PR DESCRIPTION
## Summary

Sends `max_tokens:0` keepalive requests to refresh Anthropic's prompt cache before it expires, using survival analysis to predict whether the user will return. Only warms when `P(return) × cache_miss_savings > warmup_cost`.

- **Survival model**: Empirical inter-turn gap histograms (20 log-scale bins, 10s→4h) with time-of-day slots and Bayesian blending of per-session + global data
- **User controls**: `/done` (🧊 freezes session) and `/keep` (🔥 forces warming) slash commands intercepted at gateway level
- **Safety**: Global circuit breaker (3 uncached warmups → kill switch), min 3 turns before warming, dead session detection at <2% survival, consecutive text-only turn dampening

## Design

### Cost model

Warming is worthwhile when `P(return within TTL) > cache_read_cost / cache_miss_cost`. For Sonnet this is ~8% (5m TTL) or ~5% (1h TTL). At 200K Opus tokens, one wasted warmup costs $0.30 — the min-turn guard and text-only dampening minimize this.

### Warming window

Warmups fire in the `[TTL - margin, TTL)` window only (last 45s for 5m TTL, last 5m for 1h TTL). Once `elapsed >= TTL`, no warmup is sent. This limits abandoned sessions to at most one wasted warmup.

### `/keep` multi-window warming

When the user sends `/keep`, warming continues across TTL boundaries using `elapsed % ttlMs` to find the warmup window within each cycle. `/done` stops it. Circuit breaker is always respected.

### Text-only turn dampening

Each consecutive `end_turn` response with no `tool_use` blocks halves the effective survival probability: `pReturn *= 0.5^consecutiveTextOnlyTurns`. Resets when tools are used. Provides soft task-completion detection without hard cutoffs.

## Files changed

| File | Change |
|---|---|
| `gateway/src/cache-warmer.ts` | **New** — survival model, profiles, decision function, circuit breaker, execution, SQLite persistence |
| `gateway/src/translate/types.ts` | `WarmupState`, `SurvivalModel`, `InterTurnHistogram`, `TimeSlot`, `WarmupResult` types + `SessionState` fields |
| `core/src/config.ts` | `cache.warming` config section (enabled, minReturnProbability) |
| `core/src/db.ts` | Migration 15: `warmup_histograms` table |
| `gateway/src/idle.ts` | Warmup checks on 30s tick, histogram load/flush |
| `gateway/src/pipeline.ts` | `/done` + `/keep` interception, gap recording, warmup hit tracking, text-only turn counter |
| `gateway/src/sentry.ts` | Warmup metrics (sent/refresh/uncached/hit/cost) |
| `gateway/test/cache-warmer.test.ts` | **New** — 50 tests covering histogram, survival, blending, body patching, circuit breaker, decision function, dampening, force-warm |
| `core/test/db.test.ts` | Schema version 14→15 |

## Testing

1153 tests pass (50 new), 0 failures. Covers all guard conditions, circuit breaker state machine, body patching (normal/thinking/tool_choice), histogram blending, and force-warm multi-window logic.