### PR TITLE
fix: isolate subagent turns from parent session's dynamic max_tokens EMA

### DIFF
--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -1100,6 +1100,8 @@ function postResponse(
   requestBody?: string,
   /** Active gen_ai.chat span to finalize with usage attributes. */
   genAiSpan?: Sentry.Span,
+  /** When true, skip output EMA / max_tokens state updates (sub-agent turn). */
+  isSubagentTurn = false,
 ): void {
   const { sessionID, projectPath } = sessionState;
 
@@ -1211,21 +1213,27 @@ function postResponse(
       (sessionState.turnsSinceCuration ?? 0) + 1;
 
     // --- Output tracking for dynamic max_tokens sizing ---
-    sessionState.lastStopReason = resp.stopReason;
-    sessionState.lastInputTokens =
-      (resp.usage.inputTokens ?? 0) +
-      (resp.usage.cacheReadInputTokens ?? 0) +
-      (resp.usage.cacheCreationInputTokens ?? 0);
-    const outputTokens = resp.usage.outputTokens;
-    if (outputTokens > 0) {
-      const EMA_ALPHA = 0.3;
-      sessionState.outputTokensEMA =
-        sessionState.outputTokensEMA == null
-          ? outputTokens
-          : Math.round(
-              sessionState.outputTokensEMA * (1 - EMA_ALPHA) +
-                outputTokens * EMA_ALPHA,
-            );
+    // Sub-agent turns are excluded: their short tool-call responses would
+    // contaminate the parent session's EMA, causing the next parent turn to
+    // receive an artificially low max_tokens (floor of 8192) which truncates
+    // comprehensive planning responses.
+    if (!isSubagentTurn) {
+      sessionState.lastStopReason = resp.stopReason;
+      sessionState.lastInputTokens =
+        (resp.usage.inputTokens ?? 0) +
+        (resp.usage.cacheReadInputTokens ?? 0) +
+        (resp.usage.cacheCreationInputTokens ?? 0);
+      const outputTokens = resp.usage.outputTokens;
+      if (outputTokens > 0) {
+        const EMA_ALPHA = 0.3;
+        sessionState.outputTokensEMA =
+          sessionState.outputTokensEMA == null
+            ? outputTokens
+            : Math.round(
+                sessionState.outputTokensEMA * (1 - EMA_ALPHA) +
+                  outputTokens * EMA_ALPHA,
+              );
+      }
     }
 
     // --- Schedule background work (fire-and-forget) ---
@@ -1456,6 +1464,11 @@ async function handleConversationTurn(
   const { sessionID, isNew, tier } = await identifySession(req, projectPath);
   const sessionState = getOrCreateSession(sessionID, projectPath);
 
+  // Detect sub-agent turns (e.g. OpenCode explore/general agents) that were
+  // merged into the parent session via x-parent-session-id.  These turns
+  // must NOT pollute the parent's output EMA or max_tokens state.
+  const isSubagentTurn = extractParentSessionId(req.rawHeaders) != null;
+
   // Bind auth credential to this session for background workers
   if (cred) {
     setSessionAuth(sessionID, cred);
@@ -1533,7 +1546,8 @@ async function handleConversationTurn(
 
   log.info(
     `turn: session=${sessionID.slice(0, 16)} messages=${req.messages.length} ` +
-      `model=${req.model} stream=${req.stream} new=${isNew} tier=${tier}`,
+      `model=${req.model} stream=${req.stream} new=${isNew} tier=${tier}` +
+      (isSubagentTurn ? ` subagent=true` : ``),
   );
 
   // --- 4. Set model limits ---
@@ -1568,9 +1582,14 @@ async function handleConversationTurn(
   // clients (OpenCode, generic) often send low/missing values (defaults to
   // 4096 in ingress parsing). Apply a hybrid headroom + history algorithm
   // that tightens from the 32K ceiling based on actual output patterns.
+  //
+  // Sub-agent turns are excluded: their output patterns differ wildly from
+  // the parent conversation (many short tool-call responses) and would
+  // contaminate the EMA, causing the parent's next turn to receive an
+  // artificially low max_tokens.
   const clientType = detectClientType(req.rawHeaders);
   const isCC = clientType === "claude-code" || hasBillingHeader(req.system);
-  if (!isCC) {
+  if (!isCC && !isSubagentTurn) {
     const computed = computeMaxTokens(
       modelSpec.output,
       modelSpec.context,
@@ -1820,7 +1839,7 @@ async function handleConversationTurn(
     );
     return buildStreamingResponse(
       upstreamResponse,
-      (resp) => postResponse(req, resp, sessionState, config, requestBody, genAiSpan),
+      (resp) => postResponse(req, resp, sessionState, config, requestBody, genAiSpan, isSubagentTurn),
       hasRecallTool
         ? { modifiedReq, config, sessionState, cacheOptions }
         : undefined,
@@ -1857,7 +1876,7 @@ async function handleConversationTurn(
       log.info(
         `recall (non-stream, mixed): stored result for session ${sessionState.sessionID.slice(0, 16)}`,
       );
-      postResponse(req, markerResp, sessionState, config, requestBody, genAiSpan);
+      postResponse(req, markerResp, sessionState, config, requestBody, genAiSpan, isSubagentTurn);
       return nonStreamHttpResponse(markerResp);
     }
 
@@ -1880,7 +1899,7 @@ async function handleConversationTurn(
         `recall follow-up upstream error: ${followUpResponse.status} ${errorBody.slice(0, 500)}`,
       );
       // Fall back to response with marker (no continuation)
-      postResponse(req, markerResp, sessionState, config, requestBody, genAiSpan);
+      postResponse(req, markerResp, sessionState, config, requestBody, genAiSpan, isSubagentTurn);
       return nonStreamHttpResponse(markerResp);
     }
 
@@ -1900,11 +1919,11 @@ async function handleConversationTurn(
         resp.usage.cacheCreationInputTokens;
     }
 
-    postResponse(req, continuationResp, sessionState, config, requestBody, genAiSpan);
+    postResponse(req, continuationResp, sessionState, config, requestBody, genAiSpan, isSubagentTurn);
     return nonStreamHttpResponse(continuationResp);
   }
 
-  postResponse(req, resp, sessionState, config, requestBody, genAiSpan);
+  postResponse(req, resp, sessionState, config, requestBody, genAiSpan, isSubagentTurn);
   return nonStreamHttpResponse(resp);
 }
 

--- a/packages/gateway/test/max-tokens.test.ts
+++ b/packages/gateway/test/max-tokens.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from "bun:test";
 import { computeMaxTokens } from "../src/pipeline";
-import { detectClientType } from "../src/session";
+import { detectClientType, extractParentSessionId } from "../src/session";
 import { hasBillingHeader } from "../src/cch";
 
 // ---------------------------------------------------------------------------
@@ -104,6 +104,17 @@ describe("computeMaxTokens", () => {
       computeMaxTokens(16_000, 200_000, 3000, "end_turn", 50_000),
     ).toBe(9000);
   });
+
+  test("floor (8192) is too small for comprehensive planning responses", () => {
+    // This documents the sub-agent EMA pollution scenario:
+    // After many sub-agent tool-call turns with small outputs (e.g. 200 tokens),
+    // the EMA drops low → 3 × 200 = 600 → clamped to floor 8192.
+    // 8192 is insufficient for comprehensive planning responses that need 15-30K.
+    // The fix: skip EMA updates for sub-agent turns entirely.
+    const subagentEMA = 200; // typical short tool-call output
+    const result = computeMaxTokens(128_000, 200_000, subagentEMA, "tool_use", 50_000);
+    expect(result).toBe(8192); // floor — too small for parent conversation
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -163,5 +174,30 @@ describe("hasBillingHeader", () => {
       "You are a helpful assistant.\n" +
       "x-anthropic-billing-header: cc_version=2.1.37.abc; cc_entrypoint=cli; cch=a75d0;";
     expect(hasBillingHeader(system)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractParentSessionId — sub-agent detection
+// ---------------------------------------------------------------------------
+
+describe("extractParentSessionId", () => {
+  test("returns parent session ID when x-parent-session-id is present", () => {
+    expect(
+      extractParentSessionId({ "x-parent-session-id": "parent-abc-123" }),
+    ).toBe("parent-abc-123");
+  });
+
+  test("returns null when no parent header is present", () => {
+    expect(extractParentSessionId({})).toBeNull();
+    expect(
+      extractParentSessionId({ "x-session-affinity": "my-session" }),
+    ).toBeNull();
+  });
+
+  test("returns null for empty parent header value", () => {
+    expect(
+      extractParentSessionId({ "x-parent-session-id": "" }),
+    ).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- **Fixes PR #211 regression**: OpenCode subagent turns (explore/general/code agents) are merged into the parent session via `x-parent-session-id`, polluting the parent's `outputTokensEMA` with many short tool-call responses. This causes the parent's next turn to receive `max_tokens=8192` (the floor) instead of the 32K ceiling needed for comprehensive planning responses, truncating the output mid-generation.
- **Fix**: Detect subagent turns via `extractParentSessionId()` and skip both the dynamic `max_tokens` override and the EMA/`lastStopReason`/`lastInputTokens` updates in `postResponse()`. Subagent turns use the model ceiling (32K) for `max_tokens`.
- **No impact on Claude Code** (already excluded via `isCC` check) or non-subagent OpenCode turns (EMA tracking continues normally).

## Changes

- `packages/gateway/src/pipeline.ts`: Detect `isSubagentTurn` after session identification, guard `computeMaxTokens` and EMA updates, pass flag through all `postResponse()` call sites, add `subagent=true` to turn log
- `packages/gateway/test/max-tokens.test.ts`: Add test documenting the EMA pollution scenario and `extractParentSessionId` guard tests