### PR TITLE
feat(ui): add markdown rendering to web dashboard

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -4,69 +4,57 @@
 
 ### Architecture
 
-<!-- lore:019e1349-63c2-72f1-8725-db0ee29efedd -->
-* **3-tier session identification with header learning**: 3-tier session identification: (1) Known headers (x-claude-code-session-id, x-session-affinity, x-parent-session-id); (2) Learned x-\* headers with ID-like values; (3) Fingerprint fallback. identifySession() returns {sessionId, tier}.
-
-<!-- lore:019e1405-1594-7e54-a90c-095bb0a2df12 -->
-* **Agent launcher injects environment variables per agent configuration**: Agent launcher provides agent-specific config including binary paths, detection functions, and environment variables. envVars(url) returns per-agent env setup. Claude Code agent gets DISABLE\_AUTO\_COMPACT=1 to prevent client-side compaction at 167K tokens.
-
 <!-- lore:019e1653-a5d6-7639-a060-662e873b71b2 -->
-* **Automated CI monitoring for Claude Code version updates**: CI workflow (.github/workflows/cch-seed-check.yml) monitors Claude Code releases every 6 hours via cron. Compares npm dist-tags against VERSION\_SEEDS in cch.ts. Auto-extracts new seeds via extract-cch-seed.ts --apply, runs tests, creates PR when new versions detected. Manual trigger with force-version input. scripts/check-cc-version.ts provides programmatic version checking with --json flag for CI consumption.
+* **Automated CI monitoring for Claude Code version updates**: CI workflow monitors Claude Code releases every 6 hours, compares npm dist-tags against VERSION\_SEEDS, auto-extracts seeds via extract-cch-seed.ts --apply, runs tests, creates PRs for new versions. Manual trigger available. Downloads binaries for all platforms, generates oracle pairs, extracts seeds, commits updates.
 
 <!-- lore:019e1438-5ff0-77f3-abf8-5c815425f0ec -->
-* **CCH billing signature system for Claude Code request authentication**: CCH billing signature system with version fallback: Two-layer authentication - JS layer computes SHA-256 suffix from message chars at indices 4,7,20 + version, native layer uses xxHash64(bodyBytes, versionSeed) & 0xFFFFF → 5-hex signatures. resolveSeed() provides fallback for unknown versions by finding closest known version (preferring newer). Current WORKER\_VERSION: "2.1.138", seed: 0x4D659218E32A3268n. Core files: gateway/cch.ts, gateway/pipeline.ts.
-
-<!-- lore:019e1652-4760-7eec-9ae5-b85eb3dbdf89 -->
-* **CI workflow for automated seed extraction and version monitoring**: GitHub Actions workflow monitors Claude Code releases and auto-extracts seeds: Triggers on releases to claude-ai/claude-desktop, downloads new binaries, generates oracle pairs via HTTP capture server, extracts seeds via binary scanning, commits updated VERSION\_SEEDS. Manual trigger via workflow\_dispatch for testing. Uses ubuntu-latest runner, requires GITHUB\_TOKEN for commits.
+* **CCH billing signature system for Claude Code request authentication**: CCH billing signature: two-layer auth system. JS layer computes SHA-256 suffix from message chars at indices 4,7,20 + version. Native layer uses xxHash64(bodyBytes, versionSeed) & 0xFFFFF → 5-hex signatures. resolveSeed() provides fallback for unknown versions. Current WORKER\_VERSION: 2.1.138, seed: 0x4D659218E32A3268n.
 
 <!-- lore:019e1430-1cca-7bd3-81a6-9d345b9cdd4b -->
-* **Claude Code seed extraction via brute-force binary scanning**: Automated Claude Code seed extraction via scripts/extract-cch-seed.ts: Downloads platform binaries, auto-generates oracle pairs by spawning Claude Code binary against local capture server, scans 1-byte-aligned offsets as little-endian uint64. Validates via xxHash64(body, seed) & 0xFFFFF == cch using oracle pairs. \`--apply\` mode patches cch.ts directly. Oracle generation captures signed requests from custom Bun nativeFetch without live traffic. Requires 2+ pairs for collision elimination (~11 collisions per 28M candidates with 20-bit hash).
-
-<!-- lore:019e133c-1e2a-72b4-97c9-75965fe2d0f6 -->
-* **Claude Code sends persistent session ID in HTTP headers**: Claude Code sends persistent X-Claude-Code-Session-Id header (UUID at startup). Persists across compaction, model changes. Normalizes to lowercase: rawHeaders\['x-claude-code-session-id']. Sub-agents share parent ID.
-
-<!-- lore:019e1330-a34e-7917-9802-35093f041a31 -->
-* **Data management pattern across CLI and web UI**: Unified data management: core/data.ts exports APIs (listProjects, clearProject), CLI data.ts provides terminal interface, gateway ui.ts serves web forms. Both use same core APIs. Clear operations regenerate .lore.md and warn to commit.
-
-<!-- lore:019e1328-d565-7f53-bc81-915c48531370 -->
-* **Gateway HTTP server uses Bun.serve with manual routing**: Gateway uses Bun.serve() on port 6969 with manual if/else routing in fetch() handler. Routes: POST /v1/messages (Anthropic), POST /v1/chat/completions (OpenAI), GET /v1/models, GET /health. Uses jsonResponse(), errorResponse() helpers.
+* **Claude Code seed extraction via brute-force binary scanning**: Automated seed extraction via extract-cch-seed.ts: downloads binaries, spawns Claude Code against local capture server for oracle pairs, scans 1-byte-aligned offsets as little-endian uint64. Validates via xxHash64(body, seed) & 0xFFFFF == cch. --apply mode patches cch.ts. Requires 2+ pairs for collision elimination.
 
 <!-- lore:019e13f6-44cf-7406-a618-2ef9b4faa99c -->
 * **Git-based project identification with 4-tier resolution hierarchy**: Git-based project identification: 4-tier resolution via git remote + path. ensureProject() tries: (1) exact path; (2) path alias; (3) git remote (prefers upstream > origin); (4) create new. Schema v14 adds git\_remote. Prevents fragmentation across worktrees/clones.
 
+<!-- lore:019e16c6-4b9b-78bf-85ae-90e7049076d9 -->
+* **kv\_meta table for per-path metadata caching pattern**: kv\_meta table provides key-value persistence: CREATE TABLE kv\_meta (key TEXT PRIMARY KEY, value TEXT). Used for config fingerprints and file state caching. Pattern: cache mtime+hash per .lore.md path to skip redundant processing. Keys should be namespaced, values JSON-serialized. Use INSERT...ON CONFLICT(key) DO UPDATE for upserts.
+
 <!-- lore:019e13fe-49f6-7107-b47e-c1c1f7e82306 -->
 * **Lore gradient system injects multi-layer context via system prompt prefixes**: Lore gradient system builds 4-layer hierarchical context via system prompt injection: distillations, LTM knowledge, context-specific, and session data. buildPromptPrefix() formats with markdown headers, injects via systemPromptWithGradientContext(). Replaces compaction with progressive knowledge accumulation.
 
-<!-- lore:019e1352-b81c-7997-8006-ab66063c4b32 -->
-* **Multiple host binding via Bun.serve instance spawning**: Gateway spawns one Bun.serve() instance per host (single hostname limit). Parses comma-separated LORE\_HOST and --host flags into hosts array. Returns combined stop functions. Agent connections use first host.
-
-<!-- lore:019e1651-d009-78d2-93d8-66832c595ea5 -->
-* **Version monitoring CI workflow tracks Claude Code seed changes**: CI workflow monitors Claude Code version changes via scheduled runs and manual triggers. Downloads binaries for all platforms (darwin-arm64, darwin-x64, linux-x64, win32-x64), generates oracle pairs, extracts seeds, and commits updates to VERSION\_SEEDS mapping. Handles version detection failures gracefully. Provides both automated monitoring and manual seed extraction capabilities through unified tooling.
+<!-- lore:019e16d8-2168-7ba3-9e36-7e7df4539ae3 -->
+* **Plan mode to build mode transition with .opencode/plans execution**: Plan mode transitions to build mode via system reminder indicating operational mode change from read-only to active execution. Build mode permits file changes, shell commands, and tool usage. Plans stored in .opencode/plans/ directory with timestamp-description naming. Agent reads plan file and executes defined steps sequentially. Mode transition removes read-only constraints and activates full tool arsenal for implementation.
 
 ### Gotcha
 
-<!-- lore:019e143d-5bab-7d1a-b982-58ec976ae421 -->
-* **Claude Code binary requires proper filesystem context for API calls**: Claude Code binary performs extensive filesystem scanning before making API calls, causing timeouts in isolated environments. Binary initializes OAuth flows, scans project directories, and needs proper home/working directories. Attempts to capture network traffic via minimal environments (empty dirs, fake API keys) fail as binary never reaches network phase. Use established project directories with proper auth setup for successful API interaction.
-
-<!-- lore:019e1453-61d9-73e1-973c-a8458a7b2e90 -->
-* **Claude Code uses custom unreleased Bun fork for signing**: Claude Code binary is built with custom Bun fork (v1.3.14), not publicly available. Binary has fixed entrypoint, cannot be used as general-purpose Bun runtime. BUN\_BE\_BUN env var not present. The xxHash64 seed is baked into this custom fork's nativeFetch implementation, which signs request bodies before network transmission.
+<!-- lore:019e16d4-0245-7ff4-948b-7955aa016978 -->
+* **Cache warming logs need input\_tokens for cost visibility**: Cache warming requests should log input\_tokens to show cached prefix size and cost. Enhanced logs format: 'cache-warmer: ✓ refresh session=abc... input=85000 cacheRead=84500 hit=99% cost=$0.0127'. Shows total input tokens, cache hit ratio, and actual cost. Essential for monitoring cache effectiveness and billing impact.
 
 <!-- lore:019e1403-b62a-7944-8d5e-f6d70ddc2801 -->
-* **Gradient layer resets indicate undetected Claude Code compaction events**: Claude Code compaction detection via gradient layer resets: Auto-compacts through multiple paths. Gateway detects via gradient layer drops (4→0) with system prompt changes or message count drops (19→3). Session-state detection more reliable than pattern matching. Prevention: DISABLE\_AUTO\_COMPACT=1 env var or token scaling via scaleUsageForClient().
+* **Gradient layer resets indicate undetected Claude Code compaction events**: Claude Code auto-compacts via multiple paths. Gateway detects via gradient layer drops (4→0) with system prompt changes or message count drops. Session-state detection more reliable than pattern matching. Prevention: DISABLE\_AUTO\_COMPACT=1 env var or token scaling via scaleUsageForClient().
+
+<!-- lore:019e16c9-0a74-77fc-92f7-ba05b5ed19bb -->
+* **OpenCode slash commands require SSE streaming when stream:true set**: OpenCode/Claude Code requests with stream:true expect SSE responses, not JSON. Plain JSON responses get dropped silently. Use streamHttpResponse() with buildSSETextResponse() for streaming clients, jsonResponse() for non-streaming. Check req.stream boolean to determine format. Essential for slash command responses and synthetic intercepts.
+
+<!-- lore:019e16c9-f53f-739f-b9f1-c825aec1d375 -->
+* **Subagent turns must skip temporal storage to prevent distillation contamination**: Subagent turns must skip temporal storage (lines 1196-1217), session state updates (1277-1290), and background work scheduling (1294) in gateway/pipeline.ts to prevent distillation contamination. Without isSubagentTurn guards, subagent messages trigger background distillation that injects synthetic assistant prefixes, causing plan mode sessions to stall after completion with 60-100+ second delays and model echoing plan context blocks instead of continuing execution.
 
 ### Pattern
 
-<!-- lore:019e138b-055a-7ad6-934e-4a7ac5476a04 -->
-* **Gradient system uses layerMap for O(1) context lookup optimization**: Gradient layerMap optimization: O(1) context lookup via layerMap.set(layer.id, layer) during init, layerMap.get(contextId) for retrieval. Eliminates O(n) array searches in layers 2,3,4. Essential for scaling with large context histories.
+<!-- lore:019e16d2-2d7f-70a5-8f17-038b85cc11c5 -->
+* **Cache warmer logging pattern for prompt cache telemetry**: Cache warming requests log comprehensive telemetry: input\_tokens (total request size), cache\_read\_tokens (cached prefix), cache\_write\_tokens (new content), hit percentage, and estimated cost. Format: 'cache-warmer: ✓ refresh session=... input=85000 cacheRead=84500 hit=99% cost=$0.0127'. Status symbols: ✓ (full hit), ~ (partial), ✗ (uncached). Essential for monitoring cache efficiency and costs in warmup operations.
 
 <!-- lore:019e132b-1b1f-798a-ae69-71a7f40bdeb0 -->
-* **Lore.md file managed via UUID-tracked markdown with import/export cycle**: .lore.md contains knowledge as markdown with lore:UUID markers. exportLoreFile() writes DB entries by category. importLoreFile() parses: known UUID updates, unknown creates with ID, no UUID creates new UUIDv7. shouldImportLoreFile() detects changes via hash.
+* **Lore.md file managed via UUID-tracked markdown with import/export cycle**: .lore.md managed as UUID-tracked markdown. exportLoreFile() writes DB entries by category. importLoreFile() parses: known UUIDs update, unknown creates with ID, no UUID creates new UUIDv7. shouldImportLoreFile() uses kv\_meta cache (mtime+hash) to skip redundant reads. exportLoreFile() skips writes when content hash unchanged.
 
-<!-- lore:019e1417-dcb7-7e19-ba62-122854c393bc -->
-* **scaleUsageForClient utility for consistent token capping**: scaleUsageForClient applies 40% scaling to all usage fields (input\_tokens, cache\_creation\_input\_tokens, cache\_read\_input\_tokens, output\_tokens) keeping reported usage below 167K threshold to prevent Claude Code auto-compact while preserving real values for internal tracking.
+<!-- lore:019e16d8-9660-7d58-a4ca-c8b46f72a7fb -->
+* **Markdown rendering with micromark in @loreai/core package**: Added markdown rendering capability to @loreai/core using micromark library. renderMarkdown() function in packages/core/src/markdown.ts provides HTML conversion with security defaults. Exported from main index.ts for use across Lore ecosystem. micromark chosen for lightweight, secure parsing without unsafe HTML extensions. Pattern: centralized markdown processing in core package enables consistent rendering across all Lore components.
 
-<!-- lore:019e1439-4aa6-7313-a63f-c2409129b6d1 -->
-* **sessionNeedsBilling sticky flag prevents billing header loss across turns**: sessionNeedsBilling Map tracks bearer-token sessions requiring billing headers. captureBillingPrefix() sets sticky flag when x-anthropic-billing-header detected. Flag persists for session lifetime. buildBillingBlock() returns null for unflagged sessions.
+<!-- lore:019e16d8-9646-781e-9c41-7bb0094ad8ba -->
+* **Micromark used for safe markdown rendering in UI components**: Project uses micromark library for markdown-to-HTML conversion in UI. renderMarkdown() function in packages/core/src/markdown.ts provides sanitized HTML output. Exported from core package index for use across gateway and other components. Scoped CSS classes applied to rendered content for styling isolation.
 
-<!-- lore:019e1439-c675-76be-8c0b-3e11b5390dd4 -->
-* **Version suffix computation uses message chars at indices 4,7,20**: cc\_version suffix format: MAJOR.MINOR.PATCH.XXX where XXX = sha256(WORKER\_SALT + chars + version)\[:3]. chars = user message characters at string indices 4, 7, 20 (pad with '0' if shorter). Makes billing header per-turn-unique for replay attack prevention. Current WORKER\_VERSION is "2.1.138".
+<!-- lore:019e16d8-9650-717e-a4de-acbb01defd1a -->
+* **Monorepo dependency management with workspace references**: When adding dependencies to workspace packages in monorepo, use npm install from package root, not workspace root. Pattern: cd packages/core && npm install micromark installs to correct package.json. Workspace references (@loreai/core) automatically resolve to local packages during development but publish correctly to npm. Always verify package.json changes are in target workspace, not root.
+
+<!-- lore:019e16d8-2141-7cc8-be6d-bd3c2db6b791 -->
+* **Plan execution workflow from .opencode/plans directory**: Plan mode creates executable plans in .opencode/plans/ with timestamped filenames (e.g., 1778494915984-clever-panda.md). When switching from plan to build mode, system prompts to execute the plan file. Plans contain structured task breakdowns with implementation steps. Agent reads plan content and executes sequentially. Useful for complex multi-step implementations that benefit from upfront planning phase.

--- a/bun.lock
+++ b/bun.lock
@@ -16,13 +16,16 @@
       "version": "0.16.0",
       "dependencies": {
         "@huggingface/hub": "2.11.0",
-        "fastembed": "^2.1.0",
+        "micromark": "^4.0.0",
         "remark": "^15.0.1",
         "uuidv7": "^1.1.0",
         "zod": "^4.3.6",
       },
       "devDependencies": {
         "@types/mdast": "^4.0.4",
+      },
+      "optionalDependencies": {
+        "fastembed": "^2.1.0",
       },
     },
     "packages/gateway": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@huggingface/hub": "2.11.0",
+    "micromark": "^4.0.0",
     "remark": "^15.0.1",
     "uuidv7": "^1.1.0",
     "zod": "^4.3.6"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,12 +22,15 @@ export * as log from "./log";
 
 export {
   runRecall,
+  searchRecall,
   RECALL_TOOL_DESCRIPTION,
   RECALL_PARAM_DESCRIPTIONS,
   type RecallInput,
   type RecallResult,
   type RecallScope,
   type ScoredDistillation,
+  type TaggedResult,
+  type ScoredTaggedResult,
 } from "./recall";
 
 export type {
@@ -142,4 +145,5 @@ export {
   normalize,
   sanitizeSurrogates,
   unescapeMarkdown,
+  renderMarkdown,
 } from "./markdown";

--- a/packages/core/src/markdown.ts
+++ b/packages/core/src/markdown.ts
@@ -1,3 +1,4 @@
+import { micromark } from "micromark";
 import { remark } from "remark";
 import type {
   Root,
@@ -126,4 +127,18 @@ export function strong(value: string): Strong {
 
 export function root(...children: Root["children"]): Root {
   return { type: "root", children };
+}
+
+/**
+ * Render a markdown string to sanitized HTML.
+ *
+ * Uses micromark with default options:
+ * - Raw HTML in input is escaped (no allowDangerousHtml)
+ * - Only safe URL protocols are permitted (no allowDangerousProtocol)
+ *
+ * The output is safe to embed directly in an HTML page without
+ * additional escaping.
+ */
+export function renderMarkdown(md: string): string {
+  return micromark(md);
 }

--- a/packages/core/src/recall.ts
+++ b/packages/core/src/recall.ts
@@ -64,7 +64,7 @@ export type RecallInput = {
 /** Result of a full recall run — markdown-formatted string for the LLM. */
 export type RecallResult = string;
 
-type TaggedResult =
+export type TaggedResult =
   | { source: "knowledge"; item: ltm.ScoredKnowledgeEntry }
   | {
       source: "cross-knowledge";
@@ -74,6 +74,8 @@ type TaggedResult =
   | { source: "distillation"; item: ScoredDistillation }
   | { source: "temporal"; item: temporal.ScoredTemporalMessage }
   | { source: "lat-section"; item: latReader.ScoredLatSection };
+
+export type ScoredTaggedResult = { item: TaggedResult; score: number };
 
 // ---------------------------------------------------------------------------
 // Tagged result helpers (used by exact-match boost + formatting)
@@ -256,8 +258,15 @@ function formatFusedResults(
 // Main entry point
 // ---------------------------------------------------------------------------
 
-/** Full recall run: search every relevant source, fuse with RRF, format as markdown. */
-export async function runRecall(input: RecallInput): Promise<RecallResult> {
+/**
+ * Search every relevant source, fuse with RRF, and return raw scored results.
+ *
+ * This is the search+fusion core shared by `runRecall()` (LLM-formatted) and
+ * direct consumers like the web UI that need access to the raw result items.
+ */
+export async function searchRecall(
+  input: RecallInput,
+): Promise<ScoredTaggedResult[]> {
   const {
     query,
     scope = "all",
@@ -272,7 +281,7 @@ export async function runRecall(input: RecallInput): Promise<RecallResult> {
 
   // Short-circuit vague queries — stopwords-only would match everything.
   if (ftsQuery(query) === EMPTY_QUERY) {
-    return "Query too vague — try using specific keywords, file names, or technical terms.";
+    return [];
   }
 
   // Optional query expansion: generate alternative phrasings via LLM.
@@ -566,7 +575,17 @@ export async function runRecall(input: RecallInput): Promise<RecallResult> {
     }
   }
 
-  const fused = reciprocalRankFusion<TaggedResult>(allRrfLists);
+  return reciprocalRankFusion<TaggedResult>(allRrfLists);
+}
+
+/** Full recall run: search every relevant source, fuse with RRF, format as markdown. */
+export async function runRecall(input: RecallInput): Promise<RecallResult> {
+  // Short-circuit vague queries — stopwords-only would match everything.
+  if (ftsQuery(input.query) === EMPTY_QUERY) {
+    return "Query too vague — try using specific keywords, file names, or technical terms.";
+  }
+
+  const fused = await searchRecall(input);
   return formatFusedResults(fused, 20);
 }
 

--- a/packages/core/test/markdown.test.ts
+++ b/packages/core/test/markdown.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from "bun:test";
 import fc from "fast-check";
 import { remark } from "remark";
-import { normalize, unescapeMarkdown, sanitizeSurrogates, inline } from "../src/markdown";
+import { normalize, unescapeMarkdown, sanitizeSurrogates, inline, renderMarkdown } from "../src/markdown";
 import { formatDistillations, formatKnowledge } from "../src/prompt";
 
 const proc = remark();
@@ -324,5 +324,70 @@ describe("inline sanitizes surrogates", () => {
     expect(result).toBe("line one \uFFFDmiddle end");
     // Must be JSON-safe
     expect(() => JSON.stringify(result)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderMarkdown
+// ---------------------------------------------------------------------------
+
+describe("renderMarkdown", () => {
+  test("renders headings", () => {
+    expect(renderMarkdown("# Hello")).toContain("<h1>Hello</h1>");
+  });
+
+  test("renders bold and italic", () => {
+    const result = renderMarkdown("**bold** and *italic*");
+    expect(result).toContain("<strong>bold</strong>");
+    expect(result).toContain("<em>italic</em>");
+  });
+
+  test("renders unordered lists", () => {
+    const result = renderMarkdown("- item 1\n- item 2");
+    expect(result).toContain("<li>item 1</li>");
+    expect(result).toContain("<li>item 2</li>");
+  });
+
+  test("renders code blocks", () => {
+    const result = renderMarkdown("```\nconst x = 1;\n```");
+    expect(result).toContain("<code>");
+    expect(result).toContain("const x = 1;");
+  });
+
+  test("renders inline code", () => {
+    const result = renderMarkdown("use `foo()` here");
+    expect(result).toContain("<code>foo()</code>");
+  });
+
+  test("renders links", () => {
+    const result = renderMarkdown("[click](https://example.com)");
+    expect(result).toContain('<a href="https://example.com">click</a>');
+  });
+
+  test("escapes raw HTML in input (XSS safety)", () => {
+    const result = renderMarkdown('<script>alert("xss")</script>');
+    expect(result).not.toContain("<script>");
+    expect(result).toContain("&lt;script&gt;");
+  });
+
+  test("escapes img onerror XSS", () => {
+    const result = renderMarkdown('<img onerror="alert(1)" src="x">');
+    expect(result).not.toContain("<img");
+    expect(result).toContain("&lt;img");
+  });
+
+  test("sanitizes javascript: protocol in links", () => {
+    const result = renderMarkdown("[click](javascript:alert(1))");
+    expect(result).not.toContain("javascript:");
+  });
+
+  test("handles empty string", () => {
+    expect(renderMarkdown("")).toBe("");
+  });
+
+  test("renders blockquotes", () => {
+    const result = renderMarkdown("> quoted text");
+    expect(result).toContain("<blockquote>");
+    expect(result).toContain("quoted text");
   });
 });

--- a/packages/gateway/src/ui.ts
+++ b/packages/gateway/src/ui.ts
@@ -9,10 +9,12 @@ import {
   data,
   ltm,
   temporal,
-  runRecall,
+  searchRecall,
   config,
   projectName,
   ensureProject,
+  renderMarkdown,
+  type TaggedResult,
 } from "@loreai/core";
 
 // ---------------------------------------------------------------------------
@@ -48,6 +50,11 @@ function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/** Render markdown to HTML, wrapped in a scoped container. */
+function md(markdown: string): string {
+  return `<div class="md">${renderMarkdown(markdown)}</div>`;
 }
 
 function truncate(str: string, max: number): string {
@@ -133,6 +140,23 @@ form.inline { display: inline; }
 .msg-assistant { background: var(--bg2); border-left: 3px solid #10b981; }
 .actions { margin: 16px 0; display: flex; gap: 8px; }
 .empty { color: var(--fg3); font-style: italic; padding: 24px 0; text-align: center; }
+.md { font-size: 0.9em; line-height: 1.6; overflow-wrap: break-word; }
+.md h1, .md h2, .md h3, .md h4 { margin: 12px 0 6px; font-weight: 600; }
+.md h1 { font-size: 1.3em; } .md h2 { font-size: 1.15em; } .md h3 { font-size: 1.05em; }
+.md p { margin: 6px 0; }
+.md ul, .md ol { margin: 6px 0; padding-left: 24px; }
+.md li { margin: 2px 0; }
+.md pre { background: var(--bg3); border: 1px solid var(--border); border-radius: var(--radius);
+  padding: 10px 12px; overflow-x: auto; font-family: var(--mono); font-size: 0.9em; margin: 6px 0; }
+.md code { font-family: var(--mono); font-size: 0.9em; background: var(--bg3); padding: 1px 4px; border-radius: 3px; }
+.md pre code { background: none; padding: 0; font-size: 1em; }
+.md blockquote { border-left: 3px solid var(--border); padding-left: 12px; margin: 6px 0; color: var(--fg2); }
+.md a { color: var(--accent); }
+.md hr { border: none; border-top: 1px solid var(--border); margin: 12px 0; }
+.md table { width: 100%; border-collapse: collapse; margin: 6px 0; font-size: 0.9em; }
+.md th, .md td { text-align: left; padding: 6px 8px; border: 1px solid var(--border); }
+.md th { background: var(--bg2); font-weight: 600; }
+.md img { max-width: 100%; }
 `;
 
 function layout(title: string, body: string): string {
@@ -345,7 +369,7 @@ function pageKnowledge(id: string): string | null {
   if (entry.metadata) {
     body += `<div class="field"><span class="key">Metadata:</span></div><pre>${esc(entry.metadata)}</pre>`;
   }
-  body += `<h2>Content</h2><pre>${esc(entry.content)}</pre>`;
+  body += `<h2>Content</h2>${md(entry.content)}`;
 
   body += `<div class="actions">
     ${deleteForm(`/ui/api/delete/knowledge/${esc(entry.id)}`, "Delete Entry", "Delete this knowledge entry?")}
@@ -431,13 +455,52 @@ function pageDistillation(id: string): string | null {
   body += `<div class="field"><span class="key">Archived:</span> ${dist.archived ? "Yes" : "No"}</div>`;
   body += `<div class="field"><span class="key">Created:</span> ${formatDate(dist.created_at)}</div>`;
   body += `<div class="field"><span class="key">Source IDs:</span></div><pre>${esc(dist.source_ids)}</pre>`;
-  body += `<h2>Observations</h2><pre>${esc(dist.observations)}</pre>`;
+  body += `<h2>Observations</h2>${md(dist.observations)}`;
 
   body += `<div class="actions">
     ${deleteForm(`/ui/api/delete/distillation/${esc(dist.id)}`, "Delete Distillation", "Delete this distillation?")}
   </div>`;
 
   return layout("Distillation", body);
+}
+
+function formatSearchResult(tagged: TaggedResult): string {
+  switch (tagged.source) {
+    case "knowledge":
+    case "cross-knowledge": {
+      const k = tagged.item;
+      const from =
+        tagged.source === "cross-knowledge"
+          ? ` <span style="color:var(--fg3);font-size:0.8em">from: ${esc(tagged.projectLabel)}</span>`
+          : "";
+      return `<div class="card">
+        <h3>${badge(k.category)}${from} <a href="/ui/knowledge/${esc(k.id)}">${esc(k.title)}</a></h3>
+        ${md(k.content)}
+      </div>`;
+    }
+    case "distillation": {
+      const d = tagged.item;
+      return `<div class="card">
+        <h3>${badge("distilled")} <span style="color:var(--fg3);font-size:0.8em">gen ${d.generation} &middot; session ${esc(d.session_id.slice(0, 12))} &middot; ${formatDate(d.created_at)}</span></h3>
+        ${md(d.observations)}
+      </div>`;
+    }
+    case "temporal": {
+      const m = tagged.item;
+      const cls = m.role === "user" ? "msg-user" : "msg-assistant";
+      return `<div class="card">
+        <h3>${badge(m.role)} <span style="color:var(--fg3);font-size:0.8em">session ${esc(m.session_id.slice(0, 12))} &middot; ${formatDate(m.created_at)}</span></h3>
+        <div class="msg ${cls}">${md(m.content)}</div>
+      </div>`;
+    }
+    case "lat-section": {
+      const s = tagged.item;
+      return `<div class="card">
+        <h3>${badge("lat.md")} <span style="color:var(--fg3);font-size:0.8em">${esc(s.file)}</span> ${esc(s.heading)}</h3>
+        ${md(s.content)}
+      </div>`;
+    }
+  }
 }
 
 async function pageSearch(url: URL): Promise<string> {
@@ -471,16 +534,19 @@ async function pageSearch(url: URL): Promise<string> {
           recallLimit: 20,
           queryExpansion: false,
         };
-        const result = await runRecall({
+        const results = await searchRecall({
           query,
           scope,
           projectPath,
           searchConfig,
         });
-        body += `<h2>Results</h2>`;
-        // The recall result is markdown — render as preformatted text
-        // (proper markdown rendering would require a dependency)
-        body += `<pre>${esc(result)}</pre>`;
+        body += `<h2>Results (${results.length})</h2>`;
+        if (!results.length) {
+          body += `<p class="empty">No results found for this query.</p>`;
+        }
+        for (const { item: tagged } of results.slice(0, 20)) {
+          body += formatSearchResult(tagged);
+        }
       } catch (err) {
         body += `<p style="color:var(--danger)">Search error: ${esc(err instanceof Error ? err.message : String(err))}</p>`;
       }


### PR DESCRIPTION
## Summary

Closes #205

- Render markdown content in the web UI using **micromark** (already a transitive dependency via remark — zero lockfile growth)
- Knowledge entries, distillation observations, and search results now display with proper headings, bold, lists, code blocks, and other markdown formatting instead of raw preformatted text
- Search page rewritten to show rich result cards with full content instead of the LLM-oriented flattened format

## Changes

### Core (`@loreai/core`)
- **`renderMarkdown()`** in `markdown.ts` — thin wrapper around micromark with XSS-safe defaults (raw HTML escaped, dangerous protocols blocked)
- **`searchRecall()`** in `recall.ts` — extracted search+fusion logic from `runRecall()` to expose raw `ScoredTaggedResult[]` for direct consumers like the UI. `runRecall()` now delegates to `searchRecall()` + format.
- Exported `renderMarkdown`, `searchRecall`, `TaggedResult`, `ScoredTaggedResult` from barrel

### Gateway (`packages/gateway`)
- Scoped `.md` CSS for rendered markdown (headings, lists, code, blockquotes, tables, links — works in both light and dark mode)
- `md()` helper wrapping `renderMarkdown()` in a `<div class="md">`
- Knowledge content and distillation observations render as markdown
- **Search page** uses `searchRecall()` directly — each result rendered as a card with full content, category badge, and metadata (no truncation, no newline collapsing, proper bold/heading rendering)

### Tests
- 11 new `renderMarkdown` tests covering basic rendering (headings, bold, lists, code, links, blockquotes) and XSS safety (`<script>`, `<img onerror>`, `javascript:` protocol)

## Verification
- All 1,043 tests pass (607 core + 436 gateway)
- Typechecks pass (core + gateway)
- Builds succeed (core build + gateway bundle)