### PR TITLE
fix: use valid JSON placeholder in max_tokens normalization (LOREAI-GATEWAY-5)

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -30,6 +30,9 @@
 <!-- lore:019e16d4-0245-7ff4-948b-7955aa016978 -->
 * **Cache warming logs need input\_tokens for cost visibility**: Cache warming requests should log input\_tokens to show cached prefix size and cost. Enhanced logs format: 'cache-warmer: ✓ refresh session=abc... input=85000 cacheRead=84500 hit=99% cost=$0.0127'. Shows total input tokens, cache hit ratio, and actual cost. Essential for monitoring cache effectiveness and billing impact.
 
+<!-- lore:019e1759-b992-76f7-824e-318d5d206235 -->
+* **extractModelFromMetadata must skip 'unknown' to find real model IDs**: When iterating conversation messages to extract model ID from metadata, user messages carry \`"modelID":"unknown"\`. Iterating chronologically hits user messages first and returns \`"unknown"\` instead of the real model (e.g. \`claude-opus-4-6\`). Fix: skip entries where the extracted value is \`"unknown"\` so iteration falls through to assistant messages with real model IDs.
+
 <!-- lore:019e1403-b62a-7944-8d5e-f6d70ddc2801 -->
 * **Gradient layer resets indicate undetected Claude Code compaction events**: Claude Code auto-compacts via multiple paths. Gateway detects via gradient layer drops (4→0) with system prompt changes or message count drops. Compaction threshold: ~163K tokens. Lore intercepts compaction requests and generates a summary using COMPACT\_SUMMARY\_TEMPLATE (packages/core/src/prompt.ts) with Goal/Constraints/Progress structure, stored as assistant message with \`summary:true\`. Subagent token usage doesn't directly leak into parent's \`lastFinished.tokens\`, but subagent output text becomes a tool result in the parent conversation — inflating \`inputTokens\` on the next API call, which can trigger compaction. This is technically correct behavior (context IS larger), but compaction should not occur during plan mode. Fix: Remove 'I'm ready to continue.' from COMPACT\_SUMMARY\_TEMPLATE and buildPrefixMessages — this conversational reset primes the model to echo the compaction structure after subagent results return.
 
@@ -39,7 +42,13 @@
 <!-- lore:019e16c9-f53f-739f-b9f1-c825aec1d375 -->
 * **Subagent turns must skip temporal storage to prevent distillation contamination**: Subagent turns must skip temporal storage (lines 1196-1217), session state updates (1277-1290), and background work scheduling (1294) in gateway/pipeline.ts to prevent distillation contamination. Without isSubagentTurn guards, subagent messages trigger background distillation causing plan mode sessions to stall. Subagent token usage doesn't directly leak into parent's lastFinished.tokens. However, subagent output text becomes a tool result in the parent conversation, inflating parent's inputTokens on the next API call — this can trigger compaction indirectly. This is correct behavior (context window IS larger), but compaction should be blocked during plan mode to avoid disrupting plan execution flow.
 
+<!-- lore:019e1759-b99f-7124-a1f6-1a4c4e2e0b5f -->
+* **Test sessions with \_\_tmp paths contaminate distillation cost analytics**: Distillation cost analysis is skewed by sessions from \`\_\_tmp\_agents\_file\_\_\` test projects — in one audit ~60% of distillations (6,262 of 10,466) came from test sessions. Always filter projects whose path contains \`\_\_tmp\` when computing production cost metrics. Real distillation overhead dropped from $234 to $95 after filtering.
+
 ### Pattern
+
+<!-- lore:019e1759-b9a3-7705-b678-bc8be020e18c -->
+* **Avoided compaction cost must include cache-bust penalty on conversation model**: Compaction savings calculations must include the cache-bust penalty: after each compaction, ~30K tokens of post-compaction context must be re-written to prompt cache at \`cache\_write\` rates on the conversation model (e.g. Opus at $18.75/M vs $1.50/M cache\_read). Omitting this undervalues each avoided compaction ~3.6x ($0.19 → $0.71). \`estimateCompactionCost\` requires both \`workerModel\` and \`conversationModel\` parameters; \`updateShadowContext\` and pipeline callsites must pass \`req.model\` as the conversation model.
 
 <!-- lore:019e16d2-2d7f-70a5-8f17-038b85cc11c5 -->
 * **Cache warmer logging pattern for prompt cache telemetry**: Cache warming requests log comprehensive telemetry: input\_tokens (total request size), cache\_read\_tokens (cached prefix), cache\_write\_tokens (new content), hit percentage, and estimated cost. Format: 'cache-warmer: ✓ refresh session=... input=85000 cacheRead=84500 hit=99% cost=$0.0127'. Status symbols: ✓ (full hit), ~ (partial), ✗ (uncached). Essential for monitoring cache efficiency and costs in warmup operations.

--- a/packages/gateway/src/cache-analytics.ts
+++ b/packages/gateway/src/cache-analytics.ts
@@ -74,7 +74,7 @@ export function normalizeBodyForComparison(body: string): string {
   return body
     .replace(CCH_PATTERN, CCH_REPLACEMENT)
     .replace(CC_VERSION_SUFFIX_PATTERN, CC_VERSION_SUFFIX_REPLACEMENT)
-    .replace(TOP_LEVEL_MAX_TOKENS, "$1_");
+    .replace(TOP_LEVEL_MAX_TOKENS, "$10");
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/test/cache-analytics.test.ts
+++ b/packages/gateway/test/cache-analytics.test.ts
@@ -493,7 +493,7 @@ describe("normalizeBodyForComparison", () => {
       '{"model":"claude-sonnet-4-20250514","max_tokens":16000,"stream":true}';
     const normalized = normalizeBodyForComparison(body);
     expect(normalized).toBe(
-      '{"model":"claude-sonnet-4-20250514","max_tokens":_,"stream":true}',
+      '{"model":"claude-sonnet-4-20250514","max_tokens":0,"stream":true}',
     );
   });
 
@@ -502,7 +502,7 @@ describe("normalizeBodyForComparison", () => {
       '{"model":"claude-sonnet-4-20250514","max_tokens":8192,"stream":true,"messages":[{"content":"set max_tokens to 16000"}]}';
     const normalized = normalizeBodyForComparison(body);
     // Top-level normalized, but content preserved
-    expect(normalized).toContain('"max_tokens":_,');
+    expect(normalized).toContain('"max_tokens":0,');
     expect(normalized).toContain("set max_tokens to 16000");
   });
 


### PR DESCRIPTION
## Summary

- `normalizeBodyForComparison()` replaced `"max_tokens":NNNN` with `"max_tokens":_` for stable prefix comparison. The bare `_` is invalid JSON.
- The same normalized body is stored compressed and later decompressed for warmup replay, where `prepareAnthropicWarmupBody` calls `JSON.parse()` — crashing with `SyntaxError: Unexpected identifier "_"`.
- Fix: change the placeholder from `_` to `0` so the stored body remains valid JSON while still collapsing all `max_tokens` digit counts identically for comparison.

Fixes [LOREAI-GATEWAY-5](https://byk.sentry.io/issues/?query=LOREAI-GATEWAY-5)