### PR TITLE
feat: improve project naming from git remote and add project delete/rename

### DIFF
--- a/packages/core/src/data.ts
+++ b/packages/core/src/data.ts
@@ -17,6 +17,7 @@ import {
   close,
   dbPath,
   mergeProjectInternal,
+  repoNameFromRemote,
 } from "./db";
 import { getGitRemote } from "./git";
 import * as ltm from "./ltm";
@@ -293,6 +294,13 @@ export function clearProject(projectPath: string): ClearResult {
   // Delete in dependency order
   database.exec("BEGIN IMMEDIATE");
   try {
+    // Delete session_state BEFORE temporal_messages (subquery needs the rows)
+    database
+      .query(
+        `DELETE FROM session_state WHERE session_id IN
+         (SELECT DISTINCT session_id FROM temporal_messages WHERE project_id = ?)`,
+      )
+      .run(pid);
     database
       .query("DELETE FROM knowledge WHERE project_id = ?")
       .run(pid);
@@ -302,13 +310,6 @@ export function clearProject(projectPath: string): ClearResult {
     database
       .query("DELETE FROM distillations WHERE project_id = ?")
       .run(pid);
-    database
-      .query(
-        `DELETE FROM session_state WHERE session_id IN
-         (SELECT DISTINCT session_id FROM temporal_messages WHERE project_id = ?)`,
-      )
-      .run(pid);
-    // Also clean lat_sections
     database
       .query("DELETE FROM lat_sections WHERE project_id = ?")
       .run(pid);
@@ -333,6 +334,110 @@ export function clearProject(projectPath: string): ClearResult {
     distillations_deleted: counts.distillations,
     sessions_cleared: counts.sessions,
   };
+}
+
+/**
+ * Fully delete a project: all associated data AND the project row itself.
+ * Also removes path aliases pointing to this project.
+ *
+ * Unlike clearProject(), this does NOT call ensureProject() (avoids
+ * re-creating the project) and does NOT regenerate .lore.md.
+ *
+ * Returns deletion counts, or null if the project ID doesn't exist.
+ */
+export function deleteProject(projectId: string): ClearResult | null {
+  const database = db();
+
+  // Verify the project exists
+  const project = database
+    .query("SELECT id FROM projects WHERE id = ?")
+    .get(projectId) as { id: string } | null;
+  if (!project) return null;
+
+  // Count before deleting
+  const counts = {
+    knowledge: (
+      database
+        .query(
+          "SELECT COUNT(*) as c FROM knowledge WHERE project_id = ?",
+        )
+        .get(projectId) as { c: number }
+    ).c,
+    temporal: (
+      database
+        .query(
+          "SELECT COUNT(*) as c FROM temporal_messages WHERE project_id = ?",
+        )
+        .get(projectId) as { c: number }
+    ).c,
+    distillations: (
+      database
+        .query(
+          "SELECT COUNT(*) as c FROM distillations WHERE project_id = ?",
+        )
+        .get(projectId) as { c: number }
+    ).c,
+    sessions: (
+      database
+        .query(
+          "SELECT COUNT(DISTINCT session_id) as c FROM temporal_messages WHERE project_id = ?",
+        )
+        .get(projectId) as { c: number }
+    ).c,
+  };
+
+  database.exec("BEGIN IMMEDIATE");
+  try {
+    // Delete session_state BEFORE temporal_messages (subquery needs the rows)
+    database
+      .query(
+        `DELETE FROM session_state WHERE session_id IN
+         (SELECT DISTINCT session_id FROM temporal_messages WHERE project_id = ?)`,
+      )
+      .run(projectId);
+    database
+      .query("DELETE FROM knowledge WHERE project_id = ?")
+      .run(projectId);
+    database
+      .query("DELETE FROM temporal_messages WHERE project_id = ?")
+      .run(projectId);
+    database
+      .query("DELETE FROM distillations WHERE project_id = ?")
+      .run(projectId);
+    database
+      .query("DELETE FROM lat_sections WHERE project_id = ?")
+      .run(projectId);
+    // Explicit delete for safety (FK CASCADE depends on PRAGMA foreign_keys)
+    database
+      .query("DELETE FROM project_path_aliases WHERE project_id = ?")
+      .run(projectId);
+    database
+      .query("DELETE FROM warmup_histograms WHERE project_id = ?")
+      .run(projectId);
+    // Finally, delete the project row itself
+    database
+      .query("DELETE FROM projects WHERE id = ?")
+      .run(projectId);
+    database.exec("COMMIT");
+  } catch (e) {
+    database.exec("ROLLBACK");
+    throw e;
+  }
+
+  return {
+    knowledge_deleted: counts.knowledge,
+    temporal_deleted: counts.temporal,
+    distillations_deleted: counts.distillations,
+    sessions_cleared: counts.sessions,
+  };
+}
+
+/** Rename a project. Returns true if the project exists and was renamed. */
+export function renameProject(projectId: string, newName: string): boolean {
+  const result = db()
+    .query("UPDATE projects SET name = ? WHERE id = ?")
+    .run(newName.trim(), projectId);
+  return result.changes > 0;
 }
 
 /** Clear only knowledge entries for a project. Regenerates .lore.md. */
@@ -537,13 +642,19 @@ export function mergeProjects(sourceId: string, targetId: string): MergeResult {
 }
 
 /**
- * Backfill git_remote for existing projects and merge duplicates.
+ * Backfill git_remote for existing projects, merge duplicates, and
+ * update project names from git remote repo names where still using
+ * the directory-basename default.
  *
  * Iterates all projects that lack a git_remote value, runs `git remote -v`
  * on their stored path, and:
  *  - If no other project shares that remote: sets git_remote on the row.
  *  - If another project already has that remote: merges this project into
  *    the existing one (consolidating fragmented data).
+ *
+ * Also backfills project names: if a project's name matches the directory
+ * basename (the old default) or is null, and a git remote is available,
+ * the name is updated to the repo name from the remote URL.
  *
  * Skips projects whose path no longer exists on disk or is not a git repo.
  *
@@ -552,6 +663,7 @@ export function mergeProjects(sourceId: string, targetId: string): MergeResult {
 export function backfillGitRemotes(): {
   updated: number;
   merged: number;
+  namesBackfilled: number;
   mergeDetails: Array<{
     sourcePath: string;
     targetPath: string;
@@ -561,12 +673,18 @@ export function backfillGitRemotes(): {
 } {
   const projects = db()
     .query(
-      "SELECT id, path, git_remote FROM projects ORDER BY created_at ASC",
+      "SELECT id, path, name, git_remote FROM projects ORDER BY created_at ASC",
     )
-    .all() as Array<{ id: string; path: string; git_remote: string | null }>;
+    .all() as Array<{
+    id: string;
+    path: string;
+    name: string | null;
+    git_remote: string | null;
+  }>;
 
   let updated = 0;
   let merged = 0;
+  let namesBackfilled = 0;
   const mergeDetails: Array<{
     sourcePath: string;
     targetPath: string;
@@ -575,44 +693,58 @@ export function backfillGitRemotes(): {
   }> = [];
 
   for (const project of projects) {
-    // Skip if already has git_remote
-    if (project.git_remote) continue;
+    let gitRemote = project.git_remote;
 
-    // Skip if path doesn't exist
-    if (!existsSync(project.path)) continue;
+    if (!gitRemote) {
+      // Skip if path doesn't exist
+      if (!existsSync(project.path)) continue;
 
-    // Try to get git remote
-    const gitRemote = getGitRemote(project.path);
-    if (!gitRemote) continue;
+      // Try to get git remote
+      gitRemote = getGitRemote(project.path);
+      if (!gitRemote) continue;
 
-    // Check if another project already has this git_remote
-    const existing = db()
-      .query(
-        "SELECT id, path FROM projects WHERE git_remote = ? AND id != ? LIMIT 1",
-      )
-      .get(gitRemote, project.id) as {
-      id: string;
-      path: string;
-    } | null;
+      // Check if another project already has this git_remote
+      const existing = db()
+        .query(
+          "SELECT id, path FROM projects WHERE git_remote = ? AND id != ? LIMIT 1",
+        )
+        .get(gitRemote, project.id) as {
+        id: string;
+        path: string;
+      } | null;
 
-    if (existing) {
-      // Merge this project into the existing one
-      const result = mergeProjects(project.id, existing.id);
-      mergeDetails.push({
-        sourcePath: project.path,
-        targetPath: existing.path,
-        gitRemote,
-        result,
-      });
-      merged++;
-    } else {
-      // Just set the git_remote
+      if (existing) {
+        // Merge this project into the existing one
+        const result = mergeProjects(project.id, existing.id);
+        mergeDetails.push({
+          sourcePath: project.path,
+          targetPath: existing.path,
+          gitRemote,
+          result,
+        });
+        merged++;
+        continue; // project was merged away, skip name backfill
+      }
+
+      // Set the git_remote
       db()
         .query("UPDATE projects SET git_remote = ? WHERE id = ?")
         .run(gitRemote, project.id);
       updated++;
     }
+
+    // Backfill name from git remote if still using directory basename default
+    const dirBasename = project.path.split("/").pop();
+    if (project.name === dirBasename || !project.name) {
+      const repoName = repoNameFromRemote(gitRemote);
+      if (repoName && repoName !== project.name) {
+        db()
+          .query("UPDATE projects SET name = ? WHERE id = ?")
+          .run(repoName, project.id);
+        namesBackfilled++;
+      }
+    }
   }
 
-  return { updated, merged, mergeDetails };
+  return { updated, merged, namesBackfilled, mergeDetails };
 }

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -4,6 +4,23 @@ import { mkdirSync } from "fs";
 import { homedir } from "os";
 import { getGitRemote } from "./git";
 
+/**
+ * Extract the repository name from a normalized git remote URL.
+ *
+ * Examples:
+ *   "github.com/BYK/LoreAI" → "LoreAI"
+ *   "github.com/org/repo"    → "repo"
+ *   "github.com"             → null (no path components)
+ *   null                     → null
+ */
+export function repoNameFromRemote(remote: string | null): string | null {
+  if (!remote) return null;
+  const lastSlash = remote.lastIndexOf("/");
+  if (lastSlash < 0) return null;
+  const name = remote.slice(lastSlash + 1);
+  return name.length > 0 ? name : null;
+}
+
 const SCHEMA_VERSION = 15;
 
 const MIGRATIONS: string[] = [
@@ -698,7 +715,7 @@ export function ensureProject(path: string, name?: string): string {
     .run(
       id,
       path,
-      name ?? path.split("/").pop() ?? "unknown",
+      name ?? repoNameFromRemote(gitRemote) ?? path.split("/").pop() ?? "unknown",
       gitRemote,
       Date.now(),
     );

--- a/packages/gateway/src/cli/data.ts
+++ b/packages/gateway/src/cli/data.ts
@@ -549,6 +549,7 @@ async function cmdMerge(
   console.log(`\nResults:`);
   console.log(`  Updated: ${result.updated} project(s) with git remote info`);
   console.log(`  Merged:  ${result.merged} duplicate project(s)`);
+  console.log(`  Renamed: ${result.namesBackfilled} project(s) with repo name`);
 
   if (result.mergeDetails.length > 0) {
     console.log(`\nMerge details:`);

--- a/packages/gateway/src/ui.ts
+++ b/packages/gateway/src/ui.ts
@@ -392,6 +392,11 @@ function pageProject(projectId: string): string | null {
     { label: project.name ?? project.path },
   ]);
   body += `<h1>${esc(project.name ?? "(unnamed)")}</h1>`;
+  body += `<form method="POST" action="/ui/api/rename/project/${esc(projectId)}" style="margin:4px 0 12px;display:flex;gap:8px;align-items:center">
+    <input type="text" name="name" value="${esc(project.name ?? "")}" placeholder="Project name"
+      style="padding:6px 10px;border:1px solid var(--border);border-radius:var(--radius);background:var(--bg);color:var(--fg);font-size:0.9em;width:300px">
+    <button type="submit" class="btn btn-primary">Rename</button>
+  </form>`;
   body += `<p style="font-family:var(--mono);font-size:0.85em;color:var(--fg2)">${esc(project.path)}</p>`;
   if (project.git_remote) {
     body += `<p style="font-family:var(--mono);font-size:0.85em;color:var(--fg2)">Git: ${esc(project.git_remote)}</p>`;
@@ -456,7 +461,8 @@ function pageProject(projectId: string): string | null {
 
   // Actions
   body += `<div class="actions">
-    ${deleteForm(`/ui/api/clear/project/${esc(projectId)}`, "Clear All Project Data", "This will permanently delete ALL data for this project. Continue?")}
+    ${deleteForm(`/ui/api/clear/project/${esc(projectId)}`, "Clear All Project Data", "This will permanently delete ALL data for this project but keep the project entry. Continue?")}
+    ${deleteForm(`/ui/api/delete/project/${esc(projectId)}`, "Delete Project", "This will PERMANENTLY DELETE this project and ALL its data. This cannot be undone. Continue?")}
   </div>`;
 
   return layout(project.name ?? "Project", body);
@@ -964,6 +970,24 @@ export async function handleUIRequest(
         data.clearProject(project.path);
       }
       return redirect("/ui");
+    }
+
+    // Delete project (full removal)
+    const delProject = matchRoute(pathname, "/ui/api/delete/project/:id");
+    if (delProject) {
+      data.deleteProject(delProject.id);
+      return redirect("/ui");
+    }
+
+    // Rename project
+    const renameProjectMatch = matchRoute(pathname, "/ui/api/rename/project/:id");
+    if (renameProjectMatch) {
+      const formData = await req.formData();
+      const newName = formData.get("name");
+      if (typeof newName === "string" && newName.trim()) {
+        data.renameProject(renameProjectMatch.id, newName);
+      }
+      return redirect(`/ui/projects/${renameProjectMatch.id}`);
     }
   }
 


### PR DESCRIPTION
## Summary

- **Better project naming**: New projects derive their display name from the git remote repo name (e.g. `github.com/BYK/LoreAI` → `LoreAI`) instead of the directory basename (`opencode-lore`). Fallback chain: explicit name > git repo name > directory basename > "unknown".
- **Delete project**: New `deleteProject()` function and "Delete Project" button in the dashboard UI to fully remove junk/orphaned projects and all their data.
- **Rename project**: New rename form on the project detail page for manual name correction.
- **Name backfill**: `lore data merge` now also updates existing project names from git remotes when the current name is still the old directory-basename default.
- **Bug fix**: `clearProject()` was silently failing to clean `session_state` rows — the DELETE subquery referenced `temporal_messages` which were already deleted earlier in the same transaction.

## Files changed

| File | Changes |
|------|---------|
| `packages/core/src/db.ts` | Add `repoNameFromRemote()`, update `ensureProject()` name derivation |
| `packages/core/src/data.ts` | Add `deleteProject()`, `renameProject()`, fix `clearProject()` ordering bug, extend `backfillGitRemotes()` with name backfill |
| `packages/gateway/src/ui.ts` | Add Delete Project button, rename form, and POST routes |
| `packages/gateway/src/cli/data.ts` | Show `namesBackfilled` count in merge output |

## How to fix existing projects

1. **Delete junk projects** — dashboard → project → "Delete Project"
2. **Backfill names** — `lore data merge` updates names from git remotes
3. **Manual rename** — use the rename form on any project detail page