### PR TITLE
fix: scope test DELETE to project, add cache invalidation and recovery CLI

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -2,18 +2,68 @@
 
 ## Long-term Knowledge
 
-### Decision
+### Architecture
 
-<!-- lore:019e1830-0bed-7398-8636-6829846560dd -->
-* **Decided to use a \*\*separate\*\* esbuild call for the worker (worker doesn't need Sentry debug IDs or sourcem**: Use a \*\*separate\*\* esbuild call to bundle \`embedding-worker.ts\` → \`embedding-worker.js\` (the worker doesn't need Sentry debug IDs or sourcemaps). With multiple entrypoints, esbuild's \`outfile\` doesn't work — switching to \`outdir\` is messier, so a second esbuild invocation is cleaner. After bundling: (1) copy \`embedding-worker.js\` into the staging dir alongside \`bin.js\` for vendored targets, (2) pass it as a second entrypoint to \`bun build --compile\`. The worker URL is resolved as \`./embedding-worker.js\` relative to \`import.meta.url\`, which in the binary is \`file:///$bunfs/root/bin.js\`, so Bun looks for \`/$bunfs/root/embedding-worker.js\` — it must be listed at compile time or the worker throws \`ModuleNotFound\` at runtime.
+<!-- lore:019e1653-a5d6-7639-a060-662e873b71b2 -->
+* **Automated CI monitoring for Claude Code version updates**: CI workflow monitors Claude Code releases every 6 hours, compares npm dist-tags against VERSION\_SEEDS, auto-extracts seeds via extract-cch-seed.ts --apply, runs tests, creates PRs for new versions. Manual trigger available. Downloads binaries for all platforms, generates oracle pairs, extracts seeds, commits updates.
+
+<!-- lore:019e1438-5ff0-77f3-abf8-5c815425f0ec -->
+* **CCH billing signature system for Claude Code request authentication**: CCH billing signature: two-layer auth system. JS layer computes SHA-256 suffix from message chars at indices 4,7,20 + version. Native layer uses xxHash64(bodyBytes, versionSeed) & 0xFFFFF → 5-hex signatures. resolveSeed() provides fallback for unknown versions. Current WORKER\_VERSION: 2.1.138, seed: 0x4D659218E32A3268n.
+
+<!-- lore:019e1430-1cca-7bd3-81a6-9d345b9cdd4b -->
+* **Claude Code seed extraction via brute-force binary scanning**: Automated seed extraction via extract-cch-seed.ts: downloads binaries, spawns Claude Code against local capture server for oracle pairs, scans 1-byte-aligned offsets as little-endian uint64. Validates via xxHash64(body, seed) & 0xFFFFF == cch. --apply mode patches cch.ts. Requires 2+ pairs for collision elimination.
+
+<!-- lore:019e13f6-44cf-7406-a618-2ef9b4faa99c -->
+* **Git-based project identification with 4-tier resolution hierarchy**: Git-based project identification: 4-tier resolution via git remote + path. ensureProject() tries: (1) exact path; (2) path alias; (3) git remote (prefers upstream > origin); (4) create new. Schema v14 adds git\_remote. Prevents fragmentation across worktrees/clones.
+
+<!-- lore:019e16c6-4b9b-78bf-85ae-90e7049076d9 -->
+* **kv\_meta table for per-path metadata caching pattern**: kv\_meta table provides key-value persistence: \`CREATE TABLE kv\_meta (key TEXT PRIMARY KEY, value TEXT)\`. Used for config fingerprints and file state caching. Pattern: cache mtime+hash per .lore.md path to skip redundant processing — key format: \`lore\_file\_cache:\<absolute-path>\`. Values are JSON-serialized. Use \`INSERT...ON CONFLICT(key) DO UPDATE\` for upserts. Enables two-level fast-path: mtime check first (no file read), hash check second (no DB write).
+
+<!-- lore:019e13fe-49f6-7107-b47e-c1c1f7e82306 -->
+* **Lore gradient system injects multi-layer context via system prompt prefixes**: Lore gradient system builds 4-layer hierarchical context via system prompt injection: distillations, LTM knowledge, context-specific, and session data. buildPromptPrefix() formats with markdown headers, injects via systemPromptWithGradientContext(). Replaces compaction with progressive knowledge accumulation.
+
+<!-- lore:019e16d8-2168-7ba3-9e36-7e7df4539ae3 -->
+* **Plan mode to build mode transition with .opencode/plans execution**: Plan mode transitions to build mode via system reminder indicating operational mode change from read-only to active execution. Build mode permits file changes, shell commands, and tool usage. Plans stored in .opencode/plans/ directory with timestamp-description naming. Agent reads plan file and executes defined steps sequentially. Mode transition removes read-only constraints and activates full tool arsenal for implementation.
 
 ### Gotcha
 
-<!-- lore:019e182a-b4aa-7b3a-8d52-fdfcd6638552 -->
-* **Binary smoke test: --check-embeddings path requires fastembed to load correctly**: The binary smoke test (\`--check-embeddings\`) calls \`embed()\` → \`getProvider()\` → \`ensureWorker()\` → \`tryLoadFastembed()\`. Two distinct failure modes: (1) \`tryLoadFastembed()\` returns null without throwing — likely because \`fastembedProbed=true/fastembedAvailable=false\` was set by an upstream \`isAvailable()\` call before \`ensureWorker()\` runs. (2) \`tryLoadFastembed()\` succeeds but the spawned worker throws \`ModuleNotFound resolving "/$bunfs/root/embedding-worker.js"\` — caused by omitting \`embedding-worker.js\` from \`bun build --compile\`. Fix: bundle \`embedding-worker.ts\` separately via esbuild, copy to staging dir, and add as a second compile entrypoint. \[\[019e1830-0bed-7398-8636-6829846560dd]]
+<!-- lore:019e16d4-0245-7ff4-948b-7955aa016978 -->
+* **Cache warming logs need input\_tokens for cost visibility**: Cache warming requests should log input\_tokens to show cached prefix size and cost. Enhanced logs format: 'cache-warmer: ✓ refresh session=abc... input=85000 cacheRead=84500 hit=99% cost=$0.0127'. Shows total input tokens, cache hit ratio, and actual cost. Essential for monitoring cache effectiveness and billing impact.
 
-<!-- lore:019e1830-a7b9-7bb3-b914-96e037b834c7 -->
-* **Bun standalone binary: Worker entrypoints must be explicitly included in --compile**: Per Bun docs, Worker files are NOT auto-bundled into a standalone executable. Each worker entrypoint must be passed explicitly: \`bun build --compile ./main.ts ./embedding-worker.ts --outfile myapp\`. Omitting worker entrypoints causes \`new Worker(workerUrl)\` to fail silently at runtime in the binary. This is separate from the \`tryLoadFastembed()\` main-thread probe — even if the probe succeeds, the worker spawn will fail if the worker file wasn't compiled in.
+<!-- lore:019e1759-b992-76f7-824e-318d5d206235 -->
+* **extractModelFromMetadata must skip 'unknown' to find real model IDs**: When iterating conversation messages to extract model ID from metadata, user messages carry \`"modelID":"unknown"\`. Iterating chronologically hits user messages first and returns \`"unknown"\` instead of the real model (e.g. \`claude-opus-4-6\`). Fix: skip entries where the extracted value is \`"unknown"\` so iteration falls through to assistant messages with real model IDs.
 
-<!-- lore:019e182a-b4a7-781f-81ef-91319a3d7d94 -->
-* **Fastembed worker lifecycle: null vs undefined and race conditions in tryLoadFastembed**: Three subtle bugs in the local embedding worker lifecycle: (1) After shutdown, set \`cachedProvider = null\` (not \`undefined\`) so \`getProvider()\` doesn't re-spawn orphan workers from fire-and-forget \`embedKnowledgeEntry()\` calls. (2) Test suites must save/restore the live worker (\`\_saveAndClearProvider\`/\`\_restoreProvider\`) instead of killing it — avoids double ONNX loads in the same Bun process which cause segfaults. (3) \`tryLoadFastembed()\` must re-check \`fastembedProbed\` after the async \`import()\` boundary to respect \`\_markFastembedUnavailable()\` set by concurrent tests — but over-aggressive re-checks abort loads prematurely when an upstream \`isAvailable()\` call has already set \`fastembedProbed=true, fastembedAvailable=false\`. When debugging: add logs before the early-return guard AND after \`import()\` — if neither prints, the early-return guard is firing.
+<!-- lore:019e1403-b62a-7944-8d5e-f6d70ddc2801 -->
+* **Gradient layer resets indicate undetected Claude Code compaction events**: Claude Code auto-compacts via multiple paths. Gateway detects via gradient layer drops (4→0) with system prompt changes or message count drops. Compaction threshold: ~163K tokens. Lore intercepts compaction requests and generates a summary using COMPACT\_SUMMARY\_TEMPLATE (packages/core/src/prompt.ts) with Goal/Constraints/Progress structure, stored as assistant message with \`summary:true\`. Subagent token usage doesn't directly leak into parent's \`lastFinished.tokens\`, but subagent output text becomes a tool result in the parent conversation — inflating \`inputTokens\` on the next API call, which can trigger compaction. This is technically correct behavior (context IS larger), but compaction should not occur during plan mode. Fix: Remove 'I'm ready to continue.' from COMPACT\_SUMMARY\_TEMPLATE and buildPrefixMessages — this conversational reset primes the model to echo the compaction structure after subagent results return.
+
+<!-- lore:019e16c9-0a74-77fc-92f7-ba05b5ed19bb -->
+* **OpenCode slash commands require SSE streaming when stream:true set**: OpenCode/Claude Code requests with stream:true expect SSE responses, not JSON. Plain JSON responses get dropped silently. Use streamHttpResponse() with buildSSETextResponse() for streaming clients, jsonResponse() for non-streaming. Check req.stream boolean to determine format. Essential for slash command responses and synthetic intercepts.
+
+<!-- lore:019e16c9-f53f-739f-b9f1-c825aec1d375 -->
+* **Subagent turns must skip temporal storage to prevent distillation contamination**: Subagent turns must skip temporal storage (lines 1196-1217), session state updates (1277-1290), and background work scheduling (1294) in gateway/pipeline.ts to prevent distillation contamination. Without isSubagentTurn guards, subagent messages trigger background distillation causing plan mode sessions to stall. Subagent token usage doesn't directly leak into parent's lastFinished.tokens. However, subagent output text becomes a tool result in the parent conversation, inflating parent's inputTokens on the next API call — this can trigger compaction indirectly. This is correct behavior (context window IS larger), but compaction should be blocked during plan mode to avoid disrupting plan execution flow.
+
+<!-- lore:019e1759-b99f-7124-a1f6-1a4c4e2e0b5f -->
+* **Test sessions with \_\_tmp paths contaminate distillation cost analytics**: Distillation cost analysis is skewed by sessions from \`\_\_tmp\_agents\_file\_\_\` test projects — in one audit ~60% of distillations (6,262 of 10,466) came from test sessions. Always filter projects whose path contains \`\_\_tmp\` when computing production cost metrics. Real distillation overhead dropped from $234 to $95 after filtering.
+
+### Pattern
+
+<!-- lore:019e1759-b9a3-7705-b678-bc8be020e18c -->
+* **Avoided compaction cost must include cache-bust penalty on conversation model**: Compaction savings calculations must include the cache-bust penalty: after each compaction, ~30K tokens of post-compaction context must be re-written to prompt cache at \`cache\_write\` rates on the conversation model (e.g. Opus at $18.75/M vs $1.50/M cache\_read). Omitting this undervalues each avoided compaction ~3.6x ($0.19 → $0.71). \`estimateCompactionCost\` requires both \`workerModel\` and \`conversationModel\` parameters; \`updateShadowContext\` and pipeline callsites must pass \`req.model\` as the conversation model.
+
+<!-- lore:019e16d2-2d7f-70a5-8f17-038b85cc11c5 -->
+* **Cache warmer logging pattern for prompt cache telemetry**: Cache warming requests log comprehensive telemetry: input\_tokens (total request size), cache\_read\_tokens (cached prefix), cache\_write\_tokens (new content), hit percentage, and estimated cost. Format: 'cache-warmer: ✓ refresh session=... input=85000 cacheRead=84500 hit=99% cost=$0.0127'. Status symbols: ✓ (full hit), ~ (partial), ✗ (uncached). Essential for monitoring cache efficiency and costs in warmup operations.
+
+<!-- lore:019e132b-1b1f-798a-ae69-71a7f40bdeb0 -->
+* **Lore.md file managed via UUID-tracked markdown with import/export cycle**: .lore.md managed as UUID-tracked markdown. exportLoreFile() writes DB entries by category. importLoreFile() parses: known UUIDs update, unknown creates with ID, no UUID creates new UUIDv7. shouldImportLoreFile() uses kv\_meta cache (key: \`lore\_file\_cache:\<absolute-path>\`, stores mtime+hash) — fast-paths on mtime match without reading file or calling buildSection(). On mtime mismatch, falls through to hash comparison and updates cache. exportLoreFile() skips writeFileSync when content hash matches cache, preventing unnecessary mtime bumps. clearLoreFileCache() exported from index.ts for test/reset use.
+
+<!-- lore:019e16d8-9660-7d58-a4ca-c8b46f72a7fb -->
+* **Markdown rendering with micromark in @loreai/core package**: Added markdown rendering capability to @loreai/core using micromark library. renderMarkdown() function in packages/core/src/markdown.ts provides HTML conversion with security defaults. Exported from main index.ts for use across Lore ecosystem. micromark chosen for lightweight, secure parsing without unsafe HTML extensions. Pattern: centralized markdown processing in core package enables consistent rendering across all Lore components.
+
+<!-- lore:019e16d8-9646-781e-9c41-7bb0094ad8ba -->
+* **Micromark used for safe markdown rendering in UI components**: Project uses micromark library for markdown-to-HTML conversion in UI. renderMarkdown() function in packages/core/src/markdown.ts provides sanitized HTML output. Exported from core package index for use across gateway and other components. Scoped CSS classes applied to rendered content for styling isolation.
+
+<!-- lore:019e16d8-9650-717e-a4de-acbb01defd1a -->
+* **Monorepo dependency management with workspace references**: When adding dependencies to workspace packages in monorepo, use npm install from package root, not workspace root. Pattern: cd packages/core && npm install micromark installs to correct package.json. Workspace references (@loreai/core) automatically resolve to local packages during development but publish correctly to npm. Always verify package.json changes are in target workspace, not root.
+
+<!-- lore:019e16d8-2141-7cc8-be6d-bd3c2db6b791 -->
+* **Plan execution workflow from .opencode/plans directory**: Plan execution workflow from .opencode/plans directory: Plan mode creates executable plans in .opencode/plans/ with timestamped filenames (e.g., 1778499815297-happy-tiger.md). When switching from plan to build mode, system reminder indicates operational transition from read-only to active execution. Agent reads plan content and executes steps sequentially using full tool arsenal. Plans contain structured task breakdowns with implementation steps. Essential for complex multi-step implementations requiring upfront planning.

--- a/packages/core/src/data.ts
+++ b/packages/core/src/data.ts
@@ -348,11 +348,19 @@ export function clearProject(projectPath: string): ClearResult {
 export function deleteProject(projectId: string): ClearResult | null {
   const database = db();
 
-  // Verify the project exists
+  // Verify the project exists and collect all paths BEFORE deleting.
+  // We need these to invalidate the .lore.md file cache (kv_meta) after
+  // deletion — otherwise shouldImportLoreFile() sees the stale cache,
+  // skips re-import, and the curator overwrites .lore.md with junk.
   const project = database
-    .query("SELECT id FROM projects WHERE id = ?")
-    .get(projectId) as { id: string } | null;
+    .query("SELECT id, path FROM projects WHERE id = ?")
+    .get(projectId) as { id: string; path: string } | null;
   if (!project) return null;
+
+  const aliasPaths = database
+    .query("SELECT path FROM project_path_aliases WHERE project_id = ?")
+    .all(projectId) as { path: string }[];
+  const allPaths = [project.path, ...aliasPaths.map((r) => r.path)];
 
   // Count before deleting
   const counts = {
@@ -422,6 +430,15 @@ export function deleteProject(projectId: string): ClearResult | null {
   } catch (e) {
     database.exec("ROLLBACK");
     throw e;
+  }
+
+  // Invalidate the .lore.md file cache for all known paths so that
+  // shouldImportLoreFile() re-checks the file if this project path
+  // is reused. Without this, the stale cache causes the import to be
+  // skipped, the curator creates junk entries, and exportLoreFile()
+  // overwrites the good .lore.md with garbage.
+  for (const p of allPaths) {
+    agentsFile.clearLoreFileCache(p);
   }
 
   return {

--- a/packages/core/test/embedding.test.ts
+++ b/packages/core/test/embedding.test.ts
@@ -336,8 +336,10 @@ describe("vectorSearch", () => {
   const PROJECT = "/test/embedding/vectorsearch";
 
   beforeEach(() => {
-    // vectorSearch has no project filter — clean ALL knowledge to avoid cross-test leaks
-    db().query("DELETE FROM knowledge").run();
+    // Clean test project's knowledge to avoid cross-test leaks.
+    // IMPORTANT: scope to project_id — unscoped DELETE wipes ALL projects' entries.
+    const pid = ensureProject(PROJECT);
+    db().query("DELETE FROM knowledge WHERE project_id = ?").run(pid);
   });
 
   test("returns entries sorted by similarity descending", () => {
@@ -451,7 +453,10 @@ describe("LocalProvider integration", () => {
   const PROJECT = "/test/embedding/local";
 
   beforeEach(() => {
-    db().query("DELETE FROM knowledge").run();
+    // Clean test project's knowledge to avoid cross-test leaks.
+    // IMPORTANT: scope to project_id — unscoped DELETE wipes ALL projects' entries.
+    const pid = ensureProject(PROJECT);
+    db().query("DELETE FROM knowledge WHERE project_id = ?").run(pid);
     // Don't resetProvider() between tests — reuse the worker across the suite.
     // Respawning a worker that loaded NAPI modules (fastembed/onnxruntime)
     // triggers a Bun segfault. The worker is shut down in afterAll instead.

--- a/packages/gateway/src/cli/data.ts
+++ b/packages/gateway/src/cli/data.ts
@@ -501,6 +501,109 @@ async function cmdDelete(
   }
 }
 
+async function cmdRecover(
+  _args: string[],
+  flags: Record<string, unknown>,
+): Promise<void> {
+  const { existsSync } = await import("fs");
+  const { join } = await import("path");
+  const { data, importLoreFile, importFromFile, loreFileExists, clearLoreFileCache, LORE_FILE } =
+    await import("@loreai/core");
+  const skipConfirm = !!flags.yes;
+  const asJson = !!flags.json;
+
+  const projects = data.listProjects();
+  const recoverable: Array<{
+    name: string | null;
+    path: string;
+    source: string; // ".lore.md" | "AGENTS.md" | "CLAUDE.md"
+  }> = [];
+
+  // Scan for recoverable files
+  for (const project of projects) {
+    if (!existsSync(project.path)) continue;
+
+    if (loreFileExists(project.path)) {
+      recoverable.push({ name: project.name, path: project.path, source: LORE_FILE });
+    } else {
+      // Check AGENTS.md, then CLAUDE.md
+      for (const filename of ["AGENTS.md", "CLAUDE.md"]) {
+        const filePath = join(project.path, filename);
+        if (existsSync(filePath)) {
+          recoverable.push({ name: project.name, path: project.path, source: filename });
+          break; // prefer AGENTS.md over CLAUDE.md
+        }
+      }
+    }
+  }
+
+  if (recoverable.length === 0) {
+    console.log("No recoverable files found in any project directory.");
+    return;
+  }
+
+  console.log(`Found ${recoverable.length} project(s) with recoverable knowledge files:\n`);
+  for (const r of recoverable) {
+    console.log(`  ${r.name ?? r.path}  ← ${r.source}`);
+  }
+  console.log();
+
+  if (!skipConfirm) {
+    const confirmed = await confirm(
+      `This will re-import knowledge entries from the files listed above.\n` +
+        `Entries with existing UUIDs will be updated if changed.\n` +
+        `New entries (unknown UUIDs or hand-written) will be created.`,
+    );
+    if (!confirmed) {
+      console.log("Cancelled.");
+      return;
+    }
+  }
+
+  const results: Array<{
+    name: string | null;
+    path: string;
+    source: string;
+    before: number;
+    after: number;
+  }> = [];
+
+  for (const r of recoverable) {
+    const before = data.countForProject(r.path).knowledge;
+
+    // Clear the file cache to ensure shouldImportLoreFile won't short-circuit
+    clearLoreFileCache(r.path);
+
+    if (r.source === LORE_FILE) {
+      importLoreFile(r.path);
+    } else {
+      importFromFile({ projectPath: r.path, filePath: join(r.path, r.source) });
+    }
+
+    const after = data.countForProject(r.path).knowledge;
+    results.push({ name: r.name, path: r.path, source: r.source, before, after });
+  }
+
+  if (asJson) {
+    console.log(JSON.stringify(results, null, 2));
+    return;
+  }
+
+  console.log(`\nRecovery results:`);
+  let totalImported = 0;
+  for (const r of results) {
+    const imported = r.after - r.before;
+    totalImported += imported;
+    const label = r.name ?? r.path;
+    if (imported > 0) {
+      console.log(`  ${padRight(label, 30)}  +${imported} entries (${r.before} → ${r.after}) from ${r.source}`);
+    } else {
+      console.log(`  ${padRight(label, 30)}  no change (${r.after} entries) from ${r.source}`);
+    }
+  }
+  console.log(`\nTotal: ${totalImported} entries recovered across ${results.length} project(s).`);
+}
+
 async function cmdMerge(
   _args: string[],
   flags: Record<string, unknown>,
@@ -582,6 +685,7 @@ Subcommands:
   clear [options]       Clear data for a project or wipe the database
   delete <type> <id>    Delete a single entry
   merge                 Scan git remotes and merge duplicate projects
+  recover               Re-import knowledge from .lore.md / AGENTS.md files
 
 Options:
   --project <path>      Target project directory (default: current directory)
@@ -606,6 +710,8 @@ Examples:
   lore data delete session abc12345-6789
   lore data merge                          # scan & merge git duplicates
   lore data merge --yes                    # skip confirmation
+  lore data recover                        # re-import from .lore.md / AGENTS.md
+  lore data recover --yes                  # skip confirmation
 `.trimStart();
 
 export async function commandData(
@@ -630,6 +736,9 @@ export async function commandData(
       break;
     case "merge":
       await cmdMerge(subArgs, values);
+      break;
+    case "recover":
+      await cmdRecover(subArgs, values);
       break;
     case "help":
     case undefined:


### PR DESCRIPTION
## Summary

Fixes a three-bug chain reaction that wiped ALL knowledge entries across ALL projects from the DB:

1. `embedding.test.ts` ran unscoped `DELETE FROM knowledge` — wiping every project's entries
2. Tests leaked into the production DB when `bun test` ran without the `setup.ts` preload
3. `deleteProject()` left stale `.lore.md` file caches, blocking re-import after deletion

All 281 entries across 15 projects were recovered from `.lore.md` / `AGENTS.md` files on disk.

## Changes

- **`packages/core/test/embedding.test.ts`** — Scope both `DELETE FROM knowledge` statements to `WHERE project_id = ?` using the test project's ID
- **`packages/core/src/data.ts`** — Collect project paths before deletion, call `clearLoreFileCache()` for each after commit
- **`packages/gateway/src/cli/data.ts`** — Add `lore data recover [--yes] [--json]` subcommand that iterates all projects and force-reimports from `.lore.md` / `AGENTS.md` / `CLAUDE.md` files (idempotent upserts, safe to run multiple times)
- **`.lore.md`** — Restored from git `4b082ca` (was overwritten with duplicate junk entries)