### PR TITLE
fix: guard against test runs polluting the production database

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -462,6 +462,18 @@ export function db(): Database {
     mkdirSync(dirname(envPath), { recursive: true });
     path = envPath;
   } else {
+    // Guard: refuse to open the production DB during test runs.
+    // The test preload (setup.ts) sets LORE_DB_PATH to a temp directory.
+    // If we reach here with NODE_ENV=test, the preload didn't fire
+    // (e.g. bun test invoked from outside the repo). Throw instead of
+    // silently writing test fixtures into the user's live database.
+    if (process.env.NODE_ENV === "test") {
+      throw new Error(
+        "LORE_DB_PATH is not set but NODE_ENV=test. " +
+          "Run tests via `bun test` from the repo root, or set " +
+          "LORE_DB_PATH to a temp path to avoid polluting the production DB.",
+      );
+    }
     const dir = dataDir();
     mkdirSync(dir, { recursive: true });
     path = join(dir, "lore.db");


### PR DESCRIPTION
## Summary

- Add a runtime guard in `db()` that throws when `NODE_ENV=test` but `LORE_DB_PATH` is not set
- Prevents test fixtures from leaking into the production DB when `bun test` is invoked from outside the repo (where `bunfig.toml` preload can't be found)

## Root cause

The test preload (`setup.ts`) sets `LORE_DB_PATH` to a temp directory, but bun only finds `bunfig.toml` by walking up from CWD. Running `bun test path/to/test.ts` from outside the repo means no preload fires and tests silently write `/test/` project entries into `~/.local/share/opencode-lore/lore.db`.

## Verification

- Full test suite: 1182 pass (same 1 pre-existing perf flake)
- Guard triggers correctly when running from `/tmp`: throws clear error message
- Zero test project leaks after both guarded and normal runs