### PR TITLE
fix: remap @sentry/bun to @sentry/node in CJS npm bundle

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -4,18 +4,18 @@
 
 ### Architecture
 
-<!-- lore:019e18d6-ea95-7902-9645-aabd8cb53e32 -->
-* **Distillation pipeline: skipMeta, expansion guard, and callType threading**: Distillation pipeline — three key non-obvious design points: (1) Incremental background distillation passes \`skipMeta: true\`; meta-distillation runs as a separate idle step to avoid ~374 cache busts/day. (2) \`maxAllowedExpansion()\` sliding scale: <100 tokens → 5x, <500 → 2x, else 1x; guard uses strict \`>\` (not \`>=\`). (3) \`callType\` ('batch'|'direct') is threaded from \`pipeline.ts\`/\`idle.ts\` through \`run()\` → \`distillSegment()\` → \`storeDistillation()\`, stored in DB schema v17 \`call\_type TEXT\` column; cost-tracker applies 0.5x multiplier for batch rows. \`LORE\_BATCH\_DISABLED\` env var controls batch eligibility in idle.ts. UI shows batched/direct breakdown.
+<!-- lore:019e18e8-a88c-77d6-8b10-a67410c264cd -->
+* **Short session recovery entry**: Entry visible after DB recovery on short session
 
 ### Decision
 
-<!-- lore:019e18d7-5f3a-7317-8f64-2d0b2ded6c73 -->
-* **maxSegmentTokens default is 16384, metaThreshold is 20**: \`maxSegmentTokens\` default raised from 8192 → 16384 and \`metaThreshold\` from 10 → 20 in config.ts, targeting ~50% fewer distillation calls. Tests in \`worker-model.test.ts\` and \`distillation.test.ts\` that hardcode these defaults must use the new values.
+<!-- lore:019e18e8-a8c7-7d9c-9be4-9ceea8ecbc36 -->
+* **Compact-hook knowledge entry**: Entry that should appear in /compact prompt knowledge block
 
 ### Gotcha
 
-<!-- lore:019e18d6-eaa2-7bd5-8e93-8d318433db23 -->
-* **bun test --exclude flag doesn't work; use explicit file paths instead**: The \`--exclude\` flag in bun test doesn't properly filter out test files. To skip specific test files, pass explicit file paths as positional arguments instead of trying to exclude.
+<!-- lore:019e18ec-e328-76c4-9c3c-09dbe8d51c6c -->
+* **Bun tests leak into production DB when run outside repo root**: Running \`bun test\` from a directory without \`bunfig.toml\` (e.g. \`/tmp\`) means the preload script never fires, so \`LORE\_DB\_PATH\` is never set and tests silently write to the production DB. Fix: add a runtime guard in \`db.ts\` — if \`NODE\_ENV === 'test'\` and \`LORE\_DB\_PATH\` is not pointing to a temp path, throw an error immediately rather than falling back to the production DB path.
 
-<!-- lore:019e18d7-5f08-73dc-8824-52d822d0a64b -->
-* **db.test.ts uses shared on-disk DB singleton with no cleanup**: db.test.ts uses the shared on-disk \`db()\` singleton with hardcoded paths (e.g. \`/test/git-dedup/original\`). No setup/teardown means rows accumulate across repeated runs and branch checkouts, causing \`UNIQUE constraint failed\` on \`ensureProject\` and \`mergeProjectInternal\` tests, and schema version mismatches when migrations from one branch leak into another. These are not regressions. Fix: delete the on-disk test DB file to reset state, or wire up \`test/setup.ts\` via \`bunfig.toml\` preload so tests use an isolated DB.
+<!-- lore:019e18ec-e31c-7b9d-9a1f-d7b656454b3d -->
+* **Bun tests run from /tmp leak into production DB**: Running \`bun test\` from outside the repo (e.g. \`/tmp\`) means Bun can't find \`bunfig.toml\`, so test preload never fires and tests use the production DB. Fix: add a runtime guard in \`db.ts\` — if \`NODE\_ENV === 'test'\` and \`LORE\_DB\_PATH\` is not set to a temp path, throw immediately rather than silently opening the production DB. \`bunfig.toml\`-based isolation is fragile due to CWD dependency.

--- a/packages/gateway/script/bundle.ts
+++ b/packages/gateway/script/bundle.ts
@@ -54,6 +54,23 @@ const external = [
   "@anush008/*",
 ];
 
+// Remap @sentry/bun → @sentry/node so the CJS bundle gets Node-native
+// Sentry integrations (http server instrumentation via diagnostics_channel)
+// instead of @sentry/bun's BunServer integration which uses Bun-only APIs
+// (server.reload, headers.toJSON) that the Node.js polyfill doesn't provide.
+// Resolve @sentry/node via @sentry/bun (its direct dependency), since
+// @sentry/node is not a direct dependency of this package.
+const sentryBunEntry = Bun.resolveSync("@sentry/bun", packageDir);
+const sentryNodeEntry = Bun.resolveSync("@sentry/node", sentryBunEntry);
+const sentryNodePlugin: esbuild.Plugin = {
+  name: "sentry-bun-to-node",
+  setup(build) {
+    build.onResolve({ filter: /^@sentry\/bun$/ }, () => ({
+      path: sentryNodeEntry,
+    }));
+  },
+};
+
 await esbuild.build({
   entryPoints: [join(packageDir, "src/index.ts")],
   bundle: true,
@@ -68,6 +85,7 @@ await esbuild.build({
   minify: true,
   logLevel: "info",
   legalComments: "none",
+  plugins: [sentryNodePlugin],
   // Inject polyfills — provides Bun.serve(), Bun.zstd*, etc. under Node.js
   inject: [join(here, "node-polyfills.ts")],
   // Build-time constants


### PR DESCRIPTION
## Summary

- Fixes the Node.js CJS bundle smoke test failing with `TypeError: Cannot read properties of undefined (reading 'bind')` and `TypeError: i.headers.toJSON is not a function`
- Root cause: `@sentry/bun`'s `BunServer` integration uses Bun-only APIs (`server.reload`, `Headers.toJSON()`) that the Node.js polyfill doesn't provide
- Adds an esbuild plugin in `bundle.ts` that redirects `@sentry/bun` → `@sentry/node` at CJS bundle time, giving proper Node.js HTTP server instrumentation via `diagnostics_channel` and eliminating the Bun-specific integration entirely