### PR TITLE
fix: recover missing call_type column on distillations table

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -2,20 +2,7 @@
 
 ## Long-term Knowledge
 
-### Architecture
-
-<!-- lore:019e18e8-a88c-77d6-8b10-a67410c264cd -->
-* **Short session recovery entry**: Entry visible after DB recovery on short session
-
-### Decision
-
-<!-- lore:019e18e8-a8c7-7d9c-9be4-9ceea8ecbc36 -->
-* **Compact-hook knowledge entry**: Entry that should appear in /compact prompt knowledge block
-
 ### Gotcha
 
 <!-- lore:019e18ec-e328-76c4-9c3c-09dbe8d51c6c -->
-* **Bun tests leak into production DB when run outside repo root**: Running \`bun test\` from a directory without \`bunfig.toml\` (e.g. \`/tmp\`) means the preload script never fires, so \`LORE\_DB\_PATH\` is never set and tests silently write to the production DB. Fix: add a runtime guard in \`db.ts\` — if \`NODE\_ENV === 'test'\` and \`LORE\_DB\_PATH\` is not pointing to a temp path, throw an error immediately rather than falling back to the production DB path.
-
-<!-- lore:019e18ec-e31c-7b9d-9a1f-d7b656454b3d -->
-* **Bun tests run from /tmp leak into production DB**: Running \`bun test\` from outside the repo (e.g. \`/tmp\`) means Bun can't find \`bunfig.toml\`, so test preload never fires and tests use the production DB. Fix: add a runtime guard in \`db.ts\` — if \`NODE\_ENV === 'test'\` and \`LORE\_DB\_PATH\` is not set to a temp path, throw immediately rather than silently opening the production DB. \`bunfig.toml\`-based isolation is fragile due to CWD dependency.
+* **Bun tests leak into production DB when run outside repo root**: Running \`bun test\` outside the repo means \`bunfig.toml\` is not found, preload never fires, and tests silently open the production DB. Fix (now merged to main): \`db()\` throws immediately if \`NODE\_ENV=test\` and \`LORE\_DB\_PATH\` is not set to a temp path — runtime guard rather than relying on preload. \`bunfig.toml\`-based isolation is fragile due to CWD dependency.

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -606,6 +606,16 @@ function recoverMissingObjects(database: Database) {
       project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE
     );
   `);
+
+  // Recover missing columns from partial migration runs.
+  // Version 17 added call_type to distillations but the ALTER could have been
+  // skipped if the version was bumped without the column being created.
+  const cols = database
+    .query("PRAGMA table_info(distillations)")
+    .all() as Array<{ name: string }>;
+  if (!cols.some((c) => c.name === "call_type")) {
+    database.exec("ALTER TABLE distillations ADD COLUMN call_type TEXT;");
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Bug**: Version 17 migration (`ALTER TABLE distillations ADD COLUMN call_type`) was skipped during a partial migration run — `schema_version` got bumped to 17 but the ALTER never executed, causing `storeDistillation()` to fail repeatedly with `SQLiteError: table distillations has no column named call_type`.
- **Fix**: Added column recovery to `recoverMissingObjects()` in `db.ts` so databases that hit this gap self-heal on next startup.
- **Prod hotfix**: Manually ran the ALTER on the live DB — errors stopped immediately without needing a service restart.