### PR TITLE
fix: start gateway in-process instead of spawning a subprocess

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -46,6 +46,7 @@
       "version": "0.17.0",
       "dependencies": {
         "@loreai/core": "workspace:*",
+        "@loreai/gateway": "workspace:*",
       },
       "devDependencies": {
         "@opencode-ai/plugin": "^1.1.39",
@@ -60,6 +61,7 @@
       "version": "0.17.0",
       "dependencies": {
         "@loreai/core": "workspace:*",
+        "@loreai/gateway": "workspace:*",
       },
       "devDependencies": {
         "@mariozechner/pi-coding-agent": "^0.73.1",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -21,7 +21,8 @@
     "@opencode-ai/plugin": ">=1.1.0"
   },
   "dependencies": {
-    "@loreai/core": "workspace:*"
+    "@loreai/core": "workspace:*",
+    "@loreai/gateway": "workspace:*"
   },
   "devDependencies": {
     "@opencode-ai/plugin": "^1.1.39",

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -11,14 +11,11 @@ const GATEWAY_PROVIDERS: string[] = [
   "google",
 ];
 
-/** Absolute path to the gateway entry point (src/index.ts in the workspace). */
-const GATEWAY_ENTRY = new URL("../../gateway/src/index.ts", import.meta.url).pathname;
-
 /**
  * Check if the Lore gateway is reachable at the given base URL.
  * Short timeout so this doesn't delay OpenCode startup noticeably.
  */
-async function probeGateway(baseURL: string, timeoutMs = 1500): Promise<boolean> {
+export async function probeGateway(baseURL: string, timeoutMs = 1500): Promise<boolean> {
   try {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), timeoutMs);
@@ -31,43 +28,36 @@ async function probeGateway(baseURL: string, timeoutMs = 1500): Promise<boolean>
 }
 
 /**
- * Spawn the gateway as a background child process and wait for it to be ready.
- * Returns true if the gateway started and is healthy, false otherwise.
+ * Start the gateway server in-process by importing @loreai/gateway as a library.
+ * Uses Bun.serve() under the hood — non-blocking, lives for the duration of the
+ * host process. No subprocess management needed.
  */
-async function spawnGateway(gatewayBase: string): Promise<boolean> {
+export async function startInProcess(gatewayBase: string): Promise<boolean> {
   try {
-    const child = Bun.spawn(["bun", "run", GATEWAY_ENTRY], {
-      stdout: "ignore",
-      stderr: "pipe",
-      // Detach from the plugin process group so it keeps running
-      // even if the parent signal handler fires.
-    });
+    // Dynamic import — the gateway may be resolved from src (workspace) or
+    // dist/index.cjs (npm). Use a variable to prevent tsc from resolving the
+    // module at compile time (the .d.cts only exists after building).
+    const gw = "@loreai/gateway";
+    const { loadConfig, startServer } = await import(/* webpackIgnore: true */ gw);
+    const config = loadConfig();
 
-    // Pipe gateway stderr to our own stderr so it's visible.
-    if (child.stderr) {
-      const reader = child.stderr.getReader();
-      const decoder = new TextDecoder();
-      const pump = async () => {
-        for (;;) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          process.stderr.write(decoder.decode(value));
-        }
-      };
-      pump().catch(() => {});
-    }
+    // Parse the expected port from gatewayBase so the server binds there.
+    const url = new URL(gatewayBase);
+    if (url.port) config.port = Number(url.port);
 
-    // Poll until healthy or timeout (5s max, 100ms intervals).
-    for (let i = 0; i < 50; i += 1) {
-      await Bun.sleep(100);
-      if (await probeGateway(gatewayBase, 500)) return true;
-    }
-
-    log.info("gateway did not become healthy within 5s");
-    child.kill();
-    return false;
+    startServer(config);
+    // startServer is synchronous (Bun.serve) — if it didn't throw, the
+    // server is listening. Verify with a quick health check.
+    return await probeGateway(gatewayBase, 1000);
   } catch (e) {
-    log.info("failed to spawn gateway:", e instanceof Error ? e.message : String(e));
+    const msg = e instanceof Error ? e.message : String(e);
+    // Port-in-use means something is already on that port but our probe
+    // didn't detect it (race). Treat as success — the proxy is available.
+    // Match both Node's EADDRINUSE and Bun's "Is port N in use?" format.
+    if (/EADDRINUSE/i.test(msg) || /port\b.*\bin use/i.test(msg)) {
+      return await probeGateway(gatewayBase, 1000);
+    }
+    log.info("failed to start gateway in-process:", msg);
     return false;
   }
 }
@@ -104,9 +94,9 @@ export const LorePlugin: Plugin = async (ctx) => {
             log.info(`gateway detected at ${gatewayBase}`);
             return true;
           }
-          log.info(`starting gateway at ${gatewayBase}…`);
-          if (await spawnGateway(gatewayBase)) {
-            log.info(`gateway started at ${gatewayBase}`);
+          log.info(`starting gateway in-process at ${gatewayBase}…`);
+          if (await startInProcess(gatewayBase)) {
+            log.info(`gateway started in-process at ${gatewayBase}`);
             return true;
           }
           return false;
@@ -125,7 +115,7 @@ export const LorePlugin: Plugin = async (ctx) => {
       process.argv.some((a) => a.includes(".test."));
     if (!inTestEnv) {
       const msg = "Lore gateway failed to start — memory features are unavailable. " +
-        "Check that Bun is installed and the gateway entry point exists.";
+        "Ensure @loreai/gateway is installed or start the gateway manually.";
       process.stderr.write(`[lore] ERROR: ${msg}\n`);
       log.error(msg);
     }

--- a/packages/opencode/test/gateway-smoke.test.ts
+++ b/packages/opencode/test/gateway-smoke.test.ts
@@ -1,0 +1,104 @@
+import { describe, test, expect, afterAll } from "bun:test";
+import { startInProcess, probeGateway } from "../src/index";
+
+/**
+ * Smoke tests for the in-process gateway startup.
+ *
+ * These exercise the real startInProcess → loadConfig → startServer path
+ * on an ephemeral port so they don't collide with a running gateway.
+ */
+
+// Track servers to stop after tests. startServer returns { stop, port, hosts }
+// but startInProcess doesn't expose the stop handle — we import startServer
+// directly for cleanup.
+let stopServer: (() => void) | null = null;
+
+afterAll(() => {
+  stopServer?.();
+});
+
+describe("in-process gateway startup", () => {
+  test("probeGateway returns false for a port with nothing listening", async () => {
+    // Use a random high port that's almost certainly not in use.
+    const result = await probeGateway("http://127.0.0.1:19876", 500);
+    expect(result).toBe(false);
+  });
+
+  test("startInProcess starts the gateway and responds to health checks", async () => {
+    // Use port 0 via env var so the OS assigns an ephemeral port.
+    // loadConfig reads LORE_LISTEN_PORT; startInProcess parses the URL port.
+    // We need to start the server first to discover the actual port, so we
+    // use the gateway API directly for this test. Use a variable to prevent
+    // tsc from resolving the module at compile time.
+    const gwPkg = "@loreai/gateway";
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const gw = await import(gwPkg) as any;
+    const config = gw.loadConfig();
+    config.port = 0; // ephemeral
+
+    const server = gw.startServer(config) as { stop: () => void; port: number; hosts: string[] };
+    stopServer = server.stop;
+    const port = server.port;
+    const base = `http://127.0.0.1:${port}`;
+
+    // The server should be immediately healthy (Bun.serve is synchronous).
+    const healthy = await probeGateway(base, 2000);
+    expect(healthy).toBe(true);
+
+    // Verify the health endpoint returns expected shape.
+    const res = await fetch(`${base}/health`);
+    expect(res.ok).toBe(true);
+    const body = (await res.json()) as { status: string };
+    expect(body.status).toBe("ok");
+  });
+
+  test("startInProcess returns true on success", async () => {
+    // Start a fresh server via startInProcess on another ephemeral port.
+    // Since startInProcess parses the port from the URL, we first need a
+    // free port. Bind a temporary TCP server, grab its port, close it, then
+    // pass that port to startInProcess.
+    const tmpServer = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch: () => new Response("tmp"),
+    });
+    const freePort = tmpServer.port;
+    tmpServer.stop(true);
+
+    // Small delay to ensure the port is released.
+    await Bun.sleep(50);
+
+    const base = `http://127.0.0.1:${freePort}`;
+    const result = await startInProcess(base);
+    expect(result).toBe(true);
+
+    // Verify the gateway is actually serving.
+    const healthy = await probeGateway(base, 2000);
+    expect(healthy).toBe(true);
+  });
+
+  test("startInProcess handles EADDRINUSE gracefully", async () => {
+    // Occupy a port with a server that responds to /health.
+    const occupier = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch: (req) => {
+        if (new URL(req.url).pathname === "/health") {
+          return Response.json({ status: "ok" });
+        }
+        return new Response("occupied", { status: 404 });
+      },
+    });
+    const occupiedPort = occupier.port;
+
+    try {
+      const base = `http://127.0.0.1:${occupiedPort}`;
+      // startInProcess should catch EADDRINUSE and fall back to probing,
+      // which succeeds because our occupier responds to /health.
+      const result = await startInProcess(base);
+      expect(result).toBe(true);
+    } finally {
+      occupier.stop(true);
+    }
+  });
+});

--- a/packages/pi/package.json
+++ b/packages/pi/package.json
@@ -22,7 +22,8 @@
     "build": "bun run script/build.ts"
   },
   "dependencies": {
-    "@loreai/core": "workspace:*"
+    "@loreai/core": "workspace:*",
+    "@loreai/gateway": "workspace:*"
   },
   "peerDependencies": {
     "@mariozechner/pi-coding-agent": "*"
@@ -42,7 +43,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=22.5"
+    "node": ">=22.15"
   },
   "repository": {
     "type": "git",

--- a/packages/pi/script/build.ts
+++ b/packages/pi/script/build.ts
@@ -31,6 +31,7 @@ mkdirSync(distDir, { recursive: true });
 const external = [
   "node:*",
   "@loreai/core",
+  "@loreai/gateway",
   "@mariozechner/pi-coding-agent",
   "@mariozechner/pi-tui",
 ];

--- a/packages/pi/src/index.ts
+++ b/packages/pi/src/index.ts
@@ -1,15 +1,17 @@
 /**
  * @loreai/pi — Lore memory engine as a Pi coding-agent extension.
  *
- * Gateway-only mode: the extension detects the Lore gateway, redirects
- * compatible provider URLs through it, and registers a single Pi-specific
- * hook (session_before_compact) that the gateway cannot handle via HTTP
- * interception. All other memory features (LTM injection, gradient
- * transforms, temporal capture, recall, idle work) are handled
- * exclusively by the gateway pipeline.
+ * On startup, the extension probes for an existing Lore gateway and, if
+ * none is found, starts one in-process by importing @loreai/gateway.
+ * It then redirects compatible provider URLs through the gateway and
+ * registers a single Pi-specific hook (session_before_compact) that the
+ * gateway cannot handle via HTTP interception. All other memory features
+ * (LTM injection, gradient transforms, temporal capture, recall, idle
+ * work) are handled exclusively by the gateway pipeline.
  *
- * If the gateway is not running, the extension logs an error and becomes
- * inert — no hooks are registered and Pi runs without memory features.
+ * If the gateway cannot be started, the extension logs an error and
+ * becomes inert — no hooks are registered and Pi runs without memory
+ * features.
  *
  * Installation (in user's `~/.pi/agent/extensions/`):
  *   import lore from "@loreai/pi";
@@ -78,6 +80,41 @@ async function probeGateway(baseURL: string, timeoutMs = 1500): Promise<boolean>
 }
 
 /**
+ * Start the gateway server in-process by importing @loreai/gateway as a library.
+ * The published CJS bundle includes Node.js polyfills that shim Bun.serve()
+ * to node:http.createServer(), so this works under both Bun and Node.js.
+ */
+async function startInProcess(gatewayBase: string): Promise<boolean> {
+  try {
+    // Dynamic import — the gateway may be resolved from src (workspace) or
+    // dist/index.cjs (npm). Use a variable to prevent tsc from resolving the
+    // module at compile time (the .d.cts only exists after building).
+    const gw = "@loreai/gateway";
+    const { loadConfig, startServer } = await import(/* webpackIgnore: true */ gw);
+    const config = loadConfig();
+
+    // Parse the expected port from gatewayBase so the server binds there.
+    const url = new URL(gatewayBase);
+    if (url.port) config.port = Number(url.port);
+
+    startServer(config);
+    // startServer is synchronous — if it didn't throw, the server is
+    // listening. Verify with a quick health check.
+    return await probeGateway(gatewayBase, 1000);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    // Port-in-use means something is already on that port but our probe
+    // didn't detect it (race). Treat as success — the proxy is available.
+    // Match both Node's EADDRINUSE and Bun's "Is port N in use?" format.
+    if (/EADDRINUSE/i.test(msg) || /port\b.*\bin use/i.test(msg)) {
+      return await probeGateway(gatewayBase, 1000);
+    }
+    log.info("pi: failed to start gateway in-process:", msg);
+    return false;
+  }
+}
+
+/**
  * Derive a stable session identifier from Pi's current session file path.
  */
 function sessionIDFor(sessionFile: string | undefined): string {
@@ -102,13 +139,22 @@ export default async function lorePiExtension(pi: ExtensionAPI): Promise<void> {
     process.env.LORE_GATEWAY_MODE === "test";
 
   if (process.env.LORE_GATEWAY_MODE !== "0" && !inTestEnv) {
-    gatewayActive = await probeGateway(gatewayBase);
+    if (await probeGateway(gatewayBase)) {
+      log.info(`pi: gateway detected at ${gatewayBase}`);
+      gatewayActive = true;
+    } else {
+      log.info(`pi: starting gateway in-process at ${gatewayBase}…`);
+      if (await startInProcess(gatewayBase)) {
+        log.info(`pi: gateway started in-process at ${gatewayBase}`);
+        gatewayActive = true;
+      }
+    }
   }
 
   if (!gatewayActive && !inTestEnv && process.env.LORE_GATEWAY_MODE !== "0") {
     const msg =
-      "Lore gateway not detected — memory features are unavailable. " +
-      "Run Pi through the gateway with `lore run pi`, or start the gateway separately.";
+      "Lore gateway failed to start — memory features are unavailable. " +
+      "Ensure @loreai/gateway is installed or start the gateway manually.";
     log.error("pi:", msg);
     return;
   }


### PR DESCRIPTION
## Summary

Fixes the `Module not found "/home/developer/.config/opencode/node_modules/@loreai/gateway/src/index.ts"` error when the OpenCode plugin is installed via npm (e.g. in Docker containers like [outpost](https://github.com/MathurAditya724/outpost)).

**Root cause:** Both plugins tried to spawn the gateway as a subprocess using a monorepo-relative path (`../../gateway/src/index.ts`) that doesn't exist when installed via npm.

**Fix:** Import `@loreai/gateway` as a library and call `startServer()` in-process. This eliminates subprocess management entirely — no path resolution, no polling loop, no stderr piping.

## Changes

### OpenCode plugin (`packages/opencode/`)
- Replace `Bun.spawn` + 5s polling loop with in-process `loadConfig()` / `startServer()` via dynamic `import("@loreai/gateway")`
- Add `@loreai/gateway` as a dependency
- Handle port-in-use errors for both Node (`EADDRINUSE`) and Bun (`Is port N in use?`)
- Add 4 gateway smoke tests (probe, in-process start, success path, EADDRINUSE handling)

### Pi plugin (`packages/pi/`)
- Add in-process gateway start (same pattern as OpenCode) — previously Pi was probe-only and became inert if no gateway was running
- Add `@loreai/gateway` as a dependency
- Externalize `@loreai/gateway` in esbuild config
- Bump Node engine to `>=22.15` (required by gateway's zstd polyfills)

## Testing
- 1087 tests pass, 0 failures
- Typecheck clean across all 4 packages
- New smoke tests cover: probe on empty port, in-process startup + health check, `startInProcess` success, EADDRINUSE graceful fallback