### PR TITLE
fix: avoid Bun NAPI teardown crash on gateway exit

### DIFF
--- a/packages/gateway/src/cli/exit.ts
+++ b/packages/gateway/src/cli/exit.ts
@@ -1,0 +1,47 @@
+/**
+ * Safe process exit for the Bun standalone binary.
+ *
+ * Bun 1.3.x panics with "A C++ exception occurred" when NAPI modules (e.g.
+ * onnxruntime-node loaded by fastembed) are cleaned up during normal
+ * process.exit() teardown. This module provides `safeExit()` which uses
+ * libc `_exit()` via FFI to skip atexit handlers and NAPI teardown.
+ *
+ * Falls back to `process.exit()` when:
+ *  - Not running under Bun (Node.js handles NAPI teardown correctly)
+ *  - `bun:ffi` is unavailable
+ *  - All FFI dlopen attempts fail
+ *
+ * `_exit()` skips: atexit handlers, stdio flushing, NAPI destructor hooks.
+ * This is safe for the gateway because:
+ *  - SQLite WAL mode handles incomplete writes (journal recovery)
+ *  - The embedding worker is unref'd and exits on its own
+ *  - stderr output was already flushed before shutdown() completed
+ */
+export function safeExit(code: number): never {
+  // Only use FFI _exit under Bun (the runtime that has the NAPI teardown bug).
+  if (typeof globalThis.Bun !== "undefined") {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { dlopen, FFIType } = require("bun:ffi") as typeof import("bun:ffi");
+      const libs =
+        process.platform === "win32"
+          ? ["msvcrt.dll"]
+          : process.platform === "darwin"
+            ? ["libSystem.B.dylib"]
+            : ["libc.so.6"];
+      for (const name of libs) {
+        try {
+          dlopen(name, {
+            _exit: { args: [FFIType.int], returns: FFIType.void },
+          }).symbols._exit(code);
+        } catch {
+          /* try next lib */
+        }
+      }
+    } catch {
+      /* bun:ffi not available — fall through to process.exit */
+    }
+  }
+
+  process.exit(code);
+}

--- a/packages/gateway/src/cli/main.ts
+++ b/packages/gateway/src/cli/main.ts
@@ -124,22 +124,10 @@ export async function _cli(): Promise<void> {
         process.exit(1);
       }
       console.log(`ok dim=${vec.length}`);
-      // Force-exit to avoid Bun 1.3.x NAPI teardown crash: when ONNX
-      // Runtime native bindings are cleaned up during normal process
-      // shutdown, Bun panics with a C++ exception. process.exit(0) still
-      // runs atexit handlers; _exit(0) via FFI terminates immediately.
-      try {
-        const { dlopen, FFIType } = await import("bun:ffi");
-        const libs = process.platform === "win32"
-          ? ["msvcrt.dll"]
-          : ["libSystem.B.dylib", "libc.so.6"];
-        for (const name of libs) {
-          try {
-            dlopen(name, { _exit: { args: [FFIType.int], returns: FFIType.void } }).symbols._exit(0);
-          } catch { /* try next */ }
-        }
-      } catch { /* fallthrough */ }
-      process.exit(0);
+      // Force-exit to avoid Bun NAPI teardown crash — fastembed is loaded
+      // on the main thread in this diagnostic path.
+      const { safeExit } = await import("./exit");
+      safeExit(0);
     } catch (err: unknown) {
       const cause = (err as Error & { cause?: unknown })?.cause;
       console.error(

--- a/packages/gateway/src/cli/run.ts
+++ b/packages/gateway/src/cli/run.ts
@@ -9,6 +9,7 @@ import { spawn, type ChildProcess } from "node:child_process";
 import { createInterface } from "node:readline";
 import { startGateway, type StartOptions } from "./start";
 import { detectAgents, AGENTS, type DetectedAgent } from "./agents";
+import { safeExit } from "./exit";
 
 // ---------------------------------------------------------------------------
 // Interactive agent picker (TTY only)
@@ -135,9 +136,12 @@ export async function commandRun(
     console.error("[lore] Running in server-only mode. Point your agent at the gateway manually.");
     console.error(`[lore]   export ANTHROPIC_BASE_URL=${gatewayUrl}`);
 
+    let shuttingDown = false;
     const onSignal = async () => {
+      if (shuttingDown) return;
+      shuttingDown = true;
       await shutdown();
-      process.exit(0);
+      safeExit(0);
     };
     process.on("SIGINT", () => onSignal());
     process.on("SIGTERM", () => onSignal());
@@ -167,15 +171,15 @@ export async function commandRun(
         const SIGNAL_CODES: Record<string, number> = {
           SIGHUP: 1, SIGINT: 2, SIGQUIT: 3, SIGTERM: 15,
         };
-        process.exit(128 + (SIGNAL_CODES[signal] ?? 1));
+        safeExit(128 + (SIGNAL_CODES[signal] ?? 1));
       }
-      process.exit(code ?? 0);
+      safeExit(code ?? 0);
     });
 
     child.on("error", async (err) => {
       console.error(`[lore] Failed to launch ${target.command}: ${err.message}`);
       await shutdown();
-      process.exit(1);
+      safeExit(1);
     });
   });
 }

--- a/packages/gateway/src/cli/start.ts
+++ b/packages/gateway/src/cli/start.ts
@@ -6,6 +6,8 @@
 import { loadConfig, type GatewayConfig } from "../config";
 import { startServer } from "../server";
 import { resetPipelineState } from "../pipeline";
+import { embedding } from "@loreai/core";
+import { safeExit } from "./exit";
 
 export interface StartOptions {
   port?: number;
@@ -39,6 +41,11 @@ export function startGateway(opts: StartOptions = {}): {
     console.error("[lore] Shutting down…");
     server.stop();
     await resetPipelineState();
+    // Shut down the embedding worker thread gracefully. Done after
+    // resetPipelineState (which clears sessions/timers) but before
+    // safeExit — gives the worker time to exit cleanly via its
+    // "shutdown" message handler rather than being killed by _exit().
+    await embedding.resetProvider();
   };
 
   return { config, port: actualPort, shutdown };
@@ -90,9 +97,12 @@ export async function commandStart(opts: StartOptions): Promise<never> {
     console.error("  export DISABLE_AUTO_COMPACT=1");
   }
   // Block until signal
+  let shuttingDown = false;
   const onSignal = async () => {
+    if (shuttingDown) return;
+    shuttingDown = true;
     await shutdown();
-    process.exit(0);
+    safeExit(0);
   };
 
   process.on("SIGINT", () => onSignal());


### PR DESCRIPTION
## Summary

- Fix Bun 1.3.x crash ("A C++ exception occurred") on gateway shutdown caused by NAPI module teardown of onnxruntime-node (loaded by fastembed)
- Add shared `safeExit()` utility using libc `_exit()` via `bun:ffi` to skip NAPI teardown on the Bun standalone binary
- Add double-signal guards and graceful embedding worker shutdown

## Problem

When the `lore` standalone Bun binary shuts down via `process.exit()`, Bun panics with a C++ exception during NAPI module teardown. The fastembed module loads onnxruntime-node (a NAPI addon with C++ bindings) on the main thread. When `process.exit()` fires, Bun's teardown invokes the C++ destructors which throw.

The codebase already had an inline FFI `_exit()` workaround in `--check-embeddings`, but it was not applied to normal shutdown paths.

## Changes

| File | Change |
|---|---|
| `packages/gateway/src/cli/exit.ts` | New shared `safeExit(code)` — uses `bun:ffi` to call libc `_exit()`, falls back to `process.exit()` on Node.js |
| `packages/gateway/src/cli/start.ts` | Use `safeExit()`, add double-signal guard, shut down embedding worker in `shutdown()` |
| `packages/gateway/src/cli/run.ts` | Use `safeExit()` for all exit paths, add double-signal guard |
| `packages/gateway/src/cli/main.ts` | Replace 12-line inline FFI block in `--check-embeddings` with `safeExit()` |

## Verification

- `bun run typecheck` — passes all 4 packages
- `bun test` — 1087 tests pass, 0 failures
- `bun run build` — all packages build successfully