### PR TITLE
fix: reuse existing gateway instead of crashing on EADDRINUSE

### DIFF
--- a/packages/gateway/src/cli/run.ts
+++ b/packages/gateway/src/cli/run.ts
@@ -122,11 +122,15 @@ export async function commandRun(
   opts: StartOptions,
   cmdArgs: string[],
 ): Promise<void> {
-  // 1. Start gateway
-  const { config, port, shutdown } = startGateway(opts);
+  // 1. Start gateway (or reuse an existing one)
+  const { config, port, owned, shutdown } = await startGateway(opts);
   const gatewayUrl = `http://${config.hosts[0]}:${port}`;
 
-  console.error(`[lore] Gateway listening on ${gatewayUrl}`);
+  if (owned) {
+    console.error(`[lore] Gateway listening on ${gatewayUrl}`);
+  } else {
+    console.error(`[lore] Reusing existing gateway at ${gatewayUrl}`);
+  }
 
   // 2. Resolve what to launch
   const target = await resolveLaunchTarget(gatewayUrl, cmdArgs);
@@ -136,15 +140,17 @@ export async function commandRun(
     console.error("[lore] Running in server-only mode. Point your agent at the gateway manually.");
     console.error(`[lore]   export ANTHROPIC_BASE_URL=${gatewayUrl}`);
 
-    let shuttingDown = false;
-    const onSignal = async () => {
-      if (shuttingDown) return;
-      shuttingDown = true;
-      await shutdown();
-      safeExit(0);
-    };
-    process.on("SIGINT", () => onSignal());
-    process.on("SIGTERM", () => onSignal());
+    if (owned) {
+      let shuttingDown = false;
+      const onSignal = async () => {
+        if (shuttingDown) return;
+        shuttingDown = true;
+        await shutdown();
+        safeExit(0);
+      };
+      process.on("SIGINT", () => onSignal());
+      process.on("SIGTERM", () => onSignal());
+    }
 
     // Block forever
     return new Promise(() => {});
@@ -162,10 +168,10 @@ export async function commandRun(
   process.on("SIGINT", () => forwardSignal("SIGINT"));
   process.on("SIGTERM", () => forwardSignal("SIGTERM"));
 
-  // Wait for child to exit, then tear down gateway
+  // Wait for child to exit, then tear down gateway (only if we own it)
   return new Promise<void>((resolve) => {
     child.on("exit", async (code, signal) => {
-      await shutdown();
+      if (owned) await shutdown();
       // Exit with the child's code (or 128 + signal number for signal deaths)
       if (signal) {
         const SIGNAL_CODES: Record<string, number> = {
@@ -178,7 +184,7 @@ export async function commandRun(
 
     child.on("error", async (err) => {
       console.error(`[lore] Failed to launch ${target.command}: ${err.message}`);
-      await shutdown();
+      if (owned) await shutdown();
       safeExit(1);
     });
   });

--- a/packages/gateway/src/cli/start.ts
+++ b/packages/gateway/src/cli/start.ts
@@ -17,16 +17,46 @@ export interface StartOptions {
   quiet?: boolean;
 }
 
+export interface GatewayHandle {
+  config: GatewayConfig;
+  port: number;
+  /** Whether this process owns the server (started it). False when reusing an existing instance. */
+  owned: boolean;
+  /** Shut down the gateway. No-op when `owned` is false. */
+  shutdown: () => Promise<void>;
+}
+
+/**
+ * Probe a running gateway at the given URL via its `/health` endpoint.
+ * Returns `true` if the response is 2xx, `false` on any error or timeout.
+ */
+export async function probeGateway(
+  baseURL: string,
+  timeoutMs = 1500,
+): Promise<boolean> {
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    const res = await fetch(`${baseURL}/health`, {
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Start the gateway server, returning the actual port and a shutdown function.
  *
  * Merges CLI options on top of env-var config (CLI takes precedence).
+ *
+ * If the port is already in use by another lore gateway (verified via
+ * `/health` probe), returns a handle with `owned: false` so the caller
+ * can reuse the existing instance instead of failing.
  */
-export function startGateway(opts: StartOptions = {}): {
-  config: GatewayConfig;
-  port: number;
-  shutdown: () => Promise<void>;
-} {
+export async function startGateway(opts: StartOptions = {}): Promise<GatewayHandle> {
   const config = loadConfig();
 
   // CLI overrides
@@ -34,21 +64,44 @@ export function startGateway(opts: StartOptions = {}): {
   if (opts.hosts?.length) config.hosts = opts.hosts;
   if (opts.debug !== undefined) config.debug = opts.debug;
 
-  const server = startServer(config);
-  const actualPort = server.port;
+  try {
+    const server = startServer(config);
+    const actualPort = server.port;
 
-  const shutdown = async () => {
-    console.error("[lore] Shutting down…");
-    server.stop();
-    await resetPipelineState();
-    // Shut down the embedding worker thread gracefully. Done after
-    // resetPipelineState (which clears sessions/timers) but before
-    // safeExit — gives the worker time to exit cleanly via its
-    // "shutdown" message handler rather than being killed by _exit().
-    await embedding.resetProvider();
-  };
+    const shutdown = async () => {
+      console.error("[lore] Shutting down…");
+      server.stop();
+      await resetPipelineState();
+      // Shut down the embedding worker thread gracefully. Done after
+      // resetPipelineState (which clears sessions/timers) but before
+      // safeExit — gives the worker time to exit cleanly via its
+      // "shutdown" message handler rather than being killed by _exit().
+      await embedding.resetProvider();
+    };
 
-  return { config, port: actualPort, shutdown };
+    return { config, port: actualPort, owned: true, shutdown };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (/port\b.*\bin use/i.test(msg) || /EADDRINUSE/i.test(msg)) {
+      // Port is occupied — check if it's a lore gateway we can reuse
+      const probeUrl = `http://${config.hosts[0]}:${config.port}`;
+      const alive = await probeGateway(probeUrl);
+      if (alive) {
+        return {
+          config,
+          port: config.port,
+          owned: false,
+          shutdown: async () => {},
+        };
+      }
+      // Port is taken by something else — not a lore gateway
+      throw new Error(
+        `Port ${config.port} is already in use by another process (not a lore gateway). ` +
+          `Use --port / LORE_LISTEN_PORT to pick a different port.`,
+      );
+    }
+    throw e;
+  }
 }
 
 /**
@@ -56,22 +109,19 @@ export function startGateway(opts: StartOptions = {}): {
  * SIGINT/SIGTERM.
  */
 export async function commandStart(opts: StartOptions): Promise<never> {
-  let result: ReturnType<typeof startGateway>;
-  try {
-    result = startGateway(opts);
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    if (/port\b.*\bin use/i.test(msg) || /EADDRINUSE/i.test(msg)) {
-      if (!opts.quiet) {
-        console.error(`[lore] ${msg}`);
-      }
-      process.exit(1);
-    }
-    throw e;
-  }
-  const { config, port, shutdown } = result;
+  const { config, port, owned, shutdown } = await startGateway(opts);
 
   const addrs = config.hosts.map((h) => `http://${h}:${port}`);
+
+  if (!owned) {
+    // Another lore gateway is already running — nothing to do.
+    console.error(`[lore] Gateway already running on ${addrs.join(", ")}`);
+    if (!opts.quiet) {
+      console.error("[lore] Use that instance, or stop it first to start a new one.");
+    }
+    safeExit(0);
+  }
+
   console.error(`[lore] Gateway listening on ${addrs.join(", ")}`);
 
   if (!opts.quiet) {


### PR DESCRIPTION
## Summary

- When another lore instance is already running on the same port, the CLI now probes `/health` to verify it's a lore gateway and reuses it instead of exiting with a port-in-use error.
- `lore start` prints "Gateway already running" and exits cleanly (code 0).
- `lore run` prints "Reusing existing gateway" and launches the AI agent normally, skipping shutdown on exit since we don't own the server.
- If the port is taken by a non-lore process, throws a clear error suggesting `--port` / `LORE_LISTEN_PORT`.

## Changes

### `packages/gateway/src/cli/start.ts`
- Added `GatewayHandle` interface with `owned: boolean` flag
- Added `probeGateway()` helper (same pattern as opencode/pi plugins)
- Made `startGateway()` async — catches EADDRINUSE, probes `/health`, returns `owned: false` for reuse or throws a clear error if the port is taken by something else
- `commandStart()` detects `owned: false` and exits cleanly with an informational message

### `packages/gateway/src/cli/run.ts`
- Awaits the now-async `startGateway()`
- Conditionally prints "Reusing existing gateway" vs "Gateway listening on"
- Only registers shutdown handlers / calls `shutdown()` when `owned: true`
- Agent launch works identically regardless of `owned` — env vars are injected and child process runs as before