### PR TITLE
fix: write informational CLI messages to stdout instead of stderr

### DIFF
--- a/packages/gateway/src/cli/run.ts
+++ b/packages/gateway/src/cli/run.ts
@@ -16,13 +16,13 @@ import { safeExit } from "./exit";
 // ---------------------------------------------------------------------------
 
 async function promptAgent(agents: DetectedAgent[]): Promise<DetectedAgent> {
-  console.error("\n[lore] Multiple AI agents detected:\n");
+  console.log("\n[lore] Multiple AI agents detected:\n");
   for (let i = 0; i < agents.length; i++) {
-    console.error(`  ${i + 1}) ${agents[i].def.displayName} (${agents[i].path})`);
+    console.log(`  ${i + 1}) ${agents[i].def.displayName} (${agents[i].path})`);
   }
-  console.error();
+  console.log();
 
-  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
 
   return new Promise<DetectedAgent>((resolve) => {
     const ask = () => {
@@ -33,7 +33,7 @@ async function promptAgent(agents: DetectedAgent[]): Promise<DetectedAgent> {
           rl.close();
           resolve(agents[idx]);
         } else {
-          console.error(`  Invalid choice. Enter 1–${agents.length}.`);
+          console.log(`  Invalid choice. Enter 1–${agents.length}.`);
           ask();
         }
       });
@@ -79,7 +79,7 @@ async function resolveLaunchTarget(
 
   if (detected.length === 1) {
     agent = detected[0];
-    console.error(`[lore] Detected ${agent.def.displayName} at ${agent.path}`);
+    console.log(`[lore] Detected ${agent.def.displayName} at ${agent.path}`);
   } else if (process.stdin.isTTY) {
     agent = await promptAgent(detected);
   } else {
@@ -127,9 +127,9 @@ export async function commandRun(
   const gatewayUrl = `http://${config.hosts[0]}:${port}`;
 
   if (owned) {
-    console.error(`[lore] Gateway listening on ${gatewayUrl}`);
+    console.log(`[lore] Gateway listening on ${gatewayUrl}`);
   } else {
-    console.error(`[lore] Reusing existing gateway at ${gatewayUrl}`);
+    console.log(`[lore] Reusing existing gateway at ${gatewayUrl}`);
   }
 
   // 2. Resolve what to launch
@@ -137,8 +137,8 @@ export async function commandRun(
 
   if (!target) {
     // No agent found / non-interactive — fall back to server-only mode
-    console.error("[lore] Running in server-only mode. Point your agent at the gateway manually.");
-    console.error(`[lore]   export ANTHROPIC_BASE_URL=${gatewayUrl}`);
+    console.log("[lore] Running in server-only mode. Point your agent at the gateway manually.");
+    console.log(`[lore]   export ANTHROPIC_BASE_URL=${gatewayUrl}`);
 
     if (owned) {
       let shuttingDown = false;
@@ -157,7 +157,7 @@ export async function commandRun(
   }
 
   // 3. Launch agent child process
-  console.error(`[lore] Launching: ${target.command} ${target.args.join(" ")}`.trimEnd());
+  console.log(`[lore] Launching: ${target.command} ${target.args.join(" ")}`.trimEnd());
 
   const child = launchChild(target);
 

--- a/packages/gateway/src/cli/start.ts
+++ b/packages/gateway/src/cli/start.ts
@@ -115,36 +115,36 @@ export async function commandStart(opts: StartOptions): Promise<never> {
 
   if (!owned) {
     // Another lore gateway is already running — nothing to do.
-    console.error(`[lore] Gateway already running on ${addrs.join(", ")}`);
+    console.log(`[lore] Gateway already running on ${addrs.join(", ")}`);
     if (!opts.quiet) {
-      console.error("[lore] Use that instance, or stop it first to start a new one.");
+      console.log("[lore] Use that instance, or stop it first to start a new one.");
     }
     safeExit(0);
   }
 
-  console.error(`[lore] Gateway listening on ${addrs.join(", ")}`);
+  console.log(`[lore] Gateway listening on ${addrs.join(", ")}`);
 
   if (!opts.quiet) {
     const localAddr = addrs[0];
-    console.error(
+    console.log(
       `[lore] Model routing: claude-* → Anthropic, nvidia/* → Nvidia NIM, gpt-* → OpenAI, …`,
     );
-    console.error("");
-    console.error("[lore] Point your AI agent at the gateway:");
-    console.error(`  export ANTHROPIC_BASE_URL=${localAddr}`);
-    console.error(`  export OPENAI_BASE_URL=${localAddr}/v1`);
-    console.error("");
-    console.error("[lore] Configuration (environment variables):");
-    console.error(`  LORE_LISTEN_PORT        Port to listen on (current: ${port})`);
-    console.error(`  LORE_LISTEN_HOST        Hosts to bind to, comma-separated (current: ${config.hosts.join(",")})`);
-    console.error(`  LORE_UPSTREAM_ANTHROPIC Anthropic API URL (current: ${config.upstreamAnthropic})`);
-    console.error(`  LORE_UPSTREAM_OPENAI    OpenAI API URL (current: ${config.upstreamOpenAI})`);
-    console.error(`  LORE_IDLE_TIMEOUT       Idle timeout in seconds (current: ${config.idleTimeoutSeconds})`);
-    console.error(`  LORE_DEBUG              Enable debug logging (current: ${config.debug})`);
-    console.error(`  LORE_BATCH_DISABLED     Disable batch background work (current: ${process.env.LORE_BATCH_DISABLED === "1"})`);
-    console.error("");
-    console.error("[lore] When using Claude Code, also set:");
-    console.error("  export DISABLE_AUTO_COMPACT=1");
+    console.log("");
+    console.log("[lore] Point your AI agent at the gateway:");
+    console.log(`  export ANTHROPIC_BASE_URL=${localAddr}`);
+    console.log(`  export OPENAI_BASE_URL=${localAddr}/v1`);
+    console.log("");
+    console.log("[lore] Configuration (environment variables):");
+    console.log(`  LORE_LISTEN_PORT        Port to listen on (current: ${port})`);
+    console.log(`  LORE_LISTEN_HOST        Hosts to bind to, comma-separated (current: ${config.hosts.join(",")})`);
+    console.log(`  LORE_UPSTREAM_ANTHROPIC Anthropic API URL (current: ${config.upstreamAnthropic})`);
+    console.log(`  LORE_UPSTREAM_OPENAI    OpenAI API URL (current: ${config.upstreamOpenAI})`);
+    console.log(`  LORE_IDLE_TIMEOUT       Idle timeout in seconds (current: ${config.idleTimeoutSeconds})`);
+    console.log(`  LORE_DEBUG              Enable debug logging (current: ${config.debug})`);
+    console.log(`  LORE_BATCH_DISABLED     Disable batch background work (current: ${process.env.LORE_BATCH_DISABLED === "1"})`);
+    console.log("");
+    console.log("[lore] When using Claude Code, also set:");
+    console.log("  export DISABLE_AUTO_COMPACT=1");
   }
   // Block until signal
   let shuttingDown = false;


### PR DESCRIPTION
## Summary

- Switch informational `[lore]` messages in `run.ts` and `start.ts` from `console.error` (stderr) to `console.log` (stdout) so they no longer appear red in terminals that color stderr output.
- Actual error messages (no agents found, failed to launch, non-TTY error) and shutdown lifecycle messages remain on stderr.
- The readline agent picker prompt output is also switched from `process.stderr` to `process.stdout` to match the menu stream.

All changed messages are printed **before** the child process is spawned, so there's no risk of interleaving with agent output on stdout.