### PR TITLE
feat: improve meta-request detection to prevent distilling title/summary conversations

### DIFF
--- a/packages/gateway/script/smoke-test.ts
+++ b/packages/gateway/script/smoke-test.ts
@@ -180,8 +180,8 @@ try {
   // Test 2 — Non-streaming request with marker injection
   // -----------------------------------------------------------------------
   await runTest("Test 2: Non-streaming request", async () => {
-    // Include tools so the request isn't classified as a title/summary
-    // passthrough (isTitleOrSummaryRequest checks tools.length ≤ 2)
+    // Include tools so the request isn't classified as a meta request
+    // passthrough (isMetaRequest scores tools.length ≤ 2 as a signal)
     const tools = [
       { name: "bash", description: "Run a shell command", input_schema: { type: "object", properties: { command: { type: "string" } }, required: ["command"] } },
       { name: "read", description: "Read a file", input_schema: { type: "object", properties: { path: { type: "string" } }, required: ["path"] } },

--- a/packages/gateway/src/compaction.ts
+++ b/packages/gateway/src/compaction.ts
@@ -236,38 +236,106 @@ export function extractPreviousSummary(
 }
 
 // ---------------------------------------------------------------------------
-// isTitleOrSummaryRequest
+// isMetaRequest (replaces isTitleOrSummaryRequest)
 // ---------------------------------------------------------------------------
 
-/** Max system prompt length for title/summary agents (chars). */
-const TITLE_SUMMARY_MAX_SYSTEM_LENGTH = 500;
-
-/** Max number of tools for a title/summary agent (0 or very few). */
-const TITLE_SUMMARY_MAX_TOOLS = 2;
-
-/** Max message count for a title/summary agent (system extracted, so 1–2). */
-const TITLE_SUMMARY_MAX_MESSAGES = 2;
+/** Header injected by the OpenCode plugin identifying the calling agent. */
+export const LORE_AGENT_HEADER = "x-lore-agent";
 
 /**
- * Detect non-conversation requests that should be forwarded without Lore
- * pipeline processing (title generation, summary agents, etc.).
- *
- * These have:
- *  - Empty or very few tools (≤2)
- *  - Only 1–2 messages (system already extracted to `req.system`)
- *  - Short system prompt (< 500 chars)
- *  - NOT a compaction request (handled separately)
+ * Agent names known to be primary conversation agents (NOT meta).
+ * When `x-lore-agent` matches, the request is always a normal turn.
  */
-export function isTitleOrSummaryRequest(req: GatewayRequest): boolean {
-  // Compaction requests are handled separately — don't classify as title/summary
+const PRIMARY_AGENTS = new Set(["coder", "code"]);
+
+/**
+ * Agent names known to be meta/housekeeping agents.
+ * When `x-lore-agent` matches, the request is always passthrough.
+ */
+const META_AGENTS = new Set(["title", "summary", "summarize", "categorize", "label", "classify"]);
+
+// Heuristic scoring weights — each signal contributes independently.
+// Threshold of 8 preserves backward compat: the old 3-check AND scored 3+3+2 = 8.
+const SCORE_FEW_TOOLS = 3; // tools ≤ 2  (real agents have 5+)
+const SCORE_FEW_MESSAGES = 3; // messages ≤ 2  (meta requests are single-shot)
+const SCORE_SHORT_SYSTEM = 2; // system < 500 chars  (real prompts are 2K–50K)
+const SCORE_LOW_MAX_TOKENS = 3; // maxTokens ≤ 300  (title gen uses tiny budgets)
+const SCORE_META_KEYWORDS = 2; // system prompt contains meta-task keywords
+const META_SCORE_THRESHOLD = 8;
+
+/** Max tools for the structural heuristic signal. */
+const META_MAX_TOOLS = 2;
+/** Max messages for the structural heuristic signal. */
+const META_MAX_MESSAGES = 2;
+/** Max system prompt length for the structural heuristic signal (chars). */
+const META_MAX_SYSTEM_LENGTH = 500;
+/** Max output tokens that suggests a meta/title request. */
+const META_MAX_TOKENS = 300;
+/** Max system prompt length for keyword scanning (avoid false positives on large prompts). */
+const META_KEYWORD_SYSTEM_LENGTH = 2000;
+
+const META_KEYWORDS = [
+  "generate a title",
+  "generate a short title",
+  "title for the conversation",
+  "title for this conversation",
+  "summarize this conversation",
+  "summarize the conversation",
+  "conversation summary",
+  "categorize",
+  "classify this",
+  "label this",
+];
+
+/**
+ * Detect non-conversation meta requests that should be forwarded without
+ * Lore pipeline processing (title generation, summary agents, categorization,
+ * labeling, etc.).
+ *
+ * Uses a two-layer approach:
+ *  1. Explicit `x-lore-agent` header (OpenCode plugin) — authoritative signal.
+ *  2. Heuristic scoring (all clients) — structural + budget + keyword signals.
+ *
+ * Returns `true` when the request should bypass Lore processing.
+ * Biased toward false negatives (letting meta requests through to full pipeline)
+ * over false positives (incorrectly skipping a real conversation turn).
+ */
+export function isMetaRequest(req: GatewayRequest): boolean {
+  // Compaction requests are handled separately
   if (isCompactionRequest(req)) return false;
 
-  return (
-    req.tools.length <= TITLE_SUMMARY_MAX_TOOLS &&
-    req.messages.length <= TITLE_SUMMARY_MAX_MESSAGES &&
-    req.system.length < TITLE_SUMMARY_MAX_SYSTEM_LENGTH
-  );
+  // --- Layer 1: Explicit agent header ---
+  const agentHeader = req.rawHeaders[LORE_AGENT_HEADER];
+  if (agentHeader) {
+    const agent = agentHeader.toLowerCase();
+    if (PRIMARY_AGENTS.has(agent)) return false;
+    if (META_AGENTS.has(agent)) return true;
+    // Unknown agent → fall through to heuristics
+  }
+
+  // --- Layer 2: Heuristic scoring ---
+  let score = 0;
+
+  if (req.tools.length <= META_MAX_TOOLS) score += SCORE_FEW_TOOLS;
+  if (req.messages.length <= META_MAX_MESSAGES) score += SCORE_FEW_MESSAGES;
+  if (req.system.length < META_MAX_SYSTEM_LENGTH) score += SCORE_SHORT_SYSTEM;
+  if (req.maxTokens > 0 && req.maxTokens <= META_MAX_TOKENS) score += SCORE_LOW_MAX_TOKENS;
+
+  // Keyword check — only on short-ish system prompts to avoid false positives
+  // from large prompts that mention "title" or "summary" in passing.
+  if (req.system.length < META_KEYWORD_SYSTEM_LENGTH) {
+    const systemLower = req.system.toLowerCase();
+    for (const kw of META_KEYWORDS) {
+      if (systemLower.includes(kw)) {
+        score += SCORE_META_KEYWORDS;
+        break; // Count once
+      }
+    }
+  }
+
+  return score >= META_SCORE_THRESHOLD;
 }
+
 
 // ---------------------------------------------------------------------------
 // buildCompactionResponse

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -8,7 +8,7 @@
  *
  * Three request classes are handled:
  *  1. Compaction requests → intercepted, never forwarded upstream.
- *  2. Title/summary requests → forwarded transparently, no Lore processing.
+ *  2. Meta requests (title gen, summaries, etc.) → forwarded transparently, no Lore processing.
  *  3. Normal conversation turns → full pipeline.
  */
 import type { LoreMessageWithParts, LLMClient } from "@loreai/core";
@@ -69,7 +69,8 @@ import {
   isCompactionRequest,
   detectCompactionRequest,
   isStructuralCompaction,
-  isTitleOrSummaryRequest,
+  isMetaRequest,
+  LORE_AGENT_HEADER,
   extractPreviousSummary,
   buildCompactionResponse,
   scaleUsageForClient,
@@ -1671,7 +1672,7 @@ async function handleCompaction(
 }
 
 // ---------------------------------------------------------------------------
-// Case 2: Title/summary passthrough
+// Case 2: Meta request passthrough (title gen, summaries, categorization, etc.)
 // ---------------------------------------------------------------------------
 
 async function handlePassthrough(
@@ -2025,7 +2026,7 @@ async function handleConversationTurn(
   //  - LTM: separate system block (no breakpoint, benefits from prefix)
   //  - Tools: 1h TTL on last tool (recall + git reminder are static)
   //  - Conversation: configurable TTL on last message block (5m default, 1h opt-in/auto)
-  // Title/summary passthrough (handlePassthrough) never reaches here — it
+  // Meta request passthrough (handlePassthrough) never reaches here — it
   // forwards the raw request without buildAnthropicRequest, so no caching.
 
   // Resolve conversation cache TTL: explicit "5m"/"1h" pass through,
@@ -2583,8 +2584,12 @@ export async function handleRequest(
       );
     }
 
-    // --- Case 2: Title/summary request → passthrough ---
-    if (isTitleOrSummaryRequest(req)) {
+    // --- Case 2: Meta request (title gen, summary, categorization, etc.) → passthrough ---
+    if (isMetaRequest(req)) {
+      log.info(
+        `meta request detected: messages=${req.messages.length} tools=${req.tools.length}`
+        + ` maxTokens=${req.maxTokens} agent=${req.rawHeaders[LORE_AGENT_HEADER] ?? "none"}`,
+      );
       return await handlePassthrough(req, config);
     }
 

--- a/packages/gateway/src/translate/anthropic.ts
+++ b/packages/gateway/src/translate/anthropic.ts
@@ -251,7 +251,7 @@ export function parseAnthropicRequest(
  *     layer, no distillation arrival, no window eviction), the prefix is
  *     byte-identical → cache reads at 0.1× base cost vs 1× uncached.
  *
- * Title/summary passthrough requests should NEVER enable caching — their
+ * Meta request passthrough (title gen, summaries, etc.) should NEVER enable caching — their
  * content varies every call, producing 1.25× write cost with zero reads.
  */
 export type AnthropicCacheOptions = {

--- a/packages/gateway/test/anthropic-caching.test.ts
+++ b/packages/gateway/test/anthropic-caching.test.ts
@@ -5,7 +5,7 @@
  *  1. System prompt caching with 5m TTL (conversation turns)
  *  2. System prompt caching with 1h TTL (worker calls)
  *  3. Conversation message caching (breakpoint on last block)
- *  4. No caching for passthrough (title/summary requests)
+ *  4. No caching for passthrough (meta requests: title gen, summaries, etc.)
  */
 import { describe, test, expect } from "bun:test";
 import {

--- a/packages/gateway/test/compaction.test.ts
+++ b/packages/gateway/test/compaction.test.ts
@@ -4,7 +4,8 @@ import {
   detectCompactionRequest,
   isStructuralCompaction,
   extractPreviousSummary,
-  isTitleOrSummaryRequest,
+  isMetaRequest,
+  LORE_AGENT_HEADER,
   buildCompactionResponse,
   COMPACTION_SYSTEM_PATTERNS,
   COMPACTION_USER_PATTERNS,
@@ -209,7 +210,7 @@ describe("isCompactionRequest", () => {
     expect(isCompactionRequest(req)).toBe(false);
   });
 
-  test("returns false for title/summary requests", () => {
+  test("returns false for meta requests (title/summary)", () => {
     const req = makeRequest({
       system: "Generate a title.",
       tools: [],
@@ -301,17 +302,19 @@ describe("extractPreviousSummary", () => {
 });
 
 // ---------------------------------------------------------------------------
-// isTitleOrSummaryRequest
+// isMetaRequest
 // ---------------------------------------------------------------------------
 
-describe("isTitleOrSummaryRequest", () => {
+describe("isMetaRequest", () => {
+  // -- Backward-compatible: existing structural patterns still detected ------
+
   test("detects short system prompt + single message as title request", () => {
     const req = makeRequest({
       system: "Generate a short title for the conversation.",
       tools: [],
       messages: [userMsg("Help me sort an array in JavaScript")],
     });
-    expect(isTitleOrSummaryRequest(req)).toBe(true);
+    expect(isMetaRequest(req)).toBe(true);
   });
 
   test("detects with 2 messages and 1 tool (within limits)", () => {
@@ -323,7 +326,7 @@ describe("isTitleOrSummaryRequest", () => {
         assistantMsg("Second"),
       ],
     });
-    expect(isTitleOrSummaryRequest(req)).toBe(true);
+    expect(isMetaRequest(req)).toBe(true);
   });
 
   test("returns false for normal conversation with many tools", () => {
@@ -336,7 +339,7 @@ describe("isTitleOrSummaryRequest", () => {
       ],
       messages: [userMsg("Help me with a bug")],
     });
-    expect(isTitleOrSummaryRequest(req)).toBe(false);
+    expect(isMetaRequest(req)).toBe(false);
   });
 
   test("returns false for many messages", () => {
@@ -349,7 +352,7 @@ describe("isTitleOrSummaryRequest", () => {
         userMsg("Turn 2"),
       ],
     });
-    expect(isTitleOrSummaryRequest(req)).toBe(false);
+    expect(isMetaRequest(req)).toBe(false);
   });
 
   test("returns false for long system prompt", () => {
@@ -358,7 +361,8 @@ describe("isTitleOrSummaryRequest", () => {
       tools: [],
       messages: [userMsg("Hello")],
     });
-    expect(isTitleOrSummaryRequest(req)).toBe(false);
+    // tools(3) + messages(3) + system(0) = 6 < 8 → false
+    expect(isMetaRequest(req)).toBe(false);
   });
 
   test("returns false for compaction requests (handled separately)", () => {
@@ -368,8 +372,8 @@ describe("isTitleOrSummaryRequest", () => {
       tools: [],
       messages: [userMsg("Summarize the conversation")],
     });
-    // Compaction-detected → isCompactionRequest returns true → isTitleOrSummaryRequest returns false
-    expect(isTitleOrSummaryRequest(req)).toBe(false);
+    // Compaction-detected → isCompactionRequest returns true → isMetaRequest returns false
+    expect(isMetaRequest(req)).toBe(false);
   });
 
   test("system prompt just under limit passes", () => {
@@ -378,7 +382,152 @@ describe("isTitleOrSummaryRequest", () => {
       tools: [],
       messages: [userMsg("Hello")],
     });
-    expect(isTitleOrSummaryRequest(req)).toBe(true);
+    expect(isMetaRequest(req)).toBe(true);
+  });
+
+  // -- Layer 1: x-lore-agent header -----------------------------------------
+
+  test("x-lore-agent: known meta agent → true regardless of structure", () => {
+    const req = makeRequest({
+      system: "A".repeat(2000), // would fail structural heuristics
+      tools: [
+        { name: "bash", description: "Run shell", inputSchema: {} },
+        { name: "read", description: "Read files", inputSchema: {} },
+        { name: "write", description: "Write files", inputSchema: {} },
+      ],
+      messages: [userMsg("Turn 1"), assistantMsg("Turn 2"), userMsg("Turn 3")],
+      rawHeaders: { [LORE_AGENT_HEADER]: "title" },
+    });
+    expect(isMetaRequest(req)).toBe(true);
+  });
+
+  test("x-lore-agent: known primary agent → false even if structurally meta", () => {
+    const req = makeRequest({
+      system: "Generate a short title for the conversation.",
+      tools: [],
+      messages: [userMsg("Hello")],
+      rawHeaders: { [LORE_AGENT_HEADER]: "coder" },
+    });
+    expect(isMetaRequest(req)).toBe(false);
+  });
+
+  test("x-lore-agent: unknown agent → falls through to heuristics", () => {
+    // Structurally meta — should be detected by heuristics
+    const req = makeRequest({
+      system: "Short prompt.",
+      tools: [],
+      messages: [userMsg("Hello")],
+      rawHeaders: { [LORE_AGENT_HEADER]: "custom-agent" },
+    });
+    expect(isMetaRequest(req)).toBe(true);
+  });
+
+  test("x-lore-agent: unknown agent + not structurally meta → false", () => {
+    const req = makeRequest({
+      system: "A".repeat(2000),
+      tools: [
+        { name: "bash", description: "Run shell", inputSchema: {} },
+        { name: "read", description: "Read files", inputSchema: {} },
+        { name: "write", description: "Write files", inputSchema: {} },
+      ],
+      messages: [userMsg("Turn 1"), assistantMsg("Turn 2"), userMsg("Turn 3")],
+      rawHeaders: { [LORE_AGENT_HEADER]: "custom-agent" },
+    });
+    expect(isMetaRequest(req)).toBe(false);
+  });
+
+  test("x-lore-agent: all known meta agent names detected", () => {
+    for (const agent of ["title", "summary", "summarize", "categorize", "label", "classify"]) {
+      const req = makeRequest({
+        system: "A".repeat(2000),
+        tools: [{ name: "bash", description: "Run shell", inputSchema: {} },
+                { name: "read", description: "Read", inputSchema: {} },
+                { name: "write", description: "Write", inputSchema: {} }],
+        messages: [userMsg("A"), assistantMsg("B"), userMsg("C")],
+        rawHeaders: { [LORE_AGENT_HEADER]: agent },
+      });
+      expect(isMetaRequest(req)).toBe(true);
+    }
+  });
+
+  // -- Layer 2: maxTokens signal --------------------------------------------
+
+  test("low maxTokens + few messages + few tools → detected", () => {
+    const req = makeRequest({
+      system: "A".repeat(600), // too long for short-system signal
+      tools: [],
+      messages: [userMsg("Hello")],
+      maxTokens: 100,
+    });
+    // tools(3) + messages(3) + system(0) + maxTokens(3) = 9 ≥ 8 → true
+    expect(isMetaRequest(req)).toBe(true);
+  });
+
+  test("default maxTokens + few messages + few tools + short system → detected (backward compat)", () => {
+    const req = makeRequest({
+      system: "Short.",
+      tools: [],
+      messages: [userMsg("Hello")],
+      maxTokens: 4096,
+    });
+    // tools(3) + messages(3) + system(2) = 8 ≥ 8 → true
+    expect(isMetaRequest(req)).toBe(true);
+  });
+
+  test("low maxTokens alone is not enough", () => {
+    const req = makeRequest({
+      system: "A".repeat(2000),
+      tools: [
+        { name: "bash", description: "Run shell", inputSchema: {} },
+        { name: "read", description: "Read files", inputSchema: {} },
+        { name: "write", description: "Write files", inputSchema: {} },
+      ],
+      messages: [userMsg("Turn 1"), assistantMsg("Turn 2"), userMsg("Turn 3")],
+      maxTokens: 100,
+    });
+    // tools(0) + messages(0) + system(0) + maxTokens(3) = 3 < 8 → false
+    expect(isMetaRequest(req)).toBe(false);
+  });
+
+  // -- Layer 2: keyword signal (bonus only) ---------------------------------
+
+  test("long system prompt with meta keyword + low maxTokens + few messages → detected", () => {
+    const req = makeRequest({
+      system: "Please generate a title for the conversation. " + "x".repeat(600),
+      tools: [],
+      messages: [userMsg("Help me")],
+      maxTokens: 150,
+    });
+    // tools(3) + messages(3) + system(0) + maxTokens(3) + keyword(2) = 11 ≥ 8 → true
+    expect(isMetaRequest(req)).toBe(true);
+  });
+
+  test("large system prompt mentioning 'title' casually is not detected", () => {
+    const req = makeRequest({
+      system: "You are a coding assistant. " + "x".repeat(3000) + " Always use a descriptive title for PRs.",
+      tools: [
+        { name: "bash", description: "Run shell", inputSchema: {} },
+        { name: "read", description: "Read files", inputSchema: {} },
+        { name: "write", description: "Write files", inputSchema: {} },
+      ],
+      messages: [userMsg("Help me with a bug")],
+    });
+    // tools(0) + messages(3) + system(0) + maxTokens(0) + keyword(0, system > 2000) = 3 < 8 → false
+    expect(isMetaRequest(req)).toBe(false);
+  });
+
+  test("keywords alone cannot trigger detection", () => {
+    const req = makeRequest({
+      system: "Generate a title for the conversation.",
+      tools: [
+        { name: "bash", description: "Run shell", inputSchema: {} },
+        { name: "read", description: "Read files", inputSchema: {} },
+        { name: "write", description: "Write files", inputSchema: {} },
+      ],
+      messages: [userMsg("Turn 1"), assistantMsg("Turn 2"), userMsg("Turn 3")],
+    });
+    // tools(0) + messages(0) + system(2) + keyword(2) = 4 < 8 → false
+    expect(isMetaRequest(req)).toBe(false);
   });
 });
 

--- a/packages/gateway/test/helpers/fixtures.ts
+++ b/packages/gateway/test/helpers/fixtures.ts
@@ -121,7 +121,7 @@ export function makeConversationFixtures(
 }
 
 // ---------------------------------------------------------------------------
-// Standard 3-tool set (matches smoke-test pattern — passes isTitleOrSummaryRequest)
+// Standard 3-tool set (matches smoke-test pattern — passes isMetaRequest)
 // ---------------------------------------------------------------------------
 
 /** Three tools that ensure a request is classified as a normal conversation turn. */

--- a/packages/gateway/test/replay.test.ts
+++ b/packages/gateway/test/replay.test.ts
@@ -22,7 +22,7 @@ import { parseMarker } from "../src/session";
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Minimal request body that passes isTitleOrSummaryRequest → false. */
+/** Minimal request body that passes isMetaRequest → false. */
 function makeBody(
   userMessage: string,
   extraMessages: unknown[] = [],
@@ -265,10 +265,10 @@ describe("Temporal storage", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Suite: "Title/summary passthrough"
+// Suite: "Meta request passthrough"
 // ---------------------------------------------------------------------------
 
-describe("Title/summary passthrough", () => {
+describe("Meta request passthrough", () => {
   let harness: Harness;
 
   afterEach(() => harness?.teardown());
@@ -289,7 +289,7 @@ describe("Title/summary passthrough", () => {
       ],
     });
 
-    // Title/summary request shape: short system (<500 chars), ≤2 tools, ≤2 messages
+    // Meta request shape: short system (<500 chars), ≤2 tools, ≤2 messages
     const resp = await harness.chat({
       model: DEFAULT_MODEL,
       max_tokens: 50,
@@ -298,7 +298,7 @@ describe("Title/summary passthrough", () => {
       messages: [
         { role: "user", content: "Title: User asks about math" },
       ],
-      // No tools — signals title/summary agent
+      // No tools — signals meta request (title/summary agent)
     });
 
     expect(resp.status).toBe(200);

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -157,6 +157,12 @@ export const LorePlugin: Plugin = async (ctx) => {
     },
 
     tool: {},
+
+    // Inject the agent name so the gateway can distinguish meta requests
+    // (title generation, summary agents, etc.) from real conversation turns.
+    "chat.headers": async (input, output) => {
+      output.headers["x-lore-agent"] = input.agent;
+    },
   };
 
   // Startup banner — visible in stderr so silent failures are obvious.


### PR DESCRIPTION
## Summary

- Replace `isTitleOrSummaryRequest()` with `isMetaRequest()` using a two-layer detection approach to prevent meta conversations (title generation, summaries, categorization) from being stored and distilled
- Add `chat.headers` hook to OpenCode plugin injecting `x-lore-agent` header for authoritative agent identification
- Improve heuristic scoring with `maxTokens` and keyword signals alongside existing structural checks

## Details

**Problem:** The gateway's meta-request filter used a narrow structural heuristic (tools ≤ 2, messages ≤ 2, system < 500 chars) that could miss title/summary requests with slightly different shapes, causing them to be stored in temporal and distilled into session history.

**Layer 1 — Explicit header:** The OpenCode plugin SDK provides the agent name (e.g., `"coder"`, `"title"`) via the `chat.headers` hook. We now inject it as `x-lore-agent`, giving the gateway an authoritative signal. Known meta agents (`title`, `summary`, `categorize`, etc.) are always passthrough; known primary agents (`coder`, `code`) are never meta.

**Layer 2 — Improved heuristics:** For non-OpenCode clients (Claude Code, Pi, generic), we replace the rigid boolean gate with weighted scoring:
| Signal | Score | Rationale |
|---|---|---|
| tools ≤ 2 | +3 | Real agents have 5+ tools |
| messages ≤ 2 | +3 | Meta requests are single-shot |
| system < 500 chars | +2 | Real prompts are 2K–50K |
| maxTokens ≤ 300 | +3 | Title gen uses tiny output budgets |
| Meta keywords in short system prompt | +2 | Bonus only, never standalone |

Threshold: **≥ 8** (preserves backward compat — the old 3-check AND scored 3+3+2 = 8).

**Files changed:**
- `packages/opencode/src/index.ts` — `chat.headers` hook
- `packages/gateway/src/compaction.ts` — `isMetaRequest()` with scoring
- `packages/gateway/src/pipeline.ts` — updated import, call site, observability log
- Tests and comments updated across 6 files