### PR TITLE
fix: prevent subagent turns from inflating session messageCount

### DIFF
--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -1784,8 +1784,13 @@ async function handleConversationTurn(
     );
   }
 
-  // Always update message count for proximity matching
-  sessionState.messageCount = currMsgCount;
+  // Update message count for proximity matching & structural compaction detection.
+  // Sub-agent turns have their own independent (smaller) message arrays — updating
+  // messageCount with those would inflate then "drop" the count when the main agent
+  // resumes, triggering false structural compaction detection.
+  if (!isSubagentTurn) {
+    sessionState.messageCount = currMsgCount;
+  }
 
   // Track session model for worker model discovery
   lastSeenSessionModel = req.model;


### PR DESCRIPTION
## Summary

- Fix false structural compaction detection caused by subagent turns inflating the parent session's `messageCount`
- Guard `messageCount` update with `!isSubagentTurn`, consistent with existing guards on temporal storage and output EMA

## Root Cause

Subagent turns (explore, general, code agents) share the parent session via `x-parent-session-id` but have their own independent message arrays that grow from 1 → 3 → 5 → ... → 13+. `sessionState.messageCount` was updated unconditionally on every turn (line 1788), so after subagents finished:

1. `messageCount` = 13 (from the last subagent turn)
2. Main agent resumes with 3 messages (user + assistant + new user)
3. `isStructuralCompaction` sees `prior=13 > 10` and `curr=3 ≤ 3` → **fires**
4. Gateway returns a compaction summary ("Goal, Long Term Knowledge...") instead of forwarding to upstream
5. User sees an unexpected summary and must manually say "go" to continue

Evidence from logs — every false positive has `tools=34` (real compaction has 0 tools):
```
compaction detected: structural (prior=13 curr=3) messages=3 tools=34
compaction detected: structural (prior=19 curr=3) messages=3 tools=34
compaction detected: structural (prior=27 curr=3) messages=3 tools=34
```

## Fix

Only update `messageCount` on non-subagent turns. Subagent turns already skip temporal storage (line 1367) and output EMA (line 1416) with the same `!isSubagentTurn` guard — `messageCount` should be treated consistently.