### PR TITLE
feat: show dashboard URL on startup and add `lore logs` command

### DIFF
--- a/packages/core/src/log.ts
+++ b/packages/core/src/log.ts
@@ -14,7 +14,18 @@
  * When registered, every log call (regardless of `isDebug`) also forwards
  * to the sink. This is used by the gateway to bridge logs → Sentry without
  * adding a Sentry dependency to `@loreai/core`.
+ *
+ * ## File logging
+ *
+ * All log calls (info, warn, error) are written to a persistent log file
+ * at `~/.local/share/opencode-lore/lore.log` regardless of `LORE_DEBUG`.
+ * The file is rotated when it exceeds 5 MB (single `.log.1` backup).
+ * Use `lore logs` to view; disabled during tests (`NODE_ENV=test`).
  */
+
+import { appendFileSync, renameSync, statSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
 
 // ---------------------------------------------------------------------------
 // Sink — optional external log consumer (e.g. Sentry)
@@ -57,25 +68,104 @@ function findError(args: unknown[]): Error | undefined {
 }
 
 // ---------------------------------------------------------------------------
+// File sink — persistent log file, independent of LORE_DEBUG
+// ---------------------------------------------------------------------------
+
+const LOG_MAX_BYTES = 5 * 1024 * 1024; // 5 MB
+const ROTATION_CHECK_INTERVAL = 1000; // check size every N writes
+
+let logPath: string | undefined;
+let logPathResolved = false;
+let writeCount = 0;
+
+/**
+ * Resolve the log file path. Returns `undefined` in test environments
+ * or if the directory cannot be created.
+ */
+function resolveLogPath(): string | undefined {
+  if (process.env.NODE_ENV === "test") return undefined;
+  try {
+    const base =
+      process.env.XDG_DATA_HOME || join(homedir(), ".local", "share");
+    const dir = join(base, "opencode-lore");
+    mkdirSync(dir, { recursive: true });
+    return join(dir, "lore.log");
+  } catch {
+    return undefined;
+  }
+}
+
+/** Return the resolved log file path (or `undefined` if unavailable). */
+export function logFilePath(): string | undefined {
+  if (!logPathResolved) {
+    logPath = resolveLogPath();
+    logPathResolved = true;
+  }
+  return logPath;
+}
+
+/** Rotate the log file if it exceeds the size cap. */
+function maybeRotate(): void {
+  if (!logPath) return;
+  try {
+    const stat = statSync(logPath);
+    if (stat.size > LOG_MAX_BYTES) {
+      renameSync(logPath, logPath + ".1");
+    }
+  } catch {
+    // File doesn't exist yet or stat failed — fine
+  }
+}
+
+/** Append a single log line to the persistent log file. */
+function writeToFile(level: string, message: string): void {
+  const path = logFilePath();
+  if (!path) return;
+
+  // Periodic rotation check
+  if (++writeCount % ROTATION_CHECK_INTERVAL === 0) {
+    maybeRotate();
+  }
+
+  const ts = new Date().toISOString();
+  const tag = level.toUpperCase().padEnd(5);
+  // Flatten multiline messages for clean tail -f output
+  const flat = message.replace(/\n/g, "\\n");
+  const line = `${ts} [${tag}] ${flat}\n`;
+
+  try {
+    appendFileSync(path, line);
+  } catch {
+    // Silently degrade — logging failure shouldn't crash the app
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
 /** Log an informational status message. Suppressed unless LORE_DEBUG=1. */
 export function info(...args: unknown[]): void {
   if (isDebug) console.error("[lore]", ...args);
-  sink?.info(formatArgs(args));
+  const msg = formatArgs(args);
+  sink?.info(msg);
+  writeToFile("info", msg);
 }
 
 /** Log a warning. Suppressed unless LORE_DEBUG=1. */
 export function warn(...args: unknown[]): void {
   if (isDebug) console.error("[lore] WARN:", ...args);
-  sink?.warn(formatArgs(args));
+  const msg = formatArgs(args);
+  sink?.warn(msg);
+  writeToFile("warn", msg);
 }
 
 /** Log an error. Always visible — these indicate real failures. */
 export function error(...args: unknown[]): void {
   console.error("[lore]", ...args);
-  sink?.error(formatArgs(args));
+  const msg = formatArgs(args);
+  sink?.error(msg);
+  writeToFile("error", msg);
 
   const err = findError(args);
   if (err) sink?.captureException(err);

--- a/packages/gateway/src/cli/help.ts
+++ b/packages/gateway/src/cli/help.ts
@@ -12,6 +12,7 @@ Usage:
 Commands:
   run [command...]    Start gateway and launch an AI agent (default)
   start               Start the gateway server only
+  logs                Show lore activity log
   import              Import knowledge from prior AI agent conversations
   data <subcommand>   Manage stored data (list, show, clear, delete)
   recall <query>      Search project memory from the command line
@@ -26,6 +27,11 @@ Options:
   -d, --debug         Enable debug logging (env: LORE_DEBUG=1)
   -v, --version       Print version and exit
   -h, --help          Show this help text
+
+Log options (lore logs):
+  -f, --follow        Follow log output in real-time
+  -n, --lines <n>     Number of lines to show (default: 50)
+  --path              Print log file path and exit
 
 Data subcommands:
   data list <type>              List entries (projects, knowledge, sessions, distillations)
@@ -72,6 +78,10 @@ Examples:
   lore import                   # Import knowledge from prior AI conversations
   lore import --dry-run         # Show what would be imported
   lore import --agent claude-code  # Import from Claude Code only
+  lore logs                     # Show recent log entries
+  lore logs -f                  # Follow log output in real-time
+  lore logs -n 100              # Show last 100 lines
+  lore logs --path              # Print log file path
   lore recall "error handling"  # Search project memory from CLI
 
 Environment variables:

--- a/packages/gateway/src/cli/logs.ts
+++ b/packages/gateway/src/cli/logs.ts
@@ -1,0 +1,105 @@
+/**
+ * `lore logs` — view the persistent activity log.
+ *
+ * Usage:
+ *   lore logs              Print last 50 lines and exit
+ *   lore logs -f           Follow log output in real-time
+ *   lore logs -n 100       Print last 100 lines
+ *   lore logs --path       Print the log file path and exit
+ */
+import {
+  readFileSync,
+  statSync,
+  watchFile,
+  unwatchFile,
+  openSync,
+  readSync,
+  closeSync,
+} from "node:fs";
+import { log } from "@loreai/core";
+
+// ---------------------------------------------------------------------------
+// Command entry point
+// ---------------------------------------------------------------------------
+
+export async function commandLogs(
+  _positionals: string[],
+  values: Record<string, unknown>,
+): Promise<void> {
+  const path = log.logFilePath();
+
+  // --path: just print the path and exit
+  if (values.path) {
+    if (path) {
+      console.log(path);
+    } else {
+      console.error("Log file path could not be resolved.");
+      process.exit(1);
+    }
+    return;
+  }
+
+  if (!path) {
+    console.error("Log file path could not be resolved.");
+    process.exit(1);
+  }
+
+  // Check the file exists
+  try {
+    statSync(path);
+  } catch {
+    console.error(`No log file found at ${path}`);
+    console.error("Logs are created when lore starts processing requests.");
+    process.exit(1);
+  }
+
+  const follow = !!(values.follow || values.f);
+  const lines = Number(values.n || values.lines) || 50;
+
+  // Read the file and print the last N lines.
+  // Max file size is 5 MB so reading entirely is fine.
+  const content = readFileSync(path, "utf-8");
+  const allLines = content.split("\n").filter(Boolean);
+  const tail = allLines.slice(-lines);
+
+  for (const line of tail) {
+    console.log(line);
+  }
+
+  if (!follow) return;
+
+  // Follow mode: poll for changes and print new content
+  let lastSize = statSync(path).size;
+
+  watchFile(path, { interval: 300 }, (curr) => {
+    if (curr.size > lastSize) {
+      // Read only the new bytes
+      const bytesToRead = curr.size - lastSize;
+      const fd = openSync(path, "r");
+      const buf = Buffer.alloc(bytesToRead);
+      readSync(fd, buf, 0, bytesToRead, lastSize);
+      closeSync(fd);
+
+      const newContent = buf.toString("utf-8");
+      const newLines = newContent.split("\n").filter(Boolean);
+      for (const line of newLines) {
+        console.log(line);
+      }
+      lastSize = curr.size;
+    } else if (curr.size < lastSize) {
+      // File was rotated — reset to read from the beginning
+      lastSize = 0;
+    }
+  });
+
+  // Clean up on signal
+  const cleanup = () => {
+    unwatchFile(path);
+    process.exit(0);
+  };
+  process.on("SIGINT", cleanup);
+  process.on("SIGTERM", cleanup);
+
+  // Block forever
+  return new Promise(() => {});
+}

--- a/packages/gateway/src/cli/main.ts
+++ b/packages/gateway/src/cli/main.ts
@@ -32,6 +32,11 @@ const OPTIONS = {
   debug: { type: "boolean" as const, short: "d" },
   version: { type: "boolean" as const, short: "v" },
   help: { type: "boolean" as const, short: "h" },
+  // `lore logs` flags
+  follow: { type: "boolean" as const, short: "f" },
+  n: { type: "string" as const },
+  lines: { type: "string" as const },
+  path: { type: "boolean" as const },
   // Hidden diagnostic: prints the vendored-fastembed registration set by
   // the binary build wrapper (or "none" in npm mode). Used by CI to verify
   // the embed-asset pipeline actually wired up. Not in help text.
@@ -183,6 +188,12 @@ export async function _cli(): Promise<void> {
       case "recall": {
         const { commandRecall } = await import("./recall-cmd");
         await commandRecall(rest, values as Record<string, unknown>);
+        break;
+      }
+
+      case "logs": {
+        const { commandLogs } = await import("./logs");
+        await commandLogs(rest, values as Record<string, unknown>);
         break;
       }
 

--- a/packages/gateway/src/cli/run.ts
+++ b/packages/gateway/src/cli/run.ts
@@ -132,6 +132,7 @@ export async function commandRun(
   } else {
     console.log(`[lore] Reusing existing gateway at ${gatewayUrl}`);
   }
+  console.log(`[lore] Dashboard: ${gatewayUrl}/ui`);
 
   // 2. Resolve what to launch
   const target = await resolveLaunchTarget(gatewayUrl, cmdArgs);

--- a/packages/gateway/src/cli/start.ts
+++ b/packages/gateway/src/cli/start.ts
@@ -116,6 +116,7 @@ export async function commandStart(opts: StartOptions): Promise<never> {
   if (!owned) {
     // Another lore gateway is already running — nothing to do.
     console.log(`[lore] Gateway already running on ${addrs.join(", ")}`);
+    console.log(`[lore] Dashboard: ${addrs[0]}/ui`);
     if (!opts.quiet) {
       console.log("[lore] Use that instance, or stop it first to start a new one.");
     }
@@ -123,6 +124,7 @@ export async function commandStart(opts: StartOptions): Promise<never> {
   }
 
   console.log(`[lore] Gateway listening on ${addrs.join(", ")}`);
+  console.log(`[lore] Dashboard: ${addrs[0]}/ui`);
 
   if (!opts.quiet) {
     const localAddr = addrs[0];

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -172,6 +172,7 @@ export const LorePlugin: Plugin = async (ctx) => {
 
     if (gatewayActive) {
       process.stderr.write(`[lore] gateway mode — routing through ${gatewayBase}\n`);
+      process.stderr.write(`[lore] dashboard: ${gatewayBase}/ui\n`);
     }
 
     processInitDone = true;


### PR DESCRIPTION
## Summary

- Surface the dashboard URL (`http://host:port/ui`) in all startup messages (`lore run`, `lore start`, OpenCode plugin) so users know the UI exists
- Add a persistent file-based log sink in `core/log.ts` that captures all `log.info/warn/error` calls to `~/.local/share/opencode-lore/lore.log` regardless of `LORE_DEBUG`, with 5MB rotation
- Add `lore logs` CLI command with `-f` (follow), `-n` (line count), and `--path` flags

Closes #242

## Details

### Dashboard URL notification

Added `[lore] Dashboard: <url>/ui` messages after existing "gateway listening" lines in:
- `packages/gateway/src/cli/run.ts` — both owned and reused gateway paths
- `packages/gateway/src/cli/start.ts` — both "already running" and fresh start paths
- `packages/opencode/src/index.ts` — OpenCode plugin stderr banner

### Persistent log file

All `log.info/warn/error` calls now write to `~/.local/share/opencode-lore/lore.log` regardless of `LORE_DEBUG`:
- ISO 8601 timestamps with level tags: `2025-01-15T14:32:05.123Z [INFO ] message`
- Single-file rotation at 5MB (`.log.1` backup, ~10MB max disk)
- Rotation check every 1000 writes, not every write
- Disabled during tests (`NODE_ENV=test`)
- Silently degrades on any I/O error

### `lore logs` command

| Usage | Behavior |
|---|---|
| `lore logs` | Print last 50 lines and exit |
| `lore logs -f` | Follow log output in real-time (300ms poll) |
| `lore logs -n 100` | Print last 100 lines |
| `lore logs --path` | Print log file path and exit |