### PR TITLE
feat: add cache warming dashboard page and session section

### DIFF
--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -74,14 +74,14 @@ export const HISTOGRAM_BINS: readonly number[] = [
 const BIN_COUNT = HISTOGRAM_BINS.length + 1;
 
 /** Pseudocount for Bayesian blending of session vs global histograms. */
-const BLEND_PSEUDOCOUNT = 20;
+export const BLEND_PSEUDOCOUNT = 20;
 
 /** Survival probability below which a session is marked dead. */
-const DEAD_SESSION_THRESHOLD = 0.02;
+export const DEAD_SESSION_THRESHOLD = 0.02;
 
 /** Minimum completed turns before warming is eligible. Filters out one-shot
  *  sessions and ensures the survival model has ≥2 gap observations. */
-const MIN_TURNS_FOR_WARMING = 3;
+export const MIN_TURNS_FOR_WARMING = 3;
 
 /** Max uncached warmup responses before the global circuit breaker trips. */
 const CIRCUIT_BREAKER_MAX_FAILURES = 3;
@@ -104,6 +104,19 @@ let circuitBreakerTripped = false;
  */
 export function isCircuitBreakerTripped(): boolean {
   return circuitBreakerTripped;
+}
+
+/** Snapshot of circuit breaker state for dashboard rendering. */
+export function getCircuitBreakerStatus(): {
+  tripped: boolean;
+  failures: number;
+  maxFailures: number;
+} {
+  return {
+    tripped: circuitBreakerTripped,
+    failures: circuitBreakerFailures,
+    maxFailures: CIRCUIT_BREAKER_MAX_FAILURES,
+  };
 }
 
 /**
@@ -540,6 +553,149 @@ export function shouldWarm(
 }
 
 // ---------------------------------------------------------------------------
+// Dashboard snapshot
+// ---------------------------------------------------------------------------
+
+/** All data the dashboard needs for one session's warming visualization. */
+export type WarmingSnapshot = {
+  sessionId: string;
+  projectPath: string;
+  // State
+  messageCount: number;
+  idleMs: number;
+  consecutiveTextOnlyTurns: number;
+  ttl: "5m" | "1h" | undefined;
+  // Warmup state
+  warmupCount: number;
+  warmupHits: number;
+  lastWarmupAt: number;
+  disabled: boolean;
+  forceKeepWarm: boolean;
+  // Survival analysis
+  currentSlot: TimeSlot;
+  sessionHistogram: InterTurnHistogram;
+  globalHistogram: InterTurnHistogram;
+  blendedHistogram: InterTurnHistogram;
+  sessionWeight: number;
+  survivalAtIdle: number;
+  pReturn: number;
+  pReturnDampened: number;
+  costThreshold: number;
+  // Decision
+  shouldWarmNow: boolean;
+  notWarmingReason: string | null;
+  // Circuit breaker (global, same for all sessions)
+  circuitBreaker: { tripped: boolean; failures: number; maxFailures: number };
+};
+
+/**
+ * Compute a read-only snapshot of all warming heuristics for a session.
+ *
+ * Used by the dashboard to render warming state without importing
+ * internal functions. All calls are pure or idempotent (read-only).
+ */
+export function computeWarmingSnapshot(
+  state: SessionState,
+  now: number = Date.now(),
+): WarmingSnapshot {
+  const cfg = loreConfig();
+  const slot = resolveTimeSlot(new Date(now));
+  const idleMs = now - state.lastRequestTime;
+
+  // Histograms
+  const sessionHist = state.survivalModel?.slots[slot] ?? createHistogram();
+  loadGlobalHistograms(state.projectPath);
+  const globalHist = getGlobalHistogram(state.projectPath, slot);
+  const blendedHist = blendHistograms(sessionHist, globalHist);
+  const sessionWeight = Math.min(sessionHist.total / BLEND_PSEUDOCOUNT, 1.0);
+
+  // Survival & return probability
+  const survivalAtIdle = survivalFunction(blendedHist, idleMs);
+
+  const profile = resolveProfile(
+    state.lastModel,
+    state.lastProtocol,
+    state.resolvedConversationTTL,
+  );
+  const ttlMs = profile?.ttlMs ?? 300_000;
+  const warmupMarginMs = profile?.warmupMarginMs ?? 45_000;
+
+  const pReturn = conditionalReturnProbability(blendedHist, idleMs, ttlMs);
+  const textOnlyRuns = state.consecutiveTextOnlyTurns ?? 0;
+  const pReturnDampened =
+    textOnlyRuns > 0 ? pReturn * Math.pow(0.5, textOnlyRuns) : pReturn;
+
+  // Threshold
+  const autoThreshold = profile
+    ? profile.cacheReadCostPerMTok / profile.cacheMissCostPerMTok
+    : 0.1;
+  const costThreshold = cfg.cache.warming.minReturnProbability ?? autoThreshold;
+
+  // Decision + reason
+  const warmNow =
+    profile != null &&
+    shouldWarm(state, profile, blendedHist, now);
+
+  let notWarmingReason: string | null = null;
+  if (!warmNow) {
+    if (circuitBreakerTripped) {
+      notWarmingReason = "Circuit breaker tripped";
+    } else if (!cfg.cache.warming.enabled) {
+      notWarmingReason = "Warming disabled in config";
+    } else if (!state.cacheAnalytics.lastRequestBody) {
+      notWarmingReason = "No stored request body";
+    } else if (!profile) {
+      notWarmingReason = "No warming profile (non-Anthropic or unknown model)";
+    } else if (state.warmup?.forceKeepWarm) {
+      const intoWindow = idleMs % ttlMs;
+      if (intoWindow < ttlMs - warmupMarginMs) {
+        notWarmingReason = "Force-keep: not in warmup window yet";
+      }
+    } else if (state.warmup?.lastWarmupAt && now - state.warmup.lastWarmupAt < ttlMs) {
+      notWarmingReason = "Already warmed in this TTL window";
+    } else if (idleMs < ttlMs - warmupMarginMs) {
+      notWarmingReason = "Cache still fresh";
+    } else if (idleMs >= ttlMs) {
+      notWarmingReason = "Cache already expired";
+    } else if (state.messageCount < MIN_TURNS_FOR_WARMING * 2) {
+      notWarmingReason = `Too few turns (${state.messageCount} < ${MIN_TURNS_FOR_WARMING * 2})`;
+    } else if (state.warmup?.disabled) {
+      notWarmingReason = "Session marked dead";
+    } else if (pReturnDampened <= costThreshold) {
+      notWarmingReason = `P(return) ${(pReturnDampened * 100).toFixed(1)}% <= threshold ${(costThreshold * 100).toFixed(1)}%`;
+    } else {
+      notWarmingReason = "Unknown";
+    }
+  }
+
+  return {
+    sessionId: state.sessionID,
+    projectPath: state.projectPath,
+    messageCount: state.messageCount,
+    idleMs,
+    consecutiveTextOnlyTurns: textOnlyRuns,
+    ttl: state.resolvedConversationTTL,
+    warmupCount: state.warmup?.warmupCount ?? 0,
+    warmupHits: state.warmup?.warmupHits ?? 0,
+    lastWarmupAt: state.warmup?.lastWarmupAt ?? 0,
+    disabled: state.warmup?.disabled ?? false,
+    forceKeepWarm: state.warmup?.forceKeepWarm ?? false,
+    currentSlot: slot,
+    sessionHistogram: sessionHist,
+    globalHistogram: globalHist,
+    blendedHistogram: blendedHist,
+    sessionWeight,
+    survivalAtIdle,
+    pReturn,
+    pReturnDampened,
+    costThreshold,
+    shouldWarmNow: warmNow,
+    notWarmingReason,
+    circuitBreaker: getCircuitBreakerStatus(),
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Warmup execution
 // ---------------------------------------------------------------------------
 
@@ -837,6 +993,15 @@ export function recordGlobalGap(
   const hist = getGlobalHistogram(projectPath, slot);
   recordGap(hist, gapMs);
   markDirty(projectPath, slot);
+}
+
+// ---------------------------------------------------------------------------
+// Dashboard helpers
+// ---------------------------------------------------------------------------
+
+/** Read-only snapshot of all loaded global survival models (for dashboard). */
+export function getGlobalModelsSnapshot(): ReadonlyMap<string, SurvivalModel> {
+  return globalModels;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -214,6 +214,11 @@ let cachedProjectPath: string | null = null;
 /** Per-session state tracked across requests. */
 const sessions = new Map<string, SessionState>();
 
+/** Read-only access to live session states (for dashboard rendering). */
+export function getActiveSessions(): ReadonlyMap<string, SessionState> {
+  return sessions;
+}
+
 /**
  * Reverse lookup: maps header-based session ID values to internal session IDs.
  * Key: `headerName:headerValue` (e.g. `x-claude-code-session-id:uuid-1234`).

--- a/packages/gateway/src/ui.ts
+++ b/packages/gateway/src/ui.ts
@@ -27,6 +27,16 @@ import {
   costWithoutLore,
   type SessionCosts,
 } from "./cost-tracker";
+import { getActiveSessions } from "./pipeline";
+import {
+  computeWarmingSnapshot,
+  getCircuitBreakerStatus,
+  getGlobalModelsSnapshot,
+  HISTOGRAM_BINS,
+  BLEND_PSEUDOCOUNT,
+  type WarmingSnapshot,
+} from "./cache-warmer";
+import type { InterTurnHistogram } from "./translate/types";
 
 // ---------------------------------------------------------------------------
 // HTML template helpers
@@ -304,6 +314,73 @@ th[data-sort].desc::after { content: " \\25BC"; opacity: 0.8; }
   border-radius: var(--radius); background: var(--bg); color: var(--fg);
   font-size: 0.85em; width: 260px; }
 .table-filter .count { font-size: 0.8em; color: var(--fg3); }
+/* --- Cache warming histogram bars --- */
+.histogram { margin: 8px 0; }
+.histogram .bin {
+  display: flex; align-items: center; gap: 6px;
+  font-size: 0.8em; font-family: var(--mono); line-height: 1.8;
+}
+.histogram .bin-label {
+  width: 48px; text-align: right; color: var(--fg3); flex-shrink: 0;
+}
+.histogram .bin-bars {
+  flex: 1; position: relative; height: 14px;
+  background: var(--bg3); border-radius: 2px; overflow: hidden;
+}
+.histogram .bin-bar {
+  position: absolute; top: 0; left: 0; height: 100%;
+  border-radius: 2px; opacity: 0.7;
+}
+.histogram .bin-bar.session { background: #60a5fa; z-index: 2; }
+.histogram .bin-bar.global  { background: #888; z-index: 1; }
+.histogram .bin-bar.blended { background: #34d399; z-index: 3; }
+.histogram .bin-pct {
+  width: 42px; font-size: 0.75em; color: var(--fg3); flex-shrink: 0;
+}
+.histogram .bin-ttl-marker {
+  color: var(--danger); font-weight: 600; font-size: 0.75em; margin-left: 4px;
+}
+.histogram-legend {
+  display: flex; gap: 16px; font-size: 0.75em; color: var(--fg3); margin: 4px 0 8px;
+}
+.histogram-legend span::before {
+  content: ""; display: inline-block; width: 10px; height: 10px;
+  border-radius: 2px; margin-right: 4px; vertical-align: middle;
+}
+.histogram-legend .leg-session::before { background: #60a5fa; }
+.histogram-legend .leg-global::before  { background: #888; }
+.histogram-legend .leg-blended::before { background: #34d399; }
+/* --- Expandable details --- */
+details.warming { margin: 8px 0; }
+details.warming summary {
+  cursor: pointer; font-weight: 600; font-size: 0.9em;
+  color: var(--fg2); padding: 6px 0;
+}
+details.warming summary:hover { color: var(--accent); }
+details.warming[open] summary { margin-bottom: 8px; }
+/* --- Circuit breaker bar --- */
+.cb-bar {
+  display: inline-block; width: 120px; height: 12px;
+  background: var(--bg3); border-radius: 6px; overflow: hidden;
+  vertical-align: middle; margin: 0 8px;
+}
+.cb-bar-fill { height: 100%; border-radius: 6px; transition: width 0.3s; }
+.cb-ok .cb-bar-fill { background: #34d399; }
+.cb-warn .cb-bar-fill { background: #fbbf24; }
+.cb-tripped .cb-bar-fill { background: #f87171; }
+/* --- Warming status badges --- */
+.badge-warming { background: #dcfce7; color: #166534; }
+.badge-waiting { background: #dbeafe; color: #1e40af; }
+.badge-dead { background: #fef2f2; color: #991b1b; }
+.badge-forced { background: #f3e8ff; color: #6b21a8; }
+.badge-disabled { background: var(--bg3); color: var(--fg3); }
+@media (prefers-color-scheme: dark) {
+  .badge-warming { background: #14532d; color: #86efac; }
+  .badge-waiting { background: #1e3a5f; color: #93c5fd; }
+  .badge-dead { background: #450a0a; color: #fca5a5; }
+  .badge-forced { background: #3b0764; color: #d8b4fe; }
+  .badge-disabled { background: var(--bg3); color: var(--fg3); }
+}
 `;
 
 function layout(title: string, body: string): string {
@@ -322,6 +399,7 @@ function layout(title: string, body: string): string {
   <a href="/ui/knowledge">Knowledge</a>
   <a href="/ui/search">Search</a>
   <a href="/ui/costs">Costs</a>
+  <a href="/ui/warming">Warming</a>
 </nav>
 <div class="container">
 ${body}
@@ -427,6 +505,114 @@ function redirect(url: string): Response {
     status: 302,
     headers: { location: url },
   });
+}
+
+// ---------------------------------------------------------------------------
+// Cache warming helpers
+// ---------------------------------------------------------------------------
+
+/** Format a duration in ms to a human-readable string. */
+function formatDuration(ms: number): string {
+  if (ms < 1000) return "<1s";
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  const rs = s % 60;
+  if (m < 60) return rs > 0 ? `${m}m ${rs}s` : `${m}m`;
+  const h = Math.floor(m / 60);
+  const rm = m % 60;
+  return rm > 0 ? `${h}h ${rm}m` : `${h}h`;
+}
+
+/** Human-readable histogram bin label. */
+function binLabel(index: number): string {
+  if (index >= HISTOGRAM_BINS.length) return ">4h";
+  const ms = HISTOGRAM_BINS[index];
+  if (ms < 60_000) return `${ms / 1000}s`;
+  if (ms < 3_600_000) return `${ms / 60_000}m`;
+  return `${(ms / 3_600_000).toFixed(1)}h`;
+}
+
+/** Return a TTL boundary label if this bin edge is a TTL boundary. */
+function ttlMarker(index: number): string | null {
+  if (index >= HISTOGRAM_BINS.length) return null;
+  const ms = HISTOGRAM_BINS[index];
+  if (ms === 300_000) return "5m TTL";
+  if (ms === 3_600_000) return "1h TTL";
+  return null;
+}
+
+/**
+ * Render a CSS bar chart for up to 3 overlaid histograms.
+ * Bars are scaled relative to the max count across all provided histograms.
+ */
+function renderHistogram(opts: {
+  session?: InterTurnHistogram;
+  global?: InterTurnHistogram;
+  blended?: InterTurnHistogram;
+}): string {
+  let maxCount = 1;
+  for (const h of [opts.session, opts.global, opts.blended]) {
+    if (!h) continue;
+    for (const c of h.counts) {
+      if (c > maxCount) maxCount = c;
+    }
+  }
+
+  const binCount = HISTOGRAM_BINS.length + 1;
+  let html = `<div class="histogram">`;
+
+  for (let i = 0; i < binCount; i++) {
+    const label = binLabel(i);
+    const marker = ttlMarker(i);
+
+    const sPct = opts.session ? (opts.session.counts[i] / maxCount) * 100 : 0;
+    const gPct = opts.global ? (opts.global.counts[i] / maxCount) * 100 : 0;
+    const bPct = opts.blended ? (opts.blended.counts[i] / maxCount) * 100 : 0;
+
+    const displayHist = opts.blended ?? opts.session ?? opts.global;
+    const displayPct =
+      displayHist && displayHist.total > 0
+        ? ((displayHist.counts[i] / displayHist.total) * 100).toFixed(0) + "%"
+        : "";
+
+    html += `<div class="bin">`;
+    html += `<span class="bin-label">${esc(label)}</span>`;
+    html += `<span class="bin-bars">`;
+    if (gPct > 0) html += `<span class="bin-bar global" style="width:${gPct.toFixed(1)}%"></span>`;
+    if (sPct > 0) html += `<span class="bin-bar session" style="width:${sPct.toFixed(1)}%"></span>`;
+    if (bPct > 0) html += `<span class="bin-bar blended" style="width:${bPct.toFixed(1)}%"></span>`;
+    html += `</span>`;
+    html += `<span class="bin-pct">${displayPct}</span>`;
+    if (marker) html += `<span class="bin-ttl-marker">${esc(marker)}</span>`;
+    html += `</div>`;
+  }
+
+  html += `</div>`;
+
+  // Legend
+  const layers: string[] = [];
+  if (opts.session) layers.push(`<span class="leg-session">Session (${opts.session.total} obs)</span>`);
+  if (opts.global) layers.push(`<span class="leg-global">Global (${opts.global.total} obs)</span>`);
+  if (opts.blended) layers.push(`<span class="leg-blended">Blended</span>`);
+  if (layers.length > 1) {
+    html += `<div class="histogram-legend">${layers.join("")}</div>`;
+  }
+
+  return html;
+}
+
+/** Render a warming status badge from a snapshot. */
+function warmingStatusBadge(snap: WarmingSnapshot): string {
+  if (snap.circuitBreaker.tripped)
+    return `<span class="badge badge-dead">TRIPPED</span>`;
+  if (snap.disabled)
+    return `<span class="badge badge-dead">dead</span>`;
+  if (snap.forceKeepWarm)
+    return `<span class="badge badge-forced">forced</span>`;
+  if (snap.shouldWarmNow)
+    return `<span class="badge badge-warming">warming</span>`;
+  return `<span class="badge badge-waiting">waiting</span>`;
 }
 
 // ---------------------------------------------------------------------------
@@ -659,6 +845,58 @@ function pageKnowledge(id: string): string | null {
   return layout(entry.title, body);
 }
 
+/** Render cache warming heuristics section for a live session. */
+function renderWarmingSection(sessionId: string): string {
+  const sessions = getActiveSessions();
+  const state = [...sessions.values()].find((s) => s.sessionID === sessionId);
+  if (!state) return ""; // historical session — no live warming data
+
+  const snap = computeWarmingSnapshot(state);
+  const hitRate =
+    snap.warmupCount > 0
+      ? `${snap.warmupHits}/${snap.warmupCount} (${((snap.warmupHits / snap.warmupCount) * 100).toFixed(0)}%)`
+      : "0";
+
+  let html = `<h2>Cache Warming</h2>`;
+
+  // Stat cards
+  html += `<div class="stats">
+    <div class="stat"><div class="label">Status</div><div class="value">${warmingStatusBadge(snap)}</div></div>
+    <div class="stat"><div class="label">Warmups</div><div class="value">${snap.warmupCount}</div></div>
+    <div class="stat"><div class="label">Hits</div><div class="value">${hitRate}</div></div>
+    <div class="stat"><div class="label">P(return)</div><div class="value">${(snap.pReturnDampened * 100).toFixed(1)}%</div></div>
+    <div class="stat"><div class="label">S(t)</div><div class="value">${(snap.survivalAtIdle * 100).toFixed(1)}%</div></div>
+  </div>`;
+
+  // Expandable decision details
+  html += `<details class="warming"><summary>Decision Details</summary>
+    <div class="card">
+      <div class="field"><span class="key">Idle:</span> ${formatDuration(snap.idleMs)}</div>
+      <div class="field"><span class="key">Time slot:</span> ${snap.currentSlot}</div>
+      <div class="field"><span class="key">TTL:</span> ${snap.ttl ?? "5m (default)"}</div>
+      <div class="field"><span class="key">Turns:</span> ${snap.messageCount}</div>
+      <div class="field"><span class="key">Text-only runs:</span> ${snap.consecutiveTextOnlyTurns}</div>
+      <div class="field"><span class="key">Threshold:</span> ${(snap.costThreshold * 100).toFixed(1)}%</div>
+      <div class="field"><span class="key">P(return) raw:</span> ${(snap.pReturn * 100).toFixed(1)}%</div>
+      <div class="field"><span class="key">P(return) dampened:</span> ${(snap.pReturnDampened * 100).toFixed(1)}%</div>
+      <div class="field"><span class="key">Session weight:</span> ${snap.sessionWeight.toFixed(2)} (${snap.sessionHistogram.total} obs / ${BLEND_PSEUDOCOUNT} pseudocount)</div>
+      ${snap.notWarmingReason ? `<div class="field"><span class="key">Not warming:</span> ${esc(snap.notWarmingReason)}</div>` : ""}
+      <div class="field"><span class="key">Circuit breaker:</span> ${snap.circuitBreaker.tripped ? '<span style="color:var(--danger)">TRIPPED</span>' : `OK (${snap.circuitBreaker.failures}/${snap.circuitBreaker.maxFailures})`}</div>
+    </div>
+  </details>`;
+
+  // Expandable histogram
+  html += `<details class="warming"><summary>Survival Histogram &mdash; ${esc(snap.currentSlot)} slot</summary>
+    ${renderHistogram({
+      session: snap.sessionHistogram,
+      global: snap.globalHistogram,
+      blended: snap.blendedHistogram,
+    })}
+  </details>`;
+
+  return html;
+}
+
 function pageSession(pid: string, sessionId: string): string | null {
   // Find the project path from the project ID
   const projects = data.listProjects();
@@ -686,6 +924,9 @@ function pageSession(pid: string, sessionId: string): string | null {
 
   // Cost intelligence
   body += renderCostSummary(sessionId);
+
+  // Cache warming heuristics (live sessions only)
+  body += renderWarmingSection(sessionId);
 
   // Messages
   body += `<h2>Messages (${messages.length})</h2>`;
@@ -918,6 +1159,121 @@ function pageSearchDetail(fullId: string): string | null {
   return layout(`Detail: ${fullId}`, body);
 }
 
+
+// ---------------------------------------------------------------------------
+// Cache Warming page
+// ---------------------------------------------------------------------------
+
+function pageWarming(): string {
+  let body = breadcrumb([
+    { label: "Dashboard", href: "/ui" },
+    { label: "Cache Warming" },
+  ]);
+  body += `<h1>Cache Warming</h1>`;
+
+  const sessions = getActiveSessions();
+  const cbStatus = getCircuitBreakerStatus();
+
+  // Collect snapshots for all live sessions
+  const snapshots: WarmingSnapshot[] = [];
+  for (const [, state] of sessions) {
+    snapshots.push(computeWarmingSnapshot(state));
+  }
+
+  // Aggregate stats
+  const totalWarmups = snapshots.reduce((s, x) => s + x.warmupCount, 0);
+  const totalHits = snapshots.reduce((s, x) => s + x.warmupHits, 0);
+  const warmingNow = snapshots.filter((x) => x.shouldWarmNow).length;
+  const deadCount = snapshots.filter((x) => x.disabled).length;
+
+  // Summary stat cards
+  body += `<div class="stats">
+    <div class="stat"><div class="label">Live Sessions</div><div class="value">${snapshots.length}</div></div>
+    <div class="stat"><div class="label">Warming Now</div><div class="value">${warmingNow}</div></div>
+    <div class="stat"><div class="label">Dead</div><div class="value">${deadCount}</div></div>
+    <div class="stat"><div class="label">Total Warmups</div><div class="value">${totalWarmups}</div></div>
+    <div class="stat"><div class="label">Hit Rate</div><div class="value">${totalWarmups > 0 ? ((totalHits / totalWarmups) * 100).toFixed(0) + "%" : "N/A"}</div></div>
+    <div class="stat"><div class="label">Circuit Breaker</div><div class="value">${
+      cbStatus.tripped
+        ? '<span style="color:var(--danger)">TRIPPED</span>'
+        : `OK <span style="color:var(--fg3)">${cbStatus.failures}/${cbStatus.maxFailures}</span>`
+    }</div></div>
+  </div>`;
+
+  // Circuit breaker detail (if non-zero failures or tripped)
+  if (cbStatus.failures > 0 || cbStatus.tripped) {
+    const cls = cbStatus.tripped ? "cb-tripped" : cbStatus.failures > 1 ? "cb-warn" : "cb-ok";
+    const pct = (cbStatus.failures / cbStatus.maxFailures) * 100;
+    body += `<div class="card ${cls}">
+      <strong>Circuit Breaker:</strong> ${cbStatus.failures}/${cbStatus.maxFailures} uncached warmups
+      <span class="cb-bar"><span class="cb-bar-fill" style="width:${pct}%"></span></span>
+      ${cbStatus.tripped ? '<strong style="color:var(--danger)">ALL WARMING DISABLED</strong>' : ""}
+    </div>`;
+  }
+
+  // Live sessions table
+  body += `<h2>Live Sessions</h2>`;
+  if (snapshots.length === 0) {
+    body += `<p class="empty">No active sessions. Cache warming data appears when sessions are processed through the gateway.</p>`;
+  } else {
+    body += `<div class="table-filter"><input type="text" placeholder="Filter sessions\u2026"><span class="count"></span></div>
+    <table>
+      <tr>
+        <th>Session</th>
+        <th data-sort="num">Turns</th>
+        <th data-sort="num">Idle</th>
+        <th data-sort="text">Slot</th>
+        <th data-sort="text">TTL</th>
+        <th data-sort="num">S(t)</th>
+        <th data-sort="num">P(return)</th>
+        <th data-sort="text">Status</th>
+        <th data-sort="num">Warmups</th>
+        <th data-sort="num">Hits</th>
+      </tr>`;
+    for (const snap of snapshots) {
+      body += `<tr>
+        <td><code>${esc(snap.sessionId.slice(0, 16))}</code></td>
+        <td>${snap.messageCount}</td>
+        <td>${formatDuration(snap.idleMs)}</td>
+        <td>${esc(snap.currentSlot)}</td>
+        <td>${snap.ttl ?? "5m"}</td>
+        <td>${(snap.survivalAtIdle * 100).toFixed(1)}%</td>
+        <td>${(snap.pReturnDampened * 100).toFixed(1)}%</td>
+        <td>${warmingStatusBadge(snap)}</td>
+        <td>${snap.warmupCount}</td>
+        <td>${snap.warmupHits}</td>
+      </tr>`;
+    }
+    body += `</table>`;
+  }
+
+  // Global histograms
+  const globalModels = getGlobalModelsSnapshot();
+  if (globalModels.size > 0) {
+    body += `<h2>Global Histograms</h2>`;
+    body += `<p style="color:var(--fg3);font-size:0.9em">
+      Per-project inter-turn gap distributions from all historical sessions.
+      Used as Bayesian prior for sessions with few observations.
+    </p>`;
+
+    for (const [projectPath, model] of globalModels) {
+      const name = projectPath.split("/").pop() ?? projectPath;
+      const totals = `work: ${model.slots.work.total}, evening: ${model.slots.evening.total}, night: ${model.slots.night.total}`;
+      body += `<details class="warming">
+        <summary>${esc(name)} &mdash; ${totals} observations</summary>`;
+
+      for (const slot of ["work", "evening", "night"] as const) {
+        const hist = model.slots[slot];
+        if (hist.total === 0) continue;
+        body += `<h3>${esc(slot)}</h3>`;
+        body += renderHistogram({ global: hist });
+      }
+      body += `</details>`;
+    }
+  }
+
+  return layout("Cache Warming", body);
+}
 
 // ---------------------------------------------------------------------------
 // Global Costs page
@@ -1170,6 +1526,11 @@ export async function handleUIRequest(
     // Costs
     if (pathname === "/ui/costs") {
       return htmlResponse(pageCosts());
+    }
+
+    // Cache warming
+    if (pathname === "/ui/warming") {
+      return htmlResponse(pageWarming());
     }
 
     // Search detail (by source-prefixed ID)


### PR DESCRIPTION
## Summary

- Adds a dedicated `/ui/warming` overview page surfacing all survival-analysis-driven cache warming heuristics: aggregate stats, live sessions table with sortable columns, circuit breaker visualization, and per-project global histogram charts
- Adds an expandable "Cache Warming" section to each session detail page showing status badges, decision details, and per-slot survival histograms with overlaid session/global/blended layers

## Details

**`cache-warmer.ts`** (~115 new lines):
- Exports `BLEND_PSEUDOCOUNT`, `DEAD_SESSION_THRESHOLD`, `MIN_TURNS_FOR_WARMING` constants
- Adds `getCircuitBreakerStatus()`, `computeWarmingSnapshot()` (packages all heuristics into a single read-only data object), and `getGlobalModelsSnapshot()`

**`pipeline.ts`** (+4 lines):
- Adds `getActiveSessions()` returning `ReadonlyMap<string, SessionState>` for dashboard access

**`ui.ts`** (~300 new lines):
- CSS bar charts with overlaid session/global/blended histogram layers (no chart library)
- Native `<details>/<summary>` for expandable sections (zero JS)
- Warming status badges (warming/waiting/dead/forced) with dark mode support
- `renderWarmingSection()` wired into session detail pages after Cost Intelligence
- `pageWarming()` with aggregate stats, circuit breaker progress bar, live sessions table, and global histogram `<details>` sections
- Graceful degradation: historical sessions (no live state) simply don't show the warming section

## Verification

- `bun run typecheck` passes across all 4 packages
- `bun test` — 1179 pass, 3 pre-existing failures in embedding tests (unrelated)