### PR TITLE
feat: add curator observability and fix pattern extraction false positives

### DIFF
--- a/packages/core/src/distillation.ts
+++ b/packages/core/src/distillation.ts
@@ -811,7 +811,8 @@ async function distillSegment(input: {
 
   // Fire-and-forget: extract decision/preference patterns → knowledge entries
   if (config().knowledge.enabled) {
-    for (const pat of extractPatterns(result.observations)) {
+    const patterns = extractPatterns(result.observations);
+    for (const pat of patterns) {
       try {
         ltm.create({
           projectPath: input.projectPath,
@@ -824,6 +825,9 @@ async function distillSegment(input: {
       } catch {
         // Dedup guard in ltm.create() handles duplicates — swallow errors
       }
+    }
+    if (patterns.length > 0) {
+      log.info(`pattern extraction: ${patterns.length} entries from distillation`);
     }
   }
 
@@ -928,7 +932,8 @@ export async function metaDistill(input: {
 
   // Fire-and-forget: extract decision/preference patterns → knowledge entries
   if (config().knowledge.enabled) {
-    for (const pat of extractPatterns(result.observations)) {
+    const patterns = extractPatterns(result.observations);
+    for (const pat of patterns) {
       try {
         ltm.create({
           projectPath: input.projectPath,
@@ -941,6 +946,9 @@ export async function metaDistill(input: {
       } catch {
         // Dedup guard in ltm.create() handles duplicates — swallow errors
       }
+    }
+    if (patterns.length > 0) {
+      log.info(`pattern extraction: ${patterns.length} entries from meta-distillation`);
     }
   }
 

--- a/packages/core/src/pattern-extract.ts
+++ b/packages/core/src/pattern-extract.ts
@@ -96,6 +96,13 @@ export function extractPatterns(observations: string): ExtractedPattern[] {
     regex.lastIndex = 0;
     let match: RegExpMatchArray | null;
     while ((match = regex.exec(observations)) !== null) {
+      // Skip false positives: template placeholders (e.g. "X", "Y"),
+      // quoted fragments, or very short captures that are clearly not
+      // real technology/tool names. Plain apostrophes (') are allowed
+      // since they appear in valid names like "Bun's test runner".
+      const captures = match.slice(1);
+      if (captures.some((c) => c && (c.trim().length <= 2 || /["\u201C\u201D`\u2018\u2019]/.test(c)))) continue;
+
       const title = titleFn(match);
       const key = title.toLowerCase();
       if (seen.has(key)) continue;

--- a/packages/core/test/pattern-extract.test.ts
+++ b/packages/core/test/pattern-extract.test.ts
@@ -290,5 +290,27 @@ describe("extractPatterns", () => {
         "chose Tailwind over Bootstrap for utility-first CSS.",
       );
     });
+
+    test("rejects template placeholders like X and Y", () => {
+      const results = extractPatterns(
+        'Patterns like "decided to use X" and "prefers X over Y" are matched.',
+      );
+      expect(results).toHaveLength(0);
+    });
+
+    test("rejects captures containing smart quote characters", () => {
+      const results = extractPatterns(
+        "decided to use \u201CPostgreSQL\u201D for the main database.",
+      );
+      expect(results).toHaveLength(0);
+    });
+
+    test("rejects very short captures (1-2 chars)", () => {
+      const results = extractPatterns(
+        "Decided to use Go, which is fast.",
+      );
+      // "Go" is only 2 chars — too short to be a reliable extraction
+      expect(results).toHaveLength(0);
+    });
   });
 });

--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -39,7 +39,8 @@ import {
   loadGlobalHistograms,
   flushGlobalHistograms,
 } from "./cache-warmer";
-import { emitWarmupMetric, emitSessionCostMetrics } from "./sentry";
+import * as Sentry from "@sentry/bun";
+import { emitWarmupMetric, emitSessionCostMetrics, emitCurationMetrics } from "./sentry";
 import { getSessionCosts, totalWorkerCost } from "./cost-tracker";
 
 const POLL_INTERVAL_MS = 30_000;
@@ -193,8 +194,17 @@ export function buildIdleWorkHandler(
     if (cfg.knowledge.enabled && cfg.curator.onIdle) {
       try {
         if (state.turnsSinceCuration >= cfg.curator.afterTurns) {
-          await curator.run({ llm, projectPath, sessionID, model });
+          const result = await Sentry.startSpan(
+            { name: "lore.curator", op: "lore.curation", attributes: { trigger: "idle" } },
+            () => curator.run({ llm, projectPath, sessionID, model }),
+          );
           state.turnsSinceCuration = 0;
+          if (result.created > 0 || result.updated > 0 || result.deleted > 0) {
+            log.info(
+              `idle curation: ${result.created} created, ${result.updated} updated, ${result.deleted} deleted`,
+            );
+            emitCurationMetrics({ ...result, trigger: "idle" });
+          }
         }
       } catch (e) {
         log.error("idle curation error:", e);
@@ -209,14 +219,13 @@ export function buildIdleWorkHandler(
           log.info(
             `entry count ${entries.length} exceeds maxEntries ${cfg.curator.maxEntries} — running consolidation`,
           );
-          const { updated, deleted } = await curator.consolidate({
-            llm,
-            projectPath,
-            sessionID,
-            model,
-          });
-          if (updated > 0 || deleted > 0) {
-            log.info(`consolidation: ${updated} updated, ${deleted} deleted`);
+          const result = await Sentry.startSpan(
+            { name: "lore.consolidation", op: "lore.curation", attributes: { trigger: "consolidation" } },
+            () => curator.consolidate({ llm, projectPath, sessionID, model }),
+          );
+          if (result.updated > 0 || result.deleted > 0) {
+            log.info(`consolidation: ${result.updated} updated, ${result.deleted} deleted`);
+            emitCurationMetrics({ created: 0, ...result, trigger: "consolidation" });
           }
         }
       } catch (e) {

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -125,10 +125,11 @@ import {
    setSentryLightContext,
    setGenAiUsageAttributes,
    setCacheAnalyticsAttributes,
-    emitCostMetric,
-    emitCacheBustMetric,
-    emitWarmupHitMetric,
-    type AnthropicUsage,
+     emitCostMetric,
+     emitCacheBustMetric,
+     emitWarmupHitMetric,
+     emitCurationMetrics,
+     type AnthropicUsage,
 } from "./sentry";
 import {
   recordConversationCost,
@@ -1564,12 +1565,20 @@ function scheduleBackgroundWork(
     cfg.curator.onIdle &&
     sessionState.turnsSinceCuration >= effectiveAfterTurns
   ) {
-    curator
-      .run({ llm, projectPath, sessionID, model })
-      .then(() => {
+    Sentry.startSpan(
+      { name: "lore.curator", op: "lore.curation", attributes: { trigger: "in-flight" } },
+      () => curator.run({ llm, projectPath, sessionID, model }),
+    )
+      .then((result) => {
         sessionState.turnsSinceCuration = 0;
         // Invalidate LTM cache after curation changes knowledge entries
         ltmSessionCache.delete(sessionID);
+        if (result.created > 0 || result.updated > 0 || result.deleted > 0) {
+          log.info(
+            `curation: ${result.created} created, ${result.updated} updated, ${result.deleted} deleted`,
+          );
+          emitCurationMetrics({ ...result, trigger: "in-flight" });
+        }
       })
       .catch((e) => log.error("background curation failed:", e));
   }

--- a/packages/gateway/src/sentry.ts
+++ b/packages/gateway/src/sentry.ts
@@ -430,3 +430,44 @@ export function emitSessionCostMetrics(sessionID: string): void {
     });
   }
 }
+
+// ---------------------------------------------------------------------------
+// Curation metrics
+// ---------------------------------------------------------------------------
+
+/**
+ * Emit curation result metrics to Sentry.
+ *
+ * Called after `curator.run()` or `curator.consolidate()` completes with
+ * at least one operation. Tracks create/update/delete counts by trigger
+ * source (in-flight background work vs. idle scheduler).
+ */
+export function emitCurationMetrics(result: {
+  created: number;
+  updated: number;
+  deleted: number;
+  trigger: "in-flight" | "idle" | "consolidation";
+}): void {
+  if (!Sentry.isInitialized()) return;
+  const total = result.created + result.updated + result.deleted;
+  if (total === 0) return;
+
+  Sentry.metrics.distribution("lore.curator_ops", total, {
+    attributes: { trigger: result.trigger },
+  });
+  if (result.created > 0) {
+    Sentry.metrics.distribution("lore.curator_created", result.created, {
+      attributes: { trigger: result.trigger },
+    });
+  }
+  if (result.updated > 0) {
+    Sentry.metrics.distribution("lore.curator_updated", result.updated, {
+      attributes: { trigger: result.trigger },
+    });
+  }
+  if (result.deleted > 0) {
+    Sentry.metrics.distribution("lore.curator_deleted", result.deleted, {
+      attributes: { trigger: result.trigger },
+    });
+  }
+}


### PR DESCRIPTION
## Summary

- Add Sentry spans, metrics (`lore.curator_ops/created/updated/deleted`), and result logging to `curator.run()` and `curator.consolidate()` — both call sites previously discarded return values silently
- Fix `pattern-extract.ts` regex false positives that created garbage knowledge entries like `Decided to use X"` by filtering out template placeholders (≤2 char captures) and smart-quoted fragments
- Add pattern extraction count logging in `distillation.ts` for both gen-0 and meta-distillation

## Motivation

Investigation of the knowledge DB revealed curation IS working but we had zero observability into it — no logs, no Sentry spans, no metrics. The only way to tell if curation ran was to query the SQLite DB directly. Also found 2 garbage entries created by pattern extraction matching its own docstring examples.

## Changes

| File | Change |
|---|---|
| `packages/gateway/src/sentry.ts` | New `emitCurationMetrics()` with trigger attribution |
| `packages/gateway/src/pipeline.ts` | Log curator results + emit metrics + Sentry span |
| `packages/gateway/src/idle.ts` | Log curator results + emit metrics + Sentry span (curation + consolidation) |
| `packages/core/src/pattern-extract.ts` | Filter false positives: short captures, smart quotes |
| `packages/core/src/distillation.ts` | Log pattern extraction counts |
| `packages/core/test/pattern-extract.test.ts` | 3 new tests for false positive rejection |