### PR TITLE
fix: skip post-idle compaction when cache warmer kept the cache warm

### DIFF
--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -354,11 +354,19 @@ function getSessionState(sessionID: string): SessionState {
  *
  * Set `thresholdMs <= 0` to disable. Returns true if a reset fired so the
  * caller can log/observe.
+ *
+ * @param skipCompact  When true, perform all idle-resume housekeeping
+ *   (clear caches, set cameOutOfIdle) but do NOT set postIdleCompact.
+ *   Used when the caller knows the upstream prompt cache is still warm
+ *   (e.g. cache warmer recently refreshed it) — compacting would produce
+ *   a different prompt body that doesn't match the warmed prefix, causing
+ *   a cache bust and wasting the warming cost.
  */
 export function onIdleResume(
   sessionID: string,
   thresholdMs: number,
   now: number = Date.now(),
+  skipCompact: boolean = false,
 ): { triggered: false } | { triggered: true; idleMs: number } {
   if (thresholdMs <= 0) return { triggered: false };
   const state = getSessionState(sessionID);
@@ -369,7 +377,7 @@ export function onIdleResume(
   state.rawWindowCache = null;
   state.distillationSnapshot = null;
   state.cameOutOfIdle = true;
-  state.postIdleCompact = true;
+  state.postIdleCompact = !skipCompact;
   return { triggered: true, idleMs };
 }
 

--- a/packages/core/test/embedding.test.ts
+++ b/packages/core/test/embedding.test.ts
@@ -336,10 +336,11 @@ describe("vectorSearch", () => {
   const PROJECT = "/test/embedding/vectorsearch";
 
   beforeEach(() => {
-    // Clean test project's knowledge to avoid cross-test leaks.
-    // IMPORTANT: scope to project_id — unscoped DELETE wipes ALL projects' entries.
-    const pid = ensureProject(PROJECT);
-    db().query("DELETE FROM knowledge WHERE project_id = ?").run(pid);
+    // vectorSearch() queries ALL projects (no project_id filter), so we must
+    // clear ALL knowledge entries to avoid cross-test leaks from other suites
+    // (e.g. LocalProvider integration, checkConfigChange) that insert entries
+    // with embeddings into different projects.
+    db().query("DELETE FROM knowledge").run();
   });
 
   test("returns entries sorted by similarity descending", () => {

--- a/packages/core/test/gradient.test.ts
+++ b/packages/core/test/gradient.test.ts
@@ -1944,6 +1944,37 @@ describe("onIdleResume", () => {
     const result = onIdleResume(SID, ONE_HOUR_MS);
     expect(result.triggered).toBe(false);
   });
+
+  test("skipCompact=true skips postIdleCompact but still does housekeeping", () => {
+    const now = 1_000_000_000_000;
+    setLastTurnAtForTest(SID, now - 2 * ONE_HOUR_MS);
+
+    const result = onIdleResume(SID, ONE_HOUR_MS, now, /* skipCompact */ true);
+    expect(result.triggered).toBe(true);
+    if (result.triggered) {
+      expect(result.idleMs).toBe(2 * ONE_HOUR_MS);
+    }
+
+    const state = inspectSessionState(SID);
+    // Housekeeping still happens:
+    expect(state!.hasPrefixCache).toBe(false);
+    expect(state!.hasRawWindowCache).toBe(false);
+    expect(state!.cameOutOfIdle).toBe(true);
+    expect(state!.distillationSnapshot).toBeNull();
+    // But compaction is skipped:
+    expect(state!.postIdleCompact).toBe(false);
+  });
+
+  test("skipCompact=false (default) sets postIdleCompact when idle", () => {
+    const now = 1_000_000_000_000;
+    setLastTurnAtForTest(SID, now - 2 * ONE_HOUR_MS);
+
+    const result = onIdleResume(SID, ONE_HOUR_MS, now, /* skipCompact */ false);
+    expect(result.triggered).toBe(true);
+    const state = inspectSessionState(SID);
+    expect(state!.postIdleCompact).toBe(true);
+    expect(state!.cameOutOfIdle).toBe(true);
+  });
 });
 
 describe("reasoning preservation (F-REASONING-AUDIT mini-pin)", () => {

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -118,6 +118,7 @@ import {
   recordGap,
   getSessionHistogram,
   recordGlobalGap,
+  resolveProfile as resolveWarmingProfile,
 } from "./cache-warmer";
 import {
    setSentryRequestContext,
@@ -1719,6 +1720,29 @@ async function handlePassthrough(
   });
 }
 
+/**
+ * Check whether the upstream prompt cache is likely still warm for this
+ * session. Returns true when a warmup ping was successfully sent within
+ * the current cache TTL window.
+ *
+ * When true, post-idle compaction should be skipped: the warmer replayed
+ * the full (uncompacted) request body, so compacting now would produce
+ * different bytes and bust the cache the warmer just paid to preserve.
+ */
+function isCacheWarm(state: SessionState): boolean {
+  const lastWarmup = state.warmup?.lastWarmupAt;
+  if (!lastWarmup) return false;
+
+  const profile = resolveWarmingProfile(
+    state.lastModel,
+    state.lastProtocol,
+    state.resolvedConversationTTL,
+  );
+  if (!profile) return false;
+
+  return (Date.now() - lastWarmup) < profile.ttlMs;
+}
+
 // ---------------------------------------------------------------------------
 // Case 3: Normal conversation turn — full pipeline
 // ---------------------------------------------------------------------------
@@ -1905,12 +1929,17 @@ async function handleConversationTurn(
       ? 60
       : cfg.idleResumeMinutes;
   const thresholdMs = effectiveIdleMinutes * 60_000;
-  const idleResult = onIdleResume(sessionID, thresholdMs);
+  // If the cache warmer recently refreshed this session's prompt cache,
+  // skip post-idle compaction — compacting would produce a different prompt
+  // body that doesn't match the warmed prefix, causing a cache bust.
+  const cacheWarm = isCacheWarm(sessionState);
+  const idleResult = onIdleResume(sessionID, thresholdMs, Date.now(), cacheWarm);
   sessionState.lastTurnWasIdle = idleResult.triggered;
   if (idleResult.triggered) {
     ltmSessionCache.delete(sessionID);
     log.info(
-      `session idle ${Math.round(idleResult.idleMs / 60_000)}min — refreshing caches`,
+      `session idle ${Math.round(idleResult.idleMs / 60_000)}min — refreshing caches` +
+        (cacheWarm ? " (cache warm — skipping compact)" : ""),
     );
   }
 


### PR DESCRIPTION
## Summary

- **Fix cache bust on idle resume**: `onIdleResume()` unconditionally set `postIdleCompact=true`, forcing Layer 1+ with a tight raw budget. When the cache warmer (automated or `/keep`) had recently refreshed the upstream cache, the compacted context produced different bytes than the warmed prefix — busting the cache and wasting the warming cost.
- **Add `skipCompact` parameter to `onIdleResume()`** (default `false`, backwards-compatible). The gateway pipeline checks whether the cache was warmed within the current TTL window via a new `isCacheWarm()` helper and skips compaction when the cache is warm. All other idle-resume housekeeping (cache clearing, `cameOutOfIdle`, LTM refresh) still runs.
- **Fix `vectorSearch` test isolation**: `beforeEach` was scoped to one project but `vectorSearch()` queries globally, causing 3 pre-existing test failures from cross-suite leaks.

## Changes

| File | What |
|---|---|
| `packages/core/src/gradient.ts` | Add `skipCompact` param to `onIdleResume()`, conditional `postIdleCompact` |
| `packages/gateway/src/pipeline.ts` | Add `isCacheWarm()` helper, import `resolveWarmingProfile`, pass `skipCompact` at call site |
| `packages/core/test/gradient.test.ts` | 2 new tests for `skipCompact` behavior |
| `packages/core/test/embedding.test.ts` | Fix `vectorSearch` describe cleanup to be global |

## Test plan

- `bun test` — 1187 pass, 0 fail (was 1184 pass, 3 fail before the embedding fix)
- `bun run typecheck` — clean across all 4 packages