### PR TITLE
feat: rename data directory from opencode-lore to lore with auto-migration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Lore is a **three-tier memory architecture** for AI coding agents. It intercepts
 
 **Runtime:** Bun (development/tests) and Node.js >= 22.5 (production npm bundles).
 **Language:** TypeScript (monorepo with `bun workspaces`).
-**Database:** SQLite with WAL mode, FTS5 full-text search. Stored at `~/.local/share/opencode-lore/lore.db`.
+**Database:** SQLite with WAL mode, FTS5 full-text search. Stored at `~/.local/share/lore/lore.db`.
 
 ## Monorepo Structure
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 An implementation of [Sanity's Nuum](https://www.sanity.io/blog/how-we-solved-the-agent-memory-problem) memory architecture and [Mastra's Observational Memory](https://mastra.ai/research/observational-memory) system for coding agents. Both projects pioneered the idea that coding agents need **distillation, not summarization** — preserving operational intelligence (file paths, error messages, exact decisions) rather than narrative summaries that lose the details agents need to keep working.
 
-Lore is published as three packages, all sharing the same SQLite database at `~/.local/share/opencode-lore/lore.db`:
+Lore is published as three packages, all sharing the same SQLite database at `~/.local/share/lore/lore.db`:
 
 | Package | For | Install |
 |---|---|---|
@@ -220,7 +220,7 @@ Once Lore is active, you should notice several changes:
 
 ## What gets stored
 
-All data lives locally in `~/.local/share/opencode-lore/lore.db`:
+All data lives locally in `~/.local/share/lore/lore.db`:
 
 - **Session observations** — timestamped event log of each conversation: what was asked, what was done, decisions made, errors found
 - **Long-term knowledge** — patterns, gotchas, and architectural decisions curated across sessions and projects. Entries can reference each other with `[[entry-id]]` wiki links, forming a navigable knowledge graph. Dead references are automatically cleaned up when entries are deleted or consolidated.

--- a/packages/core/src/data-dir.ts
+++ b/packages/core/src/data-dir.ts
@@ -1,0 +1,76 @@
+/**
+ * Shared data-directory path resolution with one-time migration from the
+ * legacy `opencode-lore` directory name to `lore`.
+ *
+ * Both `db.ts` and `log.ts` need the data directory path.  This module
+ * provides a single source of truth so the path logic is not duplicated.
+ */
+
+import { existsSync, renameSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const OLD_DIR_NAME = "opencode-lore";
+const NEW_DIR_NAME = "lore";
+
+let migrationAttempted = false;
+
+/**
+ * Compute the XDG-compliant base directory for lore data.
+ * Respects `$XDG_DATA_HOME`, defaults to `~/.local/share`.
+ */
+function baseDir(): string {
+  return process.env.XDG_DATA_HOME || join(homedir(), ".local", "share");
+}
+
+/**
+ * Attempt a one-time migration of the legacy data directory.
+ *
+ * - Old exists, new does not → atomic `renameSync` (same filesystem).
+ * - Both exist → keep new (user already migrated or has fresh data).
+ * - Neither exists → no-op; callers create the dir via `mkdirSync`.
+ *
+ * Runs at most once per process.  Errors are swallowed — migration
+ * failure is not fatal because callers create the directory anyway.
+ */
+function migrateDataDir(): void {
+  if (migrationAttempted) return;
+  migrationAttempted = true;
+
+  // Tests use LORE_DB_PATH pointed at a temp dir; never touch the real
+  // data directory.
+  if (process.env.NODE_ENV === "test") return;
+
+  const base = baseDir();
+  const oldDir = join(base, OLD_DIR_NAME);
+  const newDir = join(base, NEW_DIR_NAME);
+
+  try {
+    if (existsSync(oldDir) && !existsSync(newDir)) {
+      renameSync(oldDir, newDir);
+      // Can't use the lore logger here (circular dep), so use stderr.
+      console.error(`[lore] migrated data directory: ${oldDir} → ${newDir}`);
+    }
+  } catch {
+    // Permission error, cross-device rename, concurrent process already
+    // renamed it, etc.  Not fatal — dataDir() returns the new path and
+    // callers create the directory if it doesn't exist yet.
+  }
+}
+
+/**
+ * Return the resolved data directory path (`~/.local/share/lore` by
+ * default), running the legacy-directory migration on the first call.
+ *
+ * **Callers are responsible for creating the directory** — this function
+ * does not call `mkdirSync`.
+ */
+export function dataDir(): string {
+  migrateDataDir();
+  return join(baseDir(), NEW_DIR_NAME);
+}
+
+/** @internal Visible for testing only — resets the one-shot guard. */
+export function _resetMigrationFlag(): void {
+  migrationAttempted = false;
+}

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1,8 +1,8 @@
 import { Database } from "#db/driver";
 import { join, dirname } from "path";
 import { mkdirSync } from "fs";
-import { homedir } from "os";
 import { getGitRemote } from "./git";
+import { dataDir } from "./data-dir";
 
 /**
  * Extract the repository name from a normalized git remote URL.
@@ -471,12 +471,6 @@ const MIGRATIONS: string[] = [
   CREATE INDEX IF NOT EXISTS idx_import_history_project ON import_history(project_id);
   `,
 ];
-
-function dataDir() {
-  const xdg = process.env.XDG_DATA_HOME;
-  const base = xdg || join(homedir(), ".local", "share");
-  return join(base, "opencode-lore");
-}
 
 /** Return the resolved path of the SQLite database file. */
 export function dbPath(): string {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -54,6 +54,7 @@ export type {
 } from "./types";
 export { isTextPart, isReasoningPart, isToolPart } from "./types";
 
+export { dataDir } from "./data-dir";
 export { load, config, type LoreConfig } from "./config";
 export {
   db,

--- a/packages/core/src/log.ts
+++ b/packages/core/src/log.ts
@@ -18,14 +18,14 @@
  * ## File logging
  *
  * All log calls (info, warn, error) are written to a persistent log file
- * at `~/.local/share/opencode-lore/lore.log` regardless of `LORE_DEBUG`.
+ * at `~/.local/share/lore/lore.log` regardless of `LORE_DEBUG`.
  * The file is rotated when it exceeds 5 MB (single `.log.1` backup).
  * Use `lore logs` to view; disabled during tests (`NODE_ENV=test`).
  */
 
 import { appendFileSync, renameSync, statSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
-import { homedir } from "node:os";
+import { dataDir } from "./data-dir";
 
 // ---------------------------------------------------------------------------
 // Sink — optional external log consumer (e.g. Sentry)
@@ -85,9 +85,7 @@ let writeCount = 0;
 function resolveLogPath(): string | undefined {
   if (process.env.NODE_ENV === "test") return undefined;
   try {
-    const base =
-      process.env.XDG_DATA_HOME || join(homedir(), ".local", "share");
-    const dir = join(base, "opencode-lore");
+    const dir = dataDir();
     mkdirSync(dir, { recursive: true });
     return join(dir, "lore.log");
   } catch {

--- a/packages/core/test/data-dir.test.ts
+++ b/packages/core/test/data-dir.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import {
+  mkdirSync,
+  existsSync,
+  rmSync,
+  writeFileSync,
+  readFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+
+import { dataDir, _resetMigrationFlag } from "../src/data-dir";
+
+describe("dataDir — legacy directory migration", () => {
+  let tempBase: string;
+  const origXdg = process.env.XDG_DATA_HOME;
+  const origNodeEnv = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    tempBase = mkdtempSync(join(tmpdir(), "lore-migration-test-"));
+    process.env.XDG_DATA_HOME = tempBase;
+    // Migration skips when NODE_ENV=test, so unset it for these tests.
+    delete process.env.NODE_ENV;
+    _resetMigrationFlag();
+  });
+
+  afterEach(() => {
+    if (origXdg === undefined) delete process.env.XDG_DATA_HOME;
+    else process.env.XDG_DATA_HOME = origXdg;
+
+    if (origNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = origNodeEnv;
+
+    rmSync(tempBase, { recursive: true, force: true });
+  });
+
+  it("migrates old directory to new when only old exists", () => {
+    const oldDir = join(tempBase, "opencode-lore");
+    mkdirSync(oldDir);
+    writeFileSync(join(oldDir, "lore.db"), "test-data");
+    writeFileSync(join(oldDir, "lore.log"), "log-data");
+
+    const result = dataDir();
+
+    expect(result).toBe(join(tempBase, "lore"));
+    expect(existsSync(join(tempBase, "lore", "lore.db"))).toBe(true);
+    expect(existsSync(join(tempBase, "lore", "lore.log"))).toBe(true);
+    expect(existsSync(oldDir)).toBe(false);
+  });
+
+  it("does nothing when only new directory exists", () => {
+    const newDir = join(tempBase, "lore");
+    mkdirSync(newDir);
+    writeFileSync(join(newDir, "lore.db"), "new-data");
+
+    const result = dataDir();
+
+    expect(result).toBe(newDir);
+    expect(readFileSync(join(newDir, "lore.db"), "utf8")).toBe("new-data");
+  });
+
+  it("keeps new directory when both exist", () => {
+    const oldDir = join(tempBase, "opencode-lore");
+    const newDir = join(tempBase, "lore");
+    mkdirSync(oldDir);
+    mkdirSync(newDir);
+    writeFileSync(join(oldDir, "lore.db"), "old-data");
+    writeFileSync(join(newDir, "lore.db"), "new-data");
+
+    dataDir();
+
+    // New directory wins; old directory is untouched.
+    expect(readFileSync(join(newDir, "lore.db"), "utf8")).toBe("new-data");
+    expect(existsSync(oldDir)).toBe(true);
+  });
+
+  it("returns new path when neither directory exists", () => {
+    const result = dataDir();
+
+    expect(result).toBe(join(tempBase, "lore"));
+    // dataDir() does NOT create the directory — callers do.
+    expect(existsSync(result)).toBe(false);
+  });
+
+  it("runs migration only once per process (guarded by flag)", () => {
+    const oldDir = join(tempBase, "opencode-lore");
+    mkdirSync(oldDir);
+    writeFileSync(join(oldDir, "lore.db"), "data");
+
+    // First call migrates.
+    dataDir();
+    expect(existsSync(join(tempBase, "lore", "lore.db"))).toBe(true);
+
+    // Recreate old dir — second call should NOT migrate again.
+    mkdirSync(oldDir);
+    writeFileSync(join(oldDir, "lore.db"), "stale");
+    dataDir();
+    expect(existsSync(oldDir)).toBe(true); // still there
+  });
+
+  it("skips migration when NODE_ENV=test", () => {
+    process.env.NODE_ENV = "test";
+    _resetMigrationFlag();
+
+    const oldDir = join(tempBase, "opencode-lore");
+    mkdirSync(oldDir);
+    writeFileSync(join(oldDir, "lore.db"), "data");
+
+    const result = dataDir();
+
+    expect(result).toBe(join(tempBase, "lore"));
+    // Old directory should still exist — migration was skipped.
+    expect(existsSync(oldDir)).toBe(true);
+  });
+});

--- a/packages/core/test/setup.ts
+++ b/packages/core/test/setup.ts
@@ -6,7 +6,7 @@ import { close } from "../src/db";
 
 // Create an isolated temporary database for the entire test run.
 // This prevents test fixtures from leaking into the live lore DB
-// at ~/.local/share/opencode-lore/lore.db.
+// at ~/.local/share/lore/lore.db.
 const tmp = mkdtempSync(join(tmpdir(), "lore-test-"));
 process.env.LORE_DB_PATH = join(tmp, "test.db");
 

--- a/packages/opencode/README.md
+++ b/packages/opencode/README.md
@@ -34,7 +34,7 @@ If none of the above are set and fastembed isn't available, recall falls back to
 
 ## Companion packages
 
-Lore ships as three packages sharing the same SQLite database at `~/.local/share/opencode-lore/lore.db`:
+Lore ships as three packages sharing the same SQLite database at `~/.local/share/lore/lore.db`:
 
 - **`@loreai/opencode`** (you are here) — OpenCode plugin
 - [`@loreai/pi`](https://www.npmjs.com/package/@loreai/pi) — [Pi coding-agent](https://github.com/badlogic/pi-mono) extension

--- a/packages/opencode/eval/backfill.ts
+++ b/packages/opencode/eval/backfill.ts
@@ -1,12 +1,10 @@
 import { Database } from "bun:sqlite";
-import { DISTILLATION_SYSTEM, distillationUser } from "@loreai/core";
+import { DISTILLATION_SYSTEM, distillationUser, dbPath } from "@loreai/core";
 
 const BASE_URL = "http://localhost:4096";
 const MODEL = { providerID: "anthropic", modelID: "claude-sonnet-4-6" };
 
-const DB_PATH =
-  process.env.NUUM_DB ??
-  `${process.env.HOME}/.local/share/opencode-lore/lore.db`;
+const DB_PATH = dbPath();
 
 // Find sessions with undistilled messages
 function findUndistilledSessions(): Array<{

--- a/packages/opencode/eval/coding_eval.ts
+++ b/packages/opencode/eval/coding_eval.ts
@@ -1,6 +1,6 @@
 import { parseArgs } from "util";
 import { Database } from "bun:sqlite";
-import { DISTILLATION_SYSTEM, distillationUser } from "@loreai/core";
+import { DISTILLATION_SYSTEM, distillationUser, dbPath } from "@loreai/core";
 
 const BASE_URL = "http://localhost:4096";
 const MODEL = { providerID: "anthropic", modelID: "claude-sonnet-4-6" };
@@ -30,9 +30,7 @@ type Question = {
 };
 
 // --- DB access ---
-const DB_PATH =
-  process.env.NUUM_DB ??
-  `${process.env.HOME}/.local/share/opencode-lore/lore.db`;
+const DB_PATH = dbPath();
 
 function getTemporalMessages(sessionID: string): Array<{
   role: string;

--- a/packages/opencode/eval/extract_session.ts
+++ b/packages/opencode/eval/extract_session.ts
@@ -8,10 +8,9 @@
  */
 import { parseArgs } from "util";
 import { Database } from "bun:sqlite";
+import { dbPath } from "@loreai/core";
 
-const DB_PATH =
-  process.env.LORE_DB_PATH ??
-  `${process.env.HOME}/.local/share/opencode-lore/lore.db`;
+const DB_PATH = dbPath();
 
 const { values } = parseArgs({
   args: Bun.argv.slice(2),

--- a/packages/opencode/eval/session_eval.ts
+++ b/packages/opencode/eval/session_eval.ts
@@ -10,7 +10,7 @@
  */
 import { parseArgs } from "util";
 import { Database } from "bun:sqlite";
-import { DISTILLATION_SYSTEM, distillationUser } from "@loreai/core";
+import { DISTILLATION_SYSTEM, distillationUser, dbPath } from "@loreai/core";
 
 // --- Config ---
 const BASE_URL = "http://localhost:4096";
@@ -19,9 +19,7 @@ const POLL_INTERVAL = 2000;
 const MAX_WAIT = 120000;
 const TAIL_BUDGET = 80_000; // tokens for default mode tail window
 const DISTILL_CHUNK_BUDGET = 20_000; // tokens per distillation segment
-const DB_PATH =
-  process.env.LORE_DB_PATH ??
-  `${process.env.HOME}/.local/share/opencode-lore/lore.db`;
+const DB_PATH = dbPath();
 
 // --- CLI args ---
 const { values } = parseArgs({

--- a/packages/pi/README.md
+++ b/packages/pi/README.md
@@ -45,7 +45,7 @@ If none apply, recall transparently falls back to FTS-only search.
 
 ## Companion packages
 
-Lore ships as three packages sharing the same SQLite database at `~/.local/share/opencode-lore/lore.db`:
+Lore ships as three packages sharing the same SQLite database at `~/.local/share/lore/lore.db`:
 
 - **`@loreai/pi`** (you are here) — Pi coding-agent extension
 - [`@loreai/opencode`](https://www.npmjs.com/package/@loreai/opencode) — [OpenCode](https://opencode.ai) plugin (also published as [`opencode-lore`](https://www.npmjs.com/package/opencode-lore) legacy alias)


### PR DESCRIPTION
## Summary

- Renames the default data directory from `~/.local/share/opencode-lore/` to `~/.local/share/lore/` with automatic one-time migration on startup
- Extracts a shared `dataDir()` into `packages/core/src/data-dir.ts`, eliminating duplicated path logic between `db.ts` and `log.ts`
- Migrates eval scripts to use the centralized `dbPath()` from `@loreai/core` instead of hardcoded fallback paths (also fixes two scripts that still referenced the legacy `NUUM_DB` env var instead of `LORE_DB_PATH`)
- Logs the migration event to stderr for user visibility

## Migration behavior

On first access, if the old directory exists and the new one does not, the entire directory is atomically renamed via `renameSync` (moves DB, WAL, SHM, logs in one shot). Migration is:
- **One-shot** per process (guarded by a boolean flag)
- **Silent on failure** (permissions, cross-device, concurrent rename) — callers create the new dir via `mkdirSync` anyway
- **Skipped in tests** (`NODE_ENV=test`)
- **New dir wins** if both exist (no-op)
- **Logged** to stderr on success: `[lore] migrated data directory: …`

## Test plan

- 6 new migration-specific tests in `packages/core/test/data-dir.test.ts`
- All 1193 existing tests pass
- Typecheck and build pass