### PR TITLE
fix: streaming robustness, RRF list priority, and CLI suggestion quality

### DIFF
--- a/packages/core/src/recall.ts
+++ b/packages/core/src/recall.ts
@@ -492,6 +492,10 @@ export async function searchRecall(
     weight?: number;
   }> = [];
 
+  // Track where primary (first-query) lists end so the MAX_RRF_LISTS cap
+  // trims expanded-query lists first, preserving vector/supplemental lists.
+  let primaryListEnd = 0;
+
   for (const q of queries) {
     const knowledgeResults: ltm.ScoredKnowledgeEntry[] = [];
     if (knowledgeEnabled && scope !== "session") {
@@ -577,7 +581,15 @@ export async function searchRecall(
         key: (r) => `t:${r.item.id}`,
       });
     }
+
+    // Mark the end of the first (original) query's lists. Supplemental lists
+    // (vector, lat.md, cross-project, quality, exact-match) are appended after
+    // the loop and should be preserved over expanded-query lists when capping.
+    if (primaryListEnd === 0) {
+      primaryListEnd = allRrfLists.length;
+    }
   }
+  const perQueryListEnd = allRrfLists.length;
 
   // Vector search on the original query (not expansions — avoid redundant embeds).
   if (embedding.isAvailable() && scope !== "session") {
@@ -800,12 +812,21 @@ export async function searchRecall(
 
   // Cap the number of RRF lists to prevent score inflation from marginal items.
   // With query expansion (3 queries × 4 sources + supplemental lists), the list
-  // count can exceed 12. Each list gives marginal items enough cumulative RRF
-  // score to clear the relevance floor. Trim lowest-priority lists (those added
-  // last — supplemental boosters) when over the cap.
+  // count can exceed 15. Each list gives marginal items enough cumulative RRF
+  // score to clear the relevance floor.
+  //
+  // Priority: primary (original query BM25 + recency) and supplemental
+  // (vector, lat.md, cross-project, quality, exact-match) are high-value.
+  // Expanded-query BM25 lists are lowest priority — trim those first.
   const MAX_RRF_LISTS = 10;
   if (allRrfLists.length > MAX_RRF_LISTS) {
-    allRrfLists.length = MAX_RRF_LISTS;
+    // Layout: [0..primaryListEnd) = primary, [primaryListEnd..perQueryEnd) = expanded, [perQueryEnd..) = supplemental
+    const primary = allRrfLists.slice(0, primaryListEnd);
+    const expanded = allRrfLists.slice(primaryListEnd, perQueryListEnd);
+    const supplemental = allRrfLists.slice(perQueryListEnd);
+    const budget = Math.max(0, MAX_RRF_LISTS - primary.length - supplemental.length);
+    allRrfLists.length = 0;
+    allRrfLists.push(...primary, ...expanded.slice(0, budget), ...supplemental);
   }
 
   const fused = reciprocalRankFusion<TaggedResult>(allRrfLists);

--- a/packages/gateway/src/cli/main.ts
+++ b/packages/gateway/src/cli/main.ts
@@ -226,10 +226,28 @@ export async function _cli(): Promise<void> {
               "start", "run", "data", "recall", "logs", "import", "upgrade", "help",
               ...knownBinaries,
             ];
-            // Simple "did you mean?" — find closest match by common prefix
-            const suggestion = knownCommands.find(
-              (c) => c.startsWith(command.slice(0, 2)) || command.startsWith(c.slice(0, 2)),
-            );
+            // "Did you mean?" — use Levenshtein distance for robust matching
+            function levenshtein(a: string, b: string): number {
+              const m = a.length, n = b.length;
+              const dp: number[][] = Array.from({ length: m + 1 }, (_, i) =>
+                Array.from({ length: n + 1 }, (_, j) => (i === 0 ? j : j === 0 ? i : 0)),
+              );
+              for (let i = 1; i <= m; i++)
+                for (let j = 1; j <= n; j++)
+                  dp[i][j] = a[i - 1] === b[j - 1]
+                    ? dp[i - 1][j - 1]
+                    : 1 + Math.min(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1]);
+              return dp[m][n];
+            }
+            let suggestion: string | undefined;
+            let bestDist = Infinity;
+            for (const c of knownCommands) {
+              const dist = levenshtein(command, c);
+              if (dist < bestDist && dist <= Math.max(2, Math.floor(command.length / 2))) {
+                bestDist = dist;
+                suggestion = c;
+              }
+            }
             const hint = suggestion ? ` Did you mean "lore ${suggestion}"?` : "";
             console.error(`Unknown command "${command}".${hint}\nRun "lore help" for available commands.`);
             process.exitCode = 1;

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -123,6 +123,10 @@ async function handleAnthropicMessages(
   }
 }
 
+// NOTE: This endpoint only supports the Anthropic upstream. OpenAI clients
+// calling GET /v1/models will have their request forwarded to Anthropic,
+// which will likely reject the OpenAI API key. A proper fix would route
+// based on auth header type, but that's a separate enhancement.
 async function handleModelsPassthrough(req: Request, config: GatewayConfig): Promise<Response> {
   try {
     // Forward auth headers from the original request so upstream

--- a/packages/gateway/src/stream/openai-responses.ts
+++ b/packages/gateway/src/stream/openai-responses.ts
@@ -279,6 +279,7 @@ export function translateAnthropicStreamToResponses(
       };
 
   const outputItems = new Map<number, OutputItem>();
+  let cancelled = false;
 
   function emit(eventType: string, data: Record<string, unknown>): string {
     return `event: ${eventType}\ndata: ${JSON.stringify(data)}\n\n`;
@@ -286,10 +287,23 @@ export function translateAnthropicStreamToResponses(
 
   const stream = new ReadableStream<Uint8Array>({
     async start(controller) {
+      function safeEnqueue(chunk: Uint8Array): boolean {
+        if (cancelled) return false;
+        try {
+          controller.enqueue(chunk);
+          return true;
+        } catch {
+          cancelled = true;
+          return false;
+        }
+      }
+
       try {
         const reader = anthropicResponse.body!.getReader();
 
         for await (const { event, data } of parseSSEStream(reader)) {
+          if (cancelled) break;
+
           // Always feed the accumulator
           accumulator.processEvent(event, data);
 
@@ -317,7 +331,7 @@ export function translateAnthropicStreamToResponses(
               }
 
               // response.created
-              controller.enqueue(
+              safeEnqueue(
                 encoder.encode(
                   emit("response.created", {
                     type: "response.created",
@@ -335,7 +349,7 @@ export function translateAnthropicStreamToResponses(
               );
 
               // response.in_progress
-              controller.enqueue(
+              safeEnqueue(
                 encoder.encode(
                   emit("response.in_progress", {
                     type: "response.in_progress",
@@ -375,7 +389,7 @@ export function translateAnthropicStreamToResponses(
                 });
 
                 // response.output_item.added
-                controller.enqueue(
+                safeEnqueue(
                   encoder.encode(
                     emit("response.output_item.added", {
                       type: "response.output_item.added",
@@ -392,7 +406,7 @@ export function translateAnthropicStreamToResponses(
                 );
 
                 // response.content_part.added
-                controller.enqueue(
+                safeEnqueue(
                   encoder.encode(
                     emit("response.content_part.added", {
                       type: "response.content_part.added",
@@ -423,7 +437,7 @@ export function translateAnthropicStreamToResponses(
                 });
 
                 // response.output_item.added
-                controller.enqueue(
+                safeEnqueue(
                   encoder.encode(
                     emit("response.output_item.added", {
                       type: "response.output_item.added",
@@ -464,7 +478,7 @@ export function translateAnthropicStreamToResponses(
                 item.text += delta.text;
 
                 // response.output_text.delta
-                controller.enqueue(
+                safeEnqueue(
                   encoder.encode(
                     emit("response.output_text.delta", {
                       type: "response.output_text.delta",
@@ -483,7 +497,7 @@ export function translateAnthropicStreamToResponses(
                 item.args += delta.partial_json;
 
                 // response.function_call_arguments.delta
-                controller.enqueue(
+                safeEnqueue(
                   encoder.encode(
                     emit("response.function_call_arguments.delta", {
                       type: "response.function_call_arguments.delta",
@@ -506,7 +520,7 @@ export function translateAnthropicStreamToResponses(
 
               if (item.kind === "text") {
                 // response.output_text.done
-                controller.enqueue(
+                safeEnqueue(
                   encoder.encode(
                     emit("response.output_text.done", {
                       type: "response.output_text.done",
@@ -519,7 +533,7 @@ export function translateAnthropicStreamToResponses(
                 );
 
                 // response.content_part.done
-                controller.enqueue(
+                safeEnqueue(
                   encoder.encode(
                     emit("response.content_part.done", {
                       type: "response.content_part.done",
@@ -536,7 +550,7 @@ export function translateAnthropicStreamToResponses(
                 );
 
                 // response.output_item.done
-                controller.enqueue(
+                safeEnqueue(
                   encoder.encode(
                     emit("response.output_item.done", {
                       type: "response.output_item.done",
@@ -559,7 +573,7 @@ export function translateAnthropicStreamToResponses(
                 );
               } else if (item.kind === "tool_use") {
                 // response.function_call_arguments.done
-                controller.enqueue(
+                safeEnqueue(
                   encoder.encode(
                     emit("response.function_call_arguments.done", {
                       type: "response.function_call_arguments.done",
@@ -571,7 +585,7 @@ export function translateAnthropicStreamToResponses(
                 );
 
                 // response.output_item.done
-                controller.enqueue(
+                safeEnqueue(
                   encoder.encode(
                     emit("response.output_item.done", {
                       type: "response.output_item.done",
@@ -643,7 +657,7 @@ export function translateAnthropicStreamToResponses(
                 };
               }
 
-              controller.enqueue(
+              safeEnqueue(
                 encoder.encode(
                   emit("response.completed", {
                     type: "response.completed",
@@ -670,12 +684,47 @@ export function translateAnthropicStreamToResponses(
           "[lore] openai-responses stream translation error:",
           err,
         );
+        // Emit a response.failed event so clients don't hang waiting
+        try {
+          controller.enqueue(
+            encoder.encode(
+              emit("response.failed", {
+                type: "response.failed",
+                response: {
+                  id: respId || "resp_error",
+                  object: "response",
+                  created_at: created,
+                  model,
+                  status: "failed",
+                  output: [],
+                  usage: null,
+                  error: {
+                    type: "server_error",
+                    message: err instanceof Error ? err.message : "upstream stream error",
+                  },
+                },
+              }),
+            ),
+          );
+        } catch {
+          // Controller may already be closed
+        }
       } finally {
         try {
           controller.close();
         } catch {
           // Already closed
         }
+      }
+    },
+
+    cancel() {
+      // Client disconnected — cancel the upstream reader to stop wasting bandwidth
+      cancelled = true;
+      try {
+        anthropicResponse.body?.cancel();
+      } catch {
+        // Best-effort cancellation
       }
     },
   });

--- a/packages/gateway/src/stream/openai.ts
+++ b/packages/gateway/src/stream/openai.ts
@@ -84,6 +84,7 @@ export function translateAnthropicStreamToOpenAI(
   // Tool call tracking: blockIndex → InflightToolCall
   const toolCalls = new Map<number, InflightToolCall>();
   let nextToolCallIndex = 0;
+  let cancelled = false;
 
   function formatChunk(
     delta: Record<string, unknown>,
@@ -111,10 +112,23 @@ export function translateAnthropicStreamToOpenAI(
 
   const stream = new ReadableStream<Uint8Array>({
     async start(controller) {
+      function safeEnqueue(chunk: Uint8Array): boolean {
+        if (cancelled) return false;
+        try {
+          controller.enqueue(chunk);
+          return true;
+        } catch {
+          cancelled = true;
+          return false;
+        }
+      }
+
       try {
         const reader = anthropicResponse.body!.getReader();
 
         for await (const { event, data } of parseSSEStream(reader)) {
+          if (cancelled) break;
+
           // Always feed the accumulator so we get a complete GatewayResponse
           accumulator.processEvent(event, data);
 
@@ -138,7 +152,7 @@ export function translateAnthropicStreamToOpenAI(
 
               // Emit the role chunk
               if (!roleChunkEmitted) {
-                controller.enqueue(
+                safeEnqueue(
                   encoder.encode(formatChunk({ role: "assistant" }, null)),
                 );
                 roleChunkEmitted = true;
@@ -166,7 +180,7 @@ export function translateAnthropicStreamToOpenAI(
                 toolCalls.set(index, tc);
 
                 // Emit the tool call header chunk (id, type, function name)
-                controller.enqueue(
+                safeEnqueue(
                   encoder.encode(
                     formatChunk(
                       {
@@ -202,7 +216,7 @@ export function translateAnthropicStreamToOpenAI(
 
               if (delta.type === "text_delta" && typeof delta.text === "string") {
                 // Emit text content incrementally
-                controller.enqueue(
+                safeEnqueue(
                   encoder.encode(formatChunk({ content: delta.text }, null)),
                 );
               } else if (
@@ -212,7 +226,7 @@ export function translateAnthropicStreamToOpenAI(
                 // Stream tool call arguments incrementally
                 const tc = toolCalls.get(index);
                 if (tc) {
-                  controller.enqueue(
+                  safeEnqueue(
                     encoder.encode(
                       formatChunk(
                         {
@@ -265,14 +279,14 @@ export function translateAnthropicStreamToOpenAI(
               }
 
               // Emit final chunk with finish_reason and usage
-              controller.enqueue(
+              safeEnqueue(
                 encoder.encode(
                   formatChunk({}, finishReason || "stop", usage),
                 ),
               );
 
               // Emit [DONE] sentinel
-              controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+              safeEnqueue(encoder.encode("data: [DONE]\n\n"));
               break;
             }
 
@@ -282,7 +296,7 @@ export function translateAnthropicStreamToOpenAI(
       } catch (err) {
         // If upstream errors, try to close gracefully with [DONE]
         try {
-          controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+          safeEnqueue(encoder.encode("data: [DONE]\n\n"));
         } catch {
           // Controller may already be closed
         }
@@ -293,6 +307,16 @@ export function translateAnthropicStreamToOpenAI(
         } catch {
           // Already closed
         }
+      }
+    },
+
+    cancel() {
+      // Client disconnected — cancel the upstream reader to stop wasting bandwidth
+      cancelled = true;
+      try {
+        anthropicResponse.body?.cancel();
+      } catch {
+        // Best-effort cancellation
       }
     },
   });


### PR DESCRIPTION
## Summary

Follow-up fixes from self-review of PR #267. Addresses 2 critical, 2 moderate, and 1 minor issue found during code review.

### Critical: Streaming translator robustness (C1, C2)

**C1 — Responses API error handling:** The `translateAnthropicStreamToResponses` translator silently closed the stream on upstream errors, leaving clients hanging with no terminal event. Now emits a `response.failed` event with error details before closing.

**C2 — Client disconnect handling:** Neither streaming translator had a `cancel()` handler. If a client disconnected mid-stream, the upstream reader continued consuming the full response into the void, wasting bandwidth. Both translators now:
- Implement `cancel()` to cancel the upstream `Response.body` reader
- Use a `safeEnqueue()` pattern that sets a `cancelled` flag on enqueue failure
- Check `cancelled` at the top of each loop iteration to break early

### Moderate: CLI suggestion quality (M4)

The "did you mean?" matching used a 2-character prefix check, which was far too loose (e.g., `lore hi` would suggest `help`). Replaced with Levenshtein distance with a max-distance threshold of `max(2, floor(len/2))`, giving accurate suggestions for typos.

### Moderate: RRF list cap priority (m4)

With query expansion producing 3 queries, the per-query BM25 lists (9+) filled the MAX_RRF_LISTS=10 cap before vector search, lat.md, cross-project, quality re-ranking, and exact-match boost lists were added — dropping all high-value supplemental lists. Fixed by tracking list boundaries:
- **Primary lists** (original query BM25 + recency): always kept
- **Supplemental lists** (vector, lat.md, cross-project, quality, exact-match): always kept
- **Expanded-query lists**: trimmed first when over budget

### Minor: Documentation (M6)

Added a comment documenting that `/v1/models` passthrough only supports the Anthropic upstream.

## Verification
- Typecheck: all 4 packages pass
- Tests: 1254 pass, 0 fail