### PR TITLE
feat: decouple Pi plugin from @loreai/core via gateway /v1/compact endpoint

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -60,7 +60,6 @@
       "name": "@loreai/pi",
       "version": "0.17.1",
       "dependencies": {
-        "@loreai/core": "workspace:*",
         "@loreai/gateway": "workspace:*",
       },
       "devDependencies": {

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -1851,24 +1851,26 @@ function scheduleBackgroundWork(
 }
 
 // ---------------------------------------------------------------------------
-// Case 1: Compaction interception
+// Compaction summary generation — shared by HTTP interception and /v1/compact
 // ---------------------------------------------------------------------------
 
-async function handleCompaction(
-  req: GatewayRequest,
-  config: GatewayConfig,
-): Promise<Response> {
-  // Identify session
-  const projectPath = getProjectPath(req.system, req.rawHeaders);
-  await initIfNeeded(projectPath, config);
-
-  const { sessionID } = await identifySession(req, projectPath);
-  const sessionState = getOrCreateSession(sessionID, projectPath);
+/**
+ * Generate a compaction summary for a session. Force-distills any pending
+ * messages, loads existing distillation summaries, builds a knowledge block,
+ * and calls the LLM to produce a compaction summary.
+ *
+ * This is the core logic shared by both:
+ *  - `handleCompaction` (HTTP-intercepted compaction from Claude Code / OpenCode)
+ *  - `handleCompactEndpoint` (explicit POST /v1/compact from Pi plugin)
+ */
+export async function generateCompactionSummary(opts: {
+  projectPath: string;
+  sessionID: string;
+  config: GatewayConfig;
+  previousSummary?: string;
+}): Promise<string> {
+  const { projectPath, sessionID, config, previousSummary } = opts;
   const llm = getLLMClient(config);
-
-  setSentryLightContext({ model: req.model, projectPath });
-
-  log.info(`compaction intercepted for session ${sessionID.slice(0, 16)}`);
 
   // 1. Force-distill all undistilled messages.
   // Mark urgent: true — client is blocking on the compaction response.
@@ -1886,10 +1888,7 @@ async function handleCompaction(
   // 2. Load distillation summaries
   const distillations = distillation.loadForSession(projectPath, sessionID);
 
-  // 3. Extract previous summary from the request (if any)
-  const previousSummary = extractPreviousSummary(req);
-
-  // 4. Build knowledge block
+  // 3. Build knowledge block
   const cfg = loreConfig();
   const entries = cfg.knowledge.enabled
     ? ltm.forProject(projectPath, cfg.crossProject)
@@ -1904,14 +1903,14 @@ async function handleCompaction(
       )
     : "";
 
-  // 5. Build the compact prompt
+  // 4. Build the compact prompt
   const compactPrompt = buildCompactPrompt({
     hasDistillations: distillations.length > 0,
     knowledge,
     previousSummary,
   });
 
-  // 6. Build context with distillation summaries
+  // 5. Build context with distillation summaries
   let context = "";
   if (distillations.length > 0) {
     context =
@@ -1926,7 +1925,7 @@ async function handleCompaction(
         .join("\n\n");
   }
 
-  // 7. Generate the compaction summary via LLM
+  // 6. Generate the compaction summary via LLM
   const userContent = context
     ? `${context}\n\n---\n\n${compactPrompt}`
     : compactPrompt;
@@ -1936,13 +1935,37 @@ async function handleCompaction(
   const summaryText = await llm.prompt(compactPrompt, userContent, {
     model: getWorkerModel(),
     workerID: "lore-compact",
-    urgent: true, // Client is blocking on this response
+    urgent: true,
     maxTokens: compactMaxTokens,
   });
 
-  const summary = summaryText ?? "(Compaction failed — no summary generated.)";
+  return summaryText ?? "(Compaction failed — no summary generated.)";
+}
 
-  // 8. Build and return the response
+// ---------------------------------------------------------------------------
+// Case 1: Compaction interception
+// ---------------------------------------------------------------------------
+
+async function handleCompaction(
+  req: GatewayRequest,
+  config: GatewayConfig,
+): Promise<Response> {
+  const projectPath = getProjectPath(req.system, req.rawHeaders);
+  await initIfNeeded(projectPath, config);
+
+  const { sessionID } = await identifySession(req, projectPath);
+  const sessionState = getOrCreateSession(sessionID, projectPath);
+
+  setSentryLightContext({ model: req.model, projectPath });
+  log.info(`compaction intercepted for session ${sessionID.slice(0, 16)}`);
+
+  const summary = await generateCompactionSummary({
+    projectPath,
+    sessionID,
+    config,
+    previousSummary: extractPreviousSummary(req),
+  });
+
   const resp = buildCompactionResponse(sessionID, summary, req.model);
 
   // Clear the cached warmup body — post-compaction the client will send
@@ -1953,6 +1976,111 @@ async function handleCompaction(
     return streamHttpResponse(resp);
   }
   return nonStreamHttpResponse(resp);
+}
+
+// ---------------------------------------------------------------------------
+// Case 1b: Explicit compaction endpoint (POST /v1/compact)
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle an explicit compaction summary request from a plugin (e.g. Pi).
+ * Unlike `handleCompaction` which detects compaction from request patterns,
+ * this endpoint accepts a direct JSON body with project path and optional
+ * previous summary.
+ *
+ * The caller must include a session-identifying header (e.g. x-lore-session-id)
+ * so the gateway can resolve the correct internal session.
+ */
+export async function handleCompactEndpoint(
+  req: Request,
+  config: GatewayConfig,
+): Promise<Response> {
+  let body: { project_path?: string; previous_summary?: string };
+  try {
+    body = (await req.json()) as typeof body;
+  } catch {
+    return new Response(
+      JSON.stringify({ error: "invalid_request", message: "Invalid JSON body" }),
+      { status: 400, headers: { "content-type": "application/json" } },
+    );
+  }
+
+  const projectPath = body.project_path;
+  if (!projectPath || typeof projectPath !== "string") {
+    return new Response(
+      JSON.stringify({ error: "invalid_request", message: "project_path is required" }),
+      { status: 400, headers: { "content-type": "application/json" } },
+    );
+  }
+
+  await initIfNeeded(projectPath, config);
+
+  // Build a minimal GatewayRequest for session identification.
+  // Only rawHeaders and messages are used by identifySession().
+  const rawHeaders: Record<string, string> = {};
+  req.headers.forEach((value, key) => {
+    rawHeaders[key] = value;
+  });
+
+  const minimalReq: GatewayRequest = {
+    protocol: "anthropic",
+    system: "",
+    messages: [],
+    tools: [],
+    model: "",
+    maxTokens: 0,
+    stream: false,
+    metadata: {},
+    rawHeaders,
+  };
+
+  const { sessionID, isNew } = await identifySession(minimalReq, projectPath);
+
+  if (isNew) {
+    // No prior session found — the caller's session header didn't match any
+    // existing session. This typically means no conversation turns have gone
+    // through the gateway yet, so there's nothing to compact.
+    return new Response(
+      JSON.stringify({
+        error: "session_not_found",
+        message: "No active session found for the given headers. " +
+          "Ensure at least one conversation turn has been routed through the gateway.",
+      }),
+      { status: 404, headers: { "content-type": "application/json" } },
+    );
+  }
+
+  log.info(`compact endpoint: generating summary for session ${sessionID.slice(0, 16)}`);
+
+  try {
+    const summary = await generateCompactionSummary({
+      projectPath,
+      sessionID,
+      config,
+      previousSummary: typeof body.previous_summary === "string"
+        ? body.previous_summary
+        : undefined,
+    });
+
+    // Clear the cached warmup body — post-compaction the client will send
+    // entirely different messages, so the pre-compaction body is stale.
+    const sessionState = sessions.get(sessionID);
+    if (sessionState) {
+      sessionState.cacheAnalytics.lastRequestBody = null;
+    }
+
+    return new Response(
+      JSON.stringify({ summary }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Compaction failed";
+    log.error("compact endpoint error:", err);
+    return new Response(
+      JSON.stringify({ error: "compaction_failed", message: msg }),
+      { status: 500, headers: { "content-type": "application/json" } },
+    );
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -5,6 +5,7 @@
  *   POST /v1/messages          → Anthropic protocol
  *   POST /v1/chat/completions  → OpenAI Chat Completions protocol
  *   POST /v1/responses         → OpenAI Responses API protocol
+ *   POST /v1/compact           → Explicit compaction summary (Pi plugin, etc.)
  *   GET  /v1/models            → Passthrough to upstream
  *   GET  /health               → Health check
  *
@@ -20,7 +21,7 @@ import {
   buildOpenAIResponsesResponse,
 } from "./translate/openai-responses";
 import { translateAnthropicStreamToResponses } from "./stream/openai-responses";
-import { handleRequest } from "./pipeline";
+import { handleRequest, handleCompactEndpoint } from "./pipeline";
 
 // ---------------------------------------------------------------------------
 // Version — best-effort from package.json, falls back gracefully
@@ -289,6 +290,11 @@ export function startServer(config: GatewayConfig): {
       // POST /v1/responses — OpenAI Responses API protocol
       if (method === "POST" && pathname === "/v1/responses") {
         return await handleOpenAIResponses(req, config);
+      }
+
+      // POST /v1/compact — explicit compaction summary (Pi plugin, etc.)
+      if (method === "POST" && pathname === "/v1/compact") {
+        return withCors(await handleCompactEndpoint(req, config));
       }
 
       // GET /v1/models — passthrough

--- a/packages/gateway/src/session.ts
+++ b/packages/gateway/src/session.ts
@@ -267,6 +267,7 @@ export function detectClientType(
 export const KNOWN_SESSION_HEADERS = [
   "x-claude-code-session-id", // Claude Code (UUID, persists for CLI session)
   "x-session-affinity",       // OpenCode  (nanoid, persists for session)
+  "x-lore-session-id",        // Lore plugins (Pi, etc.) — injected via registerProvider
 ] as const;
 
 /**

--- a/packages/pi/package.json
+++ b/packages/pi/package.json
@@ -22,7 +22,6 @@
     "build": "bun run script/build.ts"
   },
   "dependencies": {
-    "@loreai/core": "workspace:*",
     "@loreai/gateway": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/pi/script/build.ts
+++ b/packages/pi/script/build.ts
@@ -6,8 +6,8 @@
  *
  * External — all of these are resolved at consumer install time, NOT bundled:
  *
- * - `@loreai/core` — published separately; users picking up a new core
- *   version (security/bug fix) automatically benefit without a pi republish.
+ * - `@loreai/gateway` — started in-process via dynamic import; published
+ *   separately so users benefit from gateway updates without a pi republish.
  * - `@mariozechner/*` — Pi bundles these internally and injects them via
  *   jiti's virtualModules when loading extensions. Bundling our own copies
  *   would break: jiti resolves imports to the virtual modules, but if we
@@ -30,7 +30,6 @@ mkdirSync(distDir, { recursive: true });
 
 const external = [
   "node:*",
-  "@loreai/core",
   "@loreai/gateway",
   "@mariozechner/pi-coding-agent",
   "@mariozechner/pi-tui",

--- a/packages/pi/src/index.ts
+++ b/packages/pi/src/index.ts
@@ -26,7 +26,6 @@ import type {
   SessionBeforeCompactEvent,
   SessionStartEvent,
 } from "@mariozechner/pi-coding-agent";
-import { distillation, log } from "@loreai/core";
 
 // Pi doesn't re-export these event result types at the top level — inline their
 // minimal shape here to avoid depending on an internal package path.
@@ -117,7 +116,7 @@ async function startInProcess(gatewayBase: string): Promise<boolean> {
     if (/EADDRINUSE/i.test(msg) || /port\b.*\bin use/i.test(msg)) {
       return await probeGateway(gatewayBase, 1000);
     }
-    log.info("pi: failed to start gateway in-process:", msg);
+    console.info("pi: failed to start gateway in-process:", msg);
     return false;
   }
 }
@@ -148,12 +147,12 @@ export default async function lorePiExtension(pi: ExtensionAPI): Promise<void> {
 
   if (process.env.LORE_GATEWAY_MODE !== "0" && !inTestEnv) {
     if (await probeGateway(gatewayBase)) {
-      log.info(`pi: gateway detected at ${gatewayBase}`);
+      console.info(`pi: gateway detected at ${gatewayBase}`);
       gatewayActive = true;
     } else {
-      log.info(`pi: starting gateway in-process at ${gatewayBase}…`);
+      console.info(`pi: starting gateway in-process at ${gatewayBase}…`);
       if (await startInProcess(gatewayBase)) {
-        log.info(`pi: gateway started in-process at ${gatewayBase}`);
+        console.info(`pi: gateway started in-process at ${gatewayBase}`);
         gatewayActive = true;
       }
     }
@@ -163,29 +162,47 @@ export default async function lorePiExtension(pi: ExtensionAPI): Promise<void> {
     const msg =
       "Lore gateway failed to start — memory features are unavailable. " +
       "Ensure @loreai/gateway is installed or start the gateway manually.";
-    log.error("pi:", msg);
+    console.error("pi:", msg);
     return;
   }
 
   if (!gatewayActive) return;
 
-  log.info(`pi: gateway active — routing providers through ${gatewayBase}`);
-
-  // Redirect all gateway-compatible providers through the proxy.
-  for (const provider of GATEWAY_PROVIDERS) {
-    pi.registerProvider(provider, { baseUrl: gatewayBase });
-  }
+  console.info(`pi: gateway active — routing providers through ${gatewayBase}`);
 
   // ---------------------------------------------------------------------------
-  // Minimal session tracking — only needed by session_before_compact below.
+  // Session tracking — used for provider header injection and compaction.
   // ---------------------------------------------------------------------------
 
   let projectPath = process.cwd();
   let currentSessionID = sessionIDFor(undefined);
 
+  /**
+   * Register (or re-register) all gateway-compatible providers with the
+   * current session header. Called on startup and again on session_start
+   * once the real session ID is known.
+   */
+  function registerProviders(): void {
+    for (const provider of GATEWAY_PROVIDERS) {
+      pi.registerProvider(provider, {
+        baseUrl: gatewayBase,
+        headers: { "x-lore-session-id": currentSessionID },
+      });
+    }
+  }
+
+  // Initial registration with ephemeral session ID.
+  registerProviders();
+
   pi.on("session_start", async (_event: SessionStartEvent, ctx) => {
     projectPath = ctx.cwd;
-    currentSessionID = sessionIDFor(ctx.sessionManager.getSessionFile());
+    const newID = sessionIDFor(ctx.sessionManager.getSessionFile());
+    if (newID !== currentSessionID) {
+      currentSessionID = newID;
+      // Re-register with the real session ID so all subsequent provider
+      // requests carry the correct x-lore-session-id header.
+      registerProviders();
+    }
   });
 
   // ---------------------------------------------------------------------------
@@ -193,8 +210,9 @@ export default async function lorePiExtension(pi: ExtensionAPI): Promise<void> {
   //
   // Pi's compaction goes through its extension API, not HTTP. The gateway
   // intercepts compaction via HTTP request patterns (Claude Code-specific),
-  // which don't match Pi's internal compaction flow. The extension provides
-  // Lore's distillation-aware summaries directly.
+  // which don't match Pi's internal compaction flow. This hook calls the
+  // gateway's POST /v1/compact endpoint to get a full LLM-synthesized
+  // compaction summary (force-distill + knowledge + compact prompt).
   // ---------------------------------------------------------------------------
 
   pi.on(
@@ -204,25 +222,39 @@ export default async function lorePiExtension(pi: ExtensionAPI): Promise<void> {
       _ctx,
     ): Promise<SessionBeforeCompactResult | undefined> => {
       try {
-        const summaries = distillation.loadForSession(
-          projectPath,
-          currentSessionID,
-        );
-        if (summaries.length === 0) return undefined;
+        const res = await fetch(`${gatewayBase}/v1/compact`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-lore-session-id": currentSessionID,
+          },
+          body: JSON.stringify({
+            project_path: projectPath,
+            previous_summary: event.preparation.previousSummary,
+          }),
+        });
 
-        const summaryText = summaries
-          .map((s) => s.observations)
-          .join("\n\n---\n\n");
+        if (!res.ok) {
+          // Gateway returned an error — fall back to Pi's default compaction.
+          const errBody = await res.text().catch(() => "");
+          console.error(
+            `pi: compaction endpoint returned ${res.status}: ${errBody}`,
+          );
+          return undefined;
+        }
+
+        const { summary } = (await res.json()) as { summary: string };
+        if (!summary) return undefined;
 
         return {
           compaction: {
-            summary: summaryText,
+            summary,
             firstKeptEntryId: event.preparation.firstKeptEntryId,
             tokensBefore: event.preparation.tokensBefore,
           },
         };
       } catch (err) {
-        log.error("pi: custom compaction failed, falling back to default:", err);
+        console.error("pi: custom compaction failed, falling back to default:", err);
         return undefined;
       }
     },

--- a/packages/pi/tsconfig.json
+++ b/packages/pi/tsconfig.json
@@ -1,10 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "noEmit": true,
-    "paths": {
-      "@loreai/core": ["../core/src/index.ts"]
-    }
+    "noEmit": true
   },
   "include": ["src", "test", "script"]
 }


### PR DESCRIPTION
## Summary

Removes Pi plugin's last direct `@loreai/core` dependency by routing compaction through a new gateway HTTP endpoint. Pi is now a pure HTTP client and works with remote/hosted gateways.

### What changed

**Gateway (3 files):**
- `session.ts` — Added `x-lore-session-id` to `KNOWN_SESSION_HEADERS` (Tier 1 identification). Pi requests now get stable session identification instead of falling through to Tier 3 fingerprint matching.
- `pipeline.ts` — Extracted `generateCompactionSummary()` from `handleCompaction` (shared by both HTTP-intercepted compaction and the new endpoint). Added `handleCompactEndpoint()` for `POST /v1/compact`.
- `server.ts` — Added `POST /v1/compact` route.

**Pi plugin (4 files):**
- `src/index.ts` — Injects `x-lore-session-id` header via `registerProvider({ headers })`, re-registers on `session_start` with the real session ID. Replaced `distillation.loadForSession()` with HTTP fetch to `/v1/compact`. Graceful fallback on error (returns `undefined` → Pi uses default compaction). Replaced `log` import with `console`.
- `package.json` — Removed `@loreai/core` from dependencies.
- `script/build.ts` — Removed `@loreai/core` from esbuild externals.
- `tsconfig.json` — Removed `@loreai/core` path alias.

### Why

Pi's `session_before_compact` hook directly imported `distillation` from `@loreai/core`, requiring the full core + SQLite DB locally. This was the last blocker preventing Pi from working with a remote/hosted gateway.

### Additional benefits

- **Better session identification:** Pi now uses Tier 1 header-based identification (was Tier 3 fingerprint — fragile across compaction boundaries).
- **Better compaction quality:** Upgraded from raw distillation dump to full LLM-synthesized summary (force-distill + knowledge injection + compact prompt).
- **Graceful degradation:** If the endpoint returns an error (older gateway, network issue), Pi falls back to its default compaction — no broken sessions.

### Verification
- Typecheck: 4 packages pass
- Tests: 1304 pass, 0 fail
- Build: success