### PR TITLE
fix: correct cost intelligence accuracy and add overhead breakdown

### DIFF
--- a/packages/gateway/src/cost-tracker.ts
+++ b/packages/gateway/src/cost-tracker.ts
@@ -72,8 +72,12 @@ export type SessionCosts = {
     avoidedCompactionCost: number;
   };
 
-  /** Shadow context counter — tracks virtual context growth for compaction estimation. */
+  /** Shadow context counter — tracks virtual uncompressed context growth for compaction estimation. */
   _shadowContextTokens: number;
+  /** Previous turn's actual (compressed) input tokens — for delta estimation. */
+  _lastActualInput: number;
+  /** Previous turn's output tokens (always uncompressed) — for growth estimation. */
+  _lastOutputTokens: number;
 };
 
 /** Backdated historical estimates from stored data. */
@@ -180,6 +184,8 @@ function emptyCosts(): SessionCosts {
       avoidedCompactionCost: 0,
     },
     _shadowContextTokens: 0,
+    _lastActualInput: 0,
+    _lastOutputTokens: 0,
   };
 }
 
@@ -378,35 +384,55 @@ function estimateCompactionCost(
 /**
  * Update the shadow context counter after a conversation turn.
  *
- * Maintains a virtual "what would context size be without Lore?" counter.
- * When it crosses the compaction threshold, records a counterfactual
- * compaction event and resets.
+ * Maintains a virtual "what would context size be without Lore?" counter
+ * using additive growth tracking. Instead of snapshotting the compressed
+ * API token count (which underestimates because Lore's gradient manager
+ * already trimmed the context), we accumulate per-turn growth from
+ * uncompressed signals:
+ *
+ * - Output tokens are always uncompressed (the model's full response).
+ * - The previous turn's output becomes part of the next turn's context.
+ * - New user input is estimated from the delta in actual input tokens.
+ *
+ * When the shadow counter crosses the compaction threshold, a
+ * counterfactual compaction event is recorded and the counter resets.
  *
  * @param totalInputTokens - Total input tokens for this turn (input + cache_read + cache_write)
+ * @param outputTokens - Output tokens for this turn (always uncompressed)
  * @param workerModel - Model ID used for worker calls (for compaction cost estimation)
  */
 export function updateShadowContext(
   sessionID: string,
   totalInputTokens: number,
+  outputTokens: number,
   workerModel: string,
   conversationModel?: string,
 ): void {
   const costs = getOrCreate(sessionID);
 
-  // On first turn, initialize shadow context to the actual input size
+  // On first turn, initialize shadow context to the actual input size.
+  // No compression has happened yet, so the actual count is accurate.
+  // NOTE: this check relies on recordConversationCost() having already
+  // incremented turns for this turn (called earlier in postResponse).
   if (costs.conversation.turns <= 1) {
     costs._shadowContextTokens = totalInputTokens;
+    costs._lastActualInput = totalInputTokens;
+    costs._lastOutputTokens = outputTokens;
     return;
   }
 
-  // Estimate context growth this turn. In reality, each turn adds roughly
-  // the output tokens from the previous turn + new user message tokens.
-  // We approximate by looking at the delta between current total input
-  // and the previous turn's total input (tracked separately in session state).
-  // For simplicity, use the actual total input as the shadow context.
-  // This slightly overestimates because Lore might have trimmed context,
-  // but that's fine — we want a conservative counterfactual.
-  costs._shadowContextTokens = totalInputTokens;
+  // Estimate uncompressed context growth since the last turn.
+  // Growth is at least prevOutput (the assistant's response is always
+  // added to context, uncompressed) and at most inputDelta (when new
+  // user content exceeds the response size). If gradient compression
+  // makes the delta negative, we fall back to prevOutput as the floor.
+  const inputDelta = totalInputTokens - costs._lastActualInput;
+  const prevOutput = costs._lastOutputTokens;
+  const growth = Math.max(inputDelta, prevOutput);
+
+  costs._shadowContextTokens += growth;
+  costs._lastActualInput = totalInputTokens;
+  costs._lastOutputTokens = outputTokens;
 
   if (costs._shadowContextTokens > AUTOCOMPACT_THRESHOLD) {
     costs.counterfactual.avoidedCompactions++;

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -1708,12 +1708,18 @@ function postResponse(
     // (B) Track warmup hits and TTL savings — valid for ALL turn types.
     // A user returning after a warmup is a hit regardless of whether it's
     // a subagent turn or tool-use continuation.
+    // NOTE: warmup hits and TTL savings are mutually exclusive — if a turn
+    // is attributed to a warmup hit, skip TTL savings to avoid double-counting
+    // the same cacheReadTokens in both buckets.
     if (sessionState.lastRequestTime > 0) {
+      let warmupHitThisTurn = false;
+
       // Track warmup hit: user returned after we warmed the cache
       if (sessionState.warmup?.lastWarmupAt) {
         const ttlMs = sessionState.resolvedConversationTTL === "1h" ? 3_600_000 : 300_000;
         const sinceWarmup = now - sessionState.warmup.lastWarmupAt;
         if (sinceWarmup < ttlMs) {
+          warmupHitThisTurn = true;
           sessionState.warmup.warmupHits++;
           emitWarmupHitMetric(
             sessionState.lastModel ?? req.model,
@@ -1733,12 +1739,15 @@ function postResponse(
       }
 
       // Track 1h TTL savings: if gap > 5m but we still got cache reads,
-      // the 1h TTL saved a full cache write.
-      const requestGap = now - sessionState.lastRequestTime;
-      if (requestGap > 300_000) {
-        const cacheRead = resp.usage.cacheReadInputTokens ?? 0;
-        if (cacheRead > 0) {
-          recordTTLSavings(sessionID, req.model, cacheRead);
+      // the 1h TTL saved a full cache write. Skip if already counted as
+      // a warmup hit to avoid double-counting the same tokens.
+      if (!warmupHitThisTurn) {
+        const requestGap = now - sessionState.lastRequestTime;
+        if (requestGap > 300_000) {
+          const cacheRead = resp.usage.cacheReadInputTokens ?? 0;
+          if (cacheRead > 0) {
+            recordTTLSavings(sessionID, req.model, cacheRead);
+          }
         }
       }
     }
@@ -1762,7 +1771,7 @@ function postResponse(
     // compressing it. When the shadow counter crosses the auto-compact
     // threshold, record a counterfactual compaction event.
     if (!isSubagentTurn) {
-      updateShadowContext(sessionID, actualInput, getWorkerModel()?.modelID ?? "unknown", req.model);
+      updateShadowContext(sessionID, actualInput, resp.usage.outputTokens ?? 0, getWorkerModel()?.modelID ?? "unknown", req.model);
     }
 
     // --- Schedule background work (fire-and-forget) ---

--- a/packages/gateway/src/ui.ts
+++ b/packages/gateway/src/ui.ts
@@ -1292,6 +1292,11 @@ function pageCosts(): string {
   let liveTtlSavings = 0;
   let liveAvoidedCompactions = 0;
   let liveAvoidedCompactionCost = 0;
+  let liveDistillCost = 0;
+  let liveCurateCost = 0;
+  let liveCompactCost = 0;
+  let liveWarmupCost = 0;
+  let liveRecallCost = 0;
 
   for (const [, c] of allCosts) {
     liveTotalSpend += totalActualCost(c);
@@ -1306,6 +1311,11 @@ function pageCosts(): string {
     liveTtlSavings += c.counterfactual.ttlSavings;
     liveAvoidedCompactions += c.counterfactual.avoidedCompactions;
     liveAvoidedCompactionCost += c.counterfactual.avoidedCompactionCost;
+    liveDistillCost += c.workers.distillation.cost;
+    liveCurateCost += c.workers.curation.cost;
+    liveCompactCost += c.workers.compaction.cost;
+    liveWarmupCost += c.workers.warmup.cost;
+    liveRecallCost += c.workers.recall.cost;
   }
 
   // --- Historical (backdated) estimates ---
@@ -1348,7 +1358,15 @@ function pageCosts(): string {
       <table class="cost-table">
         <tr class="section-header"><td colspan="2"><strong>Aggregated Spend</strong></td></tr>
         <tr><td>Conversation</td><td>${formatUSD(liveTotalConversation)} <span style="color:var(--fg3);font-size:0.85em">(${liveTotalTurns} turns)</span></td></tr>
-        <tr><td>+ Lore overhead</td><td>${formatUSD(liveTotalWorker)}</td></tr>
+        <tr><td>+ Lore overhead</td><td>${formatUSD(liveTotalWorker)}${(() => {
+          const parts: string[] = [];
+          if (liveDistillCost > 0) parts.push(`distill: ${formatUSD(liveDistillCost)}`);
+          if (liveCurateCost > 0) parts.push(`curate: ${formatUSD(liveCurateCost)}`);
+          if (liveCompactCost > 0) parts.push(`compact: ${formatUSD(liveCompactCost)}`);
+          if (liveWarmupCost > 0) parts.push(`warmup: ${formatUSD(liveWarmupCost)}`);
+          if (liveRecallCost > 0) parts.push(`recall: ${formatUSD(liveRecallCost)}`);
+          return parts.length ? ` <span style="color:var(--fg3);font-size:0.85em">(${parts.join(", ")})</span>` : "";
+        })()}</td></tr>
         <tr style="border-top:1px solid var(--border)"><td><strong>Total</strong></td><td><strong>${formatUSD(liveTotalSpend)}</strong></td></tr>`;
 
     if (liveTotalSavings !== 0) {


### PR DESCRIPTION
## Summary

- **Fix double-counting of warmup + TTL savings** — the same `cacheReadTokens` were counted in both `warmupSavings` and `ttlSavings` when a user returned after >5min following a warmup ping. Since warmups exist for longer gaps, this was the common case, inflating savings by ~2x. Now mutually exclusive: warmup hits take priority, TTL savings only fire for non-warmup turns.

- **Fix shadow context undercount for avoided compactions** — `updateShadowContext()` was snapshotting the compressed API token count, which underestimates the "without Lore" counterfactual because Lore's gradient manager already trimmed context. Replaced with additive growth tracking using output tokens (always uncompressed) as the reliable per-turn growth signal.

- **Add Lore overhead breakdown to main costs page** — the `/ui/costs` aggregated view now shows per-worker-bucket breakdown (distill, curate, compact, warmup, recall) on the Lore overhead line, matching the per-session Cost Intelligence card format.

## Files Changed

| File | Change |
|---|---|
| `packages/gateway/src/pipeline.ts` | Warmup/TTL mutual exclusion; pass `outputTokens` to `updateShadowContext` |
| `packages/gateway/src/cost-tracker.ts` | Additive shadow context tracking with `_lastActualInput`/`_lastOutputTokens` fields |
| `packages/gateway/src/ui.ts` | Accumulate + render per-worker-bucket overhead breakdown |