### PR TITLE
cleanup: remove "gateway mode" language

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -592,4 +592,4 @@
 ### Preference
 
 <!-- lore:019e1c54-02ef-7ca8-90ce-b75d97917b96 -->
-* **Never use --admin flag for PR merges unless explicitly told**: Always watch CI after submitting a PR — never use \`--admin\` to bypass branch protection and never use \`gh pr merge --auto\` (auto-merge). Fix any CI failures until green, then merge with \`gh pr merge --squash\`. Wait for CI to pass before merging.
+* **Never use --admin flag for PR merges unless explicitly told**: Always check for merge conflicts when CI doesn't start after pushing a PR — missing CI triggers are often caused by merge conflicts, not CI configuration issues. After resolving conflicts via rebase, force push and verify \`mergeable\` state before watching CI. Never use \`--admin\` to bypass branch protection. Fix CI failures until green, then merge with \`gh pr merge --squash\`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ Binary entry: `packages/gateway/src/cli/bin.ts` -> `packages/gateway/src/cli/mai
 | Command | Handler | Description |
 |---|---|---|
 | `run` (default) | `cli/run.ts` | Start gateway + auto-detect and launch AI agent |
-| `start` | `cli/start.ts` | Start gateway server only |
+| `start` | `cli/start.ts` | Start gateway server (without launching an agent) |
 | `data` | `cli/data.ts` | Inspect/manage stored data (`list`, `show`, `clear`, `delete`, `merge`, `recover`) |
 | `recall` | `cli/recall-cmd.ts` | Search project memory from terminal |
 | `upgrade` | `cli/upgrade.ts` | Self-update the binary |

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -183,7 +183,7 @@ export type LoreMessageWithParts = {
  * Host adapters implement this:
  * - OpenCode: wraps `client.session.create()` + `client.session.prompt()`
  * - Pi: wraps `complete()` from `@mariozechner/pi-ai`
- * - Standalone: direct `fetch()` to provider APIs
+ * - Gateway: direct `fetch()` to provider APIs
  */
 export interface LLMClient {
   /**

--- a/packages/gateway/src/batch-queue.ts
+++ b/packages/gateway/src/batch-queue.ts
@@ -13,8 +13,8 @@
  * by credential at flush time — this ensures multi-session isolation when
  * multiple clients with different API keys are connected simultaneously.
  *
- * This is a gateway-only enhancement — the OpenCode and Pi adapters
- * always process immediately regardless of the `urgent` flag.
+ * The OpenCode and Pi plugin adapters always process LLM calls
+ * immediately regardless of the `urgent` flag.
  */
 
 import type { LLMClient } from "@loreai/core";

--- a/packages/gateway/src/cli/help.ts
+++ b/packages/gateway/src/cli/help.ts
@@ -11,7 +11,7 @@ Usage:
 
 Commands:
   run [command...]    Start gateway and launch an AI agent (default)
-  start               Start the gateway server only
+  start               Start the gateway server (without launching an agent)
   logs                Show lore activity log
   import              Import knowledge from prior AI agent conversations
   data <subcommand>   Manage stored data (list, show, clear, delete)
@@ -62,7 +62,7 @@ Examples:
   lore                          # Auto-detect agent and launch with gateway
   lore run claude               # Launch Claude Code through the gateway
   lore run opencode             # Launch OpenCode through the gateway
-  lore start                    # Start gateway only (set ANTHROPIC_BASE_URL yourself)
+  lore start                    # Start gateway without launching an agent
   lore start -p 8080            # Start gateway on a custom port
   lore start -H 127.0.0.1 -H 100.69.65.125  # Bind to multiple interfaces
   lore start -H 127.0.0.1,100.69.65.125     # Same, comma-separated

--- a/packages/gateway/src/cli/main.ts
+++ b/packages/gateway/src/cli/main.ts
@@ -5,7 +5,7 @@
  *
  * Commands:
  *   (none) / run   → start gateway + launch agent
- *   start          → start gateway server only
+ *   start          → start gateway server (no agent auto-launch)
  *   data           → inspect and manage stored data
  *   recall         → search project memory from the terminal
  *   upgrade        → self-update

--- a/packages/gateway/src/cli/run.ts
+++ b/packages/gateway/src/cli/run.ts
@@ -138,8 +138,8 @@ export async function commandRun(
   const target = await resolveLaunchTarget(gatewayUrl, cmdArgs);
 
   if (!target) {
-    // No agent found / non-interactive — fall back to server-only mode
-    console.log("[lore] Running in server-only mode. Point your agent at the gateway manually.");
+    // No agent found — start server without launching an agent
+    console.log("[lore] No agent detected. Point your agent at the gateway manually.");
     console.log(`[lore]   export ANTHROPIC_BASE_URL=${gatewayUrl}`);
 
     if (owned) {

--- a/packages/gateway/src/cli/start.ts
+++ b/packages/gateway/src/cli/start.ts
@@ -1,5 +1,5 @@
 /**
- * `lore start` — start the gateway server only.
+ * `lore start` — start the gateway server without auto-launching an agent.
  *
  * Extracted from the old top-level index.ts boot logic.
  */

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -36,8 +36,8 @@ export { _cli } from "./cli/main";
 
 if (typeof Bun !== "undefined" && Bun.main === import.meta.path) {
   // Direct execution (e.g. `bun run src/index.ts` from the OpenCode plugin)
-  // defaults to server-only mode (`start`), not `run` — there's no TTY and
-  // no reason to auto-detect agents when launched as an embedded server.
+  // defaults to `start` (no agent auto-launch), not `run` — there's no TTY
+  // and no reason to auto-detect agents when launched as an embedded server.
   // esbuild CJS output drops import.meta to `{}` so the condition is
   // always false in the npm bundle — the await is dead-code-eliminated.
   import("./cli/start").then(({ commandStart }) => commandStart({ quiet: true }));

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -97,28 +97,29 @@ async function startInProcess(): Promise<string | null> {
 
 // Process-wide initialization state — shared across all sessions.
 // The plugin function is called once per OpenCode session/project, but
-// gateway detection only needs to run once per process.
+// lore init only needs to run once per process.
 let processInitDone = false;
-let processGatewayActive = false;
-let processGatewayBase = "";
+let processLoreActive = false;
+let processLoreBase = "";
 
-/** Memoized gateway init promise — ensures concurrent plugin calls don't race. */
-let gatewayInitPromise: Promise<string | null> | null = null;
+/** Memoized lore init promise — ensures concurrent plugin calls don't race. */
+let loreInitPromise: Promise<string | null> | null = null;
 
 export const LorePlugin: Plugin = async (ctx) => {
-  // Determine if the gateway is active — only probe once per process.
-  let gatewayActive = processGatewayActive;
-  let gatewayBase = processGatewayBase;
+  // Initialize lore — only probe/start once per process.
+  const loreDisabled =
+    process.env.LORE_DISABLED === "1" || process.env.LORE_DISABLED === "true";
+  let loreActive = processLoreActive;
+  let gatewayBase = processLoreBase;
   if (!processInitDone) {
     const inTestEnv =
       process.env.NODE_ENV === "test" ||
-      process.env.LORE_GATEWAY_MODE === "test" ||
       process.argv.some((a) => a.includes(".test."));
 
-    if (process.env.LORE_GATEWAY_MODE !== "0" && !inTestEnv) {
+    if (!loreDisabled && !inTestEnv) {
       // Memoize so concurrent LorePlugin calls don't race on probe→spawn.
-      if (!gatewayInitPromise) {
-        gatewayInitPromise = (async () => {
+      if (!loreInitPromise) {
+        loreInitPromise = (async () => {
           // Try to find a running gateway first (probes port file + known ports).
           const existingUrl = await resolveGatewayUrl();
           if (existingUrl) {
@@ -135,24 +136,23 @@ export const LorePlugin: Plugin = async (ctx) => {
           return null;
         })();
       }
-      const result = await gatewayInitPromise;
+      const result = await loreInitPromise;
       if (result) {
-        gatewayActive = true;
+        loreActive = true;
         gatewayBase = result;
       }
     }
-    processGatewayActive = gatewayActive;
-    processGatewayBase = gatewayBase;
+    processLoreActive = loreActive;
+    processLoreBase = gatewayBase;
   }
 
-  if (!gatewayActive && process.env.LORE_GATEWAY_MODE !== "0") {
+  if (!loreActive && !loreDisabled) {
     const inTestEnv =
       process.env.NODE_ENV === "test" ||
-      process.env.LORE_GATEWAY_MODE === "test" ||
       process.argv.some((a) => a.includes(".test."));
     if (!inTestEnv) {
-      const msg = "Lore gateway failed to start — memory features are unavailable. " +
-        "Ensure @loreai/gateway is installed or start the gateway manually.";
+      const msg = "Lore failed to start — memory features are unavailable. " +
+        "Ensure @loreai/gateway is installed.";
       process.stderr.write(`[lore] ERROR: ${msg}\n`);
       log.error(msg);
     }
@@ -181,7 +181,7 @@ export const LorePlugin: Plugin = async (ctx) => {
         },
       };
 
-      if (gatewayActive) {
+      if (loreActive) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const p = cfg.provider as Record<string, any> ?? {};
         cfg.provider = p;
@@ -207,8 +207,8 @@ export const LorePlugin: Plugin = async (ctx) => {
     const projectPath = ctx.worktree || ctx.directory;
     process.stderr.write(`[lore] active: ${projectPath}\n`);
 
-    if (gatewayActive) {
-      process.stderr.write(`[lore] gateway mode — routing through ${gatewayBase}\n`);
+    if (loreActive) {
+      process.stderr.write(`[lore] routing through ${gatewayBase}\n`);
       process.stderr.write(`[lore] dashboard: ${gatewayBase}/ui\n`);
     }
 

--- a/packages/opencode/test/index.test.ts
+++ b/packages/opencode/test/index.test.ts
@@ -117,7 +117,7 @@ describe("LorePlugin hooks", () => {
     try {
       expect(hooks.config).toBeDefined();
       expect(hooks.tool).toBeDefined();
-      // All standalone-mode hooks should be stripped
+      // Only config, tool, and chat.headers hooks should be registered
       expect(hooks.event).toBeUndefined();
       expect(hooks["experimental.chat.system.transform"]).toBeUndefined();
       expect(hooks["experimental.chat.messages.transform"]).toBeUndefined();

--- a/packages/pi/src/index.ts
+++ b/packages/pi/src/index.ts
@@ -1,17 +1,17 @@
 /**
  * @loreai/pi — Lore memory engine as a Pi coding-agent extension.
  *
- * On startup, the extension probes for an existing Lore gateway and, if
- * none is found, starts one in-process by importing @loreai/gateway.
- * It then redirects compatible provider URLs through the gateway and
- * registers a single Pi-specific hook (session_before_compact) that the
- * gateway cannot handle via HTTP interception. All other memory features
- * (LTM injection, gradient transforms, temporal capture, recall, idle
- * work) are handled exclusively by the gateway pipeline.
+ * On startup, the extension probes for an existing Lore gateway server
+ * and, if none is found, starts one in-process by importing
+ * @loreai/gateway. It then redirects compatible provider URLs through
+ * the gateway and registers a Pi-specific compaction hook
+ * (session_before_compact) that requires Pi's extension API. All other
+ * memory features (LTM injection, gradient transforms, temporal capture,
+ * recall, idle work) are handled by the gateway pipeline.
  *
- * If the gateway cannot be started, the extension logs an error and
- * becomes inert — no hooks are registered and Pi runs without memory
- * features.
+ * If the gateway server cannot be reached, the extension logs an error
+ * and becomes inert — no hooks are registered and Pi runs without
+ * memory features.
  *
  * Installation (in user's `~/.pi/agent/extensions/`):
  *   import lore from "@loreai/pi";
@@ -172,18 +172,18 @@ function sessionIDFor(sessionFile: string | undefined): string {
  */
 export default async function lorePiExtension(pi: ExtensionAPI): Promise<void> {
   let gatewayBase = "";
-  let gatewayActive = false;
-  const inTestEnv =
-    process.env.NODE_ENV === "test" ||
-    process.env.LORE_GATEWAY_MODE === "test";
+  let loreActive = false;
+  const loreDisabled =
+    process.env.LORE_DISABLED === "1" || process.env.LORE_DISABLED === "true";
+  const inTestEnv = process.env.NODE_ENV === "test";
 
-  if (process.env.LORE_GATEWAY_MODE !== "0" && !inTestEnv) {
+  if (!loreDisabled && !inTestEnv) {
     // Try to find a running gateway first (probes port file + known ports).
     const existingUrl = await resolveGatewayUrl();
     if (existingUrl) {
       console.info(`pi: gateway detected at ${existingUrl}`);
       gatewayBase = existingUrl;
-      gatewayActive = true;
+      loreActive = true;
     } else {
       // No running gateway — start one in-process (handles fallback chain).
       console.info("pi: starting gateway in-process…");
@@ -191,22 +191,22 @@ export default async function lorePiExtension(pi: ExtensionAPI): Promise<void> {
       if (startedUrl) {
         console.info(`pi: gateway started in-process at ${startedUrl}`);
         gatewayBase = startedUrl;
-        gatewayActive = true;
+        loreActive = true;
       }
     }
   }
 
-  if (!gatewayActive && !inTestEnv && process.env.LORE_GATEWAY_MODE !== "0") {
+  if (!loreActive && !inTestEnv && !loreDisabled) {
     const msg =
-      "Lore gateway failed to start — memory features are unavailable. " +
-      "Ensure @loreai/gateway is installed or start the gateway manually.";
+      "Lore failed to start — memory features are unavailable. " +
+      "Ensure @loreai/gateway is installed.";
     console.error("pi:", msg);
     return;
   }
 
-  if (!gatewayActive) return;
+  if (!loreActive) return;
 
-  console.info(`pi: gateway active — routing providers through ${gatewayBase}`);
+  console.info(`pi: routing providers through ${gatewayBase}`);
 
   // ---------------------------------------------------------------------------
   // Session tracking — used for provider header injection and compaction.


### PR DESCRIPTION
## Summary

- Remove all language implying the gateway is optional or one of multiple modes — it's been the sole mode since plugins were stripped to gateway-only
- Rename `LORE_GATEWAY_MODE` env var to `LORE_DISABLED` (set to `"1"` or `"true"` to disable)
- Clean up plugin startup banners, error messages, CLI help text, and internal variable names

## Changes

**Plugins** (`packages/opencode/src/index.ts`, `packages/pi/src/index.ts`):
- Banner: `"gateway mode — routing through"` → `"routing through"`
- Error: `"Lore gateway failed to start…start the gateway manually"` → `"Lore failed to start…Ensure @loreai/gateway is installed."`
- Env var: `LORE_GATEWAY_MODE` → `LORE_DISABLED` with explicit value check (`=== "1" || === "true"`); dropped redundant test-env check (covered by `NODE_ENV`)
- Variables: `gatewayActive` → `loreActive`, `processGatewayActive` → `processLoreActive`, etc.
- Separated `loreDisabled` and `inTestEnv` into distinct concerns (previously conflated)

**Gateway CLI** (`run.ts`, `start.ts`, `help.ts`, `main.ts`, `index.ts`):
- `"server-only mode"` → `"without launching an agent"` / `"no agent auto-launch"`

**Other** (`batch-queue.ts`, `types.ts`, `AGENTS.md`):
- Removed "gateway-only enhancement" framing
- `"Standalone: direct fetch()"` → `"Gateway: direct fetch()"`

## Breaking change

`LORE_GATEWAY_MODE=0` no longer works — use `LORE_DISABLED=1` instead. This env var was undocumented and internal-only.