### PR TITLE
fix: cache inferred project path in session state to avoid cwd fallback

### DIFF
--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -169,33 +169,41 @@ export function inferProjectPath(systemPrompt: string): string | null {
 // getProjectPath
 // ---------------------------------------------------------------------------
 
+export type ProjectPathSource = "header" | "inferred" | "cwd";
+
+export type ProjectPathResult = {
+  path: string;
+  source: ProjectPathSource;
+};
+
 /**
  * Resolve the project path for a request. Checks in order:
  *  1. `X-Lore-Project` header (explicit override)
  *  2. `inferProjectPath(systemPrompt)` (zero-config extraction)
  *  3. `process.cwd()` (last resort fallback)
+ *
+ * Returns a `{ path, source }` tuple so callers can distinguish a
+ * successful resolution from a cwd fallback and take corrective action
+ * (e.g. upgrading from session-cached state).
+ *
+ * NOTE: The cwd fallback does NOT log a warning — callers are responsible
+ * for logging after any post-hoc upgrades (e.g. from session state) so
+ * the warning only fires when the fallback truly sticks.
  */
 export function getProjectPath(
   systemPrompt: string,
   headers: Record<string, string>,
-): string {
+): ProjectPathResult {
   // 1. Explicit header override
   const headerPath = headers["x-lore-project"];
-  if (headerPath) return headerPath;
+  if (headerPath) return { path: headerPath, source: "header" };
 
   // 2. Infer from system prompt content
   const inferred = inferProjectPath(systemPrompt);
-  if (inferred) return inferred;
+  if (inferred) return { path: inferred, source: "inferred" };
 
-  // 3. Fall back to gateway's own cwd — log a warning since this may
-  // misattribute data when the gateway runs as a hosted service.
-  const cwd = process.cwd();
-  console.error(
-    `[lore] warning: project path falling back to process.cwd() (${cwd}). ` +
-    `Data may be misattributed. Set X-Lore-Project header or include a working ` +
-    `directory in the system prompt to fix this.`,
-  );
-  return cwd;
+  // 3. Fall back to gateway's own cwd
+  return { path: process.cwd(), source: "cwd" };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -56,7 +56,7 @@ import type {
   SessionState,
 } from "./translate/types";
 import type { GatewayConfig } from "./config";
-import { getProjectPath, resolveUpstreamRoute } from "./config";
+import { getProjectPath, resolveUpstreamRoute, type ProjectPathResult } from "./config";
 import {
   generateSessionID,
   fingerprintMessages,
@@ -593,6 +593,54 @@ function getLLMClient(config: GatewayConfig): LLMClient {
     }
   }
   return llmClient;
+}
+
+// ---------------------------------------------------------------------------
+// Project path resolution with session cache
+// ---------------------------------------------------------------------------
+
+/**
+ * Upgrade a project path result using the session's cached path.
+ *
+ * Some requests (e.g. Claude Code's non-streaming prompt-caching probes)
+ * have stripped-down system prompts that lack path references, causing
+ * `getProjectPath()` to fall back to `process.cwd()`. When the session
+ * already has a known-good path from a prior turn, we use that instead.
+ *
+ * Also updates the session cache when a fresh inference or header provides
+ * a new path, so future path-less turns benefit.
+ *
+ * Returns the final resolved project path.
+ */
+export function resolveSessionProjectPath(
+  result: ProjectPathResult,
+  sessionState: SessionState,
+): string {
+  let { path: projectPath, source } = result;
+
+  // Upgrade from cwd fallback using session's cached path
+  if (source === "cwd" && sessionState.projectPath !== projectPath) {
+    projectPath = sessionState.projectPath;
+    source = "cached" as typeof source;
+  }
+
+  // Update session cache when a fresh path was resolved so future
+  // path-less turns benefit from the cached value.
+  if (source === "inferred" || source === "header") {
+    sessionState.projectPath = projectPath;
+  }
+
+  // Log warning only when the cwd fallback truly sticks (no session cache
+  // was available to upgrade from).
+  if (source === "cwd") {
+    console.error(
+      `[lore] warning: project path falling back to process.cwd() (${projectPath}). ` +
+      `Data may be misattributed. Set X-Lore-Project header or include a working ` +
+      `directory in the system prompt to fix this.`,
+    );
+  }
+
+  return projectPath;
 }
 
 // ---------------------------------------------------------------------------
@@ -1959,11 +2007,12 @@ async function handleCompaction(
   req: GatewayRequest,
   config: GatewayConfig,
 ): Promise<Response> {
-  const projectPath = getProjectPath(req.system, req.rawHeaders);
-  await initIfNeeded(projectPath, config);
+  const pathResult = getProjectPath(req.system, req.rawHeaders);
+  await initIfNeeded(pathResult.path, config);
 
-  const { sessionID } = await identifySession(req, projectPath);
-  const sessionState = getOrCreateSession(sessionID, projectPath);
+  const { sessionID } = await identifySession(req, pathResult.path);
+  const sessionState = getOrCreateSession(sessionID, pathResult.path);
+  const projectPath = resolveSessionProjectPath(pathResult, sessionState);
 
   setSentryLightContext({ model: req.model, projectPath });
   log.info(`compaction intercepted for session ${sessionID.slice(0, 16)}`);
@@ -2168,8 +2217,8 @@ async function handleConversationTurn(
   config: GatewayConfig,
 ): Promise<Response> {
   // --- 1. Project path & init ---
-  const projectPath = getProjectPath(req.system, req.rawHeaders);
-  await initIfNeeded(projectPath, config);
+  const pathResult = getProjectPath(req.system, req.rawHeaders);
+  await initIfNeeded(pathResult.path, config);
 
   // --- 2. Capture auth credentials for background workers ---
   const cred = extractAuth(req.rawHeaders);
@@ -2178,8 +2227,9 @@ async function handleConversationTurn(
   }
 
   // --- 3. Session identification ---
-  const { sessionID, isNew, tier } = await identifySession(req, projectPath);
-  const sessionState = getOrCreateSession(sessionID, projectPath);
+  const { sessionID, isNew, tier } = await identifySession(req, pathResult.path);
+  const sessionState = getOrCreateSession(sessionID, pathResult.path);
+  const projectPath = resolveSessionProjectPath(pathResult, sessionState);
 
   // Detect sub-agent turns (e.g. OpenCode explore/general agents) that were
   // merged into the parent session via x-parent-session-id.  These turns

--- a/packages/gateway/test/project-path.test.ts
+++ b/packages/gateway/test/project-path.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "bun:test";
 import { inferProjectPath, getProjectPath } from "../src/config";
+import { resolveSessionProjectPath } from "../src/pipeline";
 
 // ---------------------------------------------------------------------------
 // inferProjectPath
@@ -95,7 +96,7 @@ describe("getProjectPath", () => {
       `Working directory: /home/user/inferred-project`,
       { "x-lore-project": "/home/user/explicit-project" },
     );
-    expect(result).toBe("/home/user/explicit-project");
+    expect(result).toEqual({ path: "/home/user/explicit-project", source: "header" });
   });
 
   test("falls back to inferProjectPath when no header", () => {
@@ -103,12 +104,12 @@ describe("getProjectPath", () => {
       `Working directory: /home/user/inferred-project`,
       {},
     );
-    expect(result).toBe("/home/user/inferred-project");
+    expect(result).toEqual({ path: "/home/user/inferred-project", source: "inferred" });
   });
 
   test("falls back to process.cwd() when neither header nor inference match", () => {
     const result = getProjectPath("You are a helpful assistant.", {});
-    expect(result).toBe(process.cwd());
+    expect(result).toEqual({ path: process.cwd(), source: "cwd" });
   });
 
   test("ignores empty X-Lore-Project header", () => {
@@ -116,6 +117,76 @@ describe("getProjectPath", () => {
       `Working directory: /home/user/project`,
       { "x-lore-project": "" },
     );
-    expect(result).toBe("/home/user/project");
+    expect(result).toEqual({ path: "/home/user/project", source: "inferred" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveSessionProjectPath
+// ---------------------------------------------------------------------------
+
+describe("resolveSessionProjectPath", () => {
+  function makeSessionState(projectPath: string) {
+    return { projectPath } as any;
+  }
+
+  test("upgrades cwd fallback to session's cached path", () => {
+    const state = makeSessionState("/home/user/real-project");
+    const result = resolveSessionProjectPath(
+      { path: process.cwd(), source: "cwd" },
+      state,
+    );
+    expect(result).toBe("/home/user/real-project");
+  });
+
+  test("keeps cwd when session has the same path (no upgrade available)", () => {
+    const cwd = process.cwd();
+    const state = makeSessionState(cwd);
+    const result = resolveSessionProjectPath(
+      { path: cwd, source: "cwd" },
+      state,
+    );
+    expect(result).toBe(cwd);
+  });
+
+  test("uses inferred path and updates session cache", () => {
+    const state = makeSessionState("/home/user/old-project");
+    const result = resolveSessionProjectPath(
+      { path: "/home/user/new-project", source: "inferred" },
+      state,
+    );
+    expect(result).toBe("/home/user/new-project");
+    expect(state.projectPath).toBe("/home/user/new-project");
+  });
+
+  test("uses header path and updates session cache", () => {
+    const state = makeSessionState("/home/user/old-project");
+    const result = resolveSessionProjectPath(
+      { path: "/home/user/header-project", source: "header" },
+      state,
+    );
+    expect(result).toBe("/home/user/header-project");
+    expect(state.projectPath).toBe("/home/user/header-project");
+  });
+
+  test("does not update session cache on cwd fallback", () => {
+    const state = makeSessionState("/home/user/real-project");
+    resolveSessionProjectPath(
+      { path: process.cwd(), source: "cwd" },
+      state,
+    );
+    // Session cache should remain unchanged (upgraded, not overwritten)
+    expect(state.projectPath).toBe("/home/user/real-project");
+  });
+
+  test("does not update session cache when upgrade from cwd occurs", () => {
+    const state = makeSessionState("/home/user/cached-project");
+    const result = resolveSessionProjectPath(
+      { path: "/tmp/wrong", source: "cwd" },
+      state,
+    );
+    expect(result).toBe("/home/user/cached-project");
+    // Session cache should remain unchanged
+    expect(state.projectPath).toBe("/home/user/cached-project");
   });
 });


### PR DESCRIPTION
## Summary

- `getProjectPath()` now returns a `{ path, source }` tuple so callers can distinguish successful inference from a `process.cwd()` fallback
- New `resolveSessionProjectPath()` helper upgrades cwd fallbacks from the session's cached path and updates the cache when fresh inference succeeds
- Warning only fires when the cwd fallback truly sticks (no session cache available)

## Problem

When Claude Code sends requests through the lore gateway, it alternates between streaming conversation turns (with full system prompts containing `Primary working directory:`) and non-streaming caching probes (`stream=false, messages=1`, ~4K token stripped system prompt lacking path references). The caching probes aren't classified as meta requests (they have many tools and high maxTokens), so they go through `handleConversationTurn` where `getProjectPath()` falls back to `process.cwd()` — even though the session already has the correct path from an earlier streaming turn.

This causes `[lore] warning: project path falling back to process.cwd()` on every other turn and can misattribute data to the wrong project via `ensureProject()`.

## Changes

| File | Change |
|---|---|
| `packages/gateway/src/config.ts` | `getProjectPath()` returns `ProjectPathResult` tuple; warning moved to call sites |
| `packages/gateway/src/pipeline.ts` | `resolveSessionProjectPath()` helper; used in both `handleConversationTurn` and `handleCompaction` |
| `packages/gateway/test/project-path.test.ts` | Tests for new return type + 6 `resolveSessionProjectPath` tests covering upgrade, cache writeback, and no-upgrade scenarios |