### PR TITLE
feat(warming): replace per-window survival with commitment-based warming model

### DIFF
--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -422,7 +422,7 @@ export function expectedWarmupCycles(
 ): number {
   // S(elapsed) — probability of still being idle at current time
   const sNow = survivalFunction(hist, elapsedMs);
-  if (sNow < 0.001) return maxCycles; // essentially dead — assume worst case
+  if (sNow < 0.001) return maxCycles + 1; // essentially dead — exceeds budget to trigger cap
 
   let expected = 0;
 
@@ -866,9 +866,16 @@ export function computeWarmingSnapshot(
     } else if (!profile) {
       notWarmingReason = "No warming profile (non-Anthropic or unknown model)";
     } else if (state.warmup?.forceKeepWarm) {
-      const intoWindow = idleMs % ttlMs;
-      if (intoWindow < ttlMs - warmupMarginMs) {
-        notWarmingReason = "Force-keep: not in warmup window yet";
+      const maxCyc = maxProfitableCycles(profile.cacheReadCostPerMTok, profile.cacheMissCostPerMTok);
+      if (cyclesSpent >= maxCyc) {
+        notWarmingReason = `Force-keep: break-even exceeded (${cyclesSpent} >= ${maxCyc} cycles)`;
+      } else {
+        const intoWindow = idleMs % ttlMs;
+        if (intoWindow < ttlMs - warmupMarginMs) {
+          notWarmingReason = "Force-keep: not in warmup window yet";
+        } else {
+          notWarmingReason = "Force-keep: cooldown active";
+        }
       }
     } else if (state.warmup?.lastWarmupAt && now - state.warmup.lastWarmupAt < cooldownFor(state, ttlMs, warmupMarginMs)) {
       notWarmingReason = "Already warmed in this TTL window";

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -1809,7 +1809,9 @@ function postResponse(
     // Reset warming state if session was marked dead or had active warming.
     // Dead flag is cleared so the next break gets a fresh ROI analysis.
     // warmupCount is reset so the break-even cap starts from 0 on the next break.
-    if (sessionState.warmup) {
+    // Guard: only real user turns should reset — subagent turns would falsely
+    // clear the break-even counter and re-enable dead sessions.
+    if (!isSubagentTurn && sessionState.warmup) {
       if (sessionState.warmup.disabled) {
         sessionState.warmup.disabled = false;
         log.info(

--- a/packages/gateway/src/ui.ts
+++ b/packages/gateway/src/ui.ts
@@ -1228,7 +1228,7 @@ function pageWarming(): string {
         <th data-sort="num">Idle</th>
         <th data-sort="text">TTL</th>
         <th data-sort="num">S(t)</th>
-        <th data-sort="num">P(return)</th>
+        <th data-sort="num">P(returns)</th>
         <th data-sort="text">Status</th>
         <th data-sort="num">Warmups</th>
         <th data-sort="num">Hits</th>
@@ -1240,7 +1240,7 @@ function pageWarming(): string {
         <td>${formatDuration(snap.idleMs)}</td>
         <td>${snap.ttl ?? "5m"}</td>
         <td>${(snap.survivalAtIdle * 100).toFixed(1)}%</td>
-        <td>${(snap.pReturnDampened * 100).toFixed(1)}%</td>
+        <td>${(snap.pReturns * 100).toFixed(1)}%</td>
         <td>${warmingStatusBadge(snap)}</td>
         <td>${snap.warmupCount}</td>
         <td>${snap.warmupHits}</td>

--- a/packages/gateway/test/cache-warmer.test.ts
+++ b/packages/gateway/test/cache-warmer.test.ts
@@ -947,12 +947,12 @@ describe("pSessionFinished", () => {
 });
 
 describe("expectedWarmupCycles", () => {
-  test("all short gaps → max cycles (nobody returns late)", () => {
+  test("all short gaps → exceeds max cycles (nobody returns late)", () => {
     const hist = createHistogram();
     for (let i = 0; i < 100; i++) recordGap(hist, 5_000);
-    // At 270s idle, survival is ~0 → max cycles (worst case)
+    // At 270s idle, survival is ~0 → returns maxCycles+1 to trigger cap
     const cycles = expectedWarmupCycles(hist, 270_000, 300_000, 11);
-    expect(cycles).toBe(11);
+    expect(cycles).toBe(12); // maxCycles + 1
   });
 
   test("all long gaps → low expected cycles (user returns soon)", () => {
@@ -970,9 +970,10 @@ describe("expectedWarmupCycles", () => {
     expect(cycles).toBeLessThanOrEqual(5);
   });
 
-  test("empty histogram returns max cycles (optimistic survival)", () => {
+  test("empty histogram returns max cycles (flat survival = 1.0 everywhere)", () => {
     const hist = createHistogram();
-    // Empty → survival is 1.0 everywhere → user never returns → max cycles
+    // Empty → survival is 1.0 everywhere → P(still idle) = 1.0 for each
+    // future window → we pay for every cycle → accumulates to maxCycles
     const cycles = expectedWarmupCycles(hist, 270_000, 300_000, 11);
     expect(cycles).toBe(11);
   });


### PR DESCRIPTION
## Summary

- **Bug fix**: 1h TTL `cache_write` cost now correctly uses 2× base price in `buildAnthropicProfile()` — was using the 5m price for both tiers
- **Bug fix**: Cost threshold corrected from `read/write` to `read/(write-read)`, accounting for the cache read paid on user return (~8.7% for 5m TTL, ~4.2% for 1h TTL)
- **Bug fix**: `/keep` mode now respects break-even cap — was running indefinitely (e.g. 2 hours on a 5m TTL session)
- **New model**: Replaces per-window survival analysis with a two-phase commitment model that fuses multiple signals (survival, text-only turns, break fraction, session length) to decide whether to warm, then enforces a hard break-even cap across continuation windows

### Key behavioral changes

| TTL | Max cycles | Max warming duration |
|-----|-----------|---------------------|
| 5m  | 11        | ~55 minutes         |
| 1h  | 24        | ~24 hours           |

### New helpers

- `breakFraction()` — splits histogram at 3min floor (active coding vs breaks)
- `pSessionFinished()` — log-linear signal fusion with sigmoid output
- `expectedWarmupCycles()` — forward-looking cost via conditional survival
- `costThreshold()` / `maxProfitableCycles()` — corrected cost model

### Other changes

- Pipeline resets `warmupCount` on user return for fresh break-even analysis
- Dashboard shows new commitment model fields (P(finished), P(returns), break fraction, cycles spent/max, warming phase)
- Config comment updated with corrected threshold values