### PR TITLE
feat(cli): forward extra arguments to launched agent

### DIFF
--- a/packages/gateway/src/cli/help.ts
+++ b/packages/gateway/src/cli/help.ts
@@ -10,7 +10,8 @@ Usage:
   lore [command] [options]
 
 Commands:
-  run [command...]    Start gateway and launch an AI agent (default)
+  run [command] [args...]  Start gateway and launch an AI agent (default)
+                           Extra arguments are forwarded to the launched agent
   start               Start the gateway server (without launching an agent)
   logs                Show lore activity log
   import              Import knowledge from prior AI agent conversations
@@ -51,6 +52,16 @@ Import options:
   --project <path>              Target project (default: cwd)
   --dry-run                     Show what would be imported, no LLM calls
 
+Agent arguments:
+  Arguments after the agent name are forwarded to the launched agent:
+    lore run claude --dangerously-skip-permissions
+    lore claude --model gpt-4
+  Without an agent name, unknown flags are forwarded to the auto-detected agent:
+    lore --dangerously-skip-permissions
+  Use -- to also forward flags that share names with lore's own options:
+    lore -- --verbose --debug
+    lore run -- --port 8080
+
 Recall options:
   --project <path>              Target project (default: cwd)
   --scope <scope>               all (default), session, project, knowledge
@@ -62,6 +73,10 @@ Examples:
   lore                          # Auto-detect agent and launch with gateway
   lore run claude               # Launch Claude Code through the gateway
   lore run opencode             # Launch OpenCode through the gateway
+  lore --dangerously-skip-permissions          # Forward flags to auto-detected agent
+  lore claude --dangerously-skip-permissions  # Forward flags to Claude Code
+  lore run claude --model gpt-4              # Forward --model gpt-4 to claude
+  lore -- --verbose --debug                  # Use -- to forward lore-like flags
   lore start                    # Start gateway without launching an agent
   lore start -p 8080            # Start gateway on a custom port
   lore start -H 127.0.0.1 -H 100.69.65.125  # Bind to multiple interfaces

--- a/packages/gateway/src/cli/main.ts
+++ b/packages/gateway/src/cli/main.ts
@@ -25,6 +25,66 @@ import {
 // Argument parsing
 // ---------------------------------------------------------------------------
 
+/** Token from `parseArgs` with `tokens: true`. */
+interface ParseToken {
+  kind: "option" | "positional" | "option-terminator";
+  index: number;
+  name?: string;
+  rawName?: string;
+  value?: string;
+  inlineValue?: boolean;
+}
+
+/** Set of option names defined in OPTIONS — used to detect unknown flags. */
+const KNOWN_OPTIONS = new Set<string>();
+
+/**
+ * Extract arguments that should be forwarded to the launched agent.
+ *
+ * Strategy:
+ * 1. If `--` is present, everything after it is the agent's.
+ * 2. If an agent/command positional is found, slice raw `argv` from one past
+ *    it — everything after the agent name is the agent's. This avoids
+ *    parseArgs's inability to handle unknown value-bearing flags
+ *    (e.g. `--model gpt-4`).
+ * 3. In auto-detect mode (no agent name, no `--`), reconstruct unknown option
+ *    tokens (flags not in OPTIONS) and forward them. This handles cases like
+ *    `lore --dangerously-skip-permissions` where the flag should reach the
+ *    auto-detected agent.
+ *
+ * Caveat: lore's own known options (--port, --debug, etc.) are consumed by
+ * parseArgs regardless of position. Place them before the agent name, or use
+ * `--` to prevent lore from consuming them.
+ */
+function extractAgentArgs(argv: string[], tokens: ParseToken[]): string[] {
+  // 1. If there is a `--` (option-terminator), everything after it is for the agent.
+  const terminator = tokens.find((t) => t.kind === "option-terminator");
+  if (terminator) {
+    return argv.slice(terminator.index + 1);
+  }
+
+  // 2. Find the agent/command positional — the first positional that is NOT "run".
+  const positionalTokens = tokens.filter((t) => t.kind === "positional");
+  for (const pt of positionalTokens) {
+    if (pt.value === "run") continue;
+    // This is the agent/command name. Everything after it in raw argv is the agent's.
+    return argv.slice(pt.index + 1);
+  }
+
+  // 3. Auto-detect with no agent name — collect unknown option tokens.
+  //    Unknown flags (not in OPTIONS) are reconstructed from their rawName
+  //    and forwarded to the agent. parseArgs treats all unknown flags as
+  //    booleans, so value-bearing flags like `--model gpt-4` cannot be
+  //    reconstructed here — use `--` for those cases.
+  const unknownArgs: string[] = [];
+  for (const t of tokens) {
+    if (t.kind === "option" && t.name && !KNOWN_OPTIONS.has(t.name)) {
+      unknownArgs.push(t.rawName ?? `--${t.name}`);
+    }
+  }
+  return unknownArgs;
+}
+
 /** Options shared by all commands. */
 const OPTIONS = {
   port: { type: "string" as const, short: "p" },
@@ -48,6 +108,13 @@ const OPTIONS = {
   // regressions that --print-vendor-info alone wouldn't surface.
   "check-embeddings": { type: "boolean" as const },
 } as const;
+
+// Populate the set used by extractAgentArgs to distinguish lore's own flags
+// from unknown flags that should be forwarded to the agent.
+for (const [name, def] of Object.entries(OPTIONS)) {
+  KNOWN_OPTIONS.add(name);
+  if ("short" in def && def.short) KNOWN_OPTIONS.add(def.short);
+}
 
 function parsePort(value: string): number {
   const n = Number.parseInt(value, 10);
@@ -78,19 +145,24 @@ function buildStartOptions(values: {
 // ---------------------------------------------------------------------------
 
 export async function _cli(): Promise<void> {
-  // Parse known options, allow positional args for command + pass-through
+  // Parse known options, allow positional args for command + pass-through.
+  // `tokens: true` gives us index information needed to extract agent args.
   let values: ReturnType<typeof parseArgs>["values"];
   let positionals: string[];
+  let tokens: ParseToken[];
+  const argv = process.argv.slice(2);
 
   try {
     const parsed = parseArgs({
-      args: process.argv.slice(2),
+      args: argv,
       options: OPTIONS,
       allowPositionals: true,
       strict: false,
+      tokens: true,
     });
     values = parsed.values;
     positionals = parsed.positionals;
+    tokens = parsed.tokens as ParseToken[];
   } catch (e) {
     console.error(`Error: ${e instanceof Error ? e.message : e}`);
     printHelp();
@@ -176,7 +248,10 @@ export async function _cli(): Promise<void> {
         // Lazy-import to avoid pulling in child_process + agent detection
         // when only `lore start` or `lore help` is needed.
         const { commandRun } = await import("./run");
-        await commandRun(startOpts, rest);
+        const agentArgs = extractAgentArgs(argv, tokens);
+        // Pass only the agent name (if any) as cmdArgs; extra flags go via agentArgs.
+        const agentName = rest.length > 0 ? [rest[0]] : [];
+        await commandRun(startOpts, agentName, agentArgs);
         break;
       }
 
@@ -259,7 +334,8 @@ export async function _cli(): Promise<void> {
             break;
           }
           const { commandRun } = await import("./run");
-          await commandRun(startOpts, [command, ...rest]);
+          const agentArgs = extractAgentArgs(argv, tokens);
+          await commandRun(startOpts, [command], agentArgs);
         }
         break;
     }

--- a/packages/gateway/src/cli/run.ts
+++ b/packages/gateway/src/cli/run.ts
@@ -56,6 +56,7 @@ interface LaunchTarget {
 async function resolveLaunchTarget(
   gatewayUrl: string,
   cmdArgs: string[],
+  extraArgs: string[],
 ): Promise<LaunchTarget | null> {
   // --- Explicit command given: inject all known env vars ---
   if (cmdArgs.length > 0) {
@@ -63,7 +64,7 @@ async function resolveLaunchTarget(
     for (const agent of AGENTS) {
       Object.assign(env, agent.envVars(gatewayUrl));
     }
-    return { command: cmdArgs[0], args: cmdArgs.slice(1), env };
+    return { command: cmdArgs[0], args: [...cmdArgs.slice(1), ...extraArgs], env };
   }
 
   // --- No command: auto-detect agents ---
@@ -95,7 +96,7 @@ async function resolveLaunchTarget(
 
   return {
     command: agent.def.binary,
-    args: [],
+    args: [...extraArgs],
     env: agent.def.envVars(gatewayUrl),
   };
 }
@@ -122,6 +123,7 @@ function launchChild(target: LaunchTarget): ChildProcess {
 export async function commandRun(
   opts: StartOptions,
   cmdArgs: string[],
+  extraArgs: string[] = [],
 ): Promise<void> {
   // 1. Start gateway (or reuse an existing one)
   const { config, port, owned, shutdown } = await startGateway(opts);
@@ -138,7 +140,7 @@ export async function commandRun(
   await maybeAutoImport(config);
 
   // 3. Resolve what to launch
-  const target = await resolveLaunchTarget(gatewayUrl, cmdArgs);
+  const target = await resolveLaunchTarget(gatewayUrl, cmdArgs, extraArgs);
 
   if (!target) {
     // No agent found — start server without launching an agent


### PR DESCRIPTION
## Summary

- Allow users to pass flags through to the agent process when using `lore run` or the agent shorthand
- Uses `parseArgs` token stream to identify the agent name position in argv, then slices everything after it as raw passthrough args
- In auto-detect mode (no agent name), unknown flags are reconstructed from the token stream and forwarded
- Supports `--` as separator to forward flags that share names with lore's own options

## Examples

```
lore --dangerously-skip-permissions           # auto-detect agent, forward the flag
lore claude --dangerously-skip-permissions    # forward to claude
lore run claude --model gpt-4                # forward --model gpt-4 to claude
lore --debug claude --flag                   # --debug goes to lore, --flag goes to agent
lore -- --verbose --debug                    # use -- to forward lore-like flags
```

## Changes

- **`main.ts`**: Enable `tokens: true` in `parseArgs`, add `extractAgentArgs()` helper with three strategies:
  1. `--` separator: everything after it goes to the agent
  2. Agent positional found: slice raw argv from after the agent name
  3. Auto-detect (no agent name): reconstruct unknown option tokens and forward them
- **`run.ts`**: Accept and forward `extraArgs` parameter through `commandRun` → `resolveLaunchTarget` → `launchChild`
- **`help.ts`**: Document argument forwarding with an "Agent arguments" section and new examples

## Known Limitations

- In auto-detect mode without `--`, only boolean-style flags (e.g. `--dangerously-skip-permissions`) can be forwarded. Value-bearing flags like `--model gpt-4` cannot be reconstructed because `parseArgs` treats unknown flags as booleans and separates the value as a positional. Use `--` for those: `lore -- --model gpt-4`
- Flags that match lore's own options (`--port`, `--debug`, `--host`) are consumed by lore regardless of position. Use `--` to prevent this: `lore run claude -- --port 8080`