### PR TITLE
fix: raise default maxListeners to suppress benign gz stream warning

### DIFF
--- a/packages/gateway/instrument.ts
+++ b/packages/gateway/instrument.ts
@@ -20,6 +20,13 @@
  * does not support top-level await. The modules are loaded but
  * Sentry.init() only runs when the gate passes.
  */
+// Bun's internal fetch creates a zlib.Gunzip stream for gzip-compressed
+// upstream responses. The Web Streams adapter + OpenCode's Effect-TS runtime
+// attach 11 listeners (1 above the default limit of 10), triggering a benign
+// MaxListenersExceededWarning once per process. Raise the default slightly.
+import { setMaxListeners } from "node:events";
+setMaxListeners(15);
+
 import * as Sentry from "@sentry/bun";
 import { log } from "@loreai/core";
 import { VERSION } from "./src/cli/version";


### PR DESCRIPTION
## Summary

- Raises `events.defaultMaxListeners` from 10 to 15 in `packages/gateway/instrument.ts` to eliminate a benign `MaxListenersExceededWarning` that fires once per OpenCode session.

## Root Cause

When the gateway runs in-process inside OpenCode (Bun), upstream `fetch()` calls receive gzip-compressed responses. Bun's internal fetch creates a `zlib.Gunzip` transform stream, and the Web Streams adapter + OpenCode's Effect-TS runtime attach 11 listeners to it — 1 above the default limit of 10.

Logs confirm this is **not a leak**: exactly 1 warning per process (4 occurrences across 4 PIDs over a week), always exactly 11 listeners, never growing. All listeners are cleaned up when the response body is consumed.

## Fix

Two lines at the top of `instrument.ts`:

```typescript
import { setMaxListeners } from "node:events";
setMaxListeners(15);
```

15 is still low enough to catch real leaks (which grow to hundreds).