### PR TITLE
feat: re-run forSession() for fresh LTM on Layer 4 emergency reset

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -40,7 +40,7 @@
 ### Decision
 
 <!-- lore:019e25cb-9065-73a0-8c09-085cf76c0235 -->
-* **Switched from plan (read-only) to build (file edits**: switched from plan (read-only) to build (file edits,
+* **Switched from plan (read-only) to build (file edits**: switched from plan to build — file changes,
 
 <!-- lore:019e1df9-df5a-70b7-aa49-0f569fa9ea01 -->
 * **Switched from relaxed (AND→OR cascade) to direct OR semantics for recall-oriented matching of paraphrased instructions; rationale: repetition detection needs recall**: switched from relaxed (AND→OR cascade) to direct OR semantics for recall-oriented matching of paraphrased instructions; rationale: repetition detection needs recall,

--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -1413,7 +1413,7 @@ function tryFitStable(input: {
   rawBudget: number;
   sessionID: string;
   sessState: SessionState;
-}): Omit<TransformResult, "layer" | "usable" | "distilledBudget" | "rawBudget"> | null {
+}): Omit<TransformResult, "layer" | "usable" | "distilledBudget" | "rawBudget" | "refreshLtm"> | null {
   // If the prefix already overflows its budget there's no point trying.
   if (input.prefixTokens > input.distilledBudget && input.prefix.length > 0)
     return null;
@@ -1543,6 +1543,10 @@ export type TransformResult = {
   usable: number;
   distilledBudget: number;
   rawBudget: number;
+  // Signals that the pipeline should re-run forSession() to refresh LTM
+  // relevance scoring. Set on Layer 4 (emergency) where the context is
+  // fully reset and mid-session knowledge may have changed relevance.
+  refreshLtm: boolean;
 };
 
 // Per-session urgent distillation tracking.
@@ -1719,6 +1723,7 @@ function transformInner(input: {
       usable,
       distilledBudget,
       rawBudget,
+      refreshLtm: false,
     };
   }
 
@@ -1773,7 +1778,7 @@ function transformInner(input: {
 
     // Stage 0 (layer 1) uses tryFitStable for Approach B pin cache.
     // Higher stages reset the raw window cache and use plain tryFit.
-    let result: Omit<TransformResult, "layer" | "usable" | "distilledBudget" | "rawBudget"> | null;
+    let result: Omit<TransformResult, "layer" | "usable" | "distilledBudget" | "rawBudget" | "refreshLtm"> | null;
     if (stage.useStableWindow && sid) {
       result = tryFitStable({
         messages: dedupMessages,
@@ -1806,7 +1811,7 @@ function transformInner(input: {
       if (sid && (s > 0 || cached.tokens === 0)) {
         urgentDistillationMap.set(sid, true);
       }
-      return { ...result!, layer: stageLayer, usable, distilledBudget, rawBudget };
+      return { ...result!, layer: stageLayer, usable, distilledBudget, rawBudget, refreshLtm: false };
     }
   }
 
@@ -1876,6 +1881,7 @@ function transformInner(input: {
     usable,
     distilledBudget,
     rawBudget,
+    refreshLtm: true,
   };
 }
 
@@ -1996,7 +2002,7 @@ function tryFit(input: {
   rawBudget: number;
   strip: "none" | "old-tools" | "all-tools";
   protectedTurns?: number;
-}): Omit<TransformResult, "layer" | "usable" | "distilledBudget" | "rawBudget"> | null {
+}): Omit<TransformResult, "layer" | "usable" | "distilledBudget" | "rawBudget" | "refreshLtm"> | null {
   // If distilled prefix exceeds its budget, fail this layer
   if (input.prefixTokens > input.distilledBudget && input.prefix.length > 0)
     return null;

--- a/packages/core/test/gradient.test.ts
+++ b/packages/core/test/gradient.test.ts
@@ -193,6 +193,26 @@ describe("gradient", () => {
     expect(layer0Result.layer).toBe(0);
     expect(layer0Result.refreshLtm).toBe(false);
 
+    // Layers 1-3: moderate pressure triggers compression stages
+    // context=3000, output=500 → usable=2500, rawBudget~1000
+    // 14 messages × ~250 tokens each ≈ 3500 > 1000 raw budget → forces layer 1+
+    // but messages are small enough that compression stages 1-3 can fit them
+    setModelLimits({ context: 3_000, output: 500 });
+    calibrate(0);
+    const medMessages = Array.from({ length: 14 }, (_, i) => {
+      const role = i % 2 === 0 ? "user" : "assistant";
+      const text = `Message ${i}: ${"some content that fills the budget moderately well ".repeat(8)}`;
+      return makeMsg(`ltm-flag-med-${i}`, role as "user" | "assistant", text, "ltm-flag-med-sess");
+    });
+    const layerMidResult = transform({
+      messages: medMessages,
+      projectPath: PROJECT,
+      sessionID: "ltm-flag-med-sess",
+    });
+    expect(layerMidResult.layer).toBeGreaterThanOrEqual(1);
+    expect(layerMidResult.layer).toBeLessThanOrEqual(3);
+    expect(layerMidResult.refreshLtm).toBe(false);
+
     // Layer 4: force emergency with tight context
     setModelLimits({ context: 2_000, output: 500 });
     calibrate(0);

--- a/packages/core/test/gradient.test.ts
+++ b/packages/core/test/gradient.test.ts
@@ -177,6 +177,43 @@ describe("gradient", () => {
     calibrate(0);
   });
 
+  test("refreshLtm is true on Layer 4 and false on lower layers", () => {
+    // Layer 0: small messages fit easily
+    setModelLimits({ context: 10_000, output: 2_000 });
+    calibrate(0);
+    const smallMessages = [
+      makeMsg("ltm-flag-1", "user", "Hello"),
+      makeMsg("ltm-flag-2", "assistant", "Hi there"),
+    ];
+    const layer0Result = transform({
+      messages: smallMessages,
+      projectPath: PROJECT,
+      sessionID: "ltm-flag-sess",
+    });
+    expect(layer0Result.layer).toBe(0);
+    expect(layer0Result.refreshLtm).toBe(false);
+
+    // Layer 4: force emergency with tight context
+    setModelLimits({ context: 2_000, output: 500 });
+    calibrate(0);
+    const bigMessages = Array.from({ length: 10 }, (_, i) => {
+      const role = i % 2 === 0 ? "user" : "assistant";
+      const text = `Message ${i}: ${"detailed content about various topics and implementation details that span across multiple concerns ".repeat(40)}`;
+      return makeMsg(`ltm-flag-big-${i}`, role as "user" | "assistant", text, "ltm-flag-big-sess");
+    });
+    const layer4Result = transform({
+      messages: bigMessages,
+      projectPath: PROJECT,
+      sessionID: "ltm-flag-big-sess",
+    });
+    expect(layer4Result.layer).toBe(4);
+    expect(layer4Result.refreshLtm).toBe(true);
+
+    // Reset
+    setModelLimits({ context: 10_000, output: 2_000 });
+    calibrate(0);
+  });
+
   test("returns valid token estimates", () => {
     const messages = [
       makeMsg("tok-1", "user", "Test message"),

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -2607,6 +2607,51 @@ async function handleConversationTurn(
     result.messages.pop();
   }
 
+  // --- 7b. LTM refresh on emergency layer ---
+  // Layer 4 (emergency/transient reset) signals that the context was fully
+  // reset. Re-run forSession() to re-rank knowledge entries by relevance to
+  // the current conversation state — entries that became relevant mid-session
+  // (e.g. a gotcha discovered during debugging) are surfaced on the reset
+  // turn rather than waiting for the next session. The full cache bust from
+  // Layer 4 means there's no additional cost from changing the LTM text.
+  if (result.refreshLtm && cfg.knowledge.enabled) {
+    try {
+      ltmSessionCache.delete(sessionID);
+      const ltmFraction = cfg.budget.ltm;
+      const ltmBudget = getLtmBudget(ltmFraction);
+      const entries = ltm.forSession(projectPath, sessionID, ltmBudget);
+      if (entries.length) {
+        const formatted = formatKnowledge(
+          entries.map((e) => ({
+            category: e.category,
+            title: e.title,
+            content: e.content,
+          })),
+          ltmBudget,
+        );
+
+        if (formatted) {
+          const tokenCount = Math.ceil(formatted.length / 3);
+          ltmSessionCache.set(sessionID, { formatted, tokenCount });
+          // Bypass content-diff pinning — Layer 4 already busts the cache,
+          // so there's no benefit to preserving the old pinned text.
+          ltmPinnedText.set(sessionID, { formatted, tokenCount });
+          ltmText = formatted;
+          setLtmTokens(tokenCount, sessionID);
+          saveSessionTracking(sessionID, {
+            ltmCacheText: formatted,
+            ltmCacheTokens: tokenCount,
+            ltmPinText: formatted,
+            ltmPinTokens: tokenCount,
+          });
+          log.info("LTM refreshed on emergency layer (Layer 4) for session", sessionID);
+        }
+      }
+    } catch (e) {
+      log.error("LTM refresh on emergency layer failed:", e);
+    }
+  }
+
   // --- 8. Build the modified request ---
   // Reconstruct GatewayMessages from the transformed Lore messages.
   // loreMessagesToGateway reconstructs tool_result blocks from assistant's

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -2616,10 +2616,11 @@ async function handleConversationTurn(
   // Layer 4 means there's no additional cost from changing the LTM text.
   if (result.refreshLtm && cfg.knowledge.enabled) {
     try {
-      ltmSessionCache.delete(sessionID);
       const ltmFraction = cfg.budget.ltm;
       const ltmBudget = getLtmBudget(ltmFraction);
       const entries = ltm.forSession(projectPath, sessionID, ltmBudget);
+      let refreshed = false;
+
       if (entries.length) {
         const formatted = formatKnowledge(
           entries.map((e) => ({
@@ -2632,9 +2633,10 @@ async function handleConversationTurn(
 
         if (formatted) {
           const tokenCount = Math.ceil(formatted.length / 3);
-          ltmSessionCache.set(sessionID, { formatted, tokenCount });
-          // Bypass content-diff pinning — Layer 4 already busts the cache,
+          // Replace cache and pin — Layer 4 already busts the prompt cache,
           // so there's no benefit to preserving the old pinned text.
+          ltmSessionCache.delete(sessionID);
+          ltmSessionCache.set(sessionID, { formatted, tokenCount });
           ltmPinnedText.set(sessionID, { formatted, tokenCount });
           ltmText = formatted;
           setLtmTokens(tokenCount, sessionID);
@@ -2644,10 +2646,28 @@ async function handleConversationTurn(
             ltmPinText: formatted,
             ltmPinTokens: tokenCount,
           });
+          refreshed = true;
           log.info("LTM refreshed on emergency layer (Layer 4) for session", sessionID);
         }
       }
+
+      if (!refreshed) {
+        // forSession() returned no entries or formatKnowledge() returned empty —
+        // clear all LTM state so the turn doesn't carry stale knowledge.
+        ltmSessionCache.delete(sessionID);
+        ltmPinnedText.delete(sessionID);
+        ltmText = undefined;
+        setLtmTokens(0, sessionID);
+        saveSessionTracking(sessionID, {
+          ltmCacheText: null, ltmCacheTokens: null,
+          ltmPinText: null, ltmPinTokens: null,
+        });
+        log.info("LTM cleared on emergency layer (Layer 4) — no relevant entries for session", sessionID);
+      }
     } catch (e) {
+      // On error, leave the step-6 LTM state intact (cache, pin, text)
+      // so the turn proceeds with the pre-refresh knowledge rather than
+      // an inconsistent state. The next turn will retry via step 6.
       log.error("LTM refresh on emergency layer failed:", e);
     }
   }


### PR DESCRIPTION
## Summary

Closes #302

- Adds `refreshLtm: boolean` flag to `TransformResult` in gradient.ts — set `true` on Layer 4 (emergency), `false` on all other layers
- Pipeline step 7b: when `refreshLtm` is true, invalidates LTM session cache, re-runs `forSession()` with fresh BM25 scoring, bypasses content-diff pinning (Layer 4 already busts cache — zero additional cost), and updates LTM text + token count
- Adds test verifying `refreshLtm` is correctly set based on gradient layer

## Why

Layer 4 (emergency/transient reset) fully resets the context window but previously kept stale LTM entries from session start. Knowledge entries that became relevant mid-session (e.g. a gotcha discovered during debugging) were not surfaced until the next session. Now they are re-ranked and included on the emergency reset turn.