### PR TITLE
fix: strip recall marker text from temporal storage to prevent FTS echo

### DIFF
--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -160,6 +160,7 @@ import {
   expandRecallMarkers,
   cleanupRecallStore,
   replaceRecallWithMarker,
+  isRecallMarker,
 } from "./recall";
 
 // ---------------------------------------------------------------------------
@@ -1748,17 +1749,24 @@ function postResponse(
         }
       }
 
-      // Build and store the assistant response message
-      const assistantMsg = gatewayMessagesToLore(
-        [{ role: "assistant", content: resp.content }],
-        sessionID,
-      )[0];
-      updateAssistantMessageTokens(assistantMsg, resp.usage, resp.model);
-      temporal.store({
-        projectPath,
-        info: assistantMsg.info,
-        parts: assistantMsg.parts,
-      });
+      // Build and store the assistant response message.
+      // Strip recall marker text blocks — they contain the raw query string
+      // and pollute FTS results with self-referential noise.
+      const assistantContent = resp.content.filter(
+        (b) => !(b.type === "text" && isRecallMarker(b.text)),
+      );
+      if (assistantContent.length > 0) {
+        const assistantMsg = gatewayMessagesToLore(
+          [{ role: "assistant", content: assistantContent }],
+          sessionID,
+        )[0];
+        updateAssistantMessageTokens(assistantMsg, resp.usage, resp.model);
+        temporal.store({
+          projectPath,
+          info: assistantMsg.info,
+          parts: assistantMsg.parts,
+        });
+      }
 
       // Update session state (persisted in the batched save after messageCount update)
       sessionState.turnsSinceCuration =

--- a/packages/gateway/src/recall.ts
+++ b/packages/gateway/src/recall.ts
@@ -113,7 +113,7 @@ const ID_MARKER_REGEX = /📚 Fetching detail for (.+?)…/;
 
 /** Check if a text string is a recall marker (search or detail). */
 export function isRecallMarker(text: string): boolean {
-  return MARKER_REGEX.test(text) || ID_MARKER_REGEX.test(text);
+  return parseRecallMarker(text) !== null;
 }
 
 /**

--- a/packages/gateway/src/recall.ts
+++ b/packages/gateway/src/recall.ts
@@ -111,6 +111,11 @@ const MARKER_REGEX = /📚 Searching (.+?) for "(.+?)"…/;
 /** Regex to parse an id-based recall marker. */
 const ID_MARKER_REGEX = /📚 Fetching detail for (.+?)…/;
 
+/** Check if a text string is a recall marker (search or detail). */
+export function isRecallMarker(text: string): boolean {
+  return MARKER_REGEX.test(text) || ID_MARKER_REGEX.test(text);
+}
+
 /**
  * Parse a recall marker text block, returning query and scope if valid.
  * Returns null if the text doesn't match the marker format.

--- a/packages/gateway/test/recall.test.ts
+++ b/packages/gateway/test/recall.test.ts
@@ -19,6 +19,7 @@ import {
   buildRecallFollowUp,
   buildRecallMarker,
   parseRecallMarker,
+  isRecallMarker,
   scopeToLabel,
   labelToScope,
   recallStoreKey,
@@ -266,6 +267,27 @@ describe("parseRecallMarker", () => {
     expect(parseRecallMarker("hello world")).toBeNull();
     expect(parseRecallMarker("[Searching memory...]")).toBeNull();
     expect(parseRecallMarker("")).toBeNull();
+  });
+});
+
+describe("isRecallMarker", () => {
+  test("detects search markers", () => {
+    expect(isRecallMarker('📚 Searching all archives for "test query"…')).toBe(true);
+    expect(isRecallMarker('📚 Searching session history for "auth"…')).toBe(true);
+    expect(isRecallMarker('📚 Searching project archives for "config"…')).toBe(true);
+    expect(isRecallMarker('📚 Searching knowledge base for "patterns"…')).toBe(true);
+  });
+
+  test("detects id-based detail markers", () => {
+    expect(isRecallMarker("📚 Fetching detail for k:abc123…")).toBe(true);
+    expect(isRecallMarker("📚 Fetching detail for d:019abc…")).toBe(true);
+  });
+
+  test("rejects non-marker text", () => {
+    expect(isRecallMarker("hello world")).toBe(false);
+    expect(isRecallMarker("[Searching memory...]")).toBe(false);
+    expect(isRecallMarker("")).toBe(false);
+    expect(isRecallMarker("📚 Some other text")).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- Recall markers (`📚 Searching ... for "<query>"…`) were stored as regular text parts in `temporal_messages`, causing FTS5 to index the raw query string. Future searches for the same terms surfaced the marker as a top result — pure noise that wastes result slots and creates a self-reinforcing echo effect.
- Added `isRecallMarker()` predicate in `recall.ts` and filter in `postResponse()` (`pipeline.ts`) to strip marker text blocks before `temporal.store()`. Markers are still sent to the client and used for round-trip expansion — only the FTS index is kept clean.

## Changes

| File | Change |
|---|---|
| `packages/gateway/src/recall.ts` | Export `isRecallMarker()` using existing marker regexes |
| `packages/gateway/src/pipeline.ts` | Filter recall marker blocks from assistant content before temporal storage; skip storage entirely if all blocks are markers |