### PR TITLE
feat: 3-block system prompt for cache-efficient LTM injection

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -4,6 +4,9 @@
 
 ### Architecture
 
+<!-- lore:019e2745-839f-76ba-9457-48b3be15a558 -->
+* **3-block system prompt: stable LTM prefix + context-bound LTM for cache efficiency**: Proposed system prompt structure for Anthropic requests: - Block 1: Host prompt (no explicit \`cache\_control\` — covered by block 2's prefix) - Block 2: Stable LTM (preferences only) with 1h TTL \`cache\_control\` — pinned across sessions, rarely changes except via curation - Block 3: Context-bound LTM (session-specific entries) — no \`cache\_control\`, benefits from conversation cache prefix Key points: Anthropic prefix caching means block 2's 1h breakpoint covers block 1 too, making block 1's explicit breakpoint redundant. Block 3 is covered by the conversation TTL (5m or 1h). Preferences are pinned ≥1h so cache remains warm even through curation changes. Up to 4 cache breakpoints allowed; longer TTLs must precede shorter ones. Implementation: split \`forSession()\` results by entry type; emit 3 system blocks in \`buildAnthropicRequest()\`.
+
 <!-- lore:019e25c5-5716-77a0-bcf9-d65f321e5736 -->
 * **3-layer gradient model: layer 2 is transient, falls back to layer 1 via urgent distillation**: The gradient system uses 3 effective layers: \*\*Layer 0\*\* — all raw messages, LTM in system prompt, append-only cache (many turns). \*\*Layer 1\*\* — distilled prefix + pinned raw window, 3 internal compression stages (tool stripping → distillation trimming escalation). Bust once on entry, then warm cache. \*\*Layer 2 (emergency)\*\* — transient hard reset: fresh LTM re-ranked via \`forSession()\`, 2-3 importance-ranked distillations, current agentic turn always included. Fires for 1-2 turns, urgent distillation compresses history, then falls back to layer 1. Layer 2 must NOT set stickiness. Context budget caps (160K at Opus) are cost-driven (cache-write $/token), not context-window-driven — blowing past them increases per-bust cost linearly while delaying busts sub-linearly.
 
@@ -317,6 +320,9 @@
 
 <!-- lore:019e25ec-43b5-755d-b3cd-018b8916afc1 -->
 * **Persist state on hot path, not shutdown handlers — process may crash or be killed**: Never rely on shutdown handlers (SIGTERM, graceful exit) as the sole persistence point for session state. \`SIGKILL\` and crashes bypass them entirely. Persist on the hot path: every N turns or on every mutation (e.g. in \`postResponse\` batched save, or inline on \`recordGlobalGap\`). This applies to gradient state, cache warming histograms, session identity, and cost snapshots — all must flush to DB during normal operation, not only at exit.
+
+<!-- lore:019e2745-83af-766d-8e97-c8d4ca202388 -->
+* **Pin stable LTM (preferences) for ≥1h so cache survives curation changes**: When splitting LTM into stable (preferences) vs context-bound blocks, pin stable LTM with a 1h TTL even if the curator updates a preference entry mid-session — the old cached prefix remains usable for ~1h, avoiding an unnecessary cache bust. The 1h TTL on block 2 (stable LTM) also implicitly covers block 1 (host prompt) via Anthropic prefix caching, making a separate cache\_control on block 1 redundant.
 
 <!-- lore:019e25ec-b66f-7c4a-8a26-b235267d2125 -->
 * **Prefer periodic flush over shutdown handlers for state persistence**: Never rely on shutdown handlers (SIGTERM/SIGINT hooks, \`process.on('exit')\`) for persisting important state — SIGKILL and crashes bypass them entirely. Instead, use: (1) immediate writes for rare mutations (session identity changes), (2) per-turn piggyback on existing DB saves for critical metrics, (3) periodic timed flush (e.g. 30s idle tick) for high-frequency fields like gradient EMAs. This provides crash resilience with bounded data loss (~30s max) without hot-path overhead.

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -362,6 +362,9 @@ export type ForSessionOptions = {
   contextHint?: string;
   /** Restrict to these categories (e.g., `['preference']` for turn 1). */
   categories?: string[];
+  /** Exclude these categories (e.g., `['preference']` for context-bound
+   *  entries when preferences are already injected in a separate block). */
+  excludeCategories?: string[];
 };
 
 /**
@@ -396,11 +399,18 @@ export async function forSession(
 ): Promise<KnowledgeEntry[]> {
   const pid = ensureProject(projectPath);
   const categoryFilter = options?.categories;
+  const excludeFilter = options?.excludeCategories;
 
-  // Build optional SQL category clause
-  const categoryClause = categoryFilter?.length
-    ? ` AND category IN (${categoryFilter.map(() => "?").join(",")})`
-    : "";
+  // Build optional SQL category clauses (include / exclude are mutually exclusive)
+  let categoryClause = "";
+  let categoryParams: string[] = [];
+  if (categoryFilter?.length) {
+    categoryClause = ` AND category IN (${categoryFilter.map(() => "?").join(",")})`;
+    categoryParams = categoryFilter;
+  } else if (excludeFilter?.length) {
+    categoryClause = ` AND category NOT IN (${excludeFilter.map(() => "?").join(",")})`;
+    categoryParams = excludeFilter;
+  }
 
   // --- 1. Load project-specific entries ---
   const projectEntries = db()
@@ -409,7 +419,7 @@ export async function forSession(
        WHERE project_id = ? AND cross_project = 0 AND confidence > 0.2${categoryClause}
        ORDER BY confidence DESC, updated_at DESC`,
     )
-    .all(pid, ...(categoryFilter ?? [])) as KnowledgeEntry[];
+    .all(pid, ...categoryParams) as KnowledgeEntry[];
 
   // --- 2. Load cross-project candidates ---
   const crossEntries = db()
@@ -418,7 +428,7 @@ export async function forSession(
        WHERE (project_id IS NULL OR cross_project = 1) AND confidence > 0.2${categoryClause}
        ORDER BY confidence DESC, updated_at DESC`,
     )
-    .all(...(categoryFilter ?? [])) as KnowledgeEntry[];
+    .all(...categoryParams) as KnowledgeEntry[];
 
   if (!crossEntries.length && !projectEntries.length) return [];
 

--- a/packages/core/test/ltm.test.ts
+++ b/packages/core/test/ltm.test.ts
@@ -683,6 +683,70 @@ describe("ltm.forSession", () => {
     }
   });
 
+  test("excludeCategories filters out specified categories", async () => {
+    ltm.create({
+      projectPath: PROJ,
+      category: "preference",
+      title: "Excluded preference entry",
+      content: "This preference should not appear",
+      scope: "project",
+      crossProject: false,
+    });
+    ltm.create({
+      projectPath: PROJ,
+      category: "gotcha",
+      title: "Included gotcha entry",
+      content: "This gotcha should appear in results",
+      scope: "project",
+      crossProject: false,
+    });
+    ltm.create({
+      projectPath: PROJ,
+      category: "architecture",
+      title: "Included architecture entry",
+      content: "This architecture entry should appear",
+      scope: "project",
+      crossProject: false,
+    });
+
+    const result = await ltm.forSession(PROJ, SESSION, 10_000, {
+      excludeCategories: ["preference"],
+    });
+    expect(result.length).toBeGreaterThan(0);
+    for (const entry of result) {
+      expect(entry.category).not.toBe("preference");
+    }
+  });
+
+  test("excludeCategories and categories are mutually exclusive (categories wins)", async () => {
+    ltm.create({
+      projectPath: PROJ,
+      category: "preference",
+      title: "Pref entry for mutual exclusion test",
+      content: "Should appear because categories takes priority",
+      scope: "project",
+      crossProject: false,
+    });
+    ltm.create({
+      projectPath: PROJ,
+      category: "gotcha",
+      title: "Gotcha for mutual exclusion test",
+      content: "Should NOT appear because categories restricts to preference",
+      scope: "project",
+      crossProject: false,
+    });
+
+    // When both are provided, categories wins (excludeCategories ignored)
+    const result = await ltm.forSession(PROJ, SESSION, 10_000, {
+      categories: ["preference"],
+      excludeCategories: ["gotcha"],
+    });
+    expect(result.length).toBeGreaterThan(0);
+    for (const entry of result) {
+      expect(entry.category).toBe("preference");
+    }
+  });
+
   test("contextHint provides relevance signal when no session context exists", async () => {
     // Create entries about different topics
     ltm.create({

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -200,6 +200,7 @@ export async function resetPipelineState(): Promise<void> {
   headerSessionIndex.clear();
   ltmSessionCache.clear();
   ltmPinnedText.clear();
+  stableLtmCache.clear();
   // Shut down batch queue gracefully before clearing the client
   if (llmClient && "shutdown" in llmClient) {
     await (llmClient as LLMClient & { shutdown: () => Promise<void> }).shutdown();
@@ -236,7 +237,8 @@ export function getActiveSessions(): ReadonlyMap<string, SessionState> {
 const headerSessionIndex = new Map<string, string>();
 
 /**
- * Per-session LTM cache for byte-stability.
+ * Per-session LTM cache for byte-stability of **context-bound** entries
+ * (gotchas, patterns, architecture — everything except preferences).
  *
  * Without caching, `ltm.forSession()` re-scores entries against evolving
  * session context every turn, producing different formatted text → system
@@ -248,12 +250,29 @@ const ltmSessionCache = new Map<
 >();
 
 /**
- * Pinned LTM text per session — the text currently being injected into the
- * system prompt. When ltmSessionCache is invalidated and recomputed, we
- * compare the new text against the pin. Only update if >5% character
- * difference to avoid cache busts from minor BM25 re-ranking changes.
+ * Pinned context-bound LTM text per session — the text currently being
+ * injected as system[2]. When ltmSessionCache is invalidated and
+ * recomputed, we compare the new text against the pin. Only update if
+ * >5% character difference to avoid cache busts from minor re-ranking.
  */
 const ltmPinnedText = new Map<
+  string,
+  { formatted: string; tokenCount: number }
+>();
+
+/**
+ * Stable LTM (preference entries) per session — injected as system[1]
+ * with a 1h cache breakpoint. Computed once per session and pinned for ≥1h
+ * even through curation changes, so the Anthropic prompt cache prefix
+ * (system[0] host prompt + system[1] stable LTM) stays warm across turns
+ * and sessions.
+ *
+ * Only rebuilt on new session start (cache miss). NOT invalidated by
+ * curation, idle resume, or Layer 4 emergency — the stale preferences
+ * are kept to preserve the 1h cache investment. On process restart the
+ * cache is recomputed (cheap, preferences are small).
+ */
+const stableLtmCache = new Map<
   string,
   { formatted: string; tokenCount: number }
 >();
@@ -2511,84 +2530,124 @@ async function handleConversationTurn(
     );
   }
 
-  // --- 6. LTM injection (kept separate from host system prompt for caching) ---
-  let ltmText: string | undefined;
+  // --- 6. LTM injection (3-block system prompt for cache efficiency) ---
+  // system[0]: Host prompt              [no cache_control]
+  // system[1]: Stable LTM (preferences) [cache_control: 1h] — pinned ≥1h
+  // system[2]: Context-bound LTM        [no cache_control]  — diff-pinned
+  //
+  // system[0]+[1] form a stable prefix cached at 1h TTL (written at 2×
+  // cost, read at 0.1×). system[2] rides the conversation cache (5m TTL,
+  // 1.25×). When context-bound LTM changes (turn 1→2, curation), only
+  // system[2] and messages are re-processed; system[0]+[1] are cache reads.
+  let stableLtmText: string | undefined; // block 2: preferences
+  let ltmText: string | undefined;       // block 3: context-bound entries
   if (cfg.knowledge.enabled) {
     // Track whether LTM state changed for batched DB persistence
     let ltmDirty = false;
     let pinDirty = false;
 
     try {
-      let cached = ltmSessionCache.get(sessionID);
+      const ltmFraction = cfg.budget.ltm;
+      const ltmBudget = getLtmBudget(ltmFraction);
+      const isFirstTurn = sessionID != null && !temporal.hasMessages(projectPath, sessionID);
+      const contextHint = lastUserTextTrimmed(req);
 
-      if (!cached) {
-        const ltmFraction = cfg.budget.ltm;
-        const ltmBudget = getLtmBudget(ltmFraction);
-        // Deferred LTM injection: on the first turn (no temporal messages yet),
-        // only inject preference-category entries (always-relevant coding style
-        // guidance). Context-dependent entries (gotchas, patterns, architecture)
-        // are deferred to turn 2+ when real session context exists for relevance
-        // scoring. This avoids polluting the agent's context with irrelevant
-        // entries selected by blind confidence fallback.
-        const isFirstTurn = sessionID != null && !temporal.hasMessages(projectPath, sessionID);
-        const contextHint = lastUserTextTrimmed(req);
-        const entries = await ltm.forSession(projectPath, sessionID, ltmBudget, {
-          ...(isFirstTurn ? { categories: ["preference"] } : {}),
+      // --- system[1]: Stable LTM (preferences) ---
+      // Computed once per session and pinned for ≥1h. NOT invalidated by
+      // curation — even if a preference changes, we keep the cached version
+      // so the Anthropic 1h prompt cache prefix stays warm.
+      let stable = stableLtmCache.get(sessionID);
+      if (!stable) {
+        const prefEntries = await ltm.forSession(projectPath, sessionID, ltmBudget, {
+          categories: ["preference"],
           ...(contextHint ? { contextHint } : {}),
         });
-        if (entries.length) {
+        if (prefEntries.length) {
           const formatted = formatKnowledge(
-            entries.map((e) => ({
+            prefEntries.map((e) => ({
               category: e.category,
               title: e.title,
               content: e.content,
             })),
             ltmBudget,
           );
-
           if (formatted) {
             const tokenCount = Math.ceil(formatted.length / 3);
-            cached = { formatted, tokenCount };
-            // Don't cache first-turn (preferences-only) LTM — on turn 2 the
-            // cache miss will re-trigger forSession() with full session context
-            // from temporal messages, producing a relevance-scored entry set.
-            if (!isFirstTurn) {
+            stable = { formatted, tokenCount };
+            stableLtmCache.set(sessionID, stable);
+          }
+        }
+      }
+      stableLtmText = stable?.formatted;
+
+      // --- system[2]: Context-bound LTM (non-preference entries) ---
+      // Deferred to turn 2+ when real session context exists for relevance
+      // scoring. On turn 1, only stable LTM (preferences) is injected.
+      if (!isFirstTurn) {
+        let cached = ltmSessionCache.get(sessionID);
+
+        if (!cached) {
+          // Reserve budget for stable LTM already injected in system[1]
+          const stableTokens = stable?.tokenCount ?? 0;
+          const contextBudget = Math.max(0, ltmBudget - stableTokens);
+          // Exclude preferences — they're already in system[1]
+          const contextEntries = await ltm.forSession(projectPath, sessionID, contextBudget, {
+            excludeCategories: ["preference"],
+            ...(contextHint ? { contextHint } : {}),
+          });
+          if (contextEntries.length) {
+            const formatted = formatKnowledge(
+              contextEntries.map((e) => ({
+                category: e.category,
+                title: e.title,
+                content: e.content,
+              })),
+              contextBudget,
+            );
+            if (formatted) {
+              const tokenCount = Math.ceil(formatted.length / 3);
+              cached = { formatted, tokenCount };
               ltmSessionCache.set(sessionID, cached);
               ltmDirty = true;
             }
           }
         }
-      }
 
-      if (cached) {
-        // Content-diff pinning: only update the injected LTM text if the
-        // new content differs by more than a threshold from what's currently
-        // pinned. This prevents cache busts from minor BM25 re-ranking after
-        // background curation/consolidation invalidates the LTM cache.
-        // Cost-aware threshold: on expensive models, tolerate larger diffs
-        // before busting the cache prefix (opus: 15%, sonnet: 10%, haiku: 5%).
-        const baseDiffThreshold = 0.05;
-        const effectiveDiffThreshold = (modelSpec.inputCostPerMillion ?? 3) >= 5
-          ? Math.min(baseDiffThreshold * 3, 0.20)  // opus: 15%
-          : (modelSpec.inputCostPerMillion ?? 3) >= 1
-            ? Math.min(baseDiffThreshold * 2, 0.15)  // sonnet: 10%
-            : baseDiffThreshold;                       // haiku: 5%
+        if (cached) {
+          // Content-diff pinning: only update the injected LTM text if the
+          // new content differs by more than a threshold from what's currently
+          // pinned. This prevents cache busts from minor re-ranking after
+          // background curation/consolidation invalidates the LTM cache.
+          // Cost-aware threshold: on expensive models, tolerate larger diffs
+          // before busting the cache prefix (opus: 15%, sonnet: 10%, haiku: 5%).
+          const baseDiffThreshold = 0.05;
+          const effectiveDiffThreshold = (modelSpec.inputCostPerMillion ?? 3) >= 5
+            ? Math.min(baseDiffThreshold * 3, 0.20)  // opus: 15%
+            : (modelSpec.inputCostPerMillion ?? 3) >= 1
+              ? Math.min(baseDiffThreshold * 2, 0.15)  // sonnet: 10%
+              : baseDiffThreshold;                       // haiku: 5%
 
-        const pinned = ltmPinnedText.get(sessionID);
-        if (pinned && textDiffRatio(pinned.formatted, cached.formatted) < effectiveDiffThreshold) {
-          // Near-identical — keep the pinned text to preserve cache prefix
-          ltmText = pinned.formatted;
-          setLtmTokens(pinned.tokenCount, sessionID);
-        } else {
-          // Substantially different or first injection — pin the new text
-          ltmPinnedText.set(sessionID, cached);
-          pinDirty = true;
-          ltmText = cached.formatted;
-          setLtmTokens(cached.tokenCount, sessionID);
+          const pinned = ltmPinnedText.get(sessionID);
+          if (pinned && textDiffRatio(pinned.formatted, cached.formatted) < effectiveDiffThreshold) {
+            // Near-identical — keep the pinned text to preserve cache prefix
+            ltmText = pinned.formatted;
+          } else {
+            // Substantially different or first injection — pin the new text
+            ltmPinnedText.set(sessionID, cached);
+            pinDirty = true;
+            ltmText = cached.formatted;
+          }
         }
-      } else {
-        setLtmTokens(0, sessionID);
       }
+
+      // Use stored tokenCount from cache/pin rather than re-estimating
+      // from string length — avoids inconsistent estimates.
+      const contextTokens = ltmText
+        ? (ltmPinnedText.get(sessionID)?.tokenCount
+          ?? ltmSessionCache.get(sessionID)?.tokenCount
+          ?? 0)
+        : 0;
+      setLtmTokens((stable?.tokenCount ?? 0) + contextTokens, sessionID);
     } catch (e) {
       log.error("LTM injection failed:", e);
       setLtmTokens(0, sessionID);
@@ -2633,40 +2692,45 @@ async function handleConversationTurn(
 
   // --- 7b. LTM refresh on emergency layer ---
   // Layer 4 (emergency/transient reset) signals that the context was fully
-  // reset. Re-run forSession() to re-rank knowledge entries by relevance to
-  // the current conversation state — entries that became relevant mid-session
-  // (e.g. a gotcha discovered during debugging) are surfaced on the reset
-  // turn rather than waiting for the next session. The full cache bust from
-  // Layer 4 means there's no additional cost from changing the LTM text.
+  // reset. Re-run forSession() to re-rank context-bound entries by relevance
+  // to the current conversation state — entries that became relevant mid-
+  // session (e.g. a gotcha discovered during debugging) are surfaced on the
+  // reset turn rather than waiting for the next session. Stable LTM
+  // (system[1]) is kept pinned — Layer 4 busts the prompt cache anyway, so
+  // system[1] will be re-written, but keeping the same content means the
+  // NEXT turn's prefix matches and gets a cache read.
   if (result.refreshLtm && cfg.knowledge.enabled) {
     try {
       const ltmFraction = cfg.budget.ltm;
       const ltmBudget = getLtmBudget(ltmFraction);
+      const stableTokens = stableLtmCache.get(sessionID)?.tokenCount ?? 0;
+      const contextBudget = Math.max(0, ltmBudget - stableTokens);
       const contextHint = lastUserTextTrimmed(req);
-      const entries = await ltm.forSession(projectPath, sessionID, ltmBudget, {
+      const contextEntries = await ltm.forSession(projectPath, sessionID, contextBudget, {
+        excludeCategories: ["preference"],
         ...(contextHint ? { contextHint } : {}),
       });
       let refreshed = false;
 
-      if (entries.length) {
+      if (contextEntries.length) {
         const formatted = formatKnowledge(
-          entries.map((e) => ({
+          contextEntries.map((e) => ({
             category: e.category,
             title: e.title,
             content: e.content,
           })),
-          ltmBudget,
+          contextBudget,
         );
 
         if (formatted) {
           const tokenCount = Math.ceil(formatted.length / 3);
-          // Replace cache and pin — Layer 4 already busts the prompt cache,
-          // so there's no benefit to preserving the old pinned text.
+          // Replace context-bound cache and pin — Layer 4 already busts the
+          // prompt cache, so there's no benefit to preserving the old pin.
           ltmSessionCache.delete(sessionID);
           ltmSessionCache.set(sessionID, { formatted, tokenCount });
           ltmPinnedText.set(sessionID, { formatted, tokenCount });
           ltmText = formatted;
-          setLtmTokens(tokenCount, sessionID);
+          setLtmTokens(stableTokens + tokenCount, sessionID);
           saveSessionTracking(sessionID, {
             ltmCacheText: formatted,
             ltmCacheTokens: tokenCount,
@@ -2674,22 +2738,22 @@ async function handleConversationTurn(
             ltmPinTokens: tokenCount,
           });
           refreshed = true;
-          log.info("LTM refreshed on emergency layer (Layer 4) for session", sessionID);
+          log.info("Context-bound LTM refreshed on emergency layer (Layer 4) for session", sessionID);
         }
       }
 
       if (!refreshed) {
-        // forSession() returned no entries or formatKnowledge() returned empty —
-        // clear all LTM state so the turn doesn't carry stale knowledge.
+        // forSession() returned no context-bound entries — clear context LTM
+        // state. Stable LTM (system[1]) is preserved.
         ltmSessionCache.delete(sessionID);
         ltmPinnedText.delete(sessionID);
         ltmText = undefined;
-        setLtmTokens(0, sessionID);
+        setLtmTokens(stableTokens, sessionID);
         saveSessionTracking(sessionID, {
           ltmCacheText: null, ltmCacheTokens: null,
           ltmPinText: null, ltmPinTokens: null,
         });
-        log.info("LTM cleared on emergency layer (Layer 4) — no relevant entries for session", sessionID);
+        log.info("Context-bound LTM cleared on emergency layer (Layer 4) — stable LTM preserved for session", sessionID);
       }
     } catch (e) {
       // On error, leave the step-6 LTM state intact (cache, pin, text)
@@ -2795,6 +2859,7 @@ async function handleConversationTurn(
 
   const cacheOptions: AnthropicCacheOptions = {
     systemTTL: "1h",
+    stableLtmSystem: stableLtmText,
     ltmSystem: ltmText,
     cacheTools: true,
     cacheConversation: true,

--- a/packages/gateway/src/translate/anthropic.ts
+++ b/packages/gateway/src/translate/anthropic.ts
@@ -266,13 +266,22 @@ export type AnthropicCacheOptions = {
   systemTTL?: "5m" | "1h" | false;
 
   /**
-   * LTM knowledge text to inject as a separate system block after the host
-   * prompt. Keeping it in a separate block means the host prompt gets its
-   * own cache breakpoint (1h) and LTM changes don't bust the host prefix.
+   * Stable LTM text (preference entries) to inject as system[1] with an
+   * explicit 1h cache breakpoint. Pinned for ≥1h even through curation
+   * changes so the Anthropic prompt cache prefix stays warm.
    *
-   * When provided AND systemTTL is set, the system becomes a 2-block array:
-   *   system[0]: host prompt  — cache_control with systemTTL
-   *   system[1]: LTM content  — no cache_control (benefits from prefix)
+   * When provided AND systemTTL is set, the system becomes a 3-block array:
+   *   system[0]: host prompt        — no cache_control (covered by [1]'s prefix)
+   *   system[1]: stable LTM (prefs) — cache_control: 1h TTL
+   *   system[2]: context-bound LTM  — no cache_control (rides conversation cache)
+   */
+  stableLtmSystem?: string;
+
+  /**
+   * Context-bound LTM text (gotchas, patterns, architecture) injected as
+   * system[2]. No cache_control — benefits from the conversation cache
+   * breakpoint (5m/1h TTL on the last message). Changes on turn 2 and
+   * after curation without busting the stable prefix (system[0]+[1]).
    */
   ltmSystem?: string;
 
@@ -358,33 +367,58 @@ export function buildAnthropicRequest(
   // System — only include if non-empty
   if (req.system) {
     const systemTTL = cache?.systemTTL;
-    const ltmText = cache?.ltmSystem;
+    const stableLtm = cache?.stableLtmSystem;
+    const contextLtm = cache?.ltmSystem;
 
     if (systemTTL) {
-      // Send as block array with explicit cache_control breakpoint on the
-      // host prompt. The host prompt is the most stable part (changes only
-      // when the host mutates AGENTS.md, memory, etc.) so it gets a 1h TTL.
-      const cacheControl: Record<string, string> =
-        systemTTL === "1h"
-          ? { type: "ephemeral", ttl: "1h" }
-          : { type: "ephemeral" };
-
+      // 3-block system prompt for cache efficiency:
+      //   system[0]: Host prompt        — no cache_control (covered by prefix)
+      //   system[1]: Stable LTM (prefs) — cache_control: 1h TTL
+      //   system[2]: Context-bound LTM  — no cache_control (rides conversation cache)
+      //
+      // Anthropic prefix caching means system[1]'s 1h breakpoint covers
+      // system[0] too (prefix up to the breakpoint). The host prompt
+      // doesn't need its own breakpoint — one on system[1] is sufficient.
       const blocks: Record<string, unknown>[] = [
-        { type: "text", text: req.system, cache_control: cacheControl },
+        { type: "text", text: req.system },
       ];
 
-      // LTM knowledge as a separate block — no cache_control of its own,
-      // but benefits from the host prompt prefix cache. When LTM changes,
-      // only this block and everything after it is re-processed; the host
-      // prompt prefix is still a cache read.
-      if (ltmText) {
-        blocks.push({ type: "text", text: ltmText });
+      if (stableLtm) {
+        // Stable LTM always gets a 1h cache breakpoint regardless of the
+        // caller's systemTTL — preferences are pinned ≥1h by design so
+        // the prefix stays warm across turns and sessions. Even when
+        // context-bound LTM changes (turn 1→2, curation), system[0]+[1]
+        // remain cache reads at 0.1× cost. The host prompt (system[0])
+        // needs no cache_control — Anthropic prefix caching means
+        // system[1]'s breakpoint covers everything before it.
+        blocks.push({
+          type: "text",
+          text: stableLtm,
+          cache_control: { type: "ephemeral", ttl: "1h" },
+        });
+      } else {
+        // No stable LTM — fall back to putting the cache breakpoint on
+        // the host prompt itself using the caller's requested TTL.
+        const cacheControl: Record<string, string> =
+          systemTTL === "1h"
+            ? { type: "ephemeral", ttl: "1h" }
+            : { type: "ephemeral" };
+        blocks[0].cache_control = cacheControl;
+      }
+
+      // system[2]: context-bound LTM — no cache_control of its own. It
+      // benefits from the conversation cache breakpoint on the last
+      // message (5m/1h TTL). When this block changes, only system[2] +
+      // messages are re-processed; system[0]+[1] are still cache reads.
+      if (contextLtm) {
+        blocks.push({ type: "text", text: contextLtm });
       }
 
       body.system = blocks;
     } else {
-      // No caching — concatenate LTM into a single string.
-      body.system = ltmText ? `${req.system}\n\n${ltmText}` : req.system;
+      // No caching — concatenate all LTM into a single string.
+      const allLtm = [stableLtm, contextLtm].filter(Boolean).join("\n\n");
+      body.system = allLtm ? `${req.system}\n\n${allLtm}` : req.system;
     }
   }
 

--- a/packages/gateway/test/anthropic-caching.test.ts
+++ b/packages/gateway/test/anthropic-caching.test.ts
@@ -397,6 +397,111 @@ describe("buildAnthropicRequest — LTM system block", () => {
 });
 
 // ---------------------------------------------------------------------------
+// 3-block system prompt: host + stable LTM + context-bound LTM
+// ---------------------------------------------------------------------------
+
+describe("buildAnthropicRequest — 3-block system prompt", () => {
+  test("stable LTM creates block with 1h cache, host has no cache_control", () => {
+    const body = getBody(makeRequest(), {
+      systemTTL: "1h",
+      stableLtmSystem: "## Preferences\n* coding style",
+    });
+    const blocks = body.system as Array<Record<string, unknown>>;
+    expect(blocks).toHaveLength(2);
+
+    // Block 0: host prompt — no cache_control (covered by block 1's prefix)
+    expect(blocks[0].text).toBe("You are a helpful assistant.");
+    expect(blocks[0].cache_control).toBeUndefined();
+
+    // Block 1: stable LTM — 1h cache breakpoint
+    expect(blocks[1].text).toBe("## Preferences\n* coding style");
+    expect(blocks[1].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+  });
+
+  test("all 3 blocks: host + stable LTM (1h) + context LTM (no cache)", () => {
+    const body = getBody(makeRequest(), {
+      systemTTL: "1h",
+      stableLtmSystem: "## Preferences\n* coding style",
+      ltmSystem: "## Gotcha\n* watch out for X",
+    });
+    const blocks = body.system as Array<Record<string, unknown>>;
+    expect(blocks).toHaveLength(3);
+
+    // Block 0: host prompt — no cache_control
+    expect(blocks[0].text).toBe("You are a helpful assistant.");
+    expect(blocks[0].cache_control).toBeUndefined();
+
+    // Block 1: stable LTM — 1h cache breakpoint
+    expect(blocks[1].text).toBe("## Preferences\n* coding style");
+    expect(blocks[1].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+
+    // Block 2: context-bound LTM — no cache_control (rides conversation cache)
+    expect(blocks[2].text).toBe("## Gotcha\n* watch out for X");
+    expect(blocks[2].cache_control).toBeUndefined();
+  });
+
+  test("stable LTM only (no context LTM) produces 2 blocks", () => {
+    const body = getBody(makeRequest(), {
+      systemTTL: "1h",
+      stableLtmSystem: "## Preferences\n* style",
+      ltmSystem: undefined,
+    });
+    const blocks = body.system as Array<Record<string, unknown>>;
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0].cache_control).toBeUndefined();
+    expect(blocks[1].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+  });
+
+  test("context LTM only (no stable LTM) falls back to host prompt breakpoint", () => {
+    const body = getBody(makeRequest(), {
+      systemTTL: "1h",
+      stableLtmSystem: undefined,
+      ltmSystem: "## Gotcha\n* watch out",
+    });
+    const blocks = body.system as Array<Record<string, unknown>>;
+    expect(blocks).toHaveLength(2);
+    // Host gets the cache breakpoint as fallback
+    expect(blocks[0].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+    // Context LTM — no cache_control
+    expect(blocks[1].cache_control).toBeUndefined();
+  });
+
+  test("no caching concatenates both LTM texts into single string", () => {
+    const body = getBody(makeRequest(), {
+      systemTTL: false,
+      stableLtmSystem: "prefs",
+      ltmSystem: "gotchas",
+    });
+    expect(typeof body.system).toBe("string");
+    expect(body.system).toBe("You are a helpful assistant.\n\nprefs\n\ngotchas");
+  });
+
+  test("no caching with only stable LTM concatenates correctly", () => {
+    const body = getBody(makeRequest(), {
+      systemTTL: false,
+      stableLtmSystem: "prefs",
+    });
+    expect(body.system).toBe("You are a helpful assistant.\n\nprefs");
+  });
+
+  test("5m systemTTL with stable LTM still uses 1h on stable block", () => {
+    const body = getBody(makeRequest(), {
+      systemTTL: "5m",
+      stableLtmSystem: "## Preferences\n* style",
+      ltmSystem: "## Gotcha\n* issue",
+    });
+    const blocks = body.system as Array<Record<string, unknown>>;
+    expect(blocks).toHaveLength(3);
+    // Host — no cache_control
+    expect(blocks[0].cache_control).toBeUndefined();
+    // Stable LTM always gets 1h regardless of systemTTL
+    expect(blocks[1].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+    // Context LTM — no cache_control
+    expect(blocks[2].cache_control).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Tool caching
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Split LTM injection into two separate system prompt blocks — stable LTM (preferences) and context-bound LTM (gotchas, patterns, architecture) — to improve Anthropic prompt cache hit rates.

### System prompt structure

```
Block 0: Host prompt        — no cache_control (covered by prefix)
Block 1: Stable LTM (prefs) — cache_control: 1h TTL
Block 2: Context-bound LTM  — no cache_control (rides 5m conversation cache)
```

### Cache behavior

- **Blocks 0+1** form a stable prefix written once at 2× cost, read at 0.1× for the entire session (and across sessions within 1h)
- **Block 2 + messages** ride the conversation cache (5m TTL, 1.25× write)
- When context-bound LTM changes (turn 1→2, curation), only block 2 + messages are re-processed; blocks 0+1 remain cache reads
- Stable LTM is pinned for ≥1h even through curation changes — stale preferences are tolerated to preserve the cache prefix investment

### Changes

- **`packages/gateway/src/translate/anthropic.ts`**: Add `stableLtmSystem` to `AnthropicCacheOptions`; `buildAnthropicRequest` emits 3 system blocks when `stableLtmSystem` is set. Host prompt no longer gets its own cache breakpoint — the stable LTM block's 1h breakpoint covers the prefix. Falls back to host prompt breakpoint when no stable LTM exists.
- **`packages/gateway/src/pipeline.ts`**: Compute preferences separately via `stableLtmCache` (computed once per session, not invalidated by curation or idle resume). Context-bound LTM uses `excludeCategories: ["preference"]` to avoid duplicating preferences already in block 1. Layer 4 emergency only refreshes context-bound LTM, keeping stable LTM pinned.
- **`packages/core/src/ltm.ts`**: Add `excludeCategories` to `ForSessionOptions` — generates `AND category NOT IN (...)` SQL clause. Mutually exclusive with `categories` (include wins).
- **Tests**: 8 new tests for 3-block system prompt behavior in `anthropic-caching.test.ts`; 2 new tests for `excludeCategories` in `ltm.test.ts`.

### Cost analysis

| Scenario | Before | After |
|---|---|---|
| Turn 1→2 (LTM changes) | Re-process all LTM + messages | Only block 2 + messages; blocks 0+1 are cache reads |
| Curation changes prefs | Full LTM cache bust | Block 1 stays pinned; only block 2 may change |
| New session within 1h | Host prompt is cache read, LTM is cold | Blocks 0+1 are cache reads from previous session |