### PR TITLE
fix: key global histograms by project_id instead of directory path

### DIFF
--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -318,16 +318,21 @@ export function blendHistograms(
 // Global histograms (per-project, in-memory)
 // ---------------------------------------------------------------------------
 
-/** Global histograms keyed by projectPath. */
+/** Global histograms keyed by project_id (UUID). */
 const globalHistograms = new Map<string, InterTurnHistogram>();
 
+/**
+ * Get the global histogram for a project by its ID.
+ *
+ * Creates an empty histogram if none exists for the given pid.
+ */
 export function getGlobalHistogram(
-  projectPath: string,
+  pid: string,
 ): InterTurnHistogram {
-  let hist = globalHistograms.get(projectPath);
+  let hist = globalHistograms.get(pid);
   if (!hist) {
     hist = createHistogram();
-    globalHistograms.set(projectPath, hist);
+    globalHistograms.set(pid, hist);
   }
   return hist;
 }
@@ -337,7 +342,9 @@ export function blendedHistogramForSession(
   state: SessionState,
 ): InterTurnHistogram {
   const sessionHist = getSessionHistogram(state);
-  const globalHist = getGlobalHistogram(state.projectPath);
+  const pid = projectId(state.projectPath);
+  if (!pid) return sessionHist; // no project in DB yet — session-only
+  const globalHist = getGlobalHistogram(pid);
   return blendHistograms(sessionHist, globalHist);
 }
 
@@ -826,8 +833,8 @@ export function computeWarmingSnapshot(
 
   // Histograms
   const sessionHist = state.survivalModel ?? createHistogram();
-  loadGlobalHistograms(state.projectPath);
-  const globalHist = getGlobalHistogram(state.projectPath);
+  const pid = loadGlobalHistograms(state.projectPath);
+  const globalHist = pid ? getGlobalHistogram(pid) : createHistogram();
   const blendedHist = blendHistograms(sessionHist, globalHist);
   const sessionWeight = Math.min(sessionHist.total / BLEND_PSEUDOCOUNT, 1.0);
 
@@ -1147,7 +1154,7 @@ export async function executeWarmup(
 // Global histogram persistence (SQLite)
 // ---------------------------------------------------------------------------
 
-/** Tracks which projects have been modified since last flush. */
+/** Tracks which project IDs have been modified since last flush. */
 const dirtyProjects = new Set<string>();
 
 /**
@@ -1157,19 +1164,21 @@ const dirtyProjects = new Set<string>();
  * globalHistograms map so survival analysis has data immediately after
  * a gateway restart.
  *
+ * Returns the resolved project_id (UUID) so callers can reuse it
+ * without a redundant `projectId()` query, or `undefined` if the
+ * project is not yet in the DB.
+ *
  * Backward compatibility: if the DB contains old time-slot-segmented rows
  * (work/evening/night), they are merged by summing bin counts into a single
  * histogram. New data is written under the "all" time_slot key.
  */
-export function loadGlobalHistograms(projectPath: string): void {
-  if (globalHistograms.has(projectPath)) return; // already loaded
+export function loadGlobalHistograms(projectPath: string): string | undefined {
+  const pid = projectId(projectPath);
+  if (!pid) return undefined; // project not yet in DB — nothing to load
+
+  if (globalHistograms.has(pid)) return pid; // already loaded
 
   const merged = createHistogram();
-  const pid = projectId(projectPath);
-  if (!pid) {
-    globalHistograms.set(projectPath, merged);
-    return;
-  }
 
   try {
     const rows = db()
@@ -1200,7 +1209,8 @@ export function loadGlobalHistograms(projectPath: string): void {
     log.warn("cache-warmer: failed to load global histograms:", e);
   }
 
-  globalHistograms.set(projectPath, merged);
+  globalHistograms.set(pid, merged);
+  return pid;
 }
 
 /**
@@ -1220,11 +1230,8 @@ export function flushGlobalHistograms(): void {
   const d = db();
   const now = Date.now();
 
-  for (const projectPath of dirtyProjects) {
-    const pid = projectId(projectPath);
-    if (!pid) continue;
-
-    const hist = globalHistograms.get(projectPath);
+  for (const pid of dirtyProjects) {
+    const hist = globalHistograms.get(pid);
     if (!hist) continue;
 
     try {
@@ -1269,17 +1276,18 @@ export function recordGlobalGap(
   projectPath: string,
   gapMs: number,
 ): void {
-  loadGlobalHistograms(projectPath); // ensure loaded
-  const hist = getGlobalHistogram(projectPath);
+  const pid = loadGlobalHistograms(projectPath); // ensure loaded; resolves pid
+  if (!pid) return; // project not yet in DB — skip
+  const hist = getGlobalHistogram(pid);
   recordGap(hist, gapMs);
-  dirtyProjects.add(projectPath);
+  dirtyProjects.add(pid);
 }
 
 // ---------------------------------------------------------------------------
 // Dashboard helpers
 // ---------------------------------------------------------------------------
 
-/** Read-only snapshot of all loaded global histograms (for dashboard). */
+/** Read-only snapshot of all loaded global histograms, keyed by project_id (for dashboard). */
 export function getGlobalHistogramsSnapshot(): ReadonlyMap<string, InterTurnHistogram> {
   return globalHistograms;
 }

--- a/packages/gateway/src/ui.ts
+++ b/packages/gateway/src/ui.ts
@@ -1250,8 +1250,8 @@ function pageWarming(): string {
       Used as Bayesian prior for sessions with few observations.
     </p>`;
 
-    for (const [projectPath, hist] of globalHists) {
-      const name = projectPath.split("/").pop() ?? projectPath;
+    for (const [pid, hist] of globalHists) {
+      const name = projectName(pid) ?? pid;
       body += `<details class="warming">
         <summary>${esc(name)} &mdash; ${hist.total} observations</summary>`;
       if (hist.total > 0) {

--- a/packages/gateway/test/cache-warmer.test.ts
+++ b/packages/gateway/test/cache-warmer.test.ts
@@ -1172,11 +1172,20 @@ import {
   getGlobalHistogram,
   loadGlobalHistograms,
   flushGlobalHistograms,
+  blendedHistogramForSession,
 } from "../src/cache-warmer";
 
 describe("gap recording filtering", () => {
+  const GAP_TEST_PROJECT_PATH = "/tmp/test-gap-project";
+  const GAP_TEST_PID = "test-gap-pid";
+
   beforeEach(() => {
     _resetForTest();
+    // Ensure the project exists in the DB so recordGlobalGap can resolve pid.
+    const d = db();
+    d.query(
+      "INSERT OR IGNORE INTO projects (id, path, name, git_remote, created_at) VALUES (?, ?, ?, ?, ?)",
+    ).run(GAP_TEST_PID, GAP_TEST_PROJECT_PATH, "test-gap", null, Date.now());
   });
 
   /**
@@ -1311,7 +1320,7 @@ describe("gap recording filtering", () => {
 
   test("global histogram also records gap for user turns", () => {
     const now = Date.now();
-    const state = makeSessionState({ lastUserTurnTime: now - 120_000 }); // 2 min ago
+    const state = makeSessionState({ projectPath: GAP_TEST_PROJECT_PATH, lastUserTurnTime: now - 120_000 }); // 2 min ago
 
     simulateGapRecording(state, {
       isSubagentTurn: false,
@@ -1319,13 +1328,13 @@ describe("gap recording filtering", () => {
       now,
     });
 
-    const globalHist = getGlobalHistogram(state.projectPath);
+    const globalHist = getGlobalHistogram(GAP_TEST_PID);
     expect(globalHist.total).toBe(1);
   });
 
   test("global histogram is not polluted by subagent turns", () => {
     const now = Date.now();
-    const state = makeSessionState({ lastUserTurnTime: now - 120_000 });
+    const state = makeSessionState({ projectPath: GAP_TEST_PROJECT_PATH, lastUserTurnTime: now - 120_000 });
 
     simulateGapRecording(state, {
       isSubagentTurn: true,
@@ -1333,7 +1342,7 @@ describe("gap recording filtering", () => {
       now,
     });
 
-    const globalHist = getGlobalHistogram(state.projectPath);
+    const globalHist = getGlobalHistogram(GAP_TEST_PID);
     expect(globalHist.total).toBe(0);
   });
 
@@ -1349,6 +1358,38 @@ describe("gap recording filtering", () => {
 
     // survivalModel is the histogram itself, not a { slots: ... } wrapper
     expect(state.survivalModel).toBe(hist);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Undefined pid fallback (project not yet in DB)
+// ---------------------------------------------------------------------------
+
+describe("undefined pid fallback", () => {
+  beforeEach(() => {
+    _resetForTest();
+  });
+
+  test("blendedHistogramForSession returns session-only histogram when project is not in DB", () => {
+    // Use a path that has NO corresponding project in the DB.
+    const state = makeSessionState({ projectPath: "/tmp/nonexistent-project" });
+    const sessionHist = getSessionHistogram(state);
+    recordGap(sessionHist, 60_000); // add an observation to the session histogram
+
+    const blended = blendedHistogramForSession(state);
+    // With no project in DB, blended should be the session histogram itself
+    expect(blended).toBe(sessionHist);
+    expect(blended.total).toBe(1);
+  });
+
+  test("recordGlobalGap is a no-op when project is not in DB", () => {
+    const unknownPath = "/tmp/nonexistent-project";
+    // Should not throw — silently skips
+    recordGlobalGap(unknownPath, 60_000);
+
+    // loadGlobalHistograms also returns undefined for unknown projects
+    const pid = loadGlobalHistograms(unknownPath);
+    expect(pid).toBeUndefined();
   });
 });
 
@@ -1398,7 +1439,7 @@ describe("global histogram persistence", () => {
 
     loadGlobalHistograms(TEST_PROJECT_PATH);
 
-    const hist = getGlobalHistogram(TEST_PROJECT_PATH);
+    const hist = getGlobalHistogram(pid);
     expect(hist.total).toBe(15); // 10 + 5
     expect(hist.counts[0]).toBe(10);
     expect(hist.counts[3]).toBe(5);
@@ -1454,7 +1495,7 @@ describe("global histogram persistence", () => {
     _resetForTest(); // clears in-memory state
     loadGlobalHistograms(TEST_PROJECT_PATH);
 
-    const hist = getGlobalHistogram(TEST_PROJECT_PATH);
+    const hist = getGlobalHistogram(pid);
     expect(hist.total).toBe(10); // 7 + 3, no double-count
     expect(hist.counts[0]).toBe(7);
     expect(hist.counts[5]).toBe(3);


### PR DESCRIPTION
## Summary

- Re-key the in-memory `globalHistograms` map from filesystem path to `project_id` (UUID), unifying histogram data for the same project accessed via different directories (worktrees, symlinks)
- Fix Cache Warming UI "Global Histograms" to show actual project names from DB instead of directory basenames
- External API (`loadGlobalHistograms`, `recordGlobalGap`) keeps path-based signatures for caller convenience — they resolve to `project_id` internally

## Changed Files

- `packages/gateway/src/cache-warmer.ts` — re-key map internals, update all functions that interact with the map
- `packages/gateway/src/ui.ts` — use `projectName(pid)` instead of `projectPath.split("/").pop()`
- `packages/gateway/test/cache-warmer.test.ts` — update tests for pid-keyed map, ensure test projects exist in DB