### PR TITLE
fix: use export for env vars in install script examples

### DIFF
--- a/docs/install
+++ b/docs/install
@@ -32,8 +32,8 @@ Environment Variables:
 Examples:
     curl -fsSL https://withlore.ai/install | bash
     curl -fsSL https://withlore.ai/install | bash -s -- --version 0.14.0
-    LORE_VERSION=nightly curl -fsSL https://withlore.ai/install | bash
-    LORE_INSTALL_DIR=~/.local/bin curl -fsSL https://withlore.ai/install | bash
+    export LORE_VERSION=nightly && curl -fsSL https://withlore.ai/install | bash
+    export LORE_INSTALL_DIR=~/.local/bin && curl -fsSL https://withlore.ai/install | bash
 EOF
 }
 


### PR DESCRIPTION
## Summary

- Fix env var propagation bug in install script usage examples: `LORE_VERSION=nightly curl ... | bash` sets the variable in `curl`'s environment, not in the `bash` process that runs the piped script — so `LORE_VERSION` always resolves to empty
- Changed to `export LORE_VERSION=nightly && curl ... | bash` which correctly propagates the variable through the pipe
- Same fix applied to `LORE_INSTALL_DIR` example (same bug)