### PR TITLE
fix: prevent test data from leaking into production DB

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,2 +1,5 @@
 [test]
 preload = ["./packages/core/test/setup.ts"]
+
+[test.env]
+NODE_ENV = "test"

--- a/packages/core/bunfig.toml
+++ b/packages/core/bunfig.toml
@@ -1,2 +1,5 @@
 [test]
 preload = ["./test/setup.ts"]
+
+[test.env]
+NODE_ENV = "test"

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -796,6 +796,18 @@ export function close() {
  * git_remote was not yet populated (pre-v14 rows), it is backfilled lazily.
  */
 export function ensureProject(path: string, name?: string): string {
+  // Guard: reject synthetic test paths when targeting the production DB.
+  // Test paths like "/test/ltm/project" are absolute paths that don't exist
+  // on any real filesystem — they're only valid in test suites running against
+  // a temp DB (LORE_DB_PATH set by test preload). If we see such a path
+  // without LORE_DB_PATH being set, a test is hitting the production DB.
+  if (!process.env.LORE_DB_PATH && /^\/test\//.test(path)) {
+    throw new Error(
+      `Refusing to create project with test path "${path}" in the production DB. ` +
+        `Set LORE_DB_PATH to a temp path, or run tests via \`bun test\` from the repo root.`,
+    );
+  }
+
   // 1. Exact path match (fast path)
   const existing = db()
     .query("SELECT id, git_remote FROM projects WHERE path = ?")

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -800,7 +800,10 @@ export function ensureProject(path: string, name?: string): string {
   // Test paths like "/test/ltm/project" are absolute paths that don't exist
   // on any real filesystem — they're only valid in test suites running against
   // a temp DB (LORE_DB_PATH set by test preload). If we see such a path
-  // without LORE_DB_PATH being set, a test is hitting the production DB.
+  // without LORE_DB_PATH being set, a test is likely hitting the production DB.
+  // Note: LORE_DB_PATH unset is used as a proxy for "production DB". This
+  // wouldn't catch the unlikely case of someone explicitly setting LORE_DB_PATH
+  // to the default production path, but that's not a realistic scenario.
   if (!process.env.LORE_DB_PATH && /^\/test\//.test(path)) {
     throw new Error(
       `Refusing to create project with test path "${path}" in the production DB. ` +

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -717,12 +717,17 @@ describe("db", () => {
 
     test("allows non-test paths when LORE_DB_PATH is unset", () => {
       delete process.env.LORE_DB_PATH;
-      // Real-looking paths should not be blocked (guard only rejects /test/ prefix)
-      // Note: we don't actually call ensureProject here because the DB singleton
-      // is already initialized — this verifies the guard logic doesn't throw
-      // for normal paths. The DB call itself would succeed since the singleton
-      // is already open.
+      // The guard only rejects /test/ prefix — real-looking paths pass through.
+      // The DB singleton is already initialized (pointing at the temp test DB),
+      // so this call writes to the temp DB, not the production one.
       expect(() => ensureProject("/home/user/my-project")).not.toThrow();
+    });
+
+    test("does not match similar-but-different path prefixes", () => {
+      delete process.env.LORE_DB_PATH;
+      // /testing/... and /test (no trailing slash) should NOT be rejected
+      expect(() => ensureProject("/testing/something")).not.toThrow();
+      expect(() => ensureProject("/test")).not.toThrow();
     });
   });
 });

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { db, close, ensureProject, projectId, mergeProjectInternal, loadForceMinLayer, saveForceMinLayer, getMeta, setMeta, getInstanceId, saveSessionCosts, loadSessionCosts, loadAllSessionCosts, getLastImportAt, setLastImportAt, saveSessionTracking, loadSessionTracking, loadHeaderSessionIndex, getKV, setKV } from "../src/db";
 
 
@@ -685,5 +685,44 @@ describe("db", () => {
     expect(getKV("kv_upsert")).toBe("first");
     setKV("kv_upsert", "second");
     expect(getKV("kv_upsert")).toBe("second");
+  });
+
+  describe("ensureProject test-path guard", () => {
+    let savedLoreDbPath: string | undefined;
+
+    beforeEach(() => {
+      savedLoreDbPath = process.env.LORE_DB_PATH;
+    });
+
+    afterEach(() => {
+      // Restore — tests run under setup.ts preload so LORE_DB_PATH is set
+      if (savedLoreDbPath !== undefined) {
+        process.env.LORE_DB_PATH = savedLoreDbPath;
+      } else {
+        delete process.env.LORE_DB_PATH;
+      }
+    });
+
+    test("throws for /test/ paths when LORE_DB_PATH is unset", () => {
+      delete process.env.LORE_DB_PATH;
+      expect(() => ensureProject("/test/ltm/something")).toThrow(
+        /Refusing to create project with test path/,
+      );
+    });
+
+    test("allows /test/ paths when LORE_DB_PATH is set (temp DB)", () => {
+      // LORE_DB_PATH is already set by test preload — just verify it works
+      expect(() => ensureProject("/test/guard-check")).not.toThrow();
+    });
+
+    test("allows non-test paths when LORE_DB_PATH is unset", () => {
+      delete process.env.LORE_DB_PATH;
+      // Real-looking paths should not be blocked (guard only rejects /test/ prefix)
+      // Note: we don't actually call ensureProject here because the DB singleton
+      // is already initialized — this verifies the guard logic doesn't throw
+      // for normal paths. The DB call itself would succeed since the singleton
+      // is already open.
+      expect(() => ensureProject("/home/user/my-project")).not.toThrow();
+    });
   });
 });

--- a/packages/gateway/src/cli/data.ts
+++ b/packages/gateway/src/cli/data.ts
@@ -482,7 +482,7 @@ async function cmdDelete(
 
     case "project": {
       const { projectId: resolveProjectId } = await import("@loreai/core");
-      // rawId can be a project UUID or a project path
+      // rawId can be a project UUID or a filesystem path
       let id = rawId;
       if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(rawId)) {
         const resolved = resolveProjectId(resolve(rawId));
@@ -492,27 +492,30 @@ async function cmdDelete(
         }
         id = resolved;
       }
+      // Validate existence before prompting for confirmation
+      const project = data.listProjects().find((p) => p.id === id);
+      if (!project) {
+        console.error(`Project not found: ${rawId}`);
+        process.exit(1);
+      }
       if (!skipConfirm) {
         const confirmed = await confirm(
-          `\nDelete project ${id.slice(0, 12)}... and ALL its data (knowledge, sessions, distillations)?`,
+          `\nDelete project ${project.name ?? id.slice(0, 12)}... and ALL its data ` +
+            `(${project.knowledge_count} knowledge, ${project.session_count} sessions, ` +
+            `${project.distillation_count} distillations)?`,
         );
         if (!confirmed) {
           console.log("Cancelled.");
           return;
         }
       }
-      const result = data.deleteProject(id);
-      if (result) {
-        console.log(
-          `Deleted project: ${result.knowledge_deleted} knowledge, ` +
-            `${result.temporal_deleted} messages, ` +
-            `${result.distillations_deleted} distillations, ` +
-            `${result.sessions_cleared} sessions.`,
-        );
-      } else {
-        console.error(`Project not found: ${rawId}`);
-        process.exit(1);
-      }
+      const result = data.deleteProject(id)!;
+      console.log(
+        `Deleted project: ${result.knowledge_deleted} knowledge, ` +
+          `${result.temporal_deleted} messages, ` +
+          `${result.distillations_deleted} distillations, ` +
+          `${result.sessions_cleared} sessions.`,
+      );
       break;
     }
 

--- a/packages/gateway/src/cli/data.ts
+++ b/packages/gateway/src/cli/data.ts
@@ -5,7 +5,7 @@
  *   list <type>           List entries (projects, knowledge, sessions, distillations)
  *   show <type> <id>      Show full detail for an entry
  *   clear [options]       Clear data for a project or wipe the database
- *   delete <type> <id>    Delete a single entry
+ *   delete <type> <id>    Delete a single entry (type: knowledge, session, distillation, project)
  */
 import { createInterface } from "node:readline";
 import { resolve } from "path";
@@ -480,9 +480,45 @@ async function cmdDelete(
       break;
     }
 
+    case "project": {
+      const { projectId: resolveProjectId } = await import("@loreai/core");
+      // rawId can be a project UUID or a project path
+      let id = rawId;
+      if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(rawId)) {
+        const resolved = resolveProjectId(resolve(rawId));
+        if (!resolved) {
+          console.error(`No project found for path: ${rawId}`);
+          process.exit(1);
+        }
+        id = resolved;
+      }
+      if (!skipConfirm) {
+        const confirmed = await confirm(
+          `\nDelete project ${id.slice(0, 12)}... and ALL its data (knowledge, sessions, distillations)?`,
+        );
+        if (!confirmed) {
+          console.log("Cancelled.");
+          return;
+        }
+      }
+      const result = data.deleteProject(id);
+      if (result) {
+        console.log(
+          `Deleted project: ${result.knowledge_deleted} knowledge, ` +
+            `${result.temporal_deleted} messages, ` +
+            `${result.distillations_deleted} distillations, ` +
+            `${result.sessions_cleared} sessions.`,
+        );
+      } else {
+        console.error(`Project not found: ${rawId}`);
+        process.exit(1);
+      }
+      break;
+    }
+
     default:
       console.error(
-        `Unknown type "${type ?? "(none)"}". Use: knowledge, session, distillation`,
+        `Unknown type "${type ?? "(none)"}". Use: knowledge, session, distillation, project`,
       );
       process.exit(1);
   }
@@ -818,7 +854,7 @@ Subcommands:
   list <type>           List entries (projects, knowledge, sessions, distillations)
   show <type> <id>      Show full detail for an entry
   clear [options]       Clear data for a project or wipe the database
-  delete <type> <id>    Delete a single entry
+  delete <type> <id>    Delete a single entry (type: knowledge, session, distillation, project)
   merge                 Scan git remotes and merge duplicate projects
   recover               Re-import knowledge from .lore.md / AGENTS.md files
   dedup                 Find and remove duplicate knowledge entries (all projects)
@@ -845,6 +881,7 @@ Examples:
   lore data clear --all
   lore data delete knowledge abc12345
   lore data delete session abc12345-6789
+  lore data delete project /path/to/project  # delete project and ALL its data
   lore data merge                          # scan & merge git duplicates
   lore data merge --yes                    # skip confirmation
   lore data recover                        # re-import from .lore.md / AGENTS.md


### PR DESCRIPTION
## Summary

- Add `ensureProject()` guard that rejects synthetic test paths (`/test/...`) when `LORE_DB_PATH` is unset (production DB), preventing test data leaks when test files are run directly with `bun run` instead of `bun test`
- Harden `bunfig.toml` with explicit `NODE_ENV=test` in `[test.env]` as belt-and-suspenders
- Expose `lore data delete project <path|id>` via CLI so leaked test projects can be cleaned up

## Context

A test project `/test/ltm/debug-forsession` leaked into the production DB. Root cause: running a test file directly with `bun run` (for debugging) bypasses the `bunfig.toml` preload that sets `LORE_DB_PATH` to a temp DB. The existing `NODE_ENV=test` guard in `db()` doesn't help because `NODE_ENV` isn't set when the test runner isn't involved.

The new guard in `ensureProject()` catches this by detecting that paths starting with `/test/` are synthetic test paths that should never exist in the production DB. No real project path on any OS starts with `/test/`.

## Changes

| File | Change |
|---|---|
| `packages/core/src/db.ts` | Guard in `ensureProject()` — rejects `/test/` paths when `LORE_DB_PATH` unset |
| `bunfig.toml` | Add `[test.env]` with `NODE_ENV = "test"` |
| `packages/core/bunfig.toml` | Add `[test.env]` with `NODE_ENV = "test"` |
| `packages/gateway/src/cli/data.ts` | Add `project` type to `lore data delete`, update help text |
| `packages/core/test/db.test.ts` | 3 tests for the guard |

## Testing

- All 1404 tests pass, 0 failures
- Typecheck passes for all 4 packages
- After merging, run `lore data delete project /test/ltm/debug-forsession` to clean up the leaked project