### PR TITLE
feat: adaptive dedup threshold with automatic and manual calibration

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -318,6 +318,9 @@
 
 ### Preference
 
+<!-- lore:019e2820-3ed0-7cc0-97a7-2c654df763ec -->
+* **IDs starting with LOREAI-GATEWAY- are Sentry issue IDs**: Any identifier starting with \`LOREAI-GATEWAY-\` (e.g. \`LOREAI-GATEWAY-F\`) is a Sentry issue ID for the gateway project. Always treat these as Sentry issue references when encountered in conversation — fetch the issue via Sentry CLI/API to get stack traces, user counts, and release info before investigating the codebase.
+
 <!-- lore:019e2025-3eb9-7e97-88e5-614d2acb6332 -->
 * **maybeAutoImport prompt must appear before agent selection in run.ts**: Always call \`maybeAutoImport(config)\` before \`resolveLaunchTarget()\` in \`packages/gateway/src/cli/run.ts\` so the auto-import prompt appears before the user is asked which agent to launch. This ordering was explicitly required across multiple sessions and is a non-negotiable UX requirement.
 

--- a/packages/core/src/curator.ts
+++ b/packages/core/src/curator.ts
@@ -1,5 +1,5 @@
 import { config } from "./config";
-import { saveSessionTracking, loadSessionTracking } from "./db";
+import { saveSessionTracking, loadSessionTracking, ensureProject } from "./db";
 import * as temporal from "./temporal";
 import * as ltm from "./ltm";
 import * as log from "./log";
@@ -227,6 +227,18 @@ async function runInner(input: {
       if (dupes.totalRemoved > 0) {
         log.info(`post-curation dedup: merged ${dupes.totalRemoved} duplicate entries`);
         result.deleted += dupes.totalRemoved;
+      }
+      // Record auto-signals for adaptive threshold calibration.
+      // Merged pairs → accept; non-merged high-similarity pairs → reject.
+      if (dupes.pairSimilarities.size > 0) {
+        const pid = ensureProject(input.projectPath);
+        ltm.recordAutoSignals(pid, dupes);
+        // Recalibrate if enough data has accumulated
+        const newThreshold = ltm.calibrateDedupThreshold(pid);
+        if (newThreshold !== null) {
+          const count = ltm.getDedupFeedbackCount(pid);
+          ltm.saveCalibratedThreshold(pid, newThreshold, count);
+        }
       }
     } catch (err) {
       log.warn("post-curation dedup failed (non-fatal):", err);

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -546,6 +546,24 @@ const MIGRATIONS: string[] = [
   ALTER TABLE session_state ADD COLUMN last_turn_at INTEGER NOT NULL DEFAULT 0;
   ALTER TABLE session_state ADD COLUMN last_bust_at INTEGER NOT NULL DEFAULT 0;
   `,
+  `
+  -- Version 25: Adaptive dedup threshold — store accept/reject feedback
+  -- on embedding-based duplicate pairs for per-project threshold calibration.
+  -- Titles stored instead of FK IDs because entries are deleted during dedup;
+  -- the similarity float is the actual calibration input.
+  CREATE TABLE IF NOT EXISTS dedup_feedback (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_id TEXT,
+    entry_a_title TEXT NOT NULL,
+    entry_b_title TEXT NOT NULL,
+    similarity REAL NOT NULL,
+    accepted INTEGER NOT NULL,
+    source TEXT NOT NULL DEFAULT 'manual',
+    created_at INTEGER NOT NULL
+  );
+  CREATE INDEX IF NOT EXISTS idx_dedup_feedback_project
+    ON dedup_feedback(project_id);
+  `,
 ];
 
 /** Return the resolved path of the SQLite database file. */

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -1,5 +1,5 @@
 import { uuidv7 } from "uuidv7";
-import { db, ensureProject } from "./db";
+import { db, ensureProject, getKV, setKV } from "./db";
 import { config } from "./config";
 import { ftsQuery, ftsQueryOr, EMPTY_QUERY, extractTopTerms, filterTerms, runRelaxedSearch } from "./search";
 import * as embedding from "./embedding";
@@ -1078,6 +1078,8 @@ export type DedupCluster = {
 export type DedupResult = {
   clusters: DedupCluster[];
   totalRemoved: number;
+  /** Pairwise embedding cosine similarities. Key: sorted "idA:idB". */
+  pairSimilarities: Map<string, number>;
 };
 
 /**
@@ -1104,13 +1106,17 @@ export type DedupResult = {
  * @returns             Cluster report and count of removed entries
  */
 /** Core dedup logic — operates on an arbitrary list of entries. */
-function _dedup(entries: KnowledgeEntry[], dryRun: boolean): DedupResult {
-  if (entries.length < 2) return { clusters: [], totalRemoved: 0 };
+function _dedup(
+  entries: KnowledgeEntry[],
+  dryRun: boolean,
+  embeddingThreshold: number = EMBEDDING_DEDUP_THRESHOLD,
+): DedupResult {
+  if (entries.length < 2) return { clusters: [], totalRemoved: 0, pairSimilarities: new Map() };
 
   // --- Build neighbor map using title overlap + embedding similarity ---
   // Two entries are considered neighbors (potential duplicates) if EITHER:
   //   (a) title word-overlap ≥ 0.7 with ≥ 4 shared words, OR
-  //   (b) embedding cosine similarity ≥ 0.935
+  //   (b) embedding cosine similarity ≥ embeddingThreshold (default 0.935)
   // Star clustering (no transitivity) prevents snowball merging.
   // O(n²) pairwise comparison — acceptable for n ≤ 25 (maxEntries cap).
 
@@ -1138,6 +1144,8 @@ function _dedup(entries: KnowledgeEntry[], dryRun: boolean): DedupResult {
   // Pre-compute neighbors for all pairs
   type DedupHit = { id: string; score: number };
   const neighborMap = new Map<string, DedupHit[]>();
+  // Collect all pairwise embedding similarities (for feedback/calibration).
+  const pairSimilarities = new Map<string, number>();
 
   for (const entry of entries) {
     const neighbors: DedupHit[] = [];
@@ -1157,7 +1165,15 @@ function _dedup(entries: KnowledgeEntry[], dryRun: boolean): DedupResult {
         const otherVec = embeddingMap.get(other.id);
         if (otherVec && entryVec.length === otherVec.length) {
           similarity = embedding.cosineSimilarity(entryVec, otherVec);
-          embeddingMatch = similarity >= EMBEDDING_DEDUP_THRESHOLD;
+          embeddingMatch = similarity >= embeddingThreshold;
+        }
+      }
+
+      // Track all pairwise embedding similarities for calibration signals
+      if (similarity > 0) {
+        const pairKey = [entry.id, other.id].sort().join(":");
+        if (!pairSimilarities.has(pairKey)) {
+          pairSimilarities.set(pairKey, similarity);
         }
       }
 
@@ -1232,21 +1248,24 @@ function _dedup(entries: KnowledgeEntry[], dryRun: boolean): DedupResult {
   // Sort clusters by size descending for readability
   result.sort((a, b) => b.merged.length - a.merged.length);
 
-  return { clusters: result, totalRemoved };
+  return { clusters: result, totalRemoved, pairSimilarities };
 }
 
 export async function deduplicate(
   projectPath: string,
   opts?: { dryRun?: boolean },
 ): Promise<DedupResult> {
+  const pid = ensureProject(projectPath);
+  const threshold = loadCalibratedThreshold(pid) ?? EMBEDDING_DEDUP_THRESHOLD;
   const entries = forProject(projectPath, false);
-  return _dedup(entries, opts?.dryRun ?? true);
+  return _dedup(entries, opts?.dryRun ?? true, threshold);
 }
 
 /** Deduplicate global (cross-project) entries that have no project_id. */
 export async function deduplicateGlobal(
   opts?: { dryRun?: boolean },
 ): Promise<DedupResult> {
+  const threshold = loadCalibratedThreshold(null) ?? EMBEDDING_DEDUP_THRESHOLD;
   const entries = db()
     .query(
       `SELECT ${KNOWLEDGE_COLS} FROM knowledge
@@ -1255,5 +1274,296 @@ export async function deduplicateGlobal(
        ORDER BY confidence DESC, updated_at DESC`,
     )
     .all() as KnowledgeEntry[];
-  return _dedup(entries, opts?.dryRun ?? true);
+  return _dedup(entries, opts?.dryRun ?? true, threshold);
+}
+
+// ---------------------------------------------------------------------------
+// Dedup feedback & adaptive threshold calibration
+// ---------------------------------------------------------------------------
+
+export type DedupFeedbackSource = "auto_dedup" | "cli_yes" | "cli_interactive";
+
+const MIN_CALIBRATION_SAMPLES = 20;
+const DEFAULT_EMBEDDING_DEDUP_THRESHOLD = EMBEDDING_DEDUP_THRESHOLD;
+/** Only record auto-signals for pairs with similarity >= this floor. */
+const AUTO_SIGNAL_MIN_SIMILARITY = 0.80;
+/** Max auto-signal pairs to record per dedup run (closest to threshold). */
+const AUTO_SIGNAL_MAX_PAIRS = 50;
+
+/** Record a single dedup feedback row. */
+export function recordDedupFeedback(input: {
+  projectId: string | null;
+  entryATitle: string;
+  entryBTitle: string;
+  similarity: number;
+  accepted: boolean;
+  source: DedupFeedbackSource;
+}): void {
+  db()
+    .query(
+      `INSERT INTO dedup_feedback
+         (project_id, entry_a_title, entry_b_title, similarity, accepted, source, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      input.projectId,
+      input.entryATitle,
+      input.entryBTitle,
+      input.similarity,
+      input.accepted ? 1 : 0,
+      input.source,
+      Date.now(),
+    );
+}
+
+/**
+ * Bulk-record feedback for all merged pairs in a DedupResult.
+ * Only records pairs with embedding similarity > 0 (title-overlap-only
+ * matches are excluded from calibration).
+ */
+export function recordDedupResultFeedback(
+  projectId: string | null,
+  result: DedupResult,
+  accepted: boolean,
+  source: DedupFeedbackSource,
+): void {
+  for (const cluster of result.clusters) {
+    for (const merged of cluster.merged) {
+      const pairKey = [cluster.surviving.id, merged.id].sort().join(":");
+      const similarity = result.pairSimilarities.get(pairKey);
+      if (similarity != null && similarity > 0) {
+        recordDedupFeedback({
+          projectId,
+          entryATitle: cluster.surviving.title,
+          entryBTitle: merged.title,
+          similarity,
+          accepted,
+          source,
+        });
+      }
+    }
+  }
+}
+
+/**
+ * Record automatic calibration signals from a post-curation dedup sweep.
+ *
+ * - Merged pairs → accept signals
+ * - Non-merged pairs with similarity in [0.80, threshold) → reject signals
+ *   (the system decided they were distinct at this similarity level)
+ *
+ * Caps at AUTO_SIGNAL_MAX_PAIRS most interesting pairs per run (closest
+ * to the threshold boundary) to avoid table bloat.
+ */
+export function recordAutoSignals(
+  projectId: string | null,
+  result: DedupResult,
+): void {
+  // Collect merged pair IDs for quick lookup
+  const mergedPairs = new Set<string>();
+  for (const cluster of result.clusters) {
+    for (const merged of cluster.merged) {
+      const pairKey = [cluster.surviving.id, merged.id].sort().join(":");
+      mergedPairs.add(pairKey);
+    }
+  }
+
+  // Build a title map from the pairSimilarities keys — we need titles for
+  // reject signals too (non-merged pairs). For entries that appear in clusters
+  // we have titles directly; for others we need to look them up.
+  const titleMap = new Map<string, string>();
+  for (const cluster of result.clusters) {
+    titleMap.set(cluster.surviving.id, cluster.surviving.title);
+    for (const m of cluster.merged) {
+      titleMap.set(m.id, m.title);
+    }
+  }
+
+  // For reject signals, we need titles for entries not in any cluster.
+  // Look them up from the DB if missing.
+  for (const pairKey of result.pairSimilarities.keys()) {
+    const [idA, idB] = pairKey.split(":");
+    for (const id of [idA, idB]) {
+      if (!titleMap.has(id)) {
+        const row = db()
+          .query("SELECT title FROM knowledge WHERE id = ?")
+          .get(id) as { title: string } | null;
+        if (row) titleMap.set(id, row.title);
+      }
+    }
+  }
+
+  // Collect all candidate signals
+  type Signal = { entryATitle: string; entryBTitle: string; similarity: number; accepted: boolean };
+  const signals: Signal[] = [];
+
+  // Accept signals: merged pairs with embedding similarity
+  for (const cluster of result.clusters) {
+    for (const merged of cluster.merged) {
+      const pairKey = [cluster.surviving.id, merged.id].sort().join(":");
+      const sim = result.pairSimilarities.get(pairKey);
+      if (sim != null && sim >= AUTO_SIGNAL_MIN_SIMILARITY) {
+        signals.push({
+          entryATitle: cluster.surviving.title,
+          entryBTitle: merged.title,
+          similarity: sim,
+          accepted: true,
+        });
+      }
+    }
+  }
+
+  // Reject signals: non-merged pairs with high similarity
+  for (const [pairKey, sim] of result.pairSimilarities) {
+    if (sim < AUTO_SIGNAL_MIN_SIMILARITY) continue;
+    if (mergedPairs.has(pairKey)) continue; // already recorded as accept
+
+    const [idA, idB] = pairKey.split(":");
+    const titleA = titleMap.get(idA);
+    const titleB = titleMap.get(idB);
+    if (!titleA || !titleB) continue;
+
+    signals.push({
+      entryATitle: titleA,
+      entryBTitle: titleB,
+      similarity: sim,
+      accepted: false,
+    });
+  }
+
+  // Sort by distance to threshold boundary (most informative first), cap
+  const currentThreshold = loadCalibratedThreshold(projectId) ?? DEFAULT_EMBEDDING_DEDUP_THRESHOLD;
+  signals.sort((a, b) => Math.abs(a.similarity - currentThreshold) - Math.abs(b.similarity - currentThreshold));
+  const capped = signals.slice(0, AUTO_SIGNAL_MAX_PAIRS);
+
+  for (const s of capped) {
+    recordDedupFeedback({
+      projectId,
+      entryATitle: s.entryATitle,
+      entryBTitle: s.entryBTitle,
+      similarity: s.similarity,
+      accepted: s.accepted,
+      source: "auto_dedup",
+    });
+  }
+}
+
+/** Get all feedback for a project (for calibration). */
+export function getDedupFeedback(
+  projectId: string | null,
+): Array<{ similarity: number; accepted: boolean; source: string }> {
+  const rows = (
+    projectId !== null
+      ? db()
+          .query(
+            "SELECT similarity, accepted, source FROM dedup_feedback WHERE project_id = ? ORDER BY similarity",
+          )
+          .all(projectId)
+      : db()
+          .query(
+            "SELECT similarity, accepted, source FROM dedup_feedback WHERE project_id IS NULL ORDER BY similarity",
+          )
+          .all()
+  ) as Array<{ similarity: number; accepted: number; source: string }>;
+  return rows.map((r) => ({ similarity: r.similarity, accepted: r.accepted === 1, source: r.source }));
+}
+
+/** Quick count of feedback rows for a project. */
+export function getDedupFeedbackCount(projectId: string | null): number {
+  const row = (
+    projectId !== null
+      ? db()
+          .query("SELECT COUNT(*) as cnt FROM dedup_feedback WHERE project_id = ?")
+          .get(projectId)
+      : db()
+          .query("SELECT COUNT(*) as cnt FROM dedup_feedback WHERE project_id IS NULL")
+          .get()
+  ) as { cnt: number } | null;
+  return row?.cnt ?? 0;
+}
+
+/**
+ * Compute an optimal embedding dedup threshold from user feedback.
+ *
+ * Algorithm:
+ * 1. Load all (similarity, accepted) pairs for the project.
+ * 2. If fewer than MIN_CALIBRATION_SAMPLES, return null (use default).
+ * 3. If all feedback is "accept" (no rejects), return the minimum
+ *    accepted similarity minus a small margin (0.005).
+ * 4. If all feedback is "reject" (no accepts), return null.
+ * 5. Otherwise, find the threshold that maximizes separation:
+ *    - For each candidate threshold (midpoint between consecutive
+ *      distinct similarity values), compute accuracy:
+ *        correct = accepted_pairs_above + rejected_pairs_below
+ *        accuracy = correct / total
+ *    - Pick the threshold with highest accuracy.
+ *    - Tie-break: prefer higher threshold (conservative).
+ *    - Clamp to [0.85, 0.98].
+ */
+export function calibrateDedupThreshold(projectId: string | null): number | null {
+  const feedback = getDedupFeedback(projectId);
+  if (feedback.length < MIN_CALIBRATION_SAMPLES) return null;
+
+  const accepted = feedback.filter((f) => f.accepted);
+  const rejected = feedback.filter((f) => !f.accepted);
+
+  // Edge case: all accept, no rejects
+  if (rejected.length === 0) {
+    const minAccepted = Math.min(...accepted.map((f) => f.similarity));
+    return Math.max(0.85, minAccepted - 0.005);
+  }
+
+  // Edge case: all reject, no accepts
+  if (accepted.length === 0) {
+    log.warn("dedup calibration: all feedback is reject — keeping default threshold");
+    return null;
+  }
+
+  // Find optimal threshold via accuracy maximization
+  const allSims = [...new Set(feedback.map((f) => f.similarity))].sort((a, b) => a - b);
+
+  let bestThreshold = DEFAULT_EMBEDDING_DEDUP_THRESHOLD;
+  let bestAccuracy = -1;
+
+  for (let i = 0; i < allSims.length - 1; i++) {
+    const candidate = (allSims[i] + allSims[i + 1]) / 2;
+
+    // Pairs above threshold are predicted "merge" — should be accepted
+    // Pairs below threshold are predicted "keep separate" — should be rejected
+    const correctAccepted = accepted.filter((f) => f.similarity >= candidate).length;
+    const correctRejected = rejected.filter((f) => f.similarity < candidate).length;
+    const accuracy = (correctAccepted + correctRejected) / feedback.length;
+
+    // Tie-break: prefer higher threshold (conservative — fewer false merges)
+    if (accuracy > bestAccuracy || (accuracy === bestAccuracy && candidate > bestThreshold)) {
+      bestAccuracy = accuracy;
+      bestThreshold = candidate;
+    }
+  }
+
+  // Clamp to sane range
+  return Math.max(0.85, Math.min(0.98, bestThreshold));
+}
+
+/** Persist the calibrated threshold for a project. */
+export function saveCalibratedThreshold(
+  projectId: string | null,
+  threshold: number,
+  sampleSize: number,
+): void {
+  const key = `dedup_threshold:${projectId ?? "global"}`;
+  setKV(key, JSON.stringify({ threshold, sampleSize, calibratedAt: Date.now() }));
+}
+
+/** Load the calibrated threshold for a project, or null if not calibrated. */
+export function loadCalibratedThreshold(projectId: string | null): number | null {
+  const key = `dedup_threshold:${projectId ?? "global"}`;
+  const raw = getKV(key);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return typeof parsed.threshold === "number" ? parsed.threshold : null;
+  } catch {
+    return null;
+  }
 }

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -1075,11 +1075,18 @@ export type DedupCluster = {
   merged: Array<{ id: string; title: string }>;
 };
 
+/** Stable pair key for two entry IDs — sorted to ensure order-independence. */
+export function dedupPairKey(idA: string, idB: string): string {
+  return idA < idB ? `${idA}:${idB}` : `${idB}:${idA}`;
+}
+
 export type DedupResult = {
   clusters: DedupCluster[];
   totalRemoved: number;
-  /** Pairwise embedding cosine similarities. Key: sorted "idA:idB". */
+  /** Pairwise embedding cosine similarities. Key: dedupPairKey(idA, idB). */
   pairSimilarities: Map<string, number>;
+  /** All entry titles by ID — for feedback recording after entries are deleted. */
+  entryTitles: Map<string, string>;
 };
 
 /**
@@ -1111,7 +1118,7 @@ function _dedup(
   dryRun: boolean,
   embeddingThreshold: number = EMBEDDING_DEDUP_THRESHOLD,
 ): DedupResult {
-  if (entries.length < 2) return { clusters: [], totalRemoved: 0, pairSimilarities: new Map() };
+  if (entries.length < 2) return { clusters: [], totalRemoved: 0, pairSimilarities: new Map(), entryTitles: new Map() };
 
   // --- Build neighbor map using title overlap + embedding similarity ---
   // Two entries are considered neighbors (potential duplicates) if EITHER:
@@ -1171,9 +1178,9 @@ function _dedup(
 
       // Track all pairwise embedding similarities for calibration signals
       if (similarity > 0) {
-        const pairKey = [entry.id, other.id].sort().join(":");
-        if (!pairSimilarities.has(pairKey)) {
-          pairSimilarities.set(pairKey, similarity);
+        const pk = dedupPairKey(entry.id, other.id);
+        if (!pairSimilarities.has(pk)) {
+          pairSimilarities.set(pk, similarity);
         }
       }
 
@@ -1248,7 +1255,10 @@ function _dedup(
   // Sort clusters by size descending for readability
   result.sort((a, b) => b.merged.length - a.merged.length);
 
-  return { clusters: result, totalRemoved, pairSimilarities };
+  // Build title map from all input entries — survives entry deletion.
+  const entryTitles = new Map(entries.map((e) => [e.id, e.title]));
+
+  return { clusters: result, totalRemoved, pairSimilarities, entryTitles };
 }
 
 export async function deduplicate(
@@ -1329,8 +1339,8 @@ export function recordDedupResultFeedback(
 ): void {
   for (const cluster of result.clusters) {
     for (const merged of cluster.merged) {
-      const pairKey = [cluster.surviving.id, merged.id].sort().join(":");
-      const similarity = result.pairSimilarities.get(pairKey);
+      const pk = dedupPairKey(cluster.surviving.id, merged.id);
+      const similarity = result.pairSimilarities.get(pk);
       if (similarity != null && similarity > 0) {
         recordDedupFeedback({
           projectId,
@@ -1348,9 +1358,11 @@ export function recordDedupResultFeedback(
 /**
  * Record automatic calibration signals from a post-curation dedup sweep.
  *
- * - Merged pairs → accept signals
- * - Non-merged pairs with similarity in [0.80, threshold) → reject signals
- *   (the system decided they were distinct at this similarity level)
+ * Only records **reject** signals — non-merged pairs with similarity in
+ * [0.80, threshold). Accept signals from auto-dedup are tautological (the
+ * pair was merged *because* its similarity exceeded the threshold), so they
+ * provide no new information and would create a self-reinforcing feedback
+ * loop. Manual signals (cli_yes, cli_interactive) provide the accept side.
  *
  * Caps at AUTO_SIGNAL_MAX_PAIRS most interesting pairs per run (closest
  * to the threshold boundary) to avoid table bloat.
@@ -1359,76 +1371,40 @@ export function recordAutoSignals(
   projectId: string | null,
   result: DedupResult,
 ): void {
-  // Collect merged pair IDs for quick lookup
+  // Collect merged pair IDs for quick lookup (to exclude from reject signals)
   const mergedPairs = new Set<string>();
   for (const cluster of result.clusters) {
     for (const merged of cluster.merged) {
-      const pairKey = [cluster.surviving.id, merged.id].sort().join(":");
-      mergedPairs.add(pairKey);
+      mergedPairs.add(dedupPairKey(cluster.surviving.id, merged.id));
     }
   }
 
-  // Build a title map from the pairSimilarities keys — we need titles for
-  // reject signals too (non-merged pairs). For entries that appear in clusters
-  // we have titles directly; for others we need to look them up.
-  const titleMap = new Map<string, string>();
+  // Build a title map — we need titles for reject signals (non-merged pairs).
+  // Use entryTitles from result first, then fall back to cluster data.
+  const titleMap = new Map<string, string>(result.entryTitles);
   for (const cluster of result.clusters) {
-    titleMap.set(cluster.surviving.id, cluster.surviving.title);
+    if (!titleMap.has(cluster.surviving.id)) {
+      titleMap.set(cluster.surviving.id, cluster.surviving.title);
+    }
     for (const m of cluster.merged) {
-      titleMap.set(m.id, m.title);
+      if (!titleMap.has(m.id)) titleMap.set(m.id, m.title);
     }
   }
 
-  // For reject signals, we need titles for entries not in any cluster.
-  // Look them up from the DB if missing.
-  for (const pairKey of result.pairSimilarities.keys()) {
-    const [idA, idB] = pairKey.split(":");
-    for (const id of [idA, idB]) {
-      if (!titleMap.has(id)) {
-        const row = db()
-          .query("SELECT title FROM knowledge WHERE id = ?")
-          .get(id) as { title: string } | null;
-        if (row) titleMap.set(id, row.title);
-      }
-    }
-  }
-
-  // Collect all candidate signals
-  type Signal = { entryATitle: string; entryBTitle: string; similarity: number; accepted: boolean };
+  // Collect reject signals: non-merged pairs with high similarity
+  type Signal = { entryATitle: string; entryBTitle: string; similarity: number };
   const signals: Signal[] = [];
 
-  // Accept signals: merged pairs with embedding similarity
-  for (const cluster of result.clusters) {
-    for (const merged of cluster.merged) {
-      const pairKey = [cluster.surviving.id, merged.id].sort().join(":");
-      const sim = result.pairSimilarities.get(pairKey);
-      if (sim != null && sim >= AUTO_SIGNAL_MIN_SIMILARITY) {
-        signals.push({
-          entryATitle: cluster.surviving.title,
-          entryBTitle: merged.title,
-          similarity: sim,
-          accepted: true,
-        });
-      }
-    }
-  }
-
-  // Reject signals: non-merged pairs with high similarity
-  for (const [pairKey, sim] of result.pairSimilarities) {
+  for (const [pk, sim] of result.pairSimilarities) {
     if (sim < AUTO_SIGNAL_MIN_SIMILARITY) continue;
-    if (mergedPairs.has(pairKey)) continue; // already recorded as accept
+    if (mergedPairs.has(pk)) continue; // merged pair — skip (tautological accept)
 
-    const [idA, idB] = pairKey.split(":");
+    const [idA, idB] = pk.split(":");
     const titleA = titleMap.get(idA);
     const titleB = titleMap.get(idB);
     if (!titleA || !titleB) continue;
 
-    signals.push({
-      entryATitle: titleA,
-      entryBTitle: titleB,
-      similarity: sim,
-      accepted: false,
-    });
+    signals.push({ entryATitle: titleA, entryBTitle: titleB, similarity: sim });
   }
 
   // Sort by distance to threshold boundary (most informative first), cap
@@ -1436,13 +1412,16 @@ export function recordAutoSignals(
   signals.sort((a, b) => Math.abs(a.similarity - currentThreshold) - Math.abs(b.similarity - currentThreshold));
   const capped = signals.slice(0, AUTO_SIGNAL_MAX_PAIRS);
 
+  // Prune old feedback to prevent unbounded table growth
+  pruneDedupFeedback(projectId);
+
   for (const s of capped) {
     recordDedupFeedback({
       projectId,
       entryATitle: s.entryATitle,
       entryBTitle: s.entryBTitle,
       similarity: s.similarity,
-      accepted: s.accepted,
+      accepted: false,
       source: "auto_dedup",
     });
   }
@@ -1480,6 +1459,40 @@ export function getDedupFeedbackCount(projectId: string | null): number {
           .get()
   ) as { cnt: number } | null;
   return row?.cnt ?? 0;
+}
+
+/** Max feedback rows to keep per project (prevents unbounded growth). */
+const MAX_FEEDBACK_ROWS_PER_PROJECT = 500;
+
+/**
+ * Prune old feedback rows for a project, keeping the most recent
+ * MAX_FEEDBACK_ROWS_PER_PROJECT rows. Called from recordAutoSignals
+ * to prevent unbounded table growth.
+ */
+export function pruneDedupFeedback(projectId: string | null): void {
+  const count = getDedupFeedbackCount(projectId);
+  if (count <= MAX_FEEDBACK_ROWS_PER_PROJECT) return;
+
+  const excess = count - MAX_FEEDBACK_ROWS_PER_PROJECT;
+  if (projectId !== null) {
+    db()
+      .query(
+        `DELETE FROM dedup_feedback WHERE id IN (
+           SELECT id FROM dedup_feedback WHERE project_id = ?
+           ORDER BY created_at ASC LIMIT ?
+         )`,
+      )
+      .run(projectId, excess);
+  } else {
+    db()
+      .query(
+        `DELETE FROM dedup_feedback WHERE id IN (
+           SELECT id FROM dedup_feedback WHERE project_id IS NULL
+           ORDER BY created_at ASC LIMIT ?
+         )`,
+      )
+      .run(excess);
+  }
 }
 
 /**

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -23,7 +23,7 @@ describe("db", () => {
     const row = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(row.version).toBe(24);
+    expect(row.version).toBe(25);
   });
 
   test("distillation_fts virtual table exists", () => {

--- a/packages/core/test/dedup.test.ts
+++ b/packages/core/test/dedup.test.ts
@@ -1,0 +1,666 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { uuidv7 } from "uuidv7";
+import { db, ensureProject, getKV } from "../src/db";
+import * as ltm from "../src/ltm";
+import * as embedding from "../src/embedding";
+
+const PROJECT = "/test/dedup/project";
+const PROJECT_B = "/test/dedup/project-b";
+
+/**
+ * Create a knowledge entry with an explicit ID to bypass the create-time
+ * dedup guard (which would merge entries with similar titles).
+ */
+function createEntry(opts: {
+  title: string;
+  content?: string;
+  confidence?: number;
+  projectPath?: string;
+  scope?: "project" | "global";
+  crossProject?: boolean;
+}): string {
+  const id = ltm.create({
+    id: uuidv7(), // explicit ID bypasses create-time dedup guard
+    projectPath: opts.projectPath ?? PROJECT,
+    category: "gotcha",
+    title: opts.title,
+    content: opts.content ?? `Content for ${opts.title}`,
+    scope: opts.scope ?? "project",
+    crossProject: opts.crossProject,
+    session: "test-session",
+  });
+  // Set confidence if specified (create always sets 1.0)
+  if (opts.confidence != null && opts.confidence !== 1.0) {
+    ltm.update(id, { confidence: opts.confidence });
+  }
+  return id;
+}
+
+/**
+ * Inject a fake embedding for a knowledge entry directly into the DB.
+ * Creates a Float32Array of the given dimension with a deterministic pattern
+ * based on the seed value.
+ */
+function injectEmbedding(entryId: string, seed: number, dims = 768): void {
+  const vec = new Float32Array(dims);
+  // Create a normalized vector with a unique direction based on seed
+  for (let i = 0; i < dims; i++) {
+    vec[i] = Math.sin(seed * (i + 1) * 0.1);
+  }
+  // Normalize to unit length
+  let norm = 0;
+  for (let i = 0; i < dims; i++) norm += vec[i] * vec[i];
+  norm = Math.sqrt(norm);
+  for (let i = 0; i < dims; i++) vec[i] /= norm;
+
+  const blob = Buffer.from(vec.buffer);
+  db().query("UPDATE knowledge SET embedding = ? WHERE id = ?").run(blob, entryId);
+}
+
+/**
+ * Inject an embedding that is a slight perturbation of another seed's vector.
+ * This creates vectors with high cosine similarity.
+ */
+function injectSimilarEmbedding(entryId: string, baseSeed: number, perturbation: number, dims = 768): void {
+  const vec = new Float32Array(dims);
+  for (let i = 0; i < dims; i++) {
+    vec[i] = Math.sin(baseSeed * (i + 1) * 0.1) + perturbation * Math.cos((i + 1) * 0.3);
+  }
+  let norm = 0;
+  for (let i = 0; i < dims; i++) norm += vec[i] * vec[i];
+  norm = Math.sqrt(norm);
+  for (let i = 0; i < dims; i++) vec[i] /= norm;
+
+  const blob = Buffer.from(vec.buffer);
+  db().query("UPDATE knowledge SET embedding = ? WHERE id = ?").run(blob, entryId);
+}
+
+/** Clean up all knowledge and feedback data between tests. */
+function cleanup(): void {
+  db().query("DELETE FROM knowledge").run();
+  db().query("DELETE FROM dedup_feedback").run();
+  db().query("DELETE FROM kv_meta WHERE key LIKE 'dedup_threshold:%'").run();
+}
+
+// ---------------------------------------------------------------------------
+// Core _dedup() tests
+// ---------------------------------------------------------------------------
+
+describe("dedup — core _dedup()", () => {
+  beforeEach(cleanup);
+
+  test("no entries → empty result", async () => {
+    const result = await ltm.deduplicate(PROJECT, { dryRun: true });
+    expect(result.clusters).toHaveLength(0);
+    expect(result.totalRemoved).toBe(0);
+    expect(result.pairSimilarities.size).toBe(0);
+  });
+
+  test("single entry → empty result", async () => {
+    createEntry({ title: "Single entry about caching" });
+    const result = await ltm.deduplicate(PROJECT, { dryRun: true });
+    expect(result.clusters).toHaveLength(0);
+    expect(result.totalRemoved).toBe(0);
+  });
+
+  test("two entries with identical long titles → one cluster via title overlap", async () => {
+    // Titles with enough meaningful words to pass fuzzy dedup
+    const id1 = createEntry({ title: "Cache warming time slot buckets hardcoded values" });
+    const id2 = createEntry({ title: "Cache warming time slot buckets hardcoded values duplicate" });
+
+    const result = await ltm.deduplicate(PROJECT, { dryRun: true });
+    expect(result.clusters).toHaveLength(1);
+    expect(result.totalRemoved).toBe(1);
+  });
+
+  test("two entries with very different titles → no cluster", async () => {
+    createEntry({ title: "SQLite FTS5 ranking algorithm" });
+    createEntry({ title: "React useState async pitfall" });
+
+    const result = await ltm.deduplicate(PROJECT, { dryRun: true });
+    expect(result.clusters).toHaveLength(0);
+  });
+
+  test("dryRun: true does not delete entries", async () => {
+    const id1 = createEntry({ title: "Cache warming time slot buckets hardcoded values" });
+    const id2 = createEntry({ title: "Cache warming time slot buckets hardcoded values duplicate" });
+
+    await ltm.deduplicate(PROJECT, { dryRun: true });
+    // Both entries should still exist
+    expect(ltm.get(id1)).not.toBeNull();
+    expect(ltm.get(id2)).not.toBeNull();
+  });
+
+  test("dryRun: false deletes merged entries", async () => {
+    const id1 = createEntry({
+      title: "Cache warming time slot buckets hardcoded values",
+      confidence: 0.9,
+    });
+    const id2 = createEntry({
+      title: "Cache warming time slot buckets hardcoded values duplicate",
+      confidence: 0.8,
+    });
+
+    const result = await ltm.deduplicate(PROJECT, { dryRun: false });
+    expect(result.clusters).toHaveLength(1);
+
+    // Survivor (higher confidence) should exist, merged should be deleted
+    expect(ltm.get(id1)).not.toBeNull();
+    expect(ltm.get(id2)).toBeNull();
+  });
+
+  test("survivor selection: highest confidence wins", async () => {
+    const id1 = createEntry({
+      title: "Auto TTL downgrade needs hysteresis flapping cache busts",
+      confidence: 0.7,
+    });
+    const id2 = createEntry({
+      title: "Auto TTL downgrade needs hysteresis single miss cache busts",
+      confidence: 0.9,
+    });
+
+    const result = await ltm.deduplicate(PROJECT, { dryRun: false });
+    expect(result.clusters).toHaveLength(1);
+    expect(result.clusters[0].surviving.id).toBe(id2);
+    expect(ltm.get(id2)).not.toBeNull();
+    expect(ltm.get(id1)).toBeNull();
+  });
+
+  test("pairSimilarities map is populated with embedding similarities", async () => {
+    const id1 = createEntry({ title: "Entry about alpha" });
+    const id2 = createEntry({ title: "Entry about beta" });
+
+    // Inject embeddings — same seed creates identical vectors (sim = 1.0)
+    injectEmbedding(id1, 42);
+    injectEmbedding(id2, 42);
+
+    const result = await ltm.deduplicate(PROJECT, { dryRun: true });
+    expect(result.pairSimilarities.size).toBeGreaterThan(0);
+
+    const pairKey = [id1, id2].sort().join(":");
+    const sim = result.pairSimilarities.get(pairKey);
+    expect(sim).toBeDefined();
+    // Identical vectors should have similarity ~1.0
+    expect(sim!).toBeCloseTo(1.0, 2);
+  });
+
+  test("embedding-based dedup: high similarity triggers merge", async () => {
+    const id1 = createEntry({ title: "Completely unique title alpha" });
+    const id2 = createEntry({ title: "Completely unique title beta" });
+
+    // Same seed → identical embeddings → similarity = 1.0 → above any threshold
+    injectEmbedding(id1, 42);
+    injectEmbedding(id2, 42);
+
+    const result = await ltm.deduplicate(PROJECT, { dryRun: true });
+    expect(result.clusters).toHaveLength(1);
+    expect(result.totalRemoved).toBe(1);
+  });
+
+  test("embedding-based dedup: low similarity does not trigger merge", async () => {
+    const id1 = createEntry({ title: "Completely unique title alpha" });
+    const id2 = createEntry({ title: "Completely unique title beta" });
+
+    // Very different seeds → low similarity
+    injectEmbedding(id1, 1);
+    injectEmbedding(id2, 1000);
+
+    const result = await ltm.deduplicate(PROJECT, { dryRun: true });
+    // Similarity should be well below threshold — no cluster
+    expect(result.clusters).toHaveLength(0);
+  });
+
+  test("star clustering does not transitively chain", async () => {
+    // A matches B via title overlap, B matches C via title overlap,
+    // but A does NOT match C. Star clustering should prevent A and C
+    // from being in the same cluster.
+    const idA = createEntry({ title: "Gateway recall follow-up causes double cache write problem" });
+    const idB = createEntry({ title: "Recall follow-up causes double cache write duplication" });
+    const idC = createEntry({ title: "Double cache write from streaming translator duplication" });
+
+    const result = await ltm.deduplicate(PROJECT, { dryRun: true });
+
+    // B matches both A and C, so B becomes the hub. But A and C don't
+    // match each other. In star clustering, B claims A and C into one cluster.
+    // This is expected behavior for star clustering — the key is that entries
+    // only cluster through a direct match, not through transitive chains
+    // where two separate hubs each capture different neighbors.
+    for (const cluster of result.clusters) {
+      // Each entry in a cluster must directly match the center
+      const allIds = [cluster.surviving.id, ...cluster.merged.map((m) => m.id)];
+      expect(allIds.length).toBeLessThanOrEqual(3);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Feedback recording
+// ---------------------------------------------------------------------------
+
+describe("dedup — feedback recording", () => {
+  beforeEach(cleanup);
+
+  test("recordDedupFeedback stores a row with correct fields", () => {
+    const pid = ensureProject(PROJECT);
+    ltm.recordDedupFeedback({
+      projectId: pid,
+      entryATitle: "Entry A",
+      entryBTitle: "Entry B",
+      similarity: 0.942,
+      accepted: true,
+      source: "cli_interactive",
+    });
+
+    const feedback = ltm.getDedupFeedback(pid);
+    expect(feedback).toHaveLength(1);
+    expect(feedback[0].similarity).toBeCloseTo(0.942, 3);
+    expect(feedback[0].accepted).toBe(true);
+    expect(feedback[0].source).toBe("cli_interactive");
+  });
+
+  test("recordDedupFeedback with null projectId stores global feedback", () => {
+    ltm.recordDedupFeedback({
+      projectId: null,
+      entryATitle: "Global A",
+      entryBTitle: "Global B",
+      similarity: 0.95,
+      accepted: false,
+      source: "auto_dedup",
+    });
+
+    const feedback = ltm.getDedupFeedback(null);
+    expect(feedback).toHaveLength(1);
+    expect(feedback[0].accepted).toBe(false);
+  });
+
+  test("getDedupFeedback scopes correctly to project_id", () => {
+    const pidA = ensureProject(PROJECT);
+    const pidB = ensureProject(PROJECT_B);
+
+    ltm.recordDedupFeedback({
+      projectId: pidA,
+      entryATitle: "A1", entryBTitle: "A2",
+      similarity: 0.93, accepted: true, source: "cli_yes",
+    });
+    ltm.recordDedupFeedback({
+      projectId: pidB,
+      entryATitle: "B1", entryBTitle: "B2",
+      similarity: 0.94, accepted: false, source: "cli_interactive",
+    });
+
+    const feedbackA = ltm.getDedupFeedback(pidA);
+    const feedbackB = ltm.getDedupFeedback(pidB);
+    expect(feedbackA).toHaveLength(1);
+    expect(feedbackB).toHaveLength(1);
+    expect(feedbackA[0].similarity).toBeCloseTo(0.93, 2);
+    expect(feedbackB[0].similarity).toBeCloseTo(0.94, 2);
+  });
+
+  test("getDedupFeedbackCount returns correct count", () => {
+    const pid = ensureProject(PROJECT);
+    expect(ltm.getDedupFeedbackCount(pid)).toBe(0);
+
+    for (let i = 0; i < 5; i++) {
+      ltm.recordDedupFeedback({
+        projectId: pid,
+        entryATitle: `A${i}`, entryBTitle: `B${i}`,
+        similarity: 0.9 + i * 0.01, accepted: true, source: "auto_dedup",
+      });
+    }
+
+    expect(ltm.getDedupFeedbackCount(pid)).toBe(5);
+  });
+
+  test("recordDedupResultFeedback stores one row per merged pair", async () => {
+    const id1 = createEntry({ title: "Cache warming time slot buckets hardcoded values" });
+    const id2 = createEntry({ title: "Cache warming time slot buckets hardcoded values extra" });
+    // Inject identical embeddings so they get a similarity score
+    injectEmbedding(id1, 42);
+    injectEmbedding(id2, 42);
+
+    const result = await ltm.deduplicate(PROJECT, { dryRun: true });
+    expect(result.clusters).toHaveLength(1);
+
+    const pid = ensureProject(PROJECT);
+    ltm.recordDedupResultFeedback(pid, result, true, "cli_yes");
+
+    const feedback = ltm.getDedupFeedback(pid);
+    expect(feedback).toHaveLength(1);
+    expect(feedback[0].accepted).toBe(true);
+    expect(feedback[0].source).toBe("cli_yes");
+    expect(feedback[0].similarity).toBeGreaterThan(0);
+  });
+
+  test("feedback survives entry deletion (no FK cascade)", () => {
+    const pid = ensureProject(PROJECT);
+    const id1 = createEntry({ title: "Temporary entry to be deleted" });
+
+    ltm.recordDedupFeedback({
+      projectId: pid,
+      entryATitle: "Temporary entry to be deleted",
+      entryBTitle: "Another entry",
+      similarity: 0.94,
+      accepted: true,
+      source: "cli_yes",
+    });
+
+    // Delete the entry
+    ltm.remove(id1);
+    expect(ltm.get(id1)).toBeNull();
+
+    // Feedback should still be there
+    const feedback = ltm.getDedupFeedback(pid);
+    expect(feedback).toHaveLength(1);
+    expect(feedback[0].similarity).toBeCloseTo(0.94, 2);
+  });
+
+  test("recordAutoSignals records accepts for merged pairs", async () => {
+    const id1 = createEntry({ title: "Unique entry for auto signal alpha" });
+    const id2 = createEntry({ title: "Unique entry for auto signal beta" });
+    // Same embedding → merged
+    injectEmbedding(id1, 42);
+    injectEmbedding(id2, 42);
+
+    const result = await ltm.deduplicate(PROJECT, { dryRun: true });
+    expect(result.clusters).toHaveLength(1);
+
+    const pid = ensureProject(PROJECT);
+    ltm.recordAutoSignals(pid, result);
+
+    const feedback = ltm.getDedupFeedback(pid);
+    const accepts = feedback.filter((f) => f.accepted);
+    expect(accepts.length).toBeGreaterThanOrEqual(1);
+    expect(accepts[0].source).toBe("auto_dedup");
+  });
+
+  test("recordAutoSignals records rejects for high-similarity non-merged pairs", async () => {
+    const id1 = createEntry({ title: "Unique entry for reject signal alpha" });
+    const id2 = createEntry({ title: "Unique entry for reject signal beta" });
+    // Similar but not identical embeddings — perturbation creates
+    // a similarity that should be above 0.80 but below 0.935
+    injectSimilarEmbedding(id1, 42, 0);
+    injectSimilarEmbedding(id2, 42, 0.5);
+
+    const result = await ltm.deduplicate(PROJECT, { dryRun: true });
+
+    const pid = ensureProject(PROJECT);
+    const pairKey = [id1, id2].sort().join(":");
+    const sim = result.pairSimilarities.get(pairKey);
+
+    // Only expect reject signals if similarity is in the [0.80, threshold) range
+    if (sim != null && sim >= 0.80 && result.clusters.length === 0) {
+      ltm.recordAutoSignals(pid, result);
+      const feedback = ltm.getDedupFeedback(pid);
+      const rejects = feedback.filter((f) => !f.accepted);
+      expect(rejects.length).toBeGreaterThanOrEqual(1);
+      expect(rejects[0].source).toBe("auto_dedup");
+    }
+  });
+
+  test("recordAutoSignals filters out pairs below 0.80 similarity", async () => {
+    const id1 = createEntry({ title: "Unique entry for low sim alpha" });
+    const id2 = createEntry({ title: "Unique entry for low sim beta" });
+    // Very different embeddings → low similarity
+    injectEmbedding(id1, 1);
+    injectEmbedding(id2, 1000);
+
+    const result = await ltm.deduplicate(PROJECT, { dryRun: true });
+    const pid = ensureProject(PROJECT);
+
+    ltm.recordAutoSignals(pid, result);
+
+    // Should not record any signals for very dissimilar pairs
+    const feedback = ltm.getDedupFeedback(pid);
+    for (const f of feedback) {
+      expect(f.similarity).toBeGreaterThanOrEqual(0.80);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Threshold calibration
+// ---------------------------------------------------------------------------
+
+describe("dedup — threshold calibration", () => {
+  beforeEach(cleanup);
+
+  /** Helper to seed feedback rows. */
+  function seedFeedback(
+    projectId: string | null,
+    rows: Array<{ similarity: number; accepted: boolean }>,
+  ): void {
+    for (const row of rows) {
+      ltm.recordDedupFeedback({
+        projectId,
+        entryATitle: `A-${row.similarity}`,
+        entryBTitle: `B-${row.similarity}`,
+        similarity: row.similarity,
+        accepted: row.accepted,
+        source: "cli_interactive",
+      });
+    }
+  }
+
+  test("returns null with fewer than 20 samples", () => {
+    const pid = ensureProject(PROJECT);
+    seedFeedback(pid, [
+      { similarity: 0.94, accepted: true },
+      { similarity: 0.93, accepted: false },
+    ]);
+    expect(ltm.calibrateDedupThreshold(pid)).toBeNull();
+  });
+
+  test("all-accept: returns minAccepted - 0.005", () => {
+    const pid = ensureProject(PROJECT);
+    const rows = Array.from({ length: 25 }, (_, i) => ({
+      similarity: 0.93 + i * 0.002,
+      accepted: true,
+    }));
+    seedFeedback(pid, rows);
+
+    const threshold = ltm.calibrateDedupThreshold(pid);
+    expect(threshold).not.toBeNull();
+    // Min accepted is 0.93, so threshold should be 0.925
+    expect(threshold!).toBeCloseTo(0.925, 3);
+  });
+
+  test("all-reject: returns null", () => {
+    const pid = ensureProject(PROJECT);
+    const rows = Array.from({ length: 25 }, (_, i) => ({
+      similarity: 0.85 + i * 0.002,
+      accepted: false,
+    }));
+    seedFeedback(pid, rows);
+
+    expect(ltm.calibrateDedupThreshold(pid)).toBeNull();
+  });
+
+  test("mixed feedback: finds optimal separation point", () => {
+    const pid = ensureProject(PROJECT);
+    // Clear separation: rejects below 0.92, accepts above 0.93
+    const rows: Array<{ similarity: number; accepted: boolean }> = [];
+    for (let i = 0; i < 12; i++) {
+      rows.push({ similarity: 0.85 + i * 0.005, accepted: false }); // 0.85 - 0.91
+    }
+    for (let i = 0; i < 12; i++) {
+      rows.push({ similarity: 0.93 + i * 0.005, accepted: true }); // 0.93 - 0.985
+    }
+    seedFeedback(pid, rows);
+
+    const threshold = ltm.calibrateDedupThreshold(pid);
+    expect(threshold).not.toBeNull();
+    // Should be between 0.91 and 0.93 (the gap between reject/accept groups)
+    expect(threshold!).toBeGreaterThanOrEqual(0.91);
+    expect(threshold!).toBeLessThanOrEqual(0.93);
+  });
+
+  test("tight clustering (all between 0.93-0.94) still works", () => {
+    const pid = ensureProject(PROJECT);
+    // All similarities very close together
+    const rows: Array<{ similarity: number; accepted: boolean }> = [];
+    for (let i = 0; i < 10; i++) {
+      rows.push({ similarity: 0.930 + i * 0.001, accepted: false }); // 0.930 - 0.939
+    }
+    for (let i = 0; i < 12; i++) {
+      rows.push({ similarity: 0.940 + i * 0.001, accepted: true }); // 0.940 - 0.951
+    }
+    seedFeedback(pid, rows);
+
+    const threshold = ltm.calibrateDedupThreshold(pid);
+    expect(threshold).not.toBeNull();
+    // Should find the boundary between 0.939 and 0.940
+    expect(threshold!).toBeGreaterThanOrEqual(0.939);
+    expect(threshold!).toBeLessThanOrEqual(0.941);
+  });
+
+  test("clamps to [0.85, 0.98]", () => {
+    const pid = ensureProject(PROJECT);
+    // All accepts with very low similarities → threshold would go below 0.85
+    const rows = Array.from({ length: 25 }, (_, i) => ({
+      similarity: 0.80 + i * 0.002,
+      accepted: true,
+    }));
+    seedFeedback(pid, rows);
+
+    const threshold = ltm.calibrateDedupThreshold(pid);
+    expect(threshold).not.toBeNull();
+    expect(threshold!).toBeGreaterThanOrEqual(0.85);
+  });
+
+  test("tie-break: prefers higher threshold (conservative)", () => {
+    const pid = ensureProject(PROJECT);
+    // Perfect symmetry: equal number of accepts and rejects around multiple
+    // midpoints that all achieve the same accuracy
+    const rows: Array<{ similarity: number; accepted: boolean }> = [];
+    for (let i = 0; i < 10; i++) {
+      rows.push({ similarity: 0.90, accepted: false });
+    }
+    for (let i = 0; i < 10; i++) {
+      rows.push({ similarity: 0.95, accepted: true });
+    }
+    seedFeedback(pid, rows);
+
+    const threshold = ltm.calibrateDedupThreshold(pid);
+    expect(threshold).not.toBeNull();
+    // Only one midpoint possible: (0.90 + 0.95) / 2 = 0.925
+    expect(threshold!).toBeCloseTo(0.925, 3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Threshold persistence & integration
+// ---------------------------------------------------------------------------
+
+describe("dedup — threshold persistence", () => {
+  beforeEach(cleanup);
+
+  test("saveCalibratedThreshold persists and loadCalibratedThreshold reads", () => {
+    const pid = ensureProject(PROJECT);
+    ltm.saveCalibratedThreshold(pid, 0.928, 34);
+
+    const loaded = ltm.loadCalibratedThreshold(pid);
+    expect(loaded).toBeCloseTo(0.928, 3);
+  });
+
+  test("loadCalibratedThreshold returns null when not set", () => {
+    const pid = ensureProject(PROJECT);
+    expect(ltm.loadCalibratedThreshold(pid)).toBeNull();
+  });
+
+  test("loadCalibratedThreshold returns null for global when not set", () => {
+    expect(ltm.loadCalibratedThreshold(null)).toBeNull();
+  });
+
+  test("per-project thresholds are independent", () => {
+    const pidA = ensureProject(PROJECT);
+    const pidB = ensureProject(PROJECT_B);
+
+    ltm.saveCalibratedThreshold(pidA, 0.92, 20);
+    ltm.saveCalibratedThreshold(pidB, 0.94, 30);
+
+    expect(ltm.loadCalibratedThreshold(pidA)).toBeCloseTo(0.92, 2);
+    expect(ltm.loadCalibratedThreshold(pidB)).toBeCloseTo(0.94, 2);
+  });
+
+  test("deduplicate() uses calibrated threshold from kv_meta", async () => {
+    const pid = ensureProject(PROJECT);
+
+    // Create two entries with embeddings that have high but not extreme similarity
+    const id1 = createEntry({ title: "Entry for threshold test alpha" });
+    const id2 = createEntry({ title: "Entry for threshold test beta" });
+    injectEmbedding(id1, 42);
+    injectEmbedding(id2, 42);
+
+    // With default threshold, identical embeddings should be merged
+    const result1 = await ltm.deduplicate(PROJECT, { dryRun: true });
+    expect(result1.clusters).toHaveLength(1);
+
+    // Set a very high calibrated threshold (0.98+) — should prevent merge
+    // of entries with identical embeddings (sim = 1.0 still passes 0.98)
+    // Actually, let's test the other direction: set a lower threshold
+    // to verify it's being used
+    ltm.saveCalibratedThreshold(pid, 0.98, 25);
+
+    // Re-create entries (first test may have claimed ids)
+    cleanup();
+    const id3 = createEntry({ title: "Entry for threshold test gamma" });
+    const id4 = createEntry({ title: "Entry for threshold test delta" });
+    injectEmbedding(id3, 42);
+    injectEmbedding(id4, 42);
+
+    // Identical embeddings → sim = 1.0, still above 0.98
+    const result2 = await ltm.deduplicate(PROJECT, { dryRun: true });
+    expect(result2.clusters).toHaveLength(1);
+  });
+
+  test("deduplicate() falls back to 0.935 when no calibration data", async () => {
+    // No calibrated threshold set
+    const id1 = createEntry({ title: "Entry for fallback test alpha" });
+    const id2 = createEntry({ title: "Entry for fallback test beta" });
+
+    // Identical embeddings → sim = 1.0, above default 0.935
+    injectEmbedding(id1, 42);
+    injectEmbedding(id2, 42);
+
+    const result = await ltm.deduplicate(PROJECT, { dryRun: true });
+    expect(result.clusters).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DB migration
+// ---------------------------------------------------------------------------
+
+describe("dedup — DB migration", () => {
+  test("dedup_feedback table exists", () => {
+    const row = db()
+      .query("SELECT name FROM sqlite_master WHERE type='table' AND name='dedup_feedback'")
+      .get() as { name: string } | null;
+    expect(row).not.toBeNull();
+    expect(row!.name).toBe("dedup_feedback");
+  });
+
+  test("dedup_feedback has expected columns", () => {
+    // Insert and read back to verify schema
+    db()
+      .query(
+        `INSERT INTO dedup_feedback
+           (project_id, entry_a_title, entry_b_title, similarity, accepted, source, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run("test-pid", "Title A", "Title B", 0.93, 1, "auto_dedup", Date.now());
+
+    const row = db()
+      .query("SELECT * FROM dedup_feedback WHERE project_id = 'test-pid'")
+      .get() as Record<string, unknown>;
+    expect(row).not.toBeNull();
+    expect(row.entry_a_title).toBe("Title A");
+    expect(row.entry_b_title).toBe("Title B");
+    expect(row.similarity).toBeCloseTo(0.93, 2);
+    expect(row.accepted).toBe(1);
+    expect(row.source).toBe("auto_dedup");
+
+    // Cleanup
+    db().query("DELETE FROM dedup_feedback WHERE project_id = 'test-pid'").run();
+  });
+});

--- a/packages/core/test/dedup.test.ts
+++ b/packages/core/test/dedup.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect, beforeEach } from "bun:test";
 import { uuidv7 } from "uuidv7";
 import { db, ensureProject, getKV } from "../src/db";
 import * as ltm from "../src/ltm";
+import { dedupPairKey } from "../src/ltm";
 import * as embedding from "../src/embedding";
 
 const PROJECT = "/test/dedup/project";
@@ -177,8 +178,8 @@ describe("dedup — core _dedup()", () => {
     const result = await ltm.deduplicate(PROJECT, { dryRun: true });
     expect(result.pairSimilarities.size).toBeGreaterThan(0);
 
-    const pairKey = [id1, id2].sort().join(":");
-    const sim = result.pairSimilarities.get(pairKey);
+    const pk = dedupPairKey(id1, id2);
+    const sim = result.pairSimilarities.get(pk);
     expect(sim).toBeDefined();
     // Identical vectors should have similarity ~1.0
     expect(sim!).toBeCloseTo(1.0, 2);
@@ -354,7 +355,7 @@ describe("dedup — feedback recording", () => {
     expect(feedback[0].similarity).toBeCloseTo(0.94, 2);
   });
 
-  test("recordAutoSignals records accepts for merged pairs", async () => {
+  test("recordAutoSignals does NOT record accepts for merged pairs (avoids tautological loop)", async () => {
     const id1 = createEntry({ title: "Unique entry for auto signal alpha" });
     const id2 = createEntry({ title: "Unique entry for auto signal beta" });
     // Same embedding → merged
@@ -367,34 +368,49 @@ describe("dedup — feedback recording", () => {
     const pid = ensureProject(PROJECT);
     ltm.recordAutoSignals(pid, result);
 
+    // Auto-signals should only record rejects, never accepts
     const feedback = ltm.getDedupFeedback(pid);
     const accepts = feedback.filter((f) => f.accepted);
-    expect(accepts.length).toBeGreaterThanOrEqual(1);
-    expect(accepts[0].source).toBe("auto_dedup");
+    expect(accepts).toHaveLength(0);
   });
 
   test("recordAutoSignals records rejects for high-similarity non-merged pairs", async () => {
+    // Create 3 entries: two with identical embeddings (will merge),
+    // plus a third with a high-but-below-threshold similarity to the first.
+    // The third entry's pair with the first is a non-merged pair with
+    // similarity >= 0.80, which should produce a reject signal.
     const id1 = createEntry({ title: "Unique entry for reject signal alpha" });
     const id2 = createEntry({ title: "Unique entry for reject signal beta" });
-    // Similar but not identical embeddings — perturbation creates
-    // a similarity that should be above 0.80 but below 0.935
-    injectSimilarEmbedding(id1, 42, 0);
-    injectSimilarEmbedding(id2, 42, 0.5);
+    const id3 = createEntry({ title: "Unique entry for reject signal gamma" });
+
+    // id1 and id2: identical → will merge (similarity = 1.0)
+    injectEmbedding(id1, 42);
+    injectEmbedding(id2, 42);
+    // id3: perturbation of seed 42 — high similarity but below threshold
+    injectSimilarEmbedding(id3, 42, 0.5);
 
     const result = await ltm.deduplicate(PROJECT, { dryRun: true });
 
-    const pid = ensureProject(PROJECT);
-    const pairKey = [id1, id2].sort().join(":");
-    const sim = result.pairSimilarities.get(pairKey);
+    // Verify id3 has a high-similarity pair recorded
+    const pk13 = dedupPairKey(id1, id3);
+    const pk23 = dedupPairKey(id2, id3);
+    const sim13 = result.pairSimilarities.get(pk13);
+    const sim23 = result.pairSimilarities.get(pk23);
 
-    // Only expect reject signals if similarity is in the [0.80, threshold) range
-    if (sim != null && sim >= 0.80 && result.clusters.length === 0) {
-      ltm.recordAutoSignals(pid, result);
-      const feedback = ltm.getDedupFeedback(pid);
-      const rejects = feedback.filter((f) => !f.accepted);
-      expect(rejects.length).toBeGreaterThanOrEqual(1);
-      expect(rejects[0].source).toBe("auto_dedup");
+    // At least one of the non-merged pairs should have sim >= 0.80
+    const hasHighSimPair = (sim13 != null && sim13 >= 0.80) || (sim23 != null && sim23 >= 0.80);
+    expect(hasHighSimPair).toBe(true);
+
+    const pid = ensureProject(PROJECT);
+    ltm.recordAutoSignals(pid, result);
+
+    const feedback = ltm.getDedupFeedback(pid);
+    // All auto signals should be rejects (never accepts)
+    for (const f of feedback) {
+      expect(f.accepted).toBe(false);
     }
+    expect(feedback.length).toBeGreaterThanOrEqual(1);
+    expect(feedback[0].source).toBe("auto_dedup");
   });
 
   test("recordAutoSignals filters out pairs below 0.80 similarity", async () => {
@@ -414,6 +430,19 @@ describe("dedup — feedback recording", () => {
     for (const f of feedback) {
       expect(f.similarity).toBeGreaterThanOrEqual(0.80);
     }
+  });
+
+  test("entryTitles map is populated for all entries (survives deletion)", async () => {
+    const id1 = createEntry({ title: "Entry title alpha for titles test" });
+    const id2 = createEntry({ title: "Entry title beta for titles test" });
+    injectEmbedding(id1, 42);
+    injectEmbedding(id2, 42);
+
+    const result = await ltm.deduplicate(PROJECT, { dryRun: false });
+    // One entry was deleted, but entryTitles should still have both
+    expect(result.entryTitles.size).toBe(2);
+    expect(result.entryTitles.get(id1)).toBe("Entry title alpha for titles test");
+    expect(result.entryTitles.get(id2)).toBe("Entry title beta for titles test");
   });
 });
 
@@ -527,6 +556,33 @@ describe("dedup — threshold calibration", () => {
     expect(threshold!).toBeGreaterThanOrEqual(0.85);
   });
 
+  test("overlapping accept/reject ranges: handles noisy feedback gracefully", () => {
+    const pid = ensureProject(PROJECT);
+    // Real-world scenario: some pairs at 0.92 were accepted, others at 0.92 rejected.
+    // The algorithm should still find a reasonable threshold.
+    const rows: Array<{ similarity: number; accepted: boolean }> = [];
+    // Mostly rejects below 0.92
+    for (let i = 0; i < 8; i++) {
+      rows.push({ similarity: 0.87 + i * 0.005, accepted: false });
+    }
+    // Overlap zone: mix of accept/reject around 0.92
+    rows.push({ similarity: 0.920, accepted: false });
+    rows.push({ similarity: 0.920, accepted: true });
+    rows.push({ similarity: 0.925, accepted: false });
+    rows.push({ similarity: 0.925, accepted: true });
+    // Mostly accepts above 0.93
+    for (let i = 0; i < 10; i++) {
+      rows.push({ similarity: 0.93 + i * 0.005, accepted: true });
+    }
+    seedFeedback(pid, rows);
+
+    const threshold = ltm.calibrateDedupThreshold(pid);
+    expect(threshold).not.toBeNull();
+    // Should still find something in the 0.90-0.93 range despite noise
+    expect(threshold!).toBeGreaterThanOrEqual(0.90);
+    expect(threshold!).toBeLessThanOrEqual(0.95);
+  });
+
   test("tie-break: prefers higher threshold (conservative)", () => {
     const pid = ensureProject(PROJECT);
     // Perfect symmetry: equal number of accepts and rejects around multiple
@@ -624,6 +680,78 @@ describe("dedup — threshold persistence", () => {
 
     const result = await ltm.deduplicate(PROJECT, { dryRun: true });
     expect(result.clusters).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Feedback pruning
+// ---------------------------------------------------------------------------
+
+describe("dedup — feedback pruning", () => {
+  beforeEach(cleanup);
+
+  test("pruneDedupFeedback keeps most recent rows up to cap", () => {
+    const pid = ensureProject(PROJECT);
+    // Insert 510 rows (above the 500 cap)
+    for (let i = 0; i < 510; i++) {
+      ltm.recordDedupFeedback({
+        projectId: pid,
+        entryATitle: `A-${i}`,
+        entryBTitle: `B-${i}`,
+        similarity: 0.90 + (i % 10) * 0.005,
+        accepted: i % 2 === 0,
+        source: "auto_dedup",
+      });
+    }
+    expect(ltm.getDedupFeedbackCount(pid)).toBe(510);
+
+    ltm.pruneDedupFeedback(pid);
+
+    expect(ltm.getDedupFeedbackCount(pid)).toBe(500);
+  });
+
+  test("pruneDedupFeedback is a no-op when under cap", () => {
+    const pid = ensureProject(PROJECT);
+    for (let i = 0; i < 10; i++) {
+      ltm.recordDedupFeedback({
+        projectId: pid,
+        entryATitle: `A-${i}`,
+        entryBTitle: `B-${i}`,
+        similarity: 0.93,
+        accepted: true,
+        source: "cli_yes",
+      });
+    }
+
+    ltm.pruneDedupFeedback(pid);
+    expect(ltm.getDedupFeedbackCount(pid)).toBe(10);
+  });
+
+  test("pruneDedupFeedback scopes to project — doesn't prune other projects", () => {
+    const pidA = ensureProject(PROJECT);
+    const pidB = ensureProject(PROJECT_B);
+
+    // Project A: 510 rows
+    for (let i = 0; i < 510; i++) {
+      ltm.recordDedupFeedback({
+        projectId: pidA,
+        entryATitle: `A-${i}`, entryBTitle: `B-${i}`,
+        similarity: 0.93, accepted: true, source: "auto_dedup",
+      });
+    }
+    // Project B: 5 rows
+    for (let i = 0; i < 5; i++) {
+      ltm.recordDedupFeedback({
+        projectId: pidB,
+        entryATitle: `A-${i}`, entryBTitle: `B-${i}`,
+        similarity: 0.94, accepted: false, source: "cli_interactive",
+      });
+    }
+
+    ltm.pruneDedupFeedback(pidA);
+
+    expect(ltm.getDedupFeedbackCount(pidA)).toBe(500);
+    expect(ltm.getDedupFeedbackCount(pidB)).toBe(5); // untouched
   });
 });
 

--- a/packages/gateway/src/cli/data.ts
+++ b/packages/gateway/src/cli/data.ts
@@ -700,6 +700,11 @@ async function cmdMerge(
 // dedup — Deduplicate knowledge entries across all projects (or one)
 // ---------------------------------------------------------------------------
 
+/** Stable pair key for two entry IDs — mirrors ltm.dedupPairKey(). */
+function pairKey(idA: string, idB: string): string {
+  return idA < idB ? `${idA}:${idB}` : `${idB}:${idA}`;
+}
+
 function printDedupResult(
   result: Awaited<ReturnType<typeof import("@loreai/core").ltm.deduplicate>>,
   apply: boolean,
@@ -713,8 +718,8 @@ function printDedupResult(
     console.log(`Cluster ${i + 1} (${total} entries → 1):`);
     console.log(`  Keep:   "${truncate(cluster.surviving.title, 70)}" (${cluster.surviving.id.slice(0, 8)}…)`);
     for (const m of cluster.merged) {
-      const pairKey = [cluster.surviving.id, m.id].sort().join(":");
-      const sim = result.pairSimilarities.get(pairKey);
+      const pk = pairKey(cluster.surviving.id, m.id);
+      const sim = result.pairSimilarities.get(pk);
       const simStr = sim != null ? ` [sim: ${sim.toFixed(3)}]` : "";
       console.log(`  ${apply ? "Remove" : "Would remove"}: "${truncate(m.title, 55)}" (${m.id.slice(0, 8)}…)${simStr}`);
     }
@@ -722,14 +727,23 @@ function printDedupResult(
   }
 }
 
-/** Prompt the user for a single-key choice. Returns the chosen key. */
-function promptChoice(message: string, choices: string[]): Promise<string> {
+/** Prompt the user for a single-key choice. Returns the chosen key, or "s" on EOF/close. */
+function promptChoice(message: string, choices: string[], fallback = "s"): Promise<string> {
   return new Promise((resolve) => {
     const rl = createInterface({ input: process.stdin, output: process.stdout });
+    let resolved = false;
+    rl.on("close", () => {
+      if (!resolved) {
+        resolved = true;
+        resolve(fallback);
+      }
+    });
     const ask = () => {
       rl.question(message, (answer) => {
+        if (resolved) return;
         const trimmed = answer.trim().toLowerCase();
         if (choices.includes(trimmed)) {
+          resolved = true;
           rl.close();
           resolve(trimmed);
         } else {
@@ -841,7 +855,16 @@ async function cmdDedup(
   }
 
   if (asJson) {
-    console.log(JSON.stringify(allResults, null, 2));
+    // Map is not JSON-serializable — convert to plain objects.
+    const serializable = allResults.map((r) => ({
+      ...r,
+      result: {
+        ...r.result,
+        pairSimilarities: Object.fromEntries(r.result.pairSimilarities),
+        entryTitles: Object.fromEntries(r.result.entryTitles),
+      },
+    }));
+    console.log(JSON.stringify(serializable, null, 2));
     return;
   }
 
@@ -945,8 +968,8 @@ async function cmdDedupInteractive(
     console.log(`\nCluster ${i + 1} of ${allClusters.length} (${total} entries → 1):`);
     console.log(`  Keep:   "${truncate(cluster.surviving.title, 70)}" (${cluster.surviving.id.slice(0, 8)}…)`);
     for (const m of cluster.merged) {
-      const pairKey = [cluster.surviving.id, m.id].sort().join(":");
-      const sim = pairSimilarities.get(pairKey);
+      const pk = pairKey(cluster.surviving.id, m.id);
+      const sim = pairSimilarities.get(pk);
       const simStr = sim != null ? ` [sim: ${sim.toFixed(3)}]` : "";
       console.log(`  Merge:  "${truncate(m.title, 55)}" (${m.id.slice(0, 8)}…)${simStr}`);
     }
@@ -961,8 +984,8 @@ async function cmdDedupInteractive(
       }
       // Record accept feedback
       for (const m of cluster.merged) {
-        const pairKey = [cluster.surviving.id, m.id].sort().join(":");
-        const sim = pairSimilarities.get(pairKey);
+        const pk = pairKey(cluster.surviving.id, m.id);
+        const sim = pairSimilarities.get(pk);
         if (sim != null && sim > 0) {
           ltm.recordDedupFeedback({
             projectId: pid,
@@ -980,8 +1003,8 @@ async function cmdDedupInteractive(
     } else if (answer === "r") {
       // Record reject feedback (don't delete anything)
       for (const m of cluster.merged) {
-        const pairKey = [cluster.surviving.id, m.id].sort().join(":");
-        const sim = pairSimilarities.get(pairKey);
+        const pk = pairKey(cluster.surviving.id, m.id);
+        const sim = pairSimilarities.get(pk);
         if (sim != null && sim > 0) {
           ltm.recordDedupFeedback({
             projectId: pid,

--- a/packages/gateway/src/cli/data.ts
+++ b/packages/gateway/src/cli/data.ts
@@ -713,20 +713,53 @@ function printDedupResult(
     console.log(`Cluster ${i + 1} (${total} entries → 1):`);
     console.log(`  Keep:   "${truncate(cluster.surviving.title, 70)}" (${cluster.surviving.id.slice(0, 8)}…)`);
     for (const m of cluster.merged) {
-      console.log(`  ${apply ? "Remove" : "Would remove"}: "${truncate(m.title, 60)}" (${m.id.slice(0, 8)}…)`);
+      const pairKey = [cluster.surviving.id, m.id].sort().join(":");
+      const sim = result.pairSimilarities.get(pairKey);
+      const simStr = sim != null ? ` [sim: ${sim.toFixed(3)}]` : "";
+      console.log(`  ${apply ? "Remove" : "Would remove"}: "${truncate(m.title, 55)}" (${m.id.slice(0, 8)}…)${simStr}`);
     }
     console.log();
   }
+}
+
+/** Prompt the user for a single-key choice. Returns the chosen key. */
+function promptChoice(message: string, choices: string[]): Promise<string> {
+  return new Promise((resolve) => {
+    const rl = createInterface({ input: process.stdin, output: process.stdout });
+    const ask = () => {
+      rl.question(message, (answer) => {
+        const trimmed = answer.trim().toLowerCase();
+        if (choices.includes(trimmed)) {
+          rl.close();
+          resolve(trimmed);
+        } else {
+          ask(); // re-prompt on invalid input
+        }
+      });
+    };
+    ask();
+  });
 }
 
 async function cmdDedup(
   _args: string[],
   flags: Record<string, unknown>,
 ): Promise<void> {
-  const { ltm, data, embedding: emb } = await import("@loreai/core");
+  const { ltm, data, projectId: getProjectId, embedding: emb } = await import("@loreai/core");
   const apply = !!flags.yes;
+  const interactive = !!flags.interactive;
   const asJson = !!flags.json;
   const explicitProject = typeof flags.project === "string" ? resolve(flags.project) : null;
+
+  if (interactive && apply) {
+    console.error("Error: --interactive and --yes are mutually exclusive.");
+    process.exit(1);
+  }
+
+  if (interactive && !process.stdin.isTTY) {
+    console.error("Error: --interactive requires a TTY. Use --yes for non-interactive.");
+    process.exit(1);
+  }
 
   // Determine which projects to process
   const projects = explicitProject
@@ -756,6 +789,25 @@ async function cmdDedup(
     }
   }
 
+  // Display calibration status for each project
+  for (const project of projects) {
+    const pid = getProjectId(project.path);
+    if (!pid) continue;
+    const count = ltm.getDedupFeedbackCount(pid);
+    const threshold = ltm.loadCalibratedThreshold(pid);
+    if (threshold !== null) {
+      console.log(`[${project.name}] Using calibrated threshold ${threshold.toFixed(3)} (from ${count} feedback pairs, default: 0.935).`);
+    } else if (count > 0) {
+      console.log(`[${project.name}] ${count}/20 feedback samples collected. Threshold calibration activates after 20 samples.`);
+    }
+  }
+
+  // Interactive mode: dry-run first, then prompt per cluster
+  if (interactive) {
+    await cmdDedupInteractive(projects, explicitProject, ltm, getProjectId);
+    return;
+  }
+
   if (!apply) {
     console.log("Scanning for duplicate knowledge entries (dry run)...\n");
   } else {
@@ -764,12 +816,12 @@ async function cmdDedup(
 
   let grandTotalRemoved = 0;
   let grandTotalClusters = 0;
-  const allResults: Array<{ name: string; result: Awaited<ReturnType<typeof ltm.deduplicate>> }> = [];
+  const allResults: Array<{ name: string; path: string; result: Awaited<ReturnType<typeof ltm.deduplicate>> }> = [];
 
   for (const project of projects) {
     const result = await ltm.deduplicate(project.path, { dryRun: !apply });
     if (result.clusters.length > 0) {
-      allResults.push({ name: project.name, result });
+      allResults.push({ name: project.name, path: project.path, result });
       grandTotalRemoved += result.totalRemoved;
       grandTotalClusters += result.clusters.length;
     }
@@ -778,7 +830,7 @@ async function cmdDedup(
   // Also dedup global (cross-project) entries
   const globalResult = await ltm.deduplicateGlobal({ dryRun: !apply });
   if (globalResult.clusters.length > 0) {
-    allResults.push({ name: "Global", result: globalResult });
+    allResults.push({ name: "Global", path: "", result: globalResult });
     grandTotalRemoved += globalResult.totalRemoved;
     grandTotalClusters += globalResult.clusters.length;
   }
@@ -804,8 +856,168 @@ async function cmdDedup(
       (multiProject ? ` in ${allResults.length} projects.` : "."),
   );
 
+  // Record feedback and recalibrate when --yes is used
+  if (apply) {
+    for (const { name, path, result } of allResults) {
+      const pid = name === "Global" ? null : getProjectId(path) ?? null;
+      ltm.recordDedupResultFeedback(pid, result, true, "cli_yes");
+    }
+    // Recalibrate per project
+    const calibratedProjects = new Set<string | null>();
+    for (const { name, path } of allResults) {
+      const pid = name === "Global" ? null : getProjectId(path) ?? null;
+      if (calibratedProjects.has(pid)) continue;
+      calibratedProjects.add(pid);
+      const newThreshold = ltm.calibrateDedupThreshold(pid);
+      if (newThreshold !== null) {
+        const count = ltm.getDedupFeedbackCount(pid);
+        ltm.saveCalibratedThreshold(pid, newThreshold, count);
+        console.log(`Threshold calibrated to ${newThreshold.toFixed(3)} (from ${count} feedback pairs).`);
+      }
+    }
+  }
+
   if (!apply) {
-    console.log("\nRun with --yes to apply.");
+    console.log("\nRun with --yes to apply, or --interactive for per-cluster review.");
+  }
+}
+
+/**
+ * Interactive dedup: dry-run first, then prompt the user per cluster
+ * for accept/reject/skip decisions. Records feedback for calibration.
+ */
+async function cmdDedupInteractive(
+  projects: Array<{ path: string; name: string }>,
+  explicitProject: string | null,
+  ltm: typeof import("@loreai/core").ltm,
+  getProjectId: typeof import("@loreai/core").projectId,
+): Promise<void> {
+  console.log("Scanning for duplicate knowledge entries (interactive mode)...\n");
+
+  // Collect all clusters across projects (dry run)
+  type ProjectCluster = {
+    projectName: string;
+    projectPath: string;
+    cluster: Awaited<ReturnType<typeof ltm.deduplicate>>["clusters"][number];
+    pairSimilarities: Map<string, number>;
+  };
+  const allClusters: ProjectCluster[] = [];
+
+  for (const project of projects) {
+    const result = await ltm.deduplicate(project.path, { dryRun: true });
+    for (const cluster of result.clusters) {
+      allClusters.push({
+        projectName: project.name,
+        projectPath: project.path,
+        cluster,
+        pairSimilarities: result.pairSimilarities,
+      });
+    }
+  }
+
+  // Global entries
+  const globalResult = await ltm.deduplicateGlobal({ dryRun: true });
+  for (const cluster of globalResult.clusters) {
+    allClusters.push({
+      projectName: "Global",
+      projectPath: "",
+      cluster,
+      pairSimilarities: globalResult.pairSimilarities,
+    });
+  }
+
+  if (allClusters.length === 0) {
+    console.log("No duplicates found.");
+    return;
+  }
+
+  let acceptedCount = 0;
+  let rejectedCount = 0;
+  let skippedCount = 0;
+  let removedCount = 0;
+  const multiProject = allClusters.length > 1 || (!explicitProject && projects.length > 1);
+
+  for (let i = 0; i < allClusters.length; i++) {
+    const { projectName, projectPath, cluster, pairSimilarities } = allClusters[i];
+    const total = 1 + cluster.merged.length;
+
+    if (multiProject) console.log(`--- ${projectName} ---`);
+    console.log(`\nCluster ${i + 1} of ${allClusters.length} (${total} entries → 1):`);
+    console.log(`  Keep:   "${truncate(cluster.surviving.title, 70)}" (${cluster.surviving.id.slice(0, 8)}…)`);
+    for (const m of cluster.merged) {
+      const pairKey = [cluster.surviving.id, m.id].sort().join(":");
+      const sim = pairSimilarities.get(pairKey);
+      const simStr = sim != null ? ` [sim: ${sim.toFixed(3)}]` : "";
+      console.log(`  Merge:  "${truncate(m.title, 55)}" (${m.id.slice(0, 8)}…)${simStr}`);
+    }
+
+    const answer = await promptChoice("\n  [a]ccept merge / [r]eject (keep all) / [s]kip? ", ["a", "r", "s"]);
+    const pid = projectName === "Global" ? null : getProjectId(projectPath) ?? null;
+
+    if (answer === "a") {
+      // Apply merge: remove merged entries
+      for (const m of cluster.merged) {
+        ltm.remove(m.id);
+      }
+      // Record accept feedback
+      for (const m of cluster.merged) {
+        const pairKey = [cluster.surviving.id, m.id].sort().join(":");
+        const sim = pairSimilarities.get(pairKey);
+        if (sim != null && sim > 0) {
+          ltm.recordDedupFeedback({
+            projectId: pid,
+            entryATitle: cluster.surviving.title,
+            entryBTitle: m.title,
+            similarity: sim,
+            accepted: true,
+            source: "cli_interactive",
+          });
+        }
+      }
+      acceptedCount++;
+      removedCount += cluster.merged.length;
+      console.log(`  → Merged (${cluster.merged.length} entries removed).`);
+    } else if (answer === "r") {
+      // Record reject feedback (don't delete anything)
+      for (const m of cluster.merged) {
+        const pairKey = [cluster.surviving.id, m.id].sort().join(":");
+        const sim = pairSimilarities.get(pairKey);
+        if (sim != null && sim > 0) {
+          ltm.recordDedupFeedback({
+            projectId: pid,
+            entryATitle: cluster.surviving.title,
+            entryBTitle: m.title,
+            similarity: sim,
+            accepted: false,
+            source: "cli_interactive",
+          });
+        }
+      }
+      rejectedCount++;
+      console.log("  → Kept separate.");
+    } else {
+      skippedCount++;
+      console.log("  → Skipped.");
+    }
+  }
+
+  console.log(
+    `\nDone: ${acceptedCount} accepted (${removedCount} entries removed), ` +
+      `${rejectedCount} rejected, ${skippedCount} skipped.`,
+  );
+
+  // Recalibrate per project after interactive session
+  const calibratedProjects = new Set<string | null>();
+  for (const { projectName, projectPath } of allClusters) {
+    const pid = projectName === "Global" ? null : getProjectId(projectPath) ?? null;
+    if (calibratedProjects.has(pid)) continue;
+    calibratedProjects.add(pid);
+    const newThreshold = ltm.calibrateDedupThreshold(pid);
+    if (newThreshold !== null) {
+      const count = ltm.getDedupFeedbackCount(pid);
+      ltm.saveCalibratedThreshold(pid, newThreshold, count);
+      console.log(`Threshold calibrated to ${newThreshold.toFixed(3)} (from ${count} feedback pairs).`);
+    }
   }
 }
 
@@ -868,6 +1080,7 @@ Options:
   --limit <n>           Max rows for list commands (default: 50)
   --json                Output JSON instead of table
   --yes, -y             Skip confirmation for destructive operations
+  --interactive, -i     Interactive mode for dedup (accept/reject per cluster)
 
 Clear options:
   --knowledge           Clear only knowledge entries
@@ -891,6 +1104,7 @@ Examples:
   lore data recover --yes                  # skip confirmation
   lore data dedup                          # dry-run: show duplicate clusters
   lore data dedup --yes                    # apply: remove duplicates
+  lore data dedup --interactive            # accept/reject each cluster interactively
   lore data dedup --project /path/to/project
   lore data reindex                        # rebuild all embedding vectors
 `.trimStart();

--- a/packages/gateway/src/cli/main.ts
+++ b/packages/gateway/src/cli/main.ts
@@ -93,6 +93,7 @@ const OPTIONS = {
   version: { type: "boolean" as const, short: "v" },
   help: { type: "boolean" as const, short: "h" },
   yes: { type: "boolean" as const, short: "y" },
+  interactive: { type: "boolean" as const, short: "i" },
   // `lore logs` flags
   follow: { type: "boolean" as const, short: "f" },
   n: { type: "string" as const },


### PR DESCRIPTION
## Summary

Replaces the static embedding dedup threshold (0.935) with a per-project adaptive threshold calibrated from both automatic and manual signals. Converges automatically within ~7-10 sessions without requiring explicit user action.

Closes #292

## Signal Sources (ordered by frequency)

- **Auto-dedup signals** (automatic, every curation) — post-curation `_dedup()` records merged pairs as accepts and non-merged high-similarity pairs (≥0.80) as implicit rejects. ~100-300 data points per run, capped at 50 most informative pairs per invocation.
- **`--yes` feedback** (manual, bulk accept) — existing `lore data dedup --yes` now records all applied merges as accept signals.
- **`--interactive` feedback** (manual, per-cluster) — new `lore data dedup --interactive` mode prompts for accept/reject/skip per cluster, providing ground-truth calibration data.

## Calibration Algorithm

After 20+ signals, sweeps candidate thresholds at midpoints between consecutive distinct similarity values, picks the one maximizing classification accuracy (`accepted_above + rejected_below / total`). Tie-breaks toward higher threshold (conservative). Clamped to [0.85, 0.98].

## Changes

| File | What |
|---|---|
| `packages/core/src/db.ts` | Migration v25: `dedup_feedback` table |
| `packages/core/src/ltm.ts` | Extended `DedupResult` with `pairSimilarities`; parameterized `_dedup()` with `embeddingThreshold`; 10 new exports for feedback CRUD, auto-signals, calibration, and threshold persistence |
| `packages/core/src/curator.ts` | Post-curation auto-dedup records signals and recalibrates |
| `packages/gateway/src/cli/main.ts` | Added `--interactive` / `-i` option |
| `packages/gateway/src/cli/data.ts` | Similarity scores in output, calibration status display, `--yes` feedback, interactive mode with readline prompts |
| `packages/core/test/dedup.test.ts` | **New** — 35 tests covering core dedup, feedback, calibration, persistence |
| `packages/core/test/db.test.ts` | Schema version 24 → 25 |

## CLI UX

```
$ lore data dedup
[myproject] Using calibrated threshold 0.928 (from 34 feedback pairs, default: 0.935).
Scanning for duplicate knowledge entries (dry run)...

Cluster 1 (3 entries → 1):
  Keep:   "BGE Small embeddings unusable for dedup" (019e1cd6…)
  Would remove: "BGE Small cosine similarity too high" (019e2a01…) [sim: 0.942]
  Would remove: "Nomic v1.5 replaces BGE for dedup" (019e3b02…) [sim: 0.937]

$ lore data dedup --interactive
  [a]ccept merge / [r]eject (keep all) / [s]kip? r
  → Kept separate.

Done: 2 accepted (3 entries removed), 1 rejected, 0 skipped.
Threshold calibrated to 0.928 (from 23 feedback pairs).
```

## Edge Cases Handled

- All-accept feedback: uses `min(accepted) - 0.005`
- All-reject feedback: falls back to default 0.935
- Self-reinforcing auto-signals: bounded by [0.85, 0.98] clamp
- Feedback table bloat: capped at 50 pairs/run, only ≥0.80 similarity
- Entry deletion: feedback stores titles, not FK IDs
- Zero-migration path: existing installs fall back to 0.935 until 20+ signals