### PR TITLE
fix: pass project_id (not path) to projectName() on warming costs table

### DIFF
--- a/packages/gateway/src/ui.ts
+++ b/packages/gateway/src/ui.ts
@@ -1388,7 +1388,7 @@ function pageCosts(): string {
       const sess = activeSessions.get(sid);
       const projPath = sess?.projectPath ?? "";
       const projId = projPath ? ensureProject(projPath) : "";
-      const projLabel = projPath ? (projectName(projPath) ?? "(unnamed)") : "-";
+      const projLabel = projId ? (projectName(projId) ?? "(unnamed)") : "-";
       body += `<tr>
         <td>${projId ? `<a href="/ui/projects/${esc(projId)}">${esc(projLabel)}</a>` : esc(projLabel)}</td>
         <td>${projId ? `<a href="/ui/sessions/${esc(projId)}/${esc(sid)}"><code>${esc(sid.slice(0, 16))}</code></a>` : `<code>${esc(sid.slice(0, 16))}</code>`}</td>


### PR DESCRIPTION
## Summary

- Fix `(unnamed)` showing for all projects in the per-session costs table on the Cache Warming page
- `projectName()` expects a UUID but was receiving a filesystem path (`projPath` instead of `projId`), always returning `null`
- One-line fix: `projectName(projPath)` → `projectName(projId)` at `ui.ts:1391`