### PR TITLE
fix: resolve embedding worker crash in CJS bundle (LOREAI-GATEWAY-D/E)

### DIFF
--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -272,7 +272,21 @@ class LocalProvider implements EmbeddingProvider {
           workerUrl = vendorWorkerUrl;
         }
       } else {
-        workerUrl = new URL(`./embedding-worker${import.meta.url.endsWith(".ts") ? ".ts" : ".js"}`, import.meta.url);
+        // In CJS bundles (gateway npm package), esbuild shims import.meta as
+        // an empty object {}, so import.meta.url is undefined. Fall back to
+        // __filename which esbuild defines in CJS output.
+        const selfUrl = typeof import.meta.url === "string" ? import.meta.url : undefined;
+        if (selfUrl) {
+          workerUrl = new URL(
+            `./embedding-worker${selfUrl.endsWith(".ts") ? ".ts" : ".js"}`,
+            selfUrl,
+          );
+        } else {
+          // CJS fallback: __filename is defined by esbuild's CJS output.
+          // The embedding-worker.cjs is built alongside the main bundle.
+          const { pathToFileURL } = await import("node:url");
+          workerUrl = new URL("./embedding-worker.cjs", pathToFileURL(__filename));
+        }
       }
 
       const vendor = vendorModelInfo();

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -28,6 +28,7 @@
   "dependencies": {},
   "files": [
     "dist/bin.cjs",
+    "dist/embedding-worker.cjs",
     "dist/index.cjs",
     "dist/index.d.cts"
   ],

--- a/packages/gateway/script/bundle.ts
+++ b/packages/gateway/script/bundle.ts
@@ -96,6 +96,28 @@ await esbuild.build({
 });
 
 // ---------------------------------------------------------------------------
+// Embedding worker — separate CJS file next to index.cjs
+// ---------------------------------------------------------------------------
+// LocalProvider in core/embedding.ts spawns this via node:worker_threads.
+// The binary build has its own vendored path (__LORE_VENDOR_WORKER_URL__),
+// but the npm CJS bundle needs an actual file alongside index.cjs.
+
+await esbuild.build({
+  entryPoints: [join(packageDir, "..", "core", "src", "embedding-worker.ts")],
+  bundle: true,
+  format: "cjs",
+  target: "node22",
+  platform: "node",
+  conditions: ["node"],
+  external: ["onnxruntime-node", "sharp"],
+  outfile: join(distDir, "embedding-worker.cjs"),
+  sourcemap: false,
+  minify: true,
+  logLevel: "info",
+  legalComments: "none",
+});
+
+// ---------------------------------------------------------------------------
 // Debug ID injection + sourcemap upload
 // ---------------------------------------------------------------------------
 
@@ -288,6 +310,7 @@ export declare function _cli(): Promise<void>;
 writeFileSync(join(distDir, "index.d.cts"), typeDeclarations);
 
 console.log(`\n✓ @loreai/gateway npm bundle complete (v${pkg.version})`);
-console.log(`  dist/index.cjs  — CJS bundle`);
-console.log(`  dist/bin.cjs    — CLI wrapper`);
-console.log(`  dist/index.d.cts — type declarations`);
+console.log(`  dist/index.cjs            — CJS bundle`);
+console.log(`  dist/embedding-worker.cjs — embedding worker (spawned via worker_threads)`);
+console.log(`  dist/bin.cjs              — CLI wrapper`);
+console.log(`  dist/index.d.cts          — type declarations`);


### PR DESCRIPTION
## Summary

- **Guard `import.meta.url`** in `packages/core/src/embedding.ts` with a `typeof` check — in the gateway CJS bundle, esbuild shims `import.meta` as `{}`, making `.url` undefined and crashing on `.endsWith()`
- **Build `embedding-worker.cjs`** alongside `dist/index.cjs` in the gateway npm bundle — it was never emitted for CJS consumers, only for the compiled Bun binary
- **Include `embedding-worker.cjs` in npm package** via the `files` field in `package.json`

## Context

Both [LOREAI-GATEWAY-D](https://byk.sentry.io/issues/?query=LOREAI-GATEWAY-D) and [LOREAI-GATEWAY-E](https://byk.sentry.io/issues/?query=LOREAI-GATEWAY-E) are the same root cause — `TypeError: Cannot read properties of undefined (reading 'endsWith')` at `embedding.ts:275`. This breaks **all** embedding operations (backfill, vector search, dedup) for npm/CJS consumers (Pi plugin, `npx lore`).

The fix has two co-required parts:
1. CJS-safe worker URL resolution via `__filename` + `pathToFileURL` fallback
2. A second esbuild step in `bundle.ts` to emit the worker file

Dev mode (Bun + raw .ts) and compiled binaries (which use `__LORE_VENDOR_WORKER_URL__`) are unaffected.

## Test plan

- `bun run typecheck` — all 4 packages pass
- `bun test` — 1445/1445 tests pass
- `bun run bundle` — confirms `dist/embedding-worker.cjs` (488KB) emitted alongside `dist/index.cjs`
- Smoke test: CJS `__filename` fallback correctly resolves worker path to `dist/embedding-worker.cjs`