### PR TITLE
fix: preserve thinking blocks in recall follow-up to prevent API rejection

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -239,6 +239,9 @@
 <!-- lore:019e1de2-f53e-75b8-bb27-9959553cc9f6 -->
 * **Recall follow-up sends two identical upstream requests — double cache write**: In \`packages/gateway/src/pipeline.ts\`, the recall follow-up path (non-streaming) was sending the upstream request twice: once to obtain the response body, then again to stream it. This doubles token costs (~$0.56–0.94/occurrence on Opus) and wastes a cache write slot. Fix: capture the first response body and re-emit it without a second upstream call.
 
+<!-- lore:019e283f-60c0-7cf3-a541-241a9d982933 -->
+* **Recall follow-up strips thinking blocks — Anthropic API rejects assistant messages missing thinking signatures**: In \`packages/gateway/src/recall.ts\` (lines ~401-404), the assistant message injected for recall follow-up is built with only the \`tool\_use\` block, stripping any preceding thinking blocks. When extended thinking is enabled, the Anthropic API requires thinking blocks (with their \`signature\` fields) to precede \`tool\_use\` blocks in assistant messages — omitting them causes a 400 error. Fix: when building the assistant message for recall follow-up, include all content blocks from the original response (thinking + tool\_use), not just the tool\_use block.
+
 <!-- lore:019e1de4-c06b-7559-b7c6-f7b88eca41df -->
 * **Recall follow-up turns must use cacheConversation: false to avoid double cache write**: In \`packages/gateway/src/pipeline.ts\`, recall follow-up requests (where the assistant message injects recall results) must set \`cacheConversation: false\` before forwarding upstream. Without this, the modified message array triggers a full cache write even though the conversation hasn't substantively changed, wasting 1.25x–2x cache-write tokens. Two call sites exist — both the streaming and non-streaming recall paths need this guard.
 

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -1185,6 +1185,7 @@ function buildStreamingResponse(
               const errorBody = await followUpResponse.text();
               log.error(
                 `recall follow-up upstream error: ${followUpResponse.status} ${errorBody.slice(0, 500)}`,
+                new Error(`recall follow-up upstream ${followUpResponse.status}`),
               );
               // Forward the held-back events to close the stream gracefully
               const heldBack = recallAccum.heldBackEvents();
@@ -3013,6 +3014,7 @@ async function handleConversationTurn(
       const errorBody = await followUpResponse.text();
       log.error(
         `recall follow-up upstream error: ${followUpResponse.status} ${errorBody.slice(0, 500)}`,
+        new Error(`recall follow-up upstream ${followUpResponse.status}`),
       );
       // Fall back to response with marker (no continuation)
       postResponse(req, markerResp, sessionState, config, requestBody, genAiSpan, isSubagentTurn);

--- a/packages/gateway/src/recall.ts
+++ b/packages/gateway/src/recall.ts
@@ -393,14 +393,22 @@ export function buildRecallFollowUp(
   recallResult: string,
   recallToolUseBlock: GatewayToolUseBlock,
 ): GatewayRequest {
-  // Build assistant message with ONLY the recall tool_use block.
-  // Exclude any pre-recall text/thinking blocks — those were already streamed
-  // to the client. By presenting only the tool_use, the model understands it
-  // called recall and hasn't yet produced a substantive response, so it will
-  // generate new content after receiving the tool_result.
+  // Build assistant message with thinking blocks (if any) + the recall tool_use.
+  // Text blocks are excluded — they carry no semantic state needed for the
+  // follow-up, and for the streaming path they were already sent to the client.
+  // Thinking blocks MUST be preserved: the Anthropic API requires thinking
+  // blocks (with their cryptographic signatures) to precede any tool_use
+  // blocks in assistant messages when extended thinking is enabled.
+  // Omitting them causes a 400 validation error from the API.
+  // Using a deny-list (exclude text/tool_use/tool_result) rather than an
+  // allow-list so future block types (e.g. redacted_thinking) are preserved
+  // by default.
+  const prefixBlocks = resp.content.filter(
+    (b) => b.type !== "text" && b.type !== "tool_use" && b.type !== "tool_result",
+  );
   const assistantMessage: GatewayMessage = {
     role: "assistant",
-    content: [recallToolUseBlock],
+    content: [...prefixBlocks, recallToolUseBlock],
   };
 
   // Build user message with tool_result

--- a/packages/gateway/test/recall.test.ts
+++ b/packages/gateway/test/recall.test.ts
@@ -335,7 +335,7 @@ describe("buildRecallFollowUp", () => {
     expect(followUp.messages[1].role).toBe("assistant");
     expect(followUp.messages[2].role).toBe("user");
 
-    // Assistant message contains ONLY the recall tool_use (pre-recall text excluded)
+    // Assistant message contains ONLY the recall tool_use (text blocks excluded)
     expect(followUp.messages[1].content).toHaveLength(1);
     expect(followUp.messages[1].content[0]).toBe(recallBlock);
 
@@ -365,6 +365,113 @@ describe("buildRecallFollowUp", () => {
     expect(followUp.system).toBe("my system prompt");
     expect(followUp.model).toBe("claude-opus-4");
     expect(followUp.stream).toBe(false);
+  });
+
+  test("preserves thinking blocks in assistant message for extended thinking", () => {
+    const req = makeRequest(
+      [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+      [
+        { name: "Read", description: "Read", inputSchema: {} },
+        { name: "recall", description: "Recall", inputSchema: {} },
+      ],
+    );
+
+    const recallBlock = makeRecallToolUse("find config");
+    const resp = makeResponse(
+      [
+        { type: "thinking", thinking: "Let me search for config info...", signature: "sig_abc123" },
+        { type: "text", text: "Let me search." },
+        recallBlock,
+      ],
+      "tool_use",
+    );
+
+    const followUp = buildRecallFollowUp(
+      req,
+      resp,
+      "## Recall Results\n* config is in /root",
+      recallBlock,
+    );
+
+    // Assistant message should contain thinking block + recall tool_use
+    const assistant = followUp.messages[1];
+    expect(assistant.content).toHaveLength(2);
+    expect(assistant.content[0].type).toBe("thinking");
+    expect((assistant.content[0] as { thinking: string }).thinking).toBe(
+      "Let me search for config info...",
+    );
+    expect((assistant.content[0] as { signature: string }).signature).toBe(
+      "sig_abc123",
+    );
+    expect(assistant.content[1]).toBe(recallBlock);
+  });
+
+  test("excludes text blocks but keeps thinking blocks", () => {
+    const req = makeRequest(
+      [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+    );
+
+    const recallBlock = makeRecallToolUse();
+    const resp = makeResponse(
+      [
+        { type: "thinking", thinking: "reasoning...", signature: "sig_1" },
+        { type: "text", text: "Some pre-recall text" },
+        { type: "text", text: "More text" },
+        recallBlock,
+      ],
+      "tool_use",
+    );
+
+    const followUp = buildRecallFollowUp(req, resp, "result", recallBlock);
+
+    const assistant = followUp.messages[1];
+    // Only thinking + tool_use — text blocks excluded
+    expect(assistant.content).toHaveLength(2);
+    expect(assistant.content[0].type).toBe("thinking");
+    expect(assistant.content[1].type).toBe("tool_use");
+  });
+
+  test("handles multiple thinking blocks", () => {
+    const req = makeRequest(
+      [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+    );
+
+    const recallBlock = makeRecallToolUse();
+    const resp = makeResponse(
+      [
+        { type: "thinking", thinking: "first thought", signature: "sig_1" },
+        { type: "thinking", thinking: "second thought", signature: "sig_2" },
+        recallBlock,
+      ],
+      "tool_use",
+    );
+
+    const followUp = buildRecallFollowUp(req, resp, "result", recallBlock);
+
+    const assistant = followUp.messages[1];
+    expect(assistant.content).toHaveLength(3);
+    expect(assistant.content[0].type).toBe("thinking");
+    expect(assistant.content[1].type).toBe("thinking");
+    expect(assistant.content[2]).toBe(recallBlock);
+  });
+
+  test("works without thinking blocks (non-thinking model)", () => {
+    const req = makeRequest(
+      [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+    );
+
+    const recallBlock = makeRecallToolUse();
+    const resp = makeResponse(
+      [{ type: "text", text: "Let me search." }, recallBlock],
+      "tool_use",
+    );
+
+    const followUp = buildRecallFollowUp(req, resp, "result", recallBlock);
+
+    const assistant = followUp.messages[1];
+    // No thinking blocks — just the tool_use
+    expect(assistant.content).toHaveLength(1);
+    expect(assistant.content[0]).toBe(recallBlock);
   });
 });
 


### PR DESCRIPTION
## Summary

- **Fix recall follow-up stripping thinking blocks:** When extended thinking is enabled (default in Claude Code), the model produces thinking tokens before calling recall. The follow-up request was built with only the `tool_use` block, stripping the required thinking blocks (with cryptographic signatures). The Anthropic API rejects this with a 400 error. Now thinking blocks from the original response are preserved in the follow-up assistant message.
- **Fix Sentry visibility for recall follow-up errors:** The `log.error()` call on upstream error responses only passed a string, so `captureException()` was never called (it requires an `Error` instance). Added an `Error` object so these failures create Sentry issues instead of being silently logged.

## Repro scenario

1. Run `lore --dangerously-skip-permissions` (or any thinking-enabled Claude Code session)
2. On the first message, the model thinks and then calls `recall`
3. Gateway intercepts recall, executes it, builds follow-up request
4. **Before fix:** Follow-up's assistant message has only `[tool_use]` — API returns 400
5. **After fix:** Follow-up's assistant message has `[thinking, tool_use]` — API accepts it

## Files changed

| File | Change |
|------|--------|
| `packages/gateway/src/recall.ts` | Filter thinking blocks from response and include them before `tool_use` in follow-up |
| `packages/gateway/src/pipeline.ts` | Pass `Error` object to `log.error()` on recall follow-up upstream error |
| `packages/gateway/test/recall.test.ts` | 4 new tests: thinking blocks preserved, text excluded, multiple thinking blocks, backward compat |