### PR TITLE
fix: redirect GET / to /ui dashboard

### DIFF
--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -327,6 +327,11 @@ export function startServer(config: GatewayConfig): {
         return withCors(await handleUIRequest(req, url));
       }
 
+      // GET / — redirect to dashboard
+      if (method === "GET" && pathname === "/") {
+        return withCors(Response.redirect(new URL("/ui", url), 302));
+      }
+
       // 404 for everything else
       return errorResponse(404, "not_found", `No route for ${method} ${pathname}`);
     } catch (e) {


### PR DESCRIPTION
## Summary

- `GET /` previously returned a useless 404 JSON error, which is confusing when opening the gateway URL in a browser
- Now returns a 302 redirect to `/ui` where the dashboard lives
- Uses 302 (not 301) to avoid aggressive browser/proxy caching

## Details

Single 4-line change in `packages/gateway/src/server.ts` — inserts a redirect handler just before the 404 catch-all. No risk of conflict with existing routes since all API routes (`/v1/*`) and `/health` are matched by exact equality earlier in the chain.