### PR TITLE
fix: stop merging sub-agent turns into parent session

### DIFF
--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -67,7 +67,6 @@ import {
   fingerprintMessages,
   MESSAGE_COUNT_PROXIMITY_THRESHOLD,
   extractKnownSessionHeader,
-  extractParentSessionId,
   learnHeaders,
 } from "./session";
 import {
@@ -810,19 +809,10 @@ async function identifySession(
   const headers = req.rawHeaders;
 
   // --- Tier 1: Known headers ---
-
-  // Check for parent session header first (sub-agent → parent merge).
-  const parentId = extractParentSessionId(headers);
-  if (parentId) {
-    // Look up the parent session by its header value across all known headers.
-    for (const [indexKey, sid] of headerSessionIndex) {
-      if (indexKey.endsWith(`:${parentId}`)) {
-        return { sessionID: sid, isNew: false, tier: 1 };
-      }
-    }
-    // Parent not found — fall through to check if this request also carries
-    // its own session header (some clients send both).
-  }
+  // Sub-agent requests (carrying x-parent-session-id) are NOT merged into the
+  // parent session. They carry their own x-session-affinity nanoid and get
+  // independent sessions, benefiting from the full Lore pipeline (LTM,
+  // gradient, distillation) on their own state without corrupting the parent.
 
   const known = extractKnownSessionHeader(headers);
   if (known) {
@@ -1721,8 +1711,6 @@ function postResponse(
   requestBody?: string,
   /** Active gen_ai.chat span to finalize with usage attributes. */
   genAiSpan?: Sentry.Span,
-  /** When true, skip output EMA / max_tokens state updates (sub-agent turn). */
-  isSubagentTurn = false,
 ): void {
   const { sessionID, projectPath } = sessionState;
 
@@ -1805,12 +1793,7 @@ function postResponse(
     const prevStopReason = sessionState.lastStopReason;
 
     // --- Temporal storage & session-state updates ---
-    // Sub-agent turns are excluded from temporal storage: their tool-call
-    // messages would pollute the parent session's conversation history,
-    // trigger distillation of sub-agent content, and inject a synthetic
-    // "I'm ready to continue" prefix that primes the model to echo the
-    // plan mode system prompt instead of continuing with the actual task.
-    if (!isSubagentTurn) {
+    {
       // Store all messages (user + assistant) from this turn.
       // Convert gateway messages to Lore format.
       const loreMessages = gatewayMessagesToLore(req.messages, sessionID);
@@ -1862,39 +1845,33 @@ function postResponse(
     }
 
     // --- Output tracking for dynamic max_tokens sizing ---
-    // Sub-agent turns are excluded: their short tool-call responses would
-    // contaminate the parent session's EMA, causing the next parent turn to
-    // receive an artificially low max_tokens (floor of 8192) which truncates
-    // comprehensive planning responses.
-    if (!isSubagentTurn) {
-      sessionState.lastStopReason = resp.stopReason;
-      sessionState.lastInputTokens =
-        (resp.usage.inputTokens ?? 0) +
-        (resp.usage.cacheReadInputTokens ?? 0) +
-        (resp.usage.cacheCreationInputTokens ?? 0);
-      const outputTokens = resp.usage.outputTokens;
-      if (outputTokens > 0) {
-        const EMA_ALPHA = 0.3;
-        sessionState.outputTokensEMA =
-          sessionState.outputTokensEMA == null
-            ? outputTokens
-            : Math.round(
-                sessionState.outputTokensEMA * (1 - EMA_ALPHA) +
-                  outputTokens * EMA_ALPHA,
-              );
-      }
+    sessionState.lastStopReason = resp.stopReason;
+    sessionState.lastInputTokens =
+      (resp.usage.inputTokens ?? 0) +
+      (resp.usage.cacheReadInputTokens ?? 0) +
+      (resp.usage.cacheCreationInputTokens ?? 0);
+    const outputTokens = resp.usage.outputTokens;
+    if (outputTokens > 0) {
+      const EMA_ALPHA = 0.3;
+      sessionState.outputTokensEMA =
+        sessionState.outputTokensEMA == null
+          ? outputTokens
+          : Math.round(
+              sessionState.outputTokensEMA * (1 - EMA_ALPHA) +
+                outputTokens * EMA_ALPHA,
+            );
     }
 
     // --- Cache warming: record inter-turn gap + track warmup hits ---
     const now = Date.now();
 
     // (A) Record inter-turn gap — only for genuine user-initiated turns.
-    // Subagent turns (x-parent-session-id) and tool-use auto-continuations
-    // (prior stop_reason was "tool_use") produce sub-second gaps that
-    // represent automated round-trips, not human think time. Recording
-    // these would skew the survival model toward very short return times.
+    // Tool-use auto-continuations (prior stop_reason was "tool_use") produce
+    // sub-second gaps that represent automated round-trips, not human think
+    // time. Recording these would skew the survival model toward very short
+    // return times.
     const isToolUseContinuation = prevStopReason === "tool_use";
-    if (!isSubagentTurn && !isToolUseContinuation) {
+    if (!isToolUseContinuation) {
       if (sessionState.lastUserTurnTime > 0) {
         const gap = now - sessionState.lastUserTurnTime;
         recordGap(getSessionHistogram(sessionState), gap);
@@ -1960,9 +1937,7 @@ function postResponse(
     // Reset warming state if session was marked dead or had active warming.
     // Dead flag is cleared so the next break gets a fresh ROI analysis.
     // warmupCount is reset so the break-even cap starts from 0 on the next break.
-    // Guard: only real user turns should reset — subagent turns would falsely
-    // clear the break-even counter and re-enable dead sessions.
-    if (!isSubagentTurn && sessionState.warmup) {
+    if (sessionState.warmup) {
       if (sessionState.warmup.disabled) {
         sessionState.warmup.disabled = false;
         log.info(
@@ -1978,22 +1953,14 @@ function postResponse(
     // Track how large the context *would* be without Lore's distillation
     // compressing it. When the shadow counter crosses the auto-compact
     // threshold, record a counterfactual compaction event.
-    if (!isSubagentTurn) {
-      updateShadowContext(sessionID, actualInput, resp.usage.outputTokens ?? 0, getWorkerModel()?.modelID ?? "unknown", req.model);
-    }
+    updateShadowContext(sessionID, actualInput, resp.usage.outputTokens ?? 0, getWorkerModel()?.modelID ?? "unknown", req.model);
 
     // Mark session dirty for periodic flush (gradient + warming + costs).
     // The 30s idle tick will persist state only for dirty sessions.
-    if (!isSubagentTurn) {
-      sessionState._dirty = true;
-    }
+    sessionState._dirty = true;
 
     // --- Schedule background work (fire-and-forget) ---
-    // Skip for sub-agent turns: no temporal messages were stored above,
-    // so there's nothing new to distill or curate.
-    if (!isSubagentTurn) {
-      scheduleBackgroundWork(sessionState, config);
-    }
+    scheduleBackgroundWork(sessionState, config);
   } catch (e) {
     log.error("post-response processing failed:", e);
   }
@@ -2405,11 +2372,6 @@ async function handleConversationTurn(
   const sessionState = getOrCreateSession(sessionID, pathResult.path);
   const projectPath = resolveSessionProjectPath(pathResult, sessionState);
 
-  // Detect sub-agent turns (e.g. OpenCode explore/general agents) that were
-  // merged into the parent session via x-parent-session-id.  These turns
-  // must NOT pollute the parent's output EMA or max_tokens state.
-  const isSubagentTurn = extractParentSessionId(req.rawHeaders) != null;
-
   // Bind auth credential to this session for background workers
   if (cred) {
     setSessionAuth(sessionID, cred);
@@ -2465,19 +2427,14 @@ async function handleConversationTurn(
   }
 
   // Update message count for proximity matching & structural compaction detection.
-  // Sub-agent turns have their own independent (smaller) message arrays — updating
-  // messageCount with those would inflate then "drop" the count when the main agent
-  // resumes, triggering false structural compaction detection.
-  if (!isSubagentTurn) {
-    sessionState.messageCount = currMsgCount;
-    // Batched save: messageCount + turnsSinceCuration + consecutiveTextOnlyTurns
-    // together to avoid multiple DB writes per turn.
-    saveSessionTracking(sessionID, {
-      messageCount: currMsgCount,
-      turnsSinceCuration: sessionState.turnsSinceCuration,
-      consecutiveTextOnlyTurns: sessionState.consecutiveTextOnlyTurns,
-    });
-  }
+  sessionState.messageCount = currMsgCount;
+  // Batched save: messageCount + turnsSinceCuration + consecutiveTextOnlyTurns
+  // together to avoid multiple DB writes per turn.
+  saveSessionTracking(sessionID, {
+    messageCount: currMsgCount,
+    turnsSinceCuration: sessionState.turnsSinceCuration,
+    consecutiveTextOnlyTurns: sessionState.consecutiveTextOnlyTurns,
+  });
 
   // Track session model for worker model discovery
   lastSeenSessionModel = req.model;
@@ -2508,8 +2465,7 @@ async function handleConversationTurn(
 
   log.info(
     `turn: session=${sessionID.slice(0, 16)} messages=${req.messages.length} ` +
-      `model=${req.model} stream=${req.stream} new=${isNew} tier=${tier}` +
-      (isSubagentTurn ? ` subagent=true` : ``),
+      `model=${req.model} stream=${req.stream} new=${isNew} tier=${tier}`,
   );
 
   // --- 4. Set model limits ---
@@ -2544,14 +2500,9 @@ async function handleConversationTurn(
   // clients (OpenCode, generic) often send low/missing values (defaults to
   // 4096 in ingress parsing). Apply a hybrid headroom + history algorithm
   // that tightens from the 32K ceiling based on actual output patterns.
-  //
-  // Sub-agent turns are excluded: their output patterns differ wildly from
-  // the parent conversation (many short tool-call responses) and would
-  // contaminate the EMA, causing the parent's next turn to receive an
-  // artificially low max_tokens.
   const clientType = detectClientType(req.rawHeaders);
   const isCC = clientType === "claude-code" || hasBillingHeader(req.system);
-  if (!isCC && !isSubagentTurn) {
+  if (!isCC) {
     const computed = computeMaxTokens(
       modelSpec.output,
       modelSpec.context,
@@ -2978,7 +2929,7 @@ async function handleConversationTurn(
     // since the Anthropic SSE accumulator can't parse OpenAI SSE formats.
     if (effectiveProtocol === "openai-responses") {
       const resp = await accumulateResponsesSSEStream(upstreamResponse);
-      postResponse(req, resp, sessionState, config, requestBody, genAiSpan, isSubagentTurn);
+      postResponse(req, resp, sessionState, config, requestBody, genAiSpan);
       return nonStreamHttpResponse(resp);
     }
 
@@ -2986,7 +2937,7 @@ async function handleConversationTurn(
       // OpenAI Chat Completions streaming — accumulate and return as
       // non-streaming Anthropic format (same pattern as non-stream path).
       const resp = await accumulateNonStreamOpenAIStream(upstreamResponse);
-      postResponse(req, resp, sessionState, config, requestBody, genAiSpan, isSubagentTurn);
+      postResponse(req, resp, sessionState, config, requestBody, genAiSpan);
       return nonStreamHttpResponse(resp);
     }
 
@@ -2997,7 +2948,7 @@ async function handleConversationTurn(
     );
     return buildStreamingResponse(
       upstreamResponse,
-      (resp) => postResponse(req, resp, sessionState, config, requestBody, genAiSpan, isSubagentTurn),
+      (resp) => postResponse(req, resp, sessionState, config, requestBody, genAiSpan),
       hasRecallTool
         ? { modifiedReq, config, sessionState, cacheOptions }
         : undefined,
@@ -3035,7 +2986,7 @@ async function handleConversationTurn(
       log.info(
         `recall (non-stream, mixed): stored result for session ${sessionState.sessionID.slice(0, 16)}`,
       );
-      postResponse(req, markerResp, sessionState, config, requestBody, genAiSpan, isSubagentTurn);
+      postResponse(req, markerResp, sessionState, config, requestBody, genAiSpan);
       return nonStreamHttpResponse(markerResp);
     }
 
@@ -3063,7 +3014,7 @@ async function handleConversationTurn(
         new Error(`recall follow-up upstream ${followUpResponse.status}`),
       );
       // Fall back to response with marker (no continuation)
-      postResponse(req, markerResp, sessionState, config, requestBody, genAiSpan, isSubagentTurn);
+      postResponse(req, markerResp, sessionState, config, requestBody, genAiSpan);
       return nonStreamHttpResponse(markerResp);
     }
 
@@ -3091,11 +3042,11 @@ async function handleConversationTurn(
         resp.usage.cacheCreationInputTokens;
     }
 
-    postResponse(req, continuationResp, sessionState, config, requestBody, genAiSpan, isSubagentTurn);
+    postResponse(req, continuationResp, sessionState, config, requestBody, genAiSpan);
     return nonStreamHttpResponse(continuationResp);
   }
 
-  postResponse(req, resp, sessionState, config, requestBody, genAiSpan, isSubagentTurn);
+  postResponse(req, resp, sessionState, config, requestBody, genAiSpan);
   return nonStreamHttpResponse(resp);
 }
 
@@ -3451,20 +3402,9 @@ export async function handleRequest(
 
     // --- Case 1: Compaction request → intercept ---
     // Structural detection (session-aware) first, pattern matching as fallback.
-    //
-    // IMPORTANT: structural detection catches post-compaction autocontinue turns
-    // (OpenCode already compacted internally, now sends ~3 messages to continue).
-    // For subagent sessions, intercepting these is fatal: the gateway returns a
-    // compaction summary which becomes the subagent's task_result and leaks into
-    // the parent session.  Structural detection is skipped for subagents.
-    //
-    // Pattern-detected compaction (system prompt / user keywords / template) IS
-    // a real compaction request from OpenCode.  Intercepting with our
-    // distillation-based summary is cheaper than an upstream model call and works
-    // correctly for both main and subagent sessions (the summary flows into
-    // OpenCode's compaction processor, not directly as task_result).
-    const isSubagent = extractParentSessionId(req.rawHeaders) != null;
-    const structuralCompaction = !isSubagent && isStructuralCompaction(req, priorState);
+    // Sub-agents now get their own sessions (separate x-session-affinity), so
+    // priorState is the sub-agent's own state — structural detection is safe.
+    const structuralCompaction = isStructuralCompaction(req, priorState);
     const patternDetection = structuralCompaction ? undefined : detectCompactionRequest(req);
     if (structuralCompaction || patternDetection?.detected) {
       const reason = structuralCompaction
@@ -3478,12 +3418,6 @@ export async function handleRequest(
           : "unknown";
       log.info(`compaction detected: ${reason} messages=${req.messages.length} tools=${req.tools.length}`);
       return await handleCompaction(req, config);
-    }
-    if (isSubagent && isStructuralCompaction(req, priorState)) {
-      log.info(
-        `structural compaction skipped for subagent: prior=${priorState?.messageCount ?? "?"} curr=${req.messages.length}`
-        + ` — post-compaction autocontinue, passing through to upstream`,
-      );
     }
 
     // --- Case 2: Meta request (title gen, summary, categorization, etc.) → passthrough ---

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -794,7 +794,7 @@ function getOrCreateSession(
  *
  * Uses a 3-tier strategy:
  *  1. **Known headers** — `x-claude-code-session-id`, `x-session-affinity`,
- *     `x-parent-session-id`. Immediate match, survives compaction & model changes.
+ *     `x-lore-session-id`. Immediate match, survives compaction & model changes.
  *  2. **Learned headers** — `x-` headers discovered via fingerprint-bootstrapped
  *     learning. Promoted after 3 stable turns + cross-session uniqueness.
  *  3. **Fingerprint fallback** — SHA-256 of first user message + auth suffix
@@ -1793,55 +1793,53 @@ function postResponse(
     const prevStopReason = sessionState.lastStopReason;
 
     // --- Temporal storage & session-state updates ---
-    {
-      // Store all messages (user + assistant) from this turn.
-      // Convert gateway messages to Lore format.
-      const loreMessages = gatewayMessagesToLore(req.messages, sessionID);
-      resolveToolResults(loreMessages);
+    // Store all messages (user + assistant) from this turn.
+    // Convert gateway messages to Lore format.
+    const loreMessages = gatewayMessagesToLore(req.messages, sessionID);
+    resolveToolResults(loreMessages);
 
-      // Store the latest user message (last user message in the array)
-      for (let i = loreMessages.length - 1; i >= 0; i--) {
-        if (loreMessages[i].info.role === "user") {
-          temporal.store({
-            projectPath,
-            info: loreMessages[i].info,
-            parts: loreMessages[i].parts,
-          });
-          break;
-        }
-      }
-
-      // Build and store the assistant response message.
-      // Strip recall marker text blocks — they contain the raw query string
-      // and pollute FTS results with self-referential noise.
-      const assistantContent = resp.content.filter(
-        (b) => !(b.type === "text" && isRecallMarker(b.text)),
-      );
-      if (assistantContent.length > 0) {
-        const assistantMsg = gatewayMessagesToLore(
-          [{ role: "assistant", content: assistantContent }],
-          sessionID,
-        )[0];
-        updateAssistantMessageTokens(assistantMsg, resp.usage, resp.model);
+    // Store the latest user message (last user message in the array)
+    for (let i = loreMessages.length - 1; i >= 0; i--) {
+      if (loreMessages[i].info.role === "user") {
         temporal.store({
           projectPath,
-          info: assistantMsg.info,
-          parts: assistantMsg.parts,
+          info: loreMessages[i].info,
+          parts: loreMessages[i].parts,
         });
+        break;
       }
+    }
 
-      // Update session state (persisted in the batched save after messageCount update)
-      sessionState.turnsSinceCuration =
-        (sessionState.turnsSinceCuration ?? 0) + 1;
+    // Build and store the assistant response message.
+    // Strip recall marker text blocks — they contain the raw query string
+    // and pollute FTS results with self-referential noise.
+    const assistantContent = resp.content.filter(
+      (b) => !(b.type === "text" && isRecallMarker(b.text)),
+    );
+    if (assistantContent.length > 0) {
+      const assistantMsg = gatewayMessagesToLore(
+        [{ role: "assistant", content: assistantContent }],
+        sessionID,
+      )[0];
+      updateAssistantMessageTokens(assistantMsg, resp.usage, resp.model);
+      temporal.store({
+        projectPath,
+        info: assistantMsg.info,
+        parts: assistantMsg.parts,
+      });
+    }
 
-      // --- Track consecutive text-only end_turn responses (session-end heuristic) ---
-      const hasToolUse = resp.content.some((b) => b.type === "tool_use");
-      if (resp.stopReason === "end_turn" && !hasToolUse) {
-        sessionState.consecutiveTextOnlyTurns =
-          (sessionState.consecutiveTextOnlyTurns ?? 0) + 1;
-      } else {
-        sessionState.consecutiveTextOnlyTurns = 0;
-      }
+    // Update session state (persisted in the batched save after messageCount update)
+    sessionState.turnsSinceCuration =
+      (sessionState.turnsSinceCuration ?? 0) + 1;
+
+    // --- Track consecutive text-only end_turn responses (session-end heuristic) ---
+    const hasToolUse = resp.content.some((b) => b.type === "tool_use");
+    if (resp.stopReason === "end_turn" && !hasToolUse) {
+      sessionState.consecutiveTextOnlyTurns =
+        (sessionState.consecutiveTextOnlyTurns ?? 0) + 1;
+    } else {
+      sessionState.consecutiveTextOnlyTurns = 0;
     }
 
     // --- Output tracking for dynamic max_tokens sizing ---
@@ -1883,7 +1881,7 @@ function postResponse(
 
     // (B) Track warmup hits and TTL savings — valid for ALL turn types.
     // A user returning after a warmup is a hit regardless of whether it's
-    // a subagent turn or tool-use continuation.
+    // a tool-use continuation.
     // NOTE: warmup hits and TTL savings are mutually exclusive — if a turn
     // is attributed to a warmup hit, skip TTL savings to avoid double-counting
     // the same cacheReadTokens in both buckets.

--- a/packages/gateway/src/session.ts
+++ b/packages/gateway/src/session.ts
@@ -5,9 +5,9 @@
  *
  *  **Tier 1 — Known headers** (immediate match):
  *    `x-claude-code-session-id` (Claude Code), `x-session-affinity`
- *    (OpenCode). These persist for the entire client session and survive
- *    model changes, compaction, and context rewriting.
- *    `x-parent-session-id` links sub-agent requests to a parent session.
+ *    (OpenCode), `x-lore-session-id` (Pi plugin). These persist for the
+ *    entire client session and survive model changes, compaction, and
+ *    context rewriting.
  *
  *  **Tier 2 — Learned headers** (bootstrapped via fingerprint):
  *    During the first few fingerprinted turns, collect candidate `x-`
@@ -271,19 +271,9 @@ export const KNOWN_SESSION_HEADERS = [
 ] as const;
 
 /**
- * Headers that link a sub-agent request to its parent session.
- * When present, the request is attributed to the parent session
- * rather than creating a new one.
- */
-export const PARENT_SESSION_HEADERS = [
-  "x-parent-session-id", // OpenCode sub-sessions
-] as const;
-
-/**
  * Extract a session ID from known headers (Tier 1).
  *
- * Returns the session ID value and the header name that provided it,
- * plus an optional parent session ID for sub-agent merging.
+ * Returns the session ID value and the header name that provided it.
  * Returns `null` if no known session header is present.
  */
 export function extractKnownSessionHeader(
@@ -294,20 +284,6 @@ export function extractKnownSessionHeader(
     if (value && value.length > 0) {
       return { sessionId: value, headerName: name };
     }
-  }
-  return null;
-}
-
-/**
- * Extract a parent session ID from known parent headers.
- * Returns the parent session ID value, or `null` if not present.
- */
-export function extractParentSessionId(
-  rawHeaders: Record<string, string>,
-): string | null {
-  for (const name of PARENT_SESSION_HEADERS) {
-    const value = rawHeaders[name];
-    if (value && value.length > 0) return value;
   }
   return null;
 }

--- a/packages/gateway/src/translate/types.ts
+++ b/packages/gateway/src/translate/types.ts
@@ -227,9 +227,9 @@ export type SessionState = {
   fingerprint: string;
   /** Unix timestamp (ms) of the last request in this session. */
   lastRequestTime: number;
-  /** Unix timestamp (ms) of the last user-initiated turn — excludes subagent
-   *  turns and tool-use auto-continuations. Used exclusively for inter-turn
-   *  gap histogram recording (survival analysis). */
+  /** Unix timestamp (ms) of the last user-initiated turn — excludes tool-use
+   *  auto-continuations. Used exclusively for inter-turn gap histogram
+   *  recording (survival analysis). */
   lastUserTurnTime: number;
   /** Total user+assistant messages seen in this session. */
   messageCount: number;

--- a/packages/gateway/test/cache-warmer.test.ts
+++ b/packages/gateway/test/cache-warmer.test.ts
@@ -1191,19 +1191,21 @@ describe("gap recording filtering", () => {
   /**
    * Helper to simulate the gap recording logic from pipeline.ts postResponse().
    * This mirrors the guarded block that decides whether to record a gap.
+   *
+   * Sub-agent turns now get their own sessions (not merged into the parent),
+   * so the isSubagentTurn guard has been removed from the pipeline.
    */
   function simulateGapRecording(
     sessionState: SessionState,
     opts: {
-      isSubagentTurn: boolean;
       prevStopReason: string | undefined;
       now: number;
     },
   ): void {
-    const { isSubagentTurn, prevStopReason, now } = opts;
+    const { prevStopReason, now } = opts;
     const isToolUseContinuation = prevStopReason === "tool_use";
 
-    if (!isSubagentTurn && !isToolUseContinuation) {
+    if (!isToolUseContinuation) {
       if (sessionState.lastUserTurnTime > 0) {
         const gap = now - sessionState.lastUserTurnTime;
         recordGap(getSessionHistogram(sessionState), gap);
@@ -1213,26 +1215,11 @@ describe("gap recording filtering", () => {
     }
   }
 
-  test("subagent turns do not record gaps", () => {
-    const state = makeSessionState({ lastUserTurnTime: Date.now() - 60_000 });
-    const hist = getSessionHistogram(state);
-    expect(hist.total).toBe(0);
-
-    simulateGapRecording(state, {
-      isSubagentTurn: true,
-      prevStopReason: "end_turn",
-      now: Date.now(),
-    });
-
-    expect(hist.total).toBe(0);
-  });
-
   test("tool-use continuation turns do not record gaps", () => {
     const state = makeSessionState({ lastUserTurnTime: Date.now() - 60_000 });
     const hist = getSessionHistogram(state);
 
     simulateGapRecording(state, {
-      isSubagentTurn: false,
       prevStopReason: "tool_use",
       now: Date.now(),
     });
@@ -1240,25 +1227,11 @@ describe("gap recording filtering", () => {
     expect(hist.total).toBe(0);
   });
 
-  test("lastUserTurnTime is not updated by subagent turns", () => {
-    const originalTime = Date.now() - 120_000;
-    const state = makeSessionState({ lastUserTurnTime: originalTime });
-
-    simulateGapRecording(state, {
-      isSubagentTurn: true,
-      prevStopReason: "end_turn",
-      now: Date.now(),
-    });
-
-    expect(state.lastUserTurnTime).toBe(originalTime);
-  });
-
   test("lastUserTurnTime is not updated by tool-use continuations", () => {
     const originalTime = Date.now() - 120_000;
     const state = makeSessionState({ lastUserTurnTime: originalTime });
 
     simulateGapRecording(state, {
-      isSubagentTurn: false,
       prevStopReason: "tool_use",
       now: Date.now(),
     });
@@ -1268,15 +1241,12 @@ describe("gap recording filtering", () => {
 
   test("gap is computed from lastUserTurnTime, not lastRequestTime", () => {
     const now = Date.now();
-    // lastRequestTime was updated 5s ago by a subagent, but the last
-    // actual user turn was 60s ago.
     const state = makeSessionState({
       lastRequestTime: now - 5_000,
       lastUserTurnTime: now - 60_000,
     });
 
     simulateGapRecording(state, {
-      isSubagentTurn: false,
       prevStopReason: "end_turn",
       now,
     });
@@ -1294,7 +1264,6 @@ describe("gap recording filtering", () => {
     const hist = getSessionHistogram(state);
 
     simulateGapRecording(state, {
-      isSubagentTurn: false,
       prevStopReason: undefined,
       now,
     });
@@ -1308,7 +1277,6 @@ describe("gap recording filtering", () => {
     const state = makeSessionState({ lastUserTurnTime: now - 180_000 }); // 3 min ago
 
     simulateGapRecording(state, {
-      isSubagentTurn: false,
       prevStopReason: "end_turn",
       now,
     });
@@ -1323,27 +1291,12 @@ describe("gap recording filtering", () => {
     const state = makeSessionState({ projectPath: GAP_TEST_PROJECT_PATH, lastUserTurnTime: now - 120_000 }); // 2 min ago
 
     simulateGapRecording(state, {
-      isSubagentTurn: false,
       prevStopReason: "end_turn",
       now,
     });
 
     const globalHist = getGlobalHistogram(GAP_TEST_PID);
     expect(globalHist.total).toBe(1);
-  });
-
-  test("global histogram is not polluted by subagent turns", () => {
-    const now = Date.now();
-    const state = makeSessionState({ projectPath: GAP_TEST_PROJECT_PATH, lastUserTurnTime: now - 120_000 });
-
-    simulateGapRecording(state, {
-      isSubagentTurn: true,
-      prevStopReason: "end_turn",
-      now,
-    });
-
-    const globalHist = getGlobalHistogram(GAP_TEST_PID);
-    expect(globalHist.total).toBe(0);
   });
 
   test("single histogram: no time-slot segmentation", () => {

--- a/packages/gateway/test/max-tokens.test.ts
+++ b/packages/gateway/test/max-tokens.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from "bun:test";
 import { computeMaxTokens } from "../src/pipeline";
-import { detectClientType, extractParentSessionId } from "../src/session";
+import { detectClientType } from "../src/session";
 import { hasBillingHeader } from "../src/cch";
 
 // ---------------------------------------------------------------------------
@@ -177,27 +177,4 @@ describe("hasBillingHeader", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// extractParentSessionId — sub-agent detection
-// ---------------------------------------------------------------------------
 
-describe("extractParentSessionId", () => {
-  test("returns parent session ID when x-parent-session-id is present", () => {
-    expect(
-      extractParentSessionId({ "x-parent-session-id": "parent-abc-123" }),
-    ).toBe("parent-abc-123");
-  });
-
-  test("returns null when no parent header is present", () => {
-    expect(extractParentSessionId({})).toBeNull();
-    expect(
-      extractParentSessionId({ "x-session-affinity": "my-session" }),
-    ).toBeNull();
-  });
-
-  test("returns null for empty parent header value", () => {
-    expect(
-      extractParentSessionId({ "x-parent-session-id": "" }),
-    ).toBeNull();
-  });
-});

--- a/packages/gateway/test/session.test.ts
+++ b/packages/gateway/test/session.test.ts
@@ -7,7 +7,7 @@ import {
   scanForMarker,
   fingerprintMessages,
   extractKnownSessionHeader,
-  extractParentSessionId,
+
   isSessionHeaderName,
   isIdLikeValue,
   collectCandidateHeaders,
@@ -406,29 +406,6 @@ describe("extractKnownSessionHeader", () => {
       sessionId: "valid-id",
       headerName: "x-session-affinity",
     });
-  });
-});
-
-describe("extractParentSessionId", () => {
-  test("extracts x-parent-session-id", () => {
-    const result = extractParentSessionId({
-      "x-parent-session-id": "parent-uuid-123",
-    });
-    expect(result).toBe("parent-uuid-123");
-  });
-
-  test("returns null when no parent header present", () => {
-    const result = extractParentSessionId({
-      "x-session-affinity": "not-parent",
-    });
-    expect(result).toBeNull();
-  });
-
-  test("ignores empty values", () => {
-    const result = extractParentSessionId({
-      "x-parent-session-id": "",
-    });
-    expect(result).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

- Sub-agent requests (OpenCode explore/general agents) were being merged into the parent session via `x-parent-session-id` header lookup, causing the full Lore pipeline to run on the sub-agent's messages using the parent's session state — corrupting gradient state, cache analytics, timing baselines, and model tracking
- Removed the parent-merge priority in `identifySession()` so sub-agents naturally get independent sessions through their own `x-session-affinity` header, benefiting from the full pipeline (LTM, gradient, distillation, curation) on their own state
- Cleaned up all now-dead `isSubagentTurn` guards from `handleConversationTurn()`, `postResponse()`, and the structural compaction dispatch

## Problem

When OpenCode spawns a sub-agent (e.g. "explore" for file search), the gateway merged it into the parent session, then ran the full pipeline against the parent's state with the sub-agent's completely different system prompt and messages. This caused:

1. **False cache divergence alerts** — sub-agent body compared against parent's `lastRequestBody`
2. **Gradient state corruption** — sub-agent's tiny message array overwrote parent's `lastLayer`, `lastTransformedCount`
3. **Cache analytics poisoning** — sub-agent body stored as `lastRequestBody`, poisoning next parent comparison
4. **Bust rate contamination** — sub-agent's always-cold cache stats fed into parent's dynamic context cap
5. **Model/protocol corruption** — sub-agent's model overwrote parent's `lastModel` for warmup profile
6. **Timing corruption** — `lastRequestTime` reset by sub-agent in `getOrCreateSession()`

## Approach

Sub-agents already carry their own `x-session-affinity` nanoid. The fix simply removes the `x-parent-session-id` merge priority in `identifySession()`, letting sub-agents fall through to the normal Tier 1 path where they get independent sessions. Net deletion: **-113 lines**.

## Files changed

| File | Change |
|---|---|
| `packages/gateway/src/pipeline.ts` | Remove parent-merge in `identifySession()`, remove all `isSubagentTurn` logic, remove structural compaction sub-agent guard |
| `packages/gateway/test/cache-warmer.test.ts` | Update `simulateGapRecording` helper, remove 3 obsolete sub-agent tests |