### PR TITLE
feat: REST API for remote data management, recall, and import

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -908,6 +908,39 @@ export function projectId(path: string): string | undefined {
   return alias?.project_id;
 }
 
+/**
+ * Look up a project by git_remote (preferred) or path. Returns the project ID
+ * or null if not found. Unlike `ensureProject()`, this is read-only — it never
+ * creates a project or registers path aliases.
+ */
+export function resolveProjectByRemoteOrPath(
+  gitRemote?: string,
+  path?: string,
+): string | null {
+  if (gitRemote) {
+    const row = db()
+      .query("SELECT id FROM projects WHERE git_remote = ? LIMIT 1")
+      .get(gitRemote) as { id: string } | null;
+    if (row) return row.id;
+  }
+  if (path) {
+    return projectId(path) ?? null;
+  }
+  return null;
+}
+
+/**
+ * Look up the path for a project by its internal ID.
+ * Used by the REST API to resolve project UUID → path for core functions
+ * that require a path argument.
+ */
+export function projectPath(id: string): string | null {
+  const row = db()
+    .query("SELECT path FROM projects WHERE id = ?")
+    .get(id) as { path: string } | null;
+  return row?.path ?? null;
+}
+
 /** Look up a project's display name by its internal ID. */
 export function projectName(id: string): string | null {
   const row = db()

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -66,6 +66,8 @@ export {
   isFirstRun,
   projectId,
   projectName,
+  projectPath,
+  resolveProjectByRemoteOrPath,
   mergeProjectInternal,
   loadForceMinLayer,
   saveForceMinLayer,

--- a/packages/gateway/src/api.ts
+++ b/packages/gateway/src/api.ts
@@ -21,6 +21,7 @@ import {
   config as loreConfig,
   resolveProjectByRemoteOrPath,
   projectPath as getProjectPathById,
+  isHostedMode,
   type RecallScope,
   type LLMClient,
 } from "@loreai/core";
@@ -253,7 +254,7 @@ async function handleClearProject(
 ): Promise<Response> {
   let body: { knowledge?: boolean; temporal?: boolean; distillations?: boolean } = {};
   try {
-    body = await parseBody(req);
+    body = (await parseBody(req)) ?? {};
   } catch {
     // Empty body = clear all
   }
@@ -273,11 +274,17 @@ async function handleClearProject(
 }
 
 function handleMergeProjects(): Response {
+  if (isHostedMode()) {
+    return errorResponse(
+      400, "invalid_request",
+      "Merge is not supported in hosted mode (requires local filesystem access to scan git remotes)",
+    );
+  }
   const result = data.backfillGitRemotes();
   return jsonResponse(result);
 }
 
-async function handleReindex(projectPath: string): Promise<Response> {
+async function handleReindex(): Promise<Response> {
   const knowledge = await embedding.backfillEmbeddings();
   const distillations = await embedding.backfillDistillationEmbeddings();
   return jsonResponse({ knowledge_embedded: knowledge, distillations_embedded: distillations });
@@ -308,7 +315,12 @@ async function handleRecall(
     return errorResponse(400, "invalid_request", "Recall requires ?git_remote or ?path to identify the project");
   }
 
-  const scope = (url.searchParams.get("scope") ?? "all") as RecallScope;
+  const VALID_SCOPES = new Set(["all", "session", "project", "knowledge"]);
+  const rawScope = url.searchParams.get("scope") ?? "all";
+  if (!VALID_SCOPES.has(rawScope)) {
+    return errorResponse(400, "invalid_request", `Invalid scope: "${rawScope}". Must be one of: all, session, project, knowledge`);
+  }
+  const scope = rawScope as RecallScope;
   const sessionID = url.searchParams.get("session") ?? undefined;
   const limit = getLimit(url, 10, 50);
 
@@ -523,33 +535,16 @@ export async function handleAPIRequest(
   }
 
   if (method === "POST") {
-    // POST /api/v1/projects/:id/clear
-    params = matchRoute(pathname, "/api/v1/projects/:id/clear");
-    if (params) {
-      const project = resolveProject(url, params.id);
-      if (!project) return errorResponse(404, "not_found", `Project not found: ${params.id}`);
-      return await handleClearProject(req, project.path);
-    }
+    // Literal routes first (before parameterized :id routes)
 
     // POST /api/v1/projects/merge
     if (pathname === "/api/v1/projects/merge") {
       return handleMergeProjects();
     }
 
-    // POST /api/v1/projects/:id/reindex
-    params = matchRoute(pathname, "/api/v1/projects/:id/reindex");
-    if (params) {
-      const project = resolveProject(url, params.id);
-      if (!project) return errorResponse(404, "not_found", `Project not found: ${params.id}`);
-      return await handleReindex(project.path);
-    }
-
-    // POST /api/v1/projects/:id/dedup
-    params = matchRoute(pathname, "/api/v1/projects/:id/dedup");
-    if (params) {
-      const project = resolveProject(url, params.id);
-      if (!project) return errorResponse(404, "not_found", `Project not found: ${params.id}`);
-      return await handleDedup(project.path);
+    // POST /api/v1/reindex — global, not project-scoped (backfill is DB-wide)
+    if (pathname === "/api/v1/reindex") {
+      return await handleReindex();
     }
 
     // POST /api/v1/import/extract
@@ -560,6 +555,24 @@ export async function handleAPIRequest(
     // POST /api/v1/import/record
     if (pathname === "/api/v1/import/record") {
       return await handleImportRecord(req);
+    }
+
+    // Parameterized routes
+
+    // POST /api/v1/projects/:id/clear
+    params = matchRoute(pathname, "/api/v1/projects/:id/clear");
+    if (params) {
+      const project = resolveProject(url, params.id);
+      if (!project) return errorResponse(404, "not_found", `Project not found: ${params.id}`);
+      return await handleClearProject(req, project.path);
+    }
+
+    // POST /api/v1/projects/:id/dedup
+    params = matchRoute(pathname, "/api/v1/projects/:id/dedup");
+    if (params) {
+      const project = resolveProject(url, params.id);
+      if (!project) return errorResponse(404, "not_found", `Project not found: ${params.id}`);
+      return await handleDedup(project.path);
     }
   }
 

--- a/packages/gateway/src/api.ts
+++ b/packages/gateway/src/api.ts
@@ -1,0 +1,567 @@
+/**
+ * REST API for remote data management, recall, and import.
+ *
+ * All endpoints live under `/api/v1/`. This module is lazy-imported from
+ * `server.ts` when the request path starts with `/api/` — keeping the
+ * hot LLM-proxy path free of the extra imports.
+ *
+ * Project resolution: endpoints that need a project accept either:
+ *   - `:id` URL param (project UUID)
+ *   - `?git_remote=...` query param (preferred for remote clients)
+ *   - `?path=...` query param (fallback)
+ */
+
+import {
+  data,
+  ltm,
+  temporal,
+  embedding,
+  conversationImport,
+  runRecall,
+  config as loreConfig,
+  resolveProjectByRemoteOrPath,
+  projectPath as getProjectPathById,
+  type RecallScope,
+  type LLMClient,
+} from "@loreai/core";
+import type { GatewayConfig } from "./config";
+import { createGatewayLLMClient } from "./llm-adapter";
+import { resolveAuth } from "./auth";
+
+// ---------------------------------------------------------------------------
+// Route matching (adapted from ui.ts)
+// ---------------------------------------------------------------------------
+
+type RouteParams = Record<string, string>;
+
+function matchRoute(
+  pathname: string,
+  pattern: string,
+): RouteParams | null {
+  const patternParts = pattern.split("/");
+  const pathParts = pathname.split("/");
+  if (patternParts.length !== pathParts.length) return null;
+  const params: RouteParams = {};
+  for (let i = 0; i < patternParts.length; i++) {
+    if (patternParts[i].startsWith(":")) {
+      params[patternParts[i].slice(1)] = decodeURIComponent(pathParts[i]);
+    } else if (patternParts[i] !== pathParts[i]) {
+      return null;
+    }
+  }
+  return params;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function errorResponse(
+  status: number,
+  type: string,
+  message: string,
+): Response {
+  return jsonResponse({ type: "error", error: { type, message } }, status);
+}
+
+/**
+ * Parse request body with optional zstd decompression.
+ * Checks `Content-Encoding: zstd` header — if present, decompresses
+ * the raw bytes before JSON-parsing.
+ */
+async function parseBody<T = unknown>(req: Request): Promise<T> {
+  const encoding = req.headers.get("content-encoding");
+  if (encoding === "zstd") {
+    const raw = new Uint8Array(await req.arrayBuffer());
+    const decompressed = Bun.zstdDecompressSync(
+      raw as Uint8Array<ArrayBuffer>,
+    );
+    return JSON.parse(new TextDecoder().decode(decompressed)) as T;
+  }
+  return (await req.json()) as T;
+}
+
+/**
+ * Resolve a project from URL params + query string.
+ *
+ * Priority:
+ *   1. `:id` route param (direct UUID)
+ *   2. `?git_remote=...` query param (preferred for remote clients)
+ *   3. `?path=...` query param (fallback)
+ *
+ * Returns `{ id, path }` or null if not found.
+ */
+function resolveProject(
+  url: URL,
+  routeId?: string,
+): { id: string; path: string } | null {
+  // 1. Direct UUID from route param
+  if (routeId) {
+    const path = getProjectPathById(routeId);
+    if (path) return { id: routeId, path };
+    // Maybe it's a git_remote or path passed as route param — unlikely but handle gracefully
+    return null;
+  }
+
+  // 2. Query params: git_remote preferred, path fallback
+  const gitRemote = url.searchParams.get("git_remote") ?? undefined;
+  const pathParam = url.searchParams.get("path") ?? undefined;
+  const id = resolveProjectByRemoteOrPath(gitRemote, pathParam);
+  if (!id) return null;
+
+  const path = getProjectPathById(id);
+  if (!path) return null;
+  return { id, path };
+}
+
+/** Extract `?limit=N` with a default and a max cap. */
+function getLimit(url: URL, defaultLimit = 50, maxLimit = 1000): number {
+  const raw = url.searchParams.get("limit");
+  if (!raw) return defaultLimit;
+  const n = parseInt(raw, 10);
+  if (isNaN(n) || n < 1) return defaultLimit;
+  return Math.min(n, maxLimit);
+}
+
+// ---------------------------------------------------------------------------
+// LLM client (lazy singleton — same pattern as pipeline.ts)
+// ---------------------------------------------------------------------------
+
+let apiLLMClient: LLMClient | null = null;
+
+function getAPILLMClient(config: GatewayConfig): LLMClient {
+  if (!apiLLMClient) {
+    const cfg = loreConfig();
+    const defaultModel = cfg.model ?? {
+      providerID: "anthropic",
+      modelID: "claude-sonnet-4-6",
+    };
+    apiLLMClient = createGatewayLLMClient(
+      { anthropic: config.upstreamAnthropic, openai: config.upstreamOpenAI },
+      resolveAuth,
+      defaultModel,
+    );
+  }
+  return apiLLMClient;
+}
+
+// ---------------------------------------------------------------------------
+// Data read handlers
+// ---------------------------------------------------------------------------
+
+function handleListProjects(): Response {
+  return jsonResponse(data.listProjects());
+}
+
+function handleGlobalStats(): Response {
+  return jsonResponse(data.globalStats());
+}
+
+function handleListKnowledge(url: URL, projectPath: string): Response {
+  const entries = ltm.forProject(projectPath, false);
+  return jsonResponse(entries);
+}
+
+function handleListSessions(url: URL, projectPath: string): Response {
+  const limit = getLimit(url);
+  return jsonResponse(data.listSessions(projectPath, limit));
+}
+
+function handleListDistillations(url: URL, projectPath: string): Response {
+  const limit = getLimit(url);
+  const sessionId = url.searchParams.get("session") ?? undefined;
+  return jsonResponse(data.listDistillations(projectPath, { sessionId, limit }));
+}
+
+function handleShowKnowledge(id: string): Response {
+  // Support prefix resolution
+  const resolvedId = data.resolveId("knowledge", id) ?? id;
+  const entry = ltm.get(resolvedId);
+  if (!entry) return errorResponse(404, "not_found", `Knowledge entry not found: ${id}`);
+  return jsonResponse(entry);
+}
+
+function handleShowSession(
+  url: URL,
+  sessionId: string,
+): Response {
+  // Session show needs a project to scope the query
+  const project = resolveProject(url);
+  if (!project) {
+    return errorResponse(400, "invalid_request", "Session show requires ?git_remote or ?path to identify the project");
+  }
+  const messages = temporal.bySession(project.path, sessionId);
+  const distillations = data.listDistillations(project.path, { sessionId });
+  return jsonResponse({ messages, distillations });
+}
+
+function handleShowDistillation(id: string): Response {
+  const resolvedId = data.resolveId("distillations", id) ?? id;
+  const entry = data.getDistillation(resolvedId);
+  if (!entry) return errorResponse(404, "not_found", `Distillation not found: ${id}`);
+  return jsonResponse(entry);
+}
+
+// ---------------------------------------------------------------------------
+// Data mutation handlers
+// ---------------------------------------------------------------------------
+
+function handleDeleteKnowledge(id: string): Response {
+  const resolvedId = data.resolveId("knowledge", id) ?? id;
+  if (data.deleteKnowledge(resolvedId)) {
+    return jsonResponse({ deleted: true, id: resolvedId });
+  }
+  return errorResponse(404, "not_found", `Knowledge entry not found: ${id}`);
+}
+
+function handleDeleteSession(
+  url: URL,
+  sessionId: string,
+): Response {
+  const project = resolveProject(url);
+  if (!project) {
+    return errorResponse(400, "invalid_request", "Session delete requires ?git_remote or ?path to identify the project");
+  }
+  const result = data.deleteSession(project.path, sessionId);
+  return jsonResponse(result);
+}
+
+function handleDeleteDistillation(id: string): Response {
+  const resolvedId = data.resolveId("distillations", id) ?? id;
+  if (data.deleteDistillation(resolvedId)) {
+    return jsonResponse({ deleted: true, id: resolvedId });
+  }
+  return errorResponse(404, "not_found", `Distillation not found: ${id}`);
+}
+
+function handleDeleteProject(id: string): Response {
+  const result = data.deleteProject(id);
+  if (!result) return errorResponse(404, "not_found", `Project not found: ${id}`);
+  return jsonResponse(result);
+}
+
+async function handleClearProject(
+  req: Request,
+  projectPath: string,
+): Promise<Response> {
+  let body: { knowledge?: boolean; temporal?: boolean; distillations?: boolean } = {};
+  try {
+    body = await parseBody(req);
+  } catch {
+    // Empty body = clear all
+  }
+
+  // If specific flags are set, clear selectively
+  const hasFlags = body.knowledge || body.temporal || body.distillations;
+  if (hasFlags) {
+    const result: Record<string, number> = {};
+    if (body.knowledge) result.knowledge_deleted = data.clearKnowledge(projectPath);
+    if (body.temporal) result.temporal_deleted = data.clearTemporal(projectPath);
+    if (body.distillations) result.distillations_deleted = data.clearDistillations(projectPath);
+    return jsonResponse(result);
+  }
+
+  // No flags = clear everything
+  return jsonResponse(data.clearProject(projectPath));
+}
+
+function handleMergeProjects(): Response {
+  const result = data.backfillGitRemotes();
+  return jsonResponse(result);
+}
+
+async function handleReindex(projectPath: string): Promise<Response> {
+  const knowledge = await embedding.backfillEmbeddings();
+  const distillations = await embedding.backfillDistillationEmbeddings();
+  return jsonResponse({ knowledge_embedded: knowledge, distillations_embedded: distillations });
+}
+
+async function handleDedup(projectPath: string): Promise<Response> {
+  // Always dry-run via API; apply requires explicit ?apply=true
+  const projectResult = await ltm.deduplicate(projectPath, { dryRun: true });
+  const globalResult = await ltm.deduplicateGlobal({ dryRun: true });
+  return jsonResponse({ project: projectResult, global: globalResult });
+}
+
+// ---------------------------------------------------------------------------
+// Recall handler
+// ---------------------------------------------------------------------------
+
+async function handleRecall(
+  url: URL,
+  config: GatewayConfig,
+): Promise<Response> {
+  const query = url.searchParams.get("q");
+  if (!query) {
+    return errorResponse(400, "invalid_request", "Missing required query parameter: q");
+  }
+
+  const project = resolveProject(url);
+  if (!project) {
+    return errorResponse(400, "invalid_request", "Recall requires ?git_remote or ?path to identify the project");
+  }
+
+  const scope = (url.searchParams.get("scope") ?? "all") as RecallScope;
+  const sessionID = url.searchParams.get("session") ?? undefined;
+  const limit = getLimit(url, 10, 50);
+
+  const cfg = loreConfig();
+  const searchConfig = {
+    ...cfg.search,
+    recallLimit: limit,
+  };
+
+  let llm: LLMClient | undefined;
+  try {
+    llm = getAPILLMClient(config);
+  } catch {
+    // No LLM available — proceed without query expansion
+  }
+
+  const result = await runRecall({
+    query,
+    scope,
+    projectPath: project.path,
+    sessionID,
+    llm,
+    searchConfig,
+  });
+
+  return jsonResponse({ query, scope, projectPath: project.path, result });
+}
+
+// ---------------------------------------------------------------------------
+// Import handlers
+// ---------------------------------------------------------------------------
+
+async function handleImportExtract(
+  req: Request,
+  config: GatewayConfig,
+): Promise<Response> {
+  const body = await parseBody<{
+    git_remote?: string;
+    path?: string;
+    chunks: Array<{
+      label: string;
+      text: string;
+      estimatedTokens: number;
+      timestamp: number;
+    }>;
+    model?: { providerID: string; modelID: string };
+  }>(req);
+
+  if (!body.chunks?.length) {
+    return errorResponse(400, "invalid_request", "Missing or empty chunks array");
+  }
+
+  // Resolve project
+  const projectId = resolveProjectByRemoteOrPath(body.git_remote, body.path);
+  const projectPath = projectId ? getProjectPathById(projectId) : body.path;
+  if (!projectPath) {
+    return errorResponse(404, "not_found", "Project not found. Provide git_remote or path.");
+  }
+
+  const cfg = loreConfig();
+  const defaultModel = body.model ?? cfg.model ?? {
+    providerID: "anthropic",
+    modelID: "claude-sonnet-4-6",
+  };
+
+  let llm: LLMClient;
+  try {
+    llm = getAPILLMClient(config);
+  } catch {
+    return errorResponse(503, "service_unavailable", "No LLM client available for extraction");
+  }
+
+  const result = await conversationImport.extractKnowledge({
+    llm,
+    projectPath,
+    chunks: body.chunks,
+    model: defaultModel,
+  });
+
+  return jsonResponse(result);
+}
+
+function handleImportHistory(url: URL): Response {
+  const project = resolveProject(url);
+  if (!project) {
+    return errorResponse(400, "invalid_request", "Import history requires ?git_remote or ?path to identify the project");
+  }
+
+  const records = conversationImport.listImports(project.path);
+  return jsonResponse(records);
+}
+
+async function handleImportRecord(req: Request): Promise<Response> {
+  const body = await parseBody<{
+    git_remote?: string;
+    path?: string;
+    agent_name: string;
+    source_id: string;
+    source_hash: string;
+    stats: { created: number; updated: number };
+  }>(req);
+
+  if (!body.agent_name || !body.source_id || !body.source_hash || !body.stats) {
+    return errorResponse(400, "invalid_request", "Missing required fields: agent_name, source_id, source_hash, stats");
+  }
+
+  const projectId = resolveProjectByRemoteOrPath(body.git_remote, body.path);
+  const projectPath = projectId ? getProjectPathById(projectId) : body.path;
+  if (!projectPath) {
+    return errorResponse(404, "not_found", "Project not found. Provide git_remote or path.");
+  }
+
+  conversationImport.recordImport(projectPath, body.agent_name, body.source_id, body.source_hash, body.stats);
+  return jsonResponse({ recorded: true });
+}
+
+// ---------------------------------------------------------------------------
+// Main request dispatcher
+// ---------------------------------------------------------------------------
+
+export async function handleAPIRequest(
+  req: Request,
+  url: URL,
+  config: GatewayConfig,
+): Promise<Response> {
+  const { pathname } = url;
+  const method = req.method;
+  let params: RouteParams | null;
+
+  // -----------------------------------------------------------------------
+  // Data read endpoints
+  // -----------------------------------------------------------------------
+
+  if (method === "GET") {
+    // GET /api/v1/projects
+    if (pathname === "/api/v1/projects") {
+      return handleListProjects();
+    }
+
+    // GET /api/v1/stats
+    if (pathname === "/api/v1/stats") {
+      return handleGlobalStats();
+    }
+
+    // GET /api/v1/projects/:id/knowledge
+    params = matchRoute(pathname, "/api/v1/projects/:id/knowledge");
+    if (params) {
+      const project = resolveProject(url, params.id);
+      if (!project) return errorResponse(404, "not_found", `Project not found: ${params.id}`);
+      return handleListKnowledge(url, project.path);
+    }
+
+    // GET /api/v1/projects/:id/sessions
+    params = matchRoute(pathname, "/api/v1/projects/:id/sessions");
+    if (params) {
+      const project = resolveProject(url, params.id);
+      if (!project) return errorResponse(404, "not_found", `Project not found: ${params.id}`);
+      return handleListSessions(url, project.path);
+    }
+
+    // GET /api/v1/projects/:id/distillations
+    params = matchRoute(pathname, "/api/v1/projects/:id/distillations");
+    if (params) {
+      const project = resolveProject(url, params.id);
+      if (!project) return errorResponse(404, "not_found", `Project not found: ${params.id}`);
+      return handleListDistillations(url, project.path);
+    }
+
+    // GET /api/v1/knowledge/:id
+    params = matchRoute(pathname, "/api/v1/knowledge/:id");
+    if (params) return handleShowKnowledge(params.id);
+
+    // GET /api/v1/sessions/:id
+    params = matchRoute(pathname, "/api/v1/sessions/:id");
+    if (params) return handleShowSession(url, params.id);
+
+    // GET /api/v1/distillations/:id
+    params = matchRoute(pathname, "/api/v1/distillations/:id");
+    if (params) return handleShowDistillation(params.id);
+
+    // GET /api/v1/recall
+    if (pathname === "/api/v1/recall") {
+      return await handleRecall(url, config);
+    }
+
+    // GET /api/v1/import/history
+    if (pathname === "/api/v1/import/history") {
+      return handleImportHistory(url);
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Data mutation endpoints
+  // -----------------------------------------------------------------------
+
+  if (method === "DELETE") {
+    // DELETE /api/v1/knowledge/:id
+    params = matchRoute(pathname, "/api/v1/knowledge/:id");
+    if (params) return handleDeleteKnowledge(params.id);
+
+    // DELETE /api/v1/sessions/:id
+    params = matchRoute(pathname, "/api/v1/sessions/:id");
+    if (params) return handleDeleteSession(url, params.id);
+
+    // DELETE /api/v1/distillations/:id
+    params = matchRoute(pathname, "/api/v1/distillations/:id");
+    if (params) return handleDeleteDistillation(params.id);
+
+    // DELETE /api/v1/projects/:id
+    params = matchRoute(pathname, "/api/v1/projects/:id");
+    if (params) return handleDeleteProject(params.id);
+  }
+
+  if (method === "POST") {
+    // POST /api/v1/projects/:id/clear
+    params = matchRoute(pathname, "/api/v1/projects/:id/clear");
+    if (params) {
+      const project = resolveProject(url, params.id);
+      if (!project) return errorResponse(404, "not_found", `Project not found: ${params.id}`);
+      return await handleClearProject(req, project.path);
+    }
+
+    // POST /api/v1/projects/merge
+    if (pathname === "/api/v1/projects/merge") {
+      return handleMergeProjects();
+    }
+
+    // POST /api/v1/projects/:id/reindex
+    params = matchRoute(pathname, "/api/v1/projects/:id/reindex");
+    if (params) {
+      const project = resolveProject(url, params.id);
+      if (!project) return errorResponse(404, "not_found", `Project not found: ${params.id}`);
+      return await handleReindex(project.path);
+    }
+
+    // POST /api/v1/projects/:id/dedup
+    params = matchRoute(pathname, "/api/v1/projects/:id/dedup");
+    if (params) {
+      const project = resolveProject(url, params.id);
+      if (!project) return errorResponse(404, "not_found", `Project not found: ${params.id}`);
+      return await handleDedup(project.path);
+    }
+
+    // POST /api/v1/import/extract
+    if (pathname === "/api/v1/import/extract") {
+      return await handleImportExtract(req, config);
+    }
+
+    // POST /api/v1/import/record
+    if (pathname === "/api/v1/import/record") {
+      return await handleImportRecord(req);
+    }
+  }
+
+  return errorResponse(404, "not_found", `No API route for ${method} ${pathname}`);
+}

--- a/packages/gateway/src/cli/data.ts
+++ b/packages/gateway/src/cli/data.ts
@@ -6,9 +6,19 @@
  *   show <type> <id>      Show full detail for an entry
  *   clear [options]       Clear data for a project or wipe the database
  *   delete <type> <id>    Delete a single entry (type: knowledge, session, distillation, project)
+ *
+ * When `LORE_REMOTE_URL` is set, most subcommands delegate to the remote
+ * gateway REST API instead of accessing the local database.
  */
 import { createInterface } from "node:readline";
 import { resolve } from "path";
+import {
+  getRemoteUrl,
+  projectQueryParams,
+  remoteGet,
+  remotePost,
+  remoteDelete,
+} from "./remote";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -71,6 +81,9 @@ async function cmdList(
   args: string[],
   flags: Record<string, unknown>,
 ): Promise<void> {
+  const remote = getRemoteUrl();
+  if (remote) return cmdListRemote(remote, args, flags);
+
   const { data, ltm } = await import("@loreai/core");
   const type = args[0];
   const limit = flags.limit ? Number(flags.limit) : 50;
@@ -193,6 +206,9 @@ async function cmdShow(
   args: string[],
   flags: Record<string, unknown>,
 ): Promise<void> {
+  const remote = getRemoteUrl();
+  if (remote) return cmdShowRemote(remote, args, flags);
+
   const { data, ltm, temporal } = await import("@loreai/core");
   const type = args[0];
   const rawId = args[1];
@@ -316,11 +332,16 @@ async function cmdClear(
   _args: string[],
   flags: Record<string, unknown>,
 ): Promise<void> {
-  const { data } = await import("@loreai/core");
+  const remote = getRemoteUrl();
   const skipConfirm = !!flags.yes;
 
-  // Nuclear option: wipe entire database
+  // Nuclear option: wipe entire database (local-only)
   if (flags.all) {
+    if (remote) {
+      console.error("Error: --all (wipe entire database) is not supported in remote mode.");
+      process.exit(1);
+    }
+    const { data } = await import("@loreai/core");
     if (!skipConfirm) {
       const stats = data.globalStats();
       const confirmed = await confirm(
@@ -343,6 +364,10 @@ async function cmdClear(
   }
 
   const projectPath = resolve((flags.project as string) ?? process.cwd());
+
+  if (remote) return cmdClearRemote(remote, projectPath, flags);
+
+  const { data } = await import("@loreai/core");
   const onlyKnowledge = !!flags.knowledge;
   const onlyTemporal = !!flags.temporal;
   const onlyDistillations = !!flags.distillations;
@@ -411,6 +436,9 @@ async function cmdDelete(
   args: string[],
   flags: Record<string, unknown>,
 ): Promise<void> {
+  const remote = getRemoteUrl();
+  if (remote) return cmdDeleteRemote(remote, args, flags);
+
   const { data } = await import("@loreai/core");
   const type = args[0];
   const rawId = args[1];
@@ -531,6 +559,12 @@ async function cmdRecover(
   _args: string[],
   flags: Record<string, unknown>,
 ): Promise<void> {
+  const remote = getRemoteUrl();
+  if (remote) {
+    console.error("Error: recover is not supported in remote mode (requires local filesystem access).");
+    process.exit(1);
+  }
+
   const { existsSync } = await import("fs");
   const { join } = await import("path");
   const { data, importLoreFile, importFromFile, loreFileExists, clearLoreFileCache, LORE_FILE } =
@@ -634,6 +668,9 @@ async function cmdMerge(
   _args: string[],
   flags: Record<string, unknown>,
 ): Promise<void> {
+  const remote = getRemoteUrl();
+  if (remote) return cmdMergeRemote(remote, flags);
+
   const { data } = await import("@loreai/core");
   const skipConfirm = !!flags.yes;
   const asJson = !!flags.json;
@@ -759,6 +796,9 @@ async function cmdDedup(
   _args: string[],
   flags: Record<string, unknown>,
 ): Promise<void> {
+  const remote = getRemoteUrl();
+  if (remote) return cmdDedupRemote(remote, flags);
+
   const { ltm, data, projectId: getProjectId, embedding: emb } = await import("@loreai/core");
   const apply = !!flags.yes;
   const interactive = !!flags.interactive;
@@ -1044,7 +1084,12 @@ async function cmdDedupInteractive(
   }
 }
 
-async function cmdReindex(): Promise<void> {
+async function cmdReindex(
+  flags?: Record<string, unknown>,
+): Promise<void> {
+  const remote = getRemoteUrl();
+  if (remote) return cmdReindexRemote(remote, flags ?? {});
+
   const { embedding } = await import("@loreai/core");
 
   if (!embedding.isAvailable()) {
@@ -1077,6 +1122,442 @@ async function cmdReindex(): Promise<void> {
     console.error("Re-indexing failed:", err);
     process.exit(1);
   }
+}
+
+// ---------------------------------------------------------------------------
+// Remote CLI handlers
+// ---------------------------------------------------------------------------
+
+async function cmdListRemote(
+  remote: string,
+  args: string[],
+  flags: Record<string, unknown>,
+): Promise<void> {
+  const type = args[0];
+  const limit = flags.limit ? Number(flags.limit) : 50;
+  const asJson = !!flags.json;
+  const projectPath = resolve((flags.project as string) ?? process.cwd());
+
+  switch (type) {
+    case "projects": {
+      const projects = await remoteGet<Array<{
+        id: string; path: string; name: string | null; git_remote: string | null;
+        created_at: number; knowledge_count: number; session_count: number;
+      }>>(remote, "/api/v1/projects");
+      if (asJson) { console.log(JSON.stringify(projects, null, 2)); return; }
+      if (!projects.length) { console.log("No projects found."); return; }
+      printTable(
+        ["Name", "Path", "Git Remote", "ID", "Knowledge", "Sessions", "Created"],
+        projects.map((p) => [
+          p.name ?? "(unnamed)", truncate(p.path, 35), truncate(p.git_remote ?? "-", 30),
+          p.id.slice(0, 8), String(p.knowledge_count), String(p.session_count), formatDate(p.created_at),
+        ]),
+        [16, 35, 30, 10, 10, 10, 20],
+      );
+      break;
+    }
+
+    case "knowledge": {
+      // Find project ID first
+      const projects = await remoteGet<Array<{ id: string }>>(remote, "/api/v1/projects");
+      const pq = projectQueryParams(projectPath);
+      // Use first project matching, or list all if none match
+      let entries: Array<{ id: string; category: string; title: string; confidence: number; updated_at: number }>;
+      const matchingProject = await resolveRemoteProject(remote, projectPath);
+      if (!matchingProject) { console.error(`No project found for: ${projectPath}`); process.exit(1); }
+      entries = await remoteGet(remote, `/api/v1/projects/${matchingProject}/knowledge`);
+      const limited = entries.slice(0, limit);
+      if (asJson) { console.log(JSON.stringify(limited, null, 2)); return; }
+      if (!limited.length) { console.log("No knowledge entries found for this project."); return; }
+      printTable(
+        ["Category", "Title", "Confidence", "Updated", "ID"],
+        limited.map((e) => [
+          e.category, truncate(e.title, 40), e.confidence.toFixed(2),
+          formatDate(e.updated_at), e.id.slice(0, 8),
+        ]),
+        [14, 40, 12, 20, 10],
+      );
+      break;
+    }
+
+    case "sessions": {
+      const projectId = await resolveRemoteProject(remote, projectPath);
+      if (!projectId) { console.error(`No project found for: ${projectPath}`); process.exit(1); }
+      const sessions = await remoteGet<Array<{
+        session_id: string; message_count: number; distilled_count: number;
+        distillation_count: number; first_message_at: number; last_message_at: number;
+      }>>(remote, `/api/v1/projects/${projectId}/sessions?limit=${limit}`);
+      if (asJson) { console.log(JSON.stringify(sessions, null, 2)); return; }
+      if (!sessions.length) { console.log("No sessions found for this project."); return; }
+      printTable(
+        ["Session ID", "Messages", "Distilled", "Distillations", "First", "Last"],
+        sessions.map((s) => [
+          s.session_id.slice(0, 12), String(s.message_count), String(s.distilled_count),
+          String(s.distillation_count), formatDate(s.first_message_at), formatDate(s.last_message_at),
+        ]),
+        [14, 10, 10, 14, 20, 20],
+      );
+      break;
+    }
+
+    case "distillations": {
+      const projectId = await resolveRemoteProject(remote, projectPath);
+      if (!projectId) { console.error(`No project found for: ${projectPath}`); process.exit(1); }
+      const dists = await remoteGet<Array<{
+        id: string; session_id: string; generation: number; token_count: number;
+        r_compression: number | null; c_norm: number | null; archived: number; created_at: number;
+      }>>(remote, `/api/v1/projects/${projectId}/distillations?limit=${limit}`);
+      if (asJson) { console.log(JSON.stringify(dists, null, 2)); return; }
+      if (!dists.length) { console.log("No distillations found for this project."); return; }
+      printTable(
+        ["Session", "Gen", "Tokens", "R_comp", "C_norm", "Archived", "Created", "ID"],
+        dists.map((d) => [
+          d.session_id.slice(0, 12), String(d.generation), String(d.token_count),
+          d.r_compression?.toFixed(2) ?? "-", d.c_norm?.toFixed(2) ?? "-",
+          d.archived ? "yes" : "no", formatDate(d.created_at), d.id.slice(0, 8),
+        ]),
+        [14, 5, 8, 8, 8, 10, 20, 10],
+      );
+      break;
+    }
+
+    default:
+      console.error(
+        `Unknown type "${type ?? "(none)"}". Use: projects, knowledge, sessions, distillations`,
+      );
+      process.exit(1);
+  }
+}
+
+async function cmdShowRemote(
+  remote: string,
+  args: string[],
+  flags: Record<string, unknown>,
+): Promise<void> {
+  const type = args[0];
+  const rawId = args[1];
+  const asJson = !!flags.json;
+  const projectPath = resolve((flags.project as string) ?? process.cwd());
+
+  if (!rawId) {
+    console.error("Error: Missing <id> argument.");
+    process.exit(1);
+  }
+
+  switch (type) {
+    case "knowledge": {
+      const entry = await remoteGet<{
+        id: string; category: string; title: string; content: string; confidence: number;
+        project_id: string | null; cross_project: boolean; source_session: string | null;
+        created_at: number; updated_at: number; metadata: string | null;
+      }>(remote, `/api/v1/knowledge/${encodeURIComponent(rawId)}`);
+      if (asJson) { console.log(JSON.stringify(entry, null, 2)); return; }
+      console.log(`ID:          ${entry.id}`);
+      console.log(`Category:    ${entry.category}`);
+      console.log(`Title:       ${entry.title}`);
+      console.log(`Confidence:  ${entry.confidence}`);
+      console.log(`Project ID:  ${entry.project_id ?? "(global)"}`);
+      console.log(`Cross-proj:  ${entry.cross_project ? "yes" : "no"}`);
+      console.log(`Session:     ${entry.source_session ?? "(none)"}`);
+      console.log(`Created:     ${formatDate(entry.created_at)}`);
+      console.log(`Updated:     ${formatDate(entry.updated_at)}`);
+      if (entry.metadata) console.log(`Metadata:    ${entry.metadata}`);
+      console.log(`\nContent:\n${entry.content}`);
+      break;
+    }
+
+    case "session": {
+      const pq = projectQueryParams(projectPath);
+      const data = await remoteGet<{
+        messages: Array<{ role: string; content: string; created_at: number }>;
+        distillations: Array<{ id: string; generation: number; token_count: number; created_at: number }>;
+      }>(remote, `/api/v1/sessions/${encodeURIComponent(rawId)}?${pq}`);
+      if (asJson) { console.log(JSON.stringify(data, null, 2)); return; }
+      console.log(`Session: ${rawId}`);
+      console.log(`Messages: ${data.messages.length}`);
+      console.log(`Distillations: ${data.distillations.length}`);
+      if (data.messages.length) {
+        console.log(`\n--- Messages (${data.messages.length}) ---\n`);
+        for (const msg of data.messages) {
+          const prefix = msg.role === "user" ? ">" : "<";
+          console.log(`${prefix} [${formatDate(msg.created_at)}] ${msg.role}: ${truncate(msg.content, 120)}`);
+        }
+      }
+      if (data.distillations.length) {
+        console.log(`\n--- Distillations (${data.distillations.length}) ---\n`);
+        for (const d of data.distillations) {
+          console.log(`  gen=${d.generation} tokens=${d.token_count} ${formatDate(d.created_at)} ${d.id.slice(0, 8)}`);
+        }
+      }
+      break;
+    }
+
+    case "distillation": {
+      const dist = await remoteGet<{
+        id: string; session_id: string; project_id: string; generation: number;
+        token_count: number; r_compression: number | null; c_norm: number | null;
+        archived: number; created_at: number; source_ids: string; observations: string;
+      }>(remote, `/api/v1/distillations/${encodeURIComponent(rawId)}`);
+      if (asJson) { console.log(JSON.stringify(dist, null, 2)); return; }
+      console.log(`ID:            ${dist.id}`);
+      console.log(`Session:       ${dist.session_id}`);
+      console.log(`Project ID:    ${dist.project_id}`);
+      console.log(`Generation:    ${dist.generation}`);
+      console.log(`Tokens:        ${dist.token_count}`);
+      console.log(`R_compression: ${dist.r_compression?.toFixed(3) ?? "-"}`);
+      console.log(`C_norm:        ${dist.c_norm?.toFixed(3) ?? "-"}`);
+      console.log(`Archived:      ${dist.archived ? "yes" : "no"}`);
+      console.log(`Created:       ${formatDate(dist.created_at)}`);
+      console.log(`Source IDs:    ${dist.source_ids}`);
+      console.log(`\nObservations:\n${dist.observations}`);
+      break;
+    }
+
+    default:
+      console.error(`Unknown type "${type ?? "(none)"}". Use: knowledge, session, distillation`);
+      process.exit(1);
+  }
+}
+
+async function cmdClearRemote(
+  remote: string,
+  projectPath: string,
+  flags: Record<string, unknown>,
+): Promise<void> {
+  const skipConfirm = !!flags.yes;
+  const projectId = await resolveRemoteProject(remote, projectPath);
+  if (!projectId) { console.error(`No project found for: ${projectPath}`); process.exit(1); }
+
+  const body: Record<string, boolean> = {};
+  if (flags.knowledge) body.knowledge = true;
+  if (flags.temporal) body.temporal = true;
+  if (flags.distillations) body.distillations = true;
+
+  const hasFlags = body.knowledge || body.temporal || body.distillations;
+  const label = hasFlags
+    ? `selected data (${Object.keys(body).join(", ")})`
+    : "ALL data";
+
+  if (!skipConfirm) {
+    const confirmed = await confirm(`\nClear ${label} for project at:\n  ${projectPath}\n`);
+    if (!confirmed) { console.log("Cancelled."); return; }
+  }
+
+  const result = await remotePost<Record<string, number>>(remote, `/api/v1/projects/${projectId}/clear`, body);
+  const parts = Object.entries(result).map(([k, v]) => `${v} ${k.replace("_", " ")}`);
+  console.log(`Cleared: ${parts.join(", ")}.`);
+}
+
+async function cmdDeleteRemote(
+  remote: string,
+  args: string[],
+  flags: Record<string, unknown>,
+): Promise<void> {
+  const type = args[0];
+  const rawId = args[1];
+  const skipConfirm = !!flags.yes;
+  const projectPath = resolve((flags.project as string) ?? process.cwd());
+
+  if (!rawId) { console.error("Error: Missing <id> argument."); process.exit(1); }
+
+  switch (type) {
+    case "knowledge": {
+      if (!skipConfirm) {
+        const confirmed = await confirm(`\nDelete knowledge entry ${rawId}?`);
+        if (!confirmed) { console.log("Cancelled."); return; }
+      }
+      await remoteDelete(remote, `/api/v1/knowledge/${encodeURIComponent(rawId)}`);
+      console.log(`Deleted knowledge entry: ${rawId}`);
+      break;
+    }
+
+    case "session": {
+      if (!skipConfirm) {
+        const confirmed = await confirm(`\nDelete all messages and distillations for session ${rawId}?`);
+        if (!confirmed) { console.log("Cancelled."); return; }
+      }
+      const pq = projectQueryParams(projectPath);
+      const result = await remoteDelete<{ messages_deleted: number; distillations_deleted: number }>(
+        remote, `/api/v1/sessions/${encodeURIComponent(rawId)}?${pq}`,
+      );
+      console.log(`Deleted: ${result.messages_deleted} messages, ${result.distillations_deleted} distillations.`);
+      break;
+    }
+
+    case "distillation": {
+      if (!skipConfirm) {
+        const confirmed = await confirm(`\nDelete distillation ${rawId}?`);
+        if (!confirmed) { console.log("Cancelled."); return; }
+      }
+      await remoteDelete(remote, `/api/v1/distillations/${encodeURIComponent(rawId)}`);
+      console.log(`Deleted distillation: ${rawId}`);
+      break;
+    }
+
+    case "project": {
+      // Resolve project: rawId can be UUID or path
+      let projectId = rawId;
+      if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(rawId)) {
+        const resolved = await resolveRemoteProject(remote, resolve(rawId));
+        if (!resolved) { console.error(`No project found for path: ${rawId}`); process.exit(1); }
+        projectId = resolved;
+      }
+      if (!skipConfirm) {
+        const confirmed = await confirm(`\nDelete project ${projectId.slice(0, 12)}... and ALL its data?`);
+        if (!confirmed) { console.log("Cancelled."); return; }
+      }
+      const result = await remoteDelete<{
+        knowledge_deleted: number; temporal_deleted: number;
+        distillations_deleted: number; sessions_cleared: number;
+      }>(remote, `/api/v1/projects/${encodeURIComponent(projectId)}`);
+      console.log(
+        `Deleted project: ${result.knowledge_deleted} knowledge, ` +
+          `${result.temporal_deleted} messages, ` +
+          `${result.distillations_deleted} distillations, ` +
+          `${result.sessions_cleared} sessions.`,
+      );
+      break;
+    }
+
+    default:
+      console.error(`Unknown type "${type ?? "(none)"}". Use: knowledge, session, distillation, project`);
+      process.exit(1);
+  }
+}
+
+async function cmdMergeRemote(
+  remote: string,
+  flags: Record<string, unknown>,
+): Promise<void> {
+  const skipConfirm = !!flags.yes;
+  const asJson = !!flags.json;
+
+  if (!skipConfirm) {
+    const confirmed = await confirm(
+      `This will scan git remotes and merge duplicate projects on the remote gateway.`,
+    );
+    if (!confirmed) { console.log("Cancelled."); return; }
+  }
+
+  const result = await remotePost<{
+    updated: number; merged: number; namesBackfilled: number;
+    mergeDetails: Array<{ sourcePath: string; targetPath: string; gitRemote: string; result: Record<string, number> }>;
+  }>(remote, "/api/v1/projects/merge");
+
+  if (asJson) { console.log(JSON.stringify(result, null, 2)); return; }
+
+  console.log(`\nResults:`);
+  console.log(`  Updated: ${result.updated} project(s) with git remote info`);
+  console.log(`  Merged:  ${result.merged} duplicate project(s)`);
+  console.log(`  Renamed: ${result.namesBackfilled} project(s) with repo name`);
+
+  if (result.mergeDetails?.length) {
+    console.log(`\nMerge details:`);
+    for (const detail of result.mergeDetails) {
+      console.log(`  ${detail.sourcePath}`);
+      console.log(`    → merged into: ${detail.targetPath}`);
+      console.log(`    git remote:    ${detail.gitRemote}`);
+    }
+  }
+}
+
+async function cmdDedupRemote(
+  remote: string,
+  flags: Record<string, unknown>,
+): Promise<void> {
+  const asJson = !!flags.json;
+  const interactive = !!flags.interactive;
+  const explicitProject = typeof flags.project === "string" ? resolve(flags.project) : null;
+
+  if (interactive) {
+    console.error("Error: --interactive mode is not supported in remote mode. Use --yes for non-interactive.");
+    process.exit(1);
+  }
+
+  let projectId: string | undefined;
+  if (explicitProject) {
+    projectId = await resolveRemoteProject(remote, explicitProject) ?? undefined;
+    if (!projectId) { console.error(`No project found for: ${explicitProject}`); process.exit(1); }
+  }
+
+  console.log("Scanning for duplicate knowledge entries (dry run, remote)...\n");
+
+  const endpoint = projectId
+    ? `/api/v1/projects/${projectId}/dedup`
+    : `/api/v1/projects/_/dedup`; // placeholder — we need a project ID
+  // For remote dedup, use a specific project or list projects and pick first
+  if (!projectId) {
+    const projects = await remoteGet<Array<{ id: string; name: string | null }>>(remote, "/api/v1/projects");
+    if (!projects.length) { console.log("No projects found."); return; }
+    // Dedup each project
+    for (const p of projects) {
+      const result = await remotePost(remote, `/api/v1/projects/${p.id}/dedup`);
+      if (asJson) { console.log(JSON.stringify({ project: p.name ?? p.id, ...result as object }, null, 2)); }
+      else { console.log(`[${p.name ?? p.id}] ${JSON.stringify(result)}`); }
+    }
+  } else {
+    const result = await remotePost(remote, `/api/v1/projects/${projectId}/dedup`);
+    if (asJson) { console.log(JSON.stringify(result, null, 2)); }
+    else { console.log(JSON.stringify(result, null, 2)); }
+  }
+
+  console.log("\nNote: Remote dedup is always a dry run. Apply changes locally or via the gateway.");
+}
+
+async function cmdReindexRemote(
+  remote: string,
+  flags: Record<string, unknown>,
+): Promise<void> {
+  const projectPath = resolve((flags.project as string) ?? process.cwd());
+  const projectId = await resolveRemoteProject(remote, projectPath);
+  if (!projectId) { console.error(`No project found for: ${projectPath}`); process.exit(1); }
+
+  console.log("Re-indexing embeddings on remote gateway...");
+  const result = await remotePost<{
+    knowledge_embedded: number; distillations_embedded: number;
+  }>(remote, `/api/v1/projects/${projectId}/reindex`);
+
+  const total = result.knowledge_embedded + result.distillations_embedded;
+  console.log(`  ${result.knowledge_embedded} knowledge entries embedded`);
+  console.log(`  ${result.distillations_embedded} distillations embedded`);
+  if (total === 0) {
+    console.log("\nAll embeddings are up to date.");
+  } else {
+    console.log(`\nDone — ${total} entries re-indexed.`);
+  }
+}
+
+/**
+ * Resolve a local project path to a remote project UUID.
+ * Lists projects from the remote and matches by git_remote (preferred) or path.
+ */
+async function resolveRemoteProject(
+  remote: string,
+  projectPath: string,
+): Promise<string | null> {
+  const { getGitRemote, normalizeRemoteUrl } = await import("@loreai/core");
+  const gitRemote = getGitRemote(projectPath);
+  const normalizedRemote = gitRemote ? normalizeRemoteUrl(gitRemote) : null;
+
+  const projects = await remoteGet<Array<{
+    id: string; path: string; git_remote: string | null;
+  }>>(remote, "/api/v1/projects");
+
+  // Prefer git_remote match
+  if (normalizedRemote) {
+    for (const p of projects) {
+      if (p.git_remote && normalizeRemoteUrl(p.git_remote) === normalizedRemote) {
+        return p.id;
+      }
+    }
+  }
+
+  // Fallback: exact path match
+  for (const p of projects) {
+    if (p.path === projectPath) return p.id;
+  }
+
+  return null;
 }
 
 // Main dispatch
@@ -1162,7 +1643,7 @@ export async function commandData(
       await cmdDedup(subArgs, values);
       break;
     case "reindex":
-      await cmdReindex();
+      await cmdReindex(values);
       break;
     case "help":
     case undefined:

--- a/packages/gateway/src/cli/data.ts
+++ b/packages/gateway/src/cli/data.ts
@@ -1158,14 +1158,11 @@ async function cmdListRemote(
     }
 
     case "knowledge": {
-      // Find project ID first
-      const projects = await remoteGet<Array<{ id: string }>>(remote, "/api/v1/projects");
-      const pq = projectQueryParams(projectPath);
-      // Use first project matching, or list all if none match
-      let entries: Array<{ id: string; category: string; title: string; confidence: number; updated_at: number }>;
       const matchingProject = await resolveRemoteProject(remote, projectPath);
       if (!matchingProject) { console.error(`No project found for: ${projectPath}`); process.exit(1); }
-      entries = await remoteGet(remote, `/api/v1/projects/${matchingProject}/knowledge`);
+      const entries = await remoteGet<Array<{ id: string; category: string; title: string; confidence: number; updated_at: number }>>(
+        remote, `/api/v1/projects/${matchingProject}/knowledge`,
+      );
       const limited = entries.slice(0, limit);
       if (asJson) { console.log(JSON.stringify(limited, null, 2)); return; }
       if (!limited.length) { console.log("No knowledge entries found for this project."); return; }
@@ -1482,10 +1479,6 @@ async function cmdDedupRemote(
 
   console.log("Scanning for duplicate knowledge entries (dry run, remote)...\n");
 
-  const endpoint = projectId
-    ? `/api/v1/projects/${projectId}/dedup`
-    : `/api/v1/projects/_/dedup`; // placeholder — we need a project ID
-  // For remote dedup, use a specific project or list projects and pick first
   if (!projectId) {
     const projects = await remoteGet<Array<{ id: string; name: string | null }>>(remote, "/api/v1/projects");
     if (!projects.length) { console.log("No projects found."); return; }
@@ -1508,14 +1501,10 @@ async function cmdReindexRemote(
   remote: string,
   flags: Record<string, unknown>,
 ): Promise<void> {
-  const projectPath = resolve((flags.project as string) ?? process.cwd());
-  const projectId = await resolveRemoteProject(remote, projectPath);
-  if (!projectId) { console.error(`No project found for: ${projectPath}`); process.exit(1); }
-
   console.log("Re-indexing embeddings on remote gateway...");
   const result = await remotePost<{
     knowledge_embedded: number; distillations_embedded: number;
-  }>(remote, `/api/v1/projects/${projectId}/reindex`);
+  }>(remote, "/api/v1/reindex");
 
   const total = result.knowledge_embedded + result.distillations_embedded;
   console.log(`  ${result.knowledge_embedded} knowledge entries embedded`);

--- a/packages/gateway/src/cli/import.ts
+++ b/packages/gateway/src/cli/import.ts
@@ -335,6 +335,17 @@ async function importRemote(
     totalFailed += extractResult.chunksFailed;
   }
 
+  // Record import timestamp locally (prevents auto-import re-prompting on `lore run`)
+  setLastImportAt(projectPath, Date.now());
+
+  // Export .lore.md locally so knowledge appears in the local file
+  try {
+    const { exportLoreFile } = await import("@loreai/core");
+    exportLoreFile(projectPath);
+  } catch {
+    // Non-fatal
+  }
+
   // Summary
   console.log(
     `\n[lore] Import complete: ${totalCreated} entries created, ${totalUpdated} updated` +

--- a/packages/gateway/src/cli/import.ts
+++ b/packages/gateway/src/cli/import.ts
@@ -3,6 +3,10 @@
  *
  * Scans for conversation history from Claude Code, OpenCode, and Aider,
  * then extracts knowledge entries via the curator LLM.
+ *
+ * When `LORE_REMOTE_URL` is set, detection and chunk reading happen locally
+ * (they require filesystem access), but extraction is delegated to the remote
+ * gateway via the REST API. No local gateway startup is needed.
  */
 import { createInterface } from "node:readline";
 import { resolve } from "path";
@@ -19,6 +23,12 @@ import { resolveAuth } from "../auth";
 import { exportLoreFile } from "@loreai/core";
 import { startGateway, type StartOptions } from "./start";
 import { safeExit } from "./exit";
+import {
+  getRemoteUrl,
+  projectQueryParams,
+  remoteGet,
+  remotePost,
+} from "./remote";
 
 const {
   detectAll,
@@ -148,6 +158,13 @@ export async function commandImport(
     }
   }
 
+  // Check for remote mode
+  const remote = getRemoteUrl();
+  if (remote) {
+    await importRemote(remote, projectPath, results);
+    return;
+  }
+
   // Start gateway for LLM access
   console.log("\n[lore] Starting gateway for LLM access...");
 
@@ -242,4 +259,88 @@ export async function commandImport(
   } finally {
     if (owned) await shutdown();
   }
+}
+
+// ---------------------------------------------------------------------------
+// Remote import — detection + chunk reading local, extraction via gateway API
+// ---------------------------------------------------------------------------
+
+async function importRemote(
+  remote: string,
+  projectPath: string,
+  results: ReturnType<typeof detectAll>,
+): Promise<void> {
+  const { getGitRemote, normalizeRemoteUrl } = await import("@loreai/core");
+  const gitRemote = getGitRemote(projectPath);
+  const normalized = gitRemote ? normalizeRemoteUrl(gitRemote) : undefined;
+
+  console.log(`\n[lore] Using remote gateway at ${remote}`);
+
+  let totalCreated = 0;
+  let totalUpdated = 0;
+  let totalDeleted = 0;
+  let totalChunks = 0;
+  let totalFailed = 0;
+
+  for (const result of results) {
+    const provider = getProvider(result.agentName);
+    if (!provider) continue;
+
+    const sessionIds = result.sessions.map((s) => s.id);
+    console.log(`[lore] Reading ${result.agentDisplayName} conversations...`);
+
+    const chunks = provider.readChunks(projectPath, sessionIds);
+    if (chunks.length === 0) {
+      console.log(`[lore] No extractable content from ${result.agentDisplayName}.`);
+      continue;
+    }
+
+    console.log(`[lore] Extracting knowledge from ${chunks.length} chunks via remote gateway (${result.agentDisplayName})...`);
+
+    // Send chunks to remote gateway for extraction (zstd-compressed)
+    const extractResult = await remotePost<{
+      created: number; updated: number; deleted: number;
+      chunksProcessed: number; chunksFailed: number;
+    }>(remote, "/api/v1/import/extract", {
+      git_remote: normalized,
+      path: projectPath,
+      chunks: chunks.map((c) => ({
+        label: c.label,
+        text: c.text,
+        estimatedTokens: c.estimatedTokens,
+        timestamp: c.timestamp,
+      })),
+    }, { compress: true });
+
+    // Record imports remotely for each session
+    for (const sess of result.sessions) {
+      const hash = computeHash({
+        messageCount: sess.messageCount,
+        lastTimestamp: sess.lastActivityAt,
+      });
+      await remotePost(remote, "/api/v1/import/record", {
+        git_remote: normalized,
+        path: projectPath,
+        agent_name: result.agentName,
+        source_id: sess.id,
+        source_hash: hash,
+        stats: { created: extractResult.created, updated: extractResult.updated },
+      });
+    }
+
+    totalCreated += extractResult.created;
+    totalUpdated += extractResult.updated;
+    totalDeleted += extractResult.deleted;
+    totalChunks += extractResult.chunksProcessed;
+    totalFailed += extractResult.chunksFailed;
+  }
+
+  // Summary
+  console.log(
+    `\n[lore] Import complete: ${totalCreated} entries created, ${totalUpdated} updated` +
+      (totalDeleted ? `, ${totalDeleted} deleted` : "") +
+      (totalFailed ? ` (${totalFailed} chunks failed)` : "") +
+      ".",
+  );
+  console.log("[lore] Run `lore data list knowledge` to review.");
 }

--- a/packages/gateway/src/cli/recall-cmd.ts
+++ b/packages/gateway/src/cli/recall-cmd.ts
@@ -5,10 +5,18 @@
  * gateway — directly queries the SQLite database. No LLM client is available,
  * so query expansion is disabled.
  *
+ * When `LORE_REMOTE_URL` is set, delegates to the remote gateway REST API,
+ * which has an LLM client and can run query expansion for better results.
+ *
  * Usage:
  *   lore recall "query string" [--project <path>] [--scope <scope>] [--limit <n>] [--json]
  */
 import { resolve } from "path";
+import {
+  getRemoteUrl,
+  projectQueryParams,
+  remoteGet,
+} from "./remote";
 
 export async function commandRecall(
   positionals: string[],
@@ -28,10 +36,8 @@ Options:
     process.exit(1);
   }
 
-  const { runRecall, config } = await import("@loreai/core");
-
   const projectPath = resolve((values.project as string) ?? process.cwd());
-  const scope = (values.scope as string as "all" | "session" | "project" | "knowledge") ?? "all";
+  const scope = (values.scope as string) ?? "all";
   const sessionID = values.session as string | undefined;
   const limit = values.limit ? Number(values.limit) : 10;
   const asJson = !!values.json;
@@ -40,6 +46,33 @@ Options:
     console.error("Error: --session <id> is required when --scope session is used.");
     process.exit(1);
   }
+
+  // Remote mode: delegate to gateway REST API (gets query expansion for free)
+  const remote = getRemoteUrl();
+  if (remote) {
+    try {
+      const pq = projectQueryParams(projectPath);
+      let apiPath = `/api/v1/recall?q=${encodeURIComponent(query)}&${pq}&scope=${scope}&limit=${limit}`;
+      if (sessionID) apiPath += `&session=${encodeURIComponent(sessionID)}`;
+
+      const data = await remoteGet<{ query: string; scope: string; projectPath: string; result: string }>(
+        remote, apiPath,
+      );
+
+      if (asJson) {
+        console.log(JSON.stringify(data, null, 2));
+      } else {
+        console.log(data.result);
+      }
+    } catch (err) {
+      console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+      process.exit(1);
+    }
+    return;
+  }
+
+  // Local mode: query DB directly (no LLM, no query expansion)
+  const { runRecall, config } = await import("@loreai/core");
 
   const searchConfig = {
     ...config().search,
@@ -50,7 +83,7 @@ Options:
   try {
     const result = await runRecall({
       query,
-      scope,
+      scope: scope as "all" | "session" | "project" | "knowledge",
       projectPath,
       sessionID,
       searchConfig,

--- a/packages/gateway/src/cli/remote.ts
+++ b/packages/gateway/src/cli/remote.ts
@@ -1,0 +1,114 @@
+/**
+ * CLI remote helper — shared utilities for CLI commands that need to call
+ * the remote gateway REST API when `LORE_REMOTE_URL` is set.
+ */
+
+import { getGitRemote, normalizeRemoteUrl } from "@loreai/core";
+
+// ---------------------------------------------------------------------------
+// Remote URL detection
+// ---------------------------------------------------------------------------
+
+/** Returns `LORE_REMOTE_URL` if set, undefined otherwise. */
+export function getRemoteUrl(): string | undefined {
+  const url = process.env.LORE_REMOTE_URL;
+  return url ? url.replace(/\/+$/, "") : undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Project resolution for remote calls
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a local project path to query params for the remote API.
+ * Computes `git_remote` locally (trusted FS) and prefers it over `path`.
+ *
+ * @returns Query string fragment like `git_remote=...` or `path=...`
+ */
+export function projectQueryParams(projectPath: string): string {
+  const remote = getGitRemote(projectPath);
+  if (remote) {
+    const normalized = normalizeRemoteUrl(remote);
+    return `git_remote=${encodeURIComponent(normalized ?? remote)}`;
+  }
+  return `path=${encodeURIComponent(projectPath)}`;
+}
+
+// ---------------------------------------------------------------------------
+// HTTP client
+// ---------------------------------------------------------------------------
+
+class RemoteAPIError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly type: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "RemoteAPIError";
+  }
+}
+
+async function handleResponse<T>(res: Response): Promise<T> {
+  const body = await res.json();
+  if (!res.ok) {
+    const err = body?.error ?? {};
+    throw new RemoteAPIError(
+      res.status,
+      err.type ?? "api_error",
+      err.message ?? `HTTP ${res.status}`,
+    );
+  }
+  return body as T;
+}
+
+/** GET request to remote gateway API. */
+export async function remoteGet<T = unknown>(
+  baseUrl: string,
+  path: string,
+): Promise<T> {
+  const res = await fetch(`${baseUrl}${path}`);
+  return handleResponse<T>(res);
+}
+
+/**
+ * POST request to remote gateway API.
+ * When `compress: true`, applies zstd compression and sets `Content-Encoding: zstd`.
+ */
+export async function remotePost<T = unknown>(
+  baseUrl: string,
+  path: string,
+  body?: unknown,
+  opts?: { compress?: boolean },
+): Promise<T> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+
+  let payload: BodyInit | undefined;
+  if (body !== undefined) {
+    const json = JSON.stringify(body);
+    if (opts?.compress) {
+      headers["Content-Encoding"] = "zstd";
+      payload = new Uint8Array(Bun.zstdCompressSync(Buffer.from(json)));
+    } else {
+      payload = json;
+    }
+  }
+
+  const res = await fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers,
+    body: payload,
+  });
+  return handleResponse<T>(res);
+}
+
+/** DELETE request to remote gateway API. */
+export async function remoteDelete<T = unknown>(
+  baseUrl: string,
+  path: string,
+): Promise<T> {
+  const res = await fetch(`${baseUrl}${path}`, { method: "DELETE" });
+  return handleResponse<T>(res);
+}

--- a/packages/gateway/src/cli/remote.ts
+++ b/packages/gateway/src/cli/remote.ts
@@ -50,13 +50,28 @@ class RemoteAPIError extends Error {
 }
 
 async function handleResponse<T>(res: Response): Promise<T> {
-  const body = await res.json();
+  let body: unknown;
+  const contentType = res.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    body = await res.json();
+  } else {
+    const text = await res.text();
+    if (!res.ok) {
+      throw new RemoteAPIError(res.status, "gateway_error", `HTTP ${res.status}: ${text.slice(0, 200)}`);
+    }
+    // Try JSON parse as fallback (some servers omit content-type)
+    try {
+      body = JSON.parse(text);
+    } catch {
+      throw new RemoteAPIError(res.status, "gateway_error", `Unexpected non-JSON response: ${text.slice(0, 200)}`);
+    }
+  }
   if (!res.ok) {
-    const err = body?.error ?? {};
+    const err = (body as Record<string, unknown>)?.error as Record<string, string> | undefined;
     throw new RemoteAPIError(
       res.status,
-      err.type ?? "api_error",
-      err.message ?? `HTTP ${res.status}`,
+      err?.type ?? "api_error",
+      err?.message ?? `HTTP ${res.status}`,
     );
   }
   return body as T;

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -321,6 +321,12 @@ export function startServer(config: GatewayConfig): {
         return handleHealth();
       }
 
+      // GET/POST/DELETE /api/* — REST API (lazy-imported to keep proxy hot path fast)
+      if (pathname.startsWith("/api/")) {
+        const { handleAPIRequest } = await import("./api");
+        return withCors(await handleAPIRequest(req, url, config));
+      }
+
       // GET/POST /ui/* — Web dashboard (lazy-imported to keep proxy hot path fast)
       if (pathname === "/ui" || pathname.startsWith("/ui/")) {
         const { handleUIRequest } = await import("./ui");

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -42,7 +42,7 @@ try {
 
 const CORS_HEADERS: Record<string, string> = {
   "access-control-allow-origin": "*",
-  "access-control-allow-methods": "GET, POST, OPTIONS",
+  "access-control-allow-methods": "GET, POST, DELETE, OPTIONS",
   "access-control-allow-headers": "*",
   "access-control-max-age": "86400",
 };

--- a/packages/gateway/test/api.test.ts
+++ b/packages/gateway/test/api.test.ts
@@ -13,7 +13,7 @@ import { unlinkSync, existsSync } from "node:fs";
 
 let baseURL: string;
 let dbPath: string;
-let server: ReturnType<typeof import("../src/server").startServer> extends Promise<infer T> ? T : never;
+let server: { stop: () => void; port: number; hosts: string[] };
 let closeDB: () => void;
 let resetPipelineState: () => Promise<void>;
 

--- a/packages/gateway/test/api.test.ts
+++ b/packages/gateway/test/api.test.ts
@@ -1,0 +1,405 @@
+/**
+ * Tests for the REST API endpoints in `/api/v1/`.
+ *
+ * Uses a real gateway server on an ephemeral port with an isolated temp DB.
+ * No upstream interceptor needed — these endpoints don't call LLM APIs.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { unlinkSync, existsSync } from "node:fs";
+
+// ---------------------------------------------------------------------------
+// Test-scoped server setup
+// ---------------------------------------------------------------------------
+
+let baseURL: string;
+let dbPath: string;
+let server: ReturnType<typeof import("../src/server").startServer> extends Promise<infer T> ? T : never;
+let closeDB: () => void;
+let resetPipelineState: () => Promise<void>;
+
+beforeAll(async () => {
+  dbPath = `/tmp/lore-api-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`;
+  process.env.LORE_DB_PATH = dbPath;
+
+  const port = 20000 + Math.floor(Math.random() * 30000);
+  process.env.LORE_LISTEN_PORT = String(port);
+  process.env.LORE_DEBUG = "false";
+
+  const { startServer } = await import("../src/server");
+  const { loadConfig } = await import("../src/config");
+  const { resetPipelineState: reset } = await import("../src/pipeline");
+  const { close } = await import("@loreai/core");
+
+  closeDB = close;
+  resetPipelineState = reset;
+
+  closeDB();
+  await resetPipelineState();
+
+  const config = loadConfig();
+  server = startServer(config);
+  baseURL = `http://127.0.0.1:${server.port}`;
+});
+
+afterAll(async () => {
+  if (server) server.stop();
+  if (closeDB) closeDB();
+  if (resetPipelineState) await resetPipelineState();
+
+  for (const suffix of ["", "-shm", "-wal"]) {
+    const file = `${dbPath}${suffix}`;
+    try {
+      if (existsSync(file)) unlinkSync(file);
+    } catch { /* best-effort */ }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function api(path: string, init?: RequestInit): Promise<Response> {
+  return fetch(`${baseURL}${path}`, init);
+}
+
+async function apiJSON<T = unknown>(path: string, init?: RequestInit): Promise<T> {
+  const res = await api(path, init);
+  return res.json() as Promise<T>;
+}
+
+/** Create a project + knowledge entry directly via core APIs for test setup. */
+async function seedProject() {
+  const { ensureProject } = await import("@loreai/core");
+  const { ltm } = await import("@loreai/core");
+
+  const projectPath = `/test/api/${Date.now()}`;
+  const projectId = ensureProject(projectPath, "test-project", "git@github.com:test/repo.git");
+
+  const knowledgeId = ltm.create({
+    projectPath,
+    category: "decision",
+    title: "Test Decision",
+    content: "We decided to use REST for the API",
+    session: "test-session",
+    scope: "project",
+  });
+
+  return { projectPath, projectId, knowledgeId };
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Data read endpoints
+// ---------------------------------------------------------------------------
+
+describe("GET /api/v1/projects", () => {
+  it("returns empty array when no projects", async () => {
+    const data = await apiJSON<unknown[]>("/api/v1/projects");
+    expect(Array.isArray(data)).toBe(true);
+  });
+
+  it("returns projects after seeding", async () => {
+    const { projectId } = await seedProject();
+    const projects = await apiJSON<Array<{ id: string; name: string | null }>>(
+      "/api/v1/projects",
+    );
+    expect(projects.length).toBeGreaterThanOrEqual(1);
+    const found = projects.find((p) => p.id === projectId);
+    expect(found).toBeDefined();
+    expect(found!.name).toBe("test-project");
+  });
+});
+
+describe("GET /api/v1/stats", () => {
+  it("returns global stats", async () => {
+    const stats = await apiJSON<{ project_count: number; knowledge_count: number }>(
+      "/api/v1/stats",
+    );
+    expect(stats.project_count).toBeGreaterThanOrEqual(0);
+    expect(typeof stats.knowledge_count).toBe("number");
+  });
+});
+
+describe("GET /api/v1/projects/:id/knowledge", () => {
+  it("returns knowledge entries for a project", async () => {
+    const { projectId } = await seedProject();
+    const entries = await apiJSON<Array<{ id: string; title: string }>>(
+      `/api/v1/projects/${projectId}/knowledge`,
+    );
+    expect(entries.length).toBeGreaterThanOrEqual(1);
+    expect(entries[0].title).toBe("Test Decision");
+  });
+
+  it("returns 404 for unknown project", async () => {
+    const res = await api("/api/v1/projects/00000000-0000-0000-0000-000000000000/knowledge");
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("GET /api/v1/projects/:id/sessions", () => {
+  it("returns sessions for a project (may be empty)", async () => {
+    const { projectId } = await seedProject();
+    const sessions = await apiJSON<unknown[]>(
+      `/api/v1/projects/${projectId}/sessions`,
+    );
+    expect(Array.isArray(sessions)).toBe(true);
+  });
+});
+
+describe("GET /api/v1/projects/:id/distillations", () => {
+  it("returns distillations for a project (may be empty)", async () => {
+    const { projectId } = await seedProject();
+    const dists = await apiJSON<unknown[]>(
+      `/api/v1/projects/${projectId}/distillations`,
+    );
+    expect(Array.isArray(dists)).toBe(true);
+  });
+});
+
+describe("GET /api/v1/knowledge/:id", () => {
+  it("returns a knowledge entry by ID", async () => {
+    const { knowledgeId } = await seedProject();
+    const entry = await apiJSON<{ id: string; title: string; content: string }>(
+      `/api/v1/knowledge/${knowledgeId}`,
+    );
+    expect(entry.id).toBe(knowledgeId);
+    expect(entry.title).toBe("Test Decision");
+    expect(entry.content).toBe("We decided to use REST for the API");
+  });
+
+  it("returns 404 for unknown knowledge ID", async () => {
+    const res = await api("/api/v1/knowledge/00000000-0000-0000-0000-000000000000");
+    expect(res.status).toBe(404);
+  });
+
+  it("supports prefix resolution", async () => {
+    const { knowledgeId } = await seedProject();
+    const prefix = knowledgeId.slice(0, 8);
+    const entry = await apiJSON<{ id: string }>(
+      `/api/v1/knowledge/${prefix}`,
+    );
+    expect(entry.id).toBe(knowledgeId);
+  });
+});
+
+describe("GET /api/v1/distillations/:id", () => {
+  it("returns 404 for unknown distillation ID", async () => {
+    const res = await api("/api/v1/distillations/00000000-0000-0000-0000-000000000000");
+    expect(res.status).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Data mutation endpoints
+// ---------------------------------------------------------------------------
+
+describe("DELETE /api/v1/knowledge/:id", () => {
+  it("deletes a knowledge entry", async () => {
+    const { knowledgeId } = await seedProject();
+
+    const res = await api(`/api/v1/knowledge/${knowledgeId}`, { method: "DELETE" });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { deleted: boolean };
+    expect(body.deleted).toBe(true);
+
+    // Verify it's gone
+    const check = await api(`/api/v1/knowledge/${knowledgeId}`);
+    expect(check.status).toBe(404);
+  });
+
+  it("returns 404 for unknown knowledge ID", async () => {
+    const res = await api("/api/v1/knowledge/00000000-0000-0000-0000-000000000000", { method: "DELETE" });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("DELETE /api/v1/projects/:id", () => {
+  it("deletes a project and all its data", async () => {
+    const { projectId } = await seedProject();
+
+    const res = await api(`/api/v1/projects/${projectId}`, { method: "DELETE" });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { knowledge_deleted: number };
+    expect(body.knowledge_deleted).toBeGreaterThanOrEqual(1);
+
+    // Verify project is gone
+    const check = await api(`/api/v1/projects/${projectId}/knowledge`);
+    expect(check.status).toBe(404);
+  });
+});
+
+describe("POST /api/v1/projects/:id/clear", () => {
+  it("clears all data for a project", async () => {
+    const { projectId } = await seedProject();
+
+    const res = await api(`/api/v1/projects/${projectId}/clear`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { knowledge_deleted: number };
+    expect(body.knowledge_deleted).toBeGreaterThanOrEqual(1);
+  });
+
+  it("clears only knowledge when flag is set", async () => {
+    const { projectId } = await seedProject();
+
+    const res = await api(`/api/v1/projects/${projectId}/clear`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ knowledge: true }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { knowledge_deleted: number };
+    expect(body.knowledge_deleted).toBeGreaterThanOrEqual(1);
+    // temporal_deleted should not be in response since we only asked for knowledge
+    expect(body).not.toHaveProperty("temporal_deleted");
+  });
+});
+
+describe("POST /api/v1/projects/merge", () => {
+  it("succeeds (may be a no-op)", async () => {
+    const res = await api("/api/v1/projects/merge", { method: "POST" });
+    expect(res.status).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Zstd compression
+// ---------------------------------------------------------------------------
+
+describe("Zstd request body decompression", () => {
+  it("handles zstd-compressed POST body", async () => {
+    const { projectId } = await seedProject();
+    const body = JSON.stringify({ knowledge: true });
+    const compressed = Bun.zstdCompressSync(Buffer.from(body));
+
+    const res = await api(`/api/v1/projects/${projectId}/clear`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Content-Encoding": "zstd",
+      },
+      body: new Uint8Array(compressed),
+    });
+    expect(res.status).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Project resolution via query params
+// ---------------------------------------------------------------------------
+
+describe("Project resolution", () => {
+  it("resolves project by git_remote query param", async () => {
+    const { projectId } = await seedProject();
+    // The seedProject uses git_remote "git@github.com:test/repo.git"
+    const entries = await apiJSON<Array<{ id: string }>>(
+      `/api/v1/projects/${projectId}/knowledge`,
+    );
+    expect(entries.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Error handling
+// ---------------------------------------------------------------------------
+
+describe("Error handling", () => {
+  it("returns 404 for unknown API routes", async () => {
+    const res = await api("/api/v1/nonexistent");
+    expect(res.status).toBe(404);
+    const body = await res.json() as { type: string };
+    expect(body.type).toBe("error");
+  });
+
+  it("returns 404 for DELETE on unknown routes", async () => {
+    const res = await api("/api/v1/nonexistent", { method: "DELETE" });
+    expect(res.status).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Recall endpoint
+// ---------------------------------------------------------------------------
+
+describe("GET /api/v1/recall", () => {
+  it("returns 400 when query is missing", async () => {
+    const res = await api("/api/v1/recall");
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when project is not identified", async () => {
+    const res = await api("/api/v1/recall?q=test");
+    expect(res.status).toBe(400);
+  });
+
+  it("returns results for a valid query", async () => {
+    const { projectPath } = await seedProject();
+    const pq = `path=${encodeURIComponent(projectPath)}`;
+    const data = await apiJSON<{ query: string; result: string }>(
+      `/api/v1/recall?q=REST+API&${pq}`,
+    );
+    expect(data.query).toBe("REST API");
+    expect(typeof data.result).toBe("string");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Import endpoints
+// ---------------------------------------------------------------------------
+
+describe("GET /api/v1/import/history", () => {
+  it("returns 400 when project is not identified", async () => {
+    const res = await api("/api/v1/import/history");
+    expect(res.status).toBe(400);
+  });
+
+  it("returns empty array for project with no imports", async () => {
+    const { projectPath } = await seedProject();
+    const pq = `path=${encodeURIComponent(projectPath)}`;
+    const records = await apiJSON<unknown[]>(
+      `/api/v1/import/history?${pq}`,
+    );
+    expect(Array.isArray(records)).toBe(true);
+    expect(records.length).toBe(0);
+  });
+});
+
+describe("POST /api/v1/import/record", () => {
+  it("records an import", async () => {
+    const { projectPath } = await seedProject();
+    const res = await api("/api/v1/import/record", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        path: projectPath,
+        agent_name: "test-agent",
+        source_id: "session-123",
+        source_hash: "100:50:1715000000000",
+        stats: { created: 2, updated: 1 },
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { recorded: boolean };
+    expect(body.recorded).toBe(true);
+
+    // Verify via history endpoint
+    const pq = `path=${encodeURIComponent(projectPath)}`;
+    const records = await apiJSON<Array<{ agent_name: string; source_id: string }>>(
+      `/api/v1/import/history?${pq}`,
+    );
+    expect(records.length).toBe(1);
+    expect(records[0].agent_name).toBe("test-agent");
+    expect(records[0].source_id).toBe("session-123");
+  });
+
+  it("returns 400 for missing fields", async () => {
+    const res = await api("/api/v1/import/record", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ path: "/test" }),
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/gateway/test/api.test.ts
+++ b/packages/gateway/test/api.test.ts
@@ -264,6 +264,29 @@ describe("POST /api/v1/projects/merge", () => {
   });
 });
 
+describe("POST /api/v1/reindex", () => {
+  it("succeeds (global reindex)", async () => {
+    const res = await api("/api/v1/reindex", { method: "POST" });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { knowledge_embedded: number; distillations_embedded: number };
+    expect(typeof body.knowledge_embedded).toBe("number");
+    expect(typeof body.distillations_embedded).toBe("number");
+  });
+});
+
+describe("POST /api/v1/projects/:id/clear — null body handling", () => {
+  it("handles JSON null body without crashing", async () => {
+    const { projectId } = await seedProject();
+    const res = await api(`/api/v1/projects/${projectId}/clear`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "null",
+    });
+    // Should clear everything (null treated as empty = no flags)
+    expect(res.status).toBe(200);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Tests: Zstd compression
 // ---------------------------------------------------------------------------
@@ -292,12 +315,28 @@ describe("Zstd request body decompression", () => {
 
 describe("Project resolution", () => {
   it("resolves project by git_remote query param", async () => {
-    const { projectId } = await seedProject();
+    const { projectPath } = await seedProject();
     // The seedProject uses git_remote "git@github.com:test/repo.git"
-    const entries = await apiJSON<Array<{ id: string }>>(
-      `/api/v1/projects/${projectId}/knowledge`,
+    const gitRemote = encodeURIComponent("git@github.com:test/repo.git");
+    const data = await apiJSON<{ query: string; result: string }>(
+      `/api/v1/recall?q=REST&git_remote=${gitRemote}`,
     );
-    expect(entries.length).toBeGreaterThanOrEqual(1);
+    expect(data.query).toBe("REST");
+    expect(typeof data.result).toBe("string");
+  });
+
+  it("resolves project by path query param", async () => {
+    const { projectPath } = await seedProject();
+    const data = await apiJSON<{ query: string; result: string }>(
+      `/api/v1/recall?q=REST&path=${encodeURIComponent(projectPath)}`,
+    );
+    expect(data.query).toBe("REST");
+    expect(typeof data.result).toBe("string");
+  });
+
+  it("returns 400 when project cannot be resolved", async () => {
+    const res = await api("/api/v1/recall?q=test&git_remote=nonexistent");
+    expect(res.status).toBe(400);
   });
 });
 
@@ -332,6 +371,15 @@ describe("GET /api/v1/recall", () => {
   it("returns 400 when project is not identified", async () => {
     const res = await api("/api/v1/recall?q=test");
     expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid scope", async () => {
+    const { projectPath } = await seedProject();
+    const pq = `path=${encodeURIComponent(projectPath)}`;
+    const res = await api(`/api/v1/recall?q=test&${pq}&scope=invalid`);
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: { message: string } };
+    expect(body.error.message).toContain("Invalid scope");
   });
 
   it("returns results for a valid query", async () => {


### PR DESCRIPTION
## Summary

- Add `/api/v1/` REST API endpoints enabling `lore data`, `lore recall`, and `lore import` to work against a remote gateway when `LORE_REMOTE_URL` is set
- Add `resolveProjectByRemoteOrPath()` in core for read-only project lookup preferring `git_remote` over `path`
- Support zstd-compressed request bodies (`Content-Encoding: zstd`) for efficient import payloads

## API Endpoints

**Data reads:**
- `GET /api/v1/projects` — list all projects
- `GET /api/v1/stats` — global stats
- `GET /api/v1/projects/:id/{knowledge,sessions,distillations}` — project-scoped lists
- `GET /api/v1/{knowledge,sessions,distillations}/:id` — show single entry

**Data mutations:**
- `DELETE /api/v1/{knowledge,sessions,distillations,projects}/:id`
- `POST /api/v1/projects/:id/{clear,dedup}`
- `POST /api/v1/projects/merge` (guarded against hosted mode)
- `POST /api/v1/reindex` — global embedding backfill (DB-wide, not project-scoped)

**Recall:**
- `GET /api/v1/recall?q=...&git_remote=...` — with query expansion (gateway has LLM client)
- Scope parameter validated against allowed values

**Import:**
- `POST /api/v1/import/extract` — accept chunks, run curator LLM, store results
- `POST /api/v1/import/record` — mark session as imported
- `GET /api/v1/import/history` — list import records

## CLI Remote Wiring

All CLI commands (`data`, `recall`, `import`) check `LORE_REMOTE_URL` early and delegate to the REST API. Local codepaths are unchanged. Commands that require local filesystem access (`recover`, `clear --all`) error with a clear message in remote mode.

## Self-Review Fixes (a591e38)

Addressed 11 findings from thorough self-review:

**Critical:**
- C2: Fix null body crash in `handleClearProject` (JSON `null` → TypeError)
- C3: Move reindex to global `POST /api/v1/reindex` (backfill is DB-wide, not project-scoped)
- C4: Guard `handleMergeProjects` against hosted mode (`backfillGitRemotes` runs git on local FS)
- C5: Add `DELETE` to CORS `access-control-allow-methods`

**Medium:**
- M1: Remove dead variables in `cmdListRemote` knowledge case
- M3: Handle non-JSON error responses in `remote.ts` (e.g. nginx 502)
- M5: Validate scope parameter in recall endpoint
- M6: Call `setLastImportAt` + `exportLoreFile` in `importRemote`
- M7: Check literal routes before parameterized routes in dispatcher

**Low:**
- L3: Remove dead endpoint variable in `cmdDedupRemote`
- L4: Fix test to actually test `git_remote`/`path` query param resolution

**Deferred (acceptable):**
- C1 (no auth): Consistent with existing proxy routes which also have no auth — auth is a separate concern for the gateway as a whole
- M2 (project resolution caching): Optimization, not correctness
- M4 (chunk size limits): Good follow-up, not blocking
- M8/L8 (Bun-only zstd): CLI remote helper only runs via Bun binary, not CJS bundle
- L7 (session delete 200 vs 404): 200 with zero counts is valid REST for idempotent deletes

## Files Changed

| File | Change |
|---|---|
| `packages/core/src/db.ts` | Add `resolveProjectByRemoteOrPath()` + `projectPath()` |
| `packages/core/src/index.ts` | Export new functions |
| `packages/gateway/src/api.ts` | **New** — REST API route dispatcher + all handlers |
| `packages/gateway/src/server.ts` | Add `/api/` route (lazy-imported), add DELETE to CORS |
| `packages/gateway/src/cli/remote.ts` | **New** — CLI remote HTTP client + helpers |
| `packages/gateway/src/cli/data.ts` | Add remote proxying for all subcommands |
| `packages/gateway/src/cli/recall-cmd.ts` | Add remote proxying |
| `packages/gateway/src/cli/import.ts` | Split: local detect + remote extract |
| `packages/gateway/test/api.test.ts` | **New** — 33 tests for all API endpoints |

## Test Results

- 33 API tests (scope validation, null body, git_remote resolution, etc.)
- 1524 total tests passing, 0 failures
- Clean typecheck across all 4 packages