### PR TITLE
fix: exempt sub-agent sessions from cache warming

### DIFF
--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -643,6 +643,10 @@ export function shouldWarm(
   // Global kill switch — always respected, even with /keep
   if (circuitBreakerTripped) return false;
 
+  // Sub-agent sessions are always exempt — they are too short-lived
+  // for warming to be profitable, even with /keep force.
+  if (state.isSubagent) return false;
+
   const cfg = loreConfig();
   if (!cfg.cache.warming.enabled) return false;
 

--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -900,6 +900,8 @@ export function computeWarmingSnapshot(
   if (!warmNow) {
     if (circuitBreakerTripped) {
       notWarmingReason = "Circuit breaker tripped";
+    } else if (state.isSubagent) {
+      notWarmingReason = "Sub-agent session (ephemeral)";
     } else if (!cfg.cache.warming.enabled) {
       notWarmingReason = "Warming disabled in config";
     } else if (!state.cacheAnalytics.lastRequestBody) {

--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -39,6 +39,7 @@ import {
   executeWarmup,
   loadGlobalHistograms,
   flushGlobalHistograms,
+  MIN_TURNS_FOR_WARMING,
 } from "./cache-warmer";
 import * as Sentry from "@sentry/bun";
 import { emitWarmupMetric, emitSessionCostMetrics, emitCurationMetrics } from "./sentry";
@@ -87,6 +88,15 @@ export function startIdleScheduler(
 
     for (const [sessionID, state] of sessions) {
       if (warmupInProgress.has(sessionID)) continue;
+
+      // Skip sub-agent sessions — ephemeral, warming is wasted work
+      if (state.isSubagent) continue;
+
+      // Skip sessions with too few turns — insufficient data for survival
+      // model and not worth the warmup cost ($0.30 per wasted warmup at
+      // 200K Opus tokens). Checked here to avoid expensive profile/histogram
+      // work before shouldWarm() rejects them anyway.
+      if (state.messageCount < MIN_TURNS_FOR_WARMING * 2) continue;
 
       // Ensure global histograms are loaded from SQLite for this project
       loadGlobalHistograms(state.projectPath);

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -2367,8 +2367,14 @@ async function handleConversationTurn(
 
   // --- 3. Session identification ---
   const { sessionID, isNew, tier } = await identifySession(req, pathResult.path);
-  const sessionState = getOrCreateSession(sessionID, pathResult.path);
+   const sessionState = getOrCreateSession(sessionID, pathResult.path);
   const projectPath = resolveSessionProjectPath(pathResult, sessionState);
+
+  // Mark sub-agent sessions (x-parent-session-id present).
+  // These get their own session but are flagged for cache warming exemption.
+  if (!sessionState.isSubagent && req.rawHeaders["x-parent-session-id"]) {
+    sessionState.isSubagent = true;
+  }
 
   // Bind auth credential to this session for background workers
   if (cred) {

--- a/packages/gateway/src/translate/types.ts
+++ b/packages/gateway/src/translate/types.ts
@@ -253,6 +253,14 @@ export type SessionState = {
    *  to avoid compounding cache busts from a single fluctuation. */
   ttlDowngradeStreak?: number;
 
+  // --- Sub-agent detection ---
+
+  /** True when the session was created with an `x-parent-session-id` header,
+   *  indicating it belongs to an ephemeral sub-agent (e.g. OpenCode explore).
+   *  Sub-agent sessions are exempt from cache warming — they are too
+   *  short-lived (1-3 turns) for warming to be profitable. */
+  isSubagent?: boolean;
+
   // --- Tier 1/2 session header identification ---
 
   /** Header-based session ID value (Tier 1 known header or Tier 2 promoted learned header). */

--- a/packages/gateway/src/translate/types.ts
+++ b/packages/gateway/src/translate/types.ts
@@ -255,10 +255,10 @@ export type SessionState = {
 
   // --- Sub-agent detection ---
 
-  /** True when the session was created with an `x-parent-session-id` header,
-   *  indicating it belongs to an ephemeral sub-agent (e.g. OpenCode explore).
-   *  Sub-agent sessions are exempt from cache warming — they are too
-   *  short-lived (1-3 turns) for warming to be profitable. */
+  /** True when a request in this session carried an `x-parent-session-id`
+   *  header, indicating it belongs to an ephemeral sub-agent (e.g. OpenCode
+   *  explore). Sub-agent sessions are exempt from cache warming — they are
+   *  too short-lived (1-3 turns) for warming to be profitable. */
   isSubagent?: boolean;
 
   // --- Tier 1/2 session header identification ---

--- a/packages/gateway/test/cache-warmer.test.ts
+++ b/packages/gateway/test/cache-warmer.test.ts
@@ -541,6 +541,49 @@ describe("shouldWarm", () => {
     expect(shouldWarm(state, profile, hist, now)).toBe(false);
   });
 
+  test("returns false for sub-agent sessions", () => {
+    const now = Date.now();
+    const state = makeSessionState({
+      lastRequestTime: now - 270_000,
+      messageCount: 20, // enough turns to normally qualify
+      isSubagent: true,
+      cacheAnalytics: {
+        ...makeCacheAnalytics(),
+        lastRequestBody: compressBody('{"test": true}'),
+      },
+    });
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+    const hist = createHistogram();
+    for (let i = 0; i < 50; i++) recordGap(hist, 360_000);
+
+    expect(shouldWarm(state, profile, hist, now)).toBe(false);
+  });
+
+  test("returns false for sub-agent sessions even with /keep", () => {
+    const now = Date.now();
+    const state = makeSessionState({
+      lastRequestTime: now - 270_000,
+      messageCount: 20,
+      isSubagent: true,
+      warmup: {
+        lastWarmupAt: 0,
+        warmupCount: 0,
+        warmupHits: 0,
+        disabled: false,
+        forceKeepWarm: true,
+      },
+      cacheAnalytics: {
+        ...makeCacheAnalytics(),
+        lastRequestBody: compressBody('{"test": true}'),
+      },
+    });
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+    const hist = createHistogram();
+    for (let i = 0; i < 50; i++) recordGap(hist, 360_000);
+
+    expect(shouldWarm(state, profile, hist, now)).toBe(false);
+  });
+
   test("returns false when no stored body", () => {
     const state = makeSessionState({
       lastRequestTime: Date.now() - 270_000,

--- a/packages/gateway/test/helpers/idle-worker.ts
+++ b/packages/gateway/test/helpers/idle-worker.ts
@@ -84,6 +84,7 @@ mock.module("../../src/cache-warmer", () => ({
   executeWarmup: async () => ({}),
   loadGlobalHistograms: () => {},
   flushGlobalHistograms: () => {},
+  MIN_TURNS_FOR_WARMING: 3,
 }));
 
 mock.module("../../src/worker-model", () => ({


### PR DESCRIPTION
## Summary

- Sub-agent sessions (OpenCode explore/general agents) are ephemeral (1-3 turns) — cache warming is wasted work for them
- Adds explicit `isSubagent` flag on `SessionState`, set from `x-parent-session-id` header, and checks it in both the idle loop (early skip before expensive work) and `shouldWarm()` (belt-and-suspenders)
- Also adds early `messageCount` check in the idle loop to skip all short sessions before profile/histogram computation — a general optimization that benefits non-sub-agent short sessions too

## Approach

Two-layer exemption:

1. **Explicit `isSubagent` flag** — set on `SessionState` when `x-parent-session-id` is detected in the request headers during `handleConversationTurn()`. Checked in `shouldWarm()` to block warming unconditionally, even with `/keep` force.

2. **Early idle loop skip** — both `isSubagent` and `messageCount < MIN_TURNS_FOR_WARMING * 2` are checked before `loadGlobalHistograms()`, `resolveProfile()`, and `blendedHistogramForSession()`, avoiding wasted computation. Previously, `shouldWarm()` rejected these sessions but only after all the expensive prep work.

## Files changed

| File | Change |
|---|---|
| `packages/gateway/src/translate/types.ts` | Add `isSubagent?: boolean` to `SessionState` |
| `packages/gateway/src/pipeline.ts` | Set `isSubagent` from `x-parent-session-id` header |
| `packages/gateway/src/idle.ts` | Early skip for sub-agent + low-turn sessions in warmup loop |
| `packages/gateway/src/cache-warmer.ts` | `isSubagent` guard in `shouldWarm()` |
| `packages/gateway/test/cache-warmer.test.ts` | 2 new tests for sub-agent exemption (normal + /keep) |
| `packages/gateway/test/helpers/idle-worker.ts` | Add `MIN_TURNS_FOR_WARMING` to cache-warmer mock |