### PR TITLE
fix: break Layer 4 cache hit rate death spiral

### DIFF
--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -98,9 +98,42 @@ export function updateBustRate(
   cacheWrite: number,
   cacheRead: number,
   sessionID?: string,
+  lastLayer?: number,
 ): void {
   if (!sessionID) return;
   const state = getSessionState(sessionID);
+
+  // Layer 4 (emergency) is structurally a full cache write — feeding its
+  // bust stats into the EMA and cap adaptation creates a death spiral where
+  // the cap ratchets down to MIN_CONTEXT_FLOOR and prevents the session from
+  // ever fitting in layers 1-3 again. Skip EMA updates entirely.
+  // This check is BEFORE the total===0 guard so that the consecutiveLayer4
+  // counter is always updated regardless of whether usage was reported.
+  if (lastLayer === 4) {
+    state.consecutiveLayer4++;
+
+    // Recovery hatch: after 5+ consecutive Layer 4 turns, the shrunken cap
+    // may be what's trapping us. Relax it by 10% per turn to give layers
+    // 1-3 a chance to fit. From 130K floor: turns 5-9 → 143K→157K→173K→190K→209K.
+    if (
+      state.consecutiveLayer4 >= 5 &&
+      state.dynamicContextCap > 0 &&
+      maxContextTokensCeiling > 0
+    ) {
+      state.dynamicContextCap = Math.min(
+        maxContextTokensCeiling,
+        Math.floor(state.dynamicContextCap * 1.10),
+      );
+    }
+    return;
+  }
+
+  // Non-Layer-4 turn: reset the consecutive counter (also before total===0
+  // guard — a zero-usage non-L4 turn must not leave a stale count).
+  if (lastLayer !== undefined) {
+    state.consecutiveLayer4 = 0;
+  }
+
   const total = cacheWrite + cacheRead;
   if (total === 0) return;
 
@@ -253,6 +286,10 @@ type SessionState = {
   postIdleCompact: boolean;
   /** Consecutive turns at layer >= 2. When >= 3, log a compaction hint. */
   consecutiveHighLayer: number;
+  /** Consecutive Layer 4 turns — used to skip bust-rate EMA updates
+   *  (Layer 4 busts are structural, not a caching signal) and to trigger
+   *  a recovery hatch that relaxes dynamicContextCap after prolonged trapping. */
+  consecutiveLayer4: number;
 
   // --- Cost-aware context cap dynamic state ---
 
@@ -298,6 +335,7 @@ function makeSessionState(): SessionState {
     cameOutOfIdle: false,
     postIdleCompact: false,
     consecutiveHighLayer: 0,
+    consecutiveLayer4: 0,
 
     bustRateEMA: -1,
     interBustIntervalEMA: -1,
@@ -605,6 +643,9 @@ export function inspectSessionState(sessionID: string): {
   postIdleCompact: boolean;
   lastTurnAt: number;
   distillationSnapshot: DistillationSnapshot | null;
+  bustRateEMA: number;
+  dynamicContextCap: number;
+  consecutiveLayer4: number;
 } | null {
   const state = sessionStates.get(sessionID);
   if (!state) return null;
@@ -615,6 +656,9 @@ export function inspectSessionState(sessionID: string): {
     postIdleCompact: state.postIdleCompact,
     lastTurnAt: state.lastTurnAt,
     distillationSnapshot: state.distillationSnapshot,
+    bustRateEMA: state.bustRateEMA,
+    dynamicContextCap: state.dynamicContextCap,
+    consecutiveLayer4: state.consecutiveLayer4,
   };
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -106,6 +106,7 @@ export {
   setForceMinLayer,
   getLastTransformedCount,
   getLastTransformEstimate,
+  getLastLayer,
   toolStripAnnotation,
   onIdleResume,
   getLastTurnAt,

--- a/packages/core/test/gradient.test.ts
+++ b/packages/core/test/gradient.test.ts
@@ -20,6 +20,8 @@ import {
   consumeCameOutOfIdle,
   inspectSessionState,
   setLastTurnAtForTest,
+  updateBustRate,
+  setMaxContextTokens,
 } from "../src/gradient";
 import type { LoreMessage, LorePart, LoreMessageWithParts } from "../src/types";
 import { isToolPart } from "../src/types";
@@ -2360,5 +2362,109 @@ describe("gradient — sanitizeToolParts determinism", () => {
     const json1 = JSON.stringify(toolPart1!.state);
     const json2 = JSON.stringify(toolPart2!.state);
     expect(json2).toBe(json1);
+  });
+});
+
+describe("updateBustRate — Layer 4 handling", () => {
+  const SID = "bust-rate-layer4-sess";
+
+  beforeEach(() => {
+    resetCalibration(SID);
+    setMaxContextTokens(200_000);
+  });
+
+  test("skips EMA update and cap tightening at Layer 4", () => {
+    // Prime with high bust rate to ratchet cap below ceiling — ensures
+    // the cap assertion is meaningful (not just clamped at ceiling).
+    for (let i = 0; i < 10; i++) {
+      updateBustRate(100_000, 0, SID);
+    }
+    const stateAfterPrime = inspectSessionState(SID)!;
+    const emaBefore = stateAfterPrime.bustRateEMA;
+    const capBefore = stateAfterPrime.dynamicContextCap;
+    expect(capBefore).toBeLessThan(200_000); // verify cap was actually tightened
+
+    // Layer 4 turn: 100% writes — should NOT affect EMA or cap
+    updateBustRate(100_000, 0, SID, 4);
+    const stateAfter = inspectSessionState(SID)!;
+
+    // EMA should NOT have changed
+    expect(stateAfter.bustRateEMA).toBe(emaBefore);
+    // Cap should NOT have tightened further
+    expect(stateAfter.dynamicContextCap).toBe(capBefore);
+    // L4 counter should have been incremented
+    expect(stateAfter.consecutiveLayer4).toBe(1);
+  });
+
+  test("tracks consecutiveLayer4 and resets on non-Layer-4 turn", () => {
+    updateBustRate(100_000, 0, SID, 4);
+    expect(inspectSessionState(SID)!.consecutiveLayer4).toBe(1);
+
+    updateBustRate(100_000, 0, SID, 4);
+    expect(inspectSessionState(SID)!.consecutiveLayer4).toBe(2);
+
+    updateBustRate(100_000, 0, SID, 4);
+    expect(inspectSessionState(SID)!.consecutiveLayer4).toBe(3);
+
+    // Non-Layer-4 turn resets the counter
+    updateBustRate(50_000, 50_000, SID, 1);
+    expect(inspectSessionState(SID)!.consecutiveLayer4).toBe(0);
+  });
+
+  test("recovery hatch relaxes cap after 5 consecutive Layer 4 turns", () => {
+    // Prime with high bust rate to ratchet cap down
+    for (let i = 0; i < 20; i++) {
+      updateBustRate(100_000, 0, SID);
+    }
+    const cappedState = inspectSessionState(SID)!;
+    const cappedValue = cappedState.dynamicContextCap;
+    // Cap should have been tightened significantly
+    expect(cappedValue).toBeLessThan(200_000);
+
+    // First 4 Layer 4 turns: no recovery yet
+    for (let i = 0; i < 4; i++) {
+      updateBustRate(100_000, 0, SID, 4);
+    }
+    expect(inspectSessionState(SID)!.dynamicContextCap).toBe(cappedValue);
+
+    // 5th Layer 4 turn: recovery hatch kicks in
+    updateBustRate(100_000, 0, SID, 4);
+    const recoveredCap = inspectSessionState(SID)!.dynamicContextCap;
+    expect(recoveredCap).toBeGreaterThan(cappedValue);
+
+    // 6th Layer 4 turn: continues relaxing
+    updateBustRate(100_000, 0, SID, 4);
+    expect(inspectSessionState(SID)!.dynamicContextCap).toBeGreaterThan(recoveredCap);
+  });
+
+  test("Layer 4 without lastLayer param still updates EMA normally (backward compat)", () => {
+    // When lastLayer is not passed, existing behavior is preserved
+    updateBustRate(50_000, 50_000, SID);
+    const emaBefore = inspectSessionState(SID)!.bustRateEMA;
+
+    // Call without lastLayer — should update EMA
+    updateBustRate(100_000, 0, SID);
+    const emaAfter = inspectSessionState(SID)!.bustRateEMA;
+    expect(emaAfter).toBeGreaterThan(emaBefore);
+  });
+
+  test("zero-usage Layer 4 turn still increments consecutiveLayer4", () => {
+    // API response with no cache metrics (e.g. error, or model doesn't report them)
+    updateBustRate(0, 0, SID, 4);
+    expect(inspectSessionState(SID)!.consecutiveLayer4).toBe(1);
+
+    updateBustRate(0, 0, SID, 4);
+    expect(inspectSessionState(SID)!.consecutiveLayer4).toBe(2);
+  });
+
+  test("zero-usage non-Layer-4 turn resets consecutiveLayer4", () => {
+    // Build up a count
+    updateBustRate(100_000, 0, SID, 4);
+    updateBustRate(100_000, 0, SID, 4);
+    expect(inspectSessionState(SID)!.consecutiveLayer4).toBe(2);
+
+    // Zero-usage non-L4 turn — must reset, not leave stale count
+    updateBustRate(0, 0, SID, 1);
+    expect(inspectSessionState(SID)!.consecutiveLayer4).toBe(0);
   });
 });

--- a/packages/gateway/src/cache-analytics.ts
+++ b/packages/gateway/src/cache-analytics.ts
@@ -247,14 +247,17 @@ export function inferDivergenceReason(
   if (path === "<start>") return "request structure changed from start";
   if (path === "<root>") return "top-level structure changed";
 
-  // System prompt blocks:
+  // System prompt blocks (3-block architecture):
   //  system[0] = host system prompt (stable, cached with 1h TTL)
-  //  system[1] = LTM knowledge block (Lore's injection, changes on curation)
+  //  system[1] = stable LTM: preferences (pinned >=1h, cached with 1h TTL)
+  //  system[2] = context-bound LTM: non-preference entries (diff-pinned, rides conversation cache)
   //  bare "system" = plain string system prompt (no array structure)
   if (path === "system[0]" || path.startsWith("system[0]"))
     return "host system prompt changed";
   if (path === "system[1]" || path.startsWith("system[1]"))
-    return "LTM knowledge block updated (background curation/consolidation)";
+    return "stable LTM changed (preferences — should be rare, pinned >=1h)";
+  if (path === "system[2]" || path.startsWith("system[2]"))
+    return "context-bound LTM changed (non-preference entries re-ranked)";
   if (path === "system" || path.startsWith("system"))
     return "system prompt changed";
 

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -32,6 +32,7 @@ import {
   updateBustRate,
   calibrate,
   getLastTransformedCount,
+  getLastLayer,
   onIdleResume,
   consumeCameOutOfIdle,
   needsUrgentDistillation,
@@ -1786,6 +1787,7 @@ function postResponse(
       resp.usage.cacheCreationInputTokens ?? 0,
       resp.usage.cacheReadInputTokens ?? 0,
       sessionState.sessionID,
+      getLastLayer(sessionState.sessionID),
     );
 
     // Capture previous stop reason before it's overwritten below (line ~1667).
@@ -2747,19 +2749,43 @@ async function handleConversationTurn(
 
         if (formatted) {
           const tokenCount = Math.ceil(formatted.length / 3);
-          // Replace context-bound cache and pin — Layer 4 already busts the
-          // prompt cache, so there's no benefit to preserving the old pin.
+          // Always update the cache with freshly ranked entries.
           ltmSessionCache.delete(sessionID);
           ltmSessionCache.set(sessionID, { formatted, tokenCount });
-          ltmPinnedText.set(sessionID, { formatted, tokenCount });
-          ltmText = formatted;
-          setLtmTokens(stableTokens + tokenCount, sessionID);
-          saveSessionTracking(sessionID, {
-            ltmCacheText: formatted,
-            ltmCacheTokens: tokenCount,
-            ltmPinText: formatted,
-            ltmPinTokens: tokenCount,
-          });
+
+          // Apply diff-pinning: on consecutive Layer 4 turns, system[2]
+          // stability matters because system[0]+[1] ARE still cache reads
+          // at 1h TTL. Only update the pin if the new text differs
+          // substantially — same threshold as step 6 (lines 2639-2655).
+          const pinned = ltmPinnedText.get(sessionID);
+          const baseDiffThreshold = 0.05;
+          const effectiveDiffThreshold = (modelSpec.inputCostPerMillion ?? 3) >= 5
+            ? Math.min(baseDiffThreshold * 3, 0.20)  // opus: 15%
+            : (modelSpec.inputCostPerMillion ?? 3) >= 1
+              ? Math.min(baseDiffThreshold * 2, 0.15)  // sonnet: 10%
+              : baseDiffThreshold;                       // haiku: 5%
+
+          if (pinned && textDiffRatio(pinned.formatted, formatted) < effectiveDiffThreshold) {
+            // Near-identical — keep the pinned text to preserve cache prefix
+            ltmText = pinned.formatted;
+            setLtmTokens(stableTokens + pinned.tokenCount, sessionID);
+            saveSessionTracking(sessionID, {
+              ltmCacheText: formatted,
+              ltmCacheTokens: tokenCount,
+              // pin unchanged — don't write ltmPinText/ltmPinTokens
+            });
+          } else {
+            // Substantially different or first Layer 4 turn — pin the new text
+            ltmPinnedText.set(sessionID, { formatted, tokenCount });
+            ltmText = formatted;
+            setLtmTokens(stableTokens + tokenCount, sessionID);
+            saveSessionTracking(sessionID, {
+              ltmCacheText: formatted,
+              ltmCacheTokens: tokenCount,
+              ltmPinText: formatted,
+              ltmPinTokens: tokenCount,
+            });
+          }
           refreshed = true;
           log.info("Context-bound LTM refreshed on emergency layer (Layer 4) for session", sessionID);
         }

--- a/packages/gateway/test/cache-analytics.test.ts
+++ b/packages/gateway/test/cache-analytics.test.ts
@@ -208,9 +208,15 @@ describe("inferDivergenceReason", () => {
     );
   });
 
-  test("system prompt — LTM block", () => {
+  test("system prompt — stable LTM block", () => {
     expect(inferDivergenceReason("system[1].text", 100, 100)).toBe(
-      "LTM knowledge block updated (background curation/consolidation)",
+      "stable LTM changed (preferences — should be rare, pinned >=1h)",
+    );
+  });
+
+  test("system prompt — context-bound LTM block", () => {
+    expect(inferDivergenceReason("system[2].text", 100, 100)).toBe(
+      "context-bound LTM changed (non-preference entries re-ranked)",
     );
   });
 


### PR DESCRIPTION
## Summary

Fixes a feedback loop that trapped session `0ksuww7vamkq` at Layer 4 (emergency) for 70+ consecutive turns with 18-19% cache hit rate (should be 90%+). Overall session cache hit rate was 41.5% across 113 turns.

## Root Cause

Three bugs formed a self-reinforcing loop:

1. **Layer 4 LTM refresh bypassed diff-pinning** (introduced in PR #305) — every Layer 4 turn re-ran `forSession()` and unconditionally replaced both `ltmSessionCache` and `ltmPinnedText`. Since `forSession()` re-ranks entries against evolving session context, `system[2]` text changed subtly every turn, busting the cache prefix.

2. **Dynamic context cap death spiral** — each bust (~80% writes) drove `bustRateEMA > 0.8`, compounding cap tightening to the 130K floor. At 130K the session's ~135K tokens couldn't fit in layers 1-3, permanently trapping it at Layer 4. Recovery required `bustRateEMA < 0.3` — unreachable while every turn was a bust.

3. **Misleading diagnostics** — `system[2]` changes were classified as generic "system prompt changed" instead of identifying LTM re-ranking, making diagnosis harder.

## Fixes

- **Fix 1 (primary):** Apply the same content-diff threshold to the Layer 4 `refreshLtm` path that step 6 already uses. On consecutive Layer 4 turns, if `forSession()` returns text <15% different (Opus), the old pin is preserved — keeping `system[2]` byte-identical.

- **Fix 2 (amplifier):** `updateBustRate()` now accepts a `lastLayer` parameter. When `lastLayer === 4`, EMA updates and cap tightening are skipped entirely (structural busts, not a caching signal). A recovery hatch after 5+ consecutive Layer 4 turns relaxes `dynamicContextCap` by 10%/turn.

- **Fix 3 (diagnostic):** Added `system[2]` label in `inferDivergenceReason()` ("context-bound LTM changed") and refined `system[1]` label.

## Files changed

| File | Change |
|------|--------|
| `packages/gateway/src/pipeline.ts` | Diff-pinning in Layer 4 refresh path; pass `lastLayer` to `updateBustRate` |
| `packages/core/src/gradient.ts` | Skip EMA at L4, `consecutiveLayer4` counter, recovery hatch, extend `inspectSessionState` |
| `packages/core/src/index.ts` | Export `getLastLayer` |
| `packages/gateway/src/cache-analytics.ts` | Add `system[2]` diagnostic label |
| `packages/core/test/gradient.test.ts` | 4 new tests for L4 bust-rate handling |
| `packages/gateway/test/cache-analytics.test.ts` | Updated `system[1]` label, added `system[2]` test |