### PR TITLE
fix: pre-truncate long texts to prevent ONNX OOM and report embedding errors to Sentry

### DIFF
--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -28,6 +28,15 @@ import type {
  *  embedding calls but bounded enough to avoid minutes-long hangs. */
 const EMBED_TIMEOUT_MS = 10_000;
 
+/**
+ * Safe per-text character limit for local ONNX inference. The Nomic v1.5 model
+ * supports up to 8192 tokens, but ONNX runtime OOMs on inputs near that ceiling
+ * (error codes 284432024, 287180544, 144786472). Pre-truncating to ~4096 tokens
+ * worth of characters keeps the tensor well within safe allocation bounds.
+ * The worker's `truncation: true` remains as a safety net.
+ */
+const LOCAL_MAX_CHARS = 4096 * 4; // ~4096 tokens × ~4 chars/token
+
 // ---------------------------------------------------------------------------
 // Provider interface
 // ---------------------------------------------------------------------------
@@ -332,9 +341,10 @@ class LocalProvider implements EmbeddingProvider {
             localProviderKnownBroken = true;
             if (!localProviderErrorLogged) {
               localProviderErrorLogged = true;
-              log.info(
+              log.error(
                 `local embedding provider failed to init: ${msg.error}. ` +
                   `Set VOYAGE_API_KEY/OPENAI_API_KEY for automatic remote fallback.`,
+                new Error(`embedding worker init failed: ${msg.error}`),
               );
             }
             for (const [, p] of this.pendingRequests) {
@@ -351,6 +361,7 @@ class LocalProvider implements EmbeddingProvider {
       this.worker.on("error", (err: Error) => {
         this.workerInitError = err.message;
         this.workerReady = false;
+        log.error("embedding worker crashed:", err);
         for (const [, p] of this.pendingRequests) {
           p.reject(new LocalProviderUnavailableError(err));
         }
@@ -361,6 +372,10 @@ class LocalProvider implements EmbeddingProvider {
       this.worker.on("exit", (code) => {
         if (code !== 0 && !this.workerInitError) {
           this.workerInitError = `embedding worker exited with code ${code}`;
+          log.error(
+            this.workerInitError,
+            new Error(this.workerInitError),
+          );
         }
         this.workerReady = false;
         for (const [, p] of this.pendingRequests) {
@@ -396,9 +411,15 @@ class LocalProvider implements EmbeddingProvider {
   async embed(texts: string[], inputType: "document" | "query"): Promise<Float32Array[]> {
     await this.ensureWorker();
 
+    // Pre-truncate texts that exceed the safe ONNX inference limit.
+    // This prevents OOM on single inputs near the model's 8192-token max.
+    const truncated = texts.map((t) =>
+      t.length > LOCAL_MAX_CHARS ? t.slice(0, LOCAL_MAX_CHARS) : t,
+    );
+
     // Prepend Nomic task instruction prefix.
     const prefix = inputType === "document" ? "search_document: " : "search_query: ";
-    const prefixed = texts.map((t) => prefix + t);
+    const prefixed = truncated.map((t) => prefix + t);
 
     const id = this.nextRequestId++;
     // Recall queries (single query-type texts) get high priority so they
@@ -850,7 +871,7 @@ export function embedKnowledgeEntry(
         .run(toBlob(vec), id);
     })
     .catch((err) => {
-      log.info("embedding failed for knowledge entry", id, ":", err);
+      log.error("embedding failed for knowledge entry", id, ":", err);
     });
 }
 
@@ -870,7 +891,7 @@ export function embedDistillation(
         .run(toBlob(vec), id);
     })
     .catch((err) => {
-      log.info("embedding failed for distillation", id, ":", err);
+      log.error("embedding failed for distillation", id, ":", err);
     });
 }
 
@@ -895,7 +916,7 @@ export function embedTemporalMessage(
         .run(toBlob(vec), id);
     })
     .catch((err) => {
-      log.info("embedding failed for temporal message", id, ":", err);
+      log.error("embedding failed for temporal message", id, ":", err);
     });
 }
 

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -588,7 +588,7 @@ async function initIfNeeded(projectPath: string, config: GatewayConfig, gitRemot
     log.info("metric backfill failed:", e);
   }
   embedding.runStartupBackfill().catch((e) => {
-    log.info("embedding backfill failed:", e);
+    log.error("embedding backfill failed:", e);
   });
 
   // Index lat.md/ directory sections (content-hash-based, skips unchanged files).


### PR DESCRIPTION
## Summary

- Pre-truncate texts to ~4096 tokens (`LOCAL_MAX_CHARS=16384` chars) in `LocalProvider.embed()` before sending to the ONNX worker, preventing OOM on single inputs near the model's 8192-token max (error code `284432024`)
- Upgrade 7 embedding error paths from `log.info` (or no logging) to `log.error` so failures reach Sentry via `captureException`

## Problem

**ONNX OOM:** A single text tokenized to 8192 tokens (the model's max sequence length) caused ONNX runtime allocation failure. `nextBatch()` always includes at least 1 item regardless of `MAX_BATCH_TOKEN_AREA`, so the budget guard was bypassed. The worker's `truncation: true` caps at the model max, but that's already too large for ONNX to allocate.

**Silent Sentry:** Embedding errors were invisible in Sentry because:
- `pipeline.ts:591` — top-level backfill catch used `log.info`
- `embedding.ts:335` — worker init failure used `log.info`
- `embedding.ts:853,873,898` — fire-and-forget catches used `log.info`
- `embedding.ts:351-359,361-373` — worker crash/exit handlers had no logging at all

Only `log.error()` calls `sink?.captureException(err)` via the Sentry bridge.

## Changes

| File | Change |
|---|---|
| `packages/core/src/embedding.ts` | Add `LOCAL_MAX_CHARS` constant and pre-truncation in `LocalProvider.embed()` |
| `packages/core/src/embedding.ts` | Upgrade `init-error`, `crash`, `exit` handlers to `log.error` |
| `packages/core/src/embedding.ts` | Upgrade fire-and-forget catches to `log.error` |
| `packages/gateway/src/pipeline.ts` | Upgrade backfill catch to `log.error` |