### PR TITLE
fix: resolve pi build rootDir error by adding types export to core

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/node/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "bun": "./src/index.ts",
       "default": "./dist/node/index.js"
     }

--- a/packages/pi/tsconfig.build.json
+++ b/packages/pi/tsconfig.build.json
@@ -6,10 +6,7 @@
     "emitDeclarationOnly": true,
     "declaration": true,
     "declarationMap": true,
-    "noEmit": false,
-    "paths": {
-      "@loreai/core": ["../core/src/index.ts"]
-    }
+    "noEmit": false
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary

Fixes the release build failure for v0.20.0 ([CI run #813](https://github.com/BYK/loreai/actions/runs/25925864808)).

- Remove `paths` mapping from `packages/pi/tsconfig.build.json` that caused tsc to follow into core's source files during declaration emission, violating `rootDir`
- Add `"types"` export condition to `packages/core/package.json` so tsc resolves `@loreai/core` to pre-built `.d.ts` files instead of source

The root cause was introduced in #331 which added a static `import { getGitRemote } from "@loreai/core"` to pi's `index.ts`. The `paths` mapping made tsc resolve this to `../core/src/index.ts` (the barrel file), pulling all of core's source into the compilation — all outside pi's `rootDir: "src"`. This only fails during `tsc -p tsconfig.build.json` (declaration emission), not during `tsc --noEmit` (typecheck).