### PR TITLE
fix: surface unsustainable warning on all gradient return paths

### DIFF
--- a/packages/core/src/distillation.ts
+++ b/packages/core/src/distillation.ts
@@ -623,6 +623,10 @@ export async function run(input: {
   skipMeta?: boolean;
   urgent?: boolean;
   callType?: "batch" | "direct";
+  /** Override the meta-distillation gen-0 threshold. When set, meta-distillation
+   *  triggers at this count instead of `cfg.distillation.metaThreshold`.
+   *  Used by the urgent-distillation path to consolidate earlier under bust pressure. */
+  metaThresholdOverride?: number;
 }): Promise<{ rounds: number; distilled: number }> {
   return distillLimiter.get(input.sessionID)(() => runInner(input));
 }
@@ -648,6 +652,8 @@ async function runInner(input: {
   /** Whether the LLM call will use batch or direct pricing. Recorded on the
    *  distillation row for accurate historical cost estimates. */
   callType?: "batch" | "direct";
+  /** Override the meta-distillation gen-0 threshold (see run()). */
+  metaThresholdOverride?: number;
 }): Promise<{ rounds: number; distilled: number }> {
   // Reset orphaned messages (marked distilled by a deleted/migrated distillation)
   const orphans = resetOrphans(input.projectPath, input.sessionID);
@@ -708,10 +714,11 @@ async function runInner(input: {
     // Check if meta-distillation is needed (skip when cache is warm to avoid
     // prefix cache invalidation — row IDs change after meta-distill, busting
     // the prompt cache on the next turn).
+    const effectiveMetaThreshold = input.metaThresholdOverride ?? cfg.distillation.metaThreshold;
     if (
       !input.skipMeta &&
       gen0Count(input.projectPath, input.sessionID) >=
-      cfg.distillation.metaThreshold
+      effectiveMetaThreshold
     ) {
       // Call inner directly — we're already under the per-session limiter.
       await metaDistillInner({

--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -604,6 +604,15 @@ export function inspectSessionState(sessionID: string): {
 }
 
 /**
+ * Return the consecutive-bust counter for a session.
+ * Used by the gateway idle handler and urgent-distillation scheduler to
+ * lower the meta-distillation threshold under bust pressure.
+ */
+export function getConsecutiveBusts(sessionID: string): number {
+  return getSessionState(sessionID).consecutiveBusts;
+}
+
+/**
  * For testing only — set the session's lastTurnAt field. Used to simulate
  * idle gaps without sleeping. Creates the session state if not present so
  * tests don't need to seed it via a transform() call.
@@ -1703,6 +1712,7 @@ function transformInner(input: {
       distilledBudget,
       rawBudget,
       refreshLtm: false,
+      unsustainable: sid ? getSessionState(sid).consecutiveBusts >= 5 : false,
     };
   }
 
@@ -1830,7 +1840,15 @@ function transformInner(input: {
       if (sid && (s > 0 || cached.tokens === 0)) {
         urgentDistillationMap.set(sid, true);
       }
-      return { ...result!, layer: stageLayer, usable, distilledBudget, rawBudget, refreshLtm: false };
+      return {
+        ...result!,
+        layer: stageLayer,
+        usable,
+        distilledBudget,
+        rawBudget,
+        refreshLtm: false,
+        unsustainable: sid ? getSessionState(sid).consecutiveBusts >= 5 : false,
+      };
     }
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -117,6 +117,7 @@ export {
   // gaps without sleeping. Not part of the public API.
   setLastTurnAtForTest,
   inspectSessionState,
+  getConsecutiveBusts,
 } from "./gradient";
 export {
   formatKnowledge,

--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -26,6 +26,7 @@ import {
   saveSessionCosts,
   saveSessionTracking,
   saveGradientState,
+  getConsecutiveBusts,
 } from "@loreai/core";
 import type { LLMClient } from "@loreai/core";
 import type { GatewayConfig } from "./config";
@@ -229,8 +230,15 @@ export function buildIdleWorkHandler(
       // Meta consolidation: safe on idle because cache is already cold.
       // Run as a separate step so gen-0 segments from the force-distill
       // above are counted toward the threshold.
+      // Under bust pressure (3+ consecutive busts), lower the threshold
+      // to consolidate earlier — shrinks the distilled prefix before the
+      // session becomes unsustainable.
+      const busts = getConsecutiveBusts(sessionID);
+      const effectiveMetaThreshold = busts >= 3
+        ? Math.max(3, Math.floor(cfg.distillation.metaThreshold / 4))
+        : cfg.distillation.metaThreshold;
       const g0 = distillation.gen0Count(projectPath, sessionID);
-      if (g0 >= cfg.distillation.metaThreshold) {
+      if (g0 >= effectiveMetaThreshold) {
         await distillation.metaDistill({ llm, projectPath, sessionID, model, callType });
       }
     } catch (e) {

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -35,6 +35,7 @@ import {
   onIdleResume,
   consumeCameOutOfIdle,
   needsUrgentDistillation,
+  getConsecutiveBusts,
   formatKnowledge,
   buildCompactPrompt,
   shouldImportLoreFile,
@@ -1994,7 +1995,14 @@ function scheduleBackgroundWork(
   // Check if urgent distillation is needed (gradient flagged it).
   // Mark urgent: true so these bypass the batch queue — the gradient is
   // in overflow and needs the result before the next user turn.
+  // Under bust pressure (3+ consecutive busts), lower the meta-distillation
+  // threshold to consolidate gen-0 segments earlier — shrinks the distilled
+  // prefix before the session becomes unsustainable.
   if (needsUrgentDistillation(sessionState.sessionID)) {
+    const busts = getConsecutiveBusts(sessionState.sessionID);
+    const metaThresholdOverride = busts >= 3
+      ? Math.max(3, Math.floor(cfg.distillation.metaThreshold / 4))
+      : undefined;
     distillation
       .run({
         llm,
@@ -2004,6 +2012,7 @@ function scheduleBackgroundWork(
         force: true,
         urgent: true,
         callType: "direct",
+        metaThresholdOverride,
       })
       .catch((e) => log.error("background distillation failed:", e));
   } else {

--- a/packages/gateway/test/helpers/idle-worker.ts
+++ b/packages/gateway/test/helpers/idle-worker.ts
@@ -67,6 +67,7 @@ mock.module("@loreai/core", () => ({
   saveSessionCosts: () => {},
   saveSessionTracking: () => {},
   saveGradientState: () => {},
+  getConsecutiveBusts: () => 0,
   loadSessionTracking: () => null,
   getKV: () => null,
   setKV: () => {},


### PR DESCRIPTION
## Summary

- **Bug fix**: The `unsustainable` flag on `TransformResult` was only set on 2 of 4 return paths in `transformInner()` — the tier gate (layer 0) and emergency (layer 4). The most common path for unsustainable sessions (layers 1-3 compression loop, line 1833) never set it because the sticky layer guard pins `effectiveMinLayer >= 1`, bypassing the tier gate entirely. Sessions like `0P8Jt4Th6iGN` would accumulate 5+ consecutive busts without the warning ever reaching the model.
- **Proactive meta-distillation**: When `consecutiveBusts >= 3`, lowers the meta-distillation threshold from 20 to 5 gen-0 segments in both the idle handler and urgent distillation paths. This consolidates the distilled prefix earlier under bust pressure, helping prevent sessions from becoming unsustainable in the first place.

## Changes

| File | Change |
|------|--------|
| `packages/core/src/gradient.ts` | Add `unsustainable` flag to return paths 1 (layer 0 passthrough) and 3 (layers 1/2/3 compression loop); export `getConsecutiveBusts()` |
| `packages/core/src/index.ts` | Re-export `getConsecutiveBusts` |
| `packages/core/src/distillation.ts` | Add `metaThresholdOverride` param to `run()`/`runInner()` |
| `packages/gateway/src/idle.ts` | Bust-aware meta-distillation threshold (20 → 5 when busts >= 3) |
| `packages/gateway/src/pipeline.ts` | Pass `metaThresholdOverride` in urgent distillation path |
| `packages/gateway/test/helpers/idle-worker.ts` | Add `getConsecutiveBusts` to `@loreai/core` mock |