### PR TITLE
fix: review follow-ups for unsustainable warning PR

### DIFF
--- a/packages/core/src/distillation.ts
+++ b/packages/core/src/distillation.ts
@@ -714,7 +714,11 @@ async function runInner(input: {
     // Check if meta-distillation is needed (skip when cache is warm to avoid
     // prefix cache invalidation — row IDs change after meta-distill, busting
     // the prompt cache on the next turn).
-    const effectiveMetaThreshold = input.metaThresholdOverride ?? cfg.distillation.metaThreshold;
+    // Clamp override to min 2 — meta-distillation with < 2 gen-0 segments is pointless.
+    const effectiveMetaThreshold = Math.max(
+      2,
+      input.metaThresholdOverride ?? cfg.distillation.metaThreshold,
+    );
     if (
       !input.skipMeta &&
       gen0Count(input.projectPath, input.sessionID) >=

--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -604,12 +604,31 @@ export function inspectSessionState(sessionID: string): {
 }
 
 /**
- * Return the consecutive-bust counter for a session.
- * Used by the gateway idle handler and urgent-distillation scheduler to
- * lower the meta-distillation threshold under bust pressure.
+ * Return the consecutive-bust counter for a session (read-only).
+ * Returns 0 if the session has no in-memory state — callers treat this
+ * as "no bust pressure" which is the safe default.
+ *
+ * Uses Map.get() instead of getSessionState() to avoid creating phantom
+ * SessionState entries with zeroed calibration fields, which would cause
+ * the next transform() call to treat the session as uncalibrated.
  */
 export function getConsecutiveBusts(sessionID: string): number {
-  return getSessionState(sessionID).consecutiveBusts;
+  return sessionStates.get(sessionID)?.consecutiveBusts ?? 0;
+}
+
+/** Bust-pressure threshold for meta-distillation: consecutive busts ≥ this
+ *  value trigger earlier consolidation of gen-0 segments. */
+export const BUST_PRESSURE_THRESHOLD = 3;
+
+/**
+ * Compute the effective meta-distillation threshold under bust pressure.
+ * When busts ≥ BUST_PRESSURE_THRESHOLD, lowers the threshold to 1/4 of the
+ * configured value (min 3) to consolidate the distilled prefix earlier.
+ */
+export function effectiveMetaThreshold(busts: number, configThreshold: number): number {
+  return busts >= BUST_PRESSURE_THRESHOLD
+    ? Math.max(3, Math.floor(configThreshold / 4))
+    : configThreshold;
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -118,6 +118,8 @@ export {
   setLastTurnAtForTest,
   inspectSessionState,
   getConsecutiveBusts,
+  BUST_PRESSURE_THRESHOLD,
+  effectiveMetaThreshold,
 } from "./gradient";
 export {
   formatKnowledge,

--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -27,6 +27,7 @@ import {
   saveSessionTracking,
   saveGradientState,
   getConsecutiveBusts,
+  effectiveMetaThreshold,
 } from "@loreai/core";
 import type { LLMClient } from "@loreai/core";
 import type { GatewayConfig } from "./config";
@@ -234,11 +235,9 @@ export function buildIdleWorkHandler(
       // to consolidate earlier — shrinks the distilled prefix before the
       // session becomes unsustainable.
       const busts = getConsecutiveBusts(sessionID);
-      const effectiveMetaThreshold = busts >= 3
-        ? Math.max(3, Math.floor(cfg.distillation.metaThreshold / 4))
-        : cfg.distillation.metaThreshold;
+      const metaThreshold = effectiveMetaThreshold(busts, cfg.distillation.metaThreshold);
       const g0 = distillation.gen0Count(projectPath, sessionID);
-      if (g0 >= effectiveMetaThreshold) {
+      if (g0 >= metaThreshold) {
         await distillation.metaDistill({ llm, projectPath, sessionID, model, callType });
       }
     } catch (e) {

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -36,6 +36,7 @@ import {
   consumeCameOutOfIdle,
   needsUrgentDistillation,
   getConsecutiveBusts,
+  effectiveMetaThreshold as computeMetaThreshold,
   formatKnowledge,
   buildCompactPrompt,
   shouldImportLoreFile,
@@ -2000,9 +2001,8 @@ function scheduleBackgroundWork(
   // prefix before the session becomes unsustainable.
   if (needsUrgentDistillation(sessionState.sessionID)) {
     const busts = getConsecutiveBusts(sessionState.sessionID);
-    const metaThresholdOverride = busts >= 3
-      ? Math.max(3, Math.floor(cfg.distillation.metaThreshold / 4))
-      : undefined;
+    const lowered = computeMetaThreshold(busts, cfg.distillation.metaThreshold);
+    const metaThresholdOverride = lowered < cfg.distillation.metaThreshold ? lowered : undefined;
     distillation
       .run({
         llm,

--- a/packages/gateway/test/helpers/idle-worker.ts
+++ b/packages/gateway/test/helpers/idle-worker.ts
@@ -68,6 +68,9 @@ mock.module("@loreai/core", () => ({
   saveSessionTracking: () => {},
   saveGradientState: () => {},
   getConsecutiveBusts: () => 0,
+  BUST_PRESSURE_THRESHOLD: 3,
+  effectiveMetaThreshold: (busts: number, threshold: number) =>
+    busts >= 3 ? Math.max(3, Math.floor(threshold / 4)) : threshold,
   loadSessionTracking: () => null,
   getKV: () => null,
   setKV: () => {},


### PR DESCRIPTION
## Summary

Follow-up fixes from self-review of #351:

- **`getConsecutiveBusts()` now read-only**: Uses `sessionStates.get()` instead of `getSessionState()` (get-or-create) to avoid creating phantom `SessionState` entries with zeroed calibration fields, which would cause subsequent `transform()` calls to treat the session as uncalibrated.
- **`metaThresholdOverride` clamped**: `runInner()` now clamps the override to min 2 — prevents callers from passing 0 or negative values that would trigger meta-distillation unconditionally.
- **DRY threshold formula**: Extracted `effectiveMetaThreshold()` helper and `BUST_PRESSURE_THRESHOLD` constant into `@loreai/core`, replacing duplicated `busts >= 3 ? Math.max(3, Math.floor(threshold / 4)) : threshold` logic in `idle.ts` and `pipeline.ts`.

## Files changed

| File | Change |
|------|--------|
| `packages/core/src/gradient.ts` | `getConsecutiveBusts()` uses read-only Map access; new `effectiveMetaThreshold()` helper + `BUST_PRESSURE_THRESHOLD` constant |
| `packages/core/src/index.ts` | Re-export new symbols |
| `packages/core/src/distillation.ts` | Clamp `metaThresholdOverride` to min 2 |
| `packages/gateway/src/idle.ts` | Use shared `effectiveMetaThreshold()` helper |
| `packages/gateway/src/pipeline.ts` | Use shared `computeMetaThreshold()` (aliased import) |
| `packages/gateway/test/helpers/idle-worker.ts` | Add new exports to mock |