### PR TITLE
fix: forward anthropic-beta header in cache-warmer to support beta-gated body fields

### DIFF
--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -1050,6 +1050,12 @@ export async function executeWarmup(
     ...authHeaders(cred),
   };
 
+  // Forward anthropic-beta from the last real request so beta-gated body
+  // fields (e.g. context_management) are accepted by the upstream API.
+  if (state.lastAnthropicBeta) {
+    headers["anthropic-beta"] = state.lastAnthropicBeta;
+  }
+
   // Re-sign the cch billing header. The cch hash covers the entire
   // serialized body, and we changed max_tokens/stream. The cch is
   // billing verification only — NOT part of the cache key.

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -1942,12 +1942,18 @@ function postResponse(
         }
       }
     }
-    // Track model/protocol for warmup profile resolution
+    // Track model/protocol/beta for warmup profile resolution
     sessionState.lastModel = req.model;
     sessionState.lastProtocol =
       req.protocol === "openai-responses"
         ? "openai-responses"
         : (resolveUpstreamRoute(req.model)?.protocol ?? "anthropic");
+    // Capture anthropic-beta so cache-warmer can forward it — beta-gated
+    // body fields (e.g. context_management) need the header to be accepted.
+    // Always update (including clearing) so a stale header isn't forwarded
+    // after the client stops sending it.
+    sessionState.lastAnthropicBeta =
+      req.rawHeaders["anthropic-beta"] || undefined;
 
     // Reset warming state if session was marked dead or had active warming.
     // Dead flag is cleared so the next break gets a fresh ROI analysis.

--- a/packages/gateway/src/translate/types.ts
+++ b/packages/gateway/src/translate/types.ts
@@ -296,6 +296,10 @@ export type SessionState = {
   lastModel?: string;
   /** Protocol from the last real request (for warming profile resolution). */
   lastProtocol?: "anthropic" | "openai" | "openai-responses";
+  /** anthropic-beta header from the last real request — forwarded by
+   *  cache-warmer so beta-gated body fields (e.g. context_management)
+   *  are accepted upstream. */
+  lastAnthropicBeta?: string;
 
   // --- Periodic persistence ---
 

--- a/packages/gateway/test/cache-warmer.test.ts
+++ b/packages/gateway/test/cache-warmer.test.ts
@@ -328,6 +328,22 @@ describe("prepareAnthropicWarmupBody", () => {
     expect(result.output_config).toBeUndefined();
   });
 
+  test("preserves beta-gated fields like context_management (not stripped)", () => {
+    const body = JSON.stringify({
+      model: "claude-sonnet-4-20250514",
+      max_tokens: 16384,
+      stream: true,
+      context_management: { type: "auto" },
+      messages: [{ role: "user", content: "hello" }],
+    });
+
+    const result = JSON.parse(prepareAnthropicWarmupBody(body));
+    // Beta-gated fields must NOT be stripped from the warmup body —
+    // executeWarmup() forwards the anthropic-beta header from
+    // state.lastAnthropicBeta so the API accepts them.
+    expect(result.context_management).toEqual({ type: "auto" });
+  });
+
   test("preserves all prompt content fields", () => {
     const body = JSON.stringify({
       model: "claude-sonnet-4-20250514",


### PR DESCRIPTION
## Summary

- Cache-warmer was getting 400 errors (`context_management: Extra inputs are not permitted`) because stored request bodies contained beta-gated fields but warmup requests were sent without the `anthropic-beta` header
- Store `lastAnthropicBeta` on `SessionState` from each real request and forward it in `executeWarmup()`, so any beta-gated body fields (current and future) are accepted upstream
- Header is cleared when absent to avoid forwarding a stale value after the client stops sending it
- Added regression test ensuring `prepareAnthropicWarmupBody` does not strip beta-gated fields like `context_management` from the warmup body

## Changes

| File | Change |
|---|---|
| `packages/gateway/src/translate/types.ts` | Add `lastAnthropicBeta?: string` to `SessionState` |
| `packages/gateway/src/pipeline.ts` | Capture/clear `anthropic-beta` header onto session state each turn |
| `packages/gateway/src/cache-warmer.ts` | Forward `state.lastAnthropicBeta` as header in `executeWarmup()` |
| `packages/gateway/test/cache-warmer.test.ts` | Regression test: beta-gated fields preserved in warmup body |

## Note

The broader `metadata` passthrough in `buildAnthropicRequest()` (spreads all unknown body fields back into the upstream request) remains unchanged. This PR scopes the fix to the cache-warmer header gap only. Non-beta unknown fields that Anthropic rejects would need a separate allowlist/blocklist approach.