### PR TITLE
fix: improve LTM preference injection — skip relevance scoring, dedicated budget, meaningful confidence

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -24,8 +24,10 @@ export const LoreConfig = z.object({
       distilled: z.number().min(0.05).max(0.5).default(0.25),
       raw: z.number().min(0.1).max(0.7).default(0.4),
       output: z.number().min(0.1).max(0.5).default(0.25),
-      /** Max fraction of usable context reserved for LTM system-prompt injection. Default: 0.05 (5%). */
+      /** Max fraction of usable context reserved for context-bound LTM system-prompt injection. Default: 0.05 (5%). */
       ltm: z.number().min(0.02).max(0.3).default(0.05),
+      /** Fraction of usable context for stable LTM (preferences). Independent of `ltm`. Default: 0.02 (2%). */
+      preferenceLtm: z.number().min(0.01).max(0.1).default(0.02),
       /** Per-turn cache-read cost target in dollars. Controls when layer 0 (full
        *  passthrough) escalates to layer 1 (compressed). The cap is derived as:
        *  maxLayer0Tokens = max(target / model.cost.cache.read, 40K).
@@ -41,7 +43,7 @@ export const LoreConfig = z.object({
       /** @deprecated Ignored. Tier-based bust-vs-continue replaces static cap. */
       maxContextTokens: z.number().min(0).optional(),
     })
-    .default({ distilled: 0.25, raw: 0.4, output: 0.25, ltm: 0.05, targetCacheReadCostPerTurn: 0.10 }),
+    .default({ distilled: 0.25, raw: 0.4, output: 0.25, ltm: 0.05, preferenceLtm: 0.02, targetCacheReadCostPerTurn: 0.10 }),
   /**
    * Cold-cache idle-resume handling.
    *

--- a/packages/core/src/curator.ts
+++ b/packages/core/src/curator.ts
@@ -24,6 +24,8 @@ export type CuratorOp =
       content: string;
       scope: "project" | "global";
       crossProject?: boolean;
+      /** Initial confidence (0.0–1.0). Controls injection priority for preferences. */
+      confidence?: number;
     }
   | { op: "update"; id: string; content?: string; confidence?: number }
   | { op: "delete"; id: string; reason: string };
@@ -88,6 +90,7 @@ export function applyOps(
         session: input.sessionID,
         scope: op.scope,
         crossProject: op.crossProject ?? true,
+        confidence: op.confidence,
       });
       idsToSync.push(id);
       created++;

--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -475,6 +475,13 @@ export function getLtmBudget(ltmFraction: number): number {
   return Math.floor(usable * ltmFraction);
 }
 
+/** Returns the token budget for stable LTM (preferences). Independent of context-bound LTM budget. */
+export function getPreferenceLtmBudget(prefFraction: number): number {
+  const overhead = calibratedOverhead ?? FIRST_TURN_OVERHEAD;
+  const usable = Math.max(0, contextLimit - outputReserved - overhead);
+  return Math.floor(usable * prefFraction);
+}
+
 // Called after each assistant message completes with real token usage data.
 // actualInput    = tokens.input + tokens.cache.read + tokens.cache.write
 // sessionID      = session that produced this response (for exact-tracking validity)

--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -476,11 +476,7 @@ export function getLtmBudget(ltmFraction: number): number {
 }
 
 /** Returns the token budget for stable LTM (preferences). Independent of context-bound LTM budget. */
-export function getPreferenceLtmBudget(prefFraction: number): number {
-  const overhead = calibratedOverhead ?? FIRST_TURN_OVERHEAD;
-  const usable = Math.max(0, contextLimit - outputReserved - overhead);
-  return Math.floor(usable * prefFraction);
-}
+export const getPreferenceLtmBudget = getLtmBudget;
 
 // Called after each assistant message completes with real token usage data.
 // actualInput    = tokens.input + tokens.cache.read + tokens.cache.write

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -104,6 +104,7 @@ export {
   setLtmTokens,
   getLtmTokens,
   getLtmBudget,
+  getPreferenceLtmBudget,
   setForceMinLayer,
   getLastTransformedCount,
   getLastTransformEstimate,

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -79,8 +79,15 @@ export function create(input: {
             .get(input.title)
     ) as { id: string } | null;
 
+    // Build the update payload — forward confidence when the caller provided one
+    // so the curator's scoring intent isn't silently dropped on dedup.
+    const dedupUpdate = {
+      content: input.content,
+      ...(input.confidence != null ? { confidence: input.confidence } : {}),
+    };
+
     if (existing) {
-      update(existing.id, { content: input.content });
+      update(existing.id, dedupUpdate);
       return existing.id;
     }
 
@@ -93,7 +100,7 @@ export function create(input: {
       .get(input.title) as { id: string } | null;
 
     if (crossExisting) {
-      update(crossExisting.id, { content: input.content });
+      update(crossExisting.id, dedupUpdate);
       return crossExisting.id;
     }
 
@@ -103,7 +110,7 @@ export function create(input: {
     // lock re-entry bug"). Placed after exact checks (cheaper checks first).
     const fuzzyMatch = findFuzzyDuplicate({ title: input.title, projectId: pid });
     if (fuzzyMatch) {
-      update(fuzzyMatch.id, { content: input.content });
+      update(fuzzyMatch.id, dedupUpdate);
       return fuzzyMatch.id;
     }
   }

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -44,6 +44,8 @@ export function create(input: {
   crossProject?: boolean;
   /** Explicit ID to use — for cross-machine import via agents-file. Defaults to a new UUIDv7. */
   id?: string;
+  /** Initial confidence (0.0–1.0). Default 1.0. Controls injection priority for preferences. */
+  confidence?: number;
 }): string {
   const pid =
     input.scope === "project" && input.projectPath
@@ -108,10 +110,13 @@ export function create(input: {
 
   const id = input.id ?? uuidv7();
   const now = Date.now();
+  const confidence = input.confidence != null
+    ? Math.max(0, Math.min(1, input.confidence))
+    : 1.0;
   db()
     .query(
       `INSERT INTO knowledge (id, project_id, category, title, content, source_session, cross_project, confidence, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, 1.0, ?, ?)`,
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     )
     .run(
       id,
@@ -121,6 +126,7 @@ export function create(input: {
       input.content,
       input.session ?? null,
       crossProject ? 1 : 0,
+      confidence,
       now,
       now,
     );
@@ -440,6 +446,31 @@ export async function forSession(
 
   if (!crossEntries.length && !projectEntries.length) return [];
 
+  // --- Preference-only fast path ---
+  // Preferences are unconditional user directives — relevance scoring harms them.
+  // Skip scoring; rank purely by confidence (set by curator or `lore data rerank`)
+  // then recency. Confidence carries real meaning now: 1.0 = unconditional
+  // directive, 0.9 = strong preference, 0.8 = moderate, 0.6 = mild.
+  const isPreferenceOnly = categoryFilter?.length === 1 && categoryFilter[0] === "preference";
+  if (isPreferenceOnly) {
+    const allPrefs = [...projectEntries, ...crossEntries];
+    allPrefs.sort((a, b) =>
+      a.confidence !== b.confidence ? b.confidence - a.confidence : b.updated_at - a.updated_at
+    );
+
+    const HEADER_OVERHEAD_TOKENS = 15;
+    let used = HEADER_OVERHEAD_TOKENS;
+    const result: KnowledgeEntry[] = [];
+    for (const entry of allPrefs) {
+      if (used >= maxTokens) break;
+      const cost = estimateTokens(entry.title + entry.content) + 10;
+      if (used + cost > maxTokens) continue;
+      result.push(entry);
+      used += cost;
+    }
+    return result;
+  }
+
   // --- 3. Build session context for relevance scoring ---
   let sessionContext = "";
   if (sessionID) {
@@ -649,6 +680,42 @@ export function crossProject(): KnowledgeEntry[] {
        ORDER BY confidence DESC, updated_at DESC`,
     )
     .all() as KnowledgeEntry[];
+}
+
+/**
+ * Re-score confidence on preference entries using directive-detection patterns.
+ * Only touches entries with confidence = 1.0 (legacy/unscored). Entries already
+ * scored by the curator (confidence < 1.0) are left untouched.
+ *
+ * @returns Count of entries updated.
+ */
+export function rerankPreferences(): number {
+  const prefs = db()
+    .query(`SELECT ${KNOWLEDGE_COLS} FROM knowledge WHERE category = 'preference' AND confidence = 1.0`)
+    .all() as KnowledgeEntry[];
+
+  // Strong unconditional directives
+  const STRONG_DIRECTIVE_RE = /\b(never|always|must not|must)\b/i;
+  // Explicit preference language
+  const EXPLICIT_PREF_RE = /\b(I (?:want|need|prefer|expect)|make sure to|don'?t forget)\b/i;
+
+  let updated = 0;
+  for (const entry of prefs) {
+    const text = entry.title + " " + entry.content;
+    let newConfidence: number;
+    if (STRONG_DIRECTIVE_RE.test(text)) {
+      newConfidence = 1.0; // Keep at max — unconditional directive
+    } else if (EXPLICIT_PREF_RE.test(text)) {
+      newConfidence = 0.9; // Strong but not absolute
+    } else {
+      newConfidence = 0.8; // No directive language detected — moderate
+    }
+    if (newConfidence !== entry.confidence) {
+      update(entry.id, { confidence: newConfidence });
+      updated++;
+    }
+  }
+  return updated;
 }
 
 // LIKE-based fallback for when FTS5 fails unexpectedly.

--- a/packages/core/src/prompt.ts
+++ b/packages/core/src/prompt.ts
@@ -266,6 +266,20 @@ crossProject flag:
 - Default is true — most useful knowledge is worth sharing across projects
 - Set crossProject to false for things that are meaningless outside this specific repo (e.g. a config path, a project-local naming convention that conflicts with your usual style)
 
+Confidence values (0.0–1.0) — determines injection priority when budget is tight:
+- 1.0: Unconditional directive — user used "NEVER", "ALWAYS", "from now on", or similarly
+  absolute language. These must always be respected regardless of context.
+- 0.9: Strong preference — explicit user preference ("I prefer", "I want", "make sure to",
+  "don't forget to"). Clear intent but not absolute.
+- 0.8: Moderate preference — inferred from repeated user behavior or gentle correction across
+  sessions. Not explicitly stated as a rule.
+- 0.6: Mild/contextual preference — may not apply universally. Observed once or context-dependent.
+- For non-preference categories (gotcha, pattern, architecture, decision), confidence reflects
+  how well-established the knowledge is: 1.0 = verified/confirmed, 0.8 = high confidence,
+  0.6 = probable but unverified.
+- Default to 1.0 for preferences with strong directive language, 0.8 for other preferences.
+- Always set confidence on create ops — it determines injection priority.
+
 Produce a JSON array of operations:
 [
   {
@@ -274,7 +288,8 @@ Produce a JSON array of operations:
     "title": "Short descriptive title",
     "content": "Concise knowledge entry — under 150 words",
     "scope": "project" | "global",
-    "crossProject": true
+    "crossProject": true,
+    "confidence": 1.0
   },
   {
     "op": "update",
@@ -322,7 +337,8 @@ IMPORTANT:
 4. Only create a new entry for genuinely distinct knowledge with no existing home.
 5. Keep all entries under 150 words. If an existing entry is too long, use an update op to trim it.
 6. Pay special attention to user instructions ("always do X", "never do Y", "make sure to X").
-   These are strong signals for "preference" entries with high confidence.`;
+   These are strong signals for "preference" entries with high confidence (1.0 for absolute
+   directives like "never"/"always", 0.9 for explicit preferences like "I prefer").`;
 }
 
 /**

--- a/packages/core/test/ltm.test.ts
+++ b/packages/core/test/ltm.test.ts
@@ -903,3 +903,321 @@ describe("ltm.pruneOversized", () => {
     expect(ltm.get(id)!.confidence).toBe(1.0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Preference-only fast path + confidence on create + rerankPreferences
+// ---------------------------------------------------------------------------
+
+describe("ltm.create confidence", () => {
+  test("accepts and stores explicit confidence", () => {
+    const id = ltm.create({
+      projectPath: "/test/ltm/confidence",
+      category: "preference",
+      title: "Explicit confidence test",
+      content: "I prefer dark mode",
+      scope: "project",
+      confidence: 0.9,
+    });
+    const entry = ltm.get(id);
+    expect(entry).not.toBeNull();
+    expect(entry!.confidence).toBe(0.9);
+  });
+
+  test("defaults confidence to 1.0 when omitted", () => {
+    const id = ltm.create({
+      projectPath: "/test/ltm/confidence",
+      category: "preference",
+      title: "Default confidence test",
+      content: "Some preference",
+      scope: "project",
+    });
+    const entry = ltm.get(id);
+    expect(entry).not.toBeNull();
+    expect(entry!.confidence).toBe(1.0);
+  });
+
+  test("clamps confidence to [0, 1]", () => {
+    const id1 = ltm.create({
+      projectPath: "/test/ltm/confidence",
+      category: "preference",
+      title: "Over confidence",
+      content: "Test over",
+      scope: "project",
+      confidence: 1.5,
+    });
+    expect(ltm.get(id1)!.confidence).toBe(1.0);
+
+    const id2 = ltm.create({
+      projectPath: "/test/ltm/confidence",
+      category: "preference",
+      title: "Under confidence",
+      content: "Test under",
+      scope: "project",
+      confidence: -0.5,
+    });
+    expect(ltm.get(id2)!.confidence).toBe(0);
+  });
+});
+
+describe("preference-only forSession fast path", () => {
+  const PROJ = "/test/ltm/pref-fastpath";
+  const SESSION = "pref-session";
+
+  beforeEach(() => {
+    const pid = ensureProject(PROJ);
+    db().query("DELETE FROM knowledge WHERE project_id = ?").run(pid);
+    // Clean up ALL global/cross-project preference entries to avoid leakage between tests
+    db()
+      .query("DELETE FROM knowledge WHERE category = 'preference' AND (project_id IS NULL OR cross_project = 1)")
+      .run();
+    db()
+      .query("DELETE FROM knowledge WHERE project_id IN (SELECT id FROM projects WHERE path LIKE '/test/%')")
+      .run();
+    db().query("DELETE FROM temporal_messages WHERE project_id = ?").run(pid);
+    db().query("DELETE FROM distillations WHERE project_id = ?").run(pid);
+  });
+
+  test("includes ALL cross-project preferences regardless of context", async () => {
+    // Create cross-project preferences with zero keyword overlap to session context
+    for (let i = 0; i < 5; i++) {
+      ltm.create({
+        category: "preference",
+        title: `pref-test global pref ${i}`,
+        content: `Unrelated preference content xyz ${i}`,
+        scope: "global",
+        crossProject: true,
+      });
+    }
+
+    // Seed session context about something completely unrelated
+    const pid = ensureProject(PROJ);
+    db()
+      .query(
+        "INSERT INTO temporal_messages (id, project_id, session_id, role, content, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+      )
+      .run(`tm-pref-${Date.now()}`, pid, SESSION, "user", "Let's build a React component for the dashboard", Date.now());
+
+    const result = await ltm.forSession(PROJ, SESSION, 10_000, {
+      categories: ["preference"],
+    });
+    expect(result.length).toBe(5);
+  });
+
+  test("has no count cap on first turn (no session context)", async () => {
+    // Create 15 cross-project preferences (more than NO_CONTEXT_FALLBACK_CAP=10)
+    for (let i = 0; i < 15; i++) {
+      ltm.create({
+        category: "preference",
+        title: `pref-test nocap pref ${i}`,
+        content: `Some preference content ${i}`,
+        scope: "global",
+        crossProject: true,
+      });
+    }
+
+    // No session context — brand new session
+    const result = await ltm.forSession(PROJ, "brand-new-pref-session", 10_000, {
+      categories: ["preference"],
+    });
+    // Should return all 15, not capped at 10
+    expect(result.length).toBe(15);
+  });
+
+  test("respects token budget", async () => {
+    // Create many large preferences
+    for (let i = 0; i < 20; i++) {
+      ltm.create({
+        category: "preference",
+        title: `pref-test budget pref ${i}`,
+        content: "A ".repeat(200), // ~50 tokens each
+        scope: "global",
+        crossProject: true,
+      });
+    }
+
+    // Very small budget — can only fit a few
+    const result = await ltm.forSession(PROJ, SESSION, 200, {
+      categories: ["preference"],
+    });
+    expect(result.length).toBeGreaterThan(0);
+    expect(result.length).toBeLessThan(20);
+  });
+
+  test("ranks by confidence DESC then recency", async () => {
+    // Create preferences with varying confidence
+    const id_low = ltm.create({
+      category: "preference",
+      title: "pref-test low conf",
+      content: "Low confidence preference",
+      scope: "global",
+      crossProject: true,
+      confidence: 0.6,
+    });
+    const id_mid = ltm.create({
+      category: "preference",
+      title: "pref-test mid conf",
+      content: "Mid confidence preference",
+      scope: "global",
+      crossProject: true,
+      confidence: 0.9,
+    });
+    const id_high = ltm.create({
+      category: "preference",
+      title: "pref-test high conf",
+      content: "High confidence preference",
+      scope: "global",
+      crossProject: true,
+      confidence: 1.0,
+    });
+
+    // All three should be returned with generous budget, ordered by confidence
+    const result = await ltm.forSession(PROJ, SESSION, 10_000, {
+      categories: ["preference"],
+    });
+
+    expect(result.length).toBe(3);
+    // Highest confidence should be first
+    expect(result[0].id).toBe(id_high);
+    expect(result[1].id).toBe(id_mid);
+    expect(result[2].id).toBe(id_low);
+  });
+
+  test("non-preference forSession still uses relevance scoring", async () => {
+    // Create a project-specific gotcha
+    ltm.create({
+      projectPath: PROJ,
+      category: "gotcha",
+      title: "pref-test SQLite WAL gotcha",
+      content: "WAL mode requires shared memory access",
+      scope: "project",
+      crossProject: false,
+    });
+
+    // Create a cross-project gotcha with zero keyword overlap
+    ltm.create({
+      category: "gotcha",
+      title: "pref-test Unrelated gotcha",
+      content: "Completely unrelated knowledge about quantum computing",
+      scope: "global",
+      crossProject: true,
+    });
+
+    const result = await ltm.forSession(PROJ, SESSION, 10_000, {
+      excludeCategories: ["preference"],
+    });
+
+    // Project gotcha should be included (safety net)
+    const projectGotcha = result.find((e) => e.title === "pref-test SQLite WAL gotcha");
+    expect(projectGotcha).toBeDefined();
+    // The non-preference path should still be using relevance scoring,
+    // not the preference fast path
+  });
+});
+
+describe("curator applyOps confidence", () => {
+  test("passes confidence from create op to ltm.create", async () => {
+    const { applyOps } = await import("../src/curator");
+    const result = applyOps(
+      [
+        {
+          op: "create",
+          category: "preference",
+          title: "applyOps confidence test",
+          content: "I prefer concise commit messages",
+          scope: "global",
+          crossProject: true,
+          confidence: 0.9,
+        },
+      ],
+      { projectPath: "/test/ltm/applyops", sessionID: "test-sess" },
+    );
+    expect(result.created).toBe(1);
+
+    // Find the created entry
+    const entries = ltm.all();
+    const entry = entries.find((e) => e.title === "applyOps confidence test");
+    expect(entry).toBeDefined();
+    expect(entry!.confidence).toBe(0.9);
+  });
+});
+
+describe("ltm.rerankPreferences", () => {
+  beforeEach(() => {
+    // Clean up ALL preference entries to avoid cross-test interference
+    // (rerankPreferences operates on all preferences in the DB)
+    db()
+      .query("DELETE FROM knowledge WHERE category = 'preference'")
+      .run();
+  });
+
+  test("sets 1.0 for strong directives, 0.9 for explicit prefs, 0.8 for others", () => {
+    const id_strong = ltm.create({
+      category: "preference",
+      title: "rerank-test strong",
+      content: "NEVER push directly to main without explicit permission",
+      scope: "global",
+      crossProject: true,
+    });
+    const id_explicit = ltm.create({
+      category: "preference",
+      title: "rerank-test explicit",
+      content: "I prefer tabs over spaces for indentation",
+      scope: "global",
+      crossProject: true,
+    });
+    const id_mild = ltm.create({
+      category: "preference",
+      title: "rerank-test mild",
+      content: "Use dark theme in editor when possible",
+      scope: "global",
+      crossProject: true,
+    });
+
+    // All start at confidence 1.0
+    expect(ltm.get(id_strong)!.confidence).toBe(1.0);
+    expect(ltm.get(id_explicit)!.confidence).toBe(1.0);
+    expect(ltm.get(id_mild)!.confidence).toBe(1.0);
+
+    const updated = ltm.rerankPreferences();
+    expect(updated).toBe(2); // strong stays at 1.0, only explicit and mild change
+
+    expect(ltm.get(id_strong)!.confidence).toBe(1.0);
+    expect(ltm.get(id_explicit)!.confidence).toBe(0.9);
+    expect(ltm.get(id_mild)!.confidence).toBe(0.8);
+  });
+
+  test("skips entries already scored by curator (confidence < 1.0)", () => {
+    const id = ltm.create({
+      category: "preference",
+      title: "rerank-test already-scored",
+      content: "Some preference without directive language",
+      scope: "global",
+      crossProject: true,
+      confidence: 0.6,
+    });
+
+    const updated = ltm.rerankPreferences();
+    // Should not touch this entry — its confidence is already < 1.0
+    expect(ltm.get(id)!.confidence).toBe(0.6);
+  });
+
+  test("detects various directive patterns", () => {
+    const ids = [
+      ltm.create({ category: "preference", title: "rerank-test d1", content: "Always use TypeScript strict mode", scope: "global" }),
+      ltm.create({ category: "preference", title: "rerank-test d2", content: "You must not skip tests", scope: "global" }),
+      ltm.create({ category: "preference", title: "rerank-test d3", content: "Make sure to run linting before commits", scope: "global" }),
+      ltm.create({ category: "preference", title: "rerank-test d4", content: "Don't forget to update changelog", scope: "global" }),
+    ];
+
+    ltm.rerankPreferences();
+
+    // "Always" → strong directive → 1.0
+    expect(ltm.get(ids[0])!.confidence).toBe(1.0);
+    // "must not" → strong directive → 1.0
+    expect(ltm.get(ids[1])!.confidence).toBe(1.0);
+    // "Make sure to" → explicit pref → 0.9
+    expect(ltm.get(ids[2])!.confidence).toBe(0.9);
+    // "Don't forget" → explicit pref → 0.9
+    expect(ltm.get(ids[3])!.confidence).toBe(0.9);
+  });
+});

--- a/packages/gateway/src/cli/data.ts
+++ b/packages/gateway/src/cli/data.ts
@@ -662,6 +662,13 @@ async function cmdRecover(
     }
   }
   console.log(`\nTotal: ${totalImported} entries recovered across ${results.length} project(s).`);
+
+  // Re-rank recovered preference entries so they get proper confidence values
+  const { ltm } = await import("@loreai/core");
+  const reranked = ltm.rerankPreferences();
+  if (reranked > 0) {
+    console.log(`Re-ranked ${reranked} preference entries by directive strength.`);
+  }
 }
 
 async function cmdMerge(
@@ -1081,6 +1088,23 @@ async function cmdDedupInteractive(
       ltm.saveCalibratedThreshold(pid, newThreshold, count);
       console.log(`Threshold calibrated to ${newThreshold.toFixed(3)} (from ${count} feedback pairs).`);
     }
+  }
+}
+
+async function cmdRerank(): Promise<void> {
+  const remote = getRemoteUrl();
+  if (remote) {
+    console.error("Error: rerank is not supported in remote mode (requires local DB access).");
+    process.exit(1);
+  }
+
+  const { ltm } = await import("@loreai/core");
+  console.log("Re-ranking preference entries by directive strength...");
+  const updated = ltm.rerankPreferences();
+  if (updated === 0) {
+    console.log("All preference entries are already ranked.");
+  } else {
+    console.log(`Done — ${updated} preference entries re-ranked.`);
   }
 }
 
@@ -1567,6 +1591,7 @@ Subcommands:
   recover               Re-import knowledge from .lore.md / AGENTS.md files
   dedup                 Find and remove duplicate knowledge entries (all projects)
   reindex               Rebuild embedding vectors (after model/config change)
+  rerank                Re-score preference confidence by directive strength
 
 Options:
   --project <path>      Target project directory (default: current directory)
@@ -1600,6 +1625,7 @@ Examples:
   lore data dedup --interactive            # accept/reject each cluster interactively
   lore data dedup --project /path/to/project
   lore data reindex                        # rebuild all embedding vectors
+  lore data rerank                         # re-score preference confidence
 `.trimStart();
 
 export async function commandData(
@@ -1633,6 +1659,9 @@ export async function commandData(
       break;
     case "reindex":
       await cmdReindex(values);
+      break;
+    case "rerank":
+      await cmdRerank();
       break;
     case "help":
     case undefined:

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -2607,7 +2607,7 @@ async function handleConversationTurn(
               title: e.title,
               content: e.content,
             })),
-            ltmBudget,
+            prefBudget,
           );
           if (formatted) {
             const tokenCount = Math.ceil(formatted.length / 3);

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -25,6 +25,7 @@ import {
   setModelLimits,
   setLtmTokens,
   getLtmBudget,
+  getPreferenceLtmBudget,
   setMaxLayer0Tokens,
   computeLayer0Cap,
   setCachePricing,
@@ -2584,6 +2585,7 @@ async function handleConversationTurn(
     try {
       const ltmFraction = cfg.budget.ltm;
       const ltmBudget = getLtmBudget(ltmFraction);
+      const prefBudget = getPreferenceLtmBudget(cfg.budget.preferenceLtm);
       const isFirstTurn = sessionID != null && !temporal.hasMessages(projectPath, sessionID);
       const contextHint = lastUserTextTrimmed(req);
 
@@ -2591,9 +2593,10 @@ async function handleConversationTurn(
       // Computed once per session and pinned for ≥1h. NOT invalidated by
       // curation — even if a preference changes, we keep the cached version
       // so the Anthropic 1h prompt cache prefix stays warm.
+      // Uses a dedicated budget independent of context-bound LTM.
       let stable = stableLtmCache.get(sessionID);
       if (!stable) {
-        const prefEntries = await ltm.forSession(projectPath, sessionID, ltmBudget, {
+        const prefEntries = await ltm.forSession(projectPath, sessionID, prefBudget, {
           categories: ["preference"],
           ...(contextHint ? { contextHint } : {}),
         });
@@ -2622,13 +2625,8 @@ async function handleConversationTurn(
         let cached = ltmSessionCache.get(sessionID);
 
         if (!cached) {
-          // Reserve budget for stable LTM already injected in system[1].
-          // Guarantee at least 50% of the total budget for context-bound
-          // entries — preferences are useful but gotchas/patterns are more
-          // critical for correctness during active work.
-          const stableTokens = stable?.tokenCount ?? 0;
-          const minContextBudget = Math.floor(ltmBudget * 0.5);
-          const contextBudget = Math.max(minContextBudget, ltmBudget - stableTokens);
+          // Full context-bound budget — preferences have their own dedicated budget.
+          const contextBudget = ltmBudget;
           // Exclude preferences — they're already in system[1]
           const contextEntries = await ltm.forSession(projectPath, sessionID, contextBudget, {
             excludeCategories: ["preference"],
@@ -2733,9 +2731,9 @@ async function handleConversationTurn(
     try {
       const ltmFraction = cfg.budget.ltm;
       const ltmBudget = getLtmBudget(ltmFraction);
+      // Full context-bound budget — preferences have their own dedicated budget.
+      const contextBudget = ltmBudget;
       const stableTokens = stableLtmCache.get(sessionID)?.tokenCount ?? 0;
-      const minContextBudget = Math.floor(ltmBudget * 0.5);
-      const contextBudget = Math.max(minContextBudget, ltmBudget - stableTokens);
       const contextHint = lastUserTextTrimmed(req);
       const contextEntries = await ltm.forSession(projectPath, sessionID, contextBudget, {
         excludeCategories: ["preference"],

--- a/packages/gateway/test/worker-model.test.ts
+++ b/packages/gateway/test/worker-model.test.ts
@@ -349,6 +349,7 @@ describe("resetWorkerModelState", () => {
 
   beforeEach(() => {
     originalFetch = globalThis.fetch;
+    resetWorkerModelState();
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary

- **Preference-only fast path** in `forSession()`: skips FTS5/vector relevance scoring for preferences (which are unconditional user directives, not contextual knowledge). Sorts by `confidence DESC, updated_at DESC` with no count cap — fixes cross-project preferences being silently dropped.
- **Dedicated 2% preference budget** independent of the 5% context-bound LTM budget, so preferences no longer compete with gotchas/patterns for token space.
- **Meaningful confidence on create**: `ltm.create()` and `CuratorOp` create ops now accept `confidence`. Curator prompt updated with explicit semantics (1.0=unconditional directive, 0.9=strong preference, 0.8=moderate, 0.6=mild).
- **`lore data rerank`** CLI command to re-score legacy preference entries by directive-detection patterns. Also auto-runs after `lore data recover`.

## Problem

Most user preferences were not injected into sessions because:
1. Cross-project preferences had no safety net in `forSession()` and were dropped when they scored 0 on relevance (e.g., "never push to main" has zero FTS5 overlap with a React session)
2. `NO_CONTEXT_FALLBACK_CAP=10` capped first-turn preferences
3. Preferences competed with context-bound entries for the same 5% budget
4. `confidence` was always hardcoded to 1.0, making it useless for ranking

## Files Changed

| File | Change |
|---|---|
| `packages/core/src/ltm.ts` | Preference fast path, `confidence` param on `create()`, `rerankPreferences()` |
| `packages/core/src/curator.ts` | `confidence` on `CuratorOp` create type, wired through `applyOps` |
| `packages/core/src/prompt.ts` | Curator prompt with confidence semantics |
| `packages/core/src/config.ts` | New `preferenceLtm` budget field (default 0.02) |
| `packages/core/src/gradient.ts` | `getPreferenceLtmBudget()` function |
| `packages/core/src/index.ts` | Export new function |
| `packages/gateway/src/pipeline.ts` | Dedicated preference budget, simplified context-bound budget |
| `packages/gateway/src/cli/data.ts` | `lore data rerank` command, auto-rerank after recover |
| `packages/core/test/ltm.test.ts` | 11 new tests covering fast path, confidence, and reranking |

## Testing

- 1553 tests pass, 0 failures
- All 4 packages typecheck clean
- After deploying, run `lore data rerank` to fix existing preference entries