### PR TITLE
feat: display subagent sessions as collapsible tree with cost roll-up

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -564,6 +564,17 @@ const MIGRATIONS: string[] = [
   CREATE INDEX IF NOT EXISTS idx_dedup_feedback_project
     ON dedup_feedback(project_id);
   `,
+  `
+  -- Version 26: Persist sub-agent parent–child session relationships.
+  -- parent_session_id: Lore internal session ID of the parent session
+  -- (resolved from the x-parent-session-id header at detection time).
+  -- NULL for root (non-sub-agent) sessions.
+  -- is_subagent: boolean flag (1 = sub-agent) so the flag survives
+  -- gateway restarts without requiring the header again.
+  ALTER TABLE session_state ADD COLUMN parent_session_id TEXT;
+  ALTER TABLE session_state ADD COLUMN is_subagent INTEGER NOT NULL DEFAULT 0;
+  CREATE INDEX IF NOT EXISTS idx_session_state_parent ON session_state(parent_session_id);
+  `,
 ];
 
 /** Return the resolved path of the SQLite database file. */
@@ -1194,6 +1205,9 @@ export type SessionTrackingState = {
   lastKnownInput?: number;
   lastTurnAt?: number;
   lastBustAt?: number;
+  // v26: sub-agent parent–child relationships
+  parentSessionId?: string | null;
+  isSubagent?: boolean;
 };
 
 /**
@@ -1297,6 +1311,15 @@ export function saveSessionTracking(sessionID: string, state: SessionTrackingSta
     sets.push("last_bust_at = ?");
     vals.push(state.lastBustAt);
   }
+  // v26: sub-agent parent–child relationships
+  if (state.parentSessionId !== undefined) {
+    sets.push("parent_session_id = ?");
+    vals.push(state.parentSessionId);
+  }
+  if (state.isSubagent !== undefined) {
+    sets.push("is_subagent = ?");
+    vals.push(state.isSubagent ? 1 : 0);
+  }
 
   // Update only the specified columns
   db()
@@ -1331,6 +1354,9 @@ export type LoadedSessionTracking = {
   lastKnownInput: number;
   lastTurnAt: number;
   lastBustAt: number;
+  // v26: sub-agent parent–child relationships
+  parentSessionId: string | null;
+  isSubagent: boolean;
 };
 
 /**
@@ -1345,7 +1371,8 @@ export function loadSessionTracking(sessionID: string): LoadedSessionTracking | 
               fingerprint, header_session_id, header_name,
               resolved_conversation_ttl, warmup_state,
               dynamic_context_cap, bust_rate_ema, inter_bust_interval_ema,
-              last_layer, last_known_input, last_turn_at, last_bust_at
+              last_layer, last_known_input, last_turn_at, last_bust_at,
+              parent_session_id, is_subagent
        FROM session_state WHERE session_id = ?`,
     )
     .get(sessionID) as {
@@ -1369,6 +1396,8 @@ export function loadSessionTracking(sessionID: string): LoadedSessionTracking | 
       last_known_input: number;
       last_turn_at: number;
       last_bust_at: number;
+      parent_session_id: string | null;
+      is_subagent: number;
     } | null;
   if (!row) return null;
   return {
@@ -1392,6 +1421,8 @@ export function loadSessionTracking(sessionID: string): LoadedSessionTracking | 
     lastKnownInput: row.last_known_input,
     lastTurnAt: row.last_turn_at,
     lastBustAt: row.last_bust_at,
+    parentSessionId: row.parent_session_id,
+    isSubagent: row.is_subagent === 1,
   };
 }
 
@@ -1425,6 +1456,26 @@ export function loadHeaderSessionIndex(): Array<{
     headerSessionId: row.header_session_id,
     headerName: row.header_name,
   }));
+}
+
+/**
+ * Load parent→child session mappings from the DB.
+ * Returns a map: childSessionId → parentSessionId (Lore internal IDs).
+ * Used by the dashboard to build session trees.
+ */
+export function loadParentChildMap(): Map<string, string> {
+  const rows = db()
+    .query(
+      `SELECT session_id, parent_session_id
+       FROM session_state
+       WHERE parent_session_id IS NOT NULL`,
+    )
+    .all() as Array<{ session_id: string; parent_session_id: string }>;
+  const map = new Map<string, string>();
+  for (const row of rows) {
+    map.set(row.session_id, row.parent_session_id);
+  }
+  return map;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -78,6 +78,7 @@ export {
   saveSessionTracking,
   loadSessionTracking,
   loadHeaderSessionIndex,
+  loadParentChildMap,
   type SessionTrackingState,
   type LoadedSessionTracking,
   getKV,

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -23,7 +23,7 @@ describe("db", () => {
     const row = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(row.version).toBe(25);
+    expect(row.version).toBe(26);
   });
 
   test("distillation_fts virtual table exists", () => {

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -126,7 +126,7 @@ import { startIdleScheduler, buildIdleWorkHandler } from "./idle";
 import { getWorkerModel, resetWorkerModelState, fetchModelData, getModelEntrySync } from "./worker-model";
 import * as Sentry from "@sentry/bun";
 import { captureBillingPrefix, hasBillingHeader, resignBody } from "./cch";
-import { detectClientType } from "./session";
+import { detectClientType, KNOWN_SESSION_HEADERS } from "./session";
 import { analyzeCacheTurn, categorizeBust } from "./cache-analytics";
 import {
   recordGap,
@@ -828,6 +828,14 @@ function getOrCreateSession(
         state.warmup = JSON.parse(persisted.warmupState);
       } catch {
         log.warn(`corrupt warmup state for session ${sessionID.slice(0, 16)}, starting fresh`);
+      }
+    }
+
+    // Restore sub-agent parent–child relationship (v26)
+    if (persisted?.isSubagent) {
+      state.isSubagent = true;
+      if (persisted.parentSessionId) {
+        state.parentSessionId = persisted.parentSessionId;
       }
     }
 
@@ -2526,8 +2534,25 @@ async function handleConversationTurn(
 
   // Mark sub-agent sessions (x-parent-session-id present).
   // These get their own session but are flagged for cache warming exemption.
+  // Resolve the client-side parent ID to a Lore internal session ID via the
+  // headerSessionIndex (tries all known session header prefixes).
   if (!sessionState.isSubagent && req.rawHeaders["x-parent-session-id"]) {
     sessionState.isSubagent = true;
+    const parentClientId = req.rawHeaders["x-parent-session-id"];
+    let resolvedParent: string | undefined;
+    for (const hdr of KNOWN_SESSION_HEADERS) {
+      const candidate = headerSessionIndex.get(`${hdr}:${parentClientId}`);
+      if (candidate) {
+        resolvedParent = candidate;
+        break;
+      }
+    }
+    sessionState.parentSessionId = resolvedParent;
+    // Persist immediately — rare mutation (session identity tier)
+    saveSessionTracking(sessionID, {
+      isSubagent: true,
+      parentSessionId: resolvedParent ?? null,
+    });
   }
 
   // Bind auth credential to this session for background workers

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -126,7 +126,7 @@ import { startIdleScheduler, buildIdleWorkHandler } from "./idle";
 import { getWorkerModel, resetWorkerModelState, fetchModelData, getModelEntrySync } from "./worker-model";
 import * as Sentry from "@sentry/bun";
 import { captureBillingPrefix, hasBillingHeader, resignBody } from "./cch";
-import { detectClientType, KNOWN_SESSION_HEADERS } from "./session";
+import { detectClientType } from "./session";
 import { analyzeCacheTurn, categorizeBust } from "./cache-analytics";
 import {
   recordGap,
@@ -2535,24 +2535,40 @@ async function handleConversationTurn(
   // Mark sub-agent sessions (x-parent-session-id present).
   // These get their own session but are flagged for cache warming exemption.
   // Resolve the client-side parent ID to a Lore internal session ID via the
-  // headerSessionIndex (tries all known session header prefixes).
-  if (!sessionState.isSubagent && req.rawHeaders["x-parent-session-id"]) {
-    sessionState.isSubagent = true;
+  // headerSessionIndex (searches all indexed headers, including Tier 2 learned).
+  // Tier 3 (fingerprint-only) parents have no index entry — resolution will fail
+  // and a warning is logged.
+  {
     const parentClientId = req.rawHeaders["x-parent-session-id"];
-    let resolvedParent: string | undefined;
-    for (const hdr of KNOWN_SESSION_HEADERS) {
-      const candidate = headerSessionIndex.get(`${hdr}:${parentClientId}`);
-      if (candidate) {
-        resolvedParent = candidate;
-        break;
+    if (parentClientId && (!sessionState.isSubagent || !sessionState.parentSessionId)) {
+      if (!sessionState.isSubagent) {
+        sessionState.isSubagent = true;
+      }
+      // Search the full headerSessionIndex — covers Tier 1 (known) and Tier 2 (learned) headers.
+      let resolvedParent: string | undefined;
+      for (const [key, loreId] of headerSessionIndex) {
+        const colonIdx = key.indexOf(":");
+        if (colonIdx >= 0 && key.slice(colonIdx + 1) === parentClientId) {
+          resolvedParent = loreId;
+          break;
+        }
+      }
+      if (resolvedParent) {
+        sessionState.parentSessionId = resolvedParent;
+        saveSessionTracking(sessionID, {
+          isSubagent: true,
+          parentSessionId: resolvedParent,
+        });
+      } else if (!sessionState.parentSessionId) {
+        // Parent may use Tier 3 (fingerprint) identification, or hasn't made
+        // its first request yet. Persist isSubagent but leave parentSessionId
+        // null — subsequent requests will re-attempt resolution.
+        log.info(
+          `session ${sessionID.slice(0, 16)}: subagent parent resolution pending for client ID ${parentClientId.slice(0, 16)}`,
+        );
+        saveSessionTracking(sessionID, { isSubagent: true });
       }
     }
-    sessionState.parentSessionId = resolvedParent;
-    // Persist immediately — rare mutation (session identity tier)
-    saveSessionTracking(sessionID, {
-      isSubagent: true,
-      parentSessionId: resolvedParent ?? null,
-    });
   }
 
   // Bind auth credential to this session for background workers

--- a/packages/gateway/src/translate/types.ts
+++ b/packages/gateway/src/translate/types.ts
@@ -261,6 +261,11 @@ export type SessionState = {
    *  too short-lived (1-3 turns) for warming to be profitable. */
   isSubagent?: boolean;
 
+  /** Lore internal session ID of the parent session (resolved from the
+   *  `x-parent-session-id` header value via the headerSessionIndex).
+   *  NULL/undefined for root (non-sub-agent) sessions. */
+  parentSessionId?: string;
+
   // --- Tier 1/2 session header identification ---
 
   /** Header-based session ID value (Tier 1 known header or Tier 2 promoted learned header). */

--- a/packages/gateway/src/ui.ts
+++ b/packages/gateway/src/ui.ts
@@ -37,7 +37,7 @@ import {
   BLEND_PSEUDOCOUNT,
   type WarmingSnapshot,
 } from "./cache-warmer";
-import type { InterTurnHistogram } from "./translate/types";
+import type { InterTurnHistogram, SessionState } from "./translate/types";
 
 // ---------------------------------------------------------------------------
 // HTML template helpers
@@ -426,7 +426,7 @@ document.addEventListener("DOMContentLoaded",function(){
     var ts=Date.parse(s);
     return isNaN(ts)?Infinity:(Date.now()-ts)/60000;
   }
-  // Sorting
+  // Sorting — treats parent+child rows as a unit so tree adjacency is preserved.
   function sortTable(th,dir){
     var table=th.closest("table");
     var tbody=table.querySelector("tbody")||table;
@@ -434,8 +434,16 @@ document.addEventListener("DOMContentLoaded",function(){
     var type=th.dataset.sort;
     th.parentNode.querySelectorAll("th").forEach(function(h){h.classList.remove("asc","desc");});
     th.classList.add(dir);
-    var rows=Array.from(tbody.querySelectorAll("tr")).filter(function(r){return!r.querySelector("th");});
-    rows.sort(function(a,b){
+    var allRows=Array.from(tbody.querySelectorAll("tr")).filter(function(r){return!r.querySelector("th");});
+    // Separate root rows from child (subagent) rows
+    var roots=[];var childMap={};
+    allRows.forEach(function(r){
+      var p=r.dataset.parent;
+      if(p){if(!childMap[p])childMap[p]=[];childMap[p].push(r);}
+      else{roots.push(r);}
+    });
+    // Sort only root rows
+    roots.sort(function(a,b){
       var aT=(a.children[idx]||{textContent:""}).textContent.trim();
       var bT=(b.children[idx]||{textContent:""}).textContent.trim();
       var cmp=0;
@@ -444,7 +452,14 @@ document.addEventListener("DOMContentLoaded",function(){
       else{cmp=aT.localeCompare(bT,undefined,{sensitivity:"base"});}
       return dir==="asc"?cmp:-cmp;
     });
-    rows.forEach(function(r){tbody.appendChild(r);});
+    // Re-append: each root followed by its children (preserving tree adjacency)
+    roots.forEach(function(r){
+      tbody.appendChild(r);
+      // Find session ID from the toggle button or from children that reference this row
+      var btn=r.querySelector(".toggle-btn");
+      var sid=btn?btn.dataset.sessionId:null;
+      if(sid&&childMap[sid]){childMap[sid].forEach(function(c){tbody.appendChild(c);});}
+    });
     var tableId=table.dataset.tableId;
     if(tableId){
       try{localStorage.setItem("lore-sort:"+tableId,JSON.stringify({col:idx,dir:dir}));}
@@ -491,9 +506,10 @@ document.addEventListener("DOMContentLoaded",function(){
     var rows=document.querySelectorAll('tr[data-parent="'+sid+'"]');
     var expanding=rows.length>0&&!rows[0].classList.contains("expanded");
     rows.forEach(function(r){r.classList.toggle("expanded",expanding);});
-    btn.textContent=expanding?"\\u25BC":"\\u25B6";
+    btn.textContent=expanding?"\u25BC":"\u25B6";
   });
-  // Filtering
+  // Filtering — respects tree structure: matching a parent shows it (children stay
+  // collapsed), matching a child auto-shows the parent and expands the child.
   document.querySelectorAll(".table-filter input").forEach(function(input){
     var wrapper=input.closest(".table-filter");
     var table=wrapper.nextElementSibling;
@@ -502,13 +518,50 @@ document.addEventListener("DOMContentLoaded",function(){
     var allRows=Array.from(table.querySelectorAll("tr")).filter(function(r){return!r.querySelector("th");});
     input.addEventListener("input",function(){
       var q=input.value.toLowerCase();
+      if(!q){
+        // Reset: show all roots, hide all children (collapsed state)
+        allRows.forEach(function(r){
+          if(r.dataset.parent){r.style.display="";r.classList.remove("expanded");}
+          else{r.style.display="";}
+        });
+        // Reset toggle buttons
+        table.querySelectorAll(".toggle-btn").forEach(function(b){b.textContent="\u25B6";});
+        if(countEl)countEl.textContent="";
+        return;
+      }
+      // First pass: determine which rows match the query
+      var matchSet=new Set();
+      allRows.forEach(function(r){
+        if(r.textContent.toLowerCase().indexOf(q)!==-1)matchSet.add(r);
+      });
+      // Second pass: for matching children, also include their parent
+      var parentShowSet=new Set();
+      allRows.forEach(function(r){
+        if(r.dataset.parent&&matchSet.has(r)){parentShowSet.add(r.dataset.parent);}
+      });
+      // Third pass: apply visibility
       var shown=0;
       allRows.forEach(function(r){
-        var match=!q||r.textContent.toLowerCase().indexOf(q)!==-1;
-        r.style.display=match?"":"none";
-        if(match)shown++;
+        var isChild=!!r.dataset.parent;
+        if(isChild){
+          // Show child if it matches (and auto-expand)
+          var show=matchSet.has(r);
+          r.style.display=show?"":"none";
+          if(show){r.classList.add("expanded");shown++;}
+          else{r.classList.remove("expanded");}
+        }else{
+          // Show root if it matches OR if any of its children match
+          var btn=r.querySelector(".toggle-btn");
+          var sid=btn?btn.dataset.sessionId:null;
+          var show=matchSet.has(r)||(sid&&parentShowSet.has(sid));
+          r.style.display=show?"":"none";
+          if(show)shown++;
+          // Update toggle state if children were auto-expanded
+          if(btn&&sid&&parentShowSet.has(sid)){btn.textContent="\u25BC";}
+          else if(btn){btn.textContent="\u25B6";}
+        }
       });
-      if(countEl)countEl.textContent=q?shown+"/"+allRows.length:"";
+      if(countEl)countEl.textContent=shown+"/"+allRows.filter(function(r){return!r.dataset.parent;}).length;
     });
   });
 });
@@ -701,20 +754,21 @@ type LiveSessionRow = {
  */
 function buildLiveSessionRows(
   allCosts: ReadonlyMap<string, SessionCosts>,
-  activeSessions: ReadonlyMap<string, { projectPath?: string; isSubagent?: boolean; parentSessionId?: string }>,
+  activeSessions: ReadonlyMap<string, Pick<SessionState, "projectPath" | "isSubagent" | "parentSessionId">>,
   snapshots: ReadonlyMap<string, WarmingSnapshot>,
+  dbParentMap?: ReadonlyMap<string, string>,
 ): LiveSessionRow[] {
   // Universe of session IDs from both sources
   const allIds = new Set<string>([...allCosts.keys(), ...activeSessions.keys()]);
 
   // Merge parent-child info from live sessions and persisted DB state
-  const dbParentMap = loadParentChildMap();
+  if (!dbParentMap) dbParentMap = loadParentChildMap();
 
   const rowMap = new Map<string, LiveSessionRow>();
   for (const sid of allIds) {
     const costs = allCosts.get(sid) ?? null;
     const snap = snapshots.get(sid) ?? null;
-    const sess = activeSessions.get(sid) as { projectPath?: string; isSubagent?: boolean; parentSessionId?: string } | undefined;
+    const sess = activeSessions.get(sid);
 
     const projPath = sess?.projectPath ?? "";
     const projId = projPath ? lookupProjectId(projPath) : undefined;
@@ -757,22 +811,34 @@ function buildLiveSessionRows(
     });
   }
 
-  // Build tree: attach children to parents, roll up costs
+  // Build tree: attach children to parents
   for (const row of rowMap.values()) {
     if (row.parentSessionId) {
       const parent = rowMap.get(row.parentSessionId);
       if (parent) {
         parent.children.push(row);
-        parent.rolledUpCost += row.totalCost;
-        parent.rolledUpSavings += row.savings;
       }
     }
   }
 
-  // Return only root rows (those that aren't children of another row in the set)
-  return [...rowMap.values()].filter(
+  // Recursive roll-up: bottom-up so grandchildren costs propagate correctly
+  function rollUp(row: LiveSessionRow): void {
+    for (const child of row.children) {
+      rollUp(child);
+      row.rolledUpCost += child.rolledUpCost;
+      row.rolledUpSavings += child.rolledUpSavings;
+    }
+  }
+
+  // Identify roots and roll up
+  const roots = [...rowMap.values()].filter(
     (r) => !r.parentSessionId || !rowMap.has(r.parentSessionId),
   );
+  for (const root of roots) {
+    rollUp(root);
+  }
+
+  return roots;
 }
 
 /** Render a single session row (used for both root and child rows). */
@@ -864,13 +930,16 @@ function renderLiveSessionsTable(rows: LiveSessionRow[], emptyMessage?: string, 
       <th data-sort="num">Hits/Warmups</th>
     </tr>`;
 
-  for (const r of rows) {
-    // Root row
-    html += renderSessionRow(r);
-    // Child rows (hidden by default, revealed via toggle)
-    for (const child of r.children) {
-      html += renderSessionRow(child, { isChild: true, parentId: r.sessionId });
+  // Recursively render a row and all its descendants
+  function renderTree(row: LiveSessionRow, parentId?: string): void {
+    const isChild = parentId != null;
+    html += renderSessionRow(row, isChild ? { isChild: true, parentId } : undefined);
+    for (const child of row.children) {
+      renderTree(child, row.sessionId);
     }
+  }
+  for (const r of rows) {
+    renderTree(r);
   }
 
   html += `</table>`;
@@ -978,7 +1047,7 @@ function pageProject(projectId: string): string | null {
 
     // Build tree from flat session list
     type SessNode = (typeof sessions)[number] & {
-      children: typeof sessions;
+      children: SessNode[];
     };
     const sessNodeMap = new Map<string, SessNode>();
     for (const s of sessions) {
@@ -997,7 +1066,9 @@ function pageProject(projectId: string): string | null {
 
     body += `<table data-table-id="project-sessions">
       <tr><th>Session</th><th data-sort="num">Messages</th><th data-sort="num">Distilled</th><th data-sort="num">Distillations</th><th data-sort="date" data-default-sort="desc">Last Activity</th></tr>`;
-    for (const s of sessRoots) {
+
+    function renderProjSession(s: SessNode, parentSid?: string): void {
+      const isChild = parentSid != null;
       const hasChildren = s.children.length > 0;
       const toggle = hasChildren
         ? `<span class="toggle-btn" data-session-id="${esc(s.session_id)}">\u25B6</span>`
@@ -1005,23 +1076,23 @@ function pageProject(projectId: string): string | null {
       const childCount = hasChildren
         ? `<span class="subagent-count">(+${s.children.length})</span>`
         : "";
-      body += `<tr>
-        <td>${toggle}<a href="/ui/sessions/${esc(projectId)}/${esc(s.session_id)}">${esc(s.session_id.slice(0, 12))}</a>${childCount}</td>
+      const prefix = isChild ? `<span style="opacity:0.4">\u21B3</span> ` : "";
+      const trAttrs = isChild ? ` class="subagent-row" data-parent="${esc(parentSid!)}"` : "";
+      body += `<tr${trAttrs}>
+        <td>${toggle}${prefix}<a href="/ui/sessions/${esc(projectId)}/${esc(s.session_id)}">${esc(s.session_id.slice(0, 12))}</a>${childCount}</td>
         <td>${s.message_count}</td>
         <td>${s.distilled_count}</td>
         <td>${s.distillation_count}</td>
         <td>${timeAgo(s.last_message_at)}</td>
       </tr>`;
       for (const child of s.children) {
-        body += `<tr class="subagent-row" data-parent="${esc(s.session_id)}">
-          <td style="padding-left:1.8em"><span style="opacity:0.4">\u21B3</span> <a href="/ui/sessions/${esc(projectId)}/${esc(child.session_id)}">${esc(child.session_id.slice(0, 12))}</a></td>
-          <td>${child.message_count}</td>
-          <td>${child.distilled_count}</td>
-          <td>${child.distillation_count}</td>
-          <td>${timeAgo(child.last_message_at)}</td>
-        </tr>`;
+        renderProjSession(child, s.session_id);
       }
     }
+    for (const s of sessRoots) {
+      renderProjSession(s);
+    }
+
     body += `</table>`;
   } else {
     body += `<p class="empty">No sessions.</p>`;
@@ -1483,22 +1554,28 @@ function pageWarming(): string {
   // Build unified rows (shared with Costs page)
   const rows = buildLiveSessionRows(getAllSessionCosts(), activeSessions, snapshotMap);
 
-  // Aggregate stats from rows (consistent with table content)
+  // Aggregate stats from rows (consistent with table content).
+  // Walk roots + children to count all sessions and warming stats.
   let totalWarmups = 0;
   let totalHits = 0;
   let warmingNow = 0;
   let deadCount = 0;
-  for (const r of rows) {
-    if (!r.warmingSnap) continue;
-    totalWarmups += r.warmupCount;
-    totalHits += r.warmupHits;
-    if (r.warmingSnap.shouldWarmNow) warmingNow++;
-    if (r.warmingSnap.disabled) deadCount++;
+  let totalSessionCount = 0;
+  function accumulateStats(r: LiveSessionRow): void {
+    totalSessionCount++;
+    if (r.warmingSnap) {
+      totalWarmups += r.warmupCount;
+      totalHits += r.warmupHits;
+      if (r.warmingSnap.shouldWarmNow) warmingNow++;
+      if (r.warmingSnap.disabled) deadCount++;
+    }
+    for (const child of r.children) accumulateStats(child);
   }
+  for (const r of rows) accumulateStats(r);
 
   // Summary stat cards
   body += `<div class="stats">
-    <div class="stat"><div class="label">Live Sessions</div><div class="value">${rows.length}</div></div>
+    <div class="stat"><div class="label">Live Sessions</div><div class="value">${totalSessionCount}</div></div>
     <div class="stat"><div class="label">Warming Now</div><div class="value">${warmingNow}</div></div>
     <div class="stat"><div class="label">Dead</div><div class="value">${deadCount}</div></div>
     <div class="stat"><div class="label">Total Warmups</div><div class="value">${totalWarmups}</div></div>
@@ -1559,6 +1636,9 @@ function pageCosts(): string {
   ]);
 
   body += `<h1>Cost Intelligence</h1>`;
+
+  // Pre-fetch parent-child map once for both live and historical sections
+  const parentMap = loadParentChildMap();
 
   // --- Live session costs ---
   const allCosts = getAllSessionCosts();
@@ -1669,7 +1749,7 @@ function pageCosts(): string {
     }
     body += `<h3>Per Session</h3>`;
     body += renderLiveSessionsTable(
-      buildLiveSessionRows(allCosts, activeSessions, snapshotMap),
+      buildLiveSessionRows(allCosts, activeSessions, snapshotMap, parentMap),
       "No active sessions yet. Cost tracking begins when the first conversation turn is processed.",
       "costs-live-sessions",
     );
@@ -1711,11 +1791,11 @@ function pageCosts(): string {
     </div>`;
 
     // Per-session historical table (top 50) — with sub-agent tree grouping
-    const parentMap = loadParentChildMap();
+    // (parentMap already loaded above for the live table)
 
     // Build tree: group children under parents, roll up worker costs
     type HistRow = (typeof historical.sessions)[number] & {
-      children: typeof historical.sessions;
+      children: HistRow[];
       rolledUpWorkerCost: number;
     };
     const histRowMap = new Map<string, HistRow>();
@@ -1731,49 +1811,60 @@ function pageCosts(): string {
       const parent = histRowMap.get(parentId);
       if (child && parent) {
         parent.children.push(child);
-        parent.rolledUpWorkerCost += child.rolledUpWorkerCost;
+      }
+    }
+    // Recursive roll-up (bottom-up)
+    function histRollUp(row: HistRow): void {
+      for (const child of row.children) {
+        histRollUp(child);
+        row.rolledUpWorkerCost += child.rolledUpWorkerCost;
       }
     }
     // Root rows: not a child of any known parent in the set
     const histRoots = [...histRowMap.values()].filter(
       (r) => !parentMap.has(r.sessionId) || !histRowMap.has(parentMap.get(r.sessionId)!),
     );
+    for (const root of histRoots) histRollUp(root);
+
     const displayed = histRoots.slice(0, 50);
     body += `<h3>Per Session (top ${displayed.length} by recency)</h3>
     <div class="table-filter"><input type="text" placeholder="Filter sessions\u2026"><span class="count"></span></div>
     <table data-table-id="costs-historical-sessions">
       <tr><th data-sort="text">Project</th><th>Session</th><th data-sort="num">Messages</th><th data-sort="text">Model</th><th data-sort="num">Worker Cost</th><th data-sort="num">Avoided Compactions</th><th data-sort="date" data-default-sort="desc">Last Active</th></tr>`;
-    for (const s of displayed) {
+
+    // Recursive rendering for historical rows
+    function renderHistRow(s: HistRow, parentSid?: string): void {
+      const isChild = parentSid != null;
       const hasChildren = s.children.length > 0;
-      const toggle = hasChildren
+      const toggle = hasChildren && !isChild
+        ? `<span class="toggle-btn" data-session-id="${esc(s.sessionId)}">\u25B6</span>`
+        : hasChildren
         ? `<span class="toggle-btn" data-session-id="${esc(s.sessionId)}">\u25B6</span>`
         : "";
       const childCount = hasChildren
         ? `<span class="subagent-count">(+${s.children.length})</span>`
         : "";
-      body += `<tr>
+      const prefix = isChild ? `<span style="opacity:0.4">\u21B3</span> ` : "";
+      const trAttrs = isChild ? ` class="subagent-row" data-parent="${esc(parentSid!)}"` : "";
+      const displayCost = hasChildren ? s.rolledUpWorkerCost : (s.persisted?.workerCost ?? s.distillationCost);
+
+      body += `<tr${trAttrs}>
         <td>${toggle}<a href="/ui/projects/${esc(s.projectId)}">${esc(s.projectName ?? "(unnamed)")}</a></td>
-        <td><a href="/ui/sessions/${esc(s.projectId)}/${esc(s.sessionId)}"><code>${esc(s.sessionId.slice(0, 12))}</code></a>${childCount}</td>
+        <td>${prefix}<a href="/ui/sessions/${esc(s.projectId)}/${esc(s.sessionId)}"><code>${esc(s.sessionId.slice(0, 12))}</code></a>${childCount}</td>
         <td>${s.messageCount}</td>
         <td style="font-size:0.85em">${esc(s.model.replace("claude-", "").slice(0, 20))}</td>
-        <td>${formatUSD(s.rolledUpWorkerCost)}</td>
+        <td>${formatUSD(displayCost)}</td>
         <td>${s.avoidedCompactions > 0 ? `${s.avoidedCompactions} (${formatUSD(s.avoidedCompactionCost)})` : "-"}</td>
         <td>${timeAgo(s.lastMessage)}</td>
       </tr>`;
-      // Sub-agent child rows (collapsed by default)
       for (const child of s.children) {
-        const childWorkerCost = child.persisted?.workerCost ?? child.distillationCost;
-        body += `<tr class="subagent-row" data-parent="${esc(s.sessionId)}">
-          <td><a href="/ui/projects/${esc(child.projectId)}">${esc(child.projectName ?? "(unnamed)")}</a></td>
-          <td><span style="opacity:0.4">\u21B3</span> <a href="/ui/sessions/${esc(child.projectId)}/${esc(child.sessionId)}"><code>${esc(child.sessionId.slice(0, 12))}</code></a></td>
-          <td>${child.messageCount}</td>
-          <td style="font-size:0.85em">${esc(child.model.replace("claude-", "").slice(0, 20))}</td>
-          <td>${formatUSD(childWorkerCost)}</td>
-          <td>${child.avoidedCompactions > 0 ? `${child.avoidedCompactions} (${formatUSD(child.avoidedCompactionCost)})` : "-"}</td>
-          <td>${timeAgo(child.lastMessage)}</td>
-        </tr>`;
+        renderHistRow(child, s.sessionId);
       }
     }
+    for (const s of displayed) {
+      renderHistRow(s);
+    }
+
     body += `</table>`;
     if (histRoots.length > 50) {
       body += `<p style="color:var(--fg3);font-size:0.85em">Showing 50 of ${histRoots.length} sessions.</p>`;

--- a/packages/gateway/src/ui.ts
+++ b/packages/gateway/src/ui.ts
@@ -15,6 +15,7 @@ import {
   projectName,
   projectId as lookupProjectId,
   renderMarkdown,
+  loadParentChildMap,
   type TaggedResult,
 } from "@loreai/core";
 import {
@@ -376,6 +377,13 @@ details.warming[open] summary { margin-bottom: 8px; }
   .badge-forced { background: #3b0764; color: #d8b4fe; }
   .badge-disabled { background: var(--bg3); color: var(--fg3); }
 }
+/* --- Subagent tree rows --- */
+.subagent-row { display: none; }
+.subagent-row.expanded { display: table-row; }
+.subagent-row td:nth-child(2) { padding-left: 1.8em; }
+.toggle-btn { cursor: pointer; user-select: none; font-size: 0.8em; margin-right: 4px; opacity: 0.6; }
+.toggle-btn:hover { opacity: 1; }
+.subagent-count { font-size: 0.75em; color: var(--fg3); margin-left: 4px; }
 `;
 
 function layout(title: string, body: string): string {
@@ -473,6 +481,17 @@ document.addEventListener("DOMContentLoaded",function(){
     if(defaultTh){
       sortTable(defaultTh,defaultTh.dataset.defaultSort);
     }
+  });
+  // Subagent tree toggle
+  document.addEventListener("click",function(e){
+    var btn=e.target.closest(".toggle-btn");
+    if(!btn)return;
+    var sid=btn.dataset.sessionId;
+    if(!sid)return;
+    var rows=document.querySelectorAll('tr[data-parent="'+sid+'"]');
+    var expanding=rows.length>0&&!rows[0].classList.contains("expanded");
+    rows.forEach(function(r){r.classList.toggle("expanded",expanding);});
+    btn.textContent=expanding?"\\u25BC":"\\u25B6";
   });
   // Filtering
   document.querySelectorAll(".table-filter input").forEach(function(input){
@@ -663,25 +682,39 @@ type LiveSessionRow = {
   idleMs: number;
   warmupCount: number;
   warmupHits: number;
+  // Sub-agent tree fields
+  parentSessionId: string | null;
+  isSubagent: boolean;
+  children: LiveSessionRow[];
+  /** Cost including children (populated during tree building). */
+  rolledUpCost: number;
+  /** Savings including children (populated during tree building). */
+  rolledUpSavings: number;
 };
 
 /**
  * Union-join cost tracker, active sessions, and warming snapshots into rows.
  * Accepts pre-fetched maps so callers avoid redundant data fetching.
+ *
+ * Returns a **tree**: root rows carry their children in `.children`.
+ * Subagent costs are rolled up into the parent row's `rolledUpCost`/`rolledUpSavings`.
  */
 function buildLiveSessionRows(
   allCosts: ReadonlyMap<string, SessionCosts>,
-  activeSessions: ReadonlyMap<string, { projectPath?: string }>,
+  activeSessions: ReadonlyMap<string, { projectPath?: string; isSubagent?: boolean; parentSessionId?: string }>,
   snapshots: ReadonlyMap<string, WarmingSnapshot>,
 ): LiveSessionRow[] {
   // Universe of session IDs from both sources
   const allIds = new Set<string>([...allCosts.keys(), ...activeSessions.keys()]);
 
-  const rows: LiveSessionRow[] = [];
+  // Merge parent-child info from live sessions and persisted DB state
+  const dbParentMap = loadParentChildMap();
+
+  const rowMap = new Map<string, LiveSessionRow>();
   for (const sid of allIds) {
     const costs = allCosts.get(sid) ?? null;
     const snap = snapshots.get(sid) ?? null;
-    const sess = activeSessions.get(sid);
+    const sess = activeSessions.get(sid) as { projectPath?: string; isSubagent?: boolean; parentSessionId?: string } | undefined;
 
     const projPath = sess?.projectPath ?? "";
     const projId = projPath ? lookupProjectId(projPath) : undefined;
@@ -695,24 +728,111 @@ function buildLiveSessionRows(
       cacheHitPct = totalInput > 0 ? (c.cacheReadTokens / totalInput) * 100 : 0;
     }
 
-    rows.push({
+    const ownCost = costs ? totalActualCost(costs) : 0;
+    const ownSavings = costs ? totalSavings(costs) : 0;
+
+    // Determine parent from live state first, fall back to persisted DB
+    const parentSid = sess?.parentSessionId ?? dbParentMap.get(sid) ?? null;
+    const isSub = sess?.isSubagent ?? (parentSid != null);
+
+    rowMap.set(sid, {
       sessionId: sid,
       projectId: projId ?? "",
       projectLabel: projLabel,
       turns: costs?.conversation.turns ?? snap?.messageCount ?? 0,
       hasCosts: costs !== null,
-      totalCost: costs ? totalActualCost(costs) : 0,
-      savings: costs ? totalSavings(costs) : 0,
+      totalCost: ownCost,
+      savings: ownSavings,
       cacheHitPct,
       pReturnsPct: snap ? snap.pReturns * 100 : 0,
       warmingSnap: snap,
       idleMs: snap?.idleMs ?? NaN,
       warmupCount: snap?.warmupCount ?? 0,
       warmupHits: snap?.warmupHits ?? 0,
+      parentSessionId: parentSid,
+      isSubagent: isSub,
+      children: [],
+      rolledUpCost: ownCost,
+      rolledUpSavings: ownSavings,
     });
   }
 
-  return rows;
+  // Build tree: attach children to parents, roll up costs
+  for (const row of rowMap.values()) {
+    if (row.parentSessionId) {
+      const parent = rowMap.get(row.parentSessionId);
+      if (parent) {
+        parent.children.push(row);
+        parent.rolledUpCost += row.totalCost;
+        parent.rolledUpSavings += row.savings;
+      }
+    }
+  }
+
+  // Return only root rows (those that aren't children of another row in the set)
+  return [...rowMap.values()].filter(
+    (r) => !r.parentSessionId || !rowMap.has(r.parentSessionId),
+  );
+}
+
+/** Render a single session row (used for both root and child rows). */
+function renderSessionRow(r: LiveSessionRow, opts?: { isChild?: boolean; parentId?: string }): string {
+  const isChild = opts?.isChild ?? false;
+  const parentId = opts?.parentId;
+
+  const projCell = r.projectId
+    ? `<a href="/ui/projects/${esc(r.projectId)}">${esc(r.projectLabel)}</a>`
+    : esc(r.projectLabel);
+
+  // For parent rows with children: show toggle + rolled-up cost
+  const hasChildren = r.children.length > 0;
+  const toggle = hasChildren
+    ? `<span class="toggle-btn" data-session-id="${esc(r.sessionId)}">\u25B6</span>`
+    : "";
+  const childCount = hasChildren
+    ? `<span class="subagent-count">(+${r.children.length})</span>`
+    : "";
+  const prefix = isChild ? `<span style="opacity:0.4">\u21B3</span> ` : "";
+
+  const sessLink = r.projectId
+    ? `<a href="/ui/sessions/${esc(r.projectId)}/${esc(r.sessionId)}"><code>${esc(r.sessionId.slice(0, 16))}</code></a>`
+    : `<code>${esc(r.sessionId.slice(0, 16))}</code>`;
+  const sessCell = `${prefix}${sessLink}${childCount}`;
+
+  // Use rolled-up totals for parent rows with children
+  const displayCost = hasChildren ? r.rolledUpCost : r.totalCost;
+  const displaySavings = hasChildren ? r.rolledUpSavings : r.savings;
+  const savingsColor = displaySavings >= 0 ? "#10b981" : "#e06c75";
+
+  // Status cell: badge + idle duration
+  let statusCell: string;
+  if (r.warmingSnap) {
+    const bdg = warmingStatusBadge(r.warmingSnap);
+    const idle = Number.isNaN(r.idleMs) ? "" : ` ${formatDuration(r.idleMs)}`;
+    statusCell = `${bdg}${idle}`;
+  } else {
+    statusCell = "-";
+  }
+
+  const hitsCell = r.warmingSnap
+    ? `${r.warmupHits}/${r.warmupCount}`
+    : "-";
+
+  const trAttrs = isChild
+    ? ` class="subagent-row" data-parent="${esc(parentId ?? "")}"`
+    : "";
+
+  return `<tr${trAttrs}>
+    <td>${toggle}${projCell}</td>
+    <td>${sessCell}</td>
+    <td>${r.turns}</td>
+    <td>${r.hasCosts ? formatUSD(displayCost) : "-"}</td>
+    <td>${r.hasCosts ? `<span style="color:${savingsColor}">${formatUSD(displaySavings)}</span>` : "-"}</td>
+    <td>${!Number.isNaN(r.cacheHitPct) ? r.cacheHitPct.toFixed(0) + "%" : "-"}</td>
+    <td>${r.warmingSnap ? r.pReturnsPct.toFixed(1) + "%" : "-"}</td>
+    <td>${statusCell}</td>
+    <td>${hitsCell}</td>
+  </tr>`;
 }
 
 /**
@@ -721,6 +841,9 @@ function buildLiveSessionRows(
  *
  * 9 columns: Project | Session | Turns | Total | Savings | Cache Hit |
  *            P(returns) | Status | Hits/Warmups
+ *
+ * Root rows with sub-agent children show a collapsible toggle (▶/▼).
+ * Children are hidden by default and shown on click.
  */
 function renderLiveSessionsTable(rows: LiveSessionRow[], emptyMessage?: string, tableId?: string): string {
   if (rows.length === 0) {
@@ -742,42 +865,12 @@ function renderLiveSessionsTable(rows: LiveSessionRow[], emptyMessage?: string, 
     </tr>`;
 
   for (const r of rows) {
-    const projCell = r.projectId
-      ? `<a href="/ui/projects/${esc(r.projectId)}">${esc(r.projectLabel)}</a>`
-      : esc(r.projectLabel);
-
-    const sessCell = r.projectId
-      ? `<a href="/ui/sessions/${esc(r.projectId)}/${esc(r.sessionId)}"><code>${esc(r.sessionId.slice(0, 16))}</code></a>`
-      : `<code>${esc(r.sessionId.slice(0, 16))}</code>`;
-
-    const savingsColor = r.savings >= 0 ? "#10b981" : "#e06c75";
-
-    // Status cell: badge + idle duration (e.g., "warming 3m" or "dead 15m")
-    let statusCell: string;
-    if (r.warmingSnap) {
-      const badge = warmingStatusBadge(r.warmingSnap);
-      const idle = Number.isNaN(r.idleMs) ? "" : ` ${formatDuration(r.idleMs)}`;
-      statusCell = `${badge}${idle}`;
-    } else {
-      statusCell = "-";
+    // Root row
+    html += renderSessionRow(r);
+    // Child rows (hidden by default, revealed via toggle)
+    for (const child of r.children) {
+      html += renderSessionRow(child, { isChild: true, parentId: r.sessionId });
     }
-
-    // Hits/Warmups cell: "3/10" or "-"
-    const hitsCell = r.warmingSnap
-      ? `${r.warmupHits}/${r.warmupCount}`
-      : "-";
-
-    html += `<tr>
-      <td>${projCell}</td>
-      <td>${sessCell}</td>
-      <td>${r.turns}</td>
-      <td>${r.hasCosts ? formatUSD(r.totalCost) : "-"}</td>
-      <td>${r.hasCosts ? `<span style="color:${savingsColor}">${formatUSD(r.savings)}</span>` : "-"}</td>
-      <td>${!Number.isNaN(r.cacheHitPct) ? r.cacheHitPct.toFixed(0) + "%" : "-"}</td>
-      <td>${r.warmingSnap ? r.pReturnsPct.toFixed(1) + "%" : "-"}</td>
-      <td>${statusCell}</td>
-      <td>${hitsCell}</td>
-    </tr>`;
   }
 
   html += `</table>`;
@@ -878,19 +971,56 @@ function pageProject(projectId: string): string | null {
     body += `<p class="empty">No knowledge entries.</p>`;
   }
 
-  // Sessions section
+  // Sessions section — with sub-agent tree grouping
   body += `<h2>Sessions (${sessions.length})</h2>`;
   if (sessions.length) {
+    const pMap = loadParentChildMap();
+
+    // Build tree from flat session list
+    type SessNode = (typeof sessions)[number] & {
+      children: typeof sessions;
+    };
+    const sessNodeMap = new Map<string, SessNode>();
+    for (const s of sessions) {
+      sessNodeMap.set(s.session_id, { ...s, children: [] });
+    }
+    for (const [childId, parentId] of pMap) {
+      const child = sessNodeMap.get(childId);
+      const parent = sessNodeMap.get(parentId);
+      if (child && parent) {
+        parent.children.push(child);
+      }
+    }
+    const sessRoots = [...sessNodeMap.values()].filter(
+      (r) => !pMap.has(r.session_id) || !sessNodeMap.has(pMap.get(r.session_id)!),
+    );
+
     body += `<table data-table-id="project-sessions">
       <tr><th>Session</th><th data-sort="num">Messages</th><th data-sort="num">Distilled</th><th data-sort="num">Distillations</th><th data-sort="date" data-default-sort="desc">Last Activity</th></tr>`;
-    for (const s of sessions) {
+    for (const s of sessRoots) {
+      const hasChildren = s.children.length > 0;
+      const toggle = hasChildren
+        ? `<span class="toggle-btn" data-session-id="${esc(s.session_id)}">\u25B6</span>`
+        : "";
+      const childCount = hasChildren
+        ? `<span class="subagent-count">(+${s.children.length})</span>`
+        : "";
       body += `<tr>
-        <td><a href="/ui/sessions/${esc(projectId)}/${esc(s.session_id)}">${esc(s.session_id.slice(0, 12))}</a></td>
+        <td>${toggle}<a href="/ui/sessions/${esc(projectId)}/${esc(s.session_id)}">${esc(s.session_id.slice(0, 12))}</a>${childCount}</td>
         <td>${s.message_count}</td>
         <td>${s.distilled_count}</td>
         <td>${s.distillation_count}</td>
         <td>${timeAgo(s.last_message_at)}</td>
       </tr>`;
+      for (const child of s.children) {
+        body += `<tr class="subagent-row" data-parent="${esc(s.session_id)}">
+          <td style="padding-left:1.8em"><span style="opacity:0.4">\u21B3</span> <a href="/ui/sessions/${esc(projectId)}/${esc(child.session_id)}">${esc(child.session_id.slice(0, 12))}</a></td>
+          <td>${child.message_count}</td>
+          <td>${child.distilled_count}</td>
+          <td>${child.distillation_count}</td>
+          <td>${timeAgo(child.last_message_at)}</td>
+        </tr>`;
+      }
     }
     body += `</table>`;
   } else {
@@ -1580,27 +1710,73 @@ function pageCosts(): string {
       </table>
     </div>`;
 
-    // Per-session historical table (top 50)
-    const displayed = historical.sessions.slice(0, 50);
+    // Per-session historical table (top 50) — with sub-agent tree grouping
+    const parentMap = loadParentChildMap();
+
+    // Build tree: group children under parents, roll up worker costs
+    type HistRow = (typeof historical.sessions)[number] & {
+      children: typeof historical.sessions;
+      rolledUpWorkerCost: number;
+    };
+    const histRowMap = new Map<string, HistRow>();
+    for (const s of historical.sessions) {
+      histRowMap.set(s.sessionId, {
+        ...s,
+        children: [],
+        rolledUpWorkerCost: s.persisted?.workerCost ?? s.distillationCost,
+      });
+    }
+    for (const [childId, parentId] of parentMap) {
+      const child = histRowMap.get(childId);
+      const parent = histRowMap.get(parentId);
+      if (child && parent) {
+        parent.children.push(child);
+        parent.rolledUpWorkerCost += child.rolledUpWorkerCost;
+      }
+    }
+    // Root rows: not a child of any known parent in the set
+    const histRoots = [...histRowMap.values()].filter(
+      (r) => !parentMap.has(r.sessionId) || !histRowMap.has(parentMap.get(r.sessionId)!),
+    );
+    const displayed = histRoots.slice(0, 50);
     body += `<h3>Per Session (top ${displayed.length} by recency)</h3>
     <div class="table-filter"><input type="text" placeholder="Filter sessions\u2026"><span class="count"></span></div>
     <table data-table-id="costs-historical-sessions">
       <tr><th data-sort="text">Project</th><th>Session</th><th data-sort="num">Messages</th><th data-sort="text">Model</th><th data-sort="num">Worker Cost</th><th data-sort="num">Avoided Compactions</th><th data-sort="date" data-default-sort="desc">Last Active</th></tr>`;
     for (const s of displayed) {
-      const sessionWorkerCost = s.persisted?.workerCost ?? s.distillationCost;
+      const hasChildren = s.children.length > 0;
+      const toggle = hasChildren
+        ? `<span class="toggle-btn" data-session-id="${esc(s.sessionId)}">\u25B6</span>`
+        : "";
+      const childCount = hasChildren
+        ? `<span class="subagent-count">(+${s.children.length})</span>`
+        : "";
       body += `<tr>
-        <td><a href="/ui/projects/${esc(s.projectId)}">${esc(s.projectName ?? "(unnamed)")}</a></td>
-        <td><a href="/ui/sessions/${esc(s.projectId)}/${esc(s.sessionId)}"><code>${esc(s.sessionId.slice(0, 12))}</code></a></td>
+        <td>${toggle}<a href="/ui/projects/${esc(s.projectId)}">${esc(s.projectName ?? "(unnamed)")}</a></td>
+        <td><a href="/ui/sessions/${esc(s.projectId)}/${esc(s.sessionId)}"><code>${esc(s.sessionId.slice(0, 12))}</code></a>${childCount}</td>
         <td>${s.messageCount}</td>
         <td style="font-size:0.85em">${esc(s.model.replace("claude-", "").slice(0, 20))}</td>
-        <td>${formatUSD(sessionWorkerCost)}</td>
+        <td>${formatUSD(s.rolledUpWorkerCost)}</td>
         <td>${s.avoidedCompactions > 0 ? `${s.avoidedCompactions} (${formatUSD(s.avoidedCompactionCost)})` : "-"}</td>
         <td>${timeAgo(s.lastMessage)}</td>
       </tr>`;
+      // Sub-agent child rows (collapsed by default)
+      for (const child of s.children) {
+        const childWorkerCost = child.persisted?.workerCost ?? child.distillationCost;
+        body += `<tr class="subagent-row" data-parent="${esc(s.sessionId)}">
+          <td><a href="/ui/projects/${esc(child.projectId)}">${esc(child.projectName ?? "(unnamed)")}</a></td>
+          <td><span style="opacity:0.4">\u21B3</span> <a href="/ui/sessions/${esc(child.projectId)}/${esc(child.sessionId)}"><code>${esc(child.sessionId.slice(0, 12))}</code></a></td>
+          <td>${child.messageCount}</td>
+          <td style="font-size:0.85em">${esc(child.model.replace("claude-", "").slice(0, 20))}</td>
+          <td>${formatUSD(childWorkerCost)}</td>
+          <td>${child.avoidedCompactions > 0 ? `${child.avoidedCompactions} (${formatUSD(child.avoidedCompactionCost)})` : "-"}</td>
+          <td>${timeAgo(child.lastMessage)}</td>
+        </tr>`;
+      }
     }
     body += `</table>`;
-    if (historical.sessions.length > 50) {
-      body += `<p style="color:var(--fg3);font-size:0.85em">Showing 50 of ${historical.sessions.length} sessions.</p>`;
+    if (histRoots.length > 50) {
+      body += `<p style="color:var(--fg3);font-size:0.85em">Showing 50 of ${histRoots.length} sessions.</p>`;
     }
   }
 


### PR DESCRIPTION
## Summary

- Persist parent-child session relationships via new DB migration (v26: `parent_session_id` + `is_subagent` columns on `session_state`)
- Resolve `x-parent-session-id` header value to Lore internal session ID via `headerSessionIndex` lookup at detection time
- Render subagent sessions as collapsible tree rows in **all** dashboard session tables (Cost Intelligence, warming, project detail)
- Parent rows show combined cost/savings (own + children) with expand/collapse toggle and `(+N subagents)` indicator
- Child rows hidden by default, shown with `↳` prefix and indentation on toggle click

## Files Changed

| File | Changes |
|------|---------|
| `packages/core/src/db.ts` | Migration v26, save/load for new fields, `loadParentChildMap()` query |
| `packages/core/src/index.ts` | Export `loadParentChildMap` |
| `packages/gateway/src/translate/types.ts` | Add `parentSessionId` to `SessionState` |
| `packages/gateway/src/pipeline.ts` | Resolve + persist parent ID, restore on restart |
| `packages/gateway/src/ui.ts` | Tree building, collapsible rendering, CSS, inline JS toggle |
| `packages/core/test/db.test.ts` | Update expected schema version 25 → 26 |

## How to Test

1. Start gateway with an agent that spawns subagents (e.g., OpenCode with explore/task tools)
2. Navigate to `/ui/costs` — subagent sessions should appear nested under their parent with a ▶ toggle
3. Click toggle to expand — child rows appear with `↳` prefix
4. Parent row "Total" column shows combined cost (own + children)
5. Verify same tree display on `/ui/warming` and `/ui/projects/:id` pages
6. Restart gateway — verify tree relationships survive restart