### PR TITLE
fix: stop attributing all turns after warmup as cache warming savings

### DIFF
--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -632,7 +632,7 @@ describe("db", () => {
 
   test("saveSessionTracking v24 cache warming round-trip", () => {
     const sid = `test-v24-warming-${crypto.randomUUID()}`;
-    const warmup = { lastWarmupAt: 1000, warmupCount: 3, warmupHits: 1, disabled: false, forceKeepWarm: true };
+    const warmup = { lastWarmupAt: 1000, warmupCount: 3, totalWarmups: 3, warmupHits: 1, disabled: false, forceKeepWarm: true };
     saveSessionTracking(sid, {
       resolvedConversationTTL: "1h",
       warmupState: JSON.stringify(warmup),
@@ -642,6 +642,7 @@ describe("db", () => {
     expect(loaded!.resolvedConversationTTL).toBe("1h");
     const parsed = JSON.parse(loaded!.warmupState!);
     expect(parsed.warmupCount).toBe(3);
+    expect(parsed.totalWarmups).toBe(3);
     expect(parsed.forceKeepWarm).toBe(true);
   });
 

--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -766,7 +766,7 @@ export function shouldWarm(
 function markDeadIfSurvivalLow(state: SessionState, survivalAtIdle: number): void {
   if (survivalAtIdle < DEAD_SESSION_THRESHOLD) {
     if (!state.warmup) {
-      state.warmup = { lastWarmupAt: 0, warmupCount: 0, warmupHits: 0, disabled: true };
+      state.warmup = { lastWarmupAt: 0, warmupCount: 0, totalWarmups: 0, warmupHits: 0, disabled: true };
     } else {
       state.warmup.disabled = true;
     }
@@ -792,6 +792,7 @@ export type WarmingSnapshot = {
   ttl: "5m" | "1h" | undefined;
   // Warmup state
   warmupCount: number;
+  totalWarmups: number;
   warmupHits: number;
   lastWarmupAt: number;
   disabled: boolean;
@@ -947,6 +948,7 @@ export function computeWarmingSnapshot(
     consecutiveTextOnlyTurns: textOnlyRuns,
     ttl: state.resolvedConversationTTL,
     warmupCount: cyclesSpent,
+    totalWarmups: state.warmup?.totalWarmups ?? 0,
     warmupHits: state.warmup?.warmupHits ?? 0,
     lastWarmupAt: state.warmup?.lastWarmupAt ?? 0,
     disabled: state.warmup?.disabled ?? false,
@@ -1147,10 +1149,11 @@ export async function executeWarmup(
 
     // Update session warmup state
     if (!state.warmup) {
-      state.warmup = { lastWarmupAt: 0, warmupCount: 0, warmupHits: 0, disabled: false };
+      state.warmup = { lastWarmupAt: 0, warmupCount: 0, totalWarmups: 0, warmupHits: 0, disabled: false };
     }
     state.warmup.lastWarmupAt = Date.now();
     state.warmup.warmupCount++;
+    state.warmup.totalWarmups = (state.warmup.totalWarmups ?? 0) + 1;
 
     // Check circuit breaker
     checkCircuitBreaker(result);

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -2061,10 +2061,13 @@ function postResponse(
     if (sessionState.lastRequestTime > 0) {
       let warmupHitThisTurn = false;
 
-      // Track warmup hit: user returned after we warmed the cache
+      // Track warmup hit: user returned after we warmed the cache.
+      // A warmup can only benefit the FIRST turn after it fires — clear
+      // lastWarmupAt unconditionally so subsequent turns are not attributed.
       if (sessionState.warmup?.lastWarmupAt) {
         const ttlMs = sessionState.resolvedConversationTTL === "1h" ? 3_600_000 : 300_000;
         const sinceWarmup = now - sessionState.warmup.lastWarmupAt;
+        sessionState.warmup.lastWarmupAt = 0;
         if (sinceWarmup < ttlMs) {
           warmupHitThisTurn = true;
           sessionState.warmup.warmupHits++;
@@ -3579,7 +3582,7 @@ function handleWarmupSlashCommand(
   // Update session warmup state
   if (state) {
     if (!state.warmup) {
-      state.warmup = { lastWarmupAt: 0, warmupCount: 0, warmupHits: 0, disabled: isDone };
+      state.warmup = { lastWarmupAt: 0, warmupCount: 0, totalWarmups: 0, warmupHits: 0, disabled: isDone };
     } else {
       state.warmup.disabled = isDone;
     }

--- a/packages/gateway/src/translate/types.ts
+++ b/packages/gateway/src/translate/types.ts
@@ -327,10 +327,12 @@ export type InterTurnHistogram = {
 
 /** Per-session cache warming state. */
 export type WarmupState = {
-  /** Timestamp (ms) of the last warmup ping sent. */
+  /** Timestamp (ms) of the last warmup ping sent. Cleared when consumed (user returns). */
   lastWarmupAt: number;
-  /** Total warmup pings sent in this session. */
+  /** Warmup pings sent in the CURRENT break period (reset on user return). Used for break-even cap. */
   warmupCount: number;
+  /** Lifetime total warmup pings sent across all break periods in this session. */
+  totalWarmups: number;
   /** Warmups followed by a user return within TTL (confirmed saves). */
   warmupHits: number;
   /** Session marked as dead — survival dropped below threshold. Resets on real request. */

--- a/packages/gateway/src/ui.ts
+++ b/packages/gateway/src/ui.ts
@@ -733,7 +733,7 @@ type LiveSessionRow = {
   pReturnsPct: number;
   warmingSnap: WarmingSnapshot | null;
   idleMs: number;
-  warmupCount: number;
+  totalWarmups: number;
   warmupHits: number;
   // Sub-agent tree fields
   parentSessionId: string | null;
@@ -801,7 +801,7 @@ function buildLiveSessionRows(
       pReturnsPct: snap ? snap.pReturns * 100 : 0,
       warmingSnap: snap,
       idleMs: snap?.idleMs ?? NaN,
-      warmupCount: snap?.warmupCount ?? 0,
+      totalWarmups: snap?.totalWarmups ?? 0,
       warmupHits: snap?.warmupHits ?? 0,
       parentSessionId: parentSid,
       isSubagent: isSub,
@@ -881,7 +881,7 @@ function renderSessionRow(r: LiveSessionRow, opts?: { isChild?: boolean; parentI
   }
 
   const hitsCell = r.warmingSnap
-    ? `${r.warmupHits}/${r.warmupCount}`
+    ? `${r.warmupHits}/${r.totalWarmups}`
     : "-";
 
   const trAttrs = isChild
@@ -1220,8 +1220,8 @@ function renderWarmingSection(sessionId: string): string {
 
   const snap = computeWarmingSnapshot(state);
   const hitRate =
-    snap.warmupCount > 0
-      ? `${snap.warmupHits}/${snap.warmupCount} (${((snap.warmupHits / snap.warmupCount) * 100).toFixed(0)}%)`
+    snap.totalWarmups > 0
+      ? `${snap.warmupHits}/${snap.totalWarmups} (${((snap.warmupHits / snap.totalWarmups) * 100).toFixed(0)}%)`
       : "0";
 
   let html = `<h2>Cache Warming</h2>`;
@@ -1229,7 +1229,7 @@ function renderWarmingSection(sessionId: string): string {
   // Stat cards
   html += `<div class="stats">
     <div class="stat"><div class="label">Status</div><div class="value">${warmingStatusBadge(snap)}</div></div>
-    <div class="stat"><div class="label">Warmups</div><div class="value">${snap.warmupCount}</div></div>
+    <div class="stat"><div class="label">Warmups</div><div class="value">${snap.totalWarmups}</div></div>
     <div class="stat"><div class="label">Hits</div><div class="value">${hitRate}</div></div>
     <div class="stat"><div class="label">P(returns)</div><div class="value">${(snap.pReturns * 100).toFixed(1)}%</div></div>
     <div class="stat"><div class="label">P(finished)</div><div class="value">${(snap.pSessionFinished * 100).toFixed(1)}%</div></div>
@@ -1564,7 +1564,7 @@ function pageWarming(): string {
   function accumulateStats(r: LiveSessionRow): void {
     totalSessionCount++;
     if (r.warmingSnap) {
-      totalWarmups += r.warmupCount;
+      totalWarmups += r.totalWarmups;
       totalHits += r.warmupHits;
       if (r.warmingSnap.shouldWarmNow) warmingNow++;
       if (r.warmingSnap.disabled) deadCount++;

--- a/packages/gateway/test/cache-warmer.test.ts
+++ b/packages/gateway/test/cache-warmer.test.ts
@@ -505,7 +505,7 @@ describe("shouldWarm", () => {
   test("returns false when session is marked dead", () => {
     const state = makeSessionState({
       lastRequestTime: Date.now() - 270_000,
-      warmup: { lastWarmupAt: 0, warmupCount: 0, warmupHits: 0, disabled: true },
+      warmup: { lastWarmupAt: 0, warmupCount: 0, totalWarmups: 0, warmupHits: 0, disabled: true },
       cacheAnalytics: {
         ...makeCacheAnalytics(),
         lastRequestBody: compressBody('{"test": true}'),
@@ -525,6 +525,7 @@ describe("shouldWarm", () => {
       warmup: {
         lastWarmupAt: now - 30_000, // warmed 30s ago
         warmupCount: 1,
+        totalWarmups: 1,
         warmupHits: 0,
         disabled: false,
       },
@@ -584,6 +585,7 @@ describe("shouldWarm", () => {
       warmup: {
         lastWarmupAt: 0,
         warmupCount: 0,
+        totalWarmups: 0,
         warmupHits: 0,
         disabled: false,
         forceKeepWarm: true,
@@ -677,6 +679,7 @@ describe("shouldWarm", () => {
       warmup: {
         lastWarmupAt: 0,
         warmupCount: 0,
+        totalWarmups: 0,
         warmupHits: 0,
         disabled: false,
         forceKeepWarm: true,
@@ -699,6 +702,7 @@ describe("shouldWarm", () => {
       warmup: {
         lastWarmupAt: now - 310_000, // last warmup 5m10s ago — previous window
         warmupCount: 2,
+        totalWarmups: 2,
         warmupHits: 0,
         disabled: false,
         forceKeepWarm: true,
@@ -726,6 +730,7 @@ describe("shouldWarm", () => {
       warmup: {
         lastWarmupAt: now - 260_000, // 4m20s ago — past tighter cooldown (255s) but within full TTL (300s)
         warmupCount: 1,
+        totalWarmups: 1,
         warmupHits: 0,
         disabled: false,
         forceKeepWarm: true,
@@ -753,6 +758,7 @@ describe("shouldWarm", () => {
       warmup: {
         lastWarmupAt: now - 260_000, // 4m20s ago — within full TTL cooldown
         warmupCount: 1,
+        totalWarmups: 1,
         warmupHits: 0,
         disabled: false,
         // no forceKeepWarm
@@ -782,6 +788,7 @@ describe("shouldWarm", () => {
       warmup: {
         lastWarmupAt: 0,
         warmupCount: 0,
+        totalWarmups: 0,
         warmupHits: 0,
         disabled: false,
         forceKeepWarm: true,
@@ -790,6 +797,7 @@ describe("shouldWarm", () => {
         ...makeCacheAnalytics(),
         lastRequestBody: compressBody('{"test": true}'),
       },
+      messageCount: 20,
     });
     const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
     const hist = createHistogram();
@@ -1092,6 +1100,7 @@ describe("shouldWarm continuation", () => {
       warmup: {
         lastWarmupAt: now - 310_000, // last warmup 5m10s ago — previous window
         warmupCount: 1,
+        totalWarmups: 1,
         warmupHits: 0,
         disabled: false,
       },
@@ -1121,6 +1130,7 @@ describe("shouldWarm continuation", () => {
       warmup: {
         lastWarmupAt: now - 310_000,
         warmupCount: maxCyc, // already at max
+        totalWarmups: maxCyc,
         warmupHits: 0,
         disabled: false,
       },
@@ -1144,6 +1154,7 @@ describe("shouldWarm continuation", () => {
       warmup: {
         lastWarmupAt: now - 310_000,
         warmupCount: 2,
+        totalWarmups: 2,
         warmupHits: 0,
         disabled: false,
       },
@@ -1182,6 +1193,7 @@ describe("shouldWarm /keep mode", () => {
       warmup: {
         lastWarmupAt: now - 270_000, // past cooldown
         warmupCount: maxCyc,
+        totalWarmups: maxCyc,
         warmupHits: 0,
         disabled: false,
         forceKeepWarm: true,
@@ -1206,6 +1218,7 @@ describe("shouldWarm /keep mode", () => {
       warmup: {
         lastWarmupAt: now - 270_000, // past cooldown
         warmupCount: 2,
+        totalWarmups: 2,
         warmupHits: 0,
         disabled: false,
         forceKeepWarm: true,


### PR DESCRIPTION
## Summary

Fixes wildly inflated "cache warming savings" numbers on the costs page. A single warmup ping could generate 30+ bogus hits and tens of dollars in phantom savings because `lastWarmupAt` was never cleared when the user returned.

## Changes

- **Critical fix**: Clear `lastWarmupAt` after consuming the warmup in pipeline.ts — makes warmup attribution one-shot (only the first turn after a warmup gets credit, not every subsequent turn within the TTL window)
- **Display fix**: Add `totalWarmups` lifetime counter to `WarmupState` so the "Hits/Warmups" column shows meaningful ratios instead of nonsensical ones like "38/0" (caused by `warmupCount` resetting per-break while `warmupHits` accumulates)
- Update `WarmingSnapshot`, `LiveSessionRow`, and all UI rendering to use `totalWarmups` for display

## Root Cause

`lastWarmupAt` was set when a warmup ping fired (cache-warmer.ts) but never cleared when the user returned. The hit-detection in pipeline.ts checked `sinceWarmup < ttlMs` — since `lastWarmupAt` persisted, every turn within the TTL window (up to 1h) had its entire `cacheReadTokens` attributed as warmup savings.