### PR TITLE
feat: rewrite README to align with new website messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,45 +2,82 @@
 
 > **Experimental** — Under active development. APIs, storage format, and behavior may change.
 
-Automatic memory for AI coding agents. Your AI forgets your project between sessions. Lore fixes that — no context files to write, no learnings to track, no sessions to carefully manage.
+**Stop re-explaining your project to your AI.** Your AI forgets decisions, loses file paths, and undoes its own work. Lore fixes this automatically — no context files to maintain, no workflow changes.
+
+Lore is a transparent LLM proxy that adds three-tier memory to any AI coding agent. Context management and long-term memory aren't separate problems — they're one continuous pipeline. Distillation feeds the gradient context manager, which feeds the knowledge curator, which feeds `.lore.md`, and with Lore Cloud *(coming soon)*, your team.
 
 Built on [Sanity's Nuum](https://www.sanity.io/blog/how-we-solved-the-agent-memory-problem) memory architecture and [Mastra's Observational Memory](https://mastra.ai/research/observational-memory) research. The core idea: coding agents need **distillation, not summarization** — preserving file paths, error messages, and exact decisions rather than narrative summaries that lose the details agents need to keep working.
 
-Lore is published as three packages, all sharing the same SQLite database at `~/.local/share/lore/lore.db`:
-
-| Package | For | Install |
-|---|---|---|
-| [`@loreai/opencode`](https://www.npmjs.com/package/@loreai/opencode) | [OpenCode](https://opencode.ai) plugin | Add to `opencode.json` `plugin` array |
-| [`@loreai/pi`](https://www.npmjs.com/package/@loreai/pi) | [Pi coding-agent](https://github.com/badlogic/pi-mono) extension | `pi install npm:@loreai/pi` |
-| [`@loreai/core`](https://www.npmjs.com/package/@loreai/core) | Shared memory engine | Dependency of the host packages above |
-
-The OpenCode plugin is also published as [`opencode-lore`](https://www.npmjs.com/package/opencode-lore) (legacy alias). Both names contain identical code at every release — use whichever you prefer.
-
-Because all three share the same database, switching between OpenCode and Pi on the same project preserves the curated knowledge, distillations, and AGENTS.md sync.
+Published as [`@loreai/gateway`](https://www.npmjs.com/package/@loreai/gateway) (standalone proxy), [`@loreai/opencode`](https://www.npmjs.com/package/@loreai/opencode) (OpenCode plugin), [`@loreai/pi`](https://www.npmjs.com/package/@loreai/pi) (Pi extension), and [`@loreai/core`](https://www.npmjs.com/package/@loreai/core) (shared engine).
 
 ## Why
 
 Coding agents forget. Once a conversation exceeds the context window, earlier decisions, bug fixes, and architectural choices vanish. The default approach — summarize-and-compact — loses exactly the operational details agents need. After a few compaction passes, the agent knows you "discussed authentication" but can't actually continue the work.
 
-The manual alternative is writing context files by hand — DEVELOPMENT_CONTEXT.md, key technical learnings, decision rationales. It works ([O'Reilly Radar](https://www.oreilly.com/radar/why-doesnt-anyone-teach-developers-about-context-management/) has a thorough guide), but it's a second full-time job. One project tracked 49 technical learnings manually, each with "What, Why, When, Where" — and every one had to be maintained or the AI would refactor deliberate decisions away.
+The manual alternative is writing context files by hand — key technical learnings, decision rationales, session handoff notes. It works ([O'Reilly Radar](https://www.oreilly.com/radar/why-doesnt-anyone-teach-developers-about-context-management/) has a thorough guide), but it's a second full-time job. One project tracked 49 technical learnings manually, each with "What, Why, When, Where" — and every one had to be maintained or the AI would refactor deliberate decisions away.
 
-Lore automates all of it: distillation, knowledge curation, cross-session recall, and AGENTS.md export. You keep coding. Lore keeps the context.
+Other tools try to solve this in halves. Memory-only tools store past conversations but don't manage the context window — your AI still gets compacted mid-session. Context-only tools compress history but nothing is learned from the compression — start a new session and you're back to zero.
 
-## What you'd otherwise do by hand
+Lore treats context management and memory as the same problem. Distillation, knowledge curation, cross-session recall, and `.lore.md` export — all in one pipeline. You keep coding. Lore keeps the context.
 
-Context management is [emerging as the most important skill in AI-driven development](https://www.oreilly.com/radar/why-doesnt-anyone-teach-developers-about-context-management/). The recommended manual practices include:
+## What to expect
 
-- **DEVELOPMENT_CONTEXT.md** — a bootstrap file the AI reads at session start, with loading sequences pointing to subsystem-level context files
-- **Key Technical Learnings** — numbered entries with "What, Why, When, Where" for every significant discovery
-- **Decision rationales** — every architectural choice needs the "why" recorded, or a future session will optimize it away
-- **Behavioral contracts** — observed invariants written to files before requirements work begins, so forgotten contracts are greppable gaps
-- **Session handoff files** — externalized intermediate state (EXPLORATION.md, CONTRACTS.md) so work survives across sessions
+Once Lore is active, you should notice:
 
-Lore handles all five automatically:
-- Distillation replaces DEVELOPMENT_CONTEXT.md with an always-current observation log
-- The curator extracts and maintains key learnings, decisions, and gotchas
-- AGENTS.md export provides the bootstrap file in the [universal format](https://agenticaistandard.org/)
-- The recall tool searches across all sessions — no handoff files needed
+- **No more compactions** — Lore replaces compaction with incremental distillation. Your context never gets wiped and rebuilt from a lossy summary.
+- **Infinite sessions at lower cost** — the gradient context manager keeps sessions running indefinitely without degradation. Background work runs at up to 50% off via batch APIs on supported providers, using cheaper models (A/B tested for quality parity). Predictive cache warming avoids expensive cache rebuilds.
+- **Decisions stick** — the curator preserves the "why" behind every choice. A future session won't "helpfully" refactor your workaround back to the broken approach.
+- **Your AI learns from experience** — patterns, gotchas, and architectural decisions are automatically curated across sessions and exported to `.lore.md`. Project-specific knowledge and global preferences follow you everywhere.
+- **Free on-device vector search** — Nomic Embed v1.5 runs locally with zero API cost. Hybrid architecture fuses vector similarity with BM25 keyword search and LLM-powered query expansion for best-of-both-worlds recall.
+- **Works with any provider** — `lore run` auto-detects Claude Code, OpenCode, Pi, and Codex. Cursor, Copilot, Windsurf, and any other Anthropic/OpenAI-compatible tool work by pointing their base URL at the gateway. Switch providers freely; your memory stays.*
+- **Import your history** — Lore imports conversations from Claude Code, Codex, Aider, Cline, Continue, OpenCode, and Pi, extracting knowledge from your existing sessions so your AI starts with context from day one.
+- **Team knowledge with Lore Cloud** — shared memory across your team, managed centrally. *(Coming soon.)*
+
+<sub>* Any provider accessible via an OpenAI or Anthropic-compatible API.</sub>
+
+## Quick start
+
+### Gateway (works with any AI client)
+
+```bash
+# Install and start
+curl -fsSL https://withlore.ai/install | bash
+lore run
+```
+
+`lore run` starts the gateway and auto-detects your AI agent (Claude Code, OpenCode, Pi, Codex), configuring everything automatically.
+
+Or run directly: `npx @loreai/gateway`
+
+### OpenCode plugin
+
+Add `@loreai/opencode` to the `plugin` array in your project's `opencode.json`:
+
+```json
+{
+  "plugin": [
+    "@loreai/opencode"
+  ]
+}
+```
+
+Restart OpenCode and the plugin will be installed automatically. The legacy name `opencode-lore` still works if you have an existing setup.
+
+### Pi extension
+
+Pi discovers extensions via your `~/.pi/settings.json`:
+
+```json
+{
+  "packages": [
+    "npm:@loreai/pi@latest"
+  ]
+}
+```
+
+Then run `pi install` once. The extension auto-loads on every Pi session.
+
+All three share the same SQLite database at `~/.local/share/lore/lore.db` — switching between tools on the same project preserves everything.
 
 ## How it works
 
@@ -48,11 +85,22 @@ Lore uses a three-tier memory architecture (following [Nuum's design](https://ww
 
 1. **Temporal storage** — every message is stored in a local SQLite FTS5 database, searchable on demand via the `recall` tool.
 
-2. **Distillation** — messages are incrementally distilled into an observation log (dated, timestamped, priority-tagged entries), following [Mastra's observer/reflector pattern](https://mastra.ai/research/observational-memory). When segments accumulate, older distillations are consolidated into structured context documents optimized for diverse downstream queries (current state, key decisions, technical changes, timeline) — a [context-distillation objective](https://arxiv.org/abs/2501.17390) that generalizes better than flat summarization. Consolidated entries are archived rather than deleted, preserving a searchable detail layer for the `recall` tool. The observer prompt is tuned to preserve exact numbers, bug fixes, file paths, and assistant-generated content.
+2. **Distillation** — messages are incrementally distilled into an observation log (dated, timestamped, priority-tagged entries), following [Mastra's observer/reflector pattern](https://mastra.ai/research/observational-memory). When segments accumulate, older distillations are consolidated into structured context documents optimized for diverse downstream queries (current state, key decisions, technical changes, timeline) — a [context-distillation objective](https://arxiv.org/abs/2501.17390) that generalizes better than flat summarization. Consolidated entries are archived rather than deleted, preserving a searchable detail layer for the `recall` tool.
 
-3. **Long-term knowledge** — a curated knowledge base of facts, patterns, decisions, and gotchas that matter across projects, maintained by a background curator agent.
+3. **Long-term knowledge** — a curated knowledge base of facts, patterns, decisions, and gotchas that matter across sessions and projects, maintained by a background curator agent. Entries are confidence-ranked: unconditional directives (1.0) always surface, mild preferences (0.6) only when budget allows. Project-specific knowledge stays scoped; global preferences (coding style, review habits, tooling choices) follow you across all projects.
 
-A **gradient context manager** decides how much of each tier to include in each turn, using a 4-layer safety system that calibrates overhead dynamically from real API token counts. When tool outputs are stripped for compression, [loss-annotated metadata](https://arxiv.org/abs/2602.16284) preserves key signals (tool name, size, error presence, file paths) so the model can make informed decisions about whether to recall the full content. This handles the unpredictable context consumption of coding agents (large tool outputs, system prompts, injected instructions) better than a fixed-budget approach.
+A **gradient context manager** decides how much of each tier to include in each turn, using a 4-layer safety system that calibrates overhead dynamically from real API token counts. When tool outputs are stripped for compression, [loss-annotated metadata](https://arxiv.org/abs/2602.16284) preserves key signals (tool name, size, error presence, file paths) so the model can make informed decisions about whether to recall the full content.
+
+### Cost efficiency
+
+Lore is designed to cost less than the default approach, not more:
+
+- **Up to 50% off background work** — distillation, curation, and query expansion run via batch APIs (Anthropic Messages Batches, OpenAI Batch) at half price when available
+- **Cheaper worker models** — background work automatically uses cheaper models (e.g., Sonnet instead of Opus), A/B tested for quality parity
+- **Predictive cache warming** — survival analysis predicts when you'll return and sends $0.01 keepalive requests to prevent $0.70+ cache rebuilds
+- **3-block system prompt caching** — stable preferences cached for 1 hour at 10x cheaper reads; dynamic context rides the 5-minute conversation cache
+- **No compaction cache busts** — compaction destroys the entire prompt cache on every trigger. Lore's gradient compression eliminates compaction entirely
+- **Content deduplication** — duplicate file reads and tool outputs are detected and deduplicated automatically, saving thousands of tokens per session
 
 ## Benchmarks
 
@@ -96,65 +144,17 @@ Lore's distilled context is smaller and more cacheable than raw tail windows, ma
 | cli-sentry-issue   | 318      | 113K   | ~6K tokens       | 19x         |
 | cli-nightly        | 898      | 353K   | ~19K tokens      | 19x         |
 
-The eval is self-contained and reproducible: session transcripts are stored as JSON files with no database dependency. See [`eval/`](eval/) for the harness and data.
+The eval is self-contained and reproducible: session transcripts are stored as JSON files with no database dependency.
 
-## How we got here
+## The `recall` tool
 
-This plugin was built in a few intense sessions. Some highlights:
+The assistant gets a `recall` tool that searches across stored messages, distillations, and knowledge using hybrid vector + FTS5 BM25 search with LLM-powered query expansion. It's used automatically when the distilled context doesn't have enough detail:
 
-**v1 — structured distillation.** The initial version used Nuum's `{ narrative, facts }` JSON format. It worked well for single-session preference recall (+40pp over baseline) but *regressed* on multi-session and temporal reasoning — the structured format was too rigid and lost temporal context.
+- "What did we decide about auth last week?"
+- "What was the error from the migration?"
+- "What's my database schema convention?"
 
-**Markdown injection.** Property-based testing with fast-check revealed that user-generated content in facts (code fences, heading markers, thematic breaks) could break the markdown structure of the injected context, confusing the model.
-
-**v2 — observation logs.** Switching to Mastra's observer/reflector architecture with plain-text timestamped observation logs was the breakthrough. The key insight: dated event logs preserve temporal relationships that structured JSON destroys.
-
-**Prompt refinements.** The push from 80% to 93.3% on the initial coding recall eval came from two observer prompt additions: "EXACT NUMBERS — NEVER APPROXIMATE" (the observer was rounding counts) and "BUG FIXES — ALWAYS RECORD" (early-session fixes were being compressed away during reflection).
-
-**v3 — gradient fixes, caching, and proper eval.** A month of fixes (per-session gradient state, current-turn protection, cache.write calibration, prefix caching, LTM relevance scoring) shipped alongside a new self-contained eval harness. The old coding eval used DB-resident sessions that degraded over time as temporal pruning deleted messages. The new eval extracts full session transcripts into portable JSON files, distills on the fly with the current production prompt, seeds the DB for recall tool access, and compares against OpenCode's actual compaction behavior. This moved the coding eval from 15 questions on degraded data to 20 questions on clean 113K-353K token sessions — and confirmed the +35pp accuracy gap and 7x cost efficiency advantage.
-
-**v4 — research-informed compaction improvements.** Three changes informed by the KV cache compression literature ([Zweiger et al. 2025](https://arxiv.org/abs/2602.16284), [Eyuboglu et al. 2025](https://arxiv.org/abs/2501.17390)): (1) *Loss-annotated tool stripping* — when tool outputs are compressed away at higher gradient layers, the replacement now includes metadata (tool name, line count, error presence, file paths) instead of a static placeholder, helping the model decide whether to recall the full content. (2) *Context-distillation meta-distillation* — the reflector prompt was restructured to produce a working context document with sections for current state, key decisions, technical changes, and timeline, rather than a flat re-organized event log — an objective that generalizes better to diverse downstream queries. (3) *Multi-resolution composable distillations* — gen-0 observations are now archived instead of deleted during meta-distillation, preserving a searchable detail layer for the recall tool while the compressed gen-1 serves as the in-context summary.
-
-## Installation
-
-### OpenCode
-
-Add `@loreai/opencode` to the `plugin` array in your project's `opencode.json`:
-
-```json
-{
-  "plugin": [
-    "@loreai/opencode"
-  ]
-}
-```
-
-Restart OpenCode and the plugin will be installed automatically. The legacy name `opencode-lore` still works if you have an existing setup.
-
-### Pi
-
-Pi discovers extensions via your `~/.pi/settings.json`:
-
-```json
-{
-  "packages": [
-    "npm:@loreai/pi@latest"
-  ]
-}
-```
-
-Then run `pi install` once. The extension auto-loads on every Pi session.
-
-### Development setup
-
-To use a local clone instead of the published packages:
-
-- **OpenCode**: `{ "plugin": ["file:///absolute/path/to/opencode-lore"] }`
-- **Pi**: symlink the built package into `~/.pi/agent/extensions/`, or add a local path to `~/.pi/settings.json` `packages`
-
-Contributors editing prompts in `packages/core/src/prompt.ts` or the
-user-facing system prompt injection in `packages/opencode/src/index.ts` /
-`packages/pi/src/index.ts` should follow the review bar in
-[`docs/PROMPT_CHANGES.md`](docs/PROMPT_CHANGES.md).
+Search results are ranked using Reciprocal Rank Fusion across multiple sources: knowledge entries, distillation observations, temporal messages, recency-biased temporal, cross-project knowledge, and lat.md sections.
 
 ## Configuration
 
@@ -164,7 +164,7 @@ Create a `.lore.json` file in your project root to customize behavior. All field
 {
   // Disable long-term knowledge entirely. Temporal storage, distillation,
   // gradient context management, and the recall tool (for conversation search)
-  // remain active. Only the curator, knowledge injection, and AGENTS.md sync
+  // remain active. Only the curator, knowledge injection, and .lore.md sync
   // are turned off.
   "knowledge": { "enabled": true },
 
@@ -172,14 +172,15 @@ Create a `.lore.json` file in your project root to customize behavior. All field
   "curator": {
     "enabled": true,        // set false to stop extracting knowledge entries
     "onIdle": true,         // run curation when a session goes idle
-    "afterTurns": 10,       // run curation after N user turns
+    "afterTurns": 3,        // run curation after N user turns
     "maxEntries": 25        // consolidate when entries exceed this count
   },
 
-  // AGENTS.md export/import — the universal agents file format.
+  // Knowledge file export/import. Defaults to AGENTS.md (the universal format
+  // read by 16+ AI tools). Set path to ".lore.md" for a dedicated Lore file.
   "agentsFile": {
-    "enabled": true,        // set false to disable AGENTS.md sync
-    "path": "AGENTS.md"     // change to e.g. "CLAUDE.md" or ".cursor/rules/lore.md"
+    "enabled": true,        // set false to disable knowledge file sync
+    "path": "AGENTS.md"     // or ".lore.md", "CLAUDE.md", ".cursor/rules/lore.md"
   },
 
   // Context budget fractions (of usable context window).
@@ -187,14 +188,14 @@ Create a `.lore.json` file in your project root to customize behavior. All field
     "distilled": 0.25,      // distilled history prefix
     "raw": 0.4,             // recent raw messages
     "output": 0.25,         // reserved for model output
-    "ltm": 0.10             // long-term knowledge in system prompt (2-30%)
+    "ltm": 0.05             // long-term knowledge in system prompt (2-30%)
   },
 
   // Distillation thresholds.
   "distillation": {
-    "minMessages": 8,          // min undistilled messages before distilling
+    "minMessages": 5,          // min undistilled messages before distilling
     "minSegmentTokens": 64,    // min tokens per segment (below = skip/absorb)
-    "maxSegmentTokens": 8192   // max tokens per distillation segment
+    "maxSegmentTokens": 16384  // max tokens per distillation segment
   },
 
   // Temporal message pruning.
@@ -203,8 +204,8 @@ Create a `.lore.json` file in your project root to customize behavior. All field
     "maxStorage": 1024      // max storage in MB before emergency pruning
   },
 
-  // Include cross-project knowledge entries. Default: true.
-  "crossProject": true
+  // Include cross-project knowledge entries. Default: false.
+  "crossProject": false
 }
 ```
 
@@ -221,24 +222,13 @@ If you prefer to manage context manually and only want conversation search capab
 This disables:
 - **Knowledge extraction** — the curator won't extract patterns, decisions, or gotchas from conversations
 - **Knowledge injection** — no knowledge entries are added to the system prompt
-- **AGENTS.md sync** — no import/export of the agents file
+- **Knowledge file sync** — no import/export of AGENTS.md / .lore.md
 
 This keeps active:
 - **Temporal storage** — all messages are still stored and searchable
 - **Distillation** — conversations are still distilled for context management
 - **Gradient context manager** — context window is still managed automatically
 - **The `recall` tool** — the agent can still search conversation history and distillations (knowledge search is skipped)
-
-## What to expect
-
-Once Lore is active, you should notice several changes:
-
-- **Higher cache reuse** — Lore keeps your context stable across turns, so the provider cache hits more often. You'll see higher cache read rates and lower costs.
-- **No more compactions** — Lore disables the built-in compaction system and replaces it with incremental distillation. Your context never gets wiped and rebuilt from a lossy summary.
-- **Steady context usage around 70–80%** — the gradient context manager dynamically balances distilled history, raw messages, and knowledge to keep you in the sweet spot — enough room for the model to work, but no wasted context.
-- **Agent doesn't degrade in long sessions** — instead of getting progressively dumber as compaction loses details, the agent stays sharp because distillation preserves the operational facts that matter.
-- **Better recall across and within sessions** — the agent remembers specific details from earlier in the conversation and from previous sessions, including file paths, decisions, error messages, and why things were done a certain way.
-- **Automatic `AGENTS.md` export** — Lore periodically exports curated knowledge to an `AGENTS.md` file in your repo. This is the [universal format](https://agenticaistandard.org/) read by 16+ AI coding tools (Codex, Jules, Cursor, Copilot, Windsurf, and more), so the knowledge benefits every tool — not just OpenCode.
 
 ## What gets stored
 
@@ -247,14 +237,7 @@ All data lives locally in `~/.local/share/lore/lore.db`:
 - **Session observations** — timestamped event log of each conversation: what was asked, what was done, decisions made, errors found
 - **Long-term knowledge** — patterns, gotchas, and architectural decisions curated across sessions and projects. Entries can reference each other with `[[entry-id]]` wiki links, forming a navigable knowledge graph. Dead references are automatically cleaned up when entries are deleted or consolidated.
 - **Raw messages** — full message history in FTS5-indexed SQLite for the `recall` tool
-
-## The `recall` tool
-
-The assistant gets a `recall` tool that searches across stored messages and knowledge. It's used automatically when the distilled context doesn't have enough detail:
-
-- "What did we decide about auth last week?"
-- "What was the error from the migration?"
-- "What's my database schema convention?"
+- **Embeddings** — on-device vector embeddings (Nomic Embed v1.5) for semantic search, stored alongside the entries they represent
 
 ## CLI tools
 
@@ -307,6 +290,17 @@ lore recall "auth decision" --scope knowledge --limit 5
 lore recall "migration error" --project /path/to/project --json
 ```
 
+### `lore import` — Import conversation history
+
+```bash
+# Auto-detect and import conversations from all supported agents
+lore import
+
+# Supported: Claude Code, Codex, Aider, Cline, Continue, OpenCode, Pi
+```
+
+Extracts knowledge from your existing sessions so Lore starts with context from day one. Idempotent — safe to run multiple times.
+
 ### Web dashboard
 
 When the gateway is running, visit **http://localhost:3207/ui** for a web-based dashboard that lets you:
@@ -330,15 +324,43 @@ lat.md sections also participate in LTM injection — the most relevant sections
 
 Lore re-scans the `lat.md/` directory periodically (on session idle), so changes made by the agent or by hand are picked up automatically.
 
+## How we got here
+
+This project was built in a few intense sessions. Some highlights:
+
+**v1 — structured distillation.** The initial version used Nuum's `{ narrative, facts }` JSON format. It worked well for single-session preference recall (+40pp over baseline) but *regressed* on multi-session and temporal reasoning — the structured format was too rigid and lost temporal context.
+
+**Markdown injection.** Property-based testing with fast-check revealed that user-generated content in facts (code fences, heading markers, thematic breaks) could break the markdown structure of the injected context, confusing the model.
+
+**v2 — observation logs.** Switching to Mastra's observer/reflector architecture with plain-text timestamped observation logs was the breakthrough. The key insight: dated event logs preserve temporal relationships that structured JSON destroys.
+
+**Prompt refinements.** The push from 80% to 93.3% on the initial coding recall eval came from two observer prompt additions: "EXACT NUMBERS — NEVER APPROXIMATE" (the observer was rounding counts) and "BUG FIXES — ALWAYS RECORD" (early-session fixes were being compressed away during reflection).
+
+**v3 — gradient fixes, caching, and proper eval.** A month of fixes (per-session gradient state, current-turn protection, cache.write calibration, prefix caching, LTM relevance scoring) shipped alongside a new self-contained eval harness. The old coding eval used DB-resident sessions that degraded over time as temporal pruning deleted messages. The new eval extracts full session transcripts into portable JSON files, distills on the fly with the current production prompt, seeds the DB for recall tool access, and compares against OpenCode's actual compaction behavior. This moved the coding eval from 15 questions on degraded data to 20 questions on clean 113K-353K token sessions — and confirmed the +35pp accuracy gap and 7x cost efficiency advantage.
+
+**v4 — research-informed compaction improvements.** Three changes informed by the KV cache compression literature ([Zweiger et al. 2025](https://arxiv.org/abs/2602.16284), [Eyuboglu et al. 2025](https://arxiv.org/abs/2501.17390)): (1) *Loss-annotated tool stripping* — when tool outputs are compressed away at higher gradient layers, the replacement now includes metadata (tool name, line count, error presence, file paths) instead of a static placeholder, helping the model decide whether to recall the full content. (2) *Context-distillation meta-distillation* — the reflector prompt was restructured to produce a working context document with sections for current state, key decisions, technical changes, and timeline, rather than a flat re-organized event log — an objective that generalizes better to diverse downstream queries. (3) *Multi-resolution composable distillations* — gen-0 observations are now archived instead of deleted during meta-distillation, preserving a searchable detail layer for the recall tool while the compressed gen-1 serves as the in-context summary.
+
+## Development setup
+
+To use a local clone instead of the published packages:
+
+- **OpenCode**: `{ "plugin": ["file:///absolute/path/to/opencode-lore"] }`
+- **Pi**: symlink the built package into `~/.pi/agent/extensions/`, or add a local path to `~/.pi/settings.json` `packages`
+
+Contributors editing prompts in `packages/core/src/prompt.ts` or the
+user-facing system prompt injection in `packages/opencode/src/index.ts` /
+`packages/pi/src/index.ts` should follow the review bar in
+[`docs/PROMPT_CHANGES.md`](docs/PROMPT_CHANGES.md).
+
 ## Standing on the shoulders of
 
-- [How we solved the agent memory problem](https://www.sanity.io/blog/how-we-solved-the-agent-memory-problem) — Simen Svale at Sanity on the Nuum memory architecture: three-tier storage, distillation not summarization, recursive compression. The foundation this plugin is built on.
+- [How we solved the agent memory problem](https://www.sanity.io/blog/how-we-solved-the-agent-memory-problem) — Simen Svale at Sanity on the Nuum memory architecture: three-tier storage, distillation not summarization, recursive compression. The foundation this project is built on.
 - [Mastra Observational Memory](https://mastra.ai/research/observational-memory) — the observer/reflector architecture and the switch from structured JSON to timestamped observation logs that made v2 work.
 - [Mastra Memory source](https://github.com/mastra-ai/mastra/tree/main/packages/memory) — reference implementation.
-- [Fast KV Compaction via Attention Matching](https://arxiv.org/abs/2602.16284) — Adam Zweiger, Xinghong Fu, Han Guo, Yoon Kim on preserving attention mass when compressing KV caches. Inspired the loss-annotated tool stripping approach: when content is removed during compression, preserving metadata about what was lost helps the model compensate — analogous to the per-token scalar bias β that preserves attention mass when token count is reduced.
-- [Cartridges: Compact Representations of Context for LLMs](https://arxiv.org/abs/2501.17390) — Simran Arora, Sabri Eyuboglu, Michael Zhang, Aman Timalsina, Silas Alberti, Dylan Judd, Christopher Ré on offline compressed context representations. Two key ideas adopted: (1) the context-distillation objective for meta-distillation — optimizing compressed context for downstream query-answering rather than faithful summarization, following the Self-Study finding that memorization objectives don't generalize; (2) composable multi-resolution distillations — archiving detailed observations instead of deleting them during consolidation, preserving a searchable detail layer beneath the compressed summary.
-- [Why Doesn't Anyone Teach Developers About Context Management?](https://www.oreilly.com/radar/why-doesnt-anyone-teach-developers-about-context-management/) — Andrew Stellman at O'Reilly Radar on why context management is the most important undiscussed skill in AI development. The manual practices described (DEVELOPMENT_CONTEXT.md, Key Technical Learnings, decision rationales) are what Lore automates.
-- [OpenCode](https://opencode.ai) — the coding agent this plugin extends.
+- [Fast KV Compaction via Attention Matching](https://arxiv.org/abs/2602.16284) — Adam Zweiger, Xinghong Fu, Han Guo, Yoon Kim on preserving attention mass when compressing KV caches. Inspired the loss-annotated tool stripping approach.
+- [Cartridges: Compact Representations of Context for LLMs](https://arxiv.org/abs/2501.17390) — Simran Arora, Sabri Eyuboglu, Michael Zhang et al. on offline compressed context representations. Key ideas adopted: context-distillation objective for meta-distillation, and composable multi-resolution distillations.
+- [Why Doesn't Anyone Teach Developers About Context Management?](https://www.oreilly.com/radar/why-doesnt-anyone-teach-developers-about-context-management/) — Andrew Stellman at O'Reilly Radar on why context management is the most important undiscussed skill in AI development. The manual practices described are what Lore automates.
+- [OpenCode](https://opencode.ai) — one of the AI coding agents Lore integrates with natively.
 
 ## License
 


### PR DESCRIPTION
## Summary

Rewrites the README to align with the new website messaging while preserving the project's technical depth and research roots.

## Key changes

**Messaging alignment:**
- Opens with pain + solution ("Stop re-explaining your project to your AI") instead of architecture
- Adds the unified pipeline angle: context management and memory are the same problem, not two separate tools
- "Why" section now explains the gap between memory-only and context-only approaches

**New sections:**
- **What to expect** — rewritten with user-facing benefits: infinite sessions, cost savings, decisions that stick, conversation import, any-provider compatibility, team knowledge via Lore Cloud
- **Quick Start** — `lore run` as the primary entry point, with OpenCode/Pi plugin setup as alternatives
- **Cost efficiency** — batch APIs (50% off), cheaper worker models, predictive cache warming, 3-block system prompt caching, compaction elimination, content deduplication
- **`lore import`** — documents conversation import from 7 agents (Claude Code, Codex, Aider, Cline, Continue, OpenCode, Pi)

**Fixes:**
- All AGENTS.md references → `.lore.md`
- All DEVELOPMENT_CONTEXT.md references removed
- Configuration example updated (agentsFile path → `.lore.md`)
- License confirmed as FSL-1.1-Apache-2.0

**Preserved:**
- Full research credits in "Standing on the shoulders of"
- Complete benchmark tables and methodology
- "How we got here" project history (v1→v4)
- Technical depth: three-tier architecture, gradient context manager, recall tool, CLI reference, lat.md compatibility
- Configuration reference with all options