### PR TITLE
feat: tool-call-aware cache warming + /lore:warm:* commands + UI controls

### DIFF
--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -81,6 +81,10 @@ export const DEAD_SESSION_THRESHOLD = 0.02;
  *  sessions and ensures the survival model has ≥2 gap observations. */
 export const MIN_TURNS_FOR_WARMING = 3;
 
+/** Maximum duration (ms) to keep warming during a tool call before
+ *  falling back to normal survival analysis. 30 min ≈ 6 cycles at 5m TTL. */
+export const MAX_TOOL_CALL_WARMING_MS = 30 * 60 * 1000;
+
 /** Max uncached warmup responses before the global circuit breaker trips. */
 const CIRCUIT_BREAKER_MAX_FAILURES = 3;
 
@@ -396,6 +400,9 @@ export type SessionEndSignals = {
   breakFraction: number;
   /** Total completed turns (messageCount / 2). */
   totalTurns: number;
+  /** Last stop reason from the assistant response. "tool_use" means the
+   *  agent is actively executing a tool and will return with the result. */
+  lastStopReason?: string;
 };
 
 /**
@@ -438,6 +445,12 @@ export function pSessionFinished(signals: SessionEndSignals): number {
     logOdds += 1.0;
   } else if (signals.totalTurns <= 5) {
     logOdds += 0.3;
+  }
+
+  // Signal 5: Active tool call — strong evidence session is NOT finished.
+  // The agent is executing a tool and will return with the result.
+  if (signals.lastStopReason === "tool_use") {
+    logOdds -= 4.0;
   }
 
   // Sigmoid: p = 1 / (1 + exp(-logOdds))
@@ -628,7 +641,7 @@ export function resolveProfile(
  *  2. Computes expected warming cost across a potential break
  *  3. Compares P(returns) against the corrected cost threshold
  *
- * Gate checks (circuit breaker, config, body, /keep, cooldown) are unchanged.
+ * Gate checks (circuit breaker, config, body, /lore:warm:keep, cooldown) are unchanged.
  *
  * Two phases for the normal path:
  *  - Initial commitment (first TTL window): full ROI analysis
@@ -640,11 +653,11 @@ export function shouldWarm(
   blendedHist: InterTurnHistogram,
   now: number = Date.now(),
 ): boolean {
-  // Global kill switch — always respected, even with /keep
+  // Global kill switch — always respected, even with /lore:warm:keep
   if (circuitBreakerTripped) return false;
 
   // Sub-agent sessions are always exempt — they are too short-lived
-  // for warming to be profitable, even with /keep force.
+  // for warming to be profitable, even with /lore:warm:keep force.
   if (state.isSubagent) return false;
 
   const cfg = loreConfig();
@@ -658,19 +671,20 @@ export function shouldWarm(
   const forced = state.warmup?.forceKeepWarm === true;
 
   // Already warmed recently — prevent double-warming.
-  // For /keep mode, use a tighter cooldown (ttlMs - warmupMarginMs) so the
-  // next warmup fires before the current cache expires. Without this, the
-  // full-ttlMs guard combined with margin positioning produces a ~2x TTL
+  // For /lore:warm:keep mode, use a tighter cooldown (ttlMs - warmupMarginMs)
+  // so the next warmup fires before the current cache expires. Without this,
+  // the full-ttlMs guard combined with margin positioning produces a ~2x TTL
   // cadence (e.g. 10 min on a 5 min TTL), leaving a dead zone each cycle.
-  const cooldownMs = forced ? Math.max(ttlMs - warmupMarginMs, 0) : ttlMs;
+  const toolCallActive = state.lastStopReason === "tool_use";
+  const cooldownMs = (forced || toolCallActive) ? Math.max(ttlMs - warmupMarginMs, 0) : ttlMs;
   if (state.warmup?.lastWarmupAt && (now - state.warmup.lastWarmupAt) < cooldownMs) {
     return false;
   }
 
   if (forced) {
-    // /keep mode: skip survival/signal analysis but still respect the
-    // break-even cap — warming beyond maxCycles is always unprofitable,
-    // even when the user explicitly asked for /keep.
+    // /lore:warm:keep mode: skip survival/signal analysis but still respect
+    // the break-even cap — warming beyond maxCycles is always unprofitable,
+    // even when the user explicitly asked for /lore:warm:keep.
     const maxCycles = maxProfitableCycles(cacheReadCostPerMTok, cacheMissCostPerMTok);
     const cyclesSpent = state.warmup?.warmupCount ?? 0;
     if (cyclesSpent >= maxCycles) return false;
@@ -678,6 +692,29 @@ export function shouldWarm(
     // Check we're in the warmup margin of *some* TTL window.
     const intoWindow = elapsed % ttlMs;
     if (intoWindow < ttlMs - warmupMarginMs) return false;
+    return true;
+  }
+
+  // --- Tool-call fast path ---
+  // When lastStopReason is "tool_use", the agent is executing a tool and
+  // WILL return with the result. Bypass survival analysis (return probability
+  // is ~1.0) but respect break-even cap and a maximum duration to handle
+  // agent crashes gracefully.
+  if (toolCallActive && !state.warmup?.disabled) {
+    // Cap: don't warm indefinitely if the agent crashed mid-tool-call
+    if (elapsed > MAX_TOOL_CALL_WARMING_MS) return false;
+
+    const maxCycles = maxProfitableCycles(cacheReadCostPerMTok, cacheMissCostPerMTok);
+    const cyclesSpent = state.warmup?.warmupCount ?? 0;
+    if (cyclesSpent >= maxCycles) return false;
+
+    // Still require some history to have a stored body worth warming
+    if (state.messageCount < MIN_TURNS_FOR_WARMING * 2) return false;
+
+    // Only warm in the margin window of the current TTL cycle
+    const intoWindow = elapsed % ttlMs;
+    if (intoWindow < ttlMs - warmupMarginMs) return false;
+
     return true;
   }
 
@@ -702,6 +739,7 @@ export function shouldWarm(
     consecutiveTextOnlyTurns: textOnlyRuns,
     breakFraction: breakFrac,
     totalTurns,
+    lastStopReason: state.lastStopReason,
   });
   const pReturns = 1.0 - pFinished;
 
@@ -816,6 +854,8 @@ export type WarmingSnapshot = {
   pReturn: number;
   pReturnDampened: number;
   costThreshold: number;
+  // Tool-call state
+  toolCallActive: boolean;
   // Decision
   shouldWarmNow: boolean;
   notWarmingReason: string | null;
@@ -868,6 +908,7 @@ export function computeWarmingSnapshot(
     consecutiveTextOnlyTurns: textOnlyRuns,
     breakFraction: breakFrac,
     totalTurns,
+    lastStopReason: state.lastStopReason,
   });
   const pReturns = 1.0 - pFinished;
 
@@ -921,12 +962,30 @@ export function computeWarmingSnapshot(
           notWarmingReason = "Force-keep: cooldown active";
         }
       }
+    } else if (state.lastStopReason === "tool_use") {
+      if (state.warmup?.disabled) {
+        notWarmingReason = "Warming stopped (/lore:warm:stop)";
+      } else if (state.messageCount < MIN_TURNS_FOR_WARMING * 2) {
+        notWarmingReason = `Too few turns (${state.messageCount} < ${MIN_TURNS_FOR_WARMING * 2})`;
+      } else if (idleMs > MAX_TOOL_CALL_WARMING_MS) {
+        notWarmingReason = `Tool call exceeded max duration (${Math.round(idleMs / 60_000)}min > 30min)`;
+      } else {
+        const maxCyc = maxProfitableCycles(profile.cacheReadCostPerMTok, profile.cacheMissCostPerMTok);
+        if ((state.warmup?.warmupCount ?? 0) >= maxCyc) {
+          notWarmingReason = "Tool call: break-even exceeded";
+        } else {
+          const intoWindow = idleMs % ttlMs;
+          notWarmingReason = intoWindow < ttlMs - warmupMarginMs
+            ? "Tool call: not in warmup window yet"
+            : "Tool call: cooldown active";
+        }
+      }
     } else if (state.warmup?.lastWarmupAt && now - state.warmup.lastWarmupAt < cooldownFor(state, ttlMs, warmupMarginMs)) {
       notWarmingReason = "Already warmed in this TTL window";
     } else if (state.messageCount < MIN_TURNS_FOR_WARMING * 2) {
       notWarmingReason = `Too few turns (${state.messageCount} < ${MIN_TURNS_FOR_WARMING * 2})`;
     } else if (state.warmup?.disabled) {
-      notWarmingReason = "Session marked dead";
+      notWarmingReason = "Warming stopped (/lore:warm:stop)";
     } else if (isFirstWindow && idleMs < ttlMs - warmupMarginMs) {
       notWarmingReason = "Cache still fresh";
     } else if (pReturns <= thresholdVal) {
@@ -971,6 +1030,8 @@ export function computeWarmingSnapshot(
     pReturn,
     pReturnDampened,
     costThreshold: thresholdVal,
+    // Tool-call state
+    toolCallActive: state.lastStopReason === "tool_use" && idleMs <= MAX_TOOL_CALL_WARMING_MS && !state.warmup?.disabled,
     // Decision
     shouldWarmNow: warmNow,
     notWarmingReason,
@@ -978,9 +1039,9 @@ export function computeWarmingSnapshot(
   };
 }
 
-/** Compute cooldown based on forced/normal mode. */
+/** Compute cooldown based on forced/tool-call/normal mode. */
 function cooldownFor(state: SessionState, ttlMs: number, warmupMarginMs: number): number {
-  return state.warmup?.forceKeepWarm
+  return (state.warmup?.forceKeepWarm || state.lastStopReason === "tool_use")
     ? Math.max(ttlMs - warmupMarginMs, 0)
     : ttlMs;
 }

--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -80,6 +80,11 @@ export function startIdleScheduler(
       if (inProgress.has(sessionID)) continue;
       if (now - state.lastRequestTime < timeoutMs) continue;
 
+      // Skip idle work when the agent is executing a tool — the session
+      // is still active, not genuinely idle. Distillation/curation should
+      // wait for the actual idle period after the tool-use turn completes.
+      if (state.lastStopReason === "tool_use") continue;
+
       inProgress.add(sessionID);
       runBackground(
         () => doIdleWork(sessionID, state),

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -2546,8 +2546,8 @@ function isCacheWarm(state: SessionState): boolean {
   );
   if (!profile) return false;
 
-  // /keep sessions: consider warm if the last warmup was within 2 TTL
-  // windows. The warmer fires once per TTL window, so 2× provides a
+  // /lore:warm:keep sessions: consider warm if the last warmup was within
+  // 2 TTL windows. The warmer fires once per TTL window, so 2× provides a
   // safety margin while still expiring if the warmer has stopped
   // (e.g. circuit breaker tripped, process-level failure).
   if (warmup.forceKeepWarm) {
@@ -3529,7 +3529,7 @@ export function removeOrphanedToolResults(
 }
 
 // ---------------------------------------------------------------------------
-// Slash command interception (/done, /keep)
+// Slash command interception (/lore:warm:*)
 // ---------------------------------------------------------------------------
 
 /**
@@ -3553,8 +3553,9 @@ function lastUserTextTrimmed(req: GatewayRequest): string {
 /**
  * Check if the last user message is a warmup slash command.
  *
- * `/done` — disables cache warming for this session (user is finished).
- * `/keep` — forces cache warming regardless of survival analysis.
+ * `/lore:warm:stop` — disables cache warming for this session.
+ * `/lore:warm:keep` — forces cache warming regardless of survival analysis.
+ * `/lore:warm:auto` — returns to normal survival-analysis-driven mode.
  *
  * Returns a synthetic Anthropic-format response if a command was matched,
  * or null to continue normal processing.
@@ -3566,9 +3567,10 @@ function handleWarmupSlashCommand(
   const text = lastUserTextTrimmed(req);
   const lower = text.toLowerCase();
 
-  const isDone = lower === "/done";
-  const isKeep = lower === "/keep" || lower === "/keep-warm";
-  if (!isDone && !isKeep) return null;
+  const isStop = lower === "/lore:warm:stop";
+  const isKeep = lower === "/lore:warm:keep";
+  const isAuto = lower === "/lore:warm:auto";
+  if (!isStop && !isKeep && !isAuto) return null;
 
   // Find the session for this request (use the same header-based lookup)
   const known = extractKnownSessionHeader(req.rawHeaders);
@@ -3582,18 +3584,31 @@ function handleWarmupSlashCommand(
   // Update session warmup state
   if (state) {
     if (!state.warmup) {
-      state.warmup = { lastWarmupAt: 0, warmupCount: 0, totalWarmups: 0, warmupHits: 0, disabled: isDone };
-    } else {
-      state.warmup.disabled = isDone;
+      state.warmup = { lastWarmupAt: 0, warmupCount: 0, totalWarmups: 0, warmupHits: 0, disabled: false };
     }
-    if (isKeep) state.warmup.forceKeepWarm = true;
+    if (isStop) {
+      state.warmup.disabled = true;
+      state.warmup.forceKeepWarm = false;
+    } else if (isKeep) {
+      state.warmup.forceKeepWarm = true;
+      state.warmup.disabled = false;
+    } else {
+      // isAuto — return to normal survival-analysis mode
+      state.warmup.disabled = false;
+      state.warmup.forceKeepWarm = false;
+    }
+    const modeLabel = isStop ? "stopped" : isKeep ? "forced" : "auto";
     log.info(
       `cache-warmer: ${lower} received for session=${state.sessionID.slice(0, 16)} — ` +
-        `warming ${isDone ? "disabled" : "forced"}`,
+        `warming mode: ${modeLabel}`,
     );
   }
 
-  const responseText = isDone ? "🧊 Freezing session." : "🔥 Keeping cache warm.";
+  const responseText = isStop
+    ? "🧊 Cache warming stopped."
+    : isKeep
+      ? "🔥 Keeping cache warm."
+      : "🔄 Cache warming set to auto.";
 
   const msgId = `msg_lore_${Date.now()}`;
 
@@ -3687,7 +3702,7 @@ export async function handleRequest(
       if (sid) priorState = sessions.get(sid);
     }
 
-    // --- Case 0: Slash command interception (/done, /keep) ---
+    // --- Case 0: Slash command interception (/lore:warm:*) ---
     const slashResult = handleWarmupSlashCommand(req, sessions);
     if (slashResult) return slashResult;
 

--- a/packages/gateway/src/translate/types.ts
+++ b/packages/gateway/src/translate/types.ts
@@ -337,7 +337,7 @@ export type WarmupState = {
   warmupHits: number;
   /** Session marked as dead — survival dropped below threshold. Resets on real request. */
   disabled: boolean;
-  /** User explicitly requested keep-warm via /keep command. Bypasses survival analysis. */
+  /** User explicitly requested keep-warm via /lore:warm:keep command. Bypasses survival analysis. */
   forceKeepWarm?: boolean;
 };
 

--- a/packages/gateway/src/ui.ts
+++ b/packages/gateway/src/ui.ts
@@ -368,15 +368,26 @@ details.warming[open] summary { margin-bottom: 8px; }
 .badge-warming { background: #dcfce7; color: #166534; }
 .badge-waiting { background: #dbeafe; color: #1e40af; }
 .badge-dead { background: #fef2f2; color: #991b1b; }
+.badge-stopped { background: #fef2f2; color: #991b1b; }
 .badge-forced { background: #f3e8ff; color: #6b21a8; }
 .badge-disabled { background: var(--bg3); color: var(--fg3); }
+.badge-toolcall { background: #dbeafe; color: #1e40af; }
 @media (prefers-color-scheme: dark) {
   .badge-warming { background: #14532d; color: #86efac; }
   .badge-waiting { background: #1e3a5f; color: #93c5fd; }
   .badge-dead { background: #450a0a; color: #fca5a5; }
+  .badge-stopped { background: #450a0a; color: #fca5a5; }
   .badge-forced { background: #3b0764; color: #d8b4fe; }
   .badge-disabled { background: var(--bg3); color: var(--fg3); }
+  .badge-toolcall { background: #1e3a5f; color: #93c5fd; }
 }
+/* --- Warming mode controls --- */
+.warming-controls { display: inline-flex; gap: 2px; margin-left: 6px; }
+.warming-controls form.inline { margin: 0; }
+.btn-sm { display: inline-block; padding: 2px 8px; border-radius: var(--radius); font-size: 0.75em;
+  background: var(--bg2); color: var(--fg2); border: 1px solid var(--border); cursor: pointer; }
+.btn-sm:hover { background: var(--bg3); }
+.btn-sm.btn-active { background: var(--accent); color: white; border-color: var(--accent); }
 /* --- Subagent tree rows --- */
 .subagent-row { display: none; }
 .subagent-row.expanded { display: table-row; }
@@ -708,12 +719,27 @@ function warmingStatusBadge(snap: WarmingSnapshot): string {
   if (snap.circuitBreaker.tripped)
     return `<span class="badge badge-dead">TRIPPED</span>`;
   if (snap.disabled)
-    return `<span class="badge badge-dead">dead</span>`;
+    return `<span class="badge badge-stopped">stopped</span>`;
+  if (snap.toolCallActive)
+    return `<span class="badge badge-toolcall">tool call</span>`;
   if (snap.forceKeepWarm)
     return `<span class="badge badge-forced">forced</span>`;
   if (snap.shouldWarmNow)
     return `<span class="badge badge-warming">warming</span>`;
   return `<span class="badge badge-waiting">waiting</span>`;
+}
+
+/** Render warming mode toggle buttons (auto/keep/stop) for a live session. */
+function warmingModeControls(sessionId: string, snap: WarmingSnapshot): string {
+  const modes: Array<{ mode: string; label: string; active: boolean }> = [
+    { mode: "auto", label: "Auto", active: !snap.disabled && !snap.forceKeepWarm },
+    { mode: "keep", label: "Keep", active: snap.forceKeepWarm && !snap.disabled },
+    { mode: "stop", label: "Stop", active: snap.disabled },
+  ];
+  return `<span class="warming-controls">${modes.map(m =>
+    `<form class="inline" method="POST" action="/ui/api/warming/${esc(sessionId)}/${m.mode}">` +
+    `<button type="submit" class="btn-sm${m.active ? " btn-active" : ""}">${m.label}</button></form>`,
+  ).join("")}</span>`;
 }
 
 // ---------------------------------------------------------------------------
@@ -870,12 +896,13 @@ function renderSessionRow(r: LiveSessionRow, opts?: { isChild?: boolean; parentI
   const displaySavings = hasChildren ? r.rolledUpSavings : r.savings;
   const savingsColor = displaySavings >= 0 ? "#10b981" : "#e06c75";
 
-  // Status cell: badge + idle duration
+  // Status cell: badge + controls + idle duration
   let statusCell: string;
   if (r.warmingSnap) {
     const bdg = warmingStatusBadge(r.warmingSnap);
+    const controls = warmingModeControls(r.sessionId, r.warmingSnap);
     const idle = Number.isNaN(r.idleMs) ? "" : ` ${formatDuration(r.idleMs)}`;
-    statusCell = `${bdg}${idle}`;
+    statusCell = `${bdg}${controls}${idle}`;
   } else {
     statusCell = "-";
   }
@@ -1228,7 +1255,7 @@ function renderWarmingSection(sessionId: string): string {
 
   // Stat cards
   html += `<div class="stats">
-    <div class="stat"><div class="label">Status</div><div class="value">${warmingStatusBadge(snap)}</div></div>
+    <div class="stat"><div class="label">Status</div><div class="value">${warmingStatusBadge(snap)}${warmingModeControls(sessionId, snap)}</div></div>
     <div class="stat"><div class="label">Warmups</div><div class="value">${snap.totalWarmups}</div></div>
     <div class="stat"><div class="label">Hits</div><div class="value">${hitRate}</div></div>
     <div class="stat"><div class="label">P(returns)</div><div class="value">${(snap.pReturns * 100).toFixed(1)}%</div></div>
@@ -2044,6 +2071,35 @@ export async function handleUIRequest(
         data.renameProject(renameProjectMatch.id, newName);
       }
       return redirect(`/ui/projects/${renameProjectMatch.id}`);
+    }
+
+    // Set warming mode for a live session
+    const warmingMode = matchRoute(pathname, "/ui/api/warming/:sessionId/:mode");
+    if (warmingMode) {
+      const { sessionId, mode } = warmingMode;
+      if (mode !== "keep" && mode !== "stop" && mode !== "auto") {
+        return htmlResponse(layout("Bad Request", `<h1>Unknown warming mode: ${esc(mode)}</h1>`), 400);
+      }
+      const sessions = getActiveSessions();
+      const state = [...sessions.values()].find((s) => s.sessionID === sessionId);
+      if (state) {
+        if (!state.warmup) {
+          state.warmup = { lastWarmupAt: 0, warmupCount: 0, totalWarmups: 0, warmupHits: 0, disabled: false };
+        }
+        if (mode === "keep") {
+          state.warmup.forceKeepWarm = true;
+          state.warmup.disabled = false;
+        } else if (mode === "stop") {
+          state.warmup.disabled = true;
+          state.warmup.forceKeepWarm = false;
+        } else {
+          state.warmup.disabled = false;
+          state.warmup.forceKeepWarm = false;
+        }
+        state._dirty = true;
+      }
+      const referer = req.headers.get("referer");
+      return redirect(referer ?? "/ui/warming");
     }
   }
 

--- a/packages/gateway/test/cache-warmer.test.ts
+++ b/packages/gateway/test/cache-warmer.test.ts
@@ -15,6 +15,7 @@ import {
   expectedWarmupCycles,
   costThreshold,
   maxProfitableCycles,
+  MAX_TOOL_CALL_WARMING_MS,
   HISTOGRAM_BINS,
   BREAK_FLOOR_MS,
   _resetForTest,
@@ -576,7 +577,7 @@ describe("shouldWarm", () => {
     expect(shouldWarm(state, profile, hist, now)).toBe(false);
   });
 
-  test("returns false for sub-agent sessions even with /keep", () => {
+  test("returns false for sub-agent sessions even with /lore:warm:keep", () => {
     const now = Date.now();
     const state = makeSessionState({
       lastRequestTime: now - 270_000,
@@ -1174,20 +1175,20 @@ describe("shouldWarm continuation", () => {
 });
 
 // ---------------------------------------------------------------------------
-// /keep mode break-even cap
+// /lore:warm:keep mode break-even cap
 // ---------------------------------------------------------------------------
 
-describe("shouldWarm /keep mode", () => {
+describe("shouldWarm /lore:warm:keep mode", () => {
   beforeEach(() => {
     _resetForTest();
   });
 
-  test("/keep mode stops at break-even cap", () => {
+  test("/lore:warm:keep mode stops at break-even cap", () => {
     const now = Date.now();
     const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
     const maxCyc = maxProfitableCycles(profile.cacheReadCostPerMTok, profile.cacheMissCostPerMTok);
 
-    // Session in /keep mode that has already spent maxCycles
+    // Session in /lore:warm:keep mode that has already spent maxCycles
     const state = makeSessionState({
       lastRequestTime: now - (maxCyc + 1) * 300_000 - 270_000,
       warmup: {
@@ -1208,11 +1209,11 @@ describe("shouldWarm /keep mode", () => {
     expect(shouldWarm(state, profile, hist, now)).toBe(false);
   });
 
-  test("/keep mode warms when below break-even cap", () => {
+  test("/lore:warm:keep mode warms when below break-even cap", () => {
     const now = Date.now();
     const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
 
-    // Session in /keep mode with only 2 cycles spent, in warmup margin
+    // Session in /lore:warm:keep mode with only 2 cycles spent, in warmup margin
     const state = makeSessionState({
       lastRequestTime: now - 570_000, // 9.5min — in warmup margin of 2nd window
       warmup: {
@@ -1524,5 +1525,229 @@ describe("global histogram persistence", () => {
     expect(hist.total).toBe(10); // 7 + 3, no double-count
     expect(hist.counts[0]).toBe(7);
     expect(hist.counts[5]).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tool-call-aware cache warming
+// ---------------------------------------------------------------------------
+
+describe("shouldWarm tool-call warming", () => {
+  beforeEach(() => {
+    _resetForTest();
+  });
+
+  /** Helper: session mid-tool-call (lastStopReason="tool_use") in warmup window. */
+  function makeToolCallState(overrides: Partial<SessionState> = {}): SessionState {
+    const now = Date.now();
+    return makeSessionState({
+      lastRequestTime: now - 270_000, // 4.5 min — in warmup margin of 5m TTL
+      lastStopReason: "tool_use",
+      messageCount: 10,
+      cacheAnalytics: {
+        ...makeCacheAnalytics(),
+        lastRequestBody: compressBody('{"model":"claude-sonnet-4-20250514","max_tokens":16384,"stream":true,"messages":[{"role":"user","content":"test"}]}'),
+      },
+      ...overrides,
+    });
+  }
+
+  test("returns true during tool call in warmup window", () => {
+    const now = Date.now();
+    const state = makeToolCallState({ lastRequestTime: now - 270_000 });
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+    const hist = createHistogram();
+
+    expect(shouldWarm(state, profile, hist, now)).toBe(true);
+  });
+
+  test("returns false during tool call when cache still fresh", () => {
+    const now = Date.now();
+    // 2 min — cache still fresh, not in warmup margin
+    const state = makeToolCallState({ lastRequestTime: now - 120_000 });
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+    const hist = createHistogram();
+
+    expect(shouldWarm(state, profile, hist, now)).toBe(false);
+  });
+
+  test("returns false after MAX_TOOL_CALL_WARMING_MS exceeded", () => {
+    const now = Date.now();
+    // 35 min — past 30 min cap, in warmup margin of some TTL window
+    const elapsed = MAX_TOOL_CALL_WARMING_MS + 270_000;
+    const state = makeToolCallState({ lastRequestTime: now - elapsed });
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+    const hist = createHistogram();
+
+    expect(shouldWarm(state, profile, hist, now)).toBe(false);
+  });
+
+  test("returns false when /lore:warm:stop was sent", () => {
+    const now = Date.now();
+    const state = makeToolCallState({
+      lastRequestTime: now - 270_000,
+      warmup: {
+        lastWarmupAt: 0,
+        warmupCount: 0,
+        totalWarmups: 0,
+        warmupHits: 0,
+        disabled: true,
+      },
+    });
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+    const hist = createHistogram();
+
+    expect(shouldWarm(state, profile, hist, now)).toBe(false);
+  });
+
+  test("returns false when break-even exceeded", () => {
+    const now = Date.now();
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+    const maxCyc = maxProfitableCycles(profile.cacheReadCostPerMTok, profile.cacheMissCostPerMTok);
+
+    const state = makeToolCallState({
+      lastRequestTime: now - 270_000,
+      warmup: {
+        lastWarmupAt: 0,
+        warmupCount: maxCyc,
+        totalWarmups: maxCyc,
+        warmupHits: 0,
+        disabled: false,
+      },
+    });
+    const hist = createHistogram();
+
+    expect(shouldWarm(state, profile, hist, now)).toBe(false);
+  });
+
+  test("returns false for sub-agent even with tool_use stop reason", () => {
+    const now = Date.now();
+    const state = makeToolCallState({
+      lastRequestTime: now - 270_000,
+      isSubagent: true,
+    });
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+    const hist = createHistogram();
+
+    expect(shouldWarm(state, profile, hist, now)).toBe(false);
+  });
+
+  test("respects circuit breaker", () => {
+    // Trip the circuit breaker
+    const bad = makeWarmupResult({ cacheReadTokens: 0, cacheCreationTokens: 50000 });
+    checkCircuitBreaker(bad);
+    checkCircuitBreaker(bad);
+    checkCircuitBreaker(bad);
+
+    const now = Date.now();
+    const state = makeToolCallState({ lastRequestTime: now - 270_000 });
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+    const hist = createHistogram();
+
+    expect(shouldWarm(state, profile, hist, now)).toBe(false);
+  });
+
+  test("works across multiple TTL windows", () => {
+    const now = Date.now();
+    // 14.5 min — in 3rd 5m window's warmup margin (14:15-15:00)
+    const state = makeToolCallState({
+      lastRequestTime: now - 870_000,
+      warmup: {
+        lastWarmupAt: now - 270_000, // past cooldown
+        warmupCount: 2,
+        totalWarmups: 2,
+        warmupHits: 0,
+        disabled: false,
+      },
+    });
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+    const hist = createHistogram();
+
+    expect(shouldWarm(state, profile, hist, now)).toBe(true);
+  });
+
+  test("requires minimum turns", () => {
+    const now = Date.now();
+    const state = makeToolCallState({
+      lastRequestTime: now - 270_000,
+      messageCount: 2, // too few turns
+    });
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+    const hist = createHistogram();
+
+    expect(shouldWarm(state, profile, hist, now)).toBe(false);
+  });
+
+  test("forceKeepWarm takes priority over tool-call path", () => {
+    const now = Date.now();
+    // Both forceKeepWarm=true AND lastStopReason=tool_use.
+    // The forced path should take priority (no MAX_TOOL_CALL_WARMING_MS cap).
+    const state = makeToolCallState({
+      lastRequestTime: now - 270_000,
+      warmup: {
+        lastWarmupAt: 0,
+        warmupCount: 0,
+        totalWarmups: 0,
+        warmupHits: 0,
+        disabled: false,
+        forceKeepWarm: true,
+      },
+    });
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+    const hist = createHistogram();
+
+    expect(shouldWarm(state, profile, hist, now)).toBe(true);
+  });
+
+  test("works when warmup state is undefined", () => {
+    const now = Date.now();
+    // Fresh session — warmup is undefined, but tool call is active
+    const state = makeToolCallState({
+      lastRequestTime: now - 270_000,
+      warmup: undefined,
+    });
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+    const hist = createHistogram();
+
+    // warmup?.disabled is undefined, !undefined is true → enters fast path
+    expect(shouldWarm(state, profile, hist, now)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pSessionFinished — tool_use signal
+// ---------------------------------------------------------------------------
+
+describe("pSessionFinished tool_use signal", () => {
+  test("tool_use stop reason strongly decreases P(finished)", () => {
+    const baseSignals = {
+      survivalAtIdle: 0.1, // low survival — would normally push P(finished) high
+      consecutiveTextOnlyTurns: 0,
+      breakFraction: 0.05,
+      totalTurns: 10,
+    };
+
+    const pWithout = pSessionFinished(baseSignals);
+    const pWith = pSessionFinished({ ...baseSignals, lastStopReason: "tool_use" });
+
+    // Without tool_use, P(finished) should be high (low survival)
+    expect(pWithout).toBeGreaterThan(0.5);
+    // With tool_use, P(finished) should be much lower
+    expect(pWith).toBeLessThan(pWithout);
+    expect(pWith).toBeLessThan(0.2);
+  });
+
+  test("tool_use overrides high consecutive text-only turns", () => {
+    const signals = {
+      survivalAtIdle: 0.5,
+      consecutiveTextOnlyTurns: 5, // strong signal task is wrapping up
+      breakFraction: 0.1,
+      totalTurns: 10,
+      lastStopReason: "tool_use",
+    };
+
+    // Despite high text-only runs, tool_use should keep P(finished) low
+    const p = pSessionFinished(signals);
+    expect(p).toBeLessThan(0.5);
   });
 });


### PR DESCRIPTION
## Summary

Keeps the prompt cache warm during long-running tool calls and replaces the old `/done`/`/keep` commands with namespaced `/lore:warm:*` commands. Adds UI controls on the Warming dashboard.

## Changes

### Tool-call-aware cache warming
- Adds a fast-path in `shouldWarm()` that bypasses survival analysis when `lastStopReason === "tool_use"` — the agent is executing a tool and will return with near-certainty
- Caps tool-call warming at 30 minutes (`MAX_TOOL_CALL_WARMING_MS`) to handle agent crashes gracefully
- Adds `lastStopReason` as Signal 5 in `pSessionFinished()` (-4.0 log-odds when tool_use)
- Skips idle background work (distillation/curation) during active tool calls — the session is working, not idle
- Uses tighter cooldown for tool-call sessions (same as forced mode) to ensure warmups fire before TTL expiry

### `/lore:warm:*` slash commands
- `/lore:warm:keep` — force warming (replaces `/keep`)
- `/lore:warm:stop` — stop warming (replaces `/done`)
- `/lore:warm:auto` — return to normal survival-analysis mode (new)
- Old `/done` and `/keep` removed entirely (no backward-compat aliases)
- Clean state transitions: each command clears the opposite flag

### UI controls
- Auto/Keep/Stop toggle buttons on the Warming page table and per-session warming section
- POST route at `/ui/api/warming/:sessionId/:mode` with mode validation
- New "tool call" badge when a session is actively executing a tool
- Renamed "dead" badge to "stopped" for consistency with new command naming

## Files modified

| File | Changes |
|---|---|
| `packages/gateway/src/cache-warmer.ts` | Tool-call fast-path, `pSessionFinished` signal, `WarmingSnapshot.toolCallActive`, diagnostic reasons, `cooldownFor()` update |
| `packages/gateway/src/idle.ts` | Skip idle work during tool calls |
| `packages/gateway/src/pipeline.ts` | `/lore:warm:*` slash commands |
| `packages/gateway/src/translate/types.ts` | Comment update |
| `packages/gateway/src/ui.ts` | Mode controls, POST route, badges, CSS |
| `packages/gateway/test/cache-warmer.test.ts` | 13 new tests for tool-call warming + pSessionFinished signal |

## Cost analysis

- **Typical** (3-min build, 5m TTL): 0–1 warmup = $0.00–$0.03, saves $0.70–$1.88
- **Worst case** (agent crash, 30-min cap): 6 warmups ≈ $0.18 wasted