### PR TITLE
fix: warmup cooldown timing + rising cost threshold + accurate TTL pricing

### DIFF
--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -93,6 +93,14 @@ const CIRCUIT_BREAKER_MAX_FAILURES = 3;
  *  the 5m TTL warmup window (4:15–5:00). */
 export const BREAK_FLOOR_MS = 180_000;
 
+/** Minimum total warmups before session-level hit-rate ROI check kicks in. */
+export const MIN_WARMUPS_FOR_ROI_CHECK = 10;
+
+/** Minimum session-level hit rate to continue warming. Below this,
+ *  warming is empirically unprofitable and we stop. 20% means at least
+ *  1 in 5 warmups must result in a confirmed user return. */
+export const MIN_SESSION_HIT_RATE = 0.20;
+
 // ---------------------------------------------------------------------------
 // Global circuit breaker
 // ---------------------------------------------------------------------------
@@ -510,6 +518,32 @@ export function costThreshold(
 }
 
 /**
+ * Rising cost threshold that accounts for accumulated warmup costs.
+ *
+ * After k warmup cycles, the total cost is k × read. A hit saves
+ * (write - read). Break-even: P × (write - read) ≥ k × read, so:
+ *   P(returns) > k × read / (write - read)
+ *
+ * This rises linearly with k — the more cycles spent, the higher
+ * P(returns) must be to justify the next warmup. For Opus 5m TTL
+ * (read=$0.50, write=$6.25):
+ *   k=1: 8.7%,  k=3: 26%,  k=5: 43%,  k=6: 52%,  k=11: 96%
+ *
+ * At k=1 this matches costThreshold() exactly.
+ * Clamped to 1.0 so we never require > 100% probability.
+ */
+export function cumulativeCostThreshold(
+  cyclesSpent: number,
+  cacheReadCostPerMTok: number,
+  cacheMissCostPerMTok: number,
+): number {
+  const k = Math.max(cyclesSpent, 1);
+  const denominator = cacheMissCostPerMTok - cacheReadCostPerMTok;
+  if (denominator <= 0) return 1.0;
+  return Math.min((k * cacheReadCostPerMTok) / denominator, 1.0);
+}
+
+/**
  * Maximum profitable warmup cycles before total warming cost exceeds
  * the savings from avoiding a cache write on user return.
  *
@@ -669,14 +703,16 @@ export function shouldWarm(
   const elapsed = now - state.lastRequestTime;
   const { ttlMs, warmupMarginMs, cacheReadCostPerMTok, cacheMissCostPerMTok } = profile;
   const forced = state.warmup?.forceKeepWarm === true;
+  const toolCallActive = state.lastStopReason === "tool_use";
 
   // Already warmed recently — prevent double-warming.
-  // For /lore:warm:keep mode, use a tighter cooldown (ttlMs - warmupMarginMs)
-  // so the next warmup fires before the current cache expires. Without this,
-  // the full-ttlMs guard combined with margin positioning produces a ~2x TTL
-  // cadence (e.g. 10 min on a 5 min TTL), leaving a dead zone each cycle.
-  const toolCallActive = state.lastStopReason === "tool_use";
-  const cooldownMs = (forced || toolCallActive) ? Math.max(ttlMs - warmupMarginMs, 0) : ttlMs;
+  // Cooldown = ttlMs - warmupMarginMs so the next warmup fires while the
+  // previous cache is still alive. Using the full ttlMs as cooldown causes
+  // each continuation warmup to arrive right as the cache expires, turning
+  // every warmup into a cold write (~$1.25 for Opus 200K) instead of a
+  // cheap refresh (~$0.10). This was the dominant cost driver: 65 warmups
+  // at cold-write pricing = ~$65 vs ~$6.50 with correct timing.
+  const cooldownMs = Math.max(ttlMs - warmupMarginMs, 0);
   if (state.warmup?.lastWarmupAt && (now - state.warmup.lastWarmupAt) < cooldownMs) {
     return false;
   }
@@ -698,11 +734,18 @@ export function shouldWarm(
   // --- Tool-call fast path ---
   // When lastStopReason is "tool_use", the agent is executing a tool and
   // WILL return with the result. Bypass survival analysis (return probability
-  // is ~1.0) but respect break-even cap and a maximum duration to handle
-  // agent crashes gracefully.
+  // is ~1.0) but respect break-even cap, session ROI guard, and a maximum
+  // duration to handle agent crashes gracefully.
   if (toolCallActive && !state.warmup?.disabled) {
     // Cap: don't warm indefinitely if the agent crashed mid-tool-call
     if (elapsed > MAX_TOOL_CALL_WARMING_MS) return false;
+
+    // Session-level ROI guard applies even during tool calls
+    const lifetime = state.warmup?.totalWarmups ?? 0;
+    if (lifetime >= MIN_WARMUPS_FOR_ROI_CHECK) {
+      const hitRate = (state.warmup?.warmupHits ?? 0) / lifetime;
+      if (hitRate < MIN_SESSION_HIT_RATE) return false;
+    }
 
     const maxCycles = maxProfitableCycles(cacheReadCostPerMTok, cacheMissCostPerMTok);
     const cyclesSpent = state.warmup?.warmupCount ?? 0;
@@ -727,6 +770,16 @@ export function shouldWarm(
 
   // Session marked dead
   if (state.warmup?.disabled) return false;
+
+  // Session-level ROI guard: after enough warmups, if the observed hit
+  // rate is chronically low, stop warming. This prevents unlimited
+  // spending across many short breaks where each individual break passes
+  // the per-break checks but the aggregate ROI is deeply negative.
+  const lifetime = state.warmup?.totalWarmups ?? 0;
+  if (lifetime >= MIN_WARMUPS_FOR_ROI_CHECK) {
+    const hitRate = (state.warmup?.warmupHits ?? 0) / lifetime;
+    if (hitRate < MIN_SESSION_HIT_RATE) return false;
+  }
 
   // Compute commitment model signals
   const survivalAtIdle = survivalFunction(blendedHist, elapsed);
@@ -781,6 +834,19 @@ export function shouldWarm(
 
     // Session almost certainly finished — stop warming
     if (pFinished > 0.95) {
+      markDeadIfSurvivalLow(state, survivalAtIdle);
+      return false;
+    }
+
+    // Rising cost threshold: after k cycles, the accumulated warmup cost
+    // means we need a higher P(returns) to justify the next one.
+    // k=1: 8.7%, k=3: 26%, k=5: 43%, k=6: 52% for Opus 5m.
+    const risingThreshold = cumulativeCostThreshold(
+      cyclesSpent + 1, // +1 because we're deciding whether to do the NEXT cycle
+      cacheReadCostPerMTok,
+      cacheMissCostPerMTok,
+    );
+    if (pReturns <= risingThreshold) {
       markDeadIfSurvivalLow(state, survivalAtIdle);
       return false;
     }
@@ -969,6 +1035,10 @@ export function computeWarmingSnapshot(
         notWarmingReason = `Too few turns (${state.messageCount} < ${MIN_TURNS_FOR_WARMING * 2})`;
       } else if (idleMs > MAX_TOOL_CALL_WARMING_MS) {
         notWarmingReason = `Tool call exceeded max duration (${Math.round(idleMs / 60_000)}min > 30min)`;
+      } else if ((state.warmup?.totalWarmups ?? 0) >= MIN_WARMUPS_FOR_ROI_CHECK &&
+                 (state.warmup?.warmupHits ?? 0) / (state.warmup?.totalWarmups ?? 1) < MIN_SESSION_HIT_RATE) {
+        const hitRate = ((state.warmup?.warmupHits ?? 0) / (state.warmup?.totalWarmups ?? 1) * 100).toFixed(0);
+        notWarmingReason = `Tool call: session hit rate too low (${hitRate}% < ${(MIN_SESSION_HIT_RATE * 100).toFixed(0)}%)`;
       } else {
         const maxCyc = maxProfitableCycles(profile.cacheReadCostPerMTok, profile.cacheMissCostPerMTok);
         if ((state.warmup?.warmupCount ?? 0) >= maxCyc) {
@@ -986,6 +1056,10 @@ export function computeWarmingSnapshot(
       notWarmingReason = `Too few turns (${state.messageCount} < ${MIN_TURNS_FOR_WARMING * 2})`;
     } else if (state.warmup?.disabled) {
       notWarmingReason = "Warming stopped (/lore:warm:stop)";
+    } else if ((state.warmup?.totalWarmups ?? 0) >= MIN_WARMUPS_FOR_ROI_CHECK &&
+               (state.warmup?.warmupHits ?? 0) / (state.warmup?.totalWarmups ?? 1) < MIN_SESSION_HIT_RATE) {
+      const hitRate = ((state.warmup?.warmupHits ?? 0) / (state.warmup?.totalWarmups ?? 1) * 100).toFixed(0);
+      notWarmingReason = `Session hit rate too low (${hitRate}% < ${(MIN_SESSION_HIT_RATE * 100).toFixed(0)}% after ${state.warmup?.totalWarmups} warmups)`;
     } else if (isFirstWindow && idleMs < ttlMs - warmupMarginMs) {
       notWarmingReason = "Cache still fresh";
     } else if (pReturns <= thresholdVal) {
@@ -994,6 +1068,13 @@ export function computeWarmingSnapshot(
       notWarmingReason = `Break-even exceeded (${cyclesSpent} >= ${maxCyclesVal} cycles)`;
     } else if (!isFirstWindow && pFinished > 0.95) {
       notWarmingReason = `Session finished (P=${(pFinished * 100).toFixed(0)}%)`;
+    } else if (!isFirstWindow) {
+      const risingThresh = cumulativeCostThreshold(cyclesSpent + 1, profile.cacheReadCostPerMTok, profile.cacheMissCostPerMTok);
+      if (pReturns <= risingThresh) {
+        notWarmingReason = `Rising threshold: P(returns) ${(pReturns * 100).toFixed(1)}% <= ${(risingThresh * 100).toFixed(1)}% at cycle ${cyclesSpent + 1}`;
+      } else {
+        notWarmingReason = "Unknown";
+      }
     } else {
       notWarmingReason = "Unknown";
     }
@@ -1039,11 +1120,9 @@ export function computeWarmingSnapshot(
   };
 }
 
-/** Compute cooldown based on forced/tool-call/normal mode. */
-function cooldownFor(state: SessionState, ttlMs: number, warmupMarginMs: number): number {
-  return (state.warmup?.forceKeepWarm || state.lastStopReason === "tool_use")
-    ? Math.max(ttlMs - warmupMarginMs, 0)
-    : ttlMs;
+/** Cooldown between warmups — must match shouldWarm() logic. */
+function cooldownFor(_state: SessionState, ttlMs: number, warmupMarginMs: number): number {
+  return Math.max(ttlMs - warmupMarginMs, 0);
 }
 
 // ---------------------------------------------------------------------------
@@ -1201,11 +1280,13 @@ export async function executeWarmup(
     }
 
     // Accumulate warmup cost for the session
+    const ttl: "5m" | "1h" = profile.ttlMs >= 3_600_000 ? "1h" : "5m";
     recordWarmupCost(
       state.sessionID,
       state.lastModel ?? "unknown",
       cacheReadTokens,
       cacheCreationTokens,
+      ttl,
     );
 
     // Update session warmup state

--- a/packages/gateway/src/cost-tracker.ts
+++ b/packages/gateway/src/cost-tracker.ts
@@ -322,17 +322,23 @@ export function recordWorkerCost(
 
 /**
  * Record a cache warmup cost (called from executeWarmup).
+ *
+ * @param ttl - Cache TTL for this session. Anthropic charges 2× cache_write
+ *   for 1h TTL; without this parameter the cost is undercounted by 50%.
  */
 export function recordWarmupCost(
   sessionID: string,
   model: string,
   cacheReadTokens: number,
   cacheCreationTokens: number,
+  ttl?: "5m" | "1h",
 ): void {
   const costs = getOrCreate(sessionID);
   const pricing = getPricingSync(model);
   const readCost = (cacheReadTokens / 1_000_000) * pricing.cache_read;
-  const writeCost = (cacheCreationTokens / 1_000_000) * pricing.cache_write;
+  // Anthropic doubles cache_write pricing for 1h TTL
+  const cacheWriteRate = ttl === "1h" ? pricing.cache_write * 2 : pricing.cache_write;
+  const writeCost = (cacheCreationTokens / 1_000_000) * cacheWriteRate;
   costs.workers.warmup.cost += readCost + writeCost;
   costs.workers.warmup.calls++;
 }
@@ -453,17 +459,22 @@ export function updateShadowContext(
  * the next request would pay full cache_write cost instead of cache_read.
  *
  * @param cacheReadTokens - Cache read tokens from the turn that confirmed the hit
+ * @param ttl - Cache TTL for this session. Anthropic charges 2× cache_write
+ *   for 1h TTL; without this parameter savings are undercounted.
  */
 export function recordWarmupHit(
   sessionID: string,
   model: string,
   cacheReadTokens: number,
+  ttl?: "5m" | "1h",
 ): void {
   const costs = getOrCreate(sessionID);
   const pricing = getPricingSync(model);
+  // Anthropic doubles cache_write pricing for 1h TTL
+  const cacheWriteRate = ttl === "1h" ? pricing.cache_write * 2 : pricing.cache_write;
   // Without warming, these reads would have been writes
   const savings =
-    (cacheReadTokens / 1_000_000) * (pricing.cache_write - pricing.cache_read);
+    (cacheReadTokens / 1_000_000) * (cacheWriteRate - pricing.cache_read);
   costs.counterfactual.warmupSavings += savings;
   costs.counterfactual.warmupHits++;
 }
@@ -474,6 +485,11 @@ export function recordWarmupHit(
  * Called when a turn has cache reads but the gap since the last request
  * exceeds 5 minutes — meaning the 5m TTL would have expired, but the
  * 1h TTL kept the cache alive.
+ *
+ * The counterfactual is against 5m TTL (base cache_write rate), NOT 1h —
+ * the saving comes from having 1h TTL instead of 5m, so the write cost
+ * avoided is the 5m rate. The 1h surcharge is the price we paid to get
+ * the longer TTL in the first place.
  */
 export function recordTTLSavings(
   sessionID: string,
@@ -482,6 +498,8 @@ export function recordTTLSavings(
 ): void {
   const costs = getOrCreate(sessionID);
   const pricing = getPricingSync(model);
+  // Counterfactual: without 1h TTL, the 5m cache would have expired and
+  // these reads would have been 5m-rate writes. Use base cache_write.
   const savings =
     (cacheReadTokens / 1_000_000) * (pricing.cache_write - pricing.cache_read);
   costs.counterfactual.ttlSavings += savings;

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -2079,7 +2079,12 @@ function postResponse(
           // reads would have been full cache writes.
           const cacheRead = resp.usage.cacheReadInputTokens ?? 0;
           if (cacheRead > 0) {
-            recordWarmupHit(sessionID, req.model, cacheRead);
+            recordWarmupHit(
+              sessionID,
+              req.model,
+              cacheRead,
+              sessionState.resolvedConversationTTL ?? "5m",
+            );
           }
           log.info(
             `cache-warmer: HIT session=${sessionID.slice(0, 16)} ` +

--- a/packages/gateway/test/cache-warmer.test.ts
+++ b/packages/gateway/test/cache-warmer.test.ts
@@ -14,8 +14,11 @@ import {
   pSessionFinished,
   expectedWarmupCycles,
   costThreshold,
+  cumulativeCostThreshold,
   maxProfitableCycles,
   MAX_TOOL_CALL_WARMING_MS,
+  MIN_WARMUPS_FOR_ROI_CHECK,
+  MIN_SESSION_HIT_RATE,
   HISTOGRAM_BINS,
   BREAK_FLOOR_MS,
   _resetForTest,
@@ -750,17 +753,20 @@ describe("shouldWarm", () => {
     expect(shouldWarm(state, profile, hist, now)).toBe(true);
   });
 
-  test("non-forced mode still uses full ttlMs cooldown", () => {
+  test("non-forced mode uses ttlMs - margin cooldown (same as forced)", () => {
     const now = Date.now();
-    // Same timing as above but without forceKeepWarm — should be blocked
-    // by the full ttlMs cooldown since 260s < 300s.
+    // Cooldown is ttlMs - warmupMarginMs = 300s - 45s = 255s for 5m TTL.
+    // A warmup 260s ago is past the 255s cooldown, so it should be allowed.
+    // (The old code used full ttlMs=300s cooldown, which caused every
+    // continuation warmup to arrive after the cache expired — a cold write
+    // instead of a cheap refresh.)
     const state = makeSessionState({
       lastRequestTime: now - 270_000, // 4.5 min ago — in warmup margin
       warmup: {
-        lastWarmupAt: now - 260_000, // 4m20s ago — within full TTL cooldown
+        lastWarmupAt: now - 260_000, // 4m20s ago — past 255s cooldown
         warmupCount: 1,
         totalWarmups: 1,
-        warmupHits: 0,
+        warmupHits: 1, // need hit rate >= 20% for ROI check
         disabled: false,
         // no forceKeepWarm
       },
@@ -773,8 +779,25 @@ describe("shouldWarm", () => {
     const hist = createHistogram();
     for (let i = 0; i < 50; i++) recordGap(hist, 360_000);
 
-    // 260s < 300s (full TTL cooldown) → blocked
-    expect(shouldWarm(state, profile, hist, now)).toBe(false);
+    // 260s > 255s (ttlMs - margin cooldown) → allowed
+    expect(shouldWarm(state, profile, hist, now)).toBe(true);
+
+    // But 250s ago is within the 255s cooldown → blocked
+    const stateRecent = makeSessionState({
+      lastRequestTime: now - 270_000,
+      warmup: {
+        lastWarmupAt: now - 250_000, // 4m10s ago — within 255s cooldown
+        warmupCount: 1,
+        totalWarmups: 1,
+        warmupHits: 1,
+        disabled: false,
+      },
+      cacheAnalytics: {
+        ...makeCacheAnalytics(),
+        lastRequestBody: compressBody('{"model":"claude-sonnet-4-20250514","max_tokens":16384,"stream":true,"messages":[{"role":"user","content":"test"}]}'),
+      },
+    });
+    expect(shouldWarm(stateRecent, profile, hist, now)).toBe(false);
   });
 
   test("forceKeepWarm still respects circuit breaker", () => {
@@ -1749,5 +1772,161 @@ describe("pSessionFinished tool_use signal", () => {
     // Despite high text-only runs, tool_use should keep P(finished) low
     const p = pSessionFinished(signals);
     expect(p).toBeLessThan(0.5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cumulativeCostThreshold
+// ---------------------------------------------------------------------------
+
+describe("cumulativeCostThreshold", () => {
+  // Opus 5m TTL: read=$0.50, write=$6.25
+  const read = 0.50;
+  const write = 6.25;
+  const spread = write - read; // 5.75
+
+  test("at k=1 matches costThreshold()", () => {
+    const rising = cumulativeCostThreshold(1, read, write);
+    const flat = costThreshold(read, write);
+    expect(rising).toBeCloseTo(flat, 6);
+  });
+
+  test("rises linearly with k", () => {
+    const t1 = cumulativeCostThreshold(1, read, write);
+    const t3 = cumulativeCostThreshold(3, read, write);
+    const t5 = cumulativeCostThreshold(5, read, write);
+    const t6 = cumulativeCostThreshold(6, read, write);
+
+    // k × read / (write - read)
+    expect(t1).toBeCloseTo(1 * read / spread, 6); // ~8.7%
+    expect(t3).toBeCloseTo(3 * read / spread, 6); // ~26.1%
+    expect(t5).toBeCloseTo(5 * read / spread, 6); // ~43.5%
+    expect(t6).toBeCloseTo(6 * read / spread, 6); // ~52.2%
+
+    // Must be strictly increasing
+    expect(t3).toBeGreaterThan(t1);
+    expect(t5).toBeGreaterThan(t3);
+    expect(t6).toBeGreaterThan(t5);
+  });
+
+  test("clamps to 1.0 when k exceeds maxProfitableCycles", () => {
+    const maxCyc = maxProfitableCycles(read, write); // floor(5.75/0.50) = 11
+    const tMax = cumulativeCostThreshold(maxCyc, read, write);
+    const tOver = cumulativeCostThreshold(maxCyc + 1, read, write);
+
+    // At maxCycles: 11 * 0.50 / 5.75 = 95.7%
+    expect(tMax).toBeCloseTo(11 * read / spread, 6);
+    // Beyond maxCycles: clamped to 1.0
+    expect(tOver).toBe(1.0);
+  });
+
+  test("k=0 is treated as k=1", () => {
+    expect(cumulativeCostThreshold(0, read, write)).toBe(cumulativeCostThreshold(1, read, write));
+  });
+
+  test("degenerate case: write <= read returns 1.0", () => {
+    expect(cumulativeCostThreshold(1, 5.0, 5.0)).toBe(1.0);
+    expect(cumulativeCostThreshold(1, 5.0, 3.0)).toBe(1.0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Session-level ROI guard
+// ---------------------------------------------------------------------------
+
+describe("shouldWarm session ROI guard", () => {
+  beforeEach(() => _resetForTest());
+
+  test("rejects warming when session hit rate is below threshold after enough warmups", () => {
+    const now = Date.now();
+    const state = makeSessionState({
+      lastRequestTime: now - 270_000, // in warmup margin
+      warmup: {
+        lastWarmupAt: 0,
+        warmupCount: 0,
+        totalWarmups: 12,  // >= MIN_WARMUPS_FOR_ROI_CHECK (10)
+        warmupHits: 1,     // 8.3% < MIN_SESSION_HIT_RATE (20%)
+        disabled: false,
+      },
+      cacheAnalytics: {
+        ...makeCacheAnalytics(),
+        lastRequestBody: compressBody('{"model":"claude-sonnet-4-20250514","max_tokens":16384,"stream":true,"messages":[{"role":"user","content":"test"}]}'),
+      },
+    });
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+    const hist = createHistogram();
+    for (let i = 0; i < 50; i++) recordGap(hist, 360_000);
+
+    expect(shouldWarm(state, profile, hist, now)).toBe(false);
+  });
+
+  test("allows warming when session hit rate is above threshold", () => {
+    const now = Date.now();
+    const state = makeSessionState({
+      lastRequestTime: now - 270_000,
+      warmup: {
+        lastWarmupAt: 0,
+        warmupCount: 0,
+        totalWarmups: 10,
+        warmupHits: 3,     // 30% > MIN_SESSION_HIT_RATE (20%)
+        disabled: false,
+      },
+      cacheAnalytics: {
+        ...makeCacheAnalytics(),
+        lastRequestBody: compressBody('{"model":"claude-sonnet-4-20250514","max_tokens":16384,"stream":true,"messages":[{"role":"user","content":"test"}]}'),
+      },
+    });
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+    const hist = createHistogram();
+    for (let i = 0; i < 50; i++) recordGap(hist, 360_000);
+
+    expect(shouldWarm(state, profile, hist, now)).toBe(true);
+  });
+
+  test("skips ROI check when fewer than MIN_WARMUPS_FOR_ROI_CHECK warmups", () => {
+    const now = Date.now();
+    const state = makeSessionState({
+      lastRequestTime: now - 270_000,
+      warmup: {
+        lastWarmupAt: 0,
+        warmupCount: 0,
+        totalWarmups: 5,   // < MIN_WARMUPS_FOR_ROI_CHECK (10)
+        warmupHits: 0,     // 0% hit rate, but too few warmups to judge
+        disabled: false,
+      },
+      cacheAnalytics: {
+        ...makeCacheAnalytics(),
+        lastRequestBody: compressBody('{"model":"claude-sonnet-4-20250514","max_tokens":16384,"stream":true,"messages":[{"role":"user","content":"test"}]}'),
+      },
+    });
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+    const hist = createHistogram();
+    for (let i = 0; i < 50; i++) recordGap(hist, 360_000);
+
+    expect(shouldWarm(state, profile, hist, now)).toBe(true);
+  });
+
+  test("ROI guard applies to tool-call path too", () => {
+    const now = Date.now();
+    const state = makeSessionState({
+      lastRequestTime: now - 270_000,
+      lastStopReason: "tool_use",
+      warmup: {
+        lastWarmupAt: 0,
+        warmupCount: 0,
+        totalWarmups: 15,
+        warmupHits: 1,     // 6.7% < MIN_SESSION_HIT_RATE (20%)
+        disabled: false,
+      },
+      cacheAnalytics: {
+        ...makeCacheAnalytics(),
+        lastRequestBody: compressBody('{"model":"claude-sonnet-4-20250514","max_tokens":16384,"stream":true,"messages":[{"role":"user","content":"test"}]}'),
+      },
+    });
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+    const hist = createHistogram();
+    for (let i = 0; i < 50; i++) recordGap(hist, 360_000);
+
+    expect(shouldWarm(state, profile, hist, now)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Fixes cache warming economics — warmup was costing **$65.89** but only saving **$4.43** (net -$59.50). The dominant issue was a cooldown timing bug causing every continuation warmup to be a cold cache write (~$1.25) instead of a cheap refresh (~$0.10).

## Root Cause

The normal-path cooldown was set to `ttlMs` (300s for 5m TTL) instead of `ttlMs - warmupMarginMs` (255s). Since warmups fire in the margin window (4:15–5:00), a 300s cooldown means the next warmup fires right as the previous cache expires — every warmup is a cold write. The forced/tool-call path already used the correct tighter cooldown.

## Changes

### Fix 1: Cooldown timing (the $65 → $6.50 fix)
- Uses `ttlMs - warmupMarginMs` as cooldown for **all** paths, not just forced/tool-call
- Each continuation warmup now fires while the previous cache is still alive (cache read ~$0.10 vs cold write ~$1.25)
- Also fixes `cooldownFor()` (used by dashboard diagnostics) to match

### Fix 2: Rising cumulative cost threshold
- Adds `cumulativeCostThreshold(k, read, write)` — after k warmup cycles, break-even requires higher P(returns)
- Formula: `P > k × read / (write - read)` — rises linearly with cycles spent
- For Opus 5m: k=1 needs 8.7%, k=3 needs 26%, k=5 needs 43%, k=6 needs 52%
- At k=1 matches `costThreshold()` exactly; clamped to 1.0
- Applied in Phase B continuation to replace the flat 8.7% threshold

### Fix 3: TTL-aware cost recording
- `recordWarmupCost()` and `recordWarmupHit()` accept optional `ttl` parameter
- For 1h TTL sessions, doubles `cache_write` to match Anthropic's actual pricing
- Previously, displayed costs and savings were undercounted by up to 50% for 1h sessions
- `recordTTLSavings` intentionally uses base rate (counterfactual is against 5m, not 1h)

### Fix 4: Session-level ROI guard
- After 10+ total warmups, if session hit rate < 20%, warming stops entirely
- Applies to both normal path AND tool-call fast path
- Prevents unlimited spending across many short breaks where per-break checks pass but aggregate ROI is negative
- Dashboard `notWarmingReason` updated to show ROI guard and rising threshold rejections

### Tests
- Updated cooldown test to verify the fix (260s > 255s allowed, 250s < 255s blocked)
- Added `cumulativeCostThreshold()` tests: formula values, k=1 matches `costThreshold()`, clamping, edge cases
- Added session ROI guard tests: low hit rate rejected, high hit rate allowed, skipped below 10 warmups, applies to tool-call path

## Impact Estimate

For the session that triggered investigation (410 turns, 65 warmups, 12 hits):
- **Before**: $65.89 warmup cost, $4.43 savings → net **-$61.46**
- **After (cooldown fix alone)**: ~$6.50 warmup cost → net **-$2.07**
- **After (all fixes)**: Rising threshold stops warming around cycle 5-6, ROI guard prevents chronically unprofitable sessions