### PR TITLE
feat: add session recording, replay, and scenario filtering to eval harness

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -18,11 +18,11 @@
 
 ### Decision
 
+<!-- lore:019e3d03-94ee-7074-983d-05429d165061 -->
+* **Migrated to Vitest (no longer using Mocha/Chai/ts-node)**: Migrated to Vitest (no longer using Mocha/Chai/ts-node). See code style preferences entry for full rationale (~30ms vs ~312ms startup, Jest-compatible API, no ts-node dependency).
+
 <!-- lore:019e2b12-6eb0-7996-9a6b-d7ee8ea743e7 -->
 * **SaaS/CLI-less interaction pattern: ANTHROPIC\_CUSTOM\_HEADERS won't work without local CLI**: SaaS/CLI-less interaction pattern: \`ANTHROPIC\_CUSTOM\_HEADERS\` env var requires a local \`lore\` CLI process. In a future pure SaaS product (no local CLI), this breaks. Research item: need an alternative for CLI-less context injection (API key-scoped session metadata, SDK-level header injection, or gateway-side project config API). For now, \`LORE\_REMOTE\_URL\` + local CLI is the supported pattern. When \`LORE\_REMOTE\_URL\` is set, \`lore run\`/\`lore start\` skips local gateway startup and proxies to the remote URL. Local CLI still computes git remote and injects it as \`X-Lore-Git-Remote\` — remote gateway trusts the header, never calls \`getGitRemote()\` with client-controlled paths.
-
-<!-- lore:019e3cd1-7436-7d8b-93fc-f8701dbddcde -->
-* **Switched from Mocha + Chai to Vitest**: switched from Mocha + Chai to Vitest.
 
 ### Gotcha
 
@@ -85,4 +85,4 @@
 * **Prefer WASM backend over native onnxruntime-node for compiled binaries**: WASM backend for Bun \`--compile\` binaries with transformers.js: \`binaryExternalsPlugin\` in esbuild redirects \`onnxruntime-node\` → \`onnxruntime-web\` via \`onResolve\` (static imports only — does NOT redirect dynamic \`import()\` calls) and patches transformers.js CDN fallback via \`onLoad\` to read \`wasmPaths\` from \`globalThis.\_\_LORE\_VENDOR\_WASM\_PATHS\_\_\` (object form \`{ mjs, wasm }\` with exact hashed \`$bunfs\` filenames — directory strings fail because Bun hashes bundled WASM filenames). WASM files embedded as Bun \`{ type: 'file' }\` assets in the wrapper; wrapper sets \`globalThis.\_\_LORE\_VENDOR\_WASM\_PATHS\_\_\` before importing the worker. No onnxruntime import in wrapper or worker. For npm/CJS builds, \`onnxruntime-node\` stays external. WASM is ~2x faster on batches than native. Importing \`onnxruntime-web\` explicitly alongside the redirect creates two ort instances — 'cannot register backend cpu using priority 10' error.
 
 <!-- lore:019e3cb9-82ed-725c-87ab-f03727dcd120 -->
-* **Prefers functional components over class components in React — reason: simpler**: Code style preferences (all invariant): (1) Functional components over class components in React — simpler. (2) Named exports over default exports everywhere — explicit imports, refactor-friendly. (3) Always uses pnpm (not npm or yarn) — faster, handles node\_modules better. (4) Vitest over Mocha+Chai — 30ms vs 312ms startup, Jest-compatible API, no ts-node dependency. (5) Always use TypeScript strict mode — \`strict: true\` and \`noImplicitAny: true\` in tsconfig; never allow \`any\` types. (6) Kebab-case file names — e.g. \`user-profile.tsx\`, \`data-table.tsx\`.
+* **Prefers functional components over class components in React — reason: simpler**: Code style preferences (invariant): (1) Functional components over class components in React. (2) Named exports over default exports everywhere. (3) Always uses pnpm (not npm or yarn). (4) Vitest over Mocha+Chai — ~30ms vs ~312ms startup, Jest-compatible API, no ts-node dependency. Migrated May 18. (5) TypeScript strict mode — \`strict: true\` and \`noImplicitAny: true\`; never allow \`any\`. (6) Kebab-case file names — e.g. \`user-profile.tsx\`. (7) Use \`const\` for arrays/objects that are mutated but never reassigned.

--- a/packages/core/eval/harness.ts
+++ b/packages/core/eval/harness.ts
@@ -12,9 +12,10 @@
  *   - fixture: deterministic replay via UpstreamInterceptor, no real API calls
  *   - live: real API calls through the gateway, LLM-as-judge scoring
  */
-import { existsSync, mkdirSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { appendFile } from "node:fs/promises";
-import { dirname, resolve } from "node:path";
+import { dirname, resolve, join } from "node:path";
+import type { FixtureEntry } from "../../gateway/src/recorder";
 import type {
   EvalConfig,
   EvalResult,
@@ -549,8 +550,7 @@ async function askQuestionViaGateway(
   };
 }
 
-/** Delay between gateway QA calls to respect token-per-minute limits. */
-const GATEWAY_QA_DELAY_MS = 5_000;
+
 
 async function askQuestion(
   question: string,
@@ -595,6 +595,92 @@ async function writeResult(
 // Run a single scenario
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Session recording & replay
+// ---------------------------------------------------------------------------
+
+/**
+ * Replay a session, optionally recording or replaying upstream responses.
+ *
+ * - record mode: enables the gateway recorder during replay, saves NDJSON after
+ * - replay mode: loads NDJSON fixtures, wires replay interceptor during replay
+ * - normal mode: passthrough to replaySession()
+ *
+ * The interceptor is scoped to replaySession() only — /lore:curate and QA
+ * calls happen after the interceptor is cleared, so they use real upstream.
+ */
+async function replaySessionWithFixtures(
+  session: SessionTranscript,
+  scenario: ScenarioDefinition,
+  gateway: GatewayHandle,
+  config: EvalConfig,
+): Promise<ReplayResult> {
+  const { setUpstreamInterceptor } = await import(
+    "../../gateway/src/pipeline"
+  );
+
+  if (config.recordDir) {
+    // --- RECORD MODE ---
+    const { startRecording, stopRecording, getRecordedInterceptor } =
+      await import("../../gateway/src/recorder");
+
+    const dir = join(config.recordDir, scenario.id);
+    mkdirSync(dir, { recursive: true });
+    const fixturePath = join(dir, `${session.id}.ndjson`);
+
+    startRecording(fixturePath);
+    const interceptor = getRecordedInterceptor();
+    if (interceptor) setUpstreamInterceptor(interceptor);
+
+    try {
+      return await replaySession(session, gateway);
+    } finally {
+      stopRecording();
+      setUpstreamInterceptor(undefined);
+    }
+  }
+
+  if (config.replayDir) {
+    // --- REPLAY MODE ---
+    const { getReplayInterceptor } = await import(
+      "../../gateway/src/recorder"
+    );
+
+    const fixturePath = join(
+      config.replayDir,
+      scenario.id,
+      `${session.id}.ndjson`,
+    );
+    if (!existsSync(fixturePath)) {
+      throw new Error(
+        `Replay fixture not found: ${fixturePath}\n` +
+          `Run with --record ${config.replayDir} first to create fixtures.`,
+      );
+    }
+
+    const lines = readFileSync(fixturePath, "utf-8")
+      .trim()
+      .split("\n")
+      .filter((l) => l.trim());
+    const fixtures: FixtureEntry[] = lines.map((l) => JSON.parse(l));
+
+    setUpstreamInterceptor(getReplayInterceptor(fixtures));
+
+    try {
+      return await replaySession(session, gateway);
+    } finally {
+      setUpstreamInterceptor(undefined);
+    }
+  }
+
+  // --- NORMAL MODE ---
+  return replaySession(session, gateway);
+}
+
+// ---------------------------------------------------------------------------
+// Run a single scenario
+// ---------------------------------------------------------------------------
+
 export async function runScenario(
   scenario: ScenarioDefinition,
   config: EvalConfig,
@@ -620,7 +706,7 @@ export async function runScenario(
     if (gateway.isReal !== false) {
       for (const session of scenario.sessions) {
         try {
-          await replaySession(session, gateway);
+          await replaySessionWithFixtures(session, scenario, gateway, config);
 
           // Force synchronous curation via slash command.
           // This ensures knowledge entries are created/updated before
@@ -692,8 +778,6 @@ export async function runScenario(
         ) {
           // Gateway-based baselines: send the question through the gateway
           // so it gets Lore's LTM injection, recall, and distilled context.
-          // Add delay between calls to respect token-per-minute limits.
-          await new Promise((r) => setTimeout(r, GATEWAY_QA_DELAY_MS));
           const answer = await askQuestionViaGateway(
             q.question,
             gateway,
@@ -759,8 +843,13 @@ export async function runEval(config: EvalConfig): Promise<EvalResult[]> {
   const allResults: EvalResult[] = [];
 
   try {
-    // Import scenario modules for selected dimensions
-    const scenarioModules = await loadScenarios(config.dimensions);
+    // Import scenario modules for selected dimensions, filtered by --scenarios
+    let scenarioModules = await loadScenarios(config.dimensions);
+    if (config.scenarios?.length) {
+      scenarioModules = scenarioModules.filter((s) =>
+        config.scenarios!.includes(s.id),
+      );
+    }
 
     for (const scenario of scenarioModules) {
       console.log(

--- a/packages/core/eval/run.ts
+++ b/packages/core/eval/run.ts
@@ -32,6 +32,9 @@ const { values: args } = parseArgs({
     "judge-model": { type: "string", default: "" },
     concurrency: { type: "string", default: "3" },
     output: { type: "string", default: "" },
+    record: { type: "string", default: "" },
+    replay: { type: "string", default: "" },
+    scenarios: { type: "string", default: "" },
     summarize: { type: "string", default: "" },
     help: { type: "boolean", default: false },
   },
@@ -62,6 +65,9 @@ Options:
   --judge-model <name>        Model for LLM-as-judge (default: same as --model)
   --concurrency <n>           Parallel question limit (default: 3)
   --output <path>             Output JSONL path (default: auto-generated)
+  --record <dir>              Record session replay data to directory (first run)
+  --replay <dir>              Replay session data from directory (skip upstream API calls)
+  --scenarios <id,...>        Run only specific scenarios (e.g., pr-3-evolution)
   --summarize <path>          Print summary from existing JSONL file and exit
   --help                      Show this help
 `);
@@ -119,6 +125,11 @@ const outputPath =
     `eval-${new Date().toISOString().slice(0, 19).replace(/[:.]/g, "-")}.jsonl`,
   );
 
+if (args.record && args.replay) {
+  console.error("Cannot use --record and --replay together");
+  process.exit(1);
+}
+
 const config: EvalConfig = {
   mode: (args.mode as "fixture" | "live") || "fixture",
   gateway: parseGateway(args.gateway || ""),
@@ -128,6 +139,9 @@ const config: EvalConfig = {
   outputPath,
   dimensions: parseDimensions(args.dimensions || "all"),
   baselines: parseBaselines(args.baselines || ""),
+  recordDir: args.record ? resolve(args.record) : undefined,
+  replayDir: args.replay ? resolve(args.replay) : undefined,
+  scenarios: args.scenarios ? args.scenarios.split(",").map((s) => s.trim()) : undefined,
 };
 
 // ---------------------------------------------------------------------------
@@ -138,6 +152,9 @@ console.log(`Lore Eval Suite`);
 console.log(`  Mode:       ${config.mode}`);
 console.log(`  Dimensions: ${config.dimensions.join(", ")}`);
 console.log(`  Baselines:  ${config.baselines.join(", ")}`);
+if (config.recordDir) console.log(`  Recording:  ${config.recordDir}`);
+if (config.replayDir) console.log(`  Replaying:  ${config.replayDir}`);
+if (config.scenarios) console.log(`  Scenarios:  ${config.scenarios.join(", ")}`);
 console.log(`  Output:     ${config.outputPath}`);
 console.log(`  Model:      ${config.model}`);
 console.log("");

--- a/packages/core/eval/types.ts
+++ b/packages/core/eval/types.ts
@@ -221,6 +221,12 @@ export interface EvalConfig {
   outputPath: string;
   dimensions: Dimension[];
   baselines: BaselineMode[];
+  /** Directory to write session recordings (first run). */
+  recordDir?: string;
+  /** Directory to read session recordings (subsequent runs). */
+  replayDir?: string;
+  /** Filter to specific scenario IDs. */
+  scenarios?: string[];
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds session recording/replay to the eval harness for ~90% cost reduction on subsequent runs, plus scenario filtering for targeted testing.

## New CLI flags

```bash
# First run: record session replay data
bun packages/core/eval/run.ts --mode live --record fixtures/recorded --dimensions preferences

# Subsequent runs: replay from fixtures (skip expensive upstream API calls)
bun packages/core/eval/run.ts --mode live --replay fixtures/recorded --dimensions preferences

# Run only specific scenarios
bun packages/core/eval/run.ts --mode live --scenarios pr-3-evolution --baselines lore
```

## How it works

Session replay is the dominant eval cost (~$2-3 per run with 24+ upstream Anthropic API calls with growing context windows). The recording system:

1. **Record mode** (`--record <dir>`): Enables the gateway's existing `startRecording()` interceptor during `replaySession()` calls. Upstream request/response pairs are saved as NDJSON files (one per session). The interceptor is scoped to session replay only — `/lore:curate` and QA calls are unaffected.

2. **Replay mode** (`--replay <dir>`): Loads recorded NDJSON fixtures and wires the gateway's `getReplayInterceptor()` during session replay. The gateway still fully processes every turn (temporal storage, session tracking, gradient state) — only the upstream HTTP call is replaced. `/lore:curate` and QA questions still use real API calls.

## Cost comparison (PR-3 evolution scenario)

| Mode | Session replay | Distill + Curate | QA + Judge | Total |
|---|---|---|---|---|
| Record (first run) | ~$2-3 (24 calls) | ~$0.30 | ~$0.05 | ~$2.35 |
| Replay (subsequent) | $0 (fixtures) | ~$0.30 | ~$0.03 | ~$0.33 |

## Other changes

- **`--scenarios` filter**: Run only specific scenarios by ID (comma-separated)
- **Removed 5s QA delay**: No longer needed with `/lore:curate` handling curation synchronously

## Files Changed
- `packages/core/eval/types.ts` — `recordDir`, `replayDir`, `scenarios` fields on EvalConfig
- `packages/core/eval/run.ts` — CLI flags + validation
- `packages/core/eval/harness.ts` — `replaySessionWithFixtures()`, scenario filtering, delay removal