### PR TITLE
feat: add temperature parameter to LLMClient interface

### DIFF
--- a/packages/core/src/curator.ts
+++ b/packages/core/src/curator.ts
@@ -226,7 +226,7 @@ async function runInner(input: {
   const responseText = await input.llm.prompt(
     CURATOR_SYSTEM,
     userContent,
-    { model, workerID: "lore-curator", thinking: false, sessionID: input.sessionID, maxTokens: 2048 },
+    { model, workerID: "lore-curator", thinking: false, sessionID: input.sessionID, maxTokens: 2048, temperature: 0 },
   );
   if (!responseText) return { created: 0, updated: 0, deleted: 0 };
 
@@ -314,7 +314,7 @@ export async function consolidate(input: {
   const responseText = await input.llm.prompt(
     CONSOLIDATION_SYSTEM,
     userContent,
-    { model, workerID: "lore-curator", thinking: false, sessionID: input.sessionID, maxTokens: 4096 },
+    { model, workerID: "lore-curator", thinking: false, sessionID: input.sessionID, maxTokens: 4096, temperature: 0 },
   );
   if (!responseText) return { updated: 0, deleted: 0 };
 

--- a/packages/core/src/distillation.ts
+++ b/packages/core/src/distillation.ts
@@ -783,7 +783,7 @@ async function distillSegment(input: {
   const responseText = await input.llm.prompt(
     DISTILLATION_SYSTEM,
     userContent,
-    { model, workerID: "lore-distill", thinking: false, urgent: input.urgent, sessionID: input.sessionID, maxTokens },
+    { model, workerID: "lore-distill", thinking: false, urgent: input.urgent, sessionID: input.sessionID, maxTokens, temperature: 0 },
   );
   if (!responseText) return null;
 
@@ -984,7 +984,7 @@ async function metaDistillInner(input: {
   const responseText = await input.llm.prompt(
     RECURSIVE_SYSTEM,
     userContent,
-    { model, workerID: "lore-distill", thinking: false, urgent: input.urgent, sessionID: input.sessionID, maxTokens },
+    { model, workerID: "lore-distill", thinking: false, urgent: input.urgent, sessionID: input.sessionID, maxTokens, temperature: 0 },
   );
   if (!responseText) return null;
 

--- a/packages/core/src/import/extract.ts
+++ b/packages/core/src/import/extract.ts
@@ -106,6 +106,7 @@ export async function extractKnowledge(input: {
           thinking: false,
           maxTokens: 4096,
           sessionID: input.sessionID,
+          temperature: 0,
         },
       );
 

--- a/packages/core/src/pattern-echo.ts
+++ b/packages/core/src/pattern-echo.ts
@@ -171,6 +171,7 @@ async function _detect(input: {
       thinking: false,
       sessionID: input.sessionID,
       maxTokens: 512,
+      temperature: 0,
     },
   );
 

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -407,7 +407,8 @@ export async function expandQuery(
       llm.prompt(
         QUERY_EXPANSION_SYSTEM,
         `Input: "${query}"`,
-        { model, workerID: "lore-query-expand", thinking: false, urgent: true, sessionID, maxTokens: 256 },
+        // temperature: 0 trades expansion diversity for eval reproducibility
+        { model, workerID: "lore-query-expand", thinking: false, urgent: true, sessionID, maxTokens: 256, temperature: 0 },
       ),
       new Promise<null>((resolve) => setTimeout(() => resolve(null), TIMEOUT_MS)),
     ]);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -260,6 +260,21 @@ export interface LLMClient {
        *   the field is silently ignored
        */
       maxTokens?: number;
+      /**
+       * Sampling temperature for this call. Lower values produce more
+       * deterministic output. When absent, the provider default is used
+       * (typically 1.0).
+       *
+       * Worker call sites should set `temperature: 0` for reproducible
+       * output — this eliminates eval variance across runs.
+       *
+       * Adapter behavior:
+       * - Gateway: uses as `temperature` in the API request body
+       * - Pi: delegates to gateway — temperature is honored by the gateway adapter
+       * - OpenCode: cannot honor — SDK has no temperature on session.prompt();
+       *   the field is silently ignored
+       */
+      temperature?: number;
     },
   ): Promise<string | null>;
 }

--- a/packages/gateway/src/batch-queue.ts
+++ b/packages/gateway/src/batch-queue.ts
@@ -94,6 +94,7 @@ interface PendingRequest {
   params: {
     model: string;
     max_tokens: number;
+    temperature?: number;
     system:
       | string
       | Array<{ type: string; text: string; cache_control?: { type: string; ttl?: string } }>;
@@ -466,6 +467,7 @@ export function createOpenAIBatchProvider(upstreamUrl: string): BatchProvider {
           body: {
             model: item.params.model,
             max_completion_tokens: item.params.max_tokens,
+            ...(item.params.temperature != null && { temperature: item.params.temperature }),
             messages,
           },
         });
@@ -862,6 +864,9 @@ export function createBatchLLMClient(
             const result = await inner.prompt(system, user, {
               urgent: true,
               sessionID: item.sessionID,
+              workerID: item.workerID,
+              maxTokens: item.params.max_tokens,
+              ...(item.params.temperature != null && { temperature: item.params.temperature }),
             });
             item.resolve(result);
           } catch (e) {
@@ -925,6 +930,7 @@ export function createBatchLLMClient(
           params: {
             model: model.modelID,
             max_tokens: opts?.maxTokens ?? 8192,
+            ...(opts?.temperature != null && { temperature: opts.temperature }),
             system: systemPayload ?? [],
             messages: [{ role: "user", content: user }],
           },

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -187,6 +187,7 @@ function buildAnthropicWorkerRequest(
   user: string,
   maxTokens: number,
   sessionID?: string,
+  temperature?: number,
 ): { url: string; headers: Record<string, string>; body: string } {
   // For bearer tokens (Claude Code OAuth), inject the billing header
   // as the first system block with a cch=00000 placeholder that gets
@@ -222,6 +223,7 @@ function buildAnthropicWorkerRequest(
   let body = JSON.stringify({
     model: model.modelID,
     max_tokens: maxTokens,
+    ...(temperature != null && { temperature }),
     system: systemPayload,
     messages: [{ role: "user", content: user }],
   });
@@ -253,6 +255,7 @@ function buildOpenAIWorkerRequest(
   system: string,
   user: string,
   maxTokens: number,
+  temperature?: number,
 ): { url: string; headers: Record<string, string>; body: string } {
   const messages: Array<{ role: string; content: string }> = [];
   if (system) messages.push({ role: "system", content: system });
@@ -267,6 +270,7 @@ function buildOpenAIWorkerRequest(
     body: JSON.stringify({
       model: model.modelID,
       max_completion_tokens: maxTokens,
+      ...(temperature != null && { temperature }),
       messages,
     }),
   };
@@ -336,9 +340,9 @@ export function createGatewayLLMClient(
 
       // Build provider-specific request
       const req = isOpenAI
-        ? buildOpenAIWorkerRequest(target, cred, model, system, user, maxTokens)
+        ? buildOpenAIWorkerRequest(target, cred, model, system, user, maxTokens, opts?.temperature)
         : buildAnthropicWorkerRequest(
-            target, cred, model, system, user, maxTokens, opts?.sessionID,
+            target, cred, model, system, user, maxTokens, opts?.sessionID, opts?.temperature,
           );
 
       // Track this call so temporal capture can skip it

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -2345,6 +2345,7 @@ export async function generateCompactionSummary(opts: {
     workerID: "lore-compact",
     urgent: true,
     maxTokens: compactMaxTokens,
+    temperature: 0,
   });
 
   return summaryText ?? "(Compaction failed — no summary generated.)";


### PR DESCRIPTION
## Summary

Add optional `temperature` field to `LLMClient.prompt()` opts and set `temperature: 0` in all worker call sites to eliminate eval variance caused by non-deterministic LLM sampling.

## Changes

### Interface (`packages/core/src/types.ts`)
- Added `temperature?: number` to the `LLMClient.prompt()` opts with JSDoc documenting adapter behavior

### Gateway plumbing (`packages/gateway/src/`)
- **`llm-adapter.ts`**: Thread `temperature` through `buildAnthropicWorkerRequest()`, `buildOpenAIWorkerRequest()`, and `createGatewayLLMClient.prompt()`
- **`batch-queue.ts`**: 
  - Add `temperature` to `PendingRequest.params` type
  - Include `temperature` in queued batch request params
  - Include `temperature` in OpenAI batch JSONL body (previously only Anthropic batch forwarded the full params)
  - Fix batch fallback path to forward `temperature`, `maxTokens`, and `workerID` from the queued request (previously silently dropped on fallback)

### Worker call sites (all set `temperature: 0`)
- `packages/core/src/distillation.ts` — `distillSegment()`, `metaDistillInner()`
- `packages/core/src/curator.ts` — `runInner()`, `consolidate()`
- `packages/core/src/pattern-echo.ts` — `_detect()`
- `packages/core/src/search.ts` — `expandQuery()` (with comment noting diversity trade-off)
- `packages/core/src/import/extract.ts` — `extractKnowledge()`
- `packages/gateway/src/pipeline.ts` — compaction worker

## Impact

Eval PR-2 (implicit preferences) ranged from 3.33 to 4.63 across runs with identical code due to non-deterministic distillation output. Temperature=0 makes scores reproducible and enables meaningful A/B testing of prompt changes.

## Verification
- `bun run typecheck` — passes all 4 packages
- `bun test` — 1608 tests pass, 0 failures

Closes #381