### PR TITLE
feat: add local LLM provider support (vllm, ollama, llama.cpp, etc.)

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -19,16 +19,25 @@ bun add @loreai/core
 
 You only need to install this directly if you're building a new adapter. End users install one of the host packages above.
 
-### Optional dependency: `fastembed`
+### Vector embeddings
 
-`fastembed` is declared as an `optionalDependencies` because its native `onnxruntime-node` bindings can fail to build on some hosts (e.g. CUDA 13 on Linux/x64 — [microsoft/onnxruntime#26586](https://github.com/microsoft/onnxruntime/discussions/26586)). Install always succeeds, and `embed()` resolves a provider in this order:
+Recall uses [`@huggingface/transformers`](https://www.npmjs.com/package/@huggingface/transformers) with `nomic-embed-text-v1.5` (768-dim INT8 quantized, ~137 MB) for on-device vector search — no API key required.
 
-1. **Vendored** (standalone `lore` binary only) — fastembed and its native bindings are bundled directly into the binary at compile time via `bun build --compile`. The bge-small INT8 model files and the side-load `libonnxruntime` shared library ride along as Bun assets and are materialized to `~/.lore/embeddings-vendored/v{version}-{target}/` on first call. Supported targets: `darwin-arm64`, `linux-arm64`, `linux-x64`, `windows-x64`. (`darwin-x64` is unsupported — Apple Silicon-only.)
-2. **npm-installed** — `import("fastembed")` resolves to the user's `node_modules`, including the optional-dep install.
-3. **Remote auto-fallback** — when the local probe fails AND `VOYAGE_API_KEY` or `OPENAI_API_KEY` is set, `embed()` swaps to that provider for the rest of the process. Voyage wins ties.
-4. **FTS-only** — if none of the above resolve, `recall.runRecall()` and `vectorSearch()` return zero hits and callers continue with full-text search only.
+- **Binary mode** (standalone `lore` binary): Uses WASM backend (`onnxruntime-web`). Works on all platforms without native dependencies.
+- **npm mode** (`npm install @loreai/gateway`): Uses native backend (`onnxruntime-node`). May fail on some configurations (e.g. CUDA 13 on Linux/x64 — [microsoft/onnxruntime#26586](https://github.com/microsoft/onnxruntime/discussions/26586)).
 
-To force the optional install on a CUDA-13 host, run with `ONNXRUNTIME_NODE_INSTALL_CUDA=skip` — the bundled CPU EP is sufficient for `bge-small-en-v1.5`.
+When local embeddings aren't available, recall has graceful fallbacks:
+
+1. **Remote auto-fallback** — set `VOYAGE_API_KEY` or `OPENAI_API_KEY` in your env. The first `embed()` call detects the missing local provider and swaps over for the rest of the process. Voyage wins ties.
+2. **FTS-only** — if no remote keys are set and local embeddings fail, recall uses SQLite FTS5 full-text search. Still functional, just without vector similarity ranking.
+
+To pin a specific provider, set `search.embeddings.provider` in `.lore.json`:
+
+```json
+{ "search": { "embeddings": { "provider": "voyage" } } }
+```
+
+(also supports `"openai"`; reads `VOYAGE_API_KEY` / `OPENAI_API_KEY` from env).
 
 ## Documentation
 

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -162,11 +162,16 @@ export function extractUpstreamUrlHeader(
   const sanitized = raw.replace(/[\x00-\x1f\x7f]/g, "").trim();
   if (!sanitized || sanitized.length > MAX_UPSTREAM_URL_LENGTH) return undefined;
 
-  // Must be a valid URL (http or https only).
+  // Must be a valid URL (http or https only, no embedded credentials).
   try {
     const url = new URL(sanitized);
     if (url.protocol !== "http:" && url.protocol !== "https:") return undefined;
-    return url.origin + url.pathname.replace(/\/+$/, "");
+    if (url.username || url.password) return undefined;
+    // Strip trailing /v1 — users often copy the full endpoint URL from
+    // local LLM docs (e.g. http://localhost:8000/v1) but the gateway
+    // appends /v1/... itself when building the upstream request.
+    const pathname = url.pathname.replace(/\/+$/, "").replace(/\/v1$/, "");
+    return url.origin + pathname;
   } catch {
     return undefined;
   }

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -136,6 +136,43 @@ export function resolveUpstreamRoute(model: string): UpstreamRoute | null {
 }
 
 // ---------------------------------------------------------------------------
+// Upstream URL header — local/custom provider support
+// ---------------------------------------------------------------------------
+
+/** Maximum allowed length for an upstream URL header value. */
+const MAX_UPSTREAM_URL_LENGTH = 2048;
+
+/**
+ * Extract and validate the `X-Lore-Upstream-URL` header from a request.
+ *
+ * Used by local/custom providers (vllm, llama.cpp, ollama, etc.) to tell the
+ * gateway where to forward the request when `resolveUpstreamRoute()` returns
+ * null. The Pi and OpenCode plugins inject this header when the user sets
+ * `LORE_UPSTREAM_<PROVIDER>=<url>` in their environment.
+ *
+ * Returns `undefined` when the header is absent or invalid.
+ */
+export function extractUpstreamUrlHeader(
+  headers: Record<string, string>,
+): string | undefined {
+  const raw = headers["x-lore-upstream-url"];
+  if (!raw) return undefined;
+
+  // Sanitize: strip control characters, trim.
+  const sanitized = raw.replace(/[\x00-\x1f\x7f]/g, "").trim();
+  if (!sanitized || sanitized.length > MAX_UPSTREAM_URL_LENGTH) return undefined;
+
+  // Must be a valid URL (http or https only).
+  try {
+    const url = new URL(sanitized);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return undefined;
+    return url.origin + url.pathname.replace(/\/+$/, "");
+  } catch {
+    return undefined;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Project path inference
 // ---------------------------------------------------------------------------
 

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -65,7 +65,7 @@ import type {
   SessionState,
 } from "./translate/types";
 import type { GatewayConfig } from "./config";
-import { getProjectPath, extractGitRemoteHeader, resolveUpstreamRoute, type ProjectPathResult } from "./config";
+import { getProjectPath, extractGitRemoteHeader, resolveUpstreamRoute, extractUpstreamUrlHeader, type ProjectPathResult } from "./config";
 import {
   generateSessionID,
   fingerprintMessages,
@@ -1044,8 +1044,12 @@ async function forwardToUpstream(
     req.protocol === "openai-responses"
       ? "openai-responses"
       : (route?.protocol ?? req.protocol);
+  // Priority chain: model prefix route (known cloud) > header-provided URL
+  // (local/custom providers like vllm, ollama) > env-var default (fallback).
+  const headerUpstream = extractUpstreamUrlHeader(req.rawHeaders);
   const effectiveUpstreamBase =
     route?.url ??
+    headerUpstream ??
     (effectiveProtocol === "anthropic"
       ? config.upstreamAnthropic
       : config.upstreamOpenAI);

--- a/packages/gateway/test/upstream-url-header.test.ts
+++ b/packages/gateway/test/upstream-url-header.test.ts
@@ -1,0 +1,105 @@
+import { describe, test, expect } from "bun:test";
+import { extractUpstreamUrlHeader } from "../src/config";
+
+// ---------------------------------------------------------------------------
+// extractUpstreamUrlHeader
+// ---------------------------------------------------------------------------
+
+describe("extractUpstreamUrlHeader", () => {
+  test("returns undefined when header is absent", () => {
+    expect(extractUpstreamUrlHeader({})).toBeUndefined();
+    expect(extractUpstreamUrlHeader({ "x-api-key": "sk-abc" })).toBeUndefined();
+  });
+
+  test("returns undefined for empty string", () => {
+    expect(extractUpstreamUrlHeader({ "x-lore-upstream-url": "" })).toBeUndefined();
+  });
+
+  test("returns undefined for whitespace-only string", () => {
+    expect(extractUpstreamUrlHeader({ "x-lore-upstream-url": "   " })).toBeUndefined();
+  });
+
+  test("extracts valid http URL", () => {
+    expect(
+      extractUpstreamUrlHeader({ "x-lore-upstream-url": "http://localhost:8000" }),
+    ).toBe("http://localhost:8000");
+  });
+
+  test("extracts valid https URL", () => {
+    expect(
+      extractUpstreamUrlHeader({ "x-lore-upstream-url": "https://my-server.example.com:4000" }),
+    ).toBe("https://my-server.example.com:4000");
+  });
+
+  test("preserves path component", () => {
+    expect(
+      extractUpstreamUrlHeader({ "x-lore-upstream-url": "http://localhost:8000/v1" }),
+    ).toBe("http://localhost:8000/v1");
+  });
+
+  test("strips trailing slashes from path", () => {
+    expect(
+      extractUpstreamUrlHeader({ "x-lore-upstream-url": "http://localhost:8000/v1/" }),
+    ).toBe("http://localhost:8000/v1");
+    expect(
+      extractUpstreamUrlHeader({ "x-lore-upstream-url": "http://localhost:8000/" }),
+    ).toBe("http://localhost:8000");
+  });
+
+  test("strips multiple trailing slashes", () => {
+    expect(
+      extractUpstreamUrlHeader({ "x-lore-upstream-url": "http://localhost:8000///" }),
+    ).toBe("http://localhost:8000");
+  });
+
+  test("trims surrounding whitespace", () => {
+    expect(
+      extractUpstreamUrlHeader({ "x-lore-upstream-url": "  http://localhost:8000  " }),
+    ).toBe("http://localhost:8000");
+  });
+
+  test("rejects non-http protocol (ftp)", () => {
+    expect(
+      extractUpstreamUrlHeader({ "x-lore-upstream-url": "ftp://files.example.com" }),
+    ).toBeUndefined();
+  });
+
+  test("rejects non-http protocol (file)", () => {
+    expect(
+      extractUpstreamUrlHeader({ "x-lore-upstream-url": "file:///etc/passwd" }),
+    ).toBeUndefined();
+  });
+
+  test("rejects invalid URL", () => {
+    expect(
+      extractUpstreamUrlHeader({ "x-lore-upstream-url": "not a url" }),
+    ).toBeUndefined();
+  });
+
+  test("strips control characters before validation", () => {
+    expect(
+      extractUpstreamUrlHeader({ "x-lore-upstream-url": "http://localhost:8000\x00\x1f" }),
+    ).toBe("http://localhost:8000");
+  });
+
+  test("rejects oversized value (> 2048 chars)", () => {
+    const longUrl = `http://localhost:8000/${"a".repeat(2048)}`;
+    expect(extractUpstreamUrlHeader({ "x-lore-upstream-url": longUrl })).toBeUndefined();
+  });
+
+  test("accepts value at exactly 2048 chars", () => {
+    // "http://localhost:8000/" = 22 chars, pad path to reach 2048 total
+    const path = "a".repeat(2048 - "http://localhost:8000/".length);
+    const url = `http://localhost:8000/${path}`;
+    expect(url.length).toBe(2048);
+    expect(extractUpstreamUrlHeader({ "x-lore-upstream-url": url })).toBeDefined();
+  });
+
+  test("does not strip query parameters (origin + pathname only)", () => {
+    // URL constructor includes query/fragment in href but origin+pathname excludes them
+    const result = extractUpstreamUrlHeader({
+      "x-lore-upstream-url": "http://localhost:8000/v1?key=val",
+    });
+    expect(result).toBe("http://localhost:8000/v1");
+  });
+});

--- a/packages/gateway/test/upstream-url-header.test.ts
+++ b/packages/gateway/test/upstream-url-header.test.ts
@@ -31,16 +31,31 @@ describe("extractUpstreamUrlHeader", () => {
     ).toBe("https://my-server.example.com:4000");
   });
 
-  test("preserves path component", () => {
+  test("preserves non-/v1 path component", () => {
+    expect(
+      extractUpstreamUrlHeader({ "x-lore-upstream-url": "http://localhost:8000/api" }),
+    ).toBe("http://localhost:8000/api");
+  });
+
+  test("strips trailing /v1 (common user mistake from local LLM docs)", () => {
     expect(
       extractUpstreamUrlHeader({ "x-lore-upstream-url": "http://localhost:8000/v1" }),
-    ).toBe("http://localhost:8000/v1");
+    ).toBe("http://localhost:8000");
+    expect(
+      extractUpstreamUrlHeader({ "x-lore-upstream-url": "http://localhost:8000/v1/" }),
+    ).toBe("http://localhost:8000");
+  });
+
+  test("does not strip /v1 when it is part of a longer path", () => {
+    expect(
+      extractUpstreamUrlHeader({ "x-lore-upstream-url": "http://localhost:8000/api/v1" }),
+    ).toBe("http://localhost:8000/api");
+    expect(
+      extractUpstreamUrlHeader({ "x-lore-upstream-url": "http://localhost:8000/v1beta" }),
+    ).toBe("http://localhost:8000/v1beta");
   });
 
   test("strips trailing slashes from path", () => {
-    expect(
-      extractUpstreamUrlHeader({ "x-lore-upstream-url": "http://localhost:8000/v1/" }),
-    ).toBe("http://localhost:8000/v1");
     expect(
       extractUpstreamUrlHeader({ "x-lore-upstream-url": "http://localhost:8000/" }),
     ).toBe("http://localhost:8000");
@@ -92,14 +107,41 @@ describe("extractUpstreamUrlHeader", () => {
     const path = "a".repeat(2048 - "http://localhost:8000/".length);
     const url = `http://localhost:8000/${path}`;
     expect(url.length).toBe(2048);
-    expect(extractUpstreamUrlHeader({ "x-lore-upstream-url": url })).toBeDefined();
+    const result = extractUpstreamUrlHeader({ "x-lore-upstream-url": url });
+    expect(result).toBe(url);
   });
 
-  test("does not strip query parameters (origin + pathname only)", () => {
-    // URL constructor includes query/fragment in href but origin+pathname excludes them
+  test("strips query parameters (origin + pathname only)", () => {
     const result = extractUpstreamUrlHeader({
-      "x-lore-upstream-url": "http://localhost:8000/v1?key=val",
+      "x-lore-upstream-url": "http://localhost:8000/api?key=val",
     });
-    expect(result).toBe("http://localhost:8000/v1");
+    expect(result).toBe("http://localhost:8000/api");
+  });
+
+  test("strips fragment from URL", () => {
+    expect(
+      extractUpstreamUrlHeader({ "x-lore-upstream-url": "http://localhost:8000/api#section" }),
+    ).toBe("http://localhost:8000/api");
+  });
+
+  test("rejects URL with embedded credentials", () => {
+    expect(
+      extractUpstreamUrlHeader({ "x-lore-upstream-url": "http://user:pass@localhost:8000" }),
+    ).toBeUndefined();
+    expect(
+      extractUpstreamUrlHeader({ "x-lore-upstream-url": "http://user@localhost:8000" }),
+    ).toBeUndefined();
+  });
+
+  test("rejects javascript: protocol", () => {
+    expect(
+      extractUpstreamUrlHeader({ "x-lore-upstream-url": "javascript:alert(1)" }),
+    ).toBeUndefined();
+  });
+
+  test("rejects data: protocol", () => {
+    expect(
+      extractUpstreamUrlHeader({ "x-lore-upstream-url": "data:text/html,<h1>hi</h1>" }),
+    ).toBeUndefined();
   });
 });

--- a/packages/opencode/README.md
+++ b/packages/opencode/README.md
@@ -33,6 +33,29 @@ When installed via npm, local embeddings use the native `onnxruntime-node` backe
 
 If none of the above are set and local embeddings aren't available, recall falls back to FTS-only search.
 
+## Local / self-hosted LLM providers
+
+If you use a local LLM server (vllm, llama.cpp, ollama, etc.), set an environment variable so Lore's gateway knows where to forward requests:
+
+```bash
+export LORE_UPSTREAM_VLLM=http://localhost:8000
+# or
+export LORE_UPSTREAM_OLLAMA=http://localhost:11434
+```
+
+The URL should be the **server root** — do not include `/v1` (the gateway appends API paths automatically). The naming convention is `LORE_UPSTREAM_<PROVIDER>` where `<PROVIDER>` is the uppercased provider name with hyphens replaced by underscores:
+
+| Provider | Env var |
+|----------|---------|
+| `vllm` | `LORE_UPSTREAM_VLLM` |
+| `llamacpp` | `LORE_UPSTREAM_LLAMACPP` |
+| `ollama` | `LORE_UPSTREAM_OLLAMA` |
+| `lmstudio` | `LORE_UPSTREAM_LMSTUDIO` |
+| `tgi` | `LORE_UPSTREAM_TGI` |
+| `litellm` | `LORE_UPSTREAM_LITELLM` |
+
+Cloud providers (Anthropic, OpenAI, etc.) are routed automatically by model name and don't need this.
+
 ## Companion packages
 
 Lore ships as three packages sharing the same SQLite database at `~/.local/share/lore/lore.db`:

--- a/packages/opencode/README.md
+++ b/packages/opencode/README.md
@@ -24,13 +24,14 @@ Restart OpenCode and the plugin will be installed automatically.
 
 ## Local embeddings (optional)
 
-Recall uses `fastembed` for on-device vector search by default. It's an `optionalDependencies` of `@loreai/core`: if its native `onnxruntime-node` postinstall fails (e.g. CUDA 13 on Linux/x64 — [microsoft/onnxruntime#26586](https://github.com/microsoft/onnxruntime/discussions/26586)), install still succeeds. Recovery options, in order of effort:
+Recall uses [`@huggingface/transformers`](https://www.npmjs.com/package/@huggingface/transformers) with `nomic-embed-text-v1.5` (768-dim INT8 quantized, ~137 MB) for on-device vector search by default — no API key required. The model is downloaded on first use and cached locally.
 
-1. **Set `VOYAGE_API_KEY` or `OPENAI_API_KEY`** — when fastembed can't load, recall transparently switches to that provider on the first call. Zero config.
+When installed via npm, local embeddings use the native `onnxruntime-node` backend, which may fail on some configurations (e.g. CUDA 13 on Linux/x64 — [microsoft/onnxruntime#26586](https://github.com/microsoft/onnxruntime/discussions/26586)). When local embeddings aren't available, recall has graceful fallbacks:
+
+1. **Set `VOYAGE_API_KEY` or `OPENAI_API_KEY`** — recall transparently switches to that provider on the first call. Zero config.
 2. **Configure `search.embeddings.provider`** to `"voyage"` / `"openai"` in `.lore.json` to skip the local probe entirely.
-3. **Force the optional install** with `ONNXRUNTIME_NODE_INSTALL_CUDA=skip` set before `npm install` — the bundled CPU EP is sufficient for `bge-small-en-v1.5`.
 
-If none of the above are set and fastembed isn't available, recall falls back to FTS-only.
+If none of the above are set and local embeddings aren't available, recall falls back to FTS-only search.
 
 ## Companion packages
 

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -258,8 +258,8 @@ export const LorePlugin: Plugin = async (ctx) => {
         output.headers["x-lore-git-remote"] = cachedGitRemote;
       }
       // Inject upstream URL for local/custom providers (LORE_UPSTREAM_<PROVIDER>).
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const providerID = (input as any).provider as string | undefined;
+      // input.provider is a ProviderContext { source, info: Provider, options }.
+      const providerID = input.provider?.info?.id;
       if (providerID) {
         const envKey = `LORE_UPSTREAM_${providerID.toUpperCase().replace(/-/g, "_")}`;
         const upstream = process.env[envKey];

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -10,6 +10,11 @@ import { log, getGitRemote } from "@loreai/core";
  *
  * Providers using other protocols (Google SDK, AWS Bedrock SDK)
  * are not redirected but still benefit from gateway model-prefix routing.
+ *
+ * For local/self-hosted providers, set `LORE_UPSTREAM_<PROVIDER>=<url>`
+ * (e.g. `LORE_UPSTREAM_VLLM=http://localhost:8000`) so the gateway knows
+ * where to forward requests. Cloud providers are routed automatically by
+ * model name prefix.
  */
 const GATEWAY_PROVIDERS: string[] = [
   // anthropic-messages API
@@ -30,6 +35,16 @@ const GATEWAY_PROVIDERS: string[] = [
   "nvidia",
   "mistral",
   "google",
+  // Local / self-hosted (OpenAI-compatible)
+  "vllm",
+  "llamacpp",
+  "ollama",
+  "lmstudio",
+  "jan",
+  "localai",
+  "tgi",
+  "tabbyml",
+  "litellm",
 ];
 
 /** Default ports to probe when looking for a running gateway (must match gateway defaults). */
@@ -231,6 +246,8 @@ export const LorePlugin: Plugin = async (ctx) => {
     // (title generation, summary agents, etc.) from real conversation turns.
     // Also inject the git remote URL so the remote gateway can group
     // worktrees/clones of the same repo without filesystem access.
+    // For local/custom providers, inject the original upstream URL so the
+    // gateway can forward requests to the correct endpoint.
     "chat.headers": async (input, output) => {
       output.headers["x-lore-agent"] = input.agent;
       if (cachedGitRemote === undefined) {
@@ -239,6 +256,16 @@ export const LorePlugin: Plugin = async (ctx) => {
       }
       if (cachedGitRemote) {
         output.headers["x-lore-git-remote"] = cachedGitRemote;
+      }
+      // Inject upstream URL for local/custom providers (LORE_UPSTREAM_<PROVIDER>).
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const providerID = (input as any).provider as string | undefined;
+      if (providerID) {
+        const envKey = `LORE_UPSTREAM_${providerID.toUpperCase().replace(/-/g, "_")}`;
+        const upstream = process.env[envKey];
+        if (upstream) {
+          output.headers["x-lore-upstream-url"] = upstream;
+        }
       }
     },
   };

--- a/packages/pi/README.md
+++ b/packages/pi/README.md
@@ -45,7 +45,18 @@ export LORE_UPSTREAM_VLLM=http://localhost:8000
 export LORE_UPSTREAM_OLLAMA=http://localhost:11434
 ```
 
-The naming convention is `LORE_UPSTREAM_<PROVIDER>` where `<PROVIDER>` is the uppercased Pi provider name with hyphens replaced by underscores. Cloud providers (Anthropic, OpenAI, etc.) are routed automatically by model name and don't need this.
+The URL should be the **server root** — do not include `/v1` (the gateway appends API paths automatically). The naming convention is `LORE_UPSTREAM_<PROVIDER>` where `<PROVIDER>` is the uppercased Pi provider name with hyphens replaced by underscores:
+
+| Provider | Env var |
+|----------|---------|
+| `vllm` | `LORE_UPSTREAM_VLLM` |
+| `llamacpp` | `LORE_UPSTREAM_LLAMACPP` |
+| `ollama` | `LORE_UPSTREAM_OLLAMA` |
+| `lmstudio` | `LORE_UPSTREAM_LMSTUDIO` |
+| `tgi` | `LORE_UPSTREAM_TGI` |
+| `litellm` | `LORE_UPSTREAM_LITELLM` |
+
+Cloud providers (Anthropic, OpenAI, etc.) are routed automatically by model name and don't need this.
 
 ## Companion packages
 

--- a/packages/pi/README.md
+++ b/packages/pi/README.md
@@ -20,18 +20,12 @@ Then run `pi install` once. The extension auto-loads on every Pi session.
 
 ## Local embeddings (optional)
 
-By default, recall uses `fastembed` (bge-small-en-v1.5, ~33MB) for on-device vector search — no API key required. `fastembed` ships native bindings via `onnxruntime-node`, which has known install issues on some configurations (e.g. CUDA 13 on Linux/x64 — see [microsoft/onnxruntime#26586](https://github.com/microsoft/onnxruntime/discussions/26586)). It's declared as an `optionalDependencies` of `@loreai/core`, so install will succeed regardless.
+By default, recall uses [`@huggingface/transformers`](https://www.npmjs.com/package/@huggingface/transformers) with `nomic-embed-text-v1.5` (768-dim INT8 quantized, ~137 MB) for on-device vector search — no API key required. The model is downloaded on first use and cached locally.
 
-When fastembed isn't usable, recall has graceful fallbacks (cheapest first):
+When installed via npm, local embeddings use the native `onnxruntime-node` backend, which may fail on some configurations (e.g. CUDA 13 on Linux/x64 — see [microsoft/onnxruntime#26586](https://github.com/microsoft/onnxruntime/discussions/26586)). When local embeddings aren't available, recall has graceful fallbacks:
 
 1. **Auto-fallback to a hosted provider** — set `VOYAGE_API_KEY` or `OPENAI_API_KEY` in your env. The first `embed()` call detects the missing local provider and swaps over for the rest of the process. No config changes needed.
-2. **Force the local install** — skip the CUDA EP download (the CPU EP is sufficient for `bge-small-en-v1.5`):
-
-   ```bash
-   ONNXRUNTIME_NODE_INSTALL_CUDA=skip pi install
-   ```
-
-3. **Pin a hosted provider explicitly** in `.lore.json`:
+2. **Pin a hosted provider explicitly** in `.lore.json`:
 
    ```json
    { "search": { "embeddings": { "provider": "voyage" } } }
@@ -41,7 +35,17 @@ When fastembed isn't usable, recall has graceful fallbacks (cheapest first):
 
 If none apply, recall transparently falls back to FTS-only search.
 
-> Note: `@anush008/tokenizers` (a fastembed dep) has no native package for `linux-arm64`, so local embeddings are unsupported on that platform regardless of the install path. Use the auto-fallback or pin a hosted provider.
+## Local / self-hosted LLM providers
+
+If you use a local LLM server (vllm, llama.cpp, ollama, etc.), set an environment variable so Lore's gateway knows where to forward requests:
+
+```bash
+export LORE_UPSTREAM_VLLM=http://localhost:8000
+# or
+export LORE_UPSTREAM_OLLAMA=http://localhost:11434
+```
+
+The naming convention is `LORE_UPSTREAM_<PROVIDER>` where `<PROVIDER>` is the uppercased Pi provider name with hyphens replaced by underscores. Cloud providers (Anthropic, OpenAI, etc.) are routed automatically by model name and don't need this.
 
 ## Companion packages
 

--- a/packages/pi/src/index.ts
+++ b/packages/pi/src/index.ts
@@ -49,6 +49,11 @@ type SessionBeforeCompactResult = {
  *
  * Providers using other protocols (Google SDK, AWS Bedrock SDK,
  * Mistral conversations) are not redirected.
+ *
+ * For local/self-hosted providers, set `LORE_UPSTREAM_<PROVIDER>=<url>`
+ * (e.g. `LORE_UPSTREAM_VLLM=http://localhost:8000`) so the gateway knows
+ * where to forward requests. Cloud providers are routed automatically by
+ * model name prefix.
  */
 const GATEWAY_PROVIDERS = [
   // anthropic-messages API
@@ -69,6 +74,16 @@ const GATEWAY_PROVIDERS = [
   "vercel-ai-gateway",
   // openai-responses API
   "openai",
+  // Local / self-hosted (OpenAI-compatible)
+  "vllm",
+  "llamacpp",
+  "ollama",
+  "lmstudio",
+  "jan",
+  "localai",
+  "tgi",
+  "tabbyml",
+  "litellm",
 ];
 
 /** Default ports to probe when looking for a running gateway (must match gateway defaults). */
@@ -229,15 +244,24 @@ export default async function lorePiExtension(pi: ExtensionAPI): Promise<void> {
    * once the real session ID is known.
    */
   function registerProviders(): void {
-    const headers: Record<string, string> = {
+    const baseHeaders: Record<string, string> = {
       "x-lore-session-id": currentSessionID,
     };
     // Inject git remote so the gateway can group worktrees/clones of the
     // same repo without filesystem access (important for remote gateways).
     const remote = getGitRemote(projectPath);
-    if (remote) headers["x-lore-git-remote"] = remote;
+    if (remote) baseHeaders["x-lore-git-remote"] = remote;
 
     for (const provider of GATEWAY_PROVIDERS) {
+      const headers = { ...baseHeaders };
+      // For local/custom providers, inject the original upstream URL so the
+      // gateway can forward requests to the correct endpoint. The user sets
+      // LORE_UPSTREAM_<PROVIDER>=<url> in their environment.
+      const envKey = `LORE_UPSTREAM_${provider.toUpperCase().replace(/-/g, "_")}`;
+      const upstream = process.env[envKey];
+      if (upstream) {
+        headers["x-lore-upstream-url"] = upstream;
+      }
       pi.registerProvider(provider, { baseUrl: gatewayBase, headers });
     }
   }


### PR DESCRIPTION
## Summary

Adds support for local/self-hosted LLM providers in the Pi and OpenCode plugins, so users running vllm, llama.cpp, ollama, and other local inference servers can benefit from Lore's memory features.

Closes #368

## Problem

After v0.18's gateway-only refactor (PR #238), local providers like `vllm` were not in the `GATEWAY_PROVIDERS` list, so their API traffic bypassed the gateway entirely — no temporal storage, no distillation, no knowledge extraction, no recall.

Even if traffic reached the gateway, `forwardToUpstream()` would route unknown models to `https://api.openai.com` instead of the user's local endpoint.

## Changes

### Gateway (`packages/gateway/`)
- Add `extractUpstreamUrlHeader()` to `config.ts` — reads and validates the `x-lore-upstream-url` header (http/https only, max 2048 chars, control char stripping)
- Modify `forwardToUpstream()` in `pipeline.ts` — new priority chain: model prefix route > header-provided URL > env-var default
- Add 16 unit tests for `extractUpstreamUrlHeader()`

### Pi plugin (`packages/pi/`)
- Add 9 local providers to `GATEWAY_PROVIDERS`: `vllm`, `llamacpp`, `ollama`, `lmstudio`, `jan`, `localai`, `tgi`, `tabbyml`, `litellm`
- Inject `x-lore-upstream-url` header per-provider when `LORE_UPSTREAM_<PROVIDER>` env var is set (e.g. `LORE_UPSTREAM_VLLM=http://localhost:8000`)

### OpenCode plugin (`packages/opencode/`)
- Same local providers added to `GATEWAY_PROVIDERS`
- Same header injection via `chat.headers` hook

### Documentation
- Update all 3 READMEs (core, pi, opencode) to reflect the fastembed → `@huggingface/transformers` migration (`nomic-embed-text-v1.5`, `onnxruntime-web` in binary mode)
- Add local provider setup docs to Pi README

## Usage

```bash
# Set the upstream URL for your local provider
export LORE_UPSTREAM_VLLM=http://localhost:8000
# or
export LORE_UPSTREAM_OLLAMA=http://localhost:11434

# Start Pi/OpenCode as usual — traffic is routed through the gateway
```

## Notes

- **Recall tool (issue point #4)** is automatically resolved — the gateway injects the recall tool for all protocols at `pipeline.ts:3097-3113`. Once traffic flows through the gateway, recall works.
- **CUDA 13 embeddings (issue point #2)** — code already handles this gracefully with multi-layer fallback. Updated READMEs document the current state.
- Cloud provider routing is unchanged — `resolveUpstreamRoute()` handles known model prefixes, and the header is only consulted when no prefix matches.