### PR TITLE
fix: pass local:true when starting gateway in-process to prevent hosted mode

### DIFF
--- a/packages/gateway/src/cli/start.ts
+++ b/packages/gateway/src/cli/start.ts
@@ -80,8 +80,15 @@ export async function startGateway(opts: StartOptions = {}): Promise<GatewayHand
 
   // Hosted mode: `--local` CLI flag takes precedence, then env var,
   // then the caller-provided default. `lore start` leaves `opts.local`
-  // undefined (→ hosted mode ON by default), while `lore run` and
-  // `lore import` set `opts.local = true` (→ hosted mode OFF).
+  // undefined (→ hosted mode ON by default), while `lore run`,
+  // `lore import`, and in-process callers (OpenCode plugin, Pi extension)
+  // set `opts.local = true` (→ hosted mode OFF).
+  //
+  // IMPORTANT: In-process callers MUST pass `local: true` — hosted mode
+  // is a process-wide flag that disables filesystem operations in
+  // @loreai/core. When the gateway runs in the same process as the
+  // plugin/extension, enabling hosted mode breaks the plugin's own
+  // getGitRemote(), .lore.md import, config loading, and file watching.
   if (opts.local !== undefined) {
     config.hostedMode = !opts.local;
   } else if (!process.env.LORE_HOSTED_MODE) {

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -122,7 +122,7 @@ async function startInProcess(): Promise<string | null> {
     // module at compile time (the .d.cts only exists after building).
     const gw = "@loreai/gateway";
     const { startGateway } = await import(/* webpackIgnore: true */ gw);
-    const handle = await startGateway({ quiet: true });
+    const handle = await startGateway({ quiet: true, local: true });
     const url = `http://127.0.0.1:${handle.port}`;
 
     if (!handle.owned) {

--- a/packages/pi/src/index.ts
+++ b/packages/pi/src/index.ts
@@ -163,7 +163,7 @@ async function startInProcess(): Promise<string | null> {
     // module at compile time (the .d.cts only exists after building).
     const gw = "@loreai/gateway";
     const { startGateway } = await import(/* webpackIgnore: true */ gw);
-    const handle = await startGateway({ quiet: true });
+    const handle = await startGateway({ quiet: true, local: true });
     const url = `http://127.0.0.1:${handle.port}`;
 
     if (!handle.owned) {


### PR DESCRIPTION
## Summary

Fixes in-process gateway startup incorrectly enabling hosted mode, which breaks git remote detection and causes worktree sessions to create orphaned projects instead of being associated with their parent project.

## Root Cause

When the OpenCode or Pi plugin starts the gateway in-process via `startGateway({ quiet: true })`, the `local` option defaults to `undefined`. This causes `startGateway()` to set `config.hostedMode = true`, which then sets the **process-wide** `_hostedMode` flag in `@loreai/core`.

Since the plugin and gateway share the same process, the plugin's own `getGitRemote()` call returns `null` (it checks `isHostedMode()`), the `x-lore-git-remote` header is never sent, and `ensureProject()` creates a new orphaned project with no remote — instead of matching the worktree to the existing parent project.

Other projects were unaffected because their gateways were already running as separate processes.

Hosted mode also silently disabled `.lore.md` import, `.lore.json` config loading, file watching, and lat-reader refresh for in-process gateways.

## Changes

- Passes `local: true` in `startGateway()` calls from the OpenCode and Pi plugins, matching what `lore run` already does
- Expands the comment in `startGateway()` to warn future callers that in-process usage requires `local: true`