### PR TITLE
fix: inject X-Lore-Project header to eliminate cwd fallback warning

### DIFF
--- a/packages/gateway/src/cli/agents.ts
+++ b/packages/gateway/src/cli/agents.ts
@@ -74,7 +74,7 @@ function appendCustomHeader(
   name: string,
   value: string,
 ): void {
-  const existing = process.env[envKey] ?? "";
+  const existing = env[envKey] ?? process.env[envKey] ?? "";
   const header = `${name}: ${value}`;
   env[envKey] = existing ? `${existing}\n${header}` : header;
 }
@@ -90,6 +90,9 @@ export const AGENTS: AgentDef[] = [
         ANTHROPIC_BASE_URL: url,
         DISABLE_AUTO_COMPACT: "1",
       };
+      // Inject project path so the gateway knows which project this session
+      // belongs to, regardless of system prompt format.
+      appendCustomHeader(env, "ANTHROPIC_CUSTOM_HEADERS", "X-Lore-Project", cwd);
       // Inject git remote via ANTHROPIC_CUSTOM_HEADERS so the remote gateway
       // can identify the project by git remote without filesystem access.
       const remote = safeRemote(cwd);
@@ -107,9 +110,11 @@ export const AGENTS: AgentDef[] = [
     envVars: (url, cwd) => {
       const env: Record<string, string> = { OPENAI_BASE_URL: `${url}/v1` };
       // Codex supports custom headers via env_http_headers config (since 0.3.0).
-      // Set LORE_GIT_REMOTE so users can map it in their config.toml:
+      // Set LORE_PROJECT / LORE_GIT_REMOTE so users can map them in config.toml:
       //   [model_provider.custom.env_http_headers]
+      //   X-Lore-Project = "LORE_PROJECT"
       //   X-Lore-Git-Remote = "LORE_GIT_REMOTE"
+      env.LORE_PROJECT = cwd;
       const remote = safeRemote(cwd);
       if (remote) env.LORE_GIT_REMOTE = remote;
       return env;

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -193,14 +193,18 @@ export function extractUpstreamUrlHeader(
  * possible). Ordered from most-specific to most-general.
  */
 const PROJECT_PATH_PATTERNS: RegExp[] = [
-  // "cwd": "/home/…/project" or "cwd":"/Users/…/project" (JSON-style)
-  /["']?cwd["']?\s*[:=]\s*["']?(\/(?:home|Users)\/[^\s"',}]+)/,
-  // Working directory: /home/user/project
-  /[Ww]orking\s+directory[:=]\s*(\/(?:home|Users)\/[^\s"',]+)/,
-  // CLAUDE.md / AGENTS.md / .lore.md file path → take the directory
-  /(\/(?:home|Users)\/[^\s"',]+)\/(?:CLAUDE|AGENTS|\.lore)\.md/,
-  // Generic absolute path starting with /home/ or /Users/ — first occurrence
-  // Captures until whitespace, quote, comma, or bracket.
+  // "cwd": "/path/to/project" (JSON-style in tool definitions).
+  // Accepts any absolute path — the surrounding structure (key + quotes)
+  // provides enough specificity to avoid false positives.
+  /["']?cwd["']?\s*[:=]\s*["']?(\/[^\s"',}]+)/,
+  // Working directory: /path/to/project
+  // Accepts any absolute path — the "Working directory" prefix is unambiguous.
+  /[Ww]orking\s+directory[:=]\s*(\/[^\s"',]+)/,
+  // CLAUDE.md / AGENTS.md / .lore.md file path → take the directory.
+  // Accepts any absolute path — the known filename suffix is unambiguous.
+  /(\/[^\s"',]+)\/(?:CLAUDE|AGENTS|\.lore)\.md/,
+  // Generic absolute path starting with /home/ or /Users/ — first occurrence.
+  // Kept narrow intentionally to avoid matching system paths (/usr/lib, /etc, …).
   /(\/(?:home|Users)\/[\w./-]+)/,
 ];
 
@@ -256,8 +260,8 @@ export function getProjectPath(
   // Extract git remote from header (independent of path resolution).
   const gitRemote = extractGitRemoteHeader(headers);
 
-  // 1. Explicit header override
-  const headerPath = headers["x-lore-project"];
+  // 1. Explicit header override (sanitized)
+  const headerPath = extractProjectHeader(headers);
   if (headerPath) return { path: headerPath, source: "header", gitRemote };
 
   // 2. Infer from system prompt content
@@ -293,6 +297,36 @@ export function extractGitRemoteHeader(
   if (!sanitized || sanitized.length > MAX_GIT_REMOTE_LENGTH) return undefined;
 
   return normalizeRemoteUrl(sanitized);
+}
+
+// ---------------------------------------------------------------------------
+// Project path header extraction
+// ---------------------------------------------------------------------------
+
+/** Maximum allowed length for a project path header value. */
+const MAX_PROJECT_PATH_LENGTH = 1024;
+
+/**
+ * Extract and validate the `X-Lore-Project` header from a request.
+ * Strips control characters, trims whitespace, and rejects non-absolute paths.
+ * Returns `undefined` when the header is absent or invalid.
+ */
+export function extractProjectHeader(
+  headers: Record<string, string>,
+): string | undefined {
+  const raw = headers["x-lore-project"];
+  if (!raw) return undefined;
+
+  // Strip control characters (newlines, carriage returns, null bytes) to
+  // prevent header injection and DB corruption.
+  const sanitized = raw.replace(/[\x00-\x1f\x7f]/g, "").trim();
+  if (!sanitized || sanitized.length > MAX_PROJECT_PATH_LENGTH) return undefined;
+
+  // Must be an absolute path
+  if (!sanitized.startsWith("/")) return undefined;
+
+  // Strip trailing slashes for consistency
+  return sanitized.replace(/\/+$/, "") || undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -279,6 +279,7 @@ export function setUpstreamInterceptor(
 export async function resetPipelineState(): Promise<void> {
   initialized = false;
   sessions.clear();
+  cwdWarned.clear();
   headerSessionIndex.clear();
   ltmSessionCache.clear();
   ltmPinnedText.clear();
@@ -304,6 +305,9 @@ export async function resetPipelineState(): Promise<void> {
 
 /** Per-session state tracked across requests. */
 const sessions = new Map<string, SessionState>();
+
+/** Sessions that have already logged the cwd-fallback warning (dedup). */
+const cwdWarned = new Set<string>();
 
 /** Read-only access to live session states (for dashboard rendering). */
 export function getActiveSessions(): ReadonlyMap<string, SessionState> {
@@ -795,11 +799,12 @@ export function resolveSessionProjectPath(
 
   // Log warning only when the cwd fallback truly sticks (no session cache
   // was available to upgrade from).
-  if (source === "cwd") {
+  if (source === "cwd" && !cwdWarned.has(sessionState.sessionID)) {
+    cwdWarned.add(sessionState.sessionID);
     console.error(
       `[lore] warning: project path falling back to process.cwd() (${projectPath}). ` +
-      `Data may be misattributed. Set X-Lore-Project header or include a working ` +
-      `directory in the system prompt to fix this.`,
+      `Data may be misattributed. Fix: use \`lore run\` to launch your agent, ` +
+      `or set ANTHROPIC_CUSTOM_HEADERS="X-Lore-Project: /path/to/project".`,
     );
   }
 

--- a/packages/gateway/test/agents.test.ts
+++ b/packages/gateway/test/agents.test.ts
@@ -1,0 +1,78 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { AGENTS } from "../src/cli/agents";
+
+// ---------------------------------------------------------------------------
+// Claude Code agent
+// ---------------------------------------------------------------------------
+
+describe("Claude Code agent envVars", () => {
+  const claude = AGENTS.find((a) => a.name === "claude-code")!;
+
+  // appendCustomHeader reads env[key] ?? process.env[key] to merge with
+  // existing headers. Save and restore to avoid test pollution.
+  let savedHeaders: string | undefined;
+  beforeEach(() => {
+    savedHeaders = process.env.ANTHROPIC_CUSTOM_HEADERS;
+    delete process.env.ANTHROPIC_CUSTOM_HEADERS;
+  });
+  afterEach(() => {
+    if (savedHeaders !== undefined) {
+      process.env.ANTHROPIC_CUSTOM_HEADERS = savedHeaders;
+    } else {
+      delete process.env.ANTHROPIC_CUSTOM_HEADERS;
+    }
+  });
+
+  test("injects X-Lore-Project in ANTHROPIC_CUSTOM_HEADERS", () => {
+    const env = claude.envVars("http://127.0.0.1:3207", "/home/user/my-project");
+    expect(env.ANTHROPIC_CUSTOM_HEADERS).toContain("X-Lore-Project: /home/user/my-project");
+  });
+
+  test("both X-Lore-Project and X-Lore-Git-Remote coexist when git remote is available", () => {
+    // Use the actual repo cwd so safeRemote() finds a real git remote.
+    const env = claude.envVars("http://127.0.0.1:3207", process.cwd());
+    const headers = env.ANTHROPIC_CUSTOM_HEADERS ?? "";
+    expect(headers).toContain("X-Lore-Project:");
+    expect(headers).toContain("X-Lore-Git-Remote:");
+    // Project header should appear first (injected before git remote).
+    const projectIdx = headers.indexOf("X-Lore-Project:");
+    const remoteIdx = headers.indexOf("X-Lore-Git-Remote:");
+    expect(projectIdx).toBeLessThan(remoteIdx);
+  });
+
+  test("preserves user-set ANTHROPIC_CUSTOM_HEADERS", () => {
+    process.env.ANTHROPIC_CUSTOM_HEADERS = "X-Custom: user-value";
+    const env = claude.envVars("http://127.0.0.1:3207", "/tmp/test");
+    const headers = env.ANTHROPIC_CUSTOM_HEADERS ?? "";
+    expect(headers).toContain("X-Custom: user-value");
+    expect(headers).toContain("X-Lore-Project: /tmp/test");
+  });
+
+  test("sets ANTHROPIC_BASE_URL", () => {
+    const env = claude.envVars("http://127.0.0.1:3207", "/home/user/my-project");
+    expect(env.ANTHROPIC_BASE_URL).toBe("http://127.0.0.1:3207");
+  });
+
+  test("sets DISABLE_AUTO_COMPACT", () => {
+    const env = claude.envVars("http://127.0.0.1:3207", "/tmp/test");
+    expect(env.DISABLE_AUTO_COMPACT).toBe("1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Codex agent
+// ---------------------------------------------------------------------------
+
+describe("Codex agent envVars", () => {
+  test("sets LORE_PROJECT env var to cwd", () => {
+    const codex = AGENTS.find((a) => a.name === "codex")!;
+    const env = codex.envVars("http://127.0.0.1:3207", "/home/user/my-project");
+    expect(env.LORE_PROJECT).toBe("/home/user/my-project");
+  });
+
+  test("sets OPENAI_BASE_URL with /v1 suffix", () => {
+    const codex = AGENTS.find((a) => a.name === "codex")!;
+    const env = codex.envVars("http://127.0.0.1:3207", "/tmp/test");
+    expect(env.OPENAI_BASE_URL).toBe("http://127.0.0.1:3207/v1");
+  });
+});

--- a/packages/gateway/test/project-path.test.ts
+++ b/packages/gateway/test/project-path.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { inferProjectPath, getProjectPath, extractGitRemoteHeader } from "../src/config";
+import { inferProjectPath, getProjectPath, extractGitRemoteHeader, extractProjectHeader } from "../src/config";
 import { resolveSessionProjectPath } from "../src/pipeline";
 
 // ---------------------------------------------------------------------------
@@ -65,8 +65,15 @@ describe("inferProjectPath", () => {
     expect(inferProjectPath("You are a helpful assistant.")).toBeNull();
   });
 
-  test("returns null for paths not starting with /home/ or /Users/", () => {
-    expect(inferProjectPath("cwd: /var/lib/project")).toBeNull();
+  test("cwd pattern matches any absolute path (not just /home/ or /Users/)", () => {
+    // The cwd pattern is structurally specific enough to accept any absolute path.
+    expect(inferProjectPath("cwd: /var/lib/project")).toBe("/var/lib/project");
+  });
+
+  test("generic fallback returns null for paths not starting with /home/ or /Users/", () => {
+    // Without a structural prefix (cwd, Working directory, CLAUDE.md), only
+    // /home/ and /Users/ paths are matched by the generic fallback.
+    expect(inferProjectPath("Some text /var/lib/project here")).toBeNull();
   });
 
   test("prefers cwd field over generic path match", () => {
@@ -83,6 +90,49 @@ describe("inferProjectPath", () => {
   test("strips trailing slashes", () => {
     const system = `Working directory: /home/user/project/`;
     expect(inferProjectPath(system)).toBe("/home/user/project");
+  });
+
+  // --- Broadened patterns (any absolute path for structurally-specific patterns) ---
+
+  test("extracts path from cwd field with /root/ prefix", () => {
+    expect(inferProjectPath('"cwd": "/root/project"')).toBe("/root/project");
+  });
+
+  test("extracts path from cwd field with /var/home/ prefix", () => {
+    expect(inferProjectPath('"cwd": "/var/home/user/project"')).toBe("/var/home/user/project");
+  });
+
+  test("extracts path from cwd field with /nix/store/ prefix", () => {
+    expect(inferProjectPath('"cwd": "/nix/store/abc/project"')).toBe("/nix/store/abc/project");
+  });
+
+  test("extracts path from Working directory with /root/ prefix", () => {
+    expect(inferProjectPath("Working directory: /root/my-app")).toBe("/root/my-app");
+  });
+
+  test("extracts path from Working directory with /data/ prefix (Termux)", () => {
+    expect(inferProjectPath("Working directory: /data/data/com.termux/files/home/project")).toBe(
+      "/data/data/com.termux/files/home/project",
+    );
+  });
+
+  test("extracts directory from CLAUDE.md with /root/ path", () => {
+    expect(inferProjectPath("Instructions from: /root/project/CLAUDE.md")).toBe("/root/project");
+  });
+
+  test("extracts directory from AGENTS.md with /nix/store/ path", () => {
+    expect(inferProjectPath("Instructions from: /nix/store/abc/project/AGENTS.md")).toBe(
+      "/nix/store/abc/project",
+    );
+  });
+
+  test("generic fallback still requires /home/ or /Users/", () => {
+    // Only the generic pattern should apply — and it should NOT match /root/
+    expect(inferProjectPath("Some text /root/project here")).toBeNull();
+  });
+
+  test("generic fallback still rejects /var/ paths", () => {
+    expect(inferProjectPath("Some text /var/lib/project here")).toBeNull();
   });
 });
 
@@ -126,6 +176,35 @@ describe("getProjectPath", () => {
     expect(result.path).toBe("/home/user/project");
     expect(result.source).toBe("inferred");
     expect(result.gitRemote).toBeUndefined();
+  });
+
+  test("sanitizes control characters from X-Lore-Project header", () => {
+    const result = getProjectPath("", { "x-lore-project": "/home/user/project\n" });
+    expect(result.path).toBe("/home/user/project");
+    expect(result.source).toBe("header");
+  });
+
+  test("rejects non-absolute X-Lore-Project header, falls through to inference", () => {
+    const result = getProjectPath(
+      "Working directory: /home/user/project",
+      { "x-lore-project": "relative/path" },
+    );
+    expect(result.source).toBe("inferred");
+  });
+
+  test("strips trailing slashes from X-Lore-Project header", () => {
+    const result = getProjectPath("", { "x-lore-project": "/home/user/project///" });
+    expect(result.path).toBe("/home/user/project");
+    expect(result.source).toBe("header");
+  });
+
+  test("rejects X-Lore-Project header exceeding 1024 characters", () => {
+    const longPath = "/" + "a".repeat(1030);
+    const result = getProjectPath(
+      "Working directory: /home/user/project",
+      { "x-lore-project": longPath },
+    );
+    expect(result.source).toBe("inferred");
   });
 
   test("extracts and normalizes X-Lore-Git-Remote header (HTTPS)", () => {
@@ -185,6 +264,68 @@ describe("getProjectPath", () => {
     });
     expect(r2.source).toBe("cwd");
     expect(r2.gitRemote).toBe("github.com/org/repo");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractProjectHeader
+// ---------------------------------------------------------------------------
+
+describe("extractProjectHeader", () => {
+  test("returns undefined when header is absent", () => {
+    expect(extractProjectHeader({})).toBeUndefined();
+  });
+
+  test("returns undefined for empty header", () => {
+    expect(extractProjectHeader({ "x-lore-project": "" })).toBeUndefined();
+  });
+
+  test("returns undefined for whitespace-only header", () => {
+    expect(extractProjectHeader({ "x-lore-project": "   " })).toBeUndefined();
+  });
+
+  test("extracts valid absolute path", () => {
+    expect(extractProjectHeader({ "x-lore-project": "/home/user/project" }))
+      .toBe("/home/user/project");
+  });
+
+  test("strips control characters", () => {
+    expect(extractProjectHeader({ "x-lore-project": "/home/user/project\n" }))
+      .toBe("/home/user/project");
+  });
+
+  test("strips carriage return and null bytes", () => {
+    expect(extractProjectHeader({ "x-lore-project": "/home/user/project\r\0" }))
+      .toBe("/home/user/project");
+  });
+
+  test("rejects non-absolute path", () => {
+    expect(extractProjectHeader({ "x-lore-project": "relative/path" })).toBeUndefined();
+  });
+
+  test("strips trailing slashes", () => {
+    expect(extractProjectHeader({ "x-lore-project": "/home/user/project///" }))
+      .toBe("/home/user/project");
+  });
+
+  test("rejects values exceeding 1024 characters", () => {
+    const longPath = "/" + "a".repeat(1030);
+    expect(extractProjectHeader({ "x-lore-project": longPath })).toBeUndefined();
+  });
+
+  test("accepts values at exactly 1024 characters", () => {
+    const value = "/" + "a".repeat(1023); // 1024 total
+    expect(extractProjectHeader({ "x-lore-project": value })).toBeDefined();
+  });
+
+  test("trims whitespace before validation", () => {
+    expect(extractProjectHeader({ "x-lore-project": "  /home/user/project  " }))
+      .toBe("/home/user/project");
+  });
+
+  test("accepts /root/ paths", () => {
+    expect(extractProjectHeader({ "x-lore-project": "/root/project" }))
+      .toBe("/root/project");
   });
 });
 

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -250,6 +250,8 @@ export const LorePlugin: Plugin = async (ctx) => {
     // gateway can forward requests to the correct endpoint.
     "chat.headers": async (input, output) => {
       output.headers["x-lore-agent"] = input.agent;
+      // Inject project path so the gateway can attribute data correctly.
+      output.headers["x-lore-project"] = ctx.worktree || ctx.directory;
       if (cachedGitRemote === undefined) {
         const projectPath = ctx.worktree || ctx.directory;
         cachedGitRemote = getGitRemote(projectPath) ?? "";

--- a/packages/pi/src/index.ts
+++ b/packages/pi/src/index.ts
@@ -246,6 +246,7 @@ export default async function lorePiExtension(pi: ExtensionAPI): Promise<void> {
   function registerProviders(): void {
     const baseHeaders: Record<string, string> = {
       "x-lore-session-id": currentSessionID,
+      "x-lore-project": projectPath,
     };
     // Inject git remote so the gateway can group worktrees/clones of the
     // same repo without filesystem access (important for remote gateways).


### PR DESCRIPTION
## Summary

Eliminates the noisy `project path falling back to process.cwd()` warning by injecting the `X-Lore-Project` header at agent launch time, when the project path is already known.

## Problem

When `inferProjectPath()` fails to extract the project path from the system prompt (due to format changes, non-standard home directories like `/root/` or `/nix/store/`, or stripped prompt-cache probes), the gateway falls back to `process.cwd()` and logs:

```
[lore] warning: project path falling back to process.cwd() (/Users/bete/code/init).
Data may be misattributed.
```

## Changes

**Three-layer fix:**

1. **Primary — inject header at launch time**
   - `agents.ts`: Claude Code gets `X-Lore-Project` via `ANTHROPIC_CUSTOM_HEADERS`; Codex gets `LORE_PROJECT` env var
   - `opencode/src/index.ts`: injects `x-lore-project` in `chat.headers` hook
   - `pi/src/index.ts`: injects `x-lore-project` in `registerProviders()` base headers

2. **Defense-in-depth — broaden regex patterns**
   - First 3 patterns (`cwd:`, `Working directory:`, `CLAUDE.md`) now accept any absolute path, not just `/home/` and `/Users/`. The structural context makes them unambiguous.
   - Generic fallback (pattern 4) stays narrow to avoid false positives from system paths.

3. **Hardening**
   - New `extractProjectHeader()` with control-char stripping, length limit (1024), absolute-path validation, trailing-slash removal — parity with existing `extractGitRemoteHeader()`
   - Warning message updated with actionable fix instructions
   - Warning deduped per-session to avoid log spam

**Bug fix (pre-existing):**
- Fixed `appendCustomHeader()` reading from `process.env` instead of the `env` object being built — second call would overwrite the first, silently dropping `X-Lore-Project` whenever a git remote was also injected.

**Tests:**
- 17 new test cases in `project-path.test.ts` (broadened regex, header sanitization, `getProjectPath` integration)
- New `agents.test.ts` testing env var generation for Claude Code (both headers coexist, user headers preserved) and Codex
- All 1687 tests pass, typecheck clean