### PR TITLE
fix: add anti-imitation instruction to recall tool description

### DIFF
--- a/packages/core/src/recall.ts
+++ b/packages/core/src/recall.ts
@@ -966,7 +966,8 @@ export async function runRecall(input: RecallInput): Promise<RecallResult> {
 
 /** Standard tool description reused verbatim by each host adapter. */
 export const RECALL_TOOL_DESCRIPTION =
-  'Search your persistent memory for this project. Two cases where you MUST use this tool: (1) Cross-session references — the user mentions past work, "last time", "before", "we discussed", "earlier", or "remember". Prior sessions are never in your context. (2) Missing details — file paths, past decisions, preferences, or approaches you don\'t see in your current window. Always prefer recall over assuming. Searches knowledge, distilled history, and message archives.';
+  'Search your persistent memory for this project. Two cases where you MUST use this tool: (1) Cross-session references — the user mentions past work, "last time", "before", "we discussed", "earlier", or "remember". Prior sessions are never in your context. (2) Missing details — file paths, past decisions, preferences, or approaches you don\'t see in your current window. Always prefer recall over assuming. Searches knowledge, distilled history, and message archives.' +
+  '\n\nNever write recall status text (like "📚 Searching…" or "📚 Fetching…") yourself — these are injected by the system automatically when you use this tool.';
 
 /** Standard parameter descriptions reused by each host adapter. */
 export const RECALL_PARAM_DESCRIPTIONS = {


### PR DESCRIPTION
## Summary
Prevents the model from writing text that mimics recall markers instead of actually calling the recall tool.

## Problem
In CM-1 eval (live mode), the model sometimes writes text like `📚 Fetching details for t:e8a949d7... and t:36d96080... simultaneously…` as its final answer instead of invoking the recall tool. The model sees recall markers in prior assistant turns and imitates the pattern.

## Changes
- Appends an explicit anti-imitation instruction to `RECALL_TOOL_DESCRIPTION` in `packages/core/src/recall.ts`, telling the model never to write recall status markers itself — they are injected by the system automatically

Closes #409