### PR TITLE
fix(eval): build realistic Lore context for QA questions

### DIFF
--- a/packages/core/eval/harness.ts
+++ b/packages/core/eval/harness.ts
@@ -439,6 +439,91 @@ export async function replaySession(
 // Baseline context generation
 // ---------------------------------------------------------------------------
 
+/**
+ * Build Lore context for QA questions, mimicking what the gradient context
+ * manager would provide in a real Lore session.
+ *
+ * In real usage, the gradient system allocates SEPARATE budgets:
+ *   - 25% of context for distillation prefix (compressed older context)
+ *   - 40% of context for raw tail window (recent messages)
+ *   - 5% for LTM knowledge entries
+ *   - Recall tool available for anything not in the above
+ *
+ * These are independent budgets — distillation doesn't reduce the raw tail.
+ * For a 200K context window: ~50K distilled + ~80K raw + ~10K LTM = ~140K total.
+ */
+async function buildLoreContext(
+  turns: ConversationTurn[],
+  contextWindow = 200_000,
+): Promise<string> {
+  // Match the gradient system's budget fractions (config.ts defaults).
+  // Subtract output reserve (32K) and estimated overhead (~8K) from the
+  // context window to compute the usable budget, matching gradient.ts
+  // which uses: usable = contextLimit - outputReserved - overhead - ltmTokens
+  const usable = Math.max(0, contextWindow - 32_000 - 8_000);
+  const distilledBudget = Math.floor(usable * 0.25);
+  const rawBudget = Math.floor(usable * 0.40);
+
+  try {
+    const { db, ensureProject } = await import("@loreai/core");
+    const parts: string[] = [];
+
+    // 1. Fetch non-archived distillation observations (matching gradient.ts
+    // which filters archived = 0). Archived gen-0 segments are reachable
+    // via the recall tool but not included in the in-context prefix.
+    const pid = ensureProject(process.cwd());
+    const distillations = db()
+      .query(
+        "SELECT id, observations, generation, token_count FROM distillations WHERE project_id = ? AND archived = 0 ORDER BY created_at ASC",
+      )
+      .all(pid) as Array<{ id: string; observations: string; generation: number; token_count: number }>;
+
+    let distillTokens = 0;
+    for (const d of distillations) {
+      if (d.observations) {
+        const tokens = d.token_count || estimateTokens(d.observations);
+        if (distillTokens + tokens <= distilledBudget) {
+          parts.push(d.observations);
+          distillTokens += tokens;
+        }
+      }
+    }
+
+    // 2. Add raw conversation tail (independent budget — not reduced by
+    // distillation, matching the gradient system's separate allocations).
+    // LTM is NOT included here — the gateway injects LTM into the system
+    // prompt separately, so adding it here would cause double injection.
+    if (turns.length > 0) {
+      let tailTokens = 0;
+      let cutoff = turns.length;
+      for (let i = turns.length - 1; i >= 0; i--) {
+        const turnTokens = turns[i].tokens ?? estimateTokens(renderConversation([turns[i]]));
+        if (tailTokens + turnTokens > rawBudget) {
+          cutoff = i + 1;
+          break;
+        }
+        tailTokens += turnTokens;
+        if (i === 0) cutoff = 0;
+      }
+      const tail = turns.slice(cutoff);
+      if (tail.length > 0) {
+        parts.push(`## Recent Conversation\n\n${renderConversation(tail)}`);
+      }
+    }
+
+    const context = parts.join("\n\n");
+    console.log(
+      `  [lore-context] Built ${estimateTokens(context)} tok: ${distillations.length} distillation(s) (${distillTokens} tok), ` +
+      `raw tail budget ${rawBudget} tok`,
+    );
+
+    return context;
+  } catch (err) {
+    console.warn("  Warning: failed to build Lore context from DB:", err);
+    return "";
+  }
+}
+
 async function getBaselineContext(
   mode: BaselineMode,
   turns: ConversationTurn[],
@@ -482,14 +567,21 @@ async function askQuestionViaGateway(
   question: string,
   gateway: GatewayHandle,
   model: string,
+  loreContext?: string,
 ): Promise<{ hypothesis: string; tokens: TokenUsage; recallInvoked: boolean }> {
+  // When loreContext is provided, include it in the user message so the model
+  // has the distillation observations and raw conversation context (mimicking
+  // real Lore sessions where the gradient context manager provides these).
+  const contextPreamble = loreContext
+    ? `Here are distilled observations and conversation context from previous coding sessions:\n\n${loreContext}\n\n`
+    : "";
   const requestBody = {
     model,
     system: QA_SYSTEM,
     messages: [
       {
         role: "user",
-        content: `Answer this question about our previous coding sessions. Be specific and factual. If you don't have enough information, say so.\n\nQuestion: ${question}`,
+        content: `${contextPreamble}Answer this question about our previous coding sessions. Be specific and factual. If you don't have enough information, say so.\n\nQuestion: ${question}`,
       },
     ],
     tools: STANDARD_TOOLS,
@@ -763,6 +855,15 @@ export async function runScenario(
 
       const context = await getBaselineContext(mode, allTurns, llm);
 
+      // For gateway-based baselines, build the Lore context once per baseline
+      // (distillation + raw tail), not per question — it's the same for all questions.
+      const isGatewayBaseline =
+        gateway.isReal !== false &&
+        (mode === "lore" || mode === "lore-context-only" || mode === "lore-memory-only");
+      const loreContext = isGatewayBaseline
+        ? await buildLoreContext(allTurns)
+        : "";
+
       // Ask each question
       for (const q of scenario.questions) {
         let hypothesis: string;
@@ -779,18 +880,14 @@ export async function runScenario(
             cacheWrite: 0,
             totalCost: 0,
           };
-        } else if (
-          gateway.isReal !== false &&
-          (mode === "lore" ||
-            mode === "lore-context-only" ||
-            mode === "lore-memory-only")
-        ) {
+        } else if (isGatewayBaseline) {
           // Gateway-based baselines: send the question through the gateway
-          // so it gets Lore's LTM injection, recall, and distilled context.
+          // so it gets Lore's LTM injection, recall tool, and distilled context.
           const answer = await askQuestionViaGateway(
             q.question,
             gateway,
             config.model,
+            loreContext,
           );
           hypothesis = answer.hypothesis;
           tokens = answer.tokens;


### PR DESCRIPTION
## Summary

Fixes the CM-1 eval to test Lore the way it actually works in production — with distillation prefix + raw tail window + LTM + recall, using separate budgets that match the gradient context manager.

## Problem

The eval's Lore baseline created a **fresh gateway session** per QA question. This new session had:
- **No distillation prefix** — distillations are session-scoped (`gradient.ts:691`), and the QA session had a different ID
- **No context-bound LTM** — gated by `isFirstTurn` (`pipeline.ts:2900`)
- **Only the recall tool** — which returned compressed/truncated results

In real Lore usage, the gradient system allocates **separate budgets**: 25% of usable context for distillation prefix, 40% for raw tail window, with LTM injected separately. The eval was testing recall-in-isolation rather than the full Lore experience.

## Fix

Adds `buildLoreContext()` to the eval harness that mimics the gradient context manager:
1. **Separate budgets** — distillation and raw tail don't compete for the same pool (matching `config.ts` defaults)
2. **Usable context** — subtracts output reserve (32K) and overhead (~8K) before computing budgets (matching `gradient.ts` logic)
3. **Non-archived distillations only** — `archived = 0` filter matches what the gradient system includes in-context
4. **No LTM duplication** — LTM is left to the gateway's own system prompt injection
5. **Built once per baseline** — not per question (performance)

The recall tool is still available via the gateway for additional detail.

## Results

**Base CM-1 (~16K tokens):**

| Baseline | Before | After |
|----------|--------|-------|
| **Lore** | 1.9 | **4.8** |
| Tail-window | 4.9 | 4.9 |
| Compaction | 4.9 | 4.9 |

**Inflated CM-1 (400K tokens) — Lore beats tail-window by +50%:**

| Baseline | Score |
|----------|-------|
| **Lore** | **3.9** |
| Tail-window | 2.6 |
| Compaction | 4.1 |

Remaining gap vs compaction (3.9 vs 4.1) is due to distillation compression losses — tracked in #417.

## Changes

### `packages/core/eval/harness.ts`
- Add `buildLoreContext(turns, contextWindow)` — builds distillation + raw tail context with separate budgets matching gradient defaults
- Update `askQuestionViaGateway()` to accept and inject Lore context into the QA request
- Hoist context building outside the question loop (built once per baseline)
- Remove unused `sessionHeaders` parameter

Related to #410