### PR TITLE
fix: build Bun-native ESM bundle for OpenCode plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,9 @@ jobs:
           kill $SERVER_PID
           wait $SERVER_PID 2>/dev/null || true
 
+      - name: Smoke-test bundle exports under Bun
+        run: bun test packages/gateway/test/bundle-exports.test.ts
+
       # -----------------------------------------------------------------
       # CLI: standalone binary build + smoke test
       # -----------------------------------------------------------------

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -8,7 +8,7 @@
   "types": "./dist/index.d.cts",
   "exports": {
     ".": {
-      "bun": "./src/index.ts",
+      "bun": "./dist/index.bun.js",
       "types": "./dist/index.d.cts",
       "require": "./dist/index.cjs",
       "default": "./dist/index.cjs"
@@ -23,7 +23,8 @@
     "build": "bun run script/build.ts",
     "bundle": "bun run script/bundle.ts",
     "build:binary": "bun run script/build.ts --binary",
-    "start": "bun run src/index.ts"
+    "start": "bun run src/index.ts",
+    "prepare": "node -e \"var f=require('fs'),p='dist/index.bun.js';if(!f.existsSync(p)){f.mkdirSync('dist',{recursive:true});f.writeFileSync(p,'export * from \\\"../src/index.ts\\\";\\n')}\""
   },
   "dependencies": {
     "p-limit": "7"
@@ -31,6 +32,8 @@
   "files": [
     "dist/bin.cjs",
     "dist/embedding-worker.cjs",
+    "dist/embedding-worker.js",
+    "dist/index.bun.js",
     "dist/index.cjs",
     "dist/index.d.cts"
   ],

--- a/packages/gateway/script/bundle.ts
+++ b/packages/gateway/script/bundle.ts
@@ -96,6 +96,34 @@ await esbuild.build({
 });
 
 // ---------------------------------------------------------------------------
+// Bun ESM bundle — for @loreai/opencode plugin running under Bun
+// ---------------------------------------------------------------------------
+// Uses conditions: ["bun"] so #db/driver resolves to driver.bun.ts (bun:sqlite).
+// Same @sentry/bun → @sentry/node remap as the CJS build — @sentry/node works
+// under Bun (proven by getsentry/cli which uses @sentry/node-core under Bun).
+// No Node.js polyfills needed — this runs natively under Bun.
+
+await esbuild.build({
+  entryPoints: [join(packageDir, "src/index.ts")],
+  bundle: true,
+  format: "esm",
+  target: "esnext",
+  platform: "node",
+  conditions: ["bun"],
+  external: ["bun:*", "node:*", "onnxruntime-node", "sharp"],
+  outfile: join(distDir, "index.bun.js"),
+  sourcemap: false,
+  minify: true,
+  logLevel: "info",
+  legalComments: "none",
+  plugins: [sentryNodePlugin],
+  define: {
+    LORE_CLI_VERSION: JSON.stringify(pkg.version),
+    __SENTRY_DEBUG_ID__: JSON.stringify(PLACEHOLDER_DEBUG_ID),
+  },
+});
+
+// ---------------------------------------------------------------------------
 // Embedding worker — separate CJS file next to index.cjs
 // ---------------------------------------------------------------------------
 // LocalProvider in core/embedding.ts spawns this via node:worker_threads.
@@ -111,6 +139,27 @@ await esbuild.build({
   conditions: ["node"],
   external: ["onnxruntime-node", "sharp"],
   outfile: join(distDir, "embedding-worker.cjs"),
+  sourcemap: false,
+  minify: true,
+  logLevel: "info",
+  legalComments: "none",
+});
+
+// ---------------------------------------------------------------------------
+// Embedding worker (ESM) — for the Bun ESM bundle
+// ---------------------------------------------------------------------------
+// The Bun ESM bundle resolves the worker via import.meta.url →
+// ./embedding-worker.js (see core/src/embedding.ts:300-303).
+
+await esbuild.build({
+  entryPoints: [join(packageDir, "..", "core", "src", "embedding-worker.ts")],
+  bundle: true,
+  format: "esm",
+  target: "esnext",
+  platform: "node",
+  conditions: ["bun"],
+  external: ["bun:*", "node:*", "onnxruntime-node", "sharp"],
+  outfile: join(distDir, "embedding-worker.js"),
   sourcemap: false,
   minify: true,
   logLevel: "info",
@@ -310,7 +359,9 @@ export declare function _cli(): Promise<void>;
 writeFileSync(join(distDir, "index.d.cts"), typeDeclarations);
 
 console.log(`\n✓ @loreai/gateway npm bundle complete (v${pkg.version})`);
-console.log(`  dist/index.cjs            — CJS bundle`);
-console.log(`  dist/embedding-worker.cjs — embedding worker (spawned via worker_threads)`);
+console.log(`  dist/index.cjs            — CJS bundle (Node.js, node:sqlite)`);
+console.log(`  dist/index.bun.js         — ESM bundle (Bun, bun:sqlite)`);
+console.log(`  dist/embedding-worker.cjs — embedding worker CJS (Node.js)`);
+console.log(`  dist/embedding-worker.js  — embedding worker ESM (Bun)`);
 console.log(`  dist/bin.cjs              — CLI wrapper`);
 console.log(`  dist/index.d.cts          — type declarations`);

--- a/packages/gateway/test/bundle-exports.test.ts
+++ b/packages/gateway/test/bundle-exports.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Smoke test for the npm bundle artifacts.
+ *
+ * Verifies that:
+ * - Every file referenced by package.json `files` and `exports` exists
+ * - The Bun ESM bundle uses bun:sqlite (not node:sqlite)
+ * - The CJS Node bundle uses node:sqlite (not bun:sqlite)
+ * - The Bun ESM bundle can be imported at runtime under Bun
+ * - The imported module exports the expected public API
+ *
+ * Requires `bun run bundle` to have been run first. Skipped otherwise.
+ */
+import { describe, test, expect } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageDir = join(fileURLToPath(import.meta.url), "..", "..");
+const distDir = join(packageDir, "dist");
+const pkgJson = JSON.parse(readFileSync(join(packageDir, "package.json"), "utf8"));
+const hasBundle = existsSync(join(distDir, "index.cjs")) && existsSync(join(distDir, "index.bun.js"));
+
+describe.skipIf(!hasBundle)("bundle exports", () => {
+  // -------------------------------------------------------------------------
+  // Layer 1: Static content checks
+  // -------------------------------------------------------------------------
+
+  test("all declared files exist", () => {
+    for (const file of pkgJson.files as string[]) {
+      const fullPath = join(packageDir, file);
+      expect(existsSync(fullPath)).toBe(true);
+    }
+  });
+
+  test("export conditions reference files in the files list", () => {
+    const filesSet = new Set(pkgJson.files as string[]);
+    const exports = pkgJson.exports["."] as Record<string, string>;
+    for (const [condition, filePath] of Object.entries(exports)) {
+      // Strip leading "./" for comparison with files array entries
+      const normalized = filePath.replace(/^\.\//, "");
+      expect(filesSet.has(normalized)).toBe(true);
+    }
+  });
+
+  test("Bun bundle uses bun:sqlite, not node:sqlite", () => {
+    const content = readFileSync(join(distDir, "index.bun.js"), "utf8");
+    expect(content).toContain("bun:sqlite");
+    expect(content).not.toContain("node:sqlite");
+  });
+
+  test("CJS bundle uses node:sqlite, not bun:sqlite", () => {
+    const content = readFileSync(join(distDir, "index.cjs"), "utf8");
+    expect(content).toContain("node:sqlite");
+    expect(content).not.toContain("bun:sqlite");
+  });
+
+  // -------------------------------------------------------------------------
+  // Layer 2: Runtime import under Bun
+  // -------------------------------------------------------------------------
+
+  test("Bun bundle can be imported at runtime", async () => {
+    const mod = await import(join(distDir, "index.bun.js"));
+    expect(typeof mod.startGateway).toBe("function");
+    expect(typeof mod.loadConfig).toBe("function");
+    expect(typeof mod.readPortFile).toBe("function");
+    expect(typeof mod.probeGateway).toBe("function");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #401 — the `@loreai/opencode` plugin fails when OpenCode is started directly (not via `lore run`) because the `bun` export condition pointed to source files not shipped in the npm package, and the CJS bundle hard-requires `node:sqlite` which Bun doesn't implement.

## Changes

- **`packages/gateway/package.json`**: Point `bun` export at `dist/index.bun.js` (a real shipped bundle instead of missing source), add `prepare` script for monorepo dev shim, add new files to `files` array
- **`packages/gateway/script/bundle.ts`**: Build a Bun-native ESM bundle (`dist/index.bun.js`) with `conditions: ["bun"]` so `#db/driver` resolves to `bun:sqlite`. Reuses the existing `@sentry/bun` → `@sentry/node` remap (works under Bun). Also builds an ESM embedding worker (`dist/embedding-worker.js`) since the Bun bundle resolves worker paths via `import.meta.url`
- **`packages/gateway/test/bundle-exports.test.ts`** (new): Smoke test with two layers — static content checks (correct sqlite driver per bundle, export-vs-files consistency) and runtime import verification under Bun

## Resolution matrix

| Scenario | Export condition | SQLite driver | Sentry |
|---|---|---|---|
| Monorepo dev (Bun) | `dist/index.bun.js` (dev shim → source) | `bun:sqlite` | `@sentry/bun` |
| npm + Node.js (CLI) | `dist/index.cjs` | `node:sqlite` | `@sentry/node` (remapped) |
| **npm + Bun (OpenCode plugin)** | **`dist/index.bun.js`** | **`bun:sqlite`** | **`@sentry/node`** (remapped) |