### PR TITLE
feat(ui): visual cost bars, savings hero, and daily trend chart

### DIFF
--- a/packages/gateway/src/cost-tracker.ts
+++ b/packages/gateway/src/cost-tracker.ts
@@ -832,9 +832,10 @@ export type DailyCostEntry = {
  * Compute per-day cost totals over the last N days.
  *
  * Uses historical estimates (persisted snapshots) bucketed by lastMessage date,
- * plus live session costs bucketed to today.
+ * plus live session costs bucketed to today. Pass a pre-fetched `preloaded`
+ * to avoid redundant DB scans when the caller already has the data.
  */
-export function computeDailyCosts(days = 14): DailyCostEntry[] {
+export function computeDailyCosts(days = 14, preloaded?: HistoricalEstimates): DailyCostEntry[] {
   const today = new Date();
   const cutoff = new Date(today);
   cutoff.setDate(cutoff.getDate() - days + 1);
@@ -850,7 +851,7 @@ export function computeDailyCosts(days = 14): DailyCostEntry[] {
   }
 
   // Historical sessions
-  const hist = computeHistoricalEstimates();
+  const hist = preloaded ?? computeHistoricalEstimates();
   for (const s of hist.sessions) {
     if (s.lastMessage < cutoffMs) continue;
     const dateKey = new Date(s.lastMessage).toISOString().slice(0, 10);

--- a/packages/gateway/src/cost-tracker.ts
+++ b/packages/gateway/src/cost-tracker.ts
@@ -814,3 +814,67 @@ export function invalidateHistoricalCache(): void {
   historicalCache = null;
   historicalCacheAt = 0;
 }
+
+// ---------------------------------------------------------------------------
+// Daily cost aggregation (for trend chart)
+// ---------------------------------------------------------------------------
+
+export type DailyCostEntry = {
+  /** Date string in YYYY-MM-DD format. */
+  date: string;
+  /** Total USD cost for the day (conversation + worker). */
+  cost: number;
+  /** Number of sessions active on this day. */
+  sessions: number;
+};
+
+/**
+ * Compute per-day cost totals over the last N days.
+ *
+ * Uses historical estimates (persisted snapshots) bucketed by lastMessage date,
+ * plus live session costs bucketed to today.
+ */
+export function computeDailyCosts(days = 14): DailyCostEntry[] {
+  const today = new Date();
+  const cutoff = new Date(today);
+  cutoff.setDate(cutoff.getDate() - days + 1);
+  cutoff.setHours(0, 0, 0, 0);
+  const cutoffMs = cutoff.getTime();
+
+  // Initialize date buckets
+  const buckets = new Map<string, { cost: number; sessions: number }>();
+  for (let i = 0; i < days; i++) {
+    const d = new Date(cutoff);
+    d.setDate(d.getDate() + i);
+    buckets.set(d.toISOString().slice(0, 10), { cost: 0, sessions: 0 });
+  }
+
+  // Historical sessions
+  const hist = computeHistoricalEstimates();
+  for (const s of hist.sessions) {
+    if (s.lastMessage < cutoffMs) continue;
+    const dateKey = new Date(s.lastMessage).toISOString().slice(0, 10);
+    const bucket = buckets.get(dateKey);
+    if (!bucket) continue;
+    const sessionCost = s.persisted
+      ? s.persisted.conversationCost + s.persisted.workerCost
+      : s.distillationCost;
+    bucket.cost += sessionCost;
+    bucket.sessions += 1;
+  }
+
+  // Live sessions (bucket to today)
+  const todayKey = today.toISOString().slice(0, 10);
+  const todayBucket = buckets.get(todayKey);
+  if (todayBucket) {
+    for (const [, c] of sessions) {
+      todayBucket.cost += totalActualCost(c);
+      todayBucket.sessions += 1;
+    }
+  }
+
+  // Convert to sorted array
+  return [...buckets.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, v]) => ({ date, cost: v.cost, sessions: v.sessions }));
+}

--- a/packages/gateway/src/ui.ts
+++ b/packages/gateway/src/ui.ts
@@ -212,25 +212,29 @@ function formatTokens(count: number): string {
   return `${(count / 1_000_000).toFixed(2)}M`;
 }
 
-/** Render a labeled cost progress bar with optional ghost (counterfactual) outline. */
+/**
+ * Render a labeled cost progress bar with optional ghost (counterfactual) outline.
+ * `title` and `value` are escaped. `detailLeftHtml`/`detailRightHtml` accept
+ * pre-sanitized trusted HTML (may contain entities like &times;).
+ */
 function renderCostBar(opts: {
   title: string;
   value: string;
   percent: number;
   tint?: string;
   ghostPercent?: number;
-  detailLeft?: string;
-  detailRight?: string;
+  detailLeftHtml?: string;
+  detailRightHtml?: string;
 }): string {
   const pct = Math.max(0, Math.min(100, opts.percent));
   const ghostHtml = opts.ghostPercent != null
     ? `<div class="cost-bar-ghost" style="width:${Math.min(100, opts.ghostPercent).toFixed(1)}%"></div>`
     : "";
-  const detailHtml = (opts.detailLeft || opts.detailRight)
-    ? `<div class="cost-bar-detail"><span>${opts.detailLeft ?? ""}</span><span>${opts.detailRight ?? ""}</span></div>`
+  const detailHtml = (opts.detailLeftHtml || opts.detailRightHtml)
+    ? `<div class="cost-bar-detail"><span>${opts.detailLeftHtml ?? ""}</span><span>${opts.detailRightHtml ?? ""}</span></div>`
     : "";
   return `<div class="cost-bar-container">
-    <div class="cost-bar-label"><span class="bar-title">${esc(opts.title)}</span><span class="bar-value">${opts.value}</span></div>
+    <div class="cost-bar-label"><span class="bar-title">${esc(opts.title)}</span><span class="bar-value">${esc(opts.value)}</span></div>
     <div class="cost-bar">${ghostHtml}<div class="cost-bar-fill ${opts.tint ?? "bar-blue"}" style="width:${pct.toFixed(1)}%"></div></div>
     ${detailHtml}
   </div>`;
@@ -280,8 +284,8 @@ function renderCostSummary(sessionId: string): string {
     value: formatUSD(actual),
     percent: convPct,
     tint: "bar-green",
-    detailLeft: `Conversation: ${formatUSD(costs.conversation.cost)} (${costs.conversation.turns} turns)`,
-    detailRight: workerCost > 0 ? `Overhead: ${formatUSD(workerCost)}${overheadDetail}` : "",
+    detailLeftHtml: `Conversation: ${formatUSD(costs.conversation.cost)} (${costs.conversation.turns} turns)`,
+    detailRightHtml: workerCost > 0 ? `Overhead: ${formatUSD(workerCost)}${overheadDetail}` : "",
   });
 
   // Cache hit rate bar
@@ -291,8 +295,8 @@ function renderCostSummary(sessionId: string): string {
       value: `${cacheHitRate}%`,
       percent: parseFloat(cacheHitRate),
       tint: "bar-green",
-      detailLeft: `${formatTokens(totalInput)} in, ${formatTokens(costs.conversation.outputTokens)} out`,
-      detailRight: `${formatTokens(costs.conversation.cacheReadTokens)} cache reads`,
+      detailLeftHtml: `${formatTokens(totalInput)} in, ${formatTokens(costs.conversation.outputTokens)} out`,
+      detailRightHtml: `${formatTokens(costs.conversation.cacheReadTokens)} cache reads`,
     });
   }
 
@@ -305,10 +309,10 @@ function renderCostSummary(sessionId: string): string {
       percent: actualPct,
       tint: savings >= 0 ? "bar-blue" : "bar-red",
       ghostPercent: 100,
-      detailLeft: savings >= 0
+      detailLeftHtml: savings >= 0
         ? `Saved: ${formatUSD(savings)} (${savingsPct}%)`
         : `Net overhead: ${formatUSD(-savings)}`,
-      detailRight: "",
+      detailRightHtml: "",
     });
   }
 
@@ -471,7 +475,7 @@ form.inline { display: inline; }
   background: var(--bg3); border-radius: 3px;
   overflow: hidden; vertical-align: middle; margin-right: 4px;
 }
-.mini-bar-fill { height: 100%; border-radius: 3px; }
+.mini-bar-fill { display: block; height: 100%; border-radius: 3px; }
 /* --- Daily cost trend chart --- */
 .daily-chart {
   display: flex; align-items: flex-end; gap: 3px;
@@ -2074,19 +2078,27 @@ function pageCosts(): string {
     </div>`;
   } else if (combinedNetSavings < 0) {
     body += `<div class="savings-hero">
-      <div class="big-number" style="color:#e06c75">Net overhead: ${formatUSD(-combinedNetSavings)}</div>
+      <div class="big-number" style="color:#e06c75">Net overhead: ${formatUSD(Math.abs(combinedNetSavings))}</div>
       <div class="sub-label">Total spend: ${formatUSD(combinedTotalSpend)} &middot; Overhead: ${formatUSD(combinedWorkerCost)} &middot; Savings will grow as sessions continue</div>
+    </div>`;
+  } else if (combinedTotalSpend > 0) {
+    // Exactly zero net savings — overhead equals savings
+    body += `<div class="savings-hero">
+      <div class="big-number" style="color:var(--fg2)">Breaking even</div>
+      <div class="sub-label">Total spend: ${formatUSD(combinedTotalSpend)} &middot; Lore overhead exactly matches savings</div>
     </div>`;
   }
 
   // Summary stats (compact pills for secondary metrics)
-  // Trend arrow: compare live savings rate vs historical average
+  // Trend arrow: compare live savings rate vs historical average.
+  // Both rates use the same formula: netSavings / counterfactual,
+  // where counterfactual = actualSpend + netSavings.
   const liveSavingsRate = liveTotalWithout > 0 ? liveTotalSavings / liveTotalWithout : 0;
-  const histCounterfactual = hist.persistedConversationCost + hist.totalWorkerCost +
-    hist.warmupSavings + hist.ttlSavings + hist.batchSavings + hist.avoidedCompactionCost;
-  const histSavingsRate = histCounterfactual > 0
-    ? (hist.warmupSavings + hist.ttlSavings + hist.batchSavings + hist.avoidedCompactionCost - hist.totalWorkerCost) / histCounterfactual
-    : 0;
+  const histNetSavings = hist.warmupSavings + hist.ttlSavings + hist.batchSavings +
+    hist.avoidedCompactionCost - hist.totalWorkerCost;
+  const histActualSpend = hist.persistedConversationCost + hist.totalWorkerCost;
+  const histWithoutLore = histActualSpend + histNetSavings;
+  const histSavingsRate = histWithoutLore > 0 ? histNetSavings / histWithoutLore : 0;
   let trendArrow = "";
   if (allCosts.size > 0 && hist.sessionCount > 0) {
     if (liveSavingsRate > histSavingsRate + 0.02) {
@@ -2103,7 +2115,7 @@ function pageCosts(): string {
   </div>`;
 
   // --- Daily cost trend chart ---
-  const dailyCosts = computeDailyCosts(14);
+  const dailyCosts = computeDailyCosts(14, historical);
   const maxDayCost = Math.max(...dailyCosts.map((d) => d.cost), 0.001);
   if (dailyCosts.some((d) => d.cost > 0)) {
     body += `<h3>Daily Cost Trend (last 14 days)</h3>`;
@@ -2146,8 +2158,8 @@ function pageCosts(): string {
       value: formatUSD(liveTotalSpend),
       percent: convPct,
       tint: "bar-green",
-      detailLeft: `Conversation: ${formatUSD(liveTotalConversation)} (${liveTotalTurns} turns)`,
-      detailRight: `Overhead: ${formatUSD(liveTotalWorker)}${overheadDetail}`,
+      detailLeftHtml: `Conversation: ${formatUSD(liveTotalConversation)} (${liveTotalTurns} turns)`,
+      detailRightHtml: `Overhead: ${formatUSD(liveTotalWorker)}${overheadDetail}`,
     });
 
     // Savings ratio bar: actual vs counterfactual
@@ -2159,10 +2171,10 @@ function pageCosts(): string {
         percent: actualPct,
         tint: liveTotalSavings >= 0 ? "bar-blue" : "bar-red",
         ghostPercent: 100,
-        detailLeft: liveTotalSavings >= 0
+        detailLeftHtml: liveTotalSavings >= 0
           ? `Saved: ${formatUSD(liveTotalSavings)}`
           : `Overhead: ${formatUSD(-liveTotalSavings)}`,
-        detailRight: liveTotalWithout > 0
+        detailRightHtml: liveTotalWithout > 0
           ? `${(100 - actualPct).toFixed(0)}% saved`
           : "",
       });
@@ -2178,8 +2190,8 @@ function pageCosts(): string {
         value: `${liveCacheHitPct.toFixed(0)}%`,
         percent: liveCacheHitPct,
         tint: "bar-green",
-        detailLeft: `${formatTokens(liveCacheReadTokens)} cache reads`,
-        detailRight: `${formatTokens(liveTotalInputTokens)} total input`,
+        detailLeftHtml: `${formatTokens(liveCacheReadTokens)} cache reads`,
+        detailRightHtml: `${formatTokens(liveTotalInputTokens)} total input`,
       });
     }
 

--- a/packages/gateway/src/ui.ts
+++ b/packages/gateway/src/ui.ts
@@ -20,6 +20,7 @@ import {
 } from "@loreai/core";
 import {
   computeHistoricalEstimates,
+  computeDailyCosts,
   getSessionCosts,
   getAllSessionCosts,
   totalActualCost,
@@ -211,6 +212,36 @@ function formatTokens(count: number): string {
   return `${(count / 1_000_000).toFixed(2)}M`;
 }
 
+/** Render a labeled cost progress bar with optional ghost (counterfactual) outline. */
+function renderCostBar(opts: {
+  title: string;
+  value: string;
+  percent: number;
+  tint?: string;
+  ghostPercent?: number;
+  detailLeft?: string;
+  detailRight?: string;
+}): string {
+  const pct = Math.max(0, Math.min(100, opts.percent));
+  const ghostHtml = opts.ghostPercent != null
+    ? `<div class="cost-bar-ghost" style="width:${Math.min(100, opts.ghostPercent).toFixed(1)}%"></div>`
+    : "";
+  const detailHtml = (opts.detailLeft || opts.detailRight)
+    ? `<div class="cost-bar-detail"><span>${opts.detailLeft ?? ""}</span><span>${opts.detailRight ?? ""}</span></div>`
+    : "";
+  return `<div class="cost-bar-container">
+    <div class="cost-bar-label"><span class="bar-title">${esc(opts.title)}</span><span class="bar-value">${opts.value}</span></div>
+    <div class="cost-bar">${ghostHtml}<div class="cost-bar-fill ${opts.tint ?? "bar-blue"}" style="width:${pct.toFixed(1)}%"></div></div>
+    ${detailHtml}
+  </div>`;
+}
+
+/** Render an inline mini progress bar for table cells. */
+function renderMiniBar(percent: number, tint = "bar-green"): string {
+  const pct = Math.max(0, Math.min(100, percent));
+  return `<span class="mini-bar"><span class="mini-bar-fill ${tint}" style="width:${pct.toFixed(0)}%"></span></span>`;
+}
+
 function renderCostSummary(sessionId: string): string {
   const costs = getSessionCosts(sessionId);
   if (!costs || costs.conversation.turns === 0) return "";
@@ -232,64 +263,74 @@ function renderCostSummary(sessionId: string): string {
     : "0";
 
   let html = `<div class="card" style="margin-bottom:1.5em">
-    <h2 style="margin-top:0">Cost Intelligence</h2>
-    <table class="cost-table">
-      <tr class="section-header"><td colspan="2"><strong>Your Spend</strong></td></tr>
-      <tr>
-        <td>Conversation</td>
-        <td>${formatUSD(costs.conversation.cost)}
-          <span style="color:var(--fg3);font-size:0.85em">(${formatTokens(totalInput)} in, ${formatTokens(costs.conversation.outputTokens)} out, ${cacheHitRate}% cache hit)</span></td>
-      </tr>`;
+    <h2 style="margin-top:0">Cost Intelligence</h2>`;
 
-  if (workerCost > 0) {
-    html += `<tr>
-        <td>+ Lore overhead</td>
-        <td>${formatUSD(workerCost)}`;
-    const parts: string[] = [];
-    if (costs.workers.distillation.cost > 0) parts.push(`distill: ${formatUSD(costs.workers.distillation.cost)}`);
-    if (costs.workers.curation.cost > 0) parts.push(`curate: ${formatUSD(costs.workers.curation.cost)}`);
-    if (costs.workers.compaction.cost > 0) parts.push(`compact: ${formatUSD(costs.workers.compaction.cost)}`);
-    if (costs.workers.warmup.cost > 0) parts.push(`warmup: ${formatUSD(costs.workers.warmup.cost)}`);
-    if (costs.workers.recall.cost > 0) parts.push(`recall: ${formatUSD(costs.workers.recall.cost)}`);
-    if (parts.length) html += ` <span style="color:var(--fg3);font-size:0.85em">(${parts.join(", ")})</span>`;
-    html += `</td></tr>`;
+  // Spend composition bar: conversation vs overhead
+  const spendTotal = costs.conversation.cost + workerCost;
+  const convPct = spendTotal > 0 ? (costs.conversation.cost / spendTotal) * 100 : 100;
+  const overheadParts: string[] = [];
+  if (costs.workers.distillation.cost > 0) overheadParts.push(`distill: ${formatUSD(costs.workers.distillation.cost)}`);
+  if (costs.workers.curation.cost > 0) overheadParts.push(`curate: ${formatUSD(costs.workers.curation.cost)}`);
+  if (costs.workers.compaction.cost > 0) overheadParts.push(`compact: ${formatUSD(costs.workers.compaction.cost)}`);
+  if (costs.workers.warmup.cost > 0) overheadParts.push(`warmup: ${formatUSD(costs.workers.warmup.cost)}`);
+  if (costs.workers.recall.cost > 0) overheadParts.push(`recall: ${formatUSD(costs.workers.recall.cost)}`);
+  const overheadDetail = overheadParts.length ? ` (${overheadParts.join(", ")})` : "";
+  html += renderCostBar({
+    title: "Your Spend",
+    value: formatUSD(actual),
+    percent: convPct,
+    tint: "bar-green",
+    detailLeft: `Conversation: ${formatUSD(costs.conversation.cost)} (${costs.conversation.turns} turns)`,
+    detailRight: workerCost > 0 ? `Overhead: ${formatUSD(workerCost)}${overheadDetail}` : "",
+  });
+
+  // Cache hit rate bar
+  if (totalInput > 0) {
+    html += renderCostBar({
+      title: "Cache Hit Rate",
+      value: `${cacheHitRate}%`,
+      percent: parseFloat(cacheHitRate),
+      tint: "bar-green",
+      detailLeft: `${formatTokens(totalInput)} in, ${formatTokens(costs.conversation.outputTokens)} out`,
+      detailRight: `${formatTokens(costs.conversation.cacheReadTokens)} cache reads`,
+    });
   }
 
-  html += `<tr style="border-top:1px solid var(--border)">
-        <td><strong>Total</strong></td>
-        <td><strong>${formatUSD(actual)}</strong></td>
-      </tr>`;
-
-  // Counterfactual section
-  if (withoutLore > actual) {
-    html += `<tr class="section-header"><td colspan="2" style="padding-top:0.8em"><strong>Without Lore (estimated)</strong></td></tr>
-      <tr>
-        <td>Estimated total</td>
-        <td>${formatUSD(withoutLore)}</td>
-      </tr>`;
+  // Savings ratio bar: actual vs counterfactual
+  if (withoutLore > 0) {
+    const actualPct = (actual / withoutLore) * 100;
+    html += renderCostBar({
+      title: "Actual vs Without Lore",
+      value: `${formatUSD(actual)} of ${formatUSD(withoutLore)}`,
+      percent: actualPct,
+      tint: savings >= 0 ? "bar-blue" : "bar-red",
+      ghostPercent: 100,
+      detailLeft: savings >= 0
+        ? `Saved: ${formatUSD(savings)} (${savingsPct}%)`
+        : `Net overhead: ${formatUSD(-savings)}`,
+      detailRight: "",
+    });
   }
 
-  // Savings breakdown
-  const hasSavings = savings > 0;
-  if (hasSavings) {
-    html += `<tr class="section-header"><td colspan="2" style="padding-top:0.8em"><strong>Savings: ${formatUSD(savings)} (${savingsPct}%)</strong></td></tr>`;
-    if (costs.counterfactual.warmupSavings > 0) {
-      html += `<tr><td>Cache warming</td><td>${formatUSD(costs.counterfactual.warmupSavings)} <span style="color:var(--fg3);font-size:0.85em">(${costs.counterfactual.warmupHits} hits)</span></td></tr>`;
-    }
-    if (costs.counterfactual.ttlSavings > 0) {
-      html += `<tr><td>1h TTL</td><td>${formatUSD(costs.counterfactual.ttlSavings)} <span style="color:var(--fg3);font-size:0.85em">(${costs.counterfactual.ttlHits} turns with &gt;5m gaps)</span></td></tr>`;
-    }
-    if (costs.batchSavings > 0) {
-      html += `<tr><td>Batch API</td><td>${formatUSD(costs.batchSavings)}</td></tr>`;
-    }
-    if (costs.counterfactual.avoidedCompactionCost > 0) {
-      html += `<tr><td>Avoided compactions</td><td>${formatUSD(costs.counterfactual.avoidedCompactionCost)} <span style="color:var(--fg3);font-size:0.85em">(&times;${costs.counterfactual.avoidedCompactions} compactions)</span></td></tr>`;
+  // Savings breakdown (compact)
+  if (savings > 0) {
+    const items: string[] = [];
+    if (costs.counterfactual.warmupSavings > 0) items.push(`Cache warming: ${formatUSD(costs.counterfactual.warmupSavings)} (${costs.counterfactual.warmupHits} hits)`);
+    if (costs.counterfactual.ttlSavings > 0) items.push(`1h TTL: ${formatUSD(costs.counterfactual.ttlSavings)} (${costs.counterfactual.ttlHits} turns)`);
+    if (costs.batchSavings > 0) items.push(`Batch API: ${formatUSD(costs.batchSavings)}`);
+    if (costs.counterfactual.avoidedCompactionCost > 0) items.push(`Avoided compactions: ${formatUSD(costs.counterfactual.avoidedCompactionCost)} (&times;${costs.counterfactual.avoidedCompactions})`);
+    if (items.length) {
+      html += `<div style="margin-top:10px;font-size:0.85em;color:var(--fg2)">
+        <strong style="color:#10b981">Savings breakdown:</strong> ${items.join(" &middot; ")}
+      </div>`;
     }
   } else if (savings < 0) {
-    html += `<tr class="section-header"><td colspan="2" style="padding-top:0.8em;color:#e06c75"><strong>Net overhead: ${formatUSD(-savings)}</strong> (Lore overhead exceeds savings this session)</td></tr>`;
+    html += `<div style="margin-top:10px;font-size:0.85em;color:#e06c75">
+      <strong>Net overhead: ${formatUSD(-savings)}</strong> &mdash; Lore overhead exceeds savings this session
+    </div>`;
   }
 
-  html += `</table></div>`;
+  html += `</div>`;
   return html;
 }
 
@@ -383,6 +424,72 @@ form.inline { display: inline; }
 .result-summary { font-size: 0.9em; color: var(--fg3); margin: 8px 0; }
 .cost-table td { padding: 4px 10px; font-size: 0.9em; }
 .cost-table .section-header td { padding-top: 0.6em; }
+/* --- Cost progress bars (inspired by CodexBar MetricRow) --- */
+.cost-bar-container { margin: 8px 0; }
+.cost-bar-label {
+  display: flex; justify-content: space-between; align-items: baseline;
+  font-size: 0.85em; margin-bottom: 4px;
+}
+.cost-bar-label .bar-title { font-weight: 600; }
+.cost-bar-label .bar-value { color: var(--fg2); font-family: var(--mono); }
+.cost-bar {
+  position: relative; height: 20px; background: var(--bg3);
+  border-radius: 4px; overflow: hidden;
+}
+.cost-bar-fill {
+  height: 100%; border-radius: 4px; transition: width 0.2s; min-width: 2px;
+}
+.cost-bar-ghost {
+  position: absolute; top: 0; left: 0; height: 100%;
+  border: 2px dashed var(--fg3); border-radius: 4px;
+  opacity: 0.4; box-sizing: border-box;
+}
+.cost-bar-detail {
+  display: flex; justify-content: space-between;
+  font-size: 0.8em; color: var(--fg3); margin-top: 3px;
+}
+/* Tint colors */
+.bar-green  { background: #10b981; }
+.bar-blue   { background: #60a5fa; }
+.bar-amber  { background: #f59e0b; }
+.bar-red    { background: #ef4444; }
+/* --- Savings hero stat --- */
+.savings-hero {
+  text-align: center; padding: 16px; margin: 12px 0;
+  background: var(--bg2); border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+.savings-hero .big-number {
+  font-size: 2.2em; font-weight: 700; line-height: 1.2;
+}
+.savings-hero .sub-label {
+  font-size: 0.9em; color: var(--fg3); margin-top: 2px;
+}
+/* --- Inline mini bar (for table cells) --- */
+.mini-bar {
+  display: inline-block; width: 48px; height: 8px;
+  background: var(--bg3); border-radius: 3px;
+  overflow: hidden; vertical-align: middle; margin-right: 4px;
+}
+.mini-bar-fill { height: 100%; border-radius: 3px; }
+/* --- Daily cost trend chart --- */
+.daily-chart {
+  display: flex; align-items: flex-end; gap: 3px;
+  height: 100px; padding: 8px 0; margin: 12px 0;
+  border-bottom: 1px solid var(--border);
+}
+.day-col {
+  flex: 1; display: flex; flex-direction: column;
+  align-items: center; min-width: 0;
+}
+.day-bar {
+  width: 100%; background: #60a5fa; border-radius: 2px 2px 0 0;
+  min-height: 2px;
+}
+.day-label {
+  font-size: 0.65em; color: var(--fg3); margin-top: 4px;
+  white-space: nowrap; overflow: hidden;
+}
 .actions { margin: 16px 0; display: flex; gap: 8px; }
 .empty { color: var(--fg3); font-style: italic; padding: 24px 0; text-align: center; }
 .md { font-size: 0.9em; line-height: 1.6; overflow-wrap: break-word; }
@@ -1126,13 +1233,23 @@ function renderSessionRow(r: LiveSessionRow, opts?: { isChild?: boolean; parentI
     ? ` class="subagent-row" data-parent="${esc(parentId ?? "")}"`
     : "";
 
+  // Savings cell with background tint
+  const savingsBg = r.hasCosts && displaySavings !== 0
+    ? (displaySavings >= 0 ? "rgba(16,185,129,0.08)" : "rgba(239,68,68,0.08)")
+    : "transparent";
+
+  // Cache hit cell with inline mini-bar
+  const cacheHitCell = !Number.isNaN(r.cacheHitPct)
+    ? `${renderMiniBar(r.cacheHitPct, "bar-green")}${r.cacheHitPct.toFixed(0)}%`
+    : "-";
+
   return `<tr${trAttrs}>
     <td>${toggle}${projCell}</td>
     <td>${sessCell}</td>
     <td>${r.turns}</td>
     <td>${r.hasCosts ? formatUSD(displayCost) : "-"}</td>
-    <td>${r.hasCosts ? `<span style="color:${savingsColor}">${formatUSD(displaySavings)}</span>` : "-"}</td>
-    <td>${!Number.isNaN(r.cacheHitPct) ? r.cacheHitPct.toFixed(0) + "%" : "-"}</td>
+    <td style="background:${savingsBg}">${r.hasCosts ? `<span style="color:${savingsColor}">${formatUSD(displaySavings)}</span>` : "-"}</td>
+    <td>${cacheHitCell}</td>
     <td>${r.warmingSnap ? r.pReturnsPct.toFixed(1) + "%" : "-"}</td>
     <td>${statusCell}</td>
     <td>${hitsCell}</td>
@@ -1900,6 +2017,8 @@ function pageCosts(): string {
   let liveCompactCost = 0;
   let liveWarmupCost = 0;
   let liveRecallCost = 0;
+  let liveCacheReadTokens = 0;
+  let liveTotalInputTokens = 0;
 
   for (const [, c] of allCosts) {
     liveTotalSpend += totalActualCost(c);
@@ -1919,6 +2038,8 @@ function pageCosts(): string {
     liveCompactCost += c.workers.compaction.cost;
     liveWarmupCost += c.workers.warmup.cost;
     liveRecallCost += c.workers.recall.cost;
+    liveCacheReadTokens += c.conversation.cacheReadTokens;
+    liveTotalInputTokens += c.conversation.inputTokens + c.conversation.cacheReadTokens + c.conversation.cacheWriteTokens;
   }
 
   // --- Historical (backdated) estimates ---
@@ -1941,14 +2062,63 @@ function pageCosts(): string {
   const combinedSessionCount = allCosts.size + hist.sessionCount;
   const combinedTotalSpend = liveTotalSpend + hist.persistedConversationCost + hist.totalWorkerCost;
 
-  // Summary stats (live/total format)
+  // --- Savings hero stat ---
+  const combinedCounterfactual = combinedTotalSpend + combinedNetSavings;
+  const savingsPctCombined = combinedCounterfactual > 0
+    ? (combinedNetSavings / combinedCounterfactual * 100).toFixed(0)
+    : "0";
+  if (combinedNetSavings > 0) {
+    body += `<div class="savings-hero">
+      <div class="big-number" style="color:#10b981">${formatUSD(combinedNetSavings)} saved (${savingsPctCombined}%)</div>
+      <div class="sub-label">Total spend: ${formatUSD(combinedTotalSpend)} &middot; Overhead: ${formatUSD(combinedWorkerCost)} &middot; Without Lore: ${formatUSD(combinedCounterfactual)}</div>
+    </div>`;
+  } else if (combinedNetSavings < 0) {
+    body += `<div class="savings-hero">
+      <div class="big-number" style="color:#e06c75">Net overhead: ${formatUSD(-combinedNetSavings)}</div>
+      <div class="sub-label">Total spend: ${formatUSD(combinedTotalSpend)} &middot; Overhead: ${formatUSD(combinedWorkerCost)} &middot; Savings will grow as sessions continue</div>
+    </div>`;
+  }
+
+  // Summary stats (compact pills for secondary metrics)
+  // Trend arrow: compare live savings rate vs historical average
+  const liveSavingsRate = liveTotalWithout > 0 ? liveTotalSavings / liveTotalWithout : 0;
+  const histCounterfactual = hist.persistedConversationCost + hist.totalWorkerCost +
+    hist.warmupSavings + hist.ttlSavings + hist.batchSavings + hist.avoidedCompactionCost;
+  const histSavingsRate = histCounterfactual > 0
+    ? (hist.warmupSavings + hist.ttlSavings + hist.batchSavings + hist.avoidedCompactionCost - hist.totalWorkerCost) / histCounterfactual
+    : 0;
+  let trendArrow = "";
+  if (allCosts.size > 0 && hist.sessionCount > 0) {
+    if (liveSavingsRate > histSavingsRate + 0.02) {
+      trendArrow = ` <span title="Live savings rate above historical average" style="color:#10b981;font-size:0.7em">\u25B2</span>`;
+    } else if (liveSavingsRate < histSavingsRate - 0.02) {
+      trendArrow = ` <span title="Live savings rate below historical average" style="color:#e06c75;font-size:0.7em">\u25BC</span>`;
+    }
+  }
+
   body += `<div class="stats">
     <div class="stat"><div class="label">Sessions</div><div class="value">${allCosts.size}<span class="total">/${combinedSessionCount}</span></div></div>
-    <div class="stat"><div class="label">Spend</div><div class="value">${formatUSD(liveTotalSpend)}<span class="total">/${formatUSD(combinedTotalSpend)}</span></div></div>
+    <div class="stat"><div class="label">Spend${trendArrow}</div><div class="value">${formatUSD(liveTotalSpend)}<span class="total">/${formatUSD(combinedTotalSpend)}</span></div></div>
     <div class="stat"><div class="label">Avoided Compactions</div><div class="value">${liveAvoidedCompactions}<span class="total">/${combinedAvoidedCompactions}</span></div></div>
-    ${combinedNetSavings > 0 ? `<div class="stat"><div class="label">Net Savings</div><div class="value" style="color:#10b981">${formatUSD(liveTotalSavings)}<span class="total">/${formatUSD(combinedNetSavings)}</span></div></div>` : ""}
-    ${combinedNetSavings < 0 ? `<div class="stat"><div class="label">Net Overhead</div><div class="value" style="color:#e06c75">${formatUSD(-liveTotalSavings)}<span class="total">/${formatUSD(-combinedNetSavings)}</span></div></div>` : ""}
   </div>`;
+
+  // --- Daily cost trend chart ---
+  const dailyCosts = computeDailyCosts(14);
+  const maxDayCost = Math.max(...dailyCosts.map((d) => d.cost), 0.001);
+  if (dailyCosts.some((d) => d.cost > 0)) {
+    body += `<h3>Daily Cost Trend (last 14 days)</h3>`;
+    body += `<div class="daily-chart">`;
+    for (const day of dailyCosts) {
+      const heightPct = (day.cost / maxDayCost) * 100;
+      const label = day.date.slice(5); // "MM-DD"
+      const tooltip = `${day.date}: ${formatUSD(day.cost)} (${day.sessions} session${day.sessions !== 1 ? "s" : ""})`;
+      body += `<div class="day-col" title="${esc(tooltip)}">
+        <div class="day-bar" style="height:${heightPct.toFixed(1)}%"></div>
+        <div class="day-label">${esc(label)}</div>
+      </div>`;
+    }
+    body += `</div>`;
+  }
 
   // =====================================================
   // LIVE SESSIONS section
@@ -1958,30 +2128,76 @@ function pageCosts(): string {
   if (allCosts.size === 0) {
     body += `<p class="empty">No active sessions yet. Cost tracking begins when the first conversation turn is processed.</p>`;
   } else {
-    body += `<div class="card">
-      <table class="cost-table">
-        <tr class="section-header"><td colspan="2"><strong>Aggregated Spend</strong></td></tr>
-        <tr><td>Conversation</td><td>${formatUSD(liveTotalConversation)} <span style="color:var(--fg3);font-size:0.85em">(${liveTotalTurns} turns)</span></td></tr>
-        <tr><td>+ Lore overhead</td><td>${formatUSD(liveTotalWorker)}${(() => {
-          const parts: string[] = [];
-          if (liveDistillCost > 0) parts.push(`distill: ${formatUSD(liveDistillCost)}`);
-          if (liveCurateCost > 0) parts.push(`curate: ${formatUSD(liveCurateCost)}`);
-          if (liveCompactCost > 0) parts.push(`compact: ${formatUSD(liveCompactCost)}`);
-          if (liveWarmupCost > 0) parts.push(`warmup: ${formatUSD(liveWarmupCost)}`);
-          if (liveRecallCost > 0) parts.push(`recall: ${formatUSD(liveRecallCost)}`);
-          return parts.length ? ` <span style="color:var(--fg3);font-size:0.85em">(${parts.join(", ")})</span>` : "";
-        })()}</td></tr>
-        <tr style="border-top:1px solid var(--border)"><td><strong>Total</strong></td><td><strong>${formatUSD(liveTotalSpend)}</strong></td></tr>`;
+    // --- Visual cost bars ---
+    body += `<div class="card">`;
 
-    if (liveTotalSavings !== 0) {
-      body += `<tr class="section-header"><td colspan="2" style="padding-top:0.8em"><strong>Savings Breakdown</strong></td></tr>`;
-      if (liveWarmupSavings > 0) body += `<tr><td>Cache warming</td><td>${formatUSD(liveWarmupSavings)}</td></tr>`;
-      if (liveTtlSavings > 0) body += `<tr><td>1h TTL</td><td>${formatUSD(liveTtlSavings)}</td></tr>`;
-      if (liveBatchSavings > 0) body += `<tr><td>Batch API</td><td>${formatUSD(liveBatchSavings)}</td></tr>`;
-      if (liveAvoidedCompactionCost > 0) body += `<tr><td>Avoided compactions</td><td>${formatUSD(liveAvoidedCompactionCost)} <span style="color:var(--fg3);font-size:0.85em">(&times;${liveAvoidedCompactions})</span></td></tr>`;
-      body += `<tr style="border-top:1px solid var(--border)"><td><strong>Net savings</strong></td><td><strong style="color:${liveTotalSavings >= 0 ? "#10b981" : "#e06c75"}">${formatUSD(liveTotalSavings)}</strong></td></tr>`;
+    // Spend composition bar: conversation vs overhead
+    const spendTotal = liveTotalConversation + liveTotalWorker;
+    const convPct = spendTotal > 0 ? (liveTotalConversation / spendTotal) * 100 : 100;
+    const overheadParts: string[] = [];
+    if (liveDistillCost > 0) overheadParts.push(`distill: ${formatUSD(liveDistillCost)}`);
+    if (liveCurateCost > 0) overheadParts.push(`curate: ${formatUSD(liveCurateCost)}`);
+    if (liveCompactCost > 0) overheadParts.push(`compact: ${formatUSD(liveCompactCost)}`);
+    if (liveWarmupCost > 0) overheadParts.push(`warmup: ${formatUSD(liveWarmupCost)}`);
+    if (liveRecallCost > 0) overheadParts.push(`recall: ${formatUSD(liveRecallCost)}`);
+    const overheadDetail = overheadParts.length ? ` (${overheadParts.join(", ")})` : "";
+    body += renderCostBar({
+      title: "Spend Composition",
+      value: formatUSD(liveTotalSpend),
+      percent: convPct,
+      tint: "bar-green",
+      detailLeft: `Conversation: ${formatUSD(liveTotalConversation)} (${liveTotalTurns} turns)`,
+      detailRight: `Overhead: ${formatUSD(liveTotalWorker)}${overheadDetail}`,
+    });
+
+    // Savings ratio bar: actual vs counterfactual
+    if (liveTotalWithout > 0) {
+      const actualPct = (liveTotalSpend / liveTotalWithout) * 100;
+      body += renderCostBar({
+        title: "Actual vs Without Lore",
+        value: `${formatUSD(liveTotalSpend)} of ${formatUSD(liveTotalWithout)}`,
+        percent: actualPct,
+        tint: liveTotalSavings >= 0 ? "bar-blue" : "bar-red",
+        ghostPercent: 100,
+        detailLeft: liveTotalSavings >= 0
+          ? `Saved: ${formatUSD(liveTotalSavings)}`
+          : `Overhead: ${formatUSD(-liveTotalSavings)}`,
+        detailRight: liveTotalWithout > 0
+          ? `${(100 - actualPct).toFixed(0)}% saved`
+          : "",
+      });
     }
-    body += `</table></div>`;
+
+    // Cache hit rate bar
+    const liveCacheHitPct = liveTotalInputTokens > 0
+      ? (liveCacheReadTokens / liveTotalInputTokens) * 100
+      : 0;
+    if (liveTotalInputTokens > 0) {
+      body += renderCostBar({
+        title: "Cache Hit Rate",
+        value: `${liveCacheHitPct.toFixed(0)}%`,
+        percent: liveCacheHitPct,
+        tint: "bar-green",
+        detailLeft: `${formatTokens(liveCacheReadTokens)} cache reads`,
+        detailRight: `${formatTokens(liveTotalInputTokens)} total input`,
+      });
+    }
+
+    // Savings breakdown (compact list)
+    if (liveTotalSavings !== 0) {
+      const savingsItems: string[] = [];
+      if (liveWarmupSavings > 0) savingsItems.push(`Cache warming: ${formatUSD(liveWarmupSavings)}`);
+      if (liveTtlSavings > 0) savingsItems.push(`1h TTL: ${formatUSD(liveTtlSavings)}`);
+      if (liveBatchSavings > 0) savingsItems.push(`Batch API: ${formatUSD(liveBatchSavings)}`);
+      if (liveAvoidedCompactionCost > 0) savingsItems.push(`Avoided compactions: ${formatUSD(liveAvoidedCompactionCost)} (&times;${liveAvoidedCompactions})`);
+      if (savingsItems.length) {
+        body += `<div style="margin-top:10px;font-size:0.85em;color:var(--fg2)">
+          <strong style="color:${liveTotalSavings >= 0 ? "#10b981" : "#e06c75"}">Net savings: ${formatUSD(liveTotalSavings)}</strong>
+          &mdash; ${savingsItems.join(" &middot; ")}
+        </div>`;
+      }
+    }
+    body += `</div>`;
 
     // Per-session table (unified: cost + warming columns)
     const activeSessions = getActiveSessions();
@@ -2090,13 +2306,14 @@ function pageCosts(): string {
       const trAttrs = isChild ? ` class="subagent-row" data-parent="${esc(parentSid!)}"` : "";
       const displayCost = hasChildren ? s.rolledUpWorkerCost : (s.persisted?.workerCost ?? s.distillationCost);
 
+      const savingsBg = s.avoidedCompactions > 0 ? "rgba(16,185,129,0.08)" : "transparent";
       body += `<tr${trAttrs}>
         <td>${toggle}<a href="/ui/projects/${esc(s.projectId)}">${esc(s.projectName ?? "(unnamed)")}</a></td>
         <td>${prefix}<a href="/ui/sessions/${esc(s.projectId)}/${esc(s.sessionId)}"><code>${esc(s.sessionId.slice(0, 12))}</code></a>${childCount}</td>
         <td>${s.messageCount}</td>
         <td style="font-size:0.85em">${esc(s.model.replace("claude-", "").slice(0, 20))}</td>
         <td>${formatUSD(displayCost)}</td>
-        <td>${s.avoidedCompactions > 0 ? `${s.avoidedCompactions} (${formatUSD(s.avoidedCompactionCost)})` : "-"}</td>
+        <td style="background:${savingsBg}">${s.avoidedCompactions > 0 ? `${s.avoidedCompactions} (${formatUSD(s.avoidedCompactionCost)})` : "-"}</td>
         <td>${timeAgo(s.lastMessage)}</td>
       </tr>`;
       for (const child of s.children) {


### PR DESCRIPTION
## Summary

Overhauls the Cost Intelligence page (`/ui/costs`) and per-session cost cards with CodexBar-inspired visual elements, making cost/savings data visually scannable via colored progress bars, ratio visualizations, and clear visual hierarchy.

## Changes

### Savings Hero Stat
- Replaces the plain "Net Savings" stat pill with a prominent centered card showing `$X.XX saved (Y%)` in large green text (or red for net overhead)
- Sub-label shows total spend, overhead, and counterfactual

### Cost Progress Bars
- **Spend Composition**: green bar showing conversation vs Lore overhead proportion
- **Savings Ratio**: blue fill (actual spend) with dashed ghost outline (counterfactual "without Lore") — makes savings visually obvious at a glance
- **Cache Hit Rate**: green bar for aggregated cache hit percentage
- New reusable `renderCostBar()` and `renderMiniBar()` helpers in `ui.ts`

### Daily Cost Trend Chart
- CSS-only bar chart showing cost per day over the last 14 days
- New `computeDailyCosts()` function in `cost-tracker.ts` aggregates historical + live session data by date
- Hover tooltips show exact cost and session count

### Per-Session Table Enhancements
- Cache Hit column now includes inline mini progress bars
- Savings cells have green/red background tinting based on net savings/overhead
- Historical table avoided-compaction cells get green tinting when > 0

### Trend Indicators
- Spend stat pill shows a green up-arrow or red down-arrow comparing live savings rate vs historical average (with 2% dead zone to avoid noise)

## Technical Notes
- Pure server-rendered HTML + CSS — no JS frameworks or external dependencies
- Dark/light mode works via existing `prefers-color-scheme` media queries
- Only 2 files modified: `ui.ts` (CSS + rendering) and `cost-tracker.ts` (daily aggregation)
- All 1687 tests pass, typecheck clean across all 4 packages