### PR TITLE
fix: use promise identity in dedup tests to eliminate cross-test flakiness

### DIFF
--- a/packages/gateway/test/worker-model.test.ts
+++ b/packages/gateway/test/worker-model.test.ts
@@ -126,10 +126,18 @@ describe("fetchModelData", () => {
       );
     }) as unknown as typeof fetch;
 
+    // Defensive reset: another test file's async cleanup may have populated
+    // the cache via our mock between beforeEach and here.
+    clearModelDataCache();
+    callCount = 0;
+
     const first = await fetchModelData();
+    const countAfterFirst = callCount;
     const second = await fetchModelData();
 
-    expect(callCount).toBe(1);
+    // Delta-based: immune to cross-test pollution inflating callCount.
+    expect(countAfterFirst).toBe(1);
+    expect(callCount - countAfterFirst).toBe(0); // no re-fetch — cached
     expect(first).toBe(second); // Same reference — cached
   });
 
@@ -160,12 +168,21 @@ describe("fetchModelData", () => {
       );
     }) as unknown as typeof fetch;
 
-    const [a, b, c] = await Promise.all([
-      fetchModelData(),
-      fetchModelData(),
-      fetchModelData(),
-    ]);
+    // Defensive reset: another test file's async cleanup may have populated
+    // the cache via our mock between beforeEach and here.
+    clearModelDataCache();
+    callCount = 0;
 
+    // All three calls execute synchronously — dedup returns the same promise.
+    const pa = fetchModelData();
+    const pb = fetchModelData();
+    const pc = fetchModelData();
+
+    expect(pa).toBe(pb);
+    expect(pb).toBe(pc);
+
+    const [a, b, c] = await Promise.all([pa, pb, pc]);
+    // Delta-based: only count fetches since our reset, immune to cross-test pollution.
     expect(callCount).toBe(1);
     expect(a).toBe(b);
     expect(b).toBe(c);
@@ -178,8 +195,19 @@ describe("fetchModelData", () => {
       return Promise.reject(new Error("Network error"));
     }) as unknown as typeof fetch;
 
-    const [a, b] = await Promise.all([fetchModelData(), fetchModelData()]);
+    // Defensive reset: another test file's async cleanup may have populated
+    // the cache via our mock between beforeEach and here.
+    clearModelDataCache();
+    callCount = 0;
 
+    // Dedup holds even when fetch rejects (caught internally → empty Map).
+    const pa = fetchModelData();
+    const pb = fetchModelData();
+
+    expect(pa).toBe(pb);
+
+    const [a, b] = await Promise.all([pa, pb]);
+    // Delta-based: only count fetches since our reset, immune to cross-test pollution.
     expect(callCount).toBe(1);
     expect(a).toBe(b);
     expect(a.size).toBe(0);


### PR DESCRIPTION
## Summary

Fixes flaky `fetchModelData` tests that intermittently fail in CI due to cross-test pollution.

Closes #416

## Problem

Three tests in `packages/gateway/test/worker-model.test.ts` used absolute `callCount` assertions on a `globalThis.fetch` mock — a process-wide global shared across all test files in the same Bun worker process. Other test files' `resetPipelineState()` calls (from `api.test.ts` and `harness.ts`) could clear the model cache and trigger subsequent `fetch()` calls against this mock, inflating the count.

The CI failure on main confirmed this: `Expected: 1, Received: 2` at line 183.

## Fix

Hardens all three vulnerable tests with a consistent pattern:

1. **Defensive `clearModelDataCache()` + counter reset** before assertions — guards against cache population between `beforeEach` and the test body
2. **Promise identity checks** (`expect(pa).toBe(pb)`) for dedup tests — verifies the dedup gate returns the same `inflightFetch` promise object
3. **Delta-based `callCount`** — counts fetches relative to a reset point rather than absolutely, immune to cross-test pollution

## Changes

- `caches results and returns cache on subsequent calls`: defensive reset + delta-based callCount
- `deduplicates concurrent in-flight requests`: promise identity + defensive reset + delta callCount
- `deduplicates concurrent calls even on network error`: same approach