### PR TITLE
fix: create dev shims in gateway build so workspace consumers resolve bun exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "scripts": {
     "typecheck": "bun --filter '*' typecheck",
     "test": "bun test",
-    "build": "bun --filter '*' build"
+    "build": "bun --filter '*' build",
+    "postinstall": "bun --filter '@loreai/gateway' build"
   },
   "devDependencies": {
     "@types/bun": "^1.2.0",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -23,8 +23,7 @@
     "build": "bun run script/build.ts",
     "bundle": "bun run script/bundle.ts",
     "build:binary": "bun run script/build.ts --binary",
-    "start": "bun run src/index.ts",
-    "prepare": "node -e \"var f=require('fs'),p='dist/index.bun.js';if(!f.existsSync(p)){f.mkdirSync('dist',{recursive:true});f.writeFileSync(p,'export * from \\\"../src/index.ts\\\";\\n')}\""
+    "start": "bun run src/index.ts"
   },
   "dependencies": {
     "p-limit": "7"

--- a/packages/gateway/script/build.ts
+++ b/packages/gateway/script/build.ts
@@ -89,10 +89,32 @@ const { values: flags } = parseArgs({
 // ---------------------------------------------------------------------------
 
 async function buildLibrary() {
-  // No-op: the npm package is built by `bun run bundle` (script/bundle.ts)
-  // which produces the self-contained CJS bundle (dist/index.cjs + dist/bin.cjs).
-  // This function exists only so `bun run build` (workspace-wide) doesn't fail.
-  console.log("⏭ @loreai/gateway: use `bun run bundle` for npm build");
+  // Create lightweight dev shims so workspace consumers can resolve
+  // the "bun" export condition without running the full `bun run bundle`.
+  // Real bundle builds (bundle.ts) wipe dist/ first, so these shims
+  // never interfere with production artifacts.
+  mkdirSync(distDir, { recursive: true });
+
+  const shims: Array<[string, string]> = [
+    ["index.bun.js", 'export * from "../src/index.ts";\n'],
+    ["embedding-worker.js", 'export * from "../../core/src/embedding-worker.ts";\n'],
+  ];
+
+  for (const [filename, content] of shims) {
+    const filePath = join(distDir, filename);
+    if (existsSync(filePath)) {
+      // Don't overwrite real bundle output (minified, large files).
+      const existing = readFileSync(filePath, "utf8");
+      if (!existing.startsWith("export *")) {
+        console.log(`  ${filename}: skipped (real bundle exists)`);
+        continue;
+      }
+    }
+    writeFileSync(filePath, content);
+    console.log(`  ${filename}: dev shim created`);
+  }
+
+  console.log("✓ @loreai/gateway: dev shims ready (use `bun run bundle` for npm build)");
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/test/bundle-exports.test.ts
+++ b/packages/gateway/test/bundle-exports.test.ts
@@ -18,7 +18,9 @@ import { fileURLToPath } from "node:url";
 const packageDir = join(fileURLToPath(import.meta.url), "..", "..");
 const distDir = join(packageDir, "dist");
 const pkgJson = JSON.parse(readFileSync(join(packageDir, "package.json"), "utf8"));
-const hasBundle = existsSync(join(distDir, "index.cjs")) && existsSync(join(distDir, "index.bun.js"));
+const hasBunBundle = existsSync(join(distDir, "index.bun.js")) &&
+  !readFileSync(join(distDir, "index.bun.js"), "utf8").startsWith("export *");
+const hasBundle = existsSync(join(distDir, "index.cjs")) && hasBunBundle;
 
 describe.skipIf(!hasBundle)("bundle exports", () => {
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the lore startup failure in OpenCode caused by PR #415 — `Cannot find module '@loreai/gateway'`.

PR #415 changed the gateway's `"bun"` export condition from `./src/index.ts` (always present) to `./dist/index.bun.js` (requires `bun run bundle`). A `prepare` script was added to create a dev shim, but Bun does not execute lifecycle scripts for workspace packages, so the file was never created.

## Changes

- **`packages/gateway/script/build.ts`**: Replace the no-op `buildLibrary()` with a function that creates lightweight dev shims (`export * from "../src/index.ts"`) for `dist/index.bun.js` and `dist/embedding-worker.js`. Skips overwriting real bundle output by content-checking existing files.
- **`packages/gateway/package.json`**: Remove the broken `prepare` script (never ran for workspace packages).
- **`package.json` (root)**: Add `postinstall` script that runs `bun --filter '@loreai/gateway' build` so `bun install` alone creates the dev shims.
- **`packages/gateway/test/bundle-exports.test.ts`**: Update skip condition to detect dev shims vs real bundles so content-checking tests correctly skip in dev.

## How it works

- `bun run build` (workspace-wide) now creates dev shims for gateway's `"bun"` exports
- `bun run bundle` (production) still wipes `dist/` first and creates real artifacts — shims never interfere
- Root `postinstall` ensures fresh clones + `bun install` have working exports immediately
- `.gitignore` already excludes `dist/`, so shims aren't committed