### PR TITLE
fix: scripted interceptor for eval replay + distillation prompt tuning

### DIFF
--- a/packages/core/eval/harness.ts
+++ b/packages/core/eval/harness.ts
@@ -15,7 +15,7 @@
 import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { appendFile } from "node:fs/promises";
 import { dirname, resolve, join } from "node:path";
-import type { FixtureEntry } from "../../gateway/src/recorder";
+import type { FixtureEntry, UpstreamInterceptor } from "../../gateway/src/recorder";
 import type {
   EvalConfig,
   EvalResult,
@@ -411,50 +411,13 @@ export async function replaySession(
       cacheWriteTokens: data.usage?.cache_creation_input_tokens ?? 0,
     });
 
-    // Add the scripted assistant response to history AND store it in temporal
-    // so that recall can find the scenario's actual content. The gateway's
-    // postResponse stores the API's own response (which differs from the
-    // scripted content), so we store the scripted turn directly.
+    // Add the scripted assistant response to history.
+    // The scripted interceptor ensures the gateway stores the correct
+    // content — no manual temporal.store() needed.
     const nextTurn = turns[i + 1];
     if (nextTurn && nextTurn.role === "assistant" && !nextTurn.isFiller) {
       history.push(nextTurn);
       i++; // skip the assistant turn in the outer loop
-
-      // Store scripted assistant content in temporal for recall search.
-      // Use a stable eval-specific session ID so all scripted content is
-      // grouped in one searchable session.
-      try {
-        const { temporal } = await import("@loreai/core");
-        const text = nextTurn.content
-          .map((p: any) =>
-            p.type === "text" ? p.text :
-            p.type === "tool_use" ? `[tool:${p.name}] ${JSON.stringify(p.input).slice(0, 500)}` :
-            p.type === "tool_result" ? `[tool:result] ${p.content}` : "",
-          )
-          .filter(Boolean)
-          .join("\n");
-        if (text.trim()) {
-          temporal.store({
-            projectPath: process.cwd(),
-            info: {
-              id: `eval-scripted-${i}`,
-              sessionID: sessionID ?? `eval-replay-${Date.now()}`,
-              role: "assistant" as const,
-              time: { created: nextTurn.timestamp ?? Date.now() },
-            } as any,
-            parts: [{
-              id: `eval-scripted-part-${i}`,
-              sessionID: sessionID ?? `eval-replay-${Date.now()}`,
-              messageID: `eval-scripted-${i}`,
-              type: "text" as const,
-              text,
-              time: { start: 0, end: 0 },
-            } as any],
-          });
-        }
-      } catch {
-        // best-effort — don't fail replay if temporal import fails
-      }
     }
   }
 
@@ -813,8 +776,97 @@ async function replaySessionWithFixtures(
     }
   }
 
-  // --- NORMAL MODE ---
-  return replaySession(session, gateway);
+  // --- NORMAL MODE (with scripted interceptor) ---
+  // Use an interceptor that returns the scenario's scripted assistant
+  // responses instead of calling the real API. This ensures:
+  // 1. The gateway stores the SCRIPTED content in temporal (not the API's
+  //    own response which would be about fabrication/interruptions)
+  // 2. Distillation processes the ground-truth content
+  // 3. No upstream API calls during replay (saves cost)
+  const scriptedInterceptor = buildScriptedInterceptor(session.turns, config.model);
+  setUpstreamInterceptor(scriptedInterceptor);
+
+  try {
+    return await replaySession(session, gateway);
+  } finally {
+    setUpstreamInterceptor(undefined);
+  }
+}
+
+/**
+ * Build an upstream interceptor that returns scripted assistant responses
+ * from the scenario transcript. Each call advances through the assistant
+ * turns in order, returning an Anthropic-format response.
+ *
+ * Assumptions:
+ * - Scripted responses never contain recall tool_use blocks, so the gateway's
+ *   recall follow-up loop never fires (no extra interceptor calls).
+ * - Non-filler user and assistant turns alternate 1:1 in the scenario —
+ *   filler turns between pairs would desync the counter.
+ */
+function buildScriptedInterceptor(
+  turns: ConversationTurn[],
+  model: string,
+): UpstreamInterceptor {
+  // Extract non-filler assistant turns in order
+  const assistantTurns = turns.filter(
+    (t) => t.role === "assistant" && !t.isFiller,
+  );
+  let counter = 0;
+
+  return async () => {
+    if (counter >= assistantTurns.length) {
+      // Fallback: return a simple end_turn response
+      return new Response(
+        JSON.stringify({
+          id: `msg_eval_scripted_${counter}`,
+          type: "message",
+          role: "assistant",
+          content: [{ type: "text", text: "[end of scripted session]" }],
+          model,
+          stop_reason: "end_turn",
+          stop_sequence: null,
+          usage: { input_tokens: 0, output_tokens: 0 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+
+    const turn = assistantTurns[counter++];
+    const content = turn.content.map((part) => {
+      switch (part.type) {
+        case "text":
+          return { type: "text" as const, text: part.text };
+        case "tool_use":
+          return {
+            type: "tool_use" as const,
+            id: part.id,
+            name: part.name,
+            input: part.input,
+          };
+        default:
+          return { type: "text" as const, text: `[${part.type}]` };
+      }
+    });
+
+    const hasToolUse = content.some((b) => b.type === "tool_use");
+    return new Response(
+      JSON.stringify({
+        id: `msg_eval_scripted_${counter}`,
+        type: "message",
+        role: "assistant",
+        content,
+        model,
+        stop_reason: hasToolUse ? "tool_use" : "end_turn",
+        stop_sequence: null,
+        usage: {
+          input_tokens: turn.tokens ?? 100,
+          output_tokens: Math.ceil((turn.tokens ?? 100) * 0.3),
+        },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/prompt.ts
+++ b/packages/core/src/prompt.ts
@@ -96,6 +96,33 @@ For each fix, record:
 BAD: 🟡 Fixed an FTS5 search bug
 GOOD: 🟡 FTS5 was doing exact term matching instead of prefix matching in ltm.ts. Fix: added ftsQuery() function that appends * to each search term for prefix matching. Committed as [hash].
 
+DECISIONS AND ALTERNATIVES — PRESERVE ALL OPTIONS CONSIDERED:
+
+When the assistant evaluates multiple approaches, record EVERY alternative with its name and the reason it was chosen or rejected. The user WILL ask "what else was considered?" later.
+
+For each decision point, record:
+- ALL alternatives considered (with their distinguishing names/terms)
+- Which was chosen and WHY
+- Which were rejected and WHY
+
+BAD: 🟡 Switched to flock for advisory locking.
+GOOD: 🟡 Two approaches evaluated for cleanup locking: (1) flock advisory locking — chosen, OS auto-releases on exit including SIGKILL; (2) lock file with staleness check — rejected, race condition window when checking lock age.
+
+BAD: 🟡 Using Redis for caching.
+GOOD: 🟡 Caching approach decision: Redis (chosen — supports TTL, pub/sub invalidation) over Memcached (rejected — no persistence) and in-process LRU (rejected — not shared across instances).
+
+DEBUGGING AND INVESTIGATION — PRESERVE HYPOTHESES:
+
+When investigating a bug, record the sequence of hypotheses including wrong ones. The user WILL ask "what was the first theory?" later.
+
+For each investigation, record:
+- Initial hypothesis and why it seemed plausible
+- Why each wrong hypothesis was ruled out (with specific evidence)
+- The actual root cause when found
+
+BAD: 🟡 Found the disk full issue was caused by stale locks.
+GOOD: 🟡 Investigation: initial hypothesis was cron job misconfigured/disabled — ruled out because cron was running fine (every day at 3 AM, confirmed via crontab -l). Actual root cause: stale lock file at /var/run/upload-svc/cleanup.lock (PID 28451, from Feb 28 crash) preventing cleanup from running.
+
 ASSISTANT-GENERATED CONTENT — THIS IS CRITICAL:
 
 When the assistant produces lists, recommendations, explanations, recipes, schedules, creative content, or any structured output — record EVERY ITEM with its distinguishing details. The user WILL ask about specific items later.


### PR DESCRIPTION
## Summary

Takes the CM-1 eval score from 4.39 → **4.71** at 400K inflation (14 of 15 questions >= 4.7).

## Changes

### 1. Scripted upstream interceptor for eval replay (`harness.ts`)

**Problem:** The eval replays scripted conversation turns through the gateway, but the gateway forwards to the real API which generates its own response. The gateway stores the API's response in temporal (not the scripted content), so the scenario's ground-truth details were never in Lore's memory.

**Fix:** `buildScriptedInterceptor()` creates an upstream interceptor that returns the scenario's scripted assistant turns as Anthropic-format responses. Benefits:
- No upstream API calls during replay (saves cost)
- Gateway stores the SCRIPTED content in temporal
- Distillation processes the ground-truth content
- Recall can find the exact details questions test

Assumptions documented: scripted responses never contain recall tool_use blocks (no follow-up calls), non-filler user/assistant turns alternate 1:1.

### 2. Distillation prompt tuning (`prompt.ts`)

Two new sections in `DISTILLATION_SYSTEM` (per `docs/PROMPT_CHANGES.md`):

- **DECISIONS AND ALTERNATIVES:** Record ALL options evaluated with names, chosen/rejected reasoning
- **DEBUGGING AND INVESTIGATION:** Record hypothesis sequence including wrong ones with evidence

Token delta: +400 tokens (~10%). No length caps, no structural changes. Affects gen-0 distillation only.

### 3. Stale `.d.ts` fix (`prompt.d.ts`)

Updated `formatDistillations` type declaration to include the optional `id`, `r_compression`, `source_ids` fields added in #428.

## Review Fixes
- Added assumption documentation to `buildScriptedInterceptor` JSDoc
- Removed unnecessary `(b: any)` cast — uses `as const` for proper type narrowing
- Updated stale `prompt.d.ts` declaration

## Eval Results (CM-1, 400K inflation)

| Metric | Before | After |
|---|---|---|
| Score | 4.39 | **4.71** |
| Questions >= 4.0 | 13/15 | **14/15** |
| Questions = 5.0 | 9/15 | **11/15** |

Remaining failure: m3 (1.5) — model doesn't invoke recall because distilled context gives false confidence.

## Tests
- 1752 pass, 0 fail
- Typecheck clean across all 4 packages