### PR TITLE
docs: hero stat 13/20 → 2.6x total recall

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -933,8 +933,8 @@
         <div class="stat-l">vs Compaction at 2.3M Tokens</div>
       </div>
       <div class="stat-cell">
-        <div class="stat-n">13/20</div>
-        <div class="stat-l">Perfect Recall at 2.3M Tokens</div>
+        <div class="stat-n">2.6x</div>
+        <div class="stat-l">Total Recall vs Compaction</div>
       </div>
       <div class="stat-cell">
         <div class="stat-n">2.3M+</div>


### PR DESCRIPTION
Quick follow-up to #442 — replaces the "13/20 Perfect Recall" hero stat with the punchier "2.6x Total Recall vs Compaction" (13 perfect scores vs compaction's 5 = 2.6x).