### PR TITLE
fix: 1h TTL cache write pricing and dynamic savings/overhead wording

### DIFF
--- a/packages/gateway/src/cost-tracker.ts
+++ b/packages/gateway/src/cost-tracker.ts
@@ -236,21 +236,27 @@ export function getPricingSync(model: string): Pricing {
  *
  * This is the single source of truth for cost computation — used by both
  * the accumulator (sync, hot path) and Sentry metrics emission.
+ *
+ * @param ttl - Cache TTL for this call. Anthropic charges 2× cache_write
+ *   for 1h TTL; without this parameter the cost uses the base (5m) rate.
  */
 export function computeCallCost(
   model: string,
   usage: Usage,
   callType: "conversation" | "direct" | "batch",
+  ttl?: "5m" | "1h",
 ): CallCost {
   const pricing = getPricingSync(model);
   const batchMultiplier = callType === "batch" ? 0.5 : 1.0;
+  // Anthropic doubles cache_write pricing for 1h TTL
+  const cacheWriteRate = ttl === "1h" ? pricing.cache_write * 2 : pricing.cache_write;
 
   const inputCost =
     ((usage.input_tokens ?? 0) / 1_000_000) * pricing.input * batchMultiplier;
   const cacheReadCost =
     ((usage.cache_read_input_tokens ?? 0) / 1_000_000) * pricing.cache_read;
   const cacheWriteCost =
-    ((usage.cache_creation_input_tokens ?? 0) / 1_000_000) * pricing.cache_write;
+    ((usage.cache_creation_input_tokens ?? 0) / 1_000_000) * cacheWriteRate;
   const outputCost =
     ((usage.output_tokens ?? 0) / 1_000_000) * pricing.output * batchMultiplier;
 
@@ -269,14 +275,18 @@ export function computeCallCost(
 
 /**
  * Record a conversation turn's cost (called from postResponse).
+ *
+ * @param ttl - Cache TTL for this session. Anthropic charges 2× cache_write
+ *   for 1h TTL; without this the cost uses the base (5m) rate.
  */
 export function recordConversationCost(
   sessionID: string,
   model: string,
   usage: Usage,
+  ttl?: "5m" | "1h",
 ): void {
   const costs = getOrCreate(sessionID);
-  const call = computeCallCost(model, usage, "conversation");
+  const call = computeCallCost(model, usage, "conversation", ttl);
   costs.conversation.cost += call.total;
   costs.conversation.inputTokens += usage.input_tokens ?? 0;
   costs.conversation.outputTokens += usage.output_tokens ?? 0;
@@ -364,6 +374,7 @@ const POST_COMPACTION_CONTEXT = 30_000;
 function estimateCompactionCost(
   workerModel: string,
   conversationModel?: string,
+  ttl?: "5m" | "1h",
 ): number {
   const wPricing = getPricingSync(workerModel);
   // Force-distill: ~10K input, ~2K output
@@ -376,12 +387,14 @@ function estimateCompactionCost(
   // Cache bust: post-compaction context (~POST_COMPACTION_CONTEXT tokens) must
   // be re-written to cache. The penalty is the difference between cache_write
   // and cache_read pricing on the conversation model.
+  // Anthropic charges 2× cache_write for 1h TTL.
   let cacheBustCost = 0;
   if (conversationModel) {
     const cPricing = getPricingSync(conversationModel);
+    const cacheWriteRate = ttl === "1h" ? cPricing.cache_write * 2 : cPricing.cache_write;
     cacheBustCost =
       (POST_COMPACTION_CONTEXT / 1_000_000) *
-      (cPricing.cache_write - cPricing.cache_read);
+      (cacheWriteRate - cPricing.cache_read);
   }
 
   return distillCost + compactCost + cacheBustCost;
@@ -413,6 +426,7 @@ export function updateShadowContext(
   outputTokens: number,
   workerModel: string,
   conversationModel?: string,
+  ttl?: "5m" | "1h",
 ): void {
   const costs = getOrCreate(sessionID);
 
@@ -443,7 +457,7 @@ export function updateShadowContext(
   if (costs._shadowContextTokens > AUTOCOMPACT_THRESHOLD) {
     costs.counterfactual.avoidedCompactions++;
     costs.counterfactual.avoidedCompactionCost +=
-      estimateCompactionCost(workerModel, conversationModel);
+      estimateCompactionCost(workerModel, conversationModel, ttl);
     costs._shadowContextTokens = POST_COMPACTION_CONTEXT;
     log.info(
       `cost-tracker: shadow compaction #${costs.counterfactual.avoidedCompactions} ` +

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -1983,8 +1983,8 @@ function postResponse(
       cache_read_input_tokens: resp.usage.cacheReadInputTokens,
       cache_creation_input_tokens: resp.usage.cacheCreationInputTokens,
     };
-    emitCostMetric(resp.model, usageForSentry, "conversation");
-    recordConversationCost(sessionID, resp.model, usageForSentry);
+    emitCostMetric(resp.model, usageForSentry, "conversation", sessionState.resolvedConversationTTL);
+    recordConversationCost(sessionID, resp.model, usageForSentry, sessionState.resolvedConversationTTL);
     if (genAiSpan) {
       setGenAiUsageAttributes(genAiSpan, usageForSentry, resp.model);
     }
@@ -2230,7 +2230,7 @@ function postResponse(
     // Track how large the context *would* be without Lore's distillation
     // compressing it. When the shadow counter crosses the auto-compact
     // threshold, record a counterfactual compaction event.
-    updateShadowContext(sessionID, actualInput, resp.usage.outputTokens ?? 0, getWorkerModel()?.modelID ?? "unknown", req.model);
+    updateShadowContext(sessionID, actualInput, resp.usage.outputTokens ?? 0, getWorkerModel()?.modelID ?? "unknown", req.model, sessionState.resolvedConversationTTL);
 
     // Mark session dirty for periodic flush (gradient + warming + costs).
     // The 30s idle tick will persist state only for dirty sessions.
@@ -2871,8 +2871,13 @@ async function handleConversationTurn(
   }
 
   // Set cache pricing for tier-based bust-vs-continue decisions in gradient.ts.
+  // Anthropic charges 2× cache_write for 1h TTL — adjust so shouldCompress()
+  // uses the actual write cost when deciding whether to bust the cache.
   if (modelSpec.cacheWriteCost && modelSpec.cacheReadCost) {
-    setCachePricing(modelSpec.cacheWriteCost, modelSpec.cacheReadCost);
+    const effectiveCacheWriteCost = sessionState.resolvedConversationTTL === "1h"
+      ? modelSpec.cacheWriteCost * 2
+      : modelSpec.cacheWriteCost;
+    setCachePricing(effectiveCacheWriteCost, modelSpec.cacheReadCost);
   }
 
   // --- 4c. Dynamic max_tokens sizing for non-Claude-Code clients ---

--- a/packages/gateway/src/sentry.ts
+++ b/packages/gateway/src/sentry.ts
@@ -339,6 +339,7 @@ export function emitCostMetric(
   model: string,
   usage: AnthropicUsage,
   callType: "conversation" | "direct" | "batch",
+  ttl?: "5m" | "1h",
 ): void {
   if (!Sentry.isInitialized()) return;
 
@@ -349,13 +350,15 @@ export function emitCostMetric(
     // Batch discount applies to base input/output only — cache ops have their
     // own pricing tiers and are not discounted by the batch API.
     const batchMultiplier = callType === "batch" ? 0.5 : 1.0;
+    // Anthropic charges 2× cache_write for 1h TTL
+    const cacheWriteRate = ttl === "1h" ? pricing.cache_write * 2 : pricing.cache_write;
 
     const uncachedInputCost =
       ((usage.input_tokens ?? 0) / 1_000_000) * pricing.input * batchMultiplier;
     const cacheReadCost =
       ((usage.cache_read_input_tokens ?? 0) / 1_000_000) * pricing.cache_read;
     const cacheWriteCost =
-      ((usage.cache_creation_input_tokens ?? 0) / 1_000_000) * pricing.cache_write;
+      ((usage.cache_creation_input_tokens ?? 0) / 1_000_000) * cacheWriteRate;
     const outputCost =
       ((usage.output_tokens ?? 0) / 1_000_000) * pricing.output * batchMultiplier;
 

--- a/packages/gateway/src/ui.ts
+++ b/packages/gateway/src/ui.ts
@@ -1283,7 +1283,7 @@ function renderLiveSessionsTable(rows: LiveSessionRow[], emptyMessage?: string, 
       <th data-sort="text">Session</th>
       <th data-sort="num">Turns</th>
       <th data-sort="num">Total</th>
-      <th data-sort="num">Savings</th>
+      <th data-sort="num">Net</th>
       <th data-sort="num">Cache&nbsp;Hit</th>
       <th data-sort="num">P(returns)</th>
       <th data-sort="text">Status</th>
@@ -1330,7 +1330,11 @@ function pageDashboard(): string {
     <div class="stat"><div class="label">Projects</div><div class="value">${stats.project_count}</div></div>
     <div class="stat"><div class="label">Knowledge</div><div class="value">${stats.knowledge_count}</div></div>
     <div class="stat"><div class="label">Sessions</div><div class="value">${allCosts.size}<span class="total">/${stats.session_count}</span></div></div>
-    ${netSavings > 0 ? `<div class="stat"><div class="label">Net Savings</div><div class="value" style="color:#10b981">${formatUSD(liveSavings)}<span class="total">/${formatUSD(netSavings)}</span></div></div>` : ""}
+    ${netSavings > 0
+      ? `<div class="stat"><div class="label">Net Savings</div><div class="value" style="color:#10b981">${formatUSD(liveSavings)}<span class="total">/${formatUSD(netSavings)}</span></div></div>`
+      : netSavings < 0
+        ? `<div class="stat"><div class="label">Net Overhead</div><div class="value" style="color:#e06c75">${formatUSD(Math.abs(liveSavings))}<span class="total">/${formatUSD(Math.abs(netSavings))}</span></div></div>`
+        : ""}
   </div>`;
 
   if (!projects.length) {
@@ -2177,7 +2181,9 @@ function pageCosts(): string {
           ? `Saved: ${formatUSD(liveTotalSavings)}`
           : `Overhead: ${formatUSD(-liveTotalSavings)}`,
         detailRightHtml: liveTotalWithout > 0
-          ? `${(100 - actualPct).toFixed(0)}% saved`
+          ? liveTotalSavings >= 0
+            ? `${(100 - actualPct).toFixed(0)}% saved`
+            : `${(actualPct - 100).toFixed(0)}% overhead`
           : "",
       });
     }
@@ -2205,8 +2211,10 @@ function pageCosts(): string {
       if (liveBatchSavings > 0) savingsItems.push(`Batch API: ${formatUSD(liveBatchSavings)}`);
       if (liveAvoidedCompactionCost > 0) savingsItems.push(`Avoided compactions: ${formatUSD(liveAvoidedCompactionCost)} (&times;${liveAvoidedCompactions})`);
       if (savingsItems.length) {
+        const netLabel = liveTotalSavings >= 0 ? "Net savings" : "Net overhead";
+        const netValue = liveTotalSavings >= 0 ? formatUSD(liveTotalSavings) : formatUSD(Math.abs(liveTotalSavings));
         body += `<div style="margin-top:10px;font-size:0.85em;color:var(--fg2)">
-          <strong style="color:${liveTotalSavings >= 0 ? "#10b981" : "#e06c75"}">Net savings: ${formatUSD(liveTotalSavings)}</strong>
+          <strong style="color:${liveTotalSavings >= 0 ? "#10b981" : "#e06c75"}">${netLabel}: ${netValue}</strong>
           &mdash; ${savingsItems.join(" &middot; ")}
         </div>`;
       }
@@ -2258,7 +2266,7 @@ function pageCosts(): string {
         ${hist.warmupSavings > 0 ? `<tr><td>Cache warming</td><td>${formatUSD(hist.warmupSavings)} <span style="color:var(--fg3);font-size:0.85em">(${hist.warmupHits} hits)</span></td></tr>` : ""}
         ${hist.ttlSavings > 0 ? `<tr><td>1h TTL extension</td><td>${formatUSD(hist.ttlSavings)} <span style="color:var(--fg3);font-size:0.85em">(${hist.ttlHits} hits)</span></td></tr>` : ""}
         ${hist.batchSavings > 0 ? `<tr><td>Batch API discount</td><td>${formatUSD(hist.batchSavings)}</td></tr>` : ""}
-        <tr style="border-top:1px solid var(--border)"><td><strong>Net estimated savings</strong></td><td><strong style="color:${histNetSavings >= 0 ? "#10b981" : "#e06c75"}">${formatUSD(histNetSavings)}</strong></td></tr>
+        <tr style="border-top:1px solid var(--border)"><td><strong>${histNetSavings >= 0 ? "Net estimated savings" : "Net estimated overhead"}</strong></td><td><strong style="color:${histNetSavings >= 0 ? "#10b981" : "#e06c75"}">${histNetSavings >= 0 ? formatUSD(histNetSavings) : formatUSD(Math.abs(histNetSavings))}</strong></td></tr>
       </table>
     </div>`;
 


### PR DESCRIPTION
## Problem

Anthropic charges **2x base input price** for 1h TTL cache writes ($10/MTok for Opus vs $6.25 for 5m TTL). Three code paths in the cost tracker used the 5m rate regardless of TTL, causing:

1. **`computeCallCost()`** — conversation turn costs underreported by ~6% for 1h sessions
2. **`estimateCompactionCost()`** — avoided compaction savings undercounted (e.g. $10.29 → $13.44 for 28 compactions)
3. **`setCachePricing()`** — gradient's bust-vs-continue gate used wrong write cost

Additionally, several UI locations displayed "savings" language even when the net value was negative, which was confusing.

## Fix

### 1h TTL Pricing (`cost-tracker.ts`, `pipeline.ts`, `sentry.ts`)

- Added `ttl?: "5m" | "1h"` param to `computeCallCost()`, `recordConversationCost()`, `updateShadowContext()`, `estimateCompactionCost()`, and `emitCostMetric()`
- When `ttl === "1h"`, applies 2x multiplier to `cache_write` rate
- Pipeline call sites pass `sessionState.resolvedConversationTTL`
- `setCachePricing()` now uses the 1h-adjusted rate for bust-vs-continue decisions

### Dynamic Wording (`ui.ts`)

5 locations now switch between "savings" and "overhead" based on sign:

| Location | Before (negative) | After (negative) |
|---|---|---|
| Table column header | `Savings` | `Net` (neutral) |
| Dashboard stat card | *(hidden)* | `Net Overhead` (red) |
| Live bar right side | `N% saved` | `N% overhead` |
| Live breakdown | `Net savings: -$X` | `Net overhead: $X` |
| Historical row | `Net estimated savings` | `Net estimated overhead` |
