### PR TITLE
ci: disable eval workflow on PRs

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -1,13 +1,6 @@
 name: Lore Eval Suite
 
 on:
-  # Fixture mode on PRs that touch core/gateway code or eval suite
-  pull_request:
-    paths:
-      - 'packages/core/src/**'
-      - 'packages/gateway/src/**'
-      - 'packages/core/eval/**'
-
   # Live mode on weekly schedule
   schedule:
     - cron: '0 6 * * 1' # Monday 6am UTC
@@ -31,9 +24,7 @@ on:
 
 jobs:
   eval-fixture:
-    if: >
-      github.event_name == 'pull_request' ||
-      (github.event_name == 'workflow_dispatch' && inputs.mode == 'fixture')
+    if: github.event_name == 'workflow_dispatch' && inputs.mode == 'fixture'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
The eval workflow was running on PRs that touch core/gateway/eval files, causing 401 auth errors when API credits are exhausted. Evals should only run on manual dispatch or weekly schedule — not on every PR.

- Removed `pull_request` trigger from `eval.yml`
- Updated `eval-fixture` job condition accordingly