### PR TITLE
ci(publish): finalize Sentry release after publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,6 +39,7 @@ jobs:
           ref: release/${{ steps.inputs.outputs.version }}
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Set git user
         run: |
@@ -65,6 +66,24 @@ jobs:
         run: craft publish "${{ steps.inputs.outputs.version }}" --no-input
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      # Finalize the Sentry release: associate commits and mark as deployed.
+      # Sourcemaps are already uploaded during the CI build step — this step
+      # only needs to set commits, finalize, and create a deploy marker.
+      # continue-on-error: this is post-publish telemetry — a Sentry API
+      # outage must not block issue closure or trigger false failure comments.
+      - name: Finalize Sentry release
+        if: success()
+        continue-on-error: true
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: byk
+          SENTRY_PROJECT: loreai-gateway
+          VERSION: ${{ steps.inputs.outputs.version }}
+        run: |
+          npx --yes @sentry/cli releases set-commits "$VERSION" --auto
+          npx --yes @sentry/cli releases finalize "$VERSION"
+          npx --yes @sentry/cli releases deploys "$VERSION" new -e production
 
       - name: Close issue on success
         if: success()


### PR DESCRIPTION
## Summary

Add Sentry release finalization to the publish workflow. Currently, sourcemaps are uploaded during CI builds but the release is never finalized — meaning Sentry doesn't track commits, deploys, or release health for published versions.

## Changes

**`.github/workflows/publish.yml`**

1. **New step: "Finalize Sentry release"** (after `craft publish`, before issue close):
   - `sentry-cli releases set-commits --auto` — associates commits since the previous release tag
   - `sentry-cli releases finalize` — marks the release as live with a `dateReleased` timestamp
   - `sentry-cli releases deploys new -e production` — creates a deploy marker for release health

2. **Added `fetch-tags: true`** to the checkout step so `set-commits --auto` can find the previous release tag boundary.

3. **Uses `continue-on-error: true`** since this is post-publish telemetry — a Sentry API outage must not block the issue from being closed or trigger false "publish failed" comments.

## What this does NOT change

- CI (`ci.yml`) — sourcemap upload stays where it is
- `.craft.yml` — no Craft config changes needed
- Build scripts — they continue to handle sourcemap upload with debug IDs