### PR TITLE
feat: workspace discovery for monorepo support

### DIFF
--- a/packages/core/src/agents-file.ts
+++ b/packages/core/src/agents-file.ts
@@ -617,3 +617,47 @@ export function importLoreFile(projectPath: string): void {
     // stat failure is non-fatal — worst case we re-import next time
   }
 }
+
+/**
+ * Import knowledge entries from a `.lore.md` file at `sourcePath`,
+ * attributed to `targetProjectPath`'s project.
+ *
+ * Used for monorepo workspace imports: sub-project knowledge should be
+ * visible in the parent project's session, so entries are created under
+ * the target project's ID rather than the source directory's.
+ *
+ * The source `.lore.md` is read-only — Lore does not write back to it.
+ */
+export function importLoreFileAs(
+  sourcePath: string,
+  targetProjectPath: string,
+): void {
+  if (isHostedMode()) return;
+
+  const fp = join(sourcePath, LORE_FILE);
+  if (!existsSync(fp)) return;
+
+  // Fast path: skip re-import when the source file hasn't changed since
+  // the last import (mtime check, then content hash verification).
+  try {
+    const { mtimeMs } = statSync(fp);
+    const cached = getCache(fp);
+    if (cached && cached.mtimeMs === mtimeMs) return;
+  } catch {
+    // stat failure — proceed with import
+  }
+
+  const fileContent = readFileSync(fp, "utf8");
+  const fileEntries = parseEntriesFromSection(fileContent);
+  if (!fileEntries.length) return;
+
+  _importEntries(fileEntries, targetProjectPath);
+
+  // Update cache so subsequent calls fast-path.
+  try {
+    const { mtimeMs } = statSync(fp);
+    setCache(fp, { mtimeMs, hash: hashSection(fileContent) });
+  } catch {
+    // stat failure is non-fatal
+  }
+}

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -244,6 +244,11 @@ export const LoreConfig = z.object({
       conversationTTL: "auto",
       warming: { enabled: true },
     }),
+  /** Workspace sub-project paths or globs, relative to the `.lore.json` directory.
+   *  At startup, Lore imports `.lore.md` from each resolved sub-project into the
+   *  root project's knowledge base. Supports literal paths (`"project-a"`) and
+   *  single-level globs (`"packages/*"`). */
+  workspaces: z.array(z.string()).default([]),
   crossProject: z.boolean().default(false),
   agentsFile: z
     .object({

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -147,8 +147,14 @@ export {
   shouldImportLoreFile,
   loreFileExists,
   clearLoreFileCache,
+  importLoreFileAs,
   LORE_FILE,
 } from "./agents-file";
+export {
+  discoverWorkspaceRoot,
+  resolveWorkspaces,
+  clearWorkspaceCache,
+} from "./workspace";
 export { workerSessionIDs, isWorkerSession } from "./worker";
 export * as workerModel from "./worker-model";
 export {

--- a/packages/core/src/workspace.ts
+++ b/packages/core/src/workspace.ts
@@ -1,0 +1,287 @@
+/**
+ * workspace.ts — Workspace root discovery and sub-project resolution.
+ *
+ * Provides two directions of discovery for monorepo support:
+ *
+ * 1. **Upward** (`discoverWorkspaceRoot`): Walk from a start directory toward
+ *    the filesystem root, checking for project markers at each level. Returns
+ *    the highest meaningful project root — the monorepo/workspace root.
+ *
+ * 2. **Downward** (`resolveWorkspaces`): Given a root directory and an array
+ *    of path patterns (from `.lore.json` `workspaces` field), resolve them to
+ *    concrete sub-project directories.
+ *
+ * Inspired by Sentry CLI's `walk-up.ts` and `project-root.ts` but kept
+ * synchronous and much simpler — runs once at startup, not in the hot path.
+ */
+
+import { existsSync, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+import { homedir } from "node:os";
+import { isHostedMode } from "./hosted";
+
+// ---------------------------------------------------------------------------
+// Marker taxonomy
+// ---------------------------------------------------------------------------
+
+/**
+ * VCS markers — definitive project root indicators.
+ * Finding one of these stops the walk immediately.
+ */
+const VCS_MARKERS = [".git", ".hg", ".svn", ".jj", ".bzr", "_darcs", ".fossil"];
+
+/**
+ * Workspace/monorepo markers — definitive root indicators.
+ * These explicitly declare "I am a monorepo/workspace root".
+ */
+const WORKSPACE_MARKERS = [
+  "pnpm-workspace.yaml",
+  "lerna.json",
+  "nx.json",
+  "rush.json",
+  "turbo.json",
+  "go.work",
+];
+
+/**
+ * Language markers — soft project indicators.
+ * The closest one to startDir wins, but the walk continues past them
+ * looking for a definitive marker higher up.
+ */
+const LANGUAGE_MARKERS = [
+  "package.json",
+  "pyproject.toml",
+  "Cargo.toml",
+  "go.mod",
+  "composer.json",
+  "Gemfile",
+  "mix.exs",
+  "pubspec.yaml",
+  "dune-project",
+];
+
+// ---------------------------------------------------------------------------
+// Upward discovery — discoverWorkspaceRoot()
+// ---------------------------------------------------------------------------
+
+/** Process-lifetime cache for workspace root lookups. */
+const workspaceRootCache = new Map<string, string>();
+
+/**
+ * Check whether a directory contains a `.lore.json` with a non-empty
+ * `workspaces` array. This is the strongest signal for a workspace root —
+ * the user explicitly declared it.
+ */
+function hasLoreWorkspacesConfig(dir: string): boolean {
+  const configPath = join(dir, ".lore.json");
+  if (!existsSync(configPath)) return false;
+  try {
+    const raw = JSON.parse(readFileSync(configPath, "utf8"));
+    return Array.isArray(raw.workspaces) && raw.workspaces.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/** Check whether any of the given marker files/dirs exist in `dir`. */
+function hasAnyMarker(dir: string, markers: readonly string[]): boolean {
+  for (const marker of markers) {
+    if (existsSync(join(dir, marker))) return true;
+  }
+  return false;
+}
+
+/**
+ * Walk up from `startDir` toward the filesystem root, checking for project
+ * markers at each level. Returns the highest meaningful project root.
+ *
+ * Priority (checked at each directory level):
+ *   1. `.lore.json` with `workspaces` field (definitive — strongest signal)
+ *   2. VCS markers: `.git`, `.hg`, `.svn`, `.jj`, etc. (definitive)
+ *   3. Workspace markers: `pnpm-workspace.yaml`, `nx.json`, etc. (definitive)
+ *   4. Language markers: `package.json`, `pyproject.toml`, etc. (closest-wins)
+ *
+ * The walk stops at `os.homedir()` to prevent walking into system directories.
+ * Results are cached for the process lifetime.
+ *
+ * In hosted mode, returns `startDir` unchanged (no filesystem traversal with
+ * client-controlled paths).
+ */
+export function discoverWorkspaceRoot(startDir: string): string {
+  if (isHostedMode()) return startDir;
+
+  const resolved = resolve(startDir);
+  const cached = workspaceRootCache.get(resolved);
+  if (cached !== undefined) return cached;
+
+  const stopBoundary = homedir();
+  const seen = new Set<string>();
+  let closestLanguageMarker: string | null = null;
+  let current = resolved;
+
+  while (true) {
+    // Cycle detection via realpath
+    let real: string;
+    try {
+      real = realpathSync(current);
+    } catch {
+      // Broken symlink or permission denied — stop walking
+      break;
+    }
+    if (seen.has(real)) break;
+    seen.add(real);
+
+    // Stop boundary — check BEFORE marker detection so we never claim
+    // $HOME as a workspace root (many devs have ~/.git for dotfiles).
+    if (current === stopBoundary) break;
+
+    // 1. .lore.json with workspaces — strongest signal
+    if (hasLoreWorkspacesConfig(current)) {
+      workspaceRootCache.set(resolved, current);
+      return current;
+    }
+
+    // 2. VCS markers — definitive root
+    if (hasAnyMarker(current, VCS_MARKERS)) {
+      workspaceRootCache.set(resolved, current);
+      return current;
+    }
+
+    // 3. Workspace markers — definitive root
+    if (hasAnyMarker(current, WORKSPACE_MARKERS)) {
+      workspaceRootCache.set(resolved, current);
+      return current;
+    }
+
+    // 4. Language markers — remember closest, but keep walking
+    if (closestLanguageMarker === null && hasAnyMarker(current, LANGUAGE_MARKERS)) {
+      closestLanguageMarker = current;
+    }
+
+    const parent = dirname(current);
+    if (parent === current) break; // filesystem root
+    current = parent;
+  }
+
+  const result = closestLanguageMarker ?? resolved;
+  workspaceRootCache.set(resolved, result);
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Downward resolution — resolveWorkspaces()
+// ---------------------------------------------------------------------------
+
+/** Process-lifetime cache for workspace resolution. */
+const workspacesCache = new Map<string, string[]>();
+
+/** Check if a string contains glob metacharacters. */
+function isGlob(pattern: string): boolean {
+  return /[*?[\]]/.test(pattern);
+}
+
+/**
+ * Simple single-segment glob matcher for patterns like `packages/*`.
+ * Only supports `*` (match any) and `?` (match one character).
+ * Bracket expressions `[...]` are not supported for simplicity.
+ */
+function matchGlob(name: string, pattern: string): boolean {
+  // Convert glob to regex: * → .*, ? → .
+  const regex = new RegExp(
+    "^" + pattern.replace(/[.+^${}()|\\]/g, "\\$&").replace(/\*/g, ".*").replace(/\?/g, ".") + "$",
+  );
+  return regex.test(name);
+}
+
+/**
+ * Resolve workspace patterns to concrete sub-project directories.
+ *
+ * Patterns can be:
+ *   - Literal relative paths: `"project-a"`, `"tools/cli"`
+ *   - Single-level globs: `"packages/*"`, `"apps/*"`
+ *
+ * For glob patterns containing a `/` (e.g. `packages/*`), the prefix before
+ * the glob segment is treated as a parent directory to scan, and the glob
+ * segment filters its children.
+ *
+ * Returns deduplicated absolute paths of directories that actually exist.
+ * Results are cached for the process lifetime.
+ *
+ * In hosted mode, returns an empty array (no filesystem traversal with
+ * client-controlled paths).
+ */
+export function resolveWorkspaces(
+  rootDir: string,
+  patterns: string[],
+): string[] {
+  if (isHostedMode()) return [];
+  if (patterns.length === 0) return [];
+
+  const resolvedRoot = resolve(rootDir);
+  const rootPrefix = resolvedRoot + "/";
+  const cacheKey = `${resolvedRoot}\0${patterns.join("\0")}`;
+  const cached = workspacesCache.get(cacheKey);
+  if (cached !== undefined) return cached;
+
+  const results = new Set<string>();
+
+  for (const pattern of patterns) {
+    if (!isGlob(pattern)) {
+      // Literal path — resolve and check existence
+      const absPath = resolve(resolvedRoot, pattern);
+      // Guard: resolved path must be under rootDir (prevent "../" escapes)
+      if (!absPath.startsWith(rootPrefix)) continue;
+      try {
+        if (statSync(absPath).isDirectory()) {
+          results.add(absPath);
+        }
+      } catch {
+        // Does not exist or not accessible — skip
+      }
+      continue;
+    }
+
+    // Glob pattern — split into parent dir + glob segment
+    // e.g. "packages/*" → parent="packages", globPart="*"
+    // e.g. "*" → parent=".", globPart="*"
+    const lastSlash = pattern.lastIndexOf("/");
+    const parentRel = lastSlash >= 0 ? pattern.slice(0, lastSlash) : ".";
+    const globPart = lastSlash >= 0 ? pattern.slice(lastSlash + 1) : pattern;
+    const parentAbs = resolve(resolvedRoot, parentRel);
+
+    // Guard: glob parent must be under (or equal to) rootDir
+    if (parentAbs !== resolvedRoot && !parentAbs.startsWith(rootPrefix)) continue;
+
+    try {
+      const entries = readdirSync(parentAbs, { withFileTypes: true });
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        // Skip dot-prefixed directories (.git, .vscode, etc.) — matches
+        // npm/pnpm workspace glob behavior.
+        if (entry.name.startsWith(".")) continue;
+        if (matchGlob(entry.name, globPart)) {
+          results.add(join(parentAbs, entry.name));
+        }
+      }
+    } catch {
+      // Parent dir does not exist or not readable — skip
+    }
+  }
+
+  const result = Array.from(results);
+  workspacesCache.set(cacheKey, result);
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Cache management (for tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Clear all workspace discovery caches.
+ * Intended for test harnesses that need deterministic behavior.
+ */
+export function clearWorkspaceCache(): void {
+  workspaceRootCache.clear();
+  workspacesCache.clear();
+}

--- a/packages/core/test/workspace.test.ts
+++ b/packages/core/test/workspace.test.ts
@@ -1,0 +1,407 @@
+import { describe, test, expect, beforeEach, afterAll } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  discoverWorkspaceRoot,
+  resolveWorkspaces,
+  clearWorkspaceCache,
+} from "../src/workspace";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let tempBase: string;
+
+function makeTempDir(): string {
+  if (!tempBase) {
+    tempBase = mkdtempSync(join(tmpdir(), "lore-workspace-test-"));
+  }
+  const dir = join(tempBase, `test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function touch(dir: string, file: string, content = ""): void {
+  const fp = join(dir, file);
+  mkdirSync(dirname(fp), { recursive: true });
+  writeFileSync(fp, content);
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  clearWorkspaceCache();
+});
+
+afterAll(() => {
+  if (tempBase) {
+    try { rmSync(tempBase, { recursive: true, force: true }); } catch { /* ok */ }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// discoverWorkspaceRoot
+// ---------------------------------------------------------------------------
+
+describe("discoverWorkspaceRoot", () => {
+  test("returns cwd when .git exists at cwd", () => {
+    const root = makeTempDir();
+    mkdirSync(join(root, ".git"));
+    expect(discoverWorkspaceRoot(root)).toBe(root);
+  });
+
+  test("finds .git above cwd", () => {
+    const root = makeTempDir();
+    mkdirSync(join(root, ".git"));
+    const sub = join(root, "packages", "a");
+    mkdirSync(sub, { recursive: true });
+    expect(discoverWorkspaceRoot(sub)).toBe(root);
+  });
+
+  test(".lore.json with workspaces is highest priority", () => {
+    const root = makeTempDir();
+    // .git is at the root — but .lore.json with workspaces is also there
+    mkdirSync(join(root, ".git"));
+    writeFileSync(
+      join(root, ".lore.json"),
+      JSON.stringify({ workspaces: ["project-a"] }),
+    );
+    const sub = join(root, "project-a");
+    mkdirSync(sub, { recursive: true });
+
+    // .lore.json with workspaces should be found first (before .git check)
+    // Both are at the same level, so result is the same directory
+    expect(discoverWorkspaceRoot(sub)).toBe(root);
+  });
+
+  test(".lore.json with workspaces above .git wins", () => {
+    const root = makeTempDir();
+    writeFileSync(
+      join(root, ".lore.json"),
+      JSON.stringify({ workspaces: ["project-a"] }),
+    );
+    const projectA = join(root, "project-a");
+    mkdirSync(projectA, { recursive: true });
+    // project-a has its own .git — but the parent's .lore.json with workspaces wins
+    mkdirSync(join(projectA, ".git"));
+
+    // Starting from project-a: finds .git at project-a first (definitive),
+    // but .lore.json with workspaces is above. Since .git is definitive and
+    // stops the walk, it returns project-a. This is correct — when you're
+    // inside a sub-project with its own .git, that IS your project root.
+    expect(discoverWorkspaceRoot(projectA)).toBe(projectA);
+
+    // Starting from a non-git subdir under root, the .lore.json wins
+    const noGitSub = join(root, "scripts");
+    mkdirSync(noGitSub, { recursive: true });
+    expect(discoverWorkspaceRoot(noGitSub)).toBe(root);
+  });
+
+  test("pnpm-workspace.yaml at parent returns parent", () => {
+    const root = makeTempDir();
+    touch(root, "pnpm-workspace.yaml");
+    const sub = join(root, "packages", "a");
+    mkdirSync(sub, { recursive: true });
+    expect(discoverWorkspaceRoot(sub)).toBe(root);
+  });
+
+  test("workspace markers: nx.json, turbo.json, lerna.json", () => {
+    for (const marker of ["nx.json", "turbo.json", "lerna.json"]) {
+      clearWorkspaceCache();
+      const root = makeTempDir();
+      touch(root, marker);
+      const sub = join(root, "apps", "web");
+      mkdirSync(sub, { recursive: true });
+      expect(discoverWorkspaceRoot(sub)).toBe(root);
+    }
+  });
+
+  test("language marker (package.json) returns closest-wins", () => {
+    const root = makeTempDir();
+    const sub = join(root, "project-a");
+    mkdirSync(sub, { recursive: true });
+    touch(sub, "package.json", "{}");
+    // Root has no markers — language marker at sub is closest
+    expect(discoverWorkspaceRoot(sub)).toBe(sub);
+  });
+
+  test("language marker: walk continues past to find definitive root", () => {
+    const root = makeTempDir();
+    touch(root, "pnpm-workspace.yaml");
+    const sub = join(root, "packages", "a");
+    mkdirSync(sub, { recursive: true });
+    touch(sub, "package.json", "{}");
+    // pnpm-workspace.yaml at root is definitive — wins over package.json at sub
+    expect(discoverWorkspaceRoot(sub)).toBe(root);
+  });
+
+  test("no markers found returns startDir", () => {
+    const dir = makeTempDir();
+    expect(discoverWorkspaceRoot(dir)).toBe(dir);
+  });
+
+  test("cache returns same result on second call", () => {
+    const root = makeTempDir();
+    mkdirSync(join(root, ".git"));
+    const sub = join(root, "src");
+    mkdirSync(sub, { recursive: true });
+
+    const first = discoverWorkspaceRoot(sub);
+    const second = discoverWorkspaceRoot(sub);
+    expect(first).toBe(root);
+    expect(second).toBe(root);
+  });
+
+  test("fake monorepo: sub-projects under root with pnpm-workspace.yaml", () => {
+    // This is the target scenario: monorepo root has pnpm-workspace.yaml
+    // but no .git. Sub-projects are bare directories.
+    const root = makeTempDir();
+    touch(root, "pnpm-workspace.yaml");
+    const projectA = join(root, "project-a");
+    const projectB = join(root, "project-b");
+    mkdirSync(projectA, { recursive: true });
+    mkdirSync(projectB, { recursive: true });
+    touch(projectA, "package.json", "{}");
+    touch(projectB, "package.json", "{}");
+
+    expect(discoverWorkspaceRoot(projectA)).toBe(root);
+    clearWorkspaceCache();
+    expect(discoverWorkspaceRoot(projectB)).toBe(root);
+  });
+
+  test("fake monorepo with .lore.json workspaces config", () => {
+    // The primary target scenario: no .git at root, .lore.json declares workspaces
+    const root = makeTempDir();
+    writeFileSync(
+      join(root, ".lore.json"),
+      JSON.stringify({ workspaces: ["project-a", "project-b"] }),
+    );
+    const projectA = join(root, "project-a");
+    mkdirSync(projectA, { recursive: true });
+    touch(projectA, "package.json", "{}");
+
+    expect(discoverWorkspaceRoot(projectA)).toBe(root);
+  });
+
+  test(".lore.json without workspaces is not a workspace signal", () => {
+    const root = makeTempDir();
+    // .lore.json exists but has no workspaces field
+    writeFileSync(join(root, ".lore.json"), JSON.stringify({ crossProject: true }));
+    const sub = join(root, "project");
+    mkdirSync(sub, { recursive: true });
+    // No definitive marker, no language marker → returns startDir
+    expect(discoverWorkspaceRoot(sub)).toBe(sub);
+  });
+
+  test(".lore.json with empty workspaces array is not a signal", () => {
+    const root = makeTempDir();
+    writeFileSync(
+      join(root, ".lore.json"),
+      JSON.stringify({ workspaces: [] }),
+    );
+    const sub = join(root, "project");
+    mkdirSync(sub, { recursive: true });
+    expect(discoverWorkspaceRoot(sub)).toBe(sub);
+  });
+
+  test("VCS markers: .hg, .jj, .svn", () => {
+    for (const marker of [".hg", ".jj", ".svn"]) {
+      clearWorkspaceCache();
+      const root = makeTempDir();
+      mkdirSync(join(root, marker));
+      const sub = join(root, "src");
+      mkdirSync(sub, { recursive: true });
+      expect(discoverWorkspaceRoot(sub)).toBe(root);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveWorkspaces
+// ---------------------------------------------------------------------------
+
+describe("resolveWorkspaces", () => {
+  test("resolves literal paths to existing directories", () => {
+    const root = makeTempDir();
+    const a = join(root, "project-a");
+    const b = join(root, "project-b");
+    mkdirSync(a);
+    mkdirSync(b);
+
+    const result = resolveWorkspaces(root, ["project-a", "project-b"]);
+    expect(result).toEqual([a, b]);
+  });
+
+  test("filters out non-existent literal paths", () => {
+    const root = makeTempDir();
+    const a = join(root, "project-a");
+    mkdirSync(a);
+
+    const result = resolveWorkspaces(root, ["project-a", "does-not-exist"]);
+    expect(result).toEqual([a]);
+  });
+
+  test("filters out files (only directories)", () => {
+    const root = makeTempDir();
+    touch(root, "not-a-dir");
+
+    const result = resolveWorkspaces(root, ["not-a-dir"]);
+    expect(result).toEqual([]);
+  });
+
+  test("expands glob patterns like packages/*", () => {
+    const root = makeTempDir();
+    const pkgs = join(root, "packages");
+    mkdirSync(pkgs);
+    mkdirSync(join(pkgs, "core"));
+    mkdirSync(join(pkgs, "gateway"));
+    // Also add a file — should be filtered out
+    writeFileSync(join(pkgs, "README.md"), "");
+
+    const result = resolveWorkspaces(root, ["packages/*"]);
+    expect(result.sort()).toEqual(
+      [join(pkgs, "core"), join(pkgs, "gateway")].sort(),
+    );
+  });
+
+  test("glob pattern with non-existent parent returns empty", () => {
+    const root = makeTempDir();
+    const result = resolveWorkspaces(root, ["nonexistent/*"]);
+    expect(result).toEqual([]);
+  });
+
+  test("mixed literal paths and globs", () => {
+    const root = makeTempDir();
+    const infra = join(root, "infra");
+    const pkgs = join(root, "packages");
+    mkdirSync(infra);
+    mkdirSync(pkgs);
+    mkdirSync(join(pkgs, "web"));
+    mkdirSync(join(pkgs, "api"));
+
+    const result = resolveWorkspaces(root, ["infra", "packages/*"]);
+    expect(result.sort()).toEqual(
+      [infra, join(pkgs, "api"), join(pkgs, "web")].sort(),
+    );
+  });
+
+  test("empty patterns returns empty", () => {
+    const root = makeTempDir();
+    expect(resolveWorkspaces(root, [])).toEqual([]);
+  });
+
+  test("deduplicates results", () => {
+    const root = makeTempDir();
+    const a = join(root, "project-a");
+    mkdirSync(a);
+
+    // Same dir matched by two different patterns
+    const result = resolveWorkspaces(root, ["project-a", "project-a"]);
+    expect(result).toEqual([a]);
+  });
+
+  test("glob with ? wildcard", () => {
+    const root = makeTempDir();
+    const pkgs = join(root, "packages");
+    mkdirSync(pkgs);
+    mkdirSync(join(pkgs, "app1"));
+    mkdirSync(join(pkgs, "app2"));
+    mkdirSync(join(pkgs, "lib1"));
+
+    const result = resolveWorkspaces(root, ["packages/app?"]);
+    expect(result.sort()).toEqual(
+      [join(pkgs, "app1"), join(pkgs, "app2")].sort(),
+    );
+  });
+
+  test("cache returns same result on second call", () => {
+    const root = makeTempDir();
+    const a = join(root, "project-a");
+    mkdirSync(a);
+
+    const first = resolveWorkspaces(root, ["project-a"]);
+    const second = resolveWorkspaces(root, ["project-a"]);
+    expect(first).toEqual([a]);
+    expect(second).toEqual([a]);
+    expect(first).toBe(second); // same reference (cached)
+  });
+
+  test("bare glob * at root level", () => {
+    const root = makeTempDir();
+    mkdirSync(join(root, "proj-a"));
+    mkdirSync(join(root, "proj-b"));
+    writeFileSync(join(root, "README.md"), "");
+
+    const result = resolveWorkspaces(root, ["*"]);
+    // Should include both dirs but not the file
+    expect(result.sort()).toEqual(
+      [join(root, "proj-a"), join(root, "proj-b")].sort(),
+    );
+  });
+
+  test("rejects ../ path traversal escapes", () => {
+    const root = makeTempDir();
+    // Create a sibling directory that should NOT be reachable
+    const sibling = join(root, "..", "sibling-" + Date.now());
+    mkdirSync(sibling, { recursive: true });
+
+    try {
+      const result = resolveWorkspaces(root, ["../sibling-" + sibling.split("-").pop()]);
+      expect(result).toEqual([]);
+    } finally {
+      rmSync(sibling, { recursive: true, force: true });
+    }
+  });
+
+  test("glob excludes dot-prefixed directories", () => {
+    const root = makeTempDir();
+    const pkgs = join(root, "packages");
+    mkdirSync(pkgs);
+    mkdirSync(join(pkgs, "core"));
+    mkdirSync(join(pkgs, ".hidden"));
+    mkdirSync(join(pkgs, ".git"));
+
+    const result = resolveWorkspaces(root, ["packages/*"]);
+    expect(result).toEqual([join(pkgs, "core")]);
+  });
+
+  test("glob parent with ../ is rejected", () => {
+    const root = makeTempDir();
+    const result = resolveWorkspaces(root, ["../../*"]);
+    expect(result).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// discoverWorkspaceRoot — homedir boundary
+// ---------------------------------------------------------------------------
+
+describe("discoverWorkspaceRoot — homedir boundary", () => {
+  test("does not claim homedir as workspace root even if it has .git", () => {
+    // We can't modify $HOME, but we CAN test that the walk stops at
+    // homedir by starting from a subdirectory of a temp dir that is
+    // structured to mimic the boundary scenario.
+    //
+    // The actual homedir() stop prevents us from testing this directly
+    // without mocking os.homedir(). Instead, verify that the function
+    // returns startDir when no markers exist below homedir.
+    const sub = makeTempDir();
+    // No markers anywhere in the temp tree — should return startDir
+    expect(discoverWorkspaceRoot(sub)).toBe(sub);
+  });
+
+  test("finds markers below homedir but not at homedir itself", () => {
+    // Create a structure where a marker exists at a parent that is NOT homedir
+    const root = makeTempDir();
+    mkdirSync(join(root, ".git"));
+    const deep = join(root, "a", "b", "c");
+    mkdirSync(deep, { recursive: true });
+
+    // .git at root (which is under /tmp, not $HOME) should be found
+    expect(discoverWorkspaceRoot(deep)).toBe(root);
+  });
+});

--- a/packages/gateway/src/cli/run.ts
+++ b/packages/gateway/src/cli/run.ts
@@ -12,6 +12,7 @@ import { loadConfig } from "../config";
 import { detectAgents, AGENTS, type DetectedAgent } from "./agents";
 import { safeExit } from "./exit";
 import { maybeAutoImport } from "./import-auto";
+import { discoverWorkspaceRoot } from "@loreai/core";
 
 // ---------------------------------------------------------------------------
 // Interactive agent picker (TTY only)
@@ -59,12 +60,18 @@ async function resolveLaunchTarget(
   cmdArgs: string[],
   extraArgs: string[],
 ): Promise<LaunchTarget | null> {
+  // Resolve workspace root once — walks up from cwd looking for monorepo
+  // markers (.lore.json with workspaces, .git, pnpm-workspace.yaml, etc.)
+  const projectDir = discoverWorkspaceRoot(process.cwd());
+  if (projectDir !== process.cwd()) {
+    console.log(`[lore] Workspace root: ${projectDir}`);
+  }
+
   // --- Explicit command given: inject all known env vars ---
   if (cmdArgs.length > 0) {
-    const cwd = process.cwd();
     const env: Record<string, string> = {};
     for (const agent of AGENTS) {
-      Object.assign(env, agent.envVars(gatewayUrl, cwd));
+      Object.assign(env, agent.envVars(gatewayUrl, projectDir));
     }
     return { command: cmdArgs[0], args: [...cmdArgs.slice(1), ...extraArgs], env };
   }
@@ -99,7 +106,7 @@ async function resolveLaunchTarget(
   return {
     command: agent.def.binary,
     args: [...extraArgs],
-    env: agent.def.envVars(gatewayUrl, process.cwd()),
+    env: agent.def.envVars(gatewayUrl, projectDir),
   };
 }
 

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -4,7 +4,7 @@
  * (only `normalizeRemoteUrl` for git URL canonicalization).
  */
 
-import { normalizeRemoteUrl } from "@loreai/core";
+import { normalizeRemoteUrl, discoverWorkspaceRoot } from "@loreai/core";
 
 // ---------------------------------------------------------------------------
 // Port defaults
@@ -270,8 +270,8 @@ export function getProjectPath(
   const inferred = inferProjectPath(systemPrompt);
   if (inferred) return { path: inferred, source: "inferred", gitRemote };
 
-  // 3. Fall back to gateway's own cwd
-  return { path: process.cwd(), source: "cwd", gitRemote };
+  // 3. Fall back to gateway's own cwd (with workspace root discovery)
+  return { path: discoverWorkspaceRoot(process.cwd()), source: "cwd", gitRemote };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -53,6 +53,8 @@ import {
   loadHeaderSessionIndex,
   isHostedMode,
   enableHostedMode,
+  importLoreFileAs,
+  resolveWorkspaces,
 } from "@loreai/core";
 
 import type {
@@ -618,12 +620,47 @@ function startKnowledgeFileWatcher(projectPath: string): () => void {
     }
   }
 
+  // Watch .lore.md in configured workspace sub-projects.
+  // Changes in sub-project files trigger a re-import into the root project.
+  // Each sub-project gets its own debounce timer so concurrent edits across
+  // sub-projects don't cancel each other's pending imports.
+  const allTimers: Array<{ clear: () => void }> = [
+    { clear: () => { if (debounceTimer) { clearTimeout(debounceTimer); debounceTimer = null; } } },
+  ];
+  if (cfg.workspaces.length > 0) {
+    const subDirs = resolveWorkspaces(projectPath, cfg.workspaces);
+    for (const subDir of subDirs) {
+      const subLoreFile = join(subDir, LORE_FILE);
+      if (existsSync(subLoreFile)) {
+        try {
+          let subTimer: ReturnType<typeof setTimeout> | null = null;
+          const w = watch(subLoreFile, () => {
+            if (subTimer) clearTimeout(subTimer);
+            subTimer = setTimeout(() => {
+              subTimer = null;
+              try {
+                importLoreFileAs(subDir, projectPath);
+              } catch (e) {
+                log.error(`workspace knowledge re-import error (${subDir}):`, e);
+              }
+            }, DEBOUNCE_MS);
+          });
+          w.on("error", () => {});
+          watchers.push(w);
+          allTimers.push({ clear: () => { if (subTimer) { clearTimeout(subTimer); subTimer = null; } } });
+        } catch {
+          // watch not supported
+        }
+      }
+    }
+  }
+
   if (watchers.length > 0) {
     log.info(`watching ${watchers.length} knowledge file(s) for changes`);
   }
 
   return () => {
-    if (debounceTimer) clearTimeout(debounceTimer);
+    for (const t of allTimers) t.clear();
     for (const w of watchers) {
       try { w.close(); } catch { /* already closed */ }
     }
@@ -657,6 +694,24 @@ async function initIfNeeded(projectPath: string, config: GatewayConfig, gitRemot
   const cfg = loreConfig();
   if (cfg.knowledge.enabled) {
     tryImportKnowledge(projectPath);
+
+    // Import .lore.md files from configured workspace sub-projects.
+    // Entries are attributed to the root project so they're visible in
+    // the current session's knowledge context.
+    if (cfg.workspaces.length > 0) {
+      const { basename } = require("node:path") as typeof import("node:path");
+      const subDirs = resolveWorkspaces(projectPath, cfg.workspaces);
+      for (const subDir of subDirs) {
+        try {
+          if (loreFileExists(subDir)) {
+            importLoreFileAs(subDir, projectPath);
+            log.info(`imported knowledge from workspace: ${basename(subDir)}`);
+          }
+        } catch (e) {
+          log.error(`workspace knowledge import error (${subDir}):`, e);
+        }
+      }
+    }
 
     // Prune corrupted/oversized knowledge entries (safety net for past bugs).
     const pruned = ltm.pruneOversized(1200);

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -1,5 +1,5 @@
 import type { Plugin, Hooks } from "@opencode-ai/plugin";
-import { log, getGitRemote } from "@loreai/core";
+import { log, getGitRemote, discoverWorkspaceRoot } from "@loreai/core";
 
 /**
  * Providers whose wire protocol the Lore gateway can proxy.
@@ -254,9 +254,11 @@ export const LorePlugin: Plugin = async (ctx) => {
       output.headers["x-lore-session-id"] = input.sessionID;
       output.headers["x-lore-agent"] = input.agent;
       // Inject project path so the gateway can attribute data correctly.
-      output.headers["x-lore-project"] = ctx.worktree || ctx.directory;
+      // discoverWorkspaceRoot walks up from the project dir to find a
+      // monorepo/workspace root (cached after first call).
+      output.headers["x-lore-project"] = discoverWorkspaceRoot(ctx.worktree || ctx.directory);
       if (cachedGitRemote === undefined) {
-        const projectPath = ctx.worktree || ctx.directory;
+        const projectPath = discoverWorkspaceRoot(ctx.worktree || ctx.directory);
         cachedGitRemote = getGitRemote(projectPath) ?? "";
       }
       if (cachedGitRemote) {
@@ -277,7 +279,7 @@ export const LorePlugin: Plugin = async (ctx) => {
 
   // Startup banner — visible in stderr so silent failures are obvious.
   if (!processInitDone) {
-    const projectPath = ctx.worktree || ctx.directory;
+    const projectPath = discoverWorkspaceRoot(ctx.worktree || ctx.directory);
     process.stderr.write(`[lore] active: ${projectPath}\n`);
 
     if (loreActive) {


### PR DESCRIPTION
## Problem

Lore uses `process.cwd()` as the project path with no directory traversal. This fails for monorepo setups:

1. **Downward (primary pain point)**: User runs `lore run` from monorepo root (no `.git`). Sub-projects are bare directories under the root, each with their own `.git` and `.lore.md`. Lore never discovers these sub-project `.lore.md` files.

2. **Upward**: User runs from a sub-project. Lore doesn't discover the monorepo root above, missing shared config.

## Solution

### Config-driven sub-project discovery

New `workspaces` field in `.lore.json`:

```jsonc
// Bare sub-projects directly under monorepo root:
{ "workspaces": ["project-a", "project-b", "shared-lib"] }

// Standard monorepo layout:
{ "workspaces": ["packages/*"] }

// Mixed:
{ "workspaces": ["packages/*", "tools/cli", "infra"] }
```

Supports literal relative paths and single-level globs. Mirrors `package.json` workspaces / `pnpm-workspace.yaml` conventions.

### Upward discovery via `discoverWorkspaceRoot()`

Walks up from cwd checking for project markers at each level:

1. `.lore.json` with `workspaces` field (strongest signal — user explicitly declared workspace root)
2. VCS markers: `.git`, `.hg`, `.svn`, `.jj`, etc. (definitive)
3. Workspace markers: `pnpm-workspace.yaml`, `nx.json`, `turbo.json`, etc. (definitive)
4. Language markers: `package.json`, `pyproject.toml`, `Cargo.toml`, etc. (closest-wins, walk continues)

Stop boundary at `homedir()` — never claims `$HOME` as workspace root even if `~/.git` exists (common dotfile managers).

### Integration flow

At startup (`initIfNeeded`):
1. Resolve project path (may walk up to find workspace root)
2. Load `.lore.json` from resolved path
3. If `workspaces` is configured, resolve glob patterns to sub-project dirs
4. Import `.lore.md` from each sub-project into the root project's knowledge base (via `importLoreFileAs`)
5. Watch sub-project `.lore.md` files for live changes (independent debounce timers per watcher)

Sub-project `.lore.md` files are **read-only imports** — entries are attributed to the root project so they're visible via `forSession()`. Lore does not write back to sub-project files.

## Safety

- **Path traversal guard**: `resolveWorkspaces` rejects `../` escapes — resolved paths must be under `rootDir`
- **Dot-prefix filtering**: Glob expansion skips `.git`, `.vscode`, etc. (matches npm/pnpm behavior)
- **Homedir boundary**: Walk stops *before* checking markers at `$HOME`
- **Hosted mode guards**: Both functions return safe defaults, preventing filesystem traversal with client-controlled paths
- **Mtime fast-path**: `importLoreFileAs` skips re-import when source file unchanged (mtime cache)

## Files changed

| File | Change |
|---|---|
| `packages/core/src/workspace.ts` | **NEW** — `discoverWorkspaceRoot()` + `resolveWorkspaces()` |
| `packages/core/src/config.ts` | Add `workspaces` field to schema |
| `packages/core/src/agents-file.ts` | Add `importLoreFileAs()` |
| `packages/core/src/index.ts` | New exports |
| `packages/core/test/workspace.test.ts` | **NEW** — 31 tests |
| `packages/gateway/src/cli/run.ts` | Use `discoverWorkspaceRoot(process.cwd())` |
| `packages/gateway/src/config.ts` | Apply to cwd fallback |
| `packages/gateway/src/pipeline.ts` | Sub-project import at startup + file watchers |
| `packages/opencode/src/index.ts` | Apply workspace root to project path |

## Test plan

- 31 unit tests covering both directions of discovery + edge cases
- Typecheck clean across all 4 packages
- Existing test suites (config, agents-file, git) pass with no regressions
