### PR TITLE
fix: stop background worker 401 storm when OAuth token expires

### DIFF
--- a/packages/gateway/instrument.ts
+++ b/packages/gateway/instrument.ts
@@ -81,6 +81,7 @@ if (sentryEnabled && !Sentry.isInitialized()) {
     /ZlibError/,
     /The operation timed out/i,
     /Worker upstream exhausted \d+ retries/,
+    /Worker upstream auth error/,
     /ECONNRESET\b/,
     /ECONNREFUSED\b/,
   ];

--- a/packages/gateway/src/auth.ts
+++ b/packages/gateway/src/auth.ts
@@ -160,6 +160,11 @@ export function getLastSeenAuth(): AuthCredential | null {
  *    can provide a potentially-refreshed token.
  * 2. Fall back to the global `lastSeenAuth` (for cold-start or callers
  *    that don't pass a session ID).
+ * 3. If the global fallback holds the same value as the stale session
+ *    credential, return `null` — the token is expired everywhere and
+ *    retrying would just generate another 401. This prevents the
+ *    background worker 401 storm in single-session OAuth setups where
+ *    session and global credentials are the same expired token.
  */
 export function resolveAuth(
   sessionID?: string,
@@ -167,6 +172,14 @@ export function resolveAuth(
   if (sessionID) {
     const cred = getSessionAuth(sessionID);
     if (cred && !staleSessionAuth.has(sessionID)) return cred;
+
+    // Global fallback — but guard against returning the same stale token.
+    // In single-session OAuth setups, session and global hold the exact
+    // same expired bearer token. Returning it would cause callers to make
+    // a request that immediately 401s again.
+    const global = getLastSeenAuth();
+    if (cred && global && global.value === cred.value) return null;
+    return global;
   }
   return getLastSeenAuth();
 }

--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -47,6 +47,7 @@ import {
 } from "./cache-warmer";
 import * as Sentry from "@sentry/bun";
 import { runBackground } from "./background-limiter";
+import { isAuthStale, resolveAuth } from "./auth";
 import { emitWarmupMetric, emitSessionCostMetrics, emitCurationMetrics } from "./sentry";
 import { getSessionCosts, totalWorkerCost } from "./cost-tracker";
 
@@ -86,6 +87,12 @@ export function startIdleScheduler(
       // is still active, not genuinely idle. Distillation/curation should
       // wait for the actual idle period after the tool-use turn completes.
       if (state.lastStopReason === "tool_use") continue;
+
+      // Skip sessions with stale auth credentials — background LLM calls
+      // (distillation, curation) would just 401, flooding Sentry with
+      // events every 30s. Auth refreshes when the next client request
+      // arrives via setSessionAuth(), which clears the stale flag.
+      if (isAuthStale(sessionID) && !resolveAuth(sessionID)) continue;
 
       inProgress.add(sessionID);
       runBackground(

--- a/packages/gateway/test/auth.test.ts
+++ b/packages/gateway/test/auth.test.ts
@@ -133,6 +133,27 @@ describe("resolveAuth with staleness", () => {
     expect(result).toBe(null);
   });
 
+  test("returns null when stale session and global hold the same token", () => {
+    // Single-session OAuth setup: session and global have the same expired token
+    setSessionAuth("sess-1", bearerCred);
+    setLastSeenAuth(bearerCred);
+    markAuthStale("sess-1");
+
+    // Global fallback has the same value as the stale session credential —
+    // returning it would cause another 401, so resolveAuth returns null
+    expect(resolveAuth("sess-1")).toBe(null);
+  });
+
+  test("returns global when stale session and global hold different tokens", () => {
+    // Multi-session setup: another client refreshed the global credential
+    setSessionAuth("sess-1", bearerCred);
+    setLastSeenAuth(bearerCred2);
+    markAuthStale("sess-1");
+
+    // Global has a different (potentially fresh) token — return it
+    expect(resolveAuth("sess-1")).toEqual(bearerCred2);
+  });
+
   test("re-resolves to session credential after staleness cleared", () => {
     setSessionAuth("sess-1", bearerCred);
     setLastSeenAuth(apiKeyCred);


### PR DESCRIPTION
## Problem

**Sentry Issue:** [LOREAI-GATEWAY-Z](https://byk.sentry.io/issues/7498124471/) — 19 users, 2,349 events

When a single user's OAuth bearer token expires, background workers (distillation, curation, consolidation) keep retrying every 30 seconds with the stale token. Each attempt generates a `Sentry.captureException` call, flooding Sentry with thousands of events.

### Root Cause

PR #454 added a retry-once mechanism: mark the session credential stale → fall back to global → retry if credential changed. But in single-session OAuth setups (the typical Claude Code user), the session and global credentials are the **same expired token**. So:

1. `markAuthStale(sessionID)` marks the session stale
2. `resolveAuth(sessionID)` skips the stale session, falls through to `getLastSeenAuth()`
3. The global holds the same expired token → `credentialChanged = false`
4. Retry-once path is never taken → `Sentry.captureException()` fires
5. Next 30s idle tick repeats the cycle

### Fix (three layers)

1. **`auth.ts` — `resolveAuth()` detects same-token fallback**: When the stale session credential and global credential have the same value, return `null` instead of the expired global token. This lets callers know there's no usable credential available.

2. **`idle.ts` — skip background work on stale auth**: Before scheduling idle work (distillation, curation, consolidation), check `isAuthStale(sessionID) && !resolveAuth(sessionID)`. If auth is stale and no fresh credential is available, skip the session entirely. Auth refreshes when the next client request arrives.

3. **`instrument.ts` — filter auth errors in `beforeSend`**: Add `/Worker upstream auth error/` to `TRANSIENT_ERROR_PATTERNS` as defense-in-depth, suppressing any residual auth error events that slip through.

### Tests

- Added 2 new test cases for `resolveAuth` same-token detection
- All existing auth tests pass (16 total)
- Full suite: 1810 pass, 5 skip, 0 fail