### PR TITLE
fix: OpenAI protocol translation, curator validation, and batch queue 404 handling

### DIFF
--- a/packages/core/src/curator.ts
+++ b/packages/core/src/curator.ts
@@ -107,13 +107,28 @@ export function parseResponse(text: string): CuratorResponse {
 }
 
 function filterOps(arr: unknown[]): CuratorOp[] {
-  return arr.filter(
-    (op: unknown) =>
-      typeof op === "object" &&
-      op !== null &&
-      "op" in op &&
-      typeof (op as Record<string, unknown>).op === "string",
-  ) as CuratorOp[];
+  return arr.filter((op: unknown) => {
+    if (typeof op !== "object" || op === null || !("op" in op)) return false;
+    const o = op as Record<string, unknown>;
+    if (typeof o.op !== "string") return false;
+    // Validate required fields per op type to prevent runtime crashes
+    // from malformed LLM output (e.g. missing content on create ops).
+    if (o.op === "create") {
+      return (
+        typeof o.category === "string" &&
+        typeof o.title === "string" &&
+        typeof o.content === "string" &&
+        typeof o.scope === "string"
+      );
+    }
+    if (o.op === "update") {
+      return typeof o.id === "string";
+    }
+    if (o.op === "delete") {
+      return typeof o.id === "string";
+    }
+    return false;
+  }) as CuratorOp[];
 }
 
 function filterEntities(arr: unknown[]): DetectedEntity[] {
@@ -222,6 +237,8 @@ export function applyOps(
   for (const op of ops) {
     if (op.op === "create") {
       if (input.skipCreate) continue;
+      // Defensive: skip malformed ops missing required fields
+      if (!op.content || !op.title || !op.category) continue;
       const content =
         op.content.length > MAX_ENTRY_CONTENT_LENGTH
           ? op.content.slice(0, MAX_ENTRY_CONTENT_LENGTH) +

--- a/packages/gateway/src/batch-queue.ts
+++ b/packages/gateway/src/batch-queue.ts
@@ -216,6 +216,12 @@ export function createAnthropicBatchProvider(upstreamUrl: string): BatchProvider
           log.warn(`anthropic batch auth error (${response.status}): ${text}`);
           return "auth-error";
         }
+        // 404/405 means the upstream doesn't support the batch API at all.
+        // Treat as permanent failure to avoid retrying on every flush cycle.
+        if (response.status === 404 || response.status === 405) {
+          log.warn(`anthropic batch not supported (${response.status}): ${text}`);
+          return "auth-error";
+        }
         log.error(`anthropic batch create failed: ${response.status} ${response.statusText} — ${text}`);
         return null;
       }
@@ -343,6 +349,13 @@ async function uploadOpenAIBatchFile(
     const text = await response.text().catch(() => "(no body)");
     if (response.status === 401 || response.status === 403) {
       log.warn(`openai file upload auth error (${response.status}): ${text}`);
+      return "auth-error";
+    }
+    // 404/405 means the upstream doesn't support the batch/files API at all
+    // (e.g. vLLM, local models). Treat as permanent failure to avoid retrying
+    // on every flush cycle.
+    if (response.status === 404 || response.status === 405) {
+      log.warn(`openai file upload not supported (${response.status}): ${text}`);
       return "auth-error";
     }
     log.error(`openai file upload failed: ${response.status} — ${text}`);
@@ -496,6 +509,10 @@ export function createOpenAIBatchProvider(upstreamUrl: string): BatchProvider {
         const text = await response.text().catch(() => "(no body)");
         if (response.status === 401 || response.status === 403) {
           log.warn(`openai batch auth error (${response.status}): ${text}`);
+          return "auth-error";
+        }
+        if (response.status === 404 || response.status === 405) {
+          log.warn(`openai batch not supported (${response.status}): ${text}`);
           return "auth-error";
         }
         log.error(`openai batch create failed: ${response.status} ${response.statusText} — ${text}`);

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -92,6 +92,7 @@ import {
 import {
   buildAnthropicRequest,
   buildAnthropicNonStreamResponse,
+  parseAnthropicResponseJSON,
   type AnthropicCacheOptions,
 } from "./translate/anthropic";
 import {
@@ -1779,53 +1780,8 @@ async function accumulateNonStreamResponse(
   }
 }
 
-function accumulateAnthropicNonStreamJSON(json: Record<string, unknown>): GatewayResponse {
-  const content: GatewayContentBlock[] = [];
-  const rawContent = json.content as Array<Record<string, unknown>> | undefined;
-  if (rawContent) {
-    for (const block of rawContent) {
-      switch (block.type) {
-        case "text":
-          content.push({ type: "text", text: String(block.text ?? "") });
-          break;
-        case "thinking":
-          content.push({
-            type: "thinking",
-            thinking: String(block.thinking ?? ""),
-            ...(block.signature
-              ? { signature: String(block.signature) }
-              : undefined),
-          });
-          break;
-        case "tool_use":
-          content.push({
-            type: "tool_use",
-            id: String(block.id ?? ""),
-            name: String(block.name ?? ""),
-            input: block.input,
-          });
-          break;
-      }
-    }
-  }
-
-  const usage = json.usage as Record<string, number> | undefined;
-
-  return {
-    id: String(json.id ?? ""),
-    model: String(json.model ?? ""),
-    content,
-    stopReason: String(
-      (json.stop_reason as string) ?? "end_turn",
-    ),
-    usage: {
-      inputTokens: usage?.input_tokens ?? 0,
-      outputTokens: usage?.output_tokens ?? 0,
-      cacheReadInputTokens: usage?.cache_read_input_tokens,
-      cacheCreationInputTokens: usage?.cache_creation_input_tokens,
-    },
-  };
-}
+// Anthropic non-stream JSON → GatewayResponse: use shared parseAnthropicResponseJSON
+const accumulateAnthropicNonStreamJSON = parseAnthropicResponseJSON;
 
 function accumulateOpenAINonStreamJSON(json: Record<string, unknown>): GatewayResponse {
   const content: GatewayContentBlock[] = [];

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -14,7 +14,7 @@
 import { DEFAULT_PORT, type GatewayConfig } from "./config";
 import { bootstrapDailySpend, getDailyBudget } from "./cost-tracker";
 import type { GatewayRequest } from "./translate/types";
-import { parseAnthropicRequest } from "./translate/anthropic";
+import { parseAnthropicRequest, parseAnthropicResponseJSON } from "./translate/anthropic";
 import { parseOpenAIRequest, buildOpenAIResponse } from "./translate/openai";
 import { translateAnthropicStreamToOpenAI } from "./stream/openai";
 import {
@@ -203,9 +203,10 @@ async function handleOpenAIChatCompletions(
     return withCors(translateAnthropicStreamToOpenAI(pipelineResp));
   }
 
-  // Non-streaming: translate JSON body
+  // Non-streaming: translate Anthropic wire JSON → GatewayResponse → OpenAI
   const respBody = await pipelineResp.json();
-  return withCors(buildOpenAIResponse(respBody, false));
+  const gatewayResp = parseAnthropicResponseJSON(respBody as Record<string, unknown>);
+  return withCors(buildOpenAIResponse(gatewayResp, false));
 }
 
 async function handleOpenAIResponses(
@@ -248,9 +249,10 @@ async function handleOpenAIResponses(
     return withCors(translateAnthropicStreamToResponses(pipelineResp));
   }
 
-  // Non-streaming: translate JSON body
+  // Non-streaming: translate Anthropic wire JSON → GatewayResponse → Responses API
   const respBody = await pipelineResp.json();
-  return withCors(buildOpenAIResponsesResponse(respBody, false));
+  const gatewayResp = parseAnthropicResponseJSON(respBody as Record<string, unknown>);
+  return withCors(buildOpenAIResponsesResponse(gatewayResp, false));
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/src/translate/anthropic.ts
+++ b/packages/gateway/src/translate/anthropic.ts
@@ -484,6 +484,61 @@ export function buildAnthropicRequest(
 // ---------------------------------------------------------------------------
 
 /**
+ * Parse an Anthropic-format response JSON back into a `GatewayResponse`.
+ *
+ * This is the inverse of `buildAnthropicNonStreamResponse`. Used when the
+ * pipeline returns Anthropic-format JSON that needs to be translated to
+ * another protocol (OpenAI Chat Completions, OpenAI Responses API).
+ */
+export function parseAnthropicResponseJSON(
+  json: Record<string, unknown>,
+): GatewayResponse {
+  const content: GatewayContentBlock[] = [];
+  const rawContent = json.content as Array<Record<string, unknown>> | undefined;
+  if (rawContent) {
+    for (const block of rawContent) {
+      switch (block.type) {
+        case "text":
+          content.push({ type: "text", text: String(block.text ?? "") });
+          break;
+        case "thinking":
+          content.push({
+            type: "thinking",
+            thinking: String(block.thinking ?? ""),
+            ...(block.signature
+              ? { signature: String(block.signature) }
+              : undefined),
+          });
+          break;
+        case "tool_use":
+          content.push({
+            type: "tool_use",
+            id: String(block.id ?? ""),
+            name: String(block.name ?? ""),
+            input: block.input,
+          });
+          break;
+      }
+    }
+  }
+
+  const usage = json.usage as Record<string, number> | undefined;
+
+  return {
+    id: String(json.id ?? ""),
+    model: String(json.model ?? ""),
+    content,
+    stopReason: String((json.stop_reason as string) ?? "end_turn"),
+    usage: {
+      inputTokens: usage?.input_tokens ?? 0,
+      outputTokens: usage?.output_tokens ?? 0,
+      cacheReadInputTokens: usage?.cache_read_input_tokens,
+      cacheCreationInputTokens: usage?.cache_creation_input_tokens,
+    },
+  };
+}
+
+/**
  * Build a non-streaming Anthropic response JSON from a `GatewayResponse`.
  *
  * Produces the standard Anthropic `/v1/messages` response shape with


### PR DESCRIPTION
## Summary

Fix five Sentry issues affecting users on the latest release (0.24.1):

### LOREAI-GATEWAY-1E / 1D / 1C — OpenAI protocol translation crash

**Root cause:** `server.ts` called `pipelineResp.json()` which returns Anthropic wire-format JSON (snake_case: `input_tokens`, `stop_reason`), then passed it directly to `buildOpenAIResponse()` / `buildOpenAIResponsesResponse()` which expect `GatewayResponse` (camelCase: `inputTokens`, `stopReason`). This caused `resp.usage.inputTokens` to be `undefined`, crashing with `TypeError: Cannot read properties of undefined (reading 'inputTokens')`.

**Fix:** Added `parseAnthropicResponseJSON()` — the inverse of `buildAnthropicNonStreamResponse()` — to `translate/anthropic.ts`. `server.ts` now converts Anthropic wire JSON → `GatewayResponse` before protocol translation. Also deduplicated the identical `accumulateAnthropicNonStreamJSON` in `pipeline.ts`.

### LOREAI-GATEWAY-1F — Curator crash on malformed LLM output

**Root cause:** `filterOps()` only validated that parsed JSON had an `op` field of type string, allowing malformed curator ops (e.g. `create` ops missing `content`) through to `applyOps()`, which crashed with `TypeError: undefined is not an object (evaluating 's.content.length')`.

**Fix:** Added per-op-type required field validation in `filterOps()` (create requires category/title/content/scope; update/delete require id). Added defensive guard in `applyOps()` as defense-in-depth.

### LOREAI-GATEWAY-1B — Batch queue retry storm against vLLM

**Root cause:** When the upstream doesn't support the batch/files API (e.g. vLLM returns 404), the batch queue treated this as a transient failure (`null`), retrying on every flush cycle. This caused repeated 404s and triggered fallback processing that surfaced a TDZ error in the minified binary.

**Fix:** Treat HTTP 404/405 as permanent failures (like 401/403), disabling batch for affected sessions. Applied to all three batch submission endpoints (Anthropic batch create, OpenAI file upload, OpenAI batch create).

## Test Plan

- All 1914 existing tests pass
- Typecheck passes across all packages

Closes LOREAI-GATEWAY-1B, LOREAI-GATEWAY-1C, LOREAI-GATEWAY-1D, LOREAI-GATEWAY-1E, LOREAI-GATEWAY-1F