### PR TITLE
fix: address review findings from PR #475 and #477

### DIFF
--- a/packages/core/src/curator.ts
+++ b/packages/core/src/curator.ts
@@ -118,7 +118,7 @@ function filterOps(arr: unknown[]): CuratorOp[] {
         typeof o.category === "string" &&
         typeof o.title === "string" &&
         typeof o.content === "string" &&
-        typeof o.scope === "string"
+        (o.scope === "project" || o.scope === "global")
       );
     }
     if (o.op === "update") {

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -616,9 +616,10 @@ let remoteFallbackLogged = false;
  * produces 401 errors.
  */
 function looksLikeApiKey(key: string): boolean {
-  // Real API keys are at least 20 characters and don't look like
-  // common placeholders.
-  return key.length >= 20;
+  // Real API keys are at least 20 characters, don't contain whitespace,
+  // and aren't common placeholders.
+  const trimmed = key.trim();
+  return trimmed.length >= 20 && !/\s/.test(trimmed);
 }
 
 /**

--- a/packages/gateway/instrument.ts
+++ b/packages/gateway/instrument.ts
@@ -87,9 +87,9 @@ if (sentryEnabled && !Sentry.isInitialized()) {
     /LocalProviderUnavailableError/,
     /ECONNRESET\b/,
     /ECONNREFUSED\b/,
-    // Remote embedding fallback with invalid/placeholder API key
-    /Incorrect API key/i,
-    /onnxruntime/i,
+    // Remote embedding fallback with invalid/placeholder API key (OpenAI SDK format)
+    /Incorrect API key provided/i,
+    // ONNX runtime init failures on various platforms
     /Cannot find package 'onnxruntime-node'/,
     /LoadLibrary failed/,
     /Protobuf parsing failed/,

--- a/packages/gateway/src/translate/anthropic.ts
+++ b/packages/gateway/src/translate/anthropic.ts
@@ -518,6 +518,10 @@ export function parseAnthropicResponseJSON(
             input: block.input,
           });
           break;
+        default:
+          // Preserve unknown block types as text so no data is silently lost
+          content.push({ type: "text", text: JSON.stringify(block) });
+          break;
       }
     }
   }


### PR DESCRIPTION
## Summary

Addresses findings from the adversarial self-review of PR #475 and #477.

### Changes

**C1 — Unknown block types silently dropped in `parseAnthropicResponseJSON`**

Added a `default` case to the content block switch that preserves unknown block types as serialized JSON text. This matches the pattern used in `toGatewayBlock()` for request parsing and prevents silent data loss if Anthropic adds new content block types.

**C2 — Invalid scope values accepted by `filterOps()`**

Changed scope validation from `typeof o.scope === "string"` to `o.scope === "project" || o.scope === "global"`. Previously, an LLM producing an invalid scope like `"session"` or `""` would pass validation and create all entries with `projectPath: undefined` (global scope) regardless of intent.

**M2 — `looksLikeApiKey()` doesn't trim or reject whitespace**

Added `key.trim()` and a `/\s/` check. Environment variables can contain trailing newlines which would pass the length check but fail at the API.

**M4 — `/onnxruntime/i` pattern too broad**

Removed the overly broad `/onnxruntime/i` pattern from `TRANSIENT_ERROR_PATTERNS`. The three specific patterns that follow it (`Cannot find package`, `LoadLibrary failed`, `Protobuf parsing failed`) already cover the known ONNX init failures without risking silencing real bugs.

**M5 — `/Incorrect API key/i` could match unrelated auth errors**

Narrowed to `/Incorrect API key provided/i` which is the specific error message format returned by the OpenAI SDK, avoiding false positives from other auth error formats.

## Test Plan

- All 1915 tests pass
- Typecheck passes across all 4 packages