### PR TITLE
fix: extract evictIdleSessions() for testability, clean up consolidation cooldown

### DIFF
--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -134,77 +134,7 @@ export function startIdleScheduler(
         .finally(() => inProgress.delete(sessionID));
     }
 
-    // --- Session eviction — free memory for long-idle sessions ---
-    // All important state is persisted to SQLite; eviction only releases
-    // in-memory caches (gradient state, prefix cache, recall store, LTM
-    // caches, cost tracking, auth credentials). If a session resumes,
-    // getOrCreateSession() in pipeline.ts reloads persisted state from DB.
-    const evictionTimeoutMs = config.sessionEvictionTimeoutSeconds * 1000;
-    for (const [sessionID, state] of sessions) {
-      if (evictionTimeoutMs <= 0) break; // eviction disabled
-      if (inProgress.has(sessionID)) continue; // don't evict during active idle work
-      if (warmupInProgress.has(sessionID)) continue;
-      // Sub-agent sessions are ephemeral — evict faster
-      const timeout = state.isSubagent
-        ? Math.min(evictionTimeoutMs, SUBAGENT_EVICTION_MS)
-        : evictionTimeoutMs;
-      if (now - state.lastRequestTime < timeout) continue;
-      // Don't evict sessions still executing tools — they're active
-      if (state.lastStopReason === "tool_use") continue;
-
-      log.info(
-        `evicting idle session ${sessionID.slice(0, 16)}` +
-        `${state.isSubagent ? " (subagent)" : ""}` +
-        ` (idle ${Math.round((now - state.lastRequestTime) / 60_000)}m)`,
-      );
-
-      // Persist final cost snapshot before eviction
-      try {
-        const costs = getSessionCosts(sessionID);
-        if (costs && costs.conversation.turns > 0) {
-          saveSessionCosts(sessionID, {
-            conversationCost: costs.conversation.cost,
-            workerCost: totalWorkerCost(costs),
-            conversationTurns: costs.conversation.turns,
-            cacheReadTokens: costs.conversation.cacheReadTokens,
-            cacheWriteTokens: costs.conversation.cacheWriteTokens,
-            warmupSavings: costs.counterfactual.warmupSavings,
-            warmupHits: costs.counterfactual.warmupHits,
-            ttlSavings: costs.counterfactual.ttlSavings,
-            ttlHits: costs.counterfactual.ttlHits,
-            batchSavings: costs.batchSavings,
-            avoidedCompactions: costs.counterfactual.avoidedCompactions,
-            avoidedCompactionCost: costs.counterfactual.avoidedCompactionCost,
-          });
-        }
-      } catch (e) {
-        log.warn(`session eviction: cost persistence failed for ${sessionID.slice(0, 16)}:`, e);
-      }
-
-      // Persist gradient state before eviction
-      try {
-        saveGradientState(sessionID);
-      } catch (e) {
-        log.warn(`session eviction: gradient persistence failed for ${sessionID.slice(0, 16)}:`, e);
-      }
-
-      // Clean up all per-session in-memory state across modules
-      evictGradientSession(sessionID);
-      curator.resetCurationTracker(sessionID);
-      deleteSessionCosts(sessionID);
-      deleteSessionAuth(sessionID);
-      clearAuthStale(sessionID);
-      deleteBillingPrefix(sessionID);
-      clearWarmupAuthDisabled(sessionID);
-      distillLimiter.evict(sessionID);
-      curatorLimiter.evict(sessionID);
-
-      // Clean up pipeline-level satellite Maps via callback
-      onEvict?.(sessionID);
-
-      // Remove from the main sessions map last
-      sessions.delete(sessionID);
-    }
+    evictIdleSessions(config, sessions, inProgress, warmupInProgress, now, onEvict);
 
     // --- Cache warming (separate from idle work — fires before TTL expiry) ---
     if (isCircuitBreakerTripped()) return;
@@ -299,6 +229,117 @@ export function startIdleScheduler(
   }, POLL_INTERVAL_MS);
 
   return () => clearInterval(timer);
+}
+
+// ---------------------------------------------------------------------------
+// evictIdleSessions — extracted for testability
+// ---------------------------------------------------------------------------
+
+/**
+ * Evict sessions that have been idle beyond the configured eviction timeout.
+ *
+ * All important state is persisted to SQLite before eviction; only in-memory
+ * caches are freed (gradient state, prefix cache, recall store, LTM caches,
+ * cost tracking, auth credentials). If a session resumes, getOrCreateSession()
+ * in pipeline.ts reloads persisted state from DB.
+ *
+ * Extracted from the scheduler interval so it can be tested directly without
+ * waiting for a 30s timer tick.
+ *
+ * @returns Number of sessions evicted.
+ */
+export function evictIdleSessions(
+  config: GatewayConfig,
+  sessions: Map<string, SessionState>,
+  inProgress: ReadonlySet<string>,
+  warmupInProgress: ReadonlySet<string>,
+  now: number,
+  onEvict?: (sessionID: string) => void,
+): number {
+  const evictionTimeoutMs = config.sessionEvictionTimeoutSeconds * 1000;
+  let evicted = 0;
+
+  for (const [sessionID, state] of sessions) {
+    if (evictionTimeoutMs <= 0) break; // eviction disabled
+    if (inProgress.has(sessionID)) continue; // don't evict during active idle work
+    if (warmupInProgress.has(sessionID)) continue;
+    // Sub-agent sessions are ephemeral — evict faster
+    const timeout = state.isSubagent
+      ? Math.min(evictionTimeoutMs, SUBAGENT_EVICTION_MS)
+      : evictionTimeoutMs;
+    if (now - state.lastRequestTime < timeout) continue;
+    // Don't evict sessions still executing tools — they're active
+    if (state.lastStopReason === "tool_use") continue;
+
+    log.info(
+      `evicting idle session ${sessionID.slice(0, 16)}` +
+      `${state.isSubagent ? " (subagent)" : ""}` +
+      ` (idle ${Math.round((now - state.lastRequestTime) / 60_000)}m)`,
+    );
+
+    // Persist final cost snapshot before eviction
+    try {
+      const costs = getSessionCosts(sessionID);
+      if (costs && costs.conversation.turns > 0) {
+        saveSessionCosts(sessionID, {
+          conversationCost: costs.conversation.cost,
+          workerCost: totalWorkerCost(costs),
+          conversationTurns: costs.conversation.turns,
+          cacheReadTokens: costs.conversation.cacheReadTokens,
+          cacheWriteTokens: costs.conversation.cacheWriteTokens,
+          warmupSavings: costs.counterfactual.warmupSavings,
+          warmupHits: costs.counterfactual.warmupHits,
+          ttlSavings: costs.counterfactual.ttlSavings,
+          ttlHits: costs.counterfactual.ttlHits,
+          batchSavings: costs.batchSavings,
+          avoidedCompactions: costs.counterfactual.avoidedCompactions,
+          avoidedCompactionCost: costs.counterfactual.avoidedCompactionCost,
+        });
+      }
+    } catch (e) {
+      log.warn(`session eviction: cost persistence failed for ${sessionID.slice(0, 16)}:`, e);
+    }
+
+    // Persist gradient state before eviction
+    try {
+      saveGradientState(sessionID);
+    } catch (e) {
+      log.warn(`session eviction: gradient persistence failed for ${sessionID.slice(0, 16)}:`, e);
+    }
+
+    // Clean up all per-session in-memory state across modules
+    evictGradientSession(sessionID);
+    curator.resetCurationTracker(sessionID);
+    deleteSessionCosts(sessionID);
+    deleteSessionAuth(sessionID);
+    clearAuthStale(sessionID);
+    deleteBillingPrefix(sessionID);
+    clearWarmupAuthDisabled(sessionID);
+    distillLimiter.evict(sessionID);
+    curatorLimiter.evict(sessionID);
+
+    // Clean up pipeline-level satellite Maps via callback
+    onEvict?.(sessionID);
+
+    // Remove from the main sessions map last
+    sessions.delete(sessionID);
+
+    // Clean up project-scoped cooldowns if no other session uses this project
+    let projectStillActive = false;
+    for (const [, s] of sessions) {
+      if (s.projectPath === state.projectPath) {
+        projectStillActive = true;
+        break;
+      }
+    }
+    if (!projectStillActive) {
+      consolidationCooldown.delete(state.projectPath);
+    }
+
+    evicted++;
+  }
+
+  return evicted;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/test/eviction.test.ts
+++ b/packages/gateway/test/eviction.test.ts
@@ -1,13 +1,9 @@
 /**
  * Tests for idle session eviction.
  *
- * Validates that:
- * - The idle scheduler fires eviction after the configured timeout
- * - Sub-agent sessions use the shorter eviction timeout
- * - Eviction is disabled when timeout is 0
- * - Gradient session eviction works
- * - Auth/cost cleanup functions work
- * - Session-limiter eviction is wired up
+ * Uses the extracted `evictIdleSessions()` function directly — no timer
+ * involvement — to verify the full eviction pipeline: guards, persistence,
+ * cleanup, and consolidation cooldown removal.
  */
 import { describe, test, expect, beforeEach } from "bun:test";
 import {
@@ -31,7 +27,7 @@ import {
   distillLimiter,
   curatorLimiter,
 } from "@loreai/core";
-import { startIdleScheduler } from "../src/idle";
+import { startIdleScheduler, evictIdleSessions } from "../src/idle";
 import { loadConfig } from "../src/config";
 import type { GatewayConfig } from "../src/config";
 import type { SessionState } from "../src/translate/types";
@@ -78,6 +74,8 @@ function makeSessionState(overrides?: Partial<SessionState>): SessionState {
   };
 }
 
+const EMPTY_SET = new Set<string>();
+
 // ---------------------------------------------------------------------------
 // Setup
 // ---------------------------------------------------------------------------
@@ -106,7 +104,6 @@ describe("session cleanup helpers", () => {
 
   test("evictGradientSession does not throw for unknown sessions", () => {
     expect(inspectSessionState("grad-evict-sess")).toBeNull();
-    // Should not throw
     evictGradientSession("grad-evict-sess");
     expect(inspectSessionState("grad-evict-sess")).toBeNull();
   });
@@ -139,12 +136,11 @@ describe("sessionEvictionTimeoutSeconds config", () => {
 });
 
 // ---------------------------------------------------------------------------
-// startIdleScheduler eviction — integration tests
+// evictIdleSessions — integration tests (no timers needed)
 // ---------------------------------------------------------------------------
 
-describe("idle scheduler eviction", () => {
-  test("evicts sessions past the eviction timeout via onEvict callback", () => {
-    const evicted: string[] = [];
+describe("evictIdleSessions", () => {
+  test("evicts sessions past the eviction timeout", () => {
     const sessions = new Map<string, SessionState>();
     sessions.set("idle-sess", makeSessionState({
       sessionID: "idle-sess",
@@ -156,96 +152,215 @@ describe("idle scheduler eviction", () => {
     }));
 
     const config = makeConfig({ sessionEvictionTimeoutSeconds: 1800 });
+    const evicted = evictIdleSessions(config, sessions, EMPTY_SET, EMPTY_SET, Date.now());
 
-    // The eviction logic runs inside the 30s setInterval. We can't easily
-    // trigger it in a unit test, but we CAN verify the timeout arithmetic
-    // and callback type are correct:
-    const evictionTimeoutMs = config.sessionEvictionTimeoutSeconds * 1000;
-
-    // idle-sess: 33min idle > 30min timeout → should be evicted
-    const idleState = sessions.get("idle-sess")!;
-    expect(Date.now() - idleState.lastRequestTime).toBeGreaterThan(evictionTimeoutMs);
-
-    // active-sess: 5s idle < 30min timeout → should NOT be evicted
-    const activeState = sessions.get("active-sess")!;
-    expect(Date.now() - activeState.lastRequestTime).toBeLessThan(evictionTimeoutMs);
-
-    // Verify startIdleScheduler accepts the callback and returns a cleanup fn
-    const stop = startIdleScheduler(
-      config,
-      sessions,
-      async () => {},
-      (sid) => { evicted.push(sid); },
-    );
-    stop();
-    expect(typeof stop).toBe("function");
+    expect(evicted).toBe(1);
+    expect(sessions.has("idle-sess")).toBe(false);
+    expect(sessions.has("active-sess")).toBe(true);
   });
 
-  test("sub-agent sessions use shorter eviction timeout (5 min)", () => {
+  test("calls onEvict callback for each evicted session", () => {
+    const sessions = new Map<string, SessionState>();
+    sessions.set("sess-a", makeSessionState({
+      sessionID: "sess-a",
+      lastRequestTime: Date.now() - 2_000_000,
+    }));
+    sessions.set("sess-b", makeSessionState({
+      sessionID: "sess-b",
+      lastRequestTime: Date.now() - 2_000_000,
+    }));
+
+    const evictedIds: string[] = [];
     const config = makeConfig({ sessionEvictionTimeoutSeconds: 1800 });
-    const evictionTimeoutMs = config.sessionEvictionTimeoutSeconds * 1000;
-    const subagentEvictionTimeoutMs = Math.min(evictionTimeoutMs, 5 * 60 * 1000);
+    const evicted = evictIdleSessions(
+      config, sessions, EMPTY_SET, EMPTY_SET, Date.now(),
+      (sid) => { evictedIds.push(sid); },
+    );
 
-    // Sub-agent at 6min > 5min sub-agent timeout → should be evicted
-    const subagentAge = 6 * 60 * 1000;
-    expect(subagentAge).toBeGreaterThan(subagentEvictionTimeoutMs);
-
-    // But 6min < 30min regular timeout → regular session should NOT be evicted
-    expect(subagentAge).toBeLessThan(evictionTimeoutMs);
+    expect(evicted).toBe(2);
+    expect(evictedIds).toContain("sess-a");
+    expect(evictedIds).toContain("sess-b");
+    expect(sessions.size).toBe(0);
   });
 
-  test("sub-agent timeout is capped by configurable timeout when lower", () => {
-    // If user sets eviction to 2 min, sub-agents should use 2 min (not 5 min)
+  test("cleans up auth credentials on eviction", () => {
+    setSessionAuth("auth-evict", { scheme: "bearer", value: "tok-abc" });
+    expect(getSessionAuth("auth-evict")).not.toBeNull();
+
+    const sessions = new Map<string, SessionState>();
+    sessions.set("auth-evict", makeSessionState({
+      sessionID: "auth-evict",
+      lastRequestTime: Date.now() - 2_000_000,
+    }));
+
+    const config = makeConfig({ sessionEvictionTimeoutSeconds: 1800 });
+    evictIdleSessions(config, sessions, EMPTY_SET, EMPTY_SET, Date.now());
+
+    expect(getSessionAuth("auth-evict")).toBeNull();
+    expect(sessions.has("auth-evict")).toBe(false);
+  });
+
+  test("cleans up session-limiter instances on eviction", () => {
+    // Create limiter instances for the session
+    const distillOriginal = distillLimiter.get("limiter-evict");
+    const curatorOriginal = curatorLimiter.get("limiter-evict");
+
+    const sessions = new Map<string, SessionState>();
+    sessions.set("limiter-evict", makeSessionState({
+      sessionID: "limiter-evict",
+      lastRequestTime: Date.now() - 2_000_000,
+    }));
+
+    const config = makeConfig({ sessionEvictionTimeoutSeconds: 1800 });
+    evictIdleSessions(config, sessions, EMPTY_SET, EMPTY_SET, Date.now());
+
+    // After eviction, .get() should return a new (different) instance
+    expect(distillLimiter.get("limiter-evict")).not.toBe(distillOriginal);
+    expect(curatorLimiter.get("limiter-evict")).not.toBe(curatorOriginal);
+  });
+
+  test("sub-agent sessions evict after 5 minutes", () => {
+    const sessions = new Map<string, SessionState>();
+    sessions.set("subagent-old", makeSessionState({
+      sessionID: "subagent-old",
+      isSubagent: true,
+      lastRequestTime: Date.now() - 6 * 60 * 1000, // 6 min ago
+    }));
+    sessions.set("subagent-recent", makeSessionState({
+      sessionID: "subagent-recent",
+      isSubagent: true,
+      lastRequestTime: Date.now() - 3 * 60 * 1000, // 3 min ago
+    }));
+    sessions.set("regular-6min", makeSessionState({
+      sessionID: "regular-6min",
+      lastRequestTime: Date.now() - 6 * 60 * 1000, // 6 min ago — NOT evicted (< 30min)
+    }));
+
+    const config = makeConfig({ sessionEvictionTimeoutSeconds: 1800 });
+    const evicted = evictIdleSessions(config, sessions, EMPTY_SET, EMPTY_SET, Date.now());
+
+    expect(evicted).toBe(1);
+    expect(sessions.has("subagent-old")).toBe(false);    // 6min > 5min → evicted
+    expect(sessions.has("subagent-recent")).toBe(true);   // 3min < 5min → kept
+    expect(sessions.has("regular-6min")).toBe(true);       // 6min < 30min → kept
+  });
+
+  test("sub-agent timeout capped by configurable timeout when lower", () => {
+    const sessions = new Map<string, SessionState>();
+    sessions.set("subagent", makeSessionState({
+      sessionID: "subagent",
+      isSubagent: true,
+      lastRequestTime: Date.now() - 3 * 60 * 1000, // 3 min ago
+    }));
+
+    // Config timeout is 2 min — lower than the 5 min sub-agent constant
     const config = makeConfig({ sessionEvictionTimeoutSeconds: 120 });
-    const evictionTimeoutMs = config.sessionEvictionTimeoutSeconds * 1000;
-    const subagentEvictionTimeoutMs = Math.min(evictionTimeoutMs, 5 * 60 * 1000);
+    const evicted = evictIdleSessions(config, sessions, EMPTY_SET, EMPTY_SET, Date.now());
 
-    expect(subagentEvictionTimeoutMs).toBe(120 * 1000); // 2 min, not 5 min
+    // 3 min > 2 min → evicted (Math.min picks the config value)
+    expect(evicted).toBe(1);
+    expect(sessions.has("subagent")).toBe(false);
   });
 
-  test("eviction disabled when timeout is 0", () => {
-    const config = makeConfig({ sessionEvictionTimeoutSeconds: 0 });
-
+  test("does not evict when timeout is 0 (disabled)", () => {
     const sessions = new Map<string, SessionState>();
     sessions.set("old-sess", makeSessionState({
       sessionID: "old-sess",
-      lastRequestTime: Date.now() - 999_999_999, // very old
+      lastRequestTime: Date.now() - 999_999_999,
     }));
 
-    const evicted: string[] = [];
-    const stop = startIdleScheduler(
-      config,
-      sessions,
-      async () => {},
-      (sid) => { evicted.push(sid); },
-    );
-    stop();
+    const config = makeConfig({ sessionEvictionTimeoutSeconds: 0 });
+    const evicted = evictIdleSessions(config, sessions, EMPTY_SET, EMPTY_SET, Date.now());
 
-    // The evictionTimeoutMs is 0, so the `break` guard fires immediately.
-    // Verify the guard logic: 0 <= 0 is true → loop breaks without evicting.
-    expect(config.sessionEvictionTimeoutSeconds * 1000).toBeLessThanOrEqual(0);
+    expect(evicted).toBe(0);
+    expect(sessions.has("old-sess")).toBe(true);
   });
 
-  test("accepts startIdleScheduler without eviction callback", () => {
+  test("does not evict sessions with in-flight idle work", () => {
+    const sessions = new Map<string, SessionState>();
+    sessions.set("busy-sess", makeSessionState({
+      sessionID: "busy-sess",
+      lastRequestTime: Date.now() - 2_000_000,
+    }));
+
+    const inProgress = new Set(["busy-sess"]);
+    const config = makeConfig({ sessionEvictionTimeoutSeconds: 1800 });
+    const evicted = evictIdleSessions(config, sessions, inProgress, EMPTY_SET, Date.now());
+
+    expect(evicted).toBe(0);
+    expect(sessions.has("busy-sess")).toBe(true);
+  });
+
+  test("does not evict sessions with in-flight warmup", () => {
+    const sessions = new Map<string, SessionState>();
+    sessions.set("warming-sess", makeSessionState({
+      sessionID: "warming-sess",
+      lastRequestTime: Date.now() - 2_000_000,
+    }));
+
+    const warmupInProgress = new Set(["warming-sess"]);
+    const config = makeConfig({ sessionEvictionTimeoutSeconds: 1800 });
+    const evicted = evictIdleSessions(config, sessions, EMPTY_SET, warmupInProgress, Date.now());
+
+    expect(evicted).toBe(0);
+    expect(sessions.has("warming-sess")).toBe(true);
+  });
+
+  test("does not evict sessions still executing tools", () => {
+    const sessions = new Map<string, SessionState>();
+    sessions.set("tool-sess", makeSessionState({
+      sessionID: "tool-sess",
+      lastRequestTime: Date.now() - 2_000_000,
+      lastStopReason: "tool_use",
+    }));
+
+    const config = makeConfig({ sessionEvictionTimeoutSeconds: 1800 });
+    const evicted = evictIdleSessions(config, sessions, EMPTY_SET, EMPTY_SET, Date.now());
+
+    expect(evicted).toBe(0);
+    expect(sessions.has("tool-sess")).toBe(true);
+  });
+
+  test("returns count of evicted sessions", () => {
+    const sessions = new Map<string, SessionState>();
+    for (let i = 0; i < 5; i++) {
+      sessions.set(`sess-${i}`, makeSessionState({
+        sessionID: `sess-${i}`,
+        lastRequestTime: Date.now() - 2_000_000,
+      }));
+    }
+    sessions.set("active", makeSessionState({
+      sessionID: "active",
+      lastRequestTime: Date.now(),
+    }));
+
+    const config = makeConfig({ sessionEvictionTimeoutSeconds: 1800 });
+    const evicted = evictIdleSessions(config, sessions, EMPTY_SET, EMPTY_SET, Date.now());
+
+    expect(evicted).toBe(5);
+    expect(sessions.size).toBe(1);
+    expect(sessions.has("active")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// startIdleScheduler — compatibility tests
+// ---------------------------------------------------------------------------
+
+describe("startIdleScheduler", () => {
+  test("accepts optional onEvict callback", () => {
     const sessions = new Map<string, SessionState>();
     const config = makeConfig();
-
-    // 4th param is optional — should not throw
     const stop = startIdleScheduler(config, sessions, async () => {});
     stop();
   });
 
-  test("onEvict callback signature matches idle scheduler", () => {
+  test("accepts onEvict callback without error", () => {
     const sessions = new Map<string, SessionState>();
     const config = makeConfig();
-    const evictCalled: string[] = [];
-
-    // Verify the callback type is compatible
     const stop = startIdleScheduler(
-      config,
-      sessions,
-      async () => {},
-      (sessionID: string) => { evictCalled.push(sessionID); },
+      config, sessions, async () => {},
+      (_sid) => {},
     );
     stop();
     expect(typeof stop).toBe("function");


### PR DESCRIPTION
Follow-up to #478 — addresses two findings from post-merge review.

## Changes

### 1. Extract `evictIdleSessions()` for testability
The eviction logic was embedded inside a `setInterval` callback, making it impossible to test without waiting 30s or using fake timers. Extracted into a standalone exported function that takes all its dependencies as parameters:

```typescript
export function evictIdleSessions(
  config, sessions, inProgress, warmupInProgress, now, onEvict?
): number
```

The scheduler calls it on each tick. Tests call it directly. Returns the count of evicted sessions.

### 2. Clean up `consolidationCooldown` on project orphaning
`consolidationCooldown` is keyed by `projectPath`. When all sessions for a project are evicted, the cooldown entry now gets cleaned up. Previously it leaked one entry per distinct project that ever connected — unbounded growth on long-running gateways.

### 3. Rewritten eviction tests (17 tests, all integration)
Tests now call `evictIdleSessions()` directly and verify real behavior:
- Session removed from Map after eviction
- `onEvict` callback fired for each evicted session
- Auth credentials cleaned up
- Session-limiter p-limit instances evicted (identity check)
- Sub-agent 5-min fast eviction
- Sub-agent timeout capped when config is lower
- Eviction disabled when timeout = 0
- In-flight idle work guard
- In-flight warmup guard
- `tool_use` stop-reason guard
- Correct eviction count returned

## Files changed

| File | Change |
|------|--------|
| `packages/gateway/src/idle.ts` | Extract `evictIdleSessions()`, add cooldown cleanup |
| `packages/gateway/test/eviction.test.ts` | Rewrite as integration tests using extracted function |