### PR TITLE
feat: worker credential routing and custom upstream

### DIFF
--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -56,6 +56,22 @@ export interface GatewayConfig {
    * lat.md/ directory scan, file watchers). Env: LORE_HOSTED_MODE.
    */
   hostedMode: boolean;
+  /**
+   * Standalone API key for background worker calls (distillation, curation,
+   * consolidation, etc.). When set, workers authenticate with this key
+   * instead of the session's client credential — enabling workers to use
+   * a different provider (e.g. MiniMax) than the session's Anthropic key.
+   * Env: LORE_WORKER_API_KEY
+   */
+  workerApiKey?: string;
+  /**
+   * Custom upstream URL for background worker calls. When set, all worker
+   * HTTP calls route to this URL instead of the default upstream URLs.
+   * Enables routing workers to a different provider (e.g. MiniMax's
+   * Anthropic-compatible endpoint) while sessions continue using Anthropic.
+   * Env: LORE_WORKER_UPSTREAM
+   */
+  workerUpstream?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -82,6 +98,10 @@ export function loadConfig(): GatewayConfig {
       ? trimTrailingSlash(env.LORE_REMOTE_URL)
       : undefined,
     hostedMode: isTruthy(env.LORE_HOSTED_MODE),
+    workerApiKey: env.LORE_WORKER_API_KEY || undefined,
+    workerUpstream: env.LORE_WORKER_UPSTREAM
+      ? trimTrailingSlash(env.LORE_WORKER_UPSTREAM)
+      : undefined,
   };
 }
 

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -128,6 +128,7 @@ import {
   setLastSeenAuth,
   setSessionAuth,
   resolveAuth,
+  type AuthCredential,
 } from "./auth";
 import type { UpstreamInterceptor } from "./recorder";
 import { startIdleScheduler, buildIdleWorkHandler } from "./idle";
@@ -803,9 +804,33 @@ function getLLMClient(config: GatewayConfig): LLMClient {
       providerID: "anthropic",
       modelID: "claude-sonnet-4-6",
     };
+
+    // Worker-specific auth: when LORE_WORKER_API_KEY is set, workers use a
+    // dedicated credential instead of the session's client key. This enables
+    // routing workers to a different provider (e.g. MiniMax) while sessions
+    // continue using Anthropic. Falls back to session auth when not set.
+    const getWorkerAuth: (sessionID?: string) => AuthCredential | null =
+      config.workerApiKey
+        ? () => ({ scheme: "api-key", value: config.workerApiKey! })
+        : resolveAuth;
+
+    // Worker-specific upstream: when LORE_WORKER_UPSTREAM is set, all worker
+    // calls route to this URL instead of the default upstream URLs.
+    const workerUpstreams = config.workerUpstream
+      ? { anthropic: config.workerUpstream, openai: config.workerUpstream }
+      : { anthropic: config.upstreamAnthropic, openai: config.upstreamOpenAI };
+
+    if (config.workerApiKey || config.workerUpstream) {
+      log.info(
+        `worker routing: ` +
+        `auth=${config.workerApiKey ? "dedicated key" : "session"}, ` +
+        `upstream=${config.workerUpstream ?? "default"}`,
+      );
+    }
+
     const inner = createGatewayLLMClient(
-      { anthropic: config.upstreamAnthropic, openai: config.upstreamOpenAI },
-      resolveAuth,
+      workerUpstreams,
+      getWorkerAuth,
       defaultModel,
     );
 
@@ -821,8 +846,8 @@ function getLLMClient(config: GatewayConfig): LLMClient {
     } else {
       llmClient = createBatchLLMClient(
         inner,
-        { anthropic: config.upstreamAnthropic, openai: config.upstreamOpenAI },
-        resolveAuth,
+        workerUpstreams,
+        getWorkerAuth,
         defaultModel,
       );
       batchQueueEnabled = true;

--- a/packages/gateway/src/worker-model.ts
+++ b/packages/gateway/src/worker-model.ts
@@ -299,6 +299,20 @@ function resolveGitHubCopilotWorker(sessionModelID: string): { providerID: strin
  *  4. Config model fallback (session model)
  */
 export function getWorkerModel(): { providerID: string; modelID: string } | undefined {
+  // Env var override — highest priority. Useful for global worker model
+  // configuration without per-project .lore.json (e.g. routing all workers
+  // to MiniMax). Format: "providerID/modelID" or just "modelID" (defaults
+  // to anthropic provider).
+  const envModel = process.env.LORE_WORKER_MODEL;
+  if (envModel) {
+    const slashIdx = envModel.indexOf("/");
+    if (slashIdx > 0) {
+      return { providerID: envModel.slice(0, slashIdx), modelID: envModel.slice(slashIdx + 1) };
+    }
+    // No slash — assume anthropic provider (most common case)
+    return { providerID: "anthropic", modelID: envModel };
+  }
+
   const cfg = loreConfig();
 
   // Determine if the session model is expensive enough to warrant a cheaper worker


### PR DESCRIPTION
## Summary

Adds independent configuration for background worker LLM calls (distillation, curation, consolidation, query expansion). Workers can now use a different API key, upstream URL, and model than the session's client — enabling setups like "foreground uses Anthropic Opus, background uses MiniMax" without code changes.

Motivated by Onur's MiniMax integration: background workers inherit the session's Anthropic key, which 401s at MiniMax. This PR solves the credential routing gap documented in the "Gateway auth: single credential per session" architecture entry.

## New Environment Variables

| Env Var | Purpose | Example |
|---|---|---|
| `LORE_WORKER_API_KEY` | Standalone API key for worker calls. Workers use this instead of the session's credential. | `<minimax-token-plan-key>` |
| `LORE_WORKER_UPSTREAM` | Custom upstream URL for worker HTTP calls. All workers route here instead of default upstreams. | `https://api.minimax.io/anthropic` |
| `LORE_WORKER_MODEL` | Override worker model name. Highest priority in the resolution chain. Format: `modelID` or `providerID/modelID`. | `MiniMax-M2.7` or `anthropic/MiniMax-M2.7` |

## Onur's MiniMax Setup

With these env vars, Onur's configuration becomes:
```bash
export LORE_WORKER_API_KEY="<minimax-key>"
export LORE_WORKER_UPSTREAM="https://api.minimax.io/anthropic"
export LORE_WORKER_MODEL="MiniMax-M2.7"
```

Result: background workers always authenticate with the MiniMax key and route to MiniMax's endpoint, regardless of whether the foreground session is using Opus or MiniMax.

## Design

The implementation leverages the existing dependency injection architecture — `getAuth` and `upstreams` are already injected as callbacks/objects at client construction time. The single construction site (`getLLMClient()` in pipeline.ts) is the only place that needed modification:

- **`config.ts`**: Added `workerApiKey?` and `workerUpstream?` to `GatewayConfig`
- **`pipeline.ts`**: In `getLLMClient()`, computes `getWorkerAuth` callback and `workerUpstreams` object, passes them to both `createGatewayLLMClient()` and `createBatchLLMClient()`
- **`worker-model.ts`**: In `getWorkerModel()`, checks `LORE_WORKER_MODEL` env var before config-file and cost-aware defaults

Zero changes in `@loreai/core`, `auth.ts`, `llm-adapter.ts`, `batch-queue.ts`, or `idle.ts`.