### PR TITLE
fix: OpenAI Responses API gateway translation (builds on #483)

### DIFF
--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -1871,7 +1871,7 @@ function accumulateOpenAINonStreamJSON(json: Record<string, unknown>): GatewayRe
   };
 }
 
-function accumulateResponsesNonStreamJSON(json: Record<string, unknown>): GatewayResponse {
+export function accumulateResponsesNonStreamJSON(json: Record<string, unknown>): GatewayResponse {
   const content: GatewayContentBlock[] = [];
   const output = json.output as Array<Record<string, unknown>> | undefined;
 

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -22,7 +22,7 @@ import {
   buildOpenAIResponsesResponse,
 } from "./translate/openai-responses";
 import { translateAnthropicStreamToResponses } from "./stream/openai-responses";
-import { handleRequest, handleCompactEndpoint } from "./pipeline";
+import { handleRequest, handleCompactEndpoint, accumulateResponsesNonStreamJSON } from "./pipeline";
 
 // ---------------------------------------------------------------------------
 // Version — best-effort from package.json, falls back gracefully
@@ -245,14 +245,33 @@ async function handleOpenAIResponses(
 
   const contentType = pipelineResp.headers.get("content-type") ?? "";
   if (contentType.includes("text/event-stream")) {
-    // True streaming: translate Anthropic SSE → Responses API SSE incrementally
+    // Pipeline returned SSE. This can be either:
+    //  a) Anthropic SSE from normal conversation turns → needs translation
+    //  b) Raw OpenAI Responses SSE from passthrough → forward as-is
+    // Detect by peeking at the x-lore-upstream-protocol header (set by
+    // passthrough) or by checking the original request protocol.
+    if (gatewayReq.protocol === "openai-responses") {
+      // For passthrough: the SSE is already in Responses API format,
+      // just forward it directly. For normal turns: the pipeline converts
+      // openai-responses to non-streaming internally (accumulateResponsesSSEStream),
+      // so we never get Anthropic SSE for openai-responses protocol.
+      return withCors(pipelineResp);
+    }
+    // Anthropic SSE → translate to Responses API SSE
     return withCors(translateAnthropicStreamToResponses(pipelineResp));
   }
 
-  // Non-streaming: translate Anthropic wire JSON → GatewayResponse → Responses API
-  const respBody = await pipelineResp.json();
-  const gatewayResp = parseAnthropicResponseJSON(respBody as Record<string, unknown>);
-  return withCors(buildOpenAIResponsesResponse(gatewayResp, false));
+  // Non-streaming: translate pipeline JSON → GatewayResponse → Responses API.
+  // The pipeline may return either Anthropic-format JSON (normal conversation turns
+  // go through accumulate→nonStreamHttpResponse) or raw OpenAI Responses API JSON
+  // (meta/passthrough requests forward the upstream response as-is). Detect which
+  // format we received and parse accordingly.
+  const respBody = await pipelineResp.json() as Record<string, unknown>;
+  const isRawResponsesFormat = respBody.object === "response" && Array.isArray(respBody.output);
+  const gatewayResp = isRawResponsesFormat
+    ? accumulateResponsesNonStreamJSON(respBody)
+    : parseAnthropicResponseJSON(respBody);
+  return withCors(buildOpenAIResponsesResponse(gatewayResp, gatewayReq.stream));
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/pi/src/index.ts
+++ b/packages/pi/src/index.ts
@@ -41,11 +41,12 @@ type SessionBeforeCompactResult = {
 };
 
 /**
- * Providers whose wire protocol the Lore gateway can proxy.
+ * Providers whose wire protocol the Lore gateway can proxy, split by SDK
+ * protocol so we can set the correct `baseUrl` for each group.
  *
- * - anthropic-messages API → gateway POST /v1/messages
- * - openai-completions API → gateway POST /v1/chat/completions
- * - openai-responses API   → gateway POST /v1/responses
+ * - Anthropic SDK appends `/v1/messages` to baseURL → pass gateway root.
+ * - OpenAI SDK appends `/chat/completions` or `/responses` to baseURL
+ *   and expects it to already include `/v1` → pass `${gateway}/v1`.
  *
  * Providers using other protocols (Google SDK, AWS Bedrock SDK,
  * Mistral conversations) are not redirected.
@@ -55,11 +56,16 @@ type SessionBeforeCompactResult = {
  * where to forward requests. Cloud providers are routed automatically by
  * model name prefix.
  */
-const GATEWAY_PROVIDERS = [
-  // anthropic-messages API
+
+/** Anthropic-messages API → gateway POST /v1/messages */
+const ANTHROPIC_PROVIDERS = [
   "anthropic",
   "fireworks",
   "github-copilot",
+] as const;
+
+/** OpenAI-completions / OpenAI-responses API → gateway POST /v1/chat/completions or /v1/responses */
+const OPENAI_PROVIDERS = [
   // openai-completions API
   "deepseek",
   "xai",
@@ -84,7 +90,10 @@ const GATEWAY_PROVIDERS = [
   "tgi",
   "tabbyml",
   "litellm",
-];
+] as const;
+
+/** All providers that can be routed through the gateway. */
+const GATEWAY_PROVIDERS: readonly string[] = [...ANTHROPIC_PROVIDERS, ...OPENAI_PROVIDERS];
 
 /** Default ports to probe when looking for a running gateway (must match gateway defaults). */
 const KNOWN_GATEWAY_PORTS = [3207, 5673];
@@ -253,6 +262,14 @@ export default async function lorePiExtension(pi: ExtensionAPI): Promise<void> {
     const remote = getGitRemote(projectPath);
     if (remote) baseHeaders["x-lore-git-remote"] = remote;
 
+    // Anthropic SDK appends `/v1/messages` to baseURL — pass gateway root.
+    const anthropicBase = gatewayBase;
+    // OpenAI SDK expects baseURL to already include `/v1` — it only appends
+    // `/chat/completions` or `/responses`. Matches the pattern in agents.ts.
+    const openaiBase = `${gatewayBase}/v1`;
+
+    const anthropicSet: ReadonlySet<string> = new Set(ANTHROPIC_PROVIDERS);
+
     for (const provider of GATEWAY_PROVIDERS) {
       const headers = { ...baseHeaders };
       // For local/custom providers, inject the original upstream URL so the
@@ -263,7 +280,8 @@ export default async function lorePiExtension(pi: ExtensionAPI): Promise<void> {
       if (upstream) {
         headers["x-lore-upstream-url"] = upstream;
       }
-      pi.registerProvider(provider, { baseUrl: gatewayBase, headers });
+      const baseUrl = anthropicSet.has(provider) ? anthropicBase : openaiBase;
+      pi.registerProvider(provider, { baseUrl, headers });
     }
   }
 


### PR DESCRIPTION
## Problem

Even after #483 fixes the Pi extension's URL routing, two gateway bugs prevent the OpenAI Responses API from actually working end-to-end:

1. **Empty `output: []` on non-streaming responses** — `handleOpenAIResponses` assumes the pipeline always returns Anthropic-format JSON. But meta/passthrough requests (`isMetaRequest`) forward raw OpenAI Responses JSON which has `output` not `content` at top level → `parseAnthropicResponseJSON` finds nothing → empty output.

2. **Streaming responses hang** — For streaming passthrough, raw OpenAI SSE is fed to `translateAnthropicStreamToResponses` which expects Anthropic SSE format → client SDK hangs waiting for events it can parse.

This PR includes the Pi extension fix from #483 so it can be tested standalone, but the gateway changes are the new work.

## Root Cause

`isMetaRequest` classifies simple requests (few messages, no tools, short system prompt) as title-gen/summary requests and routes them through `handlePassthrough`, which forwards the upstream response as-is without format translation. This works for Anthropic clients, but breaks OpenAI Responses API clients because:
- Non-streaming: raw OpenAI JSON (`{object: "response", output: [...]}`) gets parsed by `parseAnthropicResponseJSON` which looks for `content` → empty
- Streaming: raw OpenAI SSE (`response.output_text.delta`) gets fed to `translateAnthropicStreamToResponses` which expects Anthropic SSE (`content_block_delta`) → hangs

## Fix

### `packages/gateway/src/server.ts`
- **Non-streaming**: detect response format (`object === "response"` → raw Responses API) and use `accumulateResponsesNonStreamJSON` instead of `parseAnthropicResponseJSON`
- **Streaming**: when `protocol === "openai-responses"`, forward SSE directly instead of translating from Anthropic SSE
- Pass `gatewayReq.stream` to `buildOpenAIResponsesResponse` so streaming requests get SSE events

### `packages/gateway/src/pipeline.ts`
- Export `accumulateResponsesNonStreamJSON` for use in server.ts

### `packages/pi/src/index.ts` (from #483)
- Protocol-aware `baseUrl` for provider registration

## Testing

Verified with curl and E2E in Pi with `gpt-4.1-nano` through the gateway:
- Non-streaming: `output` now contains response message ✅
- Streaming: full SSE event stream with proper events ✅
- Multi-turn conversation works ✅
- All 1939 existing tests pass