### PR TITLE
docs: add 'Your tools change. Your memory doesn't.' tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 > **Experimental** — Under active development. APIs, storage format, and behavior may change.
 
-**Stop re-explaining your project to your AI.** Your AI forgets decisions, loses file paths, and undoes its own work. Lore fixes this automatically — no context files to maintain, no workflow changes.
+**Stop re-explaining your project to your AI.** Your tools change. Your memory doesn't.
+
+Your AI forgets decisions, loses file paths, and undoes its own work. Lore fixes this automatically — no context files to maintain, no workflow changes.
 
 Lore is a transparent LLM proxy that adds three-tier memory to any AI coding agent. Context management and long-term memory aren't separate problems — they're one continuous pipeline. Distillation feeds the gradient context manager, which feeds the knowledge curator, which feeds `.lore.md`, and with Lore Cloud *(coming soon)*, your team.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -906,7 +906,8 @@
         your project to<br>
         <em>your AI.</em>
       </h1>
-      <p class="hero-desc sr">Your AI forgets decisions, loses file paths, and undoes its own work — worse with every turn.
+      <p class="hero-desc sr">Your tools change. Your memory doesn't. Your AI forgets decisions, loses file paths,
+        and undoes its own work — worse with every turn.
         Lore gives it crystal-clear memory across sessions lasting days, hundreds of turns, any LLM provider.
         No context files to maintain. No workflow changes.</p>
       <div class="hero-install sr">
@@ -970,13 +971,13 @@
     <div class="ticker-track">
       <span class="ti">2.3M tokens, 5 days, 2.6x total recall <span class="td">&#9670;</span> Compaction: 2.4/5. Lore: 4.0/5.</span>
       <span class="ti">68 min/day re-explaining <span class="td">&#9670;</span> Lore remembers for you</span>
-      <span class="ti">Any provider, any tool <span class="td">&#9670;</span> Portable memory that travels with you</span>
+      <span class="ti">Your tools change. Your memory doesn't. <span class="td">&#9670;</span> Lore is your constant</span>
       <span class="ti">Total amnesia on new sessions <span class="td">&#9670;</span> Lore persists across sessions</span>
       <span class="ti">49 manual learnings <span class="td">&#9670;</span> Lore curates automatically</span>
       <span class="ti">5 feedback loops <span class="td">&#9670;</span> Your agent improves every session</span>
       <span class="ti">2.3M tokens, 5 days, 2.6x total recall <span class="td">&#9670;</span> Compaction: 2.4/5. Lore: 4.0/5.</span>
       <span class="ti">68 min/day re-explaining <span class="td">&#9670;</span> Lore remembers for you</span>
-      <span class="ti">Any provider, any tool <span class="td">&#9670;</span> Portable memory that travels with you</span>
+      <span class="ti">Your tools change. Your memory doesn't. <span class="td">&#9670;</span> Lore is your constant</span>
       <span class="ti">Total amnesia on new sessions <span class="td">&#9670;</span> Lore persists across sessions</span>
       <span class="ti">49 manual learnings <span class="td">&#9670;</span> Lore curates automatically</span>
       <span class="ti">5 feedback loops <span class="td">&#9670;</span> Your agent improves every session</span>
@@ -1164,7 +1165,7 @@
       </div>
       <div class="bc bc-1 sr">
         <p class="bc-tag">Compatibility</p>
-        <h3 class="bc-t">Portable memory, any provider</h3>
+        <h3 class="bc-t">Your constant</h3>
         <p class="bc-b">Claude Code, Cursor, Copilot, Windsurf, OpenCode, Pi, Codex — any tool that speaks
           Anthropic or OpenAI protocols. Switch providers, switch tools, switch machines — your memory travels
           with you. No vendor lock-in, no walled gardens.


### PR DESCRIPTION
## Summary

Adds a secondary tagline emphasizing cross-provider portability — the key differentiator as providers start implementing their own walled-garden memory.

**"Your tools change. Your memory doesn't."**

## Changes

### README.md
- Add tagline as the second line below the primary headline ("Stop re-explaining your project to your AI")

### docs/index.html (withlore.ai)
- Add tagline to the hero description paragraph
- Rename the Compatibility feature card from "Portable memory, any provider" to **"Your constant"** (a cheeky Lost reference that also works literally)
- Replace "Any provider, any tool" ticker item with "Your tools change. Your memory doesn't. / Lore is your constant"

## Follow-up to
- #499 (merged) — RSI/harness self-improvement framing