### PR TITLE
fix: OAuth worker header simulation and proactive batch bypass

### DIFF
--- a/packages/gateway/src/batch-queue.ts
+++ b/packages/gateway/src/batch-queue.ts
@@ -957,10 +957,22 @@ export function createBatchLLMClient(
         return inner.prompt(system, user, opts);
       }
 
-      // Fast-path: if this provider's batch endpoint doesn't exist (404)
-      // or this session's batch access is disabled (403 auth scope), skip
-      // the queue and process synchronously. Without this, calls wait up
-      // to 30s in the queue only to be routed through fallbackAll() at flush time.
+      // Snapshot auth credential at enqueue time for session isolation.
+      // If no credential is available, fall back to synchronous processing
+      // (which will also attempt to resolve auth — matches prior behavior).
+      const cred = getAuth(opts?.sessionID);
+      if (!cred) {
+        totalUrgent++;
+        return inner.prompt(system, user, opts);
+      }
+
+      // Fast-path: if this provider's batch endpoint doesn't exist (404),
+      // this session's batch access is disabled (403 auth scope), or the
+      // credential is an OAuth bearer token (batch API doesn't support OAuth),
+      // skip the queue and process synchronously. Without this, calls wait
+      // up to 30s in the queue only to be routed through fallbackAll() at
+      // flush time — and for bearer tokens, the batch submit always 401s
+      // before falling back to sync anyway.
       const providerID = (opts?.model ?? defaultModel).providerID;
       if (disabledBatchProviders.has(providerID)) {
         totalFallback++;
@@ -970,13 +982,8 @@ export function createBatchLLMClient(
         totalFallback++;
         return inner.prompt(system, user, opts);
       }
-
-      // Snapshot auth credential at enqueue time for session isolation.
-      // If no credential is available, fall back to synchronous processing
-      // (which will also attempt to resolve auth — matches prior behavior).
-      const cred = getAuth(opts?.sessionID);
-      if (!cred) {
-        totalUrgent++;
+      if (cred.scheme === "bearer") {
+        totalFallback++;
         return inner.prompt(system, user, opts);
       }
 

--- a/packages/gateway/src/cch.ts
+++ b/packages/gateway/src/cch.ts
@@ -29,7 +29,7 @@
  * contamination. Mirrors the per-session `sessionAuth` in `auth.ts`.
  */
 
-import { createHash } from "crypto";
+import { createHash, randomUUID } from "crypto";
 
 // ---------------------------------------------------------------------------
 // Version→seed mapping
@@ -248,6 +248,102 @@ export function buildBillingBlock(
 /** Drop billing state for a session (used by session eviction). */
 export function deleteBillingPrefix(sessionID: string): void {
   sessionNeedsBilling.delete(sessionID);
+  sessionHeaderSnapshots.delete(sessionID);
+}
+
+// ---------------------------------------------------------------------------
+// Claude Code header sniffing & simulation for OAuth worker calls
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal beta set for worker calls on OAuth sessions.
+ * Workers send simple single-turn requests (no tools, no thinking, no
+ * structured output) so only the base betas are needed. This matches
+ * CortexKit's CLAUDE_CODE_BASE_BETAS for non-agent requests.
+ *
+ * NOTE: `extended-cache-ttl-2025-04-11` is included so workers' 1h TTL
+ * cache_control breakpoints are actually honored by the API.
+ */
+const WORKER_BETAS = [
+  "oauth-2025-04-20",
+  "interleaved-thinking-2025-05-14",
+  "extended-cache-ttl-2025-04-11",
+].join(",");
+
+/**
+ * Per-session snapshot of headers observed on conversation turns.
+ *
+ * When the gateway sees a conversation turn from a Claude Code OAuth
+ * session, it captures the `anthropic-beta` and `user-agent` values.
+ * Worker calls for that session replay these headers so Anthropic sees
+ * a consistent client fingerprint. Without this, worker calls using
+ * OAuth tokens may be rejected because they lack the expected header set.
+ *
+ * Only populated for bearer-token sessions that have billing headers
+ * (i.e. Claude Code OAuth). API-key sessions don't need this.
+ */
+type SessionHeaderSnapshot = {
+  /** The anthropic-beta header from the last conversation turn. */
+  anthropicBeta?: string;
+  /** The user-agent header from the last conversation turn. */
+  userAgent?: string;
+};
+
+const sessionHeaderSnapshots = new Map<string, SessionHeaderSnapshot>();
+
+/**
+ * Capture Claude Code headers from a conversation turn for later replay
+ * on worker calls. Called alongside `captureBillingPrefix()` on each turn.
+ *
+ * Only stores headers for sessions that use billing headers (bearer-token
+ * OAuth). For API-key sessions this is a no-op.
+ */
+export function captureSessionHeaders(
+  sessionID: string,
+  rawHeaders: Record<string, string>,
+): void {
+  // Only capture for sessions that have billing headers
+  if (!sessionNeedsBilling.get(sessionID)) return;
+
+  const snapshot: SessionHeaderSnapshot = {};
+
+  const beta = rawHeaders["anthropic-beta"] || rawHeaders["Anthropic-Beta"];
+  if (beta) snapshot.anthropicBeta = beta;
+
+  const ua = rawHeaders["user-agent"] || rawHeaders["User-Agent"];
+  if (ua) snapshot.userAgent = ua;
+
+  sessionHeaderSnapshots.set(sessionID, snapshot);
+}
+
+/**
+ * Build extra HTTP headers for an Anthropic worker request on an OAuth
+ * session. Returns null for API-key sessions (no extra headers needed).
+ *
+ * For bearer-token sessions, builds the Claude Code header fingerprint:
+ * - `anthropic-beta`: from sniffed session headers, or fallback worker set
+ * - `user-agent`: from sniffed session headers, or fallback Claude Code UA
+ * - `anthropic-dangerous-direct-browser-access`: required for OAuth
+ * - `x-client-request-id`: fresh UUID per request
+ *
+ * This ensures worker calls (distillation, curation) present the same
+ * client fingerprint as conversation turns, avoiding 401 rejections from
+ * Anthropic's OAuth validation.
+ */
+export function buildOAuthWorkerHeaders(
+  sessionID: string | undefined,
+): Record<string, string> | null {
+  if (!sessionID) return null;
+  if (!sessionNeedsBilling.get(sessionID)) return null;
+
+  const snapshot = sessionHeaderSnapshots.get(sessionID);
+
+  return {
+    "anthropic-beta": snapshot?.anthropicBeta || WORKER_BETAS,
+    "user-agent": snapshot?.userAgent || `claude-cli/${WORKER_VERSION} (external, sdk-cli)`,
+    "anthropic-dangerous-direct-browser-access": "true",
+    "x-client-request-id": randomUUID(),
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -389,6 +485,7 @@ export function validateSeed(body: string): boolean | null {
 /** @internal Reset module state for tests. */
 export function _resetForTest(): void {
   sessionNeedsBilling.clear();
+  sessionHeaderSnapshots.clear();
 }
 
 /** @internal Exposed for tests. */

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -18,7 +18,7 @@ import * as Sentry from "@sentry/bun";
 import type { AuthCredential } from "./auth";
 import { authHeaders, markAuthStale } from "./auth";
 import { tripCircuitBreaker } from "./background-limiter";
-import { buildBillingBlock, signBody } from "./cch";
+import { buildBillingBlock, buildOAuthWorkerHeaders, signBody } from "./cch";
 import {
   setGenAiUsageAttributes,
   emitCostMetric,
@@ -237,12 +237,18 @@ function buildAnthropicWorkerRequest(
     body = signBody(body);
   }
 
+  // For OAuth sessions, include Claude Code headers (anthropic-beta,
+  // user-agent, etc.) sniffed from conversation turns. Without these,
+  // Anthropic may reject worker calls with 401 even when the token is valid.
+  const oauthHeaders = buildOAuthWorkerHeaders(sessionID);
+
   return {
     url: `${target.url}/v1/messages`,
     headers: {
       "Content-Type": "application/json",
       "anthropic-version": "2023-06-01",
       ...authHeaders(cred),
+      ...oauthHeaders,
     },
     body,
   };

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -134,7 +134,7 @@ import type { UpstreamInterceptor } from "./recorder";
 import { startIdleScheduler, buildIdleWorkHandler } from "./idle";
 import { getWorkerModel, resetWorkerModelState, fetchModelData, getModelEntrySync } from "./worker-model";
 import * as Sentry from "@sentry/bun";
-import { captureBillingPrefix, hasBillingHeader, resignBody } from "./cch";
+import { captureBillingPrefix, captureSessionHeaders, hasBillingHeader, resignBody } from "./cch";
 import { detectClientType } from "./session";
 import { analyzeCacheTurn, categorizeBust } from "./cache-analytics";
 import {
@@ -2943,6 +2943,11 @@ async function handleConversationTurn(
   // so workers can rebuild it. Per-session storage prevents cross-session
   // contamination when multiple Claude Code versions share one process.
   captureBillingPrefix(sessionID, req.system);
+
+  // Sniff Claude Code headers from conversation turns for replay on worker
+  // calls. For OAuth sessions, workers need the same anthropic-beta and
+  // user-agent headers as conversation turns to avoid 401 rejections.
+  captureSessionHeaders(sessionID, req.rawHeaders);
 
   // Track fingerprint for future correlation
   if (isNew) {


### PR DESCRIPTION
## Summary

Fixes worker call failures for OAuth/bearer-token sessions by proactively bypassing the batch queue and replaying Claude Code headers on worker requests. Addresses LOREAI-GATEWAY-Z (10,726 events, 24 users).

## Problem

OAuth sessions suffered a three-step failure cascade:
1. **Batch API rejects OAuth tokens** — `POST /v1/messages/batches` returns 401 for bearer tokens (only API keys work)
2. **Fallback sync also fails** — the same expired token is used for `POST /v1/messages`
3. **Missing Claude Code headers** — worker calls lacked `anthropic-beta`, `user-agent`, `anthropic-dangerous-direct-browser-access`, and other headers that Anthropic may validate for OAuth requests

## Changes

### Proactive batch bypass (`batch-queue.ts`)
- Detect `cred.scheme === "bearer"` at enqueue time and skip the batch queue entirely
- Avoids the batch→401→fallback→401 chain that generated 10K+ Sentry events
- Moved credential resolution before fast-path checks so the scheme is available

### Claude Code header sniffing (`cch.ts`)
- `captureSessionHeaders()`: sniffs `anthropic-beta` and `user-agent` from conversation turns for OAuth sessions
- `buildOAuthWorkerHeaders()`: builds Claude Code header fingerprint for worker requests:
  - `anthropic-beta` (from sniffed headers or fallback: `oauth-2025-04-20,interleaved-thinking-2025-05-14,extended-cache-ttl-2025-04-11`)
  - `user-agent` (from sniffed headers or fallback Claude Code UA)
  - `anthropic-dangerous-direct-browser-access: true`
  - `x-client-request-id`: fresh UUID per request
- Includes `extended-cache-ttl-2025-04-11` beta so workers' 1h TTL `cache_control` breakpoints are honored

### Worker request headers (`llm-adapter.ts`)
- `buildAnthropicWorkerRequest()` applies OAuth headers via `buildOAuthWorkerHeaders(sessionID)`
- API-key sessions are unaffected (returns null)

### Pipeline wiring (`pipeline.ts`)
- `captureSessionHeaders(sessionID, req.rawHeaders)` called on each conversation turn alongside `captureBillingPrefix()`

## Related

- Closes part of LOREAI-GATEWAY-Z (worker auth errors)
- Filed #501 for upstream quota API integration (follow-up feature)
- Reference: [cortexkit/anthropic-auth](https://github.com/cortexkit/anthropic-auth) for Claude Code header simulation patterns