### PR TITLE
fix(cost): apply batch discount to cache read/write costs

### DIFF
--- a/packages/gateway/src/batch-queue.ts
+++ b/packages/gateway/src/batch-queue.ts
@@ -847,8 +847,8 @@ export function createBatchLLMClient(
                   setGenAiUsageAttributes(span, result.usage!, result.model ?? undefined);
                 },
               );
-              emitCostMetric(pending.params.model, result.usage, "batch");
-              recordWorkerCost(pending.sessionID, pending.params.model, result.usage, "batch", pending.workerID);
+              emitCostMetric(pending.params.model, result.usage, "batch", "1h");
+              recordWorkerCost(pending.sessionID, pending.params.model, result.usage, "batch", pending.workerID, "1h");
             }
 
             pending.resolve(result.text);

--- a/packages/gateway/src/cost-tracker.ts
+++ b/packages/gateway/src/cost-tracker.ts
@@ -538,9 +538,9 @@ export function computeCallCost(
   const inputCost =
     ((usage.input_tokens ?? 0) / 1_000_000) * pricing.input * batchMultiplier;
   const cacheReadCost =
-    ((usage.cache_read_input_tokens ?? 0) / 1_000_000) * pricing.cache_read;
+    ((usage.cache_read_input_tokens ?? 0) / 1_000_000) * pricing.cache_read * batchMultiplier;
   const cacheWriteCost =
-    ((usage.cache_creation_input_tokens ?? 0) / 1_000_000) * cacheWriteRate;
+    ((usage.cache_creation_input_tokens ?? 0) / 1_000_000) * cacheWriteRate * batchMultiplier;
   const outputCost =
     ((usage.output_tokens ?? 0) / 1_000_000) * pricing.output * batchMultiplier;
 
@@ -603,10 +603,11 @@ export function recordWorkerCost(
   usage: Usage,
   callType: "direct" | "batch",
   workerID?: string,
+  ttl?: "5m" | "1h",
 ): void {
   if (!sessionID) return;
   const costs = getOrCreate(sessionID);
-  const call = computeCallCost(model, usage, callType);
+  const call = computeCallCost(model, usage, callType, ttl);
 
   const bucket = WORKER_BUCKETS[workerID ?? ""] ?? "distillation";
   costs.workers[bucket].cost += call.total;
@@ -614,7 +615,7 @@ export function recordWorkerCost(
 
   // Track batch savings: how much more this would have cost at full price
   if (callType === "batch") {
-    const fullCost = computeCallCost(model, usage, "direct");
+    const fullCost = computeCallCost(model, usage, "direct", ttl);
     costs.batchSavings += fullCost.total - call.total;
   }
 

--- a/packages/gateway/src/sentry.ts
+++ b/packages/gateway/src/sentry.ts
@@ -347,18 +347,18 @@ export function emitCostMetric(
   // The models.dev data is cached after first fetch, so subsequent calls resolve
   // from memory without network I/O.
   getPricing(model).then((pricing) => {
-    // Batch discount applies to base input/output only — cache ops have their
-    // own pricing tiers and are not discounted by the batch API.
+    // Batch discount (0.5×) applies to ALL token categories — input, output,
+    // cache read, and cache write. These multipliers stack with TTL modifiers.
     const batchMultiplier = callType === "batch" ? 0.5 : 1.0;
-    // Anthropic charges 2× cache_write for 1h TTL
+    // Anthropic charges 2× cache_write for 1h TTL (stacks with batch discount)
     const cacheWriteRate = ttl === "1h" ? pricing.cache_write * 2 : pricing.cache_write;
 
     const uncachedInputCost =
       ((usage.input_tokens ?? 0) / 1_000_000) * pricing.input * batchMultiplier;
     const cacheReadCost =
-      ((usage.cache_read_input_tokens ?? 0) / 1_000_000) * pricing.cache_read;
+      ((usage.cache_read_input_tokens ?? 0) / 1_000_000) * pricing.cache_read * batchMultiplier;
     const cacheWriteCost =
-      ((usage.cache_creation_input_tokens ?? 0) / 1_000_000) * cacheWriteRate;
+      ((usage.cache_creation_input_tokens ?? 0) / 1_000_000) * cacheWriteRate * batchMultiplier;
     const outputCost =
       ((usage.output_tokens ?? 0) / 1_000_000) * pricing.output * batchMultiplier;
 

--- a/packages/gateway/test/cost-tracker.test.ts
+++ b/packages/gateway/test/cost-tracker.test.ts
@@ -1,0 +1,82 @@
+import { describe, test, expect } from "bun:test";
+import { computeCallCost } from "../src/cost-tracker";
+
+// Use a fake model name to guarantee we hit getPricingSync defaults:
+//   input: 3 $/MTok, output: 15 $/MTok,
+//   cache_read: 0.3 $/MTok (input × 0.1),
+//   cache_write: 3.75 $/MTok (input × 1.25)
+const MODEL = "__test_fake_model__";
+
+// 1M tokens per category — makes expected costs equal to the $/MTok rates.
+const USAGE = {
+  input_tokens: 1_000_000,
+  output_tokens: 1_000_000,
+  cache_read_input_tokens: 1_000_000,
+  cache_creation_input_tokens: 1_000_000,
+};
+
+describe("computeCallCost", () => {
+  test("conversation call uses full pricing", () => {
+    const cost = computeCallCost(MODEL, USAGE, "conversation");
+    expect(cost.inputCost).toBeCloseTo(3.0);
+    expect(cost.outputCost).toBeCloseTo(15.0);
+    expect(cost.cacheReadCost).toBeCloseTo(0.3);
+    expect(cost.cacheWriteCost).toBeCloseTo(3.75);
+    expect(cost.total).toBeCloseTo(3.0 + 15.0 + 0.3 + 3.75);
+  });
+
+  test("batch call applies 0.5× to ALL token categories", () => {
+    const cost = computeCallCost(MODEL, USAGE, "batch");
+    expect(cost.inputCost).toBeCloseTo(1.5); // 3.0 × 0.5
+    expect(cost.outputCost).toBeCloseTo(7.5); // 15.0 × 0.5
+    expect(cost.cacheReadCost).toBeCloseTo(0.15); // 0.3 × 0.5
+    expect(cost.cacheWriteCost).toBeCloseTo(1.875); // 3.75 × 0.5
+    expect(cost.total).toBeCloseTo(1.5 + 7.5 + 0.15 + 1.875);
+  });
+
+  test("batch cost is exactly half of conversation cost", () => {
+    const conv = computeCallCost(MODEL, USAGE, "conversation");
+    const batch = computeCallCost(MODEL, USAGE, "batch");
+    expect(batch.total).toBeCloseTo(conv.total * 0.5);
+    expect(batch.inputCost).toBeCloseTo(conv.inputCost * 0.5);
+    expect(batch.cacheReadCost).toBeCloseTo(conv.cacheReadCost * 0.5);
+    expect(batch.cacheWriteCost).toBeCloseTo(conv.cacheWriteCost * 0.5);
+    expect(batch.outputCost).toBeCloseTo(conv.outputCost * 0.5);
+  });
+
+  test("1h TTL doubles cache_write rate", () => {
+    const base = computeCallCost(MODEL, USAGE, "conversation");
+    const with1h = computeCallCost(MODEL, USAGE, "conversation", "1h");
+    expect(with1h.cacheWriteCost).toBeCloseTo(base.cacheWriteCost * 2);
+    // Other costs unchanged
+    expect(with1h.inputCost).toBeCloseTo(base.inputCost);
+    expect(with1h.cacheReadCost).toBeCloseTo(base.cacheReadCost);
+    expect(with1h.outputCost).toBeCloseTo(base.outputCost);
+  });
+
+  test("batch + 1h TTL: both multipliers stack", () => {
+    const cost = computeCallCost(MODEL, USAGE, "batch", "1h");
+    // cache_write: 3.75 (base) × 2 (1h TTL) × 0.5 (batch) = 3.75
+    expect(cost.cacheWriteCost).toBeCloseTo(3.75);
+    // Other costs: just 0.5× batch
+    expect(cost.inputCost).toBeCloseTo(1.5);
+    expect(cost.cacheReadCost).toBeCloseTo(0.15);
+    expect(cost.outputCost).toBeCloseTo(7.5);
+    expect(cost.total).toBeCloseTo(1.5 + 7.5 + 0.15 + 3.75);
+  });
+
+  test("5m TTL uses base cache_write rate (no doubling)", () => {
+    const base = computeCallCost(MODEL, USAGE, "conversation");
+    const with5m = computeCallCost(MODEL, USAGE, "conversation", "5m");
+    expect(with5m.cacheWriteCost).toBeCloseTo(base.cacheWriteCost);
+  });
+
+  test("zero usage returns zero costs", () => {
+    const cost = computeCallCost(MODEL, {}, "batch");
+    expect(cost.total).toBe(0);
+    expect(cost.inputCost).toBe(0);
+    expect(cost.cacheReadCost).toBe(0);
+    expect(cost.cacheWriteCost).toBe(0);
+    expect(cost.outputCost).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Anthropic's pricing docs explicitly state that pricing multipliers **stack**: the 0.5× batch discount applies to ALL token categories — input, output, cache read, and cache write. Our `computeCallCost()` and `emitCostMetric()` were only applying the batch multiplier to input and output costs, leaving cache costs at full price.

## Changes

### Bug fix: batch multiplier on cache costs
- **`cost-tracker.ts`**: Apply `batchMultiplier` to `cacheReadCost` and `cacheWriteCost` in `computeCallCost()`
- **`sentry.ts`**: Same fix in `emitCostMetric()`, plus corrected a misleading comment that claimed "cache ops are not discounted by the batch API" (they are)

### Thread TTL parameter through batch cost recording
- **`cost-tracker.ts`**: Add `ttl` parameter to `recordWorkerCost()` and pass it to both `computeCallCost()` calls (actual cost and counterfactual)
- **`batch-queue.ts`**: Pass `"1h"` as TTL to `emitCostMetric()` and `recordWorkerCost()`, matching the 1h TTL already used in the batch queue's `cache_control` blocks

### Tests
- **`cost-tracker.test.ts`** (new): 7 unit tests covering all multiplier stacking combinations — conversation baseline, batch 0.5× on all categories, batch-is-half invariant, 1h TTL doubling, batch+1h stacking, 5m TTL baseline, zero usage edge case

## Impact

- `dailySpend` for batch calls was previously inflated → now accurate
- `batchSavings` metric was previously underestimated → now captures full savings including cache operations
- Sentry `lore.llm_cost_usd` metric was over-reporting batch costs → now correct

## Reference

[Anthropic pricing docs](https://platform.claude.com/docs/en/about-claude/pricing#prompt-caching):
> These multipliers stack with other pricing modifiers, including the Batch API discount and data residency.