### PR TITLE
test: OAuth worker header simulation tests and prompt-caching-scope beta

### DIFF
--- a/packages/gateway/src/cch.ts
+++ b/packages/gateway/src/cch.ts
@@ -268,6 +268,7 @@ const WORKER_BETAS = [
   "oauth-2025-04-20",
   "interleaved-thinking-2025-05-14",
   "extended-cache-ttl-2025-04-11",
+  "prompt-caching-scope-2026-01-05",
 ].join(",");
 
 /**

--- a/packages/gateway/test/batch-queue.test.ts
+++ b/packages/gateway/test/batch-queue.test.ts
@@ -117,6 +117,55 @@ describe("BatchLLMClient", () => {
     await client.shutdown();
   });
 
+  test("bearer-token (OAuth) calls bypass the queue and delegate to inner client", async () => {
+    const inner = createMockLLMClient();
+    const bearerAuth: AuthCredential = { scheme: "bearer", value: "sk-ant-oat-test-token" };
+    const getBearerAuth = () => bearerAuth;
+
+    const client = createBatchLLMClient(inner, UPSTREAMS, getBearerAuth, DEFAULT_MODEL, {
+      flushIntervalMs: 60_000,
+    });
+
+    const result = await client.prompt("system", "oauth worker call", {
+      workerID: "lore-distill",
+      sessionID: "oauth-session",
+    });
+
+    // Should process synchronously via inner client, not queue
+    expect(result).toBe("sync-response-for: oauth worker call");
+    expect(inner.calls).toHaveLength(1);
+    expect(inner.calls[0].user).toBe("oauth worker call");
+
+    const s = client.stats();
+    expect(s.totalFallback).toBe(1); // Counted as fallback, not urgent or queued
+    expect(s.totalQueued).toBe(0);
+    expect(s.totalUrgent).toBe(0);
+    expect(s.queued).toBe(0);
+
+    await client.shutdown();
+  });
+
+  test("api-key calls are still queued normally (not affected by bearer bypass)", async () => {
+    const inner = createMockLLMClient();
+    const client = createBatchLLMClient(inner, UPSTREAMS, getTestAuth, DEFAULT_MODEL, {
+      flushIntervalMs: 60_000,
+      maxQueueSize: 100,
+    });
+
+    // Don't await — should be queued
+    const _promise = client.prompt("system", "api-key background work", {
+      workerID: "lore-distill",
+    });
+
+    // Should be queued, not sent to inner yet
+    expect(inner.calls).toHaveLength(0);
+    const s = client.stats();
+    expect(s.totalQueued).toBe(1);
+    expect(s.queued).toBe(1);
+
+    await client.shutdown();
+  });
+
   test("non-urgent calls are queued (not immediately sent to inner)", async () => {
     const inner = createMockLLMClient();
     const client = createBatchLLMClient(inner, UPSTREAMS, getTestAuth, DEFAULT_MODEL, {

--- a/packages/gateway/test/cch.test.ts
+++ b/packages/gateway/test/cch.test.ts
@@ -3,7 +3,9 @@ import {
   signBody,
   resignBody,
   captureBillingPrefix,
+  captureSessionHeaders,
   buildBillingBlock,
+  buildOAuthWorkerHeaders,
   deleteBillingPrefix,
   validateSeed,
   resolveSeed,
@@ -743,5 +745,135 @@ describe("binary-verified values", () => {
     const cch = (hash & 0xFFFFFn).toString(16).padStart(5, "0");
     const signedOld = body2.replace("cch=00000", `cch=${cch}`);
     expect(validateSeed(signedOld)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// captureSessionHeaders + buildOAuthWorkerHeaders
+// ---------------------------------------------------------------------------
+
+const BILLING_SYSTEM = "x-anthropic-billing-header: cc_version=2.1.152.e9a; cc_entrypoint=cli; cch=abcde;";
+
+describe("captureSessionHeaders", () => {
+  test("is a no-op for non-billing sessions", () => {
+    captureSessionHeaders("non-billing-sess", {
+      "anthropic-beta": "some-beta",
+      "user-agent": "some-agent",
+    });
+    // buildOAuthWorkerHeaders should return null since session has no billing
+    expect(buildOAuthWorkerHeaders("non-billing-sess")).toBeNull();
+  });
+
+  test("captures headers for billing sessions", () => {
+    // First register as a billing session
+    captureBillingPrefix(SID_A, BILLING_SYSTEM);
+
+    // Then capture headers
+    captureSessionHeaders(SID_A, {
+      "anthropic-beta": "oauth-2025-04-20,interleaved-thinking-2025-05-14",
+      "user-agent": "claude-cli/2.1.152 (external, sdk-cli)",
+    });
+
+    const headers = buildOAuthWorkerHeaders(SID_A);
+    expect(headers).not.toBeNull();
+    expect(headers!["anthropic-beta"]).toBe("oauth-2025-04-20,interleaved-thinking-2025-05-14");
+    expect(headers!["user-agent"]).toBe("claude-cli/2.1.152 (external, sdk-cli)");
+  });
+
+  test("captures partial headers (only anthropic-beta present)", () => {
+    captureBillingPrefix(SID_A, BILLING_SYSTEM);
+    captureSessionHeaders(SID_A, {
+      "anthropic-beta": "oauth-2025-04-20",
+    });
+
+    const headers = buildOAuthWorkerHeaders(SID_A);
+    expect(headers).not.toBeNull();
+    expect(headers!["anthropic-beta"]).toBe("oauth-2025-04-20");
+    // user-agent should fall back to default
+    expect(headers!["user-agent"]).toContain("claude-cli/");
+  });
+
+  test("works on the first turn (captureBillingPrefix sets flag before captureSessionHeaders reads it)", () => {
+    // Simulate first-turn ordering: captureBillingPrefix then captureSessionHeaders
+    captureBillingPrefix(SID_A, BILLING_SYSTEM);
+    captureSessionHeaders(SID_A, {
+      "anthropic-beta": "first-turn-beta",
+      "user-agent": "first-turn-ua",
+    });
+
+    const headers = buildOAuthWorkerHeaders(SID_A);
+    expect(headers).not.toBeNull();
+    expect(headers!["anthropic-beta"]).toBe("first-turn-beta");
+    expect(headers!["user-agent"]).toBe("first-turn-ua");
+  });
+});
+
+describe("buildOAuthWorkerHeaders", () => {
+  test("returns null when sessionID is undefined", () => {
+    expect(buildOAuthWorkerHeaders(undefined)).toBeNull();
+  });
+
+  test("returns null for API-key sessions (no billing)", () => {
+    expect(buildOAuthWorkerHeaders("unknown-sess")).toBeNull();
+  });
+
+  test("uses fallback betas when no snapshot exists", () => {
+    // Register as billing session but don't capture headers
+    captureBillingPrefix(SID_A, BILLING_SYSTEM);
+
+    const headers = buildOAuthWorkerHeaders(SID_A);
+    expect(headers).not.toBeNull();
+    expect(headers!["anthropic-beta"]).toContain("oauth-2025-04-20");
+    expect(headers!["anthropic-beta"]).toContain("extended-cache-ttl-2025-04-11");
+    expect(headers!["anthropic-beta"]).toContain("prompt-caching-scope-2026-01-05");
+    expect(headers!["user-agent"]).toContain("claude-cli/");
+  });
+
+  test("includes required OAuth headers", () => {
+    captureBillingPrefix(SID_A, BILLING_SYSTEM);
+
+    const headers = buildOAuthWorkerHeaders(SID_A);
+    expect(headers).not.toBeNull();
+    expect(headers!["anthropic-dangerous-direct-browser-access"]).toBe("true");
+    expect(headers!["x-client-request-id"]).toBeDefined();
+    // UUID format
+    expect(headers!["x-client-request-id"]).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
+  test("generates unique x-client-request-id per call", () => {
+    captureBillingPrefix(SID_A, BILLING_SYSTEM);
+
+    const h1 = buildOAuthWorkerHeaders(SID_A)!;
+    const h2 = buildOAuthWorkerHeaders(SID_A)!;
+    expect(h1["x-client-request-id"]).not.toBe(h2["x-client-request-id"]);
+  });
+
+  test("sessions are isolated — different sessions get different headers", () => {
+    captureBillingPrefix(SID_A, BILLING_SYSTEM);
+    captureBillingPrefix(SID_B, BILLING_SYSTEM);
+
+    captureSessionHeaders(SID_A, { "anthropic-beta": "beta-a" });
+    captureSessionHeaders(SID_B, { "anthropic-beta": "beta-b" });
+
+    expect(buildOAuthWorkerHeaders(SID_A)!["anthropic-beta"]).toBe("beta-a");
+    expect(buildOAuthWorkerHeaders(SID_B)!["anthropic-beta"]).toBe("beta-b");
+  });
+});
+
+describe("deleteBillingPrefix clears header snapshots", () => {
+  test("removes both billing flag and header snapshot", () => {
+    captureBillingPrefix(SID_A, BILLING_SYSTEM);
+    captureSessionHeaders(SID_A, { "anthropic-beta": "test-beta" });
+
+    // Before deletion: returns headers
+    expect(buildOAuthWorkerHeaders(SID_A)).not.toBeNull();
+
+    // Delete
+    deleteBillingPrefix(SID_A);
+
+    // After deletion: returns null
+    expect(buildOAuthWorkerHeaders(SID_A)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #502 (merged via auto-merge before this commit was pushed). Adds test coverage for the OAuth worker header simulation and fixes a missing beta.

## Changes

### `prompt-caching-scope-2026-01-05` beta added to `WORKER_BETAS` (`cch.ts`)
Workers use `cache_control: { type: "ephemeral", ttl: "1h" }` on system blocks. Without the `prompt-caching-scope` beta, scoped cache control may not be honored by the API for OAuth sessions. Added alongside the existing `extended-cache-ttl` beta.

### 13 new tests

**`captureSessionHeaders` tests** (`cch.test.ts`):
- No-op for non-billing sessions
- Captures both headers when present
- Captures partial headers (only one present)
- Works on first turn (correct ordering with `captureBillingPrefix`)

**`buildOAuthWorkerHeaders` tests** (`cch.test.ts`):
- Returns null when sessionID is undefined
- Returns null for API-key sessions
- Uses fallback betas (including `prompt-caching-scope`) when no snapshot
- Includes required OAuth headers (`anthropic-dangerous-direct-browser-access`, UUID `x-client-request-id`)
- Generates unique request IDs per call
- Sessions are isolated (different headers per session)

**`deleteBillingPrefix` cleanup** (`cch.test.ts`):
- Removes both billing flag and header snapshot

**Bearer batch bypass** (`batch-queue.test.ts`):
- Bearer-token credentials skip queue, counted as fallback
- API-key credentials still queue normally