### PR TITLE
feat(core): auto-promote knowledge recurring across 3+ projects

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -254,7 +254,10 @@ export const LoreConfig = z.object({
    *  root project's knowledge base. Supports literal paths (`"project-a"`) and
    *  single-level globs (`"packages/*"`). */
   workspaces: z.array(z.string()).default([]),
-  crossProject: z.boolean().default(false),
+  /** When true, include cross-project knowledge in compaction summaries and
+   *  enable auto-promotion of knowledge that recurs across 3+ unrelated
+   *  projects to `cross_project = 1` (issue #498). */
+  crossProject: z.boolean().default(true),
   agentsFile: z
     .object({
       /** Set to false to disable all AGENTS.md export/import behaviour. */

--- a/packages/core/src/curator.ts
+++ b/packages/core/src/curator.ts
@@ -4,6 +4,7 @@ import * as temporal from "./temporal";
 import * as distillation from "./distillation";
 import * as ltm from "./ltm";
 import * as entities from "./entities";
+import * as embedding from "./embedding";
 import * as log from "./log";
 import { CURATOR_SYSTEM, curatorUser, CONSOLIDATION_SYSTEM, consolidationUser } from "./prompt";
 import { detectAndFormat } from "./instruction-detect";
@@ -550,6 +551,25 @@ async function runInner(input: {
       }
     } catch (err) {
       log.warn("post-curation dedup failed (non-fatal):", err);
+    }
+
+    // Cross-project auto-promotion (issue #498): after new knowledge lands,
+    // detect entries whose meaning recurs across 3+ unrelated projects and
+    // promote them to cross_project = 1 so they surface everywhere. Reuses the
+    // dedup similarity machinery; gated by the top-level crossProject flag and
+    // embedding availability (inner function also guards on isAvailable for
+    // callers that don't pre-check).
+    if (cfg.crossProject && embedding.isAvailable()) {
+      try {
+        const promotion = ltm.promoteCrossProject({ dryRun: false });
+        if (promotion.promoted > 0) {
+          log.info(
+            `cross-project promotion: promoted ${promotion.promoted} entries across ${promotion.clusters.length} cluster(s)`,
+          );
+        }
+      } catch (err) {
+        log.warn("cross-project promotion failed (non-fatal):", err);
+      }
     }
   }
 

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -252,6 +252,23 @@ const FUZZY_DEDUP_MIN_OVERLAP = 4;
  *  - <0.92: mixed or unrelated entries */
 const EMBEDDING_DEDUP_THRESHOLD = 0.935;
 
+// --- Cross-project auto-promotion thresholds (issue #498) ---
+/** A semantic cluster must span at least this many distinct projects to
+ *  qualify its members for cross-project promotion. */
+const MIN_PROMOTION_PROJECTS = 3;
+/** Only project-scoped entries at or above this confidence are eligible
+ *  for promotion — we only spread knowledge that is already strong/directive
+ *  in its home projects. */
+const MIN_PROMOTION_CONFIDENCE = 0.8;
+/** Cross-project semantic-match threshold. Reuses the (conservative,
+ *  empirically-tuned) dedup threshold to avoid false promotions; cross-project
+ *  phrasing varies more, but staying strict keeps promotions trustworthy. */
+const PROMOTION_SIMILARITY_THRESHOLD = EMBEDDING_DEDUP_THRESHOLD;
+/** Max candidates to consider — keeps the O(n²) pairwise comparison bounded.
+ *  With 200 candidates: 200² = 40K cosine computations (microseconds).
+ *  Query orders by confidence DESC so the highest-quality entries are kept. */
+const MAX_PROMOTION_CANDIDATES = 200;
+
 /**
  * Find an existing knowledge entry whose title is fuzzy-similar to the given title.
  *
@@ -1425,6 +1442,147 @@ export async function deduplicateGlobal(
     )
     .all() as KnowledgeEntry[];
   return _dedup(entries, opts?.dryRun ?? true, threshold);
+}
+
+// ---------------------------------------------------------------------------
+// Cross-project auto-promotion (issue #498)
+// ---------------------------------------------------------------------------
+
+/** A cluster of semantically-similar entries that spans multiple projects. */
+export type PromotionCluster = {
+  /** IDs of the entries in this cluster (all promoted when it qualifies). */
+  memberIds: string[];
+  /** Number of distinct project_ids represented in the cluster. */
+  distinctProjects: number;
+};
+
+export type PromotionResult = {
+  /** Number of entries flipped to cross_project = 1. */
+  promoted: number;
+  /** Qualifying clusters (distinctProjects >= MIN_PROMOTION_PROJECTS). */
+  clusters: PromotionCluster[];
+};
+
+/**
+ * Detect knowledge entries whose meaning appears across 3+ unrelated projects
+ * and promote them to cross_project = 1 in place.
+ *
+ * Candidates are project-scoped (non-null project_id, cross_project = 0),
+ * high-confidence (>= MIN_PROMOTION_CONFIDENCE), embedded entries. They are
+ * clustered across project boundaries by embedding cosine similarity using the
+ * same star-clustering (no-transitivity) approach as dedup. A cluster qualifies
+ * when it spans >= MIN_PROMOTION_PROJECTS distinct project_ids; every member is
+ * then flipped to cross_project = 1 with promotion_status = 'promoted'.
+ *
+ * No-ops (returns { promoted: 0, clusters: [] }) when embeddings are unavailable.
+ */
+export function promoteCrossProject(opts?: { dryRun?: boolean }): PromotionResult {
+  const dryRun = opts?.dryRun ?? false;
+  if (!embedding.isAvailable()) return { promoted: 0, clusters: [] };
+
+  // 1. Load eligible candidate entries (project-scoped, high-confidence, embedded).
+  //    Capped at MAX_PROMOTION_CANDIDATES to keep O(n²) pairwise comparison
+  //    bounded. Query orders by confidence DESC so the best entries survive.
+  const candidates = db()
+    .query(
+      `SELECT ${KNOWLEDGE_COLS} FROM knowledge
+       WHERE project_id IS NOT NULL
+       AND cross_project = 0
+       AND confidence >= ?
+       AND embedding IS NOT NULL
+       ORDER BY confidence DESC, updated_at DESC
+       LIMIT ?`,
+    )
+    .all(MIN_PROMOTION_CONFIDENCE, MAX_PROMOTION_CANDIDATES) as KnowledgeEntry[];
+
+  if (candidates.length < MIN_PROMOTION_PROJECTS) {
+    // Fewer entries than the minimum distinct-project requirement — impossible
+    // to span enough projects.
+    return { promoted: 0, clusters: [] };
+  }
+
+  // 2. Load embeddings for the candidate set.
+  const embeddingMap = new Map<string, Float32Array>();
+  {
+    const ids = candidates.map((e) => e.id);
+    const placeholders = ids.map(() => "?").join(",");
+    const rows = db()
+      .query(`SELECT id, embedding FROM knowledge WHERE embedding IS NOT NULL AND id IN (${placeholders})`)
+      .all(...ids) as Array<{ id: string; embedding: Buffer }>;
+    for (const row of rows) {
+      try {
+        embeddingMap.set(row.id, embedding.fromBlob(row.embedding));
+      } catch {
+        log.info(`skipping corrupted embedding for entry ${row.id}`);
+      }
+    }
+  }
+
+  // 3. Build neighbor map by cross-project embedding similarity.
+  const neighborMap = new Map<string, string[]>();
+  for (const entry of candidates) {
+    const entryVec = embeddingMap.get(entry.id);
+    const neighbors: string[] = [];
+    if (entryVec) {
+      for (const other of candidates) {
+        if (other.id === entry.id) continue;
+        const otherVec = embeddingMap.get(other.id);
+        if (!otherVec || otherVec.length !== entryVec.length) continue;
+        if (embedding.cosineSimilarity(entryVec, otherVec) >= PROMOTION_SIMILARITY_THRESHOLD) {
+          neighbors.push(other.id);
+        }
+      }
+    }
+    neighborMap.set(entry.id, neighbors);
+  }
+
+  // 4. Greedy star clustering (no transitivity) — process entries with the
+  //    most neighbors first, claim center + unclaimed neighbors.
+  const entryById = new Map(candidates.map((e) => [e.id, e]));
+  const claimed = new Set<string>();
+  const sortedIds = [...neighborMap.keys()].sort(
+    (a, b) => neighborMap.get(b)!.length - neighborMap.get(a)!.length,
+  );
+
+  const clusters: PromotionCluster[] = [];
+  const toPromote: string[] = [];
+
+  for (const centerId of sortedIds) {
+    if (claimed.has(centerId)) continue;
+    claimed.add(centerId);
+    const members = [centerId];
+    for (const neighborId of neighborMap.get(centerId)!) {
+      if (claimed.has(neighborId)) continue;
+      claimed.add(neighborId);
+      members.push(neighborId);
+    }
+
+    // 5. Qualify cluster by distinct project count.
+    const projects = new Set<string>();
+    for (const id of members) {
+      const pid = entryById.get(id)?.project_id;
+      if (pid) projects.add(pid);
+    }
+    if (projects.size < MIN_PROMOTION_PROJECTS) continue;
+
+    clusters.push({ memberIds: members, distinctProjects: projects.size });
+    toPromote.push(...members);
+  }
+
+  // 6. Flip qualifying members to cross_project = 1 in place.
+  if (!dryRun && toPromote.length) {
+    const now = Date.now();
+    const stmt = db().query(
+      `UPDATE knowledge
+       SET cross_project = 1, promotion_status = 'promoted', promoted_at = ?, updated_at = ?
+       WHERE id = ?`,
+    );
+    for (const id of toPromote) {
+      stmt.run(now, now, id);
+    }
+  }
+
+  return { promoted: toPromote.length, clusters };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/test/ltm.test.ts
+++ b/packages/core/test/ltm.test.ts
@@ -1,6 +1,8 @@
-import { describe, test, expect, beforeAll, beforeEach } from "bun:test";
+import { describe, test, expect, beforeAll, beforeEach, afterEach, spyOn } from "bun:test";
+import { uuidv7 } from "uuidv7";
 import { db, ensureProject } from "../src/db";
 import * as ltm from "../src/ltm";
+import * as embedding from "../src/embedding";
 
 // UUID v7 pattern: starts with version nibble 7, variant bits 10xxxxxx
 const UUID_V7_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
@@ -1339,5 +1341,192 @@ describe("ltm — multi-user columns (v29)", () => {
       .all() as Array<{ name: string }>;
     expect(tables).toHaveLength(1);
     expect(tables[0].name).toBe("team_config");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-project auto-promotion (issue #498)
+// ---------------------------------------------------------------------------
+
+describe("ltm — cross-project promotion", () => {
+  const PA = "/test/promote/project-a";
+  const PB = "/test/promote/project-b";
+  const PC = "/test/promote/project-c";
+
+  /** Inject a deterministic unit-norm embedding for an entry. Same seed => same
+   *  vector => cosine similarity 1.0 (well above the promotion threshold). */
+  function injectEmbedding(entryId: string, seed: number, dims = 768): void {
+    const vec = new Float32Array(dims);
+    for (let i = 0; i < dims; i++) vec[i] = Math.sin(seed * (i + 1) * 0.1);
+    let norm = 0;
+    for (let i = 0; i < dims; i++) norm += vec[i] * vec[i];
+    norm = Math.sqrt(norm);
+    for (let i = 0; i < dims; i++) vec[i] /= norm;
+    db().query("UPDATE knowledge SET embedding = ? WHERE id = ?").run(Buffer.from(vec.buffer), entryId);
+  }
+
+  /** Create a project-scoped entry with explicit id (bypasses create-time dedup
+   *  guard), a given confidence, and an injected embedding. */
+  function seedEntry(opts: {
+    projectPath: string;
+    title: string;
+    confidence?: number;
+    embedSeed: number;
+  }): string {
+    const id = ltm.create({
+      id: uuidv7(),
+      projectPath: opts.projectPath,
+      category: "preference",
+      title: opts.title,
+      content: `Content for ${opts.title}`,
+      scope: "project",
+      crossProject: false,
+      session: "test-session",
+    });
+    if (opts.confidence != null && opts.confidence !== 1.0) {
+      ltm.update(id, { confidence: opts.confidence });
+    }
+    injectEmbedding(id, opts.embedSeed);
+    return id;
+  }
+
+  // promoteCrossProject() reads embeddings directly from the DB; it only calls
+  // embedding.isAvailable() as a cheap "embeddings configured?" guard. Stub it
+  // rather than touch real provider/worker state — instantiating or shutting
+  // down a LocalProvider in-process triggers Bun NAPI/ONNX crashes, and other
+  // suites may have left the provider disabled or broken. Each test sets the
+  // desired return value via availableSpy.
+  let availableSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    // vectorSearch / promotion queries are unscoped — wipe ALL knowledge so
+    // embeddings from other suites don't leak in. (Documented gotcha.)
+    db().query("DELETE FROM knowledge WHERE embedding IS NOT NULL").run();
+    db().query("DELETE FROM knowledge").run();
+    availableSpy = spyOn(embedding, "isAvailable").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    availableSpy.mockRestore();
+  });
+
+  test("promotes a cluster spanning 3 distinct projects", () => {
+    const a = seedEntry({ projectPath: PA, title: "Always run tests before committing code", confidence: 0.9, embedSeed: 5 });
+    const b = seedEntry({ projectPath: PB, title: "Run the test suite prior to any commit", confidence: 0.85, embedSeed: 5 });
+    const c = seedEntry({ projectPath: PC, title: "Tests must pass before commit is made", confidence: 0.95, embedSeed: 5 });
+
+    const res = ltm.promoteCrossProject({ dryRun: false });
+    expect(res.promoted).toBe(3);
+    expect(res.clusters).toHaveLength(1);
+    expect(res.clusters[0].distinctProjects).toBe(3);
+
+    for (const id of [a, b, c]) {
+      const e = ltm.get(id)!;
+      expect(e.cross_project).toBe(1);
+      expect(e.promotion_status).toBe("promoted");
+      expect(e.promoted_at).not.toBeNull();
+    }
+  });
+
+  test("does NOT promote a cluster spanning only 2 projects", () => {
+    const a = seedEntry({ projectPath: PA, title: "Always run tests before committing code", confidence: 0.9, embedSeed: 7 });
+    const b = seedEntry({ projectPath: PB, title: "Run the test suite prior to any commit", confidence: 0.9, embedSeed: 7 });
+
+    const res = ltm.promoteCrossProject({ dryRun: false });
+    expect(res.promoted).toBe(0);
+    expect(res.clusters).toHaveLength(0);
+    expect(ltm.get(a)!.cross_project).toBe(0);
+    expect(ltm.get(b)!.cross_project).toBe(0);
+  });
+
+  test("does NOT promote low-confidence entries (< 0.8)", () => {
+    const a = seedEntry({ projectPath: PA, title: "Always run tests before committing code", confidence: 0.7, embedSeed: 9 });
+    const b = seedEntry({ projectPath: PB, title: "Run the test suite prior to any commit", confidence: 0.5, embedSeed: 9 });
+    const c = seedEntry({ projectPath: PC, title: "Tests must pass before commit is made", confidence: 0.6, embedSeed: 9 });
+
+    const res = ltm.promoteCrossProject({ dryRun: false });
+    expect(res.promoted).toBe(0);
+    for (const id of [a, b, c]) expect(ltm.get(id)!.cross_project).toBe(0);
+  });
+
+  test("ignores entries already cross_project = 1", () => {
+    // Three already-cross-project entries across 3 projects — not candidates.
+    for (const [p, seed] of [[PA, 11], [PB, 11], [PC, 11]] as const) {
+      const id = ltm.create({
+        id: uuidv7(),
+        projectPath: p,
+        category: "preference",
+        title: `Cross entry in ${p}`,
+        content: "already shared",
+        scope: "project",
+        crossProject: true,
+        session: "test-session",
+      });
+      injectEmbedding(id, seed);
+    }
+    const res = ltm.promoteCrossProject({ dryRun: false });
+    expect(res.promoted).toBe(0);
+    expect(res.clusters).toHaveLength(0);
+  });
+
+  test("dryRun: true reports clusters but does not mutate", () => {
+    const a = seedEntry({ projectPath: PA, title: "Always run tests before committing code", confidence: 0.9, embedSeed: 13 });
+    const b = seedEntry({ projectPath: PB, title: "Run the test suite prior to any commit", confidence: 0.9, embedSeed: 13 });
+    const c = seedEntry({ projectPath: PC, title: "Tests must pass before commit is made", confidence: 0.9, embedSeed: 13 });
+
+    const res = ltm.promoteCrossProject({ dryRun: true });
+    expect(res.promoted).toBe(3);
+    expect(res.clusters).toHaveLength(1);
+    for (const id of [a, b, c]) {
+      const e = ltm.get(id)!;
+      expect(e.cross_project).toBe(0);
+      expect(e.promotion_status).toBeNull();
+    }
+  });
+
+  test("no-op when embeddings are unavailable", () => {
+    seedEntry({ projectPath: PA, title: "Always run tests before committing code", confidence: 0.9, embedSeed: 15 });
+    seedEntry({ projectPath: PB, title: "Run the test suite prior to any commit", confidence: 0.9, embedSeed: 15 });
+    seedEntry({ projectPath: PC, title: "Tests must pass before commit is made", confidence: 0.9, embedSeed: 15 });
+
+    availableSpy.mockReturnValue(false);
+    const res = ltm.promoteCrossProject({ dryRun: false });
+    expect(res.promoted).toBe(0);
+    expect(res.clusters).toHaveLength(0);
+  });
+
+  test("does NOT promote when 3 similar entries are all in the same project", () => {
+    const a = seedEntry({ projectPath: PA, title: "Always run tests before committing code", confidence: 0.9, embedSeed: 17 });
+    const b = seedEntry({ projectPath: PA, title: "Run the test suite prior to any commit", confidence: 0.9, embedSeed: 17 });
+    const c = seedEntry({ projectPath: PA, title: "Tests must pass before commit is made", confidence: 0.9, embedSeed: 17 });
+
+    const res = ltm.promoteCrossProject({ dryRun: false });
+    expect(res.promoted).toBe(0);
+    expect(res.clusters).toHaveLength(0);
+    for (const id of [a, b, c]) expect(ltm.get(id)!.cross_project).toBe(0);
+  });
+
+  test("mixed-confidence cluster: low-confidence entries excluded, qualifying remainder still promotes", () => {
+    // 4 similar entries across 4 projects, but one is below the confidence threshold.
+    // The low-confidence entry is excluded from candidates entirely, so the
+    // remaining 3 high-confidence entries should still form a qualifying cluster.
+    const PD = "/test/promote/project-d";
+    const a = seedEntry({ projectPath: PA, title: "Always run tests before committing code", confidence: 0.9, embedSeed: 19 });
+    const b = seedEntry({ projectPath: PB, title: "Run the test suite prior to any commit", confidence: 0.85, embedSeed: 19 });
+    const c = seedEntry({ projectPath: PC, title: "Tests must pass before commit is made", confidence: 0.95, embedSeed: 19 });
+    const d = seedEntry({ projectPath: PD, title: "Test before every commit always", confidence: 0.5, embedSeed: 19 });
+
+    const res = ltm.promoteCrossProject({ dryRun: false });
+    // Only the 3 high-confidence entries should be promoted
+    expect(res.promoted).toBe(3);
+    expect(res.clusters).toHaveLength(1);
+    expect(res.clusters[0].distinctProjects).toBe(3);
+    for (const id of [a, b, c]) {
+      expect(ltm.get(id)!.cross_project).toBe(1);
+      expect(ltm.get(id)!.promotion_status).toBe("promoted");
+    }
+    // Low-confidence entry untouched
+    expect(ltm.get(d)!.cross_project).toBe(0);
+    expect(ltm.get(d)!.promotion_status).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Implements cross-project auto-promotion of knowledge entries (issue #498). When semantically-similar entries recur across 3+ unrelated projects with high confidence, they are promoted to `cross_project = 1` so they surface in all projects.

Closes #498

## Changes

- **`packages/core/src/ltm.ts`**: Add `promoteCrossProject()` with star-clustering (no-transitivity) reusing the dedup cosine-similarity machinery at threshold 0.935. Eligible entries must be project-scoped, confidence ≥ 0.8, and embedded. Qualifying clusters span ≥3 distinct `project_id`s. Promoted entries are flipped to `cross_project = 1` in place with `promotion_status = 'promoted'` and `promoted_at` set (reusing existing v29 scaffolding columns — no DB migration needed).
- **`packages/core/src/curator.ts`**: Wire `promoteCrossProject()` into the curator's post-dedup sweep (runs only when entries changed), gated by `cfg.crossProject && embedding.isAvailable()`.
- **`packages/core/src/config.ts`**: Flip the top-level `crossProject` config default from `false` to `true`. This also enables cross-project entries in compaction summaries (the only pre-existing reader of this flag at `pipeline.ts:2567`).
- **`packages/core/test/ltm.test.ts`**: Add 7 tests: 3-project promotion, 2-project rejection, low-confidence rejection, already-cross-project ignore, dryRun correctness, embeddings-unavailable no-op, and same-project no-promotion.

## Design decisions

- **No default knowledge baseline** — Lore ships no curated/opinionated entries. Users' own cross-project entries already surface in empty projects via `forSession()`.
- **Transfer metrics deferred** — no recall-event persistence exists yet; follow-up work.
- **Conservative threshold** (0.935) reused from the empirically-tuned dedup threshold to avoid false promotions.