### PR TITLE
fix(gateway): coalesce tool items in OpenAI Responses API parser

### DIFF
--- a/packages/gateway/src/translate/openai-responses.ts
+++ b/packages/gateway/src/translate/openai-responses.ts
@@ -140,33 +140,56 @@ function parseInputItems(input: unknown): GatewayMessage[] {
     }
 
     if (itemType === "function_call") {
-      // Function call from assistant — maps to tool_use
-      messages.push({
-        role: "assistant",
-        content: [
-          {
-            type: "tool_use",
-            id: String(item.call_id ?? item.id ?? ""),
-            name: String(item.name ?? ""),
-            input: parseArguments(item.arguments),
-          },
-        ],
-      });
+      // Function call from assistant — maps to tool_use.
+      //
+      // The Responses API emits each parallel tool call as its OWN
+      // `function_call` item, and each tool result as its own
+      // `function_call_output` item. The gateway's downstream tool-pairing
+      // (loreMessagesToGateway + removeOrphanedToolResults) assumes the
+      // Anthropic shape: one assistant message carries ALL tool_use blocks,
+      // and the single immediately-following user message carries ALL matching
+      // tool_result blocks. Coalesce consecutive function_call items into one
+      // assistant message so an N-tool-call turn keeps its N tool_use blocks
+      // together (and matched by the coalesced tool_result message below).
+      const toolUseBlock: GatewayContentBlock = {
+        type: "tool_use",
+        id: String(item.call_id ?? item.id ?? ""),
+        name: String(item.name ?? ""),
+        input: parseArguments(item.arguments),
+      };
+      const last = messages[messages.length - 1];
+      const lastIsToolUseMessage =
+        last !== undefined &&
+        last.role === "assistant" &&
+        last.content.length > 0 &&
+        last.content.every((b) => b.type === "tool_use");
+      if (lastIsToolUseMessage) {
+        last.content.push(toolUseBlock);
+      } else {
+        messages.push({ role: "assistant", content: [toolUseBlock] });
+      }
       continue;
     }
 
     if (itemType === "function_call_output") {
-      // Function output — maps to tool_result
-      messages.push({
-        role: "user",
-        content: [
-          {
-            type: "tool_result",
-            toolUseId: String(item.call_id ?? ""),
-            content: String(item.output ?? ""),
-          },
-        ],
-      });
+      // Function output — maps to tool_result. Coalesce consecutive outputs
+      // into one user message (see the function_call comment above).
+      const toolResultBlock: GatewayContentBlock = {
+        type: "tool_result",
+        toolUseId: String(item.call_id ?? ""),
+        content: String(item.output ?? ""),
+      };
+      const last = messages[messages.length - 1];
+      const lastIsToolResultMessage =
+        last !== undefined &&
+        last.role === "user" &&
+        last.content.length > 0 &&
+        last.content.every((b) => b.type === "tool_result");
+      if (lastIsToolResultMessage) {
+        last.content.push(toolResultBlock);
+      } else {
+        messages.push({ role: "user", content: [toolResultBlock] });
+      }
       continue;
     }
 

--- a/packages/gateway/test/openai-responses.test.ts
+++ b/packages/gateway/test/openai-responses.test.ts
@@ -15,7 +15,20 @@ import {
   buildOpenAIResponsesResponse,
 } from "../src/translate/openai-responses";
 import { buildOpenAIResponse } from "../src/translate/openai";
-import type { GatewayResponse } from "../src/translate/types";
+import {
+  loreMessagesToGateway,
+  removeOrphanedToolResults,
+} from "../src/pipeline";
+import {
+  gatewayMessagesToLore,
+  resolveToolResults,
+} from "../src/temporal-adapter";
+import type {
+  GatewayResponse,
+  GatewayContentBlock,
+  GatewayToolUseBlock,
+  GatewayToolResultBlock,
+} from "../src/translate/types";
 
 // ---------------------------------------------------------------------------
 // parseOpenAIResponsesRequest
@@ -113,6 +126,165 @@ describe("parseOpenAIResponsesRequest", () => {
         content: "Found 5 cats",
       },
     ]);
+  });
+
+  test("coalesces parallel function_call items into one assistant message", () => {
+    const req = parseOpenAIResponsesRequest(
+      {
+        model: "gpt-5.5",
+        input: [
+          { type: "message", role: "user", content: "do two things" },
+          { type: "function_call", call_id: "call_A", name: "read", arguments: "{}" },
+          { type: "function_call", call_id: "call_B", name: "grep", arguments: "{}" },
+          { type: "function_call_output", call_id: "call_A", output: "result A" },
+          { type: "function_call_output", call_id: "call_B", output: "result B" },
+        ],
+      },
+      headers,
+    );
+
+    // user, assistant (both tool_use), user (both tool_result)
+    expect(req.messages.map((m) => m.role)).toEqual(["user", "assistant", "user"]);
+
+    const toolUses = req.messages[1].content as GatewayToolUseBlock[];
+    expect(toolUses.map((b) => b.id)).toEqual(["call_A", "call_B"]);
+
+    const toolResults = req.messages[2].content as GatewayToolResultBlock[];
+    expect(toolResults.map((b) => b.toolUseId)).toEqual(["call_A", "call_B"]);
+  });
+
+  test("coalesces parallel function_call items across interleaved reasoning items", () => {
+    const req = parseOpenAIResponsesRequest(
+      {
+        model: "gpt-5.5",
+        input: [
+          { type: "message", role: "user", content: "do two things" },
+          { type: "function_call", call_id: "call_A", name: "read", arguments: "{}" },
+          // The Responses API can interleave reasoning items between calls;
+          // they are skipped and must NOT break coalescing of A and B.
+          { type: "reasoning", summary: [] },
+          { type: "function_call", call_id: "call_B", name: "grep", arguments: "{}" },
+          { type: "function_call_output", call_id: "call_A", output: "result A" },
+          { type: "function_call_output", call_id: "call_B", output: "result B" },
+        ],
+      },
+      headers,
+    );
+
+    expect(req.messages.map((m) => m.role)).toEqual(["user", "assistant", "user"]);
+    expect((req.messages[1].content as GatewayToolUseBlock[]).map((b) => b.id)).toEqual([
+      "call_A",
+      "call_B",
+    ]);
+    expect((req.messages[2].content as GatewayToolResultBlock[]).map((b) => b.toolUseId)).toEqual([
+      "call_A",
+      "call_B",
+    ]);
+  });
+
+  test("sequential call/output pairs are NOT coalesced across the boundary", () => {
+    const req = parseOpenAIResponsesRequest(
+      {
+        model: "gpt-5.5",
+        input: [
+          { type: "message", role: "user", content: "go" },
+          { type: "function_call", call_id: "call_A", name: "read", arguments: "{}" },
+          { type: "function_call_output", call_id: "call_A", output: "result A" },
+          { type: "function_call", call_id: "call_B", name: "grep", arguments: "{}" },
+          { type: "function_call_output", call_id: "call_B", output: "result B" },
+        ],
+      },
+      headers,
+    );
+
+    // Each call stays adjacent to its own output: asst[A] user[A] asst[B] user[B].
+    expect(req.messages.map((m) => m.role)).toEqual([
+      "user",
+      "assistant",
+      "user",
+      "assistant",
+      "user",
+    ]);
+    expect((req.messages[1].content as GatewayToolUseBlock[]).map((b) => b.id)).toEqual(["call_A"]);
+    expect((req.messages[2].content as GatewayToolResultBlock[]).map((b) => b.toolUseId)).toEqual(["call_A"]);
+    expect((req.messages[3].content as GatewayToolUseBlock[]).map((b) => b.id)).toEqual(["call_B"]);
+    expect((req.messages[4].content as GatewayToolResultBlock[]).map((b) => b.toolUseId)).toEqual(["call_B"]);
+  });
+
+  test("does not merge function_call into a preceding assistant text message", () => {
+    const req = parseOpenAIResponsesRequest(
+      {
+        model: "gpt-5.5",
+        input: [
+          { type: "message", role: "user", content: "go" },
+          { type: "message", role: "assistant", content: [{ type: "output_text", text: "Let me check." }] },
+          { type: "function_call", call_id: "call_A", name: "read", arguments: "{}" },
+          { type: "function_call_output", call_id: "call_A", output: "result A" },
+        ],
+      },
+      headers,
+    );
+
+    // The assistant text message stays separate from the tool_use message.
+    expect(req.messages.map((m) => m.role)).toEqual([
+      "user",
+      "assistant",
+      "assistant",
+      "user",
+    ]);
+    expect(req.messages[1].content).toEqual([{ type: "text", text: "Let me check." }]);
+    expect((req.messages[2].content as GatewayToolUseBlock[]).map((b) => b.id)).toEqual(["call_A"]);
+  });
+
+  test("end-to-end: parallel tool calls survive reconstruction with no orphans", () => {
+    const req = parseOpenAIResponsesRequest(
+      {
+        model: "gpt-5.5",
+        input: [
+          { type: "message", role: "user", content: "do two things" },
+          { type: "function_call", call_id: "call_A", name: "read", arguments: "{}" },
+          { type: "function_call", call_id: "call_B", name: "grep", arguments: "{}" },
+          { type: "function_call_output", call_id: "call_A", output: "result A" },
+          { type: "function_call_output", call_id: "call_B", output: "result B" },
+          { type: "message", role: "user", content: "now summarize" },
+        ],
+      },
+      headers,
+    );
+
+    const lore = gatewayMessagesToLore(req.messages, "test-session");
+    resolveToolResults(lore);
+    const reconstructed = loreMessagesToGateway(lore);
+
+    const warnings: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "));
+    };
+    try {
+      removeOrphanedToolResults(reconstructed);
+    } finally {
+      console.warn = origWarn;
+    }
+
+    expect(warnings.filter((w) => w.includes("orphaned tool_use"))).toEqual([]);
+
+    const allText = reconstructed
+      .flatMap((m) => m.content)
+      .filter((b) => b.type === "text")
+      .map((b) => (b as { text: string }).text);
+    expect(allText).not.toContain("[assistant response]");
+
+    const assistant = reconstructed.find(
+      (m) =>
+        m.role === "assistant" &&
+        m.content.some((b: GatewayContentBlock) => b.type === "tool_use"),
+    )!;
+    const ids = (assistant.content as GatewayContentBlock[])
+      .filter((b): b is GatewayToolUseBlock => b.type === "tool_use")
+      .map((b) => b.id)
+      .sort();
+    expect(ids).toEqual(["call_A", "call_B"]);
   });
 
   test("extracts instructions as system prompt", () => {


### PR DESCRIPTION
## Problem

Follow-up to #511. A user running **Codex** (OpenAI Responses API, `gpt-5.5`) still saw the orphaned-tool warnings:

```
[lore] POST /v1/responses
[lore] turn: session=... model=gpt-5.5 stream=true ...
[lore] WARN: removed 1 orphaned tool_use block(s) from assistant message 4
[lore] WARN: removed 1 orphaned tool_use block(s) from assistant message 9
[lore] WARN: removed 1 orphaned tool_use block(s) from assistant message 10
[lore] WARN: removed 1 orphaned tool_use block(s) from assistant message 19
```

#511 fixed the **Chat Completions** parser (`parseOpenAIRequest`), but the **Responses API** has its own parser (`parseOpenAIResponsesRequest` → `parseInputItems`) with the same class of bug — and worse.

## Root cause

The Responses API wire format sends each parallel tool call as its own `function_call` input item and each result as its own `function_call_output` item. `parseInputItems` emitted:

- a **separate assistant message per `function_call`** (one `tool_use` block each)
- a **separate user message per `function_call_output`** (one `tool_result` block each)

So an N-parallel-tool turn produced N consecutive assistant messages **and** N consecutive user messages:

```
assistant: [tool_use A]
assistant: [tool_use B]
user:      [tool_result A]
user:      [tool_result B]
```

This breaks the Anthropic-shape adjacency invariant that `removeOrphanedToolResults` Pass 2 depends on (it only inspects `messages[i+1]`): `tool_use A`'s next message is another assistant, not the user carrying its result → stripped → warning + `[assistant response]` placeholder.

## Fix

Coalesce in `parseInputItems`:
- consecutive `function_call` items → one assistant message with multiple `tool_use` blocks
- consecutive `function_call_output` items → one user message with multiple `tool_result` blocks

Guards mirror the #511 Chat Completions fix (`last.role` + `content.length > 0` + `every(b => b.type === ...)`), so a genuine user/assistant text turn is never merged into. Skipped item types (`reasoning`, `item_reference`) are transparent to coalescing since they never enter the output array. The upstream request builder (`buildResponsesInput`) already splits multi-block messages back into separate `function_call`/`function_call_output` items, so the outgoing wire format is unchanged.

## Tests

Added to `openai-responses.test.ts`:
- parallel `function_call` items coalesce into one assistant message
- parallel `function_call_output` items coalesce into one user message
- coalescing works across interleaved `reasoning` items
- sequential `call → output → call → output` pairs are **not** coalesced across the boundary (each call stays adjacent to its own output)
- `function_call` is **not** merged into a preceding assistant text message
- end-to-end adjacency through `loreMessagesToGateway` + `removeOrphanedToolResults` (no orphans, no `[assistant response]`)

## Follow-up (out of scope)

The adversarial review flagged that `item_reference` input items are silently dropped entirely — under `previous_response_id` continuation this could orphan outputs. Pre-existing; will file a separate issue.

## Verification

- `bun --filter '*' typecheck` — clean (all 4 packages)
- `bun test packages/gateway` — 972 pass / 0 fail (30 in openai-responses.test.ts)