### PR TITLE
feat: add `lore setup` command with Codex support

### DIFF
--- a/packages/gateway/src/cli/agents.ts
+++ b/packages/gateway/src/cli/agents.ts
@@ -52,6 +52,12 @@ export interface AgentDef {
   detect: () => string | null;
   /** Env vars to inject given the gateway URL (e.g. "http://127.0.0.1:3207") and project cwd */
   envVars: (gatewayUrl: string, cwd: string) => Record<string, string>;
+  /**
+   * Extra CLI arguments to prepend when launching the agent.
+   * Used by agents like Codex that read config from their own config file
+   * rather than environment variables — we inject `-c key=value` overrides.
+   */
+  cliArgs?: (gatewayUrl: string, cwd: string) => string[];
 }
 
 /**
@@ -107,18 +113,23 @@ export const AGENTS: AgentDef[] = [
     displayName: "Codex",
     binary: "codex",
     detect: () => which("codex"),
-    envVars: (url, cwd) => {
-      const env: Record<string, string> = { OPENAI_BASE_URL: `${url}/v1` };
-      // Codex supports custom headers via env_http_headers config (since 0.3.0).
-      // Set LORE_PROJECT / LORE_GIT_REMOTE so users can map them in config.toml:
-      //   [model_provider.custom.env_http_headers]
-      //   X-Lore-Project = "LORE_PROJECT"
-      //   X-Lore-Git-Remote = "LORE_GIT_REMOTE"
-      env.LORE_PROJECT = cwd;
+    envVars: (_url, cwd) => {
+      // Codex CLI is a Rust binary that does NOT read OPENAI_BASE_URL from the
+      // environment. Provider routing is done exclusively via config.toml or
+      // `-c` CLI overrides (see cliArgs below). We still expose LORE_PROJECT /
+      // LORE_GIT_REMOTE for env_http_headers mapping if the user configures a
+      // custom provider with env_http_headers in their config.toml.
+      const env: Record<string, string> = { LORE_PROJECT: cwd };
       const remote = safeRemote(cwd);
       if (remote) env.LORE_GIT_REMOTE = remote;
       return env;
     },
+    cliArgs: (url) => [
+      // Override the built-in OpenAI provider's base URL to route through the
+      // Lore gateway. Uses `-c` so the change is per-invocation only — it does
+      // not affect Codex's persisted config or session scoping.
+      "-c", `openai_base_url="${url}/v1"`,
+    ],
   },
   {
     name: "pi",

--- a/packages/gateway/src/cli/help.ts
+++ b/packages/gateway/src/cli/help.ts
@@ -14,6 +14,8 @@ Commands:
                            Extra arguments are forwarded to the launched agent
   start               Start the gateway server (without launching an agent)
                       Hosted mode is ON by default; use --local to disable
+  setup [app]         Configure an AI app to route through lore
+                      Supported: codex
   logs                Show lore activity log
   import              Import knowledge from prior AI agent conversations
   data <subcommand>   Manage stored data (list, show, clear, delete)
@@ -102,6 +104,9 @@ Examples:
   lore start -p 8080            # Start gateway on a custom port
   lore start -H 127.0.0.1 -H 100.69.65.125  # Bind to multiple interfaces
   lore start -H 127.0.0.1,100.69.65.125     # Same, comma-separated
+  lore setup                    # Auto-detect and configure installed apps
+  lore setup codex              # Configure Codex to use lore
+  lore setup codex -r http://remote:3207  # Configure Codex with a remote gateway
   lore upgrade                  # Upgrade to latest version
   lore upgrade --check          # Check for updates without installing
   lore upgrade --force          # Force re-download even if up to date

--- a/packages/gateway/src/cli/main.ts
+++ b/packages/gateway/src/cli/main.ts
@@ -6,6 +6,7 @@
  * Commands:
  *   (none) / run   → start gateway + launch agent
  *   start          → start gateway server (no agent auto-launch)
+ *   setup          → configure an AI app to route through lore
  *   data           → inspect and manage stored data
  *   recall         → search project memory from the terminal
  *   upgrade        → self-update
@@ -260,6 +261,12 @@ export async function _cli(): Promise<void> {
         break;
       }
 
+      case "setup": {
+        const { commandSetup } = await import("./setup");
+        await commandSetup(rest, values as Record<string, unknown>);
+        break;
+      }
+
       case "data": {
         const { commandData } = await import("./data");
         await commandData(rest, values as Record<string, unknown>);
@@ -314,7 +321,7 @@ export async function _cli(): Promise<void> {
           if (!knownBinaries.includes(command)) {
             // Not a known agent — likely a typo. Show a helpful error.
             const knownCommands = [
-              "start", "run", "data", "recall", "logs", "import", "entity", "upgrade", "help",
+              "start", "run", "setup", "data", "recall", "logs", "import", "entity", "upgrade", "help",
               ...knownBinaries,
             ];
             // "Did you mean?" — use Levenshtein distance for robust matching

--- a/packages/gateway/src/cli/run.ts
+++ b/packages/gateway/src/cli/run.ts
@@ -67,13 +67,21 @@ async function resolveLaunchTarget(
     console.log(`[lore] Workspace root: ${projectDir}`);
   }
 
-  // --- Explicit command given: inject all known env vars ---
+  // --- Explicit command given: inject all known env vars + matching CLI args ---
   if (cmdArgs.length > 0) {
     const env: Record<string, string> = {};
+    const prependArgs: string[] = [];
     for (const agent of AGENTS) {
+      // Env vars are safe to merge from all agents (unused vars are harmless).
       Object.assign(env, agent.envVars(gatewayUrl, projectDir));
+      // CLI args are agent-specific (e.g. Codex's `-c` flag) — only inject
+      // them for the agent that matches the explicit command to avoid passing
+      // unrecognized flags to other agents.
+      if (agent.cliArgs && agent.binary === cmdArgs[0]) {
+        prependArgs.push(...agent.cliArgs(gatewayUrl, projectDir));
+      }
     }
-    return { command: cmdArgs[0], args: [...cmdArgs.slice(1), ...extraArgs], env };
+    return { command: cmdArgs[0], args: [...prependArgs, ...cmdArgs.slice(1), ...extraArgs], env };
   }
 
   // --- No command: auto-detect agents ---
@@ -103,9 +111,10 @@ async function resolveLaunchTarget(
     return null;
   }
 
+  const agentCliArgs = agent.def.cliArgs?.(gatewayUrl, projectDir) ?? [];
   return {
     command: agent.def.binary,
-    args: [...extraArgs],
+    args: [...agentCliArgs, ...extraArgs],
     env: agent.def.envVars(gatewayUrl, projectDir),
   };
 }

--- a/packages/gateway/src/cli/setup.ts
+++ b/packages/gateway/src/cli/setup.ts
@@ -1,0 +1,256 @@
+/**
+ * `lore setup [app]` — configure an AI app to route through the Lore gateway.
+ *
+ * Currently supports:
+ *   - codex: writes `openai_base_url` to `~/.codex/config.toml`
+ *
+ * The command auto-detects installed apps when no argument is given,
+ * or accepts an explicit app name (e.g. `lore setup codex`).
+ */
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { detectAgents } from "./agents";
+
+// ---------------------------------------------------------------------------
+// Supported apps and their setup handlers
+// ---------------------------------------------------------------------------
+
+interface AppSetup {
+  /** Internal identifier matching AgentDef.name */
+  agentName: string;
+  /** Human-readable name */
+  displayName: string;
+  /** Run the setup for this app */
+  run: (baseUrl: string) => void;
+}
+
+const SUPPORTED_APPS: AppSetup[] = [
+  {
+    agentName: "codex",
+    displayName: "Codex",
+    run: (baseUrl) => setupCodex(baseUrl),
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Gateway URL normalization
+// ---------------------------------------------------------------------------
+
+/** Default gateway port (matches DEFAULT_PORTS[0] in start.ts) */
+const DEFAULT_PORT = 3207;
+
+/**
+ * Normalize a gateway URL for use as a provider base URL.
+ * Ensures the URL ends with `/v1` (required by Codex).
+ * Rejects URLs with characters that would break TOML string embedding.
+ */
+export function normalizeBaseUrl(
+  remoteUrl: string | undefined,
+  port: number | undefined,
+): string {
+  if (remoteUrl) {
+    const stripped = remoteUrl.trim().replace(/\/+$/, "");
+    if (!stripped) throw new Error("Remote URL cannot be empty.");
+    validateUrl(stripped);
+    return stripped.endsWith("/v1") ? stripped : `${stripped}/v1`;
+  }
+  if (port !== undefined) {
+    if (!Number.isInteger(port) || port < 0 || port > 65535) {
+      throw new Error(`Invalid port "${port}". Must be 0–65535.`);
+    }
+  }
+  return `http://127.0.0.1:${port ?? DEFAULT_PORT}/v1`;
+}
+
+/**
+ * Reject URLs containing characters that would produce malformed TOML
+ * or could be used for injection (double-quotes, backslashes, control chars).
+ */
+function validateUrl(url: string): void {
+  if (/[\x00-\x1f"\\]/.test(url)) {
+    throw new Error(`Invalid characters in URL: ${url}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Codex config.toml updater
+// ---------------------------------------------------------------------------
+
+/** Path to the Codex user-level config file. */
+export function codexConfigPath(): string {
+  return join(homedir(), ".codex", "config.toml");
+}
+
+/**
+ * Update (or create) the Codex user-level `config.toml` to set
+ * `openai_base_url` to the Lore gateway.
+ *
+ * Strategy:
+ * - If `openai_base_url` already exists as a top-level key, replace it.
+ * - Otherwise insert it at the top of the file (before any [section]).
+ * - Preserves all other config, comments, and sections.
+ * - Idempotent: running twice produces the same result.
+ */
+export function updateCodexConfig(content: string, baseUrl: string): string {
+  const newLine = `openai_base_url = "${baseUrl}"`;
+
+  // Check if openai_base_url already exists as a top-level key.
+  // Must match only top-level occurrences (not inside a [section]).
+  // We find lines matching the key and verify they're before the first section
+  // or replace them in-place.
+  const lines = content.split("\n");
+  const keyPattern = /^\s*openai_base_url\s*=/;
+  let replaced = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    if (keyPattern.test(lines[i])) {
+      // Check this is a top-level key (not inside a [section]).
+      // Walk backwards to see if we're inside a section.
+      if (isTopLevel(lines, i)) {
+        lines[i] = newLine;
+        replaced = true;
+        break;
+      }
+    }
+  }
+
+  if (replaced) {
+    return lines.join("\n");
+  }
+
+  // Insert at the top, before the first [section] or at the very start.
+  // Find the first non-comment, non-blank line that starts a section.
+  const firstSectionIdx = lines.findIndex((line) =>
+    /^\s*\[/.test(line),
+  );
+
+  if (firstSectionIdx === -1) {
+    // No sections — append at end (with blank line separator if needed)
+    const trimmed = content.trimEnd();
+    return trimmed ? `${trimmed}\n${newLine}\n` : `${newLine}\n`;
+  }
+
+  // Insert before the first section, with a blank line after if needed
+  const before = lines.slice(0, firstSectionIdx);
+  const after = lines.slice(firstSectionIdx);
+
+  // Remove trailing blank lines from 'before' to avoid double-spacing
+  while (before.length > 0 && before[before.length - 1].trim() === "") {
+    before.pop();
+  }
+
+  const beforeStr = before.length > 0 ? before.join("\n") + "\n" : "";
+  return `${beforeStr}${newLine}\n\n${after.join("\n")}`;
+}
+
+/**
+ * Check whether the line at `index` is a top-level key (not inside a [section]).
+ * Walks backwards from the line; if a `[section]` header is found before
+ * reaching the start of the file, the key belongs to that section.
+ */
+function isTopLevel(lines: string[], index: number): boolean {
+  for (let i = index - 1; i >= 0; i--) {
+    const line = lines[i].trim();
+    if (line === "" || line.startsWith("#")) continue;
+    // If we hit a section header, this key is inside that section
+    if (/^\[/.test(line)) return false;
+    // Other bare keys don't tell us anything — keep walking back
+  }
+  // Reached the start of the file without hitting a section header → top level
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Codex setup
+// ---------------------------------------------------------------------------
+
+function setupCodex(baseUrl: string): void {
+  const configPath = codexConfigPath();
+  const configDir = join(homedir(), ".codex");
+
+  // Ensure ~/.codex/ exists (recursive: true is a no-op when it already exists)
+  mkdirSync(configDir, { recursive: true });
+
+  // Read existing config or start fresh
+  let content = "";
+  try {
+    content = readFileSync(configPath, "utf8");
+  } catch (e: unknown) {
+    if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
+  }
+
+  const updated = updateCodexConfig(content, baseUrl);
+  writeFileSync(configPath, updated, "utf8");
+
+  console.log(`[lore] Codex configured to use Lore gateway.`);
+  console.log(`[lore]   openai_base_url = "${baseUrl}"`);
+  console.log(`[lore]   Config: ${configPath}`);
+  console.log(`[lore]`);
+  console.log(`[lore] Make sure the gateway is running (lore start) before using Codex.`);
+}
+
+// ---------------------------------------------------------------------------
+// Command entry point
+// ---------------------------------------------------------------------------
+
+export async function commandSetup(
+  args: string[],
+  values: Record<string, unknown>,
+): Promise<void> {
+  const remoteUrl = values.remote as string | undefined;
+  const port = values.port ? Number(values.port) : undefined;
+
+  let baseUrl: string;
+  try {
+    baseUrl = normalizeBaseUrl(remoteUrl, port);
+  } catch (e) {
+    console.error(`[lore] ${e instanceof Error ? e.message : e}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const appName = args[0]?.toLowerCase();
+
+  if (appName) {
+    // Explicit app name given
+    const app = SUPPORTED_APPS.find(
+      (a) => a.agentName === appName || a.displayName.toLowerCase() === appName,
+    );
+
+    if (!app) {
+      const supported = SUPPORTED_APPS.map((a) => a.agentName).join(", ");
+      console.error(`[lore] Unknown app "${args[0]}". Supported apps: ${supported}`);
+      process.exitCode = 1;
+      return;
+    }
+
+    // Warn if the binary isn't detected, but proceed anyway
+    const detected = detectAgents();
+    if (!detected.some((d) => d.def.name === app.agentName)) {
+      console.log(`[lore] Warning: ${app.displayName} binary not found on PATH. Configuring anyway.`);
+    }
+
+    app.run(baseUrl);
+    return;
+  }
+
+  // No app name — auto-detect
+  const detected = detectAgents();
+  const setupTargets = SUPPORTED_APPS.filter((app) =>
+    detected.some((d) => d.def.name === app.agentName),
+  );
+
+  if (setupTargets.length === 0) {
+    const supported = SUPPORTED_APPS.map((a) => `${a.displayName} (lore setup ${a.agentName})`).join(", ");
+    console.error(`[lore] No supported apps detected.`);
+    console.error(`[lore] Supported: ${supported}`);
+    console.error(`[lore] You can also specify an app explicitly: lore setup <app>`);
+    process.exitCode = 1;
+    return;
+  }
+
+  for (const app of setupTargets) {
+    app.run(baseUrl);
+  }
+}

--- a/packages/gateway/test/agents.test.ts
+++ b/packages/gateway/test/agents.test.ts
@@ -70,9 +70,24 @@ describe("Codex agent envVars", () => {
     expect(env.LORE_PROJECT).toBe("/home/user/my-project");
   });
 
-  test("sets OPENAI_BASE_URL with /v1 suffix", () => {
+  test("does NOT set OPENAI_BASE_URL (Codex CLI ignores it)", () => {
     const codex = AGENTS.find((a) => a.name === "codex")!;
     const env = codex.envVars("http://127.0.0.1:3207", "/tmp/test");
-    expect(env.OPENAI_BASE_URL).toBe("http://127.0.0.1:3207/v1");
+    expect(env.OPENAI_BASE_URL).toBeUndefined();
+  });
+});
+
+describe("Codex agent cliArgs", () => {
+  test("returns -c openai_base_url override with /v1 suffix", () => {
+    const codex = AGENTS.find((a) => a.name === "codex")!;
+    expect(codex.cliArgs).toBeDefined();
+    const args = codex.cliArgs!("http://127.0.0.1:3207", "/tmp/test");
+    expect(args).toEqual(["-c", 'openai_base_url="http://127.0.0.1:3207/v1"']);
+  });
+
+  test("includes gateway URL in the override", () => {
+    const codex = AGENTS.find((a) => a.name === "codex")!;
+    const args = codex.cliArgs!("http://192.168.1.100:5673", "/tmp/test");
+    expect(args[1]).toContain("http://192.168.1.100:5673/v1");
   });
 });

--- a/packages/gateway/test/setup.test.ts
+++ b/packages/gateway/test/setup.test.ts
@@ -1,0 +1,272 @@
+import { describe, test, expect } from "bun:test";
+import { updateCodexConfig, normalizeBaseUrl } from "../src/cli/setup";
+
+// ---------------------------------------------------------------------------
+// normalizeBaseUrl
+// ---------------------------------------------------------------------------
+
+describe("normalizeBaseUrl", () => {
+  test("default local URL with default port", () => {
+    expect(normalizeBaseUrl(undefined, undefined)).toBe("http://127.0.0.1:3207/v1");
+  });
+
+  test("default local URL with custom port", () => {
+    expect(normalizeBaseUrl(undefined, 8080)).toBe("http://127.0.0.1:8080/v1");
+  });
+
+  test("remote URL without trailing slash", () => {
+    expect(normalizeBaseUrl("http://remote:3207", undefined)).toBe("http://remote:3207/v1");
+  });
+
+  test("remote URL with trailing slash", () => {
+    expect(normalizeBaseUrl("http://remote:3207/", undefined)).toBe("http://remote:3207/v1");
+  });
+
+  test("remote URL with multiple trailing slashes", () => {
+    expect(normalizeBaseUrl("http://remote:3207///", undefined)).toBe("http://remote:3207/v1");
+  });
+
+  test("remote URL already ending in /v1", () => {
+    expect(normalizeBaseUrl("http://remote:3207/v1", undefined)).toBe("http://remote:3207/v1");
+  });
+
+  test("remote URL ending in /v1/", () => {
+    expect(normalizeBaseUrl("http://remote:3207/v1/", undefined)).toBe("http://remote:3207/v1");
+  });
+
+  test("remote URL takes precedence over port", () => {
+    expect(normalizeBaseUrl("http://remote:9999", 8080)).toBe("http://remote:9999/v1");
+  });
+
+  test("rejects URL with double-quotes", () => {
+    expect(() => normalizeBaseUrl('http://evil.com/v1"inject', undefined)).toThrow("Invalid characters");
+  });
+
+  test("rejects URL with control characters", () => {
+    expect(() => normalizeBaseUrl("http://evil.com/v1\nmalicious", undefined)).toThrow("Invalid characters");
+  });
+
+  test("rejects URL with backslash", () => {
+    expect(() => normalizeBaseUrl("http://evil.com\\v1", undefined)).toThrow("Invalid characters");
+  });
+
+  test("rejects whitespace-only remote URL", () => {
+    expect(() => normalizeBaseUrl("  ", undefined)).toThrow("cannot be empty");
+  });
+
+  test("rejects invalid port", () => {
+    expect(() => normalizeBaseUrl(undefined, 99999)).toThrow("Invalid port");
+  });
+
+  test("rejects NaN port", () => {
+    expect(() => normalizeBaseUrl(undefined, NaN)).toThrow("Invalid port");
+  });
+
+  test("rejects negative port", () => {
+    expect(() => normalizeBaseUrl(undefined, -1)).toThrow("Invalid port");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateCodexConfig — empty / new file
+// ---------------------------------------------------------------------------
+
+describe("updateCodexConfig — empty file", () => {
+  test("creates config from empty string", () => {
+    const result = updateCodexConfig("", "http://127.0.0.1:3207/v1");
+    expect(result).toBe('openai_base_url = "http://127.0.0.1:3207/v1"\n');
+  });
+
+  test("creates config from whitespace-only string", () => {
+    const result = updateCodexConfig("  \n\n  ", "http://127.0.0.1:3207/v1");
+    expect(result).toBe('openai_base_url = "http://127.0.0.1:3207/v1"\n');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateCodexConfig — idempotency
+// ---------------------------------------------------------------------------
+
+describe("updateCodexConfig — idempotency", () => {
+  test("applying twice produces identical content", () => {
+    const first = updateCodexConfig("", "http://127.0.0.1:3207/v1");
+    const second = updateCodexConfig(first, "http://127.0.0.1:3207/v1");
+    expect(second).toBe(first);
+  });
+
+  test("idempotent with existing config", () => {
+    const input = `model = "gpt-5.5"\nopenai_base_url = "http://127.0.0.1:3207/v1"\napproval_policy = "on-request"\n`;
+    const result = updateCodexConfig(input, "http://127.0.0.1:3207/v1");
+    expect(result).toBe(input);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateCodexConfig — replace existing top-level key
+// ---------------------------------------------------------------------------
+
+describe("updateCodexConfig — replace existing", () => {
+  test("replaces existing openai_base_url at top level", () => {
+    const input = `model = "gpt-5.5"\nopenai_base_url = "https://api.openai.com/v1"\napproval_policy = "on-request"\n`;
+    const result = updateCodexConfig(input, "http://127.0.0.1:3207/v1");
+    expect(result).toContain('openai_base_url = "http://127.0.0.1:3207/v1"');
+    expect(result).toContain('model = "gpt-5.5"');
+    expect(result).toContain('approval_policy = "on-request"');
+    expect(result).not.toContain("https://api.openai.com/v1");
+  });
+
+  test("replaces with different URL", () => {
+    const input = 'openai_base_url = "http://127.0.0.1:3207/v1"\n';
+    const result = updateCodexConfig(input, "http://remote:8080/v1");
+    expect(result).toBe('openai_base_url = "http://remote:8080/v1"\n');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateCodexConfig — preserve unrelated config
+// ---------------------------------------------------------------------------
+
+describe("updateCodexConfig — preserve other config", () => {
+  test("preserves comments", () => {
+    const input = `# My config\nmodel = "gpt-5.5"\n# Another comment\n`;
+    const result = updateCodexConfig(input, "http://127.0.0.1:3207/v1");
+    expect(result).toContain("# My config");
+    expect(result).toContain("# Another comment");
+    expect(result).toContain('model = "gpt-5.5"');
+    expect(result).toContain('openai_base_url = "http://127.0.0.1:3207/v1"');
+  });
+
+  test("preserves sections and their contents", () => {
+    const input = [
+      'model = "gpt-5.5"',
+      "",
+      "[features]",
+      "shell_snapshot = true",
+      "",
+      "[mcp_servers.test]",
+      'command = "/usr/bin/test"',
+      "",
+    ].join("\n");
+    const result = updateCodexConfig(input, "http://127.0.0.1:3207/v1");
+    expect(result).toContain('openai_base_url = "http://127.0.0.1:3207/v1"');
+    expect(result).toContain("[features]");
+    expect(result).toContain("shell_snapshot = true");
+    expect(result).toContain("[mcp_servers.test]");
+    expect(result).toContain('command = "/usr/bin/test"');
+  });
+
+  test("preserves other model_providers", () => {
+    const input = [
+      'model_provider = "proxy"',
+      "",
+      "[model_providers.proxy]",
+      'name = "My Proxy"',
+      'base_url = "http://proxy.example.com"',
+      "",
+    ].join("\n");
+    const result = updateCodexConfig(input, "http://127.0.0.1:3207/v1");
+    expect(result).toContain("[model_providers.proxy]");
+    expect(result).toContain('name = "My Proxy"');
+    expect(result).toContain('base_url = "http://proxy.example.com"');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateCodexConfig — TOML scoping edge case
+// ---------------------------------------------------------------------------
+
+describe("updateCodexConfig — TOML section scoping", () => {
+  test("inserts before first section when no top-level keys exist", () => {
+    const input = "[features]\nshell_snapshot = true\n";
+    const result = updateCodexConfig(input, "http://127.0.0.1:3207/v1");
+    // openai_base_url should appear before [features]
+    const urlIdx = result.indexOf("openai_base_url");
+    const sectionIdx = result.indexOf("[features]");
+    expect(urlIdx).toBeLessThan(sectionIdx);
+    expect(urlIdx).toBeGreaterThanOrEqual(0);
+  });
+
+  test("inserts after existing top-level keys but before sections", () => {
+    const input = 'model = "gpt-5.5"\n\n[features]\nshell_snapshot = true\n';
+    const result = updateCodexConfig(input, "http://127.0.0.1:3207/v1");
+    const modelIdx = result.indexOf("model =");
+    const urlIdx = result.indexOf("openai_base_url");
+    const sectionIdx = result.indexOf("[features]");
+    expect(modelIdx).toBeLessThan(urlIdx);
+    expect(urlIdx).toBeLessThan(sectionIdx);
+  });
+
+  test("does NOT replace a key that is inside a section (TOML scoping bug)", () => {
+    // This reproduces the exact bug the user hit: openai_base_url accidentally
+    // placed under [tui.model_availability_nux] due to TOML scoping.
+    const input = [
+      "[tui.model_availability_nux]",
+      '"gpt-5.5" = 1',
+      'openai_base_url = "should-not-be-touched"',
+      "",
+    ].join("\n");
+    const result = updateCodexConfig(input, "http://127.0.0.1:3207/v1");
+    // Should insert a NEW top-level key, not replace the one inside the section
+    const lines = result.split("\n");
+    // The section-scoped key should still be there
+    expect(result).toContain('openai_base_url = "should-not-be-touched"');
+    // AND a new top-level one should be added before the section
+    const topLevelUrl = lines.findIndex(
+      (l) => l.trim() === 'openai_base_url = "http://127.0.0.1:3207/v1"',
+    );
+    const sectionIdx = lines.findIndex((l) => l.trim().startsWith("["));
+    expect(topLevelUrl).toBeGreaterThanOrEqual(0);
+    expect(topLevelUrl).toBeLessThan(sectionIdx);
+  });
+
+  test("replaces top-level key even when sections follow", () => {
+    const input = [
+      'openai_base_url = "https://old.example.com/v1"',
+      "",
+      "[features]",
+      "shell_snapshot = true",
+      "",
+    ].join("\n");
+    const result = updateCodexConfig(input, "http://127.0.0.1:3207/v1");
+    expect(result).toContain('openai_base_url = "http://127.0.0.1:3207/v1"');
+    expect(result).not.toContain("https://old.example.com/v1");
+    expect(result).toContain("[features]");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateCodexConfig — real-world Codex config
+// ---------------------------------------------------------------------------
+
+describe("updateCodexConfig — real-world config", () => {
+  test("handles a typical Codex App config", () => {
+    const input = [
+      'notify = ["/path/to/notifier", "turn-ended"]',
+      "[marketplaces.openai-bundled]",
+      'last_updated = "2026-06-03T10:29:58Z"',
+      'source_type = "local"',
+      'source = "/path/to/marketplace"',
+      "[plugins.\"browser@openai-bundled\"]",
+      "enabled = true",
+      "[features]",
+      "js_repl = false",
+      "[desktop]",
+      'conversationDetailMode = "STEPS_COMMANDS"',
+      "[mcp_servers.node_repl]",
+      "args = []",
+      'command = "/path/to/node_repl"',
+      "",
+    ].join("\n");
+    const result = updateCodexConfig(input, "http://127.0.0.1:3207/v1");
+    // Should be inserted at the top, before sections
+    const urlIdx = result.indexOf("openai_base_url");
+    const firstSection = result.indexOf("[marketplaces");
+    expect(urlIdx).toBeLessThan(firstSection);
+    expect(urlIdx).toBeGreaterThanOrEqual(0);
+    // Original content preserved
+    expect(result).toContain("notify =");
+    expect(result).toContain("[features]");
+    expect(result).toContain("[desktop]");
+    expect(result).toContain("[mcp_servers.node_repl]");
+  });
+});


### PR DESCRIPTION
## Summary

Adds `lore setup [app]` CLI command that configures AI apps to route through the Lore gateway. Also fixes the broken `lore run codex` which was silently not routing traffic through the gateway.

## Problem

The Codex CLI is a Rust binary that does **not** read `OPENAI_BASE_URL` from the environment — it only reads provider config from `~/.codex/config.toml` or `-c` CLI overrides. Our existing Codex agent definition in `agents.ts` was setting `OPENAI_BASE_URL` as an env var, which was a complete no-op. Zero traffic was reaching the gateway when running `lore run codex`.

## Root Cause Analysis

Investigation of the [Codex source](https://github.com/openai/codex) (`codex-rs/`) confirmed:
- `OPENAI_BASE_URL` env var is not read anywhere in Codex's Rust codebase
- Provider base URL can only be set via `openai_base_url` in `config.toml` or `-c` CLI overrides
- Custom `model_providers` work but cause a **session scoping issue** — Codex scopes sessions to `model_provider`, so changing it hides existing sessions
- The gateway's project identification works via system prompt inference (fallback #2), so custom `X-Lore-Project` headers are not critical

## Changes

### Fix `lore run codex` (`agents.ts`, `run.ts`)
- Add optional `cliArgs` method to `AgentDef` interface for agents needing CLI argument injection
- Codex agent now returns `-c openai_base_url="<gateway>/v1"` as CLI args instead of the broken `OPENAI_BASE_URL` env var
- `run.ts` updated to prepend `cliArgs` to child process arguments in both explicit and auto-detect paths
- Still sets `LORE_PROJECT` / `LORE_GIT_REMOTE` env vars for potential `env_http_headers` use

### New `lore setup codex` command (`setup.ts`)
- Writes `openai_base_url = "http://127.0.0.1:3207/v1"` to `~/.codex/config.toml`
- Uses the built-in `openai` provider redirect (no custom provider) to avoid session scoping issues
- TOML updater correctly handles top-level key placement before `[section]` headers
- Supports `--remote` and `--port` flags for custom gateway URLs
- Auto-detect mode (`lore setup`) or explicit (`lore setup codex`)
- Idempotent — safe to run multiple times

### CLI wiring (`main.ts`, `help.ts`)
- New `setup` command in dispatch, help text, examples, and typo suggestions

### Tests
- 22 new tests for TOML updater, URL normalization, and section scoping edge cases
- Updated Codex agent tests to verify `cliArgs` instead of `OPENAI_BASE_URL`
- All 2019 tests pass, typecheck clean across all 4 packages

## Design Decision: `openai_base_url` vs custom provider

We chose `openai_base_url` (redirects the built-in `openai` provider) over a custom `loreai` provider because:
1. **No session scoping issue** — sessions stay scoped to `openai`, preserving history
2. **Simpler config** — one top-level key vs a full `[model_providers.loreai]` section
3. **Custom headers not critical** — gateway infers the project from the system prompt