### PR TITLE
fix(gateway): offer auto-import per-agent so new agents aren't skipped

### DIFF
--- a/packages/core/src/import/history.ts
+++ b/packages/core/src/import/history.ts
@@ -72,8 +72,57 @@ export function recordImport(
 }
 
 /**
+ * Check whether an agent has any import_history row for this project,
+ * including the "__declined__" sentinel. Used by auto-import to decide
+ * whether an agent is brand-new (never imported AND never declined).
+ *
+ * Unlike isImported(), this is hash-agnostic and source-agnostic — it
+ * answers "have we ever offered/handled this agent here?".
+ */
+export function hasAgentImportRecord(projectPath: string, agentName: string): boolean {
+  const projectId = ensureProject(projectPath);
+  return !!db()
+    .query(
+      `SELECT 1 FROM import_history
+       WHERE project_id = ? AND agent_name = ?
+       LIMIT 1`,
+    )
+    .get(projectId, agentName);
+}
+
+/**
+ * Record that the user declined auto-import for a specific agent in this
+ * project. Writes a sentinel row (source_id = "__declined__") so the agent
+ * is not re-offered. Excluded from listImports() by the sentinel filter.
+ *
+ * NOTE: This revives a per-agent variant of the pre-v22 decline sentinel.
+ * Do not remove the "__declined__" filter in listImports() — it keeps these
+ * sentinels invisible to the dashboard/REST surface.
+ */
+export function recordDecline(projectPath: string, agentName: string): void {
+  const projectId = ensureProject(projectPath);
+  db()
+    .query(
+      `INSERT OR REPLACE INTO import_history
+       (id, project_id, agent_name, source_id, source_hash, entries_created, entries_updated, imported_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      crypto.randomUUID(),
+      projectId,
+      agentName,
+      "__declined__",
+      "", // source_hash unused for sentinel — never compared
+      0,
+      0,
+      Date.now(),
+    );
+}
+
+/**
  * Get all import records for a project.
- * Excludes legacy "__declined__" sentinel rows from pre-v22 databases.
+ * Excludes "__declined__" sentinel rows written by {@link recordDecline}
+ * (used for auto-import gating, not visible to the user/dashboard).
  */
 export function listImports(projectPath: string): ImportRecord[] {
   const projectId = ensureProject(projectPath);

--- a/packages/core/src/import/index.ts
+++ b/packages/core/src/import/index.ts
@@ -29,6 +29,8 @@ export { extractKnowledge, type ExtractionProgress, type ExtractionResult } from
 export {
   isImported,
   recordImport,
+  recordDecline,
+  hasAgentImportRecord,
   computeHash,
   listImports,
   type ImportRecord,

--- a/packages/core/test/import/history.test.ts
+++ b/packages/core/test/import/history.test.ts
@@ -1,8 +1,10 @@
 import { describe, test, expect } from "bun:test";
-import { ensureProject } from "../../src/db";
+import { db, ensureProject } from "../../src/db";
 import {
   isImported,
   recordImport,
+  recordDecline,
+  hasAgentImportRecord,
   listImports,
   computeHash,
 } from "../../src/import/history";
@@ -69,6 +71,57 @@ describe("import history", () => {
 
       const imports = listImports(LIST_PROJECT);
       expect(imports.length).toBe(2);
+    });
+  });
+
+  describe("hasAgentImportRecord / recordDecline", () => {
+    const P = "/test/import-per-agent-project";
+
+    test("setup: create test project", () => {
+      ensureProject(P);
+    });
+
+    test("hasAgentImportRecord false for unknown agent", () => {
+      expect(hasAgentImportRecord(P, "codex")).toBe(false);
+    });
+
+    test("true after a real import; sibling agent unaffected", () => {
+      recordImport(P, "claude-code", "sess-1", "h1", { created: 1, updated: 0 });
+      expect(hasAgentImportRecord(P, "claude-code")).toBe(true);
+      expect(hasAgentImportRecord(P, "codex")).toBe(false);
+    });
+
+    test("recordDecline makes the agent 'handled'", () => {
+      expect(hasAgentImportRecord(P, "codex")).toBe(false);
+      recordDecline(P, "codex");
+      expect(hasAgentImportRecord(P, "codex")).toBe(true);
+    });
+
+    test("recordDecline is idempotent (INSERT OR REPLACE, no duplicate row)", () => {
+      recordDecline(P, "opencode");
+      recordDecline(P, "opencode");
+      const row = db()
+        .query(
+          `SELECT COUNT(*) as c FROM import_history
+           WHERE project_id = ? AND agent_name = ? AND source_id = '__declined__'`,
+        )
+        .get(ensureProject(P), "opencode") as { c: number };
+      expect(row.c).toBe(1);
+    });
+
+    test("listImports still excludes __declined__ sentinels", () => {
+      const LP = "/test/per-agent-list";
+      ensureProject(LP);
+      recordImport(LP, "claude-code", "s1", "h", { created: 1, updated: 0 });
+      recordDecline(LP, "codex");
+      const imports = listImports(LP);
+      expect(imports.length).toBe(1);
+      expect(imports.every((r) => r.source_id !== "__declined__")).toBe(true);
+    });
+
+    test("declined agent: isImported still null for real sessions", () => {
+      recordDecline(P, "aider");
+      expect(isImported(P, "aider", "some-session", "anyhash")).toBeNull();
     });
   });
 

--- a/packages/gateway/src/cli/import-auto.ts
+++ b/packages/gateway/src/cli/import-auto.ts
@@ -2,16 +2,16 @@
  * Auto-detection and background import of prior AI agent conversations.
  *
  * Called from `lore run` between gateway startup and agent launch.
- * Only triggers once per project (tracks via last_import_at on the projects table).
- * Prompts once, then runs import in the background if confirmed.
+ * Offers import per newly-detected agent (tracked via import_history per agent;
+ * declines are recorded as "__declined__" sentinels). Agents already imported or
+ * previously declined are skipped, so a newly installed agent is still offered.
+ * Prompts once per new agent, then runs import in the background if confirmed.
  */
 import { createInterface } from "node:readline";
 import {
   conversationImport,
   config as loreConfig,
   ensureProject,
-  getLastImportAt,
-  setLastImportAt,
   exportLoreFile,
 } from "@loreai/core";
 import { createGatewayLLMClient } from "../llm-adapter";
@@ -24,6 +24,8 @@ const {
   getProvider,
   isImported,
   recordImport,
+  recordDecline,
+  hasAgentImportRecord,
   computeHash,
 } = conversationImport;
 
@@ -44,10 +46,10 @@ async function promptYesNo(message: string): Promise<boolean> {
  * Auto-detect prior conversations and offer to import them.
  * Called from `commandRun()` before launching the agent.
  *
- * - Only triggers for fresh projects (no existing lore data).
+ * - Only offers agents not yet imported or declined for this project.
  * - Shows a one-line prompt to the user.
  * - If confirmed, runs extraction in the background (fire-and-forget).
- * - If declined, records the decision so we don't ask again.
+ * - If declined, records a per-agent decline sentinel so we don't ask again.
  */
 export async function maybeAutoImport(gatewayConfig: GatewayConfig): Promise<void> {
   const projectPath = process.cwd();
@@ -58,14 +60,20 @@ export async function maybeAutoImport(gatewayConfig: GatewayConfig): Promise<voi
     return; // Can't determine project — skip
   }
 
-  // Skip if import was already offered/run for this project
-  if (getLastImportAt(projectPath) !== null) return;
-
-  // Detect conversation history
+  // Detect conversation history across all known agents.
   let results = detectAll(projectPath);
   if (results.length === 0) return;
 
-  // Filter out already-imported sessions
+  // PER-AGENT GATE (apply FIRST): only consider agents we've never handled
+  // here — neither imported (real rows) nor declined ("__declined__" sentinel).
+  // This must run before the per-session filter below: a declined agent has no
+  // session rows, so isImported() would not catch it — only the gate does.
+  // Known agents with new sessions are intentionally skipped; incremental
+  // same-agent imports remain the job of explicit `lore import`.
+  results = results.filter((r) => !hasAgentImportRecord(projectPath, r.agentName));
+  if (results.length === 0) return;
+
+  // Defensive per-session filter for the surviving brand-new agents.
   for (const result of results) {
     result.sessions = result.sessions.filter((sess) => {
       const hash = computeHash({
@@ -83,14 +91,21 @@ export async function maybeAutoImport(gatewayConfig: GatewayConfig): Promise<voi
   const totalMessages = results.reduce((s, r) => s + r.totalMessages, 0);
   const agentNames = results.map((r) => r.agentDisplayName).join(", ");
 
-  // Prompt the user
+  // Prompt the user (lists only the brand-new agents).
   const ok = await promptYesNo(
     `[lore] Found ${totalMessages} messages from prior conversations (${agentNames}).\n` +
       "[lore] Import knowledge from them?",
   );
 
-  // Record that import was offered — prevents re-prompting regardless of answer
-  setLastImportAt(projectPath, Date.now());
+  // Record decline sentinels BEFORE any background work — prevents a second
+  // `lore run` from re-prompting while the background import is still running.
+  // On accept, the sentinels are harmless: real recordImport() rows (with actual
+  // session source_ids) are written later and hasAgentImportRecord() returns true
+  // regardless. This mirrors the old per-project setLastImportAt() which also
+  // ran before checking the user's answer.
+  for (const result of results) {
+    recordDecline(projectPath, result.agentName);
+  }
 
   if (!ok) return;
 

--- a/packages/gateway/src/cli/import.ts
+++ b/packages/gateway/src/cli/import.ts
@@ -270,7 +270,8 @@ export async function commandImport(
       totalFailed += extractResult.chunksFailed;
     }
 
-    // Record import timestamp (prevents auto-import re-prompting on `lore run`)
+    // Record import timestamp (supplementary — auto-import gates on per-agent
+    // import_history rows via hasAgentImportRecord, not this timestamp)
     setLastImportAt(projectPath, Date.now());
 
     // Export .lore.md
@@ -389,7 +390,8 @@ async function importRemote(
     totalFailed += extractResult.chunksFailed;
   }
 
-  // Record import timestamp locally (prevents auto-import re-prompting on `lore run`)
+  // Record import timestamp locally (supplementary — auto-import gates on per-agent
+  // import_history rows via hasAgentImportRecord, not this timestamp)
   setLastImportAt(projectPath, Date.now());
 
   // Export .lore.md locally so knowledge appears in the local file

--- a/packages/gateway/src/cli/run.ts
+++ b/packages/gateway/src/cli/run.ts
@@ -180,7 +180,7 @@ export async function commandRun(
   }
   console.log(`[lore] Dashboard: ${gatewayUrl}/ui`);
 
-  // 2. Auto-detect prior conversations (first run only)
+  // 2. Auto-detect prior conversations (per newly-detected agent)
   if (owned) {
     await maybeAutoImport(config);
   }


### PR DESCRIPTION
## Problem

When `lore run` is used in a project where import was already offered (for any agent), newly installed agents like Codex never get their conversations imported. The auto-import check at `packages/gateway/src/cli/import-auto.ts` used a **per-project** timestamp:

```ts
if (getLastImportAt(projectPath) !== null) return;
```

So if a user first ran `lore run claude` and accepted/declined, then later installed Codex, running `lore run codex` would never offer to import.

Fixes #516.

## Fix

Replace the per-project gate with **per-agent gating** backed by the already-agent-aware `import_history` table — no schema migration needed:

- **`hasAgentImportRecord(project, agent)`** — gate predicate; `true` if the agent has *any* row (a real imported session OR a `__declined__` sentinel).
- **`recordDecline(project, agent)`** — writes a per-agent `__declined__` sentinel (revives a per-agent variant of the pre-v22 sentinel; reuses the existing table).
- **`import-auto.ts`** — filters detected agents to brand-new ones *first* (agent gate before the per-session filter, since a declined agent has no session rows), prompts only for those, and records per-agent decline sentinels **before** the background import (on both accept and decline paths) to prevent a concurrent `lore run` from re-prompting while the import is still running.

`setLastImportAt` writes in `import.ts` left untouched (supplementary; auto-import now gates on per-agent `import_history` rows, not this timestamp).

### Behavior
- Brand-new agent → prompted ✅
- Declined agent → not re-prompted (sentinel) ✅
- Already-imported agent → skipped (no regression; incremental same-agent imports remain the job of explicit `lore import`) ✅
- Concurrent `lore run` during background import → not re-prompted (sentinels written synchronously before background work) ✅

## Tests

6 new unit tests in `packages/core/test/import/history.test.ts` covering the helpers, idempotency, `listImports` sentinel exclusion, and decline-vs-`isImported` independence.

## Verification

- `bun --filter '*' typecheck` — clean across all 4 packages
- `bun test packages/core/test/import/history.test.ts` — 16 pass
- Full suite: pre-existing order-dependent flakiness in `quota.test.ts` (fails on unmodified `main` too) — unrelated to these changes.