### PR TITLE
docs(gateway): clarify stateless Responses API comments (post-#517 review)

### DIFF
--- a/packages/gateway/src/translate/openai-responses.ts
+++ b/packages/gateway/src/translate/openai-responses.ts
@@ -314,6 +314,12 @@ export function buildOpenAIResponsesUpstreamRequest(
     // worse, defeating the gateway's compression and recall edits with an
     // un-editable server-side copy. Dropping it keeps the upstream's view
     // consistent with what the gateway actually sends.
+    //
+    // Logged at `warn` (not `error`) deliberately: this is the gateway working
+    // as designed, not a failure. `error` would print red `[lore]` noise on
+    // every request from a client that sets the field. The file log + Sentry
+    // breadcrumb provide observability; the application-level symptom (no
+    // server-side continuation) is what a debugging user would actually chase.
     if (req.extras.previous_response_id !== undefined) {
       log.warn(
         "dropping previous_response_id; gateway sends full conversation history " +

--- a/packages/gateway/test/openai-responses.test.ts
+++ b/packages/gateway/test/openai-responses.test.ts
@@ -6,7 +6,8 @@
  *  - Upstream request round-trip
  *  - Response conversion (non-streaming and streaming)
  *  - Stop reason → status mapping
- *  - Extras passthrough (previous_response_id, reasoning, truncation)
+ *  - Extras: reasoning/truncation passthrough; previous_response_id is DROPPED
+ *    (the gateway is a stateless full-history proxy)
  */
 import { describe, test, expect } from "bun:test";
 import {


### PR DESCRIPTION
Follow-up to #517, addressing the LOW/MEDIUM findings from the post-merge review. **Comment-only — no behavior change.**

## Changes

1. **Document the deliberate `log.warn` level** for the `previous_response_id` / `item_reference` drops (review finding #3, MEDIUM). These use `warn` (not `error`) on purpose: the gateway is working as designed (stateless full-history), not failing. `error` would print red `[lore]` noise on every request from a client that sets the field. The file log + Sentry breadcrumb already provide observability, and the real symptom (no server-side continuation) surfaces at the application level.

2. **Fix a stale test header comment** (review finding #1, LOW) that still listed `previous_response_id` under "Extras passthrough" — it is now dropped, not passed through.

## Context: why the gateway is stateless

Raised by a follow-up question ("what's so bad about letting the server tie sessions together?"). `previous_response_id` + `store: true` makes OpenAI keep prior turns server-side. But the gateway's whole job is to **rewrite** the conversation each turn (gradient compression, distillation, recall injection). If we also forwarded `previous_response_id`, OpenAI would prepend its **un-editable raw copy** of the prior turns to our curated `input` — duplicating history and defeating compression/recall entirely. You either own the context (Lore) or the server does (`previous_response_id`); the two are mutually exclusive, so the gateway owns it.

## Verification

- `bun --filter '@loreai/gateway' typecheck` — clean
- `bun test packages/gateway/test/openai-responses.test.ts` — 31 pass / 0 fail