### PR TITLE
test: add coexistence test for per-agent auto-import + fix stale JSDoc

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1216,7 +1216,9 @@ export function getLastImportAt(projectPath: string): number | null {
 
 /**
  * Record that conversation import was offered/run for a project.
- * Prevents auto-import from re-prompting, and enables incremental imports.
+ * Supplementary timestamp — auto-import now gates on per-agent import_history
+ * rows (via hasAgentImportRecord), not this field. Still written by explicit
+ * `lore import` for bookkeeping.
  */
 export function setLastImportAt(projectPath: string, timestamp: number): void {
   const id = ensureProject(projectPath);

--- a/packages/core/test/import/history.test.ts
+++ b/packages/core/test/import/history.test.ts
@@ -123,6 +123,23 @@ describe("import history", () => {
       recordDecline(P, "aider");
       expect(isImported(P, "aider", "some-session", "anyhash")).toBeNull();
     });
+
+    test("coexistence: recordDecline then recordImport — both visible appropriately", () => {
+      const CP = "/test/coexist-project";
+      ensureProject(CP);
+      recordDecline(CP, "claude-code");
+      expect(hasAgentImportRecord(CP, "claude-code")).toBe(true);
+
+      // Real import after sentinel (mirrors the accept path in auto-import)
+      recordImport(CP, "claude-code", "sess-1", "h1", { created: 3, updated: 1 });
+      expect(hasAgentImportRecord(CP, "claude-code")).toBe(true);
+
+      // listImports shows only the real import, not the sentinel
+      const imports = listImports(CP);
+      const agentImports = imports.filter((r) => r.agent_name === "claude-code");
+      expect(agentImports.length).toBe(1);
+      expect(agentImports[0].source_id).toBe("sess-1");
+    });
   });
 
   describe("computeHash", () => {


### PR DESCRIPTION
Follow-up to #518 — two review findings that didn't make it before auto-merge:

1. **Missing coexistence test** (MEDIUM): The accept path in `import-auto.ts` writes a `recordDecline` sentinel, then later `recordImport` writes real session rows. This test verifies the central invariant: `hasAgentImportRecord` returns true after both writes, and `listImports` shows only the real import (not the sentinel).

2. **Stale `setLastImportAt` JSDoc** (NIT): The doc in `db.ts` still said "Prevents auto-import from re-prompting" — but auto-import now gates on per-agent `import_history` rows via `hasAgentImportRecord`, not this timestamp. Updated to say "supplementary."