### PR TITLE
feat(core): structured tool-call execution trace for richer pattern extraction

### DIFF
--- a/packages/core/src/curator.ts
+++ b/packages/core/src/curator.ts
@@ -7,6 +7,7 @@ import * as entities from "./entities";
 import * as embedding from "./embedding";
 import * as log from "./log";
 import { CURATOR_SYSTEM, curatorUser, CONSOLIDATION_SYSTEM, consolidationUser } from "./prompt";
+import * as toolTrace from "./tool-trace";
 import { detectAndFormat } from "./instruction-detect";
 import { curatorLimiter } from "./session-limiter";
 import type { LLMClient } from "./types";
@@ -495,7 +496,17 @@ async function runInner(input: {
     log.warn("action tag context failed (non-fatal):", err);
   }
 
-  const userContent = baseUserContent + crossSessionContext + actionTagContext;
+  // Cross-session tool-failure signal: recurring tool failures across prior
+  // sessions, so the curator can decide whether they warrant a gotcha entry.
+  let toolFailureContext = "";
+  try {
+    toolFailureContext = buildToolFailureContext(input.projectPath, input.sessionID);
+  } catch (err) {
+    log.warn("tool failure context failed (non-fatal):", err);
+  }
+
+  const userContent =
+    baseUserContent + crossSessionContext + actionTagContext + toolFailureContext;
   const model = input.model ?? cfg.model;
   const responseText = await input.llm.prompt(
     CURATOR_SYSTEM,
@@ -637,6 +648,35 @@ function buildActionTagContext(
 
   return (
     "\n\n---\nCross-session behavioral patterns detected (consider creating preference entries for these):\n" +
+    lines.join("\n")
+  );
+}
+
+/**
+ * Build a compact cross-session tool-failure block for the curator prompt.
+ * Aggregates recurring tool failures from the structured `tool_calls` table
+ * (excluding the current session), so the curator can decide whether a
+ * recurring failure warrants a gotcha entry. Returns "" when none qualify.
+ */
+function buildToolFailureContext(
+  projectPath: string,
+  currentSessionID: string,
+): string {
+  const stats = toolTrace.toolFailureStats(projectPath, {
+    minSessions: 2,
+    excludeSessionID: currentSessionID,
+  });
+  if (!stats.length) return "";
+
+  const lines = stats
+    .slice(0, 8)
+    .map(
+      (s) =>
+        `- ${s.tool} failed with "${s.error_type ?? "unknown"}" in ${s.session_count} sessions (${s.failure_count}×)`,
+    );
+
+  return (
+    "\n\n---\nRecurring tool failures across sessions (consider creating gotcha entries for root causes):\n" +
     lines.join("\n")
   );
 }

--- a/packages/core/src/data.ts
+++ b/packages/core/src/data.ts
@@ -359,6 +359,9 @@ export function clearProject(projectPath: string): ClearResult {
       )
       .run(pid);
     database
+      .query("DELETE FROM tool_calls WHERE project_id = ?")
+      .run(pid);
+    database
       .query("DELETE FROM knowledge WHERE project_id = ?")
       .run(pid);
     database
@@ -459,6 +462,9 @@ export function deleteProject(projectId: string): ClearResult | null {
         `DELETE FROM session_state WHERE session_id IN
          (SELECT DISTINCT session_id FROM temporal_messages WHERE project_id = ?)`,
       )
+      .run(projectId);
+    database
+      .query("DELETE FROM tool_calls WHERE project_id = ?")
       .run(projectId);
     database
       .query("DELETE FROM knowledge WHERE project_id = ?")
@@ -617,6 +623,11 @@ export function deleteSession(
       .get(pid, sessionId) as { c: number }
   ).c;
 
+  database
+    .query(
+      "DELETE FROM tool_calls WHERE project_id = ? AND session_id = ?",
+    )
+    .run(pid, sessionId);
   database
     .query(
       "DELETE FROM temporal_messages WHERE project_id = ? AND session_id = ?",

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -738,6 +738,35 @@ const MIGRATIONS: string[] = [
     PRIMARY KEY (day, bucket)
   );
   `,
+  `
+  -- Version 31: Structured tool-call execution trace for richer pattern
+  -- extraction (issue #496). Each tool invocation is recorded with its name,
+  -- success/failure status, a bucketed error type, the raw error message, and
+  -- wall-clock duration. Feeds the curator context, the distillation observer
+  -- pinned block, auto-gotcha creation, and recall.
+  --
+  -- A tool call spans two messages in the Anthropic protocol: the assistant
+  -- tool_use (carries the tool name) and the following user message
+  -- tool_result (carries the outcome). Both phases UPSERT on the globally
+  -- unique call_id PK: the tool_use seeds name + 'pending'; the tool_result
+  -- updates status/error/duration. This also makes re-stores idempotent.
+  CREATE TABLE IF NOT EXISTS tool_calls (
+    call_id       TEXT PRIMARY KEY,
+    message_id    TEXT NOT NULL,
+    project_id    TEXT NOT NULL,
+    session_id    TEXT NOT NULL,
+    tool          TEXT NOT NULL,
+    status        TEXT NOT NULL,        -- 'pending' | 'completed' | 'error'
+    error_type    TEXT,                 -- bucketed classifier output, NULL unless error
+    error_message TEXT,                 -- raw error string (truncated), NULL unless error
+    duration_ms   INTEGER,              -- end-start, NULL if unavailable
+    created_at    INTEGER NOT NULL
+  );
+  CREATE INDEX IF NOT EXISTS idx_tool_calls_project_tool_status
+    ON tool_calls (project_id, tool, status);
+  CREATE INDEX IF NOT EXISTS idx_tool_calls_project_session
+    ON tool_calls (project_id, session_id);
+  `,
 ];
 
 /** Return the resolved path of the SQLite database file. */
@@ -958,6 +987,22 @@ function recoverMissingObjects(database: Database) {
       updated_at INTEGER NOT NULL,
       PRIMARY KEY (day, bucket)
     );
+    CREATE TABLE IF NOT EXISTS tool_calls (
+      call_id       TEXT PRIMARY KEY,
+      message_id    TEXT NOT NULL,
+      project_id    TEXT NOT NULL,
+      session_id    TEXT NOT NULL,
+      tool          TEXT NOT NULL,
+      status        TEXT NOT NULL,
+      error_type    TEXT,
+      error_message TEXT,
+      duration_ms   INTEGER,
+      created_at    INTEGER NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_tool_calls_project_tool_status
+      ON tool_calls (project_id, tool, status);
+    CREATE INDEX IF NOT EXISTS idx_tool_calls_project_session
+      ON tool_calls (project_id, session_id);
   `);
 
   // Recover missing columns from partial migration runs.
@@ -1003,6 +1048,10 @@ export function mergeProjectInternal(
       sourceId,
     );
     d.query("UPDATE entities SET project_id = ? WHERE project_id = ?").run(
+      targetId,
+      sourceId,
+    );
+    d.query("UPDATE tool_calls SET project_id = ? WHERE project_id = ?").run(
       targetId,
       sourceId,
     );

--- a/packages/core/src/distillation.ts
+++ b/packages/core/src/distillation.ts
@@ -6,6 +6,7 @@ import * as embedding from "./embedding";
 import * as ltm from "./ltm";
 import * as log from "./log";
 import { extractPatterns, extractActionTags, tagToTitle } from "./pattern-extract";
+import * as toolTrace from "./tool-trace";
 import { detectPatternEchoes } from "./pattern-echo";
 import {
   DISTILLATION_SYSTEM,
@@ -445,6 +446,51 @@ export function detectAssertions(messages: TemporalMessage[]): PinnedAssertion[]
   return results;
 }
 
+/** Max distinct tool-failure lines pinned into a single distillation prompt. */
+const MAX_PINNED_TOOL_FAILURES = 5;
+
+/**
+ * Minimum distinct sessions and total failures before a recurring tool
+ * failure is auto-promoted to a `gotcha` knowledge entry. Mirrors the
+ * cross-session bar used for action-tag behavioral preferences.
+ */
+const GOTCHA_MIN_SESSIONS = 3;
+const GOTCHA_MIN_FAILURES = 4;
+
+/**
+ * Build a compact tool-failure block for the observer prompt, scoped to the
+ * current segment's time window. Reads the structured `tool_calls` table
+ * (authoritative) rather than re-parsing `[tool:...]` text — which doesn't
+ * carry error info. Returns `undefined` when there are no in-window failures.
+ */
+export function detectToolFailures(
+  projectPath: string,
+  sessionID: string,
+  messages: TemporalMessage[],
+): string | undefined {
+  if (!messages.length) return undefined;
+  const since = messages[0].created_at;
+  const until = messages[messages.length - 1].created_at;
+  const rows = toolTrace.recentSessionFailures(projectPath, sessionID, {
+    sinceMs: since,
+    limit: 100,
+  });
+  const inWindow = rows.filter((r) => r.created_at <= until);
+  if (!inWindow.length) return undefined;
+
+  // Aggregate by (tool, error_type) for compactness.
+  const byKey = new Map<string, number>();
+  for (const r of inWindow) {
+    const key = `${r.tool}:${r.error_type ?? "unknown"}`;
+    byKey.set(key, (byKey.get(key) ?? 0) + 1);
+  }
+  const lines = [...byKey.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, MAX_PINNED_TOOL_FAILURES)
+    .map(([key, n]) => `- ${key} (×${n})`);
+  return lines.join("\n");
+}
+
 type DistillationResult = {
   observations: string;
 };
@@ -881,6 +927,13 @@ async function distillSegment(input: {
       `pinned ${assertions.length} user assertion(s) in segment of ${input.messages.length} msgs`,
     );
   }
+  // Pre-scan structured tool failures in this segment's time window so the
+  // observer surfaces recurring obstacles instead of dropping them as noise.
+  const toolFailures = detectToolFailures(
+    input.projectPath,
+    input.sessionID,
+    input.messages,
+  );
   // Derive session date from first message timestamp
   const first = input.messages[0];
   const date = first
@@ -895,6 +948,7 @@ async function distillSegment(input: {
     date,
     messages: text,
     pinnedAssertions,
+    toolFailures,
   });
 
   const model = input.model ?? config().model;
@@ -1042,6 +1096,36 @@ async function distillSegment(input: {
           // Dedup guard or DB error — swallow
         }
       }
+    }
+
+    // Tool-failure gotcha detection: a tool that fails with the same error
+    // type across multiple distinct sessions is a recurring environmental or
+    // usage gotcha worth surfacing as a knowledge entry.
+    try {
+      const failureStats = toolTrace.toolFailureStats(input.projectPath, {
+        minSessions: GOTCHA_MIN_SESSIONS,
+      });
+      for (const stat of failureStats) {
+        if (stat.failure_count < GOTCHA_MIN_FAILURES) continue;
+        try {
+          ltm.create({
+            projectPath: input.projectPath,
+            category: "gotcha",
+            title: toolTrace.toolGotchaTitle(stat.tool, stat.error_type),
+            content: toolTrace.toolGotchaContent(stat),
+            session: input.sessionID,
+            scope: "project",
+            confidence: 0.75,
+          });
+          log.info(
+            `tool-failure gotcha: ${stat.tool}/${stat.error_type} in ${stat.session_count} sessions — created gotcha`,
+          );
+        } catch {
+          // Dedup guard or DB error — swallow
+        }
+      }
+    } catch {
+      // Aggregation query failure is non-fatal — swallow
     }
   }
 

--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -24,6 +24,8 @@ function estimateParts(parts: LorePart[]): number {
       total += estimate(part.text);
     else if (isToolPart(part) && part.state.status === "completed")
       total += estimate(part.state.output) + estimate(part.tool) + 50;
+    else if (isToolPart(part) && part.state.status === "error")
+      total += estimate(part.state.error) + estimate(part.tool) + 50;
     else total += 20; // metadata overhead for other part types
   }
   return total;
@@ -1202,14 +1204,28 @@ function sanitizeToolParts(
 function stripToolOutputs(parts: LorePart[]): LorePart[] {
   return parts.map((part) => {
     if (!isToolPart(part)) return part;
-    if (part.state.status !== "completed") return part;
-    return {
-      ...part,
-      state: {
-        ...part.state,
-        output: toolStripAnnotation(part.tool, part.state.output),
-      },
-    } as LorePart;
+    if (part.state.status === "completed") {
+      return {
+        ...part,
+        state: {
+          ...part.state,
+          output: toolStripAnnotation(part.tool, part.state.output),
+        },
+      } as LorePart;
+    }
+    // Error outputs (e.g. large stack traces) must also be stripped under
+    // aggressive (Layer 2) compression — otherwise failure-heavy turns evade
+    // the strip entirely and can overflow the context.
+    if (part.state.status === "error") {
+      return {
+        ...part,
+        state: {
+          ...part.state,
+          error: toolStripAnnotation(part.tool, part.state.error),
+        },
+      } as LorePart;
+    }
+    return part;
   });
 }
 

--- a/packages/core/src/prompt.ts
+++ b/packages/core/src/prompt.ts
@@ -200,6 +200,9 @@ export function distillationUser(input: {
   /** Pre-scanned user assertions to pin in the prompt so the observer
    *  cannot accidentally drop them in large, code-dominated segments. */
   pinnedAssertions?: string;
+  /** Pre-scanned tool failures observed in this segment, so the observer
+   *  surfaces recurring obstacles instead of dropping them as noise. */
+  toolFailures?: string;
 }): string {
   const context = input.priorObservations
     ? `Previous observations (do NOT repeat these — your new observations will be appended):\n${input.priorObservations}\n\n---`
@@ -207,10 +210,13 @@ export function distillationUser(input: {
   const pinned = input.pinnedAssertions
     ? `\n⚠️ HIGH-PRIORITY USER ASSERTIONS DETECTED IN THIS SEGMENT:\n${input.pinnedAssertions}\nThese statements MUST appear in your observations — they represent user preferences, decisions, or directives that override prior state.\n`
     : "";
+  const failures = input.toolFailures
+    ? `\n⚙️ TOOL FAILURES OBSERVED IN THIS SEGMENT:\n${input.toolFailures}\nWhen these reflect a recurring obstacle, environment issue, or a fix that had to be worked around, note them in your observations using the [tool-failure] tag.\n`
+    : "";
   return `${context}
 
 Session date: ${input.date}
-${pinned}
+${pinned}${failures}
 Conversation to observe:
 
 ${input.messages}

--- a/packages/core/src/recall.ts
+++ b/packages/core/src/recall.ts
@@ -14,6 +14,7 @@ import * as ltm from "./ltm";
 import * as temporal from "./temporal";
 import * as embedding from "./embedding";
 import * as entities from "./entities";
+import * as toolTrace from "./tool-trace";
 import * as log from "./log";
 import { db, ensureProject, projectName } from "./db";
 import type { LoreConfig } from "./config";
@@ -1045,12 +1046,29 @@ export async function runRecall(input: RecallInput): Promise<RecallResult> {
 
   const fused = await searchRecall(input);
   const recallCfg = input.searchConfig?.recall;
-  return formatFusedResults(fused, {
+  let out = formatFusedResults(fused, {
     charBudget: recallCfg?.charBudget ?? DEFAULT_FORMAT_CONFIG.charBudget,
     relevanceFloor:
       recallCfg?.relevanceFloor ?? DEFAULT_FORMAT_CONFIG.relevanceFloor,
     maxResults: recallCfg?.maxResults ?? DEFAULT_FORMAT_CONFIG.maxResults,
   });
+
+  // Surface structured tool-failure stats for debugging. Appended outside the
+  // RRF scoring/budget logic so it never displaces actual search hits.
+  // Skipped for `knowledge` scope (pure LTM lookups, no execution traces).
+  if (input.scope !== "knowledge") {
+    try {
+      const section = toolTrace.formatToolFailureSection(
+        input.projectPath,
+        input.scope === "session" ? input.sessionID : undefined,
+      );
+      if (section) out += `\n\n${section}`;
+    } catch (err) {
+      log.warn("tool failure section failed (non-fatal):", err);
+    }
+  }
+
+  return out;
 }
 
 /** Standard tool description reused verbatim by each host adapter. */

--- a/packages/core/src/temporal.ts
+++ b/packages/core/src/temporal.ts
@@ -2,7 +2,8 @@ import { db, ensureProject } from "./db";
 import { ftsQuery, EMPTY_QUERY, runRelaxedSearch } from "./search";
 import { sanitizeSurrogates } from "./markdown";
 import * as embedding from "./embedding";
-import type { LoreMessage, LorePart } from "./types";
+import { classifyToolError, MAX_ERROR_MESSAGE_LEN } from "./tool-trace";
+import type { LoreMessage, LorePart, LoreToolState } from "./types";
 import { isTextPart, isReasoningPart, isToolPart } from "./types";
 
 // ~3 chars per token — validated as best heuristic against real API data.
@@ -121,6 +122,123 @@ export function store(input: {
   if (embedding.isAvailable()) {
     embedding.embedTemporalMessage(input.info.id, content);
   }
+}
+
+/**
+ * Record structured tool-call metadata into the `tool_calls` table.
+ *
+ * A tool call spans two messages in the Anthropic protocol:
+ *   - the assistant's `tool_use` part carries the tool NAME (state typically
+ *     `pending` at this point — the result hasn't arrived yet);
+ *   - the following turn's user message carries a `tool: "result"` part
+ *     (state `completed` or `error`, after the gateway adapter resolves it)
+ *     with the OUTCOME, keyed by the same `callID`.
+ *
+ * Both phases UPSERT on the globally-unique `call_id` primary key: the tool_use
+ * seeds the name + `pending`; the result updates status/error/duration in place.
+ * The result branch deliberately does NOT overwrite the recorded tool name with
+ * the synthetic `"result"` (it preserves the seeded name).
+ *
+ * This is a SEPARATE function from `store()` because `store()` early-returns on
+ * empty `partsToText()` content and `partsToText()` drops error-state tools —
+ * so failures would otherwise be invisible.
+ *
+ * Idempotent on re-store (retries / stream re-delivery) via the UPSERT.
+ */
+export function recordToolCalls(input: {
+  projectPath: string;
+  info: LoreMessage;
+  parts: LorePart[];
+}): void {
+  const toolParts = input.parts.filter(isToolPart);
+  if (!toolParts.length) return;
+
+  const pid = ensureProject(input.projectPath);
+  const createdAt = input.info.time.created;
+
+  // Phase A: assistant tool_use parts — seed name + status. May already be
+  // resolved (e.g. host delivers completed state directly). On conflict, only
+  // overwrite outcome fields when the existing row is still `pending` — never
+  // revert a resolved row back to pending on a re-seed (retry / re-delivery).
+  const seedStmt = db().query(
+    `INSERT INTO tool_calls
+       (call_id, message_id, project_id, session_id, tool, status, error_type, error_message, duration_ms, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(call_id) DO UPDATE SET
+       status = CASE WHEN tool_calls.status = 'pending' THEN excluded.status ELSE tool_calls.status END,
+       error_type = CASE WHEN tool_calls.status = 'pending' THEN excluded.error_type ELSE tool_calls.error_type END,
+       error_message = CASE WHEN tool_calls.status = 'pending' THEN excluded.error_message ELSE tool_calls.error_message END,
+       duration_ms = COALESCE(excluded.duration_ms, tool_calls.duration_ms)`,
+  );
+  // Phase B: user tool_result parts — update outcome by call_id, preserving
+  // the previously-seeded tool name and message_id.
+  const updateStmt = db().query(
+    `UPDATE tool_calls
+       SET status = ?, error_type = ?, error_message = ?, duration_ms = ?
+     WHERE call_id = ?`,
+  );
+
+  for (const p of toolParts) {
+    const st = p.state;
+    const outcome = toolOutcome(p.tool, st);
+
+    if (p.tool === "result") {
+      // Outcome-only update; the tool name was seeded by the tool_use phase.
+      updateStmt.run(
+        outcome.status,
+        outcome.errorType,
+        outcome.errorMessage,
+        outcome.duration,
+        p.callID,
+      );
+      continue;
+    }
+
+    seedStmt.run(
+      p.callID,
+      input.info.id,
+      pid,
+      input.info.sessionID,
+      p.tool,
+      outcome.status,
+      outcome.errorType,
+      outcome.errorMessage,
+      outcome.duration,
+      createdAt,
+    );
+  }
+}
+
+/** Derive structured outcome fields from a tool part's state. */
+function toolOutcome(
+  tool: string,
+  st: LoreToolState,
+): {
+  status: string;
+  errorType: string | null;
+  errorMessage: string | null;
+  duration: number | null;
+} {
+  let errorType: string | null = null;
+  let errorMessage: string | null = null;
+  let duration: number | null = null;
+
+  if (st.status === "error") {
+    const raw = st.error ?? "";
+    errorMessage = raw ? raw.slice(0, MAX_ERROR_MESSAGE_LEN) : null;
+    errorType = classifyToolError(tool, raw);
+  }
+  if (
+    (st.status === "completed" || st.status === "error") &&
+    typeof st.time?.end === "number" &&
+    st.time.end > st.time.start
+  ) {
+    // Only record a real duration. Some hosts (e.g. the gateway adapter) set
+    // start === end as a placeholder — store NULL rather than a fake 0 so
+    // aggregations aren't polluted with meaningless zeros.
+    duration = st.time.end - st.time.start;
+  }
+  return { status: st.status, errorType, errorMessage, duration };
 }
 
 export type TemporalMessage = {

--- a/packages/core/src/tool-trace.ts
+++ b/packages/core/src/tool-trace.ts
@@ -1,0 +1,219 @@
+/**
+ * Structured tool-call execution-trace analysis.
+ *
+ * Companion to `pattern-extract.ts` — a pure, no-LLM module that turns raw
+ * tool-call outcomes (recorded in the `tool_calls` table by `temporal.ts`)
+ * into structured signals consumed by four downstream readers:
+ *   - the distillation observer (a pinned "tool failures in this segment" block)
+ *   - the auto-gotcha post-distillation loop (recurring failures → knowledge)
+ *   - the curator (cross-session failure context appended to its prompt)
+ *   - recall (a tool-failure section appended to search results)
+ *
+ * `classifyToolError()` buckets an arbitrary error string into a stable,
+ * deterministic type so that the same recurring failure aggregates across
+ * sessions regardless of incidental variation (paths, ids, line numbers).
+ *
+ * Per Lee et al. (2026) "Meta-Harness" (arXiv:2603.28052), access to raw
+ * execution traces — not compressed summaries — is the single most important
+ * factor for effective harness optimization. This module preserves the
+ * diagnostic signal (which tool failed, with what error type) that the
+ * lossy `[tool:...]` text serialization in `temporal.ts` discards.
+ */
+
+import { db, ensureProject } from "./db";
+
+// ---------------------------------------------------------------------------
+// Error classification
+// ---------------------------------------------------------------------------
+
+/** Maximum length of a stored raw error message (bounded for storage). */
+export const MAX_ERROR_MESSAGE_LEN = 500;
+
+type ErrorBucket = { regex: RegExp; type: string };
+
+/**
+ * Ordered regex → bucket table. First match wins, so more specific patterns
+ * must precede broader ones. All matched against the lowercased first
+ * non-empty line of the error string.
+ */
+const ERROR_BUCKETS: ErrorBucket[] = [
+  { regex: /timed? ?out|etimedout/, type: "timeout" },
+  { regex: /permission denied|eacces|not permitted|operation not permitted/, type: "permission" },
+  // edit_noop must precede the generic not_found bucket — "oldString not
+  // found" would otherwise match /not found/ first.
+  { regex: /oldstring not found|no changes|nothing to|no replacement/, type: "edit_noop" },
+  { regex: /no such file|enoent|does not exist|not found/, type: "not_found" },
+  { regex: /already exists|eexist/, type: "already_exists" },
+  { regex: /connection|econnrefused|econnreset|network|dns|enotfound|socket/, type: "network" },
+  { regex: /syntax error|parse error|unexpected token|unexpected end/, type: "syntax" },
+  { regex: /type error|is not a function|undefined is not|cannot read propert/, type: "type_error" },
+  { regex: /exit code|command failed|non-zero|exited with/, type: "command_failed" },
+  { regex: /abort|cancel|interrupt|sigint|sigterm/, type: "aborted" },
+];
+
+/**
+ * Bucket an arbitrary tool error into a stable, deterministic type slug.
+ *
+ * Returns `"unknown"` for an empty error. Curated buckets (see
+ * `ERROR_BUCKETS`) return bare slugs (e.g. `"timeout"`); anything else is
+ * derived from the first few words of the error, prefixed `other:` so callers
+ * can distinguish curated buckets from raw-derived ones.
+ */
+export function classifyToolError(_tool: string, error: string): string {
+  // Cap the working string before regex processing. 1000 chars is generous
+  // for classification; anything beyond is noise (full stack traces, binary
+  // garbage). The raw error is stored separately in tool_calls.error_message.
+  const firstLine = (error ?? "")
+    .slice(0, 1000)
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .find((l) => l.length > 0);
+  if (!firstLine) return "unknown";
+
+  const normalized = firstLine.toLowerCase().replace(/\s+/g, " ").trim();
+  for (const bucket of ERROR_BUCKETS) {
+    if (bucket.regex.test(normalized)) return bucket.type;
+  }
+
+  // Fallback: kebab-case the first ≤4 alphabetic words, capped at 40 chars.
+  const words = normalized
+    .replace(/[^a-z\s]+/g, " ")
+    .split(/\s+/)
+    .filter((w) => w.length > 1)
+    .slice(0, 4);
+  const slug = words.join("-").slice(0, 40).replace(/-+$/g, "");
+  return slug ? `other:${slug}` : "unknown";
+}
+
+// ---------------------------------------------------------------------------
+// Aggregation accessors
+// ---------------------------------------------------------------------------
+
+export type ToolFailureStat = {
+  tool: string;
+  error_type: string | null;
+  /** Total failures matching (tool, error_type) across the project. */
+  failure_count: number;
+  /** Distinct sessions in which this (tool, error_type) failed. */
+  session_count: number;
+  /** A representative raw error message (may be null). */
+  sample_message: string | null;
+};
+
+/**
+ * Per-tool failure aggregation across all sessions in a project, grouped by
+ * `(tool, error_type)`. Used by the curator context and the auto-gotcha loop.
+ */
+export function toolFailureStats(
+  projectPath: string,
+  opts?: { minSessions?: number; excludeSessionID?: string },
+): ToolFailureStat[] {
+  const pid = ensureProject(projectPath);
+  const minSessions = opts?.minSessions ?? 1;
+  const exclude = opts?.excludeSessionID ?? null;
+  return db()
+    .query(
+      `SELECT tool, error_type,
+              COUNT(*) AS failure_count,
+              COUNT(DISTINCT session_id) AS session_count,
+              MAX(error_message) AS sample_message
+       FROM tool_calls
+       WHERE project_id = ? AND status = 'error'
+         AND (? IS NULL OR session_id <> ?)
+       GROUP BY tool, error_type
+       HAVING session_count >= ?
+       ORDER BY session_count DESC, failure_count DESC`,
+    )
+    .all(pid, exclude, exclude, minSessions) as ToolFailureStat[];
+}
+
+export type RecentToolFailure = {
+  tool: string;
+  error_type: string | null;
+  error_message: string | null;
+  created_at: number;
+};
+
+/**
+ * Recent failures within a single session. Used by the distillation observer
+ * pinned block (scoped to the current segment's time window) and recall's
+ * session-scoped tool-failure section.
+ */
+export function recentSessionFailures(
+  projectPath: string,
+  sessionID: string,
+  opts?: { limit?: number; sinceMs?: number },
+): RecentToolFailure[] {
+  const pid = ensureProject(projectPath);
+  const limit = opts?.limit ?? 10;
+  const since = opts?.sinceMs ?? 0;
+  return db()
+    .query(
+      `SELECT tool, error_type, error_message, created_at
+       FROM tool_calls
+       WHERE project_id = ? AND session_id = ? AND status = 'error'
+         AND created_at >= ?
+       ORDER BY created_at DESC
+       LIMIT ?`,
+    )
+    .all(pid, sessionID, since, limit) as RecentToolFailure[];
+}
+
+// ---------------------------------------------------------------------------
+// Knowledge-entry text helpers (auto-gotcha)
+// ---------------------------------------------------------------------------
+
+/**
+ * Deterministic gotcha title for a recurring tool failure. Stable wording so
+ * `ltm.create()`'s title-based dedup guard collapses repeats across distills.
+ */
+export function toolGotchaTitle(tool: string, errorType: string | null): string {
+  return `Recurring ${tool} failure: ${errorType ?? "unknown error"}`;
+}
+
+/** Maximum length for a knowledge entry's content field (chars). */
+const MAX_ENTRY_CONTENT_LENGTH = 1200;
+
+/** Body text for an auto-created tool-failure gotcha entry (capped at 1200 chars). */
+export function toolGotchaContent(stat: ToolFailureStat): string {
+  const sample = stat.sample_message
+    ? ` Sample error: ${stat.sample_message.slice(0, 200)}.`
+    : "";
+  const raw =
+    `The \`${stat.tool}\` tool repeatedly failed with "${stat.error_type ?? "unknown error"}" ` +
+    `across ${stat.session_count} sessions (${stat.failure_count} total failures).${sample} ` +
+    `Investigate the root cause — this is a recurring obstacle in this project.`;
+  return raw.length > MAX_ENTRY_CONTENT_LENGTH
+    ? raw.slice(0, MAX_ENTRY_CONTENT_LENGTH)
+    : raw;
+}
+
+// ---------------------------------------------------------------------------
+// Recall surfacing
+// ---------------------------------------------------------------------------
+
+/**
+ * Render a markdown tool-failure section for recall results, or `""` when
+ * there are no failures. Session-scoped when `sessionID` is provided
+ * (recent failures in this session), otherwise project-wide recurring ones.
+ */
+export function formatToolFailureSection(
+  projectPath: string,
+  sessionID?: string,
+): string {
+  if (sessionID) {
+    const rows = recentSessionFailures(projectPath, sessionID, { limit: 5 });
+    if (!rows.length) return "";
+    const lines = rows.map(
+      (r) => `- ${r.tool} → ${r.error_type ?? "unknown"}`,
+    );
+    return `### Tool Failures (this session)\n${lines.join("\n")}`;
+  }
+  const stats = toolFailureStats(projectPath, { minSessions: 1 }).slice(0, 5);
+  if (!stats.length) return "";
+  const lines = stats.map(
+    (s) =>
+      `- ${s.tool} → ${s.error_type ?? "unknown"} (${s.failure_count}× across ${s.session_count} sessions)`,
+  );
+  return `### Recurring Tool Failures\n${lines.join("\n")}`;
+}

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -17,13 +17,14 @@ describe("db", () => {
     expect(names).toContain("session_state");
     expect(names).toContain("metadata");
     expect(names).toContain("import_history");
+    expect(names).toContain("tool_calls");
   });
 
   test("schema version is set", () => {
     const row = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(row.version).toBe(30);
+    expect(row.version).toBe(31);
   });
 
   test("distillation_fts virtual table exists", () => {
@@ -925,6 +926,77 @@ describe("db", () => {
         .get() as { name: string } | null;
       expect(after).not.toBeNull();
       expect(after!.name).toBe("daily_costs");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Migration v31: structured tool-call execution trace (tool_calls)
+  // -------------------------------------------------------------------------
+
+  describe("tool_calls trace (v31)", () => {
+    test("tool_calls table exists", () => {
+      const tables = db()
+        .query("SELECT name FROM sqlite_master WHERE type='table' AND name='tool_calls'")
+        .all() as Array<{ name: string }>;
+      expect(tables.length).toBe(1);
+    });
+
+    test("tool_calls indexes exist", () => {
+      const idx = db()
+        .query("SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='tool_calls'")
+        .all() as Array<{ name: string }>;
+      const names = idx.map((i) => i.name);
+      expect(names).toContain("idx_tool_calls_project_tool_status");
+      expect(names).toContain("idx_tool_calls_project_session");
+    });
+
+    test("call_id PK upserts in place", () => {
+      const pid = ensureProject("/tmp/tool-calls-pk-test");
+      const insert = () =>
+        db()
+          .query(
+            `INSERT INTO tool_calls
+               (call_id, message_id, project_id, session_id, tool, status, error_type, error_message, duration_ms, created_at)
+             VALUES ('c1', 'm1', ?, 's1', 'bash', ?, ?, ?, ?, 1000)
+             ON CONFLICT(call_id) DO UPDATE SET
+               status = excluded.status,
+               error_type = excluded.error_type,
+               error_message = excluded.error_message,
+               duration_ms = excluded.duration_ms`,
+          );
+      insert().run(pid, "pending", null, null, null);
+      insert().run(pid, "error", "timeout", "timed out", 20);
+
+      const rows = db()
+        .query("SELECT status, error_type, duration_ms FROM tool_calls WHERE call_id='c1'")
+        .all() as Array<{ status: string; error_type: string | null; duration_ms: number }>;
+      expect(rows.length).toBe(1);
+      expect(rows[0].status).toBe("error");
+      expect(rows[0].error_type).toBe("timeout");
+      expect(rows[0].duration_ms).toBe(20);
+    });
+
+    test("recoverMissingObjects recreates tool_calls when missing", () => {
+      const d = db();
+      d.exec("DROP TABLE IF EXISTS tool_calls");
+      expect(
+        d.query("SELECT name FROM sqlite_master WHERE type='table' AND name='tool_calls'").get(),
+      ).toBeNull();
+
+      close();
+      const fresh = db();
+      const after = fresh
+        .query("SELECT name FROM sqlite_master WHERE type='table' AND name='tool_calls'")
+        .get() as { name: string } | null;
+      expect(after).not.toBeNull();
+      expect(after!.name).toBe("tool_calls");
+      // Indexes recovered too.
+      const idx = fresh
+        .query("SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='tool_calls'")
+        .all() as Array<{ name: string }>;
+      const names = idx.map((i) => i.name);
+      expect(names).toContain("idx_tool_calls_project_tool_status");
+      expect(names).toContain("idx_tool_calls_project_session");
     });
   });
 });

--- a/packages/core/test/distillation.test.ts
+++ b/packages/core/test/distillation.test.ts
@@ -10,6 +10,7 @@ import {
   distillTokenBudget,
   maxAllowedExpansion,
   detectAssertions,
+  detectToolFailures,
   run,
   type Distillation,
 } from "../src/distillation";
@@ -1793,5 +1794,79 @@ describe("distillationUser — pinned assertions", () => {
     const dateIdx = result.indexOf("Session date: April 24, 2026");
     const pinnedIdx = result.indexOf("HIGH-PRIORITY");
     expect(dateIdx).toBeLessThan(pinnedIdx);
+  });
+});
+
+describe("distillationUser — tool failures", () => {
+  test("no tool failures — output omits the block", () => {
+    const result = distillationUser({
+      date: "April 24, 2026",
+      messages: "[user] (09:15) Hello",
+    });
+    expect(result).not.toContain("TOOL FAILURES");
+  });
+
+  test("with tool failures — block injected before conversation", () => {
+    const result = distillationUser({
+      date: "April 24, 2026",
+      messages: "[user] (09:15) test",
+      toolFailures: "- bash:timeout (×2)",
+    });
+    expect(result).toContain("TOOL FAILURES OBSERVED IN THIS SEGMENT");
+    expect(result).toContain("bash:timeout");
+    expect(result).toContain("[tool-failure]");
+    const failIdx = result.indexOf("TOOL FAILURES");
+    const convIdx = result.indexOf("Conversation to observe:");
+    expect(failIdx).toBeLessThan(convIdx);
+  });
+});
+
+describe("detectToolFailures", () => {
+  const PROJECT = "/test/distillation/tool-failures";
+
+  beforeEach(() => {
+    const pid = ensureProject(PROJECT);
+    db().query("DELETE FROM tool_calls WHERE project_id = ?").run(pid);
+  });
+
+  function addFailure(session: string, tool: string, errorType: string, createdAt: number) {
+    const pid = ensureProject(PROJECT);
+    db()
+      .query(
+        `INSERT INTO tool_calls
+           (call_id, message_id, project_id, session_id, tool, status, error_type, error_message, duration_ms, created_at)
+         VALUES (?, ?, ?, ?, ?, 'error', ?, NULL, 0, ?)`,
+      )
+      .run(`c-${createdAt}`, `m-${createdAt}`, pid, session, tool, errorType, createdAt);
+  }
+
+  test("returns undefined when no messages", () => {
+    expect(detectToolFailures(PROJECT, "s1", [])).toBeUndefined();
+  });
+
+  test("returns undefined when no in-window failures", () => {
+    addFailure("s1", "bash", "timeout", 5000);
+    const messages = [
+      msg("assistant", "x", { session_id: "s1", created_at: 100 }),
+      msg("assistant", "y", { session_id: "s1", created_at: 200 }),
+    ];
+    expect(detectToolFailures(PROJECT, "s1", messages)).toBeUndefined();
+  });
+
+  test("aggregates in-window failures by tool:error_type", () => {
+    addFailure("s1", "bash", "timeout", 100);
+    addFailure("s1", "bash", "timeout", 150);
+    addFailure("s1", "edit", "edit_noop", 180);
+    // Out of window (after last message).
+    addFailure("s1", "read", "not_found", 5000);
+    const messages = [
+      msg("assistant", "x", { session_id: "s1", created_at: 100 }),
+      msg("assistant", "y", { session_id: "s1", created_at: 200 }),
+    ];
+    const result = detectToolFailures(PROJECT, "s1", messages);
+    expect(result).toBeDefined();
+    expect(result).toContain("bash:timeout (×2)");
+    expect(result).toContain("edit:edit_noop (×1)");
+    expect(result).not.toContain("read");
   });
 });

--- a/packages/core/test/gradient.test.ts
+++ b/packages/core/test/gradient.test.ts
@@ -3000,3 +3000,48 @@ describe("gradient — calibrated delta safety multiplier", () => {
     expect(result.layer).toBeGreaterThanOrEqual(1);
   });
 });
+
+describe("gradient — error-state tool outputs are estimated (not flat 20)", () => {
+  // Regression guard: error tool_result parts are now stored as error-state
+  // (status:"error", carrying `error` text). estimateParts must size them by
+  // their error payload — not the flat 20-token fallback — or the gradient's
+  // token calibration silently undercounts failure-heavy turns and overflows.
+  test("a large error output is estimated by its size", () => {
+    const SID = "err-estimate-sess";
+    const bigError = "STACK TRACE\n".repeat(2000); // ~24K chars
+    const errorMsg: LoreMessageWithParts = {
+      info: {
+        id: "err-a1",
+        sessionID: SID,
+        role: "assistant",
+        time: { created: Date.now() },
+        parentID: "p",
+        modelID: "claude-sonnet-4-20250514",
+        providerID: "anthropic",
+        mode: "build",
+        path: { cwd: "/test", root: "/test" },
+        cost: 0,
+        tokens: { input: 100, output: 50, reasoning: 0, cache: { read: 0, write: 0 } },
+      },
+      parts: [
+        {
+          id: "err-t1",
+          sessionID: SID,
+          messageID: "err-a1",
+          type: "tool",
+          callID: "call-err",
+          tool: "bash",
+          state: {
+            status: "error",
+            input: { command: "x" },
+            error: bigError,
+            time: { start: Date.now(), end: Date.now() },
+          },
+        } as unknown as LorePart,
+      ],
+    };
+    const estimate = estimateMessages([errorMsg]);
+    // ~24K chars / 3 ≈ 8000 tokens — must be far above the flat-20 fallback.
+    expect(estimate).toBeGreaterThan(1000);
+  });
+});

--- a/packages/core/test/temporal.test.ts
+++ b/packages/core/test/temporal.test.ts
@@ -54,6 +54,23 @@ function makeParts(messageID: string, text: string): LorePart[] {
   ];
 }
 
+function toolPart(
+  messageID: string,
+  callID: string,
+  tool: string,
+  state: Record<string, unknown>,
+): LorePart {
+  return {
+    id: `tp-${callID}`,
+    sessionID: "sess-tool",
+    messageID,
+    type: "tool",
+    tool,
+    callID,
+    state,
+  } as unknown as LorePart;
+}
+
 describe("temporal", () => {
   beforeAll(() => {
     // Clean stale data from prior test runs — tests are cumulative within a run
@@ -332,6 +349,156 @@ describe("temporal", () => {
       expect(() =>
         temporal.search({ projectPath: PROJECT, query: "sanity.io article" }),
       ).not.toThrow();
+    });
+  });
+
+  describe("recordToolCalls", () => {
+    const TOOL_PROJECT = "/test/temporal/tool-calls";
+
+    beforeEach(() => {
+      const pid = ensureProject(TOOL_PROJECT);
+      db().query("DELETE FROM tool_calls WHERE project_id = ?").run(pid);
+    });
+
+    function rows(pid: string) {
+      return db()
+        .query("SELECT call_id, tool, status, error_type, error_message, duration_ms FROM tool_calls WHERE project_id = ? ORDER BY call_id")
+        .all(pid) as Array<{
+        call_id: string;
+        tool: string;
+        status: string;
+        error_type: string | null;
+        error_message: string | null;
+        duration_ms: number | null;
+      }>;
+    }
+
+    test("seeds tool name + pending from assistant tool_use parts", () => {
+      const pid = ensureProject(TOOL_PROJECT);
+      const info = makeMessage("tm-1", "assistant", "sess-tool");
+      const parts: LorePart[] = [
+        toolPart("tm-1", "ca", "read", { status: "pending", input: {} }),
+        toolPart("tm-1", "cb", "bash", { status: "pending", input: {} }),
+      ];
+      temporal.recordToolCalls({ projectPath: TOOL_PROJECT, info, parts });
+
+      const r = rows(pid);
+      expect(r.length).toBe(2);
+      expect(r.find((x) => x.call_id === "ca")!.tool).toBe("read");
+      expect(r.find((x) => x.call_id === "ca")!.status).toBe("pending");
+      expect(r.find((x) => x.call_id === "cb")!.tool).toBe("bash");
+    });
+
+    test("result parts update outcome by call_id, preserving seeded name", () => {
+      const pid = ensureProject(TOOL_PROJECT);
+      // Phase A: assistant seeds names (prior turn).
+      temporal.recordToolCalls({
+        projectPath: TOOL_PROJECT,
+        info: makeMessage("tm-asst", "assistant", "sess-tool"),
+        parts: [
+          toolPart("tm-asst", "ca", "read", { status: "pending", input: {} }),
+          toolPart("tm-asst", "cb", "bash", { status: "pending", input: {} }),
+        ],
+      });
+      // Phase B: user message carries the tool_result outcomes (next turn).
+      temporal.recordToolCalls({
+        projectPath: TOOL_PROJECT,
+        info: makeMessage("tm-user", "user", "sess-tool"),
+        parts: [
+          toolPart("tm-user", "ca", "result", {
+            status: "completed",
+            input: null,
+            output: "file contents",
+            time: { start: 100, end: 150 },
+          }),
+          toolPart("tm-user", "cb", "result", {
+            status: "error",
+            input: null,
+            error: "ENOENT: no such file or directory",
+            time: { start: 200, end: 260 },
+          }),
+        ],
+      });
+
+      const r = rows(pid);
+      expect(r.length).toBe(2);
+      const completed = r.find((x) => x.call_id === "ca")!;
+      expect(completed.tool).toBe("read"); // name preserved, not "result"
+      expect(completed.status).toBe("completed");
+      expect(completed.error_type).toBeNull();
+      expect(completed.duration_ms).toBe(50);
+      const errored = r.find((x) => x.call_id === "cb")!;
+      expect(errored.tool).toBe("bash"); // name preserved
+      expect(errored.status).toBe("error");
+      expect(errored.error_type).toBe("not_found");
+      expect(errored.error_message).toBe("ENOENT: no such file or directory");
+      expect(errored.duration_ms).toBe(60);
+    });
+
+    test("is idempotent on re-store (UPSERT on call_id)", () => {
+      const pid = ensureProject(TOOL_PROJECT);
+      const info = makeMessage("tm-2", "assistant", "sess-tool");
+      const parts: LorePart[] = [
+        toolPart("tm-2", "cx", "edit", { status: "pending", input: {} }),
+      ];
+      temporal.recordToolCalls({ projectPath: TOOL_PROJECT, info, parts });
+      temporal.recordToolCalls({ projectPath: TOOL_PROJECT, info, parts });
+
+      const r = rows(pid);
+      expect(r.length).toBe(1);
+      expect(r[0].tool).toBe("edit");
+    });
+
+    test("orphan result (no seeded row) is a silent no-op", () => {
+      const pid = ensureProject(TOOL_PROJECT);
+      temporal.recordToolCalls({
+        projectPath: TOOL_PROJECT,
+        info: makeMessage("tm-orphan", "user", "sess-tool"),
+        parts: [
+          toolPart("tm-orphan", "missing", "result", {
+            status: "completed",
+            input: null,
+            output: "x",
+            time: { start: 1, end: 2 },
+          }),
+        ],
+      });
+      expect(rows(pid).length).toBe(0);
+    });
+
+    test("no-op when there are no tool parts", () => {
+      const pid = ensureProject(TOOL_PROJECT);
+      const info = makeMessage("tm-3", "assistant", "sess-tool");
+      temporal.recordToolCalls({
+        projectPath: TOOL_PROJECT,
+        info,
+        parts: makeParts("tm-3", "just text"),
+      });
+      expect(rows(pid).length).toBe(0);
+    });
+
+    test("empty error string yields error_type bucket 'unknown'", () => {
+      const pid = ensureProject(TOOL_PROJECT);
+      temporal.recordToolCalls({
+        projectPath: TOOL_PROJECT,
+        info: makeMessage("tm-4a", "assistant", "sess-tool"),
+        parts: [toolPart("tm-4a", "ce", "bash", { status: "pending", input: {} })],
+      });
+      temporal.recordToolCalls({
+        projectPath: TOOL_PROJECT,
+        info: makeMessage("tm-4b", "user", "sess-tool"),
+        parts: [
+          toolPart("tm-4b", "ce", "result", {
+            status: "error",
+            input: null,
+            error: "",
+            time: { start: 1, end: 2 },
+          }),
+        ],
+      });
+      const r = rows(pid);
+      expect(r[0].error_type).toBe("unknown");
+      expect(r[0].error_message).toBeNull();
     });
   });
 });

--- a/packages/core/test/tool-trace.test.ts
+++ b/packages/core/test/tool-trace.test.ts
@@ -1,0 +1,192 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { db, ensureProject } from "../src/db";
+import * as toolTrace from "../src/tool-trace";
+
+const PROJECT = "/test/tool-trace/project";
+
+function insertFailure(
+  pid: string,
+  opts: {
+    messageId: string;
+    callId: string;
+    session: string;
+    tool: string;
+    status?: string;
+    errorType?: string | null;
+    errorMessage?: string | null;
+    createdAt?: number;
+  },
+) {
+  db()
+    .query(
+      `INSERT INTO tool_calls
+         (call_id, message_id, project_id, session_id, tool, status, error_type, error_message, duration_ms, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      opts.callId,
+      opts.messageId,
+      pid,
+      opts.session,
+      opts.tool,
+      opts.status ?? "error",
+      opts.errorType ?? null,
+      opts.errorMessage ?? null,
+      0,
+      opts.createdAt ?? 1000,
+    );
+}
+
+describe("tool-trace", () => {
+  describe("classifyToolError", () => {
+    test("returns 'unknown' for empty error", () => {
+      expect(toolTrace.classifyToolError("bash", "")).toBe("unknown");
+      expect(toolTrace.classifyToolError("bash", "   \n  ")).toBe("unknown");
+    });
+
+    test("buckets curated error types", () => {
+      expect(toolTrace.classifyToolError("bash", "Operation timed out")).toBe("timeout");
+      expect(toolTrace.classifyToolError("read", "EACCES: permission denied")).toBe("permission");
+      expect(toolTrace.classifyToolError("read", "ENOENT: no such file or directory")).toBe("not_found");
+      expect(toolTrace.classifyToolError("write", "File already exists")).toBe("already_exists");
+      expect(toolTrace.classifyToolError("fetch", "ECONNREFUSED connection error")).toBe("network");
+      expect(toolTrace.classifyToolError("edit", "Syntax error: unexpected token")).toBe("syntax");
+      expect(toolTrace.classifyToolError("run", "TypeError: x is not a function")).toBe("type_error");
+      expect(toolTrace.classifyToolError("edit", "oldString not found in content")).toBe("edit_noop");
+      expect(toolTrace.classifyToolError("bash", "Command failed with exit code 1")).toBe("command_failed");
+      expect(toolTrace.classifyToolError("bash", "Process aborted by user")).toBe("aborted");
+    });
+
+    test("uses only the first non-empty line", () => {
+      expect(toolTrace.classifyToolError("bash", "\n\nOperation timed out\nstack trace here")).toBe("timeout");
+    });
+
+    test("falls back to 'other:' slug for unknown errors", () => {
+      const r = toolTrace.classifyToolError("custom", "Weird unmatched failure happened");
+      expect(r.startsWith("other:")).toBe(true);
+      expect(r.length).toBeLessThanOrEqual(46); // "other:" + 40
+    });
+
+    test("returns 'unknown' when fallback slug is empty", () => {
+      expect(toolTrace.classifyToolError("x", "123 456 789")).toBe("unknown");
+    });
+  });
+
+  describe("aggregation accessors", () => {
+    beforeEach(() => {
+      const pid = ensureProject(PROJECT);
+      db().query("DELETE FROM tool_calls WHERE project_id = ?").run(pid);
+    });
+
+    test("toolFailureStats groups by (tool, error_type) with session counts", () => {
+      const pid = ensureProject(PROJECT);
+      insertFailure(pid, { messageId: "m1", callId: "c1", session: "s1", tool: "edit", errorType: "edit_noop", errorMessage: "oldString not found" });
+      insertFailure(pid, { messageId: "m2", callId: "c2", session: "s2", tool: "edit", errorType: "edit_noop" });
+      insertFailure(pid, { messageId: "m3", callId: "c3", session: "s2", tool: "edit", errorType: "edit_noop" });
+      insertFailure(pid, { messageId: "m4", callId: "c4", session: "s1", tool: "bash", errorType: "timeout" });
+
+      const stats = toolTrace.toolFailureStats(PROJECT);
+      const edit = stats.find((s) => s.tool === "edit" && s.error_type === "edit_noop");
+      expect(edit).toBeDefined();
+      expect(edit!.failure_count).toBe(3);
+      expect(edit!.session_count).toBe(2);
+      expect(edit!.sample_message).toBe("oldString not found");
+    });
+
+    test("toolFailureStats respects minSessions", () => {
+      const pid = ensureProject(PROJECT);
+      insertFailure(pid, { messageId: "m1", callId: "c1", session: "s1", tool: "bash", errorType: "timeout" });
+      const all = toolTrace.toolFailureStats(PROJECT, { minSessions: 1 });
+      expect(all.length).toBe(1);
+      const filtered = toolTrace.toolFailureStats(PROJECT, { minSessions: 2 });
+      expect(filtered.length).toBe(0);
+    });
+
+    test("toolFailureStats excludes the current session", () => {
+      const pid = ensureProject(PROJECT);
+      insertFailure(pid, { messageId: "m1", callId: "c1", session: "cur", tool: "bash", errorType: "timeout" });
+      insertFailure(pid, { messageId: "m2", callId: "c2", session: "other", tool: "bash", errorType: "timeout" });
+      const stats = toolTrace.toolFailureStats(PROJECT, { excludeSessionID: "cur" });
+      expect(stats.length).toBe(1);
+      expect(stats[0].session_count).toBe(1);
+    });
+
+    test("toolFailureStats ignores completed calls", () => {
+      const pid = ensureProject(PROJECT);
+      insertFailure(pid, { messageId: "m1", callId: "c1", session: "s1", tool: "bash", status: "completed", errorType: null });
+      expect(toolTrace.toolFailureStats(PROJECT).length).toBe(0);
+    });
+
+    test("recentSessionFailures filters by session, window, and limit", () => {
+      const pid = ensureProject(PROJECT);
+      insertFailure(pid, { messageId: "m1", callId: "c1", session: "s1", tool: "a", errorType: "timeout", createdAt: 100 });
+      insertFailure(pid, { messageId: "m2", callId: "c2", session: "s1", tool: "b", errorType: "network", createdAt: 200 });
+      insertFailure(pid, { messageId: "m3", callId: "c3", session: "s2", tool: "c", errorType: "timeout", createdAt: 200 });
+
+      const all = toolTrace.recentSessionFailures(PROJECT, "s1");
+      expect(all.length).toBe(2);
+      // Ordered newest first.
+      expect(all[0].created_at).toBe(200);
+
+      const windowed = toolTrace.recentSessionFailures(PROJECT, "s1", { sinceMs: 150 });
+      expect(windowed.length).toBe(1);
+      expect(windowed[0].tool).toBe("b");
+
+      const limited = toolTrace.recentSessionFailures(PROJECT, "s1", { limit: 1 });
+      expect(limited.length).toBe(1);
+    });
+  });
+
+  describe("text helpers", () => {
+    test("toolGotchaTitle is deterministic", () => {
+      expect(toolTrace.toolGotchaTitle("bash", "timeout")).toBe("Recurring bash failure: timeout");
+      expect(toolTrace.toolGotchaTitle("bash", null)).toBe("Recurring bash failure: unknown error");
+    });
+
+    test("toolGotchaContent includes counts and sample", () => {
+      const content = toolTrace.toolGotchaContent({
+        tool: "edit",
+        error_type: "edit_noop",
+        failure_count: 5,
+        session_count: 3,
+        sample_message: "oldString not found",
+      });
+      expect(content).toContain("edit");
+      expect(content).toContain("edit_noop");
+      expect(content).toContain("3 sessions");
+      expect(content).toContain("5 total failures");
+      expect(content).toContain("oldString not found");
+      expect(content.length).toBeLessThanOrEqual(1200);
+    });
+  });
+
+  describe("formatToolFailureSection", () => {
+    beforeEach(() => {
+      const pid = ensureProject(PROJECT);
+      db().query("DELETE FROM tool_calls WHERE project_id = ?").run(pid);
+    });
+
+    test("returns '' when no failures", () => {
+      expect(toolTrace.formatToolFailureSection(PROJECT)).toBe("");
+      expect(toolTrace.formatToolFailureSection(PROJECT, "s1")).toBe("");
+    });
+
+    test("project-wide section lists recurring failures", () => {
+      const pid = ensureProject(PROJECT);
+      insertFailure(pid, { messageId: "m1", callId: "c1", session: "s1", tool: "bash", errorType: "timeout" });
+      const section = toolTrace.formatToolFailureSection(PROJECT);
+      expect(section).toContain("Recurring Tool Failures");
+      expect(section).toContain("bash");
+      expect(section).toContain("timeout");
+    });
+
+    test("session-scoped section lists this session's failures", () => {
+      const pid = ensureProject(PROJECT);
+      insertFailure(pid, { messageId: "m1", callId: "c1", session: "s1", tool: "read", errorType: "not_found" });
+      const section = toolTrace.formatToolFailureSection(PROJECT, "s1");
+      expect(section).toContain("Tool Failures (this session)");
+      expect(section).toContain("read");
+      expect(section).toContain("not_found");
+    });
+  });
+});

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -2217,6 +2217,9 @@ function postResponse(
     // The session still gets full Lore processing (LTM, recall, gradient)
     // but doesn't write to memory. Amnesia is session-scoped (toggle via
     // /lore:amnesia:on|off); no-store is per-request (header-based).
+    // Note: tool-call outcomes for a tool_use seeded during a no-store turn are
+    // intentionally dropped — the seed row never exists, so the later
+    // tool_result UPDATE is a harmless no-op (no phantom 'pending' rows leak).
     const noStore = sessionState.amnesia || req.rawHeaders["x-lore-no-store"] === "true";
     if (!noStore) {
       // Store the latest user message BEFORE resolveToolResults — we want the
@@ -2225,6 +2228,14 @@ function postResponse(
       for (let i = loreMessages.length - 1; i >= 0; i--) {
         if (loreMessages[i].info.role === "user") {
           temporal.store({
+            projectPath,
+            info: loreMessages[i].info,
+            parts: loreMessages[i].parts,
+          });
+          // The latest user message carries tool_result blocks that resolve
+          // the PRIOR assistant turn's tool calls — record their outcomes
+          // (status/error/duration) keyed by call_id.
+          temporal.recordToolCalls({
             projectPath,
             info: loreMessages[i].info,
             parts: loreMessages[i].parts,
@@ -2246,18 +2257,27 @@ function postResponse(
       const assistantContent = resp.content.filter(
         (b) => !(b.type === "text" && isRecallMarker(b.text)),
       );
+      const assistantMsg = gatewayMessagesToLore(
+        [{ role: "assistant", content: assistantContent }],
+        sessionID,
+      )[0];
+      updateAssistantMessageTokens(assistantMsg, resp.usage, resp.model);
       if (assistantContent.length > 0) {
-        const assistantMsg = gatewayMessagesToLore(
-          [{ role: "assistant", content: assistantContent }],
-          sessionID,
-        )[0];
-        updateAssistantMessageTokens(assistantMsg, resp.usage, resp.model);
         temporal.store({
           projectPath,
           info: assistantMsg.info,
           parts: assistantMsg.parts,
         });
       }
+      // Always record structured tool-call traces — even when the assistant
+      // content is empty after recall-marker stripping, or when partsToText
+      // would produce empty content (tool-only / all-failed turns). Tool parts
+      // survive the text-only recall-marker filter above.
+      temporal.recordToolCalls({
+        projectPath,
+        info: assistantMsg.info,
+        parts: assistantMsg.parts,
+      });
     }
 
     // Update session state (persisted in the batched save after messageCount update)

--- a/packages/gateway/src/temporal-adapter.ts
+++ b/packages/gateway/src/temporal-adapter.ts
@@ -121,12 +121,21 @@ function contentBlockToPart(
         type: "tool",
         tool: "result",
         callID: block.toolUseId,
-        state: {
-          status: "completed",
-          input: null,
-          output: block.content,
-          time: { start: now, end: now },
-        },
+        // Propagate the error flag so downstream consumers (structured
+        // tool-call trace, gradient) can distinguish failed tool results.
+        state: block.isError
+          ? {
+              status: "error",
+              input: null,
+              error: block.content,
+              time: { start: now, end: now },
+            }
+          : {
+              status: "completed",
+              input: null,
+              output: block.content,
+              time: { start: now, end: now },
+            },
       } satisfies LoreToolPart;
   }
 }
@@ -245,15 +254,18 @@ export function resolveToolResults(messages: LoreMessageWithParts[]): void {
 
   for (const msg of messages) {
     for (const part of msg.parts) {
-      if (
-        isToolPart(part) &&
-        part.tool === "result" &&
-        part.state.status === "completed"
-      ) {
-        resultsByCallID.set(part.callID, {
-          output: part.state.output,
-          isError: false,
-        });
+      if (isToolPart(part) && part.tool === "result") {
+        if (part.state.status === "completed") {
+          resultsByCallID.set(part.callID, {
+            output: part.state.output,
+            isError: false,
+          });
+        } else if (part.state.status === "error") {
+          resultsByCallID.set(part.callID, {
+            output: part.state.error,
+            isError: true,
+          });
+        }
       }
     }
   }
@@ -269,12 +281,19 @@ export function resolveToolResults(messages: LoreMessageWithParts[]): void {
       ) {
         const result = resultsByCallID.get(part.callID);
         if (result) {
-          part.state = {
-            status: "completed",
-            input: part.state.input,
-            output: result.output,
-            time: { start: now, end: now },
-          };
+          part.state = result.isError
+            ? {
+                status: "error",
+                input: part.state.input,
+                error: result.output,
+                time: { start: now, end: now },
+              }
+            : {
+                status: "completed",
+                input: part.state.input,
+                output: result.output,
+                time: { start: now, end: now },
+              };
         }
       }
     }

--- a/packages/gateway/test/temporal-adapter.test.ts
+++ b/packages/gateway/test/temporal-adapter.test.ts
@@ -232,4 +232,48 @@ describe("resolveToolResults", () => {
     expect(textParts).toHaveLength(1);
     expect(toolParts).toHaveLength(1);
   });
+
+  test("error tool_result resolves the tool_use to error state", () => {
+    const gwMessages: GatewayMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_err",
+            name: "bash",
+            input: { command: "false" },
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            toolUseId: "toolu_err",
+            content: "command failed with exit code 1",
+            isError: true,
+          },
+        ],
+      },
+    ];
+
+    const messages = gatewayMessagesToLore(gwMessages, "sess-err");
+    // contentBlockToPart maps an error tool_result to an error-state part.
+    const resultPart = messages[1]!.parts.find(
+      (p) => isToolPart(p) && p.tool === "result",
+    );
+    expect((resultPart as any).state.status).toBe("error");
+    expect((resultPart as any).state.error).toBe("command failed with exit code 1");
+
+    resolveToolResults(messages);
+
+    // The assistant's tool_use is now resolved to error with the message.
+    const toolPart = messages[0]!.parts.find(
+      (p) => isToolPart(p) && p.tool === "bash",
+    );
+    expect((toolPart as any).state.status).toBe("error");
+    expect((toolPart as any).state.error).toBe("command failed with exit code 1");
+  });
 });


### PR DESCRIPTION
Closes #496

## Summary

Stores structured tool-call metadata (tool name, success/failure status, bucketed error type, raw error message, duration) in a new queryable \`tool_calls\` table, and feeds failure/success patterns into four downstream consumers for richer knowledge extraction.

Motivation (from the issue): the Meta-Harness paper showed raw execution traces are the single most important factor for harness optimization — compressed summaries lose diagnostic signal. Lore previously discarded all structured tool-call metadata at the storage boundary (\`partsToText\` dropped error-state tools entirely).

## What changed

**Storage (new \`tool_calls\` table, v31 migration)**
- Keyed by \`call_id\` with tool name, status, error type/message, duration; two aggregation indexes; \`recoverMissingObjects()\` coverage.
- \`temporal.recordToolCalls()\` records calls in two phases across the Anthropic protocol's split messages: the assistant \`tool_use\` seeds name + \`pending\`; the next turn's user \`tool_result\` updates the outcome by \`call_id\`. Non-destructive UPSERT (never reverts a resolved row to pending).
- New \`tool-trace.ts\` module: deterministic \`classifyToolError()\` (no LLM), aggregation accessors, gotcha text helpers, recall formatter.

**Four downstream consumers**
1. **Distillation observer** — \`detectToolFailures()\` injects a segment-scoped tool-failure block into the observer prompt.
2. **Auto-gotcha** — recurring failures (≥3 sessions, ≥4 failures) auto-create \`gotcha\` knowledge entries (gated by \`config().knowledge.enabled\`).
3. **Curator** — \`buildToolFailureContext()\` appends cross-session failure signal to the curator prompt.
4. **Recall** — failure section appended to recall results (skipped for \`knowledge\` scope).

**Adapter correctness**
- The gateway adapter now propagates \`is_error\` so failed tool results become \`error\`-state parts.
- Fixed the resulting gradient regression: \`estimateParts\` and \`stripToolOutputs\` now size/compress error-state outputs, so failure-heavy turns can't evade token estimation and overflow context.

## Testing

- New: \`tool-trace.test.ts\` (classifier buckets, aggregation, formatters).
- Extended: \`db.test.ts\` (v31 table/indexes/recover/upsert), \`temporal.test.ts\` (two-phase recording, idempotency, orphan no-op), \`distillation.test.ts\` (\`detectToolFailures\` window scoping, observer prompt block), \`gradient.test.ts\` (error-state estimation regression guard), \`temporal-adapter.test.ts\` (is_error propagation).
- Full suite green (2119 pass / 0 fail), typecheck clean across all packages.