### PR TITLE
fix(gateway): never merge unrelated sessions onto the gateway cwd

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1262,6 +1262,26 @@ export function close() {
 // Project management
 
 /**
+ * Path prefix for synthetic "unattributed" project buckets. Created when a
+ * remote/central gateway can't determine a confident project path for a
+ * request (no `X-Lore-Project` header, no inferable path in the system
+ * prompt). Each such session gets its own bucket
+ * (`/__lore_unattributed__/<sessionID>`) so unrelated sessions are never
+ * merged onto the gateway's own cwd. Buckets self-heal (when a confident path
+ * later arrives) or can be consolidated. Defined here (in core) so both the
+ * gateway and DB-layer naming agree on the canonical prefix.
+ */
+export const UNATTRIBUTED_PROJECT_PREFIX = "/__lore_unattributed__";
+
+/** True when a project path is a synthetic unattributed bucket. */
+export function isUnattributedProjectPath(path: string): boolean {
+  return (
+    path === UNATTRIBUTED_PROJECT_PREFIX ||
+    path.startsWith(`${UNATTRIBUTED_PROJECT_PREFIX}/`)
+  );
+}
+
+/**
  * Look up or create a project by filesystem path, with git-remote awareness.
  *
  * Resolution order:
@@ -1343,6 +1363,11 @@ export function ensureProject(path: string, name?: string, suppliedGitRemote?: s
 
   // 4. Create new project
   const id = crypto.randomUUID();
+  // Synthetic unattributed buckets get a clearly-marked provisional name so the
+  // dashboard never shows a bare session ID as if it were a real repo.
+  const derivedName = isUnattributedProjectPath(path)
+    ? `(unattributed) ${(path.split("/").pop() ?? "").slice(0, 12)}`
+    : name ?? repoNameFromRemote(gitRemote) ?? path.split("/").pop() ?? "unknown";
   db()
     .query(
       "INSERT INTO projects (id, path, name, git_remote, created_at) VALUES (?, ?, ?, ?, ?)",
@@ -1350,7 +1375,7 @@ export function ensureProject(path: string, name?: string, suppliedGitRemote?: s
     .run(
       id,
       path,
-      name ?? repoNameFromRemote(gitRemote) ?? path.split("/").pop() ?? "unknown",
+      derivedName,
       gitRemote,
       Date.now(),
     );

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -70,6 +70,8 @@ export {
   projectPath,
   resolveProjectByRemoteOrPath,
   mergeProjectInternal,
+  UNATTRIBUTED_PROJECT_PREFIX,
+  isUnattributedProjectPath,
   loadForceMinLayer,
   saveForceMinLayer,
   saveSessionCosts,

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { db, close, ensureProject, projectId, mergeProjectInternal, loadForceMinLayer, saveForceMinLayer, getMeta, setMeta, getInstanceId, saveSessionCosts, loadSessionCosts, loadAllSessionCosts, getLastImportAt, setLastImportAt, saveSessionTracking, loadSessionTracking, loadHeaderSessionIndex, getKV, setKV, addDailyCost, getDailyCostTotals, getDailyCostForDay } from "../src/db";
+import { db, close, ensureProject, projectId, mergeProjectInternal, loadForceMinLayer, saveForceMinLayer, getMeta, setMeta, getInstanceId, saveSessionCosts, loadSessionCosts, loadAllSessionCosts, getLastImportAt, setLastImportAt, saveSessionTracking, loadSessionTracking, loadHeaderSessionIndex, getKV, setKV, addDailyCost, getDailyCostTotals, getDailyCostForDay, isUnattributedProjectPath, UNATTRIBUTED_PROJECT_PREFIX } from "../src/db";
 
 
 describe("db", () => {
@@ -135,6 +135,24 @@ describe("db", () => {
     ensureProject("/test/project/gamma");
     const id = projectId("/test/project/gamma");
     expect(id).toBeTruthy();
+  });
+
+  test("isUnattributedProjectPath recognizes synthetic buckets", () => {
+    expect(isUnattributedProjectPath(`${UNATTRIBUTED_PROJECT_PREFIX}/abc123`)).toBe(true);
+    expect(isUnattributedProjectPath(UNATTRIBUTED_PROJECT_PREFIX)).toBe(true);
+    expect(isUnattributedProjectPath("/home/user/real-project")).toBe(false);
+    // Must not match a real path that merely contains the segment elsewhere.
+    expect(isUnattributedProjectPath("/home/__lore_unattributed__/x")).toBe(false);
+  });
+
+  test("ensureProject gives unattributed buckets a provisional name", () => {
+    const id = ensureProject(`${UNATTRIBUTED_PROJECT_PREFIX}/sessabcdef123456`);
+    const row = db()
+      .query("SELECT name FROM projects WHERE id = ?")
+      .get(id) as { name: string };
+    expect(row.name.startsWith("(unattributed)")).toBe(true);
+    // Should not be the bare session ID as if it were a real repo.
+    expect(row.name).not.toBe("sessabcdef123456");
   });
 
   test("projectId returns undefined for unknown path", () => {

--- a/packages/gateway/src/cli/data.ts
+++ b/packages/gateway/src/cli/data.ts
@@ -1588,6 +1588,7 @@ Subcommands:
   clear [options]       Clear data for a project or wipe the database
   delete <type> <id>    Delete a single entry (type: knowledge, session, distillation, project)
   merge                 Scan git remotes and merge duplicate projects
+  consolidate           Merge "(unattributed)" buckets into matched real projects
   recover               Re-import knowledge from .lore.md / AGENTS.md files
   dedup                 Find and remove duplicate knowledge entries (all projects)
   reindex               Rebuild embedding vectors (after model/config change)
@@ -1618,6 +1619,9 @@ Examples:
   lore data delete project /path/to/project  # delete project and ALL its data
   lore data merge                          # scan & merge git duplicates
   lore data merge --yes                    # skip confirmation
+  lore data consolidate                    # dry-run: show "(unattributed)" buckets & matches
+  lore data consolidate --yes              # apply: merge matched buckets into real projects
+  lore data consolidate --json             # machine-readable plan (dryRun:true unless --yes)
   lore data recover                        # re-import from .lore.md / AGENTS.md
   lore data recover --yes                  # skip confirmation
   lore data dedup                          # dry-run: show duplicate clusters
@@ -1627,6 +1631,123 @@ Examples:
   lore data reindex                        # rebuild all embedding vectors
   lore data rerank                         # re-score preference confidence
 `.trimStart();
+
+/**
+ * Consolidate synthetic "unattributed" project buckets
+ * (`/__lore_unattributed__/<sessionID>`) created by a remote gateway when it
+ * couldn't determine a confident project path.
+ *
+ * For each bucket, attempt to match a REAL project by git_remote (the only
+ * reliable cross-session signal). When matched, merge the bucket into the real
+ * project (re-pointing all rows). Buckets with no confident match are reported
+ * but left intact (they remain a clearly-labelled cross-project memory source).
+ */
+async function cmdConsolidate(
+  _args: string[],
+  flags: Record<string, unknown>,
+): Promise<void> {
+  const remote = getRemoteUrl();
+  if (remote) {
+    console.error(
+      "Error: consolidate is not supported in remote mode (run it on the gateway host).",
+    );
+    process.exit(1);
+  }
+
+  const { data, isUnattributedProjectPath } = await import("@loreai/core");
+  const mergeProjects = data.mergeProjects;
+  const skipConfirm = !!flags.yes;
+  const asJson = !!flags.json;
+  // Destructive op → default to a dry run. Apply only with --yes. `--dry-run`
+  // forces preview even when --yes is present.
+  const dryRun = !!flags["dry-run"] || !skipConfirm;
+
+  const projects = data.listProjects();
+  const buckets = projects.filter((p) => isUnattributedProjectPath(p.path));
+  // Candidate targets are REAL projects only (never other buckets). Matching a
+  // bucket to a real project by git remote is the only reliable cross-session
+  // signal — note both the bucket AND the real project may carry the same
+  // remote, so we must explicitly exclude buckets from the target set rather
+  // than relying on a first-match lookup.
+  const realProjects = projects.filter((p) => !isUnattributedProjectPath(p.path));
+
+  type Plan = {
+    bucket: (typeof projects)[number];
+    target?: (typeof projects)[number];
+  };
+  const plans: Plan[] = [];
+  for (const bucket of buckets) {
+    let target: (typeof projects)[number] | undefined;
+    if (bucket.git_remote) {
+      target = realProjects.find((p) => p.git_remote === bucket.git_remote);
+    }
+    plans.push({ bucket, target });
+  }
+
+  const mergeable = plans.filter((p) => p.target);
+  const orphans = plans.filter((p) => !p.target);
+
+  if (asJson) {
+    console.log(
+      JSON.stringify(
+        {
+          dryRun,
+          buckets: buckets.length,
+          mergeable: mergeable.map((p) => ({
+            from: p.bucket.path,
+            into: p.target!.path,
+            gitRemote: p.bucket.git_remote,
+          })),
+          orphans: orphans.map((p) => ({
+            path: p.bucket.path,
+            knowledge: p.bucket.knowledge_count,
+            sessions: p.bucket.session_count,
+          })),
+        },
+        null,
+        2,
+      ),
+    );
+  } else {
+    console.log(`\nUnattributed buckets: ${buckets.length}`);
+    console.log(`  mergeable (matched by git remote): ${mergeable.length}`);
+    console.log(`  orphans (no confident match): ${orphans.length}\n`);
+    for (const p of mergeable) {
+      console.log(`  merge ${p.bucket.path} → ${p.target!.name ?? p.target!.path}`);
+    }
+    for (const p of orphans) {
+      console.log(
+        `  keep  ${p.bucket.path} (${p.bucket.knowledge_count} knowledge, ${p.bucket.session_count} sessions)`,
+      );
+    }
+  }
+
+  if (mergeable.length === 0) {
+    if (!asJson) console.log("\nNothing to consolidate.");
+    return;
+  }
+
+  // Dry run (default, or explicit --dry-run): preview only, never mutate.
+  if (dryRun) {
+    if (!asJson) {
+      console.log(
+        `\nDry run — no changes made. Re-run with --yes to merge ${mergeable.length} bucket(s).`,
+      );
+    }
+    return;
+  }
+
+  let merged = 0;
+  for (const p of mergeable) {
+    try {
+      mergeProjects(p.bucket.id, p.target!.id);
+      merged++;
+    } catch (e) {
+      console.error(`  failed to merge ${p.bucket.path}: ${(e as Error).message}`);
+    }
+  }
+  console.log(`\nConsolidated ${merged} bucket(s).`);
+}
 
 export async function commandData(
   positionals: string[],
@@ -1650,6 +1771,9 @@ export async function commandData(
       break;
     case "merge":
       await cmdMerge(subArgs, values);
+      break;
+    case "consolidate":
+      await cmdConsolidate(subArgs, values);
       break;
     case "recover":
       await cmdRecover(subArgs, values);

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -4,7 +4,7 @@
  * (only `normalizeRemoteUrl` for git URL canonicalization).
  */
 
-import { normalizeRemoteUrl, discoverWorkspaceRoot } from "@loreai/core";
+import { normalizeRemoteUrl, discoverWorkspaceRoot, UNATTRIBUTED_PROJECT_PREFIX, isUnattributedProjectPath } from "@loreai/core";
 
 // ---------------------------------------------------------------------------
 // Port defaults
@@ -72,6 +72,20 @@ export interface GatewayConfig {
    * Env: LORE_WORKER_UPSTREAM
    */
   workerUpstream?: string;
+  /**
+   * Remote/central gateway mode. When true, the gateway is serving agents
+   * running on OTHER machines, so its own `process.cwd()` has no relationship
+   * to any client's project. In this mode the gateway MUST NOT attribute
+   * path-less requests to its own cwd (doing so merges unrelated projects).
+   * Instead, requests that cannot resolve a confident project path are routed
+   * to a per-session synthetic "unattributed" bucket
+   * (`/__lore_unattributed__/<sessionID>`) that can later self-heal or be
+   * consolidated. Env: LORE_REMOTE_GATEWAY.
+   *
+   * Note: hosted mode (`LORE_HOSTED_MODE`) implies remote-gateway behavior —
+   * a hosted gateway never shares a filesystem with its clients.
+   */
+  remoteGateway: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -102,6 +116,8 @@ export function loadConfig(): GatewayConfig {
     workerUpstream: env.LORE_WORKER_UPSTREAM
       ? trimTrailingSlash(env.LORE_WORKER_UPSTREAM)
       : undefined,
+    // Hosted mode is always a remote gateway (no shared filesystem with clients).
+    remoteGateway: isTruthy(env.LORE_REMOTE_GATEWAY) || isTruthy(env.LORE_HOSTED_MODE),
   };
 }
 
@@ -265,6 +281,28 @@ export type ProjectPathResult = {
   /** Normalized git remote URL from `X-Lore-Git-Remote` header, if provided. */
   gitRemote?: string;
 };
+
+/**
+ * Path prefix for synthetic "unattributed" project buckets created when a
+ * remote/central gateway cannot determine a confident project path for a
+ * request. Each such session gets its own bucket
+ * (`/__lore_unattributed__/<sessionID>`) so unrelated sessions are never
+ * merged. Buckets are clearly marked (this prefix + a provisional project
+ * name) so they can later self-heal (when a confident path arrives) or be
+ * consolidated into real projects.
+ *
+ * Canonical prefix is defined in `@loreai/core` so the gateway and the DB
+ * naming layer agree. Re-exported here for gateway-local convenience.
+ */
+export const UNATTRIBUTED_PREFIX = UNATTRIBUTED_PROJECT_PREFIX;
+
+/** Build the synthetic unattributed-bucket path for a given session. */
+export function unattributedBucketPath(sessionID: string): string {
+  return `${UNATTRIBUTED_PREFIX}/${sessionID}`;
+}
+
+/** True when a project path is a synthetic unattributed bucket. */
+export const isUnattributedPath = isUnattributedProjectPath;
 
 /**
  * Resolve the project path for a request. Checks in order:

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -16,6 +16,8 @@ import {
   load,
   config as loreConfig,
   ensureProject,
+  projectId,
+  mergeProjectInternal,
   temporal,
   ltm,
   distillation,
@@ -69,7 +71,7 @@ import type {
   SessionState,
 } from "./translate/types";
 import type { GatewayConfig } from "./config";
-import { getProjectPath, extractGitRemoteHeader, resolveUpstreamRoute, extractUpstreamUrlHeader, type ProjectPathResult } from "./config";
+import { getProjectPath, extractGitRemoteHeader, resolveUpstreamRoute, extractUpstreamUrlHeader, unattributedBucketPath, type ProjectPathResult } from "./config";
 import {
   generateSessionID,
   fingerprintMessages,
@@ -866,59 +868,153 @@ function getLLMClient(config: GatewayConfig): LLMClient {
 // ---------------------------------------------------------------------------
 
 /**
- * Upgrade a project path result using the session's cached path.
+ * Resolve the final project path for a session, applying sticky per-session
+ * binding and (on remote gateways) synthetic "unattributed" bucketing.
  *
- * Some requests (e.g. Claude Code's non-streaming prompt-caching probes)
- * have stripped-down system prompts that lack path references, causing
- * `getProjectPath()` to fall back to `process.cwd()`. When the session
- * already has a known-good path from a prior turn, we use that instead.
+ * Context: some requests (Claude Code's haiku side-channel / prompt-cache
+ * probes) carry stripped-down system prompts that lack any path reference, so
+ * `getProjectPath()` returns `source: "cwd"`. On a central/remote gateway the
+ * gateway's own cwd has NO relationship to the client's project — attributing
+ * such requests to cwd merges unrelated sessions into one bogus project (the
+ * "lore-config" bug).
  *
- * Also updates the session cache when a fresh inference or header provides
- * a new path, so future path-less turns benefit.
+ * Rules:
+ *  - A **confident** path (`header`/`inferred`) always binds the session and
+ *    clears the provisional flag. If it overwrites a previously-provisional
+ *    path under which rows were already stored, those rows are re-pointed
+ *    (self-heal) to the real project.
+ *  - A **cwd** result NEVER overwrites a confident binding. If the session has
+ *    no confident binding yet, it stays/becomes provisional:
+ *      - local gateway: keep the cwd path (legacy behavior — gateway shares the
+ *        filesystem with the agent, so cwd is meaningful);
+ *      - remote gateway: route to a per-session synthetic bucket
+ *        (`/__lore_unattributed__/<sessionID>`) so unrelated sessions never
+ *        merge.
  *
  * Returns the final resolved project path.
  */
 export function resolveSessionProjectPath(
   result: ProjectPathResult,
   sessionState: SessionState,
+  config: GatewayConfig,
 ): string {
   let { path: projectPath, source } = result;
 
   // Cache git remote on the session so subsequent turns benefit even if
   // the header is absent (e.g. prompt-cache probes or follow-up requests).
-  // Also backfill ensureProject() — initIfNeeded is one-shot, so if the
-  // first request lacked the header, the project row has no git_remote.
-  // Calling ensureProject() again is safe: it's idempotent and will
-  // backfill git_remote on the existing row if missing.
   if (result.gitRemote && !sessionState.gitRemote) {
     sessionState.gitRemote = result.gitRemote;
-    ensureProject(projectPath, undefined, result.gitRemote);
   }
 
-  // Upgrade from cwd fallback using session's cached path
-  if (source === "cwd" && sessionState.projectPath !== projectPath) {
-    projectPath = sessionState.projectPath;
-    source = "cached" as typeof source;
-  }
+  const hasConfident = !!sessionState.projectPath && !sessionState.projectPathProvisional;
+  // Best git remote we know for this session — the current turn's, falling back
+  // to a value cached on an earlier turn (the header is independent of path
+  // resolution, so it can arrive on a turn that otherwise lacks a path).
+  const effectiveRemote = result.gitRemote ?? sessionState.gitRemote;
 
-  // Update session cache when a fresh path was resolved so future
-  // path-less turns benefit from the cached value.
   if (source === "inferred" || source === "header") {
+    // Confident path — bind the session.
+    const previous = sessionState.projectPath;
+    const wasProvisional = sessionState.projectPathProvisional === true;
+
+    // Self-heal: if the session was previously bound to a provisional path
+    // (cwd fallback or synthetic bucket) under which rows may already be
+    // stored, migrate those rows into the real project now that we know it.
+    // Only clear the provisional flag once the migration succeeds — otherwise
+    // a transient failure (e.g. SQLITE_BUSY from a separate process) would
+    // permanently strand the bucket data with no retry. Keeping the flag set
+    // lets the next confident turn re-attempt.
+    let healed = true;
+    if (wasProvisional && previous && previous !== projectPath) {
+      healed = reattributeProvisionalProject(previous, projectPath, effectiveRemote);
+    }
+
     sessionState.projectPath = projectPath;
+    sessionState.projectPathProvisional = healed ? false : true;
+
+    // Backfill git_remote on the (now confident) project row — idempotent.
+    if (effectiveRemote) {
+      ensureProject(projectPath, undefined, effectiveRemote);
+    }
+    return projectPath;
   }
 
-  // Log warning only when the cwd fallback truly sticks (no session cache
-  // was available to upgrade from).
-  if (source === "cwd" && !cwdWarned.has(sessionState.sessionID)) {
+  // source === "cwd" (no header, inference failed).
+  if (hasConfident) {
+    // Never downgrade a confident binding to cwd. Keep the known-good path.
+    return sessionState.projectPath;
+  }
+
+  // No confident binding yet → provisional attribution.
+  if (config.remoteGateway) {
+    // Remote/central gateway: the gateway's cwd is meaningless for the client.
+    // Use a per-session synthetic bucket so unrelated sessions never merge.
+    projectPath = unattributedBucketPath(sessionState.sessionID);
+  }
+  // (local gateway: keep the cwd path from `result` — cwd is meaningful there.)
+
+  sessionState.projectPath = projectPath;
+  sessionState.projectPathProvisional = true;
+
+  // Record the git remote on the bucket/cwd project row when known. This is
+  // what later lets self-heal and `lore data consolidate` match a provisional
+  // bucket back to its real project by git remote — a common case is a client
+  // that sends X-Lore-Git-Remote but no X-Lore-Project (and no inferable path).
+  if (effectiveRemote) {
+    ensureProject(projectPath, undefined, effectiveRemote);
+  }
+
+  // One-time warning per session when we couldn't confidently attribute.
+  if (!cwdWarned.has(sessionState.sessionID)) {
     cwdWarned.add(sessionState.sessionID);
+    const detail = config.remoteGateway
+      ? `routed to provisional bucket ${projectPath}`
+      : `falling back to process.cwd() (${projectPath})`;
     console.error(
-      `[lore] warning: project path falling back to process.cwd() (${projectPath}). ` +
-      `Data may be misattributed. Fix: use \`lore run\` to launch your agent, ` +
-      `or set ANTHROPIC_CUSTOM_HEADERS="X-Lore-Project: /path/to/project".`,
+      `[lore] warning: could not determine project for session ` +
+        `${sessionState.sessionID.slice(0, 16)} — ${detail}. ` +
+        `Data may be misattributed. Fix: launch your agent via \`lore run\`, ` +
+        `or have your client send the "X-Lore-Project: /path/to/project" header ` +
+        `(provider-agnostic; e.g. via ANTHROPIC_CUSTOM_HEADERS for Claude Code, ` +
+        `the OpenCode/Pi plugins, or your client's custom-header mechanism).`,
     );
   }
 
   return projectPath;
+}
+
+/**
+ * Migrate all rows stored under a provisional project path (a cwd fallback or
+ * a synthetic `/__lore_unattributed__/...` bucket) into the real project once
+ * a confident path is learned for the session.
+ *
+ * Returns `true` when the re-attribution is complete (either there was nothing
+ * to migrate, the source already resolves to the target, or the merge
+ * succeeded) and `false` when a transient failure left bucket data behind. The
+ * caller keeps the session provisional on `false` so a later turn retries
+ * rather than permanently stranding the data. Never throws — a failed self-heal
+ * must not break the live request.
+ */
+function reattributeProvisionalProject(
+  fromPath: string,
+  toPath: string,
+  gitRemote?: string,
+): boolean {
+  try {
+    const fromId = projectId(fromPath);
+    if (!fromId) return true; // nothing was stored under the provisional path
+    // Ensure the destination project row exists before merging into it.
+    const toId = ensureProject(toPath, undefined, gitRemote);
+    if (fromId === toId) return true;
+    mergeProjectInternal(fromId, toId);
+    log.info(
+      `self-heal: re-attributed provisional project ${fromPath} → ${toPath}`,
+    );
+    return true;
+  } catch (e) {
+    log.warn(`self-heal re-attribution failed (${fromPath} → ${toPath}); will retry on next confident turn:`, e);
+    return false;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -928,6 +1024,7 @@ export function resolveSessionProjectPath(
 function getOrCreateSession(
   sessionID: string,
   projectPath: string,
+  pathSource: ProjectPathResult["source"] = "cwd",
 ): SessionState {
   let state = sessions.get(sessionID);
   if (!state) {
@@ -936,6 +1033,12 @@ function getOrCreateSession(
     state = {
       sessionID,
       projectPath,
+      // A freshly-seeded path from the cwd fallback is NOT a confident binding.
+      // Mark it provisional so a later header/inferred turn can overwrite it
+      // (and self-heal any rows stored under the provisional path). Only
+      // header/inferred seeds are confident. `projectPath` itself is not
+      // persisted in session_state, so this is purely in-memory bootstrap.
+      projectPathProvisional: pathSource === "cwd",
       fingerprint: persisted?.fingerprint || "",
       lastRequestTime: Date.now(),
       lastUserTurnTime: 0,
@@ -2660,12 +2763,15 @@ async function handleCompaction(
     if (markerProject) req.rawHeaders["x-lore-project"] = markerProject;
   }
   const pathResult = getProjectPath(req.system, req.rawHeaders);
-  await initIfNeeded(pathResult.path, config, pathResult.gitRemote);
 
   const { sessionID } = await identifySession(req, pathResult.path);
   stripContextMarkers(req.messages);
-  const sessionState = getOrCreateSession(sessionID, pathResult.path);
-  const projectPath = resolveSessionProjectPath(pathResult, sessionState);
+  const sessionState = getOrCreateSession(sessionID, pathResult.path, pathResult.source);
+  const projectPath = resolveSessionProjectPath(pathResult, sessionState, config);
+
+  // Initialize the project AFTER path correction so we never create a row for
+  // the gateway's cwd / an unattributed bucket from a path-less probe request.
+  await initIfNeeded(projectPath, config, pathResult.gitRemote);
 
   setSentryLightContext({ model: req.model, projectPath });
   log.info(`compaction intercepted for session ${sessionID.slice(0, 16)}`);
@@ -2904,7 +3010,6 @@ async function handleConversationTurn(
     if (markerProject) req.rawHeaders["x-lore-project"] = markerProject;
   }
   const pathResult = getProjectPath(req.system, req.rawHeaders);
-  await initIfNeeded(pathResult.path, config, pathResult.gitRemote);
 
   // --- 2. Capture auth credentials for background workers ---
   const cred = extractAuth(req.rawHeaders);
@@ -2920,8 +3025,13 @@ async function handleConversationTurn(
   // temporal storage, or visible to the model.
   stripContextMarkers(req.messages);
 
-  const sessionState = getOrCreateSession(sessionID, pathResult.path);
-  const projectPath = resolveSessionProjectPath(pathResult, sessionState);
+  const sessionState = getOrCreateSession(sessionID, pathResult.path, pathResult.source);
+  const projectPath = resolveSessionProjectPath(pathResult, sessionState, config);
+
+  // Initialize the project AFTER path correction so a path-less probe request
+  // never creates a project row for the gateway's cwd or an unattributed
+  // bucket (provider-agnostic: applies to every protocol/client).
+  await initIfNeeded(projectPath, config, pathResult.gitRemote);
 
   // Mark sub-agent sessions (x-parent-session-id present).
   // These get their own session but are flagged for cache warming exemption.

--- a/packages/gateway/src/translate/types.ts
+++ b/packages/gateway/src/translate/types.ts
@@ -219,6 +219,13 @@ export type CacheAnalytics = {
 export type SessionState = {
   sessionID: string;
   projectPath: string;
+  /** True when `projectPath` was set from a low-confidence source (the cwd
+   *  fallback or a synthetic "unattributed" bucket) rather than an explicit
+   *  `X-Lore-Project` header or a path inferred from the system prompt. While
+   *  provisional, a later turn that DOES carry a confident path is allowed to
+   *  overwrite `projectPath` (and re-point any rows already stored under the
+   *  provisional path). Cleared once a confident path binds the session. */
+  projectPathProvisional?: boolean;
   /** Normalized git remote URL received via `X-Lore-Git-Remote` header.
    *  Cached on the session so subsequent turns benefit even if the header
    *  is absent (e.g. prompt-cache probes). */

--- a/packages/gateway/src/ui.ts
+++ b/packages/gateway/src/ui.ts
@@ -16,6 +16,7 @@ import {
   config,
   projectName,
   projectId as lookupProjectId,
+  isUnattributedProjectPath,
   renderMarkdown,
   loadParentChildMap,
   type TaggedResult,
@@ -1374,8 +1375,11 @@ function pageDashboard(): string {
     <table data-table-id="dashboard-projects">
       <tr><th data-sort="text">Name</th><th data-sort="text">Path</th><th data-sort="text">Git Remote</th><th data-sort="num">Knowledge</th><th data-sort="num">Sessions</th><th data-sort="num">Messages</th><th data-sort="date" data-default-sort="desc">Created</th></tr>`;
     for (const p of projects) {
+      const provisional = isUnattributedProjectPath(p.path)
+        ? ` <span title="Provisional: created when the gateway couldn't determine a project. Will self-heal or can be consolidated via 'lore data consolidate'." style="font-size:0.72em;padding:1px 5px;border-radius:6px;background:var(--bg3);color:var(--fg3);vertical-align:middle">provisional</span>`
+        : "";
       body += `<tr>
-        <td><a href="/ui/projects/${esc(p.id)}">${esc(p.name ?? "(unnamed)")}</a></td>
+        <td><a href="/ui/projects/${esc(p.id)}">${esc(p.name ?? "(unnamed)")}</a>${provisional}</td>
         <td style="font-family:var(--mono);font-size:0.85em">${esc(truncate(p.path, 50))}</td>
         <td style="font-family:var(--mono);font-size:0.85em">${esc(p.git_remote ? truncate(p.git_remote, 40) : "-")}</td>
         <td>${p.knowledge_count}</td>

--- a/packages/gateway/test/eviction.test.ts
+++ b/packages/gateway/test/eviction.test.ts
@@ -47,6 +47,7 @@ function makeConfig(overrides?: Partial<GatewayConfig>): GatewayConfig {
     sessionEvictionTimeoutSeconds: 1800,
     debug: false,
     hostedMode: false,
+    remoteGateway: false,
     ...overrides,
   };
 }

--- a/packages/gateway/test/project-path.test.ts
+++ b/packages/gateway/test/project-path.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from "bun:test";
-import { inferProjectPath, getProjectPath, extractGitRemoteHeader, extractProjectHeader } from "../src/config";
+import { inferProjectPath, getProjectPath, extractGitRemoteHeader, extractProjectHeader, unattributedBucketPath, isUnattributedPath, UNATTRIBUTED_PREFIX, type GatewayConfig } from "../src/config";
 import { resolveSessionProjectPath } from "../src/pipeline";
+import { ensureProject, projectId, ltm } from "@loreai/core";
 
 // ---------------------------------------------------------------------------
 // inferProjectPath
@@ -391,95 +392,163 @@ describe("extractGitRemoteHeader", () => {
 // ---------------------------------------------------------------------------
 
 describe("resolveSessionProjectPath", () => {
-  function makeSessionState(projectPath: string) {
-    return { projectPath } as any;
+  // A confident binding has projectPath set and projectPathProvisional falsy.
+  function confidentState(projectPath: string) {
+    return { sessionID: "sid-confident", projectPath, projectPathProvisional: false } as any;
+  }
+  // A provisional binding (cwd fallback / bucket) — overridable by a later
+  // confident path.
+  function provisionalState(sessionID: string, projectPath: string) {
+    return { sessionID, projectPath, projectPathProvisional: true } as any;
+  }
+  // Freshly-created session (e.g. first turn) seeded by getOrCreateSession with
+  // a cwd path → provisional.
+  function freshCwdState(sessionID: string, cwdPath: string) {
+    return { sessionID, projectPath: cwdPath, projectPathProvisional: true } as any;
   }
 
-  test("upgrades cwd fallback to session's cached path", () => {
-    const state = makeSessionState("/home/user/real-project");
+  const localCfg = { remoteGateway: false } as GatewayConfig;
+  const remoteCfg = { remoteGateway: true } as GatewayConfig;
+
+  test("keeps confident binding when a cwd probe arrives (no downgrade)", () => {
+    const state = confidentState("/home/user/real-project");
     const result = resolveSessionProjectPath(
       { path: process.cwd(), source: "cwd" },
       state,
+      localCfg,
     );
     expect(result).toBe("/home/user/real-project");
-  });
-
-  test("keeps cwd when session has the same path (no upgrade available)", () => {
-    const cwd = process.cwd();
-    const state = makeSessionState(cwd);
-    const result = resolveSessionProjectPath(
-      { path: cwd, source: "cwd" },
-      state,
-    );
-    expect(result).toBe(cwd);
-  });
-
-  test("uses inferred path and updates session cache", () => {
-    const state = makeSessionState("/home/user/old-project");
-    const result = resolveSessionProjectPath(
-      { path: "/home/user/new-project", source: "inferred" },
-      state,
-    );
-    expect(result).toBe("/home/user/new-project");
-    expect(state.projectPath).toBe("/home/user/new-project");
-  });
-
-  test("uses header path and updates session cache", () => {
-    const state = makeSessionState("/home/user/old-project");
-    const result = resolveSessionProjectPath(
-      { path: "/home/user/header-project", source: "header" },
-      state,
-    );
-    expect(result).toBe("/home/user/header-project");
-    expect(state.projectPath).toBe("/home/user/header-project");
-  });
-
-  test("does not update session cache on cwd fallback", () => {
-    const state = makeSessionState("/home/user/real-project");
-    resolveSessionProjectPath(
-      { path: process.cwd(), source: "cwd" },
-      state,
-    );
-    // Session cache should remain unchanged (upgraded, not overwritten)
     expect(state.projectPath).toBe("/home/user/real-project");
   });
 
-  test("does not update session cache when upgrade from cwd occurs", () => {
-    const state = makeSessionState("/home/user/cached-project");
+  test("local gateway: provisional cwd keeps the cwd path (legacy behavior)", () => {
+    const cwd = process.cwd();
+    const state = freshCwdState("sid-local", cwd);
     const result = resolveSessionProjectPath(
-      { path: "/tmp/wrong", source: "cwd" },
+      { path: cwd, source: "cwd" },
       state,
+      localCfg,
     );
-    expect(result).toBe("/home/user/cached-project");
-    // Session cache should remain unchanged
-    expect(state.projectPath).toBe("/home/user/cached-project");
+    expect(result).toBe(cwd);
+    expect(state.projectPathProvisional).toBe(true);
   });
 
+  test("inferred path binds the session and clears provisional flag", () => {
+    const state = provisionalState("sid-inf", "/home/user/old-project");
+    const result = resolveSessionProjectPath(
+      { path: "/home/user/new-project", source: "inferred" },
+      state,
+      localCfg,
+    );
+    expect(result).toBe("/home/user/new-project");
+    expect(state.projectPath).toBe("/home/user/new-project");
+    expect(state.projectPathProvisional).toBe(false);
+  });
+
+  test("header path binds the session and clears provisional flag", () => {
+    const state = provisionalState("sid-hdr", "/home/user/old-project");
+    const result = resolveSessionProjectPath(
+      { path: "/home/user/header-project", source: "header" },
+      state,
+      localCfg,
+    );
+    expect(result).toBe("/home/user/header-project");
+    expect(state.projectPath).toBe("/home/user/header-project");
+    expect(state.projectPathProvisional).toBe(false);
+  });
+
+  // --- Fix 3: remote-gateway synthetic bucketing ---
+
+  test("remote gateway: cwd fallback routes to a per-session bucket (never cwd)", () => {
+    const state = freshCwdState("abc123session", process.cwd());
+    const result = resolveSessionProjectPath(
+      { path: process.cwd(), source: "cwd" },
+      state,
+      remoteCfg,
+    );
+    expect(result).toBe(unattributedBucketPath("abc123session"));
+    expect(isUnattributedPath(result)).toBe(true);
+    expect(state.projectPath).toBe(result);
+    expect(state.projectPathProvisional).toBe(true);
+  });
+
+  test("remote gateway: two path-less sessions get DISTINCT buckets (never merged)", () => {
+    const s1 = freshCwdState("sessionAAA", process.cwd());
+    const s2 = freshCwdState("sessionBBB", process.cwd());
+    const r1 = resolveSessionProjectPath({ path: process.cwd(), source: "cwd" }, s1, remoteCfg);
+    const r2 = resolveSessionProjectPath({ path: process.cwd(), source: "cwd" }, s2, remoteCfg);
+    expect(r1).not.toBe(r2);
+    expect(r1).toBe(`${UNATTRIBUTED_PREFIX}/sessionAAA`);
+    expect(r2).toBe(`${UNATTRIBUTED_PREFIX}/sessionBBB`);
+  });
+
+  // --- Fix 3: self-heal — re-point bucket rows to the real project ---
+
+  test("self-heal: confident path re-attributes rows from a provisional bucket", () => {
+    const sessionID = "selfhealsession1";
+    const bucketPath = unattributedBucketPath(sessionID);
+    // Simulate prior provisional attribution: create the bucket project and
+    // store a knowledge entry under it.
+    const bucketId = ensureProject(bucketPath);
+    ltm.create({
+      projectPath: bucketPath,
+      scope: "project",
+      category: "gotcha",
+      title: "probe-turn-finding",
+      content: "something learned during a path-less probe turn",
+    });
+    expect(projectId(bucketPath)).toBe(bucketId);
+
+    // Now a confident header turn arrives for the same session.
+    const state = provisionalState(sessionID, bucketPath);
+    const realPath = "/home/user/real-faiss-project";
+    const result = resolveSessionProjectPath(
+      { path: realPath, source: "header", gitRemote: "github.com/onur/faiss" },
+      state,
+      remoteCfg,
+    );
+
+    expect(result).toBe(realPath);
+    expect(state.projectPathProvisional).toBe(false);
+
+    // The bucket project should have been merged into the real one: bucket row
+    // deleted, knowledge re-pointed to the real project.
+    const realId = projectId(realPath);
+    expect(realId).toBeDefined();
+    expect(realId).not.toBe(bucketId);
+    const moved = ltm.search({ query: "probe-turn-finding", projectPath: realPath });
+    expect(moved.length).toBeGreaterThan(0);
+  });
+
+  // --- gitRemote caching (unchanged behavior) ---
+
   test("caches gitRemote from result onto session state", () => {
-    const state = makeSessionState("/home/user/project");
+    const state = provisionalState("sid-gr1", "/home/user/project");
     resolveSessionProjectPath(
       { path: "/home/user/project", source: "inferred", gitRemote: "github.com/org/repo" },
       state,
+      localCfg,
     );
     expect(state.gitRemote).toBe("github.com/org/repo");
   });
 
   test("does not overwrite existing session gitRemote", () => {
-    const state = makeSessionState("/home/user/project");
+    const state = provisionalState("sid-gr2", "/home/user/project");
     state.gitRemote = "github.com/org/original-repo";
     resolveSessionProjectPath(
       { path: "/home/user/project", source: "inferred", gitRemote: "github.com/org/new-repo" },
       state,
+      localCfg,
     );
-    // Should keep the original cached value
     expect(state.gitRemote).toBe("github.com/org/original-repo");
   });
 
   test("does not set gitRemote when result has none", () => {
-    const state = makeSessionState("/home/user/project");
+    const state = provisionalState("sid-gr3", "/home/user/project");
     resolveSessionProjectPath(
       { path: "/home/user/project", source: "inferred" },
       state,
+      localCfg,
     );
     expect(state.gitRemote).toBeUndefined();
   });

--- a/packages/gateway/test/remote-attribution.test.ts
+++ b/packages/gateway/test/remote-attribution.test.ts
@@ -1,0 +1,171 @@
+/**
+ * End-to-end (harness) tests for project attribution on a REMOTE gateway.
+ *
+ * Regression coverage for the "lore-config" bug: a central/remote gateway must
+ * never merge unrelated path-less sessions onto its own cwd. With
+ * LORE_REMOTE_GATEWAY=1, path-less requests are routed to per-session synthetic
+ * "unattributed" buckets so each session stays isolated.
+ *
+ * These drive the FULL pipeline (handleRequest → handleConversationTurn →
+ * resolveSessionProjectPath) via the real HTTP server, complementing the
+ * unit-level tests in project-path.test.ts.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import type { Harness } from "./helpers/harness";
+import { createHarness } from "./helpers/harness";
+import {
+  makeConversationFixtures,
+  STANDARD_TOOLS,
+  DEFAULT_MODEL,
+  DEFAULT_SYSTEM,
+} from "./helpers/fixtures";
+
+// A request body with NO inferable project path in the system prompt, so the
+// gateway must fall back (and, on a remote gateway, bucket per-session).
+function pathlessBody(userMessage: string): Record<string, unknown> {
+  return {
+    model: DEFAULT_MODEL,
+    max_tokens: 1024,
+    stream: false,
+    system: DEFAULT_SYSTEM, // intentionally contains no absolute path
+    messages: [{ role: "user", content: userMessage }],
+    tools: STANDARD_TOOLS,
+  };
+}
+
+describe("remote gateway: path-less session attribution", () => {
+  let harness: Harness;
+  let prevRemote: string | undefined;
+
+  beforeEach(() => {
+    prevRemote = process.env.LORE_REMOTE_GATEWAY;
+    process.env.LORE_REMOTE_GATEWAY = "1";
+  });
+
+  afterEach(async () => {
+    await harness?.teardown();
+    if (prevRemote === undefined) delete process.env.LORE_REMOTE_GATEWAY;
+    else process.env.LORE_REMOTE_GATEWAY = prevRemote;
+  });
+
+  it("routes two unrelated path-less sessions to DISTINCT buckets (never merged)", async () => {
+    // Two unrelated conversations → two fingerprints → two sessions.
+    harness = await createHarness({
+      fixtures: [
+        ...makeConversationFixtures([
+          { userMessage: "alpha project question one", assistantText: "A1." },
+        ]),
+        ...makeConversationFixtures([
+          { userMessage: "beta project totally different", assistantText: "B1." },
+        ]),
+      ],
+    });
+
+    const r1 = await harness.chat(pathlessBody("alpha project question one"));
+    expect(r1.status).toBe(200);
+    await r1.text();
+    const r2 = await harness.chat(pathlessBody("beta project totally different"));
+    expect(r2.status).toBe(200);
+    await r2.text();
+
+    // Each session must have its own unattributed bucket — never the gateway cwd,
+    // and never a single shared project.
+    const projects = harness.queryDB<{ path: string; name: string }>(
+      "SELECT path, name FROM projects",
+    );
+    const buckets = projects.filter((p) =>
+      p.path.startsWith("/__lore_unattributed__/"),
+    );
+    expect(buckets.length).toBe(2);
+    // Distinct bucket paths.
+    expect(new Set(buckets.map((b) => b.path)).size).toBe(2);
+    // Provisional naming applied.
+    for (const b of buckets) {
+      expect(b.name.startsWith("(unattributed)")).toBe(true);
+    }
+    // The gateway's own cwd must NOT have become a project.
+    expect(projects.some((p) => p.path === process.cwd())).toBe(false);
+  });
+});
+
+describe("lore data consolidate", () => {
+  let prevDb: string | undefined;
+  const dbPath = `/tmp/lore-consolidate-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`;
+
+  beforeEach(async () => {
+    prevDb = process.env.LORE_DB_PATH;
+    process.env.LORE_DB_PATH = dbPath;
+    const { close } = await import("@loreai/core");
+    close();
+  });
+
+  afterEach(async () => {
+    const { close } = await import("@loreai/core");
+    close();
+    const { unlinkSync, existsSync } = await import("node:fs");
+    for (const suffix of ["", "-shm", "-wal"]) {
+      try {
+        if (existsSync(`${dbPath}${suffix}`)) unlinkSync(`${dbPath}${suffix}`);
+      } catch {
+        /* best-effort */
+      }
+    }
+    if (prevDb === undefined) delete process.env.LORE_DB_PATH;
+    else process.env.LORE_DB_PATH = prevDb;
+  });
+
+  it("merges an unattributed bucket into a real project matched by git remote", async () => {
+    const { db, ensureProject, projectId, ltm, UNATTRIBUTED_PROJECT_PREFIX } =
+      await import("@loreai/core");
+    const { commandData } = await import("../src/cli/data");
+
+    const remote = "github.com/onur/faiss";
+    const realPath = "/home/onur/code/faiss";
+    const bucketPath = `${UNATTRIBUTED_PROJECT_PREFIX}/sessionfaiss1234`;
+
+    // Real project, created by PATH without a remote initially.
+    const realId = ensureProject(realPath);
+    // Bucket, created with the git remote on a path-less turn, accumulating
+    // knowledge that must survive consolidation. (Created via direct insert so
+    // it stays a distinct row even though it shares the remote that will later
+    // be backfilled onto the real project — mirroring the lazy-backfill case
+    // ensureProject's git-remote dedup can't pre-empt.)
+    const bucketId = crypto.randomUUID();
+    db()
+      .query(
+        "INSERT INTO projects (id, path, name, git_remote, created_at) VALUES (?, ?, ?, ?, ?)",
+      )
+      .run(bucketId, bucketPath, "(unattributed) sessionfaiss", remote, Date.now());
+    ltm.create({
+      projectPath: bucketPath,
+      scope: "project",
+      category: "gotcha",
+      title: "bucket-finding-xyz",
+      content: "learned in an unattributed bucket",
+    });
+    // Backfill the remote onto the real project so the two share a remote.
+    db().query("UPDATE projects SET git_remote = ? WHERE id = ?").run(remote, realId);
+    expect(bucketId).not.toBe(realId);
+
+    // Apply consolidation.
+    await commandData(["consolidate"], { yes: true });
+
+    // Bucket project gone; knowledge re-pointed to the real project.
+    expect(projectId(bucketPath)).toBe(realId); // path now an alias of real
+    const moved = ltm.search({ query: "bucket-finding-xyz", projectPath: realPath });
+    expect(moved.length).toBeGreaterThan(0);
+  });
+
+  it("leaves an unmatched bucket intact (dry run by default)", async () => {
+    const { ensureProject, projectId, UNATTRIBUTED_PROJECT_PREFIX } =
+      await import("@loreai/core");
+    const { commandData } = await import("../src/cli/data");
+
+    const bucketPath = `${UNATTRIBUTED_PROJECT_PREFIX}/sessionorphan999`;
+    ensureProject(bucketPath); // no git remote → no match
+
+    // Default (no --yes) is a dry run: nothing changes even if matchable.
+    await commandData(["consolidate"], {});
+    expect(projectId(bucketPath)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Problem

A user (Onur) running a **central/remote lore gateway** with Claude Code on a **separate machine** (via `lore run`) reported that **two unrelated projects' sessions were both grouped under a single "lore-config" project**.

### Root cause (confirmed via Sentry + code)

- Claude Code's **haiku side-channel requests** (title generation, quota/"new topic" probes) reach the gateway **without** `X-Lore-Project` and with a minimal system prompt that has no inferable path.
- `getProjectPath()` then falls back to the **gateway's own `process.cwd()`** = `/home/onur/lore-config`.
- Because that cwd is a **single shared path**, every path-less session collapses onto it → unrelated projects merge under one bogus `lore-config` project (`ensureProject` names it `path.split('/').pop()`).
- The gateway's cwd has **no relationship** to a client's project on a remote/central gateway.

The phantom `no such column: project_path` errors seen in Sentry were traced to a *different* user's private fork and are unrelated.

## Fix (provider-agnostic)

All logic operates on the **normalized request in the shared pipeline**, so it protects Anthropic, OpenAI Chat, and OpenAI Responses clients identically — no per-provider code.

1. **Sticky per-session binding** — a confident path (`X-Lore-Project` header or one inferred from the system prompt) binds the session and clears the provisional flag. A cwd fallback **never** overwrites a confident binding; a freshly-seeded cwd path is marked *provisional* so a later confident turn takes over.
2. **Reorder `initIfNeeded()`** to run **after** path correction, so a probe request never creates a project row for the cwd / an unattributed bucket.
3. **Remote-gateway mode** (`LORE_REMOTE_GATEWAY`; implied by `LORE_HOSTED_MODE`) — path-less requests route to a **per-session synthetic bucket** `/__lore_unattributed__/<sessionID>` instead of the gateway cwd, so **unrelated sessions are never merged**. Buckets get a `(unattributed)` provisional name + a dashboard badge.
4. **Self-heal** — when a confident path later arrives for a provisional session, rows already stored under the bucket are **re-pointed** into the real project via `mergeProjectInternal()`.
5. **`lore data consolidate`** — new maintenance command that merges leftover unattributed buckets into matched real projects by git remote.

## Tests

New unit tests cover sticky binding, remote bucketing, **two path-less sessions getting distinct (non-merged) buckets**, and self-heal re-attribution. Full suite: only the pre-existing flaky `quota.test.ts` header test fails (present on clean `main` too); everything else green. Typecheck passes for all 4 packages; npm bundle + bundle-exports smoke tests pass.

## Notes

- `.lore.md` session churn intentionally excluded to keep the diff focused.
- No DB schema change: `projectPath` isn't persisted in `session_state`, so the provisional flag is purely in-memory bootstrap.