### PR TITLE
feat(core): track cross-project knowledge transfer metrics (#506)

### DIFF
--- a/packages/core/src/data.ts
+++ b/packages/core/src/data.ts
@@ -361,6 +361,13 @@ export function clearProject(projectPath: string): ClearResult {
     database
       .query("DELETE FROM tool_calls WHERE project_id = ?")
       .run(pid);
+    // knowledge_transfers has two project columns (origin via knowledge_id, and
+    // recalled_in). Delete BEFORE knowledge so the subquery still sees the rows.
+    database
+      .query(
+        "DELETE FROM knowledge_transfers WHERE recalled_in_project_id = ? OR knowledge_id IN (SELECT id FROM knowledge WHERE project_id = ?)",
+      )
+      .run(pid, pid);
     database
       .query("DELETE FROM knowledge WHERE project_id = ?")
       .run(pid);
@@ -466,6 +473,13 @@ export function deleteProject(projectId: string): ClearResult | null {
     database
       .query("DELETE FROM tool_calls WHERE project_id = ?")
       .run(projectId);
+    // knowledge_transfers has two project columns (origin via knowledge_id, and
+    // recalled_in). Delete BEFORE knowledge so the subquery still sees the rows.
+    database
+      .query(
+        "DELETE FROM knowledge_transfers WHERE recalled_in_project_id = ? OR knowledge_id IN (SELECT id FROM knowledge WHERE project_id = ?)",
+      )
+      .run(projectId, projectId);
     database
       .query("DELETE FROM knowledge WHERE project_id = ?")
       .run(projectId);
@@ -623,6 +637,9 @@ export function deleteSession(
       .get(pid, sessionId) as { c: number }
   ).c;
 
+  // Note: knowledge_transfers has no session_id column (it is a pure per-project
+  // tally); per-session dedup is handled in-memory in ltm.ts, so there is
+  // nothing session-scoped to delete here.
   database
     .query(
       "DELETE FROM tool_calls WHERE project_id = ? AND session_id = ?",

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -942,6 +942,30 @@ const MIGRATIONS: string[] = [
     VALUES (new.rowid, new.alias_value);
   END;
   `,
+
+  `
+  -- Version 33: Cross-project knowledge transfer metrics (issue #506).
+  -- One row per (knowledge entry, foreign project) pair — a bounded tally,
+  -- NOT an event log. hit_count accumulates via UPSERT; last_recalled_at is
+  -- overwritten while first_recalled_at is set once. Tracks how often a
+  -- cross-project / other-project entry is recalled or surfaced in a project
+  -- that is NOT its origin, so we can measure whether promotions are useful.
+  --
+  -- Global entries (project_id IS NULL) have no origin and are never recorded;
+  -- self-project recalls are filtered out by callers. No FTS, no triggers, no
+  -- FK CASCADE (consistent with tool_calls / daily_costs) — explicit cleanup
+  -- lives in data.ts and mergeProjectInternal().
+  CREATE TABLE IF NOT EXISTS knowledge_transfers (
+    knowledge_id           TEXT NOT NULL,
+    recalled_in_project_id TEXT NOT NULL,
+    hit_count              INTEGER NOT NULL DEFAULT 0,
+    first_recalled_at      INTEGER NOT NULL,
+    last_recalled_at       INTEGER NOT NULL,
+    PRIMARY KEY (knowledge_id, recalled_in_project_id)
+  );
+  CREATE INDEX IF NOT EXISTS idx_knowledge_transfers_recalled_in
+    ON knowledge_transfers (recalled_in_project_id);
+  `,
 ];
 
 /** Return the resolved path of the SQLite database file. */
@@ -1178,6 +1202,16 @@ function recoverMissingObjects(database: Database) {
       ON tool_calls (project_id, tool, status);
     CREATE INDEX IF NOT EXISTS idx_tool_calls_project_session
       ON tool_calls (project_id, session_id);
+    CREATE TABLE IF NOT EXISTS knowledge_transfers (
+      knowledge_id           TEXT NOT NULL,
+      recalled_in_project_id TEXT NOT NULL,
+      hit_count              INTEGER NOT NULL DEFAULT 0,
+      first_recalled_at      INTEGER NOT NULL,
+      last_recalled_at       INTEGER NOT NULL,
+      PRIMARY KEY (knowledge_id, recalled_in_project_id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_knowledge_transfers_recalled_in
+      ON knowledge_transfers (recalled_in_project_id);
   `);
 
   // Recover missing columns from partial migration runs.
@@ -1230,6 +1264,31 @@ export function mergeProjectInternal(
       targetId,
       sourceId,
     );
+    // knowledge_transfers: re-point the "recalled in" foreign project. A plain
+    // UPDATE would violate the composite PK when a (knowledge_id, targetId) row
+    // already exists, so merge the counts via UPSERT then delete the leftover
+    // source rows. The knowledge_id side needs no update — entries keep their
+    // UUID when their origin project merges.
+    d.query(
+      `INSERT INTO knowledge_transfers
+         (knowledge_id, recalled_in_project_id, hit_count, first_recalled_at, last_recalled_at)
+       SELECT knowledge_id, ?, hit_count, first_recalled_at, last_recalled_at
+         FROM knowledge_transfers WHERE recalled_in_project_id = ?
+       ON CONFLICT(knowledge_id, recalled_in_project_id) DO UPDATE SET
+         hit_count = hit_count + excluded.hit_count,
+         first_recalled_at = MIN(first_recalled_at, excluded.first_recalled_at),
+         last_recalled_at = MAX(last_recalled_at, excluded.last_recalled_at)`,
+    ).run(targetId, sourceId);
+    d.query(
+      "DELETE FROM knowledge_transfers WHERE recalled_in_project_id = ?",
+    ).run(sourceId);
+    // Drop rows that became self-referential (origin == recalled-in) after the
+    // merge: an entry whose origin was the source project, recalled in target.
+    d.query(
+      `DELETE FROM knowledge_transfers
+        WHERE recalled_in_project_id = ?
+          AND knowledge_id IN (SELECT id FROM knowledge WHERE project_id = ?)`,
+    ).run(targetId, targetId);
     // entity_relations references entities by FK — no project_id column to update.
     // Relations move implicitly when their parent entities move.
     d.query(

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -525,6 +525,10 @@ export async function forSession(
       result.push(entry);
       used += cost;
     }
+    // Note: transfer metrics (issue #506) are intentionally NOT recorded on this
+    // fast path. Preferences are typically global/cross directives rather than
+    // project-origin knowledge, so counting them as cross-project "transfers"
+    // would be misleading.
     return result;
   }
 
@@ -716,8 +720,27 @@ export async function forSession(
         source_entry_id: null,
         last_accessed_at: null,
       });
-      used += cost;
+       used += cost;
     }
+  }
+
+  // --- 7. Record cross-project transfer metrics (issue #506) ---
+  // An entry counts as a "transfer" when it was injected into a project that is
+  // NOT its origin: cross_project=1 AND a non-null project_id != pid. Global
+  // entries (project_id === null) have no origin; self-project entries
+  // (project_id === pid) are not transfers; lat.md synthetics are skipped (they
+  // are not knowledge rows). The in-memory throttle bounds writes so this
+  // every-message path does not hammer SQLite.
+  try {
+    for (const entry of result) {
+      if (entry.category === "lat.md") continue;
+      if (entry.cross_project !== 1) continue;
+      if (!entry.project_id || entry.project_id === pid) continue;
+      if (!shouldRecordTransfer(sessionID, entry.id, pid)) continue;
+      recordTransfer({ knowledgeId: entry.id, recalledInProjectId: pid });
+    }
+  } catch (err) {
+    log.warn("forSession: transfer recording failed (non-fatal):", err);
   }
 
   return result;
@@ -1801,6 +1824,130 @@ export function pruneDedupFeedback(projectId: string | null): void {
       )
       .run(excess);
   }
+}
+
+// ---------------------------------------------------------------------------
+// Cross-project knowledge transfer metrics (issue #506)
+// ---------------------------------------------------------------------------
+
+/**
+ * Record that a knowledge entry was surfaced in a project other than its
+ * origin. UPSERT-increments the (knowledge_id, recalled_in_project_id) tally.
+ *
+ * Callers MUST pre-filter:
+ *   - the entry's origin project must be non-null (global entries are not
+ *     transfers)
+ *   - recalledInProjectId !== the entry's origin project (no self-project
+ *     recalls)
+ * This function trusts those invariants but defensively no-ops on an empty
+ * recalled-in id.
+ */
+export function recordTransfer(input: {
+  knowledgeId: string;
+  recalledInProjectId: string;
+}): void {
+  if (!input.recalledInProjectId) return;
+  const now = Date.now();
+  db()
+    .query(
+      `INSERT INTO knowledge_transfers
+         (knowledge_id, recalled_in_project_id, hit_count, first_recalled_at, last_recalled_at)
+       VALUES (?, ?, 1, ?, ?)
+       ON CONFLICT(knowledge_id, recalled_in_project_id) DO UPDATE SET
+         hit_count = hit_count + 1,
+         last_recalled_at = ?`,
+    )
+    .run(input.knowledgeId, input.recalledInProjectId, now, now, now);
+}
+
+/**
+ * Number of distinct foreign projects an entry has been recalled in. Each
+ * composite-PK row is already one distinct foreign project, so a plain
+ * COUNT(*) suffices.
+ */
+export function transferCount(knowledgeId: string): number {
+  const row = db()
+    .query(
+      "SELECT COUNT(*) as cnt FROM knowledge_transfers WHERE knowledge_id = ?",
+    )
+    .get(knowledgeId) as { cnt: number } | null;
+  return row?.cnt ?? 0;
+}
+
+/**
+ * Distinct-foreign-project transfer counts for ALL entries, keyed by
+ * knowledge_id. Batch-loaded for the user-knowledge list page to avoid N+1.
+ */
+export function transferCounts(): Map<string, number> {
+  const rows = db()
+    .query(
+      "SELECT knowledge_id, COUNT(*) as cnt FROM knowledge_transfers GROUP BY knowledge_id",
+    )
+    .all() as Array<{ knowledge_id: string; cnt: number }>;
+  const m = new Map<string, number>();
+  for (const r of rows) m.set(r.knowledge_id, r.cnt);
+  return m;
+}
+
+export type KnowledgeTransfer = {
+  recalled_in_project_id: string;
+  hit_count: number;
+  first_recalled_at: number;
+  last_recalled_at: number;
+};
+
+/** Full per-foreign-project breakdown for one entry, newest activity first. */
+export function transfersFor(knowledgeId: string): KnowledgeTransfer[] {
+  return db()
+    .query(
+      `SELECT recalled_in_project_id, hit_count, first_recalled_at, last_recalled_at
+         FROM knowledge_transfers
+        WHERE knowledge_id = ?
+        ORDER BY last_recalled_at DESC`,
+    )
+    .all(knowledgeId) as KnowledgeTransfer[];
+}
+
+// --- forSession transfer-recording throttle (in-memory, process-local) ------
+//
+// forSession() runs on (nearly) every message transform. Recording every
+// cross-pool entry on every call would hammer SQLite. This guard records each
+// (sessionID, knowledgeId, recalledInProjectId) tuple at most once per
+// TRANSFER_DEDUP_WINDOW_MS. The map is bounded by TRANSFER_DEDUP_MAX_KEYS with
+// FIFO eviction (Map preserves insertion order). State is volatile — the tally
+// is durable in the DB, so a process restart simply re-opens the window.
+const transferDedup = new Map<string, number>();
+const TRANSFER_DEDUP_WINDOW_MS = 30 * 60 * 1000; // 30 min
+const TRANSFER_DEDUP_MAX_KEYS = 50_000;
+
+function shouldRecordTransfer(
+  sessionID: string | undefined,
+  knowledgeId: string,
+  recalledInProjectId: string,
+): boolean {
+  // No session → stable synthetic key so we still throttle per (entry, project).
+  const sid = sessionID ?? "__nosession__";
+  const key = `${sid}\x1f${knowledgeId}\x1f${recalledInProjectId}`;
+  const now = Date.now();
+  const last = transferDedup.get(key);
+  if (last != null && now - last < TRANSFER_DEDUP_WINDOW_MS) return false;
+
+  if (transferDedup.size >= TRANSFER_DEDUP_MAX_KEYS) {
+    // Evict ~10% oldest to bound memory.
+    const evict = Math.ceil(TRANSFER_DEDUP_MAX_KEYS * 0.1);
+    let i = 0;
+    for (const k of transferDedup.keys()) {
+      transferDedup.delete(k);
+      if (++i >= evict) break;
+    }
+  }
+  transferDedup.set(key, now);
+  return true;
+}
+
+/** Test-only: clear the in-memory forSession transfer-recording throttle. */
+export function __resetTransferDedup(): void {
+  transferDedup.clear();
 }
 
 /**

--- a/packages/core/src/recall.ts
+++ b/packages/core/src/recall.ts
@@ -64,6 +64,13 @@ export type RecallInput = {
   llm?: LLMClient;
   /** Search config — provides recallLimit, queryExpansion, ftsWeights, etc. */
   searchConfig?: LoreConfig["search"];
+  /**
+   * Record cross-project knowledge transfer metrics (issue #506) for
+   * foreign/promoted entries that survive fusion. Set true ONLY for genuine
+   * agent recall (executeRecall); left false for dashboard/CLI searches so they
+   * don't inflate counts. Default false.
+   */
+  recordTransfers?: boolean;
 };
 
 /** Result of a full recall run — markdown-formatted string for the LLM. */
@@ -1045,6 +1052,32 @@ export async function runRecall(input: RecallInput): Promise<RecallResult> {
   }
 
   const fused = await searchRecall(input);
+
+  // Record cross-project knowledge transfers (issue #506) — only for genuine
+  // agent recall. id-based detail retrieval already returned above, so
+  // recallById is never counted. Two fused sources qualify:
+  //   - "cross-knowledge": foreign-project non-promoted entries
+  //     (searchScoredOtherProjects guarantees project_id != current project).
+  //   - "knowledge": promoted cross_project=1 entries whose project_id is a
+  //     DIFFERENT non-null project than the current one.
+  if (input.recordTransfers) {
+    try {
+      const pid = ensureProject(input.projectPath);
+      for (const { item: tagged } of fused) {
+        if (tagged.source !== "cross-knowledge" && tagged.source !== "knowledge")
+          continue;
+        const entry = tagged.item;
+        // For same-source knowledge results, only promoted cross-project entries
+        // from another project count as transfers.
+        if (tagged.source === "knowledge" && entry.cross_project !== 1) continue;
+        if (!entry.project_id || entry.project_id === pid) continue;
+        ltm.recordTransfer({ knowledgeId: entry.id, recalledInProjectId: pid });
+      }
+    } catch (err) {
+      log.warn("recall: transfer recording failed (non-fatal):", err);
+    }
+  }
+
   const recallCfg = input.searchConfig?.recall;
   let out = formatFusedResults(fused, {
     charBudget: recallCfg?.charBudget ?? DEFAULT_FORMAT_CONFIG.charBudget,

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -24,7 +24,7 @@ describe("db", () => {
     const row = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(row.version).toBe(32);
+    expect(row.version).toBe(33);
   });
 
   test("distillation_fts virtual table exists", () => {
@@ -1066,6 +1066,56 @@ describe("db", () => {
       const names = idx.map((i) => i.name);
       expect(names).toContain("idx_tool_calls_project_tool_status");
       expect(names).toContain("idx_tool_calls_project_session");
+    });
+  });
+
+  // Migration v33: cross-project knowledge transfer metrics (knowledge_transfers)
+  describe("knowledge_transfers tally (v33)", () => {
+    test("knowledge_transfers table and index exist", () => {
+      const tbl = db()
+        .query(
+          "SELECT name FROM sqlite_master WHERE type='table' AND name='knowledge_transfers'",
+        )
+        .get();
+      expect(tbl).not.toBeNull();
+      const idx = db()
+        .query(
+          "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='knowledge_transfers'",
+        )
+        .all() as Array<{ name: string }>;
+      expect(idx.map((i) => i.name)).toContain(
+        "idx_knowledge_transfers_recalled_in",
+      );
+    });
+
+    test("recoverMissingObjects recreates knowledge_transfers when missing", () => {
+      const d = db();
+      d.exec("DROP TABLE IF EXISTS knowledge_transfers");
+      expect(
+        d
+          .query(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='knowledge_transfers'",
+          )
+          .get(),
+      ).toBeNull();
+
+      close();
+      const fresh = db();
+      const after = fresh
+        .query(
+          "SELECT name FROM sqlite_master WHERE type='table' AND name='knowledge_transfers'",
+        )
+        .get() as { name: string } | null;
+      expect(after).not.toBeNull();
+      expect(after!.name).toBe("knowledge_transfers");
+      const idx = fresh
+        .query(
+          "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='knowledge_transfers'",
+        )
+        .all() as Array<{ name: string }>;
+      expect(idx.map((i) => i.name)).toContain(
+        "idx_knowledge_transfers_recalled_in",
+      );
     });
   });
 });

--- a/packages/core/test/knowledge-transfers.test.ts
+++ b/packages/core/test/knowledge-transfers.test.ts
@@ -1,0 +1,268 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { uuidv7 } from "uuidv7";
+import { db, ensureProject } from "../src/db";
+import * as ltm from "../src/ltm";
+import * as data from "../src/data";
+import { runRecall } from "../src/recall";
+
+// Origin project of the promoted entry, and a DIFFERENT project where it is
+// recalled/surfaced (the "foreign" project).
+const ORIGIN = "/test/transfers/origin";
+const FOREIGN = "/test/transfers/foreign";
+const FOREIGN_SESSION = "transfers-session-1";
+
+function cleanup() {
+  // Remove all knowledge + transfers belonging to the test projects.
+  db()
+    .query(
+      "DELETE FROM knowledge_transfers WHERE knowledge_id IN (SELECT id FROM knowledge WHERE project_id IN (SELECT id FROM projects WHERE path LIKE '/test/transfers/%')) OR recalled_in_project_id IN (SELECT id FROM projects WHERE path LIKE '/test/transfers/%')",
+    )
+    .run();
+  db()
+    .query(
+      "DELETE FROM knowledge WHERE project_id IN (SELECT id FROM projects WHERE path LIKE '/test/transfers/%')",
+    )
+    .run();
+  db()
+    .query(
+      "DELETE FROM temporal_messages WHERE project_id IN (SELECT id FROM projects WHERE path LIKE '/test/transfers/%')",
+    )
+    .run();
+  db()
+    .query(
+      "DELETE FROM distillations WHERE project_id IN (SELECT id FROM projects WHERE path LIKE '/test/transfers/%')",
+    )
+    .run();
+  ltm.__resetTransferDedup();
+}
+
+/** Create a promoted (cross_project=1) entry that retains its origin project. */
+function createPromoted(title: string, content: string): string {
+  return ltm.create({
+    id: uuidv7(),
+    projectPath: ORIGIN,
+    category: "gotcha",
+    title,
+    content,
+    scope: "project",
+    crossProject: true,
+    session: "origin-session",
+  });
+}
+
+/** Seed session context in the FOREIGN project so relevance scoring matches. */
+function seedForeignContext(text: string) {
+  const pid = ensureProject(FOREIGN);
+  db()
+    .query(
+      "INSERT INTO temporal_messages (id, project_id, session_id, role, content, tokens, distilled, created_at, metadata) VALUES (?, ?, ?, ?, ?, ?, 0, ?, '{}')",
+    )
+    .run(uuidv7(), pid, FOREIGN_SESSION, "user", text, 20, Date.now());
+}
+
+describe("knowledge_transfers migration", () => {
+  test("table exists with expected columns", () => {
+    const row = db()
+      .query(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='knowledge_transfers'",
+      )
+      .get() as { name: string } | null;
+    expect(row?.name).toBe("knowledge_transfers");
+
+    const cols = (
+      db().query("PRAGMA table_info(knowledge_transfers)").all() as Array<{
+        name: string;
+      }>
+    ).map((c) => c.name);
+    expect(cols).toContain("knowledge_id");
+    expect(cols).toContain("recalled_in_project_id");
+    expect(cols).toContain("hit_count");
+    expect(cols).toContain("first_recalled_at");
+    expect(cols).toContain("last_recalled_at");
+  });
+});
+
+describe("ltm.recordTransfer / read helpers", () => {
+  beforeEach(cleanup);
+
+  test("first record inserts hit_count=1; second upserts to 2", () => {
+    const id = createPromoted("Upsert entry", "content about widgets");
+    const fpid = ensureProject(FOREIGN);
+
+    ltm.recordTransfer({ knowledgeId: id, recalledInProjectId: fpid });
+    let breakdown = ltm.transfersFor(id);
+    expect(breakdown.length).toBe(1);
+    expect(breakdown[0]!.hit_count).toBe(1);
+    const firstAt = breakdown[0]!.first_recalled_at;
+
+    ltm.recordTransfer({ knowledgeId: id, recalledInProjectId: fpid });
+    breakdown = ltm.transfersFor(id);
+    expect(breakdown.length).toBe(1);
+    expect(breakdown[0]!.hit_count).toBe(2);
+    // first_recalled_at is set once and preserved.
+    expect(breakdown[0]!.first_recalled_at).toBe(firstAt);
+    expect(breakdown[0]!.last_recalled_at).toBeGreaterThanOrEqual(firstAt);
+  });
+
+  test("transferCount = distinct foreign projects", () => {
+    const id = createPromoted("Multi-project entry", "shared content");
+    const f1 = ensureProject(FOREIGN);
+    const f2 = ensureProject("/test/transfers/foreign-2");
+
+    ltm.recordTransfer({ knowledgeId: id, recalledInProjectId: f1 });
+    ltm.recordTransfer({ knowledgeId: id, recalledInProjectId: f1 }); // same project
+    ltm.recordTransfer({ knowledgeId: id, recalledInProjectId: f2 });
+
+    expect(ltm.transferCount(id)).toBe(2); // two distinct projects, not 3 hits
+  });
+
+  test("transferCounts batch map matches per-entry counts", () => {
+    const a = createPromoted("Entry A", "alpha");
+    const b = createPromoted("Entry B", "beta");
+    const fpid = ensureProject(FOREIGN);
+    ltm.recordTransfer({ knowledgeId: a, recalledInProjectId: fpid });
+
+    const counts = ltm.transferCounts();
+    expect(counts.get(a)).toBe(1);
+    expect(counts.get(b) ?? 0).toBe(0);
+  });
+
+  test("empty recalled-in id is a no-op", () => {
+    const id = createPromoted("No-op entry", "gamma");
+    ltm.recordTransfer({ knowledgeId: id, recalledInProjectId: "" });
+    expect(ltm.transferCount(id)).toBe(0);
+  });
+});
+
+describe("forSession transfer recording", () => {
+  beforeEach(cleanup);
+
+  test("records a promoted foreign entry recalled in another project", async () => {
+    createPromoted(
+      "Caching layer decision",
+      "Use an LRU cache for the resolver hot path",
+    );
+    seedForeignContext("How should I add a cache to the resolver hot path?");
+
+    const fpid = ensureProject(FOREIGN);
+    const result = await ltm.forSession(FOREIGN, FOREIGN_SESSION, 10_000);
+    // Sanity: the promoted entry surfaced in the foreign project.
+    const surfaced = result.find((e) => e.title === "Caching layer decision");
+    expect(surfaced).toBeDefined();
+    expect(surfaced!.cross_project).toBe(1);
+    expect(surfaced!.project_id).not.toBe(fpid);
+
+    expect(ltm.transferCount(surfaced!.id)).toBe(1);
+  });
+
+  test("throttle: second forSession within window does not double-count", async () => {
+    createPromoted(
+      "Retry backoff policy",
+      "Honor Retry-After and cap exponential backoff",
+    );
+    seedForeignContext("What retry backoff policy should the client honor?");
+
+    await ltm.forSession(FOREIGN, FOREIGN_SESSION, 10_000);
+    await ltm.forSession(FOREIGN, FOREIGN_SESSION, 10_000);
+
+    const counts = ltm.transferCounts();
+    // At most 1 hit for any entry despite two forSession calls.
+    for (const c of counts.values()) expect(c).toBeLessThanOrEqual(1);
+  });
+
+  test("does NOT record self-project entries", async () => {
+    // A promoted entry whose origin IS the project it's recalled in.
+    const id = ltm.create({
+      id: uuidv7(),
+      projectPath: FOREIGN,
+      category: "gotcha",
+      title: "Self project entry",
+      content: "Local resolver detail for this very project",
+      scope: "project",
+      crossProject: true,
+      session: "s",
+    });
+    seedForeignContext("Tell me about the local resolver detail");
+
+    await ltm.forSession(FOREIGN, FOREIGN_SESSION, 10_000);
+    expect(ltm.transferCount(id)).toBe(0);
+  });
+});
+
+describe("runRecall transfer gating", () => {
+  beforeEach(cleanup);
+
+  test("records cross-project hits only when recordTransfers is set", async () => {
+    const id = createPromoted(
+      "Zigzag indexing trick",
+      "Zigzag indexing trick for sparse matrix traversal",
+    );
+    const fpid = ensureProject(FOREIGN);
+
+    // Without recordTransfers → nothing recorded.
+    await runRecall({
+      query: "zigzag indexing sparse matrix",
+      scope: "all",
+      projectPath: FOREIGN,
+      sessionID: FOREIGN_SESSION,
+      knowledgeEnabled: true,
+    });
+    expect(ltm.transferCount(id)).toBe(0);
+
+    // With recordTransfers → the foreign promoted entry is counted.
+    await runRecall({
+      query: "zigzag indexing sparse matrix",
+      scope: "all",
+      projectPath: FOREIGN,
+      sessionID: FOREIGN_SESSION,
+      knowledgeEnabled: true,
+      recordTransfers: true,
+    });
+    expect(ltm.transferCount(id)).toBeGreaterThanOrEqual(1);
+    const breakdown = ltm.transfersFor(id);
+    expect(breakdown[0]!.recalled_in_project_id).toBe(fpid);
+  });
+
+  test("recallById never records", async () => {
+    const id = createPromoted("ById entry", "content for id lookup");
+    await runRecall({
+      query: "",
+      id: `xk:${id}`,
+      projectPath: FOREIGN,
+      knowledgeEnabled: true,
+      recordTransfers: true,
+    });
+    expect(ltm.transferCount(id)).toBe(0);
+  });
+});
+
+describe("transfer cleanup on project deletion", () => {
+  beforeEach(cleanup);
+
+  test("clearProject removes rows for both project columns", () => {
+    const id = createPromoted("Cleanup entry", "to be cleared");
+    const fpid = ensureProject(FOREIGN);
+    ltm.recordTransfer({ knowledgeId: id, recalledInProjectId: fpid });
+    expect(ltm.transferCount(id)).toBe(1);
+
+    // Clearing the FOREIGN (recalled-in) project drops the transfer row.
+    data.clearProject(FOREIGN);
+    expect(ltm.transferCount(id)).toBe(0);
+  });
+
+  test("clearProject of origin project also drops its transfer rows", () => {
+    const id = createPromoted("Origin cleanup entry", "origin side");
+    const fpid = ensureProject(FOREIGN);
+    ltm.recordTransfer({ knowledgeId: id, recalledInProjectId: fpid });
+    expect(ltm.transferCount(id)).toBe(1);
+
+    data.clearProject(ORIGIN);
+    // The origin knowledge row is gone, so its transfers are gone too.
+    const remaining = db()
+      .query(
+        "SELECT COUNT(*) as c FROM knowledge_transfers WHERE knowledge_id = ?",
+      )
+      .get(id) as { c: number };
+    expect(remaining.c).toBe(0);
+  });
+});

--- a/packages/gateway/src/recall.ts
+++ b/packages/gateway/src/recall.ts
@@ -362,6 +362,8 @@ export async function executeRecall(
       knowledgeEnabled: cfg.knowledge?.enabled ?? true,
       llm,
       searchConfig: cfg.search,
+      // Genuine agent recall — record cross-project transfer metrics (#506).
+      recordTransfers: true,
     });
 
     return { result, input: { query, scope, id } };

--- a/packages/gateway/src/ui.ts
+++ b/packages/gateway/src/ui.ts
@@ -1550,9 +1550,12 @@ function pageUserKnowledge(): string {
   }
   body += `</div>`;
 
+  // Batch-load cross-project transfer counts (#506) to avoid N+1 queries.
+  const transferCounts = ltm.transferCounts();
+
   body += `<div class="table-filter"><input type="text" placeholder="Filter knowledge\u2026"><span class="count"></span></div>
   <table data-table-id="user-knowledge">
-    <tr><th data-sort="text">Category</th><th data-sort="text">Title</th><th data-sort="text">Source Project</th><th data-sort="num">Confidence</th><th data-sort="date" data-default-sort="desc">Updated</th></tr>`;
+    <tr><th data-sort="text">Category</th><th data-sort="text">Title</th><th data-sort="text">Source Project</th><th data-sort="num">Confidence</th><th data-sort="num">Recalls</th><th data-sort="date" data-default-sort="desc">Updated</th></tr>`;
   for (const e of entries) {
     const projName = e.project_id ? projectName(e.project_id) : null;
     const projDisplay = e.project_id
@@ -1563,6 +1566,7 @@ function pageUserKnowledge(): string {
       <td><a href="/ui/knowledge/${esc(e.id)}">${esc(truncate(e.title, 60))}</a></td>
       <td>${projDisplay}</td>
       <td>${e.confidence.toFixed(2)}</td>
+      <td>${transferCounts.get(e.id) ?? 0}</td>
       <td>${timeAgo(e.updated_at)}</td>
     </tr>`;
   }
@@ -1594,12 +1598,32 @@ function pageKnowledge(id: string): string | null {
   body += `<div class="field"><span class="key">ID:</span> <code>${esc(entry.id)}</code></div>`;
   body += `<div class="field"><span class="key">Project ID:</span> ${esc(entry.project_id ?? "(global)")}</div>`;
   body += `<div class="field"><span class="key">Cross-project:</span> ${entry.cross_project ? "Yes" : "No"}</div>`;
+  const transfers = ltm.transfersFor(entry.id);
+  body += `<div class="field"><span class="key">Recalled in other projects:</span> ${transfers.length}</div>`;
   body += `<div class="field"><span class="key">Source session:</span> ${esc(entry.source_session ?? "(none)")}</div>`;
   body += `<div class="field"><span class="key">Created:</span> ${formatDate(entry.created_at)}</div>`;
   body += `<div class="field"><span class="key">Updated:</span> ${formatDate(entry.updated_at)}</div>`;
   if (entry.metadata) {
     body += `<div class="field"><span class="key">Metadata:</span></div><pre>${esc(entry.metadata)}</pre>`;
   }
+
+  // Cross-project recall breakdown (#506): which foreign projects surfaced this
+  // entry, how often, and when last.
+  if (transfers.length) {
+    body += `<h2>Cross-Project Recalls</h2>
+    <table>
+      <tr><th>Project</th><th data-sort="num">Hits</th><th data-sort="date">Last recalled</th></tr>`;
+    for (const t of transfers) {
+      const name = projectName(t.recalled_in_project_id) ?? "(unknown)";
+      body += `<tr>
+        <td><a href="/ui/projects/${esc(t.recalled_in_project_id)}">${esc(name)}</a></td>
+        <td>${t.hit_count}</td>
+        <td>${timeAgo(t.last_recalled_at)}</td>
+      </tr>`;
+    }
+    body += `</table>`;
+  }
+
   body += `<h2>Content</h2>${md(entry.content)}`;
 
   body += `<div class="actions">


### PR DESCRIPTION
## Summary

Tracks how often a cross-project / promoted knowledge entry is recalled or surfaced in a project that is **not** its origin, and exposes the metric in the web dashboard. Follow-up to #505 (cross-project auto-promotion) — `promoteCrossProject()` promotes entries recurring across 3+ projects, but there was previously no way to measure whether those promotions are actually useful.

Closes #506.

## Approach

### Persistence — `knowledge_transfers` table (migration v33)
A bounded **per-(entry, foreign-project) tally** (composite PK `(knowledge_id, recalled_in_project_id)`, UPSERT-incremented `hit_count`, `first_recalled_at`, `last_recalled_at`). Naturally bounded by `#entries × #foreign-projects` — not an append-only event log. No FTS/triggers (mirrors `daily_costs`/`tool_calls`). Explicit cleanup (no FK CASCADE) in `clearProject()`, `deleteProject()`, and `mergeProjectInternal()` (which merges counts on collision and drops degenerate self-rows).

### Instrumentation — two surfacing paths
- **`forSession()` cross-pool injection** — records when a `cross_project=1` foreign-origin entry is injected into a project's system prompt. Since this runs on nearly every message, it is gated by an in-memory per-session throttle (30-min window, FIFO-bounded at 50k keys) so it doesn't hammer SQLite.
- **Genuine agent recall** — `runRecall()` records from the *fused* results when `recordTransfers` is set. Enabled **only** on `executeRecall` (the sole agent-invoked path); dashboard/CLI searches and `recallById` never inflate counts.

### Dashboard
- Entry detail page: "Recalled in N other projects" field + a Cross-Project Recalls breakdown table (project, hits, last recalled).
- User Knowledge list: a sortable "Recalls" column, batch-loaded via `transferCounts()` to avoid N+1.

## Edge cases handled
Global entries (no origin), self-project recalls, `recallById`, and lat.md synthetics are all excluded. Project merges merge counts and drop rows that become self-referential.

## Tests
- New `packages/core/test/knowledge-transfers.test.ts` (12 tests): UPSERT semantics, read helpers, `forSession` recording + throttle dedup, `runRecall` gating (records only with the flag; `recallById` never records), and cleanup on project deletion.
- `packages/core/test/db.test.ts`: v33 table/index existence + `recoverMissingObjects` recovery; schema-version assertion bumped 32 → 33.

## Verification
- `bun --filter '*' typecheck` — all 4 packages pass
- `bun test packages/core` — 1138 pass, 0 fail
- `bun test packages/gateway` — 1036 pass, 5 skip, 0 fail
- `bun run build` — all packages build (incl. gateway bundle)