### PR TITLE
fix(test): eliminate Sentry background-fetch interference in quota tests

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -3,3 +3,10 @@ preload = ["./packages/core/test/setup.ts"]
 
 [test.env]
 NODE_ENV = "test"
+# Disable Sentry SDK initialization during tests. Without this, instrument.ts
+# sees VERSION != "dev" (it reads package.json) and calls Sentry.init(), which
+# installs a background transport that uses globalThis.fetch. When quota tests
+# (or any test) mock globalThis.fetch, Sentry's background flushes race with
+# the mock — capturing Sentry DSN URLs instead of the intended test URL.
+# This eliminates the entire class of "Sentry leaks into test mocks" flakes.
+SENTRY_ENABLED = "0"

--- a/packages/core/src/embedding-vendor.ts
+++ b/packages/core/src/embedding-vendor.ts
@@ -84,12 +84,15 @@ export const LOCAL_MODEL_PATH_ENV = "LORE_LOCAL_MODEL_PATH";
 function envModelPath(): string | null {
   const p = process.env[LOCAL_MODEL_PATH_ENV];
   if (!p) return null;
-  // Best-effort existence check — a missing path falls through to HF download
-  // rather than failing init (so a stale env var never bricks embeddings).
+  // Best-effort existence check — a missing or non-directory path falls through
+  // to HF download rather than failing init (so a stale env var never bricks
+  // embeddings). We specifically check for a directory because transformers.js
+  // resolves model files as <localModelPath>/<modelId>/<file>.
   try {
     // Lazy require so this module stays usable in non-Node contexts.
-    const { existsSync } = require("node:fs") as typeof import("node:fs");
-    if (!existsSync(p)) return null;
+    const { statSync } = require("node:fs") as typeof import("node:fs");
+    const stat = statSync(p, { throwIfNoEntry: false });
+    if (!stat?.isDirectory()) return null;
   } catch {
     // If we can't stat (unusual), trust the path and let the worker report.
   }

--- a/packages/core/test/embedding-vendor.test.ts
+++ b/packages/core/test/embedding-vendor.test.ts
@@ -94,3 +94,49 @@ describe("binary mode (registration set)", () => {
     expect(vendorModelInfo()).toBeNull();
   });
 });
+
+describe("env override (LORE_LOCAL_MODEL_PATH)", () => {
+  test("existing directory is used as localModelPath", () => {
+    // /tmp always exists and is a directory on Linux/macOS.
+    process.env[LOCAL_MODEL_PATH_ENV] = "/tmp";
+    expect(vendorModelInfo()).toEqual({ localModelPath: "/tmp" });
+  });
+
+  test("non-existent path falls through to null", () => {
+    process.env[LOCAL_MODEL_PATH_ENV] = "/nonexistent/vendor/path-42";
+    expect(vendorModelInfo()).toBeNull();
+  });
+
+  test("empty string falls through to null", () => {
+    process.env[LOCAL_MODEL_PATH_ENV] = "";
+    expect(vendorModelInfo()).toBeNull();
+  });
+
+  test("regular file (not a directory) falls through to null", () => {
+    // package.json exists and is a regular file, not a directory.
+    const { resolve } = require("node:path") as typeof import("node:path");
+    process.env[LOCAL_MODEL_PATH_ENV] = resolve(__dirname, "../package.json");
+    expect(vendorModelInfo()).toBeNull();
+  });
+
+  test("env override takes precedence over binary registration", () => {
+    // Both sources are set — env must win.
+    process.env[LOCAL_MODEL_PATH_ENV] = "/tmp";
+    _setVendorRegistration({
+      localModelPath: "/home/user/.lore/vendor-binary",
+      target: "linux-x64",
+      version: "1.0.0",
+    });
+    const info = vendorModelInfo();
+    expect(info).toEqual({ localModelPath: "/tmp" });
+    // The binary registration is still readable via vendorRegistration()
+    // (diagnostic), but vendorModelInfo() returns the env override.
+    expect(vendorRegistration()).not.toBeNull();
+  });
+
+  test("isVendoredBinary is NOT affected by env override", () => {
+    // LORE_LOCAL_MODEL_PATH is for air-gapped/CI use, not a binary.
+    process.env[LOCAL_MODEL_PATH_ENV] = "/tmp";
+    expect(isVendoredBinary()).toBe(false);
+  });
+});

--- a/packages/gateway/test/quota.test.ts
+++ b/packages/gateway/test/quota.test.ts
@@ -126,7 +126,11 @@ describe("fetchOAuthQuotaSnapshot", () => {
   test("fetches from the expected quota URL", async () => {
     let capturedUrl: string | undefined;
     globalThis.fetch = mock((url: string) => {
-      capturedUrl = url;
+      // Only capture the quota request — ignore Sentry transport flushes and
+      // other background fetches that race with the mock (see #524 / #527).
+      if (typeof url === "string" && url.startsWith(QUOTA_URL)) {
+        capturedUrl = url;
+      }
       return Promise.resolve(new Response(quotaBody(), { status: 200 }));
     }) as unknown as typeof fetch;
 


### PR DESCRIPTION
## Problem

The quota test `fetchOAuthQuotaSnapshot > fetches from the expected quota URL` fails intermittently in CI (#524). Root cause: **Sentry SDK is active during tests** (`VERSION != "dev"` → `sentryEnabled = true` in `instrument.ts`) and its background transport uses `globalThis.fetch`. When quota tests mock `globalThis.fetch`, Sentry flushes race with the mock — capturing Sentry DSN URLs instead of the intended quota URL.

PR #529 added URL guards to most capture variables but **missed the `capturedUrl` test** at line 126-137, which captures every fetch URL indiscriminately. During the 1-second `QUOTA_SERIAL_GAP_MS` sleep in `fetchOAuthQuotaSnapshot`'s `finally` block, Sentry's transport can overwrite `capturedUrl`.

## Fix

### Quota flake (Closes #524)

1. **Root cause**: `SENTRY_ENABLED=0` in `bunfig.toml` test env so `instrument.ts` never calls `Sentry.init()` during tests. Eliminates the entire class of "Sentry leaks into test mocks" flakes.
2. **Defense-in-depth**: URL guard on the missed test so `capturedUrl` only records quota URLs, ignoring background fetches.

### Post-merge follow-ups from #528 review

3. **Tighten `LORE_LOCAL_MODEL_PATH` validation**: `existsSync` → `statSync().isDirectory()` so a regular file doesn't get treated as a model cache root.
4. **Test coverage for env-override code path** (`embedding-vendor.test.ts`): existing dir, non-existent path, empty string, regular file, precedence over binary registration, `isVendoredBinary` not affected.

## Verification

- Typecheck: 4/4 packages pass
- Full suite: **2181 pass, 0 fail** (locally, including the previously-flaky quota test)
- The quota test now passes deterministically regardless of Sentry background activity