### PR TITLE
chore(test): remove redundant typeof guard in quota URL capture

### DIFF
--- a/packages/gateway/test/quota.test.ts
+++ b/packages/gateway/test/quota.test.ts
@@ -128,7 +128,7 @@ describe("fetchOAuthQuotaSnapshot", () => {
     globalThis.fetch = mock((url: string) => {
       // Only capture the quota request — ignore Sentry transport flushes and
       // other background fetches that race with the mock (see #524 / #527).
-      if (typeof url === "string" && url.startsWith(QUOTA_URL)) {
+      if (url.startsWith(QUOTA_URL)) {
         capturedUrl = url;
       }
       return Promise.resolve(new Response(quotaBody(), { status: 200 }));


### PR DESCRIPTION
Trivial consistency fix: the URL guard added in #532 used `typeof url === 'string' && url.startsWith(...)` while the three sibling guards (from #529) use just `url.startsWith(...)`. The `typeof` check is always true (the parameter is typed as `string`). Remove it for consistency.

1-line test change, no production code.