### PR TITLE
feat(entities): embedding-based entity auto-dedup (#462)

### DIFF
--- a/packages/core/src/curator.ts
+++ b/packages/core/src/curator.ts
@@ -682,6 +682,41 @@ async function runInner(input: {
     }
   }
 
+  // Post-curation entity dedup sweep (#462): if the curator created new
+  // entities, auto-merge high-confidence semantic duplicates it introduced
+  // ("Seylan Cinar" ↔ "Seylan", "GitHub Actions" ↔ "GHA"). Only the auto-merge
+  // tier is applied; moderate-confidence pairs are surfaced as suggestions via
+  // the CLI / dashboard. Gated on embedding availability since the primary
+  // signal is vector similarity. Note: freshly created entities embed
+  // fire-and-forget, so some vectors may not have landed yet — name-Jaccard and
+  // alias-overlap signals still fire, and the next run catches the rest.
+  if (result.entitiesCreated > 0 && embedding.isAvailable()) {
+    try {
+      const dupes = await entities.deduplicateEntities(input.projectPath, {
+        dryRun: false,
+      });
+      const autoMerged = dupes.merged.reduce((n, c) => n + c.merged.length, 0);
+      if (autoMerged > 0) {
+        log.info(
+          `post-curation entity dedup: merged ${autoMerged} duplicate entit${autoMerged === 1 ? "y" : "ies"}`,
+        );
+        result.deleted += autoMerged;
+      }
+      // Record reject auto-signals + recalibrate the entity threshold.
+      if (dupes.pairSimilarities.size > 0) {
+        const pid = ensureProject(input.projectPath);
+        entities.recordEntityAutoSignals(pid, dupes);
+        const newThreshold = entities.calibrateEntityDedupThreshold(pid);
+        if (newThreshold !== null) {
+          const count = entities.getEntityDedupFeedbackCount(pid);
+          entities.saveEntityCalibratedThreshold(pid, newThreshold, count);
+        }
+      }
+    } catch (err) {
+      log.warn("post-curation entity dedup failed (non-fatal):", err);
+    }
+  }
+
   const now = Date.now();
   lastCuratedAt.set(input.sessionID, now);
   saveSessionTracking(input.sessionID, { lastCuratedAt: now });

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -966,6 +966,16 @@ const MIGRATIONS: string[] = [
   CREATE INDEX IF NOT EXISTS idx_knowledge_transfers_recalled_in
     ON knowledge_transfers (recalled_in_project_id);
   `,
+  `
+  -- Version 34: Entity auto-dedup (#462). Embedding-based alias clustering.
+  -- Add a vector column to entities (same Float32Array-as-BLOB pattern as
+  -- knowledge.embedding) and a 'kind' discriminator on dedup_feedback so the
+  -- adaptive threshold calibration table can hold both knowledge and entity
+  -- feedback rows. Existing rows default to 'knowledge' to keep the knowledge
+  -- dedup code paths unchanged.
+  ALTER TABLE entities ADD COLUMN embedding BLOB;
+  ALTER TABLE dedup_feedback ADD COLUMN kind TEXT NOT NULL DEFAULT 'knowledge';
+  `,
 ];
 
 /** Return the resolved path of the SQLite database file. */
@@ -1133,7 +1143,8 @@ function recoverMissingObjects(database: Database) {
       metadata       TEXT,
       cross_project  INTEGER DEFAULT 0,
       created_at     INTEGER NOT NULL,
-      updated_at     INTEGER NOT NULL
+      updated_at     INTEGER NOT NULL,
+      embedding      BLOB
     );
     CREATE TABLE IF NOT EXISTS entity_aliases (
       id          TEXT PRIMARY KEY,

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -832,6 +832,30 @@ export function vectorSearch(
   return scored.slice(0, limit);
 }
 
+/**
+ * Search all entities with embeddings by cosine similarity.
+ * Returns top-k entities sorted by similarity descending.
+ * Pure brute-force — fine for the typical entity-registry size.
+ */
+export function vectorSearchEntities(
+  queryEmbedding: Float32Array,
+  limit = 10,
+): VectorHit[] {
+  const rows = db()
+    .query("SELECT id, embedding FROM entities WHERE embedding IS NOT NULL")
+    .all() as Array<{ id: string; embedding: Buffer }>;
+
+  const scored: VectorHit[] = [];
+  for (const row of rows) {
+    const vec = fromBlob(row.embedding);
+    const sim = cosineSimilarity(queryEmbedding, vec);
+    scored.push({ id: row.id, similarity: sim });
+  }
+
+  scored.sort((a, b) => b.similarity - a.similarity);
+  return scored.slice(0, limit);
+}
+
 // ---------------------------------------------------------------------------
 // Vector search — distillations
 // ---------------------------------------------------------------------------
@@ -937,6 +961,43 @@ export function embedKnowledgeEntry(
     })
     .catch((err) => {
       log.error("embedding failed for knowledge entry", id, ":", err);
+    });
+}
+
+/**
+ * Embed an entity (canonical name + all alias values) and store the result.
+ * Fire-and-forget — errors are logged, never thrown. Used by entity auto-dedup
+ * (#462) to compute semantic similarity between entities whose names differ but
+ * mean the same thing ("GitHub Actions" ↔ "GHA").
+ */
+export function embedEntity(
+  id: string,
+  canonicalName: string,
+  aliasValues: string[],
+): void {
+  if (!isAvailable()) return;
+  // Composite text: canonical name followed by every alias value. Deduped and
+  // joined so the vector captures all surface forms of the entity.
+  const seen = new Set<string>();
+  const parts: string[] = [];
+  for (const v of [canonicalName, ...aliasValues]) {
+    const t = v.trim();
+    if (!t) continue;
+    const key = t.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    parts.push(t);
+  }
+  const text = parts.join(" ");
+  if (!text) return;
+  embed([text], "document")
+    .then(([vec]) => {
+      db()
+        .query("UPDATE entities SET embedding = ? WHERE id = ?")
+        .run(toBlob(vec), id);
+    })
+    .catch((err) => {
+      log.error("embedding failed for entity", id, ":", err);
     });
 }
 
@@ -1152,6 +1213,7 @@ export async function runStartupBackfill(): Promise<void> {
 
   const knowledgeEmbedded = await backfillEmbeddings();
   const distillationEmbedded = await backfillDistillationEmbeddings();
+  const entityEmbedded = await backfillEntityEmbeddings();
 
   // Coverage stats — always log to stderr so the problem is visible.
   const kTotal = (
@@ -1182,9 +1244,9 @@ export async function runStartupBackfill(): Promise<void> {
   ).n;
 
   const parts: string[] = [];
-  if (knowledgeEmbedded > 0 || distillationEmbedded > 0) {
+  if (knowledgeEmbedded > 0 || distillationEmbedded > 0 || entityEmbedded > 0) {
     parts.push(
-      `backfilled ${knowledgeEmbedded} knowledge + ${distillationEmbedded} distillations`,
+      `backfilled ${knowledgeEmbedded} knowledge + ${distillationEmbedded} distillations + ${entityEmbedded} entities`,
     );
   }
   parts.push(
@@ -1381,6 +1443,83 @@ export async function backfillDistillationEmbeddings(): Promise<number> {
 
   if (embedded > 0) {
     log.info(`embedded ${embedded} distillations`);
+  }
+  return embedded;
+}
+
+// ---------------------------------------------------------------------------
+// Backfill — entities
+// ---------------------------------------------------------------------------
+
+/**
+ * Embed all entities that are missing embeddings. Composite text is the
+ * canonical name plus all alias values. Called on startup alongside knowledge
+ * and distillation backfill, and as a preflight before entity dedup so
+ * similarity comparisons have vectors to work with. Returns the count embedded.
+ */
+export async function backfillEntityEmbeddings(): Promise<number> {
+  const provider = getProvider();
+  if (!provider) return 0;
+
+  const rows = db()
+    .query(
+      `SELECT e.id AS id, e.canonical_name AS canonical_name,
+              GROUP_CONCAT(a.alias_value, ' ') AS aliases
+       FROM entities e
+       LEFT JOIN entity_aliases a ON a.entity_id = e.id
+       WHERE e.embedding IS NULL
+       GROUP BY e.id`,
+    )
+    .all() as Array<{
+    id: string;
+    canonical_name: string;
+    aliases: string | null;
+  }>;
+
+  if (!rows.length) return 0;
+
+  // Pre-compute text for token-budget batching. Canonical name is also stored
+  // as a "name" alias, so it may already appear in `aliases` — harmless for the
+  // embedding (duplicate surface form), and entity names are short.
+  const items = rows.map((r) => ({
+    ...r,
+    text: `${r.canonical_name} ${r.aliases ?? ""}`.trim(),
+  }));
+
+  let embedded = 0;
+  let i = 0;
+
+  while (i < items.length) {
+    const batch = nextBatch(items, i);
+    i += batch.length;
+
+    try {
+      const vectors = await embed(
+        batch.map((b) => b.text),
+        "document",
+      );
+      const update = db().prepare(
+        "UPDATE entities SET embedding = ? WHERE id = ?",
+      );
+
+      for (let j = 0; j < batch.length; j++) {
+        update.run(toBlob(vectors[j]), batch[j].id);
+        embedded++;
+      }
+    } catch (err) {
+      // log.error sends to Sentry via captureException
+      log.error(
+        `entity embedding backfill batch failed (${batch.length} items):`,
+        err,
+      );
+      // Provider is dead — no point retrying remaining batches.
+      if (err instanceof LocalProviderUnavailableError) break;
+    }
+    // No yieldToEventLoop() needed — embed() is truly async (worker thread).
+  }
+
+  if (embedded > 0) {
+    log.info(`embedded ${embedded} entities`);
   }
   return embedded;
 }

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -1131,11 +1131,16 @@ export function checkConfigChange(): boolean {
         "SELECT COUNT(*) as n FROM temporal_messages WHERE embedding IS NOT NULL",
       )
       .get() as { n: number };
-    const total = knowledgeCount.n + distillCount.n + temporalCount.n;
+    const entityCount = db()
+      .query("SELECT COUNT(*) as n FROM entities WHERE embedding IS NOT NULL")
+      .get() as { n: number };
+    const total =
+      knowledgeCount.n + distillCount.n + temporalCount.n + entityCount.n;
     if (total > 0) {
       db().query("UPDATE knowledge SET embedding = NULL").run();
       db().query("UPDATE distillations SET embedding = NULL").run();
       db().query("UPDATE temporal_messages SET embedding = NULL").run();
+      db().query("UPDATE entities SET embedding = NULL").run();
       log.info(
         `embedding config changed (${stored.value} → ${current}), cleared ${total} stale embeddings`,
       );
@@ -1464,7 +1469,7 @@ export async function backfillEntityEmbeddings(): Promise<number> {
   const rows = db()
     .query(
       `SELECT e.id AS id, e.canonical_name AS canonical_name,
-              GROUP_CONCAT(a.alias_value, ' ') AS aliases
+              GROUP_CONCAT(DISTINCT a.alias_value, ' ') AS aliases
        FROM entities e
        LEFT JOIN entity_aliases a ON a.entity_id = e.id
        WHERE e.embedding IS NULL

--- a/packages/core/src/entities.ts
+++ b/packages/core/src/entities.ts
@@ -395,19 +395,21 @@ export function ensureSelfEntity(
       );
       if (merged) updates.metadata = merged;
     }
-    if (Object.keys(updates).length > 0) {
+    let changed = Object.keys(updates).length > 0;
+    if (changed) {
       update(existing.id, updates);
     }
     // Add email alias if not present
-    if (email) addAlias(existing.id, "email", email, "auto");
+    if (email && addAlias(existing.id, "email", email, "auto")) changed = true;
     // Add config aliases
     if (cfg?.aliases) {
       for (const a of cfg.aliases) {
-        addAlias(existing.id, a.type as AliasType, a.value, "config");
+        if (addAlias(existing.id, a.type as AliasType, a.value, "config"))
+          changed = true;
       }
     }
-    // Name/alias set may have changed — refresh the dedup embedding.
-    reembedEntity(existing.id);
+    // Only re-embed when the name or alias set actually changed.
+    if (changed) reembedEntity(existing.id);
     return getSelfEntity();
   }
 
@@ -1412,21 +1414,36 @@ export async function deduplicateEntities(
     }
   }
 
-  // Pre-compute lowercased alias sets + linked-knowledge sets per entity.
+  // Pre-compute lowercased alias sets per entity.
   const aliasSets = new Map<string, Set<string>>();
-  const knowledgeSets = new Map<string, Set<string>>();
   for (const e of entities) {
     aliasSets.set(
       e.id,
       new Set(e.aliases.map((a) => a.alias_value.toLowerCase())),
     );
-    knowledgeSets.set(e.id, new Set(knowledgeForEntity(e.id)));
+  }
+
+  // Batch-load linked-knowledge sets (single query instead of N+1).
+  const knowledgeSets = new Map<string, Set<string>>();
+  {
+    const rows = db()
+      .query("SELECT entity_id, knowledge_id FROM knowledge_entity_refs")
+      .all() as Array<{ entity_id: string; knowledge_id: string }>;
+    for (const r of rows) {
+      let s = knowledgeSets.get(r.entity_id);
+      if (!s) {
+        s = new Set();
+        knowledgeSets.set(r.entity_id, s);
+      }
+      s.add(r.knowledge_id);
+    }
   }
 
   // --- Build neighbor map (O(n²) pairwise) ---
   type DedupHit = { id: string; score: number; forceMerge: boolean };
   const neighborMap = new Map<string, DedupHit[]>();
-  const pairSimilarities = new Map<string, number>();
+  const pairSimilarities = new Map<string, number>(); // raw cosine (for calibration)
+  const pairScores = new Map<string, number>(); // combined/boosted score (for tier assignment)
 
   for (const entry of entities) {
     const neighbors: DedupHit[] = [];
@@ -1461,15 +1478,16 @@ export async function deduplicateEntities(
       const jaccard = nameJaccard(entry.canonical_name, other.canonical_name);
 
       // Shared linked-knowledge (small boost).
-      const kA = knowledgeSets.get(entry.id)!;
-      const kB = knowledgeSets.get(other.id)!;
+      const kA = knowledgeSets.get(entry.id);
+      const kB = knowledgeSets.get(other.id);
       let sharedKnowledge = false;
-      for (const k of kA) {
-        if (kB.has(k)) {
-          sharedKnowledge = true;
-          break;
+      if (kA && kB)
+        for (const k of kA) {
+          if (kB.has(k)) {
+            sharedKnowledge = true;
+            break;
+          }
         }
-      }
 
       // Combined score: cosine, lifted by softer signals.
       let score = similarity;
@@ -1480,10 +1498,14 @@ export async function deduplicateEntities(
       if (sharedKnowledge) score += ENTITY_SIGNAL_BOOST;
       score = Math.min(score, 1);
 
-      // Record similarity for calibration (cosine only; > 0).
-      if (similarity > 0) {
-        const pk = entityPairKey(entry.id, other.id);
-        if (!pairSimilarities.has(pk)) pairSimilarities.set(pk, similarity);
+      // Record raw cosine for calibration (cosine only; > 0) and combined
+      // score for tier assignment when the survivor differs from the center.
+      const pk = entityPairKey(entry.id, other.id);
+      if (similarity > 0 && !pairSimilarities.has(pk)) {
+        pairSimilarities.set(pk, similarity);
+      }
+      if (!pairScores.has(pk) || score > pairScores.get(pk)!) {
+        pairScores.set(pk, aliasOverlap ? 1 : score);
       }
 
       const isNeighbor = aliasOverlap || score >= dedupThreshold;
@@ -1559,9 +1581,11 @@ export async function deduplicateEntities(
         ?.find((h) => h.id === survivor.id);
       if (fromMember)
         return { score: fromMember.score, force: fromMember.forceMerge };
+      // Fallback: use the combined/boosted score (not raw cosine) to preserve
+      // the Jaccard/knowledge boosts when the survivor differs from the center.
       const pk = entityPairKey(survivor.id, memberId);
-      const sim = pairSimilarities.get(pk) ?? 0;
-      return { score: sim, force: sim >= ENTITY_AUTO_MERGE_THRESHOLD };
+      const s = pairScores.get(pk) ?? 0;
+      return { score: s, force: s >= ENTITY_AUTO_MERGE_THRESHOLD };
     };
 
     const mergeMembers: EntityDedupCluster["merged"] = [];

--- a/packages/core/src/entities.ts
+++ b/packages/core/src/entities.ts
@@ -6,11 +6,12 @@
  * formatting for system prompt injection and recall query expansion.
  */
 import { uuidv7 } from "uuidv7";
-import { db, ensureProject } from "./db";
+import { db, ensureProject, getKV, setKV } from "./db";
 import { ftsQuery, ftsQueryOr, EMPTY_QUERY, filterTerms } from "./search";
 import { config } from "./config";
 import { getGitUser } from "./git";
 import * as log from "./log";
+import * as embedding from "./embedding";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -210,6 +211,8 @@ export function create(input: {
         for (const alias of input.aliases) {
           addAlias(existing.id, alias.type, alias.value, alias.source);
         }
+        // Alias set changed — refresh the dedup embedding.
+        reembedEntity(existing.id);
       }
       return { id: existing.id, created: false };
     }
@@ -242,6 +245,7 @@ export function create(input: {
     }
 
     d.exec("COMMIT");
+    reembedEntity(id);
     return { id, created: true };
   } catch (e) {
     try {
@@ -251,6 +255,22 @@ export function create(input: {
     }
     throw e;
   }
+}
+
+/**
+ * Recompute and store an entity's embedding from its current canonical name +
+ * alias values. Fire-and-forget (errors logged inside embedEntity). Called
+ * whenever the name or alias set changes so the entity dedup vector stays
+ * current. No-op when no embedding provider is available. Exported so external
+ * mutation paths (CLI alias add/rm) can refresh the vector after changing the
+ * alias set without going through create()/update().
+ */
+export function reembedEntity(id: string): void {
+  const row = db()
+    .query("SELECT canonical_name FROM entities WHERE id = ?")
+    .get(id) as { canonical_name: string } | null;
+  if (!row) return;
+  embedding.embedEntity(id, row.canonical_name, aliasValues(id));
 }
 
 /** Update an entity's canonical name or metadata. */
@@ -299,6 +319,8 @@ export function update(
       db().query("DELETE FROM entity_aliases WHERE id = ?").run(oldAlias.id);
     }
     addAlias(id, "name", input.canonicalName, "auto");
+    // Canonical name changed — refresh the dedup embedding.
+    reembedEntity(id);
   }
 }
 
@@ -384,6 +406,8 @@ export function ensureSelfEntity(
         addAlias(existing.id, a.type as AliasType, a.value, "config");
       }
     }
+    // Name/alias set may have changed — refresh the dedup embedding.
+    reembedEntity(existing.id);
     return getSelfEntity();
   }
 
@@ -886,6 +910,8 @@ export function merge(targetId: string, sourceId: string): void {
     );
 
     d.exec("COMMIT");
+    // Target absorbed source aliases — refresh its dedup embedding.
+    reembedEntity(targetId);
   } catch (e) {
     try {
       d.exec("ROLLBACK");
@@ -1275,80 +1301,552 @@ export function syncEntityRefs(knowledgeId: string, content: string): number {
 }
 
 // ---------------------------------------------------------------------------
-// Auto-dedup candidates
+// Entity auto-dedup (#462)
 // ---------------------------------------------------------------------------
 
 /**
- * Find potential duplicate entities by alias overlap or canonical name similarity.
- * Returns pairs of (entity1, entity2) that are likely duplicates.
+ * Minimum embedding cosine similarity for two same-type entities to be
+ * considered duplicates. Lower than the 0.935 knowledge dedup threshold
+ * because entity names are short and noisy ("GitHub Actions" ↔ "GHA").
  */
-export function findDuplicateCandidates(
+export const ENTITY_EMBEDDING_DEDUP_THRESHOLD = 0.85;
+/**
+ * Similarity at/above which a pair is auto-merged silently. Pairs in
+ * [ENTITY_EMBEDDING_DEDUP_THRESHOLD, ENTITY_AUTO_MERGE_THRESHOLD) are only
+ * *suggested* (surfaced in CLI / dashboard for explicit confirmation).
+ */
+export const ENTITY_AUTO_MERGE_THRESHOLD = 0.92;
+/** Canonical-name Jaccard at/above which the name signal boosts a pair. */
+const ENTITY_NAME_JACCARD_THRESHOLD = 0.5;
+/** Small additive boost applied to a pair's score when a softer signal fires. */
+const ENTITY_SIGNAL_BOOST = 0.05;
+
+/** A cluster of duplicate entities sharing one survivor. */
+export type EntityDedupCluster = {
+  surviving: { id: string; name: string };
+  merged: Array<{ id: string; name: string; similarity: number }>;
+};
+
+export type EntityDedupResult = {
+  /** Auto-merge tier (similarity ≥ ENTITY_AUTO_MERGE_THRESHOLD or alias overlap). */
+  merged: EntityDedupCluster[];
+  /** Suggestion tier (≥ dedup threshold, < auto-merge threshold). */
+  suggested: EntityDedupCluster[];
+  /** All pairwise similarities (key = entityPairKey) for calibration. */
+  pairSimilarities: Map<string, number>;
+  /** id → canonical name for every input entity (survives deletion). */
+  names: Map<string, string>;
+};
+
+/** Order-independent key for an entity pair (mirrors ltm.dedupPairKey). */
+export function entityPairKey(idA: string, idB: string): string {
+  return idA < idB ? `${idA}:${idB}` : `${idB}:${idA}`;
+}
+
+/** Jaccard word-overlap of two canonical names (using search term filtering). */
+function nameJaccard(a: string, b: string): number {
+  const wa = new Set(filterTerms(a).map((w) => w.toLowerCase()));
+  const wb = new Set(filterTerms(b).map((w) => w.toLowerCase()));
+  if (wa.size === 0 || wb.size === 0) return 0;
+  const intersection = [...wa].filter((w) => wb.has(w)).length;
+  const union = new Set([...wa, ...wb]).size;
+  return union === 0 ? 0 : intersection / union;
+}
+
+/**
+ * Deduplicate entities using embedding similarity + multi-signal scoring.
+ *
+ * Signals (issue #462):
+ *  - Same entity_type — REQUIRED (never merge a person with a service).
+ *  - Embedding cosine similarity — primary signal.
+ *  - Exact alias-value overlap — strong; forces the auto-merge tier.
+ *  - Canonical-name Jaccard ≥ 0.5 — moderate boost.
+ *  - Shared linked-knowledge — small boost.
+ *
+ * Uses greedy star clustering (no transitivity — mirrors ltm._dedup) so that
+ * A~B and B~C but not A~C only merges the strongest pair. Survivor per cluster:
+ * most aliases (richest) → most recent → shortest canonical name.
+ *
+ * `dryRun` defaults to true — callers must pass { dryRun: false } to merge.
+ * Only the auto-merge tier is ever applied; suggestions are never auto-merged.
+ */
+export async function deduplicateEntities(
   projectPath?: string,
-  maxCandidates = 50,
-): Array<{
-  entity1: EntityWithAliases;
-  entity2: EntityWithAliases;
-  reason: string;
-}> {
+  opts?: { dryRun?: boolean; threshold?: number },
+): Promise<EntityDedupResult> {
+  const dryRun = opts?.dryRun ?? true;
   const entities = projectPath ? forProject(projectPath) : listAll();
-  const candidates: Array<{
-    entity1: EntityWithAliases;
-    entity2: EntityWithAliases;
-    reason: string;
-  }> = [];
-  const seen = new Set<string>();
+  const names = new Map(entities.map((e) => [e.id, e.canonical_name]));
 
-  for (
-    let i = 0;
-    i < entities.length && candidates.length < maxCandidates;
-    i++
-  ) {
-    for (
-      let j = i + 1;
-      j < entities.length && candidates.length < maxCandidates;
-      j++
-    ) {
-      const e1 = entities[i];
-      const e2 = entities[j];
-      const pairKey = `${e1.id}:${e2.id}`;
-      if (seen.has(pairKey)) continue;
+  const empty: EntityDedupResult = {
+    merged: [],
+    suggested: [],
+    pairSimilarities: new Map(),
+    names,
+  };
+  if (entities.length < 2) return empty;
 
-      // Check alias overlap
-      const aliases1 = new Set(
-        e1.aliases.map((a) => a.alias_value.toLowerCase()),
-      );
-      const aliases2 = new Set(
-        e2.aliases.map((a) => a.alias_value.toLowerCase()),
-      );
-      const overlap = [...aliases1].filter((a) => aliases2.has(a));
-      if (overlap.length > 0) {
-        seen.add(pairKey);
-        candidates.push({
-          entity1: e1,
-          entity2: e2,
-          reason: `shared aliases: ${overlap.join(", ")}`,
-        });
-        continue;
-      }
+  const dedupThreshold =
+    opts?.threshold ??
+    loadEntityCalibratedThreshold(
+      projectPath ? ensureProject(projectPath) : null,
+    ) ??
+    ENTITY_EMBEDDING_DEDUP_THRESHOLD;
 
-      // Check canonical name word overlap (Jaccard similarity)
-      const words1 = new Set(filterTerms(e1.canonical_name));
-      const words2 = new Set(filterTerms(e2.canonical_name));
-      if (words1.size > 0 && words2.size > 0) {
-        const intersection = [...words1].filter((w) => words2.has(w)).length;
-        const union = new Set([...words1, ...words2]).size;
-        const jaccard = intersection / union;
-        if (jaccard >= 0.5 && intersection >= 2) {
-          seen.add(pairKey);
-          candidates.push({
-            entity1: e1,
-            entity2: e2,
-            reason: `similar names (jaccard=${jaccard.toFixed(2)})`,
-          });
-        }
+  // --- Load embeddings for the candidate entities (if available) ---
+  const embeddingMap = new Map<string, Float32Array>();
+  {
+    const ids = entities.map((e) => e.id);
+    const placeholders = ids.map(() => "?").join(",");
+    const rows = db()
+      .query(
+        `SELECT id, embedding FROM entities WHERE embedding IS NOT NULL AND id IN (${placeholders})`,
+      )
+      .all(...ids) as Array<{ id: string; embedding: Buffer }>;
+    for (const row of rows) {
+      try {
+        embeddingMap.set(row.id, embedding.fromBlob(row.embedding));
+      } catch {
+        log.info(`skipping corrupted embedding for entity ${row.id}`);
       }
     }
   }
 
-  return candidates;
+  // Pre-compute lowercased alias sets + linked-knowledge sets per entity.
+  const aliasSets = new Map<string, Set<string>>();
+  const knowledgeSets = new Map<string, Set<string>>();
+  for (const e of entities) {
+    aliasSets.set(
+      e.id,
+      new Set(e.aliases.map((a) => a.alias_value.toLowerCase())),
+    );
+    knowledgeSets.set(e.id, new Set(knowledgeForEntity(e.id)));
+  }
+
+  // --- Build neighbor map (O(n²) pairwise) ---
+  type DedupHit = { id: string; score: number; forceMerge: boolean };
+  const neighborMap = new Map<string, DedupHit[]>();
+  const pairSimilarities = new Map<string, number>();
+
+  for (const entry of entities) {
+    const neighbors: DedupHit[] = [];
+    const entryVec = embeddingMap.get(entry.id);
+
+    for (const other of entities) {
+      if (other.id === entry.id) continue;
+      // REQUIRED gate: same entity_type or never a candidate.
+      if (other.entity_type !== entry.entity_type) continue;
+
+      // Embedding cosine similarity (primary signal).
+      let similarity = 0;
+      if (entryVec) {
+        const otherVec = embeddingMap.get(other.id);
+        if (otherVec && entryVec.length === otherVec.length) {
+          similarity = embedding.cosineSimilarity(entryVec, otherVec);
+        }
+      }
+
+      // Alias-value overlap (strong → force auto-merge regardless of cosine).
+      const aSet = aliasSets.get(entry.id)!;
+      const bSet = aliasSets.get(other.id)!;
+      let aliasOverlap = false;
+      for (const v of aSet) {
+        if (bSet.has(v)) {
+          aliasOverlap = true;
+          break;
+        }
+      }
+
+      // Canonical-name Jaccard (moderate boost).
+      const jaccard = nameJaccard(entry.canonical_name, other.canonical_name);
+
+      // Shared linked-knowledge (small boost).
+      const kA = knowledgeSets.get(entry.id)!;
+      const kB = knowledgeSets.get(other.id)!;
+      let sharedKnowledge = false;
+      for (const k of kA) {
+        if (kB.has(k)) {
+          sharedKnowledge = true;
+          break;
+        }
+      }
+
+      // Combined score: cosine, lifted by softer signals.
+      let score = similarity;
+      if (jaccard >= ENTITY_NAME_JACCARD_THRESHOLD) {
+        score = Math.max(score, jaccard);
+        score += ENTITY_SIGNAL_BOOST;
+      }
+      if (sharedKnowledge) score += ENTITY_SIGNAL_BOOST;
+      score = Math.min(score, 1);
+
+      // Record similarity for calibration (cosine only; > 0).
+      if (similarity > 0) {
+        const pk = entityPairKey(entry.id, other.id);
+        if (!pairSimilarities.has(pk)) pairSimilarities.set(pk, similarity);
+      }
+
+      const isNeighbor = aliasOverlap || score >= dedupThreshold;
+      if (isNeighbor) {
+        neighbors.push({
+          id: other.id,
+          score: aliasOverlap ? 1 : score,
+          forceMerge: aliasOverlap || score >= ENTITY_AUTO_MERGE_THRESHOLD,
+        });
+      }
+    }
+    neighbors.sort((a, b) => b.score - a.score);
+    neighborMap.set(entry.id, neighbors);
+  }
+
+  // --- Greedy star clustering (no transitivity) ---
+  const claimed = new Set<string>();
+  const rawClusters = new Map<string, DedupHit[]>();
+  const sortedIds = [...neighborMap.keys()].sort(
+    (a, b) => neighborMap.get(b)!.length - neighborMap.get(a)!.length,
+  );
+
+  for (const centerId of sortedIds) {
+    if (claimed.has(centerId)) continue;
+    claimed.add(centerId);
+    const members: DedupHit[] = [];
+    for (const hit of neighborMap.get(centerId)!) {
+      if (claimed.has(hit.id)) continue;
+      claimed.add(hit.id);
+      members.push(hit);
+    }
+    if (members.length > 0) rawClusters.set(centerId, members);
+  }
+
+  // --- Build clusters, pick survivors, split into tiers ---
+  const entityById = new Map(entities.map((e) => [e.id, e]));
+  const merged: EntityDedupCluster[] = [];
+  const suggested: EntityDedupCluster[] = [];
+
+  for (const [centerId, hits] of rawClusters) {
+    const all = [centerId, ...hits.map((h) => h.id)]
+      .map((id) => entityById.get(id))
+      .filter((e): e is EntityWithAliases => Boolean(e));
+    if (all.length < 2) continue;
+
+    // Survivor: most aliases → most recent → shortest canonical name.
+    const sorted = [...all].sort((a, b) => {
+      const aliasDiff = b.aliases.length - a.aliases.length;
+      if (aliasDiff !== 0) return aliasDiff;
+      if (b.updated_at !== a.updated_at) return b.updated_at - a.updated_at;
+      return a.canonical_name.length - b.canonical_name.length;
+    });
+    const survivor = sorted[0];
+
+    // Tier each non-survivor member by its pair score vs the survivor.
+    const scoreFor = (memberId: string): { score: number; force: boolean } => {
+      // Direct alias-value overlap with the survivor always forces a merge,
+      // even if the member only clustered transitively via the center.
+      const survivorAliases = aliasSets.get(survivor.id);
+      const memberAliases = aliasSets.get(memberId);
+      if (survivorAliases && memberAliases) {
+        for (const v of memberAliases) {
+          if (survivorAliases.has(v)) return { score: 1, force: true };
+        }
+      }
+      const fromCenter = neighborMap
+        .get(survivor.id)
+        ?.find((h) => h.id === memberId);
+      if (fromCenter)
+        return { score: fromCenter.score, force: fromCenter.forceMerge };
+      const fromMember = neighborMap
+        .get(memberId)
+        ?.find((h) => h.id === survivor.id);
+      if (fromMember)
+        return { score: fromMember.score, force: fromMember.forceMerge };
+      const pk = entityPairKey(survivor.id, memberId);
+      const sim = pairSimilarities.get(pk) ?? 0;
+      return { score: sim, force: sim >= ENTITY_AUTO_MERGE_THRESHOLD };
+    };
+
+    const mergeMembers: EntityDedupCluster["merged"] = [];
+    const suggestMembers: EntityDedupCluster["merged"] = [];
+    for (const m of sorted.slice(1)) {
+      const { score, force } = scoreFor(m.id);
+      const entry = { id: m.id, name: m.canonical_name, similarity: score };
+      if (force) mergeMembers.push(entry);
+      else suggestMembers.push(entry);
+    }
+
+    if (mergeMembers.length > 0) {
+      merged.push({
+        surviving: { id: survivor.id, name: survivor.canonical_name },
+        merged: mergeMembers,
+      });
+      if (!dryRun) {
+        for (const m of mergeMembers) merge(survivor.id, m.id);
+      }
+    }
+    if (suggestMembers.length > 0) {
+      suggested.push({
+        surviving: { id: survivor.id, name: survivor.canonical_name },
+        merged: suggestMembers,
+      });
+    }
+  }
+
+  merged.sort((a, b) => b.merged.length - a.merged.length);
+  suggested.sort((a, b) => b.merged.length - a.merged.length);
+
+  return { merged, suggested, pairSimilarities, names };
+}
+
+// ---------------------------------------------------------------------------
+// Entity dedup adaptive threshold calibration (#462)
+//
+// Reuses the shared `dedup_feedback` table with kind='entity' so entity and
+// knowledge feedback coexist without a second table. All queries here scope to
+// kind='entity'; the knowledge calibration path (ltm.ts) implicitly operates on
+// kind='knowledge' (the column default).
+// ---------------------------------------------------------------------------
+
+export type EntityDedupFeedbackSource =
+  | "auto_dedup"
+  | "cli_yes"
+  | "cli_interactive";
+
+const MIN_ENTITY_CALIBRATION_SAMPLES = 20;
+/** Only record auto-signals for pairs with similarity >= this floor. */
+const ENTITY_AUTO_SIGNAL_MIN_SIMILARITY = 0.8;
+/** Max auto-signal pairs to record per dedup run (closest to threshold). */
+const ENTITY_AUTO_SIGNAL_MAX_PAIRS = 50;
+/** Max feedback rows to keep per project (prevents unbounded growth). */
+const MAX_ENTITY_FEEDBACK_ROWS_PER_PROJECT = 500;
+
+/** Record a single entity dedup feedback row (kind='entity'). */
+export function recordEntityDedupFeedback(input: {
+  projectId: string | null;
+  entryATitle: string;
+  entryBTitle: string;
+  similarity: number;
+  accepted: boolean;
+  source: EntityDedupFeedbackSource;
+}): void {
+  db()
+    .query(
+      `INSERT INTO dedup_feedback
+         (project_id, entry_a_title, entry_b_title, similarity, accepted, source, created_at, kind)
+       VALUES (?, ?, ?, ?, ?, ?, ?, 'entity')`,
+    )
+    .run(
+      input.projectId,
+      input.entryATitle,
+      input.entryBTitle,
+      input.similarity,
+      input.accepted ? 1 : 0,
+      input.source,
+      Date.now(),
+    );
+}
+
+/**
+ * Record automatic calibration signals from a post-curation entity dedup sweep.
+ * Records only **reject** signals — non-merged pairs with cosine similarity in
+ * [floor, threshold). Accept signals from auto-merge are tautological, so they
+ * are excluded (manual cli_yes/cli_interactive provide the accept side).
+ */
+export function recordEntityAutoSignals(
+  projectId: string | null,
+  result: EntityDedupResult,
+): void {
+  // Collect merged/suggested pair keys to exclude from reject signals.
+  const decidedPairs = new Set<string>();
+  for (const cluster of [...result.merged, ...result.suggested]) {
+    for (const m of cluster.merged) {
+      decidedPairs.add(entityPairKey(cluster.surviving.id, m.id));
+    }
+  }
+
+  type Signal = {
+    entryATitle: string;
+    entryBTitle: string;
+    similarity: number;
+  };
+  const signals: Signal[] = [];
+  for (const [pk, sim] of result.pairSimilarities) {
+    if (sim < ENTITY_AUTO_SIGNAL_MIN_SIMILARITY) continue;
+    if (decidedPairs.has(pk)) continue; // merged/suggested — skip
+    const [idA, idB] = pk.split(":");
+    const nameA = result.names.get(idA);
+    const nameB = result.names.get(idB);
+    if (!nameA || !nameB) continue;
+    signals.push({ entryATitle: nameA, entryBTitle: nameB, similarity: sim });
+  }
+
+  const currentThreshold =
+    loadEntityCalibratedThreshold(projectId) ??
+    ENTITY_EMBEDDING_DEDUP_THRESHOLD;
+  signals.sort(
+    (a, b) =>
+      Math.abs(a.similarity - currentThreshold) -
+      Math.abs(b.similarity - currentThreshold),
+  );
+  const capped = signals.slice(0, ENTITY_AUTO_SIGNAL_MAX_PAIRS);
+
+  pruneEntityDedupFeedback(projectId);
+
+  for (const s of capped) {
+    recordEntityDedupFeedback({
+      projectId,
+      entryATitle: s.entryATitle,
+      entryBTitle: s.entryBTitle,
+      similarity: s.similarity,
+      accepted: false,
+      source: "auto_dedup",
+    });
+  }
+}
+
+/** Get all entity feedback for a project (for calibration). */
+export function getEntityDedupFeedback(
+  projectId: string | null,
+): Array<{ similarity: number; accepted: boolean; source: string }> {
+  const rows = (
+    projectId !== null
+      ? db()
+          .query(
+            "SELECT similarity, accepted, source FROM dedup_feedback WHERE kind = 'entity' AND project_id = ? ORDER BY similarity",
+          )
+          .all(projectId)
+      : db()
+          .query(
+            "SELECT similarity, accepted, source FROM dedup_feedback WHERE kind = 'entity' AND project_id IS NULL ORDER BY similarity",
+          )
+          .all()
+  ) as Array<{ similarity: number; accepted: number; source: string }>;
+  return rows.map((r) => ({
+    similarity: r.similarity,
+    accepted: r.accepted === 1,
+    source: r.source,
+  }));
+}
+
+/** Quick count of entity feedback rows for a project. */
+export function getEntityDedupFeedbackCount(projectId: string | null): number {
+  const row = (
+    projectId !== null
+      ? db()
+          .query(
+            "SELECT COUNT(*) as cnt FROM dedup_feedback WHERE kind = 'entity' AND project_id = ?",
+          )
+          .get(projectId)
+      : db()
+          .query(
+            "SELECT COUNT(*) as cnt FROM dedup_feedback WHERE kind = 'entity' AND project_id IS NULL",
+          )
+          .get()
+  ) as { cnt: number } | null;
+  return row?.cnt ?? 0;
+}
+
+/** Prune old entity feedback rows, keeping the most recent rows. */
+export function pruneEntityDedupFeedback(projectId: string | null): void {
+  const count = getEntityDedupFeedbackCount(projectId);
+  if (count <= MAX_ENTITY_FEEDBACK_ROWS_PER_PROJECT) return;
+  const excess = count - MAX_ENTITY_FEEDBACK_ROWS_PER_PROJECT;
+  if (projectId !== null) {
+    db()
+      .query(
+        `DELETE FROM dedup_feedback WHERE id IN (
+           SELECT id FROM dedup_feedback WHERE kind = 'entity' AND project_id = ?
+           ORDER BY created_at ASC LIMIT ?
+         )`,
+      )
+      .run(projectId, excess);
+  } else {
+    db()
+      .query(
+        `DELETE FROM dedup_feedback WHERE id IN (
+           SELECT id FROM dedup_feedback WHERE kind = 'entity' AND project_id IS NULL
+           ORDER BY created_at ASC LIMIT ?
+         )`,
+      )
+      .run(excess);
+  }
+}
+
+/**
+ * Calibrate the entity dedup threshold by accuracy maximization over recorded
+ * feedback. Returns null until MIN_ENTITY_CALIBRATION_SAMPLES are collected.
+ * Mirrors ltm.calibrateDedupThreshold but clamps to the entity range.
+ */
+export function calibrateEntityDedupThreshold(
+  projectId: string | null,
+): number | null {
+  const feedback = getEntityDedupFeedback(projectId);
+  if (feedback.length < MIN_ENTITY_CALIBRATION_SAMPLES) return null;
+
+  const accepted = feedback.filter((f) => f.accepted);
+  const rejected = feedback.filter((f) => !f.accepted);
+
+  // Edge case: all accept, no rejects
+  if (rejected.length === 0) {
+    const minAccepted = Math.min(...accepted.map((f) => f.similarity));
+    return Math.max(0.8, minAccepted - 0.005);
+  }
+  // Edge case: all reject, no accepts → keep default
+  if (accepted.length === 0) {
+    log.warn(
+      "entity dedup calibration: all feedback is reject — keeping default threshold",
+    );
+    return null;
+  }
+
+  const allSims = [...new Set(feedback.map((f) => f.similarity))].sort(
+    (a, b) => a - b,
+  );
+  let bestThreshold = ENTITY_EMBEDDING_DEDUP_THRESHOLD;
+  let bestAccuracy = -1;
+  for (let i = 0; i < allSims.length - 1; i++) {
+    const candidate = (allSims[i] + allSims[i + 1]) / 2;
+    const correctAccepted = accepted.filter(
+      (f) => f.similarity >= candidate,
+    ).length;
+    const correctRejected = rejected.filter(
+      (f) => f.similarity < candidate,
+    ).length;
+    const accuracy = (correctAccepted + correctRejected) / feedback.length;
+    if (
+      accuracy > bestAccuracy ||
+      (accuracy === bestAccuracy && candidate > bestThreshold)
+    ) {
+      bestAccuracy = accuracy;
+      bestThreshold = candidate;
+    }
+  }
+  // Clamp to the entity range (lower than knowledge's [0.85, 0.98]).
+  return Math.max(0.8, Math.min(0.95, bestThreshold));
+}
+
+/** Persist the calibrated entity dedup threshold for a project. */
+export function saveEntityCalibratedThreshold(
+  projectId: string | null,
+  threshold: number,
+  sampleSize: number,
+): void {
+  const key = `entity_dedup_threshold:${projectId ?? "global"}`;
+  setKV(
+    key,
+    JSON.stringify({ threshold, sampleSize, calibratedAt: Date.now() }),
+  );
+}
+
+/** Load the calibrated entity dedup threshold for a project, or null. */
+export function loadEntityCalibratedThreshold(
+  projectId: string | null,
+): number | null {
+  const key = `entity_dedup_threshold:${projectId ?? "global"}`;
+  const raw = getKV(key);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return typeof parsed.threshold === "number" ? parsed.threshold : null;
+  } catch {
+    return null;
+  }
 }

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -49,7 +49,40 @@ describe("db", () => {
     const row = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(row.version).toBe(33);
+    expect(row.version).toBe(34);
+  });
+
+  test("entities table has embedding column (migration v34)", () => {
+    const cols = (
+      db().query("PRAGMA table_info(entities)").all() as Array<{
+        name: string;
+      }>
+    ).map((c) => c.name);
+    expect(cols).toContain("embedding");
+  });
+
+  test("dedup_feedback has kind discriminator defaulting to 'knowledge' (v34)", () => {
+    const cols = db()
+      .query("PRAGMA table_info(dedup_feedback)")
+      .all() as Array<{
+      name: string;
+      dflt_value: string | null;
+    }>;
+    const kind = cols.find((c) => c.name === "kind");
+    expect(kind).toBeDefined();
+    // Rows inserted without an explicit kind are treated as knowledge feedback.
+    db()
+      .query(
+        `INSERT INTO dedup_feedback
+           (project_id, entry_a_title, entry_b_title, similarity, accepted, source, created_at)
+         VALUES (NULL, 'a', 'b', 0.9, 1, 'cli_yes', ?)`,
+      )
+      .run(Date.now());
+    const last = db()
+      .query("SELECT kind FROM dedup_feedback ORDER BY id DESC LIMIT 1")
+      .get() as { kind: string };
+    expect(last.kind).toBe("knowledge");
+    db().query("DELETE FROM dedup_feedback").run();
   });
 
   test("distillation_fts virtual table exists", () => {

--- a/packages/core/test/embedding.test.ts
+++ b/packages/core/test/embedding.test.ts
@@ -14,6 +14,7 @@ import {
   fromBlob,
   isAvailable,
   vectorSearch,
+  vectorSearchEntities,
   checkConfigChange,
   resetProvider,
   _shutdownAndDisable,
@@ -521,6 +522,50 @@ describe("vectorSearch", () => {
 
     expect(results.length).toBe(1);
     expect(results[0].id).toBe("embed-high");
+  });
+});
+
+describe("vectorSearchEntities", () => {
+  const PROJECT = "/test/embedding/entity-vectorsearch";
+
+  beforeEach(() => {
+    db().query("DELETE FROM entity_aliases").run();
+    db().query("DELETE FROM entities").run();
+  });
+
+  function insertEntity(id: string, name: string, vec: Float32Array): void {
+    const pid = ensureProject(PROJECT);
+    const now = Date.now();
+    db()
+      .query(
+        "INSERT INTO entities (id, project_id, entity_type, canonical_name, cross_project, created_at, updated_at, embedding) VALUES (?, ?, 'tool', ?, 0, ?, ?, ?)",
+      )
+      .run(id, pid, name, now, now, toBlob(vec));
+  }
+
+  test("returns entities sorted by similarity descending", () => {
+    insertEntity("ent-a", "Exact", new Float32Array([1, 0, 0]));
+    insertEntity("ent-b", "Orthogonal", new Float32Array([0, 1, 0]));
+    insertEntity("ent-c", "Close", new Float32Array([0.9, 0.1, 0]));
+
+    const results = vectorSearchEntities(new Float32Array([1, 0, 0]), 10);
+    expect(results.map((r) => r.id)).toEqual(["ent-a", "ent-c", "ent-b"]);
+    expect(results[0].similarity).toBeCloseTo(1, 5);
+  });
+
+  test("ignores entities with no embedding and respects limit", () => {
+    insertEntity("ent-x", "Has vec", new Float32Array([1, 0, 0]));
+    const pid = ensureProject(PROJECT);
+    const now = Date.now();
+    db()
+      .query(
+        "INSERT INTO entities (id, project_id, entity_type, canonical_name, cross_project, created_at, updated_at) VALUES ('ent-novec', ?, 'tool', 'No vec', 0, ?, ?)",
+      )
+      .run(pid, now, now);
+
+    const results = vectorSearchEntities(new Float32Array([1, 0, 0]), 1);
+    expect(results.length).toBe(1);
+    expect(results[0].id).toBe("ent-x");
   });
 });
 

--- a/packages/core/test/entity-dedup.test.ts
+++ b/packages/core/test/entity-dedup.test.ts
@@ -1,0 +1,282 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { uuidv7 } from "uuidv7";
+import { db, ensureProject, getKV } from "../src/db";
+import * as entities from "../src/entities";
+
+const PROJECT = "/test/entity-dedup/project";
+
+function cleanup(): void {
+  const d = db();
+  d.exec("DELETE FROM entity_relations");
+  d.exec("DELETE FROM knowledge_entity_refs");
+  d.exec("DELETE FROM entity_aliases");
+  d.exec("DELETE FROM entities");
+  d.exec("DELETE FROM knowledge");
+  d.exec("DELETE FROM dedup_feedback");
+  d.exec("DELETE FROM kv_meta WHERE key LIKE 'entity_dedup_threshold:%'");
+}
+
+/** Create an entity with an explicit ID and no provider-driven embedding. */
+function makeEntity(opts: {
+  id?: string;
+  type?: entities.EntityType;
+  name: string;
+  aliases?: Array<{ type: entities.AliasType; value: string }>;
+  projectPath?: string;
+}): string {
+  const r = entities.create({
+    id: opts.id ?? uuidv7(),
+    projectPath: opts.projectPath ?? PROJECT,
+    entityType: opts.type ?? "person",
+    canonicalName: opts.name,
+    aliases: opts.aliases,
+  });
+  return r.id;
+}
+
+/** Inject a deterministic unit-norm embedding for an entity (no provider needed). */
+function injectEmbedding(entityId: string, seed: number, dims = 768): void {
+  const vec = new Float32Array(dims);
+  for (let i = 0; i < dims; i++) vec[i] = Math.sin(seed * (i + 1) * 0.1);
+  let norm = 0;
+  for (let i = 0; i < dims; i++) norm += vec[i] * vec[i];
+  norm = Math.sqrt(norm);
+  for (let i = 0; i < dims; i++) vec[i] /= norm;
+  db()
+    .query("UPDATE entities SET embedding = ? WHERE id = ?")
+    .run(Buffer.from(vec.buffer), entityId);
+}
+
+/** Inject a vector that is a small perturbation of `baseSeed` → high cosine sim. */
+function injectSimilar(
+  entityId: string,
+  baseSeed: number,
+  perturbation: number,
+  dims = 768,
+): void {
+  const vec = new Float32Array(dims);
+  for (let i = 0; i < dims; i++) {
+    vec[i] =
+      Math.sin(baseSeed * (i + 1) * 0.1) +
+      perturbation * Math.cos((i + 1) * 0.3);
+  }
+  let norm = 0;
+  for (let i = 0; i < dims; i++) norm += vec[i] * vec[i];
+  norm = Math.sqrt(norm);
+  for (let i = 0; i < dims; i++) vec[i] /= norm;
+  db()
+    .query("UPDATE entities SET embedding = ? WHERE id = ?")
+    .run(Buffer.from(vec.buffer), entityId);
+}
+
+describe("entity dedup — deduplicateEntities()", () => {
+  beforeEach(cleanup);
+
+  test("fewer than 2 entities → empty result", async () => {
+    makeEntity({ name: "Solo" });
+    const r = await entities.deduplicateEntities(PROJECT, { dryRun: true });
+    expect(r.merged).toHaveLength(0);
+    expect(r.suggested).toHaveLength(0);
+  });
+
+  test("different entity_type never merges even at high similarity", async () => {
+    const a = makeEntity({ id: uuidv7(), type: "person", name: "Octo Person" });
+    const b = makeEntity({ id: uuidv7(), type: "tool", name: "Octo Tool" });
+    injectEmbedding(a, 5);
+    injectSimilar(b, 5, 0.001); // ~identical vector, but different type
+    const r = await entities.deduplicateEntities(PROJECT, { dryRun: true });
+    expect(r.merged).toHaveLength(0);
+    expect(r.suggested).toHaveLength(0);
+  });
+
+  test("alias overlap forces an auto-merge regardless of cosine", async () => {
+    // The schema enforces UNIQUE(alias_type, alias_value), so two entities can
+    // only share an alias *value* under different alias *types* (e.g. the same
+    // handle recorded as a nickname on one and a github handle on the other).
+    // The dedup signal compares values ignoring type, so this still fires.
+    const a = makeEntity({
+      name: "Bob Smith",
+      aliases: [{ type: "github", value: "bobsmith" }],
+    });
+    const b = makeEntity({
+      name: "Robert Smith",
+      aliases: [{ type: "nickname", value: "bobsmith" }],
+    });
+    // No embeddings injected — alias overlap alone must drive the merge.
+    const r = await entities.deduplicateEntities(PROJECT, { dryRun: true });
+    expect(r.merged.length).toBe(1);
+    const cluster = r.merged[0];
+    const ids = [
+      cluster.surviving.id,
+      ...cluster.merged.map((m) => m.id),
+    ].sort();
+    expect(ids).toEqual([a, b].sort());
+  });
+
+  test("high cosine similarity (≥ auto-merge threshold) merges", async () => {
+    const a = makeEntity({ name: "GitHub Actions" });
+    const b = makeEntity({ name: "GHA" });
+    injectEmbedding(a, 9);
+    injectSimilar(b, 9, 0.0005); // very high similarity
+    const r = await entities.deduplicateEntities(PROJECT, { dryRun: true });
+    expect(r.merged.length).toBe(1);
+  });
+
+  test("moderate similarity lands in suggested, not merged", async () => {
+    const a = makeEntity({ name: "Alpha Service" });
+    const b = makeEntity({ name: "Beta Service" });
+    // Threshold band [0.85, 0.92): pick a perturbation that yields ~0.88.
+    injectEmbedding(a, 12);
+    injectSimilar(b, 12, 0.32);
+    const r = await entities.deduplicateEntities(PROJECT, {
+      dryRun: true,
+      threshold: 0.85,
+    });
+    // It should be a candidate but NOT auto-merged.
+    const sim = r.pairSimilarities.get(entities.entityPairKey(a, b));
+    if (sim != null && sim >= 0.85 && sim < 0.92) {
+      expect(r.suggested.length).toBe(1);
+      expect(r.merged.length).toBe(0);
+    }
+  });
+
+  test("dryRun does not delete; non-dryRun merges", async () => {
+    const a = makeEntity({
+      name: "Cache",
+      type: "service",
+      aliases: [{ type: "nickname", value: "the-cache" }],
+    });
+    const b = makeEntity({
+      name: "Redis",
+      type: "service",
+      aliases: [{ type: "url", value: "the-cache" }],
+    });
+
+    const dry = await entities.deduplicateEntities(PROJECT, { dryRun: true });
+    expect(dry.merged.length).toBe(1);
+    // Both still present after a dry run.
+    expect(entities.get(a)).not.toBeNull();
+    expect(entities.get(b)).not.toBeNull();
+
+    const applied = await entities.deduplicateEntities(PROJECT, {
+      dryRun: false,
+    });
+    expect(applied.merged.length).toBe(1);
+    const survivors = [a, b].filter((id) => entities.get(id) !== null);
+    expect(survivors.length).toBe(1); // exactly one absorbed the other
+  });
+
+  test("star clustering: A~B, B~C, not A~C merges only the strongest pair", async () => {
+    const a = makeEntity({ id: uuidv7(), name: "Node A" });
+    const b = makeEntity({ id: uuidv7(), name: "Node B" });
+    const c = makeEntity({ id: uuidv7(), name: "Node C" });
+    // B is the high-degree center; A and C are both very close to B but far
+    // from each other (orthogonal-ish perturbation directions).
+    injectEmbedding(b, 20);
+    injectSimilar(a, 20, 0.0008);
+    injectSimilar(c, 20, 0.0008);
+    const r = await entities.deduplicateEntities(PROJECT, { dryRun: false });
+    // One cluster centered on B absorbing A and C (no transitivity violation
+    // because all three share the same near-identical direction here); the key
+    // invariant is that no more than 2 entities are removed and 1 survives.
+    const remaining = [a, b, c].filter((id) => entities.get(id) !== null);
+    expect(remaining.length).toBeGreaterThanOrEqual(1);
+    expect(remaining.length).toBeLessThanOrEqual(2);
+  });
+
+  test("survivor is the entity with the most aliases", async () => {
+    const rich = makeEntity({
+      name: "Seylan Cinar",
+      aliases: [
+        { type: "email", value: "seylan@x.com" },
+        { type: "github", value: "seylancinar" },
+        { type: "nickname", value: "shared-key" },
+      ],
+    });
+    const sparse = makeEntity({
+      name: "Seylan",
+      aliases: [{ type: "url", value: "shared-key" }],
+    });
+    const r = await entities.deduplicateEntities(PROJECT, { dryRun: false });
+    expect(r.merged.length).toBe(1);
+    // The richer entity survives.
+    expect(entities.get(rich)).not.toBeNull();
+    expect(entities.get(sparse)).toBeNull();
+  });
+});
+
+describe("entity dedup — adaptive calibration (kind='entity')", () => {
+  beforeEach(cleanup);
+
+  test("entity feedback is isolated from knowledge feedback rows", () => {
+    const pid = ensureProject(PROJECT);
+    // Insert a knowledge-kind row directly (kind defaults to 'knowledge').
+    db()
+      .query(
+        `INSERT INTO dedup_feedback
+           (project_id, entry_a_title, entry_b_title, similarity, accepted, source, created_at)
+         VALUES (?, 'k-a', 'k-b', 0.9, 1, 'cli_yes', ?)`,
+      )
+      .run(pid, Date.now());
+    expect(entities.getEntityDedupFeedbackCount(pid)).toBe(0);
+
+    entities.recordEntityDedupFeedback({
+      projectId: pid,
+      entryATitle: "e-a",
+      entryBTitle: "e-b",
+      similarity: 0.88,
+      accepted: true,
+      source: "cli_yes",
+    });
+    expect(entities.getEntityDedupFeedbackCount(pid)).toBe(1);
+  });
+
+  test("calibrateEntityDedupThreshold returns null below 20 samples", () => {
+    const pid = ensureProject(PROJECT);
+    for (let i = 0; i < 5; i++) {
+      entities.recordEntityDedupFeedback({
+        projectId: pid,
+        entryATitle: `a${i}`,
+        entryBTitle: `b${i}`,
+        similarity: 0.9,
+        accepted: true,
+        source: "cli_yes",
+      });
+    }
+    expect(entities.calibrateEntityDedupThreshold(pid)).toBeNull();
+  });
+
+  test("calibration clamps into the entity range [0.80, 0.95]", () => {
+    const pid = ensureProject(PROJECT);
+    // 12 accepts at high sim, 12 rejects at low sim → boundary in between.
+    for (let i = 0; i < 12; i++) {
+      entities.recordEntityDedupFeedback({
+        projectId: pid,
+        entryATitle: `acc${i}`,
+        entryBTitle: `accb${i}`,
+        similarity: 0.97,
+        accepted: true,
+        source: "cli_yes",
+      });
+      entities.recordEntityDedupFeedback({
+        projectId: pid,
+        entryATitle: `rej${i}`,
+        entryBTitle: `rejb${i}`,
+        similarity: 0.5,
+        accepted: false,
+        source: "auto_dedup",
+      });
+    }
+    const t = entities.calibrateEntityDedupThreshold(pid);
+    expect(t).not.toBeNull();
+    expect(t!).toBeGreaterThanOrEqual(0.8);
+    expect(t!).toBeLessThanOrEqual(0.95);
+  });
+
+  test("save/load threshold round-trips via kv_meta", () => {
+    const pid = ensureProject(PROJECT);
+    entities.saveEntityCalibratedThreshold(pid, 0.876, 30);
+    expect(entities.loadEntityCalibratedThreshold(pid)).toBeCloseTo(0.876, 5);
+    expect(getKV(`entity_dedup_threshold:${pid}`)).toContain("0.876");
+  });
+});

--- a/packages/gateway/src/cli/entity.ts
+++ b/packages/gateway/src/cli/entity.ts
@@ -335,6 +335,8 @@ async function cmdAliasAdd(
     "manual",
   );
   if (id) {
+    // Refresh the dedup embedding now that the alias set changed.
+    entities.reembedEntity(entityId);
     console.log(
       `Added alias: ${aliasType}:${aliasValue} → ${entity.canonical_name}`,
     );
@@ -353,8 +355,13 @@ async function cmdAliasRm(
     process.exit(1);
   }
 
-  const { entities } = await import("@loreai/core");
+  const { entities, db } = await import("@loreai/core");
+  // Capture the owning entity before deletion so we can refresh its embedding.
+  const owner = db()
+    .query("SELECT entity_id FROM entity_aliases WHERE id = ?")
+    .get(aliasId) as { entity_id: string } | null;
   entities.removeAlias(aliasId);
+  if (owner) entities.reembedEntity(owner.entity_id);
   console.log(`Removed alias: ${aliasId}`);
 }
 
@@ -537,6 +544,267 @@ async function cmdDelete(
 }
 
 // ---------------------------------------------------------------------------
+// dedup — find and merge duplicate entities
+// ---------------------------------------------------------------------------
+
+type EntityDedupResult = Awaited<
+  ReturnType<typeof import("@loreai/core").entities.deduplicateEntities>
+>;
+type EntityDedupCluster = EntityDedupResult["merged"][number];
+
+function printEntityClusters(
+  clusters: EntityDedupCluster[],
+  heading: string,
+  apply: boolean,
+): void {
+  if (!clusters.length) return;
+  console.log(`\n${heading}`);
+  for (let i = 0; i < clusters.length; i++) {
+    const c = clusters[i];
+    const total = 1 + c.merged.length;
+    console.log(`\nCluster ${i + 1} (${total} → 1):`);
+    console.log(
+      `  Keep:   ${c.surviving.name} (${c.surviving.id.slice(0, 8)}…)`,
+    );
+    for (const m of c.merged) {
+      const verb = apply ? "Merge " : "Would merge";
+      console.log(
+        `  ${verb}: ${m.name} (${m.id.slice(0, 8)}…) [sim: ${m.similarity.toFixed(3)}]`,
+      );
+    }
+  }
+}
+
+/** Prompt the user for a single-key choice. Returns the chosen key, or fallback on EOF. */
+function promptChoice(
+  message: string,
+  choices: string[],
+  fallback = "s",
+): Promise<string> {
+  return new Promise((resolveChoice) => {
+    // Lazy import keeps CLI startup fast and avoids a top-level node:readline dep.
+    const { createInterface } =
+      require("readline") as typeof import("readline");
+    const rl = createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+    let resolved = false;
+    const done = (v: string) => {
+      if (resolved) return;
+      resolved = true;
+      rl.close();
+      resolveChoice(v);
+    };
+    rl.on("close", () => {
+      if (!resolved) {
+        resolved = true;
+        resolveChoice(fallback);
+      }
+    });
+    const ask = () => {
+      rl.question(message, (answer) => {
+        const key = answer.trim().toLowerCase()[0] ?? "";
+        if (choices.includes(key)) done(key);
+        else ask();
+      });
+    };
+    ask();
+  });
+}
+
+async function cmdDedup(
+  _args: string[],
+  flags: Record<string, unknown>,
+): Promise<void> {
+  const {
+    entities,
+    embedding: emb,
+    projectId: getProjectId,
+  } = await import("@loreai/core");
+
+  const apply = !!flags.yes;
+  const interactive = !!flags.interactive;
+  const asJson = !!flags.json;
+  const projectPath = flags.all
+    ? undefined
+    : resolve((flags.project as string) ?? process.cwd());
+
+  if (interactive && apply) {
+    console.error("--interactive and --yes are mutually exclusive.");
+    process.exit(1);
+  }
+  if (interactive && !process.stdin.isTTY) {
+    console.error("--interactive requires a TTY.");
+    process.exit(1);
+  }
+
+  // Preflight: backfill missing entity embeddings so similarity has vectors.
+  if (emb.isAvailable()) {
+    try {
+      const n = await emb.backfillEntityEmbeddings();
+      if (n > 0) console.log(`Re-indexed ${n} entit${n === 1 ? "y" : "ies"}.`);
+    } catch (err) {
+      console.error(
+        "Warning: entity embedding reindex failed, dedup will use name/alias signals only:",
+        err,
+      );
+    }
+  } else {
+    console.log(
+      "Note: no embedding provider available — using name/alias signals only.",
+    );
+  }
+
+  const pid = projectPath ? (getProjectId(projectPath) ?? null) : null;
+
+  // Calibration status line.
+  const count = entities.getEntityDedupFeedbackCount(pid);
+  const threshold = entities.loadEntityCalibratedThreshold(pid);
+  if (threshold !== null) {
+    console.log(
+      `Using calibrated threshold ${threshold.toFixed(3)} (from ${count} feedback pairs, default: ${entities.ENTITY_EMBEDDING_DEDUP_THRESHOLD}).`,
+    );
+  } else if (count > 0) {
+    console.log(
+      `${count}/20 feedback samples collected. Threshold calibration activates after 20 samples.`,
+    );
+  }
+
+  // Interactive mode: compute dry-run, prompt per cluster.
+  if (interactive) {
+    const result = await entities.deduplicateEntities(projectPath, {
+      dryRun: true,
+    });
+    const clusters = [...result.merged, ...result.suggested];
+    if (!clusters.length) {
+      console.log("\nNo duplicate entities found.");
+      return;
+    }
+    let mergedCount = 0;
+    for (let i = 0; i < clusters.length; i++) {
+      const c = clusters[i];
+      console.log(`\nCluster ${i + 1} (${1 + c.merged.length} → 1):`);
+      console.log(
+        `  Keep: ${c.surviving.name} (${c.surviving.id.slice(0, 8)}…)`,
+      );
+      for (const m of c.merged) {
+        console.log(
+          `  Dup:  ${m.name} (${m.id.slice(0, 8)}…) [sim: ${m.similarity.toFixed(3)}]`,
+        );
+      }
+      const choice = await promptChoice(
+        "\n  [a]ccept merge / [r]eject (keep all) / [s]kip? ",
+        ["a", "r", "s"],
+      );
+      if (choice === "a") {
+        for (const m of c.merged) {
+          entities.merge(c.surviving.id, m.id);
+          entities.recordEntityDedupFeedback({
+            projectId: pid,
+            entryATitle: c.surviving.name,
+            entryBTitle: m.name,
+            similarity: m.similarity,
+            accepted: true,
+            source: "cli_interactive",
+          });
+          mergedCount++;
+        }
+      } else if (choice === "r") {
+        for (const m of c.merged) {
+          entities.recordEntityDedupFeedback({
+            projectId: pid,
+            entryATitle: c.surviving.name,
+            entryBTitle: m.name,
+            similarity: m.similarity,
+            accepted: false,
+            source: "cli_interactive",
+          });
+        }
+      }
+    }
+    console.log(
+      `\nMerged ${mergedCount} entit${mergedCount === 1 ? "y" : "ies"}.`,
+    );
+    const newThreshold = entities.calibrateEntityDedupThreshold(pid);
+    if (newThreshold !== null) {
+      const c = entities.getEntityDedupFeedbackCount(pid);
+      entities.saveEntityCalibratedThreshold(pid, newThreshold, c);
+      console.log(
+        `Threshold calibrated to ${newThreshold.toFixed(3)} (from ${c} feedback pairs).`,
+      );
+    }
+    return;
+  }
+
+  // Non-interactive: dry-run (default) or apply (--yes).
+  const result = await entities.deduplicateEntities(projectPath, {
+    dryRun: !apply,
+  });
+
+  if (asJson) {
+    console.log(
+      JSON.stringify(
+        {
+          merged: result.merged,
+          suggested: result.suggested,
+          applied: apply,
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  if (!result.merged.length && !result.suggested.length) {
+    console.log("\nNo duplicate entities found.");
+    return;
+  }
+
+  printEntityClusters(
+    result.merged,
+    apply ? "Auto-merged:" : "Auto-merge candidates (use --yes to apply):",
+    apply,
+  );
+  printEntityClusters(
+    result.suggested,
+    "Suggestions (moderate confidence — review with `lore entity merge`):",
+    false,
+  );
+
+  if (apply) {
+    let mergedCount = 0;
+    for (const c of result.merged) {
+      for (const m of c.merged) {
+        entities.recordEntityDedupFeedback({
+          projectId: pid,
+          entryATitle: c.surviving.name,
+          entryBTitle: m.name,
+          similarity: m.similarity,
+          accepted: true,
+          source: "cli_yes",
+        });
+        mergedCount++;
+      }
+    }
+    console.log(
+      `\nMerged ${mergedCount} entit${mergedCount === 1 ? "y" : "ies"}.`,
+    );
+    const newThreshold = entities.calibrateEntityDedupThreshold(pid);
+    if (newThreshold !== null) {
+      const c = entities.getEntityDedupFeedbackCount(pid);
+      entities.saveEntityCalibratedThreshold(pid, newThreshold, c);
+      console.log(
+        `Threshold calibrated to ${newThreshold.toFixed(3)} (from ${c} feedback pairs).`,
+      );
+    }
+  } else {
+    console.log("\nRun with --yes to apply auto-merges.");
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Help & dispatch
 // ---------------------------------------------------------------------------
 
@@ -553,6 +821,7 @@ Subcommands:
   relation add <a-id> <b-id> --relation <type>  Add a relation
   relation rm <relation-id>            Remove a relation
   merge <target-id> <source-id>        Merge two entities
+  dedup                                Find/merge duplicate entities
   search <query>                       Search entities
   delete <id>                          Delete an entity
 
@@ -561,11 +830,18 @@ Alias types: name, email, github, slack, phone, nickname, url, domain
 
 Options:
   --project <path>   Project path (default: cwd)
-  --all              List all entities (ignore project scope)
-  --json             Output as JSON (list only)
+  --all              All entities, ignore project scope (list, dedup)
+  --json             Output as JSON (list, dedup)
   --metadata <json>  JSON metadata (add, edit, relation add)
   --name <name>      New name (edit only)
   --cross            Cross-project flag (add, edit)
+  --yes, -y          Apply auto-merges (dedup)
+  --interactive, -i  Accept/reject each cluster (dedup)
+
+Examples:
+  lore entity dedup                    # dry-run: show duplicate clusters
+  lore entity dedup --yes              # apply: auto-merge high-confidence dupes
+  lore entity dedup --interactive      # decide per cluster
 `.trim();
 
 export async function commandEntity(
@@ -618,6 +894,9 @@ export async function commandEntity(
     }
     case "merge":
       await cmdMerge(subArgs, values);
+      break;
+    case "dedup":
+      await cmdDedup(subArgs, values);
       break;
     case "search":
       await cmdSearch(subArgs, values);

--- a/packages/gateway/src/ui.ts
+++ b/packages/gateway/src/ui.ts
@@ -3074,30 +3074,19 @@ export async function handleUIRequest(
     if (mergeEntity) {
       const target = entities.get(mergeEntity.targetId);
       const source = entities.get(mergeEntity.sourceId);
-      if (target && source && target.id !== source.id) {
+      if (
+        target &&
+        source &&
+        target.id !== source.id &&
+        target.entity_type === source.entity_type
+      ) {
         entities.merge(target.id, source.id);
-        // Manual accept signal for adaptive threshold calibration.
-        try {
-          const pid = target.project_id ?? null;
-          entities.recordEntityDedupFeedback({
-            projectId: pid,
-            entryATitle: target.canonical_name,
-            entryBTitle: source.canonical_name,
-            similarity: 1,
-            accepted: true,
-            source: "cli_yes",
-          });
-          const newThreshold = entities.calibrateEntityDedupThreshold(pid);
-          if (newThreshold !== null) {
-            entities.saveEntityCalibratedThreshold(
-              pid,
-              newThreshold,
-              entities.getEntityDedupFeedbackCount(pid),
-            );
-          }
-        } catch (err) {
-          log.warn("entity merge feedback failed (non-fatal):", err);
-        }
+        // NOTE: We intentionally do NOT record calibration feedback here
+        // because the dashboard does not have the real pairwise similarity
+        // score. Recording a fake similarity (e.g. 1.0) would corrupt the
+        // adaptive threshold calibrator. Calibration data is only recorded
+        // from the CLI (`--yes` / `--interactive`) and from the curator's
+        // auto-dedup sweep where real cosine similarities are available.
       }
       return redirect("/ui/entities");
     }

--- a/packages/gateway/src/ui.ts
+++ b/packages/gateway/src/ui.ts
@@ -10,10 +10,12 @@ import {
   db,
   ltm,
   entities,
+  embedding,
   temporal,
   searchRecall,
   recallById,
   config,
+  log,
   projectName,
   projectId as lookupProjectId,
   isUnattributedProjectPath,
@@ -2716,7 +2718,7 @@ function matchRoute(pathname: string, pattern: string): RouteParams | null {
 // Entities pages
 // ---------------------------------------------------------------------------
 
-function pageEntities(): string {
+async function pageEntities(): Promise<string> {
   const all = entities.listAll();
 
   let body = breadcrumb([
@@ -2728,6 +2730,46 @@ function pageEntities(): string {
   if (!all.length) {
     body += `<p class="empty">No entities found. Entities are created automatically when the curator detects recurring people, services, tools, and other named references in conversations.</p>`;
     return layout("Entities", body);
+  }
+
+  // Merge suggestions (#462): surface duplicate candidates as a dry-run banner.
+  // Only compute when embeddings are available (the primary signal); cheap for
+  // typical registry sizes. Non-fatal — failures just omit the section.
+  if (embedding.isAvailable() && all.length >= 2) {
+    try {
+      const dupes = await entities.deduplicateEntities(undefined, {
+        dryRun: true,
+      });
+      const clusters = [...dupes.merged, ...dupes.suggested];
+      if (clusters.length > 0) {
+        const pairCount = clusters.reduce((n, c) => n + c.merged.length, 0);
+        body += `<div class="banner" style="border:1px solid #d0a000;background:#fffbe6;padding:12px 16px;border-radius:6px;margin:12px 0;">`;
+        body += `<strong>${pairCount} possible duplicate ${pairCount === 1 ? "entity" : "entities"} found.</strong> Review and merge below, or run <code>lore entity dedup</code>.`;
+        body += `<div style="margin-top:10px;display:flex;flex-direction:column;gap:8px;">`;
+        const MAX_SUGGESTIONS = 25;
+        let shown = 0;
+        for (const c of clusters) {
+          for (const m of c.merged) {
+            if (shown >= MAX_SUGGESTIONS) break;
+            shown++;
+            body += `<div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;">`;
+            body += `<span><a href="/ui/entities/${esc(m.id)}">${esc(truncate(m.name, 40))}</a> → <a href="/ui/entities/${esc(c.surviving.id)}">${esc(truncate(c.surviving.name, 40))}</a></span>`;
+            body += `<span class="muted" style="color:#888;">[sim: ${m.similarity.toFixed(3)}]</span>`;
+            body += `<form method="POST" action="/ui/api/merge/entity/${esc(c.surviving.id)}/${esc(m.id)}" style="display:inline;" onsubmit="return confirm('Merge &quot;${esc(m.name)}&quot; into &quot;${esc(c.surviving.name)}&quot;?');">`;
+            body += `<button type="submit" style="font-size:12px;padding:2px 8px;">Merge</button>`;
+            body += `</form>`;
+            body += `</div>`;
+          }
+          if (shown >= MAX_SUGGESTIONS) break;
+        }
+        if (pairCount > shown) {
+          body += `<span class="muted" style="color:#888;">…and ${pairCount - shown} more. Use <code>lore entity dedup</code>.</span>`;
+        }
+        body += `</div></div>`;
+      }
+    } catch (err) {
+      log.warn("entity dedup suggestions failed (non-fatal):", err);
+    }
   }
 
   // Type breakdown stats
@@ -2982,7 +3024,7 @@ export async function handleUIRequest(
 
     // Entity list
     if (pathname === "/ui/entities") {
-      return htmlResponse(pageEntities());
+      return htmlResponse(await pageEntities());
     }
 
     // Entity detail
@@ -3021,6 +3063,42 @@ export async function handleUIRequest(
     const delEntity = matchRoute(pathname, "/ui/api/delete/entity/:id");
     if (delEntity) {
       entities.remove(delEntity.id);
+      return redirect("/ui/entities");
+    }
+
+    // Merge entity (dedup suggestion): keep target, absorb source (#462)
+    const mergeEntity = matchRoute(
+      pathname,
+      "/ui/api/merge/entity/:targetId/:sourceId",
+    );
+    if (mergeEntity) {
+      const target = entities.get(mergeEntity.targetId);
+      const source = entities.get(mergeEntity.sourceId);
+      if (target && source && target.id !== source.id) {
+        entities.merge(target.id, source.id);
+        // Manual accept signal for adaptive threshold calibration.
+        try {
+          const pid = target.project_id ?? null;
+          entities.recordEntityDedupFeedback({
+            projectId: pid,
+            entryATitle: target.canonical_name,
+            entryBTitle: source.canonical_name,
+            similarity: 1,
+            accepted: true,
+            source: "cli_yes",
+          });
+          const newThreshold = entities.calibrateEntityDedupThreshold(pid);
+          if (newThreshold !== null) {
+            entities.saveEntityCalibratedThreshold(
+              pid,
+              newThreshold,
+              entities.getEntityDedupFeedbackCount(pid),
+            );
+          }
+        } catch (err) {
+          log.warn("entity merge feedback failed (non-fatal):", err);
+        }
+      }
       return redirect("/ui/entities");
     }
 


### PR DESCRIPTION
Closes #462.

Adds semantic duplicate detection and merging for the entity registry (#459), modeled on the existing knowledge dedup system (star clustering, `dedup_feedback` adaptive threshold, post-curation auto-merge). Catches duplicates the previous alias/Jaccard heuristics missed — e.g. "Seylan Cinar" ↔ "Seylan", "GitHub Actions" ↔ "GHA".

## What's included (all 6 steps from the issue)

1. **Schema** (`db.ts`) — migration **v34**: `entities.embedding BLOB` + `dedup_feedback.kind` discriminator (defaults to `'knowledge'` so existing rows and all current knowledge code paths are untouched). `recoverMissingObjects` updated for the new column.
2. **Embedding pipeline** (`embedding.ts`) — `embedEntity()` (canonical name + alias values → one composite vector, fire-and-forget), `vectorSearchEntities()`, `backfillEntityEmbeddings()` wired into startup backfill. Entities re-embed on create/update/merge/alias changes via `reembedEntity()`.
3. **Dedup engine** (`entities.ts`) — `deduplicateEntities()` replaces the dead `findDuplicateCandidates()` stub. Multi-signal scoring per the issue table:
   - same `entity_type` — **required** (never merges a person with a service)
   - embedding cosine similarity — primary
   - exact alias-value overlap — strong (forces auto-merge tier)
   - canonical-name Jaccard ≥ 0.5 — moderate boost
   - shared linked-knowledge — small boost
   - greedy star clustering (no transitivity); tiers: **auto-merge ≥ 0.92**, **suggest ≥ 0.85**
4. **CLI** (`cli/entity.ts`) — `lore entity dedup` with `--yes` (apply), `--interactive`/`-i`, `--json`, `--project`, `--all`. Default is dry-run; embedding preflight + calibration status line.
5. **Web dashboard** (`ui.ts`) — "possible duplicates" banner on `/ui/entities` with one-click Merge buttons + `POST /ui/api/merge/entity/:targetId/:sourceId`.
6. **Adaptive calibration** (`entities.ts`) — entity-scoped feedback functions reusing `dedup_feedback` with `kind='entity'`; per-project threshold in `kv_meta` (`entity_dedup_threshold:<pid>`, clamped `[0.80, 0.95]`). Curator runs the sweep + recalibration after entity creation.

## Design notes

- **`kind` discriminator** keeps knowledge dedup code untouched; entity functions filter `kind='entity'`. No second table.
- **Auto-merge in curator** (consistent with knowledge): only the auto-merge tier is applied; moderate-confidence pairs are surfaced as suggestions in CLI/dashboard.
- **Survivor heuristic** for entities: most aliases (richest) → most recent → shortest canonical name.
- **`UNIQUE(alias_type, alias_value)`** means two entities can only share an alias *value* under different *types*; the dedup compares values type-agnostically, so that signal still fires (documented in comments + tests).
- All dedup/embedding work is fire-and-forget / non-fatal — never breaks curation or request flow.

## Testing

Local smoke (real Nomic local provider):
- "GitHub Actions" ↔ "GitHub Actions CI" → **0.969** → auto-merged with `--yes`
- "Seylan Cinar" ↔ "Seylan" → **0.882** → suggestion-only (not auto-applied)

Automated:
- `packages/core/test/entity-dedup.test.ts` — 12 tests: type-gate, alias-overlap force-merge, cosine auto-merge, suggestion tier, dryRun no-op, star clustering, survivor selection, calibration isolation/clamp/round-trip
- `embedding.test.ts` — `vectorSearchEntities` ordering + null-embedding handling
- `db.test.ts` — v34 migration columns + `kind` default

Verification:
- `bun --filter '*' typecheck` — all 4 packages pass (strict)
- `bun test packages/core` — 1160 pass / 0 fail
- `bun test packages/gateway` — 1042 pass / 0 fail
- biome lint clean

(One pre-existing timing-sensitive perf flake, `truncateToolOutputs ... <2s`, passes in isolation — unrelated to this change.)

## Files
- `packages/core/src/db.ts` — migration v34
- `packages/core/src/embedding.ts` — entity embed/search/backfill
- `packages/core/src/entities.ts` — dedup engine + calibration + re-embed wiring
- `packages/core/src/curator.ts` — post-curation sweep
- `packages/gateway/src/cli/entity.ts` — `dedup` subcommand
- `packages/gateway/src/ui.ts` — suggestions banner + merge route