### PR TITLE
test: block live models.dev fetch in test preload

### DIFF
--- a/packages/core/test/setup.ts
+++ b/packages/core/test/setup.ts
@@ -10,6 +10,75 @@ import { close } from "../src/db";
 const tmp = mkdtempSync(join(tmpdir(), "lore-test-"));
 process.env.LORE_DB_PATH = join(tmp, "test.db");
 
+// ---------------------------------------------------------------------------
+// Block live network to models.dev during tests.
+//
+// `fetchModelData()` (gateway/src/worker-model.ts) hits
+// https://models.dev/api.json to pull pricing/limits, and the gateway
+// pre-warms it on startup (pipeline.ts). Any test that starts a real gateway
+// — or any test running while another file's pipeline pre-warm fires — would
+// otherwise make a live HTTP call. That made the suite depend on a 3rd-party
+// API being up: it flaked when models.dev returned 500 / timed out, and it
+// polluted worker-model.test.ts's fetch-mock assertions across files.
+//
+// We install a baseline `globalThis.fetch` that intercepts ONLY the models.dev
+// endpoint (returning canned, realistic data) and delegates everything else to
+// the real implementation. Tests that override `globalThis.fetch` still work:
+// they replace the global, and when they restore the captured `originalFetch`
+// in afterEach they restore THIS guard, so post-test async pre-warms stay
+// offline too. Mirrors the SENTRY_ENABLED=0 "no background fetch leaks into
+// tests" precedent in bunfig.toml.
+const MODELS_DEV_API = "https://models.dev/api.json";
+const CANNED_MODELS_DEV = {
+  anthropic: {
+    models: {
+      "claude-opus-4-6": {
+        id: "claude-opus-4-6",
+        cost: { input: 5, output: 25, cache_read: 0.5 },
+        limit: { context: 1_000_000, output: 128_000 },
+      },
+      "claude-sonnet-4-20250514": {
+        id: "claude-sonnet-4-20250514",
+        cost: { input: 3, output: 15, cache_read: 0.3 },
+        limit: { context: 1_000_000, output: 64_000 },
+      },
+      "claude-haiku-4-5": {
+        id: "claude-haiku-4-5",
+        cost: { input: 1, output: 5, cache_read: 0.1 },
+        limit: { context: 200_000, output: 64_000 },
+      },
+    },
+  },
+  openai: {
+    models: {
+      "gpt-5.4-mini": {
+        id: "gpt-5.4-mini",
+        cost: { input: 0.75, output: 4.5, cache_read: 0.19 },
+        limit: { context: 400_000, output: 100_000 },
+      },
+    },
+  },
+};
+
+const realFetch = globalThis.fetch;
+globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+  const url =
+    typeof input === "string"
+      ? input
+      : input instanceof URL
+        ? input.href
+        : input.url;
+  if (url === MODELS_DEV_API) {
+    return Promise.resolve(
+      new Response(JSON.stringify(CANNED_MODELS_DEV), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+  }
+  return realFetch(input, init);
+}) as typeof globalThis.fetch;
+
 afterAll(() => {
   close();
   rmSync(tmp, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Eliminates the intermittent test failure where `models.dev` returned a 500 / timed out during the suite. The root cause is a **live network dependency**, not a test-local issue.

## Root cause

`worker-model.ts` fetches `https://models.dev/api.json` for model pricing/limits, and the gateway **pre-warms** that cache on startup (`pipeline.ts:843`, fire-and-forget). So:

- Any test that starts a real gateway (e.g. `createHarness`) triggers a live `models.dev` call unless it mocks `fetch`.
- Because the pre-warm is async and fire-and-forget, it can also land *during another test file*, polluting `worker-model.test.ts`'s fetch-mock assertions (the many defensive `clearModelDataCache()` comments in that file are scar tissue from this).
- When `models.dev` is down/slow in CI, the triggering test fails.

## Fix

Install a baseline `globalThis.fetch` in the shared test preload (`packages/core/test/setup.ts`) that intercepts **only** the `models.dev` endpoint — returning canned, realistic data — and delegates every other URL to the real `fetch`.

Tests that set their own `globalThis.fetch` mock are unaffected: they replace the global, and when they restore their captured `originalFetch` in `afterEach`, they restore **this guard** (not a live fetch), so post-test async pre-warms stay offline too.

This mirrors the existing `SENTRY_ENABLED=0` precedent in `bunfig.toml`, which already neutralizes the analogous "background `fetch` leaks into test mocks" flake class.

## Verification
- Direct probe: `fetch("https://models.dev/api.json")` returns canned data in <60ms with **no** network call.
- Full suite stable across repeated runs: **2206 pass / 5 skip / 0 fail**.
- `worker-model.test.ts` still passes (its own intentional 500/network-error mocks are unaffected).
- `bun run lint` clean for the changed file; `@loreai/core` typecheck passes.

## Note (out of scope)
`bun run lint` surfaced ~9 **warnings** from the recently merged entity-dedup PR (#536) — these are warning-level rules (e.g. `noNonNullAssertion`), so the Lint CI gate (which fails only on errors) let them through. Not addressed here; flagging that warning-level findings can accumulate silently under the current gate.