### PR TITLE
docs(site): add 'Why Lore' comparison page and extract shared theme

### DIFF
--- a/docs/different.html
+++ b/docs/different.html
@@ -1,0 +1,368 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Why Lore — What Makes Lore Different</title>
+  <meta name="description" content="Why choose Lore: a local-first, source-available memory proxy that unifies context management and long-term memory for any AI coding agent — no platform lock-in." />
+  <link rel="icon" href="favicon.ico" sizes="any">
+  <link rel="icon" type="image/svg+xml" href="favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="favicon-32.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,500;1,400;1,500&family=DM+Sans:wght@200;300;400;500;700&display=swap"
+    rel="stylesheet" />
+  <link rel="stylesheet" href="theme.css" />
+</head>
+
+<body>
+
+  <div class="cursor" id="cur"></div>
+
+  <!-- NAV -->
+  <nav>
+    <div class="nav-left">
+      <a href="index.html" class="logo">
+        <img src="brand-mark.svg?v=6" alt="Lore.AI" style="height: 78px; width: auto; display: block;" />
+      </a>
+    </div>
+    <div class="nav-right">
+      <ul class="nav-links">
+        <li><a href="index.html#problem">The Problem</a></li>
+        <li><a href="index.html#how">How It Works</a></li>
+        <li><a href="index.html#features">Features</a></li>
+        <li><a href="different.html">Why Lore</a></li>
+        <li><a href="https://github.com/byk/loreai" target="_blank" rel="noopener noreferrer">GitHub</a></li>
+      </ul>
+      <a href="index.html#waitlist" class="nav-btn">Lore Cloud Waitlist</a>
+    </div>
+  </nav>
+
+  <!-- HERO -->
+  <section class="hero hero-compact">
+    <div style="max-width: 760px;">
+      <div class="hero-badge sr" style="justify-content: center;">
+        <span class="badge-pill">Why Lore</span>
+        A different layer of the stack
+      </div>
+      <h1 class="sr">What makes Lore <em>different</em></h1>
+      <p class="hero-desc sr" style="max-width: 60ch; margin: 0 auto 2.5rem;">
+        Lots of tools now promise "agent memory." Most solve one half of the problem, or bolt memory onto a
+        single tool or cloud platform you have to adopt. Lore takes a different approach: it's a local-first,
+        source-available proxy that treats context management and long-term memory as <em>one</em> pipeline —
+        for whatever agent you already use.
+      </p>
+      <div class="hero-actions sr" style="justify-content: center;">
+        <a href="index.html#waitlist" class="btn-fill">
+          Join the Waitlist
+          <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.8">
+            <path d="M2 7h10M7 2l5 5-5 5" />
+          </svg>
+        </a>
+        <a href="https://github.com/byk/loreai" target="_blank" rel="noopener noreferrer" class="btn-ghost">View Repository</a>
+      </div>
+    </div>
+  </section>
+
+  <!-- THE THREE THINGS -->
+  <section class="how" id="pillars">
+    <div class="sec-hd">
+      <div>
+        <p class="eyebrow sr">The short version</p>
+        <h2 class="sec-title sr">Three reasons to <em>choose Lore</em></h2>
+      </div>
+      <p class="sec-sub sr">Not a knock on anyone else — just what Lore optimizes for that others, by design, don't.</p>
+    </div>
+    <div class="steps">
+      <div class="step sr">
+        <div class="step-n">01</div>
+        <h3 class="step-t">Memory <em>and</em> context — one pipeline</h3>
+        <p class="step-b">Most memory tools store and retrieve, but leave your context window to the agent's own
+          compaction — so it still loses track mid-session. Most context tools compress history but learn
+          nothing from it. In Lore, compression <em>is</em> the memory pipeline: distillation feeds the
+          gradient context manager, which feeds the knowledge curator, which feeds
+          <code class="code-inline">.lore.md</code>.
+          One system, not two bolted together.</p>
+      </div>
+      <div class="step sr">
+        <div class="step-n">02</div>
+        <h3 class="step-t">Local-first, source-available</h3>
+        <p class="step-b">The whole engine runs on your machine. Messages, distillations, knowledge, and
+          on-device embeddings live in a local SQLite database — zero added infrastructure, nothing to send to a
+          server to make memory work. The engine is source-available, so you can read exactly how your memory is
+          formed and stored. No black box.</p>
+      </div>
+      <div class="step sr">
+        <div class="step-n">03</div>
+        <h3 class="step-t">Your agent, no platform to adopt</h3>
+        <p class="step-b">Lore is a proxy on the API wire, so it works with the agent you already use —
+          Claude Code, Cursor, Copilot, Windsurf, OpenCode, Pi, Codex, or anything speaking the Anthropic or
+          OpenAI protocol — just by pointing its base URL at Lore. You don't move your workflow into a new
+          terminal, IDE, or cloud control plane to get memory.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- THE LANDSCAPE / COMPARISON -->
+  <section class="features" id="landscape">
+    <div class="sec-hd" style="max-width:1100px;margin:0 auto 3rem;">
+      <div>
+        <p class="eyebrow sr">The landscape</p>
+        <h2 class="sec-title sr">How the approaches <em>compare</em></h2>
+      </div>
+      <p class="sec-sub sr">A fair map of the common approaches to agent memory — and where Lore sits.</p>
+    </div>
+
+    <div class="cmp-wrap sr">
+      <table class="cmp">
+        <thead>
+          <tr>
+            <th style="width:26%;">Approach</th>
+            <th>What it does well</th>
+            <th>The trade-off</th>
+            <th class="cmp-lore"><span class="cmp-eyebrow">Where Lore differs</span>Lore's take</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th>Memory-only tools<br><span style="font-weight:300;color:var(--mid);font-size:.86em;">store &amp; retrieve past conversations</span></th>
+            <td>Good at recalling things you explicitly saved or that were captured earlier.</td>
+            <td>Don't manage the live context window — the agent can still get compacted mid-session and lose
+              track of what it's doing right now.</td>
+            <td class="cmp-lore">Lore manages the context window <span class="cmp-yes">and</span> remembers —
+              so memory arrives in-context at the right moment, not just when you ask.</td>
+          </tr>
+          <tr>
+            <th>Context-only tools<br><span style="font-weight:300;color:var(--mid);font-size:.86em;">compress history to extend a session</span></th>
+            <td>Keep a single long session alive without hitting the window limit.</td>
+            <td>Nothing is learned from the compression. New session, new project, or new tool — and you're
+              back to zero.</td>
+            <td class="cmp-lore">Lore extracts durable knowledge <span class="cmp-yes">from</span> the
+              compression, so every session makes the next one smarter.</td>
+          </tr>
+          <tr>
+            <th>Tool- or IDE-bound memory<br><span style="font-weight:300;color:var(--mid);font-size:.86em;">memory built into one agent or editor</span></th>
+            <td>Deep, polished integration inside that one tool.</td>
+            <td>Switch tools, providers, or machines and the memory stays behind. Your knowledge is tied to a
+              product choice.</td>
+            <td class="cmp-lore">Lore sits on the API wire, so memory follows you
+              <span class="cmp-yes">across</span> tools and providers — your constant, not theirs.</td>
+          </tr>
+          <tr>
+            <th>Cloud agent platforms<br><span style="font-weight:300;color:var(--mid);font-size:.86em;">memory inside a hosted control plane</span></th>
+            <td>Org-wide retrieval and governance for fleets of agents run on the platform.</td>
+            <td>Memory exists for agents run <em>through</em> the platform; the engine is hosted and closed.
+              You adopt the platform to get the memory.</td>
+            <td class="cmp-lore">Lore runs locally with the agent you already use. The engine is
+              source-available; your knowledge is a <span class="cmp-yes">plain file in your repo</span>.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <p class="sec-sub sr" style="max-width:1100px;margin:1.5rem auto 0;text-align:left;font-size:.78rem;opacity:.7;">
+      These are categories, not a scorecard against any one product. Many tools blend approaches, and the
+      good ones are genuinely good at what they target. Lore's bet is that unifying the halves — locally,
+      across any harness — is the combination most coding workflows actually want.
+    </p>
+  </section>
+
+  <!-- PORTABILITY -->
+  <section class="features" id="portability" style="background:var(--c0);">
+    <div class="bento">
+      <div class="bc bc-1 sr">
+        <p class="bc-tag">Ownership</p>
+        <h3 class="bc-t">Your memory is a file you can read</h3>
+        <p class="bc-b">Curated knowledge is exported to
+          <code class="code-inline">.lore.md</code>
+          (or AGENTS.md) in your own repository — human-readable markdown, version-controlled with your code,
+          reviewable in a pull request. Stop using Lore tomorrow and you still have everything it learned,
+          in plain text. That's portability you can verify, not just a promise to export.</p>
+      </div>
+      <div class="bc bc-2 sr">
+        <p class="bc-tag">No lock-in</p>
+        <h3 class="bc-t">Where the commitment lives matters</h3>
+        <p class="bc-b">Every memory system asks for <em>some</em> commitment. With a hosted platform, it's at
+          the platform layer — route your agents through it or get nothing. With Lore, it's a one-line base-URL
+          change you can undo at any time, and the data never leaves your machine unless you choose to share it.
+          Switch providers, switch tools, switch laptops — your memory comes with you.</p>
+      </div>
+      <div class="bc bc-3 sr">
+        <div>
+          <p class="bc-tag">Proven where it's hardest</p>
+          <h3 class="bc-t">The advantage grows with the session</h3>
+          <p class="bc-b">On a real 5-day, 2.3M-token coding session, Lore scored 4.0/5 on recall versus 2.4/5
+            for compaction — 2.6x more perfect answers. The early-session details that lossy summaries destroy
+            are exactly what Lore's three-tier memory preserves. The longer you work, the bigger the gap.</p>
+        </div>
+        <div class="code-block">
+          <code><span class="ck"># One line. Any agent.</span><br><span class="cv">$</span> lore run<br><br><span class="ck"># Local engine. Your data stays</span><br><span class="ck"># on your machine.</span></code>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- TEAM -->
+  <section class="how" id="team">
+    <div class="sec-hd">
+      <div>
+        <p class="eyebrow sr">Teams</p>
+        <h2 class="sec-title sr">Team memory, <em>without</em> giving up the local-first model</h2>
+      </div>
+      <p class="sec-sub sr">Because knowledge lives in
+        <code class="code-inline">.lore.md</code>
+        in your repo, sharing it is just git — today.</p>
+    </div>
+    <div class="steps">
+      <div class="step sr">
+        <div class="step-n">01</div>
+        <h3 class="step-t">Share via the tools you already have</h3>
+        <p class="step-b">A teammate clones the repo and Lore imports the committed
+          <code class="code-inline">.lore.md</code>.
+          Shared conventions, gotchas, and decisions travel with the codebase — no extra service required.</p>
+      </div>
+      <div class="step sr">
+        <div class="step-n">02</div>
+        <h3 class="step-t">Reviewable, like code</h3>
+        <p class="step-b">Knowledge changes show up in diffs and pull requests. Your team approves what becomes
+          shared memory the same way it approves any other change — with full history and the ability to roll back.</p>
+      </div>
+      <div class="step sr">
+        <div class="step-n">03</div>
+        <h3 class="step-t">Lore Cloud when you want it</h3>
+        <p class="step-b">For centrally-managed, multi-user shared memory with approval workflows, Lore Cloud is
+          coming. It's an option layered on top of the local-first core — not a platform you have to adopt to get
+          value today.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="cta" id="waitlist">
+    <div class="cta-inner">
+      <h2 class="sr">Memory that's <em>yours.</em></h2>
+      <p class="cta-sub sr">Self-hosted Lore is available now, free and local. Join the waitlist for Lore Cloud —
+        hosted, team-shared memory with zero setup.</p>
+
+      <div class="cta-form-view show" id="waitlist-form-view">
+        <form class="cta-form sr" id="waitlist-form"
+              action="https://app.loops.so/api/newsletter-form/cmpemslgp03m10jxaipjw78iq" method="POST">
+          <input class="cta-input" type="email" name="email" placeholder="your@email.com" id="waitlist-email" required />
+          <button class="cta-submit" type="submit" id="waitlist-btn">Join Waitlist</button>
+        </form>
+        <p class="cta-note sr">No spam. Unsubscribe anytime.</p>
+      </div>
+
+      <div class="cta-form-view" id="waitlist-success" aria-live="polite">
+        <p class="cta-success">&check; You're on the list. We'll be in touch.</p>
+      </div>
+
+      <div class="cta-form-view" id="waitlist-error" role="alert">
+        <p class="cta-error" id="waitlist-error-msg">Something went wrong. Please try again.</p>
+        <button class="cta-back" id="waitlist-retry">&larr; Try Again</button>
+      </div>
+    </div>
+  </section>
+
+  <footer>
+    <div class="foot-bottom">
+      <p>© 2026 Lore.AI · FSL-1.1-Apache-2.0 · <a href="index.html" style="border-bottom:1px solid rgba(196,221,199,.3)">Home</a></p>
+    </div>
+  </footer>
+
+  <script>
+    // custom cursor
+    const cur = document.getElementById('cur');
+    document.addEventListener('mousemove', e => {
+      cur.style.left = e.clientX + 'px';
+      cur.style.top = e.clientY + 'px';
+    });
+    document.querySelectorAll('a,button').forEach(el => {
+      el.addEventListener('mouseenter', () => cur.classList.add('expand'));
+      el.addEventListener('mouseleave', () => cur.classList.remove('expand'));
+    });
+
+    // scroll reveal
+    const obs = new IntersectionObserver(entries => {
+      entries.forEach(e => { if (e.isIntersecting) { e.target.classList.add('in'); } });
+    }, { threshold: 0.1 });
+    document.querySelectorAll('.sr').forEach(el => obs.observe(el));
+
+    // newsletter form — Loops.so integration
+    (() => {
+      const LOOPS_ENDPOINT = 'https://app.loops.so/api/newsletter-form/cmpemslgp03m10jxaipjw78iq';
+      const RATE_LIMIT_KEY = 'loops-form-timestamp';
+      const RATE_LIMIT_MS = 60_000;
+
+      const form = document.getElementById('waitlist-form');
+      const email = document.getElementById('waitlist-email');
+      const btn = document.getElementById('waitlist-btn');
+      const formView = document.getElementById('waitlist-form-view');
+      const successView = document.getElementById('waitlist-success');
+      const errorView = document.getElementById('waitlist-error');
+      const errorMsg = document.getElementById('waitlist-error-msg');
+      const retryBtn = document.getElementById('waitlist-retry');
+
+      function showView(view) {
+        formView.classList.remove('show');
+        successView.classList.remove('show');
+        errorView.classList.remove('show');
+        view.classList.add('show');
+      }
+
+      function showError(msg) {
+        errorMsg.textContent = msg || 'Something went wrong. Please try again.';
+        showView(errorView);
+        retryBtn.focus();
+      }
+
+      retryBtn?.addEventListener('click', () => {
+        showView(formView);
+        email.focus();
+      });
+
+      form?.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const value = email.value.trim();
+        if (!value) return;
+
+        let last = 0;
+        try { last = parseInt(localStorage.getItem(RATE_LIMIT_KEY) || '0', 10); } catch {}
+        if (Date.now() - last < RATE_LIMIT_MS) {
+          showError('Too many attempts. Please try again in a minute.');
+          return;
+        }
+
+        btn.textContent = 'Sending\u2026';
+        btn.disabled = true;
+
+        try {
+          const res = await fetch(LOOPS_ENDPOINT, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: new URLSearchParams({ email: value }),
+          });
+
+          const data = await res.json();
+
+          if (res.ok || data.message === 'Email already on list.') {
+            try { localStorage.setItem(RATE_LIMIT_KEY, String(Date.now())); } catch {}
+            email.value = '';
+            showView(successView);
+          } else {
+            showError(data.message || null);
+          }
+        } catch {
+          showError('Network error. Please check your connection and try again.');
+        } finally {
+          btn.textContent = 'Join Waitlist';
+          btn.disabled = false;
+        }
+      });
+    })();
+  </script>
+</body>
+
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,6 +5,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>LoreAI — Persistent Memory for AI Coding Agents</title>
+  <meta name="description" content="Lore gives your AI coding agent persistent memory across sessions — local-first, source-available, works with any LLM provider. No context files to maintain, no workflow changes." />
   <link rel="icon" href="favicon.ico" sizes="any">
   <link rel="icon" type="image/svg+xml" href="favicon.svg">
   <link rel="icon" type="image/png" sizes="32x32" href="favicon-32.png">
@@ -15,901 +16,7 @@
     href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,500;1,400;1,500&family=DM+Sans:wght@200;300;400;500;700&display=swap"
     rel="stylesheet" />
 
-  <style>
-    :root {
-      --c0: #f7f2e8;
-      --c1: #ede5d0;
-      --c2: #dfd5bb;
-      --g0: #1a3320;
-      --g1: #2a4d32;
-      --g2: #3d6644;
-      --g3: #5a8f63;
-      --g4: #8fba96;
-      --g5: #c4ddc7;
-      --g6: #e8f2e9;
-      --ink: #1a2e1b;
-      --mid: #4a5f4c;
-      --serif: 'Playfair Display', Georgia, serif;
-      --sans: 'DM Sans', sans-serif;
-      --ease: cubic-bezier(0.22, 1, 0.36, 1);
-    }
-
-    *,
-    *::before,
-    *::after {
-      box-sizing: border-box;
-      margin: 0;
-      padding: 0;
-    }
-
-    html {
-      scroll-behavior: smooth;
-    }
-
-    body {
-      background: var(--c0);
-      color: var(--ink);
-      font-family: var(--sans);
-      font-weight: 300;
-      font-size: 1.08rem;
-      line-height: 1.75;
-      overflow-x: hidden;
-      cursor: none;
-    }
-
-    .cursor {
-      position: fixed;
-      width: 8px;
-      height: 8px;
-      background: var(--g2);
-      border-radius: 50%;
-      pointer-events: none;
-      z-index: 9999;
-      transform: translate(-50%, -50%);
-      transition: width .3s var(--ease), height .3s var(--ease), background .3s;
-    }
-
-    .cursor.expand {
-      width: 36px;
-      height: 36px;
-      background: transparent;
-      border: 1px solid var(--g3);
-    }
-
-    body::after {
-      content: '';
-      position: fixed;
-      inset: 0;
-      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='300' height='300'%3E%3Cfilter id='g'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.75' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='300' height='300' filter='url(%23g)' opacity='0.035'/%3E%3C/svg%3E");
-      pointer-events: none;
-      z-index: 9998;
-    }
-
-    a {
-      color: inherit;
-      text-decoration: none;
-    }
-
-    /* NAV */
-    nav {
-      position: fixed;
-      top: 0;
-      left: 0;
-      right: 0;
-      z-index: 500;
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      padding: .45rem 3rem;
-      background: var(--ink); /* Dark green background */
-      border-bottom: 1px solid rgba(255, 255, 255, 0.05);
-      color: var(--c0);
-    }
-
-    .nav-left {
-      display: flex;
-      align-items: center;
-    }
-
-    .nav-right {
-      display: flex;
-      align-items: center;
-      gap: 2.4rem;
-    }
-
-    .logo {
-      display: flex;
-      align-items: center;
-      gap: .5rem;
-      color: var(--c0); /* Light logo text and stroke */
-      transition: color 0.3s ease;
-    }
-
-    .logo:hover {
-      color: var(--g5);
-    }
-
-    .logo-img {
-      height: 56px; /* Adjusted height to accommodate the larger viewBox height */
-      width: auto;
-      display: block;
-    }
-
-    .logo-text {
-      font-family: var(--serif); /* Garantili bir şekilde Playfair Display uygulamak için */
-    }
-
-    .logo-dot {
-      width: 6px;
-      height: 6px;
-      background: var(--g3);
-      border-radius: 50%;
-      animation: pulse 3s ease-in-out infinite;
-    }
-
-    @keyframes pulse {
-
-      0%,
-      100% {
-        opacity: 1;
-        transform: scale(1)
-      }
-
-      50% {
-        opacity: .5;
-        transform: scale(.7)
-      }
-    }
-
-    .nav-links {
-      display: flex;
-      gap: 2.2rem;
-      list-style: none;
-      font-size: 1rem;
-      font-family: var(--sans);
-      color: rgba(247, 242, 232, 0.8); /* Faded cream */
-      font-weight: 400;
-    }
-
-    .nav-links a {
-      transition: color .25s;
-    }
-
-    .nav-links a:hover {
-      color: var(--c0); /* Solid cream on hover */
-    }
-
-    .nav-btn {
-      font-size: 1rem;
-      font-family: var(--sans);
-      font-weight: 400;
-      padding: .6rem 1.6rem;
-      background: var(--c0);
-      color: var(--ink);
-      border-radius: 3px;
-      transition: background .3s, color .3s;
-    }
-
-    .nav-btn:hover {
-      background: var(--g5);
-      color: var(--ink);
-    }
-
-    /* HERO */
-    .hero {
-      min-height: 100svh;
-      padding: 10rem 3rem 5rem;
-      display: grid;
-      grid-template-columns: 1.1fr 1fr;
-      gap: 4rem;
-      align-items: center;
-      position: relative;
-      overflow: hidden;
-    }
-
-    .hero-bg {
-      position: absolute;
-      inset: 0;
-      pointer-events: none;
-      overflow: hidden;
-    }
-
-    .hero-bg svg {
-      position: absolute;
-      right: -5%;
-      top: 5%;
-      width: 55%;
-      opacity: .1;
-    }
-
-    .hero-badge {
-      display: inline-flex;
-      align-items: center;
-      gap: .7rem;
-      font-size: .7rem;
-      letter-spacing: .18em;
-      text-transform: uppercase;
-      color: var(--g3);
-      margin-bottom: 2rem;
-    }
-
-    .hero-badge::before {
-      content: '';
-      display: block;
-      width: 28px;
-      height: 1px;
-      background: var(--g4);
-    }
-
-    .badge-pill {
-      background: var(--g6);
-      border: 1px solid var(--g5);
-      padding: .22rem .65rem;
-      border-radius: 20px;
-      font-size: .64rem;
-      color: var(--g2);
-    }
-
-    h1 {
-      font-family: var(--serif);
-      font-size: clamp(2.8rem, 5.5vw, 5.5rem);
-      font-weight: 400;
-      line-height: 1.08;
-      color: var(--g0);
-      margin-bottom: 2rem;
-    }
-
-    h1 em {
-      font-style: italic;
-      color: var(--g2);
-      position: relative;
-      display: inline-block;
-    }
-
-    h1 em::after {
-      content: '';
-      position: absolute;
-      bottom: .08em;
-      left: 0;
-      right: 0;
-      height: 2px;
-      background: linear-gradient(90deg, var(--g4), transparent);
-    }
-
-    .hero-desc {
-      font-size: 1.1rem;
-      color: var(--mid);
-      max-width: 42ch;
-      line-height: 1.9;
-      margin-bottom: 3rem;
-    }
-
-    /* install block */
-    .hero-install { margin-bottom: 2rem; }
-    .install-block {
-      display: inline-flex; align-items: center; gap: 1rem;
-      background: var(--g0); border-radius: 4px; padding: .9rem 1.4rem;
-      cursor: pointer; position: relative; transition: background .2s;
-    }
-    .install-block:hover { background: var(--g1); }
-    .install-block code {
-      font-family: monospace; font-size: .88rem; color: var(--g5); letter-spacing: .02em;
-    }
-    .install-prompt { color: var(--g3); margin-right: .3rem; }
-    .install-copy { color: var(--g4); opacity: .6; transition: opacity .2s; display: flex; }
-    .install-block:hover .install-copy { opacity: 1; }
-    .install-copied {
-      position: absolute; top: -1.8rem; right: 0;
-      font-size: .7rem; color: var(--g3); opacity: 0; transition: opacity .25s;
-    }
-    .install-copied.show { opacity: 1; }
-    .install-alt {
-      margin-top: .7rem; font-size: .78rem; color: var(--mid);
-    }
-    .install-alt code {
-      font-size: .78rem; background: var(--g6); padding: .15em .45em; border-radius: 3px;
-    }
-
-    .hero-actions {
-      display: flex;
-      align-items: center;
-      gap: 1.2rem;
-      flex-wrap: wrap;
-    }
-
-    .btn-fill {
-      display: inline-flex;
-      align-items: center;
-      gap: .6rem;
-      background: var(--g0);
-      color: var(--c0);
-      padding: .9rem 2rem;
-      font-size: .78rem;
-      letter-spacing: .12em;
-      text-transform: uppercase;
-      border-radius: 2px;
-      transition: background .3s, transform .2s var(--ease);
-    }
-
-    .btn-fill:hover {
-      background: var(--g1);
-      transform: translateY(-2px);
-    }
-
-    .btn-fill svg {
-      width: 14px;
-      height: 14px;
-    }
-
-    .btn-ghost {
-      font-size: .78rem;
-      letter-spacing: .1em;
-      text-transform: uppercase;
-      color: var(--g2);
-      border-bottom: 1px solid var(--g4);
-      padding-bottom: 2px;
-      transition: color .25s, border-color .25s;
-    }
-
-    .btn-ghost:hover {
-      color: var(--g0);
-      border-color: var(--g2);
-    }
-
-    /* graph visual */
-    .hero-visual {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      position: relative;
-    }
-
-    .graph-wrap {
-      width: min(460px, 100%);
-      aspect-ratio: 1;
-      position: relative;
-      margin-top: -1.5rem;
-    }
-
-    .graph-wrap svg {
-      width: 100%;
-      height: 100%;
-      position: relative;
-      z-index: 1;
-    }
-
-    .mg-edge {
-      stroke-dasharray: 420;
-      stroke-dashoffset: 420;
-      animation: draw 2s var(--ease) forwards;
-      stroke-linecap: round;
-      stroke-linejoin: round;
-    }
-
-    .mg-edge-soft {
-      stroke-dasharray: 8 10;
-      opacity: .45;
-      stroke-linecap: round;
-      stroke-linejoin: round;
-    }
-
-    .mg-feature {
-      stroke: #3d6644;
-      stroke-width: 1;
-      opacity: .62;
-    }
-
-    .mg-node {
-      filter: drop-shadow(0 8px 16px rgba(26, 51, 32, .08));
-    }
-
-    @keyframes draw {
-      to {
-        stroke-dashoffset: 0;
-      }
-    }
-
-    .mn {
-      animation: breathe 4s ease-in-out infinite;
-    }
-
-    @keyframes breathe {
-
-      0%,
-      100% {
-        opacity: .75
-      }
-
-      50% {
-        opacity: 1
-      }
-    }
-
-    .g-chip {
-      position: absolute;
-      background: var(--c0);
-      border: 1px solid var(--c2);
-      border-radius: 3px;
-      padding: .28rem .62rem;
-      font-size: .62rem;
-      letter-spacing: .07em;
-      color: var(--mid);
-      box-shadow: 0 4px 14px rgba(26, 51, 32, .06);
-      white-space: nowrap;
-      z-index: 2;
-    }
-
-    .gc1 {
-      top: 20%;
-      left: 6%
-    }
-
-    .gc2 {
-      top: 14%;
-      right: 0%
-    }
-
-    .gc3 {
-      bottom: 19%;
-      left: 1%
-    }
-
-    .gc4 {
-      bottom: 5%;
-      right: 26%;
-    }
-
-    .gc5 {
-      top: 8%;
-      left: 50%;
-      transform: translateX(-50%);
-    }
-
-    .gc6 {
-      top: 42%;
-      left: -4%;
-    }
-
-    .gc7 {
-      top: 45%;
-      right: 2%;
-    }
-
-    .gc8 {
-      bottom: 8%;
-      left: 20%;
-    }
-
-    .gc9 {
-      bottom: 22%;
-      right: 10%;
-    }
-
-    /* stat strip */
-    .hero-stats {
-      grid-column: 1 / -1;
-      display: grid;
-      grid-template-columns: repeat(3, 1fr);
-      gap: 1px;
-      background: var(--c2);
-      border: 1px solid var(--c2);
-      border-radius: 3px;
-      overflow: hidden;
-      margin-top: 1rem;
-    }
-
-    .stat-cell {
-      background: var(--c0);
-      padding: 1.6rem 2rem;
-    }
-
-    .stat-n {
-      font-family: var(--serif);
-      font-size: 2.2rem;
-      color: var(--g1);
-      line-height: 1;
-      margin-bottom: .3rem;
-    }
-
-    .stat-l {
-      font-size: .72rem;
-      letter-spacing: .1em;
-      text-transform: uppercase;
-      color: var(--mid);
-    }
-
-    /* TICKER */
-    .ticker {
-      overflow: hidden;
-      background: var(--g0);
-      padding: .9rem 0;
-      white-space: nowrap;
-    }
-
-    .ticker-track {
-      display: inline-flex;
-      animation: scroll 26s linear infinite;
-    }
-
-    .ti {
-      font-family: var(--serif);
-      font-size: 1rem;
-      font-style: italic;
-      color: var(--g5);
-      padding: 0 2.5rem;
-    }
-
-    .td {
-      color: var(--g3);
-      font-style: normal;
-      font-family: var(--sans);
-      font-size: .44rem;
-      display: inline-flex;
-      align-items: center;
-    }
-
-    @keyframes scroll {
-      to {
-        transform: translateX(-50%);
-      }
-    }
-
-    /* HOW */
-    .how {
-      padding: 8rem 3rem;
-      background: var(--c0);
-    }
-
-    .sec-hd {
-      max-width: 1100px;
-      margin: 0 auto 5rem;
-      display: flex;
-      justify-content: space-between;
-      align-items: flex-end;
-      flex-wrap: wrap;
-      gap: 2rem;
-    }
-
-    .eyebrow {
-      font-size: .7rem;
-      letter-spacing: .22em;
-      text-transform: uppercase;
-      color: var(--g3);
-      margin-bottom: 1rem;
-    }
-
-    .sec-title {
-      font-family: var(--serif);
-      font-size: clamp(2rem, 3.5vw, 3rem);
-      font-weight: 400;
-      color: var(--g0);
-      line-height: 1.2;
-    }
-
-    .sec-title em {
-      font-style: italic;
-      color: var(--g2);
-    }
-
-    .sec-sub {
-      font-size: .9rem;
-      color: var(--mid);
-      max-width: 34ch;
-      line-height: 1.8;
-    }
-
-    .steps {
-      max-width: 1100px;
-      margin: 0 auto;
-      display: grid;
-      grid-template-columns: repeat(3, 1fr);
-      border: 1px solid var(--c2);
-      border-radius: 4px;
-      overflow: hidden;
-    }
-
-    .step {
-      padding: 3.5rem 2.5rem;
-      border-right: 1px solid var(--c2);
-      position: relative;
-      transition: background .35s;
-    }
-
-    .step:last-child {
-      border-right: none;
-    }
-
-    .step:hover {
-      background: var(--g6);
-    }
-
-    .step-n {
-      font-family: var(--serif);
-      font-size: .8rem;
-      color: var(--g4);
-      margin-bottom: 2rem;
-    }
-
-    .step-icon {
-      width: 40px;
-      height: 40px;
-      color: var(--g2);
-      margin-bottom: 1.5rem;
-    }
-
-    .step-t {
-      font-family: var(--serif);
-      font-size: 1.5rem;
-      color: var(--g0);
-      margin-bottom: .8rem;
-    }
-
-    .step-b {
-      font-size: .92rem;
-      color: var(--mid);
-      line-height: 1.9;
-    }
-
-    /* FEATURES */
-    .features {
-      padding: 8rem 3rem;
-      background: var(--c1);
-    }
-
-    .bento {
-      max-width: 1100px;
-      margin: 4rem auto 0;
-      display: grid;
-      grid-template-columns: repeat(12, 1fr);
-      gap: 1rem;
-    }
-
-    .bc {
-      background: var(--c0);
-      border: 1px solid var(--c2);
-      border-radius: 4px;
-      padding: 2.5rem;
-      overflow: hidden;
-      position: relative;
-      transition: transform .35s var(--ease), box-shadow .35s;
-    }
-
-    .bc:hover {
-      transform: translateY(-3px);
-      box-shadow: 0 16px 48px rgba(26, 51, 32, .08);
-    }
-
-    .bc-1 {
-      grid-column: span 7;
-    }
-
-    .bc-2 {
-      grid-column: span 5;
-    }
-
-    .bc-3 {
-      grid-column: span 12;
-      display: grid;
-      grid-template-columns: 1.2fr 1fr;
-      gap: 3rem;
-      align-items: center;
-    }
-
-    .bc-tag {
-      font-size: .65rem;
-      letter-spacing: .18em;
-      text-transform: uppercase;
-      color: var(--g3);
-      margin-bottom: 1.2rem;
-    }
-
-    .bc-t {
-      font-family: var(--serif);
-      font-size: 1.55rem;
-      color: var(--g0);
-      line-height: 1.25;
-      margin-bottom: .8rem;
-    }
-
-    .bc-b {
-      font-size: .92rem;
-      color: var(--mid);
-      line-height: 1.85;
-    }
-
-    /* code */
-    .code-block {
-      margin-top: 1.2rem;
-      background: var(--g0);
-      border-radius: 3px;
-      padding: 1.5rem;
-    }
-
-    .code-block code {
-      font-size: .78rem;
-      color: var(--g4);
-      font-family: monospace;
-      line-height: 1.6;
-    }
-
-    .code-block .ck {
-      color: var(--c0);
-    }
-
-    .code-block .cv {
-      color: var(--g5);
-    }
-
-    /* CTA */
-    .cta {
-      padding: 9rem 3rem;
-      background: var(--c1);
-      position: relative;
-      text-align: center;
-    }
-
-    .cta-inner {
-      max-width: 680px;
-      margin: 0 auto;
-      position: relative;
-      z-index: 1;
-    }
-
-    .cta-inner h2 {
-      font-family: var(--serif);
-      font-size: clamp(2rem, 4vw, 3.4rem);
-      color: var(--g0);
-      line-height: 1.2;
-      margin-bottom: 1.2rem;
-    }
-
-    .cta-sub {
-      font-size: .92rem;
-      color: var(--mid);
-      line-height: 1.9;
-      max-width: 42ch;
-      margin: 0 auto 2.8rem;
-    }
-
-    .cta-input {
-      width: 268px;
-      padding: .85rem 1.3rem;
-      background: var(--c0);
-      border: 1px solid var(--c2);
-      border-radius: 2px;
-      outline: none;
-    }
-
-    .cta-submit {
-      padding: .85rem 2rem;
-      background: var(--g0);
-      color: var(--c0);
-      border: none;
-      border-radius: 2px;
-      cursor: pointer;
-      text-transform: uppercase;
-      letter-spacing: .1em;
-    }
-
-    .cta-submit:hover {
-      background: var(--g1);
-    }
-
-    .cta-note {
-      margin-top: 1.2rem;
-      font-size: .72rem;
-      color: var(--mid);
-      opacity: .7;
-    }
-
-    .cta-form-view { display: none; }
-    .cta-form-view.show { display: block; }
-
-    .cta-success {
-      font-family: var(--serif);
-      font-size: 1.3rem;
-      color: var(--g2);
-      margin-top: 1rem;
-    }
-
-    .cta-error {
-      font-size: .88rem;
-      color: #8b3a3a;
-      margin-top: 1rem;
-      line-height: 1.6;
-    }
-
-    .cta-back {
-      display: inline-block;
-      margin-top: 1rem;
-      padding: .6rem 1.6rem;
-      background: transparent;
-      border: 1px solid var(--c2);
-      border-radius: 2px;
-      color: var(--g0);
-      cursor: pointer;
-      font-size: .82rem;
-      text-transform: uppercase;
-      letter-spacing: .08em;
-    }
-
-    .cta-back:hover { background: var(--c0); }
-    .cta-submit:disabled { opacity: .7; cursor: not-allowed; }
-
-    /* FOOTER */
-    footer {
-      background: var(--g0);
-      color: var(--g5);
-      padding: 4rem 3rem 2rem;
-      text-align: center;
-    }
-
-    .foot-bottom {
-      padding-top: 1.8rem;
-      border-top: 1px solid rgba(196, 221, 199, .1);
-    }
-
-    /* REVEAL */
-    .sr {
-      opacity: 0;
-      transform: translateY(20px);
-      transition: 0.8s var(--ease);
-    }
-
-    .sr.in {
-      opacity: 1;
-      transform: none;
-    }    @media(max-width:900px){
-      html, body { overflow-x: hidden; width: 100%; -webkit-text-size-adjust: 100%; }
-      
-      nav { padding: .8rem 1.2rem; }
-      .nav-links { display: none; }
-      .nav-btn { padding: .5rem 1rem; font-size: .65rem; }
-      
-      h1 { font-size: 2.4rem !important; line-height: 1.1; word-wrap: break-word; }
-      .hero { grid-template-columns: 1fr; text-align: center; padding: 6rem 1.2rem 3rem; }
-      .hero-badge { flex-wrap: wrap; justify-content: center; line-height: 1.6; }
-      .hero-desc { margin: 0 auto 2rem; font-size: 0.95rem; }
-      .hero-install { display: flex; flex-direction: column; align-items: center; }
-      .install-block { width: 100%; box-sizing: border-box; justify-content: center; }
-      .hero-actions { justify-content: center; flex-direction: column; gap: 1rem; width: 100%; }
-      .btn-fill, .btn-ghost { width: 100%; justify-content: center; box-sizing: border-box; }
-      
-      .hero-visual { order: -1; margin-bottom: 1rem; max-width: 100%; }
-      .graph-wrap { width: min(340px, 100%); margin-top: 0; }
-      .g-chip { display: none; }
-      
-      .hero-stats { grid-template-columns: 1fr; margin-top: 1.5rem; }
-      .stat-cell { padding: 1.2rem; }
-      
-      .how, .features, .cta { padding: 4rem 1.2rem; overflow: hidden; }
-      footer { padding: 3rem 1.2rem 1.5rem; text-align: center; }
-      
-      .sec-hd { margin-bottom: 2rem; justify-content: center; text-align: center; }
-      .sec-title { font-size: 2rem !important; word-wrap: break-word; }
-      
-      .steps { grid-template-columns: 1fr; max-width: 100%; }
-      .step { border-right: none; border-bottom: 1px solid var(--c2); padding: 2rem 1.2rem; text-align: center; min-width: 0; }
-      .step-icon { margin: 0 auto 1.5rem; }
-      .step:last-child { border-bottom: none; }
-      
-      .bento { grid-template-columns: 1fr; gap: 1.2rem; margin-top: 2rem; max-width: 100%; }
-      .bc { padding: 1.5rem; min-width: 0; }
-      .bc-1, .bc-2, .bc-3 { grid-column: span 1; }
-      .bc-3 { grid-template-columns: 1fr; gap: 1.5rem; }
-      
-      .code-block { padding: 1rem; width: 100%; box-sizing: border-box; overflow-x: auto; }
-      .code-block code { font-size: 0.75rem; white-space: pre; }
-      
-      .cta-form { display: flex; flex-direction: column; align-items: center; gap: 0.8rem; width: 100%; }
-      .cta-input, .cta-submit, .cta-back { width: 100%; max-width: none; box-sizing: border-box; }
-    }
-
-    @media(pointer: coarse), (max-width: 768px) {
-      body { cursor: auto; }
-      .cursor { display: none; }
-    }
-  </style>
+  <link rel="stylesheet" href="theme.css" />
 </head>
 
 <body>
@@ -919,7 +26,7 @@
   <!-- NAV -->
   <nav>
     <div class="nav-left">
-      <a href="#" class="logo" style="display: flex; align-items: center; text-decoration: none;">
+      <a href="#" class="logo">
         <img src="brand-mark.svg?v=6" alt="Lore.AI" style="height: 78px; width: auto; display: block;" />
       </a>
     </div>
@@ -928,7 +35,8 @@
         <li><a href="#problem">The Problem</a></li>
         <li><a href="#how">How It Works</a></li>
         <li><a href="#features">Features</a></li>
-        <li><a href="https://github.com/byk/loreai" target="_blank">GitHub</a></li>
+        <li><a href="different.html">Why Lore</a></li>
+        <li><a href="https://github.com/byk/loreai" target="_blank" rel="noopener noreferrer">GitHub</a></li>
       </ul>
       <a href="#waitlist" class="nav-btn">Lore Cloud Waitlist</a>
     </div>
@@ -974,7 +82,7 @@
             <path d="M2 7h10M7 2l5 5-5 5" />
           </svg>
         </a>
-        <a href="https://github.com/byk/loreai" target="_blank" class="btn-ghost">View Repository</a>
+        <a href="https://github.com/byk/loreai" target="_blank" rel="noopener noreferrer" class="btn-ghost">View Repository</a>
       </div>
     </div>
 
@@ -1071,7 +179,7 @@
       <p class="sec-sub sr">There's no error message when your AI forgets.
         Just worse answers, undone decisions, and
         <a href="https://devblogs.microsoft.com/all-things-azure/i-wasted-68-minutes-a-day-re-explaining-my-code-then-i-built-auto-memory/"
-          target="_blank" style="border-bottom:1px solid var(--g4);color:var(--g2)">hours spent re-explaining</a>.</p>
+          target="_blank" rel="noopener noreferrer" style="border-bottom:1px solid var(--g4);color:var(--g2)">hours spent re-explaining</a>.</p>
     </div>
     <div class="steps">
       <div class="step sr">
@@ -1079,7 +187,7 @@
         <h3 class="step-t">Compaction destroys details</h3>
         <p class="step-b">When the context window fills up, your AI tool
           <a href="https://www.oreilly.com/radar/why-doesnt-anyone-teach-developers-about-context-management/"
-            target="_blank" style="border-bottom:1px solid var(--g4)">compacts the conversation</a>.
+            target="_blank" rel="noopener noreferrer" style="border-bottom:1px solid var(--g4)">compacts the conversation</a>.
           In a real 5-day coding session, compaction reduces 2.3 million tokens to an 11K summary — a 200x
           compression that loses which issues were picked, what alternatives were rejected, and why.
           It scores 2.4/5 on recall. Lore scores 4.0/5.</p>
@@ -1089,7 +197,7 @@
         <h3 class="step-t">Starting fresh is starting from zero</h3>
         <p class="step-b">Most developers see "Compacting conversation" and start a new session. That
           <a href="https://newsletter.pragmaticengineer.com/p/microsoft-ai-dev-tools"
-            target="_blank" style="border-bottom:1px solid var(--g4)">trades compaction for total amnesia</a>.
+            target="_blank" rel="noopener noreferrer" style="border-bottom:1px solid var(--g4)">trades compaction for total amnesia</a>.
           The new session produces output that looks fine — but it's working
           from incomplete information, and you can't tell.</p>
       </div>
@@ -1099,7 +207,7 @@
         <p class="step-b">The alternative is maintaining context files, key technical learnings, and decision
           rationales — by hand. It works, but it's a second full-time job. One team
           <a href="https://www.oreilly.com/radar/why-doesnt-anyone-teach-developers-about-context-management/"
-            target="_blank" style="border-bottom:1px solid var(--g4)">tracked 49 technical
+            target="_blank" rel="noopener noreferrer" style="border-bottom:1px solid var(--g4)">tracked 49 technical
           learnings manually</a>. Every decision needs the "why" or the AI will refactor it away.</p>
       </div>
     </div>
@@ -1148,7 +256,8 @@
         <h2 class="sec-title sr">Context management and memory are <em>the same problem.</em></h2>
       </div>
       <p class="sec-sub sr">Other tools force you to solve them separately.
-        Lore treats them as one continuous pipeline.</p>
+        Lore treats them as one continuous pipeline.
+        <a href="different.html" style="border-bottom:1px solid var(--g4);color:var(--g2)">See how Lore compares &rarr;</a></p>
     </div>
     <div class="steps">
       <div class="step sr">
@@ -1166,14 +275,14 @@
           is extracted from the compression. Start a new session and you're back to zero. Switch tools
           and the knowledge stays behind. Nothing transfers to other projects, team members,
           or <a href="https://arxiv.org/abs/2603.28052"
-          target="_blank" style="border-bottom:1px solid var(--g4)">even other models</a>.</p>
+          target="_blank" rel="noopener noreferrer" style="border-bottom:1px solid var(--g4)">even other models</a>.</p>
       </div>
       <div class="step sr">
         <div class="step-n">03</div>
         <h3 class="step-t">Lore connects them into one pipeline</h3>
         <p class="step-b">In Lore, context compression <em>is</em> the memory pipeline. Distillation
           feeds the gradient context manager, which feeds the knowledge curator, which feeds
-          <code style="font-size:.85em;background:var(--g6);padding:.15em .4em;border-radius:3px;">.lore.md</code>
+          <code class="code-inline">.lore.md</code>
           — and with Lore Cloud, your team. Every conversation makes every future session smarter,
           across any provider, any tool, any team member.</p>
       </div>
@@ -1196,9 +305,9 @@
         <p class="bc-b">Five feedback loops — behavioral pattern detection, semantic clustering,
           instruction capture, LLM-mediated curation, and adaptive calibration —
           compound across sessions. Patterns, gotchas, and decisions are automatically curated and exported to
-          <code style="font-size:.85em;background:var(--g6);padding:.15em .4em;border-radius:3px;">.lore.md</code>,
+          <code class="code-inline">.lore.md</code>,
           git-portable and model-agnostic. What <a href="https://arxiv.org/abs/2605.27276"
-          target="_blank" style="border-bottom:1px solid var(--g4)">researchers call</a>
+          target="_blank" rel="noopener noreferrer" style="border-bottom:1px solid var(--g4)">researchers call</a>
           "harness self-improvement" — Lore does it automatically.</p>
       </div>
       <div class="bc bc-3 sr">
@@ -1244,8 +353,10 @@
         <p class="bc-tag">Compatibility</p>
         <h3 class="bc-t">Your constant</h3>
         <p class="bc-b">Claude Code, Cursor, Copilot, Windsurf, OpenCode, Pi, Codex — any tool that speaks
-          Anthropic or OpenAI protocols. Switch providers, switch tools, switch machines — your memory travels
-          with you. No vendor lock-in, no walled gardens.
+          Anthropic or OpenAI protocols. No new terminal, IDE, or cloud platform to adopt — just a one-line
+          base-URL change. The engine runs locally and is source-available; your data stays on your machine.
+          Switch providers, switch tools, switch machines — your memory travels with you. No vendor lock-in,
+          no walled gardens.
           <span style="display:block;margin-top:.6rem;font-size:.78rem;opacity:.7">* Any provider accessible
           via an OpenAI or Anthropic-compatible API.</span></p>
       </div>
@@ -1281,7 +392,7 @@
           end that will actually go wrong if you skip it."
         </h3>
         <p class="step-b"><a href="https://www.oreilly.com/radar/why-doesnt-anyone-teach-developers-about-context-management/"
-          target="_blank" style="border-bottom:1px solid var(--g4)">Andrew Stellman</a> — on why context management
+          target="_blank" rel="noopener noreferrer" style="border-bottom:1px solid var(--g4)">Andrew Stellman</a> — on why context management
           is the most important undiscussed skill in AI-driven development.</p>
       </div>
       <div class="step sr">
@@ -1293,7 +404,7 @@
           AI agents."
         </h3>
         <p class="step-b"><a href="https://newsletter.pragmaticengineer.com/p/microsoft-ai-dev-tools"
-          target="_blank" style="border-bottom:1px solid var(--g4)">Gergely Orosz</a> — on Microsoft's internal
+          target="_blank" rel="noopener noreferrer" style="border-bottom:1px solid var(--g4)">Gergely Orosz</a> — on Microsoft's internal
           experience with AI coding tools and the gap between demos and real codebases.</p>
       </div>
       <div class="step sr">
@@ -1304,7 +415,7 @@
           to store, retrieve, and present to the model."
         </h3>
         <p class="step-b"><a href="https://arxiv.org/abs/2603.28052"
-          target="_blank" style="border-bottom:1px solid var(--g4)">Meta-Harness</a> (Stanford, 2026) —
+          target="_blank" rel="noopener noreferrer" style="border-bottom:1px solid var(--g4)">Meta-Harness</a> (Stanford, 2026) —
           on why optimizing what context the model sees matters as much as the model itself.
           Lore is this optimization layer for coding agents.</p>
       </div>

--- a/docs/theme.css
+++ b/docs/theme.css
@@ -1,0 +1,957 @@
+/* Lore.AI shared theme — used by index.html, different.html, etc. */
+
+:root {
+  --c0: #f7f2e8;
+  --c1: #ede5d0;
+  --c2: #dfd5bb;
+  --g0: #1a3320;
+  --g1: #2a4d32;
+  --g2: #3d6644;
+  --g3: #5a8f63;
+  --g4: #8fba96;
+  --g5: #c4ddc7;
+  --g6: #e8f2e9;
+  --ink: #1a2e1b;
+  --mid: #4a5f4c;
+  --serif: 'Playfair Display', Georgia, serif;
+  --sans: 'DM Sans', sans-serif;
+  --ease: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  background: var(--c0);
+  color: var(--ink);
+  font-family: var(--sans);
+  font-weight: 300;
+  font-size: 1.08rem;
+  line-height: 1.75;
+  overflow-x: hidden;
+  cursor: none;
+}
+
+.cursor {
+  position: fixed;
+  width: 8px;
+  height: 8px;
+  background: var(--g2);
+  border-radius: 50%;
+  pointer-events: none;
+  z-index: 9999;
+  transform: translate(-50%, -50%);
+  transition: width .3s var(--ease), height .3s var(--ease), background .3s;
+}
+
+.cursor.expand {
+  width: 36px;
+  height: 36px;
+  background: transparent;
+  border: 1px solid var(--g3);
+}
+
+body::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='300' height='300'%3E%3Cfilter id='g'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.75' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='300' height='300' filter='url(%23g)' opacity='0.035'/%3E%3C/svg%3E");
+  pointer-events: none;
+  z-index: 9998;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+/* NAV */
+nav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 500;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: .45rem 3rem;
+  background: var(--ink);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  color: var(--c0);
+}
+
+.nav-left {
+  display: flex;
+  align-items: center;
+}
+
+.nav-right {
+  display: flex;
+  align-items: center;
+  gap: 2.4rem;
+}
+
+.logo {
+  display: flex;
+  align-items: center;
+  gap: .5rem;
+  color: var(--c0);
+  transition: color 0.3s ease;
+}
+
+.logo:hover {
+  color: var(--g5);
+}
+
+.logo-img {
+  height: 56px;
+  width: auto;
+  display: block;
+}
+
+.logo-text {
+  font-family: var(--serif);
+}
+
+.logo-dot {
+  width: 6px;
+  height: 6px;
+  background: var(--g3);
+  border-radius: 50%;
+  animation: pulse 3s ease-in-out infinite;
+}
+
+@keyframes pulse {
+
+  0%,
+  100% {
+    opacity: 1;
+    transform: scale(1)
+  }
+
+  50% {
+    opacity: .5;
+    transform: scale(.7)
+  }
+}
+
+.nav-links {
+  display: flex;
+  gap: 2.2rem;
+  list-style: none;
+  font-size: 1rem;
+  font-family: var(--sans);
+  color: rgba(247, 242, 232, 0.8);
+  font-weight: 400;
+}
+
+.nav-links a {
+  transition: color .25s;
+}
+
+.nav-links a:hover {
+  color: var(--c0);
+}
+
+.nav-btn {
+  font-size: 1rem;
+  font-family: var(--sans);
+  font-weight: 400;
+  padding: .6rem 1.6rem;
+  background: var(--c0);
+  color: var(--ink);
+  border-radius: 3px;
+  transition: background .3s, color .3s;
+}
+
+.nav-btn:hover {
+  background: var(--g5);
+  color: var(--ink);
+}
+
+/* HERO */
+.hero {
+  min-height: 100svh;
+  padding: 10rem 3rem 5rem;
+  display: grid;
+  grid-template-columns: 1.1fr 1fr;
+  gap: 4rem;
+  align-items: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.hero-bg {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+}
+
+.hero-bg svg {
+  position: absolute;
+  right: -5%;
+  top: 5%;
+  width: 55%;
+  opacity: .1;
+}
+
+.hero-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: .7rem;
+  font-size: .7rem;
+  letter-spacing: .18em;
+  text-transform: uppercase;
+  color: var(--g3);
+  margin-bottom: 2rem;
+}
+
+.hero-badge::before {
+  content: '';
+  display: block;
+  width: 28px;
+  height: 1px;
+  background: var(--g4);
+}
+
+.badge-pill {
+  background: var(--g6);
+  border: 1px solid var(--g5);
+  padding: .22rem .65rem;
+  border-radius: 20px;
+  font-size: .64rem;
+  color: var(--g2);
+}
+
+h1 {
+  font-family: var(--serif);
+  font-size: clamp(2.8rem, 5.5vw, 5.5rem);
+  font-weight: 400;
+  line-height: 1.08;
+  color: var(--g0);
+  margin-bottom: 2rem;
+}
+
+h1 em {
+  font-style: italic;
+  color: var(--g2);
+  position: relative;
+  display: inline-block;
+}
+
+h1 em::after {
+  content: '';
+  position: absolute;
+  bottom: .08em;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: linear-gradient(90deg, var(--g4), transparent);
+}
+
+.hero-desc {
+  font-size: 1.1rem;
+  color: var(--mid);
+  max-width: 42ch;
+  line-height: 1.9;
+  margin-bottom: 3rem;
+}
+
+/* install block */
+.hero-install { margin-bottom: 2rem; }
+.install-block {
+  display: inline-flex; align-items: center; gap: 1rem;
+  background: var(--g0); border-radius: 4px; padding: .9rem 1.4rem;
+  cursor: pointer; position: relative; transition: background .2s;
+}
+.install-block:hover { background: var(--g1); }
+.install-block code {
+  font-family: monospace; font-size: .88rem; color: var(--g5); letter-spacing: .02em;
+}
+.install-prompt { color: var(--g3); margin-right: .3rem; }
+.install-copy { color: var(--g4); opacity: .6; transition: opacity .2s; display: flex; }
+.install-block:hover .install-copy { opacity: 1; }
+.install-copied {
+  position: absolute; top: -1.8rem; right: 0;
+  font-size: .7rem; color: var(--g3); opacity: 0; transition: opacity .25s;
+}
+.install-copied.show { opacity: 1; }
+.install-alt {
+  margin-top: .7rem; font-size: .78rem; color: var(--mid);
+}
+.install-alt code {
+  font-size: .78rem; background: var(--g6); padding: .15em .45em; border-radius: 3px;
+}
+
+.hero-actions {
+  display: flex;
+  align-items: center;
+  gap: 1.2rem;
+  flex-wrap: wrap;
+}
+
+.btn-fill {
+  display: inline-flex;
+  align-items: center;
+  gap: .6rem;
+  background: var(--g0);
+  color: var(--c0);
+  padding: .9rem 2rem;
+  font-size: .78rem;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  border-radius: 2px;
+  transition: background .3s, transform .2s var(--ease);
+}
+
+.btn-fill:hover {
+  background: var(--g1);
+  transform: translateY(-2px);
+}
+
+.btn-fill svg {
+  width: 14px;
+  height: 14px;
+}
+
+.btn-ghost {
+  font-size: .78rem;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  color: var(--g2);
+  border-bottom: 1px solid var(--g4);
+  padding-bottom: 2px;
+  transition: color .25s, border-color .25s;
+}
+
+.btn-ghost:hover {
+  color: var(--g0);
+  border-color: var(--g2);
+}
+
+/* graph visual */
+.hero-visual {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+}
+
+.graph-wrap {
+  width: min(460px, 100%);
+  aspect-ratio: 1;
+  position: relative;
+  margin-top: -1.5rem;
+}
+
+.graph-wrap svg {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 1;
+}
+
+.mg-edge {
+  stroke-dasharray: 420;
+  stroke-dashoffset: 420;
+  animation: draw 2s var(--ease) forwards;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.mg-edge-soft {
+  stroke-dasharray: 8 10;
+  opacity: .45;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.mg-feature {
+  stroke: #3d6644;
+  stroke-width: 1;
+  opacity: .62;
+}
+
+.mg-node {
+  filter: drop-shadow(0 8px 16px rgba(26, 51, 32, .08));
+}
+
+@keyframes draw {
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+
+.mn {
+  animation: breathe 4s ease-in-out infinite;
+}
+
+@keyframes breathe {
+
+  0%,
+  100% {
+    opacity: .75
+  }
+
+  50% {
+    opacity: 1
+  }
+}
+
+.g-chip {
+  position: absolute;
+  background: var(--c0);
+  border: 1px solid var(--c2);
+  border-radius: 3px;
+  padding: .28rem .62rem;
+  font-size: .62rem;
+  letter-spacing: .07em;
+  color: var(--mid);
+  box-shadow: 0 4px 14px rgba(26, 51, 32, .06);
+  white-space: nowrap;
+  z-index: 2;
+}
+
+.gc1 { top: 20%; left: 6% }
+.gc2 { top: 14%; right: 0% }
+.gc3 { bottom: 19%; left: 1% }
+.gc4 { bottom: 5%; right: 26%; }
+.gc5 { top: 8%; left: 50%; transform: translateX(-50%); }
+.gc6 { top: 42%; left: -4%; }
+.gc7 { top: 45%; right: 2%; }
+.gc8 { bottom: 8%; left: 20%; }
+.gc9 { bottom: 22%; right: 10%; }
+
+/* stat strip */
+.hero-stats {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1px;
+  background: var(--c2);
+  border: 1px solid var(--c2);
+  border-radius: 3px;
+  overflow: hidden;
+  margin-top: 1rem;
+}
+
+.stat-cell {
+  background: var(--c0);
+  padding: 1.6rem 2rem;
+}
+
+.stat-n {
+  font-family: var(--serif);
+  font-size: 2.2rem;
+  color: var(--g1);
+  line-height: 1;
+  margin-bottom: .3rem;
+}
+
+.stat-l {
+  font-size: .72rem;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  color: var(--mid);
+}
+
+/* TICKER */
+.ticker {
+  overflow: hidden;
+  background: var(--g0);
+  padding: .9rem 0;
+  white-space: nowrap;
+}
+
+.ticker-track {
+  display: inline-flex;
+  animation: scroll 26s linear infinite;
+}
+
+.ti {
+  font-family: var(--serif);
+  font-size: 1rem;
+  font-style: italic;
+  color: var(--g5);
+  padding: 0 2.5rem;
+}
+
+.td {
+  color: var(--g3);
+  font-style: normal;
+  font-family: var(--sans);
+  font-size: .44rem;
+  display: inline-flex;
+  align-items: center;
+}
+
+@keyframes scroll {
+  to {
+    transform: translateX(-50%);
+  }
+}
+
+/* HOW / generic section */
+.how {
+  padding: 8rem 3rem;
+  background: var(--c0);
+}
+
+.sec-hd {
+  max-width: 1100px;
+  margin: 0 auto 5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  gap: 2rem;
+}
+
+.eyebrow {
+  font-size: .7rem;
+  letter-spacing: .22em;
+  text-transform: uppercase;
+  color: var(--g3);
+  margin-bottom: 1rem;
+}
+
+.sec-title {
+  font-family: var(--serif);
+  font-size: clamp(2rem, 3.5vw, 3rem);
+  font-weight: 400;
+  color: var(--g0);
+  line-height: 1.2;
+}
+
+.sec-title em {
+  font-style: italic;
+  color: var(--g2);
+}
+
+.sec-sub {
+  font-size: .9rem;
+  color: var(--mid);
+  max-width: 34ch;
+  line-height: 1.8;
+}
+
+.steps {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  border: 1px solid var(--c2);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.step {
+  padding: 3.5rem 2.5rem;
+  border-right: 1px solid var(--c2);
+  position: relative;
+  transition: background .35s;
+}
+
+.step:last-child {
+  border-right: none;
+}
+
+.step:hover {
+  background: var(--g6);
+}
+
+.step-n {
+  font-family: var(--serif);
+  font-size: .8rem;
+  color: var(--g4);
+  margin-bottom: 2rem;
+}
+
+.step-icon {
+  width: 40px;
+  height: 40px;
+  color: var(--g2);
+  margin-bottom: 1.5rem;
+}
+
+.step-t {
+  font-family: var(--serif);
+  font-size: 1.5rem;
+  color: var(--g0);
+  margin-bottom: .8rem;
+}
+
+.step-b {
+  font-size: .92rem;
+  color: var(--mid);
+  line-height: 1.9;
+}
+
+/* FEATURES */
+.features {
+  padding: 8rem 3rem;
+  background: var(--c1);
+}
+
+.bento {
+  max-width: 1100px;
+  margin: 4rem auto 0;
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 1rem;
+}
+
+.bc {
+  background: var(--c0);
+  border: 1px solid var(--c2);
+  border-radius: 4px;
+  padding: 2.5rem;
+  overflow: hidden;
+  position: relative;
+  transition: transform .35s var(--ease), box-shadow .35s;
+}
+
+.bc:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 16px 48px rgba(26, 51, 32, .08);
+}
+
+.bc-1 { grid-column: span 7; }
+.bc-2 { grid-column: span 5; }
+
+.bc-3 {
+  grid-column: span 12;
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: 3rem;
+  align-items: center;
+}
+
+.bc-tag {
+  font-size: .65rem;
+  letter-spacing: .18em;
+  text-transform: uppercase;
+  color: var(--g3);
+  margin-bottom: 1.2rem;
+}
+
+.bc-t {
+  font-family: var(--serif);
+  font-size: 1.55rem;
+  color: var(--g0);
+  line-height: 1.25;
+  margin-bottom: .8rem;
+}
+
+.bc-b {
+  font-size: .92rem;
+  color: var(--mid);
+  line-height: 1.85;
+}
+
+/* code */
+.code-block {
+  margin-top: 1.2rem;
+  background: var(--g0);
+  border-radius: 3px;
+  padding: 1.5rem;
+}
+
+.code-block code {
+  font-size: .78rem;
+  color: var(--g4);
+  font-family: monospace;
+  line-height: 1.6;
+}
+
+.code-block .ck {
+  color: var(--c0);
+}
+
+.code-block .cv {
+  color: var(--g5);
+}
+
+/* Inline code highlight */
+.code-inline {
+  font-size: .85em;
+  background: var(--g6);
+  padding: .15em .4em;
+  border-radius: 3px;
+}
+
+/* Compact hero variant (used by different.html) */
+.hero-compact {
+  grid-template-columns: 1fr;
+  place-items: center;
+  text-align: center;
+  min-height: auto;
+  padding: 11rem 3rem 5rem;
+}
+
+/* COMPARISON TABLE (used by different.html) */
+.cmp-wrap {
+  max-width: 1100px;
+  margin: 0 auto;
+  border: 1px solid var(--c2);
+  border-radius: 4px;
+  overflow: hidden;
+  background: var(--c0);
+}
+
+.cmp {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: .92rem;
+}
+
+.cmp thead th {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: 1rem;
+  color: var(--g0);
+  text-align: left;
+  padding: 1.4rem 1.6rem;
+  background: var(--g6);
+  border-bottom: 1px solid var(--c2);
+  vertical-align: bottom;
+}
+
+.cmp thead th.cmp-lore {
+  color: var(--g1);
+}
+
+.cmp thead th .cmp-eyebrow {
+  display: block;
+  font-family: var(--sans);
+  font-size: .62rem;
+  letter-spacing: .16em;
+  text-transform: uppercase;
+  color: var(--g3);
+  margin-bottom: .3rem;
+}
+
+.cmp tbody th {
+  font-family: var(--sans);
+  font-weight: 500;
+  text-align: left;
+  color: var(--g0);
+  padding: 1.2rem 1.6rem;
+  width: 26%;
+  border-bottom: 1px solid var(--c2);
+  border-right: 1px solid var(--c2);
+  background: var(--c1);
+  vertical-align: top;
+}
+
+.cmp tbody td {
+  padding: 1.2rem 1.6rem;
+  color: var(--mid);
+  border-bottom: 1px solid var(--c2);
+  border-right: 1px solid var(--c2);
+  vertical-align: top;
+  line-height: 1.7;
+}
+
+.cmp tbody td:last-child {
+  border-right: none;
+}
+
+.cmp tbody td.cmp-lore {
+  background: var(--g6);
+  color: var(--g1);
+}
+
+.cmp tbody tr:last-child th,
+.cmp tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.cmp-yes { color: var(--g2); font-weight: 500; }
+
+/* CTA */
+.cta {
+  padding: 9rem 3rem;
+  background: var(--c1);
+  position: relative;
+  text-align: center;
+}
+
+.cta-inner {
+  max-width: 680px;
+  margin: 0 auto;
+  position: relative;
+  z-index: 1;
+}
+
+.cta-inner h2 {
+  font-family: var(--serif);
+  font-size: clamp(2rem, 4vw, 3.4rem);
+  color: var(--g0);
+  line-height: 1.2;
+  margin-bottom: 1.2rem;
+}
+
+.cta-sub {
+  font-size: .92rem;
+  color: var(--mid);
+  line-height: 1.9;
+  max-width: 42ch;
+  margin: 0 auto 2.8rem;
+}
+
+.cta-input {
+  width: 268px;
+  padding: .85rem 1.3rem;
+  background: var(--c0);
+  border: 1px solid var(--c2);
+  border-radius: 2px;
+  outline: none;
+}
+
+.cta-submit {
+  padding: .85rem 2rem;
+  background: var(--g0);
+  color: var(--c0);
+  border: none;
+  border-radius: 2px;
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: .1em;
+}
+
+.cta-submit:hover {
+  background: var(--g1);
+}
+
+.cta-note {
+  margin-top: 1.2rem;
+  font-size: .72rem;
+  color: var(--mid);
+  opacity: .7;
+}
+
+.cta-form-view { display: none; }
+.cta-form-view.show { display: block; }
+
+.cta-success {
+  font-family: var(--serif);
+  font-size: 1.3rem;
+  color: var(--g2);
+  margin-top: 1rem;
+}
+
+.cta-error {
+  font-size: .88rem;
+  color: #8b3a3a;
+  margin-top: 1rem;
+  line-height: 1.6;
+}
+
+.cta-back {
+  display: inline-block;
+  margin-top: 1rem;
+  padding: .6rem 1.6rem;
+  background: transparent;
+  border: 1px solid var(--c2);
+  border-radius: 2px;
+  color: var(--g0);
+  cursor: pointer;
+  font-size: .82rem;
+  text-transform: uppercase;
+  letter-spacing: .08em;
+}
+
+.cta-back:hover { background: var(--c0); }
+.cta-submit:disabled { opacity: .7; cursor: not-allowed; }
+
+/* FOOTER */
+footer {
+  background: var(--g0);
+  color: var(--g5);
+  padding: 4rem 3rem 2rem;
+  text-align: center;
+}
+
+.foot-bottom {
+  padding-top: 1.8rem;
+  border-top: 1px solid rgba(196, 221, 199, .1);
+}
+
+/* REVEAL */
+.sr {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: 0.8s var(--ease);
+}
+
+.sr.in {
+  opacity: 1;
+  transform: none;
+}
+
+@media(max-width:900px){
+  html, body { overflow-x: hidden; width: 100%; -webkit-text-size-adjust: 100%; }
+
+  nav { padding: .8rem 1.2rem; }
+  .nav-links { display: none; }
+  .nav-btn { padding: .5rem 1rem; font-size: .65rem; }
+
+  h1 { font-size: 2.4rem !important; line-height: 1.1; word-wrap: break-word; }
+  .hero { grid-template-columns: 1fr; text-align: center; padding: 6rem 1.2rem 3rem; }
+  .hero-compact { padding: 6rem 1.2rem 3rem; }
+  .hero-badge { flex-wrap: wrap; justify-content: center; line-height: 1.6; }
+  .hero-desc { margin: 0 auto 2rem; font-size: 0.95rem; }
+  .hero-install { display: flex; flex-direction: column; align-items: center; }
+  .install-block { width: 100%; box-sizing: border-box; justify-content: center; }
+  .hero-actions { justify-content: center; flex-direction: column; gap: 1rem; width: 100%; }
+  .btn-fill, .btn-ghost { width: 100%; justify-content: center; box-sizing: border-box; }
+
+  .hero-visual { order: -1; margin-bottom: 1rem; max-width: 100%; }
+  .graph-wrap { width: min(340px, 100%); margin-top: 0; }
+  .g-chip { display: none; }
+
+  .hero-stats { grid-template-columns: 1fr; margin-top: 1.5rem; }
+  .stat-cell { padding: 1.2rem; }
+
+  .how, .features, .cta { padding: 4rem 1.2rem; overflow: hidden; }
+  footer { padding: 3rem 1.2rem 1.5rem; text-align: center; }
+
+  .sec-hd { margin-bottom: 2rem; justify-content: center; text-align: center; }
+  .sec-title { font-size: 2rem !important; word-wrap: break-word; }
+
+  .steps { grid-template-columns: 1fr; max-width: 100%; }
+  .step { border-right: none; border-bottom: 1px solid var(--c2); padding: 2rem 1.2rem; text-align: center; min-width: 0; }
+  .step-icon { margin: 0 auto 1.5rem; }
+  .step:last-child { border-bottom: none; }
+
+  .bento { grid-template-columns: 1fr; gap: 1.2rem; margin-top: 2rem; max-width: 100%; }
+  .bc { padding: 1.5rem; min-width: 0; }
+  .bc-1, .bc-2, .bc-3 { grid-column: span 1; }
+  .bc-3 { grid-template-columns: 1fr; gap: 1.5rem; }
+
+  .code-block { padding: 1rem; width: 100%; box-sizing: border-box; overflow-x: auto; }
+  .code-block code { font-size: 0.75rem; white-space: pre; }
+
+  .cmp-wrap { overflow-x: auto; }
+  .cmp { min-width: 640px; }
+
+  .cta-form { display: flex; flex-direction: column; align-items: center; gap: 0.8rem; width: 100%; }
+  .cta-input, .cta-submit, .cta-back { width: 100%; max-width: none; box-sizing: border-box; }
+}
+
+@media(pointer: coarse), (max-width: 768px) {
+  body { cursor: auto; }
+  .cursor { display: none; }
+}


### PR DESCRIPTION
## Summary

Adds a dedicated **"Why Lore"** page to the marketing site (`withlore.ai`) that explains what makes Lore different and lightly compares it to the common categories of agent-memory tools — framed positively, not as competitor-bashing. Also refactors the shared theme out of `index.html` into a single stylesheet now that the site has more than one page.

Motivation: competitors are increasingly marketing "cross-harness agent memory." This page sharpens Lore's positioning around its genuine, verified differentiators rather than reacting defensively.

## Changes

- **`docs/theme.css` (new)** — Extracted the entire shared style block from `index.html` into one stylesheet that both pages link. Editing the theme is now a single-file change (no build step; browsers cache across pages). Added comparison-table styles for the new page.
- **`docs/different.html` (new)** — "What makes Lore different":
  - Three pillars: memory **and** context in one pipeline; local-first + source-available; works with your existing agent (no platform to adopt).
  - **Comparison table** using *category framing, no competitor names*: memory-only, context-only, tool/IDE-bound, and cloud agent platforms — each with "what it does well / the trade-off / where Lore differs", plus an explicit "these are categories, not a scorecard" disclaimer.
  - Portability (`.lore.md` as a readable, git-versioned file you keep even if you stop using Lore) and a teams section (git-based sharing today, Lore Cloud as an option on top).
- **`docs/index.html`** — Replaced the inline `<style>` block with a `theme.css` link; added a "Why Lore" nav link + a "See how Lore compares →" link; lightly sharpened the compatibility card to foreground local-first / source-available / no-platform-lock-in.

## Notes

- All claims are ones we verified (local-first proxy, source-available engine, any-harness via base-URL, git-native `.lore.md`). No unverifiable claims about competitors.
- Pure static-site/docs change — no code, no tests affected.

## Verification

- HTML tag balance checks pass on both pages.
- All local links resolve; cross-page anchors (`#problem/#how/#features/#waitlist`) exist; all referenced assets present.
- Both pages link `theme.css`; zero inline `<style>` remains in `index.html`.
- Preview locally: `python3 -m http.server` in `docs/`, then open `/` and `/different.html`.