### PR TITLE
fix(core): clean up knowledge_transfers on entry removal

### DIFF
--- a/packages/core/src/data.ts
+++ b/packages/core/src/data.ts
@@ -522,6 +522,12 @@ export function clearKnowledge(projectPath: string): number {
       .get(pid) as { c: number }
   ).c;
 
+  // Clean up transfer metrics before deleting entries (no FK CASCADE).
+  db()
+    .query(
+      "DELETE FROM knowledge_transfers WHERE knowledge_id IN (SELECT id FROM knowledge WHERE project_id = ?)",
+    )
+    .run(pid);
   db().query("DELETE FROM knowledge WHERE project_id = ?").run(pid);
 
   // Regenerate .lore.md

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -226,6 +226,8 @@ export function update(
 }
 
 export function remove(id: string) {
+  // Clean up transfer metrics before deleting the entry (no FK CASCADE).
+  db().query("DELETE FROM knowledge_transfers WHERE knowledge_id = ?").run(id);
   db().query("DELETE FROM knowledge WHERE id = ?").run(id);
 }
 

--- a/packages/core/test/knowledge-transfers.test.ts
+++ b/packages/core/test/knowledge-transfers.test.ts
@@ -266,4 +266,24 @@ describe("transfer cleanup on project deletion", () => {
       .get(id) as { c: number };
     expect(remaining.c).toBe(0);
   });
+
+  test("ltm.remove() cleans up transfer rows for the deleted entry", () => {
+    const id = createPromoted("Remove cleanup entry", "to be removed");
+    const fpid = ensureProject(FOREIGN);
+    ltm.recordTransfer({ knowledgeId: id, recalledInProjectId: fpid });
+    expect(ltm.transferCount(id)).toBe(1);
+
+    ltm.remove(id);
+    expect(ltm.transferCount(id)).toBe(0);
+  });
+
+  test("clearKnowledge() cleans up transfer rows for deleted entries", () => {
+    const id = createPromoted("ClearKnowledge entry", "to be bulk-cleared");
+    const fpid = ensureProject(FOREIGN);
+    ltm.recordTransfer({ knowledgeId: id, recalledInProjectId: fpid });
+    expect(ltm.transferCount(id)).toBe(1);
+
+    data.clearKnowledge(ORIGIN);
+    expect(ltm.transferCount(id)).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary

Fixes orphaned `knowledge_transfers` rows left behind when knowledge entries are deleted via `ltm.remove()` (curator-driven) or `clearKnowledge()` (bulk project knowledge wipe). Since the table has no FK `ON DELETE CASCADE` (intentional, matching `tool_calls`/`daily_costs`), the transfer tally rows for deleted entries were left behind — inflating the "Recalled in N other projects" dashboard count for non-existent entries.

Found during self-review of #531.

## Fix
- `ltm.remove(id)`: add `DELETE FROM knowledge_transfers WHERE knowledge_id = ?` before the knowledge delete.
- `clearKnowledge(projectPath)`: add `DELETE FROM knowledge_transfers WHERE knowledge_id IN (SELECT id FROM knowledge WHERE project_id = ?)` before the knowledge delete.

The full-project cleanup paths (`clearProject`/`deleteProject`) were already correct — those delete transfers before knowledge. This fixes the two partial-delete paths that were missed.

## Tests
Two new cases in `knowledge-transfers.test.ts`:
- `ltm.remove()` cleans up transfer rows for the deleted entry.
- `clearKnowledge()` cleans up transfer rows for deleted entries.

14 pass / 0 fail. Lint clean, typecheck clean.