### PR TITLE
ci: add docs preview workflow and skip CI for docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,45 @@ env:
   COMMIT_TIMESTAMP: ${{ github.event.head_commit.timestamp }}
 
 jobs:
+  # ---------------------------------------------------------------------------
+  # Change detection: skip heavy CI for docs-only changes
+  # ---------------------------------------------------------------------------
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      code: ${{ steps.force.outputs.code || steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'packages/**'
+              - 'scripts/**'
+              - 'bun.lock'
+              - 'bun.lockb'
+              - 'bunfig.toml'
+              - 'tsconfig*.json'
+              - 'package.json'
+              - '.craft.yml'
+              - '.github/workflows/ci.yml'
+              - '.github/workflows/publish.yml'
+              - '.github/workflows/release.yml'
+
+      # Force code=true on main/release pushes — these always run full CI.
+      # dorny/paths-filter only matters for PRs.
+      - name: Force full CI on main/release push
+        id: force
+        if: github.event_name == 'push'
+        run: echo "code=true" >> "$GITHUB_OUTPUT"
+
   test:
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     outputs:
       nightly-version: ${{ steps.nightly.outputs.version }}
@@ -310,7 +348,8 @@ jobs:
 
   binary-smoke-native:
     name: Binary smoke (${{ matrix.target }})
-    needs: [test]
+    needs: [changes, test]
+    if: needs.changes.outputs.code == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -368,9 +407,11 @@ jobs:
 
   build-nightly-binaries:
     name: Build Nightly Binaries
-    needs: [test]
+    needs: [changes, test]
     # Only on main pushes (not PRs, not release branches)
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: >-
+      needs.changes.outputs.code == 'true' &&
+      github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -429,8 +470,10 @@ jobs:
 
   generate-patches:
     name: Generate Delta Patches
-    needs: [test, build-nightly-binaries]
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    needs: [changes, test, build-nightly-binaries]
+    if: >-
+      needs.changes.outputs.code == 'true' &&
+      github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
@@ -560,8 +603,10 @@ jobs:
 
   publish-nightly:
     name: Publish Nightly to GHCR
-    needs: [test, build-nightly-binaries, generate-patches]
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    needs: [changes, test, build-nightly-binaries, generate-patches]
+    if: >-
+      needs.changes.outputs.code == 'true' &&
+      github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Download compressed artifacts
@@ -677,9 +722,11 @@ jobs:
 
   generate-release-patches:
     name: Generate Release Patches
-    needs: [test]
+    needs: [changes, test]
     # Only on release branches, not PRs or main
-    if: startsWith(github.ref, 'refs/heads/release/')
+    if: >-
+      needs.changes.outputs.code == 'true' &&
+      startsWith(github.ref, 'refs/heads/release/')
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
@@ -790,3 +837,28 @@ jobs:
           # the placeholder ensures upload-artifact creates the artifact.
           # (upload-artifact ignores hidden files by default)
           path: patches/
+
+  # ---------------------------------------------------------------------------
+  # CI status: single required check for branch protection.
+  # Reports success when either (a) all code jobs passed or (b) they were
+  # legitimately skipped because only docs changed.
+  # ---------------------------------------------------------------------------
+  ci-status:
+    name: CI Status
+    if: always()
+    needs: [changes, test, binary-smoke-native]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check CI result
+        run: |
+          if [ "${{ needs.changes.outputs.code }}" == "true" ]; then
+            if [ "${{ needs.test.result }}" != "success" ]; then
+              echo "::error::test job did not succeed (result: ${{ needs.test.result }})"
+              exit 1
+            fi
+            if [ "${{ needs.binary-smoke-native.result }}" == "failure" ]; then
+              echo "::error::binary-smoke-native failed"
+              exit 1
+            fi
+          fi
+          echo "CI passed (code=${{ needs.changes.outputs.code }})"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -41,6 +41,7 @@ jobs:
               - 'bunfig.toml'
               - 'tsconfig*.json'
               - 'package.json'
+              - 'biome.json'
               - '.craft.yml'
               - '.github/workflows/ci.yml'
               - '.github/workflows/publish.yml'
@@ -856,8 +857,9 @@ jobs:
               echo "::error::test job did not succeed (result: ${{ needs.test.result }})"
               exit 1
             fi
-            if [ "${{ needs.binary-smoke-native.result }}" == "failure" ]; then
-              echo "::error::binary-smoke-native failed"
+            result="${{ needs.binary-smoke-native.result }}"
+            if [ "$result" == "failure" ] || [ "$result" == "cancelled" ]; then
+              echo "::error::binary-smoke-native did not succeed (result: $result)"
               exit 1
             fi
           fi

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -47,7 +47,7 @@ jobs:
               git add .nojekyll
               git commit -m "Add .nojekyll to disable Jekyll processing"
               git push origin gh-pages
-              git checkout -
+              git checkout "$GITHUB_SHA"
             fi
           else
             # Branch doesn't exist, create it as an orphan branch
@@ -58,7 +58,7 @@ jobs:
             git add .nojekyll
             git commit -m "Initialize gh-pages with .nojekyll"
             git push origin gh-pages
-            git checkout -
+            git checkout "$GITHUB_SHA"
           fi
 
       - name: Deploy Preview

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,0 +1,75 @@
+name: Docs Preview
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs-preview.yml'
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs-preview.yml'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: docs-preview-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Ensure .nojekyll at gh-pages root
+        # Fork PRs can't push to the base repo (GITHUB_TOKEN is read-only on
+        # pull_request from forks). Skip the deploy but still run the checkout
+        # above so the workflow validates cleanly.
+        if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Try to fetch the gh-pages branch
+          if git fetch origin gh-pages:gh-pages 2>/dev/null; then
+            # Branch exists remotely, check if .nojekyll is present
+            if git show gh-pages:.nojekyll &>/dev/null; then
+              echo ".nojekyll already exists at gh-pages root"
+            else
+              echo "Adding .nojekyll to existing gh-pages branch"
+              git checkout gh-pages
+              touch .nojekyll
+              git add .nojekyll
+              git commit -m "Add .nojekyll to disable Jekyll processing"
+              git push origin gh-pages
+              git checkout -
+            fi
+          else
+            # Branch doesn't exist, create it as an orphan branch
+            echo "Creating gh-pages branch with .nojekyll"
+            git checkout --orphan gh-pages
+            git rm -rf .
+            touch .nojekyll
+            git add .nojekyll
+            git commit -m "Initialize gh-pages with .nojekyll"
+            git push origin gh-pages
+            git checkout -
+          fi
+
+      - name: Deploy Preview
+        # Same fork-PR guard as the .nojekyll step above.
+        if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: docs/
+          preview-branch: gh-pages
+          umbrella-dir: _preview
+          pages-base-url: withlore.ai
+          action: ${{ github.event_name == 'push' && 'deploy' || 'auto' }}
+          pr-number: ${{ github.event_name == 'push' && 'main' || github.event.pull_request.number }}
+          comment: ${{ github.event_name != 'push' }}

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -7,10 +7,10 @@ on:
       - 'docs/**'
       - '.github/workflows/docs-preview.yml'
   pull_request:
+    # No paths filter on pull_request: the 'closed' event must always fire
+    # so the preview action can clean up deployed previews. A paths-filter
+    # step inside the job skips deploy for non-docs PRs.
     types: [opened, reopened, synchronize, closed]
-    paths:
-      - 'docs/**'
-      - '.github/workflows/docs-preview.yml'
 
 permissions:
   contents: write
@@ -26,11 +26,23 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Check if docs files changed. On 'closed' events we always proceed
+      # (cleanup). On push events paths are already filtered at trigger level.
+      - name: Check for docs changes
+        id: filter
+        if: github.event_name == 'pull_request' && github.event.action != 'closed'
+        uses: dorny/paths-filter@v4
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
+              - '.github/workflows/docs-preview.yml'
+
       - name: Ensure .nojekyll at gh-pages root
-        # Fork PRs can't push to the base repo (GITHUB_TOKEN is read-only on
-        # pull_request from forks). Skip the deploy but still run the checkout
-        # above so the workflow validates cleanly.
-        if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
+        # Skip when: (a) non-docs PR (not closed), or (b) fork PR
+        if: >-
+          (github.event.action == 'closed' || steps.filter.outputs.docs == 'true' || github.event_name == 'push') &&
+          (github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request')
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -62,8 +74,10 @@ jobs:
           fi
 
       - name: Deploy Preview
-        # Same fork-PR guard as the .nojekyll step above.
-        if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
+        # Skip when: (a) non-docs PR (not closed), or (b) fork PR
+        if: >-
+          (github.event.action == 'closed' || steps.filter.outputs.docs == 'true' || github.event_name == 'push') &&
+          (github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request')
         uses: rossjrw/pr-preview-action@v1
         with:
           source-dir: docs/


### PR DESCRIPTION
## Summary

Adds GitHub Pages preview deployments for docs changes and skips the heavy CI pipeline for docs-only PRs.

### New: `.github/workflows/docs-preview.yml`
- Deploys PR previews to `gh-pages` branch via `rossjrw/pr-preview-action`
- Preview URL: `https://withlore.ai/_preview/pr-N/`
- Production docs deployed on push to `main` (to `_preview/pr-main`)
- Fork PRs: workflow runs (validates docs) but skips deployment
- Triggers only on `docs/**` and workflow file changes
- Concurrency group prevents races

### Modified: `.github/workflows/ci.yml`
- **`changes` job**: uses `dorny/paths-filter@v3` to detect code vs docs-only changes
- **Job gating**: all heavy jobs (`test`, `binary-smoke-native`, `build-nightly-binaries`, `generate-patches`, `publish-nightly`, `generate-release-patches`) check `needs.changes.outputs.code == 'true'`
- **Force override**: main/release pushes always run full CI regardless of paths
- **`ci-status` safety net**: runs `if: always()`, validates skip was legitimate (docs-only) vs unexpected failure — suitable as single required status check for branch protection

### Post-merge steps

After the first push to `main` creates the `gh-pages` branch:

```bash
# Switch Pages source from main:/docs to gh-pages:/
gh api --method PUT repos/BYK/loreai/pages \
  -f source[branch]=gh-pages -f source[path]=/

# Enable HTTPS enforcement
gh api --method PUT repos/BYK/loreai/pages \
  -F https_enforced=true
```

### Pattern reference
Based on `getsentry/cli` (`docs-preview.yml` + `dorny/paths-filter` in `ci.yml`) and `getsentry/craft` (`docs-preview.yml`) patterns.