### PR TITLE
docs(site): fix self-hosted terminology contradiction + deduplicate comparison

### DIFF
--- a/docs/different.html
+++ b/docs/different.html
@@ -155,8 +155,7 @@
             <th>Cloud agent platforms<br><span style="font-weight:300;color:var(--mid);font-size:.86em;">memory inside a hosted control plane</span></th>
             <td>Org-wide retrieval and governance for fleets of agents run on the platform.</td>
             <td>Memory exists for agents run <em>through</em> the platform; the engine is hosted and closed.
-              "Self-hosted" usually means you can hold the data <em>artifacts</em> — but they're in the
-              platform's format, produced and read by its engine. You adopt the platform to get the memory.</td>
+              You adopt the platform to get the memory.</td>
             <td class="cmp-lore">Lore runs locally with the agent you already use. The engine is
               fair source; your knowledge is a <span class="cmp-yes">plain file in your repo</span> you can
               read and use without us.</td>
@@ -253,8 +252,8 @@
   <section class="cta" id="waitlist">
     <div class="cta-inner">
       <h2 class="sr">Memory that's <em>yours.</em></h2>
-      <p class="cta-sub sr">Self-hosted Lore is available now, free and local. Join the waitlist for Lore Cloud —
-        hosted, team-shared memory with zero setup.</p>
+      <p class="cta-sub sr">Lore runs locally today — free, fair source, and yours. Join the waitlist for Lore Cloud —
+        team-shared memory with zero setup.</p>
 
       <div class="cta-form-view show" id="waitlist-form-view">
         <form class="cta-form sr" id="waitlist-form"

--- a/docs/index.html
+++ b/docs/index.html
@@ -426,7 +426,7 @@
   <section class="cta" id="waitlist">
     <div class="cta-inner">
       <h2 class="sr">Stop managing context. <em>Start building.</em></h2>
-      <p class="cta-sub sr">Self-hosted Lore is available now. Join the waitlist for Lore Cloud — hosted memory with zero setup.</p>
+      <p class="cta-sub sr">Lore runs locally today — free, fair source, and yours. Join the waitlist for Lore Cloud — team-shared memory with zero setup.</p>
 
       <!-- View 1: Form (default) -->
       <div class="cta-form-view show" id="waitlist-form-view">


### PR DESCRIPTION
## Summary

Follow-up to #542 and the direct-to-main wording commit (`3f2c63e`). Addresses two review findings from adversarial self-review.

## Changes

**M1: "Self-hosted" terminology contradiction** — both CTAs described Lore as "Self-hosted Lore is available now" while the comparison section critiques what "self-hosted" means when others use it. Fixed by replacing both CTAs with *"Lore runs locally today — free, fair source, and yours."*

**M2: Deduplicate comparison table / portability note** — the cloud-platform table row and the "What portable really means" callout below it made the same artifacts-vs-ownership argument in nearly identical words. Slimmed the table row back to its original concise form ("the engine is hosted and closed; you adopt the platform to get the memory") and let the portability note carry the full nuanced argument.

## Files changed

- `docs/different.html` — CTA copy + comparison table row
- `docs/index.html` — CTA copy

Pure docs change, no code or tests affected.