### PR TITLE
fix(gateway): preserve 5m cache TTL for non-native Anthropic upstreams

### DIFF
--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -1625,18 +1625,19 @@ async function forwardToUpstream(
     headers = result.headers;
     body = result.body;
   } else {
-    // For non-native-Anthropic upstreams (MiniMax, Fireworks, etc.), strip
-    // extended cache TTL ("1h") — it's an Anthropic beta extension that
-    // third-party endpoints may reject. Standard cache_control ephemeral
-    // breakpoints are kept (widely supported).
+    // For non-native-Anthropic upstreams (MiniMax, Fireworks, etc.), downgrade
+    // extended cache TTL ("1h") to standard 5-minute ephemeral — the "1h" TTL
+    // is an Anthropic beta extension that third-party endpoints may reject.
+    // Standard cache_control breakpoints with bare ephemeral are kept (widely
+    // supported) so third-party providers still benefit from prompt caching.
     const isNativeAnthropic =
       effectiveUpstreamBase === "https://api.anthropic.com";
     const effectiveCache =
       cache && !isNativeAnthropic
         ? {
             ...cache,
-            systemTTL: undefined as undefined,
-            conversationTTL: undefined as undefined,
+            systemTTL: "5m" as const,
+            conversationTTL: "5m" as const,
           }
         : cache;
     const result = buildAnthropicRequest(req, effectiveCache);


### PR DESCRIPTION
## Problem

PR #560 stripped extended cache TTL (`1h`) for third-party Anthropic endpoints (MiniMax, Fireworks, etc.) by setting `systemTTL: undefined`. But `undefined` disables ALL prompt caching — `buildAnthropicRequest` treats a falsy `systemTTL` as 'no caching' and sends the system prompt as a plain string without any `cache_control` breakpoints.

This means third-party Anthropic-protocol providers got **zero prompt caching** instead of standard 5-minute caching — significantly increasing costs.

## Fix

One-line change: use `"5m"` instead of `undefined` for `systemTTL` and `conversationTTL` on non-native Anthropic upstreams.

```typescript
// Before (strips ALL caching):
systemTTL: undefined,
conversationTTL: undefined,

// After (downgrades to standard 5m):
systemTTL: "5m" as const,
conversationTTL: "5m" as const,
```

This preserves the system block array format with bare `{ type: "ephemeral" }` cache_control breakpoints — standard 5-minute prompt caching that third-party endpoints accept.

## Verification
- Typecheck: 4/4 pass
- Tests: 2250 pass, 0 fail
- Lint: 0 errors