### PR TITLE
fix(gateway): provider routing follow-up fixes from post-merge audit

### DIFF
--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -306,7 +306,7 @@ const PROVIDER_ROUTES: Record<string, ProviderRoute> = {
     url: "https://api.fireworks.ai/inference",
     protocol: "anthropic",
   },
-  "github-copilot": { url: null, protocol: "anthropic" },
+  "github-copilot": { url: null, protocol: "openai" },
   minimax: {
     url: "https://api.minimax.io/anthropic",
     protocol: "anthropic",

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -1563,8 +1563,9 @@ async function forwardToUpstream(
   const providerID = extractProviderHeader(req.rawHeaders);
   let providerRoute = providerID ? resolveProviderRoute(providerID) : null;
   // Dynamic fallback: look up unknown providers from models.dev cache.
+  // Non-blocking — returns cached data or null (triggers background refresh).
   if (!providerRoute && providerID) {
-    providerRoute = await lookupProviderRoute(providerID);
+    providerRoute = lookupProviderRoute(providerID);
   }
   const modelRoute = resolveUpstreamRoute(req.model);
 
@@ -1589,6 +1590,22 @@ async function forwardToUpstream(
     (effectiveProtocol === "anthropic"
       ? config.upstreamAnthropic
       : config.upstreamOpenAI);
+
+  // Warn when a provider route exists but has no URL and no header override —
+  // the request will fall through to config defaults which likely have wrong
+  // credentials. The user should set LORE_UPSTREAM_<PROVIDER>=<url>.
+  if (
+    providerRoute?.url == null &&
+    providerID &&
+    !headerUpstream &&
+    !modelRoute
+  ) {
+    log.warn(
+      `provider "${providerID}" has no upstream URL configured — falling back to default. ` +
+        `Set LORE_UPSTREAM_${providerID.toUpperCase().replace(/-/g, "_")}=<url> ` +
+        `to route requests correctly.`,
+    );
+  }
 
   if (effectiveProtocol === "openai-responses") {
     // Inject LTM into system prompt for non-Anthropic paths.
@@ -2736,13 +2753,19 @@ function postResponse(
     }
     // Track model/protocol/beta for warmup profile resolution
     sessionState.lastModel = req.model;
-    // Use provider-aware protocol resolution: provider route > model prefix > fallback.
+    // Use provider-aware protocol resolution with the same providerRouteUsable
+    // guard as forwardToUpstream: only trust the provider route's protocol when
+    // it also has a usable URL (or headerUpstream is set). Otherwise fall back
+    // to model-prefix routing to avoid protocol/worker mismatch.
     const lpProvider = extractProviderHeader(req.rawHeaders);
     const lpRoute = lpProvider ? resolveProviderRoute(lpProvider) : null;
+    const lpHeaderUpstream = extractUpstreamUrlHeader(req.rawHeaders);
+    const lpRouteUsable =
+      lpRoute && (lpRoute.url != null || lpHeaderUpstream) ? lpRoute : null;
     sessionState.lastProtocol =
       req.protocol === "openai-responses"
         ? "openai-responses"
-        : (lpRoute?.protocol ??
+        : (lpRouteUsable?.protocol ??
           resolveUpstreamRoute(req.model)?.protocol ??
           "anthropic");
     // Capture anthropic-beta so cache-warmer can forward it — beta-gated
@@ -4288,10 +4311,14 @@ async function handleConversationTurn(
       "gen_ai.request.model": req.model,
       "gen_ai.provider.name": (() => {
         if (req.protocol === "openai-responses") return "openai-responses";
+        // Apply the same providerRouteUsable guard as forwardToUpstream:
+        // only trust provider route protocol when it has a usable URL.
         const pid = extractProviderHeader(req.rawHeaders);
         const pr = pid ? resolveProviderRoute(pid) : null;
+        const hdrUp = extractUpstreamUrlHeader(req.rawHeaders);
+        const prUsable = pr && (pr.url != null || hdrUp) ? pr : null;
         return (
-          pr?.protocol ??
+          prUsable?.protocol ??
           resolveUpstreamRoute(req.model)?.protocol ??
           "anthropic"
         );

--- a/packages/gateway/src/worker-model.ts
+++ b/packages/gateway/src/worker-model.ts
@@ -252,19 +252,22 @@ function npmToProtocol(
  * Dynamically look up a provider route from the models.dev API cache.
  *
  * Called as a fallback when `resolveProviderRoute()` (static table) returns
- * null. Triggers a models.dev fetch if the cache is stale, but never blocks
- * on a fresh network call — returns null if no cached data is available.
+ * null. Returns cached data immediately when available. On cache miss or
+ * stale cache, triggers a background refresh and returns stale data (or
+ * null) — never blocks the hot request path on a network call.
  */
-export async function lookupProviderRoute(
-  providerID: string,
-): Promise<ProviderRoute | null> {
-  // If we have fresh cached routes, use them directly (no network call).
-  if (cachedProviderRoutes && Date.now() - cachedModelDataAt < CACHE_TTL_MS) {
+export function lookupProviderRoute(providerID: string): ProviderRoute | null {
+  // Return from cache (fresh or stale) — never block the request.
+  if (cachedProviderRoutes) {
+    // If stale, trigger a background refresh (fire-and-forget).
+    if (Date.now() - cachedModelDataAt >= CACHE_TTL_MS) {
+      fetchModelData().catch(() => {});
+    }
     return cachedProviderRoutes.get(providerID) ?? null;
   }
-  // Trigger a fetch (deduped + cached) — this also populates cachedProviderRoutes.
-  await fetchModelData();
-  return cachedProviderRoutes?.get(providerID) ?? null;
+  // No cache at all — trigger a background fetch for next request.
+  fetchModelData().catch(() => {});
+  return null;
 }
 
 /**

--- a/packages/gateway/test/upstream-routes.test.ts
+++ b/packages/gateway/test/upstream-routes.test.ts
@@ -209,7 +209,7 @@ describe("resolveProviderRoute", () => {
     test("returns null url for github-copilot (requires user config)", () => {
       expect(resolveProviderRoute("github-copilot")).toEqual({
         url: null,
-        protocol: "anthropic",
+        protocol: "openai",
       });
     });
   });

--- a/packages/gateway/test/worker-model.test.ts
+++ b/packages/gateway/test/worker-model.test.ts
@@ -6,6 +6,7 @@ import {
   getWorkerModel,
   resetWorkerModelState,
   clearModelDataCache,
+  lookupProviderRoute,
   type ModelsDevEntry,
 } from "../src/worker-model";
 
@@ -292,7 +293,7 @@ describe("lookupProviderRoute", () => {
     resetWorkerModelState();
   });
 
-  test("resolves anthropic-protocol provider from models.dev", async () => {
+  test("resolves anthropic-protocol provider after cache is populated", async () => {
     globalThis.fetch = mock(() =>
       Promise.resolve(
         new Response(
@@ -310,15 +311,16 @@ describe("lookupProviderRoute", () => {
       ),
     ) as unknown as typeof fetch;
 
-    const { lookupProviderRoute } = await import("../src/worker-model");
-    const route = await lookupProviderRoute("some-new-provider");
+    // Populate cache first (lookupProviderRoute is sync, non-blocking).
+    await fetchModelData();
+    const route = lookupProviderRoute("some-new-provider");
     expect(route).toEqual({
       url: "https://api.newprovider.com/anthropic",
       protocol: "anthropic",
     });
   });
 
-  test("resolves openai-compatible provider from models.dev", async () => {
+  test("resolves openai-compatible provider after cache is populated", async () => {
     globalThis.fetch = mock(() =>
       Promise.resolve(
         new Response(
@@ -336,15 +338,15 @@ describe("lookupProviderRoute", () => {
       ),
     ) as unknown as typeof fetch;
 
-    const { lookupProviderRoute } = await import("../src/worker-model");
-    const route = await lookupProviderRoute("custom-openai");
+    await fetchModelData();
+    const route = lookupProviderRoute("custom-openai");
     expect(route).toEqual({
       url: "https://api.custom.com",
       protocol: "openai",
     });
   });
 
-  test("resolves openai-responses provider from models.dev", async () => {
+  test("resolves openai-responses provider after cache is populated", async () => {
     globalThis.fetch = mock(() =>
       Promise.resolve(
         new Response(
@@ -362,8 +364,8 @@ describe("lookupProviderRoute", () => {
       ),
     ) as unknown as typeof fetch;
 
-    const { lookupProviderRoute } = await import("../src/worker-model");
-    const route = await lookupProviderRoute("openai-like");
+    await fetchModelData();
+    const route = lookupProviderRoute("openai-like");
     expect(route).toEqual({
       url: "https://api.openailike.com",
       protocol: "openai-responses",
@@ -386,10 +388,9 @@ describe("lookupProviderRoute", () => {
       ),
     ) as unknown as typeof fetch;
 
-    const { lookupProviderRoute } = await import("../src/worker-model");
-    const route = await lookupProviderRoute("anthropic");
+    await fetchModelData();
     // anthropic in models.dev has no `api` field — SDK handles routing
-    expect(route).toBeNull();
+    expect(lookupProviderRoute("anthropic")).toBeNull();
   });
 
   test("returns null for unknown provider", async () => {
@@ -404,9 +405,33 @@ describe("lookupProviderRoute", () => {
       ),
     ) as unknown as typeof fetch;
 
-    const { lookupProviderRoute } = await import("../src/worker-model");
-    const route = await lookupProviderRoute("nonexistent");
+    await fetchModelData();
+    expect(lookupProviderRoute("nonexistent")).toBeNull();
+  });
+
+  test("returns null on cold cache and triggers background fetch", () => {
+    globalThis.fetch = mock(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            anthropic: { models: {} },
+            "delayed-provider": {
+              id: "delayed-provider",
+              api: "https://api.delayed.com/v1",
+              npm: "@ai-sdk/openai-compatible",
+              models: {},
+            },
+          }),
+          { status: 200 },
+        ),
+      ),
+    ) as unknown as typeof fetch;
+
+    // Cold cache — returns null immediately, doesn't block.
+    const route = lookupProviderRoute("delayed-provider");
     expect(route).toBeNull();
+    // Background fetch was triggered.
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/pi/src/index.ts
+++ b/packages/pi/src/index.ts
@@ -61,7 +61,6 @@ type SessionBeforeCompactResult = {
 const ANTHROPIC_PROVIDERS = [
   "anthropic",
   "fireworks",
-  "github-copilot",
   "minimax",
   "minimax-cn",
   "kimi-coding",
@@ -70,6 +69,7 @@ const ANTHROPIC_PROVIDERS = [
 /** OpenAI-completions / OpenAI-responses API → gateway POST /v1/chat/completions or /v1/responses */
 const OPENAI_PROVIDERS = [
   // openai-completions API
+  "github-copilot",
   "deepseek",
   "xai",
   "groq",


### PR DESCRIPTION
## Context

Post-merge audit of PRs #557, #560, #562, #563 identified four issues. This PR addresses all of them.

## Fixes

### 1. `lastProtocol` and Sentry span use `providerRouteUsable` guard (Finding 1/8)

**Problem:** `lastProtocol` and the Sentry `gen_ai.provider.name` span used the raw provider route protocol without checking if the route had a usable URL. For `url: null` providers (e.g. `github-copilot`), this caused protocol mismatch — worker model selection picked the wrong provider's defaults.

**Fix:** Apply the same `providerRouteUsable` guard from `forwardToUpstream()`: only trust the provider route's protocol when it also has a usable URL or `headerUpstream` is set.

### 2. `lookupProviderRoute()` is now synchronous and non-blocking (Finding 2)

**Problem:** The dynamic models.dev fallback was `async` and called `await fetchModelData()` on the hot request path. On cold start or after 1h cache expiry, this could add up to 10s latency to a user-facing request.

**Fix:** Changed to synchronous — returns cached data immediately (fresh or stale). If the cache is stale or empty, triggers a fire-and-forget background refresh. The next request benefits from the refreshed cache.

### 3. Log warning for misconfigured `url: null` providers (Finding 6)

**Problem:** When a provider has `url: null` in `PROVIDER_ROUTES` and no `X-Lore-Upstream-URL` header or model-prefix match, requests silently fall through to config defaults (`api.anthropic.com` or `api.openai.com`) with wrong credentials → 401.

**Fix:** Log a warning with the exact env var to set (`LORE_UPSTREAM_<PROVIDER>=<url>`).

### 4. Fix `github-copilot` protocol classification (Finding 12)

**Problem:** `github-copilot` was classified as `"anthropic"` protocol in `PROVIDER_ROUTES` and Pi's `ANTHROPIC_PROVIDERS`, but models.dev shows it uses `@ai-sdk/openai-compatible` (OpenAI protocol).

**Fix:** Changed to `"openai"` in both `PROVIDER_ROUTES` and Pi plugin.

## Verification
- Typecheck: 4/4 pass
- Tests: 2251 pass, 0 fail (1 new test for cold-cache behavior)
- Lint: 0 errors