### PR TITLE
fix(gateway): route worker calls through session's provider

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -299,6 +299,17 @@ export interface LLMClient {
        *   the field is silently ignored
        */
       temperature?: number;
+      /**
+       * Override the upstream URL for this call. When set, the adapter
+       * routes the request to this URL instead of the default provider
+       * endpoint. Used by the gateway to route worker calls through the
+       * same proxy/aggregator (e.g. OpenCode Zen) that the owning
+       * session uses, rather than hitting the direct provider API.
+       *
+       * Only the gateway adapter honors this field; other adapters
+       * (OpenCode, Pi) ignore it.
+       */
+      upstreamUrl?: string;
     },
   ): Promise<string | null>;
 }

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -164,11 +164,23 @@ type ProviderTarget = {
   providerName: string;
 };
 
-/** Resolve upstream target based on model provider. */
+/** Resolve upstream target based on model provider.
+ *  When `upstreamOverride` is set, the request routes to that URL instead
+ *  of the default — used for proxy/aggregator sessions (e.g. OpenCode Zen)
+ *  where the session's credentials only work against the proxy endpoint. */
 function resolveTarget(
   upstreams: { anthropic: string; openai: string },
   providerID: string,
+  upstreamOverride?: string,
 ): ProviderTarget {
+  if (upstreamOverride) {
+    // Proxy/aggregator route — providerName reflects the wire protocol
+    // target, not the physical endpoint. The override URL IS the endpoint.
+    return {
+      url: upstreamOverride.replace(/\/$/, ""),
+      providerName: providerID === "openai" ? "openai" : "anthropic",
+    };
+  }
   if (providerID === "openai") {
     return {
       url: upstreams.openai.replace(/\/$/, ""),
@@ -348,7 +360,12 @@ export function createGatewayLLMClient(
 
       const model = opts?.model ?? defaultModel;
       const isOpenAI = model.providerID === "openai";
-      const target = resolveTarget(upstreams, model.providerID);
+      const upstreamOverride = opts?.upstreamUrl;
+      const target = resolveTarget(
+        upstreams,
+        model.providerID,
+        upstreamOverride,
+      );
       const maxTokens = opts?.maxTokens ?? 8192;
 
       // Defense-in-depth: detect API key / provider mismatch before making
@@ -357,7 +374,10 @@ export function createGatewayLLMClient(
       // distinguished by prefix, so only API keys are checked.
       // Skip when LORE_WORKER_API_KEY is set — the user deliberately chose
       // a cross-provider credential/model combination.
-      if (cred.scheme === "api-key" && !hasDedicatedKey) {
+      // Also skip when an upstream override is active — the session routes
+      // through a proxy/aggregator (e.g. OpenCode Zen) that accepts the
+      // session's credentials regardless of the provider prefix.
+      if (cred.scheme === "api-key" && !hasDedicatedKey && !upstreamOverride) {
         const isAnthropicKey = cred.value.startsWith("sk-ant-");
         if (target.providerName === "anthropic" && !isAnthropicKey) {
           log.warn(

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -910,12 +910,34 @@ function getLLMClient(config: GatewayConfig): LLMClient {
       );
     }
 
-    const inner = createGatewayLLMClient(
+    const rawClient = createGatewayLLMClient(
       workerUpstreams,
       getWorkerAuth,
       defaultModel,
       { dedicatedWorkerKey: !!workerApiKey },
     );
+
+    // Session-aware wrapper: automatically inject the session's upstream URL
+    // so worker calls route through the same proxy/aggregator (e.g. OpenCode
+    // Zen) as the owning session. Without this, sessions behind a proxy would
+    // have their workers route directly to the provider API with the wrong
+    // credentials (the proxy's key, not the provider's).
+    // Only injects when no explicit upstreamUrl is already set, and the
+    // session has a non-default upstream (lastUpstreamUrl from a provider route).
+    const inner: LLMClient = {
+      async prompt(system, user, opts) {
+        if (opts?.sessionID && !opts.upstreamUrl && !workerApiKey) {
+          const state = sessions.get(opts.sessionID);
+          if (state?.lastUpstreamUrl) {
+            return rawClient.prompt(system, user, {
+              ...opts,
+              upstreamUrl: state.lastUpstreamUrl,
+            });
+          }
+        }
+        return rawClient.prompt(system, user, opts);
+      },
+    };
 
     // Wrap with batch queue for 50% cost savings on non-urgent worker calls.
     // Enabled by default — disable via LORE_BATCH_DISABLED=1.
@@ -2786,6 +2808,17 @@ function postResponse(
         : (lpRouteUsable?.protocol ??
           resolveUpstreamRoute(req.model)?.protocol ??
           req.protocol);
+    // Track the session's provider route so background workers (distillation,
+    // curation) can route through the same proxy/aggregator instead of hitting
+    // the direct provider API with the wrong credentials.
+    // Always update (including clearing) so a stale header isn't forwarded
+    // after the client switches providers mid-session.
+    // Exclude model-prefix routes from lastUpstreamUrl — those are default
+    // behavior (e.g. claude-* → api.anthropic.com) and don't need an
+    // override. Only header/provider-route overrides indicate a proxy session.
+    sessionState.lastProviderID = lpProvider || undefined;
+    sessionState.lastUpstreamUrl =
+      lpHeaderUpstream ?? lpRoute?.url ?? undefined;
     // Capture anthropic-beta so cache-warmer can forward it — beta-gated
     // body fields (e.g. context_management) need the header to be accepted.
     // Always update (including clearing) so a stale header isn't forwarded

--- a/packages/gateway/src/translate/types.ts
+++ b/packages/gateway/src/translate/types.ts
@@ -395,6 +395,14 @@ export type SessionState = {
   lastModel?: string;
   /** Protocol from the last real request (for warming profile resolution). */
   lastProtocol?: "anthropic" | "openai" | "openai-responses";
+  /** Provider ID from the last request's `X-Lore-Provider` header. Used to
+   *  route worker calls through the same provider as the owning session. */
+  lastProviderID?: string;
+  /** Resolved upstream base URL from the last request. When set, worker calls
+   *  route through this URL instead of the default provider endpoint — ensures
+   *  proxy/aggregator sessions (e.g. OpenCode Zen) keep working for background
+   *  tasks like distillation and curation. */
+  lastUpstreamUrl?: string;
   /** anthropic-beta header from the last real request — forwarded by
    *  cache-warmer so beta-gated body fields (e.g. context_management)
    *  are accepted upstream. */


### PR DESCRIPTION
## Summary

Background workers (distillation, curation, consolidation) now route through the same upstream as their owning session, instead of always hitting the default provider API.

## Problem

After #571 fixed provider routing for conversation requests, a follow-up issue emerged: sessions behind a proxy/aggregator (e.g., OpenCode Zen with `provider=opencode`) had their background workers silently dropped.

The flow was:
1. Session uses `opencode` provider → `https://opencode.ai/zen` → `public…` API key
2. Worker tries: `anthropic` provider → `https://api.anthropic.com` → same `public…` key
3. Mismatch guard: `public…` is not `sk-ant-*` → **skip** all background work

This meant no distillation, no curation, and no knowledge extraction for any session routed through a proxy.

## Changes

- **`SessionState`**: Add `lastProviderID` and `lastUpstreamUrl` fields, recorded in `postResponse()` alongside `lastProtocol`/`lastModel`
- **`LLMClient.prompt()`**: Add optional `upstreamUrl` field to opts (gateway-only, other adapters ignore it)
- **Gateway LLM client wrapper**: Auto-injects the session's `lastUpstreamUrl` into worker calls when the session has a non-default provider route
- **`resolveTarget()`** in `llm-adapter.ts`: Accepts optional upstream override URL
- **Mismatch guard**: Skipped when upstream override is active — proxy credentials don't follow standard provider prefixes

## Verification

- `bun run typecheck`: 4/4 pass
- `bun run lint`: 0 errors
- `bun test`: 2251 pass, 0 fail