### PR TITLE
fix(gateway): couple recall follow-up stream flag to its consumer

### DIFF
--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -4524,13 +4524,35 @@ async function handleConversationTurn(
           }),
         parseJSON: accumulateNonStreamResponse,
       };
-      const jsonFollowUp = await runRecallFollowUpJSON(
-        jsonRecallCtx,
-        currentModifiedReq,
-        currentResp,
-        result,
-        recallBlock,
-      );
+      let jsonFollowUp: Awaited<ReturnType<typeof runRecallFollowUpJSON>>;
+      try {
+        jsonFollowUp = await runRecallFollowUpJSON(
+          jsonRecallCtx,
+          currentModifiedReq,
+          currentResp,
+          result,
+          recallBlock,
+        );
+      } catch (fetchErr) {
+        log.error(
+          `recall follow-up fetch error (non-stream, depth=${recallDepth}) for session ${sessionState.sessionID.slice(0, 16)}:`,
+          fetchErr,
+        );
+        // Fall back to response with marker (no continuation)
+        markerResp.usage = cumulativeUsage;
+        postResponse(
+          req,
+          markerResp,
+          sessionState,
+          config,
+          requestBody,
+          genAiSpan,
+        );
+        return nonStreamHttpResponse(
+          unsustainable ? injectContextWarning(markerResp) : markerResp,
+          { "x-lore-recall-invoked": "true" },
+        );
+      }
 
       if (!jsonFollowUp.ok) {
         log.error(

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -205,7 +205,9 @@ import {
   hasRecallToolUse,
   hasOtherToolUse,
   clientHasRecallTool,
-  buildRecallFollowUp,
+  runRecallFollowUpStreaming,
+  runRecallFollowUpJSON,
+  type RecallFollowUpCtx,
   buildRecallMarker,
   recallStoreKey,
   expandRecallMarkers,
@@ -1995,23 +1997,38 @@ function buildStreamingResponse(
                 `${recallContext.sessionState.sessionID.slice(0, 16)}`,
             );
 
-            const followUp = buildRecallFollowUp(
-              currentModifiedReq,
-              currentResp,
-              result,
-              recallBlock,
-            );
-            let followUpResponse: Response;
+            // Build (stream:true) + forward + assert-SSE + get reader in one
+            // coupled call so the follow-up's stream flag can never diverge
+            // from how the continuation is consumed (parseSSEStream below).
+            // Disable conversation caching on the follow-up: the appended
+            // recall result makes the prefix diverge from the next real turn,
+            // so the cache write would be wasted money.
+            const streamingRecallCtx: RecallFollowUpCtx = {
+              forward: (r) =>
+                forwardToUpstream(r, recallContext.config, undefined, {
+                  ...recallContext.cacheOptions,
+                  cacheConversation: false,
+                }),
+              // JSON parsing is unused on the streaming path (assertSSEResponse
+              // guarantees an SSE body); provide a guard that throws if reached.
+              parseJSON: () => {
+                throw new Error(
+                  "parseJSON must not be called on the streaming recall path",
+                );
+              },
+            };
+
+            let streamingFollowUp: Awaited<
+              ReturnType<typeof runRecallFollowUpStreaming>
+            >;
             try {
-              ({ response: followUpResponse } = await forwardToUpstream(
-                followUp,
-                recallContext.config,
-                undefined,
-                // Disable conversation caching on follow-up: the appended
-                // recall result makes the prefix diverge from the next real
-                // turn, so the cache write would be wasted money.
-                { ...recallContext.cacheOptions, cacheConversation: false },
-              ));
+              streamingFollowUp = await runRecallFollowUpStreaming(
+                streamingRecallCtx,
+                currentModifiedReq,
+                currentResp,
+                result,
+                recallBlock,
+              );
             } catch (fetchErr) {
               log.error(
                 `recall follow-up fetch error (depth=${recallDepth}) for session ${recallContext.sessionState.sessionID.slice(0, 16)}:`,
@@ -2027,17 +2044,11 @@ function buildStreamingResponse(
               return;
             }
 
-            log.info(
-              `recall follow-up response (depth=${recallDepth}): status=${followUpResponse.status} ` +
-                `hasBody=${!!followUpResponse.body} session=${recallContext.sessionState.sessionID.slice(0, 16)}`,
-            );
-
-            if (!followUpResponse.ok) {
-              const errorBody = await followUpResponse.text();
+            if (!streamingFollowUp.ok) {
               log.error(
-                `recall follow-up upstream error: ${followUpResponse.status} ${errorBody.slice(0, 500)}`,
+                `recall follow-up upstream error: ${streamingFollowUp.status ?? "?"} ${streamingFollowUp.detail}`,
                 new Error(
-                  `recall follow-up upstream ${followUpResponse.status}`,
+                  `recall follow-up upstream ${streamingFollowUp.status ?? "?"}`,
                 ),
               );
               const heldBack = currentAccum.heldBackEvents();
@@ -2050,6 +2061,11 @@ function buildStreamingResponse(
               return;
             }
 
+            const followUp = streamingFollowUp.followUp;
+            log.info(
+              `recall follow-up response (depth=${recallDepth}): session=${recallContext.sessionState.sessionID.slice(0, 16)}`,
+            );
+
             // Pipe the continuation stream through a recall-aware accumulator.
             // +1 accounts for the synthetic marker block just emitted.
             const contBlockOffset =
@@ -2058,10 +2074,7 @@ function buildStreamingResponse(
               blockOffset: contBlockOffset,
               suppressMessageStart: true,
             });
-            if (!followUpResponse.body) {
-              throw new Error("Follow-up response has no body");
-            }
-            const contReader = followUpResponse.body.getReader();
+            const contReader = streamingFollowUp.reader;
             activeReader = contReader;
 
             for await (const {
@@ -4496,34 +4509,33 @@ async function handleConversationTurn(
         );
       }
 
-      // Recall-only — send follow-up request for seamless UX
+      // Recall-only — send follow-up request for seamless UX.
+      // Build (stream:false) + forward + assert-JSON + parse in one coupled
+      // call so the follow-up's stream flag can never diverge from how the
+      // continuation is consumed (accumulateNonStreamResponse).
       log.info(
         `recall (non-stream, depth=${recallDepth}): executing follow-up for session ${sessionState.sessionID.slice(0, 16)}`,
       );
-      const followUp = buildRecallFollowUp(
+      const jsonRecallCtx: RecallFollowUpCtx = {
+        forward: (r) =>
+          forwardToUpstream(r, config, undefined, {
+            ...cacheOptions,
+            cacheConversation: false,
+          }),
+        parseJSON: accumulateNonStreamResponse,
+      };
+      const jsonFollowUp = await runRecallFollowUpJSON(
+        jsonRecallCtx,
         currentModifiedReq,
         currentResp,
         result,
         recallBlock,
       );
-      const {
-        response: followUpResponse,
-        effectiveProtocol: followUpProtocol,
-      } = await forwardToUpstream(
-        followUp,
-        config,
-        undefined,
-        // Disable conversation caching on follow-up: the appended
-        // recall result makes the prefix diverge from the next real turn,
-        // so the cache write would be wasted money.
-        { ...cacheOptions, cacheConversation: false },
-      );
 
-      if (!followUpResponse.ok) {
-        const errorBody = await followUpResponse.text();
+      if (!jsonFollowUp.ok) {
         log.error(
-          `recall follow-up upstream error: ${followUpResponse.status} ${errorBody.slice(0, 500)}`,
-          new Error(`recall follow-up upstream ${followUpResponse.status}`),
+          `recall follow-up upstream error: ${jsonFollowUp.status ?? "?"} ${jsonFollowUp.detail}`,
+          new Error(`recall follow-up upstream ${jsonFollowUp.status ?? "?"}`),
         );
         // Fall back to response with marker (no continuation)
         markerResp.usage = cumulativeUsage;
@@ -4541,10 +4553,7 @@ async function handleConversationTurn(
         );
       }
 
-      const continuationResp = await accumulateNonStreamResponse(
-        followUpResponse,
-        followUpProtocol,
-      );
+      const { continuation: continuationResp, followUp } = jsonFollowUp;
 
       // Accumulate usage from this iteration
       cumulativeUsage.inputTokens += continuationResp.usage.inputTokens;

--- a/packages/gateway/src/recall.ts
+++ b/packages/gateway/src/recall.ts
@@ -392,6 +392,29 @@ export async function executeRecall(
 // Follow-up request builder (Case 1: recall-only)
 // ---------------------------------------------------------------------------
 
+/** Wire protocol used for a recall follow-up upstream response. */
+export type RecallProtocol = "anthropic" | "openai" | "openai-responses";
+
+/**
+ * Injected upstream dependencies for recall follow-up execution.
+ *
+ * Passed by the pipeline so `recall.ts` never imports `pipeline.ts`
+ * (avoids a circular dependency). `forward` wraps `forwardToUpstream`
+ * (with `cacheConversation: false` already applied); `parseJSON` wraps
+ * `accumulateNonStreamResponse`.
+ */
+export interface RecallFollowUpCtx {
+  /** Forward a follow-up request upstream and return the raw response. */
+  forward: (
+    req: GatewayRequest,
+  ) => Promise<{ response: Response; effectiveProtocol: RecallProtocol }>;
+  /** Parse a non-streaming (JSON) upstream response into a GatewayResponse. */
+  parseJSON: (
+    response: Response,
+    protocol: RecallProtocol,
+  ) => Promise<GatewayResponse>;
+}
+
 /**
  * Build a follow-up request after recall execution.
  *
@@ -403,12 +426,21 @@ export async function executeRecall(
  *
  * The model continues from where it left off, now with recall results
  * in context. If it needs more detail it can call recall again.
+ *
+ * `stream` is REQUIRED (no default) and MUST match how the caller consumes
+ * the upstream response: `false` → JSON via `accumulateNonStreamResponse()`,
+ * `true` → SSE via `parseSSEStream()`. A mismatch produces a silent empty
+ * stream ("conversation stops after recall"). Callers should NOT use this
+ * builder directly — use `runRecallFollowUpStreaming()` /
+ * `runRecallFollowUpJSON()`, which couple the flag to its consumer so the two
+ * can never diverge. Exported only for unit-testing the message structure.
  */
-export function buildRecallFollowUp(
+export function buildRecallFollowUpRequest(
   originalReq: GatewayRequest,
   resp: GatewayResponse,
   recallResult: string,
   recallToolUseBlock: GatewayToolUseBlock,
+  stream: boolean,
 ): GatewayRequest {
   // Build the follow-up using proper tool_use/tool_result pairs.
   //
@@ -460,13 +492,144 @@ export function buildRecallFollowUp(
 
   return {
     ...originalReq,
-    // Recall follow-ups are always non-streaming: the accumulated response is
-    // parsed as JSON via accumulateNonStreamResponse(). Without this override,
-    // a streaming client request would forward stream:true to the upstream,
-    // which returns SSE — causing a JSON parse crash.
-    stream: false,
+    // The stream flag is set by the caller-specific helper to match its
+    // consumer (JSON vs SSE) — see buildRecallFollowUpRequest's doc comment.
+    stream,
     messages: [...originalReq.messages, assistantMessage, resultMessage],
   };
+}
+
+// ---------------------------------------------------------------------------
+// Content-type guards — fail loud on a stream-flag / consumer mismatch
+// ---------------------------------------------------------------------------
+
+/**
+ * Assert an upstream recall follow-up response is SSE (`text/event-stream`).
+ *
+ * The streaming follow-up path consumes the body via `parseSSEStream()`. If
+ * the follow-up's `stream` flag is ever wrong, the upstream returns JSON and
+ * the SSE parser silently yields zero events — the client gets the recall
+ * marker then dead air. Throwing here converts that silent failure into a
+ * loud, greppable error (caught by the recall try/catch → marker fallback +
+ * Sentry via log.error).
+ */
+function assertSSEResponse(response: Response): void {
+  const ct = response.headers.get("content-type") ?? "";
+  if (!ct.includes("text/event-stream")) {
+    throw new Error(
+      `recall follow-up expected SSE but got "${ct}" — stream flag/consumer mismatch`,
+    );
+  }
+}
+
+/**
+ * Assert an upstream recall follow-up response is NOT SSE (JSON expected).
+ *
+ * The non-streaming follow-up path parses the body as JSON. An SSE body would
+ * crash `response.json()`; throwing here gives a clear diagnostic instead.
+ */
+function assertJSONResponse(response: Response): void {
+  const ct = response.headers.get("content-type") ?? "";
+  if (ct.includes("text/event-stream")) {
+    throw new Error(
+      `recall follow-up expected JSON but got SSE — stream flag/consumer mismatch`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Coupled build + consume — the ONLY entry points the pipeline should use
+// ---------------------------------------------------------------------------
+
+/** Result of a streaming recall follow-up: the SSE reader + the request sent. */
+export interface RecallFollowUpStreaming {
+  ok: true;
+  /** SSE reader for the continuation stream — pipe through parseSSEStream(). */
+  reader: ReadableStreamDefaultReader<Uint8Array>;
+  /** The follow-up request that was sent (for the next loop iteration). */
+  followUp: GatewayRequest;
+}
+
+/** Result of a non-streaming recall follow-up: the parsed continuation. */
+export interface RecallFollowUpJSON {
+  ok: true;
+  /** Parsed continuation response. */
+  continuation: GatewayResponse;
+  /** The follow-up request that was sent (for the next loop iteration). */
+  followUp: GatewayRequest;
+}
+
+/** Failure result shared by both follow-up modes. */
+export interface RecallFollowUpError {
+  ok: false;
+  /** HTTP status when the upstream responded with a non-OK status. */
+  status?: number;
+  /** Human-readable error detail for logging. */
+  detail: string;
+}
+
+/**
+ * Build a `stream: true` follow-up, forward it, and return the SSE reader.
+ *
+ * Couples the stream flag to its consumer: the body is asserted to be SSE and
+ * returned as a reader, so a flag/consumer mismatch is structurally impossible
+ * and any divergence fails loud (see assertSSEResponse).
+ */
+export async function runRecallFollowUpStreaming(
+  ctx: RecallFollowUpCtx,
+  originalReq: GatewayRequest,
+  resp: GatewayResponse,
+  recallResult: string,
+  recallToolUseBlock: GatewayToolUseBlock,
+): Promise<RecallFollowUpStreaming | RecallFollowUpError> {
+  const followUp = buildRecallFollowUpRequest(
+    originalReq,
+    resp,
+    recallResult,
+    recallToolUseBlock,
+    /* stream */ true,
+  );
+  const { response } = await ctx.forward(followUp);
+  if (!response.ok) {
+    const detail = await response.text().catch(() => "");
+    return { ok: false, status: response.status, detail: detail.slice(0, 500) };
+  }
+  assertSSEResponse(response);
+  if (!response.body) {
+    throw new Error("recall follow-up (streaming) response has no body");
+  }
+  return { ok: true, reader: response.body.getReader(), followUp };
+}
+
+/**
+ * Build a `stream: false` follow-up, forward it, and parse the JSON response.
+ *
+ * Couples the stream flag to its consumer: the body is asserted to be JSON and
+ * parsed via the injected `parseJSON`, so a flag/consumer mismatch is
+ * structurally impossible and any divergence fails loud (see assertJSONResponse).
+ */
+export async function runRecallFollowUpJSON(
+  ctx: RecallFollowUpCtx,
+  originalReq: GatewayRequest,
+  resp: GatewayResponse,
+  recallResult: string,
+  recallToolUseBlock: GatewayToolUseBlock,
+): Promise<RecallFollowUpJSON | RecallFollowUpError> {
+  const followUp = buildRecallFollowUpRequest(
+    originalReq,
+    resp,
+    recallResult,
+    recallToolUseBlock,
+    /* stream */ false,
+  );
+  const { response, effectiveProtocol } = await ctx.forward(followUp);
+  if (!response.ok) {
+    const detail = await response.text().catch(() => "");
+    return { ok: false, status: response.status, detail: detail.slice(0, 500) };
+  }
+  assertJSONResponse(response);
+  const continuation = await ctx.parseJSON(response, effectiveProtocol);
+  return { ok: true, continuation, followUp };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/src/recall.ts
+++ b/packages/gateway/src/recall.ts
@@ -400,8 +400,8 @@ export type RecallProtocol = "anthropic" | "openai" | "openai-responses";
  *
  * Passed by the pipeline so `recall.ts` never imports `pipeline.ts`
  * (avoids a circular dependency). `forward` wraps `forwardToUpstream`
- * (with `cacheConversation: false` already applied); `parseJSON` wraps
- * `accumulateNonStreamResponse`.
+ * — callers should disable conversation caching on the follow-up;
+ * `parseJSON` wraps `accumulateNonStreamResponse`.
  */
 export interface RecallFollowUpCtx {
   /** Forward a follow-up request upstream and return the raw response. */

--- a/packages/gateway/test/recall.test.ts
+++ b/packages/gateway/test/recall.test.ts
@@ -17,7 +17,10 @@ import {
   hasRecallToolUse,
   hasOtherToolUse,
   clientHasRecallTool,
-  buildRecallFollowUp,
+  buildRecallFollowUpRequest,
+  runRecallFollowUpStreaming,
+  runRecallFollowUpJSON,
+  type RecallFollowUpCtx,
   buildRecallMarker,
   parseRecallMarker,
   isRecallMarker,
@@ -314,10 +317,10 @@ describe("recallStoreKey", () => {
 });
 
 // ---------------------------------------------------------------------------
-// buildRecallFollowUp
+// buildRecallFollowUpRequest
 // ---------------------------------------------------------------------------
 
-describe("buildRecallFollowUp", () => {
+describe("buildRecallFollowUpRequest", () => {
   test("builds correct follow-up request structure with tool_use/tool_result", () => {
     const req = makeRequest(
       [{ role: "user", content: [{ type: "text", text: "hello" }] }],
@@ -333,11 +336,12 @@ describe("buildRecallFollowUp", () => {
       "tool_use",
     );
 
-    const followUp = buildRecallFollowUp(
+    const followUp = buildRecallFollowUpRequest(
       req,
       resp,
       "## Recall Results\n* config is in /root",
       recallBlock,
+      /* stream */ false,
     );
 
     // Original messages + assistant (tool_use) + user (tool_result)
@@ -380,16 +384,43 @@ describe("buildRecallFollowUp", () => {
     const req = makeRequest();
     req.system = "my system prompt";
     req.model = "claude-opus-4";
-    req.stream = false;
+    req.stream = true; // originalReq.stream is irrelevant — explicit arg wins
 
     const recallBlock = makeRecallToolUse();
     const resp = makeResponse([recallBlock]);
 
-    const followUp = buildRecallFollowUp(req, resp, "result", recallBlock);
+    const followUp = buildRecallFollowUpRequest(
+      req,
+      resp,
+      "result",
+      recallBlock,
+      /* stream */ false,
+    );
 
     expect(followUp.system).toBe("my system prompt");
     expect(followUp.model).toBe("claude-opus-4");
+    // stream flag comes from the explicit parameter, NOT originalReq.stream
     expect(followUp.stream).toBe(false);
+  });
+
+  test("stream flag is set by the explicit parameter (true for SSE)", () => {
+    const req = makeRequest();
+    req.stream = false; // originalReq says false, but explicit arg overrides
+
+    const recallBlock = makeRecallToolUse();
+    const resp = makeResponse([recallBlock]);
+
+    const followUp = buildRecallFollowUpRequest(
+      req,
+      resp,
+      "result",
+      recallBlock,
+      /* stream */ true,
+    );
+
+    // The explicit stream arg wins — this is what the streaming follow-up
+    // path needs so parseSSEStream() receives an SSE body.
+    expect(followUp.stream).toBe(true);
   });
 
   test("preserves thinking blocks in assistant message for extended thinking", () => {
@@ -415,11 +446,12 @@ describe("buildRecallFollowUp", () => {
       "tool_use",
     );
 
-    const followUp = buildRecallFollowUp(
+    const followUp = buildRecallFollowUpRequest(
       req,
       resp,
       "## Recall Results\n* config is in /root",
       recallBlock,
+      /* stream */ false,
     );
 
     // Assistant message should contain thinking block + tool_use
@@ -454,7 +486,13 @@ describe("buildRecallFollowUp", () => {
       "tool_use",
     );
 
-    const followUp = buildRecallFollowUp(req, resp, "result", recallBlock);
+    const followUp = buildRecallFollowUpRequest(
+      req,
+      resp,
+      "result",
+      recallBlock,
+      false,
+    );
 
     const assistant = followUp.messages[1];
     // Only thinking + tool_use — original text blocks excluded
@@ -481,7 +519,13 @@ describe("buildRecallFollowUp", () => {
       "tool_use",
     );
 
-    const followUp = buildRecallFollowUp(req, resp, "result", recallBlock);
+    const followUp = buildRecallFollowUpRequest(
+      req,
+      resp,
+      "result",
+      recallBlock,
+      false,
+    );
 
     const assistant = followUp.messages[1];
     expect(assistant.content).toHaveLength(3);
@@ -504,7 +548,13 @@ describe("buildRecallFollowUp", () => {
       "tool_use",
     );
 
-    const followUp = buildRecallFollowUp(req, resp, "result", recallBlock);
+    const followUp = buildRecallFollowUpRequest(
+      req,
+      resp,
+      "result",
+      recallBlock,
+      false,
+    );
 
     const assistant = followUp.messages[1];
     // No thinking blocks — just the tool_use
@@ -523,7 +573,13 @@ describe("buildRecallFollowUp", () => {
     const recallBlock = makeRecallToolUse();
     const resp = makeResponse([recallBlock], "tool_use");
 
-    const followUp = buildRecallFollowUp(req, resp, "", recallBlock);
+    const followUp = buildRecallFollowUpRequest(
+      req,
+      resp,
+      "",
+      recallBlock,
+      false,
+    );
 
     const resultBlock = followUp.messages[2].content[0];
     expect(resultBlock.type).toBe("tool_result");
@@ -534,6 +590,203 @@ describe("buildRecallFollowUp", () => {
     expect((resultBlock as { toolUseId: string }).toolUseId).toBe(
       recallBlock.id,
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runRecallFollowUpStreaming / runRecallFollowUpJSON — coupled helpers
+// ---------------------------------------------------------------------------
+
+describe("runRecallFollowUpStreaming", () => {
+  const recallBlock = makeRecallToolUse("test query");
+  const resp = makeResponse([recallBlock], "tool_use");
+
+  function makeSseResponse(): Response {
+    return new Response("data: test\n\n", {
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+    });
+  }
+
+  test("sends stream:true and returns the SSE reader", async () => {
+    let capturedReq: GatewayRequest | null = null;
+    const ctx: RecallFollowUpCtx = {
+      forward: async (r) => {
+        capturedReq = r;
+        return { response: makeSseResponse(), effectiveProtocol: "anthropic" };
+      },
+      parseJSON: () => {
+        throw new Error("should not be called");
+      },
+    };
+
+    const result = await runRecallFollowUpStreaming(
+      ctx,
+      makeRequest(),
+      resp,
+      "recall results",
+      recallBlock,
+    );
+
+    expect(capturedReq?.stream).toBe(true);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.reader).toBeDefined();
+      expect(result.followUp).toBeDefined();
+      result.reader.cancel(); // cleanup
+    }
+  });
+
+  test("returns error when upstream responds with non-OK status", async () => {
+    const ctx: RecallFollowUpCtx = {
+      forward: async () => ({
+        response: new Response("bad request", {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        }),
+        effectiveProtocol: "anthropic",
+      }),
+      parseJSON: () => {
+        throw new Error("should not be called");
+      },
+    };
+
+    const result = await runRecallFollowUpStreaming(
+      ctx,
+      makeRequest(),
+      resp,
+      "recall results",
+      recallBlock,
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(400);
+      expect(result.detail).toBe("bad request");
+    }
+  });
+
+  test("throws on content-type mismatch (JSON instead of SSE) — #511 regression guard", async () => {
+    // This is the exact failure shape from #511: the follow-up returns JSON
+    // instead of SSE. Without the assertSSEResponse guard, parseSSEStream
+    // would silently yield zero events and the client would see dead air.
+    const ctx: RecallFollowUpCtx = {
+      forward: async () => ({
+        response: new Response(JSON.stringify({ type: "message" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+        effectiveProtocol: "anthropic",
+      }),
+      parseJSON: () => {
+        throw new Error("should not be called");
+      },
+    };
+
+    await expect(
+      runRecallFollowUpStreaming(
+        ctx,
+        makeRequest(),
+        resp,
+        "recall results",
+        recallBlock,
+      ),
+    ).rejects.toThrow("recall follow-up expected SSE");
+  });
+});
+
+describe("runRecallFollowUpJSON", () => {
+  const recallBlock = makeRecallToolUse("test query");
+  const resp = makeResponse([recallBlock], "tool_use");
+
+  test("sends stream:false and returns parsed continuation", async () => {
+    let capturedReq: GatewayRequest | null = null;
+    const fakeGatewayResponse: GatewayResponse = makeResponse(
+      [{ type: "text", text: "Here is the answer." }],
+      "end_turn",
+    );
+    const ctx: RecallFollowUpCtx = {
+      forward: async (r) => {
+        capturedReq = r;
+        return {
+          response: new Response(JSON.stringify({}), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+          effectiveProtocol: "anthropic",
+        };
+      },
+      parseJSON: async () => fakeGatewayResponse,
+    };
+
+    const result = await runRecallFollowUpJSON(
+      ctx,
+      makeRequest(),
+      resp,
+      "recall results",
+      recallBlock,
+    );
+
+    expect(capturedReq?.stream).toBe(false);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.continuation).toBe(fakeGatewayResponse);
+      expect(result.followUp).toBeDefined();
+    }
+  });
+
+  test("returns error when upstream responds with non-OK status", async () => {
+    const ctx: RecallFollowUpCtx = {
+      forward: async () => ({
+        response: new Response("server error", {
+          status: 500,
+          headers: { "content-type": "application/json" },
+        }),
+        effectiveProtocol: "anthropic",
+      }),
+      parseJSON: () => {
+        throw new Error("should not be called");
+      },
+    };
+
+    const result = await runRecallFollowUpJSON(
+      ctx,
+      makeRequest(),
+      resp,
+      "recall results",
+      recallBlock,
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(500);
+      expect(result.detail).toBe("server error");
+    }
+  });
+
+  test("throws on content-type mismatch (SSE instead of JSON)", async () => {
+    const ctx: RecallFollowUpCtx = {
+      forward: async () => ({
+        response: new Response("data: test\n\n", {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        }),
+        effectiveProtocol: "anthropic",
+      }),
+      parseJSON: () => {
+        throw new Error("should not be called after assert");
+      },
+    };
+
+    await expect(
+      runRecallFollowUpJSON(
+        ctx,
+        makeRequest(),
+        resp,
+        "recall results",
+        recallBlock,
+      ),
+    ).rejects.toThrow("recall follow-up expected JSON but got SSE");
   });
 });
 

--- a/packages/gateway/test/recall.test.ts
+++ b/packages/gateway/test/recall.test.ts
@@ -628,7 +628,8 @@ describe("runRecallFollowUpStreaming", () => {
       recallBlock,
     );
 
-    expect(capturedReq?.stream).toBe(true);
+    expect(capturedReq).not.toBeNull();
+    expect(capturedReq!.stream).toBe(true);
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.reader).toBeDefined();
@@ -727,7 +728,8 @@ describe("runRecallFollowUpJSON", () => {
       recallBlock,
     );
 
-    expect(capturedReq?.stream).toBe(false);
+    expect(capturedReq).not.toBeNull();
+    expect(capturedReq!.stream).toBe(false);
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.continuation).toBe(fakeGatewayResponse);


### PR DESCRIPTION
## Summary

Fixes the "conversation stops after recall" regression introduced by #511. The `buildRecallFollowUp()` helper hard-coded `stream: false`, which broke the streaming recall path: the upstream returned JSON but `parseSSEStream()` expected SSE — zero events parsed, dead air, the client never receives continuation content or terminal events.

## Root cause

`buildRecallFollowUp()` was shared by two recall consumers with **opposite** stream needs:

| Path | Consumer | Needs |
|---|---|---|
| Non-streaming (`pipeline.ts:4452`) | `accumulateNonStreamResponse()` (JSON) | `stream: false` ✓ |
| Streaming (`pipeline.ts:1958`) | `parseSSEStream(body.getReader())` (SSE) | `stream: true` ✗ |

The `stream: false` override was added in #511 to fix a JSON-parse crash in the non-streaming path, but applied unconditionally inside the shared builder — silently breaking streaming.

## Fix — 4 layered defenses to prevent recurrence

1. **Structural**: Replace the shared builder with two coupled helpers that each own BOTH the `stream` flag AND the matching response consumer:
   - `runRecallFollowUpStreaming()`: `stream:true` + `assertSSEResponse` + returns SSE reader
   - `runRecallFollowUpJSON()`: `stream:false` + `assertJSONResponse` + returns parsed `GatewayResponse`
   
2. **Compile-time**: The underlying `buildRecallFollowUpRequest()` takes a **required** `stream: boolean` (no default) — omitting it is a type error.

3. **Run-time**: `assertSSEResponse` / `assertJSONResponse` check upstream `content-type`. Any future mismatch throws a clear, greppable error instead of producing silent dead air.

4. **Test-time**: New tests for both helpers including a **#511 regression guard** that reproduces the exact failure shape (follow-up returns JSON on the streaming path → throws `recall follow-up expected SSE`).

## Changes
- `packages/gateway/src/recall.ts` — `RecallFollowUpCtx` interface, `buildRecallFollowUpRequest` (required `stream`), `runRecallFollowUpStreaming`, `runRecallFollowUpJSON`, content-type assertions
- `packages/gateway/src/pipeline.ts` — streaming site uses `runRecallFollowUpStreaming`, non-streaming site uses `runRecallFollowUpJSON`, ctx injection
- `packages/gateway/test/recall.test.ts` — updated builder tests + new suites for both coupled helpers + regression guards

## Testing
- Typecheck: all 4 packages clean
- Lint: clean
- Full suite: **2253 pass, 0 fail, 5 skip** (9830 expect() calls)