### PR TITLE
refactor(gateway): replace 5 last* SessionState fields with UpstreamSnapshot

### DIFF
--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -1060,8 +1060,8 @@ export function computeWarmingSnapshot(
   const survivalAtIdle = survivalFunction(blendedHist, idleMs);
 
   const profile = resolveProfile(
-    state.lastModel,
-    state.lastProtocol,
+    state.lastUpstream?.model,
+    state.lastUpstream?.protocol,
     state.resolvedConversationTTL,
   );
   const ttlMs = profile?.ttlMs ?? 300_000;
@@ -1356,8 +1356,9 @@ export async function executeWarmup(
 
   // Forward anthropic-beta from the last real request so beta-gated body
   // fields (e.g. context_management) are accepted by the upstream API.
-  if (state.lastAnthropicBeta) {
-    headers["anthropic-beta"] = state.lastAnthropicBeta;
+  const betaHeader = state.lastUpstream?.headers["anthropic-beta"];
+  if (betaHeader) {
+    headers["anthropic-beta"] = betaHeader;
   }
 
   // Re-sign the cch billing header. The cch hash covers the entire
@@ -1368,7 +1369,7 @@ export async function executeWarmup(
 
   log.info(
     `cache-warmer: sending warmup for session=${state.sessionID.slice(0, 16)} ` +
-      `model=${state.lastModel} ttl=${profile.ttlMs / 1000}s`,
+      `model=${state.lastUpstream?.model} ttl=${profile.ttlMs / 1000}s`,
   );
 
   try {
@@ -1458,7 +1459,7 @@ export async function executeWarmup(
     const ttl: "5m" | "1h" = profile.ttlMs >= 3_600_000 ? "1h" : "5m";
     recordWarmupCost(
       state.sessionID,
-      state.lastModel ?? "unknown",
+      state.lastUpstream?.model ?? "unknown",
       cacheReadTokens,
       cacheCreationTokens,
       ttl,

--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -209,8 +209,8 @@ export function startIdleScheduler(
       loadGlobalHistograms(state.projectPath);
 
       const profile = resolveProfile(
-        state.lastModel,
-        state.lastProtocol,
+        state.lastUpstream?.model,
+        state.lastUpstream?.protocol,
         state.resolvedConversationTTL,
       );
       if (!profile) continue;
@@ -466,7 +466,10 @@ export function buildIdleWorkHandler(
   return async (sessionID: string, state: SessionState) => {
     const projectPath = state.projectPath;
     const cfg = loreConfig();
-    const model = getWorkerModel(protocolToProviderID(state.lastProtocol));
+    const model = getWorkerModel(
+      state.lastUpstream?.providerID ??
+        protocolToProviderID(state.lastUpstream?.protocol),
+    );
 
     // 1. Distillation — force-distill ALL pending messages on idle, even
     // below minMessages. The cache is going cold; aggressive distillation

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -68,8 +68,9 @@ import type {
   GatewayToolUseBlock,
   GatewayToolResultBlock,
   SessionState,
+  UpstreamSnapshot,
 } from "./translate/types";
-import { blocksToText } from "./translate/types";
+import { blocksToText, forwardClientHeaders } from "./translate/types";
 import type { GatewayConfig } from "./config";
 import {
   getProjectPath,
@@ -925,15 +926,15 @@ function getLLMClient(config: GatewayConfig): LLMClient {
     // have their workers route directly to the provider API with the wrong
     // credentials (the proxy's key, not the provider's).
     // Only injects when no explicit upstreamUrl is already set, and the
-    // session has a non-default upstream (lastUpstreamUrl from a provider route).
+    // session has a non-default upstream (lastUpstream.url from a provider route).
     const inner: LLMClient = {
       async prompt(system, user, opts) {
         if (opts?.sessionID && !opts.upstreamUrl && !workerApiKey) {
           const state = sessions.get(opts.sessionID);
-          if (state?.lastUpstreamUrl) {
+          if (state?.lastUpstream?.url) {
             return rawClient.prompt(system, user, {
               ...opts,
-              upstreamUrl: state.lastUpstreamUrl,
+              upstreamUrl: state.lastUpstream.url,
             });
           }
         }
@@ -2783,7 +2784,7 @@ function postResponse(
           warmupHitThisTurn = true;
           sessionState.warmup.warmupHits++;
           emitWarmupHitMetric(
-            sessionState.lastModel ?? req.model,
+            sessionState.lastUpstream?.model ?? req.model,
             sessionState.resolvedConversationTTL ?? "5m",
           );
           // Record counterfactual savings: without warming, these cache
@@ -2817,40 +2818,28 @@ function postResponse(
         }
       }
     }
-    // Track model/protocol/beta for warmup profile resolution
-    sessionState.lastModel = req.model;
-    // Use provider-aware protocol resolution with the same providerRouteUsable
-    // guard as forwardToUpstream: only trust the provider route's protocol when
-    // it also has a usable URL (or headerUpstream is set). Otherwise fall back
-    // to model-prefix routing to avoid protocol/worker mismatch.
+    // Capture the full routing snapshot from this request. Workers, cache
+    // warmer, and idle handler all read from this single source of truth
+    // instead of reconstructing from individual last* fields.
     const lpProvider = extractProviderHeader(req.rawHeaders);
     const lpRoute = lpProvider ? resolveProviderRoute(lpProvider) : null;
     const lpHeaderUpstream = extractUpstreamUrlHeader(req.rawHeaders);
     const lpRouteUsable =
       lpRoute && (lpRoute.url != null || lpHeaderUpstream) ? lpRoute : null;
-    sessionState.lastProtocol =
+    const snapshotProtocol: "anthropic" | "openai" | "openai-responses" =
       req.protocol === "openai-responses"
         ? "openai-responses"
         : (lpRouteUsable?.protocol ??
           resolveUpstreamRoute(req.model)?.protocol ??
           req.protocol);
-    // Track the session's provider route so background workers (distillation,
-    // curation) can route through the same proxy/aggregator instead of hitting
-    // the direct provider API with the wrong credentials.
-    // Always update (including clearing) so a stale header isn't forwarded
-    // after the client switches providers mid-session.
-    // Exclude model-prefix routes from lastUpstreamUrl — those are default
-    // behavior (e.g. claude-* → api.anthropic.com) and don't need an
-    // override. Only header/provider-route overrides indicate a proxy session.
-    sessionState.lastProviderID = lpProvider || undefined;
-    sessionState.lastUpstreamUrl =
-      lpHeaderUpstream ?? lpRoute?.url ?? undefined;
-    // Capture anthropic-beta so cache-warmer can forward it — beta-gated
-    // body fields (e.g. context_management) need the header to be accepted.
-    // Always update (including clearing) so a stale header isn't forwarded
-    // after the client stops sending it.
-    sessionState.lastAnthropicBeta =
-      req.rawHeaders["anthropic-beta"] || undefined;
+
+    sessionState.lastUpstream = {
+      url: lpHeaderUpstream ?? lpRoute?.url ?? "",
+      protocol: snapshotProtocol,
+      providerID: lpProvider || undefined,
+      model: req.model,
+      headers: forwardClientHeaders(req.rawHeaders),
+    };
 
     // Reset warming state if session was marked dead or had active warming.
     // Dead flag is cleared so the next break gets a fresh ROI analysis.
@@ -2878,8 +2867,10 @@ function postResponse(
       sessionID,
       actualInput,
       resp.usage.outputTokens ?? 0,
-      getWorkerModel(protocolToProviderID(sessionState.lastProtocol))
-        ?.modelID ?? "unknown",
+      getWorkerModel(
+        sessionState.lastUpstream?.providerID ??
+          protocolToProviderID(sessionState.lastUpstream?.protocol),
+      )?.modelID ?? "unknown",
       req.model,
       sessionState.resolvedConversationTTL,
     );
@@ -2899,8 +2890,10 @@ function postResponse(
     ) {
       const modelInputCost =
         getModelEntrySync(
-          getWorkerModel(protocolToProviderID(sessionState.lastProtocol))
-            ?.modelID ?? "unknown",
+          getWorkerModel(
+            sessionState.lastUpstream?.providerID ??
+              protocolToProviderID(sessionState.lastUpstream?.protocol),
+          )?.modelID ?? "unknown",
         ).cost?.input ?? 3;
       const curationMultiplier =
         modelInputCost >= 5 ? 3 : modelInputCost >= 1 ? 2 : 1;
@@ -2939,7 +2932,9 @@ function scheduleBackgroundWork(
 
   const llm = getLLMClient(config);
   const cfg = loreConfig();
-  const sessionProvider = protocolToProviderID(sessionState.lastProtocol);
+  const sessionProvider =
+    sessionState.lastUpstream?.providerID ??
+    protocolToProviderID(sessionState.lastUpstream?.protocol);
   const model = getWorkerModel(sessionProvider);
 
   // When the OAuth account is near quota exhaustion, skip non-urgent
@@ -3192,7 +3187,9 @@ async function handleCompaction(
     sessionID,
     config,
     previousSummary: extractPreviousSummary(req),
-    sessionProviderID: protocolToProviderID(sessionState.lastProtocol),
+    sessionProviderID:
+      sessionState.lastUpstream?.providerID ??
+      protocolToProviderID(sessionState.lastUpstream?.protocol),
   });
 
   // If Lore's own summary generation failed (rate limits, auth issues, etc.),
@@ -3316,7 +3313,9 @@ export async function handleCompactEndpoint(
         typeof body.previous_summary === "string"
           ? body.previous_summary
           : undefined,
-      sessionProviderID: protocolToProviderID(state?.lastProtocol),
+      sessionProviderID:
+        state?.lastUpstream?.providerID ??
+        protocolToProviderID(state?.lastUpstream?.protocol),
     });
 
     if (summary == null) {
@@ -3574,8 +3573,8 @@ function isCacheWarm(state: SessionState): boolean {
   if (!warmup?.lastWarmupAt) return false;
 
   const profile = resolveWarmingProfile(
-    state.lastModel,
-    state.lastProtocol,
+    state.lastUpstream?.model,
+    state.lastUpstream?.protocol,
     state.resolvedConversationTTL,
   );
   if (!profile) return false;
@@ -5167,7 +5166,10 @@ async function handleCurateSlashCommand(
   const projectPath = state.projectPath;
   const { distillation, curator } = await import("@loreai/core");
   const llm = getLLMClient(config);
-  const model = getWorkerModel(protocolToProviderID(state.lastProtocol));
+  const model = getWorkerModel(
+    state.lastUpstream?.providerID ??
+      protocolToProviderID(state.lastUpstream?.protocol),
+  );
 
   log.info(`/lore:curate: running for session=${sessionID.slice(0, 16)}`);
 

--- a/packages/gateway/src/sentry.ts
+++ b/packages/gateway/src/sentry.ts
@@ -293,7 +293,7 @@ export function emitWarmupMetric(
 ): void {
   if (!Sentry.isInitialized()) return;
 
-  const model = state.lastModel ?? "unknown";
+  const model = state.lastUpstream?.model ?? "unknown";
   const ttl = state.resolvedConversationTTL ?? "5m";
   const attrs = { model, ttl };
 

--- a/packages/gateway/src/translate/types.ts
+++ b/packages/gateway/src/translate/types.ts
@@ -299,6 +299,24 @@ export type CacheAnalytics = {
   bustCount: number;
 };
 
+/** Routing snapshot captured from the last successful session request.
+ *  Workers (distillation, curation) and the cache warmer use this
+ *  to route through the same upstream with matching credentials.
+ *  Single source of truth — replaces lastModel, lastProtocol,
+ *  lastProviderID, lastUpstreamUrl, lastAnthropicBeta. */
+export interface UpstreamSnapshot {
+  /** Resolved upstream base URL (e.g., "https://api.minimax.io/anthropic"). */
+  url: string;
+  /** Wire protocol used for the request. */
+  protocol: "anthropic" | "openai" | "openai-responses";
+  /** Provider ID from X-Lore-Provider header (for worker model selection). */
+  providerID?: string;
+  /** Session model ID (for cost-aware worker model downgrade). */
+  model: string;
+  /** Non-managed headers to forward upstream (anthropic-beta, etc.). */
+  headers: Record<string, string>;
+}
+
 /** Per-session state tracked by the gateway for Lore pipeline decisions. */
 export type SessionState = {
   sessionID: string;
@@ -391,22 +409,9 @@ export type SessionState = {
   warmup?: WarmupState;
   /** Per-session survival model (inter-turn gap histogram). */
   survivalModel?: InterTurnHistogram;
-  /** Model name from the last real request (for warming profile resolution). */
-  lastModel?: string;
-  /** Protocol from the last real request (for warming profile resolution). */
-  lastProtocol?: "anthropic" | "openai" | "openai-responses";
-  /** Provider ID from the last request's `X-Lore-Provider` header. Used to
-   *  route worker calls through the same provider as the owning session. */
-  lastProviderID?: string;
-  /** Resolved upstream base URL from the last request. When set, worker calls
-   *  route through this URL instead of the default provider endpoint — ensures
-   *  proxy/aggregator sessions (e.g. OpenCode Zen) keep working for background
-   *  tasks like distillation and curation. */
-  lastUpstreamUrl?: string;
-  /** anthropic-beta header from the last real request — forwarded by
-   *  cache-warmer so beta-gated body fields (e.g. context_management)
-   *  are accepted upstream. */
-  lastAnthropicBeta?: string;
+  /** Routing snapshot from the last successful session request.
+   *  Used by workers, cache warmer, and idle handler. */
+  lastUpstream?: UpstreamSnapshot;
 
   // --- Amnesia mode ---
 

--- a/packages/gateway/test/cache-warmer.test.ts
+++ b/packages/gateway/test/cache-warmer.test.ts
@@ -60,8 +60,12 @@ function makeSessionState(overrides: Partial<SessionState> = {}): SessionState {
     consecutiveTextOnlyTurns: 0,
     recallStore: new Map(),
     cacheAnalytics: makeCacheAnalytics(),
-    lastModel: "claude-sonnet-4-20250514",
-    lastProtocol: "anthropic",
+    lastUpstream: {
+      url: "https://api.anthropic.com",
+      protocol: "anthropic" as const,
+      model: "claude-sonnet-4-20250514",
+      headers: {},
+    },
     resolvedConversationTTL: "5m",
     lastInputTokens: 100_000, // above MIN_INPUT_TOKENS_FOR_WARMING
     ...overrides,
@@ -348,7 +352,7 @@ describe("prepareAnthropicWarmupBody", () => {
     const result = JSON.parse(prepareAnthropicWarmupBody(body));
     // Beta-gated fields must NOT be stripped from the warmup body —
     // executeWarmup() forwards the anthropic-beta header from
-    // state.lastAnthropicBeta so the API accepts them.
+    // state.lastUpstream.headers["anthropic-beta"] so the API accepts them.
     expect(result.context_management).toEqual({ type: "auto" });
   });
 


### PR DESCRIPTION
## Summary

Replaces five individual `SessionState` fields (`lastModel`, `lastProtocol`, `lastProviderID`, `lastUpstreamUrl`, `lastAnthropicBeta`) with a single `lastUpstream: UpstreamSnapshot` struct. Workers, cache warmer, and idle handler all read from this single source of truth instead of reconstructing routing context from fragments.

Follow-up to #574 (fetch-level interception). The snapshot captures the full resolved routing from the last successful session request — URL, protocol, provider ID, model, and forwarded headers — in one assignment.

## Changes

- **`translate/types.ts`**: Add `UpstreamSnapshot` interface; replace 5 `last*` fields with `lastUpstream?: UpstreamSnapshot` on `SessionState`
- **`pipeline.ts`**: Capture snapshot in `postResponse()` using `forwardClientHeaders()`; update 12 read sites to use `lastUpstream`; prefer `snapshot.providerID` over `protocolToProviderID()` lossy mapping at all worker model selection sites
- **`idle.ts`**: Update 2 read sites (warming profile + worker model)
- **`cache-warmer.ts`**: Update 4 read sites (`anthropic-beta` header from `snapshot.headers`, model from `snapshot.model`)
- **`sentry.ts`**: Update 1 read site (warmup metric model attribute)
- **`cache-warmer.test.ts`**: Update test fixture to use `lastUpstream` struct

## What this eliminates

- **`protocolToProviderID()` lossy mapping**: Worker model selection now uses `snapshot.providerID` directly (e.g., `"github-copilot"` instead of collapsing to `"openai"`)
- **Dead code**: `lastProviderID` was written but never read — now it lives inside the snapshot where it's actually consumed
- **Fragmented state**: No more threading 5 individual fields through separate code paths — one struct, one assignment
- **Divergent sources of truth**: Workers and cache warmer read the same snapshot

## Verification

- `bun run typecheck`: 4/4 pass
- `bun run lint`: 0 errors
- `bun test`: 2258 pass, 0 fail
- `grep -rn 'lastModel\|lastProtocol\|lastProviderID\|lastUpstreamUrl\|lastAnthropicBeta' packages/gateway/src/`: only JSDoc on the new type