### PR TITLE
fix(gateway): use original fetch for upstream calls to prevent interceptor loop

### DIFF
--- a/packages/core/src/fetch-interceptor.ts
+++ b/packages/core/src/fetch-interceptor.ts
@@ -76,10 +76,34 @@ export function shouldIntercept(url: string, gatewayBase: string): boolean {
  *
  * Returns a cleanup function that restores the original `globalThis.fetch`.
  */
+/**
+ * The original `globalThis.fetch` captured before any interceptor was
+ * installed. The gateway (which may run in the same process) must use
+ * this for its own upstream calls to avoid being intercepted in a loop.
+ *
+ * Null until `installFetchInterceptor()` is called.
+ */
+let _originalFetch: typeof globalThis.fetch | null = null;
+
+/**
+ * Return the original, un-intercepted `fetch` function.
+ *
+ * When the gateway runs in-process alongside the plugin, it shares
+ * `globalThis.fetch` — which the interceptor patches. The gateway must
+ * use this function for its own upstream calls to avoid being caught by
+ * the interceptor in an infinite loop.
+ *
+ * Returns `globalThis.fetch` if no interceptor has been installed.
+ */
+export function getOriginalFetch(): typeof globalThis.fetch {
+  return _originalFetch ?? globalThis.fetch;
+}
+
 export function installFetchInterceptor(
   config: FetchInterceptorConfig,
 ): () => void {
-  const originalFetch = globalThis.fetch;
+  _originalFetch = globalThis.fetch;
+  const originalFetch = _originalFetch;
 
   const interceptor = async (
     input: RequestInfo | URL,
@@ -142,5 +166,6 @@ export function installFetchInterceptor(
   // Return cleanup function that restores the original fetch
   return () => {
     globalThis.fetch = originalFetch;
+    _originalFetch = null;
   };
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -174,6 +174,7 @@ export { workerSessionIDs, isWorkerSession } from "./worker";
 export { distillLimiter, curatorLimiter } from "./session-limiter";
 export {
   installFetchInterceptor,
+  getOriginalFetch,
   shouldIntercept,
   type FetchInterceptorConfig,
 } from "./fetch-interceptor";

--- a/packages/gateway/src/batch-queue.ts
+++ b/packages/gateway/src/batch-queue.ts
@@ -36,6 +36,7 @@ import {
 } from "./sentry";
 import { recordWorkerCost } from "./cost-tracker";
 import { normalizeOpenAIUsage } from "./llm-adapter";
+import { upstreamFetch } from "./fetch";
 
 // ---------------------------------------------------------------------------
 // BatchProvider strategy interface
@@ -207,7 +208,7 @@ export function createAnthropicBatchProvider(
       }));
 
       const url = `${baseUrl}/v1/messages/batches`;
-      const response = await fetch(url, {
+      const response = await upstreamFetch(url, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -241,7 +242,7 @@ export function createAnthropicBatchProvider(
 
     async poll(auth, batchId) {
       const url = `${baseUrl}/v1/messages/batches/${batchId}`;
-      const response = await fetch(url, {
+      const response = await upstreamFetch(url, {
         headers: {
           "anthropic-version": "2023-06-01",
           ...authHeaders(auth),
@@ -265,7 +266,7 @@ export function createAnthropicBatchProvider(
       // Batch is done — retrieve results
       const resultsUrl =
         data.results_url ?? `${baseUrl}/v1/messages/batches/${batchId}/results`;
-      const resultsResponse = await fetch(resultsUrl, {
+      const resultsResponse = await upstreamFetch(resultsUrl, {
         headers: {
           "anthropic-version": "2023-06-01",
           ...authHeaders(auth),
@@ -355,7 +356,7 @@ async function uploadOpenAIBatchFile(
     "batch.jsonl",
   );
 
-  const response = await fetch(`${baseUrl}/v1/files`, {
+  const response = await upstreamFetch(`${baseUrl}/v1/files`, {
     method: "POST",
     headers: authHeaders(auth), // No Content-Type — FormData sets it with boundary
     body: formData,
@@ -392,9 +393,12 @@ async function downloadOpenAIResults(
   auth: AuthCredential,
   fileId: string,
 ): Promise<BatchResult[]> {
-  const response = await fetch(`${baseUrl}/v1/files/${fileId}/content`, {
-    headers: authHeaders(auth),
-  });
+  const response = await upstreamFetch(
+    `${baseUrl}/v1/files/${fileId}/content`,
+    {
+      headers: authHeaders(auth),
+    },
+  );
   if (!response.ok) {
     log.error(`openai results download failed: ${response.status}`);
     return [];
@@ -514,7 +518,7 @@ export function createOpenAIBatchProvider(upstreamUrl: string): BatchProvider {
         return fileId;
 
       // 3. Create batch
-      const response = await fetch(`${baseUrl}/v1/batches`, {
+      const response = await upstreamFetch(`${baseUrl}/v1/batches`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -550,7 +554,7 @@ export function createOpenAIBatchProvider(upstreamUrl: string): BatchProvider {
     },
 
     async poll(auth, batchId) {
-      const response = await fetch(`${baseUrl}/v1/batches/${batchId}`, {
+      const response = await upstreamFetch(`${baseUrl}/v1/batches/${batchId}`, {
         headers: authHeaders(auth),
       });
 

--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -42,6 +42,7 @@ import { resignBody } from "./cch";
 import { resolveUpstreamRoute } from "./config";
 import { getModelEntrySync } from "./worker-model";
 import { recordWarmupCost } from "./cost-tracker";
+import { upstreamFetch } from "./fetch";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -1373,7 +1374,7 @@ export async function executeWarmup(
   );
 
   try {
-    const response = await fetch(profile.upstreamUrl, {
+    const response = await upstreamFetch(profile.upstreamUrl, {
       method: "POST",
       headers,
       body: signedBody,

--- a/packages/gateway/src/fetch.ts
+++ b/packages/gateway/src/fetch.ts
@@ -1,0 +1,28 @@
+/**
+ * Upstream-safe fetch for the gateway.
+ *
+ * When the gateway runs in-process alongside a plugin (OpenCode, Pi),
+ * `globalThis.fetch` may be patched by the fetch interceptor to redirect
+ * LLM API calls through the gateway. The gateway's own upstream calls
+ * must bypass this interception to avoid an infinite loop.
+ *
+ * This module re-exports the original, un-intercepted `fetch` via
+ * `getOriginalFetch()` from `@loreai/core`. All gateway code that
+ * makes HTTP requests to upstream LLM providers (or any external
+ * endpoint) should use `upstreamFetch` instead of bare `fetch`.
+ *
+ * When no interceptor is installed (standalone gateway, CLI), this
+ * falls back to `globalThis.fetch`.
+ */
+import { getOriginalFetch } from "@loreai/core";
+
+/**
+ * Fetch function that bypasses the plugin's fetch interceptor.
+ * Use this for all gateway upstream HTTP calls.
+ */
+export function upstreamFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<Response> {
+  return getOriginalFetch()(input, init);
+}

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -25,6 +25,7 @@ import {
   type AnthropicUsage,
 } from "./sentry";
 import { recordWorkerCost } from "./cost-tracker";
+import { upstreamFetch } from "./fetch";
 
 // ---------------------------------------------------------------------------
 // Worker call tracking
@@ -448,7 +449,7 @@ export function createGatewayLLMClient(
             for (let attempt = 0; ; attempt++) {
               let response: Response;
               try {
-                response = await fetch(req.url, {
+                response = await upstreamFetch(req.url, {
                   method: "POST",
                   headers: req.headers,
                   // opts.thinking is intentionally not forwarded — this bare API

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -216,6 +216,7 @@ import {
   replaceRecallWithMarker,
   isRecallMarker,
 } from "./recall";
+import { upstreamFetch } from "./fetch";
 
 // ---------------------------------------------------------------------------
 // Module state
@@ -1745,7 +1746,7 @@ async function forwardToUpstream(
       req.model,
       req.stream,
       () =>
-        fetch(url, {
+        upstreamFetch(url, {
           method: "POST",
           headers,
           body: serializedBody,
@@ -1754,7 +1755,7 @@ async function forwardToUpstream(
     return { response, serializedBody, effectiveProtocol };
   }
 
-  const response = await fetch(url, {
+  const response = await upstreamFetch(url, {
     method: "POST",
     headers,
     body: serializedBody,
@@ -3501,7 +3502,7 @@ async function passthroughResponsesCompact(
   if (openAiBeta) headers["openai-beta"] = openAiBeta;
 
   try {
-    const upstream = await fetch(upstreamUrl, {
+    const upstream = await upstreamFetch(upstreamUrl, {
       method: "POST",
       headers,
       body: bodyText,

--- a/packages/gateway/src/quota.ts
+++ b/packages/gateway/src/quota.ts
@@ -30,6 +30,7 @@ import { authFingerprint, resolveAuth } from "./auth";
 import { runBackground } from "./background-limiter";
 import { isClaudeCodeOAuthSession, buildOAuthWorkerHeaders } from "./cch";
 import { parseRetryAfter } from "./llm-adapter";
+import { upstreamFetch } from "./fetch";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -207,7 +208,7 @@ export async function fetchOAuthQuotaSnapshot(
     // turns. Anthropic's OAuth endpoints validate the client fingerprint and
     // can 403 a request that lacks a recognizable Claude Code user-agent.
     const ccHeaders = sessionID ? buildOAuthWorkerHeaders(sessionID) : null;
-    const response = await fetch(QUOTA_URL, {
+    const response = await upstreamFetch(QUOTA_URL, {
       method: "GET",
       headers: {
         Authorization: `Bearer ${cred.value}`,

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -32,6 +32,7 @@ import {
   handleResponsesCompactEndpoint,
   accumulateResponsesNonStreamJSON,
 } from "./pipeline";
+import { upstreamFetch } from "./fetch";
 
 // ---------------------------------------------------------------------------
 // Version — best-effort from package.json, falls back gracefully
@@ -195,9 +196,12 @@ async function handleModelsPassthrough(
     const anthropicVersion = req.headers.get("anthropic-version");
     if (anthropicVersion) headers["anthropic-version"] = anthropicVersion;
 
-    const upstream = await fetch(`${config.upstreamAnthropic}/v1/models`, {
-      headers,
-    });
+    const upstream = await upstreamFetch(
+      `${config.upstreamAnthropic}/v1/models`,
+      {
+        headers,
+      },
+    );
     // Clone to a new Response so we can append CORS headers
     const response = new Response(upstream.body, {
       status: upstream.status,

--- a/packages/gateway/src/worker-model.ts
+++ b/packages/gateway/src/worker-model.ts
@@ -10,6 +10,7 @@
 
 import { workerModel, config as loreConfig, log } from "@loreai/core";
 import type { ProviderRoute } from "./config";
+import { upstreamFetch } from "./fetch";
 
 // ---------------------------------------------------------------------------
 // Cost lookup — models.dev
@@ -166,7 +167,7 @@ export function fetchModelData(): Promise<Map<string, ModelsDevEntry>> {
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), 10_000);
 
-      const response = await fetch(MODELS_DEV_API, {
+      const response = await upstreamFetch(MODELS_DEV_API, {
         signal: controller.signal,
       });
       clearTimeout(timeout);


### PR DESCRIPTION
## Summary

Fixes an infinite loop caused by #574's fetch interceptor: when the gateway runs in-process with the plugin, its upstream `fetch()` calls were being intercepted and redirected back to itself.

## Problem

`installFetchInterceptor()` patches `globalThis.fetch`. The gateway shares `globalThis` when running in-process. Flow:
1. Plugin intercepts SDK `fetch(api.anthropic.com)` → redirects to gateway
2. Gateway processes request, calls `fetch(api.anthropic.com)` to upstream
3. Interceptor catches this too → redirects back to gateway
4. Infinite loop

## Fix

- **`@loreai/core`**: `installFetchInterceptor()` now stores the pre-patch fetch; new `getOriginalFetch()` export returns it
- **`packages/gateway/src/fetch.ts`** (new): `upstreamFetch()` wrapper that calls `getOriginalFetch()` — bypasses any installed interceptor
- **15 call sites** across 7 gateway files replaced: `fetch(` → `upstreamFetch(`
  - `pipeline.ts` (3), `batch-queue.ts` (7), `llm-adapter.ts` (1), `cache-warmer.ts` (1), `server.ts` (1), `worker-model.ts` (1), `quota.ts` (1)
- CLI files (`cli/`) are NOT changed — they don't run in-process with plugins

## Verification

- `bun run typecheck`: 4/4 pass
- `bun run lint`: 0 errors
- `bun test`: 2258 pass, 0 fail
- `grep -rn '\bfetch(' packages/gateway/src/ | grep -v cli/ | grep -v fetch.ts`: 0 bare fetch calls remain