### PR TITLE
fix(core): normalize provider API paths in fetch interceptor

### DIFF
--- a/packages/core/src/fetch-interceptor.ts
+++ b/packages/core/src/fetch-interceptor.ts
@@ -128,8 +128,9 @@ export function installFetchInterceptor(
     // any prefix) is passed via X-Lore-Upstream-URL.
     const upstream = new URL(url);
     const gateway = new URL(config.gatewayBase);
-    const v1Match = upstream.pathname.match(/(\/v1\/.*)$/);
-    const apiPath = v1Match?.[1] ?? upstream.pathname;
+    const v1Idx = upstream.pathname.lastIndexOf("/v1/");
+    const apiPath =
+      v1Idx >= 0 ? upstream.pathname.slice(v1Idx) : upstream.pathname;
     const gatewayUrl = `${gateway.origin}${apiPath}${upstream.search}`;
 
     // Merge original headers + X-Lore-* headers.
@@ -145,10 +146,10 @@ export function installFetchInterceptor(
 
     // Pass the original upstream base URL (everything before /v1/...).
     // The gateway uses this as the highest-priority routing signal.
-    const upstreamBase = v1Match
-      ? upstream.origin +
-        upstream.pathname.slice(0, upstream.pathname.length - v1Match[1].length)
-      : upstream.origin;
+    const upstreamBase =
+      v1Idx >= 0
+        ? upstream.origin + upstream.pathname.slice(0, v1Idx)
+        : upstream.origin;
     headers.set("x-lore-upstream-url", upstreamBase);
 
     // Inject dynamic context headers (session ID, project, git remote, etc.)

--- a/packages/core/src/fetch-interceptor.ts
+++ b/packages/core/src/fetch-interceptor.ts
@@ -25,7 +25,8 @@ export type FetchInterceptorConfig = {
 /**
  * LLM API path patterns that should be intercepted.
  * These are the standard paths used by Anthropic, OpenAI Chat Completions,
- * and OpenAI Responses API endpoints.
+ * and OpenAI Responses API endpoints. Some providers prefix with /api
+ * (e.g., OpenRouter uses /api/v1/chat/completions).
  */
 const LLM_API_PATH_PATTERN =
   /\/v1\/(messages|chat\/completions|responses)(\/.*)?$/;
@@ -120,10 +121,16 @@ export function installFetchInterceptor(
       return originalFetch(input, init);
     }
 
-    // Rewrite URL to gateway, preserving the path and query string
+    // Rewrite URL to gateway, keeping only the /v1/... API path.
+    // Provider base paths vary (e.g., openrouter.ai uses /api/v1/...,
+    // Anthropic uses /v1/...). The gateway only routes /v1/... paths,
+    // so we extract just that portion. The full original URL (including
+    // any prefix) is passed via X-Lore-Upstream-URL.
     const upstream = new URL(url);
     const gateway = new URL(config.gatewayBase);
-    const gatewayUrl = `${gateway.origin}${upstream.pathname}${upstream.search}`;
+    const v1Match = upstream.pathname.match(/(\/v1\/.*)$/);
+    const apiPath = v1Match?.[1] ?? upstream.pathname;
+    const gatewayUrl = `${gateway.origin}${apiPath}${upstream.search}`;
 
     // Merge original headers + X-Lore-* headers.
     // Original headers (including auth) are preserved — the gateway
@@ -136,10 +143,12 @@ export function installFetchInterceptor(
         : undefined);
     const headers = new Headers(existingHeaders);
 
-    // Pass the original upstream base URL (strip API path suffix).
+    // Pass the original upstream base URL (everything before /v1/...).
     // The gateway uses this as the highest-priority routing signal.
-    const upstreamBase =
-      upstream.origin + upstream.pathname.replace(/\/v1\/.*/, "");
+    const upstreamBase = v1Match
+      ? upstream.origin +
+        upstream.pathname.slice(0, upstream.pathname.length - v1Match[1].length)
+      : upstream.origin;
     headers.set("x-lore-upstream-url", upstreamBase);
 
     // Inject dynamic context headers (session ID, project, git remote, etc.)

--- a/packages/gateway/src/cost-tracker.ts
+++ b/packages/gateway/src/cost-tracker.ts
@@ -571,6 +571,10 @@ type Pricing = {
  * Falls back to sensible defaults (same logic as sentry.ts getPricing).
  */
 export function getPricingSync(model: string): Pricing {
+  // OpenRouter `:free` suffix models cost nothing — don't inflate budget.
+  if (model.endsWith(":free")) {
+    return { input: 0, output: 0, cache_read: 0, cache_write: 0 };
+  }
   const entry = getModelEntrySync(model);
   const input = entry.cost?.input ?? 3;
   return {

--- a/packages/gateway/src/worker-model.ts
+++ b/packages/gateway/src/worker-model.ts
@@ -125,6 +125,15 @@ const FALLBACK_PRICING: Array<{
 ];
 
 function fallbackEntry(modelID: string): ModelsDevEntry {
+  // OpenRouter `:free` suffix models cost nothing — don't inflate budget.
+  if (modelID.endsWith(":free")) {
+    return {
+      id: modelID,
+      cost: { input: 0, output: 0, cache_read: 0, cache_write: 0 },
+      limit: { context: 200_000, output: 8_192 },
+    };
+  }
+
   for (const fb of FALLBACK_PRICING) {
     if (modelID.startsWith(fb.prefix)) {
       return {


### PR DESCRIPTION
## Summary

Two fixes for OpenRouter and other non-standard provider support:

1. **Path normalization**: Providers use different base paths (e.g., OpenRouter uses `/api/v1/chat/completions`, Anthropic uses `/v1/messages`). The fetch interceptor now extracts only the `/v1/...` portion for the gateway URL since it only routes standard `/v1/` paths. The full original URL is passed via `X-Lore-Upstream-URL`.

2. **`:free` model zero-cost**: OpenRouter models with `:free` suffix (e.g., `nvidia/nemotron-3-ultra-550b-a55b:free`) were falling through to unknown-model fallback pricing ($3/M input, $15/M output — Opus-tier). This inflated the daily budget tracker and triggered throttling on free models. Now detected at both the pricing layer (`getPricingSync`) and fallback entry layer (`fallbackEntry`) and assigned $0 pricing.

## Changes

### Path normalization (`packages/core/src/fetch-interceptor.ts`)
- Use `lastIndexOf('/v1/')` to extract the API path suffix, handling providers with base path prefixes (e.g., `/api/v1/...`)
- Compute `X-Lore-Upstream-URL` as everything before the `/v1/` segment

### Free model pricing (`packages/gateway/src/`)
- `cost-tracker.ts`: `getPricingSync()` returns $0 for models ending in `:free`
- `worker-model.ts`: `fallbackEntry()` returns $0 cost for `:free` models (defense-in-depth — also checked when models.dev cache has no match)

## Verification

- `bun run typecheck`: 4/4 pass
- `bun run lint`: 0 errors
- `bun test`: 2258 pass, 0 fail
- Manual: OpenRouter `/api/v1/chat/completions` now routes correctly as `/v1/chat/completions`