### PR TITLE
fix(gateway): clear cached warmup body on provider/model switch

### DIFF
--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -2925,6 +2925,19 @@ function postResponse(
       model: req.model,
       headers: forwardClientHeaders(req.rawHeaders),
     };
+    // Detect provider switch: if the model or provider changed, the cached
+    // warmup body is stale (different model field at byte 10). Clear it to
+    // avoid false cache-bust warnings ("early divergence at byte 10") and
+    // wasted warmup requests that can never hit the cache prefix.
+    const prevUpstream = sessionState.lastUpstream;
+    if (
+      prevUpstream &&
+      (prevUpstream.model !== upstreamSnapshot.model ||
+        prevUpstream.providerID !== upstreamSnapshot.providerID)
+    ) {
+      sessionState.cacheAnalytics.lastRequestBody = null;
+    }
+
     sessionState.lastUpstream = upstreamSnapshot;
     // Store per-provider snapshot so workers/cache-warmer can look up the
     // correct URL and credentials when the session uses multiple providers.


### PR DESCRIPTION
## Problem

When a user switches providers mid-conversation (e.g., Anthropic → MiniMax → Anthropic), the cache analytics `lastRequestBody` holds the previous provider's request body. This causes:

```
cache-analytics: early divergence at byte 10
  prev: "{\"model\":\"MiniMax-M3\",...}"
  curr: "{\"model\":\"claude-opus-4-6\",...}"
```

The cache warmer compares the current request against the stale body and reports a false cache bust. The warmup body also targets the wrong model, wasting warmup requests that can never hit the cache prefix.

## Fix

In `postResponse()`, detect when the model or provider changes between turns by comparing the new upstream snapshot against the previous one. When a change is detected, clear `lastRequestBody` so the cache analytics start fresh for the new provider.

## Verification

- `pnpm run typecheck`: 4/4 pass
- `pnpm run lint`: 0 errors
- `pnpm test`: 2253 pass, 0 fail