### PR TITLE
fix(gateway): route NVIDIA and other OpenAI-protocol providers to OpenAI batch API

### DIFF
--- a/packages/gateway/src/batch-queue.ts
+++ b/packages/gateway/src/batch-queue.ts
@@ -28,6 +28,7 @@ import type { LLMClient } from "@loreai/core";
 import { log, getKV, setKV } from "@loreai/core";
 import * as Sentry from "@sentry/bun";
 import { authFingerprint, type AuthCredential } from "./auth";
+import { resolveProviderRoute } from "./config";
 import { authHeaders } from "./auth";
 import {
   setGenAiUsageAttributes,
@@ -635,8 +636,19 @@ export function createBatchLLMClient(
     openai: createOpenAIBatchProvider(upstreams.openai),
   };
 
+  // Map providerID to the correct batch provider. Providers using the
+  // OpenAI wire protocol (NVIDIA, OpenRouter, HuggingFace, etc.) route
+  // through the OpenAI batch provider since they share the same API format.
   function resolveProvider(providerID: string): BatchProvider {
-    return providers[providerID] ?? providers.anthropic;
+    if (providers[providerID]) return providers[providerID];
+    const route = resolveProviderRoute(providerID);
+    if (
+      route?.protocol === "openai" ||
+      route?.protocol === "openai-responses"
+    ) {
+      return providers.openai;
+    }
+    return providers.anthropic;
   }
 
   // State


### PR DESCRIPTION
## Problem

NVIDIA sessions (and other OpenAI-protocol providers like OpenRouter, HuggingFace) were falling through to the Anthropic batch provider, causing 401 auth errors:

```
batch flush (anthropic): submitting 1 requests
WARN: anthropic batch auth error (401): invalid x-api-key
batch API (anthropic) disabled for sessions [...]
worker upstream auth error: 401 Unauthorized — Invalid bearer token
```

The batch queue only had explicit providers for  and . NVIDIA's  is , which didn't match either.

## Fix

In , map any provider whose  is  or  to the OpenAI batch provider. This covers NVIDIA, OpenRouter, HuggingFace, and any future OpenAI-protocol providers automatically.

## Verification

- `pnpm run typecheck`: 4/4 pass
- `pnpm run lint`: 0 errors
- `pnpm test`: 2272 pass, 0 fail