### PR TITLE
fix(gateway): enforce same-provider worker routing — never cross-provider

### DIFF
--- a/packages/gateway/src/batch-queue.ts
+++ b/packages/gateway/src/batch-queue.ts
@@ -27,9 +27,7 @@
 import type { LLMClient } from "@loreai/core";
 import { log, getKV, setKV } from "@loreai/core";
 import * as Sentry from "@sentry/bun";
-import { authFingerprint, type AuthCredential } from "./auth";
-import { resolveProviderRoute } from "./config";
-import { authHeaders } from "./auth";
+import { authFingerprint, type AuthCredential, authHeaders } from "./auth";
 import {
   setGenAiUsageAttributes,
   emitCostMetric,
@@ -636,19 +634,11 @@ export function createBatchLLMClient(
     openai: createOpenAIBatchProvider(upstreams.openai),
   };
 
-  // Map providerID to the correct batch provider. Providers using the
-  // OpenAI wire protocol (NVIDIA, OpenRouter, HuggingFace, etc.) route
-  // through the OpenAI batch provider since they share the same API format.
-  function resolveProvider(providerID: string): BatchProvider {
-    if (providers[providerID]) return providers[providerID];
-    const route = resolveProviderRoute(providerID);
-    if (
-      route?.protocol === "openai" ||
-      route?.protocol === "openai-responses"
-    ) {
-      return providers.openai;
-    }
-    return providers.anthropic;
+  // Only Anthropic and OpenAI have batch APIs. Return the matching batch
+  // provider, or null for providers that don't support batching (NVIDIA,
+  // OpenRouter, etc.) — callers fall through to synchronous processing.
+  function resolveProvider(providerID: string): BatchProvider | null {
+    return providers[providerID] ?? null;
   }
 
   // State
@@ -847,7 +837,12 @@ export function createBatchLLMClient(
       }
       if (batchable.length > 0) {
         const provider = resolveProvider(providerID);
-        await submitBatch(provider, auth, batchable);
+        if (provider) {
+          await submitBatch(provider, auth, batchable);
+        } else {
+          // No batch API for this provider — process synchronously
+          await fallbackAll(batchable);
+        }
       }
     }
   }
@@ -1058,7 +1053,12 @@ export function createBatchLLMClient(
       // flush time — and for bearer tokens, the batch submit always 401s
       // before falling back to sync anyway.
       const providerID = (opts?.model ?? defaultModel).providerID;
-      if (disabledBatchProviders.has(providerID)) {
+      // Skip queue for providers without batch API support (NVIDIA, etc.)
+      // or providers whose batch endpoint has been disabled (404/auth error).
+      if (
+        !resolveProvider(providerID) ||
+        disabledBatchProviders.has(providerID)
+      ) {
         totalFallback++;
         return inner.prompt(system, user, opts);
       }

--- a/packages/gateway/src/cost-tracker.ts
+++ b/packages/gateway/src/cost-tracker.ts
@@ -1050,6 +1050,7 @@ export function computeHistoricalEstimates(
   // Resolve the worker model used for distillation calls.
   // Distillations run on the worker model (e.g. claude-sonnet-4-6), not the
   // conversation model (e.g. claude-opus-4-6). Use worker pricing for overhead.
+  // No session context available — use default provider for estimation.
   const workerResult = getWorkerModel();
   const workerModelID = workerResult?.modelID ?? DEFAULT_ESTIMATION_MODEL;
   const workerPricing = getPricingSync(workerModelID);

--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -462,7 +462,7 @@ export function buildIdleWorkHandler(
   return async (sessionID: string, state: SessionState) => {
     const projectPath = state.projectPath;
     const cfg = loreConfig();
-    const model = getWorkerModel(state.lastUpstream?.providerID);
+    const model = getWorkerModel(state.lastUpstream);
 
     // 1. Distillation — force-distill ALL pending messages on idle, even
     // below minMessages. The cache is going cold; aggressive distillation

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -4,9 +4,9 @@
  * running inside the gateway process.
  *
  * Supports both Anthropic Messages API and OpenAI Chat Completions API.
- * The provider is selected at call time based on `model.providerID`:
- *   - "anthropic" → POST /v1/messages (Anthropic wire format)
- *   - "openai"    → POST /v1/chat/completions (OpenAI wire format)
+ * The wire protocol is resolved from the provider route registry:
+ *   - Anthropic-protocol providers → POST /v1/messages
+ *   - OpenAI-protocol providers   → POST /v1/chat/completions
  *
  * Retry logic, Sentry instrumentation, worker call tracking, and error
  * handling are shared across both providers.
@@ -18,6 +18,7 @@ import * as Sentry from "@sentry/bun";
 import type { AuthCredential } from "./auth";
 import { authHeaders, markAuthStale } from "./auth";
 import { tripCircuitBreaker } from "./background-limiter";
+import { resolveProviderRoute } from "./config";
 import { buildBillingBlock, buildOAuthWorkerHeaders, signBody } from "./cch";
 import {
   setGenAiUsageAttributes,
@@ -165,24 +166,43 @@ type ProviderTarget = {
   providerName: string;
 };
 
+/**
+ * Determine whether a provider uses the OpenAI wire protocol.
+ * Checks the provider route registry (PROVIDER_ROUTES) for the wire
+ * protocol. Falls back to name-based heuristic for unregistered providers.
+ * When an upstream override is active, the route's protocol is the source
+ * of truth — the override URL accepts the provider's native format.
+ */
+function resolveIsOpenAI(
+  providerID: string,
+  _upstreamOverride?: string,
+): boolean {
+  const route = resolveProviderRoute(providerID);
+  if (route?.protocol) {
+    return route.protocol === "openai" || route.protocol === "openai-responses";
+  }
+  // Proxy/aggregator (protocol=null) or unknown provider: fall back to
+  // name-based heuristic. Anthropic is the only known non-OpenAI provider.
+  return providerID !== "anthropic";
+}
+
 /** Resolve upstream target based on model provider.
  *  When `upstreamOverride` is set, the request routes to that URL instead
- *  of the default — used for proxy/aggregator sessions (e.g. OpenCode Zen)
- *  where the session's credentials only work against the proxy endpoint. */
+ *  of the default — used for same-provider routing where the session's
+ *  credentials only work against the session's endpoint. */
 function resolveTarget(
   upstreams: { anthropic: string; openai: string },
   providerID: string,
+  isOpenAI: boolean,
   upstreamOverride?: string,
 ): ProviderTarget {
   if (upstreamOverride) {
-    // Proxy/aggregator route — providerName reflects the wire protocol
-    // target, not the physical endpoint. The override URL IS the endpoint.
     return {
       url: upstreamOverride.replace(/\/$/, ""),
-      providerName: providerID === "openai" ? "openai" : "anthropic",
+      providerName: isOpenAI ? "openai" : "anthropic",
     };
   }
-  if (providerID === "openai") {
+  if (isOpenAI) {
     return {
       url: upstreams.openai.replace(/\/$/, ""),
       providerName: "openai",
@@ -359,11 +379,12 @@ export function createGatewayLLMClient(
         log.warn("no auth credentials available for worker call");
         return null;
       }
-      const isOpenAI = model.providerID === "openai";
       const upstreamOverride = opts?.upstreamUrl;
+      const isOpenAI = resolveIsOpenAI(model.providerID, upstreamOverride);
       const target = resolveTarget(
         upstreams,
         model.providerID,
+        isOpenAI,
         upstreamOverride,
       );
       const maxTokens = opts?.maxTokens ?? 8192;

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -937,61 +937,20 @@ function getLLMClient(config: GatewayConfig): LLMClient {
     // credentials (the proxy's key, not the provider's).
     //
     // When the session has used multiple providers (e.g. Anthropic + MiniMax),
-    // inject the upstream URL only when the snapshot's provider matches the
-    // worker's target. This prevents routing a Claude worker model through
-    // MiniMax's API (which rejects non-MiniMax models with 401).
-    //
-    // The providerID in the snapshot is the X-Lore-Provider header value
-    // (e.g. "minimax-coding-plan", "anthropic", "openrouter"). The worker
-    // model's providerID is a canonical name (e.g. "anthropic", "openai").
-    // We match by checking if the snapshot's providerID exactly equals the
-    // worker model's providerID. When no exact match exists (e.g. worker
-    // wants "anthropic" but session only used "minimax-coding-plan"), we
-    // DON'T inject any upstream URL — the worker uses its default upstream
-    // (api.anthropic.com), which is correct for a Claude worker model.
+    // Workers always use the same provider as the session. Route worker
+    // calls through the session's upstream URL so they use the session's
+    // credentials and endpoint. When a dedicated worker API key is set
+    // (LORE_WORKER_API_KEY), skip URL injection — the worker uses its own
+    // credentials and default upstream.
     const inner: LLMClient = {
       async prompt(system, user, opts) {
         if (opts?.sessionID && !opts.upstreamUrl && !workerApiKey) {
           const state = sessions.get(opts.sessionID);
-          if (state) {
-            const workerProviderID = opts.model?.providerID;
-
-            // Look for a snapshot whose provider exactly matches the worker's
-            // target (e.g. worker="anthropic" matches snapshot="anthropic").
-            //
-            // When no exact match is found, check if the session's last
-            // provider is a proxy/aggregator (protocol=null in PROVIDER_ROUTES,
-            // e.g. OpenCode Zen). Proxy credentials only work through the
-            // proxy URL, so workers must route through it too. For direct
-            // providers (MiniMax, OpenRouter), DON'T fall back — the worker
-            // should use its default upstream to avoid sending wrong models
-            // to provider-specific APIs.
-            let snapshot: typeof state.lastUpstream;
-            if (workerProviderID) {
-              snapshot = state.upstreamByProvider.get(workerProviderID);
-              if (
-                !snapshot &&
-                state.lastUpstream?.url &&
-                state.lastUpstream.providerID
-              ) {
-                const route = resolveProviderRoute(
-                  state.lastUpstream.providerID,
-                );
-                if (route && route.protocol === null) {
-                  // Proxy/aggregator (protocol=null) — route workers through it
-                  snapshot = state.lastUpstream;
-                }
-              }
-            } else {
-              snapshot = state.lastUpstream;
-            }
-
-            if (snapshot?.url) {
-              return rawClient.prompt(system, user, {
-                ...opts,
-                upstreamUrl: snapshot.url,
-              });
-            }
+          if (state?.lastUpstream?.url) {
+            return rawClient.prompt(system, user, {
+              ...opts,
+              upstreamUrl: state.lastUpstream.url,
+            });
           }
         }
         return rawClient.prompt(system, user, opts);
@@ -2974,8 +2933,7 @@ function postResponse(
       sessionID,
       actualInput,
       resp.usage.outputTokens ?? 0,
-      getWorkerModel(sessionState.lastUpstream?.providerID)?.modelID ??
-        "unknown",
+      getWorkerModel(sessionState.lastUpstream)?.modelID ?? "unknown",
       req.model,
       sessionState.resolvedConversationTTL,
     );
@@ -2995,8 +2953,7 @@ function postResponse(
     ) {
       const modelInputCost =
         getModelEntrySync(
-          getWorkerModel(sessionState.lastUpstream?.providerID)?.modelID ??
-            "unknown",
+          getWorkerModel(sessionState.lastUpstream)?.modelID ?? "unknown",
         ).cost?.input ?? 3;
       const curationMultiplier =
         modelInputCost >= 5 ? 3 : modelInputCost >= 1 ? 2 : 1;
@@ -3035,8 +2992,7 @@ function scheduleBackgroundWork(
 
   const llm = getLLMClient(config);
   const cfg = loreConfig();
-  const sessionProvider = sessionState.lastUpstream?.providerID;
-  const model = getWorkerModel(sessionProvider);
+  const model = getWorkerModel(sessionState.lastUpstream);
 
   // When the OAuth account is near quota exhaustion, skip non-urgent
   // background work to preserve remaining entitlement for user-facing turns.
@@ -3107,8 +3063,9 @@ function scheduleBackgroundWork(
   if (isBackgroundPaused() || quotaPaused) return;
 
   const modelInputCost =
-    getModelEntrySync(getWorkerModel(sessionProvider)?.modelID ?? "unknown")
-      .cost?.input ?? 3;
+    getModelEntrySync(
+      getWorkerModel(sessionState.lastUpstream)?.modelID ?? "unknown",
+    ).cost?.input ?? 3;
   const curationMultiplier =
     modelInputCost >= 5 ? 3 : modelInputCost >= 1 ? 2 : 1;
   const effectiveAfterTurns = cfg.curator.afterTurns * curationMultiplier;
@@ -3169,15 +3126,15 @@ export async function generateCompactionSummary(opts: {
   sessionID: string;
   config: GatewayConfig;
   previousSummary?: string;
-  sessionProviderID?: string;
+  sessionUpstream?: { providerID?: string; modelID?: string };
 }): Promise<string | null> {
-  const { projectPath, sessionID, config, previousSummary, sessionProviderID } =
+  const { projectPath, sessionID, config, previousSummary, sessionUpstream } =
     opts;
   const llm = getLLMClient(config);
 
   // 1. Force-distill all undistilled messages.
   // Mark urgent: true — client is blocking on the compaction response.
-  const model = getWorkerModel(sessionProviderID);
+  const model = getWorkerModel(sessionUpstream);
   await distillation.run({
     llm,
     projectPath,
@@ -3239,7 +3196,7 @@ export async function generateCompactionSummary(opts: {
     Math.min(Math.ceil(compactInputTokens * 0.5), 20_000),
   );
   const summaryText = await llm.prompt(compactPrompt, userContent, {
-    model: getWorkerModel(sessionProviderID),
+    model: getWorkerModel(sessionUpstream),
     workerID: "lore-compact",
     urgent: true,
     maxTokens: compactMaxTokens,
@@ -3288,7 +3245,7 @@ async function handleCompaction(
     sessionID,
     config,
     previousSummary: extractPreviousSummary(req),
-    sessionProviderID: sessionState.lastUpstream?.providerID,
+    sessionUpstream: sessionState.lastUpstream,
   });
 
   // If Lore's own summary generation failed (rate limits, auth issues, etc.),
@@ -3420,7 +3377,7 @@ export async function handleCompactEndpoint(
         typeof body.previous_summary === "string"
           ? body.previous_summary
           : undefined,
-      sessionProviderID: state?.lastUpstream?.providerID,
+      sessionUpstream: state?.lastUpstream,
     });
 
     if (summary == null) {
@@ -5329,7 +5286,7 @@ async function handleCurateSlashCommand(
   const projectPath = state.projectPath;
   const { distillation, curator } = await import("@loreai/core");
   const llm = getLLMClient(config);
-  const model = getWorkerModel(state.lastUpstream?.providerID);
+  const model = getWorkerModel(state.lastUpstream);
 
   log.info(`/lore:curate: running for session=${sessionID.slice(0, 16)}`);
 

--- a/packages/gateway/src/worker-model.ts
+++ b/packages/gateway/src/worker-model.ts
@@ -434,9 +434,11 @@ function resolveGitHubCopilotWorker(sessionModelID: string): {
  *  3. General fallback (GPT-5.4-mini) for unknown providers
  *  4. Config model fallback (session model)
  */
-export function getWorkerModel(
-  sessionProviderID?: string,
-): { providerID: string; modelID: string } | undefined {
+export function getWorkerModel(session?: {
+  providerID?: string;
+  /** Session model ID (UpstreamSnapshot uses `model`, callers may use `modelID`). */
+  model?: string;
+}): { providerID: string; modelID: string } | undefined {
   // Env var override — highest priority. Useful for global worker model
   // configuration without per-project .lore.json (e.g. routing all workers
   // to MiniMax). Format: "providerID/modelID" or just "modelID" (defaults
@@ -456,42 +458,58 @@ export function getWorkerModel(
 
   const cfg = loreConfig();
 
-  // Determine if the session model is expensive enough to warrant a cheaper worker
+  // The session's actual provider and model (from the last API request).
+  // Workers MUST use the same provider as the session — cross-provider
+  // calls always fail (wrong credentials, wrong API format).
+  const sessionProviderID = session?.providerID;
+  const sessionModelID = session?.model;
+
+  // Effective provider: explicit config > session > anthropic default.
+  const effectiveProvider =
+    cfg.model?.providerID ?? sessionProviderID ?? "anthropic";
+
+  // Effective session model: config > session snapshot > provider default.
+  const effectiveModelID = cfg.model?.modelID ?? sessionModelID ?? undefined;
+
+  // Determine if the session model is expensive enough to warrant a cheaper
+  // worker from the SAME provider. Never cross-provider.
   let costAwareDefault: { providerID: string; modelID: string } | undefined;
-  if (cfg.model?.modelID && cfg.model?.providerID) {
-    const entry = getModelEntrySync(cfg.model.modelID);
+  if (effectiveModelID) {
+    const entry = getModelEntrySync(effectiveModelID);
     const inputCost = entry.cost?.input ?? 3;
 
     if (inputCost >= EXPENSIVE_MODEL_THRESHOLD) {
-      const providerID = cfg.model.providerID;
-
-      if (providerID === "github-copilot") {
+      if (effectiveProvider === "github-copilot") {
         // GitHub Copilot proxies many providers — detect family from model ID
-        costAwareDefault = resolveGitHubCopilotWorker(cfg.model.modelID);
+        costAwareDefault = resolveGitHubCopilotWorker(effectiveModelID);
       } else {
-        const mapping = WORKER_DEFAULTS[providerID];
-        if (mapping && !mapping.alreadyCheap(cfg.model.modelID)) {
+        const mapping = WORKER_DEFAULTS[effectiveProvider];
+        if (mapping && !mapping.alreadyCheap(effectiveModelID)) {
           costAwareDefault = {
             providerID: mapping.providerID,
             modelID: mapping.modelID,
           };
         }
-        // Unknown providers (Google, xAI, Mistral, etc.): fall back to session
-        // model rather than calling a provider that may not be configured.
+        // Unknown providers (Google, xAI, Mistral, NVIDIA, etc.): no cheaper
+        // validated model available — fall through to use session model as-is.
       }
     }
   }
 
-  // When no session model is configured (no .lore.json or no model field),
-  // use the session's provider to pick a compatible default. Without this,
-  // an OpenAI-only session (e.g. Codex) would get an Anthropic worker model
-  // and every worker call would send the OpenAI key to api.anthropic.com → 401.
-  const effectiveProvider =
-    cfg.model?.providerID ?? sessionProviderID ?? "anthropic";
-  const fallback =
+  // Build the fallback model (used when no cost-aware default or config
+  // override applies). Priority:
+  //   1. Config model from .lore.json
+  //   2. Session model (actual model from the last API request)
+  //   3. Provider's default worker model (WORKER_DEFAULTS)
+  //   4. undefined → skip background work
+  const fallback: { providerID: string; modelID: string } | undefined =
     cfg.model ??
-    WORKER_DEFAULTS[effectiveProvider] ??
-    WORKER_DEFAULTS.anthropic;
+    (sessionModelID
+      ? { providerID: effectiveProvider, modelID: sessionModelID }
+      : undefined) ??
+    WORKER_DEFAULTS[effectiveProvider];
+
+  if (!fallback) return undefined;
 
   return workerModel.resolveWorkerModel(
     effectiveProvider,


### PR DESCRIPTION
## Problem

Workers (distillation, curation, query expansion) were crossing provider boundaries. An NVIDIA session would resolve to an Anthropic worker model, then try to call api.anthropic.com with NVIDIA credentials → 401.

The batch queue would also route NVIDIA sessions to the Anthropic batch API, causing more 401s.

## Rules Enforced

1. **Same provider, always.** Workers use the session's provider — never cross-provider.
2. **Same model or cheaper.** Use the session model, or a cheaper validated model from the same provider (sonnet-4.6 floor for Anthropic, gpt-5.4-mini for OpenAI). Unknown providers use the session model as-is.
3. **Batch if available.** Use batch API only when the provider supports it (Anthropic, OpenAI). Never switch providers to get batch access.

## Changes

### `worker-model.ts` — `getWorkerModel()` redesign
- Accepts `{ providerID, model }` (full UpstreamSnapshot fields) instead of just `providerID`
- Uses session model as fallback for unknown providers (NVIDIA, Google, xAI, etc.) instead of cross-provider `WORKER_DEFAULTS.anthropic`
- Returns `undefined` when no model can be resolved (no session, no config, no defaults)

### `pipeline.ts` — simplified session-aware LLM wrapper
- Workers always route through the session's upstream URL (`state.lastUpstream.url`)
- Removed complex cross-provider matching and proxy/aggregator detection
- All callers pass full `lastUpstream` snapshot to `getWorkerModel()`

### `llm-adapter.ts` — protocol-aware request format
- New `resolveIsOpenAI()` determines wire protocol from provider route registry instead of hardcoded `providerID === "openai"` check
- NVIDIA (OpenAI-protocol) workers now correctly build OpenAI-format requests

### `batch-queue.ts` — no cross-provider batching
- `resolveProvider()` returns `null` for providers without batch API support
- Enqueue path skips queue entirely for non-batchable providers
- Flush path falls back to synchronous processing when no batch provider found

## Verification

- `pnpm run typecheck`: 4/4 pass
- `pnpm run lint`: 0 errors
- `pnpm test`: 2272 pass, 0 fail