### PR TITLE
fix(gateway): remove unused providerID param from resolveTarget

### DIFF
--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -192,7 +192,6 @@ function resolveIsOpenAI(
  *  credentials only work against the session's endpoint. */
 function resolveTarget(
   upstreams: { anthropic: string; openai: string },
-  providerID: string,
   isOpenAI: boolean,
   upstreamOverride?: string,
 ): ProviderTarget {
@@ -381,12 +380,7 @@ export function createGatewayLLMClient(
       }
       const upstreamOverride = opts?.upstreamUrl;
       const isOpenAI = resolveIsOpenAI(model.providerID, upstreamOverride);
-      const target = resolveTarget(
-        upstreams,
-        model.providerID,
-        isOpenAI,
-        upstreamOverride,
-      );
+      const target = resolveTarget(upstreams, isOpenAI, upstreamOverride);
       const maxTokens = opts?.maxTokens ?? 8192;
 
       // Defense-in-depth: detect API key / provider mismatch before making


### PR DESCRIPTION
## Summary

`resolveTarget()` in `packages/gateway/src/llm-adapter.ts` had a `providerID` parameter that became dead after #588 ("enforce same-provider worker routing") removed the last in-body reference. Biome flags it with `lint/correctness/noUnusedFunctionParameters`.

## Fix

Remove the unused parameter entirely, along with the corresponding `model.providerID` argument at the call site (`llm-adapter.ts:386`).

## Verification

- `pnpm run typecheck` → 4/4 packages pass
- `pnpm test` → 2270/2270 tests pass
- `pnpm run lint` → warnings dropped from 5 to 4