### PR TITLE
fix(entities): fix self/person merge, dashboard UX, and alias copy bug

### DIFF
--- a/packages/core/src/entities.ts
+++ b/packages/core/src/entities.ts
@@ -410,7 +410,7 @@ export function ensureSelfEntity(
     }
     // Only re-embed when the name or alias set actually changed.
     if (changed) reembedEntity(existing.id);
-    return getSelfEntity();
+    return finalizeSelfEntity(getSelfEntity()!);
   }
 
   // Create self entity
@@ -437,7 +437,74 @@ export function ensureSelfEntity(
     crossProject: true,
   });
 
-  return result.id ? getSelfEntity() : null;
+  const created = result.id ? getSelfEntity() : null;
+  return created ? finalizeSelfEntity(created) : null;
+}
+
+/**
+ * After ensuring the self entity exists, check for "person" entities that
+ * share a canonical name or alias with the self entity and merge them in.
+ * This handles the case where the LLM curator created a "person" entity for
+ * the user (it cannot create "self" type) before or alongside the self entity.
+ */
+function finalizeSelfEntity(self: EntityWithAliases): EntityWithAliases {
+  const count = mergeSelfPersonDuplicates(self);
+  if (count > 0) {
+    log.info(
+      `merged ${count} person entit${count === 1 ? "y" : "ies"} into self entity`,
+    );
+    return getSelfEntity()!; // re-fetch with merged aliases
+  }
+  return self;
+}
+
+/**
+ * Find "person" entities whose canonical name or alias values overlap with the
+ * self entity's aliases, and merge them into the self entity.
+ * Exported for testing.
+ *
+ * NOTE: The alias set used for matching is captured once before the loop and
+ * is NOT refreshed after each merge. This means transitive overlaps (person A
+ * has alias X → merges into self → self now has alias Y from A → person B has
+ * alias Y) require a second pass to converge. Since `ensureSelfEntity` runs on
+ * every curator invocation, this converges naturally across sessions.
+ */
+export function mergeSelfPersonDuplicates(
+  selfEntity: EntityWithAliases,
+): number {
+  // Collect all self alias values (lowercased) including canonical_name
+  const selfAliasValues = new Set<string>();
+  selfAliasValues.add(selfEntity.canonical_name.toLowerCase());
+  for (const a of selfEntity.aliases) {
+    selfAliasValues.add(a.alias_value.toLowerCase());
+  }
+
+  // Find all "person" entities
+  const persons = db()
+    .query(`SELECT ${ENTITY_COLS} FROM entities WHERE entity_type = 'person'`)
+    .all() as Entity[];
+
+  // For each person, check canonical_name or alias overlap
+  let mergedCount = 0;
+  for (const person of persons) {
+    if (selfAliasValues.has(person.canonical_name.toLowerCase())) {
+      merge(selfEntity.id, person.id); // absorb person into self
+      mergedCount++;
+      continue;
+    }
+    // Check alias overlap
+    const personAliases = db()
+      .query("SELECT alias_value FROM entity_aliases WHERE entity_id = ?")
+      .all(person.id) as Array<{ alias_value: string }>;
+    const hasOverlap = personAliases.some((a) =>
+      selfAliasValues.has(a.alias_value.toLowerCase()),
+    );
+    if (hasOverlap) {
+      merge(selfEntity.id, person.id);
+      mergedCount++;
+    }
+  }
+  return mergedCount;
 }
 
 // ---------------------------------------------------------------------------
@@ -849,36 +916,18 @@ export function merge(targetId: string, sourceId: string): void {
   const d = db();
   d.exec("BEGIN IMMEDIATE");
   try {
-    // Move aliases from source to target (skip duplicates via OR IGNORE)
-    const sourceAliases = d
-      .query(
-        "SELECT alias_type, alias_value, source FROM entity_aliases WHERE entity_id = ?",
-      )
-      .all(sourceId) as Array<{
-      alias_type: string;
-      alias_value: string;
-      source: string | null;
-    }>;
-
-    for (const a of sourceAliases) {
-      try {
-        d.query(
-          `INSERT INTO entity_aliases (id, entity_id, alias_type, alias_value, source, created_at)
-           VALUES (?, ?, ?, ?, ?, ?)`,
-        ).run(
-          uuidv7(),
-          targetId,
-          a.alias_type,
-          a.alias_value,
-          a.source,
-          Date.now(),
-        );
-      } catch (e: unknown) {
-        // UNIQUE constraint — alias already exists on target, skip
-        if (!(e instanceof Error && /UNIQUE constraint/i.test(e.message)))
-          throw e;
-      }
-    }
+    // Move aliases from source to target. The UNIQUE(alias_type, alias_value)
+    // constraint is table-wide, so we UPDATE entity_id rather than
+    // INSERT+DELETE — the source still owns the row and INSERT would always
+    // conflict. Aliases that already exist on the target (same type+value)
+    // are dropped via OR IGNORE + cleanup.
+    d.query(
+      `UPDATE OR IGNORE entity_aliases SET entity_id = ?, created_at = ?
+       WHERE entity_id = ?`,
+    ).run(targetId, Date.now(), sourceId);
+    // Clean up any source aliases left behind (OR IGNORE skipped them because
+    // target already has the same alias_type+alias_value pair)
+    d.query("DELETE FROM entity_aliases WHERE entity_id = ?").run(sourceId);
 
     // Move knowledge_entity_refs from source to target
     d.query(
@@ -1642,7 +1691,8 @@ export async function deduplicateEntities(
 export type EntityDedupFeedbackSource =
   | "auto_dedup"
   | "cli_yes"
-  | "cli_interactive";
+  | "cli_interactive"
+  | "dashboard";
 
 const MIN_ENTITY_CALIBRATION_SAMPLES = 20;
 /** Only record auto-signals for pairs with similarity >= this floor. */

--- a/packages/core/test/entities.test.ts
+++ b/packages/core/test/entities.test.ts
@@ -803,5 +803,234 @@ describe("entities", () => {
       expect(rels.length).toBe(1);
       expect(rels[0].other_name).toBe("MergeOther");
     });
+
+    test("merge transfers non-overlapping aliases from source to target", () => {
+      const target = entities.create({
+        projectPath: PROJECT,
+        entityType: "person",
+        canonicalName: "TargetPerson",
+        aliases: [
+          { type: "email", value: "target@example.com", source: "auto" },
+        ],
+      });
+      const source = entities.create({
+        projectPath: PROJECT,
+        entityType: "person",
+        canonicalName: "SourcePerson",
+        aliases: [
+          { type: "github", value: "source-gh", source: "curator" },
+          { type: "slack", value: "source-slack", source: "curator" },
+        ],
+      });
+
+      entities.merge(target.id, source.id);
+
+      expect(entities.get(source.id)).toBeNull();
+      const updated = entities.getWithAliases(target.id)!;
+      const aliasValues = updated.aliases.map((a) => a.alias_value);
+      // Original target aliases preserved
+      expect(aliasValues).toContain("TargetPerson");
+      expect(aliasValues).toContain("target@example.com");
+      // Source aliases transferred
+      expect(aliasValues).toContain("source-gh");
+      expect(aliasValues).toContain("source-slack");
+      expect(aliasValues).toContain("SourcePerson");
+    });
+
+    test("merge handles overlapping alias (same type+value) without data loss", () => {
+      const target = entities.create({
+        projectPath: PROJECT,
+        entityType: "person",
+        canonicalName: "TargetDup",
+        aliases: [{ type: "github", value: "shared-handle", source: "auto" }],
+      });
+      const source = entities.create({
+        projectPath: PROJECT,
+        entityType: "person",
+        canonicalName: "SourceDup",
+        aliases: [
+          { type: "github", value: "shared-handle", source: "curator" },
+          { type: "slack", value: "unique-slack", source: "curator" },
+        ],
+      });
+
+      entities.merge(target.id, source.id);
+
+      expect(entities.get(source.id)).toBeNull();
+      const updated = entities.getWithAliases(target.id)!;
+      const aliasValues = updated.aliases.map((a) => a.alias_value);
+      // Shared alias preserved (not duplicated, not lost)
+      expect(aliasValues).toContain("shared-handle");
+      // Unique source alias transferred
+      expect(aliasValues).toContain("unique-slack");
+      expect(aliasValues).toContain("SourceDup");
+      // No duplicate github:shared-handle entries
+      const githubAliases = updated.aliases.filter(
+        (a) => a.alias_type === "github" && a.alias_value === "shared-handle",
+      );
+      expect(githubAliases.length).toBe(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // mergeSelfPersonDuplicates
+  // ---------------------------------------------------------------------------
+
+  describe("mergeSelfPersonDuplicates", () => {
+    // Helper: insert a person entity directly via SQL to bypass create()'s
+    // canonical-name dedup (which would merge into the existing self entity).
+    // This simulates the real scenario where the curator creates a person
+    // before the self entity exists, or with a name variant that differs.
+    // In the real world, the curator creates a "person" entity for the user
+    // (often with a different name variant) before or alongside the self entity.
+    // create() deduplicates by canonical_name (case-insensitive) regardless of
+    // entity_type, so same-name entities are already handled at creation time.
+    // mergeSelfPersonDuplicates() catches the cases where names differ but
+    // aliases overlap (e.g., same email) or the person's canonical name matches
+    // one of the self entity's alias values.
+
+    test("merges person whose canonical name matches a self alias", () => {
+      // Curator created "person" with a name variant
+      const person = entities.create({
+        entityType: "person",
+        canonicalName: "Alice",
+        crossProject: true,
+      });
+      // Self entity has full name but "Alice" as a nickname alias
+      const self = entities.create({
+        entityType: "self",
+        canonicalName: "Alice Smith",
+        aliases: [{ type: "nickname", value: "Alice", source: "config" }],
+        crossProject: true,
+      });
+
+      const selfEntity = entities.getWithAliases(self.id)!;
+      const count = entities.mergeSelfPersonDuplicates(selfEntity);
+
+      expect(count).toBe(1);
+      expect(entities.get(person.id)).toBeNull(); // person absorbed
+      expect(entities.get(self.id)).not.toBeNull(); // self preserved
+    });
+
+    test("merges person with overlapping alias value", () => {
+      // Person created first — owns the github alias
+      const person = entities.create({
+        entityType: "person",
+        canonicalName: "A. Smith",
+        aliases: [{ type: "github", value: "alicesmith", source: "curator" }],
+        crossProject: true,
+      });
+      // Self entity created later — also has the same github handle
+      const self = entities.create({
+        entityType: "self",
+        canonicalName: "Alice Smith",
+        aliases: [{ type: "nickname", value: "alicesmith", source: "config" }],
+        crossProject: true,
+      });
+
+      const selfEntity = entities.getWithAliases(self.id)!;
+      const count = entities.mergeSelfPersonDuplicates(selfEntity);
+
+      expect(count).toBe(1);
+      expect(entities.get(person.id)).toBeNull();
+    });
+
+    test("does not merge unrelated person entities", () => {
+      const person = entities.create({
+        entityType: "person",
+        canonicalName: "Bob",
+        crossProject: true,
+      });
+      const self = entities.create({
+        entityType: "self",
+        canonicalName: "Alice",
+        crossProject: true,
+      });
+
+      const selfEntity = entities.getWithAliases(self.id)!;
+      const count = entities.mergeSelfPersonDuplicates(selfEntity);
+
+      expect(count).toBe(0);
+      expect(entities.get(person.id)).not.toBeNull(); // Bob still exists
+    });
+
+    test("merges multiple matching person entities", () => {
+      // Person matching by canonical name → self nickname alias
+      const person1 = entities.create({
+        entityType: "person",
+        canonicalName: "Ali",
+        crossProject: true,
+      });
+      // Person matching by github alias → self nickname alias
+      const person2 = entities.create({
+        entityType: "person",
+        canonicalName: "A. Smith",
+        aliases: [{ type: "github", value: "asmith42", source: "curator" }],
+        crossProject: true,
+      });
+      // Unrelated person — should NOT be merged
+      const bob = entities.create({
+        entityType: "person",
+        canonicalName: "Bob",
+        crossProject: true,
+      });
+      // Self entity with aliases matching both persons
+      const self = entities.create({
+        entityType: "self",
+        canonicalName: "Alice Smith",
+        aliases: [
+          { type: "nickname", value: "Ali", source: "config" },
+          { type: "nickname", value: "asmith42", source: "config" },
+        ],
+        crossProject: true,
+      });
+
+      const selfEntity = entities.getWithAliases(self.id)!;
+      const count = entities.mergeSelfPersonDuplicates(selfEntity);
+
+      expect(count).toBe(2);
+      expect(entities.get(person1.id)).toBeNull();
+      expect(entities.get(person2.id)).toBeNull();
+      expect(entities.get(bob.id)).not.toBeNull(); // Bob untouched
+    });
+
+    test("preserves aliases from absorbed person entity", () => {
+      // Person with extra aliases
+      const person = entities.create({
+        entityType: "person",
+        canonicalName: "Ali",
+        aliases: [
+          { type: "github", value: "alice-gh", source: "curator" },
+          { type: "slack", value: "alice-slack", source: "curator" },
+        ],
+        crossProject: true,
+      });
+      // Self entity — "Ali" nickname matches person's canonical name
+      const self = entities.create({
+        entityType: "self",
+        canonicalName: "Alice Smith",
+        aliases: [{ type: "nickname", value: "Ali", source: "config" }],
+        crossProject: true,
+      });
+
+      // Verify person was actually created separately
+      expect(person.created).toBe(true);
+      expect(entities.get(person.id)).not.toBeNull();
+      const personAliases = entities.getWithAliases(person.id)!.aliases;
+      expect(personAliases.map((a) => a.alias_value)).toContain("alice-gh");
+
+      const selfEntity = entities.getWithAliases(self.id)!;
+      const count = entities.mergeSelfPersonDuplicates(selfEntity);
+      expect(count).toBe(1);
+
+      // Person should be deleted
+      expect(entities.get(person.id)).toBeNull();
+
+      // Re-fetch self with aliases
+      const updated = entities.getWithAliases(self.id)!;
+      const aliasValues = updated.aliases.map((a) => a.alias_value);
+      expect(aliasValues).toContain("alice-gh");
+      expect(aliasValues).toContain("alice-slack");
+    });
   });
 });

--- a/packages/gateway/src/ui.ts
+++ b/packages/gateway/src/ui.ts
@@ -443,6 +443,9 @@ nav a { font-size: 0.9em; }
 .stat .label { font-size: 0.8em; color: var(--fg3); text-transform: uppercase; }
 .stat .value { font-size: 1.4em; font-weight: 600; }
 .stat .value .total { font-size: 0.7em; font-weight: 400; color: var(--fg3); }
+.stat-filter { cursor: pointer; transition: border-color 0.15s; user-select: none; }
+.stat-filter:hover { border-color: var(--accent); }
+.stat-filter.active { border-color: var(--accent); box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 25%, transparent); }
 table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 0.9em; }
 th, td { text-align: left; padding: 8px 10px; border-bottom: 1px solid var(--border); }
 th { background: var(--bg2); font-weight: 600; font-size: 0.85em; color: var(--fg2); text-transform: uppercase; }
@@ -893,6 +896,8 @@ document.addEventListener("DOMContentLoaded",function(){
     var wrapper=input.closest(".table-filter");
     var table=wrapper.nextElementSibling;
     if(!table||table.tagName!=="TABLE")return;
+    // Skip tables with custom filter logic (e.g. entity stat-filter)
+    if(table.dataset.customFilter!==undefined)return;
     var countEl=wrapper.querySelector(".count");
     var allRows=Array.from(table.querySelectorAll("tr")).filter(function(r){return!r.querySelector("th");});
     input.addEventListener("input",function(){
@@ -943,6 +948,55 @@ document.addEventListener("DOMContentLoaded",function(){
       if(countEl)countEl.textContent=shown+"/"+allRows.filter(function(r){return!r.dataset.parent;}).length;
     });
   });
+  // Stat-card type filter (entity list page): clicking a stat card filters the
+  // table to show only entities of that type; clicking again (or "Total") clears.
+  // Composes with the text filter above — both must pass for a row to be visible.
+  (function(){
+    var stats=document.querySelectorAll(".stat-filter");
+    if(!stats.length)return;
+    var statsContainer=stats[0].parentElement;
+    var table=statsContainer?statsContainer.parentElement.querySelector("table[data-table-id]"):null;
+    if(!table)return;
+    var allRows=Array.from(table.querySelectorAll("tr")).filter(function(r){return!r.querySelector("th");});
+    var textInput=statsContainer.parentElement.querySelector(".table-filter input");
+    var countEl=statsContainer.parentElement.querySelector(".table-filter .count");
+    var activeType=null;
+    function applyFilters(){
+      var q=textInput?textInput.value.toLowerCase():"";
+      var shown=0;var total=allRows.length;
+      allRows.forEach(function(r){
+        var typeMatch=!activeType||r.dataset.entityType===activeType;
+        var textMatch=!q||r.textContent.toLowerCase().indexOf(q)!==-1;
+        var show=typeMatch&&textMatch;
+        r.style.display=show?"":"none";
+        if(show)shown++;
+      });
+      if(countEl){
+        if(q||activeType)countEl.textContent=shown+"/"+total;
+        else countEl.textContent="";
+      }
+    }
+    stats.forEach(function(stat){
+      stat.addEventListener("click",function(){
+        var type=stat.dataset.typeFilter;
+        if(type==="all"||activeType===type){
+          activeType=null;
+          stats.forEach(function(s){s.classList.remove("active");});
+        }else{
+          activeType=type;
+          stats.forEach(function(s){s.classList.remove("active");});
+          stat.classList.add("active");
+        }
+        applyFilters();
+      });
+    });
+    // Override the text filter to use combined logic when a type filter is active
+    if(textInput){
+      textInput.addEventListener("input",function(){
+        applyFilters();
+      });
+    }
+  })();
   // Chat message filter (session page only)
   var chatSearch=document.getElementById("chat-search");
   var chatContainer=document.getElementById("chat-container");
@@ -2759,7 +2813,14 @@ async function pageEntities(): Promise<string> {
             body += `<span><a href="/ui/entities/${esc(m.id)}">${esc(truncate(m.name, 40))}</a> → <a href="/ui/entities/${esc(c.surviving.id)}">${esc(truncate(c.surviving.name, 40))}</a></span>`;
             body += `<span class="muted" style="color:#888;">[sim: ${m.similarity.toFixed(3)}]</span>`;
             body += `<form method="POST" action="/ui/api/merge/entity/${esc(c.surviving.id)}/${esc(m.id)}" style="display:inline;" onsubmit="return confirm('Merge &quot;${esc(m.name)}&quot; into &quot;${esc(c.surviving.name)}&quot;?');">`;
+            body += `<input type="hidden" name="similarity" value="${m.similarity}">`;
+            body += `<input type="hidden" name="nameA" value="${esc(m.name)}">`;
+            body += `<input type="hidden" name="nameB" value="${esc(c.surviving.name)}">`;
             body += `<button type="submit" style="font-size:12px;padding:2px 8px;">Merge</button>`;
+            body += `</form>`;
+            body += `<form method="POST" action="/ui/api/dismiss/entity/${esc(m.id)}/${esc(c.surviving.id)}" style="display:inline;">`;
+            body += `<input type="hidden" name="similarity" value="${m.similarity}">`;
+            body += `<button type="submit" style="font-size:12px;padding:2px 8px;" title="Not duplicates — don\u2019t suggest again">Dismiss</button>`;
             body += `</form>`;
             body += `</div>`;
           }
@@ -2775,17 +2836,19 @@ async function pageEntities(): Promise<string> {
     }
   }
 
-  // Type breakdown stats
+  // Type breakdown stats — fold "self" into "person" (there's at most one self
+  // entity so a separate stat is noise; mirrors formatForPrompt() grouping).
   const types: Record<string, number> = {};
   for (const e of all) {
-    types[e.entity_type] = (types[e.entity_type] || 0) + 1;
+    const displayType = e.entity_type === "self" ? "person" : e.entity_type;
+    types[displayType] = (types[displayType] || 0) + 1;
   }
   body += `<div class="stats">
-    <div class="stat"><div class="label">Total</div><div class="value">${all.length}</div></div>`;
+    <div class="stat stat-filter" data-type-filter="all"><div class="label">Total</div><div class="value">${all.length}</div></div>`;
   for (const [type, count] of Object.entries(types).sort(
     (a, b) => b[1] - a[1],
   )) {
-    body += `<div class="stat"><div class="label">${esc(type)}</div><div class="value">${count}</div></div>`;
+    body += `<div class="stat stat-filter" data-type-filter="${esc(type)}"><div class="label">${esc(type)}</div><div class="value">${count}</div></div>`;
   }
   body += `</div>`;
 
@@ -2801,14 +2864,15 @@ async function pageEntities(): Promise<string> {
   }
 
   body += `<div class="table-filter"><input type="text" placeholder="Filter entities\u2026"><span class="count"></span></div>
-  <table data-table-id="entities">
+  <table data-table-id="entities" data-custom-filter>
     <tr><th data-sort="text">Type</th><th data-sort="text">Name</th><th data-sort="num">Aliases</th><th data-sort="num">Knowledge</th><th data-sort="text">Cross</th><th data-sort="date" data-default-sort="desc">Updated</th></tr>`;
   for (const e of all) {
     const aliasCount = e.aliases.filter(
       (a) => a.alias_value !== e.canonical_name,
     ).length;
     const knowledgeCount = knowledgeCounts.get(e.id) ?? 0;
-    body += `<tr>
+    const rowType = e.entity_type === "self" ? "person" : e.entity_type;
+    body += `<tr data-entity-type="${esc(rowType)}">
       <td>${badge(e.entity_type)}</td>
       <td><a href="/ui/entities/${esc(e.id)}">${esc(truncate(e.canonical_name, 50))}</a></td>
       <td>${aliasCount}</td>
@@ -3077,19 +3141,60 @@ export async function handleUIRequest(
     if (mergeEntity) {
       const target = entities.get(mergeEntity.targetId);
       const source = entities.get(mergeEntity.sourceId);
-      if (
+      // Allow same-type merges + self↔person (self is conceptually a person)
+      const selfPersonSet = new Set(["self", "person"]);
+      const typesCompatible =
         target &&
         source &&
-        target.id !== source.id &&
-        target.entity_type === source.entity_type
-      ) {
+        (target.entity_type === source.entity_type ||
+          (selfPersonSet.has(target.entity_type) &&
+            selfPersonSet.has(source.entity_type)));
+      if (target && source && target.id !== source.id && typesCompatible) {
+        // Parse form data before merge — source entity is deleted by merge().
+        const formData = await req.formData();
+        const similarity = Number.parseFloat(
+          (formData.get("similarity") as string) || "",
+        );
         entities.merge(target.id, source.id);
-        // NOTE: We intentionally do NOT record calibration feedback here
-        // because the dashboard does not have the real pairwise similarity
-        // score. Recording a fake similarity (e.g. 1.0) would corrupt the
-        // adaptive threshold calibrator. Calibration data is only recorded
-        // from the CLI (`--yes` / `--interactive`) and from the curator's
-        // auto-dedup sweep where real cosine similarities are available.
+        // Record accept feedback — the similarity score is the real cosine
+        // value from the dedup dry-run, passed through as a hidden form field.
+        if (Number.isFinite(similarity)) {
+          entities.recordEntityDedupFeedback({
+            projectId: null,
+            entryATitle:
+              (formData.get("nameA") as string) || source.canonical_name,
+            entryBTitle:
+              (formData.get("nameB") as string) || target.canonical_name,
+            similarity,
+            accepted: true,
+            source: "dashboard",
+          });
+        }
+      }
+      return redirect("/ui/entities");
+    }
+
+    // Dismiss entity merge suggestion: record reject feedback (#462)
+    const dismissEntity = matchRoute(
+      pathname,
+      "/ui/api/dismiss/entity/:entityAId/:entityBId",
+    );
+    if (dismissEntity) {
+      const entityA = entities.get(dismissEntity.entityAId);
+      const entityB = entities.get(dismissEntity.entityBId);
+      const formData = await req.formData();
+      const similarity = Number.parseFloat(
+        (formData.get("similarity") as string) || "",
+      );
+      if (Number.isFinite(similarity) && entityA && entityB) {
+        entities.recordEntityDedupFeedback({
+          projectId: null,
+          entryATitle: entityA.canonical_name,
+          entryBTitle: entityB.canonical_name,
+          similarity,
+          accepted: false,
+          source: "dashboard",
+        });
       }
       return redirect("/ui/entities");
     }


### PR DESCRIPTION
## Summary

Fixes 4 entity system issues plus a pre-existing bug discovered during implementation.

### 1. Self + person entities never merge
The LLM curator creates "person" entities for the user (it cannot create "self" type), while `ensureSelfEntity()` creates a separate "self" entity from git config. These never merged because the dedup gate requires same `entity_type`.

**Fix:** New `mergeSelfPersonDuplicates()` function called at the end of `ensureSelfEntity()`. Finds "person" entities with overlapping names/aliases and merges them into the self entity. The dedup gate is left unchanged (safety invariant).

### 2. No "dismiss" button for merge suggestions
The dashboard only had a "Merge" button for each suggestion — no way to say "these are separate entities."

**Fix:** Added "Dismiss" button next to each "Merge" button. Records reject feedback via `recordEntityDedupFeedback()` with source `"dashboard"`. Also records accept feedback on merge (the similarity score IS available from the dedup dry-run, contrary to the old code comment). Relaxed the merge handler type guard to allow self↔person merges.

### 3. Pointless "self" category stat
The type breakdown showed "self: 1" as a separate stat — noise since there can only be one.

**Fix:** Folded "self" into "person" in the stats display, matching how `formatForPrompt()` already groups them.

### 4. (Bonus) Category stats now filter the entity table
Clicking a stat card filters the table to show only entities of that type. Clicking again clears the filter. Composes with the existing text filter.

### 5. Pre-existing bug: `merge()` alias copy silently failed
Discovered while testing: `merge()` used INSERT+DELETE to transfer aliases, but `UNIQUE(alias_type, alias_value)` is table-wide — the INSERT always conflicted with the source row that still existed. **All entity merges (CLI, dashboard, auto-dedup) silently lost aliases.**

**Fix:** Changed to `UPDATE OR IGNORE` to re-assign alias ownership in-place, with cleanup DELETE for duplicates.

## Changes

| File | Changes |
|---|---|
| `packages/core/src/entities.ts` | Fix `merge()` alias copy, add `"dashboard"` feedback source, add `mergeSelfPersonDuplicates()` + `finalizeSelfEntity()` |
| `packages/gateway/src/ui.ts` | Fold self→person in stats, clickable stat filters (CSS+JS+HTML), dismiss button, accept feedback on merge, relax type guard |
| `packages/core/test/entities.test.ts` | 5 new tests for `mergeSelfPersonDuplicates()` |

## Test Plan
- `bun run typecheck` — passes
- `bun test packages/core/test/entities.test.ts` — 52 tests pass (5 new)
- `bun test packages/core/test/entity-dedup.test.ts` — passes
- `bun test packages/core/test/dedup.test.ts` — passes