### PR TITLE
fix(gateway): decouple worker wire protocol from provider identity

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -310,6 +310,17 @@ export interface LLMClient {
        * (OpenCode, Pi) ignore it.
        */
       upstreamUrl?: string;
+      /**
+       * Wire protocol for the upstream endpoint. When set, the adapter
+       * uses this protocol for request/response formatting instead of
+       * inferring it from the provider ID. Threaded from the session's
+       * UpstreamSnapshot by the gateway to ensure workers use the same
+       * wire format as the owning session.
+       *
+       * Only the gateway adapter honors this field; other adapters
+       * (OpenCode, Pi) ignore it.
+       */
+      protocol?: "anthropic" | "openai" | "openai-responses";
     },
   ): Promise<string | null>;
 }

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -4,12 +4,19 @@
  * running inside the gateway process.
  *
  * Supports both Anthropic Messages API and OpenAI Chat Completions API.
- * The wire protocol is resolved from the provider route registry:
- *   - Anthropic-protocol providers → POST /v1/messages
- *   - OpenAI-protocol providers   → POST /v1/chat/completions
+ * The wire protocol is determined by explicit protocol from the session's
+ * UpstreamSnapshot (threaded via opts.protocol), with fallback to the
+ * provider route registry (PROVIDER_ROUTES) and a safe default of
+ * "anthropic" for unknown/aggregator providers:
+ *   - Anthropic protocol → POST /v1/messages
+ *   - OpenAI protocol    → POST /v1/chat/completions
+ *
+ * Protocol is decoupled from provider identity — proxy/aggregator
+ * providers (e.g. OpenCode Zen) that have protocol=null in the route
+ * table receive their protocol from the session snapshot instead.
  *
  * Retry logic, Sentry instrumentation, worker call tracking, and error
- * handling are shared across both providers.
+ * handling are shared across both protocols.
  */
 
 import type { LLMClient } from "@loreai/core";
@@ -160,55 +167,71 @@ export function normalizeOpenAIUsage(
 // Provider-specific request builders
 // ---------------------------------------------------------------------------
 
-/** Upstream URL + provider name for a resolved provider. */
+/** Wire protocol for worker requests (openai-responses collapsed to openai). */
+type WorkerProtocol = "anthropic" | "openai";
+
+/** Upstream URL, wire protocol, and provider label for a resolved target. */
 type ProviderTarget = {
   url: string;
+  protocol: WorkerProtocol;
+  /** Provider label for Sentry spans and logging. */
   providerName: string;
 };
 
 /**
- * Determine whether a provider uses the OpenAI wire protocol.
- * Checks the provider route registry (PROVIDER_ROUTES) for the wire
- * protocol. Falls back to name-based heuristic for unregistered providers.
- * When an upstream override is active, the route's protocol is the source
- * of truth — the override URL accepts the provider's native format.
+ * Resolve the wire protocol for a worker request.
+ *
+ * Priority:
+ *  1. Explicit protocol from caller (threaded from UpstreamSnapshot)
+ *  2. Route table lookup via PROVIDER_ROUTES
+ *  3. Default: "anthropic" (safest — most aggregators speak Anthropic)
+ *
+ * `openai-responses` is collapsed to `"openai"` because workers only
+ * use simple prompt→response via Chat Completions, not the Responses API.
  */
-function resolveIsOpenAI(
+export function resolveWorkerProtocol(
   providerID: string,
-  _upstreamOverride?: string,
-): boolean {
+  explicit?: "anthropic" | "openai" | "openai-responses",
+): WorkerProtocol {
+  // 1. Explicit protocol from caller (threaded from UpstreamSnapshot)
+  if (explicit) {
+    return explicit === "anthropic" ? "anthropic" : "openai";
+  }
+  // 2. Route table lookup
   const route = resolveProviderRoute(providerID);
   if (route?.protocol) {
-    return route.protocol === "openai" || route.protocol === "openai-responses";
+    return route.protocol === "anthropic" ? "anthropic" : "openai";
   }
-  // Proxy/aggregator (protocol=null) or unknown provider: fall back to
-  // name-based heuristic. Anthropic is the only known non-OpenAI provider.
-  return providerID !== "anthropic";
+  // 3. Default: anthropic (safest for unknown/aggregator providers)
+  return "anthropic";
 }
 
-/** Resolve upstream target based on model provider.
+/** Resolve upstream target URL and protocol.
  *  When `upstreamOverride` is set, the request routes to that URL instead
  *  of the default — used for same-provider routing where the session's
  *  credentials only work against the session's endpoint. */
 function resolveTarget(
   upstreams: { anthropic: string; openai: string },
-  isOpenAI: boolean,
+  protocol: WorkerProtocol,
   upstreamOverride?: string,
 ): ProviderTarget {
   if (upstreamOverride) {
     return {
       url: upstreamOverride.replace(/\/$/, ""),
-      providerName: isOpenAI ? "openai" : "anthropic",
+      protocol,
+      providerName: protocol,
     };
   }
-  if (isOpenAI) {
+  if (protocol === "openai") {
     return {
       url: upstreams.openai.replace(/\/$/, ""),
+      protocol,
       providerName: "openai",
     };
   }
   return {
     url: upstreams.anthropic.replace(/\/$/, ""),
+    protocol,
     providerName: "anthropic",
   };
 }
@@ -356,8 +379,10 @@ function parseOpenAIResponse(data: OpenAIChatResponse): {
  * Create an LLMClient that sends single-turn prompts to the appropriate provider.
  *
  * Routes to Anthropic Messages API or OpenAI Chat Completions API based on
- * `model.providerID`. Retry logic, Sentry instrumentation, and error handling
- * are shared across both providers.
+ * the resolved wire protocol (explicit `opts.protocol` from the session's
+ * UpstreamSnapshot, then provider route table, then default "anthropic").
+ * Retry logic, Sentry instrumentation, and error handling are shared across
+ * both protocols.
  *
  * @param upstreams     Base URLs for each provider
  * @param getAuth       Callback to resolve auth credentials (per-session → global fallback)
@@ -379,8 +404,8 @@ export function createGatewayLLMClient(
         return null;
       }
       const upstreamOverride = opts?.upstreamUrl;
-      const isOpenAI = resolveIsOpenAI(model.providerID, upstreamOverride);
-      const target = resolveTarget(upstreams, isOpenAI, upstreamOverride);
+      const protocol = resolveWorkerProtocol(model.providerID, opts?.protocol);
+      const target = resolveTarget(upstreams, protocol, upstreamOverride);
       const maxTokens = opts?.maxTokens ?? 8192;
 
       // Defense-in-depth: detect API key / provider mismatch before making
@@ -394,41 +419,42 @@ export function createGatewayLLMClient(
       // session's credentials regardless of the provider prefix.
       if (cred.scheme === "api-key" && !hasDedicatedKey && !upstreamOverride) {
         const isAnthropicKey = cred.value.startsWith("sk-ant-");
-        if (target.providerName === "anthropic" && !isAnthropicKey) {
+        if (target.protocol === "anthropic" && !isAnthropicKey) {
           log.warn(
-            `worker provider mismatch: ${target.providerName} target with non-Anthropic API key — skipping (model=${model.modelID}, worker=${opts?.workerID ?? "unknown"})`,
+            `worker protocol mismatch: ${target.protocol} target with non-Anthropic API key — skipping (model=${model.modelID}, worker=${opts?.workerID ?? "unknown"})`,
           );
           return null;
         }
-        if (target.providerName === "openai" && isAnthropicKey) {
+        if (target.protocol === "openai" && isAnthropicKey) {
           log.warn(
-            `worker provider mismatch: ${target.providerName} target with Anthropic API key — skipping (model=${model.modelID}, worker=${opts?.workerID ?? "unknown"})`,
+            `worker protocol mismatch: ${target.protocol} target with Anthropic API key — skipping (model=${model.modelID}, worker=${opts?.workerID ?? "unknown"})`,
           );
           return null;
         }
       }
 
-      // Build provider-specific request
-      let req = isOpenAI
-        ? buildOpenAIWorkerRequest(
-            target,
-            cred,
-            model,
-            system,
-            user,
-            maxTokens,
-            opts?.temperature,
-          )
-        : buildAnthropicWorkerRequest(
-            target,
-            cred,
-            model,
-            system,
-            user,
-            maxTokens,
-            opts?.sessionID,
-            opts?.temperature,
-          );
+      // Build protocol-specific request
+      let req =
+        target.protocol === "openai"
+          ? buildOpenAIWorkerRequest(
+              target,
+              cred,
+              model,
+              system,
+              user,
+              maxTokens,
+              opts?.temperature,
+            )
+          : buildAnthropicWorkerRequest(
+              target,
+              cred,
+              model,
+              system,
+              user,
+              maxTokens,
+              opts?.sessionID,
+              opts?.temperature,
+            );
 
       // Track this call so temporal capture can skip it
       const callID = `gw-worker-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -498,9 +524,10 @@ export function createGatewayLLMClient(
                 const rawData = await response.json();
 
                 // Parse response based on provider
-                const parsed = isOpenAI
-                  ? parseOpenAIResponse(rawData as OpenAIChatResponse)
-                  : parseAnthropicResponse(rawData);
+                const parsed =
+                  target.protocol === "openai"
+                    ? parseOpenAIResponse(rawData as OpenAIChatResponse)
+                    : parseAnthropicResponse(rawData);
 
                 // Set usage attributes on the span
                 if (parsed.usage) {
@@ -553,26 +580,27 @@ export function createGatewayLLMClient(
                   log.info(
                     `worker auth error ${response.status}, credential refreshed — retrying: ${text.slice(0, 200)}`,
                   );
-                  req = isOpenAI
-                    ? buildOpenAIWorkerRequest(
-                        target,
-                        freshCred,
-                        model,
-                        system,
-                        user,
-                        maxTokens,
-                        opts?.temperature,
-                      )
-                    : buildAnthropicWorkerRequest(
-                        target,
-                        freshCred,
-                        model,
-                        system,
-                        user,
-                        maxTokens,
-                        opts?.sessionID,
-                        opts?.temperature,
-                      );
+                  req =
+                    target.protocol === "openai"
+                      ? buildOpenAIWorkerRequest(
+                          target,
+                          freshCred,
+                          model,
+                          system,
+                          user,
+                          maxTokens,
+                          opts?.temperature,
+                        )
+                      : buildAnthropicWorkerRequest(
+                          target,
+                          freshCred,
+                          model,
+                          system,
+                          user,
+                          maxTokens,
+                          opts?.sessionID,
+                          opts?.temperature,
+                        );
                   retryCount++;
                   continue;
                 }

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -889,26 +889,6 @@ async function initIfNeeded(
   log.info(`gateway pipeline initialized: ${projectPath}`);
 }
 
-/**
- * Map a `providerID` string to its wire-protocol family. Provider IDs follow
- * the convention `{vendor}/{family}` (e.g. `minimax/anthropic`,
- * `github-copilot`, `openrouter/openai`). The substring check is deliberate:
- * a provider that ships an "anthropic"-shaped API is wire-compatible with
- * Anthropic regardless of the vendor prefix.
- *
- * Order matters: `"openai-responses"` is checked before `"anthropic"` so the
- * more-specific match wins (both contain `"openai"` as a substring).
- *
- * @internal Exported for tests.
- */
-export function protocolOfProviderID(
-  providerID: string,
-): "anthropic" | "openai" | "openai-responses" {
-  if (providerID.includes("openai-responses")) return "openai-responses";
-  if (providerID.includes("anthropic")) return "anthropic";
-  return "openai";
-}
-
 function getLLMClient(config: GatewayConfig): LLMClient {
   if (!llmClient) {
     const cfg = loreConfig();
@@ -950,46 +930,25 @@ function getLLMClient(config: GatewayConfig): LLMClient {
       { dedicatedWorkerKey: !!workerApiKey },
     );
 
-    // Session-aware wrapper: automatically inject the session's upstream URL
-    // so worker calls route through the same proxy/aggregator (e.g. OpenCode
-    // Zen) as the owning session. Without this, sessions behind a proxy would
-    // have their workers route directly to the provider API with the wrong
-    // credentials (the proxy's key, not the provider's).
-    //
-    // When the session has used multiple providers (e.g. Anthropic + MiniMax),
     // Workers always use the same provider as the session. Route worker
-    // calls through the session's upstream URL so they use the session's
-    // credentials and endpoint. When a dedicated worker API key is set
-    // (LORE_WORKER_API_KEY), skip URL injection — the worker uses its own
-    // credentials and default upstream.
+    // calls through the session's upstream URL and wire protocol so they
+    // use the session's credentials, endpoint, and request format. The
+    // protocol from the UpstreamSnapshot is the source of truth — it was
+    // resolved at conversation-turn time and correctly handles aggregator
+    // providers (e.g. OpenCode Zen) whose route has protocol=null.
     //
-    // Protocol-compatibility guard: only inject the session's URL when the
-    // worker's model wire protocol matches the session's protocol. A session
-    // on an OpenAI-only endpoint (e.g. Nvidia's integrate.api.nvidia.com)
-    // must NOT receive a worker whose model is Anthropic-format — the URL
-    // won't have a `/v1/messages` route and the request 404s. Mismatched
-    // workers fall through to their own provider config.
+    // When a dedicated worker API key is set (LORE_WORKER_API_KEY), skip
+    // injection — the worker uses its own credentials and default upstream.
     const inner: LLMClient = {
       async prompt(system, user, opts) {
         if (opts?.sessionID && !opts.upstreamUrl && !workerApiKey) {
           const state = sessions.get(opts.sessionID);
-          const session = state?.lastUpstream;
-          if (session?.url && session.protocol) {
-            const workerProviderID =
-              opts?.model?.providerID ?? defaultModel.providerID;
-            if (protocolOfProviderID(workerProviderID) === session.protocol) {
-              return rawClient.prompt(system, user, {
-                ...opts,
-                upstreamUrl: session.url,
-              });
-            }
-            log.info(
-              `worker protocol mismatch: session=${session.protocol} ` +
-                `worker=${workerProviderID}/` +
-                `${opts?.model?.modelID ?? defaultModel.modelID} ` +
-                `sessionID=${opts.sessionID.slice(0, 16)} — ` +
-                `worker will use its own provider config`,
-            );
+          if (state?.lastUpstream?.url) {
+            return rawClient.prompt(system, user, {
+              ...opts,
+              upstreamUrl: state.lastUpstream.url,
+              protocol: state.lastUpstream.protocol,
+            });
           }
         }
         return rawClient.prompt(system, user, opts);

--- a/packages/gateway/test/eviction.test.ts
+++ b/packages/gateway/test/eviction.test.ts
@@ -6,7 +6,6 @@
  * cleanup, and consolidation cooldown removal.
  */
 import { describe, test, expect, beforeEach } from "vitest";
-import { protocolOfProviderID } from "../src/pipeline";
 import { resetPipelineState } from "../src/pipeline";
 import {
   setSessionAuth,
@@ -465,47 +464,5 @@ describe("startIdleScheduler", () => {
     );
     stop();
     expect(typeof stop).toBe("function");
-  });
-});
-
-describe("protocolOfProviderID — worker URL injection guard", () => {
-  test("bare 'anthropic' maps to anthropic protocol", () => {
-    expect(protocolOfProviderID("anthropic")).toBe("anthropic");
-  });
-
-  test("vendor-prefixed anthropic providers map to anthropic", () => {
-    expect(protocolOfProviderID("minimax/anthropic")).toBe("anthropic");
-    expect(protocolOfProviderID("minimax-coding-plan/anthropic")).toBe(
-      "anthropic",
-    );
-    expect(protocolOfProviderID("openrouter/anthropic")).toBe("anthropic");
-  });
-
-  test("bare 'openai' maps to openai protocol", () => {
-    expect(protocolOfProviderID("openai")).toBe("openai");
-  });
-
-  test("vendor-prefixed openai providers (e.g. nvidia, github-copilot) map to openai", () => {
-    expect(protocolOfProviderID("nvidia")).toBe("openai");
-    expect(protocolOfProviderID("openrouter/openai")).toBe("openai");
-    expect(protocolOfProviderID("github-copilot")).toBe("openai");
-  });
-
-  test("'openai-responses' maps to openai-responses protocol", () => {
-    expect(protocolOfProviderID("openai-responses")).toBe("openai-responses");
-  });
-
-  test("unknown provider IDs default to openai protocol (most permissive fallback)", () => {
-    expect(protocolOfProviderID("google")).toBe("openai");
-    expect(protocolOfProviderID("mistral")).toBe("openai");
-    expect(protocolOfProviderID("xai")).toBe("openai");
-    expect(protocolOfProviderID("")).toBe("openai");
-  });
-
-  test("'openai-responses' substring check takes precedence over 'openai' (more specific wins)", () => {
-    expect(protocolOfProviderID("openai-responses")).toBe("openai-responses");
-    expect(protocolOfProviderID("vendor/openai-responses")).toBe(
-      "openai-responses",
-    );
   });
 });

--- a/packages/gateway/test/llm-adapter.test.ts
+++ b/packages/gateway/test/llm-adapter.test.ts
@@ -3,6 +3,7 @@ import {
   backoffMs,
   maxRetriesFor,
   normalizeOpenAIUsage,
+  resolveWorkerProtocol,
   AUTH_ERROR_CODES,
 } from "../src/llm-adapter";
 
@@ -267,5 +268,48 @@ describe("AUTH_ERROR_CODES", () => {
     expect(AUTH_ERROR_CODES.has(200)).toBe(false);
     expect(AUTH_ERROR_CODES.has(400)).toBe(false);
     expect(AUTH_ERROR_CODES.has(404)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveWorkerProtocol
+// ---------------------------------------------------------------------------
+
+describe("resolveWorkerProtocol", () => {
+  // Priority 1: explicit protocol from UpstreamSnapshot wins
+  test("explicit 'anthropic' wins over route table", () => {
+    expect(resolveWorkerProtocol("openai", "anthropic")).toBe("anthropic");
+  });
+
+  test("explicit 'openai' wins over route table", () => {
+    expect(resolveWorkerProtocol("anthropic", "openai")).toBe("openai");
+  });
+
+  test("explicit 'openai-responses' collapses to 'openai'", () => {
+    expect(resolveWorkerProtocol("anthropic", "openai-responses")).toBe(
+      "openai",
+    );
+  });
+
+  // Priority 2: route table lookup
+  test("anthropic provider resolves to 'anthropic' via route table", () => {
+    expect(resolveWorkerProtocol("anthropic")).toBe("anthropic");
+  });
+
+  test("openai provider resolves to 'openai' via route table", () => {
+    expect(resolveWorkerProtocol("openai")).toBe("openai");
+  });
+
+  test("deepseek provider resolves to 'openai' via route table", () => {
+    expect(resolveWorkerProtocol("deepseek")).toBe("openai");
+  });
+
+  // Priority 3: default for aggregators/unknown providers
+  test("opencode (protocol: null) defaults to 'anthropic'", () => {
+    expect(resolveWorkerProtocol("opencode")).toBe("anthropic");
+  });
+
+  test("unknown provider defaults to 'anthropic'", () => {
+    expect(resolveWorkerProtocol("some-unknown-provider")).toBe("anthropic");
   });
 });


### PR DESCRIPTION
## Problem

Workers (distillation, curation, pattern extraction) get continuous 404 errors when sessions use proxy/aggregator providers like `opencode` (OpenCode Zen).

The root cause: `resolveIsOpenAI()` inferred the wire protocol from `providerID`, falling back to `providerID !== "anthropic"` for providers with `protocol: null` in the route table. This incorrectly classified `"opencode"` as OpenAI-protocol, causing workers to POST to `/v1/chat/completions` on a server that only serves `/v1/messages` — returning `404 Page not found`.

The `UpstreamSnapshot` already captures the correct protocol at conversation-turn time, but it was never threaded through to workers.

## Changes

### `packages/core/src/types.ts`
- Add optional `protocol?: "anthropic" | "openai" | "openai-responses"` to `LLMClient.prompt()` opts

### `packages/gateway/src/llm-adapter.ts`
- Delete `resolveIsOpenAI()` — the broken heuristic
- Add `WorkerProtocol` type and `resolveWorkerProtocol()` — takes explicit protocol first (from snapshot), falls back to route table, defaults to `"anthropic"` (safer for unknown/aggregator providers)
- Export `resolveWorkerProtocol()` for testing
- Add `protocol` field to `ProviderTarget` type
- Update `resolveTarget()` to accept `WorkerProtocol` instead of `isOpenAI` boolean
- Replace all 5 `isOpenAI` branch points with `target.protocol === "openai"`
- Update mismatch guard log messages from "provider mismatch" to "protocol mismatch"

### `packages/gateway/src/pipeline.ts`
- Thread `state.lastUpstream.protocol` alongside `state.lastUpstream.url` in session-aware wrapper
- Remove `protocolOfProviderID()` — substring-based provider-to-protocol heuristic superseded by explicit protocol threading

### `packages/gateway/test/llm-adapter.test.ts`
- Add 8 unit tests for `resolveWorkerProtocol()` covering explicit protocol, route table lookup, and default fallback

### `packages/gateway/test/eviction.test.ts`
- Remove `protocolOfProviderID` tests (function deleted)

## Design

Protocol is now decoupled from provider identity. The resolution priority is:
1. **Explicit protocol** from `opts.protocol` (threaded from `UpstreamSnapshot`) — fixes the bug
2. **Route table** lookup via `PROVIDER_ROUTES`
3. **Default** `"anthropic"` (was: `providerID !== "anthropic"` which broke aggregators)

`openai-responses` is collapsed to `"openai"` for workers — they use Chat Completions, not the Responses API.

## Edge cases

- **Non-session callers** (api.ts, cli tools): no `opts.protocol` → route table → `"anthropic"` → correct
- **Unknown providers with `protocol: null`**: new default `"anthropic"` is safer than old OpenAI default
- **`LORE_WORKER_API_KEY`**: session wrapper skips injection → falls through to route table → correct
- **Batch queue**: unchanged — its use of `providerID` for batch API availability is semantically correct