### PR TITLE
fix(core,gateway): restore bun export conditions for OpenCode plugin

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,11 +9,13 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
+      "bun": "./dist/bun/index.js",
       "default": "./dist/node/index.js"
     }
   },
   "imports": {
     "#db/driver": {
+      "bun": "./src/db/driver.bun.ts",
       "default": "./src/db/driver.node.ts"
     }
   },

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -9,6 +9,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.cts",
+      "bun": "./dist/index.bun.js",
       "require": "./dist/index.cjs",
       "default": "./dist/index.cjs"
     }
@@ -33,6 +34,7 @@
     "dist/bin.cjs",
     "dist/embedding-worker.cjs",
     "dist/embedding-worker.js",
+    "dist/index.bun.js",
     "dist/index.cjs",
     "dist/index.d.cts"
   ],


### PR DESCRIPTION
## Summary

Restores the `"bun"` export/import conditions that were accidentally removed during the vitest migration (PR #590), fixing a crash when the OpenCode plugin starts under Bun.

## Root Cause

The vitest migration removed the `"bun"` condition from `@loreai/core`'s `package.json` `imports` and `exports` maps. This caused `#db/driver` to always resolve to `driver.node.ts` (`node:sqlite`), even under Bun. Since Bun doesn't implement `node:sqlite`, the OpenCode plugin crashed immediately:

```
[lore] failed to start gateway in-process: ResolveMessage: No such built-in module: node:sqlite
```

Additionally, `@loreai/gateway` was missing a `"bun"` export condition, so even with the core fix, Bun would load the CJS bundle (which has `node:sqlite` baked in) instead of the Bun ESM shim.

## Changes

- **`packages/core/package.json`**: Restore `"bun"` condition in `exports` (`dist/bun/index.js`) and `imports` (`src/db/driver.bun.ts`)
- **`packages/gateway/package.json`**: Add `"bun"` condition in `exports` (`dist/index.bun.js`)

## Verification

- Build passes (both `dist/node/` and `dist/bun/` targets)
- Typecheck passes across all 4 packages
- Gateway starts and shuts down cleanly under Bun with no `node:sqlite` errors
- Plugin loads correctly from both workspace and installed paths