### PR TITLE
fix(entities): filter dismissed pairs from dashboard dedup suggestions

### DIFF
--- a/packages/core/src/entities.ts
+++ b/packages/core/src/entities.ts
@@ -1697,6 +1697,31 @@ export type EntityDedupFeedbackSource =
 const MIN_ENTITY_CALIBRATION_SAMPLES = 20;
 /** Only record auto-signals for pairs with similarity >= this floor. */
 const ENTITY_AUTO_SIGNAL_MIN_SIMILARITY = 0.8;
+/**
+ * Return a Set of "nameA\x1fnameB" keys for entity pairs that have been
+ * explicitly dismissed (accepted=0) via the dashboard. Both orderings are
+ * included so callers can do a single `has()` check.
+ *
+ * Dismissals are name-based; renaming an entity resets its dismiss state
+ * (the old names won't match), which is the correct behavior since the
+ * entity's identity has changed.
+ */
+export function getDismissedEntityPairs(): Set<string> {
+  const rows = db()
+    .query(
+      `SELECT entry_a_title, entry_b_title FROM dedup_feedback
+       WHERE kind = 'entity' AND accepted = 0 AND source = 'dashboard'
+         AND project_id IS NULL`,
+    )
+    .all() as Array<{ entry_a_title: string; entry_b_title: string }>;
+  const dismissed = new Set<string>();
+  for (const r of rows) {
+    dismissed.add(`${r.entry_a_title}\x1f${r.entry_b_title}`);
+    dismissed.add(`${r.entry_b_title}\x1f${r.entry_a_title}`);
+  }
+  return dismissed;
+}
+
 /** Max auto-signal pairs to record per dedup run (closest to threshold). */
 const ENTITY_AUTO_SIGNAL_MAX_PAIRS = 50;
 /** Max feedback rows to keep per project (prevents unbounded growth). */

--- a/packages/core/test/entity-dedup.test.ts
+++ b/packages/core/test/entity-dedup.test.ts
@@ -281,4 +281,32 @@ describe("entity dedup — adaptive calibration (kind='entity')", () => {
     expect(entities.loadEntityCalibratedThreshold(pid)).toBeCloseTo(0.876, 5);
     expect(getKV(`entity_dedup_threshold:${pid}`)).toContain("0.876");
   });
+
+  test("getDismissedEntityPairs returns both orderings for dashboard rejects", () => {
+    // Record a dashboard dismiss
+    entities.recordEntityDedupFeedback({
+      projectId: null,
+      entryATitle: "Alice",
+      entryBTitle: "Bob",
+      similarity: 0.87,
+      accepted: false,
+      source: "dashboard",
+    });
+    // Record a non-dashboard reject (should NOT appear)
+    entities.recordEntityDedupFeedback({
+      projectId: null,
+      entryATitle: "Carol",
+      entryBTitle: "Dave",
+      similarity: 0.88,
+      accepted: false,
+      source: "cli_interactive",
+    });
+
+    const dismissed = entities.getDismissedEntityPairs();
+    // Both orderings present for the dashboard dismiss
+    expect(dismissed.has("Alice\x1fBob")).toBe(true);
+    expect(dismissed.has("Bob\x1fAlice")).toBe(true);
+    // CLI reject NOT included
+    expect(dismissed.has("Carol\x1fDave")).toBe(false);
+  });
 });

--- a/packages/gateway/src/ui.ts
+++ b/packages/gateway/src/ui.ts
@@ -2797,7 +2797,16 @@ async function pageEntities(): Promise<string> {
       const dupes = await entities.deduplicateEntities(undefined, {
         dryRun: true,
       });
-      const clusters = [...dupes.merged, ...dupes.suggested];
+      // Filter out pairs the user has already dismissed via the dashboard.
+      const dismissed = entities.getDismissedEntityPairs();
+      const clusters = [...dupes.merged, ...dupes.suggested]
+        .map((c) => ({
+          ...c,
+          merged: c.merged.filter(
+            (m) => !dismissed.has(`${m.name}\x1f${c.surviving.name}`),
+          ),
+        }))
+        .filter((c) => c.merged.length > 0);
       if (clusters.length > 0) {
         const pairCount = clusters.reduce((n, c) => n + c.merged.length, 0);
         body += `<div class="banner" style="border:1px solid #d0a000;background:#fffbe6;padding:12px 16px;border-radius:6px;margin:12px 0;">`;


### PR DESCRIPTION
## Summary

Follow-up to #595. The dismiss button recorded reject feedback in `dedup_feedback` but the dashboard never checked it — dismissed pairs kept reappearing on every page load.

### Changes

**`packages/core/src/entities.ts`**
- Added `getDismissedEntityPairs()`: queries `dedup_feedback` for dashboard-rejected entity pairs and returns a Set of bidirectional `"nameA\x1fnameB"` keys for O(1) lookup.

**`packages/gateway/src/ui.ts`**
- After `deduplicateEntities()` dry-run, filters out pairs present in the dismissed set before rendering. Empty clusters are dropped entirely so the banner disappears when all suggestions are dismissed.