### PR TITLE
fix(site): grain z-index, blog footer, CWD-relative fs read

### DIFF
--- a/packages/website/public/theme.css
+++ b/packages/website/public/theme.css
@@ -66,7 +66,7 @@ body::after {
   inset: 0;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='300' height='300'%3E%3Cfilter id='g'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.75' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='300' height='300' filter='url(%23g)' opacity='0.035'/%3E%3C/svg%3E");
   pointer-events: none;
-  z-index: 9998;
+  z-index: 0;
 }
 
 a {

--- a/packages/website/src/layouts/BlogLayout.astro
+++ b/packages/website/src/layouts/BlogLayout.astro
@@ -40,5 +40,10 @@ const {
     <main>
       <slot />
     </main>
+    <footer>
+      <div class="foot-bottom">
+        <small>&copy; {new Date().getFullYear()} Lore.AI</small>
+      </div>
+    </footer>
   </body>
 </html>

--- a/packages/website/src/pages/different.astro
+++ b/packages/website/src/pages/different.astro
@@ -1,6 +1,5 @@
 ---
-import fs from "node:fs";
-const siteJs = fs.readFileSync("src/scripts/site.js", "utf-8");
+import siteJs from "../scripts/site.js?raw";
 ---
 <!DOCTYPE html>
 <html lang="en">

--- a/packages/website/src/pages/index.astro
+++ b/packages/website/src/pages/index.astro
@@ -1,6 +1,5 @@
 ---
-import fs from "node:fs";
-const siteJs = fs.readFileSync("src/scripts/site.js", "utf-8");
+import siteJs from "../scripts/site.js?raw";
 ---
 <!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
## Summary

Three small pre-existing fixes from the PR #559 review that make the docs and blog feel less like 2nd-class citizens.

### Changes

1. **Grain overlay z-index 9998 → 0** (`theme.css`): The `body::after` noise overlay was at `z-index: 9998`, above the fixed top-nav (`z-index: 500`). The grain is a background texture, not an overlay — it should sit below all content. Lowered to `z-index: 0` so the nav renders cleanly above it.

2. **Blog layout footer** (`BlogLayout.astro`): BlogLayout only rendered `<header>` + `<main>`. Marketing pages use the global footer CSS in theme.css. Added a minimal `<footer>` with copyright so the blog doesn't feel like a dead end.

3. **CWD-relative `fs.readFileSync`** (`index.astro`, `different.astro`): Both pages used `fs.readFileSync("src/scripts/site.js")` to inline the client script. This works only when the build CWD is the website package directory. Replaced with Astro/Vite's idiomatic `?raw` import — script is inlined as a static string at build time with no runtime CWD dependency.

### Verification

```bash
PR_NUMBER=N pnpm --filter "@loreai/website" build
pnpm run typecheck  # ✓
pnpm run lint       # ✓ (15 pre-existing warnings, 0 in website/)
```

Dist verification:
- `dist/theme.css`: `body::after` has `z-index: 0`
- `dist/blog.html`: contains `foot-bottom` class
- `dist/index.html` and `dist/different.html`: `siteJs` inlined as `<script type="module">`