### PR TITLE
fix(gateway): polyfill getSystemErrorMap for Bun to prevent Sentry SDK crash

### DIFF
--- a/packages/gateway/instrument.ts
+++ b/packages/gateway/instrument.ts
@@ -27,6 +27,21 @@
 import { setMaxListeners } from "node:events";
 setMaxListeners(15);
 
+// Bun doesn't implement node:util's getSystemErrorMap(). The Sentry SDK calls
+// it during processEvent() to enrich errors with system error code names. When
+// it's missing, Sentry itself crashes with "getSystemErrorMap is not a function"
+// (LOREAI-GATEWAY-1X). Provide a no-op stub so Sentry's event pipeline doesn't
+// break — the only loss is cosmetic (no OS error code labels on events).
+// Use globalThis-based patching because esbuild treats ESM namespace imports
+// as immutable and rejects property assignment on `import * as util`.
+{
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const util = require("node:util") as Record<string, unknown>;
+  if (typeof util.getSystemErrorMap !== "function") {
+    util.getSystemErrorMap = () => new Map();
+  }
+}
+
 import * as Sentry from "@sentry/bun";
 import { log } from "@loreai/core";
 import { VERSION } from "./src/cli/version";


### PR DESCRIPTION
## Summary
Prevents Sentry SDK crash under Bun by polyfilling `node:util.getSystemErrorMap()`.

## Changes
- Adds a no-op stub (`() => new Map()`) for `getSystemErrorMap` in `instrument.ts` before `Sentry.init()`
- The polyfill only activates when the function is missing (Bun); Node.js is unaffected

## Sentry Issue
Closes LOREAI-GATEWAY-1X: `TypeError: ile.getSystemErrorMap is not a function`

The crash occurs inside Sentry's own `processEvent()` pipeline when running under Bun. Since `@sentry/bun` depends on `@sentry/node-core` which calls `getSystemErrorMap`, switching SDK packages doesn't help — only a polyfill works.

## Verification
- `pnpm -r typecheck` — all packages pass
- `pnpm run lint` — no new warnings/errors