### PR TITLE
fix(core): recognize WASM fatal error wrapper prefix in isWasmFatalError()

### DIFF
--- a/packages/core/src/embedding-worker-types.ts
+++ b/packages/core/src/embedding-worker-types.ts
@@ -103,6 +103,11 @@ export function isOomError(msg: string): boolean {
  * thread's `on("exit")` handler marks the provider as broken.
  */
 export function isWasmFatalError(msg: string): boolean {
+  // Recognize the wrapper prefix the worker adds before process.exit(1).
+  // The main thread receives "WASM fatal error (worker exiting): <raw>"
+  // and must classify it as fatal to create LocalProviderUnavailableError
+  // instead of a plain Error in the on("message") handler.
+  if (/WASM fatal error/i.test(msg)) return true;
   // WASM abort() — "Aborted(). Build with -sASSERTIONS for more info."
   if (/\bAborted\b/i.test(msg)) return true;
   // RuntimeError from WASM (e.g. "unreachable", "memory access out of bounds")


### PR DESCRIPTION
## Summary
Fixes a classification gap where the main thread's `isWasmFatalError()` didn't recognize its own wrapper prefix, causing ONNX OOM errors to be reported as plain `Error` instead of `LocalProviderUnavailableError`.

## Changes
- Adds `/WASM fatal error/i` regex pattern to `isWasmFatalError()` in `embedding-worker-types.ts`
- This matches the wrapper prefix `"WASM fatal error (worker exiting): <raw>"` that the worker adds before `process.exit(1)`

## Root Cause
The embedding worker wraps raw OOM errors in a descriptive prefix before posting to the main thread. The main thread's `isWasmFatalError()` checked for `Aborted`, `RuntimeError`, and `isOomError()` — but the wrapped string no longer matched any of these (the raw numeric code is no longer bare, and the prefix doesn't contain those keywords). This caused the `on('message')` error handler to create a plain `Error` instead of `LocalProviderUnavailableError`, which meant callers didn't get the expected error type for graceful degradation.

## Sentry Issue
Closes LOREAI-GATEWAY-C (11035 events, 3 users — all from 0.24.1, but this prefix mismatch was still present in current code)

## Verification
- `pnpm -r typecheck` — all packages pass
- `pnpm test` — 82 files, 2287 tests pass
- `pnpm run lint` — no new warnings/errors