### PR TITLE
fix(gateway): handle SSE response from upstream when stream: false was sent

### DIFF
--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -332,6 +332,7 @@ function buildOpenAIWorkerRequest(
     body: JSON.stringify({
       model: model.modelID,
       max_completion_tokens: maxTokens,
+      stream: false,
       ...(temperature != null && { temperature }),
       messages,
     }),
@@ -521,13 +522,31 @@ export function createGatewayLLMClient(
               finalStatus = response.status;
 
               if (response.ok) {
-                const rawData = await response.json();
+                // Guard: some providers return SSE even when stream: false
+                // was sent. Extract JSON from the data: lines instead.
+                const ct = response.headers.get("content-type") ?? "";
+                let rawData: unknown;
+                if (ct.includes("text/event-stream")) {
+                  const text = await response.text();
+                  let lastPayload: string | null = null;
+                  for (const line of text.split("\n")) {
+                    if (line.startsWith("data: ")) {
+                      const p = line.slice(6).trim();
+                      if (p && p !== "[DONE]") lastPayload = p;
+                    }
+                  }
+                  rawData = lastPayload ? JSON.parse(lastPayload) : {};
+                } else {
+                  rawData = await response.json();
+                }
 
                 // Parse response based on provider
                 const parsed =
                   target.protocol === "openai"
                     ? parseOpenAIResponse(rawData as OpenAIChatResponse)
-                    : parseAnthropicResponse(rawData);
+                    : parseAnthropicResponse(
+                        rawData as Parameters<typeof parseAnthropicResponse>[0],
+                      );
 
                 // Set usage attributes on the span
                 if (parsed.usage) {

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -2203,7 +2203,17 @@ async function accumulateNonStreamResponse(
   upstreamResponse: Response,
   protocol: "anthropic" | "openai" | "openai-responses" = "anthropic",
 ): Promise<GatewayResponse> {
-  const json = (await upstreamResponse.json()) as Record<string, unknown>;
+  // Some providers (e.g. DeepSeek) return SSE-formatted responses even when
+  // stream: false was sent. Detect this via content-type and extract the JSON
+  // payload from the SSE data lines instead of calling response.json() which
+  // would throw a SyntaxError on "data: {...}" prefixed text.
+  const ct = upstreamResponse.headers.get("content-type") ?? "";
+  let json: Record<string, unknown>;
+  if (ct.includes("text/event-stream")) {
+    json = await extractJSONFromSSE(upstreamResponse);
+  } else {
+    json = (await upstreamResponse.json()) as Record<string, unknown>;
+  }
 
   switch (protocol) {
     case "openai":
@@ -2213,6 +2223,39 @@ async function accumulateNonStreamResponse(
     default:
       return accumulateAnthropicNonStreamJSON(json);
   }
+}
+
+/**
+ * Extract a JSON payload from an SSE response body.
+ *
+ * Reads all `data: ` lines, ignoring `data: [DONE]` sentinel, and returns
+ * the **last** non-sentinel data payload as parsed JSON. This handles the
+ * common case where a provider returns a complete response as SSE despite
+ * stream: false — the final `data:` line contains the full response object.
+ */
+async function extractJSONFromSSE(
+  response: Response,
+): Promise<Record<string, unknown>> {
+  const text = await response.text();
+  const lines = text.split("\n");
+  let lastPayload: string | null = null;
+
+  for (const line of lines) {
+    if (line.startsWith("data: ")) {
+      const payload = line.slice(6).trim();
+      if (payload && payload !== "[DONE]") {
+        lastPayload = payload;
+      }
+    }
+  }
+
+  if (!lastPayload) {
+    throw new Error(
+      "upstream returned SSE but no data payload found — expected JSON in data: lines",
+    );
+  }
+
+  return JSON.parse(lastPayload) as Record<string, unknown>;
 }
 
 // Anthropic non-stream JSON → GatewayResponse: use shared parseAnthropicResponseJSON


### PR DESCRIPTION
## Summary
Handles the case where upstream providers return SSE-formatted responses despite `stream: false` being sent, preventing a `SyntaxError` from `response.json()`.

## Changes
- Adds content-type check in `accumulateNonStreamResponse()` (pipeline.ts) — detects `text/event-stream` and extracts JSON from `data:` lines via new `extractJSONFromSSE()` helper
- Adds the same SSE guard in the worker LLM adapter response path (llm-adapter.ts)
- Adds explicit `stream: false` to `buildOpenAIWorkerRequest()` body — it was previously omitted, which some providers interpret as defaulting to streaming

## Root Cause
DeepSeek (and potentially other OpenAI-compatible providers) returns SSE-formatted responses even when `stream: false` is sent. The gateway's non-streaming path called `response.json()` without checking the content-type, causing `SyntaxError: Unexpected token 'd', "data: {"id"...` when the body started with `data: ` SSE lines.

The recall follow-up path already had `assertJSONResponse()` / `assertSSEResponse()` guards (recall.ts:516-538), but the main pipeline and worker paths did not.

## Sentry Issue
Closes LOREAI-GATEWAY-1P

## Verification
- `pnpm -r typecheck` — all packages pass
- `pnpm test` — 82 files, 2287 tests pass
- `pnpm run lint` — no new warnings/errors