### PR TITLE
fix(ci): remove empty `with:` from pnpm/action-setup in eval.yml

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -30,7 +30,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
-        with:
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -55,7 +54,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
-        with:
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -101,7 +99,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
-        with:
       - uses: actions/setup-node@v6
         with:
           node-version: '24'


### PR DESCRIPTION
## Summary

The three `pnpm/action-setup@v4` steps in `eval.yml` had a bare `with:` key with no value (YAML null). GitHub Actions treats this as a schema error — `with` expects a mapping, not null — causing a "workflow file issue" failure on every push event, even though the eval jobs themselves are gated behind `workflow_dispatch` / `schedule`.

`pnpm/action-setup@v4` needs no parameters (it reads `packageManager` from `package.json` automatically). The empty `with:` blocks were left behind in #578 (bun → pnpm migration) where the `with: version:` parameter was removed but the `with:` key itself was not.

## Change

Removed the bare `with:` key from all three job steps:
- `eval-fixture` (line 33)
- `eval-live` (line 58)
- `eval-auto-memory` (line 104)

```diff
- uses: pnpm/action-setup@v4
-   with:
+ uses: pnpm/action-setup@v4
```

## Verification

The fix is syntactic — no runtime behavior change. The eval jobs are still gated behind `workflow_dispatch` / `schedule` and won't run on PR push. The validation failure should disappear once this merges.