### PR TITLE
fix(gateway): remove cache fields from ZERO_USAGE and consolidate SSE extraction

### DIFF
--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -34,6 +34,7 @@ import {
 } from "./sentry";
 import { recordWorkerCost } from "./cost-tracker";
 import { upstreamFetch } from "./fetch";
+import { extractJSONFromSSE } from "./translate/types";
 
 // ---------------------------------------------------------------------------
 // Worker call tracking
@@ -525,20 +526,9 @@ export function createGatewayLLMClient(
                 // Guard: some providers return SSE even when stream: false
                 // was sent. Extract JSON from the data: lines instead.
                 const ct = response.headers.get("content-type") ?? "";
-                let rawData: unknown;
-                if (ct.includes("text/event-stream")) {
-                  const text = await response.text();
-                  let lastPayload: string | null = null;
-                  for (const line of text.split("\n")) {
-                    if (line.startsWith("data: ")) {
-                      const p = line.slice(6).trim();
-                      if (p && p !== "[DONE]") lastPayload = p;
-                    }
-                  }
-                  rawData = lastPayload ? JSON.parse(lastPayload) : {};
-                } else {
-                  rawData = await response.json();
-                }
+                const rawData = ct.includes("text/event-stream")
+                  ? await extractJSONFromSSE(response)
+                  : await response.json();
 
                 // Parse response based on provider
                 const parsed =

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -72,6 +72,7 @@ import type {
 } from "./translate/types";
 import {
   blocksToText,
+  extractJSONFromSSE,
   forwardClientHeaders,
   ZERO_USAGE,
 } from "./translate/types";
@@ -2227,39 +2228,6 @@ async function accumulateNonStreamResponse(
     default:
       return accumulateAnthropicNonStreamJSON(json);
   }
-}
-
-/**
- * Extract a JSON payload from an SSE response body.
- *
- * Reads all `data: ` lines, ignoring `data: [DONE]` sentinel, and returns
- * the **last** non-sentinel data payload as parsed JSON. This handles the
- * common case where a provider returns a complete response as SSE despite
- * stream: false — the final `data:` line contains the full response object.
- */
-async function extractJSONFromSSE(
-  response: Response,
-): Promise<Record<string, unknown>> {
-  const text = await response.text();
-  const lines = text.split("\n");
-  let lastPayload: string | null = null;
-
-  for (const line of lines) {
-    if (line.startsWith("data: ")) {
-      const payload = line.slice(6).trim();
-      if (payload && payload !== "[DONE]") {
-        lastPayload = payload;
-      }
-    }
-  }
-
-  if (!lastPayload) {
-    throw new Error(
-      "upstream returned SSE but no data payload found — expected JSON in data: lines",
-    );
-  }
-
-  return JSON.parse(lastPayload) as Record<string, unknown>;
 }
 
 // Anthropic non-stream JSON → GatewayResponse: use shared parseAnthropicResponseJSON

--- a/packages/gateway/src/stream/anthropic.ts
+++ b/packages/gateway/src/stream/anthropic.ts
@@ -11,10 +11,11 @@
  * All functions are pure (no side effects) except `parseSSEStream` which is
  * an async generator consuming a byte stream.
  */
-import type {
-  GatewayContentBlock,
-  GatewayResponse,
-  GatewayUsage,
+import {
+  ZERO_USAGE,
+  type GatewayContentBlock,
+  type GatewayResponse,
+  type GatewayUsage,
 } from "../translate/types";
 import { scaleUsageForClient } from "../compaction";
 
@@ -458,7 +459,7 @@ export function createStreamAccumulator(options?: {
  * interception) and needs to emit a well-formed Anthropic stream.
  */
 export function buildSSEMessageStart(response: GatewayResponse): string {
-  const u = response.usage ?? { inputTokens: 0, outputTokens: 0 };
+  const u = response.usage ?? ZERO_USAGE;
   const message = {
     type: "message_start",
     message: {
@@ -686,7 +687,7 @@ export function createRecallAwareAccumulator(
         return null;
       // Scale based on total accumulated in the inner accumulator
       const innerResp = inner.getResponse();
-      const iu = innerResp.usage ?? { inputTokens: 0, outputTokens: 0 };
+      const iu = innerResp.usage ?? ZERO_USAGE;
       const scaled = scaleUsageForClient({
         input_tokens: iu.inputTokens,
         output_tokens: deltaUsage.output_tokens,

--- a/packages/gateway/src/stream/openai-responses.ts
+++ b/packages/gateway/src/stream/openai-responses.ts
@@ -14,10 +14,11 @@
  * Reuses `parseSSEStream` from the Anthropic stream module since the
  * underlying SSE wire format is the same.
  */
-import type {
-  GatewayContentBlock,
-  GatewayResponse,
-  GatewayUsage,
+import {
+  ZERO_USAGE,
+  type GatewayContentBlock,
+  type GatewayResponse,
+  type GatewayUsage,
 } from "../translate/types";
 import { parseSSEStream, createStreamAccumulator } from "./anthropic";
 
@@ -652,7 +653,7 @@ export function translateAnthropicStreamToResponses(
 
               const finalStatus = mapStatusFromStopReason(resp.stopReason);
 
-              const ru = resp.usage ?? { inputTokens: 0, outputTokens: 0 };
+              const ru = resp.usage ?? ZERO_USAGE;
               const usageData: Record<string, unknown> = {
                 input_tokens: ru.inputTokens,
                 output_tokens: ru.outputTokens,

--- a/packages/gateway/src/stream/openai.ts
+++ b/packages/gateway/src/stream/openai.ts
@@ -17,6 +17,7 @@
  * events, and `createStreamAccumulator` to build the internal GatewayResponse
  * (for pipeline post-processing that may read it).
  */
+import { ZERO_USAGE } from "../translate/types";
 import { parseSSEStream, createStreamAccumulator } from "./anthropic";
 
 // ---------------------------------------------------------------------------
@@ -279,7 +280,7 @@ export function translateAnthropicStreamToOpenAI(
             case "message_stop": {
               // Build usage from accumulator
               const resp = accumulator.getResponse();
-              const ru = resp.usage ?? { inputTokens: 0, outputTokens: 0 };
+              const ru = resp.usage ?? ZERO_USAGE;
               const usage: Record<string, unknown> = {
                 prompt_tokens: ru.inputTokens,
                 completion_tokens: ru.outputTokens,

--- a/packages/gateway/src/translate/types.ts
+++ b/packages/gateway/src/translate/types.ts
@@ -221,13 +221,56 @@ export type GatewayUsage = {
 /**
  * Zero-value usage — used as a safe fallback when `resp.usage` is undefined
  * at runtime (e.g. vLLM or partial responses from OpenAI-compatible providers).
+ *
+ * INVARIANT: Must only contain required fields (inputTokens, outputTokens).
+ * Do NOT add cacheReadInputTokens or cacheCreationInputTokens here — their
+ * *presence* (even as 0) makes downstream `!= null` guards emit cache fields
+ * in the wire response when no caching actually occurred. This invariant is
+ * enforced by a test in translate-types.test.ts.
  */
-export const ZERO_USAGE: GatewayUsage = {
+export const ZERO_USAGE: GatewayUsage = Object.freeze({
   inputTokens: 0,
   outputTokens: 0,
-  cacheReadInputTokens: 0,
-  cacheCreationInputTokens: 0,
-};
+});
+
+/**
+ * Extract a JSON payload from an SSE response body.
+ *
+ * Some providers (e.g. DeepSeek) return SSE-formatted responses even when
+ * `stream: false` was sent. This function reads all `data: ` lines, ignores
+ * the `data: [DONE]` sentinel, and returns the **last** non-sentinel data
+ * payload as parsed JSON. The final `data:` line contains the full response
+ * object in this scenario.
+ *
+ * NOTE: This does not handle the SSE spec's multiline `data:` continuation
+ * (consecutive `data:` lines joined by `\n`). In practice, providers that
+ * return a complete non-streaming response as SSE always send the JSON
+ * object on a single `data:` line.
+ */
+export async function extractJSONFromSSE(
+  response: Response,
+): Promise<Record<string, unknown>> {
+  const text = await response.text();
+  const lines = text.split("\n");
+  let lastPayload: string | null = null;
+
+  for (const line of lines) {
+    if (line.startsWith("data: ")) {
+      const payload = line.slice(6).trim();
+      if (payload && payload !== "[DONE]") {
+        lastPayload = payload;
+      }
+    }
+  }
+
+  if (!lastPayload) {
+    throw new Error(
+      "upstream returned SSE but no data payload found — expected JSON in data: lines",
+    );
+  }
+
+  return JSON.parse(lastPayload) as Record<string, unknown>;
+}
 
 /** Accumulated response from the upstream provider. */
 export type GatewayResponse = {

--- a/packages/gateway/test/translate-types.test.ts
+++ b/packages/gateway/test/translate-types.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { ZERO_USAGE, extractJSONFromSSE } from "../src/translate/types";
+
+// ---------------------------------------------------------------------------
+// ZERO_USAGE
+// ---------------------------------------------------------------------------
+
+describe("ZERO_USAGE", () => {
+  it("must not include optional cache fields", () => {
+    // INVARIANT: ZERO_USAGE must only contain required fields (inputTokens,
+    // outputTokens). The optional cache fields (cacheReadInputTokens,
+    // cacheCreationInputTokens) must NOT be present — their mere presence
+    // (even as 0) causes downstream `!= null` guards to emit cache fields
+    // in the wire response, leaking "cache_read_input_tokens: 0" to clients
+    // when no caching actually occurred.
+    expect(Object.keys(ZERO_USAGE).sort()).toEqual([
+      "inputTokens",
+      "outputTokens",
+    ]);
+    expect(ZERO_USAGE).not.toHaveProperty("cacheReadInputTokens");
+    expect(ZERO_USAGE).not.toHaveProperty("cacheCreationInputTokens");
+  });
+
+  it("has zero values for required fields", () => {
+    expect(ZERO_USAGE.inputTokens).toBe(0);
+    expect(ZERO_USAGE.outputTokens).toBe(0);
+  });
+
+  it("is frozen to prevent accidental mutation", () => {
+    expect(Object.isFrozen(ZERO_USAGE)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractJSONFromSSE
+// ---------------------------------------------------------------------------
+
+/** Helper: create a Response with the given body text and content-type. */
+function sseResponse(body: string): Response {
+  return new Response(body, {
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+describe("extractJSONFromSSE", () => {
+  it("extracts JSON from a single data: line", async () => {
+    const resp = sseResponse('data: {"id":"abc","model":"gpt-4"}\n\n');
+    const json = await extractJSONFromSSE(resp);
+    expect(json).toEqual({ id: "abc", model: "gpt-4" });
+  });
+
+  it("returns the last non-[DONE] payload when multiple data: lines exist", async () => {
+    const body = [
+      'data: {"id":"1","choices":[]}',
+      'data: {"id":"2","choices":[{"finish_reason":"stop"}]}',
+      "data: [DONE]",
+      "",
+    ].join("\n");
+    const json = await extractJSONFromSSE(sseResponse(body));
+    expect(json).toEqual({
+      id: "2",
+      choices: [{ finish_reason: "stop" }],
+    });
+  });
+
+  it("ignores data: [DONE] sentinel", async () => {
+    const body = 'data: {"id":"x"}\ndata: [DONE]\n\n';
+    const json = await extractJSONFromSSE(sseResponse(body));
+    expect(json).toEqual({ id: "x" });
+  });
+
+  it("throws when body has no data: lines", async () => {
+    const resp = sseResponse("event: ping\n: comment\n\n");
+    await expect(extractJSONFromSSE(resp)).rejects.toThrow(
+      "no data payload found",
+    );
+  });
+
+  it("throws when body has only data: [DONE]", async () => {
+    const resp = sseResponse("data: [DONE]\n\n");
+    await expect(extractJSONFromSSE(resp)).rejects.toThrow(
+      "no data payload found",
+    );
+  });
+
+  it("throws on malformed JSON in data: line", async () => {
+    const resp = sseResponse("data: {broken json}\n\n");
+    await expect(extractJSONFromSSE(resp)).rejects.toThrow();
+  });
+
+  it("handles \\r\\n line endings", async () => {
+    const body = 'data: {"id":"crlf"}\r\ndata: [DONE]\r\n\r\n';
+    const json = await extractJSONFromSSE(sseResponse(body));
+    expect(json).toEqual({ id: "crlf" });
+  });
+});


### PR DESCRIPTION
## Summary
Follow-up fixes from self-review of PRs #600 and #605 — addresses a semantic regression, adds runtime safety, and consolidates duplicated code.

## Changes

### 1. Fix ZERO_USAGE semantic bug (from PR #600)
`ZERO_USAGE` previously included `cacheReadInputTokens: 0` and `cacheCreationInputTokens: 0`. These optional fields' *presence* (even as 0) caused downstream `!= null` guards to pass, leaking `cache_read_input_tokens: 0` in wire responses to clients when no caching actually occurred.

**Fix:** Remove cache fields from `ZERO_USAGE`, leaving only the required `inputTokens` and `outputTokens`.

### 2. Freeze ZERO_USAGE
`Object.freeze()` the constant to prevent accidental mutation of the shared sentinel object. Without this, a careless `usage.cacheReadInputTokens = value` on a reference from `resp.usage ?? ZERO_USAGE` would silently corrupt the sentinel for all subsequent requests.

### 3. Add invariant tests
New tests in `translate-types.test.ts`:
- **ZERO_USAGE invariants:** required-fields-only allowlist, no cache properties, frozen
- **extractJSONFromSSE:** single/multi data lines, `[DONE]` sentinel skipping, empty body throws, malformed JSON throws, CRLF line ending support

### 4. Consolidate SSE extraction (from PR #605)
`extractJSONFromSSE()` was duplicated: once in `pipeline.ts` and once inline in `llm-adapter.ts` (with different error handling — one threw, the other fell back to `{}`). Moved to `translate/types.ts` as a shared export. The throwing behavior is used consistently now, which is correct — the `{}` fallback silently produced empty responses without diagnostics.

Added JSDoc noting the known limitation: multiline `data:` continuation per SSE spec is not handled, as providers returning complete non-streaming responses as SSE always use single-line JSON payloads.

### 5. Unify inline fallbacks
Replaced all inline `{ inputTokens: 0, outputTokens: 0 }` fallbacks in `stream/openai.ts`, `stream/openai-responses.ts`, and `stream/anthropic.ts` with the shared `ZERO_USAGE` constant.

## Verification
- `pnpm -r typecheck` — all packages pass
- `pnpm test` — 83 files, 2297 tests pass (10 new)
- `pnpm run lint` — no new warnings/errors