### PR TITLE
ci: add actionlint to catch workflow YAML errors

### DIFF
--- a/.github/workflows/cch-seed-check.yml
+++ b/.github/workflows/cch-seed-check.yml
@@ -38,9 +38,11 @@ jobs:
         run: |
           if [ -n "${{ inputs.force-version }}" ]; then
             VERSION="${{ inputs.force-version }}"
-            echo "needs-extraction=true" >> "$GITHUB_OUTPUT"
-            echo "latest-version=$VERSION" >> "$GITHUB_OUTPUT"
-            echo "missing-versions=[\"$VERSION\"]" >> "$GITHUB_OUTPUT"
+            {
+              echo "needs-extraction=true"
+              echo "latest-version=$VERSION"
+              echo "missing-versions=[\"$VERSION\"]"
+            } >> "$GITHUB_OUTPUT"
             echo "Force extraction for version: $VERSION"
           else
             # check-cc-version.ts exits 1 if extraction is needed
@@ -52,22 +54,28 @@ jobs:
             echo "Raw output: $result"
 
             if [ $exit_code -eq 0 ]; then
-              echo "needs-extraction=false" >> "$GITHUB_OUTPUT"
-              echo "latest-version=" >> "$GITHUB_OUTPUT"
-              echo "missing-versions=[]" >> "$GITHUB_OUTPUT"
+              {
+                echo "needs-extraction=false"
+                echo "latest-version="
+                echo "missing-versions=[]"
+              } >> "$GITHUB_OUTPUT"
               echo "All versions have known seeds"
             else
               latest=$(echo "$result" | jq -r '.latestVersion // empty')
               missing=$(echo "$result" | jq -c '.missingVersions // []')
               if [ -n "$latest" ] && [ "$missing" != "[]" ]; then
-                echo "needs-extraction=true" >> "$GITHUB_OUTPUT"
-                echo "latest-version=$latest" >> "$GITHUB_OUTPUT"
-                echo "missing-versions=$missing" >> "$GITHUB_OUTPUT"
+                {
+                  echo "needs-extraction=true"
+                  echo "latest-version=$latest"
+                  echo "missing-versions=$missing"
+                } >> "$GITHUB_OUTPUT"
                 echo "Missing versions: $missing"
               else
-                echo "needs-extraction=false" >> "$GITHUB_OUTPUT"
-                echo "latest-version=" >> "$GITHUB_OUTPUT"
-                echo "missing-versions=[]" >> "$GITHUB_OUTPUT"
+                {
+                  echo "needs-extraction=false"
+                  echo "latest-version="
+                  echo "missing-versions=[]"
+                } >> "$GITHUB_OUTPUT"
                 echo "Check failed but no versions to extract"
               fi
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,25 @@ jobs:
         if: github.event_name == 'push'
         run: echo "code=true" >> "$GITHUB_OUTPUT"
 
+  # ---------------------------------------------------------------------------
+  # Lint GitHub Actions workflow files (catches schema errors, empty `with:`
+  # blocks, expression type mismatches, invalid action inputs, etc.)
+  # Runs unconditionally — sub-second, no Node/pnpm deps, and workflow bugs
+  # should never slip through regardless of which files changed.
+  # ---------------------------------------------------------------------------
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install actionlint
+        run: bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+      - name: Lint workflow files
+        # -shellcheck="" disables shellcheck integration — the existing
+        # run: blocks have cosmetic shellcheck findings (SC2086, SC2129,
+        # SC2035, SC2012) that are not bugs. The value of actionlint is
+        # in workflow schema validation, not shell style.
+        run: ./actionlint -color
+
   test:
     needs: [changes]
     if: needs.changes.outputs.code == 'true'
@@ -712,7 +731,7 @@ jobs:
             --artifact-type application/vnd.lore.cli.nightly \
             --annotation "org.opencontainers.image.source=https://github.com/BYK/loreai" \
             --annotation "version=${VERSION}" \
-            *.gz
+            ./*.gz
 
       - name: Tag versioned nightly
         # Create an immutable versioned tag via zero-copy oras tag.
@@ -768,8 +787,8 @@ jobs:
           eval oras push "${REPO}:patch-${VERSION}" \
             --artifact-type application/vnd.lore.cli.patch \
             --annotation "from-version=${PREV_VERSION}" \
-            ${ANNOTATIONS} \
-            ${PATCH_FILES}
+            "${ANNOTATIONS}" \
+            "${PATCH_FILES}"
 
           echo "Pushed patch manifest: patch-${VERSION} (from ${PREV_VERSION})"
 
@@ -903,11 +922,15 @@ jobs:
   ci-status:
     name: CI Status
     if: always()
-    needs: [changes, test, binary-smoke-native]
+    needs: [changes, test, binary-smoke-native, actionlint]
     runs-on: ubuntu-latest
     steps:
       - name: Check CI result
         run: |
+          if [ "${{ needs.actionlint.result }}" != "success" ]; then
+            echo "::error::actionlint job did not succeed (result: ${{ needs.actionlint.result }})"
+            exit 1
+          fi
           if [ "${{ needs.changes.outputs.code }}" == "true" ]; then
             if [ "${{ needs.test.result }}" != "success" ]; then
               echo "::error::test job did not succeed (result: ${{ needs.test.result }})"

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -82,9 +82,9 @@ jobs:
       - name: Post summary
         if: always()
         run: |
-          LATEST=$(ls -t packages/core/eval/results/*.jsonl 2>/dev/null | head -1)
+          LATEST=$(find packages/core/eval/results/ -maxdepth 1 -name '*.jsonl' -printf '%T@\t%p\n' 2>/dev/null | sort -rn | head -1 | cut -f2)
           if [ -n "$LATEST" ]; then
-            pnpm tsx packages/core/eval/run.ts --summarize "$LATEST" >> $GITHUB_STEP_SUMMARY
+            pnpm tsx packages/core/eval/run.ts --summarize "$LATEST" >> "$GITHUB_STEP_SUMMARY"
           fi
 
   eval-auto-memory:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -169,7 +169,7 @@ jobs:
           while IFS= read -r target; do
             # Escape special regex chars in target name
             escaped=$(printf '%s' "$target" | sed 's/[][().\*^$?+{}|/]/\\&/g')
-            body=$(echo "$body" | sed "s/- \[ \] ${escaped}/- [x] ${escaped}/")
+            body="${body//- \[ \] ${escaped}/- [x] ${escaped}}"
           done <<< "$published_targets"
 
           gh issue edit "${{ github.event.issue.number }}" --body "$body"


### PR DESCRIPTION
## Summary

Adds a lightweight `actionlint` job to CI that validates all 7 GitHub Actions workflow files on every push and PR. Prevents regressions like the empty `with:` bug fixed in #610. Also fixes all pre-existing shellcheck findings in workflow `run:` blocks so the lint starts clean.

## What actionlint catches

- Schema errors (empty `with:` blocks, invalid keys, missing required fields)
- Expression type mismatches in `${{ }}` blocks
- Invalid action inputs (e.g. typo in `node_version` vs `node-version`)
- Runner label validation, `needs:` dependency graph errors
- Glob pattern and cron syntax validation
- Script injection risks from untrusted inputs in `run:` blocks
- shellcheck integration for `run:` blocks

## Changes

### New `actionlint` CI job
- Standalone job: 3 steps (checkout, install, lint), no Node/pnpm deps
- Runs unconditionally — not gated behind `changes` filter (sub-second, workflow bugs should always be caught)
- Added to `ci-status` gate so workflow errors block the PR

### Pre-existing shellcheck fixes (all 6 findings)

| File | SC code | Fix |
|---|---|---|
| `cch-seed-check.yml:38` | SC2129 (x4) | Grouped consecutive `>> "$GITHUB_OUTPUT"` redirects into `{ ...; } >> "$GITHUB_OUTPUT"` blocks |
| `ci.yml:734` | SC2035 | `*.gz` → `./*.gz` (prevents dash-prefixed filenames becoming options) |
| `ci.yml:790-791` | SC2086 (x2) | `${ANNOTATIONS}` → `"${ANNOTATIONS}"`, `${PATCH_FILES}` → `"${PATCH_FILES}"` |
| `eval.yml:85` | SC2012+SC2086 | `ls -t *.jsonl` → `find ... -printf '%T@\t%p\n' | sort -rn | head -1 | cut -f2`; quoted `$GITHUB_STEP_SUMMARY` |
| `publish.yml:172` | SC2001 | `sed "s/.../.../"`  → `${body//pattern/replacement}` (bash parameter expansion) |

## Verification

The `actionlint` job self-verified on this PR: all 7 workflow files pass with zero findings (schema + shellcheck).