### PR TITLE
fix(gateway,core): address 4 Sentry issues (1J, Q, 10, 1Z)

### DIFF
--- a/packages/core/eval/harness.ts
+++ b/packages/core/eval/harness.ts
@@ -214,7 +214,7 @@ async function startLiveGateway(): Promise<GatewayHandle> {
 
   // NO replay interceptor — requests go to real upstream
   const config = loadConfig();
-  const server = startServer(config);
+  const server = await startServer(config);
   const baseURL = `http://127.0.0.1:${server.port}`;
 
   console.log(`  Live gateway started at ${baseURL} (db: ${dbPath})`);

--- a/packages/core/eval/lore-harness.ts
+++ b/packages/core/eval/lore-harness.ts
@@ -82,7 +82,7 @@ export async function startGateway(): Promise<GatewayHandle> {
   await resetPipelineState();
 
   const config = loadConfig();
-  const server = startServer(config);
+  const server = await startServer(config);
   const baseURL = `http://127.0.0.1:${server.port}`;
 
   console.log(`  Gateway started at ${baseURL} (db: ${dbPath})`);

--- a/packages/core/src/embedding-worker-types.ts
+++ b/packages/core/src/embedding-worker-types.ts
@@ -116,6 +116,13 @@ export function isWasmFatalError(msg: string): boolean {
   // These are model-init-time OOMs, not input-size-driven, so truncation
   // retries cannot help. Treat as fatal to stop the event storm.
   if (isOomError(msg)) return true;
+  // Pipeline Callable pattern broken — @huggingface/transformers uses
+  // Object.setPrototypeOf to make pipeline instances callable. Under
+  // esbuild CJS + Node v24, this can fail silently — the pipeline object
+  // is truthy but not a function, so every subsequent inference attempt
+  // throws "pipe is not a function" (LOREAI-GATEWAY-10). Treating this
+  // as fatal stops the 346-event storm by marking the provider broken.
+  if (/is not a function/.test(msg)) return true;
   return false;
 }
 

--- a/packages/core/src/embedding-worker.ts
+++ b/packages/core/src/embedding-worker.ts
@@ -162,6 +162,22 @@ async function ensurePipeline(): Promise<void> {
         device: "cpu",
       })) as unknown as FeatureExtractionPipeline;
 
+      // Guard against Callable pattern failure: @huggingface/transformers
+      // uses Object.setPrototypeOf(closure, new.target.prototype) in the
+      // Callable base class to make pipeline instances callable. Under
+      // esbuild CJS bundling + Node v24, this pattern can break — the
+      // pipeline object is truthy but not a function, causing "pipe is not
+      // a function" on every subsequent inference (LOREAI-GATEWAY-10).
+      // Detect at construction time and fail fast with a descriptive error.
+      if (typeof pipe !== "function") {
+        const actualType = typeof pipe;
+        pipe = null;
+        throw new Error(
+          `pipeline() returned a non-callable ${actualType} — ` +
+            `Callable pattern broken (Node ${process.versions.node})`,
+        );
+      }
+
       // Stash a reference to the pipeline's tokenizer for token-level
       // truncation during OOM retries.
       tokenizer = (pipe as unknown as { tokenizer: typeof tokenizer })

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -323,19 +323,23 @@ class LocalProvider implements EmbeddingProvider {
         this.worker = new Worker(workerSource, opts);
       } else {
         // npm bundle / dev path: point at a sibling worker file.
+        // CJS uses __filename (always defined); ESM uses import.meta.url.
         let workerUrl: string | URL;
-        const selfUrl =
-          typeof import.meta.url === "string" ? import.meta.url : undefined;
-        if (selfUrl) {
-          workerUrl = new URL(
-            `./embedding-worker${selfUrl.endsWith(".ts") ? ".ts" : ".js"}`,
-            selfUrl,
-          );
-        } else {
+        if (typeof __filename === "string") {
           const { pathToFileURL } = await import("node:url");
           workerUrl = new URL(
             "./embedding-worker.cjs",
             pathToFileURL(__filename),
+          );
+        } else {
+          // ESM (Bun, tsx): resolve worker relative to this module's URL.
+          // Use indirect access via Function to avoid esbuild's static
+          // "empty-import-meta" warning in CJS output — this branch is
+          // unreachable in CJS since __filename is always defined there.
+          const selfUrl = new Function("return import.meta.url")() as string;
+          workerUrl = new URL(
+            `./embedding-worker${selfUrl.endsWith(".ts") ? ".ts" : ".js"}`,
+            selfUrl,
           );
         }
         this.worker = new Worker(workerUrl, {
@@ -981,6 +985,7 @@ export function embedKnowledgeEntry(
         .run(toBlob(vec), id);
     })
     .catch((err) => {
+      if (err instanceof LocalProviderUnavailableError) return;
       log.error("embedding failed for knowledge entry", id, ":", err);
     });
 }
@@ -1018,6 +1023,7 @@ export function embedEntity(
         .run(toBlob(vec), id);
     })
     .catch((err) => {
+      if (err instanceof LocalProviderUnavailableError) return;
       log.error("embedding failed for entity", id, ":", err);
     });
 }
@@ -1036,6 +1042,7 @@ export function embedDistillation(id: string, observations: string): void {
         .run(toBlob(vec), id);
     })
     .catch((err) => {
+      if (err instanceof LocalProviderUnavailableError) return;
       log.error("embedding failed for distillation", id, ":", err);
     });
 }
@@ -1059,6 +1066,7 @@ export function embedTemporalMessage(id: string, content: string): void {
         .run(toBlob(vec), id);
     })
     .catch((err) => {
+      if (err instanceof LocalProviderUnavailableError) return;
       log.error("embedding failed for temporal message", id, ":", err);
     });
 }
@@ -1383,13 +1391,17 @@ export async function backfillEmbeddings(): Promise<number> {
         embedded++;
       }
     } catch (err) {
-      // log.error sends to Sentry via captureException
+      // Provider shutdown / unavailability is expected graceful degradation,
+      // not a bug — check before log.error so captureException doesn't fire
+      // and create Sentry noise (LOREAI-GATEWAY-Q).
+      if (err instanceof LocalProviderUnavailableError) {
+        log.info("embedding backfill stopped: provider unavailable");
+        break;
+      }
       log.error(
         `embedding backfill batch failed (${batch.length} items):`,
         err,
       );
-      // Provider is dead — no point retrying remaining batches.
-      if (err instanceof LocalProviderUnavailableError) break;
     }
     // No yieldToEventLoop() needed — embed() is truly async (worker thread).
   }
@@ -1451,13 +1463,19 @@ export async function backfillDistillationEmbeddings(): Promise<number> {
         embedded++;
       }
     } catch (err) {
-      // log.error sends to Sentry via captureException
+      // Provider shutdown / unavailability is expected graceful degradation,
+      // not a bug — check before log.error so captureException doesn't fire
+      // and create Sentry noise (LOREAI-GATEWAY-Q).
+      if (err instanceof LocalProviderUnavailableError) {
+        log.info(
+          "distillation embedding backfill stopped: provider unavailable",
+        );
+        break;
+      }
       log.error(
         `distillation embedding backfill batch failed (${batch.length} items):`,
         err,
       );
-      // Provider is dead — no point retrying remaining batches.
-      if (err instanceof LocalProviderUnavailableError) break;
     }
 
     if (embedded >= nextProgressAt) {
@@ -1536,13 +1554,17 @@ export async function backfillEntityEmbeddings(): Promise<number> {
         embedded++;
       }
     } catch (err) {
-      // log.error sends to Sentry via captureException
+      // Provider shutdown / unavailability is expected graceful degradation,
+      // not a bug — check before log.error so captureException doesn't fire
+      // and create Sentry noise (LOREAI-GATEWAY-Q).
+      if (err instanceof LocalProviderUnavailableError) {
+        log.info("entity embedding backfill stopped: provider unavailable");
+        break;
+      }
       log.error(
         `entity embedding backfill batch failed (${batch.length} items):`,
         err,
       );
-      // Provider is dead — no point retrying remaining batches.
-      if (err instanceof LocalProviderUnavailableError) break;
     }
     // No yieldToEventLoop() needed — embed() is truly async (worker thread).
   }

--- a/packages/gateway/instrument.ts
+++ b/packages/gateway/instrument.ts
@@ -155,6 +155,17 @@ if (sentryEnabled && !Sentry.isInitialized()) {
     tracesSampleRate: 1.0,
     enableLogs: true,
 
+    // Disable the NodeFetch integration. In the esbuild CJS bundle, the
+    // vendored undici code inside @sentry/node has 100+ `let` declarations
+    // that get flattened into a single scope. The NodeFetch integration
+    // registers a `diagnostics_channel` hook during init() that fires
+    // synchronously on the first fetch() — but the hook's callback
+    // accesses variables that are still in the Temporal Dead Zone because
+    // the Sentry sub-module's lazy wrapper hasn't fully evaluated yet.
+    // This causes "Cannot access '_e' before initialization" (LOREAI-GATEWAY-1J).
+    // The gateway does its own upstream fetch tracing, so no functionality is lost.
+    integrations: (defaults) => defaults.filter((i) => i.name !== "NodeFetch"),
+
     // Drop transient network errors that are not actionable bugs.
     // Each exception in the chain is tested independently so a real bug
     // wrapping a transient cause isn't accidentally silenced.

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -36,13 +36,22 @@ export { _cli } from "./cli/main";
 // ---------------------------------------------------------------------------
 
 // Direct execution detection: only auto-start when this module is the entry
-// point. Under the esbuild CJS bundle, `import.meta.url` is replaced with
-// `""` so the IIFE returns false — the block becomes dead code (the bin.cjs
-// wrapper handles entry). Under tsx/bun ESM, the check works correctly.
+// point. CJS path uses __filename (always defined). ESM path uses
+// import.meta.url via a dynamic expression that esbuild can't statically
+// analyze, avoiding the "empty-import-meta" warning in CJS output.
 const isMainModule = (() => {
-  if (!import.meta.url) return false;
   try {
-    return process.argv[1] === fileURLToPath(import.meta.url);
+    // CJS bundles and Node.js CJS: __filename is always defined.
+    if (typeof __filename === "string") {
+      return process.argv[1] === __filename;
+    }
+    // ESM (Bun, tsx): derive __filename from import.meta.url.
+    // Dynamic property access prevents esbuild from warning about
+    // import.meta usage in CJS output — this branch is unreachable
+    // in CJS anyway since __filename is always defined there.
+    const meta = import.meta as unknown as Record<string, unknown>;
+    const url = meta.url;
+    return typeof url === "string" && process.argv[1] === fileURLToPath(url);
   } catch {
     return false;
   }

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -504,7 +504,7 @@ export async function startServer(config: GatewayConfig): Promise<{
     .map((s) => serverReadyPromises.get(s))
     .filter((p): p is Promise<void> => p !== undefined);
 
-  return {
+  const result = {
     stop: () => {
       for (const s of servers) s.close();
     },
@@ -512,6 +512,29 @@ export async function startServer(config: GatewayConfig): Promise<{
     hosts: config.hosts,
     ready: Promise.all(readyPromises).then(() => {}),
   };
+
+  // Defensive: startServer() is async, so callers must use `await`.
+  // If someone writes `const server = startServer(config)` (missing await),
+  // `server` is a Promise — accessing .port/.hosts returns undefined,
+  // producing cryptic errors like "Failed to parse URL from
+  // http://127.0.0.1:undefined/health" (LOREAI-GATEWAY-1Z).
+  // These property traps turn the silent undefined into a loud, actionable
+  // error message. They're defined on the specific Promise instance, not
+  // on Promise.prototype, so they only affect this call site.
+  const promise = Promise.resolve(result);
+  for (const prop of ["port", "hosts", "ready", "stop"] as const) {
+    Object.defineProperty(promise, prop, {
+      get() {
+        throw new TypeError(
+          `startServer() is async — use \`const server = await startServer(config)\` ` +
+            `before accessing .${prop}`,
+        );
+      },
+      configurable: true,
+    });
+  }
+
+  return promise;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes four unresolved Sentry issues with targeted, minimal changes. Also eliminates 3 esbuild `import.meta` warnings from the CJS bundle.

## Changes

### LOREAI-GATEWAY-1J — TDZ crash in CJS bundle (8 events)
**Root cause:** Sentry's `NodeFetch` integration registers a `diagnostics_channel` hook during `Sentry.init()`. In the esbuild CJS bundle, the vendored undici code has 100+ `let` declarations flattened into a single scope. When the first `fetch()` fires, the hook's callback accesses variables still in the Temporal Dead Zone — `"Cannot access '_e' before initialization"`.

**Fix:** Disable the `NodeFetch` integration in `Sentry.init()`. The gateway does its own upstream fetch tracing, so no functionality is lost.

**File:** `packages/gateway/instrument.ts`

### LOREAI-GATEWAY-Q — Embedding backfill Sentry noise (53 events)
**Root cause:** The backfill catch blocks called `log.error()` (which triggers `captureException`) *before* checking `instanceof LocalProviderUnavailableError`. Provider shutdown is expected graceful degradation, not a bug.

**Fix:** Reorder all 3 backfill catch blocks (knowledge, distillation, entity) to check `instanceof` first, use `log.info` for expected shutdown, and `break`. Also adds `instanceof` guard to all 4 fire-and-forget embed functions (`embedKnowledgeEntry`, `embedEntity`, `embedDistillation`, `embedTemporalMessage`) for consistency — silently returns on provider unavailability instead of logging as error.

**File:** `packages/core/src/embedding.ts`

### LOREAI-GATEWAY-10 — "pipe is not a function" storm (346 events)
**Root cause:** `@huggingface/transformers` uses a `Callable` class pattern (`Object.setPrototypeOf`) to make pipeline instances callable. Under esbuild CJS + Node v24, this can break silently — the pipeline object is truthy but not callable. The error wasn't classified as fatal, so the worker kept running and every subsequent embed request failed.

**Fix:** Two parts:
1. Add `"is not a function"` pattern to `isWasmFatalError()` so the provider gets marked broken immediately
2. Add `typeof pipe !== "function"` guard after pipeline construction in the worker for early detection with a descriptive error

**Files:** `packages/core/src/embedding-worker-types.ts`, `packages/core/src/embedding-worker.ts`

### LOREAI-GATEWAY-1Z — startServer() port undefined (1 event, fatal)
**Root cause:** Eval harness callers forgot `await` on `startServer()` (which is `async`). `server.port` was `undefined` because `server` was a `Promise`, producing `"Failed to parse URL from http://127.0.0.1:undefined/health"`.

**Fix:** Three parts:
1. Add `Object.defineProperty` traps on the returned Promise for `.port`, `.hosts`, `.ready`, `.stop` that throw a helpful `TypeError` guiding callers to use `await` — defensive safety net for future callers
2. Fix the known broken callers in `packages/core/eval/harness.ts` and `packages/core/eval/lore-harness.ts` by adding the missing `await`

**Files:** `packages/gateway/src/server.ts`, `packages/core/eval/harness.ts`, `packages/core/eval/lore-harness.ts`

### Bonus: Eliminate esbuild `import.meta` warnings
The CJS bundle produced 3 `[empty-import-meta]` warnings from `import.meta.url` references in `index.ts` and `embedding.ts`. Both usages already had runtime guards (checking for empty/undefined), but esbuild warns statically.

**Fix:** Refactor both sites to prefer `__filename` (always defined in CJS) as the primary path, with `import.meta.url` only in the ESM fallback branch — accessed indirectly to avoid esbuild's static analysis:
- `index.ts`: `typeof __filename === "string"` check first, ESM branch uses `import.meta` via intermediate variable
- `embedding.ts`: `typeof __filename === "string"` check first, ESM branch uses `new Function("return import.meta.url")()` to hide from esbuild

Bundle output is now warning-free.

**Files:** `packages/gateway/src/index.ts`, `packages/core/src/embedding.ts`

## Verification

- Typecheck: all packages pass (pre-existing `fossilize` type error unchanged)
- Lint: 0 errors, 15 warnings (all pre-existing)
- Tests: 83 files, 2297 tests passed
- Bundle: 0 warnings (was 3)