### PR TITLE
docs: align site and README with pitch deck positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Your AI forgets decisions, loses file paths, and undoes its own work. Lore gives it shared context across projects, tools, and providers — no context files to maintain, no workflow changes. Every new session starts with the relevant facts and gets a fresh injection after the first turn.
 
-Lore is a transparent LLM proxy that gives any AI agent shared context — across tools, projects, and teams. The memory that compounds. Context management and long-term memory aren't separate problems: they're one continuous pipeline. Distillation feeds the gradient context manager, which feeds the knowledge curator, which feeds `.lore.md`, and with Lore Cloud *(coming soon)*, your team.
+Lore is a transparent LLM proxy that gives any AI agent shared context — across tools, projects, and teams. The memory that compounds. Context management and long-term memory aren't separate problems: they're one continuous pipeline. Distillation feeds the gradient context manager, which feeds the knowledge curator, which feeds `.lore.md`, and with Folk Lore *(coming soon)*, your team.
 
 Built on [Sanity's Nuum](https://www.sanity.io/blog/how-we-solved-the-agent-memory-problem) memory architecture and [Mastra's Observational Memory](https://mastra.ai/research/observational-memory) research. The core idea: coding agents need **distillation, not summarization** — preserving file paths, error messages, and exact decisions rather than narrative summaries that lose the details agents need to keep working.
 
@@ -37,7 +37,7 @@ Once Lore is active, you should notice:
 - **Free on-device vector search** — Nomic Embed v1.5 runs locally with zero API cost. Hybrid architecture fuses vector similarity with BM25 keyword search and LLM-powered query expansion for best-of-both-worlds recall.
 - **Works with any provider** — `lore run` auto-detects Claude Code, OpenCode, Pi, and Codex. Cursor, Copilot, Windsurf, and any other Anthropic/OpenAI-compatible tool work by pointing their base URL at the gateway. Switch providers freely; your memory stays.*
 - **Import your history** — Lore imports conversations from Claude Code, Codex, Aider, Cline, Continue, OpenCode, and Pi, extracting knowledge from your existing sessions so your AI starts with context from day one.
-- **Team knowledge with Lore Cloud** — shared memory across your team, managed centrally. *(Coming soon.)*
+- **Team knowledge with Folk Lore** — shared memory across your team, managed centrally. *(Coming soon.)*
 
 <sub>* Any provider accessible via an OpenAI or Anthropic-compatible API.</sub>
 

--- a/packages/website/public/theme.css
+++ b/packages/website/public/theme.css
@@ -842,6 +842,33 @@ h1 em::after {
   margin: 0 auto 2.8rem;
 }
 
+.cta-eyebrow {
+  font-size: 0.72rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--g4);
+  margin: 0 0 1rem 0;
+  text-align: center;
+}
+
+.cta-vision {
+  font-size: 1.05rem;
+  line-height: 1.6;
+  color: var(--g1);
+  text-align: center;
+  max-width: 56ch;
+  margin: 1.25rem auto 0;
+  padding-top: 1.5rem;
+  border-top: 1px solid rgba(196, 221, 199, 0.2); /* --g5 @ 0.2 */
+}
+
+.cta-vision em {
+  color: var(--g2);
+  font-style: normal;
+  font-weight: 500;
+}
+
 .cta-input {
   width: 268px;
   padding: .85rem 1.3rem;

--- a/packages/website/src/pages/different.astro
+++ b/packages/website/src/pages/different.astro
@@ -45,7 +45,7 @@ import siteJs from "../scripts/site.js?raw";
         <a href="https://x.com/withLoreAI" target="_blank" rel="noopener noreferrer" class="social-link" aria-label="Lore.AI on X"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18.901 1.153h3.68l-8.04 9.19L24 22.846h-7.406l-5.8-7.584-6.638 7.584H.474l8.6-9.83L0 1.154h7.594l5.243 6.932ZM17.61 20.644h2.039L6.486 3.24H4.298Z" /></svg></a>
         <a href="https://github.com/byk/loreai" target="_blank" rel="noopener noreferrer" class="social-link" aria-label="Lore.AI on GitHub"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.043-1.61-4.043-1.61-.546-1.387-1.333-1.757-1.333-1.757-1.09-.745.083-.73.083-.73 1.205.085 1.84 1.237 1.84 1.237 1.07 1.835 2.807 1.305 3.492.998.108-.776.418-1.305.762-1.605-2.665-.3-5.467-1.332-5.467-5.93 0-1.31.468-2.38 1.235-3.22-.123-.303-.535-1.523.118-3.176 0 0 1.008-.322 3.3 1.23a11.48 11.48 0 0 1 3.003-.404c1.02.005 2.045.138 3.003.404 2.29-1.552 3.295-1.23 3.295-1.23.655 1.653.243 2.873.12 3.176.77.84 1.233 1.91 1.233 3.22 0 4.61-2.807 5.625-5.48 5.922.43.372.823 1.102.823 2.222 0 1.605-.015 2.898-.015 3.293 0 .32.218.695.825.577C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" /></svg></a>
       </div>
-      <a href="index.html#waitlist" class="nav-btn">Lore Cloud Waitlist</a>
+      <a href="index.html#waitlist" class="nav-btn">Folk Lore Waitlist</a>
     </div>
   </nav>
 
@@ -250,8 +250,8 @@ import siteJs from "../scripts/site.js?raw";
       </div>
       <div class="step sr">
         <div class="step-n">03</div>
-        <h3 class="step-t">Lore Cloud when you want it</h3>
-        <p class="step-b">For centrally-managed, multi-user shared memory with approval workflows, Lore Cloud is
+        <h3 class="step-t">Folk Lore when you want it</h3>
+        <p class="step-b">For centrally-managed, multi-user shared memory with approval workflows, Folk Lore is
           coming. It's an option layered on top of the local-first core — not a platform you have to adopt to get
           value today.</p>
       </div>
@@ -262,8 +262,10 @@ import siteJs from "../scripts/site.js?raw";
   <section class="cta" id="waitlist">
     <div class="cta-inner">
       <h2 class="sr">Memory that's <em>yours.</em></h2>
-      <p class="cta-sub sr">Lore runs locally today — free, fair source, and yours. Join the waitlist for Lore Cloud —
-        team-shared memory with zero setup.</p>
+      <p class="cta-sub sr">Lore is free and local today. <strong>Folk Lore</strong> brings your team's memory together — shared, searchable, always current.
+        Early access is rolling out. <strong>Be part of the myth.</strong></p>
+      <p class="cta-vision sr">Models will commoditize. The <em>context harness</em> will differentiate.
+        <strong>Lore is that harness</strong> — the <em>context engine</em> every agent needs to build the future.</p>
 
       <div class="cta-form-view show" id="waitlist-form-view">
         <form class="cta-form sr" id="waitlist-form"

--- a/packages/website/src/pages/different.astro
+++ b/packages/website/src/pages/different.astro
@@ -261,6 +261,7 @@ import siteJs from "../scripts/site.js?raw";
   <!-- CTA -->
   <section class="cta" id="waitlist">
     <div class="cta-inner">
+      <p class="cta-eyebrow sr">The future of AI agents</p>
       <h2 class="sr">Memory that's <em>yours.</em></h2>
       <p class="cta-sub sr">Lore is free and local today. <strong>Folk Lore</strong> brings your team's memory together — shared, searchable, always current.
         Early access is rolling out. <strong>Be part of the myth.</strong></p>

--- a/packages/website/src/pages/index.astro
+++ b/packages/website/src/pages/index.astro
@@ -442,6 +442,7 @@ import siteJs from "../scripts/site.js?raw";
       <p class="cta-vision sr">Models will commoditize. The <em>context harness</em> will differentiate.
         <strong>Lore is that harness</strong> — the <em>context engine</em> every agent needs to build the future.</p>
 
+      <!-- View 1: Form (default) -->
       <div class="cta-form-view show" id="waitlist-form-view">
         <form class="cta-form sr" id="waitlist-form"
               action="https://app.loops.so/api/newsletter-form/cmpemslgp03m10jxaipjw78iq" method="POST">

--- a/packages/website/src/pages/index.astro
+++ b/packages/website/src/pages/index.astro
@@ -46,7 +46,7 @@ import siteJs from "../scripts/site.js?raw";
         <a href="https://x.com/withLoreAI" target="_blank" rel="noopener noreferrer" class="social-link" aria-label="Lore.AI on X"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18.901 1.153h3.68l-8.04 9.19L24 22.846h-7.406l-5.8-7.584-6.638 7.584H.474l8.6-9.83L0 1.154h7.594l5.243 6.932ZM17.61 20.644h2.039L6.486 3.24H4.298Z" /></svg></a>
         <a href="https://github.com/byk/loreai" target="_blank" rel="noopener noreferrer" class="social-link" aria-label="Lore.AI on GitHub"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.043-1.61-4.043-1.61-.546-1.387-1.333-1.757-1.333-1.757-1.09-.745.083-.73.083-.73 1.205.085 1.84 1.237 1.84 1.237 1.07 1.835 2.807 1.305 3.492.998.108-.776.418-1.305.762-1.605-2.665-.3-5.467-1.332-5.467-5.93 0-1.31.468-2.38 1.235-3.22-.123-.303-.535-1.523.118-3.176 0 0 1.008-.322 3.3 1.23a11.48 11.48 0 0 1 3.003-.404c1.02.005 2.045.138 3.003.404 2.29-1.552 3.295-1.23 3.295-1.23.655 1.653.243 2.873.12 3.176.77.84 1.233 1.91 1.233 3.22 0 4.61-2.807 5.625-5.48 5.922.43.372.823 1.102.823 2.222 0 1.605-.015 2.898-.015 3.293 0 .32.218.695.825.577C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" /></svg></a>
       </div>
-      <a href="#waitlist" class="nav-btn">Lore Cloud Waitlist</a>
+      <a href="#waitlist" class="nav-btn">Folk Lore Waitlist</a>
     </div>
   </nav>
 
@@ -239,7 +239,7 @@ import siteJs from "../scripts/site.js?raw";
       </div>
       <div class="step sr">
         <div class="step-n">02</div>
-        <h3 class="step-t">Remember</h3>
+        <h3 class="step-t">Distill</h3>
         <p class="step-b">Lore replaces compaction entirely. Instead of lossy summaries that forget your file paths
           and decisions, it distills conversations into timestamped observation logs — the operational details
           your AI actually needs to keep working. Your manual "Key Technical Learnings"? Lore extracts and
@@ -291,8 +291,9 @@ import siteJs from "../scripts/site.js?raw";
         <p class="step-b">In Lore, context compression <em>is</em> the memory pipeline. Distillation
           feeds the gradient context manager, which feeds the knowledge curator, which feeds
           <code class="code-inline">.lore.md</code>
-          — and with Lore Cloud, your team. Every conversation makes every future session smarter,
-          across any provider, any tool, any team member.
+          — and with Folk Lore, your team. Every conversation makes every future session smarter,
+          across any provider, any tool, any team member. Every new session starts with the relevant
+          facts and gets a fresh injection after the first turn.
           <a href="docs.html" style="border-bottom:1px solid var(--g4);color:var(--g2)">Read the docs &rarr;</a></p>
       </div>
     </div>
@@ -434,10 +435,13 @@ import siteJs from "../scripts/site.js?raw";
   <!-- CTA -->
   <section class="cta" id="waitlist">
     <div class="cta-inner">
+      <p class="cta-eyebrow sr">The future of AI agents</p>
       <h2 class="sr">Stop managing context. <em>Start building.</em></h2>
-      <p class="cta-sub sr">Lore runs locally today — free, fair source, and yours. Join the waitlist for Lore Cloud — team-shared memory with zero setup.</p>
+      <p class="cta-sub sr">Lore is free and local today. <strong>Folk Lore</strong> brings your team's memory together — shared, searchable, always current.
+        Early access is rolling out. <strong>Be part of the myth.</strong></p>
+      <p class="cta-vision sr">Models will commoditize. The <em>context harness</em> will differentiate.
+        <strong>Lore is that harness</strong> — the <em>context engine</em> every agent needs to build the future.</p>
 
-      <!-- View 1: Form (default) -->
       <div class="cta-form-view show" id="waitlist-form-view">
         <form class="cta-form sr" id="waitlist-form"
               action="https://app.loops.so/api/newsletter-form/cmpemslgp03m10jxaipjw78iq" method="POST">

--- a/packages/website/src/styles/starlight.css
+++ b/packages/website/src/styles/starlight.css
@@ -36,30 +36,3 @@ html[data-theme="light"] {
   font-family: "Playfair Display", Georgia, serif;
   font-weight: 400;
 }
-
-.cta-eyebrow {
-  font-size: 0.72rem;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  color: var(--g4);
-  margin: 0 0 1rem 0;
-  text-align: center;
-}
-
-.cta-vision {
-  font-size: 1.05rem;
-  line-height: 1.6;
-  color: var(--g1);
-  text-align: center;
-  max-width: 56ch;
-  margin: 1.25rem auto 0;
-  padding-top: 1.5rem;
-  border-top: 1px solid rgba(196, 221, 199, 0.2);
-}
-
-.cta-vision em {
-  color: var(--g2);
-  font-style: normal;
-  font-weight: 500;
-}

--- a/packages/website/src/styles/starlight.css
+++ b/packages/website/src/styles/starlight.css
@@ -36,3 +36,30 @@ html[data-theme="light"] {
   font-family: "Playfair Display", Georgia, serif;
   font-weight: 400;
 }
+
+.cta-eyebrow {
+  font-size: 0.72rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--g4);
+  margin: 0 0 1rem 0;
+  text-align: center;
+}
+
+.cta-vision {
+  font-size: 1.05rem;
+  line-height: 1.6;
+  color: var(--g1);
+  text-align: center;
+  max-width: 56ch;
+  margin: 1.25rem auto 0;
+  padding-top: 1.5rem;
+  border-top: 1px solid rgba(196, 221, 199, 0.2);
+}
+
+.cta-vision em {
+  color: var(--g2);
+  font-style: normal;
+  font-weight: 500;
+}


### PR DESCRIPTION
Aligns the Astro site and README with the latest pitch deck positioning.

- Renames 'Remember' to 'Distill' in the 3-stage pipeline.
- Renames 'Lore Cloud' to 'Folk Lore' across the site and README.
- Updates CTA sections with 'context harness' and 'context engine' framing.
- Adds 'Be part of the myth' call to action.
- Ports first-turn injection line to the index page.
- Adds corresponding CSS for new CTA elements.