### PR TITLE
fix(gateway): externalize @loreai/core in Bun ESM bundle to prevent fetch loop

### DIFF
--- a/packages/gateway/script/bundle.ts
+++ b/packages/gateway/script/bundle.ts
@@ -127,7 +127,16 @@ await esbuild.build({
   target: "esnext",
   platform: "node",
   conditions: ["bun"],
-  external: ["bun:*", "node:*", "onnxruntime-node", "sharp"],
+  // @loreai/core MUST be external in the Bun ESM bundle. When the gateway
+  // runs in-process alongside the OpenCode plugin, both must share a single
+  // module instance of @loreai/core — specifically the _originalFetch
+  // variable in fetch-interceptor.ts. If core is bundled into the gateway,
+  // installFetchInterceptor() (called by the plugin) sets _originalFetch
+  // on the plugin's copy while getOriginalFetch() (called by the gateway)
+  // reads from the bundled copy (always null → returns globalThis.fetch =
+  // the interceptor). This creates an infinite request loop: gateway →
+  // interceptor → gateway → interceptor → …
+  external: ["bun:*", "node:*", "onnxruntime-node", "sharp", "@loreai/core"],
   outfile: join(distDir, "index.bun.js"),
   sourcemap: false,
   minify: true,


### PR DESCRIPTION
## Problem

When the gateway runs in-process alongside the OpenCode plugin (the standard Bun/OpenCode setup), the Bun ESM bundle (`dist/index.bun.js`) was bundling `@loreai/core` inline. This created a **separate module instance** from the plugin's copy, causing an infinite fetch loop:

1. `installFetchInterceptor()` (plugin side) sets `_originalFetch` on the plugin's `@loreai/core`
2. `getOriginalFetch()` (gateway side, via `upstreamFetch()`) reads from the bundled copy where `_originalFetch` is always `null`
3. Falls back to `globalThis.fetch` — which IS the interceptor
4. Gateway upstream call → interceptor → gateway → interceptor → ...

**Result:** No responses reach the OpenCode UI. Requests pile up in logs (same session/message count retried every second).

## Fix

Add `"@loreai/core"` to the ESM bundle's `external` list in `packages/gateway/script/bundle.ts`. Bun resolves it from the workspace at runtime, sharing the same module instance as the plugin.

- Bundle size: 2.1MB → 1.3MB (core no longer inlined)
- 32 external `@loreai/core` imports in the output
- CJS bundle unchanged (correctly inlines core for standalone use)

## Verification

- `pnpm --filter @loreai/gateway run bundle`: builds without warnings
- ESM bundle has `@loreai/core` as external imports (verified via grep)
- CJS bundle still inlines core (no change)