### PR TITLE
fix(gateway): pass session upstream URL to cache-warmer profile resolution

### DIFF
--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -1065,6 +1065,7 @@ export function computeWarmingSnapshot(
     state.lastUpstream?.model,
     state.lastUpstream?.protocol,
     state.resolvedConversationTTL,
+    state.lastUpstream?.url,
   );
   const ttlMs = profile?.ttlMs ?? 300_000;
   const warmupMarginMs = profile?.warmupMarginMs ?? 45_000;


### PR DESCRIPTION
## Summary

Fixes cache-warmer 401 errors on non-Anthropic sessions that use the anthropic-compatible protocol (e.g. MiniMax).

**Root cause:** `resolveProfile()` was called without `upstreamBase`, so `buildAnthropicProfile()` fell back to `https://api.anthropic.com` for models not in the static route table. When the session used MiniMax (`api.minimax.io/anthropic`), the warmup request went to `api.anthropic.com` with the MiniMax API key → 401.

**Fix:** Pass `state.lastUpstream?.url` as the `upstreamBase` parameter so the warmup goes to the same upstream URL as the session's real API calls.

## Evidence from logs
```
cache-warmer: sending warmup for session=0ODuRFTC6IwbH0jG model=MiniMax-M3 ttl=300s
cache-warmer: upstream error 401 for session=0ODuRFTC6IwbH0jG: {"message":"invalid x-api-key"}
```

## Verification
- Typecheck: all 4 packages clean
- Tests: `cache-warmer.test.ts` 126/126 pass
- Lint: clean (0 errors)