### PR TITLE
fix(gateway): per-provider auth staleness to prevent cross-provider credential poisoning

### DIFF
--- a/packages/gateway/src/auth.ts
+++ b/packages/gateway/src/auth.ts
@@ -112,7 +112,11 @@ export function setSessionAuth(
   // Also keep the _default slot in sync with the latest credential so
   // callers that don't pass a providerID still get a reasonable result.
   if (key !== "_default") byProvider.set("_default", cred);
-  staleSessionAuth.delete(sessionID); // Fresh credential clears staleness
+  // Fresh credential clears staleness for this specific provider.
+  // Also clear _default when a named provider refreshes, since _default
+  // tracks the latest-used provider.
+  clearProviderStale(sessionID, key);
+  if (key !== "_default") clearProviderStale(sessionID, "_default");
 }
 
 /**
@@ -135,36 +139,75 @@ export function getSessionAuth(
 /** Delete a session's credentials (for eviction). */
 export function deleteSessionAuth(sessionID: string): void {
   sessionAuth.delete(sessionID);
-  staleSessionAuth.delete(sessionID);
+  clearAuthStale(sessionID);
 }
 
 // ---------------------------------------------------------------------------
-// Staleness tracking (per-session)
+// Staleness tracking (per-session, per-provider)
 // ---------------------------------------------------------------------------
 
 /**
- * Session IDs whose stored credential returned a 401/403.
+ * Per-session, per-provider staleness registry. Outer key is session ID,
+ * inner set contains provider IDs whose credentials returned 401/403.
  *
  * Tracked separately from AuthCredential to keep the type clean (follows
  * batch-queue's `disabledBatchSessions` pattern). Not persisted — on
  * process restart, the first client request provides fresh credentials.
- * Cleared automatically when `setSessionAuth()` stores a new credential.
+ * Cleared per-provider when `setSessionAuth()` stores a new credential.
+ *
+ * Per-provider granularity prevents cross-contamination: a 401 from
+ * MiniMax should not poison the Anthropic credential for the same session.
  */
-const staleSessionAuth = new Set<string>();
+const staleSessionAuth = new Map<string, Set<string>>();
 
-/** Mark a session's credential as stale (401/403 received). */
-export function markAuthStale(sessionID: string): void {
-  staleSessionAuth.add(sessionID);
+/**
+ * Mark a session's credential as stale (401/403 received).
+ *
+ * @param providerID - When provided, only the specific provider's credential
+ *   is marked stale. When omitted, marks the `_default` slot (backward compat).
+ */
+export function markAuthStale(sessionID: string, providerID?: string): void {
+  let providers = staleSessionAuth.get(sessionID);
+  if (!providers) {
+    providers = new Set();
+    staleSessionAuth.set(sessionID, providers);
+  }
+  providers.add(providerID || "_default");
+  // Also mark _default stale when a named provider is marked, since
+  // _default tracks the latest-used provider (mirrors setSessionAuth's
+  // dual-clear on refresh). Without this, resolveAuth(sid) without
+  // providerID would return the stale credential via _default.
+  if (providerID && providerID !== "_default") providers.add("_default");
 }
 
-/** Check if a session's credential is marked stale. */
-export function isAuthStale(sessionID: string): boolean {
-  return staleSessionAuth.has(sessionID);
+/**
+ * Check if a session's credential is marked stale.
+ *
+ * @param providerID - When provided, checks only that provider. When omitted,
+ *   returns true if ANY provider for the session is stale (used by idle.ts
+ *   for session-level skip decisions).
+ */
+export function isAuthStale(sessionID: string, providerID?: string): boolean {
+  const providers = staleSessionAuth.get(sessionID);
+  if (!providers) return false;
+  if (providerID) return providers.has(providerID);
+  return providers.size > 0;
 }
 
-/** Clear staleness for a session (fresh credential arrived). */
+/** Clear staleness for a session (eviction cleanup). */
 export function clearAuthStale(sessionID: string): void {
   staleSessionAuth.delete(sessionID);
+}
+
+/**
+ * Clear staleness for a specific (session, provider) pair.
+ * Called when `setSessionAuth()` stores a fresh credential.
+ */
+function clearProviderStale(sessionID: string, providerID: string): void {
+  const providers = staleSessionAuth.get(sessionID);
+  if (!providers) return;
+  providers.delete(providerID);
+  if (providers.size === 0) staleSessionAuth.delete(sessionID);
 }
 
 // ---------------------------------------------------------------------------
@@ -192,8 +235,8 @@ export function getLastSeenAuth(): AuthCredential | null {
  *    When `providerID` is also given, returns the credential stored for
  *    that specific provider — preventing cross-contamination when a session
  *    uses multiple providers (e.g. Anthropic + MiniMax).
- *    Skips stale credentials (401/403 received) so the global fallback
- *    can provide a potentially-refreshed token.
+ *    Skips credentials whose specific provider is marked stale (401/403)
+ *    so the global fallback can provide a potentially-refreshed token.
  * 2. Fall back to the global `lastSeenAuth` (for cold-start or callers
  *    that don't pass a session ID).
  * 3. If the global fallback holds the same value as the stale session
@@ -208,7 +251,11 @@ export function resolveAuth(
 ): AuthCredential | null {
   if (sessionID) {
     const cred = getSessionAuth(sessionID, providerID);
-    if (cred && !staleSessionAuth.has(sessionID)) return cred;
+    // Check staleness for the specific provider being requested.
+    // A stale MiniMax credential should NOT cause the Anthropic credential
+    // to be skipped (or vice versa).
+    const staleKey = providerID || "_default";
+    if (cred && !isAuthStale(sessionID, staleKey)) return cred;
 
     // Global fallback — but guard against returning the same stale token.
     // In single-session OAuth setups, session and global hold the exact
@@ -231,3 +278,7 @@ export function _resetAuthForTest(): void {
   staleSessionAuth.clear();
   lastSeenAuth = null;
 }
+
+// Re-export for documentation — staleSessionAuth is Map<sessionID, Set<providerID>>.
+// Invariant: markAuthStale(sid, pid) only poisons resolveAuth(sid, pid),
+// NOT resolveAuth(sid, otherPid). Cross-provider credential poisoning is a bug.

--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -1394,7 +1394,7 @@ export async function executeWarmup(
       // a fresh credential arrives. Prevents unbounded 401 spam every 30s.
       if (response.status === 401 || response.status === 403) {
         authDisabledSessions.add(state.sessionID);
-        markAuthStale(state.sessionID);
+        markAuthStale(state.sessionID, state.lastUpstream?.providerID);
         recordWorkerFailure(state.sessionID, "cache-warmer", "auth-rejected");
         log.warn(
           `cache-warmer: auth error ${response.status} — disabling warmup for ` +

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -623,14 +623,16 @@ export function createGatewayLLMClient(
               if (AUTH_ERROR_CODES.has(response.status)) {
                 const text = await response.text().catch(() => "(no body)");
 
-                // Mark session credential stale so resolveAuth() falls through to global
+                // Mark this provider's credential stale so resolveAuth()
+                // falls through to global — but only for THIS provider,
+                // not other providers on the same session.
                 if (opts?.sessionID) {
                   recordWorkerFailure(
                     opts.sessionID,
                     opts?.workerID ?? "unknown",
                     "auth-rejected",
                   );
-                  markAuthStale(opts.sessionID);
+                  markAuthStale(opts.sessionID, model.providerID);
                 }
 
                 // Re-resolve: credential may have been refreshed by a concurrent client request

--- a/packages/gateway/test/auth.test.ts
+++ b/packages/gateway/test/auth.test.ts
@@ -29,6 +29,10 @@ const bearerCred2: AuthCredential = {
   value: "tok-session-xyz",
 };
 const apiKeyCred: AuthCredential = { scheme: "api-key", value: "sk-test-key" };
+const minimaxCred: AuthCredential = {
+  scheme: "api-key",
+  value: "sk-cp-minimax-key",
+};
 
 // ---------------------------------------------------------------------------
 // Staleness tracking
@@ -39,7 +43,7 @@ describe("markAuthStale / isAuthStale", () => {
     expect(isAuthStale("sess-1")).toBe(false);
   });
 
-  test("marks a session as stale", () => {
+  test("marks a session as stale (no providerID → _default)", () => {
     markAuthStale("sess-1");
     expect(isAuthStale("sess-1")).toBe(true);
   });
@@ -55,6 +59,24 @@ describe("markAuthStale / isAuthStale", () => {
     markAuthStale("sess-1");
     expect(isAuthStale("sess-1")).toBe(true);
   });
+
+  test("staleness is per-provider within a session", () => {
+    markAuthStale("sess-1", "minimax");
+    // Session-level: any provider stale → true
+    expect(isAuthStale("sess-1")).toBe(true);
+    // Provider-level: only minimax is stale
+    expect(isAuthStale("sess-1", "minimax")).toBe(true);
+    expect(isAuthStale("sess-1", "anthropic")).toBe(false);
+  });
+
+  test("multiple providers can be stale independently", () => {
+    markAuthStale("sess-1", "minimax");
+    markAuthStale("sess-1", "anthropic");
+    expect(isAuthStale("sess-1", "minimax")).toBe(true);
+    expect(isAuthStale("sess-1", "anthropic")).toBe(true);
+    expect(isAuthStale("sess-1", "openai")).toBe(false);
+    expect(isAuthStale("sess-1")).toBe(true);
+  });
 });
 
 describe("clearAuthStale", () => {
@@ -63,6 +85,15 @@ describe("clearAuthStale", () => {
     expect(isAuthStale("sess-1")).toBe(true);
     clearAuthStale("sess-1");
     expect(isAuthStale("sess-1")).toBe(false);
+  });
+
+  test("clears all providers for a session", () => {
+    markAuthStale("sess-1", "minimax");
+    markAuthStale("sess-1", "anthropic");
+    clearAuthStale("sess-1");
+    expect(isAuthStale("sess-1")).toBe(false);
+    expect(isAuthStale("sess-1", "minimax")).toBe(false);
+    expect(isAuthStale("sess-1", "anthropic")).toBe(false);
   });
 
   test("clearing a non-stale session is a no-op", () => {
@@ -80,6 +111,21 @@ describe("setSessionAuth clears staleness", () => {
     // Setting a new credential should clear staleness
     setSessionAuth("sess-1", bearerCred2);
     expect(isAuthStale("sess-1")).toBe(false);
+  });
+
+  test("setting credential for one provider clears only that provider", () => {
+    setSessionAuth("sess-1", bearerCred, "anthropic");
+    setSessionAuth("sess-1", minimaxCred, "minimax");
+    markAuthStale("sess-1", "anthropic");
+    markAuthStale("sess-1", "minimax");
+
+    // Refresh only anthropic
+    setSessionAuth("sess-1", bearerCred2, "anthropic");
+    expect(isAuthStale("sess-1", "anthropic")).toBe(false);
+    // minimax should still be stale
+    expect(isAuthStale("sess-1", "minimax")).toBe(true);
+    // Session-level: still stale (minimax)
+    expect(isAuthStale("sess-1")).toBe(true);
   });
 });
 
@@ -172,5 +218,75 @@ describe("resolveAuth with staleness", () => {
 
     // Now returns the fresh session credential
     expect(resolveAuth("sess-1")).toEqual(bearerCred2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-provider staleness isolation (cross-provider credential poisoning fix)
+// ---------------------------------------------------------------------------
+
+describe("resolveAuth per-provider staleness", () => {
+  test("stale MiniMax does not poison Anthropic credential", () => {
+    // Session uses both Anthropic and MiniMax
+    setSessionAuth("sess-1", apiKeyCred, "anthropic");
+    setSessionAuth("sess-1", minimaxCred, "minimax");
+    setLastSeenAuth(apiKeyCred);
+
+    // MiniMax goes stale (e.g. cache-warmer 401)
+    markAuthStale("sess-1", "minimax");
+
+    // Anthropic credential should still resolve normally
+    expect(resolveAuth("sess-1", "anthropic")).toEqual(apiKeyCred);
+    // MiniMax should fall through to global
+    expect(resolveAuth("sess-1", "minimax")).toEqual(apiKeyCred);
+  });
+
+  test("stale Anthropic does not poison MiniMax credential", () => {
+    setSessionAuth("sess-1", apiKeyCred, "anthropic");
+    setSessionAuth("sess-1", minimaxCred, "minimax");
+    setLastSeenAuth(apiKeyCred);
+
+    markAuthStale("sess-1", "anthropic");
+
+    // MiniMax credential should still resolve
+    expect(resolveAuth("sess-1", "minimax")).toEqual(minimaxCred);
+    // Anthropic falls through to global (same value → null)
+    expect(resolveAuth("sess-1", "anthropic")).toBe(null);
+  });
+
+  test("marking named provider stale also marks _default stale", () => {
+    setSessionAuth("sess-1", minimaxCred, "minimax");
+    // _default was set to minimaxCred by setSessionAuth's dual-write
+    setLastSeenAuth(apiKeyCred);
+
+    // Mark only minimax stale — should automatically mark _default too,
+    // since _default tracks the latest-used provider.
+    markAuthStale("sess-1", "minimax");
+
+    // _default should be stale (auto-marked)
+    expect(isAuthStale("sess-1", "_default")).toBe(true);
+    // No providerID → checks _default → stale → falls through to global
+    expect(resolveAuth("sess-1")).toEqual(apiKeyCred);
+  });
+
+  test("refreshing one provider clears only that provider staleness", () => {
+    setSessionAuth("sess-1", apiKeyCred, "anthropic");
+    setSessionAuth("sess-1", minimaxCred, "minimax");
+    setLastSeenAuth(apiKeyCred);
+
+    markAuthStale("sess-1", "anthropic");
+    markAuthStale("sess-1", "minimax");
+
+    // Refresh only anthropic — clears anthropic + _default staleness
+    setSessionAuth("sess-1", bearerCred2, "anthropic");
+
+    // Anthropic is fresh — resolves to new credential
+    expect(resolveAuth("sess-1", "anthropic")).toEqual(bearerCred2);
+    // MiniMax still stale — falls through to global
+    expect(resolveAuth("sess-1", "minimax")).toEqual(apiKeyCred);
+    // _default was cleared by setSessionAuth refresh
+    expect(isAuthStale("sess-1", "_default")).toBe(false);
+    // But session-level still stale (minimax)
+    expect(isAuthStale("sess-1")).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Fixes cascading worker failures (713 observed) caused by a single provider's 401 poisoning the entire session's auth state.

## Problem

`markAuthStale()` was per-session (`Set<string>`). When a cache-warmer or worker received a 401 from one provider (e.g. MiniMax), it marked the **entire session** as stale. Subsequent workers for any provider on that session would skip their valid per-provider credential and fall back to the global credential (typically Anthropic), sending the wrong API key to the session's actual upstream.

### Production failure chain

```
1. Cache-warmer hits wrong URL for MiniMax session → 401
2. markAuthStale(sessionID) marks ENTIRE session stale
3. Worker: resolveAuth(sessionID, 'minimax') → skips valid MiniMax cred (stale!)
4. Falls through to getLastSeenAuth() → returns Anthropic key (sk-ant-...)
5. Worker sends Anthropic key to api.minimax.io → 'login fail' 401
6. 713 cascading worker failures across the session
```

## Fix

Changed `staleSessionAuth` from `Set<sessionID>` to `Map<sessionID, Set<providerID>>`:

- **`markAuthStale(sessionID, providerID?)`** — marks only the specific provider's credential as stale
- **`isAuthStale(sessionID, providerID?)`** — when providerID given, checks only that provider; when omitted, returns true if ANY provider is stale (preserves session-level guards in idle.ts/pipeline.ts)
- **`resolveAuth()`** — checks staleness for the specific providerID being requested, not session-wide
- **`setSessionAuth()`** — clears staleness for the refreshed provider only, not the whole session
- **All callers** (llm-adapter.ts, cache-warmer.ts) now pass `providerID` to `markAuthStale()`

## Verification

- **Auth tests**: 24/24 pass (16 existing + 8 new per-provider tests)
- **Gateway tests**: 1175/1177 pass (2 pre-existing failures)
- **Typecheck**: all 4 packages clean
- **Lint**: clean