### PR TITLE
fix(gateway): only mark _default stale when it holds the same credential as the stale provider

### DIFF
--- a/packages/gateway/src/auth.ts
+++ b/packages/gateway/src/auth.ts
@@ -173,11 +173,23 @@ export function markAuthStale(sessionID: string, providerID?: string): void {
     staleSessionAuth.set(sessionID, providers);
   }
   providers.add(providerID || "_default");
-  // Also mark _default stale when a named provider is marked, since
-  // _default tracks the latest-used provider (mirrors setSessionAuth's
-  // dual-clear on refresh). Without this, resolveAuth(sid) without
-  // providerID would return the stale credential via _default.
-  if (providerID && providerID !== "_default") providers.add("_default");
+  // Also mark _default stale when it currently holds the same credential
+  // as the provider being marked. This prevents resolveAuth(sid) without
+  // providerID from returning a stale credential via _default.
+  // Only poisons _default when it actually points to the stale provider —
+  // if another provider was set more recently, _default is left alone.
+  if (providerID && providerID !== "_default") {
+    const byProvider = sessionAuth.get(sessionID);
+    const providerCred = byProvider?.get(providerID);
+    const defaultCred = byProvider?.get("_default");
+    if (
+      providerCred &&
+      defaultCred &&
+      providerCred.value === defaultCred.value
+    ) {
+      providers.add("_default");
+    }
+  }
 }
 
 /**

--- a/packages/gateway/test/auth.test.ts
+++ b/packages/gateway/test/auth.test.ts
@@ -254,19 +254,40 @@ describe("resolveAuth per-provider staleness", () => {
     expect(resolveAuth("sess-1", "anthropic")).toBe(null);
   });
 
-  test("marking named provider stale also marks _default stale", () => {
+  test("marking named provider stale marks _default when _default holds same credential", () => {
     setSessionAuth("sess-1", minimaxCred, "minimax");
     // _default was set to minimaxCred by setSessionAuth's dual-write
     setLastSeenAuth(apiKeyCred);
 
     // Mark only minimax stale — should automatically mark _default too,
-    // since _default tracks the latest-used provider.
+    // since _default currently holds the same credential as minimax.
     markAuthStale("sess-1", "minimax");
 
-    // _default should be stale (auto-marked)
+    // _default should be stale (auto-marked — same credential)
     expect(isAuthStale("sess-1", "_default")).toBe(true);
     // No providerID → checks _default → stale → falls through to global
     expect(resolveAuth("sess-1")).toEqual(apiKeyCred);
+  });
+
+  test("marking named provider stale does NOT mark _default when another provider was set last", () => {
+    // MiniMax set first, then Anthropic set last → _default = anthropic
+    setSessionAuth("sess-1", minimaxCred, "minimax");
+    setSessionAuth("sess-1", apiKeyCred, "anthropic");
+    setLastSeenAuth(bearerCred);
+
+    // Mark minimax stale — _default points to anthropic (different cred),
+    // so _default should NOT be marked stale.
+    markAuthStale("sess-1", "minimax");
+
+    expect(isAuthStale("sess-1", "minimax")).toBe(true);
+    // _default should NOT be stale — it holds the anthropic credential
+    expect(isAuthStale("sess-1", "_default")).toBe(false);
+    // resolveAuth without providerID returns _default (anthropic) — not stale
+    expect(resolveAuth("sess-1")).toEqual(apiKeyCred);
+    // Anthropic also not stale
+    expect(resolveAuth("sess-1", "anthropic")).toEqual(apiKeyCred);
+    // MiniMax stale → falls to global
+    expect(resolveAuth("sess-1", "minimax")).toEqual(bearerCred);
   });
 
   test("refreshing one provider clears only that provider staleness", () => {


### PR DESCRIPTION
## Summary

Follow-up to #632. Fixes over-aggressive `_default` staleness that could unnecessarily skip background work.

## Problem

`markAuthStale(sid, "minimax")` unconditionally marked `_default` stale. But `_default` tracks the **last-used** provider — if Anthropic was set more recently, `_default` points to a valid Anthropic credential. Marking it stale causes session-level guards in `idle.ts:145` and `pipeline.ts:3052` to skip background work (distillation, curation) for the entire session.

### Scenario
```
1. setSessionAuth(sid, anthropicCred, "anthropic") → _default = anthropic
2. MiniMax 401 → markAuthStale(sid, "minimax") → also marks _default stale
3. idle.ts: isAuthStale(sid) → true, resolveAuth(sid) → stale _default → global
4. Background work skipped even though Anthropic credential is perfectly valid
```

## Fix

Compare credential values before poisoning `_default`. Only mark `_default` stale when it currently holds the **same credential** as the provider being marked:

```typescript
if (providerCred && defaultCred && providerCred.value === defaultCred.value) {
  providers.add("_default");
}
```

Self-healing is preserved: the next client request calls `setSessionAuth` which clears staleness.

## Verification
- Auth tests: 25/25 pass (added test for both same-credential and different-credential scenarios)
- Gateway tests: 1176/1178 pass (2 pre-existing failures)
- Typecheck: all 4 packages clean