### PR TITLE
fix(install): strip macOS quarantine flag and bump fossilize to 0.9.1

### DIFF
--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -64,6 +64,6 @@
     "@sentry/bun": "^10.52.0",
     "@types/bun": "^1.2.0",
     "@types/semver": "^7.7.1",
-    "fossilize": "^0.9.0"
+    "fossilize": "^0.9.1"
   }
 }

--- a/packages/website/public/install
+++ b/packages/website/public/install
@@ -186,6 +186,12 @@ fi
 
 chmod +x "$tmp_binary"
 
+# macOS: remove quarantine flag so the binary can execute without
+# Gatekeeper blocking it. Curl may set this attribute on downloads.
+if [[ "$os" == "darwin" ]]; then
+  xattr -d com.apple.quarantine "$tmp_binary" 2>/dev/null || true
+fi
+
 # Quick sanity check
 if ! "$tmp_binary" --version >/dev/null 2>&1; then
   die "Downloaded binary failed sanity check. Platform: ${os}-${arch}"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,8 +80,8 @@ importers:
         specifier: ^7.7.1
         version: 7.7.1
       fossilize:
-        specifier: ^0.9.0
-        version: 0.9.0
+        specifier: ^0.9.1
+        version: 0.9.1
 
   packages/opencode:
     dependencies:
@@ -2275,8 +2275,8 @@ packages:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
 
-  fossilize@0.9.0:
-    resolution: {integrity: sha512-BIZh9GO7tEx353Zlmmn6qCd8BgMhYgpBlZnfXd52aQCIQKY0UoNsxcV2mt535dv8TgOAQe9kBhsDxTgC2wor/A==}
+  fossilize@0.9.1:
+    resolution: {integrity: sha512-lnO/gVpAe9M6SHEVxSwK4C+DbJXse1gADUzXIOPygKwaX5K5g6scOG6ovE4iOeLel65827ZcvRqdfVbu+WVXlw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -6071,7 +6071,7 @@ snapshots:
     dependencies:
       fetch-blob: 3.2.0
 
-  fossilize@0.9.0:
+  fossilize@0.9.1:
     dependencies:
       '@stricli/auto-complete': 1.2.7
       '@stricli/core': 1.2.7


### PR DESCRIPTION
## Problem

On macOS, the Lore binary is immediately killed when users try to run it after downloading:

1. **Apple Silicon kernel**: refuses to execute unsigned Mach-O binaries at `execve()` time
2. **Gatekeeper**: blocks downloaded binaries with the `com.apple.quarantine` extended attribute

## Fix

Two changes:

### 1. Bump fossilize to 0.9.1

[`fossilize@0.9.1`](https://github.com/BYK/fossilize/releases/tag/0.9.1) ([PR #26](https://github.com/BYK/fossilize/pull/26)) now ad-hoc signs darwin binaries when `sign=false` (the default):
- On macOS build hosts: uses native `codesign --sign - --force --entitlements <plist>`
- On Linux (cross-compilation in CI): uses `rcodesign sign --code-signature-flags runtime`
- Entitlements include all required V8 JIT permissions (`allow-jit`, `allow-unsigned-executable-memory`, etc.)

This satisfies the Apple Silicon kernel's code signature requirement. Verified locally:
```
> rcodesign sign --code-signature-flags runtime --entitlements-xml-path .../entitlements.plist .../lore-darwin-arm64
Ad-hoc signed .../lore-darwin-arm64

# Signature info:
flags: CodeSignatureFlags(ADHOC | RUNTIME)
identifier: lore-darwin-arm64
runtime_version: 15.0.0
# All 6 entitlement slots present
```

### 2. Strip quarantine in install script

Added `xattr -d com.apple.quarantine` after `chmod +x` and before the sanity check. This removes the Gatekeeper trigger so `curl | bash` installs work seamlessly on macOS.

## User experience after this PR

| Install method | Before | After |
|---|---|---|
| `curl \| bash` | Binary killed immediately | Works seamlessly |
| Direct download from GitHub Releases | Binary killed immediately | Works after `xattr -d com.apple.quarantine ./lore-darwin-arm64` |

## Future: Developer ID + Notarization

When an Apple Developer account is available, set `sign: true` in `build-binary-sea.ts` + add `APPLE_TEAM_ID`, `APPLE_CERT_PATH`, `APPLE_CERT_PASSWORD`, `APPLE_API_KEY_PATH` as GitHub Actions secrets. Fossilize already handles the full pipeline — no code changes needed.