### PR TITLE
fix(gateway): strengthen .lore.md commit reminder in recall tool

### DIFF
--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -232,6 +232,28 @@ import {
 import { upstreamFetch } from "./fetch";
 
 // ---------------------------------------------------------------------------
+// Recall tool commit reminder
+// ---------------------------------------------------------------------------
+
+/**
+ * Text appended to the recall tool's description to remind the agent that
+ * `.lore.md` is shared project knowledge and must be committed alongside the
+ * agent's work — never stashed, never skipped.
+ *
+ * Lives in the stable tools prefix (1h cache) on purpose: the rule is static
+ * and benefits from Anthropic prompt caching. Gated at the call site on
+ * `cfg.knowledge.enabled`.
+ *
+ * Exported for unit testing — see `packages/gateway/test/recall.test.ts`.
+ */
+export const LORE_COMMIT_REMINDER =
+  "Before any git commit, always run `git add .lore.md`. " +
+  "This includes changes you did NOT make — a background process updates " +
+  "this file automatically. NEVER `git stash` `.lore.md` changes. " +
+  "NEVER leave `.lore.md` modified or untracked after a commit. " +
+  "`.lore.md` is shared project knowledge and must always be version-controlled.";
+
+// ---------------------------------------------------------------------------
 // Module state
 // ---------------------------------------------------------------------------
 
@@ -4382,11 +4404,7 @@ async function handleConversationTurn(
       ? {
           ...RECALL_GATEWAY_TOOL,
           description:
-            RECALL_GATEWAY_TOOL.description +
-            "\n\nWhen making git commits, always check if .lore.md " +
-            "has unstaged changes and include it in the commit. " +
-            "This file contains shared project knowledge managed " +
-            "by lore and must be version-controlled.",
+            RECALL_GATEWAY_TOOL.description + "\n\n" + LORE_COMMIT_REMINDER,
         }
       : RECALL_GATEWAY_TOOL;
     modifiedReq.tools = [...modifiedReq.tools, recallTool];

--- a/packages/gateway/test/recall.test.ts
+++ b/packages/gateway/test/recall.test.ts
@@ -9,6 +9,7 @@
  *  - Response stripping
  */
 import { describe, test, expect } from "vitest";
+import { LORE_COMMIT_REMINDER } from "../src/pipeline";
 import {
   RECALL_GATEWAY_TOOL,
   RECALL_TOOL_NAME,
@@ -110,6 +111,28 @@ describe("RECALL_GATEWAY_TOOL", () => {
     expect(props).toHaveProperty("query");
     expect(props).toHaveProperty("scope");
     expect(schema.required).toEqual(["query"]);
+  });
+});
+
+describe("LORE_COMMIT_REMINDER", () => {
+  test("instructs `git add .lore.md` as a concrete pre-commit step", () => {
+    expect(LORE_COMMIT_REMINDER).toContain("git add .lore.md");
+  });
+
+  test("explicitly forbids `git stash` on .lore.md", () => {
+    expect(LORE_COMMIT_REMINDER).toContain("NEVER `git stash` `.lore.md`");
+  });
+
+  test("clarifies that background changes must also be committed", () => {
+    expect(LORE_COMMIT_REMINDER).toContain("changes you did NOT make");
+  });
+
+  test("does not contain the old soft wording (regression guard)", () => {
+    expect(LORE_COMMIT_REMINDER).not.toContain("always check if .lore.md");
+  });
+
+  test("does not start with whitespace (separator belongs at call site)", () => {
+    expect(LORE_COMMIT_REMINDER).toMatch(/^\S/);
   });
 });
 


### PR DESCRIPTION
## Problem

The recall tool description appends a reminder to commit `.lore.md` changes:

> When making git commits, always check if .lore.md has unstaged changes and include it in the commit.

An agent noticed this rule but **stashed** the changes instead of committing them:

> "Per the lore: 'When making git commits, always check if .lore.md has unstaged changes and include it in the commit.' But my work didn't modify .lore.md — the previous session's curator did. I shouldn't pollute my env-docs commit with unrelated .lore.md changes. Let me stash those."

The agent's reasoning: "include in the commit" → "but these aren't mine" → "stash to keep commit clean." The wording was too soft and the agent's "keep commits focused" heuristic overrode it.

## Fix

Replace the soft wording with a stronger, escape-proof instruction:

**Before:**
```
When making git commits, always check if .lore.md has unstaged changes
and include it in the commit. This file contains shared project knowledge
managed by lore and must be version-controlled.
```

**After:**
```
Before any git commit, always run `git add .lore.md`. This includes
changes you did NOT make — a background process updates this file
automatically. NEVER `git stash` `.lore.md` changes. NEVER leave
`.lore.md` modified or untracked after a commit. `.lore.md` is shared
project knowledge and must always be version-controlled.
```

Key improvements:
- **`git add .lore.md`** — idempotent, no output parsing, single concrete action
- **"changes you did NOT make"** — closes the authorship loophole
- **"NEVER `git stash`"** — explicitly forbids the observed failure mode
- **No escape hatch** — removed the original plan's "separate commit on top" alternative (review found agents could use it to justify stash→commit→pop→commit)
- **`\n\n` separator at call site** — constant doesn't start with whitespace

## Implementation

- Extracted text into an exported `LORE_COMMIT_REMINDER` constant (`pipeline.ts:248`) for direct unit testing
- 5 new tests in `recall.test.ts`: concrete action, stash prohibition, background-change clarification, old-wording regression guard, no-leading-whitespace invariant

## Verification

- `pnpm exec vitest run` — 2316 passed, 6 skipped (85 test files)
- `pnpm -r typecheck` — only pre-existing `fossilize` error in `script/build-binary-sea.ts` (unrelated)
- `pnpm lint` — no new warnings on changed files
