### PR TITLE
ci: install rcodesign for macOS binary ad-hoc signing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,6 +348,24 @@ jobs:
       # exists even when the test-job's build:binary call was skipped on
       # PR runs. No additional vendor step needed here.
 
+      # rcodesign is needed to ad-hoc sign macOS binaries when cross-
+      # compiling on Linux. Without it, darwin binaries are unsigned and
+      # cannot execute on Apple Silicon.
+      # NOTE: Keep in sync with the identical step in build-nightly-binaries.
+      - name: Install rcodesign (macOS cross-signing)
+        if: startsWith(github.ref, 'refs/heads/release/')
+        run: |
+          RCODESIGN_VERSION="0.29.0"
+          RCODESIGN_SHA256="dbe85cedd8ee4217b64e9a0e4c2aef92ab8bcaaa41f20bde99781ff02e600002"
+          TARBALL="apple-codesign-${RCODESIGN_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          curl -fsSL -o "/tmp/${TARBALL}" \
+            "https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign%2F${RCODESIGN_VERSION}/${TARBALL}"
+          echo "${RCODESIGN_SHA256}  /tmp/${TARBALL}" | sha256sum -c -
+          tar -xzf "/tmp/${TARBALL}" -C /usr/local/bin --strip-components=1 \
+            "apple-codesign-${RCODESIGN_VERSION}-x86_64-unknown-linux-musl/rcodesign"
+          rm "/tmp/${TARBALL}"
+          rcodesign --version
+
       - name: Build release binaries (all platforms)
         if: startsWith(github.ref, 'refs/heads/release/')
         run: |
@@ -518,6 +536,23 @@ jobs:
         with:
           path: .node-cache
           key: fossilize-${{ hashFiles('packages/gateway/script/build-binary-sea.ts') }}
+
+      # rcodesign is needed to ad-hoc sign macOS binaries when cross-
+      # compiling on Linux. Without it, darwin binaries are unsigned and
+      # cannot execute on Apple Silicon.
+      # NOTE: Keep in sync with the identical step in the test job (release builds).
+      - name: Install rcodesign (macOS cross-signing)
+        run: |
+          RCODESIGN_VERSION="0.29.0"
+          RCODESIGN_SHA256="dbe85cedd8ee4217b64e9a0e4c2aef92ab8bcaaa41f20bde99781ff02e600002"
+          TARBALL="apple-codesign-${RCODESIGN_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          curl -fsSL -o "/tmp/${TARBALL}" \
+            "https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign%2F${RCODESIGN_VERSION}/${TARBALL}"
+          echo "${RCODESIGN_SHA256}  /tmp/${TARBALL}" | sha256sum -c -
+          tar -xzf "/tmp/${TARBALL}" -C /usr/local/bin --strip-components=1 \
+            "apple-codesign-${RCODESIGN_VERSION}-x86_64-unknown-linux-musl/rcodesign"
+          rm "/tmp/${TARBALL}"
+          rcodesign --version
 
       - name: Build all platform binaries
         run: |


### PR DESCRIPTION
## Problem

The nightly and release build jobs cross-compile darwin binaries on `ubuntu-latest`. `fossilize@0.9.1` attempts to ad-hoc sign these via `rcodesign`, but since `rcodesign` isn't installed, it falls back gracefully — producing **unsigned binaries** that can't execute on Apple Silicon.

This was observed in the first nightly after #634 merged:
```
Failed to `run rcodesign sign --code-signature-flags runtime ...`
Warning: Could not ad-hoc sign .../lore-darwin-arm64. Install rcodesign or run on macOS...
```

Meanwhile, the `binary-smoke-native` job on `macos-14` used native `codesign` successfully — but that binary is only used for smoke testing, not published.

## Fix

Install [`rcodesign`](https://github.com/indygreg/apple-platform-rs) (v0.29.0, cross-platform Rust implementation of Apple's codesign) in both CI jobs that cross-compile darwin binaries:

1. **Release build** (in `test` job, conditioned on `release/` branches)
2. **Nightly build** (`build-nightly-binaries` job)

Downloads use the official `indygreg/apple-platform-rs` release with **SHA-256 checksum verification** (matching the existing ORAS/zig-bsdiff pattern in this workflow).

## Follows up on

- https://github.com/BYK/fossilize/pull/26 — fossilize ad-hoc signs darwin binaries when `sign=false`
- #634 — bumped fossilize to 0.9.1 + quarantine strip in install script