### PR TITLE
feat(core,gateway): add loreFile.enabled config toggle

### DIFF
--- a/packages/core/src/agents-file.ts
+++ b/packages/core/src/agents-file.ts
@@ -14,6 +14,7 @@ import {
   writeFileSync,
   mkdirSync,
   statSync,
+  unlinkSync,
 } from "node:fs";
 import { dirname, join } from "node:path";
 import { db, ensureProject } from "./db";
@@ -29,6 +30,7 @@ import {
   unescapeMarkdown,
 } from "./markdown";
 import { isHostedMode } from "./hosted";
+import { config as loreConfig } from "./config";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -407,6 +409,70 @@ export function exportToFile(input: {
   writeFileSync(input.filePath, result, "utf8");
 }
 
+/**
+ * Write the full knowledge section inline into the agents file (AGENTS.md /
+ * CLAUDE.md), preserving all non-lore content. Use this when `.lore.md` is
+ * disabled but the user still wants AGENTS.md to carry project knowledge.
+ */
+export function exportInlineToAgentsFile(input: {
+  projectPath: string;
+  filePath: string;
+}): void {
+  if (isHostedMode()) return;
+  if (!loreConfig().agentsFile.enabled) return;
+
+  const sectionBody = buildSection(input.projectPath);
+  const newSection = `${LORE_SECTION_START}\n${sectionBody}${LORE_SECTION_END}\n`;
+
+  let fileContent = "";
+  if (existsSync(input.filePath)) {
+    fileContent = readFileSync(input.filePath, "utf8");
+  }
+
+  const { before, after } = splitFile(fileContent);
+
+  // Reuse the same layout logic as exportToFile for consistency.
+  const prefix = before.trimEnd();
+  const prefixWithSep = prefix.length > 0 ? `${prefix}\n\n` : "";
+  const suffix = after.trimStart();
+  const suffixWithSep = suffix.length > 0 ? `\n${suffix}` : "";
+
+  const result = prefixWithSep + newSection + suffixWithSep;
+
+  // Skip write if content hash matches cached hash (DB state unchanged).
+  const hash = hashSection(newSection);
+  const cached = getCache(input.filePath);
+  if (cached && cached.hash === hash) return;
+
+  try {
+    mkdirSync(dirname(input.filePath), { recursive: true });
+    writeFileSync(input.filePath, result, "utf8");
+    const { mtimeMs } = statSync(input.filePath);
+    setCache(input.filePath, { mtimeMs, hash });
+  } catch (e: unknown) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw e;
+  }
+}
+
+/**
+ * Delete `.lore.md` from the project root if it exists. Used by clear commands
+ * to prevent stale content from being re-imported when the user has disabled
+ * `.lore.md` via `loreFile.enabled = false`.
+ */
+export function deleteLoreFile(projectPath: string): boolean {
+  if (isHostedMode()) return false;
+  const fp = join(projectPath, LORE_FILE);
+  if (!existsSync(fp)) return false;
+  try {
+    unlinkSync(fp);
+    clearLoreFileCache(projectPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // shouldImport
 // ---------------------------------------------------------------------------
@@ -570,6 +636,7 @@ export function loreFileExists(projectPath: string): boolean {
  */
 export function exportLoreFile(projectPath: string): void {
   if (isHostedMode()) return;
+  if (!loreConfig().loreFile.enabled) return;
 
   const sectionBody = buildSection(projectPath);
   const content = `${LORE_FILE_HEADER}\n${sectionBody}`;

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -285,6 +285,21 @@ export const LoreConfig = z.object({
       path: z.string().default("AGENTS.md"),
     })
     .default({ enabled: true, path: "AGENTS.md" }),
+  loreFile: z
+    .object({
+      /** Set to false to disable `.lore.md` export/import. When disabled:
+       *  - `.lore.md` is not written by the idle knowledge exporter.
+       *  - Startup import skips the `.lore.md` branch and ignores any stale
+       *    `.lore.md` on disk.
+       *  - The recall tool description omits the "include .lore.md in commits"
+       *    reminder.
+       *  - The file watcher no longer watches `.lore.md` (root or sub-projects).
+       *  Knowledge stays in the database and is still injected into the system
+       *  prompt via LTM. Pair with `agentsFile.enabled=true` to keep sharing
+       *  knowledge via an inline section in AGENTS.md. Default: true. */
+      enabled: z.boolean().default(true),
+    })
+    .default({ enabled: true }),
   /** User identity for the self-entity. When provided, creates/updates a "self" entity
    *  with this information. If omitted, falls back to git config user.name / user.email. */
   user: z

--- a/packages/core/src/data.ts
+++ b/packages/core/src/data.ts
@@ -23,6 +23,7 @@ import {
 import { getGitRemote } from "./git";
 import * as ltm from "./ltm";
 import * as agentsFile from "./agents-file";
+import { config as loreConfig } from "./config";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -526,10 +527,14 @@ export function clearProject(projectPath: string): ClearResult {
     throw e;
   }
 
-  // Regenerate .lore.md (will be empty/minimal after clearing knowledge)
+  // Regenerate or delete .lore.md depending on toggle
   if (existsSync(projectPath)) {
     try {
-      agentsFile.exportLoreFile(projectPath);
+      if (loreConfig().loreFile.enabled) {
+        agentsFile.exportLoreFile(projectPath);
+      } else {
+        agentsFile.deleteLoreFile(projectPath);
+      }
     } catch {
       // Non-fatal: project dir may not be writable
     }
@@ -693,10 +698,14 @@ export function clearKnowledge(projectPath: string): number {
   invalidateProjectsCache();
   invalidateGlobalStatsCache();
 
-  // Regenerate .lore.md
+  // Regenerate or delete .lore.md depending on toggle
   if (existsSync(projectPath)) {
     try {
-      agentsFile.exportLoreFile(projectPath);
+      if (loreConfig().loreFile.enabled) {
+        agentsFile.exportLoreFile(projectPath);
+      } else {
+        agentsFile.deleteLoreFile(projectPath);
+      }
     } catch {
       // Non-fatal
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -158,6 +158,8 @@ export {
   importFromFile,
   exportToFile,
   exportLoreFile,
+  exportInlineToAgentsFile,
+  deleteLoreFile,
   importLoreFile,
   shouldImportLoreFile,
   loreFileExists,

--- a/packages/core/test/agents-file.test.ts
+++ b/packages/core/test/agents-file.test.ts
@@ -1,4 +1,11 @@
-import { describe, test, expect, beforeEach, afterAll } from "vitest";
+import {
+  describe,
+  test,
+  expect,
+  beforeEach,
+  afterEach,
+  afterAll,
+} from "vitest";
 import { fileURLToPath } from "node:url";
 import {
   mkdirSync,
@@ -17,6 +24,8 @@ import {
   LORE_FILE,
   exportToFile,
   exportLoreFile,
+  exportInlineToAgentsFile,
+  deleteLoreFile,
   importFromFile,
   importLoreFile,
   shouldImport,
@@ -25,6 +34,7 @@ import {
   clearLoreFileCache,
   parseEntriesFromSection,
 } from "../src/agents-file";
+import { load } from "../src/config";
 
 // ---------------------------------------------------------------------------
 // Test fixtures
@@ -1654,3 +1664,104 @@ describe("lore file cache optimization", () => {
 function escapeRegex(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
+
+// ---------------------------------------------------------------------------
+// loreFile.enabled toggle
+// ---------------------------------------------------------------------------
+
+describe("loreFile.enabled toggle", () => {
+  /** Helper: write .lore.json to TMP_DIR and load it into the global config. */
+  async function setConfig(overrides: Record<string, unknown>) {
+    writeFileSync(
+      join(TMP_DIR, ".lore.json"),
+      JSON.stringify(overrides),
+      "utf8",
+    );
+    await load(TMP_DIR);
+  }
+
+  /** Helper: seed a knowledge entry so exports have content. */
+  function seedEntry(id = TEST_UUIDS[0]) {
+    const pid = ensureProject(PROJECT);
+    db()
+      .query(
+        `INSERT OR REPLACE INTO knowledge (id, project_id, category, title, content, confidence, created_at, updated_at)
+         VALUES (?, ?, 'decision', 'Test entry', 'Test content', 1.0, datetime('now'), datetime('now'))`,
+      )
+      .run(id, pid);
+  }
+
+  // Reset config to defaults after each test in this block.
+  afterEach(async () => {
+    if (existsSync(join(TMP_DIR, ".lore.json"))) {
+      rmSync(join(TMP_DIR, ".lore.json"));
+    }
+    await load(TMP_DIR);
+  });
+
+  test("exportLoreFile writes .lore.md when loreFile.enabled=true (default)", async () => {
+    await setConfig({});
+    seedEntry();
+    exportLoreFile(PROJECT);
+    expect(existsSync(LORE_FILE_PATH)).toBe(true);
+    const content = readFileSync(LORE_FILE_PATH, "utf8");
+    expect(content).toContain("Test entry");
+  });
+
+  test("exportLoreFile is a no-op when loreFile.enabled=false", async () => {
+    await setConfig({ loreFile: { enabled: false } });
+    seedEntry();
+    exportLoreFile(PROJECT);
+    expect(existsSync(LORE_FILE_PATH)).toBe(false);
+  });
+
+  test("exportInlineToAgentsFile writes inline section when agentsFile.enabled=true", async () => {
+    await setConfig({
+      loreFile: { enabled: false },
+      agentsFile: { enabled: true },
+    });
+    seedEntry();
+    exportInlineToAgentsFile({ projectPath: PROJECT, filePath: AGENTS_FILE });
+    expect(existsSync(AGENTS_FILE)).toBe(true);
+    const content = readFileSync(AGENTS_FILE, "utf8");
+    expect(content).toContain(LORE_SECTION_START);
+    expect(content).toContain("Test entry");
+    // Should NOT contain the pointer text (that's exportToFile's job)
+    expect(content).not.toContain("see [`.lore.md`](.lore.md)");
+  });
+
+  test("exportInlineToAgentsFile preserves non-lore content in AGENTS.md", async () => {
+    await setConfig({
+      loreFile: { enabled: false },
+      agentsFile: { enabled: true },
+    });
+    seedEntry();
+    writeFile("# My Project\n\nSome hand-written content.\n");
+    exportInlineToAgentsFile({ projectPath: PROJECT, filePath: AGENTS_FILE });
+    const content = readFileSync(AGENTS_FILE, "utf8");
+    expect(content).toContain("# My Project");
+    expect(content).toContain("Some hand-written content.");
+    expect(content).toContain("Test entry");
+  });
+
+  test("exportInlineToAgentsFile is a no-op when agentsFile.enabled=false", async () => {
+    await setConfig({
+      loreFile: { enabled: false },
+      agentsFile: { enabled: false },
+    });
+    seedEntry();
+    exportInlineToAgentsFile({ projectPath: PROJECT, filePath: AGENTS_FILE });
+    expect(existsSync(AGENTS_FILE)).toBe(false);
+  });
+
+  test("deleteLoreFile removes the file and returns true when it exists", () => {
+    writeFileSync(LORE_FILE_PATH, "stale content", "utf8");
+    expect(deleteLoreFile(PROJECT)).toBe(true);
+    expect(existsSync(LORE_FILE_PATH)).toBe(false);
+  });
+
+  test("deleteLoreFile returns false when the file does not exist", () => {
+    expect(existsSync(LORE_FILE_PATH)).toBe(false);
+    expect(deleteLoreFile(PROJECT)).toBe(false);
+  });
+});

--- a/packages/core/test/config.test.ts
+++ b/packages/core/test/config.test.ts
@@ -63,6 +63,39 @@ describe("LoreConfig — knowledge schema", () => {
   });
 });
 
+describe("LoreConfig — loreFile schema", () => {
+  test("loreFile defaults: enabled=true", () => {
+    const cfg = LoreConfig.parse({});
+    expect(cfg.loreFile.enabled).toBe(true);
+  });
+
+  test("loreFile.enabled can be set to false", () => {
+    const cfg = LoreConfig.parse({ loreFile: { enabled: false } });
+    expect(cfg.loreFile.enabled).toBe(false);
+  });
+
+  test("loreFile section is optional — omitting it uses defaults", () => {
+    const cfg = LoreConfig.parse({ curator: { enabled: false } });
+    expect(cfg.loreFile.enabled).toBe(true);
+  });
+
+  test("loreFile and agentsFile are independent", () => {
+    const both = LoreConfig.parse({
+      loreFile: { enabled: false },
+      agentsFile: { enabled: true },
+    });
+    expect(both.loreFile.enabled).toBe(false);
+    expect(both.agentsFile.enabled).toBe(true);
+
+    const neither = LoreConfig.parse({
+      loreFile: { enabled: false },
+      agentsFile: { enabled: false },
+    });
+    expect(neither.loreFile.enabled).toBe(false);
+    expect(neither.agentsFile.enabled).toBe(false);
+  });
+});
+
 describe("LoreConfig — curator schema", () => {
   test("curator defaults: enabled=true, onIdle=true, afterTurns=3, maxEntries=25", () => {
     const cfg = LoreConfig.parse({});

--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -22,6 +22,7 @@ import {
   config as loreConfig,
   exportToFile,
   exportLoreFile,
+  exportInlineToAgentsFile,
   saveSessionCosts,
   saveSessionTracking,
   saveGradientState,
@@ -640,17 +641,24 @@ export function buildIdleWorkHandler(
       log.error("idle pruning error:", e);
     }
 
-    // 5. Knowledge export (.lore.md + optional agents file pointer)
+    // 5. Knowledge export (.lore.md + optional agents file)
     if (cfg.knowledge.enabled) {
       try {
         const entries = ltm.forProject(projectPath, false);
         if (entries.length > 0) {
-          if (cfg.agentsFile.enabled) {
+          if (cfg.loreFile.enabled && cfg.agentsFile.enabled) {
+            // Default: .lore.md + AGENTS.md pointer
             const filePath = join(projectPath, cfg.agentsFile.path);
             exportToFile({ projectPath, filePath });
-          } else {
+          } else if (cfg.loreFile.enabled) {
+            // .lore.md only
             exportLoreFile(projectPath);
+          } else if (cfg.agentsFile.enabled) {
+            // Inline knowledge in AGENTS.md (no .lore.md)
+            const filePath = join(projectPath, cfg.agentsFile.path);
+            exportInlineToAgentsFile({ projectPath, filePath });
           }
+          // else: both disabled — no markdown file
         }
       } catch (e) {
         log.error("idle knowledge export error:", e);

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -635,7 +635,7 @@ function tryImportKnowledge(projectPath: string): boolean {
   if (!cfg.knowledge.enabled) return false;
 
   try {
-    if (loreFileExists(projectPath)) {
+    if (cfg.loreFile.enabled && loreFileExists(projectPath)) {
       if (shouldImportLoreFile(projectPath)) {
         importLoreFile(projectPath);
         log.info("imported knowledge from .lore.md");
@@ -677,6 +677,7 @@ function startKnowledgeFileWatcher(projectPath: string): () => void {
   const { join } = require("node:path") as typeof import("node:path");
   const { watch, existsSync } = require("node:fs") as typeof import("node:fs");
 
+  const cfg = loreConfig();
   const watchers: import("node:fs").FSWatcher[] = [];
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
   const DEBOUNCE_MS = 500;
@@ -690,20 +691,21 @@ function startKnowledgeFileWatcher(projectPath: string): () => void {
     }, DEBOUNCE_MS);
   };
 
-  // Watch .lore.md
-  const loreFilePath = join(projectPath, LORE_FILE);
-  if (existsSync(loreFilePath)) {
-    try {
-      const w = watch(loreFilePath, onFileChange);
-      w.on("error", () => {}); // suppress — file may be deleted
-      watchers.push(w);
-    } catch {
-      // watch not supported (rare) — fall back to session-start checks only
+  // Watch .lore.md (gated on loreFile.enabled)
+  if (cfg.loreFile.enabled) {
+    const loreFilePath = join(projectPath, LORE_FILE);
+    if (existsSync(loreFilePath)) {
+      try {
+        const w = watch(loreFilePath, onFileChange);
+        w.on("error", () => {}); // suppress — file may be deleted
+        watchers.push(w);
+      } catch {
+        // watch not supported (rare) — fall back to session-start checks only
+      }
     }
   }
 
   // Watch agents file (AGENTS.md etc.) as fallback
-  const cfg = loreConfig();
   if (cfg.agentsFile.enabled) {
     const agentsFilePath = join(projectPath, cfg.agentsFile.path);
     if (existsSync(agentsFilePath)) {
@@ -731,7 +733,7 @@ function startKnowledgeFileWatcher(projectPath: string): () => void {
       },
     },
   ];
-  if (cfg.workspaces.length > 0) {
+  if (cfg.loreFile.enabled && cfg.workspaces.length > 0) {
     const subDirs = resolveWorkspaces(projectPath, cfg.workspaces);
     for (const subDir of subDirs) {
       const subLoreFile = join(subDir, LORE_FILE);
@@ -4445,13 +4447,14 @@ async function handleConversationTurn(
     // Build the recall tool with git reminder baked into its description.
     // This keeps the reminder in the stable tools prefix (1h cache) rather
     // than the volatile system prompt.
-    const recallTool = cfg.knowledge.enabled
-      ? {
-          ...RECALL_GATEWAY_TOOL,
-          description:
-            RECALL_GATEWAY_TOOL.description + "\n\n" + LORE_COMMIT_REMINDER,
-        }
-      : RECALL_GATEWAY_TOOL;
+    const recallTool =
+      cfg.knowledge.enabled && cfg.loreFile.enabled
+        ? {
+            ...RECALL_GATEWAY_TOOL,
+            description:
+              RECALL_GATEWAY_TOOL.description + "\n\n" + LORE_COMMIT_REMINDER,
+          }
+        : RECALL_GATEWAY_TOOL;
     modifiedReq.tools = [...modifiedReq.tools, recallTool];
   }
 


### PR DESCRIPTION
## Problem

When a project doesn't want `.lore.md` version-controlled in its repo, there's no way to opt out. The only existing toggle (`knowledge.enabled`) is a sledgehammer that disables the entire knowledge system (curator, DB writes, LTM injection). The user wants to disable just the file, not the knowledge.

Additionally, when `loreFile` is disabled and AGENTS.md is still enabled, the existing `exportToFile()` writes a pointer section that links to a non-existent `.lore.md` — a broken UX.

Companion to #635 (stronger commit reminder wording).

## Solution

Add a per-project `loreFile.enabled` config toggle in `.lore.json`:

```json
{ "loreFile": { "enabled": false } }
```

### Toggle interaction matrix

| `loreFile` | `agentsFile` | Behavior |
|---|---|---|
| `true` | `true` | Write `.lore.md` + AGENTS.md pointer (**default**) |
| `true` | `false` | Write `.lore.md` only |
| `false` | `true` | Write **inline** knowledge section in AGENTS.md (new) |
| `false` | `false` | DB-only, no markdown files |

### What's gated

When `loreFile.enabled = false`:

- `exportLoreFile()` early-returns (no `.lore.md` written)
- `tryImportKnowledge()` skips the `.lore.md` branch (stale files on disk are ignored)
- The file watcher skips `.lore.md` (root and sub-projects)
- The recall tool omits the commit reminder
- `clearProject`/`clearProjectKnowledge` delete stale `.lore.md` instead of regenerating it (prevents re-import on next start)

Knowledge stays in the DB and is still injected into the system prompt via LTM.

### New functions

- **`exportInlineToAgentsFile()`** — writes the full knowledge section inline into AGENTS.md (preserves non-lore content). Used for the `loreFile=false, agentsFile=true` mode, avoiding a broken pointer to a non-existent `.lore.md`.
- **`deleteLoreFile()`** — removes stale `.lore.md` and clears its cache. Used by clear commands to prevent re-import when the toggle is off.

## Files changed

| Package | File | Change |
|---|---|---|
| core | `config.ts` | New `loreFile: { enabled: boolean }` Zod schema |
| core | `agents-file.ts` | Gate on `exportLoreFile`, new `exportInlineToAgentsFile` + `deleteLoreFile` |
| core | `index.ts` | Re-export new functions |
| core | `data.ts` | Clear paths: regenerate vs delete based on toggle |
| gateway | `idle.ts` | Three-way export switch |
| gateway | `pipeline.ts` | Gate `tryImportKnowledge`, watcher, recall reminder |
| core/test | `config.test.ts` | 4 new schema tests |
| core/test | `agents-file.test.ts` | 7 new toggle tests |

## Verification

- `tsc --noEmit` — clean (only pre-existing `fossilize` error in `script/build-binary-sea.ts`)
- `vitest run packages/core/test/agents-file.test.ts` — 75/75 passed
- `vitest run packages/core/test/config.test.ts` — all passed
- `vitest run packages/gateway/test/recall.test.ts` — 58/58 passed
- `pnpm lint` — no new warnings on changed files
- Pre-existing failures in `replay.test.ts`, `recall-openai-stream.test.ts`, `remote-attribution.test.ts` (unrelated; reproduce on clean main)
