### PR TITLE
docs(site): add Setup command page + trim duplicated Codex sections

### DIFF
--- a/packages/website/astro.config.mjs
+++ b/packages/website/astro.config.mjs
@@ -52,6 +52,7 @@ export default defineConfig({
             { label: "Pi", slug: "docs/guides/with-pi" },
             { label: "Claude Code", slug: "docs/guides/with-claude-code" },
             { label: "Codex", slug: "docs/guides/with-codex" },
+            { label: "Setup command", slug: "docs/setup" },
             { label: "Custom upstreams", slug: "docs/guides/custom-upstreams" },
             { label: "Local inference", slug: "docs/guides/local-inference" },
           ],

--- a/packages/website/src/content/docs/docs/guides/with-codex.md
+++ b/packages/website/src/content/docs/docs/guides/with-codex.md
@@ -41,35 +41,7 @@ Both overrides are per-invocation — they do not affect Codex's persisted `conf
 
 ## Manual setup (CLI)
 
-If you'd rather start the gateway yourself and launch Codex directly, edit `~/.codex/config.toml`:
-
-```toml
-[model]
-auto_compact_token_limit = 999999999
-
-[providers.openai]
-base_url = "http://127.0.0.1:3207/v1"
-```
-
-Start the gateway and Codex in separate terminals:
-
-```bash
-# Terminal 1
-lore start
-
-# Terminal 2
-codex
-```
-
-## Codex Desktop app
-
-The Codex Desktop app does not accept `-c` CLI overrides at launch and has no obvious way to inject a custom `openai_base_url` through its UI. The recommended setup is to point the Desktop app at a `config.toml` that routes through the Lore gateway.
-
-1. Start the Lore gateway in the background (via `lore start` or a system service).
-2. Edit or create `~/.codex/config.toml` with the snippet above.
-3. Launch the Codex Desktop app and verify the request log shows requests going to `127.0.0.1:3207` instead of `api.openai.com`.
-
-If the Desktop app overwrites or ignores your `config.toml`, run the gateway under a system service manager (`systemd`, `launchd`, etc.) so the URL stays stable, and consider using a session-scoped override file at `~/.codex/sessions/<session-id>/config.toml` if the Desktop app supports per-session configs.
+If you'd rather start the gateway yourself and launch Codex directly — or if you're setting up the Codex Desktop app, which doesn't accept `-c` CLI overrides — run [`lore setup codex`](../setup/) once. It writes the right `~/.codex/config.toml` for both the CLI and the Desktop app, and supports `-r <url>` for remote gateways. See the [Setup command](../setup/) page for the full command reference.
 
 ## Custom upstream headers
 
@@ -82,6 +54,7 @@ The Codex plugin reads `LORE_UPSTREAM_EXTRA_HEADERS` from your environment and f
 
 ## Next steps
 
+- [Setup command](../setup/) — `lore setup codex` for manual/Desktop configuration and remote gateways.
 - [Architecture](../architecture/) — how temporal storage, distillation, and the gradient context manager fit together.
 - [Configuration](../configuration/) — full reference for `.lore.json`.
 - [Custom upstreams](./custom-upstreams/) — corporate proxies, LiteLLM, Cloudflare AI Gateway.

--- a/packages/website/src/content/docs/docs/install.md
+++ b/packages/website/src/content/docs/docs/install.md
@@ -19,6 +19,8 @@ lore run
 
 Lore auto-detects Claude Code, OpenCode, Pi, Codex, and Hermes Agent when you run `lore run`. For harness-specific setup, see the Guides section.
 
+If you'd rather configure Codex manually (for the Codex Desktop app, or to run `codex` without going through `lore run`), run [`lore setup codex`](./setup/) once — it writes `~/.codex/config.toml` with the gateway URL and the no-auto-compact override. See the [Setup command](./setup/) page for the full reference.
+
 You can also run the gateway directly with npm:
 
 ```bash

--- a/packages/website/src/content/docs/docs/setup.md
+++ b/packages/website/src/content/docs/docs/setup.md
@@ -1,0 +1,62 @@
+---
+title: Setup command
+description: Use `lore setup` to configure an AI coding agent to route through the Lore memory gateway. The recommended path for Codex and Codex Desktop.
+sidebar:
+  order: 5
+---
+
+`lore setup [app]` configures a supported AI coding agent to route its requests through the Lore gateway. It writes the right config file (or, for agents that don't read env vars at runtime, the right `-c` override) so the agent's API calls land on the gateway instead of going to the upstream provider directly.
+
+## When to use `lore setup`
+
+- **Codex Desktop** — the Desktop app does not accept `-c` CLI overrides at launch and has no obvious way to inject a custom `openai_base_url` through its UI. `lore setup codex` writes `~/.codex/config.toml` once and the Desktop app picks it up on next launch. This is the **recommended** path for Codex Desktop.
+- **Codex CLI without `lore run`** — if you'd rather start the gateway yourself and launch Codex directly (for example, in a long-running dev workflow where you don't want `lore run` to manage the gateway lifecycle), `lore setup codex` writes the same config.
+- **Remote gateway** — `lore setup codex -r http://remote:3207` writes a `config.toml` pointing at a non-default gateway URL, useful when the gateway runs on a different machine (Tailscale, LAN, a hosted deployment) and you want the local Codex client to talk to it.
+
+If you're using `lore run` with a CLI-based agent that reads env vars (OpenCode, Pi, Claude Code, Hermes Agent), you do **not** need `lore setup` — `lore run` injects the right env vars into the child process at launch.
+
+## Usage
+
+```bash
+lore setup                     # Auto-detect installed supported apps and configure them
+lore setup codex               # Configure Codex explicitly
+lore setup codex -p 8080       # Configure Codex to talk to a gateway on a non-default port
+lore setup codex -r http://remote:3207  # Configure Codex for a remote gateway
+```
+
+If no app is given, `lore setup` scans `$PATH` for supported apps and configures whichever ones it finds. If nothing matches, it prints the supported app list and exits with a non-zero status — it never modifies a config file unless it found a matching installed app (or you passed an app name explicitly).
+
+If the named app isn't installed (for example, `lore setup codex` on a machine without the Codex binary), the command prints a warning and proceeds with the configuration. The intent is to let you set up Codex on a workstation where the binary lives elsewhere, or to pre-configure before installing the binary.
+
+## Supported apps
+
+| App          | Config written                                                            | Notes                                                                                       |
+| ------------ | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `codex`      | `~/.codex/config.toml` (with `openai_base_url` + `model_auto_compact_token_limit`) | Required for Codex Desktop. Idempotent — re-running updates existing fields without losing other settings. |
+
+`openai_base_url` is set to the gateway's `baseUrl`, normalized to end with `/v1` (required by Codex). The port defaults to `3207` (the first entry in `DEFAULT_PORTS`); override with `-p` or `-r`.
+
+`model_auto_compact_token_limit = 999999999` disables Codex's built-in auto-compaction so Lore's gradient context manager and distillation pipeline can do their job. If you re-run `lore setup`, this value is restored if you've changed it.
+
+To remove the configuration and restore Codex's default behavior, delete the relevant lines from `~/.codex/config.toml` or run `git checkout -- ~/.codex/config.toml` if you keep the file under version control.
+
+## Verifying the setup
+
+After `lore setup codex`, launch the gateway in one terminal:
+
+```bash
+lore start
+```
+
+In a second terminal, run Codex (or launch the Codex Desktop app). In the gateway's request log you should see requests originating from `127.0.0.1` with `model` set to your configured Codex model. If you see requests going to `api.openai.com` instead, the `config.toml` write was overridden — check that no other tool (Codex's own first-run wizard, a system service, a different shell profile) is writing to the file after `lore setup` runs.
+
+## Per-harness notes
+
+- **Codex Desktop** — `lore setup codex` is the **only** way to route the Desktop app through Lore (the app does not honor `-c` CLI overrides at launch). Run it once, leave the gateway running via `lore start` (or a system service), and the Desktop app routes correctly.
+- **Codex CLI** — `lore run codex` is simpler than `lore setup codex` because it manages the gateway lifecycle and passes `-c` overrides per-invocation (no persisted config). Use `lore setup` only when you want to launch Codex without `lore run`.
+
+## Next steps
+
+- [Codex with Lore](./guides/with-codex/) — full per-harness guide for Codex, including the Codex Desktop caveat and custom-upstream headers.
+- [Custom upstreams](./guides/custom-upstreams/) — corporate proxies, LiteLLM, Cloudflare AI Gateway. Pairs with `lore setup -r` for remote gateways.
+- [Architecture](./architecture/) — how temporal storage, distillation, and the gradient context manager fit together.


### PR DESCRIPTION
## Summary

Documents the `lore setup` CLI command in the user-facing docs site. This was previously undocumented — see #638.

The command is the ONLY way to route the Codex Desktop app through Lore (the app doesn't honor `-c` CLI overrides at launch). Without docs, Codex Desktop users have to discover the manual TOML editing path by reading the source.

## What's in this PR

**New page: `docs/setup.md`**

Full `lore setup` command reference:
* `lore setup` (auto-detect) and `lore setup codex` (explicit) syntax
* `-p <port>` and `-r <url>` flags for non-default gateways
* When to use `lore setup` vs `lore run` (run for env-var-based agents like OpenCode/Pi/Claude Code/Hermes; setup for Codex and Codex Desktop)
* Supported apps table (currently: `codex`, idempotent writes)
* Verifying the setup (request log check)
* **Codex Desktop explicitly called out as the recommended path**

**Trimmed: `docs/guides/with-codex.md`**

The `Manual setup (CLI)` and `Codex Desktop app` sections were 30 lines of duplicated content (same TOML snippet, same setup steps). Both now point to the new `../setup/` page. The Codex guide stays focused on the `lore run` path and harness-specific notes (custom upstream headers, per-harness quirks).

**Updated: `docs/install.md`**

Added a one-paragraph mention of `lore setup codex` after the `lore run` block, so the command is discoverable from the install path.

**Updated: `astro.config.mjs` sidebar**

New `Setup command` entry in the Guides group, between `Codex` and `Custom upstreams`.

## Verification

* `pnpm run check:docs` passes (no doc drift)
* `pnpm run check:links` passes (0 real broken links; new page's cross-links resolve)
* `pnpm lint` clean (0 errors, 13 pre-existing warnings)
* Site build: 16 pages render (was 15)
* Preview at https://withlore.ai/_preview/pr-639/ (or whatever PR number)

## Resolves

Closes #638