### PR TITLE
feat(ci): build darwin binary natively on macOS for code cache + codesign

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -709,7 +709,7 @@ jobs:
       - name: Build darwin-arm64 binary from staging
         run: |
           pnpm --filter @loreai/gateway run build:binary:sea \
-            --from-staging packages/gateway/.sea-staging \
+            --from-staging .sea-staging \
             --platforms darwin-arm64 --release
           echo "--- Darwin binary: ---"
           ls -la packages/gateway/dist-bin/
@@ -735,6 +735,8 @@ jobs:
           echo "codesign -v: passed"
           SIG_INFO=$(codesign -d --verbose=2 "$BIN" 2>&1)
           echo "$SIG_INFO"
+          # Verify the binary has SOME signature (ad-hoc or certificate).
+          # Update this check if switching to a real Apple Developer certificate.
           echo "$SIG_INFO" | grep -q "Signature=adhoc" \
             || (echo "::error::Binary is not ad-hoc signed — will fail on Apple Silicon"; exit 1)
           echo "Ad-hoc signature verified"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,6 +310,26 @@ jobs:
           name: lore-linux-x64
           path: packages/gateway/dist-bin/lore-linux-x64
 
+      # Prepare platform-independent staging dir for cross-platform builds.
+      # The linux-x64 build above already ran esbuild and populated
+      # .sea-staging/, but we run --prepare-only explicitly to make the
+      # intent clear and ensure the staging dir is complete for darwin-arm64.
+      - name: Prepare staging for cross-platform builds
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        run: |
+          pnpm --filter @loreai/gateway run build:binary:sea \
+            --platforms darwin-arm64 --prepare-only
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          FOSSILIZE_CACHE_DIR: ${{ github.workspace }}/.node-cache
+
+      - name: Upload staging artifact
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        uses: actions/upload-artifact@v7
+        with:
+          name: sea-staging
+          path: packages/gateway/.sea-staging/
+
       # -----------------------------------------------------------------
       # Release: build all packages + pack tarballs + multi-platform binaries
       # -----------------------------------------------------------------
@@ -604,8 +624,8 @@ jobs:
         if: steps.vendor-cache.outputs.cache-hit != 'true'
         run: pnpm tsx packages/gateway/script/vendor-embeddings.ts
 
-      # Cache fossilize's downloaded Node.js binaries (~200 MB across 4
-      # platforms) so nightly builds don't re-download on every run.
+      # Cache fossilize's downloaded Node.js binaries so nightly builds
+      # don't re-download on every run.
       - name: Cache fossilize Node binaries
         id: fossilize-cache
         uses: actions/cache@v5
@@ -613,27 +633,12 @@ jobs:
           path: .node-cache
           key: fossilize-${{ hashFiles('packages/gateway/script/build-binary-sea.ts') }}
 
-      # rcodesign is needed to ad-hoc sign macOS binaries when cross-
-      # compiling on Linux. Without it, darwin binaries are unsigned and
-      # cannot execute on Apple Silicon.
-      # NOTE: Keep in sync with the identical step in the test job (release builds).
-      - name: Install rcodesign (macOS cross-signing)
-        run: |
-          RCODESIGN_VERSION="0.29.0"
-          RCODESIGN_SHA256="dbe85cedd8ee4217b64e9a0e4c2aef92ab8bcaaa41f20bde99781ff02e600002"
-          TARBALL="apple-codesign-${RCODESIGN_VERSION}-x86_64-unknown-linux-musl.tar.gz"
-          curl -fsSL -o "/tmp/${TARBALL}" \
-            "https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign%2F${RCODESIGN_VERSION}/${TARBALL}"
-          echo "${RCODESIGN_SHA256}  /tmp/${TARBALL}" | sha256sum -c -
-          tar -xzf "/tmp/${TARBALL}" -C /usr/local/bin --strip-components=1 \
-            "apple-codesign-${RCODESIGN_VERSION}-x86_64-unknown-linux-musl/rcodesign"
-          rm "/tmp/${TARBALL}"
-          rcodesign --version
-
-      - name: Build all platform binaries
+      # darwin-arm64 is built natively on macOS (build-nightly-darwin job)
+      # to get V8 code cache + native codesign.
+      - name: Build platform binaries
         run: |
           pnpm --filter @loreai/gateway run build:binary:sea \
-            --platforms "darwin-arm64,linux-arm64,linux-x64,windows-x64" \
+            --platforms "linux-arm64,linux-x64,windows-x64" \
             --release
           echo "--- Nightly binaries: ---"
           ls -la packages/gateway/dist-bin/
@@ -655,9 +660,102 @@ jobs:
             packages/gateway/dist-bin/lore-*
             !packages/gateway/dist-bin/*.gz
 
+  # ---------------------------------------------------------------------------
+  # Nightly: build darwin-arm64 natively on macOS
+  #
+  # Cross-compiling darwin on Linux requires rcodesign (ad-hoc signing) and
+  # cannot produce V8 code cache. Building natively on macOS gets both a
+  # real codesign and a V8 snapshot, and lets us smoke-test the actual
+  # shipped binary.
+  # ---------------------------------------------------------------------------
+
+  build-nightly-darwin:
+    name: Build Nightly Darwin
+    needs: [changes, test]
+    if: >-
+      needs.changes.outputs.code == 'true' &&
+      github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Set nightly version
+        run: |
+          jq --arg v "${{ needs.test.outputs.nightly-version }}" '.version = $v' \
+            packages/gateway/package.json > packages/gateway/package.json.tmp
+          mv packages/gateway/package.json.tmp packages/gateway/package.json
+          echo "Building nightly version: ${{ needs.test.outputs.nightly-version }}"
+
+      - name: Download staging artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: sea-staging
+          path: packages/gateway/.sea-staging/
+
+      - name: Cache fossilize Node binaries
+        uses: actions/cache@v5
+        with:
+          path: .node-cache
+          key: fossilize-darwin-arm64-${{ hashFiles('packages/gateway/script/build-binary-sea.ts') }}
+
+      - name: Build darwin-arm64 binary from staging
+        run: |
+          pnpm --filter @loreai/gateway run build:binary:sea \
+            --from-staging packages/gateway/.sea-staging \
+            --platforms darwin-arm64 --release
+          echo "--- Darwin binary: ---"
+          ls -la packages/gateway/dist-bin/
+        env:
+          FOSSILIZE_CACHE_DIR: ${{ github.workspace }}/.node-cache
+
+      - name: Smoke-test
+        run: |
+          BIN="./packages/gateway/dist-bin/lore-darwin-arm64"
+          "$BIN" --version
+          info=$("$BIN" --print-vendor-info)
+          echo "Vendor info: $info"
+          echo "$info" | jq -e '.target == "darwin-arm64" and .localModelPath != null and .version != null' \
+            || (echo "::error::vendor not embedded in darwin-arm64 binary"; exit 1)
+          "$BIN" --check-embeddings \
+            || (echo "::error::--check-embeddings failed in darwin-arm64 binary"; exit 1)
+
+      - name: Verify code signature
+        run: |
+          BIN="./packages/gateway/dist-bin/lore-darwin-arm64"
+          echo "--- Code signature verification ---"
+          codesign -v --strict "$BIN"
+          echo "codesign -v: passed"
+          SIG_INFO=$(codesign -d --verbose=2 "$BIN" 2>&1)
+          echo "$SIG_INFO"
+          echo "$SIG_INFO" | grep -q "Signature=adhoc" \
+            || (echo "::error::Binary is not ad-hoc signed — will fail on Apple Silicon"; exit 1)
+          echo "Ad-hoc signature verified"
+
+      - name: Upload compressed artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: nightly-darwin-gz
+          path: packages/gateway/dist-bin/*.gz
+
+      - name: Upload uncompressed artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: nightly-darwin-raw
+          path: |
+            packages/gateway/dist-bin/lore-*
+            !packages/gateway/dist-bin/*.gz
+
   generate-patches:
     name: Generate Delta Patches
-    needs: [changes, test, build-nightly-binaries]
+    needs: [changes, test, build-nightly-binaries, build-nightly-darwin]
     if: >-
       needs.changes.outputs.code == 'true' &&
       github.ref == 'refs/heads/main' && github.event_name == 'push'
@@ -692,10 +790,22 @@ jobs:
           name: nightly-binaries-raw
           path: new-binaries
 
+      - name: Download darwin binary
+        uses: actions/download-artifact@v8
+        with:
+          name: nightly-darwin-raw
+          path: new-binaries
+
       - name: Download current compressed binaries
         uses: actions/download-artifact@v8
         with:
           name: nightly-binaries-gz
+          path: new-binaries
+
+      - name: Download darwin compressed binary
+        uses: actions/download-artifact@v8
+        with:
+          name: nightly-darwin-gz
           path: new-binaries
 
       - name: Download previous nightly binaries from GHCR
@@ -790,7 +900,7 @@ jobs:
 
   publish-nightly:
     name: Publish Nightly to GHCR
-    needs: [changes, test, build-nightly-binaries, generate-patches]
+    needs: [changes, test, build-nightly-binaries, build-nightly-darwin, generate-patches]
     if: >-
       needs.changes.outputs.code == 'true' &&
       github.ref == 'refs/heads/main' && github.event_name == 'push'
@@ -802,10 +912,22 @@ jobs:
           name: nightly-binaries-gz
           path: artifacts
 
+      - name: Download darwin compressed artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: nightly-darwin-gz
+          path: artifacts
+
       - name: Download uncompressed artifacts (for SHA-256 computation)
         uses: actions/download-artifact@v8
         with:
           name: nightly-binaries-raw
+          path: binaries
+
+      - name: Download darwin uncompressed artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: nightly-darwin-raw
           path: binaries
 
       - name: Download patch artifacts

--- a/packages/core/src/db/driver.node.ts
+++ b/packages/core/src/db/driver.node.ts
@@ -29,16 +29,15 @@ export class Database extends DatabaseSync {
     let entry = map.get(sql);
     if (!entry) {
       const stmt = this.prepare(sql);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       entry = {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // biome-ignore lint/suspicious/noExplicitAny: node:sqlite prepare().all() accepts variadic args
         all: (...args: any[]) => stmt.all(...args) as Record<string, unknown>[],
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // biome-ignore lint/suspicious/noExplicitAny: node:sqlite prepare().get() accepts variadic args
         get: (...args: any[]) => {
           const result = stmt.get(...args) as Record<string, unknown> | null;
           return result ?? null;
         },
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // biome-ignore lint/suspicious/noExplicitAny: node:sqlite prepare().run() accepts variadic args
         run: (...args: any[]) =>
           stmt.run(...args) as { changes: number; lastInsertRowid: bigint },
       };

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -1099,7 +1099,7 @@ export function getWorkerSource(
     worker_provider_id: string | null;
     worker_model_id: string | null;
   } | null;
-  if (!row || !row.worker_provider_id || !row.worker_model_id) return null;
+  if (!row?.worker_provider_id || !row.worker_model_id) return null;
   return {
     providerID: row.worker_provider_id,
     modelID: row.worker_model_id,

--- a/packages/core/src/pattern-echo.ts
+++ b/packages/core/src/pattern-echo.ts
@@ -14,7 +14,6 @@
  */
 
 import { db, ensureProject } from "./db";
-import { config } from "./config";
 import * as embedding from "./embedding";
 import * as ltm from "./ltm";
 import * as log from "./log";

--- a/packages/core/test/embedding.test.ts
+++ b/packages/core/test/embedding.test.ts
@@ -1,11 +1,4 @@
-import {
-  afterEach,
-  describe,
-  test,
-  expect,
-  beforeAll,
-  beforeEach,
-} from "vitest";
+import { afterEach, describe, test, expect, beforeEach } from "vitest";
 import { existsSync } from "node:fs";
 import { db, ensureProject } from "../src/db";
 import { LOCAL_MODEL_PATH_ENV } from "../src/embedding-vendor";

--- a/packages/core/test/entities.test.ts
+++ b/packages/core/test/entities.test.ts
@@ -1022,6 +1022,7 @@ describe("entities", () => {
       // Verify person was actually created separately
       expect(person.created).toBe(true);
       expect(entities.get(person.id)).not.toBeNull();
+      // biome-ignore lint/style/noNonNullAssertion: entity was just created above
       const personAliases = entities.getWithAliases(person.id)!.aliases;
       expect(personAliases.map((a) => a.alias_value)).toContain("alice-gh");
 

--- a/packages/gateway/script/build-binary-sea.ts
+++ b/packages/gateway/script/build-binary-sea.ts
@@ -299,14 +299,9 @@ function sentryBunToNodePlugin(): esbuild.Plugin {
 // Sentry sourcemap upload
 // ---------------------------------------------------------------------------
 
-function uploadSentrySourcemap(
-  stagingDirPath: string,
-  mapPath: string,
-): void {
+function uploadSentrySourcemap(stagingDirPath: string, mapPath: string): void {
   if (process.env.SENTRY_AUTH_TOKEN) {
-    console.log(
-      `  Uploading sourcemap to Sentry (release: ${pkg.version})...`,
-    );
+    console.log(`  Uploading sourcemap to Sentry (release: ${pkg.version})...`);
     try {
       execSync(
         [
@@ -358,7 +353,7 @@ async function runFossilize(
   targets: CompileTarget[],
   bundlePath: string,
   manifestPath: string,
-  stagingDirPath: string,
+  _stagingDirPath: string,
 ): Promise<void> {
   const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
 

--- a/packages/gateway/script/build-binary-sea.ts
+++ b/packages/gateway/script/build-binary-sea.ts
@@ -76,6 +76,16 @@ const { values: flags } = parseArgs({
      *  require a network download on first use.
      *  Useful for iteration speed during local dev. */
     "no-vendor": { type: "boolean", default: false },
+    /** Run esbuild + asset staging only — skip fossilize and everything
+     *  after it. The .sea-staging/ directory is the output artifact,
+     *  suitable for transfer to another machine (e.g. macOS) where
+     *  fossilize runs natively for V8 code cache + native codesign.
+     *  Sentry sourcemap upload still runs in this mode. */
+    "prepare-only": { type: "boolean", default: false },
+    /** Skip esbuild — reuse a pre-built .sea-staging/ directory
+     *  (e.g. downloaded as a CI artifact from a --prepare-only run).
+     *  Runs fossilize, gzip, and rename steps only. */
+    "from-staging": { type: "string" },
   },
   allowPositionals: false,
   strict: true,
@@ -286,11 +296,175 @@ function sentryBunToNodePlugin(): esbuild.Plugin {
 }
 
 // ---------------------------------------------------------------------------
+// Sentry sourcemap upload
+// ---------------------------------------------------------------------------
+
+function uploadSentrySourcemap(
+  stagingDirPath: string,
+  mapPath: string,
+): void {
+  if (process.env.SENTRY_AUTH_TOKEN) {
+    console.log(
+      `  Uploading sourcemap to Sentry (release: ${pkg.version})...`,
+    );
+    try {
+      execSync(
+        [
+          "npx",
+          "sentry",
+          "sourcemap",
+          "upload",
+          // Sourcemap lives in .sea-staging/ (produced by esbuild
+          // with sourcemap:"linked"). The final binary embeds the
+          // debug ID that links errors back to this map.
+          `${stagingDirPath}/`,
+          "--release",
+          pkg.version,
+          "--org",
+          "byk",
+          "--project",
+          "loreai-gateway",
+          "--url-prefix",
+          "~/sea-staging/",
+        ].join(" "),
+        { cwd: packageDir, stdio: "inherit" },
+      );
+      console.log("✓ Sourcemap uploaded to Sentry");
+      // Delete the .map file after upload — it's not needed in the
+      // staging artifact and would waste transfer bandwidth.
+      try {
+        unlinkSync(mapPath);
+        console.log("✓ Sourcemap deleted (uploaded to Sentry)");
+      } catch {
+        // best-effort
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`⚠ Sourcemap upload failed: ${msg}`);
+    }
+  } else {
+    console.log("  No SENTRY_AUTH_TOKEN — skipping sourcemap upload");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fossilize: SEA binary creation, gzip, rename
+// ---------------------------------------------------------------------------
+
+const fossilizeTarget = (t: CompileTarget): string =>
+  t.startsWith("windows") ? t.replace("windows", "win") : t;
+
+async function runFossilize(
+  targets: CompileTarget[],
+  bundlePath: string,
+  manifestPath: string,
+  stagingDirPath: string,
+): Promise<void> {
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+
+  console.log(
+    `→ fossilize: ${targets.length} platform(s), ${Object.keys(manifest).length} asset(s)`,
+  );
+  try {
+    await fossilize(
+      {
+        nodeVersion: "lts",
+        platforms: targets.map(fossilizeTarget),
+        noBundle: true,
+        holePunch: true,
+        outputName: "lore",
+        outDir: distBinDir,
+        cacheDir: join(packageDir, ".node-cache"),
+        assetManifest: manifestPath,
+        sign: false,
+        concurrencyLimit: 3,
+      },
+      bundlePath,
+    );
+  } catch (err) {
+    console.error("✗ fossilize failed:", err);
+    process.exit(1);
+  }
+
+  // fossilize creates output files with its own platform naming
+  // (e.g. lore-win-x64 for our windows-x64). Verify the expected
+  // paths exist, then rename to our naming convention for CI
+  // compatibility (CI expects lore-windows-x64.exe).
+  for (const target of targets) {
+    const fTarget = fossilizeTarget(target);
+    const ext = fTarget.startsWith("win") ? ".exe" : "";
+    const fossilizePath = join(distBinDir, `lore-${fTarget}${ext}`);
+    if (!existsSync(fossilizePath)) {
+      console.error(
+        `✗ expected output not found: ${fossilizePath}. Check fossilize logs.`,
+      );
+      process.exit(1);
+    }
+    if (fTarget !== target) {
+      const ourPath = join(distBinDir, `lore-${target}${ext}`);
+      renameSync(fossilizePath, ourPath);
+      console.log(`✓ Binary: ${ourPath} (was ${fossilizePath})`);
+    } else {
+      console.log(`✓ Binary: ${fossilizePath}`);
+    }
+  }
+
+  // gzip (if --release)
+  if (flags.release) {
+    for (const target of targets) {
+      const ext = target.startsWith("windows") ? ".exe" : "";
+      const binaryPath = join(distBinDir, `lore-${target}${ext}`);
+      const raw = readFileSync(binaryPath);
+      const compressed = gzipSync(raw, { level: 6 });
+      const gzPath = `${binaryPath}.gz`;
+      writeFileSync(gzPath, compressed);
+      const ratio = ((compressed.length / raw.length) * 100).toFixed(1);
+      console.log(
+        `✓ gzip: ${gzPath} (${(compressed.length / 1024 / 1024).toFixed(1)}MB, ${ratio}% of original)`,
+      );
+    }
+  }
+
+  console.log(
+    `\n✓ Binary build complete: ${targets.map((t) => `lore-${t}`).join(", ")} (v${pkg.version})`,
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Main pipeline
 // ---------------------------------------------------------------------------
 
 async function buildBinary() {
   const targets = parseTargets();
+
+  // --from-staging: skip esbuild, reuse a pre-built staging directory.
+  // Jump straight to fossilize + gzip + rename.
+  if (flags["from-staging"]) {
+    const externalStaging = flags["from-staging"];
+    if (!existsSync(externalStaging)) {
+      console.error(`✗ --from-staging dir not found: ${externalStaging}`);
+      process.exit(1);
+    }
+    const manifestPath = join(externalStaging, "asset-manifest.json");
+    if (!existsSync(manifestPath)) {
+      console.error(
+        `✗ asset-manifest.json not found in staging dir: ${externalStaging}`,
+      );
+      process.exit(1);
+    }
+    const bundlePath = join(externalStaging, "sea-entry.cjs");
+    if (!existsSync(bundlePath)) {
+      console.error(
+        `✗ sea-entry.cjs not found in staging dir: ${externalStaging}`,
+      );
+      process.exit(1);
+    }
+    console.log(`→ Using pre-built staging: ${externalStaging}`);
+    mkdirSync(distBinDir, { recursive: true });
+    await runFossilize(targets, bundlePath, manifestPath, externalStaging);
+    return;
+  }
+
   const firstTarget = targets[0];
   let vendorModelDir: string | null = null;
   if (targets.length === 1 && firstTarget) {
@@ -571,137 +745,25 @@ async function buildBinary() {
   writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
 
   // -------------------------------------------------------------------------
-  // Step 4: Run fossilize
+  // Sentry sourcemap upload (runs before fossilize — the .map file lives
+  // in stagingDir, not the final binary dir)
   // -------------------------------------------------------------------------
-  // fossilize uses Node.js archive naming which differs from our
-  // VALID_TARGETS on some platforms:
-  //   our "windows-x64"  → fossilize "win-x64"
-  //   our "darwin-arm64" → fossilize "darwin-arm64" (same)
-  //   our "linux-x64"    → fossilize "linux-x64" (same)
-  const fossilizeTarget = (t: CompileTarget): string =>
-    t.startsWith("windows") ? t.replace("windows", "win") : t;
+  uploadSentrySourcemap(stagingDir, mapPath);
 
-  console.log(
-    `→ fossilize: ${targets.length} platform(s), ${Object.keys(manifest).length} asset(s)`,
-  );
-  try {
-    await fossilize(
-      {
-        nodeVersion: "lts",
-        platforms: targets.map(fossilizeTarget),
-        noBundle: true,
-        holePunch: true,
-        outputName: "lore",
-        outDir: distBinDir,
-        cacheDir: join(packageDir, ".node-cache"),
-        assetManifest: manifestPath,
-        sign: false,
-        concurrencyLimit: 3,
-      },
-      bundlePath,
+  // --prepare-only: stop here. The staging dir is the output artifact
+  // for transfer to another machine (e.g. macOS for native fossilize).
+  if (flags["prepare-only"]) {
+    console.log(
+      `\n✓ Staging prepared: ${stagingDir}\n` +
+        `  Use --from-staging ${stagingDir} on the target machine to run fossilize.`,
     );
-  } catch (err) {
-    console.error("✗ fossilize failed:", err);
-    process.exit(1);
-  }
-
-  // fossilize creates output files with its own platform naming
-  // (e.g. lore-win-x64 for our windows-x64). Verify the expected
-  // paths exist, then rename to our naming convention for CI
-  // compatibility (CI expects lore-windows-x64.exe).
-  for (const target of targets) {
-    const fossilizePlat = fossilizeTarget(target);
-    const ext = fossilizePlat.startsWith("win") ? ".exe" : "";
-    const fossilizePath = join(distBinDir, `lore-${fossilizePlat}${ext}`);
-    if (!existsSync(fossilizePath)) {
-      console.error(
-        `✗ expected output not found: ${fossilizePath}. Check fossilize logs.`,
-      );
-      process.exit(1);
-    }
-    if (fossilizePlat !== target) {
-      const ourPath = join(distBinDir, `lore-${target}${ext}`);
-      renameSync(fossilizePath, ourPath);
-      console.log(`✓ Binary: ${ourPath} (was ${fossilizePath})`);
-    } else {
-      console.log(`✓ Binary: ${fossilizePath}`);
-    }
+    return;
   }
 
   // -------------------------------------------------------------------------
-  // Step 5: gzip (if --release)
+  // Steps 4-5: fossilize + gzip + rename
   // -------------------------------------------------------------------------
-  if (flags.release) {
-    for (const target of targets) {
-      const ext = target.startsWith("windows") ? ".exe" : "";
-      const binaryPath = join(distBinDir, `lore-${target}${ext}`);
-      const raw = readFileSync(binaryPath);
-      const compressed = gzipSync(raw, { level: 6 });
-      const gzPath = `${binaryPath}.gz`;
-      writeFileSync(gzPath, compressed);
-      const ratio = ((compressed.length / raw.length) * 100).toFixed(1);
-      console.log(
-        `✓ gzip: ${gzPath} (${(compressed.length / 1024 / 1024).toFixed(1)}MB, ${ratio}% of original)`,
-      );
-    }
-  }
-
-  // -------------------------------------------------------------------------
-  // Step 6: Upload sourcemap to Sentry
-  // -------------------------------------------------------------------------
-  let uploaded = false;
-  if (process.env.SENTRY_AUTH_TOKEN) {
-    console.log(`  Uploading sourcemap to Sentry (release: ${pkg.version})...`);
-    try {
-      execSync(
-        [
-          "npx",
-          "sentry",
-          "sourcemap",
-          "upload",
-          // Sourcemap lives in .sea-staging/ (produced by esbuild
-          // with sourcemap:"linked"). The final binary embeds the
-          // debug ID that links errors back to this map.
-          `${stagingDir}/`,
-          "--release",
-          pkg.version,
-          "--org",
-          "byk",
-          "--project",
-          "loreai-gateway",
-          "--url-prefix",
-          "~/sea-staging/",
-        ].join(" "),
-        { cwd: packageDir, stdio: "inherit" },
-      );
-      uploaded = true;
-      console.log("✓ Sourcemap uploaded to Sentry");
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      console.warn(`⚠ Sourcemap upload failed: ${msg}`);
-    }
-  } else {
-    console.log("  No SENTRY_AUTH_TOKEN — skipping sourcemap upload");
-  }
-
-  // -------------------------------------------------------------------------
-  // Step 7: Cleanup intermediates
-  // -------------------------------------------------------------------------
-  // Preserve bundle + worker for debugging — fossilize has already
-  // consumed them, and removing them would force a full rebuild on
-  // every run. CI cleans the staging dir at job start.
-  if (uploaded) {
-    try {
-      unlinkSync(mapPath);
-      console.log("✓ Sourcemap deleted (uploaded to Sentry)");
-    } catch {
-      // best-effort
-    }
-  }
-
-  console.log(
-    `\n✓ Binary build complete: ${targets.map((t) => `lore-${t}`).join(", ")} (v${pkg.version})`,
-  );
+  await runFossilize(targets, bundlePath, manifestPath, stagingDir);
 }
 
 await buildBinary();

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -4481,8 +4481,7 @@ async function handleConversationTurn(
       cfg.knowledge.enabled && cfg.loreFile.enabled
         ? {
             ...RECALL_GATEWAY_TOOL,
-            description:
-              RECALL_GATEWAY_TOOL.description + "\n\n" + LORE_COMMIT_REMINDER,
+            description: `${RECALL_GATEWAY_TOOL.description}\n\n${LORE_COMMIT_REMINDER}`,
           }
         : RECALL_GATEWAY_TOOL;
     modifiedReq.tools = [...modifiedReq.tools, recallTool];

--- a/packages/gateway/test/agents.test.ts
+++ b/packages/gateway/test/agents.test.ts
@@ -141,9 +141,10 @@ describe("Codex agent cliArgs", () => {
         (a) => typeof a === "string" && a.startsWith("openai_provider_headers"),
       );
       expect(providerHeadersIdx).toBeGreaterThan(0);
-      const prev = args?.[providerHeadersIdx! - 1];
+      const idx = providerHeadersIdx as number;
+      const prev = args?.[idx - 1];
       expect(prev).toBe("-c");
-      const tomlLine = args?.[providerHeadersIdx!];
+      const tomlLine = args?.[idx];
       expect(tomlLine).toContain("X-Corp-Token");
       expect(tomlLine).toContain("abc");
       expect(tomlLine).toContain("X-Tenant");
@@ -160,7 +161,7 @@ describe("Codex agent cliArgs", () => {
       );
       expect(idx).toBeGreaterThan(0);
       // TOML basic string: embedded " is escaped
-      expect(args?.[idx!]).toContain('\\"');
+      expect(args?.[idx as number]).toContain('\\"');
     });
 
     test("omits openai_provider_headers when env is empty", () => {

--- a/packages/gateway/test/helpers/harness.ts
+++ b/packages/gateway/test/helpers/harness.ts
@@ -95,7 +95,7 @@ export async function createHarness(opts: HarnessOptions): Promise<Harness> {
       const db = new DatabaseSync(dbPath, { readOnly: true });
       try {
         const stmt = db.prepare(sql);
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // biome-ignore lint/suspicious/noExplicitAny: node:sqlite stmt.all() accepts variadic args
         return stmt.all(...((params ?? []) as any)) as T[];
       } finally {
         db.close();

--- a/packages/gateway/test/parse-curl-headers.test.ts
+++ b/packages/gateway/test/parse-curl-headers.test.ts
@@ -96,7 +96,6 @@ describe("parseCurlHeaders", () => {
     const origError = console.error;
     console.error = () => {};
     try {
-      // biome-ignore lint/suspicious/noControlCharactersInRegex: testing sanitization
       const result = parseCurlHeaders("X Bad: x\nX\x00Bad: y");
       // The whitespace name parses as "X Bad" but fails the RFC 7230 token
       // check, so it's rejected. The control-char name is sanitized to
@@ -112,7 +111,6 @@ describe("parseCurlHeaders", () => {
     const origError = console.error;
     console.error = () => {};
     try {
-      // biome-ignore lint/suspicious/noControlCharactersInRegex: testing sanitization
       const result = parseCurlHeaders("X-Inject: a\x00b\x01c");
       // Value has control chars stripped, leaving "abc"
       expect(result["x-inject"]).toBe("abc");


### PR DESCRIPTION
## Problem

Three issues with the current nightly darwin binary:

1. **No V8 code cache**: Cross-compiling on Ubuntu means `hostIsTarget=false` in fossilize — the darwin binary gets no V8 code cache (~15% startup penalty)
2. **Binary never tested**: The smoke test builds its **own** binary on macOS, which always works. The actual nightly artifact (cross-compiled on Ubuntu) is never tested — unsigned binaries slip through undetected
3. **Fragile signing**: Cross-compiling requires `rcodesign` (10 MB download, SHA-256 verification, extra CI step) when native `codesign` is available on macOS

## Solution

Split the build pipeline with two new flags in `build-binary-sea.ts`:
- `--prepare-only`: Run esbuild + asset staging only (platform-independent). Output `.sea-staging/` directory.
- `--from-staging <dir>`: Skip esbuild, reuse a pre-built staging directory. Run fossilize + gzip only.

### New CI flow for nightlies

```
test (ubuntu)
  ├── Build linux-x64, smoke test
  ├── Run --prepare-only, upload .sea-staging/ artifact
  │
  ├──> build-nightly-binaries (ubuntu)
  │      Builds: linux-arm64, linux-x64, windows-x64
  │
  ├──> build-nightly-darwin (macos-14)  ← NEW
  │      Downloads staging artifact
  │      Runs fossilize natively (V8 code cache + native codesign)
  │      Smoke tests the actual binary
  │      Verifies ad-hoc code signature
  │      Uploads darwin artifacts
  │
  └──> generate-patches, publish-nightly
         Downloads from both artifact sets
```

### What the darwin binary gains

| Aspect | Before (cross-compiled) | After (native) |
|---|---|---|
| V8 code cache | None (`hostIsTarget=false`) | Yes (~15% faster startup) |
| Code signing | `rcodesign` (ad-hoc, extra dep) | Native `codesign` (ad-hoc, built-in) |
| `strip -x` | Fails (can't strip Mach-O on Linux) | Works natively |
| Smoke tested | Never (smoke test built its own binary) | Yes — same binary that's shipped |
| Signature verified | Never | `codesign -v --strict` + `Signature=adhoc` check |

### Build script changes

`build-binary-sea.ts` is refactored to support the split:
- `uploadSentrySourcemap()` extracted as a function
- `runFossilize()` extracted — handles fossilize invocation, rename, gzip
- `--from-staging` validates the staging dir has `sea-entry.cjs` and `asset-manifest.json`
- `--prepare-only` exits after esbuild + asset manifest + Sentry upload

### Release builds unchanged

Release builds still cross-compile all 4 platforms on Ubuntu with `rcodesign`. The macOS-native path is nightly-only for now — can be extended to releases when the extra macOS runner time is justified.