### PR TITLE
docs(site): fix 5 accuracy/sidebar issues from post-merge audit of #640

### DIFF
--- a/packages/website/astro.config.mjs
+++ b/packages/website/astro.config.mjs
@@ -52,7 +52,6 @@ export default defineConfig({
             { label: "Pi", slug: "docs/guides/with-pi" },
             { label: "Claude Code", slug: "docs/guides/with-claude-code" },
             { label: "Codex", slug: "docs/guides/with-codex" },
-            { label: "Setup command", slug: "docs/setup" },
             { label: "Custom upstreams", slug: "docs/guides/custom-upstreams" },
             { label: "Local inference", slug: "docs/guides/local-inference" },
           ],
@@ -62,6 +61,7 @@ export default defineConfig({
           items: [
             { label: "Configuration", slug: "docs/configuration" },
             { label: "Environment variables", slug: "docs/environment" },
+            { label: "Setup command", slug: "docs/setup" },
           ],
         },
       ],

--- a/packages/website/src/content/docs/docs/guides/with-codex.md
+++ b/packages/website/src/content/docs/docs/guides/with-codex.md
@@ -5,7 +5,7 @@ sidebar:
   order: 4
 ---
 
-[Codex](https://github.com/openai/codex) is OpenAI's terminal-based AI coding agent. Lore's gateway is the recommended way to run Codex with persistent memory and gradient context management.
+[Codex](https://github.com/openai/codex) is OpenAI's terminal-based AI coding agent. Lore's gateway is the recommended way to run Codex with persistent memory and gradient context management. For CLI users, `lore run` is the simplest path. For the Codex Desktop app — which can't accept `-c` CLI overrides — see [Setup command](../setup/).
 
 The Codex CLI is a Rust binary that does NOT read `OPENAI_BASE_URL` from the environment. Provider routing is done exclusively via `~/.codex/config.toml` or `-c` CLI overrides. The gateway uses `-c` overrides when launched via `lore run` so you do not have to edit the config file by hand.
 

--- a/packages/website/src/content/docs/docs/setup.md
+++ b/packages/website/src/content/docs/docs/setup.md
@@ -13,7 +13,7 @@ sidebar:
 - **Codex CLI without `lore run`** — if you'd rather start the gateway yourself and launch Codex directly (for example, in a long-running dev workflow where you don't want `lore run` to manage the gateway lifecycle), `lore setup codex` writes the same config.
 - **Remote gateway** — `lore setup codex -r http://remote:3207` writes a `config.toml` pointing at a non-default gateway URL, useful when the gateway runs on a different machine (Tailscale, LAN, a hosted deployment) and you want the local Codex client to talk to it.
 
-If you're using `lore run` with a CLI-based agent that reads env vars (OpenCode, Pi, Claude Code, Hermes Agent), you do **not** need `lore setup` — `lore run` injects the right env vars into the child process at launch.
+If you're using `lore run` with a CLI-based agent that reads env vars (OpenCode, Pi, Claude Code, Hermes Agent), you do **not** need `lore setup` — `lore run` injects the right env vars into the child process at launch. Codex is the exception on two counts: the Codex CLI does not read `OPENAI_BASE_URL` from env (only from `config.toml` or `-c` overrides), and Codex Desktop has no way to inject `-c` at all. `lore setup codex` writes the persistent config both need.
 
 ## Usage
 
@@ -24,7 +24,7 @@ lore setup codex -p 8080       # Configure Codex to talk to a gateway on a non-d
 lore setup codex -r http://remote:3207  # Configure Codex for a remote gateway
 ```
 
-If no app is given, `lore setup` scans `$PATH` for supported apps and configures whichever ones it finds. If nothing matches, it prints the supported app list and exits with a non-zero status — it never modifies a config file unless it found a matching installed app (or you passed an app name explicitly).
+If no app is given, `lore setup` scans `$PATH` for supported apps and configures whichever ones it finds. If nothing matches, it prints the supported app list and exits with a non-zero status — it never modifies a config file unless it found a matching installed app. When you pass an explicit app name, `setup` proceeds even if the binary is missing on `$PATH` (prints a warning and writes the config anyway). This is intentional so you can pre-configure Codex on a workstation where the binary lives elsewhere, or write the config before installing the binary.
 
 If the named app isn't installed (for example, `lore setup codex` on a machine without the Codex binary), the command prints a warning and proceeds with the configuration. The intent is to let you set up Codex on a workstation where the binary lives elsewhere, or to pre-configure before installing the binary.
 
@@ -36,7 +36,7 @@ If the named app isn't installed (for example, `lore setup codex` on a machine w
 
 `openai_base_url` is set to the gateway's `baseUrl`, normalized to end with `/v1` (required by Codex). The port defaults to `3207` (the first entry in `DEFAULT_PORTS`); override with `-p` or `-r`.
 
-`model_auto_compact_token_limit = 999999999` disables Codex's built-in auto-compaction so Lore's gradient context manager and distillation pipeline can do their job. If you re-run `lore setup`, this value is restored if you've changed it.
+`model_auto_compact_token_limit = 999999999` disables Codex's built-in auto-compaction so Lore's gradient context manager and distillation pipeline can do their job. Re-running `lore setup` resets this value to `999999999` — any custom value you set is overwritten.
 
 To remove the configuration and restore Codex's default behavior, delete the relevant lines from `~/.codex/config.toml` or run `git checkout -- ~/.codex/config.toml` if you keep the file under version control.
 
@@ -50,9 +50,11 @@ lore start
 
 In a second terminal, run Codex (or launch the Codex Desktop app). In the gateway's request log you should see requests originating from `127.0.0.1` with `model` set to your configured Codex model. If you see requests going to `api.openai.com` instead, the `config.toml` write was overridden — check that no other tool (Codex's own first-run wizard, a system service, a different shell profile) is writing to the file after `lore setup` runs.
 
+A quick check for override-by-another-tool: `stat -c '%y' ~/.codex/config.toml`. If the mtime updates after the next Codex Desktop launch and you didn't change anything, another tool is touching the file.
+
 ## Per-harness notes
 
-- **Codex Desktop** — `lore setup codex` is the **only** way to route the Desktop app through Lore (the app does not honor `-c` CLI overrides at launch). Run it once, leave the gateway running via `lore start` (or a system service), and the Desktop app routes correctly.
+- **Codex Desktop** — `lore setup codex` is the **only** way to route the Desktop app through Lore (the app does not honor `-c` CLI overrides at launch). Run it once, leave the gateway running via `lore start` (or a system service), and the Desktop app routes correctly. If the Desktop app overwrites or ignores your `config.toml`, run the gateway under a system service manager (`systemd`, `launchd`, etc.) so the URL stays stable. Check Codex's docs for a session-scoped override file at `~/.codex/sessions/<session-id>/config.toml` if your Codex version supports it.
 - **Codex CLI** — `lore run codex` is simpler than `lore setup codex` because it manages the gateway lifecycle and passes `-c` overrides per-invocation (no persisted config). Use `lore setup` only when you want to launch Codex without `lore run`.
 
 ## Next steps


### PR DESCRIPTION
## Summary

Post-merge audit of PR #640 (`docs(site): add Setup command page + trim duplicated Codex sections`) surfaced 5 issues. All fixed here in a single docs-only commit.

## What's fixed

**1. Lost Codex Desktop operational caveat (#643)** — PR #640's trim of `with-codex.md` silently dropped the recovery guidance for when the Codex Desktop app overwrites or ignores the `~/.codex/config.toml`. Restored in `setup.md` under 'Per-harness notes > Codex Desktop'. Added a `stat` snippet to 'Verifying the setup' for the override-by-another-tool case.

**2. 'When to use `lore setup`' mischaracterized Codex CLI (#644)** — The CLI also doesn't read `OPENAI_BASE_URL` from env (only `config.toml` or `-c` overrides). Rephrased to call out the CLI behavior explicitly so Codex's status as a special case is accurate.

**3. Auto-detect no-side-effects guarantee oversold (#644)** — Added a sentence clarifying that with an explicit app name and a missing binary, `setup` prints a warning and proceeds (so users can pre-configure Codex on a workstation where the binary lives elsewhere).

**4. `model_auto_compact_token_limit` restoration claim ambiguous (#644)** — Replaced 'this value is restored if you've changed it' with 'Re-running `lore setup` resets this value to `999999999` — any custom value you set is overwritten.' The original phrasing was unclear about whether 'restored' meant 'set back to default' or 'preserved at your value'.

**5. `Setup command` in the wrong sidebar group (#644)** — Moved from Guides to Reference (alongside `Configuration` and `Environment variables`). It's a CLI command reference, not a harness guide.

**Bonus: `with-codex.md` intro missing Codex Desktop mention (#644)** — Added a sentence so Codex Desktop users get pointed to the Setup command page from the per-harness guide.

## Out of scope

Issue #645 (add setup handlers for `opencode`/`pi`/`claude-code`/`hermes`) is a feature, not a docs fix. Deferred.

## Verification

* `pnpm run check:docs` — both generators report up-to-date
* `pnpm run check:links` — 0 real broken links; cross-links resolve
* `pnpm lint` — 0 errors, 13 pre-existing warnings

## Resolves

Closes #643, Closes #644