### PR TITLE
feat(gateway): add setup handlers for opencode + claude-code

### DIFF
--- a/packages/gateway/src/cli/setup.ts
+++ b/packages/gateway/src/cli/setup.ts
@@ -4,6 +4,10 @@
  * Currently supports:
  *   - codex: writes `openai_base_url` and `model_auto_compact_token_limit`
  *     to `~/.codex/config.toml`
+ *   - opencode: writes `provider.openai.options.baseURL` to
+ *     `~/.config/opencode/opencode.json`
+ *   - claude-code: writes `env.ANTHROPIC_BASE_URL` and `env.DISABLE_AUTO_COMPACT`
+ *     to `~/.claude/settings.json`
  *
  * The command auto-detects installed apps when no argument is given,
  * or accepts an explicit app name (e.g. `lore setup codex`).
@@ -31,6 +35,16 @@ const SUPPORTED_APPS: AppSetup[] = [
     agentName: "codex",
     displayName: "Codex",
     run: (baseUrl) => setupCodex(baseUrl),
+  },
+  {
+    agentName: "opencode",
+    displayName: "OpenCode",
+    run: (baseUrl) => setupOpencode(baseUrl),
+  },
+  {
+    agentName: "claude-code",
+    displayName: "Claude Code",
+    run: (baseUrl) => setupClaudeCode(baseUrl),
   },
 ];
 
@@ -219,6 +233,202 @@ function setupCodex(baseUrl: string): void {
   console.log(`[lore]`);
   console.log(
     `[lore] Make sure the gateway is running (lore start) before using Codex.`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// JSON config updater
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse JSON config, returning `{}` for missing files and an empty object
+ * for syntactically invalid files (with a warning). Callers should
+ * validate the resulting object structure before use.
+ */
+export function readJsonConfig(path: string): Record<string, unknown> {
+  try {
+    const raw = readFileSync(path, "utf8");
+    return JSON.parse(raw) as Record<string, unknown>;
+  } catch (e: unknown) {
+    const err = e as NodeJS.ErrnoException;
+    if (err.code === "ENOENT") return {};
+    console.warn(
+      `[lore] Warning: could not parse ${path} as JSON (${err.message}). Starting with empty config.`,
+    );
+    return {};
+  }
+}
+
+/**
+ * Update (or create) a JSON config file by deep-merging `updates` into the
+ * top-level object. Preserves all other keys, arrays, and nested objects.
+ *
+ * For object values, recursively merges. For primitive/array values, replaces
+ * (which matches the behavior we need for `env.ANTHROPIC_BASE_URL` and
+ * `provider.<id>.options.baseURL` — both should be string-typed).
+ *
+ * Writes a 2-space indented JSON file with a trailing newline.
+ */
+export function updateJsonConfig(
+  path: string,
+  updates: Record<string, unknown>,
+): void {
+  const existing = readJsonConfig(path);
+  const merged = deepMerge(existing, updates);
+  writeFileSync(path, `${JSON.stringify(merged, null, 2)}\n`, "utf8");
+}
+
+/**
+ * Recursively merge `b` into `a` (mutates `a` for object targets).
+ * Object values are merged key-by-key; all other values are replaced.
+ */
+function deepMerge(
+  a: Record<string, unknown>,
+  b: Record<string, unknown>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...a };
+  for (const [key, bVal] of Object.entries(b)) {
+    const aVal = out[key];
+    if (
+      aVal !== null &&
+      aVal !== undefined &&
+      typeof aVal === "object" &&
+      !Array.isArray(aVal) &&
+      bVal !== null &&
+      typeof bVal === "object" &&
+      !Array.isArray(bVal)
+    ) {
+      out[key] = deepMerge(
+        aVal as Record<string, unknown>,
+        bVal as Record<string, unknown>,
+      );
+    } else {
+      out[key] = bVal;
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// opencode setup
+// ---------------------------------------------------------------------------
+
+/** Path to the OpenCode user-level config file. */
+export function opencodeConfigPath(): string {
+  return join(homedir(), ".config", "opencode", "opencode.json");
+}
+
+/**
+ * Update (or create) the OpenCode user-level `opencode.json` to route the
+ * built-in `openai` provider through the Lore gateway, and disable
+ * OpenCode's built-in auto-compaction.
+ *
+ * Strategy:
+ * - Sets `provider.openai.options.baseURL` to the gateway URL (must include
+ *   `/v1` — OpenAI SDK convention used by OpenCode's OpenAI provider).
+ * - Sets `compaction.auto` to `false` so the Lore gradient context manager
+ *   and distillation pipeline are the source of truth.
+ * - Deep-merges with the existing config; preserves user-set custom
+ *   providers, themes, keybinds, and other settings.
+ * - Idempotent: running twice produces the same result.
+ */
+export function updateOpencodeConfig(
+  config: Record<string, unknown>,
+  baseUrl: string,
+): Record<string, unknown> {
+  return deepMerge(config, {
+    provider: {
+      openai: {
+        options: {
+          baseURL: baseUrl,
+        },
+      },
+    },
+    compaction: {
+      auto: false,
+    },
+  });
+}
+
+function setupOpencode(baseUrl: string): void {
+  const configPath = opencodeConfigPath();
+  const configDir = join(homedir(), ".config", "opencode");
+
+  mkdirSync(configDir, { recursive: true });
+
+  const existing = readJsonConfig(configPath);
+  const updated = updateOpencodeConfig(existing, baseUrl);
+  writeFileSync(configPath, `${JSON.stringify(updated, null, 2)}\n`, "utf8");
+
+  console.log(`[lore] OpenCode configured to use Lore gateway.`);
+  console.log(`[lore]   provider.openai.options.baseURL = "${baseUrl}"`);
+  console.log(`[lore]   compaction.auto = false (auto-compaction disabled)`);
+  console.log(`[lore]   Config: ${configPath}`);
+  console.log(`[lore]`);
+  console.log(
+    `[lore] Make sure the gateway is running (lore start) before using OpenCode.`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// claude-code setup
+// ---------------------------------------------------------------------------
+
+/** Path to the Claude Code user-level settings file. */
+export function claudeCodeSettingsPath(): string {
+  return join(homedir(), ".claude", "settings.json");
+}
+
+/**
+ * Update (or create) the Claude Code user-level `settings.json` to route
+ * through the Lore gateway.
+ *
+ * Strategy:
+ * - Sets `env.ANTHROPIC_BASE_URL` to the gateway URL (NOT including `/v1` —
+ *   Claude Code appends `/v1/messages` itself per the Anthropic SDK
+ *   convention).
+ * - Sets `env.DISABLE_AUTO_COMPACT` to `"1"` so the Lore gradient
+ *   context manager and distillation pipeline are the source of truth.
+ * - Deep-merges with the existing settings; preserves permissions,
+ *   hooks, model overrides, and other env vars.
+ * - Idempotent: running twice produces the same result.
+ */
+export function updateClaudeCodeSettings(
+  config: Record<string, unknown>,
+  gatewayUrl: string,
+): Record<string, unknown> {
+  return deepMerge(config, {
+    env: {
+      ANTHROPIC_BASE_URL: gatewayUrl,
+      DISABLE_AUTO_COMPACT: "1",
+    },
+  });
+}
+
+function setupClaudeCode(baseUrl: string): void {
+  const configPath = claudeCodeSettingsPath();
+  const configDir = join(homedir(), ".claude");
+
+  mkdirSync(configDir, { recursive: true });
+
+  // Strip the /v1 suffix — Claude Code appends /v1/messages itself.
+  const anthropicBaseUrl = baseUrl.endsWith("/v1")
+    ? baseUrl.slice(0, -3)
+    : baseUrl;
+
+  const existing = readJsonConfig(configPath);
+  const updated = updateClaudeCodeSettings(existing, anthropicBaseUrl);
+  writeFileSync(configPath, `${JSON.stringify(updated, null, 2)}\n`, "utf8");
+
+  console.log(`[lore] Claude Code configured to use Lore gateway.`);
+  console.log(`[lore]   env.ANTHROPIC_BASE_URL = "${anthropicBaseUrl}"`);
+  console.log(
+    `[lore]   env.DISABLE_AUTO_COMPACT = "1" (auto-compaction disabled)`,
+  );
+  console.log(`[lore]   Config: ${configPath}`);
+  console.log(`[lore]`);
+  console.log(
+    `[lore] Make sure the gateway is running (lore start) before using Claude Code.`,
   );
 }
 

--- a/packages/gateway/test/setup.test.ts
+++ b/packages/gateway/test/setup.test.ts
@@ -3,6 +3,8 @@ import {
   updateCodexConfig,
   normalizeBaseUrl,
   setTopLevelKey,
+  updateOpencodeConfig,
+  updateClaudeCodeSettings,
 } from "../src/cli/setup";
 
 // ---------------------------------------------------------------------------
@@ -372,5 +374,114 @@ describe("setTopLevelKey", () => {
     const first = setTopLevelKey("", "my_key", "42");
     const second = setTopLevelKey(first, "my_key", "42");
     expect(second).toBe(first);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateOpencodeConfig
+// ---------------------------------------------------------------------------
+
+describe("updateOpencodeConfig", () => {
+  test("sets provider.openai.options.baseURL and disables compaction on empty config", () => {
+    const result = updateOpencodeConfig({}, "http://127.0.0.1:3207/v1");
+    expect(result).toEqual({
+      provider: {
+        openai: {
+          options: {
+            baseURL: "http://127.0.0.1:3207/v1",
+          },
+        },
+      },
+      compaction: {
+        auto: false,
+      },
+    });
+  });
+
+  test("preserves existing user settings (custom providers, themes, keybinds)", () => {
+    const existing = {
+      theme: "dark",
+      keybinds: { leader: "ctrl+x" },
+      provider: {
+        anthropic: {
+          options: { baseURL: "https://example.com" },
+        },
+      },
+    };
+    const result = updateOpencodeConfig(existing, "http://127.0.0.1:3207/v1");
+    expect(result.theme).toBe("dark");
+    expect(result.keybinds).toEqual({ leader: "ctrl+x" });
+    expect(result.provider).toEqual({
+      anthropic: {
+        options: { baseURL: "https://example.com" },
+      },
+      openai: {
+        options: { baseURL: "http://127.0.0.1:3207/v1" },
+      },
+    });
+  });
+
+  test("is idempotent", () => {
+    const first = updateOpencodeConfig({}, "http://127.0.0.1:3207/v1");
+    const second = updateOpencodeConfig(first, "http://127.0.0.1:3207/v1");
+    expect(second).toEqual(first);
+  });
+
+  test("replaces baseURL when re-run with a different value", () => {
+    const first = updateOpencodeConfig({}, "http://old:3207/v1");
+    const second = updateOpencodeConfig(first, "http://new:3207/v1");
+    expect(second.provider?.openai?.options?.baseURL).toBe(
+      "http://new:3207/v1",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateClaudeCodeSettings
+// ---------------------------------------------------------------------------
+
+describe("updateClaudeCodeSettings", () => {
+  test("sets env.ANTHROPIC_BASE_URL and DISABLE_AUTO_COMPACT on empty config", () => {
+    const result = updateClaudeCodeSettings({}, "http://127.0.0.1:3207");
+    expect(result).toEqual({
+      env: {
+        ANTHROPIC_BASE_URL: "http://127.0.0.1:3207",
+        DISABLE_AUTO_COMPACT: "1",
+      },
+    });
+  });
+
+  test("strips trailing /v1 from the Anthropic base URL", () => {
+    // The setupClaudeCode wrapper strips /v1 before calling, but the
+    // helper itself accepts whatever the caller passes. The wrapper
+    // contract is what matters here.
+    const result = updateClaudeCodeSettings({}, "http://127.0.0.1:3207/v1");
+    // We document the wrapper strips /v1; the helper does not.
+    // This test documents the helper's raw behavior.
+    expect(result.env?.ANTHROPIC_BASE_URL).toBe("http://127.0.0.1:3207/v1");
+  });
+
+  test("preserves existing user settings (permissions, hooks, model)", () => {
+    const existing = {
+      permissions: { allow: ["Read"] },
+      hooks: { PreToolUse: [] },
+      model: "claude-opus-4-20250514",
+      env: { OTHER_VAR: "value" },
+    };
+    const result = updateClaudeCodeSettings(existing, "http://127.0.0.1:3207");
+    expect(result.permissions).toEqual({ allow: ["Read"] });
+    expect(result.hooks).toEqual({ PreToolUse: [] });
+    expect(result.model).toBe("claude-opus-4-20250514");
+    expect(result.env).toEqual({
+      OTHER_VAR: "value",
+      ANTHROPIC_BASE_URL: "http://127.0.0.1:3207",
+      DISABLE_AUTO_COMPACT: "1",
+    });
+  });
+
+  test("is idempotent", () => {
+    const first = updateClaudeCodeSettings({}, "http://127.0.0.1:3207");
+    const second = updateClaudeCodeSettings(first, "http://127.0.0.1:3207");
+    expect(second).toEqual(first);
   });
 });

--- a/packages/gateway/test/setup.test.ts
+++ b/packages/gateway/test/setup.test.ts
@@ -428,8 +428,12 @@ describe("updateOpencodeConfig", () => {
   });
 
   test("replaces baseURL when re-run with a different value", () => {
-    const first = updateOpencodeConfig({}, "http://old:3207/v1");
-    const second = updateOpencodeConfig(first, "http://new:3207/v1");
+    const first = updateOpencodeConfig({}, "http://old:3207/v1") as {
+      provider?: { openai?: { options?: { baseURL?: string } } };
+    };
+    const second = updateOpencodeConfig(first, "http://new:3207/v1") as {
+      provider?: { openai?: { options?: { baseURL?: string } } };
+    };
     expect(second.provider?.openai?.options?.baseURL).toBe(
       "http://new:3207/v1",
     );
@@ -455,7 +459,9 @@ describe("updateClaudeCodeSettings", () => {
     // The setupClaudeCode wrapper strips /v1 before calling, but the
     // helper itself accepts whatever the caller passes. The wrapper
     // contract is what matters here.
-    const result = updateClaudeCodeSettings({}, "http://127.0.0.1:3207/v1");
+    const result = updateClaudeCodeSettings({}, "http://127.0.0.1:3207/v1") as {
+      env?: { ANTHROPIC_BASE_URL?: string };
+    };
     // We document the wrapper strips /v1; the helper does not.
     // This test documents the helper's raw behavior.
     expect(result.env?.ANTHROPIC_BASE_URL).toBe("http://127.0.0.1:3207/v1");

--- a/packages/website/src/content/docs/docs/setup.md
+++ b/packages/website/src/content/docs/docs/setup.md
@@ -11,15 +11,19 @@ sidebar:
 
 - **Codex Desktop** — the Desktop app does not accept `-c` CLI overrides at launch and has no obvious way to inject a custom `openai_base_url` through its UI. `lore setup codex` writes `~/.codex/config.toml` once and the Desktop app picks it up on next launch. This is the **recommended** path for Codex Desktop.
 - **Codex CLI without `lore run`** — if you'd rather start the gateway yourself and launch Codex directly (for example, in a long-running dev workflow where you don't want `lore run` to manage the gateway lifecycle), `lore setup codex` writes the same config.
-- **Remote gateway** — `lore setup codex -r http://remote:3207` writes a `config.toml` pointing at a non-default gateway URL, useful when the gateway runs on a different machine (Tailscale, LAN, a hosted deployment) and you want the local Codex client to talk to it.
+- **OpenCode without `lore run`** — `lore setup opencode` writes `~/.config/opencode/opencode.json` with the gateway URL and disables OpenCode's built-in auto-compaction.
+- **Claude Code without `lore run`** — `lore setup claude-code` writes `~/.claude/settings.json` with `env.ANTHROPIC_BASE_URL` and `env.DISABLE_AUTO_COMPACT`.
+- **Remote gateway** — `lore setup <app> -r http://remote:3207` writes the config pointing at a non-default gateway URL, useful when the gateway runs on a different machine (Tailscale, LAN, a hosted deployment) and you want the local client to talk to it.
 
-If you're using `lore run` with a CLI-based agent that reads env vars (OpenCode, Pi, Claude Code, Hermes Agent), you do **not** need `lore setup` — `lore run` injects the right env vars into the child process at launch. Codex is the exception on two counts: the Codex CLI does not read `OPENAI_BASE_URL` from env (only from `config.toml` or `-c` overrides), and Codex Desktop has no way to inject `-c` at all. `lore setup codex` writes the persistent config both need.
+If you're using `lore run` with a CLI-based agent that reads env vars (Pi, Hermes Agent), you do **not** need `lore setup` — `lore run` injects the right env vars into the child process at launch. Codex, OpenCode, and Claude Code are the exceptions: each reads provider config from its own config file rather than env vars at launch. `lore setup <app>` writes the persistent config they need so you can launch them directly without going through `lore run`.
 
 ## Usage
 
 ```bash
 lore setup                     # Auto-detect installed supported apps and configure them
 lore setup codex               # Configure Codex explicitly
+lore setup opencode            # Configure OpenCode explicitly
+lore setup claude-code         # Configure Claude Code explicitly
 lore setup codex -p 8080       # Configure Codex to talk to a gateway on a non-default port
 lore setup codex -r http://remote:3207  # Configure Codex for a remote gateway
 ```
@@ -33,6 +37,8 @@ If the named app isn't installed (for example, `lore setup codex` on a machine w
 | App          | Config written                                                            | Notes                                                                                       |
 | ------------ | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
 | `codex`      | `~/.codex/config.toml` (with `openai_base_url` + `model_auto_compact_token_limit`) | Required for Codex Desktop. Idempotent — re-running updates existing fields without losing other settings. |
+| `opencode`   | `~/.config/opencode/opencode.json` (with `provider.openai.options.baseURL` + `compaction.auto: false`) | Sets the built-in `openai` provider's `baseURL` and disables OpenCode's auto-compaction. Deep-merges with existing config (preserves custom providers, themes, keybinds). |
+| `claude-code`| `~/.claude/settings.json` (with `env.ANTHROPIC_BASE_URL` + `env.DISABLE_AUTO_COMPACT`) | The Anthropic base URL is written without the `/v1` suffix — Claude Code appends `/v1/messages` itself. Deep-merges with existing settings (preserves permissions, hooks, model overrides). |
 
 `openai_base_url` is set to the gateway's `baseUrl`, normalized to end with `/v1` (required by Codex). The port defaults to `3207` (the first entry in `DEFAULT_PORTS`); override with `-p` or `-r`.
 
@@ -56,6 +62,8 @@ A quick check for override-by-another-tool: `stat -c '%y' ~/.codex/config.toml`.
 
 - **Codex Desktop** — `lore setup codex` is the **only** way to route the Desktop app through Lore (the app does not honor `-c` CLI overrides at launch). Run it once, leave the gateway running via `lore start` (or a system service), and the Desktop app routes correctly. If the Desktop app overwrites or ignores your `config.toml`, run the gateway under a system service manager (`systemd`, `launchd`, etc.) so the URL stays stable. Check Codex's docs for a session-scoped override file at `~/.codex/sessions/<session-id>/config.toml` if your Codex version supports it.
 - **Codex CLI** — `lore run codex` is simpler than `lore setup codex` because it manages the gateway lifecycle and passes `-c` overrides per-invocation (no persisted config). Use `lore setup` only when you want to launch Codex without `lore run`.
+- **OpenCode** — `lore setup opencode` writes `provider.openai.options.baseURL` to `~/.config/opencode/opencode.json`. If you have a custom OpenAI provider configured (e.g. `provider.openrouter`), the helper only updates the built-in `openai` provider — your custom providers are preserved. The compaction setting is also disabled by default; you can re-enable it in the same file if you want.
+- **Claude Code** — `lore setup claude-code` writes `env.ANTHROPIC_BASE_URL` (without the `/v1` suffix) to `~/.claude/settings.json`. The Anthropic SDK appends `/v1/messages` itself, so the gateway URL must not have `/v1`. If you have a project-level `.claude/settings.local.json`, that file overrides the user-level one — re-run `lore setup` after editing the project-level file.
 
 ## Next steps
 


### PR DESCRIPTION
## Summary

Implements `lore setup` handlers for **opencode** and **claude-code**. Pi + Hermes are deferred to follow-ups (#648, #649) because they have different config formats requiring new dependencies.

Closes part of #645.

## What's in this PR

**1. JSON config updater (`packages/gateway/src/cli/setup.ts`)**

Reusable `readJsonConfig` / `updateJsonConfig` / `deepMerge` triplet that mirrors the existing `setTopLevelKey` / `updateCodexConfig` pattern for Codex's TOML config. Uses only built-in `JSON.parse`/`JSON.stringify` — no new deps.

**2. `setup opencode`**

Writes `~/.config/opencode/opencode.json`:

```json
{
  "provider": {
    "openai": {
      "options": { "baseURL": "<gateway>/v1" }
    }
  },
  "compaction": { "auto": false }
}
```

Deep-merges with the existing config — preserves custom providers, themes, keybinds.

**3. `setup claude-code`**

Writes `~/.claude/settings.json`:

```json
{
  "env": {
    "ANTHROPIC_BASE_URL": "<gateway>",
    "DISABLE_AUTO_COMPACT": "1"
  }
}
```

**Note**: `ANTHROPIC_BASE_URL` is written **without** the `/v1` suffix — Claude Code appends `/v1/messages` itself per the Anthropic SDK convention. (This is the inverse of Codex/opencode which require `/v1`.)

**4. 8 new tests in `packages/gateway/test/setup.test.ts`** (36 → 44 total, all pass).

**5. `docs/setup.md` updates**: added opencode + claude-code to the when-to-use, supported apps, and per-harness notes sections.

## Deferred (filed as follow-ups)

- **#648**: `feat(setup): add setup handlers for pi and hermes` — pi uses `~/.pi/agent/models.json` (JSON, no new dep), hermes uses `~/.hermes/config.yaml` (YAML, needs `js-yaml`).
- **#649**: `fix(gateway): investigate HERMES_INFERENCE_PROVIDER=custom env var in agents.ts:208` — env var is not in the official Hermes docs and may be a no-op.

## Verification

* `pnpm run check:docs` — both generators report up-to-date
* `pnpm run check:links` — 0 real broken links
* `pnpm lint` — 0 errors, 13 pre-existing warnings
* `vitest run packages/gateway/test/setup.test.ts` — **44/44 pass** (36 pre-existing + 8 new)
* `vitest run packages/gateway/test/` (full gateway suite) — 1214 pass, **10 fail**
  * The 10 failures are **pre-existing on `origin/main`** (verified by stashing the changes and re-running). The failures are in `replay.test.ts`, `recall-openai-stream.test.ts`, and `remote-attribution.test.ts` — all related to a separate `pipeline.ts:639` config-loading bug (`Cannot read properties of undefined (reading 'enabled')`), not to any of my changes. Filed as a follow-up if it isn't already tracked.

## Resolves

Part of #645 (opencode + claude-code complete; pi + hermes deferred)