### PR TITLE
fix(test): move vitest resolve.alias to top level so tests use source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
               - 'tsconfig*.json'
+              - 'vitest.config.ts'
+              - 'vitest.evals.config.ts'
               - 'package.json'
               - 'biome.json'
               - '.craft.yml'

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,17 @@ import { defineConfig } from "vitest/config";
 import path from "node:path";
 
 export default defineConfig({
+  // Alias @loreai/core and @loreai/gateway for test imports.
+  // MUST be at the top level of the vite config — putting this under
+  // `test.resolve.alias` does NOT work (vite's resolver is a top-level
+  // option, not a test.* option). The previous placement silently
+  // resolved to the stale dist build, masking real test failures.
+  resolve: {
+    alias: {
+      "@loreai/core": path.resolve(__dirname, "packages/core/src"),
+      "@loreai/gateway": path.resolve(__dirname, "packages/gateway/src"),
+    },
+  },
   test: {
     // Run all packages' tests
     include: [
@@ -34,13 +45,6 @@ export default defineConfig({
         "**/script/**",
         "**/dist/**",
       ],
-    },
-    // Alias @loreai/core and @loreai/gateway for test imports
-    resolve: {
-      alias: {
-        "@loreai/core": path.resolve(__dirname, "packages/core/src"),
-        "@loreai/gateway": path.resolve(__dirname, "packages/gateway/src"),
-      },
     },
   },
 });


### PR DESCRIPTION
## Summary

Fixes 10 pre-existing test failures in `replay.test.ts`, `recall-openai-stream.test.ts`, and `remote-attribution.test.ts` — all the same root cause.

## Root cause

`vitest.config.ts` placed the `@loreai/core` / `@loreai/gateway` aliases **inside `test.resolve.alias`**. Vite's module resolver is a **top-level** config option — the `test.*` block is for test-runner options (timeout, env, include patterns), not module resolution. The misplaced alias was silently ignored, so vitest tests were resolving `@loreai/core` to the **stale dist build** at `packages/core/dist/node/index.js` instead of the TypeScript source at `packages/core/src`.

## Why this caused 10 failures

The dist build was compiled **before** `loreFile` was added to the schema in PR #637 (`feat(core,gateway): add loreFile.enabled config toggle`). The 10 pre-existing failures were all the same TypeError:

```
TypeError: Cannot read properties of undefined (reading 'enabled')
    at tryImportKnowledge (pipeline.ts:639:22)
    at startKnowledgeFileWatcher (pipeline.ts:696:20)
```

The pipeline reads `cfg.loreFile.enabled` at `packages/gateway/src/pipeline.ts:639` and `pipeline.ts:696`. The stale dist build didn't have `loreFile` in its Zod schema, so `cfg.loreFile` was `undefined`. Tests crashed with 502 because `server.ts:170` wraps any pipeline TypeError as a 502.

## Fix

Move `resolve.alias` from inside `test.*` to the top level of `defineConfig`. Add a comment explaining the trap so future contributors don't move it back.

## Verification

* `vitest run packages/` — **90 test files, 2458 pass, 0 fail, 6 skipped** (was: 10 fail / 1206 pass in affected packages)
* `pnpm run typecheck` — clean
* `pnpm lint` — clean (13 pre-existing warnings, 0 errors)

Confirmed by inspection: `@loreai/core` now resolves to `packages/core/src/index.ts` (was: `packages/core/dist/node/index.js`).

## Test plan

Re-running CI on this PR will exercise the full test suite against the corrected alias and should pass all previously-failing tests.