### PR TITLE
fix(deps): patch transitive yaml@2.7.1 (CVE-2026-33532) via pnpm override

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,14 @@
     "onlyBuiltDependencies": [
       "esbuild",
       "sharp"
-    ]
+    ],
+    "overrides": {
+      "basic-ftp": "5.3.1",
+      "ip-address": "10.2.0",
+      "fast-xml-parser": "5.7.3",
+      "@huggingface/hub": "2.11.0",
+      "yaml": ">=2.8.3"
+    }
   },
   "scripts": {
     "typecheck": "pnpm -r run typecheck",
@@ -47,12 +54,6 @@
     "url": "git+https://github.com/BYK/loreai.git"
   },
   "author": "BYK",
-  "overrides": {
-    "basic-ftp": "5.3.1",
-    "ip-address": "10.2.0",
-    "fast-xml-parser": "5.7.3",
-    "@huggingface/hub": "2.11.0"
-  },
   "workspaces": [
     "packages/*"
   ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,13 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  basic-ftp: 5.3.1
+  ip-address: 10.2.0
+  fast-xml-parser: 5.7.3
+  '@huggingface/hub': 2.11.0
+  yaml: '>=2.8.3'
+
 importers:
 
   .:
@@ -3571,7 +3578,7 @@ packages:
       sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
-      yaml: ^2.4.2
+      yaml: '>=2.8.3'
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -3816,11 +3823,6 @@ packages:
 
   yaml-language-server@1.20.0:
     resolution: {integrity: sha512-qhjK/bzSRZ6HtTvgeFvjNPJGWdZ0+x5NREV/9XZWFjIGezew2b4r5JPy66IfOhd5OA7KeFwk1JfmEbnTvev0cA==}
-    hasBin: true
-
-  yaml@2.7.1:
-    resolution: {integrity: sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==}
-    engines: {node: '>= 14'}
     hasBin: true
 
   yaml@2.9.0:
@@ -8151,9 +8153,7 @@ snapshots:
       vscode-languageserver-textdocument: 1.0.12
       vscode-languageserver-types: 3.18.0
       vscode-uri: 3.1.0
-      yaml: 2.7.1
-
-  yaml@2.7.1: {}
+      yaml: 2.9.0
 
   yaml@2.9.0: {}
 


### PR DESCRIPTION
## Summary

Fixes Dependabot alert #2 (CVE-2026-33532) — `yaml@2.7.1` is vulnerable to stack overflow via deeply nested YAML collections.

### Root cause

`yaml@2.7.1` was a transitive dependency pulled in by the Astro website toolchain:
```
@astrojs/check → @astrojs/language-server → volar-service-yaml@0.0.70 (pinned) → yaml-language-server@1.20.0 → yaml@2.7.1
```

The natural upgrade is blocked upstream: `@astrojs/language-server@2.16.10` (latest) hardcodes `volar-service-yaml@0.0.70`.

### Fix

Add `yaml: ">=2.8.3"` to `pnpm.overrides` in root `package.json`. Since `yaml` is never imported in our source code and the only other consumer already used `yaml@2.9.0`, a direct override is safe.

### Bonus fix

The existing 4 override entries (`basic-ftp`, `ip-address`, `fast-xml-parser`, `@huggingface/hub`) were at the top-level `overrides` key. **pnpm v10 ignores the top-level location** — it expects `pnpm.overrides`. Moved them to the correct location so they actually take effect.

## Verification

- `pnpm install` succeeds; `yaml@2.7.1` is gone from `pnpm-lock.yaml`
- `pnpm -r run typecheck` passes for all packages
- `pnpm test` — pre-existing failure unrelated to this change (vitest can't resolve `node:sqlite` in this env; confirmed identical on base branch)

## Notes

- The `feat(core,gateway): add loreFile.enabled config toggle` commit is also on this branch (it was already pushed as part of an in-progress branch).

🤖 Generated with [Claude Code](https://claude.ai/code)