### PR TITLE
ci(publish): pin Craft to 2.26.5 to fix silent publish failure

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,10 +55,13 @@ jobs:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
 
+      # Pin to a specific Craft version to avoid upstream regressions.
+      # Craft 2.26.6+ hangs during artifact extraction — see #648.
       - name: Install Craft
+        env:
+          CRAFT_VERSION: '2.26.5'
         run: |
-          CRAFT_URL=$(curl -fsSL https://api.github.com/repos/getsentry/craft/releases/latest \
-            | jq -r '.assets[] | select(.name == "craft") | .browser_download_url')
+          CRAFT_URL="https://github.com/getsentry/craft/releases/download/${CRAFT_VERSION}/craft"
           sudo curl -fsSL -o /usr/local/bin/craft "$CRAFT_URL"
           sudo chmod +x /usr/local/bin/craft
 


### PR DESCRIPTION
## Problem

The 0.25.0 publish workflow completed successfully (exit 0) but **published nothing** — no npm packages, no GitHub Release. The workflow silently closed the publish issue as "success".

### Root cause

`publish.yml` downloads the **latest** Craft binary. Craft 2.26.6+ (released June 4–5) introduced a regression where artifact extraction hangs or silently exits after downloading. The last successful publish (0.24.1 on May 22) used Craft 2.26.5.

Reproduced locally: Craft 2.26.8 with Node 24 hangs indefinitely after `Downloaded 3 artifacts.` — no further output, no error.

## Fix

Pin the Craft binary to 2.26.5 (last known working version) instead of always fetching the latest release. This prevents future upstream Craft regressions from breaking our publish workflow.

## Re-publishing 0.25.0

After this merges, re-run the release workflow:
```bash
gh workflow run release.yml -f version=0.25.0
```