### PR TITLE
fix(ci): include hidden files in sea-staging artifact upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,6 +329,8 @@ jobs:
         with:
           name: sea-staging
           path: packages/gateway/.sea-staging/
+          # .sea-staging is a dot-prefixed (hidden) directory
+          include-hidden-files: true
 
       # -----------------------------------------------------------------
       # Release: build all packages + pack tarballs + multi-platform binaries


### PR DESCRIPTION
## Problem

The `build-nightly-darwin` job fails with:
```
Unable to download artifact(s): Artifact not found for name: sea-staging
```

## Root cause

`upload-artifact@v7` defaults to `include-hidden-files: false`. The staging directory is `.sea-staging/` (dot-prefixed = hidden), so the upload silently produces an empty artifact — the step reports success but no files are uploaded.

## Fix

Add `include-hidden-files: true` to the staging artifact upload step.