### PR TITLE
fix(gateway): address self-review findings in setup plugin install

### DIFF
--- a/packages/gateway/src/cli/help.ts
+++ b/packages/gateway/src/cli/help.ts
@@ -18,7 +18,7 @@ Commands:
                        setups — path-less sessions route to per-session buckets
                        so unrelated projects never merge onto the gateway cwd.
   setup [app]         Configure an AI app to route through lore
-                       Supported: codex
+                       Supported: codex, opencode, claude-code
   logs                Show lore activity log
   import              Import knowledge from prior AI agent conversations
   data <subcommand>   Manage stored data (list, show, clear, delete)

--- a/packages/gateway/src/cli/setup.ts
+++ b/packages/gateway/src/cli/setup.ts
@@ -32,11 +32,6 @@ interface PluginSpec {
   /** npm package name (e.g. `@loreai/opencode`) */
   npmPackage: string;
   /**
-   * Path to the agent's plugin array in its config (e.g. `["plugin"]`).
-   * The plugin is appended if absent, kept in place if present.
-   */
-  registerConfigPath: string[];
-  /**
    * Apply the plugin to the parsed config (mutates the config in place).
    * Returns true if the config was modified.
    */
@@ -63,7 +58,6 @@ interface AppSetup {
  */
 export const opencodePluginSpec: PluginSpec = {
   npmPackage: "@loreai/opencode",
-  registerConfigPath: ["plugin"],
   apply: (config) => {
     const existing = config.plugin;
     if (Array.isArray(existing) && existing.includes("@loreai/opencode")) {
@@ -547,8 +541,8 @@ function setupOpencode(baseUrl: string, noPlugin: boolean): void {
     return;
   }
 
-  if (opencodePluginSpec) {
-    installPlugin(opencodePluginSpec, configPath);
+  if (!installPlugin(opencodePluginSpec, configPath)) {
+    process.exitCode = 1;
   }
 }
 

--- a/packages/gateway/test/setup.test.ts
+++ b/packages/gateway/test/setup.test.ts
@@ -498,9 +498,8 @@ describe("updateClaudeCodeSettings", () => {
 // ---------------------------------------------------------------------------
 
 describe("opencodePluginSpec", () => {
-  test("has expected package name and registration target", () => {
+  test("has expected package name", () => {
     expect(opencodePluginSpec.npmPackage).toBe("@loreai/opencode");
-    expect(opencodePluginSpec.registerConfigPath).toEqual(["plugin"]);
   });
 
   test("adds plugin to empty config", () => {


### PR DESCRIPTION
## Summary

Four fixes from critical self-review of PR #658 (`feat(gateway): auto-install @loreai/opencode plugin in lore setup opencode`).

## Changes

1. **Help text stale app list** — `lore help` listed only `Supported: codex` for the `setup` command. Updated to `codex, opencode, claude-code` to match `SUPPORTED_APPS`. User-facing bug — anyone running `lore help` wouldn't know opencode and claude-code are supported.

2. **Dead `registerConfigPath` field** — `PluginSpec.registerConfigPath` was declared, populated (`["plugin"]`), and asserted in tests, but never read by any runtime code. `apply()` accesses `config.plugin` directly. Removed from the interface, the spec, and the test assertion.

3. **Always-truthy guard** — `if (opencodePluginSpec) { installPlugin(...) }` guarded a module-level `const` that is always truthy. Replaced with a direct call.

4. **Discarded return value** — `installPlugin()` returns `boolean` indicating success/failure, but the caller discarded it. Now `process.exitCode = 1` is set on failure, signaling partial setup to the user's shell. The gateway-URL config write still completes — half a setup is better than no setup.

## Verification

- `pnpm run typecheck` — clean
- `vitest run packages/gateway/test/setup.test.ts` — 49/49 pass
- `pnpm lint` — clean

## Related

- PR #658 — the original implementation this fixes