### PR TITLE
fix(website): lead with install CTA, demote Folk Lore waitlist

### DIFF
--- a/packages/website/public/theme.css
+++ b/packages/website/public/theme.css
@@ -345,6 +345,18 @@ h1 em::after {
   flex-wrap: wrap;
 }
 
+.hero-folklore {
+  margin-top: 1.4rem;
+  font-size: .8rem;
+  color: var(--mid);
+}
+.hero-folklore a {
+  color: var(--mid);
+  border-bottom: 1px solid var(--g4);
+  transition: color .2s;
+}
+.hero-folklore a:hover { color: var(--g1); }
+
 .btn-fill {
   display: inline-flex;
   align-items: center;

--- a/packages/website/src/content/docs/docs/index.md
+++ b/packages/website/src/content/docs/docs/index.md
@@ -25,6 +25,6 @@ Lore is a local-first memory layer for AI coding agents. It captures conversatio
 
 ## Site Sections
 
-- [Home](index.html) introduces the product and waitlist.
+- [Home](index.html) introduces the product and Folk Lore early access signup.
 - [Why Lore](different.html) compares Lore to memory-only and context-only approaches.
 - [Blog](blog.html) is ready for essays, release notes, and engineering writeups.

--- a/packages/website/src/pages/different.astro
+++ b/packages/website/src/pages/different.astro
@@ -43,7 +43,7 @@ import Logo from "../components/Logo.astro";
         <a href="https://x.com/withLoreAI" target="_blank" rel="noopener noreferrer" class="social-link" aria-label="Lore.AI on X"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18.901 1.153h3.68l-8.04 9.19L24 22.846h-7.406l-5.8-7.584-6.638 7.584H.474l8.6-9.83L0 1.154h7.594l5.243 6.932ZM17.61 20.644h2.039L6.486 3.24H4.298Z" /></svg></a>
         <a href="https://github.com/byk/loreai" target="_blank" rel="noopener noreferrer" class="social-link" aria-label="Lore.AI on GitHub"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.043-1.61-4.043-1.61-.546-1.387-1.333-1.757-1.333-1.757-1.09-.745.083-.73.083-.73 1.205.085 1.84 1.237 1.84 1.237 1.07 1.835 2.807 1.305 3.492.998.108-.776.418-1.305.762-1.605-2.665-.3-5.467-1.332-5.467-5.93 0-1.31.468-2.38 1.235-3.22-.123-.303-.535-1.523.118-3.176 0 0 1.008-.322 3.3 1.23a11.48 11.48 0 0 1 3.003-.404c1.02.005 2.045.138 3.003.404 2.29-1.552 3.295-1.23 3.295-1.23.655 1.653.243 2.873.12 3.176.77.84 1.233 1.91 1.233 3.22 0 4.61-2.807 5.625-5.48 5.922.43.372.823 1.102.823 2.222 0 1.605-.015 2.898-.015 3.293 0 .32.218.695.825.577C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" /></svg></a>
       </div>
-      <a href="index.html#waitlist" class="nav-btn">Folk Lore Waitlist</a>
+      <a href="index.html#waitlist" class="nav-btn">Folk Lore</a>
     </div>
   </nav>
 
@@ -63,8 +63,8 @@ import Logo from "../components/Logo.astro";
         <strong style="color:var(--g1);">Only one scales.</strong>
       </p>
       <div class="hero-actions sr" style="justify-content: center;">
-        <a href="index.html#waitlist" class="btn-fill">
-          Join the Waitlist
+        <a href="docs.html" class="btn-fill">
+          Get Started
           <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.8">
             <path d="M2 7h10M7 2l5 5-5 5" />
           </svg>
@@ -72,6 +72,7 @@ import Logo from "../components/Logo.astro";
         <a href="https://github.com/byk/loreai" target="_blank" rel="noopener noreferrer" class="btn-ghost">View Repository</a>
         <a href="docs.html" class="btn-ghost">Read Docs</a>
       </div>
+      <p class="hero-folklore sr" style="text-align: center;">Building with a team? <a href="index.html#waitlist"><strong>Folk Lore</strong> — shared team memory, coming soon &rarr;</a></p>
     </div>
   </section>
 

--- a/packages/website/src/pages/different.astro
+++ b/packages/website/src/pages/different.astro
@@ -38,12 +38,13 @@ import Logo from "../components/Logo.astro";
         <li><a href="different.html">Why Lore</a></li>
         <li><a href="docs.html">Docs</a></li>
         <li><a href="blog.html">Blog</a></li>
+        <li><a href="index.html#waitlist">Folk Lore</a></li>
       </ul>
       <div class="nav-socials" aria-label="Social links">
         <a href="https://x.com/withLoreAI" target="_blank" rel="noopener noreferrer" class="social-link" aria-label="Lore.AI on X"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18.901 1.153h3.68l-8.04 9.19L24 22.846h-7.406l-5.8-7.584-6.638 7.584H.474l8.6-9.83L0 1.154h7.594l5.243 6.932ZM17.61 20.644h2.039L6.486 3.24H4.298Z" /></svg></a>
         <a href="https://github.com/byk/loreai" target="_blank" rel="noopener noreferrer" class="social-link" aria-label="Lore.AI on GitHub"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.043-1.61-4.043-1.61-.546-1.387-1.333-1.757-1.333-1.757-1.09-.745.083-.73.083-.73 1.205.085 1.84 1.237 1.84 1.237 1.07 1.835 2.807 1.305 3.492.998.108-.776.418-1.305.762-1.605-2.665-.3-5.467-1.332-5.467-5.93 0-1.31.468-2.38 1.235-3.22-.123-.303-.535-1.523.118-3.176 0 0 1.008-.322 3.3 1.23a11.48 11.48 0 0 1 3.003-.404c1.02.005 2.045.138 3.003.404 2.29-1.552 3.295-1.23 3.295-1.23.655 1.653.243 2.873.12 3.176.77.84 1.233 1.91 1.233 3.22 0 4.61-2.807 5.625-5.48 5.922.43.372.823 1.102.823 2.222 0 1.605-.015 2.898-.015 3.293 0 .32.218.695.825.577C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" /></svg></a>
       </div>
-      <a href="index.html#waitlist" class="nav-btn">Folk Lore</a>
+      <a href="docs.html" class="nav-btn">Get Started</a>
     </div>
   </nav>
 

--- a/packages/website/src/pages/different.astro
+++ b/packages/website/src/pages/different.astro
@@ -71,7 +71,6 @@ import Logo from "../components/Logo.astro";
           </svg>
         </a>
         <a href="https://github.com/byk/loreai" target="_blank" rel="noopener noreferrer" class="btn-ghost">View Repository</a>
-        <a href="docs.html" class="btn-ghost">Read Docs</a>
       </div>
       <p class="hero-folklore sr" style="text-align: center;">Building with a team? <a href="index.html#waitlist"><strong>Folk Lore</strong> — shared team memory, coming soon &rarr;</a></p>
     </div>
@@ -387,9 +386,10 @@ import Logo from "../components/Logo.astro";
   <!-- CTA -->
   <section class="cta" id="waitlist">
     <div class="cta-inner">
-      <p class="cta-eyebrow sr">The future of AI agents</p>
-      <h2 class="sr">Memory that's <em>yours.</em></h2>
-      <p class="cta-sub sr">Lore is free and local today. <strong>Folk Lore</strong> brings your team's memory together — shared, searchable, always current.
+      <p class="cta-eyebrow sr">Folk Lore · early access for teams</p>
+      <h2 class="sr">Your team's memory, <em>together.</em></h2>
+      <p class="cta-sub sr"><strong>Lore is free and local today</strong> — install it now with <code class="code-inline">curl -fsSL https://withlore.ai/install | bash</code>.
+        <strong>Folk Lore</strong> brings your team's memory together — shared, searchable, always current.
         Early access is rolling out. <strong>Be part of the myth.</strong></p>
       <p class="cta-vision sr">Models will commoditize. The <em>context harness</em> will differentiate.
         <strong>Lore is that harness</strong> — the <em>context engine</em> every agent needs to build the future.</p>

--- a/packages/website/src/pages/index.astro
+++ b/packages/website/src/pages/index.astro
@@ -44,7 +44,7 @@ import Logo from "../components/Logo.astro";
         <a href="https://x.com/withLoreAI" target="_blank" rel="noopener noreferrer" class="social-link" aria-label="Lore.AI on X"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18.901 1.153h3.68l-8.04 9.19L24 22.846h-7.406l-5.8-7.584-6.638 7.584H.474l8.6-9.83L0 1.154h7.594l5.243 6.932ZM17.61 20.644h2.039L6.486 3.24H4.298Z" /></svg></a>
         <a href="https://github.com/byk/loreai" target="_blank" rel="noopener noreferrer" class="social-link" aria-label="Lore.AI on GitHub"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.043-1.61-4.043-1.61-.546-1.387-1.333-1.757-1.333-1.757-1.09-.745.083-.73.083-.73 1.205.085 1.84 1.237 1.84 1.237 1.07 1.835 2.807 1.305 3.492.998.108-.776.418-1.305.762-1.605-2.665-.3-5.467-1.332-5.467-5.93 0-1.31.468-2.38 1.235-3.22-.123-.303-.535-1.523.118-3.176 0 0 1.008-.322 3.3 1.23a11.48 11.48 0 0 1 3.003-.404c1.02.005 2.045.138 3.003.404 2.29-1.552 3.295-1.23 3.295-1.23.655 1.653.243 2.873.12 3.176.77.84 1.233 1.91 1.233 3.22 0 4.61-2.807 5.625-5.48 5.922.43.372.823 1.102.823 2.222 0 1.605-.015 2.898-.015 3.293 0 .32.218.695.825.577C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" /></svg></a>
       </div>
-      <a href="#waitlist" class="nav-btn">Folk Lore Waitlist</a>
+      <a href="#waitlist" class="nav-btn">Folk Lore</a>
     </div>
   </nav>
 
@@ -81,8 +81,8 @@ import Logo from "../components/Logo.astro";
         <p class="install-alt">or <code>npx @loreai/gateway</code></p>
       </div>
       <div class="hero-actions sr">
-        <a href="#waitlist" class="btn-fill">
-          Join the Waitlist
+        <a href="docs.html" class="btn-fill">
+          Get Started
           <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.8">
             <path d="M2 7h10M7 2l5 5-5 5" />
           </svg>
@@ -90,6 +90,7 @@ import Logo from "../components/Logo.astro";
         <a href="https://github.com/byk/loreai" target="_blank" rel="noopener noreferrer" class="btn-ghost">View Repository</a>
         <a href="docs.html" class="btn-ghost">Read Docs</a>
       </div>
+      <p class="hero-folklore sr">Building with a team? <a href="#waitlist"><strong>Folk Lore</strong> — shared team memory, coming soon &rarr;</a></p>
     </div>
 
     <div class="hero-visual sr">
@@ -433,9 +434,10 @@ import Logo from "../components/Logo.astro";
   <!-- CTA -->
   <section class="cta" id="waitlist">
     <div class="cta-inner">
-      <p class="cta-eyebrow sr">The future of AI agents</p>
-      <h2 class="sr">Stop managing context. <em>Start building.</em></h2>
-      <p class="cta-sub sr">Lore is free and local today. <strong>Folk Lore</strong> brings your team's memory together — shared, searchable, always current.
+      <p class="cta-eyebrow sr">Folk Lore · early access for teams</p>
+      <h2 class="sr">Your team's memory, <em>together.</em></h2>
+      <p class="cta-sub sr"><strong>Lore is free and local today</strong> — install it now with <code>curl -fsSL https://withlore.ai/install | bash</code>.
+        <strong>Folk Lore</strong> brings your team's memory together — shared, searchable, always current.
         Early access is rolling out. <strong>Be part of the myth.</strong></p>
       <p class="cta-vision sr">Models will commoditize. The <em>context harness</em> will differentiate.
         <strong>Lore is that harness</strong> — the <em>context engine</em> every agent needs to build the future.</p>

--- a/packages/website/src/pages/index.astro
+++ b/packages/website/src/pages/index.astro
@@ -89,7 +89,6 @@ import Logo from "../components/Logo.astro";
           </svg>
         </a>
         <a href="https://github.com/byk/loreai" target="_blank" rel="noopener noreferrer" class="btn-ghost">View Repository</a>
-        <a href="docs.html" class="btn-ghost">Read Docs</a>
       </div>
       <p class="hero-folklore sr">Building with a team? <a href="#waitlist"><strong>Folk Lore</strong> — shared team memory, coming soon &rarr;</a></p>
     </div>
@@ -437,7 +436,7 @@ import Logo from "../components/Logo.astro";
     <div class="cta-inner">
       <p class="cta-eyebrow sr">Folk Lore · early access for teams</p>
       <h2 class="sr">Your team's memory, <em>together.</em></h2>
-      <p class="cta-sub sr"><strong>Lore is free and local today</strong> — install it now with <code>curl -fsSL https://withlore.ai/install | bash</code>.
+      <p class="cta-sub sr"><strong>Lore is free and local today</strong> — install it now with <code class="code-inline">curl -fsSL https://withlore.ai/install | bash</code>.
         <strong>Folk Lore</strong> brings your team's memory together — shared, searchable, always current.
         Early access is rolling out. <strong>Be part of the myth.</strong></p>
       <p class="cta-vision sr">Models will commoditize. The <em>context harness</em> will differentiate.

--- a/packages/website/src/pages/index.astro
+++ b/packages/website/src/pages/index.astro
@@ -39,12 +39,13 @@ import Logo from "../components/Logo.astro";
         <li><a href="different.html">Why Lore</a></li>
         <li><a href="docs.html">Docs</a></li>
         <li><a href="blog.html">Blog</a></li>
+        <li><a href="#waitlist">Folk Lore</a></li>
       </ul>
       <div class="nav-socials" aria-label="Social links">
         <a href="https://x.com/withLoreAI" target="_blank" rel="noopener noreferrer" class="social-link" aria-label="Lore.AI on X"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18.901 1.153h3.68l-8.04 9.19L24 22.846h-7.406l-5.8-7.584-6.638 7.584H.474l8.6-9.83L0 1.154h7.594l5.243 6.932ZM17.61 20.644h2.039L6.486 3.24H4.298Z" /></svg></a>
         <a href="https://github.com/byk/loreai" target="_blank" rel="noopener noreferrer" class="social-link" aria-label="Lore.AI on GitHub"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.043-1.61-4.043-1.61-.546-1.387-1.333-1.757-1.333-1.757-1.09-.745.083-.73.083-.73 1.205.085 1.84 1.237 1.84 1.237 1.07 1.835 2.807 1.305 3.492.998.108-.776.418-1.305.762-1.605-2.665-.3-5.467-1.332-5.467-5.93 0-1.31.468-2.38 1.235-3.22-.123-.303-.535-1.523.118-3.176 0 0 1.008-.322 3.3 1.23a11.48 11.48 0 0 1 3.003-.404c1.02.005 2.045.138 3.003.404 2.29-1.552 3.295-1.23 3.295-1.23.655 1.653.243 2.873.12 3.176.77.84 1.233 1.91 1.233 3.22 0 4.61-2.807 5.625-5.48 5.922.43.372.823 1.102.823 2.222 0 1.605-.015 2.898-.015 3.293 0 .32.218.695.825.577C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" /></svg></a>
       </div>
-      <a href="#waitlist" class="nav-btn">Folk Lore</a>
+      <a href="docs.html" class="nav-btn">Get Started</a>
     </div>
   </nav>
 


### PR DESCRIPTION
## Problem

People landing on the site got confused by seeing both a working **install command** (`curl … | bash`, `npx @loreai/gateway`) *and* a primary **"Join the Waitlist"** button right below it — reading it as "the product isn't ready yet." The waitlist is actually for **Folk Lore** (the team feature, coming soon), but that distinction was buried in the CTA copy near the bottom.

## Fix

Make **install / get-started** the primary action everywhere and demote the waitlist to a clearly-scoped, coming-soon link for Folk Lore — on both the home page and the "Why Lore" page.

### Hero (both pages)
- Primary button: `Join the Waitlist` → **`Get Started`** (→ docs)
- Removed redundant `Read Docs` ghost button (now covered by `Get Started` + nav `Docs` link)
- Added a quiet secondary line: *"Building with a team? **Folk Lore** — shared team memory, coming soon →"*

### Nav (both pages)
- Top-right filled button: `Folk Lore Waitlist` → **`Get Started`** (→ docs)
- `Folk Lore` moved to a regular nav link alongside Docs / Blog

### CTA / waitlist section (both pages)
- Eyebrow: `The future of AI agents` → **`Folk Lore · early access for teams`**
- Heading: reframed around team memory
- Sub-copy: **"Lore is free and local today"** (with styled install command) + Folk Lore is the waitlist
- Added `code-inline` class to the inline `<code>` for proper styling

### Docs
- Updated `docs/index.md` reference from "waitlist" to "Folk Lore early access signup"

The Loops signup form, `#waitlist` anchor, IDs, and `site.js` logic are untouched — the waitlist still works, it just no longer signals "not ready."

## Files changed

- `packages/website/src/pages/index.astro`
- `packages/website/src/pages/different.astro`
- `packages/website/public/theme.css`
- `packages/website/src/content/docs/docs/index.md`