### PR TITLE
docs(website): lead with context management and add the cost story

### DIFF
--- a/packages/website/astro.config.mjs
+++ b/packages/website/astro.config.mjs
@@ -116,7 +116,7 @@ export default defineConfig({
           attrs: {
             property: "og:description",
             content:
-              "Install, operate, and understand Lore's local-first memory layer for AI coding agents.",
+              "Install, operate, and understand Lore's local-first context management and long-term memory for AI coding agents.",
           },
         },
         {
@@ -181,7 +181,7 @@ export default defineConfig({
           attrs: {
             name: "twitter:description",
             content:
-              "Install, operate, and understand Lore's local-first memory layer for AI coding agents.",
+              "Install, operate, and understand Lore's local-first context management and long-term memory for AI coding agents.",
           },
         },
         {

--- a/packages/website/integrations/favicon-assets.ts
+++ b/packages/website/integrations/favicon-assets.ts
@@ -42,7 +42,7 @@ const OG_HEIGHT = 630;
 // agent" line doubles as a CTA — pointing at the proxy that runs
 // alongside any AI agent (Claude Code, Codex, Pi, OpenCode, etc.).
 const OG_HEADLINE = "Shared context for AI agents";
-const OG_TAGLINE = "Local-first. Any agent. Zero setup.";
+const OG_TAGLINE = "Local-first. Any agent. Never compacted.";
 const OG_CTA = "→ withlore.ai";
 // Dark green background (site's --g0) and high-contrast text colors.
 // The tagline uses a brighter sage than the brand --g2 so it stays

--- a/packages/website/src/pages/different.astro
+++ b/packages/website/src/pages/different.astro
@@ -166,6 +166,15 @@ import SocialMeta from "../components/SocialMeta.astro";
               <span class="cmp-yes">across</span> tools and providers — your constant, not theirs.</td>
           </tr>
           <tr>
+            <th>Self-hosted memory stacks<br><span style="font-weight:300;color:var(--mid);font-size:.86em;">vector DB + workers as separate services</span></th>
+            <td>Powerful hybrid retrieval, fully local, no cloud.</td>
+            <td>A cluster to stand up and maintain — a vector database, a queue or worker, extra runtimes — and
+              often bound to a single agent.</td>
+            <td class="cmp-lore">Lore does the same hybrid recall (vector + keyword + RRF)
+              <span class="cmp-yes">embedded</span> in one process — no services to run, and it works with any
+              agent.</td>
+          </tr>
+          <tr>
             <th>Cloud agent platforms<br><span style="font-weight:300;color:var(--mid);font-size:.86em;">memory inside a hosted control plane</span></th>
             <td>Org-wide retrieval and governance for fleets of agents run on the platform.</td>
             <td>Memory exists for agents run <em>through</em> the platform; the engine is hosted and closed.
@@ -299,6 +308,48 @@ import SocialMeta from "../components/SocialMeta.astro";
           tool that searches knowledge entries, distillation observations, raw conversation messages,
           and cross-project knowledge in parallel — fused with reciprocal rank scoring
           and LLM-powered query expansion. Your agent reaches for context when it needs it.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- COST -->
+  <section class="how" id="cost">
+    <div class="sec-hd">
+      <div>
+        <p class="eyebrow sr">The cost story</p>
+        <h2 class="sec-title sr">Memory that <em>pays for itself</em></h2>
+      </div>
+      <p class="sec-sub sr">A memory layer that makes extra LLM calls can quietly cost more than it saves.
+        Lore is engineered the other way — every optimization is gated on real model pricing.</p>
+    </div>
+    <div class="steps">
+      <div class="step sr">
+        <div class="step-n">01</div>
+        <h3 class="step-t">No compaction, <em>no cache bust</em></h3>
+        <p class="step-b">This is the big one. Every compaction destroys the entire prompt cache, so the next
+          turn re-writes tens of thousands of tokens at full price. Lore's gradient compression never triggers
+          a compaction — your prompt cache stays intact, turn after turn. Lore also caches in layers, the way a
+          Dockerfile does: order the stable parts first and a change later never rebuilds them. Stable
+          preferences sit in a long-lived 1-hour cache block at 10&times; cheaper reads; the live conversation
+          rides the short-lived cache that follows — so editing the conversation never invalidates your
+          preferences, just as touching your source doesn't reinstall your dependencies. The quality win and
+          the cost win are the same mechanism.</p>
+      </div>
+      <div class="step sr">
+        <div class="step-n">02</div>
+        <h3 class="step-t">Warm across long tool calls — only when it pays</h3>
+        <p class="step-b">Long-running tool calls and idle gaps are where prompt caches expire, and a cold cache
+          means an expensive rebuild on the next turn. Lore runs survival analysis on your inter-turn timing to
+          keep the cache warm across those gaps with near-zero keepalive requests — and only when the expected
+          savings beat the cost. A circuit breaker disables warming entirely if the math ever stops working.</p>
+      </div>
+      <div class="step sr">
+        <div class="step-n">03</div>
+        <h3 class="step-t">Cheaper by default, and <em>capped</em></h3>
+        <p class="step-b">Background distillation and curation run at half price through batch APIs when
+          available, on cheaper worker models A/B-tested for parity. You can set a daily spend cap — background
+          work throttles as you approach it. And Lore reuses the plan you already have, including Claude
+          Pro/Max, so memory doesn't show up as a surprise line item.</p>
       </div>
     </div>
   </section>

--- a/packages/website/src/pages/index.astro
+++ b/packages/website/src/pages/index.astro
@@ -9,11 +9,11 @@ import SocialMeta from "../components/SocialMeta.astro";
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Lore.AI — Shared Context for AI Agents</title>
-  <meta name="description" content="Shared context that compounds for AI agents. Local-first, fair source, zero context files to maintain." />
+  <title>Lore.AI — Shared context that never gets compacted</title>
+  <meta name="description" content="Lore unifies context-window management and long-term memory for AI agents in one local-first pipeline — infinite sessions, compounding knowledge, shared across tools and providers. No Docker, no cloud." />
   <SocialMeta
-    title="Lore.AI — Shared Context for AI Agents"
-    description="Shared context that compounds for AI agents. Local-first, fair source, zero context files."
+    title="Lore.AI — Shared context that never gets compacted"
+    description="Context-window management and long-term memory for AI agents — one local-first pipeline. Infinite sessions, compounding knowledge, shared across your tools."
     path="index.html"
   />
   <link rel="icon" type="image/svg+xml" href="favicon.svg">
@@ -70,13 +70,12 @@ import SocialMeta from "../components/SocialMeta.astro";
         Lore. The memory that compounds.
       </div>
       <h1 class="sr">
-        Stop re-explaining<br>
-        your project to<br>
-        <em>your AI.</em>
+        Stop re-explaining.<br>
+        <em>Stop losing the thread.</em>
       </h1>
-      <p class="hero-desc sr">Your team's memory, in every session. Lore gives AI agents persistent shared context — capturing
-        decisions, file paths, and patterns across sessions lasting days and hundreds of turns.
-        No context files to maintain. No workflow changes.</p>
+      <p class="hero-desc sr">Your AI never starts over. Lore keeps sessions coherent for days and millions of
+        tokens — no lossy summary that wipes your file paths and decisions — and turns every session into
+        compounding memory across tools, providers, and (soon) your team. No context files. No workflow changes.</p>
       <div class="hero-install sr">
         <div class="install-block" onclick="navigator.clipboard.writeText('curl -fsSL https://withlore.ai/install | bash').then(()=>{this.querySelector('.install-copied').classList.add('show');setTimeout(()=>this.querySelector('.install-copied').classList.remove('show'),2000)})">
           <code><span class="install-prompt">$</span> curl -fsSL https://withlore.ai/install | bash</code>
@@ -344,18 +343,20 @@ import SocialMeta from "../components/SocialMeta.astro";
     <div class="bento" style="margin-top:1rem">
       <div class="bc bc-2 sr">
         <p class="bc-tag">Cost</p>
-        <h3 class="bc-t">Sessions as long as you want</h3>
+        <h3 class="bc-t">Longer sessions, lower bills</h3>
         <p class="bc-b">Work for days, hundreds of turns, millions of tokens — memory stays sharp.
-          Tested on a real 5-day, 2.3M-token session. Background distillation
-          and curation run at 50% off via batch APIs on cheaper models. Predictive cache warming
-          avoids the expensive cache rebuilds that compaction triggers on every turn.</p>
+          Tested on a real 5-day, 2.3M-token session. And it costs less: avoiding compaction means your prompt
+          cache is never busted, cache warming spans long-running tool calls only when it pays, background work
+          runs at half price via batch APIs, and you can set a daily spend cap.
+          <a href="different.html#cost" style="border-bottom:1px solid var(--g4);color:var(--g2)">See the cost story &rarr;</a></p>
       </div>
       <div class="bc bc-1 sr">
         <p class="bc-tag">Search</p>
         <h3 class="bc-t">Free on-device vector search</h3>
-        <p class="bc-b">Nomic Embed v1.5 runs locally — zero API cost, zero latency. Hybrid architecture
-          fuses vector similarity with BM25 keyword search for best-of-both-worlds recall. LLM-powered
-          query expansion finds what you mean, not just what you typed.</p>
+        <p class="bc-b">Nomic Embed v1.5 runs in-process — zero API cost, zero latency, and no separate
+          vector database or background services to deploy and babysit. Hybrid architecture fuses vector
+          similarity with BM25 keyword search for best-of-both-worlds recall, and LLM-powered query expansion
+          finds what you mean, not just what you typed.</p>
       </div>
       <div class="bc bc-2 sr">
         <p class="bc-tag">Knowledge</p>


### PR DESCRIPTION
## Summary
Sharpen Lore's positioning on the marketing site. Lead with the differentiator competitors can't claim — sessions that never get compacted, plus unified context management *and* memory — and add a dedicated cost story. Informed by a competitive review against Engram, memory-os, and Copilot Memory.

## Changes

**Homepage (`index.astro`)**
- Hero now leads with "Your AI never gets compacted again" + compounding memory (was the generic "persistent shared context")
- Meta + social descriptions updated to match (context management + memory, no Docker/cloud)
- Vector-search card: notes no separate vector database or background services to run (generic — no product names)
- Cost card retitled **"Longer sessions, lower bills"**, keeps the 2.3M-token benchmark hook, teases the new cost section

**Why Lore (`different.astro`)**
- New **"The cost story"** section:
  - No compaction = no prompt-cache bust; layered caching explained via a Dockerfile analogy (stable layers first so a later change never rebuilds them)
  - EV-gated cache warming across long-running tool calls (with circuit-breaker safety)
  - Half-price batch APIs, cheaper worker models, settable daily spend cap, and subscription reuse (incl. Claude Pro/Max)
- Comparison table: added a generic **"self-hosted memory stacks"** row (vector DB + workers as services → Lore does the same hybrid recall embedded in one process)

## Notes
- All claims verified against the gateway/core implementation (compaction cache-bust, tool-call warming fast path, batch queue, `getDailyBudget`, OAuth worker headers).
- Fair-play posture preserved: categories, not named call-outs.
- Site builds clean (`pnpm build`, 17 pages).