### PR TITLE
fix(gateway): unify worker retry policy to ride out 429s and quiet noise

### DIFF
--- a/packages/gateway/src/background-limiter.ts
+++ b/packages/gateway/src/background-limiter.ts
@@ -9,8 +9,9 @@
  * Note: auto-import extraction (`import-auto.ts`) is NOT wrapped here —
  * it creates its own LLM client and runs sequentially per-process.
  * The circuit breaker still provides protection for import because
- * `tripCircuitBreaker` is called from `llm-adapter.ts` on any
- * non-urgent 429, and import uses the same adapter.
+ * `tripCircuitBreaker` is called from `llm-adapter.ts` on any 429
+ * (urgent included — an urgent call keeps retrying but still pauses
+ * other background work), and import uses the same adapter.
  *
  * Also provides a circuit breaker that trips on upstream 429 responses,
  * pausing all background work for the Retry-After period. This prevents
@@ -59,8 +60,9 @@ export function isBackgroundPaused(): boolean {
 }
 
 /**
- * Trip the circuit breaker. Called when any background LLM call
- * receives a 429. Pauses all background work with escalating backoff.
+ * Trip the circuit breaker. Called when any LLM worker call receives a 429
+ * (urgent calls included — they keep retrying themselves but still pause
+ * other background work). Pauses all background work with escalating backoff.
  *
  * When `retryAfterSeconds` is provided (from Retry-After header), the
  * pause duration is the greater of the server-guided value and the

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -73,18 +73,38 @@ export const AUTH_ERROR_CODES = new Set([401, 403]);
 const BASE_DELAY_MS = 500;
 const MAX_DELAY_MS = 32_000;
 
+// Why we retry rather than bail fast on rate limits (kept as a line comment so
+// the env-docs generator scrapes only the concise JSDoc below, not this prose):
+// Worker calls share the session's credential and (usually) model, so a 429 the
+// worker hits is the same 429 the client's own request would hit — bailing
+// early doesn't let the client "continue", it just discards Lore's enriched
+// output and hands the identical wait to the client. So we ride out transient
+// 429s here (honoring Retry-After). The fall-back path is the last-resort
+// safety net for *non-shared* failures (a Lore-specific worker error, or a
+// worker-model-only 429/529) and for surfacing a sustained outage rather than
+// holding the client's connection open indefinitely. Raw conversation data is
+// never lost on fall-back: turns are already in temporal storage,
+// distillation/curation retry on the next idle pass, and compaction forwards
+// the client's native compaction. The total hold is bounded (~MAX_DELAY_MS ×
+// retries) to stay under typical client read-timeouts; SSE keep-alive
+// heartbeats (a follow-up) would let us wait out longer windows.
 /**
- * Number of retries for a worker upstream call before giving up (the call
- * then returns null and the caller falls back). Override with the
+ * Number of times a worker upstream call retries a transient failure before
+ * falling back to the caller's own handling (default: 8). Override with the
  * LORE_MAX_RETRIES env var.
  */
 const DEFAULT_MAX_RETRIES = 8;
 
+/**
+ * Resolve the retry budget. `LORE_MAX_RETRIES` overrides the default; values
+ * that are non-numeric, negative, or zero fall back to the default (we never
+ * silently disable retries — that would contradict the "ride it out" policy).
+ */
 function resolveMaxRetries(): number {
   const env = process.env.LORE_MAX_RETRIES;
   if (env) {
     const n = Number.parseInt(env, 10);
-    if (Number.isFinite(n) && n >= 0) return n;
+    if (Number.isFinite(n) && n >= 1) return n;
   }
   return DEFAULT_MAX_RETRIES;
 }
@@ -528,6 +548,10 @@ export function createGatewayLLMClient(
             // Trip the circuit breaker at most once per call so a multi-retry
             // 429 loop doesn't runaway-escalate the breaker's backoff schedule.
             let breakerTripped = false;
+            // Resolve the retry budget once per call (not per attempt) — the
+            // value can't change mid-loop and re-reading the env each iteration
+            // is wasteful.
+            const maxRetries = maxRetriesFor();
 
             // Retry loop for transient errors (429, 5xx)
             for (let attempt = 0; ; attempt++) {
@@ -543,7 +567,6 @@ export function createGatewayLLMClient(
                 });
               } catch (e) {
                 // Network/fetch error — retry if attempts remain
-                const maxRetries = maxRetriesFor();
                 if (attempt < maxRetries) {
                   const delay = backoffMs(attempt, null);
                   retryCount++;
@@ -740,7 +763,6 @@ export function createGatewayLLMClient(
                 tripCircuitBreaker(pauseSec);
               }
 
-              const maxRetries = maxRetriesFor(response.status);
               if (attempt < maxRetries) {
                 const retryAfter = parseRetryAfter(response);
                 const delay = backoffMs(attempt, retryAfter);
@@ -758,13 +780,16 @@ export function createGatewayLLMClient(
                 continue;
               }
 
-              // Exhausted retries — log, capture Sentry error, enrich span.
-              // Urgent calls (compaction, query expansion) have a graceful
-              // caller-side fallback — e.g. handleCompaction forwards the
-              // client's own compaction upstream — so their exhaustion is
-              // harmless. Log it at `warn` (hidden unless LORE_DEBUG) to avoid
-              // alarming red `[lore]` noise; background exhaustion stays at
-              // `error` since it can indicate a sustained problem.
+              // Exhausted retries — fall back, log, capture Sentry, enrich span.
+              // Urgent calls (compaction, query expansion) hand control back to
+              // a caller that degrades gracefully without losing data — e.g.
+              // handleCompaction forwards the client's own compaction upstream.
+              // On a shared-quota 429 that fallback will hit the same limit and
+              // the client handles it, so our exhaustion here is not itself a
+              // failure to surface loudly. Log it at `warn` (hidden unless
+              // LORE_DEBUG) to avoid alarming red `[lore]` noise; non-urgent
+              // background exhaustion stays at `error` since it can indicate a
+              // sustained problem worth investigating.
               const text = await response.text().catch(() => "(no body)");
               const exhaustionMsg =
                 `worker upstream request failed after ${maxRetries + 1} attempts: ${response.status} ${response.statusText}` +

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -73,7 +73,11 @@ export const AUTH_ERROR_CODES = new Set([401, 403]);
 const BASE_DELAY_MS = 500;
 const MAX_DELAY_MS = 32_000;
 
-/** Default retry budget, overridable via LORE_MAX_RETRIES. */
+/**
+ * Number of retries for a worker upstream call before giving up (the call
+ * then returns null and the caller falls back). Override with the
+ * LORE_MAX_RETRIES env var.
+ */
 const DEFAULT_MAX_RETRIES = 8;
 
 function resolveMaxRetries(): number {

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -54,32 +54,44 @@ const TRANSIENT_CODES = new Set([429, 500, 502, 503, 529]);
 /** HTTP status codes indicating permanent auth failure. */
 export const AUTH_ERROR_CODES = new Set([401, 403]);
 
-/** Max retries by error category for **background** (non-urgent) calls. */
-const MAX_RETRIES_RATE_LIMIT = 3; // 429s: ~6 min with wider spacing to reduce API pressure
-const MAX_RETRIES_SERVER = 3; // 5xx: fast retries
+/**
+ * Unified retry policy (modeled on Claude Code's `getRetryDelay`).
+ *
+ * A single policy governs every worker call — urgent or background, 429 or
+ * 5xx, Anthropic or any OpenAI-compatible provider. We deliberately do NOT
+ * bifurcate retry timing by urgency: the early retries are fast (sub-second),
+ * so a transient blip clears quickly without the old 60s background first-wait
+ * that made urgent calls (compaction) "hang", while the cap + jitter keep a
+ * sustained 429 storm from hammering the API. Aggregate pressure is managed
+ * centrally by the circuit breaker (see `background-limiter.ts`), which now
+ * trips on any 429 — so per-call wide spacing is no longer needed.
+ *
+ * Server `Retry-After` is always honored (capped at MAX_DELAY_MS so a
+ * pathological header can't wait unbounded). Without a header we use
+ * exponential backoff with jitter: 0.5s, 1s, 2s, 4s, 8s, 16s, 32s, 32s…
+ */
+const BASE_DELAY_MS = 500;
+const MAX_DELAY_MS = 32_000;
+
+/** Default retry budget, overridable via LORE_MAX_RETRIES. */
+const DEFAULT_MAX_RETRIES = 8;
+
+function resolveMaxRetries(): number {
+  const env = process.env.LORE_MAX_RETRIES;
+  if (env) {
+    const n = Number.parseInt(env, 10);
+    if (Number.isFinite(n) && n >= 0) return n;
+  }
+  return DEFAULT_MAX_RETRIES;
+}
 
 /**
- * Max retries for **urgent** calls — synchronous worker work that the
- * client is awaiting (compaction, query expansion, overflow distillation).
- * Tight budget so a 429 storm cannot turn the SSE response into a multi-
- * minute hang. The user-visible "Lore made OpenCode hang" symptom that
- * motivated splitting these budgets came from urgent calls inheriting the
- * background-worker retry timing. 2 retries × ~3s max = ~6s ceiling.
+ * Max retries for a worker call. A single budget regardless of status code or
+ * urgency (the `_status` parameter is retained for call-site readability and
+ * potential future tuning).
  */
-const MAX_RETRIES_URGENT = 2;
-
-/** Cap Retry-After server hints separately for urgent vs background calls.
- *  Urgent paths cannot afford a 60-120s pause even if the server asks. */
-const RETRY_AFTER_CAP_URGENT_MS = 8_000;
-const RETRY_AFTER_CAP_BACKGROUND_MS = 120_000;
-
-export function maxRetriesFor(
-  status: number | null,
-  urgent: boolean = false,
-): number {
-  if (urgent) return MAX_RETRIES_URGENT;
-  if (status === 429) return MAX_RETRIES_RATE_LIMIT;
-  return MAX_RETRIES_SERVER;
+export function maxRetriesFor(_status: number | null = null): number {
+  return resolveMaxRetries();
 }
 
 /** Parse the Retry-After header into milliseconds, or null if absent/invalid. */
@@ -94,36 +106,18 @@ export function parseRetryAfter(response: Response): number | null {
 }
 
 /**
- * Compute delay for a retry attempt.
- * - Always honor Retry-After when present, capped per-mode (urgent: 8s, bg: 120s)
- * - 429 without Retry-After:
- *    - urgent: 1s, 2s, 4s (capped 4s)
- *    - background: 60s, 120s, 180s (wider spacing to reduce pressure on
- *      tight-quota environments like Claude Max)
- * - 5xx: aggressive 1s, 2s, 4s (capped 8s) — same for urgent and background
+ * Compute delay for a retry attempt (0-based) using the unified policy.
+ * - Honor Retry-After when present, capped at MAX_DELAY_MS.
+ * - Otherwise exponential backoff with 0-25% jitter:
+ *   min(BASE_DELAY_MS * 2^attempt, MAX_DELAY_MS) + jitter.
  */
 export function backoffMs(
   attempt: number,
   retryAfterMs: number | null,
-  status: number | null,
-  urgent: boolean = false,
 ): number {
-  // Always honor Retry-After from server, but cap tighter for urgent calls
-  if (retryAfterMs != null) {
-    const cap = urgent
-      ? RETRY_AFTER_CAP_URGENT_MS
-      : RETRY_AFTER_CAP_BACKGROUND_MS;
-    return Math.min(retryAfterMs, cap);
-  }
-
-  // Urgent path: aggressive exponential regardless of status
-  if (urgent) return Math.min(1000 * 2 ** attempt, 4000);
-
-  // 429 without Retry-After: wide spacing to give rate limits time to recover
-  if (status === 429) return Math.min(60_000 + attempt * 60_000, 180_000);
-
-  // 5xx: aggressive exponential backoff
-  return Math.min(1000 * 2 ** attempt, 8000);
+  if (retryAfterMs != null) return Math.min(retryAfterMs, MAX_DELAY_MS);
+  const base = Math.min(BASE_DELAY_MS * 2 ** attempt, MAX_DELAY_MS);
+  return base + Math.random() * 0.25 * base;
 }
 
 function sleep(ms: number): Promise<void> {
@@ -527,6 +521,9 @@ export function createGatewayLLMClient(
             let totalDelayMs = 0;
             let lastRetryAfterMs: number | null = null;
             let finalStatus = 0;
+            // Trip the circuit breaker at most once per call so a multi-retry
+            // 429 loop doesn't runaway-escalate the breaker's backoff schedule.
+            let breakerTripped = false;
 
             // Retry loop for transient errors (429, 5xx)
             for (let attempt = 0; ; attempt++) {
@@ -542,9 +539,9 @@ export function createGatewayLLMClient(
                 });
               } catch (e) {
                 // Network/fetch error — retry if attempts remain
-                const maxRetries = maxRetriesFor(null, urgent);
+                const maxRetries = maxRetriesFor();
                 if (attempt < maxRetries) {
-                  const delay = backoffMs(attempt, null, null, urgent);
+                  const delay = backoffMs(attempt, null);
                   retryCount++;
                   totalDelayMs += delay;
                   log.warn(
@@ -723,10 +720,15 @@ export function createGatewayLLMClient(
                 return null;
               }
 
-              // Transient error — retry if attempts remain
-              // Trip the global circuit breaker on non-urgent 429s so other
-              // background work pauses instead of piling on more requests.
-              if (response.status === 429 && !urgent) {
+              // Transient error — retry if attempts remain.
+              // Trip the global circuit breaker on ANY 429 (urgent included) so
+              // background work pauses instead of piling on more requests while
+              // this call rides out the rate limit. The urgent call itself is
+              // not gated by the breaker, so it keeps retrying. Trip at most
+              // once per call to avoid runaway escalation of the backoff
+              // schedule across a multi-retry loop.
+              if (response.status === 429 && !breakerTripped) {
+                breakerTripped = true;
                 const cbRetryAfter = parseRetryAfter(response);
                 const pauseSec = cbRetryAfter
                   ? Math.ceil(cbRetryAfter / 1000)
@@ -734,15 +736,10 @@ export function createGatewayLLMClient(
                 tripCircuitBreaker(pauseSec);
               }
 
-              const maxRetries = maxRetriesFor(response.status, urgent);
+              const maxRetries = maxRetriesFor(response.status);
               if (attempt < maxRetries) {
                 const retryAfter = parseRetryAfter(response);
-                const delay = backoffMs(
-                  attempt,
-                  retryAfter,
-                  response.status,
-                  urgent,
-                );
+                const delay = backoffMs(attempt, retryAfter);
                 retryCount++;
                 totalDelayMs += delay;
                 if (retryAfter != null) lastRetryAfterMs = retryAfter;
@@ -757,15 +754,25 @@ export function createGatewayLLMClient(
                 continue;
               }
 
-              // Exhausted retries — log, capture Sentry error, enrich span
+              // Exhausted retries — log, capture Sentry error, enrich span.
+              // Urgent calls (compaction, query expansion) have a graceful
+              // caller-side fallback — e.g. handleCompaction forwards the
+              // client's own compaction upstream — so their exhaustion is
+              // harmless. Log it at `warn` (hidden unless LORE_DEBUG) to avoid
+              // alarming red `[lore]` noise; background exhaustion stays at
+              // `error` since it can indicate a sustained problem.
               const text = await response.text().catch(() => "(no body)");
-              log.error(
+              const exhaustionMsg =
                 `worker upstream request failed after ${maxRetries + 1} attempts: ${response.status} ${response.statusText}` +
-                  ` — url=${target.url} model=${model.providerID}/${model.modelID}` +
-                  ` cred=${cred.scheme} worker=${opts?.workerID ?? "unknown"}` +
-                  ` session=${opts?.sessionID?.slice(0, 16) ?? "none"}` +
-                  ` — ${text}`,
-              );
+                ` — url=${target.url} model=${model.providerID}/${model.modelID}` +
+                ` cred=${cred.scheme} worker=${opts?.workerID ?? "unknown"}` +
+                ` session=${opts?.sessionID?.slice(0, 16) ?? "none"}` +
+                ` — ${text}`;
+              if (urgent) {
+                log.warn(exhaustionMsg);
+              } else {
+                log.error(exhaustionMsg);
+              }
 
               // Capture as Sentry error for alerting
               Sentry.captureException(

--- a/packages/gateway/test/llm-adapter.test.ts
+++ b/packages/gateway/test/llm-adapter.test.ts
@@ -1,4 +1,11 @@
-import { describe, test, expect, afterEach } from "vitest";
+import { describe, test, expect, afterEach, vi } from "vitest";
+
+// Mock the upstream fetch wrapper so the adapter's retry loop is driven by our
+// stubbed responses regardless of whether a fetch interceptor is installed
+// (stubbing globalThis.fetch alone would silently break if `getOriginalFetch`
+// had captured the real fetch).
+vi.mock("../src/fetch", () => ({ upstreamFetch: vi.fn() }));
+
 import {
   backoffMs,
   createGatewayLLMClient,
@@ -11,6 +18,7 @@ import {
   getConsecutiveTrips,
   resetBackgroundLimiter,
 } from "../src/background-limiter";
+import { upstreamFetch } from "../src/fetch";
 
 // ---------------------------------------------------------------------------
 // maxRetriesFor — unified policy (modeled on Claude Code's single budget)
@@ -260,15 +268,49 @@ describe("resolveWorkerProtocol", () => {
 });
 
 // ---------------------------------------------------------------------------
+// resolveMaxRetries (via maxRetriesFor) — LORE_MAX_RETRIES parsing edge cases
+// ---------------------------------------------------------------------------
+
+describe("LORE_MAX_RETRIES env parsing", () => {
+  const original = process.env.LORE_MAX_RETRIES;
+  afterEach(() => {
+    if (original === undefined) delete process.env.LORE_MAX_RETRIES;
+    else process.env.LORE_MAX_RETRIES = original;
+  });
+
+  test("defaults to 8 when unset", () => {
+    delete process.env.LORE_MAX_RETRIES;
+    expect(maxRetriesFor()).toBe(8);
+  });
+
+  test("honors a valid positive integer", () => {
+    process.env.LORE_MAX_RETRIES = "3";
+    expect(maxRetriesFor()).toBe(3);
+  });
+
+  test("truncates a float via parseInt", () => {
+    process.env.LORE_MAX_RETRIES = "5.9";
+    expect(maxRetriesFor()).toBe(5);
+  });
+
+  test("falls back to default for 0, negative, empty, and non-numeric (never disables retries)", () => {
+    for (const bad of ["0", "-1", "", "abc", "Infinity"]) {
+      process.env.LORE_MAX_RETRIES = bad;
+      expect(maxRetriesFor()).toBe(8);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Circuit breaker: a 429 trips the breaker once per call, even when urgent
 // ---------------------------------------------------------------------------
 
 describe("worker 429 trips the circuit breaker (urgent included)", () => {
-  const realFetch = globalThis.fetch;
+  const mockFetch = vi.mocked(upstreamFetch);
   const realMaxRetries = process.env.LORE_MAX_RETRIES;
 
   afterEach(() => {
-    globalThis.fetch = realFetch;
+    mockFetch.mockReset();
     if (realMaxRetries === undefined) delete process.env.LORE_MAX_RETRIES;
     else process.env.LORE_MAX_RETRIES = realMaxRetries;
   });
@@ -279,17 +321,16 @@ describe("worker 429 trips the circuit breaker (urgent included)", () => {
     process.env.LORE_MAX_RETRIES = "3";
     resetBackgroundLimiter();
 
-    let fetchCalls = 0;
-    globalThis.fetch = (async () => {
-      fetchCalls++;
-      return new Response(
-        JSON.stringify({
-          type: "error",
-          error: { type: "rate_limit_error", message: "Error" },
-        }),
-        { status: 429, headers: { "retry-after": "0" } },
-      );
-    }) as unknown as typeof globalThis.fetch;
+    mockFetch.mockImplementation(
+      async () =>
+        new Response(
+          JSON.stringify({
+            type: "error",
+            error: { type: "rate_limit_error", message: "Error" },
+          }),
+          { status: 429, headers: { "retry-after": "0" } },
+        ),
+    );
 
     const client = createGatewayLLMClient(
       {
@@ -307,7 +348,7 @@ describe("worker 429 trips the circuit breaker (urgent included)", () => {
 
     // Exhausted → null (caller falls back), all attempts made, breaker tripped once.
     expect(result).toBeNull();
-    expect(fetchCalls).toBe(4); // maxRetries(3) + 1
+    expect(mockFetch).toHaveBeenCalledTimes(4); // maxRetries(3) + 1
     expect(getConsecutiveTrips()).toBe(1);
   });
 });

--- a/packages/gateway/test/llm-adapter.test.ts
+++ b/packages/gateway/test/llm-adapter.test.ts
@@ -1,172 +1,117 @@
-import { describe, test, expect } from "vitest";
+import { describe, test, expect, afterEach } from "vitest";
 import {
   backoffMs,
+  createGatewayLLMClient,
   maxRetriesFor,
   normalizeOpenAIUsage,
   resolveWorkerProtocol,
   AUTH_ERROR_CODES,
 } from "../src/llm-adapter";
+import {
+  getConsecutiveTrips,
+  resetBackgroundLimiter,
+} from "../src/background-limiter";
 
 // ---------------------------------------------------------------------------
-// maxRetriesFor — background (default)
+// maxRetriesFor — unified policy (modeled on Claude Code's single budget)
 // ---------------------------------------------------------------------------
 
-describe("maxRetriesFor (background)", () => {
-  test("returns 3 for 429 (rate limit)", () => {
-    expect(maxRetriesFor(429)).toBe(3);
-  });
-
-  test("returns 3 for 5xx", () => {
-    expect(maxRetriesFor(500)).toBe(3);
-    expect(maxRetriesFor(502)).toBe(3);
-    expect(maxRetriesFor(503)).toBe(3);
-    expect(maxRetriesFor(529)).toBe(3);
-  });
-
-  test("returns 3 for null (network error)", () => {
-    expect(maxRetriesFor(null)).toBe(3);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// maxRetriesFor — urgent (synchronous, blocking the SSE response)
-// ---------------------------------------------------------------------------
-
-describe("maxRetriesFor (urgent)", () => {
-  test("returns 2 regardless of status — short budget for blocking calls", () => {
-    expect(maxRetriesFor(429, true)).toBe(2);
-    expect(maxRetriesFor(500, true)).toBe(2);
-    expect(maxRetriesFor(503, true)).toBe(2);
-    expect(maxRetriesFor(null, true)).toBe(2);
+describe("maxRetriesFor (unified policy)", () => {
+  test("returns the default budget (8) regardless of status or urgency", () => {
+    expect(maxRetriesFor()).toBe(8);
+    expect(maxRetriesFor(429)).toBe(8);
+    expect(maxRetriesFor(500)).toBe(8);
+    expect(maxRetriesFor(502)).toBe(8);
+    expect(maxRetriesFor(503)).toBe(8);
+    expect(maxRetriesFor(529)).toBe(8);
+    expect(maxRetriesFor(null)).toBe(8);
   });
 });
 
 // ---------------------------------------------------------------------------
-// backoffMs — Retry-After
+// backoffMs — Retry-After (honored exactly, capped at MAX_DELAY_MS = 32s)
 // ---------------------------------------------------------------------------
 
 describe("backoffMs — with Retry-After", () => {
-  test("background: caps Retry-After at 120s", () => {
-    expect(backoffMs(0, 300_000, 429)).toBe(120_000);
-    expect(backoffMs(2, 200_000, 500)).toBe(120_000);
+  test("honors small Retry-After exactly (no jitter on the server-hint path)", () => {
+    expect(backoffMs(0, 1000)).toBe(1000);
+    expect(backoffMs(3, 5000)).toBe(5000);
+    expect(backoffMs(0, 100)).toBe(100);
   });
 
-  test("urgent: caps Retry-After at 8s", () => {
-    expect(backoffMs(0, 60_000, 429, true)).toBe(8_000);
-    expect(backoffMs(0, 120_000, 429, true)).toBe(8_000);
+  test("honors Retry-After right up to the 32s cap", () => {
+    expect(backoffMs(0, 32_000)).toBe(32_000);
   });
 
-  test("urgent: honors small Retry-After exactly (under cap)", () => {
-    expect(backoffMs(0, 1000, 429, true)).toBe(1000);
-    expect(backoffMs(0, 5000, 429, true)).toBe(5000);
-  });
-
-  test("background: honors small Retry-After values exactly", () => {
-    expect(backoffMs(0, 1000, 429)).toBe(1000);
-    expect(backoffMs(0, 100, 500)).toBe(100);
-  });
-
-  test("Retry-After honored regardless of status code", () => {
-    expect(backoffMs(0, 10_000, 500)).toBe(10_000);
-    expect(backoffMs(0, 10_000, null)).toBe(10_000);
+  test("caps Retry-After at 32s regardless of attempt", () => {
+    expect(backoffMs(0, 60_000)).toBe(32_000);
+    expect(backoffMs(2, 300_000)).toBe(32_000);
   });
 });
 
 // ---------------------------------------------------------------------------
-// backoffMs — 429 without Retry-After
+// backoffMs — exponential backoff with jitter (no Retry-After)
 // ---------------------------------------------------------------------------
 
-describe("backoffMs — 429 without Retry-After", () => {
-  test("background uses wide spacing: 60s, 120s, 180s (capped 180s)", () => {
-    expect(backoffMs(0, null, 429)).toBe(60_000);
-    expect(backoffMs(1, null, 429)).toBe(120_000);
-    expect(backoffMs(2, null, 429)).toBe(180_000);
-    expect(backoffMs(3, null, 429)).toBe(180_000);
-  });
-
-  test("urgent uses aggressive exponential: 1s, 2s, 4s (capped 4s)", () => {
-    expect(backoffMs(0, null, 429, true)).toBe(1000);
-    expect(backoffMs(1, null, 429, true)).toBe(2000);
-    expect(backoffMs(2, null, 429, true)).toBe(4000);
-    expect(backoffMs(3, null, 429, true)).toBe(4000);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// backoffMs — 5xx without Retry-After
-// ---------------------------------------------------------------------------
-
-describe("backoffMs — 5xx without Retry-After", () => {
-  test("background: 1s, 2s, 4s, 8s (capped 8s)", () => {
-    expect(backoffMs(0, null, 500)).toBe(1000);
-    expect(backoffMs(1, null, 500)).toBe(2000);
-    expect(backoffMs(2, null, 500)).toBe(4000);
-    expect(backoffMs(3, null, 500)).toBe(8000);
-    expect(backoffMs(10, null, 502)).toBe(8000);
-  });
-
-  test("urgent: 1s, 2s, 4s (capped 4s) — tighter than background", () => {
-    expect(backoffMs(0, null, 500, true)).toBe(1000);
-    expect(backoffMs(1, null, 500, true)).toBe(2000);
-    expect(backoffMs(2, null, 500, true)).toBe(4000);
-    expect(backoffMs(10, null, 502, true)).toBe(4000);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// backoffMs — network errors (null status)
-// ---------------------------------------------------------------------------
-
-describe("backoffMs — network errors", () => {
-  test("background uses 1s, 2s, 4s exponential", () => {
-    expect(backoffMs(0, null, null)).toBe(1000);
-    expect(backoffMs(1, null, null)).toBe(2000);
-    expect(backoffMs(2, null, null)).toBe(4000);
-  });
-
-  test("urgent uses the same exponential capped 4s", () => {
-    expect(backoffMs(0, null, null, true)).toBe(1000);
-    expect(backoffMs(1, null, null, true)).toBe(2000);
-    expect(backoffMs(2, null, null, true)).toBe(4000);
-    expect(backoffMs(5, null, null, true)).toBe(4000);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Total worst-case budget (regression guard for the OpenCode-hang report)
-// ---------------------------------------------------------------------------
-
-describe("worst-case urgent budget", () => {
-  test("urgent 429 with Retry-After: 60 stays under ~25s end-to-end", () => {
-    // 2 retries × max 8s honored from Retry-After = 16s of waits total.
-    // Per-attempt fetch latency is bounded by Anthropic's own server timeout
-    // (~10s on rate-limit reject), so total ≤ ~25s. This is the ceiling that
-    // prevents OpenCode's SSE stream from looking hung.
-    let total = 0;
-    for (let attempt = 0; attempt < maxRetriesFor(429, true); attempt++) {
-      total += backoffMs(attempt, 60_000, 429, true);
+describe("backoffMs — exponential backoff without Retry-After", () => {
+  test("ramps 0.5s → 32s (capped), each within [base, 1.25*base)", () => {
+    const cases: Array<[number, number]> = [
+      [0, 500],
+      [1, 1000],
+      [2, 2000],
+      [3, 4000],
+      [4, 8000],
+      [5, 16_000],
+      [6, 32_000],
+      [10, 32_000], // capped
+    ];
+    for (const [attempt, base] of cases) {
+      const delay = backoffMs(attempt, null);
+      expect(delay).toBeGreaterThanOrEqual(base);
+      expect(delay).toBeLessThan(base * 1.25);
     }
-    expect(total).toBeLessThanOrEqual(16_000);
   });
 
-  test("background 429 with Retry-After: 60 budgets up to ~3min", () => {
-    // 3 retries × 60s (Retry-After honored, under 120s cap) = 180s.
-    // Reduced from 5×60s to lower API pressure on tight-quota environments.
+  test("jitter makes repeated delays non-constant", () => {
+    const samples = new Set(
+      Array.from({ length: 25 }, () => backoffMs(3, null)),
+    );
+    expect(samples.size).toBeGreaterThan(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unified retry budget (regression guard for the OpenCode-hang report)
+// ---------------------------------------------------------------------------
+
+describe("unified retry budget", () => {
+  test("first retry is sub-second — no 60s background first-wait (hang regression)", () => {
+    // The old urgent/background split made urgent calls (compaction) inherit a
+    // 60s background first-wait, which looked like a hang. The unified policy's
+    // first retry without Retry-After is ~0.5s + jitter.
+    const first = backoffMs(0, null);
+    expect(first).toBeGreaterThanOrEqual(500);
+    expect(first).toBeLessThan(700); // 500 + up to 25% jitter
+  });
+
+  test("429 with Retry-After: 60 — every wait capped at 32s", () => {
+    // 8 retries × 32s cap = 256s ceiling. Server hint honored, no jitter.
     let total = 0;
     for (let attempt = 0; attempt < maxRetriesFor(429); attempt++) {
-      total += backoffMs(attempt, 60_000, 429);
+      total += backoffMs(attempt, 60_000);
     }
-    expect(total).toBe(180_000); // 3 retries × 60s
+    expect(total).toBe(256_000);
   });
 
-  test("background 429 without Retry-After: total up to ~6min", () => {
-    // Without server-guided Retry-After, backoff is wider: 60+120+180 = 360s.
-    // Intentionally generous to ride out rate-limit windows without hammering.
+  test("429 without Retry-After: bounded exponential sum", () => {
+    // 0.5 + 1 + 2 + 4 + 8 + 16 + 32 + 32 = 95.5s of base delay, + jitter.
     let total = 0;
     for (let attempt = 0; attempt < maxRetriesFor(429); attempt++) {
-      total += backoffMs(attempt, null, 429);
+      total += backoffMs(attempt, null);
     }
-    expect(total).toBe(360_000); // 60s + 120s + 180s
+    const base = 500 + 1000 + 2000 + 4000 + 8000 + 16_000 + 32_000 + 32_000;
+    expect(total).toBeGreaterThanOrEqual(base);
+    expect(total).toBeLessThan(base * 1.25);
   });
 });
 
@@ -311,5 +256,58 @@ describe("resolveWorkerProtocol", () => {
 
   test("unknown provider defaults to 'anthropic'", () => {
     expect(resolveWorkerProtocol("some-unknown-provider")).toBe("anthropic");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Circuit breaker: a 429 trips the breaker once per call, even when urgent
+// ---------------------------------------------------------------------------
+
+describe("worker 429 trips the circuit breaker (urgent included)", () => {
+  const realFetch = globalThis.fetch;
+  const realMaxRetries = process.env.LORE_MAX_RETRIES;
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    if (realMaxRetries === undefined) delete process.env.LORE_MAX_RETRIES;
+    else process.env.LORE_MAX_RETRIES = realMaxRetries;
+  });
+
+  test("urgent 429 storm trips the breaker exactly once across the retry loop", async () => {
+    // Small budget + Retry-After: 0 → retries are instant, so the loop runs
+    // to exhaustion without real waits.
+    process.env.LORE_MAX_RETRIES = "3";
+    resetBackgroundLimiter();
+
+    let fetchCalls = 0;
+    globalThis.fetch = (async () => {
+      fetchCalls++;
+      return new Response(
+        JSON.stringify({
+          type: "error",
+          error: { type: "rate_limit_error", message: "Error" },
+        }),
+        { status: 429, headers: { "retry-after": "0" } },
+      );
+    }) as unknown as typeof globalThis.fetch;
+
+    const client = createGatewayLLMClient(
+      {
+        anthropic: "https://api.anthropic.com",
+        openai: "https://api.openai.com",
+      },
+      () => ({ scheme: "api-key", value: "sk-ant-test" }),
+      { providerID: "anthropic", modelID: "claude-test" },
+    );
+
+    const result = await client.prompt("system", "user", {
+      urgent: true,
+      workerID: "lore-compact",
+    });
+
+    // Exhausted → null (caller falls back), all attempts made, breaker tripped once.
+    expect(result).toBeNull();
+    expect(fetchCalls).toBe(4); // maxRetries(3) + 1
+    expect(getConsecutiveTrips()).toBe(1);
   });
 });

--- a/packages/website/src/content/docs/docs/environment.md
+++ b/packages/website/src/content/docs/docs/environment.md
@@ -45,7 +45,7 @@ Env vars override `.lore.json` for the same setting. To override a `.lore.json` 
 | Variable | Description |
 |---|---|
 | `LORE_DAILY_BUDGET` | Get the effective daily budget in USD. Resolution priority: 1. `LORE_DAILY_BUDGET` env var (override for automation / CI) 2. DB-persisted value from `kv_meta` (set via UI) 3. 0 (disabled) |
-| `LORE_MAX_RETRIES` | Number of retries for a worker upstream call before giving up (the call then returns null and the caller falls back). Override with the LORE_MAX_RETRIES env var. |
+| `LORE_MAX_RETRIES` | Number of times a worker upstream call retries a transient failure before falling back to the caller's own handling (default: 8). Override with the LORE_MAX_RETRIES env var. |
 | `LORE_WORKER_MODEL` | Env var override — highest priority. Useful for global worker model configuration without per-project .lore.json (e.g. routing all workers to MiniMax). Format: "providerID/modelID" or just "modelID" (defaults to anthropic provider). |
 
 ## Pipeline + idle work

--- a/packages/website/src/content/docs/docs/environment.md
+++ b/packages/website/src/content/docs/docs/environment.md
@@ -45,6 +45,7 @@ Env vars override `.lore.json` for the same setting. To override a `.lore.json` 
 | Variable | Description |
 |---|---|
 | `LORE_DAILY_BUDGET` | Get the effective daily budget in USD. Resolution priority: 1. `LORE_DAILY_BUDGET` env var (override for automation / CI) 2. DB-persisted value from `kv_meta` (set via UI) 3. 0 (disabled) |
+| `LORE_MAX_RETRIES` | Number of retries for a worker upstream call before giving up (the call then returns null and the caller falls back). Override with the LORE_MAX_RETRIES env var. |
 | `LORE_WORKER_MODEL` | Env var override — highest priority. Useful for global worker model configuration without per-project .lore.json (e.g. routing all workers to MiniMax). Format: "providerID/modelID" or just "modelID" (defaults to anthropic provider). |
 
 ## Pipeline + idle work


### PR DESCRIPTION
## Problem

`@bete` repeatedly hit (May 19, May 27, Jun 10) a red, alarming line in his terminal:

```
[lore] worker upstream request failed after 3 attempts: 429 Too Many Requests
  — url=https://api.anthropic.com model=anthropic/claude-sonnet-4-6 cred=bearer worker=lore-compact session=none
```

Root cause: the urgent compaction call (`pipeline.ts` `workerID:"lore-compact", urgent:true`) inherited a tiny retry budget — 2 retries with `Retry-After` capped at **8s**. On OAuth / Claude-Max accounts (`cred=bearer`) a 429 typically needs 30-60s to clear, so it bailed almost instantly. A 429 on an urgent call also never tripped the circuit breaker, so our own background distill/curate kept piling on, sustaining the rate limit. The failure was logged at `error` → red, even though it's not actionable.

## What Claude Code does (ref: [paoloanzn/free-code](https://github.com/paoloanzn/free-code) `src/services/api/withRetry.ts`)

One retry policy, not a family of modes: `getRetryDelay` honors `Retry-After` else exponential `500ms → 32s` + jitter, with a single `DEFAULT_MAX_RETRIES = 10`. No urgent/background bifurcation. That's the model adopted here.

## Why retrying (not bailing) is correct for rate limits

A key insight that shaped this PR: **bailing fast on a 429 does not help the client continue.** `lore-compact` uses the session's own credential and (usually) model, so a 429 the worker hits is the *same* 429 the client's own request would hit. Falling back forwards the client's native compaction to the *same* endpoint with the *same* token — it 429s too, and the client then waits/surfaces it itself. So giving up early just (a) throws away Lore's enriched summary and (b) hands the identical wait to the client. Riding the 429 out in Lore is strictly at least as good.

**No data is ever lost on fall-back:** raw turns are already in temporal storage, distillation/curation retry on the next idle pass, and compaction forwards the client's native compaction. The fall-back path is the last-resort safety net for *non-shared* failures (a Lore-specific worker error, or a worker-model-only 429/529) and for surfacing a sustained outage rather than holding the client's connection open indefinitely.

## Change

Replace lore's urgent/background retry split with a single unified policy (net **−2 constants**, and the `urgent`/`status` params drop out of the retry helpers):

- **`backoffMs`** honors `Retry-After` (capped at `MAX_DELAY_MS = 32s`), else exponential `0.5s → 32s` with 0-25% jitter. Single budget `MAX_RETRIES = 8` (override via `LORE_MAX_RETRIES`; `0`/negative/invalid → default, never silently disables retries). Compaction now rides out typical 429s instead of giving up.
- **Trip the circuit breaker on _any_ 429** (urgent included), at most once per call, so background work pauses while the urgent call retries — removing the self-inflicted concurrency that caused the 429s. The urgent call itself isn't gated by the breaker, so it keeps retrying.
- **Downgrade the exhausted-retry log to `warn` for urgent calls** — hidden unless `LORE_DEBUG`, so the harmless line no longer prints red. Non-urgent background exhaustion stays `error`. Sentry alerting is preserved (independent `captureException`, already filtered by the transient allow-list).

### Provider-general
All changes live in the **shared worker retry loop**, keyed only off HTTP status codes + the standard `Retry-After` header — so they apply to Anthropic **and** every OpenAI-compatible upstream (OpenRouter, OpenCode Zen, NVIDIA, …). We deliberately do **not** adopt CC's Anthropic-only `anthropic-ratelimit-unified-reset` logic.

## Behavior change to note
Background 429s lose the bespoke 60/120/180s spacing and use the unified `0.5 → 32s` curve. Mitigation: the breaker now trips on the first 429 and pauses *all other* background work (60-600s), so aggregate pressure is governed centrally (closer to CC + a global pause) rather than per-call.

## Tests
- Rewrote the retry-policy unit tests for the unified policy (jitter-aware ranges, 32s cap, OpenCode-hang regression guard).
- Added `LORE_MAX_RETRIES` env-parsing edge-case tests (0/negative/empty/non-numeric/float → default).
- Added an integration test (mocks `upstreamFetch` via `vi.mock`): an urgent 429 storm exhausts to `null` (caller falls back) and trips the breaker **exactly once** across the retry loop.
- Full gateway suite: **1222 passed, 3 skipped**. Typecheck + Biome + `check:docs` clean.

## Follow-up (separate PR)
- Holding the compaction response while retrying could trip a client read-timeout on prolonged storms; CC solves this with 30s heartbeat yields. An **SSE keep-alive ping** for lore's streaming compaction would let us wait out longer windows without the connection bound. The bounded `8 × 32s` window + graceful fallback keeps the worst case safe meanwhile.
- The separate `[lore] warning: project path falling back to process.cwd()` line is a different code path (`pipeline.ts` direct `console.error`).