### PR TITLE
fix(gateway): harden request entrypoints against malformed input

### DIFF
--- a/packages/gateway/src/auth.ts
+++ b/packages/gateway/src/auth.ts
@@ -34,8 +34,10 @@ export type AuthCredential =
  * Returns `null` if neither is present.
  */
 export function extractAuth(
-  headers: Record<string, string>,
+  headers: Record<string, string> | null | undefined,
 ): AuthCredential | null {
+  if (!headers) return null;
+
   const apiKey = headers["x-api-key"] || headers["X-Api-Key"];
   if (apiKey) return { scheme: "api-key", value: apiKey };
 

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -5536,6 +5536,14 @@ export async function handleRequest(
   config: GatewayConfig,
 ): Promise<Response> {
   try {
+    // Guard against malformed invocations (e.g. fuzzers / direct module calls
+    // that pass an undefined or header-less request). The real server path
+    // always supplies a fully-formed GatewayRequest; bailing out cleanly here
+    // avoids a TypeError on `req.rawHeaders` deeper in the pipeline.
+    if (!req?.rawHeaders) {
+      return errorResponse(400, "Malformed request: missing headers");
+    }
+
     // Capture auth credentials early for background workers
     const earlyAuth = extractAuth(req.rawHeaders);
     if (earlyAuth) {

--- a/packages/gateway/test/auth.test.ts
+++ b/packages/gateway/test/auth.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, beforeEach } from "vitest";
 import {
+  extractAuth,
   setSessionAuth,
   getSessionAuth,
   deleteSessionAuth,
@@ -33,6 +34,38 @@ const minimaxCred: AuthCredential = {
   scheme: "api-key",
   value: "sk-cp-minimax-key",
 };
+
+// ---------------------------------------------------------------------------
+// Header extraction
+// ---------------------------------------------------------------------------
+
+describe("extractAuth", () => {
+  test("extracts x-api-key as api-key credential", () => {
+    expect(extractAuth({ "x-api-key": "sk-123" })).toEqual({
+      scheme: "api-key",
+      value: "sk-123",
+    });
+  });
+
+  test("extracts Bearer token as bearer credential", () => {
+    expect(extractAuth({ authorization: "Bearer tok-abc" })).toEqual({
+      scheme: "bearer",
+      value: "tok-abc",
+    });
+  });
+
+  test("returns null when no auth headers present", () => {
+    expect(extractAuth({})).toBeNull();
+  });
+
+  // Regression: a fuzzer (/opt/audit/fuzz-exports.js) called extractAuth()
+  // with undefined, triggering "Cannot read properties of undefined
+  // (reading 'x-api-key')" (Sentry LOREAI-GATEWAY-28). Guard returns null.
+  test("returns null for null/undefined headers instead of throwing", () => {
+    expect(extractAuth(null)).toBeNull();
+    expect(extractAuth(undefined)).toBeNull();
+  });
+});
 
 // ---------------------------------------------------------------------------
 // Staleness tracking


### PR DESCRIPTION
## What

Adds defensive guards to two gateway entrypoints that dereferenced their header arguments without a null check:

- **`extractAuth()`** (`auth.ts`) — now accepts `null | undefined` headers and returns `null` early, instead of throwing `TypeError: Cannot read properties of undefined (reading 'x-api-key')`.
- **`handleRequest()`** (`pipeline.ts`) — bails out with a clean `400 Malformed request: missing headers` when `req`/`req.rawHeaders` is missing, instead of throwing `Cannot read properties of undefined (reading 'rawHeaders')`.

## Why

Surfaced while reviewing post-launch Sentry telemetry. Issue **LOREAI-GATEWAY-28** (19 events, **0 affected users**, all in a single second from one host on release `0.25.0`) traced to an audit fuzzer at `/opt/audit/fuzz-exports.js` importing the bundle and invoking exports (`extractAuth`, `handleRequest`) with `undefined`/`null` args.

The real server path always supplies a fully-formed `GatewayRequest`, so this was never user-facing — but the unguarded derefs turned malformed/direct calls into uncaught `TypeError`s. Hardening the entrypoints makes them robust to fuzzing and any future direct-module invocation while keeping the fuzzer's behavior observable in Sentry (no inbound filtering added — these now register as benign `400`s rather than crashes).

## Tests

- Adds 4 regression tests for `extractAuth()` (valid api-key, valid bearer, no-auth → null, and **null/undefined → null** instead of throwing).
- `bun test packages/gateway/test/auth.test.ts` → 29 pass.
- `bun run typecheck` → passes (all packages).
- Biome clean on changed files.