### PR TITLE
fix(gateway): circuit-break runaway worker failures + stable Sentry grouping

### DIFF
--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -33,7 +33,7 @@ import {
   curatorLimiter,
 } from "@loreai/core";
 import type { LLMClient } from "@loreai/core";
-import { makeWorkerHealth } from "./worker-health";
+import { makeWorkerHealth, allowWorkerProbe } from "./worker-health";
 import type { GatewayConfig } from "./config";
 import type { SessionState } from "./translate/types";
 import { getWorkerModel, getModelEntrySync } from "./worker-model";
@@ -466,6 +466,13 @@ export function buildIdleWorkHandler(
     const cfg = loreConfig();
     const model = getWorkerModel(state.lastUpstream);
 
+    // Worker circuit breaker: when this session's background workers have been
+    // failing for a sustained period, skip the LLM-calling steps (distillation,
+    // curation, consolidation) and allow only a periodic probe — prevents the
+    // idle scheduler from re-driving a dead upstream every tick. Local steps
+    // (pruning, export, lat refresh, cost metrics) are unaffected.
+    const allowWorker = allowWorkerProbe(sessionID);
+
     // 1. Distillation — force-distill ALL pending messages on idle, even
     // below minMessages. The cache is going cold; aggressive distillation
     // now means a smaller context on the next turn via post-idle compact.
@@ -477,7 +484,7 @@ export function buildIdleWorkHandler(
           ? ("direct" as const)
           : ("batch" as const);
       const pending = temporal.undistilledCount(projectPath, sessionID);
-      if (pending > 0) {
+      if (allowWorker && pending > 0) {
         await distillation.run({
           llm,
           projectPath,
@@ -501,7 +508,7 @@ export function buildIdleWorkHandler(
         cfg.distillation.metaThreshold,
       );
       const g0 = distillation.gen0Count(projectPath, sessionID);
-      if (g0 >= metaThreshold) {
+      if (allowWorker && g0 >= metaThreshold) {
         await distillation.metaDistill({
           llm,
           projectPath,
@@ -517,7 +524,7 @@ export function buildIdleWorkHandler(
 
     // 2. Curation — cost-aware frequency: on expensive worker models, curate
     //    less often (same multiplier as the inline path in pipeline.ts).
-    if (cfg.knowledge.enabled && cfg.curator.onIdle) {
+    if (allowWorker && cfg.knowledge.enabled && cfg.curator.onIdle) {
       try {
         const workerModelID = model?.modelID ?? "unknown";
         const modelInputCost =
@@ -562,7 +569,7 @@ export function buildIdleWorkHandler(
     //    Cooldown: skip if we already attempted consolidation for this project
     //    with the same entry count within the last hour — avoids wasting
     //    Sonnet calls when the LLM correctly concludes all entries are unique.
-    if (cfg.knowledge.enabled) {
+    if (allowWorker && cfg.knowledge.enabled) {
       try {
         const entries = ltm.forProject(projectPath, false);
         if (entries.length > cfg.curator.maxEntries) {

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -158,7 +158,11 @@ import {
 } from "./auth";
 import type { UpstreamInterceptor } from "./recorder";
 import { startIdleScheduler, buildIdleWorkHandler } from "./idle";
-import { makeWorkerHealth, recordWorkerFailure } from "./worker-health";
+import {
+  makeWorkerHealth,
+  recordWorkerFailure,
+  allowWorkerProbe,
+} from "./worker-health";
 import {
   getWorkerModel,
   resetWorkerModelState,
@@ -3109,6 +3113,13 @@ function scheduleBackgroundWork(
   // Urgent distillation is exempt (it unblocks the next user turn).
   const quotaPaused = isQuotaPaused(resolveAuth(sessionID));
 
+  // Worker circuit breaker: when background workers have been failing for a
+  // sustained period, stop hammering the upstream every turn — allow only a
+  // periodic probe so a recovered upstream is detected without burning
+  // thousands of futile calls (Sentry: runaway lore-distill failure counts).
+  // Urgent distillation below is intentionally exempt — it unblocks the user.
+  const workerThrottled = !allowWorkerProbe(sessionID);
+
   // Check if urgent distillation is needed (gradient flagged it).
   // Mark urgent: true so these bypass the batch queue — the gradient is
   // in overflow and needs the result before the next user turn.
@@ -3137,7 +3148,7 @@ function scheduleBackgroundWork(
         metaThresholdOverride,
       })
       .catch((e) => log.error("background distillation failed:", e));
-  } else if (!isBackgroundPaused() && !quotaPaused) {
+  } else if (!isBackgroundPaused() && !quotaPaused && !workerThrottled) {
     // Incremental distillation and curation are non-urgent — skip when the
     // circuit breaker is active to reduce API pressure. These are also gated
     // by runBackground() which checks isBackgroundPaused(), but the early
@@ -3171,7 +3182,8 @@ function scheduleBackgroundWork(
   // that exceeds the diff pinning threshold invalidates tools + messages.
   // Also gated by circuit breaker — curation is never urgent.
   // Quota-paused accounts skip curation too (non-urgent background work).
-  if (isBackgroundPaused() || quotaPaused) return;
+  // Worker-throttled sessions (sustained worker failure) skip it as well.
+  if (isBackgroundPaused() || quotaPaused || workerThrottled) return;
 
   const modelInputCost =
     getModelEntrySync(

--- a/packages/gateway/src/worker-health.ts
+++ b/packages/gateway/src/worker-health.ts
@@ -104,12 +104,16 @@ const SESSION_TTL_MS = 60 * 60 * 1000; // 1 hour
 const SWEEP_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 
 /**
- * Sustained failure duration after which the circuit breaker opens. Aligned
- * with the user-facing "degraded" threshold: once we've been failing this
- * long, the upstream is genuinely down (not a transient blip), so callers
- * should stop hammering it every turn and probe only periodically.
+ * Sustained failure duration after which the circuit breaker opens. Once we've
+ * been failing this long the upstream is genuinely down (not a transient blip),
+ * so callers should stop hammering it every turn and probe only periodically.
+ *
+ * Independent of (but currently equal to) {@link RESPONSE_MESSAGE_THRESHOLD_MS}:
+ * "when to stop hammering the upstream" is a distinct concern from "when to
+ * warn the user", so they get their own constants even though both are 30m
+ * today — changing one for UX reasons must not silently change the other.
  */
-const CIRCUIT_OPEN_THRESHOLD_MS = RESPONSE_MESSAGE_THRESHOLD_MS; // 30 minutes
+const CIRCUIT_OPEN_THRESHOLD_MS = 30 * 60 * 1000; // 30 minutes
 
 /**
  * While the circuit is open, allow at most one worker probe per this interval.
@@ -353,6 +357,13 @@ export function recordWorkerSuccess(sessionID: string): void {
  * Callers MUST only gate *non-urgent* background work with this. Urgent
  * distillation and blocking compaction are intentionally exempt — starving
  * them harms the user more than a futile retry costs.
+ *
+ * Note: those exempt paths omit the `workerHealth` hook entirely, so they are
+ * invisible to the breaker — they neither open/extend it (their failures
+ * aren't recorded) nor close it (no `recordWorkerSuccess`). Recovery is
+ * therefore detected only by the periodic non-urgent probe this gate lets
+ * through, which DOES carry the hook; recovery latency is bounded by
+ * {@link CIRCUIT_PROBE_INTERVAL_MS}.
  */
 export function allowWorkerProbe(sessionID: string): boolean {
   const entry = state.get(sessionID);

--- a/packages/gateway/src/worker-health.ts
+++ b/packages/gateway/src/worker-health.ts
@@ -103,6 +103,23 @@ const SESSION_TTL_MS = 60 * 60 * 1000; // 1 hour
 /** How often the TTL sweep runs. */
 const SWEEP_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 
+/**
+ * Sustained failure duration after which the circuit breaker opens. Aligned
+ * with the user-facing "degraded" threshold: once we've been failing this
+ * long, the upstream is genuinely down (not a transient blip), so callers
+ * should stop hammering it every turn and probe only periodically.
+ */
+const CIRCUIT_OPEN_THRESHOLD_MS = RESPONSE_MESSAGE_THRESHOLD_MS; // 30 minutes
+
+/**
+ * While the circuit is open, allow at most one worker probe per this interval.
+ * Because every failed probe refreshes `lastFailureAt`, gating on the age of
+ * the last failure throttles attempts to roughly one per interval — turning a
+ * runaway (thousands of failures/hour) into a slow heartbeat that still
+ * detects recovery.
+ */
+const CIRCUIT_PROBE_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+
 // ---------------------------------------------------------------------------
 // State
 // ---------------------------------------------------------------------------
@@ -224,28 +241,30 @@ export function recordWorkerFailure(
     !entry.alertSentAt || t - entry.alertSentAt > ALERT_COOLDOWN_MS;
   if (shouldAlert) {
     entry.alertSentAt = t;
-    Sentry.captureMessage(
-      `Worker health degraded for session ${sessionID.slice(0, 16)}`,
-      {
-        level: "error",
-        tags: {
-          worker_id: workerID,
-          reason,
-          session_id: sessionID,
-          failure_count: String(entry.failureCount),
-        },
-        contexts: {
-          worker_health: {
-            sessionID,
-            workerIDs: [...entry.workerIDs],
-            reasons: [...entry.reasons],
-            failureCount: entry.failureCount,
-            firstFailureAt: entry.firstFailureAt,
-            lastFailureAt: entry.lastFailureAt,
-          },
+    // Stable message + fingerprint so Sentry groups all degradations of a
+    // given worker into ONE issue. The session ID / counts vary per event and
+    // MUST live in tags+contexts only — embedding them in the message text
+    // spawns a new Sentry issue per session (LOREAI-GATEWAY worker-health noise).
+    Sentry.captureMessage("Worker health degraded", {
+      level: "error",
+      fingerprint: ["worker-health-degraded", workerID],
+      tags: {
+        worker_id: workerID,
+        reason,
+        session_id: sessionID,
+        failure_count: String(entry.failureCount),
+      },
+      contexts: {
+        worker_health: {
+          sessionID,
+          workerIDs: [...entry.workerIDs],
+          reasons: [...entry.reasons],
+          failureCount: entry.failureCount,
+          firstFailureAt: entry.firstFailureAt,
+          lastFailureAt: entry.lastFailureAt,
         },
       },
-    );
+    });
   }
 
   // Critical escalation: sustained 1h+ of failure → Sentry exception.
@@ -256,14 +275,20 @@ export function recordWorkerFailure(
       !entry.exceptionSentAt || t - entry.exceptionSentAt > 60 * 60 * 1000;
     if (shouldException) {
       entry.exceptionSentAt = t;
-      const err = new Error(
-        `Worker health critical: ${entry.failureCount} failures sustained for ${formatDuration(sustainedMs)} on session ${sessionID}`,
-      );
+      // Stable Error message + fingerprint so Sentry groups all critical
+      // outages of a given worker into ONE issue. The previous message
+      // embedded the failure count, duration, AND session ID, so EVERY event
+      // was a unique issue (dozens of one-off LOREAI-GATEWAY issues). The
+      // varying detail lives in tags+contexts below.
+      const err = new Error("Worker health critical: sustained worker failure");
       Sentry.captureException(err, {
+        fingerprint: ["worker-health-critical", workerID],
         tags: {
           worker_id: workerID,
           reason,
           session_id: sessionID,
+          failure_count: String(entry.failureCount),
+          sustained: formatDuration(sustainedMs),
         },
         contexts: {
           worker_health: {
@@ -297,14 +322,48 @@ export function recordWorkerSuccess(sessionID: string): void {
     log.info(
       `[worker-health] session ${sessionID.slice(0, 16)} recovered (was degraded, now healthy)`,
     );
-    Sentry.captureMessage(
-      `Worker health recovered for session ${sessionID.slice(0, 16)}`,
-      {
-        level: "info",
-        tags: { session_id: sessionID },
-      },
-    );
+    // Recovery is a GOOD event — record it as a breadcrumb (forensic context
+    // for any later event in this scope) rather than a captured message, which
+    // would otherwise spawn its own Sentry issue per session (noise).
+    Sentry.addBreadcrumb({
+      category: "worker-health",
+      level: "info",
+      message: "Worker health recovered",
+      data: { session_id: sessionID },
+    });
   }
+}
+
+/**
+ * Circuit breaker: decide whether a non-urgent background worker should be
+ * allowed to run for this session right now.
+ *
+ * Returns `true` when the session is healthy, when sustained failure hasn't
+ * yet crossed {@link CIRCUIT_OPEN_THRESHOLD_MS} (circuit closed), or when the
+ * circuit is open but enough time has elapsed since the last failure to allow
+ * a single recovery probe. Returns `false` while the circuit is open and
+ * within the probe cooldown.
+ *
+ * Pure read-only predicate (no side effects): the throttle clock is the
+ * existing `lastFailureAt`, which {@link recordWorkerFailure} refreshes on
+ * every failure. So a failed probe pushes the next allowed probe out by
+ * {@link CIRCUIT_PROBE_INTERVAL_MS}, and a success ({@link recordWorkerSuccess})
+ * clears the entry entirely, closing the circuit.
+ *
+ * Callers MUST only gate *non-urgent* background work with this. Urgent
+ * distillation and blocking compaction are intentionally exempt — starving
+ * them harms the user more than a futile retry costs.
+ */
+export function allowWorkerProbe(sessionID: string): boolean {
+  const entry = state.get(sessionID);
+  if (!entry) return true; // healthy — no recorded failures
+
+  const t = now();
+  // Circuit closed: failures haven't been sustained long enough to throttle.
+  if (t - entry.firstFailureAt < CIRCUIT_OPEN_THRESHOLD_MS) return true;
+
+  // Circuit open: allow a probe only once the last failure is old enough.
+  return t - entry.lastFailureAt >= CIRCUIT_PROBE_INTERVAL_MS;
 }
 
 /**

--- a/packages/gateway/test/worker-health.test.ts
+++ b/packages/gateway/test/worker-health.test.ts
@@ -1,7 +1,9 @@
 import { describe, test, expect, beforeEach, vi } from "vitest";
+import * as Sentry from "@sentry/bun";
 import {
   recordWorkerFailure,
   recordWorkerSuccess,
+  allowWorkerProbe,
   getStatus,
   getDegradationWarning,
   getWorkerHealth,
@@ -13,6 +15,7 @@ import {
 vi.mock("@sentry/bun", () => ({
   captureMessage: vi.fn(),
   captureException: vi.fn(),
+  addBreadcrumb: vi.fn(),
 }));
 
 vi.mock("@loreai/core", () => ({
@@ -28,6 +31,7 @@ describe("worker-health", () => {
   beforeEach(() => {
     _resetForTest();
     _setNowForTest(() => 1_000_000);
+    vi.clearAllMocks();
   });
 
   describe("sliding window", () => {
@@ -157,6 +161,118 @@ describe("worker-health", () => {
       recordWorkerFailure("s1", "lore-distill", "no-auth");
       expect(getStatus("s2")).toBe("healthy");
       expect(getDegradationWarning("s2")).toBeNull();
+    });
+  });
+
+  // Regression: variable data (session ID, counts, durations) used to be
+  // embedded in the Sentry message/Error text, spawning a new issue per
+  // session — dozens of one-off LOREAI-GATEWAY worker-health issues. Stable
+  // message + fingerprint groups them into one issue per worker.
+  describe("Sentry grouping", () => {
+    test("degraded alert uses stable message + fingerprint, ids in tags", () => {
+      // 3 rapid failures in the window fire the degraded alert.
+      recordWorkerFailure("s1", "lore-distill", "no-response");
+      recordWorkerFailure("s1", "lore-distill", "no-response");
+      recordWorkerFailure("s1", "lore-distill", "no-response");
+
+      expect(Sentry.captureMessage).toHaveBeenCalledTimes(1);
+      const [msg, opts] = (Sentry.captureMessage as ReturnType<typeof vi.fn>)
+        .mock.calls[0];
+      expect(msg).toBe("Worker health degraded");
+      expect(opts.fingerprint).toEqual([
+        "worker-health-degraded",
+        "lore-distill",
+      ]);
+      // Variable data must live in tags, NOT the grouping message.
+      expect(opts.tags.session_id).toBe("s1");
+      expect(opts.tags.worker_id).toBe("lore-distill");
+    });
+
+    test("critical alert uses stable Error message + fingerprint", () => {
+      // Keep failures within the 5-min window (no reset) so firstFailureAt
+      // stays put while sustained duration crosses the 60-min threshold.
+      let t = 1_000_000;
+      for (let i = 0; i <= 16; i++) {
+        _setNowForTest(() => t);
+        recordWorkerFailure("s1", "lore-distill", "no-response");
+        t += 4 * 60 * 1000; // 4 min apart — inside the 5-min window
+      }
+
+      expect(Sentry.captureException).toHaveBeenCalled();
+      const [err, opts] = (Sentry.captureException as ReturnType<typeof vi.fn>)
+        .mock.calls[0];
+      expect((err as Error).message).toBe(
+        "Worker health critical: sustained worker failure",
+      );
+      expect(opts.fingerprint).toEqual([
+        "worker-health-critical",
+        "lore-distill",
+      ]);
+      expect(opts.tags.session_id).toBe("s1");
+    });
+
+    test("recovery is a breadcrumb, not a captured issue", () => {
+      // Drive to degraded so the recovery path is in alert state.
+      let t = 1_000_000;
+      for (let i = 0; i < 3; i++) {
+        _setNowForTest(() => t);
+        recordWorkerFailure("s1", "lore-distill", "no-response");
+        t += 5 * 60 * 1000;
+      }
+      _setNowForTest(() => 1_000_000 + 31 * 60 * 1000);
+      expect(getStatus("s1")).toBe("degraded");
+
+      recordWorkerSuccess("s1");
+      expect(Sentry.addBreadcrumb).toHaveBeenCalledTimes(1);
+      const [crumb] = (Sentry.addBreadcrumb as ReturnType<typeof vi.fn>).mock
+        .calls[0];
+      expect(crumb.message).toBe("Worker health recovered");
+    });
+  });
+
+  describe("circuit breaker (allowWorkerProbe)", () => {
+    test("healthy session is always allowed", () => {
+      expect(allowWorkerProbe("s1")).toBe(true);
+    });
+
+    test("recent failures keep the circuit closed (allowed)", () => {
+      recordWorkerFailure("s1", "lore-distill", "no-response");
+      recordWorkerFailure("s1", "lore-distill", "no-response");
+      expect(allowWorkerProbe("s1")).toBe(true);
+    });
+
+    test("sustained failure opens circuit and throttles to one probe per interval", () => {
+      const t0 = 1_000_000;
+      // First failure sets firstFailureAt.
+      _setNowForTest(() => t0);
+      recordWorkerFailure("s1", "lore-distill", "no-response");
+      // A failure 31 min later: window rotates, firstFailureAt preserved →
+      // sustained 31 min ≥ 30 min open threshold.
+      _setNowForTest(() => t0 + 31 * 60 * 1000);
+      recordWorkerFailure("s1", "lore-distill", "no-response");
+
+      // Just failed → within probe cooldown → blocked.
+      expect(allowWorkerProbe("s1")).toBe(false);
+
+      // 5 min after the last failure → one probe allowed.
+      _setNowForTest(() => t0 + 36 * 60 * 1000);
+      expect(allowWorkerProbe("s1")).toBe(true);
+
+      // A failed probe refreshes lastFailureAt → blocked again.
+      recordWorkerFailure("s1", "lore-distill", "no-response");
+      expect(allowWorkerProbe("s1")).toBe(false);
+    });
+
+    test("a successful worker call closes the circuit", () => {
+      const t0 = 1_000_000;
+      _setNowForTest(() => t0);
+      recordWorkerFailure("s1", "lore-distill", "no-response");
+      _setNowForTest(() => t0 + 31 * 60 * 1000);
+      recordWorkerFailure("s1", "lore-distill", "no-response");
+      expect(allowWorkerProbe("s1")).toBe(false);
+
+      recordWorkerSuccess("s1");
+      expect(allowWorkerProbe("s1")).toBe(true);
     });
   });
 });

--- a/packages/gateway/test/worker-health.test.ts
+++ b/packages/gateway/test/worker-health.test.ts
@@ -191,6 +191,8 @@ describe("worker-health", () => {
     test("critical alert uses stable Error message + fingerprint", () => {
       // Keep failures within the 5-min window (no reset) so firstFailureAt
       // stays put while sustained duration crosses the 60-min threshold.
+      // 17 failures × 4 min = 68 min elapsed > 60-min CRITICAL_THRESHOLD_MS,
+      // so the captureException fires on the failure at the 60-min mark.
       let t = 1_000_000;
       for (let i = 0; i <= 16; i++) {
         _setNowForTest(() => t);
@@ -273,6 +275,36 @@ describe("worker-health", () => {
 
       recordWorkerSuccess("s1");
       expect(allowWorkerProbe("s1")).toBe(true);
+    });
+
+    test("long gap since last failure allows a probe even while open", () => {
+      // After the circuit opens, a long stretch with no new failures means
+      // the next attempt is always allowed (probe interval long-since passed),
+      // so a recovered upstream is re-probed rather than starved forever.
+      const t0 = 1_000_000;
+      _setNowForTest(() => t0);
+      recordWorkerFailure("s1", "lore-distill", "no-response");
+      _setNowForTest(() => t0 + 31 * 60 * 1000);
+      recordWorkerFailure("s1", "lore-distill", "no-response");
+      expect(allowWorkerProbe("s1")).toBe(false); // just failed → cooldown
+
+      // 61 min after the last failure — well past the 5-min probe interval.
+      _setNowForTest(() => t0 + 31 * 60 * 1000 + 61 * 60 * 1000);
+      expect(allowWorkerProbe("s1")).toBe(true);
+    });
+
+    test("breaker is per-session, spanning workers (one circuit per session)", () => {
+      // Failures attributed to different workers in the same session share one
+      // circuit — when the upstream is down, distill failures gate curation too.
+      const t0 = 1_000_000;
+      _setNowForTest(() => t0);
+      recordWorkerFailure("s1", "lore-distill", "no-response");
+      _setNowForTest(() => t0 + 31 * 60 * 1000);
+      recordWorkerFailure("s1", "lore-curator", "no-response");
+      // Circuit is open for the whole session regardless of which worker asks.
+      expect(allowWorkerProbe("s1")).toBe(false);
+      // A different session is unaffected.
+      expect(allowWorkerProbe("s2")).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## What

Two fixes to the background-worker health subsystem, both surfaced by post-launch Sentry triage of the `Worker health degraded`/`critical` issues.

### 1. Stable Sentry grouping (observability)
The degraded `captureMessage` and critical `captureException` embedded variable data — session ID, and for "critical" the failure count + duration — directly in the message/Error text. Sentry groups by message, so **every session (and every count/duration combo) became a brand-new issue** — dozens of one-off `LOREAI-GATEWAY` worker-health issues. Recovery events were also captured as their own issues.

- Degraded → stable message `"Worker health degraded"` + `fingerprint: ["worker-health-degraded", workerID]`.
- Critical → stable `Error("Worker health critical: sustained worker failure")` + `fingerprint: ["worker-health-critical", workerID]`.
- All variable data (session ID, failure count, duration) moved to **tags + contexts**.
- Recovery is now a **breadcrumb**, not a captured issue (it's a good event — no need to spawn an issue).

Net effect: the fragmented issues collapse into one issue per worker per severity.

### 2. Circuit breaker (root cause of the runaway counts)
`worker-health` was purely observational — `getStatus()` had **no consumer in the scheduler**. So the idle + in-flight schedulers kept re-driving a dead upstream every turn, accumulating huge failure counts over hours (observed in Sentry: **10,783 failures over 15h** on `lore-distill`; 5,545 over 2h).

- New `allowWorkerProbe(sessionID)` — a **pure predicate** (no side effects) that:
  - returns `true` while healthy or while sustained failure is under the open threshold (30m);
  - once open, allows only **one probe per 5m**, throttled via the existing `lastFailureAt` clock (a failed probe pushes the next one out; a success clears state and closes the circuit).
- Wired into `scheduleBackgroundWork()` (in-flight) and the idle handler for **non-urgent** distillation / curation / consolidation only.
- **Urgent distillation and blocking compaction are intentionally exempt** — starving them harms the user more than a futile retry costs.

This turns a runaway (thousands of failures/hour) into a slow heartbeat that still detects recovery.

## Tests
Adds coverage for: stable degraded message/fingerprint/tags, stable critical Error/fingerprint, recovery-as-breadcrumb, and the circuit-breaker open → throttle → close lifecycle. `worker-health.test.ts`: 17 pass.

`bun run typecheck` passes; Biome clean; full gateway suite shows no new failures (the 2 pre-existing `node:sqlite` env failures are unchanged).

## Follow-up
The previously-fragmented worker-health issues (GATEWAY-21..29) will stop receiving events under the new grouping; they can be bulk-resolved once this ships.