### PR TITLE
fix(gateway): make the LLM adapter the single owner of worker-failure attribution

### DIFF
--- a/packages/core/src/curator.ts
+++ b/packages/core/src/curator.ts
@@ -622,7 +622,9 @@ async function runInner(input: {
     temperature: 0,
   });
   if (!responseText) {
-    input.workerHealth?.recordFailure("no-response");
+    // Transport failure / empty completion already recorded by the LLM
+    // adapter (single owner of transport-failure attribution) — avoid
+    // double-counting here.
     return {
       created: 0,
       updated: 0,
@@ -961,7 +963,9 @@ export async function consolidate(input: {
     },
   );
   if (!responseText) {
-    input.workerHealth?.recordFailure("no-response");
+    // Transport failure / empty completion already recorded by the LLM
+    // adapter (single owner of transport-failure attribution) — avoid
+    // double-counting here.
     return { updated: 0, deleted: 0 };
   }
 

--- a/packages/core/src/distillation.ts
+++ b/packages/core/src/distillation.ts
@@ -1035,7 +1035,9 @@ async function distillSegment(input: {
     },
   );
   if (!responseText) {
-    input.workerHealth?.recordFailure("no-response");
+    // Transport failure / empty completion is already recorded by the LLM
+    // adapter (single owner of transport-failure attribution) — recording
+    // here too would double-count (e.g. a no-auth failure logged twice).
     return null;
   }
 
@@ -1315,7 +1317,9 @@ async function metaDistillInner(input: {
     temperature: 0,
   });
   if (!responseText) {
-    input.workerHealth?.recordFailure("no-response");
+    // Transport failure / empty completion is already recorded by the LLM
+    // adapter (single owner of transport-failure attribution) — recording
+    // here too would double-count (e.g. a no-auth failure logged twice).
     return null;
   }
 

--- a/packages/core/test/distillation.test.ts
+++ b/packages/core/test/distillation.test.ts
@@ -1488,7 +1488,7 @@ describe("run() expansion guard and tiny-segment handling", () => {
     // counts (the gpt-5.5 no-auth runaway). The adapter is now the single
     // owner of transport-failure attribution; the core must stay silent.
     insertTemporalMessages(6, 200);
-    const llm = makeStubLLM(null); // prompt() resolves to "" (empty)
+    const llm = makeStubLLM(null); // prompt() returns "" (null → ""), falsy
     const reasons: string[] = [];
     const workerHealth = {
       recordFailure: (reason: string) => reasons.push(reason),

--- a/packages/core/test/distillation.test.ts
+++ b/packages/core/test/distillation.test.ts
@@ -1481,6 +1481,35 @@ describe("run() expansion guard and tiny-segment handling", () => {
     db().query("DELETE FROM distillations WHERE project_id = ?").run(pid);
   });
 
+  test("empty LLM response does NOT record no-response in core (adapter owns it)", async () => {
+    // Regression: a null/empty worker response used to be recorded as
+    // "no-response" by BOTH the LLM adapter (on the failing call) and the
+    // distiller here — double-counting and inflating worker-health failure
+    // counts (the gpt-5.5 no-auth runaway). The adapter is now the single
+    // owner of transport-failure attribution; the core must stay silent.
+    insertTemporalMessages(6, 200);
+    const llm = makeStubLLM(null); // prompt() resolves to "" (empty)
+    const reasons: string[] = [];
+    const workerHealth = {
+      recordFailure: (reason: string) => reasons.push(reason),
+      recordSuccess: () => {},
+    };
+
+    await run({
+      llm,
+      projectPath: RUN_PROJECT,
+      sessionID: RUN_SESSION,
+      force: true,
+      workerHealth,
+    });
+
+    // LLM was called and returned empty — but core recorded NO failure
+    // (neither no-response nor anything else); the adapter would have.
+    expect(llm.prompts.length).toBeGreaterThan(0);
+    expect(reasons).not.toContain("no-response");
+    expect(reasons).toHaveLength(0);
+  });
+
   test("expansion guard: discards distillation when output > expansion limit, marks messages distilled", async () => {
     // Insert 6 messages × 200 tokens = 1200 tokens (above minSegmentTokens=64)
     const ids = insertTemporalMessages(6, 200);

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -660,15 +660,19 @@ export function createGatewayLLMClient(
               if (AUTH_ERROR_CODES.has(response.status)) {
                 const text = await response.text().catch(() => "(no body)");
 
+                // Always record the auth failure so the worker-health ladder
+                // sees it even for session-less paths (the adapter is the
+                // single owner of transport-failure attribution).
+                recordWorkerFailure(
+                  opts?.sessionID ?? "_unknown",
+                  opts?.workerID ?? "unknown",
+                  "auth-rejected",
+                );
                 // Mark this provider's credential stale so resolveAuth()
                 // falls through to global — but only for THIS provider,
-                // not other providers on the same session.
+                // not other providers on the same session. Requires a real
+                // session ID (staleness is per-session state).
                 if (opts?.sessionID) {
-                  recordWorkerFailure(
-                    opts.sessionID,
-                    opts?.workerID ?? "unknown",
-                    "auth-rejected",
-                  );
                   markAuthStale(opts.sessionID, model.providerID);
                 }
 

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -640,7 +640,20 @@ export function createGatewayLLMClient(
                 // transport layer would clear failure state before the parse
                 // step can record "parse-error", making sustained parse
                 // failures invisible to the health ladder.
-                return parsed.text;
+                if (parsed.text) return parsed.text;
+
+                // Transport succeeded but the model returned no usable text.
+                // Record as no-response here so the adapter is the single
+                // owner of transport-failure attribution — core workers no
+                // longer record on a null return (which double-counted, e.g.
+                // a no-auth failure was logged by both the adapter AND the
+                // distiller). Sustained empty completions still escalate.
+                recordWorkerFailure(
+                  opts?.sessionID ?? "_unknown",
+                  opts?.workerID ?? "unknown",
+                  "no-response",
+                );
+                return null;
               }
 
               // --- Auth error: 401/403 — mark stale, re-resolve, retry once ---
@@ -836,12 +849,25 @@ export function createGatewayLLMClient(
               }
               span.setAttribute("lore.retry.final_status", finalStatus);
               span.setStatus({ code: 2, message: `HTTP exhausted retries` });
+              recordWorkerFailure(
+                opts?.sessionID ?? "_unknown",
+                opts?.workerID ?? "unknown",
+                response.status === 429 ? "rate-limit" : "upstream-error",
+              );
               return null;
             }
           },
         );
       } catch (e) {
         log.error("worker prompt failed:", e);
+        // Network/timeout error — no response was received. Record here so the
+        // adapter remains the single owner of transport-failure attribution
+        // (core workers no longer record on a null return).
+        recordWorkerFailure(
+          opts?.sessionID ?? "_unknown",
+          opts?.workerID ?? "unknown",
+          "no-response",
+        );
         return null;
       } finally {
         activeWorkerCalls.delete(callID);


### PR DESCRIPTION
## What

Eliminates double-counting of background-worker failures by making the LLM adapter the single owner of transport-failure attribution.

## Why

Post-launch Sentry triage of the worker-health issues showed the dominant `lore-distill` failure reason over 30 days is **`no-auth` (83 events, 76 on gpt-5.5)** — not `no-response`. While investigating, I found a clear accounting bug:

A failed worker prompt was recorded **twice** for one logical attempt:
- `llm-adapter.ts` records the specific reason (`no-auth`, `protocol-mismatch`, `auth-rejected`, `upstream-error`) and returns `null`.
- The core distiller/curator then sees `responseText == null` and records `no-response` on top.

This ~2x-inflated worker-health failure counts (a contributor to the runaway counts that triggered the circuit breaker in #669) and polluted the reason mix.

## Change

**Adapter** (`llm-adapter.ts`) — record a failure on the three null-return paths that previously recorded nothing, so the adapter owns *all* transport-failure attribution:
- empty completion (HTTP 200 with no usable text) → `no-response`
- exhausted retries → `rate-limit` (429) / `upstream-error`
- network/timeout throw → `no-response`

**Core** (`distillation.ts` ×2, `curator.ts` ×2) — stop recording `no-response` on a null return (now adapter-owned). They still record `parse-error` (a post-success semantic failure the adapter can't see) and `recordSuccess()` after a good parse.

Net: exactly one failure per failed attempt, with a more accurate reason (e.g. exhaustion now reads `rate-limit`/`upstream-error` instead of generic `no-response`).

## Tests
- New core test: an empty LLM response no longer triggers a core `no-response` recording.
- Full `vitest run`: 90 files, 2477 passed, 0 failures. `typecheck` + Biome clean.

## Scope note
This is the safe accounting fix. It does **not** change *why* `no-auth` happens on gpt-5.5 sessions — that root cause (suspected provider-ID namespace mismatch in worker auth resolution) is a separate, more delicate investigation to follow.