### PR TITLE
feat(gateway): offline compaction from distillations + SSE keepalive

### DIFF
--- a/packages/core/src/prompt.ts
+++ b/packages/core/src/prompt.ts
@@ -629,6 +629,11 @@ function formatOneDistillation(d: {
   return `(${meta})\n${d.observations.trim()}`;
 }
 
+// TODO: COMPACT_SUMMARY_TEMPLATE and buildCompactPrompt are dead code since
+// compaction switched to offline assembly from distillations (PR #672). The
+// template + prompt were used by the now-removed `lore-compact` LLM call.
+// Remove in a follow-up cleanup PR.
+//
 // Strict Markdown skeleton for the /compact session summary. Task-oriented
 // sections so the next agent starting from the compacted context has a clear
 // "where am I, what's next, what's blocked" briefing. Derived from upstream

--- a/packages/gateway/src/compaction.ts
+++ b/packages/gateway/src/compaction.ts
@@ -69,7 +69,7 @@ function lastUserText(req: GatewayRequest): string {
 }
 
 /** Rough token estimate: ~4 characters per token. */
-function estimateTokens(text: string): number {
+export function estimateTokens(text: string): number {
   return Math.ceil(text.length / 4);
 }
 

--- a/packages/gateway/src/compaction.ts
+++ b/packages/gateway/src/compaction.ts
@@ -358,6 +358,101 @@ export function isMetaRequest(req: GatewayRequest): boolean {
 }
 
 // ---------------------------------------------------------------------------
+// Offline compaction assembly
+// ---------------------------------------------------------------------------
+
+/**
+ * Assemble a compaction summary deterministically from Lore's own memory —
+ * no LLM call. The distillation observations are already prose summaries of
+ * conversation segments (Lore's compressed history), so concatenating them in
+ * order, plus the prior compacted summary and the long-term knowledge block,
+ * produces a usable summary on its own.
+ *
+ * This deliberately does NOT follow the LLM `COMPACT_SUMMARY_TEMPLATE`
+ * (Goal / Progress / Decisions / …) — that shaping requires the model. The
+ * raw assembly is intentionally accepted as "good enough": it preserves the
+ * salient compressed history without depending on the rate-limited compaction
+ * LLM call.
+ *
+ * @returns the assembled markdown summary, or `null` when there is genuinely
+ *   nothing to compact (no prior summary, no distillations, no pending
+ *   messages, no knowledge).
+ */
+export function assembleOfflineCompaction(input: {
+  /** Prior `/compact` output, carried forward verbatim when present. */
+  previousSummary?: string;
+  /** Distillation rows for the session, oldest-first. */
+  distillations: Array<{ observations: string; generation: number }>;
+  /** Long-term knowledge block (already formatted markdown), if any. */
+  knowledge?: string;
+  /**
+   * Any still-undistilled messages — included verbatim (truncated) as a
+   * trailing "recent activity" section so the conversation tail is never lost
+   * if distillation could not bring everything current (e.g. a sustained 429).
+   */
+  undistilled?: Array<{ role: string; content: string }>;
+}): string | null {
+  const { distillations } = input;
+  const prevTrimmed = input.previousSummary?.trim() ?? "";
+  const knowledgeTrimmed = input.knowledge?.trim() ?? "";
+  const tail = input.undistilled ?? [];
+
+  const hasDistillations = distillations.length > 0;
+  const hasUndistilled = tail.length > 0;
+  const hasPrev = prevTrimmed.length > 0;
+  const hasKnowledge = knowledgeTrimmed.length > 0;
+  if (!hasDistillations && !hasUndistilled && !hasPrev && !hasKnowledge) {
+    return null;
+  }
+
+  const sections: string[] = ["# Session Summary"];
+
+  if (hasPrev) {
+    sections.push(`## Earlier summary\n\n${prevTrimmed}`);
+  }
+
+  if (hasDistillations) {
+    const chunks = distillations.map((d, i) => {
+      const label =
+        d.generation > 0
+          ? `### Segment ${i + 1} (consolidated)`
+          : `### Segment ${i + 1}`;
+      return `${label}\n${d.observations.trim()}`;
+    });
+    sections.push(`## Conversation history\n\n${chunks.join("\n\n")}`);
+  }
+
+  if (hasUndistilled) {
+    // Cap the raw tail so an un-distilled burst can't bloat the summary.
+    const MAX_RAW_CHARS = 4000;
+    const lines: string[] = [];
+    let used = 0;
+    for (const m of tail) {
+      const text = m.content.trim();
+      if (!text) continue;
+      const entry = `- **${m.role}**: ${text}`;
+      if (used + entry.length > MAX_RAW_CHARS) {
+        lines.push("- …(remaining recent messages omitted)");
+        break;
+      }
+      lines.push(entry);
+      used += entry.length;
+    }
+    if (lines.length > 0) {
+      sections.push(
+        `## Recent activity (not yet summarized)\n\n${lines.join("\n")}`,
+      );
+    }
+  }
+
+  if (hasKnowledge) {
+    sections.push(knowledgeTrimmed);
+  }
+
+  return sections.join("\n\n");
+}
+
+// ---------------------------------------------------------------------------
 // buildCompactionResponse
 // ---------------------------------------------------------------------------
 

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -42,7 +42,6 @@ import {
   getConsecutiveBusts,
   effectiveMetaThreshold as computeMetaThreshold,
   formatKnowledge,
-  buildCompactPrompt,
   shouldImportLoreFile,
   importLoreFile,
   loreFileExists,
@@ -104,6 +103,7 @@ import {
   LORE_AGENT_HEADER,
   extractPreviousSummary,
   buildCompactionResponse,
+  assembleOfflineCompaction,
   scaleUsageForClient,
 } from "./compaction";
 import {
@@ -131,6 +131,7 @@ import {
   createRecallAwareAccumulator,
   parseSSEStream,
   buildSSETextResponse,
+  buildKeepaliveCompactionStream,
   formatSSEEvent,
   type StreamAccumulator,
   type RecallAwareAccumulator,
@@ -3243,9 +3244,19 @@ function scheduleBackgroundWork(
 // ---------------------------------------------------------------------------
 
 /**
- * Generate a compaction summary for a session. Force-distills any pending
- * messages, loads existing distillation summaries, builds a knowledge block,
- * and calls the LLM to produce a compaction summary.
+ * Interval between keep-alive `ping` events sent on the compaction SSE stream
+ * while the summary is being generated. Anthropic itself sends periodic pings
+ * on long-running streams; this keeps the client connection from timing out
+ * while we (possibly) distill the remainder under a rate limit.
+ */
+const COMPACT_KEEPALIVE_PING_MS = 15_000;
+
+/**
+ * Generate a compaction summary for a session, assembled deterministically
+ * from Lore's own memory (distillations + long-term knowledge + the prior
+ * summary). The only LLM work is urgently distilling any undistilled
+ * remainder first; there is no dedicated "compaction" LLM call. Returns null
+ * only when there is genuinely nothing to compact.
  *
  * This is the core logic shared by both:
  *  - `handleCompaction` (HTTP-intercepted compaction from Claude Code / OpenCode)
@@ -3260,26 +3271,31 @@ export async function generateCompactionSummary(opts: {
 }): Promise<string | null> {
   const { projectPath, sessionID, config, previousSummary, sessionUpstream } =
     opts;
-  const llm = getLLMClient(config);
 
-  // 1. Force-distill all undistilled messages.
-  // Mark urgent: true — client is blocking on the compaction response.
-  const model = getWorkerModel(sessionUpstream);
-  await distillation.run({
-    llm,
-    projectPath,
-    sessionID,
-    model,
-    force: true,
-    urgent: true,
-    callType: "direct",
-    workerHealth: makeWorkerHealth(sessionID, "lore-distill"),
-  });
+  // 1. Bring distillations current. Compaction does NOT make a dedicated
+  //    "compaction" LLM call anymore — its only LLM work is distilling the
+  //    undistilled remainder. When everything is already distilled this is
+  //    skipped entirely (instant, zero-cost compaction). When not, we distill
+  //    urgently; the caller's keep-alive stream holds the client connection
+  //    open during any rate-limit wait. A distillation failure is non-fatal:
+  //    step 3 assembles from whatever distillations exist plus the raw tail.
+  if (temporal.undistilledCount(projectPath, sessionID) > 0) {
+    const llm = getLLMClient(config);
+    const model = getWorkerModel(sessionUpstream);
+    await distillation.run({
+      llm,
+      projectPath,
+      sessionID,
+      model,
+      force: true,
+      urgent: true,
+      callType: "direct",
+      workerHealth: makeWorkerHealth(sessionID, "lore-distill"),
+    });
+  }
 
-  // 2. Load distillation summaries
+  // 2. Load distillation summaries + long-term knowledge.
   const distillations = distillation.loadForSession(projectPath, sessionID);
-
-  // 3. Build knowledge block
   const cfg = loreConfig();
   const entries = cfg.knowledge.enabled
     ? ltm.forProject(projectPath, cfg.crossProject)
@@ -3294,47 +3310,17 @@ export async function generateCompactionSummary(opts: {
       )
     : "";
 
-  // 4. Build the compact prompt
-  const compactPrompt = buildCompactPrompt({
-    hasDistillations: distillations.length > 0,
-    knowledge,
+  // 3. Assemble the compaction summary deterministically from Lore's memory —
+  //    no LLM. Include any still-undistilled messages verbatim so the recent
+  //    tail is never lost if distillation could not bring everything current.
+  return assembleOfflineCompaction({
     previousSummary,
+    distillations,
+    knowledge,
+    undistilled: temporal
+      .undistilled(projectPath, sessionID)
+      .map((m) => ({ role: m.role, content: m.content })),
   });
-
-  // 5. Build context with distillation summaries
-  let context = "";
-  if (distillations.length > 0) {
-    context =
-      `## Lore Pre-computed Session Summaries\n\n` +
-      `The following ${distillations.length} summary chunk(s) were pre-computed ` +
-      `from the conversation history. Use these as the authoritative source.\n\n` +
-      distillations
-        .map(
-          (d, i) =>
-            `### Chunk ${i + 1}${d.generation > 0 ? " (consolidated)" : ""}\n${d.observations}`,
-        )
-        .join("\n\n");
-  }
-
-  // 6. Generate the compaction summary via LLM
-  const userContent = context
-    ? `${context}\n\n---\n\n${compactPrompt}`
-    : compactPrompt;
-
-  const compactInputTokens = Math.ceil(userContent.length / 3);
-  const compactMaxTokens = Math.max(
-    2048,
-    Math.min(Math.ceil(compactInputTokens * 0.5), 20_000),
-  );
-  const summaryText = await llm.prompt(compactPrompt, userContent, {
-    model: getWorkerModel(sessionUpstream),
-    workerID: "lore-compact",
-    urgent: true,
-    maxTokens: compactMaxTokens,
-    temperature: 0,
-  });
-
-  return summaryText ?? null;
 }
 
 // ---------------------------------------------------------------------------
@@ -3371,7 +3357,15 @@ async function handleCompaction(
   setSentryLightContext({ model: req.model, projectPath });
   log.info(`compaction intercepted for session ${sessionID.slice(0, 16)}`);
 
-  const summary = await generateCompactionSummary({
+  // Post-compaction the client sends an entirely different message set, so the
+  // cached pre-compaction warmup body is stale regardless of how this resolves.
+  sessionState.cacheAnalytics.lastRequestBody = null;
+
+  // Kick off summary generation. This makes at most one LLM call (urgent
+  // distillation of the undistilled remainder, if any) and then assembles the
+  // summary deterministically from Lore's memory — it (almost) never returns
+  // null, so the upstream passthrough fallback is now a rare last resort.
+  const summaryPromise = generateCompactionSummary({
     projectPath,
     sessionID,
     config,
@@ -3379,28 +3373,18 @@ async function handleCompaction(
     sessionUpstream: sessionState.lastUpstream,
   });
 
-  // If Lore's own summary generation failed (rate limits, auth issues, etc.),
-  // fall back to forwarding the original compaction request to the upstream API
-  // so the client still gets a proper compaction response.
-  if (summary == null) {
-    log.warn(
-      `compaction summary generation failed for session ${sessionID.slice(0, 16)} — falling back to upstream`,
-    );
-    // Compaction still happens (upstream), so post-compaction messages will
-    // differ — clear the stale warmup body to avoid false cache bust signals.
-    sessionState.cacheAnalytics.lastRequestBody = null;
-    return await handlePassthrough(req, config);
-  }
-
-  const resp = buildCompactionResponse(sessionID, summary, req.model);
-
-  // Clear the cached warmup body — post-compaction the client will send
-  // entirely different messages, so the pre-compaction body is stale.
-  sessionState.cacheAnalytics.lastRequestBody = null;
-
   if (req.stream) {
-    // streamHttpResponse always emits Anthropic SSE — wrap for OpenAI clients.
-    const anthropicSSE = streamHttpResponse(resp);
+    // Open the SSE stream immediately and emit keep-alive `ping`s while the
+    // summary is computed (the remainder-distillation may ride out a 429), so
+    // the client connection never hits a read-timeout. Always Anthropic SSE —
+    // wrap for OpenAI-protocol clients (their translators skip pings).
+    const id = `msg_lore_compact_${crypto.randomUUID().slice(0, 8)}`;
+    const anthropicSSE = buildKeepaliveCompactionStream(
+      id,
+      req.model,
+      summaryPromise,
+      COMPACT_KEEPALIVE_PING_MS,
+    );
     if (req.protocol === "openai") {
       return translateAnthropicStreamToOpenAI(anthropicSSE);
     }
@@ -3409,6 +3393,18 @@ async function handleCompaction(
     }
     return anthropicSSE;
   }
+
+  // Non-streaming clients have no SSE channel to ping — await the summary and
+  // return JSON. Fall back to upstream passthrough only when there is genuinely
+  // nothing to compact (no distillations, no pending messages, no knowledge).
+  const summary = await summaryPromise;
+  if (summary == null) {
+    log.warn(
+      `compaction summary empty for session ${sessionID.slice(0, 16)} — falling back to upstream`,
+    );
+    return await handlePassthrough(req, config);
+  }
+  const resp = buildCompactionResponse(sessionID, summary, req.model);
   return nonStreamHttpResponse(resp, req.protocol, req.stream);
 }
 

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -3313,6 +3313,10 @@ export async function generateCompactionSummary(opts: {
   // 3. Assemble the compaction summary deterministically from Lore's memory —
   //    no LLM. Include any still-undistilled messages verbatim so the recent
   //    tail is never lost if distillation could not bring everything current.
+  //    Note: a concurrent client turn could store new temporal messages between
+  //    step 1 (distillation) and this read — those messages appear in both the
+  //    summary tail AND the next conversation turn. This is benign duplication,
+  //    not data loss, and the window is narrow (active concurrent turns only).
   return assembleOfflineCompaction({
     previousSummary,
     distillations,
@@ -3361,10 +3365,10 @@ async function handleCompaction(
   // cached pre-compaction warmup body is stale regardless of how this resolves.
   sessionState.cacheAnalytics.lastRequestBody = null;
 
-  // Kick off summary generation. This makes at most one LLM call (urgent
-  // distillation of the undistilled remainder, if any) and then assembles the
-  // summary deterministically from Lore's memory — it (almost) never returns
-  // null, so the upstream passthrough fallback is now a rare last resort.
+  // Kick off summary generation: at most one LLM call (urgent distillation
+  // of the undistilled remainder, if any), then deterministic assembly from
+  // Lore's memory. Returns null only when there is genuinely nothing to
+  // compact (brand-new session, no history, no knowledge).
   const summaryPromise = generateCompactionSummary({
     projectPath,
     sessionID,
@@ -3376,15 +3380,30 @@ async function handleCompaction(
   if (req.stream) {
     // Open the SSE stream immediately and emit keep-alive `ping`s while the
     // summary is computed (the remainder-distillation may ride out a 429), so
-    // the client connection never hits a read-timeout. Always Anthropic SSE —
-    // wrap for OpenAI-protocol clients (their translators skip pings).
+    // the client connection never hits a read-timeout. The Response must be
+    // returned without awaiting so the pings flow to the client progressively.
+    //
+    // Null safety: assembleOfflineCompaction returns null only for a brand-new
+    // session with zero history — in that case an empty assistant turn is
+    // correct (there's nothing to compact, so "replacing context with nothing"
+    // is accurate). We log a warning for observability.
+    const loggedPromise = summaryPromise.then((s) => {
+      if (s == null) {
+        log.warn(
+          `compaction summary empty (streaming) for session ${sessionID.slice(0, 16)}`,
+        );
+      }
+      return s;
+    });
     const id = `msg_lore_compact_${crypto.randomUUID().slice(0, 8)}`;
     const anthropicSSE = buildKeepaliveCompactionStream(
       id,
       req.model,
-      summaryPromise,
+      loggedPromise,
       COMPACT_KEEPALIVE_PING_MS,
     );
+    // Always Anthropic SSE — wrap for OpenAI-protocol clients (their
+    // translators skip pings).
     if (req.protocol === "openai") {
       return translateAnthropicStreamToOpenAI(anthropicSSE);
     }
@@ -3394,9 +3413,8 @@ async function handleCompaction(
     return anthropicSSE;
   }
 
-  // Non-streaming clients have no SSE channel to ping — await the summary and
-  // return JSON. Fall back to upstream passthrough only when there is genuinely
-  // nothing to compact (no distillations, no pending messages, no knowledge).
+  // Non-streaming clients: await the summary and return JSON. Fall back to
+  // upstream passthrough only when there is genuinely nothing to compact.
   const summary = await summaryPromise;
   if (summary == null) {
     log.warn(

--- a/packages/gateway/src/stream/anthropic.ts
+++ b/packages/gateway/src/stream/anthropic.ts
@@ -17,7 +17,7 @@ import {
   type GatewayResponse,
   type GatewayUsage,
 } from "../translate/types";
-import { scaleUsageForClient } from "../compaction";
+import { scaleUsageForClient, estimateTokens } from "../compaction";
 
 // ---------------------------------------------------------------------------
 // SSE formatting
@@ -680,7 +680,7 @@ export function buildKeepaliveCompactionStream(
           JSON.stringify({
             type: "message_delta",
             delta: { stop_reason: "end_turn", stop_sequence: null },
-            usage: { output_tokens: Math.ceil(text.length / 3) },
+            usage: { output_tokens: estimateTokens(text) },
           }),
         ),
       );

--- a/packages/gateway/src/stream/anthropic.ts
+++ b/packages/gateway/src/stream/anthropic.ts
@@ -584,6 +584,129 @@ export function buildSSETextResponse(
   return events.join("");
 }
 
+/**
+ * Build a *live* compaction SSE `Response` that emits keep-alive `ping` events
+ * while `summaryPromise` is still pending, then streams the summary text once
+ * it resolves.
+ *
+ * This lets the gateway hold the client connection open during a long
+ * compaction wait (e.g. urgent distillation of the remainder riding out a 429)
+ * without the client hitting a read-timeout. `ping` is a first-class event in
+ * Anthropic's streaming protocol — clients (and our openai/openai-responses
+ * translators) skip it — so the heartbeats are protocol-safe.
+ *
+ * The event lifecycle is always well-formed:
+ *   message_start → content_block_start → ping* → content_block_delta →
+ *   content_block_stop → message_delta → message_stop
+ *
+ * If `summaryPromise` resolves to `null` (nothing to compact) or rejects, an
+ * empty assistant turn is emitted so the stream still terminates cleanly.
+ */
+export function buildKeepaliveCompactionStream(
+  id: string,
+  model: string,
+  summaryPromise: Promise<string | null>,
+  pingMs: number,
+): Response {
+  const enc = new TextEncoder();
+  const messageStart = buildSSEMessageStart({
+    id,
+    model,
+    content: [],
+    stopReason: "end_turn",
+    usage: ZERO_USAGE,
+  });
+
+  let pingTimer: ReturnType<typeof setInterval> | null = null;
+  const clearPing = () => {
+    if (pingTimer) clearInterval(pingTimer);
+    pingTimer = null;
+  };
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const emit = (s: string) => {
+        try {
+          controller.enqueue(enc.encode(s));
+        } catch {
+          // Controller already closed (client disconnected) — ignore.
+        }
+      };
+
+      emit(messageStart);
+      emit(
+        formatSSEEvent(
+          "content_block_start",
+          JSON.stringify({
+            type: "content_block_start",
+            index: 0,
+            content_block: { type: "text", text: "" },
+          }),
+        ),
+      );
+
+      pingTimer = setInterval(() => {
+        emit(formatSSEEvent("ping", JSON.stringify({ type: "ping" })));
+      }, pingMs);
+
+      let text = "";
+      try {
+        text = (await summaryPromise) ?? "";
+      } catch {
+        text = "";
+      } finally {
+        clearPing();
+      }
+
+      emit(
+        formatSSEEvent(
+          "content_block_delta",
+          JSON.stringify({
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "text_delta", text },
+          }),
+        ),
+      );
+      emit(
+        formatSSEEvent(
+          "content_block_stop",
+          JSON.stringify({ type: "content_block_stop", index: 0 }),
+        ),
+      );
+      emit(
+        formatSSEEvent(
+          "message_delta",
+          JSON.stringify({
+            type: "message_delta",
+            delta: { stop_reason: "end_turn", stop_sequence: null },
+            usage: { output_tokens: Math.ceil(text.length / 3) },
+          }),
+        ),
+      );
+      emit(
+        formatSSEEvent(
+          "message_stop",
+          JSON.stringify({ type: "message_stop" }),
+        ),
+      );
+      controller.close();
+    },
+    cancel() {
+      clearPing();
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: {
+      "content-type": "text/event-stream",
+      "cache-control": "no-cache",
+      connection: "keep-alive",
+    },
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Recall-aware stream accumulator
 // ---------------------------------------------------------------------------

--- a/packages/gateway/test/compaction.test.ts
+++ b/packages/gateway/test/compaction.test.ts
@@ -7,6 +7,7 @@ import {
   isMetaRequest,
   LORE_AGENT_HEADER,
   buildCompactionResponse,
+  assembleOfflineCompaction,
   COMPACTION_SYSTEM_PATTERNS,
   COMPACTION_USER_PATTERNS,
 } from "../src/compaction";
@@ -590,6 +591,97 @@ describe("buildCompactionResponse", () => {
   test("passes through model name unchanged", () => {
     const response = buildCompactionResponse("s1", "text", "gpt-4o-2024-05-13");
     expect(response.model).toBe("gpt-4o-2024-05-13");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assembleOfflineCompaction
+// ---------------------------------------------------------------------------
+
+describe("assembleOfflineCompaction", () => {
+  test("returns null when there is nothing to compact", () => {
+    expect(assembleOfflineCompaction({ distillations: [] })).toBeNull();
+    expect(
+      assembleOfflineCompaction({
+        distillations: [],
+        previousSummary: "  ",
+        knowledge: "",
+        undistilled: [],
+      }),
+    ).toBeNull();
+  });
+
+  test("assembles distillation observations in order with segment headings", () => {
+    const out = assembleOfflineCompaction({
+      distillations: [
+        { observations: "First segment notes", generation: 0 },
+        { observations: "Consolidated notes", generation: 1 },
+      ],
+    });
+    expect(out).not.toBeNull();
+    expect(out).toContain("# Session Summary");
+    expect(out).toContain("### Segment 1");
+    expect(out).toContain("First segment notes");
+    expect(out).toContain("### Segment 2 (consolidated)");
+    expect(out).toContain("Consolidated notes");
+    // Order preserved
+    const text = out ?? "";
+    expect(text.indexOf("First segment notes")).toBeLessThan(
+      text.indexOf("Consolidated notes"),
+    );
+  });
+
+  test("carries the previous summary forward verbatim", () => {
+    const out = assembleOfflineCompaction({
+      previousSummary: "PRIOR SUMMARY TEXT",
+      distillations: [{ observations: "obs", generation: 0 }],
+    });
+    expect(out).toContain("## Earlier summary");
+    expect(out).toContain("PRIOR SUMMARY TEXT");
+  });
+
+  test("includes the still-undistilled tail (capped) so it is never lost", () => {
+    const out = assembleOfflineCompaction({
+      distillations: [{ observations: "obs", generation: 0 }],
+      undistilled: [
+        { role: "user", content: "latest question" },
+        { role: "assistant", content: "latest answer" },
+      ],
+    });
+    expect(out).toContain("## Recent activity (not yet summarized)");
+    expect(out).toContain("**user**: latest question");
+    expect(out).toContain("**assistant**: latest answer");
+  });
+
+  test("truncates a large raw tail with an omission marker", () => {
+    const big = "x".repeat(6000);
+    const out = assembleOfflineCompaction({
+      distillations: [],
+      undistilled: [
+        { role: "user", content: big },
+        { role: "user", content: "should be omitted" },
+      ],
+    });
+    expect(out).not.toBeNull();
+    expect(out).toContain("…(remaining recent messages omitted)");
+  });
+
+  test("works from distillations even when knowledge and prior summary are absent", () => {
+    const out = assembleOfflineCompaction({
+      distillations: [{ observations: "only obs", generation: 0 }],
+      knowledge: "",
+    });
+    expect(out).toContain("only obs");
+    expect(out).not.toContain("## Earlier summary");
+  });
+
+  test("appends the knowledge block when present", () => {
+    const out = assembleOfflineCompaction({
+      distillations: [{ observations: "obs", generation: 0 }],
+      knowledge: "## Long-term Knowledge\n### Pattern\n* **X**: Y.",
+    });
+    expect(out).toContain("## Long-term Knowledge");
+    expect(out).toContain("**X**: Y.");
   });
 });
 

--- a/packages/gateway/test/keepalive-compaction.test.ts
+++ b/packages/gateway/test/keepalive-compaction.test.ts
@@ -1,0 +1,101 @@
+import { describe, test, expect } from "vitest";
+import { buildKeepaliveCompactionStream } from "../src/stream/anthropic";
+import { translateAnthropicStreamToOpenAI } from "../src/stream/openai";
+
+async function readAll(resp: Response): Promise<string> {
+  const stream = resp.body;
+  if (!stream) throw new Error("response has no body");
+  const reader = stream.getReader();
+  const dec = new TextDecoder();
+  let out = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    out += dec.decode(value, { stream: true });
+  }
+  return out;
+}
+
+describe("buildKeepaliveCompactionStream", () => {
+  test("emits ping heartbeats while pending, then the summary content", async () => {
+    let resolve!: (s: string | null) => void;
+    const pending = new Promise<string | null>((r) => {
+      resolve = r;
+    });
+    const resp = buildKeepaliveCompactionStream(
+      "msg_test",
+      "model-x",
+      pending,
+      5,
+    );
+    // Resolve after enough time for several 5ms pings to fire.
+    setTimeout(() => resolve("THE SUMMARY"), 50);
+    const body = await readAll(resp);
+
+    expect(resp.headers.get("content-type")).toBe("text/event-stream");
+    expect(body).toContain("event: message_start");
+    expect(body).toContain("event: content_block_start");
+    expect(body).toContain("event: ping");
+    expect(body).toContain("THE SUMMARY");
+    expect(body).toContain("event: content_block_stop");
+    expect(body).toContain("event: message_delta");
+    expect(body).toContain("event: message_stop");
+    // Heartbeats precede the resolved content.
+    expect(body.indexOf("event: ping")).toBeLessThan(
+      body.indexOf("THE SUMMARY"),
+    );
+  });
+
+  test("null summary yields a well-formed empty assistant turn", async () => {
+    const resp = buildKeepaliveCompactionStream(
+      "msg_test2",
+      "model-x",
+      Promise.resolve(null),
+      50,
+    );
+    const body = await readAll(resp);
+    expect(body).toContain("event: message_start");
+    expect(body).toContain("event: content_block_delta");
+    expect(body).toContain('"text":""');
+    expect(body).toContain("event: message_stop");
+  });
+
+  test("translates cleanly to OpenAI SSE (pings dropped, summary preserved)", async () => {
+    let resolve!: (s: string | null) => void;
+    const pending = new Promise<string | null>((r) => {
+      resolve = r;
+    });
+    const anthropicSSE = buildKeepaliveCompactionStream(
+      "msg_x",
+      "model-x",
+      pending,
+      5,
+    );
+    const openaiResp = translateAnthropicStreamToOpenAI(anthropicSSE);
+    setTimeout(() => resolve("TRANSLATED SUMMARY"), 40);
+    const body = await readAll(openaiResp);
+
+    // OpenAI chat.completion chunks carry the text in delta.content; pings are
+    // not a valid OpenAI event and must be dropped by the translator.
+    expect(body).toContain("chat.completion.chunk");
+    expect(body).toContain("TRANSLATED SUMMARY");
+    expect(body).not.toContain("event: ping");
+    expect(body).toContain("[DONE]");
+  });
+
+  test("a rejected summary promise still terminates the stream cleanly", async () => {
+    const rejecting = new Promise<string | null>((_, rej) => {
+      setTimeout(() => rej(new Error("boom")), 5);
+    });
+    const resp = buildKeepaliveCompactionStream(
+      "msg_test3",
+      "model-x",
+      rejecting,
+      50,
+    );
+    const body = await readAll(resp);
+    expect(body).toContain("event: message_start");
+    expect(body).toContain("event: message_stop");
+    expect(body).toContain('"text":""');
+  });
+});

--- a/packages/gateway/test/keepalive-compaction.test.ts
+++ b/packages/gateway/test/keepalive-compaction.test.ts
@@ -26,10 +26,10 @@ describe("buildKeepaliveCompactionStream", () => {
       "msg_test",
       "model-x",
       pending,
-      5,
+      10, // 10ms ping interval
     );
-    // Resolve after enough time for several 5ms pings to fire.
-    setTimeout(() => resolve("THE SUMMARY"), 50);
+    // Resolve after enough time for several pings to fire.
+    setTimeout(() => resolve("THE SUMMARY"), 200);
     const body = await readAll(resp);
 
     expect(resp.headers.get("content-type")).toBe("text/event-stream");
@@ -69,10 +69,10 @@ describe("buildKeepaliveCompactionStream", () => {
       "msg_x",
       "model-x",
       pending,
-      5,
+      10, // 10ms ping interval
     );
     const openaiResp = translateAnthropicStreamToOpenAI(anthropicSSE);
-    setTimeout(() => resolve("TRANSLATED SUMMARY"), 40);
+    setTimeout(() => resolve("TRANSLATED SUMMARY"), 200);
     const body = await readAll(openaiResp);
 
     // OpenAI chat.completion chunks carry the text in delta.content; pings are


### PR DESCRIPTION
## Background

Follow-up to #666. Compaction made a dedicated urgent `lore-compact` LLM call to synthesize the summary. On rate-limited OAuth/Max accounts that call was the recurring source of `worker upstream request failed … 429`, and holding the client's HTTP connection open during its retries risked a read-timeout (the only remaining gap versus literal "wait until it works").

## Insight

The distillations **are** Lore's compressed conversation memory. `generateCompactionSummary` already loaded and assembled them — it just fed them to the LLM to polish into the `Goal/Decisions/…` template. So we can drop the LLM synthesis entirely and assemble the summary **deterministically from the distillations** (+ long-term knowledge + the prior summary). No API call, no rate-limit dependency, no data loss.

## Change

- **`generateCompactionSummary`** no longer makes the `lore-compact` LLM call. Its only LLM work is **urgent distillation of the undistilled remainder**, and only when there is one — if distillations are already current, compaction is **instant and zero-cost**. It then assembles the summary via the new **`assembleOfflineCompaction`** (distillations + knowledge + prior summary). Any still-undistilled tail is included verbatim (capped) so the recent conversation is never lost if distillation couldn't complete. This intentionally skips the LLM template — the raw assembly is sufficient for continuation.
- **`handleCompaction`** opens the SSE stream immediately for streaming clients and emits keep-alive **`ping`** events (new **`buildKeepaliveCompactionStream`**) while the summary is generated, so a long remainder-distillation (e.g. riding out a 429) never trips the client's read-timeout. `ping` is a first-class Anthropic stream event; the `openai`/`openai-responses` translators already skip it.
- The upstream **passthrough fallback** is now a rare last resort (only when there is genuinely nothing to compact).

### Why this is the right shape
- Removes bete's exact error source (`lore-compact`) entirely.
- "Wait until it works" is now safe and cheap: the expensive part (distillation) is work we'd do anyway, it's covered by keepalive heartbeats, and we always end with a Lore-backed summary.
- No data loss in any path: raw turns persist in temporal storage; distillation/curation retry on idle; the compaction summary is assembled from Lore's memory.

## Tests
- `assembleOfflineCompaction`: ordering, prior-summary carry-forward, capped raw tail, knowledge block, empty→null.
- `buildKeepaliveCompactionStream`: pings precede content; null/rejected promises terminate cleanly; **end-to-end OpenAI translation** drops pings and preserves the summary.
- Full gateway suite: **1245 passed, 3 skipped**. Typecheck + Biome + check:docs clean.

## Notes
- The Pi `/v1/compact` JSON endpoint also goes through `generateCompactionSummary`, so it transparently gets the offline summary (no SSE needed — it's a JSON POST whose caller controls the timeout).
- Behavior change: compaction summaries are now distillation assemblies rather than LLM-polished template output — an intentional, accepted trade for robustness and zero rate-limit dependency.