### PR TITLE
fix(gateway): persist session project binding so restarts don't split sessions

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1009,6 +1009,25 @@ const MIGRATIONS: string[] = [
   CREATE INDEX IF NOT EXISTS idx_knowledge_worker
     ON knowledge(worker_provider_id, worker_model_id);
   `,
+  `
+  -- Version 36: Persist the session's resolved project binding so a gateway
+  -- restart does not re-resolve (and potentially split) the project_id.
+  -- Without this, a previously-confident session whose first post-restart turn
+  -- lacks X-Lore-Project (and an inferable prompt) re-binds provisionally to
+  -- cwd / an unattributed bucket, and its new temporal rows + distillations land
+  -- under a different project_id than the pre-restart half until a later
+  -- confident turn self-heals.
+  -- project_path: the project path the session is bound to. NULL for pre-v36
+  -- rows and sessions that never got a binding.
+  -- project_path_provisional: 1 = provisional (cwd fallback / unattributed
+  -- bucket), 0 = confident (header/inferred). Persisting BOTH lets restart
+  -- distinguish a confident binding (must not be downgraded by a path-less turn)
+  -- from a provisional one (may still be overwritten/self-healed). The
+  -- NOT NULL DEFAULT 1 is the safe default: never falsely claims confidence for
+  -- legacy / INSERT-OR-IGNORE rows.
+  ALTER TABLE session_state ADD COLUMN project_path TEXT;
+  ALTER TABLE session_state ADD COLUMN project_path_provisional INTEGER NOT NULL DEFAULT 1;
+  `,
 ];
 
 /**
@@ -1296,6 +1315,22 @@ function recoverMissingObjects(database: Database) {
     CREATE INDEX IF NOT EXISTS idx_knowledge_worker
       ON knowledge(worker_provider_id, worker_model_id);
   `);
+  // Version 36: session project binding. Recover each column independently in
+  // case a partial ALTER (e.g. the first succeeded, the second was skipped on a
+  // prior failure) left the table missing a column.
+  {
+    const scols = database
+      .query("PRAGMA table_info(session_state)")
+      .all() as Array<{ name: string }>;
+    if (!scols.some((c) => c.name === "project_path")) {
+      database.exec("ALTER TABLE session_state ADD COLUMN project_path TEXT;");
+    }
+    if (!scols.some((c) => c.name === "project_path_provisional")) {
+      database.exec(
+        "ALTER TABLE session_state ADD COLUMN project_path_provisional INTEGER NOT NULL DEFAULT 1;",
+      );
+    }
+  }
 }
 
 /**
@@ -1898,6 +1933,9 @@ export type SessionTrackingState = {
   // v26: sub-agent parent–child relationships
   parentSessionId?: string | null;
   isSubagent?: boolean;
+  // v36: project binding (survives restart so the project_id never splits)
+  projectPath?: string | null;
+  projectPathProvisional?: boolean;
 };
 
 /**
@@ -2013,6 +2051,15 @@ export function saveSessionTracking(
     sets.push("is_subagent = ?");
     vals.push(state.isSubagent ? 1 : 0);
   }
+  // v36: project binding
+  if (state.projectPath !== undefined) {
+    sets.push("project_path = ?");
+    vals.push(state.projectPath);
+  }
+  if (state.projectPathProvisional !== undefined) {
+    sets.push("project_path_provisional = ?");
+    vals.push(state.projectPathProvisional ? 1 : 0);
+  }
 
   // Update only the specified columns
   db()
@@ -2048,6 +2095,9 @@ export type LoadedSessionTracking = {
   // v26: sub-agent parent–child relationships
   parentSessionId: string | null;
   isSubagent: boolean;
+  // v36: project binding
+  projectPath: string | null;
+  projectPathProvisional: boolean;
 };
 
 /**
@@ -2065,7 +2115,8 @@ export function loadSessionTracking(
               resolved_conversation_ttl, warmup_state,
               dynamic_context_cap, bust_rate_ema, inter_bust_interval_ema,
               last_layer, last_known_input, last_turn_at, last_bust_at,
-              parent_session_id, is_subagent
+              parent_session_id, is_subagent,
+              project_path, project_path_provisional
        FROM session_state WHERE session_id = ?`,
     )
     .get(sessionID) as {
@@ -2091,6 +2142,8 @@ export function loadSessionTracking(
     last_bust_at: number;
     parent_session_id: string | null;
     is_subagent: number;
+    project_path: string | null;
+    project_path_provisional: number;
   } | null;
   if (!row) return null;
   return {
@@ -2116,6 +2169,8 @@ export function loadSessionTracking(
     lastBustAt: row.last_bust_at,
     parentSessionId: row.parent_session_id,
     isSubagent: row.is_subagent === 1,
+    projectPath: row.project_path,
+    projectPathProvisional: row.project_path_provisional === 1,
   };
 }
 

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -49,7 +49,7 @@ describe("db", () => {
     const row = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(row.version).toBe(35);
+    expect(row.version).toBe(36);
   });
 
   test("entities table has embedding column (migration v34)", () => {
@@ -931,6 +931,54 @@ describe("db", () => {
     expect(loaded?.lastKnownInput).toBe(0);
     expect(loaded?.lastTurnAt).toBe(0);
     expect(loaded?.lastBustAt).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // v36: project binding persistence (restart continuity)
+  // -------------------------------------------------------------------------
+
+  test("session_state has v36 project binding columns", () => {
+    const cols = db().query("PRAGMA table_info(session_state)").all() as Array<{
+      name: string;
+    }>;
+    const names = cols.map((c) => c.name);
+    expect(names).toContain("project_path");
+    expect(names).toContain("project_path_provisional");
+  });
+
+  test("saveSessionTracking v36 project binding round-trip", () => {
+    const sid = `test-v36-binding-${crypto.randomUUID()}`;
+    saveSessionTracking(sid, {
+      projectPath: "/home/me/proj",
+      projectPathProvisional: false,
+    });
+    const loaded = loadSessionTracking(sid);
+    expect(loaded?.projectPath).toBe("/home/me/proj");
+    expect(loaded?.projectPathProvisional).toBe(false);
+  });
+
+  test("saveSessionTracking v36 partial update preserves project binding", () => {
+    const sid = `test-v36-partial-${crypto.randomUUID()}`;
+    saveSessionTracking(sid, {
+      projectPath: "/home/me/proj",
+      projectPathProvisional: false,
+    });
+    // A later save that omits the binding must NOT clobber it.
+    saveSessionTracking(sid, { messageCount: 7 });
+    const loaded = loadSessionTracking(sid);
+    expect(loaded?.messageCount).toBe(7);
+    expect(loaded?.projectPath).toBe("/home/me/proj");
+    expect(loaded?.projectPathProvisional).toBe(false);
+  });
+
+  test("saveSessionTracking v36 defaults: legacy row has no binding", () => {
+    const sid = `test-v36-defaults-${crypto.randomUUID()}`;
+    // Row created without ever writing the binding (pre-v36 / INSERT OR IGNORE).
+    saveSessionTracking(sid, { messageCount: 1 });
+    const loaded = loadSessionTracking(sid);
+    expect(loaded?.projectPath).toBeNull();
+    // Default flag is provisional (1) — never falsely claims confidence.
+    expect(loaded?.projectPathProvisional).toBe(true);
   });
 
   // -------------------------------------------------------------------------

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -1234,15 +1234,38 @@ function getOrCreateSession(
   if (!state) {
     // Restore persisted tracking state from DB (survives process restarts)
     const persisted = loadSessionTracking(sessionID);
+    // Project binding (v36): a persisted binding must survive restart so the
+    // session's project_id never splits. A persisted CONFIDENT binding wins
+    // over the current request's path — otherwise a path-less first
+    // post-restart turn would downgrade it to a provisional cwd/bucket and
+    // strand the pre-restart rows under a different project_id. A persisted
+    // PROVISIONAL binding is resumed (same path) so self-heal keeps targeting
+    // the exact bucket where earlier rows were stored.
+    //
+    // ORDERING DEPENDENCY: callers MUST invoke getOrCreateSession() →
+    // resolveSessionProjectPath() → the per-turn saveSessionTracking() in that
+    // order. The rehydrated confident binding below is what makes
+    // resolveSessionProjectPath()'s `hasConfident` short-circuit keep the known
+    // path on a path-less turn; reordering these breaks restart continuity.
+    const persistedConfident =
+      !!persisted?.projectPath && persisted.projectPathProvisional === false;
+    const persistedProvisional =
+      !!persisted?.projectPath && persisted.projectPathProvisional === true;
     state = {
       sessionID,
-      projectPath,
       // A freshly-seeded path from the cwd fallback is NOT a confident binding.
       // Mark it provisional so a later header/inferred turn can overwrite it
       // (and self-heal any rows stored under the provisional path). Only
-      // header/inferred seeds are confident. `projectPath` itself is not
-      // persisted in session_state, so this is purely in-memory bootstrap.
-      projectPathProvisional: pathSource === "cwd",
+      // header/inferred seeds are confident.
+      projectPath:
+        persistedConfident || persistedProvisional
+          ? (persisted?.projectPath as string)
+          : projectPath,
+      projectPathProvisional: persistedConfident
+        ? false
+        : persistedProvisional
+          ? true
+          : pathSource === "cwd",
       fingerprint: persisted?.fingerprint || "",
       lastRequestTime: Date.now(),
       lastUserTurnTime: 0,
@@ -3363,6 +3386,11 @@ async function handleCompaction(
     sessionState,
     config,
   );
+  // NOTE: the project binding is NOT persisted here — compaction never changes
+  // the binding, and the preceding normal turn already persisted it. A restart
+  // between the last normal turn and a compaction-only turn rehydrates the
+  // binding from the prior save, which is always present (compaction requires
+  // accumulated context that implies at least one normal turn happened first).
 
   // Initialize the project AFTER path correction so we never create a row for
   // the gateway's cwd / an unattributed bucket from a path-less probe request.
@@ -3996,10 +4024,16 @@ async function handleConversationTurn(
   sessionState.messageCount = currMsgCount;
   // Batched save: messageCount + turnsSinceCuration + consecutiveTextOnlyTurns
   // together to avoid multiple DB writes per turn.
+  // Also persist the project binding (v36): this runs AFTER
+  // resolveSessionProjectPath() above, so it captures the post-resolution
+  // binding — including a provisional→confident transition from self-heal —
+  // letting a gateway restart rehydrate the exact project_id and never split it.
   saveSessionTracking(sessionID, {
     messageCount: currMsgCount,
     turnsSinceCuration: sessionState.turnsSinceCuration,
     consecutiveTextOnlyTurns: sessionState.consecutiveTextOnlyTurns,
+    projectPath: sessionState.projectPath || null,
+    projectPathProvisional: sessionState.projectPathProvisional === true,
   });
 
   // Track session model for worker model discovery

--- a/packages/gateway/test/project-path.test.ts
+++ b/packages/gateway/test/project-path.test.ts
@@ -11,7 +11,14 @@ import {
 } from "../src/config";
 import { resolveSessionProjectPath } from "../src/pipeline";
 import type { SessionState } from "../src/translate/types";
-import { ensureProject, projectId, ltm } from "@loreai/core";
+import {
+  ensureProject,
+  projectId,
+  ltm,
+  saveSessionTracking,
+  loadSessionTracking,
+  type LoadedSessionTracking,
+} from "@loreai/core";
 
 // ---------------------------------------------------------------------------
 // inferProjectPath
@@ -630,5 +637,127 @@ describe("resolveSessionProjectPath", () => {
       localCfg,
     );
     expect(state.gitRemote).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// v36: restart continuity — persisted project binding rehydration
+//
+// getOrCreateSession() is private, so these tests reconstruct the exact seed it
+// builds from loadSessionTracking() (see pipeline.ts getOrCreateSession), then
+// drive the rehydrated state through the public resolveSessionProjectPath() to
+// assert the no-split invariant: a persisted confident binding must NOT be
+// downgraded by a path-less first post-restart turn.
+// ---------------------------------------------------------------------------
+
+describe("restart continuity: persisted project binding", () => {
+  const localCfg = { remoteGateway: false } as GatewayConfig;
+  const remoteCfg = { remoteGateway: true } as GatewayConfig;
+
+  // Mirrors the project-binding seed inside getOrCreateSession(): a persisted
+  // confident binding wins over the current request path; a persisted
+  // provisional binding is resumed; otherwise fall back to the request seed.
+  function rehydrateSeed(
+    sessionID: string,
+    persisted: LoadedSessionTracking | null,
+    reqPath: string,
+    reqSource: "header" | "inferred" | "cwd",
+  ): SessionState {
+    const persistedConfident =
+      !!persisted?.projectPath && persisted.projectPathProvisional === false;
+    const persistedProvisional =
+      !!persisted?.projectPath && persisted.projectPathProvisional === true;
+    return {
+      sessionID,
+      projectPath:
+        persistedConfident || persistedProvisional
+          ? (persisted?.projectPath as string)
+          : reqPath,
+      projectPathProvisional: persistedConfident
+        ? false
+        : persistedProvisional
+          ? true
+          : reqSource === "cwd",
+    } as Partial<SessionState> as SessionState;
+  }
+
+  test("confident binding survives restart (rehydrated from DB)", () => {
+    const sid = `restart-confident-${crypto.randomUUID()}`;
+    saveSessionTracking(sid, {
+      projectPath: "/home/me/real",
+      projectPathProvisional: false,
+    });
+    // Simulate restart: in-memory state is gone; rehydrate from DB with a
+    // path-less first turn (cwd).
+    const persisted = loadSessionTracking(sid);
+    const state = rehydrateSeed(sid, persisted, process.cwd(), "cwd");
+    expect(state.projectPath).toBe("/home/me/real");
+    expect(state.projectPathProvisional).toBe(false);
+  });
+
+  test("path-less first post-restart turn does NOT downgrade confident binding", () => {
+    const sid = `restart-nodowngrade-${crypto.randomUUID()}`;
+    saveSessionTracking(sid, {
+      projectPath: "/home/me/real",
+      projectPathProvisional: false,
+    });
+    const persisted = loadSessionTracking(sid);
+    const state = rehydrateSeed(sid, persisted, process.cwd(), "cwd");
+    const result = resolveSessionProjectPath(
+      { path: process.cwd(), source: "cwd" },
+      state,
+      localCfg,
+    );
+    expect(result).toBe("/home/me/real");
+    expect(state.projectPath).toBe("/home/me/real");
+    expect(state.projectPathProvisional).toBe(false);
+  });
+
+  test("provisional binding resumes the same bucket and still self-heals", () => {
+    const sid = `restart-provisional-${crypto.randomUUID()}`;
+    const bucket = unattributedBucketPath(sid);
+    saveSessionTracking(sid, {
+      projectPath: bucket,
+      projectPathProvisional: true,
+    });
+    const persisted = loadSessionTracking(sid);
+    // Restart, path-less turn: resumes the same provisional bucket.
+    const state = rehydrateSeed(sid, persisted, process.cwd(), "cwd");
+    expect(state.projectPath).toBe(bucket);
+    expect(state.projectPathProvisional).toBe(true);
+    // A later confident header turn rebinds to the real project.
+    const result = resolveSessionProjectPath(
+      { path: "/home/me/real", source: "header" },
+      state,
+      remoteCfg,
+    );
+    expect(result).toBe("/home/me/real");
+    expect(state.projectPathProvisional).toBe(false);
+  });
+
+  test("no persisted binding falls back to legacy request-seed behavior", () => {
+    const sid = `restart-legacy-${crypto.randomUUID()}`;
+    // No prior save → loadSessionTracking returns null.
+    const persisted = loadSessionTracking(sid);
+    expect(persisted).toBeNull();
+    const cwdState = rehydrateSeed(sid, persisted, process.cwd(), "cwd");
+    expect(cwdState.projectPathProvisional).toBe(true);
+    const headerState = rehydrateSeed(sid, persisted, "/home/me/x", "header");
+    expect(headerState.projectPathProvisional).toBe(false);
+    expect(headerState.projectPath).toBe("/home/me/x");
+  });
+
+  test("legacy DB row (binding never written) rehydrates as no-binding", () => {
+    const sid = `restart-legacyrow-${crypto.randomUUID()}`;
+    // Row exists but the v36 binding columns were never written.
+    saveSessionTracking(sid, { messageCount: 3 });
+    const persisted = loadSessionTracking(sid);
+    expect(persisted?.projectPath).toBeNull();
+    expect(persisted?.projectPathProvisional).toBe(true);
+    // With a NULL persisted path, the seed uses the current request — a cwd
+    // turn stays provisional (no false confidence inherited from the default).
+    const state = rehydrateSeed(sid, persisted, process.cwd(), "cwd");
+    expect(state.projectPath).toBe(process.cwd());
+    expect(state.projectPathProvisional).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Makes a gateway process restart a continuity no-op: it no longer splits a logical conversation across two `project_id`s or misattributes its data.

## Root cause

The internal session ID was already stable across restarts, but `projectPath` / `projectPathProvisional` were **deliberately never persisted** to `session_state`. After a restart, a re-identified session re-seeded its project binding from the *current* request. If the first post-restart turn lacked `X-Lore-Project` and an inferable system prompt, it re-bound **provisionally** to cwd / an `/__lore_unattributed__/<sid>` bucket. Since all temporal/distillation/recall queries filter by `project_id`, the pre- and post-restart halves of one conversation became invisible to each other until a later confident turn self-healed.

## Changes

- **`packages/core/src/db.ts`**: migration **v36** adds `project_path` + `project_path_provisional` to `session_state` (with a partial-migration recovery block, mirroring v35). Extends `SessionTrackingState`, `saveSessionTracking`, `loadSessionTracking`, and `LoadedSessionTracking`.
- **`packages/gateway/src/pipeline.ts`**:
  - `getOrCreateSession` rehydrates the binding from DB. A persisted **confident** binding wins over a path-less first post-restart turn (via the existing `hasConfident` short-circuit in `resolveSessionProjectPath` — no logic change there); a **provisional** binding resumes the same bucket so self-heal keeps targeting it.
  - The existing per-turn batch save now persists the post-resolution binding (no extra DB round-trip), capturing provisional→confident self-heal transitions.
  - Documents the `getOrCreateSession → resolveSessionProjectPath → save` ordering dependency that keeps this safe.

## Scope decisions

- Tier 2 learned headers are already durable once promoted; the 1–2-turn un-promoted window is covered by the persisted fingerprint — left untouched.
- `sessionAuth` is in-memory by design and doesn't affect continuity — untouched.

## Tests

- New: db round-trip / partial-update / defaults for the v36 columns, plus restart-rehydration tests (confident survives, path-less turn does not downgrade, provisional resumes bucket + self-heals, legacy/no-binding fallback). Bumped the schema-version assertion 35→36.
- Full suite: **2481 passed, 6 skipped, 0 failed**. `typecheck` and `biome check` clean.

## Manual repro (before/after)

```
LORE_DB_PATH=/tmp/lore-test.db lore start &
curl ... -H 'x-lore-session-id: S1' -H 'X-Lore-Project: /home/me/proj' -d @turn1.json
kill %1; LORE_DB_PATH=/tmp/lore-test.db lore start &
curl ... -H 'x-lore-session-id: S1' -d @turn2.json   # path-less
sqlite3 /tmp/lore-test.db \
  "SELECT DISTINCT p.path FROM temporal_messages t JOIN projects p ON p.id=t.project_id \
   WHERE t.session_id=(SELECT session_id FROM session_state WHERE header_session_id='S1');"
# expect exactly one row: /home/me/proj  (no cwd, no __lore_unattributed__)
```