### PR TITLE
docs: update documentation for bun to node+pnpm+vitest migration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,8 +8,8 @@ For long-term knowledge entries managed by [lore](https://github.com/BYK/loreai)
 
 Lore is a **three-tier memory architecture** for AI coding agents. It intercepts LLM API calls (as a transparent proxy or native plugin), distills conversation history into compressed summaries, and extracts long-term knowledge entries that persist across sessions.
 
-**Runtime:** Bun (development/tests) and Node.js >= 22.5 (production npm bundles).
-**Language:** TypeScript (monorepo with `bun workspaces`).
+**Runtime:** Node.js >= 22.5 (development/tests/production).
+**Language:** TypeScript (monorepo with `pnpm workspaces`).
 **Database:** SQLite with WAL mode, FTS5 full-text search. Stored at `~/.local/share/lore/lore.db`.
 
 ## Monorepo Structure
@@ -144,15 +144,15 @@ recall tool (searchRecall) ----------------> Tool response to agent
 ## Build & Test
 
 ```bash
-bun install          # install all workspace dependencies
-bun test             # run all tests (uses bunfig.toml preload for test DB isolation)
-bun run typecheck    # typecheck all packages
-bun run lint         # Biome lint + format check (CI-gated); `bun run lint:fix` to autofix
-bun run format       # apply Biome formatting
-bun run build        # build all packages (esbuild bundles)
+pnpm install         # install all workspace dependencies
+pnpm test            # run all tests via Vitest (uses packages/core/test/setup.ts for DB isolation)
+pnpm run typecheck   # typecheck all packages
+pnpm run lint        # Biome lint + format check (CI-gated); `pnpm run lint:fix` to autofix
+pnpm run format      # apply Biome formatting
+pnpm run build       # build all packages (esbuild bundles)
 ```
 
-- Tests use a temporary SQLite DB (via `packages/core/test/setup.ts` preload) — never the production DB
+- Tests use a temporary SQLite DB (via `packages/core/test/setup.ts` Vitest setup file) — never the production DB
 - Gateway build: `packages/gateway/script/build.ts` produces CJS bundle; `script/bundle.ts` creates standalone binary
 - Core build: `packages/core/script/build.ts` produces Node.js-compatible CJS output
 

--- a/README.md
+++ b/README.md
@@ -379,10 +379,10 @@ The eval suite is open source in `packages/core/eval/`. Run it yourself:
 
 ```bash
 # 400K inflated scenario
-bun packages/core/eval/run.ts --mode live --inflate 400000
+npx tsx packages/core/eval/run.ts --mode live --inflate 400000
 
 # 2.3M mega-session (real session, no inflation needed)
-bun packages/core/eval/run.ts --mode live --scenarios mega-cli-refactor
+npx tsx packages/core/eval/run.ts --mode live --scenarios mega-cli-refactor
 ```
 
 **Cost:** Lore's memory layer runs at minimal additional cost — background distillation and curation use batch APIs (50% off on supported providers) and cheaper models. Local on-device embeddings (Nomic Embed v1.5) mean zero API cost for vector search. Predictive cache warming reduces expensive cache rebuilds.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -14,7 +14,7 @@ This package is host-agnostic. It doesn't ship a user-facing extension on its ow
 ```bash
 npm install @loreai/core
 # or
-bun add @loreai/core
+pnpm add @loreai/core
 ```
 
 You only need to install this directly if you're building a new adapter. End users install one of the host packages above.

--- a/quality/RUN_INTEGRATION_TESTS.md
+++ b/quality/RUN_INTEGRATION_TESTS.md
@@ -7,8 +7,8 @@ Integration test groups verifying end-to-end behavior across Lore's gateway, cor
 
 ## Prerequisites
 
-- Bun runtime installed (test runner)
-- All workspace dependencies installed (`bun install`)
+- Node.js >= 22.5 installed
+- All workspace dependencies installed (`pnpm install`)
 - No production database used — tests use `packages/core/test/setup.ts` preload for DB isolation
 - Environment: `NODE_ENV=test`, `LORE_HOSTED_MODE=0`
 - Upstream API mocks: use `packages/gateway/test/helpers/harness.ts` test harness where available


### PR DESCRIPTION
## Summary

Updates stale `bun` references across 4 documentation files to reflect the completed migration to Node.js + pnpm + Vitest.

## Changes

- **AGENTS.md**: Runtime description → Node.js >= 22.5, workspaces → pnpm, Build & Test commands → pnpm, test isolation note → Vitest setup file
- **README.md**: Eval run commands `bun` → `npx tsx`
- **packages/core/README.md**: Install example `bun add` → `pnpm add`
- **quality/RUN_INTEGRATION_TESTS.md**: Prerequisites updated from Bun runtime to Node.js >= 22.5, `bun install` → `pnpm install`

CHANGELOG.md and .lore.md references are historical/intentional and left as-is.