### PR TITLE
fix(gateway): error the compaction keepalive stream on summary failure

### DIFF
--- a/packages/gateway/src/stream/anthropic.ts
+++ b/packages/gateway/src/stream/anthropic.ts
@@ -649,14 +649,27 @@ export function buildKeepaliveCompactionStream(
         emit(formatSSEEvent("ping", JSON.stringify({ type: "ping" })));
       }, pingMs);
 
-      let text = "";
+      let text: string;
       try {
         text = (await summaryPromise) ?? "";
-      } catch {
-        text = "";
-      } finally {
+      } catch (e) {
+        // The summary genuinely failed (e.g. a DB error mid-compaction). Do
+        // NOT emit a normal `message_stop` — a complete-but-empty turn would
+        // be treated by the client as a *successful* empty compaction and wipe
+        // its context. Instead, error the stream: the truncated SSE (no
+        // message_stop) signals failure, so the client keeps its history and
+        // can retry. (A null/empty *resolution* below is different — that means
+        // there is genuinely nothing to compact, for which an empty turn is
+        // correct.)
         clearPing();
+        try {
+          controller.error(e instanceof Error ? e : new Error(String(e)));
+        } catch {
+          // Controller already closed (client disconnected) — nothing to do.
+        }
+        return;
       }
+      clearPing();
 
       emit(
         formatSSEEvent(

--- a/packages/gateway/test/keepalive-compaction.test.ts
+++ b/packages/gateway/test/keepalive-compaction.test.ts
@@ -83,7 +83,7 @@ describe("buildKeepaliveCompactionStream", () => {
     expect(body).toContain("[DONE]");
   });
 
-  test("a rejected summary promise still terminates the stream cleanly", async () => {
+  test("a rejected summary errors the stream (no message_stop) so the client keeps context", async () => {
     const rejecting = new Promise<string | null>((_, rej) => {
       setTimeout(() => rej(new Error("boom")), 5);
     });
@@ -93,9 +93,10 @@ describe("buildKeepaliveCompactionStream", () => {
       rejecting,
       50,
     );
-    const body = await readAll(resp);
-    expect(body).toContain("event: message_start");
-    expect(body).toContain("event: message_stop");
-    expect(body).toContain('"text":""');
+    // The stream errors after the opening events — reading it must reject, and
+    // the client never sees a `message_stop`, so it treats compaction as failed
+    // (keeps its full history) rather than as a successful empty summary.
+    // (A null *resolution* is different — see the empty-turn test above.)
+    await expect(readAll(resp)).rejects.toThrow("boom");
   });
 });


### PR DESCRIPTION
## Context

Post-merge review of #672 (offline compaction + SSE keepalive) ahead of a release.

## Bug (context loss on compaction failure)

In `handleCompaction`'s streaming path, the keepalive stream is returned without awaiting the summary. If `generateCompactionSummary` **rejects** (e.g. a DB error mid-compaction), `buildKeepaliveCompactionStream` caught the rejection and emitted a **complete-but-empty assistant turn** (`message_start … message_stop` with empty text).

A client like Claude Code treats a completed compaction response as authoritative and **replaces its conversation history with the (empty) summary** — silent context loss. The pre-#672 code surfaced a 500 instead, so the client kept its history.

## Fix

On rejection, call `controller.error()` instead of emitting an empty turn. The truncated SSE (no `message_stop`) signals failure, so the client keeps its full history and can retry.

A null/empty **resolution** is intentionally left unchanged — that means there is genuinely nothing to compact (brand-new session with no history), for which an empty turn is correct. The fix distinguishes *failure* (reject → error the stream) from *nothing-to-do* (null → benign empty turn).

## Verified during review (no action needed)
- `server.ts` streams `ReadableStream` bodies progressively (chunked write loop), so keepalive pings reach the client in real time. ✅
- The #669 worker-health circuit (`allowWorkerProbe`) gates only background work — the urgent compaction distillation is a direct call and isn't blocked. ✅
- #671's single-owner `recordWorkerFailure` attribution at retry-exhaustion is coherent with #666. ✅
- `resolveMaxRetries()` is hoisted (one env read per call, not per attempt). ✅

## Follow-ups (not release-blocking, filed for later)
- Dead-but-harmless `lore-compact` references remain in `worker-health.ts` (WorkerID union) and `cost-tracker.ts` (bucket map) after #672 removed the worker. Pure cleanup.
- `COMPACT_SUMMARY_TEMPLATE` / `buildCompactPrompt` in `@loreai/core` are now dead code (TODO already added in #672).
- `assembleOfflineCompaction` caps the raw tail (4000 chars) but not the distillation section; with very many live distillations the summary could grow large. Bounded in practice by meta-distillation, but worth a token budget later.

## Tests
- Rejection test now asserts the stream errors (read rejects with the original error, no `message_stop`).
- Null-resolution test still asserts a well-formed empty turn.
- Full gateway suite: 1251 passed, 3 skipped. Typecheck + Biome clean.