### PR TITLE
ci(publish): restore npm upgrade for OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,6 +54,13 @@ jobs:
         with:
           registry-url: 'https://registry.npmjs.org'
 
+      # Craft's OIDC trusted publishing requires npm >= 11.5.1, but the default
+      # runner Node (22.x) ships npm 10.x — upgrade explicitly. (Regression:
+      # this step was dropped in the Craft 2.26.9 bump assuming the default Node
+      # would already ship npm 11.x; it does not.)
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
+
       # Pin to a specific Craft version to avoid upstream regressions.
       - name: Install Craft
         env:


### PR DESCRIPTION
## Problem

The 0.26.0 Publish run failed (run 27284072387):
```
npm target: OIDC trusted publishing requires npm >= 11.5.1, but found 10.9.8
```
All release artifacts built fine; npm just couldn't authenticate.

## Cause

`61ea4bf` ("bump Craft to 2.26.9 and drop Node 22 workaround") removed both the `node-version: 22` pin **and** the `npm install -g npm@latest` step, assuming the default runner Node ships npm >= 11.5.1. It doesn't — the runner default is Node 22.x with **npm 10.9.8**, below Craft's OIDC requirement.

## Fix

Re-add the explicit npm upgrade step after `setup-node` (the proven config from `c68bca8`). Staying on the default Node avoids the Node 24 `extract-zip` hang that the original Node 22 pin guarded against. Craft stays pinned at 2.26.9.

Unblocks the 0.26.0 release (publish issue #677).