### PR TITLE
ci(publish): use sudo for global npm upgrade (EACCES on /usr/local)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,8 +58,10 @@ jobs:
       # runner Node (22.x) ships npm 10.x — upgrade explicitly. (Regression:
       # this step was dropped in the Craft 2.26.9 bump assuming the default Node
       # would already ship npm 11.x; it does not.)
+      # `sudo` because the global prefix is /usr/local (root-owned) — same as
+      # the Craft install step below.
       - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
+        run: sudo npm install -g npm@latest
 
       # Pin to a specific Craft version to avoid upstream regressions.
       - name: Install Craft


### PR DESCRIPTION
Follow-up to #678. The `npm install -g npm@latest` step failed with:
```
npm error code EACCES — EACCES: permission denied, mkdir '/usr/local/share/man/man7'
```
The npm global prefix is `/usr/local` (root-owned). Prefix with `sudo`, consistent with the workflow's existing `sudo` writes to `/usr/local` for the Craft binary. Unblocks 0.26.0 (#677).