### PR TITLE
ci: add Codecov coverage reporting with 80% patch requirement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
               - '.github/workflows/ci.yml'
               - '.github/workflows/publish.yml'
               - '.github/workflows/release.yml'
+              - 'codecov.yml'
             # Docs-only changes still need check-docs to run (so the
             # generator reflects config-schema updates), but skip the
             # heavy test/binary jobs.
@@ -89,6 +90,15 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    # Override the workflow-default permissions (contents: read, packages: write)
+    # to also grant what the Codecov upload step needs to post PR comments and
+    # commit statuses. A job-level block REPLACES the default, so the inherited
+    # perms are re-listed here.
+    permissions:
+      contents: read
+      pull-requests: write
+      statuses: write
+      actions: read
     outputs:
       nightly-version: ${{ steps.nightly.outputs.version }}
     steps:
@@ -134,7 +144,10 @@ jobs:
         run: pnpm run lint
 
       - name: Test
-        run: pnpm test
+        # `--` forwards `--coverage` to the underlying `vitest run` while still
+        # triggering the `pretest` hook (gateway bundle). Produces
+        # ./coverage/lcov.info for the Codecov upload below.
+        run: pnpm test -- --coverage
         env:
           # Silence the ~85-line "ExperimentalWarning: SQLite is an experimental
           # feature" noise from node:sqlite — emitted once per worker fork in
@@ -144,6 +157,19 @@ jobs:
           # (transformers.js resolves <root>/<modelId>/...). Keeps the test run
           # off HuggingFace Hub. See packages/core/src/embedding-vendor.ts.
           LORE_LOCAL_MODEL_PATH: ${{ github.workspace }}/.vendor-build/.model-cache
+
+      # Upload coverage to Codecov. Uses Sentry's fork with the standard
+      # GITHUB_TOKEN (no CODECOV_TOKEN secret needed). `informational-patch` is
+      # true on push events so the 80% patch gate only BLOCKS on pull requests;
+      # on main/release pushes it reports without failing. Patch target (80%)
+      # and project-informational status are configured in codecov.yml.
+      - name: Coverage Report
+        if: '!cancelled()'
+        uses: getsentry/codecov-action@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: ./coverage/lcov.info
+          informational-patch: ${{ github.event_name == 'push' }}
 
       # Compute nightly version once, pass as job output to downstream jobs.
       # Only on main pushes — PRs and release branches don't get nightly versions.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,10 +144,12 @@ jobs:
         run: pnpm run lint
 
       - name: Test
-        # `--` forwards `--coverage` to the underlying `vitest run` while still
-        # triggering the `pretest` hook (gateway bundle). Produces
+        # Runs the gateway bundle (needed by tests) then `vitest run --coverage`.
+        # `--coverage` is baked into the script rather than forwarded via
+        # `pnpm test -- --coverage`, because pnpm does NOT forward args past the
+        # `test` lifecycle script — the flag was silently dropped. Produces
         # ./coverage/lcov.info for the Codecov upload below.
-        run: pnpm test -- --coverage
+        run: pnpm run test:coverage
         env:
           # Silence the ~85-line "ExperimentalWarning: SQLite is an experimental
           # feature" noise from node:sqlite — emitted once per worker fork in

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ dist-vendor/
 .node-cache/
 local_cache/
 *.tgz
+coverage/
 *.db
 *.db-journal
 *.db-wal

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+comment: true
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        target: 80%

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.16",
+    "@vitest/coverage-v8": "^4.1.8",
     "esbuild": "^0.25.12",
     "fast-check": "^4.5.3",
     "linkinator": "^7.6.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "typecheck": "pnpm -r run typecheck",
     "test": "vitest run",
     "pretest": "pnpm --filter @loreai/gateway run bundle",
+    "test:coverage": "pnpm --filter @loreai/gateway run bundle && vitest run --coverage",
     "build": "pnpm -r run build",
     "site:dev": "pnpm --filter '@loreai/website' dev",
     "site:build": "pnpm --filter '@loreai/website' build",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
       '@biomejs/biome':
         specifier: 2.4.16
         version: 2.4.16
+      '@vitest/coverage-v8':
+        specifier: ^4.1.8
+        version: 4.1.8(vitest@4.1.8)
       esbuild:
         specifier: ^0.25.12
         version: 0.25.12
@@ -35,10 +38,10 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.7
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.3.2)(vite@7.3.5(@types/node@25.3.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.3.2)(@vitest/coverage-v8@4.1.8)(vite@7.3.5(@types/node@25.3.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       vitest-evals:
         specifier: ^0.10.0
-        version: 0.10.0(tinyrainbow@3.1.0)(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.3.2)(vite@7.3.5(@types/node@25.3.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(zod@4.3.6)
+        version: 0.10.0(tinyrainbow@3.1.0)(vitest@4.1.8)(zod@4.3.6)
 
   packages/core:
     dependencies:
@@ -335,6 +338,10 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@biomejs/biome@2.4.16':
     resolution: {integrity: sha512-x9ajFh1zChVybCiM3TN6OD4phAqLgtPZjFrZF+aTMYCPjwBO+k529TX7PPsAqtGNLeV4UgzwQnowEgS7bGmzcA==}
@@ -1077,8 +1084,15 @@ packages:
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
 
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@mariozechner/clipboard-darwin-arm64@0.3.9':
     resolution: {integrity: sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==}
@@ -1626,6 +1640,15 @@ packages:
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
 
+  '@vitest/coverage-v8@4.1.8':
+    resolution: {integrity: sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==}
+    peerDependencies:
+      '@vitest/browser': 4.1.8
+      vitest: 4.1.8
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@4.1.8':
     resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
 
@@ -1750,6 +1773,9 @@ packages:
   ast-types@0.13.4:
     resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
     engines: {node: '>=4'}
+
+  ast-v8-to-istanbul@1.0.4:
+    resolution: {integrity: sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==}
 
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
@@ -2440,6 +2466,9 @@ packages:
     resolution: {integrity: sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
   html-escaper@3.0.3:
     resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
 
@@ -2531,9 +2560,24 @@ packages:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-yaml@4.2.0:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
@@ -2603,6 +2647,10 @@ packages:
 
   magicast@0.5.3:
     resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   markdown-extensions@2.0.0:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
@@ -4291,6 +4339,8 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
+  '@bcoe/v8-coverage@1.0.2': {}
+
   '@biomejs/biome@2.4.16':
     optionalDependencies:
       '@biomejs/cli-darwin-arm64': 2.4.16
@@ -4761,7 +4811,14 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
+  '@jridgewell/resolve-uri@3.1.2': {}
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@mariozechner/clipboard-darwin-arm64@0.3.9':
     optional: true
@@ -5323,6 +5380,20 @@ snapshots:
 
   '@ungap/structured-clone@1.3.1': {}
 
+  '@vitest/coverage-v8@4.1.8(vitest@4.1.8)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.8
+      ast-v8-to-istanbul: 1.0.4
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.3
+      obug: 2.1.2
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.3.2)(@vitest/coverage-v8@4.1.8)(vite@7.3.5(@types/node@25.3.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+
   '@vitest/expect@4.1.8':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -5465,6 +5536,12 @@ snapshots:
   ast-types@0.13.4:
     dependencies:
       tslib: 2.8.1
+
+  ast-v8-to-istanbul@1.0.4:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   astring@1.9.0: {}
 
@@ -6429,6 +6506,8 @@ snapshots:
     dependencies:
       lru-cache: 11.5.1
 
+  html-escaper@2.0.2: {}
+
   html-escaper@3.0.3: {}
 
   html-void-elements@3.0.0: {}
@@ -6506,7 +6585,22 @@ snapshots:
     dependencies:
       is-inside-container: 1.0.0
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   jiti@2.7.0: {}
+
+  js-tokens@10.0.0: {}
 
   js-yaml@4.2.0:
     dependencies:
@@ -6579,6 +6673,10 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
       source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.2
 
   markdown-extensions@2.0.0: {}
 
@@ -7969,14 +8067,14 @@ snapshots:
     optionalDependencies:
       vite: 7.3.5(@types/node@25.3.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
-  vitest-evals@0.10.0(tinyrainbow@3.1.0)(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.3.2)(vite@7.3.5(@types/node@25.3.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(zod@4.3.6):
+  vitest-evals@0.10.0(tinyrainbow@3.1.0)(vitest@4.1.8)(zod@4.3.6):
     dependencies:
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.3.2)(vite@7.3.5(@types/node@25.3.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.3.2)(@vitest/coverage-v8@4.1.8)(vite@7.3.5(@types/node@25.3.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
     optionalDependencies:
       zod: 4.3.6
 
-  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.3.2)(vite@7.3.5(@types/node@25.3.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.3.2)(@vitest/coverage-v8@4.1.8)(vite@7.3.5(@types/node@25.3.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
       '@vitest/mocker': 4.1.8(vite@7.3.5(@types/node@25.3.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -8001,6 +8099,7 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 25.3.2
+      '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
     transitivePeerDependencies:
       - msw
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -34,16 +34,26 @@ export default defineConfig({
       SENTRY_ENABLED: "0",
       LORE_DEBUG: "0",
     },
-    // Coverage is optional and run separately
+    // Coverage is optional and run separately. `lcov` is required for the
+    // Codecov upload in CI; text/json/html are kept for local inspection.
     coverage: {
       provider: "v8",
-      reporter: ["text", "json", "html"],
+      reporter: ["text", "json", "html", "lcov"],
       exclude: [
         "**/*.test.ts",
         "**/test/setup.ts",
         "**/test/helpers/**",
         "**/script/**",
         "**/dist/**",
+        // Non-tested / non-source packages — keep them out of the report so
+        // they don't drag down or pollute patch coverage. Only core, gateway,
+        // and opencode have tests.
+        "packages/website/**",
+        "packages/pi/**",
+        "**/eval/**",
+        "**/*.eval.ts",
+        "*.config.ts",
+        "scripts/**",
       ],
     },
   },


### PR DESCRIPTION
## What

Adds test-coverage reporting to CI, replicating the system used in `getsentry/cli`, with an **80% patch-coverage requirement**.

The flow: Vitest + `@vitest/coverage-v8` emits `coverage/lcov.info`, which is uploaded to Codecov via `getsentry/codecov-action@main`. The Sentry fork uses the standard `GITHUB_TOKEN`, so **no `CODECOV_TOKEN` secret is required**.

## Changes

- **`package.json` / `pnpm-lock.yaml`** — add `@vitest/coverage-v8` devDependency (the V8 coverage provider; was previously uninstalled, so `--coverage` would have failed).
- **`vitest.config.ts`** — add `"lcov"` to the coverage reporters; exclude non-tested / non-source paths (`packages/website`, `packages/pi`, `**/eval`, `*.eval.ts`, root `*.config.ts`, `scripts`). The `*.config.ts` glob is intentionally root-only so it does **not** exclude `packages/core/src/config.ts` or `packages/gateway/src/config.ts`.
- **`codecov.yml`** (new) — `patch` target **80%** (blocking on PRs); `project` coverage **informational** (reported, never blocks).
- **`.github/workflows/ci.yml`**:
  - `Test` step runs `pnpm run test:coverage` (a dedicated script: gateway bundle + `vitest run --coverage`). NOTE: `pnpm test -- --coverage` does **not** work — pnpm drops args past the `test` lifecycle script, so `--coverage` is silently ignored; baking it into the script avoids that.
  - New `Coverage Report` step (`getsentry/codecov-action@main`) with `informational-patch: ${{ github.event_name == 'push' }}` — so the 80% patch gate **blocks on PRs** but is informational on `main`/`release` pushes. Runs `if: '!cancelled()'` so coverage still uploads when tests fail.
  - Job-level `permissions` for the `test` job grant `pull-requests: write` + `statuses: write` + `actions: read` (least-privilege — deliberately omits `packages: write`, which the test job doesn't need; `publish-nightly` inherits it from the workflow default).
  - Add `codecov.yml` to the `code:` paths filter so config-only PRs still run tests.
- **`.gitignore`** — ignore `coverage/`.

## Verification

- `codecov.yml` validates against the Codecov API (`Valid!`; patch target parsed as `80.0`).
- `actionlint` on `ci.yml`: clean.
- `pnpm run lint` (Biome, 272 files): clean.
- `pnpm install --frozen-lockfile`: consistent.
- Scoped `vitest run --coverage` produces `coverage/lcov.info`; report contains only source files (excludes verified), and `packages/core/src/config.ts` confirmed present (not excluded by the `*.config.ts` glob).

## Manual follow-up (repo admin, outside this PR)

Codecov posts its own `codecov/patch` status check. For the 80% gate to actually **block merges**, add `codecov/patch` to the branch-protection required checks. No `ci-status` change is needed since the upload is folded into the existing `test` job. Also ensure the repo is enabled on codecov.io.
