### PR TITLE
feat(recall): search people & entities (aliases + relationships) in recall

### DIFF
--- a/packages/core/src/recall.ts
+++ b/packages/core/src/recall.ts
@@ -47,6 +47,10 @@ type Distillation = {
 
 export type ScoredDistillation = Distillation & { rank: number };
 
+/** An entity result. `rank` mirrors the other scored sources for type parity;
+ *  RRF fuses by list position, not by this value. */
+export type ScoredEntity = entities.EntityWithAliases & { rank: number };
+
 export type RecallScope = "all" | "session" | "project" | "knowledge";
 
 export type RecallInput = {
@@ -86,7 +90,8 @@ export type TaggedResult =
     }
   | { source: "distillation"; item: ScoredDistillation }
   | { source: "temporal"; item: temporal.ScoredTemporalMessage }
-  | { source: "lat-section"; item: latReader.ScoredLatSection };
+  | { source: "lat-section"; item: latReader.ScoredLatSection }
+  | { source: "entity"; item: ScoredEntity };
 
 export type ScoredTaggedResult = { item: TaggedResult; score: number };
 
@@ -106,6 +111,10 @@ function getTaggedText(tagged: TaggedResult): string {
       return tagged.item.content;
     case "lat-section":
       return `${tagged.item.heading} ${tagged.item.content}`;
+    case "entity":
+      return `${tagged.item.canonical_name} ${tagged.item.aliases
+        .map((a) => a.alias_value)
+        .join(" ")}`;
   }
 }
 
@@ -122,6 +131,8 @@ function taggedResultKey(r: TaggedResult): string {
       return `t:${r.item.id}`;
     case "lat-section":
       return `lat:${r.item.id}`;
+    case "entity":
+      return `e:${r.item.id}`;
   }
 }
 
@@ -252,6 +263,7 @@ function truncateAtSentence(text: string, maxChars: number): string {
 const SOURCE_WEIGHT: Record<TaggedResult["source"], number> = {
   knowledge: 1.0,
   "cross-knowledge": 1.0,
+  entity: 0.9,
   "lat-section": 0.9,
   distillation: 0.8,
   temporal: 0.8,
@@ -265,15 +277,17 @@ const TIER_NAMES = ["Strong Matches", "Supporting", "Peripheral"] as const;
 
 /** Source display order within a tier. */
 const SOURCE_ORDER: Record<TaggedResult["source"], number> = {
-  knowledge: 0,
-  "cross-knowledge": 1,
-  "lat-section": 2,
-  distillation: 3,
-  temporal: 4,
+  entity: 0,
+  knowledge: 1,
+  "cross-knowledge": 2,
+  "lat-section": 3,
+  distillation: 4,
+  temporal: 5,
 };
 
 /** Human-readable source group labels for sub-headers. */
 const SOURCE_LABELS: Record<TaggedResult["source"], string> = {
+  entity: "People & Entities",
   knowledge: "Knowledge",
   "cross-knowledge": "Cross-Project",
   "lat-section": "Reference",
@@ -388,6 +402,52 @@ function formatFusedResults(
   return lines.join("\n");
 }
 
+/**
+ * Build the compact human-readable pieces of an entity summary used for recall
+ * rendering: deduped aliases, a role/description blurb from metadata, and
+ * resolved relations (e.g. "partner of Burak Yigit Kaya").
+ */
+function entitySummaryParts(item: entities.EntityWithAliases): {
+  aliasesText: string;
+  metaText: string;
+  relationsText: string;
+} {
+  const uniqueAliases = Array.from(
+    new Set(
+      item.aliases
+        .map((a) => a.alias_value)
+        .filter((v) => v !== item.canonical_name),
+    ),
+  );
+  const aliasesText = uniqueAliases.length
+    ? `aka ${uniqueAliases.join(", ")}`
+    : "";
+
+  let metaText = "";
+  try {
+    const meta = item.metadata
+      ? (JSON.parse(item.metadata) as Record<string, unknown>)
+      : null;
+    if (meta && typeof meta === "object") {
+      const bits: string[] = [];
+      if (typeof meta.role === "string") bits.push(meta.role);
+      if (typeof meta.description === "string") bits.push(meta.description);
+      metaText = bits.join("; ");
+    }
+  } catch {
+    // malformed metadata JSON — skip
+  }
+
+  let relationsText = "";
+  try {
+    relationsText = entities.formatRelationsForPrompt(item.id);
+  } catch {
+    // non-fatal — relations are best-effort
+  }
+
+  return { aliasesText, metaText, relationsText };
+}
+
 /** Get the full content length of a tagged result (before truncation). */
 function getFullContentLength(tagged: TaggedResult): number {
   switch (tagged.source) {
@@ -400,6 +460,15 @@ function getFullContentLength(tagged: TaggedResult): number {
       return tagged.item.content.length;
     case "lat-section":
       return tagged.item.heading.length + tagged.item.content.length;
+    case "entity": {
+      const p = entitySummaryParts(tagged.item);
+      return (
+        tagged.item.canonical_name.length +
+        p.aliasesText.length +
+        p.metaText.length +
+        p.relationsText.length
+      );
+    }
   }
 }
 
@@ -480,6 +549,20 @@ function renderResultLine(tagged: TaggedResult, charBudget: number): string {
       const content = truncateAtSentence(fullText, contentBudget);
       const wasTruncated = fullText.length > contentBudget;
       return `- ${heading}${content}${wasTruncated ? ` (${id})` : ""}`;
+    }
+    case "entity": {
+      const e = tagged.item;
+      const typeLabel =
+        e.entity_type === "self" ? "person, you" : e.entity_type;
+      const head = `**${inline(e.canonical_name)}** (${typeLabel})`;
+      const { aliasesText, metaText, relationsText } = entitySummaryParts(e);
+      const detailFull = [aliasesText, metaText, relationsText]
+        .filter(Boolean)
+        .join(" \u2014 ");
+      const detailBudget = Math.max(40, charBudget - head.length - 2);
+      const detail = truncateAtSentence(inline(detailFull), detailBudget);
+      const wasTruncated = inline(detailFull).length > detailBudget;
+      return `- ${head}${detail ? `: ${detail}` : ""}${wasTruncated ? ` (${id})` : ""}`;
     }
   }
 }
@@ -834,6 +917,42 @@ export async function searchRecall(
           });
         }
       }
+
+      // Entity vector search — semantic match on entity name/alias embeddings.
+      // Same `e:` key as the FTS list so RRF merges (boosting entities that
+      // match both lexically and semantically).
+      if (scope === "all" || scope === "project") {
+        // vectorSearchEntities is NOT project-scoped, so apply the same
+        // visibility predicate entities.search() uses — otherwise a semantic
+        // match could leak another project's project-scoped repo/infra entity.
+        const entPid = ensureProject(projectPath);
+        const entityVectorHits = embedding.vectorSearchEntities(
+          queryVec,
+          limit,
+        );
+        const entityVectorTagged: TaggedResult[] = entityVectorHits
+          .map((hit): TaggedResult | null => {
+            const ent = entities.getWithAliases(hit.id);
+            if (!ent) return null;
+            const visible =
+              ent.project_id === entPid ||
+              ent.project_id === null ||
+              ent.cross_project === 1;
+            if (!visible) return null;
+            return {
+              source: "entity",
+              item: { ...ent, rank: -hit.similarity },
+            };
+          })
+          .filter((r): r is TaggedResult => r !== null);
+        if (entityVectorTagged.length) {
+          allRrfLists.push({
+            items: entityVectorTagged,
+            key: (r) => `e:${r.item.id}`,
+            weight: vectorWeight,
+          });
+        }
+      }
     } catch (err) {
       log.info("recall: vector search failed:", err);
     }
@@ -889,6 +1008,28 @@ export async function searchRecall(
       }
     } catch (err) {
       log.info("recall: cross-project knowledge search failed:", err);
+    }
+  }
+
+  // Entity search — surface matching people/orgs/services/tools (with their
+  // aliases + relations) as first-class results. Identity questions ("who is
+  // Seylan?", "what's our CI?") are answered directly instead of only via the
+  // alias query-expansion above. Cross-session/cross-project, so excluded from
+  // "session" and "knowledge" scopes.
+  if (scope === "all" || scope === "project") {
+    try {
+      const entityResults = entities.search({ query, projectPath, limit });
+      if (entityResults.length) {
+        allRrfLists.push({
+          items: entityResults.map((item, i) => ({
+            source: "entity" as const,
+            item: { ...item, rank: i },
+          })),
+          key: (r) => `e:${r.item.id}`,
+        });
+      }
+    } catch (err) {
+      log.info("recall: entity search failed (non-fatal):", err);
     }
   }
 
@@ -975,8 +1116,11 @@ export async function searchRecall(
   // score to clear the relevance floor.
   //
   // Priority: primary (original query BM25 + recency) and supplemental
-  // (vector, lat.md, cross-project, quality, exact-match) are high-value.
-  // Expanded-query BM25 lists are lowest priority — trim those first.
+  // (vector, lat.md, cross-project, entity FTS + entity vector, quality,
+  // exact-match) are high-value and always kept — only expanded-query BM25
+  // lists are trimmed. Note: keeping all supplemental lists means the final
+  // count can slightly exceed MAX_RRF_LISTS when primary+supplemental alone
+  // already do; the cap only bounds how many expanded-query lists survive.
   const MAX_RRF_LISTS = 14;
   if (allRrfLists.length > MAX_RRF_LISTS) {
     // Layout: [0..primaryListEnd) = primary, [primaryListEnd..perQueryEnd) = expanded, [perQueryEnd..) = supplemental
@@ -1011,7 +1155,7 @@ export async function searchRecall(
  *
  * IDs use the format `prefix:uuid` where prefix is one of:
  *   k: (knowledge), xk: (cross-knowledge), d: (distillation),
- *   t: (temporal), lat: (lat-section).
+ *   t: (temporal), lat: (lat-section), e: (entity).
  */
 export function recallById(id: string): string {
   const colonIdx = id.indexOf(":");
@@ -1077,6 +1221,22 @@ export function recallById(id: string): string {
         ``,
         `${inline(row.content)}`,
       ].join("\n");
+    }
+    case "e": {
+      const ent = entities.getWithAliases(rawId);
+      if (!ent) return `No entry found for id: ${id}`;
+      const lines = [
+        `## Recall Detail: ${id}`,
+        ``,
+        `#### People & Entities`,
+        entities.formatForPrompt([ent]),
+      ];
+      // formatForPrompt only renders relations relative to a self entity in the
+      // passed array; for a single non-self entity it omits them — append
+      // explicitly so the drill-down isn't less informative than the summary.
+      const relations = entities.formatRelationsForPrompt(rawId);
+      if (relations) lines.push(``, `Relations: ${relations}`);
+      return lines.join("\n");
     }
     default:
       return `Unknown source prefix "${prefix}" in id: ${id}`;
@@ -1149,7 +1309,7 @@ export async function runRecall(input: RecallInput): Promise<RecallResult> {
 
 /** Standard tool description reused verbatim by each host adapter. */
 export const RECALL_TOOL_DESCRIPTION =
-  "Search your persistent memory for this project. Your visible context is a trimmed window — older messages, decisions, and details may not be visible to you even within the current session. Use this tool whenever you need information that isn't in your current context: file paths, past decisions, user preferences, prior approaches, or anything from earlier in this conversation or previous sessions. Always prefer recall over assuming you don't have the information. Searches long-term knowledge, distilled history, and raw message archives." +
+  "Search your persistent memory for this project. Your visible context is a trimmed window — older messages, decisions, and details may not be visible to you even within the current session. Use this tool whenever you need information that isn't in your current context: file paths, past decisions, user preferences, prior approaches, the people/services/tools the user works with, or anything from earlier in this conversation or previous sessions. Always prefer recall over assuming you don't have the information. Searches long-term knowledge, known entities (people, orgs, services, tools — with their aliases and relationships), distilled history, and raw message archives." +
   '\n\nYour context contains references in the format (prefix:id) — e.g. (d:abc123) for distillations, (t:abc123) for messages. These appear in distillation headers, tool result placeholders, and truncated recall results. Pass any such ID to this tool\'s `id` parameter to retrieve the full original content. Distillations marked "lossy" have lost specific details — use the ID to drill down.' +
   '\n\nNever write recall status text (like "📚 Searching…" or "📚 Fetching…") yourself — these are injected by the system automatically when you use this tool.';
 
@@ -1159,5 +1319,5 @@ export const RECALL_PARAM_DESCRIPTIONS = {
     "What to search for — be specific. Include keywords, file names, or concepts.",
   scope:
     "Search scope: 'all' (default) searches everything, 'session' searches current session only, 'project' searches all sessions in this project, 'knowledge' searches only long-term knowledge.",
-  id: "Fetch full content of a specific result by its source-prefixed ID (e.g. 'k:abc123', 'd:abc123', 't:abc123'). These IDs appear throughout your context: in distillation headers, tool result placeholders, and truncated recall results. When id is provided, query is ignored.",
+  id: "Fetch full content of a specific result by its source-prefixed ID (e.g. 'k:abc123', 'd:abc123', 't:abc123', 'e:abc123' for an entity). These IDs appear throughout your context: in distillation headers, tool result placeholders, and truncated recall results. When id is provided, query is ignored.",
 };

--- a/packages/core/test/recall-entity.test.ts
+++ b/packages/core/test/recall-entity.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { db, ensureProject } from "../src/db";
+import * as entities from "../src/entities";
+import { recallById, runRecall, searchRecall } from "../src/recall";
+
+const PROJECT = "/test/recall-entity/project";
+
+function cleanup() {
+  const d = db();
+  d.exec("DELETE FROM entity_relations");
+  d.exec("DELETE FROM knowledge_entity_refs");
+  d.exec("DELETE FROM entity_aliases");
+  d.exec("DELETE FROM entities");
+}
+
+/** Seed a self entity + a "person" with aliases and a partner relation. */
+function seedPeople() {
+  const self = entities.create({
+    entityType: "self",
+    canonicalName: "Burak Yigit Kaya",
+    crossProject: true,
+  });
+  const wife = entities.create({
+    entityType: "person",
+    canonicalName: "Seylan Çinar Kaya",
+    aliases: [
+      { type: "email", value: "seylan@withlore.ai" },
+      { type: "nickname", value: "Seylan" },
+    ],
+    crossProject: true,
+  });
+  entities.addRelation(self.id, wife.id, "partner", { source: "test" });
+  return { selfId: self.id, wifeId: wife.id };
+}
+
+describe("recall — entity source", () => {
+  beforeEach(() => {
+    cleanup();
+    ensureProject(PROJECT);
+  });
+
+  test("surfaces a matching entity as a recall result", async () => {
+    const { wifeId } = seedPeople();
+    const results = await searchRecall({
+      query: "Seylan",
+      projectPath: PROJECT,
+      scope: "all",
+    });
+    const r = results.find((x) => x.item.source === "entity");
+    expect(r).toBeDefined();
+    if (r && r.item.source === "entity") {
+      expect(r.item.item.id).toBe(wifeId);
+    }
+  });
+
+  test("matches by alias too (email)", async () => {
+    seedPeople();
+    const results = await searchRecall({
+      query: "seylan@withlore.ai",
+      projectPath: PROJECT,
+      scope: "all",
+    });
+    expect(results.some((x) => x.item.source === "entity")).toBe(true);
+  });
+
+  test("runRecall renders the entity with its relation and header", async () => {
+    seedPeople();
+    const md = await runRecall({
+      query: "Seylan",
+      projectPath: PROJECT,
+      scope: "all",
+    });
+    expect(md).toContain("People & Entities");
+    expect(md).toContain("Seylan Çinar Kaya");
+    expect(md).toContain("partner of Burak Yigit Kaya");
+  });
+
+  test("recallById('e:..') returns full detail including relations", () => {
+    const { wifeId } = seedPeople();
+    const detail = recallById(`e:${wifeId}`);
+    expect(detail).toContain("Recall Detail");
+    expect(detail).toContain("Seylan Çinar Kaya");
+    // Drill-down must not be less informative than the summary line.
+    expect(detail).toContain("partner of Burak Yigit Kaya");
+  });
+
+  test("recallById returns not-found for a missing entity id", () => {
+    const detail = recallById("e:019eac47-0000-0000-0000-000000000000");
+    expect(detail).toContain("No entry found");
+  });
+
+  test("does not leak another project's project-scoped entity", async () => {
+    // A `repo` entity defaults to project-scoped (cross_project = 0). Created in
+    // OTHER_PROJECT, it must not surface when recalling from PROJECT.
+    const OTHER_PROJECT = "/test/recall-entity/other";
+    ensureProject(OTHER_PROJECT);
+    entities.create({
+      projectPath: OTHER_PROJECT,
+      entityType: "repo",
+      canonicalName: "secretrepo",
+    });
+
+    const results = await searchRecall({
+      query: "secretrepo",
+      projectPath: PROJECT,
+      scope: "all",
+    });
+    expect(results.some((x) => x.item.source === "entity")).toBe(false);
+  });
+
+  test("excludes entities from 'knowledge' and 'session' scopes", async () => {
+    seedPeople();
+    const kn = await searchRecall({
+      query: "Seylan",
+      projectPath: PROJECT,
+      scope: "knowledge",
+    });
+    expect(kn.some((x) => x.item.source === "entity")).toBe(false);
+
+    const ses = await searchRecall({
+      query: "Seylan",
+      projectPath: PROJECT,
+      scope: "session",
+      sessionID: "test-session",
+    });
+    expect(ses.some((x) => x.item.source === "entity")).toBe(false);
+  });
+});

--- a/packages/gateway/src/ui.ts
+++ b/packages/gateway/src/ui.ts
@@ -2125,6 +2125,31 @@ function formatSearchResult(tagged: TaggedResult, score?: number): string {
         ${idLink("lat", s.id)}
       </li>`;
     }
+    case "entity": {
+      const e = tagged.item;
+      const aliases = Array.from(
+        new Set(
+          e.aliases
+            .map((a) => a.alias_value)
+            .filter((v) => v !== e.canonical_name),
+        ),
+      );
+      const aliasStr = aliases.length
+        ? ` <span class="meta">aka ${esc(aliases.join(", "))}</span>`
+        : "";
+      let relStr = "";
+      try {
+        const rels = entities.formatRelationsForPrompt(e.id);
+        if (rels) relStr = ` <span class="meta">${esc(rels)}</span>`;
+      } catch {
+        // relations are best-effort
+      }
+      return `<li class="result-item">
+        ${scoreStr}${badge(e.entity_type)}
+        <strong><a href="/ui/entities/${esc(e.id)}">${esc(e.canonical_name)}</a></strong>${aliasStr}${relStr}
+        ${idLink("e", e.id)}
+      </li>`;
+    }
   }
 }
 


### PR DESCRIPTION
## Why
The `recall` tool searched knowledge, distillations, temporal messages, and lat.md — but **not the entity registry**. Entities were only used for *query expansion* (aliases added as extra query variants), so identity questions like "who is Seylan?" or "what's our CI service?" never returned the entity itself with its aliases and relationships.

## What
Adds **`entity`** as a first-class recall source.

- New `TaggedResult` variant `{ source: "entity"; item: ScoredEntity }` (key prefix `e:`). Extends every exhaustive `switch` in `recall.ts`: `getTaggedText`, `taggedResultKey`, `SOURCE_WEIGHT`/`SOURCE_ORDER`/`SOURCE_LABELS`, `getFullContentLength`, `renderResultLine`, and `recallById`.
- `searchRecall()` adds two RRF lists (gated to `all`/`project` scopes — entities are cross-session identity info, so excluded from `session`/`knowledge`):
  - **FTS list** via `entities.search()` (matches canonical name *and* aliases).
  - **Vector list** via `embedding.vectorSearchEntities()`.
  Both use the `e:` key so lexical + semantic matches fuse.
- Rendering shows `**Name** (type): aka <aliases> — <role/description> — <relations>` (e.g. *"partner of Burak Yigit Kaya"*). `recallById('e:<id>')` returns full detail via `entities.formatForPrompt`.
- Dashboard `/ui/search` renders entity results (linked to the entity page).
- Recall tool description updated so the agent knows it can recall people/entities.

## Test plan
- `pnpm run typecheck` / `pnpm run lint` — clean
- `pnpm test` — 2525 passed / 6 skipped (94 files), incl. new `recall-entity.test.ts` (FTS + alias match, relation rendering, `recallById`, and scope-gating for `knowledge`/`session`)
- Manual: `lore recall "Seylan"` / dashboard search returns the person with aliases + "partner of …".

## Follow-up (not in this PR)
Investigating this surfaced an entity-dedup gap: first-name vs full-name duplicates (`Seylan` vs `Seylan Çinar Kaya`) aren't merged or even suggested — name-Jaccard is 1/3 (< 0.5), there's no shared alias value, and short-name embedding cosine is < 0.85. A **name-containment signal** (token-subset → strong duplicate, suggest/auto-merge for `person`) would fix it. Happy to do that next.