### PR TITLE
test(gateway): cover recorder, cost-tracker, idle, anthropic stream

### DIFF
--- a/packages/gateway/test/cost-tracker-accumulation.test.ts
+++ b/packages/gateway/test/cost-tracker-accumulation.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Tests for the in-memory cost accumulation + query helpers in
+ * `src/cost-tracker.ts`. The existing `cost-tracker.test.ts` only covers the
+ * pure `computeCallCost` pricing math; this file covers the accumulators
+ * (recordConversationCost / recordWorkerCost / recordWarmupCost /
+ * recordWarmupHit / recordTTLSavings), the totals (totalActualCost /
+ * totalWorkerCost / totalSavings / costWithoutLore), and the session
+ * lifecycle queries.
+ *
+ * Uses the same `__test_fake_model__` pricing fixture as cost-tracker.test.ts:
+ *   input 3 / output 15 / cache_read 0.3 / cache_write 3.75 ($/MTok).
+ */
+import { describe, test, expect, beforeEach } from "vitest";
+import {
+  clearAllCosts,
+  resetDailyBudgetState,
+  getSessionCosts,
+  getAllSessionCosts,
+  deleteSessionCosts,
+  recordConversationCost,
+  recordWorkerCost,
+  recordWarmupCost,
+  recordWarmupHit,
+  recordTTLSavings,
+  totalActualCost,
+  totalWorkerCost,
+  totalSavings,
+  costWithoutLore,
+  computeCallCost,
+  type SessionCosts,
+} from "../src/cost-tracker";
+
+const MODEL = "__test_fake_model__";
+
+/** 1M tokens per category — makes expected costs equal the $/MTok rates. */
+const USAGE = {
+  input_tokens: 1_000_000,
+  output_tokens: 1_000_000,
+  cache_read_input_tokens: 1_000_000,
+  cache_creation_input_tokens: 1_000_000,
+};
+
+/** Fetch a session's costs, asserting it exists (avoids non-null assertions). */
+function costsFor(sessionID: string): SessionCosts {
+  const c = getSessionCosts(sessionID);
+  expect(c).not.toBeNull();
+  return c as SessionCosts;
+}
+
+beforeEach(() => {
+  clearAllCosts();
+  resetDailyBudgetState();
+});
+
+describe("recordConversationCost", () => {
+  test("accumulates cost, token counters, and turn count", () => {
+    recordConversationCost("s1", MODEL, USAGE);
+    const expected = computeCallCost(MODEL, USAGE, "conversation");
+    const c = costsFor("s1");
+    expect(c.conversation.turns).toBe(1);
+    expect(c.conversation.cost).toBeCloseTo(expected.total);
+    expect(c.conversation.inputTokens).toBe(1_000_000);
+    expect(c.conversation.outputTokens).toBe(1_000_000);
+    expect(c.conversation.cacheReadTokens).toBe(1_000_000);
+    expect(c.conversation.cacheWriteTokens).toBe(1_000_000);
+
+    recordConversationCost("s1", MODEL, USAGE);
+    expect(costsFor("s1").conversation.turns).toBe(2);
+    expect(costsFor("s1").conversation.cost).toBeCloseTo(expected.total * 2);
+  });
+
+  test("honors 1h TTL (cache_write doubled)", () => {
+    recordConversationCost("s1", MODEL, USAGE, "1h");
+    const base = computeCallCost(MODEL, USAGE, "conversation");
+    const ttl = computeCallCost(MODEL, USAGE, "conversation", "1h");
+    expect(ttl.total).toBeGreaterThan(base.total);
+    expect(costsFor("s1").conversation.cost).toBeCloseTo(ttl.total);
+  });
+});
+
+describe("recordWorkerCost", () => {
+  test("is a no-op when sessionID is undefined", () => {
+    recordWorkerCost(undefined, MODEL, USAGE, "direct", "lore-distill");
+    expect(getAllSessionCosts().size).toBe(0);
+  });
+
+  test("maps each workerID to its cost bucket", () => {
+    recordWorkerCost("s1", MODEL, USAGE, "direct", "lore-distill");
+    recordWorkerCost("s1", MODEL, USAGE, "direct", "lore-curator");
+    recordWorkerCost("s1", MODEL, USAGE, "direct", "lore-query-expand");
+    recordWorkerCost("s1", MODEL, USAGE, "direct", "lore-compact");
+
+    const c = costsFor("s1");
+    expect(c.workers.distillation.calls).toBe(1);
+    expect(c.workers.curation.calls).toBe(1);
+    expect(c.workers.recall.calls).toBe(1);
+    expect(c.workers.compaction.calls).toBe(1);
+
+    const expected = computeCallCost(MODEL, USAGE, "direct");
+    expect(c.workers.distillation.cost).toBeCloseTo(expected.total);
+  });
+
+  test("defaults unknown/absent workerID to the distillation bucket", () => {
+    recordWorkerCost("s1", MODEL, USAGE, "direct");
+    recordWorkerCost("s1", MODEL, USAGE, "direct", "mystery-worker");
+    expect(costsFor("s1").workers.distillation.calls).toBe(2);
+  });
+
+  test("batch calls record batchSavings (direct minus batch cost)", () => {
+    recordWorkerCost("s1", MODEL, USAGE, "batch", "lore-distill");
+    const direct = computeCallCost(MODEL, USAGE, "direct");
+    const batch = computeCallCost(MODEL, USAGE, "batch");
+    expect(costsFor("s1").batchSavings).toBeCloseTo(direct.total - batch.total);
+  });
+});
+
+describe("recordWarmupCost", () => {
+  test("accumulates warmup worker cost (read + write)", () => {
+    recordWarmupCost("s1", MODEL, 1_000_000, 1_000_000);
+    const c = costsFor("s1");
+    // read: 1M × 0.3/M = 0.3; write: 1M × 3.75/M = 3.75
+    expect(c.workers.warmup.calls).toBe(1);
+    expect(c.workers.warmup.cost).toBeCloseTo(0.3 + 3.75);
+  });
+
+  test("doubles cache_write at 1h TTL", () => {
+    recordWarmupCost("s1", MODEL, 0, 1_000_000, "1h");
+    expect(costsFor("s1").workers.warmup.cost).toBeCloseTo(3.75 * 2);
+  });
+});
+
+describe("counterfactual savings", () => {
+  test("recordWarmupHit accumulates warmup savings + hits", () => {
+    recordWarmupHit("s1", MODEL, 1_000_000);
+    const c = costsFor("s1");
+    // savings = 1M × (cache_write − cache_read) = 3.75 − 0.3
+    expect(c.counterfactual.warmupHits).toBe(1);
+    expect(c.counterfactual.warmupSavings).toBeCloseTo(3.75 - 0.3);
+  });
+
+  test("recordTTLSavings accumulates TTL savings + hits", () => {
+    recordTTLSavings("s1", MODEL, 1_000_000);
+    const c = costsFor("s1");
+    expect(c.counterfactual.ttlHits).toBe(1);
+    expect(c.counterfactual.ttlSavings).toBeCloseTo(3.75 - 0.3);
+  });
+});
+
+describe("totals", () => {
+  test("aggregate conversation, worker, and savings figures consistently", () => {
+    recordConversationCost("s1", MODEL, USAGE);
+    recordWorkerCost("s1", MODEL, USAGE, "direct", "lore-distill");
+    recordWorkerCost("s1", MODEL, USAGE, "batch", "lore-curator");
+    recordWarmupCost("s1", MODEL, 1_000_000, 1_000_000);
+    recordWarmupHit("s1", MODEL, 1_000_000);
+    recordTTLSavings("s1", MODEL, 1_000_000);
+
+    const c = costsFor("s1");
+    const actual = totalActualCost(c);
+    const worker = totalWorkerCost(c);
+
+    expect(actual).toBeCloseTo(
+      c.conversation.cost +
+        c.workers.distillation.cost +
+        c.workers.curation.cost +
+        c.workers.compaction.cost +
+        c.workers.recall.cost +
+        c.workers.warmup.cost,
+    );
+    expect(worker).toBeCloseTo(actual - c.conversation.cost);
+    expect(totalSavings(c)).toBeCloseTo(
+      c.counterfactual.warmupSavings +
+        c.counterfactual.ttlSavings +
+        c.batchSavings +
+        c.counterfactual.avoidedCompactionCost -
+        worker,
+    );
+    expect(costWithoutLore(c)).toBeCloseTo(actual + totalSavings(c));
+  });
+});
+
+describe("queries + lifecycle", () => {
+  test("getSessionCosts returns null for an unknown session", () => {
+    expect(getSessionCosts("nope")).toBeNull();
+  });
+
+  test("getAllSessionCosts exposes tracked sessions; delete + clear remove them", () => {
+    recordConversationCost("s1", MODEL, USAGE);
+    recordConversationCost("s2", MODEL, USAGE);
+    expect(getAllSessionCosts().size).toBe(2);
+    expect(getAllSessionCosts().has("s1")).toBe(true);
+
+    deleteSessionCosts("s1");
+    expect(getSessionCosts("s1")).toBeNull();
+    expect(getAllSessionCosts().size).toBe(1);
+
+    clearAllCosts();
+    expect(getAllSessionCosts().size).toBe(0);
+  });
+});

--- a/packages/gateway/test/idle-work.test.ts
+++ b/packages/gateway/test/idle-work.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for `touchSession` and `buildIdleWorkHandler` in `src/idle.ts`.
+ *
+ * `evictIdleSessions` / `startIdleScheduler` are covered by eviction.test.ts.
+ * Here we focus on the idle work handler's local steps (pruning, knowledge
+ * export, dead-ref cleanup, lat refresh, cost persistence) and its skip
+ * guards. The LLM-calling branches (distillation/curation/consolidation) are
+ * intentionally NOT driven here — they couple to core worker internals and
+ * the batch queue; on an empty DB they are correctly skipped.
+ */
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildIdleWorkHandler, touchSession } from "../src/idle";
+import { recordConversationCost, clearAllCosts } from "../src/cost-tracker";
+import { resetPipelineState } from "../src/pipeline";
+import { ltm, loadSessionCosts } from "@loreai/core";
+import type { LLMClient } from "@loreai/core";
+import type { SessionState } from "../src/translate/types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSessionState(overrides?: Partial<SessionState>): SessionState {
+  return {
+    sessionID: "idle-session",
+    projectPath: "/tmp/test-project",
+    fingerprint: "fp-123",
+    lastRequestTime: Date.now(),
+    lastUserTurnTime: 0,
+    messageCount: 5,
+    turnsSinceCuration: 0,
+    consecutiveTextOnlyTurns: 0,
+    recallStore: new Map(),
+    upstreamByProvider: new Map(),
+    cacheAnalytics: {
+      lastRequestBody: null,
+      lastRequestBodyLength: 0,
+      lastCacheRead: 0,
+      lastCacheCreation: 0,
+      turnCount: 0,
+      bustCount: 0,
+    },
+    ...overrides,
+  };
+}
+
+/** A no-op LLM client — handler steps that would call it are skipped here. */
+function makeLLM(): LLMClient {
+  return { prompt: vi.fn(async () => null) };
+}
+
+const tmpDirs: string[] = [];
+function makeProjectDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "lore-idle-test-"));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+beforeEach(async () => {
+  await resetPipelineState();
+  clearAllCosts();
+});
+
+afterEach(() => {
+  for (const dir of tmpDirs) {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // best-effort cleanup
+    }
+  }
+  tmpDirs.length = 0;
+});
+
+// ---------------------------------------------------------------------------
+// touchSession
+// ---------------------------------------------------------------------------
+
+describe("touchSession", () => {
+  test("updates lastRequestTime for a known session", () => {
+    const sessions = new Map<string, SessionState>();
+    const state = makeSessionState({ lastRequestTime: 0 });
+    sessions.set("s1", state);
+    touchSession(sessions, "s1");
+    expect(state.lastRequestTime).toBeGreaterThan(0);
+  });
+
+  test("is a no-op for an unknown session", () => {
+    const sessions = new Map<string, SessionState>();
+    expect(() => touchSession(sessions, "nope")).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildIdleWorkHandler
+// ---------------------------------------------------------------------------
+
+describe("buildIdleWorkHandler", () => {
+  test("runs local idle steps on an empty project without calling the LLM", async () => {
+    const llm = makeLLM();
+    const handler = buildIdleWorkHandler(llm);
+    const projectPath = makeProjectDir();
+    const state = makeSessionState({ projectPath, turnsSinceCuration: 0 });
+
+    await expect(handler("idle-empty", state)).resolves.toBeUndefined();
+    // No undistilled messages and no knowledge entries → all worker LLM
+    // steps (distillation/curation/consolidation) are skipped.
+    expect(llm.prompt).not.toHaveBeenCalled();
+  });
+
+  test("exports a knowledge file when the project has entries", async () => {
+    const llm = makeLLM();
+    const handler = buildIdleWorkHandler(llm);
+    const projectPath = makeProjectDir();
+    ltm.create({
+      projectPath,
+      category: "gotcha",
+      title: "Idle test entry",
+      content: "Some knowledge content for the idle export test.",
+      scope: "project",
+    });
+    const state = makeSessionState({ projectPath, turnsSinceCuration: 0 });
+
+    await handler("idle-export", state);
+
+    // Default config enables loreFile + agentsFile → writes AGENTS.md (+ .lore.md).
+    const files = readdirSync(projectPath);
+    expect(files.some((f) => f === "AGENTS.md" || f === ".lore.md")).toBe(true);
+  });
+
+  test("persists the session cost snapshot when conversation cost exists", async () => {
+    const llm = makeLLM();
+    const handler = buildIdleWorkHandler(llm);
+    const projectPath = makeProjectDir();
+    recordConversationCost("idle-cost", "__test_fake_model__", {
+      input_tokens: 1000,
+      output_tokens: 500,
+    });
+    const state = makeSessionState({
+      sessionID: "idle-cost",
+      projectPath,
+      turnsSinceCuration: 0,
+    });
+
+    await expect(handler("idle-cost", state)).resolves.toBeUndefined();
+
+    const persisted = loadSessionCosts("idle-cost");
+    expect(persisted).not.toBeNull();
+    expect(persisted?.conversationTurns).toBe(1);
+  });
+});

--- a/packages/gateway/test/recorder.test.ts
+++ b/packages/gateway/test/recorder.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Tests for the fixture recorder/replayer (`src/recorder.ts`).
+ *
+ * Recording mode: intercepts upstream calls, appends a `FixtureEntry` NDJSON
+ * line, and returns a reconstituted Response. Replay mode: serves stored
+ * fixtures in sequence without ever touching upstream.
+ */
+import { describe, test, expect, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  startRecording,
+  stopRecording,
+  getRecordedInterceptor,
+  getReplayInterceptor,
+  type FixtureEntry,
+} from "../src/recorder";
+
+let tmpDir: string | null = null;
+
+function makeFixturePath(): string {
+  tmpDir = mkdtempSync(join(tmpdir(), "lore-recorder-test-"));
+  return join(tmpDir, "fixtures.ndjson");
+}
+
+function readEntries(path: string): FixtureEntry[] {
+  return readFileSync(path, "utf8")
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line) as FixtureEntry);
+}
+
+/** Get the active recording interceptor, asserting it exists. */
+function activeInterceptor() {
+  const i = getRecordedInterceptor();
+  expect(i).not.toBeNull();
+  return i as NonNullable<typeof i>;
+}
+
+afterEach(() => {
+  stopRecording();
+  if (tmpDir) {
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      // best-effort cleanup
+    }
+    tmpDir = null;
+  }
+});
+
+describe("recorder — recording mode", () => {
+  test("getRecordedInterceptor returns null when not recording", () => {
+    stopRecording();
+    expect(getRecordedInterceptor()).toBeNull();
+  });
+
+  test("records a JSON upstream call and reconstitutes the response", async () => {
+    const path = makeFixturePath();
+    startRecording(path);
+    const interceptor = activeInterceptor();
+
+    const requestBody = {
+      model: "m",
+      messages: [{ role: "user", content: "hi" }],
+    };
+    const responseBody = { id: "resp_1", type: "message", content: [] };
+    let calls = 0;
+    const makeRealRequest = async () => {
+      calls++;
+      return new Response(JSON.stringify(responseBody), {
+        status: 200,
+        headers: { "content-type": "application/json", "x-custom": "v" },
+      });
+    };
+
+    const out = await interceptor(requestBody, "m", false, makeRealRequest);
+
+    // The real request is performed exactly once and the response is preserved.
+    expect(calls).toBe(1);
+    expect(out.status).toBe(200);
+    expect(out.headers.get("x-custom")).toBe("v");
+    expect(await out.json()).toEqual(responseBody);
+
+    // A single fixture entry is appended with parsed request/response.
+    const entries = readEntries(path);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].seq).toBe(0);
+    expect(entries[0].model).toBe("m");
+    expect(entries[0].wasStreaming).toBe(false);
+    expect(entries[0].request).toEqual(requestBody);
+    expect(entries[0].response).toEqual(responseBody);
+    expect(typeof entries[0].ts).toBe("number");
+  });
+
+  test("increments the sequence counter across calls", async () => {
+    const path = makeFixturePath();
+    startRecording(path);
+    const interceptor = activeInterceptor();
+    const thunk = (b: unknown) => async () =>
+      new Response(JSON.stringify(b), { status: 200 });
+
+    await interceptor({ q: 1 }, "m", true, thunk({ a: 1 }));
+    await interceptor({ q: 2 }, "m", false, thunk({ a: 2 }));
+
+    const entries = readEntries(path);
+    expect(entries).toHaveLength(2);
+    expect(entries[0].seq).toBe(0);
+    expect(entries[0].wasStreaming).toBe(true);
+    expect(entries[1].seq).toBe(1);
+    expect(entries[1].wasStreaming).toBe(false);
+  });
+
+  test("stores a non-JSON upstream body as a raw string", async () => {
+    const path = makeFixturePath();
+    startRecording(path);
+    const interceptor = activeInterceptor();
+    const raw = "event: message\ndata: not-json\n\n";
+
+    const out = await interceptor(
+      {},
+      "m",
+      true,
+      async () => new Response(raw, { status: 200 }),
+    );
+
+    expect(await out.text()).toBe(raw);
+    expect(readEntries(path)[0].response).toBe(raw);
+  });
+
+  test("startRecording resets the sequence counter", async () => {
+    const path = makeFixturePath();
+    startRecording(path);
+    const i1 = activeInterceptor();
+    await i1({}, "m", false, async () => new Response("{}", { status: 200 }));
+
+    // Restart recording — counter should reset to 0.
+    startRecording(path);
+    const i2 = activeInterceptor();
+    await i2({}, "m", false, async () => new Response("{}", { status: 200 }));
+
+    const entries = readEntries(path);
+    expect(entries).toHaveLength(2);
+    expect(entries[0].seq).toBe(0);
+    expect(entries[1].seq).toBe(0);
+  });
+
+  test("stopRecording disables the interceptor", () => {
+    startRecording(makeFixturePath());
+    expect(getRecordedInterceptor()).not.toBeNull();
+    stopRecording();
+    expect(getRecordedInterceptor()).toBeNull();
+  });
+});
+
+describe("recorder — replay mode", () => {
+  const fixtures: FixtureEntry[] = [
+    {
+      seq: 0,
+      ts: 1,
+      request: { a: 1 },
+      response: { id: "r0" },
+      wasStreaming: false,
+      model: "m0",
+    },
+    {
+      seq: 1,
+      ts: 2,
+      request: { a: 2 },
+      response: { id: "r1" },
+      wasStreaming: true,
+      model: "m1",
+    },
+  ];
+
+  test("replays fixtures in sequence without calling makeRealRequest", async () => {
+    const interceptor = getReplayInterceptor(fixtures);
+    const throwThunk = async (): Promise<Response> => {
+      throw new Error("upstream should not be called during replay");
+    };
+
+    const r0 = await interceptor({}, "m", false, throwThunk);
+    expect(r0.status).toBe(200);
+    expect(r0.headers.get("content-type")).toBe("application/json");
+    expect(await r0.json()).toEqual({ id: "r0" });
+
+    const r1 = await interceptor({}, "m", false, throwThunk);
+    expect(await r1.json()).toEqual({ id: "r1" });
+  });
+
+  test("throws when fixtures are exhausted", async () => {
+    const interceptor = getReplayInterceptor([fixtures[0]]);
+    await interceptor({}, "m", false, async () => new Response("{}"));
+    await expect(
+      interceptor({}, "m", false, async () => new Response("{}")),
+    ).rejects.toThrow(/Replay exhausted/);
+  });
+});

--- a/packages/gateway/test/stream-anthropic.test.ts
+++ b/packages/gateway/test/stream-anthropic.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Tests for the pure Anthropic SSE helpers in `src/stream/anthropic.ts`:
+ * formatSSEEvent, parseSSEStream, createStreamAccumulator,
+ * buildSSEMessageStart, buildSSETextResponse, accumulateSSEResponse.
+ *
+ * (buildKeepaliveCompactionStream and createRecallAwareAccumulator are
+ * covered by keepalive-compaction.test.ts / recall-stream.test.ts.)
+ */
+import { describe, test, expect } from "vitest";
+import {
+  formatSSEEvent,
+  parseSSEStream,
+  createStreamAccumulator,
+  buildSSEMessageStart,
+  buildSSETextResponse,
+  accumulateSSEResponse,
+} from "../src/stream/anthropic";
+import type { GatewayResponse } from "../src/translate/types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function readerFromChunks(
+  chunks: string[],
+): ReadableStreamDefaultReader<Uint8Array> {
+  const enc = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const c of chunks) controller.enqueue(enc.encode(c));
+      controller.close();
+    },
+  });
+  return stream.getReader();
+}
+
+async function collect(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): Promise<{ event: string; data: string }[]> {
+  const out: { event: string; data: string }[] = [];
+  for await (const ev of parseSSEStream(reader)) out.push(ev);
+  return out;
+}
+
+/** Parse the JSON payload out of a single `event: <t>\ndata: <json>\n\n` block. */
+function parseEventData(
+  sse: string,
+  eventType: string,
+): Record<string, unknown> {
+  const prefix = `event: ${eventType}\ndata: `;
+  const idx = sse.indexOf(prefix);
+  if (idx === -1) throw new Error(`event ${eventType} not found in: ${sse}`);
+  const rest = sse.slice(idx + prefix.length);
+  const end = rest.indexOf("\n\n");
+  return JSON.parse(rest.slice(0, end === -1 ? undefined : end));
+}
+
+// ---------------------------------------------------------------------------
+// formatSSEEvent
+// ---------------------------------------------------------------------------
+
+describe("formatSSEEvent", () => {
+  test("formats a named SSE event", () => {
+    expect(formatSSEEvent("ping", "{}")).toBe("event: ping\ndata: {}\n\n");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseSSEStream
+// ---------------------------------------------------------------------------
+
+describe("parseSSEStream", () => {
+  test("parses named events, multi-data lines, comments, and the default event", async () => {
+    const sse =
+      'event: message_start\ndata: {"a":1}\n\n' +
+      // No `event:` line → default "message"; comment line ignored; data joined.
+      ": this is a comment\ndata: line1\ndata: line2\n\n" +
+      "event: message_stop\ndata: {}\n\n";
+
+    const events = await collect(readerFromChunks([sse]));
+    expect(events).toEqual([
+      { event: "message_start", data: '{"a":1}' },
+      { event: "message", data: "line1\nline2" },
+      { event: "message_stop", data: "{}" },
+    ]);
+  });
+
+  test("handles events split across chunk boundaries", async () => {
+    const events = await collect(
+      readerFromChunks(["event: message_start\nda", 'ta: {"x":1}\n\n']),
+    );
+    expect(events).toEqual([{ event: "message_start", data: '{"x":1}' }]);
+  });
+
+  test("flushes a trailing block that lacks a final blank line", async () => {
+    const events = await collect(
+      readerFromChunks(["event: message_stop\ndata: {}"]),
+    );
+    expect(events).toEqual([{ event: "message_stop", data: "{}" }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createStreamAccumulator
+// ---------------------------------------------------------------------------
+
+describe("createStreamAccumulator", () => {
+  test("accumulates a text response across the full lifecycle", () => {
+    const acc = createStreamAccumulator();
+    expect(acc.isDone()).toBe(false);
+
+    acc.processEvent(
+      "message_start",
+      JSON.stringify({
+        type: "message_start",
+        message: {
+          id: "msg_1",
+          model: "claude-x",
+          usage: { input_tokens: 10, output_tokens: 1 },
+        },
+      }),
+    );
+    acc.processEvent(
+      "content_block_start",
+      JSON.stringify({ index: 0, content_block: { type: "text", text: "" } }),
+    );
+    acc.processEvent(
+      "content_block_delta",
+      JSON.stringify({
+        index: 0,
+        delta: { type: "text_delta", text: "Hello" },
+      }),
+    );
+    acc.processEvent(
+      "content_block_delta",
+      JSON.stringify({
+        index: 0,
+        delta: { type: "text_delta", text: " world" },
+      }),
+    );
+    acc.processEvent("content_block_stop", JSON.stringify({ index: 0 }));
+    acc.processEvent(
+      "message_delta",
+      JSON.stringify({
+        delta: { stop_reason: "end_turn" },
+        usage: { output_tokens: 5 },
+      }),
+    );
+    const forwarded = acc.processEvent(
+      "message_stop",
+      JSON.stringify({ type: "message_stop" }),
+    );
+
+    expect(forwarded).toBe(
+      'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+    );
+    expect(acc.isDone()).toBe(true);
+
+    const resp = acc.getResponse();
+    expect(resp.id).toBe("msg_1");
+    expect(resp.model).toBe("claude-x");
+    expect(resp.stopReason).toBe("end_turn");
+    expect(resp.content).toEqual([{ type: "text", text: "Hello world" }]);
+    expect(resp.usage?.inputTokens).toBe(10);
+    expect(resp.usage?.outputTokens).toBe(5);
+  });
+
+  test("accumulates a tool_use block with parsed input JSON", () => {
+    const acc = createStreamAccumulator();
+    acc.processEvent(
+      "message_start",
+      JSON.stringify({
+        message: {
+          id: "m",
+          model: "x",
+          usage: { input_tokens: 1, output_tokens: 1 },
+        },
+      }),
+    );
+    acc.processEvent(
+      "content_block_start",
+      JSON.stringify({
+        index: 0,
+        content_block: { type: "tool_use", id: "tool_1", name: "bash" },
+      }),
+    );
+    acc.processEvent(
+      "content_block_delta",
+      JSON.stringify({
+        index: 0,
+        delta: { type: "input_json_delta", partial_json: '{"cmd":' },
+      }),
+    );
+    acc.processEvent(
+      "content_block_delta",
+      JSON.stringify({
+        index: 0,
+        delta: { type: "input_json_delta", partial_json: '"ls"}' },
+      }),
+    );
+    acc.processEvent("content_block_stop", JSON.stringify({ index: 0 }));
+
+    const resp = acc.getResponse();
+    expect(resp.content).toEqual([
+      { type: "tool_use", id: "tool_1", name: "bash", input: { cmd: "ls" } },
+    ]);
+  });
+
+  test("forwards events with invalid JSON verbatim", () => {
+    const acc = createStreamAccumulator();
+    expect(acc.processEvent("ping", "not json")).toBe(
+      "event: ping\ndata: not json\n\n",
+    );
+  });
+
+  test("scaleClientUsage scales forwarded usage but not internal accumulation", () => {
+    const acc = createStreamAccumulator({ scaleClientUsage: true });
+    const bigInput = 10_000_000;
+    const forwarded = acc.processEvent(
+      "message_start",
+      JSON.stringify({
+        type: "message_start",
+        message: {
+          id: "m",
+          model: "x",
+          usage: { input_tokens: bigInput, output_tokens: 1 },
+        },
+      }),
+    );
+
+    // Forwarded (client-facing) usage is scaled down below the real value.
+    const data = parseEventData(forwarded, "message_start");
+    const msg = data.message as { usage: { input_tokens: number } };
+    expect(msg.usage.input_tokens).toBeLessThan(bigInput);
+
+    // Internal accumulation keeps the real (unscaled) token count.
+    expect(acc.getResponse().usage?.inputTokens).toBe(bigInput);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildSSEMessageStart
+// ---------------------------------------------------------------------------
+
+describe("buildSSEMessageStart", () => {
+  test("emits message_start with usage; output_tokens is forced to 1", () => {
+    const resp: GatewayResponse = {
+      id: "m",
+      model: "x",
+      content: [],
+      stopReason: "end_turn",
+      usage: {
+        inputTokens: 100,
+        outputTokens: 50,
+        cacheReadInputTokens: 10,
+        cacheCreationInputTokens: 20,
+      },
+    };
+    const sse = buildSSEMessageStart(resp);
+    expect(sse.startsWith("event: message_start\ndata: ")).toBe(true);
+
+    const parsed = parseEventData(sse, "message_start");
+    const message = parsed.message as { usage: Record<string, number> };
+    expect(parsed.type).toBe("message_start");
+    expect(message.usage.input_tokens).toBe(100);
+    expect(message.usage.output_tokens).toBe(1);
+    expect(message.usage.cache_read_input_tokens).toBe(10);
+    expect(message.usage.cache_creation_input_tokens).toBe(20);
+  });
+
+  test("omits cache fields when absent from usage", () => {
+    const resp: GatewayResponse = {
+      id: "m",
+      model: "x",
+      content: [],
+      stopReason: "end_turn",
+      usage: { inputTokens: 100, outputTokens: 50 },
+    };
+    const message = parseEventData(buildSSEMessageStart(resp), "message_start")
+      .message as { usage: Record<string, number> };
+    expect("cache_read_input_tokens" in message.usage).toBe(false);
+    expect("cache_creation_input_tokens" in message.usage).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildSSETextResponse + accumulateSSEResponse (round trip)
+// ---------------------------------------------------------------------------
+
+describe("buildSSETextResponse", () => {
+  test("emits the full Anthropic lifecycle in order", () => {
+    const sse = buildSSETextResponse("id_1", "claude-x", "Hi there", {
+      inputTokens: 7,
+      outputTokens: 3,
+    });
+
+    const order = [
+      "message_start",
+      "content_block_start",
+      "content_block_delta",
+      "content_block_stop",
+      "message_delta",
+      "message_stop",
+    ];
+    let prev = -1;
+    for (const ev of order) {
+      const at = sse.indexOf(`event: ${ev}\n`);
+      expect(at).toBeGreaterThan(prev);
+      prev = at;
+    }
+    expect(sse).toContain('"text":"Hi there"');
+    expect(sse).toContain('"output_tokens":3');
+  });
+});
+
+describe("accumulateSSEResponse", () => {
+  test("round-trips a synthetic text response back into a GatewayResponse", async () => {
+    const sse = buildSSETextResponse("id_1", "claude-x", "Round trip", {
+      inputTokens: 7,
+      outputTokens: 3,
+    });
+    const resp = await accumulateSSEResponse(new Response(sse));
+    expect(resp.id).toBe("id_1");
+    expect(resp.model).toBe("claude-x");
+    expect(resp.content).toEqual([{ type: "text", text: "Round trip" }]);
+    expect(resp.stopReason).toBe("end_turn");
+    expect(resp.usage?.inputTokens).toBe(7);
+    expect(resp.usage?.outputTokens).toBe(3);
+  });
+});


### PR DESCRIPTION
## What

First pass at #690 — raising `@loreai/gateway` test coverage. Per the issue's "prioritize runtime logic" guidance and the agreed scope, this PR focuses on **high-value gateway files with little/no dedicated coverage**. Tests only — **no source changes, no `codecov.yml` changes**.

## New test files (883 lines, 38 tests)

| File | Target | Lines: before → after |
|---|---|---|
| `test/recorder.test.ts` | `src/recorder.ts` | 26.7% → **100%** |
| `test/cost-tracker-accumulation.test.ts` | `src/cost-tracker.ts` | 56.4% → **63.1%** |
| `test/idle-work.test.ts` | `src/idle.ts` | 26.6% → **51.0%** |
| `test/stream-anthropic.test.ts` | `src/stream/anthropic.ts` | 70.9% → **84.5%** |

### Coverage detail
- **`recorder.ts`** — record interceptor (NDJSON write, body reconstitution, seq counter, non-JSON fallback) and replay interceptor (sequencing + exhaustion error). Now 100% lines/branches/functions.
- **`cost-tracker.ts`** — in-memory accumulators (`recordConversationCost`, `recordWorkerCost` bucket mapping + batch savings, `recordWarmupCost`, `recordWarmupHit`, `recordTTLSavings`), totals (`totalActualCost` / `totalWorkerCost` / `totalSavings` / `costWithoutLore`), and query/lifecycle helpers. (DB-backed `computeHistoricalEstimates` / `computeDailyCosts` deferred — they need DB seeding.)
- **`idle.ts`** — `touchSession` plus `buildIdleWorkHandler` local steps (pruning, knowledge export, dead-ref cleanup, lat refresh, cost persistence) and skip guards. The LLM-calling branches (distillation/curation/consolidation) are intentionally not driven here — they couple to core worker internals + the batch queue; on an empty DB they are correctly skipped.
- **`stream/anthropic.ts`** — `formatSSEEvent`, `parseSSEStream` (chunk-split + trailing flush), `createStreamAccumulator` (text / tool_use / invalid-JSON / usage scaling), `buildSSEMessageStart`, `buildSSETextResponse`, and `accumulateSSEResponse` round-trip.

## Out of scope (follow-ups)
- `@loreai/opencode` coverage (incl. exporting internal helpers for direct unit tests).
- Remaining gateway files (`pipeline.ts`, `server.ts`, `llm-adapter.ts`, other stream/translate adapters).
- Codecov `component_management` / flags.

## Verification
- `pnpm test` — full suite green (97 files, 2557 passed, 6 skipped).
- `pnpm run typecheck` — zero errors.
- `biome check` — clean (no warnings on new files).
- `pnpm run test:coverage` — confirms the per-file jumps above.

Refs #690