### PR TITLE
test(entities): fix flaky containment survivor assertion (timestamp tiebreaker, not collation)

### DIFF
--- a/packages/core/test/entity-dedup.test.ts
+++ b/packages/core/test/entity-dedup.test.ts
@@ -211,6 +211,15 @@ describe("entity dedup — deduplicateEntities()", () => {
     // must only suggest (the user confirms), never auto-merge.
     const a = makeEntity({ name: "Seylan" });
     const b = makeEntity({ name: "Seylan Çinar Kaya" });
+    // Pin equal timestamps so the survivor tiebreaker is deterministic across
+    // platforms. The survivor *direction* is timing-dependent (most aliases →
+    // most recent → shortest name) and is NOT what this test asserts — only
+    // that the pair is suggested, not merged. (Without this, both creates can
+    // land in the same millisecond on fast CI, flipping the survivor to the
+    // shorter "Seylan" — the flake that failed on main.)
+    db()
+      .query("UPDATE entities SET updated_at = 1000 WHERE id IN (?, ?)")
+      .run(a, b);
     const r = await entities.deduplicateEntities(PROJECT, { dryRun: true });
     expect(r.merged).toHaveLength(0);
     expect(r.suggested).toHaveLength(1);
@@ -220,8 +229,12 @@ describe("entity dedup — deduplicateEntities()", () => {
       ...cluster.merged.map((m) => m.id),
     ].sort();
     expect(ids).toEqual([a, b].sort());
-    // The full name is kept as the survivor.
-    expect(cluster.surviving.name).toBe("Seylan Çinar Kaya");
+    // Both names are represented in the cluster (survivor direction not asserted).
+    const names = [
+      cluster.surviving.name,
+      ...cluster.merged.map((m) => m.name),
+    ].sort();
+    expect(names).toEqual(["Seylan", "Seylan Çinar Kaya"].sort());
   });
 
   test("multi-token prefix ⊂ full name is suggested", async () => {


### PR DESCRIPTION
## Problem
The `name containment ('Seylan' ⊂ 'Seylan Çinar Kaya') is SUGGESTED, not merged` test (added in #692) **fails on CI** (e.g. run [27315675602](https://github.com/BYK/loreai/actions/runs/27315675602)) while passing locally:

```
AssertionError: expected 'Seylan' to be 'Seylan Çinar Kaya'
  at entity-dedup.test.ts:224  →  expect(cluster.surviving.name).toBe("Seylan Çinar Kaya")
```

## Root cause — **not** locale/collation
The dedup survivor is chosen by `most aliases → most recent (updated_at) → shortest name` (`entities.ts`). Both test entities have **0 aliases**, so it falls to `updated_at`. Locally the two `create()` calls land in **different** milliseconds → "Seylan Çinar Kaya" wins on recency. On fast CI they land in the **same** millisecond → `updated_at` ties → the final tiebreaker (**shortest name**, numeric `.length`) picks `"Seylan"`.

No Turkish `Ç` / collation is involved — the tiebreaker is `a.canonical_name.length - b.canonical_name.length`, and the cluster ordering is by numeric neighbor-count. The assertion was checking the survivor *direction*, which is timing-dependent and **not** what the test verifies (suggest-vs-merge).

## Fix
- Pin both entities to an equal `updated_at` so the tiebreaker is deterministic across platforms (this also **reproduces the CI condition** locally).
- Drop the brittle `surviving.name` assertion; instead assert both names are present in the cluster (survivor direction not asserted) plus the existing `merged: 0` / `suggested: 1` / id-set checks.

The product behaviour is unchanged — containment still only ever *suggests*; which side is labelled "surviving" in a suggestion is cosmetic (the user picks the merge direction anyway).

## Test plan
- `pnpm test` — 2596 passed / 6 skipped (95 files); the containment test now deterministically exercises the equal-timestamp (CI) path.
- `pnpm run typecheck` / `pnpm run lint` — clean.