### PR TITLE
fix(gateway): redirect root path instead of 500; backfill server + llm-adapter tests

### DIFF
--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -414,9 +414,17 @@ export async function startServer(config: GatewayConfig): Promise<{
         return withCors(await Promise.race([uiPromise, timeoutPromise]));
       }
 
-      // GET / — redirect to dashboard
+      // GET / — redirect to dashboard. Build the redirect manually instead of
+      // via Response.redirect(), whose headers are immutable: withCors() would
+      // throw "immutable" while adding CORS headers and the root path would 500
+      // instead of redirecting.
       if (method === "GET" && pathname === "/") {
-        return withCors(Response.redirect(new URL("/ui", url), 302));
+        return withCors(
+          new Response(null, {
+            status: 302,
+            headers: { location: new URL("/ui", url).toString() },
+          }),
+        );
       }
 
       // 404 for everything else

--- a/packages/gateway/test/llm-adapter.test.ts
+++ b/packages/gateway/test/llm-adapter.test.ts
@@ -19,6 +19,7 @@ import {
   resetBackgroundLimiter,
 } from "../src/background-limiter";
 import { upstreamFetch } from "../src/fetch";
+import { clearAllCosts, getSessionCosts } from "../src/cost-tracker";
 
 // ---------------------------------------------------------------------------
 // maxRetriesFor — unified policy (modeled on Claude Code's single budget)
@@ -350,5 +351,132 @@ describe("worker 429 trips the circuit breaker (urgent included)", () => {
     expect(result).toBeNull();
     expect(mockFetch).toHaveBeenCalledTimes(4); // maxRetries(3) + 1
     expect(getConsecutiveTrips()).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createGatewayLLMClient.prompt() — request building, success, and guards
+// ---------------------------------------------------------------------------
+
+describe("createGatewayLLMClient.prompt", () => {
+  const mockFetch = vi.mocked(upstreamFetch);
+
+  const UPSTREAMS = {
+    anthropic: "https://api.anthropic.com",
+    openai: "https://api.openai.com",
+  };
+
+  afterEach(() => {
+    mockFetch.mockReset();
+    clearAllCosts();
+    resetBackgroundLimiter();
+  });
+
+  function anthropicResponse() {
+    return new Response(
+      JSON.stringify({
+        content: [{ type: "text", text: "hello from worker" }],
+        model: "claude-test",
+        usage: { input_tokens: 10, output_tokens: 5 },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  }
+
+  test("Anthropic success returns text and records worker cost", async () => {
+    mockFetch.mockResolvedValue(anthropicResponse());
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "sk-ant-test" }),
+      { providerID: "anthropic", modelID: "claude-test" },
+    );
+
+    const text = await client.prompt("system", "user", {
+      sessionID: "sess-1",
+      workerID: "lore-distill",
+    });
+
+    expect(text).toBe("hello from worker");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    // Anthropic Messages endpoint + usage recorded into the distillation bucket.
+    expect(mockFetch.mock.calls[0][0]).toContain("/v1/messages");
+    expect(getSessionCosts("sess-1")?.workers.distillation.calls).toBe(1);
+  });
+
+  test("OpenAI success returns text via the chat-completions endpoint", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          choices: [{ message: { content: "hi from openai" } }],
+          model: "gpt-test",
+          usage: { prompt_tokens: 8, completion_tokens: 4 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "sk-openai-test" }),
+      { providerID: "openai", modelID: "gpt-test" },
+    );
+
+    const text = await client.prompt("system", "user", {
+      workerID: "lore-curator",
+    });
+
+    expect(text).toBe("hi from openai");
+    expect(mockFetch.mock.calls[0][0]).toContain("/chat/completions");
+  });
+
+  test("returns null without calling upstream when no auth is available", async () => {
+    const client = createGatewayLLMClient(UPSTREAMS, () => null, {
+      providerID: "anthropic",
+      modelID: "claude-test",
+    });
+
+    const text = await client.prompt("system", "user", {
+      workerID: "lore-distill",
+    });
+
+    expect(text).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  test("skips the request on a provider/key protocol mismatch", async () => {
+    // Anthropic target but an OpenAI-style key → mismatch guard returns null
+    // before any upstream call.
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "sk-openai-not-anthropic" }),
+      { providerID: "anthropic", modelID: "claude-test" },
+    );
+
+    const text = await client.prompt("system", "user", {
+      workerID: "lore-distill",
+    });
+
+    expect(text).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  test("returns null on a 401 auth error (no credential change)", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ error: { message: "unauthorized" } }), {
+        status: 401,
+      }),
+    );
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "sk-ant-test" }),
+      { providerID: "anthropic", modelID: "claude-test" },
+    );
+
+    // No sessionID → markAuthStale is skipped; static cred → no retry.
+    const text = await client.prompt("system", "user", {
+      workerID: "lore-distill",
+    });
+
+    expect(text).toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/gateway/test/server.test.ts
+++ b/packages/gateway/test/server.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Route-level tests for `src/server.ts`.
+ *
+ * Starts a real gateway server (via `startServer`) on a random port and
+ * exercises the pre-pipeline routes + error paths that the replay
+ * integration tests (replay.test.ts) don't reach: CORS preflight, health,
+ * 404, invalid-JSON 400 on each protocol endpoint, the /v1/models passthrough
+ * 502 path (unreachable upstream), the `/` redirect, and the empty-hosts
+ * defensive default.
+ *
+ * The upstream is pointed at a refused port so /v1/models fails fast (502)
+ * without real network access; the other routes never reach the pipeline.
+ */
+import { describe, test, expect, beforeAll, afterAll } from "vitest";
+import { connect } from "node:net";
+import { startServer } from "../src/server";
+import { loadConfig } from "../src/config";
+import type { GatewayConfig } from "../src/config";
+
+type ServerHandle = Awaited<ReturnType<typeof startServer>>;
+
+function makeConfig(overrides?: Partial<GatewayConfig>): GatewayConfig {
+  return {
+    ...loadConfig(),
+    port: 0,
+    hosts: ["127.0.0.1"],
+    debug: false,
+    // Refused port → upstreamFetch fails fast so /v1/models returns 502.
+    upstreamAnthropic: "http://127.0.0.1:9",
+    ...overrides,
+  };
+}
+
+let server: ServerHandle;
+let baseURL: string;
+
+beforeAll(async () => {
+  server = await startServer(makeConfig());
+  baseURL = `http://127.0.0.1:${server.port}`;
+});
+
+afterAll(() => {
+  server.stop();
+});
+
+describe("server routing", () => {
+  test("OPTIONS preflight returns 204 with permissive CORS headers", async () => {
+    const res = await fetch(`${baseURL}/v1/messages`, { method: "OPTIONS" });
+    expect(res.status).toBe(204);
+    expect(res.headers.get("access-control-allow-origin")).toBe("*");
+    expect(res.headers.get("access-control-allow-methods")).toContain("POST");
+  });
+
+  test("GET /health returns ok + version with CORS", async () => {
+    const res = await fetch(`${baseURL}/health`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { status: string; version: string };
+    expect(body.status).toBe("ok");
+    expect(typeof body.version).toBe("string");
+    expect(res.headers.get("access-control-allow-origin")).toBe("*");
+  });
+
+  test("unknown route returns a 404 error envelope", async () => {
+    const res = await fetch(`${baseURL}/definitely-not-a-route`);
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as {
+      type: string;
+      error: { type: string };
+    };
+    expect(body.type).toBe("error");
+    expect(body.error.type).toBe("not_found");
+  });
+
+  test.each([
+    "/v1/messages",
+    "/v1/chat/completions",
+    "/v1/responses",
+  ])("POST %s with invalid JSON returns 400", async (path) => {
+    const res = await fetch(`${baseURL}${path}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{ this is not valid json",
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as {
+      error: { type: string; message: string };
+    };
+    expect(body.error.type).toBe("invalid_request_error");
+    expect(body.error.message).toBe("Invalid JSON body");
+  });
+
+  test("GET /v1/models returns 502 when the upstream is unreachable", async () => {
+    const res = await fetch(`${baseURL}/v1/models`);
+    expect(res.status).toBe(502);
+    const body = (await res.json()) as { error: { type: string } };
+    expect(body.error.type).toBe("api_error");
+  });
+
+  test("rejects a raw WebSocket upgrade with 426 at the socket level", async () => {
+    // node:http dispatches Upgrade requests via a separate 'upgrade' event,
+    // bypassing the fetch handler. undici's fetch refuses to parse a non-101
+    // upgrade response, so use a raw TCP socket to exercise the dedicated
+    // upgrade listener (server.ts) and read the raw 426 it writes.
+    const raw = await new Promise<string>((resolve, reject) => {
+      const socket = connect(server.port, "127.0.0.1", () => {
+        socket.write(
+          "GET /v1/responses HTTP/1.1\r\n" +
+            `Host: 127.0.0.1:${server.port}\r\n` +
+            "Upgrade: websocket\r\n" +
+            "Connection: Upgrade\r\n" +
+            "Sec-WebSocket-Version: 13\r\n" +
+            "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+            "\r\n",
+        );
+      });
+      let data = "";
+      socket.on("data", (chunk) => {
+        data += chunk.toString();
+      });
+      socket.on("close", () => resolve(data));
+      socket.on("error", reject);
+      setTimeout(() => {
+        socket.destroy();
+        resolve(data);
+      }, 2000);
+    });
+    expect(raw).toContain("426 Upgrade Required");
+    expect(raw).toContain("websocket_not_supported");
+  });
+
+  test("GET / redirects toward the dashboard (not a 500)", async () => {
+    const res = await fetch(`${baseURL}/`, { redirect: "manual" });
+    // undici surfaces a manual redirect as an opaqueredirect (status 0); a
+    // real 3xx is also acceptable. Regression guard: Response.redirect()'s
+    // headers are immutable, so withCors() used to throw "immutable" and the
+    // root path 500'd instead of redirecting.
+    expect(res.status).not.toBe(500);
+    expect([0, 301, 302, 307, 308]).toContain(res.status);
+  });
+});
+
+describe("startServer configuration", () => {
+  test("defaults empty hosts to 127.0.0.1 and still serves", async () => {
+    const s = await startServer(makeConfig({ hosts: [] }));
+    try {
+      expect(s.hosts).toEqual(["127.0.0.1"]);
+      const res = await fetch(`http://127.0.0.1:${s.port}/health`);
+      expect(res.status).toBe(200);
+    } finally {
+      s.stop();
+    }
+  });
+
+  test("debug mode serves requests (covers debug logging branch)", async () => {
+    const s = await startServer(makeConfig({ debug: true }));
+    try {
+      const res = await fetch(`http://127.0.0.1:${s.port}/health`);
+      expect(res.status).toBe(200);
+    } finally {
+      s.stop();
+    }
+  });
+});


### PR DESCRIPTION
## What

Continues #690 (raising `@loreai/gateway` coverage), targeting two more "core runtime logic" files. While adding route-level tests for `server.ts`, a new test **caught a real bug**, which this PR also fixes.

## Bug fix: `GET /` returned 500 instead of redirecting

`GET /` is meant to 302-redirect to `/ui`, but it returned **500** (`[lore] uncaught error: immutable`). `Response.redirect()` yields a response with **immutable** headers, so `withCors()` threw a `TypeError` while adding CORS headers, which the outer handler mapped to 500. Fixed by building the redirect response manually (mutable headers) so `withCors()` works.

## Coverage added

| File | Lines: before → after |
|---|---|
| `src/server.ts` | 52.9% → **65.8%** |
| `src/llm-adapter.ts` | 57.3% → **75.3%** |

### `test/server.test.ts` (new, 12 tests)
Starts a real server via `startServer()` and exercises the pre-pipeline routes + error paths the replay integration tests don't reach:
- CORS preflight (`OPTIONS` → 204), `GET /health`, unknown route → 404 envelope
- Invalid-JSON → 400 on `/v1/messages`, `/v1/chat/completions`, `/v1/responses`
- `GET /v1/models` → 502 when upstream unreachable
- Raw-socket `node:net` WebSocket upgrade → 426 (the dedicated `'upgrade'` listener `fetch` can't reach)
- `GET /` redirect regression guard (the bug above)
- `startServer` empty-hosts defensive default

### `test/llm-adapter.test.ts` (extended, +5 tests)
Covers the previously-untested `prompt()` closure (the bulk of the file's gap), driven by the existing `vi.mock("../src/fetch")`:
- Anthropic success → returns text + records worker cost (correct endpoint + bucket)
- OpenAI success → returns text via `/chat/completions`
- No-auth → returns null without calling upstream
- Provider/key protocol mismatch → skips the request
- 401 auth error (no credential change) → returns null

## Verification
- `pnpm test` — full suite green (101 files, 2652 passed, 6 skipped).
- `pnpm run typecheck` — zero errors; `biome check` — clean.
- `pnpm run test:coverage` — confirms the per-file jumps above.

## Follow-ups (still open from #690)
`pipeline.ts`, `cache-warmer.ts` (executeWarmup/persistence), `sentry.ts`, `api.ts`, and `@loreai/opencode`.

Refs #690