### PR TITLE
test(gateway): cover pipeline /lore:* slash commands and /v1/compact validation

### DIFF
--- a/packages/gateway/test/compact-endpoint.test.ts
+++ b/packages/gateway/test/compact-endpoint.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Coverage for the explicit compaction endpoints (`POST /v1/compact`, used by
+ * the Pi plugin). Focuses on the request-validation + no-session branches of
+ * handleCompactEndpoint, which return deterministic responses without any
+ * upstream call.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import type { Harness } from "./helpers/harness";
+import { createHarness } from "./helpers/harness";
+
+async function postCompact(baseURL: string, body: string): Promise<Response> {
+  return fetch(`${baseURL}/v1/compact`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body,
+  });
+}
+
+describe("POST /v1/compact", () => {
+  let harness: Harness;
+
+  afterEach(() => harness?.teardown());
+
+  it("returns 400 on invalid JSON", async () => {
+    harness = await createHarness({ fixtures: [] });
+    const resp = await postCompact(harness.baseURL, "{ not json");
+    expect(resp.status).toBe(400);
+    const body = (await resp.json()) as { error: string; message: string };
+    expect(body.error).toBe("invalid_request");
+    expect(body.message).toBe("Invalid JSON body");
+  });
+
+  it("returns 400 when project_path is missing", async () => {
+    harness = await createHarness({ fixtures: [] });
+    const resp = await postCompact(harness.baseURL, JSON.stringify({}));
+    expect(resp.status).toBe(400);
+    const body = (await resp.json()) as { error: string; message: string };
+    expect(body.error).toBe("invalid_request");
+    expect(body.message).toContain("project_path is required");
+  });
+
+  it("returns 404 when no active session exists for the project", async () => {
+    harness = await createHarness({ fixtures: [] });
+    const resp = await postCompact(
+      harness.baseURL,
+      JSON.stringify({ project_path: process.cwd() }),
+    );
+    expect(resp.status).toBe(404);
+    const body = (await resp.json()) as { error: string; message: string };
+    expect(body.error).toBe("session_not_found");
+    expect(body.message).toContain("No active session found");
+  });
+});

--- a/packages/gateway/test/pipeline-slash.test.ts
+++ b/packages/gateway/test/pipeline-slash.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Pipeline `/lore:*` slash-command coverage.
+ *
+ * Slash commands are intercepted in handleRequest (Case 0) and answered with
+ * a synthetic response — no upstream call — so these run against the harness
+ * with empty fixtures. This exercises the slash dispatcher + per-command
+ * handlers + the synthetic-response builders (slashResponse →
+ * nonStreamHttpResponse / streamHttpResponse), including the streaming SSE
+ * wire path that the replay harness can't drive for normal turns.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import type { Harness } from "./helpers/harness";
+import { createHarness } from "./helpers/harness";
+import { DEFAULT_MODEL } from "./helpers/fixtures";
+
+function slashBody(command: string, stream = false): Record<string, unknown> {
+  return {
+    model: DEFAULT_MODEL,
+    max_tokens: 256,
+    stream,
+    messages: [{ role: "user", content: command }],
+  };
+}
+
+async function textOf(resp: Response): Promise<string> {
+  const body = (await resp.json()) as {
+    content: Array<{ type: string; text?: string }>;
+  };
+  return body.content
+    .filter((b) => b.type === "text")
+    .map((b) => b.text ?? "")
+    .join("");
+}
+
+describe("Pipeline — /lore:* slash commands", () => {
+  let harness: Harness;
+
+  afterEach(() => harness?.teardown());
+
+  it("intercepts /lore:amnesia:on and :off without forwarding upstream", async () => {
+    harness = await createHarness({ fixtures: [] });
+
+    const on = await harness.chat(slashBody("/lore:amnesia:on"));
+    expect(on.status).toBe(200);
+    expect(await textOf(on)).toContain("Amnesia mode on");
+
+    const off = await harness.chat(slashBody("/lore:amnesia:off"));
+    expect(off.status).toBe(200);
+    expect(await textOf(off)).toContain("Amnesia mode off");
+  });
+
+  it("handles /lore:warm:stop|keep|auto", async () => {
+    harness = await createHarness({ fixtures: [] });
+
+    expect(
+      await textOf(await harness.chat(slashBody("/lore:warm:stop"))),
+    ).toContain("Cache warming stopped");
+    expect(
+      await textOf(await harness.chat(slashBody("/lore:warm:keep"))),
+    ).toContain("Keeping cache warm");
+    expect(
+      await textOf(await harness.chat(slashBody("/lore:warm:auto"))),
+    ).toContain("Cache warming set to auto");
+  });
+
+  it("returns a helpful error for an unknown /lore:* command", async () => {
+    harness = await createHarness({ fixtures: [] });
+
+    const resp = await harness.chat(slashBody("/lore:bogus"));
+    expect(resp.status).toBe(200);
+    const text = await textOf(resp);
+    expect(text).toContain("Unknown command");
+    expect(text).toContain("/lore:curate");
+  });
+
+  it("intercepts /lore:curate (reports no active session when session-less)", async () => {
+    // Without a known session header the curate handler can't resolve a
+    // session, so it reports that rather than forwarding upstream. This still
+    // covers the dispatcher + handleCurateSlashCommand entry path.
+    harness = await createHarness({ fixtures: [] });
+
+    const resp = await harness.chat(slashBody("/lore:curate"));
+    expect(resp.status).toBe(200);
+    expect(await textOf(resp)).toContain(
+      "No active session found for curation",
+    );
+  });
+
+  it("streams a slash-command response as Anthropic SSE", async () => {
+    harness = await createHarness({ fixtures: [] });
+
+    const resp = await harness.chat(slashBody("/lore:warm:stop", true));
+    expect(resp.status).toBe(200);
+    expect(resp.headers.get("content-type")).toContain("text/event-stream");
+
+    const sse = await resp.text();
+    expect(sse).toContain("event: message_start");
+    expect(sse).toContain("Cache warming stopped.");
+    expect(sse).toContain("event: message_stop");
+  });
+});


### PR DESCRIPTION
## What

Continues #690 (raising `@loreai/gateway` coverage), targeting `pipeline.ts` — the largest, lowest-coverage runtime file. Adds harness-based coverage for two self-contained pipeline paths that require **no upstream fixture**, so they're deterministic and fast.

### `test/pipeline-slash.test.ts` (5 tests)
`/lore:*` slash commands are intercepted in `handleRequest` (Case 0) and answered with a synthetic response:
- `/lore:amnesia:on` / `:off`
- `/lore:warm:stop` / `:keep` / `:auto`
- unknown `/lore:*` → helpful error listing available commands
- `/lore:curate` (session-less → "no active session" branch)
- **streaming** slash response → Anthropic SSE (covers `streamHttpResponse` + `buildSSETextResponse` through the pipeline — the streaming wire path the replay harness can't drive for normal turns)

### `test/compact-endpoint.test.ts` (3 tests)
`POST /v1/compact` (Pi plugin) validation branches in `handleCompactEndpoint`:
- invalid JSON → 400
- missing `project_path` → 400
- valid project but no active session → 404 `session_not_found`

## Why this scope

Streaming **conversation** turns and **OpenAI-protocol** turns were attempted but aren't reliably coverable through the current replay harness: `getReplayInterceptor` always returns non-streaming JSON, while those paths consume an SSE byte stream / a protocol-specific upstream shape. Driving them needs an SSE/protocol-aware fixture (a harness enhancement) — noted as future work rather than shipping fragile tests.

## Verification
- `pnpm test` — full suite green (103 files, 2668 passed, 6 skipped).
- `pnpm run typecheck` — zero errors; `biome check` — clean.

Refs #690