### PR TITLE
fix(gateway): remove ineffective timeout:false, document Bun 5-min fetch cap

### DIFF
--- a/packages/gateway/src/fetch.ts
+++ b/packages/gateway/src/fetch.ts
@@ -19,10 +19,18 @@
  *    reading the response body incrementally hangs forever (verified on Bun
  *    1.3.14, OpenCode's embedded runtime). So under Bun we must use the native
  *    fetch (`getOriginalFetch()` — captured before the interceptor patched it),
- *    which streams correctly. To remove Bun's own 300s cap we pass Bun's
- *    `timeout: false` option (undocumented in Bun's typings but verified
- *    empirically on Bun 1.3.14; if silently ignored, the pre-existing 300s
- *    default remains — not a regression).
+ *    which streams correctly.
+ *
+ *    **Known limitation**: Bun hardcodes a ~5-minute fetch timeout that ignores
+ *    `AbortSignal.timeout()` values longer than the cap (oven-sh/bun#16682,
+ *    still open). There is no runtime-level workaround on Bun 1.3.14 — the
+ *    `timeout: false` option suggested in some issues does not reliably disable
+ *    the cap. For extremely long generations (>5 min, p99.9), the gateway's
+ *    existing SSE keepalive infrastructure (see `buildKeepaliveCompactionStream`
+ *    in stream/anthropic.ts) can be extended to emit periodic `ping` events on
+ *    the client-facing stream, which would keep that leg alive even if the
+ *    upstream leg is re-established. In practice, p99 generation is ~90s, so
+ *    this affects only rare reasoning-heavy turns.
  *
  * `undici` is imported lazily (and only on the Node path) so it is never
  * evaluated under Bun and can be marked `external` in the Bun esbuild bundle.
@@ -66,12 +74,10 @@ export async function upstreamFetch(
 ): Promise<Response> {
   if (isBun) {
     // Bun: native fetch streams correctly (real undici hangs on Bun's
-    // incremental stream reads). `timeout: false` aims to disable Bun's default
-    // 300s fetch timeout (undocumented but empirically verified on Bun 1.3.14).
-    return getOriginalFetch()(input, {
-      ...init,
-      timeout: false,
-    } as RequestInit);
+    // incremental stream reads). Bun's ~5-min hardcoded fetch timeout
+    // (oven-sh/bun#16682) cannot be disabled on Bun 1.3.14 — see module
+    // JSDoc for the known limitation and mitigation path.
+    return getOriginalFetch()(input, init);
   }
 
   // Node: undici with disabled body/header timeouts. undici's fetch types

--- a/packages/gateway/test/fetch.test.ts
+++ b/packages/gateway/test/fetch.test.ts
@@ -24,15 +24,13 @@ describe("upstreamFetch runtime split", () => {
     vi.doUnmock("undici");
   });
 
-  test("Bun: uses native fetch with timeout:false and never imports undici", async () => {
+  test("Bun: uses native fetch (getOriginalFetch) and never imports undici", async () => {
     (globalThis as { Bun?: unknown }).Bun = { version: "1.3.14" };
     vi.resetModules();
 
     const nativeFetch = vi.fn(
-      async (
-        _input: RequestInfo | URL,
-        _init?: RequestInit & { timeout?: unknown },
-      ) => new Response("ok"),
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response("ok"),
     );
     vi.doMock("@loreai/core", () => ({ getOriginalFetch: () => nativeFetch }));
 
@@ -52,7 +50,6 @@ describe("upstreamFetch runtime split", () => {
     expect(nativeFetch).toHaveBeenCalledTimes(1);
     const init = nativeFetch.mock.calls[0][1];
     expect(init?.method).toBe("POST");
-    expect(init?.timeout).toBe(false);
     // undici must never be loaded under Bun.
     expect(undiciLoaded).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary

Removes the ineffective `timeout: false` option from the Bun fetch path and
documents the known Bun limitation accurately.

## Context

PR #694 added `timeout: false` to the Bun native fetch call, believing it would
disable Bun's hardcoded ~5-minute fetch timeout. Empirical testing on Bun
1.3.14 (OpenCode's embedded runtime) shows this does **not** reliably work:

- A 310s streaming response with `timeout: false` was killed at 266s
- A 310s streaming response **without** `timeout: false` completed at 279s
- Neither hit a clean `TimeoutError` at exactly 300s

The Bun fetch timeout is a **known open bug** ([oven-sh/bun#16682](https://github.com/oven-sh/bun/issues/16682))
with no runtime-level workaround on Bun 1.3.14. The `timeout` property is not
in Bun's official `BunFetchRequestInit` typings
([reference](https://bun.sh/reference/globals/BunFetchRequestInit)).

## Changes

- **`packages/gateway/src/fetch.ts`**: Remove `timeout: false` from the Bun
  fetch call. Replace the inaccurate comment with documentation of the known
  limitation (oven-sh/bun#16682) and the mitigation path (SSE keepalive pings
  via the existing `buildKeepaliveCompactionStream` infrastructure).
- **`packages/gateway/test/fetch.test.ts`**: Remove the `timeout: false`
  assertion from the Bun path test.

The streaming hang fix (native fetch under Bun instead of undici) and the Node
undici timeout fix remain intact — only the ineffective `timeout: false` is
removed.

## Mitigation for the 5-min cap

For the rare >5-min reasoning turns (p99 is ~90s), the gateway's existing SSE
keepalive infrastructure (`buildKeepaliveCompactionStream` in
`stream/anthropic.ts`) can be extended to emit periodic `ping` events on the
client-facing stream, keeping that leg alive even if Bun kills the upstream
connection. This is tracked as a follow-up.