### PR TITLE
test(gateway): SSE-aware replay harness + streaming pipeline coverage

### DIFF
--- a/packages/gateway/test/helpers/harness.ts
+++ b/packages/gateway/test/helpers/harness.ts
@@ -64,7 +64,7 @@ export async function createHarness(opts: HarnessOptions): Promise<Harness> {
   }
 
   // --- 3. Dynamic imports so env vars take effect before module-level code runs ---
-  const { getReplayInterceptor } = await import("../../src/recorder");
+  const { makeReplayInterceptor } = await import("./replay");
   const { setUpstreamInterceptor, resetPipelineState } = await import(
     "../../src/pipeline"
   );
@@ -79,8 +79,9 @@ export async function createHarness(opts: HarnessOptions): Promise<Harness> {
   closeDB();
   await resetPipelineState();
 
-  // --- 4. Wire in replay interceptor ---
-  setUpstreamInterceptor(getReplayInterceptor(opts.fixtures));
+  // --- 4. Wire in replay interceptor (streaming-aware: emits SSE for
+  // streaming turns, JSON otherwise) ---
+  setUpstreamInterceptor(makeReplayInterceptor(opts.fixtures));
 
   // --- 5. Start gateway ---
   const config = loadConfig();

--- a/packages/gateway/test/helpers/replay.ts
+++ b/packages/gateway/test/helpers/replay.ts
@@ -1,0 +1,190 @@
+/**
+ * Streaming-aware replay interceptor for the gateway test harness.
+ *
+ * The production `getReplayInterceptor` (src/recorder.ts) always returns a
+ * non-streaming JSON response. That works for `stream: false` turns, but the
+ * pipeline's streaming path forwards an upstream **SSE byte stream**
+ * (buildStreamingResponse parses Anthropic named events). When the client
+ * requested streaming, the gateway sends `stream: true` upstream, so a
+ * faithful replay must hand back an SSE stream — otherwise the accumulator
+ * sees no events and the client receives an empty body.
+ *
+ * This helper mirrors that: it returns Anthropic SSE for streaming requests
+ * whose fixture is an Anthropic message (has a `content` array), and plain
+ * JSON otherwise (preserving the existing non-streaming behavior exactly).
+ *
+ * Lives under test/helpers (excluded from coverage) and is wired only into
+ * the gateway harness — src/recorder.ts and the core eval harness are
+ * intentionally left unchanged.
+ */
+import type { FixtureEntry, UpstreamInterceptor } from "../../src/recorder";
+
+interface AnthropicBlock {
+  type: string;
+  text?: string;
+  id?: string;
+  name?: string;
+  input?: unknown;
+}
+
+interface AnthropicMessage {
+  id?: string;
+  model?: string;
+  content?: AnthropicBlock[];
+  stop_reason?: string;
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    cache_read_input_tokens?: number;
+    cache_creation_input_tokens?: number;
+  };
+}
+
+function isAnthropicMessage(resp: unknown): resp is AnthropicMessage {
+  return (
+    typeof resp === "object" &&
+    resp !== null &&
+    Array.isArray((resp as { content?: unknown }).content)
+  );
+}
+
+function sseEvent(type: string, data: unknown): string {
+  return `event: ${type}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+/**
+ * Convert an Anthropic message JSON into a well-formed Anthropic SSE event
+ * sequence:
+ *   message_start → (content_block_start/delta/stop)* → message_delta →
+ *   message_stop
+ *
+ * Handles text and tool_use content blocks.
+ */
+export function anthropicMessageToSSE(message: AnthropicMessage): string {
+  const id = message.id ?? "msg_replay";
+  const model = message.model ?? "claude-replay";
+  const content = message.content ?? [];
+  const usage = message.usage ?? {};
+  const stopReason = message.stop_reason ?? "end_turn";
+
+  const events: string[] = [];
+
+  events.push(
+    sseEvent("message_start", {
+      type: "message_start",
+      message: {
+        id,
+        type: "message",
+        role: "assistant",
+        content: [],
+        model,
+        stop_reason: null,
+        stop_sequence: null,
+        usage: {
+          input_tokens: usage.input_tokens ?? 0,
+          output_tokens: 1,
+          ...(usage.cache_read_input_tokens != null
+            ? { cache_read_input_tokens: usage.cache_read_input_tokens }
+            : {}),
+          ...(usage.cache_creation_input_tokens != null
+            ? { cache_creation_input_tokens: usage.cache_creation_input_tokens }
+            : {}),
+        },
+      },
+    }),
+  );
+
+  content.forEach((block, index) => {
+    if (block.type === "text") {
+      events.push(
+        sseEvent("content_block_start", {
+          type: "content_block_start",
+          index,
+          content_block: { type: "text", text: "" },
+        }),
+      );
+      events.push(
+        sseEvent("content_block_delta", {
+          type: "content_block_delta",
+          index,
+          delta: { type: "text_delta", text: block.text ?? "" },
+        }),
+      );
+      events.push(
+        sseEvent("content_block_stop", { type: "content_block_stop", index }),
+      );
+    } else if (block.type === "tool_use") {
+      events.push(
+        sseEvent("content_block_start", {
+          type: "content_block_start",
+          index,
+          content_block: {
+            type: "tool_use",
+            id: block.id ?? `toolu_${index}`,
+            name: block.name ?? "tool",
+            input: {},
+          },
+        }),
+      );
+      events.push(
+        sseEvent("content_block_delta", {
+          type: "content_block_delta",
+          index,
+          delta: {
+            type: "input_json_delta",
+            partial_json: JSON.stringify(block.input ?? {}),
+          },
+        }),
+      );
+      events.push(
+        sseEvent("content_block_stop", { type: "content_block_stop", index }),
+      );
+    }
+  });
+
+  events.push(
+    sseEvent("message_delta", {
+      type: "message_delta",
+      delta: { stop_reason: stopReason, stop_sequence: null },
+      usage: { output_tokens: usage.output_tokens ?? 0 },
+    }),
+  );
+  events.push(sseEvent("message_stop", { type: "message_stop" }));
+
+  return events.join("");
+}
+
+/**
+ * Build a replay interceptor that serves fixtures in sequence. For streaming
+ * Anthropic turns it returns reconstructed SSE; otherwise it returns the
+ * fixture response as JSON (identical to getReplayInterceptor). Throws when
+ * fixtures are exhausted.
+ */
+export function makeReplayInterceptor(
+  fixtures: FixtureEntry[],
+): UpstreamInterceptor {
+  let replayCounter = 0;
+
+  return async (_requestBody, _model, wasStreaming, _makeRealRequest) => {
+    if (replayCounter >= fixtures.length) {
+      throw new Error(
+        `Replay exhausted: no more fixtures (tried to replay entry ${replayCounter}, ` +
+          `but only ${fixtures.length} fixture(s) are available)`,
+      );
+    }
+
+    const fixture = fixtures[replayCounter++];
+
+    if (wasStreaming && isAnthropicMessage(fixture.response)) {
+      return new Response(anthropicMessageToSSE(fixture.response), {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      });
+    }
+
+    return new Response(JSON.stringify(fixture.response), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  };
+}

--- a/packages/gateway/test/pipeline-streaming.test.ts
+++ b/packages/gateway/test/pipeline-streaming.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Pipeline streaming-response coverage (Anthropic conversation turns).
+ *
+ * The harness's replay interceptor now emits Anthropic SSE for streaming
+ * requests (see test/helpers/replay.ts), so a `stream: true` turn exercises
+ * the streaming path end-to-end: buildStreamingResponse parses the upstream
+ * SSE, forwards it to the client, and accumulates in parallel for
+ * postResponse storage.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import type { Harness } from "./helpers/harness";
+import { createHarness } from "./helpers/harness";
+import type { FixtureEntry } from "../src/recorder";
+import {
+  makeConversationFixtures,
+  STANDARD_TOOLS,
+  DEFAULT_MODEL,
+  DEFAULT_SYSTEM,
+} from "./helpers/fixtures";
+
+function makeStreamBody(userMessage: string): Record<string, unknown> {
+  return {
+    model: DEFAULT_MODEL,
+    max_tokens: 1024,
+    stream: true,
+    system: DEFAULT_SYSTEM,
+    messages: [{ role: "user", content: userMessage }],
+    tools: STANDARD_TOOLS,
+  };
+}
+
+async function readSSE(resp: Response): Promise<string> {
+  return resp.text();
+}
+
+describe("Pipeline — streaming responses", () => {
+  let harness: Harness;
+
+  afterEach(() => harness?.teardown());
+
+  it("streams an Anthropic SSE response containing the assistant text", async () => {
+    harness = await createHarness({
+      fixtures: makeConversationFixtures([
+        { userMessage: "Stream please", assistantText: "Streamed answer." },
+      ]),
+    });
+
+    const resp = await harness.chat(makeStreamBody("Stream please"));
+    expect(resp.status).toBe(200);
+    expect(resp.headers.get("content-type")).toContain("text/event-stream");
+
+    const sse = await readSSE(resp);
+    expect(sse).toContain("event: message_start");
+    expect(sse).toContain("event: content_block_delta");
+    expect(sse).toContain("Streamed answer.");
+    expect(sse).toContain("event: message_stop");
+  });
+
+  it("persists the streamed turn to temporal storage", async () => {
+    harness = await createHarness({
+      fixtures: makeConversationFixtures([
+        { userMessage: "Persist this stream", assistantText: "Done." },
+      ]),
+    });
+
+    const resp = await harness.chat(makeStreamBody("Persist this stream"));
+    expect(resp.status).toBe(200);
+    // Drain the stream so postResponse runs.
+    await readSSE(resp);
+    await new Promise((r) => setTimeout(r, 200));
+
+    const rows = harness.queryDB<{ n: number }>(
+      "SELECT COUNT(*) as n FROM temporal_messages WHERE role='assistant'",
+    );
+    expect(rows[0].n).toBeGreaterThanOrEqual(1);
+  });
+
+  it("streams a tool_use response (text + tool_use blocks)", async () => {
+    const toolFixture: FixtureEntry = {
+      seq: 0,
+      ts: Date.now(),
+      request: {},
+      response: {
+        id: "msg_tool",
+        type: "message",
+        role: "assistant",
+        model: DEFAULT_MODEL,
+        content: [
+          { type: "text", text: "Running it now." },
+          {
+            type: "tool_use",
+            id: "toolu_1",
+            name: "bash",
+            input: { command: "ls -la" },
+          },
+        ],
+        stop_reason: "tool_use",
+        usage: { input_tokens: 10, output_tokens: 8 },
+      },
+      wasStreaming: false,
+      model: DEFAULT_MODEL,
+    };
+
+    harness = await createHarness({ fixtures: [toolFixture] });
+
+    const resp = await harness.chat(makeStreamBody("List files"));
+    expect(resp.status).toBe(200);
+    expect(resp.headers.get("content-type")).toContain("text/event-stream");
+
+    const sse = await readSSE(resp);
+    expect(sse).toContain("Running it now.");
+    expect(sse).toContain('"type":"tool_use"');
+    expect(sse).toContain('"name":"bash"');
+    expect(sse).toContain("ls -la");
+    expect(sse).toContain("event: message_stop");
+  });
+});


### PR DESCRIPTION
## What

Continues #690. Unlocks **streaming** conversation-turn coverage for `pipeline.ts` by teaching the test harness's replay interceptor to emulate a streaming upstream.

### The gap
The replay interceptor (`getReplayInterceptor`) always returned non-streaming JSON. But `buildAnthropicRequest` sends `stream: req.stream` upstream, and the pipeline's streaming path (`buildStreamingResponse`) parses an upstream **SSE byte stream**. So a `stream: true` turn against the harness produced an **empty body** — the accumulator saw no SSE events. This is why the earlier coverage PRs couldn't test streaming turns.

### The fix (test infrastructure only)
`test/helpers/replay.ts` adds a streaming-aware replay interceptor:
- streaming request + Anthropic-shaped fixture → reconstructs Anthropic SSE (`message_start → content_block_start/delta/stop* → message_delta → message_stop`, handling **text and tool_use** blocks)
- otherwise → returns JSON, identical to the previous behavior

Wired **only** into the gateway harness (`test/helpers/harness.ts`). `src/recorder.ts` and the core eval harness are intentionally untouched, and `test/helpers/**` is excluded from coverage — this is pure test infrastructure, **no production source change**.

### New tests (`test/pipeline-streaming.test.ts`)
- streams an Anthropic SSE response containing the assistant text
- persists a streamed turn to temporal storage (postResponse runs after drain)
- streams a `tool_use` response (text + tool_use blocks)

## Verification
- `pnpm test` — full suite green (104 files, 2671 passed, 6 skipped); all 12 existing harness tests unaffected (backward-compatible).
- `pnpm run typecheck` — zero errors; `biome check` — clean.

## Follow-ups
This unblocks further pipeline streaming coverage (recall-over-stream, compaction interception). OpenAI/Responses-protocol streaming would need an analogous OpenAI-SSE reconstruction — noted for a later PR.

Refs #690