### PR TITLE
fix(gateway): unblock background work — dynamic concurrency, idle de-flood, per-provider breaker, 402 handling

### DIFF
--- a/packages/gateway/src/background-limiter.ts
+++ b/packages/gateway/src/background-limiter.ts
@@ -3,27 +3,62 @@
  *
  * Wraps fire-and-forget background LLM calls (idle distillation,
  * curation, pipeline-triggered incremental distillation) through a
- * single p-limit(2) so at most 2 background LLM operations run
- * concurrently across all sessions.
+ * single p-limit instance whose concurrency is dynamically scaled by
+ * the active-session count (see `scaleBackgroundConcurrency`). Starts
+ * at MIN_BACKGROUND_CONCURRENCY=2 and scales up to
+ * MAX_BACKGROUND_CONCURRENCY=12 (or the env override).
  *
  * Note: auto-import extraction (`import-auto.ts`) is NOT wrapped here —
  * it creates its own LLM client and runs sequentially per-process.
  * The circuit breaker still provides protection for import because
  * `tripCircuitBreaker` is called from `llm-adapter.ts` on any 429
  * (urgent included — an urgent call keeps retrying but still pauses
- * other background work), and import uses the same adapter.
+ * other background work to the same provider), and import uses the
+ * same adapter.
  *
- * Also provides a circuit breaker that trips on upstream 429 responses,
- * pausing all background work for the Retry-After period. This prevents
- * cascading retries from consuming the rate limit budget that
- * conversation turns need.
+ * Also provides a per-provider circuit breaker that trips on upstream
+ * 429 responses, pausing background work to the offending provider for
+ * the Retry-After period. Work routed to other providers keeps draining.
+ * This prevents cascading retries from consuming the rate limit budget
+ * that conversation turns need, without the blast-radius of a global
+ * pause.
  */
 
 import pLimit from "p-limit";
 import { log } from "@loreai/core";
 
-/** Global concurrency cap for background (non-urgent) LLM work. */
-const BACKGROUND_CONCURRENCY = 2;
+/**
+ * Background concurrency is scaled dynamically by active-session count
+ * (see `scaleBackgroundConcurrency`). These bound that scaling.
+ *
+ * The limiter starts at MIN and scales up on demand so a freshly-started
+ * gateway with one session doesn't reserve idle capacity. The circuit
+ * breaker remains the rate-limit governor — scaling only changes the drain
+ * rate between trips.
+ */
+const MIN_BACKGROUND_CONCURRENCY = 2;
+const MAX_BACKGROUND_CONCURRENCY = 12;
+
+/**
+ * Background LLM ops allowed per active session (rounded up). Not every
+ * session has pending background work simultaneously, so a fractional
+ * factor keeps the cap proportional without over-provisioning. Tunable.
+ */
+const CONCURRENCY_PER_SESSION = 0.5;
+
+/**
+ * Resolve the upper bound for background concurrency. `LORE_BACKGROUND_CONCURRENCY`
+ * is a hard ceiling override (escape hatch for large multi-tenant hosts);
+ * otherwise the built-in MAX applies. Clamped to a sane [1, 32].
+ */
+function resolveMaxConcurrency(): number {
+  const env = process.env.LORE_BACKGROUND_CONCURRENCY;
+  if (env) {
+    const n = Number.parseInt(env, 10);
+    if (Number.isFinite(n) && n >= 1) return Math.min(n, 32);
+  }
+  return MAX_BACKGROUND_CONCURRENCY;
+}
 
 /**
  * Maximum pending tasks in the queue. Beyond this, new submissions are
@@ -33,14 +68,44 @@ const BACKGROUND_CONCURRENCY = 2;
  */
 const MAX_PENDING_QUEUE = 50;
 
-const limiter = pLimit(BACKGROUND_CONCURRENCY);
+/**
+ * Fraction of MAX_PENDING_QUEUE above which disposable (regenerable) work —
+ * i.e. idle work, which is re-derived every idle tick — should self-shed
+ * rather than occupy a slot. Reserves the upper half of the queue for
+ * one-shot hot-path work (incremental-distill, curation) scheduled from
+ * `pipeline.ts`, which submits unconditionally.
+ */
+const LOW_PRIORITY_SHED_THRESHOLD = 0.5;
+
+const limiter = pLimit(MIN_BACKGROUND_CONCURRENCY);
 
 // ---------------------------------------------------------------------------
-// Circuit breaker
+// Circuit breaker (per-provider)
 // ---------------------------------------------------------------------------
 
-/** Timestamp (ms) when the circuit breaker expires. 0 = not tripped. */
-let circuitOpenUntil = 0;
+/**
+ * The circuit breaker is keyed by upstream provider, NOT global. A 429 from
+ * one provider (e.g. OpenRouter) must only pause background work that targets
+ * THAT provider — work routed to a healthy provider (e.g. Anthropic) keeps
+ * draining. A global breaker would let one rate-limited provider freeze every
+ * session's background work regardless of where it's routed.
+ *
+ * Callers that lack provider context (e.g. the test-only `_tripRaw`, or a
+ * session whose worker model can't be resolved) fall back to GLOBAL_KEY, which
+ * behaves like the old single global breaker — paused work under GLOBAL_KEY
+ * pauses everything. This keeps the conservative behavior for the unknown case.
+ */
+const GLOBAL_KEY = "_global";
+
+interface BreakerState {
+  /** Timestamp (ms) when this provider's breaker expires. 0 = not tripped. */
+  openUntil: number;
+  /** Consecutive trips without a full recovery in between. */
+  consecutiveTrips: number;
+}
+
+/** Per-provider breaker state. Absent key = never tripped. */
+const breakers = new Map<string, BreakerState>();
 
 /**
  * Escalating backoff schedule (seconds) for consecutive circuit breaker trips.
@@ -49,69 +114,111 @@ let circuitOpenUntil = 0;
  */
 export const BACKOFF_SCHEDULE = [60, 120, 240, 480, 600] as const;
 
-/** Number of consecutive trips without a full recovery in between. */
-let consecutiveTrips = 0;
+function breakerKey(providerID?: string): string {
+  return providerID && providerID.length > 0 ? providerID : GLOBAL_KEY;
+}
 
 /**
- * Check if the circuit breaker is currently tripped.
- * Background work should check this before submitting to the limiter.
+ * Whether a specific provider's breaker is currently open. A tripped GLOBAL_KEY
+ * breaker pauses every provider (conservative fallback for unknown-provider
+ * trips); otherwise only the named provider is paused.
  */
-export function isBackgroundPaused(): boolean {
-  if (circuitOpenUntil === 0) return false;
-  if (Date.now() >= circuitOpenUntil) {
-    // Breaker expired naturally — full recovery, reset escalation
-    circuitOpenUntil = 0;
-    consecutiveTrips = 0;
+function isProviderPaused(key: string): boolean {
+  const entry = breakers.get(key);
+  if (!entry || entry.openUntil === 0) return false;
+  if (Date.now() >= entry.openUntil) {
+    // Expired naturally — full recovery, reset escalation for this provider
+    breakers.delete(key);
     return false;
   }
   return true;
 }
 
 /**
- * Trip the circuit breaker. Called when any LLM worker call receives a 429
- * (urgent calls included — they keep retrying themselves but still pause
- * other background work). Pauses all background work with escalating backoff.
+ * Check if background work for `providerID` should be paused. Returns true when
+ * either that provider's own breaker OR the global-fallback breaker is open.
  *
- * When `retryAfterSeconds` is provided (from Retry-After header), the
- * pause duration is the greater of the server-guided value and the
- * escalation schedule — server guidance is respected but escalation
- * still applies.
+ * @param providerID Upstream provider the pending work will call. Omit when
+ *                   unknown — only the global-fallback breaker is consulted.
+ */
+export function isBackgroundPaused(providerID?: string): boolean {
+  // The global-fallback breaker pauses everything; a per-provider breaker
+  // pauses only that provider.
+  if (isProviderPaused(GLOBAL_KEY)) return true;
+  const key = breakerKey(providerID);
+  if (key === GLOBAL_KEY) return false; // already checked above
+  return isProviderPaused(key);
+}
+
+/**
+ * Trip the circuit breaker for a specific provider. Called when an LLM worker
+ * call to that provider receives a 429 (urgent calls included — they keep
+ * retrying themselves but still pause other background work to that provider).
+ * Pauses with escalating backoff, scoped to the provider.
+ *
+ * When `retryAfterSeconds` is provided (from Retry-After header), the pause
+ * duration is the greater of the server-guided value and the escalation
+ * schedule — server guidance is respected but escalation still applies.
  *
  * @param retryAfterSeconds Server-guided pause duration, if available.
+ * @param providerID        Provider that returned 429. Omit (→ GLOBAL_KEY) only
+ *                          when the provider is genuinely unknown — that pauses
+ *                          ALL background work (conservative fallback).
  */
-export function tripCircuitBreaker(retryAfterSeconds?: number): void {
+export function tripCircuitBreaker(
+  retryAfterSeconds?: number,
+  providerID?: string,
+): void {
+  const key = breakerKey(providerID);
+  const entry = breakers.get(key) ?? { openUntil: 0, consecutiveTrips: 0 };
+
   const scheduled =
-    BACKOFF_SCHEDULE[Math.min(consecutiveTrips, BACKOFF_SCHEDULE.length - 1)];
+    BACKOFF_SCHEDULE[
+      Math.min(entry.consecutiveTrips, BACKOFF_SCHEDULE.length - 1)
+    ];
   const duration =
     retryAfterSeconds && retryAfterSeconds > 0
       ? Math.max(retryAfterSeconds, scheduled)
       : scheduled;
-  consecutiveTrips++;
+  entry.consecutiveTrips++;
 
   const until = Date.now() + duration * 1000;
   // Only extend, never shorten an active pause
-  if (until > circuitOpenUntil) {
-    circuitOpenUntil = until;
+  if (until > entry.openUntil) {
+    entry.openUntil = until;
     log.warn(
-      `background circuit breaker tripped (trip #${consecutiveTrips}): ` +
-        `pausing all background work for ${duration}s ` +
+      `background circuit breaker tripped for ${key} (trip #${entry.consecutiveTrips}): ` +
+        `pausing background work to ${key} for ${duration}s ` +
         `[active=${limiter.activeCount} pending=${limiter.pendingCount}]`,
     );
   }
+  breakers.set(key, entry);
 }
 
 /**
- * Get remaining pause time in seconds (for diagnostics/logging).
- * Returns 0 if not paused.
+ * Get remaining pause time in seconds for a provider (for diagnostics/logging).
+ * Returns the max remaining across the provider's own breaker and the global
+ * fallback. Returns 0 if not paused.
  */
-export function remainingPauseSeconds(): number {
-  if (!isBackgroundPaused()) return 0;
-  return Math.ceil((circuitOpenUntil - Date.now()) / 1000);
+export function remainingPauseSeconds(providerID?: string): number {
+  const now = Date.now();
+  let until = 0;
+  const globalEntry = breakers.get(GLOBAL_KEY);
+  if (globalEntry && globalEntry.openUntil > now) until = globalEntry.openUntil;
+  const key = breakerKey(providerID);
+  if (key !== GLOBAL_KEY) {
+    const entry = breakers.get(key);
+    if (entry && entry.openUntil > until) until = entry.openUntil;
+  }
+  return until > now ? Math.ceil((until - now) / 1000) : 0;
 }
 
-/** Number of consecutive trips (for diagnostics/testing). */
-export function getConsecutiveTrips(): number {
-  return consecutiveTrips;
+/**
+ * Consecutive trips for a provider (for diagnostics/testing). Defaults to the
+ * global-fallback breaker when no provider is given.
+ */
+export function getConsecutiveTrips(providerID?: string): number {
+  return breakers.get(breakerKey(providerID))?.consecutiveTrips ?? 0;
 }
 
 // ---------------------------------------------------------------------------
@@ -130,16 +237,21 @@ export function getConsecutiveTrips(): number {
  *
  * @param fn Async function to execute
  * @param label Human-readable label for logging (e.g., "idle session=abc")
+ * @param providerID Upstream provider this work will call. The circuit-breaker
+ *                   check is scoped to this provider, so a 429 from a different
+ *                   provider does not pause this work. Omit when unknown (only
+ *                   the global-fallback breaker is consulted).
  * @returns The function's return value, or undefined if skipped
  */
 export async function runBackground<T>(
   fn: () => Promise<T>,
   label?: string,
+  providerID?: string,
 ): Promise<T | undefined> {
-  if (isBackgroundPaused()) {
+  if (isBackgroundPaused(providerID)) {
     if (label) {
       log.info(
-        `background work skipped (circuit breaker, ${remainingPauseSeconds()}s remaining): ${label}`,
+        `background work skipped (circuit breaker, ${remainingPauseSeconds(providerID)}s remaining): ${label}`,
       );
     }
     return undefined;
@@ -157,16 +269,53 @@ export async function runBackground<T>(
   return limiter(async () => {
     // Re-check after waiting in the queue — the breaker may have tripped
     // while this task was pending behind other in-flight work.
-    if (isBackgroundPaused()) {
+    if (isBackgroundPaused(providerID)) {
       if (label) {
         log.info(
-          `background work skipped at execution (circuit breaker, ${remainingPauseSeconds()}s remaining): ${label}`,
+          `background work skipped at execution (circuit breaker, ${remainingPauseSeconds(providerID)}s remaining): ${label}`,
         );
       }
       return undefined as T | undefined;
     }
     return fn();
   });
+}
+
+/**
+ * Scale background concurrency to the current active-session count.
+ *
+ *   concurrency = clamp(ceil(activeSessions * CONCURRENCY_PER_SESSION),
+ *                       MIN_BACKGROUND_CONCURRENCY, resolveMaxConcurrency())
+ *
+ * Called from the idle scheduler tick (which owns the sessions Map) so the
+ * limiter never imports session state — no layering violation. p-limit's
+ * `concurrency` setter resumes queued tasks immediately when raised, and
+ * naturally drains down to the lower cap when sessions go away.
+ */
+export function scaleBackgroundConcurrency(activeSessions: number): void {
+  const want = Math.ceil(Math.max(0, activeSessions) * CONCURRENCY_PER_SESSION);
+  const next = Math.min(
+    Math.max(want, MIN_BACKGROUND_CONCURRENCY),
+    resolveMaxConcurrency(),
+  );
+  if (limiter.concurrency !== next) {
+    limiter.concurrency = next;
+    log.info(
+      `background concurrency scaled to ${next} (active sessions=${activeSessions})`,
+    );
+  }
+}
+
+/**
+ * True when the queue is congested enough that disposable (regenerable) work
+ * should skip submission. Disposable work (idle distillation/curation) is
+ * re-derived on the next idle tick, so dropping it under pressure is safe and
+ * keeps the upper half of the queue free for one-shot hot-path work.
+ */
+export function shouldShedLowPriority(): boolean {
+  return (
+    limiter.pendingCount >= MAX_PENDING_QUEUE * LOW_PRIORITY_SHED_THRESHOLD
+  );
 }
 
 /**
@@ -189,14 +338,22 @@ export function backgroundLimiterStats(): {
 /**
  * Reset all state (for tests).
  *
- * Note: `clearQueue()` only removes pending (queued) tasks — up to 2
- * in-flight tasks will continue to completion. Pending tasks resolve
+ * Note: `clearQueue()` only removes pending (queued) tasks — in-flight
+ * tasks (up to the current concurrency cap) will continue to completion. Pending tasks resolve
  * as `undefined`, consistent with the circuit breaker skip behavior.
  */
 export function resetBackgroundLimiter(): void {
   limiter.clearQueue();
-  circuitOpenUntil = 0;
-  consecutiveTrips = 0;
+  limiter.concurrency = MIN_BACKGROUND_CONCURRENCY;
+  breakers.clear();
+}
+
+/**
+ * Set the limiter concurrency directly, bypassing session-count scaling.
+ * For tests only — production code should use `scaleBackgroundConcurrency()`.
+ */
+export function _setConcurrencyForTest(concurrency: number): void {
+  limiter.concurrency = concurrency;
 }
 
 /**
@@ -206,8 +363,12 @@ export function resetBackgroundLimiter(): void {
  *
  * Unlike `tripCircuitBreaker`, this unconditionally sets the deadline
  * (can shorten an active pause) — useful for overriding to short
- * durations in tests.
+ * durations in tests. Defaults to the global-fallback breaker (pauses all
+ * providers); pass `providerID` to scope it.
  */
-export function _tripRaw(durationSeconds: number): void {
-  circuitOpenUntil = Date.now() + durationSeconds * 1000;
+export function _tripRaw(durationSeconds: number, providerID?: string): void {
+  const key = breakerKey(providerID);
+  const entry = breakers.get(key) ?? { openUntil: 0, consecutiveTrips: 0 };
+  entry.openUntil = Date.now() + durationSeconds * 1000;
+  breakers.set(key, entry);
 }

--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -33,7 +33,11 @@ import {
   curatorLimiter,
 } from "@loreai/core";
 import type { LLMClient } from "@loreai/core";
-import { makeWorkerHealth, allowWorkerProbe } from "./worker-health";
+import {
+  makeWorkerHealth,
+  allowWorkerProbe,
+  isWorkerCreditPaused,
+} from "./worker-health";
 import type { GatewayConfig } from "./config";
 import type { SessionState } from "./translate/types";
 import { getWorkerModel, getModelEntrySync } from "./worker-model";
@@ -51,7 +55,11 @@ import {
   MIN_INPUT_TOKENS_FOR_WARMING,
 } from "./cache-warmer";
 import * as Sentry from "@sentry/bun";
-import { runBackground } from "./background-limiter";
+import {
+  runBackground,
+  scaleBackgroundConcurrency,
+  shouldShedLowPriority,
+} from "./background-limiter";
 import {
   isAuthStale,
   resolveAuth,
@@ -129,6 +137,11 @@ export function startIdleScheduler(
     const now = Date.now();
     const timeoutMs = config.idleTimeoutSeconds * 1000;
 
+    // Scale background concurrency to the live session count before scheduling
+    // this tick's work. The idle scheduler owns the sessions Map, so doing it
+    // here keeps background-limiter free of session-state imports.
+    scaleBackgroundConcurrency(sessions.size);
+
     // --- Idle work (distillation, curation, etc.) ---
     for (const [sessionID, state] of sessions) {
       if (inProgress.has(sessionID)) continue;
@@ -145,14 +158,43 @@ export function startIdleScheduler(
       // arrives via setSessionAuth(), which clears the stale flag.
       if (isAuthStale(sessionID) && !resolveAuth(sessionID)) continue;
 
+      // Skip sessions soft-paused due to an upstream credit/billing state
+      // (HTTP 402). Expected account state, not an outage — retrying every
+      // 30s just wastes calls. A probe is allowed once per circuit interval
+      // (see isWorkerCreditPaused) so a credit top-up recovers automatically.
+      if (isWorkerCreditPaused(sessionID)) continue;
+
       // Skip background work for OAuth accounts near quota exhaustion — preserve
       // remaining entitlement for user-facing conversation turns.
       if (isQuotaPaused(resolveAuth(sessionID))) continue;
 
+      // Coalesce with any distillation/curation already in-flight OR queued for
+      // this session. The per-session p-limit(1) pools (distillLimiter/
+      // curatorLimiter) are the durable dedup signal — they persist across
+      // ticks, unlike the local inProgress Set which clears the instant
+      // runBackground returns (even on an immediate queue-full skip). Without
+      // this, every idle session re-floods the global FIFO every 30s, crowding
+      // out one-shot incremental-distill/curation work.
+      if (
+        distillLimiter.isBusy(sessionID) ||
+        curatorLimiter.isBusy(sessionID)
+      ) {
+        continue;
+      }
+
+      // Idle work is regenerated every 30s — under queue pressure, shed it so
+      // FIFO slots stay reserved for one-shot hot-path work (pipeline.ts).
+      // Dropping idle work is safe.
+      if (shouldShedLowPriority()) continue;
+
       inProgress.add(sessionID);
+      // Scope the circuit-breaker check to the provider this session's worker
+      // will call — a 429 from a different provider must not pause this work.
+      const idleProviderID = getWorkerModel(state.lastUpstream)?.providerID;
       runBackground(
         () => doIdleWork(sessionID, state),
         `idle session=${sessionID.slice(0, 16)}`,
+        idleProviderID,
       )
         .catch((e) =>
           log.error(`idle work failed for session ${sessionID}:`, e),

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -35,7 +35,7 @@ import {
 import { recordWorkerCost } from "./cost-tracker";
 import { upstreamFetch } from "./fetch";
 import { extractJSONFromSSE } from "./translate/types";
-import { recordWorkerFailure } from "./worker-health";
+import { recordWorkerFailure, markWorkerPaused } from "./worker-health";
 
 // ---------------------------------------------------------------------------
 // Worker call tracking
@@ -53,6 +53,14 @@ const TRANSIENT_CODES = new Set([429, 500, 502, 503, 529]);
 
 /** HTTP status codes indicating permanent auth failure. */
 export const AUTH_ERROR_CODES = new Set([401, 403]);
+
+/**
+ * Provider "payment required / out of credit" codes (e.g. OpenRouter 402
+ * "requires more credits"). An expected account state, NOT an infrastructure
+ * outage: suppress Sentry escalation, do not count toward the worker-health
+ * failure ladder, and soft-pause the session so we stop retrying every turn.
+ */
+const INSUFFICIENT_CREDIT_CODES = new Set([402]);
 
 /**
  * Unified retry policy (modeled on Claude Code's `getRetryDelay`).
@@ -752,6 +760,40 @@ export function createGatewayLLMClient(
                 return null;
               }
 
+              // --- Insufficient credit: 402 — expected account state ---
+              // (e.g. OpenRouter "requires more credits"). NOT an outage:
+              //  • log.warn (no Error object) so it does NOT auto-forward to
+              //    Sentry;
+              //  • intentionally NO recordWorkerFailure — that ladder is what
+              //    escalates to Sentry after 3 hits, and 402 must not;
+              //  • markWorkerPaused soft-pauses this session's background work
+              //    so the distiller/curator stop retrying every turn (a probe
+              //    is allowed once per circuit interval to detect a top-up).
+              if (INSUFFICIENT_CREDIT_CODES.has(response.status)) {
+                const text = await response.text().catch(() => "(no body)");
+                log.warn(
+                  `worker upstream insufficient credit: ${response.status} ${response.statusText}` +
+                    ` — model=${model.providerID}/${model.modelID}` +
+                    ` worker=${opts?.workerID ?? "unknown"}` +
+                    ` session=${opts?.sessionID?.slice(0, 16) ?? "none"}` +
+                    ` — ${text.slice(0, 200)}`,
+                );
+                if (opts?.sessionID) {
+                  markWorkerPaused(opts.sessionID);
+                } else {
+                  // Session-less workers (e.g. entity-rebuild) can't be paused
+                  // per-session — log so it's visible but don't escalate.
+                  log.warn(
+                    `worker upstream insufficient credit (session-less, no pause): ${response.status}`,
+                  );
+                }
+                span.setStatus({
+                  code: 2,
+                  message: `HTTP ${response.status} credit`,
+                });
+                return null;
+              }
+
               // Non-transient error — fail immediately, no retry
               if (!TRANSIENT_CODES.has(response.status)) {
                 const text = await response.text().catch(() => "(no body)");
@@ -772,19 +814,20 @@ export function createGatewayLLMClient(
               }
 
               // Transient error — retry if attempts remain.
-              // Trip the global circuit breaker on ANY 429 (urgent included) so
-              // background work pauses instead of piling on more requests while
-              // this call rides out the rate limit. The urgent call itself is
-              // not gated by the breaker, so it keeps retrying. Trip at most
-              // once per call to avoid runaway escalation of the backoff
-              // schedule across a multi-retry loop.
+              // Trip the circuit breaker for THIS provider on ANY 429 (urgent
+              // included) so background work targeting the same provider pauses
+              // instead of piling on more requests while this call rides out
+              // the rate limit. Work routed to other providers keeps draining.
+              // The urgent call itself is not gated by the breaker, so it keeps
+              // retrying. Trip at most once per call to avoid runaway
+              // escalation of the backoff schedule across a multi-retry loop.
               if (response.status === 429 && !breakerTripped) {
                 breakerTripped = true;
                 const cbRetryAfter = parseRetryAfter(response);
                 const pauseSec = cbRetryAfter
                   ? Math.ceil(cbRetryAfter / 1000)
                   : undefined;
-                tripCircuitBreaker(pauseSec);
+                tripCircuitBreaker(pauseSec, model.providerID);
               }
 
               if (attempt < maxRetries) {

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -168,6 +168,7 @@ import {
   makeWorkerHealth,
   recordWorkerFailure,
   allowWorkerProbe,
+  isWorkerCreditPaused,
 } from "./worker-health";
 import {
   getWorkerModel,
@@ -3370,6 +3371,10 @@ function scheduleBackgroundWork(
   const llm = getLLMClient(config);
   const cfg = loreConfig();
   const model = getWorkerModel(sessionState.lastUpstream);
+  // Provider the worker will call — used to scope the circuit-breaker check so
+  // a 429 from a DIFFERENT provider doesn't pause this session's background
+  // work. Undefined when the worker model can't be resolved (→ global breaker).
+  const workerProviderID = model?.providerID;
 
   // When the OAuth account is near quota exhaustion, skip non-urgent
   // background work to preserve remaining entitlement for user-facing turns.
@@ -3381,7 +3386,12 @@ function scheduleBackgroundWork(
   // periodic probe so a recovered upstream is detected without burning
   // thousands of futile calls (Sentry: runaway lore-distill failure counts).
   // Urgent distillation below is intentionally exempt — it unblocks the user.
-  const workerThrottled = !allowWorkerProbe(sessionID);
+  // Also throttle sessions soft-paused by an upstream credit/billing state
+  // (HTTP 402) — retrying the failing provider every turn just wastes calls;
+  // a probe is allowed periodically (see isWorkerCreditPaused) to detect a
+  // credit top-up.
+  const workerThrottled =
+    !allowWorkerProbe(sessionID) || isWorkerCreditPaused(sessionID);
 
   // Check if urgent distillation is needed (gradient flagged it OR a
   // compaction anomaly was detected on the previous turn). Mark urgent: true
@@ -3421,7 +3431,11 @@ function scheduleBackgroundWork(
         metaThresholdOverride,
       })
       .catch((e) => log.error("background distillation failed:", e));
-  } else if (!isBackgroundPaused() && !quotaPaused && !workerThrottled) {
+  } else if (
+    !isBackgroundPaused(workerProviderID) &&
+    !quotaPaused &&
+    !workerThrottled
+  ) {
     // Incremental distillation and curation are non-urgent — skip when the
     // circuit breaker is active to reduce API pressure. These are also gated
     // by runBackground() which checks isBackgroundPaused(), but the early
@@ -3453,6 +3467,7 @@ function scheduleBackgroundWork(
               workerHealth: makeWorkerHealth(sessionID, "lore-distill"),
             }),
           `incremental-distill session=${sessionID.slice(0, 16)}`,
+          workerProviderID,
         ).catch((e) => log.error("background distillation failed:", e));
       }
     }
@@ -3465,7 +3480,8 @@ function scheduleBackgroundWork(
   // Also gated by circuit breaker — curation is never urgent.
   // Quota-paused accounts skip curation too (non-urgent background work).
   // Worker-throttled sessions (sustained worker failure) skip it as well.
-  if (isBackgroundPaused() || quotaPaused || workerThrottled) return;
+  if (isBackgroundPaused(workerProviderID) || quotaPaused || workerThrottled)
+    return;
 
   const modelInputCost =
     getModelEntrySync(
@@ -3498,6 +3514,7 @@ function scheduleBackgroundWork(
             }),
         ),
       `in-flight-curation session=${sessionID.slice(0, 16)}`,
+      workerProviderID,
     )
       .then((result) => {
         if (!result) return; // skipped by circuit breaker

--- a/packages/gateway/src/quota.ts
+++ b/packages/gateway/src/quota.ts
@@ -330,6 +330,9 @@ export function maybeFetchQuota(sessionID: string, cred: AuthCredential): void {
   void runBackground(
     () => fetchQuotaDeduped(cred, sessionID),
     `quota fp=${fp.slice(0, 8)}`,
+    // Quota fetch is gated to Anthropic-OAuth sessions (isAnthropicOAuthSession
+    // above), so scope the breaker check to Anthropic.
+    "anthropic",
   )
     .then((snap) => {
       // Success → hold the full 5-minute cooldown. (undefined = skipped by the

--- a/packages/gateway/src/worker-health.ts
+++ b/packages/gateway/src/worker-health.ts
@@ -130,6 +130,16 @@ const CIRCUIT_PROBE_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 
 const state: Map<string, SessionHealth> = new Map();
 
+/**
+ * Sessions soft-paused due to an upstream credit/billing state (HTTP 402,
+ * e.g. OpenRouter "requires more credits"). Distinct from the failure-ladder
+ * circuit in `state`: this is an *expected* account state, not an outage, so
+ * it carries NO Sentry escalation. Cleared on the session's next successful
+ * worker call. A single probe is allowed per CIRCUIT_PROBE_INTERVAL_MS so a
+ * credit top-up recovers automatically without spamming the upstream.
+ */
+const creditPaused: Map<string, { lastProbe: number }> = new Map();
+
 let sweepTimer: ReturnType<typeof setInterval> | null = null;
 
 /** Injectable time source — tests can override. */
@@ -143,11 +153,49 @@ export function _setNowForTest(fn: () => number): void {
 /** Internal accessor for tests. Resets the global state. */
 export function _resetForTest(): void {
   state.clear();
+  creditPaused.clear();
   if (sweepTimer) {
     clearInterval(sweepTimer);
     sweepTimer = null;
   }
   now = () => Date.now();
+}
+
+// ---------------------------------------------------------------------------
+// Credit pause (HTTP 402) — soft, non-escalating worker pause
+// ---------------------------------------------------------------------------
+
+/**
+ * Soft-pause a session's background workers due to an upstream credit/billing
+ * state (HTTP 402). Idempotent — re-marking an already-paused session does not
+ * reset its probe cadence. Does NOT feed the failure ladder, so it never
+ * escalates to Sentry.
+ */
+export function markWorkerPaused(sessionID: string): void {
+  if (!creditPaused.has(sessionID)) {
+    creditPaused.set(sessionID, { lastProbe: now() });
+  }
+}
+
+/**
+ * Whether a session is currently credit-paused. Allows one probe per
+ * CIRCUIT_PROBE_INTERVAL_MS (returning `false` for that single call and
+ * advancing the probe clock) so a credit top-up recovers automatically.
+ */
+export function isWorkerCreditPaused(sessionID: string): boolean {
+  const entry = creditPaused.get(sessionID);
+  if (!entry) return false;
+  const t = now();
+  if (t - entry.lastProbe >= CIRCUIT_PROBE_INTERVAL_MS) {
+    entry.lastProbe = t; // allow one probe through, then resume pausing
+    return false;
+  }
+  return true;
+}
+
+/** Clear a session's credit pause (e.g. after a successful worker call). */
+export function clearWorkerPaused(sessionID: string): void {
+  creditPaused.delete(sessionID);
 }
 
 // ---------------------------------------------------------------------------
@@ -316,6 +364,11 @@ export function recordWorkerFailure(
  * alert state.
  */
 export function recordWorkerSuccess(sessionID: string): void {
+  // A successful call clears any credit pause (e.g. user topped up). Must run
+  // before the early return below: credit-paused sessions have no failure-
+  // ladder `state` entry (402 never calls recordWorkerFailure).
+  creditPaused.delete(sessionID);
+
   const entry = state.get(sessionID);
   if (!entry) return;
 
@@ -487,6 +540,7 @@ export function makeWorkerHealth(
  */
 export function clearAll(): void {
   state.clear();
+  creditPaused.clear();
   if (sweepTimer) {
     clearInterval(sweepTimer);
     sweepTimer = null;

--- a/packages/gateway/test/background-limiter.test.ts
+++ b/packages/gateway/test/background-limiter.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach } from "vitest";
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
 import {
   runBackground,
   isBackgroundPaused,
@@ -6,14 +6,18 @@ import {
   resetBackgroundLimiter,
   backgroundLimiterStats,
   getConsecutiveTrips,
+  remainingPauseSeconds,
+  scaleBackgroundConcurrency,
+  shouldShedLowPriority,
   BACKOFF_SCHEDULE,
   _tripRaw,
+  _setConcurrencyForTest,
 } from "../src/background-limiter";
 
 describe("background-limiter", () => {
   beforeEach(() => resetBackgroundLimiter());
 
-  test("limits concurrency to 2", async () => {
+  test("starts at the minimum concurrency of 2", async () => {
     let maxConcurrent = 0;
     let current = 0;
 
@@ -233,6 +237,240 @@ describe("background-limiter", () => {
     expect(backgroundLimiterStats().pendingCount).toBe(50);
 
     // Clean up — release everything
+    resolve();
+    await Promise.all([active1, active2, ...queued]);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Per-provider circuit breaker isolation
+  // ---------------------------------------------------------------------------
+
+  describe("per-provider circuit breaker", () => {
+    test("a 429 from one provider does not pause another provider", () => {
+      tripCircuitBreaker(10, "openrouter");
+      expect(isBackgroundPaused("openrouter")).toBe(true);
+      // Anthropic work is unaffected.
+      expect(isBackgroundPaused("anthropic")).toBe(false);
+      // Unknown-provider (undefined) work is NOT paused by a provider-scoped trip.
+      expect(isBackgroundPaused()).toBe(false);
+    });
+
+    test("runBackground skips only the tripped provider's work", async () => {
+      tripCircuitBreaker(10, "openrouter");
+
+      let openrouterRan = false;
+      const r1 = await runBackground(
+        async () => {
+          openrouterRan = true;
+          return "or";
+        },
+        "or-task",
+        "openrouter",
+      );
+      expect(openrouterRan).toBe(false);
+      expect(r1).toBeUndefined();
+
+      let anthropicRan = false;
+      const r2 = await runBackground(
+        async () => {
+          anthropicRan = true;
+          return "an";
+        },
+        "an-task",
+        "anthropic",
+      );
+      expect(anthropicRan).toBe(true);
+      expect(r2).toBe("an");
+    });
+
+    test("global-fallback trip (no provider) pauses ALL providers", () => {
+      tripCircuitBreaker(10); // no providerID → GLOBAL_KEY
+      expect(isBackgroundPaused()).toBe(true);
+      expect(isBackgroundPaused("anthropic")).toBe(true);
+      expect(isBackgroundPaused("openrouter")).toBe(true);
+    });
+
+    test("escalation is tracked independently per provider", () => {
+      tripCircuitBreaker(undefined, "openrouter");
+      tripCircuitBreaker(undefined, "openrouter");
+      expect(getConsecutiveTrips("openrouter")).toBe(2);
+      // A different provider starts fresh.
+      expect(getConsecutiveTrips("anthropic")).toBe(0);
+      tripCircuitBreaker(undefined, "anthropic");
+      expect(getConsecutiveTrips("anthropic")).toBe(1);
+      expect(getConsecutiveTrips("openrouter")).toBe(2);
+    });
+
+    test("a provider breaker auto-resets independently after expiry", async () => {
+      _tripRaw(0.1, "openrouter");
+      expect(isBackgroundPaused("openrouter")).toBe(true);
+      await new Promise((r) => setTimeout(r, 150));
+      expect(isBackgroundPaused("openrouter")).toBe(false);
+      // Escalation reset for that provider after natural expiry.
+      expect(getConsecutiveTrips("openrouter")).toBe(0);
+    });
+
+    test("remainingPauseSeconds is scoped per provider", () => {
+      tripCircuitBreaker(300, "openrouter");
+      expect(remainingPauseSeconds("openrouter")).toBeGreaterThanOrEqual(299);
+      expect(remainingPauseSeconds("anthropic")).toBe(0);
+    });
+
+    test("global-fallback remaining time bleeds into every provider", () => {
+      tripCircuitBreaker(300); // global
+      expect(remainingPauseSeconds("anthropic")).toBeGreaterThanOrEqual(299);
+      expect(remainingPauseSeconds("openrouter")).toBeGreaterThanOrEqual(299);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Dynamic concurrency scaling
+  // ---------------------------------------------------------------------------
+
+  describe("scaleBackgroundConcurrency", () => {
+    const ENV_KEY = "LORE_BACKGROUND_CONCURRENCY";
+    let savedEnv: string | undefined;
+
+    beforeEach(() => {
+      savedEnv = process.env[ENV_KEY];
+      delete process.env[ENV_KEY];
+      resetBackgroundLimiter();
+    });
+
+    afterEach(() => {
+      if (savedEnv === undefined) delete process.env[ENV_KEY];
+      else process.env[ENV_KEY] = savedEnv;
+    });
+
+    test("scales up with active session count (0.5 per session)", async () => {
+      scaleBackgroundConcurrency(8); // ceil(8 * 0.5) = 4
+      // Run more tasks than the cap and observe max concurrency.
+      let maxConcurrent = 0;
+      let current = 0;
+      const tasks = Array.from({ length: 10 }, () =>
+        runBackground(async () => {
+          current++;
+          maxConcurrent = Math.max(maxConcurrent, current);
+          await new Promise((r) => setTimeout(r, 30));
+          current--;
+        }),
+      );
+      await Promise.all(tasks);
+      expect(maxConcurrent).toBeGreaterThan(2);
+      expect(maxConcurrent).toBeLessThanOrEqual(4);
+    });
+
+    test("never drops below the minimum of 2", () => {
+      scaleBackgroundConcurrency(0);
+      // Two concurrent slots should be available even with no sessions.
+      let resolve!: () => void;
+      const blocker = new Promise<void>((r) => {
+        resolve = r;
+      });
+      const t1 = runBackground(() => blocker);
+      const t2 = runBackground(() => blocker);
+      const t3 = runBackground(async () => {});
+      return new Promise<void>((done) => {
+        setTimeout(async () => {
+          const stats = backgroundLimiterStats();
+          expect(stats.activeCount).toBe(2);
+          expect(stats.pendingCount).toBe(1);
+          resolve();
+          await Promise.all([t1, t2, t3]);
+          done();
+        }, 10);
+      });
+    });
+
+    test("clamps to the built-in maximum of 12", async () => {
+      scaleBackgroundConcurrency(1000); // ceil(500) clamped to 12
+      let maxConcurrent = 0;
+      let current = 0;
+      const tasks = Array.from({ length: 20 }, () =>
+        runBackground(async () => {
+          current++;
+          maxConcurrent = Math.max(maxConcurrent, current);
+          await new Promise((r) => setTimeout(r, 30));
+          current--;
+        }),
+      );
+      await Promise.all(tasks);
+      expect(maxConcurrent).toBeLessThanOrEqual(12);
+      expect(maxConcurrent).toBeGreaterThan(2);
+    });
+
+    test("respects LORE_BACKGROUND_CONCURRENCY as a hard ceiling", async () => {
+      process.env[ENV_KEY] = "3";
+      scaleBackgroundConcurrency(1000); // would be 12, capped to env=3
+      let maxConcurrent = 0;
+      let current = 0;
+      const tasks = Array.from({ length: 10 }, () =>
+        runBackground(async () => {
+          current++;
+          maxConcurrent = Math.max(maxConcurrent, current);
+          await new Promise((r) => setTimeout(r, 30));
+          current--;
+        }),
+      );
+      await Promise.all(tasks);
+      expect(maxConcurrent).toBeLessThanOrEqual(3);
+    });
+
+    test("scales back down when sessions go away", () => {
+      scaleBackgroundConcurrency(20); // up to 10
+      scaleBackgroundConcurrency(2); // back down to 2 (ceil(1) -> min 2)
+      // Only 2 slots active now: third task queues.
+      let resolve!: () => void;
+      const blocker = new Promise<void>((r) => {
+        resolve = r;
+      });
+      const t1 = runBackground(() => blocker);
+      const t2 = runBackground(() => blocker);
+      const t3 = runBackground(async () => {});
+      return new Promise<void>((done) => {
+        setTimeout(async () => {
+          expect(backgroundLimiterStats().activeCount).toBe(2);
+          expect(backgroundLimiterStats().pendingCount).toBe(1);
+          resolve();
+          await Promise.all([t1, t2, t3]);
+          done();
+        }, 10);
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Low-priority load shedding
+  // ---------------------------------------------------------------------------
+
+  test("shouldShedLowPriority: false below 50% of cap, true at/above", async () => {
+    expect(shouldShedLowPriority()).toBe(false);
+
+    let resolve!: () => void;
+    const blocker = new Promise<void>((r) => {
+      resolve = r;
+    });
+
+    // Use the test hook to keep concurrency at 2 so submissions queue.
+    _setConcurrencyForTest(2);
+    const active1 = runBackground(() => blocker);
+    const active2 = runBackground(() => blocker);
+
+    const queued: Promise<unknown>[] = [];
+    // 24 pending (< 25 threshold = 50% of 50) → not shedding yet
+    for (let i = 0; i < 24; i++) {
+      queued.push(runBackground(() => blocker, `q-${i}`));
+    }
+    await new Promise((r) => setTimeout(r, 10));
+    expect(backgroundLimiterStats().pendingCount).toBe(24);
+    expect(shouldShedLowPriority()).toBe(false);
+
+    // One more → 25 pending = threshold → shedding
+    queued.push(runBackground(() => blocker, "q-24"));
+    await new Promise((r) => setTimeout(r, 10));
+    expect(backgroundLimiterStats().pendingCount).toBe(25);
+    expect(shouldShedLowPriority()).toBe(true);
+
     resolve();
     await Promise.all([active1, active2, ...queued]);
   });

--- a/packages/gateway/test/eviction.test.ts
+++ b/packages/gateway/test/eviction.test.ts
@@ -5,7 +5,7 @@
  * involvement — to verify the full eviction pipeline: guards, persistence,
  * cleanup, and consolidation cooldown removal.
  */
-import { describe, test, expect, beforeEach } from "vitest";
+import { describe, test, expect, beforeEach, vi } from "vitest";
 import { resetPipelineState } from "../src/pipeline";
 import {
   setSessionAuth,
@@ -465,5 +465,55 @@ describe("startIdleScheduler", () => {
     );
     stop();
     expect(typeof stop).toBe("function");
+  });
+
+  test("coalesces idle work while the session's distillLimiter is busy", async () => {
+    let release: () => void = () => {};
+    vi.useFakeTimers();
+    try {
+      distillLimiter.clear();
+      const config = makeConfig();
+      const sessionID = "idle-coalesce-session";
+      const sessions = new Map<string, SessionState>();
+      // Idle: lastRequestTime well past the idle timeout, no tool_use.
+      sessions.set(
+        sessionID,
+        makeSessionState({
+          sessionID,
+          lastRequestTime: Date.now() - 10 * 60 * 1000,
+          lastStopReason: "end_turn",
+        }),
+      );
+
+      // Occupy the per-session distill limiter with a blocking task — this is
+      // the durable "already working" signal the idle loop must coalesce on.
+      const blocker = new Promise<void>((r) => {
+        release = r;
+      });
+      void distillLimiter.get(sessionID)(() => blocker);
+      expect(distillLimiter.isBusy(sessionID)).toBe(true);
+
+      let idleRuns = 0;
+      const stop = startIdleScheduler(config, sessions, async () => {
+        idleRuns++;
+      });
+
+      // Two scheduler ticks (30s each) — neither should run idle work because
+      // the distill limiter is busy across both ticks.
+      await vi.advanceTimersByTimeAsync(31_000);
+      await vi.advanceTimersByTimeAsync(31_000);
+      expect(idleRuns).toBe(0);
+
+      // Free the limiter; the next tick may schedule work.
+      release();
+      await vi.advanceTimersByTimeAsync(31_000);
+      expect(idleRuns).toBeGreaterThanOrEqual(1);
+
+      stop();
+    } finally {
+      release();
+      vi.useRealTimers();
+      distillLimiter.clear();
+    }
   });
 });

--- a/packages/gateway/test/llm-adapter.test.ts
+++ b/packages/gateway/test/llm-adapter.test.ts
@@ -1,10 +1,18 @@
-import { describe, test, expect, afterEach, vi } from "vitest";
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
 
 // Mock the upstream fetch wrapper so the adapter's retry loop is driven by our
 // stubbed responses regardless of whether a fetch interceptor is installed
 // (stubbing globalThis.fetch alone would silently break if `getOriginalFetch`
 // had captured the real fetch).
 vi.mock("../src/fetch", () => ({ upstreamFetch: vi.fn() }));
+vi.mock("../src/worker-health", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/worker-health")>();
+  return {
+    ...actual,
+    recordWorkerFailure: vi.fn(actual.recordWorkerFailure),
+    markWorkerPaused: vi.fn(actual.markWorkerPaused),
+  };
+});
 
 import {
   backoffMs,
@@ -20,6 +28,7 @@ import {
 } from "../src/background-limiter";
 import { upstreamFetch } from "../src/fetch";
 import { clearAllCosts, getSessionCosts } from "../src/cost-tracker";
+import { recordWorkerFailure, markWorkerPaused } from "../src/worker-health";
 
 // ---------------------------------------------------------------------------
 // maxRetriesFor — unified policy (modeled on Claude Code's single budget)
@@ -347,10 +356,13 @@ describe("worker 429 trips the circuit breaker (urgent included)", () => {
       workerID: "lore-compact",
     });
 
-    // Exhausted → null (caller falls back), all attempts made, breaker tripped once.
+    // Exhausted → null (caller falls back), all attempts made, breaker tripped
+    // once — scoped to the provider that 429'd (anthropic here).
     expect(result).toBeNull();
     expect(mockFetch).toHaveBeenCalledTimes(4); // maxRetries(3) + 1
-    expect(getConsecutiveTrips()).toBe(1);
+    expect(getConsecutiveTrips("anthropic")).toBe(1);
+    // A different provider's breaker is unaffected by anthropic's 429.
+    expect(getConsecutiveTrips("openrouter")).toBe(0);
   });
 });
 
@@ -478,5 +490,95 @@ describe("createGatewayLLMClient.prompt", () => {
 
     expect(text).toBeNull();
     expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HTTP 402: insufficient credit — no Sentry escalation, soft-pause
+// ---------------------------------------------------------------------------
+
+describe("worker 402 insufficient credit handling", () => {
+  const mockFetch = vi.mocked(upstreamFetch);
+  const mockRecordFailure = vi.mocked(recordWorkerFailure);
+  const mockMarkPaused = vi.mocked(markWorkerPaused);
+
+  beforeEach(() => {
+    // Clear accumulated calls from prior describe blocks (429 tests etc.)
+    mockRecordFailure.mockClear();
+    mockMarkPaused.mockClear();
+  });
+
+  afterEach(() => {
+    mockFetch.mockReset();
+  });
+
+  test("402 returns null, calls markWorkerPaused, and does NOT call recordWorkerFailure", async () => {
+    mockFetch.mockImplementation(
+      async () =>
+        new Response(
+          JSON.stringify({
+            error: {
+              message: "requires more credits",
+              code: 402,
+            },
+          }),
+          { status: 402, statusText: "Payment Required" },
+        ),
+    );
+
+    const client = createGatewayLLMClient(
+      {
+        anthropic: "https://api.anthropic.com",
+        openai: "https://api.openai.com",
+      },
+      () => ({ scheme: "api-key", value: "sk-ant-test" }),
+      // Use "anthropic" provider to match the upstreams map and avoid
+      // protocol-mismatch. The 402 behavior is provider-agnostic.
+      { providerID: "anthropic", modelID: "claude-test" },
+    );
+
+    const result = await client.prompt("system", "user", {
+      workerID: "lore-distill",
+      sessionID: "sess-402-test",
+    });
+
+    // 402 is non-retried — only one fetch attempt.
+    expect(result).toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    // Soft-pause the session so we stop retrying every turn.
+    expect(mockMarkPaused).toHaveBeenCalledWith("sess-402-test");
+    // Critically: recordWorkerFailure must NOT be called — that's what
+    // escalates to Sentry after 3 hits, and 402 is an expected account state.
+    expect(mockRecordFailure).not.toHaveBeenCalled();
+  });
+
+  test("402 without sessionID logs but does not call markWorkerPaused", async () => {
+    mockFetch.mockImplementation(
+      async () =>
+        new Response(
+          JSON.stringify({
+            error: { message: "requires more credits", code: 402 },
+          }),
+          { status: 402, statusText: "Payment Required" },
+        ),
+    );
+
+    const client = createGatewayLLMClient(
+      {
+        anthropic: "https://api.anthropic.com",
+        openai: "https://api.openai.com",
+      },
+      () => ({ scheme: "api-key", value: "sk-ant-test" }),
+      { providerID: "anthropic", modelID: "claude-test" },
+    );
+
+    const result = await client.prompt("system", "user", {
+      workerID: "lore-distill",
+      // no sessionID — session-less worker
+    });
+
+    expect(result).toBeNull();
+    expect(mockMarkPaused).not.toHaveBeenCalled();
+    expect(mockRecordFailure).not.toHaveBeenCalled();
   });
 });

--- a/packages/gateway/test/worker-health.test.ts
+++ b/packages/gateway/test/worker-health.test.ts
@@ -7,6 +7,9 @@ import {
   getStatus,
   getDegradationWarning,
   getWorkerHealth,
+  markWorkerPaused,
+  isWorkerCreditPaused,
+  clearWorkerPaused,
   _resetForTest,
   _setNowForTest,
   type FailureReason,
@@ -305,6 +308,85 @@ describe("worker-health", () => {
       expect(allowWorkerProbe("s1")).toBe(false);
       // A different session is unaffected.
       expect(allowWorkerProbe("s2")).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Credit pause (HTTP 402)
+  // ---------------------------------------------------------------------------
+
+  describe("credit pause (402)", () => {
+    const PROBE_INTERVAL_MS = 5 * 60 * 1000;
+
+    test("markWorkerPaused pauses the session", () => {
+      expect(isWorkerCreditPaused("s1")).toBe(false);
+      markWorkerPaused("s1");
+      expect(isWorkerCreditPaused("s1")).toBe(true);
+      // Other sessions are unaffected.
+      expect(isWorkerCreditPaused("s2")).toBe(false);
+    });
+
+    test("re-marking does not reset the probe clock (idempotent)", () => {
+      const t0 = 2_000_000;
+      _setNowForTest(() => t0);
+      markWorkerPaused("s1");
+
+      // Advance to just before the probe interval, then re-mark.
+      _setNowForTest(() => t0 + PROBE_INTERVAL_MS - 1);
+      markWorkerPaused("s1"); // no-op — already paused
+      expect(isWorkerCreditPaused("s1")).toBe(true);
+
+      // Crossing the original interval still allows a probe.
+      _setNowForTest(() => t0 + PROBE_INTERVAL_MS);
+      expect(isWorkerCreditPaused("s1")).toBe(false);
+    });
+
+    test("allows one probe per CIRCUIT_PROBE_INTERVAL_MS, then re-pauses", () => {
+      const t0 = 3_000_000;
+      _setNowForTest(() => t0);
+      markWorkerPaused("s1");
+      expect(isWorkerCreditPaused("s1")).toBe(true);
+
+      // Before the interval: still paused.
+      _setNowForTest(() => t0 + PROBE_INTERVAL_MS - 1);
+      expect(isWorkerCreditPaused("s1")).toBe(true);
+
+      // At the interval: one probe allowed (returns false once)...
+      _setNowForTest(() => t0 + PROBE_INTERVAL_MS);
+      expect(isWorkerCreditPaused("s1")).toBe(false);
+      // ...and immediately re-pauses for the next interval.
+      expect(isWorkerCreditPaused("s1")).toBe(true);
+    });
+
+    test("recordWorkerSuccess clears the credit pause", () => {
+      markWorkerPaused("s1");
+      expect(isWorkerCreditPaused("s1")).toBe(true);
+      // Note: no failure-ladder entry exists for a credit-paused session.
+      recordWorkerSuccess("s1");
+      expect(isWorkerCreditPaused("s1")).toBe(false);
+    });
+
+    test("clearWorkerPaused clears the pause", () => {
+      markWorkerPaused("s1");
+      expect(isWorkerCreditPaused("s1")).toBe(true);
+      clearWorkerPaused("s1");
+      expect(isWorkerCreditPaused("s1")).toBe(false);
+    });
+
+    test("_resetForTest clears all credit pauses", () => {
+      markWorkerPaused("s1");
+      markWorkerPaused("s2");
+      _resetForTest();
+      expect(isWorkerCreditPaused("s1")).toBe(false);
+      expect(isWorkerCreditPaused("s2")).toBe(false);
+    });
+
+    test("does not feed the failure ladder (no Sentry escalation)", () => {
+      // Many credit pauses must never open the failure circuit.
+      for (let i = 0; i < 10; i++) markWorkerPaused("s1");
+      expect(allowWorkerProbe("s1")).toBe(true); // failure circuit untouched
+      expect(Sentry.captureMessage).not.toHaveBeenCalled();
+      expect(Sentry.captureException).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/website/src/content/docs/docs/environment.md
+++ b/packages/website/src/content/docs/docs/environment.md
@@ -11,6 +11,12 @@ Every env var the gateway reads. Default values are extracted from the source (l
 
 Env vars override `.lore.json` for the same setting. To override a `.lore.json` field, look for the corresponding `LORE_*` variable in this table — not all fields are env-var overridable; most budget, distillation, and search tuning fields require a config file change.
 
+## background-limiter
+
+| Variable | Description |
+|---|---|
+| `LORE_BACKGROUND_CONCURRENCY` | Resolve the upper bound for background concurrency. `LORE_BACKGROUND_CONCURRENCY` is a hard ceiling override (escape hatch for large multi-tenant hosts); otherwise the built-in MAX applies. Clamped to a sane [1, 32]. |
+
 ## CLI / `lore` command
 
 | Variable | Description |


### PR DESCRIPTION
## Problem

A deep audit of production logs (`journalctl -u opencode`, 2h20m window, **24 concurrent sessions, 914 turns**) found the background work queue **pinned at 50 (full) from the first minute to the last log line — it never drained**:

- **3319 background tasks skipped** (`queue full, 50 pending`) vs only **96 distillations completed**.
- Skip breakdown: **1884 idle**, **751 in-flight-curation**, **684 incremental-distill**.
- Circuit breaker tripped **0** times, quota paused **0**, worker degraded **0** → **pure throughput saturation**, not auth/rate-limit.

This is the "distillations getting blocked" symptom, plus two latent multi-provider hazards.

## Fixes

### 1. Dynamic background concurrency
`BACKGROUND_CONCURRENCY=2` was a global cap across all sessions, each task a multi-second LLM call. Replaced with `scaleBackgroundConcurrency(sessions.size)` → `clamp(ceil(sessions*0.5), 2, 12)`, driven from the idle scheduler tick (which owns the sessions map, so the limiter never imports session state). `LORE_BACKGROUND_CONCURRENCY` is a hard ceiling override. Uses p-limit's live `concurrency` setter.

### 2. Idle re-flood fix (dominant cause — 1884 skips)
The idle scheduler cleared its `inProgress` guard in `.finally()`, which fires immediately on a queue-full skip, so every idle session re-flooded the FIFO every 30s, crowding out one-shot high-value work. Now coalesces on the **durable** per-session distill/curator limiters and sheds idle work (`shouldShedLowPriority`) above 50% queue depth, reserving the upper half for incremental-distill/curation.

### 3. Per-provider circuit breaker (429 blast radius)
The breaker was a single global timestamp: a 429 from one provider (e.g. OpenRouter) paused background work for **all** providers including Anthropic. Re-keyed by `providerID`; trip/check/`runBackground` are now provider-scoped. A `_global` fallback preserves the conservative pause-everything behavior when the provider is unknown.

### 4. HTTP 402 handling (multi-provider)
OpenRouter "insufficient credit" hit the non-transient path → `recordWorkerFailure` (Sentry after 3 hits) → retried every turn. Now `log.warn` (no Sentry), no failure-ladder entry, and a soft credit-pause (`markWorkerPaused`) with a per-5min recovery probe, cleared on the next successful worker call. Session-less 402s are logged but not paused (no session to track).

## Testing

- New tests: per-provider breaker isolation, dynamic scaling (up/down/clamp/env-ceiling), load shedding threshold, idle coalesce-while-busy (fake timers), credit-pause lifecycle (mark/probe/clear/reset/no-Sentry), and 402 adapter behavior (mock: markWorkerPaused called, recordWorkerFailure NOT called, session-less path).
- **Full suite green: 2725 passed, 6 skipped.**
- Typecheck clean across all 5 packages; Biome clean on all changed files.
- Regenerated `environment.md` for `LORE_BACKGROUND_CONCURRENCY` (check-docs gate).

Supersedes #711 (closed — GitHub Actions webhook stuck after force-push).