### PR TITLE
ci(website): split production deploy into its own workflow

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,0 +1,79 @@
+name: Docs Deploy
+
+# Production deploy of the website to GitHub Pages. Kept in its own workflow
+# (separate from docs-preview.yml) so it never shares a trigger with the
+# PR-preview runs. A merge to main fires both a `push: main` event and a
+# `pull_request: closed` event; when both lived in docs-preview.yml, GitHub
+# would nondeterministically cancel one of the two runs from the same merge.
+# If the cancelled one happened to be the production deploy, the live site
+# silently went stale and the main commit showed a ✗. Isolating the deploy
+# here guarantees it always runs to completion on merge.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/website/**'
+      - '.github/workflows/docs-deploy.yml'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: docs-deploy-production
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build website
+        run: pnpm --filter '@loreai/website' build
+
+      - name: Ensure .nojekyll at gh-pages root
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          if git fetch origin gh-pages:gh-pages 2>/dev/null; then
+            if git show gh-pages:.nojekyll &>/dev/null; then
+              echo ".nojekyll already exists at gh-pages root"
+            else
+              echo "Adding .nojekyll to existing gh-pages branch"
+              git checkout gh-pages
+              touch .nojekyll
+              git add .nojekyll
+              git commit -m "Add .nojekyll to disable Jekyll processing"
+              git push origin gh-pages
+              git checkout "$GITHUB_SHA"
+            fi
+          else
+            echo "Creating gh-pages branch with .nojekyll"
+            git checkout --orphan gh-pages
+            git rm -rf .
+            touch .nojekyll
+            git add .nojekyll
+            git commit -m "Initialize gh-pages with .nojekyll"
+            git push origin gh-pages
+            git checkout "$GITHUB_SHA"
+          fi
+
+      - name: Deploy to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: packages/website/dist
+          branch: gh-pages
+          clean-exclude: _preview
+          force: false

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,12 +1,12 @@
 name: Docs Preview
 
+# PR-preview deploys and cleanup only. Production deploys to GitHub Pages
+# live in docs-deploy.yml (push: main) — kept separate so a merge's
+# simultaneous `push: main` and `pull_request: closed` triggers never race
+# and cancel each other.
+
 on:
   workflow_dispatch:
-  push:
-    branches: [main]
-    paths:
-      - 'packages/website/**'
-      - '.github/workflows/docs-preview.yml'
   pull_request:
     # No paths filter on pull_request: the 'closed' event must always fire
     # so the preview action can clean up deployed previews. A paths-filter
@@ -37,10 +37,10 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       # Check if website files changed. On 'closed' events we always proceed
-      # (cleanup). On push events paths are already filtered at trigger level.
+      # (cleanup). Otherwise we only build/deploy when website files changed.
       - name: Check for website changes
         id: filter
-        if: github.event_name == 'pull_request' && github.event.action != 'closed'
+        if: github.event.action != 'closed'
         uses: dorny/paths-filter@v4
         with:
           filters: |
@@ -50,57 +50,16 @@ jobs:
 
       - name: Build website
         if: >-
-          (github.event_name != 'pull_request' || github.event.action == 'closed' || steps.filter.outputs.website == 'true') &&
-          (github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request')
+          (github.event.action == 'closed' || steps.filter.outputs.website == 'true') &&
+          github.event.pull_request.head.repo.full_name == github.repository
         run: pnpm --filter '@loreai/website' build
         env:
           PR_NUMBER: ${{ github.event.number }}
 
-      - name: Ensure .nojekyll at gh-pages root
-        if: >-
-          (github.event_name != 'pull_request' || github.event.action == 'closed' || steps.filter.outputs.website == 'true') &&
-          (github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request')
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          if git fetch origin gh-pages:gh-pages 2>/dev/null; then
-            if git show gh-pages:.nojekyll &>/dev/null; then
-              echo ".nojekyll already exists at gh-pages root"
-            else
-              echo "Adding .nojekyll to existing gh-pages branch"
-              git checkout gh-pages
-              touch .nojekyll
-              git add .nojekyll
-              git commit -m "Add .nojekyll to disable Jekyll processing"
-              git push origin gh-pages
-              git checkout "$GITHUB_SHA"
-            fi
-          else
-            echo "Creating gh-pages branch with .nojekyll"
-            git checkout --orphan gh-pages
-            git rm -rf .
-            touch .nojekyll
-            git add .nojekyll
-            git commit -m "Initialize gh-pages with .nojekyll"
-            git push origin gh-pages
-            git checkout "$GITHUB_SHA"
-          fi
-
-      - name: Deploy to GitHub Pages
-        if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          folder: packages/website/dist
-          branch: gh-pages
-          clean-exclude: _preview
-          force: false
-
       - name: Deploy PR Preview
         if: >-
-          github.event_name == 'pull_request' &&
           (github.event.action == 'closed' || steps.filter.outputs.website == 'true') &&
-          (github.event.pull_request.head.repo.full_name == github.repository)
+          github.event.pull_request.head.repo.full_name == github.repository
         uses: rossjrw/pr-preview-action@v1
         with:
           source-dir: packages/website/dist/


### PR DESCRIPTION
## Problem

A merge to `main` fires **two** `Docs Preview` runs simultaneously:
- `push: main` — the run that **deploys production** to GitHub Pages
- `pull_request: closed` — the run that **cleans up the PR preview**

GitHub nondeterministically cancels one of the two runs originating from the same merge (2s, zero steps). This has two bad consequences when the **push** run is the one cancelled (as happened on #714):

1. **Production silently goes stale** — the "Deploy to GitHub Pages" step only runs in the push run, so the live site never gets the merged changes. After #714 merged, `https://withlore.ai/different/` returned **404** and the old `/different.html` was still served.
2. **The main commit shows a ✗** — a cancelled run on `main` looks like a broken build.

This was nondeterministic: on #706's merge the push run won (prod deployed); on #714's it lost (prod stale).

## Fix

Split the production deploy into a dedicated **`docs-deploy.yml`** triggered only by `push: main`. Reduce **`docs-preview.yml`** to PR-preview deploy + cleanup (`pull_request` only). The two paths no longer share a trigger, so the production deploy always runs to completion on merge, and there's no cancelled run polluting `main`.

- `docs-deploy.yml`: build + `.nojekyll` ensure + `JamesIves/github-pages-deploy-action` (production). Concurrency group `docs-deploy-production`.
- `docs-preview.yml`: drops the `push: main` trigger and the production-deploy/`.nojekyll` steps; keeps `dorny/paths-filter` + `rossjrw/pr-preview-action` for preview deploy/cleanup.

## Notes

- Merging this PR touches `docs-deploy.yml` (in its own `paths` filter), so the merge will trigger the **first production deploy** — which also publishes the clean-URL build from #714 that's currently missing from production.
- `actionlint -shellcheck=""` passes locally on both files.