### PR TITLE
fix(cch): run seed scripts under native Node, file issues on failure

### DIFF
--- a/.github/workflows/cch-seed-check.yml
+++ b/.github/workflows/cch-seed-check.yml
@@ -47,7 +47,7 @@ jobs:
           else
             # check-cc-version.ts exits 1 if extraction is needed
             set +e
-            result=$(pnpm tsx scripts/check-cc-version.ts --json 2>&1)
+            result=$(node scripts/check-cc-version.ts --json 2>&1)
             exit_code=$?
             set -e
 
@@ -126,7 +126,7 @@ jobs:
             echo "========================================"
 
             OUTPUT="/tmp/seed-result-${VERSION}.json"
-            pnpm tsx scripts/extract-cch-seed.ts \
+            node scripts/extract-cch-seed.ts \
               --version "$VERSION" \
               --output "$OUTPUT"
 
@@ -139,10 +139,10 @@ jobs:
             # Apply: pin WORKER_VERSION only for the latest version
             if [ "$VERSION" = "$LATEST_VERSION" ]; then
               echo "Applying seed for $VERSION (pinning as WORKER_VERSION)..."
-              pnpm tsx scripts/extract-cch-seed.ts --apply "$VERSION" "$SEED"
+              node scripts/extract-cch-seed.ts --apply "$VERSION" "$SEED"
             else
               echo "Applying seed for $VERSION (backfill, no pin)..."
-              pnpm tsx scripts/extract-cch-seed.ts --apply --no-pin "$VERSION" "$SEED"
+              node scripts/extract-cch-seed.ts --apply --no-pin "$VERSION" "$SEED"
             fi
 
             EXTRACTED+=("$VERSION")
@@ -208,3 +208,44 @@ jobs:
           gh pr create \
             --title "feat(cch): add seeds for Claude Code up to ${LATEST_VERSION}" \
             --body-file /tmp/pr-body.md
+
+  notify-failure:
+    needs: [check-version, extract-seed]
+    if: always() && (needs.check-version.result == 'failure' || needs.extract-seed.result == 'failure')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: File failure issue (deduped)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          LATEST_VERSION: ${{ needs.check-version.outputs.latest-version }}
+          CHECK_RESULT: ${{ needs.check-version.result }}
+          EXTRACT_RESULT: ${{ needs.extract-seed.result }}
+        run: |
+          LABEL="cch-seed-check-failure"
+          VER="${LATEST_VERSION:-unknown}"
+          MARKER="<!-- cch-seed-check:${VER} -->"
+
+          # Dedupe: reuse an existing open issue carrying this exact marker so
+          # the 6-hourly schedule does not file a new issue on every failure.
+          # GitHub search ignores punctuation, so match the marker literally
+          # against each labelled open issue's body rather than via --search.
+          existing=$(gh issue list --state open --label "$LABEL" \
+            --json number,body \
+            --jq "map(select(.body | contains(\"$MARKER\"))) | .[0].number // empty")
+          if [ -n "$existing" ]; then
+            echo "Open issue #${existing} already tracks this failure; skipping."
+            exit 0
+          fi
+
+          # Ensure the label exists (ignore failure if already present).
+          gh label create "$LABEL" --color B60205 \
+            --description "Automated CCH seed extraction failures" 2>/dev/null || true
+
+          TITLE="CCH Seed Check failed${LATEST_VERSION:+ (v${LATEST_VERSION})}"
+          BODY=$(printf '%s\n\nThe scheduled **CCH Seed Check** workflow failed.\n\n- check-version: %s\n- extract-seed: %s\n- Run: %s\n\n_Auto-filed; deduped per latest version._' \
+            "$MARKER" "$CHECK_RESULT" "$EXTRACT_RESULT" "$RUN_URL")
+
+          gh issue create --title "$TITLE" --label "$LABEL" --body "$BODY"

--- a/packages/gateway/src/cch.ts
+++ b/packages/gateway/src/cch.ts
@@ -30,7 +30,7 @@
  */
 
 import { createHash, randomUUID } from "node:crypto";
-import { xxHash64 } from "./xxhash";
+import { xxHash64 } from "./xxhash.ts";
 
 // ---------------------------------------------------------------------------
 // Version→seed mapping

--- a/scripts/check-cc-version.ts
+++ b/scripts/check-cc-version.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env tsx
+#!/usr/bin/env node
 /**
  * Check if recent Claude Code versions have known cch seeds.
  *
@@ -23,7 +23,7 @@ import {
   VERSION_SEEDS,
   _parseSemver,
   _compareSemver,
-} from "../packages/gateway/src/cch";
+} from "../packages/gateway/src/cch.ts";
 
 const { values: args } = parseArgs({
   args: process.argv.slice(2),

--- a/scripts/extract-cch-seed.ts
+++ b/scripts/extract-cch-seed.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env tsx
+#!/usr/bin/env node
 /**
  * Extract the xxHash64 seed from a Claude Code binary.
  *
@@ -6,19 +6,23 @@
  * by running the binary against a local capture server, then scans the
  * binary for the seed that satisfies all oracle pairs.
  *
+ * Runs under Node.js (>= 22.5) via built-in TypeScript type-stripping — no
+ * bundler or `tsx` required. Relative imports use explicit `.ts` extensions
+ * because native Node does not resolve extensionless module specifiers.
+ *
  * Usage:
  *   # Fully automated — download + generate oracles + extract
- *   bun run scripts/extract-cch-seed.ts --version 2.1.138
+ *   node scripts/extract-cch-seed.ts --version 2.1.138
  *
  *   # Use a local binary — generate oracles + extract
- *   bun run scripts/extract-cch-seed.ts --binary ./claude
+ *   node scripts/extract-cch-seed.ts --binary ./claude
  *
  *   # Legacy mode — use pre-captured oracle pairs
- *   bun run scripts/extract-cch-seed.ts --version 2.1.138 --oracle pairs.json
- *   bun run scripts/extract-cch-seed.ts --binary ./claude --oracle pairs.json
+ *   node scripts/extract-cch-seed.ts --version 2.1.138 --oracle pairs.json
+ *   node scripts/extract-cch-seed.ts --binary ./claude --oracle pairs.json
  *
  *   # Apply extracted seed to cch.ts
- *   bun run scripts/extract-cch-seed.ts --apply 2.1.138 0x4D659218E32A3268
+ *   node scripts/extract-cch-seed.ts --apply 2.1.138 0x4D659218E32A3268
  *
  * Oracle pairs JSON format (for --oracle):
  *   [
@@ -41,11 +45,15 @@ import {
   readFileSync,
   existsSync,
   mkdirSync,
+  readdirSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
-import { execSync } from "node:child_process";
+import { execSync, spawn } from "node:child_process";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
 import { parseArgs } from "node:util";
+import { xxHash64 } from "../packages/gateway/src/xxhash.ts";
 
 // ---------------------------------------------------------------------------
 // CLI argument parsing
@@ -67,11 +75,11 @@ const { values: args, positionals } = parseArgs({
 
 if (args.help) {
   console.log(`Usage:
-  bun run scripts/extract-cch-seed.ts --version <VERSION>
-  bun run scripts/extract-cch-seed.ts --binary <path>
-  bun run scripts/extract-cch-seed.ts --version <VERSION> --oracle <pairs.json>
-  bun run scripts/extract-cch-seed.ts --apply <VERSION> <SEED_HEX>
-  bun run scripts/extract-cch-seed.ts --apply --no-pin <VERSION> <SEED_HEX>
+  node scripts/extract-cch-seed.ts --version <VERSION>
+  node scripts/extract-cch-seed.ts --binary <path>
+  node scripts/extract-cch-seed.ts --version <VERSION> --oracle <pairs.json>
+  node scripts/extract-cch-seed.ts --apply <VERSION> <SEED_HEX>
+  node scripts/extract-cch-seed.ts --apply --no-pin <VERSION> <SEED_HEX>
 
 Options:
   -v, --version   Claude Code version to download from npm (e.g. 2.1.138)
@@ -179,57 +187,64 @@ async function captureOnePair(
 ): Promise<OraclePair | null> {
   let captured: OraclePair | null = null;
 
-  const server = Bun.serve({
-    port: 0, // ephemeral port
-    async fetch(req) {
-      if (req.method === "HEAD") {
-        return new Response(null, { status: 200 });
-      }
+  const server = createServer(async (req, res) => {
+    if (req.method === "HEAD") {
+      res.writeHead(200);
+      res.end();
+      return;
+    }
 
-      const body = await req.text();
-      if (!captured) {
-        const cchMatch = body.match(/cch=([0-9a-f]{5})/);
-        if (cchMatch) {
-          const placeholder = body.replace(`cch=${cchMatch[1]}`, "cch=00000");
-          captured = { body: placeholder, cch: cchMatch[1] };
-        }
+    let body = "";
+    for await (const chunk of req) {
+      body += chunk;
+    }
+    if (!captured) {
+      const cchMatch = body.match(/cch=([0-9a-f]{5})/);
+      if (cchMatch) {
+        const placeholder = body.replace(`cch=${cchMatch[1]}`, "cch=00000");
+        captured = { body: placeholder, cch: cchMatch[1] };
       }
+    }
 
-      return Response.json(
-        {
-          type: "error",
-          error: {
-            type: "authentication_error",
-            message: "invalid x-api-key",
-          },
+    res.writeHead(401, { "content-type": "application/json" });
+    res.end(
+      JSON.stringify({
+        type: "error",
+        error: {
+          type: "authentication_error",
+          message: "invalid x-api-key",
         },
-        { status: 401 },
-      );
-    },
+      }),
+    );
   });
 
+  // Bind to an ephemeral port and read the assigned port back.
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const { port } = server.address() as AddressInfo;
+
   try {
-    const proc = Bun.spawn([binaryPath, "--print", "--bare", "-p", prompt], {
+    const proc = spawn(binaryPath, ["--print", "--bare", "-p", prompt], {
       env: {
         ...process.env,
         HOME: `${tmpDir}/home`,
         ANTHROPIC_API_KEY:
           "sk-ant-api03-fakekey1234567890abcdef1234567890abcdef1234567890abcdef",
-        ANTHROPIC_BASE_URL: `http://127.0.0.1:${server.port}`,
+        ANTHROPIC_BASE_URL: `http://127.0.0.1:${port}`,
         DISABLE_AUTOUPDATER: "1",
         DISABLE_UPDATES: "1",
       },
       cwd: `${tmpDir}/workdir`,
-      stdout: "ignore",
-      stderr: "ignore",
+      stdio: "ignore",
     });
 
     // Wait up to 15s for the binary to make its request
     const timeout = setTimeout(() => proc.kill(), 15_000);
-    await proc.exited;
+    await new Promise<void>((resolve) => proc.on("exit", () => resolve()));
     clearTimeout(timeout);
   } finally {
-    server.stop();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
   }
 
   return captured;
@@ -310,12 +325,10 @@ function obtainBinary(version?: string, binaryPath?: string): string {
   }
 
   // Find the tarball
-  const tgzGlob = new Bun.Glob("anthropic-ai-claude-code-*-*.tgz");
-  let tgzPath = "";
-  for (const file of tgzGlob.scanSync(tmpDir)) {
-    tgzPath = `${tmpDir}/${file}`;
-    break;
-  }
+  const tgz = readdirSync(tmpDir).find((f) =>
+    /^anthropic-ai-claude-code-.*-.*\.tgz$/.test(f),
+  );
+  const tgzPath = tgz ? `${tmpDir}/${tgz}` : "";
   if (!tgzPath) {
     console.error("Could not find downloaded tarball");
     process.exit(1);
@@ -356,7 +369,7 @@ function obtainBinary(version?: string, binaryPath?: string): string {
 
 function testCandidate(seed: bigint, pairs: OraclePair[]): boolean {
   for (const pair of pairs) {
-    const hash = Bun.hash.xxHash64(pair.body, seed);
+    const hash = xxHash64(pair.body, seed);
     const cch = (hash & 0xfffffn).toString(16).padStart(5, "0");
     if (cch !== pair.cch) return false;
   }
@@ -531,7 +544,7 @@ Add this to VERSION_SEEDS in packages/gateway/src/cch.ts:
 Then update WORKER_VERSION if pinning to this version.
 
 Or run:
-  bun run scripts/extract-cch-seed.ts --apply "${version}" "0x${hex}"
+  node scripts/extract-cch-seed.ts --apply "${version}" "0x${hex}"
 ================================================================================`);
 
     // Write JSON output if requested

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,6 +3,7 @@
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary

The **CCH Seed Check** scheduled workflow has been failing since the Bun → Node migration. `scripts/extract-cch-seed.ts` still used Bun-only globals, so under Node it crashed with `ReferenceError: Bun is not defined` (first hit: `Bun.Glob`). This ports the seed scripts fully to Node and ensures future failures are never silent.

## Changes

- **Remove all 4 Bun globals** from `scripts/extract-cch-seed.ts`:
  - `Bun.hash.xxHash64` → existing Node port `xxHash64` from `packages/gateway/src/xxhash.ts` (documented to match Bun's output)
  - `Bun.Glob` → `node:fs.readdirSync` + filter
  - `Bun.serve` → `node:http.createServer` (ephemeral port via `server.address()`)
  - `Bun.spawn` → `node:child_process.spawn`
- **Run seed scripts via native Node TS type-stripping** instead of `tsx` (`pnpm tsx` → `node` in the workflow). Native Node needs explicit `.ts` import extensions, so `check-cc-version.ts` and `cch.ts` imports get `.ts`, and `tsconfig.base.json` gains `allowImportingTsExtensions` (safe — all packages typecheck with `noEmit`).
- **File issues on failure**: new `notify-failure` job files a GitHub issue whenever the scheduled run fails, deduped per latest version via a hidden marker so the 6-hourly schedule reuses one open issue.

## Verification

- `pnpm run typecheck` — all packages pass
- `pnpm test packages/gateway` — 1468/1468 pass (incl. cch hash-parity)
- `pnpm --filter @loreai/gateway run bundle` — clean
- `node scripts/extract-cch-seed.ts --help` & `node scripts/check-cc-version.ts --json` — run natively, no tsx
- `actionlint -shellcheck=""` on the workflow — clean