### PR TITLE
fix(gateway): stop background-queue saturation (curation debounce + load-aware scaling)

### DIFF
--- a/packages/core/test/session-limiter.test.ts
+++ b/packages/core/test/session-limiter.test.ts
@@ -144,6 +144,41 @@ describe("session-limiter", () => {
     await pd;
   });
 
+  test("curation debounce: isBusy stays true across a queued duplicate (re-schedule guard)", async () => {
+    // Models the pipeline.ts curation guard: while a curation run is in-flight
+    // OR queued for a session, `!curatorLimiter.isBusy(sessionID)` must be false
+    // so subsequent turns do NOT re-schedule a duplicate. turnsSinceCuration is
+    // only reset after a real run completes, so the limiter is the durable
+    // dedup signal that prevents per-turn re-flooding of the background queue.
+    const sid = "curation-session";
+    expect(curatorLimiter.isBusy(sid)).toBe(false);
+
+    let resolveRun: (() => void) | undefined;
+    const runBlocker = new Promise<void>((r) => {
+      resolveRun = r;
+    });
+    const limiter = curatorLimiter.get(sid);
+
+    // First (real) curation starts and stays in-flight.
+    const first = limiter(async () => {
+      await runBlocker;
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(curatorLimiter.isBusy(sid)).toBe(true);
+
+    // A duplicate scheduled while busy would queue behind it — isBusy remains
+    // true, so the pipeline guard short-circuits and never schedules it.
+    const duplicate = limiter(async () => {
+      /* would be a wasted curation */
+    });
+    expect(curatorLimiter.isBusy(sid)).toBe(true);
+
+    resolveRun?.();
+    await Promise.all([first, duplicate]);
+    // Only once both drain does the session free up again.
+    expect(curatorLimiter.isBusy(sid)).toBe(false);
+  });
+
   test("clear removes all limiters", () => {
     distillLimiter.get("a");
     distillLimiter.get("b");

--- a/packages/gateway/src/background-limiter.ts
+++ b/packages/gateway/src/background-limiter.ts
@@ -40,11 +40,13 @@ const MIN_BACKGROUND_CONCURRENCY = 2;
 const MAX_BACKGROUND_CONCURRENCY = 12;
 
 /**
- * Background LLM ops allowed per active session (rounded up). Not every
- * session has pending background work simultaneously, so a fractional
- * factor keeps the cap proportional without over-provisioning. Tunable.
+ * Background LLM ops allowed per active session (rounded up). Heavy sessions
+ * (large contexts, every-turn incremental distillation + curation) produce
+ * more background work than the old 0.5 assumed, so the queue saturated and
+ * shed non-disposable hot-path work. 1.5 gives heavy sessions enough drain
+ * capacity while still clamping to MAX_BACKGROUND_CONCURRENCY. Tunable.
  */
-const CONCURRENCY_PER_SESSION = 0.5;
+const CONCURRENCY_PER_SESSION = 1.5;
 
 /**
  * Resolve the upper bound for background concurrency. `LORE_BACKGROUND_CONCURRENCY`
@@ -76,6 +78,13 @@ const MAX_PENDING_QUEUE = 50;
  * `pipeline.ts`, which submits unconditionally.
  */
 const LOW_PRIORITY_SHED_THRESHOLD = 0.5;
+
+/**
+ * Queue-pressure fraction (pending / MAX_PENDING_QUEUE) above which load-aware
+ * scaling overrides the session-count heuristic and scales toward MAX. Guards
+ * against under-provisioning when a few heavy sessions saturate the queue.
+ */
+const LOAD_BOOST_THRESHOLD = 0.5;
 
 const limiter = pLimit(MIN_BACKGROUND_CONCURRENCY);
 
@@ -293,15 +302,28 @@ export async function runBackground<T>(
  * naturally drains down to the lower cap when sessions go away.
  */
 export function scaleBackgroundConcurrency(activeSessions: number): void {
-  const want = Math.ceil(Math.max(0, activeSessions) * CONCURRENCY_PER_SESSION);
-  const next = Math.min(
-    Math.max(want, MIN_BACKGROUND_CONCURRENCY),
-    resolveMaxConcurrency(),
+  const max = resolveMaxConcurrency();
+  const bySessions = Math.ceil(
+    Math.max(0, activeSessions) * CONCURRENCY_PER_SESSION,
   );
+
+  // Load-aware boost: the per-session heuristic under-provisions when a few
+  // heavy sessions saturate the queue (each produces more background work than
+  // CONCURRENCY_PER_SESSION assumes). When pending depth crosses the threshold,
+  // scale toward MAX proportional to queue pressure so the backlog drains.
+  const queuePressure = limiter.pendingCount / MAX_PENDING_QUEUE;
+  const byLoad =
+    queuePressure >= LOAD_BOOST_THRESHOLD
+      ? Math.ceil(max * Math.min(queuePressure, 1))
+      : 0;
+
+  const want = Math.max(bySessions, byLoad);
+  const next = Math.min(Math.max(want, MIN_BACKGROUND_CONCURRENCY), max);
   if (limiter.concurrency !== next) {
     limiter.concurrency = next;
     log.info(
-      `background concurrency scaled to ${next} (active sessions=${activeSessions})`,
+      `background concurrency scaled to ${next} ` +
+        `(active sessions=${activeSessions}, pending=${limiter.pendingCount})`,
     );
   }
 }

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -36,6 +36,7 @@ import {
   computeLayer0Cap,
   setCachePricing,
   distillLimiter,
+  curatorLimiter,
   recordCacheUsage,
   calibrate,
   getLastTransformedCount,
@@ -3532,10 +3533,18 @@ function scheduleBackgroundWork(
     modelInputCost >= 5 ? 3 : modelInputCost >= 1 ? 2 : 1;
   const effectiveAfterTurns = cfg.curator.afterTurns * curationMultiplier;
 
+  // Coalesce: skip scheduling curation when one is already in-flight or queued
+  // for THIS session (curatorLimiter is per-session p-limit(1)). Without this,
+  // `turnsSinceCuration` stays at/above the threshold (it is only reset in the
+  // `.then()` after a run completes — see below), so every subsequent turn
+  // re-schedules curation, flooding the background queue with duplicates that
+  // are shed at queue-full. Mirrors the incremental-distill guard above and the
+  // idle-path guard in idle.ts.
   if (
     cfg.knowledge.enabled &&
     cfg.curator.onIdle &&
-    sessionState.turnsSinceCuration >= effectiveAfterTurns
+    sessionState.turnsSinceCuration >= effectiveAfterTurns &&
+    !curatorLimiter.isBusy(sessionID)
   ) {
     runBackground(
       () =>

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -3533,19 +3533,29 @@ function scheduleBackgroundWork(
     modelInputCost >= 5 ? 3 : modelInputCost >= 1 ? 2 : 1;
   const effectiveAfterTurns = cfg.curator.afterTurns * curationMultiplier;
 
-  // Coalesce: skip scheduling curation when one is already in-flight or queued
-  // for THIS session (curatorLimiter is per-session p-limit(1)). Without this,
-  // `turnsSinceCuration` stays at/above the threshold (it is only reset in the
-  // `.then()` after a run completes — see below), so every subsequent turn
-  // re-schedules curation, flooding the background queue with duplicates that
-  // are shed at queue-full. Mirrors the incremental-distill guard above and the
-  // idle-path guard in idle.ts.
+  // Coalesce: skip scheduling curation when one is already scheduled, queued,
+  // or in-flight for THIS session. Without this, `turnsSinceCuration` stays
+  // at/above the threshold (it is only reset in the `.then()` after a run
+  // completes — see below), so every subsequent turn re-schedules curation,
+  // flooding the background queue with duplicates that are shed at queue-full.
+  //
+  // Two signals are required:
+  //  - `curationScheduled` (synchronous): set BEFORE runBackground() and
+  //    cleared in .finally(). `curatorLimiter` is only entered when the task
+  //    actually executes inside curator.run(), so under a saturated global
+  //    queue `isBusy` stays false between scheduling and execution — this flag
+  //    closes that window deterministically.
+  //  - `curatorLimiter.isBusy` (durable across ticks): also covers the
+  //    idle-path curation (idle.ts) which doesn't set curationScheduled.
+  // Mirrors the incremental-distill guard above and the idle-path guard.
   if (
     cfg.knowledge.enabled &&
     cfg.curator.onIdle &&
     sessionState.turnsSinceCuration >= effectiveAfterTurns &&
+    !sessionState.curationScheduled &&
     !curatorLimiter.isBusy(sessionID)
   ) {
+    sessionState.curationScheduled = true;
     runBackground(
       () =>
         Sentry.startSpan(
@@ -3583,7 +3593,10 @@ function scheduleBackgroundWork(
           emitCurationMetrics({ ...result, trigger: "in-flight" });
         }
       })
-      .catch((e) => log.error("background curation failed:", e));
+      .catch((e) => log.error("background curation failed:", e))
+      .finally(() => {
+        sessionState.curationScheduled = false;
+      });
   }
 }
 

--- a/packages/gateway/src/translate/types.ts
+++ b/packages/gateway/src/translate/types.ts
@@ -406,6 +406,14 @@ export type SessionState = {
   messageCount: number;
   /** Turns since last curation run — triggers background curation. */
   turnsSinceCuration: number;
+  /** True while a background curation has been scheduled for this session but
+   *  has not yet entered curatorLimiter (i.e. still waiting in the global
+   *  background queue). `curatorLimiter.isBusy` only flips once the task
+   *  executes, so under a saturated global queue it stays false between
+   *  scheduling and execution — this synchronous flag closes that window so
+   *  subsequent turns don't re-schedule duplicate curations. Set before
+   *  runBackground(), cleared in its .finally(). Transient (not persisted). */
+  curationScheduled?: boolean;
   /** Stored recall results for marker-based round-trip expansion. */
   recallStore: RecallStore;
   /** Cache analytics — request body prefix comparison + API cache fields. */

--- a/packages/gateway/test/background-limiter.test.ts
+++ b/packages/gateway/test/background-limiter.test.ts
@@ -342,8 +342,8 @@ describe("background-limiter", () => {
       else process.env[ENV_KEY] = savedEnv;
     });
 
-    test("scales up with active session count (0.5 per session)", async () => {
-      scaleBackgroundConcurrency(8); // ceil(8 * 0.5) = 4
+    test("scales up with active session count (1.5 per session)", async () => {
+      scaleBackgroundConcurrency(2); // ceil(2 * 1.5) = 3
       // Run more tasks than the cap and observe max concurrency.
       let maxConcurrent = 0;
       let current = 0;
@@ -357,7 +357,7 @@ describe("background-limiter", () => {
       );
       await Promise.all(tasks);
       expect(maxConcurrent).toBeGreaterThan(2);
-      expect(maxConcurrent).toBeLessThanOrEqual(4);
+      expect(maxConcurrent).toBeLessThanOrEqual(3);
     });
 
     test("never drops below the minimum of 2", () => {
@@ -417,8 +417,8 @@ describe("background-limiter", () => {
     });
 
     test("scales back down when sessions go away", () => {
-      scaleBackgroundConcurrency(20); // up to 10
-      scaleBackgroundConcurrency(2); // back down to 2 (ceil(1) -> min 2)
+      scaleBackgroundConcurrency(20); // up to 12 (clamped)
+      scaleBackgroundConcurrency(1); // back down to 2 (ceil(1.5) -> 2)
       // Only 2 slots active now: third task queues.
       let resolve!: () => void;
       const blocker = new Promise<void>((r) => {
@@ -436,6 +436,34 @@ describe("background-limiter", () => {
           done();
         }, 10);
       });
+    });
+
+    test("load-aware: boosts toward MAX when queue saturated despite low session count", async () => {
+      // Pin concurrency low so submissions pile up in the queue.
+      _setConcurrencyForTest(2);
+      let resolve!: () => void;
+      const blocker = new Promise<void>((r) => {
+        resolve = r;
+      });
+      const active1 = runBackground(() => blocker);
+      const active2 = runBackground(() => blocker);
+
+      // 30 pending > LOAD_BOOST_THRESHOLD (0.5) * MAX_PENDING_QUEUE (50) = 25.
+      const queued: Promise<unknown>[] = [];
+      for (let i = 0; i < 30; i++) {
+        queued.push(runBackground(() => blocker, `q-${i}`));
+      }
+      await new Promise((r) => setTimeout(r, 10));
+      expect(backgroundLimiterStats().pendingCount).toBe(30);
+
+      // Session count alone would yield ceil(1 * 1.5) = 2, but queue pressure
+      // (30/50 = 0.6) boosts to ceil(12 * 0.6) = 8.
+      scaleBackgroundConcurrency(1);
+      await new Promise((r) => setTimeout(r, 10));
+      expect(backgroundLimiterStats().activeCount).toBeGreaterThan(2);
+
+      resolve();
+      await Promise.all([active1, active2, ...queued]);
     });
   });
 

--- a/packages/gateway/test/background-limiter.test.ts
+++ b/packages/gateway/test/background-limiter.test.ts
@@ -457,10 +457,11 @@ describe("background-limiter", () => {
       expect(backgroundLimiterStats().pendingCount).toBe(30);
 
       // Session count alone would yield ceil(1 * 1.5) = 2, but queue pressure
-      // (30/50 = 0.6) boosts to ceil(12 * 0.6) = 8.
+      // (30/50 = 0.6) boosts to ceil(12 * 0.6) = 8. p-limit resumes queued
+      // tasks immediately when concurrency is raised, so exactly 8 become active.
       scaleBackgroundConcurrency(1);
       await new Promise((r) => setTimeout(r, 10));
-      expect(backgroundLimiterStats().activeCount).toBeGreaterThan(2);
+      expect(backgroundLimiterStats().activeCount).toBe(8);
 
       resolve();
       await Promise.all([active1, active2, ...queued]);


### PR DESCRIPTION
## Problem

Production logs showed a constant flood of `background work skipped (queue full, 50 pending)` — ~7,000 over 4.5 days. Investigation traced it to **two independent issues**:

### 1. Producer-side: curation re-scheduled every turn (missing debounce)
`incremental-distill` is debounced with `if (!distillLimiter.isBusy(sessionID))` (`pipeline.ts`), and the idle path guards with `curatorLimiter.isBusy` (`idle.ts`). But the **in-flight-curation** scheduler in `pipeline.ts` had **no such guard** — its only gate was `turnsSinceCuration >= effectiveAfterTurns`.

`turnsSinceCuration` is reset to 0 only inside the `.then()` callback **after** a run completes. So while a curation task sat queued (or was shed at queue-full), the counter stayed above threshold and curation was **re-scheduled on every subsequent turn**, flooding the queue with duplicates (2,009 `in-flight-curation` skips).

### 2. Drain-side: under-provisioned concurrency
- `CONCURRENCY_PER_SESSION = 0.5` assumed light per-session load, but heavy sessions (one had 405 msgs / 299K tokens) trigger incremental-distill + curation every turn. Drain rate (2–3) was ~6.5× below production rate.
- `scaleBackgroundConcurrency` scaled **only** by session count, so a few heavy sessions pinned the queue at `MAX_PENDING_QUEUE = 50` while concurrency stayed at the floor of 2.

## Changes

- **`pipeline.ts` (producer guard)** — gate curation scheduling on **two** signals:
  - `!sessionState.curationScheduled` (synchronous flag, set before `runBackground()` and cleared in `.finally()`) — `curatorLimiter` is only entered when the task *executes* inside `curator.run()`, so under a saturated global queue `isBusy` stays false between scheduling and execution; this flag closes that window deterministically.
  - `!curatorLimiter.isBusy(sessionID)` — durable across ticks, and also covers the idle-path curation (which doesn't set the flag).
  A shed (queue-full) task still clears the flag, so retries are not blocked.
- **`background-limiter.ts` (drain)** — `CONCURRENCY_PER_SESSION` 0.5 → 1.5; add `LOAD_BOOST_THRESHOLD = 0.5` and make `scaleBackgroundConcurrency` load-aware (boost toward MAX when pending depth crosses the threshold; `resolveMaxConcurrency()` still caps the load path so `LORE_BACKGROUND_CONCURRENCY` is honored). Scaler log now includes `pending=N`.
- **Tests** — update existing scale assertions for the new factor; add a load-aware boost test pinning concurrency=8; add a curator-limiter debounce contract test (`session-limiter.test.ts`).

### Which fix does what
The drain-side change (1.5 + load boost) is what actually clears the backlog. The producer-side two-signal guard prevents the per-turn duplicate scheduling that *created* the backlog. Both are needed: without the producer guard, duplicates regenerate every turn; without the drain fix, even a single scheduled task can be shed under saturation.

## Verification

- `pnpm run typecheck` — zero errors (all 5 packages)
- `pnpm biome check` — clean
- Full suite: **2768 passed, 6 skipped, 0 failures** (110 files)

### Observing live (post-deploy)
Under multi-session load via `journalctl -u opencode -f`:
- `background concurrency scaled to N (active sessions=…, pending=…)` lines now appear
- `in-flight-curation` queue-full skips drop sharply
- Per-session undistilled-token counts trend down instead of climbing

## Out of scope
`idle.ts` imports `@sentry/bun` (violates the Node.js-only rule) — pre-existing, unrelated; flagged for separate cleanup.