### PR TITLE
fix(core): self-heal corrupt/truncated embedding model download

### DIFF
--- a/packages/core/src/embedding-worker-types.ts
+++ b/packages/core/src/embedding-worker-types.ts
@@ -138,14 +138,80 @@ export function isWasmFatalError(msg: string): boolean {
  * these are recoverable: deleting the cached file and re-downloading fixes them.
  * The worker uses this to self-heal a bad download instead of bricking embeddings
  * until the next manual intervention.
+ *
+ * IMPORTANT: this gates a destructive purge + re-download. A false positive on a
+ * transient *download* failure (401/403/404/network) would cause a
+ * purge→redownload→fail→purge loop that never converges and hammers the Hub. So
+ * we explicitly exclude auth/HTTP-status/network errors, and only treat an
+ * ONNX-side *parse/deserialize* failure of an already-downloaded file as corrupt
+ * (the "load model … failed" branch additionally requires a parse signal).
  */
 export function isCorruptModelError(msg: string): boolean {
+  // Exclude transient download/auth/network failures — these are NOT on-disk
+  // corruption and must not trigger a purge (would loop forever). Covers the
+  // real transformers.js download-failure strings ("Unauthorized access to
+  // file", "Could not locate file") and common network errors. HTTP status
+  // codes are matched only in an explicit status/error context to avoid hitting
+  // arbitrary 3-digit numbers in paths/sizes.
+  if (
+    /unauthorized|forbidden|access to file|could not (locate|find)|network|fetch failed|econnreset|etimedout|enotfound|en.*not.*found/i.test(
+      msg,
+    )
+  ) {
+    return false;
+  }
+  if (/\b(?:status|error|http)\b[^.]*\b(?:40[1349]|4\d\d|5\d\d)\b/i.test(msg)) {
+    return false;
+  }
   if (/protobuf parsing failed/i.test(msg)) return true;
-  if (/load model .* failed/i.test(msg)) return true;
-  if (/failed to load model|invalid model|corrupt/i.test(msg)) return true;
+  // ONNX "load model … failed" only counts as corruption when accompanied by a
+  // parse/deserialize signal — a bare "load model failed" can be a download/IO
+  // error, which the exclusion above already filters but we keep this tight.
+  if (/load model .*failed.*(protobuf|pars|deserial|modelproto)/i.test(msg))
+    return true;
+  if (/failed to load model .*(protobuf|pars|deserial|corrupt)/i.test(msg))
+    return true;
+  if (/invalid model|corrupt(ed)? model|model .*corrupt/i.test(msg))
+    return true;
   // ONNX deserialization errors surface as "ModelProto" / "deserialize" failures.
   if (/modelproto|deserializ/i.test(msg)) return true;
   return false;
+}
+
+/**
+ * Resolve the on-disk cache directory for a model, given transformers.js's
+ * `env.cacheDir` and the HF model id. transformers.js stores files at
+ * `<cacheDir>/<modelId>/<file>` (e.g.
+ * `<cacheDir>/nomic-ai/nomic-embed-text-v1.5/onnx/model_quantized.onnx`), so the
+ * model's directory is `<cacheDir>/<...modelId segments>`. Pure (no fs access)
+ * so it can be unit-tested; the worker passes the result to an `rm(recursive)`.
+ *
+ * Returns null when inputs are unusable (empty cacheDir/modelId), signalling the
+ * caller that there is nothing safe to purge.
+ */
+export function resolveModelCacheDir(
+  cacheDir: string | undefined | null,
+  modelId: string,
+): string | null {
+  if (!cacheDir || !modelId) return null;
+  const segments = modelId.split("/").filter((s) => s.length > 0);
+  if (segments.length === 0) return null;
+  const base = cacheDir.replace(/[/\\]+$/, "");
+  return `${base}/${segments.join("/")}`;
+}
+
+/**
+ * Decide whether a failed pipeline init should trigger the self-heal path
+ * (purge cached model + retry download once). Heal only when the model is NOT
+ * vendored (npm mode — re-downloadable) AND the error indicates on-disk
+ * corruption. Vendored binaries ship a read-only model that must not be deleted.
+ * Pure predicate, extracted for testability.
+ */
+export function shouldHealCorruptModel(
+  isVendored: boolean,
+  errorMessage: string,
+): boolean {
+  return !isVendored && isCorruptModelError(errorMessage);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/embedding-worker.ts
+++ b/packages/core/src/embedding-worker.ts
@@ -81,20 +81,49 @@ function isWasmFatalError(msg: string): boolean {
 }
 
 /**
- * Detect a corrupt / incomplete model file on disk. The most common cause is a
- * truncated HF Hub download (e.g. a 137MB ONNX model that only got 87MB written
- * before the connection dropped): the file header parses but the protobuf body
- * is incomplete, so ONNX reports "Protobuf parsing failed" / "Load model …
- * failed". These are recoverable by deleting the cached file and re-downloading,
- * unlike OOM or WASM aborts which are environmental.
+ * Detect a corrupt / incomplete model file on disk (truncated HF download →
+ * "Protobuf parsing failed"). Gates a destructive purge + re-download, so it
+ * MUST exclude transient download/auth/network failures (else a 401/network
+ * error loops purge→redownload→fail forever). Inlined copy of the canonical
+ * `isCorruptModelError` in embedding-worker-types.ts — keep in sync.
  */
 function isCorruptModelError(msg: string): boolean {
+  if (
+    /unauthorized|forbidden|access to file|could not (locate|find)|network|fetch failed|econnreset|etimedout|enotfound|en.*not.*found/i.test(
+      msg,
+    )
+  ) {
+    return false;
+  }
+  if (/\b(?:status|error|http)\b[^.]*\b(?:40[1349]|4\d\d|5\d\d)\b/i.test(msg)) {
+    return false;
+  }
   if (/protobuf parsing failed/i.test(msg)) return true;
-  if (/load model .* failed/i.test(msg)) return true;
-  if (/failed to load model|invalid model|corrupt/i.test(msg)) return true;
+  if (/load model .*failed.*(protobuf|pars|deserial|modelproto)/i.test(msg))
+    return true;
+  if (/failed to load model .*(protobuf|pars|deserial|corrupt)/i.test(msg))
+    return true;
+  if (/invalid model|corrupt(ed)? model|model .*corrupt/i.test(msg))
+    return true;
   // ONNX deserialization errors surface as "ModelProto" / "deserialize" failures.
   if (/modelproto|deserializ/i.test(msg)) return true;
   return false;
+}
+
+/**
+ * Resolve `<cacheDir>/<...modelId>` — the dir transformers.js caches a model in.
+ * Inlined copy of the canonical `resolveModelCacheDir` in
+ * embedding-worker-types.ts — keep in sync. Returns null when unusable.
+ */
+function resolveModelCacheDir(
+  cacheDir: string | undefined | null,
+  id: string,
+): string | null {
+  if (!cacheDir || !id) return null;
+  const segments = id.split("/").filter((s) => s.length > 0);
+  if (segments.length === 0) return null;
+  const base = cacheDir.replace(/[/\\]+$/, "");
+  return `${base}/${segments.join("/")}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -288,11 +317,9 @@ async function purgeCachedModel(): Promise<boolean> {
   try {
     const { env } = await import("@huggingface/transformers");
     const cacheDir = (env as { cacheDir?: string }).cacheDir;
-    if (!cacheDir) return false;
+    const modelDir = resolveModelCacheDir(cacheDir, modelId);
+    if (!modelDir) return false;
     const { rm, stat } = await import("node:fs/promises");
-    const { join } = await import("node:path");
-    // transformers.js resolves files at <cacheDir>/<modelId>/<file>.
-    const modelDir = join(cacheDir, ...modelId.split("/"));
     try {
       await stat(modelDir);
     } catch {

--- a/packages/core/test/embedding-worker-types.test.ts
+++ b/packages/core/test/embedding-worker-types.test.ts
@@ -3,23 +3,26 @@ import {
   isOomError,
   isWasmFatalError,
   isCorruptModelError,
+  resolveModelCacheDir,
+  shouldHealCorruptModel,
 } from "../src/embedding-worker-types";
 
 describe("isCorruptModelError", () => {
-  test("matches the real truncated-download error from ONNX", () => {
+  test("matches the real truncated-download error observed in production", () => {
     // The exact message observed when a 137MB model only downloaded ~87MB.
     const msg =
-      "Load model from /home/.../onnx/model_quantized.onnx failed:Protobuf parsing failed.";
+      "Load model from /home/byk/.../onnx/model_quantized.onnx failed:Protobuf parsing failed.";
     expect(isCorruptModelError(msg)).toBe(true);
   });
 
   test.each([
     "Protobuf parsing failed.",
     "protobuf parsing failed",
-    "Load model from foo.onnx failed: bad data",
-    "Failed to load model: unexpected EOF",
+    "Load model from foo.onnx failed: protobuf parsing error",
+    "Failed to load model: deserialization error",
     "invalid model file",
-    "model appears corrupt",
+    "corrupt model data",
+    "corrupted model",
     "Error deserializing ModelProto",
     "deserialization error",
   ])("classifies corrupt-model message: %s", (msg) => {
@@ -39,12 +42,83 @@ describe("isCorruptModelError", () => {
     expect(isCorruptModelError(msg)).toBe(false);
   });
 
-  test("is disjoint from OOM/WASM-fatal classification for OOM codes", () => {
+  // The critical false-positive class: transient download/auth/network failures
+  // must NOT be treated as on-disk corruption, or the worker would loop
+  // purge→redownload→fail forever. These are the real transformers.js / HF Hub
+  // download-failure strings.
+  test.each([
+    'Unauthorized access to file: "https://huggingface.co/..."',
+    'Could not locate file: "https://huggingface.co/.../model_quantized.onnx"',
+    "401 Unauthorized: failed to load model download",
+    "Failed to load model: 403 Forbidden",
+    "Could not load model nomic-ai/x: network request failed",
+    'Error (500) occurred while trying to load file: "..."',
+    "fetch failed",
+    "ETIMEDOUT while downloading model",
+    "ENOTFOUND huggingface.co",
+  ])("does NOT misclassify transient download failure: %s", (msg) => {
+    expect(isCorruptModelError(msg)).toBe(false);
+  });
+
+  test("is disjoint from OOM classification for OOM codes", () => {
     // An OOM numeric code must not be treated as a corrupt model (it would
     // trigger a pointless re-download instead of the correct fatal handling).
     const oom = "287180544";
     expect(isOomError(oom)).toBe(true);
     expect(isWasmFatalError(oom)).toBe(true);
     expect(isCorruptModelError(oom)).toBe(false);
+  });
+});
+
+describe("resolveModelCacheDir", () => {
+  test("resolves <cacheDir>/<modelId segments>", () => {
+    expect(
+      resolveModelCacheDir("/cache", "nomic-ai/nomic-embed-text-v1.5"),
+    ).toBe("/cache/nomic-ai/nomic-embed-text-v1.5");
+  });
+
+  test("strips trailing slashes from cacheDir", () => {
+    expect(resolveModelCacheDir("/cache/", "org/model")).toBe(
+      "/cache/org/model",
+    );
+    expect(resolveModelCacheDir("/cache//", "org/model")).toBe(
+      "/cache/org/model",
+    );
+  });
+
+  test("handles a single-segment model id", () => {
+    expect(resolveModelCacheDir("/cache", "model")).toBe("/cache/model");
+  });
+
+  test.each([
+    [null, "org/model"],
+    [undefined, "org/model"],
+    ["", "org/model"],
+    ["/cache", ""],
+    ["/cache", "/"],
+  ])("returns null for unusable input cacheDir=%s id=%s", (dir, id) => {
+    expect(resolveModelCacheDir(dir as string | null, id)).toBeNull();
+  });
+});
+
+describe("shouldHealCorruptModel", () => {
+  test("heals when not vendored and error is corruption", () => {
+    expect(shouldHealCorruptModel(false, "Protobuf parsing failed.")).toBe(
+      true,
+    );
+  });
+
+  test("does NOT heal a vendored binary even on corruption", () => {
+    // Vendored model is read-only / shipped in-binary — never delete/redownload.
+    expect(shouldHealCorruptModel(true, "Protobuf parsing failed.")).toBe(
+      false,
+    );
+  });
+
+  test("does NOT heal on a non-corruption error", () => {
+    expect(shouldHealCorruptModel(false, "out of memory")).toBe(false);
+    expect(
+      shouldHealCorruptModel(false, "401 Unauthorized: failed to load model"),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Problem

A dropped HuggingFace Hub download leaves a **truncated** ONNX model on disk — e.g. 87MB of an expected 137MB `model_quantized.onnx`. The file header parses but the protobuf body is incomplete, so onnxruntime reports `Protobuf parsing failed` / `Load model … failed`.

The embedding worker then sets `initFailed = true` **permanently** for the process and posts `init-error`, which the main thread treats as a permanent break (`localProviderKnownBroken = true`). Result: **local embeddings are bricked until manual cache cleanup**, even though the fix is just re-downloading the file. Observed live: backfill stopped with `provider unavailable`, coverage frozen at `knowledge 88/115, distillations 1097/1291`.

## Fix

Self-heal a corrupt/truncated download: when pipeline init fails with a corrupt-model error in **npm mode**, delete the cached model directory and retry the download **once**.

- **`isCorruptModelError(msg)`** — classifier (canonical in `embedding-worker-types.ts`, inlined byte-identical in the worker per the existing `isOomError`/`isWasmFatalError` pattern, since the spawned worker can't import `./*.ts`). Because it gates a **destructive purge + re-download**, it explicitly **excludes transient download/auth/network failures** (401/403/404/5xx, `Unauthorized access to file`, `Could not locate file`, `ECONNRESET`, `ETIMEDOUT`, `fetch failed`, …). Without this, a 401 whose message contains "load model"/"failed" would loop purge→redownload→401 forever. HTTP status codes are matched only in an explicit status/error context to avoid hitting arbitrary 3-digit numbers in paths. The "load model … failed" branch additionally requires a parse/deserialize signal.
- **`loadPipeline()`** — extracted from `ensurePipeline()` so it can be retried after a purge (idempotent: env re-assigned to same values; module import cached; `pipe` only left non-null on success).
- **`purgeCachedModel()`** — removes `<env.cacheDir>/<modelId>/` (full model dir → forces a complete re-download) and returns whether a retry is worthwhile.
- **`resolveModelCacheDir()` / `shouldHealCorruptModel()`** — pure helpers extracted into `embedding-worker-types.ts` so the path-resolution and heal-decision logic are unit-tested (the worker module itself can't be imported in tests).
- **Critical correctness detail:** the intermediate purge-and-retry uses `console.warn`, **not** `post({type:"init-error"})`. Posting `init-error` would prematurely mark the provider broken on the main thread even though the retry is about to succeed. Only a genuine final failure (the existing `.catch`) posts `init-error`.
- **Skipped for vendored binaries** — the model ships in the binary (read-only); re-downloading is inappropriate.

## Tests

`embedding-worker-types.test.ts` (39 cases):
- Corrupt-model positives incl. the **real** production message.
- OOM/WASM/`is not a function`/network-timeout negatives + OOM-disjointness.
- **Transient download/auth failure negatives** (`Unauthorized access to file`, `Could not locate file`, `401/403/500 … failed to load model`, `fetch failed`, `ETIMEDOUT`, `ENOTFOUND`) — locks in that these never trigger a purge loop.
- `resolveModelCacheDir` path/edge cases; `shouldHealCorruptModel` vendored-guard cases.

## Verification

- `pnpm --filter @loreai/core run typecheck` — clean
- `pnpm biome check` — clean
- Embedding suites: 87 passed, 6 skipped (model-dependent)
- Verified end-to-end on the affected host: removed the truncated 87MB file, re-downloaded the correct 137MB model (loads via onnxruntime), restarted, confirmed `embedded 27 knowledge entries`.

## Notes
Scope limited to the 3 embedding files; unrelated working-tree changes were excluded from this branch. Incorporates self-review hardening (auth/network exclusion + extracted testable helpers).