### PR TITLE
fix(gateway): stop system[2] cache busts from LTM re-ranking

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1049,6 +1049,15 @@ const MIGRATIONS: string[] = [
      AND project_id IS NOT NULL
      AND promotion_status IS NULL;
   `,
+  `
+  -- Version 39: Reorder-tolerant LTM diff-pin.
+  -- Stores the identity of the entry SET (and per-entry content hash) that the
+  -- pinned system[2] text was rendered from. The pin is reused verbatim when the
+  -- selected entry-ID set is identical (any order) and no entry's content
+  -- changed, eliminating cache busts from pure re-ranking. NULL for pre-v39 rows
+  -- (treated as "unknown set" → the first post-upgrade turn re-pins once).
+  ALTER TABLE session_state ADD COLUMN ltm_pin_keys TEXT;
+  `,
 ];
 
 /**
@@ -1350,6 +1359,10 @@ function recoverMissingObjects(database: Database) {
       database.exec(
         "ALTER TABLE session_state ADD COLUMN project_path_provisional INTEGER NOT NULL DEFAULT 1;",
       );
+    }
+    // Version 39: reorder-tolerant LTM diff-pin entry-set keys.
+    if (!scols.some((c) => c.name === "ltm_pin_keys")) {
+      database.exec("ALTER TABLE session_state ADD COLUMN ltm_pin_keys TEXT;");
     }
   }
 }
@@ -1983,6 +1996,8 @@ export type SessionTrackingState = {
   ltmCacheTokens?: number | null;
   ltmPinText?: string | null;
   ltmPinTokens?: number | null;
+  /** JSON array of sorted "id:hash(title+content)" keys for the pinned entry set (v39). */
+  ltmPinKeys?: string | null;
   // v24: session identity
   fingerprint?: string;
   headerSessionId?: string | null;
@@ -2060,6 +2075,10 @@ export function saveSessionTracking(
   if (state.ltmPinTokens !== undefined) {
     sets.push("ltm_pin_tokens = ?");
     vals.push(state.ltmPinTokens);
+  }
+  if (state.ltmPinKeys !== undefined) {
+    sets.push("ltm_pin_keys = ?");
+    vals.push(state.ltmPinKeys);
   }
   // v24: session identity
   if (state.fingerprint !== undefined) {
@@ -2152,6 +2171,8 @@ export type LoadedSessionTracking = {
   ltmCacheTokens: number | null;
   ltmPinText: string | null;
   ltmPinTokens: number | null;
+  // v39: reorder-tolerant pin entry-set keys (JSON)
+  ltmPinKeys: string | null;
   // v24: session identity
   fingerprint: string;
   headerSessionId: string | null;
@@ -2188,6 +2209,7 @@ export function loadSessionTracking(
       `SELECT last_curated_at, message_count, turns_since_curation,
               consecutive_text_only_turns,
               ltm_cache_text, ltm_cache_tokens, ltm_pin_text, ltm_pin_tokens,
+              ltm_pin_keys,
               fingerprint, header_session_id, header_name,
               resolved_conversation_ttl, warmup_state,
               dynamic_context_cap, bust_rate_ema, inter_bust_interval_ema,
@@ -2206,6 +2228,7 @@ export function loadSessionTracking(
     ltm_cache_tokens: number | null;
     ltm_pin_text: string | null;
     ltm_pin_tokens: number | null;
+    ltm_pin_keys: string | null;
     fingerprint: string;
     header_session_id: string | null;
     header_name: string | null;
@@ -2234,6 +2257,7 @@ export function loadSessionTracking(
     ltmCacheTokens: row.ltm_cache_tokens,
     ltmPinText: row.ltm_pin_text,
     ltmPinTokens: row.ltm_pin_tokens,
+    ltmPinKeys: row.ltm_pin_keys,
     fingerprint: row.fingerprint,
     headerSessionId: row.header_session_id,
     headerName: row.header_name,

--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -124,10 +124,26 @@ export function isFreeWriteSession(sessionID: string): boolean {
   );
 }
 
+/** Consecutive-bust count at/above which a session is in a "sustained-bust
+ *  regime": the prompt cache is being rewritten nearly every turn, so the
+ *  "continue" path is paying cache *write* cost — not the cheap read cost the
+ *  tier gate normally assumes. */
+const SUSTAINED_BUST_THRESHOLD = 5;
+
 /**
  * Decide whether compression is economical at a tier boundary.
  *
- * @param currentTokens   - expected input tokens if we stay at the current layer
+ * The core comparison is bustCost (write the compressed context once) vs
+ * continueCost (keep sending the full context each turn). Normally "continue"
+ * is a cheap cache *read*, so growing the context is fine. But when the session
+ * is in a sustained-bust regime (`consecutiveBusts >= SUSTAINED_BUST_THRESHOLD`),
+ * the full context is being *written* every turn anyway — so "continue" costs
+ * write, not read. In that regime we price continueCost at the write rate,
+ * which makes compression economical precisely when it's needed (growth-driven
+ * busts), instead of refusing to compress and letting the context grow
+ * unbounded.
+ *
+ * @param currentTokens    - expected input tokens if we stay at the current layer
  * @param compressedTokens - expected tokens after compression
  * @param consecutiveBusts - how many turns in a row we've busted the cache
  * @param opts.threshold   - bust cost must be < threshold × continue cost (default 0.85)
@@ -142,24 +158,39 @@ export function shouldCompress(
 ): boolean {
   const { threshold = 0.85, freeWrite = false } = opts ?? {};
 
-  // Rolling bust detection: if we've been busting 5+ turns in a row,
-  // stop trying to compress — it's clearly not helping.
-  // Applies even to free-write sessions to prevent compress→overflow loops.
-  if (consecutiveBusts >= 5) return false;
-
   // Free-write cache (or no cache): compression never incurs a write cost.
-  // Always compress at tier boundaries — there's no economic downside.
-  if (freeWrite) return true;
+  // Always compress at tier boundaries — there's no economic downside — EXCEPT
+  // after a sustained run of busts, where repeated free compression that keeps
+  // overflowing is just churn (compress→overflow loop). This guard applies to
+  // free-write sessions only; paid-cache sessions are handled by the
+  // write-cost repricing below (Fix C).
+  if (freeWrite) {
+    return consecutiveBusts < SUSTAINED_BUST_THRESHOLD;
+  }
 
   // If no pricing data, fall back to conservative: do NOT compress.
   // Compression busts the cache, which is expensive. Without pricing data
   // we can't prove it's worthwhile, so err on the side of keeping the cache.
   if (cacheWriteCostPerToken <= 0 || cacheReadCostPerToken <= 0) return false;
 
-  const bustCost = compressedTokens * cacheWriteCostPerToken;
-  const continueCost = currentTokens * cacheReadCostPerToken;
+  const sustainedBust = consecutiveBusts >= SUSTAINED_BUST_THRESHOLD;
 
-  // Compress only if the bust cost is meaningfully less than continuing
+  const bustCost = compressedTokens * cacheWriteCostPerToken;
+  // In a sustained-bust regime the "continue" path is paying cache *write*
+  // cost on the whole context every turn, not the cheap read cost. Price it
+  // accordingly so the gate reflects reality. Otherwise use the read rate.
+  const continuePerToken = sustainedBust
+    ? cacheWriteCostPerToken
+    : cacheReadCostPerToken;
+  const continueCost = currentTokens * continuePerToken;
+
+  // Compress only if the bust cost is meaningfully less than continuing.
+  // Note: we deliberately do NOT short-circuit to "never compress" on a high
+  // bust count anymore. Structural system[2] busts (the historical cause of
+  // runaway bust counts) are eliminated by the reorder-tolerant LTM pin, so a
+  // sustained bust now indicates raw-window growth — exactly the case where
+  // compressing (writing once) is cheaper than continuing to rewrite the whole
+  // grown context every turn.
   return bustCost < threshold * continueCost;
 }
 

--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -2025,7 +2025,9 @@ function transformInner(input: {
       distilledBudget,
       rawBudget,
       refreshLtm: false,
-      unsustainable: sid ? getSessionState(sid).consecutiveBusts >= 5 : false,
+      unsustainable: sid
+        ? getSessionState(sid).consecutiveBusts >= SUSTAINED_BUST_THRESHOLD
+        : false,
     };
   }
 
@@ -2180,7 +2182,9 @@ function transformInner(input: {
         distilledBudget,
         rawBudget,
         refreshLtm: false,
-        unsustainable: sid ? getSessionState(sid).consecutiveBusts >= 5 : false,
+        unsustainable: sid
+          ? getSessionState(sid).consecutiveBusts >= SUSTAINED_BUST_THRESHOLD
+          : false,
       };
     }
   }
@@ -2257,7 +2261,7 @@ function transformInner(input: {
   const nuclearRawTokens = olderTokens + currentTurnTokens;
 
   const unsustainable = sid
-    ? getSessionState(sid).consecutiveBusts >= 5
+    ? getSessionState(sid).consecutiveBusts >= SUSTAINED_BUST_THRESHOLD
     : false;
 
   return {

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -517,7 +517,27 @@ export type ForSessionOptions = {
    *  Mutually exclusive with `categories` — if both are provided,
    *  `categories` (include) wins. */
   excludeCategories?: (KnowledgeCategory | (string & {}))[];
+  /**
+   * IDs of entries that were selected on the PREVIOUS turn (the currently
+   * pinned system[2] set). These receive a relevance hysteresis bonus so they
+   * stay selected across turns unless a genuinely stronger entry displaces
+   * them or they are removed. Without this, vector scores re-computed against
+   * the evolving per-turn session context churn the budget-boundary subset
+   * every turn — each a real set change that busts the prompt cache. The bonus
+   * is multiplicative and modest, so a clearly more-relevant new entry still
+   * wins, but ties and minor fluctuations don't reshuffle the selected set.
+   */
+  stickyIds?: Set<string>;
 };
+
+/**
+ * Multiplicative relevance bonus applied to entries already selected on the
+ * previous turn (see ForSessionOptions.stickyIds). Tuned so a previously-shown
+ * entry keeps its slot against minor score fluctuations, but a new entry that
+ * scores >25% higher can still displace it — selection stays relevance-driven,
+ * just with anti-churn hysteresis.
+ */
+const STICKY_RELEVANCE_BONUS = 1.25;
 
 /**
  * Build a relevance-ranked, budget-capped list of knowledge entries for injection
@@ -760,6 +780,18 @@ export async function forSession(
   // the structural "map" that makes specific gotchas/decisions interpretable
   // — without them, a gotcha about a subsystem is harder to contextualize.
   const allScored = [...scoredProject, ...scoredCross];
+
+  // Set-stabilization hysteresis: boost entries that were selected last turn so
+  // the budget-boundary subset doesn't churn turn-to-turn (which would bust the
+  // system[2] prompt cache). Applied uniformly across all scoring paths. A new
+  // entry must out-score a sticky one by >(STICKY_RELEVANCE_BONUS-1) to displace
+  // it, so selection stays relevance-driven but resists minor fluctuations.
+  if (options?.stickyIds?.size) {
+    for (const s of allScored) {
+      if (options.stickyIds.has(s.entry.id)) s.score *= STICKY_RELEVANCE_BONUS;
+    }
+  }
+
   // Deterministic ordering: sort by score DESC, then by entry id ASC as a
   // stable tiebreak. Without the id tiebreak, equal/near-equal scores (or float
   // micro-variations from re-embedding the evolving session context) reorder

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -613,11 +613,12 @@ export async function forSession(
     }
 
     const allPrefs = [...blanketPrefs, ...relevantForeign];
-    allPrefs.sort((a, b) =>
-      a.confidence !== b.confidence
-        ? b.confidence - a.confidence
-        : b.updated_at - a.updated_at,
-    );
+    allPrefs.sort((a, b) => {
+      if (a.confidence !== b.confidence) return b.confidence - a.confidence;
+      if (a.updated_at !== b.updated_at) return b.updated_at - a.updated_at;
+      // Deterministic id tiebreak — keeps preference ordering byte-stable.
+      return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+    });
 
     const HEADER_OVERHEAD_TOKENS = 15;
     let used = HEADER_OVERHEAD_TOKENS;
@@ -759,7 +760,13 @@ export async function forSession(
   // the structural "map" that makes specific gotchas/decisions interpretable
   // — without them, a gotcha about a subsystem is harder to contextualize.
   const allScored = [...scoredProject, ...scoredCross];
-  allScored.sort((a, b) => b.score - a.score);
+  // Deterministic ordering: sort by score DESC, then by entry id ASC as a
+  // stable tiebreak. Without the id tiebreak, equal/near-equal scores (or float
+  // micro-variations from re-embedding the evolving session context) reorder
+  // turn-to-turn, which churns the rendered system[2] text and busts the cache.
+  allScored.sort((a, b) =>
+    b.score !== a.score ? b.score - a.score : a.entry.id < b.entry.id ? -1 : 1,
+  );
 
   const HEADER_OVERHEAD_TOKENS = 15;
   const ARCH_BUDGET_FRACTION = 0.2;
@@ -772,8 +779,11 @@ export async function forSession(
   const archEntries = allScored.filter(
     (s) => s.entry.category === "architecture",
   );
-  // Sort architecture by score descending (already sorted, but filter may reorder)
-  archEntries.sort((a, b) => b.score - a.score);
+  // Sort architecture by score descending (already sorted, but filter may
+  // reorder) with the same id tiebreak for deterministic selection.
+  archEntries.sort((a, b) =>
+    b.score !== a.score ? b.score - a.score : a.entry.id < b.entry.id ? -1 : 1,
+  );
   for (const { entry } of archEntries) {
     if (used >= archBudget + HEADER_OVERHEAD_TOKENS) break;
     const cost = estimateTokens(entry.title + entry.content) + 10;

--- a/packages/core/src/prompt.ts
+++ b/packages/core/src/prompt.ts
@@ -784,8 +784,21 @@ function estimateTokens(text: string): number {
 }
 
 export function formatKnowledge(
-  entries: Array<{ category: string; title: string; content: string }>,
+  entries: Array<{
+    category: string;
+    title: string;
+    content: string;
+    id?: string;
+  }>,
   maxTokens?: number,
+  /**
+   * Optional out-param: when provided, it is populated with the `id`s of the
+   * entries that were actually rendered (after budget packing). Callers that
+   * pin the rendered text (system[2] diff-pin) use this to compute a key set
+   * that exactly matches the rendered output, so re-ranking the same set never
+   * busts the cache while a genuine selection change always re-pins.
+   */
+  outIncludedIds?: string[],
 ): string {
   if (!entries.length) return "";
 
@@ -807,6 +820,12 @@ export function formatKnowledge(
     if (!included.length) return "";
   }
 
+  if (outIncludedIds) {
+    for (const e of included) {
+      if (e.id !== undefined) outIncludedIds.push(e.id);
+    }
+  }
+
   const grouped: Record<string, Array<{ title: string; content: string }>> = {};
   for (const e of included) {
     let group = grouped[e.category];
@@ -817,8 +836,16 @@ export function formatKnowledge(
     group.push(e);
   }
 
+  // Canonical layout: relevance ranking decides *selection* (which entries fit
+  // the budget above); the rendered *order* is fixed — categories alphabetically,
+  // entries alphabetically by title within each category. This makes the output
+  // byte-stable for a stable selected set, so re-ranking the same entries does
+  // not churn system[2] text and bust the prompt cache.
   const children: Root["children"] = [h(2, "Long-term Knowledge")];
-  for (const [category, items] of Object.entries(grouped)) {
+  const categories = Object.keys(grouped).sort();
+  for (const category of categories) {
+    const items = grouped[category];
+    items.sort((a, b) => (a.title < b.title ? -1 : a.title > b.title ? 1 : 0));
     children.push(h(3, category.charAt(0).toUpperCase() + category.slice(1)));
     children.push(
       ul(

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -50,7 +50,7 @@ describe("db", () => {
     const row = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(row.version).toBe(38);
+    expect(row.version).toBe(39);
   });
 
   test("entities table has embedding column (migration v34)", () => {
@@ -848,6 +848,13 @@ describe("db", () => {
     expect(names).toContain("consecutive_text_only_turns");
   });
 
+  test("session_state has ltm_pin_keys column (migration v39)", () => {
+    const cols = db().query("PRAGMA table_info(session_state)").all() as Array<{
+      name: string;
+    }>;
+    expect(cols.map((c) => c.name)).toContain("ltm_pin_keys");
+  });
+
   test("saveSessionTracking and loadSessionTracking round-trip", () => {
     const sid = `test-tracking-${crypto.randomUUID()}`;
     saveSessionTracking(sid, {
@@ -858,6 +865,7 @@ describe("db", () => {
       ltmCacheTokens: 100,
       ltmPinText: "pinned LTM text",
       ltmPinTokens: 90,
+      ltmPinKeys: JSON.stringify(["a:1", "b:2"]),
     });
     const loaded = loadSessionTracking(sid);
     expect(loaded).not.toBeNull();
@@ -868,6 +876,7 @@ describe("db", () => {
     expect(loaded?.ltmCacheTokens).toBe(100);
     expect(loaded?.ltmPinText).toBe("pinned LTM text");
     expect(loaded?.ltmPinTokens).toBe(90);
+    expect(loaded?.ltmPinKeys).toBe(JSON.stringify(["a:1", "b:2"]));
   });
 
   test("saveSessionTracking partial update preserves other fields", () => {

--- a/packages/core/test/gradient.test.ts
+++ b/packages/core/test/gradient.test.ts
@@ -3071,14 +3071,34 @@ describe("tier-based context management", () => {
       expect(shouldCompress(2_000_000, 100_000, 0)).toBe(true);
     });
 
-    test("does not compress after 5 consecutive busts", () => {
-      // Even when compression would be economical, stop after 5 busts
-      expect(shouldCompress(2_000_000, 100_000, 5)).toBe(false);
-      expect(shouldCompress(2_000_000, 100_000, 10)).toBe(false);
+    test("sustained bust prices continue at WRITE cost (compresses to stop growth)", () => {
+      // In a sustained-bust regime (>=5 busts) the "continue" path is paying
+      // cache WRITE cost on the whole context every turn, not the cheap read
+      // cost. So continueCost is priced with write:
+      //   continueCost = 2M × $6.25/M = $12.50
+      //   bustCost     = 100K × $6.25/M = $0.625
+      //   0.625 < 0.85 × 12.50 = 10.6 → compress (break the growth loop)
+      expect(shouldCompress(2_000_000, 100_000, 5)).toBe(true);
+      expect(shouldCompress(2_000_000, 100_000, 10)).toBe(true);
     });
 
-    test("compresses with 4 or fewer consecutive busts", () => {
+    test("sustained bust still refuses when compression isn't cheaper than rewriting", () => {
+      // When compressed size is close to current size, writing the compressed
+      // context is NOT cheaper than continuing — even at the write rate.
+      //   continueCost = 250K × $6.25/M = $1.5625
+      //   bustCost     = 240K × $6.25/M = $1.50
+      //   1.50 < 0.85 × 1.5625 = 1.328 → false (don't compress)
+      expect(shouldCompress(250_000, 240_000, 5)).toBe(false);
+    });
+
+    test("below the sustained-bust threshold uses the cheap read cost", () => {
+      // 4 busts → not sustained → continue priced at READ cost.
+      //   continueCost = 2M × $0.50/M = $1.00
+      //   bustCost     = 100K × $6.25/M = $0.625
+      //   0.625 < 0.85 × 1.00 = 0.85 → compress
       expect(shouldCompress(2_000_000, 100_000, 4)).toBe(true);
+      // A modestly-grown context at 0 busts: continue is cheap → don't compress.
+      expect(shouldCompress(250_000, 150_000, 0)).toBe(false);
     });
 
     test("falls back to conservative (do NOT compress) when no pricing", () => {

--- a/packages/core/test/ltm.test.ts
+++ b/packages/core/test/ltm.test.ts
@@ -436,6 +436,37 @@ describe("ltm.forSession", () => {
     expect(first.map((e) => e.id)).toEqual(second.map((e) => e.id));
   });
 
+  test("stickyIds keeps previously-selected entries when budget is tight (fix: set-stabilization)", async () => {
+    // 10 equal-confidence entries (~50 tokens each) but a budget that fits ~4.
+    // Which 4 get selected is otherwise score-order-dependent; with stickyIds,
+    // the previously-selected set is retained across turns.
+    const ids: string[] = [];
+    for (let i = 0; i < 10; i++) {
+      ids.push(
+        ltm.create({
+          projectPath: PROJ,
+          category: "pattern",
+          title: `Tight pattern ${i}`,
+          content: "B ".repeat(150),
+          scope: "project",
+          crossProject: false,
+        }),
+      );
+    }
+
+    const TIGHT = 250;
+    const firstSel = await ltm.forSession(PROJ, SESSION, TIGHT);
+    const firstIds = new Set(firstSel.map((e) => e.id));
+    expect(firstIds.size).toBeGreaterThan(0);
+    expect(firstIds.size).toBeLessThan(10);
+
+    // Next turn, pass the prior selection as stickyIds → identical set retained.
+    const secondSel = await ltm.forSession(PROJ, SESSION, TIGHT, {
+      stickyIds: firstIds,
+    });
+    expect(new Set(secondSel.map((e) => e.id))).toEqual(firstIds);
+  });
+
   test("respects token budget — stops adding entries when budget exhausted", async () => {
     // Create many project entries
     for (let i = 0; i < 10; i++) {

--- a/packages/core/test/ltm.test.ts
+++ b/packages/core/test/ltm.test.ts
@@ -415,6 +415,27 @@ describe("ltm.forSession", () => {
     expect(found?.cross_project).toBe(0);
   });
 
+  test("deterministic ordering — equal-score entries keep a stable order (fix B)", async () => {
+    // Many entries with identical confidence and no distinguishing session
+    // context → equal/near-equal scores. Without the id tiebreak these reorder
+    // turn-to-turn and churn system[2]. With it, two calls produce identical
+    // ordering, so the rendered set is byte-stable.
+    for (let i = 0; i < 8; i++) {
+      ltm.create({
+        projectPath: PROJ,
+        category: "pattern",
+        title: `Equal pattern ${i}`,
+        content: "Neutral content with no session-context keywords.",
+        scope: "project",
+        crossProject: false,
+      });
+    }
+
+    const first = await ltm.forSession(PROJ, SESSION, 10_000);
+    const second = await ltm.forSession(PROJ, SESSION, 10_000);
+    expect(first.map((e) => e.id)).toEqual(second.map((e) => e.id));
+  });
+
   test("respects token budget — stops adding entries when budget exhausted", async () => {
     // Create many project entries
     for (let i = 0; i < 10; i++) {

--- a/packages/core/test/markdown.test.ts
+++ b/packages/core/test/markdown.test.ts
@@ -235,6 +235,53 @@ describe("formatKnowledge", () => {
     // Both should produce the same number of items
     expect(countListItems(all)).toBe(countListItems(budgeted));
   });
+
+  test("canonical layout — output is byte-stable regardless of input order", () => {
+    const entries = [
+      { category: "gotcha", title: "Zeta gotcha", content: "z" },
+      { category: "decision", title: "Bravo decision", content: "b" },
+      { category: "decision", title: "Alpha decision", content: "a" },
+      { category: "pattern", title: "Mid pattern", content: "m" },
+    ];
+    const reversed = [...entries].reverse();
+    const shuffled = [entries[2], entries[0], entries[3], entries[1]];
+    const out = formatKnowledge(entries);
+    expect(formatKnowledge(reversed)).toBe(out);
+    expect(formatKnowledge(shuffled)).toBe(out);
+  });
+
+  test("canonical layout — categories alphabetical, titles alphabetical within", () => {
+    const out = formatKnowledge([
+      { category: "pattern", title: "Bravo", content: "b" },
+      { category: "decision", title: "Zeta", content: "z" },
+      { category: "decision", title: "Alpha", content: "a" },
+    ]);
+    // "Decision" section before "Pattern" section
+    expect(out.indexOf("### Decision")).toBeLessThan(
+      out.indexOf("### Pattern"),
+    );
+    // Within Decision: Alpha before Zeta
+    expect(out.indexOf("Alpha")).toBeLessThan(out.indexOf("Zeta"));
+  });
+
+  test("outIncludedIds reports rendered entry ids after budget packing", () => {
+    const included: string[] = [];
+    formatKnowledge(
+      [
+        { category: "pattern", title: "Small", content: "x", id: "s" },
+        {
+          category: "pattern",
+          title: "Huge",
+          content: "Y".repeat(10_000),
+          id: "h",
+        },
+      ],
+      200,
+      included,
+    );
+    expect(included).toContain("s");
+    expect(included).not.toContain("h");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -545,6 +545,22 @@ export function ltmEntryKeys(
     .sort();
 }
 
+/**
+ * Extract the entry-ID portion ("<id>" before the ":") from a sorted entry-key
+ * array. Used to feed the previous turn's selected set back into forSession()
+ * as a stability hint (stickyIds) so the budget-boundary selection doesn't
+ * churn turn-to-turn.
+ */
+export function entryKeyIds(keys: string[] | undefined): Set<string> {
+  const ids = new Set<string>();
+  if (!keys) return ids;
+  for (const k of keys) {
+    const idx = k.lastIndexOf(":");
+    ids.add(idx === -1 ? k : k.slice(0, idx));
+  }
+  return ids;
+}
+
 /** True when two sorted entry-key arrays are element-wise identical. */
 export function sameEntryKeys(
   a: string[] | undefined,
@@ -4737,6 +4753,13 @@ async function handleConversationTurn(
         if (!cached) {
           // Full context-bound budget — preferences have their own dedicated budget.
           const contextBudget = ltmBudget;
+          // Feed the previously-pinned entry set back in as a stability hint so
+          // per-turn relevance re-scoring doesn't churn the budget-boundary
+          // selection (which would bust the system[2] cache). New/removed/
+          // genuinely-more-relevant entries still change the set.
+          const stickyIds = entryKeyIds(
+            ltmPinnedText.get(sessionID)?.entryKeys,
+          );
           // Exclude preferences — they're already in system[1]
           const contextEntries = await ltm.forSession(
             projectPath,
@@ -4745,6 +4768,7 @@ async function handleConversationTurn(
             {
               excludeCategories: ["preference"],
               ...(contextHint ? { contextHint } : {}),
+              ...(stickyIds.size ? { stickyIds } : {}),
             },
           );
           if (contextEntries.length) {
@@ -4788,6 +4812,18 @@ async function handleConversationTurn(
             // Same entry set (or identical text) — keep the pinned text to
             // preserve the cache prefix. Zero bust on pure re-ranking.
             ltmText = pinned.formatted;
+            // Keep the session cache in lock-step with the pin so the persisted
+            // ltmCacheText never diverges from ltmPinText. Otherwise a restart
+            // would reload cache=freshText / pin=oldText, and the warm-cache
+            // byte-equality check would spuriously re-pin (one needless bust)
+            // and drop entryKeys. (Addresses review finding S1.)
+            if (cachedKeys && cached.formatted !== pinned.formatted) {
+              ltmSessionCache.set(sessionID, {
+                formatted: pinned.formatted,
+                tokenCount: pinned.tokenCount,
+              });
+              ltmDirty = true;
+            }
           } else {
             // Set changed, content changed, or first injection — pin the new
             // text along with its entry-key identity.
@@ -4877,6 +4913,9 @@ async function handleConversationTurn(
       const contextBudget = ltmBudget;
       const stableTokens = stableLtmCache.get(sessionID)?.tokenCount ?? 0;
       const contextHint = lastUserTextTrimmed(req);
+      // Stability hint: keep the previously-pinned set sticky so consecutive
+      // Layer-4 turns don't churn the selection (see step-6).
+      const stickyIds = entryKeyIds(ltmPinnedText.get(sessionID)?.entryKeys);
       const contextEntries = await ltm.forSession(
         projectPath,
         sessionID,
@@ -4884,6 +4923,7 @@ async function handleConversationTurn(
         {
           excludeCategories: ["preference"],
           ...(contextHint ? { contextHint } : {}),
+          ...(stickyIds.size ? { stickyIds } : {}),
         },
       );
       let refreshed = false;

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -490,14 +490,73 @@ const ltmSessionCache = new Map<
 
 /**
  * Pinned context-bound LTM text per session — the text currently being
- * injected as system[2]. When ltmSessionCache is invalidated and
- * recomputed, we compare the new text against the pin. Only update if
- * >5% character difference to avoid cache busts from minor re-ranking.
+ * injected as system[2]. When ltmSessionCache is invalidated and recomputed,
+ * we compare the *selected entry set* against the pin: if the set of entry IDs
+ * is identical (any order) and no entry's content changed, the pinned text is
+ * reused verbatim so the system[2] cache prefix stays warm. Re-pinning happens
+ * only when the selected set changes or an entry's content changes.
+ *
+ * `entryKeys` is the sorted array of `"<id>:<hash(title+content)>"` keys for
+ * the entries the pinned text was rendered from. `undefined` means the pin
+ * predates entry-key tracking (legacy/restored rows) — treated as "unknown
+ * set", which forces a one-time re-pin on the next turn.
  */
 const ltmPinnedText = new Map<
   string,
-  { formatted: string; tokenCount: number }
+  { formatted: string; tokenCount: number; entryKeys?: string[] }
 >();
+
+/**
+ * FNV-1a 32-bit hash of a string, returned as a short hex string. Used to
+ * detect per-entry content changes cheaply without storing full text. A
+ * collision would at worst suppress one legitimate re-pin (the curator's next
+ * content edit re-rolls the hash), so a 32-bit hash is acceptable here.
+ */
+export function fnv1a(s: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = (h + ((h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24))) >>> 0;
+  }
+  return h.toString(16);
+}
+
+/**
+ * Compute the sorted entry-key array for a set of context-bound LTM entries.
+ * Each key is `"<id>:<hash(title+content)>"`. Sorted so order is canonical:
+ * the same set of entries always produces the same key array regardless of
+ * ranking order, which is exactly the property the reorder-tolerant pin needs.
+ *
+ * When `renderedIds` is provided, only those entries (the ones that survived
+ * budget packing in formatKnowledge and are actually in the rendered text) are
+ * keyed — so the key set always matches the rendered string byte-for-byte.
+ */
+export function ltmEntryKeys(
+  entries: Array<{ id: string; title: string; content: string }>,
+  renderedIds?: Iterable<string>,
+): string[] {
+  let source = entries;
+  if (renderedIds) {
+    const allow = new Set(renderedIds);
+    source = entries.filter((e) => allow.has(e.id));
+  }
+  return source
+    .map((e) => `${e.id}:${fnv1a(`${e.title}\x1f${e.content}`)}`)
+    .sort();
+}
+
+/** True when two sorted entry-key arrays are element-wise identical. */
+export function sameEntryKeys(
+  a: string[] | undefined,
+  b: string[] | undefined,
+): boolean {
+  if (!a || !b) return false;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
 
 /**
  * Stable LTM (preference entries) + known entities per session — injected as
@@ -515,53 +574,6 @@ const stableLtmCache = new Map<
   string,
   { formatted: string; tokenCount: number }
 >();
-
-/**
- * Measure character-level difference between two strings as a ratio (0..1).
- * Samples characters at regular intervals across the full string length to
- * detect interior changes, not just prefix/suffix differences.
- *
- * For short strings (≤1000 chars) compares every character. For longer
- * strings samples up to 1000 evenly-spaced positions for O(1) cost.
- */
-function textDiffRatio(a: string, b: string): number {
-  if (a === b) return 0;
-  if (!a || !b) return 1;
-
-  const maxLen = Math.max(a.length, b.length);
-  const minLen = Math.min(a.length, b.length);
-
-  // Length difference accounts for part of the diff
-  const lengthDiff = maxLen - minLen;
-
-  // Sample up to 1000 positions across the overlapping region
-  const sampleCount = Math.min(minLen, 1000);
-  const step = sampleCount < minLen ? minLen / sampleCount : 1;
-  let mismatches = 0;
-  for (let i = 0; i < sampleCount; i++) {
-    const idx = Math.floor(i * step);
-    if (a[idx] !== b[idx]) mismatches++;
-  }
-
-  // Extrapolate mismatch rate to the full overlapping region + length diff
-  const mismatchRate = sampleCount > 0 ? mismatches / sampleCount : 0;
-  const estimatedMismatches = mismatchRate * minLen + lengthDiff;
-  return Math.min(1, estimatedMismatches / maxLen);
-}
-
-/**
- * Cost-aware diff threshold for LTM diff-pinning. More expensive models
- * tolerate larger diffs before busting the cache prefix, since each bust
- * costs more. Used by both step-6 (normal turn) and step-7b (Layer 4
- * refresh) to keep the threshold in sync.
- */
-function ltmDiffThreshold(inputCostPerMillion?: number): number {
-  const base = 0.05;
-  const cost = inputCostPerMillion ?? 3;
-  if (cost >= 5) return Math.min(base * 3, 0.2); // opus: 15%
-  if (cost >= 1) return Math.min(base * 2, 0.15); // sonnet: 10%
-  return base; // haiku: 5%
-}
 
 /** Cached LLM client for background workers. */
 let llmClient: LLMClient | null = null;
@@ -1522,9 +1534,24 @@ function getOrCreateSession(
       });
     }
     if (persisted?.ltmPinText != null && persisted.ltmPinTokens != null) {
+      let entryKeys: string[] | undefined;
+      if (persisted.ltmPinKeys != null) {
+        try {
+          const parsed = JSON.parse(persisted.ltmPinKeys);
+          if (
+            Array.isArray(parsed) &&
+            parsed.every((k) => typeof k === "string")
+          ) {
+            entryKeys = parsed;
+          }
+        } catch {
+          // Corrupt pin keys — leave undefined so the next turn re-pins once.
+        }
+      }
       ltmPinnedText.set(sessionID, {
         formatted: persisted.ltmPinText,
         tokenCount: persisted.ltmPinTokens,
+        ...(entryKeys ? { entryKeys } : {}),
       });
     }
     sessions.set(sessionID, state);
@@ -4700,6 +4727,12 @@ async function handleConversationTurn(
       // scoring. On turn 1, only stable LTM (preferences) is injected.
       if (!isFirstTurn) {
         let cached = ltmSessionCache.get(sessionID);
+        // Entry-set keys for the *freshly computed* selection. Only populated
+        // on the recompute path (when ltmSessionCache was cold/invalidated) —
+        // that's the only path where re-ranking can churn the text. On the
+        // warm-cache path the text is unchanged, so byte equality with the pin
+        // suffices and keys aren't needed.
+        let cachedKeys: string[] | undefined;
 
         if (!cached) {
           // Full context-bound budget — preferences have their own dedicated budget.
@@ -4715,17 +4748,21 @@ async function handleConversationTurn(
             },
           );
           if (contextEntries.length) {
+            const renderedIds: string[] = [];
             const formatted = formatKnowledge(
               contextEntries.map((e) => ({
                 category: e.category,
                 title: e.title,
                 content: e.content,
+                id: e.id,
               })),
               contextBudget,
+              renderedIds,
             );
             if (formatted) {
               const tokenCount = Math.ceil(formatted.length / 3);
               cached = { formatted, tokenCount };
+              cachedKeys = ltmEntryKeys(contextEntries, renderedIds);
               ltmSessionCache.set(sessionID, cached);
               ltmDirty = true;
             }
@@ -4733,23 +4770,31 @@ async function handleConversationTurn(
         }
 
         if (cached) {
-          // Content-diff pinning: only update the injected LTM text if the
-          // new content differs by more than a threshold from what's currently
-          // pinned. This prevents cache busts from minor re-ranking after
-          // background curation/consolidation invalidates the LTM cache.
+          // Reorder-tolerant diff-pinning: reuse the pinned system[2] text
+          // whenever the *selected entry set* is unchanged (same entry IDs,
+          // any order; same per-entry content). Pure re-ranking by
+          // forSession() must never bust the cache. Re-pin only when the
+          // selected set changes, an entry's content changed (curator update),
+          // or there is no pin yet. See ltmPinnedText docs.
           const pinned = ltmPinnedText.get(sessionID);
-          if (
-            pinned &&
-            textDiffRatio(pinned.formatted, cached.formatted) <
-              ltmDiffThreshold(modelSpec.inputCostPerMillion)
-          ) {
-            // Near-identical — keep the pinned text to preserve cache prefix
+          const setUnchanged = cachedKeys
+            ? // Recompute path: compare entry-key sets.
+              sameEntryKeys(pinned?.entryKeys, cachedKeys)
+            : // Warm-cache path (no fresh entries): the text didn't change, so
+              // byte equality against the pin is sufficient.
+              pinned != null && pinned.formatted === cached.formatted;
+
+          if (pinned && setUnchanged) {
+            // Same entry set (or identical text) — keep the pinned text to
+            // preserve the cache prefix. Zero bust on pure re-ranking.
             ltmText = pinned.formatted;
           } else {
-            // Substantially different or first injection — pin the new text
-            ltmPinnedText.set(sessionID, cached);
+            // Set changed, content changed, or first injection — pin the new
+            // text along with its entry-key identity.
+            const newPin = { ...cached, entryKeys: cachedKeys };
+            ltmPinnedText.set(sessionID, newPin);
             pinDirty = true;
-            ltmText = cached.formatted;
+            ltmText = newPin.formatted;
           }
         }
       }
@@ -4781,7 +4826,13 @@ async function handleConversationTurn(
             }
           : {}),
         ...(pinDirty && pinned
-          ? { ltmPinText: pinned.formatted, ltmPinTokens: pinned.tokenCount }
+          ? {
+              ltmPinText: pinned.formatted,
+              ltmPinTokens: pinned.tokenCount,
+              ltmPinKeys: pinned.entryKeys
+                ? JSON.stringify(pinned.entryKeys)
+                : null,
+            }
           : {}),
       });
     }
@@ -4838,43 +4889,43 @@ async function handleConversationTurn(
       let refreshed = false;
 
       if (contextEntries.length) {
+        const renderedIds: string[] = [];
         const formatted = formatKnowledge(
           contextEntries.map((e) => ({
             category: e.category,
             title: e.title,
             content: e.content,
+            id: e.id,
           })),
           contextBudget,
+          renderedIds,
         );
 
         if (formatted) {
           const tokenCount = Math.ceil(formatted.length / 3);
+          const entryKeys = ltmEntryKeys(contextEntries, renderedIds);
           // Always update the cache with freshly ranked entries.
           ltmSessionCache.delete(sessionID);
           ltmSessionCache.set(sessionID, { formatted, tokenCount });
 
-          // Apply diff-pinning: on consecutive Layer 4 turns, system[2]
-          // stability matters because system[0]+[1] ARE still cache reads
-          // at 1h TTL. Only update the pin if the new text differs
-          // substantially — same threshold as step 6.
+          // Reorder-tolerant diff-pinning: on consecutive Layer 4 turns,
+          // system[2] stability matters because system[0]+[1] ARE still cache
+          // reads at 1h TTL. Reuse the pin whenever the selected entry set is
+          // unchanged (same IDs + content, any order) — same policy as step 6.
           const pinned = ltmPinnedText.get(sessionID);
 
-          if (
-            pinned &&
-            textDiffRatio(pinned.formatted, formatted) <
-              ltmDiffThreshold(modelSpec.inputCostPerMillion)
-          ) {
-            // Near-identical — keep the pinned text to preserve cache prefix
+          if (pinned && sameEntryKeys(pinned.entryKeys, entryKeys)) {
+            // Same entry set — keep the pinned text to preserve cache prefix
             ltmText = pinned.formatted;
             setLtmTokens(stableTokens + pinned.tokenCount, sessionID);
             saveSessionTracking(sessionID, {
               ltmCacheText: formatted,
               ltmCacheTokens: tokenCount,
-              // pin unchanged — don't write ltmPinText/ltmPinTokens
+              // pin unchanged — don't write ltmPinText/ltmPinTokens/ltmPinKeys
             });
           } else {
-            // Substantially different or first Layer 4 turn — pin the new text
-            ltmPinnedText.set(sessionID, { formatted, tokenCount });
+            // Set changed or first Layer 4 turn — pin the new text + identity
+            ltmPinnedText.set(sessionID, { formatted, tokenCount, entryKeys });
             ltmText = formatted;
             setLtmTokens(stableTokens + tokenCount, sessionID);
             saveSessionTracking(sessionID, {
@@ -4882,6 +4933,7 @@ async function handleConversationTurn(
               ltmCacheTokens: tokenCount,
               ltmPinText: formatted,
               ltmPinTokens: tokenCount,
+              ltmPinKeys: JSON.stringify(entryKeys),
             });
           }
           refreshed = true;
@@ -4904,6 +4956,7 @@ async function handleConversationTurn(
           ltmCacheTokens: null,
           ltmPinText: null,
           ltmPinTokens: null,
+          ltmPinKeys: null,
         });
         log.info(
           "Context-bound LTM cleared on emergency layer (Layer 4) — stable LTM preserved for session",

--- a/packages/gateway/test/ltm-pin.test.ts
+++ b/packages/gateway/test/ltm-pin.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Unit tests for the reorder-tolerant LTM diff-pin (system[2] cache stability).
+ *
+ * The pin reuses its rendered text verbatim whenever the *selected entry set*
+ * is unchanged (same entry IDs, any order, same per-entry content), and re-pins
+ * only when the set changes or an entry's content changes. This eliminates the
+ * cache busts that the old positional `textDiffRatio` metric produced on pure
+ * re-ranking. See packages/gateway/src/pipeline.ts.
+ */
+import { describe, test, expect } from "vitest";
+import { fnv1a, ltmEntryKeys, sameEntryKeys } from "../src/pipeline";
+
+type Entry = { id: string; title: string; content: string };
+
+const A: Entry = { id: "a", title: "Alpha", content: "first" };
+const B: Entry = { id: "b", title: "Bravo", content: "second" };
+const C: Entry = { id: "c", title: "Charlie", content: "third" };
+
+/**
+ * Mirror the pin decision made in pipeline.ts step-6: given the previously
+ * pinned key set and the freshly computed entries, decide whether the pin is
+ * reused (no bust) or re-pinned (bust).
+ */
+function decide(
+  pinnedKeys: string[] | undefined,
+  entries: Entry[],
+  renderedIds?: string[],
+): { rePin: boolean; keys: string[] } {
+  const keys = ltmEntryKeys(entries, renderedIds);
+  const setUnchanged = sameEntryKeys(pinnedKeys, keys);
+  return { rePin: !(pinnedKeys && setUnchanged), keys };
+}
+
+describe("fnv1a", () => {
+  test("is deterministic and content-sensitive", () => {
+    expect(fnv1a("hello")).toBe(fnv1a("hello"));
+    expect(fnv1a("hello")).not.toBe(fnv1a("world"));
+  });
+});
+
+describe("ltmEntryKeys", () => {
+  test("is order-independent (canonical sorted output)", () => {
+    expect(ltmEntryKeys([A, B, C])).toEqual(ltmEntryKeys([C, A, B]));
+  });
+
+  test("changes when an entry's content changes", () => {
+    const before = ltmEntryKeys([A, B]);
+    const after = ltmEntryKeys([{ ...A, content: "edited" }, B]);
+    expect(before).not.toEqual(after);
+  });
+
+  test("changes when the selected set changes", () => {
+    expect(ltmEntryKeys([A, B])).not.toEqual(ltmEntryKeys([A, B, C]));
+  });
+
+  test("restricts keys to rendered ids when provided", () => {
+    // B was dropped by budget packing — only a and c rendered.
+    expect(ltmEntryKeys([A, B, C], ["a", "c"])).toEqual(ltmEntryKeys([A, C]));
+  });
+});
+
+describe("reorder-tolerant pin decision", () => {
+  test("same entry set in a different order → pin reused (no re-pin)", () => {
+    const first = decide(undefined, [A, B, C]); // first injection always pins
+    expect(first.rePin).toBe(true);
+
+    const reordered = decide(first.keys, [C, B, A]);
+    expect(reordered.rePin).toBe(false);
+  });
+
+  test("one entry's content changed → re-pin", () => {
+    const first = decide(undefined, [A, B, C]);
+    const edited = decide(first.keys, [
+      A,
+      { ...B, content: "curator updated this" },
+      C,
+    ]);
+    expect(edited.rePin).toBe(true);
+  });
+
+  test("selected set changes (entry added) → re-pin", () => {
+    const first = decide(undefined, [A, B]);
+    const grown = decide(first.keys, [A, B, C]);
+    expect(grown.rePin).toBe(true);
+  });
+
+  test("selected set changes (entry removed) → re-pin", () => {
+    const first = decide(undefined, [A, B, C]);
+    const shrunk = decide(first.keys, [A, B]);
+    expect(shrunk.rePin).toBe(true);
+  });
+
+  test("legacy pin with unknown keys → re-pin once", () => {
+    // A restored pin without entryKeys is treated as unknown set.
+    const decision = decide(undefined, [A, B]);
+    expect(decision.rePin).toBe(true);
+  });
+
+  test("reorder that drops the same entry by budget → still reused", () => {
+    // Turn 1: a,b,c selected but only a,c fit the budget.
+    const first = decide(undefined, [A, B, C], ["a", "c"]);
+    // Turn 2: re-ranked to c,a,b but again only a,c fit — same rendered set.
+    const next = decide(first.keys, [C, A, B], ["a", "c"]);
+    expect(next.rePin).toBe(false);
+  });
+});

--- a/packages/gateway/test/ltm-pin.test.ts
+++ b/packages/gateway/test/ltm-pin.test.ts
@@ -8,7 +8,12 @@
  * re-ranking. See packages/gateway/src/pipeline.ts.
  */
 import { describe, test, expect } from "vitest";
-import { fnv1a, ltmEntryKeys, sameEntryKeys } from "../src/pipeline";
+import {
+  entryKeyIds,
+  fnv1a,
+  ltmEntryKeys,
+  sameEntryKeys,
+} from "../src/pipeline";
 
 type Entry = { id: string; title: string; content: string };
 
@@ -56,6 +61,25 @@ describe("ltmEntryKeys", () => {
   test("restricts keys to rendered ids when provided", () => {
     // B was dropped by budget packing — only a and c rendered.
     expect(ltmEntryKeys([A, B, C], ["a", "c"])).toEqual(ltmEntryKeys([A, C]));
+  });
+});
+
+describe("entryKeyIds", () => {
+  test("extracts the id portion from entry keys (sticky-set hint)", () => {
+    const keys = ltmEntryKeys([A, B, C]); // "<id>:<hash>" sorted
+    expect(entryKeyIds(keys)).toEqual(new Set(["a", "b", "c"]));
+  });
+
+  test("returns empty set for undefined", () => {
+    expect(entryKeyIds(undefined)).toEqual(new Set());
+  });
+
+  test("handles ids containing no colon defensively", () => {
+    expect(entryKeyIds(["plainid"])).toEqual(new Set(["plainid"]));
+  });
+
+  test("uses last colon so UUID-with-colon ids survive (hash is last segment)", () => {
+    expect(entryKeyIds(["a:b:c:deadbeef"])).toEqual(new Set(["a:b:c"]));
   });
 });
 


### PR DESCRIPTION
## Problem

The context-bound LTM block (`system[2]`) re-ranked and rewrote its text on nearly every turn, busting the Anthropic prompt cache. Because `system[2]` sits before the entire conversation, any change invalidated the whole downstream cache. This also triggered a compounding tier-gate feedback loop that grew the context unbounded.

Observed in `lore.log` as recurring `divergence="system[2].text"` with reason `"context-bound LTM changed (non-preference entries re-ranked)"`, hit rate collapsing to ~5%, body growing past 2MB.

## Root cause (two layers)

1. **`textDiffRatio()` measured positional difference, not set difference** — any reorder read as a large diff, so the diff-pin re-pinned (busted) on every re-rank.
2. **The selected entry SET churns every turn.** `forSession()` scores entries by vector similarity against the evolving per-turn session context (latest distillation + last 10 messages). When a project's entries exceed the LTM budget (e.g. 22 entries / ~4400 tok vs a ~3400 tok budget), a *different subset* crosses the budget boundary each turn — a genuine set change, not just a reorder. Verified against live data: the set, not the order, was changing.
3. **The tier gate priced "continue" as a cheap cache read** even while `system[2]` busts forced full cache writes, so it refused to compress and the context grew unbounded.

## Fix

**A. Reorder-tolerant LTM diff-pin** (`pipeline.ts`). Replace the positional `textDiffRatio`/`ltmDiffThreshold` metric with an exact entry-set match keyed by `id + fnv1a(title+content)`: reuse the pinned `system[2]` text verbatim when the selected entry IDs and content hashes are unchanged (any order); re-pin only on set/content change. Keys are computed from the entries actually rendered (via `formatKnowledge`'s `outIncludedIds`). Persisted via new `ltm_pin_keys` column (migration v39).

**B. Stabilize ordering** (`ltm.ts`, `prompt.ts`). Deterministic `id` tiebreak in all ranking sorts; canonical alphabetical layout in `formatKnowledge` so a stable set yields byte-stable text.

**B2. Stabilize the selected SET** (`ltm.ts`) — the key fix for the live busts. `forSession()` accepts `stickyIds` (the previously-pinned set) and applies a multiplicative relevance hysteresis bonus (`STICKY_RELEVANCE_BONUS = 1.25`). Previously-selected entries keep their slot against minor per-turn score fluctuations; a new entry scoring >25% higher still displaces them. The gateway threads the current pin's IDs into the step-6 and Layer-4 `forSession` calls. Without this, the budget-boundary subset churns every turn and Fix A correctly (but unhelpfully) re-pins each time.

**C. Break the tier-gate feedback loop** (`gradient.ts`). In a sustained-bust regime (`consecutiveBusts >= SUSTAINED_BUST_THRESHOLD`), price `shouldCompress()`'s `continueCost` at the cache *write* rate so compression becomes economical when needed; drop the blanket `>=5` no-compress short-circuit for paid-cache sessions (kept for free-write).

## Review follow-ups addressed
- **S1**: on recompute-reuse, keep `ltmSessionCache` in lock-step with the pin so persisted `ltmCacheText` never diverges from `ltmPinText` (prevents a spurious re-pin + `entryKeys` loss on restart).
- **S2**: replace hardcoded `>= 5` literals with `SUSTAINED_BUST_THRESHOLD`.

## Tests
- `packages/gateway/test/ltm-pin.test.ts`: reorder→reuse, content/set change→re-pin, budget-drop alignment, `entryKeyIds` extraction.
- `ltm.test.ts`: `forSession` determinism + `stickyIds` set retention under a tight budget.
- `markdown.test.ts`: canonical layout byte-stability + `outIncludedIds`.
- `gradient.test.ts`: sustained-bust write-cost repricing; free-write guard preserved.
- `db.test.ts`: schema v39 + `ltm_pin_keys` round-trip.

All touched-area tests green; typecheck + biome clean.