### PR TITLE
fix(recall): prevent off-topic cross-session archives from derailing new sessions

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -479,8 +479,25 @@ export const LoreConfig = z.object({
             .max(30)
             .default(15)
             .describe("Max results to show in recall output. Default: 15."),
+          /** Absolute (not relative) RRF score floor. Results below this are
+           *  dropped even when they are the top result and even by the
+           *  "keep at least 3" backfill. Prevents weak cross-session archives
+           *  from being injected when nothing is genuinely relevant. Default:
+           *  0 (disabled). */
+          absoluteFloor: z
+            .number()
+            .min(0)
+            .default(0)
+            .describe(
+              "Absolute RRF score floor; drops weak matches even via the keep-3 backfill. Default: 0 (disabled).",
+            ),
         })
-        .default({ charBudget: 12000, relevanceFloor: 0.15, maxResults: 15 })
+        .default({
+          charBudget: 12000,
+          relevanceFloor: 0.15,
+          maxResults: 15,
+          absoluteFloor: 0,
+        })
         .describe("Recall output formatting and result-count limits."),
     })
     .default({
@@ -496,7 +513,12 @@ export const LoreConfig = z.object({
         model: "nomic-ai/nomic-embed-text-v1.5",
         dimensions: 768,
       },
-      recall: { charBudget: 12000, relevanceFloor: 0.15, maxResults: 15 },
+      recall: {
+        charBudget: 12000,
+        relevanceFloor: 0.15,
+        maxResults: 15,
+        absoluteFloor: 0,
+      },
     })
     .describe(
       "Recall and search pipeline tuning: FTS weights, query expansion, vector boost, embeddings, and output formatting.",

--- a/packages/core/src/recall.ts
+++ b/packages/core/src/recall.ts
@@ -95,6 +95,15 @@ export type TaggedResult =
 
 export type ScoredTaggedResult = { item: TaggedResult; score: number };
 
+/**
+ * Multiplier applied to the fused score of raw/archived history (`temporal`
+ * and `distillation` sources) that belongs to a session OTHER than the current
+ * one, under non-session scopes. Keeps cross-session raw history reachable when
+ * it is strongly relevant, but prevents weak keyword overlap from injecting
+ * unrelated prior-session content into a fresh session.
+ */
+const CROSS_SESSION_RAW_PENALTY = 0.5;
+
 // ---------------------------------------------------------------------------
 // Tagged result helpers (used by exact-match boost + formatting)
 // ---------------------------------------------------------------------------
@@ -226,6 +235,11 @@ const DEFAULT_FORMAT_CONFIG = {
   charBudget: 12000,
   relevanceFloor: 0.15,
   maxResults: 15,
+  // Absolute RRF score floor. Unlike `relevanceFloor` (relative to the top
+  // result), this drops results whose absolute fused score is too low to be
+  // trustworthy — preventing weak cross-session archives from being force-
+  // injected when nothing in the project is genuinely relevant. 0 disables it.
+  absoluteFloor: 0,
 };
 
 type FormatConfig = typeof DEFAULT_FORMAT_CONFIG;
@@ -319,12 +333,26 @@ function formatFusedResults(
 
   const totalFound = results.length;
   const topScore = results[0].score;
-  const scoreFloor = topScore * config.relevanceFloor;
+  // Combine the relative floor (topScore * relevanceFloor) with an absolute
+  // floor so weak matches are dropped even when the whole result set is weak.
+  const scoreFloor = Math.max(
+    topScore * config.relevanceFloor,
+    config.absoluteFloor,
+  );
 
-  // Step 1: Score-based cutoff + hard cap. Always keep at least 3.
+  // Step 1: Score-based cutoff + hard cap. Backfill to 3 results only with
+  // items that still clear the ABSOLUTE floor, so we never force-inject
+  // content that is weak in absolute terms (e.g. stale cross-session archives
+  // surfaced by an off-topic recall query).
   let kept = results.filter((r) => r.score >= scoreFloor);
   kept = kept.slice(0, config.maxResults);
-  if (kept.length < 3) kept = results.slice(0, Math.min(3, results.length));
+  if (kept.length < 3) {
+    kept = results
+      .filter((r) => r.score >= config.absoluteFloor)
+      .slice(0, Math.min(3, results.length));
+  }
+
+  if (!kept.length) return "No results found for this query.";
 
   // Step 2: Assign tiers based on relative score.
   const tiered: TieredResult[] = kept.map((r) => ({
@@ -1167,7 +1195,25 @@ export async function searchRecall(
     allRrfLists.push(...primary, ...expanded.slice(0, budget), ...supplemental);
   }
 
-  const fused = reciprocalRankFusion<TaggedResult>(allRrfLists);
+  let fused = reciprocalRankFusion<TaggedResult>(allRrfLists);
+
+  // Demote cross-session raw/archived history. Under `scope="all"`/`"project"`
+  // the temporal and distillation searches span the whole project, so raw
+  // conversation and archived gen-0 distillations from prior, unrelated
+  // sessions can surface on weak keyword overlap and derail a new session.
+  // Knowledge / entities / lat-sections are intentionally cross-session and are
+  // never penalized. Same-session results are never penalized either.
+  if (scope !== "session" && sessionID) {
+    fused = fused
+      .map((r) => {
+        if (r.item.source !== "temporal" && r.item.source !== "distillation") {
+          return r;
+        }
+        if (r.item.item.session_id === sessionID) return r;
+        return { ...r, score: r.score * CROSS_SESSION_RAW_PENALTY };
+      })
+      .sort((a, b) => b.score - a.score);
+  }
 
   // Cap output: return at most 3x the per-source limit. With 7+ RRF sources
   // each contributing up to `limit` items, uncapped output can be huge (89+
@@ -1319,6 +1365,8 @@ export async function runRecall(input: RecallInput): Promise<RecallResult> {
     relevanceFloor:
       recallCfg?.relevanceFloor ?? DEFAULT_FORMAT_CONFIG.relevanceFloor,
     maxResults: recallCfg?.maxResults ?? DEFAULT_FORMAT_CONFIG.maxResults,
+    absoluteFloor:
+      recallCfg?.absoluteFloor ?? DEFAULT_FORMAT_CONFIG.absoluteFloor,
   });
 
   // Surface structured tool-failure stats for debugging. Appended outside the

--- a/packages/core/src/recall.ts
+++ b/packages/core/src/recall.ts
@@ -347,9 +347,7 @@ function formatFusedResults(
   let kept = results.filter((r) => r.score >= scoreFloor);
   kept = kept.slice(0, config.maxResults);
   if (kept.length < 3) {
-    kept = results
-      .filter((r) => r.score >= config.absoluteFloor)
-      .slice(0, Math.min(3, results.length));
+    kept = results.filter((r) => r.score >= config.absoluteFloor).slice(0, 3);
   }
 
   if (!kept.length) return "No results found for this query.";

--- a/packages/core/test/recall-cross-session.test.ts
+++ b/packages/core/test/recall-cross-session.test.ts
@@ -10,6 +10,7 @@ const OTHER_SESSION = "other-session";
 
 function cleanup() {
   db().exec("DELETE FROM temporal_messages");
+  db().exec("DELETE FROM distillations");
 }
 
 function seedTemporal(
@@ -27,24 +28,56 @@ function seedTemporal(
   return id;
 }
 
+function seedDistillation(
+  sessionID: string,
+  observations: string,
+  createdAt: number,
+): string {
+  const pid = ensureProject(PROJECT);
+  const id = uuidv7();
+  db()
+    .query(
+      `INSERT INTO distillations (id, project_id, session_id, narrative, facts, observations, source_ids, generation, token_count, archived, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      id,
+      pid,
+      sessionID,
+      "",
+      "[]",
+      observations,
+      "[]",
+      0,
+      Math.ceil(observations.length / 3),
+      0,
+      createdAt,
+    );
+  return id;
+}
+
 describe("recall — cross-session raw history demotion", () => {
   beforeEach(() => {
     cleanup();
     ensureProject(PROJECT);
   });
 
-  test("same-session raw history outranks an equally-matching other-session row", async () => {
-    // Identical distinctive content in two different sessions. Without the
-    // cross-session penalty their fused scores would tie (or the older/other
-    // one could win on recency); with the penalty the current session wins.
+  // Uses scope="project" deliberately: the pre-existing session-affinity boost
+  // only runs under scope="all", so "project" isolates the cross-session
+  // penalty as the *only* thing differentiating same- vs other-session rows.
+  // This test fails if CROSS_SESSION_RAW_PENALTY is set to 1.0 (disabled).
+  test("penalizes a cross-session temporal row below an equal current-session row", async () => {
+    // Identical distinctive content in two sessions, the OTHER one newer so
+    // recency does not favor the current session. Only the penalty can make
+    // the current-session row win.
     const now = Date.now();
-    const otherId = seedTemporal(
-      OTHER_SESSION,
+    const currentId = seedTemporal(
+      CURRENT_SESSION,
       "xyzzy plugh frobnicate widget investigation",
       now - 10_000,
     );
-    const currentId = seedTemporal(
-      CURRENT_SESSION,
+    const otherId = seedTemporal(
+      OTHER_SESSION,
       "xyzzy plugh frobnicate widget investigation",
       now,
     );
@@ -53,11 +86,11 @@ describe("recall — cross-session raw history demotion", () => {
       query: "xyzzy plugh frobnicate widget",
       projectPath: PROJECT,
       sessionID: CURRENT_SESSION,
-      scope: "all",
+      scope: "project",
     });
 
     const temporal = results.filter((r) => r.item.source === "temporal");
-    expect(temporal.length).toBeGreaterThanOrEqual(2);
+    expect(temporal.length).toBe(2);
 
     const currentRank = temporal.findIndex(
       (r) => r.item.source === "temporal" && r.item.item.id === currentId,
@@ -65,15 +98,53 @@ describe("recall — cross-session raw history demotion", () => {
     const otherRank = temporal.findIndex(
       (r) => r.item.source === "temporal" && r.item.item.id === otherId,
     );
-    expect(currentRank).toBeGreaterThanOrEqual(0);
-    expect(otherRank).toBeGreaterThanOrEqual(0);
-    // Current-session result must come first.
-    expect(currentRank).toBeLessThan(otherRank);
+    // The current-session row must rank first purely due to the penalty.
+    // (The other row is NEWER, so without the penalty recency would rank it
+    // first — this assertion fails if CROSS_SESSION_RAW_PENALTY is 1.0.)
+    expect(currentRank).toBe(0);
+    expect(otherRank).toBe(1);
 
-    // The other-session row's fused score must be strictly lower (penalized).
+    // The other-session row is demoted: its score is meaningfully lower than
+    // the current row's, consistent with the 0.5 multiplier (allow slack for
+    // small RRF rank differences across recency-biased lists).
     const currentScore = temporal[currentRank].score;
     const otherScore = temporal[otherRank].score;
-    expect(otherScore).toBeLessThan(currentScore);
+    expect(otherScore).toBeLessThan(currentScore * 0.6);
+  });
+
+  // Same isolation for the distillation source (the riskier session_id access).
+  test("penalizes a cross-session distillation below an equal current-session one", async () => {
+    const now = Date.now();
+    const currentId = seedDistillation(
+      CURRENT_SESSION,
+      "blorptron quffle zindar marker observation",
+      now - 10_000,
+    );
+    const otherId = seedDistillation(
+      OTHER_SESSION,
+      "blorptron quffle zindar marker observation",
+      now,
+    );
+
+    const results = await searchRecall({
+      query: "blorptron quffle zindar marker",
+      projectPath: PROJECT,
+      sessionID: CURRENT_SESSION,
+      scope: "project",
+    });
+
+    const dist = results.filter((r) => r.item.source === "distillation");
+    expect(dist.length).toBe(2);
+
+    const currentRank = dist.findIndex(
+      (r) => r.item.source === "distillation" && r.item.item.id === currentId,
+    );
+    const otherRank = dist.findIndex(
+      (r) => r.item.source === "distillation" && r.item.item.id === otherId,
+    );
+    expect(currentRank).toBe(0);
+    expect(otherRank).toBe(1);
+    expect(dist[otherRank].score).toBeLessThan(dist[currentRank].score * 0.6);
   });
 
   test("cross-session penalty is NOT applied under session scope", async () => {
@@ -99,6 +170,30 @@ describe("recall — cross-session raw history demotion", () => {
     expect(
       temporal[0].item.source === "temporal" && temporal[0].item.item.id,
     ).toBe(currentId);
+  });
+
+  // A cross-session row is demoted but NOT removed — it still surfaces when it
+  // is the only match. Guards against the penalty being mistaken for a filter.
+  test("a demoted cross-session row still surfaces when it is the only match", async () => {
+    const otherId = seedTemporal(
+      OTHER_SESSION,
+      "snarfblat wibble cromulent token",
+      Date.now(),
+    );
+
+    const results = await searchRecall({
+      query: "snarfblat wibble cromulent",
+      projectPath: PROJECT,
+      sessionID: CURRENT_SESSION,
+      scope: "all",
+    });
+
+    const temporal = results.filter((r) => r.item.source === "temporal");
+    expect(
+      temporal.some(
+        (r) => r.item.source === "temporal" && r.item.item.id === otherId,
+      ),
+    ).toBe(true);
   });
 });
 
@@ -132,9 +227,12 @@ describe("recall — absolute relevance floor", () => {
     expect(md).toContain("No results found");
   });
 
-  test("default absoluteFloor (0) keeps matching results", async () => {
+  test("default absoluteFloor (0) is a no-op — even a cross-session match is kept", async () => {
+    // Seed ONLY a cross-session row: it is penalized (score halved) but must
+    // still appear under the default config, proving absoluteFloor=0 does not
+    // filter anything.
     seedTemporal(
-      CURRENT_SESSION,
+      OTHER_SESSION,
       "thaumaturgy obscure tangential remark",
       Date.now(),
     );

--- a/packages/core/test/recall-cross-session.test.ts
+++ b/packages/core/test/recall-cross-session.test.ts
@@ -1,0 +1,152 @@
+import { uuidv7 } from "uuidv7";
+import { beforeEach, describe, expect, test } from "vitest";
+import { LoreConfig } from "../src/config";
+import { db, ensureProject } from "../src/db";
+import { runRecall, searchRecall } from "../src/recall";
+
+const PROJECT = "/test/recall-cross-session/project";
+const CURRENT_SESSION = "current-session";
+const OTHER_SESSION = "other-session";
+
+function cleanup() {
+  db().exec("DELETE FROM temporal_messages");
+}
+
+function seedTemporal(
+  sessionID: string,
+  content: string,
+  createdAt: number,
+): string {
+  const pid = ensureProject(PROJECT);
+  const id = uuidv7();
+  db()
+    .query(
+      "INSERT INTO temporal_messages (id, project_id, session_id, role, content, tokens, distilled, created_at, metadata) VALUES (?, ?, ?, ?, ?, ?, 0, ?, '{}')",
+    )
+    .run(id, pid, sessionID, "user", content, 20, createdAt);
+  return id;
+}
+
+describe("recall — cross-session raw history demotion", () => {
+  beforeEach(() => {
+    cleanup();
+    ensureProject(PROJECT);
+  });
+
+  test("same-session raw history outranks an equally-matching other-session row", async () => {
+    // Identical distinctive content in two different sessions. Without the
+    // cross-session penalty their fused scores would tie (or the older/other
+    // one could win on recency); with the penalty the current session wins.
+    const now = Date.now();
+    const otherId = seedTemporal(
+      OTHER_SESSION,
+      "xyzzy plugh frobnicate widget investigation",
+      now - 10_000,
+    );
+    const currentId = seedTemporal(
+      CURRENT_SESSION,
+      "xyzzy plugh frobnicate widget investigation",
+      now,
+    );
+
+    const results = await searchRecall({
+      query: "xyzzy plugh frobnicate widget",
+      projectPath: PROJECT,
+      sessionID: CURRENT_SESSION,
+      scope: "all",
+    });
+
+    const temporal = results.filter((r) => r.item.source === "temporal");
+    expect(temporal.length).toBeGreaterThanOrEqual(2);
+
+    const currentRank = temporal.findIndex(
+      (r) => r.item.source === "temporal" && r.item.item.id === currentId,
+    );
+    const otherRank = temporal.findIndex(
+      (r) => r.item.source === "temporal" && r.item.item.id === otherId,
+    );
+    expect(currentRank).toBeGreaterThanOrEqual(0);
+    expect(otherRank).toBeGreaterThanOrEqual(0);
+    // Current-session result must come first.
+    expect(currentRank).toBeLessThan(otherRank);
+
+    // The other-session row's fused score must be strictly lower (penalized).
+    const currentScore = temporal[currentRank].score;
+    const otherScore = temporal[otherRank].score;
+    expect(otherScore).toBeLessThan(currentScore);
+  });
+
+  test("cross-session penalty is NOT applied under session scope", async () => {
+    // Under scope="session" only the current session is searched, so the other
+    // session's row should not appear at all and no penalty math runs.
+    const now = Date.now();
+    seedTemporal(OTHER_SESSION, "quux garply zorch token", now - 5_000);
+    const currentId = seedTemporal(
+      CURRENT_SESSION,
+      "quux garply zorch token",
+      now,
+    );
+
+    const results = await searchRecall({
+      query: "quux garply zorch token",
+      projectPath: PROJECT,
+      sessionID: CURRENT_SESSION,
+      scope: "session",
+    });
+
+    const temporal = results.filter((r) => r.item.source === "temporal");
+    expect(temporal.length).toBe(1);
+    expect(
+      temporal[0].item.source === "temporal" && temporal[0].item.item.id,
+    ).toBe(currentId);
+  });
+});
+
+describe("recall — absolute relevance floor", () => {
+  beforeEach(() => {
+    cleanup();
+    ensureProject(PROJECT);
+  });
+
+  test("a high absoluteFloor drops weak matches even via the keep-3 backfill", async () => {
+    seedTemporal(
+      OTHER_SESSION,
+      "thaumaturgy obscure tangential remark",
+      Date.now(),
+    );
+
+    const search = LoreConfig.parse({}).search;
+    // An impossibly high absolute floor: every real RRF score is < 1, so all
+    // results must be dropped — including the keep-3 backfill, which now also
+    // respects the absolute floor.
+    search.recall.absoluteFloor = 1_000_000;
+
+    const md = await runRecall({
+      query: "thaumaturgy obscure tangential",
+      projectPath: PROJECT,
+      sessionID: CURRENT_SESSION,
+      scope: "all",
+      searchConfig: search,
+    });
+
+    expect(md).toContain("No results found");
+  });
+
+  test("default absoluteFloor (0) keeps matching results", async () => {
+    seedTemporal(
+      CURRENT_SESSION,
+      "thaumaturgy obscure tangential remark",
+      Date.now(),
+    );
+
+    const md = await runRecall({
+      query: "thaumaturgy obscure tangential",
+      projectPath: PROJECT,
+      sessionID: CURRENT_SESSION,
+      scope: "all",
+    });
+
+    expect(md).toContain("Recall Results");
+    expect(md).not.toContain("No results found");
+  });
+});

--- a/packages/website/src/content/docs/docs/configuration.md
+++ b/packages/website/src/content/docs/docs/configuration.md
@@ -155,7 +155,7 @@ Recall and search pipeline tuning: FTS weights, query expansion, vector boost, e
 | `vectorBoostWeight` | number | `1.5` | min 1, max 5 | RRF weight multiplier for vector search lists (when query has enough terms). Set to 1.0 to disable. Default: 1.5. |
 | `vectorBoostMinTerms` | number | `2` | min 1, max 10 | Minimum meaningful query terms (after stopword removal) to activate vector boost. Default: 2. |
 | `embeddings` | object | `{"enabled":true,"provider":"local","model":"nomic-ai/nomic-embed-text-v1.5","dimensions":768}` |  | Vector embedding search provider, model, and dimensions. |
-| `recall` | object | `{"charBudget":12000,"relevanceFloor":0.15,"maxResults":15}` |  | Recall output formatting and result-count limits. |
+| `recall` | object | `{"charBudget":12000,"relevanceFloor":0.15,"maxResults":15,"absoluteFloor":0}` |  | Recall output formatting and result-count limits. |
 
 ### `search.ftsWeights`
 
@@ -187,6 +187,7 @@ Recall output formatting and result-count limits.
 | `charBudget` | number | `12000` | min 2000, max 20000 | Total character budget for recall output (~3K tokens at 12000 chars). Default: 12000. |
 | `relevanceFloor` | number | `0.15` | min 0, max 1 | Minimum RRF score (relative to top) to keep. Set to 0 to disable. Default: 0.15. |
 | `maxResults` | number | `15` | min 3, max 30 | Max results to show in recall output. Default: 15. |
+| `absoluteFloor` | number | `0` | min 0 | Absolute RRF score floor; drops weak matches even via the keep-3 backfill. Default: 0 (disabled). |
 
 
 ## `cache`


### PR DESCRIPTION
## Problem

While investigating an opencode session that "switched to a different work track mid-conversation", the root cause turned out to be a **recall scoping** issue:

At the start of a fresh session, an agent's orienting `recall` call (default `scope="all"`) searches the **whole project across all sessions**, including archived rows. The temporal/distillation FTS queries filter by `project_id` only — no session or archived filter. Combined with a purely **relative** relevance floor and an **always-keep-3** backfill in the formatter, weak keyword matches from prior, unrelated sessions get force-injected into context. In the observed case this pulled in archived content from a CCH seed-scanning task and a CI workflow-fix task, steering the agent off its actual task.

## Fix (`@loreai/core`)

1. **Demote cross-session raw/archived history** (`recall.ts` `searchRecall`): after RRF fusion, for non-session scopes with a known sessionID, `temporal` + `distillation` results from a session *other* than the current one get a `0.5` score penalty (`CROSS_SESSION_RAW_PENALTY`), then results are re-sorted before the output cap. Knowledge / entities / lat-sections (intentionally cross-session) and same-session results are never penalized. Demotion ≠ removal: a cross-session row still surfaces when it is genuinely the best/only match.
2. **Absolute relevance floor** (`recall.ts` `formatFusedResults` + `config.ts`): new `search.recall.absoluteFloor` (default `0` = disabled) applied alongside the relative floor (`scoreFloor = max(topScore*relevanceFloor, absoluteFloor)`). The "keep at least 3" backfill now also respects it, and a new guard returns "No results found" if nothing clears the floor — which also fixes a latent `kept[-1]` crash that the old code would have hit under a high floor.

The default scope (`"all"`) is intentionally unchanged — cross-session knowledge/entities remain valuable. Only the cross-session **raw/archived** leak is tightened. `absoluteFloor` defaults to off pending empirical RRF-score calibration; the cross-session demotion is the always-on safeguard.

## Tests

`packages/core/test/recall-cross-session.test.ts` (6 tests):
- **penalizes a cross-session temporal row below an equal current-session row** — uses `scope="project"` (where the pre-existing session-affinity boost does NOT run) so the penalty is the *only* differentiator; the other row is seeded *newer* so recency would otherwise win. **This test fails if the penalty is neutralized** (verified by toggling `CROSS_SESSION_RAW_PENALTY` to 1.0).
- **penalizes a cross-session distillation below an equal current-session one** — same isolation, covering the distillation source / `session_id` access.
- **penalty is NOT applied under session scope** — only the current session is searched.
- **a demoted cross-session row still surfaces when it is the only match** — proves demotion is not a filter.
- **a high `absoluteFloor` drops weak matches even via the keep-3 backfill**.
- **default `absoluteFloor` (0) is a no-op** — a penalized cross-session row is still kept.

## Verification

- `pnpm --filter @loreai/core run typecheck` ✅
- `pnpm run lint` ✅ (no new warnings)
- `pnpm run check:docs` ✅ (regenerated `configuration.md` for the new field)
- recall test suite (cross-session + entity): 14 passed ✅
- Independent subagent review: no correctness/edge-case bugs; default config provably unchanged.