### PR TITLE
fix(core): tombstone deleted knowledge to stop consolidation thrash

### DIFF
--- a/packages/core/src/agents-file.ts
+++ b/packages/core/src/agents-file.ts
@@ -530,6 +530,7 @@ function _importEntries(entries: ParsedFileEntry[], projectPath: string): void {
         if (existing.content !== entry.content) {
           ltm.update(entry.id, { content: entry.content });
         }
+      } else if (ltm.isTombstoned(entry.id)) {
       } else {
         // Unknown UUID — entry came from another machine.
         // Check for a fuzzy title match before creating — prevents duplicates

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1058,6 +1058,23 @@ const MIGRATIONS: string[] = [
   -- (treated as "unknown set" → the first post-upgrade turn re-pins once).
   ALTER TABLE session_state ADD COLUMN ltm_pin_keys TEXT;
   `,
+  `
+  -- Version 40: Knowledge tombstones.
+  -- Records UUIDs of knowledge entries that were intentionally deleted (by the
+  -- curator's consolidation, or manual deletion). Without this, a stale
+  -- .lore.md that still lists a deleted entry would resurrect it via the
+  -- import "unknown UUID -> create" path, and the next consolidation would
+  -- delete it again — a thrash loop that invalidates the LTM cache and busts
+  -- the prompt cache every cycle. importLoreFile() consults this table and
+  -- refuses to re-create a tombstoned UUID.
+  CREATE TABLE IF NOT EXISTS knowledge_tombstones (
+    id         TEXT PRIMARY KEY,
+    project_id TEXT,
+    deleted_at INTEGER NOT NULL
+  );
+  CREATE INDEX IF NOT EXISTS idx_knowledge_tombstones_project
+    ON knowledge_tombstones (project_id);
+  `,
 ];
 
 /**
@@ -1313,6 +1330,13 @@ function recoverMissingObjects(database: Database) {
     );
     CREATE INDEX IF NOT EXISTS idx_knowledge_transfers_recalled_in
       ON knowledge_transfers (recalled_in_project_id);
+    CREATE TABLE IF NOT EXISTS knowledge_tombstones (
+      id         TEXT PRIMARY KEY,
+      project_id TEXT,
+      deleted_at INTEGER NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_knowledge_tombstones_project
+      ON knowledge_tombstones (project_id);
   `);
 
   // Recover missing columns from partial migration runs.

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -236,9 +236,41 @@ export function update(
 }
 
 export function remove(id: string) {
+  // Record a tombstone BEFORE deleting so a stale .lore.md re-import can't
+  // resurrect this UUID (which would thrash with the next consolidation pass —
+  // delete → re-import recreates → delete again, busting the prompt cache each
+  // cycle). Capture the project_id while the row still exists.
+  const row = db()
+    .query("SELECT project_id FROM knowledge WHERE id = ?")
+    .get(id) as { project_id: string | null } | null;
+  if (row) {
+    db()
+      .query(
+        `INSERT INTO knowledge_tombstones (id, project_id, deleted_at)
+         VALUES (?, ?, ?)
+         ON CONFLICT(id) DO UPDATE SET deleted_at = excluded.deleted_at`,
+      )
+      .run(id, row.project_id, Date.now());
+  }
   // Clean up transfer metrics before deleting the entry (no FK CASCADE).
   db().query("DELETE FROM knowledge_transfers WHERE knowledge_id = ?").run(id);
   db().query("DELETE FROM knowledge WHERE id = ?").run(id);
+}
+
+/** True when the given knowledge UUID was previously deleted (tombstoned). */
+export function isTombstoned(id: string): boolean {
+  const row = db()
+    .query("SELECT 1 FROM knowledge_tombstones WHERE id = ?")
+    .get(id) as { 1: number } | null;
+  return row != null;
+}
+
+/**
+ * Clear a tombstone for the given UUID — called when an entry is legitimately
+ * (re-)created with that exact UUID, so a future delete can tombstone it again.
+ */
+export function clearTombstone(id: string): void {
+  db().query("DELETE FROM knowledge_tombstones WHERE id = ?").run(id);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/prompt.ts
+++ b/packages/core/src/prompt.ts
@@ -845,7 +845,12 @@ export function formatKnowledge(
   const categories = Object.keys(grouped).sort();
   for (const category of categories) {
     const items = grouped[category];
-    items.sort((a, b) => (a.title < b.title ? -1 : a.title > b.title ? 1 : 0));
+    // Sort by title, then content as a deterministic tiebreak so two entries
+    // with identical titles don't render in input-dependent (churning) order.
+    items.sort((a, b) => {
+      if (a.title !== b.title) return a.title < b.title ? -1 : 1;
+      return a.content < b.content ? -1 : a.content > b.content ? 1 : 0;
+    });
     children.push(h(3, category.charAt(0).toUpperCase() + category.slice(1)));
     children.push(
       ul(

--- a/packages/core/test/agents-file.test.ts
+++ b/packages/core/test/agents-file.test.ts
@@ -133,6 +133,8 @@ beforeEach(() => {
   }
   // Clear lore file cache entries to ensure test isolation
   db().query("DELETE FROM kv_meta WHERE key LIKE 'lore_file_cache:%'").run();
+  // Clear tombstones so deletes in one test don't block creates in another
+  db().query("DELETE FROM knowledge_tombstones").run();
   // Reset the agents file and .lore.md
   if (existsSync(AGENTS_FILE)) rmSync(AGENTS_FILE);
   if (existsSync(LORE_FILE_PATH)) rmSync(LORE_FILE_PATH);
@@ -1271,6 +1273,42 @@ describe("importLoreFile", () => {
     expect(entry).not.toBeNull();
     expect(entry?.title).toBe("Auth strategy");
     expect(entry?.content).toBe("OAuth2 with PKCE");
+  });
+
+  test("does NOT resurrect an entry deleted via ltm.remove() (anti-thrash tombstone)", () => {
+    // Reproduces the consolidation thrash: an entry is exported to .lore.md,
+    // then the curator deletes it (ltm.remove → tombstone). A subsequent
+    // import of the still-stale .lore.md must NOT re-create it, otherwise the
+    // next consolidation deletes it again — an infinite delete/recreate loop
+    // that busts the prompt cache every cycle.
+    const keepId = ltm.create({
+      projectPath: PROJECT,
+      category: "decision",
+      title: "Keep me",
+      content: "Stays",
+      scope: "project",
+    });
+    const dropId = ltm.create({
+      projectPath: PROJECT,
+      category: "gotcha",
+      title: "Delete me",
+      content: "Consolidation removes this",
+      scope: "project",
+    });
+    exportLoreFile(PROJECT); // .lore.md now lists BOTH entries
+
+    // Curator consolidation deletes the entry from the DB (tombstones it).
+    ltm.remove(dropId);
+    expect(ltm.get(dropId)).toBeNull();
+
+    // A turn re-imports the stale .lore.md (still lists dropId).
+    clearLoreFileCache(PROJECT);
+    importLoreFile(PROJECT);
+
+    // The deleted entry must stay gone; the kept entry is unaffected.
+    expect(ltm.get(dropId)).toBeNull();
+    expect(ltm.isTombstoned(dropId)).toBe(true);
+    expect(ltm.get(keepId)).not.toBeNull();
   });
 
   test("updates content when .lore.md has been edited", () => {

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -50,7 +50,18 @@ describe("db", () => {
     const row = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(row.version).toBe(39);
+    expect(row.version).toBe(40);
+  });
+
+  test("knowledge_tombstones table exists (migration v40)", () => {
+    const names = (
+      db().query("PRAGMA table_info(knowledge_tombstones)").all() as Array<{
+        name: string;
+      }>
+    ).map((c) => c.name);
+    expect(names).toContain("id");
+    expect(names).toContain("project_id");
+    expect(names).toContain("deleted_at");
   });
 
   test("entities table has embedding column (migration v34)", () => {

--- a/packages/core/test/ltm.test.ts
+++ b/packages/core/test/ltm.test.ts
@@ -53,6 +53,23 @@ describe("ltm", () => {
     expect(entry?.cross_project).toBe(1);
   });
 
+  test("remove() tombstones the UUID; clearTombstone() lifts it", () => {
+    const id = ltm.create({
+      projectPath: PROJECT,
+      category: "gotcha",
+      title: "Tombstone target",
+      content: "Will be deleted",
+      scope: "project",
+    });
+    expect(ltm.isTombstoned(id)).toBe(false);
+    ltm.remove(id);
+    expect(ltm.get(id)).toBeNull();
+    // The UUID is now tombstoned so a stale .lore.md can't resurrect it.
+    expect(ltm.isTombstoned(id)).toBe(true);
+    ltm.clearTombstone(id);
+    expect(ltm.isTombstoned(id)).toBe(false);
+  });
+
   test("update knowledge entry", () => {
     const id = ltm.create({
       projectPath: PROJECT,


### PR DESCRIPTION
Follow-up to #727 (set-stabilization). Live logs revealed a second churn source feeding the system[2] cache busts.

## Problem

The curator's consolidation was deleting **8-10 entries every ~2.5 min** on a loop (`consolidation: 2 updated, 8 deleted` repeating), each cycle invalidating the LTM cache and busting the prompt cache. Verified against the live DB: `.lore.md` listed **24** entries while the DB held **22** — the file kept re-introducing entries consolidation had deleted.

## Root cause

`ltm.remove()` was a hard delete with no record. So:
1. Consolidation deletes entries from the DB and exports a trimmed `.lore.md`.
2. But on a turn, `importLoreFile()` re-reads `.lore.md`; any entry still listed there with a now-unknown UUID hits the **"unknown UUID → create"** path and is **resurrected**.
3. The next consolidation deletes it again. Infinite delete/recreate loop → cache invalidation → bust every cycle.

The import path couldn't distinguish "new entry synced from another machine" from "entry I just intentionally deleted here."

## Fix

- **`knowledge_tombstones` table** (migration v40) records intentionally-deleted UUIDs (with `project_id` + `deleted_at`).
- **`ltm.remove()`** writes a tombstone before deleting; adds `ltm.isTombstoned()` / `ltm.clearTombstone()`.
- **`importLoreFile()` / `_importEntries()`** skips re-creating a tombstoned UUID. Legitimate cross-machine sync is unaffected (those rows were never `ltm.remove()`'d); a deliberate re-add is simply a new entry with a fresh UUID.

Also addresses review **nit N2** from #727: `formatKnowledge()` canonical layout now breaks title ties by content, so duplicate-titled entries render in a stable (non-churning) order.

## Tests
- `db.test.ts`: schema v40 + `knowledge_tombstones` table shape.
- `ltm.test.ts`: `remove()` tombstones; `clearTombstone()` lifts it.
- `agents-file.test.ts`: an entry deleted via `ltm.remove()` is NOT resurrected by re-importing a stale `.lore.md` (the anti-thrash guarantee); cross-machine raw-delete resurrection still works.

Full core suite green (1334 passed); typecheck + biome clean.