### PR TITLE
feat(cli): add `lore data export` to regenerate .lore.md from the DB

### DIFF
--- a/packages/core/src/agents-file.ts
+++ b/packages/core/src/agents-file.ts
@@ -105,14 +105,19 @@ function setCache(fp: string, entry: LoreFileCache): void {
     .run(key, value, value);
 }
 
+/** Clear the cached mtime/hash for an arbitrary agents/lore file path. */
+function clearCache(fp: string): void {
+  db()
+    .query("DELETE FROM kv_meta WHERE key = ?")
+    .run(CACHE_PREFIX + fp);
+}
+
 /**
  * Clear the cached mtime/hash for a project's `.lore.md`.
  * Useful in tests or after data wipes to force a full re-check.
  */
 export function clearLoreFileCache(projectPath: string): void {
-  db()
-    .query("DELETE FROM kv_meta WHERE key = ?")
-    .run(CACHE_PREFIX + join(projectPath, LORE_FILE));
+  clearCache(join(projectPath, LORE_FILE));
 }
 
 // ---------------------------------------------------------------------------
@@ -467,6 +472,39 @@ export function deleteLoreFile(projectPath: string): boolean {
   try {
     unlinkSync(fp);
     clearLoreFileCache(projectPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Strip lore's managed section (pointer or inline knowledge) from an agents
+ * file (AGENTS.md / CLAUDE.md), preserving all surrounding user content. Used
+ * when a project drops to zero knowledge entries so the file doesn't keep a
+ * dangling pointer to a deleted `.lore.md` or a stale inline knowledge list.
+ *
+ * Returns true if the file was modified (or removed). If, after removing the
+ * section, no user content remains, the file is deleted entirely.
+ */
+export function removeLoreSectionFromFile(filePath: string): boolean {
+  if (isHostedMode()) return false;
+  if (!existsSync(filePath)) return false;
+
+  const fileContent = readFileSync(filePath, "utf8");
+  const { before, after, section } = splitFile(fileContent);
+  // No lore section present → nothing to strip.
+  if (section === null) return false;
+
+  const remainder = `${before.trimEnd()}\n${after.trimStart()}`.trim();
+  try {
+    if (remainder.length === 0) {
+      // The file was lore-only — remove it entirely.
+      unlinkSync(filePath);
+    } else {
+      writeFileSync(filePath, `${remainder}\n`, "utf8");
+    }
+    clearCache(filePath);
     return true;
   } catch {
     return false;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -162,6 +162,7 @@ export {
   exportLoreFile,
   exportInlineToAgentsFile,
   deleteLoreFile,
+  removeLoreSectionFromFile,
   importLoreFile,
   shouldImportLoreFile,
   loreFileExists,

--- a/packages/gateway/src/cli/data.ts
+++ b/packages/gateway/src/cli/data.ts
@@ -8,12 +8,13 @@
  *   delete <type> <id>    Delete a single entry (type: knowledge, session, distillation, project)
  *   move <type> <id..>    Move session(s) or knowledge to another project (--to required)
  *   split                 Auto-suggest & move mis-grouped sessions to correct projects
+ *   export                Regenerate .lore.md / AGENTS.md from the DB for a project
  *
  * When `LORE_REMOTE_URL` is set, most subcommands delegate to the remote
  * gateway REST API instead of accessing the local database.
  */
 import { createInterface } from "node:readline";
-import { resolve } from "node:path";
+import { join, resolve } from "node:path";
 import {
   getRemoteUrl,
   projectQueryParams,
@@ -2447,6 +2448,7 @@ Subcommands:
   split                 Auto-suggest & move mis-grouped sessions to correct projects
   merge                 Scan git remotes and merge duplicate projects
   consolidate           Merge "(unattributed)" buckets into matched real projects
+  export                Regenerate .lore.md / AGENTS.md from the DB for a project
   recover               Re-import knowledge from .lore.md / AGENTS.md files
   reground-entities     Re-derive entities (people, tools, ...) from history (needs a running gateway)
   dedup                 Find and remove duplicate knowledge entries (all projects)
@@ -2492,6 +2494,8 @@ Examples:
   lore data consolidate                    # dry-run: show "(unattributed)" buckets & matches
   lore data consolidate --yes              # apply: merge matched buckets into real projects
   lore data consolidate --json             # machine-readable plan (dryRun:true unless --yes)
+  lore data export                         # regenerate .lore.md for current project from the DB
+  lore data export --project /path         # regenerate for a specific project
   lore data recover                        # re-import from .lore.md / AGENTS.md
   lore data recover --yes                  # skip confirmation
   lore data reground-entities --dry-run    # preview entities re-derived from history (current project)
@@ -2515,6 +2519,91 @@ Examples:
  * project (re-pointing all rows). Buckets with no confident match are reported
  * but left intact (they remain a clearly-labelled cross-project memory source).
  */
+/**
+ * `lore data export [--project <path>]` — regenerate the on-disk knowledge
+ * file(s) from the current DB state for a single project. Useful when the
+ * file has drifted from the DB (e.g. stale entries that consolidation/tombstones
+ * removed from the DB but still linger in a committed .lore.md), without
+ * waiting for the idle exporter or running a destructive `clear`.
+ *
+ * Respects the same loreFile/agentsFile config the idle exporter uses.
+ */
+async function cmdExport(
+  _args: string[],
+  flags: Record<string, unknown>,
+): Promise<void> {
+  if (getRemoteUrl()) {
+    console.error(
+      "Error: export is not supported in remote mode (requires local filesystem access).",
+    );
+    process.exit(1);
+  }
+
+  const projectPath = resolve((flags.project as string) ?? process.cwd());
+
+  const {
+    config: loreConfig,
+    ltm,
+    exportToFile,
+    exportLoreFile,
+    exportInlineToAgentsFile,
+    deleteLoreFile,
+  } = await import("@loreai/core");
+  const cfg = loreConfig();
+
+  if (!cfg.knowledge.enabled) {
+    console.error(
+      "Error: knowledge is disabled in config — nothing to export.",
+    );
+    process.exit(1);
+  }
+
+  const entries = ltm.forProject(projectPath, false);
+  const written: string[] = [];
+
+  if (entries.length === 0) {
+    // No knowledge for this project — remove a stale .lore.md so it can't
+    // re-import deleted entries from git.
+    if (cfg.loreFile.enabled) {
+      const removed = deleteLoreFile(projectPath);
+      console.log(
+        removed
+          ? `No knowledge for ${projectPath} — removed stale .lore.md.`
+          : `No knowledge for ${projectPath} — nothing to export.`,
+      );
+    } else {
+      console.log(`No knowledge for ${projectPath} — nothing to export.`);
+    }
+    return;
+  }
+
+  if (cfg.loreFile.enabled && cfg.agentsFile.enabled) {
+    const filePath = join(projectPath, cfg.agentsFile.path);
+    exportToFile({ projectPath, filePath });
+    written.push(join(projectPath, ".lore.md"), filePath);
+  } else if (cfg.loreFile.enabled) {
+    exportLoreFile(projectPath);
+    written.push(join(projectPath, ".lore.md"));
+  } else if (cfg.agentsFile.enabled) {
+    const filePath = join(projectPath, cfg.agentsFile.path);
+    exportInlineToAgentsFile({ projectPath, filePath });
+    written.push(filePath);
+  } else {
+    console.log(
+      "Both loreFile and agentsFile are disabled in config — nothing written.",
+    );
+    return;
+  }
+
+  console.log(
+    `Exported ${entries.length} knowledge ${entries.length === 1 ? "entry" : "entries"} for ${projectPath}:`,
+  );
+  for (const f of written) console.log(`  ${f}`);
+  console.log(
+    "Commit the regenerated file(s) to keep git in sync and prevent re-import of stale entries.",
+  );
+}
+
 async function cmdConsolidate(
   _args: string[],
   flags: Record<string, unknown>,
@@ -2785,6 +2874,9 @@ export async function commandData(
       break;
     case "consolidate":
       await cmdConsolidate(subArgs, values);
+      break;
+    case "export":
+      await cmdExport(subArgs, values);
       break;
     case "recover":
       await cmdRecover(subArgs, values);

--- a/packages/gateway/src/cli/data.ts
+++ b/packages/gateway/src/cli/data.ts
@@ -2548,6 +2548,7 @@ async function cmdExport(
     exportLoreFile,
     exportInlineToAgentsFile,
     deleteLoreFile,
+    removeLoreSectionFromFile,
   } = await import("@loreai/core");
   const cfg = loreConfig();
 
@@ -2559,35 +2560,43 @@ async function cmdExport(
   }
 
   const entries = ltm.forProject(projectPath, false);
-  const written: string[] = [];
+  const agentsFilePath = join(projectPath, cfg.agentsFile.path);
 
   if (entries.length === 0) {
-    // No knowledge for this project — remove a stale .lore.md so it can't
-    // re-import deleted entries from git.
-    if (cfg.loreFile.enabled) {
-      const removed = deleteLoreFile(projectPath);
-      console.log(
-        removed
-          ? `No knowledge for ${projectPath} — removed stale .lore.md.`
-          : `No knowledge for ${projectPath} — nothing to export.`,
-      );
+    // No knowledge for this project — fully reconcile the on-disk files so no
+    // stale entries remain to be re-imported from git. This must cover EVERY
+    // config combination, not just .lore.md: a dangling AGENTS.md pointer (to a
+    // now-deleted .lore.md) or a stale inline AGENTS.md knowledge section would
+    // otherwise survive — exactly the drift this command exists to fix.
+    const cleaned: string[] = [];
+    if (cfg.loreFile.enabled && deleteLoreFile(projectPath)) {
+      cleaned.push(join(projectPath, ".lore.md"));
+    }
+    // Strip lore's section from the agents file (pointer in the default config,
+    // inline knowledge in the agentsFile-only config). Preserves user content.
+    if (cfg.agentsFile.enabled && removeLoreSectionFromFile(agentsFilePath)) {
+      cleaned.push(agentsFilePath);
+    }
+    if (cleaned.length) {
+      console.log(`No knowledge for ${projectPath} — cleaned stale file(s):`);
+      for (const f of cleaned) console.log(`  ${f}`);
+      console.log("Commit the change(s) to keep git in sync.");
     } else {
       console.log(`No knowledge for ${projectPath} — nothing to export.`);
     }
     return;
   }
 
+  const written: string[] = [];
   if (cfg.loreFile.enabled && cfg.agentsFile.enabled) {
-    const filePath = join(projectPath, cfg.agentsFile.path);
-    exportToFile({ projectPath, filePath });
-    written.push(join(projectPath, ".lore.md"), filePath);
+    exportToFile({ projectPath, filePath: agentsFilePath });
+    written.push(join(projectPath, ".lore.md"), agentsFilePath);
   } else if (cfg.loreFile.enabled) {
     exportLoreFile(projectPath);
     written.push(join(projectPath, ".lore.md"));
   } else if (cfg.agentsFile.enabled) {
-    const filePath = join(projectPath, cfg.agentsFile.path);
-    exportInlineToAgentsFile({ projectPath, filePath });
-    written.push(filePath);
+    exportInlineToAgentsFile({ projectPath, filePath: agentsFilePath });
+    written.push(agentsFilePath);
   } else {
     console.log(
       "Both loreFile and agentsFile are disabled in config — nothing written.",

--- a/packages/gateway/test/data-export.test.ts
+++ b/packages/gateway/test/data-export.test.ts
@@ -2,11 +2,21 @@
  * Tests for `lore data export` — regenerates .lore.md / AGENTS.md from the
  * current DB for a project, on demand. Used to reconcile a drifted file (e.g.
  * stale entries that consolidation/tombstones removed from the DB but still
- * linger in a committed .lore.md) without waiting for the idle exporter or
- * running a destructive `clear`.
+ * linger in a committed .lore.md / AGENTS.md) without waiting for the idle
+ * exporter or running a destructive `clear`.
+ *
+ * Config is pinned explicitly per test (via a written .lore.json) rather than
+ * relying on defaults, so the tests don't silently change meaning if defaults
+ * move, and so every loreFile/agentsFile combination is covered.
  */
 import { describe, test, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, existsSync, readFileSync } from "node:fs";
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { load, ltm } from "@loreai/core";
@@ -14,85 +24,152 @@ import { commandData } from "../src/cli/data";
 
 let projectDir: string;
 
-beforeEach(async () => {
-  projectDir = mkdtempSync(join(tmpdir(), "lore-export-"));
-  // Load config for the project (default: .lore.md + AGENTS.md pointer).
+/** Write a .lore.json with the given overrides and load it into config. */
+async function setConfig(overrides: Record<string, unknown>): Promise<void> {
+  writeFileSync(
+    join(projectDir, ".lore.json"),
+    JSON.stringify(overrides),
+    "utf8",
+  );
   await load(projectDir);
+}
+
+function seed(title: string, content = "x"): string {
+  return ltm.create({
+    projectPath: projectDir,
+    category: "decision",
+    title,
+    content,
+    scope: "project",
+  });
+}
+
+const loreFilePath = () => join(projectDir, ".lore.md");
+const agentsFilePath = () => join(projectDir, "AGENTS.md");
+const read = (p: string) => readFileSync(p, "utf8");
+
+beforeEach(() => {
+  projectDir = mkdtempSync(join(tmpdir(), "lore-export-"));
 });
 
-afterEach(() => {
+afterEach(async () => {
   rmSync(projectDir, { recursive: true, force: true });
+  // Reset global config so other suites aren't affected by our overrides.
+  await load(process.cwd());
 });
 
-describe("lore data export", () => {
-  test("regenerates .lore.md (+ AGENTS.md) from the DB", async () => {
-    ltm.create({
-      projectPath: projectDir,
-      category: "decision",
-      title: "Export A",
-      content: "first",
-      scope: "project",
+describe("lore data export — default config (.lore.md + AGENTS.md pointer)", () => {
+  beforeEach(async () => {
+    await setConfig({
+      loreFile: { enabled: true },
+      agentsFile: { enabled: true },
     });
-    ltm.create({
-      projectPath: projectDir,
-      category: "gotcha",
-      title: "Export B",
-      content: "second",
-      scope: "project",
-    });
+  });
+
+  test("regenerates .lore.md + AGENTS.md pointer from the DB", async () => {
+    seed("Export A", "first");
+    seed("Export B", "second");
 
     await commandData(["export"], { project: projectDir });
 
-    const loreFile = join(projectDir, ".lore.md");
-    expect(existsSync(loreFile)).toBe(true);
-    const content = readFileSync(loreFile, "utf8");
-    expect(content).toContain("Export A");
-    expect(content).toContain("Export B");
-    // AGENTS.md pointer is written in the default config.
-    expect(existsSync(join(projectDir, "AGENTS.md"))).toBe(true);
+    expect(existsSync(loreFilePath())).toBe(true);
+    const lore = read(loreFilePath());
+    expect(lore).toContain("Export A");
+    expect(lore).toContain("Export B");
+    expect(existsSync(agentsFilePath())).toBe(true);
+    expect(read(agentsFilePath())).toContain(".lore.md");
   });
 
-  test("does not list entries deleted via remove() (tombstoned)", async () => {
-    const keep = ltm.create({
-      projectPath: projectDir,
-      category: "decision",
-      title: "Keep",
-      content: "stays",
-      scope: "project",
-    });
-    const drop = ltm.create({
-      projectPath: projectDir,
-      category: "gotcha",
-      title: "Drop",
-      content: "removed",
-      scope: "project",
-    });
+  test("excludes entries deleted via remove() (tombstoned)", async () => {
+    const keep = seed("Keep", "stays");
+    const drop = seed("Drop", "removed");
     ltm.remove(drop);
 
     await commandData(["export"], { project: projectDir });
 
-    const content = readFileSync(join(projectDir, ".lore.md"), "utf8");
-    expect(content).toContain("Keep");
-    expect(content).not.toContain("Drop");
+    const lore = read(loreFilePath());
+    expect(lore).toContain("Keep");
+    expect(lore).not.toContain("Drop");
     expect(ltm.get(keep)).not.toBeNull();
   });
 
-  test("removes a stale .lore.md when the project has no knowledge", async () => {
-    // Seed + export so a .lore.md exists, then delete all entries and re-export.
-    const id = ltm.create({
-      projectPath: projectDir,
-      category: "decision",
-      title: "Temp",
-      content: "x",
-      scope: "project",
-    });
+  test("at 0 entries: removes .lore.md AND strips the AGENTS.md pointer (no dangling link)", async () => {
+    const id = seed("Temp");
     await commandData(["export"], { project: projectDir });
-    expect(existsSync(join(projectDir, ".lore.md"))).toBe(true);
+    expect(existsSync(loreFilePath())).toBe(true);
+    expect(read(agentsFilePath())).toContain(".lore.md");
 
     ltm.remove(id);
     await commandData(["export"], { project: projectDir });
 
-    // No knowledge left → the stale file is removed so git won't re-import it.
-    expect(existsSync(join(projectDir, ".lore.md"))).toBe(false);
+    // .lore.md gone, and the AGENTS.md pointer to it must not survive.
+    expect(existsSync(loreFilePath())).toBe(false);
+    if (existsSync(agentsFilePath())) {
+      expect(read(agentsFilePath())).not.toContain(".lore.md");
+    }
+  });
+
+  test("preserves user content in AGENTS.md when stripping the lore section at 0 entries", async () => {
+    const id = seed("Temp");
+    // Pre-seed AGENTS.md with user content, then export to add the lore pointer.
+    writeFileSync(
+      agentsFilePath(),
+      "# My Project\n\nHand-written notes.\n",
+      "utf8",
+    );
+    await commandData(["export"], { project: projectDir });
+    expect(read(agentsFilePath())).toContain(".lore.md");
+
+    ltm.remove(id);
+    await commandData(["export"], { project: projectDir });
+
+    const agents = read(agentsFilePath());
+    expect(agents).toContain("Hand-written notes.");
+    expect(agents).not.toContain(".lore.md");
+  });
+});
+
+describe("lore data export — agentsFile-only (inline) config", () => {
+  beforeEach(async () => {
+    await setConfig({
+      loreFile: { enabled: false },
+      agentsFile: { enabled: true },
+    });
+  });
+
+  test("writes the inline knowledge section into AGENTS.md (no .lore.md)", async () => {
+    seed("Inline entry", "body");
+    await commandData(["export"], { project: projectDir });
+
+    expect(existsSync(loreFilePath())).toBe(false);
+    expect(existsSync(agentsFilePath())).toBe(true);
+    expect(read(agentsFilePath())).toContain("Inline entry");
+  });
+
+  test("at 0 entries: strips the stale inline section from AGENTS.md", async () => {
+    const id = seed("Inline entry", "body");
+    writeFileSync(agentsFilePath(), "# Notes\n\nKeep me.\n", "utf8");
+    await commandData(["export"], { project: projectDir });
+    expect(read(agentsFilePath())).toContain("Inline entry");
+
+    ltm.remove(id);
+    await commandData(["export"], { project: projectDir });
+
+    const agents = read(agentsFilePath());
+    expect(agents).toContain("Keep me.");
+    expect(agents).not.toContain("Inline entry");
+  });
+});
+
+describe("lore data export — both files disabled", () => {
+  test("writes nothing", async () => {
+    await setConfig({
+      loreFile: { enabled: false },
+      agentsFile: { enabled: false },
+    });
+    seed("Nowhere");
+    await commandData(["export"], { project: projectDir });
+    expect(existsSync(loreFilePath())).toBe(false);
+    expect(existsSync(agentsFilePath())).toBe(false);
   });
 });

--- a/packages/gateway/test/data-export.test.ts
+++ b/packages/gateway/test/data-export.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for `lore data export` — regenerates .lore.md / AGENTS.md from the
+ * current DB for a project, on demand. Used to reconcile a drifted file (e.g.
+ * stale entries that consolidation/tombstones removed from the DB but still
+ * linger in a committed .lore.md) without waiting for the idle exporter or
+ * running a destructive `clear`.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { load, ltm } from "@loreai/core";
+import { commandData } from "../src/cli/data";
+
+let projectDir: string;
+
+beforeEach(async () => {
+  projectDir = mkdtempSync(join(tmpdir(), "lore-export-"));
+  // Load config for the project (default: .lore.md + AGENTS.md pointer).
+  await load(projectDir);
+});
+
+afterEach(() => {
+  rmSync(projectDir, { recursive: true, force: true });
+});
+
+describe("lore data export", () => {
+  test("regenerates .lore.md (+ AGENTS.md) from the DB", async () => {
+    ltm.create({
+      projectPath: projectDir,
+      category: "decision",
+      title: "Export A",
+      content: "first",
+      scope: "project",
+    });
+    ltm.create({
+      projectPath: projectDir,
+      category: "gotcha",
+      title: "Export B",
+      content: "second",
+      scope: "project",
+    });
+
+    await commandData(["export"], { project: projectDir });
+
+    const loreFile = join(projectDir, ".lore.md");
+    expect(existsSync(loreFile)).toBe(true);
+    const content = readFileSync(loreFile, "utf8");
+    expect(content).toContain("Export A");
+    expect(content).toContain("Export B");
+    // AGENTS.md pointer is written in the default config.
+    expect(existsSync(join(projectDir, "AGENTS.md"))).toBe(true);
+  });
+
+  test("does not list entries deleted via remove() (tombstoned)", async () => {
+    const keep = ltm.create({
+      projectPath: projectDir,
+      category: "decision",
+      title: "Keep",
+      content: "stays",
+      scope: "project",
+    });
+    const drop = ltm.create({
+      projectPath: projectDir,
+      category: "gotcha",
+      title: "Drop",
+      content: "removed",
+      scope: "project",
+    });
+    ltm.remove(drop);
+
+    await commandData(["export"], { project: projectDir });
+
+    const content = readFileSync(join(projectDir, ".lore.md"), "utf8");
+    expect(content).toContain("Keep");
+    expect(content).not.toContain("Drop");
+    expect(ltm.get(keep)).not.toBeNull();
+  });
+
+  test("removes a stale .lore.md when the project has no knowledge", async () => {
+    // Seed + export so a .lore.md exists, then delete all entries and re-export.
+    const id = ltm.create({
+      projectPath: projectDir,
+      category: "decision",
+      title: "Temp",
+      content: "x",
+      scope: "project",
+    });
+    await commandData(["export"], { project: projectDir });
+    expect(existsSync(join(projectDir, ".lore.md"))).toBe(true);
+
+    ltm.remove(id);
+    await commandData(["export"], { project: projectDir });
+
+    // No knowledge left → the stale file is removed so git won't re-import it.
+    expect(existsSync(join(projectDir, ".lore.md"))).toBe(false);
+  });
+});


### PR DESCRIPTION
Follow-up to #727 / #729.

## Why

There was no standalone way to reconcile a project's on-disk knowledge file(s) with the DB. Regeneration only happened as a side effect of the destructive `clear`/`delete` commands or the idle exporter. After the consolidation/tombstone work in #729, a committed `.lore.md` (or AGENTS.md section) can still list entries the DB no longer has. `lore data export` rewrites the file(s) from the current DB on demand.

## What

- New `export` subcommand (`lore data export [--project <path>]`).
- For `entries > 0`: regenerates per the `loreFile`/`agentsFile` config — `.lore.md` + AGENTS.md pointer (default), `.lore.md` only, or inline AGENTS.md. This branch mirrors the idle exporter's logic.
- For `entries == 0`: **fully reconciles every config combination** so no stale entries can be re-imported from git — deletes `.lore.md` AND strips lore's section from AGENTS.md (the dangling pointer in the default config, or the stale inline knowledge section in the agentsFile-only config). Note: this 0-entry cleanup is *new* behavior the idle exporter does not have (it no-ops at 0 entries).
- New helper `agents-file.removeLoreSectionFromFile()` strips lore's managed section while preserving surrounding user content (removes the file only if it was lore-only).
- Local-only (errors clearly in remote mode); `--project` selects the target dir (defaults to cwd). Help text + examples updated.

## Tests

`packages/gateway/test/data-export.test.ts` — config pinned explicitly per case (no reliance on defaults):
- default config: regenerates `.lore.md` + pointer; excludes tombstoned entries; at 0 entries removes `.lore.md` AND strips the pointer; preserves user content in AGENTS.md.
- agentsFile-only: writes inline section; at 0 entries strips the stale inline section (preserving user content).
- both-disabled: writes nothing.

Verified by mutation — reverting the 0-entry agents-file cleanup fails the three new edge-case tests. Typecheck + biome clean.