### PR TITLE
fix(opencode): stop leaking helper exports that crash OpenCode v1.17.4

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -280,7 +280,7 @@ export const LorePlugin: Plugin = async (ctx) => {
           },
         };
         // Pin the Anthropic provider's baseURL to the gateway. See
-        // applyLoreProviderConfig for the full rationale.
+        // applyLoreProviderConfig in ./internal.ts for the full rationale.
         applyLoreProviderConfig(cfg, gatewayBase);
       },
 
@@ -403,4 +403,10 @@ export const LorePlugin: Plugin = async (ctx) => {
   }
 };
 
+// WARNING: do NOT add any other export to this module. OpenCode's legacy
+// plugin loader invokes every FUNCTION export as a plugin (pushing its return
+// value into the host hooks array) and THROWS on any non-function export,
+// dropping the plugin entirely. Keep helpers in ./internal.ts. This module
+// must export only LorePlugin + this same-reference default. Guarded by the
+// "plugin entry module export shape" test in test/index.test.ts.
 export default LorePlugin;

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -5,6 +5,12 @@ import {
   discoverWorkspaceRoot,
   installFetchInterceptor,
 } from "@loreai/core";
+// Helpers live in a separate module so they are NOT re-exported from this
+// plugin entry. OpenCode's legacy plugin loader invokes every function
+// exported from the entry module as a plugin; leaking these helpers pushed
+// `undefined` into the host hooks array and crashed it on event dispatch
+// (`undefined is not an object (evaluating 'A.event')`). See ./internal.ts.
+import { applyLoreProviderConfig, probeGateway } from "./internal";
 
 /**
  * Lore plugin for OpenCode — transparent LLM proxy routing.
@@ -22,70 +28,6 @@ import {
 
 /** Default ports to probe when looking for a running gateway (must match gateway defaults). */
 const KNOWN_GATEWAY_PORTS = [3207, 5673];
-
-/**
- * Pin every opencode provider's `options.baseURL` to the Lore gateway.
- * Without this, opencode can derive the Anthropic baseURL from
- * `OPENAI_BASE_URL` (stripping `/v1`), sending the SDK to
- * `http://host/messages` (no /v1) — the gateway only routes `/v1/messages`,
- * and the fetch interceptor skips 127.0.0.1 to avoid loops, so the call
- * lands as a bare `/messages` 404. Worse, the `OPENAI_BASE_URL` /
- * `ANTHROPIC_BASE_URL` env vars are bypassed by opencode's `resolveSDK()`
- * (it always passes `options.baseURL` to the @ai-sdk factory, and the
- * @ai-sdk `loadOptionalSetting()` only consults the env var when the
- * factory receives an undefined `baseURL`). Every other @ai-sdk provider
- * (google, mistral, groq, cohere, xai, perplexity, togetherai, vercel,
- * alibaba, deepinfra, gateway, openrouter, cerebras, etc.) has NO
- * baseURL env var at all. Iterating over `cfg.provider` is the only
- * universal lever.
- *
- * Deep-merges per-provider so user-set keys under `provider.<id>` (custom
- * headers, model overrides, etc.) are preserved.
- *
- * Exported for direct testing — the config hook delegates here so unit tests
- * can verify the merge logic without spinning up a real gateway (the
- * surrounding `LorePlugin` skips gateway start in `NODE_ENV=test`).
- */
-export function applyLoreProviderConfig(
-  cfg: Record<string, unknown>,
-  gatewayBase: string,
-): void {
-  if (!gatewayBase) return;
-  const baseUrl = `${gatewayBase}/v1`;
-  const existingProvider = (cfg.provider ?? {}) as Record<string, unknown>;
-  const pinned: Record<string, unknown> = {};
-  for (const [id, provider] of Object.entries(existingProvider)) {
-    if (!provider || typeof provider !== "object") continue;
-    const p = provider as Record<string, unknown>;
-    const existingOptions = (p.options ?? {}) as Record<string, unknown>;
-    pinned[id] = {
-      ...p,
-      options: { ...existingOptions, baseURL: baseUrl },
-    };
-  }
-  if (Object.keys(pinned).length > 0) {
-    cfg.provider = { ...existingProvider, ...pinned };
-  }
-}
-
-/**
- * Check if the Lore gateway is reachable at the given base URL.
- * Short timeout so this doesn't delay OpenCode startup noticeably.
- */
-export async function probeGateway(
-  baseURL: string,
-  timeoutMs = 1500,
-): Promise<boolean> {
-  try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
-    const res = await fetch(`${baseURL}/health`, { signal: controller.signal });
-    clearTimeout(timer);
-    return res.ok;
-  } catch {
-    return false;
-  }
-}
 
 /**
  * Resolve the gateway URL by probing known ports and reading the port file.

--- a/packages/opencode/src/internal.ts
+++ b/packages/opencode/src/internal.ts
@@ -5,11 +5,13 @@
  * (`./index.ts`). OpenCode's legacy plugin loader treats EVERY function
  * exported from a plugin module as a plugin instance and invokes it (see
  * `getServerPlugin`/`getLegacyPlugins` in opencode's plugin loader). Exporting
- * these helpers from the entry module caused them to be invoked as plugins,
- * pushing `undefined` into the host's hooks array and crashing the host with
- * `undefined is not an object (evaluating 'A.event')` on the first event
- * dispatch. Keeping them in a separate module means the entry module exposes
- * only the plugin function itself, while tests can still import them here.
+ * these helpers from the entry module caused them to be invoked as plugins and
+ * their return values pushed into the host's hooks array:
+ * `applyLoreProviderConfig` returns `undefined`, so the host crashed on the
+ * first hook dispatch with `undefined is not an object (evaluating 'A.event')`
+ * (the `?.` guards the `.event` property, not the `undefined` hook element).
+ * Keeping them in a separate module means the entry module exposes only the
+ * plugin function itself, while tests can still import them here.
  */
 
 /**

--- a/packages/opencode/src/internal.ts
+++ b/packages/opencode/src/internal.ts
@@ -1,0 +1,77 @@
+/**
+ * Internal helpers for the Lore OpenCode plugin.
+ *
+ * These functions are intentionally kept OUT of the plugin entry module
+ * (`./index.ts`). OpenCode's legacy plugin loader treats EVERY function
+ * exported from a plugin module as a plugin instance and invokes it (see
+ * `getServerPlugin`/`getLegacyPlugins` in opencode's plugin loader). Exporting
+ * these helpers from the entry module caused them to be invoked as plugins,
+ * pushing `undefined` into the host's hooks array and crashing the host with
+ * `undefined is not an object (evaluating 'A.event')` on the first event
+ * dispatch. Keeping them in a separate module means the entry module exposes
+ * only the plugin function itself, while tests can still import them here.
+ */
+
+/**
+ * Pin every opencode provider's `options.baseURL` to the Lore gateway.
+ * Without this, opencode can derive the Anthropic baseURL from
+ * `OPENAI_BASE_URL` (stripping `/v1`), sending the SDK to
+ * `http://host/messages` (no /v1) — the gateway only routes `/v1/messages`,
+ * and the fetch interceptor skips 127.0.0.1 to avoid loops, so the call
+ * lands as a bare `/messages` 404. Worse, the `OPENAI_BASE_URL` /
+ * `ANTHROPIC_BASE_URL` env vars are bypassed by opencode's `resolveSDK()`
+ * (it always passes `options.baseURL` to the @ai-sdk factory, and the
+ * @ai-sdk `loadOptionalSetting()` only consults the env var when the
+ * factory receives an undefined `baseURL`). Every other @ai-sdk provider
+ * (google, mistral, groq, cohere, xai, perplexity, togetherai, vercel,
+ * alibaba, deepinfra, gateway, openrouter, cerebras, etc.) has NO
+ * baseURL env var at all. Iterating over `cfg.provider` is the only
+ * universal lever.
+ *
+ * Deep-merges per-provider so user-set keys under `provider.<id>` (custom
+ * headers, model overrides, etc.) are preserved.
+ *
+ * Exported for direct testing — the config hook delegates here so unit tests
+ * can verify the merge logic without spinning up a real gateway (the
+ * surrounding `LorePlugin` skips gateway start in `NODE_ENV=test`).
+ */
+export function applyLoreProviderConfig(
+  cfg: Record<string, unknown>,
+  gatewayBase: string,
+): void {
+  if (!gatewayBase) return;
+  const baseUrl = `${gatewayBase}/v1`;
+  const existingProvider = (cfg.provider ?? {}) as Record<string, unknown>;
+  const pinned: Record<string, unknown> = {};
+  for (const [id, provider] of Object.entries(existingProvider)) {
+    if (!provider || typeof provider !== "object") continue;
+    const p = provider as Record<string, unknown>;
+    const existingOptions = (p.options ?? {}) as Record<string, unknown>;
+    pinned[id] = {
+      ...p,
+      options: { ...existingOptions, baseURL: baseUrl },
+    };
+  }
+  if (Object.keys(pinned).length > 0) {
+    cfg.provider = { ...existingProvider, ...pinned };
+  }
+}
+
+/**
+ * Check if the Lore gateway is reachable at the given base URL.
+ * Short timeout so this doesn't delay OpenCode startup noticeably.
+ */
+export async function probeGateway(
+  baseURL: string,
+  timeoutMs = 1500,
+): Promise<boolean> {
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    const res = await fetch(`${baseURL}/health`, { signal: controller.signal });
+    clearTimeout(timer);
+    return res.ok;
+  } catch {
+    return false;
+  }
+}

--- a/packages/opencode/test/gateway-smoke.test.ts
+++ b/packages/opencode/test/gateway-smoke.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, afterAll } from "vitest";
-import { probeGateway } from "../src/index";
+import { probeGateway } from "../src/internal";
 
 /**
  * Smoke tests for the in-process gateway startup.

--- a/packages/opencode/test/index.test.ts
+++ b/packages/opencode/test/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from "vitest";
 import { fileURLToPath } from "node:url";
-import { LorePlugin, applyLoreProviderConfig } from "../src/index";
+import { LorePlugin } from "../src/index";
+import { applyLoreProviderConfig } from "../src/internal";
 import type { Plugin } from "@opencode-ai/plugin";
 
 /**
@@ -229,5 +230,35 @@ describe("LorePlugin hooks", () => {
     } finally {
       cleanup();
     }
+  });
+});
+
+describe("plugin entry module export shape", () => {
+  // Regression guard for the v1.17.4 crash (`undefined is not an object
+  // (evaluating 'A.event')`). OpenCode's legacy plugin loader treats EVERY
+  // function exported from the entry module as a plugin and invokes it
+  // (`getServerPlugin`/`getLegacyPlugins`), pushing the (often `undefined`)
+  // return value into the host hooks array. Leaking helper exports like
+  // `applyLoreProviderConfig`/`probeGateway` therefore crashed the host on the
+  // first event dispatch. The entry module must export ONLY the plugin
+  // function (named + default, pointing at the same reference).
+  test("exports only the plugin function (named + default, same ref)", async () => {
+    const mod = (await import("../src/index")) as Record<string, unknown>;
+
+    // The default export must be the LorePlugin function reference.
+    expect(typeof mod.default).toBe("function");
+    expect(mod.default).toBe(mod.LorePlugin);
+
+    // Simulate getLegacyPlugins: dedupe function-typed exports by reference.
+    const functionExports = Object.entries(mod).filter(
+      ([, value]) => typeof value === "function",
+    );
+    const uniqueFns = new Set(functionExports.map(([, value]) => value));
+
+    // After dedup there must be exactly ONE plugin function. Any extra
+    // distinct function export would be invoked as a plugin by the host and
+    // could push `undefined` into the hooks array.
+    expect(uniqueFns.size).toBe(1);
+    expect(uniqueFns.has(mod.LorePlugin)).toBe(true);
   });
 });

--- a/packages/opencode/test/index.test.ts
+++ b/packages/opencode/test/index.test.ts
@@ -235,29 +235,33 @@ describe("LorePlugin hooks", () => {
 
 describe("plugin entry module export shape", () => {
   // Regression guard for the v1.17.4 crash (`undefined is not an object
-  // (evaluating 'A.event')`). OpenCode's legacy plugin loader treats EVERY
-  // function exported from the entry module as a plugin and invokes it
-  // (`getServerPlugin`/`getLegacyPlugins`), pushing the (often `undefined`)
-  // return value into the host hooks array. Leaking helper exports like
-  // `applyLoreProviderConfig`/`probeGateway` therefore crashed the host on the
-  // first event dispatch. The entry module must export ONLY the plugin
-  // function (named + default, pointing at the same reference).
-  test("exports only the plugin function (named + default, same ref)", async () => {
+  // (evaluating 'A.event')`). OpenCode's legacy plugin loader iterates
+  // `Object.values(mod)` (`getLegacyPlugins`/`getServerPlugin`): every
+  // FUNCTION export is invoked as a plugin (and its return value pushed into
+  // the host hooks array — `applyLoreProviderConfig` returned `undefined`,
+  // which then crashed the dispatch loops), and every NON-function export
+  // makes the loader throw `Plugin export is not a function`, dropping the
+  // plugin entirely. So the entry module must export ONLY the plugin (the
+  // named `LorePlugin` and the same-reference `default`) — nothing else.
+  test("exports only the plugin (LorePlugin + same-ref default)", async () => {
     const mod = (await import("../src/index")) as Record<string, unknown>;
 
     // The default export must be the LorePlugin function reference.
     expect(typeof mod.default).toBe("function");
     expect(mod.default).toBe(mod.LorePlugin);
 
-    // Simulate getLegacyPlugins: dedupe function-typed exports by reference.
-    const functionExports = Object.entries(mod).filter(
-      ([, value]) => typeof value === "function",
-    );
-    const uniqueFns = new Set(functionExports.map(([, value]) => value));
+    // The ONLY export keys allowed are `LorePlugin` and `default`. Any other
+    // export — function OR not — breaks the legacy loader (functions get
+    // invoked as bogus plugins; non-functions make it throw). This is the
+    // strict guard: it catches both failure modes, including a future
+    // `export const FOO = ...` that a function-only filter would miss.
+    expect(Object.keys(mod).sort()).toEqual(["LorePlugin", "default"]);
 
-    // After dedup there must be exactly ONE plugin function. Any extra
-    // distinct function export would be invoked as a plugin by the host and
-    // could push `undefined` into the hooks array.
+    // Belt-and-suspenders: simulate getLegacyPlugins' reference dedup so the
+    // host invokes exactly one plugin function (the named + default pair).
+    const uniqueFns = new Set<unknown>(
+      Object.values(mod).filter((value) => typeof value === "function"),
+    );
     expect(uniqueFns.size).toBe(1);
     expect(uniqueFns.has(mod.LorePlugin)).toBe(true);
   });


### PR DESCRIPTION
## Problem

`@loreai/opencode` (published as `opencode-lore`) crashes on OpenCode **v1.17.4**:

> `undefined is not an object (evaluating 'A.event')` — Removed until compatibility is fixed.

## Root cause

The plugin entry module (`packages/opencode/src/index.ts`) exported two **test-only** helper functions — `applyLoreProviderConfig` and `probeGateway` — alongside the actual `LorePlugin` (and `export default LorePlugin`).

OpenCode loads lore via its **legacy plugin path**: `readV1Plugin` returns `undefined` for a function default export, so `applyPlugin` falls through to `getLegacyPlugins`. That function iterates `Object.values(mod)`, dedupes by reference (a `seen` Set), and `getServerPlugin` treats **any function** as a server plugin (`isServerPlugin = typeof === "function"`). So each distinct exported function is invoked as a plugin and its return value pushed into the host `hooks[]` array:

```js
// opencode 1.17.4: packages/opencode/src/plugin/index.ts
for (const server of getLegacyPlugins(load.mod)) {
  hooks.push(await server(input, load.options))
}
```

Because `default` is the **same reference** as the named `LorePlugin`, the dedup collapses them, so the pre-fix module pushed **three** entries:

- `applyLoreProviderConfig(...)` → returns `undefined` → **pushes `undefined`**
- `probeGateway(...)` → returns a `Promise<boolean>` → pushes a boolean (also not a valid hook)
- `LorePlugin(...)` → returns the real `Hooks` object

The dispatch loops then dereference the bad elements. The `undefined` element is the fatal one:

- `hook["event"]?.(...)` with `hook === undefined` → **`undefined is not an object (evaluating 'A.event')`** (`?.` guards the `.event` property, not the `undefined` `hook` element). In the event listener this becomes a `Die` defect → fatal "Unexpected server error".
- The same defect also surfaces on the `config` and `dispose` dispatch loops (`j.config` / `j.dispose`).

## Fix

- Move `applyLoreProviderConfig` + `probeGateway` into a new internal module `packages/opencode/src/internal.ts`. The plugin entry now exports only `LorePlugin` (+ same-ref `default`), so the legacy loader sees exactly one plugin function.
- Tests import the helpers from `../src/internal`.
- **Regression test**: asserts the entry module's export keys are exactly `{LorePlugin, default}`. This catches both legacy-loader failure modes — extra **function** exports (invoked as bogus plugins) and extra **non-function** exports (the loader throws `Plugin export is not a function` and drops the plugin).
- A warning comment above `export default LorePlugin` tells maintainers not to re-add exports here.

## Verification

- `tsc --noEmit` ✅
- 20/20 tests pass ✅ (the regression test fails if either a function or a non-function export is re-introduced — both confirmed)
- Biome lint clean ✅
- **End-to-end against the real `opencode-ai@1.17.4` binary**: plugin loads (`[lore] active`), and **0** occurrences of `A.event` / `j.config` / `j.dispose` / `Event observer failed` in the server log (vs. all of them before the fix).

## Upstream

The underlying host-side brittleness (loader invoking arbitrary function exports + missing `undefined`-hook guards in the `config`/`event`/`dispose` dispatch loops) should be reported to sst/opencode separately. This PR fully resolves the user-facing crash from lore's side.