### PR TITLE
fix(gradient): stabilize tool-output dedup across turns (messages[N] cache bust)

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1075,6 +1075,15 @@ const MIGRATIONS: string[] = [
   CREATE INDEX IF NOT EXISTS idx_knowledge_tombstones_project
     ON knowledge_tombstones (project_id);
   `,
+  `
+  -- Version 41: Cross-turn dedup decisions.
+  -- JSON map of "<messageID>:<partID>" -> wasCollapsed, recording whether each
+  -- tool output was sent full or collapsed. Persisted so the decision survives
+  -- a gateway restart: without it, the first post-restart turn re-derives dedup
+  -- from scratch and may flip an already-cached message (full <-> collapsed),
+  -- busting the prompt cache once. NULL for pre-v41 rows / sessions.
+  ALTER TABLE session_state ADD COLUMN dedup_decisions TEXT;
+  `,
 ];
 
 /**
@@ -1387,6 +1396,12 @@ function recoverMissingObjects(database: Database) {
     // Version 39: reorder-tolerant LTM diff-pin entry-set keys.
     if (!scols.some((c) => c.name === "ltm_pin_keys")) {
       database.exec("ALTER TABLE session_state ADD COLUMN ltm_pin_keys TEXT;");
+    }
+    // Version 41: cross-turn dedup decisions.
+    if (!scols.some((c) => c.name === "dedup_decisions")) {
+      database.exec(
+        "ALTER TABLE session_state ADD COLUMN dedup_decisions TEXT;",
+      );
     }
   }
 }
@@ -2022,6 +2037,8 @@ export type SessionTrackingState = {
   ltmPinTokens?: number | null;
   /** JSON array of sorted "id:hash(title+content)" keys for the pinned entry set (v39). */
   ltmPinKeys?: string | null;
+  /** JSON map of "<messageID>:<partID>" -> wasCollapsed for stable dedup (v41). */
+  dedupDecisions?: string | null;
   // v24: session identity
   fingerprint?: string;
   headerSessionId?: string | null;
@@ -2103,6 +2120,10 @@ export function saveSessionTracking(
   if (state.ltmPinKeys !== undefined) {
     sets.push("ltm_pin_keys = ?");
     vals.push(state.ltmPinKeys);
+  }
+  if (state.dedupDecisions !== undefined) {
+    sets.push("dedup_decisions = ?");
+    vals.push(state.dedupDecisions);
   }
   // v24: session identity
   if (state.fingerprint !== undefined) {
@@ -2197,6 +2218,7 @@ export type LoadedSessionTracking = {
   ltmPinTokens: number | null;
   // v39: reorder-tolerant pin entry-set keys (JSON)
   ltmPinKeys: string | null;
+  dedupDecisions: string | null;
   // v24: session identity
   fingerprint: string;
   headerSessionId: string | null;
@@ -2233,7 +2255,7 @@ export function loadSessionTracking(
       `SELECT last_curated_at, message_count, turns_since_curation,
               consecutive_text_only_turns,
               ltm_cache_text, ltm_cache_tokens, ltm_pin_text, ltm_pin_tokens,
-              ltm_pin_keys,
+              ltm_pin_keys, dedup_decisions,
               fingerprint, header_session_id, header_name,
               resolved_conversation_ttl, warmup_state,
               dynamic_context_cap, bust_rate_ema, inter_bust_interval_ema,
@@ -2253,6 +2275,7 @@ export function loadSessionTracking(
     ltm_pin_text: string | null;
     ltm_pin_tokens: number | null;
     ltm_pin_keys: string | null;
+    dedup_decisions: string | null;
     fingerprint: string;
     header_session_id: string | null;
     header_name: string | null;
@@ -2282,6 +2305,7 @@ export function loadSessionTracking(
     ltmPinText: row.ltm_pin_text,
     ltmPinTokens: row.ltm_pin_tokens,
     ltmPinKeys: row.ltm_pin_keys,
+    dedupDecisions: row.dedup_decisions,
     fingerprint: row.fingerprint,
     headerSessionId: row.header_session_id,
     headerName: row.header_name,

--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -377,6 +377,13 @@ type SessionState = {
    * marginal value mid-chain since the model already has raw messages.
    */
   distillationSnapshot: DistillationSnapshot | null;
+  /**
+   * Cross-turn dedup decisions, keyed by "<messageID>:<partID>" → wasCollapsed.
+   * Keeps deduplicateToolOutputs() stable as the conversation grows: a tool
+   * output already sent (full or collapsed) keeps that form so the prompt cache
+   * isn't busted by a newly-appended later duplicate flipping an early message.
+   */
+  dedupDecisions: Map<string, boolean>;
 };
 
 function makeSessionState(): SessionState {
@@ -400,6 +407,7 @@ function makeSessionState(): SessionState {
     zeroCacheWriteTurns: 0,
 
     distillationSnapshot: null,
+    dedupDecisions: new Map(),
   };
 }
 
@@ -492,6 +500,9 @@ export function onIdleResume(
   state.prefixCache = null;
   state.rawWindowCache = null;
   state.distillationSnapshot = null;
+  // Cache is cold after idle eviction — a fresh window will be rebuilt, so the
+  // stable-dedup memo can reset too (its purpose is warm-cache stability).
+  state.dedupDecisions.clear();
   state.cameOutOfIdle = true;
   state.postIdleCompact = !skipCompact;
   return { triggered: true, idleMs };
@@ -1098,6 +1109,16 @@ function dedupAnnotation(
 export function deduplicateToolOutputs(
   messages: MessageWithParts[],
   currentTurnIdx: number,
+  /**
+   * Optional per-session memo of prior collapse decisions, keyed by
+   * `"<messageID>:<partID>"` → wasCollapsed. Makes dedup STABLE across turns:
+   * once a tool output has been sent (full or collapsed) it keeps that form, so
+   * a newly-appended later duplicate can't retroactively flip an already-cached
+   * earlier message and bust the prompt cache. Caller persists this map across
+   * transform() calls (per session). When omitted, dedup is stateless (legacy
+   * behavior — still correct, just not cross-turn-stable).
+   */
+  stableDecisions?: Map<string, boolean>,
 ): MessageWithParts[] {
   // Track latest occurrence: contentKey → latest message index
   const contentLatest = new Map<string, number>();
@@ -1181,8 +1202,29 @@ export function deduplicateToolOutputs(
         }
       }
 
-      // Keep if this is both the latest content AND not covered by a later read
-      if (isLatestContent && !coveredByLater) return part;
+      // Cross-turn stability: if we already decided this exact tool part's
+      // fate on a prior turn, honor it verbatim. A part sent full stays full;
+      // a part collapsed stays collapsed. This prevents a newly-appended later
+      // duplicate from retroactively collapsing an already-cached earlier
+      // message (which would change its bytes and bust the prompt cache).
+      const decisionKey = stableDecisions
+        ? `${msg.info.id}:${part.id}`
+        : undefined;
+      const priorCollapsed = decisionKey
+        ? stableDecisions?.get(decisionKey)
+        : undefined;
+
+      // Fresh decision: keep if this is both the latest content AND not covered
+      // by a later read. A prior decision (when present) overrides this.
+      const freshKeep = isLatestContent && !coveredByLater;
+      const collapse = priorCollapsed ?? !freshKeep;
+
+      if (decisionKey && priorCollapsed === undefined) {
+        // Record the first-seen decision so it sticks on later turns.
+        stableDecisions?.set(decisionKey, collapse);
+      }
+
+      if (!collapse) return part;
 
       // This is a duplicate — replace with compact annotation.
       // Drop structured `blocks` — the content is being compressed away.
@@ -1544,6 +1586,43 @@ function distilledPrefixCached(
     prefixTokens: tokens,
   };
   return { messages, tokens };
+}
+
+/**
+ * Serialize the cross-turn dedup decision memo for a session to a JSON string,
+ * so the host can persist it (survives gateway restarts). Returns null when the
+ * session has no recorded decisions.
+ */
+export function exportDedupDecisions(sessionID: string): string | null {
+  const state = sessionStates.get(sessionID);
+  if (!state || state.dedupDecisions.size === 0) return null;
+  return JSON.stringify(Array.from(state.dedupDecisions.entries()));
+}
+
+/**
+ * Restore a previously-persisted dedup decision memo into a session's state.
+ * Ignores malformed input (the memo is an optimization — a bad blob just means
+ * the first post-restart turn re-derives decisions). Does not overwrite an
+ * already-populated in-memory memo.
+ */
+export function importDedupDecisions(sessionID: string, json: string): void {
+  const state = getSessionState(sessionID);
+  if (state.dedupDecisions.size > 0) return;
+  try {
+    const parsed = JSON.parse(json);
+    if (!Array.isArray(parsed)) return;
+    for (const entry of parsed) {
+      if (
+        Array.isArray(entry) &&
+        typeof entry[0] === "string" &&
+        typeof entry[1] === "boolean"
+      ) {
+        state.dedupDecisions.set(entry[0], entry[1]);
+      }
+    }
+  } catch {
+    // Corrupt blob — start fresh.
+  }
 }
 
 // For testing only — reset prefix cache state for a specific session (or all)
@@ -2083,7 +2162,14 @@ function transformInner(input: {
   // ones with compact annotations. This can save thousands of tokens for sessions
   // with repeated file reads, potentially avoiding escalation to higher layers.
   const turnStart = currentTurnStart(input.messages);
-  const dedupMessages = deduplicateToolOutputs(input.messages, turnStart);
+  // Pass the per-session decision memo so dedup stays byte-stable across turns
+  // (an already-sent output keeps its full/collapsed form). Only when we have a
+  // session to scope the memo to.
+  const dedupMessages = deduplicateToolOutputs(
+    input.messages,
+    turnStart,
+    sid ? sessState.dedupDecisions : undefined,
+  );
 
   const distillations = sid
     ? loadDistillationsCached(input.projectPath, sid, input.messages, sessState)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -116,6 +116,8 @@ export {
   shouldCompress,
   getTier,
   recordCacheUsage,
+  exportDedupDecisions,
+  importDedupDecisions,
   needsUrgentDistillation,
   calibrate,
   setLtmTokens,

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -50,7 +50,7 @@ describe("db", () => {
     const row = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(row.version).toBe(40);
+    expect(row.version).toBe(41);
   });
 
   test("knowledge_tombstones table exists (migration v40)", () => {
@@ -877,6 +877,7 @@ describe("db", () => {
       ltmPinText: "pinned LTM text",
       ltmPinTokens: 90,
       ltmPinKeys: JSON.stringify(["a:1", "b:2"]),
+      dedupDecisions: JSON.stringify([["m1:p1", true]]),
     });
     const loaded = loadSessionTracking(sid);
     expect(loaded).not.toBeNull();
@@ -888,6 +889,7 @@ describe("db", () => {
     expect(loaded?.ltmPinText).toBe("pinned LTM text");
     expect(loaded?.ltmPinTokens).toBe(90);
     expect(loaded?.ltmPinKeys).toBe(JSON.stringify(["a:1", "b:2"]));
+    expect(loaded?.dedupDecisions).toBe(JSON.stringify([["m1:p1", true]]));
   });
 
   test("saveSessionTracking partial update preserves other fields", () => {

--- a/packages/core/test/gradient.test.ts
+++ b/packages/core/test/gradient.test.ts
@@ -33,6 +33,8 @@ import {
   isFreeWriteSession,
   getTier,
   selectDistillations,
+  exportDedupDecisions,
+  importDedupDecisions,
 } from "../src/gradient";
 import type { LoreMessage, LorePart, LoreMessageWithParts } from "../src/types";
 import { isToolPart, isTextPart } from "../src/types";
@@ -1846,6 +1848,75 @@ function getToolOutput(part: LorePart): string | undefined {
 describe("deduplicateToolOutputs", () => {
   const LARGE_CONTENT = "x".repeat(800); // above DEDUP_MIN_CHARS (600)
 
+  test("cross-turn stability: an already-shown earlier output is NOT retroactively collapsed by a newly-appended duplicate", () => {
+    // Reproduces the messages[N] cache-bust: on turn N an early read has no
+    // later duplicate so it is sent FULL. On turn N+1 the user triggers the
+    // same read again (appended at the tail). dedup must NOT now collapse the
+    // early read — doing so changes the content of an already-cached message
+    // position and busts the prompt cache every time a file is re-read.
+    const readA = (id: string) =>
+      makeMsgWithTool(
+        id,
+        "assistant",
+        "read_file",
+        '{"path":"src/foo.ts"}',
+        LARGE_CONTENT,
+      );
+
+    // Shared per-session decision memo (as transform threads sessState.dedupDecisions).
+    const memo = new Map<string, boolean>();
+
+    // Turn N window: the early read at index 1 has no later duplicate.
+    const turnN = [
+      makeMsg("u1", "user", "read file A"),
+      readA("a1"),
+      makeMsg("u2", "user", "thanks"), // current turn
+    ];
+    const outN = deduplicateToolOutputs(turnN, 2, memo);
+    // Index 1 is sent in full on turn N.
+    expect(getToolOutput(outN[1].parts[0])).toBe(LARGE_CONTENT);
+
+    // Turn N+1: same conversation plus a NEW later duplicate read appended.
+    const turnN1 = [
+      makeMsg("u1", "user", "read file A"),
+      readA("a1"), // SAME early message — already cached on turn N
+      makeMsg("u2", "user", "thanks"),
+      makeMsg("u3", "user", "read file A again"),
+      readA("a3"), // new duplicate appended this turn
+      makeMsg("u4", "user", "ok"), // current turn
+    ];
+    const outN1 = deduplicateToolOutputs(turnN1, 5, memo);
+
+    // The early read at index 1 was already shown FULL on turn N; it must stay
+    // full so its cached bytes don't change. (Regression guard for the
+    // messages[N] window-content cache bust.)
+    expect(getToolOutput(outN1[1].parts[0])).toBe(LARGE_CONTENT);
+  });
+
+  test("stateless (no memo) preserves legacy behavior: later duplicate collapses the earlier read", () => {
+    const readA = (id: string) =>
+      makeMsgWithTool(
+        id,
+        "assistant",
+        "read_file",
+        '{"path":"src/foo.ts"}',
+        LARGE_CONTENT,
+      );
+    const msgs = [
+      makeMsg("u1", "user", "read file A"),
+      readA("a1"),
+      makeMsg("u3", "user", "read again"),
+      readA("a3"),
+      makeMsg("u4", "user", "ok"), // current turn
+    ];
+    // No memo passed → stateless: earlier read collapses (latest kept).
+    const out = deduplicateToolOutputs(msgs, 4);
+    expect(getToolOutput(out[1].parts[0])).toContain(
+      "earlier read of src/foo.ts",
+    );
+    expect(getToolOutput(out[3].parts[0])).toBe(LARGE_CONTENT);
+  });
+
   test("deduplicates identical tool outputs, keeps latest", () => {
     const msgs = [
       makeMsg("u1", "user", "read file A"),
@@ -2071,6 +2142,49 @@ describe("deduplicateToolOutputs", () => {
 
     // Third (latest) should be intact
     expect(getToolOutput(result[5].parts[0])).toBe(LARGE_CONTENT);
+  });
+});
+
+describe("dedup decision persistence (export/import round-trip)", () => {
+  const SID = "dedup-persist-session";
+
+  beforeEach(() => {
+    resetCalibration(SID);
+  });
+
+  test("export returns null when no decisions recorded", () => {
+    expect(exportDedupDecisions(SID)).toBeNull();
+  });
+
+  test("import then export round-trips the memo", () => {
+    const blob = JSON.stringify([
+      ["m1:p1", true],
+      ["m2:p2", false],
+    ]);
+    importDedupDecisions(SID, blob);
+    const out = exportDedupDecisions(SID);
+    expect(out).not.toBeNull();
+    // Order-independent comparison.
+    expect(new Map(JSON.parse(out as string))).toEqual(
+      new Map([
+        ["m1:p1", true],
+        ["m2:p2", false],
+      ]),
+    );
+  });
+
+  test("import ignores a corrupt blob (memo stays empty)", () => {
+    importDedupDecisions(SID, "{not json");
+    expect(exportDedupDecisions(SID)).toBeNull();
+  });
+
+  test("import does not overwrite an already-populated memo", () => {
+    importDedupDecisions(SID, JSON.stringify([["m1:p1", true]]));
+    // Second import (e.g. a stale restore) must not clobber live decisions.
+    importDedupDecisions(SID, JSON.stringify([["m9:p9", false]]));
+    const out = new Map(JSON.parse(exportDedupDecisions(SID) as string));
+    expect(out.has("m1:p1")).toBe(true);
+    expect(out.has("m9:p9")).toBe(false);
   });
 });
 

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -38,6 +38,8 @@ import {
   distillLimiter,
   curatorLimiter,
   recordCacheUsage,
+  exportDedupDecisions,
+  importDedupDecisions,
   calibrate,
   getLastTransformedCount,
   getLastTransformEstimate,
@@ -405,6 +407,7 @@ export async function resetPipelineState(opts?: {
   headerSessionIndex.clear();
   ltmSessionCache.clear();
   ltmPinnedText.clear();
+  lastSavedDedupDecisions.clear();
   stableLtmCache.clear();
   // Shut down the batch queue before clearing the client. On process exit
   // (`fast`), skip the synchronous LLM drain — replaying queued background
@@ -505,6 +508,12 @@ const ltmPinnedText = new Map<
   string,
   { formatted: string; tokenCount: number; entryKeys?: string[] }
 >();
+
+/**
+ * Last-persisted serialized dedup-decision memo per session — a change guard so
+ * we only write `dedup_decisions` to the DB on turns where it actually changed.
+ */
+const lastSavedDedupDecisions = new Map<string, string | undefined>();
 
 /**
  * FNV-1a 32-bit hash of a string, returned as a short hex string. Used to
@@ -992,6 +1001,7 @@ async function initIfNeeded(
         }
         ltmSessionCache.delete(sessionID);
         ltmPinnedText.delete(sessionID);
+        lastSavedDedupDecisions.delete(sessionID);
         stableLtmCache.delete(sessionID);
         cwdWarned.delete(sessionID);
         // Clear subagent parent-pending dedup entries for this session —
@@ -1569,6 +1579,11 @@ function getOrCreateSession(
         tokenCount: persisted.ltmPinTokens,
         ...(entryKeys ? { entryKeys } : {}),
       });
+    }
+    // Restore the cross-turn dedup decision memo so the first post-restart turn
+    // doesn't flip an already-cached message's full/collapsed form (v41).
+    if (persisted?.dedupDecisions) {
+      importDedupDecisions(sessionID, persisted.dedupDecisions);
     }
     sessions.set(sessionID, state);
   }
@@ -4894,6 +4909,17 @@ async function handleConversationTurn(
     const hasToolParts = last.parts.some((p) => p.type === "tool");
     if (hasToolParts) break;
     result.messages.pop();
+  }
+
+  // Persist the cross-turn dedup decision memo when it changed, so the stable
+  // full/collapsed form of each tool output survives a gateway restart (v41).
+  // Cheap change-guard avoids a DB write on turns where dedup didn't run.
+  {
+    const serialized = exportDedupDecisions(sessionID);
+    if (serialized !== lastSavedDedupDecisions.get(sessionID)) {
+      lastSavedDedupDecisions.set(sessionID, serialized ?? undefined);
+      saveSessionTracking(sessionID, { dedupDecisions: serialized });
+    }
   }
 
   // --- 7b. LTM refresh on emergency layer ---


### PR DESCRIPTION
Follow-up from live monitoring after #727/#729. With the system[2] LTM bug fixed, the dominant remaining cache-buster for long sessions was divergence at a **fixed early raw-window position** (`messages[10]`/`messages[12]`) with **no `pin-overflow`** — the window boundary was stable, but a message's *content* changed every turn, pinning hit rate at 5%.

## Root cause

`deduplicateToolOutputs()` collapses an earlier tool output whenever **any later message** has the same content (or a covering file read). As the conversation grows, a **newly-appended** later duplicate retroactively collapses an **already-cached earlier** message (full → annotation). That changes the bytes at a fixed early position → prompt-cache bust every time a file is re-read or a command re-run. The dedup result for an early message depended on *future* messages, so it wasn't stable across turns.

## Fix

Make the collapse decision **stable per session**:
- `deduplicateToolOutputs()` takes an optional decision memo keyed by `"<messageID>:<partID>" → wasCollapsed`. Once a tool output has been sent (full or collapsed) it keeps that form, so a new later duplicate can't flip an already-cached message.
- The memo lives in the gradient `SessionState`, is threaded from `transform()`, and cleared on idle resume (cache is cold then anyway).
- **Persisted to the DB** (`dedup_decisions` column, migration v41) so the form survives gateway restarts — no one-off bust on the first post-restart turn (same "survives restart" property as the LTM pin).
- When no memo is passed, the function keeps its **legacy stateless behavior** — all existing call sites/tests unaffected.

## Tests
- **Cross-turn stability regression**: an already-shown output is NOT retroactively collapsed by a newly-appended duplicate (this test fails without the fix).
- Legacy stateless behavior preserved (no memo → earlier duplicate still collapses).
- `export`/`import` round-trip, corrupt-blob guard, no-overwrite-live-memo guard.
- DB v41 schema + `dedup_decisions` round-trip.

Full core+gateway suites green (2867 passed); typecheck + biome clean.

## Note on the other two findings
Live triage found three distinct issues behind the "unsustainable" warning. This PR fixes the dominant one (dedup window-content churn). The other two are separate follow-ups: (a) **meta-distillation prefix rewrite** — reassessed as infrequent/legitimate post-restart (one-off when meta-distillation runs, not every turn); (b) **curator re-creating entries that consolidation deletes** — a curator-behavior thrash the tombstones (#729) don't cover. Tracked separately.