### PR TITLE
fix(core): stop pattern-echo/consolidation thrash (semantic dedup + maxEntries bump)

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -280,16 +280,16 @@ export const LoreConfig = z.object({
         .min(1)
         .default(3)
         .describe("Minimum turns between curator runs. Default: 3."),
-      /** Max knowledge entries per project before consolidation triggers. Default: 25. */
+      /** Max knowledge entries per project before consolidation triggers. Default: 40. */
       maxEntries: z
         .number()
         .min(10)
-        .default(25)
+        .default(40)
         .describe(
-          "Max knowledge entries per project before consolidation. Default: 25.",
+          "Max knowledge entries per project before consolidation. Default: 40.",
         ),
     })
-    .default({ enabled: true, onIdle: true, afterTurns: 3, maxEntries: 25 })
+    .default({ enabled: true, onIdle: true, afterTurns: 3, maxEntries: 40 })
     .describe("Curator scheduling and consolidation thresholds."),
   pruning: z
     .object({

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -405,6 +405,49 @@ export function findFuzzyDuplicate(input: {
   return null;
 }
 
+/**
+ * Find a SEMANTIC near-duplicate of the given title+content among existing
+ * entries (this project + cross-project), using embedding cosine similarity.
+ * Catches duplicates that `findFuzzyDuplicate` (title-word overlap) misses —
+ * e.g. the same behavioral preference auto-extracted twice with differently
+ * worded titles. Returns the closest match at or above EMBEDDING_DEDUP_THRESHOLD,
+ * or null. No-ops (returns null) when embeddings are unavailable.
+ *
+ * Used by pattern-echo to avoid re-creating a preference that is semantically
+ * already present (which would otherwise thrash with consolidation trimming).
+ */
+export async function findSemanticDuplicate(input: {
+  title: string;
+  content: string;
+  projectId: string | null;
+}): Promise<{ id: string; similarity: number } | null> {
+  if (!embedding.isAvailable()) return null;
+  let vec: Float32Array;
+  try {
+    [vec] = await embedding.embed(
+      [`${input.title}\n${input.content}`],
+      "document",
+    );
+  } catch (err) {
+    log.warn("findSemanticDuplicate: embed failed (non-fatal):", err);
+    return null;
+  }
+  // Search a few nearest neighbors, then keep only those visible to this
+  // project (same project or cross-project) — vectorSearch is global.
+  const hits = embedding.vectorSearch(vec, 10);
+  for (const hit of hits) {
+    if (hit.similarity < EMBEDDING_DEDUP_THRESHOLD) break; // sorted desc
+    const row = db()
+      .query(
+        `SELECT id FROM knowledge
+         WHERE id = ? AND (project_id = ? OR project_id IS NULL OR cross_project = 1)`,
+      )
+      .get(hit.id, input.projectId) as { id: string } | null;
+    if (row) return { id: row.id, similarity: hit.similarity };
+  }
+  return null;
+}
+
 export function forProject(
   projectPath: string,
   includeCross = true,

--- a/packages/core/src/pattern-echo.ts
+++ b/packages/core/src/pattern-echo.ts
@@ -196,6 +196,23 @@ async function _detect(input: {
     .get(pid, pattern.title) as { id: string } | null;
   if (existingPattern) return;
 
+  // Semantic dedup: the exact-title check above misses the same behavioral
+  // preference re-extracted with differently-worded titles. Without this,
+  // pattern-echo re-creates a near-duplicate that consolidation just trimmed,
+  // thrashing the entry count and re-running consolidation every few minutes.
+  // Skip creation when a semantically-equivalent entry already exists.
+  const semanticDup = await ltm.findSemanticDuplicate({
+    title: pattern.title,
+    content: pattern.content,
+    projectId: pid,
+  });
+  if (semanticDup) {
+    log.info(
+      `pattern echo: skipping near-duplicate (sim=${semanticDup.similarity.toFixed(3)}): "${pattern.title}"`,
+    );
+    return;
+  }
+
   try {
     ltm.create({
       projectPath: input.projectPath,

--- a/packages/core/test/config.test.ts
+++ b/packages/core/test/config.test.ts
@@ -97,12 +97,12 @@ describe("LoreConfig — loreFile schema", () => {
 });
 
 describe("LoreConfig — curator schema", () => {
-  test("curator defaults: enabled=true, onIdle=true, afterTurns=3, maxEntries=25", () => {
+  test("curator defaults: enabled=true, onIdle=true, afterTurns=3, maxEntries=40", () => {
     const cfg = LoreConfig.parse({});
     expect(cfg.curator.enabled).toBe(true);
     expect(cfg.curator.onIdle).toBe(true);
     expect(cfg.curator.afterTurns).toBe(3);
-    expect(cfg.curator.maxEntries).toBe(25);
+    expect(cfg.curator.maxEntries).toBe(40);
   });
 
   test("curator.maxEntries can be customised", () => {

--- a/packages/core/test/ltm.test.ts
+++ b/packages/core/test/ltm.test.ts
@@ -1995,3 +1995,86 @@ describe("ltm — cross-project promotion", () => {
     expect(ltm.get(d)?.promotion_status).toBeNull();
   });
 });
+
+describe("ltm.findSemanticDuplicate", () => {
+  const PROJ = "/test/ltm/semdup";
+  let availableSpy: ReturnType<typeof vi.spyOn>;
+  let embedSpy: ReturnType<typeof vi.spyOn>;
+
+  /** Deterministic unit-norm vector for a seed (same formula as injectEmbedding). */
+  function seedVec(seed: number, dims = 768): Float32Array {
+    const vec = new Float32Array(dims);
+    for (let i = 0; i < dims; i++) vec[i] = Math.sin(seed * (i + 1) * 0.1);
+    let norm = 0;
+    for (let i = 0; i < dims; i++) norm += vec[i] * vec[i];
+    norm = Math.sqrt(norm);
+    for (let i = 0; i < dims; i++) vec[i] /= norm;
+    return vec;
+  }
+
+  function seedEntry(title: string, seed: number): string {
+    const id = ltm.create({
+      id: uuidv7(),
+      projectPath: PROJ,
+      category: "preference",
+      title,
+      content: `content for ${title}`,
+      scope: "project",
+    });
+    db()
+      .query("UPDATE knowledge SET embedding = ? WHERE id = ?")
+      .run(Buffer.from(seedVec(seed).buffer), id);
+    return id;
+  }
+
+  beforeEach(() => {
+    const pid = ensureProject(PROJ);
+    db().query("DELETE FROM knowledge WHERE project_id = ?").run(pid);
+    availableSpy = vi.spyOn(embedding, "isAvailable").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    availableSpy.mockRestore();
+    embedSpy?.mockRestore();
+  });
+
+  test("returns a match when a semantically-identical entry exists (sim >= threshold)", async () => {
+    const existing = seedEntry("Always write tests after features", 7);
+    // Candidate embeds to the SAME vector → cosine 1.0 → above 0.935.
+    embedSpy = vi.spyOn(embedding, "embed").mockResolvedValue([seedVec(7)]);
+
+    const pid = ensureProject(PROJ);
+    const dup = await ltm.findSemanticDuplicate({
+      title: "Always add tests once a feature lands",
+      content: "differently worded but same behavior",
+      projectId: pid,
+    });
+    expect(dup?.id).toBe(existing);
+    expect(dup?.similarity).toBeGreaterThanOrEqual(0.935);
+  });
+
+  test("returns null when no entry is similar enough", async () => {
+    seedEntry("Use SQLite for storage", 3);
+    // Candidate embeds to a very different vector → low cosine → no match.
+    embedSpy = vi.spyOn(embedding, "embed").mockResolvedValue([seedVec(99)]);
+
+    const pid = ensureProject(PROJ);
+    const dup = await ltm.findSemanticDuplicate({
+      title: "Prefer Postgres for storage",
+      content: "unrelated wording",
+      projectId: pid,
+    });
+    expect(dup).toBeNull();
+  });
+
+  test("returns null (no-op) when embeddings are unavailable", async () => {
+    availableSpy.mockReturnValue(false);
+    const pid = ensureProject(PROJ);
+    const dup = await ltm.findSemanticDuplicate({
+      title: "anything",
+      content: "anything",
+      projectId: pid,
+    });
+    expect(dup).toBeNull();
+  });
+});

--- a/packages/gateway/src/cache-analytics.ts
+++ b/packages/gateway/src/cache-analytics.ts
@@ -367,11 +367,16 @@ export function analyzeCacheTurn(
         messageCount,
       );
 
-      // Capture and log diverging byte snippets for early divergences (< 5%
-      // prefix match) to help diagnose what the client is changing (e.g.
-      // timestamps, turn counters). Snippets are also stored on the result
-      // for Sentry span enrichment.
-      if (prefixMatchPercent < 0.05) {
+      // Capture and log diverging byte snippets to help diagnose what changed
+      // (e.g. timestamps, turn counters, host-side message re-rendering).
+      // Logged for early divergences (< 5% prefix match) AND for any
+      // mid-conversation messages[N] content change — the latter is the
+      // expensive "earlier message modified" case where we need to see whether
+      // the change originates upstream (host) or in lore's own pipeline.
+      const isMidConversationMessageChange =
+        /^messages\[\d+\]/.test(divergencePoint) &&
+        !divergenceReason.startsWith("new conversation message");
+      if (prefixMatchPercent < 0.05 || isMidConversationMessageChange) {
         const start = Math.max(0, prefixMatchBytes - 20);
         const end = prefixMatchBytes + 80;
         prevSnippet = prevBody.slice(start, Math.min(prevLength, end));

--- a/packages/website/src/content/docs/docs/configuration.md
+++ b/packages/website/src/content/docs/docs/configuration.md
@@ -129,7 +129,7 @@ Curator scheduling and consolidation thresholds.
 | `enabled` | boolean | `true` |  | Enable the curator (knowledge extraction from conversation). Default: true. |
 | `onIdle` | boolean | `true` |  | Run the curator on session idle (in addition to turn-based). Default: true. |
 | `afterTurns` | number | `3` | min 1 | Minimum turns between curator runs. Default: 3. |
-| `maxEntries` | number | `25` | min 10 | Max knowledge entries per project before consolidation. Default: 25. |
+| `maxEntries` | number | `40` | min 10 | Max knowledge entries per project before consolidation. Default: 40. |
 
 
 ## `pruning`


### PR DESCRIPTION
Live triage follow-up. Logs showed consolidation deleting **7-9 entries every few minutes on a loop** — re-running constantly and churning the injected knowledge set (which also contributes to cache pressure).

## Root cause

`pattern-echo` auto-creates 0.8-confidence preference entries, guarded only by an **exact-title** check. The same behavioral pattern, re-extracted later with a **differently-worded title**, slips past that guard and creates a near-duplicate. That pushes the project over `maxEntries`; consolidation trims the low-confidence prefs back; the next detection re-creates them. An endless create→delete loop.

## Fix (dedup smarter, don't block generation; raise the low cap)

- **`ltm.findSemanticDuplicate()`** — embedding cosine-similarity lookup (`EMBEDDING_DEDUP_THRESHOLD = 0.935`) over this project's + cross-project entries. Catches semantic duplicates that the title-overlap `findFuzzyDuplicate` misses. No-ops when embeddings are unavailable.
- **pattern-echo** consults it before creating and skips a semantic near-duplicate (in addition to the existing exact-title guard).
- **Bump `curator.maxEntries` default 25 → 40.** 25 was arbitrary and too low — active projects legitimately carry 30+ distinct entries, forcing near-constant consolidation.

## Diagnostic

Widen the cache-analytics byte-snippet logging to capture the prev/curr content for **any mid-conversation `messages[N]` divergence** (previously only logged for <5% prefix-match system busts). This lets us see *what* changes at a given message position — needed to distinguish host-side (OpenCode re-rendering a message) from lore-side changes for the layer-0 `messages[N]` busts still under investigation.

## Tests
- `findSemanticDuplicate`: match (sim ≥ 0.935) / no-match / embeddings-unavailable no-op.
- Updated curator default assertion (maxEntries = 40); regenerated config docs.

Full core suite green (1353 passed); typecheck, biome, and `check:docs` clean.