### PR TITLE
fix(gateway): stop mid-session curation cache busts; refresh stale prefs on cold idle

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -280,10 +280,14 @@ export const LoreConfig = z.object({
         .default(false)
         .describe(
           "Run the curator mid-conversation (turn-based), not just on idle. " +
-            "Default: false — mid-session curation changes the knowledge base, " +
-            "which rewrites the context-bound LTM block (system[2]) and busts " +
-            "the prompt cache for the rest of a large conversation. Deferring " +
-            "curation to idle makes that rewrite free (the cache is cold then).",
+            "Default: false. WARNING: only enable on free-write / non-caching " +
+            "providers (e.g. MiniMax). On cache-sensitive providers (Anthropic), " +
+            "mid-session curation changes the knowledge base, which rewrites the " +
+            "context-bound LTM block (system[2]) and busts the prompt cache for " +
+            "the rest of a large conversation (a single change can re-write " +
+            "hundreds of thousands of cached tokens). Deferring curation to idle " +
+            "makes that rewrite free (the cache is cold then). Where cache writes " +
+            "are free this is harmless and yields fresher knowledge sooner.",
         ),
       afterTurns: z
         .number()

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -275,6 +275,16 @@ export const LoreConfig = z.object({
         .describe(
           "Run the curator on session idle (in addition to turn-based). Default: true.",
         ),
+      inFlight: z
+        .boolean()
+        .default(false)
+        .describe(
+          "Run the curator mid-conversation (turn-based), not just on idle. " +
+            "Default: false — mid-session curation changes the knowledge base, " +
+            "which rewrites the context-bound LTM block (system[2]) and busts " +
+            "the prompt cache for the rest of a large conversation. Deferring " +
+            "curation to idle makes that rewrite free (the cache is cold then).",
+        ),
       afterTurns: z
         .number()
         .min(1)
@@ -289,7 +299,13 @@ export const LoreConfig = z.object({
           "Max knowledge entries per project before consolidation. Default: 40.",
         ),
     })
-    .default({ enabled: true, onIdle: true, afterTurns: 3, maxEntries: 40 })
+    .default({
+      enabled: true,
+      onIdle: true,
+      inFlight: false,
+      afterTurns: 3,
+      maxEntries: 40,
+    })
     .describe("Curator scheduling and consolidation thresholds."),
   pruning: z
     .object({

--- a/packages/core/test/config.test.ts
+++ b/packages/core/test/config.test.ts
@@ -97,10 +97,12 @@ describe("LoreConfig — loreFile schema", () => {
 });
 
 describe("LoreConfig — curator schema", () => {
-  test("curator defaults: enabled=true, onIdle=true, afterTurns=3, maxEntries=40", () => {
+  test("curator defaults: enabled=true, onIdle=true, inFlight=false, afterTurns=3, maxEntries=40", () => {
     const cfg = LoreConfig.parse({});
     expect(cfg.curator.enabled).toBe(true);
     expect(cfg.curator.onIdle).toBe(true);
+    // Off by default: mid-session curation rewrites system[2] and busts cache.
+    expect(cfg.curator.inFlight).toBe(false);
     expect(cfg.curator.afterTurns).toBe(3);
     expect(cfg.curator.maxEntries).toBe(40);
   });

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -554,6 +554,45 @@ export function ltmEntryKeys(
     .sort();
 }
 
+/** system[1] (stable LTM) cache breakpoint TTL in ms. Once an idle gap exceeds
+ *  this, that prefix is cold and can be rebuilt with fresh preferences for free. */
+export const STABLE_LTM_TTL_MS = 3_600_000; // 1h — matches the system[1] cache_control
+
+/**
+ * Decide whether in-flight (turn-based) curation should run this turn.
+ * Off by default (`curator.inFlight === false`): mid-session curation rewrites
+ * system[2] and busts the prompt cache. Pure/testable.
+ */
+export function shouldRunInFlightCuration(input: {
+  knowledgeEnabled: boolean;
+  inFlight: boolean;
+  turnsSinceCuration: number;
+  effectiveAfterTurns: number;
+  curationScheduled: boolean;
+  curatorBusy: boolean;
+}): boolean {
+  return (
+    input.knowledgeEnabled &&
+    input.inFlight &&
+    input.turnsSinceCuration >= input.effectiveAfterTurns &&
+    !input.curationScheduled &&
+    !input.curatorBusy
+  );
+}
+
+/**
+ * Decide whether the stable LTM block (system[1]: preferences + entities) should
+ * be refreshed on an idle resume. Only when the idle gap exceeds the system[1]
+ * 1h cache TTL — that prefix is then cold, so rebuilding it with freshly-curated
+ * preferences costs nothing. Shorter gaps keep it pinned. Pure/testable.
+ */
+export function shouldRefreshStableLtm(
+  idleTriggered: boolean,
+  idleMs: number,
+): boolean {
+  return idleTriggered && idleMs >= STABLE_LTM_TTL_MS;
+}
+
 /**
  * Extract the entry-ID portion ("<id>" before the ":") from a sorted entry-key
  * array. Used to feed the previous turn's selected set back into forSession()
@@ -3612,11 +3651,14 @@ function scheduleBackgroundWork(
   // (idle.ts), where the cache is cold so the rewrite is free. `turnsSinceCuration`
   // keeps accumulating during the active conversation and fires on the next idle.
   if (
-    cfg.knowledge.enabled &&
-    cfg.curator.inFlight &&
-    sessionState.turnsSinceCuration >= effectiveAfterTurns &&
-    !sessionState.curationScheduled &&
-    !curatorLimiter.isBusy(sessionID)
+    shouldRunInFlightCuration({
+      knowledgeEnabled: cfg.knowledge.enabled,
+      inFlight: cfg.curator.inFlight,
+      turnsSinceCuration: sessionState.turnsSinceCuration,
+      effectiveAfterTurns,
+      curationScheduled: !!sessionState.curationScheduled,
+      curatorBusy: curatorLimiter.isBusy(sessionID),
+    })
   ) {
     sessionState.curationScheduled = true;
     runBackground(
@@ -4668,11 +4710,9 @@ async function handleConversationTurn(
     // costs nothing. (Lore promotes long-running sessions; without this they
     // would keep using stale preferences indefinitely.) A shorter idle gap
     // leaves system[1] warm, so we keep it pinned to preserve the 1h cache.
-    const STABLE_LTM_TTL_MS = 3_600_000; // 1h — matches the system[1] breakpoint
-    let refreshedStable = false;
-    if (idleResult.idleMs >= STABLE_LTM_TTL_MS) {
+    const refreshedStable = shouldRefreshStableLtm(true, idleResult.idleMs);
+    if (refreshedStable) {
       stableLtmCache.delete(sessionID);
-      refreshedStable = true;
     }
     log.info(
       `session idle ${Math.round(idleResult.idleMs / 60_000)}min — refreshing caches` +

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -3606,9 +3606,14 @@ function scheduleBackgroundWork(
   //  - `curatorLimiter.isBusy` (durable across ticks): also covers the
   //    idle-path curation (idle.ts) which doesn't set curationScheduled.
   // Mirrors the incremental-distill guard above and the idle-path guard.
+  // In-flight (turn-based) curation is OFF by default: changing the knowledge
+  // base mid-conversation rewrites system[2] (context-bound LTM) and busts the
+  // prompt cache for the rest of a large session. Curation still runs on idle
+  // (idle.ts), where the cache is cold so the rewrite is free. `turnsSinceCuration`
+  // keeps accumulating during the active conversation and fires on the next idle.
   if (
     cfg.knowledge.enabled &&
-    cfg.curator.onIdle &&
+    cfg.curator.inFlight &&
     sessionState.turnsSinceCuration >= effectiveAfterTurns &&
     !sessionState.curationScheduled &&
     !curatorLimiter.isBusy(sessionID)
@@ -4657,8 +4662,21 @@ async function handleConversationTurn(
       ltmCacheText: null,
       ltmCacheTokens: null,
     });
+    // Refresh the stable LTM block (system[1]: preferences + entities) too, but
+    // ONLY when the idle gap exceeds system[1]'s own 1h cache TTL — i.e. that
+    // prefix is already cold, so rebuilding it with freshly-curated preferences
+    // costs nothing. (Lore promotes long-running sessions; without this they
+    // would keep using stale preferences indefinitely.) A shorter idle gap
+    // leaves system[1] warm, so we keep it pinned to preserve the 1h cache.
+    const STABLE_LTM_TTL_MS = 3_600_000; // 1h — matches the system[1] breakpoint
+    let refreshedStable = false;
+    if (idleResult.idleMs >= STABLE_LTM_TTL_MS) {
+      stableLtmCache.delete(sessionID);
+      refreshedStable = true;
+    }
     log.info(
       `session idle ${Math.round(idleResult.idleMs / 60_000)}min — refreshing caches` +
+        (refreshedStable ? " (incl. stable LTM — 1h cold)" : "") +
         (cacheWarm ? " (cache warm — skipping compact)" : ""),
     );
   }

--- a/packages/gateway/test/curation-cache-stability.test.ts
+++ b/packages/gateway/test/curation-cache-stability.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Tests for the two cache-stability decisions added to the curation pipeline:
+ *  - in-flight (turn-based) curation gating (off by default), and
+ *  - cold-boundary refresh of the stable LTM block (system[1]).
+ *
+ * These are the pure decision functions extracted from handleRequest so the
+ * actual gating logic is unit-tested (not just the config default).
+ */
+import { describe, test, expect } from "vitest";
+import {
+  shouldRunInFlightCuration,
+  shouldRefreshStableLtm,
+  STABLE_LTM_TTL_MS,
+} from "../src/pipeline";
+
+describe("shouldRunInFlightCuration", () => {
+  const base = {
+    knowledgeEnabled: true,
+    inFlight: true,
+    turnsSinceCuration: 5,
+    effectiveAfterTurns: 3,
+    curationScheduled: false,
+    curatorBusy: false,
+  };
+
+  test("runs when all conditions are met and inFlight is enabled", () => {
+    expect(shouldRunInFlightCuration(base)).toBe(true);
+  });
+
+  test("does NOT run when inFlight is off (the default) even past the threshold", () => {
+    // This is the fix: mid-session curation is gated off by default so it can't
+    // rewrite system[2] and bust the prompt cache during an active conversation.
+    expect(shouldRunInFlightCuration({ ...base, inFlight: false })).toBe(false);
+  });
+
+  test("does NOT run before the turn threshold", () => {
+    expect(shouldRunInFlightCuration({ ...base, turnsSinceCuration: 2 })).toBe(
+      false,
+    );
+  });
+
+  test("does NOT run when knowledge is disabled", () => {
+    expect(
+      shouldRunInFlightCuration({ ...base, knowledgeEnabled: false }),
+    ).toBe(false);
+  });
+
+  test("does NOT run when a curation is already scheduled (coalesce)", () => {
+    expect(
+      shouldRunInFlightCuration({ ...base, curationScheduled: true }),
+    ).toBe(false);
+  });
+
+  test("does NOT run when the curator limiter is busy (coalesce)", () => {
+    expect(shouldRunInFlightCuration({ ...base, curatorBusy: true })).toBe(
+      false,
+    );
+  });
+});
+
+describe("shouldRefreshStableLtm", () => {
+  test("refreshes when idle gap exceeds the 1h system[1] TTL", () => {
+    expect(shouldRefreshStableLtm(true, STABLE_LTM_TTL_MS)).toBe(true);
+    expect(shouldRefreshStableLtm(true, STABLE_LTM_TTL_MS + 60_000)).toBe(true);
+  });
+
+  test("does NOT refresh when system[1] is still warm (gap < 1h)", () => {
+    // A 5-minute idle resume cools the conversation cache but NOT the pinned
+    // 1h system[1] block — keep it pinned to preserve the cache investment.
+    expect(shouldRefreshStableLtm(true, 5 * 60_000)).toBe(false);
+    expect(shouldRefreshStableLtm(true, STABLE_LTM_TTL_MS - 1)).toBe(false);
+  });
+
+  test("does NOT refresh when there was no idle resume at all", () => {
+    expect(shouldRefreshStableLtm(false, STABLE_LTM_TTL_MS * 10)).toBe(false);
+  });
+
+  test("STABLE_LTM_TTL_MS matches the 1h system[1] cache breakpoint", () => {
+    expect(STABLE_LTM_TTL_MS).toBe(3_600_000);
+  });
+});

--- a/packages/website/src/content/docs/docs/configuration.md
+++ b/packages/website/src/content/docs/docs/configuration.md
@@ -128,7 +128,7 @@ Curator scheduling and consolidation thresholds.
 |---|---|---|---|---|
 | `enabled` | boolean | `true` |  | Enable the curator (knowledge extraction from conversation). Default: true. |
 | `onIdle` | boolean | `true` |  | Run the curator on session idle (in addition to turn-based). Default: true. |
-| `inFlight` | boolean | `false` |  | Run the curator mid-conversation (turn-based), not just on idle. Default: false — mid-session curation changes the knowledge base, which rewrites the context-bound LTM block (system[2]) and busts the prompt cache for the rest of a large conversation. Deferring curation to idle makes that rewrite free (the cache is cold then). |
+| `inFlight` | boolean | `false` |  | Run the curator mid-conversation (turn-based), not just on idle. Default: false. WARNING: only enable on free-write / non-caching providers (e.g. MiniMax). On cache-sensitive providers (Anthropic), mid-session curation changes the knowledge base, which rewrites the context-bound LTM block (system[2]) and busts the prompt cache for the rest of a large conversation (a single change can re-write hundreds of thousands of cached tokens). Deferring curation to idle makes that rewrite free (the cache is cold then). Where cache writes are free this is harmless and yields fresher knowledge sooner. |
 | `afterTurns` | number | `3` | min 1 | Minimum turns between curator runs. Default: 3. |
 | `maxEntries` | number | `40` | min 10 | Max knowledge entries per project before consolidation. Default: 40. |
 

--- a/packages/website/src/content/docs/docs/configuration.md
+++ b/packages/website/src/content/docs/docs/configuration.md
@@ -128,6 +128,7 @@ Curator scheduling and consolidation thresholds.
 |---|---|---|---|---|
 | `enabled` | boolean | `true` |  | Enable the curator (knowledge extraction from conversation). Default: true. |
 | `onIdle` | boolean | `true` |  | Run the curator on session idle (in addition to turn-based). Default: true. |
+| `inFlight` | boolean | `false` |  | Run the curator mid-conversation (turn-based), not just on idle. Default: false — mid-session curation changes the knowledge base, which rewrites the context-bound LTM block (system[2]) and busts the prompt cache for the rest of a large conversation. Deferring curation to idle makes that rewrite free (the cache is cold then). |
 | `afterTurns` | number | `3` | min 1 | Minimum turns between curator runs. Default: 3. |
 | `maxEntries` | number | `40` | min 10 | Max knowledge entries per project before consolidation. Default: 40. |
 


### PR DESCRIPTION
Root-caused from live logs (`journalctl -u opencode`). A long **warm** session (100% cache hit for many turns) suddenly dropped to **6% hit / 549K-token cache WRITE** on a single turn:

```
turn=17 hit=6% read=35927 create=549136 prefixMatch=2.5%
divergence="system[2].text" reason="context-bound LTM changed (non-preference entries re-ranked)"
WARN: dramatic hit rate drop: 100% → 6%
```

…immediately after an in-flight `curation: 0 created, 2 updated` + `1 created`.

## Cause

**In-flight (turn-based) curation runs mid-conversation, changes the knowledge base, and forces a full `system[2]` (context-bound LTM) rewrite.** Because `system[2]` sits before the entire conversation, rewriting it invalidates the whole downstream prompt cache. #727's sticky-set fix removed the *per-turn* churn, but any **legitimate** knowledge change still pays this catastrophic full bust on a large session.

## Fix

**1. Pause in-flight curation by default.** New `curator.inFlight` config (default `false`). Curation still runs on idle (`idle.ts`), where the cache is cold so the `system[2]` rewrite is **free**. `turnsSinceCuration` keeps accumulating during the active conversation and fires on the next idle. Set `curator.inFlight: true` to restore turn-based curation.

**2. Refresh stale preferences on a fully-cold idle resume.** `system[1]` (preferences + entities) is pinned at a 1h cache TTL and was *never* refreshed mid-session — so long-running sessions (which Lore promotes) kept using stale preferences indefinitely. Now, when the idle gap exceeds 1h, that prefix is already cold, so `stableLtmCache` is cleared and rebuilt with freshly-curated preferences at **zero cache cost**. Shorter idle gaps leave `system[1]` warm and keep it pinned.

## Why `system[1]` only refreshes on cold (not the same as `system[2]`)
`system[1]` has its own 1h `cache_control` breakpoint; `system[2]` rides the 5m conversation cache. So `system[1]` is only safe to rebuild once its own 1h TTL has elapsed — gated on `idleMs >= 1h`.

## Follow-up (separate PR)
A volatile **knowledge-delta channel**: surface ID-referenced changed/new entries in the always-rewritten conversation tail (post-cache-breakpoint), so updates appear **immediately even on warm sessions** at zero cache cost — without rebuilding the pinned blocks.

## Tests
Curator defaults assert `inFlight=false`; docs regenerated. Full core+gateway suites green (2870 passed); typecheck, biome, `check:docs` clean.