### PR TITLE
fix(cch): anchor cch signing to billing header to stop self-referential cache busts

### DIFF
--- a/packages/gateway/src/cache-analytics.ts
+++ b/packages/gateway/src/cache-analytics.ts
@@ -47,9 +47,21 @@ export function decompressBody(compressed: Uint8Array): string {
  * variable-width replacements are safe (offsets stay aligned across turns).
  */
 
-/** Claude Code content-cache hash: changes every turn. */
-const CCH_PATTERN = /cch=[0-9a-fA-F]+;/g;
-const CCH_REPLACEMENT = "cch=__;";
+/**
+ * Claude Code content-cache hash: changes every turn.
+ *
+ * Matches the billing-header form (`cch=abcde;`) AND content occurrences that
+ * appear as markdown code spans or quoted text (`` `cch=abcde` ``,
+ * `"cch=abcde"`) or bare/whitespace-terminated tokens. These content tokens
+ * are NOT real upstream cache busts (Anthropic strips `cch=` before computing
+ * its cache key), but if left un-normalized they produce false-positive
+ * `messages[N]`/`system[N]` divergence in this analytics comparison.
+ *
+ * The trailing terminator (`;`, backtick, quote, whitespace, or end) is kept
+ * out of the match so it is preserved and byte offsets stay aligned.
+ */
+const CCH_PATTERN = /cch=[0-9a-fA-F]+(?=[;`"'\s\\]|$)/g;
+const CCH_REPLACEMENT = "cch=__";
 
 /**
  * Claude Code version suffix: 3 hex chars derived from

--- a/packages/gateway/src/cch.ts
+++ b/packages/gateway/src/cch.ts
@@ -102,6 +102,17 @@ const WORKER_SALT = "59cf53e54c78";
 
 const CCH_PLACEHOLDER = "cch=00000";
 
+/**
+ * Matches the `cch=00000` placeholder ONLY when it sits inside a billing
+ * header (i.e. immediately preceded by `cc_entrypoint=<value>; `). This
+ * prevents `signBody` from rewriting a `cch=00000` that happens to appear in
+ * arbitrary system / LTM / message content — which would silently mutate the
+ * cached prefix every turn and bust the entire prompt cache.
+ *
+ * Capture group 1 is the `cc_entrypoint=...; ` prefix so it can be preserved.
+ */
+const BILLING_PLACEHOLDER_RE = /(cc_entrypoint=[^;]*;\s*)cch=0{5}/;
+
 // ---------------------------------------------------------------------------
 // Signing
 // ---------------------------------------------------------------------------
@@ -110,12 +121,23 @@ const CCH_PLACEHOLDER = "cch=00000";
  * Compute the `cch` hash for a JSON request body containing `cch=00000`.
  * Returns the body with the placeholder replaced by the computed hash.
  *
- * @param bodyWithPlaceholder — JSON string containing `cch=00000`
- * @returns body with `cch=00000` replaced by `cch=XXXXX`
+ * Only the billing-header placeholder is rewritten: the replacement is
+ * anchored to the `cc_entrypoint=...; ` prefix so a `cch=00000` literal in
+ * conversation/LTM content is never touched. The hash itself is still
+ * computed over the entire body bytes (matching Claude Code's algorithm).
+ *
+ * @param bodyWithPlaceholder — JSON string containing a billing `cch=00000`
+ * @returns body with the billing `cch=00000` replaced by `cch=XXXXX`
  */
 export function signBody(bodyWithPlaceholder: string): string {
   const hash = xxHash64(bodyWithPlaceholder, WORKER_SEED);
   const cch = (hash & 0xfffffn).toString(16).padStart(5, "0");
+  if (BILLING_PLACEHOLDER_RE.test(bodyWithPlaceholder)) {
+    return bodyWithPlaceholder.replace(BILLING_PLACEHOLDER_RE, `$1cch=${cch}`);
+  }
+  // Fallback for callers/tests that pass a bare placeholder with no billing
+  // header context (e.g. `{"text":"cch=00000;"}`): replace the first literal
+  // occurrence, preserving prior behavior.
   return bodyWithPlaceholder.replace(CCH_PLACEHOLDER, `cch=${cch}`);
 }
 
@@ -143,11 +165,16 @@ function computeVersionSuffix(firstUserMessage: string): string {
 
 /**
  * Regex matching a billing header's cch field in a serialized JSON body.
- * The cch value is exactly 5 hex chars followed by a semicolon.
- * Used to detect conversation turns that need re-signing after body
- * reconstruction by buildAnthropicRequest.
+ * The cch value is exactly 5 hex chars followed by a semicolon, and it must
+ * be anchored to the `cc_entrypoint=...; ` prefix so we only ever match the
+ * billing header — never a `cch=XXXXX;` token that appears inside LTM /
+ * system / message content. Matching a content token would rewrite it every
+ * turn and bust the entire prompt cache.
+ *
+ * Capture group 1 is the `cc_entrypoint=...; ` prefix (preserved on replace);
+ * group 2 is the 5-hex cch value.
  */
-const CCH_IN_BODY_RE = /cch=([0-9a-fA-F]{5});/;
+const CCH_IN_BODY_RE = /(cc_entrypoint=[^;]*;\s*)cch=([0-9a-fA-F]{5});/;
 
 /**
  * Regex matching the cc_version field in a billing header.
@@ -188,8 +215,10 @@ export function resignBody(
   const suffix = computeVersionSuffix(firstUserMessage);
   body = body.replace(CC_VERSION_RE, `cc_version=${WORKER_VERSION}.${suffix};`);
 
-  // Step 2: Replace existing cch with placeholder
-  body = body.replace(CCH_IN_BODY_RE, `${CCH_PLACEHOLDER};`);
+  // Step 2: Replace the billing header's existing cch with the placeholder.
+  // Anchored to the cc_entrypoint prefix so a cch= token in content is left
+  // untouched (preserving prefix-cache stability).
+  body = body.replace(CCH_IN_BODY_RE, `$1${CCH_PLACEHOLDER};`);
 
   // Step 3: Hash and replace placeholder with computed value
   return signBody(body);
@@ -546,13 +575,15 @@ export function resolveSeed(version: string): {
  * @returns null if no cch found, true if a seed matches, false if none match
  */
 export function validateSeed(body: string): boolean | null {
-  const cchMatch = body.match(/cch=([0-9a-fA-F]{5});/);
+  // Anchor to the billing header so a cch= token in content can't be
+  // mistaken for the signed billing cch.
+  const cchMatch = body.match(CCH_IN_BODY_RE);
   if (!cchMatch) return null;
 
-  const clientCch = cchMatch[1].toLowerCase();
+  const clientCch = cchMatch[2].toLowerCase();
   const bodyWithPlaceholder = body.replace(
-    `cch=${cchMatch[1]}`,
-    CCH_PLACEHOLDER,
+    CCH_IN_BODY_RE,
+    `$1${CCH_PLACEHOLDER};`,
   );
 
   for (const seed of Object.values(VERSION_SEEDS)) {

--- a/packages/gateway/src/cch.ts
+++ b/packages/gateway/src/cch.ts
@@ -103,15 +103,35 @@ const WORKER_SALT = "59cf53e54c78";
 const CCH_PLACEHOLDER = "cch=00000";
 
 /**
- * Matches the `cch=00000` placeholder ONLY when it sits inside a billing
- * header (i.e. immediately preceded by `cc_entrypoint=<value>; `). This
- * prevents `signBody` from rewriting a `cch=00000` that happens to appear in
- * arbitrary system / LTM / message content — which would silently mutate the
- * cached prefix every turn and bust the entire prompt cache.
+ * The full billing-header sentinel as it appears in a serialized JSON body:
  *
- * Capture group 1 is the `cc_entrypoint=...; ` prefix so it can be preserved.
+ *   x-anthropic-billing-header: cc_version=<semver>.<suffix>; cc_entrypoint=<x>; cch=<value>;
+ *
+ * We anchor every cch / cc_version rewrite to this whole shape rather than to
+ * a bare `cc_entrypoint=…;` or `cch=…;` fragment. This makes the rewrite
+ * STRUCTURAL, not positional: a token in system / LTM / message content can
+ * only be mistaken for the header if it reproduces the entire header verbatim
+ * (the same self-referential class that caused the original incident — an LTM
+ * entry documenting the header format). The fragment-anchored form was
+ * defeated by content that serializes *before* the real header.
+ *
+ * Capture groups:
+ *   1 = `x-anthropic-billing-header: ` prefix + `cc_version=` up to the suffix
+ *       (everything before the 3-hex suffix, preserved verbatim)
+ *   — handled per-call; see BILLING_HEADER_SIGN_RE / BILLING_HEADER_RESIGN_RE.
+ *
+ * The value classes are intentionally permissive (`[^;]*`) for cc_version /
+ * cc_entrypoint so we tolerate client variations, but the cch field is pinned
+ * to its exact shape (5 hex for a signed value, `00000` for the placeholder).
  */
-const BILLING_PLACEHOLDER_RE = /(cc_entrypoint=[^;]*;\s*)cch=0{5}/;
+const BILLING_HEADER_PREFIX = String.raw`x-anthropic-billing-header:\s*cc_version=[^;]*;\s*cc_entrypoint=[^;]*;\s*`;
+
+/**
+ * Matches the billing header ending in the `cch=00000` placeholder. Group 1
+ * is the entire header up to and including `cch=` so it is preserved on
+ * replace; the `00000` is swapped for the computed hash.
+ */
+const BILLING_SIGN_RE = new RegExp(`(${BILLING_HEADER_PREFIX}cch=)0{5}`);
 
 // ---------------------------------------------------------------------------
 // Signing
@@ -122,9 +142,13 @@ const BILLING_PLACEHOLDER_RE = /(cc_entrypoint=[^;]*;\s*)cch=0{5}/;
  * Returns the body with the placeholder replaced by the computed hash.
  *
  * Only the billing-header placeholder is rewritten: the replacement is
- * anchored to the `cc_entrypoint=...; ` prefix so a `cch=00000` literal in
- * conversation/LTM content is never touched. The hash itself is still
+ * anchored to the full `x-anthropic-billing-header: …` sentinel so a
+ * `cch=00000` literal in conversation/LTM content is never touched, regardless
+ * of where it serializes relative to the header. The hash itself is still
  * computed over the entire body bytes (matching Claude Code's algorithm).
+ *
+ * If no billing header is present the body is returned unchanged — there is
+ * nothing to sign, and we must never rewrite a bare content `cch=00000`.
  *
  * @param bodyWithPlaceholder — JSON string containing a billing `cch=00000`
  * @returns body with the billing `cch=00000` replaced by `cch=XXXXX`
@@ -132,13 +156,7 @@ const BILLING_PLACEHOLDER_RE = /(cc_entrypoint=[^;]*;\s*)cch=0{5}/;
 export function signBody(bodyWithPlaceholder: string): string {
   const hash = xxHash64(bodyWithPlaceholder, WORKER_SEED);
   const cch = (hash & 0xfffffn).toString(16).padStart(5, "0");
-  if (BILLING_PLACEHOLDER_RE.test(bodyWithPlaceholder)) {
-    return bodyWithPlaceholder.replace(BILLING_PLACEHOLDER_RE, `$1cch=${cch}`);
-  }
-  // Fallback for callers/tests that pass a bare placeholder with no billing
-  // header context (e.g. `{"text":"cch=00000;"}`): replace the first literal
-  // occurrence, preserving prior behavior.
-  return bodyWithPlaceholder.replace(CCH_PLACEHOLDER, `cch=${cch}`);
+  return bodyWithPlaceholder.replace(BILLING_SIGN_RE, `$1${cch}`);
 }
 
 /**
@@ -164,23 +182,33 @@ function computeVersionSuffix(firstUserMessage: string): string {
 // ---------------------------------------------------------------------------
 
 /**
- * Regex matching a billing header's cch field in a serialized JSON body.
- * The cch value is exactly 5 hex chars followed by a semicolon, and it must
- * be anchored to the `cc_entrypoint=...; ` prefix so we only ever match the
- * billing header — never a `cch=XXXXX;` token that appears inside LTM /
- * system / message content. Matching a content token would rewrite it every
- * turn and bust the entire prompt cache.
+ * Matches a full client-signed billing header in a serialized JSON body and
+ * captures every variable field so cc_version AND cch can be rewritten in a
+ * single anchored pass:
  *
- * Capture group 1 is the `cc_entrypoint=...; ` prefix (preserved on replace);
- * group 2 is the 5-hex cch value.
+ *   group 1 = cc_version base (MAJOR.MINOR.PATCH)
+ *   group 2 = cc_version suffix (3 hex)
+ *   group 3 = cc_entrypoint value
+ *   group 4 = cch value (5 hex)
+ *
+ * Anchored to the full `x-anthropic-billing-header:` sentinel so neither field
+ * can be matched against a `cc_version=…;` / `cch=…;` token that appears in
+ * LTM / system / message content — even if that content serializes BEFORE the
+ * real header. Matching content would rewrite it every turn and bust the
+ * entire prompt cache (the original incident's failure mode).
  */
-const CCH_IN_BODY_RE = /(cc_entrypoint=[^;]*;\s*)cch=([0-9a-fA-F]{5});/;
+const BILLING_RESIGN_RE =
+  /x-anthropic-billing-header:\s*cc_version=(\d+\.\d+\.\d+)\.([0-9a-f]{3});\s*cc_entrypoint=([^;]*);\s*cch=([0-9a-fA-F]{5});/;
 
 /**
- * Regex matching the cc_version field in a billing header.
- * Format: cc_version=MAJOR.MINOR.PATCH.SUFFIX (suffix is 3 hex chars).
+ * Matches a full signed billing header for validation. Group 1 is the whole
+ * header up to and including `cch=` (preserved on replace); group 2 is the
+ * 5-hex signed value. Anchored so a content `cch=…;` token is never validated
+ * in place of the real header.
  */
-const CC_VERSION_RE = /cc_version=(\d+\.\d+\.\d+)\.([0-9a-f]{3});/;
+const BILLING_VALIDATE_RE = new RegExp(
+  `(${BILLING_HEADER_PREFIX}cch=)([0-9a-fA-F]{5});`,
+);
 
 /**
  * Re-sign a serialized request body that contains a client-signed billing
@@ -189,11 +217,10 @@ const CC_VERSION_RE = /cc_version=(\d+\.\d+\.\d+)\.([0-9a-f]{3});/;
  * wrappers, message transforms) — invalidating the client's original cch.
  *
  * The function:
- *   1. Detects `cch=XXXXX` in the serialized body — returns unchanged if absent
- *   2. Replaces `cc_version=X.Y.Z.abc` with our worker version + recomputed suffix
- *   3. Replaces `cch=XXXXX` with `cch=00000` placeholder
- *   4. Hashes with our known seed → compute new cch
- *   5. Replaces `cch=00000` with the computed value
+ *   1. Detects a full billing header — returns unchanged if absent
+ *   2. Rewrites cc_version (worker version + recomputed suffix) AND cch
+ *      (→ placeholder) in a single anchored pass over the header
+ *   3. Hashes the resulting body with our known seed and stamps the cch
  *
  * @param serializedBody — JSON string after JSON.stringify(body)
  * @param firstUserMessage — text of the first user message (for version suffix)
@@ -203,24 +230,25 @@ export function resignBody(
   serializedBody: string,
   firstUserMessage: string,
 ): string {
-  // Quick check: no billing header → return unchanged
-  if (!CCH_IN_BODY_RE.test(serializedBody)) {
+  // Quick check: no billing header → return unchanged. Anchored match ensures
+  // a content cch=/cc_version= token never qualifies.
+  if (!BILLING_RESIGN_RE.test(serializedBody)) {
     return serializedBody;
   }
 
-  let body = serializedBody;
-
-  // Step 1: Replace cc_version with our worker version + recomputed suffix.
-  // The suffix depends on chars[4,7,20] from the first user message.
+  // Step 1+2: in a single anchored replace, swap cc_version for our worker
+  // version + recomputed suffix and reset cch to the placeholder. cc_entrypoint
+  // (group 3) is preserved verbatim. The suffix depends on chars[4,7,20] of the
+  // first user message.
   const suffix = computeVersionSuffix(firstUserMessage);
-  body = body.replace(CC_VERSION_RE, `cc_version=${WORKER_VERSION}.${suffix};`);
+  const body = serializedBody.replace(
+    BILLING_RESIGN_RE,
+    (_m, _base, _suf, entrypoint) =>
+      `x-anthropic-billing-header: cc_version=${WORKER_VERSION}.${suffix};` +
+      ` cc_entrypoint=${entrypoint}; ${CCH_PLACEHOLDER};`,
+  );
 
-  // Step 2: Replace the billing header's existing cch with the placeholder.
-  // Anchored to the cc_entrypoint prefix so a cch= token in content is left
-  // untouched (preserving prefix-cache stability).
-  body = body.replace(CCH_IN_BODY_RE, `$1${CCH_PLACEHOLDER};`);
-
-  // Step 3: Hash and replace placeholder with computed value
+  // Step 3: Hash and replace placeholder with computed value (anchored).
   return signBody(body);
 }
 
@@ -575,15 +603,18 @@ export function resolveSeed(version: string): {
  * @returns null if no cch found, true if a seed matches, false if none match
  */
 export function validateSeed(body: string): boolean | null {
-  // Anchor to the billing header so a cch= token in content can't be
-  // mistaken for the signed billing cch.
-  const cchMatch = body.match(CCH_IN_BODY_RE);
+  // Anchor to the full billing header so a cch= token in content can't be
+  // mistaken for the signed billing cch. Group 1 = entire header up to and
+  // including `cch=` (preserved); group 2 = the 5-hex signed value. cc_version
+  // is intentionally left as-received — we validate the signature as sent.
+  const cchMatch = body.match(BILLING_VALIDATE_RE);
   if (!cchMatch) return null;
 
   const clientCch = cchMatch[2].toLowerCase();
+  // Group 1 already ends with `cch=`, so only the value + `;` follow.
   const bodyWithPlaceholder = body.replace(
-    CCH_IN_BODY_RE,
-    `$1${CCH_PLACEHOLDER};`,
+    BILLING_VALIDATE_RE,
+    (_m, prefix) => `${prefix}00000;`,
   );
 
   for (const seed of Object.values(VERSION_SEEDS)) {

--- a/packages/gateway/src/cch.ts
+++ b/packages/gateway/src/cch.ts
@@ -108,21 +108,26 @@ const CCH_PLACEHOLDER = "cch=00000";
  *   x-anthropic-billing-header: cc_version=<semver>.<suffix>; cc_entrypoint=<x>; cch=<value>;
  *
  * We anchor every cch / cc_version rewrite to this whole shape rather than to
- * a bare `cc_entrypoint=…;` or `cch=…;` fragment. This makes the rewrite
- * STRUCTURAL, not positional: a token in system / LTM / message content can
- * only be mistaken for the header if it reproduces the entire header verbatim
- * (the same self-referential class that caused the original incident — an LTM
- * entry documenting the header format). The fragment-anchored form was
- * defeated by content that serializes *before* the real header.
+ * a bare `cc_entrypoint=…;` or `cch=…;` fragment. A token in system / LTM /
+ * message content can only be mistaken for the header if it reproduces the
+ * ENTIRE `x-anthropic-billing-header: …` sentinel verbatim — a far narrower
+ * surface than the bare `cch=`/`cc_entrypoint=` fragment the original fix
+ * caught, which was defeated by content (an LTM entry documenting the header
+ * format) serializing before the real header.
  *
- * Capture groups:
- *   1 = `x-anthropic-billing-header: ` prefix + `cc_version=` up to the suffix
- *       (everything before the 3-hex suffix, preserved verbatim)
- *   — handled per-call; see BILLING_HEADER_SIGN_RE / BILLING_HEADER_RESIGN_RE.
+ * Residual: these regexes are first-match, so a content block that reproduces
+ * the whole sentinel AND serializes *before* the real header would still be
+ * rewritten. In practice the real billing header is always the FIRST system
+ * block (the worker prepends it via `buildBillingBlock`; Claude Code emits it
+ * as system[0], which `BILLING_HEADER_RE` enforces with a `^` anchor), and
+ * nothing in a serialized body precedes system[0] except the JSON envelope —
+ * so no content can sort before it. The two-sentinel ordering is covered by a
+ * regression test that locks in "real header (first block) wins".
  *
  * The value classes are intentionally permissive (`[^;]*`) for cc_version /
- * cc_entrypoint so we tolerate client variations, but the cch field is pinned
- * to its exact shape (5 hex for a signed value, `00000` for the placeholder).
+ * cc_entrypoint so we tolerate client variations (e.g. a missing 3-hex version
+ * suffix), but the cch field is pinned to its exact shape (5 hex for a signed
+ * value, `00000` for the placeholder).
  */
 const BILLING_HEADER_PREFIX = String.raw`x-anthropic-billing-header:\s*cc_version=[^;]*;\s*cc_entrypoint=[^;]*;\s*`;
 
@@ -142,10 +147,12 @@ const BILLING_SIGN_RE = new RegExp(`(${BILLING_HEADER_PREFIX}cch=)0{5}`);
  * Returns the body with the placeholder replaced by the computed hash.
  *
  * Only the billing-header placeholder is rewritten: the replacement is
- * anchored to the full `x-anthropic-billing-header: …` sentinel so a
- * `cch=00000` literal in conversation/LTM content is never touched, regardless
- * of where it serializes relative to the header. The hash itself is still
- * computed over the entire body bytes (matching Claude Code's algorithm).
+ * anchored to the full `x-anthropic-billing-header: …` sentinel so a bare
+ * `cch=00000` literal in conversation/LTM content is never touched (it lacks
+ * the sentinel prefix). Because the real header is always system[0], no
+ * content can serialize before it, so first-match always targets it. The hash
+ * itself is still computed over the entire body bytes (matching Claude Code's
+ * algorithm).
  *
  * If no billing header is present the body is returned unchanged — there is
  * nothing to sign, and we must never rewrite a bare content `cch=00000`.
@@ -182,14 +189,19 @@ function computeVersionSuffix(firstUserMessage: string): string {
 // ---------------------------------------------------------------------------
 
 /**
- * Matches a full client-signed billing header in a serialized JSON body and
- * captures every variable field so cc_version AND cch can be rewritten in a
- * single anchored pass:
+ * Matches a full client-signed billing header in a serialized JSON body so
+ * cc_version AND cch can be rewritten in a single anchored pass. We rewrite the
+ * whole `cc_version=…;` and `cch=…;` segments wholesale (we don't need to
+ * preserve the client's version/suffix — they're replaced with the worker's),
+ * so only cc_entrypoint is captured for preservation:
  *
- *   group 1 = cc_version base (MAJOR.MINOR.PATCH)
- *   group 2 = cc_version suffix (3 hex)
- *   group 3 = cc_entrypoint value
- *   group 4 = cch value (5 hex)
+ *   group 1 = cc_entrypoint value (preserved verbatim)
+ *
+ * The cc_version value class is permissive: the suffix is optional and
+ * case-insensitive (`cc_version=[^;]*`) so a client header that omits the
+ * 3-hex suffix still re-signs rather than silently passing through a stale
+ * cch (which upstream would reject). The cch value is pinned to its signed
+ * shape (5 hex, case-insensitive).
  *
  * Anchored to the full `x-anthropic-billing-header:` sentinel so neither field
  * can be matched against a `cc_version=…;` / `cch=…;` token that appears in
@@ -198,7 +210,7 @@ function computeVersionSuffix(firstUserMessage: string): string {
  * entire prompt cache (the original incident's failure mode).
  */
 const BILLING_RESIGN_RE =
-  /x-anthropic-billing-header:\s*cc_version=(\d+\.\d+\.\d+)\.([0-9a-f]{3});\s*cc_entrypoint=([^;]*);\s*cch=([0-9a-fA-F]{5});/;
+  /x-anthropic-billing-header:\s*cc_version=[^;]*;\s*cc_entrypoint=([^;]*);\s*cch=[0-9a-fA-F]{5};/;
 
 /**
  * Matches a full signed billing header for validation. Group 1 is the whole
@@ -238,12 +250,12 @@ export function resignBody(
 
   // Step 1+2: in a single anchored replace, swap cc_version for our worker
   // version + recomputed suffix and reset cch to the placeholder. cc_entrypoint
-  // (group 3) is preserved verbatim. The suffix depends on chars[4,7,20] of the
+  // (group 1) is preserved verbatim. The suffix depends on chars[4,7,20] of the
   // first user message.
   const suffix = computeVersionSuffix(firstUserMessage);
   const body = serializedBody.replace(
     BILLING_RESIGN_RE,
-    (_m, _base, _suf, entrypoint) =>
+    (_m, entrypoint) =>
       `x-anthropic-billing-header: cc_version=${WORKER_VERSION}.${suffix};` +
       ` cc_entrypoint=${entrypoint}; ${CCH_PLACEHOLDER};`,
   );

--- a/packages/gateway/test/cache-analytics.test.ts
+++ b/packages/gateway/test/cache-analytics.test.ts
@@ -490,6 +490,20 @@ describe("normalizeBodyForComparison", () => {
     expect(normalizeBodyForComparison(body)).toBe("cch=__; some text cch=__;");
   });
 
+  test("normalizes backtick/quote-terminated cch= tokens in content", () => {
+    // Markdown code span (`` `cch=2d825` ``) and quoted forms previously
+    // slipped past the `;`-only pattern, producing false-positive divergence.
+    expect(normalizeBodyForComparison("note: `cch=2d825` end")).toBe(
+      "note: `cch=__` end",
+    );
+    expect(normalizeBodyForComparison('"cch=64ee6"')).toBe('"cch=__"');
+    // Two turns with different content hashes normalize identically → no
+    // false-positive divergence.
+    expect(normalizeBodyForComparison("x `cch=2d825` y")).toBe(
+      normalizeBodyForComparison("x `cch=928b9` y"),
+    );
+  });
+
   test("normalizes cc_version suffix to fixed placeholder", () => {
     const body =
       '{"system":[{"type":"text","text":"x-anthropic-billing-header: cc_version=2.1.37.5a7; cc_entrypoint=cli; cch=__;\\nYou are Claude Code"}]}';

--- a/packages/gateway/test/cch.test.ts
+++ b/packages/gateway/test/cch.test.ts
@@ -80,6 +80,63 @@ describe("signBody", () => {
       expect(match?.[1]).toHaveLength(5);
     }
   });
+
+  test("does NOT rewrite a cch=00000 token in system/LTM content (cache-bust regression)", () => {
+    // Regression for the self-referential cache bust: an LTM entry whose text
+    // literally contains `cch=00000` must be left untouched, otherwise system[N]
+    // bytes change every turn and bust the entire prompt cache.
+    const body = JSON.stringify({
+      model: "claude-opus-4-8",
+      system: [
+        {
+          type: "text",
+          text: "x-anthropic-billing-header: cc_version=2.1.165.abc; cc_entrypoint=cli; cch=00000;",
+        },
+        {
+          type: "text",
+          // LTM content documenting the placeholder — contains cch=00000.
+          text: "CCH_PLACEHOLDER = `cch=00000` (cch.ts:103); signBody() replaces it.",
+        },
+      ],
+      messages: [{ role: "user", content: "hello" }],
+    });
+
+    const signed = signBody(body);
+    // The LTM content placeholder must be preserved verbatim.
+    expect(signed).toContain("CCH_PLACEHOLDER = `cch=00000`");
+    // Exactly one cch=00000 (the content one) should remain; the billing
+    // header's was rewritten to a real hash.
+    const placeholderCount = signed.split("cch=00000").length - 1;
+    expect(placeholderCount).toBe(1);
+    // The billing header carries a real signed hash.
+    const billing = JSON.parse(signed).system[0].text as string;
+    expect(billing).toMatch(/cc_entrypoint=cli; cch=[0-9a-f]{5};/);
+    expect(billing).not.toContain("cch=00000");
+  });
+
+  test("signing is stable across turns when only content cch changes", () => {
+    // Two turns where the billing header is identical but the (irrelevant)
+    // content cch token differs — the billing cch must be identical, proving
+    // content tokens don't leak into the signature target.
+    const make = (contentCch: string) =>
+      JSON.stringify({
+        model: "claude-opus-4-8",
+        system: [
+          {
+            type: "text",
+            text: "x-anthropic-billing-header: cc_version=2.1.165.abc; cc_entrypoint=cli; cch=00000;",
+          },
+          { type: "text", text: `note: \`cch=${contentCch}\`` },
+        ],
+        messages: [{ role: "user", content: "same" }],
+      });
+
+    const a = signBody(make("11111"));
+    const b = signBody(make("11111"));
+    expect(a).toBe(b);
+    // Both preserve their distinct content tokens untouched.
+    expect(signBody(make("aaaaa"))).toContain("`cch=aaaaa`");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -567,6 +624,48 @@ describe("resignBody", () => {
     expect(resigned).not.toContain("cch=abcde");
     expect(resigned).toMatch(/cch=[0-9a-f]{5};/);
     expect(validateSeed(resigned)).toBe(true);
+  });
+
+  test("does NOT rewrite a cch=XXXXX; token in content (cache-bust regression)", () => {
+    // A conversation turn whose LTM/system or message content contains a
+    // `cch=XXXXX;` token must keep that token byte-for-byte across re-signing,
+    // otherwise the cached prefix changes every turn.
+    const body = JSON.stringify({
+      model: "claude-opus-4-8",
+      system: [
+        {
+          type: "text",
+          text: "x-anthropic-billing-header: cc_version=2.1.35.abc; cc_entrypoint=cli; cch=deadb;",
+          cache_control: { type: "ephemeral", ttl: "1h" },
+        },
+        {
+          type: "text",
+          // Content token with the exact 5-hex-plus-semicolon shape.
+          text: "gotcha: CCH_IN_BODY_RE = /cch=([0-9a-fA-F]{5});/ matched cch=2d825; here",
+        },
+      ],
+      messages: [{ role: "user", content: "explain caching" }],
+    });
+
+    const resigned = resignBody(body, "explain caching");
+    // Content token preserved verbatim.
+    expect(resigned).toContain("cch=2d825;");
+    // Billing header re-signed (client value gone, valid worker hash present).
+    expect(resigned).not.toContain("cch=deadb");
+    expect(validateSeed(resigned)).toBe(true);
+    // Re-signing twice is idempotent for the content token (stable prefix).
+    expect(resignBody(resigned, "explain caching")).toContain("cch=2d825;");
+  });
+
+  test("leaves the body unchanged when only content cch= tokens exist (no billing header)", () => {
+    // No billing header present — resignBody must be a pure no-op even though
+    // content contains cch= tokens.
+    const body = JSON.stringify({
+      model: "claude-opus-4-8",
+      system: [{ type: "text", text: "note: `cch=12345` and cch=67890;" }],
+      messages: [{ role: "user", content: "hi" }],
+    });
+    expect(resignBody(body, "hi")).toBe(body);
   });
 });
 

--- a/packages/gateway/test/cch.test.ts
+++ b/packages/gateway/test/cch.test.ts
@@ -36,6 +36,23 @@ beforeEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("signBody", () => {
+  /**
+   * Build a body whose system prompt carries a real billing header with the
+   * `cch=00000` placeholder, plus an arbitrary `extra` payload to vary the
+   * hash input. signBody only signs a genuine billing header, so the
+   * placeholder must live inside one.
+   */
+  const billingBody = (extra: string) =>
+    JSON.stringify({
+      system: [
+        {
+          type: "text",
+          text: "x-anthropic-billing-header: cc_version=2.1.37.fbe; cc_entrypoint=cli; cch=00000;",
+        },
+      ],
+      messages: [{ role: "user", content: extra }],
+    });
+
   test("replaces cch=00000 with a 5-char hex hash", () => {
     const body = JSON.stringify({
       model: "claude-sonnet-4-20250514",
@@ -54,13 +71,8 @@ describe("signBody", () => {
   });
 
   test("produces different hashes for different bodies", () => {
-    const body1 =
-      '{"system":[{"type":"text","text":"cch=00000;"}],"messages":[{"role":"user","content":"hello"}]}';
-    const body2 =
-      '{"system":[{"type":"text","text":"cch=00000;"}],"messages":[{"role":"user","content":"world"}]}';
-
-    const cch1 = signBody(body1).match(/cch=([0-9a-f]{5})/)?.[1];
-    const cch2 = signBody(body2).match(/cch=([0-9a-f]{5})/)?.[1];
+    const cch1 = signBody(billingBody("hello")).match(/cch=([0-9a-f]{5})/)?.[1];
+    const cch2 = signBody(billingBody("world")).match(/cch=([0-9a-f]{5})/)?.[1];
 
     expect(cch1).toBeDefined();
     expect(cch2).toBeDefined();
@@ -68,17 +80,51 @@ describe("signBody", () => {
   });
 
   test("produces deterministic output for the same input", () => {
-    const body = '{"text":"cch=00000;","data":"stable"}';
+    const body = billingBody("stable");
     expect(signBody(body)).toEqual(signBody(body));
   });
 
   test("zero-pads short hashes to 5 chars", () => {
     for (let i = 0; i < 20; i++) {
-      const body = `{"text":"cch=00000;","i":${i}}`;
-      const match = signBody(body).match(/cch=([0-9a-f]+);/);
+      const signed = signBody(billingBody(`i${i}`));
+      const match = signed.match(/cch=([0-9a-f]+);/);
       expect(match).not.toBeNull();
       expect(match?.[1]).toHaveLength(5);
     }
+  });
+
+  test("is a no-op when no billing header is present (structural anchor)", () => {
+    // Reviewer #3: the bare-placeholder fallback re-introduced the original
+    // bug. signBody must NEVER rewrite a content cch=00000 with no header.
+    const body =
+      '{"system":[{"type":"text","text":"docs: `cch=00000`"}],"messages":[]}';
+    expect(signBody(body)).toBe(body);
+  });
+
+  test("signs the billing header even when content cch=00000 sorts FIRST", () => {
+    // Reviewer #1: content documenting the header (serialized before it) must
+    // not steal the signature. The content placeholder stays; the header is
+    // signed.
+    const body = JSON.stringify({
+      system: [
+        {
+          type: "text",
+          text: "LTM doc: cc_entrypoint=cli; cch=00000 (example)",
+        },
+        {
+          type: "text",
+          text: "x-anthropic-billing-header: cc_version=2.1.37.fbe; cc_entrypoint=cli; cch=00000;",
+        },
+      ],
+      messages: [{ role: "user", content: "hi" }],
+    });
+    const signed = signBody(body);
+    // Content placeholder preserved verbatim.
+    expect(signed).toContain("cc_entrypoint=cli; cch=00000 (example)");
+    // Billing header signed with a real hash.
+    expect(signed).toMatch(
+      /x-anthropic-billing-header: cc_version=2\.1\.37\.fbe; cc_entrypoint=cli; cch=[0-9a-f]{5};/,
+    );
   });
 
   test("does NOT rewrite a cch=00000 token in system/LTM content (cache-bust regression)", () => {
@@ -666,6 +712,95 @@ describe("resignBody", () => {
       messages: [{ role: "user", content: "hi" }],
     });
     expect(resignBody(body, "hi")).toBe(body);
+  });
+
+  test("ignores a content `cc_entrypoint=…; cch=…;` fragment that sorts BEFORE the header", () => {
+    // Reviewer #1: an LTM entry documenting the header format (containing
+    // `cc_entrypoint=cli; cch=…;`) serialized before the real header must NOT
+    // steal the rewrite. Fragment-anchoring was defeated by exactly this.
+    const body = JSON.stringify({
+      model: "claude-opus-4-8",
+      system: [
+        {
+          type: "text",
+          // Looks like a header fragment but lacks the full sentinel prefix.
+          text: "gotcha doc: format is `cc_entrypoint=cli; cch=aaaaa;` — note the suffix",
+        },
+        {
+          type: "text",
+          text: "x-anthropic-billing-header: cc_version=2.1.35.abc; cc_entrypoint=cli; cch=deadb;",
+          cache_control: { type: "ephemeral", ttl: "1h" },
+        },
+      ],
+      messages: [{ role: "user", content: "explain caching" }],
+    });
+
+    const resigned = resignBody(body, "explain caching");
+    // The documented fragment is preserved verbatim.
+    expect(resigned).toContain("`cc_entrypoint=cli; cch=aaaaa;`");
+    // Only the real header was re-signed.
+    expect(resigned).not.toContain("cch=deadb");
+    expect(validateSeed(resigned)).toBe(true);
+    // Stable across turns: the content fragment never changes.
+    expect(resignBody(resigned, "explain caching")).toContain(
+      "`cc_entrypoint=cli; cch=aaaaa;`",
+    );
+  });
+
+  test("ignores a content `cc_version=…;` token that sorts BEFORE the header (reviewer #2)", () => {
+    // Reviewer #2: the cc_version rewrite was fully unanchored. A content
+    // `cc_version=2.1.35.abc;` before the header must be left untouched, else
+    // it is rewritten every turn → cache bust.
+    const body = JSON.stringify({
+      model: "claude-opus-4-8",
+      system: [
+        {
+          type: "text",
+          text: "changelog: bumped cc_version=2.1.35.abc; in the client header",
+        },
+        {
+          type: "text",
+          text: "x-anthropic-billing-header: cc_version=2.1.35.abc; cc_entrypoint=cli; cch=deadb;",
+          cache_control: { type: "ephemeral", ttl: "1h" },
+        },
+      ],
+      messages: [{ role: "user", content: "explain caching" }],
+    });
+
+    const resigned = resignBody(body, "explain caching");
+    // The content cc_version token is preserved verbatim (NOT rewritten to
+    // the worker version).
+    expect(resigned).toContain(
+      "changelog: bumped cc_version=2.1.35.abc; in the client header",
+    );
+    // The header's cc_version WAS rewritten to the worker version.
+    expect(resigned).toMatch(
+      new RegExp(
+        `x-anthropic-billing-header: cc_version=${WORKER_VERSION}\\.[0-9a-f]{3}; cc_entrypoint=cli; cch=[0-9a-f]{5};`,
+      ),
+    );
+    expect(validateSeed(resigned)).toBe(true);
+    // Idempotent: content token stays stable across re-signs.
+    expect(resignBody(resigned, "explain caching")).toContain(
+      "changelog: bumped cc_version=2.1.35.abc; in the client header",
+    );
+  });
+
+  test("preserves a non-default cc_entrypoint value", () => {
+    // The single-pass rewrite must keep cc_entrypoint (group 3) verbatim.
+    const body = JSON.stringify({
+      model: "claude-opus-4-8",
+      system: [
+        {
+          type: "text",
+          text: "x-anthropic-billing-header: cc_version=2.1.35.abc; cc_entrypoint=vscode; cch=deadb;",
+        },
+      ],
+      messages: [{ role: "user", content: "hi" }],
+    });
+    const resigned = resignBody(body, "hi");
+    expect(resigned).toContain("cc_entrypoint=vscode;");
+    expect(validateSeed(resigned)).toBe(true);
   });
 });
 

--- a/packages/gateway/test/cch.test.ts
+++ b/packages/gateway/test/cch.test.ts
@@ -787,7 +787,7 @@ describe("resignBody", () => {
   });
 
   test("preserves a non-default cc_entrypoint value", () => {
-    // The single-pass rewrite must keep cc_entrypoint (group 3) verbatim.
+    // The single-pass rewrite must keep cc_entrypoint verbatim.
     const body = JSON.stringify({
       model: "claude-opus-4-8",
       system: [
@@ -800,6 +800,77 @@ describe("resignBody", () => {
     });
     const resigned = resignBody(body, "hi");
     expect(resigned).toContain("cc_entrypoint=vscode;");
+    expect(validateSeed(resigned)).toBe(true);
+  });
+
+  test("the real header (first system block) wins over a full-sentinel doc block after it", () => {
+    // Review #1 residual: even if an LTM entry reproduces the WHOLE sentinel,
+    // the real header is always system[0] and nothing serializes before it, so
+    // first-match targets the real header. The doc block (which carries a
+    // placeholder) is left as-is.
+    const body = JSON.stringify({
+      system: [
+        {
+          type: "text",
+          text: "x-anthropic-billing-header: cc_version=2.1.35.abc; cc_entrypoint=cli; cch=deadb;",
+          cache_control: { type: "ephemeral", ttl: "1h" },
+        },
+        {
+          type: "text",
+          // LTM doc reproducing the full sentinel with the placeholder.
+          text: "docs: header looks like `x-anthropic-billing-header: cc_version=2.1.0.aaa; cc_entrypoint=cli; cch=00000;`",
+        },
+      ],
+      messages: [{ role: "user", content: "explain caching" }],
+    });
+    const resigned = resignBody(body, "explain caching");
+    // The doc block's placeholder is untouched (still 00000).
+    expect(resigned).toContain(
+      "`x-anthropic-billing-header: cc_version=2.1.0.aaa; cc_entrypoint=cli; cch=00000;`",
+    );
+    // The real header was re-signed and validates.
+    expect(resigned).not.toContain("cch=deadb");
+    expect(validateSeed(resigned)).toBe(true);
+  });
+
+  test("re-signs a client header WITHOUT a 3-hex version suffix (no silent skip → no 401)", () => {
+    // Review #2: a suffix-less header must still re-sign rather than pass the
+    // stale client cch through (which upstream rejects).
+    const body = JSON.stringify({
+      system: [
+        {
+          type: "text",
+          text: "x-anthropic-billing-header: cc_version=2.1.165; cc_entrypoint=cli; cch=deadb;",
+        },
+      ],
+      messages: [{ role: "user", content: "hi there friend" }],
+    });
+    const resigned = resignBody(body, "hi there friend");
+    expect(resigned).not.toContain("cch=deadb");
+    expect(resigned).toMatch(
+      new RegExp(
+        `cc_version=${WORKER_VERSION}\\.[0-9a-f]{3}; cc_entrypoint=cli;`,
+      ),
+    );
+    expect(validateSeed(resigned)).toBe(true);
+  });
+
+  test("re-signs a client header with an UPPERCASE version suffix and cch", () => {
+    // Review #3: casing tolerance — uppercase suffix/cch must not silently skip.
+    const body = JSON.stringify({
+      system: [
+        {
+          type: "text",
+          text: "x-anthropic-billing-header: cc_version=2.1.163.7C7; cc_entrypoint=cli; cch=DEADB;",
+        },
+      ],
+      messages: [{ role: "user", content: "hi there friend" }],
+    });
+    const resigned = resignBody(body, "hi there friend");
+    expect(resigned).not.toContain("cch=DEADB");
+    expect(resigned).toMatch(
+      new RegExp(`cc_version=${WORKER_VERSION}\\.[0-9a-f]{3};`),
+    );
     expect(validateSeed(resigned)).toBe(true);
   });
 });


### PR DESCRIPTION
## Problem

Session `0cYAkvpcYYf5qonx` was busting its ~1.7MB prompt cache on **every turn**. `journalctl -u opencode` pinned the divergence to `system[2].text` at byte 40354, where a `cch=XXXXX` token kept changing (`cch=2d825` → `cch=928b9` → …):

```
cache-analytics: session=0cYAkvpcYYf5qonx turn=129 hit=5% read=35927 create=638460 prefixMatch=2.3% (40354/1744282B) divergence="system[2].text"
WARN: session ...: unsustainable conversation detected (5+ consecutive cache busts)
```

## Root cause (self-referential)

LTM knowledge entry `019ebc55` (rendered into `system[2]`) literally contains the text `` CCH_PLACEHOLDER = `cch=00000` (cch.ts:103); signBody() replaces it… ``.

The signing functions rewrote the *first* `cch=`/`cc_version=` token in the serialized body, which could be a token embedded in LTM/system/message content instead of the billing header. Every turn that token was re-stamped with a fresh hash → `system[2]` bytes changed → full prompt-cache bust (hit 100%→5%).

## Fix

`packages/gateway/src/cch.ts` — anchor all `cch`/`cc_version` rewrites to the **full billing-header sentinel** `x-anthropic-billing-header: cc_version=…; cc_entrypoint=…; cch=…`:
- `signBody`, `resignBody`, `validateSeed` anchor to the full sentinel (not a bare `cch=`/`cc_entrypoint=` fragment).
- `resignBody` rewrites `cc_version` **and** `cch` in one anchored pass; `cc_entrypoint` preserved verbatim.
- `signBody` is a strict no-op when no billing header is present (bare-placeholder fallback removed) — a content `cch=00000` is never signed.
- Correctness relies on the real header always being **system[0]** (worker prepends it via `buildBillingBlock`; Claude Code emits it first, enforced by `BILLING_HEADER_RE`'s `^` anchor), so first-match always targets the real header and no content can serialize before it.
- `BILLING_RESIGN_RE` is permissive on `cc_version` (suffix optional + case-insensitive) so a client header lacking the 3-hex suffix still re-signs instead of silently forwarding a stale cch (→ 401).

`packages/gateway/src/cache-analytics.ts` — broaden `CCH_PATTERN` to normalize backtick/quote/whitespace-terminated `cch=` tokens (previously required a trailing `;`), removing false-positive `messages[N]` divergence noise in the analytics-only comparison.

## Review follow-ups (all addressed)

Round 1 (positional → structural):
- **#1 anchor defeated by content before the header** → anchored to the full sentinel; the real header is always system[0], so content can't precede it. Regression test locks in "real header wins over a full-sentinel doc block after it".
- **#2 unanchored `cc_version=`** → rewritten in the same anchored pass; regression test with content `cc_version=…;` before the header.
- **#3 bare-placeholder fallback** → removed; tests assert no-op with no header and header-still-signed when content `cch=00000` sorts first.

Round 2 (self-review via subagent):
- Suffix-less / uppercase client header would have silently skipped re-signing (→ 401) → `BILLING_RESIGN_RE` made permissive; regression tests added for both.
- Docstrings corrected (removed stale regex reference and overstated "never regardless of order" wording).

## Tests

- Reworked bare-placeholder `signBody` tests to use a real billing header.
- Added regression tests: content `cc_entrypoint`/`cc_version`/`cch` tokens that sort before the header, two-sentinel ordering, suffix-less header, uppercase suffix/cch, no-header no-op, non-default `cc_entrypoint`, backtick/quote analytics normalization.
- Full gateway suite: **1530 passed**; typecheck clean; lint clean.