### PR TITLE
test(gateway): e2e cache-stability guardrail

### DIFF
--- a/packages/gateway/test/cache-stability.e2e.test.ts
+++ b/packages/gateway/test/cache-stability.e2e.test.ts
@@ -1,0 +1,163 @@
+/**
+ * End-to-end cache-stability tests.
+ *
+ * These drive multi-turn conversations through a REAL gateway (replay harness,
+ * no live API) and assert the invariant that every cache-bust bug we've chased
+ * violated: across consecutive turns, the UPSTREAM request body's stable prefix
+ * (system[0] host prompt, system[1] preferences, system[2] context-bound LTM,
+ * and already-sent messages) must stay byte-identical. The only thing that may
+ * change between turns is the conversation TAIL (newly appended messages).
+ *
+ * If a future change makes system[1]/system[2]/an early message churn turn-to-
+ * turn (LTM re-ranking, mid-session curation rewrite, dedup toggle, a per-turn
+ * token injected into a cached block, etc.), the divergence offset jumps out of
+ * the tail and these tests fail — turning whack-a-mole into a guardrail.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import type { Harness } from "./helpers/harness";
+import { createHarness } from "./helpers/harness";
+import {
+  STANDARD_TOOLS,
+  DEFAULT_MODEL,
+  DEFAULT_SYSTEM,
+  makeConversationFixtures,
+} from "./helpers/fixtures";
+import {
+  findDivergenceOffset,
+  mapOffsetToJsonPath,
+  normalizeBodyForComparison,
+} from "../src/cache-analytics";
+
+function makeBody(
+  userMessage: string,
+  history: unknown[] = [],
+): Record<string, unknown> {
+  return {
+    model: DEFAULT_MODEL,
+    max_tokens: 1024,
+    stream: false,
+    system: DEFAULT_SYSTEM,
+    messages: [...history, { role: "user", content: userMessage }],
+    tools: STANDARD_TOOLS,
+  };
+}
+
+/**
+ * Given two consecutive upstream bodies, return the JSON path where they first
+ * diverge (after normalizing volatile client tokens the same way the live
+ * cache analytics does). "<end>" / "<identical>" mean no mid-body divergence.
+ */
+function divergencePath(prev: string, curr: string): string {
+  const p = normalizeBodyForComparison(prev);
+  const c = normalizeBodyForComparison(curr);
+  const offset = findDivergenceOffset(p, c);
+  if (offset >= Math.min(p.length, c.length)) {
+    return p.length === c.length ? "<identical>" : "<end>";
+  }
+  return mapOffsetToJsonPath(c, offset);
+}
+
+/** True when a divergence path points at the conversation tail (a message),
+ *  not at a system block — i.e. an acceptable, cache-friendly change. */
+function isTailDivergence(path: string): boolean {
+  return (
+    path === "<end>" || path === "<identical>" || /^messages\[\d+\]/.test(path)
+  );
+}
+
+describe("cache stability (e2e)", () => {
+  let harness: Harness;
+  afterEach(() => harness?.teardown());
+
+  it("system prefix stays byte-stable across the steady state (turn 2+)", async () => {
+    // Turn 1→2 legitimately introduces system[2] (context-bound LTM is deferred
+    // to turn 2 by design). From turn 2 onward the full system prefix must be
+    // byte-stable — that's the steady state every cache-bust bug violated.
+    const turns = [
+      {
+        userMessage: "Let's start working on the parser.",
+        assistantText: "Sure.",
+      },
+      { userMessage: "Add support for nested groups.", assistantText: "Done." },
+      {
+        userMessage: "Now handle escape sequences.",
+        assistantText: "Handled.",
+      },
+      {
+        userMessage: "Write tests for the new cases.",
+        assistantText: "Tests added.",
+      },
+      {
+        userMessage: "Refactor the tokenizer a bit.",
+        assistantText: "Refactored.",
+      },
+      { userMessage: "Tidy up the comments.", assistantText: "Tidied." },
+    ];
+    harness = await createHarness({
+      fixtures: makeConversationFixtures(turns),
+    });
+
+    // Drive the conversation, accumulating history client-side like a real
+    // client would.
+    const history: unknown[] = [];
+    for (const turn of turns) {
+      const resp = await harness.chat(makeBody(turn.userMessage, history));
+      expect(resp.status).toBe(200);
+      history.push({ role: "user", content: turn.userMessage });
+      history.push({
+        role: "assistant",
+        content: [{ type: "text", text: turn.assistantText }],
+      });
+    }
+
+    const bodies = harness.upstreamBodies();
+    expect(bodies.length).toBe(turns.length);
+
+    // Steady state: from turn 2 (index 1) onward, each transition must diverge
+    // only in the tail (new messages), never inside a system block.
+    for (let i = 2; i < bodies.length; i++) {
+      const path = divergencePath(bodies[i - 1], bodies[i]);
+      expect(
+        isTailDivergence(path),
+        `turn ${i}→${i + 1} diverged at "${path}" (expected a messages[N] tail change, ` +
+          `not a system-block rewrite — that would bust the prompt cache)`,
+      ).toBe(true);
+    }
+  });
+
+  it("the system block is byte-identical once system[2] is established (turn 2+)", async () => {
+    const turns = Array.from({ length: 5 }, (_, i) => ({
+      userMessage: `Step ${i}: do the thing with some detail to grow the body.`,
+      assistantText: `Acknowledged step ${i}.`,
+    }));
+    harness = await createHarness({
+      fixtures: makeConversationFixtures(turns),
+    });
+
+    const history: unknown[] = [];
+    for (const turn of turns) {
+      await harness.chat(makeBody(turn.userMessage, history));
+      history.push({ role: "user", content: turn.userMessage });
+      history.push({
+        role: "assistant",
+        content: [{ type: "text", text: turn.assistantText }],
+      });
+    }
+
+    const bodies = harness.upstreamBodies().map(normalizeBodyForComparison);
+    // Extract the serialized `system` field from each body. From turn 2 (index
+    // 1) — where system[2] is first injected — onward it must never change.
+    const systems = bodies.map((b) => {
+      const parsed = JSON.parse(b) as { system?: unknown };
+      return JSON.stringify(parsed.system ?? null);
+    });
+    const steady = systems[1]; // turn 2: system[2] established
+    for (let i = 2; i < systems.length; i++) {
+      expect(
+        systems[i],
+        `system block changed between turn ${i} and ${i + 1} — this busts the ` +
+          `cached system prefix on every subsequent turn`,
+      ).toBe(steady);
+    }
+  });
+});

--- a/packages/gateway/test/helpers/harness.ts
+++ b/packages/gateway/test/helpers/harness.ts
@@ -37,6 +37,13 @@ export interface Harness {
   ): Promise<Response>;
   /** Query the temporal DB directly via a read-only SQLite connection */
   queryDB<T = Record<string, unknown>>(sql: string, params?: unknown[]): T[];
+  /**
+   * The exact request bodies lore sent UPSTREAM (to the model), one per turn,
+   * in order. This is the post-transform body (system blocks, LTM, cch,
+   * gradient window) — i.e. exactly what Anthropic would see and key its prompt
+   * cache on. Use this to assert cache-prefix stability across turns.
+   */
+  upstreamBodies(): string[];
   /** Stop the gateway and clean up */
   teardown(): void;
 }
@@ -80,8 +87,18 @@ export async function createHarness(opts: HarnessOptions): Promise<Harness> {
   await resetPipelineState();
 
   // --- 4. Wire in replay interceptor (streaming-aware: emits SSE for
-  // streaming turns, JSON otherwise) ---
-  setUpstreamInterceptor(makeReplayInterceptor(opts.fixtures));
+  // streaming turns, JSON otherwise), wrapped to capture the exact upstream
+  // request body lore sends each turn (for cache-stability assertions). ---
+  const capturedBodies: string[] = [];
+  const replay = makeReplayInterceptor(opts.fixtures);
+  setUpstreamInterceptor(async (requestBody, model, wasStreaming, makeReal) => {
+    capturedBodies.push(
+      typeof requestBody === "string"
+        ? requestBody
+        : JSON.stringify(requestBody),
+    );
+    return replay(requestBody, model, wasStreaming, makeReal);
+  });
 
   // --- 5. Start gateway ---
   const config = loadConfig();
@@ -154,5 +171,9 @@ export async function createHarness(opts: HarnessOptions): Promise<Harness> {
     }
   }
 
-  return { baseURL, dbPath, chat, queryDB, teardown };
+  function upstreamBodies(): string[] {
+    return capturedBodies.slice();
+  }
+
+  return { baseURL, dbPath, chat, queryDB, upstreamBodies, teardown };
 }


### PR DESCRIPTION
We've been playing whack-a-mole with prompt-cache busts — fixing them one at a time (system[2] re-ranking #727, mid-session curation rewrite #738, dedup toggle #736, self-referential cch #739, ...). This adds an **end-to-end guardrail** so the class is caught automatically in CI.

## What

- **Harness capability**: the replay harness now captures the exact UPSTREAM request body lore sends each turn (post-transform — system blocks + LTM + gradient window — i.e. what Anthropic keys its prompt cache on), exposed via `harness.upstreamBodies()`. Backward-compatible (wraps the existing interceptor); the full gateway suite stays green (1529 passed).
- **`cache-stability.e2e.test.ts`**: drives multi-turn conversations through a real gateway (replay, no live API) and asserts the invariant **every** bust violated:
  > From the steady state (turn 2+, once `system[2]` is established), consecutive upstream bodies may diverge ONLY in the conversation **tail** (new messages) — never inside a `system` block.

  It uses the gateway's own `findDivergenceOffset` / `mapOffsetToJsonPath`, so the assertion matches the live cache-analytics classification exactly. A failure prints e.g. `turn 2→3 diverged at "system[1].text"` — pinpointing which cached block broke.

## Mutation-verified
Injecting a per-turn token into a system block fails the suite with `diverged at "system[1].text"`. The test has teeth.

## Scope / honest limitation
These two tests exercise **layer 0** (the common, full-passthrough case). Driving real gradient compression (layers 1-4) through the fast HTTP harness proved fragile — under a synthetic tiny context the background distill/curate workers retry-loop and hang. Multi-layer cache-stability coverage belongs in the **eval** suite (which already drives 2.3M-token multi-layer sessions via `inflate.ts`/`mega-session.eval.ts`) and is filed as **#744**. The layer-varying `system[2]` bug surfaced while building this is filed as **#741**.

## Follow-ups (filed)
- #744 — cache-stability across gradient layers 1-4 (via eval).
- #741 — context-health note appended to `system[2]` varies by compression layer (a live bug).
- #740 — volatile knowledge-delta channel.

Typecheck + biome clean.