### PR TITLE
feat(cch): alert on duplicate billing-header sentinel (cache-bust early warning)

### DIFF
--- a/packages/gateway/src/cch.ts
+++ b/packages/gateway/src/cch.ts
@@ -30,6 +30,8 @@
  */
 
 import { createHash, randomUUID } from "node:crypto";
+import { log } from "@loreai/core";
+import * as Sentry from "@sentry/bun";
 import { xxHash64 } from "./xxhash.ts";
 
 // ---------------------------------------------------------------------------
@@ -203,6 +205,67 @@ function cchPreimage(body: string): string {
 }
 
 // ---------------------------------------------------------------------------
+// First-block invariant verification
+// ---------------------------------------------------------------------------
+
+/**
+ * The literal billing-header marker. The real header always starts with this;
+ * we count occurrences to detect ambiguity.
+ */
+const BILLING_MARKER = "x-anthropic-billing-header:";
+
+/**
+ * Verify the invariant the anchored signer relies on: the body contains
+ * exactly ONE `x-anthropic-billing-header:` marker.
+ *
+ * Both `signBody` and `resignBody` use first-match `.replace()` and trust that
+ * the single match is the real header (always system[0], nothing precedes it).
+ * That trust is only safe when the marker is unique. If a second sentinel
+ * appears — e.g. an LTM entry reproducing the whole header, or Anthropic
+ * reordering/duplicating system blocks — first-match could stamp the wrong
+ * token and bust the entire prompt cache. We can't tell the real header from a
+ * content copy by position alone, so any duplication is treated as a hazard.
+ *
+ * In practice this should never fire. When it does we surface it to Sentry as
+ * an early warning. Report-only: signing proceeds unchanged (the real header is
+ * still overwhelmingly likely to be first, so signing remains correct today).
+ *
+ * @param body — the serialized body being signed
+ * @param caller — "signBody" | "resignBody" for the alert fingerprint
+ */
+function verifyBillingHeaderUnique(body: string, caller: string): void {
+  const markerCount = body.split(BILLING_MARKER).length - 1;
+  if (markerCount <= 1) {
+    return; // unique (or absent) — invariant holds.
+  }
+
+  log.warn(
+    `cch: billing-header first-block invariant violated in ${caller} ` +
+      `(found ${markerCount} billing-header markers; expected 1) — ` +
+      `first-match may sign the wrong token and bust the prompt cache`,
+  );
+  if (Sentry.isInitialized()) {
+    Sentry.captureException(
+      new Error(
+        "cch: multiple billing-header sentinels in request body (cache-bust risk)",
+      ),
+      {
+        fingerprint: [
+          "LOREAI-GATEWAY",
+          "cch-billing-header-not-unique",
+          caller,
+        ],
+        extra: {
+          caller,
+          markerCount,
+          bodyLength: body.length,
+        },
+      },
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Signing
 // ---------------------------------------------------------------------------
 
@@ -227,6 +290,11 @@ function cchPreimage(body: string): string {
  * @returns body with the billing `cch=00000` replaced by `cch=XXXXX`
  */
 export function signBody(bodyWithPlaceholder: string): string {
+  if (!BILLING_SIGN_RE.test(bodyWithPlaceholder)) {
+    return bodyWithPlaceholder; // no billing placeholder to sign
+  }
+  verifyBillingHeaderUnique(bodyWithPlaceholder, "signBody");
+
   const hash = xxHash64(cchPreimage(bodyWithPlaceholder), WORKER_SEED);
   const cch = (hash & 0xfffffn).toString(16).padStart(5, "0");
   return bodyWithPlaceholder.replace(BILLING_SIGN_RE, `$1${cch}`);
@@ -313,6 +381,7 @@ export function resignBody(
   if (!BILLING_RESIGN_RE.test(serializedBody)) {
     return serializedBody;
   }
+  verifyBillingHeaderUnique(serializedBody, "resignBody");
 
   // Step 1+2: in a single anchored replace, swap cc_version for our worker
   // version + recomputed suffix and reset cch to the placeholder. cc_entrypoint

--- a/packages/gateway/test/cch.test.ts
+++ b/packages/gateway/test/cch.test.ts
@@ -22,6 +22,7 @@ import {
   _cchPreimage,
 } from "../src/cch";
 import { xxHash64 } from "../src/xxhash";
+import { log } from "@loreai/core";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
@@ -923,6 +924,117 @@ describe("resignBody", () => {
       new RegExp(`cc_version=${WORKER_VERSION}\\.[0-9a-f]{3};`),
     );
     expect(validateSeed(resigned)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// First-block invariant verification (Sentry early-warning)
+// ---------------------------------------------------------------------------
+
+describe("billing-header first-block invariant", () => {
+  /** Capture warnings emitted via the core log sink. */
+  let warnings: string[];
+
+  beforeEach(() => {
+    warnings = [];
+    log.registerSink({
+      info: () => {},
+      warn: (msg) => warnings.push(msg),
+      error: () => {},
+      captureException: () => {},
+    });
+  });
+
+  /** Build a body with the real billing header as the FIRST system block. */
+  const headerFirst = (extraBlocks: string[] = []) =>
+    JSON.stringify({
+      system: [
+        {
+          type: "text",
+          text: "x-anthropic-billing-header: cc_version=2.1.165.abc; cc_entrypoint=cli; cch=00000;",
+        },
+        ...extraBlocks.map((text) => ({ type: "text", text })),
+      ],
+      messages: [{ role: "user", content: "hi" }],
+    });
+
+  test("does NOT warn when the billing header is the first occurrence (signBody)", () => {
+    signBody(headerFirst(["docs: `cch=00000` example"]));
+    expect(warnings).toHaveLength(0);
+  });
+
+  test("WARNS when content reproduces the FULL sentinel, even sorted after the real header", () => {
+    // Conservative invariant: any second `x-anthropic-billing-header:` marker is
+    // a hazard. Signing still succeeds (real header is first), but we surface it
+    // because we can't robustly guarantee first-match hit the real one.
+    signBody(
+      headerFirst([
+        "docs: `x-anthropic-billing-header: cc_version=2.1.0.aaa; cc_entrypoint=cli; cch=00000;`",
+      ]),
+    );
+    expect(warnings.length).toBeGreaterThan(0);
+    expect(warnings[0]).toContain("billing-header markers");
+  });
+
+  test("does NOT warn when content has a cch= token but NOT the full sentinel", () => {
+    // A bare `cch=00000` / `cc_entrypoint=…` fragment in content is NOT a
+    // duplicate marker, so it must not trip the guard (no false positives on
+    // the common case — e.g. the LTM entry from the original incident).
+    signBody(
+      headerFirst([
+        "gotcha: CCH_PLACEHOLDER = `cch=00000`; cc_entrypoint=cli appears here",
+      ]),
+    );
+    expect(warnings).toHaveLength(0);
+  });
+
+  test("WARNS when a sentinel-shaped block serializes BEFORE the real header (signBody)", () => {
+    // Simulates the dangerous reorder: a content block reproducing the full
+    // sentinel is placed first, the real header second. first-match would
+    // target the content block → cache-bust risk → must alert.
+    const body = JSON.stringify({
+      system: [
+        {
+          type: "text",
+          text: "x-anthropic-billing-header: cc_version=2.1.0.aaa; cc_entrypoint=cli; cch=00000;",
+        },
+        {
+          type: "text",
+          text: "x-anthropic-billing-header: cc_version=2.1.165.abc; cc_entrypoint=cli; cch=00000;",
+        },
+      ],
+      messages: [{ role: "user", content: "hi" }],
+    });
+    signBody(body);
+    expect(warnings.length).toBeGreaterThan(0);
+    expect(warnings[0]).toContain("first-block invariant violated");
+    expect(warnings[0]).toContain("signBody");
+  });
+
+  test("WARNS when a sentinel-shaped block serializes BEFORE the real header (resignBody)", () => {
+    const body = JSON.stringify({
+      system: [
+        {
+          type: "text",
+          text: "x-anthropic-billing-header: cc_version=2.1.0.aaa; cc_entrypoint=cli; cch=aaaaa;",
+        },
+        {
+          type: "text",
+          text: "x-anthropic-billing-header: cc_version=2.1.165.abc; cc_entrypoint=cli; cch=bbbbb;",
+        },
+      ],
+      messages: [{ role: "user", content: "hi there friend" }],
+    });
+    resignBody(body, "hi there friend");
+    expect(
+      warnings.some((w) => w.includes("first-block invariant violated")),
+    ).toBe(true);
+    expect(warnings.some((w) => w.includes("resignBody"))).toBe(true);
+  });
+
+  test("does NOT warn for a no-billing-header body", () => {
+    signBody('{"system":[{"type":"text","text":"no header here"}]}');
+    expect(warnings).toHaveLength(0);
   });
 });
 

--- a/packages/gateway/test/cch.test.ts
+++ b/packages/gateway/test/cch.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach } from "vitest";
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
 import {
   signBody,
   resignBody,
@@ -935,6 +935,15 @@ describe("billing-header first-block invariant", () => {
   /** Capture warnings emitted via the core log sink. */
   let warnings: string[];
 
+  /** Silent sink restored after each test so we don't leak capture into
+   *  other test files sharing the (global) log sink. */
+  const silentSink = {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    captureException: () => {},
+  };
+
   beforeEach(() => {
     warnings = [];
     log.registerSink({
@@ -943,6 +952,10 @@ describe("billing-header first-block invariant", () => {
       error: () => {},
       captureException: () => {},
     });
+  });
+
+  afterEach(() => {
+    log.registerSink(silentSink);
   });
 
   /** Build a body with the real billing header as the FIRST system block. */


### PR DESCRIPTION
## Context

Follow-up to #739. That PR made the `cch` signer **structurally** anchored to the full `x-anthropic-billing-header:` sentinel, but correctness still relies on an **unenforced invariant**: the real header is always the first system block, so first-match `.replace()` targets it. The review explicitly flagged this as a documented-but-unguarded residual.

This PR adds the guard + Sentry alert the residual warranted.

## What it does

`verifyBillingHeaderUnique()` in `signBody`/`resignBody`: if the serialized body contains **more than one** `x-anthropic-billing-header:` marker, emit `log.warn` + `Sentry.captureException` (fingerprint `LOREAI-GATEWAY / cch-billing-header-not-unique / <caller>`).

- **Report-only.** Signing proceeds unchanged — the real header is still first today, so live traffic is unaffected. This is early-warning telemetry for if Anthropic ever reorders/duplicates system blocks, or LTM content reproduces the whole sentinel.
- **Count-based / conservative.** We can't distinguish the real header from a content copy by position, so any duplicate marker is treated as a hazard.
- **No false positives on the common case.** A bare `cch=`/`cc_entrypoint=` token in content (the original incident's LTM entry) is *not* a duplicate marker, so it doesn't trip the guard — only a full duplicated sentinel does.

## Why count-based instead of position-based

My first attempt checked "is the matched sentinel the earliest marker?" — but first-match `.replace()` *always* matches the earliest by construction, so that check couldn't detect the real hazard (a content sentinel sitting first, the real header second). Uniqueness is the genuinely detectable, meaningful condition.

## Tests

- Duplicate sentinel before/after the real header → warns (both `signBody` and `resignBody`).
- Bare content `cch=`/`cc_entrypoint=` token → does **not** warn.
- No-header body → does **not** warn.
- Captures via the core `log.registerSink` API (no brittle spies).
- Full gateway suite: **1554 passed**; typecheck clean; lint clean.

Note: this addresses the first of the two residuals from #739's review. The `forSession` LTM re-ranking churn (the *other* cache-bust cause) is being handled separately.