### PR TITLE
fix(gateway): skip meta-distillation while cache is warm

### DIFF
--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -46,8 +46,6 @@ import {
   onIdleResume,
   consumeCameOutOfIdle,
   needsUrgentDistillation,
-  getConsecutiveBusts,
-  effectiveMetaThreshold as computeMetaThreshold,
   formatKnowledge,
   shouldImportLoreFile,
   importLoreFile,
@@ -3536,10 +3534,6 @@ function scheduleBackgroundWork(
   // compaction anomaly was detected on the previous turn). Mark urgent: true
   // so these bypass the batch queue — the gradient is in overflow (or the
   // client just compacted) and needs the result before the next user turn.
-  // Under bust pressure (3+ consecutive busts), lower the meta-distillation
-  // threshold to consolidate gen-0 segments earlier — shrinks the distilled
-  // prefix before the session becomes unsustainable.
-  //
   // Note: urgent distillation is NOT gated by isBackgroundPaused() — a
   // degraded/overflowing context window for up to 10 minutes (max breaker
   // duration) is worse than one API call with its own tight retry budget
@@ -3554,10 +3548,6 @@ function scheduleBackgroundWork(
     saveSessionTracking(sessionID, { compactionAnomalyPending: false });
   }
   if (urgentFromGradient || urgentFromCompaction) {
-    const busts = getConsecutiveBusts(sessionState.sessionID);
-    const lowered = computeMetaThreshold(busts, cfg.distillation.metaThreshold);
-    const metaThresholdOverride =
-      lowered < cfg.distillation.metaThreshold ? lowered : undefined;
     distillation
       .run({
         llm,
@@ -3567,7 +3557,12 @@ function scheduleBackgroundWork(
         force: true,
         urgent: true,
         callType: "direct",
-        metaThresholdOverride,
+        // Never run meta-distillation while the conversation cache is warm.
+        // Meta archives gen-0 rows and creates a gen-1 row, rewriting the
+        // synthetic distilled prefix at messages[0/1] on the next turn. That
+        // early-message rewrite is a real prompt-cache bust. Idle-time meta in
+        // idle.ts remains enabled because the cache is already cold there.
+        skipMeta: true,
       })
       .catch((e) => log.error("background distillation failed:", e));
   } else if (

--- a/packages/gateway/test/cache-stability.e2e.test.ts
+++ b/packages/gateway/test/cache-stability.e2e.test.ts
@@ -69,12 +69,18 @@ function divergencePath(prev: string, curr: string): string {
   return mapOffsetToJsonPath(c, offset);
 }
 
-/** True when a divergence path points at the conversation tail (a message),
- *  not at a system block — i.e. an acceptable, cache-friendly change. */
+/** True when a divergence path points at raw conversation messages, not at a
+ *  cached prefix message. `messages[0/1]` are lore's synthetic distilled
+ *  prefix when gradient compression is active, so accepting all messages[N]
+ *  paths (as #748 originally did) misses meta-distillation prefix rewrites.
+ *  Raw-message window shifts at messages[2+] are still allowed by this broad
+ *  guardrail; cache-analytics has narrower hit-rate checks for those. */
 function isTailDivergence(path: string): boolean {
-  return (
-    path === "<end>" || path === "<identical>" || /^messages\[\d+\]/.test(path)
-  );
+  if (path === "<end>" || path === "<identical>") return true;
+  const match = path.match(/^messages\[(\d+)\]/);
+  if (!match) return false;
+  const idx = Number(match[1]);
+  return idx > 1;
 }
 
 /**
@@ -279,6 +285,15 @@ describe("cache stability (e2e)", () => {
     const { resetCalibration } = await import("../../core/src/gradient");
     resetCalibration();
     await harness?.teardown();
+  });
+
+  it("guard rejects synthetic distilled-prefix message rewrites", () => {
+    // Regression for the gap in #748: accepting every messages[N] divergence
+    // lets meta-distillation rewrites at messages[0/1] pass as "tail" growth.
+    expect(isTailDivergence("messages[0].content")).toBe(false);
+    expect(isTailDivergence("messages[1].content[0].text")).toBe(false);
+    expect(isTailDivergence("messages[2].content[0].text")).toBe(true);
+    expect(isTailDivergence("<end>")).toBe(true);
   });
 
   it("system prefix stays byte-stable across the steady state (turn 2+)", async () => {


### PR DESCRIPTION
## Problem

Live logs still show early prompt-cache divergence after the cch/system[2] fixes:

```
cache-analytics: early divergence at byte 44500
cache-analytics: session=1V435XJ9lkzczbA8 turn=21 hit=8% read=8320 create=0 input=91989 prefixMatch=12.8% (44500/350807B) divergence="messages[0].content" reason="distilled conversation prefix changed (meta-distillation rewrite)"
```

This is a third cache-bust class: **meta-distillation rewrites the synthetic distilled-prefix messages** (`messages[0/1]`).

## Root cause

`scheduleBackgroundWork()` treated urgent distillation differently from non-urgent incremental distillation:

- Non-urgent incremental distillation already passes `skipMeta: true`.
- Urgent direct distillation did **not** pass `skipMeta`, and additionally lowered the meta threshold under bust pressure.

When active-turn meta-distillation runs, it archives old gen-0 distillation rows and inserts a new gen-1 row. On the next turn, `gradient.distilledPrefixCached()` sees a different row set, invalidates the prefix cache, and full re-renders the synthetic prefix. That changes `messages[0/1]` near the front of the prompt and causes a real warm-cache bust.

The code already documents this exact hazard in `distillation.run()` / `skipMeta`: meta rewrites row IDs and busts the distilled prefix cache on the next turn. The urgent path was the remaining warm-cache caller that violated that rule.

## Fix

- Set `skipMeta: true` on urgent direct distillation in `scheduleBackgroundWork()`.
- Remove the bust-pressure meta-threshold lowering from that warm-cache path.
- Leave idle-time meta-distillation enabled; `idle.ts` already treats the cache as cold before running meta.

## Why #748 did not catch this

#748 added an e2e cache-stability guardrail, but its helper accepted **any** `messages[N]` divergence as acceptable tail growth:

```ts
/^messages\[\d+\]/
```

That means `messages[0].content` and `messages[1].content` — lore's synthetic distilled-prefix messages — were explicitly allowed. So #748 could catch `system[1/2]` churn, but not this prefix-rewrite class.

This PR tightens the guardrail:

- `messages[0]` / `messages[1]` → fail (synthetic distilled prefix)
- `messages[2+]` → still allowed by this broad guardrail (raw-message/window shifts are covered by cache analytics hit-rate checks)
- Added a small regression assertion proving the helper rejects `messages[0/1]`.

## Verification

- `pnpm exec vitest run packages/gateway/test/cache-stability.e2e.test.ts packages/gateway/test/cache-analytics.test.ts` → 56 passed
- `pnpm exec vitest run packages/gateway/test/` → 1561 passed
- `pnpm run typecheck` → pass
- `pnpm run lint` → pass