### PR TITLE
fix(core): freeze distilled prefix during warm sessions

### DIFF
--- a/packages/core/src/distillation.ts
+++ b/packages/core/src/distillation.ts
@@ -859,10 +859,6 @@ export async function run(input: {
   skipMeta?: boolean;
   urgent?: boolean;
   callType?: "batch" | "direct";
-  /** Override the meta-distillation gen-0 threshold. When set, meta-distillation
-   *  triggers at this count instead of `cfg.distillation.metaThreshold`.
-   *  Used by the urgent-distillation path to consolidate earlier under bust pressure. */
-  metaThresholdOverride?: number;
   /** Optional hook for the gateway to record worker health events. When the
    *  LLM call returns null (no response), the hook is called with a categorical
    *  reason. The gateway uses this to escalate to Sentry / dashboard after
@@ -896,8 +892,6 @@ async function runInner(input: {
   /** Whether the LLM call will use batch or direct pricing. Recorded on the
    *  distillation row for accurate historical cost estimates. */
   callType?: "batch" | "direct";
-  /** Override the meta-distillation gen-0 threshold (see run()). */
-  metaThresholdOverride?: number;
   /** See run() — optional gateway worker-health hook. */
   workerHealth?: {
     recordFailure(reason: string): void;
@@ -965,11 +959,7 @@ async function runInner(input: {
     // Check if meta-distillation is needed (skip when cache is warm to avoid
     // prefix cache invalidation — row IDs change after meta-distill, busting
     // the prompt cache on the next turn).
-    // Clamp override to min 2 — meta-distillation with < 2 gen-0 segments is pointless.
-    const effectiveMetaThreshold = Math.max(
-      2,
-      input.metaThresholdOverride ?? cfg.distillation.metaThreshold,
-    );
+    const effectiveMetaThreshold = Math.max(2, cfg.distillation.metaThreshold);
     if (
       !input.skipMeta &&
       gen0Count(input.projectPath, input.sessionID) >= effectiveMetaThreshold

--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -1513,10 +1513,13 @@ type PrefixCache = {
  *
  * Cache hit  — no new rows: returns the exact same prefixMessages object
  *              (byte-identical content, prompt cache preserved).
- * Cache miss — new rows appended: renders only the delta, appends to cached
- *              text, updates cache.
- * Full reset — first call, or rows were rewritten by meta-distillation:
- *              renders everything from scratch.
+ * Warm hit   — returns the cached prefix as-is even when new gen-0 rows were
+ *              appended in the DB. Re-rendering/appending those rows would
+ *              mutate messages[1].content near the front of the prompt and
+ *              bust the warm Anthropic prompt cache.
+ * Full reset — first call, idle resume (onIdleResume clears prefixCache), or
+ *              rows were rewritten by cold-boundary meta-distillation:
+ *              renders everything from scratch and folds in accumulated rows.
  */
 function distilledPrefixCached(
   distillations: Distillation[],
@@ -1524,7 +1527,18 @@ function distilledPrefixCached(
   sessState: SessionState,
 ): { messages: MessageWithParts[]; tokens: number } {
   if (!distillations.length) {
-    sessState.prefixCache = null;
+    // Freeze the *absence* of a prefix too. If the first gen-0 distillation
+    // arrives while the conversation cache is warm, injecting synthetic
+    // messages[0/1] would be just as cache-busting as appending to an existing
+    // prefix. onIdleResume clears this empty pin so a cold turn can render it.
+    sessState.prefixCache = {
+      sessionID,
+      lastDistillationID: "",
+      rowCount: 0,
+      cachedText: "",
+      prefixMessages: [],
+      prefixTokens: 0,
+    };
     return { messages: [], tokens: 0 };
   }
 
@@ -1542,32 +1556,15 @@ function distilledPrefixCached(
         prefixCache.lastDistillationID);
 
   if (cacheValid) {
-    if (prefixCache?.lastDistillationID === lastRow.id) {
-      // No new rows — return cached prefix as-is (byte-identical for prompt cache)
-      return {
-        messages: prefixCache?.prefixMessages,
-        tokens: prefixCache?.prefixTokens,
-      };
-    }
-
-    // New rows appended — render only the delta and append to cached text
-    const newRows = distillations.slice(prefixCache?.rowCount);
-    const deltaText = formatDistillations(newRows);
-
-    if (deltaText) {
-      const fullText = `${prefixCache?.cachedText}\n\n${deltaText}`;
-      const messages = buildPrefixMessages(fullText);
-      const tokens = messages.reduce((sum, m) => sum + estimateMessage(m), 0);
-      sessState.prefixCache = {
-        sessionID,
-        lastDistillationID: lastRow.id,
-        rowCount: distillations.length,
-        cachedText: fullText,
-        prefixMessages: messages,
-        prefixTokens: tokens,
-      };
-      return { messages, tokens };
-    }
+    // Warm-session freeze: keep messages[0/1] byte-identical. New gen-0
+    // distillations accumulate in the DB but are not rendered into the prefix
+    // until a cold boundary clears prefixCache (idle resume / test reset). This
+    // trades slight memory staleness for prompt-cache stability; recall can
+    // still retrieve the newly-distilled rows if needed.
+    return {
+      messages: prefixCache.prefixMessages,
+      tokens: prefixCache.prefixTokens,
+    };
   }
 
   // Full re-render: first call or meta-distillation rewrote rows

--- a/packages/core/test/gradient.test.ts
+++ b/packages/core/test/gradient.test.ts
@@ -2836,6 +2836,7 @@ describe("gradient — distillation snapshot caching", () => {
   const SID = "distill-snapshot-sess";
   const PID_KEY = "distill-snapshot-project";
   let projectId: string;
+  let createdCounter = 0;
 
   function insertDistillation(opts: {
     sessionID: string;
@@ -2859,15 +2860,16 @@ describe("gradient — distillation snapshot caching", () => {
         0,
         Math.ceil(opts.observations.length / 3),
         opts.archived ?? 0,
-        Date.now(),
+        Date.now() + createdCounter++,
       );
     return id;
   }
 
   beforeAll(() => {
     projectId = ensureProject(`/test/${PID_KEY}`);
-    // Small context to force gradient mode (layer 1+)
-    setModelLimits({ context: 5_000, output: 1_000 });
+    // Wide enough to avoid emergency Layer 4; tests explicitly force Layer 1
+    // where the warm distilled-prefix cache is used.
+    setModelLimits({ context: 50_000, output: 1_000 });
     calibrate(0);
   });
 
@@ -2876,6 +2878,7 @@ describe("gradient — distillation snapshot caching", () => {
     resetPrefixCache(SID);
     resetRawWindowCache(SID);
     resetDistillationSnapshot(SID);
+    createdCounter = 0;
     db().query("DELETE FROM distillations WHERE project_id = ?").run(projectId);
   });
 
@@ -2904,6 +2907,7 @@ describe("gradient — distillation snapshot caching", () => {
     );
 
     const projectPath = `/test/${PID_KEY}`;
+    setForceMinLayer(1, SID);
     const result1 = transform({ messages, projectPath, sessionID: SID });
     expect(result1.layer).toBeGreaterThanOrEqual(1);
 
@@ -2914,6 +2918,7 @@ describe("gradient — distillation snapshot caching", () => {
     });
 
     // Same messages (same last user message) — should get cached snapshot
+    setForceMinLayer(1, SID);
     const result2 = transform({ messages, projectPath, sessionID: SID });
     expect(result2.layer).toBeGreaterThanOrEqual(1);
 
@@ -2937,7 +2942,7 @@ describe("gradient — distillation snapshot caching", () => {
     expect(text1).not.toContain("should NOT be consumed");
   });
 
-  test("new user message triggers distillation refresh", () => {
+  test("new gen-0 rows do not rewrite the warm distilled prefix at a turn boundary", () => {
     insertDistillation({
       sessionID: SID,
       observations: "- First observation",
@@ -2946,6 +2951,7 @@ describe("gradient — distillation snapshot caching", () => {
     const projectPath = `/test/${PID_KEY}`;
 
     // First call with user msg u-0
+    setForceMinLayer(1, SID);
     const messages1 = Array.from({ length: 16 }, (_, i) =>
       makeMsg(
         `ref-${i}`,
@@ -2960,6 +2966,7 @@ describe("gradient — distillation snapshot caching", () => {
       sessionID: SID,
     });
     expect(result1.layer).toBeGreaterThanOrEqual(1);
+    expect(inspectSessionState(SID)?.hasPrefixCache).toBe(true);
 
     // Insert a new distillation row
     insertDistillation({
@@ -2967,11 +2974,15 @@ describe("gradient — distillation snapshot caching", () => {
       observations: "- Second observation after turn boundary",
     });
 
-    // Append a NEW user message — this is a turn boundary, should refresh
+    // Append a NEW user message — this is a turn boundary, so the DB snapshot
+    // refreshes, but the rendered prefix remains frozen while the session is
+    // warm. Rendering the appended gen-0 row here would rewrite messages[1]
+    // near the prompt front and bust the Anthropic cache.
     const messages2 = [
       ...messages1,
       makeMsg("ref-new-user", "user", "New question from the user", SID),
     ];
+    setForceMinLayer(1, SID);
     const result2 = transform({
       messages: messages2,
       projectPath,
@@ -2979,11 +2990,71 @@ describe("gradient — distillation snapshot caching", () => {
     });
     expect(result2.layer).toBeGreaterThanOrEqual(1);
 
-    // The prefix should now contain the new distillation
+    // The new row is visible in the DB but must NOT be rendered into the warm
+    // prefix. It will be folded in after onIdleResume clears prefixCache.
     const allText = result2.messages
       .map((m) => m.parts.map((p) => ("text" in p ? p.text : "")).join())
       .join();
-    expect(allText).toContain("Second observation");
+    expect(allText).toContain("First observation");
+    expect(allText).not.toContain("Second observation");
+  });
+
+  test("first gen-0 row is also deferred when the warm session had no prefix", () => {
+    const projectPath = `/test/${PID_KEY}`;
+    const messages1 = Array.from({ length: 16 }, (_, i) =>
+      makeMsg(
+        `first-row-${i}`,
+        i % 2 === 0 ? "user" : "assistant",
+        "X".repeat(1_000),
+        SID,
+      ),
+    );
+
+    setForceMinLayer(1, SID);
+    const result1 = transform({
+      messages: messages1,
+      projectPath,
+      sessionID: SID,
+    });
+    expect(result1.layer).toBeGreaterThanOrEqual(1);
+    expect(inspectSessionState(SID)?.hasPrefixCache).toBe(true);
+    expect(
+      result1.messages.some((m) => m.info.id === "lore-distilled-assistant"),
+    ).toBe(false);
+
+    insertDistillation({
+      sessionID: SID,
+      observations: "- First warm-row observation that must wait for idle",
+    });
+
+    const messages2 = [
+      ...messages1,
+      makeMsg("first-row-new-user", "user", "Next warm turn", SID),
+    ];
+    setForceMinLayer(1, SID);
+    const warm = transform({
+      messages: messages2,
+      projectPath,
+      sessionID: SID,
+    });
+    const warmText = warm.messages
+      .map((m) => m.parts.map((p) => ("text" in p ? p.text : "")).join())
+      .join();
+    expect(warmText).not.toContain("First warm-row observation");
+
+    setLastTurnAtForTest(SID, Date.now() - 600_000);
+    expect(onIdleResume(SID, 60_000).triggered).toBe(true);
+
+    setForceMinLayer(1, SID);
+    const cold = transform({
+      messages: messages2,
+      projectPath,
+      sessionID: SID,
+    });
+    const coldText = cold.messages
+      .map((m) => m.parts.map((p) => ("text" in p ? p.text : "")).join())
+      .join();
+    expect(coldText).toContain("First warm-row observation");
   });
 
   test("onIdleResume clears distillation snapshot", () => {
@@ -3003,6 +3074,7 @@ describe("gradient — distillation snapshot caching", () => {
         SID,
       ),
     );
+    setForceMinLayer(1, SID);
     transform({ messages, projectPath, sessionID: SID });
 
     // Verify snapshot exists via inspectSessionState
@@ -3025,6 +3097,7 @@ describe("gradient — distillation snapshot caching", () => {
     expect(state2?.distillationSnapshot).toBeNull();
 
     // Next transform should pick up the new distillation (same user messages — but snapshot was cleared)
+    setForceMinLayer(1, SID);
     const result = transform({ messages, projectPath, sessionID: SID });
     const allText = result.messages
       .map((m) => m.parts.map((p) => ("text" in p ? p.text : "")).join())


### PR DESCRIPTION
## Problem

Post-#751 review found a residual warm-cache prefix mutation: active-turn **gen-0 incremental distillation** can append new rows into the synthetic distilled prefix (`messages[1].content`) on the next warm turn.

This is less severe than meta-distillation's full prefix re-render, but it still mutates an early prompt message and forces a cache write for everything after the append point. It also means continuous never-idle sessions can grow the rendered prefix in layers 1/2 (`distLimit: Infinity`).

## Fix

Freeze the rendered distilled prefix for the whole warm session:

- If `prefixCache` is valid, return the cached prefix byte-for-byte even when new gen-0 rows were appended in the DB.
- New gen-0 rows still accumulate in the DB and remain recallable, but are not rendered into `messages[0/1]` until a cold boundary clears `prefixCache`.
- `onIdleResume` already clears `prefixCache`, so the next cold turn folds accumulated rows into the full render.
- Also freeze the absence of a prefix: if a session had zero distillations, the first gen-0 row arriving mid-session no longer injects synthetic `messages[0/1]` into a warm prompt.

This completes the #751 direction: active/warm sessions keep `messages[0/1]` byte-stable; cold boundaries refresh.

## Cleanup

Remove the dead `metaThresholdOverride` parameter from `distillation.run()` / `runInner()`. #751 removed its only caller (the urgent bust-pressure meta path), leaving stale comments about a path that no longer exists.

## Tests

- Same-message snapshot caching remains byte-stable.
- New gen-0 rows at a warm turn boundary do **not** rewrite the prefix.
- First gen-0 row is deferred when the warm session had no prefix.
- Idle resume clears the pin and folds accumulated rows into the cold prefix.

Verification:
- `pnpm exec vitest run packages/core/test/gradient.test.ts packages/gateway/test/cache-stability.e2e.test.ts packages/gateway/test/cache-analytics.test.ts` → 187 passed
- `pnpm exec vitest run packages/core/test/ packages/gateway/test/` → 2959 passed, 6 skipped
- `pnpm run typecheck` → pass
- `pnpm run lint` → pass