### PR TITLE
fix(gateway): accurate divergence reason for turn-2 system[2] insertion

### DIFF
--- a/packages/gateway/src/cache-analytics.ts
+++ b/packages/gateway/src/cache-analytics.ts
@@ -242,12 +242,14 @@ function isObjectKeyPosition(json: string, offset: number): boolean {
  *  - messages mid-conversation → "earlier message modified" (distillation rewrite)
  *
  * @param messageCount - total messages in the current request (for end-detection)
+ * @param turn - 1-based turn number (for disambiguating the turn-2 system[2] insertion)
  */
 export function inferDivergenceReason(
   path: string,
   prevLength: number,
   currLength: number,
   messageCount?: number,
+  turn?: number,
 ): string {
   if (path === "<end>") {
     return currLength > prevLength
@@ -264,8 +266,23 @@ export function inferDivergenceReason(
   //  bare "system" = plain string system prompt (no array structure)
   if (path === "system[0]" || path.startsWith("system[0]"))
     return "host system prompt changed";
-  if (path === "system[1]" || path.startsWith("system[1]"))
-    return "stable LTM changed (preferences — should be rare, pinned >=1h)";
+  if (path === "system[1]" || path.startsWith("system[1]")) {
+    // A divergence reported at system[1] is ambiguous: it can mean either
+    // (a) the system array GREW — context-bound LTM (system[2]) is injected
+    // for the first time on turn 2, so the byte diff lands at the ]→,
+    // boundary right after system[1] even though system[1] is byte-identical,
+    // or (b) system[1]'s own content genuinely changed (preference re-curation).
+    // We cannot cheaply tell these apart from byte lengths alone: at a system[1]
+    // divergence EVERYTHING after it differs (incl. the whole messages array),
+    // so a body-size delta is dominated by message growth, not the inserted
+    // block. The one reliable signal is the turn number: the system[2] insertion
+    // is deterministically a turn-2 transient (block absent on turn 1, present
+    // from turn 2). Use that; fall back to the honest ambiguous wording when the
+    // turn is unknown.
+    if (turn === 2)
+      return "stable LTM pinned — context-bound LTM (system[2]) first injected on turn 2 (expected, not a real system[1] change)";
+    return "stable LTM block diverged (preference re-curation or system-block insertion)";
+  }
   if (path === "system[2]" || path.startsWith("system[2]"))
     return "context-bound LTM changed (non-preference entries re-ranked)";
   if (path === "system" || path.startsWith("system"))
@@ -377,6 +394,7 @@ export function analyzeCacheTurn(
         prevLength,
         currLength,
         messageCount,
+        analytics.turnCount,
       );
 
       // Capture and log diverging byte snippets to help diagnose what changed

--- a/packages/gateway/test/cache-analytics.test.ts
+++ b/packages/gateway/test/cache-analytics.test.ts
@@ -217,9 +217,28 @@ describe("inferDivergenceReason", () => {
     );
   });
 
-  test("system prompt — stable LTM block", () => {
+  test("system prompt — system[1] divergence on turn 2 is the system[2] insertion", () => {
+    // The turn-2 transient: context-bound LTM (system[2]) is injected for the
+    // first time, shifting the array boundary so the byte diff lands at system[1].
+    expect(
+      inferDivergenceReason("system[1].text", 12000, 12500, undefined, 2),
+    ).toBe(
+      "stable LTM pinned — context-bound LTM (system[2]) first injected on turn 2 (expected, not a real system[1] change)",
+    );
+  });
+
+  test("system prompt — system[1] divergence after turn 2 is ambiguous (not over-claimed)", () => {
+    // After turn 2 we can't cheaply tell a real preference re-curation from a
+    // block insertion (body delta is dominated by message growth), so we report
+    // the honest ambiguous wording rather than asserting a specific cause.
+    expect(
+      inferDivergenceReason("system[1].text", 12000, 12500, undefined, 5),
+    ).toBe(
+      "stable LTM block diverged (preference re-curation or system-block insertion)",
+    );
+    // Same when the turn is unknown.
     expect(inferDivergenceReason("system[1].text", 100, 100)).toBe(
-      "stable LTM changed (preferences — should be rare, pinned >=1h)",
+      "stable LTM block diverged (preference re-curation or system-block insertion)",
     );
   });
 


### PR DESCRIPTION
## Summary
Every session reports a cache bust at turn 2 with the misleading reason `"stable LTM changed (preferences — should be rare, pinned >=1h)"`. This is **not** a real preference change — it is the first injection of `system[2]` (context-bound LTM) after turn 1, which is deliberately withheld on turn 1 (no session context yet to relevance-score against) and injected from turn 2 onward. That grows the system array, so the byte-level diff lands at the `]`→`,` boundary right after `system[1]`, and `mapOffsetToJsonPath` reports the path as `system[1]` even though `system[1]` is byte-identical.

## Why not a byte-size heuristic
A first attempt keyed on body growth (`currLength - prevLength > 200`). That is unsound: at a `system[1]` divergence, **everything after it differs** — including the entire `messages[]` array — so the body-size delta is dominated by normal message growth, not the inserted block. It would mislabel almost every genuine preference re-curation as a block insertion. (Caught in adversarial review.)

## The fix
The one reliable signal is the **turn number**: the `system[2]` insertion is deterministically a turn-2 transient (absent turn 1, present from turn 2 — confirmed in production logs where every `system[1]` divergence was at `turn=2` and never recurred). So:
- `turn === 2` → `"stable LTM pinned — context-bound LTM (system[2]) first injected on turn 2 (expected, not a real system[1] change)"`
- otherwise (later turns / unknown turn) → honest ambiguous wording: `"stable LTM block diverged (preference re-curation or system-block insertion)"` — we don't over-claim a cause we can't cheaply prove.

## Changes
- `inferDivergenceReason` gains a `turn?` parameter; `analyzeCacheTurn` passes `analytics.turnCount`.
- Replaced the misleading single reason with the two turn-aware reasons above.
- Tests: turn-2 insertion case + post-turn-2 / unknown-turn ambiguous case.

Diagnostic-only change (a log label) — no behavioral/cache impact. Typecheck + 52 cache-analytics tests pass.