### PR TITLE
fix(ci): build @loreai/core in CCH seed check workflow

### DIFF
--- a/.github/workflows/cch-seed-check.yml
+++ b/.github/workflows/cch-seed-check.yml
@@ -32,6 +32,9 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - run: pnpm install --frozen-lockfile
+      # scripts/check-cc-version.ts imports the gateway -> @loreai/core chain,
+      # which resolves to packages/core/dist. Build core so the import succeeds.
+      - run: pnpm --filter @loreai/core run build
 
       - name: Check for new Claude Code versions
         id: check
@@ -95,6 +98,10 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - run: pnpm install --frozen-lockfile
+      # scripts/extract-cch-seed.ts (and the cch test) import the gateway ->
+      # @loreai/core chain, which resolves to packages/core/dist. Build core
+      # so the imports succeed.
+      - run: pnpm --filter @loreai/core run build
 
       - name: Extract and apply all missing seeds
         id: extract


### PR DESCRIPTION
## Summary

Fixes #749 — the scheduled **CCH Seed Check** workflow fails at the `check-version`
job's "Check for new Claude Code versions" step with exit code 5.

## Root cause

`scripts/check-cc-version.ts` imports `packages/gateway/src/cch.ts`, which imports
`@loreai/core` (resolving to `packages/core/dist/node/index.js` under Node ESM). The
workflow only ran `pnpm install --frozen-lockfile`, and the root `postinstall` builds
**only the gateway**, not core — so `packages/core/dist/` never existed and the import
failed with `ERR_MODULE_NOT_FOUND`. Because the step uses `2>&1`, the Node error stack
was piped into `jq`, producing `Invalid numeric literal` and exit 5.

The `extract-seed` job has the same install-only pattern and the same import chain
(`scripts/extract-cch-seed.ts` -> `cch.ts` -> `@loreai/core`), so it would fail too.

## Fix

Add `pnpm --filter @loreai/core run build` after `pnpm install` in both jobs, mirroring
the existing `check-docs` precedent in `ci.yml` (which builds core so a workspace-importing
script can resolve `packages/core/dist`).

## Verification

Reproduced locally: removing `packages/core/dist` triggers the exact `ERR_MODULE_NOT_FOUND`;
running `pnpm --filter @loreai/core run build` makes `node scripts/check-cc-version.ts --json`
print valid JSON again.