### PR TITLE
fix(gateway): stop prompt deltas from splitting tool_use/tool_result pairs

### DIFF
--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -659,7 +659,105 @@ function parseDeltaMessage(raw: string): GatewayMessage | null {
   }
 }
 
-function applySessionPromptDeltas(
+/**
+ * Anthropic requires every `tool_use` block to be immediately followed by its
+ * matching `tool_result` block in the next message. Inserting a synthetic
+ * delta message between such a pair orphans the `tool_use` and triggers a 400
+ * ("tool_use ids were found without tool_result blocks immediately after").
+ *
+ * Returns an insert index (clamped to [0, messages.length]) that never lands
+ * between an assistant `tool_use` and the following user `tool_result`. When
+ * the desired index would split a pair, it walks backward past the issuing
+ * assistant so the pair stays adjacent (placing the delta before, rather than
+ * inside, the tool turn).
+ *
+ * @internal Exported for tests.
+ */
+export function safeDeltaInsertIndex(
+  messages: GatewayMessage[],
+  desired: number,
+): number {
+  let idx = Math.max(0, Math.min(desired, messages.length));
+  // While the message at `idx` is a user message carrying a tool_result whose
+  // matching tool_use is on the immediately-preceding assistant, the boundary
+  // at `idx` is inside an atomic pair — move before the assistant.
+  while (idx > 0 && idx < messages.length) {
+    const here = messages[idx];
+    const prev = messages[idx - 1];
+    const splitsPair =
+      here?.role === "user" &&
+      prev?.role === "assistant" &&
+      here.content.some((b) => b.type === "tool_result") &&
+      prev.content.some((b) => b.type === "tool_use");
+    if (!splitsPair) break;
+    idx -= 1;
+  }
+  return idx;
+}
+
+/**
+ * Tool-pairing 400: Anthropic rejects when a `tool_use` block is not
+ * immediately followed by its `tool_result` ("tool_use ids were found without
+ * tool_result blocks immediately after"). The gateway forwards the 400 body to
+ * the client, which surfaces it as "tool use concurrency" — otherwise invisible
+ * to us. This captures diagnostics so the class is measurable.
+ *
+ * Privacy: counts / layer / model / 16-char session prefix ONLY — never any
+ * message content (honors the "NO gen_ai.input.messages" proxy posture).
+ *
+ * @internal Exported for tests.
+ */
+export function captureToolPairing400(input: {
+  status: number;
+  errorBody: string;
+  messages: GatewayMessage[];
+  layer: number;
+  model: string;
+  sessionID: string;
+}): boolean {
+  // Match the specific Anthropic phrasing to avoid false-positiving on other
+  // 400s that merely mention tools (e.g. malformed tool schema).
+  const isToolPairing400 =
+    input.status === 400 &&
+    input.errorBody.includes("tool_use") &&
+    input.errorBody.includes("without") &&
+    input.errorBody.includes("tool_result");
+  if (!isToolPairing400) return false;
+  if (!Sentry.isInitialized()) return true;
+
+  let toolUseCount = 0;
+  let toolResultCount = 0;
+  for (const m of input.messages) {
+    for (const b of m.content) {
+      if (b.type === "tool_use") toolUseCount++;
+      else if (b.type === "tool_result") toolResultCount++;
+    }
+  }
+  Sentry.captureException(
+    new Error("tool-pairing 400 (tool_use/tool_result concurrency)"),
+    {
+      tags: {
+        error_class: "tool_pairing_400",
+        gradient_layer: String(input.layer),
+        model: input.model,
+      },
+      contexts: {
+        tool_pairing: {
+          layer: input.layer,
+          tool_use_count: toolUseCount,
+          tool_result_count: toolResultCount,
+          message_count: input.messages.length,
+          session_id_prefix: input.sessionID.slice(0, 16),
+          concurrency_class: true,
+        },
+      },
+    },
+  );
+  return true;
+}
+
+/** @internal Exported for tests. */
+export function applySessionPromptDeltas(
   messages: GatewayMessage[],
   sessionID: string,
 ): GatewayMessage[] {
@@ -690,8 +788,17 @@ function applySessionPromptDeltas(
 
   for (const { selector, message } of parsed) {
     // Selector positions are defined against the transformed upstream message
-    // array at the time the delta is created. Re-inserting at the same index on
-    // subsequent turns preserves byte-identical prefixes across process restarts.
+    // array at the time the delta is created (where they were already made
+    // tool-pair-safe via safeDeltaInsertIndex). Re-inserting at the SAME index
+    // on subsequent turns is intentional: #747 requires the delta to stay at a
+    // byte-identical position to preserve the conversation prompt cache.
+    //
+    // We deliberately do NOT re-run safeDeltaInsertIndex here — a layout-
+    // dependent adjustment at replay would move the delta across turns and bust
+    // the very cache prefix it exists to protect. In the rare case a later
+    // turn's layout makes this persisted index split a tool pair,
+    // removeOrphanedToolResults (run after this function on the wire array) is
+    // the hard guarantee that no orphaned tool_use/tool_result reaches the API.
     const insertAt = Math.min(selector.insertAt, out.length);
     out.splice(insertAt, 0, message);
   }
@@ -2855,6 +2962,16 @@ function buildStreamingResponse(
                   `recall follow-up upstream ${streamingFollowUp.status ?? "?"}`,
                 ),
               );
+              captureToolPairing400({
+                status: streamingFollowUp.status ?? 0,
+                errorBody: streamingFollowUp.detail,
+                messages: currentModifiedReq.messages,
+                // Layer is not in scope on the streaming recall continuation;
+                // -1 signals "unknown" while still tagging the error class.
+                layer: -1,
+                model: currentModifiedReq.model,
+                sessionID: recallContext.sessionState.sessionID,
+              });
               const heldBack = currentAccum.heldBackEvents();
               if (heldBack) {
                 safeEnqueue(encoder.encode(heldBack));
@@ -5685,7 +5802,15 @@ async function handleConversationTurn(
   }
 
   if (pendingKnowledgeDelta) {
-    const insertAt = Math.max(0, modifiedReq.messages.length - 1);
+    // Place the durable delta near the tail, but never between an
+    // assistant(tool_use) and its user(tool_result) — inserting there orphans
+    // the tool_use and triggers an Anthropic 400 (#747 regression). The index
+    // is computed once here, made tool-pair-safe, and persisted; replay reuses
+    // it verbatim to keep the delta byte-position-stable for the prompt cache.
+    const insertAt = safeDeltaInsertIndex(
+      modifiedReq.messages,
+      Math.max(0, modifiedReq.messages.length - 1),
+    );
     appendKnowledgePromptDelta({
       sessionID,
       projectPath,
@@ -5697,6 +5822,16 @@ async function handleConversationTurn(
     modifiedReq.messages,
     sessionID,
   );
+  // Hard guarantee: deltas are spliced into the wire array AFTER the orphan
+  // safety net (step 8) and persisted indices are replayed verbatim, so a
+  // later turn whose layout differs from the delta's creation turn could place
+  // a delta adjacent to a tool turn. Re-running the safety net ensures no
+  // orphaned tool_use/tool_result ever reaches the API. Note this is a
+  // last-ditch net: if it fires it strips the orphaned tool_use, which rewrites
+  // a historical assistant message and busts the cache from that point — strictly
+  // better than a hard 400, but it should essentially never fire given the
+  // creation-time placement above.
+  removeOrphanedToolResults(modifiedReq.messages);
 
   // --- 9. Forward to upstream ---
   // Enable prompt caching for conversation turns with layered breakpoints:
@@ -5886,6 +6021,15 @@ async function handleConversationTurn(
       );
     }
 
+    captureToolPairing400({
+      status: upstreamResponse.status,
+      errorBody,
+      messages: modifiedReq.messages,
+      layer: result.layer,
+      model: req.model,
+      sessionID,
+    });
+
     genAiSpan.setStatus({
       code: 2,
       message: `HTTP ${upstreamResponse.status}`,
@@ -6016,6 +6160,16 @@ async function handleConversationTurn(
           `recall follow-up upstream error: ${jsonFollowUp.status ?? "?"} ${jsonFollowUp.detail}`,
           new Error(`recall follow-up upstream ${jsonFollowUp.status ?? "?"}`),
         );
+        captureToolPairing400({
+          status: jsonFollowUp.status ?? 0,
+          errorBody: jsonFollowUp.detail,
+          messages: currentModifiedReq.messages,
+          // `result` here is the recall string (shadowed); the transform layer
+          // is not in scope on the recall continuation. -1 signals "unknown".
+          layer: -1,
+          model: currentModifiedReq.model,
+          sessionID: sessionState.sessionID,
+        });
         // Fall back to response with marker (no continuation)
         markerResp.usage = cumulativeUsage;
         postResponse(

--- a/packages/gateway/test/prompt-delta-tools.test.ts
+++ b/packages/gateway/test/prompt-delta-tools.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Regression tests for the durable prompt-delta channel (#747).
+ *
+ * Bug: appendKnowledgePromptDelta inserts a synthetic *user* "knowledge
+ * update" message at `messages.length - 1`, and applySessionPromptDeltas
+ * replays persisted deltas at their stored index. When a turn ends with a
+ * tool call, the wire layout is:
+ *
+ *   assistant(tool_use X)
+ *   user(tool_result X)            <- last message
+ *
+ * Inserting a synthetic user message at length-1 lands it BETWEEN the
+ * tool_use and its tool_result:
+ *
+ *   assistant(tool_use X)
+ *   user(knowledge update)         <- inserted, breaks adjacency
+ *   user(tool_result X)
+ *
+ * which Anthropic rejects with "tool_use ids were found without tool_result
+ * blocks immediately after". The insert index must be tool-pair-aware, and
+ * the orphan safety net must run after deltas are applied.
+ */
+import { describe, test, expect } from "vitest";
+import {
+  safeDeltaInsertIndex,
+  applySessionPromptDeltas,
+  removeOrphanedToolResults,
+  captureToolPairing400,
+} from "../src/pipeline";
+import { appendSessionPromptDelta, ensureProject } from "@loreai/core";
+import type {
+  GatewayContentBlock,
+  GatewayMessage,
+} from "../src/translate/types";
+
+function user(...content: GatewayContentBlock[]): GatewayMessage {
+  return { role: "user", content };
+}
+function assistant(...content: GatewayContentBlock[]): GatewayMessage {
+  return { role: "assistant", content };
+}
+function toolUse(id: string): GatewayContentBlock {
+  return { type: "tool_use", id, name: "read", input: {} };
+}
+function toolResult(id: string): GatewayContentBlock {
+  return {
+    type: "tool_result",
+    toolUseId: id,
+    content: [{ type: "text", text: "ok" }],
+  };
+}
+function text(t: string): GatewayContentBlock {
+  return { type: "text", text: t };
+}
+
+describe("safeDeltaInsertIndex — never splits a tool_use/tool_result pair", () => {
+  test("moves a tail insert before the assistant(tool_use) when it would split the pair", () => {
+    // [user, assistant(tool_use X), user(tool_result X)]
+    // desired = length-1 = 2, which is between tool_use and tool_result.
+    const messages = [
+      user(text("hi")),
+      assistant(toolUse("X")),
+      user(toolResult("X")),
+    ];
+    const idx = safeDeltaInsertIndex(messages, messages.length - 1);
+    // Must not land at 2 (between use and result). Acceptable: 1 (before the
+    // assistant) so the pair stays adjacent.
+    expect(idx).not.toBe(2);
+    // Verify the resulting array keeps the pair adjacent.
+    const out = messages.slice();
+    out.splice(idx, 0, user(text("delta")));
+    assertNoOrphanedTools(out);
+  });
+
+  test("keeps a safe tail insert at the end when the last message is not a tool_result", () => {
+    const messages = [
+      user(text("hi")),
+      assistant(toolUse("X")),
+      user(toolResult("X")),
+      assistant(text("done")),
+    ];
+    const idx = safeDeltaInsertIndex(messages, messages.length - 1);
+    const out = messages.slice();
+    out.splice(idx, 0, user(text("delta")));
+    assertNoOrphanedTools(out);
+  });
+
+  test("handles parallel tool calls (multi tool_use / multi tool_result)", () => {
+    const messages = [
+      user(text("hi")),
+      assistant(toolUse("A"), toolUse("B")),
+      user(toolResult("A"), toolResult("B")),
+    ];
+    const idx = safeDeltaInsertIndex(messages, messages.length - 1);
+    expect(idx).not.toBe(2);
+    const out = messages.slice();
+    out.splice(idx, 0, user(text("delta")));
+    assertNoOrphanedTools(out);
+  });
+
+  test("clamps to array bounds", () => {
+    const messages = [user(text("hi"))];
+    expect(safeDeltaInsertIndex(messages, 99)).toBeLessThanOrEqual(
+      messages.length,
+    );
+    expect(safeDeltaInsertIndex(messages, -5)).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe("persisted delta + backstop never orphans a tool pair on the wire", () => {
+  // applySessionPromptDeltas replays a persisted index VERBATIM (byte-position
+  // stable for the prompt cache — #747). If a later turn's layout makes that
+  // index land between a tool_use/tool_result pair, the production pipeline's
+  // removeOrphanedToolResults backstop (run right after) is the hard guarantee
+  // that no orphan reaches the API. This test mirrors that exact sequence.
+  test("stale persisted index splitting a pair is repaired by the backstop", () => {
+    const sessionID = `delta-tools-${Date.now()}`;
+    const projectID = ensureProject(`/tmp/lore-delta-tools-${Date.now()}`);
+
+    // Persist a delta whose stored insertAt (2) lands between the tool_use and
+    // its tool_result for THIS turn's layout (a layout that differs from the
+    // delta's creation turn — exactly the cross-turn drift case).
+    appendSessionPromptDelta({
+      sessionID,
+      projectID,
+      selector: JSON.stringify({ target: "messages", insertAt: 2 }),
+      content: JSON.stringify({
+        role: "user",
+        content: [{ type: "text", text: "Lore knowledge update" }],
+      }),
+    });
+
+    const messages: GatewayMessage[] = [
+      user(text("hi")),
+      assistant(toolUse("X")),
+      user(toolResult("X")),
+    ];
+
+    // Production sequence: apply deltas (verbatim index), then the backstop.
+    const out = applySessionPromptDeltas(messages, sessionID);
+    removeOrphanedToolResults(out);
+
+    // The wire array must be orphan-free regardless of where the delta landed.
+    assertNoOrphanedTools(out);
+  });
+
+  test("replay is byte-position stable: a non-splitting persisted index is not moved", () => {
+    const sessionID = `delta-stable-${Date.now()}`;
+    const projectID = ensureProject(`/tmp/lore-delta-stable-${Date.now()}`);
+
+    // insertAt=1 sits before the assistant — does not split the pair.
+    appendSessionPromptDelta({
+      sessionID,
+      projectID,
+      selector: JSON.stringify({ target: "messages", insertAt: 1 }),
+      content: JSON.stringify({
+        role: "user",
+        content: [{ type: "text", text: "Lore knowledge update" }],
+      }),
+    });
+
+    const messages: GatewayMessage[] = [
+      user(text("hi")),
+      assistant(toolUse("X")),
+      user(toolResult("X")),
+    ];
+
+    const out = applySessionPromptDeltas(messages, sessionID);
+    // Delta replayed at exactly index 1 (byte-position stable), pair intact.
+    expect(out[1]?.role).toBe("user");
+    expect(
+      out[1]?.content.some(
+        (b) => b.type === "text" && b.text === "Lore knowledge update",
+      ),
+    ).toBe(true);
+    assertNoOrphanedTools(out);
+  });
+});
+
+describe("captureToolPairing400 — detection", () => {
+  // Sentry is not initialized in tests, so captureToolPairing400 returns true
+  // when it *would* capture (detection matched) and false otherwise, without
+  // emitting. We assert on the detection decision only.
+  const anthropicBody =
+    '{"type":"error","error":{"type":"invalid_request_error","message":"messages.560: `tool_use` ids were found without `tool_result` blocks immediately after: toolu_x. Each `tool_use` block must have a corresponding `tool_result` block in the next message."}}';
+
+  test("matches the real Anthropic tool-pairing 400 body", () => {
+    expect(
+      captureToolPairing400({
+        status: 400,
+        errorBody: anthropicBody,
+        messages: [],
+        layer: 0,
+        model: "claude-opus-4-8",
+        sessionID: "abc",
+      }),
+    ).toBe(true);
+  });
+
+  test("does not match a non-400 status", () => {
+    expect(
+      captureToolPairing400({
+        status: 429,
+        errorBody: anthropicBody,
+        messages: [],
+        layer: 0,
+        model: "m",
+        sessionID: "abc",
+      }),
+    ).toBe(false);
+  });
+
+  test("does not match a 400 that merely mentions tools (no 'without')", () => {
+    expect(
+      captureToolPairing400({
+        status: 400,
+        errorBody:
+          '{"error":{"message":"tool_use input does not match tool_result schema"}}',
+        messages: [],
+        layer: 0,
+        model: "m",
+        sessionID: "abc",
+      }),
+    ).toBe(false);
+  });
+});
+
+/**
+ * Asserts every tool_use has an adjacent matching tool_result on the next
+ * message, and every tool_result has an adjacent matching tool_use on the
+ * preceding message — the exact invariant Anthropic enforces.
+ */
+function assertNoOrphanedTools(messages: GatewayMessage[]): void {
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    if (msg.role === "assistant") {
+      const useIds = msg.content
+        .filter((b) => b.type === "tool_use")
+        .map((b) => (b as { id: string }).id);
+      if (useIds.length === 0) continue;
+      const next = messages[i + 1];
+      const resultIds = new Set(
+        next?.role === "user"
+          ? next.content
+              .filter((b) => b.type === "tool_result")
+              .map((b) => (b as { toolUseId: string }).toolUseId)
+          : [],
+      );
+      for (const id of useIds) expect(resultIds.has(id)).toBe(true);
+    } else {
+      const resultIds = msg.content
+        .filter((b) => b.type === "tool_result")
+        .map((b) => (b as { toolUseId: string }).toolUseId);
+      if (resultIds.length === 0) continue;
+      const prev = messages[i - 1];
+      const useIds = new Set(
+        prev?.role === "assistant"
+          ? prev.content
+              .filter((b) => b.type === "tool_use")
+              .map((b) => (b as { id: string }).id)
+          : [],
+      );
+      for (const id of resultIds) expect(useIds.has(id)).toBe(true);
+    }
+  }
+}


### PR DESCRIPTION
## Problem

Users hit Anthropic **HTTP 400** "`tool_use` ids were found without `tool_result` blocks immediately after", surfaced by the client as *"API Error: 400 due to tool use concurrency issues. Run /rewind to recover the conversation."*

Root cause is the durable prompt-delta channel (#747). `appendKnowledgePromptDelta` inserts a synthetic **user** "knowledge update" message near the tail (`insertAt = length - 1`), and `applySessionPromptDeltas` replays persisted deltas at their stored index. When a turn ends with a tool call the wire layout is:

```
assistant(tool_use X)
user(tool_result X)        <- last message
```

Inserting the delta at `length - 1` lands it **between** the pair:

```
assistant(tool_use X)
user(knowledge update)     <- inserted, breaks adjacency
user(tool_result X)
```

→ Anthropic 400. This runs **after** `removeOrphanedToolResults`, so the existing safety net never saw it.

### Evidence (production, `~/.local/share/lore/lore.log`)

Two failures, both at **gradient layer 0** (no compression), orphan always the **last message**, both on tool-ending turns (`lastStop=tool_use`):

- `messages.560` of 561 (`toolu_01EUFc8H6ajCcdAjtTruZBfh`)
- `messages.32` of 33 (`toolu_01SQJGpbVVVWJD7Ni5Xe226N`)

This is why it only reproduces on `main` (which has #747), not on older branches — the original investigation into the gradient/compression path was a red herring.

## Fix

1. **`safeDeltaInsertIndex()`** — compute a tool-pair-safe index at delta **creation** so it never lands between an `assistant(tool_use)` and its `user(tool_result)`. The safe index is persisted and **replayed verbatim** — we deliberately do **not** re-adjust at replay, since a layout-dependent adjustment would move the delta across turns and bust the very prompt cache #747 exists to protect (byte-position stability).
2. **Backstop** — re-run `removeOrphanedToolResults` on the wire array **after** deltas are applied. Hard guarantee that no orphaned pair reaches the API even if a later turn's layout differs from the delta's creation turn. (If it ever fires it strips the orphaned `tool_use`, busting cache from that point — strictly better than a 400, and should essentially never happen given creation-time placement.)
3. **Observability** — `captureToolPairing400()` reports these 400s to Sentry (tag `error_class: tool_pairing_400`) with **counts/layer/model/16-char session prefix only — no message content** (honors the proxy privacy posture). Wired into the main path **and** both recall follow-up error sites. Previously the 400 body was forwarded to the client and never captured.

## Tests

`packages/gateway/test/prompt-delta-tools.test.ts` (9 tests):
- `safeDeltaInsertIndex` never splits a pair (tail insert, parallel tool calls, bounds clamping)
- replay is byte-position stable (a non-splitting persisted index is not moved)
- the backstop repairs a stale persisted index that splits a pair (verified to fail without the backstop)
- 400 detection matches the real Anthropic body and rejects non-400s / unrelated tool 400s

## Verification

- `pnpm run typecheck` ✅
- `pnpm run lint` ✅ (0 errors)
- `pnpm test` ✅ **126 files, 3073 passed, 6 skipped**

## Review notes

This PR incorporates a critical self-review that caught an earlier version applying `safeDeltaInsertIndex` at **replay** time — which would have traded a loud 400 for a silent conversation-cache bust under gradient layer oscillation. Replay now reuses the persisted index verbatim; the backstop is the hard guarantee.