### PR TITLE
fix(gateway): bundle ONNX WASM runtime so npm installs don't need onnxruntime-node (#763)

### DIFF
--- a/packages/core/src/embedding-worker.ts
+++ b/packages/core/src/embedding-worker.ts
@@ -235,6 +235,37 @@ async function ensurePipeline(): Promise<void> {
  * so it can be retried after a corrupt-model purge. Throws on any failure.
  */
 async function loadPipeline(): Promise<void> {
+  // npm/dev path: the bundled worker redirects onnxruntime-node →
+  // onnxruntime-web (WASM) and the gateway bundle ships the WASM runtime
+  // (ort-wasm-simd-threaded.{mjs,wasm}) next to this file in dist/. Point
+  // transformers.js' patched wasmPaths read at those sibling files so the
+  // WASM loads locally instead of from the jsdelivr CDN (wrong variant +
+  // requires network). The binary path sets __LORE_VENDOR_WASM_PATHS__ via
+  // native-loader.cjs instead, so we only act when neither global is set and
+  // we're not in vendored (binary) mode. Guarded by existsSync so dev/test
+  // (which run the raw .ts with the real native onnxruntime-node and have no
+  // sibling WASM) are unaffected — the block is simply inert there.
+  const globals = globalThis as Record<string, unknown>;
+  if (
+    !vendorModel &&
+    !globals.__LORE_VENDOR_WASM_PATHS__ &&
+    !globals.__LORE_NPM_WASM_PATHS__ &&
+    typeof __filename === "string"
+  ) {
+    const { dirname, join } = await import("node:path");
+    const { pathToFileURL } = await import("node:url");
+    const { existsSync } = await import("node:fs");
+    const distDir = dirname(__filename);
+    const wasmMjs = join(distDir, "ort-wasm-simd-threaded.mjs");
+    const wasmBin = join(distDir, "ort-wasm-simd-threaded.wasm");
+    if (existsSync(wasmMjs) && existsSync(wasmBin)) {
+      globals.__LORE_NPM_WASM_PATHS__ = {
+        mjs: pathToFileURL(wasmMjs).href,
+        wasm: wasmBin,
+      };
+    }
+  }
+
   const transformers = await import("@huggingface/transformers");
   const { pipeline, env, layer_norm } = transformers;
 

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -38,7 +38,9 @@
     "dist/embedding-worker.js",
     "dist/index.bun.js",
     "dist/index.cjs",
-    "dist/index.d.cts"
+    "dist/index.d.cts",
+    "dist/ort-wasm-simd-threaded.mjs",
+    "dist/ort-wasm-simd-threaded.wasm"
   ],
   "engines": {
     "node": ">=22.15"

--- a/packages/gateway/script/build-binary-sea.ts
+++ b/packages/gateway/script/build-binary-sea.ts
@@ -43,6 +43,7 @@ import { dirname, join } from "node:path";
 import { parseArgs } from "node:util";
 import { PLACEHOLDER_DEBUG_ID, injectDebugId } from "./debug-id";
 import { MODEL_DIR_NAME, MODEL_FILES } from "./vendor-paths";
+import { findOrtWebDir, ortWebRedirectPlugin } from "./ort-web-plugin";
 import { fossilize } from "fossilize";
 
 const require = createRequire(import.meta.url);
@@ -183,93 +184,17 @@ function prepareVendorModelCache(target: CompileTarget): string | null {
 // ---------------------------------------------------------------------------
 // esbuild: onnxruntime-node → onnxruntime-web (WASM) redirect
 // ---------------------------------------------------------------------------
-
-/** Resolve the onnxruntime-web package directory using Node's module
- *  resolution. onnxruntime-web is a transitive dep of
- *  @huggingface/transformers → we resolve from @loreai/core (which
- *  has transformers as a direct dep), then from transformers to
- *  onnxruntime-web. Works with any package manager layout (bun, pnpm,
- *  npm) because it uses require.resolve, not filesystem scanning. */
-function findOrtWebDir(): string {
-  const coreDir = join(repoRoot, "packages", "core");
-  const coreRequire = createRequire(`${coreDir}/`);
-  // Step 1: find @huggingface/transformers
-  const tfEntry = coreRequire.resolve("@huggingface/transformers");
-  let tfDir = dirname(tfEntry);
-  while (tfDir !== "/" && !existsSync(join(tfDir, "package.json"))) {
-    tfDir = dirname(tfDir);
-  }
-  // Step 2: from transformers, find onnxruntime-web
-  const tfRequire = createRequire(`${tfDir}/`);
-  const ortEntry = tfRequire.resolve("onnxruntime-web");
-  let ortDir = dirname(ortEntry);
-  while (ortDir !== "/" && !existsSync(join(ortDir, "package.json"))) {
-    ortDir = dirname(ortDir);
-  }
-  return ortDir;
-}
-
-/**
- * esbuild plugin that:
- * 1. Stubs `sharp` (vision models, unused for text embeddings).
- * 2. Redirects `onnxruntime-node` → `onnxruntime-web`'s Node entry
- *    (`dist/ort.node.min.mjs`). The WASM runtime is API-compatible.
- * 3. Resolves transitive deps from Bun's `.bun/` store.
- * 4. Patches transformers.js to read WASM paths from globalThis
- *    (`__LORE_VENDOR_WASM_PATHS__`) instead of the CDN fallback.
- */
+// The onnxruntime-node → onnxruntime-web redirect + transformers.js wasmPaths
+// patch live in the shared ./ort-web-plugin module (also used by bundle.ts).
+// The binary path vendors the WASM as SEA assets and sets
+// __LORE_VENDOR_WASM_PATHS__ on globalThis (via native-loader.cjs) before the
+// worker evaluates, so the wasmPaths replacement reads from that global.
 function binaryExternalsPlugin(): esbuild.Plugin {
-  const ortWebDir = findOrtWebDir();
-  const ortWebNodeEntry = join(ortWebDir, "dist", "ort.node.min.mjs");
-  const ortWebPkgJson = join(ortWebDir, "package.json");
-  const ortWebPkg = JSON.parse(readFileSync(ortWebPkgJson, "utf8")) as {
-    main: string;
-  };
-  // Resolve `onnxruntime-web` to its dist/ort.node.min.mjs (matching the
-  // redirect for onnxruntime-node). This ensures the bundled code
-  // imports the same Node-targeted entry regardless of which name it uses.
-  const ortWebMainEntry = join(ortWebDir, ortWebPkg.main);
-
-  return {
-    name: "binary-externals",
-    setup(build) {
-      // Stub sharp as an empty module.
-      build.onResolve({ filter: /^sharp$/ }, (args) => ({
-        path: args.path,
-        namespace: "empty-module",
-      }));
-      build.onLoad({ filter: /.*/, namespace: "empty-module" }, () => ({
-        contents: "module.exports = {};",
-        loader: "js",
-      }));
-
-      // Redirect onnxruntime-node → onnxruntime-web's Node.js entry.
-      build.onResolve({ filter: /^onnxruntime-node$/ }, () => ({
-        path: ortWebNodeEntry,
-      }));
-
-      // Also redirect onnxruntime-web → the same Node-targeted entry
-      // (in case transformers.js or anything else imports it directly).
-      build.onResolve({ filter: /^onnxruntime-web$/ }, () => ({
-        path: ortWebMainEntry,
-      }));
-
-      // Patch transformers.js onnx.js to read wasmPaths from globalThis
-      // instead of the CDN URL. The binary's native-loader.cjs sets
-      // __LORE_VENDOR_WASM_PATHS__ = { mjs, wasm } before the worker
-      // evaluates. transformers.js checks `!ONNX_ENV.wasm.wasmPaths`
-      // and falls back to a CDN URL — we replace that fallback with a
-      // globalThis read.
-      build.onLoad({ filter: /transformers\.node\.mjs$/ }, (args) => {
-        let src = readFileSync(args.path, "utf8");
-        src = src.replace(
-          /ONNX_ENV\.wasm\.wasmPaths\s*=\s*`https:\/\/cdn\.jsdelivr\.net[^`]*`;/,
-          "ONNX_ENV.wasm.wasmPaths = globalThis.__LORE_VENDOR_WASM_PATHS__ || ONNX_ENV.wasm.wasmPaths;",
-        );
-        return { contents: src, loader: "js", resolveDir: dirname(args.path) };
-      });
-    },
-  };
+  return ortWebRedirectPlugin({
+    repoRoot,
+    wasmPathsExpr:
+      "globalThis.__LORE_VENDOR_WASM_PATHS__ || ONNX_ENV.wasm.wasmPaths",
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -651,7 +576,7 @@ async function buildBinary() {
   // --asset-manifest. The manifest's `entry.file` field is the asset
   // key, and `entry.src` (or `file` path) is where fossilize reads
   // the bytes from.
-  const ortWebDir = findOrtWebDir();
+  const ortWebDir = findOrtWebDir(repoRoot);
   const wasmMjsPath = join(ortWebDir, "dist", "ort-wasm-simd-threaded.mjs");
   const wasmBinPath = join(ortWebDir, "dist", "ort-wasm-simd-threaded.wasm");
 

--- a/packages/gateway/script/bundle.ts
+++ b/packages/gateway/script/bundle.ts
@@ -18,6 +18,7 @@
  */
 import * as esbuild from "esbuild";
 import {
+  copyFileSync,
   rmSync,
   mkdirSync,
   writeFileSync,
@@ -29,9 +30,11 @@ import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { PLACEHOLDER_DEBUG_ID, injectDebugId } from "./debug-id";
+import { findOrtWebDir, ortWebRedirectPlugin } from "./ort-web-plugin";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const packageDir = dirname(here);
+const repoRoot = dirname(dirname(packageDir));
 const distDir = join(packageDir, "dist");
 
 // Read version from package.json for build-time injection
@@ -175,7 +178,17 @@ await esbuild.build({
   target: "node22",
   platform: "node",
   conditions: ["node"],
-  external: ["onnxruntime-node", "sharp"],
+  // onnxruntime-node is redirected to onnxruntime-web (WASM) by the plugin so
+  // the npm bundle has no native-module dependency. The WASM runtime files are
+  // copied into dist/ below and located at runtime via __LORE_NPM_WASM_PATHS__
+  // (set in embedding-worker.ts). sharp is stubbed by the plugin.
+  plugins: [
+    ortWebRedirectPlugin({
+      repoRoot,
+      wasmPathsExpr:
+        "globalThis.__LORE_NPM_WASM_PATHS__ || ONNX_ENV.wasm.wasmPaths",
+    }),
+  ],
   outfile: join(distDir, "embedding-worker.cjs"),
   sourcemap: false,
   minify: true,
@@ -200,13 +213,55 @@ await esbuild.build({
   target: "esnext",
   platform: "node",
   conditions: ["bun"],
-  external: ["bun:*", "node:*", "onnxruntime-node", "sharp"],
+  external: ["bun:*", "node:*"],
+  // Same onnxruntime-node → onnxruntime-web redirect as the CJS worker, for
+  // consistency and defense-in-depth. NOTE: this is NOT the worker the
+  // opencode/pi (Bun) path actually loads — under Bun, the gateway bundle
+  // keeps @loreai/core external (see the index.bun.js build above), so
+  // LocalProvider runs from core's own dist and spawns core's
+  // dist/bun/embedding-worker.js (which still uses the native onnxruntime-node
+  // that ships as a non-optional dep of @huggingface/transformers in a
+  // raw-deps install). This gateway-side ESM worker only matters if the
+  // gateway's own Bun bundle is run as a standalone worker host. The bug
+  // (#763) is on the dist-only CJS path → embedding-worker.cjs (fixed above).
+  plugins: [
+    ortWebRedirectPlugin({
+      repoRoot,
+      wasmPathsExpr:
+        "globalThis.__LORE_NPM_WASM_PATHS__ || ONNX_ENV.wasm.wasmPaths",
+    }),
+  ],
   outfile: join(distDir, "embedding-worker.js"),
   sourcemap: false,
   minify: true,
   logLevel: "info",
   legalComments: "none",
 });
+
+// ---------------------------------------------------------------------------
+// Ship onnxruntime-web WASM runtime next to the worker bundles
+// ---------------------------------------------------------------------------
+// The worker bundles redirect onnxruntime-node → onnxruntime-web (WASM). At
+// runtime, embedding-worker.ts sets __LORE_NPM_WASM_PATHS__ to these sibling
+// files so transformers.js loads the WASM locally instead of from the jsdelivr
+// CDN (wrong variant + requires network). Must stay in sync with the `files`
+// array in package.json and the runtime block in embedding-worker.ts.
+//
+// We ship the UNPATCHED ort-wasm-simd-threaded.mjs (unlike the SEA binary,
+// which patches its pthread spawn to a no-op). This is safe ONLY because the
+// worker forces numThreads=1 (embedding-worker.ts), so ort-web takes the
+// single-thread path and never calls its pthread `new Worker(...)` — which
+// would otherwise crash under Node, where the worker has no global `Worker`.
+// If numThreads ever changes, patch the copied .mjs the way build-binary-sea
+// does, or this becomes a latent crash.
+
+const ortWebDir = findOrtWebDir(repoRoot);
+for (const wasmFile of [
+  "ort-wasm-simd-threaded.mjs",
+  "ort-wasm-simd-threaded.wasm",
+]) {
+  copyFileSync(join(ortWebDir, "dist", wasmFile), join(distDir, wasmFile));
+}
 
 // ---------------------------------------------------------------------------
 // Debug ID injection + sourcemap upload
@@ -415,5 +470,6 @@ console.log(`  dist/index.cjs            — CJS bundle (Node.js, node:sqlite)`)
 console.log(`  dist/index.bun.js         — ESM bundle (Bun, bun:sqlite)`);
 console.log(`  dist/embedding-worker.cjs — embedding worker CJS (Node.js)`);
 console.log(`  dist/embedding-worker.js  — embedding worker ESM (Bun)`);
+console.log(`  dist/ort-wasm-simd-threaded.{mjs,wasm} — ONNX WASM runtime`);
 console.log(`  dist/bin.cjs              — CLI wrapper`);
 console.log(`  dist/index.d.cts          — type declarations`);

--- a/packages/gateway/script/native-loader.cjs
+++ b/packages/gateway/script/native-loader.cjs
@@ -19,12 +19,16 @@
  *       (`ort-wasm-simd-threaded.mjs` and `ort-wasm-simd-threaded.wasm`)
  *       from SEA assets to a stable tmp dir on disk.
  *    b. Register their paths on `globalThis.__LORE_VENDOR_WASM_PATHS__`
- *       so the bundled `transformers.js` (patched via `binaryExternalsPlugin`)
- *       can load them without going to the CDN fallback.
+ *       so the bundled `transformers.js` (patched via the shared
+ *       `ortWebRedirectPlugin` in `ort-web-plugin.ts`) can load them
+ *       without going to the CDN fallback.
  *
  * 2. If NOT running inside a SEA (npm CJS bundle, dev mode, tests):
- *    Do nothing — `transformers.js` uses the CDN fallback for WASM
- *    (the npm path) or the local file system (with `LORE_LOCAL_MODEL_PATH`).
+ *    Do nothing. The npm CJS bundle handles WASM itself — it ships
+ *    `ort-wasm-simd-threaded.{mjs,wasm}` in `dist/` and `embedding-worker.ts`
+ *    registers `globalThis.__LORE_NPM_WASM_PATHS__` at runtime (also patched
+ *    away from the CDN by `ortWebRedirectPlugin`). Dev/test use the real
+ *    native `onnxruntime-node` from `node_modules`.
  *
  * The extraction uses a per-pid tmp dir, so each process gets a
  * fresh copy. The OS reaps /tmp on reboot, so disk leaks are

--- a/packages/gateway/script/ort-web-plugin.ts
+++ b/packages/gateway/script/ort-web-plugin.ts
@@ -1,0 +1,148 @@
+/**
+ * Shared esbuild plugin: redirect `onnxruntime-node` → `onnxruntime-web`
+ * (WASM, Node entry) and patch transformers.js' CDN wasmPaths fallback.
+ *
+ * Used by both build pipelines:
+ *   - `build-binary-sea.ts` (standalone binary): vendors WASM as SEA assets
+ *     and sets `globalThis.__LORE_VENDOR_WASM_PATHS__` at runtime.
+ *   - `bundle.ts` (npm package): ships the WASM files in `dist/` and sets
+ *     `globalThis.__LORE_NPM_WASM_PATHS__` at runtime (see embedding-worker.ts).
+ *
+ * Without this redirect, the npm worker bundle leaves `onnxruntime-node`
+ * (a native `.node` backend that esbuild can't bundle) as an external
+ * `require`, which fails for dist-only installs (npm/AUR) with
+ * "Cannot find module 'onnxruntime-node'" (see GitHub issue #763).
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import type * as esbuild from "esbuild";
+
+/**
+ * Resolve the onnxruntime-web package directory using Node's module
+ * resolution. onnxruntime-web is a transitive dep of
+ * @huggingface/transformers → we resolve from @loreai/core (which has
+ * transformers as a direct dep), then from transformers to onnxruntime-web.
+ * Works with any package manager layout (bun, pnpm, npm) because it uses
+ * require.resolve, not filesystem scanning.
+ */
+export function findOrtWebDir(repoRoot: string): string {
+  const coreDir = join(repoRoot, "packages", "core");
+  const coreRequire = createRequire(`${coreDir}/`);
+  // Step 1: find @huggingface/transformers
+  const tfEntry = coreRequire.resolve("@huggingface/transformers");
+  let tfDir = dirname(tfEntry);
+  while (tfDir !== "/" && !existsSync(join(tfDir, "package.json"))) {
+    tfDir = dirname(tfDir);
+  }
+  // Step 2: from transformers, find onnxruntime-web
+  const tfRequire = createRequire(`${tfDir}/`);
+  const ortEntry = tfRequire.resolve("onnxruntime-web");
+  let ortDir = dirname(ortEntry);
+  while (ortDir !== "/" && !existsSync(join(ortDir, "package.json"))) {
+    ortDir = dirname(ortDir);
+  }
+  return ortDir;
+}
+
+export interface OrtWebPluginOptions {
+  /** Monorepo root (used to resolve onnxruntime-web). */
+  repoRoot: string;
+  /**
+   * The replacement RHS for transformers.js' `ONNX_ENV.wasm.wasmPaths = <CDN>`
+   * assignment. The value is read at runtime to locate the local WASM files:
+   *   - binary: `globalThis.__LORE_VENDOR_WASM_PATHS__ || ONNX_ENV.wasm.wasmPaths`
+   *   - npm:    `globalThis.__LORE_NPM_WASM_PATHS__ || ONNX_ENV.wasm.wasmPaths`
+   */
+  wasmPathsExpr: string;
+}
+
+/**
+ * esbuild plugin that:
+ * 1. Stubs `sharp` (vision models, unused for text embeddings).
+ * 2. Redirects `onnxruntime-node` → `onnxruntime-web`'s Node entry
+ *    (`dist/ort.node.min.mjs`). The WASM runtime is API-compatible and
+ *    registers its backend under both "cpu" and "wasm" names, so the
+ *    worker's `device: "cpu"` request works unchanged.
+ * 3. Also redirects `onnxruntime-web` → the same Node-targeted entry.
+ * 4. Patches transformers.js' CDN `wasmPaths` fallback (in both the `.mjs`
+ *    and `.cjs` transformers variants) to read from globalThis instead, so
+ *    the local WASM files are used at runtime (no network / CDN dependency).
+ */
+export function ortWebRedirectPlugin(
+  opts: OrtWebPluginOptions,
+): esbuild.Plugin {
+  const ortWebDir = findOrtWebDir(opts.repoRoot);
+  const ortWebNodeEntry = join(ortWebDir, "dist", "ort.node.min.mjs");
+  const ortWebPkgJson = join(ortWebDir, "package.json");
+  const ortWebPkg = JSON.parse(readFileSync(ortWebPkgJson, "utf8")) as {
+    main: string;
+  };
+  // Resolve `onnxruntime-web` to its package main entry. Note this is the
+  // package's `main` (`dist/ort.node.min.js`, CJS), which differs from the
+  // `.mjs` node entry used for the onnxruntime-node redirect below — the
+  // asymmetry is intentional and preserved from the original binary plugin.
+  // In practice transformers.js (`device:"cpu"`) only imports the
+  // `onnxruntime-node` specifier, so the `onnxruntime-web` redirect is a
+  // belt-and-suspenders catch for any direct import and is rarely exercised.
+  const ortWebMainEntry = join(ortWebDir, ortWebPkg.main);
+
+  return {
+    name: "ort-web-redirect",
+    setup(build) {
+      // Stub sharp as an empty module.
+      build.onResolve({ filter: /^sharp$/ }, (args) => ({
+        path: args.path,
+        namespace: "empty-module",
+      }));
+      build.onLoad({ filter: /.*/, namespace: "empty-module" }, () => ({
+        contents: "module.exports = {};",
+        loader: "js",
+      }));
+
+      // Redirect onnxruntime-node → onnxruntime-web's Node.js entry.
+      build.onResolve({ filter: /^onnxruntime-node$/ }, () => ({
+        path: ortWebNodeEntry,
+      }));
+
+      // Also redirect onnxruntime-web → its package main entry (in case
+      // transformers.js or anything else imports it directly). See the note
+      // on ortWebMainEntry above re: the .js/.mjs asymmetry.
+      build.onResolve({ filter: /^onnxruntime-web$/ }, () => ({
+        path: ortWebMainEntry,
+      }));
+
+      // Patch transformers.js onnx.js to read wasmPaths from globalThis
+      // instead of the CDN URL. transformers.js sets `ONNX_ENV.wasm.wasmPaths`
+      // to a jsdelivr CDN URL that only ships the `jsep` WASM variant (wrong
+      // filename for ort-web 1.22 + requires network). We replace that with a
+      // globalThis read so the locally shipped/vendored WASM is used instead.
+      // Match both the `.mjs` (binary) and `.cjs` (npm) transformers variants.
+      build.onLoad({ filter: /transformers\.node\.(mjs|cjs)$/ }, (args) => {
+        const src = readFileSync(args.path, "utf8");
+        const cdnAssign =
+          /ONNX_ENV\.wasm\.wasmPaths\s*=\s*`https:\/\/cdn\.jsdelivr\.net[^`]*`;/;
+        // Fail the build loudly if transformers.js changes/removes the CDN
+        // wasmPaths assignment we patch. A silent no-op here would ship a
+        // bundle that falls back to the jsdelivr CDN at runtime (network +
+        // wrong WASM variant) — exactly the failure mode we're fixing (#763).
+        if (!cdnAssign.test(src)) {
+          throw new Error(
+            `ort-web-plugin: expected CDN wasmPaths assignment not found in ` +
+              `${args.path}. transformers.js likely changed its onnx.js — ` +
+              `update the regex in ort-web-plugin.ts.`,
+          );
+        }
+        const patched = src.replace(
+          cdnAssign,
+          `ONNX_ENV.wasm.wasmPaths = ${opts.wasmPathsExpr};`,
+        );
+        return {
+          contents: patched,
+          loader: "js",
+          resolveDir: dirname(args.path),
+        };
+      });
+    },
+  };
+}


### PR DESCRIPTION
Fixes #763.

## Problem

npm/AUR installs of `@loreai/gateway` fail local embeddings with `Cannot find module 'onnxruntime-node'` from `dist/embedding-worker.cjs`. The worker bundle marked `onnxruntime-node` (a native `.node` backend) as esbuild `external`, but it's never shipped — the package is dist-only and `onnxruntime-node` is only a *transitive* dep of `@huggingface/transformers`. So every npm install hits it; AUR's `--ignore-scripts` just makes it deterministic. This degrades users to FTS-only search and spams errors.

The standalone binary already avoided this by redirecting `onnxruntime-node` → `onnxruntime-web` (WASM).

## Fix

Make the npm worker self-contained the same way:

- **New shared plugin** `packages/gateway/script/ort-web-plugin.ts` — extracted `findOrtWebDir()` + `ortWebRedirectPlugin({ repoRoot, wasmPathsExpr })`, now used by **both** `bundle.ts` and `build-binary-sea.ts`. Redirects `onnxruntime-node`/`-web` → ort-web's Node WASM entry, stubs `sharp`, and patches transformers' jsdelivr CDN `wasmPaths` to a `globalThis` read. The patch is **build-asserted** — if a future transformers version changes its `onnx.js`, the build fails loudly instead of silently shipping a CDN-dependent bundle.
- `bundle.ts` ships `ort-wasm-simd-threaded.{mjs,wasm}` in `dist/`; `embedding-worker.ts` registers `__LORE_NPM_WASM_PATHS__` at runtime so the WASM loads locally (no CDN/network).
- Added the WASM files to `package.json` `files`.

The **binary path is unchanged** (still vendors WASM as SEA assets, uses `__LORE_VENDOR_WASM_PATHS__`). **dev/test** keep using the native `onnxruntime-node` from `node_modules`.

## Size impact

+~11 MB unpacked / +~2.85 MB gzipped tarball (the WASM binary). For context, the binary already embeds this same WASM, and the model itself (~137 MB, runtime-downloaded) dwarfs it.

## Verification

- `pnpm run typecheck` + `pnpm run lint` clean
- 74 core embedding tests pass
- npm bundle: worker has `__LORE_NPM_WASM_PATHS__`, zero `onnxruntime-node`/CDN references
- **Dist-only worker smoke test** (no `node_modules`) produces a 768-dim embedding — including **offline** (`HF_HUB_OFFLINE=1`), proving WASM loads locally
- Binary `--prepare-only` build still uses vendored WASM (no regression)