### PR TITLE
fix(core): clamp tier-gate compressedEstimate to the layer-0 ceiling

### DIFF
--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -1962,6 +1962,14 @@ function transformInner(input: {
   // Usable = full context minus output reservation minus fixed overhead (system + tools)
   // minus LTM tokens already injected into the system prompt this turn.
   // Read LTM tokens from per-session state to avoid cross-session contamination.
+  //
+  // NOTE: `usable` is sensitive to BOTH `contextLimit` (set per-turn from the
+  // model spec, which can climb as models.dev data warms from a cold fallback)
+  // and `overhead` (a shared EMA from calibrate()). Anything derived as a
+  // fraction of `usable` — e.g. distilled/raw budgets — therefore scales with a
+  // large context window. Downstream economic decisions must not treat such a
+  // budget as the real compressed size (see the tier gate's compressedEstimate
+  // clamp below).
   const sessLtmTokens = sid ? sessState.ltmTokens : ltmTokensFallback;
   const usableRaw = Math.max(
     0,
@@ -2178,7 +2186,20 @@ function transformInner(input: {
     // For compression, estimate the compressed size as the layer-1 budget
     // (distilled + raw fractions). This is a rough upper bound — actual
     // compressed output may be smaller.
-    const compressedEstimate = distilledBudget + rawBudget;
+    //
+    // Clamp to layer0Ceiling (the cost-aware layer-0 cap, ~l0cap): the raw
+    // distilled+raw budget is scaled off `usable`, which for high-context
+    // models (e.g. a 1M-token opus → usable ~957K) inflates the estimate to
+    // ~0.65*usable (~620K) — far larger than what compression actually yields
+    // (it targets layer0Ceiling, ~200K). Feeding the inflated figure to
+    // shouldCompress() makes bustCost dwarf continueCost, so the gate refuses
+    // to compress every turn — even under sustained-bust write-rate repricing —
+    // and the raw context grows unbounded until the hard ceiling. Clamping to
+    // the real compression target makes the economics reflect reality.
+    const compressedEstimate = Math.min(
+      distilledBudget + rawBudget,
+      layer0Ceiling,
+    );
     if (
       !shouldCompress(Math.round(layer0Input), compressedEstimate, busts, {
         freeWrite,

--- a/packages/core/test/gradient.test.ts
+++ b/packages/core/test/gradient.test.ts
@@ -3377,6 +3377,141 @@ describe("tier-based context management", () => {
       // so err on the side of keeping the cache (don't bust).
       expect(shouldCompress(250_000, 150_000, 0)).toBe(false);
     });
+
+    test("realistic compressed target compresses where inflated estimate would not", () => {
+      // Regression for the "growing unsustainably" runaway (session
+      // 0AVWKugtmhBKqLOX9 / ses_14b9bf3d4ffe…): on a high-context model the
+      // tier gate fed shouldCompress() a compressedEstimate scaled off `usable`
+      // (~0.65*usable). For a 1M-token model usable≈957K, so the estimate was
+      // ~620K — but compression actually targets l0cap (~200K). With the
+      // INFLATED estimate, even sustained-bust write-rate repricing refuses to
+      // compress; with the REAL target it correctly compresses.
+      const current = 635_000; // observed grown context
+      const inflated = 620_000; // distilledBudget+rawBudget ≈ 0.65 * 957K usable
+      const realTarget = 200_000; // layer0Ceiling (what compression yields)
+
+      // Sustained-bust regime (>=5): continue is priced at the WRITE rate.
+      //   continueCost = 635K × $6.25/M = $3.969
+      //   inflated  bustCost = 620K × $6.25/M = $3.875  → 3.875 < 0.85*3.969=3.374? NO → don't compress
+      //   real      bustCost = 200K × $6.25/M = $1.25   → 1.25  < 3.374           ? YES → compress
+      expect(shouldCompress(current, inflated, 5)).toBe(false);
+      expect(shouldCompress(current, realTarget, 5)).toBe(true);
+    });
+  });
+
+  describe("tier gate — clamps compressedEstimate to the real compression target", () => {
+    const SESSION = "tier-gate-clamp-sess";
+
+    beforeEach(() => {
+      resetCalibration(SESSION);
+      resetPrefixCache();
+      resetRawWindowCache();
+      // High-context model (e.g. a 1M-token opus): usable ≈ 968K, so the naive
+      // distilled+raw budget (~0.65*usable ≈ 629K) is far larger than what
+      // compression actually produces.
+      setModelLimits({ context: 1_000_000, output: 32_000 });
+      // Cost-aware layer-0 cap (the real compression target). min(maxInput, this)
+      // → layer0Ceiling = 200K, the value the runaway session logged as l0cap.
+      setMaxLayer0Tokens(200_000);
+      // Anthropic opus pricing: write=$6.25/M, read=$0.50/M (write ~12.5× read).
+      setCachePricing(6.25 / 1_000_000, 0.5 / 1_000_000);
+    });
+
+    afterAll(() => {
+      // Restore the suite-wide defaults so later describe blocks are unaffected.
+      setModelLimits({ context: 10_000, output: 2_000 });
+      setMaxLayer0Tokens(0);
+      setCachePricing(0, 0);
+      resetCalibration(SESSION);
+      // resetCalibration sets calibratedOverhead = null (→ FIRST_TURN_OVERHEAD
+      // fallback). The suite baseline (top-level beforeAll) is calibrate(0) =
+      // zero overhead, so restore that to avoid leaking a 15K overhead default
+      // into any later test that relies on the baseline.
+      calibrate(0);
+    });
+
+    test("compresses a sustained-bust runaway instead of layer-0 passthrough", () => {
+      // A handful of small messages — their token count is irrelevant because we
+      // drive the SIZE via calibration below (mirrors a real long session whose
+      // exact input is known from the API).
+      const msgs = Array.from({ length: 8 }, (_, i) =>
+        makeMsg(
+          `clamp-${i}`,
+          i % 2 === 0 ? "user" : "assistant",
+          "x".repeat(200),
+          SESSION,
+        ),
+      );
+
+      // Calibrate the session directly to a large grown input, WITHOUT a prior
+      // transform. This is critical: calibrate() only updates the (shared)
+      // overhead EMA when a previous transform estimate exists (lastTransform-
+      // Estimate > 0). With no prior transform that branch is skipped, so
+      // `usable` stays at the model's true ~968K instead of collapsing — which
+      // is exactly the high-context condition that triggers the bug. Passing
+      // messageCount = msgs.length means the calibrated path sees zero "new"
+      // messages, so expectedInput == lastKnownInput == 635K.
+      calibrate(635_000, SESSION, msgs.length);
+
+      // Drive the cache into a sustained-bust regime (>=5 consecutive busts):
+      // every turn is ~93% cache write, exactly like the runaway logs.
+      for (let i = 0; i < 6; i++) {
+        recordCacheUsage(440_000, 34_813, 2, SESSION);
+      }
+      expect(
+        inspectSessionState(SESSION)?.consecutiveBusts,
+      ).toBeGreaterThanOrEqual(5);
+
+      const result = transform({
+        messages: msgs,
+        projectPath: PROJECT,
+        sessionID: SESSION,
+      });
+
+      // Guard the scenario actually exercises the tier gate (not the overhead-
+      // collapsed path that masked the bug originally). At the decision turn
+      // `usable` must be near the full model context (~968K), so the UN-clamped
+      // distilled+raw budget (~0.65*usable ≈ 620K) genuinely exceeds the clamp
+      // target (layer0Ceiling = 200K). If usable here collapses (e.g. overhead
+      // pollution), the test would pass for the wrong reason — so assert it.
+      expect(result.usable).toBeGreaterThan(900_000);
+      expect(result.distilledBudget + result.rawBudget).toBeGreaterThan(
+        300_000,
+      );
+
+      // Before the fix: the gate fed shouldCompress() the un-clamped ~620K
+      // estimate; bustCost (620K×write) dwarfed continueCost even under
+      // sustained-bust write-rate repricing, so it STAYED at layer 0 and grew
+      // unbounded. After clamping compressedEstimate to layer0Ceiling (200K),
+      // the economics flip and the gate compresses (layer >= 1). This assertion
+      // FAILS on revert of the one-line fix (verified).
+      expect(result.layer).toBeGreaterThanOrEqual(1);
+    });
+
+    test("small session still passes through layer 0 (no over-compression)", () => {
+      // A genuinely small session (well under layer0Ceiling) must not be
+      // compressed — the clamp only affects the gate's economic estimate, not
+      // the passthrough decision for sessions that comfortably fit.
+      const msgs = Array.from({ length: 6 }, (_, i) =>
+        makeMsg(
+          `small-${i}`,
+          i % 2 === 0 ? "user" : "assistant",
+          "y".repeat(100),
+          SESSION,
+        ),
+      );
+
+      transform({ messages: msgs, projectPath: PROJECT, sessionID: SESSION });
+      // Tiny calibrated input — well below layer0Ceiling (200K).
+      calibrate(5_000, SESSION, msgs.length);
+
+      const result = transform({
+        messages: msgs,
+        projectPath: PROJECT,
+        sessionID: SESSION,
+      });
+      expect(result.layer).toBe(0);
+    });
   });
 
   describe("recordCacheUsage — consecutive bust tracking", () => {


### PR DESCRIPTION
## Problem

A user's opencode session (`ses_14b9bf3d4ffe…` → internal `0AVWKugtmhBKqLOX9`, model `claude-opus-4-8`) hit the **"growing unsustainably"** warning. Investigation of the gateway logs showed the conversation grew to **660K raw tokens on Layer 0 passthrough** while the cache fully busted every turn (~440K write, read frozen at 34.8K, `consecutiveBusts` climbing 1→13). The warning fired correctly but did nothing — the context kept growing until the hard ceiling finally forced compression down to ~188K (a 3.5× reduction, proving compression was viable the whole time).

## Root cause

In `packages/core/src/gradient.ts`, the tier-based bust-vs-continue gate estimated the compressed context size as:

```ts
const compressedEstimate = distilledBudget + rawBudget;  // ≈ 0.65 × usable
```

`usable` ≈ `contextLimit − outputReserved − overhead − ltm`. For a high-context model (opus-4-8 carries a ~1M window from models.dev → `usable ≈ 957K`), this estimate inflates to **~620K** — far larger than what compression actually produces, which targets `layer0Ceiling` (the cost-aware layer-0 cap, `l0cap` ≈ **200K**).

`shouldCompress()` then compares `bustCost = compressedEstimate × writeCost` against `continueCost`. With the inflated 620K estimate, `bustCost` dwarfs `continueCost` **even under sustained-bust write-rate repricing** (`620K > 0.85 × 635K`), so the gate refuses to compress every turn. The only escape valve (`layer0Input > 0.95 × maxInput` ≈ 919K) sits far above the observed size, so the context grows unbounded.

## Fix

Clamp `compressedEstimate` to the real compression target:

```ts
const compressedEstimate = Math.min(distilledBudget + rawBudget, layer0Ceiling);
```

Now the gate weighs "compress to ~200K" vs "continue at 635K" and correctly compresses. The clamp is **local and isolated**: `compressedEstimate` is a throwaway used only by the `shouldCompress()` call and its log line — returned budgets, stage budgets, and the passthrough decision are untouched. When `l0cap` is disabled (`maxLayer0Tokens === 0`), `layer0Ceiling === maxInput` and the gate is never entered, so the clamp is inert (no behavior change).

A NOTE comment was added near the `usable` computation flagging that anything derived as a fraction of `usable` scales with the context window and must not be treated as a real compressed size.

## Tests

- **`shouldCompress` unit regression**: the inflated estimate (620K) refuses to compress; the real target (200K) compresses — at `busts ≥ 5` with Anthropic-like pricing.
- **Tier-gate integration regression**: reproduces the runaway (1M-context model, `l0cap=200K`, sustained busts, calibrated 635K input) and asserts compression now runs (`layer ≥ 1`). **Verified to fail when the one-line fix is reverted** (`layer=0 tokens=635905 usable=953000`). Guard assertions (`usable > 900K`, `budget > 300K`) ensure the test exercises the gate rather than an overhead-collapsed path.
- **Small-session guard**: a session well under the ceiling still passes through at Layer 0 (no over-compression regression).

## Verification

- `pnpm run typecheck` — clean (all packages)
- `pnpm test` — 3149 passed / 6 skipped / 0 failed
- `pnpm run lint` — exit 0
- Fails-on-revert of the one-line fix — verified

🤖 Generated with [opencode](https://opencode.ai)