### PR TITLE
fix(core): stop layer-1 raw-window pin from marching every turn

### DIFF
--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -59,9 +59,9 @@ let outputReserved = 32_000;
 //   continueCost = currentSize   × cacheReadCostPerToken
 // If bustCost ≥ threshold × continueCost, don't compress — reads are cheap.
 //
-// Rolling bust detection: if 5+ consecutive turns bust the cache, stop trying
-// to compress — something structural is causing busts, and compression just
-// adds cost on top.
+// Rolling bust detection: once SUSTAINED_BUST_THRESHOLD consecutive turns bust
+// the cache, stop trying to compress — something structural is causing busts,
+// and compression just adds cost on top.
 // ---------------------------------------------------------------------------
 
 /** Tier boundary tokens. Configurable for testing. */
@@ -127,8 +127,15 @@ export function isFreeWriteSession(sessionID: string): boolean {
 /** Consecutive-bust count at/above which a session is in a "sustained-bust
  *  regime": the prompt cache is being rewritten nearly every turn, so the
  *  "continue" path is paying cache *write* cost — not the cheap read cost the
- *  tier gate normally assumes. */
-const SUSTAINED_BUST_THRESHOLD = 5;
+ *  tier gate normally assumes.
+ *
+ *  Kept low (2): at large context windows a single full cache bust rewrites
+ *  hundreds of thousands of tokens at ~12.5× the read price, so even two
+ *  consecutive full busts is already too expensive to keep paying. A low
+ *  threshold makes shouldCompress() reprice "continue" at the write rate
+ *  sooner (compressing earlier instead of letting the context grow), and
+ *  surfaces the unsustainable-conversation warning promptly. */
+const SUSTAINED_BUST_THRESHOLD = 2;
 
 /**
  * Decide whether compression is economical at a tier boundary.
@@ -353,8 +360,9 @@ type SessionState = {
   /** Consecutive turns at layer >= 2. When >= 3, log a compaction hint. */
   consecutiveHighLayer: number;
   /** Consecutive turns where the cache was busted (>50% writes).
-   *  Used for rolling bust detection: after 5+ consecutive busts, stop
-   *  trying to compress and warn that the conversation is unsustainable. */
+   *  Used for rolling bust detection: once consecutiveBusts reaches
+   *  SUSTAINED_BUST_THRESHOLD, stop trying to compress and warn that the
+   *  conversation is unsustainable. */
   consecutiveBusts: number;
   /** Consecutive turns where the upstream reported zero cache_creation_input_tokens.
    *  After >= NO_CACHE_WRITE_THRESHOLD turns, the session is treated as "free-write" —
@@ -1706,6 +1714,16 @@ export function resetDistillationSnapshot(sessionID?: string) {
 //
 // Reset conditions: session changes, or layer escalates to 2+ (the pinned
 // window was too large even with stripping — something genuinely changed).
+//
+// When the pinned window overflows and we must rescan, we evict down to
+// RAW_WINDOW_EVICT_TARGET of rawBudget rather than re-pinning right at the
+// ceiling. A window re-pinned exactly at the budget ceiling overflows again
+// after the next ~2 messages, degrading the pin into a per-turn sliding window
+// that busts the prompt cache on every turn (the boundary marches forward ~2
+// messages/turn). Evicting a chunk leaves headroom so the boundary stays stable
+// for many turns between evictions, trading a little retained history for a
+// large reduction in cache-write cost.
+const RAW_WINDOW_EVICT_TARGET = 0.75;
 
 type RawWindowCache = {
   sessionID: string;
@@ -1838,13 +1856,25 @@ function tryFitStable(input: {
     );
   }
 
-  // Normal backward scan to find the tightest fitting cutoff.
+  // Normal backward scan to find the tightest fitting cutoff. Evict down to a
+  // chunk below the ceiling (rawFillBudget) so the re-pinned boundary has
+  // headroom and won't overflow again on the next turn — preventing the
+  // per-turn boundary march that busts the cache. The current-turn escalation
+  // guard inside tryFit still uses the full rawBudget.
+  //
+  // Edge case: when the current turn alone is larger than rawFillBudget
+  // (i.e. > 75% of rawBudget), the older-message fill collapses to ~0 and the
+  // window keeps only the current turn — so a session whose every turn is that
+  // large can still march. That's an extreme regime (the old full-budget rescan
+  // also degraded, just at the 100% boundary); higher layers (tool stripping)
+  // take over when even the current turn doesn't fit the full rawBudget.
   const result = tryFit({
     messages: input.messages,
     prefix: input.prefix,
     prefixTokens: input.prefixTokens,
     distilledBudget: input.distilledBudget,
     rawBudget: input.rawBudget,
+    rawFillBudget: Math.floor(input.rawBudget * RAW_WINDOW_EVICT_TARGET),
     strip: "none",
   });
 
@@ -1924,9 +1954,10 @@ export type TransformResult = {
   // relevance scoring. Set on Layer 4 (emergency) where the context is
   // fully reset and mid-session knowledge may have changed relevance.
   refreshLtm: boolean;
-  /** When set, the conversation is growing unsustainably — 5+ consecutive
-   *  cache busts detected. The pipeline should inject a warning message
-   *  advising the user to compact or start a new conversation. */
+  /** When set, the conversation is growing unsustainably —
+   *  SUSTAINED_BUST_THRESHOLD+ consecutive cache busts detected. The pipeline
+   *  should inject a warning message advising the user to compact or start a
+   *  new conversation. */
   unsustainable?: boolean;
 };
 
@@ -2222,7 +2253,7 @@ function transformInner(input: {
         distilledBudget,
         rawBudget,
         refreshLtm: false,
-        unsustainable: busts >= 5,
+        unsustainable: busts >= SUSTAINED_BUST_THRESHOLD,
       };
     }
   }
@@ -2564,6 +2595,16 @@ function tryFit(input: {
   rawBudget: number;
   strip: "none" | "old-tools" | "all-tools";
   protectedTurns?: number;
+  /**
+   * Optional target budget for the backward fill of OLDER messages. Defaults to
+   * `rawBudget`. The current-turn escalation guard always uses the full
+   * `rawBudget` (a turn that doesn't fit must still escalate), but the older-
+   * message fill can target a smaller budget so the chosen window leaves
+   * headroom below the ceiling. Used by tryFitStable's rescan path to evict in
+   * a chunk (so the re-pinned boundary doesn't sit right at the ceiling and
+   * overflow again next turn).
+   */
+  rawFillBudget?: number;
 }): Omit<
   TransformResult,
   "layer" | "usable" | "distilledBudget" | "rawBudget" | "refreshLtm"
@@ -2590,8 +2631,13 @@ function tryFit(input: {
 
   // Walk backwards through older messages (before the current turn),
   // filling the remaining budget after reserving space for the current turn.
+  // The fill targets `rawFillBudget` (defaults to rawBudget); callers can pass a
+  // smaller value to evict in a chunk and leave headroom below the ceiling. The
+  // current turn is always reserved against the full rawBudget (already checked
+  // above), so clamp so the older-fill target can't go negative.
   const olderMessages = input.messages.slice(0, turnStart);
-  const remainingBudget = input.rawBudget - currentTurnTokens;
+  const fillBudget = input.rawFillBudget ?? input.rawBudget;
+  const remainingBudget = Math.max(0, fillBudget - currentTurnTokens);
   let olderTokens = 0;
   let cutoff = olderMessages.length; // default: include none of the older messages
   const protectedTurns = input.protectedTurns ?? 0;

--- a/packages/core/test/gradient.test.ts
+++ b/packages/core/test/gradient.test.ts
@@ -500,6 +500,82 @@ describe("gradient — lazy raw window eviction (Approach B)", () => {
     calibrate(0);
     resetRawWindowCache();
   });
+
+  test("raw window boundary stays pinned across many growing turns at the budget ceiling", () => {
+    // Regression for the layer-1 per-turn cache-bust march (session
+    // 0AVWKugtmhBKqLOX9): when the raw window sits AT the rawBudget ceiling,
+    // each turn's ~2 new messages overflow the 15% pin hysteresis. Before the
+    // chunked-eviction fix, tryFitStable re-pinned right back at the ceiling
+    // with the boundary advanced ~2 messages — so the start boundary marched
+    // forward EVERY turn, busting the prompt cache each time. With the fix, an
+    // overflow evicts a chunk (down to RAW_WINDOW_EVICT_TARGET of budget),
+    // leaving headroom so the boundary holds for many turns between steps.
+    resetRawWindowCache();
+    // context=20000, output=4000 → usable=16000, rawBudget=floor(16000*0.4)=6400.
+    // Each 1000-char message ≈ 354 tokens (1000/3 + 20). ~18 raw msgs saturate
+    // the budget (18×354=6372 ≤ 6400), so the window sits at the ceiling.
+    setModelLimits({ context: 20_000, output: 4_000 });
+    calibrate(0);
+
+    const SESS = "pin-ceiling-march";
+    // Start with a saturated conversation so gradient fires at layer 1 and the
+    // raw window is pinned right at the ceiling.
+    const msgs = Array.from({ length: 40 }, (_, i) =>
+      makeMsg(
+        `march-${i}`,
+        i % 2 === 0 ? "user" : "assistant",
+        "A".repeat(1_000),
+        SESS,
+      ),
+    );
+
+    const r0 = transform({
+      messages: msgs,
+      projectPath: PROJECT,
+      sessionID: SESS,
+    });
+    expect(r0.layer).toBe(1);
+
+    const firstRawId = (r: { messages: typeof msgs }) =>
+      r.messages.find((m) => m.info.sessionID === SESS)?.info.id;
+
+    // Simulate 12 consecutive turns, each appending a user+assistant pair sized
+    // so a single turn's growth (~1374 tokens ≈ 21% of the 6400 budget) exceeds
+    // the 15% pin hysteresis on its own. Pre-fix, that means the pin overflows
+    // and re-pins at the ceiling EVERY turn → boundary advances every turn.
+    const boundaries: (string | undefined)[] = [firstRawId(r0)];
+    for (let turn = 0; turn < 12; turn++) {
+      msgs.push(
+        makeMsg(`march-u-${turn}`, "user", "A".repeat(2_000), SESS),
+        makeMsg(`march-a-${turn}`, "assistant", "A".repeat(2_000), SESS),
+      );
+      const r = transform({
+        messages: msgs,
+        projectPath: PROJECT,
+        sessionID: SESS,
+      });
+      expect(r.layer).toBe(1);
+      boundaries.push(firstRawId(r));
+    }
+
+    // Count how many turns advanced the boundary. A marching boundary (the bug)
+    // advances on every one of the 12 turns. With chunked eviction the boundary
+    // holds for several turns between steps (~25% headroom / ~21% growth).
+    let advances = 0;
+    for (let i = 1; i < boundaries.length; i++) {
+      if (boundaries[i] !== boundaries[i - 1]) advances++;
+    }
+    // Strong guard: pre-fix advances ≈ 12 (every turn); post-fix ≤ 6 (chunked
+    // steps with headroom). The bound cleanly separates the two regimes.
+    expect(advances).toBeLessThanOrEqual(6);
+    // Sanity: the pin must actually hold for some turns (not a sliding window).
+    expect(advances).toBeLessThan(10);
+
+    // Reset
+    setModelLimits({ context: 5_000, output: 1_000 });
+    calibrate(0);
+    resetRawWindowCache();
+  });
 });
 
 describe("gradient — LTM budget coordination", () => {
@@ -3342,13 +3418,13 @@ describe("tier-based context management", () => {
     });
 
     test("sustained bust prices continue at WRITE cost (compresses to stop growth)", () => {
-      // In a sustained-bust regime (>=5 busts) the "continue" path is paying
-      // cache WRITE cost on the whole context every turn, not the cheap read
-      // cost. So continueCost is priced with write:
+      // In a sustained-bust regime (>=SUSTAINED_BUST_THRESHOLD=2 busts) the
+      // "continue" path is paying cache WRITE cost on the whole context every
+      // turn, not the cheap read cost. So continueCost is priced with write:
       //   continueCost = 2M × $6.25/M = $12.50
       //   bustCost     = 100K × $6.25/M = $0.625
       //   0.625 < 0.85 × 12.50 = 10.6 → compress (break the growth loop)
-      expect(shouldCompress(2_000_000, 100_000, 5)).toBe(true);
+      expect(shouldCompress(2_000_000, 100_000, 2)).toBe(true);
       expect(shouldCompress(2_000_000, 100_000, 10)).toBe(true);
     });
 
@@ -3358,15 +3434,15 @@ describe("tier-based context management", () => {
       //   continueCost = 250K × $6.25/M = $1.5625
       //   bustCost     = 240K × $6.25/M = $1.50
       //   1.50 < 0.85 × 1.5625 = 1.328 → false (don't compress)
-      expect(shouldCompress(250_000, 240_000, 5)).toBe(false);
+      expect(shouldCompress(250_000, 240_000, 2)).toBe(false);
     });
 
     test("below the sustained-bust threshold uses the cheap read cost", () => {
-      // 4 busts → not sustained → continue priced at READ cost.
+      // 1 bust → below threshold (2) → not sustained → continue priced at READ.
       //   continueCost = 2M × $0.50/M = $1.00
       //   bustCost     = 100K × $6.25/M = $0.625
       //   0.625 < 0.85 × 1.00 = 0.85 → compress
-      expect(shouldCompress(2_000_000, 100_000, 4)).toBe(true);
+      expect(shouldCompress(2_000_000, 100_000, 1)).toBe(true);
       // A modestly-grown context at 0 busts: continue is cheap → don't compress.
       expect(shouldCompress(250_000, 150_000, 0)).toBe(false);
     });
@@ -3453,8 +3529,9 @@ describe("tier-based context management", () => {
       // messages, so expectedInput == lastKnownInput == 635K.
       calibrate(635_000, SESSION, msgs.length);
 
-      // Drive the cache into a sustained-bust regime (>=5 consecutive busts):
-      // every turn is ~93% cache write, exactly like the runaway logs.
+      // Drive the cache into a sustained-bust regime (well past
+      // SUSTAINED_BUST_THRESHOLD): every turn is ~93% cache write, exactly like
+      // the runaway logs.
       for (let i = 0; i < 6; i++) {
         recordCacheUsage(440_000, 34_813, 2, SESSION);
       }
@@ -3680,9 +3757,9 @@ describe("tier-based context management", () => {
       );
     });
 
-    test("returns false with freeWrite when busts >= 5", () => {
-      // Even free compression shouldn't run if it's not helping
-      expect(shouldCompress(250_000, 150_000, 5, { freeWrite: true })).toBe(
+    test("returns false with freeWrite at/above the sustained-bust threshold", () => {
+      // Even free compression shouldn't run if it's not helping (>= threshold=2)
+      expect(shouldCompress(250_000, 150_000, 2, { freeWrite: true })).toBe(
         false,
       );
       expect(shouldCompress(250_000, 150_000, 10, { freeWrite: true })).toBe(
@@ -3690,8 +3767,9 @@ describe("tier-based context management", () => {
       );
     });
 
-    test("returns true with freeWrite at 4 busts", () => {
-      expect(shouldCompress(250_000, 150_000, 4, { freeWrite: true })).toBe(
+    test("returns true with freeWrite below the sustained-bust threshold", () => {
+      // 1 bust < threshold (2) → free compression still runs
+      expect(shouldCompress(250_000, 150_000, 1, { freeWrite: true })).toBe(
         true,
       );
     });

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -5782,7 +5782,8 @@ async function handleConversationTurn(
   // See issue #741.
 
   // --- 7d. Unsustainable conversation warning ---
-  // When 5+ consecutive cache busts are detected, flag for response-side injection.
+  // When a sustained run of consecutive cache busts is detected (gradient's
+  // SUSTAINED_BUST_THRESHOLD), flag for response-side injection.
   // The warning is injected into the assistant response (not the user message) so:
   //  1. The user can actually see it (not hidden in <system-reminder> tags)
   //  2. No modification to user messages → no cache prefix divergence
@@ -5790,7 +5791,7 @@ async function handleConversationTurn(
   const unsustainable = result.unsustainable;
   if (unsustainable) {
     log.warn(
-      `session ${sessionID}: unsustainable conversation detected (5+ consecutive cache busts). ` +
+      `session ${sessionID}: unsustainable conversation detected (sustained consecutive cache busts). ` +
         `Warning will be prepended to response.`,
     );
   }

--- a/packages/gateway/test/cache-analytics.test.ts
+++ b/packages/gateway/test/cache-analytics.test.ts
@@ -6,9 +6,14 @@ import {
   mapOffsetToJsonPath,
   inferDivergenceReason,
   analyzeCacheTurn,
+  categorizeBust,
   normalizeBodyForComparison,
 } from "../src/cache-analytics";
-import type { CacheAnalytics, GatewayUsage } from "../src/translate/types";
+import type {
+  CacheAnalytics,
+  CacheTurnAnalysis,
+  GatewayUsage,
+} from "../src/translate/types";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -670,5 +675,102 @@ describe("analyzeCacheTurn — cch normalization", () => {
 
     expect(result.divergencePoint).toBe("<identical>");
     expect(result.divergenceReason).toBe("request bodies are identical");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// categorizeBust — previously had ZERO test coverage. This classifier is the
+// telemetry oracle that distinguishes a raw-window march ("window-shift") from
+// other bust causes; the layer-1 pin-march bug escaped because nothing tested it.
+// ---------------------------------------------------------------------------
+
+describe("categorizeBust", () => {
+  function makeAnalysis(
+    overrides: Partial<CacheTurnAnalysis> = {},
+  ): CacheTurnAnalysis {
+    // A full cache bust (cacheRead=0, cacheCreation>0) on a steady-state turn,
+    // so categorizeBust classifies by divergence location.
+    return {
+      turn: 5,
+      cacheRead: 0,
+      cacheCreation: 100_000,
+      inputTokens: 2,
+      cacheHitRate: 0,
+      prefixMatchBytes: 0,
+      prefixMatchPercent: 0,
+      divergencePoint: "messages[42].content[0].text",
+      divergenceReason: "",
+      prevSnippet: undefined,
+      currSnippet: undefined,
+      ...overrides,
+    };
+  }
+
+  test("classifies a mid-history message divergence as window-shift", () => {
+    // messages[idx>1] divergence on a full bust = raw window eviction shifted
+    // message positions — the exact signature of the layer-1 pin march.
+    expect(
+      categorizeBust(
+        makeAnalysis({ divergencePoint: "messages[42].content[0].text" }),
+        false,
+      ),
+    ).toBe("window-shift");
+    expect(
+      categorizeBust(makeAnalysis({ divergencePoint: "messages[2]" }), false),
+    ).toBe("window-shift");
+  });
+
+  test("classifies an early-message divergence as prefix-rewrite", () => {
+    // messages[0/1] are the synthetic distilled prefix → meta-distillation rewrite.
+    expect(
+      categorizeBust(makeAnalysis({ divergencePoint: "messages[0]" }), false),
+    ).toBe("prefix-rewrite");
+    expect(
+      categorizeBust(
+        makeAnalysis({ divergencePoint: "messages[1].content[0].text" }),
+        false,
+      ),
+    ).toBe("prefix-rewrite");
+  });
+
+  test("classifies system/tools divergences distinctly", () => {
+    expect(
+      categorizeBust(makeAnalysis({ divergencePoint: "system[2]" }), false),
+    ).toBe("system-change");
+    expect(
+      categorizeBust(makeAnalysis({ divergencePoint: "tools[0].name" }), false),
+    ).toBe("tools-change");
+  });
+
+  test("does not classify a cache-hit turn as a window-shift", () => {
+    // cacheRead > 0 → incremental append, never a bust regardless of divergence.
+    expect(
+      categorizeBust(
+        makeAnalysis({
+          cacheRead: 50_000,
+          cacheCreation: 1_000,
+          divergencePoint: "messages[42].content[0].text",
+        }),
+        false,
+      ),
+    ).toBe("incremental");
+  });
+
+  test("post-idle cold cache is idle-resume, not window-shift", () => {
+    expect(
+      categorizeBust(
+        makeAnalysis({ divergencePoint: "messages[42].content[0].text" }),
+        true,
+      ),
+    ).toBe("idle-resume");
+  });
+
+  test("first turn is never a bust", () => {
+    expect(
+      categorizeBust(
+        makeAnalysis({ turn: 1, divergencePoint: "<first-turn>" }),
+        false,
+      ),
+    ).toBe("first-turn");
   });
 });

--- a/packages/gateway/test/cache-stability.e2e.test.ts
+++ b/packages/gateway/test/cache-stability.e2e.test.ts
@@ -110,6 +110,25 @@ function serializedMessages(body: string): string {
   return JSON.stringify(parsed.messages ?? null);
 }
 
+/**
+ * Find the START of the raw window in a serialized upstream body: the first
+ * message whose text contains `marker` (our test messages embed a unique marker
+ * per message; the synthetic distilled prefix does not). Returns the marker
+ * substring of that first raw message — a stable identifier for the raw-window
+ * start boundary. Used to detect a marching boundary across turns.
+ */
+function firstRawWindowMarker(body: string, marker: RegExp): string | null {
+  const parsed = JSON.parse(normalizeBodyForComparison(body)) as {
+    messages?: Array<{ content?: unknown }>;
+  };
+  for (const msg of parsed.messages ?? []) {
+    const text = JSON.stringify(msg.content ?? "");
+    const m = text.match(marker);
+    if (m) return m[0];
+  }
+  return null;
+}
+
 function textTurn(
   role: "user" | "assistant",
   text: string,
@@ -866,6 +885,175 @@ describe("cache stability (e2e)", () => {
             `mid-session LTM write must not bust the cached system prefix (#741)`,
         ).toEqual(steadyBlocks);
       }
+    } finally {
+      if (prevIdleTimeout === undefined) delete process.env.LORE_IDLE_TIMEOUT;
+      else process.env.LORE_IDLE_TIMEOUT = prevIdleTimeout;
+    }
+  });
+
+  it("raw-window start boundary does not march every turn across compressed turns", async () => {
+    // Regression for the layer-1 raw-window pin march (session 0AVWKugtmhBKqLOX9):
+    // once a large session compresses at layer 1 and the raw window sits at the
+    // rawBudget ceiling, the pin must NOT re-pin at the ceiling and advance the
+    // window START boundary ~2 messages every turn (which busts the prompt cache
+    // mid-history every turn). The chunked-eviction fix evicts below the ceiling
+    // so the boundary holds for many turns between steps.
+    //
+    // This is the gateway-level analogue of the core unit regression: we drive a
+    // real multi-turn conversation through the gateway, then inspect each
+    // UPSTREAM body and track the FIRST raw-window message (identified by its
+    // unique marker). A marching boundary advances that first marker on (nearly)
+    // every turn; the fix holds it for stretches. We avoid the full-body
+    // divergence oracle here because at layer 1 it cannot distinguish legitimate
+    // tail growth (high message index) from a real mid-history march.
+    const prevIdleTimeout = process.env.LORE_IDLE_TIMEOUT;
+    process.env.LORE_IDLE_TIMEOUT = "3600"; // keep idle workers from firing
+    try {
+      const projectPath = `/tmp/lore-window-march-${Date.now()}`;
+      const clientSessionID = `window-march-client-${Date.now()}`;
+
+      // Force a low layer-0 cap via project .lore.json so a ~125K session
+      // compresses to layer 1 (the raw-window pin path) deterministically —
+      // without depending on models.dev pricing being warm in the test. The
+      // pipeline calls config.load(projectPath) per request, so this is honored.
+      const { mkdirSync, writeFileSync } = await import("node:fs");
+      mkdirSync(projectPath, { recursive: true });
+      writeFileSync(
+        `${projectPath}/.lore.json`,
+        JSON.stringify({ budget: { maxLayer0Tokens: 40000 } }),
+      );
+
+      // Large messages so the raw window overflows rawBudget and the gradient
+      // pins a layer-1 SUB-window at the ceiling. Each message ≈ 8K tokens
+      // (~24K chars), so a single user+assistant pair (~16K tokens) is a large
+      // fraction of rawBudget — enough that one turn's growth trips the pin's
+      // 15% hysteresis on its own. Pre-fix that forces a re-pin at the ceiling
+      // and a boundary advance EVERY turn; the fix evicts a chunk so the
+      // boundary holds for many turns between steps.
+      const big = (label: string) =>
+        `${label} ${"lorem ipsum dolor ".repeat(1_350)}`;
+      const TOTAL_TURNS = 14;
+      const BASE_PAIRS = 14; // ~28 base messages × ~8K ≈ 224K → well over budget
+
+      const fixtures = Array.from({ length: TOTAL_TURNS }, (_, i) =>
+        makeFixtureEntry({
+          seq: i,
+          requestMessages: [],
+          responseText: big(`assistant reply ${i}`),
+          model: DEFAULT_MODEL,
+          // Realistic growing large input so calibrate() tracks the true body
+          // size and the gradient pins a real layer-1 sub-window.
+          inputTokens: 120_000 + i * 8_000,
+          outputTokens: 1_200,
+        }),
+      );
+
+      harness = await createHarness({ fixtures });
+
+      const {
+        calibrate,
+        resetCalibration,
+        setUrgentDistillationEnabledForTest,
+      } = await import("../../core/src/gradient");
+      resetCalibration();
+      setUrgentDistillationEnabledForTest(false);
+      calibrate(0);
+
+      const headers = {
+        "x-lore-project": projectPath,
+        "x-lore-session-id": clientSessionID,
+      };
+
+      const history: GatewayMessage[] = [];
+      for (let i = 0; i < BASE_PAIRS; i++) {
+        history.push(
+          toGatewayMessage(textTurn("user", big(`baseuser${i}end`))),
+        );
+        history.push(
+          toGatewayMessage(textTurn("assistant", big(`baseasst${i}end`))),
+        );
+      }
+
+      let sessionID = "";
+      let peakLayer = 0;
+      const observedLayers: number[] = [];
+      for (let turn = 0; turn < TOTAL_TURNS; turn++) {
+        history.push(
+          toGatewayMessage(textTurn("user", big(`turnuser${turn}end`))),
+        );
+        const resp = await harness.chat(
+          makeGatewayBody(history),
+          "test-key",
+          headers,
+        );
+        expect(resp.status).toBe(200);
+        await resp.json();
+        history.push(
+          toGatewayMessage(textTurn("assistant", big(`turnasst${turn}end`))),
+        );
+
+        if (turn === 0) {
+          const rows = harness.queryDB<{ session_id: string }>(
+            "SELECT session_id FROM session_state ORDER BY updated_at DESC LIMIT 1",
+          );
+          sessionID = rows[0]?.session_id ?? "";
+          expect(sessionID).not.toBe("");
+        } else {
+          const layer = await observedLayer(sessionID);
+          peakLayer = Math.max(peakLayer, layer);
+          observedLayers.push(layer);
+        }
+      }
+
+      // The raw-window pin (tryFitStable) runs ONLY at layer 1 (stage 0); higher
+      // layers use plain tryFit and reset the pin. So this test is only a valid
+      // guard if the session is actually transformed AT layer 1. Assert the
+      // steady-state turns sat at layer 1 — not layer 0 (no compression, no pin)
+      // and not escalated to 2+ (different code path). If a future budget change
+      // moved this session off layer 1, the test must fail loudly rather than
+      // silently stop guarding the pin march.
+      const layer1Turns = observedLayers.filter((l) => l === 1).length;
+      expect(
+        layer1Turns,
+        `expected most steady-state turns at layer 1 (raw-window pin path), but ` +
+          `observed layers were ${JSON.stringify(observedLayers)} (peak ${peakLayer})`,
+      ).toBeGreaterThanOrEqual(Math.ceil(observedLayers.length / 2));
+
+      const bodies = harness.upstreamBodies();
+      expect(bodies.length).toBe(TOTAL_TURNS);
+
+      // Track the FIRST raw-window message marker per turn. Markers look like
+      // "baseuser12end" / "turnuser3end" / "baseasst5end".
+      const markerRe = /(?:base|turn)(?:user|asst)\d+end/;
+      const boundaries = bodies.map((b) => firstRawWindowMarker(b, markerRe));
+      // All turns must have located a raw-window start (sanity).
+      expect(boundaries.every((b) => b !== null)).toBe(true);
+
+      // Count boundary advances and holds across steady-state turns (from turn 2
+      // / index 1, after the layer-1 distilled prefix is established).
+      let advances = 0;
+      let holds = 0;
+      let comparisons = 0;
+      for (let i = 2; i < boundaries.length; i++) {
+        comparisons++;
+        if (boundaries[i] !== boundaries[i - 1]) advances++;
+        else holds++;
+      }
+      // The bug is a boundary that marches on EVERY steady-state turn: it advances
+      // every turn and never holds (the raw window is re-pinned at the ceiling, so
+      // each turn's growth re-evicts). The chunked-eviction fix leaves headroom so
+      // the boundary holds on at least some turns. Assert at least one held turn —
+      // a per-turn march has zero holds, so this fails pre-fix (verified) and the
+      // bound is robust to the harness's coarse per-turn step size.
+      const detail =
+        `advanced on ${advances}/${comparisons} steady-state turns (holds=${holds}, ` +
+        `boundaries=${JSON.stringify(boundaries)})`;
+      expect(
+        holds,
+        `raw-window start boundary marched on every steady-state turn — ${detail}. ` +
+          `The layer-1 pin must hold the boundary on at least some turns, evicting ` +
+          `only in occasional chunks (regression: per-turn window march).`,
+      ).toBeGreaterThan(0);
     } finally {
       if (prevIdleTimeout === undefined) delete process.env.LORE_IDLE_TIMEOUT;
       else process.env.LORE_IDLE_TIMEOUT = prevIdleTimeout;


### PR DESCRIPTION
## Problem

Follow-up to #771. After that fix correctly routed a large `claude-opus-4-8` session off layer-0 passthrough and onto layer-1 compression, the user **kept getting the "growing unsustainably" warning every turn** — even though compression was now working (session held at ~180K).

Logs showed every turn busting the cache: `hit=7% read=31777 create=~445000`, with `divergence="messages[N]"` where **N advanced ~2 per turn** (524 → 546). Because every turn busts, `consecutiveBusts` never reset, so the warning fired perpetually.

## Root cause

The layer-1 raw-window pin (`tryFitStable`) keeps the raw window's start boundary byte-stable across turns to preserve the prompt cache. The pin holds only while `pinnedTokens <= max(pinnedBudget, rawBudget) * 1.15`. When the raw window sits **at the `rawBudget` ceiling**, each turn's ~2 new messages overflow the 15% hysteresis, forcing a rescan via `tryFit`. `tryFit` fills `rawBudget` *exactly*, so the rescan re-pinned the boundary **right back at the ceiling** with the cutoff advanced ~2 messages. The boundary therefore marched forward every turn, busting the cache mid-history (~440K tokens re-written each turn).

This was latent in the layer-1 path forever, but only hit large sessions once #771 stopped keeping them at layer-0 passthrough.

## Fix

1. **Chunked eviction.** `tryFit` gains an optional `rawFillBudget` param (defaults to `rawBudget`) used only for the older-message backward fill; the current-turn escalation guard still uses the full `rawBudget`. `tryFitStable`'s rescan passes `rawFillBudget = floor(rawBudget * RAW_WINDOW_EVICT_TARGET)` (0.75), so the re-pinned window sits below the ceiling with headroom and holds for many turns between evictions instead of re-overflowing next turn.

2. **Lower `SUSTAINED_BUST_THRESHOLD` 5 → 2.** At large context windows a single full cache bust rewrites hundreds of thousands of tokens at ~12.5× the read price, so even two consecutive full busts is too expensive to keep paying. This makes `shouldCompress()` reprice "continue" at the write rate sooner and surfaces the warning promptly. All three semantic uses (free-write branch, sustained-bust repricing, warning flag) updated to the constant — including a previously-hardcoded `busts >= 5` site, found in review.

## Tests (closing the gap that let this slip through)

A review of *why existing tests missed this* found: unit tests for `tryFitStable` stopped at 2 turns; the e2e cache-stability guardrail deliberately exempted `messages[2+]` shifts (`isTailDivergence`); and `categorizeBust`'s `window-shift` classifier had **zero** coverage.

- **Core regression** (`gradient.test.ts`): drives 12 growing turns at the budget ceiling and asserts the raw-window boundary does not advance every turn. Fixed = 4 advances, buggy = 12 — **verified fails-on-revert**.
- **Gateway e2e** (`cache-stability.e2e.test.ts`): drives a real multi-turn compressed conversation through the gateway and asserts the first raw-window message marker holds on at least some steady-state turns. Buggy marches 12/12 with zero holds — **verified fails-on-revert**. Includes a guard that the session actually sits at layer 1 (the pin path).
- **`categorizeBust` unit tests** (`cache-analytics.test.ts`): close the zero-coverage gap on the `window-shift` / `prefix-rewrite` classifier.

## Verification
- `pnpm run typecheck` — clean (all packages)
- `pnpm test` — 3132 passed / 6 skipped / 0 failed
- Both boundary regression tests verified to fail when the one-line fix is reverted
- Independent critical review performed; all findings (incl. a hardcoded `5` and stale comments) addressed

🤖 Generated with [opencode](https://opencode.ai)