### PR TITLE
chore(build): run the build pipeline under Node (tsx), not Bun

### DIFF
--- a/packages/core/script/build.ts
+++ b/packages/core/script/build.ts
@@ -11,8 +11,10 @@
  * TypeScript declarations (.d.ts) are emitted separately by `tsc` below.
  * esbuild alone can't produce declarations.
  *
- * Runs under either Bun (during `bun run build`) or Node; the build itself is
- * runtime-agnostic (esbuild is a plain npm package).
+ * The build runs under Node (via tsx, e.g. `pnpm run build`) — it does not
+ * require the Bun runtime. esbuild is a plain npm package, so the build is
+ * runtime-agnostic; the dist/bun target is produced via esbuild's
+ * `conditions: ["bun"]`, not by running under Bun.
  */
 import * as esbuild from "esbuild";
 import { rmSync, mkdirSync, cpSync, existsSync } from "node:fs";

--- a/packages/gateway/script/build-binary-sea.ts
+++ b/packages/gateway/script/build-binary-sea.ts
@@ -20,9 +20,12 @@
  * Linux x64/arm64 and Windows x64). Intel Macs and Windows-arm64 are
  * intentionally not supported (see `vendor-paths.ts:18`).
  *
+ * Runs under Node (via tsx) — no Bun runtime required.
+ *
  * Example:
- *   bun run script/build-binary-sea.ts -- --platforms linux-x64
- *   bun run script/build-binary-sea.ts -- --platforms "darwin-arm64,linux-arm64,linux-x64,windows-x64" --release
+ *   tsx script/build-binary-sea.ts --platforms linux-x64
+ *   tsx script/build-binary-sea.ts --platforms "darwin-arm64,linux-arm64,linux-x64,windows-x64" --release
+ *   (or via the package script: `pnpm run build:binary:sea -- --platforms linux-x64`)
  */
 import * as esbuild from "esbuild";
 import {
@@ -163,9 +166,12 @@ function prepareVendorModelCache(target: CompileTarget): string | null {
   console.log(
     `  Vendor: missing model artefacts — running vendor-embeddings.ts`,
   );
+  // Run under Node (via tsx) — no Bun runtime required. tsx is resolved from
+  // node_modules so this works regardless of cwd / PATH.
+  const tsxCli = require.resolve("tsx/cli");
   const result = spawnSync(
-    "bun",
-    ["run", join(packageDir, "script/vendor-embeddings.ts")],
+    process.execPath,
+    [tsxCli, join(packageDir, "script/vendor-embeddings.ts")],
     { stdio: "inherit", cwd: repoRoot },
   );
   if (result.status !== 0) {

--- a/packages/gateway/script/build.ts
+++ b/packages/gateway/script/build.ts
@@ -3,16 +3,21 @@
  *
  * Two build modes:
  *
- *   1. `bun run script/build.ts` (default)
+ *   1. `tsx script/build.ts` (default; via `pnpm run build`)
  *      Produces dist/index.js — publishable ESM bundle for npm.
  *      @loreai/core is external (workspace dep, installed alongside).
  *
- *   2. `bun run script/build.ts --binary`
+ *   2. `tsx script/build.ts --binary` (via `pnpm run build:binary`)
  *      Delegates to `script/build-binary-sea.ts` which produces a
  *      standalone Node SEA binary via fossilize. The legacy Bun
  *      `--compile` pipeline was removed in #551 in favor of Node SEA
  *      because Bun's WASM engine has unfixed bugs that cause ONNX
  *      embedding OOM on all platforms (oven-sh/bun#18145, #25677, #31158).
+ *
+ * Lore's build pipeline runs entirely under Node (via tsx) — it never
+ * requires the Bun runtime. (The `bun` export condition / dist/index.bun.js
+ * artifact still exists for the @loreai/opencode plugin, which runs under
+ * Bun; it is produced by esbuild here, not by Bun.)
  */
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -45,7 +50,7 @@ const { values: flags } = parseArgs({
 
 async function buildLibrary() {
   // Create lightweight dev shims so workspace consumers can resolve
-  // the "bun" export condition without running the full `bun run bundle`.
+  // the "bun" export condition without running the full `pnpm run bundle`.
   // Real bundle builds (bundle.ts) wipe dist/ first, so these shims
   // never interfere with production artifacts.
   mkdirSync(distDir, { recursive: true });
@@ -81,7 +86,7 @@ async function buildLibrary() {
   }
 
   console.log(
-    "✓ @loreai/gateway: dev shims ready (use `bun run bundle` for npm build)",
+    "✓ @loreai/gateway: dev shims ready (use `pnpm run bundle` for npm build)",
   );
 }
 
@@ -96,10 +101,16 @@ if (flags.binary) {
   if (flags.release) args.push("--release");
   if (flags["no-vendor"]) args.push("--no-vendor");
 
+  // Run the SEA build script under Node (via tsx) — Lore's build pipeline
+  // never requires the Bun runtime. tsx is resolved from node_modules so this
+  // works regardless of cwd / PATH.
   const { spawnSync } = await import("node:child_process");
+  const { createRequire } = await import("node:module");
+  const require = createRequire(import.meta.url);
+  const tsxCli = require.resolve("tsx/cli");
   const result = spawnSync(
-    "bun",
-    ["run", join(here, "build-binary-sea.ts"), ...args],
+    process.execPath,
+    [tsxCli, join(here, "build-binary-sea.ts"), ...args],
     {
       cwd: packageDir,
       stdio: "inherit",

--- a/packages/gateway/script/record-session.ts
+++ b/packages/gateway/script/record-session.ts
@@ -7,7 +7,7 @@
  * integration tests without hitting the real Anthropic API.
  *
  * Usage:
- *   bun run packages/gateway/script/record-session.ts [output-file]
+ *   tsx packages/gateway/script/record-session.ts [output-file]
  *
  * Default output:
  *   packages/gateway/test/fixtures/recorded-<timestamp>.ndjson
@@ -21,7 +21,7 @@
  *   LORE_DEBUG          — set to "1" to enable request logging
  *
  * After recording, use the fixture for replay tests:
- *   bun test packages/gateway/test/replay.test.ts FIXTURE=<file>
+ *   FIXTURE=<file> npx vitest run packages/gateway/test/replay.test.ts
  */
 import { mkdirSync } from "node:fs";
 import { dirname, resolve } from "node:path";

--- a/packages/gateway/script/smoke-test.ts
+++ b/packages/gateway/script/smoke-test.ts
@@ -6,7 +6,7 @@
  * instance and verifies responses end-to-end.
  *
  * Usage:
- *   bun run packages/gateway/script/smoke-test.ts
+ *   tsx packages/gateway/script/smoke-test.ts
  *
  * Prerequisites:
  *   - ANTHROPIC_API_KEY env var, or key stored in

--- a/packages/gateway/script/vendor-embeddings.ts
+++ b/packages/gateway/script/vendor-embeddings.ts
@@ -13,7 +13,7 @@
  *     per-target binary.
  *
  * Usage:
- *   bun run packages/gateway/script/vendor-embeddings.ts
+ *   tsx packages/gateway/script/vendor-embeddings.ts
  */
 
 import {

--- a/packages/hermes/test-integration.sh
+++ b/packages/hermes/test-integration.sh
@@ -58,7 +58,7 @@ if command -v lore &>/dev/null || command -v lore-gateway &>/dev/null; then
 else
   fail "lore binary not found on PATH"
   echo "  Install: curl -fsSL https://withlore.ai/install | bash"
-  echo "  Or build from this repo: bun run build && export PATH=\$PWD/packages/gateway/dist:\$PATH"
+  echo "  Or build from this repo: pnpm run build && export PATH=\$PWD/packages/gateway/dist:\$PATH"
   exit 1
 fi
 

--- a/packages/opencode/scripts/list-sessions.ts
+++ b/packages/opencode/scripts/list-sessions.ts
@@ -2,7 +2,7 @@
  * List sessions in lore's temporal storage with distillation status.
  *
  * Usage:
- *   bun run scripts/list-sessions.ts [--project <path>] [--all]
+ *   tsx scripts/list-sessions.ts [--project <path>] [--all]
  *
  * Options:
  *   --project <path>  Filter to a specific project path (substring match).

--- a/scripts/check-cc-version.ts
+++ b/scripts/check-cc-version.ts
@@ -7,8 +7,8 @@
  * dist-tag that lacks a seed, and reports them for extraction.
  *
  * Usage:
- *   bun run scripts/check-cc-version.ts          # human-readable output
- *   bun run scripts/check-cc-version.ts --json    # machine-readable JSON
+ *   tsx scripts/check-cc-version.ts          # human-readable output
+ *   tsx scripts/check-cc-version.ts --json    # machine-readable JSON
  *
  * JSON output includes:
  *   - latestVersion: the latest dist-tag version (becomes WORKER_VERSION)
@@ -35,7 +35,7 @@ const { values: args } = parseArgs({
 
 if (args.help) {
   console.log(`Usage:
-  bun run scripts/check-cc-version.ts [--json]
+  tsx scripts/check-cc-version.ts [--json]
 
 Checks if recent Claude Code versions on npm have known cch seeds.
 Exits 0 if all versions are known, 1 if any needs extraction.
@@ -138,9 +138,7 @@ async function main() {
       for (const v of uniqueMissing) {
         console.log(`  ✗ ${v}`);
       }
-      console.log(
-        `\nRun: bun run scripts/extract-cch-seed.ts --version <VERSION>`,
-      );
+      console.log(`\nRun: tsx scripts/extract-cch-seed.ts --version <VERSION>`);
     } else {
       console.log("All published versions have known seeds.");
     }


### PR DESCRIPTION
## Why

Lore's build pipeline never actually required the **Bun runtime** — the bundles are produced by **esbuild** (a plain npm package), and every `package.json` script already runs via `tsx`. But a few spots still shelled out to `bun` or told contributors to use `bun run`, making Bun look like a build dependency.

## What changed (build/docs only — no source/runtime behavior change)

- **`gateway/script/build.ts`**: the `--binary` dispatch spawned `bun run build-binary-sea.ts`; now spawns Node (`process.execPath`) with the tsx CLI resolved from `node_modules`. Library-build message updated from "use `bun run bundle`" → `pnpm run bundle`.
- **`gateway/script/build-binary-sea.ts`**: spawned `bun run vendor-embeddings.ts`; now uses the same Node + tsx invocation.
- **Doc comments / help strings** across `build.ts` (core + gateway), `record-session.ts`, `smoke-test.ts`, `vendor-embeddings.ts`, `list-sessions.ts`, `check-cc-version.ts`, and `hermes/test-integration.sh`: `bun run …` → `tsx` / `pnpm run …`.

## Deliberately unchanged

These describe the **consumer** runtime (opencode runs the gateway in-process under Bun), not Lore's pipeline, so they stay:
- the `bun` export conditions, `dist/index.bun.js`, `driver.bun.ts`
- esbuild `conditions: ["bun"]`, the `bun:sqlite` driver, the `@sentry/bun` → `@sentry/node` remap
- src comments noting the gateway runs under Bun when launched by the `@loreai/opencode` plugin

The `dist/bun` target is still produced — by esbuild, under Node.

## Verification
- `pnpm run typecheck` — clean (all packages)
- `pnpm run lint` — 0 errors (13 pre-existing warnings, none in changed files)
- `pnpm run bundle` — produces `dist/index.bun.js` with no Bun invocation
- `build:binary:sea --no-vendor` — runs under tsx, produces esbuild bundles; no Bun
- `tsx/cli` resolves correctly from the gateway script context

🤖 Generated with [opencode](https://opencode.ai)