### PR TITLE
fix(gateway): prevent cross-provider worker collusion + harden worker failure handling

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -311,6 +311,20 @@ export interface LLMClient {
        */
       upstreamUrl?: string;
       /**
+       * Provider ID that the `upstreamUrl` override belongs to (the owning
+       * session's provider). The gateway adapter uses this to enforce
+       * cross-provider safety: the session `upstreamUrl` is only honored when
+       * the worker model's provider matches this. When they differ, the worker
+       * model is routed by its OWN provider route instead of being sent to the
+       * session's (foreign) endpoint. Prevents the production class of bug
+       * where a configured cross-provider `workerModel` (e.g. minimax) was sent
+       * to the session's Anthropic endpoint with the Anthropic credential.
+       *
+       * Only the gateway adapter honors this field; other adapters
+       * (OpenCode, Pi) ignore it.
+       */
+      upstreamProviderID?: string;
+      /**
        * Wire protocol for the upstream endpoint. When set, the adapter
        * uses this protocol for request/response formatting instead of
        * inferring it from the provider ID. Threaded from the session's

--- a/packages/gateway/src/auth.ts
+++ b/packages/gateway/src/auth.ts
@@ -347,6 +347,19 @@ export function resolveAuth(
     const staleKey = providerID || "_default";
     if (cred && !isAuthStale(sessionID, staleKey)) return cred;
 
+    // CROSS-PROVIDER GUARD: when a SPECIFIC providerID is requested and this
+    // session has no credential for it, do NOT borrow the global fallback —
+    // it belongs to whatever provider the session authenticated with, NOT the
+    // requested one. Returning it produces the exact production bug: a worker
+    // configured for `minimax` borrows the session's Anthropic key and gets
+    // sent off as a doomed cross-provider request (401 "invalid x-api-key"
+    // loop). The global fallback is only safe for provider-agnostic callers
+    // (no providerID) and for cold-start when the session genuinely has no
+    // provider-specific store yet.
+    if (providerID && !cred && sessionHasProviderStore(sessionID)) {
+      return null;
+    }
+
     // Global fallback — but guard against returning the same stale token.
     // In single-session OAuth setups, session and global hold the exact
     // same expired bearer token. Returning it would cause callers to make
@@ -356,6 +369,22 @@ export function resolveAuth(
     return global;
   }
   return getLastSeenAuth();
+}
+
+/**
+ * Whether a session has any provider-specific credential stored (i.e. the
+ * gateway has observed at least one real authenticated turn for it). Used by
+ * `resolveAuth` to decide that a missing credential for a SPECIFIC provider is
+ * a genuine "this provider isn't authenticated here" signal — not a cold-start
+ * — so the global (foreign-provider) fallback must be suppressed.
+ */
+function sessionHasProviderStore(sessionID: string): boolean {
+  const byProvider = sessionAuth.get(sessionID);
+  if (!byProvider) return false;
+  for (const key of byProvider.keys()) {
+    if (key !== "_default") return true;
+  }
+  return false;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -47,6 +47,7 @@ import {
   recordEmptyWorkerResponse,
   clearEmptyWorkerStreak,
 } from "./worker-health";
+import { getModelEntrySync } from "./worker-model";
 
 // ---------------------------------------------------------------------------
 // Worker call tracking
@@ -72,6 +73,44 @@ export const AUTH_ERROR_CODES = new Set([401, 403]);
  * failure ladder, and soft-pause the session so we stop retrying every turn.
  */
 const INSUFFICIENT_CREDIT_CODES = new Set([402]);
+
+/**
+ * Does this header set carry an `anthropic-beta` (case-insensitive)?
+ */
+function hasBetaHeader(headers: Record<string, string>): boolean {
+  return Object.keys(headers).some((k) => k.toLowerCase() === "anthropic-beta");
+}
+
+/**
+ * Return a copy of the headers with every `anthropic-beta` entry removed.
+ * Used as a runtime fallback when a 400 looks beta-related.
+ */
+function stripBetaHeaders(
+  headers: Record<string, string>,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers)) {
+    if (k.toLowerCase() === "anthropic-beta") continue;
+    out[k] = v;
+  }
+  return out;
+}
+
+/**
+ * Heuristic: does a 400 body indicate the request used a beta feature the
+ * model/subscription doesn't support? Matches Anthropic's long-context and
+ * generic beta-availability errors (e.g. "The long context beta is not yet
+ * available for this subscription", "... beta is not available", "unsupported
+ * beta"). Conservative — only triggers the one-shot beta-stripped retry.
+ */
+function isBetaRelated400(body: string): boolean {
+  return (
+    /\bbeta\b/i.test(body) &&
+    /\b(not\s+(yet\s+)?available|unsupported|not\s+enabled|invalid)\b/i.test(
+      body,
+    )
+  );
+}
 
 /**
  * Unified retry policy (modeled on Claude Code's `getRetryDelay`).
@@ -289,16 +328,35 @@ export function resolveWorkerProtocol(
   return "anthropic";
 }
 
-/** Resolve upstream target URL and protocol.
- *  When `upstreamOverride` is set, the request routes to that URL instead
- *  of the default — used for same-provider routing where the session's
- *  credentials only work against the session's endpoint. */
+/**
+ * Resolve upstream target URL and protocol for a worker model.
+ *
+ * CROSS-PROVIDER SAFETY: the `upstreamOverride` (the session's endpoint) is
+ * ONLY honored when the worker model's provider matches the session/override
+ * provider. A session endpoint belongs to provider A; sending provider B's
+ * model there with provider A's credential is the exact misconfig that caused
+ * the production 401 loop (minimax model → api.anthropic.com). When the worker
+ * model's provider differs, we route by the model's OWN provider route table
+ * (`resolveProviderRoute`) and ignore the session override. If the model's
+ * provider has no route URL, `routeUrl` is null and the caller must fail closed
+ * rather than fall back to a foreign endpoint.
+ *
+ * @param modelProviderID  The worker model's provider (authoritative for routing)
+ * @param overrideProviderID  The session/override provider, if known
+ */
 function resolveTarget(
   upstreams: { anthropic: string; openai: string },
   protocol: WorkerProtocol,
-  upstreamOverride?: string,
-): ProviderTarget {
-  if (upstreamOverride) {
+  upstreamOverride: string | undefined,
+  modelProviderID: string,
+  overrideProviderID?: string,
+): ProviderTarget & { routeUnavailable?: boolean } {
+  // Honor the session override ONLY when the worker model belongs to the same
+  // provider as the override endpoint. Otherwise the override is a foreign
+  // endpoint for this model and MUST NOT be used.
+  const overrideMatchesModel =
+    !overrideProviderID || overrideProviderID === modelProviderID;
+  if (upstreamOverride && overrideMatchesModel) {
     return {
       url: upstreamOverride.replace(/\/$/, ""),
       protocol,
@@ -308,15 +366,48 @@ function resolveTarget(
         protocol === "openai-codex-responses" ? "openai-codex" : protocol,
     };
   }
-  if (protocol === "openai-codex-responses") {
-    // Codex has no static default upstream — it always arrives via the
-    // session's upstream override (chatgpt.com/backend-api). Fall back to the
-    // provider route URL if present.
-    const route = resolveProviderRoute("openai-codex");
+
+  // Cross-provider (or no override): route by the worker model's OWN provider.
+  // This is what sends a minimax worker to api.minimax.io instead of colluding
+  // with the session's Anthropic endpoint.
+  // No usable session override for this model — route by the worker model's
+  // OWN provider. This covers both (a) a cross-provider override that doesn't
+  // match the model, and (b) no override at all. The default anthropic/openai
+  // endpoints (below) are ONLY for the two providers they actually belong to;
+  // a foreign provider (minimax, xai, ...) must use its route or fail closed,
+  // never silently land on api.anthropic.com.
+  const isCrossProviderOverride = !!upstreamOverride && !overrideMatchesModel;
+  const isDefaultProvider =
+    modelProviderID === "anthropic" || modelProviderID === "openai";
+  if (isCrossProviderOverride || !isDefaultProvider) {
+    if (protocol === "openai-codex-responses") {
+      // Codex has no static default upstream — fall back to its provider route.
+      const route = resolveProviderRoute("openai-codex");
+      if (route?.url) {
+        return {
+          url: route.url.replace(/\/$/, ""),
+          protocol,
+          providerName: "openai-codex",
+        };
+      }
+    } else {
+      const route = resolveProviderRoute(modelProviderID);
+      if (route?.url) {
+        return {
+          url: route.url.replace(/\/$/, ""),
+          protocol,
+          providerName: modelProviderID,
+        };
+      }
+    }
+    // No route URL for this provider (unknown, or a local provider needing an
+    // explicit LORE_UPSTREAM_<PROVIDER>). Signal the caller to fail closed —
+    // we must NOT fall back to a foreign default endpoint.
     return {
-      url: (route?.url ?? upstreams.openai).replace(/\/$/, ""),
+      url: "",
       protocol,
-      providerName: "openai-codex",
+      providerName: modelProviderID,
+      routeUnavailable: true,
     };
   }
   if (protocol === "openai") {
@@ -391,16 +482,74 @@ function buildAnthropicWorkerRequest(
   // Anthropic may reject worker calls with 401 even when the token is valid.
   const oauthHeaders = buildOAuthWorkerHeaders(sessionID);
 
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "anthropic-version": "2023-06-01",
+    ...authHeaders(cred),
+    ...oauthHeaders,
+  };
+
+  // Capability-aware beta filtering (primary defense against the long-context
+  // 400 loop). The client's `anthropic-beta` is replayed verbatim onto worker
+  // calls, but a sniffed `context-1m` long-context beta is meaningless — and
+  // rejected with a 400 — for a worker model that doesn't support a 1M context
+  // window (e.g. claude-haiku-4-5, whose limit is 200K and will likely never
+  // support 1M). Requesting 1M on such a model is a logical error, so we drop
+  // the long-context beta unless the SELECTED worker model actually supports
+  // a 1M+ context window. (A runtime 400-retry-without-beta fallback in the
+  // retry loop covers any beta we couldn't validate here.)
+  applyModelBetaCapabilityFilter(headers, model.modelID);
+
   return {
     url: `${target.url}/v1/messages`,
-    headers: {
-      "Content-Type": "application/json",
-      "anthropic-version": "2023-06-01",
-      ...authHeaders(cred),
-      ...oauthHeaders,
-    },
+    headers,
     body,
   };
+}
+
+/**
+ * Matches the long-context (1M) beta token family, e.g.
+ * `context-1m-2025-08-07`. The date suffix changes over time, so match the
+ * `context-1m` stem (optionally followed by `-<suffix>`), anchored on a
+ * trimmed token so it can't match a substring inside another beta name.
+ */
+const LONG_CONTEXT_BETA_RE = /^context-1m(?:-.*)?$/;
+
+/** Minimum model context window (tokens) required to keep a `context-1m` beta. */
+const LONG_CONTEXT_MIN_WINDOW = 1_000_000;
+
+/**
+ * Drop beta tokens that the selected worker model cannot honor. Currently
+ * removes the long-context (`context-1m`) beta when the model's context window
+ * is below 1M — requesting 1M context on, e.g., haiku is a logical error that
+ * Anthropic rejects with a 400. Mutates `headers` in place. Other betas are
+ * preserved. If stripping leaves no betas, the header is removed entirely.
+ */
+function applyModelBetaCapabilityFilter(
+  headers: Record<string, string>,
+  modelID: string,
+): void {
+  const betaKey = Object.keys(headers).find(
+    (k) => k.toLowerCase() === "anthropic-beta",
+  );
+  if (!betaKey) return;
+  const betaValue = headers[betaKey];
+  if (!betaValue || !/context-1m/i.test(betaValue)) return;
+
+  // Look up the model's real context window (models.dev-backed, with a
+  // conservative fallback table). Unknown models default to 200K.
+  const contextWindow = getModelEntrySync(modelID).limit?.context ?? 200_000;
+  if (contextWindow >= LONG_CONTEXT_MIN_WINDOW) return; // model supports 1M
+
+  const kept = betaValue
+    .split(",")
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0 && !LONG_CONTEXT_BETA_RE.test(t));
+  if (kept.length > 0) {
+    headers[betaKey] = kept.join(",");
+  } else {
+    delete headers[betaKey];
+  }
 }
 
 /**
@@ -776,8 +925,34 @@ export function createGatewayLLMClient(
       }
       const upstreamOverride = opts?.upstreamUrl;
       const protocol = resolveWorkerProtocol(model.providerID, opts?.protocol);
-      const target = resolveTarget(upstreams, protocol, upstreamOverride);
+      const target = resolveTarget(
+        upstreams,
+        protocol,
+        upstreamOverride,
+        model.providerID,
+        opts?.upstreamProviderID,
+      );
       const maxTokens = opts?.maxTokens ?? DEFAULT_WORKER_MAX_TOKENS;
+
+      // Cross-provider fail-closed: the worker model's provider has no route
+      // URL (unknown provider, or a local provider missing its explicit
+      // upstream). We must NOT fall back to the session's foreign endpoint —
+      // that's the exact collusion that caused the minimax→Anthropic 401 loop.
+      // Skip the call, record it, and soft-pause so it doesn't re-fire.
+      if (target.routeUnavailable || !target.url) {
+        log.warn(
+          `worker cross-provider: no route for model provider="${model.providerID}" ` +
+            `(model=${model.modelID}, worker=${opts?.workerID ?? "unknown"}, ` +
+            `session=${opts?.sessionID?.slice(0, 16) ?? "none"}) — skipping`,
+        );
+        recordWorkerFailure(
+          opts?.sessionID ?? "_unknown",
+          opts?.workerID ?? "unknown",
+          "cross-provider",
+        );
+        if (opts?.sessionID) markWorkerPaused(opts.sessionID);
+        return null;
+      }
 
       // Defense-in-depth: detect API key / provider mismatch before making
       // a doomed request. Anthropic keys start with "sk-ant-"; OpenAI keys
@@ -785,29 +960,21 @@ export function createGatewayLLMClient(
       // distinguished by prefix, so only API keys are checked.
       // Skip when LORE_WORKER_API_KEY is set — the user deliberately chose
       // a cross-provider credential/model combination.
-      // Also skip when an upstream override points to a known
-      // proxy/aggregator (e.g. OpenCode Zen, OpenRouter) that accepts the
-      // session's credentials regardless of the provider prefix.
-      // DO NOT skip for direct provider URLs (api.anthropic.com,
-      // api.openai.com) — the mismatch check is still needed there.
-      let shouldCheckProtocolMismatch = true;
-      if (upstreamOverride) {
-        try {
-          const hostname = new URL(upstreamOverride).hostname;
-          // Only skip the check for proxy/aggregator hosts — direct
-          // provider URLs still need the mismatch guard.
-          // Only Anthropic and OpenAI are checked because they're the
-          // only providers whose API key prefixes are distinguishable
-          // (sk-ant- vs sk-). Other providers use bearer tokens or
-          // non-standard key formats this prefix check can't validate.
-          const isDirectProvider =
-            hostname === "api.anthropic.com" || hostname === "api.openai.com";
-          if (!isDirectProvider) {
-            shouldCheckProtocolMismatch = false;
-          }
-        } catch {
-          // Malformed URL — run the check to be safe.
-        }
+      // The check is keyed off the RESOLVED TARGET host (not the raw
+      // override): after cross-provider routing the target may be the model's
+      // own endpoint (e.g. api.minimax.io) where an `sk-`-prefixed key is
+      // perfectly valid and must NOT be rejected as an "Anthropic mismatch".
+      // Only the two direct providers whose key prefixes are distinguishable
+      // (api.anthropic.com / api.openai.com) get the prefix check; everything
+      // else (aggregators, minimax, bearer tokens) is exempt.
+      let shouldCheckProtocolMismatch = false;
+      try {
+        const targetHost = new URL(target.url).hostname;
+        shouldCheckProtocolMismatch =
+          targetHost === "api.anthropic.com" || targetHost === "api.openai.com";
+      } catch {
+        // Malformed target URL — leave the check off (the route resolution
+        // above already failed closed for unroutable providers).
       }
       if (
         cred.scheme === "api-key" &&
@@ -882,6 +1049,9 @@ export function createGatewayLLMClient(
             // Trip the circuit breaker at most once per call so a multi-retry
             // 429 loop doesn't runaway-escalate the breaker's backoff schedule.
             let breakerTripped = false;
+            // Strip beta headers at most once per call (runtime fallback for a
+            // beta-related 400 — see the non-transient block below).
+            let betaStripped = false;
             // Resolve the retry budget once per call (not per attempt) — the
             // value can't change mid-loop and re-reading the env each iteration
             // is wasteful.
@@ -1111,6 +1281,14 @@ export function createGatewayLLMClient(
                   code: 2,
                   message: `HTTP ${response.status} auth`,
                 });
+                // Soft-pause so a persistent auth failure doesn't re-fire on
+                // every idle tick + turn. The per-provider staleness above
+                // does NOT stop the loop for a cross-provider 401 (the key is
+                // valid for its real provider, so it's never marked stale) —
+                // the pause is the robust backstop. isWorkerCreditPaused()
+                // still lets one probe through per 5 min so a refreshed
+                // credential recovers automatically. Urgent calls are exempt.
+                if (opts?.sessionID) markWorkerPaused(opts.sessionID);
                 return null;
               }
 
@@ -1151,6 +1329,31 @@ export function createGatewayLLMClient(
               // Non-transient error — fail immediately, no retry
               if (!TRANSIENT_CODES.has(response.status)) {
                 const text = await response.text().catch(() => "(no body)");
+
+                // 400 + a beta-related complaint → the request carries a beta
+                // header the model/subscription doesn't support (e.g. a
+                // `context-1m` long-context beta sniffed from the client turn
+                // and replayed onto a worker call to a non-1M model like
+                // haiku). The upfront capability check (buildWorkerRequest)
+                // should already strip incompatible betas, but this is the
+                // runtime safety net: retry ONCE with all beta headers removed
+                // before giving up. Bounded to a single retry to avoid a loop.
+                if (
+                  response.status === 400 &&
+                  !betaStripped &&
+                  hasBetaHeader(req.headers) &&
+                  isBetaRelated400(text)
+                ) {
+                  betaStripped = true;
+                  req = { ...req, headers: stripBetaHeaders(req.headers) };
+                  log.warn(
+                    `worker 400 looks beta-related — retrying once without beta headers ` +
+                      `(model=${model.providerID}/${model.modelID}, worker=${opts?.workerID ?? "unknown"}): ${text.slice(0, 160)}`,
+                  );
+                  retryCount++;
+                  continue;
+                }
+
                 log.error(
                   `worker upstream request failed: ${response.status} ${response.statusText}` +
                     ` — url=${target.url} model=${model.providerID}/${model.modelID}` +
@@ -1164,6 +1367,11 @@ export function createGatewayLLMClient(
                   opts?.workerID ?? "unknown",
                   "upstream-error",
                 );
+                // Soft-pause: a non-transient 4xx for a worker re-sending the
+                // same content is permanent. Stops the re-fire-every-turn loop;
+                // isWorkerCreditPaused() still probes once per 5 min so a fixed
+                // request recovers. Urgent calls are pause-exempt.
+                if (opts?.sessionID) markWorkerPaused(opts.sessionID);
                 return null;
               }
 

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -75,22 +75,53 @@ export const AUTH_ERROR_CODES = new Set([401, 403]);
 const INSUFFICIENT_CREDIT_CODES = new Set([402]);
 
 /**
- * Does this header set carry an `anthropic-beta` (case-insensitive)?
+ * Matches the long-context (1M) beta token family, e.g.
+ * `context-1m-2025-08-07`. The date suffix changes over time, so match the
+ * `context-1m` stem (optionally followed by `-<suffix>`), anchored on a
+ * trimmed token so it can't match a substring inside another beta name.
  */
-function hasBetaHeader(headers: Record<string, string>): boolean {
-  return Object.keys(headers).some((k) => k.toLowerCase() === "anthropic-beta");
+const LONG_CONTEXT_BETA_RE = /^context-1m(?:-.*)?$/;
+
+/** Minimum model context window (tokens) required to keep a `context-1m` beta. */
+const LONG_CONTEXT_MIN_WINDOW = 1_000_000;
+
+/**
+ * Does this header set carry an `anthropic-beta` whose value contains a
+ * long-context (`context-1m`) token? Only the long-context beta is a plausible
+ * cause of the "beta not available for this subscription" 400 on worker calls,
+ * so the retry fallback is gated on its presence — we never strip betas (and
+ * lose the OAuth gate) for an unrelated 400.
+ */
+function hasLongContextBeta(headers: Record<string, string>): boolean {
+  for (const [k, v] of Object.entries(headers)) {
+    if (k.toLowerCase() === "anthropic-beta" && /context-1m/i.test(v)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /**
- * Return a copy of the headers with every `anthropic-beta` entry removed.
- * Used as a runtime fallback when a 400 looks beta-related.
+ * Return a copy of the headers with ONLY the long-context (`context-1m`) beta
+ * token removed from `anthropic-beta`, preserving every other beta — crucially
+ * `oauth-2025-04-20`, which OAuth/bearer worker calls require to authenticate.
+ * Stripping the whole header would turn a recoverable beta-400 into a 401 on
+ * OAuth sessions. If removing the long-context token leaves no betas, the
+ * header is dropped entirely. Used as a runtime fallback on a beta-related 400.
  */
 function stripBetaHeaders(
   headers: Record<string, string>,
 ): Record<string, string> {
   const out: Record<string, string> = {};
   for (const [k, v] of Object.entries(headers)) {
-    if (k.toLowerCase() === "anthropic-beta") continue;
+    if (k.toLowerCase() === "anthropic-beta") {
+      const kept = v
+        .split(",")
+        .map((t) => t.trim())
+        .filter((t) => t.length > 0 && !LONG_CONTEXT_BETA_RE.test(t));
+      if (kept.length > 0) out[k] = kept.join(",");
+      continue;
+    }
     out[k] = v;
   }
   return out;
@@ -351,11 +382,20 @@ function resolveTarget(
   modelProviderID: string,
   overrideProviderID?: string,
 ): ProviderTarget & { routeUnavailable?: boolean } {
-  // Honor the session override ONLY when the worker model belongs to the same
-  // provider as the override endpoint. Otherwise the override is a foreign
-  // endpoint for this model and MUST NOT be used.
-  const overrideMatchesModel =
-    !overrideProviderID || overrideProviderID === modelProviderID;
+  // Honor the session override ONLY when we have positive evidence it belongs
+  // to this worker model's provider:
+  //  - overrideProviderID matches the model's provider (the normal case), OR
+  //  - overrideProviderID is unknown AND the model provider does NOT have its
+  //    own distinct provider route (so there's no safer endpoint to prefer —
+  //    e.g. the model provider IS the override's, or it's an aggregator).
+  // When overrideProviderID is unknown but the model HAS its own route (e.g.
+  // minimax → api.minimax.io), we do NOT trust the foreign override — we route
+  // by the model's own provider below. This fails safe: a future caller that
+  // sets `upstreamUrl` without `upstreamProviderID` cannot silently re-open the
+  // cross-provider collusion (the production minimax→Anthropic 401 loop).
+  const overrideMatchesModel = overrideProviderID
+    ? overrideProviderID === modelProviderID
+    : resolveProviderRoute(modelProviderID)?.url == null;
   if (upstreamOverride && overrideMatchesModel) {
     return {
       url: upstreamOverride.replace(/\/$/, ""),
@@ -506,17 +546,6 @@ function buildAnthropicWorkerRequest(
     body,
   };
 }
-
-/**
- * Matches the long-context (1M) beta token family, e.g.
- * `context-1m-2025-08-07`. The date suffix changes over time, so match the
- * `context-1m` stem (optionally followed by `-<suffix>`), anchored on a
- * trimmed token so it can't match a substring inside another beta name.
- */
-const LONG_CONTEXT_BETA_RE = /^context-1m(?:-.*)?$/;
-
-/** Minimum model context window (tokens) required to keep a `context-1m` beta. */
-const LONG_CONTEXT_MIN_WINDOW = 1_000_000;
 
 /**
  * Drop beta tokens that the selected worker model cannot honor. Currently
@@ -924,7 +953,20 @@ export function createGatewayLLMClient(
         return null;
       }
       const upstreamOverride = opts?.upstreamUrl;
-      const protocol = resolveWorkerProtocol(model.providerID, opts?.protocol);
+      // The explicit protocol hint comes from the SESSION's upstream. Only
+      // honor it when the worker model belongs to the same provider as the
+      // session — otherwise it's the wrong wire protocol for this model (e.g.
+      // an "anthropic" hint applied to an openai worker model). For a
+      // cross-provider worker, derive the protocol from the model's OWN
+      // provider route instead. This keeps protocol, URL, and credential all
+      // consistent with the worker model's provider.
+      const sameProviderAsSession =
+        !opts?.upstreamProviderID ||
+        opts.upstreamProviderID === model.providerID;
+      const protocol = resolveWorkerProtocol(
+        model.providerID,
+        sameProviderAsSession ? opts?.protocol : undefined,
+      );
       const target = resolveTarget(
         upstreams,
         protocol,
@@ -1336,18 +1378,19 @@ export function createGatewayLLMClient(
                 // and replayed onto a worker call to a non-1M model like
                 // haiku). The upfront capability check (buildWorkerRequest)
                 // should already strip incompatible betas, but this is the
-                // runtime safety net: retry ONCE with all beta headers removed
-                // before giving up. Bounded to a single retry to avoid a loop.
+                // runtime safety net: retry ONCE with the long-context beta
+                // removed (preserving oauth-2025-04-20 et al. so OAuth calls
+                // still authenticate) before giving up. Bounded to one retry.
                 if (
                   response.status === 400 &&
                   !betaStripped &&
-                  hasBetaHeader(req.headers) &&
+                  hasLongContextBeta(req.headers) &&
                   isBetaRelated400(text)
                 ) {
                   betaStripped = true;
                   req = { ...req, headers: stripBetaHeaders(req.headers) };
                   log.warn(
-                    `worker 400 looks beta-related — retrying once without beta headers ` +
+                    `worker 400 looks long-context-beta-related — retrying once without the context-1m beta ` +
                       `(model=${model.providerID}/${model.modelID}, worker=${opts?.workerID ?? "unknown"}): ${text.slice(0, 160)}`,
                   );
                   retryCount++;

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -173,6 +173,7 @@ import {
   recordWorkerFailure,
   allowWorkerProbe,
   isWorkerCreditPaused,
+  getDegradationWarning,
 } from "./worker-health";
 import {
   getWorkerModel,
@@ -296,8 +297,30 @@ const CONTEXT_WARNING_TEXT =
   `it has exceeded the context limit 5+ times in a row and compression cannot keep up. ` +
   `Consider running /compact or starting a new conversation.\n\n---\n\n`;
 
-/** Insert the context warning text block into a response, after any leading thinking blocks. */
-function injectContextWarning(resp: GatewayResponse): GatewayResponse {
+/**
+ * Build the worker-degradation warning text (or null if the session's
+ * background workers are healthy / not yet sustained-failing). Reuses the
+ * CONTEXT_WARNING_MARKER so it is stripped on the next turn like the
+ * unsustainable-conversation warning, preserving the prompt cache prefix.
+ *
+ * This is the user-visible signal that distillation/curation/cache-warming
+ * are failing — so degradation (context bloat, no LTM growth) is never silent.
+ */
+function buildWorkerDegradationWarning(sessionID: string): string | null {
+  const warning = getDegradationWarning(sessionID);
+  if (!warning) return null;
+  return `${CONTEXT_WARNING_MARKER} ${warning}\n\n---\n\n`;
+}
+
+/**
+ * Insert a warning text block into a response, after any leading thinking
+ * blocks. Defaults to the unsustainable-conversation text; pass `text` to
+ * inject a different marker'd warning (e.g. worker degradation).
+ */
+function injectContextWarning(
+  resp: GatewayResponse,
+  text: string = CONTEXT_WARNING_TEXT,
+): GatewayResponse {
   // Insert after thinking blocks to preserve the expected block ordering
   // (thinking first, then text). Clients may inspect the first block's type
   // to determine if extended thinking is active.
@@ -311,7 +334,7 @@ function injectContextWarning(resp: GatewayResponse): GatewayResponse {
   const content = [...resp.content];
   content.splice(insertIdx, 0, {
     type: "text" as const,
-    text: CONTEXT_WARNING_TEXT,
+    text,
   });
   return { ...resp, content };
 }
@@ -1523,9 +1546,18 @@ function getLLMClient(config: GatewayConfig): LLMClient {
                 return null;
               }
             }
+            // Thread the session's provider so the adapter can enforce
+            // cross-provider safety: it only honors `upstreamUrl` when the
+            // (possibly re-resolved) worker model's provider matches
+            // `upstreamProviderID`. If a configured `workerModel` re-resolves
+            // to a DIFFERENT provider than the session (the production
+            // minimax-on-Anthropic case), the adapter routes by the worker
+            // model's own provider route — or fails closed if it has none —
+            // instead of sending it to the session's foreign endpoint.
             return rawClient.prompt(system, user, {
               ...effectiveOpts,
               upstreamUrl: state.lastUpstream.url,
+              upstreamProviderID: upstreamProvider,
               protocol: state.lastUpstream.protocol,
             });
           }
@@ -5795,6 +5827,26 @@ async function handleConversationTurn(
     );
   }
 
+  // Worker-degradation warning: surfaced when background workers (distillation,
+  // curation, cache-warming) have been failing for a sustained period, so the
+  // user is told instead of silently losing compression/LTM. Reuses the same
+  // marker-based response injection as the unsustainable warning. The
+  // unsustainable warning takes precedence when both apply (it's the more
+  // urgent, actionable signal); we never inject two warning blocks.
+  const workerWarningText = unsustainable
+    ? undefined
+    : buildWorkerDegradationWarning(sessionID);
+  if (workerWarningText) {
+    log.warn(
+      `session ${sessionID}: worker degradation detected — warning will be prepended to response.`,
+    );
+  }
+  // A single combined flag/text drives all injection sites below.
+  const warningText: string | undefined = unsustainable
+    ? CONTEXT_WARNING_TEXT
+    : (workerWarningText ?? undefined);
+  const shouldInjectWarning = !!warningText;
+
   // --- 8. Build the modified request ---
   // Reconstruct GatewayMessages from the transformed Lore messages.
   // loreMessagesToGateway reconstructs tool_result blocks from assistant's
@@ -6169,7 +6221,9 @@ async function handleConversationTurn(
           genAiSpan,
         );
         return nonStreamHttpResponse(
-          unsustainable ? injectContextWarning(markerResp) : markerResp,
+          shouldInjectWarning
+            ? injectContextWarning(markerResp, warningText)
+            : markerResp,
           req.protocol,
           req.stream,
           { "x-lore-recall-invoked": "true" },
@@ -6216,7 +6270,9 @@ async function handleConversationTurn(
           genAiSpan,
         );
         return nonStreamHttpResponse(
-          unsustainable ? injectContextWarning(markerResp) : markerResp,
+          shouldInjectWarning
+            ? injectContextWarning(markerResp, warningText)
+            : markerResp,
           req.protocol,
           req.stream,
           { "x-lore-recall-invoked": "true" },
@@ -6249,7 +6305,9 @@ async function handleConversationTurn(
           genAiSpan,
         );
         return nonStreamHttpResponse(
-          unsustainable ? injectContextWarning(markerResp) : markerResp,
+          shouldInjectWarning
+            ? injectContextWarning(markerResp, warningText)
+            : markerResp,
           req.protocol,
           req.stream,
           { "x-lore-recall-invoked": "true" },
@@ -6298,7 +6356,9 @@ async function handleConversationTurn(
     const recallHeaders =
       recallDepth > 0 ? { "x-lore-recall-invoked": "true" } : undefined;
     return nonStreamHttpResponse(
-      unsustainable ? injectContextWarning(currentResp) : currentResp,
+      shouldInjectWarning
+        ? injectContextWarning(currentResp, warningText)
+        : currentResp,
       req.protocol,
       req.stream,
       recallHeaders,
@@ -6335,7 +6395,7 @@ async function handleConversationTurn(
       hasRecallTool
         ? { modifiedReq, config, sessionState, cacheOptions }
         : undefined,
-      unsustainable ? CONTEXT_WARNING_TEXT : undefined,
+      warningText,
     );
     // Translate to client's wire format if needed. When the upstream is
     // Anthropic but the client speaks OpenAI, wrap the Anthropic SSE stream.

--- a/packages/gateway/test/auth.test.ts
+++ b/packages/gateway/test/auth.test.ts
@@ -281,6 +281,39 @@ describe("resolveAuth with staleness", () => {
     expect(resolveAuth("sess-1")).toEqual(bearerCred2);
   });
 
+  // -------------------------------------------------------------------------
+  // Cross-provider fallback guard (production 401-loop regression)
+  // -------------------------------------------------------------------------
+
+  test("does NOT borrow the global credential for a provider the session never authenticated", () => {
+    // Session authenticated ONLY with Anthropic (stored under "anthropic").
+    setSessionAuth("sess-1", apiKeyCred, "anthropic");
+    // Global fallback holds that same Anthropic key.
+    setLastSeenAuth(apiKeyCred);
+
+    // A worker configured for "minimax" must NOT get the Anthropic key — that
+    // produced the production cross-provider 401 loop. Fail closed (null).
+    expect(resolveAuth("sess-1", "minimax")).toBe(null);
+    // The legitimate provider still resolves correctly.
+    expect(resolveAuth("sess-1", "anthropic")).toEqual(apiKeyCred);
+  });
+
+  test("returns the provider's own credential when the session has it", () => {
+    setSessionAuth("sess-1", apiKeyCred, "anthropic");
+    setSessionAuth("sess-1", minimaxCred, "minimax");
+    setLastSeenAuth(apiKeyCred);
+
+    expect(resolveAuth("sess-1", "minimax")).toEqual(minimaxCred);
+    expect(resolveAuth("sess-1", "anthropic")).toEqual(apiKeyCred);
+  });
+
+  test("still allows global fallback for cold-start sessions with no provider store", () => {
+    // No setSessionAuth at all — a cold-start worker before the first turn's
+    // credential was registered. The global fallback is still legitimate here.
+    setLastSeenAuth(apiKeyCred);
+    expect(resolveAuth("sess-cold", "anthropic")).toEqual(apiKeyCred);
+  });
+
   test("re-resolves to session credential after staleness cleared", () => {
     setSessionAuth("sess-1", bearerCred);
     setLastSeenAuth(apiKeyCred);

--- a/packages/gateway/test/llm-adapter.test.ts
+++ b/packages/gateway/test/llm-adapter.test.ts
@@ -1011,10 +1011,12 @@ describe("worker beta capability validation", () => {
     // Use a 1M-capable model (opus) so the capability filter KEEPS the beta —
     // then simulate the real scenario where the model supports 1M but the
     // SUBSCRIPTION isn't entitled, so Anthropic still 400s. The runtime
-    // beta-stripped retry is what recovers.
+    // beta-stripped retry is what recovers. The sniffed beta also carries the
+    // OAuth gate (oauth-2025-04-20) which MUST survive the retry — stripping it
+    // would turn the recoverable 400 into a 401.
     captureBillingPrefix("sess-400-beta", BILLING_SYSTEM);
     captureSessionHeaders("sess-400-beta", {
-      "anthropic-beta": "context-1m-2025-08-07",
+      "anthropic-beta": "oauth-2025-04-20,context-1m-2025-08-07",
     });
 
     const client = createGatewayLLMClient(
@@ -1031,8 +1033,13 @@ describe("worker beta capability validation", () => {
 
     expect(result).toBe("recovered");
     expect(mockFetch).toHaveBeenCalledTimes(2);
-    // First attempt carried the beta; retry dropped it.
+    // First attempt carried the long-context beta.
     expect(betaOf(0)).toContain("context-1m");
-    expect(betaOf(1)).toBeUndefined();
+    expect(betaOf(0)).toContain("oauth-2025-04-20");
+    // Retry dropped ONLY the long-context beta — the OAuth gate is preserved
+    // (stripping it would 401 the retry).
+    expect(betaOf(1)).toBeDefined();
+    expect(betaOf(1)).not.toContain("context-1m");
+    expect(betaOf(1)).toContain("oauth-2025-04-20");
   });
 });

--- a/packages/gateway/test/llm-adapter.test.ts
+++ b/packages/gateway/test/llm-adapter.test.ts
@@ -29,7 +29,12 @@ import {
 import { upstreamFetch } from "../src/fetch";
 import { clearAllCosts, getSessionCosts } from "../src/cost-tracker";
 import { recordWorkerFailure, markWorkerPaused } from "../src/worker-health";
-import { captureSessionHeaders } from "../src/cch";
+import { captureSessionHeaders, captureBillingPrefix } from "../src/cch";
+
+// Claude Code billing-header system prompt — marks a session as an OAuth
+// billing session so worker calls replay its sniffed anthropic-beta header.
+const BILLING_SYSTEM =
+  "x-anthropic-billing-header: cc_version=2.1.177.00c; cc_entrypoint=cli; cch=a55d7;";
 
 // ---------------------------------------------------------------------------
 // maxRetriesFor — unified policy (modeled on Claude Code's single budget)
@@ -647,5 +652,387 @@ describe("worker 402 insufficient credit handling", () => {
     expect(result).toBeNull();
     expect(mockMarkPaused).not.toHaveBeenCalled();
     expect(mockRecordFailure).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-provider collusion guard
+//
+// REGRESSION: production incident where a configured `workerModel:
+// minimax/MiniMax-M2.7` was sent to https://api.anthropic.com with the
+// session's Anthropic api-key, producing a 401 "invalid x-api-key" loop with
+// no backoff (auth errors don't retry) — 175 of 200 worker errors, pinning a
+// CPU core across multiple sessions.
+//
+// INVARIANT (must hold forever): a worker model's provider MUST match BOTH
+//  (a) the upstream URL the request is sent to, AND
+//  (b) the credential used.
+// A worker call may NEVER send provider A's model to provider B's endpoint, and
+// MUST fail closed (skip + record "cross-provider", no upstream request) when a
+// matching route/credential is unavailable.
+// ---------------------------------------------------------------------------
+
+describe("cross-provider collusion guard", () => {
+  const mockFetch = vi.mocked(upstreamFetch);
+  const mockRecordFailure = vi.mocked(recordWorkerFailure);
+
+  const UPSTREAMS = {
+    anthropic: "https://api.anthropic.com",
+    openai: "https://api.openai.com",
+  };
+
+  beforeEach(() => {
+    mockRecordFailure.mockClear();
+  });
+
+  afterEach(() => {
+    mockFetch.mockReset();
+    clearAllCosts();
+    resetBackgroundLimiter();
+  });
+
+  // The core regression: minimax model + Anthropic api-key (the exact prod
+  // misconfig). It must NOT reach api.anthropic.com. Either it routes to
+  // minimax's own endpoint (only if a minimax credential exists) or it fails
+  // closed — but it must never collude provider A's model with provider B's
+  // direct endpoint.
+  test("NEVER sends a minimax model to api.anthropic.com with an Anthropic key", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({ error: { message: "invalid x-api-key" } }),
+        { status: 401 },
+      ),
+    );
+
+    // getAuth simulates production: no minimax credential, only the Anthropic
+    // key is known (returned for any provider via the global fallback today).
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "sk-ant-anthropic-key" }),
+      { providerID: "anthropic", modelID: "claude-haiku-4-5" },
+    );
+
+    const result = await client.prompt("system", "user", {
+      sessionID: "sess-xprov",
+      workerID: "lore-distill",
+      model: { providerID: "minimax", modelID: "MiniMax-M2.7" },
+    });
+
+    expect(result).toBeNull();
+    // The invariant: if any upstream call was made, it must NOT be to the
+    // Anthropic direct endpoint with the minimax model.
+    for (const call of mockFetch.mock.calls) {
+      const url = String(call[0]);
+      expect(url).not.toContain("api.anthropic.com");
+    }
+  });
+
+  test("fails closed (skip + record cross-provider, no fetch) when no matching credential", async () => {
+    // getAuth returns null for the minimax provider (no minimax credential) —
+    // the post-fix resolveAuth behavior. The call must be skipped entirely.
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      (_sid, providerID) =>
+        providerID === "minimax"
+          ? null
+          : { scheme: "api-key", value: "sk-ant-anthropic-key" },
+      { providerID: "anthropic", modelID: "claude-haiku-4-5" },
+    );
+
+    const result = await client.prompt("system", "user", {
+      sessionID: "sess-xprov-2",
+      workerID: "lore-distill",
+      model: { providerID: "minimax", modelID: "MiniMax-M2.7" },
+    });
+
+    expect(result).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockRecordFailure).toHaveBeenCalledWith(
+      "sess-xprov-2",
+      "lore-distill",
+      expect.stringMatching(/cross-provider|no-auth/),
+    );
+  });
+
+  test("routes a minimax model to the minimax endpoint when a minimax credential exists", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          content: [{ type: "text", text: "minimax reply" }],
+          model: "MiniMax-M2.7",
+          usage: { input_tokens: 5, output_tokens: 2 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    // A real minimax credential is available for the minimax provider.
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      (_sid, providerID) =>
+        providerID === "minimax"
+          ? { scheme: "api-key", value: "minimax-secret-key" }
+          : { scheme: "api-key", value: "sk-ant-anthropic-key" },
+      { providerID: "anthropic", modelID: "claude-haiku-4-5" },
+    );
+
+    const result = await client.prompt("system", "user", {
+      sessionID: "sess-xprov-3",
+      workerID: "lore-distill",
+      model: { providerID: "minimax", modelID: "MiniMax-M2.7" },
+    });
+
+    expect(result).toBe("minimax reply");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const url = String(mockFetch.mock.calls[0][0]);
+    // minimax PROVIDER_ROUTES url is https://api.minimax.io/anthropic
+    expect(url).toContain("api.minimax.io");
+    expect(url).not.toContain("api.anthropic.com");
+  });
+
+  test("soft-pauses on a non-transient 400 so it stops re-firing every turn", async () => {
+    const mockMarkPaused = vi.mocked(markWorkerPaused);
+    mockMarkPaused.mockClear();
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({ error: { message: "bad request, model not found" } }),
+        { status: 400 },
+      ),
+    );
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "sk-ant-test" }),
+      { providerID: "anthropic", modelID: "claude-test" },
+    );
+
+    const result = await client.prompt("system", "user", {
+      sessionID: "sess-400-pause",
+      workerID: "lore-distill",
+    });
+
+    expect(result).toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(1); // no retry
+    expect(mockMarkPaused).toHaveBeenCalledWith("sess-400-pause");
+  });
+
+  test("soft-pauses on a persistent 401 auth error (cross-provider key-valid-but-wrong loop)", async () => {
+    const mockMarkPaused = vi.mocked(markWorkerPaused);
+    mockMarkPaused.mockClear();
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({ error: { message: "invalid x-api-key" } }),
+        { status: 401 },
+      ),
+    );
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "sk-ant-test" }),
+      { providerID: "anthropic", modelID: "claude-test" },
+    );
+
+    const result = await client.prompt("system", "user", {
+      sessionID: "sess-401-pause",
+      workerID: "lore-distill",
+    });
+
+    expect(result).toBeNull();
+    expect(mockMarkPaused).toHaveBeenCalledWith("sess-401-pause");
+  });
+
+  test("does not let a session upstreamUrl override re-home a different provider's model", async () => {
+    // Session is Anthropic (upstreamUrl=api.anthropic.com) but the worker model
+    // is minimax. The session override must NOT be applied to the minimax model.
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          content: [{ type: "text", text: "ok" }],
+          model: "MiniMax-M2.7",
+          usage: { input_tokens: 5, output_tokens: 2 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      (_sid, providerID) =>
+        providerID === "minimax"
+          ? { scheme: "api-key", value: "minimax-secret-key" }
+          : { scheme: "api-key", value: "sk-ant-anthropic-key" },
+      { providerID: "anthropic", modelID: "claude-haiku-4-5" },
+    );
+
+    await client.prompt("system", "user", {
+      sessionID: "sess-xprov-4",
+      workerID: "lore-distill",
+      model: { providerID: "minimax", modelID: "MiniMax-M2.7" },
+      // The session's Anthropic endpoint — must be IGNORED for a minimax model.
+      upstreamUrl: "https://api.anthropic.com",
+      protocol: "anthropic",
+    });
+
+    for (const call of mockFetch.mock.calls) {
+      expect(String(call[0])).not.toContain("api.anthropic.com");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Beta-vs-model capability validation + runtime 400-retry-without-beta
+//
+// The client's `anthropic-beta` (incl. a `context-1m` long-context beta) is
+// replayed onto worker calls. A 1M beta is a logical error for a model whose
+// context window is < 1M (e.g. claude-haiku-4-5, 200K) and Anthropic rejects it
+// with a 400. We (1) validate betas against the selected model's capability
+// matrix and drop incompatible ones up front, and (2) as a runtime safety net,
+// retry once with all beta headers removed on a beta-related 400.
+// ---------------------------------------------------------------------------
+
+describe("worker beta capability validation", () => {
+  const mockFetch = vi.mocked(upstreamFetch);
+
+  const UPSTREAMS = {
+    anthropic: "https://api.anthropic.com",
+    openai: "https://api.openai.com",
+  };
+
+  afterEach(() => {
+    mockFetch.mockReset();
+    clearAllCosts();
+    resetBackgroundLimiter();
+  });
+
+  function betaOf(callIndex: number): string | undefined {
+    const init = mockFetch.mock.calls[callIndex]?.[1];
+    const headers = init?.headers as Record<string, string> | undefined;
+    if (!headers) return undefined;
+    const key = Object.keys(headers).find(
+      (k) => k.toLowerCase() === "anthropic-beta",
+    );
+    return key ? headers[key] : undefined;
+  }
+
+  test("drops the context-1m beta for a sub-1M model (haiku) but keeps other betas", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          content: [{ type: "text", text: "ok" }],
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    // Mark the session as a billing/OAuth session and seed a sniffed beta that
+    // includes context-1m alongside legitimate betas.
+    captureBillingPrefix("sess-haiku-beta", BILLING_SYSTEM);
+    captureSessionHeaders("sess-haiku-beta", {
+      "anthropic-beta":
+        "oauth-2025-04-20,context-1m-2025-08-07,fine-grained-tool-streaming-2025-05-14",
+    });
+
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "bearer", value: "oauth-token" }),
+      { providerID: "anthropic", modelID: "claude-haiku-4-5" },
+    );
+
+    await client.prompt("system", "user", {
+      sessionID: "sess-haiku-beta",
+      workerID: "lore-distill",
+      model: { providerID: "anthropic", modelID: "claude-haiku-4-5" },
+    });
+
+    const beta = betaOf(0);
+    expect(beta).toBeDefined();
+    expect(beta).not.toContain("context-1m");
+    // Other betas preserved.
+    expect(beta).toContain("oauth-2025-04-20");
+    expect(beta).toContain("fine-grained-tool-streaming-2025-05-14");
+  });
+
+  test("keeps the context-1m beta for a 1M-capable model (opus)", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          content: [{ type: "text", text: "ok" }],
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    captureBillingPrefix("sess-opus-beta", BILLING_SYSTEM);
+    captureSessionHeaders("sess-opus-beta", {
+      "anthropic-beta": "oauth-2025-04-20,context-1m-2025-08-07",
+    });
+
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "bearer", value: "oauth-token" }),
+      { providerID: "anthropic", modelID: "claude-opus-4-8" },
+    );
+
+    await client.prompt("system", "user", {
+      sessionID: "sess-opus-beta",
+      workerID: "lore-distill",
+      model: { providerID: "anthropic", modelID: "claude-opus-4-8" },
+    });
+
+    // opus-4 has a 1M context window in the fallback table → beta retained.
+    expect(betaOf(0)).toContain("context-1m");
+  });
+
+  test("retries once without beta headers on a beta-related 400, then succeeds", async () => {
+    let call = 0;
+    mockFetch.mockImplementation(async () => {
+      call++;
+      if (call === 1) {
+        return new Response(
+          JSON.stringify({
+            error: {
+              type: "invalid_request_error",
+              message:
+                "The long context beta is not yet available for this subscription.",
+            },
+          }),
+          { status: 400 },
+        );
+      }
+      return new Response(
+        JSON.stringify({
+          content: [{ type: "text", text: "recovered" }],
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+
+    // Use a 1M-capable model (opus) so the capability filter KEEPS the beta —
+    // then simulate the real scenario where the model supports 1M but the
+    // SUBSCRIPTION isn't entitled, so Anthropic still 400s. The runtime
+    // beta-stripped retry is what recovers.
+    captureBillingPrefix("sess-400-beta", BILLING_SYSTEM);
+    captureSessionHeaders("sess-400-beta", {
+      "anthropic-beta": "context-1m-2025-08-07",
+    });
+
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "bearer", value: "oauth-token" }),
+      { providerID: "anthropic", modelID: "claude-opus-4-8" },
+    );
+
+    const result = await client.prompt("system", "user", {
+      sessionID: "sess-400-beta",
+      workerID: "lore-distill",
+      model: { providerID: "anthropic", modelID: "claude-opus-4-8" },
+    });
+
+    expect(result).toBe("recovered");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    // First attempt carried the beta; retry dropped it.
+    expect(betaOf(0)).toContain("context-1m");
+    expect(betaOf(1)).toBeUndefined();
   });
 });

--- a/packages/gateway/test/worker-cross-provider.test.ts
+++ b/packages/gateway/test/worker-cross-provider.test.ts
@@ -1,0 +1,188 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+
+// Structural / property-based guard against CROSS-PROVIDER COLLUSION on worker
+// calls. This is the permanent regression net for the production incident where
+// a configured `workerModel: minimax/MiniMax-M2.7` was sent to
+// https://api.anthropic.com with the session's Anthropic api-key, looping on
+// 401 "invalid x-api-key" with no backoff (auth errors don't retry) and pinning
+// a CPU core.
+//
+// INVARIANT (must hold for EVERY provider, forever):
+//   A worker model belonging to provider X must never have its request sent to
+//   a DIFFERENT direct provider's endpoint (api.anthropic.com / api.openai.com).
+//   It either routes to X's own endpoint (when a credential for X exists) or
+//   fails closed (no upstream request) — but it never collides X's model with
+//   Y's direct endpoint + Y's credential.
+//
+// This test drives the real `createGatewayLLMClient().prompt()` path across a
+// matrix of (worker model provider × session/override provider) so that ANY
+// future change to routing (resolveTarget, resolveWorkerProtocol, the guard) is
+// caught if it reintroduces collusion.
+
+vi.mock("../src/fetch", () => ({ upstreamFetch: vi.fn() }));
+vi.mock("../src/worker-health", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/worker-health")>();
+  return {
+    ...actual,
+    recordWorkerFailure: vi.fn(actual.recordWorkerFailure),
+    markWorkerPaused: vi.fn(actual.markWorkerPaused),
+  };
+});
+
+import { createGatewayLLMClient } from "../src/llm-adapter";
+import { upstreamFetch } from "../src/fetch";
+import { clearAllCosts } from "../src/cost-tracker";
+import { resetBackgroundLimiter } from "../src/background-limiter";
+
+const mockFetch = vi.mocked(upstreamFetch);
+
+const UPSTREAMS = {
+  anthropic: "https://api.anthropic.com",
+  openai: "https://api.openai.com",
+};
+
+const DIRECT_HOSTS = ["api.anthropic.com", "api.openai.com"];
+
+// Representative worker-model providers spanning the routing categories:
+//  - direct providers (anthropic, openai)
+//  - anthropic-protocol third parties with their own endpoint (minimax, fireworks)
+//  - openai-protocol third parties (xai, deepseek)
+//  - unknown provider (no route → must fail closed)
+const WORKER_PROVIDERS: Array<{
+  providerID: string;
+  modelID: string;
+  ownHost?: string; // present → routes here; absent → fail closed
+}> = [
+  {
+    providerID: "anthropic",
+    modelID: "claude-haiku-4-5",
+    ownHost: "api.anthropic.com",
+  },
+  { providerID: "openai", modelID: "gpt-5-mini", ownHost: "api.openai.com" },
+  { providerID: "minimax", modelID: "MiniMax-M2.7", ownHost: "api.minimax.io" },
+  { providerID: "fireworks", modelID: "fw-model", ownHost: "api.fireworks.ai" },
+  { providerID: "xai", modelID: "grok-x", ownHost: "api.x.ai" },
+  {
+    providerID: "deepseek",
+    modelID: "deepseek-chat",
+    ownHost: "api.deepseek.com",
+  },
+  { providerID: "totally-unknown-provider", modelID: "mystery-1" }, // no route
+];
+
+// Session/override providers the worker call might be "attached" to.
+const SESSION_PROVIDERS = ["anthropic", "openai"] as const;
+
+function okResponse() {
+  return new Response(
+    JSON.stringify({
+      content: [{ type: "text", text: "ok" }],
+      choices: [{ message: { content: "ok" } }],
+      model: "m",
+      usage: {
+        input_tokens: 1,
+        output_tokens: 1,
+        prompt_tokens: 1,
+        completion_tokens: 1,
+      },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+describe("worker cross-provider routing matrix (structural guard)", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue(okResponse());
+  });
+  afterEach(() => {
+    mockFetch.mockReset();
+    clearAllCosts();
+    resetBackgroundLimiter();
+  });
+
+  for (const wp of WORKER_PROVIDERS) {
+    for (const sessionProvider of SESSION_PROVIDERS) {
+      const sessionHost =
+        sessionProvider === "anthropic"
+          ? "api.anthropic.com"
+          : "api.openai.com";
+
+      test(`worker=${wp.providerID} on ${sessionProvider} session never collides with the other direct provider`, async () => {
+        // A credential EXISTS for the worker model's provider (so routing is
+        // possible) AND for the session provider (the global/foreign cred).
+        const client = createGatewayLLMClient(
+          UPSTREAMS,
+          (_sid, providerID) => {
+            if (providerID === wp.providerID) {
+              // Use an Anthropic-prefixed key only for anthropic; a generic key
+              // otherwise. The prefix guard must not reject valid foreign keys.
+              return {
+                scheme: "api-key",
+                value:
+                  wp.providerID === "anthropic"
+                    ? "sk-ant-worker"
+                    : "worker-key",
+              };
+            }
+            return { scheme: "api-key", value: "sk-ant-session" };
+          },
+          { providerID: sessionProvider, modelID: "session-model" },
+        );
+
+        await client.prompt("system", "user", {
+          sessionID: `sess-${wp.providerID}-${sessionProvider}`,
+          workerID: "lore-distill",
+          model: { providerID: wp.providerID, modelID: wp.modelID },
+          // Simulate the session's endpoint override + its provider id.
+          upstreamUrl: `https://${sessionHost}`,
+          upstreamProviderID: sessionProvider,
+          protocol: sessionProvider === "anthropic" ? "anthropic" : "openai",
+        });
+
+        // THE INVARIANT: no request may go to a direct provider host that the
+        // worker model does NOT belong to.
+        for (const call of mockFetch.mock.calls) {
+          const url = String(call[0]);
+          for (const host of DIRECT_HOSTS) {
+            const belongsToWorker = wp.ownHost === host;
+            if (!belongsToWorker) {
+              expect(url).not.toContain(host);
+            }
+          }
+        }
+
+        // Positive expectation: known providers route to their own host;
+        // unknown providers fail closed (no upstream request at all).
+        if (wp.ownHost) {
+          // Some call was made and it was to the worker provider's own host.
+          if (mockFetch.mock.calls.length > 0) {
+            expect(String(mockFetch.mock.calls[0][0])).toContain(wp.ownHost);
+          }
+        } else {
+          expect(mockFetch).not.toHaveBeenCalled();
+        }
+      });
+    }
+  }
+
+  test("an unknown worker-model provider with no route ALWAYS fails closed (never falls back to a direct endpoint)", async () => {
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "sk-ant-session" }),
+      { providerID: "anthropic", modelID: "session-model" },
+    );
+
+    const result = await client.prompt("system", "user", {
+      sessionID: "sess-unknown",
+      workerID: "lore-distill",
+      model: { providerID: "no-such-provider", modelID: "x" },
+      upstreamUrl: "https://api.anthropic.com",
+      upstreamProviderID: "anthropic",
+      protocol: "anthropic",
+    });
+
+    expect(result).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/gateway/test/worker-cross-provider.test.ts
+++ b/packages/gateway/test/worker-cross-provider.test.ts
@@ -109,24 +109,24 @@ describe("worker cross-provider routing matrix (structural guard)", () => {
           : "api.openai.com";
 
       test(`worker=${wp.providerID} on ${sessionProvider} session never collides with the other direct provider`, async () => {
-        // A credential EXISTS for the worker model's provider (so routing is
-        // possible) AND for the session provider (the global/foreign cred).
+        // Provide a VALID, correctly-prefixed credential for the worker model's
+        // provider so routing genuinely succeeds (not skipped by the protocol-
+        // mismatch prefix guard) — this keeps the positive assertion below
+        // non-vacuous. anthropic → sk-ant-; openai → sk- (non-ant); third
+        // parties use a generic key (their host is exempt from the prefix
+        // guard). The session/global cred is a foreign Anthropic key.
+        const workerKey =
+          wp.providerID === "anthropic"
+            ? "sk-ant-worker"
+            : wp.providerID === "openai"
+              ? "sk-openai-worker"
+              : "worker-key";
         const client = createGatewayLLMClient(
           UPSTREAMS,
-          (_sid, providerID) => {
-            if (providerID === wp.providerID) {
-              // Use an Anthropic-prefixed key only for anthropic; a generic key
-              // otherwise. The prefix guard must not reject valid foreign keys.
-              return {
-                scheme: "api-key",
-                value:
-                  wp.providerID === "anthropic"
-                    ? "sk-ant-worker"
-                    : "worker-key",
-              };
-            }
-            return { scheme: "api-key", value: "sk-ant-session" };
-          },
+          (_sid, providerID) =>
+            providerID === wp.providerID
+              ? { scheme: "api-key", value: workerKey }
+              : { scheme: "api-key", value: "sk-ant-session" },
           { providerID: sessionProvider, modelID: "session-model" },
         );
 
@@ -152,13 +152,13 @@ describe("worker cross-provider routing matrix (structural guard)", () => {
           }
         }
 
-        // Positive expectation: known providers route to their own host;
-        // unknown providers fail closed (no upstream request at all).
+        // Positive expectation (NON-vacuous): a routable provider with a valid
+        // credential MUST make exactly one upstream call, to its OWN host. If a
+        // regression makes such a provider fail closed (zero calls) or route to
+        // a foreign host, this fails. Unknown/unroutable providers fail closed.
         if (wp.ownHost) {
-          // Some call was made and it was to the worker provider's own host.
-          if (mockFetch.mock.calls.length > 0) {
-            expect(String(mockFetch.mock.calls[0][0])).toContain(wp.ownHost);
-          }
+          expect(mockFetch).toHaveBeenCalledTimes(1);
+          expect(String(mockFetch.mock.calls[0][0])).toContain(wp.ownHost);
         } else {
           expect(mockFetch).not.toHaveBeenCalled();
         }


### PR DESCRIPTION
## Problem

A user's nightly run reported the distillation worker hammering Anthropic. Investigation via the **actual Sentry logs** (not the reported symptom) showed the dominant failure is **cross-provider misrouting**, not the long-context beta:

| Count | Status | cred | model | URL |
|---|---|---|---|---|
| **175** | 401 `invalid x-api-key` | api-key | `minimax/MiniMax-M2.7` | `api.anthropic.com` |
| 18 | 401 | Bearer | `claude-sonnet-4-6` | `api.anthropic.com` |
| 1 | 429 long-context | Bearer | `claude-sonnet-4-6` | `api.anthropic.com` |
| (also) | 400 long-context | Bearer | `claude-haiku-4-5` | `api.anthropic.com` |

The CPU-pinning zombie session (`0tCs8IKXzSANidbg`, 87 hits; 4 sessions affected) is the **MiniMax→Anthropic 401 loop**: a configured `workerModel: minimax/MiniMax-M2.7` was sent to the session's Anthropic endpoint with the Anthropic key. 401 is an auth error → no backoff → tight loop.

## Root causes

1. `resolveTarget()` ignored the worker model's provider — it used the session `upstreamUrl` override or static anthropic/openai defaults, never the model's own provider route (`PROVIDER_ROUTES["minimax"]`).
2. `resolveAuth()` fell back to the global (foreign-provider) credential when the session had no credential for the requested provider.
3. The pipeline cross-provider guard only handled a mid-flight provider *race*, not a static misconfig (it re-resolved to the same configured model and injected the session URL anyway).
4. A non-transient 400/401 returned with no soft-pause (unlike 402), so the worker re-fired every idle tick + turn.

## Fixes

- **`resolveTarget()` routes by the worker model's `providerID`** — and derives protocol from the model's own provider when it differs from the session, so URL + protocol + credential are all consistent. The session override is honored only with positive evidence it belongs to the model's provider; unknown/unroutable providers **fail closed** (skip + record `cross-provider` + soft-pause) instead of colluding with a foreign direct endpoint. With no provider hint, a foreign provider that has its own route is routed by that route (never the foreign override) — so a future caller can't silently re-open the hole.
- **`resolveAuth()`** no longer borrows the global credential for a specific `providerID` the session never authenticated.
- **Pipeline** threads `upstreamProviderID` so the adapter enforces the match end-to-end.
- **Soft-pause** on persistent 401/403 and non-transient 4xx → ~1 self-probe/5min instead of a storm. Urgent compaction is pause-exempt.
- **Capability-aware beta filtering**: drop the `context-1m` long-context beta when the selected worker model's context window < 1M (e.g. haiku=200K — a logical error). Runtime safety net: on a long-context-beta 400, retry once dropping **only** the `context-1m` token (preserving `oauth-2025-04-20` so OAuth calls still authenticate), then fall through to soft-pause.
- **User-visible degradation warning** via the existing response-warning channel — degradation is never silent.

## Tests (regression net)

- **`worker-cross-provider.test.ts`** — structural/property-based guard across a provider matrix (anthropic, openai, minimax, fireworks, xai, deepseek, unknown × anthropic/openai sessions). Asserts (non-vacuously — exactly one call to the correct host) that **a provider's model only ever reaches its own endpoint, never a different direct provider's**, and that unroutable providers fail closed.
- Cross-provider collusion, beta-capability + OAuth-gate-preserving retry, and soft-pause cases in `llm-adapter.test.ts`; cross-provider auth guard in `auth.test.ts`. Written TDD red-first (the two core tests reproduced the exact prod 401 against the buggy code).

## Review

Self-reviewed adversarially via subagent; fixed three findings before merge: a vacuous matrix assertion (M1, which surfaced a latent cross-provider protocol bug), the OAuth-gate-on-retry bug (m2), and a defense-in-depth gap when `upstreamProviderID` is absent (m1). All in the second commit.

## Verification

- Full suite: 2956+ passed, 6 pre-existing skips · gateway suite 1691 passed
- Typecheck: clean (all packages) · Lint: clean (Biome)
- Real bun bundle rebuilds and loads

## Operational note

The configured `workerModel: MiniMax-M2.7` is the active cause — users hitting this can stop the loop immediately by removing `workerModel` from their `.lore.json` and restarting, without waiting for this release.