### PR TITLE
docs(website): add Mermaid diagrams to architecture page

### DIFF
--- a/packages/website/astro.config.mjs
+++ b/packages/website/astro.config.mjs
@@ -213,12 +213,16 @@ export default defineConfig({
         // the .ec-line divs and call mermaid.render() directly. Mermaid's
         // "neutral" theme is a safe default for both light and dark
         // Starlight themes; theme-aware switching (reading
-        // document.documentElement.dataset.theme) is a follow-up.
+        // document.documentElement.dataset.theme) is a follow-up. The
+        // version is pinned to an exact release for reproducible diagram
+        // output; SRI is not used because integrity hashes do not apply to
+        // bare ESM `import` URLs, and the render call already degrades
+        // gracefully to the source text on failure (see the catch below).
         {
           tag: "script",
           attrs: { type: "module" },
           content: [
-            'import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";',
+            'import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11.16.0/dist/mermaid.esm.min.mjs";',
             'mermaid.initialize({ startOnLoad: false, theme: "neutral", securityLevel: "loose", fontFamily: "var(--sl-font)" });',
             "const blocks = document.querySelectorAll('pre[data-language=\"mermaid\"]');",
             "for (const pre of blocks) {",

--- a/packages/website/astro.config.mjs
+++ b/packages/website/astro.config.mjs
@@ -220,7 +220,7 @@ export default defineConfig({
           content: [
             'import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";',
             'mermaid.initialize({ startOnLoad: false, theme: "neutral", securityLevel: "loose", fontFamily: "var(--sl-font)" });',
-            'const blocks = document.querySelectorAll(\'pre[data-language="mermaid"]\');',
+            "const blocks = document.querySelectorAll('pre[data-language=\"mermaid\"]');",
             "for (const pre of blocks) {",
             "  const source = Array.from(pre.querySelectorAll('.ec-line')).map((l) => l.textContent).join('\\n');",
             "  if (!source.trim()) continue;",

--- a/packages/website/astro.config.mjs
+++ b/packages/website/astro.config.mjs
@@ -206,6 +206,38 @@ export default defineConfig({
             content: "@withLoreAI",
           },
         },
+        // Mermaid (architecture diagrams). Loaded from jsdelivr ESM build
+        // and rendered client-side. Starlight's expressive-code wraps
+        // fenced code blocks in styled <div>s without preserving line
+        // breaks in textContent, so we extract the source per-line from
+        // the .ec-line divs and call mermaid.render() directly. Mermaid's
+        // "neutral" theme is a safe default for both light and dark
+        // Starlight themes; theme-aware switching (reading
+        // document.documentElement.dataset.theme) is a follow-up.
+        {
+          tag: "script",
+          attrs: { type: "module" },
+          content: [
+            'import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";',
+            'mermaid.initialize({ startOnLoad: false, theme: "neutral", securityLevel: "loose", fontFamily: "var(--sl-font)" });',
+            'const blocks = document.querySelectorAll(\'pre[data-language="mermaid"]\');',
+            "for (const pre of blocks) {",
+            "  const source = Array.from(pre.querySelectorAll('.ec-line')).map((l) => l.textContent).join('\\n');",
+            "  if (!source.trim()) continue;",
+            "  const id = 'mermaid-' + Math.random().toString(36).slice(2, 9);",
+            "  try {",
+            "    const { svg } = await mermaid.render(id, source);",
+            "    const wrap = document.createElement('div');",
+            "    wrap.className = 'mermaid';",
+            "    wrap.innerHTML = svg;",
+            "    pre.replaceWith(wrap);",
+            "  } catch (err) {",
+            "    console.error('Mermaid render failed:', err);",
+            "    pre.textContent = source;",
+            "  }",
+            "}",
+          ].join("\n"),
+        },
       ],
     }),
   ],

--- a/packages/website/src/content/docs/docs/architecture.md
+++ b/packages/website/src/content/docs/docs/architecture.md
@@ -29,9 +29,9 @@ flowchart LR
 
 The supported agents reach the proxy through one of three mechanisms:
 
-- **OpenCode and Pi** ship dedicated plugins (`@loreai/opencode`, `@loreai/pi`) that install a fetch interceptor and pin each provider's `baseURL` to the local gateway.
-- **Claude Code, Codex, and Hermes** are auto-detected by `lore run` (`gateway/src/cli/agents.ts`), which sets the right env var (`ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL`) or CLI flag (`codex -c openai_base_url=...`) for that agent's SDK.
-- **Anything else** that reads `baseURL` from environment can be pointed at the gateway manually.
+- **`lore run` auto-detects all five agents** (`gateway/src/cli/agents.ts`) and sets the right base-URL knob for each: `ANTHROPIC_BASE_URL` for Claude Code and Pi, `OPENAI_BASE_URL` for Hermes, and the `codex -c openai_base_url=...` CLI flag for Codex (the Codex CLI is a Rust binary that doesn't read `OPENAI_BASE_URL`).
+- **OpenCode and Pi additionally ship dedicated plugins** (`@loreai/opencode`, `@loreai/pi`) that install a fetch interceptor and pin each provider's `baseURL` to the local gateway — so they work even when launched outside `lore run`.
+- **Anything else** that reads `baseURL` from the environment can be pointed at the gateway manually.
 
 ## How context and knowledge flow through Lore
 
@@ -40,46 +40,39 @@ Once a request lands in the gateway, two flows kick off in parallel: a **request
 **System + LTM + Meta-Distillations + Distillations + Delta Updates + Conversation**
 
 ```mermaid
-flowchart LR
-    subgraph Tiers["Sources — three-tier memory"]
-        direction TB
-        T1["Tier 1 — Temporal<br/>raw messages"]
-        T2["Tier 2 — Distillation<br/>gen-0 + gen-1+"]
-        T3["Tier 3 — LTM<br/>curated knowledge"]
+flowchart TB
+    subgraph Sources["Three-tier memory · sources"]
+        direction LR
+        T1["Tier 1 · Temporal<br/>raw messages"]:::tier
+        T2["Tier 2 · Distillation<br/>gen-0 + gen-1+"]:::tier
+        T3["Tier 3 · LTM<br/>curated knowledge"]:::tier
     end
 
-    G["Gradient context manager<br/>L0–L4 · cost-aware caps<br/>3-block system prompt"]:::gradient
+    G["Gradient context manager<br/>picks a layer and composes the prompt<br/>within the cost-aware budget, every turn"]:::gradient
 
-    subgraph Formula["The formula — what the model sees"]
+    subgraph Stack["What the model sees · one stacked prompt, top → bottom"]
         direction TB
-        S0["System<br/>(harness rules, base)"]:::prompt
-        L["LTM<br/>(pinned entries)"]:::pinned
-        M["Meta-Distillations<br/>(gen-1+ summaries)"]:::distill
-        D["Distillations<br/>(gen-0 observations)"]:::distill
-        DU["Delta Updates<br/>(volatile channel)"]:::tail
-        C["Conversation<br/>(raw tail)"]:::tail
+        B1["System — system[0]<br/>harness rules + Lore identity · cache-stable"]:::sys
+        B2["LTM — system[1]<br/>preferences · entities · knowledge catalog<br/>frozen baseline, cached 1h · cache-write anchor"]:::pinned
+        B3["LTM — system[2]<br/>context-bound entries · diff-pinned, 5m cache"]:::pinned
+        B4["Meta-Distillations + Distillations<br/>distilled prefix at the head of the messages"]:::distill
+        B5["Delta Updates<br/>knowledge deltas in the tail · volatile"]:::tail
+        B6["Conversation<br/>raw message tail"]:::tail
+        B1 --- B2 --- B3 --- B4 --- B5 --- B6
     end
 
-    T1 --> C
-    T1 -. "volatile" .-> DU
-    T2 --> M
-    T2 --> D
-    T3 --> L
-    Base["Lore identity<br/>(system base)"]:::neutral --> S0
-    G --> Formula
-    Tiers --> G
+    Sources --> G --> Stack --> Call["Upstream LLM call"]:::ext
 
-    Formula --> Call[Upstream LLM call]
-
+    classDef tier fill:#f7f2e8,stroke:#5a8f63,color:#1a3320
     classDef gradient fill:#c4ddc7,stroke:#1a3320,stroke-width:2px,color:#1a3320
-    classDef neutral fill:#ececec,stroke:#888,color:#333
-    classDef prompt fill:#f7f2e8,stroke:#5a8f63,color:#1a3320
+    classDef sys fill:#ececec,stroke:#888,color:#333
     classDef pinned fill:#8fba96,stroke:#1a3320,color:#1a3320
     classDef distill fill:#c4ddc7,stroke:#1a3320,color:#1a3320
     classDef tail fill:#ececec,stroke:#888,color:#333
+    classDef ext fill:#ececec,stroke:#888,color:#333
 ```
 
-The formula's six parts map to specific prompt blocks: **System** lives in `system[0]` (cache-stable base), **LTM** in `system[2]` (frozen pin baseline — see the [LTM pin invariant](#the-ltm-pin-frozen-baseline) below), **Meta-Distillations** and **Distillations** together make up `system[1]` (the distilled prefix, the cache-write anchor for new turns), and **Delta Updates** and **Conversation** live in the conversation tail (volatile, ID-referenced, not cache-stable). The gradient's job is to compose these six pieces within the context-window budget on every turn. The next diagram zooms in on that composition.
+The formula's parts map onto the wire in the order the model reads them. **System** is `system[0]` — the harness rules and Lore's identity, cache-stable. **LTM** spans two system blocks: `system[1]` holds the stable baseline (preferences, known entities, and a knowledge catalog), frozen for the session and cached at a 1-hour TTL — it's the cache-write anchor — while `system[2]` holds the context-bound entries, re-pinned only when they materially change (see the [LTM pin invariant](#the-ltm-pin-frozen-baseline) below). **Meta-Distillations** and **Distillations** are not a system block at all: they ride at the head of the message array as a distilled prefix, kept byte-stable so appending a new turn stays cheap. **Delta Updates** and **Conversation** fill the rest of the message tail (volatile, ID-referenced, not cache-stable). The gradient's job is to compose these pieces within the context-window budget on every turn; the next section zooms in on that composition.
 
 ## Three-tier memory
 
@@ -97,45 +90,39 @@ Durable project facts — decisions, patterns, preferences, gotchas — are cura
 
 #### Long-term knowledge structure
 
-The LTM table stores five categories of curated entries, each available in two scopes — **per-project** (the default, scoped to the working directory) and **cross-project** (`cross_project: true`, available across every project the gateway sees). The recall tool searches per-project first and falls back to cross-project results when scope is `all`. **Entities** are a sibling concept: a knowledge graph (canonical names, aliases, relations) maintained by the sync engine, not an LTM category. The recall tool searches them alongside LTM, distillations, and temporal messages.
+The LTM table stores five categories of curated entries, each carrying a scope — **per-project** (the default, scoped to the working directory) or **cross-project** (`cross_project: true`, available across every project the gateway sees). Per-project knowledge is always in play; cross-project entries join the search only when the scope is `all`, fused in rather than consulted as a strict fallback. **Entities** are a sibling concept: a knowledge graph (canonical names, aliases, relations) maintained by the sync engine, not an LTM category. The recall tool searches them alongside LTM, distillations, and temporal messages.
 
 ```mermaid
 flowchart LR
-    subgraph PerProject["Per-project (knowledge)"]
+    Sources["curator · pattern-extract · file import"]:::src
+    Recall["recall tool · parallel search"]:::search
+
+    subgraph KB["Long-term knowledge"]
         direction TB
-        P1[Decisions]:::cat
-        P2[Patterns]:::cat
-        P3[Preferences]:::cat
-        P4[Architecture]:::cat
-        P5[Gotchas]:::cat
+        Cats["5 categories<br/>Decisions · Patterns · Preferences<br/>Architecture · Gotchas"]:::cat
+        subgraph Scopes["every entry carries a scope"]
+            direction LR
+            SP["per-project<br/>default"]:::scopeA
+            SC["cross-project<br/>cross_project = true"]:::scopeB
+        end
+        Cats --> Scopes
     end
 
-    subgraph Cross["Cross-project (cross_project=true)"]
-        direction TB
-        C1[Decisions]:::cross
-        C2[Patterns]:::cross
-        C3[Preferences]:::cross
-        C4[Architecture]:::cross
-        C5[Gotchas]:::cross
-    end
-
-    subgraph Entities["Entities (sync engine)"]
-        direction TB
+    subgraph Ent["Entities · knowledge graph (sync engine)"]
+        direction LR
         E1[Canonical names]:::ent
         E2[Aliases]:::ent
         E3[Relations]:::ent
     end
 
-    Sources["curator · pattern-extract · file import"]:::src --> PerProject
-    Sources --> Cross
-    Sources --> Entities
+    Sources --> KB
+    Sources --> Ent
+    Recall -. searches .-> KB
+    Recall -. searches .-> Ent
 
-    Search["recall tool<br/>(parallel search)"]:::search --> PerProject
-    Search --> Cross
-    Search --> Entities
-
-    classDef cat fill:#c4ddc7,stroke:#1a3320,color:#1a3320
-    classDef cross fill:#8fba96,stroke:#1a3320,color:#1a3320
+    classDef cat fill:#8fba96,stroke:#1a3320,color:#1a3320
+    classDef scopeA fill:#c4ddc7,stroke:#1a3320,color:#1a3320
+    classDef scopeB fill:#f7f2e8,stroke:#5a8f63,color:#1a3320
     classDef ent fill:#f7f2e8,stroke:#5a8f63,color:#1a3320
     classDef src fill:#ececec,stroke:#888,color:#333
     classDef search fill:#c4ddc7,stroke:#1a3320,stroke-width:2px,color:#1a3320
@@ -143,57 +130,45 @@ flowchart LR
 
 ## Gradient context manager
 
-The gradient context manager is what makes Lore different from a summarization wrapper. It is a four-layer system that decides — on **every turn** — how much of each tier to include in the next request, balancing detail preservation against prompt-cache cost.
+The gradient context manager is what makes Lore different from a summarization wrapper. It is a five-layer system (L0–L4) that decides — on **every turn** — how much of each tier to include in the next request, balancing detail preservation against prompt-cache cost. Each layer keeps everything the layer above it did and removes a little more.
 
 | Layer | Contents | When used |
 |---|---|---|
 | **0** | Full raw window (no distillation, no compression) | Best quality. Default for sessions under the cost-aware cap. |
 | **1** | Distilled prefix + recent raw window | When the raw window no longer fits. The cached distilled prefix is the cache-write anchor — appending a new raw message at the front is cheap. |
 | **2** | Distilled prefix + raw window with old tool outputs stripped | When the distilled prefix plus full raw still overflows. Tool outputs from old turns are replaced with compact annotations preserving line count, error signals, and file paths. The last 2 turns are always protected from stripping. |
-| **3** | Distilled prefix + raw window with all tool outputs stripped + only the 5 most-recent gen-0 distillations retained | Emergency compression. The 5 most recent gen-0 segments retain full detail in the prefix; older distillations are consolidated by the meta-distillation pass. |
+| **3** | Distilled prefix + raw window with all tool outputs stripped + only the 5 most-recent gen-0 distillations retained | Heavy compression. The 5 most recent gen-0 segments retain full detail in the prefix; older distillations are consolidated by the meta-distillation pass. |
+| **4** | Only the 2 most-recent distillations + a small raw tail (`clamp(usable × 0.25, 2K, 8K)` tokens); the current turn is always included in full | Emergency, terminal layer. Tool outputs are *not* stripped here (that would make the model re-invoke its own in-progress tool calls); instead the oldest messages are dropped, and the recall tool retrieves anything older the model still needs. |
 
-The escalation between layers is automatic. The 0→1 boundary is driven by **cost-aware context management** (see below); the 1→2 and 2→3 boundaries are driven by token-fit. There is also a per-session `forceMinLayer` floor, persisted to SQLite, that survives process restarts — when the upstream API returns "prompt is too long", the error handler sets it to the layer that fit, and the next turn starts at that layer.
+The escalation between layers is automatic. The 0→1 boundary is driven by **cost-aware context management** (see below); the 1→2, 2→3, and 3→4 boundaries are driven by token-fit. There is also a per-session `forceMinLayer` floor, persisted to SQLite, that survives process restarts — when the upstream API returns "prompt is too long", the error handler raises the floor to the layer that fits (2 or 3, depending on how badly the request overshot), and the next turn starts there.
 
-The diagram below shows how the four layers collapse into the 3-block system prompt — the structure the LLM actually sees. The L0–L4 layers are an *escalation ladder*: only one is active per turn, chosen by the cost-aware cap and token fit. The 3-block system prompt is the *output* of the active layer.
+The layers form an **escalation ladder** — only one is active on any given turn, and the gradient walks *down* it only as far as the budget and token-fit force it. The diagram reads top-to-bottom as increasing compression: each rung labels what it removes from the stacked prompt above, and the edges label what pushes the gradient to the next rung.
 
 ```mermaid
 flowchart TB
-    L0["L0 passthrough<br/>full raw window<br/>cheapest per turn"]:::layer
-    L1["L1 distilled prefix + raw tail<br/>when raw no longer fits"]:::layer
-    L2["L2 strip old tool outputs<br/>last 2 turns protected"]:::layer
-    L3["L3 strip all tool outputs<br/>+ 5 most recent gen-0 in prefix"]:::layer
-    L4["L4 emergency<br/>maxed out"]:::layer
+    L0["L0 · full raw passthrough<br/>everything verbatim — cheapest per turn"]:::l0
+    L1["L1 · distilled prefix + recent raw window<br/>cached prefix anchors the cache"]:::l1
+    L2["L2 · also strip OLD tool outputs<br/>last 2 turns always protected"]:::l2
+    L3["L3 · also strip ALL tool outputs<br/>keep only the 5 most-recent gen-0"]:::l3
+    L4["L4 · emergency / terminal<br/>2 distillations + small raw tail<br/>current turn always kept in full"]:::l4
 
-    L0 --> Compose
-    L1 --> Compose
-    L2 --> Compose
-    L3 --> Compose
-    L4 --> Compose
+    L0 -->|"cost-aware cap exceeded"| L1
+    L1 -->|"raw no longer fits"| L2
+    L2 -->|"still overflows"| L3
+    L3 -->|"still overflows"| L4
+    L4 -.->|"older detail on demand"| R["recall tool"]:::ext
 
-    Compose["3-block system prompt + tail<br/>(the formula)"]:::compose
-
-    subgraph Formula["System + LTM + Meta-Distillations + Distillations + Delta Updates + Conversation"]
-        direction TB
-        S0["system[0] · System<br/>(base, cache-stable)"]:::sys
-        S1["system[1] · Meta-Distillations + Distillations<br/>(distilled prefix, cache-write anchor)"]:::sys
-        S2["system[2] · LTM pin<br/>(frozen baseline, cache-stable)"]:::sys
-        DU["tail · Delta Updates<br/>(volatile, ID-referenced)"]:::tail
-        C["tail · Conversation<br/>(raw messages)"]:::tail
-    end
-
-    Compose --> Formula
-    Formula --> LLM["Upstream LLM call"]:::ext
-
-    classDef layer fill:#f7f2e8,stroke:#5a8f63,color:#1a3320
-    classDef compose fill:#c4ddc7,stroke:#1a3320,stroke-width:2px,color:#1a3320
-    classDef sys fill:#8fba96,stroke:#1a3320,color:#1a3320
-    classDef tail fill:#ececec,stroke:#888,color:#333
+    classDef l0 fill:#f7f2e8,stroke:#5a8f63,color:#1a3320
+    classDef l1 fill:#cfe3d2,stroke:#1a3320,color:#1a3320
+    classDef l2 fill:#a9cdb0,stroke:#1a3320,color:#1a3320
+    classDef l3 fill:#7fb088,stroke:#14301c,color:#0d2113
+    classDef l4 fill:#d98c8c,stroke:#7a1f1f,color:#3d0d0d
     classDef ext fill:#ececec,stroke:#888,color:#333
 ```
 
 #### The LTM pin frozen-baseline
 
-`system[2]` is a **pin**: the set of LTM entry keys rendered into the first system-block is captured at the moment the pin is first established and held constant for the rest of the session. Later turns re-render the *same* entry keys — even as new entries are added, edited, or curated out of the top-K — so the system-block bytes are byte-stable and the upstream prompt cache stays hot. The current rendered set advances on every turn; the pin does not. This is what makes the LTM pin cache-stable: advancing the baseline on every turn would drop earlier supersessions from the coalesced seq-0 row, busting the cache every turn and paying the cache-write price on top.
+`system[2]` — the third system block, holding context-bound LTM — is **diff-pinned**. The set of entry keys rendered into it is captured the moment the pin is first established and held constant for the rest of the session: later turns re-render the *same* keys, so the block stays byte-stable even as entries are added, edited, or curated out of the top-K. Genuinely new or changed entries don't rewrite the block; they're surfaced as append-only **delta updates** in the message tail. That keeps `system[2]` stable against the 5-minute conversation cache, while the separate `system[1]` baseline (preferences, entities, knowledge catalog) is frozen for the whole session and cached at the 1-hour TTL. Advancing the pinned set on every turn would instead rewrite the block — busting the cache every turn and paying the cache-write price on top.
 
 ## Cost-aware context management
 
@@ -209,7 +184,7 @@ The layer-0 cap is the answer. Instead of "use the full context because it's the
 maxLayer0Tokens = max(target / model.cost.cache.read, 40K)
 ```
 
-So a Claude Sonnet session with `cache.read = $3/Mtok` and the default target gets a 33K-token cap, while a cheaper model with `cache.read = $0.30/Mtok` gets a 333K cap. **The floor at 40K is a safety net**: a free-write or near-zero-cost provider would otherwise produce an absurdly large or even negative cap. 40K is enough to fit a representative code-editing session comfortably and small enough that the worst-case per-turn read cost stays bounded.
+So a Claude Sonnet session with `cache.read = $3/Mtok` and the default target works out to ~33K from the formula — which lands *below* the 40K floor, so the floor wins and the cap is **40K**. A cheaper model with `cache.read = $0.30/Mtok` clears the floor easily and gets a 333K cap. **The floor at 40K is a safety net**: a free-write or near-zero-cost provider would otherwise produce an absurdly large or even negative cap. 40K is enough to fit a representative code-editing session comfortably and small enough that the worst-case per-turn read cost stays bounded.
 
 The default of `$0.10` per turn is calibrated to a typical developer session: ~100 turns/day × $0.10 = $10 in cache reads, sitting comfortably under most pro-tier daily budgets. **Lower the target** (say to $0.05) and the cap drops proportionally — sessions compress earlier, layer 1/2/3 kick in sooner, and total spend decreases. **Raise it** (to $0.30 or $0.50) and the cap grows — sessions stay in layer 0 longer, but you pay more in cache reads. Set the cap to $0 to disable cost-aware capping entirely (the session then uses the model's full context at layer 0). Set `budget.maxLayer0Tokens` directly to override the formula and pin a specific cap (useful for benchmarks, or for forcing layer 1 to engage earlier than the cost model would naturally dictate).
 
@@ -236,7 +211,7 @@ continueCost = currentSize   × cacheReadCostPerToken
 compress when bustCost < continueCost × threshold
 ```
 
-If 5+ consecutive turns bust the cache, Lore stops trying to compress and just keeps growing — something structural is causing the busts, and forced compression would just add cost on top of churn. The threshold is per-tier, calibrated so that compression fires in the same scenarios where the user would manually choose it.
+If 2+ consecutive turns bust the cache, Lore stops trying to compress and just keeps growing — something structural is causing the busts, and forced compression would just add cost on top of churn. The threshold is per-tier, calibrated so that compression fires in the same scenarios where the user would manually choose it.
 
 ### Per-turn usage signal
 
@@ -249,7 +224,7 @@ The cost tracker watches the session against an optional `LORE_DAILY_BUDGET` (US
 1. **Compresses earlier** — forces layer 2 at smaller context sizes, trading prompt detail for per-turn spend.
 2. **Injects invisible proxy-level sleeps** to slow the agent's request rate. The throttle delay is computed from the current spend velocity vs the budget, with the curve `MAX_THROTTLE_DELAY × pressure² × tanh(overshoot / 3)`. A session burning twice its target rate gets a squared penalty; one burning at 3× the target saturates to the max delay. The delay is also capped to keep the next request *inside* the cache TTL window (delaying past TTL would bust the cache and undo the savings).
 
-A second independent throttle signal comes from the **Anthropic OAuth quota** (`packages/gateway/src/quota.ts`): the gateway tracks the model's utilization against its 5-hour rolling entitlement and derives a quota pressure in `[0, 1]`. The final delay is the **max** of the budget-derived delay and the quota-derived delay, so either signal can engage throttling — and quota throttling works even when no USD budget is configured (a free user on a tight OAuth entitlement still gets throttled, not silently 429'd).
+A second independent throttle signal comes from the **Anthropic OAuth quota** (`packages/gateway/src/quota.ts`): the gateway tracks the model's utilization against its rolling OAuth entitlement — the higher of the 5-hour and 7-day windows — and derives a quota pressure in `[0, 1]`. The final delay is the **max** of the budget-derived delay and the quota-derived delay, so either signal can engage throttling — and quota throttling works even when no USD budget is configured (a free user on a tight OAuth entitlement still gets throttled, not silently 429'd).
 
 The dashboard surfaces a "budget pressure" signal with two counters: `throttle.events` (number of requests delayed) and `throttle.totalDelayMs` (total wait time imposed).
 
@@ -264,45 +239,42 @@ The distillation input is rendered from temporal messages with a configurable `t
 The recall tool is the escape hatch when neither the in-context prefix nor the gradient layer has the answer. It runs a hybrid search over temporal messages, distillations, and the knowledge base, fusing:
 
 - **BM25 keyword search** over FTS5 indices, with per-column weights configurable in `search.ftsWeights` (default: title 6, content 2, category 3).
-- **Vector similarity search** using `@huggingface/transformers` + `nomic-embed-text-v1.5` (768-dim INT8 quantized, on-device by default). Hosted providers (`voyage`, `openai`) are an explicit opt-in via `search.embeddings.provider` in `.lore.json` — there is no automatic fallback from local to remote. If the local model fails to load (for example, on Linux/x64 with CUDA 13 where `onnxruntime-node` is broken), recall degrades to FTS-only with a one-time `log.info` notification.
+- **Vector similarity search** using `@huggingface/transformers` + `nomic-embed-text-v1.5` (768-dim INT8 quantized, on-device by default). The embedding model runs in a dedicated worker thread, so inference never blocks the gateway's event loop. Hosted providers (`voyage`, `openai`) are an explicit opt-in via `search.embeddings.provider` in `.lore.json` — there is no automatic fallback from local to remote. If the local model fails to load (for example, on Linux/x64 with CUDA 13 where `onnxruntime-node` is broken), recall degrades to FTS-only with a one-time `log.info` notification.
 - **LLM-based query expansion** generates 2-3 alternative phrasings of the query before search, guarded by a 3-second timeout.
 
 Results are fused with reciprocal rank fusion (RRF) and re-ranked. A query-expansion-aware boost is applied to vector results when the query has enough terms (≥2 after stopword removal) — single-term queries stay on BM25 because that's where it wins.
 
-The diagram below shows the recall pipeline. **Vector search is per-source, not a separate stage** — each of the five main sources runs both an FTS5 query and an embedding query, and both lists feed the same RRF. Cross-project LTM and `lat.md` sections are FTS-only because embeddings only cover per-project rows; they're marked with `*` in the diagram.
+The diagram below shows the recall pipeline. **Vector search is per-source, not a separate stage** — four of the five sources (LTM, distillations, temporal messages, entities) run both an FTS5 query and a vector query, and both lists feed the same RRF. Cross-project LTM and `lat.md` sections are FTS-only because embeddings only cover per-project rows. The vector scans run on a small **worker-thread pool** (default 2 workers, each with its own read-only database connection), so a large similarity scan never blocks the gateway's event loop; a scan that exceeds its timeout returns empty rather than falling back to a blocking main-thread scan.
 
 ```mermaid
-flowchart TB
-    Q["recall('query')"]:::ext
-    Q --> Expand["Pre-stage<br/>• LLM query expansion (short queries, config-gated)<br/>• Entity-aware alias expansion (always)"]:::stage
-    Expand --> Search
+flowchart LR
+    Q["recall('query')"]:::ext --> Pre["Pre-stage<br/>• query expansion (short queries, gated)<br/>• entity alias expansion (always)"]:::stage
+    Pre --> Search
 
-    subgraph Search["Parallel search — each source: FTS5 + vector*"]
-        direction LR
-        LTM["LTM (knowledge)<br/>FTS5 + vec"]:::src
-        Dist["Distillations<br/>(gen-0 + gen-1+)<br/>FTS5 + vec"]:::src
-        Temp["Temporal messages<br/>FTS5 + vec"]:::src
-        Ent["Entities<br/>FTS5 + vec"]:::src
-        Cross["Cross-project LTM<br/>FTS5 only*"]:::src
+    subgraph Search["Parallel search · every source runs at once"]
+        direction TB
+        LTM["LTM knowledge · FTS5 + vector"]:::src
+        Dist["Distillations gen-0/1+ · FTS5 + vector"]:::src
+        Temp["Temporal messages · FTS5 + vector"]:::src
+        Ent["Entities · FTS5 + vector"]:::src
+        Cross["Cross-project LTM · FTS5 only"]:::srcf
     end
 
-    Search --> RRF["RRF fusion<br/>(12+ lists)"]:::stage
-    RRF --> Rank["Hybrid rank + budget cap"]:::stage
-    Rank --> Out["Tool result markdown<br/>injected via tool_use"]:::stage
+    Pool["vector scans run on a<br/>worker-thread pool<br/>(off the event loop)"]:::note -.-> Search
 
-    Out --> Map["source_id maps back to raw:"]:::map
-    Map --> D["d:* → distillation → temporal_messages"]
-    Map --> T["t:* → temporal_messages (raw conversation)"]
-    Map --> K["k:* → knowledge (standalone, no raw)"]
-    Map --> E["e:* → entity (canonical + aliases)"]
+    Search --> RRF["RRF fusion<br/>up to 14 lists"]:::stage --> Rank["Hybrid rank<br/>+ budget cap"]:::stage --> Out["Tool-result<br/>markdown"]:::stage
+
+    Out --> Map["source_id → raw<br/>d: distillation → temporal · t: temporal (raw)<br/>k: knowledge (standalone) · e: entity (name + aliases)"]:::map
 
     classDef ext fill:#ececec,stroke:#888,color:#333
     classDef stage fill:#c4ddc7,stroke:#1a3320,color:#1a3320
-    classDef src fill:#f7f2e8,stroke:#5a8f63,color:#1a3320
-    classDef map fill:#8fba96,stroke:#1a3320,color:#1a3320
+    classDef src fill:#8fba96,stroke:#1a3320,color:#1a3320
+    classDef srcf fill:#f7f2e8,stroke:#5a8f63,color:#1a3320
+    classDef map fill:#ececec,stroke:#888,color:#333
+    classDef note fill:#ffffff,stroke:#5a8f63,color:#1a3320
 ```
 
-`*` Cross-project LTM and `lat.md` sections are FTS-only — embeddings only cover per-project rows. The recall tool downweights cross-project LTM BM25 (factor 0.6) when session-specific results exist, so current-session context ranks above general cross-project knowledge.
+When the scope is `all` and the session already has its own results, recall downweights the knowledge BM25 list (factor 0.6) so current-session context — distillations and temporal messages — ranks above general curated knowledge.
 
 ## What this means in practice
 

--- a/packages/website/src/content/docs/docs/architecture.md
+++ b/packages/website/src/content/docs/docs/architecture.md
@@ -9,41 +9,22 @@ Lore treats context management and memory as one pipeline. The same gradient eng
 
 ## Where Lore fits in the stack
 
-Lore is a **transparent HTTP proxy** that sits between a coding agent and its upstream LLM provider. Every supported agent — Claude Code, Codex, OpenCode, Pi, or Hermes — already speaks one of the standard LLM HTTP APIs (Anthropic's `/v1/messages`, OpenAI's `/v1/chat/completions` and `/v1/responses`, Codex's `/v1/codex/responses`). Lore redirects those requests to its own gateway, where the conversation is parsed, persisted, and transformed before being forwarded to the real upstream. The agent never knows it's there.
+Lore is a **transparent HTTP proxy** that sits between an AI harness and its upstream LLM provider. Every supported harness — Claude Code, Codex, OpenCode, Pi, or Hermes — already speaks one of the standard LLM HTTP APIs (Anthropic's `/v1/messages`, OpenAI's `/v1/chat/completions` and `/v1/responses`, Codex's `/v1/codex/responses`). Lore redirects those requests to its own gateway, where the conversation is parsed, persisted, and transformed before being forwarded to the real upstream. The agent never knows it's there.
 
-This position is deliberate. It means Lore is **agent-agnostic by construction** — any new agent that uses one of those HTTP APIs gets the full memory pipeline for free, with no per-agent SDK. It also means every conversation is captured exactly once, at the only place where it exists as structured LLM traffic: the request itself.
+This position is deliberate. It means Lore is **agent-agnostic by construction** — any new harness that uses one of those HTTP APIs gets the full memory pipeline for free, with no per-harness SDK. It also means every conversation is captured exactly once, at the only place where it exists as structured LLM traffic: the request itself.
+
+Existing AI harnesses are also **closed ecosystems**: Claude Code, Codex, and the others don't expose their internals to plugins in a way that lets an external tool actively manage context mid-conversation. Sitting at the HTTP boundary — the one place these harnesses must cross to talk to a model — is the only viable integration point that works with every harness, current and future. It's also the only way to stay portable: switching harnesses doesn't lose your memory, because Lore lives below them, not inside.
 
 ```mermaid
-flowchart TD
-    User([Developer]) --> Agent["Coding Agent<br/>Claude Code · Codex · OpenCode · Pi · Hermes"]
-
-    Agent -->|"LLM API request"| Adapter{How Lore gets the request}
-
-    Adapter -->|"Plugin + fetch interceptor"| P1["@loreai/opencode<br/>@loreai/pi"]
-    Adapter -->|"Env var / CLI flag"| P2["ANTHROPIC_BASE_URL<br/>OPENAI_BASE_URL · codex -c<br/>gateway/src/cli/agents.ts"]
-
-    P1 --> Gateway
-    P2 --> Gateway
-
-    subgraph Lore["Lore Gateway — sits in the LLM data path"]
-        direction TB
-        Gateway["HTTP proxy · :3207<br/>/v1/messages · /v1/chat/completions<br/>/v1/responses · /v1/codex/responses"]
-        Gateway --> Parse["Protocol parser"]
-        Parse --> Engine["Memory engine<br/>Tier 1 · Tier 2 · Tier 3 · Gradient"]
-        Engine --> Transform["Provider-agnostic transformer<br/>gradient.transform"]
-    end
-
-    Transform -->|"Lore-shaped request"| Upstream["Upstream LLM provider<br/>Anthropic · OpenAI · vLLM · Ollama"]
-    Upstream -->|"Response"| Transform
-
-    Engine -. "idle 30s · in-flight" .-> SQLite[("SQLite + FTS5<br/>~/.local/share/lore/lore.db")]
+flowchart LR
+    User([User]) --> Harness["AI Harness"]
+    Harness --> Gateway["Lore Gateway"]
+    Gateway --> Upstream["Upstream LLM Provider"]
 
     classDef lore fill:#c4ddc7,stroke:#1a3320,stroke-width:2px,color:#1a3320
-    classDef agent fill:#f7f2e8,stroke:#5a8f63,color:#1a3320
     classDef ext fill:#ececec,stroke:#888,color:#333
-    class Gateway,Parse,Engine,Transform,SQLite lore
-    class Agent,User,Adapter,P1,P2 agent
-    class Upstream ext
+    class Gateway lore
+    class User,Harness,Upstream ext
 ```
 
 The supported agents reach the proxy through one of three mechanisms:

--- a/packages/website/src/content/docs/docs/architecture.md
+++ b/packages/website/src/content/docs/docs/architecture.md
@@ -7,6 +7,142 @@ sidebar:
 
 Lore treats context management and memory as one pipeline. The same gradient engine that decides what to put in the prompt also decides when to distill, when to compress, and when to bust the cache — balancing detail preservation against cost on every turn.
 
+## Where Lore fits in the stack
+
+Lore is a **transparent HTTP proxy** that sits between a coding agent and its upstream LLM provider. Every supported agent — Claude Code, Codex, OpenCode, Pi, or Hermes — already speaks one of the standard LLM HTTP APIs (Anthropic's `/v1/messages`, OpenAI's `/v1/chat/completions` and `/v1/responses`, Codex's `/v1/codex/responses`). Lore redirects those requests to its own gateway, where the conversation is parsed, persisted, and transformed before being forwarded to the real upstream. The agent never knows it's there.
+
+This position is deliberate. It means Lore is **agent-agnostic by construction** — any new agent that uses one of those HTTP APIs gets the full memory pipeline for free, with no per-agent SDK. It also means every conversation is captured exactly once, at the only place where it exists as structured LLM traffic: the request itself.
+
+```mermaid
+flowchart TD
+    User([Developer]) --> Agent["Coding Agent<br/>Claude Code · Codex · OpenCode · Pi · Hermes"]
+
+    Agent -->|"LLM API request"| Adapter{How Lore gets the request}
+
+    Adapter -->|"Plugin + fetch interceptor"| P1["@loreai/opencode<br/>@loreai/pi"]
+    Adapter -->|"Env var / CLI flag"| P2["ANTHROPIC_BASE_URL<br/>OPENAI_BASE_URL · codex -c<br/>gateway/src/cli/agents.ts"]
+
+    P1 --> Gateway
+    P2 --> Gateway
+
+    subgraph Lore["Lore Gateway — sits in the LLM data path"]
+        direction TB
+        Gateway["HTTP proxy · :3207<br/>/v1/messages · /v1/chat/completions<br/>/v1/responses · /v1/codex/responses"]
+        Gateway --> Parse["Protocol parser"]
+        Parse --> Engine["Memory engine<br/>Tier 1 · Tier 2 · Tier 3 · Gradient"]
+        Engine --> Transform["Provider-agnostic transformer<br/>gradient.transform"]
+    end
+
+    Transform -->|"Lore-shaped request"| Upstream["Upstream LLM provider<br/>Anthropic · OpenAI · vLLM · Ollama"]
+    Upstream -->|"Response"| Transform
+
+    Engine -. "idle 30s · in-flight" .-> SQLite[("SQLite + FTS5<br/>~/.local/share/lore/lore.db")]
+
+    classDef lore fill:#c4ddc7,stroke:#1a3320,stroke-width:2px,color:#1a3320
+    classDef agent fill:#f7f2e8,stroke:#5a8f63,color:#1a3320
+    classDef ext fill:#ececec,stroke:#888,color:#333
+    class Gateway,Parse,Engine,Transform,SQLite lore
+    class Agent,User,Adapter,P1,P2 agent
+    class Upstream ext
+```
+
+The supported agents reach the proxy through one of three mechanisms:
+
+- **OpenCode and Pi** ship dedicated plugins (`@loreai/opencode`, `@loreai/pi`) that install a fetch interceptor and pin each provider's `baseURL` to the local gateway.
+- **Claude Code, Codex, and Hermes** are auto-detected by `lore run` (`gateway/src/cli/agents.ts`), which sets the right env var (`ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL`) or CLI flag (`codex -c openai_base_url=...`) for that agent's SDK.
+- **Anything else** that reads `baseURL` from environment can be pointed at the gateway manually.
+
+## How context and knowledge flow through Lore
+
+Once a request lands in the gateway, two flows kick off in parallel: a **request path** that runs on every LLM call and shapes the prompt, and a **knowledge path** that runs on an idle tick (every 30s) and consolidates the conversation into long-term memory. The diagram below shows both. Solid arrows are synchronous within a single request; dotted arrows are async, decoupled from any specific turn.
+
+```mermaid
+flowchart TB
+    subgraph Sources["Sources"]
+        S1["LLM traffic from agent"]
+        S2[".lore.md / AGENTS.md<br/>startup + file watcher"]
+        S3["lore import CLI<br/>7 providers, one-time history"]
+    end
+
+    subgraph Ingress["Ingress"]
+        I1["Protocol parser<br/>Anthropic / OpenAI / Responses / Codex"]
+    end
+
+    subgraph T1["Tier 1 — Temporal storage"]
+        TT["temporal.store"]
+        DB1[("temporal_messages<br/>+ FTS5")]
+    end
+
+    subgraph Realtime["Real-time request path"]
+        G0["L0 passthrough"]
+        G1["L1 distilled prefix + raw tail"]
+        G2["L2 strip old tool outputs"]
+        G3["L3 strip all tool outputs"]
+        G4["L4 emergency"]
+        SP["3-block system prompt<br/>system 0/1/2 + cache_control"]
+        RC["recall tool · 6 RRF sources"]
+        UP["Upstream LLM call"]
+        Resp["Response to agent"]
+    end
+
+    subgraph T2["Tier 2 — Distillation"]
+        DR["distillation.run"]
+        OB["LLM observer · gen-0"]
+        DB2[("distillations gen-0<br/>archived")]
+        MD["metaDistill"]
+        DB3[("distillations gen-1+")]
+    end
+
+    subgraph T3["Tier 3 — Long-term knowledge"]
+        CR["curator.run · LLM"]
+        PE["pattern-extract · regex"]
+        DB4[("knowledge + entities")]
+        EX["exportLoreFile"]
+        F4[".lore.md +<br/>AGENTS.md pointer"]
+    end
+
+    S1 --> I1
+    S2 -. "startup / on edit" .-> DB4
+    S3 -. "one-time" .-> DB4
+
+    I1 --> TT
+    TT --> DB1
+    I1 --> G0
+    G0 --> G1 --> G2 --> G3 --> G4
+    G4 --> SP
+    SP --> RC
+    RC --> UP
+    UP --> Resp
+
+    DB1 -. "idle · in-flight" .-> DR
+    DR --> OB
+    OB --> DB2
+    DB2 --> MD
+    MD --> DB3
+    DB2 -. "prefix for L1+" .-> G1
+
+    DB1 -. "periodic" .-> CR
+    OB -. "periodic" .-> CR
+    CR --> DB4
+    PE --> DB4
+    DB4 --> EX
+    EX --> F4
+    DB4 -. "forSession · hybrid vector + FTS5" .-> SP
+
+    classDef t1 fill:#c4ddc7,stroke:#1a3320,color:#1a3320
+    classDef t2 fill:#8fba96,stroke:#1a3320,color:#1a3320
+    classDef t3 fill:#5a8f63,stroke:#fff
+    classDef rt fill:#f7f2e8,stroke:#5a8f63,color:#1a3320
+    classDef src fill:#ececec,stroke:#888,color:#333
+    class TT,DB1 t1
+    class DR,OB,DB2,MD,DB3 t2
+    class CR,PE,DB4,EX,F4 t3
+    class G0,G1,G2,G3,G4,SP,RC,UP,Resp rt
+    class S1,S2,S3,I1 src
+```
+
+The two paths converge at the upstream call: the request path assembles the prompt that the model actually sees (gradient-compressed messages + a 3-block system prompt with the most relevant knowledge entries + the recall tool), and the knowledge path quietly feeds the inputs that make that prompt useful in the first place. The sections below walk through each tier and each layer in detail.
+
 ## Three-tier memory
 
 ### Tier 1 — Temporal storage

--- a/packages/website/src/content/docs/docs/architecture.md
+++ b/packages/website/src/content/docs/docs/architecture.md
@@ -39,36 +39,26 @@ Once a request lands in the gateway, two flows kick off in parallel: a **request
 
 **System + LTM + Meta-Distillations + Distillations + Delta Updates + Conversation**
 
+They stack into one contiguous prompt, read top to bottom — the cache-stable blocks on top (green is the LTM cache-write anchor), the volatile message tail at the bottom:
+
 ```mermaid
-%%{init: {"flowchart": {"nodeSpacing": 22, "rankSpacing": 6, "padding": 14}}}%%
-flowchart TB
-    subgraph Sources["Three-tier memory · sources"]
-        direction LR
-        T1["Tier 1 · Temporal<br/>raw messages"]:::tier
-        T2["Tier 2 · Distillation<br/>gen-0 + gen-1+"]:::tier
-        T3["Tier 3 · LTM<br/>curated knowledge"]:::tier
-        T1 ~~~ T2 ~~~ T3
-    end
-
-    subgraph Stack["What the model sees · one stacked prompt, top → bottom"]
-        direction TB
-        B1["System — system[0]<br/>harness rules + Lore identity · cache-stable"]:::sys
-        B2["LTM — system[1]<br/>preferences · entities · knowledge catalog<br/>frozen baseline, cached 1h · cache-write anchor"]:::pinned
-        B3["LTM — system[2]<br/>context-bound entries · diff-pinned, 5m cache"]:::pinned
-        B4["Meta-Distillations + Distillations<br/>distilled prefix at the head of the messages"]:::distill
-        B5["Delta Updates<br/>knowledge deltas in the tail · volatile"]:::tail
-        B6["Conversation<br/>raw message tail"]:::tail
-        B1 ~~~ B2 ~~~ B3 ~~~ B4 ~~~ B5 ~~~ B6
-    end
-
-    Sources --> Stack --> Call["Upstream LLM call"]:::ext
-
-    classDef tier fill:#f7f2e8,stroke:#5a8f63,color:#1a3320
-    classDef sys fill:#ececec,stroke:#888,color:#333
-    classDef pinned fill:#8fba96,stroke:#1a3320,color:#1a3320
-    classDef distill fill:#c4ddc7,stroke:#1a3320,color:#1a3320
-    classDef tail fill:#ececec,stroke:#888,color:#333
-    classDef ext fill:#ececec,stroke:#888,color:#333
+block-beta
+  columns 1
+  B1["System · system[0]<br/>harness rules + Lore identity · cache-stable"]
+  B2["LTM · system[1]<br/>preferences · entities · knowledge catalog<br/>frozen baseline, cached 1h · cache-write anchor"]
+  B3["LTM · system[2]<br/>context-bound entries · diff-pinned, 5m cache"]
+  B4["Meta-Distillations + Distillations<br/>distilled prefix at the head of the messages"]
+  B5["Delta Updates<br/>knowledge deltas in the tail · volatile"]
+  B6["Conversation<br/>raw message tail · volatile"]
+  classDef sys fill:#ececec,stroke:#888,color:#333
+  classDef pinned fill:#8fba96,stroke:#1a3320,color:#1a3320
+  classDef distill fill:#c4ddc7,stroke:#1a3320,color:#1a3320
+  class B1 sys
+  class B2 pinned
+  class B3 pinned
+  class B4 distill
+  class B5 sys
+  class B6 sys
 ```
 
 The formula's parts map onto the wire in the order the model reads them. **System** is `system[0]` — the harness rules and Lore's identity, cache-stable. **LTM** spans two system blocks: `system[1]` holds the stable baseline (preferences, known entities, and a knowledge catalog), frozen for the session and cached at a 1-hour TTL — it's the cache-write anchor — while `system[2]` holds the context-bound entries, re-pinned only when they materially change (see the [LTM pin invariant](#the-ltm-pin-frozen-baseline) below). **Meta-Distillations** and **Distillations** are not a system block at all: they ride at the head of the message array as a distilled prefix, kept byte-stable so appending a new turn stays cheap. **Delta Updates** and **Conversation** fill the rest of the message tail (volatile, ID-referenced, not cache-stable). The gradient's job is to compose these pieces within the context-window budget on every turn; the next section zooms in on that composition.

--- a/packages/website/src/content/docs/docs/architecture.md
+++ b/packages/website/src/content/docs/docs/architecture.md
@@ -35,94 +35,51 @@ The supported agents reach the proxy through one of three mechanisms:
 
 ## How context and knowledge flow through Lore
 
-Once a request lands in the gateway, two flows kick off in parallel: a **request path** that runs on every LLM call and shapes the prompt, and a **knowledge path** that runs on an idle tick (every 30s) and consolidates the conversation into long-term memory. The diagram below shows both. Solid arrows are synchronous within a single request; dotted arrows are async, decoupled from any specific turn.
+Once a request lands in the gateway, two flows kick off in parallel: a **request path** that runs on every LLM call and shapes the prompt, and a **knowledge path** that runs on an idle tick and consolidates the conversation into long-term memory. The diagram below ties both flows to a single formula — the six things every LLM call sees, regardless of what triggered it:
+
+**System + LTM + Meta-Distillations + Distillations + Delta Updates + Conversation**
 
 ```mermaid
-flowchart TB
-    subgraph Sources["Sources"]
-        S1["LLM traffic from agent"]
-        S2[".lore.md / AGENTS.md<br/>startup + file watcher"]
-        S3["lore import CLI<br/>7 providers, one-time history"]
+flowchart LR
+    subgraph Tiers["Sources — three-tier memory"]
+        direction TB
+        T1["Tier 1 — Temporal<br/>raw messages"]
+        T2["Tier 2 — Distillation<br/>gen-0 + gen-1+"]
+        T3["Tier 3 — LTM<br/>curated knowledge"]
     end
 
-    subgraph Ingress["Ingress"]
-        I1["Protocol parser<br/>Anthropic / OpenAI / Responses / Codex"]
+    G["Gradient context manager<br/>L0–L4 · cost-aware caps<br/>3-block system prompt"]:::gradient
+
+    subgraph Formula["The formula — what the model sees"]
+        direction TB
+        S0["System<br/>(harness rules, base)"]:::prompt
+        L["LTM<br/>(pinned entries)"]:::pinned
+        M["Meta-Distillations<br/>(gen-1+ summaries)"]:::distill
+        D["Distillations<br/>(gen-0 observations)"]:::distill
+        DU["Delta Updates<br/>(volatile channel)"]:::tail
+        C["Conversation<br/>(raw tail)"]:::tail
     end
 
-    subgraph T1["Tier 1 — Temporal storage"]
-        TT["temporal.store"]
-        DB1[("temporal_messages<br/>+ FTS5")]
-    end
+    T1 --> C
+    T1 -. "volatile" .-> DU
+    T2 --> M
+    T2 --> D
+    T3 --> L
+    Base["Lore identity<br/>(system base)"]:::neutral --> S0
+    G --> Formula
+    Tiers --> G
 
-    subgraph Realtime["Real-time request path"]
-        G0["L0 passthrough"]
-        G1["L1 distilled prefix + raw tail"]
-        G2["L2 strip old tool outputs"]
-        G3["L3 strip all tool outputs"]
-        G4["L4 emergency"]
-        SP["3-block system prompt<br/>system 0/1/2 + cache_control"]
-        RC["recall tool · 6 RRF sources"]
-        UP["Upstream LLM call"]
-        Resp["Response to agent"]
-    end
+    Formula --> Call[Upstream LLM call]
 
-    subgraph T2["Tier 2 — Distillation"]
-        DR["distillation.run"]
-        OB["LLM observer · gen-0"]
-        DB2[("distillations gen-0<br/>archived")]
-        MD["metaDistill"]
-        DB3[("distillations gen-1+")]
-    end
-
-    subgraph T3["Tier 3 — Long-term knowledge"]
-        CR["curator.run · LLM"]
-        PE["pattern-extract · regex"]
-        DB4[("knowledge + entities")]
-        EX["exportLoreFile"]
-        F4[".lore.md +<br/>AGENTS.md pointer"]
-    end
-
-    S1 --> I1
-    S2 -. "startup / on edit" .-> DB4
-    S3 -. "one-time" .-> DB4
-
-    I1 --> TT
-    TT --> DB1
-    I1 --> G0
-    G0 --> G1 --> G2 --> G3 --> G4
-    G4 --> SP
-    SP --> RC
-    RC --> UP
-    UP --> Resp
-
-    DB1 -. "idle · in-flight" .-> DR
-    DR --> OB
-    OB --> DB2
-    DB2 --> MD
-    MD --> DB3
-    DB2 -. "prefix for L1+" .-> G1
-
-    DB1 -. "periodic" .-> CR
-    OB -. "periodic" .-> CR
-    CR --> DB4
-    PE --> DB4
-    DB4 --> EX
-    EX --> F4
-    DB4 -. "forSession · hybrid vector + FTS5" .-> SP
-
-    classDef t1 fill:#c4ddc7,stroke:#1a3320,color:#1a3320
-    classDef t2 fill:#8fba96,stroke:#1a3320,color:#1a3320
-    classDef t3 fill:#5a8f63,stroke:#fff
-    classDef rt fill:#f7f2e8,stroke:#5a8f63,color:#1a3320
-    classDef src fill:#ececec,stroke:#888,color:#333
-    class TT,DB1 t1
-    class DR,OB,DB2,MD,DB3 t2
-    class CR,PE,DB4,EX,F4 t3
-    class G0,G1,G2,G3,G4,SP,RC,UP,Resp rt
-    class S1,S2,S3,I1 src
+    classDef gradient fill:#c4ddc7,stroke:#1a3320,stroke-width:2px,color:#1a3320
+    classDef neutral fill:#ececec,stroke:#888,color:#333
+    classDef prompt fill:#f7f2e8,stroke:#5a8f63,color:#1a3320
+    classDef pinned fill:#8fba96,stroke:#1a3320,color:#1a3320
+    classDef distill fill:#c4ddc7,stroke:#1a3320,color:#1a3320
+    classDef tail fill:#ececec,stroke:#888,color:#333
 ```
 
-The two paths converge at the upstream call: the request path assembles the prompt that the model actually sees (gradient-compressed messages + a 3-block system prompt with the most relevant knowledge entries + the recall tool), and the knowledge path quietly feeds the inputs that make that prompt useful in the first place. The sections below walk through each tier and each layer in detail.
+The formula's six parts map to specific prompt blocks: **System** lives in `system[0]` (cache-stable base), **LTM** in `system[2]` (frozen pin baseline — see the [LTM pin invariant](#the-ltm-pin-frozen-baseline) below), **Meta-Distillations** and **Distillations** together make up `system[1]` (the distilled prefix, the cache-write anchor for new turns), and **Delta Updates** and **Conversation** live in the conversation tail (volatile, ID-referenced, not cache-stable). The gradient's job is to compose these six pieces within the context-window budget on every turn. The next diagram zooms in on that composition.
 
 ## Three-tier memory
 
@@ -138,6 +95,52 @@ Conversation segments are distilled into observation logs by an LLM observer. Di
 
 Durable project facts — decisions, patterns, preferences, gotchas — are curated into long-term memory. The curator is an LLM call that runs on idle or after a configurable number of turns. Curated knowledge can be exported to `.lore.md` and reviewed in pull requests, so team knowledge moves with the code, not in a private database.
 
+#### Long-term knowledge structure
+
+The LTM table stores five categories of curated entries, each available in two scopes — **per-project** (the default, scoped to the working directory) and **cross-project** (`cross_project: true`, available across every project the gateway sees). The recall tool searches per-project first and falls back to cross-project results when scope is `all`. **Entities** are a sibling concept: a knowledge graph (canonical names, aliases, relations) maintained by the sync engine, not an LTM category. The recall tool searches them alongside LTM, distillations, and temporal messages.
+
+```mermaid
+flowchart LR
+    subgraph PerProject["Per-project (knowledge)"]
+        direction TB
+        P1[Decisions]:::cat
+        P2[Patterns]:::cat
+        P3[Preferences]:::cat
+        P4[Architecture]:::cat
+        P5[Gotchas]:::cat
+    end
+
+    subgraph Cross["Cross-project (cross_project=true)"]
+        direction TB
+        C1[Decisions]:::cross
+        C2[Patterns]:::cross
+        C3[Preferences]:::cross
+        C4[Architecture]:::cross
+        C5[Gotchas]:::cross
+    end
+
+    subgraph Entities["Entities (sync engine)"]
+        direction TB
+        E1[Canonical names]:::ent
+        E2[Aliases]:::ent
+        E3[Relations]:::ent
+    end
+
+    Sources["curator · pattern-extract · file import"]:::src --> PerProject
+    Sources --> Cross
+    Sources --> Entities
+
+    Search["recall tool<br/>(parallel search)"]:::search --> PerProject
+    Search --> Cross
+    Search --> Entities
+
+    classDef cat fill:#c4ddc7,stroke:#1a3320,color:#1a3320
+    classDef cross fill:#8fba96,stroke:#1a3320,color:#1a3320
+    classDef ent fill:#f7f2e8,stroke:#5a8f63,color:#1a3320
+    classDef src fill:#ececec,stroke:#888,color:#333
+    classDef search fill:#c4ddc7,stroke:#1a3320,stroke-width:2px,color:#1a3320
+```
+
 ## Gradient context manager
 
 The gradient context manager is what makes Lore different from a summarization wrapper. It is a four-layer system that decides — on **every turn** — how much of each tier to include in the next request, balancing detail preservation against prompt-cache cost.
@@ -150,6 +153,47 @@ The gradient context manager is what makes Lore different from a summarization w
 | **3** | Distilled prefix + raw window with all tool outputs stripped + only the 5 most-recent gen-0 distillations retained | Emergency compression. The 5 most recent gen-0 segments retain full detail in the prefix; older distillations are consolidated by the meta-distillation pass. |
 
 The escalation between layers is automatic. The 0→1 boundary is driven by **cost-aware context management** (see below); the 1→2 and 2→3 boundaries are driven by token-fit. There is also a per-session `forceMinLayer` floor, persisted to SQLite, that survives process restarts — when the upstream API returns "prompt is too long", the error handler sets it to the layer that fit, and the next turn starts at that layer.
+
+The diagram below shows how the four layers collapse into the 3-block system prompt — the structure the LLM actually sees. The L0–L4 layers are an *escalation ladder*: only one is active per turn, chosen by the cost-aware cap and token fit. The 3-block system prompt is the *output* of the active layer.
+
+```mermaid
+flowchart TB
+    L0["L0 passthrough<br/>full raw window<br/>cheapest per turn"]:::layer
+    L1["L1 distilled prefix + raw tail<br/>when raw no longer fits"]:::layer
+    L2["L2 strip old tool outputs<br/>last 2 turns protected"]:::layer
+    L3["L3 strip all tool outputs<br/>+ 5 most recent gen-0 in prefix"]:::layer
+    L4["L4 emergency<br/>maxed out"]:::layer
+
+    L0 --> Compose
+    L1 --> Compose
+    L2 --> Compose
+    L3 --> Compose
+    L4 --> Compose
+
+    Compose["3-block system prompt + tail<br/>(the formula)"]:::compose
+
+    subgraph Formula["System + LTM + Meta-Distillations + Distillations + Delta Updates + Conversation"]
+        direction TB
+        S0["system[0] · System<br/>(base, cache-stable)"]:::sys
+        S1["system[1] · Meta-Distillations + Distillations<br/>(distilled prefix, cache-write anchor)"]:::sys
+        S2["system[2] · LTM pin<br/>(frozen baseline, cache-stable)"]:::sys
+        DU["tail · Delta Updates<br/>(volatile, ID-referenced)"]:::tail
+        C["tail · Conversation<br/>(raw messages)"]:::tail
+    end
+
+    Compose --> Formula
+    Formula --> LLM["Upstream LLM call"]:::ext
+
+    classDef layer fill:#f7f2e8,stroke:#5a8f63,color:#1a3320
+    classDef compose fill:#c4ddc7,stroke:#1a3320,stroke-width:2px,color:#1a3320
+    classDef sys fill:#8fba96,stroke:#1a3320,color:#1a3320
+    classDef tail fill:#ececec,stroke:#888,color:#333
+    classDef ext fill:#ececec,stroke:#888,color:#333
+```
+
+#### The LTM pin frozen-baseline
+
+`system[2]` is a **pin**: the set of LTM entry keys rendered into the first system-block is captured at the moment the pin is first established and held constant for the rest of the session. Later turns re-render the *same* entry keys — even as new entries are added, edited, or curated out of the top-K — so the system-block bytes are byte-stable and the upstream prompt cache stays hot. The current rendered set advances on every turn; the pin does not. This is what makes the LTM pin cache-stable: advancing the baseline on every turn would drop earlier supersessions from the coalesced seq-0 row, busting the cache every turn and paying the cache-write price on top.
 
 ## Cost-aware context management
 
@@ -224,6 +268,41 @@ The recall tool is the escape hatch when neither the in-context prefix nor the g
 - **LLM-based query expansion** generates 2-3 alternative phrasings of the query before search, guarded by a 3-second timeout.
 
 Results are fused with reciprocal rank fusion (RRF) and re-ranked. A query-expansion-aware boost is applied to vector results when the query has enough terms (≥2 after stopword removal) — single-term queries stay on BM25 because that's where it wins.
+
+The diagram below shows the recall pipeline. **Vector search is per-source, not a separate stage** — each of the five main sources runs both an FTS5 query and an embedding query, and both lists feed the same RRF. Cross-project LTM and `lat.md` sections are FTS-only because embeddings only cover per-project rows; they're marked with `*` in the diagram.
+
+```mermaid
+flowchart TB
+    Q["recall('query')"]:::ext
+    Q --> Expand["Pre-stage<br/>• LLM query expansion (short queries, config-gated)<br/>• Entity-aware alias expansion (always)"]:::stage
+    Expand --> Search
+
+    subgraph Search["Parallel search — each source: FTS5 + vector*"]
+        direction LR
+        LTM["LTM (knowledge)<br/>FTS5 + vec"]:::src
+        Dist["Distillations<br/>(gen-0 + gen-1+)<br/>FTS5 + vec"]:::src
+        Temp["Temporal messages<br/>FTS5 + vec"]:::src
+        Ent["Entities<br/>FTS5 + vec"]:::src
+        Cross["Cross-project LTM<br/>FTS5 only*"]:::src
+    end
+
+    Search --> RRF["RRF fusion<br/>(12+ lists)"]:::stage
+    RRF --> Rank["Hybrid rank + budget cap"]:::stage
+    Rank --> Out["Tool result markdown<br/>injected via tool_use"]:::stage
+
+    Out --> Map["source_id maps back to raw:"]:::map
+    Map --> D["d:* → distillation → temporal_messages"]
+    Map --> T["t:* → temporal_messages (raw conversation)"]
+    Map --> K["k:* → knowledge (standalone, no raw)"]
+    Map --> E["e:* → entity (canonical + aliases)"]
+
+    classDef ext fill:#ececec,stroke:#888,color:#333
+    classDef stage fill:#c4ddc7,stroke:#1a3320,color:#1a3320
+    classDef src fill:#f7f2e8,stroke:#5a8f63,color:#1a3320
+    classDef map fill:#8fba96,stroke:#1a3320,color:#1a3320
+```
+
+`*` Cross-project LTM and `lat.md` sections are FTS-only — embeddings only cover per-project rows. The recall tool downweights cross-project LTM BM25 (factor 0.6) when session-specific results exist, so current-session context ranks above general cross-project knowledge.
 
 ## What this means in practice
 

--- a/packages/website/src/content/docs/docs/architecture.md
+++ b/packages/website/src/content/docs/docs/architecture.md
@@ -40,15 +40,15 @@ Once a request lands in the gateway, two flows kick off in parallel: a **request
 **System + LTM + Meta-Distillations + Distillations + Delta Updates + Conversation**
 
 ```mermaid
+%%{init: {"flowchart": {"nodeSpacing": 22, "rankSpacing": 14}}}%%
 flowchart TB
     subgraph Sources["Three-tier memory · sources"]
         direction LR
         T1["Tier 1 · Temporal<br/>raw messages"]:::tier
         T2["Tier 2 · Distillation<br/>gen-0 + gen-1+"]:::tier
         T3["Tier 3 · LTM<br/>curated knowledge"]:::tier
+        T1 ~~~ T2 ~~~ T3
     end
-
-    G["Gradient context manager<br/>picks a layer and composes the prompt<br/>within the cost-aware budget, every turn"]:::gradient
 
     subgraph Stack["What the model sees · one stacked prompt, top → bottom"]
         direction TB
@@ -58,13 +58,12 @@ flowchart TB
         B4["Meta-Distillations + Distillations<br/>distilled prefix at the head of the messages"]:::distill
         B5["Delta Updates<br/>knowledge deltas in the tail · volatile"]:::tail
         B6["Conversation<br/>raw message tail"]:::tail
-        B1 --- B2 --- B3 --- B4 --- B5 --- B6
+        B1 ~~~ B2 ~~~ B3 ~~~ B4 ~~~ B5 ~~~ B6
     end
 
-    Sources --> G --> Stack --> Call["Upstream LLM call"]:::ext
+    Sources --> Stack --> Call["Upstream LLM call"]:::ext
 
     classDef tier fill:#f7f2e8,stroke:#5a8f63,color:#1a3320
-    classDef gradient fill:#c4ddc7,stroke:#1a3320,stroke-width:2px,color:#1a3320
     classDef sys fill:#ececec,stroke:#888,color:#333
     classDef pinned fill:#8fba96,stroke:#1a3320,color:#1a3320
     classDef distill fill:#c4ddc7,stroke:#1a3320,color:#1a3320
@@ -247,23 +246,23 @@ Results are fused with reciprocal rank fusion (RRF) and re-ranked. A query-expan
 The diagram below shows the recall pipeline. **Vector search is per-source, not a separate stage** — four of the five sources (LTM, distillations, temporal messages, entities) run both an FTS5 query and a vector query, and both lists feed the same RRF. Cross-project LTM and `lat.md` sections are FTS-only because embeddings only cover per-project rows. The vector scans run on a small **worker-thread pool** (default 2 workers, each with its own read-only database connection), so a large similarity scan never blocks the gateway's event loop; a scan that exceeds its timeout returns empty rather than falling back to a blocking main-thread scan.
 
 ```mermaid
-flowchart LR
-    Q["recall('query')"]:::ext --> Pre["Pre-stage<br/>• query expansion (short queries, gated)<br/>• entity alias expansion (always)"]:::stage
+flowchart TB
+    Q["recall('query')"]:::ext --> Pre["Pre-stage<br/>• query expansion · short queries, gated<br/>• entity alias expansion · always"]:::stage
     Pre --> Search
+    Note["vector scans run on a worker-thread pool<br/>off the event loop"]:::note -.-> Search
 
     subgraph Search["Parallel search · every source runs at once"]
-        direction TB
-        LTM["LTM knowledge · FTS5 + vector"]:::src
-        Dist["Distillations gen-0/1+ · FTS5 + vector"]:::src
-        Temp["Temporal messages · FTS5 + vector"]:::src
-        Ent["Entities · FTS5 + vector"]:::src
-        Cross["Cross-project LTM · FTS5 only"]:::srcf
+        direction LR
+        LTM["LTM knowledge<br/>FTS5 + vector"]:::src
+        Dist["Distillations gen-0/1+<br/>FTS5 + vector"]:::src
+        Temp["Temporal messages<br/>FTS5 + vector"]:::src
+        Ent["Entities<br/>FTS5 + vector"]:::src
+        Cross["Cross-project LTM<br/>FTS5 only"]:::srcf
     end
 
-    Pool["vector scans run on a<br/>worker-thread pool<br/>(off the event loop)"]:::note -.-> Search
-
-    Search --> RRF["RRF fusion<br/>up to 14 lists"]:::stage --> Rank["Hybrid rank<br/>+ budget cap"]:::stage --> Out["Tool-result<br/>markdown"]:::stage
-
+    Search --> RRF["RRF fusion · up to 14 lists"]:::stage
+    RRF --> Rank["Hybrid rank · + budget cap"]:::stage
+    Rank --> Out["Tool-result markdown"]:::stage
     Out --> Map["source_id → raw<br/>d: distillation → temporal · t: temporal (raw)<br/>k: knowledge (standalone) · e: entity (name + aliases)"]:::map
 
     classDef ext fill:#ececec,stroke:#888,color:#333

--- a/packages/website/src/content/docs/docs/architecture.md
+++ b/packages/website/src/content/docs/docs/architecture.md
@@ -243,7 +243,7 @@ The recall tool is the escape hatch when neither the in-context prefix nor the g
 
 Results are fused with reciprocal rank fusion (RRF) and re-ranked. A query-expansion-aware boost is applied to vector results when the query has enough terms (≥2 after stopword removal) — single-term queries stay on BM25 because that's where it wins.
 
-The diagram below shows the recall pipeline. **Vector search is per-source, not a separate stage** — four of the five sources (LTM, distillations, temporal messages, entities) run both an FTS5 query and a vector query, and both lists feed the same RRF. Cross-project LTM and `lat.md` sections are FTS-only because embeddings only cover per-project rows. The vector scans run on a small **worker-thread pool** (default 2 workers, each with its own read-only database connection), so a large similarity scan never blocks the gateway's event loop; a scan that exceeds its timeout returns empty rather than falling back to a blocking main-thread scan.
+The diagram below shows the recall pipeline. **Vector search is per-source, not a separate stage** — four of the five sources shown (LTM, distillations, temporal messages, entities) run both an FTS5 query and a vector query, and both lists feed the same RRF. The fifth — cross-project LTM — plus the `lat.md` sections are FTS-only, because the vector index only covers the current project's rows. The vector scans run on a small **worker-thread pool** (default 2 workers, each with its own read-only database connection), so a large similarity scan never blocks the gateway's event loop; a scan that exceeds its timeout returns empty rather than falling back to a blocking main-thread scan.
 
 ```mermaid
 flowchart TB
@@ -277,4 +277,4 @@ When the scope is `all` and the session already has its own results, recall down
 
 ## What this means in practice
 
-You should not have to think about context management. The gradient engine handles layer escalation, the cost-aware cap keeps you in the cheap layer for as long as possible, distillation preserves the details that summaries lose, and the recall tool gives you a way out when none of the layers have what you need. The settings that *are* worth tuning (cost targets, distillation thresholds, embedding provider) are surfaced in the [configuration reference](/docs/configuration/).
+You should not have to think about context management. The gradient engine handles layer escalation, the cost-aware cap keeps you in the cheap layer for as long as possible, distillation preserves the details that summaries lose, and the recall tool gives you a way out when none of the layers have what you need. The settings that *are* worth tuning (cost targets, distillation thresholds, embedding provider) are surfaced in the [configuration reference](../configuration/).

--- a/packages/website/src/content/docs/docs/architecture.md
+++ b/packages/website/src/content/docs/docs/architecture.md
@@ -40,7 +40,7 @@ Once a request lands in the gateway, two flows kick off in parallel: a **request
 **System + LTM + Meta-Distillations + Distillations + Delta Updates + Conversation**
 
 ```mermaid
-%%{init: {"flowchart": {"nodeSpacing": 22, "rankSpacing": 14}}}%%
+%%{init: {"flowchart": {"nodeSpacing": 22, "rankSpacing": 6, "padding": 14}}}%%
 flowchart TB
     subgraph Sources["Three-tier memory · sources"]
         direction LR

--- a/packages/website/src/content/docs/docs/index.md
+++ b/packages/website/src/content/docs/docs/index.md
@@ -25,6 +25,6 @@ Lore is a local-first memory layer for AI coding agents. It captures conversatio
 
 ## Site Sections
 
-- [Home](/) introduces the product and Folk Lore early access signup.
-- [Why Lore](/different/) compares Lore to memory-only and context-only approaches.
-- [Blog](/blog/) is ready for essays, release notes, and engineering writeups.
+- [Home](../) introduces the product and Folk Lore early access signup.
+- [Why Lore](../different/) compares Lore to memory-only and context-only approaches.
+- [Blog](../blog/) is ready for essays, release notes, and engineering writeups.

--- a/packages/website/src/content/docs/docs/index.md
+++ b/packages/website/src/content/docs/docs/index.md
@@ -7,11 +7,11 @@ hero:
   tagline: Persistent memory and context management for the coding agents you already use.
   actions:
     - text: Install Lore
-      link: /docs/install/
+      link: install/
       icon: right-arrow
       variant: primary
     - text: Architecture
-      link: /docs/architecture/
+      link: architecture/
       icon: open-book
 ---
 

--- a/packages/website/src/styles/starlight.css
+++ b/packages/website/src/styles/starlight.css
@@ -79,3 +79,19 @@ html[data-theme="light"] {
   font-family: "Playfair Display", Georgia, serif;
   font-weight: 400;
 }
+
+/* Mermaid diagrams (architecture page). Center, contain, and let wide
+   graphs scroll horizontally on narrow viewports without overflowing the
+   prose column. */
+.mermaid {
+  display: block;
+  text-align: center;
+  margin: 1.5rem auto;
+  max-width: 100%;
+  overflow-x: auto;
+}
+.mermaid svg {
+  display: inline-block;
+  max-width: 100%;
+  height: auto;
+}


### PR DESCRIPTION
## What

Adds Mermaid architecture diagrams to the **Architecture** docs page, plus
the homepage link fix. The diagrams have since been reworked for
readability and corrected against the current `gateway`/`core` code.

## Diagrams

Five Mermaid diagrams on `docs/architecture.md`:

1. **Where Lore fits in the stack** — the proxy position: user → harness →
   Lore gateway → upstream LLM.
2. **How context & knowledge flow** — a **vertical stacked prompt** showing
   the six things the model sees, top-to-bottom in wire order (System →
   LTM `system[1]`/`system[2]` → distilled prefix → delta updates →
   conversation).
3. **Long-term knowledge structure** — the 5 categories shown **once**, with
   per-project / cross-project as a *scope* property (no duplication), and
   entities as a sibling knowledge graph.
4. **Gradient context manager** — a top-down **escalation ladder** (color
   gradient L0→L4) labeling each trigger and what each layer strips.
5. **Recall tool** — an LR pipeline with a vertical **parallel-search** band,
   the embedding worker thread + vector-search worker pool, and a compact
   `source_id` legend.

## Accuracy fixes

Verified against `packages/{gateway,core}/src` (the prose and graphs had
drifted as the engine evolved — worker pool, layer count, prompt blocks):

- Gradient is **five layers (L0–L4)**, not four; added the L4 emergency row.
- Corrected the **formula → prompt-block mapping**: LTM spans `system[1]`
  (stable, 1h cache) and `system[2]` (context-bound, diff-pinned); the
  meta-distillations/distillations are the **distilled prefix at the head of
  the message array**, not `system[1]`.
- `SUSTAINED_BUST_THRESHOLD` is **2**, not 5.
- Layer-0 cap example: `$3/Mtok` floors to **40K**, not 33K.
- `OPENAI_BASE_URL` is set for **Hermes**, not Codex; all five agents are
  auto-detected by `lore run`.
- Documented the **embedding worker thread** and **vector-search worker
  pool** (default 2 workers, own read-only DB conn, 10s timeout → empty).
- Fixed the 0.6 knowledge-BM25 downweight attribution and the LTM-pin block
  description (`system[2]` is diff-pinned; `system[1]` is the 1h-frozen one).

## Homepage link fix

`docs/index.md` root-absolute links (`/`, `/different/`, `/blog/`) converted
to file-relative so they resolve under PR-preview `base` prefixes.

## Mermaid rendering

Mermaid 11 ESM is loaded from `cdn.jsdelivr.net` in a `head` module script
(`astro.config.mjs`); a small client init extracts each block's source from
Starlight's `expressive-code` wrapper and calls `mermaid.render()`. CSS in
`starlight.css` centers the SVGs. No new dependencies.

## Verification

- `pnpm --filter @loreai/website build` — clean.
- All five diagrams **parse** via `mermaid.parse()` (Mermaid 11 + JSDOM).
- `biome check .` — 0 errors.
- Accuracy audit performed against current source with file:line evidence.
