### PR TITLE
fix(core): stop LTM cache churn + close the cache-bust test blind spot

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -258,8 +258,24 @@ export const LoreConfig = z.object({
         .describe(
           "Max entities to inject into the agent system prompt. Set to 0 to disable. Default: 30.",
         ),
+      /** Auto-create `gotcha` knowledge entries from recurring tool failures
+       *  (same tool + error type across multiple sessions). Default false:
+       *  these entries are usually environmental noise (agent/tool flakiness,
+       *  not codebase facts), and minting them mid-session churns the selected
+       *  LTM set, which can bust the prompt cache. Opt in to surface recurring
+       *  tool-failure patterns as knowledge. */
+      autoToolFailureGotchas: z
+        .boolean()
+        .default(false)
+        .describe(
+          "Auto-create gotcha entries from recurring tool failures. Default false (noisy; can churn the LTM cache).",
+        ),
     })
-    .default({ enabled: true, maxEntityInject: 30 })
+    .default({
+      enabled: true,
+      maxEntityInject: 30,
+      autoToolFailureGotchas: false,
+    })
     .describe("Long-term knowledge (curator, entity injection) controls."),
   curator: z
     .object({

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -2294,6 +2294,38 @@ export function appendSessionPromptDelta(input: {
     );
 }
 
+/**
+ * Upsert a SINGLE coalesced prompt delta for a session, pinned to sentinel
+ * `seq = 0`, replacing any prior value in place.
+ *
+ * Unlike `appendSessionPromptDelta` (which appends a new row at MAX(seq)+1 each
+ * call), this keeps exactly one durable-delta row per session. The knowledge
+ * delta describes the CURRENT selected-vs-pinned state, so it must REPLACE the
+ * previous delta, not accumulate alongside it. Accumulating rows (each at a
+ * different insertAt as the conversation grew) inserts a new synthetic message
+ * into the cached prefix every time the knowledge set changes, shifting all
+ * later messages and busting the prompt cache. Coalescing into one row at a
+ * frozen insertAt keeps the message prefix byte-stable until the delta's
+ * CONTENT genuinely changes (one bust per real change, not a growing cascade).
+ */
+export function upsertSessionPromptDelta(input: {
+  sessionID: string;
+  projectID: string;
+  selector: string;
+  content: string;
+}): void {
+  db()
+    .query(
+      `INSERT INTO session_prompt_deltas (session_id, seq, project_id, selector, content)
+       VALUES (?, 0, ?, ?, ?)
+       ON CONFLICT(session_id, seq) DO UPDATE SET
+         project_id = excluded.project_id,
+         selector   = excluded.selector,
+         content    = excluded.content`,
+    )
+    .run(input.sessionID, input.projectID, input.selector, input.content);
+}
+
 export function listSessionPromptDeltas(
   sessionID: string,
 ): SessionPromptDelta[] {

--- a/packages/core/src/distillation.ts
+++ b/packages/core/src/distillation.ts
@@ -1233,54 +1233,60 @@ async function distillSegment(input: {
     // Tool-failure gotcha detection: a tool that fails with the same error
     // type across multiple distinct sessions is a recurring environmental or
     // usage gotcha worth surfacing as a knowledge entry.
-    try {
-      const failureStats = toolTrace.toolFailureStats(input.projectPath, {
-        minSessions: GOTCHA_MIN_SESSIONS,
-      });
-      const gotchaProjectId = ensureProject(input.projectPath);
-      for (const stat of failureStats) {
-        if (stat.failure_count < GOTCHA_MIN_FAILURES) continue;
-        const gotchaTitle = toolTrace.toolGotchaTitle(
-          stat.tool,
-          stat.error_type,
-        );
-        // Pre-check for an existing gotcha with the same title. ltm.create()
-        // dedups via the same title check, but it returns the existing ID
-        // silently — the caller can't tell whether a row was inserted or an
-        // existing one was updated. Without this pre-check, the "created
-        // gotcha" log below fires on every distill run, even when dedup
-        // collapsed the call (43+ identical lines in production for a single
-        // persistent webfetch failure pattern).
-        const existingGotcha = db()
-          .query(
-            `SELECT id FROM knowledge
+    //
+    // Off by default: these entries are usually environmental noise (agent/tool
+    // flakiness, not codebase facts), and minting them mid-session churns the
+    // selected LTM set, which can bust the prompt cache. Opt in via
+    // `knowledge.autoToolFailureGotchas`.
+    if (config().knowledge.autoToolFailureGotchas)
+      try {
+        const failureStats = toolTrace.toolFailureStats(input.projectPath, {
+          minSessions: GOTCHA_MIN_SESSIONS,
+        });
+        const gotchaProjectId = ensureProject(input.projectPath);
+        for (const stat of failureStats) {
+          if (stat.failure_count < GOTCHA_MIN_FAILURES) continue;
+          const gotchaTitle = toolTrace.toolGotchaTitle(
+            stat.tool,
+            stat.error_type,
+          );
+          // Pre-check for an existing gotcha with the same title. ltm.create()
+          // dedups via the same title check, but it returns the existing ID
+          // silently — the caller can't tell whether a row was inserted or an
+          // existing one was updated. Without this pre-check, the "created
+          // gotcha" log below fires on every distill run, even when dedup
+          // collapsed the call (43+ identical lines in production for a single
+          // persistent webfetch failure pattern).
+          const existingGotcha = db()
+            .query(
+              `SELECT id FROM knowledge
              WHERE project_id = ? AND LOWER(title) = LOWER(?) AND category = 'gotcha'
              AND confidence > 0 LIMIT 1`,
-          )
-          .get(gotchaProjectId, gotchaTitle) as { id: string } | null;
-        if (existingGotcha) continue;
-        try {
-          ltm.create({
-            projectPath: input.projectPath,
-            category: "gotcha",
-            title: gotchaTitle,
-            content: toolTrace.toolGotchaContent(stat),
-            session: input.sessionID,
-            scope: "project",
-            confidence: 0.75,
-            workerProviderID: input.model?.providerID,
-            workerModelID: input.model?.modelID,
-          });
-          log.info(
-            `tool-failure gotcha: ${stat.tool}/${stat.error_type} in ${stat.session_count} sessions — created gotcha`,
-          );
-        } catch {
-          // Dedup guard or DB error — swallow
+            )
+            .get(gotchaProjectId, gotchaTitle) as { id: string } | null;
+          if (existingGotcha) continue;
+          try {
+            ltm.create({
+              projectPath: input.projectPath,
+              category: "gotcha",
+              title: gotchaTitle,
+              content: toolTrace.toolGotchaContent(stat),
+              session: input.sessionID,
+              scope: "project",
+              confidence: 0.75,
+              workerProviderID: input.model?.providerID,
+              workerModelID: input.model?.modelID,
+            });
+            log.info(
+              `tool-failure gotcha: ${stat.tool}/${stat.error_type} in ${stat.session_count} sessions — created gotcha`,
+            );
+          } catch {
+            // Dedup guard or DB error — swallow
+          }
         }
+      } catch {
+        // Aggregation query failure is non-fatal — swallow
       }
-    } catch {
-      // Aggregation query failure is non-fatal — swallow
-    }
   }
 
   return result;

--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -96,6 +96,18 @@ let maxLayer0Tokens = 0;
 
 const MIN_LAYER0_FLOOR = 40_000;
 
+/** Quantization step for the LTM token budget (getLtmBudget). The budget is
+ *  derived from `usable`, which wobbles every turn via the per-turn overhead
+ *  EMA; snapping it to this step keeps the budget — and therefore the
+ *  ltm.forSession() greedy entry-packing boundary — stable across normal
+ *  wobble, so the selected entry set (and thus the pinned system[2] block) only
+ *  changes when knowledge genuinely changes. Without this, the lowest-ranked
+ *  pinned entry drops/re-enters as the budget drifts, churning the set and
+ *  appending a durable prompt-delta into the cached prefix every turn (a cache
+ *  bust). Sized to absorb typical per-turn overhead drift on high-context
+ *  models. */
+const LTM_BUDGET_STEP = 8_000;
+
 /** Consecutive zero-cache-write turns before treating the session as free-write. */
 const NO_CACHE_WRITE_THRESHOLD = 3;
 
@@ -642,7 +654,19 @@ export function getLtmTokens(sessionID?: string): number {
 export function getLtmBudget(ltmFraction: number): number {
   const overhead = calibratedOverhead ?? FIRST_TURN_OVERHEAD;
   const usable = Math.max(0, contextLimit - outputReserved - overhead);
-  return Math.floor(usable * ltmFraction);
+  // Quantize to a coarse step so per-turn `usable` wobble (overhead EMA drift)
+  // does not move the ltm.forSession() packing boundary and churn the pinned
+  // LTM set every turn. See LTM_BUDGET_STEP.
+  //
+  // Round to the NEAREST step (not floor) so the budget never collapses to 0
+  // when the raw budget is below one step (small-context models): a raw budget
+  // under half a step rounds up to one full step rather than to zero, and the
+  // common large-context case (raw >> step) is unaffected. This keeps the
+  // budget stable across wobble while never disabling LTM.
+  const raw = Math.floor(usable * ltmFraction);
+  if (raw <= 0) return 0;
+  const quantized = Math.round(raw / LTM_BUDGET_STEP) * LTM_BUDGET_STEP;
+  return Math.max(LTM_BUDGET_STEP, quantized);
 }
 
 /** Returns the token budget for stable LTM (preferences). Independent of context-bound LTM budget. */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -89,6 +89,7 @@ export {
   saveSessionTracking,
   loadSessionTracking,
   appendSessionPromptDelta,
+  upsertSessionPromptDelta,
   listSessionPromptDeltas,
   loadHeaderSessionIndex,
   loadParentChildMap,

--- a/packages/core/test/gradient.test.ts
+++ b/packages/core/test/gradient.test.ts
@@ -584,16 +584,85 @@ describe("gradient — LTM budget coordination", () => {
     calibrate(0); // zero overhead for these tests
   });
 
-  test("getLtmBudget returns fraction of usable context", () => {
+  test("getLtmBudget returns fraction of usable context, quantized to LTM_BUDGET_STEP", () => {
     // usable = 10_000 - 2_000 - 0 (overhead) = 8_000
-    // ltm fraction 0.10 → 800 tokens
+    // ltm fraction 0.10 → raw 800 → quantized to nearest 8_000 step, floored at
+    // one step so LTM is never disabled on small-context models → 8_000.
     const budget = getLtmBudget(0.1);
-    expect(budget).toBe(800);
+    expect(budget).toBe(8_000);
   });
 
-  test("getLtmBudget respects different fractions", () => {
-    expect(getLtmBudget(0.25)).toBe(2_000);
-    expect(getLtmBudget(0.05)).toBe(400);
+  test("getLtmBudget respects different fractions (quantized, never below one step)", () => {
+    // raw 2_000 → rounds to 0 step but floored to one step (8_000).
+    expect(getLtmBudget(0.25)).toBe(8_000);
+    // raw 400 → floored to one step (8_000).
+    expect(getLtmBudget(0.05)).toBe(8_000);
+  });
+
+  test("getLtmBudget returns 0 only when there is no usable budget", () => {
+    setModelLimits({ context: 1_000, output: 1_000 }); // usable = 0
+    calibrate(0);
+    expect(getLtmBudget(0.1)).toBe(0);
+    setModelLimits({ context: 10_000, output: 2_000 });
+    calibrate(0);
+  });
+
+  test("getLtmBudget is STABLE across per-turn overhead wobble (no LTM set churn)", () => {
+    // Regression for the LTM-delta-churn cache bust: `usable` is derived from
+    // the per-turn calibrated-overhead EMA, which wobbles every turn. If
+    // getLtmBudget passes that wobble straight through, the ltm.forSession
+    // packing boundary moves every turn → the selected LTM set changes → a new
+    // durable prompt-delta is appended into the cached message prefix → the
+    // prompt cache busts every turn. The budget must be QUANTIZED so normal
+    // overhead wobble does not move it.
+    //
+    // Large context (1M) so the absolute overhead swing is production-scale.
+    setModelLimits({ context: 1_000_000, output: 32_000 });
+    resetCalibration();
+
+    const SID = "ltm-budget-wobble-sess";
+    // Seed lastTransformEstimate via a real transform so calibrate() has a
+    // baseline to compare actualInput against.
+    const msgs = Array.from({ length: 4 }, (_, i) =>
+      makeMsg(`wobble-${i}`, i % 2 === 0 ? "user" : "assistant", "hello", SID),
+    );
+    transform({ messages: msgs, projectPath: PROJECT, sessionID: SID });
+
+    // Drive several turns whose real input swings by tens of thousands of
+    // tokens (exactly what production showed: usable swinging 940K↔797K). Each
+    // calibrate() call moves calibratedOverhead, hence `usable`, hence the raw
+    // (un-quantized) LTM budget.
+    const wobblingInputs = [
+      120_000, 260_000, 130_000, 280_000, 140_000, 250_000, 135_000,
+    ];
+    const budgets = new Set<number>();
+    for (const input of wobblingInputs) {
+      // Re-seed the transform estimate each turn so calibrate has a baseline
+      // and the overhead (actualInput - estimate) genuinely varies.
+      transform({ messages: msgs, projectPath: PROJECT, sessionID: SID });
+      calibrate(input, SID, msgs.length);
+      budgets.add(getLtmBudget(0.05));
+    }
+
+    // The fix quantizes the budget so all these wobbling turns collapse to a
+    // tiny number of distinct values. Pre-fix, every turn yields a different
+    // budget (one per distinct overhead) → set churn. We require the budget to
+    // take at most 2 distinct values across 7 wildly-varying-overhead turns.
+    expect(
+      budgets.size,
+      `LTM budget changed ${budgets.size} times across overhead wobble ` +
+        `(values=${[...budgets].join(",")}). A wobbling budget moves the ` +
+        `forSession packing boundary and churns the pinned LTM set every turn ` +
+        `(regression: LTM-delta-churn cache bust). The budget must be quantized.`,
+    ).toBeLessThanOrEqual(2);
+
+    // Restore the shared test baseline: resetCalibration() alone leaves
+    // calibratedOverhead null → getLtmBudget falls back to FIRST_TURN_OVERHEAD
+    // (15K), which would zero out usable for the small-context tests that
+    // follow. calibrate(0) pins overhead to 0 like the other tests expect.
+    resetCalibration();
+    setModelLimits({ context: 10_000, output: 2_000 });
+    calibrate(0);
   });
 
   test("setLtmTokens / getLtmTokens round-trip", () => {

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -57,7 +57,7 @@ import {
   embedding,
   saveSessionTracking,
   loadSessionTracking,
-  appendSessionPromptDelta,
+  upsertSessionPromptDelta,
   listSessionPromptDeltas,
   loadHeaderSessionIndex,
   isHostedMode,
@@ -916,7 +916,16 @@ function buildKnowledgeDeltaMessage(
   }
   rendered ??= "";
   const renderedIDSet = new Set(renderedIds);
-  const skipped = entries.filter((entry) => !renderedIDSet.has(entry.id));
+  // Sort the overflow ("Additional Changed Knowledge") deterministically by id
+  // before slicing. `entries` arrives in forSession() ranking order, which is
+  // volatile per turn (relevance scoring), so an unsorted slice could pick a
+  // different 3 entries / different order across turns → a byte-different delta
+  // even when nothing materially changed → a needless cache bust. The primary
+  // `rendered` section is already order-stabilized by formatKnowledge; this
+  // makes the overflow section byte-stable too.
+  const skipped = entries
+    .filter((entry) => !renderedIDSet.has(entry.id))
+    .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
   const skippedRendered = skipped.length
     ? `\n\n## Additional Changed Knowledge (truncated)\n\n${skipped
         .slice(0, 3)
@@ -975,14 +984,35 @@ function appendKnowledgePromptDelta(input: {
   );
   if (!message) return false;
 
-  appendSessionPromptDelta({
+  // Coalesce into a SINGLE durable-delta row (sentinel seq 0), replacing any
+  // prior delta in place rather than appending a new row each time the
+  // knowledge set changes. Appending accumulated rows at ever-larger insertAt
+  // positions, inserting a new synthetic message into the cached prefix every
+  // change → shifting all later messages → busting the prompt cache. One
+  // coalesced row at a FROZEN insertAt keeps the message prefix byte-stable
+  // until the delta's content genuinely changes.
+  //
+  // Freeze the position: reuse the already-persisted insertAt if a delta row
+  // exists, so the durable delta does not migrate as the conversation grows
+  // (which would itself shift the prefix and bust the cache). Only compute a
+  // fresh insertAt the first time.
+  const existing = listSessionPromptDeltas(input.sessionID).find(
+    (d) => d.seq === 0,
+  );
+  let insertAt = input.insertAt;
+  if (existing) {
+    const prevSelector = parseMessageInsertSelector(existing.selector);
+    if (prevSelector) insertAt = prevSelector.insertAt;
+  }
+
+  upsertSessionPromptDelta({
     sessionID: input.sessionID,
     projectID: ensureProject(input.projectPath),
-    selector: JSON.stringify({ target: "messages", insertAt: input.insertAt }),
+    selector: JSON.stringify({ target: "messages", insertAt }),
     content: JSON.stringify(message),
   });
   log.info(
-    `prompt-delta: appended knowledge update for session ${input.sessionID.slice(0, 16)} (${entries.length} entr${entries.length === 1 ? "y" : "ies"})`,
+    `prompt-delta: upserted knowledge update for session ${input.sessionID.slice(0, 16)} (${entries.length} entr${entries.length === 1 ? "y" : "ies"}, insertAt=${insertAt})`,
   );
   return true;
 }
@@ -5457,7 +5487,10 @@ async function handleConversationTurn(
           if (!cached && pinned) {
             // The fresh selection is empty, but removing the pinned system[2]
             // block would still bust the cached prefix. Preserve the exact
-            // bytes and append a durable removal delta instead.
+            // bytes and append a durable removal delta instead. Keep entryKeys
+            // frozen at the baseline (not []) so the coalesced delta describes
+            // the full frozen→current (empty) supersession — see the Layer-1
+            // material-delta note.
             pendingKnowledgeDelta = {
               previousKeys: pinned.entryKeys,
               nextKeys: [],
@@ -5472,7 +5505,7 @@ async function handleConversationTurn(
             ltmPinnedText.set(sessionID, {
               formatted: pinned.formatted,
               tokenCount: pinned.tokenCount,
-              entryKeys: [],
+              entryKeys: pinned.entryKeys,
             });
             ltmDirty = true;
             pinDirty = true;
@@ -5524,6 +5557,18 @@ async function handleConversationTurn(
             // before the conversation cache breakpoint, so changing it would
             // throw away the cached prefix. Keep the exact pinned bytes and
             // append a durable prompt delta at the conversation tail instead.
+            //
+            // CRITICAL: keep `entryKeys` frozen at the baseline that matches the
+            // pinned `formatted` bytes — do NOT advance it to cachedKeys. The
+            // durable delta is coalesced into a single row that is REPLACED each
+            // turn, so it must describe the CUMULATIVE delta between the frozen
+            // system[2] bytes and the current selection. If we advanced the
+            // baseline, the next turn's delta would only describe that turn's
+            // increment and the coalesced row would silently drop earlier
+            // supersessions (leaving stale entries pinned in system[2] with no
+            // correcting delta). The diff is recomputed from the frozen baseline
+            // every turn → re-upserting the same (frozen, current) pair yields
+            // byte-identical content (idempotent, no extra cache bust).
             pendingKnowledgeDelta = {
               previousKeys: pinned.entryKeys,
               nextKeys: cachedKeys,
@@ -5532,7 +5577,7 @@ async function handleConversationTurn(
             ltmPinnedText.set(sessionID, {
               formatted: pinned.formatted,
               tokenCount: pinned.tokenCount,
-              entryKeys: cachedKeys,
+              entryKeys: pinned.entryKeys,
             });
             ltmSessionCache.set(sessionID, {
               formatted: pinned.formatted,
@@ -5706,15 +5751,23 @@ async function handleConversationTurn(
             // Material LTM changed during emergency refresh. Preserve the exact
             // cached system[2] bytes and surface the change as a durable prompt
             // delta instead of rewriting the pre-breakpoint system block.
+            //
+            // CRITICAL: keep `entryKeys` frozen at the baseline matching the
+            // pinned bytes — do NOT advance to the current `entryKeys`. The
+            // coalesced durable delta is replaced each turn, so it must describe
+            // the CUMULATIVE delta from the frozen system[2] to the current
+            // selection; advancing the baseline would drop earlier supersessions
+            // from the single row. (See the matching note on the Layer-1 path.)
+            const frozenKeys = pinned.entryKeys;
             pendingKnowledgeDelta = {
-              previousKeys: pinned.entryKeys,
+              previousKeys: frozenKeys,
               nextKeys: entryKeys,
               entries: contextEntries,
             };
             ltmPinnedText.set(sessionID, {
               formatted: pinned.formatted,
               tokenCount: pinned.tokenCount,
-              entryKeys,
+              entryKeys: frozenKeys,
             });
             ltmSessionCache.delete(sessionID);
             ltmSessionCache.set(sessionID, {
@@ -5728,7 +5781,7 @@ async function handleConversationTurn(
               ltmCacheTokens: pinned.tokenCount,
               ltmPinText: pinned.formatted,
               ltmPinTokens: pinned.tokenCount,
-              ltmPinKeys: JSON.stringify(entryKeys),
+              ltmPinKeys: JSON.stringify(frozenKeys),
             });
           } else {
             // First Layer 4 injection — pin the new text + identity. There is no
@@ -5759,15 +5812,23 @@ async function handleConversationTurn(
           // already-cached system[2] block would still bust the prefix. Keep the
           // existing pin byte-for-byte and append a durable removal delta so the
           // model knows the older pinned entries are superseded.
+          //
+          // CRITICAL: keep entryKeys FROZEN at the baseline matching the pinned
+          // bytes — do NOT wipe to []. The coalesced durable delta is replaced
+          // each turn and must describe the full cumulative frozen→current
+          // (empty) supersession. Wiping the baseline to [] here (in memory AND
+          // persisted) makes the next turn compute previous=[]→next=[] = no
+          // removals, dropping every earlier supersession from the single row.
+          const frozenKeys = pinned.entryKeys;
           pendingKnowledgeDelta = {
-            previousKeys: pinned.entryKeys,
+            previousKeys: frozenKeys,
             nextKeys: [],
             entries: [],
           };
           ltmPinnedText.set(sessionID, {
             formatted: pinned.formatted,
             tokenCount: pinned.tokenCount,
-            entryKeys: [],
+            entryKeys: frozenKeys,
           });
           ltmSessionCache.delete(sessionID);
           ltmSessionCache.set(sessionID, {
@@ -5781,7 +5842,7 @@ async function handleConversationTurn(
             ltmCacheTokens: pinned.tokenCount,
             ltmPinText: pinned.formatted,
             ltmPinTokens: pinned.tokenCount,
-            ltmPinKeys: JSON.stringify([]),
+            ltmPinKeys: JSON.stringify(frozenKeys),
           });
           log.info(
             "Context-bound LTM refresh returned no entries; preserving existing pinned system[2] for session",

--- a/packages/gateway/test/cache-bust-oracle.e2e.test.ts
+++ b/packages/gateway/test/cache-bust-oracle.e2e.test.ts
@@ -1,0 +1,279 @@
+/**
+ * End-to-end cache-bust ORACLE tests.
+ *
+ * WHY THIS FILE EXISTS
+ * --------------------
+ * Three separate production cache-bust bugs (tier-gate, raw-window pin-march,
+ * LTM-delta-churn) all slipped past the cache-stability suite. The post-mortem
+ * root cause: replay fixtures report ZERO cache usage, so the gateway's own
+ * cache oracles (categorizeBust / recordCacheUsage / calibrate) ran blindfolded
+ * in every test — a prompt-cache bust produced no observable difference. Every
+ * existing assertion was on cache *inputs* (byte-stability of system blocks
+ * between two turns); none was on the cache *output* (read vs write) over a long
+ * driven session.
+ *
+ * These tests close that gap. They use `createHarness({ simulateCache: true })`,
+ * which computes each turn's cache_read / cache_creation from the ACTUAL
+ * upstream-body prefix stability (the way Anthropic's prompt cache behaves) and
+ * feeds it back into the response — so the gateway sees production-faithful
+ * numbers and a real bust is observable. The tests then assert on the cache
+ * OUTPUT: the steady-state write:read ratio stays low, i.e. the prompt cache is
+ * being READ, not rewritten every turn.
+ *
+ * A churning prefix (window march, mid-history delta append, system[2] rewrite)
+ * makes cache_creation dominate every turn → the ratio assertion fails. That is
+ * exactly the signal the production bust-tracker logged (write:read ≈ 12.5:1)
+ * but that no test could previously reproduce.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import type { Harness } from "./helpers/harness";
+import { createHarness } from "./helpers/harness";
+import { DEFAULT_MODEL, makeFixtureEntry } from "./helpers/fixtures";
+import type { GatewayMessage } from "../src/translate/types";
+
+let harness: Harness | undefined;
+
+afterEach(async () => {
+  const { resetCalibration } = await import("../../core/src/gradient");
+  resetCalibration();
+  await harness?.teardown();
+  harness = undefined;
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** ~1200 tokens per message so a long history overflows the budget and the
+ *  gradient pins a layer-1 sub-window. */
+function big(label: string): string {
+  return `${label} ${"lorem ipsum dolor sit amet ".repeat(170)}`;
+}
+
+function userMsg(text: string): GatewayMessage {
+  return { role: "user", content: [{ type: "text", text }] };
+}
+function asstMsg(text: string): GatewayMessage {
+  return { role: "assistant", content: [{ type: "text", text }] };
+}
+
+function makeBody(messages: GatewayMessage[]): Record<string, unknown> {
+  return {
+    model: DEFAULT_MODEL,
+    max_tokens: 1024,
+    stream: false,
+    system: "You are a helpful coding agent.",
+    messages,
+  };
+}
+
+async function observedLayer(sessionID: string): Promise<number> {
+  const { getLastLayer } = await import("../../core/src/gradient");
+  return getLastLayer(sessionID);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("cache-bust oracle (e2e)", () => {
+  it("simulated cache reports a clean read after a stable steady state", async () => {
+    // Sanity check the oracle itself: a session whose prefix is stable (only
+    // new tail messages each turn) must show high cache reads and near-zero
+    // creation after the cold-start turn. If THIS fails, the oracle is wrong.
+    const fixtures = Array.from({ length: 6 }, (_, i) =>
+      makeFixtureEntry({
+        seq: i,
+        requestMessages: [],
+        responseText: "ok",
+        model: DEFAULT_MODEL,
+        wasStreaming: false,
+      }),
+    );
+    harness = await createHarness({ fixtures, simulateCache: true });
+
+    const history: GatewayMessage[] = [];
+    for (let i = 0; i < 6; i++) {
+      history.push(userMsg(`small turn ${i}`));
+      const resp = await harness.chat(makeBody(history));
+      expect(resp.status).toBe(200);
+      await resp.json();
+      history.push(asstMsg("ok"));
+    }
+
+    const turns = harness.cacheTurns();
+    expect(turns.length).toBe(6);
+    // Turn 0 is a cold write; turn 1 (index 1) legitimately injects the
+    // context-bound LTM block (system[2]) by design, which lowers the prefix
+    // match once. Steady state is turn 2 (index 2) onward: only a tiny new tail
+    // each turn → near-full cache hit on the unchanged prefix.
+    for (let i = 3; i < turns.length; i++) {
+      expect(
+        turns[i].prefixMatch,
+        `turn ${i} prefixMatch=${turns[i].prefixMatch} (expected a near-full ` +
+          `cache hit on a stable prefix)`,
+      ).toBeGreaterThan(0.8);
+    }
+  });
+
+  it("prompt cache is READ (not rewritten) on a long compressed session with mid-session knowledge growth", async () => {
+    // Broad guardrail over the whole compressed pipeline: drive a long, large,
+    // NATURALLY-compressed (layer 1) session and, midway through, create a burst
+    // of knowledge entries (simulating the curator / tool-failure gotcha
+    // auto-mint that fueled the production churn). Assert via the SIMULATED
+    // CACHE that the steady-state prompt cache is READ, not rewritten.
+    //
+    // This catches any regression that busts the cache on (nearly) every
+    // compressed turn — raw-window pin-march, system[2] rewrite, or a
+    // durable-delta appended into the cached prefix every turn. (The narrow,
+    // deterministic reproduction of the budget-wobble LTM-churn root cause lives
+    // in the gradient unit test "getLtmBudget is STABLE across per-turn overhead
+    // wobble"; this e2e is the end-to-end safety net at the cache-output level —
+    // the level that was completely unguarded before.)
+    const TOTAL_TURNS = 16;
+    const BASE_PAIRS = 30; // ~60 base messages → well over the 40K l0cap
+
+    const fixtures = Array.from({ length: TOTAL_TURNS }, (_, i) =>
+      makeFixtureEntry({
+        seq: i,
+        requestMessages: [],
+        responseText: big(`assistant reply ${i}`),
+        model: DEFAULT_MODEL,
+        wasStreaming: false,
+        // input_tokens kept small; the simulated cache supplies read/creation.
+        outputTokens: 1_200,
+      }),
+    );
+
+    const projectPath = `/tmp/lore-cache-oracle-${Date.now()}-${Math.random()
+      .toString(36)
+      .slice(2)}`;
+    harness = await createHarness({
+      fixtures,
+      simulateCache: true,
+      projectPath,
+      // Force layer-1 compression deterministically without depending on
+      // models.dev pricing being warm in the test.
+      budget: { maxLayer0Tokens: 40_000 },
+    });
+
+    const { resetCalibration, setUrgentDistillationEnabledForTest } =
+      await import("../../core/src/gradient");
+    const { ltm, ensureProject } = await import("@loreai/core");
+    resetCalibration();
+    setUrgentDistillationEnabledForTest(false);
+    ensureProject(projectPath);
+
+    // Seed an initial knowledge set so system[2] (context-bound LTM) is
+    // populated from turn 1.
+    for (let i = 0; i < 8; i++) {
+      ltm.create({
+        projectPath,
+        scope: "project",
+        category: "pattern",
+        title: `Seed knowledge ${i}`,
+        content: `Seed knowledge entry ${i}: ${"detail ".repeat(40)}`,
+      });
+    }
+
+    const history: GatewayMessage[] = [];
+    for (let i = 0; i < BASE_PAIRS; i++) {
+      history.push(userMsg(big(`base user ${i}`)));
+      history.push(asstMsg(big(`base assistant ${i}`)));
+    }
+
+    let sessionID = "";
+    let peakLayer = 0;
+    const layers: number[] = [];
+    for (let turn = 0; turn < TOTAL_TURNS; turn++) {
+      history.push(userMsg(big(`turn user ${turn}`)));
+
+      // Mid-session: mint a burst of new knowledge entries, simulating the
+      // tool-failure gotcha auto-mint that churned the selected LTM set in
+      // production. This is the trigger that must NOT bust the cache every turn.
+      if (turn === 6) {
+        for (let g = 0; g < 10; g++) {
+          ltm.create({
+            projectPath,
+            scope: "project",
+            category: "gotcha",
+            title: `Recurring failure ${g}`,
+            content: `Recurring failure pattern ${g}: ${"noise ".repeat(30)}`,
+            confidence: 0.75,
+          });
+        }
+      }
+
+      const resp = await harness.chat(makeBody(history));
+      expect(resp.status).toBe(200);
+      await resp.json();
+      history.push(asstMsg(big(`turn assistant ${turn}`)));
+
+      if (turn === 0) {
+        const rows = harness.queryDB<{ session_id: string }>(
+          "SELECT session_id FROM session_state ORDER BY updated_at DESC LIMIT 1",
+        );
+        sessionID = rows[0]?.session_id ?? "";
+        expect(sessionID).not.toBe("");
+      } else {
+        const layer = await observedLayer(sessionID);
+        peakLayer = Math.max(peakLayer, layer);
+        layers.push(layer);
+      }
+    }
+
+    // Guard: the session must actually be compressing at layer 1 (the regime
+    // every one of these bugs lived in). If a future change moved it off
+    // layer 1, this test would stop guarding the bug — fail loudly instead.
+    const layer1Turns = layers.filter((l) => l === 1).length;
+    expect(
+      layer1Turns,
+      `expected most steady-state turns at layer 1 (compressed pin path), but ` +
+        `observed layers were ${JSON.stringify(layers)} (peak ${peakLayer})`,
+    ).toBeGreaterThanOrEqual(Math.ceil(layers.length / 2));
+
+    const turns = harness.cacheTurns();
+    expect(turns.length).toBe(TOTAL_TURNS);
+
+    // STEADY STATE = turn 2 onward (turn 0 is a cold write; turn 1 establishes
+    // system[2]/context-bound LTM by design). In steady state the prompt cache
+    // must be READ, not rewritten: cache_creation should be a small fraction of
+    // cache_read. The production bug showed write:read ≈ 12.5:1 (ratio ≈ 12.5).
+    let totalRead = 0;
+    let totalCreation = 0;
+    let bustTurns = 0;
+    for (let i = 3; i < turns.length; i++) {
+      totalRead += turns[i].cacheReadTokens;
+      totalCreation += turns[i].cacheCreationTokens;
+      // A "bust turn": more than half the body was rewritten (matches the
+      // gateway's own bust definition: write/(write+read) > 0.5).
+      const total = turns[i].cacheReadTokens + turns[i].cacheCreationTokens;
+      if (total > 0 && turns[i].cacheCreationTokens / total > 0.5) bustTurns++;
+    }
+    const ratio = totalRead > 0 ? totalCreation / totalRead : Infinity;
+
+    const detail =
+      `steady-state write:read ratio=${ratio.toFixed(3)} ` +
+      `(creation=${totalCreation} read=${totalRead}), bustTurns=${bustTurns}/` +
+      `${turns.length - 2}, prefixMatch per turn=` +
+      JSON.stringify(turns.map((t) => Number(t.prefixMatch.toFixed(3))));
+
+    // The cache must be mostly read. Allow a modest write share for the genuine
+    // tail growth + the single legitimate delta when knowledge first changes,
+    // but a churning prefix (rewrite every turn) cannot satisfy this.
+    expect(
+      ratio,
+      `prompt cache is being rewritten, not read — ${detail}. A healthy ` +
+        `compressed session reads the cached prefix every turn; a high ratio ` +
+        `means a mid-prefix divergence is busting the cache (regression: ` +
+        `LTM-delta-churn / window-march / system[2] rewrite).`,
+    ).toBeLessThan(0.5);
+
+    // And the bust must not happen on (nearly) every steady-state turn.
+    expect(
+      bustTurns,
+      `prompt cache busted on ${bustTurns} of ${turns.length - 3} steady-state ` +
+        `turns — ${detail}`,
+    ).toBeLessThan(Math.floor((turns.length - 3) / 2));
+  });
+});

--- a/packages/gateway/test/cache-stability.e2e.test.ts
+++ b/packages/gateway/test/cache-stability.e2e.test.ts
@@ -604,6 +604,209 @@ describe("cache stability (e2e)", () => {
     expect(rows[0].content).toContain("Changed huge durable delta marker");
   });
 
+  it("coalesces MULTIPLE successive knowledge changes into ONE position-stable delta row", async () => {
+    // Regression for the durable-delta accumulation that busts the cache every
+    // turn: pre-fix, EACH material knowledge-set change appended a NEW
+    // session_prompt_deltas row (seq 0,1,2,...) at a DIFFERENT insertAt (the
+    // tail had grown). Replaying all of them inserts a new synthetic message
+    // into the cached prefix every change → shifts later messages → prompt-cache
+    // bust. The coalescing fix keeps exactly ONE row (seq 0) at a FROZEN
+    // insertAt, replaced in place, so the message prefix is byte-stable until
+    // the delta CONTENT changes.
+    const turns = Array.from({ length: 6 }, (_, i) => ({
+      userMessage: `Coalesce turn ${i}: keep working.`,
+      assistantText: `Coalesce response ${i}.`,
+    }));
+    harness = await createHarness({
+      fixtures: makeConversationFixtures(turns),
+    });
+
+    const projectPath = `/tmp/lore-cache-coalesce-${Date.now()}`;
+    const clientSessionID = `cache-coalesce-client-${Date.now()}`;
+    const headers = {
+      "x-lore-project": projectPath,
+      "x-lore-session-id": clientSessionID,
+    };
+
+    const { ltm, setForceMinLayer } = await import("@loreai/core");
+    const history: unknown[] = [];
+    let sessionID = "";
+    let ctxID = "";
+
+    for (let i = 0; i < turns.length; i++) {
+      // Force emergency LTM refresh from turn 2 on, so each turn re-evaluates
+      // the selected set and emits a delta when it changed.
+      if (i >= 2 && sessionID) setForceMinLayer(4, sessionID);
+      const resp = await harness.chat(
+        makeBody(turns[i].userMessage, history),
+        "test-key",
+        headers,
+      );
+      expect(resp.status).toBe(200);
+      await resp.json();
+      history.push({ role: "user", content: turns[i].userMessage });
+      history.push({
+        role: "assistant",
+        content: [{ type: "text", text: turns[i].assistantText }],
+      });
+
+      if (i === 0) {
+        const rows = harness.queryDB<{ session_id: string }>(
+          "SELECT session_id FROM session_state ORDER BY updated_at DESC LIMIT 1",
+        );
+        sessionID = rows[0]?.session_id ?? "";
+        expect(sessionID).not.toBe("");
+        ctxID = ltm.create({
+          projectPath,
+          scope: "project",
+          category: "gotcha",
+          title: "Coalesce gotcha",
+          content: "Initial coalesce knowledge pinned in system[2].",
+          session: sessionID,
+        });
+      }
+      // Mutate the pinned entry on MULTIPLE successive turns → multiple material
+      // changes. Pre-fix this appends one delta row per change.
+      if (i === 1) ltm.update(ctxID, { content: "First change to coalesce." });
+      if (i === 2) ltm.update(ctxID, { content: "Second change to coalesce." });
+      if (i === 3) ltm.update(ctxID, { content: "Third change to coalesce." });
+    }
+
+    const rows = harness.queryDB<{ seq: number; selector: string }>(
+      "SELECT seq, selector FROM session_prompt_deltas WHERE session_id = ? ORDER BY seq",
+      [sessionID],
+    );
+
+    // The core coalescing guarantee: exactly ONE durable-delta row, at sentinel
+    // seq 0, regardless of how many successive knowledge changes occurred.
+    expect(
+      rows.length,
+      `expected exactly one coalesced delta row after multiple knowledge ` +
+        `changes, got ${rows.length} (seqs=${rows.map((r) => r.seq).join(",")}) ` +
+        `— accumulating rows shifts the cached prefix and busts the cache`,
+    ).toBe(1);
+    expect(rows[0].seq).toBe(0);
+  });
+
+  it("coalesced delta is CUMULATIVE: two entries superseded on different turns both stay in the single row", async () => {
+    // Regression for the coalescing correctness BLOCKER (B1): the durable delta
+    // is an incremental diff. If the coalesced (replaced) row were computed
+    // against the ROLLING pin baseline, a later turn's supersession would
+    // OVERWRITE the row and DROP an earlier turn's supersession — leaving a
+    // stale entry pinned in system[2] with no correcting delta. The pin must
+    // keep its baseline FROZEN at the bytes rendered into system[2], so the
+    // single row always describes the full cumulative frozen→current delta.
+    //
+    // Mirrors the proven single-removal test mechanism (force layer 4 + restart
+    // so the pin reloads its frozen baseline from the DB), but removes TWO
+    // distinct entries on TWO different turns.
+    const turns = Array.from({ length: 7 }, (_, i) => ({
+      userMessage: `Cumulative turn ${i}: continue.`,
+      assistantText: `Cumulative response ${i}.`,
+    }));
+    harness = await createHarness({
+      fixtures: makeConversationFixtures(turns),
+    });
+
+    const projectPath = `/tmp/lore-cache-cumulative-${Date.now()}`;
+    const clientSessionID = `cache-cumulative-client-${Date.now()}`;
+    const headers = {
+      "x-lore-project": projectPath,
+      "x-lore-session-id": clientSessionID,
+    };
+
+    const { ltm, setForceMinLayer } = await import("@loreai/core");
+    const history: unknown[] = [];
+    let sessionID = "";
+    let idA = "";
+    let idB = "";
+
+    for (let i = 0; i < turns.length; i++) {
+      // Force emergency LTM refresh from turn 2 on (where the durable-delta path
+      // lives), matching the single-removal test.
+      if (i >= 2 && sessionID) setForceMinLayer(4, sessionID);
+      const resp = await harness.chat(
+        makeBody(turns[i].userMessage, history),
+        "test-key",
+        headers,
+      );
+      expect(resp.status).toBe(200);
+      await resp.json();
+      history.push({ role: "user", content: turns[i].userMessage });
+      history.push({
+        role: "assistant",
+        content: [{ type: "text", text: turns[i].assistantText }],
+      });
+
+      if (i === 0) {
+        const rows = harness.queryDB<{ session_id: string }>(
+          "SELECT session_id FROM session_state ORDER BY updated_at DESC LIMIT 1",
+        );
+        sessionID = rows[0]?.session_id ?? "";
+        expect(sessionID).not.toBe("");
+        // Create BOTH entries on turn 0 (before the pin freezes at turn 1), so
+        // the frozen system[2] baseline contains both. We count superseded
+        // BULLETS (not id prefixes) so same-ms UUIDv7 8-char-prefix collision is
+        // irrelevant.
+        idA = ltm.create({
+          projectPath,
+          scope: "project",
+          category: "gotcha",
+          title: "Cumulative entry A",
+          content: "Entry A pinned in system[2] before removal. ".repeat(8),
+          session: sessionID,
+        });
+        idB = ltm.create({
+          projectPath,
+          scope: "project",
+          category: "gotcha",
+          title: "Cumulative entry B",
+          content: "Entry B pinned in system[2] before removal. ".repeat(8),
+          session: sessionID,
+        });
+      }
+
+      // Supersede A on turn 2, then restart (pin reloads frozen baseline from
+      // DB), then supersede B on turn 4. Pre-fix (rolling baseline + coalesce),
+      // the turn-4 delta drops A's supersession.
+      if (i === 2) ltm.remove(idA);
+      if (i === 3) await harness.restartPipeline();
+      if (i === 4) ltm.remove(idB);
+    }
+
+    const rows = harness.queryDB<{ seq: number; content: string }>(
+      "SELECT seq, content FROM session_prompt_deltas WHERE session_id = ? ORDER BY seq",
+      [sessionID],
+    );
+    expect(rows).toHaveLength(1);
+
+    const content = rows[0].content;
+    expect(content).toContain("Superseded Long-term Knowledge");
+    // The superseded section renders one `* [<id8>]` bullet per removed entry.
+    // (UUIDv7's first 8 hex chars are a coarse time prefix shared by entries
+    // created within the same ~49-day window, so we count BULLETS rather than
+    // match specific ids.) With the frozen-baseline fix the coalesced row
+    // describes the full cumulative delta → BOTH removals → 2 bullets. Pre-fix
+    // (rolling baseline + replace), the turn-4 row holds only B's removal → 1.
+    // content is a serialized GatewayMessage; extract the text and count bullets.
+    const text = (
+      JSON.parse(content) as { content: Array<{ text?: string }> }
+    ).content
+      .map((b) => b.text ?? "")
+      .join("");
+    const supersededSection = text.slice(
+      text.indexOf("## Superseded Long-term Knowledge"),
+    );
+    const bulletCount = (supersededSection.match(/\n\* \[/g) ?? []).length;
+    expect(
+      bulletCount,
+      `coalesced delta superseded ${bulletCount} entr${bulletCount === 1 ? "y" : "ies"}, ` +
+        `expected 2 (both A removed on turn 2 and B removed on turn 4). A count ` +
+        `of 1 means a later supersession overwrote an earlier one in the single ` +
+        `coalesced row (B1 regression). Content: ${content}`,
+    ).toBe(2);
+  });
+
   it("removed LTM entries are replayed as durable superseded deltas without rewriting system[2]", async () => {
     const turns = Array.from({ length: 4 }, (_, i) => ({
       userMessage: `Removal delta turn ${i}: continue the work.`,

--- a/packages/gateway/test/helpers/harness.ts
+++ b/packages/gateway/test/helpers/harness.ts
@@ -10,9 +10,10 @@
  *   const resp = await harness.chat(body);
  *   harness.teardown();
  */
-import { unlinkSync, existsSync } from "node:fs";
+import { unlinkSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { DatabaseSync } from "node:sqlite";
 import type { FixtureEntry } from "../../src/recorder";
+import type { SimulatedCacheTurn } from "./simulated-cache";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -22,6 +23,27 @@ export interface HarnessOptions {
   fixtures: FixtureEntry[];
   /** Override any config values */
   configOverrides?: Partial<{ port: number; debug: boolean }>;
+  /**
+   * Compute realistic prompt-cache usage (cache_read / cache_creation) from the
+   * actual upstream body prefix-stability and inject it into each replayed
+   * response — so the gateway's own cache oracles (categorizeBust,
+   * recordCacheUsage, calibrate) see production-faithful numbers instead of the
+   * static zero-cache usage that replay fixtures otherwise report. Required for
+   * any test that asserts on cache busts. Drive NON-streaming turns when using
+   * this (the simulated cache only re-stamps JSON responses). Read the per-turn
+   * trace via `harness.cacheTurns()`.
+   */
+  simulateCache?: boolean;
+  /**
+   * Optional budget config written into a project `.lore.json` so a session can
+   * reach a target compression layer deterministically (e.g.
+   * `{ maxLayer0Tokens: 40000 }` to force layer-1 compression). Written into
+   * `projectPath` (defaults to the harness project dir); the pipeline calls
+   * config.load(projectPath) per request, so it is honored.
+   */
+  budget?: { maxLayer0Tokens?: number };
+  /** Project path to bind requests to (and where `budget` .lore.json is written). */
+  projectPath?: string;
 }
 
 export interface Harness {
@@ -44,6 +66,13 @@ export interface Harness {
    * cache on. Use this to assert cache-prefix stability across turns.
    */
   upstreamBodies(): string[];
+  /**
+   * Per-turn simulated cache observations (only populated when the harness was
+   * created with `simulateCache: true`). Each entry reports the prefix-match and
+   * the cache_read / cache_creation tokens that were injected into that turn's
+   * response — the same numbers the gateway's bust oracles consumed.
+   */
+  cacheTurns(): SimulatedCacheTurn[];
   /** Clear in-memory pipeline/core state while preserving the temp DB/server. */
   restartPipeline(): Promise<void>;
   /** Stop the gateway and clean up */
@@ -74,6 +103,7 @@ export async function createHarness(opts: HarnessOptions): Promise<Harness> {
 
   // --- 3. Dynamic imports so env vars take effect before module-level code runs ---
   const { makeReplayInterceptor } = await import("./replay");
+  const { withSimulatedCache } = await import("./simulated-cache");
   const { setUpstreamInterceptor, resetPipelineState } = await import(
     "../../src/pipeline"
   );
@@ -92,7 +122,13 @@ export async function createHarness(opts: HarnessOptions): Promise<Harness> {
   // streaming turns, JSON otherwise), wrapped to capture the exact upstream
   // request body lore sends each turn (for cache-stability assertions). ---
   const capturedBodies: string[] = [];
-  const replay = makeReplayInterceptor(opts.fixtures);
+  const baseReplay = makeReplayInterceptor(opts.fixtures);
+  // Optionally wrap the replay so each response carries cache usage computed
+  // from real prompt-prefix stability — see simulated-cache.ts for why this is
+  // required for any test that asserts on cache busts.
+  const { interceptor: replay, turns: simCacheTurns } = opts.simulateCache
+    ? withSimulatedCache(baseReplay)
+    : { interceptor: baseReplay, turns: [] as SimulatedCacheTurn[] };
   function installReplayInterceptor() {
     setUpstreamInterceptor(
       async (requestBody, model, wasStreaming, makeReal) => {
@@ -106,6 +142,21 @@ export async function createHarness(opts: HarnessOptions): Promise<Harness> {
     );
   }
   installReplayInterceptor();
+
+  // --- 4b. Optional per-project budget config (written before server start so
+  // the first request's config.load(projectPath) picks it up). ---
+  const projectPath = opts.projectPath ?? process.cwd();
+  if (opts.budget) {
+    try {
+      mkdirSync(projectPath, { recursive: true });
+      writeFileSync(
+        `${projectPath}/.lore.json`,
+        JSON.stringify({ budget: opts.budget }),
+      );
+    } catch {
+      // best-effort; tests that need this will fail loudly on the layer assertion
+    }
+  }
 
   // --- 5. Start gateway ---
   const config = loadConfig();
@@ -151,7 +202,7 @@ export async function createHarness(opts: HarnessOptions): Promise<Harness> {
         // project-resolution probe is never triggered in harness-based tests.
         // Tests that intentionally test path-less sessions can override this
         // via extraHeaders (set to empty string to suppress).
-        "x-lore-project": process.cwd(),
+        "x-lore-project": projectPath,
         ...extraHeaders,
       },
       body: JSON.stringify(requestBody),
@@ -182,6 +233,10 @@ export async function createHarness(opts: HarnessOptions): Promise<Harness> {
     return capturedBodies.slice();
   }
 
+  function cacheTurns(): SimulatedCacheTurn[] {
+    return simCacheTurns.slice();
+  }
+
   async function restartPipeline(): Promise<void> {
     closeDB();
     await resetPipelineState({ fast: true });
@@ -194,6 +249,7 @@ export async function createHarness(opts: HarnessOptions): Promise<Harness> {
     chat,
     queryDB,
     upstreamBodies,
+    cacheTurns,
     restartPipeline,
     teardown,
   };

--- a/packages/gateway/test/helpers/simulated-cache.ts
+++ b/packages/gateway/test/helpers/simulated-cache.ts
@@ -1,0 +1,169 @@
+/**
+ * Simulated prompt-cache oracle for the gateway replay harness.
+ *
+ * THE PROBLEM THIS SOLVES
+ * -----------------------
+ * Replay fixtures script their `usage` statically and omit cache fields
+ * entirely (see fixtures.ts: only input_tokens/output_tokens are set). So in
+ * every replay test the gateway's real cache oracles — analyzeCacheTurn,
+ * categorizeBust, recordCacheUsage, and calibrate() — are fed
+ * `cache_read=0, cache_creation=0` every turn and therefore CAN NEVER OBSERVE A
+ * BUST. A bug that rewrites the whole prompt prefix produces zero observable
+ * difference in a replay test. This is why three separate production
+ * cache-bust bugs (tier-gate, raw-window pin-march, LTM-delta-churn) all slipped
+ * past the suite: the suite asserts on cache *inputs* (byte stability) but the
+ * oracle that measures the cache *output* was blindfolded.
+ *
+ * WHAT THIS DOES
+ * --------------
+ * Wraps a replay interceptor and, before handing back the fixture response,
+ * OVERWRITES its usage.cache_read_input_tokens / cache_creation_input_tokens
+ * with values COMPUTED from the actual upstream request body — exactly the way
+ * Anthropic's prompt cache behaves:
+ *
+ *   - The cache reads the longest common *prefix* (in bytes) shared with the
+ *     previous turn's request, up to the last cache breakpoint, and rewrites
+ *     everything after the first divergence.
+ *   - read_tokens     ≈ prefixBytes / CHARS_PER_TOKEN
+ *   - creation_tokens ≈ (currentBytes - prefixBytes) / CHARS_PER_TOKEN
+ *   - First turn (no prior body): cold cache → all creation, zero read.
+ *
+ * This makes the gateway's own oracles see production-faithful numbers, so a
+ * mid-history divergence (window march, delta append, system churn) shows up as
+ * a real cache bust (high creation / low read, categorizeBust → window-shift /
+ * system-change / prefix-rewrite) — observable and assertable in an e2e test.
+ *
+ * Lives under test/helpers (excluded from coverage) and is wired only into the
+ * gateway harness via createHarness({ simulateCache: true }).
+ */
+import {
+  findDivergenceOffset,
+  normalizeBodyForComparison,
+} from "../../src/cache-analytics";
+import type { UpstreamInterceptor } from "../../src/recorder";
+
+/** Anthropic-ish bytes→tokens heuristic. Only the RATIO matters for the
+ *  oracles (bust detection thresholds, write:read ratio), not the absolute
+ *  count, so a constant divisor is sufficient and stable. */
+const CHARS_PER_TOKEN = 4;
+
+/** One per-turn cache observation, as the simulated cache computed it. */
+export interface SimulatedCacheTurn {
+  /** 0-based turn index (order of upstream requests). */
+  turn: number;
+  /** Bytes of the normalized body shared as a prefix with the previous turn. */
+  prefixBytes: number;
+  /** Total bytes of the normalized current body. */
+  totalBytes: number;
+  /** Simulated cache_read_input_tokens injected into the response. */
+  cacheReadTokens: number;
+  /** Simulated cache_creation_input_tokens injected into the response. */
+  cacheCreationTokens: number;
+  /** prefixBytes / totalBytes — 1.0 = full cache hit, low = bust. */
+  prefixMatch: number;
+}
+
+function clonePlainResponse(resp: unknown): Record<string, unknown> {
+  // Fixtures are plain JSON objects; structuredClone keeps us from mutating the
+  // caller's fixture array across turns.
+  return typeof resp === "object" && resp !== null
+    ? (structuredClone(resp) as Record<string, unknown>)
+    : {};
+}
+
+/**
+ * Wrap an interceptor so each replayed response carries cache usage computed
+ * from real prompt-prefix stability. Records a per-turn trace accessible via
+ * the returned `turns` array (the harness exposes this as `cacheTurns()`).
+ */
+export function withSimulatedCache(inner: UpstreamInterceptor): {
+  interceptor: UpstreamInterceptor;
+  turns: SimulatedCacheTurn[];
+} {
+  const turns: SimulatedCacheTurn[] = [];
+  let prevNormalized: string | null = null;
+  let turnIndex = 0;
+
+  const interceptor: UpstreamInterceptor = async (
+    requestBody,
+    model,
+    wasStreaming,
+    makeRealRequest,
+  ) => {
+    const turn = turnIndex++;
+
+    // Serialize + normalize the upstream body the SAME way the production
+    // analyzer does (strips volatile per-turn client metadata like cch=).
+    const raw =
+      typeof requestBody === "string"
+        ? requestBody
+        : JSON.stringify(requestBody ?? {});
+    const normalized = normalizeBodyForComparison(raw);
+    const totalBytes = normalized.length;
+
+    let prefixBytes: number;
+    if (prevNormalized === null) {
+      // Cold cache: nothing cached yet → full creation, zero read.
+      prefixBytes = 0;
+    } else {
+      prefixBytes = findDivergenceOffset(prevNormalized, normalized);
+    }
+    prevNormalized = normalized;
+
+    const cacheReadTokens = Math.floor(prefixBytes / CHARS_PER_TOKEN);
+    const cacheCreationTokens = Math.max(
+      0,
+      Math.floor((totalBytes - prefixBytes) / CHARS_PER_TOKEN),
+    );
+    turns.push({
+      turn,
+      prefixBytes,
+      totalBytes,
+      cacheReadTokens,
+      cacheCreationTokens,
+      prefixMatch: totalBytes > 0 ? prefixBytes / totalBytes : 1,
+    });
+
+    // Get the fixture response from the inner interceptor, then re-stamp usage.
+    const response = await inner(
+      requestBody,
+      model,
+      wasStreaming,
+      makeRealRequest,
+    );
+
+    // SSE streaming path: the inner interceptor already serialized the body to
+    // an event stream. Rewriting usage inside SSE is brittle; the production
+    // bust oracles read usage from the accumulated non-stream usage, which for
+    // streaming responses the gateway derives from message_start/message_delta.
+    // To keep this oracle simple and deterministic, simulated-cache tests drive
+    // NON-streaming turns (stream:false), so we only handle JSON here. If a
+    // streaming response slips through, pass it untouched (the test should use
+    // non-streaming bodies to get faithful numbers).
+    const contentType = response.headers.get("content-type") ?? "";
+    if (contentType.includes("text/event-stream")) {
+      return response;
+    }
+
+    const json = clonePlainResponse(await response.json());
+    const usage = (
+      typeof json.usage === "object" && json.usage !== null ? json.usage : {}
+    ) as Record<string, unknown>;
+    usage.cache_read_input_tokens = cacheReadTokens;
+    usage.cache_creation_input_tokens = cacheCreationTokens;
+    // input_tokens excludes cached/created in Anthropic's accounting; keep it
+    // tiny so total input ≈ read + creation (the bust ratio denominator).
+    usage.input_tokens =
+      typeof usage.input_tokens === "number" && usage.input_tokens < 100
+        ? usage.input_tokens
+        : 2;
+    json.usage = usage;
+
+    return new Response(JSON.stringify(json), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  };
+
+  return { interceptor, turns };
+}

--- a/packages/website/src/content/docs/docs/configuration.md
+++ b/packages/website/src/content/docs/docs/configuration.md
@@ -118,6 +118,7 @@ Long-term knowledge (curator, entity injection) controls.
 |---|---|---|---|---|
 | `enabled` | boolean | `true` |  | Enable long-term knowledge storage and system-prompt injection. When false, the curator is disabled but recall and context management remain active. Default: true. |
 | `maxEntityInject` | number | `30` | min 0 | Max entities to inject into the agent system prompt. Set to 0 to disable. Default: 30. |
+| `autoToolFailureGotchas` | boolean | `false` |  | Auto-create gotcha entries from recurring tool failures. Default false (noisy; can churn the LTM cache). |
 
 
 ## `curator`


### PR DESCRIPTION
## The bug (third in a series)

After the tier-gate (#771) and raw-window pin-march (#773) fixes, a large opus session **still** busted the prompt cache every turn (cache_write:read ≈ 12.5:1, "unsustainable" warning every turn). Root cause: the context-bound LTM block (system[2]) churned. Two compounding mechanisms:

1. **Budget wobble → LTM set churn.** `getLtmBudget()` derives the LTM token budget from `usable`, which shifts every turn (it's computed from the per-turn calibrated-overhead EMA). That moving budget moved the `ltm.forSession()` greedy packing boundary, so the lowest-ranked pinned entry dropped in/out **every turn** → the selected knowledge set changed every turn.
2. **Delta accumulation.** Each set change **appended a new** durable prompt-delta row (seq 0,1,2,…) at a different `insertAt`. Replaying them inserts a fresh synthetic message into the cached prefix every change → shifts later messages → cache bust.

Fueled by a feedback loop: tool failures in a debugging session caused idle distillation to auto-mint `Recurring <tool> failure` gotcha entries that entered the selected set and amplified the churn.

## Fixes
- **Quantize the LTM budget** (`getLtmBudget`): snap to `LTM_BUDGET_STEP` (8K), round to nearest, never below one step — so normal overhead wobble no longer moves the packing boundary.
- **Coalesce the durable-delta channel** (`upsertSessionPromptDelta` + `appendKnowledgePromptDelta`): keep exactly ONE row (sentinel `seq 0`), replaced in place via `ON CONFLICT`, at a **frozen** `insertAt`. The message prefix is byte-stable until the delta CONTENT genuinely changes.
- **Gate the tool-failure gotcha auto-mint** behind `knowledge.autoToolFailureGotchas` (default **false**).

## Why the suite never caught this — and the structural fix

Post-mortem: the cache-stability suite asserted only on cache **inputs** (byte-stability between two turns) and never on the cache **output**. Replay fixtures report **zero** cache usage, so the gateway's own oracles (`categorizeBust` / `recordCacheUsage` / `calibrate`) ran **blindfolded** in every test — a bust produced no observable difference. All three production bugs lived in exactly the region (`messages[idx>1]`) that `isTailDivergence()` waved through.

- **Simulated-cache oracle** (`test/helpers/simulated-cache.ts` + harness `simulateCache`): computes each turn's `cache_read`/`cache_creation` from the **actual** upstream-body prefix stability and feeds it back, so a real bust is observable/assertable.
- **New e2e** (`cache-bust-oracle.e2e.test.ts`): long, naturally-compressed session + mid-session knowledge growth; asserts the steady-state write:read ratio stays low — the cache-output guardrail that was absent.
- **Unit regression**: `getLtmBudget` stable across overhead wobble (fails pre-fix: 7 distinct budgets; passes quantized).
- **Coalescing regression**: multiple successive knowledge changes → ONE `seq 0` row (fails pre-fix: 3 rows).
- Harness gains first-class `budget` (per-project `.lore.json`) + `cacheTurns()`.

All three new regressions **verified to fail on revert** of their respective fix.

## Verification
- `pnpm test` — **3170 passed**, 6 skipped, 0 failed
- `pnpm run typecheck` — clean (all packages)
- `pnpm run lint` — exit 0 (13 pre-existing warnings, none in changed files)

🤖 Generated with [opencode](https://opencode.ai)