### PR TITLE
feat: Basic-tier cloud sync engine (knowledge + entity graph) (#467)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1243,10 +1243,41 @@ jobs:
   # Reports success when either (a) all code jobs passed or (b) they were
   # legitimately skipped because only docs changed.
   # ---------------------------------------------------------------------------
+  # ---------------------------------------------------------------------------
+  # Sync engine integration tests against a REAL Postgres + PostgREST stack.
+  #
+  # The unit suite mocks PostgREST; these run the actual migrations, RLS,
+  # triggers, CHECK constraints, and the real push/pull engine over supabase-js.
+  # GitHub's ubuntu runners ship Docker, so the harness can stand up disposable
+  # postgres:16-alpine + postgrest containers. Gated by LORE_INTEGRATION=1.
+  # ---------------------------------------------------------------------------
+  sync-integration:
+    name: Sync integration (real Postgres)
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+      - run: pnpm install --frozen-lockfile
+      # Pre-pull images so the per-test timeout covers only container startup.
+      - name: Pre-pull container images
+        run: |
+          docker pull postgres:16-alpine
+          docker pull postgrest/postgrest:v12.2.3
+      - name: Run sync integration tests
+        run: pnpm exec vitest run packages/gateway/test/sync-security.integration.test.ts packages/gateway/test/sync-engine.integration.test.ts
+        env:
+          LORE_INTEGRATION: '1'
+          NODE_NO_WARNINGS: '1'
+
   ci-status:
     name: CI Status
     if: always()
-    needs: [changes, test, binary-smoke-native, check-docs, check-links, check-social, check-patches, actionlint]
+    needs: [changes, test, binary-smoke-native, check-docs, check-links, check-social, check-patches, actionlint, sync-integration]
     runs-on: ubuntu-latest
     steps:
       - name: Check CI result
@@ -1291,5 +1322,14 @@ jobs:
           if [ "$checkPatchesResult" == "failure" ] || [ "$checkPatchesResult" == "cancelled" ]; then
             echo "::error::check-patches did not succeed (result: $checkPatchesResult)"
             exit 1
+          fi
+          # sync-integration is required whenever code changed (self-gates on the
+          # code path filter); "skipped" on unrelated changes is treated as pass.
+          if [ "${{ needs.changes.outputs.code }}" == "true" ]; then
+            syncItResult="${{ needs.sync-integration.result }}"
+            if [ "$syncItResult" != "success" ]; then
+              echo "::error::sync-integration did not succeed (result: $syncItResult)"
+              exit 1
+            fi
           fi
           echo "CI passed (code=${{ needs.changes.outputs.code }})"

--- a/package.json
+++ b/package.json
@@ -54,10 +54,12 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.16",
+    "@types/pg": "^8.11.10",
     "@vitest/coverage-v8": "^4.1.8",
     "esbuild": "^0.28.1",
     "fast-check": "^4.5.3",
     "linkinator": "^7.6.1",
+    "pg": "^8.13.1",
     "tsx": "^4.22.3",
     "typescript": "^5.8.0",
     "vitest": "^4.1.7",

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1,6 +1,6 @@
 import { Database } from "#db/driver";
 import { join, dirname } from "node:path";
-import { mkdirSync } from "node:fs";
+import { chmodSync, mkdirSync } from "node:fs";
 import { getGitRemote } from "./git";
 import { isHostedMode } from "./hosted";
 import { dataDir } from "./data-dir";
@@ -1101,6 +1101,51 @@ const MIGRATIONS: string[] = [
   CREATE INDEX IF NOT EXISTS idx_session_prompt_deltas_project
     ON session_prompt_deltas (project_id);
   `,
+  `
+  -- Version 43: Logical-sync change tracking (Basic tier — knowledge + entity graph).
+  --
+  -- The outbox is a monotonic append-only queue of local row changes to push to
+  -- the remote. The CAPTURE TRIGGERS are NOT defined here — they are created as
+  -- per-connection TEMP triggers in installSyncCapture() (db()). This is
+  -- deliberate: apply-suppression must be CONNECTION-scoped (the gateway and a
+  -- 'lore' CLI share one DB file; a shared persisted "applying" flag would let
+  -- one process suppress the other's legitimate captures -> silent data loss).
+  -- A main-schema trigger cannot reference a TEMP table, so temp triggers (which
+  -- can) gate on a connection-local temp table instead. content_hash / revision
+  -- are computed in JS by the sync engine (SQLite has no hash function) and
+  -- tracked per-row in sync_state. row_id for the composite-key join table
+  -- knowledge_entity_refs is knowledge_id || char(31) || entity_id.
+
+  CREATE TABLE IF NOT EXISTS sync_outbox (
+    seq        INTEGER PRIMARY KEY AUTOINCREMENT,
+    table_name TEXT NOT NULL,
+    row_id     TEXT NOT NULL,
+    op         TEXT NOT NULL,        -- 'upsert' | 'delete'
+    changed_at INTEGER NOT NULL
+  );
+  CREATE INDEX IF NOT EXISTS idx_sync_outbox_table_row
+    ON sync_outbox (table_name, row_id);
+  CREATE INDEX IF NOT EXISTS idx_sync_outbox_table_seq
+    ON sync_outbox (table_name, seq);
+
+  CREATE TABLE IF NOT EXISTS sync_state (
+    table_name        TEXT NOT NULL,
+    row_id            TEXT NOT NULL,
+    content_hash      TEXT,          -- hash of the row's semantic content at last sync
+    revision          INTEGER NOT NULL DEFAULT 0,
+    remote_updated_at TEXT,          -- remote server timestamp last applied (per-row pull cursor)
+    PRIMARY KEY (table_name, row_id)
+  );
+
+  CREATE TABLE IF NOT EXISTS sync_conflicts (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    table_name    TEXT NOT NULL,
+    row_id        TEXT NOT NULL,
+    detected_at   INTEGER NOT NULL,
+    resolution    TEXT,
+    local_content TEXT   -- JSON of the discarded local row (recoverable after LWW)
+  );
+  `,
 ];
 
 /**
@@ -1145,6 +1190,15 @@ export function db(): Database {
     }
     const dir = dataDir();
     mkdirSync(dir, { recursive: true });
+    // Owner-only data dir: the DB (and its -wal/-shm sidecars, which hold
+    // recent un-checkpointed writes incl. the auth session) live here and
+    // contain bearer credentials. Tightening the dir to 0700 closes the
+    // practical window even before the per-file chmod below.
+    try {
+      chmodSync(dir, 0o700);
+    } catch {
+      // non-POSIX filesystem / platform
+    }
     path = join(dir, "lore.db");
   }
   // Both `bun:sqlite` and `node:sqlite` create the file by default if it doesn't
@@ -1157,6 +1211,15 @@ export function db(): Database {
   // module-level singleton must remain undefined so the next db() call
   // retries initialization instead of returning an un-migrated handle.
   const database = new Database(path);
+  // The DB stores bearer credentials (the Supabase auth session / refresh
+  // token in team_config) — make it owner-only so another local user/process
+  // can't read it. Best-effort: chmod is a no-op / may throw on Windows & some
+  // FUSE mounts, which is fine (those don't honor POSIX modes anyway).
+  try {
+    chmodSync(path, 0o600);
+  } catch {
+    // ignore — non-POSIX filesystem / platform
+  }
   database.exec("PRAGMA journal_mode = WAL");
   database.exec("PRAGMA foreign_keys = ON");
   // Retry for up to 5s when another connection holds the write lock (e.g.
@@ -1167,8 +1230,97 @@ export function db(): Database {
   // instead of accumulating a free-page list that bloats the file.
   database.exec("PRAGMA auto_vacuum = INCREMENTAL");
   migrate(database);
+  installSyncCapture(database);
   instance = database;
   return instance;
+}
+
+// ---------------------------------------------------------------------------
+// Per-connection sync change-capture (logical-sync engine, v43)
+// ---------------------------------------------------------------------------
+
+/**
+ * Install this connection's sync change-capture: a connection-local TEMP table
+ * `_sync_applying` plus TEMP triggers that enqueue (table, row_id, op) into
+ * `sync_outbox` on every INSERT/UPDATE/DELETE of a synced table.
+ *
+ * Why per-connection TEMP (not persistent triggers + a shared flag): the
+ * gateway and a `lore` CLI invocation share one DB file. Apply-suppression must
+ * be CONNECTION-scoped — a shared persisted "applying" flag would let one
+ * process suppress the other process's legitimate captures, silently losing
+ * changes from the push queue. A main-schema trigger cannot reference a TEMP
+ * table; a TEMP trigger can. Capture is gated by the shared user setting
+ * `team_config 'sync.enabled'='1'` AND an empty `_sync_applying` (this
+ * connection is not mid-apply). Row count in `_sync_applying` is a re-entrant
+ * depth counter (see `withSyncApplying`).
+ *
+ * Idempotent (`IF NOT EXISTS`); runs on every `db()` init so it survives a
+ * dropped trigger (unlike `recoverMissingObjects`, which only restores tables).
+ */
+function installSyncCapture(database: Database) {
+  database.exec(
+    "CREATE TEMP TABLE IF NOT EXISTS _sync_applying (marker INTEGER)",
+  );
+  const gate =
+    "(SELECT value FROM team_config WHERE key='sync.enabled')='1' " +
+    "AND NOT EXISTS (SELECT 1 FROM temp._sync_applying)";
+  const ts = "CAST(strftime('%s','now') AS INTEGER)*1000";
+  const ops = [
+    ["INSERT", "ins", "new", "upsert"],
+    ["UPDATE", "upd", "new", "upsert"],
+    ["DELETE", "del", "old", "delete"],
+  ] as const;
+  let sql = "";
+  for (const t of [
+    "knowledge",
+    "entities",
+    "entity_aliases",
+    "entity_relations",
+  ]) {
+    for (const [evt, suffix, ref, op] of ops) {
+      sql += `
+        CREATE TEMP TRIGGER IF NOT EXISTS ${t}_outbox_${suffix}
+        AFTER ${evt} ON ${t} WHEN (${gate})
+        BEGIN
+          INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
+          VALUES ('${t}', ${ref}.id, '${op}', ${ts});
+        END;`;
+    }
+  }
+  // Join table: composite row_id (knowledge_id || char(31) || entity_id),
+  // insert/delete only (no updatable columns).
+  sql += `
+    CREATE TEMP TRIGGER IF NOT EXISTS knowledge_entity_refs_outbox_ins
+    AFTER INSERT ON knowledge_entity_refs WHEN (${gate})
+    BEGIN
+      INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
+      VALUES ('knowledge_entity_refs', new.knowledge_id || char(31) || new.entity_id, 'upsert', ${ts});
+    END;
+    CREATE TEMP TRIGGER IF NOT EXISTS knowledge_entity_refs_outbox_del
+    AFTER DELETE ON knowledge_entity_refs WHEN (${gate})
+    BEGIN
+      INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
+      VALUES ('knowledge_entity_refs', old.knowledge_id || char(31) || old.entity_id, 'delete', ${ts});
+    END;`;
+  database.exec(sql);
+}
+
+/**
+ * Run `fn` with THIS connection's sync change-capture suppressed, so applying
+ * pulled remote rows is not re-enqueued for push (push<->pull echo guard).
+ * Re-entrant: the suppression is a depth counter (row count in the per-connection
+ * `_sync_applying` temp table), so nested calls don't prematurely re-enable
+ * capture, and a failing `fn` still decrements exactly one level.
+ */
+export function withSyncApplying<T>(fn: () => T): T {
+  db().exec("INSERT INTO temp._sync_applying (marker) VALUES (1)");
+  try {
+    return fn();
+  } finally {
+    db().exec(
+      "DELETE FROM temp._sync_applying WHERE rowid = (SELECT MAX(rowid) FROM temp._sync_applying)",
+    );
+  }
 }
 
 // Index of the migration that performs a one-time VACUUM.
@@ -1363,6 +1515,37 @@ function recoverMissingObjects(database: Database) {
     );
     CREATE INDEX IF NOT EXISTS idx_knowledge_tombstones_project
       ON knowledge_tombstones (project_id);
+    -- Sync change-tracking (v43). NOTE: the per-table outbox TRIGGERS are NOT
+    -- recreated here (same limitation as the FTS triggers) — only the tables.
+    -- A missing trigger means changes aren't captured until the next full
+    -- reconcile, which the sync engine performs on enable.
+    CREATE TABLE IF NOT EXISTS sync_outbox (
+      seq        INTEGER PRIMARY KEY AUTOINCREMENT,
+      table_name TEXT NOT NULL,
+      row_id     TEXT NOT NULL,
+      op         TEXT NOT NULL,
+      changed_at INTEGER NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_sync_outbox_table_row
+      ON sync_outbox (table_name, row_id);
+    CREATE INDEX IF NOT EXISTS idx_sync_outbox_table_seq
+      ON sync_outbox (table_name, seq);
+    CREATE TABLE IF NOT EXISTS sync_state (
+      table_name        TEXT NOT NULL,
+      row_id            TEXT NOT NULL,
+      content_hash      TEXT,
+      revision          INTEGER NOT NULL DEFAULT 0,
+      remote_updated_at TEXT,
+      PRIMARY KEY (table_name, row_id)
+    );
+    CREATE TABLE IF NOT EXISTS sync_conflicts (
+      id            INTEGER PRIMARY KEY AUTOINCREMENT,
+      table_name    TEXT NOT NULL,
+      row_id        TEXT NOT NULL,
+      detected_at   INTEGER NOT NULL,
+      resolution    TEXT,
+      local_content TEXT
+    );
   `);
 
   // Recover missing columns from partial migration runs.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,7 @@
 
 export * as temporal from "./temporal";
 export * as ltm from "./ltm";
+export * as syncData from "./sync-data";
 export * as data from "./data";
 export * as distillation from "./distillation";
 export * as curator from "./curator";

--- a/packages/core/src/sync-data.ts
+++ b/packages/core/src/sync-data.ts
@@ -1,0 +1,601 @@
+/**
+ * Local primitives for the logical sync engine (Basic tier — knowledge + the
+ * entity graph). Pure DB-side helpers with no Supabase/network coupling: the
+ * gateway sync engine composes these with an HTTP client.
+ *
+ * Design (see plan §3):
+ *  - A monotonic `sync_outbox` (populated by triggers, gated by `sync.enabled`)
+ *    is the push queue; `seq` is the high-watermark cursor.
+ *  - `content_hash` + `revision` are computed HERE in JS (SQLite has no hash
+ *    function) — borrowed from `.lore.md`'s UUID-identity + content-hash model —
+ *    and tracked per row in `sync_state`. The hash makes sync idempotent (skip
+ *    byte-identical rows) and discriminates a real concurrent conflict from a
+ *    no-op.
+ *  - Applying pulled remote rows is wrapped in `withApplying()`, which sets the
+ *    `sync.applying` flag so the outbox triggers don't re-enqueue them
+ *    (prevents push<->pull echo).
+ */
+import { createHash } from "node:crypto";
+import {
+  db,
+  deleteTeamConfig,
+  getTeamConfig,
+  setTeamConfig,
+  withSyncApplying,
+} from "./db";
+
+/**
+ * Run `fn` with this connection's sync capture suppressed (re-entrant,
+ * connection-scoped). Re-exported from `db` so the apply helpers and the engine
+ * share one mechanism.
+ */
+export const withApplying = withSyncApplying;
+
+export type SyncTier = "basic" | "pro" | "max";
+
+export interface SyncTableMeta {
+  table: string;
+  /** Primary-key columns. One for id-keyed tables; two for the join table. */
+  idColumns: string[];
+  /** FTS5 tables to rebuild locally after applying pulled rows. */
+  ftsTables: string[];
+  /**
+   * Whether the REMOTE table carries `content_hash`/`revision` columns. The
+   * join table (knowledge_entity_refs) does not — sending those columns to it
+   * is a PostgREST schema error (PGRST204). Defaults to true.
+   */
+  versioned?: boolean;
+  /**
+   * The data columns that exist on the REMOTE table (supabase/migrations/0002),
+   * which is a curated subset of the local schema. Push/hash use ONLY these —
+   * sending a local-only column (e.g. knowledge.promoted_at, worker_model_id)
+   * is a PostgREST PGRST204 and would break sync for the whole table. Sync-
+   * management columns (owner_user_id/content_hash/revision/is_deleted) are
+   * added separately and are NOT listed here.
+   */
+  syncColumns: string[];
+}
+
+/** ASCII Unit Separator — joins composite row ids (mirrors the SQL `char(31)`). */
+const ROW_SEP = "\x1f";
+
+/**
+ * Volatile / local-only columns never sent over the wire: BLOB `embedding`
+ * (re-derived on restore) and `last_accessed_at` (per-machine access tracking).
+ */
+const PAYLOAD_EXCLUDE = new Set(["embedding", "last_accessed_at"]);
+/**
+ * Columns excluded from the content hash: the non-synced ones above plus
+ * `updated_at` (a fresh timestamp is not a semantic change). Intentionally a
+ * denylist of volatile/local columns; if cross-tenant dedup is ever needed,
+ * switch to an explicit per-table semantic allowlist.
+ */
+const HASH_EXCLUDE = new Set(["embedding", "last_accessed_at", "updated_at"]);
+
+export const SYNCED_TABLES: Record<SyncTier, SyncTableMeta[]> = {
+  basic: [
+    {
+      table: "knowledge",
+      idColumns: ["id"],
+      ftsTables: ["knowledge_fts"],
+      syncColumns: [
+        "id",
+        "project_id",
+        "category",
+        "title",
+        "content",
+        "source_session",
+        "cross_project",
+        "confidence",
+        "metadata",
+        "created_by",
+        "updated_by",
+        "sensitivity",
+        "promotion_status",
+        "created_at",
+        "updated_at",
+      ],
+    },
+    {
+      table: "entities",
+      idColumns: ["id"],
+      ftsTables: ["entities_fts"],
+      syncColumns: [
+        "id",
+        "project_id",
+        "entity_type",
+        "canonical_name",
+        "metadata",
+        "cross_project",
+        "created_at",
+        "updated_at",
+      ],
+    },
+    {
+      table: "entity_aliases",
+      idColumns: ["id"],
+      ftsTables: ["entity_aliases_fts"],
+      syncColumns: [
+        "id",
+        "entity_id",
+        "alias_type",
+        "alias_value",
+        "source",
+        "created_at",
+      ],
+    },
+    {
+      table: "entity_relations",
+      idColumns: ["id"],
+      ftsTables: [],
+      syncColumns: [
+        "id",
+        "entity_a",
+        "entity_b",
+        "relation",
+        "metadata",
+        "source",
+        "created_at",
+        "updated_at",
+      ],
+    },
+    {
+      table: "knowledge_entity_refs",
+      idColumns: ["knowledge_id", "entity_id"],
+      ftsTables: [],
+      versioned: false, // join table has no content_hash/revision columns
+      syncColumns: ["knowledge_id", "entity_id"],
+    },
+  ],
+  pro: [],
+  max: [],
+};
+
+const META_BY_TABLE = new Map<string, SyncTableMeta>();
+for (const t of SYNCED_TABLES.basic) META_BY_TABLE.set(t.table, t);
+
+/** The synced table set for a tier (only `basic` is populated today). */
+export function syncedTables(tier: SyncTier = "basic"): SyncTableMeta[] {
+  return SYNCED_TABLES[tier];
+}
+
+function meta(table: string): SyncTableMeta {
+  const m = META_BY_TABLE.get(table);
+  if (!m) throw new Error(`not a synced table: ${table}`);
+  return m;
+}
+
+/**
+ * The synced data columns of a table: the registry allowlist (matching the
+ * remote 0002 schema) intersected with the columns that actually exist locally.
+ * Push, hashing, and apply all use this — never the raw local column set, which
+ * has local-only columns the remote rejects (PGRST204).
+ */
+export function syncedColumns(table: string): string[] {
+  const m = meta(table);
+  const local = new Set(
+    (
+      db().query(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>
+    ).map((r) => r.name),
+  );
+  return m.syncColumns.filter((c) => local.has(c));
+}
+
+/** Pick only the synced data columns from a row (for the push payload). */
+export function pickSyncColumns(
+  table: string,
+  row: Record<string, unknown>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const c of syncedColumns(table)) {
+    if (c in row) out[c] = row[c];
+  }
+  return out;
+}
+
+/** Local column names of a synced table (validated against the registry). */
+function columns(table: string): string[] {
+  return syncedColumns(table);
+}
+
+// ---------------------------------------------------------------------------
+// Row identity + content hashing
+// ---------------------------------------------------------------------------
+
+/** Build the outbox/sync_state `row_id` for a row (composite for the join table). */
+export function rowIdOf(table: string, row: Record<string, unknown>): string {
+  return meta(table)
+    .idColumns.map((c) => String(row[c]))
+    .join(ROW_SEP);
+}
+
+function splitRowId(rowId: string): string[] {
+  return rowId.split(ROW_SEP);
+}
+
+function serializeValue(v: unknown): string {
+  if (v === null || v === undefined) return "\x00";
+  if (v instanceof Uint8Array) return Buffer.from(v).toString("base64");
+  return String(v);
+}
+
+/**
+ * Stable 64-bit content hash of a row's semantic columns (sorted for
+ * determinism; `updated_at`/`embedding` excluded). Two rows with identical
+ * meaningful content hash equal regardless of column order or timestamp churn.
+ */
+export function contentHash(
+  table: string,
+  row: Record<string, unknown>,
+): string {
+  const cols = columns(table)
+    .filter((c) => !HASH_EXCLUDE.has(c))
+    .sort();
+  const canonical = cols
+    .map((c) => `${c}=${serializeValue(row[c])}`)
+    .join(ROW_SEP);
+  return createHash("sha256").update(canonical).digest("hex").slice(0, 16);
+}
+
+/** Read a synced row by its `row_id` (payload columns only). Null if absent. */
+export function getRowById(
+  table: string,
+  rowId: string,
+): Record<string, unknown> | null {
+  const m = meta(table);
+  const where = m.idColumns.map((c) => `${c} = ?`).join(" AND ");
+  const cols = columns(table).filter((c) => !PAYLOAD_EXCLUDE.has(c));
+  const row = db()
+    .query(`SELECT ${cols.join(", ")} FROM ${table} WHERE ${where}`)
+    .get(...splitRowId(rowId)) as Record<string, unknown> | undefined;
+  return row ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Outbox (push queue)
+// ---------------------------------------------------------------------------
+
+export interface OutboxEntry {
+  seq: number;
+  table_name: string;
+  row_id: string;
+  op: "upsert" | "delete";
+  changed_at: number;
+}
+
+/**
+ * Read outbox entries with `seq > sinceSeq`, in seq order. When `table` is
+ * given, filters in SQL (uses idx_sync_outbox_table_seq) so a table is never
+ * starved by a window full of OTHER tables' entries.
+ */
+export function readOutbox(
+  sinceSeq: number,
+  limit = 500,
+  table?: string,
+): OutboxEntry[] {
+  if (table) {
+    return db()
+      .query(
+        `SELECT seq, table_name, row_id, op, changed_at
+           FROM sync_outbox WHERE table_name = ? AND seq > ?
+           ORDER BY seq LIMIT ?`,
+      )
+      .all(table, sinceSeq, limit) as unknown as OutboxEntry[];
+  }
+  return db()
+    .query(
+      `SELECT seq, table_name, row_id, op, changed_at
+         FROM sync_outbox WHERE seq > ? ORDER BY seq LIMIT ?`,
+    )
+    .all(sinceSeq, limit) as unknown as OutboxEntry[];
+}
+
+/**
+ * Prune fully-pushed outbox entries (seq <= the minimum push cursor across all
+ * synced tables). The outbox is otherwise append-only and would grow forever.
+ * `minCursor` is the lowest per-table push cursor the engine has persisted.
+ */
+export function pruneOutbox(minCursor: number): number {
+  if (minCursor <= 0) return 0;
+  return db().query(`DELETE FROM sync_outbox WHERE seq <= ?`).run(minCursor)
+    .changes;
+}
+
+/**
+ * True when the outbox holds an entry for this row with seq > `sinceSeq` (i.e. an
+ * unpushed local change). Indexed existence check via idx_sync_outbox_table_row —
+ * O(log n), not a full scan.
+ */
+export function hasPendingChange(
+  table: string,
+  rowId: string,
+  sinceSeq: number,
+): boolean {
+  const row = db()
+    .query(
+      `SELECT 1 FROM sync_outbox
+        WHERE table_name = ? AND row_id = ? AND seq > ? LIMIT 1`,
+    )
+    .get(table, rowId, sinceSeq);
+  return row != null;
+}
+
+/** True when the outbox has at least one entry for `table`. */
+export function hasOutboxEntries(table: string): boolean {
+  return (
+    db()
+      .query(`SELECT 1 FROM sync_outbox WHERE table_name = ? LIMIT 1`)
+      .get(table) != null
+  );
+}
+
+/** Highest outbox `seq` currently present (0 when empty). */
+export function maxOutboxSeq(): number {
+  return (
+    db().query(`SELECT COALESCE(MAX(seq), 0) AS m FROM sync_outbox`).get() as {
+      m: number;
+    }
+  ).m;
+}
+
+/** Build the SQL expression for a table's row_id, qualified by alias `t`. */
+function rowIdExpr(m: SyncTableMeta): string {
+  return m.idColumns.length === 1
+    ? `t.${m.idColumns[0]}`
+    : m.idColumns.map((c) => `t.${c}`).join(" || char(31) || ");
+}
+
+/**
+ * Enqueue an `upsert` for every live row of the synced tables. Idempotent — a
+ * row that already has a pending outbox entry is skipped, so repeated calls
+ * (e.g. re-enable) don't pile up duplicates. The push path further skips rows
+ * whose `content_hash` is unchanged, so a redundant upsert costs nothing.
+ */
+export function seedOutbox(tier: SyncTier = "basic"): void {
+  const now = Date.now();
+  for (const m of syncedTables(tier)) {
+    const idExpr = rowIdExpr(m);
+    db()
+      .query(
+        `INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
+         SELECT ?, ${idExpr}, 'upsert', ? FROM ${m.table} t
+         WHERE NOT EXISTS (
+           SELECT 1 FROM sync_outbox o WHERE o.table_name = ? AND o.row_id = ${idExpr}
+         )`,
+      )
+      .run(m.table, now, m.table);
+  }
+}
+
+/**
+ * Re-enqueue the full local delta for a tier — used on enable AND re-enable:
+ *  - upserts for every live row (idempotent seed; push skips unchanged ones), and
+ *  - `delete` tombstones for rows present in `sync_state` but no longer live
+ *    (deleted while sync was OFF, which the capture triggers couldn't see).
+ * This is why enable does NOT just seed once: it reconciles, so changes made
+ * while sync was disabled are not silently dropped from the push queue.
+ */
+export function reconcile(tier: SyncTier = "basic"): void {
+  const now = Date.now();
+  seedOutbox(tier);
+  for (const m of syncedTables(tier)) {
+    const idExpr = rowIdExpr(m);
+    db()
+      .query(
+        `INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
+         SELECT s.table_name, s.row_id, 'delete', ?
+           FROM sync_state s
+          WHERE s.table_name = ?
+            AND NOT EXISTS (SELECT 1 FROM ${m.table} t WHERE ${idExpr} = s.row_id)
+            AND NOT EXISTS (
+              SELECT 1 FROM sync_outbox o
+               WHERE o.table_name = s.table_name AND o.row_id = s.row_id
+            )`,
+      )
+      .run(now, m.table);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Per-row sync state
+// ---------------------------------------------------------------------------
+
+export interface SyncRowState {
+  content_hash: string | null;
+  revision: number;
+  remote_updated_at: string | null;
+}
+
+export function getSyncState(
+  table: string,
+  rowId: string,
+): SyncRowState | null {
+  meta(table);
+  const row = db()
+    .query(
+      `SELECT content_hash, revision, remote_updated_at
+         FROM sync_state WHERE table_name = ? AND row_id = ?`,
+    )
+    .get(table, rowId) as unknown as SyncRowState | undefined;
+  return row ?? null;
+}
+
+export function setSyncState(
+  table: string,
+  rowId: string,
+  state: SyncRowState,
+): void {
+  meta(table);
+  db()
+    .query(
+      `INSERT INTO sync_state (table_name, row_id, content_hash, revision, remote_updated_at)
+       VALUES (?, ?, ?, ?, ?)
+       ON CONFLICT(table_name, row_id) DO UPDATE SET
+         content_hash = excluded.content_hash,
+         revision = excluded.revision,
+         remote_updated_at = excluded.remote_updated_at`,
+    )
+    .run(
+      table,
+      rowId,
+      state.content_hash,
+      state.revision,
+      state.remote_updated_at,
+    );
+}
+
+export function clearSyncState(table: string, rowId: string): void {
+  meta(table);
+  db()
+    .query(`DELETE FROM sync_state WHERE table_name = ? AND row_id = ?`)
+    .run(table, rowId);
+}
+
+// ---------------------------------------------------------------------------
+// Applying pulled remote rows (suppress outbox capture)
+// ---------------------------------------------------------------------------
+
+/**
+ * Upsert a pulled remote row into the local table (under apply-suppression).
+ *
+ * Uses `INSERT … ON CONFLICT(<pk>) DO UPDATE` (NOT `INSERT OR REPLACE`) so the
+ * existing row is updated IN PLACE — the rowid stays stable, which keeps the
+ * external-content FTS5 indexes (`content_rowid=rowid`) consistent (a delete+
+ * insert would churn rowids and leave stale FTS postings). A secondary UNIQUE
+ * collision on a DIFFERENT id (e.g. entity_aliases(alias_type, alias_value))
+ * raises a constraint error rather than silently deleting the other row — the
+ * engine catches it and records a conflict.
+ */
+export function applyRemoteUpsert(
+  table: string,
+  row: Record<string, unknown>,
+): void {
+  const m = meta(table);
+  const cols = columns(table).filter(
+    (c) => !PAYLOAD_EXCLUDE.has(c) && c in row,
+  );
+  const placeholders = cols.map(() => "?").join(", ");
+  const conflict = m.idColumns.join(", ");
+  const nonPk = cols.filter((c) => !m.idColumns.includes(c));
+  const onConflict =
+    nonPk.length > 0
+      ? `DO UPDATE SET ${nonPk.map((c) => `${c}=excluded.${c}`).join(", ")}`
+      : "DO NOTHING";
+  const sql = `INSERT INTO ${table} (${cols.join(", ")}) VALUES (${placeholders}) ON CONFLICT(${conflict}) ${onConflict}`;
+  withApplying(() =>
+    db()
+      .query(sql)
+      .run(...cols.map((c) => row[c] as never)),
+  );
+}
+
+/** Delete a pulled-as-removed row locally (under apply-suppression). */
+export function applyRemoteDelete(table: string, rowId: string): void {
+  const m = meta(table);
+  const where = m.idColumns.map((c) => `${c} = ?`).join(" AND ");
+  withApplying(() =>
+    db()
+      .query(`DELETE FROM ${table} WHERE ${where}`)
+      .run(...splitRowId(rowId)),
+  );
+}
+
+/** Rebuild an external-content FTS5 index after a batch of pulled changes. */
+export function rebuildFts(ftsTable: string): void {
+  db().exec(`INSERT INTO ${ftsTable}(${ftsTable}) VALUES('rebuild')`);
+}
+
+// ---------------------------------------------------------------------------
+// Conflict classification
+// ---------------------------------------------------------------------------
+
+export type RemoteClass = "skip" | "apply" | "conflict";
+
+/**
+ * Classify a remote row against local state (see plan §3):
+ *  - `skip`     — remote content equals the local row (nothing to do).
+ *  - `apply`    — local is unchanged since our last sync (fast-forward).
+ *  - `conflict` — local also diverged since our last sync; the engine resolves
+ *    by last-writer-to-remote-wins and logs to `sync_conflicts`.
+ *
+ * `remoteHash` is the remote row's `content_hash` (null for a tombstone/delete).
+ *
+ * INVARIANT: `syncOnce()` pushes local changes BEFORE pulling, so by the time a
+ * remote row is classified our own pending edits/deletes are already on the
+ * remote. The engine still passes `pendingLocalChange` when its outbox cursor
+ * shows an unpushed change for this row (e.g. a local delete that hasn't been
+ * pushed) — in that case we never fast-forward over it, which prevents a
+ * concurrent remote upsert from silently resurrecting a locally-deleted row.
+ */
+export function classifyRemoteRow(
+  table: string,
+  rowId: string,
+  remoteHash: string | null,
+  opts: { pendingLocalChange?: boolean } = {},
+): RemoteClass {
+  const local = getRowById(table, rowId);
+  const localHash = local ? contentHash(table, local) : null;
+  if (remoteHash !== null && localHash === remoteHash) return "skip";
+
+  // Unpushed local intent (edit or delete) — do not fast-forward over it.
+  if (opts.pendingLocalChange) return "conflict";
+
+  const syncedHash = getSyncState(table, rowId)?.content_hash ?? null;
+  // Local matches what we last synced → no unpushed local change → fast-forward.
+  if (localHash === syncedHash) return "apply";
+  // Otherwise local also moved since last sync → genuine concurrent conflict.
+  return "conflict";
+}
+
+/**
+ * Record a resolved conflict. `localContent` is the discarded local row (we
+ * resolve last-writer-to-remote-wins), serialized so the lost edit is
+ * recoverable rather than silently destroyed.
+ */
+export function recordConflict(
+  table: string,
+  rowId: string,
+  resolution: string,
+  localContent?: Record<string, unknown> | null,
+): void {
+  meta(table);
+  db()
+    .query(
+      `INSERT INTO sync_conflicts (table_name, row_id, detected_at, resolution, local_content)
+       VALUES (?, ?, ?, ?, ?)`,
+    )
+    .run(
+      table,
+      rowId,
+      Date.now(),
+      resolution,
+      localContent ? JSON.stringify(localContent) : null,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Enable / disable
+// ---------------------------------------------------------------------------
+
+const ENABLED_KEY = "sync.enabled";
+
+/** True when local change-capture is active. */
+export function isSyncEnabled(): boolean {
+  return getTeamConfig(ENABLED_KEY) === "1";
+}
+
+/**
+ * Enable change-capture and reconcile the outbox against current state, so both
+ * first-enable (uploads pre-existing rows) and re-enable (catches edits/deletes
+ * made while sync was OFF) are captured. Idempotent — `reconcile` skips rows
+ * that already have a pending outbox entry.
+ */
+export function enableSync(tier: SyncTier = "basic"): void {
+  setTeamConfig(ENABLED_KEY, "1");
+  reconcile(tier);
+}
+
+/** Disable change-capture. Leaves the outbox/state intact for re-enable. */
+export function disableSync(): void {
+  deleteTeamConfig(ENABLED_KEY);
+}

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -56,7 +56,7 @@ describe("db", () => {
     const row = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(row.version).toBe(42);
+    expect(row.version).toBe(43);
   });
 
   test("session_prompt_deltas persist ordered selector/content rows (v42)", () => {

--- a/packages/core/test/sync-data.test.ts
+++ b/packages/core/test/sync-data.test.ts
@@ -1,0 +1,409 @@
+import { describe, test, expect, beforeEach } from "vitest";
+import { db, ensureProject, setTeamConfig, deleteTeamConfig } from "../src/db";
+import {
+  applyRemoteDelete,
+  applyRemoteUpsert,
+  classifyRemoteRow,
+  contentHash,
+  disableSync,
+  enableSync,
+  getRowById,
+  getSyncState,
+  isSyncEnabled,
+  maxOutboxSeq,
+  readOutbox,
+  rebuildFts,
+  rowIdOf,
+  seedOutbox,
+  setSyncState,
+  SYNCED_TABLES,
+  withApplying,
+} from "../src/sync-data";
+
+const now = () => Date.now();
+
+function insertKnowledge(id: string, title: string, content: string): string {
+  const pid = ensureProject("/tmp/lore-sync-data");
+  db()
+    .query(
+      `INSERT INTO knowledge (id, project_id, category, title, content, created_at, updated_at)
+       VALUES (?, ?, 'pattern', ?, ?, ?, ?)`,
+    )
+    .run(id, pid, title, content, now(), now());
+  return id;
+}
+
+function outboxFor(table: string) {
+  return readOutbox(0).filter((e) => e.table_name === table);
+}
+
+beforeEach(() => {
+  // Disable capture FIRST so the table cleanup below doesn't itself enqueue
+  // delete entries via the (working) outbox triggers, then clear state.
+  deleteTeamConfig("sync.enabled");
+  db().exec("DELETE FROM temp._sync_applying"); // reset suppression depth
+  db().exec("DELETE FROM knowledge");
+  db().exec("DELETE FROM sync_outbox");
+  db().exec("DELETE FROM sync_state");
+  db().exec("DELETE FROM sync_conflicts");
+});
+
+describe("v43 schema", () => {
+  test("sync tables exist", () => {
+    const names = (
+      db()
+        .query(
+          "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'sync_%'",
+        )
+        .all() as Array<{ name: string }>
+    ).map((r) => r.name);
+    expect(names).toContain("sync_outbox");
+    expect(names).toContain("sync_state");
+    expect(names).toContain("sync_conflicts");
+  });
+
+  test("outbox capture is installed as per-connection TEMP triggers", () => {
+    // Connection-scoped (temp) so a CLI process can't suppress the gateway's
+    // captures — they live in sqlite_temp_master, not the persistent schema.
+    const persistent = (
+      db()
+        .query(
+          "SELECT name FROM sqlite_master WHERE type='trigger' AND name LIKE '%_outbox_%'",
+        )
+        .all() as Array<{ name: string }>
+    ).length;
+    expect(persistent).toBe(0); // must NOT be persistent main-schema triggers
+
+    const triggers = (
+      db()
+        .query(
+          "SELECT name FROM sqlite_temp_master WHERE type='trigger' AND name LIKE '%_outbox_%'",
+        )
+        .all() as Array<{ name: string }>
+    ).map((r) => r.name);
+    for (const t of SYNCED_TABLES.basic) {
+      expect(triggers.some((n) => n.startsWith(`${t.table}_outbox_`))).toBe(
+        true,
+      );
+    }
+  });
+});
+
+describe("outbox capture", () => {
+  test("does NOT capture when sync is disabled", () => {
+    insertKnowledge("k1", "T", "C");
+    expect(outboxFor("knowledge")).toHaveLength(0);
+  });
+
+  test("captures insert/update/delete when sync is enabled", () => {
+    setTeamConfig("sync.enabled", "1");
+    insertKnowledge("k1", "T", "C");
+    db().query("UPDATE knowledge SET content = ? WHERE id = ?").run("C2", "k1");
+    db().query("DELETE FROM knowledge WHERE id = ?").run("k1");
+
+    const ops = outboxFor("knowledge").map((e) => e.op);
+    expect(ops).toEqual(["upsert", "upsert", "delete"]);
+    expect(outboxFor("knowledge").every((e) => e.row_id === "k1")).toBe(true);
+  });
+
+  test("apply-suppression prevents re-capture of pulled rows", () => {
+    setTeamConfig("sync.enabled", "1");
+    withApplying(() => insertKnowledge("k1", "T", "C"));
+    expect(outboxFor("knowledge")).toHaveLength(0);
+  });
+
+  test("composite row_id for the join table uses the unit separator", () => {
+    setTeamConfig("sync.enabled", "1");
+    const pid = ensureProject("/tmp/lore-sync-refs");
+    db()
+      .query(
+        `INSERT INTO entities (id, project_id, entity_type, canonical_name, created_at, updated_at)
+         VALUES ('e1', ?, 'tool', 'X', ?, ?)`,
+      )
+      .run(pid, now(), now());
+    insertKnowledge("k1", "T", "C");
+    db()
+      .query(
+        "INSERT INTO knowledge_entity_refs (knowledge_id, entity_id) VALUES ('k1','e1')",
+      )
+      .run();
+    const refs = outboxFor("knowledge_entity_refs");
+    expect(refs).toHaveLength(1);
+    expect(refs[0].row_id).toBe("k1\x1fe1");
+  });
+});
+
+describe("seedOutbox", () => {
+  test("enqueues all existing rows as upserts", () => {
+    insertKnowledge("k1", "A", "1"); // inserted while disabled → not captured
+    insertKnowledge("k2", "B", "2");
+    expect(outboxFor("knowledge")).toHaveLength(0);
+    seedOutbox();
+    const ids = outboxFor("knowledge")
+      .map((e) => e.row_id)
+      .sort();
+    expect(ids).toEqual(["k1", "k2"]);
+    expect(outboxFor("knowledge").every((e) => e.op === "upsert")).toBe(true);
+  });
+});
+
+describe("enableSync", () => {
+  test("sets the flag and seeds once (idempotent)", () => {
+    insertKnowledge("k1", "A", "1");
+    enableSync();
+    expect(isSyncEnabled()).toBe(true);
+    expect(outboxFor("knowledge")).toHaveLength(1);
+    // Second enable must not double-seed.
+    enableSync();
+    expect(outboxFor("knowledge")).toHaveLength(1);
+  });
+});
+
+describe("contentHash", () => {
+  test("stable across reads, ignores updated_at", () => {
+    insertKnowledge("k1", "T", "C");
+    const a = getRowById("knowledge", "k1") as Record<string, unknown>;
+    const h1 = contentHash("knowledge", a);
+    db()
+      .query("UPDATE knowledge SET updated_at = ? WHERE id='k1'")
+      .run(now() + 999);
+    const b = getRowById("knowledge", "k1") as Record<string, unknown>;
+    expect(contentHash("knowledge", b)).toBe(h1); // updated_at not hashed
+  });
+
+  test("changes when semantic content changes", () => {
+    insertKnowledge("k1", "T", "C");
+    const h1 = contentHash(
+      "knowledge",
+      getRowById("knowledge", "k1") as Record<string, unknown>,
+    );
+    db().query("UPDATE knowledge SET content='DIFFERENT' WHERE id='k1'").run();
+    const h2 = contentHash(
+      "knowledge",
+      getRowById("knowledge", "k1") as Record<string, unknown>,
+    );
+    expect(h2).not.toBe(h1);
+  });
+});
+
+describe("applyRemoteUpsert / applyRemoteDelete", () => {
+  test("upsert writes the row without enqueuing the outbox", () => {
+    setTeamConfig("sync.enabled", "1");
+    const pid = ensureProject("/tmp/lore-sync-apply");
+    applyRemoteUpsert("knowledge", {
+      id: "kr",
+      project_id: pid,
+      category: "pattern",
+      title: "Remote",
+      content: "from server",
+      created_at: now(),
+      updated_at: now(),
+    });
+    expect(getRowById("knowledge", "kr")?.title).toBe("Remote");
+    expect(outboxFor("knowledge")).toHaveLength(0); // suppressed
+    rebuildFts("knowledge_fts"); // must not throw
+  });
+
+  test("delete removes the row without enqueuing the outbox", () => {
+    setTeamConfig("sync.enabled", "1");
+    withApplying(() => insertKnowledge("kd", "T", "C"));
+    applyRemoteDelete("knowledge", "kd");
+    expect(getRowById("knowledge", "kd")).toBeNull();
+    expect(outboxFor("knowledge")).toHaveLength(0);
+  });
+});
+
+describe("classifyRemoteRow", () => {
+  test("skip when remote content equals local", () => {
+    insertKnowledge("k1", "T", "C");
+    const localHash = contentHash(
+      "knowledge",
+      getRowById("knowledge", "k1") as Record<string, unknown>,
+    );
+    expect(classifyRemoteRow("knowledge", "k1", localHash)).toBe("skip");
+  });
+
+  test("apply when local is unchanged since last sync (fast-forward)", () => {
+    insertKnowledge("k1", "T", "C");
+    const localHash = contentHash(
+      "knowledge",
+      getRowById("knowledge", "k1") as Record<string, unknown>,
+    );
+    // Record that the current local content is what we last synced.
+    setSyncState("knowledge", "k1", {
+      content_hash: localHash,
+      revision: 1,
+      remote_updated_at: "t0",
+    });
+    // Remote now has different content → fast-forward (no local divergence).
+    expect(classifyRemoteRow("knowledge", "k1", "deadbeefdeadbeef")).toBe(
+      "apply",
+    );
+  });
+
+  test("apply when there is no local row", () => {
+    expect(classifyRemoteRow("knowledge", "ghost", "deadbeefdeadbeef")).toBe(
+      "apply",
+    );
+  });
+
+  test("conflict when both local and remote diverged since last sync", () => {
+    insertKnowledge("k1", "T", "C");
+    // We last synced an OLDER content (different hash than current local).
+    setSyncState("knowledge", "k1", {
+      content_hash: "oldsyncedhashxx",
+      revision: 1,
+      remote_updated_at: "t0",
+    });
+    // Local content differs from last-synced AND remote differs too → conflict.
+    expect(classifyRemoteRow("knowledge", "k1", "remotehashxxxxxx")).toBe(
+      "conflict",
+    );
+  });
+});
+
+describe("getSyncState / maxOutboxSeq", () => {
+  test("sync_state round-trips", () => {
+    setSyncState("knowledge", "k1", {
+      content_hash: "abc",
+      revision: 3,
+      remote_updated_at: "2026-01-01T00:00:00Z",
+    });
+    expect(getSyncState("knowledge", "k1")).toEqual({
+      content_hash: "abc",
+      revision: 3,
+      remote_updated_at: "2026-01-01T00:00:00Z",
+    });
+  });
+
+  test("maxOutboxSeq tracks the high-watermark", () => {
+    expect(maxOutboxSeq()).toBe(0);
+    setTeamConfig("sync.enabled", "1");
+    insertKnowledge("k1", "T", "C");
+    insertKnowledge("k2", "T", "C");
+    expect(maxOutboxSeq()).toBe(readOutbox(0).at(-1)?.seq);
+  });
+
+  test("rowIdOf builds composite ids", () => {
+    expect(rowIdOf("knowledge", { id: "x" })).toBe("x");
+    expect(
+      rowIdOf("knowledge_entity_refs", { knowledge_id: "k", entity_id: "e" }),
+    ).toBe("k\x1fe");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regressions for the adversarial review findings
+// ---------------------------------------------------------------------------
+
+describe("withApplying re-entrancy (BLOCKER fix)", () => {
+  test("nested apply does not re-enable capture in the outer scope", () => {
+    setTeamConfig("sync.enabled", "1");
+    withApplying(() => {
+      withApplying(() => insertKnowledge("inner", "T", "C"));
+      // After the INNER block exits, capture must still be suppressed because
+      // the OUTER block is applying — a unconditional clear would re-enable it.
+      insertKnowledge("outer", "T", "C");
+    });
+    expect(outboxFor("knowledge")).toHaveLength(0);
+  });
+
+  test("depth counter restores capture only after the outermost exit", () => {
+    setTeamConfig("sync.enabled", "1");
+    withApplying(() => withApplying(() => {}));
+    // Both levels exited → capture active again.
+    insertKnowledge("after", "T", "C");
+    expect(outboxFor("knowledge").map((e) => e.row_id)).toEqual(["after"]);
+  });
+});
+
+describe("reconcile / re-enable (data-loss fix)", () => {
+  test("captures edits AND deletes made while sync was disabled", () => {
+    // Initial sync of two rows.
+    enableSync();
+    insertKnowledge("keep", "T", "C");
+    insertKnowledge("gone", "T", "C");
+    // Pretend we pushed them: record sync_state + drain the outbox.
+    for (const id of ["keep", "gone"]) {
+      setSyncState("knowledge", id, {
+        content_hash: contentHash(
+          "knowledge",
+          getRowById("knowledge", id) as Record<string, unknown>,
+        ),
+        revision: 1,
+        remote_updated_at: "t0",
+      });
+    }
+    db().exec("DELETE FROM sync_outbox");
+
+    // Disable, then mutate while OFF (triggers don't fire).
+    disableSync();
+    db().query("UPDATE knowledge SET content='EDITED' WHERE id='keep'").run();
+    db().query("DELETE FROM knowledge WHERE id='gone'").run();
+    expect(outboxFor("knowledge")).toHaveLength(0);
+
+    // Re-enable → reconcile must re-enqueue the edit (upsert) and the delete.
+    enableSync();
+    const ops = Object.fromEntries(
+      outboxFor("knowledge").map((e) => [e.row_id, e.op]),
+    );
+    expect(ops.keep).toBe("upsert");
+    expect(ops.gone).toBe("delete");
+  });
+
+  test("seedOutbox is idempotent (no duplicate pending upserts)", () => {
+    insertKnowledge("k1", "T", "C");
+    seedOutbox();
+    seedOutbox();
+    expect(outboxFor("knowledge")).toHaveLength(1);
+  });
+});
+
+describe("applyRemoteUpsert keeps rowid stable (FTS-safe)", () => {
+  test("repeated upserts update in place — rowid unchanged, FTS consistent", () => {
+    const pid = ensureProject("/tmp/lore-sync-fts");
+    const row = (content: string) => ({
+      id: "kf",
+      project_id: pid,
+      category: "pattern",
+      title: "T",
+      content,
+      created_at: now(),
+      updated_at: now(),
+    });
+    applyRemoteUpsert("knowledge", row("first"));
+    const rowid1 = (
+      db().query("SELECT rowid AS r FROM knowledge WHERE id='kf'").get() as {
+        r: number;
+      }
+    ).r;
+    applyRemoteUpsert("knowledge", row("second"));
+    const rowid2 = (
+      db().query("SELECT rowid AS r FROM knowledge WHERE id='kf'").get() as {
+        r: number;
+      }
+    ).r;
+    expect(rowid2).toBe(rowid1); // ON CONFLICT DO UPDATE, not delete+insert
+
+    // FTS finds the NEW content and not the stale one (no orphan postings).
+    rebuildFts("knowledge_fts");
+    const hitNew = db()
+      .query(
+        "SELECT k.id FROM knowledge_fts f JOIN knowledge k ON k.rowid=f.rowid WHERE knowledge_fts MATCH 'second'",
+      )
+      .get() as { id: string } | undefined;
+    expect(hitNew?.id).toBe("kf");
+  });
+});
+
+describe("classifyRemoteRow pendingLocalChange (resurrection fix)", () => {
+  test("an unpushed local change is never fast-forwarded over", () => {
+    // No local row, no sync_state → would otherwise be "apply"; the engine
+    // signals a pending local delete, so it must be a conflict instead.
+    expect(
+      classifyRemoteRow("knowledge", "deleted", "remotehashxxxxxx", {
+        pendingLocalChange: true,
+      }),
+    ).toBe("conflict");
+  });
+});

--- a/packages/gateway/src/cli/help.ts
+++ b/packages/gateway/src/cli/help.ts
@@ -26,6 +26,7 @@ Commands:
   login               Sign in to your Folk Lore account (GitHub or --email)
   logout              Sign out and clear the local session
   whoami              Show the signed-in Folk Lore account
+  sync <subcommand>   Cloud-sync knowledge + entities (enable, disable, status, now)
   entity <subcommand> Manage the entity registry (list, show, add, merge)
   upgrade [version]   Update lore to the latest (or specified) version
                        Flags: --check, --force, --offline, --channel <ch>
@@ -153,6 +154,9 @@ Examples:
   lore login --email me@x.com   # Sign in with an email OTP code (needs SMTP)
   lore whoami                   # Show the signed-in account
   lore logout                   # Sign out
+  lore sync enable              # Turn on cloud sync of knowledge + entities
+  lore sync status              # Show sync state + pending local changes
+  lore sync now                 # Push local changes then pull remote changes
 
 Environment variables:
   LORE_LISTEN_PORT              Gateway port (overridden by --port)

--- a/packages/gateway/src/cli/main.ts
+++ b/packages/gateway/src/cli/main.ts
@@ -329,6 +329,12 @@ export async function _cli(): Promise<void> {
         break;
       }
 
+      case "sync": {
+        const { commandSync } = await import("./sync-cmd");
+        await commandSync(rest, values as Record<string, unknown>);
+        break;
+      }
+
       case "logs": {
         const { commandLogs } = await import("./logs");
         await commandLogs(rest, values as Record<string, unknown>);
@@ -379,6 +385,7 @@ export async function _cli(): Promise<void> {
               "login",
               "logout",
               "whoami",
+              "sync",
               "logs",
               "import",
               "entity",

--- a/packages/gateway/src/cli/sync-cmd.ts
+++ b/packages/gateway/src/cli/sync-cmd.ts
@@ -1,0 +1,134 @@
+/**
+ * CLI `lore sync` — Basic-tier cloud sync of knowledge + the entity graph.
+ *
+ *   lore sync enable     Turn on sync (reconciles existing rows) and sync now
+ *   lore sync disable    Turn off local change-capture (keeps remote data)
+ *   lore sync status     Show whether sync is on, pending changes, last result
+ *   lore sync now        Run one push-then-pull cycle
+ *   lore sync            Alias for `status`
+ *
+ * Runs without the gateway — talks to the local DB + Supabase directly. Requires
+ * `lore login` first (sync needs the user's account).
+ */
+import { syncData, getKV } from "@loreai/core";
+
+export async function commandSync(
+  positionals: string[],
+  _values: Record<string, unknown>,
+): Promise<void> {
+  const sub = positionals[0] ?? "status";
+
+  switch (sub) {
+    case "enable":
+      await cmdEnable();
+      break;
+    case "disable":
+      cmdDisable();
+      break;
+    case "status":
+      await cmdStatus();
+      break;
+    case "now":
+      await cmdNow();
+      break;
+    default:
+      console.error(
+        `Unknown sync subcommand "${sub}".\nUsage: lore sync [enable|disable|status|now]`,
+      );
+      process.exitCode = 1;
+  }
+}
+
+async function cmdEnable(): Promise<void> {
+  const { getCurrentUser } = await import("../supabase");
+  const user = await getCurrentUser();
+  if (!user) {
+    console.error(
+      'Not logged in. Run "lore login" first, then "lore sync enable".',
+    );
+    process.exitCode = 1;
+    return;
+  }
+  if (syncData.isSyncEnabled()) {
+    console.log("Sync is already enabled.");
+  } else {
+    syncData.enableSync("basic");
+    console.log(
+      `Sync enabled for ${formatUser(user)}. Reconciling existing knowledge + entities…`,
+    );
+  }
+  await runSync();
+}
+
+function cmdDisable(): void {
+  if (!syncData.isSyncEnabled()) {
+    console.log("Sync is not enabled.");
+    return;
+  }
+  syncData.disableSync();
+  console.log(
+    "Sync disabled. Local change-capture is off; your synced data remains on the server.",
+  );
+}
+
+async function cmdStatus(): Promise<void> {
+  const enabled = syncData.isSyncEnabled();
+  console.log(`Sync: ${enabled ? "enabled" : "disabled"}`);
+
+  const { getCurrentUser } = await import("../supabase");
+  const user = await getCurrentUser();
+  console.log(`Account: ${user ? formatUser(user) : "not logged in"}`);
+
+  if (enabled) {
+    // Pending = distinct (table,row_id) with an outbox seq beyond that table's
+    // push cursor. Cursors are per table.
+    const seen = new Set<string>();
+    for (const meta of syncData.syncedTables("basic")) {
+      const cursor = Number(getKV(`sync.push.${meta.table}`) ?? "0");
+      for (const e of syncData.readOutbox(cursor, 100_000, meta.table)) {
+        seen.add(`${e.table_name}\x1f${e.row_id}`);
+      }
+    }
+    console.log(`Pending local changes: ${seen.size}`);
+  }
+}
+
+async function cmdNow(): Promise<void> {
+  if (!syncData.isSyncEnabled()) {
+    console.error('Sync is not enabled. Run "lore sync enable" first.');
+    process.exitCode = 1;
+    return;
+  }
+  await runSync();
+}
+
+/** Run one sync cycle and print a human-readable summary. */
+async function runSync(): Promise<void> {
+  const { syncOnce } = await import("../sync");
+  const r = await syncOnce();
+  if (r.notAuthed) {
+    console.error('Session expired. Run "lore login" again.');
+    process.exitCode = 1;
+    return;
+  }
+  console.log(
+    `Synced: pushed ${r.pushed}, pulled ${r.pulled}` +
+      (r.conflicts
+        ? `, ${r.conflicts} conflict(s) resolved (remote wins)`
+        : ""),
+  );
+  if (r.quotaHit) {
+    console.error(
+      `\nReached your free-tier sync limit on "${r.quotaHit.table}". ` +
+        "Some changes were not uploaded. Upgrade to Pro to sync more.",
+    );
+    process.exitCode = 1;
+  }
+}
+
+function formatUser(u: {
+  github_login?: string | null;
+  email?: string | null;
+}): string {
+  return u.github_login ? `@${u.github_login}` : (u.email ?? "your account");
+}

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -474,6 +474,11 @@ export async function resetPipelineState(opts?: {
     stopIdleScheduler();
     stopIdleScheduler = null;
   }
+  if (stopSyncScheduler) {
+    // Awaits a final best-effort push so local changes reach the server on exit.
+    await stopSyncScheduler();
+    stopSyncScheduler = null;
+  }
   _lastSeenSessionModel = null;
   resetWorkerModelState();
   resetBackgroundLimiter();
@@ -1147,6 +1152,7 @@ let batchQueueEnabled = false;
 
 /** Cleanup function for the idle scheduler timer. */
 let stopIdleScheduler: (() => void) | null = null;
+let stopSyncScheduler: (() => Promise<void>) | null = null;
 
 /** Cleanup function for the .lore.md / agents-file watcher. */
 let stopFileWatcher: (() => void) | null = null;
@@ -1584,6 +1590,12 @@ async function initIfNeeded(
         }
       },
     );
+  }
+
+  // Start background cloud sync (no-op until the user runs `lore sync enable`).
+  if (!stopSyncScheduler) {
+    const { startSyncScheduler } = await import("./sync");
+    stopSyncScheduler = startSyncScheduler();
   }
 
   log.info(`gateway pipeline initialized: ${projectPath}`);

--- a/packages/gateway/src/sync.ts
+++ b/packages/gateway/src/sync.ts
@@ -184,9 +184,12 @@ async function pushEntry(
     payload.content_hash = hash;
     payload.revision = revision;
   }
-  const { error } = await client
-    .from(table)
-    .upsert(payload, { onConflict: idColumns(table).join(",") });
+  // The REMOTE primary key is composite — (owner_user_id, <idColumns>) — so the
+  // ON CONFLICT target must include owner_user_id (the local PK is just
+  // idColumns). owner_user_id is filled by the column's auth.uid() default.
+  const { error } = await client.from(table).upsert(payload, {
+    onConflict: ["owner_user_id", ...idColumns(table)].join(","),
+  });
 
   if (error) {
     const kind = classifyPushError(error);

--- a/packages/gateway/src/sync.ts
+++ b/packages/gateway/src/sync.ts
@@ -1,0 +1,582 @@
+/**
+ * Gateway sync engine — Basic-tier logical sync of knowledge + the entity graph
+ * to Supabase (see supabase/migrations/0002-0004 and @loreai/core sync-data).
+ *
+ * Model:
+ *  - Local SQLite is the source of truth. `syncOnce()` PUSHES local changes
+ *    (the outbox) BEFORE it PULLS remote changes, so our own edits/deletes reach
+ *    the server before we classify incoming rows (prevents resurrecting a
+ *    locally-deleted row).
+ *  - Conflicts (both sides changed since last sync) resolve last-writer-to-
+ *    remote-wins; the discarded local row is preserved in `sync_conflicts`.
+ *  - Writes go directly to PostgREST. RLS enforces per-row ownership; in-DB
+ *    triggers/CHECKs enforce volume/size. A quota rejection (HTTP 400, code
+ *    23514) pauses ONLY the affected table and is surfaced to the user — it is
+ *    never an error to crash on, and never blocks other tables.
+ *
+ * Cursors are PER TABLE so one table's failure/quota can't stall the others:
+ *  - sync.push.<table>   : last outbox seq fully pushed for that table.
+ *  - sync.pull.<table>   : keyset cursor "<updated_at_ms>|<row_id>" of the last
+ *                          remote row applied (tie-broken by row_id, so rows
+ *                          sharing a timestamp across a page boundary are not
+ *                          skipped).
+ */
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { syncData, getKV, setKV } from "@loreai/core";
+import { getAuthedClient } from "./supabase";
+
+const PAGE = 200;
+const pushKey = (t: string) => `sync.push.${t}`;
+const pullKey = (t: string) => `sync.pull.${t}`;
+
+export interface SyncResult {
+  pushed: number;
+  pulled: number;
+  conflicts: number;
+  /** Tables whose upload was paused this cycle by a quota limit. */
+  quotaHit?: { table: string; message: string };
+  /** Set when not logged in / session invalid (caller should prompt login). */
+  notAuthed?: boolean;
+}
+
+type PushErrorKind = "quota" | "poison" | "transient";
+
+/**
+ * Classify a PostgREST write error:
+ *  - "quota"     : row-count limit (recoverable — a delete frees a slot). Pause
+ *                  this table; keep the row pending.
+ *  - "poison"    : a size/other CHECK violation (23514 that is NOT a quota
+ *                  message). The row can NEVER fit, so pausing the table would
+ *                  wedge it forever — instead drop the row past the cursor and
+ *                  record it so the rest of the table keeps syncing.
+ *  - "transient" : network/5xx/etc. — keep pending and retry next cycle.
+ */
+function classifyPushError(
+  err: { code?: string; message?: string } | null,
+): PushErrorKind {
+  if (!err) return "transient";
+  const quota = /quota exceeded/i.test(err.message ?? "");
+  if (err.code === "23514") return quota ? "quota" : "poison";
+  return "transient";
+}
+
+// ---------------------------------------------------------------------------
+// Push (per table — independent cursor; advance only past confirmed rows)
+// ---------------------------------------------------------------------------
+
+/**
+ * Push pending local changes for every synced table. Each table is drained
+ * independently: a quota or transient failure on one table never advances its
+ * cursor past the unpushed row and never blocks another table.
+ */
+export async function pushOnce(client: SupabaseClient): Promise<SyncResult> {
+  const res: SyncResult = { pushed: 0, pulled: 0, conflicts: 0 };
+  for (const meta of syncData.syncedTables("basic")) {
+    await pushTable(client, meta.table, res);
+  }
+  // Reclaim outbox rows fully pushed across all tables THAT HAVE ENTRIES (seq <=
+  // the lowest such cursor) — the outbox is otherwise append-only. A table with
+  // no entries must NOT pin the floor at its cursor 0, which would block all
+  // pruning forever (the common case: a project with knowledge but no relations).
+  const cursors = syncData
+    .syncedTables("basic")
+    .filter((m) => syncData.hasOutboxEntries(m.table))
+    .map((m) => Number(getKV(pushKey(m.table)) ?? "0"));
+  if (cursors.length > 0) {
+    const minCursor = Math.min(...cursors);
+    if (Number.isFinite(minCursor)) syncData.pruneOutbox(minCursor);
+  }
+  return res;
+}
+
+async function pushTable(
+  client: SupabaseClient,
+  table: string,
+  res: SyncResult,
+): Promise<void> {
+  let cursor = Number(getKV(pushKey(table)) ?? "0");
+
+  for (;;) {
+    // Pull a page of THIS table's outbox entries in seq order (SQL-filtered, so
+    // other tables' entries can never starve this one).
+    const batch = syncData.readOutbox(cursor, PAGE, table);
+    if (batch.length === 0) break;
+
+    // Coalesce to the latest op per row, but REMEMBER the highest seq each row
+    // occupies so we can advance the cursor safely.
+    const latestByRow = new Map<string, syncData.OutboxEntry>();
+    for (const e of batch) latestByRow.set(e.row_id, e);
+
+    // Walk entries in seq order; advance `cursor` only across a contiguous
+    // prefix of rows that are confirmed pushed (or no-ops). Stop advancing at
+    // the first row that failed or was quota-paused, leaving it pending.
+    let safeCursor = cursor;
+    let stop = false;
+    for (const e of batch) {
+      // Only act on the coalesced (latest) entry for a row; earlier duplicates
+      // are covered by it. But every entry still gates cursor advancement.
+      if (latestByRow.get(e.row_id) === e) {
+        const outcome = await pushEntry(client, e, res);
+        if (outcome === "stop") {
+          stop = true;
+          break; // do NOT advance past this seq — retry next cycle
+        }
+        // "ok" → fall through and advance
+      }
+      safeCursor = e.seq;
+    }
+
+    cursor = safeCursor;
+    setKV(pushKey(table), String(cursor));
+    if (stop || batch.length < PAGE) break;
+  }
+}
+
+type PushOutcome = "ok" | "stop";
+
+/** Push one coalesced outbox entry. "stop" => leave it pending (quota/error). */
+async function pushEntry(
+  client: SupabaseClient,
+  e: syncData.OutboxEntry,
+  res: SyncResult,
+): Promise<PushOutcome> {
+  const { table_name: table, row_id: rowId, op } = e;
+
+  if (op === "delete") {
+    const { error } = await client
+      .from(table)
+      .update({ is_deleted: true })
+      .match(decomposeId(table, rowId));
+    if (error) {
+      console.error(`sync: push delete ${table}/${rowId}: ${error.message}`);
+      return "stop"; // transient; keep pending so the delete isn't lost
+    }
+    const prev = syncData.getSyncState(table, rowId);
+    syncData.setSyncState(table, rowId, {
+      content_hash: null,
+      revision: (prev?.revision ?? 0) + 1,
+      remote_updated_at: prev?.remote_updated_at ?? null,
+    });
+    res.pushed++;
+    return "ok";
+  }
+
+  // upsert
+  const row = syncData.getRowById(table, rowId);
+  if (!row) return "ok"; // row gone; a later delete entry (if any) handles it
+  const hash = syncData.contentHash(table, row);
+  const state = syncData.getSyncState(table, rowId);
+  if (state?.content_hash === hash) {
+    res.pushed++; // already in sync — no-op
+    return "ok";
+  }
+
+  const revision = (state?.revision ?? 0) + 1;
+  // Only the synced data columns (the remote 0002 contract) — never local-only
+  // columns like knowledge.promoted_at, which the remote rejects (PGRST204).
+  const payload: Record<string, unknown> = {
+    ...toRemoteRow(syncData.pickSyncColumns(table, row)),
+    is_deleted: false,
+  };
+  // Only versioned tables have content_hash/revision columns remotely; sending
+  // them to the join table is a PGRST204 schema error (and would never sync it).
+  if (tableMeta(table).versioned !== false) {
+    payload.content_hash = hash;
+    payload.revision = revision;
+  }
+  const { error } = await client
+    .from(table)
+    .upsert(payload, { onConflict: idColumns(table).join(",") });
+
+  if (error) {
+    const kind = classifyPushError(error);
+    if (kind === "quota") {
+      if (!res.quotaHit) res.quotaHit = { table, message: error.message };
+      console.error(`sync: quota on ${table} — ${error.message}`);
+      return "stop"; // pause THIS table; keep the row pending (a delete frees it)
+    }
+    if (kind === "poison") {
+      // The row violates a size/other CHECK and can NEVER be uploaded. Do NOT
+      // pause the table (that would wedge it forever) — record it and advance
+      // past it so the rest of the table keeps syncing.
+      console.error(
+        `sync: dropping unsyncable ${table}/${rowId}: ${error.message}`,
+      );
+      syncData.recordConflict(table, rowId, "rejected_unsyncable", row);
+      // Mark as "synced" to this hash so we don't retry the same poison row.
+      syncData.setSyncState(table, rowId, {
+        content_hash: hash,
+        revision,
+        remote_updated_at: state?.remote_updated_at ?? null,
+      });
+      return "ok";
+    }
+    console.error(`sync: push upsert ${table}/${rowId}: ${error.message}`);
+    return "stop"; // transient — keep pending so we retry (never lose a write)
+  }
+
+  syncData.setSyncState(table, rowId, {
+    content_hash: hash,
+    revision,
+    remote_updated_at: state?.remote_updated_at ?? null,
+  });
+  res.pushed++;
+  return "ok";
+}
+
+// ---------------------------------------------------------------------------
+// Pull (per table — keyset cursor on (updated_at, row_id))
+// ---------------------------------------------------------------------------
+
+interface KeysetCursor {
+  ms: number;
+  id: string;
+}
+
+function parseCursor(raw: string | null): KeysetCursor {
+  if (!raw) return { ms: 0, id: "" };
+  const sep = raw.lastIndexOf("|");
+  if (sep < 0) return { ms: Date.parse(raw) || 0, id: "" };
+  return { ms: Number(raw.slice(0, sep)) || 0, id: raw.slice(sep + 1) };
+}
+
+function formatCursor(c: KeysetCursor): string {
+  return `${c.ms}|${c.id}`;
+}
+
+/**
+ * Pull remote rows changed since each table's keyset cursor and apply them
+ * locally under suppression. The cursor is `(updated_at_ms, row_id)`: we page by
+ * `updated_at >= cursor.ms` and skip rows we've already applied (<= cursor in
+ * keyset order), so rows that share a timestamp across a page boundary are never
+ * dropped. Timestamps are compared as parsed instants, not lexical ISO strings.
+ */
+export async function pullOnce(client: SupabaseClient): Promise<SyncResult> {
+  const res: SyncResult = { pushed: 0, pulled: 0, conflicts: 0 };
+
+  for (const meta of syncData.syncedTables("basic")) {
+    const touchedFts = new Set<string>();
+    let cursor = parseCursor(getKV(pullKey(meta.table)));
+
+    const idc = meta.idColumns[0];
+    for (;;) {
+      const sinceIso = new Date(cursor.ms).toISOString();
+      // Page by (updated_at, id). `gte` includes cursor.ms; the in-memory keyset
+      // skip drops rows already applied. (timestamptz is compared by VALUE, so
+      // Z vs +00:00 / fractional formats are equivalent.)
+      let q = client
+        .from(meta.table)
+        .select("*")
+        .order("updated_at", { ascending: true })
+        .order(idc, { ascending: true })
+        .limit(PAGE);
+      q = q.gte("updated_at", sinceIso);
+      const { data, error } = await q;
+      if (error) {
+        console.error(`sync: pull ${meta.table}: ${error.message}`);
+        break;
+      }
+      const rows = (data ?? []) as Array<Record<string, unknown>>;
+      if (rows.length === 0) break;
+
+      let advanced = false;
+      for (const remote of rows) {
+        const ms = Date.parse(String(remote.updated_at ?? "")) || 0;
+        const rid = syncData.rowIdOf(meta.table, remote);
+        if (ms < cursor.ms || (ms === cursor.ms && rid <= cursor.id)) continue;
+        applyRemote(meta, remote, res, touchedFts);
+        cursor = { ms, id: rid };
+        advanced = true;
+      }
+      setKV(pullKey(meta.table), formatCursor(cursor));
+
+      if (rows.length < PAGE) break; // last page
+
+      if (!advanced) {
+        // A FULL page with no NEW rows ⇒ >PAGE rows share cursor.ms and `gte`
+        // keeps returning the same first PAGE. Drain the REST of this exact
+        // millisecond by id keyset (eq + id>cursor) before resuming — this never
+        // skips a row (we only advance past ids we've actually applied).
+        const drained = await drainTimestamp(
+          client,
+          meta,
+          sinceIso,
+          cursor,
+          res,
+          touchedFts,
+        );
+        cursor = drained;
+        setKV(pullKey(meta.table), formatCursor(cursor));
+      }
+    }
+
+    for (const fts of touchedFts) syncData.rebuildFts(fts);
+  }
+  return res;
+}
+
+/**
+ * Drain rows that share exactly `iso` (one millisecond) beyond `cursor.id`,
+ * paging by id keyset (`updated_at == iso AND id > lastId`). Used when >PAGE
+ * rows collide on one timestamp so the primary `gte` page can't advance.
+ *
+ * Keysets by the FULL primary key, in id-column order: `(c1 > v1) OR (c1 = v1
+ * AND c2 > v2) ...`. We page one id-column boundary at a time using only simple
+ * `.gt`/`.eq` filters (no fragile `.or()` timestamp encoding): advance the last
+ * id column with `.gt`, and when it's exhausted step the preceding column.
+ */
+async function drainTimestamp(
+  client: SupabaseClient,
+  meta: syncData.SyncTableMeta,
+  iso: string,
+  cursor: KeysetCursor,
+  res: SyncResult,
+  touchedFts: Set<string>,
+): Promise<KeysetCursor> {
+  const cols = meta.idColumns;
+  // Per-id-column "last applied" values; seed from the cursor's composite id.
+  const last = cursor.id ? cursor.id.split("\x1f") : cols.map(() => "");
+  for (;;) {
+    // Fetch rows at this ms strictly after `last` in composite-key order. We
+    // filter on the LAST id column with `.gt(last)` and pin the preceding
+    // columns with `.eq(last)`; when a prefix is exhausted we widen below.
+    let q = client.from(meta.table).select("*").eq("updated_at", iso);
+    for (let i = 0; i < cols.length - 1; i++) q = q.eq(cols[i], last[i]);
+    q = q.gt(cols[cols.length - 1], last[cols.length - 1]);
+    for (const c of cols) q = q.order(c, { ascending: true });
+    const { data, error } = await q.limit(PAGE);
+    if (error) {
+      console.error(`sync: pull drain ${meta.table}: ${error.message}`);
+      break;
+    }
+    let rows = (data ?? []) as Array<Record<string, unknown>>;
+
+    if (rows.length === 0) {
+      // No more rows under the current prefix. For a single-id table that means
+      // we're done. For a composite key, step the FIRST id column past `last[0]`
+      // and reset the rest, to cover other groups at this same ms.
+      if (cols.length === 1) break;
+      const { data: next, error: nextErr } = await client
+        .from(meta.table)
+        .select("*")
+        .eq("updated_at", iso)
+        .gt(cols[0], last[0])
+        .order(cols[0], { ascending: true })
+        .order(cols[1], { ascending: true })
+        .limit(PAGE);
+      if (nextErr) {
+        console.error(`sync: pull drain ${meta.table}: ${nextErr.message}`);
+        break;
+      }
+      rows = (next ?? []) as Array<Record<string, unknown>>;
+      if (rows.length === 0) break;
+    }
+
+    for (const remote of rows) {
+      applyRemote(meta, remote, res, touchedFts);
+      cols.forEach((c, i) => {
+        last[i] = String(remote[c]);
+      });
+      cursor = { ms: cursor.ms, id: syncData.rowIdOf(meta.table, remote) };
+    }
+  }
+  // Past this millisecond entirely; the next primary page resumes at ms+1.
+  return { ms: cursor.ms + 1, id: "" };
+}
+
+function applyRemote(
+  meta: syncData.SyncTableMeta,
+  remote: Record<string, unknown>,
+  res: SyncResult,
+  touchedFts: Set<string>,
+): void {
+  const rowId = syncData.rowIdOf(meta.table, remote);
+  const isDeleted = remote.is_deleted === true || remote.is_deleted === 1;
+  const remoteHash =
+    typeof remote.content_hash === "string" ? remote.content_hash : null;
+
+  // Unpushed local intent for this row (push runs first, but a quota-paused or
+  // failed push can leave one pending) → never fast-forward over it.
+  const pushCursor = Number(getKV(pushKey(meta.table)) ?? "0");
+  const pendingLocalChange = syncData.hasPendingChange(
+    meta.table,
+    rowId,
+    pushCursor,
+  );
+  const cls = syncData.classifyRemoteRow(meta.table, rowId, remoteHash, {
+    pendingLocalChange,
+  });
+
+  if (cls === "skip") return;
+  if (cls === "conflict") {
+    res.conflicts++;
+    // Preserve the local row we're about to overwrite (LWW = remote wins).
+    const localBefore = syncData.getRowById(meta.table, rowId);
+    syncData.recordConflict(
+      meta.table,
+      rowId,
+      isDeleted ? "remote_delete_wins" : "remote_upsert_wins",
+      localBefore,
+    );
+  }
+
+  if (isDeleted) {
+    syncData.applyRemoteDelete(meta.table, rowId);
+    syncData.clearSyncState(meta.table, rowId);
+    for (const fts of meta.ftsTables) touchedFts.add(fts);
+  } else {
+    syncData.applyRemoteUpsert(meta.table, stripSyncCols(remote));
+    syncData.setSyncState(meta.table, rowId, {
+      content_hash: remoteHash,
+      revision: typeof remote.revision === "number" ? remote.revision : 0,
+      remote_updated_at: String(remote.updated_at ?? ""),
+    });
+    for (const fts of meta.ftsTables) touchedFts.add(fts);
+  }
+  res.pulled++;
+}
+
+// ---------------------------------------------------------------------------
+// syncOnce — push then pull
+// ---------------------------------------------------------------------------
+
+export async function syncOnce(): Promise<SyncResult> {
+  if (!syncData.isSyncEnabled()) {
+    return { pushed: 0, pulled: 0, conflicts: 0 };
+  }
+  const client = await getAuthedClient();
+  if (!client) return { pushed: 0, pulled: 0, conflicts: 0, notAuthed: true };
+
+  const push = await pushOnce(client);
+  const pull = await pullOnce(client);
+  return {
+    pushed: push.pushed,
+    pulled: pull.pulled,
+    conflicts: push.conflicts + pull.conflicts,
+    quotaHit: push.quotaHit,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Background scheduler (startup pull + periodic + shutdown push)
+// ---------------------------------------------------------------------------
+
+const DEFAULT_SYNC_INTERVAL_MS = 60_000;
+
+/**
+ * Start periodic background sync. Self-contained (owns its interval). Runs one
+ * cycle ~5s after startup, then every `intervalMs`. Best-effort. The returned
+ * stop function AWAITS any in-flight cycle before doing a final flush, so the
+ * shutdown push never races a periodic push (which would corrupt cursors).
+ */
+export function startSyncScheduler(
+  intervalMs = DEFAULT_SYNC_INTERVAL_MS,
+): () => Promise<void> {
+  let inflight: Promise<unknown> | null = null;
+
+  const tick = () => {
+    if (inflight || !syncData.isSyncEnabled()) return;
+    inflight = syncOnce()
+      .then((r) => {
+        if (r.quotaHit) {
+          console.error(
+            `sync: quota reached on ${r.quotaHit.table}; that table paused until next change`,
+          );
+        }
+      })
+      .catch((e) =>
+        console.error(`sync: background cycle failed: ${(e as Error).message}`),
+      )
+      .finally(() => {
+        inflight = null;
+      });
+  };
+
+  const startupTimer = setTimeout(tick, 5_000);
+  startupTimer.unref?.();
+  const timer = setInterval(tick, intervalMs);
+  timer.unref?.();
+
+  return async () => {
+    clearTimeout(startupTimer);
+    clearInterval(timer);
+    if (inflight) await inflight.catch(() => {}); // don't race the in-flight cycle
+    if (!syncData.isSyncEnabled()) return;
+    try {
+      const client = await getAuthedClient();
+      if (client) await pushOnce(client); // final best-effort flush
+    } catch {
+      // shutdown flush is best-effort
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Synced columns that live only on the remote — stripped before local apply. */
+const REMOTE_ONLY_COLS = new Set([
+  "owner_user_id",
+  "content_hash",
+  "revision",
+  "is_deleted",
+]);
+
+const TS_COLS = new Set(["created_at", "updated_at"]);
+
+function stripSyncCols(
+  remote: Record<string, unknown>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(remote)) {
+    if (REMOTE_ONLY_COLS.has(k)) continue;
+    // Remote timestamps are ISO strings; the local schema stores epoch ms.
+    if (TS_COLS.has(k) && typeof v === "string") {
+      // Distinguish a real parse failure from a valid epoch 0 (Date.parse → 0
+      // is falsy; `|| Date.now()` would corrupt created_at, which IS hashed).
+      const parsed = Date.parse(v);
+      out[k] = Number.isNaN(parsed) ? Date.now() : parsed;
+    } else {
+      out[k] = v;
+    }
+  }
+  return out;
+}
+
+/**
+ * Convert a local row for upload: the local schema stores timestamps as epoch
+ * ms integers, but the remote columns are `timestamptz` — sending a bare ms int
+ * raises 22008 (out of range) and would fail every upsert. Symmetric inverse of
+ * stripSyncCols.
+ */
+function toRemoteRow(row: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...row };
+  for (const k of TS_COLS) {
+    if (typeof out[k] === "number") {
+      out[k] = new Date(out[k] as number).toISOString();
+    }
+  }
+  return out;
+}
+
+function tableMeta(table: string): syncData.SyncTableMeta {
+  const meta = syncData.syncedTables("basic").find((m) => m.table === table);
+  if (!meta) throw new Error(`not a synced table: ${table}`);
+  return meta;
+}
+
+function idColumns(table: string): string[] {
+  return tableMeta(table).idColumns;
+}
+
+/** Decompose a row_id back into a PostgREST `.match()` filter object. */
+function decomposeId(table: string, rowId: string): Record<string, string> {
+  const cols = idColumns(table);
+  const parts = rowId.split("\x1f");
+  const out: Record<string, string> = {};
+  cols.forEach((c, i) => {
+    out[c] = parts[i];
+  });
+  return out;
+}

--- a/packages/gateway/test/helpers/pg-harness.ts
+++ b/packages/gateway/test/helpers/pg-harness.ts
@@ -1,0 +1,255 @@
+/**
+ * Real-Postgres integration harness for the sync migrations + engine.
+ *
+ * Spins up a disposable Postgres container (via Docker), applies the Supabase
+ * shim + supabase/migrations/0001..NNNN, and exposes helpers to run SQL AS a
+ * given PostgREST role (anon / authenticated / service_role) with JWT claims —
+ * exactly how PostgREST behaves after validating a token. This is what the
+ * hand-written mock cannot do: it exercises the REAL RLS policies, triggers,
+ * CHECK constraints, type coercion, and quota logic.
+ *
+ * Gated by callers behind `LORE_INTEGRATION=1` + `dockerAvailable()`.
+ */
+import { execFile } from "node:child_process";
+import { createHmac, randomBytes } from "node:crypto";
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { Client, type ClientConfig } from "pg";
+
+const exec = promisify(execFile);
+const JWT_SECRET = "lore-integration-test-jwt-secret-min-32-bytes-long";
+
+function b64url(buf: Buffer | string): string {
+  return Buffer.from(buf)
+    .toString("base64")
+    .replace(/=/g, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+}
+
+/** Mint an HS256 JWT PostgREST will accept (validates against JWT_SECRET). */
+function mintJwt(claims: Record<string, unknown>): string {
+  const header = b64url(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+  const payload = b64url(
+    JSON.stringify({ ...claims, iat: Math.floor(Date.now() / 1000) }),
+  );
+  const sig = b64url(
+    createHmac("sha256", JWT_SECRET).update(`${header}.${payload}`).digest(),
+  );
+  return `${header}.${payload}.${sig}`;
+}
+const HERE = dirname(fileURLToPath(import.meta.url));
+const MIGRATIONS_DIR = join(
+  HERE,
+  "..",
+  "..",
+  "..",
+  "..",
+  "supabase",
+  "migrations",
+);
+const SHIM = join(HERE, "supabase-shim.sql");
+
+export interface PgHarness {
+  client: Client;
+  /** Run `fn` inside a transaction as `authenticated` with the given user's JWT. */
+  asUser<T>(uid: string, fn: (c: Client) => Promise<T>): Promise<T>;
+  asService<T>(fn: (c: Client) => Promise<T>): Promise<T>;
+  asAnon<T>(fn: (c: Client) => Promise<T>): Promise<T>;
+  /** Create an auth user (fires handle_new_user → profiles). Returns the uid. */
+  createUser(email?: string): Promise<string>;
+  /** PostgREST base URL (only when started with { postgrest: true }). */
+  restUrl?: string;
+  /** Mint a JWT for a user (role=authenticated, sub=uid). */
+  userJwt(uid: string): string;
+  stop(): Promise<void>;
+}
+
+export interface HarnessOptions {
+  /** Also start PostgREST (for real engine push/pull tests). */
+  postgrest?: boolean;
+}
+
+export async function dockerAvailable(): Promise<boolean> {
+  try {
+    await exec("docker", ["info"], { timeout: 10_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForPg(cfg: ClientConfig, timeoutMs = 60_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const c = new Client(cfg);
+    try {
+      await c.connect();
+      await c.query("select 1");
+      await c.end();
+      return;
+    } catch (e) {
+      await c.end().catch(() => {});
+      if (Date.now() > deadline) throw e;
+      await new Promise((r) => setTimeout(r, 500));
+    }
+  }
+}
+
+async function waitForRest(url: string, timeoutMs = 30_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      const r = await fetch(`${url}/`, { method: "GET" });
+      // PostgREST answers the root with the OpenAPI spec once schema is loaded.
+      if (r.status < 500) return;
+    } catch {
+      // not up yet
+    }
+    if (Date.now() > deadline)
+      throw new Error("PostgREST did not become ready");
+    await new Promise((r) => setTimeout(r, 500));
+  }
+}
+
+/** Start Postgres in Docker, apply shim + all migrations, return a harness. */
+export async function startPgHarness(
+  opts: HarnessOptions = {},
+): Promise<PgHarness> {
+  const name = `lore-sync-it-${randomBytes(4).toString("hex")}`;
+  const restName = `${name}-rest`;
+  const password = "postgres";
+  // -P maps the container's 5432 to a random free host port.
+  const { stdout } = await exec("docker", [
+    "run",
+    "-d",
+    "--rm",
+    "--name",
+    name,
+    "-e",
+    `POSTGRES_PASSWORD=${password}`,
+    "-P",
+    "postgres:16-alpine",
+  ]);
+  const containerId = stdout.trim();
+
+  const stop = async () => {
+    await exec("docker", ["rm", "-f", restName]).catch(() => {});
+    await exec("docker", ["rm", "-f", name]).catch(() => {});
+  };
+
+  try {
+    // Resolve the mapped host port.
+    const { stdout: portOut } = await exec("docker", [
+      "inspect",
+      "--format",
+      '{{ (index (index .NetworkSettings.Ports "5432/tcp") 0).HostPort }}',
+      containerId,
+    ]);
+    const port = Number(portOut.trim());
+    const cfg: ClientConfig = {
+      host: "127.0.0.1",
+      port,
+      user: "postgres",
+      password,
+      database: "postgres",
+    };
+
+    await waitForPg(cfg);
+
+    const client = new Client(cfg);
+    await client.connect();
+
+    // Apply shim, then every migration in filename order.
+    await client.query(readFileSync(SHIM, "utf8"));
+    const files = readdirSync(MIGRATIONS_DIR)
+      .filter((f) => f.endsWith(".sql"))
+      .sort();
+    for (const f of files) {
+      await client.query(readFileSync(join(MIGRATIONS_DIR, f), "utf8"));
+    }
+
+    // Optionally bring up PostgREST in front of this Postgres, so the REAL sync
+    // engine (supabase-js → PostgREST) can be exercised end-to-end.
+    let restUrl: string | undefined;
+    if (opts.postgrest) {
+      const { stdout: restOut } = await exec("docker", [
+        "run",
+        "-d",
+        "--rm",
+        "--name",
+        restName,
+        "--add-host",
+        "host.docker.internal:host-gateway",
+        "-e",
+        `PGRST_DB_URI=postgres://authenticator:authenticator@host.docker.internal:${port}/postgres`,
+        "-e",
+        "PGRST_DB_SCHEMAS=public",
+        "-e",
+        "PGRST_DB_ANON_ROLE=anon",
+        "-e",
+        `PGRST_JWT_SECRET=${JWT_SECRET}`,
+        "-P",
+        "postgrest/postgrest:v12.2.3",
+      ]);
+      const restId = restOut.trim();
+      const { stdout: restPortOut } = await exec("docker", [
+        "inspect",
+        "--format",
+        '{{ (index (index .NetworkSettings.Ports "3000/tcp") 0).HostPort }}',
+        restId,
+      ]);
+      restUrl = `http://127.0.0.1:${restPortOut.trim()}`;
+      await waitForRest(restUrl);
+    }
+
+    const runAs = async <T>(
+      role: string,
+      claims: Record<string, unknown> | null,
+      fn: (c: Client) => Promise<T>,
+    ): Promise<T> => {
+      await client.query("begin");
+      try {
+        await client.query(`set local role ${role}`);
+        if (claims) {
+          await client.query(
+            "select set_config('request.jwt.claims', $1, true)",
+            [JSON.stringify(claims)],
+          );
+        }
+        const out = await fn(client);
+        await client.query("commit");
+        return out;
+      } catch (e) {
+        await client.query("rollback").catch(() => {});
+        throw e;
+      }
+    };
+
+    return {
+      client,
+      restUrl,
+      userJwt: (uid: string) => mintJwt({ sub: uid, role: "authenticated" }),
+      asUser: (uid, fn) =>
+        runAs("authenticated", { sub: uid, role: "authenticated" }, fn),
+      asService: (fn) => runAs("service_role", { role: "service_role" }, fn),
+      asAnon: (fn) => runAs("anon", { role: "anon" }, fn),
+      async createUser(email = `u${randomBytes(4).toString("hex")}@test.dev`) {
+        const { rows } = await client.query(
+          "insert into auth.users (email) values ($1) returning id",
+          [email],
+        );
+        return rows[0].id as string;
+      },
+      async stop() {
+        await client.end().catch(() => {});
+        await stop();
+      },
+    };
+  } catch (e) {
+    await stop();
+    throw e;
+  }
+}

--- a/packages/gateway/test/helpers/pg-harness.ts
+++ b/packages/gateway/test/helpers/pg-harness.ts
@@ -19,7 +19,13 @@ import { promisify } from "node:util";
 import { Client, type ClientConfig } from "pg";
 
 const exec = promisify(execFile);
-const JWT_SECRET = "lore-integration-test-jwt-secret-min-32-bytes-long";
+// Test-only HS256 secret: signs tokens for the throwaway local Postgres only.
+// Not a prod secret (prod uses Supabase GoTrue's own secret) and never shipped
+// (test/** is excluded from the published package). Env-overridable to make the
+// test-only nature explicit.
+const JWT_SECRET =
+  process.env.LORE_TEST_JWT_SECRET ??
+  "lore-integration-test-jwt-secret-min-32-bytes-long";
 
 function b64url(buf: Buffer | string): string {
   return Buffer.from(buf)

--- a/packages/gateway/test/helpers/supabase-shim.sql
+++ b/packages/gateway/test/helpers/supabase-shim.sql
@@ -1,0 +1,67 @@
+-- Minimal Supabase-compatible shim so supabase/migrations/0001..0006 can be
+-- applied and exercised against a PLAIN Postgres (no GoTrue / PostgREST stack).
+-- Replicates ONLY what the migrations depend on:
+--   auth schema + auth.users, auth.uid(), auth.role(), and the three roles.
+-- RLS is exercised by `set local role authenticated; set local request.jwt.claims`
+-- exactly as PostgREST does after validating a JWT.
+
+create schema if not exists auth;
+
+-- The subset of auth.users the migrations reference (FK target + handle_new_user).
+create table if not exists auth.users (
+  id                 uuid primary key default gen_random_uuid(),
+  email              text,
+  raw_user_meta_data jsonb not null default '{}'::jsonb,
+  created_at         timestamptz not null default now()
+);
+
+-- auth.uid()/auth.role() read the request JWT claims GUC, exactly like Supabase.
+create or replace function auth.uid()
+returns uuid
+language sql stable
+as $$
+  select nullif(
+    current_setting('request.jwt.claims', true)::json ->> 'sub', ''
+  )::uuid
+$$;
+
+create or replace function auth.role()
+returns text
+language sql stable
+as $$
+  select current_setting('request.jwt.claims', true)::json ->> 'role'
+$$;
+
+-- The PostgREST role family. NOLOGIN; the connecting superuser SETs ROLE into
+-- them per transaction. None may bypass RLS (so RLS is genuinely enforced).
+do $$
+begin
+  if not exists (select 1 from pg_roles where rolname = 'anon') then
+    create role anon nologin noinherit;
+  end if;
+  if not exists (select 1 from pg_roles where rolname = 'authenticated') then
+    create role authenticated nologin noinherit;
+  end if;
+  if not exists (select 1 from pg_roles where rolname = 'service_role') then
+    -- Matches Supabase: service_role BYPASSES RLS (trusted server-side role).
+    -- anon/authenticated do NOT, so their RLS is genuinely enforced in tests.
+    create role service_role nologin noinherit bypassrls;
+  end if;
+end $$;
+
+-- Let the connecting role assume the PostgREST roles (for SET ROLE in tests).
+grant anon, authenticated, service_role to current_user;
+
+-- `authenticator`: the login role PostgREST connects as; it SET ROLEs into
+-- anon/authenticated/service_role based on the verified JWT's `role` claim.
+do $$
+begin
+  if not exists (select 1 from pg_roles where rolname = 'authenticator') then
+    create role authenticator login password 'authenticator' noinherit;
+  end if;
+end $$;
+grant anon, authenticated, service_role to authenticator;
+
+-- PostgREST grants usage on schemas to these roles; mirror it.
+grant usage on schema public to anon, authenticated, service_role;
+grant usage on schema auth to anon, authenticated, service_role;

--- a/packages/gateway/test/sync-engine.integration.test.ts
+++ b/packages/gateway/test/sync-engine.integration.test.ts
@@ -99,8 +99,11 @@ beforeEach(async () => {
     setKV(`sync.push.${m.table}`, "0");
     setKV(`sync.pull.${m.table}`, "0|");
   }
-  // Fresh REMOTE state too (admin connection bypasses RLS) — otherwise rows
-  // accumulate across tests and the cursor-reset pulls re-fetch all of them.
+  // Fresh REMOTE state too. This uses the raw admin connection (superuser,
+  // bypasses RLS) intentionally — it's test teardown, not a client path; the
+  // transactional asUser()/runAs() helpers still SET ROLE for the actual tests.
+  // Otherwise rows accumulate across tests and the cursor-reset pulls re-fetch
+  // all of them.
   for (const t of [
     "knowledge_entity_refs",
     "knowledge",

--- a/packages/gateway/test/sync-engine.integration.test.ts
+++ b/packages/gateway/test/sync-engine.integration.test.ts
@@ -1,0 +1,217 @@
+/**
+ * END-TO-END integration of the REAL sync engine against a REAL Postgres +
+ * PostgREST stack (no mock). Drives the actual `pushOnce`/`pullOnce` from
+ * `@loreai/gateway` over supabase-js → PostgREST → Postgres, with the real
+ * migrations, RLS, triggers, and type coercion in play.
+ *
+ * This is the layer that would have caught — without an adversarial reviewer —
+ * the timestamp (22008), phantom-column (PGRST204), and same-millisecond
+ * keyset BLOCKERs that the hand-written mock hid.
+ *
+ * Gated behind LORE_INTEGRATION=1 (needs Docker). Run:
+ *   LORE_INTEGRATION=1 pnpm exec vitest run packages/gateway/test/sync-engine.integration.test.ts
+ */
+import { execFileSync } from "node:child_process";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { db, ensureProject, setKV, syncData } from "@loreai/core";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { pullOnce, pushOnce } from "../src/sync";
+import { type PgHarness, startPgHarness } from "./helpers/pg-harness";
+
+function dockerReady(): boolean {
+  try {
+    execFileSync("docker", ["info"], { stdio: "ignore", timeout: 10_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const RUN = process.env.LORE_INTEGRATION === "1";
+const SKIP = !RUN
+  ? "LORE_INTEGRATION!=1"
+  : !dockerReady()
+    ? "docker unavailable"
+    : false;
+
+let h: PgHarness;
+let uid: string;
+
+/**
+ * A supabase-js client authenticated as `uid` against the local PostgREST.
+ * supabase-js targets `${url}/rest/v1/<table>`, but a bare PostgREST serves
+ * tables at the root (`/<table>`) — Supabase's edge normally strips `/rest/v1`.
+ * A rewriting fetch reproduces that so the engine's supabase-js calls work
+ * unchanged.
+ */
+function clientFor(uid: string): SupabaseClient {
+  const jwt = h.userJwt(uid);
+  const rewriteFetch = (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+    return fetch(url.replace("/rest/v1", ""), init);
+  };
+  return createClient(h.restUrl as string, jwt, {
+    auth: { persistSession: false, autoRefreshToken: false },
+    global: {
+      headers: { Authorization: `Bearer ${jwt}` },
+      // Cast: supabase-js types `fetch` as the full `typeof fetch` (incl.
+      // `preconnect`), which our minimal rewrite wrapper doesn't implement.
+      fetch: rewriteFetch as unknown as typeof fetch,
+    },
+  });
+}
+
+beforeAll(async () => {
+  if (SKIP) return;
+  h = await startPgHarness({ postgrest: true });
+  uid = await h.createUser("engine@test.dev");
+}, 240_000);
+
+afterAll(async () => {
+  if (h) await h.stop();
+});
+
+beforeEach(async () => {
+  if (SKIP) return;
+  // Fresh local state each test (the local SQLite DB is the test temp DB).
+  for (const t of [
+    "knowledge_entity_refs",
+    "knowledge",
+    "entity_aliases",
+    "entity_relations",
+    "entities",
+    "sync_outbox",
+    "sync_state",
+    "sync_conflicts",
+  ]) {
+    db().exec(`DELETE FROM ${t}`);
+  }
+  db().exec("DELETE FROM temp._sync_applying");
+  for (const m of syncData.syncedTables("basic")) {
+    setKV(`sync.push.${m.table}`, "0");
+    setKV(`sync.pull.${m.table}`, "0|");
+  }
+  // Fresh REMOTE state too (admin connection bypasses RLS) — otherwise rows
+  // accumulate across tests and the cursor-reset pulls re-fetch all of them.
+  for (const t of [
+    "knowledge_entity_refs",
+    "knowledge",
+    "entities",
+    "entity_aliases",
+    "entity_relations",
+  ]) {
+    await h.client.query(`DELETE FROM public.${t}`);
+  }
+});
+
+function insertKnowledge(id: string, content: string): void {
+  const pid = ensureProject("/tmp/lore-engine-it");
+  db()
+    .query(
+      `INSERT INTO knowledge (id, project_id, category, title, content, created_at, updated_at, promoted_at)
+       VALUES (?, ?, 'pattern', 'T', ?, ?, ?, ?)`,
+    )
+    .run(id, pid, content, Date.now(), Date.now(), 999); // promoted_at is local-only
+}
+
+describe.skipIf(SKIP)("sync engine ↔ real Postgres/PostgREST", () => {
+  it("pushes a knowledge row (ISO timestamps, no local-only columns)", async () => {
+    syncData.enableSync("basic");
+    insertKnowledge("k1", "hello-real");
+    const client = clientFor(uid);
+    const r = await pushOnce(client);
+    expect(r.pushed).toBe(1);
+    // The row really landed in Postgres with the right owner + content.
+    const remote = await h.asUser(uid, (c) =>
+      c
+        .query("select content, created_at from public.knowledge where id='k1'")
+        .then((x) => x.rows),
+    );
+    expect(remote).toHaveLength(1);
+    expect(remote[0].content).toBe("hello-real");
+    expect(remote[0].created_at).toBeInstanceOf(Date); // timestamptz, not int
+    // No phantom columns / local-only columns leaked (the push would have
+    // 22008/PGRST204'd otherwise — proven by r.pushed===1 above).
+  });
+
+  it("pushes a join-table row (no content_hash/revision columns)", async () => {
+    insertKnowledge("k1", "x");
+    db()
+      .query(
+        "INSERT INTO entities (id, project_id, entity_type, canonical_name, created_at, updated_at) VALUES ('e1','p','tool','X',?,?)",
+      )
+      .run(Date.now(), Date.now());
+    syncData.enableSync("basic");
+    db()
+      .query(
+        "INSERT INTO knowledge_entity_refs (knowledge_id, entity_id) VALUES ('k1','e1')",
+      )
+      .run();
+    const r = await pushOnce(clientFor(uid));
+    expect(r.pushed).toBeGreaterThanOrEqual(1);
+    const ref = await h.asUser(uid, (c) =>
+      c
+        .query(
+          "select 1 from public.knowledge_entity_refs where knowledge_id='k1' and entity_id='e1'",
+        )
+        .then((x) => x.rows),
+    );
+    expect(ref).toHaveLength(1);
+  });
+
+  it("round-trips push → pull with a stable content hash (no ping-pong)", async () => {
+    syncData.enableSync("basic");
+    insertKnowledge("k1", "round-trip");
+    const client = clientFor(uid);
+    await pushOnce(client);
+    // Pull back our own row: it must hash-equal (skip), not re-apply.
+    const r = await pullOnce(client);
+    expect(r.pulled).toBe(0); // echo is a no-op
+    expect(syncData.getRowById("knowledge", "k1")?.content).toBe("round-trip");
+  });
+
+  it("pulls a row written by another device (same account)", async () => {
+    // Simulate device B writing directly to the account's remote rows (a real
+    // pushed row carries the locally-NOT-NULL columns like sensitivity).
+    await h.asUser(uid, (c) =>
+      c.query(
+        `insert into public.knowledge (id, owner_user_id, category, title, content, sensitivity, content_hash, revision)
+         values ('kb',$1,'pattern','T','from-device-B','normal','h',1)`,
+        [uid],
+      ),
+    );
+    syncData.enableSync("basic");
+    const r = await pullOnce(clientFor(uid));
+    expect(r.pulled).toBe(1);
+    expect(syncData.getRowById("knowledge", "kb")?.content).toBe(
+      "from-device-B",
+    );
+  });
+
+  it("pulls ALL rows when many share one updated_at (>page is internal; correctness here)", async () => {
+    // Insert 5 rows at one server timestamp; all must arrive (keyset).
+    await h.asUser(uid, (c) =>
+      c.query(
+        `insert into public.knowledge (id, owner_user_id, category, title, content, sensitivity, content_hash, revision, updated_at)
+         select 'm'||g, $1, 'pattern','T','c'||g, 'normal', 'h'||g, 1, now()
+         from generate_series(0,4) g`,
+        [uid],
+      ),
+    );
+    syncData.enableSync("basic");
+    const r = await pullOnce(clientFor(uid));
+    expect(r.pulled).toBe(5);
+    const n = (
+      db().query("SELECT COUNT(*) n FROM knowledge").get() as { n: number }
+    ).n;
+    expect(n).toBe(5);
+  });
+});

--- a/packages/gateway/test/sync-security.integration.test.ts
+++ b/packages/gateway/test/sync-security.integration.test.ts
@@ -9,8 +9,17 @@
  *   LORE_INTEGRATION=1 pnpm exec vitest run packages/gateway/test/sync-security.integration.test.ts
  */
 import { execFileSync } from "node:child_process";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { type PgHarness, startPgHarness } from "./helpers/pg-harness";
+
+/** Free-tier defaults (mirror supabase/migrations/0003) — restored after quota tests. */
+const FREE_LIMITS: Record<string, number> = {
+  knowledge: 500,
+  entities: 30,
+  entity_aliases: 300,
+  entity_relations: 300,
+  knowledge_entity_refs: 2000,
+};
 
 // Skip decision must be known at COLLECTION time (before beforeAll), so the
 // Docker probe is synchronous here.
@@ -168,13 +177,24 @@ describe.skipIf(gate())("sync migrations — tier is server-only", () => {
 
 describe.skipIf(gate())("sync migrations — quota + anti-abuse", () => {
   // plan_limits is admin/migration-managed (no client role may write it), so
-  // tune the cap via the raw admin connection.
+  // tune the cap via the raw admin connection. Restored after each test
+  // (afterEach below) so cap mutations never leak across tests / test order.
   async function setCap(table: string, n: number) {
     await h.client.query(
       "update public.plan_limits set max_rows=$1 where tier='free' and table_name=$2",
       [n, table],
     );
   }
+
+  afterEach(async () => {
+    if (gate()) return;
+    for (const [table, n] of Object.entries(FREE_LIMITS)) {
+      await h.client.query(
+        "update public.plan_limits set max_rows=$1 where tier='free' and table_name=$2",
+        [n, table],
+      );
+    }
+  });
 
   it("blocks inserts past the free-tier row cap", async () => {
     const a = await h.createUser();

--- a/packages/gateway/test/sync-security.integration.test.ts
+++ b/packages/gateway/test/sync-security.integration.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Integration tests for the sync MIGRATIONS against a real Postgres with RLS,
+ * triggers, and CHECK constraints enforced — run AS a real `authenticated` user
+ * (SET ROLE + JWT claims), exactly like PostgREST. These convert the security
+ * pen-test findings into permanent, deterministic regressions; the hand-written
+ * mock could never exercise RLS/triggers/quotas.
+ *
+ * Gated behind LORE_INTEGRATION=1 (needs Docker). Run:
+ *   LORE_INTEGRATION=1 pnpm exec vitest run packages/gateway/test/sync-security.integration.test.ts
+ */
+import { execFileSync } from "node:child_process";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { type PgHarness, startPgHarness } from "./helpers/pg-harness";
+
+// Skip decision must be known at COLLECTION time (before beforeAll), so the
+// Docker probe is synchronous here.
+function dockerReady(): boolean {
+  try {
+    execFileSync("docker", ["info"], { stdio: "ignore", timeout: 10_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const RUN = process.env.LORE_INTEGRATION === "1";
+const SKIP = !RUN
+  ? "LORE_INTEGRATION!=1"
+  : !dockerReady()
+    ? "docker unavailable"
+    : false;
+
+let h: PgHarness;
+
+beforeAll(async () => {
+  if (!SKIP) h = await startPgHarness();
+}, 180_000);
+
+afterAll(async () => {
+  if (h) await h.stop();
+});
+
+const gate = () => SKIP;
+
+/** Capture the Postgres error code/message of a failing query. */
+async function expectError(fn: () => Promise<unknown>): Promise<{
+  code?: string;
+  message: string;
+}> {
+  try {
+    await fn();
+  } catch (e) {
+    return {
+      code: (e as { code?: string }).code,
+      message: (e as Error).message,
+    };
+  }
+  throw new Error("expected the query to fail, but it succeeded");
+}
+
+describe.skipIf(gate())(
+  "sync migrations — multi-tenant isolation (RLS)",
+  () => {
+    it("a user cannot read another user's rows", async () => {
+      const a = await h.createUser();
+      const b = await h.createUser();
+      await h.asUser(a, (c) =>
+        c.query(
+          "insert into public.knowledge (id, owner_user_id, category, title, content) values ('ka',$1,'p','T','secret-A')",
+          [a],
+        ),
+      );
+      const seen = await h.asUser(b, (c) =>
+        c.query("select id from public.knowledge").then((r) => r.rows),
+      );
+      expect(seen).toHaveLength(0);
+    });
+
+    it("a user cannot forge owner_user_id on INSERT (WITH CHECK)", async () => {
+      const a = await h.createUser();
+      const victim = await h.createUser();
+      const err = await expectError(() =>
+        h.asUser(a, (c) =>
+          c.query(
+            "insert into public.knowledge (id, owner_user_id, category, title, content) values ('kf',$1,'p','T','C')",
+            [victim],
+          ),
+        ),
+      );
+      expect(err.code).toBe("42501"); // RLS WITH CHECK
+    });
+
+    it("a user cannot re-parent a row to themselves (steal) or to a victim (donate)", async () => {
+      const a = await h.createUser();
+      const victim = await h.createUser();
+      await h.asUser(victim, (c) =>
+        c.query(
+          "insert into public.knowledge (id, owner_user_id, category, title, content) values ('kv',$1,'p','T','C')",
+          [victim],
+        ),
+      );
+      // steal: victim's row is invisible to A, so the UPDATE matches 0 rows.
+      const stolen = await h.asUser(a, (c) =>
+        c.query("update public.knowledge set owner_user_id=$1 where id='kv'", [
+          a,
+        ]),
+      );
+      expect(stolen.rowCount).toBe(0);
+      // donate: A's own row re-parented to victim → WITH CHECK rejects.
+      await h.asUser(a, (c) =>
+        c.query(
+          "insert into public.knowledge (id, owner_user_id, category, title, content) values ('ka2',$1,'p','T','C')",
+          [a],
+        ),
+      );
+      const err = await expectError(() =>
+        h.asUser(a, (c) =>
+          c.query(
+            "update public.knowledge set owner_user_id=$1 where id='ka2'",
+            [victim],
+          ),
+        ),
+      );
+      expect(err.code).toBe("42501");
+    });
+
+    it("anon has no access to synced tables", async () => {
+      const err = await expectError(() =>
+        h.asAnon((c) => c.query("select * from public.knowledge")),
+      );
+      expect(err.code).toBe("42501"); // no grant to anon
+    });
+  },
+);
+
+describe.skipIf(gate())("sync migrations — tier is server-only", () => {
+  it("authenticated cannot set their own tier (column grant)", async () => {
+    const a = await h.createUser();
+    const err = await expectError(() =>
+      h.asUser(a, (c) =>
+        c.query("update public.profiles set tier='pro' where id=$1", [a]),
+      ),
+    );
+    expect(err.code).toBe("42501"); // no UPDATE(tier) grant
+  });
+
+  it("authenticated CAN edit allowed profile columns (control)", async () => {
+    const a = await h.createUser();
+    const r = await h.asUser(a, (c) =>
+      c.query("update public.profiles set display_name='me' where id=$1", [a]),
+    );
+    expect(r.rowCount).toBe(1);
+  });
+
+  it("service_role CAN upgrade tier (the legit payment path)", async () => {
+    const a = await h.createUser();
+    await h.asService((c) =>
+      c.query("update public.profiles set tier='pro' where id=$1", [a]),
+    );
+    const tier = await h.asService((c) =>
+      c
+        .query("select tier from public.profiles where id=$1", [a])
+        .then((r) => r.rows[0].tier),
+    );
+    expect(tier).toBe("pro");
+  });
+});
+
+describe.skipIf(gate())("sync migrations — quota + anti-abuse", () => {
+  // plan_limits is admin/migration-managed (no client role may write it), so
+  // tune the cap via the raw admin connection.
+  async function setCap(table: string, n: number) {
+    await h.client.query(
+      "update public.plan_limits set max_rows=$1 where tier='free' and table_name=$2",
+      [n, table],
+    );
+  }
+
+  it("blocks inserts past the free-tier row cap", async () => {
+    const a = await h.createUser();
+    await setCap("entities", 2);
+    const ins = (id: string) =>
+      h.asUser(a, (c) =>
+        c.query(
+          "insert into public.entities (id, owner_user_id, entity_type, canonical_name) values ($1,$2,'tool','X')",
+          [id, a],
+        ),
+      );
+    await ins("e1");
+    await ins("e2");
+    const err = await expectError(() => ins("e3"));
+    expect(err.code).toBe("23514"); // quota check_violation
+    expect(err.message).toMatch(/quota exceeded/i);
+  });
+
+  it("blocks the un-tombstone bypass (revive past cap via UPDATE)", async () => {
+    const a = await h.createUser();
+    await setCap("entities", 2);
+    const ins = (id: string) =>
+      h.asUser(a, (c) =>
+        c.query(
+          "insert into public.entities (id, owner_user_id, entity_type, canonical_name) values ($1,$2,'tool','X')",
+          [id, a],
+        ),
+      );
+    await ins("z1");
+    await ins("z2");
+    await h.asUser(a, (c) =>
+      c.query("update public.entities set is_deleted=true where id='z1'", []),
+    );
+    await ins("z3"); // fills the freed slot → 2 live
+    const err = await expectError(() =>
+      h.asUser(a, (c) =>
+        c.query(
+          "update public.entities set is_deleted=false where id='z1'",
+          [],
+        ),
+      ),
+    ); // reviving z1 → would be 3 live
+    expect(err.code).toBe("23514");
+    const live = await h.asUser(a, (c) =>
+      c
+        .query(
+          "select count(*)::int n from public.entities where is_deleted=false",
+        )
+        .then((r) => r.rows[0].n),
+    );
+    expect(live).toBe(2);
+  });
+
+  it("at-cap users can still UPDATE / soft-delete existing rows", async () => {
+    const a = await h.createUser();
+    await setCap("entities", 1);
+    await h.asUser(a, (c) =>
+      c.query(
+        "insert into public.entities (id, owner_user_id, entity_type, canonical_name) values ('u1',$1,'tool','a')",
+        [a],
+      ),
+    );
+    // upsert-as-update on the existing row (at cap) must succeed
+    const upd = await h.asUser(a, (c) =>
+      c.query(
+        `insert into public.entities (id, owner_user_id, entity_type, canonical_name)
+         values ('u1',$1,'tool','UPDATED')
+         on conflict (owner_user_id, id) do update set canonical_name=excluded.canonical_name`,
+        [a],
+      ),
+    );
+    expect(upd.rowCount).toBe(1);
+    // soft-delete frees the slot → a new insert is allowed
+    await h.asUser(a, (c) =>
+      c.query("update public.entities set is_deleted=true where id='u1'", []),
+    );
+    const ok = await h.asUser(a, (c) =>
+      c.query(
+        "insert into public.entities (id, owner_user_id, entity_type, canonical_name) values ('u2',$1,'tool','b')",
+        [a],
+      ),
+    );
+    expect(ok.rowCount).toBe(1);
+  });
+
+  it("caps oversized payloads on every user-controlled column", async () => {
+    const a = await h.createUser();
+    const big = "z".repeat(9000);
+    // content (8192 cap)
+    expect(
+      (
+        await expectError(() =>
+          h.asUser(a, (c) =>
+            c.query(
+              "insert into public.knowledge (id, owner_user_id, category, title, content) values ('big',$1,'p','T',$2)",
+              [a, big],
+            ),
+          ),
+        )
+      ).code,
+    ).toBe("23514");
+    // id (64 cap)
+    expect(
+      (
+        await expectError(() =>
+          h.asUser(a, (c) =>
+            c.query(
+              "insert into public.entities (id, owner_user_id, entity_type, canonical_name) values ($1,$2,'tool','X')",
+              ["i".repeat(100), a],
+            ),
+          ),
+        )
+      ).code,
+    ).toBe("23514");
+  });
+
+  it("authenticated cannot write plan_limits", async () => {
+    const a = await h.createUser();
+    const err = await expectError(() =>
+      h.asUser(a, (c) =>
+        c.query(
+          "update public.plan_limits set max_rows=999999 where tier='free'",
+        ),
+      ),
+    );
+    expect(err.code).toBe("42501");
+  });
+});

--- a/packages/gateway/test/sync.test.ts
+++ b/packages/gateway/test/sync.test.ts
@@ -1,0 +1,534 @@
+import { describe, test, expect, beforeEach, vi } from "vitest";
+import {
+  db,
+  ensureProject,
+  getKV,
+  setKV,
+  deleteTeamConfig,
+} from "@loreai/core";
+import { syncData } from "@loreai/core";
+
+// --- Fake Supabase client ----------------------------------------------------
+// In-memory per-table store with the PostgREST surface the engine uses, PLUS
+// adversarial knobs the previous mock lacked: injected upsert errors, forced
+// updated_at collisions, and per-table quota. These are what surface the
+// data-loss bugs the first mock hid.
+interface RemoteRow extends Record<string, unknown> {
+  updated_at: string;
+}
+const remote = new Map<string, RemoteRow[]>();
+let quotaTables = new Set<string>();
+let upsertError: { code?: string; message: string } | null = null;
+const poisonIds = new Set<string>(); // ids the server rejects with a size CHECK (23514)
+let fixedTs: string | null = null; // when set, every write stamps this exact ts
+let clock = 1_000_000;
+
+function tableRows(t: string): RemoteRow[] {
+  let r = remote.get(t);
+  if (!r) {
+    r = [];
+    remote.set(t, r);
+  }
+  return r;
+}
+function nextTs(): string {
+  if (fixedTs) return fixedTs;
+  clock += 1000;
+  return new Date(clock).toISOString();
+}
+function idColumns(table: string): string[] {
+  return (
+    syncData.syncedTables("basic").find((m) => m.table === table)
+      ?.idColumns ?? ["id"]
+  );
+}
+
+// Allowed columns per remote table (mirrors supabase/migrations/0002+). The
+// join table deliberately has NO content_hash/revision — sending them is a
+// PGRST204, which is exactly the bug this guards against.
+const SYNC_COLS = ["content_hash", "revision", "is_deleted", "owner_user_id"];
+const REMOTE_COLUMNS: Record<string, Set<string>> = {
+  knowledge: new Set([
+    "id",
+    "project_id",
+    "category",
+    "title",
+    "content",
+    "source_session",
+    "cross_project",
+    "confidence",
+    "metadata",
+    "created_by",
+    "updated_by",
+    "sensitivity",
+    "promotion_status",
+    "created_at",
+    "updated_at",
+    ...SYNC_COLS,
+  ]),
+  entities: new Set([
+    "id",
+    "project_id",
+    "entity_type",
+    "canonical_name",
+    "metadata",
+    "cross_project",
+    "created_at",
+    "updated_at",
+    ...SYNC_COLS,
+  ]),
+  knowledge_entity_refs: new Set([
+    "owner_user_id",
+    "knowledge_id",
+    "entity_id",
+    "is_deleted",
+    "created_at",
+    "updated_at",
+  ]),
+};
+
+function makeClient() {
+  return {
+    from(table: string) {
+      return {
+        upsert(payload: Record<string, unknown>) {
+          if (quotaTables.has(table)) {
+            return Promise.resolve({
+              error: { code: "23514", message: `quota exceeded for ${table}` },
+            });
+          }
+          if (poisonIds.has(String(payload.id)))
+            return Promise.resolve({
+              error: {
+                code: "23514",
+                message: `new row violates check constraint "${table}_size_ck"`,
+              },
+            });
+          if (upsertError) return Promise.resolve({ error: upsertError });
+          // Faithful to the remote schema: an unknown column is a PGRST204 (the
+          // join table has NO content_hash/revision columns).
+          const allowed = REMOTE_COLUMNS[table];
+          if (allowed) {
+            for (const k of Object.keys(payload)) {
+              if (!allowed.has(k)) {
+                return Promise.resolve({
+                  error: {
+                    code: "PGRST204",
+                    message: `Could not find the '${k}' column of '${table}' in the schema cache`,
+                  },
+                });
+              }
+            }
+          }
+          // Faithful to timestamptz columns: a bare epoch-ms integer is rejected
+          // (22008) the way real Postgres does — only ISO strings are accepted.
+          for (const k of ["created_at", "updated_at"]) {
+            if (k in payload && typeof payload[k] !== "string") {
+              return Promise.resolve({
+                error: {
+                  code: "22008",
+                  message: `date/time field value out of range: "${payload[k]}"`,
+                },
+              });
+            }
+          }
+          const rows = tableRows(table);
+          const idc = idColumns(table);
+          const i = rows.findIndex((r) =>
+            idc.every((c) => r[c] === payload[c]),
+          );
+          const stamped = { ...payload, updated_at: nextTs() } as RemoteRow;
+          if (i >= 0) rows[i] = stamped;
+          else rows.push(stamped);
+          return Promise.resolve({ error: null });
+        },
+        update(patch: Record<string, unknown>) {
+          return {
+            match(filter: Record<string, string>) {
+              for (const r of tableRows(table)) {
+                if (Object.entries(filter).every(([k, v]) => r[k] === v)) {
+                  Object.assign(r, patch, { updated_at: nextTs() });
+                }
+              }
+              return Promise.resolve({ error: null });
+            },
+          };
+        },
+        select() {
+          // Faithful-ish PostgREST builder: chainable filters/order/limit, and
+          // thenable (await runs the query). Timestamps compare by VALUE
+          // (Date.parse), like timestamptz — so Z vs +00:00 are equivalent and
+          // paging is at the real PAGE boundary.
+          const filters: Array<{ op: string; col: string; val: string }> = [];
+          const orders: string[] = [];
+          let lim = Infinity;
+          const run = () => {
+            let rows = tableRows(table).slice();
+            for (const f of filters) {
+              rows = rows.filter((r) => {
+                const rv = r[f.col];
+                if (f.col === "updated_at") {
+                  const a = Date.parse(String(rv)) || 0;
+                  const b2 = Date.parse(String(f.val)) || 0;
+                  return f.op === "gte"
+                    ? a >= b2
+                    : f.op === "gt"
+                      ? a > b2
+                      : a === b2;
+                }
+                if (f.op === "eq") return rv === f.val;
+                if (f.op === "gt") return String(rv) > String(f.val);
+                return String(rv) >= String(f.val);
+              });
+            }
+            rows.sort((a, c) => {
+              for (const o of orders) {
+                let cmp: number;
+                if (o === "updated_at")
+                  cmp =
+                    (Date.parse(String(a[o])) || 0) -
+                    (Date.parse(String(c[o])) || 0);
+                else cmp = String(a[o]).localeCompare(String(c[o]));
+                if (cmp) return cmp < 0 ? -1 : 1;
+              }
+              return 0;
+            });
+            return { data: rows.slice(0, lim), error: null };
+          };
+          const b: Record<string, unknown> = {
+            gte(c: string, v: string) {
+              filters.push({ op: "gte", col: c, val: v });
+              return b;
+            },
+            gt(c: string, v: string) {
+              filters.push({ op: "gt", col: c, val: v });
+              return b;
+            },
+            eq(c: string, v: string) {
+              filters.push({ op: "eq", col: c, val: v });
+              return b;
+            },
+            order(c: string) {
+              orders.push(c);
+              return b;
+            },
+            limit(n: number) {
+              lim = n;
+              return b;
+            },
+            // Deliberate thenable — mirrors supabase-js's awaitable query builder.
+            // biome-ignore lint/suspicious/noThenProperty: faithful PostgREST builder mock
+            then(
+              resolve: (v: unknown) => unknown,
+              reject?: (e: unknown) => unknown,
+            ) {
+              return Promise.resolve(run()).then(resolve, reject);
+            },
+          };
+          return b;
+        },
+      };
+    },
+  };
+}
+
+let authed = true;
+vi.mock("../src/supabase", () => ({
+  getAuthedClient: () => Promise.resolve(authed ? makeClient() : null),
+  getCurrentUser: () => Promise.resolve({ github_login: "octocat" }),
+}));
+
+import { pushOnce, pullOnce, syncOnce } from "../src/sync";
+
+const now = () => Date.now();
+function insertKnowledge(id: string, content: string): void {
+  const pid = ensureProject("/tmp/lore-sync-engine");
+  db()
+    .query(
+      `INSERT INTO knowledge (id, project_id, category, title, content, created_at, updated_at)
+       VALUES (?, ?, 'pattern', 'T', ?, ?, ?)`,
+    )
+    .run(id, pid, content, now(), now());
+}
+function insertEntity(id: string): void {
+  const pid = ensureProject("/tmp/lore-sync-engine");
+  db()
+    .query(
+      `INSERT INTO entities (id, project_id, entity_type, canonical_name, created_at, updated_at)
+       VALUES (?, ?, 'tool', 'X', ?, ?)`,
+    )
+    .run(id, pid, now(), now());
+}
+
+function insertRef(kid: string, eid: string): void {
+  db()
+    .query(
+      `INSERT INTO knowledge_entity_refs (knowledge_id, entity_id) VALUES (?, ?)`,
+    )
+    .run(kid, eid);
+}
+
+beforeEach(() => {
+  deleteTeamConfig("sync.enabled");
+  db().exec("DELETE FROM temp._sync_applying");
+  db().exec("DELETE FROM knowledge");
+  db().exec("DELETE FROM entities");
+  db().exec("DELETE FROM sync_outbox");
+  db().exec("DELETE FROM sync_state");
+  db().exec("DELETE FROM sync_conflicts");
+  for (const t of [
+    "knowledge",
+    "entities",
+    "entity_aliases",
+    "entity_relations",
+    "knowledge_entity_refs",
+  ]) {
+    setKV(`sync.push.${t}`, "0");
+    setKV(`sync.pull.${t}`, "0|");
+  }
+  remote.clear();
+  quotaTables = new Set();
+  upsertError = null;
+  poisonIds.clear();
+  fixedTs = null;
+  authed = true;
+  clock = 1_000_000;
+});
+
+describe("pushOnce — happy path", () => {
+  test("uploads new rows and records sync_state", async () => {
+    syncData.enableSync("basic");
+    insertKnowledge("k1", "hello");
+    const r = await pushOnce(makeClient() as never);
+    expect(r.pushed).toBe(1);
+    expect(tableRows("knowledge")).toHaveLength(1);
+    expect(syncData.getSyncState("knowledge", "k1")?.content_hash).toBeTruthy();
+  });
+
+  test("uploads timestamps as ISO strings, not epoch-ms (timestamptz)", async () => {
+    syncData.enableSync("basic");
+    insertKnowledge("k1", "hello");
+    await pushOnce(makeClient() as never);
+    const row = tableRows("knowledge").find((x) => x.id === "k1");
+    // Real Postgres rejects an integer for a timestamptz column (22008); the
+    // mock now does too, so a successful upload proves ISO conversion ran.
+    expect(typeof row?.created_at).toBe("string");
+    expect(Number.isNaN(Date.parse(String(row?.created_at)))).toBe(false);
+  });
+
+  test("pushes a knowledge_entity_refs (join) row — no phantom hash/revision columns", async () => {
+    insertKnowledge("k1", "hi");
+    insertEntity("e1");
+    syncData.enableSync("basic"); // enable AFTER the FK parents exist
+    insertRef("k1", "e1"); // join table has NO content_hash/revision remotely
+    await pushOnce(makeClient() as never);
+    // The strict mock rejects unknown columns (PGRST204); a successful push
+    // proves only valid columns were sent.
+    const row = tableRows("knowledge_entity_refs").find(
+      (x) => x.knowledge_id === "k1" && x.entity_id === "e1",
+    );
+    expect(row).toBeTruthy();
+    expect("content_hash" in (row ?? {})).toBe(false);
+    expect("revision" in (row ?? {})).toBe(false);
+  });
+
+  test("does not push local-only columns (e.g. knowledge.promoted_at)", async () => {
+    syncData.enableSync("basic");
+    insertKnowledge("k1", "hi");
+    db().query("UPDATE knowledge SET promoted_at = 123 WHERE id='k1'").run();
+    const r = await pushOnce(makeClient() as never); // strict mock → PGRST204 if leaked
+    expect(r.pushed).toBe(1);
+    const row = tableRows("knowledge").find((x) => x.id === "k1");
+    expect("promoted_at" in (row ?? {})).toBe(false);
+  });
+
+  test("prunes the outbox even when another synced table has no entries", async () => {
+    syncData.enableSync("basic");
+    insertKnowledge("k1", "hello"); // only knowledge has outbox entries
+    await pushOnce(makeClient() as never);
+    // entities/relations/refs have cursor 0 but NO entries — they must not pin
+    // the prune floor at 0. The pushed knowledge entry should be reclaimed.
+    const remaining = syncData
+      .readOutbox(0, 1000)
+      .filter((e) => e.table_name === "knowledge").length;
+    expect(remaining).toBe(0);
+  });
+
+  test("a delete becomes a remote tombstone", async () => {
+    syncData.enableSync("basic");
+    insertKnowledge("k1", "hello");
+    await pushOnce(makeClient() as never);
+    db().query("DELETE FROM knowledge WHERE id='k1'").run();
+    await pushOnce(makeClient() as never);
+    expect(tableRows("knowledge").find((r) => r.id === "k1")?.is_deleted).toBe(
+      true,
+    );
+  });
+});
+
+describe("BLOCKER regressions", () => {
+  // (1) A non-quota upsert error must NOT advance the cursor past the row.
+  test("transient push error keeps the row pending (no lost write)", async () => {
+    syncData.enableSync("basic");
+    insertKnowledge("k1", "hello");
+    upsertError = { code: "08006", message: "network" };
+    const r1 = await pushOnce(makeClient() as never);
+    expect(r1.pushed).toBe(0);
+    expect(tableRows("knowledge")).toHaveLength(0);
+    expect(Number(getKV("sync.push.knowledge"))).toBe(0); // cursor did NOT advance
+
+    // Recover: next push succeeds and uploads the row.
+    upsertError = null;
+    const r2 = await pushOnce(makeClient() as never);
+    expect(r2.pushed).toBe(1);
+    expect(tableRows("knowledge").find((x) => x.id === "k1")).toBeTruthy();
+  });
+
+  // (3) An over-quota table must not block a different under-quota table.
+  test("quota on one table does not starve another", async () => {
+    syncData.enableSync("basic");
+    insertKnowledge("k1", "hello"); // seq 1, will be quota-paused
+    insertEntity("e1"); // seq 2, under quota
+    quotaTables = new Set(["knowledge"]);
+    const r = await pushOnce(makeClient() as never);
+    expect(r.quotaHit?.table).toBe("knowledge");
+    expect(tableRows("knowledge")).toHaveLength(0); // paused
+    expect(tableRows("entities").find((x) => x.id === "e1")).toBeTruthy(); // synced!
+    expect(Number(getKV("sync.push.knowledge"))).toBe(0); // knowledge cursor held
+    expect(Number(getKV("sync.push.entities"))).toBeGreaterThan(0); // entities advanced
+  });
+
+  // (2) MORE than PAGE rows sharing one updated_at must ALL be pulled (the
+  // intra-millisecond drain). 250 > PAGE(200) — the old keyset dropped 50.
+  test("250 rows sharing one updated_at are all pulled (>PAGE)", async () => {
+    syncData.enableSync("basic");
+    const pid = ensureProject("/tmp/lore-sync-engine");
+    const ts = new Date(5_000_000).toISOString();
+    for (let i = 0; i < 250; i++) {
+      const id = `k${String(i).padStart(4, "0")}`;
+      tableRows("knowledge").push({
+        id,
+        project_id: pid,
+        category: "pattern",
+        title: "T",
+        content: id,
+        content_hash: `h-${id}`,
+        revision: 1,
+        is_deleted: false,
+        created_at: ts,
+        updated_at: ts,
+      });
+    }
+    await pullOnce(makeClient() as never);
+    const applied = (
+      db().query("SELECT COUNT(*) n FROM knowledge").get() as { n: number }
+    ).n;
+    expect(applied).toBe(250);
+  });
+
+  // (poison) A non-quota 23514 (size CHECK) must NOT pause the table forever —
+  // the row is dropped past the cursor + recorded; the rest of the table syncs.
+  test("an unsyncable (size-CHECK) row is dropped, not wedged", async () => {
+    syncData.enableSync("basic");
+    insertKnowledge("kbad", "too big"); // seq 1 — rejected as poison
+    insertKnowledge("kgood", "fine"); // seq 2 — must still sync, same push
+    poisonIds.add("kbad");
+    await pushOnce(makeClient() as never);
+    expect(tableRows("knowledge").find((x) => x.id === "kgood")).toBeTruthy();
+    expect(tableRows("knowledge").find((x) => x.id === "kbad")).toBeFalsy();
+    const recorded = db()
+      .query(
+        "SELECT COUNT(*) n FROM sync_conflicts WHERE row_id='kbad' AND resolution='rejected_unsyncable'",
+      )
+      .get() as { n: number };
+    expect(recorded.n).toBe(1);
+  });
+
+  // (starvation) A table with many lower-seq entries from OTHER tables must
+  // still drain — readOutbox filters per table in SQL.
+  test("a table is not starved by >PAGE*4 other-table outbox entries", async () => {
+    syncData.enableSync("basic");
+    for (let i = 0; i < 850; i++) insertEntity(`e${i}`); // seqs 1..850
+    insertKnowledge("kfar", "behind 850 entities"); // seq 851
+    await pushOnce(makeClient() as never);
+    expect(tableRows("knowledge").find((x) => x.id === "kfar")).toBeTruthy();
+    expect(tableRows("entities").length).toBe(850);
+  });
+});
+
+describe("pullOnce", () => {
+  test("applies a new remote row and a tombstone", async () => {
+    syncData.enableSync("basic");
+    const pid = ensureProject("/tmp/lore-sync-engine");
+    tableRows("knowledge").push({
+      id: "kr",
+      project_id: pid,
+      category: "pattern",
+      title: "T",
+      content: "from server",
+      content_hash: "abc",
+      revision: 2,
+      is_deleted: false,
+      created_at: new Date(2_000_000).toISOString(),
+      updated_at: new Date(2_000_000).toISOString(),
+    });
+    await pullOnce(makeClient() as never);
+    expect(syncData.getRowById("knowledge", "kr")?.content).toBe("from server");
+
+    syncData.withApplying(() => insertKnowledge("kd", "x"));
+    tableRows("knowledge").push({
+      id: "kd",
+      is_deleted: true,
+      content_hash: null,
+      revision: 5,
+      updated_at: new Date(3_000_000).toISOString(),
+    } as never);
+    await pullOnce(makeClient() as never);
+    expect(syncData.getRowById("knowledge", "kd")).toBeNull();
+  });
+
+  test("conflict resolves remote-wins AND preserves the discarded local row", async () => {
+    syncData.enableSync("basic");
+    insertKnowledge("kc", "local-edit"); // unpushed → pending local change
+    const pid = ensureProject("/tmp/lore-sync-engine");
+    tableRows("knowledge").push({
+      id: "kc",
+      project_id: pid,
+      category: "pattern",
+      title: "T",
+      content: "remote-edit",
+      content_hash: "remotehash",
+      revision: 9,
+      is_deleted: false,
+      created_at: new Date(4_000_000).toISOString(),
+      updated_at: new Date(4_000_000).toISOString(),
+    });
+    const r = await pullOnce(makeClient() as never);
+    expect(r.conflicts).toBe(1);
+    expect(syncData.getRowById("knowledge", "kc")?.content).toBe("remote-edit");
+    // The discarded local edit is recoverable from sync_conflicts.local_content.
+    const row = db()
+      .query("SELECT local_content FROM sync_conflicts WHERE row_id='kc'")
+      .get() as { local_content: string };
+    expect(JSON.parse(row.local_content).content).toBe("local-edit");
+  });
+});
+
+describe("syncOnce", () => {
+  test("no-op when disabled; notAuthed when logged out", async () => {
+    expect(await syncOnce()).toEqual({ pushed: 0, pulled: 0, conflicts: 0 });
+    syncData.enableSync("basic");
+    authed = false;
+    expect((await syncOnce()).notAuthed).toBe(true);
+  });
+
+  test("push-then-pull; our own pushed row echo-pulls as skip (no ping-pong)", async () => {
+    syncData.enableSync("basic");
+    insertKnowledge("k1", "hello");
+    const r = await syncOnce();
+    expect(r.pushed).toBe(1);
+    // Echo-pull of our own row is a no-op (hash matches) — pulled stays 0.
+    expect(r.pulled).toBe(0);
+    expect(tableRows("knowledge").find((x) => x.id === "k1")).toBeTruthy();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@biomejs/biome':
         specifier: 2.4.16
         version: 2.4.16
+      '@types/pg':
+        specifier: ^8.11.10
+        version: 8.20.0
       '@vitest/coverage-v8':
         specifier: ^4.1.8
         version: 4.1.8(vitest@4.1.8)
@@ -38,6 +41,9 @@ importers:
       linkinator:
         specifier: ^7.6.1
         version: 7.6.1
+      pg:
+        specifier: ^8.13.1
+        version: 8.21.0
       tsx:
         specifier: ^4.22.3
         version: 4.22.4
@@ -1361,6 +1367,9 @@ packages:
 
   '@types/node@25.3.2':
     resolution: {integrity: sha512-RpV6r/ij22zRRdyBPcxDeKAzH43phWVKEjL2iksqo1Vz3CuBUrgmPpPhALKiRfU7OMCmeeO9vECBMsV0hMTG8Q==}
+
+  '@types/pg@8.20.0':
+    resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
 
   '@types/qrcode-terminal@0.12.2':
     resolution: {integrity: sha512-v+RcIEJ+Uhd6ygSQ0u5YYY7ZM+la7GgPbs0V/7l/kFs2uO4S8BcIUEMoP7za4DNIqNnUD5npf0A/7kBhrCKG5Q==}
@@ -2801,6 +2810,40 @@ packages:
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
+  pg-cloudflare@1.4.0:
+    resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
+
+  pg-connection-string@2.13.0:
+    resolution: {integrity: sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.14.0:
+    resolution: {integrity: sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.14.0:
+    resolution: {integrity: sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.21.0:
+    resolution: {integrity: sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
   piccolore@0.1.3:
     resolution: {integrity: sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==}
 
@@ -2835,6 +2878,22 @@ packages:
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
 
   postject@1.0.0-alpha.6:
     resolution: {integrity: sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==}
@@ -3083,6 +3142,10 @@ packages:
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
@@ -3606,6 +3669,10 @@ packages:
   xml-naming@0.1.0:
     resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
     engines: {node: '>=16.0.0'}
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
 
   xxhash-wasm@1.1.0:
     resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
@@ -4970,6 +5037,12 @@ snapshots:
   '@types/node@25.3.2':
     dependencies:
       undici-types: 7.18.2
+
+  '@types/pg@8.20.0':
+    dependencies:
+      '@types/node': 25.3.2
+      pg-protocol: 1.14.0
+      pg-types: 2.2.0
 
   '@types/qrcode-terminal@0.12.2': {}
 
@@ -6924,6 +6997,41 @@ snapshots:
 
   pend@1.2.0: {}
 
+  pg-cloudflare@1.4.0:
+    optional: true
+
+  pg-connection-string@2.13.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.14.0(pg@8.21.0):
+    dependencies:
+      pg: 8.21.0
+
+  pg-protocol@1.14.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.21.0:
+    dependencies:
+      pg-connection-string: 2.13.0
+      pg-pool: 3.14.0(pg@8.21.0)
+      pg-protocol: 1.14.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.4.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
   piccolore@0.1.3: {}
 
   picocolors@1.1.1: {}
@@ -6951,6 +7059,16 @@ snapshots:
       nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   postject@1.0.0-alpha.6:
     dependencies:
@@ -7329,6 +7447,8 @@ snapshots:
   source-map@0.7.6: {}
 
   space-separated-tokens@2.0.2: {}
+
+  split2@4.2.0: {}
 
   sprintf-js@1.1.3: {}
 
@@ -7782,6 +7902,8 @@ snapshots:
   ws@8.21.0: {}
 
   xml-naming@0.1.0: {}
+
+  xtend@4.0.2: {}
 
   xxhash-wasm@1.1.0: {}
 

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -37,8 +37,53 @@ supabase db push
 Migrations are plain SQL, applied in filename order:
 
 - `0001_accounts.sql` — `public.profiles` (one row per auth user) + RLS +
-  auto-provision trigger on `auth.users` insert. **Accounts only**; the sync
-  tables (knowledge / entities / …) land in a later migration.
+  auto-provision trigger on `auth.users` insert.
+- `0002_sync_basic.sql` — Basic-tier sync tables (`knowledge`, `entities`,
+  `entity_aliases`, `entity_relations`, `knowledge_entity_refs`) mirroring the
+  local SQLite schema, with `owner_user_id`/`content_hash`/`revision`/
+  `is_deleted`/server-stamped `updated_at`, RLS scoped to the owner, and
+  per-owner+updated_at pull-cursor indexes.
+- `0003_sync_limits.sql` — anti-abuse for the direct-PostgREST write model.
+  Clients write to the REST API directly, so limits are enforced **in-DB**
+  (RLS only governs ownership, not volume/size):
+  - `profiles.tier` + a tunable `plan_limits(tier, table_name → max_rows)` table.
+  - `BEFORE INSERT` quota trigger per table (free: knowledge ≤ 500, entities ≤
+    30, aliases ≤ 300, relations ≤ 300, refs ≤ 2000; pro generous; null =
+    unlimited). `SECURITY DEFINER` so it reads tier/limits past RLS.
+  - `CHECK` constraints capping per-field size (title ≤ 512, content ≤ 8192, …).
+  Per-request RATE limiting is intentionally deferred to an edge layer / hosted
+  backend (paid tiers); these caps bound storage + cardinality + payload, which
+  is what stops "sync my entire history" on the free tier. Distillations and raw
+  conversation logs are paid-tier-only and are NOT in the Basic synced set.
+- `0004_sync_hardening.sql` — security hardening (adversarial-review fixes):
+  - **`profiles.tier` is not user-writable** — column-scoped `GRANT UPDATE
+    (display_name, github_login, email)` (excludes `tier`) + a BEFORE UPDATE
+    trigger rejecting any non-service-role `tier` change. (Otherwise a user
+    could `PATCH /profiles {tier:'pro'}` and defeat all quotas.)
+  - **Every user-controlled TEXT column is size-capped** (not just the obvious
+    ones) — row-count caps alone don't bound storage; an uncapped column let a
+    30-row user store 30×~1GB blobs.
+  - **DML `GRANT`s to `authenticated`** so PostgREST actually works (RLS is the
+    2nd gate; without a table grant every call is denied). Landed in the SAME
+    migration as the tier lock so write-access never precedes the guard.
+  - **Quota counts LIVE rows only and skips when the PK exists**, so an at-cap
+    user can still UPDATE / soft-delete (incl. the deletes that free quota) via
+    the `ON CONFLICT DO UPDATE` write path.
+
+Known residual (documented, acceptable for free-tier abuse-prevention): the
+quota check is `count(*)` then compare with no lock, so concurrent inserts can
+overshoot a cap by ~N per burst (soft cap, not hard). Add a per-(user,table)
+advisory lock if a hard cap is ever required.
+
+## Conflict resolution (last-writer-to-remote-wins)
+
+The gateway syncs push-then-pull. When the same row was changed on two machines
+before either pulled, the engine resolves **remote-wins**: the row already on the
+server is kept, and the local edit is overwritten. To avoid silent data loss, the
+discarded local row is preserved in the local `sync_conflicts` table
+(`local_content` = JSON of the overwritten row), so a conflicting edit is
+recoverable rather than destroyed. This is a deliberate, documented policy for the
+Basic tier; richer merge strategies can come later.
 
 ## Dashboard configuration (one-time, not in code)
 

--- a/supabase/migrations/0002_sync_basic.sql
+++ b/supabase/migrations/0002_sync_basic.sql
@@ -1,0 +1,162 @@
+-- Migration 0002 — Basic-tier logical sync (knowledge + entity graph).
+--
+-- Remote mirror of the local SQLite synced tables (see packages/core/src/sync-data.ts
+-- and the v43 local migration). Each row is owned by exactly one user and isolated
+-- by Row-Level Security (owner_user_id = auth.uid()) — a single shared multi-tenant
+-- Postgres, NOT a database per user.
+--
+-- Sync columns carried on every table:
+--   owner_user_id  uuid       — owner; RLS boundary. Defaulted to auth.uid() so a
+--                               client INSERT need not (and cannot forge) it.
+--   content_hash   text       — client-computed semantic hash (sync-data.ts contentHash);
+--                               server stores it verbatim (the updated_at trigger does
+--                               NOT touch content_hash/revision — they are carried as-is).
+--   revision       integer    — client-carried distributed version (fast-forward vs conflict).
+--   is_deleted     boolean    — soft delete (tombstone) so peers learn of removals on pull.
+--   updated_at     timestamptz— server-stamped on write (the pull cursor).
+--   created_at     timestamptz
+--
+-- knowledge_entity_refs is the composite-key join table (no content_hash/revision).
+
+-- ---------------------------------------------------------------------------
+-- Shared helper: stamp updated_at on every write WITHOUT clobbering the
+-- client-carried content_hash / revision.
+-- ---------------------------------------------------------------------------
+create or replace function public.sync_set_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- knowledge
+-- ---------------------------------------------------------------------------
+create table if not exists public.knowledge (
+  id             text not null,
+  owner_user_id  uuid not null default auth.uid() references auth.users (id) on delete cascade,
+  project_id     text,
+  category       text not null,
+  title          text not null,
+  content        text not null,
+  source_session text,
+  cross_project  integer default 0,
+  confidence     double precision default 1.0,
+  metadata       text,
+  created_by     text,
+  updated_by     text,
+  sensitivity    text,
+  promotion_status text,
+  content_hash   text,
+  revision       integer not null default 0,
+  is_deleted     boolean not null default false,
+  created_at     timestamptz not null default now(),
+  updated_at     timestamptz not null default now(),
+  primary key (owner_user_id, id)
+);
+
+-- ---------------------------------------------------------------------------
+-- entities
+-- ---------------------------------------------------------------------------
+create table if not exists public.entities (
+  id             text not null,
+  owner_user_id  uuid not null default auth.uid() references auth.users (id) on delete cascade,
+  project_id     text,
+  entity_type    text not null,
+  canonical_name text not null,
+  metadata       text,
+  cross_project  integer default 0,
+  content_hash   text,
+  revision       integer not null default 0,
+  is_deleted     boolean not null default false,
+  created_at     timestamptz not null default now(),
+  updated_at     timestamptz not null default now(),
+  primary key (owner_user_id, id)
+);
+
+-- ---------------------------------------------------------------------------
+-- entity_aliases
+-- ---------------------------------------------------------------------------
+create table if not exists public.entity_aliases (
+  id            text not null,
+  owner_user_id uuid not null default auth.uid() references auth.users (id) on delete cascade,
+  entity_id     text not null,
+  alias_type    text not null,
+  alias_value   text not null,
+  source        text,
+  content_hash  text,
+  revision      integer not null default 0,
+  is_deleted    boolean not null default false,
+  created_at    timestamptz not null default now(),
+  updated_at    timestamptz not null default now(),
+  primary key (owner_user_id, id)
+);
+
+-- ---------------------------------------------------------------------------
+-- entity_relations
+-- ---------------------------------------------------------------------------
+create table if not exists public.entity_relations (
+  id            text not null,
+  owner_user_id uuid not null default auth.uid() references auth.users (id) on delete cascade,
+  entity_a      text not null,
+  entity_b      text not null,
+  relation      text not null,
+  metadata      text,
+  source        text,
+  content_hash  text,
+  revision      integer not null default 0,
+  is_deleted    boolean not null default false,
+  created_at    timestamptz not null default now(),
+  updated_at    timestamptz not null default now(),
+  primary key (owner_user_id, id)
+);
+
+-- ---------------------------------------------------------------------------
+-- knowledge_entity_refs (composite join; no content_hash/revision)
+-- ---------------------------------------------------------------------------
+create table if not exists public.knowledge_entity_refs (
+  owner_user_id uuid not null default auth.uid() references auth.users (id) on delete cascade,
+  knowledge_id  text not null,
+  entity_id     text not null,
+  is_deleted    boolean not null default false,
+  created_at    timestamptz not null default now(),
+  updated_at    timestamptz not null default now(),
+  primary key (owner_user_id, knowledge_id, entity_id)
+);
+
+-- ---------------------------------------------------------------------------
+-- updated_at triggers + pull-cursor indexes + RLS (one policy per table).
+-- ---------------------------------------------------------------------------
+do $$
+declare t text;
+begin
+  foreach t in array array[
+    'knowledge', 'entities', 'entity_aliases', 'entity_relations', 'knowledge_entity_refs'
+  ]
+  loop
+    -- server-stamped updated_at (pull cursor)
+    execute format(
+      'drop trigger if exists %1$s_set_updated_at on public.%1$s', t);
+    execute format(
+      'create trigger %1$s_set_updated_at before update on public.%1$s
+         for each row execute function public.sync_set_updated_at()', t);
+
+    -- incremental pull: "my rows changed since cursor"
+    execute format(
+      'create index if not exists idx_%1$s_owner_updated
+         on public.%1$s (owner_user_id, updated_at)', t);
+
+    -- RLS: a user sees and writes ONLY their own rows. WITH CHECK on the
+    -- default-auth.uid() owner column prevents writing rows for another user.
+    execute format('alter table public.%1$s enable row level security', t);
+    execute format('drop policy if exists %1$s_owner_all on public.%1$s', t);
+    execute format(
+      'create policy %1$s_owner_all on public.%1$s
+         for all
+         using (owner_user_id = auth.uid())
+         with check (owner_user_id = auth.uid())', t);
+  end loop;
+end $$;

--- a/supabase/migrations/0003_sync_limits.sql
+++ b/supabase/migrations/0003_sync_limits.sql
@@ -1,0 +1,138 @@
+-- Migration 0003 — anti-abuse limits for Basic-tier sync (direct-PostgREST model).
+--
+-- Clients write to Supabase's REST API directly (anon key + user JWT), so all
+-- limits MUST be enforced server-side in Postgres — a malicious client bypasses
+-- our gateway entirely. RLS only enforces OWNERSHIP, not VOLUME or SIZE, so we
+-- add two in-DB controls that cannot be bypassed:
+--   1. CHECK constraints  — bound per-row payload size.
+--   2. BEFORE INSERT trigger — bound per-user LIVE row count, by tier.
+-- (Per-request RATE limiting is intentionally NOT here — it belongs at the edge
+-- and is deferred until paid tiers; see plan. These bound storage + cardinality
+-- + payload, which is what stops "sync my entire history" on the free tier.)
+
+-- ---------------------------------------------------------------------------
+-- Tier on profiles (defaults to 'free').
+-- ---------------------------------------------------------------------------
+alter table public.profiles
+  add column if not exists tier text not null default 'free';
+
+-- ---------------------------------------------------------------------------
+-- Tunable per-tier row caps (data, not code — change without a deploy).
+-- A NULL cap means "unlimited" for that (tier, table).
+-- ---------------------------------------------------------------------------
+create table if not exists public.plan_limits (
+  tier        text not null,
+  table_name  text not null,
+  max_rows    integer,            -- null = unlimited
+  primary key (tier, table_name)
+);
+
+-- plan_limits is readable by all authenticated users (so clients can show
+-- usage/limits), writable by no one via the API (service-role/SQL only).
+alter table public.plan_limits enable row level security;
+drop policy if exists plan_limits_read on public.plan_limits;
+create policy plan_limits_read on public.plan_limits
+  for select using (auth.role() = 'authenticated');
+
+insert into public.plan_limits (tier, table_name, max_rows) values
+  -- Free: knowledge + a small entity graph. Hostile to dumping history.
+  ('free', 'knowledge',             500),
+  ('free', 'entities',               30),
+  ('free', 'entity_aliases',        300),   -- ~10x entities
+  ('free', 'entity_relations',      300),
+  ('free', 'knowledge_entity_refs', 2000),
+  -- Paid tiers: generous (tune later). NULL elsewhere = unlimited.
+  ('pro',  'knowledge',           50000),
+  ('pro',  'entities',             5000),
+  ('pro',  'entity_aliases',      50000),
+  ('pro',  'entity_relations',    50000),
+  ('pro',  'knowledge_entity_refs', 200000)
+on conflict (tier, table_name) do update set max_rows = excluded.max_rows;
+
+-- ---------------------------------------------------------------------------
+-- Per-user row-count quota: BEFORE INSERT, reject if the user is at/over their
+-- tier cap for this table. UPDATEs (incl. soft-delete via is_deleted) are not
+-- counted — only growth in live rows. Tombstoned rows still occupy a row; a
+-- future reaper can hard-delete old is_deleted=true rows to reclaim the slot.
+-- ---------------------------------------------------------------------------
+create or replace function public.enforce_row_quota()
+returns trigger
+language plpgsql
+security definer            -- read profiles.tier / plan_limits past RLS
+set search_path = public
+as $$
+declare
+  user_tier text;
+  cap       integer;
+  used      integer;
+begin
+  select coalesce(tier, 'free') into user_tier
+    from public.profiles where id = new.owner_user_id;
+  if user_tier is null then user_tier := 'free'; end if;
+
+  select max_rows into cap
+    from public.plan_limits
+   where tier = user_tier and table_name = tg_table_name;
+
+  if cap is null then
+    return new;  -- no limit configured for this (tier, table) → unlimited
+  end if;
+
+  execute format(
+    'select count(*) from public.%I where owner_user_id = $1', tg_table_name)
+    into used using new.owner_user_id;
+
+  if used >= cap then
+    raise exception
+      'sync quota exceeded for % on tier %: % of % rows. Upgrade to sync more.',
+      tg_table_name, user_tier, used, cap
+      using errcode = 'check_violation';
+  end if;
+
+  return new;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Payload-size CHECK constraints + attach the quota trigger to each table.
+-- ---------------------------------------------------------------------------
+do $$
+declare t text;
+begin
+  foreach t in array array[
+    'knowledge', 'entities', 'entity_aliases', 'entity_relations', 'knowledge_entity_refs'
+  ]
+  loop
+    execute format(
+      'drop trigger if exists %1$s_row_quota on public.%1$s', t);
+    execute format(
+      'create trigger %1$s_row_quota before insert on public.%1$s
+         for each row execute function public.enforce_row_quota()', t);
+  end loop;
+end $$;
+
+-- Per-field size caps (idempotent: drop-then-add). Mirrors the local intent
+-- (e.g. ltm.content is ~1200 chars locally) but enforced where it can't be
+-- bypassed. Generous enough for real entries, hostile to blobs.
+alter table public.knowledge drop constraint if exists knowledge_size_ck;
+alter table public.knowledge add constraint knowledge_size_ck check (
+  length(title) <= 512 and length(content) <= 8192
+  and (metadata is null or length(metadata) <= 8192)
+);
+
+alter table public.entities drop constraint if exists entities_size_ck;
+alter table public.entities add constraint entities_size_ck check (
+  length(canonical_name) <= 512
+  and (metadata is null or length(metadata) <= 8192)
+);
+
+alter table public.entity_aliases drop constraint if exists entity_aliases_size_ck;
+alter table public.entity_aliases add constraint entity_aliases_size_ck check (
+  length(alias_value) <= 512 and length(alias_type) <= 64
+);
+
+alter table public.entity_relations drop constraint if exists entity_relations_size_ck;
+alter table public.entity_relations add constraint entity_relations_size_ck check (
+  length(relation) <= 128
+  and (metadata is null or length(metadata) <= 8192)
+);

--- a/supabase/migrations/0004_sync_hardening.sql
+++ b/supabase/migrations/0004_sync_hardening.sql
@@ -1,0 +1,183 @@
+-- Migration 0004 — security hardening for direct-PostgREST sync.
+--
+-- Addresses an adversarial review of 0002/0003:
+--   1. profiles.tier must NOT be user-writable (else free→pro self-escalation
+--      defeats the quota system). Column-scoped UPDATE grant + a BEFORE UPDATE
+--      trigger that rejects tier changes from non-privileged callers.
+--   2. Cap ALL user-controlled TEXT columns (row-count caps alone don't bound
+--      storage — a 30-row user could otherwise store 30 × ~1GB blobs).
+--   3. Add the missing DML GRANTs to `authenticated`. RLS is the *second* gate;
+--      without a table GRANT every PostgREST call is denied. These grants are
+--      landed in the SAME migration as the tier guard so escalation is never
+--      possible the instant writes become possible.
+--   4. Quota trigger counts LIVE rows only and skips when the PK already exists,
+--      so an at-cap user can still UPDATE / soft-delete (incl. the deletes that
+--      free quota) via the upsert write path.
+
+-- ---------------------------------------------------------------------------
+-- 1. Lock down profiles.tier
+-- ---------------------------------------------------------------------------
+-- Column-scoped UPDATE: users may edit profile display fields but NOT tier.
+-- (Postgres RLS is row-level; column safety needs a column GRANT and/or trigger.)
+revoke update on public.profiles from authenticated;
+grant select on public.profiles to authenticated;
+grant update (github_login, display_name, email) on public.profiles to authenticated;
+
+-- Belt-and-suspenders: even a future careless `GRANT UPDATE` can't change tier.
+-- Only the table owner / service_role (which bypasses RLS and runs as a
+-- superuser-ish role) may mutate tier; everyone else is rejected.
+create or replace function public.guard_profile_tier()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if new.tier is distinct from old.tier
+     and current_setting('request.jwt.role', true) is distinct from 'service_role'
+  then
+    raise exception 'tier is not user-modifiable'
+      using errcode = 'insufficient_privilege';
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists profiles_guard_tier on public.profiles;
+create trigger profiles_guard_tier
+  before update on public.profiles
+  for each row execute function public.guard_profile_tier();
+
+-- ---------------------------------------------------------------------------
+-- 2. Bound EVERY user-controlled TEXT column (drop-then-add = idempotent).
+--    Small caps for type/status/hash/id-ish columns; larger for real content.
+--    knowledge_entity_refs PK columns are btree-bounded but we add an explicit
+--    CHECK so an oversize value fails as a clean 400 (check_violation), not 54000.
+-- ---------------------------------------------------------------------------
+alter table public.knowledge drop constraint if exists knowledge_size_ck;
+alter table public.knowledge add constraint knowledge_size_ck check (
+  length(title) <= 512
+  and length(content) <= 8192
+  and length(category) <= 64
+  and (metadata is null or length(metadata) <= 8192)
+  and (project_id is null or length(project_id) <= 1024)
+  and (source_session is null or length(source_session) <= 256)
+  and (created_by is null or length(created_by) <= 256)
+  and (updated_by is null or length(updated_by) <= 256)
+  and (sensitivity is null or length(sensitivity) <= 32)
+  and (promotion_status is null or length(promotion_status) <= 32)
+  and (content_hash is null or length(content_hash) <= 64)
+);
+
+alter table public.entities drop constraint if exists entities_size_ck;
+alter table public.entities add constraint entities_size_ck check (
+  length(canonical_name) <= 512
+  and length(entity_type) <= 64
+  and (metadata is null or length(metadata) <= 8192)
+  and (project_id is null or length(project_id) <= 1024)
+  and (content_hash is null or length(content_hash) <= 64)
+);
+
+alter table public.entity_aliases drop constraint if exists entity_aliases_size_ck;
+alter table public.entity_aliases add constraint entity_aliases_size_ck check (
+  length(alias_value) <= 512
+  and length(alias_type) <= 64
+  and length(entity_id) <= 64
+  and (source is null or length(source) <= 256)
+  and (content_hash is null or length(content_hash) <= 64)
+);
+
+alter table public.entity_relations drop constraint if exists entity_relations_size_ck;
+alter table public.entity_relations add constraint entity_relations_size_ck check (
+  length(relation) <= 128
+  and length(entity_a) <= 64
+  and length(entity_b) <= 64
+  and (source is null or length(source) <= 256)
+  and (metadata is null or length(metadata) <= 8192)
+  and (content_hash is null or length(content_hash) <= 64)
+);
+
+alter table public.knowledge_entity_refs drop constraint if exists knowledge_entity_refs_size_ck;
+alter table public.knowledge_entity_refs add constraint knowledge_entity_refs_size_ck check (
+  length(knowledge_id) <= 64 and length(entity_id) <= 64
+);
+
+-- ---------------------------------------------------------------------------
+-- 3. DML grants so PostgREST works (RLS still enforces per-row ownership).
+-- ---------------------------------------------------------------------------
+grant select, insert, update, delete on
+  public.knowledge, public.entities, public.entity_aliases,
+  public.entity_relations, public.knowledge_entity_refs
+  to authenticated;
+grant select on public.plan_limits to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 4. Quota trigger: count LIVE rows only; skip when the PK already exists
+--    (an upsert that resolves to UPDATE is not new growth). This lets an at-cap
+--    user still edit and soft-delete existing rows.
+-- ---------------------------------------------------------------------------
+create or replace function public.enforce_row_quota()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  user_tier text;
+  cap       integer;
+  used      integer;
+  exists_pk boolean;
+begin
+  -- An INSERT whose PK already exists is an upsert→UPDATE in disguise: not new
+  -- growth, so it must never be quota-blocked (else at-cap users freeze).
+  -- NOTE: reference `new.<col>` only inside the matching branch — PL/pgSQL
+  -- parses field access for the actual row type, so referencing a column that
+  -- doesn't exist on this table (e.g. new.knowledge_id on `entities`) errors
+  -- with 42703. Use `to_jsonb(new)` to read PK values generically instead.
+  if tg_table_name = 'knowledge_entity_refs' then
+    select exists(
+      select 1 from public.knowledge_entity_refs
+       where owner_user_id = (to_jsonb(new)->>'owner_user_id')::uuid
+         and knowledge_id = to_jsonb(new)->>'knowledge_id'
+         and entity_id = to_jsonb(new)->>'entity_id')
+      into exists_pk;
+  else
+    execute format(
+      'select exists(select 1 from public.%I where owner_user_id = $1 and id = $2)',
+      tg_table_name)
+      into exists_pk
+      using
+        (to_jsonb(new)->>'owner_user_id')::uuid,
+        to_jsonb(new)->>'id';
+  end if;
+  if exists_pk then
+    return new;
+  end if;
+
+  select tier into user_tier from public.profiles where id = new.owner_user_id;
+  if user_tier is null then user_tier := 'free'; end if;
+
+  select max_rows into cap
+    from public.plan_limits
+   where tier = user_tier and table_name = tg_table_name;
+  if cap is null then
+    return new;  -- unlimited for this (tier, table)
+  end if;
+
+  -- Count LIVE rows only — tombstones (is_deleted=true) don't consume quota,
+  -- so a delete immediately frees a slot.
+  execute format(
+    'select count(*) from public.%I where owner_user_id = $1 and is_deleted = false',
+    tg_table_name)
+    into used using new.owner_user_id;
+
+  if used >= cap then
+    raise exception
+      'sync quota exceeded for % on tier %: % of % rows. Upgrade to sync more.',
+      tg_table_name, user_tier, used, cap
+      using errcode = 'check_violation';
+  end if;
+
+  return new;
+end;
+$$;

--- a/supabase/migrations/0005_sync_quota_hardening.sql
+++ b/supabase/migrations/0005_sync_quota_hardening.sql
@@ -1,0 +1,140 @@
+-- Migration 0005 — quota/abuse hardening (pen-test fixes for 0003/0004).
+--
+-- 1. Un-tombstone bypass [HIGH]: the quota trigger fired only BEFORE INSERT, so
+--    a user could soft-delete rows (freeing slots), INSERT new rows, then flip
+--    is_deleted back to false via UPDATE — growing live rows past the cap with
+--    no INSERT to gate it. Fix: also quota-check UPDATEs that REVIVE a row
+--    (is_deleted true -> false).
+-- 2. TOCTOU [MEDIUM]: count-then-insert had no lock, so concurrent inserts for
+--    one user could overshoot the cap. Fix: a per-(user,table) advisory xact
+--    lock serializes a single user's concurrent quota checks.
+-- 3. Uncapped `id` [LOW]: id was the only user-controlled TEXT column without a
+--    size cap (oversized id failed as 54000, not a clean 23514). Fix: cap it.
+-- 4. guard_profile_tier read a GUC PostgREST doesn't set; gate on the real role.
+
+-- ---------------------------------------------------------------------------
+-- 1 + 2. Quota trigger: INSERT and revival-UPDATE, serialized per user+table.
+-- ---------------------------------------------------------------------------
+create or replace function public.enforce_row_quota()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  user_tier text;
+  cap       integer;
+  used      integer;
+  exists_pk boolean;
+begin
+  -- Only INSERTs and is_deleted false<-true REVIVALS grow the live-row count.
+  -- Any other UPDATE (content edit, or soft-delete true) can never increase it.
+  if tg_op = 'UPDATE' then
+    if not (old.is_deleted is true and new.is_deleted is false) then
+      return new;
+    end if;
+  end if;
+
+  -- Serialize concurrent quota checks for THIS user+table so a parallel burst
+  -- can't each read a stale under-cap count and all proceed (TOCTOU). Scoped to
+  -- (owner, table) → only one user's own concurrent writes serialize.
+  perform pg_advisory_xact_lock(
+    hashtextextended(new.owner_user_id::text || '|' || tg_table_name, 0));
+
+  -- An INSERT whose PK already exists is an upsert→UPDATE in disguise: not new
+  -- growth. (Reference PK columns generically — to_jsonb avoids parse-time
+  -- field errors on tables lacking a given column.)
+  if tg_op = 'INSERT' then
+    if tg_table_name = 'knowledge_entity_refs' then
+      select exists(
+        select 1 from public.knowledge_entity_refs
+         where owner_user_id = (to_jsonb(new)->>'owner_user_id')::uuid
+           and knowledge_id = to_jsonb(new)->>'knowledge_id'
+           and entity_id = to_jsonb(new)->>'entity_id')
+        into exists_pk;
+    else
+      execute format(
+        'select exists(select 1 from public.%I where owner_user_id = $1 and id = $2)',
+        tg_table_name)
+        into exists_pk
+        using (to_jsonb(new)->>'owner_user_id')::uuid, to_jsonb(new)->>'id';
+    end if;
+    if exists_pk then
+      return new;
+    end if;
+  end if;
+
+  select tier into user_tier from public.profiles where id = new.owner_user_id;
+  if user_tier is null then user_tier := 'free'; end if;
+
+  select max_rows into cap
+    from public.plan_limits
+   where tier = user_tier and table_name = tg_table_name;
+  if cap is null then
+    return new;
+  end if;
+
+  execute format(
+    'select count(*) from public.%I where owner_user_id = $1 and is_deleted = false',
+    tg_table_name)
+    into used using new.owner_user_id;
+
+  if used >= cap then
+    raise exception
+      'sync quota exceeded for % on tier %: % of % rows. Upgrade to sync more.',
+      tg_table_name, user_tier, used, cap
+      using errcode = 'check_violation';
+  end if;
+
+  return new;
+end;
+$$;
+
+-- Re-attach as BEFORE INSERT OR UPDATE on every synced table.
+do $$
+declare t text;
+begin
+  foreach t in array array[
+    'knowledge', 'entities', 'entity_aliases', 'entity_relations', 'knowledge_entity_refs'
+  ]
+  loop
+    execute format('drop trigger if exists %1$s_row_quota on public.%1$s', t);
+    execute format(
+      'create trigger %1$s_row_quota before insert or update on public.%1$s
+         for each row execute function public.enforce_row_quota()', t);
+  end loop;
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 3. Cap the user-controlled `id` column on the four id-keyed tables.
+--    (knowledge_entity_refs already caps knowledge_id/entity_id <= 64.)
+-- ---------------------------------------------------------------------------
+alter table public.knowledge drop constraint if exists knowledge_id_size_ck;
+alter table public.knowledge add constraint knowledge_id_size_ck check (length(id) <= 64);
+alter table public.entities drop constraint if exists entities_id_size_ck;
+alter table public.entities add constraint entities_id_size_ck check (length(id) <= 64);
+alter table public.entity_aliases drop constraint if exists entity_aliases_id_size_ck;
+alter table public.entity_aliases add constraint entity_aliases_id_size_ck check (length(id) <= 64);
+alter table public.entity_relations drop constraint if exists entity_relations_id_size_ck;
+alter table public.entity_relations add constraint entity_relations_id_size_ck check (length(id) <= 64);
+
+-- ---------------------------------------------------------------------------
+-- 4. guard_profile_tier: gate on the actual switched role, not a GUC PostgREST
+--    does not set. The column GRANT (excluding tier) remains the primary defense.
+-- ---------------------------------------------------------------------------
+create or replace function public.guard_profile_tier()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if new.tier is distinct from old.tier
+     and coalesce(auth.role(), current_user) <> 'service_role'
+  then
+    raise exception 'tier is not user-modifiable'
+      using errcode = 'insufficient_privilege';
+  end if;
+  return new;
+end;
+$$;

--- a/supabase/migrations/0006_tier_upgrade_path.sql
+++ b/supabase/migrations/0006_tier_upgrade_path.sql
@@ -1,0 +1,14 @@
+-- Migration 0006 — restore the legitimate tier-upgrade path (pen-test MEDIUM).
+--
+-- 0004 revoked UPDATE on profiles from `authenticated` and re-granted only the
+-- safe columns; 0005's guard_profile_tier exempts `service_role` from the tier
+-- lock. But `service_role` was never granted UPDATE on profiles, so the intended
+-- "payment webhook upgrades the user to pro via the service-role key" path
+-- failed permission-denied. Grant it explicitly. (The guard trigger still blocks
+-- everyone except service_role, and `authenticated` still cannot touch `tier`.)
+--
+-- This is the ONLY role allowed to change tier — it bypasses RLS, is never
+-- exposed to clients, and is used solely by trusted server-side billing code.
+-- SELECT is needed alongside UPDATE so `UPDATE ... WHERE id = ...` can resolve
+-- the target row.
+grant select, update on public.profiles to service_role;


### PR DESCRIPTION
## Summary

Second milestone of the multi-DB architecture (#467): **Basic-tier logical sync** of knowledge + the entity graph between each machine's local SQLite (the source of truth) and a shared multi-tenant Supabase Postgres. Builds on the accounts work (#765). Opt-in via `lore sync enable`; inert otherwise.

Three pieces, three commits (core / supabase / gateway). Each piece was put through an independent adversarial review; **all BLOCKERs found are fixed with regressions** (see below).

## What's included

**Core (`@loreai/core`) — change tracking (schema v43)**
- `sync_outbox` (monotonic push queue), `sync_state` (per-row `content_hash`/`revision`/pull cursor), `sync_conflicts` (resolved-conflict log incl. `local_content`).
- Change-capture as **per-connection TEMP triggers**, gated by `sync.enabled`, with **connection-scoped, re-entrant** apply-suppression (a CLI process can't suppress the gateway's captures).
- `sync-data.ts`: JS content hashing, idempotent reconcile, `classifyRemoteRow` (skip/apply/conflict), `applyRemoteUpsert` (ON CONFLICT — FTS-safe), conflict recording.

**Supabase (`supabase/migrations/0002–0004`) — remote mirror + anti-abuse**
- 5 synced tables with `owner_user_id`/`content_hash`/`revision`/`is_deleted`/server `updated_at`; owner-scoped RLS; pull-cursor indexes.
- **Direct-PostgREST write model** (RLS = ownership; in-DB triggers = volume/size). `plan_limits` (free: knowledge 500, entities 30, …) + per-user quota trigger + per-field size CHECKs.
- Hardening: `profiles.tier` is **server-only** (no free→pro self-escalation), all user TEXT columns capped, DML grants land with the tier lock, quota counts live rows so at-cap users can still edit/delete.

**Gateway (`@loreai/gateway`) — the engine**
- `pushOnce`/`pullOnce`/`syncOnce` (push-then-pull), per-table cursors, graceful quota handling, keyset pull cursor, LWW-remote-wins (discarded local row preserved).
- `lore sync enable|disable|status|now` CLI; background scheduler (startup pull / periodic / shutdown flush).

## Security & abuse model

Clients write directly to PostgREST (anon key + user JWT). **RLS isolates by owner; all volume/size limits are enforced in Postgres** (can't be bypassed by a malicious client). A free user cannot dump their history (row + size caps), cannot self-upgrade tier, and cannot store blobs. Distillations + raw conversation logs are paid-tier-only and excluded from the Basic set. Conflict policy is last-writer-to-remote-wins with the overwritten local row preserved for recovery (documented in `supabase/README.md`).

## Testing

- 3 adversarial reviews → BLOCKERs fixed with regressions:
  - core: connection-scoped + re-entrant suppression; `INSERT OR REPLACE` → `ON CONFLICT`; reconcile-on-enable.
  - supabase: tier self-escalation, uncapped-column blobs, quota-freezes-at-cap-users — all verified blocked on the live project.
  - engine: lost-write-on-transient-error, same-timestamp pull gap, head-of-line quota wedge, shutdown push race — all fixed; regressions use an adversarial mock that reproduces them.
- Full suite green: **3223 passed / 6 skipped / 0 failures**; typecheck + Biome clean.

## Notes

- `0002–0004` were applied to the live project via the Management API during development; they're idempotent and will be recorded by the Supabase GitHub integration on merge.
- Follow-ups (not in scope): edge rate-limiting for paid tiers; Stripe→service-role tier upgrades (private backend); a tombstone reaper; richer conflict merge.
