### PR TITLE
fix(core): stop curator from minting near-duplicate preferences

### DIFF
--- a/packages/core/src/curator.ts
+++ b/packages/core/src/curator.ts
@@ -15,9 +15,11 @@ import {
   CURATOR_SYSTEM,
   curatorUser,
   CONSOLIDATION_SYSTEM,
+  CONSOLIDATION_MERGE_SYSTEM,
   consolidationUser,
 } from "./prompt";
 import * as toolTrace from "./tool-trace";
+import { tagToTitle } from "./pattern-extract";
 import { detectAndFormat } from "./instruction-detect";
 import { curatorLimiter } from "./session-limiter";
 import type { LLMClient } from "./types";
@@ -562,6 +564,86 @@ export async function run(input: {
   return curatorLimiter.get(input.sessionID)(() => runInner(input));
 }
 
+/**
+ * Collapse near-duplicate `preference` create ops into update ops before they
+ * reach applyOps. For each `op:"create"` with category `preference`, look up a
+ * semantic duplicate (embedding cosine ≥ PREFERENCE_DEDUP_THRESHOLD, looser than
+ * the global dedup cutoff because the curator re-phrases the same rule every
+ * session). On a hit, rewrite the op to `{op:"update", id, content, confidence}`
+ * so the existing entry is refreshed in place instead of a paraphrase being
+ * minted — preventing system[1] preference bloat. Non-preference ops and ops
+ * with no semantic match pass through unchanged. No-ops when embeddings are
+ * unavailable (findSemanticDuplicate returns null).
+ */
+export async function dedupePreferenceCreates(
+  ops: CuratorOp[],
+  projectPath: string,
+): Promise<CuratorOp[]> {
+  if (!embedding.isAvailable()) return ops;
+  const pid = ensureProject(projectPath);
+  // Track ids already matched this batch so two paraphrases in the SAME op list
+  // don't both redirect onto the same existing entry (the second would clobber
+  // the first's content). ACCEPTED LIMITATION: the second paraphrase then falls
+  // through as a normal create, so two same-rule paraphrases emitted in ONE
+  // curator batch still yield two entries this turn. The per-category
+  // consolidation trigger merges that residual on a later idle pass; in practice
+  // the curator rarely emits two paraphrases of one rule in a single batch.
+  const claimed = new Set<string>();
+  const out: CuratorOp[] = [];
+  for (const op of ops) {
+    if (op.op !== "create" || op.category !== "preference" || !op.title) {
+      out.push(op);
+      continue;
+    }
+    let dup: { id: string; similarity: number } | null = null;
+    try {
+      dup = await ltm.findSemanticDuplicate({
+        title: op.title,
+        content: op.content,
+        projectId: op.scope === "global" ? null : pid,
+        threshold: ltm.PREFERENCE_DEDUP_THRESHOLD,
+      });
+    } catch (err) {
+      log.warn(
+        "preference dedup: findSemanticDuplicate failed (non-fatal):",
+        err,
+      );
+    }
+    const existing = dup && !claimed.has(dup.id) ? ltm.get(dup.id) : null;
+    // Guard: a project-scoped create must NOT mutate a globally-shared
+    // (cross-project) preference — that would let one project overwrite a
+    // preference visible to all projects. Let it fall through as a normal
+    // project-scoped create instead. (A global create may still update a global
+    // match; a project create may update a same-project match.)
+    const wouldMutateGlobalFromProject =
+      existing != null &&
+      op.scope !== "global" &&
+      (existing.cross_project === 1 || existing.project_id == null);
+    if (existing && !wouldMutateGlobalFromProject) {
+      claimed.add(existing.id);
+      // Keep the richer text: don't let a terser paraphrase degrade a more
+      // detailed existing entry. Only adopt the new content when it is at least
+      // as long (a fuller restatement); otherwise refresh confidence only.
+      const keepNewContent =
+        (op.content?.length ?? 0) >= (existing.content?.length ?? 0);
+      log.info(
+        `curation: collapsing near-duplicate preference into existing entry ` +
+          `${existing.id.slice(0, 8)} (sim=${dup?.similarity.toFixed(3)}, ` +
+          `content=${keepNewContent ? "new" : "kept"}): "${op.title}"`,
+      );
+      out.push({
+        op: "update",
+        id: existing.id,
+        ...(keepNewContent ? { content: op.content } : {}),
+        confidence: op.confidence,
+      });
+    } else {
+      out.push(op);
+    }
+  }
+  return out;
+}
+
 async function runInner(input: {
   llm: LLMClient;
   projectPath: string;
@@ -751,7 +833,17 @@ async function runInner(input: {
     );
   }
 
-  const result = applyOps(response.ops, {
+  // Pre-pass: collapse near-duplicate `preference` creates into updates.
+  // The curator re-observes the same behavioral rule each session and re-phrases
+  // it ("document invariants in code" stated 3 ways), producing paraphrases that
+  // ltm.create()'s title-only dedup misses. Preferences inject into the
+  // always-pinned system[1] block, so duplicates are the most costly. Use
+  // embedding similarity at a preference-specific (looser) threshold to redirect
+  // a near-dup create onto the existing entry. Async embedding work lives here
+  // (runInner is async) so applyOps can stay synchronous.
+  const ops = await dedupePreferenceCreates(response.ops, input.projectPath);
+
+  const result = applyOps(ops, {
     projectPath: input.projectPath,
     sessionID: input.sessionID,
     skipCreate: atLimit,
@@ -854,6 +946,30 @@ async function runInner(input: {
 // ---------------------------------------------------------------------------
 
 /**
+ * True if a non-zero-confidence knowledge entry with this exact (case-folded)
+ * title already exists for the project in the given category. Used to suppress
+ * behavioral-signal lines for patterns the curator has ALREADY captured — so it
+ * is not re-prompted every run to re-create the same preference/gotcha (the
+ * re-observation → near-duplicate-mint loop). Mirrors the title check ltm.create
+ * uses, so "already captured" here means "would dedup-merge on create".
+ */
+function hasKnowledgeTitle(
+  projectId: string,
+  category: string,
+  title: string,
+): boolean {
+  return (
+    db()
+      .query(
+        `SELECT id FROM knowledge
+         WHERE project_id = ? AND LOWER(title) = LOWER(?)
+         AND category = ? AND confidence > 0 LIMIT 1`,
+      )
+      .get(projectId, title, category) != null
+  );
+}
+
+/**
  * Scan distillation observations for action tags and count their occurrence
  * across distinct sessions. Returns a compact summary like:
  *
@@ -862,9 +978,10 @@ async function runInner(input: {
  *    - [corrected-style] appeared in 3 sessions"
  *
  * This helps the curator recognize implicit preferences from repeated behavior
- * without the noise of full recall results.
+ * without the noise of full recall results. Tags already captured as preference
+ * entries are filtered out so the curator is not re-prompted to re-create them.
  */
-function buildActionTagContext(
+export function buildActionTagContext(
   projectPath: string,
   currentSessionID: string,
 ): string {
@@ -895,9 +1012,14 @@ function buildActionTagContext(
     }
   }
 
-  // Filter to tags that appeared in 2+ sessions (emerging patterns)
+  // Filter to tags that appeared in 2+ sessions (emerging patterns), AND that
+  // are not already captured as a preference entry — otherwise the curator is
+  // re-prompted to re-create the same preference on every run (re-observation
+  // loop → near-duplicate mints). tagToTitle maps a tag to the canonical
+  // preference title the distiller/curator would create for it.
   const significant = [...tagSessions.entries()]
     .filter(([, sessions]) => sessions.size >= 2)
+    .filter(([tag]) => !hasKnowledgeTitle(pid, "preference", tagToTitle(tag)))
     .sort((a, b) => b[1].size - a[1].size);
 
   if (!significant.length) return "";
@@ -923,10 +1045,22 @@ function buildToolFailureContext(
   projectPath: string,
   currentSessionID: string,
 ): string {
-  const stats = toolTrace.toolFailureStats(projectPath, {
-    minSessions: 2,
-    excludeSessionID: currentSessionID,
-  });
+  const pid = ensureProject(projectPath);
+  const stats = toolTrace
+    .toolFailureStats(projectPath, {
+      minSessions: 2,
+      excludeSessionID: currentSessionID,
+    })
+    // Drop failures already captured as a gotcha entry so the curator is not
+    // re-prompted to re-create them every run (re-observation loop).
+    .filter(
+      (s) =>
+        !hasKnowledgeTitle(
+          pid,
+          "gotcha",
+          toolTrace.toolGotchaTitle(s.tool, s.error_type),
+        ),
+    );
   if (!stats.length) return "";
 
   const lines = stats
@@ -981,6 +1115,16 @@ export async function consolidate(input: {
   projectPath: string;
   sessionID: string;
   model?: { providerID: string; modelID: string };
+  /**
+   * When set, consolidate a single bloated category (e.g. "preference") even
+   * though the GLOBAL entry count is under maxEntries. Sends all PROJECT-SCOPED
+   * entries of that category (cross-project/global entries are EXCLUDED for
+   * deletion safety — one project must not delete a globally-shared preference)
+   * to the LLM so it can merge paraphrased near-duplicates that the
+   * confidence-tail batched mode would never surface. Used by the per-category
+   * consolidation trigger.
+   */
+  focusCategory?: string;
   workerHealth?: {
     recordFailure(reason: string): void;
     recordSuccess(): void;
@@ -988,6 +1132,23 @@ export async function consolidate(input: {
 }): Promise<{ updated: number; deleted: number }> {
   const cfg = config();
   if (!cfg.curator.enabled) return { updated: 0, deleted: 0 };
+
+  // Category-focused mode: bypass the global-count gate and merge one bloated
+  // category. Only send PROJECT-SCOPED entries to the consolidator — never
+  // cross-project (global) ones. applyOps' project guard treats global
+  // (project_id=NULL) rows as freely mutable/deletable, so a single project's
+  // consolidation could otherwise delete a preference shared across ALL
+  // projects. Excluding them mirrors the global path's includeCross=false
+  // safety. (Global-preference dedup is handled at create time by
+  // dedupePreferenceCreates, which redirects onto the existing global entry.)
+  if (input.focusCategory) {
+    const projectScoped = ltm.forProject(input.projectPath, false);
+    const catEntries = projectScoped.filter(
+      (e) => e.category === input.focusCategory,
+    );
+    if (catEntries.length < 2) return { updated: 0, deleted: 0 };
+    return consolidateEntries(input, catEntries);
+  }
 
   // Intentionally excludes cross-project entries (includeCross=false).
   // Consolidation should only merge/trim project-scoped entries — cross-project
@@ -1038,9 +1199,58 @@ export async function consolidate(input: {
     );
   }
 
+  return runConsolidationPrompt(input, entriesForPrompt, batchTarget);
+}
+
+/**
+ * Consolidate an explicit set of entries (a single bloated category) by merging
+ * GENUINE DUPLICATES only — no numeric eviction target. Uses the merge-oriented
+ * prompt so distinct entries are never force-deleted (unlike the global trim
+ * path). Bypasses the lowest-confidence batched selection (which never surfaces
+ * high-confidence preference dups).
+ */
+async function consolidateEntries(
+  input: Parameters<typeof consolidate>[0],
+  entries: Array<{
+    id: string;
+    category: string;
+    title: string;
+    content: string;
+  }>,
+): Promise<{ updated: number; deleted: number }> {
+  const entriesForPrompt = entries.map((e) => ({
+    id: e.id,
+    category: e.category,
+    title: e.title,
+    content: e.content,
+  }));
+  log.info(
+    `consolidation: category-focused — evaluating ${entries.length} "${entries[0]?.category}" entries for near-duplicate merge`,
+  );
+  return runConsolidationPrompt(input, entriesForPrompt, 0, "merge-duplicates");
+}
+
+/**
+ * Shared tail of consolidate(): build the prompt, call the LLM, apply the
+ * returned merge/delete ops. Never creates (skipCreate). Used by both the
+ * global-count trim path ("trim") and the category-focused merge path
+ * ("merge-duplicates").
+ */
+async function runConsolidationPrompt(
+  input: Parameters<typeof consolidate>[0],
+  entriesForPrompt: Array<{
+    id: string;
+    category: string;
+    title: string;
+    content: string;
+  }>,
+  targetMax: number,
+  mode: "trim" | "merge-duplicates" = "trim",
+): Promise<{ updated: number; deleted: number }> {
   const userContent = consolidationUser({
     entries: entriesForPrompt,
-    targetMax: batchTarget,
+    targetMax,
+    mode,
   });
   // Pass the explicit worker model through — never fall back to cfg.model
   // which is the project/session model and may be from a different provider
@@ -1049,7 +1259,9 @@ export async function consolidate(input: {
   // or skips the call before the adapter's defaultModel is used.
   const model = input.model;
   const responseText = await input.llm.prompt(
-    CONSOLIDATION_SYSTEM,
+    mode === "merge-duplicates"
+      ? CONSOLIDATION_MERGE_SYSTEM
+      : CONSOLIDATION_SYSTEM,
     userContent,
     {
       model,

--- a/packages/core/src/instruction-detect.ts
+++ b/packages/core/src/instruction-detect.ts
@@ -16,6 +16,7 @@
 import { db, ensureProject } from "./db";
 import * as temporal from "./temporal";
 import * as embedding from "./embedding";
+import * as ltm from "./ltm";
 import { filterTerms, ftsQueryOr, EMPTY_QUERY } from "./search";
 import * as log from "./log";
 
@@ -310,11 +311,43 @@ export async function detectAndFormat(input: {
     threshold: input.threshold,
   });
 
-  if (repeated.length) {
+  // Drop instructions already captured as a preference entry, so the curator is
+  // not re-prompted to re-create them every run (re-observation loop →
+  // near-duplicate preference mints). Uses embedding similarity at the
+  // preference threshold; no-ops when embeddings are unavailable (keeps all).
+  const pid = ensureProject(input.projectPath);
+  const novel: RepeatedInstruction[] = [];
+  for (const r of repeated) {
+    let alreadyCaptured = false;
+    if (embedding.isAvailable()) {
+      try {
+        const dup = await ltm.findSemanticDuplicate({
+          title: r.instruction,
+          content: r.instruction,
+          projectId: pid,
+          threshold: ltm.PREFERENCE_DEDUP_THRESHOLD,
+        });
+        // Only suppress when the matched entry is actually a preference.
+        if (dup) {
+          const entry = ltm.get(dup.id);
+          alreadyCaptured = entry?.category === "preference";
+        }
+      } catch (err) {
+        log.warn(
+          "instruction-detect: preference-match check failed (non-fatal):",
+          err,
+        );
+      }
+    }
+    if (!alreadyCaptured) novel.push(r);
+  }
+
+  if (novel.length) {
     log.info(
-      `instruction-detect: ${repeated.length} repeated instruction(s) found across sessions`,
+      `instruction-detect: ${novel.length} novel repeated instruction(s) found across sessions ` +
+        `(${repeated.length - novel.length} already captured as preferences)`,
     );
   }
 
-  return formatForCurator(repeated);
+  return formatForCurator(novel);
 }

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -386,6 +386,16 @@ const FUZZY_DEDUP_MIN_OVERLAP = 4;
  *  - <0.92: mixed or unrelated entries */
 const EMBEDDING_DEDUP_THRESHOLD = 0.935;
 
+/** Cosine cutoff for deduping `preference` entries at create time. Lower than
+ *  the global 0.935 because preferences are behavioral directives the LLM
+ *  curator re-observes and re-phrases every session ("document invariants in
+ *  code" stated 3 ways), producing paraphrases that cluster ~0.85–0.92 — below
+ *  the conservative global threshold yet clearly the same rule. Scoped to a
+ *  single category (preferences inject into the always-pinned system[1] block,
+ *  so duplicates are the most costly), so the looser cutoff cannot false-merge
+ *  distinct architecture/gotcha entries. */
+export const PREFERENCE_DEDUP_THRESHOLD = 0.88;
+
 // --- Cross-project auto-promotion thresholds (issue #498) ---
 /** A semantic cluster must span at least this many distinct projects to
  *  qualify its members for cross-project promotion. */
@@ -492,8 +502,16 @@ export async function findSemanticDuplicate(input: {
   title: string;
   content: string;
   projectId: string | null;
+  /**
+   * Cosine-similarity cutoff. Defaults to EMBEDDING_DEDUP_THRESHOLD (0.935),
+   * tuned high to avoid false-merging distinct same-subsystem entries. Callers
+   * deduping a single category where paraphrase is common (e.g. preferences)
+   * may pass a lower, category-specific threshold (see PREFERENCE_DEDUP_THRESHOLD).
+   */
+  threshold?: number;
 }): Promise<{ id: string; similarity: number } | null> {
   if (!embedding.isAvailable()) return null;
+  const threshold = input.threshold ?? EMBEDDING_DEDUP_THRESHOLD;
   let vec: Float32Array;
   try {
     [vec] = await embedding.embed(
@@ -508,7 +526,7 @@ export async function findSemanticDuplicate(input: {
   // project (same project or cross-project) — vectorSearch is global.
   const hits = embedding.vectorSearch(vec, 10);
   for (const hit of hits) {
-    if (hit.similarity < EMBEDDING_DEDUP_THRESHOLD) break; // sorted desc
+    if (hit.similarity < threshold) break; // sorted desc
     const row = db()
       .query(
         `SELECT id FROM knowledge

--- a/packages/core/src/prompt.ts
+++ b/packages/core/src/prompt.ts
@@ -608,6 +608,28 @@ extracting new knowledge, only consolidating existing knowledge.
 
 Output ONLY valid JSON. No markdown fences, no explanation, no preamble.`;
 
+/**
+ * Merge-oriented consolidation prompt for the category-focused path. Unlike the
+ * trim-to-target CONSOLIDATION_SYSTEM, this instructs the model to merge only
+ * genuine semantic DUPLICATES (paraphrases of the same rule) within one
+ * category — with NO numeric eviction target — so it never force-deletes
+ * distinct entries. Returning an empty array IS acceptable here (means nothing
+ * was a true duplicate).
+ */
+export const CONSOLIDATION_MERGE_SYSTEM = `You are a long-term memory curator. You are given all knowledge entries of a SINGLE category that has grown bloated with near-duplicates. Your ONLY job is to merge genuine duplicates.
+
+RULES:
+1. Find groups of entries that express the SAME underlying rule/fact, just phrased differently (paraphrases). For each such group, pick ONE survivor, "update" it to the clearest concise wording (under 150 words), and "delete" the others.
+2. Do NOT merge entries that are merely related or about the same area but make DISTINCT points. Two different rules are NOT duplicates even if they share words. Opposing rules (e.g. "always use tabs" vs "always use spaces") are NEVER duplicates — never merge them.
+3. There is NO target count. If nothing is a true duplicate, return an empty array — that is correct and acceptable.
+4. Never invent new knowledge; only "update" survivors and "delete" true duplicates.
+
+OUTPUT: A JSON array of "update" and "delete" ops only (may be empty). No "create" ops.
+- "update": { "op": "update", "id": "...", "content": "concise merged wording" }
+- "delete": { "op": "delete", "id": "...", "reason": "duplicate of <survivor id>" }
+
+Output ONLY valid JSON. No markdown fences, no explanation, no preamble.`;
+
 export function consolidationUser(input: {
   entries: Array<{
     id: string;
@@ -616,11 +638,23 @@ export function consolidationUser(input: {
     content: string;
   }>;
   targetMax: number;
+  /** "trim" (default): reduce to targetMax via merge+evict. "merge-duplicates":
+   *  merge true paraphrases only, no eviction target (focus-category path). */
+  mode?: "trim" | "merge-duplicates";
 }): string {
   const count = input.entries.length;
   const listed = input.entries
     .map((e) => `- [${e.id}] (${e.category}) ${e.title}: ${e.content}`)
     .join("\n");
+
+  if (input.mode === "merge-duplicates") {
+    return `Knowledge entries in the "${input.entries[0]?.category ?? "?"}" category (${count} total). Merge only genuine duplicates (paraphrases of the same rule); leave distinct entries untouched:
+
+${listed}
+
+Produce update/delete ops to merge true duplicates. If none are duplicates, return [].`;
+  }
+
   const excess = count - input.targetMax;
   return `Current knowledge entries (${count} total, target max: ${input.targetMax}, must remove at least ${excess}):
 

--- a/packages/core/test/curator-preference-dedup.test.ts
+++ b/packages/core/test/curator-preference-dedup.test.ts
@@ -1,0 +1,201 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import { dedupePreferenceCreates } from "../src/curator";
+import type { CuratorOp } from "../src/curator";
+import { db, ensureProject } from "../src/db";
+import * as ltm from "../src/ltm";
+import * as embedding from "../src/embedding";
+
+/**
+ * The curator re-observes the same behavioral rule each session and re-phrases
+ * it, producing paraphrased `preference` creates that ltm.create()'s title-only
+ * dedup misses. dedupePreferenceCreates() collapses such near-duplicate creates
+ * into updates against the existing entry (embedding similarity at the looser
+ * preference threshold), preventing system[1] preference bloat.
+ */
+describe("curator dedupePreferenceCreates", () => {
+  const PROJ = "/test/curator/pref-dedup";
+  let availableSpy: ReturnType<typeof vi.spyOn>;
+  let embedSpy: ReturnType<typeof vi.spyOn>;
+  let vectorSpy: ReturnType<typeof vi.spyOn>;
+  let existingId = "";
+
+  beforeEach(() => {
+    const pid = ensureProject(PROJ);
+    db().query("DELETE FROM knowledge WHERE project_id = ?").run(pid);
+    existingId = ltm.create({
+      projectPath: PROJ,
+      category: "preference",
+      title: "Always document invariants as code comments",
+      content: "Document load-bearing invariants inline in source.",
+      scope: "project",
+    });
+    availableSpy = vi.spyOn(embedding, "isAvailable").mockReturnValue(true);
+    embedSpy = vi
+      .spyOn(embedding, "embed")
+      .mockResolvedValue([new Float32Array([1, 0, 0])]);
+    // 0.90: a near-duplicate preference — above the 0.88 preference threshold,
+    // below the global 0.935.
+    vectorSpy = vi
+      .spyOn(embedding, "vectorSearch")
+      .mockImplementation(() => [{ id: existingId, similarity: 0.9 }]);
+  });
+
+  afterEach(() => {
+    availableSpy.mockRestore();
+    embedSpy.mockRestore();
+    vectorSpy.mockRestore();
+  });
+
+  test("rewrites a near-duplicate preference create into an update; adopts new content when it is at least as long", async () => {
+    const longerContent =
+      "Document load-bearing invariants and design rationale inline in the source, with examples.";
+    const ops: CuratorOp[] = [
+      {
+        op: "create",
+        category: "preference",
+        title: "Always write invariants as inline code comments",
+        content: longerContent, // longer than the existing entry's content
+        scope: "project",
+        confidence: 0.9,
+      },
+    ];
+    const out = await dedupePreferenceCreates(ops, PROJ);
+    expect(out).toHaveLength(1);
+    expect(out[0].op).toBe("update");
+    // The existing entry is refreshed in place — no new entry minted.
+    expect(out[0]).toMatchObject({
+      op: "update",
+      id: existingId,
+      content: longerContent,
+      confidence: 0.9,
+    });
+  });
+
+  test("does NOT overwrite richer existing content with a terser paraphrase (refreshes confidence only)", async () => {
+    const ops: CuratorOp[] = [
+      {
+        op: "create",
+        category: "preference",
+        title: "Always write invariants as inline code comments",
+        content: "Terser.", // shorter than the existing entry's content
+        scope: "project",
+        confidence: 0.95,
+      },
+    ];
+    const out = await dedupePreferenceCreates(ops, PROJ);
+    expect(out).toHaveLength(1);
+    expect(out[0].op).toBe("update");
+    expect(out[0]).toMatchObject({
+      op: "update",
+      id: existingId,
+      confidence: 0.95,
+    });
+    // content must NOT be present — the richer existing content is preserved.
+    expect((out[0] as { content?: string }).content).toBeUndefined();
+  });
+
+  test("project-scoped create does NOT mutate a globally-shared preference (falls through as create)", async () => {
+    // Replace the project entry with a CROSS-PROJECT (global) match.
+    db()
+      .query("DELETE FROM knowledge WHERE project_id = ?")
+      .run(ensureProject(PROJ));
+    const globalId = ltm.create({
+      category: "preference",
+      title: "Always document invariants as code comments",
+      content: "Global preference shared across all projects.",
+      scope: "global",
+      crossProject: true,
+    });
+    vectorSpy.mockImplementation(() => [{ id: globalId, similarity: 0.9 }]);
+    const ops: CuratorOp[] = [
+      {
+        op: "create",
+        category: "preference",
+        title: "Always write invariants as inline code comments",
+        content:
+          "Project-local phrasing that must not clobber the global entry.",
+        scope: "project",
+        confidence: 0.9,
+      },
+    ];
+    const out = await dedupePreferenceCreates(ops, PROJ);
+    expect(out).toHaveLength(1);
+    // Must remain a create — a project create may not overwrite a global entry.
+    expect(out[0].op).toBe("create");
+    db().query("DELETE FROM knowledge WHERE id = ?").run(globalId);
+  });
+
+  test("passes NON-preference creates through unchanged (no dedup applied)", async () => {
+    const ops: CuratorOp[] = [
+      {
+        op: "create",
+        category: "architecture",
+        title: "Some architecture fact",
+        content: "Distinct architectural detail.",
+        scope: "project",
+      },
+    ];
+    const out = await dedupePreferenceCreates(ops, PROJ);
+    expect(out).toEqual(ops);
+  });
+
+  test("passes a preference create through when there is no semantic duplicate", async () => {
+    vectorSpy.mockImplementation(() => []); // no neighbors
+    const ops: CuratorOp[] = [
+      {
+        op: "create",
+        category: "preference",
+        title: "A genuinely new preference",
+        content: "Unrelated rule.",
+        scope: "project",
+        confidence: 0.8,
+      },
+    ];
+    const out = await dedupePreferenceCreates(ops, PROJ);
+    expect(out).toHaveLength(1);
+    expect(out[0].op).toBe("create");
+  });
+
+  test("two paraphrases in the SAME batch don't both redirect onto one entry", async () => {
+    // Only the first should collapse; the second falls through as a create so
+    // it doesn't clobber the first's update content.
+    const ops: CuratorOp[] = [
+      {
+        op: "create",
+        category: "preference",
+        title: "Paraphrase one of the rule",
+        content: "First paraphrase.",
+        scope: "project",
+        confidence: 0.9,
+      },
+      {
+        op: "create",
+        category: "preference",
+        title: "Paraphrase two of the rule",
+        content: "Second paraphrase.",
+        scope: "project",
+        confidence: 0.9,
+      },
+    ];
+    const out = await dedupePreferenceCreates(ops, PROJ);
+    expect(out).toHaveLength(2);
+    expect(out[0].op).toBe("update");
+    expect(out[1].op).toBe("create");
+  });
+
+  test("no-ops when embeddings are unavailable", async () => {
+    availableSpy.mockReturnValue(false);
+    const ops: CuratorOp[] = [
+      {
+        op: "create",
+        category: "preference",
+        title: "Always write invariants as inline code comments",
+        content: "Same rule, no embeddings available.",
+        scope: "project",
+        confidence: 0.9,
+      },
+    ];
+    const out = await dedupePreferenceCreates(ops, PROJ);
+    expect(out).toEqual(ops);
+  });
+});

--- a/packages/core/test/curator-reobservation.test.ts
+++ b/packages/core/test/curator-reobservation.test.ts
@@ -1,0 +1,141 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import { buildActionTagContext, consolidate } from "../src/curator";
+import { db, ensureProject } from "../src/db";
+import * as ltm from "../src/ltm";
+import { uuidv7 } from "uuidv7";
+import type { LLMClient } from "../src/types";
+
+/**
+ * The curator appends a "behavioral patterns detected" signal built over ALL
+ * project history every run. Without an already-captured filter it re-prompts
+ * the curator to re-create preferences it already minted (re-observation loop →
+ * near-duplicate mints). These tests pin the exclusion.
+ */
+describe("curator re-observation suppression — buildActionTagContext", () => {
+  const PROJ = "/test/curator/reobs-tags";
+
+  function seedDistillation(sessionID: string, observations: string) {
+    const pid = ensureProject(PROJ);
+    db()
+      .query(
+        `INSERT INTO distillations
+           (id, project_id, session_id, narrative, facts, observations,
+            source_ids, generation, token_count, created_at)
+         VALUES (?, ?, ?, '', '', ?, '[]', 0, 10, ?)`,
+      )
+      .run(uuidv7(), pid, sessionID, observations, Date.now());
+  }
+
+  beforeEach(() => {
+    const pid = ensureProject(PROJ);
+    db().query("DELETE FROM knowledge WHERE project_id = ?").run(pid);
+    db().query("DELETE FROM distillations WHERE project_id = ?").run(pid);
+    // The [requested-tests] tag appears in two prior sessions → "significant".
+    seedDistillation(
+      "sess-A",
+      "The user [requested-tests] for the new module.",
+    );
+    seedDistillation("sess-B", "Again the user [requested-tests] here.");
+  });
+
+  test("surfaces a significant tag when it is NOT yet captured as a preference", () => {
+    const out = buildActionTagContext(PROJ, "sess-current");
+    expect(out).toContain("[requested-tests]");
+    expect(out).toContain("behavioral patterns detected");
+  });
+
+  test("suppresses a tag already captured as a preference (no re-prompt)", () => {
+    // tagToTitle("requested-tests") = "Always write tests alongside implementation"
+    ltm.create({
+      projectPath: PROJ,
+      category: "preference",
+      title: "Always write tests alongside implementation",
+      content: "Write tests with each change.",
+      scope: "project",
+    });
+    const out = buildActionTagContext(PROJ, "sess-current");
+    // The tag is already captured → excluded → no signal emitted at all.
+    expect(out).toBe("");
+  });
+});
+
+/**
+ * The per-category consolidation path must actually MERGE duplicates. Pre-fix it
+ * passed targetMax=length to the trim prompt ("remove at least 0") and merged
+ * nothing. This pins that focusCategory uses the merge prompt and applies the
+ * LLM's merge/delete ops.
+ */
+describe("curator consolidate — focusCategory merge", () => {
+  const PROJ = "/test/curator/reobs-consolidate";
+  let aId = "";
+  let bId = "";
+
+  beforeEach(() => {
+    const pid = ensureProject(PROJ);
+    db().query("DELETE FROM knowledge WHERE project_id = ?").run(pid);
+    aId = ltm.create({
+      projectPath: PROJ,
+      category: "preference",
+      title: "Always document invariants in code",
+      content: "Document invariants inline.",
+      scope: "project",
+    });
+    bId = ltm.create({
+      projectPath: PROJ,
+      category: "preference",
+      title: "Always write invariants as code comments",
+      content: "Put invariants in comments.",
+      scope: "project",
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("uses the merge prompt and applies the LLM's merge (delete) op", async () => {
+    let receivedSystem = "";
+    const llm: LLMClient = {
+      prompt: async (system: string) => {
+        receivedSystem = system;
+        // Simulate the model merging B into A.
+        return JSON.stringify([
+          {
+            op: "update",
+            id: aId,
+            content: "Document invariants inline (merged).",
+          },
+          { op: "delete", id: bId, reason: `duplicate of ${aId}` },
+        ]);
+      },
+    };
+
+    const result = await consolidate({
+      llm,
+      projectPath: PROJ,
+      sessionID: "sess-consolidate",
+      focusCategory: "preference",
+    });
+
+    // Merge prompt used (not the trim/eviction prompt).
+    expect(receivedSystem).toContain("merge genuine duplicates");
+    expect(receivedSystem).not.toContain("target maximum");
+    // The delete was applied — B is gone, A survives.
+    expect(result.deleted).toBeGreaterThanOrEqual(1);
+    expect(ltm.get(bId)).toBeNull();
+    expect(ltm.get(aId)).not.toBeNull();
+  });
+
+  test("does nothing when fewer than 2 entries in the category", async () => {
+    db().query("DELETE FROM knowledge WHERE id = ?").run(bId);
+    const llm: LLMClient = { prompt: vi.fn(async () => "[]") };
+    const result = await consolidate({
+      llm,
+      projectPath: PROJ,
+      sessionID: "sess-consolidate",
+      focusCategory: "preference",
+    });
+    expect(result).toEqual({ updated: 0, deleted: 0 });
+    expect(llm.prompt).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/test/ltm.test.ts
+++ b/packages/core/test/ltm.test.ts
@@ -295,6 +295,72 @@ describe("ltm — crossProject defaults and dedup", () => {
   });
 });
 
+describe("ltm.findSemanticDuplicate — preference-specific threshold", () => {
+  const PROJ = "/test/ltm/semdup-threshold";
+  let availableSpy: ReturnType<typeof vi.spyOn>;
+  let embedSpy: ReturnType<typeof vi.spyOn>;
+  let vectorSpy: ReturnType<typeof vi.spyOn>;
+  let existingId = "";
+
+  beforeEach(() => {
+    const pid = ensureProject(PROJ);
+    db().query("DELETE FROM knowledge WHERE project_id = ?").run(pid);
+    existingId = ltm.create({
+      projectPath: PROJ,
+      category: "preference",
+      title: "Always document invariants as code comments",
+      content: "Document load-bearing invariants inline in source.",
+      scope: "project",
+    });
+
+    availableSpy = vi.spyOn(embedding, "isAvailable").mockReturnValue(true);
+    embedSpy = vi
+      .spyOn(embedding, "embed")
+      .mockResolvedValue([new Float32Array([1, 0, 0])]);
+    // The existing entry scores 0.90 cosine vs the incoming paraphrase — a
+    // realistic near-duplicate-preference similarity: above the new 0.88
+    // preference threshold, but BELOW the conservative global 0.935.
+    vectorSpy = vi
+      .spyOn(embedding, "vectorSearch")
+      .mockImplementation(() => [{ id: existingId, similarity: 0.9 }]);
+  });
+
+  afterEach(() => {
+    availableSpy.mockRestore();
+    embedSpy.mockRestore();
+    vectorSpy.mockRestore();
+  });
+
+  test("default (global 0.935) threshold does NOT match a 0.90 paraphrase", async () => {
+    const dup = await ltm.findSemanticDuplicate({
+      title: "Always write invariants as inline code comments",
+      content: "Put design rationale and invariants in the source.",
+      projectId: ensureProject(PROJ),
+    });
+    expect(dup).toBeNull();
+  });
+
+  test("PREFERENCE_DEDUP_THRESHOLD (0.88) DOES match the 0.90 paraphrase", async () => {
+    const dup = await ltm.findSemanticDuplicate({
+      title: "Always write invariants as inline code comments",
+      content: "Put design rationale and invariants in the source.",
+      projectId: ensureProject(PROJ),
+      threshold: ltm.PREFERENCE_DEDUP_THRESHOLD,
+    });
+    expect(dup).not.toBeNull();
+    expect(dup?.id).toBe(existingId);
+    expect(dup?.similarity).toBeCloseTo(0.9, 5);
+  });
+
+  test("PREFERENCE_DEDUP_THRESHOLD is below the global dedup cutoff", () => {
+    // Guards the invariant that the preference cutoff is intentionally looser
+    // (so paraphrases collapse) but still > 0 — a revert to the global value
+    // would make the dedup test above fail.
+    expect(ltm.PREFERENCE_DEDUP_THRESHOLD).toBeLessThan(0.935);
+    expect(ltm.PREFERENCE_DEDUP_THRESHOLD).toBeGreaterThan(0.5);
+  });
+});
+
 describe("ltm — UUIDv7 IDs", () => {
   const PROJ = "/test/ltm/uuidv7";
 

--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -98,11 +98,21 @@ const POLL_INTERVAL_MS = 30_000;
  */
 const consolidationCooldown = new Map<
   string,
-  { attemptedAt: number; entryCount: number }
+  { attemptedAt: number; entryCount: number; topCategoryCount: number }
 >();
 
 /** 1 hour cooldown before retrying consolidation with the same entry count. */
 const CONSOLIDATION_COOLDOWN_MS = 60 * 60 * 1000;
+
+/**
+ * Per-category entry count that triggers consolidation even when the GLOBAL
+ * count is below maxEntries. The global trigger structurally misses single-
+ * category bloat: a category (notably `preference`, which the curator re-mints
+ * and re-phrases each session) can swell to dozens while the total stays under
+ * maxEntries, so consolidation never fires and the duplicates inject into the
+ * always-pinned system[1] block every session. This catches that case.
+ */
+const PER_CATEGORY_CONSOLIDATION_THRESHOLD = 12;
 
 /**
  * Sub-agent sessions are ephemeral (1-3 turns) — evict them faster than
@@ -645,19 +655,45 @@ export function buildIdleWorkHandler(
     if (allowWorker && cfg.knowledge.enabled) {
       try {
         const entries = ltm.forProject(projectPath, false);
-        if (entries.length > cfg.curator.maxEntries) {
+        // Per-category bloat check counts PROJECT-SCOPED entries only — matching
+        // what category-focused consolidation will actually merge (it excludes
+        // cross-project entries to avoid one project deleting a globally-shared
+        // preference). Global-preference duplicates are prevented at create time
+        // by dedupePreferenceCreates instead.
+        const catCounts = new Map<string, number>();
+        for (const e of entries) {
+          catCounts.set(e.category, (catCounts.get(e.category) ?? 0) + 1);
+        }
+        let topCategory = "";
+        let topCategoryCount = 0;
+        for (const [cat, n] of catCounts) {
+          if (n > topCategoryCount) {
+            topCategoryCount = n;
+            topCategory = cat;
+          }
+        }
+        const globalOver = entries.length > cfg.curator.maxEntries;
+        const categoryOver =
+          topCategoryCount > PER_CATEGORY_CONSOLIDATION_THRESHOLD;
+        if (globalOver || categoryOver) {
           const cooldown = consolidationCooldown.get(projectPath);
           const now = Date.now();
+          // Cooldown is keyed on the global count; include the top-category
+          // count so a category-only trigger still re-attempts as it grows.
+          const cooldownKey = entries.length;
           if (
             cooldown &&
-            cooldown.entryCount === entries.length &&
+            cooldown.entryCount === cooldownKey &&
+            cooldown.topCategoryCount === topCategoryCount &&
             now - cooldown.attemptedAt < CONSOLIDATION_COOLDOWN_MS
           ) {
             // Cooldown active — skip to avoid wasting Sonnet calls on
             // repeated consolidation attempts that produce no changes.
           } else {
             log.info(
-              `entry count ${entries.length} exceeds maxEntries ${cfg.curator.maxEntries} — running consolidation`,
+              globalOver
+                ? `entry count ${entries.length} exceeds maxEntries ${cfg.curator.maxEntries} — running consolidation`
+                : `category "${topCategory}" count ${topCategoryCount} exceeds per-category threshold ${PER_CATEGORY_CONSOLIDATION_THRESHOLD} — running consolidation`,
             );
             const beforeCount = entries.length;
             const result = await Sentry.startSpan(
@@ -672,6 +708,12 @@ export function buildIdleWorkHandler(
                   projectPath,
                   sessionID,
                   model,
+                  // Category-focused mode when only the per-category threshold
+                  // is exceeded (global count still under maxEntries) — merges
+                  // the bloated category's near-duplicates directly.
+                  ...(!globalOver && categoryOver
+                    ? { focusCategory: topCategory }
+                    : {}),
                   workerHealth: makeWorkerHealth(sessionID, "lore-curator"),
                 }),
             );
@@ -692,6 +734,7 @@ export function buildIdleWorkHandler(
               consolidationCooldown.set(projectPath, {
                 attemptedAt: Date.now(),
                 entryCount: beforeCount,
+                topCategoryCount,
               });
               log.info(
                 `consolidation produced no changes — cooldown active for 1h ` +


### PR DESCRIPTION
## Problem

The LLM curator re-observes the same behavioral rule each session and re-phrases it — e.g. "document invariants in code" stated 3 ways, and a cluster of 4 "always run adversarial review before merge" entries. In one day a single project accumulated **19 `preference` entries**, most near-duplicates.

This is the most costly kind of bloat: preferences inject into the **stable `system[1]` LTM block** pinned into *every* session's prompt (~5,300 tokens of duplicated rules became permanent overhead).

**Root cause:** `ltm.create()` dedups on **title only** (exact `LOWER(title)` + fuzzy title word-overlap) — never content, never embeddings. The embedding-based `findSemanticDuplicate` existed but was wired only into pattern-echo. The post-create sweep uses cosine ≥ 0.935 (deliberately strict); paraphrased preferences cluster ~0.85–0.92, just under it. Consolidation never fired (global-count trigger, excludes cross-project, only sends the low-confidence tail).

## Fix (two parts)

**1. Block new near-duplicate preferences at create time.** `findSemanticDuplicate` gains an optional `threshold`; new `PREFERENCE_DEDUP_THRESHOLD = 0.88` (looser than global 0.935, scoped to one category so it can't false-merge distinct architecture/gotcha entries). New async pre-pass `dedupePreferenceCreates` in the curator rewrites a near-duplicate preference `create` into an `update` of the existing entry. Same-batch double-claim guarded.

**2. Merge existing per-category bloat over time.** New per-category consolidation trigger (`PER_CATEGORY_CONSOLIDATION_THRESHOLD = 12`) fires even when global count is under `maxEntries`. `consolidate()` gains a `focusCategory` mode that sends **all project-scoped** entries of that category (not just the low-confidence tail) to the LLM to merge. Cross-project (global) entries are **excluded** from the focus path so one project can't delete a globally-shared preference; global dups are handled at create time.

## Tests
- `ltm.test.ts`: a 0.90 paraphrase is missed by the global 0.935 cutoff but caught at `PREFERENCE_DEDUP_THRESHOLD`.
- `curator-preference-dedup.test.ts`: create→update rewrite; non-preference passthrough; no-dup passthrough; same-batch double-claim guard; embeddings-unavailable no-op. **Verified fail-on-revert.**

## Verification
- `pnpm test` — **3197 passed**, 6 skipped, 0 failed
- `pnpm run typecheck` — clean; `pnpm run lint` — exit 0

🤖 Generated with [opencode](https://opencode.ai)