### PR TITLE
fix(gateway): stop background-worker 401s on non-Anthropic providers

### DIFF
--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -689,6 +689,11 @@ export function buildAnthropicProfile(
   ttl: "5m" | "1h",
   upstreamBase?: string,
 ): CacheWarmingProfile {
+  const route = resolveUpstreamRoute(model);
+  // || (not ??): an empty-string upstreamBase (header-less Anthropic sessions)
+  // must coalesce to the model route, not produce a base of "".
+  const base = upstreamBase || route?.url || "https://api.anthropic.com";
+
   const entry = getModelEntrySync(model);
   const cacheReadCost =
     entry.cost?.cache_read ?? (entry.cost?.input ?? 3) * 0.1;
@@ -702,36 +707,71 @@ export function buildAnthropicProfile(
   // For 1h TTL: warm in the last 5m (55:00–60:00)
   const warmupMarginMs = ttl === "1h" ? 300_000 : 45_000;
 
-  const route = resolveUpstreamRoute(model);
-  const base = upstreamBase ?? route?.url ?? "https://api.anthropic.com";
-
   return {
     ttlMs,
     cacheReadCostPerMTok: cacheReadCost,
     cacheMissCostPerMTok: cacheWriteCost,
     warmupMarginMs,
     prepareWarmupBody: prepareAnthropicWarmupBody,
-    upstreamUrl: `${base}/v1/messages`,
+    upstreamUrl: `${base.replace(/\/$/, "")}/v1/messages`,
   };
+}
+
+/**
+ * True only for Anthropic's first-party API host. Anthropic-compatible
+ * providers (MiniMax `api.minimax.io/anthropic`, Fireworks, Kimi, …) report
+ * `protocol:"anthropic"` but do NOT support Anthropic prompt-cache warming and
+ * reject the session's foreign key if sent to api.anthropic.com. Cache warming
+ * is gated to this host (see resolveProfile).
+ */
+function isAnthropicFirstPartyHost(url: string): boolean {
+  try {
+    return new URL(url).host === "api.anthropic.com";
+  } catch {
+    return false;
+  }
 }
 
 /**
  * Resolve a warming profile for a session.
  *
  * Returns null if warming is not applicable (unknown provider, warming
- * disabled, etc.).
+ * disabled, or a non-Anthropic-first-party host).
  */
 export function resolveProfile(
   model: string | undefined,
   protocol: "anthropic" | "openai" | "openai-responses" | undefined,
   ttl: "5m" | "1h" | undefined,
   upstreamBase?: string,
+  providerID?: string,
 ): CacheWarmingProfile | null {
   if (!model || !protocol) return null;
 
-  // Only Anthropic for now — OpenAI has automatic prefix caching
-  // with no explicit warming API
+  // Only Anthropic protocol for now — OpenAI has automatic prefix caching with
+  // no explicit warming API.
   if (protocol !== "anthropic") return null;
+
+  // 🔴 Gate on Anthropic IDENTITY, not just the wire protocol. Anthropic-compat
+  // providers (MiniMax, Fireworks, Kimi) report protocol:"anthropic" but
+  // warming them sends the session's foreign api-key to api.anthropic.com (the
+  // buildAnthropicProfile fallback) → 401 "invalid x-api-key" loop, and they
+  // don't honor cache_control warming anyway. Accept the session as Anthropic
+  // when EITHER:
+  //   (a) its explicit providerID is "anthropic" — preserves warming for
+  //       Anthropic routed through a proxy (LORE_UPSTREAM_ANTHROPIC / LiteLLM /
+  //       Cloudflare AI Gateway), where the host is not api.anthropic.com; OR
+  //   (b) the host the warmup would hit IS api.anthropic.com — covers the
+  //       header-less flagship case (Claude Code CLI/Desktop send no
+  //       x-lore-provider / x-lore-upstream-url, so providerID is undefined and
+  //       lastUpstream.url is "").
+  // Use || (not ??) so an EMPTY-STRING upstreamBase coalesces to the model route
+  // (api.anthropic.com) instead of leaving warmupHost = "" → wrongly skipped.
+  const route = resolveUpstreamRoute(model);
+  const warmupHost = upstreamBase || route?.url;
+  const isAnthropic =
+    providerID === "anthropic" ||
+    (!!warmupHost && isAnthropicFirstPartyHost(warmupHost));
+  if (!isAnthropic) return null;
 
   return buildAnthropicProfile(model, ttl ?? "5m", upstreamBase);
 }
@@ -1095,6 +1135,10 @@ export function computeWarmingSnapshot(
     state.lastUpstream?.protocol,
     state.resolvedConversationTTL,
     state.lastUpstream?.url,
+    // Match the live warming path (idle.ts) so the dashboard snapshot doesn't
+    // under-report a profile for proxied-Anthropic sessions (providerID
+    // "anthropic" + non-first-party host).
+    state.lastUpstream?.providerID,
   );
   const ttlMs = profile?.ttlMs ?? 300_000;
   const warmupMarginMs = profile?.warmupMarginMs ?? 45_000;

--- a/packages/gateway/src/cch.ts
+++ b/packages/gateway/src/cch.ts
@@ -590,6 +590,22 @@ export function captureSessionHeaders(
  * client fingerprint as conversation turns, avoiding 401 rejections from
  * Anthropic's OAuth validation.
  */
+/**
+ * The `user-agent` to send on worker requests. Anthropic-compat providers
+ * (e.g. MiniMax) reject requests that lack a recognized user-agent with a
+ * generic auth-failure ("login fail: carry the API secret key in X-Api-Key"),
+ * even when the key and host are correct — the conversation path works only
+ * because it forwards the client's user-agent. Replay the session's sniffed
+ * user-agent (captured in sessionHeaderSnapshots), falling back to a Claude
+ * Code-style UA. Returns a value for ANY session, not just OAuth/billing ones.
+ */
+export function workerUserAgent(sessionID: string | undefined): string {
+  const sniffed = sessionID
+    ? sessionHeaderSnapshots.get(sessionID)?.userAgent
+    : undefined;
+  return sniffed || `claude-cli/${WORKER_VERSION} (external, sdk-cli)`;
+}
+
 export function buildOAuthWorkerHeaders(
   sessionID: string | undefined,
 ): Record<string, string> | null {

--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -262,6 +262,12 @@ export function startIdleScheduler(
         state.lastUpstream?.model,
         state.lastUpstream?.protocol,
         state.resolvedConversationTTL,
+        // Pass the session's real upstream URL + providerID so the warmer warms
+        // only true-Anthropic sessions (first-party host OR providerID
+        // "anthropic", incl. proxied Anthropic) and never sends a compat
+        // provider's key to api.anthropic.com (MiniMax 401 loop).
+        state.lastUpstream?.url,
+        state.lastUpstream?.providerID,
       );
       if (!profile) continue;
 

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -30,6 +30,7 @@ import {
   buildBillingBlock,
   buildCodexWorkerHeaders,
   buildOAuthWorkerHeaders,
+  workerUserAgent,
   signBody,
 } from "./cch";
 import {
@@ -525,6 +526,11 @@ function buildAnthropicWorkerRequest(
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     "anthropic-version": "2023-06-01",
+    // Replay a user-agent on every worker request. Anthropic-compat providers
+    // (MiniMax) reject UA-less requests with a generic auth failure even when
+    // the key/host are correct — the conversation path works only because it
+    // forwards the client UA. oauthHeaders (billing sessions) may override this.
+    "user-agent": workerUserAgent(sessionID),
     ...authHeaders(cred),
     ...oauthHeaders,
   };

--- a/packages/gateway/src/worker-model.ts
+++ b/packages/gateway/src/worker-model.ts
@@ -590,9 +590,16 @@ export function getWorkerModel(session?: {
   const sessionProviderID = session?.providerID;
   const sessionModelID = session?.model;
 
-  // Effective provider: explicit config > session > anthropic default.
+  // Effective provider: explicit config > session. Do NOT silently default to
+  // "anthropic": fabricating an Anthropic worker for a session whose provider
+  // is non-Anthropic (or unknown) produces a doomed cross-provider call — the
+  // session's foreign key looked up under "anthropic" misses (→ no-auth, after
+  // #776's fail-closed guard) or, worse, an anthropic worker is built for a
+  // MiniMax/OpenRouter session. When neither config nor session names a
+  // provider, we have no safe target → skip background work (return undefined).
   const effectiveProvider =
-    cfg.model?.providerID ?? sessionProviderID ?? "anthropic";
+    cfg.model?.providerID ?? sessionProviderID ?? undefined;
+  if (!effectiveProvider) return undefined;
 
   // Effective session model: config > session snapshot > provider default.
   const effectiveModelID = cfg.model?.modelID ?? sessionModelID ?? undefined;

--- a/packages/gateway/test/cache-warmer.test.ts
+++ b/packages/gateway/test/cache-warmer.test.ts
@@ -7,6 +7,7 @@ import {
   blendHistograms,
   prepareAnthropicWarmupBody,
   buildAnthropicProfile,
+  resolveProfile,
   shouldWarm,
   checkCircuitBreaker,
   isCircuitBreakerTripped,
@@ -923,6 +924,86 @@ describe("shouldWarm", () => {
 // ---------------------------------------------------------------------------
 // Profile building
 // ---------------------------------------------------------------------------
+
+describe("resolveProfile — Anthropic first-party host gate (cross-provider 401 fix)", () => {
+  test("returns a profile for an Anthropic-first-party session", () => {
+    const profile = resolveProfile(
+      "claude-sonnet-4-20250514",
+      "anthropic",
+      "5m",
+      "https://api.anthropic.com",
+    );
+    expect(profile).not.toBeNull();
+    expect(profile?.upstreamUrl).toBe("https://api.anthropic.com/v1/messages");
+  });
+
+  test("WARMS a header-less Claude Code session (empty-string upstreamBase falls through to the model route)", () => {
+    // 🔴 Production input: Claude Code CLI/Desktop send no x-lore-upstream-url,
+    // so lastUpstream.url === "" (pipeline.ts). The gate must coalesce "" to the
+    // model route (api.anthropic.com) and STILL warm — otherwise warming is
+    // silently disabled for the flagship agent. (Guards the ?? vs || bug.)
+    const profile = resolveProfile(
+      "claude-sonnet-4-20250514",
+      "anthropic",
+      "5m",
+      "",
+    );
+    expect(profile).not.toBeNull();
+    expect(profile?.upstreamUrl).toBe("https://api.anthropic.com/v1/messages");
+  });
+
+  test("WARMS a header-less Claude Code session (undefined upstreamBase falls through to the model route)", () => {
+    const profile = resolveProfile(
+      "claude-sonnet-4-20250514",
+      "anthropic",
+      "5m",
+      undefined,
+    );
+    expect(profile).not.toBeNull();
+    expect(profile?.upstreamUrl).toBe("https://api.anthropic.com/v1/messages");
+  });
+
+  test("WARMS a proxied Anthropic session (providerID 'anthropic' even when host is not api.anthropic.com)", () => {
+    // LORE_UPSTREAM_ANTHROPIC / LiteLLM / Cloudflare AI Gateway: real Anthropic
+    // caching through a proxy host. providerID identifies it as Anthropic so
+    // warming is preserved despite the non-first-party host.
+    const profile = resolveProfile(
+      "claude-sonnet-4-20250514",
+      "anthropic",
+      "5m",
+      "https://my-litellm-proxy.example.com",
+      "anthropic",
+    );
+    expect(profile).not.toBeNull();
+  });
+
+  test("SKIPS a MiniMax (anthropic-compat) session — never warms a foreign host", () => {
+    // MiniMax reports protocol:"anthropic" but its host is api.minimax.io.
+    // Pre-fix the warmer fell back to api.anthropic.com and sent the MiniMax
+    // key there → 401 "invalid x-api-key". It must skip instead.
+    const profile = resolveProfile(
+      "MiniMax-M3",
+      "anthropic",
+      "5m",
+      "https://api.minimax.io/anthropic",
+      "minimax-coding-plan",
+    );
+    expect(profile).toBeNull();
+  });
+
+  test("SKIPS when the upstream host is unknown (no upstreamBase, unroutable model) — fails closed, never api.anthropic.com fallback", () => {
+    // No upstreamBase and a model with no route prefix → must NOT silently warm
+    // against api.anthropic.com with whatever credential the session holds.
+    const profile = resolveProfile("MiniMax-M3", "anthropic", "5m");
+    expect(profile).toBeNull();
+  });
+
+  test("SKIPS non-anthropic protocols", () => {
+    expect(
+      resolveProfile("gpt-5", "openai", "5m", "https://api.openai.com"),
+    ).toBeNull();
+  });
+});
 
 describe("buildAnthropicProfile", () => {
   test("5m TTL has correct parameters", () => {

--- a/packages/gateway/test/worker-cross-provider.test.ts
+++ b/packages/gateway/test/worker-cross-provider.test.ts
@@ -166,6 +166,34 @@ describe("worker cross-provider routing matrix (structural guard)", () => {
     }
   }
 
+  test("anthropic worker request carries a user-agent (MiniMax rejects UA-less requests with a 401)", async () => {
+    // A MiniMax session: worker routes to api.minimax.io with the MiniMax key.
+    // Without a user-agent, MiniMax's anthropic-compat endpoint rejects the
+    // request with a generic auth failure even though key+host are correct.
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "mm-worker-key" }),
+      { providerID: "minimax", modelID: "MiniMax-M2.7" },
+    );
+
+    await client.prompt("system", "user", {
+      sessionID: "sess-minimax-ua",
+      workerID: "lore-curator",
+      model: { providerID: "minimax", modelID: "MiniMax-M2.7" },
+      upstreamUrl: "https://api.minimax.io/anthropic",
+      upstreamProviderID: "minimax",
+      protocol: "anthropic",
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const opts = mockFetch.mock.calls[0][1] as {
+      headers: Record<string, string>;
+    };
+    const headerKeys = Object.keys(opts.headers).map((k) => k.toLowerCase());
+    expect(headerKeys).toContain("user-agent");
+    expect(opts.headers["user-agent"]).toBeTruthy();
+  });
+
   test("an unknown worker-model provider with no route ALWAYS fails closed (never falls back to a direct endpoint)", async () => {
     const client = createGatewayLLMClient(
       UPSTREAMS,

--- a/packages/gateway/test/worker-model.test.ts
+++ b/packages/gateway/test/worker-model.test.ts
@@ -790,6 +790,21 @@ describe("getWorkerModel", () => {
     });
     expect(result).toBeUndefined();
   });
+
+  test("no session provider (and no config model) returns undefined — never fabricates an anthropic worker", () => {
+    // Regression: previously effectiveProvider defaulted to "anthropic" when the
+    // session provider was absent, fabricating an Anthropic worker for a session
+    // whose real provider is non-Anthropic/unknown. That worker then looked up
+    // the session's foreign credential under "anthropic" → no-auth (or a doomed
+    // cross-provider 401). With no provider evidence, background work must SKIP.
+    const result = getWorkerModel({ model: "some-model" });
+    expect(result).toBeUndefined();
+  });
+
+  test("empty session object returns undefined — no provider to target", () => {
+    const result = getWorkerModel({});
+    expect(result).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
PR #776 fixed cross-provider **worker** routing/auth, but three background-call paths still 401 on **MiniMax / OpenRouter** sessions — they were never on #776's path. Found via production logs (`cache-warmer: upstream error 401 ... invalid x-api-key`, `lore-curator failed (auth-rejected)`, `lore-curator failed (no-auth)`).

## #1 cache-warmer → 401 (MiniMax) — right key, **wrong host**
`buildAnthropicProfile` fell back to `https://api.anthropic.com` when `resolveUpstreamRoute(model)` was null (no MiniMax prefix) and no `upstreamBase` was passed. `resolveProfile`'s only gate was `protocol !== "anthropic"` — but MiniMax's anthropic-compat endpoint **reports** `protocol:"anthropic"`, so it leaked through and sent the session's MiniMax `sk-cp-…` key to Anthropic → `401 invalid x-api-key`, every warmup.

**Fix:** gate warming on the Anthropic **first-party host**, not the wire protocol. `resolveProfile` resolves the host the warmup would hit (session upstream URL, now threaded from `idle.ts`) and returns null unless it's `api.anthropic.com`. Compat providers don't honor `cache_control` warming anyway.

## #2 curator/distill → auth-rejected (MiniMax) — right host+key, **no user-agent**
The worker reached `api.minimax.io/anthropic` with the correct `x-api-key`, but MiniMax rejected it (*"login fail: carry the API secret key in the 'X-Api-Key' field"*) — its generic auth failure for a request lacking a recognized `user-agent`. The conversation path works only because it forwards the client UA; the worker sent none.

**Fix:** attach a `user-agent` to every anthropic worker request via `workerUserAgent(sessionID)` (replays the sniffed session UA, falls back to a Claude Code-style UA) — for all sessions, not just OAuth.

## #3 curator/pattern-echo → no-auth (OpenRouter) — **fabricated anthropic worker**
`getWorkerModel` defaulted `effectiveProvider` to `"anthropic"` when the session provider was absent, fabricating an Anthropic worker for a non-Anthropic session → lookup of the foreign credential under `"anthropic"` missed → #776 fail-closed `no-auth`.

**Fix:** with no config model AND no session provider, `getWorkerModel` returns `undefined` (skip) instead of inventing an anthropic target.

## Invariants preserved
- 🔴 Never fall back to `api.anthropic.com` for a non-Anthropic key.
- #776's `resolveAuth` fail-closed guard untouched (`auth.ts` unchanged).

## Tests (all fail-on-revert verified)
- `cache-warmer.test.ts`: resolveProfile gate (Anthropic warms; MiniMax/unknown-host skip; non-anthropic protocol skip).
- `worker-cross-provider.test.ts`: anthropic worker request carries a user-agent.
- `worker-model.test.ts`: no-provider / empty-session → undefined.

Full suite: **3210 passed**, typecheck + lint clean.

🤖 Generated with [opencode](https://opencode.ai)