### PR TITLE
fix(gateway): re-anchor durable knowledge-delta on compression (stop tool-pair stripping)

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -2326,6 +2326,23 @@ export function upsertSessionPromptDelta(input: {
     .run(input.sessionID, input.projectID, input.selector, input.content);
 }
 
+/**
+ * Delete all persisted prompt-delta rows for a session.
+ *
+ * Used when the gradient compresses (a cache-busting layer change): the
+ * durable delta's `insertAt` is a frozen absolute index into the
+ * gradient-transformed message array, which is non-stationary — compression
+ * reshuffles what sits at each index, so a once-safe index can drift into a
+ * tool_use/tool_result pair. Rather than tracking/validating the frozen index,
+ * we delete the row on compression so the same turn recomputes the delta
+ * (position + content) fresh against the new array. No-op when no rows exist.
+ */
+export function deleteSessionPromptDelta(sessionID: string): void {
+  db()
+    .query("DELETE FROM session_prompt_deltas WHERE session_id = ?")
+    .run(sessionID);
+}
+
 export function listSessionPromptDeltas(
   sessionID: string,
 ): SessionPromptDelta[] {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -90,6 +90,7 @@ export {
   loadSessionTracking,
   appendSessionPromptDelta,
   upsertSessionPromptDelta,
+  deleteSessionPromptDelta,
   listSessionPromptDeltas,
   loadHeaderSessionIndex,
   loadParentChildMap,

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -58,6 +58,7 @@ import {
   saveSessionTracking,
   loadSessionTracking,
   upsertSessionPromptDelta,
+  deleteSessionPromptDelta,
   listSessionPromptDeltas,
   loadHeaderSessionIndex,
   isHostedMode,
@@ -692,30 +693,69 @@ function parseDeltaMessage(raw: string): GatewayMessage | null {
  * ("tool_use ids were found without tool_result blocks immediately after").
  *
  * Returns an insert index (clamped to [0, messages.length]) that never lands
- * between an assistant `tool_use` and the following user `tool_result`. When
- * the desired index would split a pair, it walks backward past the issuing
- * assistant so the pair stays adjacent (placing the delta before, rather than
- * inside, the tool turn).
+ * immediately after an assistant `tool_use`. Anthropic requires every
+ * `tool_use` to be followed immediately by its `tool_result`; a delta inserted
+ * right after the assistant breaks that adjacency and is rejected with a
+ * tool-pairing 400 (#747). The desired index is walked backward past the
+ * issuing assistant in two cases:
+ *
+ *  1. The boundary at `idx` sits between an assistant(tool_use) and the
+ *     following user(tool_result) — a completed pair (mid-history split).
+ *  2. The boundary at `idx` immediately follows an assistant(tool_use) whose
+ *     result is NOT present at `idx` — a PENDING/in-flight tool call (the agent
+ *     is mid-tool-execution, the tail ends with a dangling tool_use, or the
+ *     result lives elsewhere). Inserting here would orphan the tool_use.
+ *
+ * Both reduce to the same rule: never let `messages[idx-1]` be an
+ * assistant(tool_use) — walk before it.
  *
  * @internal Exported for tests.
  */
+/**
+ * Decide whether the durable knowledge-delta must be reset (deleted +
+ * recomputed) on THIS turn because the gradient compressed the conversation.
+ *
+ * The delta's persisted `insertAt` is a frozen absolute index into the
+ * gradient-transformed message array. That array is non-stationary: when the
+ * gradient compresses (raw-window eviction / layer escalation), the content at
+ * each absolute index shifts, so a once-tool-pair-safe index can drift into a
+ * tool_use/tool_result pair. A compressing turn ALSO busts the conversation
+ * prompt cache anyway, so this is the right moment to throw the stale delta
+ * away and recompute a fresh, tool-pair-safe, near-tail position — paying the
+ * (already-incurred) bust once instead of destructively stripping a real tool
+ * pair every subsequent turn.
+ *
+ * Layer-only predicate: a compressing turn is any turn at a compressed layer
+ * (>= 1) whose layer DIFFERS from the previous turn (entering, escalating, or
+ * de-escalating compression — all reshuffle the array). A stable layer
+ * (prev === cur) returns false here; steady-state-at-layer-1 raw-window slide
+ * is handled by the caller's additional raw-window-repin check. Layer 0
+ * (passthrough) never compresses.
+ *
+ * @internal Exported for tests.
+ */
+export function shouldResetDeltaOnCompression(
+  prevLayer: number,
+  curLayer: number,
+): boolean {
+  return curLayer >= 1 && curLayer !== prevLayer;
+}
+
 export function safeDeltaInsertIndex(
   messages: GatewayMessage[],
   desired: number,
 ): number {
   let idx = Math.max(0, Math.min(desired, messages.length));
-  // While the message at `idx` is a user message carrying a tool_result whose
-  // matching tool_use is on the immediately-preceding assistant, the boundary
-  // at `idx` is inside an atomic pair — move before the assistant.
-  while (idx > 0 && idx < messages.length) {
-    const here = messages[idx];
+  // Walk backward while the immediately-preceding message is an assistant
+  // carrying a tool_use. This covers both a completed pair (the tool_result is
+  // at idx) AND a pending tool call (no tool_result follows yet) — in either
+  // case the delta must go BEFORE the assistant, never after its tool_use.
+  while (idx > 0) {
     const prev = messages[idx - 1];
-    const splitsPair =
-      here?.role === "user" &&
+    const prevHasToolUse =
       prev?.role === "assistant" &&
-      here.content.some((b) => b.type === "tool_result") &&
       prev.content.some((b) => b.type === "tool_use");
-    if (!splitsPair) break;
+    if (!prevHasToolUse) break;
     idx -= 1;
   }
   return idx;
@@ -819,13 +859,23 @@ export function applySessionPromptDeltas(
     // on subsequent turns is intentional: #747 requires the delta to stay at a
     // byte-identical position to preserve the conversation prompt cache.
     //
-    // We deliberately do NOT re-run safeDeltaInsertIndex here — a layout-
-    // dependent adjustment at replay would move the delta across turns and bust
-    // the very cache prefix it exists to protect. In the rare case a later
-    // turn's layout makes this persisted index split a tool pair,
-    // removeOrphanedToolResults (run after this function on the wire array) is
-    // the hard guarantee that no orphaned tool_use/tool_result reaches the API.
-    const insertAt = Math.min(selector.insertAt, out.length);
+    // We re-run safeDeltaInsertIndex ONLY as a tool-pair guard, not a general
+    // re-placement: when the persisted index still points at a safe boundary
+    // (the common case) it returns the index unchanged → byte-identical replay,
+    // preserving the cache exactly as before. But the conversation grows and the
+    // raw-window/distilled-prefix boundary below the delta slides, so a once-safe
+    // absolute index can later land BETWEEN an assistant(tool_use) and its
+    // user(tool_result). Previously the splice went in anyway and
+    // removeOrphanedToolResults DESTRUCTIVELY stripped both blocks every turn —
+    // silently deleting a real tool call from history (and firing on every turn,
+    // not "rarely" as assumed). Nudging to the nearest safe boundary preserves
+    // the tool pair. The nudge is deterministic and layout-stable turn-over-turn
+    // (the messages below the delta are themselves stable until they change), so
+    // it does not introduce per-turn churn; at worst it shifts ONCE when the
+    // split first appears — strictly better than rewriting two historical
+    // messages every turn.
+    const clamped = Math.min(selector.insertAt, out.length);
+    const insertAt = safeDeltaInsertIndex(out, clamped);
     out.splice(insertAt, 0, message);
   }
   return out;
@@ -6016,12 +6066,61 @@ async function handleConversationTurn(
     }
   }
 
+  // Reset the durable delta on a cache-busting compression. The delta's
+  // persisted insertAt is a frozen absolute index into the gradient-transformed
+  // array; when the gradient compresses (layer change), that array reshuffles
+  // and the once-safe index can drift into a tool_use/tool_result pair. A
+  // compressing turn busts the prompt cache anyway, so we recompute the delta
+  // (position + content) THIS turn rather than replaying a stale index. This
+  // keeps the conversation coherent (the compressed request still carries an
+  // accurate, correctly-placed delta) and stops removeOrphanedToolResults from
+  // destructively stripping a real tool pair every subsequent turn.
+  const deltaCompressed = shouldResetDeltaOnCompression(
+    sessionState.lastDeltaLayer ?? 0,
+    result.layer,
+  );
+  if (deltaCompressed) {
+    if (pendingKnowledgeDelta) {
+      // New knowledge delta is being produced this turn anyway — drop the stale
+      // row so appendKnowledgePromptDelta computes a FRESH insertAt below
+      // (no persisted row to reuse) instead of re-freezing the drifted index.
+      deleteSessionPromptDelta(sessionID);
+    } else {
+      // No new knowledge this turn, but the array reshuffled: re-anchor the
+      // EXISTING delta (same content) to a fresh tool-pair-safe near-tail index
+      // so it doesn't replay at a drifted position. Delete + re-persist with a
+      // recomputed insertAt.
+      const existing = listSessionPromptDeltas(sessionID).find(
+        (d) => d.seq === 0,
+      );
+      if (existing) {
+        const reInsertAt = safeDeltaInsertIndex(
+          modifiedReq.messages,
+          Math.max(0, modifiedReq.messages.length - 1),
+        );
+        upsertSessionPromptDelta({
+          sessionID,
+          projectID: ensureProject(projectPath),
+          selector: JSON.stringify({
+            target: "messages",
+            insertAt: reInsertAt,
+          }),
+          content: existing.content,
+        });
+        log.info(
+          `prompt-delta: re-anchored durable delta for session ${sessionID.slice(0, 16)} after compression (layer ${sessionState.lastDeltaLayer ?? 0}→${result.layer}, insertAt=${reInsertAt})`,
+        );
+      }
+    }
+  }
+
   if (pendingKnowledgeDelta) {
     // Place the durable delta near the tail, but never between an
     // assistant(tool_use) and its user(tool_result) — inserting there orphans
     // the tool_use and triggers an Anthropic 400 (#747 regression). The index
-    // is computed once here, made tool-pair-safe, and persisted; replay reuses
-    // it verbatim to keep the delta byte-position-stable for the prompt cache.
+    // is computed tool-pair-safe and persisted; replay reuses it verbatim to
+    // keep the delta byte-position-stable for the prompt cache until the next
+    // compression resets it.
     const insertAt = safeDeltaInsertIndex(
       modifiedReq.messages,
       Math.max(0, modifiedReq.messages.length - 1),
@@ -6033,6 +6132,9 @@ async function handleConversationTurn(
       ...pendingKnowledgeDelta,
     });
   }
+  // Track the layer that produced the current delta placement so the next turn
+  // can detect a compression-driven reshuffle.
+  sessionState.lastDeltaLayer = result.layer;
   modifiedReq.messages = applySessionPromptDeltas(
     modifiedReq.messages,
     sessionID,

--- a/packages/gateway/src/translate/types.ts
+++ b/packages/gateway/src/translate/types.ts
@@ -443,6 +443,10 @@ export type SessionState = {
   /** Rolling window of recent turns' cold-cache status for auto-TTL upgrade.
    *  true = cold cache (full bust), false = cache hit. */
   coldCacheWindow?: boolean[];
+  /** Gradient layer used on the previous turn that emitted/placed the durable
+   *  knowledge-delta. Used to detect a cache-busting compression (layer change)
+   *  so the stale frozen delta index is reset + recomputed that turn. */
+  lastDeltaLayer?: number;
   /** Resolved conversation TTL for this session ("5m" | "1h"). Updated by
    *  the auto-upgrade logic each turn. */
   resolvedConversationTTL?: "5m" | "1h";

--- a/packages/gateway/test/delta-compress-reanchor.test.ts
+++ b/packages/gateway/test/delta-compress-reanchor.test.ts
@@ -1,0 +1,390 @@
+/**
+ * TDD spec for the delta-compress re-anchor fix (tool-pair-safe knowledge
+ * delta placement + layer-transition-driven delta reset).
+ *
+ * Background: a single sentinel seq-0 knowledge-delta row is persisted per
+ * session in `session_prompt_deltas` (via core's upsert/append/list helpers).
+ * Its stored `insertAt` is FROZEN to keep the cached message prefix byte-stable
+ * across STABLE turns. But on a COMPRESSING turn the message array reshuffles
+ * (raw-window slides, layers escalate), so a frozen insertAt can land between a
+ * tool_use and its tool_result — orphaning the pair on the wire. The fix:
+ *
+ *   1. `safeDeltaInsertIndex` must NEVER return an index immediately after an
+ *      assistant containing a tool_use (it walks back before the assistant).
+ *   2. On a compressing/layer-changing turn the caller deletes the stored
+ *      delta (`deleteSessionPromptDelta`) and recomputes a fresh index; on a
+ *      stable turn the stored index is left frozen.
+ *   3. `shouldResetDeltaOnCompression(prevLayer, curLayer)` is the pure
+ *      predicate gating that delete/recompute decision.
+ *
+ * Some of these APIs are not implemented yet — tests that exercise an
+ * unimplemented symbol fail cleanly (typeof check) rather than crashing
+ * collection.
+ *
+ * EXPECTED API signatures (implementation pending):
+ *   - core: deleteSessionPromptDelta(sessionID: string): void
+ *   - pipeline: shouldResetDeltaOnCompression(prevLayer: number, curLayer: number): boolean
+ *   - pipeline: safeDeltaInsertIndex(messages, desired): number   (already exists)
+ *   - core: appendSessionPromptDelta({sessionID, projectID, selector, content}): void
+ *   - core: listSessionPromptDeltas(sessionID): Array<{seq, selector, content, projectID}>
+ *   - core: ensureProject(path): string
+ */
+import { describe, test, expect } from "vitest";
+import {
+  safeDeltaInsertIndex,
+  applySessionPromptDeltas,
+  removeOrphanedToolResults,
+  shouldResetDeltaOnCompression,
+} from "../src/pipeline";
+import {
+  appendSessionPromptDelta,
+  deleteSessionPromptDelta,
+  listSessionPromptDeltas,
+  ensureProject,
+} from "@loreai/core";
+import type {
+  GatewayContentBlock,
+  GatewayMessage,
+} from "../src/translate/types";
+
+function user(...content: GatewayContentBlock[]): GatewayMessage {
+  return { role: "user", content };
+}
+function assistant(...content: GatewayContentBlock[]): GatewayMessage {
+  return { role: "assistant", content };
+}
+function toolUse(id: string): GatewayContentBlock {
+  return { type: "tool_use", id, name: "read", input: {} };
+}
+function toolResult(id: string): GatewayContentBlock {
+  return {
+    type: "tool_result",
+    toolUseId: id,
+    content: [{ type: "text", text: "ok" }],
+  };
+}
+function text(t: string): GatewayContentBlock {
+  return { type: "text", text: t };
+}
+
+/**
+ * Asserts every tool_use has an adjacent matching tool_result on the next
+ * message, and every tool_result has an adjacent matching tool_use on the
+ * preceding message — the exact invariant Anthropic enforces.
+ */
+function assertNoOrphanedTools(messages: GatewayMessage[]): void {
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    if (msg.role === "assistant") {
+      const useIds = msg.content
+        .filter((b) => b.type === "tool_use")
+        .map((b) => (b as { id: string }).id);
+      if (useIds.length === 0) continue;
+      const next = messages[i + 1];
+      const resultIds = new Set(
+        next?.role === "user"
+          ? next.content
+              .filter((b) => b.type === "tool_result")
+              .map((b) => (b as { toolUseId: string }).toolUseId)
+          : [],
+      );
+      for (const id of useIds) expect(resultIds.has(id)).toBe(true);
+    } else {
+      const resultIds = msg.content
+        .filter((b) => b.type === "tool_result")
+        .map((b) => (b as { toolUseId: string }).toolUseId);
+      if (resultIds.length === 0) continue;
+      const prev = messages[i - 1];
+      const useIds = new Set(
+        prev?.role === "assistant"
+          ? prev.content
+              .filter((b) => b.type === "tool_use")
+              .map((b) => (b as { id: string }).id)
+          : [],
+      );
+      for (const id of resultIds) expect(useIds.has(id)).toBe(true);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 2. shouldResetDeltaOnCompression — pure layer-transition predicate
+// ---------------------------------------------------------------------------
+describe("shouldResetDeltaOnCompression — layer-transition predicate", () => {
+  // EXPECTED API — implementation pending
+  test("is exported as a function", () => {
+    expect(typeof shouldResetDeltaOnCompression).toBe("function");
+  });
+
+  test("FALSE at passthrough (0,0): no compression this turn", () => {
+    expect(typeof shouldResetDeltaOnCompression).toBe("function");
+    expect(shouldResetDeltaOnCompression(0, 0)).toBe(false);
+  });
+
+  test("TRUE entering compression (0,1)", () => {
+    expect(typeof shouldResetDeltaOnCompression).toBe("function");
+    expect(shouldResetDeltaOnCompression(0, 1)).toBe(true);
+  });
+
+  test("FALSE stable within layer 1 (1,1): caller handles raw-window repin separately", () => {
+    expect(typeof shouldResetDeltaOnCompression).toBe("function");
+    expect(shouldResetDeltaOnCompression(1, 1)).toBe(false);
+  });
+
+  test("TRUE escalated (1,2)", () => {
+    expect(typeof shouldResetDeltaOnCompression).toBe("function");
+    expect(shouldResetDeltaOnCompression(1, 2)).toBe(true);
+  });
+
+  test("TRUE de-escalated but layer changed (2,1): array reshuffled", () => {
+    expect(typeof shouldResetDeltaOnCompression).toBe("function");
+    expect(shouldResetDeltaOnCompression(2, 1)).toBe(true);
+  });
+
+  test("FALSE dropped back to passthrough (1,0): no compression this turn", () => {
+    expect(typeof shouldResetDeltaOnCompression).toBe("function");
+    expect(shouldResetDeltaOnCompression(1, 0)).toBe(false);
+  });
+
+  test("TRUE layer-4 refresh from passthrough (0,4)", () => {
+    expect(typeof shouldResetDeltaOnCompression).toBe("function");
+    expect(shouldResetDeltaOnCompression(0, 4)).toBe(true);
+  });
+
+  test("TRUE layer-4 refresh from layer 3 (3,4)", () => {
+    expect(typeof shouldResetDeltaOnCompression).toBe("function");
+    expect(shouldResetDeltaOnCompression(3, 4)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. safeDeltaInsertIndex — never lands immediately after an assistant tool_use
+// ---------------------------------------------------------------------------
+describe("safeDeltaInsertIndex — never splits a tool_use/tool_result pair", () => {
+  test("(a) completed pair: desired=2 returns <=1 (before the assistant)", () => {
+    const messages = [
+      user(text("hi")),
+      assistant(toolUse("X")),
+      user(toolResult("X")),
+    ];
+    const idx = safeDeltaInsertIndex(messages, 2);
+    // index 2 is immediately after assistant(tool_use) => would split the pair.
+    expect(idx).toBeLessThanOrEqual(1);
+    expect(idx).not.toBe(2);
+    const out = messages.slice();
+    out.splice(idx, 0, user(text("delta")));
+    assertNoOrphanedTools(out);
+  });
+
+  test("(b) PENDING tool call: tail desired=length returns 1 (before the assistant), NOT 2", () => {
+    // No tool_result yet — assistant(tool_use) is the LAST message. The delta
+    // must NOT split the pending tool_use from its (future) tool_result, so it
+    // must land BEFORE the assistant. (The pair is inherently pending here, so
+    // assertNoOrphanedTools does not apply; the index is the discriminator.)
+    const messages = [user(text("hi")), assistant(toolUse("X"))];
+    const idx = safeDeltaInsertIndex(messages, messages.length); // desired = 2
+    expect(idx).toBe(1);
+    expect(idx).not.toBe(2);
+    // The inserted delta must sit BEFORE the assistant(tool_use), never after.
+    const out = messages.slice();
+    out.splice(idx, 0, user(text("delta")));
+    const deltaIdx = out.findIndex((m) =>
+      m.content.some((b) => b.type === "text" && b.text === "delta"),
+    );
+    const useIdx = out.findIndex((m) =>
+      m.content.some((b) => b.type === "tool_use"),
+    );
+    expect(deltaIdx).toBeLessThan(useIdx);
+  });
+
+  test("(c) parallel tool_use (X and Y): desired right after walks back before it", () => {
+    const messages = [
+      user(text("hi")),
+      assistant(toolUse("X"), toolUse("Y")),
+      user(toolResult("X"), toolResult("Y")),
+    ];
+    const idx = safeDeltaInsertIndex(messages, 2);
+    expect(idx).toBeLessThanOrEqual(1);
+    expect(idx).not.toBe(2);
+    const out = messages.slice();
+    out.splice(idx, 0, user(text("delta")));
+    assertNoOrphanedTools(out);
+  });
+
+  test("(d) safe: text-only assistant, desired=2 returns 2 unchanged", () => {
+    const messages = [
+      user(text("hi")),
+      assistant(text("hi back")),
+      user(text("more")),
+    ];
+    const idx = safeDeltaInsertIndex(messages, 2);
+    // prev is a text-only assistant (no tool_use) => safe, leave at 2.
+    expect(idx).toBe(2);
+    const out = messages.slice();
+    out.splice(idx, 0, user(text("delta")));
+    assertNoOrphanedTools(out);
+  });
+
+  test("(e) consecutive tool turns: desired=3 (pending B) walks back to 2, stops (prev is tool_result)", () => {
+    const messages = [
+      assistant(toolUse("A")),
+      user(toolResult("A")),
+      assistant(toolUse("B")),
+    ];
+    const idx = safeDeltaInsertIndex(messages, 3); // tail, B is pending
+    // Walk back before assistant(toolUse B) => index 2. Index 2's prev is
+    // user(toolResult A), which is NOT a tool_use, so it stops at 2 — does NOT
+    // walk all the way back. (B is inherently pending, so the completed A pair
+    // must remain intact; assert the delta sits between the A pair and B.)
+    expect(idx).toBe(2);
+    const out = messages.slice();
+    out.splice(idx, 0, user(text("delta")));
+    // The completed A pair (indices 0,1) is untouched and adjacent.
+    expect(out[0]?.content.some((b) => b.type === "tool_use")).toBe(true);
+    expect(out[1]?.content.some((b) => b.type === "tool_result")).toBe(true);
+    // The delta lands AT index 2 (between the A pair and the pending B).
+    expect(
+      out[2]?.content.some((b) => b.type === "text" && b.text === "delta"),
+    ).toBe(true);
+    // And BEFORE the pending assistant(toolUse B).
+    const deltaIdx = 2;
+    const bUseIdx = out.findIndex((m, i) =>
+      i > 2 ? m.content.some((b) => b.type === "tool_use") : false,
+    );
+    expect(deltaIdx).toBeLessThan(bUseIdx);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Delete-and-recompute keeps the tool pair intact (production scenario)
+// ---------------------------------------------------------------------------
+describe("persisted delta + backstop keeps the tool pair intact", () => {
+  test("stale insertAt splitting a completed pair is placed safely; pair survives", () => {
+    const sessionID = `delta-reanchor-${Date.now()}-${Math.random()}`;
+    const projectID = ensureProject(
+      `/tmp/lore-delta-reanchor-${Date.now()}-${Math.random()}`,
+    );
+
+    // Persist a delta whose stored insertAt (2) lands between tool_use and
+    // tool_result for THIS turn's layout.
+    appendSessionPromptDelta({
+      sessionID,
+      projectID,
+      selector: JSON.stringify({ target: "messages", insertAt: 2 }),
+      content: JSON.stringify({
+        role: "user",
+        content: [{ type: "text", text: "Lore knowledge update" }],
+      }),
+    });
+
+    const messages: GatewayMessage[] = [
+      user(text("hi")),
+      assistant(toolUse("X")),
+      user(toolResult("X")),
+    ];
+
+    const out = applySessionPromptDeltas(messages, sessionID);
+    removeOrphanedToolResults(out);
+
+    // No orphaned tool blocks on the wire.
+    assertNoOrphanedTools(out);
+
+    // The tool_use AND tool_result BOTH still exist (not destructively stripped).
+    expect(out.some((m) => m.content.some((b) => b.type === "tool_use"))).toBe(
+      true,
+    );
+    expect(
+      out.some((m) => m.content.some((b) => b.type === "tool_result")),
+    ).toBe(true);
+
+    // The delta landed BEFORE the assistant(tool_use), not between the pair.
+    const deltaIdx = out.findIndex((m) =>
+      m.content.some(
+        (b) => b.type === "text" && b.text === "Lore knowledge update",
+      ),
+    );
+    const toolUseIdx = out.findIndex((m) =>
+      m.content.some((b) => b.type === "tool_use"),
+    );
+    expect(deltaIdx).toBeGreaterThanOrEqual(0);
+    expect(deltaIdx).toBeLessThan(toolUseIdx);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Stable turn keeps insertAt frozen; compressing turn re-anchors
+// ---------------------------------------------------------------------------
+describe("layer-transition gates the delete/recompute of the persisted delta", () => {
+  test("STABLE turn (1,1): predicate false => row left frozen at insertAt=5", () => {
+    expect(typeof shouldResetDeltaOnCompression).toBe("function");
+    expect(typeof listSessionPromptDeltas).toBe("function");
+
+    const sessionID = `delta-stable-${Date.now()}-${Math.random()}`;
+    const projectID = ensureProject(
+      `/tmp/lore-delta-stable-${Date.now()}-${Math.random()}`,
+    );
+
+    appendSessionPromptDelta({
+      sessionID,
+      projectID,
+      selector: JSON.stringify({ target: "messages", insertAt: 5 }),
+      content: JSON.stringify({
+        role: "user",
+        content: [{ type: "text", text: "Lore knowledge update" }],
+      }),
+    });
+
+    // Stable turn within layer 1 => caller must NOT delete.
+    const wouldReset = shouldResetDeltaOnCompression(1, 1);
+    expect(wouldReset).toBe(false);
+    if (wouldReset) deleteSessionPromptDelta(sessionID);
+
+    const rows = listSessionPromptDeltas(sessionID);
+    expect(rows.length).toBe(1);
+    expect(JSON.parse(rows[0].selector)).toEqual({
+      target: "messages",
+      insertAt: 5,
+    });
+  });
+
+  test("COMPRESSING turn (1,2): predicate true => delete clears the row", () => {
+    expect(typeof shouldResetDeltaOnCompression).toBe("function");
+    expect(typeof deleteSessionPromptDelta).toBe("function");
+    expect(typeof listSessionPromptDeltas).toBe("function");
+
+    const sessionID = `delta-compress-${Date.now()}-${Math.random()}`;
+    const projectID = ensureProject(
+      `/tmp/lore-delta-compress-${Date.now()}-${Math.random()}`,
+    );
+
+    appendSessionPromptDelta({
+      sessionID,
+      projectID,
+      selector: JSON.stringify({ target: "messages", insertAt: 5 }),
+      content: JSON.stringify({
+        role: "user",
+        content: [{ type: "text", text: "Lore knowledge update" }],
+      }),
+    });
+    expect(listSessionPromptDeltas(sessionID).length).toBe(1);
+
+    // Compressing turn (escalation 1 -> 2) => caller deletes & recomputes.
+    const wouldReset = shouldResetDeltaOnCompression(1, 2);
+    expect(wouldReset).toBe(true);
+    if (wouldReset) deleteSessionPromptDelta(sessionID);
+
+    // Precondition for recompute: the row is gone, so the next append computes
+    // a fresh index (recompute is the pipeline's job, out of unit scope).
+    expect(listSessionPromptDeltas(sessionID).length).toBe(0);
+  });
+
+  test("deleteSessionPromptDelta on a session with no rows is a no-op", () => {
+    expect(typeof deleteSessionPromptDelta).toBe("function");
+    expect(typeof listSessionPromptDeltas).toBe("function");
+
+    const sessionID = `delta-empty-${Date.now()}-${Math.random()}`;
+    expect(listSessionPromptDeltas(sessionID).length).toBe(0);
+    expect(() => deleteSessionPromptDelta(sessionID)).not.toThrow();
+    expect(listSessionPromptDeltas(sessionID).length).toBe(0);
+  });
+});

--- a/packages/gateway/test/prompt-delta-tools.test.ts
+++ b/packages/gateway/test/prompt-delta-tools.test.ts
@@ -108,18 +108,21 @@ describe("safeDeltaInsertIndex — never splits a tool_use/tool_result pair", ()
 });
 
 describe("persisted delta + backstop never orphans a tool pair on the wire", () => {
-  // applySessionPromptDeltas replays a persisted index VERBATIM (byte-position
-  // stable for the prompt cache — #747). If a later turn's layout makes that
-  // index land between a tool_use/tool_result pair, the production pipeline's
-  // removeOrphanedToolResults backstop (run right after) is the hard guarantee
-  // that no orphan reaches the API. This test mirrors that exact sequence.
-  test("stale persisted index splitting a pair is repaired by the backstop", () => {
+  // applySessionPromptDeltas replays a persisted index, nudging it to the
+  // nearest tool-pair-safe boundary (#747 byte-position stability is preserved
+  // for safe indices; only an index that WOULD split a pair is moved). If a
+  // later turn's layout makes the stored index land between a
+  // tool_use/tool_result pair, the delta is placed BEFORE the assistant so the
+  // pair stays intact — instead of relying on removeOrphanedToolResults to
+  // destructively strip the (real) tool call every turn.
+  test("stale persisted index splitting a pair is nudged so the tool pair survives", () => {
     const sessionID = `delta-tools-${Date.now()}`;
     const projectID = ensureProject(`/tmp/lore-delta-tools-${Date.now()}`);
 
     // Persist a delta whose stored insertAt (2) lands between the tool_use and
     // its tool_result for THIS turn's layout (a layout that differs from the
-    // delta's creation turn — exactly the cross-turn drift case).
+    // delta's creation turn — exactly the cross-turn drift case seen in prod
+    // where a frozen insertAt became mid-pair as the conversation grew).
     appendSessionPromptDelta({
       sessionID,
       projectID,
@@ -136,12 +139,32 @@ describe("persisted delta + backstop never orphans a tool pair on the wire", () 
       user(toolResult("X")),
     ];
 
-    // Production sequence: apply deltas (verbatim index), then the backstop.
+    // Production sequence: apply deltas (now tool-pair-safe), then the backstop.
     const out = applySessionPromptDeltas(messages, sessionID);
+    const beforeBackstop = JSON.stringify(out);
     removeOrphanedToolResults(out);
 
-    // The wire array must be orphan-free regardless of where the delta landed.
+    // The wire array must be orphan-free...
     assertNoOrphanedTools(out);
+    // ...AND the tool pair must SURVIVE (not be stripped): the backstop is a
+    // no-op because applySessionPromptDeltas already placed the delta safely.
+    expect(JSON.stringify(out)).toBe(beforeBackstop);
+    expect(out.some((m) => m.content.some((b) => b.type === "tool_use"))).toBe(
+      true,
+    );
+    expect(
+      out.some((m) => m.content.some((b) => b.type === "tool_result")),
+    ).toBe(true);
+    // The delta landed BEFORE the assistant(tool_use), not between the pair.
+    const deltaIdx = out.findIndex((m) =>
+      m.content.some(
+        (b) => b.type === "text" && b.text === "Lore knowledge update",
+      ),
+    );
+    const toolUseIdx = out.findIndex((m) =>
+      m.content.some((b) => b.type === "tool_use"),
+    );
+    expect(deltaIdx).toBeLessThan(toolUseIdx);
   });
 
   test("replay is byte-position stable: a non-splitting persisted index is not moved", () => {


### PR DESCRIPTION
## Problem
Production logs showed `removed orphaned tool_use/tool_result block(s) from message 497/499` firing **every turn** for ~16 min, correlated with `prompt-delta: upserted knowledge update ... insertAt=498`. A real tool call was being **silently deleted from history every turn** (plus noisy WARNs) — though it did NOT bust the cache (the strip was byte-stable turn-over-turn).

**Root cause:** the durable knowledge-delta's `insertAt` is a frozen **absolute** index into the gradient-transformed message array, which is **non-stationary** — as the conversation grows and the gradient compresses (raw-window eviction / layer changes), the content at each absolute index shifts. An index that was tool-pair-safe when frozen (then the tail, ~msg 499) drifts deep into history (msg 498 of 1777) and lands **between** an `assistant(tool_use)` and its `user(tool_result)`. The old replay spliced anyway and relied on `removeOrphanedToolResults` to **destructively strip** the pair every turn — its "should essentially never fire" assumption was violated.

## Fix
Tie the delta's lifetime to the event that invalidates everything else — **compression**. When the gradient compresses (a cache-busting layer change), the cache is busting anyway, so recompute the delta (position **and** content) **that same turn** instead of replaying a stale frozen index:

- `deleteSessionPromptDelta(sessionID)` (core) — clears the row.
- `shouldResetDeltaOnCompression(prevLayer, curLayer)` — pure predicate (compressed layer `>=1` whose layer differs from the previous turn).
- Pipeline tracks `lastDeltaLayer`; on a compressing turn it deletes the stale row (recompute fresh if a delta is pending) or re-anchors the existing content to a fresh tool-pair-safe near-tail index. Recompute happens **on** the compressing turn so the request stays coherent. Stable turns keep the index frozen → cache stays warm.

**Defense-in-depth:**
- `safeDeltaInsertIndex` now walks back past a **pending/in-flight** `tool_use` (no following result), not just completed pairs.
- `applySessionPromptDeltas` re-validates the persisted index on replay (no-op for safe indices → byte-stable; nudges a drifted index instead of destructive stripping).

## Tests
- `delta-compress-reanchor.test.ts` (**NEW** — written TDD by an independent agent against the spec): predicate table, `safeDeltaInsertIndex` pending/completed/parallel/safe/consecutive cases, delete + no-op, production tool-pair-survival.
- `prompt-delta-tools.test.ts`: existing "splitting a pair" test strengthened to assert the pair **survives**. Verified fail-on-revert.

## Verification
- `pnpm test` — **3231 passed**, 6 skipped, 0 failed
- `pnpm run typecheck` clean; `pnpm run lint` exit 0

## Follow-up (separate)
The cache-analytics early-divergence logs are mostly normal tail-growth; there's a distinct cache-warmer early-prefix divergence (`messages[2]`/`system[0]` busts, ~3×/day) to chase separately.

🤖 Generated with [opencode](https://opencode.ai)