### PR TITLE
fix(core): gate unsustainable warning to genuinely over-cap sessions

### DIFF
--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -1983,6 +1983,10 @@ export type TransformResult = {
    *  should inject a warning message advising the user to compact or start a
    *  new conversation. */
   unsustainable?: boolean;
+  /** Number of consecutive cache busts detected for this session at the time
+   *  of this transform. Surfaced so the pipeline can report the actual count in
+   *  the unsustainable-conversation warning instead of a hardcoded figure. */
+  consecutiveBusts?: number;
 };
 
 // Per-session urgent distillation tracking.
@@ -2218,9 +2222,14 @@ function transformInner(input: {
       distilledBudget,
       rawBudget,
       refreshLtm: false,
-      unsustainable: sid
-        ? getSessionState(sid).consecutiveBusts >= SUSTAINED_BUST_THRESHOLD
-        : false,
+      // Layer-0 passthrough means the conversation fits the layer-0 cap with
+      // headroom — it is sustainable by definition. Never surface the
+      // unsustainable warning here even under a sustained bust count: at this
+      // layer busts come from structural causes (e.g. a prompt-delta whose
+      // position drifted after a post-idle recompression), not from genuine
+      // context growth. Gating on the cap-fit prevents the false-positive
+      // warning observed on tier-0 sessions.
+      unsustainable: false,
     };
   }
 
@@ -2278,6 +2287,7 @@ function transformInner(input: {
         rawBudget,
         refreshLtm: false,
         unsustainable: busts >= SUSTAINED_BUST_THRESHOLD,
+        consecutiveBusts: busts,
       };
     }
   }
@@ -2398,6 +2408,7 @@ function transformInner(input: {
         unsustainable: sid
           ? getSessionState(sid).consecutiveBusts >= SUSTAINED_BUST_THRESHOLD
           : false,
+        consecutiveBusts: sid ? getSessionState(sid).consecutiveBusts : 0,
       };
     }
   }
@@ -2473,9 +2484,8 @@ function transformInner(input: {
   const nuclearRaw = [...olderMessages, ...currentTurn];
   const nuclearRawTokens = olderTokens + currentTurnTokens;
 
-  const unsustainable = sid
-    ? getSessionState(sid).consecutiveBusts >= SUSTAINED_BUST_THRESHOLD
-    : false;
+  const busts = sid ? getSessionState(sid).consecutiveBusts : 0;
+  const unsustainable = busts >= SUSTAINED_BUST_THRESHOLD;
 
   return {
     messages: [...nuclearPrefix, ...nuclearRaw],
@@ -2488,6 +2498,7 @@ function transformInner(input: {
     rawBudget,
     refreshLtm: true,
     unsustainable,
+    consecutiveBusts: busts,
   };
 }
 

--- a/packages/core/test/gradient.test.ts
+++ b/packages/core/test/gradient.test.ts
@@ -3658,6 +3658,52 @@ describe("tier-based context management", () => {
       });
       expect(result.layer).toBe(0);
     });
+
+    test("over-cap session that bypasses compression STILL reports unsustainable", () => {
+      // The tier-gate bypass returns at layer 0 but for a genuinely over-cap
+      // conversation (it merely declined to compress because the bust cost
+      // wasn't justified). That path MUST keep surfacing the warning — it is a
+      // real exhaustion signal, distinct from the cap-fitting passthrough which
+      // hardcodes unsustainable:false. This locks the intentional distinction
+      // so a future refactor can't silently collapse the two layer-0 returns.
+      const msgs = Array.from({ length: 8 }, (_, i) =>
+        makeMsg(
+          `bypass-${i}`,
+          i % 2 === 0 ? "user" : "assistant",
+          "z".repeat(200),
+          SESSION,
+        ),
+      );
+
+      // Large grown input, over the 200K layer-0 cap (see beforeEach).
+      calibrate(635_000, SESSION, msgs.length);
+
+      // No pricing data → shouldCompress() conservatively returns false, so the
+      // tier gate bypasses compression and returns at layer 0 while over-cap.
+      setCachePricing(0, 0);
+
+      // Sustained-bust regime.
+      for (let i = 0; i < 4; i++) {
+        recordCacheUsage(440_000, 34_813, 2, SESSION);
+      }
+      expect((inspectSessionState(SESSION)?.consecutiveBusts ?? 0) >= 2).toBe(
+        true,
+      );
+
+      const result = transform({
+        messages: msgs,
+        projectPath: PROJECT,
+        sessionID: SESSION,
+      });
+
+      // Bypassed compression → layer 0, but genuinely over the cap (tier >= 1)…
+      expect(result.layer).toBe(0);
+      expect(getTier(result.totalTokens)).toBeGreaterThanOrEqual(1);
+      // …so the warning MUST still fire (unlike the cap-fitting passthrough).
+      expect(result.unsustainable).toBe(true);
+      // Restore pricing for sibling tests.
+      setCachePricing(6.25 / 1_000_000, 0.5 / 1_000_000);
+    });
   });
 
   describe("recordCacheUsage — consecutive bust tracking", () => {
@@ -3701,6 +3747,53 @@ describe("tier-based context management", () => {
       // Zero usage — no change
       recordCacheUsage(0, 0, 0, SID);
       expect(inspectSessionState(SID)?.consecutiveBusts).toBe(1);
+    });
+  });
+
+  describe("unsustainable gating — only fires when genuinely over the layer-0 cap", () => {
+    // Regression for false "unsustainable conversation" warnings on a small
+    // (tier-0) session that fits layer 0 with headroom. The bug surfaced when a
+    // sub-cap session accumulated consecutive cache busts from a structural
+    // cause (stale prompt-delta position post-idle) — consecutiveBusts climbed
+    // unbounded and the warning fired every turn even though the conversation
+    // was trivially sustainable. unsustainable must be gated on real context
+    // exhaustion (tier >= 1 / over the layer-0 cap), not on the bust count alone.
+    const SID = "unsustainable-gate-sess";
+
+    beforeEach(() => {
+      resetCalibration(SID);
+      setModelLimits({ context: 10_000, output: 2_000 });
+      calibrate(0);
+    });
+
+    afterAll(() => {
+      setModelLimits({ context: 10_000, output: 2_000 });
+      calibrate(0);
+    });
+
+    test("tier-0 layer-0 passthrough never reports unsustainable, even after sustained busts", () => {
+      const messages = [
+        makeMsg("u-1", "user", "Hello", SID),
+        makeMsg("u-2", "assistant", "Hi", SID),
+      ];
+
+      // Force a sustained-bust regime (>= SUSTAINED_BUST_THRESHOLD = 2).
+      recordCacheUsage(100_000, 0, 3, SID);
+      recordCacheUsage(100_000, 0, 3, SID);
+      recordCacheUsage(100_000, 0, 3, SID);
+      expect((inspectSessionState(SID)?.consecutiveBusts ?? 0) >= 2).toBe(true);
+
+      const result = transform({
+        messages,
+        projectPath: PROJECT,
+        sessionID: SID,
+      });
+
+      // Small conversation: layer 0, tier 0 — genuinely sustainable.
+      expect(result.layer).toBe(0);
+      expect(getTier(result.totalTokens)).toBe(0);
+      // The signal must NOT fire for a sub-cap conversation.
+      expect(result.unsustainable).toBe(false);
     });
   });
 

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -295,10 +295,21 @@ let initialized = false;
 // Injected into the response (assistant message) so the user can see it.
 // Stripped from incoming requests on subsequent turns to preserve cache prefix.
 const CONTEXT_WARNING_MARKER = "[lore:context-warning]";
-const CONTEXT_WARNING_TEXT =
-  `${CONTEXT_WARNING_MARKER} This conversation is growing unsustainably \u2014 ` +
-  `it has exceeded the context limit 5+ times in a row and compression cannot keep up. ` +
-  `Consider running /compact or starting a new conversation.\n\n---\n\n`;
+
+/**
+ * Build the unsustainable-conversation warning, reporting the ACTUAL number of
+ * consecutive cache busts rather than a hardcoded figure. `count` falls back to
+ * generic wording when unknown/zero.
+ */
+function contextWarningText(count?: number): string {
+  const times =
+    count && count > 0 ? `${count} times in a row` : "several times in a row";
+  return (
+    `${CONTEXT_WARNING_MARKER} This conversation is growing unsustainably \u2014 ` +
+    `it has exceeded the context limit ${times} and compression cannot keep up. ` +
+    `Consider running /compact or starting a new conversation.\n\n---\n\n`
+  );
+}
 
 /**
  * Build the worker-degradation warning text (or null if the session's
@@ -322,7 +333,7 @@ function buildWorkerDegradationWarning(sessionID: string): string | null {
  */
 function injectContextWarning(
   resp: GatewayResponse,
-  text: string = CONTEXT_WARNING_TEXT,
+  text: string = contextWarningText(),
 ): GatewayResponse {
   // Insert after thinking blocks to preserve the expected block ordering
   // (thinking first, then text). Clients may inspect the first block's type
@@ -5965,9 +5976,10 @@ async function handleConversationTurn(
   //  2. No modification to user messages → no cache prefix divergence
   //  3. Stripped on the next turn to restore API-original content for cache
   const unsustainable = result.unsustainable;
+  const unsustainableBusts = result.consecutiveBusts;
   if (unsustainable) {
     log.warn(
-      `session ${sessionID}: unsustainable conversation detected (sustained consecutive cache busts). ` +
+      `session ${sessionID}: unsustainable conversation detected (${unsustainableBusts ?? "several"} consecutive cache busts). ` +
         `Warning will be prepended to response.`,
     );
   }
@@ -5988,7 +6000,7 @@ async function handleConversationTurn(
   }
   // A single combined flag/text drives all injection sites below.
   const warningText: string | undefined = unsustainable
-    ? CONTEXT_WARNING_TEXT
+    ? contextWarningText(unsustainableBusts)
     : (workerWarningText ?? undefined);
   const shouldInjectWarning = !!warningText;
 

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -294,14 +294,16 @@ let initialized = false;
 // --- Context warning marker for unsustainable conversations ---
 // Injected into the response (assistant message) so the user can see it.
 // Stripped from incoming requests on subsequent turns to preserve cache prefix.
-const CONTEXT_WARNING_MARKER = "[lore:context-warning]";
+export const CONTEXT_WARNING_MARKER = "[lore:context-warning]";
 
 /**
  * Build the unsustainable-conversation warning, reporting the ACTUAL number of
  * consecutive cache busts rather than a hardcoded figure. `count` falls back to
  * generic wording when unknown/zero.
+ *
+ * @internal Exported for tests.
  */
-function contextWarningText(count?: number): string {
+export function contextWarningText(count?: number): string {
   const times =
     count && count > 0 ? `${count} times in a row` : "several times in a row";
   return (
@@ -361,8 +363,10 @@ function injectContextWarning(
  * Only checks the first non-thinking content block of each assistant message —
  * that's where injectContextWarning() inserts it. This avoids false positives
  * if the model happens to echo the marker in its own output.
+ *
+ * @internal Exported for tests.
  */
-function stripContextWarnings(messages: GatewayMessage[]): void {
+export function stripContextWarnings(messages: GatewayMessage[]): void {
   for (const msg of messages) {
     if (msg.role !== "assistant") continue;
     // Find the first non-thinking block (mirrors injectContextWarning insertion point)

--- a/packages/gateway/test/context-warning.test.ts
+++ b/packages/gateway/test/context-warning.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Unit tests for the unsustainable-conversation warning text + strip round-trip.
+ *
+ * Covers the PIPELINE-side plumbing of the "gate unsustainable warning" fix:
+ * (1) the warning reports the ACTUAL consecutive-bust count (not a hardcoded
+ * "5+ times"), and (2) the marker prefix is byte-stable so stripContextWarnings
+ * removes the injected warning on the next turn — preserving the prompt-cache
+ * prefix regardless of the (variable) count in the text.
+ */
+import { describe, test, expect } from "vitest";
+import {
+  contextWarningText,
+  stripContextWarnings,
+  CONTEXT_WARNING_MARKER,
+} from "../src/pipeline";
+import type {
+  GatewayContentBlock,
+  GatewayMessage,
+} from "../src/translate/types";
+
+function assistant(...content: GatewayContentBlock[]): GatewayMessage {
+  return { role: "assistant", content };
+}
+function user(...content: GatewayContentBlock[]): GatewayMessage {
+  return { role: "user", content };
+}
+function text(t: string): GatewayContentBlock {
+  return { type: "text", text: t };
+}
+
+describe("contextWarningText — reports the actual consecutive-bust count", () => {
+  test("interpolates the real count", () => {
+    const t = contextWarningText(7);
+    expect(t).toContain("7 times in a row");
+    // No hardcoded legacy figure.
+    expect(t).not.toContain("5+ times");
+  });
+
+  test("falls back to generic wording when count is unknown/zero", () => {
+    expect(contextWarningText()).toContain("several times in a row");
+    expect(contextWarningText(0)).toContain("several times in a row");
+    expect(contextWarningText(undefined)).toContain("several times in a row");
+  });
+
+  test("always starts with the stable marker prefix (strip-safe)", () => {
+    for (const c of [undefined, 0, 2, 99]) {
+      expect(contextWarningText(c).startsWith(CONTEXT_WARNING_MARKER)).toBe(
+        true,
+      );
+    }
+  });
+
+  test("is actionable (advises /compact)", () => {
+    expect(contextWarningText(3)).toContain("/compact");
+  });
+});
+
+describe("stripContextWarnings — removes the injected warning regardless of count", () => {
+  test("strips a warning block with any count, restoring API-original content", () => {
+    // Two different counts must both be stripped — proving the variable count
+    // doesn't defeat the marker-prefix match (the cache-preservation invariant).
+    for (const count of [2, 42]) {
+      const messages: GatewayMessage[] = [
+        user(text("hi")),
+        assistant(text(contextWarningText(count)), text("real answer")),
+      ];
+      stripContextWarnings(messages);
+      const a = messages[1];
+      // The warning block is gone; the model's real text remains.
+      expect(
+        a.content.some(
+          (b) => b.type === "text" && b.text.startsWith(CONTEXT_WARNING_MARKER),
+        ),
+      ).toBe(false);
+      expect(
+        a.content.some((b) => b.type === "text" && b.text === "real answer"),
+      ).toBe(true);
+    }
+  });
+
+  test("leaves messages without the marker untouched", () => {
+    const messages: GatewayMessage[] = [
+      user(text("hi")),
+      assistant(text("a normal answer that mentions /compact in passing")),
+    ];
+    const before = JSON.stringify(messages);
+    stripContextWarnings(messages);
+    expect(JSON.stringify(messages)).toBe(before);
+  });
+});


### PR DESCRIPTION
## Problem

A **tier-0** conversation — one that fits the layer-0 cap with headroom — could still surface the user-visible *"This conversation is growing unsustainably — run /compact"* warning on **every turn**.

The layer-0 passthrough path returned `unsustainable = consecutiveBusts >= SUSTAINED_BUST_THRESHOLD`. But on a sub-cap session, sustained busts come from **structural** causes (e.g. a durable prompt-delta whose absolute position drifted across a post-idle recompression — see #786), not from genuine context growth. The conversation is sustainable by definition, yet the warning fired repeatedly (observed on session `0rG8v7uBA0BOoV8yZ`).

The warning also reported a hardcoded *"5+ times in a row"* regardless of the real count.

## Fix

- **Gate the layer-0 passthrough return to `unsustainable: false`.** When the conversation fits the layer-0 cap it is sustainable; structural busts there must not raise the alarm. The **tier-gate-bypass** path (genuinely over the cap, but compression wasn't economically justified) still reports `unsustainable` — that's a real exhaustion signal and is intentionally preserved.
- **Report the actual consecutive-bust count.** `TransformResult` gains `consecutiveBusts`; the pipeline feeds it into a new `contextWarningText(count)` so the message says e.g. *"3 times in a row"* instead of *"5+ times"*.

## Tests

- `tier-0 layer-0 passthrough never reports unsustainable, even after sustained busts`
- `over-cap session that bypasses compression STILL reports unsustainable` (locks the intentional distinction so a future refactor can't collapse the two layer-0 returns)
- warning text reports the real count

## Verification

- `pnpm run typecheck` clean; `pnpm run lint` exit 0
- Targeted suites green (gradient + pipeline)

Independent of the cache-analytics `cache_control` normalization fix (separate PR).
