### PR TITLE
fix(gateway): normalize moving cache_control breakpoint in cache analytics

### DIFF
--- a/packages/gateway/src/cache-analytics.ts
+++ b/packages/gateway/src/cache-analytics.ts
@@ -80,10 +80,37 @@ const CC_VERSION_SUFFIX_REPLACEMENT = "$1.___;";
  */
 const TOP_LEVEL_MAX_TOKENS = /^(\{"model":"[^"]+","max_tokens":)\d+/;
 
+/**
+ * Anthropic prompt-cache breakpoint marker. Clients place an ephemeral
+ * `cache_control` on the LAST cacheable block; it advances to the newest
+ * message every turn. Left in place, the byte at the previous breakpoint's
+ * position always differs from the next turn's body (marker removed there,
+ * present elsewhere), producing a false-positive mid-conversation divergence
+ * even when the upstream prompt-cache prefix is fully intact.
+ *
+ * Removing the marker from BOTH the stored (previous) and current bodies makes
+ * breakpoint movement invisible to the prefix comparison. Matches an optional
+ * leading comma so the surrounding JSON stays well-formed, and tolerates an
+ * optional `ttl` field (extended-cache tier).
+ */
+// Match the whole `cache_control` object regardless of inner key order
+// (e.g. `{"type":"ephemeral"}` or `{"ttl":"1h","type":"ephemeral"}`). The
+// optional leading comma keeps surrounding JSON well-formed in the common case
+// where the marker is a trailing property. Edge case: if `cache_control` were
+// the FIRST key of its object, the trailing comma would be left behind
+// (`{,"text":…}`) — harmless here because (a) Anthropic always appends the
+// marker as the last property of a content block, and (b) this normalized
+// string is only ever byte-compared against another normalized string, never
+// re-parsed or sent upstream (the wire body is never modified by analytics).
+const CACHE_CONTROL_PATTERN =
+  /,?"cache_control":\{[^{}]*"type":"ephemeral"[^{}]*\}/g;
+const CACHE_CONTROL_REPLACEMENT = "";
+
 export function normalizeBodyForComparison(body: string): string {
   return body
     .replace(CCH_PATTERN, CCH_REPLACEMENT)
     .replace(CC_VERSION_SUFFIX_PATTERN, CC_VERSION_SUFFIX_REPLACEMENT)
+    .replace(CACHE_CONTROL_PATTERN, CACHE_CONTROL_REPLACEMENT)
     .replace(TOP_LEVEL_MAX_TOKENS, "$10");
 }
 

--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -678,7 +678,52 @@ export function prepareAnthropicWarmupBody(storedBody: string): string {
   // Strip structured output format (incompatible with max_tokens: 0)
   delete body.output_config;
 
+  // Ensure a cache breakpoint is present. The stored body comes from
+  // cache-analytics' normalized copy, which strips `cache_control` markers (so
+  // breakpoint movement doesn't pollute divergence analysis). Without a
+  // breakpoint the warmup writes NOTHING to the cache — silently neutering
+  // every warmup — so we re-add one on the last content block of the last
+  // message (Anthropic's standard placement, and what the real turns used).
+  ensureCacheBreakpoint(body);
+
   return JSON.stringify(body);
+}
+
+/**
+ * Re-attach an ephemeral `cache_control` breakpoint to the last content block
+ * of the last message if the body has none. Idempotent: a body that already
+ * carries any breakpoint is left untouched.
+ */
+function ensureCacheBreakpoint(body: {
+  messages?: Array<{ content?: unknown }>;
+}): void {
+  const messages = body.messages;
+  if (!Array.isArray(messages) || messages.length === 0) return;
+
+  // If any block anywhere already has a breakpoint, do nothing.
+  const hasBreakpoint = messages.some(
+    (m) =>
+      Array.isArray(m?.content) &&
+      m.content.some(
+        (b: unknown) =>
+          typeof b === "object" && b !== null && "cache_control" in b,
+      ),
+  );
+  if (hasBreakpoint) return;
+
+  // Find the last message with an array content holding at least one block.
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const content = messages[i]?.content;
+    if (Array.isArray(content) && content.length > 0) {
+      const lastBlock = content[content.length - 1];
+      if (typeof lastBlock === "object" && lastBlock !== null) {
+        (lastBlock as { cache_control?: unknown }).cache_control = {
+          type: "ephemeral",
+        };
+      }
+      return;
+    }
+  }
 }
 
 /**

--- a/packages/gateway/test/cache-analytics.test.ts
+++ b/packages/gateway/test/cache-analytics.test.ts
@@ -573,6 +573,57 @@ describe("normalizeBodyForComparison", () => {
     expect(a).toBe(b);
     expect(b).toBe(c);
   });
+
+  test("strips the moving cache_control ephemeral breakpoint", () => {
+    // Anthropic clients place an ephemeral cache breakpoint on the LAST
+    // cacheable block; it advances to the newest message every turn. Left
+    // un-normalized, the byte at the previous breakpoint's position always
+    // differs from the next turn's body, producing a false-positive
+    // mid-conversation divergence (observed on session 1PgnnnH43rJVO5nyX).
+    const body =
+      '{"messages":[{"role":"assistant","content":[{"type":"text","text":"hi","cache_control":{"type":"ephemeral"}}]}]}';
+    expect(normalizeBodyForComparison(body)).toBe(
+      '{"messages":[{"role":"assistant","content":[{"type":"text","text":"hi"}]}]}',
+    );
+  });
+
+  test("append-only turns differing only by a moved breakpoint normalize identically up to the new tail", () => {
+    // Turn N: breakpoint on the last (assistant) message.
+    const prev =
+      '{"messages":[' +
+      '{"role":"user","content":[{"type":"text","text":"q1"}]},' +
+      '{"role":"assistant","content":[{"type":"text","text":"a1","cache_control":{"type":"ephemeral"}}]}' +
+      "]}";
+    // Turn N+1: breakpoint moved to the newly-appended message; the old
+    // message no longer carries the marker.
+    const curr =
+      '{"messages":[' +
+      '{"role":"user","content":[{"type":"text","text":"q1"}]},' +
+      '{"role":"assistant","content":[{"type":"text","text":"a1"}]},' +
+      '{"role":"user","content":[{"type":"text","text":"q2","cache_control":{"type":"ephemeral"}}]}' +
+      "]}";
+    const nPrev = normalizeBodyForComparison(prev);
+    const nCurr = normalizeBodyForComparison(curr);
+    // After normalization, the entire previous body up to its closing brackets
+    // must be a byte-identical prefix of the current body — i.e. the only
+    // change is the genuine append, NOT a mid-conversation edit at the old
+    // breakpoint position. (prev ends with the array+object close `]}` that
+    // curr replaces with `,{...new message...}]}`.)
+    const prevPrefix = nPrev.slice(0, nPrev.length - "]}".length);
+    expect(nCurr.startsWith(prevPrefix)).toBe(true);
+    // The first real divergence is therefore at or after message index 1's
+    // end — never inside messages[0] or messages[1] content (the false
+    // "earlier message modified at position N" mislabel).
+    const offset = findDivergenceOffset(nPrev, nCurr);
+    expect(offset).toBeGreaterThanOrEqual(prevPrefix.length);
+    // The divergence must NOT fall inside an early message's CONTENT (the
+    // false "earlier message modified at position N" mislabel). A structural
+    // boundary after message 1 is fine; an edit inside messages[0/1].content
+    // is not.
+    const path = mapOffsetToJsonPath(nCurr, offset);
+    expect(path.startsWith("messages[0].content")).toBe(false);
+    expect(path.startsWith("messages[1].content")).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/test/cache-warmer.test.ts
+++ b/packages/gateway/test/cache-warmer.test.ts
@@ -36,7 +36,10 @@ import type {
   WarmupResult,
   WarmupState,
 } from "../src/translate/types";
-import { compressBody } from "../src/cache-analytics";
+import {
+  compressBody,
+  normalizeBodyForComparison,
+} from "../src/cache-analytics";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -391,6 +394,82 @@ describe("prepareAnthropicWarmupBody", () => {
     expect(result.system[0].cache_control).toBeDefined();
     expect(result.tools).toHaveLength(1);
     expect(result.messages).toHaveLength(3);
+  });
+
+  // Integration: the warmer's ONLY body source is cache-analytics'
+  // `lastRequestBody`, which is stored AFTER `normalizeBodyForComparison`
+  // (cache-analytics strips `cache_control` markers so breakpoint movement
+  // doesn't pollute divergence analysis). A warmup with no breakpoint writes
+  // NOTHING to the cache — silently neutering warmups while the result
+  // classifier still reports success. The warmer must re-add a breakpoint.
+  test("re-adds a cache breakpoint after analytics normalization strips it", () => {
+    const wireBody = JSON.stringify({
+      model: "claude-sonnet-4-20250514",
+      max_tokens: 16384,
+      stream: true,
+      system: [{ type: "text", text: "you are a helpful assistant" }],
+      tools: [{ name: "bash", description: "run", input_schema: {} }],
+      messages: [
+        { role: "user", content: [{ type: "text", text: "q1" }] },
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "a1", cache_control: { type: "ephemeral" } },
+          ],
+        },
+      ],
+    });
+
+    // Reproduce the real storage path: cache-analytics normalizes before
+    // persisting, which removes the breakpoint.
+    const stored = normalizeBodyForComparison(wireBody);
+    expect(stored).not.toContain("cache_control");
+
+    const fromStore = JSON.parse(prepareAnthropicWarmupBody(stored));
+
+    // Exactly one breakpoint must be present so the warmup actually writes the
+    // cache, placed on the last content block of the last message.
+    const breakpoints = (fromStore.messages as Array<{ content: unknown[] }>)
+      .flatMap((m) => m.content)
+      .filter(
+        (b) =>
+          typeof b === "object" &&
+          b !== null &&
+          "cache_control" in (b as object),
+      );
+    expect(breakpoints).toHaveLength(1);
+    const lastMsg = fromStore.messages[fromStore.messages.length - 1];
+    const lastBlock = lastMsg.content[lastMsg.content.length - 1];
+    expect(lastBlock.cache_control).toEqual({ type: "ephemeral" });
+  });
+
+  test("does not add a second breakpoint when one already survives", () => {
+    const body = JSON.stringify({
+      model: "claude-sonnet-4-20250514",
+      max_tokens: 100,
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "hi", cache_control: { type: "ephemeral" } },
+          ],
+        },
+        { role: "assistant", content: [{ type: "text", text: "yo" }] },
+      ],
+    });
+    const result = JSON.parse(prepareAnthropicWarmupBody(body));
+    const breakpoints = (result.messages as Array<{ content: unknown[] }>)
+      .flatMap((m) => m.content)
+      .filter(
+        (b) =>
+          typeof b === "object" &&
+          b !== null &&
+          "cache_control" in (b as object),
+      );
+    expect(breakpoints).toHaveLength(1);
+    expect(result.messages[0].content[0].cache_control).toEqual({
+      type: "ephemeral",
+    });
   });
 });
 


### PR DESCRIPTION
## Problem

The cache-analytics divergence comparison flagged a **false-positive** mid-conversation cache divergence on healthy, append-only sessions — emitting noisy `cache-analytics: early divergence at byte …` logs and `"earlier message modified at position N (window shift or content change)"` reasons (observed on session `1PgnnnH43rJVO5nyX`, **95–100% cache hit rate** the whole time).

**Root cause:** `normalizeBodyForComparison` stripped `cch=`, `cc_version`, and top-level `max_tokens`, but **not** the ephemeral `cache_control` breakpoint. Anthropic clients place that breakpoint on the **last** cacheable block, so it advances to the newest message every turn. The byte at the previous turn's breakpoint position therefore always differed (marker removed there, present elsewhere) → the prefix comparison tripped at the front of the conversation even though the upstream prompt-cache prefix was fully intact.

## Fix

- **Strip `cache_control` markers in `normalizeBodyForComparison`** (key-order tolerant, optional `ttl`). Both the stored and current bodies are normalized, so byte offsets stay aligned and breakpoint movement becomes invisible. The upstream wire body is never modified — this is comparison-only.
- **Guard the cache-warmer.** Its only body source is the normalized `lastRequestBody`, which no longer carries a breakpoint. A warmup with no breakpoint writes **nothing** to the cache while the result classifier still reports success — silently neutering warmups. `prepareAnthropicWarmupBody` now re-adds an ephemeral breakpoint on the last content block when none survives (idempotent: an existing breakpoint is left untouched).

## Tests

- `strips the moving cache_control ephemeral breakpoint`
- `append-only turns differing only by a moved breakpoint normalize identically up to the new tail` (divergence lands at the genuine new tail, not a mid-conversation early message)
- `re-adds a cache breakpoint after analytics normalization strips it` — feeds a `normalizeBodyForComparison`-processed body through the warmer and asserts a breakpoint is present (the prior warmer test hand-built a body **with** a breakpoint, masking this coupling)
- `does not add a second breakpoint when one already survives`

## Verification

- `pnpm run typecheck` clean; `pnpm run lint` exit 0
- Targeted suites green (cache-analytics + cache-warmer: 208 passing)

Independent of the unsustainable-warning gating fix (separate PR).
