### PR TITLE
fix(gateway): gate cache-warming on write-efficiency + quiet divergence log noise

### DIFF
--- a/packages/gateway/src/cache-analytics.ts
+++ b/packages/gateway/src/cache-analytics.ts
@@ -106,6 +106,10 @@ const CACHE_CONTROL_PATTERN =
   /,?"cache_control":\{[^{}]*"type":"ephemeral"[^{}]*\}/g;
 const CACHE_CONTROL_REPLACEMENT = "";
 
+/** API cache hit-rate below which an "early divergence" is logged at INFO (a
+ *  real bust worth surfacing) rather than DEBUG (normal tail-growth noise). */
+const LOW_HIT_FOR_DIVERGENCE_LOG = 0.5;
+
 export function normalizeBodyForComparison(body: string): string {
   return body
     .replace(CCH_PATTERN, CCH_REPLACEMENT)
@@ -433,7 +437,18 @@ export function analyzeCacheTurn(
       const isMidConversationMessageChange =
         /^messages\[\d+\]/.test(divergencePoint) &&
         !divergenceReason.startsWith("new conversation message");
-      if (prefixMatchPercent < 0.05 || isMidConversationMessageChange) {
+      // Most mid-conversation divergences are NORMAL tail growth: the previous
+      // turn's body simply ended where this turn appends new messages, and the
+      // API still reports a near-100% cache hit. Only surface the snippet when
+      // it correlates with an ACTUAL cache bust (low hit-rate) or a genuine
+      // early prefix divergence; the high-hit tail-growth case is pure noise
+      // (the logger has no debug level, so we suppress it rather than spam INFO).
+      const isRealBust =
+        cacheHitRate < LOW_HIT_FOR_DIVERGENCE_LOG || prefixMatchPercent < 0.05;
+      if (
+        (prefixMatchPercent < 0.05 || isMidConversationMessageChange) &&
+        isRealBust
+      ) {
         const start = Math.max(0, prefixMatchBytes - 20);
         const end = prefixMatchBytes + 80;
         prevSnippet = prevBody.slice(start, Math.min(prevLength, end));

--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -125,6 +125,19 @@ export const MIN_WARMUPS_FOR_ROI_CHECK = 5;
  *  1 in 4 warmups must result in a confirmed user return. */
 export const MIN_SESSION_HIT_RATE = 0.25;
 
+/** Minimum cache-WRITE efficiency (cacheRead / (cacheRead + cacheWrite), from
+ *  each warmup's own response) to continue warming. Below this, the warmup is
+ *  writing far more than it reuses — e.g. a large, actively-growing session
+ *  whose full-body warm refreshes only the ~37K stable prefix (efficiency ~6%)
+ *  while writing ~550K every time. Distinct from MIN_SESSION_HIT_RATE, which
+ *  measures user-return probability, not write efficiency. */
+export const MIN_WRITE_EFFICIENCY = 0.2;
+/** Minimum number of recorded warmup-efficiency samples before the
+ *  write-efficiency gate engages (avoid acting on one noisy sample). */
+export const MIN_WARMUPS_FOR_EFFICIENCY_CHECK = 3;
+/** Rolling window size for per-session warmup write-efficiency samples. */
+export const WRITE_EFFICIENCY_WINDOW = 5;
+
 /** Minimum total input tokens (input + cache_read + cache_creation) before
  *  warming is eligible. Below this threshold the absolute savings per hit
  *  are too small to justify the risk of wasted warmups. At 50K tokens with
@@ -839,6 +852,34 @@ export function resolveProfile(
  *  - Initial commitment (first TTL window): full ROI analysis
  *  - Continuation (subsequent windows): check break-even cap + re-evaluate
  */
+/**
+ * Chronically-low cache-WRITE efficiency guard. Returns true when the session
+ * has enough warmup-efficiency samples AND their average is below
+ * MIN_WRITE_EFFICIENCY — i.e. the full-body warm keeps re-writing a prefix that
+ * won't survive to the next real turn (large/growing session), wasting spend
+ * the return-rate guard cannot detect. Returns false (do not block) when there
+ * are too few samples to judge.
+ */
+export function warmupWriteEfficiencyTooLow(
+  warmup: WarmupState | undefined,
+): boolean {
+  const samples = warmup?.writeEfficiencySamples ?? [];
+  if (samples.length < MIN_WARMUPS_FOR_EFFICIENCY_CHECK) return false;
+  const avg = samples.reduce((a, b) => a + b, 0) / samples.length;
+  return avg < MIN_WRITE_EFFICIENCY;
+}
+
+/** Human-readable dashboard reason for the write-efficiency gate. */
+export function warmupWriteEfficiencyReason(
+  warmup: WarmupState | undefined,
+): string {
+  const samples = warmup?.writeEfficiencySamples ?? [];
+  const avg = samples.length
+    ? (samples.reduce((a, b) => a + b, 0) / samples.length) * 100
+    : 0;
+  return `Write efficiency too low (${avg.toFixed(0)}% < ${(MIN_WRITE_EFFICIENCY * 100).toFixed(0)}%) — full-body warm refreshes only a small stable prefix`;
+}
+
 export function shouldWarm(
   state: SessionState,
   profile: CacheWarmingProfile,
@@ -918,6 +959,20 @@ export function shouldWarm(
     );
     const cyclesSpent = state.warmup?.warmupCount ?? 0;
 
+    // Write-efficiency guard: stop warming a large/growing session whose
+    // full-body warms refresh only a tiny stable prefix (chronically low
+    // cacheRead/(read+write)). Independent of the return-rate guard above.
+    // 🔴 Gated on `cyclesSpent >= 1`: the FIRST warmup of every break
+    // (cyclesSpent === 0) must ALWAYS be funded — it is the irreducible probe
+    // that REFRESHES writeEfficiencySamples. writeEfficiencySamples is lifetime/
+    // durable (not reset per-break, persists across restart), so blocking the
+    // first probe on stale samples would permanently lock out a session whose
+    // prefix has since re-stabilized (it could never record a fresh, higher
+    // sample). Matches the evidence-gate invariant below.
+    if (cyclesSpent >= 1 && warmupWriteEfficiencyTooLow(state.warmup)) {
+      return false;
+    }
+
     // 🔴 Evidence gate (Bug C): ALWAYS fund the first warmup of a break
     // (cyclesSpent === 0 — the probe that learns if this slow tool returns
     // within TTL), but NEVER fund a second-or-later cycle for a session that
@@ -975,6 +1030,10 @@ export function shouldWarm(
     const hitRate = (state.warmup?.warmupHits ?? 0) / lifetime;
     if (hitRate < MIN_SESSION_HIT_RATE) return false;
   }
+  // Write-efficiency guard: stop warming a large/growing session whose
+  // full-body warms refresh only a tiny stable prefix (chronically low
+  // cacheRead/(read+write)). Independent of the return-rate guard above.
+  if (warmupWriteEfficiencyTooLow(state.warmup)) return false;
 
   // Compute commitment model signals
   const survivalAtIdle = survivalFunction(blendedHist, elapsed);
@@ -1288,6 +1347,13 @@ export function computeWarmingSnapshot(
         ).toFixed(0);
         notWarmingReason = `Tool call: session hit rate too low (${hitRate}% < ${(MIN_SESSION_HIT_RATE * 100).toFixed(0)}%)`;
       } else if (
+        // Mirror shouldWarm: the efficiency gate skips the first probe of a
+        // break (cyclesSpent===0), so the snapshot must too.
+        (state.warmup?.warmupCount ?? 0) >= 1 &&
+        warmupWriteEfficiencyTooLow(state.warmup)
+      ) {
+        notWarmingReason = warmupWriteEfficiencyReason(state.warmup);
+      } else if (
         (state.warmup?.warmupCount ?? 0) >= 1 &&
         (state.warmup?.warmupHits ?? 0) < TOOL_CALL_MIN_HITS_FOR_CONTINUATION
       ) {
@@ -1332,6 +1398,8 @@ export function computeWarmingSnapshot(
         100
       ).toFixed(0);
       notWarmingReason = `Session hit rate too low (${hitRate}% < ${(MIN_SESSION_HIT_RATE * 100).toFixed(0)}% after ${state.warmup?.totalWarmups} warmups)`;
+    } else if (warmupWriteEfficiencyTooLow(state.warmup)) {
+      notWarmingReason = warmupWriteEfficiencyReason(state.warmup);
     } else if (isFirstWindow && idleMs < ttlMs - warmupMarginMs) {
       notWarmingReason = "Cache still fresh";
     } else if (pReturns <= thresholdVal) {
@@ -1626,6 +1694,22 @@ export async function executeWarmup(
     // session as the warmup's payer (see WarmupState invariant), gating hit
     // attribution to prevent phantom savings.
     state.warmup.lastWarmupRefreshTokens = cacheReadTokens;
+
+    // Record this warmup's cache-WRITE efficiency = read / (read + write) into
+    // a bounded rolling window. A chronically low average means the full-body
+    // warm is mostly re-writing a prefix that won't survive to the next real
+    // turn (large/growing session); shouldWarm uses it to stop wasteful warming.
+    // Skip when the denominator is 0 (uncached/error — no signal).
+    if (cacheReadTokens + cacheCreationTokens > 0) {
+      const efficiency =
+        cacheReadTokens / (cacheReadTokens + cacheCreationTokens);
+      const samples = state.warmup.writeEfficiencySamples ?? [];
+      samples.push(efficiency);
+      if (samples.length > WRITE_EFFICIENCY_WINDOW) {
+        samples.splice(0, samples.length - WRITE_EFFICIENCY_WINDOW);
+      }
+      state.warmup.writeEfficiencySamples = samples;
+    }
 
     // Check circuit breaker
     checkCircuitBreaker(result);

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -2162,6 +2162,9 @@ function getOrCreateSession(
         if ((state.warmup.totalWarmups ?? 0) === 0) {
           state.warmup.lastWarmupAt = 0;
           state.warmup.lastWarmupRefreshTokens = 0;
+          // Scrub write-efficiency samples too — they must never bleed across a
+          // session-identity change (inherited blob), same as refresh tokens.
+          state.warmup.writeEfficiencySamples = [];
         }
       } catch {
         log.warn(

--- a/packages/gateway/src/translate/types.ts
+++ b/packages/gateway/src/translate/types.ts
@@ -596,6 +596,21 @@ export type WarmupState = {
    * attribution to prevent phantom savings.
    */
   lastWarmupRefreshTokens?: number;
+  /**
+   * Rolling window (FIFO — oldest evicted from the front, capped at
+   * WRITE_EFFICIENCY_WINDOW) of per-warmup cache-WRITE efficiency =
+   * cacheRead / (cacheRead + cacheWrite)
+   * from each warmup's own response usage. This is the fraction of the warmed
+   * prefix that was already cached (cheap read) vs freshly written (expensive).
+   *
+   * 🔴 Distinct from `warmupHits/totalWarmups` (USER-RETURN probability): a
+   * large, actively-growing session reliably returns (return-rate ~1.0) yet
+   * each full-body warm writes ~550K to refresh only the ~37K stable prefix
+   * (efficiency ~6%) — pure waste the return-rate guard cannot see. shouldWarm
+   * stops warming when this stays chronically low. Scrubbed on session-identity
+   * change alongside lastWarmupRefreshTokens (no cross-session bleed).
+   */
+  writeEfficiencySamples?: number[];
 };
 
 /** Result from a warmup request — used for circuit breaker and metrics. */

--- a/packages/gateway/test/cache-analytics.test.ts
+++ b/packages/gateway/test/cache-analytics.test.ts
@@ -1,4 +1,5 @@
-import { describe, test, expect } from "vitest";
+import { describe, test, expect, vi, afterEach } from "vitest";
+import { log } from "@loreai/core";
 import {
   compressBody,
   decompressBody,
@@ -303,6 +304,64 @@ describe("inferDivergenceReason", () => {
 // ---------------------------------------------------------------------------
 // analyzeCacheTurn — integration
 // ---------------------------------------------------------------------------
+
+describe("analyzeCacheTurn — early-divergence log noise gating", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  // Two bodies that diverge at an EARLY message (mid-conversation message
+  // change), so isMidConversationMessageChange is true. The only difference
+  // between the two scenarios below is the API cache hit-rate.
+  const bodyA = JSON.stringify({
+    model: "opus",
+    messages: [
+      { role: "user", content: "first message original" },
+      { role: "assistant", content: "reply one" },
+      { role: "user", content: "second" },
+    ],
+  });
+  const bodyB = JSON.stringify({
+    model: "opus",
+    messages: [
+      { role: "user", content: "first message CHANGED EARLY" },
+      { role: "assistant", content: "reply one" },
+      { role: "user", content: "second" },
+    ],
+  });
+
+  function earlyDivergenceLogs(infoSpy: ReturnType<typeof vi.spyOn>): number {
+    return infoSpy.mock.calls.filter((c: unknown[]) =>
+      String(c[0]).includes("early divergence at byte"),
+    ).length;
+  }
+
+  test("does NOT log the divergence snippet at INFO when the cache hit-rate is high (normal tail growth)", () => {
+    const analytics = makeCacheAnalytics();
+    const infoSpy = vi.spyOn(log, "info").mockImplementation(() => {});
+    // high hit-rate: cacheRead dominates → ~99%
+    const highHit = makeUsage({
+      inputTokens: 2,
+      cacheReadInputTokens: 100_000,
+      cacheCreationInputTokens: 500,
+    });
+    analyzeCacheTurn(analytics, bodyA, highHit);
+    analyzeCacheTurn(analytics, bodyB, highHit);
+    expect(earlyDivergenceLogs(infoSpy)).toBe(0);
+  });
+
+  test("DOES log the divergence snippet at INFO when the cache hit-rate is low (real bust)", () => {
+    const analytics = makeCacheAnalytics();
+    const infoSpy = vi.spyOn(log, "info").mockImplementation(() => {});
+    // low hit-rate: cacheCreation dominates → big bust
+    const lowHit = makeUsage({
+      inputTokens: 2,
+      cacheReadInputTokens: 5_000,
+      cacheCreationInputTokens: 200_000,
+    });
+    analyzeCacheTurn(analytics, bodyA, lowHit);
+    analyzeCacheTurn(analytics, bodyB, lowHit);
+    expect(earlyDivergenceLogs(infoSpy)).toBeGreaterThan(0);
+  });
+});
 
 describe("analyzeCacheTurn", () => {
   test("first turn — no comparison, stores body", () => {

--- a/packages/gateway/test/cache-warmer.test.ts
+++ b/packages/gateway/test/cache-warmer.test.ts
@@ -9,6 +9,10 @@ import {
   buildAnthropicProfile,
   resolveProfile,
   shouldWarm,
+  warmupWriteEfficiencyTooLow,
+  MIN_WRITE_EFFICIENCY,
+  MIN_WARMUPS_FOR_EFFICIENCY_CHECK,
+  WRITE_EFFICIENCY_WINDOW,
   checkCircuitBreaker,
   isCircuitBreakerTripped,
   isWarmupAuthDisabled,
@@ -585,6 +589,57 @@ describe("circuit breaker", () => {
 // shouldWarm decision function
 // ---------------------------------------------------------------------------
 
+describe("warmupWriteEfficiencyTooLow", () => {
+  test("false when fewer than the minimum samples (insufficient evidence)", () => {
+    const samples = Array(MIN_WARMUPS_FOR_EFFICIENCY_CHECK - 1).fill(0.01);
+    expect(
+      warmupWriteEfficiencyTooLow({
+        lastWarmupAt: 0,
+        warmupCount: 0,
+        totalWarmups: samples.length,
+        warmupHits: 0,
+        disabled: false,
+        writeEfficiencySamples: samples,
+      }),
+    ).toBe(false);
+  });
+
+  test("true when avg efficiency is below the threshold over enough samples", () => {
+    expect(
+      warmupWriteEfficiencyTooLow({
+        lastWarmupAt: 0,
+        warmupCount: 0,
+        totalWarmups: 3,
+        warmupHits: 0,
+        disabled: false,
+        writeEfficiencySamples: [0.06, 0.06, 0.06],
+      }),
+    ).toBe(true);
+  });
+
+  test("false when avg efficiency is at/above the threshold", () => {
+    const atThreshold = MIN_WRITE_EFFICIENCY + 0.01;
+    expect(
+      warmupWriteEfficiencyTooLow({
+        lastWarmupAt: 0,
+        warmupCount: 0,
+        totalWarmups: 3,
+        warmupHits: 0,
+        disabled: false,
+        writeEfficiencySamples: [atThreshold, atThreshold, atThreshold],
+      }),
+    ).toBe(false);
+  });
+
+  test("false for undefined warmup / no samples", () => {
+    expect(warmupWriteEfficiencyTooLow(undefined)).toBe(false);
+  });
+
+  test("window size constant is positive (rolling window bounded)", () => {
+    expect(WRITE_EFFICIENCY_WINDOW).toBeGreaterThan(0);
+  });
+});
+
 describe("shouldWarm", () => {
   beforeEach(() => {
     _resetForTest();
@@ -678,6 +733,62 @@ describe("shouldWarm", () => {
     for (let i = 0; i < 50; i++) recordGap(hist, 360_000);
 
     expect(shouldWarm(state, profile, hist, now)).toBe(false);
+  });
+
+  test("returns FALSE when write-efficiency is chronically low, even with a perfect return rate", () => {
+    // Regression: a large/growing session reliably returns (return-rate ~1.0,
+    // passes MIN_SESSION_HIT_RATE) but each full-body warm refreshes only the
+    // ~37K stable prefix (efficiency ~6%) while writing ~550K — pure waste. The
+    // return-rate guard cannot see this; the write-efficiency guard must block.
+    const now = Date.now();
+    const state = makeSessionState({
+      lastRequestTime: now - 270_000,
+      warmup: {
+        lastWarmupAt: 0,
+        warmupCount: 0,
+        totalWarmups: 10,
+        warmupHits: 10, // perfect RETURN rate — return-guard would pass
+        disabled: false,
+        writeEfficiencySamples: [0.06, 0.06, 0.06, 0.08, 0.06], // ~6% WRITE efficiency
+      },
+      cacheAnalytics: {
+        ...makeCacheAnalytics(),
+        lastRequestBody: compressBody(
+          '{"model":"claude-sonnet-4-20250514","max_tokens":16384,"stream":true,"messages":[{"role":"user","content":"test"}]}',
+        ),
+      },
+    });
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+    const hist = createHistogram();
+    for (let i = 0; i < 50; i++) recordGap(hist, 360_000);
+
+    expect(shouldWarm(state, profile, hist, now)).toBe(false);
+  });
+
+  test("returns TRUE when write-efficiency is healthy (gate does not over-block)", () => {
+    const now = Date.now();
+    const state = makeSessionState({
+      lastRequestTime: now - 270_000,
+      warmup: {
+        lastWarmupAt: 0,
+        warmupCount: 0,
+        totalWarmups: 10,
+        warmupHits: 10,
+        disabled: false,
+        writeEfficiencySamples: [0.9, 0.85, 0.95, 0.88, 0.92], // healthy
+      },
+      cacheAnalytics: {
+        ...makeCacheAnalytics(),
+        lastRequestBody: compressBody(
+          '{"model":"claude-sonnet-4-20250514","max_tokens":16384,"stream":true,"messages":[{"role":"user","content":"test"}]}',
+        ),
+      },
+    });
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+    const hist = createHistogram();
+    for (let i = 0; i < 50; i++) recordGap(hist, 360_000);
+
+    expect(shouldWarm(state, profile, hist, now)).toBe(true);
   });
 
   test("returns false when session has too few turns", () => {
@@ -1854,6 +1965,46 @@ describe("shouldWarm tool-call warming", () => {
     expect(shouldWarm(state, profile, hist, now)).toBe(false);
   });
 
+  test("ALWAYS funds the FIRST warmup of a break (cyclesSpent=0) even when write-efficiency is chronically low", () => {
+    // 🔴 The first probe of every break refreshes writeEfficiencySamples (which
+    // is lifetime/durable). Blocking it on stale low samples would permanently
+    // lock the session out (it could never record a fresh sample). The
+    // efficiency gate must be skipped when warmupCount===0.
+    const now = Date.now();
+    const state = makeToolCallState({
+      warmup: {
+        lastWarmupAt: 0,
+        warmupCount: 0, // first probe of THIS break
+        totalWarmups: 10,
+        warmupHits: 10,
+        disabled: false,
+        writeEfficiencySamples: [0.06, 0.06, 0.06, 0.06, 0.06], // chronically low
+      },
+    });
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+    const hist = createHistogram();
+
+    expect(shouldWarm(state, profile, hist, now)).toBe(true);
+  });
+
+  test("BLOCKS a continuation warmup (cyclesSpent>=1) when write-efficiency is chronically low", () => {
+    const now = Date.now();
+    const state = makeToolCallState({
+      warmup: {
+        lastWarmupAt: 0,
+        warmupCount: 1, // continuation within the break
+        totalWarmups: 10,
+        warmupHits: 10,
+        disabled: false,
+        writeEfficiencySamples: [0.06, 0.06, 0.06, 0.06, 0.06],
+      },
+    });
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+    const hist = createHistogram();
+
+    expect(shouldWarm(state, profile, hist, now)).toBe(false);
+  });
+
   test("returns false after MAX_TOOL_CALL_WARMING_MS exceeded", () => {
     const now = Date.now();
     // 35 min — past 30 min cap, in warmup margin of some TTL window
@@ -2115,6 +2266,24 @@ describe("shouldWarm tool-call warming", () => {
     const snap = computeWarmingSnapshot(state, now);
     expect(snap.shouldWarmNow).toBe(true);
     expect(snap.notWarmingReason).toBeNull();
+  });
+
+  test("snapshot reports the write-efficiency reason when chronically low (continuation)", () => {
+    const now = Date.now();
+    const state = makeToolCallState({
+      lastRequestTime: now - 270_000,
+      warmup: {
+        lastWarmupAt: now - 270_000, // past cooldown
+        warmupCount: 1, // continuation — past the first-probe carve-out
+        totalWarmups: 10,
+        warmupHits: 10, // clears the return-rate guard
+        disabled: false,
+        writeEfficiencySamples: [0.06, 0.06, 0.06, 0.06, 0.06],
+      },
+    });
+    const snap = computeWarmingSnapshot(state, now);
+    expect(snap.shouldWarmNow).toBe(false);
+    expect(snap.notWarmingReason).toContain("Write efficiency too low");
   });
 
   test("Bug C: snapshot falls through to cycle-cap reason past the gate branch", () => {

--- a/packages/gateway/test/warmup-execute.test.ts
+++ b/packages/gateway/test/warmup-execute.test.ts
@@ -20,7 +20,11 @@ vi.mock("../src/fetch", () => ({
     globalThis.fetch(...args),
 }));
 
-import { executeWarmup, buildAnthropicProfile } from "../src/cache-warmer";
+import {
+  executeWarmup,
+  buildAnthropicProfile,
+  WRITE_EFFICIENCY_WINDOW,
+} from "../src/cache-warmer";
 import { setSessionAuth, _resetAuthForTest } from "../src/auth";
 import { clearAllCosts } from "../src/cost-tracker";
 import { compressBody } from "../src/cache-analytics";
@@ -144,5 +148,72 @@ describe("executeWarmup → lastWarmupRefreshTokens (Bug B producer)", () => {
     // refresh credit must be 0 so creditWarmupHit later denies a bogus hit.
     expect(state.warmup?.lastWarmupRefreshTokens).toBe(0);
     expect(state.warmup?.totalWarmups).toBe(1);
+  });
+});
+
+describe("executeWarmup → writeEfficiencySamples (efficiency gate producer)", () => {
+  test("records read/(read+write) efficiency on a partial warmup", async () => {
+    globalThis.fetch = fetchReturningUsage({
+      input_tokens: 5,
+      cache_read_input_tokens: 30_000,
+      cache_creation_input_tokens: 470_000, // 30k/(30k+470k) = 0.06
+    }) as unknown as typeof fetch;
+
+    const state = makeState();
+    const profile = buildAnthropicProfile(MODEL, "5m");
+    await executeWarmup(state, profile);
+
+    const samples = state.warmup?.writeEfficiencySamples ?? [];
+    expect(samples).toHaveLength(1);
+    expect(samples[0]).toBeCloseTo(0.06, 2);
+  });
+
+  test("records 1.0 on a perfect refresh (cacheWrite=0) — keeps the average healthy", async () => {
+    globalThis.fetch = fetchReturningUsage({
+      input_tokens: 5,
+      cache_read_input_tokens: 168_000,
+      cache_creation_input_tokens: 0,
+    }) as unknown as typeof fetch;
+
+    const state = makeState();
+    const profile = buildAnthropicProfile(MODEL, "5m");
+    await executeWarmup(state, profile);
+
+    const samples = state.warmup?.writeEfficiencySamples ?? [];
+    expect(samples).toHaveLength(1);
+    expect(samples[0]).toBe(1);
+  });
+
+  test("does NOT record a sample when read+write is 0 (no signal)", async () => {
+    globalThis.fetch = fetchReturningUsage({
+      input_tokens: 5,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+    }) as unknown as typeof fetch;
+
+    const state = makeState();
+    const profile = buildAnthropicProfile(MODEL, "5m");
+    await executeWarmup(state, profile);
+
+    expect(state.warmup?.writeEfficiencySamples ?? []).toHaveLength(0);
+  });
+
+  test("rolling window is capped at WRITE_EFFICIENCY_WINDOW (oldest evicted)", async () => {
+    globalThis.fetch = fetchReturningUsage({
+      input_tokens: 5,
+      cache_read_input_tokens: 30_000,
+      cache_creation_input_tokens: 470_000,
+    }) as unknown as typeof fetch;
+
+    const profile = buildAnthropicProfile(MODEL, "5m");
+    const state = makeState();
+    // Fire more warmups than the window size; cooldown is bypassed because
+    // executeWarmup itself does not gate on cooldown (shouldWarm does).
+    for (let i = 0; i < WRITE_EFFICIENCY_WINDOW + 3; i++) {
+      await executeWarmup(state, profile);
+    }
+    expect(state.warmup?.writeEfficiencySamples ?? []).toHaveLength(
+      WRITE_EFFICIENCY_WINDOW,
+    );
   });
 });


### PR DESCRIPTION
## Problem (production logs, large session)
The cache-warmer replays the **full** last-turn body (~550K tokens) and writes it all, but only the 1h-TTL stable prefix (system[0]+system[1]+tools ≈ **37K, a fixed floor**) ever survives to the next real turn — the conversation tail grew/compressed since the stored body. Result: `cacheWrite=553122 cacheRead=37030 hit=6% ~$3.50` per warmup, ~10 warmups/day → **~$35/day wasted** on one session. The 37K it "refreshes" was already cached at 1h TTL anyway → the ~516K write is pure waste.

**Why the existing ROI guard misses it:** `MIN_SESSION_HIT_RATE` measures `warmupHits/totalWarmups` = **user-return probability** (~1.0 here — the user always returns), NOT cache-**write** efficiency (6%). So it never trips for a reliably-returning session whose warms are write-inefficient.

## Fix 1 — write-efficiency gate
Record each warmup's `cacheRead/(cacheRead+cacheWrite)` in a bounded rolling window (`WRITE_EFFICIENCY_WINDOW=5`) on `WarmupState`. `shouldWarm` stops warming (both tool-call and normal paths) when the rolling average stays below `MIN_WRITE_EFFICIENCY` (0.20) over ≥3 samples — independent of the return-rate guard. Samples scrubbed on session-identity change (no cross-session bleed). Surfaced in the dashboard "not warming" reason.

## Fix 2 — quiet "early divergence at byte" log noise
~95% of these were normal tail growth (prev body ended where this turn appends new messages; hit ~100%). The multi-line snippet now only logs at INFO on an **actual bust** (`cacheHitRate < 0.5`) or genuine early prefix divergence (`prefixMatch < 5%`); high-hit tail-growth is suppressed (the logger has no debug level).

## Tests (fail-on-revert verified)
- `cache-warmer.test.ts`: `warmupWriteEfficiencyTooLow` predicate; `shouldWarm` blocks on chronically-low efficiency **even with a perfect return rate**; does not over-block healthy sessions.
- `cache-analytics.test.ts`: snippet suppressed at high hit-rate, logged at low hit-rate.

## Verification
- `pnpm test` — **3259 passed**, 6 skipped, 0 failed
- typecheck clean; lint exit 0

## Scope note
Investigation showed "stable-prefix warming" (warm only the 37K head) would be largely redundant — that prefix already lives 1h and survives the sub-5m inter-turn gaps on its own. So this PR targets the actual waste (stop inefficient full-body warms) rather than restructuring the warmup body.

🤖 Generated with [opencode](https://opencode.ai)