### PR TITLE
fix(core): pin compressed sessions to Layer >= 1 — no Layer-0 re-entry (prefix front-bust)

### DIFF
--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -739,6 +739,35 @@ export function getLastLayer(sessionID?: string): SafetyLayer {
 }
 
 /**
+ * Decide whether the "prefix-present floor" applies — i.e. whether the next
+ * transform must pin to at least Layer 1 (keeping the distilled prefix present
+ * at messages[0]/[1]) because the session has already compressed.
+ *
+ * Returns true when the session has compressed before (`lastLayer >= 1`) AND
+ * this turn is NOT a genuine compaction. A genuine compaction is detected when
+ * the last-known window size is known (> 0) and the incoming conversation has
+ * shrunk below it — that is the one case where dropping back to Layer 0 is
+ * correct (the host shrank the conversation, so the prefix is no longer needed).
+ *
+ * Notes:
+ *  - Covers `lastLayer === 4` (the strong sticky guard's `<= 3` excludes it).
+ *  - When `lastKnownMessageCount === 0` (fresh process, not yet set), this never
+ *    treats the turn as a compaction — it relies on the DB-restored `lastLayer`
+ *    to hold the floor until the live count is established.
+ *  - Pure function of its inputs — unit-testable without driving a full transform.
+ */
+export function prefixPresentFloorApplies(
+  lastLayer: number,
+  messagesLength: number,
+  lastKnownMessageCount: number,
+): boolean {
+  const hasCompressed = lastLayer >= 1;
+  const genuineCompaction =
+    lastKnownMessageCount > 0 && messagesLength < lastKnownMessageCount;
+  return hasCompressed && !genuineCompaction;
+}
+
+/**
  * Force the next transform() call for this session to use at least the given layer.
  * Called when the API returns "prompt is too long" so the next attempt
  * trims the context enough to fit within the model's context window.
@@ -2112,6 +2141,41 @@ function transformInner(input: {
       effectiveMinLayer,
       sessState.lastLayer,
     ) as SafetyLayer;
+  }
+
+  // --- Prefix-present floor (no Layer-0 re-entry once compressed) ---
+  // Once a session has compressed (reached Layer >= 1), the distilled prefix is
+  // injected at messages[0]/[1]. Dropping back to Layer 0 omits the prefix —
+  // messages[0] changes → full prompt-cache front-bust; the reverse re-injects
+  // it → bust again (0<->N thrash). The strong sticky guard above pins to the
+  // FULL lastLayer, but only for lastLayer 1-3 AND only while `calibrated`.
+  //
+  // For a CALIBRATED 1-3 session this floor's condition equals the sticky
+  // guard's (both gate on `messages.length >= lastKnownMessageCount`), so here
+  // it is pure defense-in-depth. Its GENUINELY NEW coverage is the two gaps the
+  // sticky guard leaves open — exactly where the production front-busts occur:
+  //   (1) lastLayer === 4 (genuine emergency overflow) — excluded by `<= 3`.
+  //   (2) a compressed-but-UNCALIBRATED session (lastKnownInput == 0, so
+  //       `calibrated` is false): the API call hasn't established a token count
+  //       yet (first compressed turn whose call failed before calibrate, or a
+  //       resume/restart before the first calibrate of this process). The sticky
+  //       guard is skipped entirely; without this floor the layer-0 fit and the
+  //       tier-based bust-vs-continue gate (both gated on effectiveMinLayer===0)
+  //       pass the session through at Layer 0 and vanish the prefix.
+  // The floor pins to >= Layer 1 ONLY (prefix PRESENT) — NEVER higher, so it
+  // never traps the session at an emergency layer. It is released only on a
+  // GENUINE compaction: the host shrank the conversation below the last-known
+  // window (and that window is known, i.e. > 0 — so a fresh process with
+  // lastKnownMessageCount=0 does not spuriously release; it relies on the
+  // DB-restored lastLayer to hold the floor until the live count is set).
+  if (
+    prefixPresentFloorApplies(
+      sessState.lastLayer,
+      input.messages.length,
+      sessState.lastKnownMessageCount,
+    )
+  ) {
+    effectiveMinLayer = Math.max(effectiveMinLayer, 1) as SafetyLayer;
   }
 
   // --- Post-idle compact layer ---

--- a/packages/core/test/gradient.test.ts
+++ b/packages/core/test/gradient.test.ts
@@ -27,6 +27,7 @@ import {
   consumeCameOutOfIdle,
   inspectSessionState,
   setLastTurnAtForTest,
+  prefixPresentFloorApplies,
   recordCacheUsage,
   setCachePricing,
   setMaxLayer0Tokens,
@@ -738,13 +739,17 @@ describe("gradient — force escalation (reactive error recovery)", () => {
     });
     // Despite tiny messages, force min layer should push to at least layer 2
     expect(result.layer).toBeGreaterThanOrEqual(2);
-    // After one use, the flag is consumed — next call should behave normally
+    // After one use, the forceMinLayer flag is consumed (proven directly below).
+    // The resulting layer drops from the forced 2 to 1 — NOT back to 0 — because
+    // the prefix-present floor holds a once-compressed session at Layer >= 1
+    // (prefixPresentFloorApplies). The 2→1 drop proves the flag was consumed.
+    expect(loadForceMinLayer("force-sess")).toBe(0);
     const result2 = transform({
       messages,
       projectPath: PROJECT,
       sessionID: "force-sess",
     });
-    expect(result2.layer).toBe(0);
+    expect(result2.layer).toBe(1);
   });
 
   test("forceMinLayer is one-shot — cleared after single use", () => {
@@ -752,21 +757,25 @@ describe("gradient — force escalation (reactive error recovery)", () => {
       makeMsg("os-1", "user", "test", "oneshot-sess"),
       makeMsg("os-2", "assistant", "ok", "oneshot-sess"),
     ];
-    setForceMinLayer(1, "oneshot-sess");
-    // First call consumes the flag
+    setForceMinLayer(2, "oneshot-sess");
+    // First call consumes the flag (forces layer >= 2).
     const r1 = transform({
       messages,
       projectPath: PROJECT,
       sessionID: "oneshot-sess",
     });
-    expect(r1.layer).toBeGreaterThanOrEqual(1);
-    // Second call — no flag, tiny messages → layer 0
+    expect(r1.layer).toBeGreaterThanOrEqual(2);
+    // Flag is consumed (one-shot) — proven directly.
+    expect(loadForceMinLayer("oneshot-sess")).toBe(0);
+    // Second call — no flag. The layer drops from 2, but the prefix-present
+    // floor holds it at 1 (a once-compressed session never re-enters Layer 0
+    // absent a genuine compaction). The 2→1 drop confirms the flag was consumed.
     const r2 = transform({
       messages,
       projectPath: PROJECT,
       sessionID: "oneshot-sess",
     });
-    expect(r2.layer).toBe(0);
+    expect(r2.layer).toBe(1);
   });
 
   test("resetCalibration clears forceMinLayer", () => {
@@ -824,13 +833,15 @@ describe("gradient — forceMinLayer persistence (restart survival)", () => {
     // One-shot: consumed — DB should be cleared
     expect(loadForceMinLayer(SID)).toBe(0);
 
-    // Next call should be layer 0 (tiny messages, no escalation)
+    // Next call: the forced flag is gone, but the prefix-present floor holds a
+    // once-compressed session at Layer 1 (no re-entry to Layer 0 absent a
+    // genuine compaction). The 2→1 drop confirms the flag was consumed.
     const result2 = transform({
       messages,
       projectPath: PROJECT,
       sessionID: SID,
     });
-    expect(result2.layer).toBe(0);
+    expect(result2.layer).toBe(1);
   });
 
   test("setForceMinLayer writes to DB and transform consumes it", () => {
@@ -2152,6 +2163,167 @@ describe("gradient — distilled-prefix front-bust (spurious Layer 4 + thrash)",
       sessionID: SID,
     });
     expect(r2.layer).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No Layer-0 re-entry once compressed (prefix-present floor)
+// ---------------------------------------------------------------------------
+// Once a session has compressed (reached Layer >= 1, injecting the distilled
+// prefix at messages[0]/[1]), it must NOT drop back to Layer 0 on a later turn —
+// that vanishes the prefix and front-busts the cache. The existing sticky guard
+// only covers lastLayer 1-3 while calibrated; this floor also covers a prior
+// Layer-4 turn and survives a process restart (calibrated=false). It still
+// RELEASES on a genuine compaction (the host shrank the conversation).
+//
+// The floor decision is `prefixPresentFloorApplies`, a pure predicate. We test
+// it directly (a full truth table — discriminating: any revert of the predicate
+// flips at least one case). The predicate's WIRING into transform() (pinning the
+// layer UP to >= 1) is proven by the repurposed `forceMinLayer` tests below,
+// which now assert a once-compressed session holds at Layer 1 (2->1) instead of
+// returning to Layer 0. The two transform-level guards here cover the other
+// direction — that the floor does NOT over-apply: a genuine compaction still
+// releases to Layer 0, and a never-compressed small session stays at Layer 0.
+describe("gradient — prefixPresentFloorApplies (no Layer-0 re-entry predicate)", () => {
+  test("never compressed (lastLayer 0) → floor does NOT apply", () => {
+    expect(prefixPresentFloorApplies(0, 100, 0)).toBe(false);
+    expect(prefixPresentFloorApplies(0, 5, 100)).toBe(false);
+    expect(prefixPresentFloorApplies(0, 100, 50)).toBe(false);
+  });
+
+  test("compressed (lastLayer 1-4) + growing/steady conversation → floor applies", () => {
+    for (const layer of [1, 2, 3, 4]) {
+      // count unknown yet (fresh process)
+      expect(prefixPresentFloorApplies(layer, 500, 0)).toBe(true);
+      // conversation grew
+      expect(prefixPresentFloorApplies(layer, 600, 500)).toBe(true);
+      // conversation steady (equal — NOT a shrink)
+      expect(prefixPresentFloorApplies(layer, 500, 500)).toBe(true);
+    }
+  });
+
+  test("covers lastLayer === 4 (the strong sticky guard's `<= 3` excludes it)", () => {
+    expect(prefixPresentFloorApplies(4, 500, 400)).toBe(true);
+  });
+
+  test("genuine compaction (messages shrank below the known window) → floor RELEASES", () => {
+    expect(prefixPresentFloorApplies(1, 3, 500)).toBe(false);
+    expect(prefixPresentFloorApplies(4, 10, 760)).toBe(false);
+  });
+
+  test("shrink is ignored when the window size is not yet known (count 0)", () => {
+    // Fresh process: lastKnownMessageCount=0 must NOT be read as a compaction —
+    // rely on the DB-restored lastLayer to hold the floor until the live count is set.
+    expect(prefixPresentFloorApplies(1, 1, 0)).toBe(true);
+  });
+});
+
+describe("gradient — prefix-present floor: transform-level guards", () => {
+  const SID = "prefix-floor-guard-sess";
+  const PID_KEY = "prefix-floor-guard-project";
+  let projectId: string;
+  let createdCounter = 0;
+
+  function seedDistillations(count: number, charsEach: number) {
+    for (let i = 0; i < count; i++) {
+      const id = crypto.randomUUID();
+      db()
+        .query(
+          `INSERT INTO distillations (id, project_id, session_id, narrative, facts, observations, source_ids, generation, token_count, archived, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          id,
+          projectId,
+          SID,
+          "",
+          "[]",
+          `Distillation ${i}: ${"o".repeat(charsEach)}`,
+          "[]",
+          0,
+          Math.ceil(charsEach / 3),
+          0,
+          Date.now() + createdCounter++,
+        );
+    }
+  }
+
+  function largeRawConversation(): LoreMessageWithParts[] {
+    const msgs = Array.from({ length: 80 }, (_, i) =>
+      makeMsg(
+        `g-${i}`,
+        i % 2 === 0 ? "user" : "assistant",
+        "r".repeat(900),
+        SID,
+      ),
+    );
+    msgs.push(makeMsg("g-final", "user", "step", SID));
+    return msgs;
+  }
+
+  beforeAll(() => {
+    projectId = ensureProject(`/test/${PID_KEY}`);
+  });
+
+  beforeEach(() => {
+    resetCalibration(SID);
+    resetPrefixCache(SID);
+    resetRawWindowCache(SID);
+    resetDistillationSnapshot(SID);
+    createdCounter = 0;
+    db().query("DELETE FROM distillations WHERE project_id = ?").run(projectId);
+    db().query("DELETE FROM session_state WHERE session_id = ?").run(SID);
+    setModelLimits({ context: 100_000, output: 4_000 });
+    calibrate(0);
+  });
+
+  afterAll(() => {
+    setModelLimits({ context: 10_000, output: 2_000 });
+    calibrate(0);
+    db().query("DELETE FROM distillations WHERE project_id = ?").run(projectId);
+    db().query("DELETE FROM session_state WHERE session_id = ?").run(SID);
+  });
+
+  test("the floor does NOT trap a genuinely compacted session (releases to Layer 0)", () => {
+    // Compress once (post-idle forces Layer >= 1, setting lastKnownMessageCount).
+    seedDistillations(3, 1500);
+    const conv = largeRawConversation();
+    setLastTurnAtForTest(SID, Date.now() - 10 * 60_000);
+    onIdleResume(SID, 5 * 60_000);
+    const r1 = transform({
+      messages: conv,
+      projectPath: `/test/${PID_KEY}`,
+      sessionID: SID,
+    });
+    expect(r1.layer).toBeGreaterThanOrEqual(1);
+    calibrate(estimateMessages(r1.messages), SID, r1.messages.length);
+
+    // Genuine compaction: 3 tiny messages, far below the known window.
+    db().query("DELETE FROM distillations WHERE project_id = ?").run(projectId);
+    seedDistillations(1, 150);
+    const r2 = transform({
+      messages: [
+        makeMsg("g-c1", "user", "fresh", SID),
+        makeMsg("g-c2", "assistant", "ok", SID),
+        makeMsg("g-c3", "user", "go", SID),
+      ],
+      projectPath: `/test/${PID_KEY}`,
+      sessionID: SID,
+    });
+    expect(r2.layer).toBe(0);
+  });
+
+  test("a never-compressed small session sits at Layer 0 (floor does not over-apply)", () => {
+    const r = transform({
+      messages: [
+        makeMsg("g-s1", "user", "hello", SID),
+        makeMsg("g-s2", "assistant", "hi", SID),
+        makeMsg("g-s3", "user", "go", SID),
+      ],
+      projectPath: `/test/${PID_KEY}`,
+      sessionID: SID,
+    });
+    expect(r.layer).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Problem
Once a session compresses (gradient Layer >= 1), the distilled prefix is injected at `messages[0]/[1]`. If a later turn drops back to **Layer 0**, the prefix **vanishes** from the front → `messages[0]` changes → the entire cached prompt prefix busts; the reverse re-injects it → bust again (0↔N thrash).

The existing sticky-layer guard only pins downward-oscillation for `lastLayer` 1-3 **while calibrated**, leaving two front-bust gaps that recur in production:
1. `lastLayer === 4` (genuine emergency overflow) — excluded by the guard's `<= 3`.
2. the tier-based bust-vs-continue gate, which passes a large session through at Layer 0 (`effectiveMinLayer === 0`) when `shouldCompress()` declines on a huge-context model — dropping the prefix.

**Production evidence:** 86 genuine `1-3 → 0` re-entries across **19 distinct sessions** over 6 days (~14/day), each a full-prefix front-bust. (Distinct from the spurious Layer-4 thrash fixed in #794.)

## Fix
Add a **prefix-present floor**: once a session has compressed (`lastLayer >= 1`), pin `effectiveMinLayer` to at least 1 — keeping the distilled prefix present — **except on a genuine compaction** (the host shrank the conversation below the last-known window). The decision is a pure predicate, `prefixPresentFloorApplies`, placed before all drop-to-0 paths (sticky guard, post-idle, layer-0 fit, tier gate).

🔴 Properties:
- Pins to **>= Layer 1 only** (prefix present) — never higher, so it never traps a session at an emergency layer.
- Covers `lastLayer === 4` (which the strong guard's `<= 3` excludes).
- Releases on genuine compaction (`messages.length < lastKnownMessageCount`, when that count is known `> 0`). A fresh process (count 0) does not spuriously release — it relies on the DB-restored `lastLayer` to hold the floor until the live count is set.
- Never applies to a never-compressed session (`lastLayer 0`) — small sessions stay at 0.

## Behavior change
A session that was force-escalated (`forceMinLayer` / "prompt too long" recovery) and then has a steady conversation now stays at Layer 1 instead of returning to Layer 0. The `forceMinLayer` one-shot semantics are unchanged (the flag is still cleared after one use — proven independently via `loadForceMinLayer`); only the resulting layer differs (2→1 instead of 2→0). Three `forceMinLayer` tests updated to assert the new floor with that rationale.

## Tests
- `prefixPresentFloorApplies` unit truth-table — **discriminating in both directions** (reverting the predicate to always-false fails the "applies" cases; dropping the compaction check fails the "release" cases).
- transform-level guards: genuine compaction still releases to Layer 0; a never-compressed small session stays at Layer 0 (floor does not over-apply).

## Honest limitation
The full production economic confluence (huge-context model + tier-0→1 transition + `shouldCompress` declining) could not be reproduced as a fail-on-revert **end-to-end** test in the synthetic harness — the predicate is tested directly instead, and transform-level guards confirm it's wired in and does not over-apply.

## Verification
- `pnpm test` — **3278 passed**, 6 skipped, 0 failed
- typecheck clean; lint exit 0

🤖 Generated with [opencode](https://opencode.ai)