### PR TITLE
docs(env): document LORE_NO_DB_TRACING in generated env docs

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1237,11 +1237,10 @@ export function db(): Database {
   // TEMP-trigger setup queries are never traced / re-entrant, and (b) the
   // singleton is only assigned a fully-migrated handle (see invariant above).
   // The Proxy is transparent when no tracer is registered (see db/traced.ts).
-  // Set LORE_NO_DB_TRACING=1 to bypass it entirely.
-  instance =
-    process.env.LORE_NO_DB_TRACING === "1"
-      ? database
-      : tracedDatabase(database);
+
+  // LORE_NO_DB_TRACING=1 returns the raw connection instead of the query-tracing Proxy (disables automatic per-query DB spans).
+  const dbTracingDisabled = process.env.LORE_NO_DB_TRACING === "1";
+  instance = dbTracingDisabled ? database : tracedDatabase(database);
   return instance;
 }
 

--- a/packages/website/src/content/docs/docs/environment.md
+++ b/packages/website/src/content/docs/docs/environment.md
@@ -67,6 +67,7 @@ Env vars override `.lore.json` for the same setting. To override a `.lore.json` 
 | Variable | Description |
 |---|---|
 | `LORE_DB_PATH` | Resolved path of the SQLite database file. Reads `LORE_DB_PATH` first; falls back to `${dataDir}/lore.db` (typically `~/.local/share/lore/lore.db`). The test preload (`packages/core/test/setup.ts`) sets `LORE_DB_PATH` to a temp directory so tests never touch the production DB. Setting it to a non-existent path will create the file on first use. The gateway itself does not set this — it expects a stable location for the DB so the SQLite WAL and FTS5 indices persist across restarts. Env: `LORE_DB_PATH`. |
+| `LORE_NO_DB_TRACING` | LORE_NO_DB_TRACING=1 returns the raw connection instead of the query-tracing Proxy (disables automatic per-query DB spans). |
 
 ## How variables are evaluated
 


### PR DESCRIPTION
Follow-up to #802. That PR added the `LORE_NO_DB_TRACING` env var but auto-merged on the required checks before the **Check generated docs** job (non-required) could be addressed, so `environment.md` on `main` is now stale and that check is red.

This regenerates `environment.md` and restructures the gate in `db.ts` into a named boolean (`dbTracingDisabled`) with a concise doc-comment at the use site, so `generate-env-docs.ts` extracts a real description instead of `_no description in source_`. Behavior is unchanged.

Verified: `pnpm run check:docs` passes, core typecheck clean, db-traced tests green.