### PR TITLE
fix(gateway): restart-proof session adoption to stop cold-start busts (#796)

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1147,6 +1147,16 @@ const MIGRATIONS: string[] = [
     local_content TEXT   -- JSON of the discarded local row (recoverable after LWW)
   );
   `,
+  `
+  -- Version 44: persist lastKnownMessageCount for restart-proof calibration.
+  -- The gradient's calibrated-delta estimate needs the message count that was
+  -- sent last turn (to identify only genuinely-new messages). last_known_input
+  -- and last_layer already persist; without the count, an adopted/resumed
+  -- session after a restart is "calibrated" but treats the whole conversation
+  -- as new, over-estimating expectedInput and over-escalating the layer for one
+  -- turn. Persisting it makes the resume turn accurate. (issue #796)
+  ALTER TABLE session_state ADD COLUMN last_known_message_count INTEGER NOT NULL DEFAULT 0;
+  `,
 ];
 
 /**
@@ -1610,6 +1620,12 @@ function recoverMissingObjects(database: Database) {
     if (!scols.some((c) => c.name === "dedup_decisions")) {
       database.exec(
         "ALTER TABLE session_state ADD COLUMN dedup_decisions TEXT;",
+      );
+    }
+    // Version 44: persisted last-known message count for restart-proof calibration.
+    if (!scols.some((c) => c.name === "last_known_message_count")) {
+      database.exec(
+        "ALTER TABLE session_state ADD COLUMN last_known_message_count INTEGER NOT NULL DEFAULT 0;",
       );
     }
   }
@@ -2337,6 +2353,8 @@ export type SessionTrackingState = {
   interBustIntervalEMA?: number;
   lastLayer?: number;
   lastKnownInput?: number;
+  /** v43: messages sent last turn — for restart-proof calibrated-delta estimation. */
+  lastKnownMessageCount?: number;
   lastTurnAt?: number;
   lastBustAt?: number;
   // v26: sub-agent parent–child relationships
@@ -2453,6 +2471,10 @@ export function saveSessionTracking(
     sets.push("last_known_input = ?");
     vals.push(state.lastKnownInput);
   }
+  if (state.lastKnownMessageCount !== undefined) {
+    sets.push("last_known_message_count = ?");
+    vals.push(state.lastKnownMessageCount);
+  }
   if (state.lastTurnAt !== undefined) {
     sets.push("last_turn_at = ?");
     vals.push(state.lastTurnAt);
@@ -2516,6 +2538,8 @@ export type LoadedSessionTracking = {
   interBustIntervalEMA: number;
   lastLayer: number;
   lastKnownInput: number;
+  /** v43: messages sent last turn (0 for pre-v43 / never-calibrated rows). */
+  lastKnownMessageCount: number;
   lastTurnAt: number;
   lastBustAt: number;
   // v26: sub-agent parent–child relationships
@@ -2653,7 +2677,8 @@ export function loadSessionTracking(
               fingerprint, header_session_id, header_name,
               resolved_conversation_ttl, warmup_state,
               dynamic_context_cap, bust_rate_ema, inter_bust_interval_ema,
-              last_layer, last_known_input, last_turn_at, last_bust_at,
+              last_layer, last_known_input, last_known_message_count,
+              last_turn_at, last_bust_at,
               parent_session_id, is_subagent,
               project_path, project_path_provisional,
               compaction_anomaly_pending
@@ -2680,6 +2705,7 @@ export function loadSessionTracking(
     inter_bust_interval_ema: number;
     last_layer: number;
     last_known_input: number;
+    last_known_message_count: number;
     last_turn_at: number;
     last_bust_at: number;
     parent_session_id: string | null;
@@ -2710,6 +2736,7 @@ export function loadSessionTracking(
     interBustIntervalEMA: row.inter_bust_interval_ema,
     lastLayer: row.last_layer,
     lastKnownInput: row.last_known_input,
+    lastKnownMessageCount: row.last_known_message_count,
     lastTurnAt: row.last_turn_at,
     lastBustAt: row.last_bust_at,
     parentSessionId: row.parent_session_id,
@@ -2718,6 +2745,66 @@ export function loadSessionTracking(
     projectPathProvisional: row.project_path_provisional === 1,
     compactionAnomalyPending: row.compaction_anomaly_pending === 1,
   };
+}
+
+/**
+ * Find persisted sessions whose stored fingerprint matches `fingerprint`.
+ *
+ * Restart-proof session adoption (issue #796): after a process restart the
+ * in-memory session index is empty, so the Tier-3 fingerprint scan (which only
+ * iterates memory) can never rematch a resumed conversation. This DB-backed
+ * lookup recovers candidate sessions by their persisted fingerprint. The empty
+ * fingerprint ('' — the default for untracked rows) never matches, so
+ * uninitialized rows are excluded.
+ */
+export function findSessionStatesByFingerprint(
+  fingerprint: string,
+): Array<{ session_id: string; message_count: number; is_subagent: number }> {
+  if (!fingerprint) return [];
+  return db()
+    .query(
+      `SELECT session_id, message_count, is_subagent
+         FROM session_state
+        WHERE fingerprint = ? AND fingerprint != ''`,
+    )
+    .all(fingerprint) as Array<{
+    session_id: string;
+    message_count: number;
+    is_subagent: number;
+  }>;
+}
+
+/**
+ * Count how many of `ids` exist as temporal messages in (projectId, sessionId).
+ *
+ * Confirms a fingerprint-matched adoption candidate by content overlap: temporal
+ * message IDs are deterministic content hashes, so a genuinely-resumed
+ * conversation reproduces the same IDs for its (index-stable) leading messages.
+ * The project_id predicate also enforces same-project — a cross-project
+ * fingerprint twin yields zero overlap. `ids` is chunked to stay under SQLite's
+ * bound-variable limit. (issue #796)
+ */
+export function countMatchingTemporalIds(
+  projectId: string,
+  sessionId: string,
+  ids: string[],
+): number {
+  if (ids.length === 0) return 0;
+  // < SQLite's 999 bound-variable ceiling, leaving headroom for the 2 fixed params.
+  const CHUNK = 800;
+  let total = 0;
+  for (let i = 0; i < ids.length; i += CHUNK) {
+    const chunk = ids.slice(i, i + CHUNK);
+    const placeholders = chunk.map(() => "?").join(",");
+    const row = db()
+      .query(
+        `SELECT COUNT(*) AS n FROM temporal_messages
+          WHERE project_id = ? AND session_id = ? AND id IN (${placeholders})`,
+      )
+      .get(projectId, sessionId, ...chunk) as { n: number };
+    total += row.n;
+  }
+  return total;
 }
 
 /**

--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -116,6 +116,15 @@ const NO_CACHE_WRITE_THRESHOLD = 3;
 const FREE_WRITE_LAYER0_FRACTION = 0.65;
 
 /**
+ * On uncalibrated turns, multiply the chars/3 estimate to approximate the real
+ * token count. chars/3 undercounts by ~1.68x on real data, but the overhead EMA
+ * captures most of the gap; 1.5 provides a safe margin. Module-scoped so the
+ * layer-0 sizing helper (and isLargeColdStart) share one definition with the
+ * transform path.
+ */
+const UNCALIBRATED_SAFETY = 1.5;
+
+/**
  * True when the session's upstream has reported zero cache_creation_input_tokens
  * for at least {@link NO_CACHE_WRITE_THRESHOLD} consecutive turns.  Covers both
  * free-write-cache providers (e.g. MiniMax passive caching) and non-caching
@@ -455,6 +464,10 @@ function getSessionState(sessionID: string): SessionState {
     if (persisted && persisted.lastTurnAt > 0) {
       state.lastLayer = persisted.lastLayer as SafetyLayer;
       state.lastKnownInput = persisted.lastKnownInput;
+      // v43: restore the last-sent message count so the calibrated-delta
+      // estimate identifies only genuinely-new messages on the resume turn
+      // (without it, the whole conversation looks new → over-escalation). (#796)
+      state.lastKnownMessageCount = persisted.lastKnownMessageCount;
       state.lastTurnAt = persisted.lastTurnAt;
       // Don't restore consecutiveBusts from DB — it's a short-term rolling
       // signal that must rebuild from live API responses in the current process.
@@ -831,6 +844,7 @@ export function inspectSessionState(sessionID: string): {
   distillationSnapshot: DistillationSnapshot | null;
   consecutiveBusts: number;
   zeroCacheWriteTurns: number;
+  lastKnownMessageCount: number;
 } | null {
   const state = sessionStates.get(sessionID);
   if (!state) return null;
@@ -843,6 +857,7 @@ export function inspectSessionState(sessionID: string): {
     distillationSnapshot: state.distillationSnapshot,
     consecutiveBusts: state.consecutiveBusts,
     zeroCacheWriteTurns: state.zeroCacheWriteTurns,
+    lastKnownMessageCount: state.lastKnownMessageCount,
   };
 }
 
@@ -900,6 +915,7 @@ export function saveGradientState(sessionID: string): void {
   saveSessionTracking(sessionID, {
     lastLayer: state.lastLayer,
     lastKnownInput: state.lastKnownInput,
+    lastKnownMessageCount: state.lastKnownMessageCount,
     lastTurnAt: state.lastTurnAt,
     // Repurpose the dead dynamicContextCap column (v24, always 0 now)
     // to persist consecutiveBusts — avoids a new DB migration.
@@ -2035,6 +2051,82 @@ export function needsUrgentDistillation(sessionID: string): boolean {
   return v;
 }
 
+/**
+ * Layer-0 sizing for a given expected input. Single source of truth shared by
+ * transformInner() (the layer decision) and isLargeColdStart() (the pipeline's
+ * turn-1 LTM-injection decision) so the two never diverge. Reads the
+ * module-global model limits set per-request by the host before transform().
+ * (issue #796)
+ */
+function layer0Bounds(
+  expectedInput: number,
+  calibrated: boolean,
+  sid: string | undefined,
+): { layer0Input: number; layer0Ceiling: number } {
+  const maxInput = contextLimit - outputReserved;
+  // chars/3 undercounts by ~1.63x on real sessions — without this an
+  // uncalibrated session estimated at 146K passes Layer 0 but actually costs
+  // 214K → overflow.
+  const layer0Input = calibrated
+    ? expectedInput
+    : expectedInput * UNCALIBRATED_SAFETY;
+  // Cost-aware cap: smaller of the API limit and the cost-derived cap
+  // (0 = disabled → pure maxInput).
+  let layer0Ceiling =
+    maxLayer0Tokens > 0 ? Math.min(maxInput, maxLayer0Tokens) : maxInput;
+  // Cold-cache awareness: the entire context is a cache WRITE on an
+  // uncalibrated turn — tighten the cap to 70% to reduce cold-write cost.
+  if (!calibrated && layer0Ceiling < maxInput) {
+    layer0Ceiling = Math.floor(layer0Ceiling * 0.7);
+  }
+  // Free-write / non-caching: no expensive write to avoid → compress earlier.
+  if (sid && isFreeWriteSession(sid)) {
+    layer0Ceiling = Math.min(
+      layer0Ceiling,
+      Math.floor(maxInput * FREE_WRITE_LAYER0_FRACTION),
+    );
+  }
+  return { layer0Input, layer0Ceiling };
+}
+
+/**
+ * Will an uncalibrated (first-sight) session of this size be forced to skip
+ * Layer-0 passthrough and compress on its cold turn? Pure, read-only.
+ *
+ * Used by the gateway pipeline to decide whether to inject context-bound LTM
+ * (system[2]) on turn 1 for an already-large resumed session instead of
+ * deferring to turn 2. Returns false once the session is calibrated
+ * (lastKnownInput > 0) — by then the normal per-turn logic applies.
+ *
+ * Shares layer0Bounds() with transformInner, so the caller can make the two
+ * agree EXACTLY: pass `ltmTokens` = the LTM tokens that will be set for this
+ * turn when system[2] is NOT injected (i.e. the stable/preference block only).
+ * Then on a "not large" result the pipeline skips system[2] and calls
+ * setLtmTokens(stableOnly), so transformInner's expectedInput equals the value
+ * tested here — no decision-vs-compression drift band. (#796)
+ */
+export function isLargeColdStart(input: {
+  messages: MessageWithParts[];
+  sessionID?: string;
+  /** Override the session's in-flight LTM token count (see docstring). */
+  ltmTokens?: number;
+}): boolean {
+  const sid = input.sessionID ?? input.messages[0]?.info.sessionID;
+  const sessState = sid ? getSessionState(sid) : makeSessionState();
+  if (sessState.lastKnownInput > 0) return false;
+  const overhead = getOverhead();
+  const sessLtmTokens =
+    input.ltmTokens ?? (sid ? sessState.ltmTokens : ltmTokensFallback);
+  const expectedInput =
+    estimateMessages(input.messages) + overhead + sessLtmTokens;
+  const { layer0Input, layer0Ceiling } = layer0Bounds(
+    expectedInput,
+    false,
+    sid,
+  );
+  return layer0Input > layer0Ceiling;
+}
+
 function transformInner(input: {
   messages: MessageWithParts[];
   projectPath: string;
@@ -2094,11 +2186,6 @@ function transformInner(input: {
   // from the real tokenizer — so tryFit output must be validated with a safety
   // multiplier before being used.
   const calibrated = sessState.lastKnownInput > 0;
-
-  // On uncalibrated turns, apply this multiplier to tryFit's estimated total to
-  // approximate the real token count. chars/3 undercounts by ~1.68x on real data,
-  // but overhead EMA captures most of the gap. 1.5 provides a safe margin.
-  const UNCALIBRATED_SAFETY = 1.5;
 
   // Hard ceiling: never allow layer-0 passthrough within 5% of maxInput,
   // regardless of calibration accuracy or economic analysis.  The estimation
@@ -2238,32 +2325,26 @@ function transformInner(input: {
     expectedInput = messageTokens + overhead + sessLtmTokens;
   }
 
-  // When uncalibrated, apply safety multiplier to the layer-0 decision too.
-  // chars/3 undercounts by ~1.63x on real sessions — without this, a session
-  // estimated at 146K passes layer 0 but actually costs 214K → overflow.
-  const layer0Input = calibrated
-    ? expectedInput
-    : expectedInput * UNCALIBRATED_SAFETY;
+  // Layer-0 sizing (input estimate + ceiling). Extracted to layer0Bounds() so
+  // the pipeline's turn-1 LTM decision (isLargeColdStart) shares ONE definition
+  // with the layer choice here — a disagreement would re-introduce a bust. (#796)
+  const { layer0Input, layer0Ceiling } = layer0Bounds(
+    expectedInput,
+    calibrated,
+    sid,
+  );
 
-  // Cost-aware layer-0 cap: use the smaller of the API limit and the cost-derived
-  // cap. When maxLayer0Tokens is 0 (disabled), fall back to pure maxInput.
-  let layer0Ceiling =
-    maxLayer0Tokens > 0 ? Math.min(maxInput, maxLayer0Tokens) : maxInput;
-
-  // Cold-cache awareness: on the first turn (uncalibrated = no prior API data),
-  // the entire context is a cache WRITE at 12.5× the cache-read price. Use 70%
-  // of the normal cap to reduce the cold-write cost.
-  if (!calibrated && layer0Ceiling < maxInput) {
-    layer0Ceiling = Math.floor(layer0Ceiling * 0.7);
-  }
-
-  // Free-write cache / non-caching: no expensive cache writes to avoid, so
-  // compress earlier to leave headroom for tool-heavy turns.
-  if (sid && isFreeWriteSession(sid)) {
-    layer0Ceiling = Math.min(
-      layer0Ceiling,
-      Math.floor(maxInput * FREE_WRITE_LAYER0_FRACTION),
-    );
+  // First-sight large session → skip the Layer-0 cold full-write. An
+  // uncalibrated session already over the Layer-0 ceiling is a resumed
+  // conversation Lore hasn't tracked in-process. Passing it through at Layer 0
+  // writes the entire raw body on a cold cache; the next (calibrated) turn then
+  // re-windows to Layer 1 (a second full write), and LTM injection adds a third
+  // (system[2]) bust. Compressing now collapses all of that into the single
+  // unavoidable cold write. Mirrors postIdleCompact's "cache write regardless"
+  // rationale: the tier gate's continue-at-Layer-0 economics assume a WARM
+  // cache, which does not exist on a cold turn. (issue #796)
+  if (!calibrated && layer0Input > layer0Ceiling) {
+    effectiveMinLayer = Math.max(effectiveMinLayer, 1) as SafetyLayer;
   }
 
   if (

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -89,6 +89,8 @@ export {
   type DailyCostBucket,
   saveSessionTracking,
   loadSessionTracking,
+  findSessionStatesByFingerprint,
+  countMatchingTemporalIds,
   appendSessionPromptDelta,
   upsertSessionPromptDelta,
   deleteSessionPromptDelta,
@@ -158,6 +160,7 @@ export {
   getConsecutiveBusts,
   BUST_PRESSURE_THRESHOLD,
   effectiveMetaThreshold,
+  isLargeColdStart,
 } from "./gradient";
 export {
   formatKnowledge,

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -17,6 +17,8 @@ import {
   setLastImportAt,
   saveSessionTracking,
   loadSessionTracking,
+  findSessionStatesByFingerprint,
+  countMatchingTemporalIds,
   appendSessionPromptDelta,
   listSessionPromptDeltas,
   loadHeaderSessionIndex,
@@ -56,7 +58,7 @@ describe("db", () => {
     const row = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(row.version).toBe(43);
+    expect(row.version).toBe(44);
   });
 
   test("session_prompt_deltas persist ordered selector/content rows (v42)", () => {
@@ -914,6 +916,7 @@ describe("db", () => {
       ltmPinTokens: 90,
       ltmPinKeys: JSON.stringify(["a:1", "b:2"]),
       dedupDecisions: JSON.stringify([["m1:p1", true]]),
+      lastKnownMessageCount: 137,
     });
     const loaded = loadSessionTracking(sid);
     expect(loaded).not.toBeNull();
@@ -926,6 +929,8 @@ describe("db", () => {
     expect(loaded?.ltmPinTokens).toBe(90);
     expect(loaded?.ltmPinKeys).toBe(JSON.stringify(["a:1", "b:2"]));
     expect(loaded?.dedupDecisions).toBe(JSON.stringify([["m1:p1", true]]));
+    // v43: persisted for accurate calibrated-delta estimation after restart.
+    expect(loaded?.lastKnownMessageCount).toBe(137);
   });
 
   test("saveSessionTracking partial update preserves other fields", () => {
@@ -1499,6 +1504,129 @@ describe("db", () => {
       const names = idx.map((i) => i.name);
       expect(names).toContain("idx_tool_calls_project_tool_status");
       expect(names).toContain("idx_tool_calls_project_session");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Migration v43: persist lastKnownMessageCount + restart-proof session
+  // adoption helpers (issue #796)
+  // -------------------------------------------------------------------------
+
+  describe("session adoption helpers (v43)", () => {
+    test("session_state has last_known_message_count column", () => {
+      const cols = db()
+        .query("PRAGMA table_info(session_state)")
+        .all() as Array<{ name: string }>;
+      expect(cols.map((c) => c.name)).toContain("last_known_message_count");
+    });
+
+    test("recoverMissingObjects re-adds last_known_message_count when missing", () => {
+      const d = db();
+      d.exec("ALTER TABLE session_state DROP COLUMN last_known_message_count");
+      expect(
+        (
+          d.query("PRAGMA table_info(session_state)").all() as Array<{
+            name: string;
+          }>
+        ).some((c) => c.name === "last_known_message_count"),
+      ).toBe(false);
+
+      close();
+      const fresh = db();
+      expect(
+        (
+          fresh.query("PRAGMA table_info(session_state)").all() as Array<{
+            name: string;
+          }>
+        ).some((c) => c.name === "last_known_message_count"),
+      ).toBe(true);
+    });
+
+    test("findSessionStatesByFingerprint returns only matching non-empty fingerprints", () => {
+      const sidA = `adopt-a-${crypto.randomUUID()}`;
+      const sidB = `adopt-b-${crypto.randomUUID()}`;
+      const sidOther = `adopt-other-${crypto.randomUUID()}`;
+      const sidEmpty = `adopt-empty-${crypto.randomUUID()}`;
+      const fp = `fp-${crypto.randomUUID().slice(0, 8)}`;
+      saveSessionTracking(sidA, { fingerprint: fp, messageCount: 100 });
+      saveSessionTracking(sidB, {
+        fingerprint: fp,
+        messageCount: 200,
+        isSubagent: true,
+      });
+      saveSessionTracking(sidOther, {
+        fingerprint: `other-${crypto.randomUUID().slice(0, 8)}`,
+        messageCount: 50,
+      });
+      // Empty fingerprint must never be returned (default for untracked rows).
+      saveSessionTracking(sidEmpty, { fingerprint: "", messageCount: 10 });
+
+      const got = findSessionStatesByFingerprint(fp);
+      const bySid = new Map(got.map((r) => [r.session_id, r]));
+      expect(bySid.has(sidA)).toBe(true);
+      expect(bySid.has(sidB)).toBe(true);
+      expect(bySid.has(sidOther)).toBe(false);
+      expect(bySid.has(sidEmpty)).toBe(false);
+      expect(bySid.get(sidA)?.message_count).toBe(100);
+      expect(bySid.get(sidB)?.is_subagent).toBe(1);
+      expect(bySid.get(sidA)?.is_subagent).toBe(0);
+
+      // Empty query never matches the empty-fingerprint rows.
+      expect(findSessionStatesByFingerprint("")).toEqual([]);
+    });
+
+    test("countMatchingTemporalIds counts only same-project, same-session ids", () => {
+      const pidA = ensureProject(`/tmp/adopt-overlap-a-${crypto.randomUUID()}`);
+      const pidB = ensureProject(`/tmp/adopt-overlap-b-${crypto.randomUUID()}`);
+      const sess = `ov-sess-${crypto.randomUUID()}`;
+      const ins = (pid: string, sid: string, id: string) =>
+        db()
+          .query(
+            `INSERT INTO temporal_messages
+               (id, project_id, session_id, role, content, tokens, distilled, created_at)
+             VALUES (?, ?, ?, 'user', 'x', 1, 0, 1000)`,
+          )
+          .run(id, pid, sid);
+      ins(pidA, sess, "m1");
+      ins(pidA, sess, "m2");
+      ins(pidA, sess, "m3");
+      ins(pidA, "other-sess", "m9"); // same project, different session
+      ins(pidB, sess, "mb"); // different project, same session id
+
+      // 2 of the 3 probed ids exist in (pidA, sess); "x" does not.
+      expect(countMatchingTemporalIds(pidA, sess, ["m1", "m2", "x"])).toBe(2);
+      // Different session → no overlap.
+      expect(countMatchingTemporalIds(pidA, "other-sess", ["m1", "m2"])).toBe(
+        0,
+      );
+      // Different project → no overlap.
+      expect(countMatchingTemporalIds(pidB, sess, ["m1", "m2", "m3"])).toBe(0);
+      // Empty id list → 0, no query error.
+      expect(countMatchingTemporalIds(pidA, sess, [])).toBe(0);
+    });
+
+    test("countMatchingTemporalIds chunks id lists beyond the SQLite variable limit", () => {
+      const pid = ensureProject(`/tmp/adopt-chunk-${crypto.randomUUID()}`);
+      const sess = `chunk-sess-${crypto.randomUUID()}`;
+      const real: string[] = [];
+      for (let i = 0; i < 5; i++) {
+        const id = `real-${i}`;
+        real.push(id);
+        db()
+          .query(
+            `INSERT INTO temporal_messages
+               (id, project_id, session_id, role, content, tokens, distilled, created_at)
+             VALUES (?, ?, ?, 'user', 'x', 1, 0, 1000)`,
+          )
+          .run(id, pid, sess);
+      }
+      // 1200 ids (>999 SQLite bound-variable limit) — must not throw and must
+      // count only the 5 that exist.
+      const ids = [
+        ...real,
+        ...Array.from({ length: 1195 }, (_, i) => `fake-${i}`),
+      ];
+      expect(countMatchingTemporalIds(pid, sess, ids)).toBe(5);
     });
   });
 

--- a/packages/core/test/gradient.test.ts
+++ b/packages/core/test/gradient.test.ts
@@ -38,6 +38,9 @@ import {
   selectDistillations,
   exportDedupDecisions,
   importDedupDecisions,
+  isLargeColdStart,
+  saveGradientState,
+  evictSession,
   type ModelBudget,
 } from "../src/gradient";
 import type { LoreMessage, LorePart, LoreMessageWithParts } from "../src/types";
@@ -5111,5 +5114,175 @@ describe("gradient — per-session model budget (RC2: cross-model contamination)
       budget: noPriceBudget,
     });
     expect(getCachePricing()).toEqual({ write: 0, read: 0 });
+  });
+});
+
+// ===========================================================================
+// Issue #796: restart-proof calibration + cold-start large-session handling
+// ===========================================================================
+
+describe("issue #796: lastKnownMessageCount persistence", () => {
+  test("persists to DB via saveGradientState and restores after eviction", () => {
+    const sid = `lkmc-${crypto.randomUUID()}`;
+    resetCalibration(sid);
+    setModelLimits({ context: 10_000, output: 2_000 });
+    // calibrate() records lastKnownInput + lastKnownMessageCount in memory.
+    calibrate(50_000, sid, 250);
+    // lastTurnAt > 0 is the proxy that gates the atomic restore in getSessionState.
+    setLastTurnAtForTest(sid, Date.now());
+    saveGradientState(sid);
+
+    // Simulate restart: drop the in-memory state.
+    evictSession(sid);
+    expect(inspectSessionState(sid)).toBeNull();
+
+    // Any getSessionState-driven call restores from DB; setLtmTokens is benign.
+    setLtmTokens(0, sid);
+    expect(inspectSessionState(sid)?.lastKnownMessageCount).toBe(250);
+
+    // Reset shared baseline.
+    setModelLimits({ context: 10_000, output: 2_000 });
+    calibrate(0);
+  });
+});
+
+describe("issue #796: isLargeColdStart + cold-start force-compress", () => {
+  // Build N messages with enough text to exceed a low Layer-0 ceiling.
+  function bulk(sessionID: string, n: number, pad: string) {
+    return Array.from({ length: n }, (_, i) =>
+      makeMsg(
+        `${sessionID}-${i}`,
+        i % 2 === 0 ? "user" : "assistant",
+        `Message ${i}: ${pad}`,
+        sessionID,
+      ),
+    );
+  }
+
+  function configureLowCeiling() {
+    // maxInput = 5000, usable = 5000, rawBudget = 2000.
+    setModelLimits({ context: 6_000, output: 1_000 });
+    calibrate(0); // zero overhead
+    setMaxLayer0Tokens(500); // ceiling base 500, uncalibrated ×0.7 = 350
+    setCachePricing(0, 0); // no pricing → shouldCompress() = false (tier gate keeps Layer 0)
+  }
+
+  function resetBaseline() {
+    setModelLimits({ context: 10_000, output: 2_000 });
+    setMaxLayer0Tokens(0);
+    calibrate(0);
+  }
+
+  test("isLargeColdStart is true for a large uncalibrated session", () => {
+    configureLowCeiling();
+    const sid = `cold-large-${crypto.randomUUID()}`;
+    const messages = bulk(sid, 30, "padding text to take up token space here");
+    // Precondition: clearly over the ~350 ceiling after the ×1.5 uncalibrated factor.
+    expect(estimateMessages(messages)).toBeGreaterThan(500);
+    expect(isLargeColdStart({ messages, sessionID: sid })).toBe(true);
+    resetBaseline();
+  });
+
+  test("isLargeColdStart is false for a small uncalibrated session", () => {
+    configureLowCeiling();
+    const sid = `cold-small-${crypto.randomUUID()}`;
+    const messages = [
+      makeMsg(`${sid}-1`, "user", "hi", sid),
+      makeMsg(`${sid}-2`, "assistant", "hello", sid),
+    ];
+    expect(isLargeColdStart({ messages, sessionID: sid })).toBe(false);
+    resetBaseline();
+  });
+
+  test("isLargeColdStart is false once the session is calibrated, even when large", () => {
+    configureLowCeiling();
+    const sid = `cold-calibrated-${crypto.randomUUID()}`;
+    const messages = bulk(sid, 30, "padding text to take up token space here");
+    // Calibrate the session (lastKnownInput > 0) — no longer a cold start.
+    calibrate(50_000, sid, 30);
+    expect(isLargeColdStart({ messages, sessionID: sid })).toBe(false);
+    resetBaseline();
+  });
+
+  test("isLargeColdStart honors the ltmTokens hint (Part A/B alignment)", () => {
+    // A small session that is NOT a cold start on its own becomes one once the
+    // about-to-be-injected LTM tokens push it over the ceiling. The pipeline
+    // passes the stable-LTM token count as this hint so the turn-1 LTM decision
+    // matches what the gradient transform will see. (#796)
+    configureLowCeiling();
+    const sid = `cold-ltm-hint-${crypto.randomUUID()}`;
+    const messages = [
+      makeMsg(`${sid}-1`, "user", "hi", sid),
+      makeMsg(`${sid}-2`, "assistant", "hello", sid),
+    ];
+    // Without the hint: tiny → not a cold start.
+    expect(isLargeColdStart({ messages, sessionID: sid })).toBe(false);
+    // With a large LTM hint: now over the ceiling → cold start. If the param
+    // were ignored, this would still be false.
+    expect(
+      isLargeColdStart({ messages, sessionID: sid, ltmTokens: 1000 }),
+    ).toBe(true);
+    resetBaseline();
+  });
+
+  test("transform forces layer >= 1 for a large uncalibrated session (would be Layer 0 without the fix)", () => {
+    configureLowCeiling();
+    const sid = `cold-force-${crypto.randomUUID()}`;
+    const messages = bulk(sid, 30, "padding text to take up token space here");
+    // Sanity: the tier gate would otherwise pass this through at Layer 0 (no
+    // pricing → shouldCompress() = false). The cold-start force-compress flips it.
+    const result = transform({
+      messages,
+      projectPath: PROJECT,
+      sessionID: sid,
+    });
+    expect(result.layer).toBeGreaterThanOrEqual(1);
+    resetBaseline();
+  });
+
+  test("transform stays at Layer 0 for a small uncalibrated session (no over-fire)", () => {
+    configureLowCeiling();
+    const sid = `cold-small-pass-${crypto.randomUUID()}`;
+    const messages = [
+      makeMsg(`${sid}-1`, "user", "hi", sid),
+      makeMsg(`${sid}-2`, "assistant", "hello", sid),
+    ];
+    const result = transform({
+      messages,
+      projectPath: PROJECT,
+      sessionID: sid,
+    });
+    expect(result.layer).toBe(0);
+    resetBaseline();
+  });
+
+  // Scope: this validates gradient-level agreement at EQUAL ltm tokens (neither
+  // call injects LTM between them). The pipeline closes the remaining
+  // decision-vs-compression band by passing setLtmTokens's stable count as the
+  // isLargeColdStart `ltmTokens` hint — exercised by the "honors the ltmTokens
+  // hint" test above. (#796)
+  test("isLargeColdStart agrees with transform's layer decision (drift guard)", () => {
+    configureLowCeiling();
+    for (const [n, pad] of [
+      [30, "padding text to take up token space here"],
+      [2, ""],
+    ] as const) {
+      const sid = `cold-agree-${n}-${crypto.randomUUID()}`;
+      const messages =
+        n === 2
+          ? [
+              makeMsg(`${sid}-1`, "user", "hi", sid),
+              makeMsg(`${sid}-2`, "assistant", "ok", sid),
+            ]
+          : bulk(sid, n, pad);
+      const predicted = isLargeColdStart({ messages, sessionID: sid });
+      const result = transform({
+        messages,
+        projectPath: PROJECT,
+        sessionID: sid,
+      });
+      expect(predicted).toBe(result.layer >= 1);
+    }
+    resetBaseline();
   });
 });

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -16,6 +16,8 @@ import {
   load,
   config as loreConfig,
   ensureProject,
+  findSessionStatesByFingerprint,
+  countMatchingTemporalIds,
   projectId,
   projectGitRemote,
   mergeProjectInternal,
@@ -27,6 +29,7 @@ import {
   curator,
   log,
   transform,
+  isLargeColdStart,
   setModelLimits,
   setLtmTokens,
   getLtmBudget,
@@ -151,6 +154,7 @@ import {
   gatewayMessagesToLore,
   updateAssistantMessageTokens,
   resolveToolResults,
+  deterministicID,
 } from "./temporal-adapter";
 import { createGatewayLLMClient } from "./llm-adapter";
 import { createBatchLLMClient } from "./batch-queue";
@@ -2363,9 +2367,116 @@ export function stripContextMarkers(messages: GatewayMessage[]): void {
   }
 }
 
+/** How many leading messages to probe for content-hash overlap when adopting a
+ *  resumed session after a restart (Tier 3b, issue #796). */
+const ADOPT_PROBE_MESSAGES = 16;
+/** Minimum confirmed user-message overlap to adopt a fingerprint-matched
+ *  candidate — requires evidence beyond the (fingerprint-implied) first message. */
+const ADOPT_MIN_OVERLAP = 2;
+
+/**
+ * Restart-proof session adoption (issue #796). Recovers a prior session for a
+ * resumed conversation from its persisted fingerprint, CONFIRMS it by
+ * content-hash overlap of the leading USER messages, and ADOPTS its id so the
+ * conversation inherits the prior distillations, gradient calibration, and LTM
+ * pin. Returns the adopted session (isNew=false) or null when no candidate is
+ * confidently confirmed.
+ *
+ * Confirmation uses user messages only: temporal storage persists user messages
+ * with position-stable deterministic IDs, while assistant responses are stored
+ * under a synthetic index-0 ID — so only user messages are a reliable
+ * cross-restart match signal. The project_id scope of the overlap query also
+ * enforces same-project (a cross-project fingerprint twin yields zero overlap).
+ * Subagent status must match, and a fork guard rejects a count that dropped far
+ * below the candidate's stored count.
+ *
+ * Called from BOTH mint paths: the Tier-1 path (known header present but its
+ * value is new — the opencode restart case; `known` is rebound to the adopted
+ * sid for a future Tier-1 fast path) and the Tier-3 path (no known header).
+ */
+async function adoptByFingerprint(input: {
+  req: GatewayRequest;
+  headers: Record<string, string>;
+  projectPath: string;
+  known: { headerName: string; sessionId: string } | null;
+  msgCount: number;
+}): Promise<{ sessionID: string; isNew: false; tier: 3 } | null> {
+  const { req, headers, projectPath, known, msgCount } = input;
+  if (!projectPath) return null;
+
+  const cred = extractAuth(req.rawHeaders);
+  const fingerprint = await fingerprintMessages(
+    req.messages.map((m) => ({ role: m.role, content: m.content })),
+    { authSuffix: cred ? authFingerprint(cred) : "" },
+  );
+
+  const reqIsSubagent = !!headers["x-parent-session-id"];
+  const candidates = findSessionStatesByFingerprint(fingerprint).filter(
+    (c) => (c.is_subagent === 1) === reqIsSubagent,
+  );
+  if (candidates.length === 0) return null;
+
+  // Hash the leading user messages by their absolute index (the only
+  // position-stable IDs in temporal storage). NOTE: identifySession runs before
+  // stripContextMarkers, so these IDs (and the fingerprint above) are computed
+  // from UN-stripped content, while stored IDs are post-strip. Adoption thus
+  // assumes the LEADING user messages are marker-free; a `[lore:...]` marker in
+  // an early message only lowers overlap (graceful miss → no adoption), never a
+  // false positive. The primary target (opencode x-lore-session-id) sends no
+  // such markers, and marker clients carry them on the latest turn only.
+  const probeIDs: string[] = [];
+  let probedUsers = 0;
+  const probeLimit = Math.min(req.messages.length, ADOPT_PROBE_MESSAGES);
+  for (let i = 0; i < probeLimit; i++) {
+    const m = req.messages[i];
+    if (m.role !== "user") continue;
+    probedUsers++;
+    probeIDs.push(deterministicID(m.role, i, m.content));
+  }
+  if (probeIDs.length < ADOPT_MIN_OVERLAP) return null;
+
+  const pid = ensureProject(projectPath);
+  const minOverlap = Math.max(ADOPT_MIN_OVERLAP, Math.ceil(probedUsers * 0.5));
+  let best: { sid: string; overlap: number; countDiff: number } | null = null;
+  for (const c of candidates) {
+    // Fork guard (mirrors the in-memory Tier-3 scan): a count that dropped far
+    // below the stored count is a fork, not a resume.
+    if (msgCount - c.message_count < -MESSAGE_COUNT_PROXIMITY_THRESHOLD) {
+      continue;
+    }
+    const overlap = countMatchingTemporalIds(pid, c.session_id, probeIDs);
+    if (overlap < minOverlap) continue;
+    const countDiff = Math.abs(msgCount - c.message_count);
+    if (
+      !best ||
+      overlap > best.overlap ||
+      (overlap === best.overlap && countDiff < best.countDiff)
+    ) {
+      best = { sid: c.session_id, overlap, countDiff };
+    }
+  }
+  if (!best) return null;
+
+  // When a known header is present, rebind it → adopted sid so future turns
+  // identify via the Tier 1 fast path (and stop re-confirming overlap).
+  if (known) {
+    headerSessionIndex.set(`${known.headerName}:${known.sessionId}`, best.sid);
+    saveSessionTracking(best.sid, {
+      headerSessionId: known.sessionId,
+      headerName: known.headerName,
+    });
+  }
+  log.info(
+    `adopted prior session ${best.sid.slice(0, 16)} for resumed conversation ` +
+      `(overlap=${best.overlap}/${probedUsers}` +
+      `${known ? `, header=${known.headerName}` : ""})`,
+  );
+  return { sessionID: best.sid, isNew: false, tier: 3 };
+}
+
 async function identifySession(
   req: GatewayRequest,
-  _projectPath: string,
+  projectPath: string,
 ): Promise<{ sessionID: string; isNew: boolean; tier: 1 | 2 | 2.5 | 3 }> {
   const headers = req.rawHeaders;
 
@@ -2521,6 +2632,20 @@ async function identifySession(
       return { sessionID: predecessor.sid, isNew: false, tier: 1 };
     }
 
+    // --- Tier 1 → 3b: restart-proof adoption ---
+    // The known header value is new and rotation found no predecessor. Before
+    // minting a fresh session, try to adopt a prior session for this same
+    // conversation (resumed after a restart under a new x-lore-session-id) via
+    // its persisted fingerprint + content-hash overlap. (issue #796)
+    const adopted = await adoptByFingerprint({
+      req,
+      headers,
+      projectPath,
+      known,
+      msgCount: req.messages.length,
+    });
+    if (adopted) return adopted;
+
     // Genuinely new session — no predecessor or ambiguous concurrent sessions.
     const sessionID = generateSessionID();
     headerSessionIndex.set(indexKey, sessionID);
@@ -2613,6 +2738,21 @@ async function identifySession(
     }
     return { sessionID: bestMatch.sid, isNew: false, tier: 3 };
   }
+
+  // --- Tier 3b: DB-backed fingerprint adoption (restart-proof) ---
+  // The in-memory scan above is empty after a restart, so it can never rematch
+  // a resumed conversation. For a header-less client, recover + adopt the prior
+  // session from its persisted fingerprint, confirmed by content overlap. (The
+  // header-bearing case — e.g. opencode's x-lore-session-id — is handled in the
+  // Tier 1 mint path above.) (issue #796)
+  const adopted = await adoptByFingerprint({
+    req,
+    headers,
+    projectPath,
+    known: null,
+    msgCount,
+  });
+  if (adopted) return adopted;
 
   // No matching session → create new.
   const sessionID = generateSessionID();
@@ -5455,6 +5595,12 @@ async function handleConversationTurn(
     );
   }
 
+  // Build the Lore message array once (resolved) — shared by the turn-1 LTM
+  // decision below (isLargeColdStart) and the gradient transform in step 7, so
+  // both see identical input and agree on whether this cold session compresses.
+  const loreMessages = gatewayMessagesToLore(req.messages, sessionID);
+  resolveToolResults(loreMessages);
+
   // --- 6. LTM injection (3-block system prompt for cache efficiency) ---
   // system[0]: Host prompt              [no cache_control]
   // system[1]: Stable LTM (preferences) [cache_control: 1h] — pinned ≥1h
@@ -5558,10 +5704,33 @@ async function handleConversationTurn(
       }
       stableLtmText = stable?.formatted;
 
+      // Fallback for a genuinely-new but already-large session (no prior session
+      // to adopt — e.g. a transcript imported from another machine): the gradient
+      // will compress it on turn 1 (see gradient.isLargeColdStart), so inject
+      // context-bound LTM (system[2]) NOW instead of deferring to turn 2,
+      // collapsing the turn-2 system[2] bust and the turn-3 Layer 0→1 bust into
+      // the single cold write. Pass the stable-LTM token count as the ltm hint:
+      // when this returns false we skip system[2] and setLtmTokens(stableOnly),
+      // so the gradient transform sees the SAME expectedInput tested here — no
+      // decision-vs-compression drift band. (Adopted/resumed sessions are
+      // calibrated, so this is false for them — the restored pin handles
+      // system[2].) (issue #796)
+      const largeColdStart =
+        isFirstTurn &&
+        isLargeColdStart({
+          messages: loreMessages,
+          sessionID,
+          ltmTokens: stable?.tokenCount ?? 0,
+        });
+
       // --- system[2]: Context-bound LTM (non-preference entries) ---
       // Deferred to turn 2+ when real session context exists for relevance
-      // scoring. On turn 1, only stable LTM (preferences) is injected.
-      if (!isFirstTurn) {
+      // scoring. On turn 1, only stable LTM (preferences) is injected — EXCEPT
+      // for an already-large cold start (largeColdStart), where we inject now so
+      // LTM + the turn-1 compression are decided together (relevance scoring
+      // still works: contextHint comes from the incoming request, not temporal
+      // storage). (issue #796)
+      if (!isFirstTurn || largeColdStart) {
         let cached = ltmSessionCache.get(sessionID);
         // Entry-set keys for the *freshly computed* selection. Only populated
         // on the recompute path (when ltmSessionCache was cold/invalidated) —
@@ -5778,9 +5947,8 @@ async function handleConversationTurn(
   }
 
   // --- 7. Gradient transform on messages ---
-  const loreMessages = gatewayMessagesToLore(req.messages, sessionID);
-  resolveToolResults(loreMessages);
-
+  // loreMessages was built + resolved once before the LTM block (step 6) so the
+  // turn-1 LTM decision and this transform share identical input. Reuse it.
   const result = transform({
     messages: loreMessages,
     projectPath,

--- a/packages/gateway/src/temporal-adapter.ts
+++ b/packages/gateway/src/temporal-adapter.ts
@@ -37,7 +37,7 @@ import { blocksToText } from "./translate/types";
  * Same message at the same position produces the same ID across requests,
  * which is critical for gradient prefix fingerprinting and cache-bust detection.
  */
-function deterministicID(
+export function deterministicID(
   role: string,
   index: number,
   content: GatewayContentBlock[],

--- a/packages/gateway/test/session-adoption.e2e.test.ts
+++ b/packages/gateway/test/session-adoption.e2e.test.ts
@@ -1,0 +1,206 @@
+/**
+ * End-to-end regression tests for restart-proof session adoption (issue #796).
+ *
+ * Scenario: a long conversation is distilled, then lore+opencode RESTART, and
+ * the client resumes the conversation under a FRESH `x-lore-session-id`. Before
+ * the fix, the in-memory session index is empty after a restart and the
+ * persisted fingerprint is not value-searchable, so the resumed conversation
+ * was treated as brand-new — orphaning the prior session's distillations,
+ * gradient calibration, and LTM pin.
+ *
+ * Tier 3b recovers the prior session from its persisted fingerprint, CONFIRMS
+ * it by content-hash overlap of the leading user messages (scoped to the
+ * project), and ADOPTS its id — so the resumed conversation inherits the prior
+ * state instead of cold-starting.
+ *
+ * These tests drive the full pipeline (handleRequest -> identifySession) through
+ * the real HTTP server, simulate a restart via `harness.restartPipeline()`
+ * (clears in-memory maps, keeps the DB), and assert on session_state rows.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import type { Harness } from "./helpers/harness";
+import { createHarness } from "./helpers/harness";
+import {
+  makeFixtureEntry,
+  STANDARD_TOOLS,
+  DEFAULT_MODEL,
+  DEFAULT_SYSTEM,
+} from "./helpers/fixtures";
+
+const U0 = "alpha first task: please implement the parser module";
+const U1 = "second follow-up: now add tests for the parser";
+const U2 = "third instruction after the restart: refactor the helper";
+
+function body(messages: Array<{ role: string; content: string }>) {
+  return {
+    model: DEFAULT_MODEL,
+    max_tokens: 1024,
+    stream: false,
+    system: DEFAULT_SYSTEM,
+    messages,
+    tools: STANDARD_TOOLS,
+  };
+}
+
+// Replay is order-based and ignores request content, so plain text fixtures
+// suffice; assistant text does not affect user-message content-hash IDs.
+function fixtures() {
+  return [
+    makeFixtureEntry({ seq: 0, requestMessages: [], responseText: "A0 done." }),
+    makeFixtureEntry({ seq: 1, requestMessages: [], responseText: "A1 done." }),
+    makeFixtureEntry({ seq: 2, requestMessages: [], responseText: "A2 done." }),
+  ];
+}
+
+type Row = { session_id: string; header_session_id: string | null };
+
+function loreSessionRows(h: Harness): Row[] {
+  return h.queryDB<Row>(
+    "SELECT session_id, header_session_id FROM session_state WHERE header_name = 'x-lore-session-id'",
+  );
+}
+
+describe("issue #796: restart-proof session adoption (Tier 3b)", () => {
+  let harness: Harness;
+
+  afterEach(async () => {
+    await harness?.teardown();
+  });
+
+  it("adopts the prior session when a resumed conversation arrives under a new x-lore-session-id after restart", async () => {
+    harness = await createHarness({ fixtures: fixtures() });
+
+    // Turn 1 (new session under V1) — persists fingerprint + stores u0.
+    let r = await harness.chat(body([{ role: "user", content: U0 }]), "key-A", {
+      "x-lore-session-id": "V1",
+    });
+    expect(r.status).toBe(200);
+    await r.text();
+
+    // Turn 2 (same session V1 continues) — stores u1, updates message_count.
+    r = await harness.chat(
+      body([
+        { role: "user", content: U0 },
+        { role: "assistant", content: "A0 done." },
+        { role: "user", content: U1 },
+      ]),
+      "key-A",
+      { "x-lore-session-id": "V1" },
+    );
+    expect(r.status).toBe(200);
+    await r.text();
+
+    // Exactly one conversation session so far, bound to V1.
+    let rows = loreSessionRows(harness);
+    expect(rows.length).toBe(1);
+    expect(rows[0].header_session_id).toBe("V1");
+    const s1 = rows[0].session_id;
+
+    // --- Simulate restart: in-memory maps cleared, DB preserved. ---
+    await harness.restartPipeline();
+
+    // Resume the SAME conversation under a NEW x-lore-session-id (V2).
+    r = await harness.chat(
+      body([
+        { role: "user", content: U0 },
+        { role: "assistant", content: "A0 done." },
+        { role: "user", content: U1 },
+        { role: "assistant", content: "A1 done." },
+        { role: "user", content: U2 },
+      ]),
+      "key-A",
+      { "x-lore-session-id": "V2" },
+    );
+    expect(r.status).toBe(200);
+    await r.text();
+
+    // Adopted: still ONE conversation session (no new row), same internal id,
+    // now rebound to the new header value for the Tier-1 fast path.
+    rows = loreSessionRows(harness);
+    expect(rows.length).toBe(1);
+    expect(rows[0].session_id).toBe(s1);
+    expect(rows[0].header_session_id).toBe("V2");
+  });
+
+  it("does NOT adopt when the resumed conversation has a different fingerprint (different first message)", async () => {
+    harness = await createHarness({ fixtures: fixtures() });
+
+    let r = await harness.chat(body([{ role: "user", content: U0 }]), "key-A", {
+      "x-lore-session-id": "V1",
+    });
+    expect(r.status).toBe(200);
+    await r.text();
+    r = await harness.chat(
+      body([
+        { role: "user", content: U0 },
+        { role: "assistant", content: "A0 done." },
+        { role: "user", content: U1 },
+      ]),
+      "key-A",
+      { "x-lore-session-id": "V1" },
+    );
+    expect(r.status).toBe(200);
+    await r.text();
+
+    await harness.restartPipeline();
+
+    // A genuinely different conversation (different first user message) under a
+    // new header → fingerprint miss → must create a NEW session, not adopt.
+    r = await harness.chat(
+      body([{ role: "user", content: "completely unrelated opening task" }]),
+      "key-A",
+      { "x-lore-session-id": "V2" },
+    );
+    expect(r.status).toBe(200);
+    await r.text();
+
+    const rows = loreSessionRows(harness);
+    expect(rows.length).toBe(2);
+  });
+
+  it("does NOT adopt across projects (overlap is project-scoped)", async () => {
+    harness = await createHarness({ fixtures: fixtures() });
+
+    let r = await harness.chat(body([{ role: "user", content: U0 }]), "key-A", {
+      "x-lore-session-id": "V1",
+    });
+    expect(r.status).toBe(200);
+    await r.text();
+    r = await harness.chat(
+      body([
+        { role: "user", content: U0 },
+        { role: "assistant", content: "A0 done." },
+        { role: "user", content: U1 },
+      ]),
+      "key-A",
+      { "x-lore-session-id": "V1" },
+    );
+    expect(r.status).toBe(200);
+    await r.text();
+
+    await harness.restartPipeline();
+
+    // Same fingerprint (same first message + key) but a DIFFERENT project: the
+    // content-overlap query is project-scoped, so it finds zero overlap and must
+    // not adopt.
+    r = await harness.chat(
+      body([
+        { role: "user", content: U0 },
+        { role: "assistant", content: "A0 done." },
+        { role: "user", content: U1 },
+        { role: "assistant", content: "A1 done." },
+        { role: "user", content: U2 },
+      ]),
+      "key-A",
+      {
+        "x-lore-session-id": "V2",
+        "x-lore-project": "/tmp/lore-other-project",
+      },
+    );
+    expect(r.status).toBe(200);
+    await r.text();
+
+    const rows = loreSessionRows(harness);
+    expect(rows.length).toBe(2);
+  });
+});


### PR DESCRIPTION
Closes #796.

## Problem
When a long conversation resumes after a **lore+opencode restart** under a fresh `x-lore-session-id`, the gateway treated it as brand-new, orphaning the prior session's distillations, gradient calibration, and LTM pin. The result was three cache busts on resume:
1. Turn 1 — cold full-write at Layer 0 (no distilled prefix).
2. Turn 2 — first `system[2]` (context-bound LTM) injection bust.
3. Turn 3 — Layer 0→1 re-window bust.

## Primary fix — session adoption (Tier 3b)
`adoptByFingerprint()` recovers the prior session from its **persisted fingerprint** and confirms it by **content-hash overlap of the leading user messages** before adopting its session id (so the resume turn inherits prior state — `isFirstTurn` becomes false, calibration + LTM pin are restored, and it compresses immediately).

Wired into **both** mint paths:
- **Tier 1** (known header present but value is new — the opencode restart case): rebinds the new `x-lore-session-id` to the adopted sid for a Tier-1 fast path next turn.
- **Tier 3** (header-less clients): `known: null`, no rebind.

Safety guards (adoption is strictly *more* conservative than the pre-existing in-memory Tier-3 fingerprint matcher):
- **User-message-only overlap.** Assistant responses are stored under a synthetic index-0 ID (`gatewayMessagesToLore([{role:"assistant"}])[0]`), so only user messages have position-stable IDs. Threshold: `overlap >= max(2, ceil(probedUsers/2))` — a single shared opening message can never adopt.
- **Project-scoped** overlap query (`countMatchingTemporalIds` filters `project_id`) → a cross-project fingerprint twin yields zero overlap.
- **Subagent-status match** + **message-count fork guard**.

## Fallback — turn-1 LTM + compress for genuinely-new large sessions
For a large session with no prior session to adopt (e.g. a transcript imported from another machine), inject `system[2]` on turn 1 instead of deferring to turn 2, so LTM + the turn-1 compression are decided together. `isLargeColdStart()` shares `layer0Bounds()` with the gradient transform; the pipeline passes the stable-LTM token count as an `ltmTokens` hint so the decision and the compression see the same `expectedInput` — **no decision-vs-compression drift band**. Adopted/resumed sessions are calibrated, so this stays dormant for them.

## Supporting changes
- `core/db.ts`: `findSessionStatesByFingerprint`, `countMatchingTemporalIds` (chunked under the SQLite 999-var limit); **v44 migration** persisting `last_known_message_count` (+ recover + save/load) so a post-restart calibrated turn estimates accurately instead of over-escalating one turn.
- `core/gradient.ts`: persist/restore `lastKnownMessageCount`; hoisted module-level `UNCALIBRATED_SAFETY`; extracted `layer0Bounds()`; cold-start force-compress; `isLargeColdStart()`.
- `gateway/temporal-adapter.ts`: export `deterministicID`.

## Testing
TDD throughout. New coverage:
- `db.test.ts`: helpers, v44 column, recover, round-trip.
- `gradient.test.ts`: `isLargeColdStart` matrix, `ltmTokens` hint, cold-start force-compress (discriminating — Layer 0 before the fix), drift guard.
- `session-adoption.e2e.test.ts`: restart→resume adopts (1 session row, header rebound); negative cases for different fingerprint and cross-project (no adoption).

Full gate on this branch (rebased onto current `main`, which includes #798/#794/#802/#782): lint clean, typecheck clean (4 packages), **3350 tests pass / 23 skipped** (skips are the pre-existing Postgres-dependent sync integration tests), build clean.

## Review
Self-reviewed via an adversarial read-only pass (verdict: *merge with minor fixes*, no blockers/majors). Acted on the findings: eliminated the Part A/B alignment band via the `ltmTokens` hint, documented the marker-free-leading-message assumption, and added a discriminating test for the hint.