### PR TITLE
feat(cch): add seed for Claude Code 2.1.181 and harden oracle capture

### DIFF
--- a/packages/gateway/src/cch.ts
+++ b/packages/gateway/src/cch.ts
@@ -99,12 +99,13 @@ const VERSION_SEEDS: Record<string, bigint> = {
   "2.1.177": SEED_2_1_138,
   "2.1.178": SEED_2_1_138,
   "2.1.179": SEED_2_1_138,
+  "2.1.181": SEED_2_1_138,
   // Future versions: extract and add entries here.
   // Use `node scripts/extract-cch-seed.ts --version X.Y.Z` to extract.
 };
 
 /** Version we pin worker billing headers to (must have a known seed). */
-const WORKER_VERSION = "2.1.179";
+const WORKER_VERSION = "2.1.181";
 const WORKER_SEED = VERSION_SEEDS[WORKER_VERSION];
 if (WORKER_SEED === undefined) {
   throw new Error(`Missing CCH seed for worker version ${WORKER_VERSION}`);

--- a/quality/CCH.md
+++ b/quality/CCH.md
@@ -245,3 +245,57 @@ But when testing from captured **bytes**, hash the `Uint8Array` directly — a
 `latin1` string reconstruction passed to `xxHash64` would be re-encoded as UTF-8
 and corrupt any multibyte byte. Use latin1 only to *apply the ASCII-only
 strip*, then hash the resulting bytes.
+
+## Update (Claude Code 2.1.181): the `cch` is now gated to the first-party base URL
+
+The "CCH Seed Check" failure for **2.1.181** (issue #801) was **not** a seed or
+preimage change — both are unchanged (`0x4d659218e32a3268`, the Zig-std
+xxHash64 with the stripped `model`/`max_tokens` preimage). The extractor's oracle
+capture simply got **0 pairs**: the binary now refuses to emit `cch` at all when
+it does not believe it is talking to the first-party API.
+
+### Root cause
+The attribution-header builder in 2.1.181 emits the `cch=00000` segment only
+when `kr() === "firstParty" && qu()` (or `kr() === "vertex"`):
+
+```js
+let o = kr(),                                         // provider: firstParty/bedrock/vertex/…
+    s = o === "firstParty" && qu() || o === "vertex" ? " cch=00000;" : "";
+function qu(){ if (qe._CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL) return true; return uln(); }
+function uln(){ let e = process.env.ANTHROPIC_BASE_URL; if (!e) return true; return C7e(e); }
+function C7e(e){ try { return ["api.anthropic.com"].includes(new URL(e).host); } catch { return false; } }
+```
+
+So `cch` is written only when `ANTHROPIC_BASE_URL` is unset, its host is exactly
+`api.anthropic.com`, or the internal env override is set. The seed extractor (and
+the lore gateway) point `ANTHROPIC_BASE_URL` at a `127.0.0.1` server, so `qu()`
+returns false and the billing header comes out as
+`cc_version=2.1.181.fdb; cc_entrypoint=sdk-cli;` — **no `cch`**. 2.1.173 had no
+such gate (it emitted `cch` for any base URL), which is why capture worked before.
+
+### The fix (extractor)
+`scripts/extract-cch-seed.ts` now sets **`_CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL=1`**
+in the capture spawn env, which forces `qu()` true so the binary writes `cch`
+even for the localhost capture server. With this, 2.1.178, 2.1.179 and 2.1.181 all
+capture 2 oracle pairs that validate against `SEED_2_1_138` (`0x4d659218e32a3268`).
+The capture spawn also pipes stdout/stderr (was `stdio: "ignore"`) and prints the
+binary's output + exit reason on a failed capture, so the next regression is
+diagnosable straight from the CI log instead of an opaque "Failed to capture".
+`CCH_DEBUG=1` adds the binary's `--debug` output.
+
+### How it was found (Linux x86_64)
+A capture against a local server showed the binary **did** send
+`POST /v1/messages` (6 retries on the 401) but with no `cch` in the body. A string
+scan of the binary found the still-present `cch=00000` template and the
+`cc_version=${n}; cc_entrypoint=${r};${…}` builder; disassembling the surrounding
+JS revealed the `qu()` first-party gate above. Setting the env override made
+`cch` reappear, and the captured pairs hashed to the known seed bit-for-bit.
+
+### Gotcha / follow-up (gateway runtime — not changed here)
+The same gate affects the **gateway at runtime**: `lore` launches Claude Code with
+`ANTHROPIC_BASE_URL` pointed at the gateway (localhost), so a 2.1.181+ client's
+`qu()` is false and it sends **no `cch`**. `resignBody`'s regex requires a
+`cch=[0-9a-fA-F]{5};` segment, so it will not match such a client's body. The
+likely fix is to set `_CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL=1` in the
+`claude-code` agent `envVars` (`packages/gateway/src/cli/agents.ts`) so clients
+keep emitting `cch` for the gateway to re-sign. Tracked separately from #801.

--- a/scripts/extract-cch-seed.ts
+++ b/scripts/extract-cch-seed.ts
@@ -179,6 +179,11 @@ const PROMPTS = [
   "explain quantum computing in one sentence",
 ];
 
+// How long to wait for the binary to make its `/v1/messages` request before
+// killing it. Bare-mode startup is fast, but cold-starting a 230 MB binary in
+// CI can be slow, so allow generous headroom.
+const CAPTURE_TIMEOUT_MS = 30_000;
+
 async function generateOraclePairs(
   binaryPath: string,
   count: number = 2,
@@ -284,27 +289,74 @@ async function captureOnePair(
   });
   const { port } = server.address() as AddressInfo;
 
+  // Capture the binary's stdout+stderr so a failed capture can explain itself.
+  // Bounded so a chatty `--debug` run can't blow up memory.
+  let output = "";
+  const appendOutput = (buf: Buffer) => {
+    output = (output + buf.toString("utf-8")).slice(-8192);
+  };
+
+  // Enable the binary's own debug logging on demand (CCH_DEBUG=1) so a capture
+  // failure can be diagnosed from CI logs without noise on the happy path.
+  const cliArgs = ["--print", "--bare", "-p", prompt];
+  if (process.env.CCH_DEBUG) cliArgs.push("--debug");
+
+  let exitInfo = "unknown";
   try {
-    const proc = spawn(binaryPath, ["--print", "--bare", "-p", prompt], {
+    const proc = spawn(binaryPath, cliArgs, {
       env: {
         ...process.env,
         HOME: `${tmpDir}/home`,
         ANTHROPIC_API_KEY:
           "sk-ant-api03-fakekey1234567890abcdef1234567890abcdef1234567890abcdef",
         ANTHROPIC_BASE_URL: `http://127.0.0.1:${port}`,
+        // Claude Code >= 2.1.181 only emits the `cch` billing field when it
+        // believes it is talking to the first-party API: `qu()` returns false
+        // unless ANTHROPIC_BASE_URL's host is exactly `api.anthropic.com` (or
+        // unset). Our capture server runs on 127.0.0.1, so without this override
+        // the binary sends NO `cch` at all and extraction fails (issue #801).
+        // This internal env var forces the first-party assumption so the cch is
+        // still written for the localhost capture server. NEVER remove it.
+        _CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL: "1",
         DISABLE_AUTOUPDATER: "1",
         DISABLE_UPDATES: "1",
       },
       cwd: `${tmpDir}/workdir`,
-      stdio: "ignore",
+      // Pipe stdout/stderr (instead of "ignore") so the binary's output is
+      // available for diagnostics when no `cch` is captured.
+      stdio: ["ignore", "pipe", "pipe"],
     });
+    proc.stdout?.on("data", appendOutput);
+    proc.stderr?.on("data", appendOutput);
 
-    // Wait up to 15s for the binary to make its request
-    const timeout = setTimeout(() => proc.kill(), 15_000);
-    await new Promise<void>((resolve) => proc.on("exit", () => resolve()));
+    // Wait for the binary to make its request, then kill it on timeout.
+    let timedOut = false;
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      proc.kill();
+    }, CAPTURE_TIMEOUT_MS);
+    const [code, signal] = await new Promise<[number | null, string | null]>(
+      (resolve) => proc.on("exit", (c, s) => resolve([c, s])),
+    );
     clearTimeout(timeout);
+    exitInfo = timedOut
+      ? `timed out after ${CAPTURE_TIMEOUT_MS / 1000}s (killed)`
+      : `exit code=${code} signal=${signal}`;
   } finally {
     await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+
+  // Surface the binary's output when capture failed — otherwise the failure is
+  // invisible (the binary ran but no `cch` was seen). This is the single most
+  // useful signal for diagnosing future capture regressions.
+  if (!captured) {
+    console.error(`    Binary did not yield a cch (${exitInfo}).`);
+    const trimmed = output.trim();
+    console.error(
+      trimmed
+        ? `    --- binary output (last ${trimmed.length} chars) ---\n${trimmed}`
+        : "    (binary produced no stdout/stderr)",
+    );
   }
 
   return captured;


### PR DESCRIPTION
## Summary

Fixes #801 — the scheduled **CCH Seed Check** workflow fails on Claude Code **2.1.181**.

### Root cause
2.1.181 added a **first-party gate** to the billing header. The `cch` field is emitted only when the binary believes it is talking to the first-party API:

```js
s = kr() === "firstParty" && qu() || kr() === "vertex" ? " cch=00000;" : "";
function qu(){ if (qe._CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL) return true; return uln(); }
function uln(){ let e = process.env.ANTHROPIC_BASE_URL; if (!e) return true; return C7e(e); }
function C7e(e){ try { return ["api.anthropic.com"].includes(new URL(e).host); } catch { return false; } }
```

The extractor points `ANTHROPIC_BASE_URL` at a `127.0.0.1` capture server, so `qu()` is false and 2.1.181 sends **no `cch` at all** (`cc_version=2.1.181.fdb; cc_entrypoint=sdk-cli;`). With 0 oracle pairs (< 2 required) the extractor exits 1. 2.1.173 had no such gate, which is why capture worked before.

The **seed and preimage are unchanged** — 2.1.181 validates against `SEED_2_1_138` (`0x4d659218e32a3268`) with 2 oracle pairs.

### Changes
- **`scripts/extract-cch-seed.ts`** — set `_CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL=1` in the capture spawn (forces `qu()` true). Pipe the binary's stdout/stderr (was `stdio: "ignore"`) and print it + the exit reason on a failed capture, so the next regression is diagnosable from the CI log. `CCH_DEBUG=1` adds the binary's `--debug` output. Capture timeout extracted to a named const.
- **`packages/gateway/src/cch.ts`** — add `"2.1.181": SEED_2_1_138` and pin `WORKER_VERSION = "2.1.181"`.
- **`quality/CCH.md`** — field-report section documenting the gate, the fix, and how it was found.

### Verification (empirical, local Linux x64)
- Hardened extractor captured 2 oracle pairs for 2.1.181; known-seed fast path validates `0x4d659218e32a3268`.
- `pnpm test packages/gateway/test/cch.test.ts` → 108 passed.
- Full suite: 3350 passed / 23 skipped / 0 failed. Typecheck clean. Lint exit 0.

### Follow-up (separate PR)
The same gate affects the **gateway at runtime**: `lore` launches Claude Code with `ANTHROPIC_BASE_URL` pointed at the gateway (localhost), so a 2.1.181+ client omits `cch` and `resignBody`'s regex won't match. Fix will set `_CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL=1` in the `claude-code` agent `envVars` (`packages/gateway/src/cli/agents.ts`). Documented in CCH.md; addressed next.
