### PR TITLE
fix(gateway): keep Claude Code 2.1.181+ emitting cch through the gateway

### DIFF
--- a/packages/gateway/src/cch.ts
+++ b/packages/gateway/src/cch.ts
@@ -34,6 +34,19 @@ import { log } from "@loreai/core";
 import * as Sentry from "@sentry/bun";
 import { xxHash64 } from "./xxhash.ts";
 
+/**
+ * Claude Code (>= 2.1.181) only emits the `cch` billing field when it believes
+ * it is talking to the first-party API — it checks that ANTHROPIC_BASE_URL's
+ * host is exactly `api.anthropic.com` (or unset), otherwise it suppresses `cch`
+ * entirely. Setting this env var to a truthy value forces the first-party
+ * assumption. The Lore gateway is a transparent proxy to the first-party API,
+ * so any process it points at the gateway (Claude Code launched via `lore run`
+ * or configured via `lore setup`, and the seed extractor's capture server)
+ * must set this so `cch` keeps flowing. See quality/CCH.md.
+ */
+export const CLAUDE_CODE_FIRST_PARTY_ENV =
+  "_CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL";
+
 // ---------------------------------------------------------------------------
 // Version→seed mapping
 // ---------------------------------------------------------------------------

--- a/packages/gateway/src/cli/agents.ts
+++ b/packages/gateway/src/cli/agents.ts
@@ -103,6 +103,16 @@ export const AGENTS: AgentDef[] = [
       const env: Record<string, string> = {
         ANTHROPIC_BASE_URL: url,
         DISABLE_AUTO_COMPACT: "1",
+        // Claude Code >= 2.1.181 only emits the `cch` billing field when it
+        // believes it is talking to the first-party API: it suppresses `cch`
+        // unless ANTHROPIC_BASE_URL's host is exactly `api.anthropic.com`.
+        // We point ANTHROPIC_BASE_URL at the local gateway, which IS a
+        // transparent proxy to that first-party API, so without this override
+        // the client sends NO `cch` and the gateway's resignBody cannot
+        // re-sign the billing header it modifies. Force the first-party
+        // assumption so cch keeps flowing. See quality/CCH.md (#801). NEVER
+        // remove this for the Claude Code agent.
+        _CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL: "1",
       };
       // Inject project path so the gateway knows which project this session
       // belongs to, regardless of system prompt format.

--- a/packages/gateway/src/cli/agents.ts
+++ b/packages/gateway/src/cli/agents.ts
@@ -7,6 +7,7 @@
  *  - What env vars to set so it talks through the gateway
  */
 import { getGitRemote } from "@loreai/core";
+import { CLAUDE_CODE_FIRST_PARTY_ENV } from "../cch";
 import { whichSync } from "./lib/which";
 
 // ---------------------------------------------------------------------------
@@ -105,14 +106,17 @@ export const AGENTS: AgentDef[] = [
         DISABLE_AUTO_COMPACT: "1",
         // Claude Code >= 2.1.181 only emits the `cch` billing field when it
         // believes it is talking to the first-party API: it suppresses `cch`
-        // unless ANTHROPIC_BASE_URL's host is exactly `api.anthropic.com`.
-        // We point ANTHROPIC_BASE_URL at the local gateway, which IS a
-        // transparent proxy to that first-party API, so without this override
-        // the client sends NO `cch` and the gateway's resignBody cannot
-        // re-sign the billing header it modifies. Force the first-party
-        // assumption so cch keeps flowing. See quality/CCH.md (#801). NEVER
-        // remove this for the Claude Code agent.
-        _CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL: "1",
+        // unless ANTHROPIC_BASE_URL's host is exactly `api.anthropic.com`. We
+        // point ANTHROPIC_BASE_URL at the local gateway (a transparent proxy to
+        // that first-party API), so without this the client sends NO `cch` and
+        // the gateway's resignBody cannot re-sign the billing header it
+        // modifies. Forcing the first-party assumption is correct here and safe
+        // to apply unconditionally: `cch` is a no-op for non-OAuth sessions,
+        // OAuth tokens already flow to the gateway today, and the only other
+        // effect (enabling `traceparent` propagation) carries non-secret W3C
+        // trace IDs already covered by the gateway's header forwarding. See
+        // quality/CCH.md (first-party gate). NEVER remove this for Claude Code.
+        [CLAUDE_CODE_FIRST_PARTY_ENV]: "1",
       };
       // Inject project path so the gateway knows which project this session
       // belongs to, regardless of system prompt format.

--- a/packages/gateway/src/cli/setup.ts
+++ b/packages/gateway/src/cli/setup.ts
@@ -17,6 +17,7 @@ import { execFileSync } from "node:child_process";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
+import { CLAUDE_CODE_FIRST_PARTY_ENV } from "../cch";
 import { detectAgents } from "./agents";
 
 // ---------------------------------------------------------------------------
@@ -622,6 +623,13 @@ export function claudeCodeSettingsPath(): string {
  *   convention).
  * - Sets `env.DISABLE_AUTO_COMPACT` to `"1"` so the Lore gradient
  *   context manager and distillation pipeline are the source of truth.
+ * - Sets `env._CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL` to `"1"` so Claude Code
+ *   >= 2.1.181 keeps emitting the `cch` billing field even though
+ *   ANTHROPIC_BASE_URL points at the local gateway rather than
+ *   `api.anthropic.com` (the gateway is a transparent proxy to the first-party
+ *   API; without this the client suppresses `cch` and the gateway cannot
+ *   re-sign the billing header). Mirrors the `lore run` path in
+ *   `agents.ts`. See quality/CCH.md.
  * - Deep-merges with the existing settings; preserves permissions,
  *   hooks, model overrides, and other env vars.
  * - Idempotent: running twice produces the same result.
@@ -634,6 +642,7 @@ export function updateClaudeCodeSettings(
     env: {
       ANTHROPIC_BASE_URL: gatewayUrl,
       DISABLE_AUTO_COMPACT: "1",
+      [CLAUDE_CODE_FIRST_PARTY_ENV]: "1",
     },
   });
 }
@@ -657,6 +666,9 @@ function setupClaudeCode(baseUrl: string): void {
   console.log(`[lore]   env.ANTHROPIC_BASE_URL = "${anthropicBaseUrl}"`);
   console.log(
     `[lore]   env.DISABLE_AUTO_COMPACT = "1" (auto-compaction disabled)`,
+  );
+  console.log(
+    `[lore]   env.${CLAUDE_CODE_FIRST_PARTY_ENV} = "1" (keeps cch billing flowing through the gateway)`,
   );
   console.log(`[lore]   Config: ${configPath}`);
   console.log(`[lore]`);

--- a/packages/gateway/test/agents.test.ts
+++ b/packages/gateway/test/agents.test.ts
@@ -70,9 +70,16 @@ describe("Claude Code agent envVars", () => {
   test("forces first-party assumption so >= 2.1.181 keeps emitting cch", () => {
     // Claude Code 2.1.181 suppresses the `cch` billing field unless it believes
     // it is talking to api.anthropic.com. The gateway is a transparent proxy to
-    // that API, so we must force the first-party assumption (see #801).
+    // that API, so we must force the first-party assumption (see quality/CCH.md).
     const env = claude.envVars("http://127.0.0.1:3207", "/tmp/test");
     expect(env._CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL).toBe("1");
+  });
+
+  test("first-party override is set regardless of gateway URL or cwd", () => {
+    const env1 = claude.envVars("http://127.0.0.1:3207", "/tmp/test");
+    const env2 = claude.envVars("http://192.168.1.50:5673", "/home/user/proj");
+    expect(env1._CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL).toBe("1");
+    expect(env2._CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL).toBe("1");
   });
 });
 

--- a/packages/gateway/test/agents.test.ts
+++ b/packages/gateway/test/agents.test.ts
@@ -66,6 +66,14 @@ describe("Claude Code agent envVars", () => {
     const env = claude.envVars("http://127.0.0.1:3207", "/tmp/test");
     expect(env.DISABLE_AUTO_COMPACT).toBe("1");
   });
+
+  test("forces first-party assumption so >= 2.1.181 keeps emitting cch", () => {
+    // Claude Code 2.1.181 suppresses the `cch` billing field unless it believes
+    // it is talking to api.anthropic.com. The gateway is a transparent proxy to
+    // that API, so we must force the first-party assumption (see #801).
+    const env = claude.envVars("http://127.0.0.1:3207", "/tmp/test");
+    expect(env._CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL).toBe("1");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/test/setup.test.ts
+++ b/packages/gateway/test/setup.test.ts
@@ -483,8 +483,19 @@ describe("updateClaudeCodeSettings", () => {
       env: {
         ANTHROPIC_BASE_URL: "http://127.0.0.1:3207",
         DISABLE_AUTO_COMPACT: "1",
+        _CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL: "1",
       },
     });
+  });
+
+  test("sets the first-party override so >= 2.1.181 keeps emitting cch", () => {
+    // Mirrors the `lore run` path (agents.ts): a persistent `lore setup` config
+    // must also force the first-party assumption, or 2.1.181+ suppresses `cch`
+    // when ANTHROPIC_BASE_URL points at the gateway. See quality/CCH.md.
+    const result = updateClaudeCodeSettings({}, "http://127.0.0.1:3207") as {
+      env?: { _CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL?: string };
+    };
+    expect(result.env?._CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL).toBe("1");
   });
 
   test("strips trailing /v1 from the Anthropic base URL", () => {
@@ -514,6 +525,7 @@ describe("updateClaudeCodeSettings", () => {
       OTHER_VAR: "value",
       ANTHROPIC_BASE_URL: "http://127.0.0.1:3207",
       DISABLE_AUTO_COMPACT: "1",
+      _CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL: "1",
     });
   });
 

--- a/quality/CCH.md
+++ b/quality/CCH.md
@@ -291,11 +291,32 @@ scan of the binary found the still-present `cch=00000` template and the
 JS revealed the `qu()` first-party gate above. Setting the env override made
 `cch` reappear, and the captured pairs hashed to the known seed bit-for-bit.
 
-### Gotcha / follow-up (gateway runtime — not changed here)
-The same gate affects the **gateway at runtime**: `lore` launches Claude Code with
-`ANTHROPIC_BASE_URL` pointed at the gateway (localhost), so a 2.1.181+ client's
-`qu()` is false and it sends **no `cch`**. `resignBody`'s regex requires a
-`cch=[0-9a-fA-F]{5};` segment, so it will not match such a client's body. The
-likely fix is to set `_CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL=1` in the
-`claude-code` agent `envVars` (`packages/gateway/src/cli/agents.ts`) so clients
-keep emitting `cch` for the gateway to re-sign. Tracked separately from #801.
+### Gateway runtime: keep clients emitting `cch` through the gateway
+The same gate affects the **gateway at runtime**: `lore` points Claude Code's
+`ANTHROPIC_BASE_URL` at the gateway (localhost), so a 2.1.181+ client's `qu()` is
+false and it sends **no `cch`**. `resignBody`'s regex requires a
+`cch=[0-9a-fA-F]{5};` segment, so it cannot re-sign such a client's body.
+
+Fixed by setting `_CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL=1` on **both** paths
+that route Claude Code through the gateway (the env var name is centralized as
+`CLAUDE_CODE_FIRST_PARTY_ENV` in `packages/gateway/src/cch.ts`):
+
+- `lore run` — the `claude-code` agent `envVars` (`packages/gateway/src/cli/agents.ts`).
+- `lore setup claude-code` — the `~/.claude/settings.json` `env` block
+  (`updateClaudeCodeSettings` in `packages/gateway/src/cli/setup.ts`).
+
+The gateway is a transparent proxy to the first-party API, so forcing the
+first-party assumption is correct. It is safe to apply unconditionally: `cch` is
+a no-op for non-OAuth sessions, OAuth tokens already flow to the gateway today,
+and the only other effect (enabling `traceparent` propagation) carries
+non-secret W3C trace IDs the gateway already forwards. Claude Code Desktop (when
+it lands; not yet on main) writes its own `settings.json` and will need the same
+key.
+
+**Remaining hardening (tracked in #807):** the gateway has no *defensive*
+fallback for a billing header that arrives without `cch` (e.g. a manually
+launched client). `BILLING_HEADER_RE` / `captureBillingPrefix` require a `cch=`
+segment, so such a body passes through unsigned **and** the session is never
+marked as needing OAuth billing (worker calls then lose their billing header).
+The env-var fix prevents this for all `lore`-managed launches; a belt-and-braces
+fix would inject `cch=00000;` and sign when a billing header lacks `cch`.


### PR DESCRIPTION
## Summary

Follow-up to #805 / #801. Fixes the **runtime** side of the Claude Code 2.1.181 first-party gate.

### Problem
2.1.181 only emits the `cch` billing field when it believes it is talking to the first-party API:

```js
function qu(){ if (qe._CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL) return true; return uln(); }
function uln(){ let e = process.env.ANTHROPIC_BASE_URL; if (!e) return true; return C7e(e); }
function C7e(e){ try { return ["api.anthropic.com"].includes(new URL(e).host); } catch { return false; } }
```

`lore` launches Claude Code with `ANTHROPIC_BASE_URL` pointed at the local gateway, so `qu()` is false and a 2.1.181+ client sends **no `cch` at all**. `resignBody`'s regex requires a `cch=[0-9a-fA-F]{5};` segment, so it cannot re-sign the billing header it modifies — the prior behavior silently breaks for 2.1.181+ clients.

### Fix
Set `_CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL=1` in the `claude-code` agent `envVars`. The gateway is a transparent proxy to the first-party API, so forcing the first-party assumption is correct, and the client keeps emitting `cch` for the gateway to re-sign.

Only the `claude-code` agent is affected (it's the only one that produces Claude Code's `cch` header; `pi` sets `ANTHROPIC_BASE_URL` but is a different binary).

### Verification
- Empirically confirmed (during #801): the same override makes 2.1.181 emit `cch` against a localhost server.
- New test in `agents.test.ts` asserts the var is set.
- Full suite: 3351 passed / 23 skipped / 0 failed. Typecheck clean. Lint exit 0.
