### PR TITLE
fix(gateway): stop spurious prompt-cache busts and false unsustainable warnings

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1157,6 +1157,30 @@ const MIGRATIONS: string[] = [
   -- turn. Persisting it makes the resume turn accurate. (issue #796)
   ALTER TABLE session_state ADD COLUMN last_known_message_count INTEGER NOT NULL DEFAULT 0;
   `,
+  `
+  -- Version 45: Durably pin the stable LTM block (system[1]: preferences +
+  -- entities) per session. Previously system[1] lived only in an in-memory
+  -- cache (stableLtmCache) and was recomputed from the live knowledge table on
+  -- idle-resume >=1h, session eviction, or process restart. A curator/
+  -- consolidation delete or update mid-session then silently changed the
+  -- "stable" prefix, busting the whole prompt cache (ses_14b9bf3d… incident).
+  -- Persisting the frozen text lets system[1] be replayed byte-identically for
+  -- the session's life — only a brand-new session computes it fresh.
+  ALTER TABLE session_state ADD COLUMN stable_ltm_text TEXT;
+  ALTER TABLE session_state ADD COLUMN stable_ltm_tokens INTEGER;
+  `,
+  `
+  -- Version 46: Persist the per-session recall store across restarts. The recall
+  -- "Marker and Expand" strategy keeps executed recall results in an in-memory
+  -- Map (sessionState.recallStore) keyed by query/scope; on each turn the marker
+  -- text in history is expanded back into the original tool_use + tool_result
+  -- pair. The Map was in-memory only, so a gateway restart lost it: historical
+  -- recall markers could no longer be expanded and leaked upstream as raw marker
+  -- TEXT — rewriting that (deep) assistant message tool_use→text and busting the
+  -- prompt cache mid-history (ses_14b9bf3d… incident, messages[549]). Persisting
+  -- the store as JSON lets expansion stay byte-stable across restarts.
+  ALTER TABLE session_state ADD COLUMN recall_store TEXT;
+  `,
 ];
 
 /**
@@ -2338,6 +2362,13 @@ export type SessionTrackingState = {
   ltmPinTokens?: number | null;
   /** JSON array of sorted "id:hash(title+content)" keys for the pinned entry set (v39). */
   ltmPinKeys?: string | null;
+  /** Frozen stable LTM block (system[1]: preferences + entities), pinned for the
+   *  session's life so curator/consolidation changes never bust the prefix (v45). */
+  stableLtmText?: string | null;
+  stableLtmTokens?: number | null;
+  /** JSON-serialized recall store (marker→result map) so recall markers expand
+   *  byte-identically across process restarts (v46). */
+  recallStore?: string | null;
   /** JSON map of "<messageID>:<partID>" -> wasCollapsed for stable dedup (v41). */
   dedupDecisions?: string | null;
   // v24: session identity
@@ -2423,6 +2454,18 @@ export function saveSessionTracking(
   if (state.ltmPinKeys !== undefined) {
     sets.push("ltm_pin_keys = ?");
     vals.push(state.ltmPinKeys);
+  }
+  if (state.stableLtmText !== undefined) {
+    sets.push("stable_ltm_text = ?");
+    vals.push(state.stableLtmText);
+  }
+  if (state.stableLtmTokens !== undefined) {
+    sets.push("stable_ltm_tokens = ?");
+    vals.push(state.stableLtmTokens);
+  }
+  if (state.recallStore !== undefined) {
+    sets.push("recall_store = ?");
+    vals.push(state.recallStore);
   }
   if (state.dedupDecisions !== undefined) {
     sets.push("dedup_decisions = ?");
@@ -2524,6 +2567,11 @@ export type LoadedSessionTracking = {
   ltmPinTokens: number | null;
   // v39: reorder-tolerant pin entry-set keys (JSON)
   ltmPinKeys: string | null;
+  // v45: frozen stable LTM block (system[1])
+  stableLtmText: string | null;
+  stableLtmTokens: number | null;
+  // v46: persisted recall store (marker→result map, JSON)
+  recallStore: string | null;
   dedupDecisions: string | null;
   // v24: session identity
   fingerprint: string;
@@ -2673,7 +2721,8 @@ export function loadSessionTracking(
       `SELECT last_curated_at, message_count, turns_since_curation,
               consecutive_text_only_turns,
               ltm_cache_text, ltm_cache_tokens, ltm_pin_text, ltm_pin_tokens,
-              ltm_pin_keys, dedup_decisions,
+              ltm_pin_keys, stable_ltm_text, stable_ltm_tokens, recall_store,
+              dedup_decisions,
               fingerprint, header_session_id, header_name,
               resolved_conversation_ttl, warmup_state,
               dynamic_context_cap, bust_rate_ema, inter_bust_interval_ema,
@@ -2694,6 +2743,9 @@ export function loadSessionTracking(
     ltm_pin_text: string | null;
     ltm_pin_tokens: number | null;
     ltm_pin_keys: string | null;
+    stable_ltm_text: string | null;
+    stable_ltm_tokens: number | null;
+    recall_store: string | null;
     dedup_decisions: string | null;
     fingerprint: string;
     header_session_id: string | null;
@@ -2725,6 +2777,9 @@ export function loadSessionTracking(
     ltmPinText: row.ltm_pin_text,
     ltmPinTokens: row.ltm_pin_tokens,
     ltmPinKeys: row.ltm_pin_keys,
+    stableLtmText: row.stable_ltm_text,
+    stableLtmTokens: row.stable_ltm_tokens,
+    recallStore: row.recall_store,
     dedupDecisions: row.dedup_decisions,
     fingerprint: row.fingerprint,
     headerSessionId: row.header_session_id,

--- a/packages/core/src/distillation.ts
+++ b/packages/core/src/distillation.ts
@@ -8,6 +8,7 @@ import * as log from "./log";
 import {
   extractPatterns,
   extractActionTags,
+  isKnownActionTag,
   tagToTitle,
 } from "./pattern-extract";
 import * as toolTrace from "./tool-trace";
@@ -1185,6 +1186,12 @@ async function distillSegment(input: {
     if (tags.length > 0) {
       const pid = ensureProject(input.projectPath);
       for (const tag of tags) {
+        // Only mint preferences for curated tags we have a deliberate canonical
+        // title for. `tagToTitle` title-cases any string, so without this gate a
+        // spurious regex match becomes a garbage entry (e.g. "A Z" from a literal
+        // `[a-z]` range) that pollutes system[1] and busts the prompt cache when
+        // later deleted by consolidation (ses_14b9bf3d… incident).
+        if (!isKnownActionTag(tag)) continue;
         try {
           const tagPattern = `%[${tag}]%`;
           const rows = db()

--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -249,6 +249,7 @@ export function recordCacheUsage(
   cacheRead: number,
   inputTokens: number,
   sessionID?: string,
+  isIdleResume = false,
 ): void {
   if (!sessionID) return;
   const state = getSessionState(sessionID);
@@ -261,7 +262,18 @@ export function recordCacheUsage(
     const bustRatio = cacheWrite / total;
     const prev = state.consecutiveBusts;
     if (bustRatio > 0.5) {
-      state.consecutiveBusts++;
+      // Idle-resume re-warms are EXPECTED cold-cache writes, NOT sustained
+      // growth: when the user pauses longer than the conversation cache TTL the
+      // cache legitimately expires, so the next turn re-warms it (a write-heavy
+      // "bust"). Counting these toward consecutiveBusts produces false
+      // "unsustainable conversation" warnings on bursty sessions whose turns are
+      // spaced beyond the TTL — every threshold-crossing bust in the
+      // ses_14b9bf3d… incident followed an 11m–2h idle gap past the 5m TTL.
+      // HOLD the counter on an idle resume: neither advance toward the threshold
+      // nor erase a genuine prior run (a real warm-window bust that preceded the
+      // idle is still real). A genuine cache HIT (ratio <= 0.5) below still
+      // resets, even on an idle resume.
+      if (!isIdleResume) state.consecutiveBusts++;
     } else {
       state.consecutiveBusts = 0;
     }
@@ -270,6 +282,12 @@ export function recordCacheUsage(
         `bust-tracker: session=${sessionID.slice(0, 16)} ratio=${bustRatio.toFixed(3)}` +
           ` (write=${cacheWrite} read=${cacheRead} uncached=${inputTokens})` +
           ` busts=${prev}→${state.consecutiveBusts}`,
+      );
+    } else if (isIdleResume && bustRatio > 0.5) {
+      log.info(
+        `bust-tracker: session=${sessionID.slice(0, 16)} idle-resume re-warm` +
+          ` ratio=${bustRatio.toFixed(3)} (write=${cacheWrite} read=${cacheRead}` +
+          ` uncached=${inputTokens}) — not counted (busts held at ${state.consecutiveBusts})`,
       );
     }
 

--- a/packages/core/src/pattern-extract.ts
+++ b/packages/core/src/pattern-extract.ts
@@ -188,8 +188,17 @@ export function extractPatterns(observations: string): ExtractedPattern[] {
 // Action tag extraction and cross-session counting
 // ---------------------------------------------------------------------------
 
-/** Regex to match action tags like [requested-tests], [corrected-style], etc. */
-const ACTION_TAG_RE = /\[([a-z]+-[a-z-]+)\]/g;
+/**
+ * Regex to match action tags like [requested-tests], [corrected-style], etc.
+ *
+ * Every kebab segment must be >=2 chars. This deliberately excludes literal
+ * single-letter character ranges that appear in code/prose — e.g. `[a-z]`,
+ * `[a-f]` — which the old `/\[([a-z]+-[a-z-]+)\]/g` matched as a tag "a-z" and
+ * turned into a garbage preference titled "A Z" (ses_14b9bf3d… cache-bust
+ * incident: such junk pollutes system[1] and busts the prompt cache when later
+ * deleted by consolidation).
+ */
+const ACTION_TAG_RE = /\[([a-z]{2,}(?:-[a-z]{2,})+)\]/g;
 
 /**
  * Extract action tags from distillation observation text.
@@ -217,6 +226,18 @@ const TAG_TITLE_MAP: Record<string, string> = {
   "enforced-workflow":
     "Follow the established git workflow (branch, PR, review)",
 };
+
+/**
+ * Whether a tag is a curated, known action tag (present in TAG_TITLE_MAP).
+ *
+ * Minting preference entries must be gated on this: `tagToTitle` manufactures a
+ * title-cased fallback for ANY string, so without an allow-list a spurious
+ * regex match (e.g. a stray `[foo-bar]`) would become a knowledge entry. Only
+ * tags we have a deliberate canonical title for are real behavioral signals.
+ */
+export function isKnownActionTag(tag: string): boolean {
+  return Object.hasOwn(TAG_TITLE_MAP, tag);
+}
 
 /**
  * Generate a preference title from a tag name.

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -58,7 +58,7 @@ describe("db", () => {
     const row = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(row.version).toBe(44);
+    expect(row.version).toBe(46);
   });
 
   test("session_prompt_deltas persist ordered selector/content rows (v42)", () => {
@@ -915,6 +915,9 @@ describe("db", () => {
       ltmPinText: "pinned LTM text",
       ltmPinTokens: 90,
       ltmPinKeys: JSON.stringify(["a:1", "b:2"]),
+      stableLtmText: "frozen stable LTM text",
+      stableLtmTokens: 77,
+      recallStore: JSON.stringify([["all:q", { toolUseId: "t1" }]]),
       dedupDecisions: JSON.stringify([["m1:p1", true]]),
       lastKnownMessageCount: 137,
     });
@@ -928,9 +931,36 @@ describe("db", () => {
     expect(loaded?.ltmPinText).toBe("pinned LTM text");
     expect(loaded?.ltmPinTokens).toBe(90);
     expect(loaded?.ltmPinKeys).toBe(JSON.stringify(["a:1", "b:2"]));
+    expect(loaded?.stableLtmText).toBe("frozen stable LTM text");
+    expect(loaded?.stableLtmTokens).toBe(77);
+    expect(loaded?.recallStore).toBe(
+      JSON.stringify([["all:q", { toolUseId: "t1" }]]),
+    );
     expect(loaded?.dedupDecisions).toBe(JSON.stringify([["m1:p1", true]]));
     // v43: persisted for accurate calibrated-delta estimation after restart.
     expect(loaded?.lastKnownMessageCount).toBe(137);
+  });
+
+  test("stable LTM (system[1]) freeze round-trips and survives partial updates (v45)", () => {
+    const sid = `test-stable-ltm-${crypto.randomUUID()}`;
+    saveSessionTracking(sid, {
+      stableLtmText: "## Long-term Knowledge\n\n* pref A\n* pref B",
+      stableLtmTokens: 123,
+    });
+    expect(loadSessionTracking(sid)?.stableLtmText).toBe(
+      "## Long-term Knowledge\n\n* pref A\n* pref B",
+    );
+    expect(loadSessionTracking(sid)?.stableLtmTokens).toBe(123);
+
+    // A later unrelated update must NOT clobber the frozen stable LTM — this is
+    // what guarantees the system[1] prefix replays byte-identically.
+    saveSessionTracking(sid, { messageCount: 9 });
+    const loaded = loadSessionTracking(sid);
+    expect(loaded?.messageCount).toBe(9);
+    expect(loaded?.stableLtmText).toBe(
+      "## Long-term Knowledge\n\n* pref A\n* pref B",
+    );
+    expect(loaded?.stableLtmTokens).toBe(123);
   });
 
   test("saveSessionTracking partial update preserves other fields", () => {

--- a/packages/core/test/gradient.test.ts
+++ b/packages/core/test/gradient.test.ts
@@ -4131,6 +4131,50 @@ describe("tier-based context management", () => {
       recordCacheUsage(0, 0, 0, SID);
       expect(inspectSessionState(SID)?.consecutiveBusts).toBe(1);
     });
+
+    // Regression for the ses_14b9bf3d… false "unsustainable" warning: a bursty
+    // session whose turns are spaced beyond the conversation cache TTL re-warms a
+    // legitimately-cold cache on every resume (a write-heavy "bust"). Those
+    // idle-resume re-warms are EXPECTED, not sustained growth, and must not push
+    // the counter toward SUSTAINED_BUST_THRESHOLD.
+    test("idle-resume re-warm does NOT increment consecutive busts", () => {
+      recordCacheUsage(100_000, 0, 3, SID, true);
+      expect(inspectSessionState(SID)?.consecutiveBusts).toBe(0);
+    });
+
+    test("two idle-resume re-warms stay below the unsustainable threshold", () => {
+      recordCacheUsage(100_000, 0, 3, SID, true);
+      recordCacheUsage(100_000, 0, 3, SID, true);
+      // Without the idle guard these two cold re-warms would read as "2
+      // consecutive busts" and trip the unsustainable warning.
+      expect(inspectSessionState(SID)?.consecutiveBusts).toBe(0);
+    });
+
+    test("idle-resume holds (does not erase) a genuine prior bust run", () => {
+      // A real warm-cache bust happened first.
+      recordCacheUsage(100_000, 0, 3, SID);
+      expect(inspectSessionState(SID)?.consecutiveBusts).toBe(1);
+      // Then an idle resume re-warms: hold the counter — neither advance toward
+      // the threshold nor wipe the genuine prior bust.
+      recordCacheUsage(100_000, 0, 3, SID, true);
+      expect(inspectSessionState(SID)?.consecutiveBusts).toBe(1);
+    });
+
+    test("a genuine (non-idle) bust after an idle re-warm still increments", () => {
+      recordCacheUsage(100_000, 0, 3, SID, true); // idle — held at 0
+      recordCacheUsage(100_000, 0, 3, SID); // genuine warm-window bust
+      recordCacheUsage(100_000, 0, 3, SID); // genuine warm-window bust
+      expect(inspectSessionState(SID)?.consecutiveBusts).toBe(2);
+    });
+
+    test("idle-resume cache HIT still resets the counter", () => {
+      recordCacheUsage(100_000, 0, 3, SID);
+      recordCacheUsage(100_000, 0, 3, SID);
+      expect(inspectSessionState(SID)?.consecutiveBusts).toBe(2);
+      // A genuine cache hit on an idle resume is still a hit — reset.
+      recordCacheUsage(1_000, 90_000, 3, SID, true);
+      expect(inspectSessionState(SID)?.consecutiveBusts).toBe(0);
+    });
   });
 
   describe("unsustainable gating — only fires when genuinely over the layer-0 cap", () => {

--- a/packages/core/test/pattern-extract.test.ts
+++ b/packages/core/test/pattern-extract.test.ts
@@ -1,5 +1,9 @@
 import { describe, test, expect } from "vitest";
-import { extractPatterns } from "../src/pattern-extract";
+import {
+  extractActionTags,
+  extractPatterns,
+  isKnownActionTag,
+} from "../src/pattern-extract";
 
 describe("extractPatterns", () => {
   // -----------------------------------------------------------------------
@@ -590,5 +594,60 @@ describe("extractPatterns", () => {
       // "Go" is only 2 chars — too short to be a reliable extraction
       expect(results).toHaveLength(0);
     });
+  });
+});
+
+describe("extractActionTags", () => {
+  test("matches a single-segment action tag", () => {
+    expect(extractActionTags("The user [requested-tests] here.")).toEqual([
+      "requested-tests",
+    ]);
+  });
+
+  test("matches a multi-segment action tag", () => {
+    expect(
+      extractActionTags("Observed [requested-error-handling] behavior."),
+    ).toEqual(["requested-error-handling"]);
+  });
+
+  test("deduplicates repeated tags", () => {
+    expect(
+      extractActionTags("[corrected-style] then later [corrected-style]"),
+    ).toEqual(["corrected-style"]);
+  });
+
+  test("does NOT match a single-letter character range like [a-z]", () => {
+    // Regression for the ses_14b9bf3d… incident: `[a-z]` in code/prose was
+    // matched as a tag "a-z" → tagToTitle → garbage preference titled "A Z"
+    // that polluted system[1] and busted the cache when later deleted.
+    expect(extractActionTags("matches any char in the [a-z] range")).toEqual(
+      [],
+    );
+  });
+
+  test("does NOT match short character ranges like [a-f] or [0-9-like] artifacts", () => {
+    expect(extractActionTags("hex digits [a-f] are valid")).toEqual([]);
+    expect(extractActionTags("a [x-y] mapping")).toEqual([]);
+  });
+
+  test("does not match tags with a single-char segment", () => {
+    // e.g. "[requested-x]" — the trailing single-char segment is almost
+    // certainly an artifact, not a real action tag.
+    expect(extractActionTags("see [requested-x] note")).toEqual([]);
+  });
+});
+
+describe("isKnownActionTag", () => {
+  test("returns true for curated action tags", () => {
+    expect(isKnownActionTag("requested-tests")).toBe(true);
+    expect(isKnownActionTag("enforced-workflow")).toBe(true);
+  });
+
+  test("returns false for unknown / fabricated tags", () => {
+    // The title-case fallback in tagToTitle manufactures a title for ANY tag;
+    // minting must be gated on this allow-list so spurious regex matches never
+    // become knowledge entries.
+    expect(isKnownActionTag("a-z")).toBe(false);
+    expect(isKnownActionTag("foo-bar")).toBe(false);
   });
 });

--- a/packages/gateway/src/cache-analytics.ts
+++ b/packages/gateway/src/cache-analytics.ts
@@ -298,21 +298,27 @@ export function inferDivergenceReason(
   if (path === "system[0]" || path.startsWith("system[0]"))
     return "host system prompt changed";
   if (path === "system[1]" || path.startsWith("system[1]")) {
-    // A divergence reported at system[1] is ambiguous: it can mean either
-    // (a) the system array GREW — context-bound LTM (system[2]) is injected
-    // for the first time on turn 2, so the byte diff lands at the ]→,
-    // boundary right after system[1] even though system[1] is byte-identical,
-    // or (b) system[1]'s own content genuinely changed (preference re-curation).
-    // We cannot cheaply tell these apart from byte lengths alone: at a system[1]
-    // divergence EVERYTHING after it differs (incl. the whole messages array),
-    // so a body-size delta is dominated by message growth, not the inserted
-    // block. The one reliable signal is the turn number: the system[2] insertion
-    // is deterministically a turn-2 transient (block absent on turn 1, present
-    // from turn 2). Use that; fall back to the honest ambiguous wording when the
-    // turn is unknown.
-    if (turn === 2)
-      return "stable LTM pinned — context-bound LTM (system[2]) first injected on turn 2 (expected, not a real system[1] change)";
-    return "stable LTM block diverged (preference re-curation or system-block insertion)";
+    // The PATH SUFFIX reliably disambiguates the two very different system[1]
+    // divergence cases (the old turn===2-only heuristic conflated them and hid
+    // the ses_14b9bf3d… incident, where consolidation deleted entries that were
+    // in the frozen system[1]):
+    //
+    //  (a) BARE "system[1]" — the system array GREW: context-bound LTM
+    //      (system[2]) is injected for the first time, so the first differing
+    //      byte lands at the array boundary (`]`→`,`) right after system[1]
+    //      while system[1] itself is byte-identical. mapOffsetToJsonPath reports
+    //      the array-frame path with no inner key (no ".text"). On turn 2 this
+    //      is the expected one-shot transient; otherwise it is a structural
+    //      block-insertion shift.
+    //  (b) "system[1].text" (any sub-path) — system[1]'s OWN content changed
+    //      (preference re-curation/consolidation add/remove/edit). This busts
+    //      the entire prefix and is a REAL bust regardless of turn number.
+    if (path === "system[1]") {
+      if (turn === 2)
+        return "stable LTM array grew — context-bound LTM (system[2]) first injected on turn 2 (expected, not a real system[1] change)";
+      return "stable LTM block boundary shifted (system-block insertion)";
+    }
+    return "stable LTM block content changed (preference re-curation/consolidation — prefix bust)";
   }
   if (path === "system[2]" || path.startsWith("system[2]"))
     return "context-bound LTM changed (non-preference entries re-ranked)";

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -254,6 +254,8 @@ import {
   cleanupRecallStore,
   replaceRecallWithMarker,
   isRecallMarker,
+  serializeRecallStore,
+  deserializeRecallStore,
 } from "./recall";
 import { upstreamFetch } from "./fetch";
 import {
@@ -610,8 +612,11 @@ export function ltmEntryKeys(
     .sort();
 }
 
-/** system[1] (stable LTM) cache breakpoint TTL in ms. Once an idle gap exceeds
- *  this, that prefix is cold and can be rebuilt with fresh preferences for free. */
+/** system[1] (stable LTM) cache breakpoint TTL in ms. Documents the 1h
+ *  `cache_control` TTL carried by the system[1] block. As of v45 system[1] is
+ *  frozen for the session's life and never recomputed mid-session, so an idle
+ *  gap past this TTL re-warms the SAME frozen bytes rather than rebuilding from
+ *  the live knowledge table (which used to bust the prefix on curator deletes). */
 export const STABLE_LTM_TTL_MS = 3_600_000; // 1h — matches the system[1] cache_control
 
 /**
@@ -634,19 +639,6 @@ export function shouldRunInFlightCuration(input: {
     !input.curationScheduled &&
     !input.curatorBusy
   );
-}
-
-/**
- * Decide whether the stable LTM block (system[1]: preferences + entities) should
- * be refreshed on an idle resume. Only when the idle gap exceeds the system[1]
- * 1h cache TTL — that prefix is then cold, so rebuilding it with freshly-curated
- * preferences costs nothing. Shorter gaps keep it pinned. Pure/testable.
- */
-export function shouldRefreshStableLtm(
-  idleTriggered: boolean,
-  idleMs: number,
-): boolean {
-  return idleTriggered && idleMs >= STABLE_LTM_TTL_MS;
 }
 
 /**
@@ -2211,6 +2203,22 @@ function getOrCreateSession(
         tokenCount: persisted.ltmCacheTokens,
       });
     }
+    // Restore the frozen stable LTM block (system[1]) so it replays
+    // byte-identically across process restarts and idle resumes — never
+    // recomputed from the live knowledge table mid-session (v45). This is what
+    // prevents a curator/consolidation delete from busting the cached prefix.
+    if (persisted?.stableLtmText != null && persisted.stableLtmTokens != null) {
+      stableLtmCache.set(sessionID, {
+        formatted: persisted.stableLtmText,
+        tokenCount: persisted.stableLtmTokens,
+      });
+    }
+    // Restore the recall store (v46) so historical recall markers still expand
+    // to their original tool_use + tool_result pair after a restart, instead of
+    // leaking upstream as raw marker text and rewriting that message.
+    if (persisted?.recallStore != null) {
+      state.recallStore = deserializeRecallStore(persisted.recallStore);
+    }
     if (persisted?.ltmPinText != null && persisted.ltmPinTokens != null) {
       let entryKeys: string[] | undefined;
       if (persisted.ltmPinKeys != null) {
@@ -3224,6 +3232,13 @@ function buildStreamingResponse(
               position,
               result,
             });
+            // Persist the store (v46) so the marker still expands byte-identically
+            // after a gateway restart instead of leaking raw marker text upstream.
+            saveSessionTracking(recallContext.sessionState.sessionID, {
+              recallStore: serializeRecallStore(
+                recallContext.sessionState.recallStore,
+              ),
+            });
 
             // Emit marker text block in place of the suppressed recall block
             const markerText = buildRecallMarker(input.query, scope, input.id);
@@ -3926,6 +3941,10 @@ function postResponse(
     // --- Cache analytics + bust cause telemetry ---
     // Run BEFORE genAiSpan.end() so we can enrich the span with
     // divergence diagnostics (divergence point, prefix match, bust cause).
+    // Capture the idle-resume flag up front: it is consumed (set false) inside
+    // the block below but is still needed afterwards by recordCacheUsage so a
+    // cold-cache re-warm is not counted as a consecutive bust.
+    const turnWasIdleResume = sessionState.lastTurnWasIdle ?? false;
     if (requestBody) {
       const turnAnalysis = analyzeCacheTurn(
         sessionState.cacheAnalytics,
@@ -3934,10 +3953,7 @@ function postResponse(
         sessionID,
         sessionState.messageCount,
       );
-      const bustCause = categorizeBust(
-        turnAnalysis,
-        sessionState.lastTurnWasIdle ?? false,
-      );
+      const bustCause = categorizeBust(turnAnalysis, turnWasIdleResume);
       if (genAiSpan) {
         setCacheAnalyticsAttributes(
           genAiSpan,
@@ -3971,11 +3987,16 @@ function postResponse(
     }
 
     // --- Consecutive bust tracking for tier-based decisions ---
+    // Pass the current turn's idle-resume flag so a cold-cache re-warm (cache
+    // legitimately expired during the user's pause) is not counted as a
+    // consecutive bust — that produced false "unsustainable" warnings on bursty
+    // sessions whose turns are spaced beyond the conversation cache TTL.
     recordCacheUsage(
       usage.cacheCreationInputTokens ?? 0,
       usage.cacheReadInputTokens ?? 0,
       usage.inputTokens ?? 0,
       sessionState.sessionID,
+      turnWasIdleResume,
     );
 
     // Capture previous stop reason before it's overwritten below (line ~1667).
@@ -5578,19 +5599,15 @@ async function handleConversationTurn(
       ltmCacheText: null,
       ltmCacheTokens: null,
     });
-    // Refresh the stable LTM block (system[1]: preferences + entities) too, but
-    // ONLY when the idle gap exceeds system[1]'s own 1h cache TTL — i.e. that
-    // prefix is already cold, so rebuilding it with freshly-curated preferences
-    // costs nothing. (Lore promotes long-running sessions; without this they
-    // would keep using stale preferences indefinitely.) A shorter idle gap
-    // leaves system[1] warm, so we keep it pinned to preserve the 1h cache.
-    const refreshedStable = shouldRefreshStableLtm(true, idleResult.idleMs);
-    if (refreshedStable) {
-      stableLtmCache.delete(sessionID);
-    }
+    // NOTE: the stable LTM block (system[1]: preferences + entities) is
+    // deliberately NOT refreshed here (v45). It is frozen for the session's life
+    // and replayed byte-identically — recomputing it from the live knowledge
+    // table on idle resume is what let a curator/consolidation delete change the
+    // "stable" prefix and bust the whole prompt cache (ses_14b9bf3d… incident).
+    // Re-warming after the 1h breakpoint expires re-sends the same frozen bytes;
+    // newly-curated preferences are picked up by the NEXT session, not mid-session.
     log.info(
       `session idle ${Math.round(idleResult.idleMs / 60_000)}min — refreshing caches` +
-        (refreshedStable ? " (incl. stable LTM — 1h cold)" : "") +
         (cacheWarm ? " (cache warm — skipping compact)" : ""),
     );
   }
@@ -5696,11 +5713,26 @@ async function handleConversationTurn(
         }
 
         const formatted = [prefText, entitiesText].filter(Boolean).join("\n\n");
-        if (formatted) {
-          const tokenCount = Math.ceil(formatted.length / 3);
-          stable = { formatted, tokenCount };
-          stableLtmCache.set(sessionID, stable);
-        }
+        // Freeze this baseline durably (v45) — INCLUDING an empty result. The
+        // in-memory cache is lost on process restart / session eviction;
+        // persisting lets getOrCreateSession restore the exact bytes so system[1]
+        // is never recomputed from the live knowledge table mid-session (which is
+        // what let a consolidation delete bust the cached prefix — ses_14b9bf3d…
+        // incident). Caching even the EMPTY baseline matters: a session that
+        // starts with no preferences/entities must stay system[1]-absent for its
+        // life — otherwise a preference minted mid-session (curator/pattern-
+        // extract) would make system[1] appear, growing the array and busting the
+        // prefix once. An empty `formatted` is falsy at the assembly site
+        // (anthropic.ts `if (stableLtm)`), so freezing "" keeps system[1] absent
+        // rather than injecting an empty block; new preferences surface next
+        // session. This compute path only runs once per session (cache miss).
+        const tokenCount = formatted ? Math.ceil(formatted.length / 3) : 0;
+        stable = { formatted, tokenCount };
+        stableLtmCache.set(sessionID, stable);
+        saveSessionTracking(sessionID, {
+          stableLtmText: formatted,
+          stableLtmTokens: tokenCount,
+        });
       }
       stableLtmText = stable?.formatted;
 
@@ -6633,6 +6665,11 @@ async function handleConversationTurn(
         input,
         position,
         result,
+      });
+      // Persist the store (v46) so the marker still expands byte-identically
+      // after a gateway restart instead of leaking raw marker text upstream.
+      saveSessionTracking(sessionState.sessionID, {
+        recallStore: serializeRecallStore(sessionState.recallStore),
       });
 
       const markerResp = replaceRecallWithMarker(currentResp);

--- a/packages/gateway/src/recall.ts
+++ b/packages/gateway/src/recall.ts
@@ -34,6 +34,7 @@ import type {
   GatewayToolUseBlock,
   GatewayMessage,
   RecallStore,
+  StoredRecall,
 } from "./translate/types";
 
 // ---------------------------------------------------------------------------
@@ -141,6 +142,45 @@ export function parseRecallMarker(
     query: match[2],
     scope: labelToScope(match[1]),
   };
+}
+
+/**
+ * Serialize a recall store to JSON for cross-restart persistence.
+ *
+ * The store is in-memory per session; without persistence a gateway restart
+ * loses it, so historical recall markers can no longer be expanded into their
+ * tool_use + tool_result pair and instead leak upstream as raw marker TEXT —
+ * rewriting that (deep) assistant message and busting the prompt cache
+ * (ses_14b9bf3d… incident). Persisting + restoring keeps expansion byte-stable.
+ */
+export function serializeRecallStore(store: RecallStore): string {
+  return JSON.stringify([...store.entries()]);
+}
+
+/** Restore a recall store from its JSON form. Tolerant of corrupt/old blobs. */
+export function deserializeRecallStore(json: string): RecallStore {
+  const store: RecallStore = new Map();
+  try {
+    const entries = JSON.parse(json);
+    if (!Array.isArray(entries)) return store;
+    for (const entry of entries) {
+      if (
+        Array.isArray(entry) &&
+        entry.length === 2 &&
+        typeof entry[0] === "string" &&
+        entry[1] &&
+        typeof entry[1] === "object" &&
+        typeof (entry[1] as StoredRecall).toolUseId === "string" &&
+        typeof (entry[1] as StoredRecall).result === "string"
+      ) {
+        store.set(entry[0], entry[1] as StoredRecall);
+      }
+    }
+  } catch {
+    // Corrupt blob — start empty (markers fall back to raw text; recoverable
+    // once the recall re-executes).
+  }
+  return store;
 }
 
 /** Derive a store key from query + scope, or from id for detail lookups. */

--- a/packages/gateway/test/cache-analytics.test.ts
+++ b/packages/gateway/test/cache-analytics.test.ts
@@ -223,29 +223,43 @@ describe("inferDivergenceReason", () => {
     );
   });
 
-  test("system prompt — system[1] divergence on turn 2 is the system[2] insertion", () => {
+  test("system prompt — bare system[1] boundary on turn 2 is the system[2] insertion", () => {
     // The turn-2 transient: context-bound LTM (system[2]) is injected for the
-    // first time, shifting the array boundary so the byte diff lands at system[1].
-    expect(
-      inferDivergenceReason("system[1].text", 12000, 12500, undefined, 2),
-    ).toBe(
-      "stable LTM pinned — context-bound LTM (system[2]) first injected on turn 2 (expected, not a real system[1] change)",
+    // first time, growing the system array. system[1] itself is byte-identical,
+    // so the first differing byte lands at the array boundary (`]`→`,`) right
+    // after system[1] — mapOffsetToJsonPath reports the BARE "system[1]" path
+    // (no ".text" suffix). This is expected and not a real content change.
+    expect(inferDivergenceReason("system[1]", 12000, 12500, undefined, 2)).toBe(
+      "stable LTM array grew — context-bound LTM (system[2]) first injected on turn 2 (expected, not a real system[1] change)",
     );
   });
 
-  test("system prompt — system[1] divergence after turn 2 is ambiguous (not over-claimed)", () => {
-    // After turn 2 we can't cheaply tell a real preference re-curation from a
-    // block insertion (body delta is dominated by message growth), so we report
-    // the honest ambiguous wording rather than asserting a specific cause.
+  test("system prompt — bare system[1] boundary after turn 2 is a block-insertion shift", () => {
+    // A bare-boundary divergence outside the turn-2 transient means the system
+    // array structure shifted (a block was inserted/removed) without system[1]'s
+    // own content changing.
+    expect(inferDivergenceReason("system[1]", 12000, 12500, undefined, 5)).toBe(
+      "stable LTM block boundary shifted (system-block insertion)",
+    );
+  });
+
+  test("system prompt — system[1].text content change is a REAL bust, even on turn 2", () => {
+    // Regression for the ses_14b9bf3d… incident: a divergence INSIDE system[1]'s
+    // text value (path "system[1].text") means the stable LTM block's bytes
+    // genuinely changed — a preference was added/removed/edited by the curator or
+    // consolidation mid-session. This busts the entire prefix and must NOT be
+    // dismissed as the benign turn-2 array-grew transient (which the old turn===2
+    // heuristic did, hiding the incident).
+    const realChange =
+      "stable LTM block content changed (preference re-curation/consolidation — prefix bust)";
+    expect(
+      inferDivergenceReason("system[1].text", 12000, 12500, undefined, 2),
+    ).toBe(realChange);
     expect(
       inferDivergenceReason("system[1].text", 12000, 12500, undefined, 5),
-    ).toBe(
-      "stable LTM block diverged (preference re-curation or system-block insertion)",
-    );
+    ).toBe(realChange);
     // Same when the turn is unknown.
-    expect(inferDivergenceReason("system[1].text", 100, 100)).toBe(
-      "stable LTM block diverged (preference re-curation or system-block insertion)",
-    );
+    expect(inferDivergenceReason("system[1].text", 100, 100)).toBe(realChange);
   });
 
   test("system prompt — context-bound LTM block", () => {

--- a/packages/gateway/test/cache-stability.e2e.test.ts
+++ b/packages/gateway/test/cache-stability.e2e.test.ts
@@ -887,6 +887,175 @@ describe("cache stability (e2e)", () => {
     expect(rows[0].content).toContain(contextID.slice(0, 8));
   });
 
+  it("frozen system[1] survives a mid-session preference DELETE across a restart (ses_14b9bf3d… incident)", async () => {
+    // Regression for the ses_14b9bf3d… cache-bust incident. system[1] (stable
+    // LTM: preferences) used to live ONLY in an in-memory cache and be recomputed
+    // from the live knowledge table whenever that cache went cold (idle resume
+    // >=1h, session eviction, process restart). An idle consolidation deleted 25
+    // entries mid-session; the next (post-idle) turn recomputed system[1] WITHOUT
+    // them, changing the "stable" prefix and busting ~356K tokens of prompt cache.
+    //
+    // The fix (v45) persists the frozen system[1] text to session_state and
+    // replays it byte-identically — never recomputing from the live DB
+    // mid-session. This test reproduces the exact sequence: freeze system[1] with
+    // a preference present, DELETE it, restart the gateway (drops the in-memory
+    // cache), and assert the next turn's system[1] is byte-identical (restored
+    // from the persisted pin, not recomputed from the now-deleted-entry DB).
+    const turns = Array.from({ length: 3 }, (_, i) => ({
+      userMessage: `Stable-pref turn ${i}: continue the work.`,
+      assistantText: `Stable-pref response ${i}.`,
+    }));
+    harness = await createHarness({
+      fixtures: makeConversationFixtures(turns),
+    });
+
+    const projectPath = `/tmp/lore-stable-pref-freeze-${Date.now()}`;
+    const headers = {
+      "x-lore-project": projectPath,
+      "x-lore-session-id": `stable-pref-client-${Date.now()}`,
+    };
+
+    const { ltm } = await import("@loreai/core");
+
+    // Pre-seed TWO project-scoped preferences BEFORE the first turn so both are
+    // present in system[1] when it freezes on turn 1.
+    const prefA = ltm.create({
+      projectPath,
+      scope: "project",
+      category: "preference",
+      title: "Aaa first stable preference",
+      content:
+        "Always keep the system[1] prefix byte-stable for the session's life.",
+    });
+    ltm.create({
+      projectPath,
+      scope: "project",
+      category: "preference",
+      title: "Bbb second stable preference",
+      content: "Prefer durable pins over mid-session recomputation.",
+    });
+
+    const history: unknown[] = [];
+    let sessionID = "";
+    for (let i = 0; i < turns.length; i++) {
+      const resp = await harness.chat(
+        makeBody(turns[i].userMessage, history),
+        "test-key",
+        headers,
+      );
+      expect(resp.status).toBe(200);
+      await resp.json();
+      history.push({ role: "user", content: turns[i].userMessage });
+      history.push({
+        role: "assistant",
+        content: [{ type: "text", text: turns[i].assistantText }],
+      });
+
+      if (i === 0) {
+        const rows = harness.queryDB<{ session_id: string }>(
+          "SELECT session_id FROM session_state ORDER BY updated_at DESC LIMIT 1",
+        );
+        sessionID = rows[0]?.session_id ?? "";
+        expect(sessionID).not.toBe("");
+      }
+
+      if (i === 1) {
+        // Mid-session: a consolidation/curator delete removes a pinned
+        // preference, then the gateway restarts (drops the in-memory stable LTM
+        // cache). This is the exact ses_14b9bf3d… sequence.
+        ltm.remove(prefA);
+        await harness.restartPipeline();
+      }
+    }
+
+    const bodies = harness.upstreamBodies();
+    expect(bodies.length).toBe(turns.length);
+
+    const sys1 = (b: string) => systemBlocks(b)[1];
+    // Sanity: the deleted preference WAS rendered into the frozen system[1].
+    expect(sys1(bodies[0])).toContain("Aaa first stable preference");
+    // The invariant: turn 3 (post-delete, post-restart) replays the SAME frozen
+    // system[1] bytes as turn 1 — restored from the persisted pin, not recomputed
+    // from the now-deleted-entry knowledge table.
+    expect(
+      sys1(bodies[2]),
+      "system[1] changed after a mid-session preference delete + restart — it " +
+        "was recomputed from the live knowledge table instead of replaying the " +
+        "persisted frozen pin (this is the ses_14b9bf3d… prefix bust)",
+    ).toBe(sys1(bodies[0]));
+  });
+
+  it("an EMPTY system[1] is frozen too: a preference minted mid-session does not appear (no array-grow bust)", async () => {
+    // Point-4 gap from the adversarial review: a session that starts with no
+    // preferences/entities has an empty system[1] (the cache breakpoint falls on
+    // the host block). Before the empty-baseline freeze, the compute path skipped
+    // caching when `formatted` was empty, so it recomputed every turn — and the
+    // moment the curator/pattern-extract minted a preference mid-session, system[1]
+    // appeared, growing the system array and busting the prefix once. Freezing the
+    // empty baseline keeps system[1] absent for the session's life (new prefs
+    // surface next session).
+    const turns = Array.from({ length: 3 }, (_, i) => ({
+      userMessage: `Empty-stable turn ${i}: continue the work.`,
+      assistantText: `Empty-stable response ${i}.`,
+    }));
+    harness = await createHarness({
+      fixtures: makeConversationFixtures(turns),
+    });
+
+    const projectPath = `/tmp/lore-empty-stable-${Date.now()}`;
+    const headers = {
+      "x-lore-project": projectPath,
+      "x-lore-session-id": `empty-stable-client-${Date.now()}`,
+    };
+
+    const { ltm } = await import("@loreai/core");
+    const history: unknown[] = [];
+    for (let i = 0; i < turns.length; i++) {
+      const resp = await harness.chat(
+        makeBody(turns[i].userMessage, history),
+        "test-key",
+        headers,
+      );
+      expect(resp.status).toBe(200);
+      await resp.json();
+      history.push({ role: "user", content: turns[i].userMessage });
+      history.push({
+        role: "assistant",
+        content: [{ type: "text", text: turns[i].assistantText }],
+      });
+
+      // After the empty baseline is frozen on turn 1, mint a project preference
+      // mid-session. With the freeze it must NOT appear as a new system[1] block.
+      if (i === 0) {
+        ltm.create({
+          projectPath,
+          scope: "project",
+          category: "preference",
+          title: "Mid-session minted preference",
+          content:
+            "This preference was minted after the empty system[1] baseline froze.",
+        });
+      }
+    }
+
+    const bodies = harness.upstreamBodies().map(normalizeBodyForComparison);
+    const systems = bodies.map((b) => {
+      const parsed = JSON.parse(b) as { system?: unknown };
+      return JSON.stringify(parsed.system ?? null);
+    });
+    // The full system array must be byte-identical across all turns: the minted
+    // preference does not grow the array (frozen empty system[1]).
+    for (let i = 1; i < systems.length; i++) {
+      expect(
+        systems[i],
+        `system array changed on turn ${i + 1} after a mid-session preference ` +
+          `mint — the empty system[1] baseline was not frozen (array-grow bust)`,
+      ).toBe(systems[0]);
+    }
+    // And the minted preference's title must NOT have leaked into the prompt.
+    expect(bodies[2]).not.toContain("Mid-session minted preference");
+  });
+
   it("normal LTM refresh preserves system[2] and emits durable removal deltas", async () => {
     const turns = Array.from({ length: 4 }, (_, i) => ({
       userMessage: `Normal removal delta turn ${i}: continue the work.`,

--- a/packages/gateway/test/curation-cache-stability.test.ts
+++ b/packages/gateway/test/curation-cache-stability.test.ts
@@ -7,11 +7,7 @@
  * actual gating logic is unit-tested (not just the config default).
  */
 import { describe, test, expect } from "vitest";
-import {
-  shouldRunInFlightCuration,
-  shouldRefreshStableLtm,
-  STABLE_LTM_TTL_MS,
-} from "../src/pipeline";
+import { shouldRunInFlightCuration, STABLE_LTM_TTL_MS } from "../src/pipeline";
 
 describe("shouldRunInFlightCuration", () => {
   const base = {
@@ -58,23 +54,12 @@ describe("shouldRunInFlightCuration", () => {
   });
 });
 
-describe("shouldRefreshStableLtm", () => {
-  test("refreshes when idle gap exceeds the 1h system[1] TTL", () => {
-    expect(shouldRefreshStableLtm(true, STABLE_LTM_TTL_MS)).toBe(true);
-    expect(shouldRefreshStableLtm(true, STABLE_LTM_TTL_MS + 60_000)).toBe(true);
-  });
-
-  test("does NOT refresh when system[1] is still warm (gap < 1h)", () => {
-    // A 5-minute idle resume cools the conversation cache but NOT the pinned
-    // 1h system[1] block — keep it pinned to preserve the cache investment.
-    expect(shouldRefreshStableLtm(true, 5 * 60_000)).toBe(false);
-    expect(shouldRefreshStableLtm(true, STABLE_LTM_TTL_MS - 1)).toBe(false);
-  });
-
-  test("does NOT refresh when there was no idle resume at all", () => {
-    expect(shouldRefreshStableLtm(false, STABLE_LTM_TTL_MS * 10)).toBe(false);
-  });
-
+describe("stable LTM (system[1]) is frozen for the session's life (v44)", () => {
+  // The old shouldRefreshStableLtm() idle-recompute was removed: system[1] is
+  // now persisted and replayed byte-identically, so a curator/consolidation
+  // delete can never change the cached prefix mid-session (ses_14b9bf3d…
+  // incident). The TTL constant is retained to document the 1h system[1]
+  // cache_control breakpoint.
   test("STABLE_LTM_TTL_MS matches the 1h system[1] cache breakpoint", () => {
     expect(STABLE_LTM_TTL_MS).toBe(3_600_000);
   });

--- a/packages/gateway/test/recall.test.ts
+++ b/packages/gateway/test/recall.test.ts
@@ -31,6 +31,8 @@ import {
   expandRecallMarkers,
   cleanupRecallStore,
   replaceRecallWithMarker,
+  serializeRecallStore,
+  deserializeRecallStore,
 } from "../src/recall";
 import type {
   GatewayResponse,
@@ -304,6 +306,76 @@ describe("parseRecallMarker", () => {
     expect(parseRecallMarker("hello world")).toBeNull();
     expect(parseRecallMarker("[Searching memory...]")).toBeNull();
     expect(parseRecallMarker("")).toBeNull();
+  });
+
+  test("parses a query containing double quotes without truncating (#cache-bust)", () => {
+    // Regression for the ses_14b9bf3d… recall rewrite: the lazy `(.+?)` query
+    // capture stopped at the first `"`, so a query containing quotes parsed to a
+    // DIFFERENT string than was stored under. expandRecallMarkers then missed the
+    // store, left the raw marker upstream, and rewrote that historical assistant
+    // message (tool_use → text) — a deep-history prompt-cache bust.
+    const marker = buildRecallMarker('how to use "async" patterns', "project");
+    expect(parseRecallMarker(marker)).toEqual({
+      query: 'how to use "async" patterns',
+      scope: "project",
+    });
+  });
+
+  test("build → parse round-trips an arbitrary query (store key stays stable)", () => {
+    for (const query of [
+      'sync tiers "pro" max distillations',
+      'a query with a trailing quote"',
+      'nested "a" and "b" quotes',
+      "plain query",
+    ]) {
+      const parsed = parseRecallMarker(buildRecallMarker(query, "all"));
+      expect(parsed?.query).toBe(query);
+      expect(parsed?.scope).toBe("all");
+    }
+  });
+});
+
+describe("serializeRecallStore / deserializeRecallStore", () => {
+  test("round-trips a populated store (cross-restart persistence, v46)", () => {
+    const store: RecallStore = new Map([
+      [
+        'all:sync tiers "pro" max',
+        {
+          toolUseId: "toolu_1",
+          input: { query: 'sync tiers "pro" max', scope: "all" },
+          position: 2,
+          result: "## Results\n\n* entry one\n* entry two",
+        },
+      ],
+      [
+        "id:k:abc123",
+        {
+          toolUseId: "toolu_2",
+          input: { query: "", scope: "all", id: "k:abc123" },
+          position: 0,
+          result: "detail body",
+        },
+      ],
+    ]);
+    const restored = deserializeRecallStore(serializeRecallStore(store));
+    expect(restored).toEqual(store);
+  });
+
+  test("deserialize tolerates corrupt / empty blobs", () => {
+    expect(deserializeRecallStore("not json").size).toBe(0);
+    expect(deserializeRecallStore("{}").size).toBe(0);
+    expect(deserializeRecallStore("[]").size).toBe(0);
+    // Entries missing required fields are dropped, valid ones kept.
+    const mixed = JSON.stringify([
+      ["bad", { toolUseId: 123 }],
+      [
+        "good",
+        { toolUseId: "t", input: { query: "q" }, position: 0, result: "r" },
+      ],
+    ]);
+    const restored = deserializeRecallStore(mixed);
+    expect(restored.size).toBe(1);
+    expect(restored.get("good")?.result).toBe("r");
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes the `ses_14b9bf3d…` incident where a long opencode session surfaced a false **"unsustainable conversation"** warning. Production-log forensics on the mapped lore session (`0AVWKugtmhBKqLOX9`) traced it to **two distinct problems**:

1. The threshold-crossing busts were **idle cold-cache re-warms** (cache legitimately expired during the user's pause), miscounted as *sustained* growth.
2. A class of **systemic content-drift busts** (mid-session LTM consolidation rewriting `system[1]`; recall-marker rewrites after a restart) that also showed up across other sessions.

### Validation (production-evidenced)
Every warning-triggering bust (`consecutiveBusts 1→2`) on this session occurred **after an idle gap far exceeding the 5m conversation TTL** (15m, 11m, 2h14m), with cache-warming inactive — i.e. expected cold re-warms, not real growth:

| Episode | bust 0→1 | bust 1→2 (fires warning) | gap |
|---|---|---|---|
| 06-16a | 01:16 | 01:31 | 15m |
| 06-16b | 13:13 | 13:24 | 11m |
| 06-18 | 10:36 | 12:50 | 2h14m → +13s recall rewrite |

## Fixes

- **Fix 5 — idle-aware bust counting** *(directly stops the false warning)*: `recordCacheUsage` takes `isIdleResume`; a cold re-warm after an idle gap **holds** `consecutiveBusts` instead of counting it. The pipeline captures `lastTurnWasIdle` **before** it is consumed (at the `categorizeBust` site) and passes it through. A genuine cache hit still resets.
- **Fix 1 — durably freeze `system[1]`** (stable LTM: preferences + entities): migration **v45** (`stable_ltm_text`/`stable_ltm_tokens`), persisted on first compute (including an **empty** baseline), restored on session load; the idle-≥1h recompute is removed. A curator/consolidation delete can no longer change the cached prefix mid-session. Holds across process restart, session eviction, and idle resume.
- **Fix 4 — persist the recall store** (migration **v46** `recall_store`): the in-memory `recallStore` was lost on restart, so historical recall markers leaked upstream as raw text and rewrote deep history. Now serialized/restored so expansion stays byte-identical.
- **Fix 2 — stop pattern-extract garbage**: tightened `ACTION_TAG_RE` (rejects literal `[a-z]`) and gated minting on a curated allow-list (`isKnownActionTag`). Root cause of the garbage `A Z` preference whose later consolidation triggered the `system[1]` drift.
- **Fix 3 — honest telemetry**: `inferDivergenceReason` distinguishes a real `system[1].text` content change (prefix bust) from the benign turn-2 array-grow, so this bust class is no longer hidden.

## Testing
- TDD red→green for each fix; two new behavioral discriminating-verified e2e regressions: preference **delete + restart → `system[1]` byte-identical**, and the **empty→non-empty `system[1]`** transition.
- Full suite **3371 passed / 23 skipped / 0 failed**; `pnpm -r run typecheck` clean; `pnpm run lint` clean.

## Notes for reviewers
- An adversarial self-review (subagent) recommended merge; its top residual concern (empty `system[1]` not frozen) is **closed** in this PR with the empty-baseline freeze + a discriminating test.
- Migrations are additive/nullable (v45, v46) — safe on existing rows. Rebased onto `main` (kept main's v44 `last_known_message_count`).
- Known minor follow-ups (non-blocking): `STABLE_LTM_TTL_MS` is now documentation-only; an all-idle bursty session can never accumulate busts (intended trade-off); `cleanupRecallStore` isn't followed by a persist (self-healing on next `set`).