### PR TITLE
fix(gateway): handle Claude Code billing headers without a cch segment

### DIFF
--- a/packages/gateway/src/cch.ts
+++ b/packages/gateway/src/cch.ts
@@ -360,9 +360,18 @@ function computeVersionSuffix(firstUserMessage: string): string {
  * LTM / system / message content — even if that content serializes BEFORE the
  * real header. Matching content would rewrite it every turn and bust the
  * entire prompt cache (the original incident's failure mode).
+ *
+ * The trailing `cch=…;` segment is OPTIONAL: Claude Code >= 2.1.181 omits it
+ * entirely when it does not assume a first-party base URL (no
+ * `_CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL=1`, e.g. a client launched outside
+ * `lore run`/`lore setup`). When absent the replacement still emits the
+ * `cch=00000;` placeholder, which `signBody` then signs — so a cch-less header
+ * is re-signed exactly like a cch-bearing one (issue #807). The greedy optional
+ * group consumes ` cch=<5hex>;` when present, so the cch-bearing match is
+ * byte-identical to before.
  */
 const BILLING_RESIGN_RE =
-  /x-anthropic-billing-header:\s*cc_version=[^;]*;\s*cc_entrypoint=([^;]*);\s*cch=[0-9a-fA-F]{5};/;
+  /x-anthropic-billing-header:\s*cc_version=[^;]*;\s*cc_entrypoint=([^;]*);(?:\s*cch=[0-9a-fA-F]{5};)?/;
 
 /**
  * Matches a full signed billing header for validation. Group 1 is the whole
@@ -405,6 +414,12 @@ export function resignBody(
   // version + recomputed suffix and reset cch to the placeholder. cc_entrypoint
   // (group 1) is preserved verbatim. The suffix depends on chars[4,7,20] of the
   // first user message.
+  //
+  // The replacement ALWAYS emits `${CCH_PLACEHOLDER};` whether or not the client
+  // header carried a `cch=…;` segment — cch-less headers (Claude Code >= 2.1.181
+  // launched without _CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL) get the
+  // placeholder injected here, so signBody (below) always has something to sign
+  // (issue #807).
   const suffix = computeVersionSuffix(firstUserMessage);
   const body = serializedBody.replace(
     BILLING_RESIGN_RE,
@@ -421,9 +436,17 @@ export function resignBody(
 // Per-session bearer-token registry
 // ---------------------------------------------------------------------------
 
-/** Regex to detect a billing header in a system prompt. */
+/**
+ * Regex to detect a billing header in a system prompt. The trailing `cch=…;`
+ * segment is OPTIONAL: Claude Code >= 2.1.181 omits `cch` when it does not
+ * assume a first-party base URL (no `_CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL=1`),
+ * but the header is still a real Claude Code OAuth billing header that must mark
+ * the session and gate re-signing (issue #807). The `^` anchor is load-bearing —
+ * only a real header at system[0] matches; a content-quoted sentinel (never at
+ * offset 0) is correctly rejected.
+ */
 const BILLING_HEADER_RE =
-  /^x-anthropic-billing-header:\s*cc_version=[^;]+;\s*cc_entrypoint=[^;]+;\s*cch=[0-9a-fA-F]+;/;
+  /^x-anthropic-billing-header:\s*cc_version=[^;]+;\s*cc_entrypoint=[^;]+;(?:\s*cch=[0-9a-fA-F]+;)?/;
 
 /** Check if a system prompt contains the Claude Code billing header. */
 export function hasBillingHeader(system: string): boolean {

--- a/packages/gateway/test/cch.test.ts
+++ b/packages/gateway/test/cch.test.ts
@@ -9,6 +9,7 @@ import {
   buildCodexWorkerHeaders,
   buildOAuthWorkerHeaders,
   deleteBillingPrefix,
+  isClaudeCodeOAuthSession,
   validateSeed,
   resolveSeed,
   _resetForTest,
@@ -990,6 +991,20 @@ describe("billing-header first-block invariant", () => {
     expect(warnings[0]).toContain("billing-header markers");
   });
 
+  test("WARNS when content reproduces a cch-LESS full sentinel after the real header (issue #807)", () => {
+    // The cch-optional regexes (issue #807) widen the matchable surface: a
+    // cch-less full sentinel in content is now a second marker. Signing still
+    // targets the real header (first block), but the duplicate must surface the
+    // early-warning rather than silently risk a wrong-token sign / cache bust.
+    signBody(
+      headerFirst([
+        "docs: `x-anthropic-billing-header: cc_version=2.1.0.aaa; cc_entrypoint=cli;`",
+      ]),
+    );
+    expect(warnings.length).toBeGreaterThan(0);
+    expect(warnings[0]).toContain("billing-header markers");
+  });
+
   test("does NOT warn when content has a cch= token but NOT the full sentinel", () => {
     // A bare `cch=00000` / `cc_entrypoint=…` fragment in content is NOT a
     // duplicate marker, so it must not trip the guard (no false positives on
@@ -1651,5 +1666,140 @@ describe("buildCodexWorkerHeaders", () => {
     const h1 = buildCodexWorkerHeaders("codex-sess");
     const h2 = buildCodexWorkerHeaders("codex-sess");
     expect(h1?.["x-client-request-id"]).not.toBe(h2?.["x-client-request-id"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cch-less billing header (issue #807)
+// ---------------------------------------------------------------------------
+
+describe("cch-less billing header (issue #807)", () => {
+  // Claude Code >= 2.1.181 only emits the `cch` field when it believes it is
+  // talking to the first-party API. A client launched WITHOUT
+  // _CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL=1 (i.e. not via `lore run`/`lore
+  // setup`) sends a billing header whose `cch=…;` segment is entirely absent.
+  // The gateway must still detect it, mark the OAuth session, and inject +
+  // sign a placeholder when re-signing.
+  const CCHLESS_HEADER =
+    "x-anthropic-billing-header: cc_version=2.1.181.abc; cc_entrypoint=cli;";
+  const CCH_HEADER =
+    "x-anthropic-billing-header: cc_version=2.1.181.abc; cc_entrypoint=cli; cch=1a2b3;";
+
+  // (a) Detection -----------------------------------------------------------
+
+  test("hasBillingHeader is TRUE for a cch-less header at system start", () => {
+    expect(hasBillingHeader(CCHLESS_HEADER)).toBe(true);
+  });
+
+  test("hasBillingHeader is TRUE for a cch-less header followed by host prompt", () => {
+    expect(hasBillingHeader(`${CCHLESS_HEADER}\nYou are Claude Code.`)).toBe(
+      true,
+    );
+  });
+
+  test("hasBillingHeader still TRUE for a cch-bearing header (regression anchor)", () => {
+    expect(hasBillingHeader(CCH_HEADER)).toBe(true);
+  });
+
+  test("hasBillingHeader is FALSE when a cch-less sentinel is quoted in content", () => {
+    // Not at offset 0 → the ^ anchor rejects it (api-key session editing cch.ts).
+    expect(
+      hasBillingHeader(`You are Claude Code.\n\nExample: ${CCHLESS_HEADER}`),
+    ).toBe(false);
+  });
+
+  // (b) OAuth session marking ----------------------------------------------
+
+  test("captureBillingPrefix marks the OAuth session for a cch-less header", () => {
+    expect(captureBillingPrefix(SID_A, CCHLESS_HEADER)).toBe(true);
+    expect(isClaudeCodeOAuthSession(SID_A)).toBe(true);
+    expect(buildBillingBlock(SID_A, "Summarize this.")).not.toBeNull();
+    expect(buildOAuthWorkerHeaders(SID_A)).not.toBeNull();
+  });
+
+  // (c) Re-signing ----------------------------------------------------------
+
+  test("resignBody injects a placeholder and signs a cch-less header", () => {
+    const body = JSON.stringify({
+      model: "claude-opus-4-8",
+      max_tokens: 8192,
+      system: [
+        {
+          type: "text",
+          text: CCHLESS_HEADER,
+          cache_control: { type: "ephemeral", ttl: "1h" },
+        },
+        { type: "text", text: "You are a helpful assistant." },
+      ],
+      messages: [{ role: "user", content: "explain caching please" }],
+    });
+
+    const resigned = resignBody(body, "explain caching please");
+    // A real signed cch was produced (not the placeholder, not absent).
+    expect(resigned).not.toContain("cch=00000");
+    expect(resigned).toMatch(/cch=[0-9a-f]{5};/);
+    // cc_version rewritten to the worker version + 3-hex suffix.
+    expect(resigned).toMatch(
+      new RegExp(`cc_version=${WORKER_VERSION}\\.[0-9a-f]{3};`),
+    );
+    // cc_entrypoint preserved.
+    expect(resigned).toContain("cc_entrypoint=cli;");
+    // Validates against our known seed.
+    expect(validateSeed(resigned)).toBe(true);
+  });
+
+  test("resignBody preserves a non-default cc_entrypoint on a cch-less header", () => {
+    const body = JSON.stringify({
+      system: [
+        {
+          type: "text",
+          text: "x-anthropic-billing-header: cc_version=2.1.181.abc; cc_entrypoint=vscode;",
+        },
+      ],
+      messages: [{ role: "user", content: "hi there friend" }],
+    });
+    const resigned = resignBody(body, "hi there friend");
+    expect(resigned).toContain("cc_entrypoint=vscode;");
+    expect(validateSeed(resigned)).toBe(true);
+  });
+
+  test("resignBody cch-bearing path still validates (regression anchor)", () => {
+    const body = JSON.stringify({
+      system: [{ type: "text", text: CCH_HEADER }],
+      messages: [{ role: "user", content: "hi there friend" }],
+    });
+    const resigned = resignBody(body, "hi there friend");
+    expect(resigned).not.toContain("cch=1a2b3");
+    expect(validateSeed(resigned)).toBe(true);
+  });
+
+  test("resignBody is a no-op when a cch-less sentinel only appears in content (no real header)", () => {
+    // No full `x-anthropic-billing-header:` sentinel anywhere → pure no-op.
+    const body = JSON.stringify({
+      system: [{ type: "text", text: "note: header is `cc_entrypoint=cli;`" }],
+      messages: [{ role: "user", content: "hi" }],
+    });
+    expect(resignBody(body, "hi")).toBe(body);
+  });
+
+  // (d) Pipeline-gate simulation -------------------------------------------
+
+  test("pipeline gate re-signs a cch-less header at system[0] to a valid worker cch", () => {
+    const system = `${CCHLESS_HEADER}\nYou are Claude Code.`;
+    const serializedBody = JSON.stringify({
+      model: "claude-sonnet-4-20250514",
+      max_tokens: 1024,
+      system: [{ type: "text", text: system }],
+      messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+    });
+    // Mirror pipeline.ts forwardToUpstream: re-sign only when the real header
+    // is at system[0].
+    const out = hasBillingHeader(system)
+      ? resignBody(serializedBody, "hi")
+      : serializedBody;
+
+    expect(out).not.toBe(serializedBody); // gate fired → re-signed
+    expect(out).toMatch(/cch=[0-9a-f]{5};/);
+    expect(validateSeed(out)).toBe(true);
   });
 });


### PR DESCRIPTION
## What & why

Closes #807. Follow-up to #806.

Claude Code ≥ 2.1.181 only emits the `cch` field in its `x-anthropic-billing-header` when it believes it is talking to the first-party API. PR #806 keeps `cch` flowing for all **`lore`-managed** launches by setting `_CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL=1`. This PR adds the **defensive gateway-side fallback** for a billing header that arrives **without** a `cch` segment — a now-reachable state for any non-`lore`-managed launcher (manual `ANTHROPIC_BASE_URL`, or a future env-var rename by Anthropic).

### The gap (all on two regexes in `cch.ts`)

A `cch`-less header looks like:

    x-anthropic-billing-header: cc_version=<semver>.<suffix>; cc_entrypoint=<x>;

- `BILLING_HEADER_RE` required `cch=[0-9a-fA-F]+;` → `hasBillingHeader()` false → the pipeline resign gate (`pipeline.ts`) was skipped → body forwarded **unsigned**.
- `captureBillingPrefix()` is gated on the same regex → the session was never marked → `buildBillingBlock` / `buildOAuthWorkerHeaders` / `isClaudeCodeOAuthSession` all no-op → worker calls (distillation/curation) lose their billing header + OAuth fingerprint → **401 risk**.
- `BILLING_RESIGN_RE` required `cch=[0-9a-fA-F]{5};` → `resignBody()` returned the body unchanged (never signed).

## The fix

Make the trailing `cch=…;` segment **optional** in both regexes:

```diff
-  /x-anthropic-billing-header:\s*cc_version=[^;]*;\s*cc_entrypoint=([^;]*);\s*cch=[0-9a-fA-F]{5};/
+  /x-anthropic-billing-header:\s*cc_version=[^;]*;\s*cc_entrypoint=([^;]*);(?:\s*cch=[0-9a-fA-F]{5};)?/

-  /^x-anthropic-billing-header:\s*cc_version=[^;]+;\s*cc_entrypoint=[^;]+;\s*cch=[0-9a-fA-F]+;/
+  /^x-anthropic-billing-header:\s*cc_version=[^;]+;\s*cc_entrypoint=[^;]+;(?:\s*cch=[0-9a-fA-F]+;)?/
```

`resignBody`'s replacement callback is unchanged — it already emits `cch=00000;` unconditionally, so a `cch`-less header gets the placeholder injected and then `signBody` signs it, exactly like a `cch`-bearing one.

No `pipeline.ts` change: its resign gate already routes through `hasBillingHeader`.

## Safety / no regression

- **Byte-identical signed path:** the greedy optional group consumes ` cch=<5hex>;` when present, so the `cch`-bearing match (and `resignBody` output) is byte-identical to before. The existing exact-equality test (`produces same result as signing from scratch`) still passes.
- **`^` anchor preserved** on `BILLING_HEADER_RE` → a content-quoted sentinel (never at offset 0) still returns false.
- **Cache-bust safety preserved:** `BILLING_RESIGN_RE` still requires the full `x-anthropic-billing-header: …` sentinel; the real header is always system[0] and serializes first, so first-match targets it. `verifyBillingHeaderUnique` still warns on the widened match surface (locked in by a new test).
- **Out of scope:** an empty-valued `cch=;` (vs. an absent segment) leaves a harmless stray token — Claude Code omits the whole segment, not the value. Documented, no crash, valid JSON.

## Tests

New `describe("cch-less billing header (issue #807)")` (TDD — written RED first): detection (with/without host prompt, content-quoted false), OAuth-session marking (`captureBillingPrefix` → `isClaudeCodeOAuthSession`/`buildBillingBlock`/`buildOAuthWorkerHeaders`), re-signing (placeholder injection + `validateSeed`, `cc_entrypoint` preserved, `cch`-bearing regression anchor, no-op without a real header), and a pipeline-gate simulation. Plus a permanent unique-marker warning test for the widened surface.

## Verification

- `pnpm -r run typecheck` — 0 errors
- `pnpm run lint` — clean (changed files); 13 pre-existing warnings unrelated
- `pnpm test` — full suite green (**+11** new cch tests)
- `pnpm run build` — ok