### PR TITLE
fix(gateway): stop consolidation retry storm across worktrees and concurrent sessions

### DIFF
--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -17,6 +17,7 @@ import {
   distillation,
   curator,
   ltm,
+  ensureProject,
   latReader,
   log,
   config as loreConfig,
@@ -93,16 +94,64 @@ const POLL_INTERVAL_MS = 30_000;
  * (e.g. all entries are genuinely unique), we record the attempt so the
  * idle scheduler doesn't retry every 30s — which wastes Sonnet calls.
  *
- * Keyed by projectPath. Cleared when entry count changes (new curation
- * creates/deletes entries) so consolidation retries with fresh data.
+ * Keyed by resolved PROJECT ID (not the raw session/worktree path): N worktrees
+ * of one repo resolve to a single canonical project via ensureProject(), and
+ * ltm.forProject() operates on that shared knowledge set. Keying by raw path
+ * gave each worktree its own cooldown bucket guarding the same entries, so
+ * consolidation ran N× redundantly (bug: the consolidation retry storm).
  */
 const consolidationCooldown = new Map<
   string,
   { attemptedAt: number; entryCount: number; topCategoryCount: number }
 >();
 
+/**
+ * Projects with an in-flight consolidation LLM call (keyed by resolved project
+ * ID). The cooldown is checked before the `await` and set after it returns, so
+ * without this guard concurrent idle sessions for the same project all pass the
+ * gate before any sets the cooldown → thundering herd. Set before the await,
+ * cleared in a `finally`.
+ */
+const consolidationInProgress = new Set<string>();
+
 /** 1 hour cooldown before retrying consolidation with the same entry count. */
-const CONSOLIDATION_COOLDOWN_MS = 60 * 60 * 1000;
+export const CONSOLIDATION_COOLDOWN_MS = 60 * 60 * 1000;
+
+/**
+ * Entry-count growth (since the last no-op consolidation) required to re-attempt
+ * early, before the cooldown window elapses. A no-op consolidation means the LLM
+ * found nothing to merge; only genuinely NEW entries create fresh merge
+ * candidates. A decrease (eviction/delete) or trivial churn does not — so the
+ * cooldown stays sticky against the count oscillation seen at a saturated cap.
+ */
+export const CONSOLIDATION_REATTEMPT_GROWTH = 3;
+
+/**
+ * Pure decision: is consolidation still on cooldown for this project?
+ *
+ * Returns true (skip) when a prior no-op attempt is still within the cooldown
+ * window AND the knowledge set has not materially grown since. Returns false
+ * (allow) when there is no prior attempt, the window has elapsed, or new merge
+ * candidates have appeared (global count grew past the reattempt threshold, or
+ * the top category grew).
+ */
+export function consolidationCooldownActive(
+  cooldown:
+    | { attemptedAt: number; entryCount: number; topCategoryCount: number }
+    | undefined,
+  now: number,
+  entryCount: number,
+  topCategoryCount: number,
+): boolean {
+  if (!cooldown) return false;
+  if (now - cooldown.attemptedAt >= CONSOLIDATION_COOLDOWN_MS) return false;
+  // Re-attempt early only when knowledge GREW (new merge candidates). A
+  // decrease yields no new opportunity, so the prior verdict still stands.
+  if (entryCount > cooldown.entryCount + CONSOLIDATION_REATTEMPT_GROWTH)
+    return false;
+  if (topCategoryCount > cooldown.topCategoryCount) return false;
+  return true;
+}
 
 /**
  * Per-category entry count that triggers consolidation even when the GLOBAL
@@ -471,16 +520,19 @@ export function evictIdleSessions(
     // Remove from the main sessions map last
     sessions.delete(sessionID);
 
-    // Clean up project-scoped cooldowns if no other session uses this project
+    // Clean up project-scoped consolidation state when no remaining session
+    // resolves to the same canonical project (worktrees share one project ID).
+    const evictedProjectId = ensureProject(state.projectPath);
     let projectStillActive = false;
     for (const [, s] of sessions) {
-      if (s.projectPath === state.projectPath) {
+      if (ensureProject(s.projectPath) === evictedProjectId) {
         projectStillActive = true;
         break;
       }
     }
     if (!projectStillActive) {
-      consolidationCooldown.delete(state.projectPath);
+      consolidationCooldown.delete(evictedProjectId);
+      consolidationInProgress.delete(evictedProjectId);
     }
 
     // GC the shared quota cache only when no remaining session uses this
@@ -551,6 +603,10 @@ export function buildIdleWorkHandler(
 ): (sessionID: string, state: SessionState) => Promise<void> {
   return async (sessionID: string, state: SessionState) => {
     const projectPath = state.projectPath;
+    // Resolve the raw worktree/session path to the canonical project ID so the
+    // consolidation cooldown / in-flight guard collapse across worktrees of the
+    // same repo (they share one knowledge set via ltm.forProject()).
+    const projectId = ensureProject(projectPath);
     const cfg = loreConfig();
     const model = getWorkerModel(state.lastUpstream);
 
@@ -644,9 +700,10 @@ export function buildIdleWorkHandler(
             );
             emitCurationMetrics({ ...result, trigger: "idle" });
             onKnowledgeChanged?.(sessionID, result);
-            // Entry count changed — clear consolidation cooldown so it
-            // retries with fresh data on the next idle tick.
-            consolidationCooldown.delete(projectPath);
+            // NOTE: intentionally do NOT clear the consolidation cooldown here.
+            // At a saturated cap, curation churns entries every sweep; clearing
+            // on any change defeated the cooldown entirely. consolidationCooldown-
+            // Active() instead re-attempts only when the set materially GROWS.
           }
         }
       } catch (e) {
@@ -682,19 +739,22 @@ export function buildIdleWorkHandler(
         const categoryOver =
           topCategoryCount > PER_CATEGORY_CONSOLIDATION_THRESHOLD;
         if (globalOver || categoryOver) {
-          const cooldown = consolidationCooldown.get(projectPath);
+          const cooldown = consolidationCooldown.get(projectId);
           const now = Date.now();
-          // Cooldown is keyed on the global count; include the top-category
-          // count so a category-only trigger still re-attempts as it grows.
-          const cooldownKey = entries.length;
+          // Skip when (a) a no-op attempt is still sticky (see helper), or
+          // (b) another idle session for this project already has a
+          // consolidation in flight — the cooldown is set only AFTER the await,
+          // so without this guard concurrent sessions all pass the gate.
           if (
-            cooldown &&
-            cooldown.entryCount === cooldownKey &&
-            cooldown.topCategoryCount === topCategoryCount &&
-            now - cooldown.attemptedAt < CONSOLIDATION_COOLDOWN_MS
+            consolidationCooldownActive(
+              cooldown,
+              now,
+              entries.length,
+              topCategoryCount,
+            ) ||
+            consolidationInProgress.has(projectId)
           ) {
-            // Cooldown active — skip to avoid wasting Sonnet calls on
-            // repeated consolidation attempts that produce no changes.
+            // Skip — avoid the consolidation retry storm.
           } else {
             log.info(
               globalOver
@@ -702,50 +762,55 @@ export function buildIdleWorkHandler(
                 : `category "${topCategory}" count ${topCategoryCount} exceeds per-category threshold ${PER_CATEGORY_CONSOLIDATION_THRESHOLD} — running consolidation`,
             );
             const beforeCount = entries.length;
-            const result = await Sentry.startSpan(
-              {
-                name: "lore.consolidation",
-                op: "lore.curation",
-                attributes: { trigger: "consolidation" },
-              },
-              () =>
-                curator.consolidate({
-                  llm,
-                  projectPath,
-                  sessionID,
-                  model,
-                  // Category-focused mode when only the per-category threshold
-                  // is exceeded (global count still under maxEntries) — merges
-                  // the bloated category's near-duplicates directly.
-                  ...(!globalOver && categoryOver
-                    ? { focusCategory: topCategory }
-                    : {}),
-                  workerHealth: makeWorkerHealth(sessionID, "lore-curator"),
-                }),
-            );
-            if (result.updated > 0 || result.deleted > 0) {
-              log.info(
-                `consolidation: ${result.updated} updated, ${result.deleted} deleted`,
+            consolidationInProgress.add(projectId);
+            try {
+              const result = await Sentry.startSpan(
+                {
+                  name: "lore.consolidation",
+                  op: "lore.curation",
+                  attributes: { trigger: "consolidation" },
+                },
+                () =>
+                  curator.consolidate({
+                    llm,
+                    projectPath,
+                    sessionID,
+                    model,
+                    // Category-focused mode when only the per-category threshold
+                    // is exceeded (global count still under maxEntries) — merges
+                    // the bloated category's near-duplicates directly.
+                    ...(!globalOver && categoryOver
+                      ? { focusCategory: topCategory }
+                      : {}),
+                    workerHealth: makeWorkerHealth(sessionID, "lore-curator"),
+                  }),
               );
-              emitCurationMetrics({
-                created: 0,
-                ...result,
-                trigger: "consolidation",
-              });
-              // Consolidation made progress — clear cooldown so it can retry
-              consolidationCooldown.delete(projectPath);
-            } else {
-              // Consolidation produced no changes — enter cooldown to prevent
-              // retry storm (the LLM thinks all entries are unique).
-              consolidationCooldown.set(projectPath, {
-                attemptedAt: Date.now(),
-                entryCount: beforeCount,
-                topCategoryCount,
-              });
-              log.info(
-                `consolidation produced no changes — cooldown active for 1h ` +
-                  `(${beforeCount} entries in ${projectPath})`,
-              );
+              if (result.updated > 0 || result.deleted > 0) {
+                log.info(
+                  `consolidation: ${result.updated} updated, ${result.deleted} deleted`,
+                );
+                emitCurationMetrics({
+                  created: 0,
+                  ...result,
+                  trigger: "consolidation",
+                });
+                // Consolidation made progress — clear cooldown so it can retry
+                consolidationCooldown.delete(projectId);
+              } else {
+                // Consolidation produced no changes — enter cooldown to prevent
+                // retry storm (the LLM thinks all entries are unique).
+                consolidationCooldown.set(projectId, {
+                  attemptedAt: Date.now(),
+                  entryCount: beforeCount,
+                  topCategoryCount,
+                });
+                log.info(
+                  `consolidation produced no changes — cooldown active for 1h ` +
+                    `(${beforeCount} entries in ${projectPath})`,
+                );
+              }
+            } finally {
+              consolidationInProgress.delete(projectId);
             }
           }
         }

--- a/packages/gateway/test/idle-work.test.ts
+++ b/packages/gateway/test/idle-work.test.ts
@@ -213,9 +213,11 @@ describe("buildIdleWorkHandler", () => {
     const llm = makeLLM(); // prompt() returns null → consolidation is a no-op
     const handler = buildIdleWorkHandler(llm);
     const projectPath = makeProjectDir();
-    // Seed enough single-category entries to exceed the per-category
-    // consolidation threshold (12) AND the global cap (40) on this branch.
-    for (let i = 0; i < 61; i++) {
+    // Seed one category well past the per-category consolidation threshold so
+    // the consolidation block fires regardless of the threshold/cap values on
+    // whichever branch of the stack runs this (they grow up the stack). 75
+    // comfortably clears the largest per-category threshold in the stack.
+    for (let i = 0; i < 75; i++) {
       ltm.create({
         projectPath,
         category: "preference",
@@ -245,11 +247,12 @@ describe("buildIdleWorkHandler", () => {
 
   test("consolidation that makes progress deletes the entry and clears the cooldown", async () => {
     const projectPath = makeProjectDir();
-    // 60 full-confidence entries plus one low-confidence target. The target
-    // (lowest confidence) is always in the consolidation set on every branch —
-    // whether the global batched path (lowest-confidence tail) or the
+    // 74 full-confidence entries plus one low-confidence target (75 total, well
+    // past the largest per-category threshold in the stack). The target, being
+    // the lowest confidence, is always in the consolidation set on every branch
+    // — whether the global batched path (lowest-confidence tail) or the
     // category-focused path (whole category) is taken.
-    for (let i = 0; i < 60; i++) {
+    for (let i = 0; i < 74; i++) {
       ltm.create({
         projectPath,
         category: "preference",

--- a/packages/gateway/test/idle-work.test.ts
+++ b/packages/gateway/test/idle-work.test.ts
@@ -209,6 +209,85 @@ describe("buildIdleWorkHandler", () => {
     expect(files.some((f) => f === "AGENTS.md" || f === ".lore.md")).toBe(true);
   });
 
+  test("runs consolidation when a category is over threshold, then the cooldown skips the next tick", async () => {
+    const llm = makeLLM(); // prompt() returns null → consolidation is a no-op
+    const handler = buildIdleWorkHandler(llm);
+    const projectPath = makeProjectDir();
+    // Seed enough single-category entries to exceed the per-category
+    // consolidation threshold (12) AND the global cap (40) on this branch.
+    for (let i = 0; i < 61; i++) {
+      ltm.create({
+        projectPath,
+        category: "preference",
+        title: `Pref ${i}`,
+        content: `Preference number ${i} content.`,
+        scope: "project",
+      });
+    }
+    const state = makeSessionState({
+      sessionID: "idle-consolidate",
+      projectPath,
+      turnsSinceCuration: 0, // keep curation from firing — isolate consolidation
+    });
+    const prompt = llm.prompt as ReturnType<typeof vi.fn>;
+
+    // First idle tick: over threshold → consolidation runs and calls the LLM.
+    // The no-op completion arms the cooldown.
+    await handler("idle-consolidate", state);
+    const callsAfterFirst = prompt.mock.calls.length;
+    expect(callsAfterFirst).toBeGreaterThan(0);
+
+    // Second idle tick: entry count unchanged → cooldown is active → the
+    // consolidation block is skipped, so the LLM is not called again.
+    await handler("idle-consolidate", state);
+    expect(prompt.mock.calls.length).toBe(callsAfterFirst);
+  });
+
+  test("consolidation that makes progress deletes the entry and clears the cooldown", async () => {
+    const projectPath = makeProjectDir();
+    // 60 full-confidence entries plus one low-confidence target. The target
+    // (lowest confidence) is always in the consolidation set on every branch —
+    // whether the global batched path (lowest-confidence tail) or the
+    // category-focused path (whole category) is taken.
+    for (let i = 0; i < 60; i++) {
+      ltm.create({
+        projectPath,
+        category: "preference",
+        title: `Keep ${i}`,
+        content: `Preference number ${i} content.`,
+        scope: "project",
+      });
+    }
+    const targetId = ltm.create({
+      projectPath,
+      category: "preference",
+      title: "Merge me",
+      content: "A near-duplicate preference the consolidator removes.",
+      scope: "project",
+      confidence: 0.3,
+    });
+    // LLM returns a consolidation delete op for the target → result.deleted > 0
+    // → the "made progress" branch (clears the cooldown).
+    const llm: LLMClient = {
+      prompt: vi.fn(async () =>
+        JSON.stringify({
+          ops: [{ op: "delete", id: targetId, reason: "dup" }],
+        }),
+      ),
+    };
+    const handler = buildIdleWorkHandler(llm);
+    const state = makeSessionState({
+      sessionID: "idle-consolidate-progress",
+      projectPath,
+      turnsSinceCuration: 0,
+    });
+
+    await handler("idle-consolidate-progress", state);
+
+    expect(llm.prompt).toHaveBeenCalled();
+    expect(ltm.get(targetId)).toBeNull(); // consolidation deleted it
+  });
+
   test("persists the session cost snapshot when conversation cost exists", async () => {
     const llm = makeLLM();
     const handler = buildIdleWorkHandler(llm);

--- a/packages/gateway/test/idle-work.test.ts
+++ b/packages/gateway/test/idle-work.test.ts
@@ -12,7 +12,13 @@ import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, rmSync, readdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { buildIdleWorkHandler, touchSession } from "../src/idle";
+import {
+  buildIdleWorkHandler,
+  touchSession,
+  consolidationCooldownActive,
+  CONSOLIDATION_COOLDOWN_MS,
+  CONSOLIDATION_REATTEMPT_GROWTH,
+} from "../src/idle";
 import { recordConversationCost, clearAllCosts } from "../src/cost-tracker";
 import { resetPipelineState } from "../src/pipeline";
 import { ltm, loadSessionCosts } from "@loreai/core";
@@ -91,6 +97,78 @@ describe("touchSession", () => {
   test("is a no-op for an unknown session", () => {
     const sessions = new Map<string, SessionState>();
     expect(() => touchSession(sessions, "nope")).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// consolidationCooldownActive (pure decision — no LLM, no DB)
+// ---------------------------------------------------------------------------
+
+describe("consolidationCooldownActive", () => {
+  const now = 1_000_000_000_000;
+  const fresh = (
+    over: Partial<{
+      attemptedAt: number;
+      entryCount: number;
+      topCategoryCount: number;
+    }> = {},
+  ) => ({
+    attemptedAt: now,
+    entryCount: 50,
+    topCategoryCount: 14,
+    ...over,
+  });
+
+  test("no prior cooldown → not active (allowed to run)", () => {
+    expect(consolidationCooldownActive(undefined, now, 50, 14)).toBe(false);
+  });
+
+  test("within the window with flat counts → active (sticky skip)", () => {
+    const cd = fresh();
+    expect(consolidationCooldownActive(cd, now + 60_000, 50, 14)).toBe(true);
+  });
+
+  test("stays sticky when the entry count DECREASES (eviction/delete)", () => {
+    // A decrease yields no new merge candidate, so the prior "nothing to
+    // merge" verdict still holds — must not re-trigger.
+    const cd = fresh({ entryCount: 50 });
+    expect(consolidationCooldownActive(cd, now + 60_000, 49, 14)).toBe(true);
+  });
+
+  test("stays sticky on small growth (<= reattempt threshold)", () => {
+    const cd = fresh({ entryCount: 50 });
+    expect(
+      consolidationCooldownActive(
+        cd,
+        now + 60_000,
+        50 + CONSOLIDATION_REATTEMPT_GROWTH,
+        14,
+      ),
+    ).toBe(true);
+  });
+
+  test("re-attempts when the entry count GROWS past the threshold", () => {
+    const cd = fresh({ entryCount: 50 });
+    expect(
+      consolidationCooldownActive(
+        cd,
+        now + 60_000,
+        50 + CONSOLIDATION_REATTEMPT_GROWTH + 1,
+        14,
+      ),
+    ).toBe(false);
+  });
+
+  test("re-attempts when the top category grows", () => {
+    const cd = fresh({ topCategoryCount: 14 });
+    expect(consolidationCooldownActive(cd, now + 60_000, 50, 15)).toBe(false);
+  });
+
+  test("expires after the cooldown window elapses", () => {
+    const cd = fresh();
+    expect(
+      consolidationCooldownActive(cd, now + CONSOLIDATION_COOLDOWN_MS, 50, 14),
+    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Problem

Logs were full of `consolidation produced no changes — cooldown active for 1h`. Across two log files, **1,198 consolidation runs produced only 164 changes (~86% wasted Sonnet calls)**. The same projects repeated endlessly: `opencode-lore` (190×), `witty-wolf` (150×), `lucky-cactus` (62×) — which are all **worktrees of the same repo**.

The consolidation cooldown was defeated three independent ways:

1. **Keyed by raw worktree path.** `ltm.forProject()` resolves every worktree to one canonical `project_id`, so N worktrees got N independent cooldown buckets all guarding the *same* knowledge set → consolidation ran N× redundantly.
2. **No in-flight guard (thundering herd).** The cooldown is checked *before* the `await curator.consolidate()` and set *after*. Concurrent idle sessions for one project all passed the gate before any set the cooldown (observed: 6 simultaneous runs within 2.5s).
3. **Cleared on every curation change.** At a saturated cap, curation churns entries every sweep; clearing the cooldown on any change defeated it entirely, and the brittle exact-`(count, topCategoryCount)` key re-triggered on the 40↔41 oscillation.

## Fix

- **Key the cooldown + a new `consolidationInProgress` guard by resolved `project_id`** (`ensureProject`) — collapses the per-worktree buckets and serialises concurrent sessions.
- **In-flight guard** added before the `await`, cleared in `finally` — kills the same-sweep herd.
- **Sticky cooldown**: stop clearing on curation churn; replace the exact-count check with a pure, unit-tested `consolidationCooldownActive()` that only re-attempts when the knowledge set materially **grows** (global count up by > `CONSOLIDATION_REATTEMPT_GROWTH`, or the top category grows) or the 1h window elapses.
- GC cleanup on session eviction now compares resolved project IDs.

This is the first of three changes addressing the consolidation storm + LTM cap saturation; it's the small, independent correctness fix that gives immediate relief.

## Tests

- New pure-helper tests for `consolidationCooldownActive` (sticky on flat/decreased counts, re-attempts on growth, expires after the window).
- Full suite: 3413 passed / 23 skipped. Typecheck, lint (no new warnings in touched files), and build all green.