### PR TITLE
feat(core): bound curator cost by token budget and prune dead knowledge

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -318,6 +318,17 @@ export const LoreConfig = z.object({
         .describe(
           "Max knowledge entries per project before consolidation. Default: 40.",
         ),
+      /** Token budget for the curator's existing-entries context. Default: 20000. */
+      contextTokenBudget: z
+        .number()
+        .min(2000)
+        .default(20000)
+        .describe(
+          "Token budget for the existing-entries context sent to the curator " +
+            "each run. Bounds curator LLM cost so it stops scaling with stored " +
+            "entry count; a generous safety ceiling that only trims pathological " +
+            "sets (cross-project entries are always kept). Default: 20000.",
+        ),
     })
     .default({
       enabled: true,
@@ -325,6 +336,7 @@ export const LoreConfig = z.object({
       inFlight: false,
       afterTurns: 3,
       maxEntries: 40,
+      contextTokenBudget: 20000,
     })
     .describe("Curator scheduling and consolidation thresholds."),
   pruning: z

--- a/packages/core/src/curator.ts
+++ b/packages/core/src/curator.ts
@@ -708,7 +708,12 @@ async function runInner(input: {
   // preferences created in earlier sessions (preferences default to
   // crossProject: true, so excluding them makes them invisible).
   // A project guard in applyOps prevents mutating entries from foreign projects.
-  const existing = ltm.forProject(input.projectPath, true);
+  // forCurator() token-budgets this set so curator LLM cost stops scaling with
+  // stored count (cross-project entries are always kept; see forCurator docs).
+  const existing = ltm.forCurator(
+    input.projectPath,
+    cfg.curator.contextTokenBudget,
+  );
   const existingForPrompt = existing.map((e) => ({
     id: e.id,
     category: e.category,

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -575,8 +575,11 @@ export const DEAD_CONFIDENCE_FLOOR = 0.2;
  * relevance floor (`confidence <= DEAD_CONFIDENCE_FLOOR`). They contribute
  * nothing (already filtered everywhere) and only bloat the row count and the
  * curator's existing-entries context. `remove()` tombstones each id so a stale
- * `.lore.md` re-import can't resurrect it. Restricted to PROJECT-SCOPED rows:
- * cross-project/global entries are shared and must not be reaped by one project.
+ * `.lore.md` re-import can't resurrect it. Restricted to EXCLUSIVELY
+ * project-owned rows (`cross_project = 0`): a cross-project entry keeps its
+ * origin `project_id` after promotion (promoteCrossProject flips the flag in
+ * place), so filtering on `project_id` alone would let a single project delete
+ * shared knowledge if its confidence decayed (Seer review, PR #815).
  * Returns the pruned entries (for op-log / metrics).
  */
 export function pruneDeadEntries(projectPath: string): KnowledgeEntry[] {
@@ -584,7 +587,7 @@ export function pruneDeadEntries(projectPath: string): KnowledgeEntry[] {
   const dead = db()
     .query(
       `SELECT ${KNOWLEDGE_COLS} FROM knowledge
-       WHERE project_id = ? AND confidence <= ?`,
+       WHERE project_id = ? AND cross_project = 0 AND confidence <= ?`,
     )
     .all(pid, DEAD_CONFIDENCE_FLOOR) as KnowledgeEntry[];
   for (const e of dead) remove(e.id);

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -563,6 +563,84 @@ export function forProject(
     .all(pid) as KnowledgeEntry[];
 }
 
+/**
+ * Relevance floor: entries at or below this confidence are filtered out of
+ * `forProject()` (it requires `confidence > 0.2`), so they are invisible to
+ * injection, curation, and consolidation — pure dead weight.
+ */
+export const DEAD_CONFIDENCE_FLOOR = 0.2;
+
+/**
+ * Hard-delete a project's "dead" entries — those that have decayed to/below the
+ * relevance floor (`confidence <= DEAD_CONFIDENCE_FLOOR`). They contribute
+ * nothing (already filtered everywhere) and only bloat the row count and the
+ * curator's existing-entries context. `remove()` tombstones each id so a stale
+ * `.lore.md` re-import can't resurrect it. Restricted to PROJECT-SCOPED rows:
+ * cross-project/global entries are shared and must not be reaped by one project.
+ * Returns the pruned entries (for op-log / metrics).
+ */
+export function pruneDeadEntries(projectPath: string): KnowledgeEntry[] {
+  const pid = ensureProject(projectPath);
+  const dead = db()
+    .query(
+      `SELECT ${KNOWLEDGE_COLS} FROM knowledge
+       WHERE project_id = ? AND confidence <= ?`,
+    )
+    .all(pid, DEAD_CONFIDENCE_FLOOR) as KnowledgeEntry[];
+  for (const e of dead) remove(e.id);
+  return dead;
+}
+
+/** Token cost of one entry as the curator prompt renders it (see curatorUser). */
+function curatorEntryTokens(e: KnowledgeEntry): number {
+  return estimateTokens(`[${e.id}] (${e.category}) ${e.title}: ${e.content}`);
+}
+
+/**
+ * Budget the curator's "existing entries" context so curator LLM cost stops
+ * scaling with stored count. Returns the entries the curator may update / delete
+ * / dedup against, packed into `maxTokens` by priority:
+ *
+ *   1. ALL cross-project / global entries — shared and few; they must stay
+ *      visible so a project can update them and avoid re-minting duplicates.
+ *   2. Project-scoped entries in `forProject` rank order (confidence DESC,
+ *      updated_at DESC), packed greedily until the budget is exhausted.
+ *
+ * When everything fits (the common case) the full set is returned unchanged.
+ * Dropped entries are the lowest-confidence / stalest project-scoped ones —
+ * least likely to be re-observed this session; the curator's post-create
+ * embedding dedup sweep backstops any duplicate minted for an unseen entry.
+ * Result preserves `forProject` ordering for determinism.
+ */
+export function forCurator(
+  projectPath: string,
+  maxTokens: number,
+): KnowledgeEntry[] {
+  const all = forProject(projectPath, true);
+  let total = 0;
+  for (const e of all) total += curatorEntryTokens(e);
+  if (total <= maxTokens) return all;
+
+  const keep = new Set<string>();
+  let used = 0;
+  // Pass 1: pin all cross-project / global entries (always visible).
+  for (const e of all) {
+    if (e.cross_project === 1 || e.project_id === null) {
+      keep.add(e.id);
+      used += curatorEntryTokens(e);
+    }
+  }
+  // Pass 2: pack project-scoped entries by rank until the budget is full.
+  for (const e of all) {
+    if (e.cross_project === 1 || e.project_id === null) continue;
+    const cost = curatorEntryTokens(e);
+    if (used + cost > maxTokens) continue;
+    keep.add(e.id);
+    used += cost;
+  }
+  return all.filter((e) => keep.has(e.id));
+}
+
 type Scored = { entry: KnowledgeEntry; score: number };
 
 /** BM25 column weights for knowledge_fts: title, content, category.

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -603,8 +603,19 @@ function curatorEntryTokens(e: KnowledgeEntry): number {
  *
  *   1. ALL cross-project / global entries — shared and few; they must stay
  *      visible so a project can update them and avoid re-minting duplicates.
- *   2. Project-scoped entries in `forProject` rank order (confidence DESC,
- *      updated_at DESC), packed greedily until the budget is exhausted.
+ *   2. Project-scoped entries are CONSIDERED in `forProject` rank order
+ *      (confidence DESC, updated_at DESC), so the highest-confidence entries are
+ *      always packed first.
+ *
+ * Pass 2 uses `continue` (not `break`) on an over-budget entry — matching the
+ * established `forSession` packer. This MAXIMISES the number of entries the
+ * curator can see (its whole job is to dedup/update against existing knowledge,
+ * so coverage minimises duplicate creation), and it never sacrifices a
+ * high-confidence entry for a low-confidence one: by the time an entry is
+ * skipped for size, every higher-ranked entry has already been packed. `break`
+ * would be strictly worse — a single oversized top entry would drop the entire
+ * remainder, so the curator could see zero existing entries and re-mint
+ * everything.
  *
  * When everything fits (the common case) the full set is returned unchanged.
  * Dropped entries are the lowest-confidence / stalest project-scoped ones —

--- a/packages/core/test/config.test.ts
+++ b/packages/core/test/config.test.ts
@@ -105,11 +105,22 @@ describe("LoreConfig — curator schema", () => {
     expect(cfg.curator.inFlight).toBe(false);
     expect(cfg.curator.afterTurns).toBe(3);
     expect(cfg.curator.maxEntries).toBe(40);
+    expect(cfg.curator.contextTokenBudget).toBe(20000);
   });
 
   test("curator.maxEntries can be customised", () => {
     const cfg = LoreConfig.parse({ curator: { maxEntries: 30 } });
     expect(cfg.curator.maxEntries).toBe(30);
+  });
+
+  test("curator.contextTokenBudget can be customised (min 2000)", () => {
+    expect(
+      LoreConfig.parse({ curator: { contextTokenBudget: 8000 } }).curator
+        .contextTokenBudget,
+    ).toBe(8000);
+    expect(() =>
+      LoreConfig.parse({ curator: { contextTokenBudget: 500 } }),
+    ).toThrow();
   });
 
   test("curator.maxEntries minimum is 10", () => {

--- a/packages/core/test/ltm-curator-budget.test.ts
+++ b/packages/core/test/ltm-curator-budget.test.ts
@@ -50,6 +50,29 @@ describe("ltm.pruneDeadEntries", () => {
     expect(ltm.get(alive)).not.toBeNull();
   });
 
+  test("never prunes a promoted cross-project entry that kept its origin project_id (Seer #815)", () => {
+    // Promotion (promoteCrossProject) flips cross_project = 1 in place, keeping
+    // the origin project_id. A decayed promoted entry must NOT be reaped by its
+    // origin project — that would delete shared knowledge for everyone.
+    const promoted = ltm.create({
+      projectPath: PROJECT,
+      category: "preference",
+      title: "Promoted shared",
+      content: "x",
+      scope: "project",
+    });
+    db()
+      .query(
+        "UPDATE knowledge SET cross_project = 1, confidence = 0.1 WHERE id = ?",
+      )
+      .run(promoted);
+
+    const pruned = ltm.pruneDeadEntries(PROJECT);
+
+    expect(pruned).toHaveLength(0);
+    expect(ltm.get(promoted)).not.toBeNull();
+  });
+
   test("never touches other-project or cross-project (global) dead entries", () => {
     const otherDead = ltm.create({
       projectPath: OTHER,

--- a/packages/core/test/ltm-curator-budget.test.ts
+++ b/packages/core/test/ltm-curator-budget.test.ts
@@ -1,0 +1,147 @@
+import { describe, test, expect, beforeEach } from "vitest";
+import { db } from "../src/db";
+import * as ltm from "../src/ltm";
+
+const PROJECT = "/test/ltm/curator-budget";
+const OTHER = "/test/ltm/curator-budget-other";
+
+function clearKnowledge() {
+  db().query("DELETE FROM knowledge").run();
+}
+
+// ---------------------------------------------------------------------------
+// pruneDeadEntries
+// ---------------------------------------------------------------------------
+
+describe("ltm.pruneDeadEntries", () => {
+  beforeEach(clearKnowledge);
+
+  test("deletes only project entries at/below the 0.2 floor and tombstones them", () => {
+    const dead = ltm.create({
+      projectPath: PROJECT,
+      category: "gotcha",
+      title: "Dead",
+      content: "decayed out",
+      scope: "project",
+    });
+    ltm.update(dead, { confidence: 0.1 });
+    const boundary = ltm.create({
+      projectPath: PROJECT,
+      category: "gotcha",
+      title: "Boundary",
+      content: "exactly at floor",
+      scope: "project",
+    });
+    ltm.update(boundary, { confidence: 0.2 }); // forProject filters > 0.2, so 0.2 is dead
+    const alive = ltm.create({
+      projectPath: PROJECT,
+      category: "gotcha",
+      title: "Alive",
+      content: "still useful",
+      scope: "project",
+    });
+
+    const pruned = ltm.pruneDeadEntries(PROJECT);
+
+    expect(pruned.map((e) => e.id).sort()).toEqual([dead, boundary].sort());
+    expect(ltm.get(dead)).toBeNull();
+    expect(ltm.get(boundary)).toBeNull();
+    expect(ltm.isTombstoned(dead)).toBe(true);
+    expect(ltm.get(alive)).not.toBeNull();
+  });
+
+  test("never touches other-project or cross-project (global) dead entries", () => {
+    const otherDead = ltm.create({
+      projectPath: OTHER,
+      category: "gotcha",
+      title: "OtherDead",
+      content: "x",
+      scope: "project",
+    });
+    ltm.update(otherDead, { confidence: 0.0 });
+    const globalDead = ltm.create({
+      category: "preference",
+      title: "GlobalDead",
+      content: "z",
+      scope: "global",
+      crossProject: true,
+    });
+    ltm.update(globalDead, { confidence: 0.0 });
+
+    const pruned = ltm.pruneDeadEntries(PROJECT);
+
+    expect(pruned).toHaveLength(0);
+    expect(ltm.get(otherDead)).not.toBeNull();
+    expect(ltm.get(globalDead)).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// forCurator (token-budgeted existing-entries context)
+// ---------------------------------------------------------------------------
+
+describe("ltm.forCurator", () => {
+  beforeEach(clearKnowledge);
+
+  test("returns the full set unchanged when it fits the budget", () => {
+    for (let i = 0; i < 5; i++) {
+      ltm.create({
+        projectPath: PROJECT,
+        category: "gotcha",
+        title: `T${i}`,
+        content: "short",
+        scope: "project",
+      });
+    }
+    const out = ltm.forCurator(PROJECT, 1_000_000);
+    expect(out).toHaveLength(5);
+  });
+
+  test("over budget: always includes cross-project entries, packs project-scoped by confidence, never exceeds budget", () => {
+    const global = ltm.create({
+      category: "preference",
+      title: "Global pref",
+      content: "g".repeat(300),
+      scope: "global",
+      crossProject: true,
+    });
+    const ids: string[] = [];
+    for (let i = 0; i < 20; i++) {
+      ids.push(
+        ltm.create({
+          projectPath: PROJECT,
+          category: "gotcha",
+          title: `T${i}`,
+          content: "c".repeat(300),
+          scope: "project",
+          confidence: 1 - i * 0.01, // T0 highest → T19 lowest
+        }),
+      );
+    }
+
+    const budget = 400; // tokens — only a few entries fit
+    const out = ltm.forCurator(PROJECT, budget);
+
+    // Cross-project entry is always visible (shared; must be dedup/update-able).
+    expect(out.some((e) => e.id === global)).toBe(true);
+    // Highest-confidence project entry kept; lowest dropped.
+    expect(out.some((e) => e.id === ids[0])).toBe(true);
+    expect(out.some((e) => e.id === ids[19])).toBe(false);
+    // The project-scoped slice never exceeds the token budget.
+    const projTokens = out
+      .filter((e) => e.project_id !== null && e.cross_project !== 1)
+      .reduce(
+        (sum, e) =>
+          sum +
+          Math.ceil(
+            `[${e.id}] (${e.category}) ${e.title}: ${e.content}`.length / 3,
+          ),
+        0,
+      );
+    expect(projTokens).toBeLessThanOrEqual(budget);
+    // Result preserves forProject ordering (confidence DESC).
+    const projOut = out.filter((e) => e.cross_project !== 1);
+    const confs = projOut.map((e) => e.confidence);
+    expect(confs).toEqual([...confs].sort((a, b) => b - a));
+  });
+});

--- a/packages/core/test/ltm-curator-budget.test.ts
+++ b/packages/core/test/ltm-curator-budget.test.ts
@@ -144,4 +144,38 @@ describe("ltm.forCurator", () => {
     const confs = projOut.map((e) => e.confidence);
     expect(confs).toEqual([...confs].sort((a, b) => b - a));
   });
+
+  test("an oversized top-confidence entry does not starve smaller lower-confidence entries (continue, not break)", () => {
+    // The highest-confidence entry alone blows the budget. A break-on-overflow
+    // packer would drop EVERYTHING after it (curator sees nothing); the
+    // continue-on-overflow packer skips just the oversized entry and keeps the
+    // smaller ones it can still afford — maximising dedup coverage.
+    const huge = ltm.create({
+      projectPath: PROJECT,
+      category: "gotcha",
+      title: "Huge",
+      content: "h".repeat(3000), // ~1000 tokens — exceeds the budget alone
+      scope: "project",
+      confidence: 1.0,
+    });
+    const small: string[] = [];
+    for (let i = 0; i < 3; i++) {
+      small.push(
+        ltm.create({
+          projectPath: PROJECT,
+          category: "gotcha",
+          title: `Small ${i}`,
+          content: "s".repeat(30), // ~tens of tokens each
+          scope: "project",
+          confidence: 0.9 - i * 0.01,
+        }),
+      );
+    }
+
+    const out = ltm.forCurator(PROJECT, 300);
+
+    expect(out.some((e) => e.id === huge)).toBe(false); // oversized → skipped
+    // ...but the smaller, lower-confidence entries are still visible.
+    expect(small.every((id) => out.some((e) => e.id === id))).toBe(true);
+  });
 });

--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -711,7 +711,24 @@ export function buildIdleWorkHandler(
       }
     }
 
-    // 3. Consolidation — runs after curation so new entries are counted.
+    // 3. Prune dead knowledge — hard-delete entries that have decayed to/below
+    //    the relevance floor (already invisible everywhere). Local DB-only step,
+    //    so it runs regardless of allowWorker. Keeps the row count and the
+    //    curator's existing-entries context lean.
+    if (cfg.knowledge.enabled) {
+      try {
+        const pruned = ltm.pruneDeadEntries(projectPath);
+        if (pruned.length > 0) {
+          log.info(
+            `pruned ${pruned.length} dead knowledge entries (<= relevance floor)`,
+          );
+        }
+      } catch (e) {
+        log.error("idle dead-entry prune error:", e);
+      }
+    }
+
+    // 4. Consolidation — runs after curation so new entries are counted.
     //    Cooldown: skip if we already attempted consolidation for this project
     //    with the same entry count within the last hour — avoids wasting
     //    Sonnet calls when the LLM correctly concludes all entries are unique.
@@ -819,7 +836,7 @@ export function buildIdleWorkHandler(
       }
     }
 
-    // 4. Temporal pruning
+    // 5. Temporal pruning
     try {
       const { ttlDeleted, capDeleted } = temporal.prune({
         projectPath,
@@ -835,7 +852,7 @@ export function buildIdleWorkHandler(
       log.error("idle pruning error:", e);
     }
 
-    // 5. Knowledge export (.lore.md + optional agents file)
+    // 6. Knowledge export (.lore.md + optional agents file)
     if (cfg.knowledge.enabled) {
       try {
         const entries = ltm.forProject(projectPath, false);
@@ -859,7 +876,7 @@ export function buildIdleWorkHandler(
       }
     }
 
-    // 6. Dead reference cleanup
+    // 7. Dead reference cleanup
     if (cfg.knowledge.enabled) {
       try {
         const cleaned = ltm.cleanDeadRefs();
@@ -871,17 +888,17 @@ export function buildIdleWorkHandler(
       }
     }
 
-    // 7. lat.md refresh
+    // 8. lat.md refresh
     try {
       latReader.refresh(projectPath);
     } catch (e) {
       log.error("idle lat-reader refresh error:", e);
     }
 
-    // 8. Emit session cost/savings metrics to Sentry
+    // 9. Emit session cost/savings metrics to Sentry
     emitSessionCostMetrics(sessionID);
 
-    // 9. Persist live session cost snapshot to DB so historical estimates
+    // 10. Persist live session cost snapshot to DB so historical estimates
     //    include all worker costs, avoided compactions, cache warming,
     //    1h TTL, and batch API savings after restart.
     try {

--- a/packages/website/src/content/docs/docs/configuration.md
+++ b/packages/website/src/content/docs/docs/configuration.md
@@ -132,6 +132,7 @@ Curator scheduling and consolidation thresholds.
 | `inFlight` | boolean | `false` |  | Run the curator mid-conversation (turn-based), not just on idle. Default: false. WARNING: only enable on free-write / non-caching providers (e.g. MiniMax). On cache-sensitive providers (Anthropic), mid-session curation changes the knowledge base, which rewrites the context-bound LTM block (system[2]) and busts the prompt cache for the rest of a large conversation (a single change can re-write hundreds of thousands of cached tokens). Deferring curation to idle makes that rewrite free (the cache is cold then). Where cache writes are free this is harmless and yields fresher knowledge sooner. |
 | `afterTurns` | number | `3` | min 1 | Minimum turns between curator runs. Default: 3. |
 | `maxEntries` | number | `40` | min 10 | Max knowledge entries per project before consolidation. Default: 40. |
+| `contextTokenBudget` | number | `20000` | min 2000 | Token budget for the existing-entries context sent to the curator each run. Bounds curator LLM cost so it stops scaling with stored entry count; a generous safety ceiling that only trims pathological sets (cross-project entries are always kept). Default: 20000. |
 
 
 ## `pruning`


### PR DESCRIPTION
> Stacked on #814 (base = `fix/consolidation-cooldown-correctness`). Review/merge that first.

## Why

A count cap on stored knowledge is the wrong primary control: **injection is already token-budget-capped** by `forSession`, so what the agent sees never depends on stored count. The cap's *only* real job is bounding **curator LLM cost** — `curator.run()` sends **every** entry to the LLM each run (`forProject(path, true)`), so cost scaled linearly with stored count. This PR bounds that at the source.

## Changes

- **`forCurator(projectPath, maxTokens)`** — token-budgets the curator's existing-entries context. Cross-project/global entries are always kept (shared, few); the rest pack by `forProject` rank (confidence DESC, updated_at DESC) until the budget is exhausted. Returns the full set unchanged when it fits (the common case). Dropped entries are the lowest-confidence/stalest; the curator's existing post-create embedding dedup sweep backstops any duplicate minted for an unseen entry.
- **`curator.contextTokenBudget`** config (default `20000`) — a generous safety ceiling that only trims pathological sets; min 2000.
- **`pruneDeadEntries(projectPath)`** — hard-deletes project-scoped entries that have decayed to/below the `0.2` relevance floor (already invisible to injection/curation/consolidation, so pure dead weight). Tombstoned against `.lore.md` re-import resurrection. Wired into the idle pass as a local DB-only step before consolidation. (Your live DB currently has 12 such zombies.)

## Tests

- `ltm-curator-budget.test.ts`: `pruneDeadEntries` deletes only `<= 0.2`, tombstones, never touches other-project/global entries; `forCurator` returns all under budget, always keeps cross-project, packs by confidence, never exceeds budget, preserves order.
- Full suite: 3418 passed / 23 skipped. Typecheck, lint (no new warnings in touched files), build green.