### PR TITLE
feat(core): knowledge confidence lifecycle — decay, reinforcement, value eviction

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -310,13 +310,16 @@ export const LoreConfig = z.object({
         .min(1)
         .default(3)
         .describe("Minimum turns between curator runs. Default: 3."),
-      /** Max knowledge entries per project before consolidation triggers. Default: 40. */
+      /** Per-project entry ceiling enforced by value-based eviction. Default: 200. */
       maxEntries: z
         .number()
         .min(10)
-        .default(40)
+        .default(200)
         .describe(
-          "Max knowledge entries per project before consolidation. Default: 40.",
+          "Per-project knowledge entry ceiling. A generous backstop, not a " +
+            "quality gate: injection is already token-budget-capped, and the " +
+            "confidence lifecycle (decay + reinforcement) governs what stays. " +
+            "When exceeded, the lowest-value entries are evicted. Default: 200.",
         ),
       /** Token budget for the curator's existing-entries context. Default: 20000. */
       contextTokenBudget: z
@@ -335,7 +338,7 @@ export const LoreConfig = z.object({
       onIdle: true,
       inFlight: false,
       afterTurns: 3,
-      maxEntries: 40,
+      maxEntries: 200,
       contextTokenBudget: 20000,
     })
     .describe("Curator scheduling and consolidation thresholds."),

--- a/packages/core/src/curator.ts
+++ b/packages/core/src/curator.ts
@@ -825,18 +825,12 @@ async function runInner(input: {
   // the health state, making sustained parse failures invisible.
   input.workerHealth?.recordSuccess();
 
-  // Gate entry creation when at or above maxEntries to prevent the ratchet
-  // effect: curation creates entries → count exceeds limit → consolidation
-  // can't reduce (all unique) → curation creates more → count grows forever.
-  // When at the limit, only allow update/delete ops. Creates are allowed
-  // again once consolidation (or manual deletion) brings count below limit.
-  const currentEntries = ltm.forProject(input.projectPath, false);
-  const atLimit = currentEntries.length >= cfg.curator.maxEntries;
-  if (atLimit && response.ops.some((op) => op.op === "create")) {
-    log.info(
-      `curation: skipping creates (${currentEntries.length} entries >= maxEntries ${cfg.curator.maxEntries})`,
-    );
-  }
+  // Soft cap (v48): admit creates even at the limit, then evict the lowest-VALUE
+  // tail back down to maxEntries below (see post-applyOps eviction). This breaks
+  // the old ratchet (creates frozen at the cap → consolidation can't reduce a
+  // genuinely-unique set → knowledge base frozen) without relying on an LLM merge
+  // that will never succeed. Eviction ranks by decayed confidence, so a create
+  // weaker than every incumbent self-evicts and nothing valuable is displaced.
 
   // Pre-pass: collapse near-duplicate `preference` creates into updates.
   // The curator re-observes the same behavioral rule each session and re-phrases
@@ -851,7 +845,7 @@ async function runInner(input: {
   const result = applyOps(ops, {
     projectPath: input.projectPath,
     sessionID: input.sessionID,
-    skipCreate: atLimit,
+    skipCreate: false, // soft cap: admit creates, evict the lowest-value tail below
     detectedEntities: response.entities,
     detectedRelations: response.relations,
     workerModel: input.model,
@@ -938,6 +932,19 @@ async function runInner(input: {
     } catch (err) {
       log.warn("post-curation entity dedup failed (non-fatal):", err);
     }
+  }
+
+  // Soft-cap enforcement: after creates and the dedup sweeps settle the count,
+  // evict the lowest-value project-scoped entries back down to maxEntries.
+  const evictedCount = enforceEntryCap(
+    input.projectPath,
+    cfg.curator.maxEntries,
+    result,
+  );
+  if (evictedCount > 0) {
+    log.info(
+      `curation: cap reached (${cfg.curator.maxEntries}) — evicted ${evictedCount} lowest-value entries`,
+    );
   }
 
   const now = Date.now();
@@ -1101,6 +1108,40 @@ export function resetCurationTracker(sessionID?: string) {
  * and the idle scheduler runs subsequent passes as the count drops.
  */
 const CONSOLIDATION_BATCH_SIZE = 50;
+
+/**
+ * Soft-cap enforcement (the eviction half of the decoupled create-gate). When a
+ * project exceeds `maxEntries`, evict the lowest-VALUE project-scoped entries
+ * (decayed confidence, then least-recently reinforced) back down to the cap, and
+ * fold the evictions into `result` (deletes + changedEntries) so session LTM
+ * caches / durable deltas stay consistent — exactly as consolidation deletes do.
+ *
+ * The knowledge base can always admit new high-value knowledge; the confidence
+ * lifecycle (decay + reinforcement) decides what leaves. A freshly-created entry
+ * weaker than every incumbent self-evicts (evictLowestValue ranks it to the
+ * tail), so weak new knowledge never displaces stronger existing knowledge.
+ * Returns the number of entries evicted. Exported for testing.
+ */
+export function enforceEntryCap(
+  projectPath: string,
+  maxEntries: number,
+  result: { deleted: number; changedEntries: ChangedEntry[] },
+): number {
+  const overBy = ltm.forProject(projectPath, false).length - maxEntries;
+  if (overBy <= 0) return 0;
+  const evicted = ltm.evictLowestValue(projectPath, overBy);
+  for (const e of evicted) {
+    result.changedEntries.push({
+      op: "deleted",
+      id: e.id,
+      category: e.category,
+      title: e.title,
+      prevContent: e.content,
+    });
+  }
+  result.deleted += evicted.length;
+  return evicted.length;
+}
 
 /**
  * Consolidation pass: reviews project entries and merges/trims/deletes

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1201,6 +1201,22 @@ const MIGRATIONS: string[] = [
     PRIMARY KEY (project_id, cause, relocatable)
   );
   `,
+  `
+  -- Version 48: Knowledge confidence lifecycle (reinforcement clock + decay).
+  -- last_reinforced_at records when an entry's relevance was last CONFIRMED —
+  -- injected into a prompt, recalled, or re-confirmed by the curator. The idle
+  -- decay pass lowers confidence for entries unreinforced past a grace window,
+  -- so unused knowledge ages out below the relevance floor (and is then pruned)
+  -- while genuinely useful (regularly-injected) knowledge never decays. Backfill
+  -- existing rows to updated_at so they start with a sane "last seen" time.
+  --
+  -- projects.last_decay_at gates the decay pass to once per interval, making the
+  -- per-pass decrement rate-stable regardless of how often the idle scheduler
+  -- fires (a per-tick decrement would depend on session activity).
+  ALTER TABLE knowledge ADD COLUMN last_reinforced_at INTEGER;
+  UPDATE knowledge SET last_reinforced_at = updated_at WHERE last_reinforced_at IS NULL;
+  ALTER TABLE projects ADD COLUMN last_decay_at INTEGER;
+  `,
 ];
 
 /**

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -759,6 +759,12 @@ export function decayProject(
  * by a single project. `remove()` tombstones each id. Returns the evicted rows
  * (for the changed-entries / delta channel).
  *
+ * Only considers LIVE entries (`confidence > DEAD_CONFIDENCE_FLOOR`) — the same
+ * set `forProject` counts. Callers (enforceEntryCap) compute `count` from the
+ * live count over the cap, so eviction must draw from the same population or it
+ * would reap already-dead entries (handled by pruneDeadEntries) without reducing
+ * the live count, under-enforcing the cap. (Seer review, PR #816.)
+ *
  * Self-correcting at the cap: a freshly-created entry less confident than every
  * incumbent sorts to the tail and evicts itself, so weak new knowledge never
  * displaces stronger existing knowledge.
@@ -772,11 +778,11 @@ export function evictLowestValue(
   const victims = db()
     .query(
       `SELECT ${KNOWLEDGE_COLS} FROM knowledge
-       WHERE project_id = ?
+       WHERE project_id = ? AND confidence > ?
        ORDER BY confidence ASC, COALESCE(last_reinforced_at, updated_at) ASC
        LIMIT ?`,
     )
-    .all(pid, count) as KnowledgeEntry[];
+    .all(pid, DEAD_CONFIDENCE_FLOOR, count) as KnowledgeEntry[];
   for (const e of victims) remove(e.id);
   return victims;
 }

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -739,14 +739,20 @@ export function decayProject(
   // cross_project = 0: a promoted entry keeps its origin project_id, so a single
   // project must not decay shared knowledge it merely originated (it may be
   // actively used — and reinforced — in OTHER projects). (Seer review, PR #816.)
+  // confidence > floor: only decay still-LIVE entries. Already-dead rows
+  // (<= floor) are invisible everywhere and reaped by pruneDeadEntries; matching
+  // them here would re-apply a no-op MAX(0, …) and inflate the returned/logged
+  // count with rows whose confidence didn't actually change. (Seer review.)
   const res = db()
     .query(
       `UPDATE knowledge
        SET confidence = MAX(0, confidence - ?)
-       WHERE project_id = ? AND cross_project = 0
+       WHERE project_id = ? AND cross_project = 0 AND confidence > ?
          AND COALESCE(last_reinforced_at, updated_at) < ?`,
     )
-    .run(DECAY_STEP, pid, cutoff) as { changes?: number | bigint };
+    .run(DECAY_STEP, pid, DEAD_CONFIDENCE_FLOOR, cutoff) as {
+    changes?: number | bigint;
+  };
   db()
     .query("UPDATE projects SET last_decay_at = ? WHERE id = ?")
     .run(now, pid);

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -1048,6 +1048,21 @@ export async function forSession(
     // fast path. Preferences are typically global/cross directives rather than
     // project-origin knowledge, so counting them as cross-project "transfers"
     // would be misleading.
+    //
+    // Reinforce injected preferences (confidence lifecycle): this is the ONLY
+    // injection path for preferences (the context-block callers pass
+    // excludeCategories: ["preference"]). Without this, a project-scoped
+    // preference injected into system[1] every turn would still age out and be
+    // pruned by decayProject/pruneDeadEntries after the grace window — silently
+    // deleting an actively-used directive. Resets the decay clock only.
+    try {
+      markInjected(result.map((e) => e.id));
+    } catch (err) {
+      log.warn(
+        "forSession(preference): reinforcement failed (non-fatal):",
+        err,
+      );
+    }
     return result;
   }
 

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -53,16 +53,20 @@ export type KnowledgeEntry = {
   // Nullable for backward compatibility with pre-v35 rows.
   worker_provider_id: string | null;
   worker_model_id: string | null;
+  // Confidence lifecycle (v48): when relevance was last confirmed (injected,
+  // recalled, or curator-reconfirmed). The decay pass uses this to age out
+  // unreinforced entries. Nullable for pre-v48 rows (backfilled to updated_at).
+  last_reinforced_at: number | null;
 };
 
 /** Columns to select for KnowledgeEntry — excludes the embedding BLOB
  *  (4KB per entry) which is only needed by vectorSearch() in embedding.ts. */
 const KNOWLEDGE_COLS =
-  "id, project_id, category, title, content, source_session, cross_project, confidence, created_at, updated_at, metadata, created_by, updated_by, sensitivity, promotion_status, promoted_at, approval_status, approved_by, approved_at, source_user_id, source_entry_id, last_accessed_at, worker_provider_id, worker_model_id";
+  "id, project_id, category, title, content, source_session, cross_project, confidence, created_at, updated_at, metadata, created_by, updated_by, sensitivity, promotion_status, promoted_at, approval_status, approved_by, approved_at, source_user_id, source_entry_id, last_accessed_at, worker_provider_id, worker_model_id, last_reinforced_at";
 
 /** Same columns with table alias prefix for use in JOIN queries. */
 const KNOWLEDGE_COLS_K =
-  "k.id, k.project_id, k.category, k.title, k.content, k.source_session, k.cross_project, k.confidence, k.created_at, k.updated_at, k.metadata, k.created_by, k.updated_by, k.sensitivity, k.promotion_status, k.promoted_at, k.approval_status, k.approved_by, k.approved_at, k.source_user_id, k.source_entry_id, k.last_accessed_at, k.worker_provider_id, k.worker_model_id";
+  "k.id, k.project_id, k.category, k.title, k.content, k.source_session, k.cross_project, k.confidence, k.created_at, k.updated_at, k.metadata, k.created_by, k.updated_by, k.sensitivity, k.promotion_status, k.promoted_at, k.approval_status, k.approved_by, k.approved_at, k.source_user_id, k.source_entry_id, k.last_accessed_at, k.worker_provider_id, k.worker_model_id, k.last_reinforced_at";
 
 export function create(input: {
   projectPath?: string;
@@ -162,8 +166,8 @@ export function create(input: {
     input.confidence != null ? Math.max(0, Math.min(1, input.confidence)) : 1.0;
   db()
     .query(
-      `INSERT INTO knowledge (id, project_id, category, title, content, source_session, cross_project, confidence, created_at, updated_at, created_by, sensitivity, worker_provider_id, worker_model_id)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO knowledge (id, project_id, category, title, content, source_session, cross_project, confidence, created_at, updated_at, created_by, sensitivity, worker_provider_id, worker_model_id, last_reinforced_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     )
     .run(
       id,
@@ -180,6 +184,7 @@ export function create(input: {
       input.sensitivity ?? "normal",
       input.workerProviderID ?? null,
       input.workerModelID ?? null,
+      now, // last_reinforced_at — a fresh entry starts its decay clock now
     );
 
   // Fire-and-forget: embed for vector search (errors logged, never thrown)
@@ -291,8 +296,13 @@ export function update(
     sets.push("sensitivity = ?");
     params.push(input.sensitivity);
   }
+  const now = Date.now();
   sets.push("updated_at = ?");
-  params.push(Date.now());
+  params.push(now);
+  // Any update is a re-confirmation (curator edit, dedup-merge, .lore.md import)
+  // → reset the decay clock so a freshly-touched entry never ages out (v48).
+  sets.push("last_reinforced_at = ?");
+  params.push(now);
   params.push(id);
   db()
     .query(`UPDATE knowledge SET ${sets.join(", ")} WHERE id = ?`)
@@ -653,6 +663,122 @@ export function forCurator(
     used += cost;
   }
   return all.filter((e) => keep.has(e.id));
+}
+
+// ---------------------------------------------------------------------------
+// Confidence lifecycle (v48): reinforcement, decay, value-based eviction
+// ---------------------------------------------------------------------------
+
+/** Confidence boost applied when an entry is explicitly re-confirmed. */
+export const REINFORCE_STEP = 0.05;
+/** Min interval between decay passes per project (rate-stable decrement). */
+export const DECAY_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24h
+/** An entry must be unreinforced for this long before it starts decaying. */
+export const DECAY_GRACE_MS = 7 * 24 * 60 * 60 * 1000; // 7d
+/** Confidence removed per decay pass for an unreinforced entry. */
+export const DECAY_STEP = 0.1;
+
+/**
+ * Mark entries as injected into a prompt this turn: reset the decay clock
+ * WITHOUT changing confidence. Selection by forSession means "still relevant",
+ * not "more certain" — bumping confidence every turn would re-flatten all
+ * entries to 1.0 and destroy the decay signal that makes confidence a real
+ * value ranking. Single batched UPDATE; safe to call on the hot path.
+ */
+export function markInjected(ids: string[]): void {
+  if (ids.length === 0) return;
+  const placeholders = ids.map(() => "?").join(",");
+  db()
+    .query(
+      `UPDATE knowledge SET last_reinforced_at = ? WHERE id IN (${placeholders})`,
+    )
+    .run(Date.now(), ...ids);
+}
+
+/**
+ * Reinforce an entry: adjust confidence by `delta` (clamped to [0,1]) and reset
+ * the decay clock. Positive delta = the entry was re-confirmed (curator re-saw
+ * it, a dedup-merge landed on it); a future negative delta expresses staleness
+ * (#627: a cited file changed) without deleting. Extension point for outcome
+ * reward (#497: test/build pass → boost).
+ */
+export function reinforce(id: string, delta: number = REINFORCE_STEP): void {
+  db()
+    .query(
+      `UPDATE knowledge
+       SET confidence = MAX(0, MIN(1, confidence + ?)), last_reinforced_at = ?
+       WHERE id = ?`,
+    )
+    .run(delta, Date.now(), id);
+}
+
+/**
+ * Idle decay pass for one project. Lowers confidence by DECAY_STEP for
+ * project-scoped entries that have been unreinforced (not injected / recalled /
+ * re-confirmed) for longer than DECAY_GRACE_MS, so genuinely unused knowledge
+ * ages toward the relevance floor (then `pruneDeadEntries` reaps it) while
+ * regularly-injected knowledge never decays.
+ *
+ * Gated to once per DECAY_INTERVAL_MS per project via `projects.last_decay_at`,
+ * so the per-pass decrement is rate-stable regardless of idle-tick frequency.
+ * Cross-project/global entries are never decayed by a single project. Returns
+ * the number of entries decayed (0 when the interval gate blocks the run).
+ */
+export function decayProject(
+  projectPath: string,
+  now: number = Date.now(),
+): number {
+  const pid = ensureProject(projectPath);
+  const proj = db()
+    .query("SELECT last_decay_at FROM projects WHERE id = ?")
+    .get(pid) as { last_decay_at: number | null } | null;
+  const lastDecay = proj?.last_decay_at ?? 0;
+  if (now - lastDecay < DECAY_INTERVAL_MS) return 0; // interval gate
+
+  const cutoff = now - DECAY_GRACE_MS;
+  const res = db()
+    .query(
+      `UPDATE knowledge
+       SET confidence = MAX(0, confidence - ?)
+       WHERE project_id = ?
+         AND COALESCE(last_reinforced_at, updated_at) < ?`,
+    )
+    .run(DECAY_STEP, pid, cutoff) as { changes?: number | bigint };
+  db()
+    .query("UPDATE projects SET last_decay_at = ? WHERE id = ?")
+    .run(now, pid);
+  return Number(res.changes ?? 0);
+}
+
+/**
+ * Value-based eviction backstop. Deletes the `count` lowest-VALUE project-scoped
+ * entries — ranked by confidence ASC, then last_reinforced_at ASC (least
+ * confident, then least-recently reinforced). Confidence is the decayed value
+ * (the decay pass mutates it in place), so this evicts what the lifecycle has
+ * already judged least valuable. Cross-project/global entries are never evicted
+ * by a single project. `remove()` tombstones each id. Returns the evicted rows
+ * (for the changed-entries / delta channel).
+ *
+ * Self-correcting at the cap: a freshly-created entry less confident than every
+ * incumbent sorts to the tail and evicts itself, so weak new knowledge never
+ * displaces stronger existing knowledge.
+ */
+export function evictLowestValue(
+  projectPath: string,
+  count: number,
+): KnowledgeEntry[] {
+  if (count <= 0) return [];
+  const pid = ensureProject(projectPath);
+  const victims = db()
+    .query(
+      `SELECT ${KNOWLEDGE_COLS} FROM knowledge
+       WHERE project_id = ?
+       ORDER BY confidence ASC, COALESCE(last_reinforced_at, updated_at) ASC
+       LIMIT ?`,
+    )
+    .all(pid, count) as KnowledgeEntry[];
+  for (const e of victims) remove(e.id);
+  return victims;
 }
 
 type Scored = { entry: KnowledgeEntry; score: number };
@@ -1132,6 +1258,7 @@ export async function forSession(
         last_accessed_at: null,
         worker_provider_id: null,
         worker_model_id: null,
+        last_reinforced_at: null,
       });
       used += cost;
     }
@@ -1154,6 +1281,18 @@ export async function forSession(
     }
   } catch (err) {
     log.warn("forSession: transfer recording failed (non-fatal):", err);
+  }
+
+  // --- 8. Reinforce injected entries (confidence lifecycle) ---
+  // Being selected for the prompt resets each entry's decay clock — it is "still
+  // relevant" — WITHOUT bumping confidence (that would re-flatten everything to
+  // 1.0 and destroy the decay signal). lat.md synthetics are not knowledge rows.
+  try {
+    markInjected(
+      result.filter((e) => e.category !== "lat.md").map((e) => e.id),
+    );
+  } catch (err) {
+    log.warn("forSession: reinforcement failed (non-fatal):", err);
   }
 
   return result;

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -736,11 +736,14 @@ export function decayProject(
   if (now - lastDecay < DECAY_INTERVAL_MS) return 0; // interval gate
 
   const cutoff = now - DECAY_GRACE_MS;
+  // cross_project = 0: a promoted entry keeps its origin project_id, so a single
+  // project must not decay shared knowledge it merely originated (it may be
+  // actively used — and reinforced — in OTHER projects). (Seer review, PR #816.)
   const res = db()
     .query(
       `UPDATE knowledge
        SET confidence = MAX(0, confidence - ?)
-       WHERE project_id = ?
+       WHERE project_id = ? AND cross_project = 0
          AND COALESCE(last_reinforced_at, updated_at) < ?`,
     )
     .run(DECAY_STEP, pid, cutoff) as { changes?: number | bigint };
@@ -755,8 +758,10 @@ export function decayProject(
  * entries — ranked by confidence ASC, then last_reinforced_at ASC (least
  * confident, then least-recently reinforced). Confidence is the decayed value
  * (the decay pass mutates it in place), so this evicts what the lifecycle has
- * already judged least valuable. Cross-project/global entries are never evicted
- * by a single project. `remove()` tombstones each id. Returns the evicted rows
+ * already judged least valuable. Only EXCLUSIVELY project-owned rows
+ * (`cross_project = 0`) are eligible — a promoted entry keeps its origin
+ * project_id, so a single project must never evict shared knowledge (Seer
+ * review, PR #816). `remove()` tombstones each id. Returns the evicted rows
  * (for the changed-entries / delta channel).
  *
  * Only considers LIVE entries (`confidence > DEAD_CONFIDENCE_FLOOR`) — the same
@@ -778,7 +783,7 @@ export function evictLowestValue(
   const victims = db()
     .query(
       `SELECT ${KNOWLEDGE_COLS} FROM knowledge
-       WHERE project_id = ? AND confidence > ?
+       WHERE project_id = ? AND cross_project = 0 AND confidence > ?
        ORDER BY confidence ASC, COALESCE(last_reinforced_at, updated_at) ASC
        LIMIT ?`,
     )

--- a/packages/core/src/sync-data.ts
+++ b/packages/core/src/sync-data.ts
@@ -61,16 +61,27 @@ const ROW_SEP = "\x1f";
 
 /**
  * Volatile / local-only columns never sent over the wire: BLOB `embedding`
- * (re-derived on restore) and `last_accessed_at` (per-machine access tracking).
+ * (re-derived on restore), `last_accessed_at` and `last_reinforced_at`
+ * (per-machine access / reinforcement tracking — the synced `confidence` already
+ * carries the meaningful decayed state).
  */
-const PAYLOAD_EXCLUDE = new Set(["embedding", "last_accessed_at"]);
+const PAYLOAD_EXCLUDE = new Set([
+  "embedding",
+  "last_accessed_at",
+  "last_reinforced_at",
+]);
 /**
  * Columns excluded from the content hash: the non-synced ones above plus
  * `updated_at` (a fresh timestamp is not a semantic change). Intentionally a
  * denylist of volatile/local columns; if cross-tenant dedup is ever needed,
  * switch to an explicit per-table semantic allowlist.
  */
-const HASH_EXCLUDE = new Set(["embedding", "last_accessed_at", "updated_at"]);
+const HASH_EXCLUDE = new Set([
+  "embedding",
+  "last_accessed_at",
+  "last_reinforced_at",
+  "updated_at",
+]);
 
 export const SYNCED_TABLES: Record<SyncTier, SyncTableMeta[]> = {
   basic: [

--- a/packages/core/test/config.test.ts
+++ b/packages/core/test/config.test.ts
@@ -97,14 +97,14 @@ describe("LoreConfig — loreFile schema", () => {
 });
 
 describe("LoreConfig — curator schema", () => {
-  test("curator defaults: enabled=true, onIdle=true, inFlight=false, afterTurns=3, maxEntries=40", () => {
+  test("curator defaults: enabled=true, onIdle=true, inFlight=false, afterTurns=3, maxEntries=200", () => {
     const cfg = LoreConfig.parse({});
     expect(cfg.curator.enabled).toBe(true);
     expect(cfg.curator.onIdle).toBe(true);
     // Off by default: mid-session curation rewrites system[2] and busts cache.
     expect(cfg.curator.inFlight).toBe(false);
     expect(cfg.curator.afterTurns).toBe(3);
-    expect(cfg.curator.maxEntries).toBe(40);
+    expect(cfg.curator.maxEntries).toBe(200);
     expect(cfg.curator.contextTokenBudget).toBe(20000);
   });
 

--- a/packages/core/test/curator-changed-entries.test.ts
+++ b/packages/core/test/curator-changed-entries.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "vitest";
-import { applyOps } from "../src/curator";
+import { applyOps, enforceEntryCap } from "../src/curator";
+import type { ChangedEntry } from "../src/curator";
+import { db, ensureProject } from "../src/db";
 import * as ltm from "../src/ltm";
 
 const PROJECT = "/tmp/lore-curator-delta/project";
@@ -119,5 +121,72 @@ describe("curator applyOps changedEntries", () => {
       }),
     ]);
     expect(ltm.get(id)).toBeNull();
+  });
+});
+
+describe("curator enforceEntryCap (soft-cap eviction)", () => {
+  const CAP_PROJECT = "/tmp/lore-curator-cap/project";
+
+  function reset() {
+    const pid = ensureProject(CAP_PROJECT);
+    db().query("DELETE FROM knowledge WHERE project_id = ?").run(pid);
+  }
+
+  test("no-op when at or under the cap", () => {
+    reset();
+    for (let i = 0; i < 3; i++) {
+      ltm.create({
+        projectPath: CAP_PROJECT,
+        category: "gotcha",
+        title: `Under ${i}`,
+        content: "x",
+        scope: "project",
+      });
+    }
+    const result = { deleted: 0, changedEntries: [] as ChangedEntry[] };
+    expect(enforceEntryCap(CAP_PROJECT, 3, result)).toBe(0);
+    expect(result.deleted).toBe(0);
+    expect(ltm.forProject(CAP_PROJECT, false)).toHaveLength(3);
+  });
+
+  test("evicts the lowest-value tail down to the cap and records deletes", () => {
+    reset();
+    const high = ltm.create({
+      projectPath: CAP_PROJECT,
+      category: "gotcha",
+      title: "Keep high",
+      content: "x",
+      scope: "project",
+      confidence: 0.9,
+    });
+    const lowA = ltm.create({
+      projectPath: CAP_PROJECT,
+      category: "gotcha",
+      title: "Evict A",
+      content: "x",
+      scope: "project",
+      confidence: 0.3,
+    });
+    const lowB = ltm.create({
+      projectPath: CAP_PROJECT,
+      category: "gotcha",
+      title: "Evict B",
+      content: "x",
+      scope: "project",
+      confidence: 0.4,
+    });
+
+    const result = { deleted: 0, changedEntries: [] as ChangedEntry[] };
+    const evicted = enforceEntryCap(CAP_PROJECT, 1, result);
+
+    expect(evicted).toBe(2);
+    expect(result.deleted).toBe(2);
+    // Highest-value entry survives; the two lowest are gone.
+    expect(ltm.get(high)).not.toBeNull();
+    expect(ltm.get(lowA)).toBeNull();
+    expect(ltm.get(lowB)).toBeNull();
+    expect(result.changedEntries.map((e) => e.id).sort()).toEqual(
+      [lowA, lowB].sort(),
+    );
   });
 });

--- a/packages/core/test/curator-changed-entries.test.ts
+++ b/packages/core/test/curator-changed-entries.test.ts
@@ -189,4 +189,44 @@ describe("curator enforceEntryCap (soft-cap eviction)", () => {
       [lowA, lowB].sort(),
     );
   });
+
+  test("promoted cross-project entries are counted toward the cap but evicted from owned rows only (converges)", () => {
+    reset();
+    // 3 exclusively-owned + 2 promoted-in-place (cross_project=1, same project_id).
+    const owned = [0.9, 0.5, 0.7].map((c, i) =>
+      ltm.create({
+        projectPath: CAP_PROJECT,
+        category: "gotcha",
+        title: `Owned ${i}`,
+        content: "x",
+        scope: "project",
+        confidence: c,
+      }),
+    );
+    const promoted = [0.4, 0.45].map((c, i) => {
+      const id = ltm.create({
+        projectPath: CAP_PROJECT,
+        category: "preference",
+        title: `Promoted ${i}`,
+        content: "p",
+        scope: "project",
+        confidence: c,
+      });
+      db().query("UPDATE knowledge SET cross_project = 1 WHERE id = ?").run(id);
+      return id;
+    });
+
+    // forProject counts all 5 (project_id matches, confidence > 0.2) → overBy=2.
+    const result = { deleted: 0, changedEntries: [] as ChangedEntry[] };
+    const evicted = enforceEntryCap(CAP_PROJECT, 3, result);
+
+    // Eviction draws ONLY from owned rows (the two lowest-confidence owned),
+    // never the promoted/shared ones; the live count converges to the cap.
+    expect(evicted).toBe(2);
+    expect(promoted.every((id) => ltm.get(id) !== null)).toBe(true);
+    expect(ltm.get(owned[0])).not.toBeNull(); // 0.9 survives
+    expect(ltm.get(owned[1])).toBeNull(); // 0.5 evicted
+    expect(ltm.get(owned[2])).toBeNull(); // 0.7 evicted
+    expect(ltm.forProject(CAP_PROJECT, false)).toHaveLength(3);
+  });
 });

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -58,7 +58,7 @@ describe("db", () => {
     const row = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(row.version).toBe(47);
+    expect(row.version).toBe(48);
   });
 
   test("session_prompt_deltas persist ordered selector/content rows (v42)", () => {

--- a/packages/core/test/ltm-lifecycle.test.ts
+++ b/packages/core/test/ltm-lifecycle.test.ts
@@ -155,6 +155,25 @@ describe("ltm.decayProject", () => {
     ltm.decayProject(PROJECT, base + ltm.DECAY_GRACE_MS + 60_000);
     expect(ltm.get(other)?.confidence).toBe(1.0);
   });
+
+  test("never decays a promoted cross-project entry that kept its origin project_id (Seer #816)", () => {
+    const base = Date.now();
+    const promoted = ltm.create({
+      projectPath: PROJECT,
+      category: "preference",
+      title: "Promoted shared",
+      content: "x",
+      scope: "project",
+    });
+    // Promote in place (origin project_id retained) and backdate reinforcement.
+    db()
+      .query(
+        "UPDATE knowledge SET cross_project = 1, last_reinforced_at = 1000 WHERE id = ?",
+      )
+      .run(promoted);
+    ltm.decayProject(PROJECT, base + ltm.DECAY_GRACE_MS + 60_000);
+    expect(ltm.get(promoted)?.confidence).toBe(1.0); // shared knowledge untouched
+  });
 });
 
 describe("ltm.evictLowestValue", () => {
@@ -248,7 +267,7 @@ describe("ltm.evictLowestValue", () => {
     expect(ltm.get(dead)).not.toBeNull(); // dead entry untouched
   });
 
-  test("count <= 0 is a no-op; never evicts cross-project entries", () => {
+  test("count <= 0 is a no-op; never evicts global or promoted cross-project entries", () => {
     const g = ltm.create({
       category: "preference",
       title: "Global",
@@ -257,6 +276,18 @@ describe("ltm.evictLowestValue", () => {
       crossProject: true,
       confidence: 0.1,
     });
+    // Promoted-in-place: cross_project = 1 while keeping this project's id.
+    const promoted = ltm.create({
+      projectPath: PROJECT,
+      category: "preference",
+      title: "Promoted shared",
+      content: "p",
+      scope: "project",
+      confidence: 0.25,
+    });
+    db()
+      .query("UPDATE knowledge SET cross_project = 1 WHERE id = ?")
+      .run(promoted);
     ltm.create({
       projectPath: PROJECT,
       category: "gotcha",
@@ -266,9 +297,12 @@ describe("ltm.evictLowestValue", () => {
       confidence: 0.9,
     });
     expect(ltm.evictLowestValue(PROJECT, 0)).toHaveLength(0);
-    // Even though the global entry is the lowest confidence, it is never a victim.
+    // Both the global and the promoted entry are lower confidence than "Proj",
+    // yet neither is ever a victim — shared knowledge is protected (Seer #816).
     const evicted = ltm.evictLowestValue(PROJECT, 5);
     expect(evicted.some((e) => e.id === g)).toBe(false);
+    expect(evicted.some((e) => e.id === promoted)).toBe(false);
     expect(ltm.get(g)).not.toBeNull();
+    expect(ltm.get(promoted)).not.toBeNull();
   });
 });

--- a/packages/core/test/ltm-lifecycle.test.ts
+++ b/packages/core/test/ltm-lifecycle.test.ts
@@ -1,0 +1,249 @@
+import { describe, test, expect, beforeEach } from "vitest";
+import { db } from "../src/db";
+import * as ltm from "../src/ltm";
+
+const PROJECT = "/test/ltm/lifecycle";
+const OTHER = "/test/ltm/lifecycle-other";
+
+function clearKnowledge() {
+  db().query("DELETE FROM knowledge").run();
+  db().query("UPDATE projects SET last_decay_at = NULL").run();
+}
+
+function reinforcedAt(id: string): number | null {
+  return ltm.get(id)?.last_reinforced_at ?? null;
+}
+
+describe("ltm reinforcement", () => {
+  beforeEach(clearKnowledge);
+
+  test("create() stamps last_reinforced_at", () => {
+    const id = ltm.create({
+      projectPath: PROJECT,
+      category: "gotcha",
+      title: "Fresh",
+      content: "x",
+      scope: "project",
+    });
+    expect(reinforcedAt(id)).toBeGreaterThan(0);
+  });
+
+  test("markInjected resets the decay clock WITHOUT changing confidence", () => {
+    const id = ltm.create({
+      projectPath: PROJECT,
+      category: "gotcha",
+      title: "Injected",
+      content: "x",
+      scope: "project",
+    });
+    // Backdate the clock so we can observe a forward move.
+    db()
+      .query("UPDATE knowledge SET last_reinforced_at = 1000 WHERE id = ?")
+      .run(id);
+    const beforeConf = ltm.get(id)?.confidence;
+
+    ltm.markInjected([id]);
+
+    expect(reinforcedAt(id)).toBeGreaterThan(1000);
+    expect(ltm.get(id)?.confidence).toBe(beforeConf); // unchanged
+  });
+
+  test("markInjected is a no-op for an empty id list", () => {
+    expect(() => ltm.markInjected([])).not.toThrow();
+  });
+
+  test("update() resets the decay clock (any edit is a re-confirmation)", () => {
+    const id = ltm.create({
+      projectPath: PROJECT,
+      category: "gotcha",
+      title: "Edited",
+      content: "x",
+      scope: "project",
+    });
+    db()
+      .query("UPDATE knowledge SET last_reinforced_at = 1000 WHERE id = ?")
+      .run(id);
+    ltm.update(id, { content: "y" });
+    expect(reinforcedAt(id)).toBeGreaterThan(1000);
+  });
+
+  test("reinforce boosts confidence (clamped) and resets the clock", () => {
+    const id = ltm.create({
+      projectPath: PROJECT,
+      category: "gotcha",
+      title: "Boosted",
+      content: "x",
+      scope: "project",
+      confidence: 0.5,
+    });
+    db()
+      .query("UPDATE knowledge SET last_reinforced_at = 1000 WHERE id = ?")
+      .run(id);
+    ltm.reinforce(id, 0.2);
+    expect(ltm.get(id)?.confidence).toBeCloseTo(0.7, 5);
+    expect(reinforcedAt(id)).toBeGreaterThan(1000);
+
+    ltm.reinforce(id, 1.0); // clamps at 1.0
+    expect(ltm.get(id)?.confidence).toBe(1.0);
+
+    ltm.reinforce(id, -2.0); // clamps at 0.0
+    expect(ltm.get(id)?.confidence).toBe(0.0);
+  });
+});
+
+describe("ltm.decayProject", () => {
+  beforeEach(clearKnowledge);
+
+  test("decays only entries unreinforced past the grace window", () => {
+    const base = Date.now();
+    const stale = ltm.create({
+      projectPath: PROJECT,
+      category: "gotcha",
+      title: "Stale",
+      content: "x",
+      scope: "project",
+    });
+    const fresh = ltm.create({
+      projectPath: PROJECT,
+      category: "gotcha",
+      title: "Fresh",
+      content: "y",
+      scope: "project",
+    });
+    // Run decay far enough in the future that BOTH are past grace, then re-mark
+    // `fresh` as reinforced just before the run so only `stale` decays.
+    const decayNow = base + ltm.DECAY_GRACE_MS + 60_000;
+    db()
+      .query("UPDATE knowledge SET last_reinforced_at = ? WHERE id = ?")
+      .run(decayNow - 1000, fresh); // reinforced after the cutoff
+
+    const decayed = ltm.decayProject(PROJECT, decayNow);
+
+    expect(decayed).toBe(1);
+    expect(ltm.get(stale)?.confidence).toBeCloseTo(1.0 - ltm.DECAY_STEP, 5);
+    expect(ltm.get(fresh)?.confidence).toBe(1.0);
+  });
+
+  test("is interval-gated: a second run within the interval is a no-op", () => {
+    const base = Date.now();
+    ltm.create({
+      projectPath: PROJECT,
+      category: "gotcha",
+      title: "Stale",
+      content: "x",
+      scope: "project",
+    });
+    const decayNow = base + ltm.DECAY_GRACE_MS + 60_000;
+    expect(ltm.decayProject(PROJECT, decayNow)).toBe(1);
+    // Same timestamp → within the interval since last_decay_at was just set.
+    expect(ltm.decayProject(PROJECT, decayNow)).toBe(0);
+    // Just under the interval → still gated.
+    expect(
+      ltm.decayProject(PROJECT, decayNow + ltm.DECAY_INTERVAL_MS - 1),
+    ).toBe(0);
+  });
+
+  test("never decays another project's entries", () => {
+    const base = Date.now();
+    const other = ltm.create({
+      projectPath: OTHER,
+      category: "gotcha",
+      title: "OtherStale",
+      content: "x",
+      scope: "project",
+    });
+    ltm.decayProject(PROJECT, base + ltm.DECAY_GRACE_MS + 60_000);
+    expect(ltm.get(other)?.confidence).toBe(1.0);
+  });
+});
+
+describe("ltm.evictLowestValue", () => {
+  beforeEach(clearKnowledge);
+
+  test("evicts the lowest-confidence entries, tombstones them, returns the rows", () => {
+    const high = ltm.create({
+      projectPath: PROJECT,
+      category: "gotcha",
+      title: "High",
+      content: "x",
+      scope: "project",
+      confidence: 0.9,
+    });
+    const low = ltm.create({
+      projectPath: PROJECT,
+      category: "gotcha",
+      title: "Low",
+      content: "y",
+      scope: "project",
+      confidence: 0.3,
+    });
+    const mid = ltm.create({
+      projectPath: PROJECT,
+      category: "gotcha",
+      title: "Mid",
+      content: "z",
+      scope: "project",
+      confidence: 0.6,
+    });
+
+    const evicted = ltm.evictLowestValue(PROJECT, 1);
+
+    expect(evicted.map((e) => e.id)).toEqual([low]);
+    expect(ltm.get(low)).toBeNull();
+    expect(ltm.isTombstoned(low)).toBe(true);
+    expect(ltm.get(high)).not.toBeNull();
+    expect(ltm.get(mid)).not.toBeNull();
+  });
+
+  test("breaks ties by least-recently-reinforced", () => {
+    const older = ltm.create({
+      projectPath: PROJECT,
+      category: "gotcha",
+      title: "Older",
+      content: "x",
+      scope: "project",
+      confidence: 0.5,
+    });
+    const newer = ltm.create({
+      projectPath: PROJECT,
+      category: "gotcha",
+      title: "Newer",
+      content: "y",
+      scope: "project",
+      confidence: 0.5,
+    });
+    db()
+      .query("UPDATE knowledge SET last_reinforced_at = 1000 WHERE id = ?")
+      .run(older);
+    db()
+      .query("UPDATE knowledge SET last_reinforced_at = 9000 WHERE id = ?")
+      .run(newer);
+
+    const evicted = ltm.evictLowestValue(PROJECT, 1);
+    expect(evicted.map((e) => e.id)).toEqual([older]);
+  });
+
+  test("count <= 0 is a no-op; never evicts cross-project entries", () => {
+    const g = ltm.create({
+      category: "preference",
+      title: "Global",
+      content: "x",
+      scope: "global",
+      crossProject: true,
+      confidence: 0.1,
+    });
+    ltm.create({
+      projectPath: PROJECT,
+      category: "gotcha",
+      title: "Proj",
+      content: "y",
+      scope: "project",
+      confidence: 0.9,
+    });
+    expect(ltm.evictLowestValue(PROJECT, 0)).toHaveLength(0);
+    // Even though the global entry is the lowest confidence, it is never a victim.
+    const evicted = ltm.evictLowestValue(PROJECT, 5);
+    expect(evicted.some((e) => e.id === g)).toBe(false);
+    expect(ltm.get(g)).not.toBeNull();
+  });
+});

--- a/packages/core/test/ltm-lifecycle.test.ts
+++ b/packages/core/test/ltm-lifecycle.test.ts
@@ -223,6 +223,31 @@ describe("ltm.evictLowestValue", () => {
     expect(evicted.map((e) => e.id)).toEqual([older]);
   });
 
+  test("never evicts dead (<= floor) entries — they belong to pruneDeadEntries, and evicting them would not reduce the live count (Seer #816)", () => {
+    const dead = ltm.create({
+      projectPath: PROJECT,
+      category: "gotcha",
+      title: "Dead",
+      content: "x",
+      scope: "project",
+    });
+    ltm.update(dead, { confidence: 0.1 }); // below the 0.2 relevance floor
+    const liveLow = ltm.create({
+      projectPath: PROJECT,
+      category: "gotcha",
+      title: "LiveLow",
+      content: "y",
+      scope: "project",
+      confidence: 0.5,
+    });
+
+    // enforceEntryCap counts only live entries, so a request to evict 1 must
+    // remove the lowest LIVE entry — not the cheaper dead one.
+    const evicted = ltm.evictLowestValue(PROJECT, 1);
+    expect(evicted.map((e) => e.id)).toEqual([liveLow]);
+    expect(ltm.get(dead)).not.toBeNull(); // dead entry untouched
+  });
+
   test("count <= 0 is a no-op; never evicts cross-project entries", () => {
     const g = ltm.create({
       category: "preference",

--- a/packages/core/test/ltm-lifecycle.test.ts
+++ b/packages/core/test/ltm-lifecycle.test.ts
@@ -306,3 +306,41 @@ describe("ltm.evictLowestValue", () => {
     expect(ltm.get(promoted)).not.toBeNull();
   });
 });
+
+describe("preference reinforcement on injection (forSession fast path)", () => {
+  beforeEach(clearKnowledge);
+
+  test("injecting a project-scoped preference resets its decay clock so decay does not delete it while in use", async () => {
+    const id = ltm.create({
+      projectPath: PROJECT,
+      category: "preference",
+      title: "Always run the linter before committing",
+      content: "Run the linter before every commit.",
+      scope: "project",
+    });
+    // Simulate a long-unreinforced entry that WOULD decay on the next pass.
+    db()
+      .query("UPDATE knowledge SET last_reinforced_at = 1000 WHERE id = ?")
+      .run(id);
+
+    // The preference-only fast path is the ONLY injection path for preferences
+    // (context blocks pass excludeCategories: ["preference"]).
+    const injected = await ltm.forSession(PROJECT, "sess-pref", 10_000, {
+      categories: ["preference"],
+    });
+    expect(injected.some((e) => e.id === id)).toBe(true);
+
+    // Injection moved the decay clock forward without touching confidence.
+    const after = ltm.get(id);
+    expect(after?.last_reinforced_at ?? 0).toBeGreaterThan(1000);
+    expect(after?.confidence).toBe(1.0);
+
+    // A decay pass within the grace window of the injection leaves it untouched —
+    // an actively-injected preference is never aged out. (Adversarial-review fix.)
+    const decayNow =
+      (after?.last_reinforced_at as number) + ltm.DECAY_GRACE_MS - 1000;
+    ltm.decayProject(PROJECT, decayNow);
+    expect(ltm.get(id)?.confidence).toBe(1.0);
+    expect(ltm.get(id)).not.toBeNull();
+  });
+});

--- a/packages/core/test/ltm-lifecycle.test.ts
+++ b/packages/core/test/ltm-lifecycle.test.ts
@@ -156,6 +156,37 @@ describe("ltm.decayProject", () => {
     expect(ltm.get(other)?.confidence).toBe(1.0);
   });
 
+  test("does not count (or touch) already-dead entries below the floor (Seer #816 count accuracy)", () => {
+    const base = Date.now();
+    const live = ltm.create({
+      projectPath: PROJECT,
+      category: "gotcha",
+      title: "Live stale",
+      content: "x",
+      scope: "project",
+    });
+    const dead = ltm.create({
+      projectPath: PROJECT,
+      category: "gotcha",
+      title: "Dead stale",
+      content: "y",
+      scope: "project",
+    });
+    // dead is below the relevance floor; both are long-unreinforced.
+    db().query("UPDATE knowledge SET confidence = 0.15 WHERE id = ?").run(dead);
+
+    const decayed = ltm.decayProject(
+      PROJECT,
+      base + ltm.DECAY_GRACE_MS + 60_000,
+    );
+
+    // Only the live entry is decayed and counted; the dead one is left for
+    // pruneDeadEntries and excluded from the count.
+    expect(decayed).toBe(1);
+    expect(ltm.get(live)?.confidence).toBeCloseTo(1.0 - ltm.DECAY_STEP, 5);
+    expect(ltm.get(dead)?.confidence).toBe(0.15);
+  });
+
   test("never decays a promoted cross-project entry that kept its origin project_id (Seer #816)", () => {
     const base = Date.now();
     const promoted = ltm.create({

--- a/packages/core/test/sync-data.test.ts
+++ b/packages/core/test/sync-data.test.ts
@@ -184,6 +184,40 @@ describe("contentHash", () => {
     );
     expect(h2).not.toBe(h1);
   });
+
+  test("changes when confidence changes (decay must propagate to sync)", () => {
+    // decayProject lowers confidence without bumping updated_at; the content
+    // hash must still change so the row is pushed to other clients.
+    insertKnowledge("k1", "T", "C");
+    const h1 = contentHash(
+      "knowledge",
+      getRowById("knowledge", "k1") as Record<string, unknown>,
+    );
+    db().query("UPDATE knowledge SET confidence = 0.5 WHERE id='k1'").run();
+    const h2 = contentHash(
+      "knowledge",
+      getRowById("knowledge", "k1") as Record<string, unknown>,
+    );
+    expect(h2).not.toBe(h1);
+  });
+
+  test("stable when only last_reinforced_at changes (injection must not churn sync)", () => {
+    // markInjected fires every turn on the hot path; it must not alter the hash
+    // or every injected entry would be re-pushed each turn.
+    insertKnowledge("k1", "T", "C");
+    const h1 = contentHash(
+      "knowledge",
+      getRowById("knowledge", "k1") as Record<string, unknown>,
+    );
+    db()
+      .query("UPDATE knowledge SET last_reinforced_at = ? WHERE id='k1'")
+      .run(now() + 12345);
+    const h2 = contentHash(
+      "knowledge",
+      getRowById("knowledge", "k1") as Record<string, unknown>,
+    );
+    expect(h2).toBe(h1);
+  });
 });
 
 describe("applyRemoteUpsert / applyRemoteDelete", () => {

--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -154,14 +154,17 @@ export function consolidationCooldownActive(
 }
 
 /**
- * Per-category entry count that triggers consolidation even when the GLOBAL
- * count is below maxEntries. The global trigger structurally misses single-
- * category bloat: a category (notably `preference`, which the curator re-mints
- * and re-phrases each session) can swell to dozens while the total stays under
- * maxEntries, so consolidation never fires and the duplicates inject into the
- * always-pinned system[1] block every session. This catches that case.
+ * Per-category consolidation trigger, proportional to the global cap so it
+ * scales with `maxEntries` instead of being a magic constant. The global
+ * trigger structurally misses single-category bloat: a category (notably
+ * `preference`, which the curator re-mints and re-phrases each session) can
+ * swell while the total stays under maxEntries, so consolidation never fires and
+ * the near-duplicates inject into the always-pinned system[1] block. Preserves
+ * the historical 12/40 = 0.3 ratio (→ 60 at the default maxEntries of 200).
  */
-const PER_CATEGORY_CONSOLIDATION_THRESHOLD = 12;
+export function perCategoryThreshold(maxEntries: number): number {
+  return Math.ceil(maxEntries * 0.3);
+}
 
 /**
  * Sub-agent sessions are ephemeral (1-3 turns) — evict them faster than
@@ -711,12 +714,17 @@ export function buildIdleWorkHandler(
       }
     }
 
-    // 3. Prune dead knowledge — hard-delete entries that have decayed to/below
-    //    the relevance floor (already invisible everywhere). Local DB-only step,
-    //    so it runs regardless of allowWorker. Keeps the row count and the
-    //    curator's existing-entries context lean.
+    // 3. Knowledge confidence lifecycle (local DB-only, runs regardless of
+    //    allowWorker). Decay first — lower confidence for entries unreinforced
+    //    past the grace window (interval-gated to once/24h per project) — then
+    //    prune anything that has reached the relevance floor. Keeps the row
+    //    count and the curator's existing-entries context lean.
     if (cfg.knowledge.enabled) {
       try {
+        const decayed = ltm.decayProject(projectPath);
+        if (decayed > 0) {
+          log.info(`decayed ${decayed} unreinforced knowledge entries`);
+        }
         const pruned = ltm.pruneDeadEntries(projectPath);
         if (pruned.length > 0) {
           log.info(
@@ -724,7 +732,7 @@ export function buildIdleWorkHandler(
           );
         }
       } catch (e) {
-        log.error("idle dead-entry prune error:", e);
+        log.error("idle knowledge-lifecycle error:", e);
       }
     }
 
@@ -752,9 +760,9 @@ export function buildIdleWorkHandler(
             topCategory = cat;
           }
         }
+        const categoryThreshold = perCategoryThreshold(cfg.curator.maxEntries);
         const globalOver = entries.length > cfg.curator.maxEntries;
-        const categoryOver =
-          topCategoryCount > PER_CATEGORY_CONSOLIDATION_THRESHOLD;
+        const categoryOver = topCategoryCount > categoryThreshold;
         if (globalOver || categoryOver) {
           const cooldown = consolidationCooldown.get(projectId);
           const now = Date.now();
@@ -776,7 +784,7 @@ export function buildIdleWorkHandler(
             log.info(
               globalOver
                 ? `entry count ${entries.length} exceeds maxEntries ${cfg.curator.maxEntries} — running consolidation`
-                : `category "${topCategory}" count ${topCategoryCount} exceeds per-category threshold ${PER_CATEGORY_CONSOLIDATION_THRESHOLD} — running consolidation`,
+                : `category "${topCategory}" count ${topCategoryCount} exceeds per-category threshold ${categoryThreshold} — running consolidation`,
             );
             const beforeCount = entries.length;
             consolidationInProgress.add(projectId);

--- a/packages/gateway/test/idle-work.test.ts
+++ b/packages/gateway/test/idle-work.test.ts
@@ -16,6 +16,7 @@ import {
   buildIdleWorkHandler,
   touchSession,
   consolidationCooldownActive,
+  perCategoryThreshold,
   CONSOLIDATION_COOLDOWN_MS,
   CONSOLIDATION_REATTEMPT_GROWTH,
 } from "../src/idle";
@@ -169,6 +170,14 @@ describe("consolidationCooldownActive", () => {
     expect(
       consolidationCooldownActive(cd, now + CONSOLIDATION_COOLDOWN_MS, 50, 14),
     ).toBe(false);
+  });
+});
+
+describe("perCategoryThreshold", () => {
+  test("is proportional to maxEntries (0.3 ratio), preserving the historical 12/40", () => {
+    expect(perCategoryThreshold(40)).toBe(12);
+    expect(perCategoryThreshold(200)).toBe(60);
+    expect(perCategoryThreshold(100)).toBe(30);
   });
 });
 

--- a/packages/website/src/content/docs/docs/configuration.md
+++ b/packages/website/src/content/docs/docs/configuration.md
@@ -131,7 +131,7 @@ Curator scheduling and consolidation thresholds.
 | `onIdle` | boolean | `true` |  | Run the curator on session idle (in addition to turn-based). Default: true. |
 | `inFlight` | boolean | `false` |  | Run the curator mid-conversation (turn-based), not just on idle. Default: false. WARNING: only enable on free-write / non-caching providers (e.g. MiniMax). On cache-sensitive providers (Anthropic), mid-session curation changes the knowledge base, which rewrites the context-bound LTM block (system[2]) and busts the prompt cache for the rest of a large conversation (a single change can re-write hundreds of thousands of cached tokens). Deferring curation to idle makes that rewrite free (the cache is cold then). Where cache writes are free this is harmless and yields fresher knowledge sooner. |
 | `afterTurns` | number | `3` | min 1 | Minimum turns between curator runs. Default: 3. |
-| `maxEntries` | number | `40` | min 10 | Max knowledge entries per project before consolidation. Default: 40. |
+| `maxEntries` | number | `200` | min 10 | Per-project knowledge entry ceiling. A generous backstop, not a quality gate: injection is already token-budget-capped, and the confidence lifecycle (decay + reinforcement) governs what stays. When exceeded, the lowest-value entries are evicted. Default: 200. |
 | `contextTokenBudget` | number | `20000` | min 2000 | Token budget for the existing-entries context sent to the curator each run. Bounds curator LLM cost so it stops scaling with stored entry count; a generous safety ceiling that only trims pathological sets (cross-project entries are always kept). Default: 20000. |
 
 


### PR DESCRIPTION
> Stacked on #815 → #814. Review/merge those first. The diff against `feat/curator-token-budget-prune` is the lifecycle engine itself.

## Why

A count cap on stored knowledge was the wrong primary control. Injection is already token-budget-capped (`forSession`), and #815 bounds curator cost — so the cap was doing nothing useful except freezing new knowledge when hit. And **confidence barely discriminated** (live DB: 114 entries at 1.0, 21 at 0.9, 25 at 0.8) because *nothing ever moved it* — so "evict lowest confidence" was effectively FIFO.

This builds a continuous **confidence lifecycle**: confidence is reinforced by use and decays without it, becoming a real value signal. It's the core primitive that **#627** (staleness → decay), **#497** (test/build outcomes → confidence), and **#495** (op log) all depend on — designed with pluggable reinforcement sources and a `reinforce()` seam.

## Changes

**Schema (migration v48):** `knowledge.last_reinforced_at` (relevance-confirmed clock) + `projects.last_decay_at` (per-project decay checkpoint). Both excluded from sync payload/hash — per-machine tracking; the synced `confidence` carries the meaningful state. `db.test.ts` schema assertion 47→48.

**Reinforcement:**
- `markInjected(ids)` — `forSession` resets the decay clock for injected entries **without** bumping confidence (bumping every turn would re-flatten everything to 1.0 and destroy the signal). Injection is finally a live signal (`last_accessed_at` was vestigial).
- `update()` resets the clock — any edit (curator op, dedup-merge, `.lore.md` import) is a re-confirmation.
- `reinforce(id, delta)` — explicit confidence boost + clock reset; the extension seam for #497/#627.

**Decay (`decayProject`):** interval-gated to once/24h per project (rate-stable, not tied to idle-tick frequency); lowers confidence by `DECAY_STEP` for entries unreinforced past a 7-day grace window. Unused knowledge ages to the relevance floor (then #815's `pruneDeadEntries` reaps it); regularly-injected knowledge never decays. The cap becomes **emergent**.

**Value eviction (`evictLowestValue` / `enforceEntryCap`):** replaces the hard create-gate. Creates are always admitted; if over `maxEntries`, the lowest-VALUE tail (decayed confidence, then least-recently reinforced) is evicted — a weak new entry self-evicts, so nothing valuable is displaced. Evictions flow through `changedEntries` as deletes (cache/delta consistency).

**Cap reframed:** `maxEntries` 40 → **200** (a generous backstop, not a gate); per-category consolidation threshold now `perCategoryThreshold = ceil(maxEntries * 0.3)` (preserves the historical 12/40 ratio → 60).

Idle pass gains a knowledge-lifecycle step (decay → prune) before consolidation.

## Tests

- `ltm-lifecycle.test.ts`: reinforcement (create stamps clock; markInjected resets clock without touching confidence; update resets; reinforce boosts + clamps); decay (only past grace, interval-gated, never other projects); eviction (lowest-confidence first, tie-break by reinforcement recency, tombstones, cross-project-safe, no-op on count≤0).
- `curator-changed-entries.test.ts`: `enforceEntryCap` no-ops under cap; evicts the lowest-value tail and records deletes.
- `idle-work.test.ts`: `perCategoryThreshold` proportionality.
- `config.test.ts` / `db.test.ts`: new defaults + schema version.
- Full suite: 3432 passed / 23 skipped. Typecheck, lint (no new warnings), build all green.