### PR TITLE
feat(core): global dead-knowledge sweep across all projects

### DIFF
--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -604,6 +604,26 @@ export function pruneDeadEntries(projectPath: string): KnowledgeEntry[] {
   return dead;
 }
 
+/**
+ * Global counterpart of `pruneDeadEntries`: reap dead rows across ALL projects
+ * in a single pass. The per-project version only runs for the active session's
+ * project on its idle tick, so dead entries in projects nobody is currently
+ * working in linger indefinitely (invisible, but counted). A periodic global
+ * sweep clears those. Same safety rule applies — only EXCLUSIVELY project-owned
+ * rows (`cross_project = 0`) are eligible; shared/global knowledge is never
+ * touched. `remove()` tombstones each id. Returns the pruned entries.
+ */
+export function pruneDeadEntriesAllProjects(): KnowledgeEntry[] {
+  const dead = db()
+    .query(
+      `SELECT ${KNOWLEDGE_COLS} FROM knowledge
+       WHERE cross_project = 0 AND confidence <= ?`,
+    )
+    .all(DEAD_CONFIDENCE_FLOOR) as KnowledgeEntry[];
+  for (const e of dead) remove(e.id);
+  return dead;
+}
+
 /** Token cost of one entry as the curator prompt renders it (see curatorUser). */
 function curatorEntryTokens(e: KnowledgeEntry): number {
   return estimateTokens(`[${e.id}] (${e.category}) ${e.title}: ${e.content}`);

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -612,14 +612,18 @@ export function pruneDeadEntries(projectPath: string): KnowledgeEntry[] {
  * sweep clears those. Same safety rule applies — only EXCLUSIVELY project-owned
  * rows (`cross_project = 0`) are eligible; shared/global knowledge is never
  * touched. `remove()` tombstones each id. Returns the pruned entries.
+ *
+ * `limit` bounds the per-pass delete count so a future mass-decay can never run
+ * an unbounded synchronous delete loop on the caller's event loop; the caller
+ * re-runs until the backlog clears. The default `-1` is SQLite's "no limit".
  */
-export function pruneDeadEntriesAllProjects(): KnowledgeEntry[] {
+export function pruneDeadEntriesAllProjects(limit = -1): KnowledgeEntry[] {
   const dead = db()
     .query(
       `SELECT ${KNOWLEDGE_COLS} FROM knowledge
-       WHERE cross_project = 0 AND confidence <= ?`,
+       WHERE cross_project = 0 AND confidence <= ? LIMIT ?`,
     )
-    .all(DEAD_CONFIDENCE_FLOOR) as KnowledgeEntry[];
+    .all(DEAD_CONFIDENCE_FLOOR, limit) as KnowledgeEntry[];
   for (const e of dead) remove(e.id);
   return dead;
 }

--- a/packages/core/test/ltm-curator-budget.test.ts
+++ b/packages/core/test/ltm-curator-budget.test.ts
@@ -179,6 +179,25 @@ describe("ltm.pruneDeadEntriesAllProjects", () => {
     });
     expect(ltm.pruneDeadEntriesAllProjects()).toHaveLength(0);
   });
+
+  test("respects the per-pass limit, draining the backlog over multiple calls", () => {
+    for (let i = 0; i < 5; i++) {
+      const id = ltm.create({
+        projectPath: PROJECT,
+        category: "gotcha",
+        title: `Dead ${i}`,
+        content: "x",
+        scope: "project",
+      });
+      ltm.update(id, { confidence: 0.0 });
+    }
+    // First bounded pass reaps at most `limit`; the rest survive for later passes.
+    expect(ltm.pruneDeadEntriesAllProjects(2)).toHaveLength(2);
+    expect(ltm.pruneDeadEntriesAllProjects(2)).toHaveLength(2);
+    // Remainder drains; then it's a no-op.
+    expect(ltm.pruneDeadEntriesAllProjects(2)).toHaveLength(1);
+    expect(ltm.pruneDeadEntriesAllProjects(2)).toHaveLength(0);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/test/ltm-curator-budget.test.ts
+++ b/packages/core/test/ltm-curator-budget.test.ts
@@ -100,6 +100,88 @@ describe("ltm.pruneDeadEntries", () => {
 });
 
 // ---------------------------------------------------------------------------
+// pruneDeadEntriesAllProjects (global sweep)
+// ---------------------------------------------------------------------------
+
+describe("ltm.pruneDeadEntriesAllProjects", () => {
+  beforeEach(clearKnowledge);
+
+  test("reaps dead project-owned entries across ALL projects, preserving live and shared ones", () => {
+    const deadHere = ltm.create({
+      projectPath: PROJECT,
+      category: "gotcha",
+      title: "Dead here",
+      content: "x",
+      scope: "project",
+    });
+    const deadThere = ltm.create({
+      projectPath: OTHER,
+      category: "gotcha",
+      title: "Dead there",
+      content: "y",
+      scope: "project",
+    });
+    ltm.update(deadHere, { confidence: 0.0 });
+    ltm.update(deadThere, { confidence: 0.1 });
+
+    const liveHere = ltm.create({
+      projectPath: PROJECT,
+      category: "gotcha",
+      title: "Live here",
+      content: "z",
+      scope: "project",
+    });
+    // A promoted (cross_project=1, kept origin project_id) dead entry — shared.
+    const promotedDead = ltm.create({
+      projectPath: OTHER,
+      category: "preference",
+      title: "Promoted dead",
+      content: "p",
+      scope: "project",
+    });
+    db()
+      .query(
+        "UPDATE knowledge SET cross_project = 1, confidence = 0.0 WHERE id = ?",
+      )
+      .run(promotedDead);
+    // A true global (project_id NULL) dead entry — shared.
+    const globalDead = ltm.create({
+      category: "preference",
+      title: "Global dead",
+      content: "g",
+      scope: "global",
+      crossProject: true,
+    });
+    ltm.update(globalDead, { confidence: 0.0 });
+
+    const pruned = ltm.pruneDeadEntriesAllProjects();
+
+    // Both project-owned dead entries (in different projects) are reaped.
+    expect(pruned.map((e) => e.id).sort()).toEqual(
+      [deadHere, deadThere].sort(),
+    );
+    expect(ltm.get(deadHere)).toBeNull();
+    expect(ltm.get(deadThere)).toBeNull();
+    expect(ltm.isTombstoned(deadHere)).toBe(true);
+    // Live and shared (promoted / global) entries are untouched.
+    expect(ltm.get(liveHere)).not.toBeNull();
+    expect(ltm.get(promotedDead)).not.toBeNull();
+    expect(ltm.get(globalDead)).not.toBeNull();
+  });
+
+  test("is a no-op when there are no dead entries", () => {
+    ltm.create({
+      projectPath: PROJECT,
+      category: "gotcha",
+      title: "Healthy",
+      content: "x",
+      scope: "project",
+    });
+    expect(ltm.pruneDeadEntriesAllProjects()).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // forCurator (token-budgeted existing-entries context)
 // ---------------------------------------------------------------------------
 

--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -98,6 +98,14 @@ const POLL_INTERVAL_MS = 30_000;
 export const GLOBAL_DEAD_SWEEP_INTERVAL_MS = 60 * 60 * 1000; // 1h
 
 /**
+ * Max entries the global sweep reaps per tick — bounds the synchronous delete
+ * loop so a pathological mass-decay backlog can't stall the proxy event loop.
+ * When a tick fills this batch, the gate is reset so the remainder drains on the
+ * next tick (every ~30s) instead of waiting the full interval.
+ */
+const GLOBAL_DEAD_SWEEP_BATCH = 1000;
+
+/**
  * Cooldown tracking for knowledge consolidation.
  *
  * When consolidation runs but fails to reduce entries below maxEntries
@@ -225,14 +233,19 @@ export function startIdleScheduler(
       loreConfig().knowledge.enabled &&
       now - lastGlobalDeadSweepAt >= GLOBAL_DEAD_SWEEP_INTERVAL_MS
     ) {
+      // Arm the gate BEFORE the work so a throw can't cause a per-tick retry
+      // storm (matches the consolidation cooldown pattern).
       lastGlobalDeadSweepAt = now;
       try {
-        const pruned = ltm.pruneDeadEntriesAllProjects();
+        const pruned = ltm.pruneDeadEntriesAllProjects(GLOBAL_DEAD_SWEEP_BATCH);
         if (pruned.length > 0) {
           log.info(
             `global sweep: pruned ${pruned.length} dead knowledge entries across all projects`,
           );
         }
+        // Filled the batch → more dead rows likely remain; drain on the next
+        // tick instead of waiting the full interval (re-open the gate).
+        if (pruned.length >= GLOBAL_DEAD_SWEEP_BATCH) lastGlobalDeadSweepAt = 0;
       } catch (e) {
         log.error("global dead-entry sweep error:", e);
       }

--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -88,6 +88,16 @@ import {
 const POLL_INTERVAL_MS = 30_000;
 
 /**
+ * How often the scheduler runs the GLOBAL dead-knowledge sweep
+ * (`pruneDeadEntriesAllProjects`). The per-session idle pass only prunes the
+ * active session's project, so dead entries in projects nobody is currently
+ * working in would linger. This backstop reaps them across all projects on a
+ * slow cadence (the work is a single local query that returns nothing most
+ * ticks). In-memory gate; the first tick after startup runs it once.
+ */
+export const GLOBAL_DEAD_SWEEP_INTERVAL_MS = 60 * 60 * 1000; // 1h
+
+/**
  * Cooldown tracking for knowledge consolidation.
  *
  * When consolidation runs but fails to reduce entries below maxEntries
@@ -194,6 +204,10 @@ export function startIdleScheduler(
 ): () => void {
   const inProgress = new Set<string>();
   const warmupInProgress = new Set<string>();
+  // In-memory gate for the global dead-knowledge sweep. Starts at 0 so the first
+  // tick after startup runs it once (catches entries that decayed while the
+  // gateway was down), then at most once per GLOBAL_DEAD_SWEEP_INTERVAL_MS.
+  let lastGlobalDeadSweepAt = 0;
 
   const timer = setInterval(() => {
     const now = Date.now();
@@ -203,6 +217,26 @@ export function startIdleScheduler(
     // this tick's work. The idle scheduler owns the sessions Map, so doing it
     // here keeps background-limiter free of session-state imports.
     scaleBackgroundConcurrency(sessions.size);
+
+    // Global dead-knowledge sweep — interval-gated backstop for entries in
+    // projects with no active session (the per-session pass only prunes the
+    // active project). Knowledge-gated; cheap local query; never throws out.
+    if (
+      loreConfig().knowledge.enabled &&
+      now - lastGlobalDeadSweepAt >= GLOBAL_DEAD_SWEEP_INTERVAL_MS
+    ) {
+      lastGlobalDeadSweepAt = now;
+      try {
+        const pruned = ltm.pruneDeadEntriesAllProjects();
+        if (pruned.length > 0) {
+          log.info(
+            `global sweep: pruned ${pruned.length} dead knowledge entries across all projects`,
+          );
+        }
+      } catch (e) {
+        log.error("global dead-entry sweep error:", e);
+      }
+    }
 
     // --- Idle work (distillation, curation, etc.) ---
     for (const [sessionID, state] of sessions) {

--- a/packages/gateway/test/eviction.test.ts
+++ b/packages/gateway/test/eviction.test.ts
@@ -21,6 +21,7 @@ import {
   distillLimiter,
   curatorLimiter,
   loadSessionTracking,
+  ltm,
 } from "@loreai/core";
 import { startIdleScheduler, evictIdleSessions } from "../src/idle";
 import { loadConfig } from "../src/config";
@@ -558,6 +559,34 @@ describe("startIdleScheduler", () => {
       release();
       vi.useRealTimers();
       distillLimiter.clear();
+    }
+  });
+
+  test("runs the global dead-knowledge sweep on the first tick, with no active session", async () => {
+    vi.useFakeTimers();
+    try {
+      // A dead entry in a project with NO active session — the per-session pass
+      // would never reach it; only the global sweep does.
+      const id = ltm.create({
+        projectPath: "/test/idle/global-sweep",
+        category: "gotcha",
+        title: "Idle-project zombie",
+        content: "x",
+        scope: "project",
+      });
+      ltm.update(id, { confidence: 0 }); // below the relevance floor → dead
+      expect(ltm.get(id)).not.toBeNull();
+
+      const sessions = new Map<string, SessionState>();
+      const stop = startIdleScheduler(makeConfig(), sessions, async () => {});
+
+      // First scheduler tick fires the sweep even with an empty sessions map.
+      await vi.advanceTimersByTimeAsync(31_000);
+      expect(ltm.get(id)).toBeNull();
+
+      stop();
+    } finally {
+      vi.useRealTimers();
     }
   });
 });

--- a/packages/gateway/test/eviction.test.ts
+++ b/packages/gateway/test/eviction.test.ts
@@ -589,4 +589,39 @@ describe("startIdleScheduler", () => {
       vi.useRealTimers();
     }
   });
+
+  test("the global sweep is interval-gated: a second tick within the hour does not re-run", async () => {
+    vi.useFakeTimers();
+    try {
+      const stop = startIdleScheduler(
+        makeConfig(),
+        new Map<string, SessionState>(),
+        async () => {},
+      );
+      // First tick runs the sweep and arms the 1h gate.
+      await vi.advanceTimersByTimeAsync(31_000);
+
+      // A new zombie appears AFTER the first sweep.
+      const id = ltm.create({
+        projectPath: "/test/idle/global-sweep-gate",
+        category: "gotcha",
+        title: "Late zombie",
+        content: "x",
+        scope: "project",
+      });
+      ltm.update(id, { confidence: 0 });
+
+      // Another tick within the interval must NOT sweep (gate still active).
+      await vi.advanceTimersByTimeAsync(31_000);
+      expect(ltm.get(id)).not.toBeNull();
+
+      // Once the interval elapses, the next tick reaps it.
+      await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+      expect(ltm.get(id)).toBeNull();
+
+      stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });


### PR DESCRIPTION
## Why

The confidence lifecycle (#816) reaps dead entries via `pruneDeadEntries`, but that only runs for the **active session's project** on its idle tick. Dead entries (`confidence <= 0.2`) in projects nobody is currently working in linger indefinitely — invisible to injection/recall/curation, but still counted and stored.

A live check right after the lifecycle shipped found **14 such zombies** spread across 4 idle projects (`/home/byk/Code`, `fossilize`, `getsentry/cli`, `opencode-lore`) — none in the project that was active, so the per-session pass would never reach them.

## Changes

- **`ltm.pruneDeadEntriesAllProjects()`** — global counterpart of `pruneDeadEntries`: reaps dead **exclusively-owned** rows (`cross_project = 0`) across all projects in one pass. Shared/global knowledge is never touched (same safety rule as the per-project version). `remove()` tombstones each id.
- **Scheduler wiring** — the idle scheduler runs the sweep **interval-gated** (`GLOBAL_DEAD_SWEEP_INTERVAL_MS = 1h`, in-memory gate). The first tick after startup runs it once (clearing entries that decayed while the gateway was down), then at most once/hour. Gated on `knowledge.enabled`; it's a single cheap local query that returns nothing most ticks, and runs regardless of whether any session is active.

## Tests

- `ltm-curator-budget.test.ts`: reaps dead project-owned entries across **multiple** projects while preserving live, promoted (`cross_project=1` in place), and true-global entries; no-op when nothing is dead.
- `eviction.test.ts`: the scheduler fires the sweep on the first tick with an **empty** sessions map (proving it doesn't depend on an active session).
- Full suite 3457 passed / 23 skipped; typecheck, lint (no new warnings), build all green.

Follow-up to the consolidation-storm / LTM-saturation stack (#814 → #815 → #816).