### PR TITLE
test(sync): registry-contract + identity-lifecycle invariant batteries

### DIFF
--- a/packages/core/test/sync-registry-contract.test.ts
+++ b/packages/core/test/sync-registry-contract.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Registry contract battery for SYNCED_TABLES.
+ *
+ * The two #828 sync bugs (prune-floor wedge, cross-account tier residue) shared
+ * a root cause that example-based tests miss: adding a row to the SYNCED_TABLES
+ * fan-out has ripple effects (capture triggers, seedOutbox, reconcile, push
+ * skip, prune floor) that no single feature test enforces as a contract. This
+ * battery loops EVERY registered table and asserts the cross-cutting invariants
+ * each flag (`pullOnly`, `versioned`) implies — so a future table (a team scope,
+ * a Pro table in #826/D) automatically inherits the checks and cannot silently
+ * violate them on a path nobody re-examined.
+ *
+ * Core-level invariants live here (triggers + seedOutbox/reconcile). The
+ * engine-level pull-only invariants (pushOnce skips it; it never wedges the
+ * prune floor) are asserted in packages/gateway/test/sync.test.ts against the
+ * real push path.
+ */
+import { beforeEach, describe, expect, test } from "vitest";
+import { db, deleteTeamConfig } from "../src/db";
+import {
+  enableSync,
+  readOutbox,
+  SYNCED_TABLES,
+  seedOutbox,
+} from "../src/sync-data";
+
+const now = () => Date.now();
+
+/**
+ * Live-row factories used by the BEHAVIORAL pull-only checks. EVERY pull-only
+ * table MUST register one here — the completeness test below fails otherwise, so
+ * a new pull-only table can't quietly skip the prune-floor-wedge guard.
+ */
+const SAMPLE_ROW: Record<string, () => void> = {
+  profiles: () =>
+    db()
+      .query(
+        "INSERT INTO profiles (id, tier, created_at, updated_at) VALUES ('rc-sample', 'pro', ?, ?)",
+      )
+      .run(now(), now()),
+};
+
+function tempTriggers(): string[] {
+  return (
+    db()
+      .query("SELECT name FROM sqlite_temp_master WHERE type='trigger'")
+      .all() as Array<{ name: string }>
+  ).map((r) => r.name);
+}
+
+function outboxFor(table: string) {
+  return readOutbox(0).filter((e) => e.table_name === table);
+}
+
+beforeEach(() => {
+  deleteTeamConfig("sync.enabled");
+  db().exec("DELETE FROM temp._sync_applying");
+  db().exec("DELETE FROM sync_outbox");
+  db().exec("DELETE FROM sync_state");
+  for (const m of SYNCED_TABLES.basic) {
+    db().exec(`DELETE FROM ${m.table}`);
+  }
+});
+
+describe("SYNCED_TABLES registry contract", () => {
+  for (const m of SYNCED_TABLES.basic) {
+    describe(`${m.table}${m.pullOnly ? " (pull-only)" : ""}`, () => {
+      test("idColumns are non-empty and a subset of syncColumns", () => {
+        // rowIdOf()/getRowById() read the id columns out of a syncColumns-only
+        // projection, so the PK must be carried in syncColumns.
+        expect(m.idColumns.length).toBeGreaterThan(0);
+        for (const c of m.idColumns) expect(m.syncColumns).toContain(c);
+      });
+
+      test("has a change-capture trigger IFF it is not pull-only", () => {
+        // Pull-only tables are server-authoritative; capturing local writes
+        // would enqueue an entry that can never be pushed.
+        const captured = tempTriggers().some((n) =>
+          n.startsWith(`${m.table}_outbox_`),
+        );
+        expect(captured).toBe(!m.pullOnly);
+      });
+
+      if (m.pullOnly) {
+        test("registers a SAMPLE_ROW (contract completeness)", () => {
+          expect(SAMPLE_ROW[m.table]).toBeDefined();
+        });
+
+        test("seedOutbox NEVER enqueues it, even with a live row", () => {
+          SAMPLE_ROW[m.table]?.();
+          seedOutbox();
+          expect(outboxFor(m.table)).toHaveLength(0);
+        });
+
+        test("reconcile/enableSync NEVER enqueues it, even with a live row", () => {
+          // The disable→enable path the capture-trigger exclusion does NOT cover:
+          // a populated mirror at enable time must not be seeded (else its
+          // never-advancing push cursor pins the prune floor at 0 for ALL tables).
+          SAMPLE_ROW[m.table]?.();
+          enableSync();
+          expect(outboxFor(m.table)).toHaveLength(0);
+        });
+      }
+    });
+  }
+});

--- a/packages/gateway/test/supabase.test.ts
+++ b/packages/gateway/test/supabase.test.ts
@@ -181,6 +181,16 @@ describe("getAuthedClient / getCurrentUser", () => {
   });
 });
 
+/**
+ * Identity-lifecycle battery — the standing pattern for any per-user state the
+ * client caches locally (today: the pulled `profiles` mirror; future: Pro
+ * tables in #826, team scopes). Asserts the full identity state-machine, not
+ * single operations: logout, account switch, and token refresh, plus
+ * cross-account isolation in BOTH directions. The #828 tier-residue bug lived
+ * exactly here (login→logout→read and A→B switch were never exercised). When a
+ * second piece of per-user state is added, extend `seedState`/`readState` below
+ * rather than re-deriving the sequences.
+ */
 describe("profile mirror lifecycle (tier must not leak across sessions)", () => {
   function seedProfile(tier: string): void {
     db()
@@ -217,5 +227,23 @@ describe("profile mirror lifecycle (tier must not leak across sessions)", () => 
     seedProfile("pro");
     persistSession({ ...SAMPLE, access_token: "at-refreshed" });
     expect(syncData.currentTier()).toBe("pro"); // refresh must not wipe the tier
+  });
+
+  test("no tier leak across an account switch in EITHER direction", () => {
+    // A (pro) → switch to B: B must NOT inherit A's pro — the mirror is cleared
+    // and B re-pulls its own 'free'. Switch back to A: A must NOT see a stale
+    // pro either; it re-pulls fresh. The mirror always reflects exactly the
+    // currently-authenticated account.
+    persistSession(SAMPLE); // account A (user-123)
+    seedProfile("pro");
+    expect(syncData.currentTier()).toBe("pro");
+
+    persistSession({ ...SAMPLE, user_id: "user-B" }); // switch to B
+    expect(syncData.currentTier()).toBe("free"); // A's pro dropped, not inherited
+    seedProfile("free"); // B pulls its own (free) profile
+    expect(syncData.currentTier()).toBe("free");
+
+    persistSession(SAMPLE); // switch back to A
+    expect(syncData.currentTier()).toBe("free"); // A's stale pro NOT resurrected
   });
 });


### PR DESCRIPTION
**Stacked on #828** (uses its `pullOnly` + `clearProfileMirror`). Retarget to `main` once #828 merges.

Follow-up to the testing-strategy review: the two #828 bugs (outbox prune-floor wedge, cross-account tier residue) were both **state-transition / registry fan-out** bugs that example-based, author-ordered tests miss. This converts those one-off regressions into **standing, generalized batteries** so future tables/state inherit the checks automatically.

## Battery #1 — registry contract (`sync-registry-contract.test.ts`)
Loops **every** `SYNCED_TABLES` entry and asserts the invariants each flag implies:
- `idColumns` non-empty and ⊆ `syncColumns`
- capture trigger exists **IFF** not `pullOnly`
- every `pullOnly` table registers a sample row (completeness guard) and is **NEVER** enqueued by `seedOutbox`/`reconcile` even with a live row present (the prune-floor-wedge guard)

A new synced/pull-only table (team scope, Pro table in #826) automatically inherits these — closing the "added profiles, broke paths nobody re-checked" class.

## Battery #2 — identity lifecycle (`supabase.test.ts`)
Rounds the profile-mirror tests into the full identity state-machine battery: logout-clears, account-switch-clears, token-refresh-keeps, plus **cross-account isolation in both directions** (no tier leak A→B or B→A). Documents the pattern for future per-user cached state.

## Notes
- **Test-only**; no src changes.
- Each pull-only behavioral assertion fails if the `pullOnly` guard is removed (they insert a row and assert the outbox stays empty), so they genuinely constrain the fix.
- The remaining review recommendations (mutation testing, fast-check property/sequence tests, runtime invariant asserts, process) are filed as follow-up issues.
- Full suite 3488 passed; typecheck + lint clean.