### PR TITLE
fix(gateway): scope cache-warmer circuit breaker per (session, model, upstream)

### DIFF
--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -45,6 +45,7 @@ import { resolveUpstreamRoute } from "./config";
 import { getModelEntrySync } from "./worker-model";
 import { recordWarmupCost } from "./cost-tracker";
 import { upstreamFetch } from "./fetch";
+import { emitWarmupCircuitBreakerMetric } from "./sentry";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -109,8 +110,14 @@ export const TOOL_CALL_MAX_CYCLES = 2;
  *  MIN_WARMUPS_FOR_ROI_CHECK=5 guard let nearly all of them through. */
 export const TOOL_CALL_MIN_HITS_FOR_CONTINUATION = 1;
 
-/** Max uncached warmup responses before the global circuit breaker trips. */
+/** Max uncached warmup responses before a bucket's circuit breaker trips. */
 const CIRCUIT_BREAKER_MAX_FAILURES = 3;
+
+/** How long a tripped bucket stays disabled before auto-decaying (ms). A
+ *  transient upstream cache-key change recovers on its own within this window;
+ *  a genuinely broken bucket wastes at most a few warmups per decay period.
+ *  Buckets can also be cleared immediately via resetCircuitBreaker(). */
+export const CIRCUIT_BREAKER_DECAY_MS = 6 * 3_600_000; // 6 hours
 
 /** Gap duration floor (ms) separating "active coding turns" from "breaks".
  *  3 minutes is well past typical agent think time (10s–60s) but before
@@ -151,117 +158,250 @@ export const MIN_INPUT_TOKENS_FOR_WARMING = 50_000;
 export const MIN_RETURN_PROBABILITY_FLOOR = 0.3;
 
 // ---------------------------------------------------------------------------
-// Global circuit breaker
+// Per-bucket circuit breaker
 // ---------------------------------------------------------------------------
+//
+// A warmup "failure" is a response with cacheCreation > 0 AND cacheRead === 0
+// while the cached prefix should still have been alive (see `cacheLikelyAlive`
+// in executeWarmup) — meaning the warmup body did not match the cached prefix.
+//
+// The breaker is scoped PER BUCKET — keyed by (sessionID, model, upstreamURL) —
+// so one pathological session/model/provider can never disable warming for
+// healthy sessions. Switching model or provider mid-session lands in a separate
+// bucket. A tripped bucket auto-decays after CIRCUIT_BREAKER_DECAY_MS so a
+// transient upstream cache-key change recovers on its own; it can also be
+// cleared explicitly via resetCircuitBreaker() (/lore:warm:reset, UI button).
 
-let circuitBreakerFailures = 0;
-let circuitBreakerTripped = false;
-let circuitBreakerLoaded = false;
+type BreakerEntry = {
+  /** Consecutive uncached warmups (reset on a confirmed cache read). In-memory only. */
+  failures: number;
+  /** True once `failures` reached CIRCUIT_BREAKER_MAX_FAILURES. */
+  tripped: boolean;
+  /** ms timestamp when this bucket tripped (0 when not tripped). Drives auto-decay. */
+  trippedAt: number;
+};
+
+/** Per-bucket breaker state. Key = warmupBucketKey(state). */
+const circuitBreakers = new Map<string, BreakerEntry>();
+let circuitBreakersLoaded = false;
 
 const CB_KV_KEY = "warmup_circuit_breaker";
 
-/** Load circuit breaker state from DB on first access. */
-function ensureCircuitBreakerLoaded(): void {
-  if (circuitBreakerLoaded) return;
-  circuitBreakerLoaded = true;
+/**
+ * Compute the circuit-breaker bucket key for a session: (sessionID, model,
+ * upstreamURL). Switching model or upstream mid-session yields a distinct
+ * bucket so failures never cross-contaminate.
+ */
+export function warmupBucketKey(state: SessionState): string {
+  const model = state.lastUpstream?.model ?? "unknown";
+  const url = state.lastUpstream?.url ?? "unknown";
+  return `${state.sessionID}\x1f${model}\x1f${url}`;
+}
+
+/** Load tripped buckets from DB on first access (only tripped buckets persist). */
+function ensureCircuitBreakersLoaded(): void {
+  if (circuitBreakersLoaded) return;
+  circuitBreakersLoaded = true;
   try {
     const raw = getKV(CB_KV_KEY);
-    if (raw) {
-      const parsed = JSON.parse(raw) as {
-        tripped?: boolean;
-        failures?: number;
-      };
-      circuitBreakerTripped = parsed.tripped ?? false;
-      circuitBreakerFailures = parsed.failures ?? 0;
+    if (!raw) return;
+    const parsed = JSON.parse(raw) as {
+      version?: number;
+      buckets?: Record<string, { trippedAt?: number }>;
+    };
+    // Legacy v1 shape ({tripped, failures}) carried no bucket identity. A stale
+    // global flag must NOT permanently disable per-bucket warming, so drop it
+    // (rewrite the KV to the empty v2 shape). This also auto-clears any breaker
+    // latched by the old global implementation on first run of this build.
+    if (parsed.version !== 2 || !parsed.buckets) {
+      setKV(CB_KV_KEY, JSON.stringify({ version: 2, buckets: {} }));
+      return;
     }
+    const now = Date.now();
+    let droppedStale = false;
+    for (const [bucket, entry] of Object.entries(parsed.buckets)) {
+      const trippedAt = entry.trippedAt ?? 0;
+      // Apply decay on load — drop buckets older than the decay window.
+      if (trippedAt > 0 && now - trippedAt < CIRCUIT_BREAKER_DECAY_MS) {
+        circuitBreakers.set(bucket, { failures: 0, tripped: true, trippedAt });
+      } else {
+        droppedStale = true;
+      }
+    }
+    // Shrink the persisted set across restarts when stale buckets were dropped.
+    if (droppedStale) saveCircuitBreakers();
   } catch {
-    // Corrupted value — start fresh
+    // Corrupted value — start fresh.
   }
 }
 
-/** Persist circuit breaker state to DB. */
-function saveCircuitBreaker(): void {
-  setKV(
-    CB_KV_KEY,
-    JSON.stringify({
-      tripped: circuitBreakerTripped,
-      failures: circuitBreakerFailures,
-    }),
-  );
+/** Persist only tripped buckets to DB in the v2 shape. */
+function saveCircuitBreakers(): void {
+  const buckets: Record<string, { trippedAt: number }> = {};
+  for (const [bucket, entry] of circuitBreakers) {
+    if (entry.tripped) buckets[bucket] = { trippedAt: entry.trippedAt };
+  }
+  setKV(CB_KV_KEY, JSON.stringify({ version: 2, buckets }));
 }
 
 /**
- * Check if the global circuit breaker has tripped.
+ * Check if a bucket's circuit breaker has tripped.
  *
- * Once tripped, ALL cache warming is disabled for the process lifetime.
- * This is intentionally non-recoverable — if warmups are causing cache
- * writes instead of reads, something fundamental is wrong (our assumptions
- * about cache key computation, body format, auth, etc.) and we cannot
- * afford to keep trying.
+ * Applies auto-decay: a tripped bucket older than CIRCUIT_BREAKER_DECAY_MS is
+ * cleared and re-armed, so a transient upstream cache-key change recovers on
+ * its own without a restart or manual reset.
  */
-export function isCircuitBreakerTripped(): boolean {
-  ensureCircuitBreakerLoaded();
-  return circuitBreakerTripped;
+export function isCircuitBreakerTripped(
+  bucketKey: string,
+  now: number = Date.now(),
+): boolean {
+  ensureCircuitBreakersLoaded();
+  const entry = circuitBreakers.get(bucketKey);
+  if (!entry?.tripped) return false;
+  if (now - entry.trippedAt >= CIRCUIT_BREAKER_DECAY_MS) {
+    circuitBreakers.delete(bucketKey);
+    saveCircuitBreakers();
+    return false;
+  }
+  return true;
 }
 
-/** Snapshot of circuit breaker state for dashboard rendering. */
-export function getCircuitBreakerStatus(): {
+/** Snapshot of a bucket's circuit breaker state for dashboard rendering. */
+export function getCircuitBreakerStatus(
+  bucketKey: string,
+  now: number = Date.now(),
+): {
   tripped: boolean;
   failures: number;
   maxFailures: number;
+  trippedAt: number;
 } {
-  ensureCircuitBreakerLoaded();
+  ensureCircuitBreakersLoaded();
+  const tripped = isCircuitBreakerTripped(bucketKey, now);
+  const entry = circuitBreakers.get(bucketKey);
   return {
-    tripped: circuitBreakerTripped,
-    failures: circuitBreakerFailures,
+    tripped,
+    failures: entry?.failures ?? 0,
     maxFailures: CIRCUIT_BREAKER_MAX_FAILURES,
+    trippedAt: entry?.trippedAt ?? 0,
   };
 }
 
+/** Aggregate breaker state across all buckets (for the dashboard global card). */
+export function getCircuitBreakerSummary(now: number = Date.now()): {
+  trippedCount: number;
+  entries: Array<{ bucket: string; trippedAt: number }>;
+} {
+  ensureCircuitBreakersLoaded();
+  const entries: Array<{ bucket: string; trippedAt: number }> = [];
+  for (const [bucket, entry] of circuitBreakers) {
+    if (entry.tripped && now - entry.trippedAt < CIRCUIT_BREAKER_DECAY_MS) {
+      entries.push({ bucket, trippedAt: entry.trippedAt });
+    }
+  }
+  return { trippedCount: entries.length, entries };
+}
+
 /**
- * Record a warmup result and check the circuit breaker.
+ * Drop tripped buckets that have aged past the decay window. The decay-on-read
+ * path in isCircuitBreakerTripped only fires for buckets that are re-queried;
+ * a bucket belonging to an evicted/dead session is never re-checked, so without
+ * this sweep its (persisted) tripped entry would linger until process restart.
+ * Called periodically from the idle loop to keep both the in-memory map and the
+ * persisted KV bounded. Returns the number of buckets pruned.
  *
- * A "failure" is a warmup where cacheCreationTokens > 0 AND
- * cacheReadTokens === 0 — meaning the warmup caused a fresh cache write
- * instead of refreshing an existing entry. This should never happen if
- * the warmup body matches the cached prefix.
- *
- * Returns true if the circuit breaker has tripped (warming should stop).
+ * Non-tripped failure entries are not persisted and are cleared on the next
+ * confirmed read or reset, so they are intentionally left untouched here.
  */
-export function checkCircuitBreaker(result: WarmupResult): boolean {
-  ensureCircuitBreakerLoaded();
-  if (circuitBreakerTripped) return true;
+export function pruneExpiredCircuitBreakers(now: number = Date.now()): number {
+  ensureCircuitBreakersLoaded();
+  let pruned = 0;
+  for (const [bucket, entry] of circuitBreakers) {
+    if (entry.tripped && now - entry.trippedAt >= CIRCUIT_BREAKER_DECAY_MS) {
+      circuitBreakers.delete(bucket);
+      pruned++;
+    }
+  }
+  if (pruned > 0) saveCircuitBreakers();
+  return pruned;
+}
+
+/**
+ * Record a warmup result for a bucket and check its circuit breaker.
+ *
+ * A "failure" is a warmup where cacheCreationTokens > 0 AND cacheReadTokens === 0
+ * AND the cached prefix should still have been alive (`cacheLikelyAlive`). When
+ * the cache had already expired, a fresh write is the warmer legitimately
+ * re-priming a cold cache — NOT a body/prefix mismatch — so it is neutral
+ * (neither increments nor resets the counter). Likewise non-2xx responses
+ * (`result.ok === false`, e.g. thinking-session 400s) are neutral.
+ *
+ * Returns true if the bucket's breaker is tripped (warming should stop).
+ */
+export function checkCircuitBreaker(
+  result: WarmupResult,
+  bucketKey: string,
+  cacheLikelyAlive: boolean,
+  now: number = Date.now(),
+): boolean {
+  ensureCircuitBreakersLoaded();
+  if (isCircuitBreakerTripped(bucketKey, now)) return true;
 
   if (
     result.ok &&
     result.cacheCreationTokens > 0 &&
-    result.cacheReadTokens === 0
+    result.cacheReadTokens === 0 &&
+    cacheLikelyAlive
   ) {
-    circuitBreakerFailures++;
+    const entry = circuitBreakers.get(bucketKey) ?? {
+      failures: 0,
+      tripped: false,
+      trippedAt: 0,
+    };
+    entry.failures++;
+    circuitBreakers.set(bucketKey, entry);
     log.error(
-      `cache-warmer CIRCUIT BREAKER: warmup caused uncached write ` +
-        `(${circuitBreakerFailures}/${CIRCUIT_BREAKER_MAX_FAILURES}). ` +
+      `cache-warmer CIRCUIT BREAKER: warmup caused uncached write for ` +
+        `bucket=${bucketKey.slice(0, 24)} ` +
+        `(${entry.failures}/${CIRCUIT_BREAKER_MAX_FAILURES}). ` +
         `cacheCreation=${result.cacheCreationTokens} cacheRead=${result.cacheReadTokens}`,
     );
-    saveCircuitBreaker();
-    if (circuitBreakerFailures >= CIRCUIT_BREAKER_MAX_FAILURES) {
-      circuitBreakerTripped = true;
-      saveCircuitBreaker();
+    if (entry.failures >= CIRCUIT_BREAKER_MAX_FAILURES) {
+      entry.tripped = true;
+      entry.trippedAt = now;
+      saveCircuitBreakers();
+      emitWarmupCircuitBreakerMetric();
       log.error(
-        `cache-warmer CIRCUIT BREAKER TRIPPED: ${CIRCUIT_BREAKER_MAX_FAILURES} consecutive ` +
-          `uncached warmups detected. ALL cache warming disabled for this process. ` +
-          `This indicates warmup bodies don't match the cached prefix — ` +
-          `investigate cache key computation assumptions.`,
+        `cache-warmer CIRCUIT BREAKER TRIPPED for bucket=${bucketKey.slice(0, 24)}: ` +
+          `${CIRCUIT_BREAKER_MAX_FAILURES} uncached warmups detected. Warming disabled for ` +
+          `this (session, model, upstream) until it decays in ` +
+          `${Math.round(CIRCUIT_BREAKER_DECAY_MS / 3_600_000)}h or is reset. This indicates ` +
+          `warmup bodies don't match the cached prefix — investigate cache key assumptions.`,
       );
       return true;
     }
   } else if (result.ok && result.cacheReadTokens > 0) {
-    // Successful cache read — reset the failure counter
-    circuitBreakerFailures = 0;
-    saveCircuitBreaker();
+    // Confirmed cache read — clear any accumulated (non-tripped) failures.
+    const entry = circuitBreakers.get(bucketKey);
+    if (entry && !entry.tripped) circuitBreakers.delete(bucketKey);
   }
 
-  return circuitBreakerTripped;
+  return false;
+}
+
+/**
+ * Reset the circuit breaker. Pass a bucket key to clear a single bucket, or
+ * omit to clear ALL buckets. The production recovery path — reachable via the
+ * /lore:warm:reset slash command and the POST /ui/api/warming/reset route.
+ */
+export function resetCircuitBreaker(bucketKey?: string): void {
+  ensureCircuitBreakersLoaded();
+  if (bucketKey) {
+    circuitBreakers.delete(bucketKey);
+  } else {
+    circuitBreakers.clear();
+  }
+  saveCircuitBreakers();
 }
 
 // ---------------------------------------------------------------------------
@@ -886,8 +1026,8 @@ export function shouldWarm(
   blendedHist: InterTurnHistogram,
   now: number = Date.now(),
 ): boolean {
-  // Global kill switch — always respected, even with /lore:warm:keep
-  if (circuitBreakerTripped) return false;
+  // Per-bucket kill switch — always respected, even with /lore:warm:keep.
+  if (isCircuitBreakerTripped(warmupBucketKey(state), now)) return false;
 
   // Sub-agent sessions are always exempt — they are too short-lived
   // for warming to be profitable, even with /lore:warm:keep force.
@@ -1207,8 +1347,13 @@ export type WarmingSnapshot = {
   // Decision
   shouldWarmNow: boolean;
   notWarmingReason: string | null;
-  // Circuit breaker (global, same for all sessions)
-  circuitBreaker: { tripped: boolean; failures: number; maxFailures: number };
+  // Circuit breaker for THIS session's (model, upstream) bucket.
+  circuitBreaker: {
+    tripped: boolean;
+    failures: number;
+    maxFailures: number;
+    trippedAt: number;
+  };
 };
 
 /**
@@ -1300,7 +1445,7 @@ export function computeWarmingSnapshot(
 
   let notWarmingReason: string | null = null;
   if (!warmNow) {
-    if (circuitBreakerTripped) {
+    if (isCircuitBreakerTripped(warmupBucketKey(state), now)) {
       notWarmingReason = "Circuit breaker tripped";
     } else if (state.isSubagent) {
       notWarmingReason = "Sub-agent session (ephemeral)";
@@ -1463,7 +1608,7 @@ export function computeWarmingSnapshot(
     // Decision
     shouldWarmNow: warmNow,
     notWarmingReason,
-    circuitBreaker: getCircuitBreakerStatus(),
+    circuitBreaker: getCircuitBreakerStatus(warmupBucketKey(state), now),
   };
 }
 
@@ -1528,6 +1673,20 @@ export async function executeWarmup(
 
   const { lastRequestBody } = state.cacheAnalytics;
   if (!lastRequestBody) return noResult;
+
+  // Circuit-breaker bucket + cache-liveness, captured BEFORE the warmup state
+  // mutation below overwrites lastWarmupAt. cacheRead=0 only indicates a
+  // body/prefix mismatch when the cached entry should still be alive; if the
+  // last cache write (real turn or prior warmup) is older than the breakpoint
+  // TTL, the entry expired and a fresh write is the warmer re-priming a cold
+  // cache — expected, not a fault. checkCircuitBreaker ignores those.
+  const breakerBucket = warmupBucketKey(state);
+  const lastCacheTouch = Math.max(
+    state.lastRequestTime ?? 0,
+    state.warmup?.lastWarmupAt ?? 0,
+  );
+  const cacheLikelyAlive =
+    lastCacheTouch > 0 && Date.now() - lastCacheTouch < profile.ttlMs;
 
   // Decompress the stored body
   const storedBody = decompressBody(lastRequestBody);
@@ -1711,8 +1870,8 @@ export async function executeWarmup(
       state.warmup.writeEfficiencySamples = samples;
     }
 
-    // Check circuit breaker
-    checkCircuitBreaker(result);
+    // Check circuit breaker for this (session, model, upstream) bucket.
+    checkCircuitBreaker(result, breakerBucket, cacheLikelyAlive);
 
     // Clear worker-health failure state on successful warmup.
     recordWorkerSuccess(state.sessionID);
@@ -1932,13 +2091,22 @@ export function getGlobalHistogramsSnapshot(): ReadonlyMap<
 // Test helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * @internal Drop in-memory breaker state and force the next access to re-read
+ * from the DB (exercises ensureCircuitBreakersLoaded, incl. legacy migration
+ * and on-load decay). Tests seed the KV directly, then call this.
+ */
+export function _forceReloadForTest(): void {
+  circuitBreakers.clear();
+  circuitBreakersLoaded = false;
+}
+
 /** @internal Reset module state for tests. */
 export function _resetForTest(): void {
-  circuitBreakerFailures = 0;
-  circuitBreakerTripped = false;
-  circuitBreakerLoaded = true; // Mark as loaded so it doesn't re-read stale DB state
+  circuitBreakers.clear();
+  circuitBreakersLoaded = true; // Mark as loaded so it doesn't re-read stale DB state
   try {
-    setKV(CB_KV_KEY, JSON.stringify({ tripped: false, failures: 0 }));
+    setKV(CB_KV_KEY, JSON.stringify({ version: 2, buckets: {} }));
   } catch {
     /* DB may not be available in all test contexts */
   }

--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -44,6 +44,8 @@ import type { SessionState } from "./translate/types";
 import { getWorkerModel, getModelEntrySync } from "./worker-model";
 import {
   isCircuitBreakerTripped,
+  pruneExpiredCircuitBreakers,
+  warmupBucketKey,
   isWarmupAuthDisabled,
   clearWarmupAuthDisabled,
   resolveProfile,
@@ -333,7 +335,12 @@ export function startIdleScheduler(
     );
 
     // --- Cache warming (separate from idle work — fires before TTL expiry) ---
-    if (isCircuitBreakerTripped()) return;
+    // NOTE: the circuit breaker is per-bucket (session, model, upstream), not
+    // global, so it's checked inside the loop below — a tripped bucket must
+    // never short-circuit warming for every other (healthy) session.
+    // Sweep decayed tripped buckets first so state stays bounded even for
+    // buckets whose session was evicted (never re-queried on the read path).
+    pruneExpiredCircuitBreakers(now);
 
     for (const [sessionID, state] of sessions) {
       if (warmupInProgress.has(sessionID)) continue;
@@ -369,6 +376,10 @@ export function startIdleScheduler(
         state.lastUpstream?.providerID,
       );
       if (!profile) continue;
+
+      // Skip only this session's tripped (model, upstream) bucket — other
+      // sessions/models keep warming. Auto-decays after CIRCUIT_BREAKER_DECAY_MS.
+      if (isCircuitBreakerTripped(warmupBucketKey(state), now)) continue;
 
       const blendedHist = blendedHistogramForSession(state);
       if (!shouldWarm(state, profile, blendedHist, now)) continue;

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -207,6 +207,7 @@ import {
   resolveProfile as resolveWarmingProfile,
   clearWarmupAuthDisabled,
   creditWarmupHit,
+  resetCircuitBreaker,
 } from "./cache-warmer";
 import {
   setSentryRequestContext,
@@ -7327,6 +7328,8 @@ function handleAmnesiaSlashCommand(
  * `/lore:warm:stop` — disables cache warming for this session.
  * `/lore:warm:keep` — forces cache warming regardless of survival analysis.
  * `/lore:warm:auto` — returns to normal survival-analysis-driven mode.
+ * `/lore:warm:reset` — clears ALL tripped circuit-breaker buckets (re-enables
+ *   warming that was disabled after repeated uncached warmups).
  *
  * Returns a synthetic Anthropic-format response if a command was matched,
  * or null to continue normal processing.
@@ -7341,7 +7344,22 @@ function handleWarmupSlashCommand(
   const isStop = lower === "/lore:warm:stop";
   const isKeep = lower === "/lore:warm:keep";
   const isAuto = lower === "/lore:warm:auto";
-  if (!isStop && !isKeep && !isAuto) return null;
+  const isReset = lower === "/lore:warm:reset";
+  if (!isStop && !isKeep && !isAuto && !isReset) return null;
+
+  // Reset is a breaker-wide admin action — clear every tripped bucket and
+  // return immediately (it does not depend on resolving this session).
+  if (isReset) {
+    resetCircuitBreaker();
+    log.info(
+      "cache-warmer: /lore:warm:reset received — circuit breaker cleared",
+    );
+    return slashResponse(
+      req,
+      "Cache warming circuit breaker reset.",
+      `msg_lore_${Date.now()}`,
+    );
+  }
 
   // Find the session for this request (use the same header-based lookup)
   const known = extractKnownSessionHeader(req.rawHeaders);

--- a/packages/gateway/src/ui.ts
+++ b/packages/gateway/src/ui.ts
@@ -42,7 +42,8 @@ import {
 import { getActiveSessions, rebindActiveSession } from "./pipeline";
 import {
   computeWarmingSnapshot,
-  getCircuitBreakerStatus,
+  getCircuitBreakerSummary,
+  resetCircuitBreaker,
   getGlobalHistogramsSnapshot,
   HISTOGRAM_BINS,
   BLEND_PSEUDOCOUNT,
@@ -2432,7 +2433,7 @@ function pageWarming(): string {
   body += `<h1>Cache Warming</h1>`;
 
   const activeSessions = getActiveSessions();
-  const cbStatus = getCircuitBreakerStatus();
+  const cbSummary = getCircuitBreakerSummary();
 
   // Build warming snapshots once — used for both stat cards and table
   const snapshotMap = new Map<string, WarmingSnapshot>();
@@ -2473,25 +2474,31 @@ function pageWarming(): string {
     <div class="stat"><div class="label">Dead</div><div class="value">${deadCount}</div></div>
     <div class="stat"><div class="label">Total Warmups</div><div class="value">${totalWarmups}</div></div>
     <div class="stat"><div class="label">Hit Rate</div><div class="value">${totalWarmups > 0 ? `${((totalHits / totalWarmups) * 100).toFixed(0)}%` : "N/A"}</div></div>
-    <div class="stat"><div class="label">Circuit Breaker</div><div class="value">${
-      cbStatus.tripped
-        ? '<span style="color:var(--danger)">TRIPPED</span>'
-        : `OK <span style="color:var(--fg3)">${cbStatus.failures}/${cbStatus.maxFailures}</span>`
+    <div class="stat"><div class="label">Tripped Buckets</div><div class="value">${
+      cbSummary.trippedCount > 0
+        ? `<span style="color:var(--danger)">${cbSummary.trippedCount}</span>`
+        : "OK"
     }</div></div>
   </div>`;
 
-  // Circuit breaker detail (if non-zero failures or tripped)
-  if (cbStatus.failures > 0 || cbStatus.tripped) {
-    const cls = cbStatus.tripped
-      ? "cb-tripped"
-      : cbStatus.failures > 1
-        ? "cb-warn"
-        : "cb-ok";
-    const pct = (cbStatus.failures / cbStatus.maxFailures) * 100;
-    body += `<div class="card ${cls}">
-      <strong>Circuit Breaker:</strong> ${cbStatus.failures}/${cbStatus.maxFailures} uncached warmups
-      <span class="cb-bar"><span class="cb-bar-fill" style="width:${pct}%"></span></span>
-      ${cbStatus.tripped ? '<strong style="color:var(--danger)">ALL WARMING DISABLED</strong>' : ""}
+  // Circuit breaker detail — list tripped (session, model, upstream) buckets
+  // and offer a reset. The breaker is per-bucket, so only the listed buckets
+  // are disabled; everything else keeps warming.
+  if (cbSummary.trippedCount > 0) {
+    const items = cbSummary.entries
+      .map((e) => {
+        const [sid, model] = e.bucket.split("\x1f");
+        const ago = formatDate(e.trippedAt);
+        return `<li><code>${esc(sid.slice(0, 16))}</code> &middot; ${esc(model ?? "unknown")} <span style="color:var(--fg3)">(tripped ${esc(ago)})</span></li>`;
+      })
+      .join("");
+    body += `<div class="card cb-tripped">
+      <strong style="color:var(--danger)">Circuit Breaker:</strong> ${cbSummary.trippedCount} bucket${cbSummary.trippedCount === 1 ? "" : "s"} disabled (uncached warmups).
+      They auto-recover after the decay window; or reset now.
+      <ul style="margin:6px 0 8px 18px">${items}</ul>
+      <form class="inline" method="POST" action="/ui/api/warming/reset">
+        <button type="submit" class="btn-sm">Reset circuit breaker</button>
+      </form>
     </div>`;
   }
 
@@ -3723,6 +3730,14 @@ export async function handleUIRequest(
         setDailyBudget(budgetVal);
       }
       return redirect("/ui/costs");
+    }
+
+    // Reset all tripped circuit-breaker buckets (re-enable warming).
+    // Matched before the :sessionId/:mode route (single-segment path).
+    if (pathname === "/ui/api/warming/reset") {
+      resetCircuitBreaker();
+      const referer = req.headers.get("referer");
+      return redirect(referer ?? "/ui/warming");
     }
 
     // Set warming mode for a live session

--- a/packages/gateway/test/cache-warmer.test.ts
+++ b/packages/gateway/test/cache-warmer.test.ts
@@ -15,6 +15,12 @@ import {
   WRITE_EFFICIENCY_WINDOW,
   checkCircuitBreaker,
   isCircuitBreakerTripped,
+  getCircuitBreakerStatus,
+  getCircuitBreakerSummary,
+  resetCircuitBreaker,
+  pruneExpiredCircuitBreakers,
+  warmupBucketKey,
+  CIRCUIT_BREAKER_DECAY_MS,
   isWarmupAuthDisabled,
   clearWarmupAuthDisabled,
   breakFraction,
@@ -33,6 +39,7 @@ import {
   creditWarmupHit,
   computeWarmingSnapshot,
   _resetForTest,
+  _forceReloadForTest,
 } from "../src/cache-warmer";
 import type {
   SessionState,
@@ -44,6 +51,7 @@ import {
   compressBody,
   normalizeBodyForComparison,
 } from "../src/cache-analytics";
+import { getKV, setKV } from "@loreai/core";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -482,6 +490,9 @@ describe("prepareAnthropicWarmupBody", () => {
 // ---------------------------------------------------------------------------
 
 describe("circuit breaker", () => {
+  const BUCKET = "s1\x1fclaude-sonnet-4\x1fhttps://api.anthropic.com";
+  const BUCKET_B = "s2\x1fclaude-opus-4\x1fhttps://api.anthropic.com";
+
   beforeEach(() => {
     _resetForTest();
   });
@@ -491,8 +502,8 @@ describe("circuit breaker", () => {
       cacheReadTokens: 50000,
       cacheCreationTokens: 0,
     });
-    expect(checkCircuitBreaker(result)).toBe(false);
-    expect(isCircuitBreakerTripped()).toBe(false);
+    expect(checkCircuitBreaker(result, BUCKET, true)).toBe(false);
+    expect(isCircuitBreakerTripped(BUCKET)).toBe(false);
   });
 
   test("counts uncached warmups", () => {
@@ -500,21 +511,21 @@ describe("circuit breaker", () => {
       cacheReadTokens: 0,
       cacheCreationTokens: 50000,
     });
-    expect(checkCircuitBreaker(bad)).toBe(false); // 1st failure
-    expect(checkCircuitBreaker(bad)).toBe(false); // 2nd failure
-    expect(isCircuitBreakerTripped()).toBe(false);
+    expect(checkCircuitBreaker(bad, BUCKET, true)).toBe(false); // 1st failure
+    expect(checkCircuitBreaker(bad, BUCKET, true)).toBe(false); // 2nd failure
+    expect(isCircuitBreakerTripped(BUCKET)).toBe(false);
   });
 
-  test("trips after 3 consecutive uncached warmups", () => {
+  test("trips after 3 uncached warmups", () => {
     const bad = makeWarmupResult({
       cacheReadTokens: 0,
       cacheCreationTokens: 50000,
     });
-    checkCircuitBreaker(bad); // 1
-    checkCircuitBreaker(bad); // 2
-    const tripped = checkCircuitBreaker(bad); // 3
+    checkCircuitBreaker(bad, BUCKET, true); // 1
+    checkCircuitBreaker(bad, BUCKET, true); // 2
+    const tripped = checkCircuitBreaker(bad, BUCKET, true); // 3
     expect(tripped).toBe(true);
-    expect(isCircuitBreakerTripped()).toBe(true);
+    expect(isCircuitBreakerTripped(BUCKET)).toBe(true);
   });
 
   test("resets failure count on successful read", () => {
@@ -527,15 +538,15 @@ describe("circuit breaker", () => {
       cacheCreationTokens: 0,
     });
 
-    checkCircuitBreaker(bad); // 1
-    checkCircuitBreaker(bad); // 2
-    checkCircuitBreaker(good); // reset
-    checkCircuitBreaker(bad); // 1 (restarted)
-    checkCircuitBreaker(bad); // 2
-    expect(isCircuitBreakerTripped()).toBe(false);
+    checkCircuitBreaker(bad, BUCKET, true); // 1
+    checkCircuitBreaker(bad, BUCKET, true); // 2
+    checkCircuitBreaker(good, BUCKET, true); // reset
+    checkCircuitBreaker(bad, BUCKET, true); // 1 (restarted)
+    checkCircuitBreaker(bad, BUCKET, true); // 2
+    expect(isCircuitBreakerTripped(BUCKET)).toBe(false);
   });
 
-  test("stays tripped permanently after tripping", () => {
+  test("stays tripped until decay or reset", () => {
     const bad = makeWarmupResult({
       cacheReadTokens: 0,
       cacheCreationTokens: 50000,
@@ -545,14 +556,14 @@ describe("circuit breaker", () => {
       cacheCreationTokens: 0,
     });
 
-    checkCircuitBreaker(bad);
-    checkCircuitBreaker(bad);
-    checkCircuitBreaker(bad); // tripped
-    expect(isCircuitBreakerTripped()).toBe(true);
+    checkCircuitBreaker(bad, BUCKET, true);
+    checkCircuitBreaker(bad, BUCKET, true);
+    checkCircuitBreaker(bad, BUCKET, true); // tripped
+    expect(isCircuitBreakerTripped(BUCKET)).toBe(true);
 
-    // Even good results don't un-trip
-    checkCircuitBreaker(good);
-    expect(isCircuitBreakerTripped()).toBe(true);
+    // A good result while tripped does not un-trip (short-circuits early).
+    checkCircuitBreaker(good, BUCKET, true);
+    expect(isCircuitBreakerTripped(BUCKET)).toBe(true);
   });
 
   test("does not count failed requests", () => {
@@ -561,10 +572,25 @@ describe("circuit breaker", () => {
       cacheReadTokens: 0,
       cacheCreationTokens: 0,
     });
-    checkCircuitBreaker(failed);
-    checkCircuitBreaker(failed);
-    checkCircuitBreaker(failed);
-    expect(isCircuitBreakerTripped()).toBe(false);
+    checkCircuitBreaker(failed, BUCKET, true);
+    checkCircuitBreaker(failed, BUCKET, true);
+    checkCircuitBreaker(failed, BUCKET, true);
+    expect(isCircuitBreakerTripped(BUCKET)).toBe(false);
+  });
+
+  test("non-2xx with a cache write does not count (thinking-session 400)", () => {
+    // A thinking-session warmup (max_tokens:1) is rejected with HTTP 400 →
+    // result.ok === false. Even if usage reported a write, it must be neutral.
+    const rejected = makeWarmupResult({
+      ok: false,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 50000,
+    });
+    checkCircuitBreaker(rejected, BUCKET, true);
+    checkCircuitBreaker(rejected, BUCKET, true);
+    checkCircuitBreaker(rejected, BUCKET, true);
+    expect(isCircuitBreakerTripped(BUCKET)).toBe(false);
+    expect(getCircuitBreakerStatus(BUCKET).failures).toBe(0);
   });
 
   test("partial hits (read > 0 + creation > 0) reset counter", () => {
@@ -577,11 +603,222 @@ describe("circuit breaker", () => {
       cacheCreationTokens: 20000,
     });
 
-    checkCircuitBreaker(bad); // 1
-    checkCircuitBreaker(bad); // 2
-    checkCircuitBreaker(partial); // has reads → reset
-    checkCircuitBreaker(bad); // 1
-    expect(isCircuitBreakerTripped()).toBe(false);
+    checkCircuitBreaker(bad, BUCKET, true); // 1
+    checkCircuitBreaker(bad, BUCKET, true); // 2
+    checkCircuitBreaker(partial, BUCKET, true); // has reads → reset
+    checkCircuitBreaker(bad, BUCKET, true); // 1
+    expect(isCircuitBreakerTripped(BUCKET)).toBe(false);
+  });
+
+  test("is per-bucket: tripping one bucket does not affect another", () => {
+    const bad = makeWarmupResult({
+      cacheReadTokens: 0,
+      cacheCreationTokens: 50000,
+    });
+    checkCircuitBreaker(bad, BUCKET, true);
+    checkCircuitBreaker(bad, BUCKET, true);
+    checkCircuitBreaker(bad, BUCKET, true); // BUCKET tripped
+    expect(isCircuitBreakerTripped(BUCKET)).toBe(true);
+    // A different (session, model, upstream) bucket is unaffected.
+    expect(isCircuitBreakerTripped(BUCKET_B)).toBe(false);
+  });
+
+  test("cold re-warm (cacheLikelyAlive=false) does not count as a failure", () => {
+    const bad = makeWarmupResult({
+      cacheReadTokens: 0,
+      cacheCreationTokens: 50000,
+    });
+    // Cache had expired — a fresh write is the warmer re-priming, not a fault.
+    checkCircuitBreaker(bad, BUCKET, false);
+    checkCircuitBreaker(bad, BUCKET, false);
+    checkCircuitBreaker(bad, BUCKET, false);
+    expect(isCircuitBreakerTripped(BUCKET)).toBe(false);
+    expect(getCircuitBreakerStatus(BUCKET).failures).toBe(0);
+  });
+
+  test("tripped bucket auto-decays after CIRCUIT_BREAKER_DECAY_MS", () => {
+    const bad = makeWarmupResult({
+      cacheReadTokens: 0,
+      cacheCreationTokens: 50000,
+    });
+    const t0 = 1_000_000;
+    checkCircuitBreaker(bad, BUCKET, true, t0);
+    checkCircuitBreaker(bad, BUCKET, true, t0);
+    checkCircuitBreaker(bad, BUCKET, true, t0); // tripped at t0
+    expect(isCircuitBreakerTripped(BUCKET, t0)).toBe(true);
+
+    // Just before the decay window — still tripped.
+    expect(
+      isCircuitBreakerTripped(BUCKET, t0 + CIRCUIT_BREAKER_DECAY_MS - 1),
+    ).toBe(true);
+
+    // At/after the decay window — auto-recovers and re-arms.
+    expect(isCircuitBreakerTripped(BUCKET, t0 + CIRCUIT_BREAKER_DECAY_MS)).toBe(
+      false,
+    );
+    expect(getCircuitBreakerStatus(BUCKET).failures).toBe(0);
+  });
+
+  test("resetCircuitBreaker(bucket) clears a single bucket", () => {
+    const bad = makeWarmupResult({
+      cacheReadTokens: 0,
+      cacheCreationTokens: 50000,
+    });
+    for (let i = 0; i < 3; i++) checkCircuitBreaker(bad, BUCKET, true);
+    for (let i = 0; i < 3; i++) checkCircuitBreaker(bad, BUCKET_B, true);
+    expect(isCircuitBreakerTripped(BUCKET)).toBe(true);
+    expect(isCircuitBreakerTripped(BUCKET_B)).toBe(true);
+
+    resetCircuitBreaker(BUCKET);
+    expect(isCircuitBreakerTripped(BUCKET)).toBe(false);
+    expect(isCircuitBreakerTripped(BUCKET_B)).toBe(true); // other bucket intact
+  });
+
+  test("resetCircuitBreaker() clears all buckets", () => {
+    const bad = makeWarmupResult({
+      cacheReadTokens: 0,
+      cacheCreationTokens: 50000,
+    });
+    for (let i = 0; i < 3; i++) checkCircuitBreaker(bad, BUCKET, true);
+    for (let i = 0; i < 3; i++) checkCircuitBreaker(bad, BUCKET_B, true);
+    expect(getCircuitBreakerSummary().trippedCount).toBe(2);
+
+    resetCircuitBreaker();
+    expect(getCircuitBreakerSummary().trippedCount).toBe(0);
+    expect(isCircuitBreakerTripped(BUCKET)).toBe(false);
+    expect(isCircuitBreakerTripped(BUCKET_B)).toBe(false);
+  });
+
+  test("warmupBucketKey keys by (session, model, upstream)", () => {
+    const base = makeSessionState();
+    const key = warmupBucketKey(base);
+    expect(key).toContain(base.sessionID);
+    expect(key).toContain("claude-sonnet-4-20250514");
+    expect(key).toContain("https://api.anthropic.com");
+    // Switching model yields a different bucket.
+    const switched = makeSessionState({
+      lastUpstream: {
+        url: "https://api.anthropic.com",
+        protocol: "anthropic",
+        model: "claude-opus-4-20250514",
+        headers: {},
+      },
+    });
+    expect(warmupBucketKey(switched)).not.toBe(key);
+  });
+
+  test("getCircuitBreakerSummary lists tripped buckets", () => {
+    const bad = makeWarmupResult({
+      cacheReadTokens: 0,
+      cacheCreationTokens: 50000,
+    });
+    const t0 = 2_000_000;
+    for (let i = 0; i < 3; i++) checkCircuitBreaker(bad, BUCKET, true, t0);
+    const summary = getCircuitBreakerSummary(t0);
+    expect(summary.trippedCount).toBe(1);
+    expect(summary.entries[0]?.bucket).toBe(BUCKET);
+    expect(summary.entries[0]?.trippedAt).toBe(t0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Circuit breaker persistence + legacy migration
+// ---------------------------------------------------------------------------
+
+describe("circuit breaker persistence", () => {
+  const CB_KV_KEY = "warmup_circuit_breaker";
+  const BUCKET = "sP\x1fclaude-sonnet-4\x1fhttps://api.anthropic.com";
+
+  beforeEach(() => {
+    _resetForTest();
+  });
+
+  test("legacy v1 KV ({tripped,failures}) is dropped on load", () => {
+    // Simulate the old global-breaker latch persisted by a previous build.
+    setKV(CB_KV_KEY, JSON.stringify({ tripped: true, failures: 3 }));
+    _forceReloadForTest();
+    // No bucket should be considered tripped — the stale global flag is dropped.
+    expect(getCircuitBreakerSummary().trippedCount).toBe(0);
+    // And the KV is rewritten to the empty v2 shape.
+    const raw = getKV(CB_KV_KEY);
+    expect(raw).toBeTruthy();
+    expect(JSON.parse(raw as string)).toEqual({ version: 2, buckets: {} });
+  });
+
+  test("tripped buckets persist across a reload; failure counts do not", () => {
+    const bad = makeWarmupResult({
+      cacheReadTokens: 0,
+      cacheCreationTokens: 50000,
+    });
+    // Trip BUCKET fully, and accrue a non-tripped failure on another bucket.
+    for (let i = 0; i < 3; i++) checkCircuitBreaker(bad, BUCKET, true);
+    const OTHER = "sQ\x1fm\x1fu";
+    checkCircuitBreaker(bad, OTHER, true); // 1 failure, not tripped
+
+    _forceReloadForTest();
+
+    // Tripped bucket survives.
+    expect(isCircuitBreakerTripped(BUCKET)).toBe(true);
+    // Non-tripped failure count is not persisted → starts clean.
+    expect(getCircuitBreakerStatus(OTHER).failures).toBe(0);
+  });
+
+  test("on-load decay drops buckets older than the decay window", () => {
+    const stale = Date.now() - CIRCUIT_BREAKER_DECAY_MS - 1;
+    setKV(
+      CB_KV_KEY,
+      JSON.stringify({
+        version: 2,
+        buckets: { [BUCKET]: { trippedAt: stale } },
+      }),
+    );
+    _forceReloadForTest();
+    expect(isCircuitBreakerTripped(BUCKET)).toBe(false);
+  });
+
+  test("on-load decay rewrites KV to drop stale buckets", () => {
+    const stale = Date.now() - CIRCUIT_BREAKER_DECAY_MS - 1;
+    const fresh = Date.now();
+    const FRESH_BUCKET = "sFresh\x1fm\x1fu";
+    setKV(
+      CB_KV_KEY,
+      JSON.stringify({
+        version: 2,
+        buckets: {
+          [BUCKET]: { trippedAt: stale },
+          [FRESH_BUCKET]: { trippedAt: fresh },
+        },
+      }),
+    );
+    _forceReloadForTest();
+    // Force the lazy load to run.
+    expect(isCircuitBreakerTripped(FRESH_BUCKET)).toBe(true);
+    // The persisted set no longer contains the stale bucket.
+    const persisted = JSON.parse(getKV(CB_KV_KEY) as string) as {
+      buckets: Record<string, unknown>;
+    };
+    expect(Object.keys(persisted.buckets)).toEqual([FRESH_BUCKET]);
+  });
+
+  test("pruneExpiredCircuitBreakers removes decayed tripped buckets + rewrites KV", () => {
+    const bad = makeWarmupResult({
+      cacheReadTokens: 0,
+      cacheCreationTokens: 50000,
+    });
+    const t0 = 5_000_000;
+    for (let i = 0; i < 3; i++) checkCircuitBreaker(bad, BUCKET, true, t0);
+    expect(getCircuitBreakerSummary(t0).trippedCount).toBe(1);
+
+    // Before the window: nothing pruned.
+    expect(pruneExpiredCircuitBreakers(t0 + CIRCUIT_BREAKER_DECAY_MS - 1)).toBe(
+      0,
+    );
+    // At/after the window: the dead bucket is swept and the KV shrinks.
+    expect(pruneExpiredCircuitBreakers(t0 + CIRCUIT_BREAKER_DECAY_MS)).toBe(1);
+    const persisted = JSON.parse(getKV(CB_KV_KEY) as string) as {
+      buckets: Record<string, unknown>;
+    };
+    expect(Object.keys(persisted.buckets)).toEqual([]);
   });
 });
 
@@ -864,15 +1101,6 @@ describe("shouldWarm", () => {
   });
 
   test("returns false when circuit breaker is tripped", () => {
-    // Trip the circuit breaker
-    const bad = makeWarmupResult({
-      cacheReadTokens: 0,
-      cacheCreationTokens: 50000,
-    });
-    checkCircuitBreaker(bad);
-    checkCircuitBreaker(bad);
-    checkCircuitBreaker(bad);
-
     const state = makeSessionState({
       lastRequestTime: Date.now() - 270_000,
       cacheAnalytics: {
@@ -880,6 +1108,16 @@ describe("shouldWarm", () => {
         lastRequestBody: compressBody('{"test": true}'),
       },
     });
+    // Trip the circuit breaker for THIS session's bucket.
+    const bad = makeWarmupResult({
+      cacheReadTokens: 0,
+      cacheCreationTokens: 50000,
+    });
+    const bucket = warmupBucketKey(state);
+    checkCircuitBreaker(bad, bucket, true);
+    checkCircuitBreaker(bad, bucket, true);
+    checkCircuitBreaker(bad, bucket, true);
+
     const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
     const hist = createHistogram();
     for (let i = 0; i < 50; i++) recordGap(hist, 360_000);
@@ -1058,14 +1296,6 @@ describe("shouldWarm", () => {
   });
 
   test("forceKeepWarm still respects circuit breaker", () => {
-    const bad = makeWarmupResult({
-      cacheReadTokens: 0,
-      cacheCreationTokens: 50000,
-    });
-    checkCircuitBreaker(bad);
-    checkCircuitBreaker(bad);
-    checkCircuitBreaker(bad);
-
     const now = Date.now();
     const state = makeSessionState({
       lastRequestTime: now - 270_000,
@@ -1083,6 +1313,16 @@ describe("shouldWarm", () => {
       },
       messageCount: 20,
     });
+    // Trip this session's bucket.
+    const bad = makeWarmupResult({
+      cacheReadTokens: 0,
+      cacheCreationTokens: 50000,
+    });
+    const bucket = warmupBucketKey(state);
+    checkCircuitBreaker(bad, bucket, true);
+    checkCircuitBreaker(bad, bucket, true);
+    checkCircuitBreaker(bad, bucket, true);
+
     const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
     const hist = createHistogram();
 
@@ -2074,17 +2314,18 @@ describe("shouldWarm tool-call warming", () => {
   });
 
   test("respects circuit breaker", () => {
-    // Trip the circuit breaker
+    const now = Date.now();
+    const state = makeToolCallState({ lastRequestTime: now - 270_000 });
+    // Trip this session's bucket.
     const bad = makeWarmupResult({
       cacheReadTokens: 0,
       cacheCreationTokens: 50000,
     });
-    checkCircuitBreaker(bad);
-    checkCircuitBreaker(bad);
-    checkCircuitBreaker(bad);
+    const bucket = warmupBucketKey(state);
+    checkCircuitBreaker(bad, bucket, true);
+    checkCircuitBreaker(bad, bucket, true);
+    checkCircuitBreaker(bad, bucket, true);
 
-    const now = Date.now();
-    const state = makeToolCallState({ lastRequestTime: now - 270_000 });
     const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
     const hist = createHistogram();
 


### PR DESCRIPTION
## Problem

The cache-warmer circuit breaker was a single **global** latch. When 3 warmups returned `cacheCreation>0 && cacheRead===0`, it disabled **all** cache warming for the entire process and persisted that to SQLite (`kv_meta.warmup_circuit_breaker`), surviving restarts with **no production reset path**. Symptom: every session's warming status on `/ui/costs` showed `TRIPPED`.

Confirmed live: the breaker tripped on Jun 16 from 2 large, actively-growing sessions (writes 104K→398K→584K tokens, `cacheRead=0`) and stayed off for days while other sessions were getting 100% cache refreshes.

## Fix

**1. Per-bucket breaker** keyed by `(sessionID, model, upstreamURL)` (`warmupBucketKey`). One pathological session/model/provider can no longer disable warming for healthy sessions. Switching model/provider mid-session lands in a separate bucket. `idle.ts` no longer has the global early-return that aborted the whole warming loop — the check is per-bucket inside the loop.

**2. Recovery**
- `resetCircuitBreaker(bucketKey?)` — clears one or all buckets.
- `/lore:warm:reset` slash command and `POST /ui/api/warming/reset` route + a Reset button on the warming page (with a tripped-bucket list).
- Auto-decay after `CIRCUIT_BREAKER_DECAY_MS` (6h) — applied on check, on load, and via a periodic sweep.
- Persistence migrated to a v2 per-bucket shape (`{version:2, buckets:{[key]:{trippedAt}}}`); only tripped buckets persist. **Legacy v1 global state is dropped on load**, so any breaker stuck by the old implementation auto-clears on upgrade.

**3. Cold-rewarm exclusion**: a `cacheRead=0` write only counts as a failure when `cacheLikelyAlive` (last cache touch within `profile.ttlMs`). Expired-cache re-primes and non-2xx responses (e.g. thinking-session `max_tokens:1` → HTTP 400) are neutral — they neither trip nor reset.

**4. Bounded state**: a periodic `pruneExpiredCircuitBreakers()` sweep (idle loop) plus load-time pruning keep the in-memory map and persisted KV bounded for evicted/dead sessions.

**5.** Wires the previously-defined-but-never-called `emitWarmupCircuitBreakerMetric()` trip metric.

## Tests
171 cache-warmer tests pass (added: per-bucket isolation, cold-rewarm exclusion, non-2xx neutrality, auto-decay with injected clock, single/all reset, legacy v1 drop, persistence round-trip, on-load decay + KV rewrite, periodic prune).

## Verification
- `pnpm run typecheck` — clean (all 5 packages)
- `pnpm run lint` — no errors (13 pre-existing warnings, none in changed files)
- Full suite: 3430 passed / 23 skipped
- `pnpm run build` — success

## Notes
- 6h decay window is a documented constant (`CIRCUIT_BREAKER_DECAY_MS`); can be promoted to config if desired.
- `/lore:warm:reset` and the UI button clear **all** buckets (admin action).