### PR TITLE
fix(gateway): make getCircuitBreakerStatus a pure, decay-safe read

### DIFF
--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -266,7 +266,18 @@ export function isCircuitBreakerTripped(
   return true;
 }
 
-/** Snapshot of a bucket's circuit breaker state for dashboard rendering. */
+/**
+ * Snapshot of a bucket's circuit breaker state for dashboard rendering.
+ *
+ * Pure read — never mutates the map or persists (unlike isCircuitBreakerTripped,
+ * which prunes the entry on decay). A tripped bucket past its decay window is
+ * reported as fully recovered (tripped:false, failures:0, trippedAt:0); the
+ * stale entry is reclaimed by the idle sweep or the next isCircuitBreakerTripped
+ * call, not here. Computing decay inline (rather than calling
+ * isCircuitBreakerTripped and then re-reading the entry) avoids an
+ * order-of-operations hazard where the just-deleted entry would read back as
+ * trippedAt:0.
+ */
 export function getCircuitBreakerStatus(
   bucketKey: string,
   now: number = Date.now(),
@@ -277,13 +288,22 @@ export function getCircuitBreakerStatus(
   trippedAt: number;
 } {
   ensureCircuitBreakersLoaded();
-  const tripped = isCircuitBreakerTripped(bucketKey, now);
   const entry = circuitBreakers.get(bucketKey);
+  const decayed =
+    !!entry?.tripped && now - entry.trippedAt >= CIRCUIT_BREAKER_DECAY_MS;
+  if (!entry || decayed) {
+    return {
+      tripped: false,
+      failures: 0,
+      maxFailures: CIRCUIT_BREAKER_MAX_FAILURES,
+      trippedAt: 0,
+    };
+  }
   return {
-    tripped,
-    failures: entry?.failures ?? 0,
+    tripped: entry.tripped,
+    failures: entry.failures,
     maxFailures: CIRCUIT_BREAKER_MAX_FAILURES,
-    trippedAt: entry?.trippedAt ?? 0,
+    trippedAt: entry.tripped ? entry.trippedAt : 0,
   };
 }
 

--- a/packages/gateway/test/cache-warmer.test.ts
+++ b/packages/gateway/test/cache-warmer.test.ts
@@ -659,6 +659,36 @@ describe("circuit breaker", () => {
     expect(getCircuitBreakerStatus(BUCKET).failures).toBe(0);
   });
 
+  test("getCircuitBreakerStatus is a pure read that handles decay on its own", () => {
+    const bad = makeWarmupResult({
+      cacheReadTokens: 0,
+      cacheCreationTokens: 50000,
+    });
+    const t0 = 9_000_000;
+    for (let i = 0; i < 3; i++) checkCircuitBreaker(bad, BUCKET, true, t0);
+
+    // In-window: reports tripped + the original trippedAt.
+    const live = getCircuitBreakerStatus(BUCKET, t0);
+    expect(live.tripped).toBe(true);
+    expect(live.trippedAt).toBe(t0);
+    expect(live.failures).toBe(3);
+
+    // Past the decay window: reported as fully recovered WITHOUT a preceding
+    // isCircuitBreakerTripped call to clear it (no reliance on a delete
+    // side-effect), and without losing the timestamp to a mid-function delete.
+    const decayed = getCircuitBreakerStatus(
+      BUCKET,
+      t0 + CIRCUIT_BREAKER_DECAY_MS,
+    );
+    expect(decayed.tripped).toBe(false);
+    expect(decayed.trippedAt).toBe(0);
+    expect(decayed.failures).toBe(0);
+
+    // It must NOT have mutated state: an in-window query still sees the trip.
+    expect(getCircuitBreakerStatus(BUCKET, t0).tripped).toBe(true);
+    expect(getCircuitBreakerSummary(t0).trippedCount).toBe(1);
+  });
+
   test("resetCircuitBreaker(bucket) clears a single bucket", () => {
     const bad = makeWarmupResult({
       cacheReadTokens: 0,


### PR DESCRIPTION
Follow-up to #836, addressing a [Seer review comment](https://github.com/BYK/loreai/pull/836).

## Issue
`getCircuitBreakerStatus` called `isCircuitBreakerTripped` (which **deletes** the bucket entry on decay and persists) and then re-read the same entry:

```ts
const tripped = isCircuitBreakerTripped(bucketKey, now); // may delete the entry
const entry = circuitBreakers.get(bucketKey);            // now undefined if just decayed
// → trippedAt: entry?.trippedAt ?? 0  // reads back as 0
```

Two problems:
1. A just-decayed bucket read back as `trippedAt: 0` (order-of-operations hazard flagged by Seer, LOW).
2. A *status getter* mutated the map and wrote to SQLite on the dashboard read path.

## Fix
Compute decay inline — pure, order-independent, no mutation/persist. A decayed bucket is reported as fully recovered (`tripped:false, failures:0, trippedAt:0`); pruning stays with `isCircuitBreakerTripped` and the periodic idle sweep. Output is identical to before in every case, minus the side effects.

Added a test asserting `getCircuitBreakerStatus` handles decay on its own (no preceding `isCircuitBreakerTripped` call) and does not mutate state.

## Verification
- `pnpm run typecheck` clean; `pnpm run lint` clean (13 pre-existing warnings, none in changed files)
- cache-warmer tests: 172 pass; full gateway suite: 1875 pass