### PR TITLE
feat(gateway): diagnose UNCACHED warmups (expiry vs body divergence)

### DIFF
--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -1833,10 +1833,30 @@ export async function executeWarmup(
           `hit=${hitRate} cost=${costStr}`,
       );
     } else {
+      // cacheRead=0: the warmup wrote a fresh cache instead of refreshing an
+      // existing one. `cacheLikelyAlive` (captured before the lastWarmupAt
+      // mutation above) is the diagnostic discriminator:
+      //   - false → the cached prefix had simply expired; this is a benign cold
+      //             re-prime (and is excluded from the circuit breaker).
+      //   - true  → the cache SHOULD still have been live, so the warmup body
+      //             diverged from what the real turn cached. THIS is the genuine
+      //             "divergence" signal worth investigating (issue: warmup body
+      //             ≠ cached prefix). If this never fires in practice, every
+      //             UNCACHED warmup is pure expiry and there is no body bug.
+      const ageSec =
+        lastCacheTouch > 0
+          ? Math.round((Date.now() - lastCacheTouch) / 1000)
+          : -1;
       log.warn(
         `cache-warmer: ✗ UNCACHED session=${sid} ` +
           `input=${totalInput} cacheRead=${cacheReadTokens} cacheWrite=${cacheCreationTokens} ` +
-          `cost=${costStr} — warmup body may not match cached prefix`,
+          `cost=${costStr} cacheLikelyAlive=${cacheLikelyAlive} ` +
+          `ageSinceCacheTouch=${ageSec}s ttl=${Math.round(profile.ttlMs / 1000)}s ` +
+          `bodyBytes=${signedBody.length}` +
+          (cacheLikelyAlive
+            ? " — DIVERGENCE: cache should have been live but warmup missed " +
+              "(warmup body ≠ cached prefix)"
+            : " — expired-cache re-prime (expected)"),
       );
     }
 


### PR DESCRIPTION
Small diagnostic step toward fixing the cache-warmer divergence issue (warmups getting `cacheRead=0`).

## What
When a warmup returns `cacheRead=0` (it wrote a fresh cache instead of refreshing an existing one), the `✗ UNCACHED` log line now includes the **decisive discriminator** `cacheLikelyAlive` plus context:

```
cache-warmer: ✗ UNCACHED session=… input=… cacheRead=0 cacheWrite=… cost=$…
  cacheLikelyAlive=true ageSinceCacheTouch=140s ttl=300s bodyBytes=…
  — DIVERGENCE: cache should have been live but warmup missed (warmup body ≠ cached prefix)
```

`cacheLikelyAlive` (captured *before* the `lastWarmupAt` mutation, from `max(lastRequestTime, prior lastWarmupAt)` vs `profile.ttlMs`) tells us which of two root causes we're looking at:

- **`false`** → the cached prefix had simply **expired** — a benign cold re-prime (already excluded from the per-bucket circuit breaker).
- **`true`** → the cache **should still have been live**, so the warmup body **diverged** from what the real turn cached — the genuine bug signal.

## Why
Log analysis of the tripping sessions showed real turns holding 92–100% hits, busting only after lore's own idle-time prefix mutations (post-idle compaction / meta-distillation / prompt-delta). But logs can't distinguish "warmup missed because the cache expired" from "warmup body byte-diverges from the cached prefix." This line settles it from production data: if the `true` case never fires, there is no warmup-body bug and every UNCACHED warmup is pure expiry.

Diagnostic only — no behavior change. Follow-up will unify the warmer and compaction economics (the real fix).

## Verification
- `pnpm --filter @loreai/gateway typecheck` clean; `pnpm run lint` clean (13 pre-existing warnings, none here)
- cache-warmer tests: 172 pass