### PR TITLE
fix(gateway): report UNCACHED warmup bodyBytes in UTF-8 bytes

### DIFF
--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -1852,7 +1852,11 @@ export async function executeWarmup(
           `input=${totalInput} cacheRead=${cacheReadTokens} cacheWrite=${cacheCreationTokens} ` +
           `cost=${costStr} cacheLikelyAlive=${cacheLikelyAlive} ` +
           `ageSinceCacheTouch=${ageSec}s ttl=${Math.round(profile.ttlMs / 1000)}s ` +
-          `bodyBytes=${signedBody.length}` +
+          // Buffer.byteLength gives the UTF-8 byte size actually sent over the
+          // wire; signedBody.length would count UTF-16 code units and underreport
+          // for multi-byte content (prose/code-heavy bodies — exactly the ones
+          // this diagnostic targets).
+          `bodyBytes=${Buffer.byteLength(signedBody, "utf8")}` +
           (cacheLikelyAlive
             ? " — DIVERGENCE: cache should have been live but warmup missed " +
               "(warmup body ≠ cached prefix)"


### PR DESCRIPTION
Addresses a [Seer review comment](https://github.com/BYK/loreai/pull/838) on #838 (LOW).

The UNCACHED warmup diagnostic logged `bodyBytes=${signedBody.length}`. `String.length` counts UTF-16 code units, not UTF-8 bytes, so it underreports the real wire size for any body with multi-byte characters — i.e. the prose/code-heavy sessions this divergence diagnostic is specifically meant to measure.

Fix: `Buffer.byteLength(signedBody, "utf8")` (allocation-free, reports the actual UTF-8 byte size sent over the wire).

Diagnostic-only, no behavior change.

## Verification
- `pnpm --filter @loreai/gateway typecheck` clean; `pnpm run lint` clean (13 pre-existing warnings)