### PR TITLE
feat(core): shared cache-economics decision module (no wiring yet)

### DIFF
--- a/packages/core/src/cache-economics.ts
+++ b/packages/core/src/cache-economics.ts
@@ -91,7 +91,11 @@ export interface CacheEconomicsInput {
 
 export interface CacheEconomicsResult {
   strategy: CacheStrategy;
-  /** Expected cost of holding the body warm across the horizon ($). */
+  // The *Cost fields are in the SAME currency unit as the pricing inputs. The
+  // chosen `strategy` is invariant to a common scaling of read+write pricing,
+  // but these reported costs are only dollars if pricing was passed as $/token
+  // (NOT $/MTok). They are primarily for logging/telemetry.
+  /** Expected cost of holding the body warm across the horizon. */
   holdWarmCost: number;
   /** Expected cost of cooling and compacting on return ($). */
   coolBustCost: number;
@@ -106,10 +110,15 @@ export interface CacheEconomicsResult {
 }
 
 function clamp01(x: number): number {
-  if (Number.isNaN(x)) return 0;
+  if (!Number.isFinite(x)) return x > 0 ? 1 : 0; // +Inf→1, -Inf/NaN→0
   if (x < 0) return 0;
   if (x > 1) return 1;
   return x;
+}
+
+/** A finite, non-negative count; non-finite or negative inputs collapse to 0. */
+function finiteNonNeg(x: number): number {
+  return Number.isFinite(x) && x > 0 ? x : 0;
 }
 
 /**
@@ -143,12 +152,23 @@ export function decideCacheStrategy(
 ): CacheEconomicsResult {
   const { fullBodyTokens, readPerToken, writePerToken } = input;
   const pReturn = clamp01(input.pReturn);
-  const cycles = Math.max(0, input.expectedCycles);
-  const futureTurns = Math.max(0, input.expectedFutureTurns);
+  const cycles = finiteNonNeg(input.expectedCycles);
+  const futureTurns = finiteNonNeg(input.expectedFutureTurns);
 
-  // Without pricing (or with an empty body) the comparison is meaningless —
-  // signal low confidence so the caller keeps its legacy behaviour.
-  if (readPerToken <= 0 || writePerToken <= 0 || fullBodyTokens <= 0) {
+  // Without finite, positive pricing (or with a non-finite/empty body) the
+  // comparison is meaningless — signal low confidence so the caller keeps its
+  // legacy behaviour. The finiteness checks are LOAD-BEARING: a model missing
+  // from the pricing table arrives here as undefined/NaN, and `NaN <= 0` is
+  // false, so a bare `<= 0` guard would let garbage through and report it as a
+  // trustworthy decision (NaN costs → arbitrary strategy, confident:true).
+  if (
+    !Number.isFinite(readPerToken) ||
+    !Number.isFinite(writePerToken) ||
+    !Number.isFinite(fullBodyTokens) ||
+    readPerToken <= 0 ||
+    writePerToken <= 0 ||
+    fullBodyTokens <= 0
+  ) {
     return {
       strategy: "cool-full-write",
       holdWarmCost: 0,
@@ -158,12 +178,14 @@ export function decideCacheStrategy(
     };
   }
 
-  // The compacted body can never be larger than the full body. A caller that
-  // has no compaction available passes compressed == full (handled by clamp).
-  const compressed = Math.min(
-    Math.max(0, input.compressedTokens),
-    fullBodyTokens,
-  );
+  // The compacted body can never be larger than the full body. A non-finite
+  // estimate means the caller had no compaction figure — treat it as "no
+  // compaction available" (compressed === full), which collapses cool-bust into
+  // cool-full-write rather than fabricating a phantom (and falsely cheapest)
+  // bust from a NaN cost.
+  const compressed = Number.isFinite(input.compressedTokens)
+    ? Math.min(Math.max(0, input.compressedTokens), fullBodyTokens)
+    : fullBodyTokens;
 
   const holdWarmCost =
     cycles * fullBodyTokens * readPerToken +

--- a/packages/core/src/cache-economics.ts
+++ b/packages/core/src/cache-economics.ts
@@ -1,0 +1,213 @@
+// ---------------------------------------------------------------------------
+// Shared cache economics
+// ---------------------------------------------------------------------------
+//
+// WHY THIS MODULE EXISTS
+//
+// Two subsystems independently model the SAME future event — "what happens to
+// the prompt cache when the user next returns to an idle session" — but with
+// inconsistent assumptions, so they fight each other:
+//
+//   * The cache warmer (gateway/cache-warmer.ts) prices the value of warming as
+//     "avoid a full-body WRITE on return" (costThreshold = read/(write-read),
+//     maxProfitableCycles = (write-read)/read). It implicitly assumes that NOT
+//     warming means the return turn pays a full cold write of the CURRENT body.
+//
+//   * The bust calculator (gradient.ts: shouldCompress) prices "continue" as a
+//     cheap READ of the current body (repriced to write only under a sustained
+//     bust run). It ignores warming and ignores that a cold/expired return is a
+//     full WRITE, not a read.
+//
+// The only coupling was a single boolean (isCacheWarm) wired into onIdleResume's
+// skipCompact. When the warmer's write-efficiency guard stopped warming a large
+// session, isCacheWarm flipped false, which re-enabled post-idle compaction,
+// which busted the cache the warming was trying to preserve — an oscillation.
+//
+// THE CRUX
+//
+// The genuine tradeoff is NOT "read vs write of the full body on one turn". It
+// is "keep the session large and warm" vs "compact it once and run small from
+// then on". Staying large means paying to read the full body on EVERY future
+// turn; compacting pays a single compressed write now and reads a small body
+// forever after. The decision therefore has to account for the ONGOING cost of
+// the chosen body size, not just the single return turn.
+//
+// This module is the one place that comparison lives. It is pure (no I/O, no
+// module state) so both the gateway warmer and the core gradient can call it
+// with the same numbers and agree. Both `shouldWarm` (warmer) and
+// `shouldCompress`/`onIdleResume` (gradient) are intended to derive their
+// decision from `decideCacheStrategy` so the two never disagree.
+
+/**
+ * The chosen strategy for an idle session over the horizon until the user
+ * returns (or the session ends).
+ *
+ *  - `hold-warm`       Keep the current (large) body cached via warmups and do
+ *                      NOT compact on return; the return turn is a cheap cache
+ *                      read. Worth it only when the session is likely to return
+ *                      soon AND staying large is cheaper than compacting.
+ *  - `cool-bust`       Stop warming; on return, compact (one compressed write)
+ *                      and run small thereafter. This is also the natural,
+ *                      "free" moment to flush deferred LTM/distillation work
+ *                      (the prefix is busting anyway).
+ *  - `cool-full-write` Degenerate fallback: don't warm and don't compact, so a
+ *                      cold return pays a full-body write. Chosen when
+ *                      compression offers no benefit (e.g. a small layer-0
+ *                      session below the compaction tier boundary) yet warming
+ *                      still isn't worth it.
+ */
+export type CacheStrategy = "hold-warm" | "cool-bust" | "cool-full-write";
+
+export interface CacheEconomicsInput {
+  /** Expected input tokens if the session stays at its current layer. */
+  fullBodyTokens: number;
+  /**
+   * Expected input tokens after compaction. A caller with no compaction
+   * available (e.g. a layer-0 session below the tier boundary) passes
+   * `compressedTokens === fullBodyTokens`, which collapses `cool-bust` into
+   * `cool-full-write` and reduces the decision to the classic warm-vs-cold one.
+   */
+  compressedTokens: number;
+  /** Per-token cost to READ from cache ($/token). */
+  readPerToken: number;
+  /** Per-token cost to WRITE/miss ($/token). */
+  writePerToken: number;
+  /** Probability the session returns within the warming horizon (0..1). */
+  pReturn: number;
+  /**
+   * Expected number of warmup cycles spent before the session resolves
+   * (returns or is abandoned). Encodes the idle keepalive spend in expectation;
+   * forward-looking only (sunk cycles are intentionally excluded — callers keep
+   * their own hard cycle cap as a separate guard).
+   */
+  expectedCycles: number;
+  /**
+   * Expected number of turns the resumed session runs before it ends. This is
+   * the "ongoing cost" horizon that captures the crux: staying large costs
+   * `fullBody·read` every one of these turns, vs `compressed·read` if compacted.
+   */
+  expectedFutureTurns: number;
+}
+
+export interface CacheEconomicsResult {
+  strategy: CacheStrategy;
+  /** Expected cost of holding the body warm across the horizon ($). */
+  holdWarmCost: number;
+  /** Expected cost of cooling and compacting on return ($). */
+  coolBustCost: number;
+  /** Expected cost of cooling without compacting (cold full write) ($). */
+  coolFullWriteCost: number;
+  /**
+   * False when inputs were insufficient to trust the comparison (e.g. missing
+   * pricing). Callers MUST fall back to their legacy heuristic when false
+   * rather than acting on the (meaningless) strategy.
+   */
+  confident: boolean;
+}
+
+function clamp01(x: number): number {
+  if (Number.isNaN(x)) return 0;
+  if (x < 0) return 0;
+  if (x > 1) return 1;
+  return x;
+}
+
+/**
+ * Decide the cheapest cache strategy for an idle session.
+ *
+ * Expected-cost model over the idle→return horizon (all terms in $):
+ *
+ *   holdWarm      = expectedCycles · full · read                 (idle keepalive: warmups READ the still-warm cache to refresh its TTL)
+ *                 + pReturn · (1 + futureTurns) · full · read     (warm return read + ongoing reads while staying large)
+ *
+ *   coolBust      = pReturn · ( compressed · write               (one compaction WRITE on return)
+ *                             + futureTurns · compressed · read ) (ongoing reads of the small body)
+ *
+ *   coolFullWrite = pReturn · ( full · write                     (cold full WRITE on return, no compaction)
+ *                             + futureTurns · full · read )       (ongoing reads while staying large)
+ *
+ * The keepalive term is unconditional (warming is paid during idle whether or
+ * not the user returns); every return-conditional term is scaled by `pReturn`.
+ * The function returns the cheapest of the three.
+ *
+ * Notes on how this subsumes the legacy heuristics:
+ *  - With `compressed === full` (no compaction available) `coolBust === coolFullWrite`,
+ *    and `holdWarm < coolFullWrite` reduces to `cycles·read + pReturn·read < pReturn·write`
+ *    — i.e. exactly the classic costThreshold / maxProfitableCycles break-even.
+ *  - The write-efficiency guard becomes unnecessary: a large body that is cheap
+ *    to compact yields `coolBust < holdWarm` directly, so warming stops without
+ *    a separate "low read/write ratio" gate.
+ */
+export function decideCacheStrategy(
+  input: CacheEconomicsInput,
+): CacheEconomicsResult {
+  const { fullBodyTokens, readPerToken, writePerToken } = input;
+  const pReturn = clamp01(input.pReturn);
+  const cycles = Math.max(0, input.expectedCycles);
+  const futureTurns = Math.max(0, input.expectedFutureTurns);
+
+  // Without pricing (or with an empty body) the comparison is meaningless —
+  // signal low confidence so the caller keeps its legacy behaviour.
+  if (readPerToken <= 0 || writePerToken <= 0 || fullBodyTokens <= 0) {
+    return {
+      strategy: "cool-full-write",
+      holdWarmCost: 0,
+      coolBustCost: 0,
+      coolFullWriteCost: 0,
+      confident: false,
+    };
+  }
+
+  // The compacted body can never be larger than the full body. A caller that
+  // has no compaction available passes compressed == full (handled by clamp).
+  const compressed = Math.min(
+    Math.max(0, input.compressedTokens),
+    fullBodyTokens,
+  );
+
+  const holdWarmCost =
+    cycles * fullBodyTokens * readPerToken +
+    pReturn * (1 + futureTurns) * fullBodyTokens * readPerToken;
+
+  const coolBustCost =
+    pReturn *
+    (compressed * writePerToken + futureTurns * compressed * readPerToken);
+
+  const coolFullWriteCost =
+    pReturn *
+    (fullBodyTokens * writePerToken +
+      futureTurns * fullBodyTokens * readPerToken);
+
+  // Pick the cheapest. Among the two cool options, prefer `cool-bust` only when
+  // compaction is STRICTLY cheaper — a tie means compaction buys nothing (e.g.
+  // compressed === full), so default to `cool-full-write` and never claim a
+  // pointless bust. Choose `hold-warm` only when it is STRICTLY cheaper than the
+  // best cool option — never pay to warm on a tie.
+  const bestCool: CacheStrategy =
+    coolBustCost < coolFullWriteCost ? "cool-bust" : "cool-full-write";
+  const bestCoolCost = Math.min(coolBustCost, coolFullWriteCost);
+  const strategy: CacheStrategy =
+    holdWarmCost < bestCoolCost ? "hold-warm" : bestCool;
+
+  return {
+    strategy,
+    holdWarmCost,
+    coolBustCost,
+    coolFullWriteCost,
+    confident: true,
+  };
+}
+
+/** Whether the chosen strategy calls for the cache warmer to keep warming. */
+export function strategyWantsWarming(strategy: CacheStrategy): boolean {
+  return strategy === "hold-warm";
+}
+
+/**
+ * Whether the chosen strategy calls for compaction (a deliberate cache bust) on
+ * the next turn. This is also the signal that deferred LTM/distillation work may
+ * piggy-back for free (the prefix is busting anyway).
+ */
+export function strategyWantsCompaction(strategy: CacheStrategy): boolean {
+  return strategy === "cool-bust";
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -242,3 +242,13 @@ export {
   unescapeMarkdown,
   renderMarkdown,
 } from "./markdown";
+export {
+  decideCacheStrategy,
+  strategyWantsWarming,
+  strategyWantsCompaction,
+} from "./cache-economics";
+export type {
+  CacheStrategy,
+  CacheEconomicsInput,
+  CacheEconomicsResult,
+} from "./cache-economics";

--- a/packages/core/test/cache-economics.test.ts
+++ b/packages/core/test/cache-economics.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, test } from "vitest";
+import {
+  type CacheEconomicsInput,
+  decideCacheStrategy,
+  strategyWantsCompaction,
+  strategyWantsWarming,
+} from "../src/cache-economics";
+
+// Unit-agnostic pricing: the module only cares about the read/write ratio.
+// Use read=1, write=12 (a ~12× miss premium, close to Anthropic 1h-cache Opus).
+const READ = 1;
+const WRITE = 12;
+
+function decide(overrides: Partial<CacheEconomicsInput>) {
+  return decideCacheStrategy({
+    fullBodyTokens: 100_000,
+    compressedTokens: 100_000,
+    readPerToken: READ,
+    writePerToken: WRITE,
+    pReturn: 0.8,
+    expectedCycles: 1,
+    expectedFutureTurns: 5,
+    ...overrides,
+  });
+}
+
+describe("decideCacheStrategy — guards & fallback", () => {
+  test("missing read pricing → low confidence, callers fall back", () => {
+    const r = decide({ readPerToken: 0 });
+    expect(r.confident).toBe(false);
+    expect(r.strategy).toBe("cool-full-write");
+  });
+
+  test("missing write pricing → low confidence", () => {
+    expect(decide({ writePerToken: 0 }).confident).toBe(false);
+  });
+
+  test("empty body → low confidence", () => {
+    expect(decide({ fullBodyTokens: 0 }).confident).toBe(false);
+  });
+
+  test("valid pricing → confident", () => {
+    expect(decide({}).confident).toBe(true);
+  });
+});
+
+describe("decideCacheStrategy — core decisions", () => {
+  test("small body, likely return → hold-warm (warming pays off)", () => {
+    const r = decide({
+      fullBodyTokens: 10_000,
+      compressedTokens: 10_000, // small session: no compaction available
+      pReturn: 0.9,
+      expectedCycles: 1,
+      expectedFutureTurns: 5,
+    });
+    expect(r.strategy).toBe("hold-warm");
+    expect(strategyWantsWarming(r.strategy)).toBe(true);
+    expect(r.holdWarmCost).toBeLessThan(r.coolFullWriteCost);
+  });
+
+  test("large body, many future turns, cheap compaction → cool-bust", () => {
+    const r = decide({
+      fullBodyTokens: 580_000,
+      compressedTokens: 190_000,
+      pReturn: 0.8,
+      expectedCycles: 3,
+      expectedFutureTurns: 20,
+    });
+    expect(r.strategy).toBe("cool-bust");
+    expect(strategyWantsCompaction(r.strategy)).toBe(true);
+    expect(strategyWantsWarming(r.strategy)).toBe(false);
+    // cool-bust is strictly cheaper than both alternatives here.
+    expect(r.coolBustCost).toBeLessThan(r.holdWarmCost);
+    expect(r.coolBustCost).toBeLessThan(r.coolFullWriteCost);
+  });
+
+  test("session almost certainly finished (pReturn≈0) → never hold-warm", () => {
+    const r = decide({ pReturn: 0 });
+    expect(strategyWantsWarming(r.strategy)).toBe(false);
+    // Keepalive is the only nonzero cost and it buys nothing.
+    expect(r.holdWarmCost).toBeGreaterThan(0);
+    expect(r.coolBustCost).toBe(0);
+    expect(r.coolFullWriteCost).toBe(0);
+  });
+});
+
+describe("decideCacheStrategy — reduces to classic warm-vs-cold when no compaction", () => {
+  test("compressed == full + cheap warming → hold-warm", () => {
+    const r = decide({
+      fullBodyTokens: 20_000,
+      compressedTokens: 20_000,
+      pReturn: 0.8,
+      expectedCycles: 1,
+      expectedFutureTurns: 3,
+    });
+    expect(r.strategy).toBe("hold-warm");
+  });
+
+  test("compressed == full + warming not worth it → cool-full-write (not a phantom bust)", () => {
+    // Many sunk-free cycles + modest return prob make keepalive dominate.
+    const r = decide({
+      fullBodyTokens: 100_000,
+      compressedTokens: 100_000,
+      pReturn: 0.3,
+      expectedCycles: 10,
+      expectedFutureTurns: 2,
+    });
+    expect(r.strategy).toBe("cool-full-write");
+    expect(strategyWantsCompaction(r.strategy)).toBe(false);
+    // With no real compaction, a bust must never be reported as cheaper.
+    expect(r.coolBustCost).toBe(r.coolFullWriteCost);
+  });
+});
+
+describe("decideCacheStrategy — monotonicity (the crux: ongoing cost of staying large)", () => {
+  test("more future turns shifts a large session toward cool-bust", () => {
+    const base = {
+      fullBodyTokens: 400_000,
+      compressedTokens: 150_000,
+      pReturn: 0.7,
+      expectedCycles: 2,
+    };
+    // Few remaining turns: ongoing cost barely matters → keep large.
+    const few = decide({ ...base, expectedFutureTurns: 0 });
+    // Many remaining turns: paying full-body read every turn dominates → compact.
+    const many = decide({ ...base, expectedFutureTurns: 50 });
+    expect(few.strategy).not.toBe("cool-bust");
+    expect(many.strategy).toBe("cool-bust");
+  });
+
+  test("more expected warmup cycles shifts away from hold-warm", () => {
+    const base = {
+      fullBodyTokens: 30_000,
+      compressedTokens: 30_000,
+      pReturn: 0.85,
+      expectedFutureTurns: 4,
+    };
+    expect(decide({ ...base, expectedCycles: 1 }).strategy).toBe("hold-warm");
+    // Enough keepalive cycles eventually outweighs the avoided write.
+    expect(
+      strategyWantsWarming(decide({ ...base, expectedCycles: 50 }).strategy),
+    ).toBe(false);
+  });
+
+  test("higher return probability shifts a small session toward hold-warm", () => {
+    const base = {
+      fullBodyTokens: 25_000,
+      compressedTokens: 25_000,
+      expectedCycles: 3,
+      expectedFutureTurns: 4,
+    };
+    expect(
+      strategyWantsWarming(decide({ ...base, pReturn: 0.1 }).strategy),
+    ).toBe(false);
+    expect(decide({ ...base, pReturn: 0.95 }).strategy).toBe("hold-warm");
+  });
+});
+
+describe("decideCacheStrategy — input hardening", () => {
+  test("compressedTokens larger than full is clamped (no phantom benefit/crash)", () => {
+    const r = decide({
+      fullBodyTokens: 1_000,
+      compressedTokens: 999_999,
+      pReturn: 0.5,
+    });
+    expect(r.confident).toBe(true);
+    // Clamped to full → bust offers nothing → never cheaper than full write.
+    expect(r.coolBustCost).toBe(r.coolFullWriteCost);
+    expect(strategyWantsCompaction(r.strategy)).toBe(false);
+  });
+
+  test("out-of-range pReturn is clamped to [0,1]", () => {
+    const hi = decide({ pReturn: 2 });
+    const at1 = decide({ pReturn: 1 });
+    expect(hi.holdWarmCost).toBe(at1.holdWarmCost);
+    expect(hi.coolBustCost).toBe(at1.coolBustCost);
+
+    const lo = decide({ pReturn: -5 });
+    const at0 = decide({ pReturn: 0 });
+    expect(lo.coolBustCost).toBe(at0.coolBustCost);
+  });
+
+  test("negative cycles / future turns are floored at 0", () => {
+    const neg = decide({ expectedCycles: -3, expectedFutureTurns: -10 });
+    const zero = decide({ expectedCycles: 0, expectedFutureTurns: 0 });
+    expect(neg.holdWarmCost).toBe(zero.holdWarmCost);
+    expect(neg.coolBustCost).toBe(zero.coolBustCost);
+  });
+});
+
+describe("strategy helpers", () => {
+  test("strategyWantsWarming only for hold-warm", () => {
+    expect(strategyWantsWarming("hold-warm")).toBe(true);
+    expect(strategyWantsWarming("cool-bust")).toBe(false);
+    expect(strategyWantsWarming("cool-full-write")).toBe(false);
+  });
+
+  test("strategyWantsCompaction only for cool-bust", () => {
+    expect(strategyWantsCompaction("cool-bust")).toBe(true);
+    expect(strategyWantsCompaction("hold-warm")).toBe(false);
+    expect(strategyWantsCompaction("cool-full-write")).toBe(false);
+  });
+});

--- a/packages/core/test/cache-economics.test.ts
+++ b/packages/core/test/cache-economics.test.ts
@@ -156,6 +156,90 @@ describe("decideCacheStrategy — monotonicity (the crux: ongoing cost of stayin
   });
 });
 
+describe("decideCacheStrategy — exact cost arithmetic", () => {
+  test("each cost term matches the formula exactly", () => {
+    // F=200k, C=80k, r=1, w=12, p=0.5, k=2, f=4
+    const r = decide({
+      fullBodyTokens: 200_000,
+      compressedTokens: 80_000,
+      readPerToken: 1,
+      writePerToken: 12,
+      pReturn: 0.5,
+      expectedCycles: 2,
+      expectedFutureTurns: 4,
+    });
+    // holdWarm = k·F·r + p·(1+f)·F·r = 2·200000 + 0.5·5·200000
+    expect(r.holdWarmCost).toBe(2 * 200_000 + 0.5 * 5 * 200_000);
+    // coolBust = p·(C·w + f·C·r) = 0.5·(80000·12 + 4·80000)
+    expect(r.coolBustCost).toBe(0.5 * (80_000 * 12 + 4 * 80_000));
+    // coolFullWrite = p·(F·w + f·F·r) = 0.5·(200000·12 + 4·200000)
+    expect(r.coolFullWriteCost).toBe(0.5 * (200_000 * 12 + 4 * 200_000));
+  });
+});
+
+describe("decideCacheStrategy — strict-tie boundary (never pay to warm on a tie)", () => {
+  // With compressed==full, holdWarm == coolFullWrite exactly when
+  // p = k·r/(w−r). Pick r=1, w=3, k=1 ⇒ break-even p=0.5 (exact in float).
+  const tie = {
+    fullBodyTokens: 100_000,
+    compressedTokens: 100_000,
+    readPerToken: 1,
+    writePerToken: 3,
+    expectedCycles: 1,
+    expectedFutureTurns: 3,
+  };
+  test("exactly at break-even → cool-full-write (not hold-warm)", () => {
+    const r = decide({ ...tie, pReturn: 0.5 });
+    expect(r.holdWarmCost).toBe(r.coolFullWriteCost); // genuine tie
+    expect(r.strategy).toBe("cool-full-write");
+  });
+  test("just above break-even → hold-warm", () => {
+    expect(decide({ ...tie, pReturn: 0.51 }).strategy).toBe("hold-warm");
+  });
+  test("just below break-even → cool-full-write", () => {
+    expect(decide({ ...tie, pReturn: 0.49 }).strategy).toBe("cool-full-write");
+  });
+});
+
+describe("decideCacheStrategy — non-finite inputs break confidence, not the contract", () => {
+  test("undefined pricing (missing model) → confident:false, no NaN", () => {
+    const r = decide({ readPerToken: undefined as unknown as number });
+    expect(r.confident).toBe(false);
+    expect(Number.isNaN(r.holdWarmCost)).toBe(false);
+  });
+  test("NaN write pricing → confident:false", () => {
+    expect(decide({ writePerToken: Number.NaN }).confident).toBe(false);
+  });
+  test("Infinite body → confident:false", () => {
+    expect(decide({ fullBodyTokens: Number.POSITIVE_INFINITY }).confident).toBe(
+      false,
+    );
+  });
+  test("NaN compressedTokens with valid pricing → treated as no-compaction, still confident", () => {
+    // The reviewer's case: a NaN compaction figure must NOT silently suppress a
+    // genuinely-cheapest hold-warm. Treated as compressed==full ⇒ hold-warm.
+    const r = decide({
+      fullBodyTokens: 10_000,
+      compressedTokens: Number.NaN,
+      pReturn: 0.95,
+      expectedCycles: 1,
+      expectedFutureTurns: 2,
+    });
+    expect(r.confident).toBe(true);
+    expect(r.coolBustCost).toBe(r.coolFullWriteCost); // no phantom bust
+    expect(r.strategy).toBe("hold-warm");
+  });
+  test("NaN expectedCycles/futureTurns are floored to 0 (no NaN leak)", () => {
+    const r = decide({
+      expectedCycles: Number.NaN,
+      expectedFutureTurns: Number.NaN,
+    });
+    expect(r.confident).toBe(true);
+    expect(Number.isFinite(r.holdWarmCost)).toBe(true);
+    expect(Number.isFinite(r.coolBustCost)).toBe(true);
+  });
+});
+
 describe("decideCacheStrategy — input hardening", () => {
   test("compressedTokens larger than full is clamped (no phantom benefit/crash)", () => {
     const r = decide({


### PR DESCRIPTION
First of three PRs unifying the cache-warmer economics with the gradient bust calculator (the "real gap": both model the same return event with inconsistent assumptions and oscillate).

## What
A single pure function `decideCacheStrategy` in `@loreai/core` (`cache-economics.ts`) prices the three strategies for an idle session over the idle→return horizon and returns the cheapest:

- **`hold-warm`** — keep the large body cached via warmups, skip compaction; return = cheap read.
- **`cool-bust`** — stop warming, compact once on return, run small thereafter (also the free moment to flush deferred LTM/distillation).
- **`cool-full-write`** — don't warm, don't compact (cold full write on return); the degenerate fallback when compaction offers no benefit.

### The model (expected cost over the horizon)
```
holdWarm      = expectedCycles·full·read                  (idle keepalive: warmups READ to refresh TTL)
              + pReturn·(1+futureTurns)·full·read          (warm return + ongoing reads while large)
coolBust      = pReturn·(compressed·write + futureTurns·compressed·read)
coolFullWrite = pReturn·(full·write + futureTurns·full·read)
```
Keepalive is unconditional; return-conditional terms scale by `pReturn`. The **`expectedFutureTurns`** term encodes the crux we agreed on: the *ongoing* cost of staying at the larger layer, so giant sessions resolve to `cool-bust` without a separate write-efficiency guard.

It gracefully reduces to the classic warm-vs-cold break-even when `compressed === full` (no compaction available), and returns `confident:false` when pricing is missing so callers keep their legacy path.

## Scope
Pure, no I/O, no module state. **No call site is wired — zero behavior change.** Follow-ups:
- PR2 — `shouldWarm` + `shouldCompress`/`onIdleResume` consume `decideCacheStrategy`
- PR3 — gate the deferred LTM/distillation flush on the `cool-bust` event (independent schedule, bust as preferred trigger, urgency override)

## Tests
26 cases (final count; the description originally said 17 before non-finite-input tests were added): guards/fallback, the three core decisions, reduction to classic warm-vs-cold, monotonicity (future-turns/cycles/pReturn), input clamping, helpers.

## Verification
- typecheck (5 packages) clean; lint clean (13 pre-existing warnings); full suite 3519 passed.