### PR TITLE
feat(cache-economics): single evaluator + shadow-mode wiring (no behavior change)

### DIFF
--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -2465,6 +2465,13 @@ function transformInner(input: {
   // from one place. Baseline assumes no compaction (compressed === full); the
   // tier gate below refines `cacheSizeCompressed` when it actually evaluates a
   // compression target.
+  //
+  // KNOWN GAP (shadow-only, PR2a): the refine ONLY fires on the layer-0 tier
+  // gate. Sessions held at layer >= 1 by the sticky/prefix-floor/post-idle/
+  // first-sight-large guards below bypass it, so for an already-compressing
+  // session `cacheSizeCompressed` stays == full and the shadow under-reports
+  // real compaction savings. Harmless while we only LOG; PR2b MUST source a real
+  // compressed target for the layer >= 1 paths before it acts on cool-bust.
   if (sid) {
     sessState.cacheSizeFull = Math.max(0, Math.round(layer0Input));
     sessState.cacheSizeCompressed = sessState.cacheSizeFull;
@@ -2547,12 +2554,11 @@ function transformInner(input: {
     );
     // Refine the shared-economics snapshot with the real compression target so
     // the warmer's cool-bust math uses the same compressed size this gate does.
-    if (sid) {
-      sessState.cacheSizeCompressed = Math.max(
-        0,
-        Math.min(compressedEstimate, sessState.cacheSizeFull),
-      );
-    }
+    // (Already inside a `… && sid` block, so the session state exists.)
+    sessState.cacheSizeCompressed = Math.max(
+      0,
+      Math.min(compressedEstimate, sessState.cacheSizeFull),
+    );
     if (
       !shouldCompress(Math.round(layer0Input), compressedEstimate, busts, {
         freeWrite,

--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -8,6 +8,10 @@ import {
   saveSessionTracking,
   loadSessionTracking,
 } from "./db";
+import {
+  type CacheEconomicsResult,
+  decideCacheStrategy,
+} from "./cache-economics";
 import { config } from "./config";
 import { formatDistillations } from "./prompt";
 import { normalize } from "./markdown";
@@ -431,6 +435,18 @@ type SessionState = {
    * isn't busted by a newly-appended later duplicate flipping an early message.
    */
   dedupDecisions: Map<string, boolean>;
+
+  // --- Shared cache-economics inputs/result (see cache-economics.ts) ---
+  // The single-entry-point design (evaluateCacheStrategy) reads every input for
+  // the warm-vs-compact decision from this one place and stores the one result
+  // here, so the cache warmer and the gradient bust calculator branch off an
+  // identical decision and cannot diverge.
+  /** Full-body token size from the most recent transform() (gradient's own estimate). */
+  cacheSizeFull: number;
+  /** Compacted-body token target from the most recent transform(); === cacheSizeFull when no compaction is available. */
+  cacheSizeCompressed: number;
+  /** The single stored strategy decision + when it was computed (null until first evaluated). */
+  cacheStrategy: { result: CacheEconomicsResult; decidedAt: number } | null;
 };
 
 function makeSessionState(): SessionState {
@@ -455,6 +471,9 @@ function makeSessionState(): SessionState {
 
     distillationSnapshot: null,
     dedupDecisions: new Map(),
+    cacheSizeFull: 0,
+    cacheSizeCompressed: 0,
+    cacheStrategy: null,
   };
 }
 
@@ -579,6 +598,95 @@ export function consumeCameOutOfIdle(sessionID: string): boolean {
   if (!state?.cameOutOfIdle) return false;
   state.cameOutOfIdle = false;
   return true;
+}
+
+// ---------------------------------------------------------------------------
+// Shared cache-economics: single entry point
+// ---------------------------------------------------------------------------
+
+/** Survival inputs supplied by the cache warmer for the shared strategy decision. */
+export interface CacheSurvivalInputs {
+  /** Probability the session returns within the warming horizon (0..1). */
+  pReturn: number;
+  /** Expected warmup cycles before the session resolves. */
+  expectedCycles: number;
+  /** Expected turns the resumed session runs (the "ongoing cost" horizon). */
+  expectedFutureTurns: number;
+}
+
+/**
+ * Record the gradient's own size estimate for a session's current body. Called
+ * from transform() so the warmer and the bust calculator both read identical
+ * full/compressed sizes from one place. `compressed === full` means "no
+ * compaction available" (collapses cool-bust into cool-full-write downstream).
+ */
+export function setCacheSizeSnapshot(
+  sessionID: string,
+  fullBodyTokens: number,
+  compressedTokens: number,
+): void {
+  const state = getSessionState(sessionID);
+  state.cacheSizeFull = Math.max(0, fullBodyTokens);
+  state.cacheSizeCompressed = Math.max(
+    0,
+    Math.min(compressedTokens, fullBodyTokens),
+  );
+}
+
+/**
+ * THE single entry point for the warm-vs-compact decision. Reads every input
+ * from one place — the gradient's size snapshot (set by transform), the cache
+ * pricing (module state), and the survival inputs passed in by the warmer — runs
+ * the pure decideCacheStrategy ONCE, stores the single result on the session
+ * state, and returns it. Both the cache warmer and the gradient bust calculator
+ * branch off this stored result (via getCacheStrategy) so they cannot disagree.
+ *
+ * Returns null when there is no size snapshot yet (the session has not been
+ * transformed) so callers keep their legacy behaviour.
+ */
+export function evaluateCacheStrategy(
+  sessionID: string,
+  survival: CacheSurvivalInputs,
+  // Per-token pricing. Callers SHOULD pass the session's own model pricing — the
+  // module-global getCachePricing() reflects the LAST transform's model, which
+  // can belong to a different session/model when a background warmer evaluates.
+  pricing?: { readPerToken: number; writePerToken: number },
+  now: number = Date.now(),
+): CacheEconomicsResult | null {
+  const state = sessionStates.get(sessionID);
+  if (!state || state.cacheSizeFull <= 0) return null;
+  const global = getCachePricing();
+  const result = decideCacheStrategy({
+    fullBodyTokens: state.cacheSizeFull,
+    compressedTokens: state.cacheSizeCompressed,
+    readPerToken: pricing?.readPerToken ?? global.read,
+    writePerToken: pricing?.writePerToken ?? global.write,
+    pReturn: survival.pReturn,
+    expectedCycles: survival.expectedCycles,
+    expectedFutureTurns: survival.expectedFutureTurns,
+  });
+  state.cacheStrategy = { result, decidedAt: now };
+  return result;
+}
+
+/** Read the single stored strategy decision for a session (null if never evaluated). */
+export function getCacheStrategy(
+  sessionID: string,
+): { result: CacheEconomicsResult; decidedAt: number } | null {
+  return sessionStates.get(sessionID)?.cacheStrategy ?? null;
+}
+
+/**
+ * Read the gradient's last full/compressed size estimate for a session (null if
+ * never transformed). Exposed so the warmer can log the shared sizes and
+ * cross-check the gradient estimate against the real API token count.
+ */
+export function getCacheSizeSnapshot(
+  sessionID: string,
+): { full: number; compressed: number } | null {
+  const state = sessionStates.get(sessionID);
+  if (!state || state.cacheSizeFull <= 0) return null;
+  return { full: state.cacheSizeFull, compressed: state.cacheSizeCompressed };
 }
 
 // LTM tokens injected via system transform hook this turn.
@@ -2352,6 +2460,16 @@ function transformInner(input: {
     sid,
   );
 
+  // Record the gradient's own size estimate so the shared cache-economics
+  // evaluator (and therefore the warmer) reads identical full/compressed sizes
+  // from one place. Baseline assumes no compaction (compressed === full); the
+  // tier gate below refines `cacheSizeCompressed` when it actually evaluates a
+  // compression target.
+  if (sid) {
+    sessState.cacheSizeFull = Math.max(0, Math.round(layer0Input));
+    sessState.cacheSizeCompressed = sessState.cacheSizeFull;
+  }
+
   // First-sight large session → skip the Layer-0 cold full-write. An
   // uncalibrated session already over the Layer-0 ceiling is a resumed
   // conversation Lore hasn't tracked in-process. Passing it through at Layer 0
@@ -2427,6 +2545,14 @@ function transformInner(input: {
       distilledBudget + rawBudget,
       layer0Ceiling,
     );
+    // Refine the shared-economics snapshot with the real compression target so
+    // the warmer's cool-bust math uses the same compressed size this gate does.
+    if (sid) {
+      sessState.cacheSizeCompressed = Math.max(
+        0,
+        Math.min(compressedEstimate, sessState.cacheSizeFull),
+      );
+    }
     if (
       !shouldCompress(Math.round(layer0Input), compressedEstimate, busts, {
         freeWrite,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -166,7 +166,12 @@ export {
   BUST_PRESSURE_THRESHOLD,
   effectiveMetaThreshold,
   isLargeColdStart,
+  setCacheSizeSnapshot,
+  evaluateCacheStrategy,
+  getCacheStrategy,
+  getCacheSizeSnapshot,
 } from "./gradient";
+export type { CacheSurvivalInputs } from "./gradient";
 export {
   formatKnowledge,
   formatKnowledgeDelta,

--- a/packages/core/test/cache-strategy-evaluator.test.ts
+++ b/packages/core/test/cache-strategy-evaluator.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  evaluateCacheStrategy,
+  evictSession,
+  getCacheSizeSnapshot,
+  getCacheStrategy,
+  setCacheSizeSnapshot,
+  setCachePricing,
+} from "../src/gradient";
+
+// Per-token pricing with a 12x miss premium (read=1e-6, write=12e-6).
+const PRICING = { readPerToken: 1e-6, writePerToken: 12e-6 };
+
+let counter = 0;
+function freshSession(): string {
+  return `econ-test-${Date.now()}-${counter++}`;
+}
+
+describe("cache-strategy evaluator (single entry point)", () => {
+  const created: string[] = [];
+  function sid(): string {
+    const id = freshSession();
+    created.push(id);
+    return id;
+  }
+  afterEach(() => {
+    for (const id of created.splice(0)) evictSession(id);
+  });
+
+  test("evaluate returns null when the session has no size snapshot", () => {
+    expect(
+      evaluateCacheStrategy(sid(), {
+        pReturn: 0.9,
+        expectedCycles: 1,
+        expectedFutureTurns: 5,
+      }),
+    ).toBeNull();
+  });
+
+  test("snapshot → evaluate → getCacheStrategy round-trips the same result", () => {
+    const id = sid();
+    setCacheSizeSnapshot(id, 580_000, 190_000);
+    const result = evaluateCacheStrategy(
+      id,
+      { pReturn: 0.8, expectedCycles: 3, expectedFutureTurns: 20 },
+      PRICING,
+    );
+    expect(result).not.toBeNull();
+    // Large body, many future turns, cheap compaction → cool-bust.
+    expect(result?.strategy).toBe("cool-bust");
+    expect(result?.confident).toBe(true);
+    // The stored decision is exactly the one returned (single source of truth).
+    const stored = getCacheStrategy(id);
+    expect(stored?.result).toEqual(result);
+    expect(stored?.decidedAt).toBeGreaterThan(0);
+  });
+
+  test("a small, likely-return session evaluates to hold-warm", () => {
+    const id = sid();
+    setCacheSizeSnapshot(id, 10_000, 10_000); // no compaction available
+    const result = evaluateCacheStrategy(
+      id,
+      { pReturn: 0.95, expectedCycles: 1, expectedFutureTurns: 4 },
+      PRICING,
+    );
+    expect(result?.strategy).toBe("hold-warm");
+  });
+
+  test("getCacheSizeSnapshot reflects the snapshot and clamps compressed ≤ full", () => {
+    const id = sid();
+    setCacheSizeSnapshot(id, 100_000, 250_000); // compressed > full
+    expect(getCacheSizeSnapshot(id)).toEqual({
+      full: 100_000,
+      compressed: 100_000,
+    });
+  });
+
+  test("getCacheSizeSnapshot is null before any snapshot", () => {
+    expect(getCacheSizeSnapshot(sid())).toBeNull();
+  });
+
+  test("explicit pricing override is used instead of the module global", () => {
+    const id = sid();
+    setCacheSizeSnapshot(id, 50_000, 50_000);
+    // Set a degenerate global pricing (read>=write) that, if used, would make
+    // warming never pay off; the override must take precedence.
+    setCachePricing(0, 0);
+    const result = evaluateCacheStrategy(
+      id,
+      { pReturn: 0.95, expectedCycles: 1, expectedFutureTurns: 3 },
+      PRICING,
+    );
+    expect(result?.confident).toBe(true);
+    expect(result?.strategy).toBe("hold-warm");
+  });
+
+  test("without override, missing global pricing yields low confidence", () => {
+    const id = sid();
+    setCacheSizeSnapshot(id, 50_000, 50_000);
+    setCachePricing(0, 0); // global pricing unavailable
+    const result = evaluateCacheStrategy(id, {
+      pReturn: 0.9,
+      expectedCycles: 1,
+      expectedFutureTurns: 3,
+    });
+    expect(result?.confident).toBe(false);
+  });
+});

--- a/packages/core/test/cache-strategy-evaluator.test.ts
+++ b/packages/core/test/cache-strategy-evaluator.test.ts
@@ -1,12 +1,51 @@
-import { afterEach, describe, expect, test } from "vitest";
+import { afterEach, beforeAll, describe, expect, test } from "vitest";
+import { ensureProject } from "../src/db";
 import {
+  calibrate,
   evaluateCacheStrategy,
   evictSession,
   getCacheSizeSnapshot,
   getCacheStrategy,
   setCacheSizeSnapshot,
   setCachePricing,
+  setModelLimits,
+  transform,
 } from "../src/gradient";
+import type { LoreMessage, LoreMessageWithParts } from "../src/types";
+
+const PROJECT = "/tmp/econ-evaluator-test";
+
+function makeMsg(
+  id: string,
+  role: "user" | "assistant",
+  text: string,
+  sessionID: string,
+): LoreMessageWithParts {
+  const info = {
+    id,
+    sessionID,
+    role,
+    time: { created: Date.now() },
+    ...(role === "user"
+      ? { agent: "build" }
+      : { parentID: `parent-${id}`, mode: "build", cost: 0 }),
+    modelID: "claude-sonnet-4-20250514",
+    providerID: "anthropic",
+  } as unknown as LoreMessage;
+  return {
+    info,
+    parts: [
+      {
+        id: `part-${id}`,
+        sessionID,
+        messageID: id,
+        type: "text",
+        text,
+        time: { start: Date.now(), end: Date.now() },
+      },
+    ],
+  };
+}
 
 // Per-token pricing with a 12x miss premium (read=1e-6, write=12e-6).
 const PRICING = { readPerToken: 1e-6, writePerToken: 12e-6 };
@@ -104,5 +143,51 @@ describe("cache-strategy evaluator (single entry point)", () => {
       expectedFutureTurns: 3,
     });
     expect(result?.confident).toBe(false);
+  });
+
+  test("evaluate on an unknown session creates no state entry (no leak)", () => {
+    const id = sid();
+    evaluateCacheStrategy(id, {
+      pReturn: 0.9,
+      expectedCycles: 1,
+      expectedFutureTurns: 3,
+    });
+    // A non-creating read: the warmer must never materialize a core session.
+    expect(getCacheSizeSnapshot(id)).toBeNull();
+    expect(getCacheStrategy(id)).toBeNull();
+  });
+});
+
+describe("transform writes the size snapshot end-to-end", () => {
+  beforeAll(() => {
+    ensureProject(PROJECT);
+    setModelLimits({ context: 10_000, output: 2_000 });
+    calibrate(0); // no system-prompt overhead in unit tests
+  });
+
+  test("a layer-0 transform populates getCacheSizeSnapshot (compressed === full)", () => {
+    const session = `econ-e2e-${Date.now()}`;
+    // Before any transform there is no snapshot.
+    expect(getCacheSizeSnapshot(session)).toBeNull();
+
+    const messages = [
+      makeMsg("e2e-1", "user", "Hello, how are you today?", session),
+      makeMsg("e2e-2", "assistant", "I'm ready to help.", session),
+    ];
+    const result = transform({
+      messages,
+      projectPath: PROJECT,
+      sessionID: session,
+    });
+    expect(result.layer).toBe(0);
+
+    // The transform wrote the gradient's own size estimate; with no compaction
+    // evaluated on this small layer-0 turn, compressed === full.
+    const snap = getCacheSizeSnapshot(session);
+    expect(snap).not.toBeNull();
+    expect(snap?.full).toBeGreaterThan(0);
+    expect(snap?.compressed).toBe(snap?.full);
+
+    evictSession(session);
   });
 });

--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -30,6 +30,9 @@ import {
   projectId,
   getKV,
   setKV,
+  evaluateCacheStrategy,
+  strategyWantsWarming,
+  getCacheSizeSnapshot,
 } from "@loreai/core";
 import type {
   InterTurnHistogram,
@@ -139,6 +142,14 @@ export const MIN_SESSION_HIT_RATE = 0.25;
  *  while writing ~550K every time. Distinct from MIN_SESSION_HIT_RATE, which
  *  measures user-return probability, not write efficiency. */
 export const MIN_WRITE_EFFICIENCY = 0.2;
+/**
+ * Shadow-mode (PR2a) cap on the `expectedFutureTurns` proxy fed into the shared
+ * cache-economics evaluator. Until PR2b derives a principled mean-residual-life
+ * estimate, we use "turns seen so far" (a session that has run N turns is, on
+ * average, about halfway) capped here so a single very long session doesn't
+ * dominate the ongoing-cost term while we are only MEASURING. Behavior-neutral.
+ */
+export const SHADOW_FUTURE_TURNS_CAP = 50;
 /** Minimum number of recorded warmup-efficiency samples before the
  *  write-efficiency gate engages (avoid acting on one noisy sample). */
 export const MIN_WARMUPS_FOR_EFFICIENCY_CHECK = 3;
@@ -1227,6 +1238,46 @@ export function shouldWarm(
     cacheReadCostPerMTok,
     cacheMissCostPerMTok,
   );
+
+  // --- Shared cache-economics: SHADOW evaluation (measure-only, PR2a) ---
+  // Run the single core entry point and LOG the unified strategy next to the
+  // legacy decision. No behavior change: shouldWarm still returns its existing
+  // result below. This lets us watch, on real sessions, whether the shared model
+  // agrees with reality (and cross-check the gradient size estimate against the
+  // real API token count) before PR2b hands it the wheel.
+  {
+    const expectedCycles = expectedWarmupCycles(
+      blendedHist,
+      elapsed,
+      ttlMs,
+      maxCycles,
+    );
+    const expectedFutureTurns = Math.min(totalTurns, SHADOW_FUTURE_TURNS_CAP);
+    const shadow = evaluateCacheStrategy(
+      state.sessionID,
+      { pReturn: pReturns, expectedCycles, expectedFutureTurns },
+      {
+        readPerToken: cacheReadCostPerMTok / 1_000_000,
+        writePerToken: cacheMissCostPerMTok / 1_000_000,
+      },
+    );
+    if (shadow?.confident) {
+      const snap = getCacheSizeSnapshot(state.sessionID);
+      const apiActual =
+        (state.cacheAnalytics?.lastCacheRead ?? 0) +
+        (state.cacheAnalytics?.lastCacheCreation ?? 0);
+      log.info(
+        `cache-economics shadow: session=${state.sessionID.slice(0, 16)} ` +
+          `strategy=${shadow.strategy} wouldWarm=${strategyWantsWarming(shadow.strategy)} ` +
+          `gradFull=${snap?.full ?? "?"} gradCompressed=${snap?.compressed ?? "?"} ` +
+          `apiActual=${apiActual} pReturn=${pReturns.toFixed(2)} ` +
+          `cycles=${expectedCycles.toFixed(1)} futureTurns=${expectedFutureTurns} ` +
+          `costs[hold=${shadow.holdWarmCost.toFixed(4)} ` +
+          `coolBust=${shadow.coolBustCost.toFixed(4)} ` +
+          `coolFull=${shadow.coolFullWriteCost.toFixed(4)}]`,
+      );
+    }
+  }
 
   // Determine if this is the initial commitment or a continuation
   const cyclesSpent = state.warmup?.warmupCount ?? 0;

--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -1261,7 +1261,11 @@ export function shouldWarm(
         writePerToken: cacheMissCostPerMTok / 1_000_000,
       },
     );
-    if (shadow?.confident) {
+    // Only log near a real warm decision (within the warmup margin of the
+    // current TTL window), not on every tick while the cache is still fresh —
+    // keeps the shadow measurement readable without dropping any decision point.
+    const inWarmupMargin = elapsed % ttlMs >= ttlMs - warmupMarginMs;
+    if (shadow?.confident && inWarmupMargin) {
       const snap = getCacheSizeSnapshot(state.sessionID);
       const apiActual =
         (state.cacheAnalytics?.lastCacheRead ?? 0) +

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -48,6 +48,8 @@ import {
   getLastTransformedCount,
   getLastTransformEstimate,
   onIdleResume,
+  getCacheStrategy,
+  strategyWantsWarming,
   consumeCameOutOfIdle,
   needsUrgentDistillation,
   formatKnowledge,
@@ -5684,6 +5686,19 @@ async function handleConversationTurn(
       `session idle ${Math.round(idleResult.idleMs / 60_000)}min — refreshing caches` +
         (cacheWarm ? " (cache warm — skipping compact)" : ""),
     );
+    // --- Shared cache-economics: SHADOW compaction decision (measure-only) ---
+    // Compare what the unified strategy WOULD do (skip compaction iff hold-warm)
+    // against the legacy isCacheWarm-driven skipCompact. No behavior change —
+    // onIdleResume above still used the legacy `cacheWarm`.
+    const econ = getCacheStrategy(sessionID);
+    if (econ) {
+      const wouldSkipCompact = strategyWantsWarming(econ.result.strategy);
+      log.info(
+        `cache-economics shadow (compaction): session=${sessionID.slice(0, 16)} ` +
+          `strategy=${econ.result.strategy} wouldSkipCompact=${wouldSkipCompact} ` +
+          `actualSkipCompact=${cacheWarm} strategyAgeMs=${Date.now() - econ.decidedAt}`,
+      );
+    }
   }
 
   // Build the Lore message array once (resolved) — shared by the turn-1 LTM


### PR DESCRIPTION
PR(2a) of the cache-warmer/gradient economics unification. Builds on #842 (the pure `decideCacheStrategy` module).

## The single entry point (divergence-proof by design)
Per the design: **one** function gathers every input and produces **one** stored decision; consumers will only read + branch. NOTE: this PR is shadow-only — no consumer branches on the stored strategy yet (that is PR2b), so it does not *yet* deliver the divergence-proof guarantee; it builds the structure for it.

- `SessionState` (core) gains `cacheSizeFull`/`cacheSizeCompressed` — the gradient's own size estimate, written during `transform` — and one stored `cacheStrategy`.
- `evaluateCacheStrategy(sessionID, survival, pricing?)` reads every input from that one place, runs `decideCacheStrategy` **once**, stores + returns the result. Accessors: `getCacheStrategy`, `getCacheSizeSnapshot`, `setCacheSizeSnapshot`.
- Pricing is passed by the caller — the module-global `getCachePricing()` reflects the *last transform's* model, which is wrong for a background warmer evaluating another session.

## Shadow mode — measure only, zero behavior change
Every legacy decision path is untouched; we only **log** what the unified model would do:
- `shouldWarm` logs `strategy` + `wouldWarm` + the cost breakdown + survival inputs, and the **gradient size estimate vs the real API token count** (validates the D-vs-A question).
- idle-resume logs `wouldSkipCompact` (strategy) vs the legacy `isCacheWarm`-driven `skipCompact`.

This lets us watch, on real sessions, whether the shared model agrees with reality before PR(2b) flips the switch — same measure-first pattern as #838.

## Notes
- `expectedFutureTurns` is a first-cut proxy (turns-seen-so-far, capped at 50), refined into a principled mean-residual-life estimate in PR(2b).
- The transform writes are additive (set two numbers on session state); they do not feed any decision yet.

## Verification
- typecheck (5 packages) clean; lint clean (15 warnings, all pre-existing/non-touched files); full suite **3546 passed**; `pnpm build` clean.
- 9 new evaluator tests (round-trip, null-without-snapshot, clamping, pricing override, low-confidence fallback) + the 26 from #842.

## Next
- **PR(2b):** flip `shouldWarm` + `shouldCompress`/`onIdleResume` to branch on the stored strategy; principled `expectedFutureTurns`.
- **PR(3):** gate the deferred LTM/distillation flush on the `cool-bust` event (independent schedule, bust as preferred trigger, urgency override).