### PR TITLE
test(sync): assertSyncInvariants() teardown — continuous invariant enforcement (#834)

### DIFF
--- a/packages/core/src/sync-data.ts
+++ b/packages/core/src/sync-data.ts
@@ -685,3 +685,70 @@ export function enableSync(tier: SyncTier = "basic"): void {
 export function disableSync(): void {
   deleteTeamConfig(ENABLED_KEY);
 }
+
+// ---------------------------------------------------------------------------
+// Invariant self-check
+// ---------------------------------------------------------------------------
+
+/**
+ * Assert the sync engine's local invariants hold; throws an Error listing every
+ * violation. These are the load-bearing rules the #828 bugs broke — encoding
+ * them here (and calling this in tests' `afterEach`) turns every test that
+ * touches sync state into a continuous regression check, instead of trusting a
+ * comment. Pure, cheap COUNT/DISTINCT queries — safe to run after each test, and
+ * usable as a runtime diagnostic (e.g. a future `lore data check`).
+ */
+export function assertSyncInvariants(): void {
+  const violations: string[] = [];
+  const tables = syncedTables();
+
+  // 1. Pull-only tables are server-authoritative and never pushed, so an outbox
+  //    entry for one can NEVER advance its push cursor — it pins the prune floor
+  //    at 0 and disables outbox pruning for ALL tables (bug #828). Must be empty.
+  for (const m of tables) {
+    if (!m.pullOnly) continue;
+    const n = (
+      db()
+        .query("SELECT COUNT(*) AS n FROM sync_outbox WHERE table_name = ?")
+        .get(m.table) as { n: number }
+    ).n;
+    if (n > 0) {
+      violations.push(
+        `pull-only table "${m.table}" has ${n} sync_outbox entr${n === 1 ? "y" : "ies"} — prune-floor wedge (#828)`,
+      );
+    }
+  }
+
+  // 2. The profiles mirror holds AT MOST the current account's row, so
+  //    currentTier()'s unqualified LIMIT 1 is deterministic and a logged-out or
+  //    foreign account's tier can't linger (#828). clearProfileMirror() enforces
+  //    this on logout/account-switch.
+  const profileRows = (
+    db().query("SELECT COUNT(*) AS n FROM profiles").get() as { n: number }
+  ).n;
+  if (profileRows > 1) {
+    violations.push(
+      `profiles mirror holds ${profileRows} rows — must be <= 1 (currentTier single-row invariant, #828)`,
+    );
+  }
+
+  // 3. Every outbox / sync_state row references a registered synced table — a
+  //    typo or registry drift would silently strand rows the engine can't route.
+  const known = new Set(tables.map((m) => m.table));
+  for (const tbl of ["sync_outbox", "sync_state"] as const) {
+    const names = db()
+      .query(`SELECT DISTINCT table_name FROM ${tbl}`)
+      .all() as Array<{ table_name: string }>;
+    for (const { table_name } of names) {
+      if (!known.has(table_name)) {
+        violations.push(`${tbl} references unregistered table "${table_name}"`);
+      }
+    }
+  }
+
+  if (violations.length > 0) {
+    throw new Error(
+      `sync invariant violation(s):\n  - ${violations.join("\n  - ")}`,
+    );
+  }
+}

--- a/packages/core/test/sync-data.test.ts
+++ b/packages/core/test/sync-data.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import {
   db,
   ensureProject,
@@ -10,6 +10,7 @@ import {
 import {
   applyRemoteDelete,
   applyRemoteUpsert,
+  assertSyncInvariants,
   classifyRemoteRow,
   clearProfileMirror,
   contentHash,
@@ -57,6 +58,12 @@ beforeEach(() => {
   db().exec("DELETE FROM sync_state");
   db().exec("DELETE FROM sync_conflicts");
 });
+
+// Every test in this file leaves a state that must satisfy the sync invariants
+// (no pull-only outbox entry, profiles mirror <= 1 row, no unregistered tables).
+// Running the check in afterEach turns each test into a continuous regression
+// guard for the #828 bug classes (issue #834).
+afterEach(() => assertSyncInvariants());
 
 describe("v43 schema", () => {
   test("sync tables exist", () => {
@@ -530,5 +537,47 @@ describe("classifyRemoteRow pendingLocalChange (resurrection fix)", () => {
         pendingLocalChange: true,
       }),
     ).toBe("conflict");
+  });
+});
+
+describe("assertSyncInvariants", () => {
+  test("passes on a clean state", () => {
+    expect(() => assertSyncInvariants()).not.toThrow();
+  });
+
+  test("throws when a pull-only table has a sync_outbox entry (prune-floor wedge)", () => {
+    db()
+      .query(
+        "INSERT INTO sync_outbox (table_name, row_id, op, changed_at) VALUES ('profiles', 'u1', 'upsert', ?)",
+      )
+      .run(now());
+    expect(() => assertSyncInvariants()).toThrow(/pull-only table "profiles"/);
+    db().exec("DELETE FROM sync_outbox"); // restore clean state for afterEach
+  });
+
+  test("throws when the profiles mirror holds more than one row", () => {
+    for (const id of ["a", "b"]) {
+      db()
+        .query(
+          "INSERT INTO profiles (id, tier, created_at, updated_at) VALUES (?, 'pro', ?, ?)",
+        )
+        .run(id, now(), now());
+    }
+    expect(() => assertSyncInvariants()).toThrow(
+      /profiles mirror holds 2 rows/,
+    );
+    db().exec("DELETE FROM profiles"); // restore clean state for afterEach
+  });
+
+  test("throws when sync_state references an unregistered table", () => {
+    db()
+      .query(
+        "INSERT INTO sync_state (table_name, row_id, content_hash, revision, remote_updated_at) VALUES ('bogus_table', 'x', NULL, 0, NULL)",
+      )
+      .run();
+    expect(() => assertSyncInvariants()).toThrow(
+      /unregistered table "bogus_table"/,
+    );
+    db().exec("DELETE FROM sync_state"); // restore clean state for afterEach
   });
 });

--- a/packages/core/test/sync-registry-contract.test.ts
+++ b/packages/core/test/sync-registry-contract.test.ts
@@ -15,9 +15,10 @@
  * prune floor) are asserted in packages/gateway/test/sync.test.ts against the
  * real push path.
  */
-import { beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { db, deleteTeamConfig } from "../src/db";
 import {
+  assertSyncInvariants,
   enableSync,
   readOutbox,
   SYNCED_TABLES,
@@ -61,6 +62,8 @@ beforeEach(() => {
     db().exec(`DELETE FROM ${m.table}`);
   }
 });
+
+afterEach(() => assertSyncInvariants()); // #834 — continuous invariant guard
 
 describe("SYNCED_TABLES registry contract", () => {
   for (const m of SYNCED_TABLES.basic) {

--- a/packages/gateway/test/supabase.test.ts
+++ b/packages/gateway/test/supabase.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 // Shared mock handles for the Supabase client (hoisted so the vi.mock factory
 // can reference them safely).
@@ -54,6 +54,10 @@ function fakeSupabaseSession(overrides: Record<string, unknown> = {}) {
     ...overrides,
   };
 }
+
+// The profiles mirror is touched here via clearSession()/persistSession(); assert
+// the sync invariants hold after every test (#834).
+afterEach(() => syncData.assertSyncInvariants());
 
 describe("supabase session persistence", () => {
   beforeEach(() => {

--- a/packages/gateway/test/sync-engine.integration.test.ts
+++ b/packages/gateway/test/sync-engine.integration.test.ts
@@ -14,7 +14,15 @@
 import { execFileSync } from "node:child_process";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import { db, ensureProject, setKV, syncData } from "@loreai/core";
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
 import { pullOnce, pushOnce } from "../src/sync";
 import { type PgHarness, startPgHarness } from "./helpers/pg-harness";
 
@@ -121,6 +129,11 @@ beforeEach(async () => {
   ]) {
     await h.client.query(`DELETE FROM public.${t}`);
   }
+});
+
+// Local sync invariants must hold after every real-engine round-trip too (#834).
+afterEach(() => {
+  if (!SKIP) syncData.assertSyncInvariants();
 });
 
 function insertKnowledge(id: string, content: string): void {

--- a/packages/gateway/test/sync.test.ts
+++ b/packages/gateway/test/sync.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import {
   db,
   ensureProject,
@@ -303,6 +303,8 @@ beforeEach(() => {
   authed = true;
   clock = 1_000_000;
 });
+
+afterEach(() => syncData.assertSyncInvariants()); // #834 — continuous invariant guard
 
 describe("pushOnce — happy path", () => {
   test("uploads new rows and records sync_state", async () => {


### PR DESCRIPTION
Closes #834. Promotes the load-bearing sync invariants from *comments* to a runtime check run in `afterEach` across the sync suites — so every test that touches sync state becomes a continuous regression guard for the #828 bug classes. This is the **runtime complement** to the structural #831 registry-contract battery, and it delivers the "continuously enforce invariants" value we'd hoped to get from mutation testing (which turned out unreliable on Vitest 4 — see #843/#840).

## What
- **`packages/core/src/sync-data.ts` → `assertSyncInvariants()`** — throws an Error listing every violation. Checks:
  1. **No pull-only table has a `sync_outbox` entry** — an unpushable entry pins the prune floor at 0 and disables outbox pruning for all tables (the #828 wedge).
  2. **`profiles` mirror holds ≤ 1 row** — `currentTier()`'s single-row invariant; a logged-out/foreign tier can't linger (#828).
  3. **Every `sync_outbox`/`sync_state` row references a registered synced table** — catches registry drift / typos.

  Pure `COUNT`/`DISTINCT` queries (negligible per-test cost); also usable as a runtime diagnostic (e.g. a future `lore data check`).
- **Wired `afterEach(assertSyncInvariants)`** into `sync-data`, `sync-registry-contract`, gateway `sync`, `supabase`, and `sync-engine.integration` test files. **No existing test violates the invariants** — they hold across all unit, mock, and real-Postgres round-trips.
- **Tests for the helper itself:** passes on clean state; throws on a pull-only outbox entry, on >1 `profiles` rows, and on an unregistered table.

## Validation
Full suite **3543 passed**; sync-engine integration **7/7** (real Postgres); typecheck, lint, build green.

Independent of the A2 work and of #840 (mutation testing). Part of the testing-strategy hardening (#832/#833/#834/#835).