### PR TITLE
fix(cache-economics): measure large sessions in shadow; review tidy-ups

### DIFF
--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -615,10 +615,16 @@ export interface CacheSurvivalInputs {
 }
 
 /**
- * Record the gradient's own size estimate for a session's current body. Called
- * from transform() so the warmer and the bust calculator both read identical
- * full/compressed sizes from one place. `compressed === full` means "no
- * compaction available" (collapses cool-bust into cool-full-write downstream).
+ * Record the gradient's own size estimate for a session's current body.
+ *
+ * This is the WRITER side and intentionally CREATES the session state (via
+ * getSessionState) — in production the writer is transform() (which writes the
+ * fields directly) and this exported helper is used by tests. The READ
+ * accessors (getCacheStrategy / getCacheSizeSnapshot) and the warmer-facing
+ * evaluateCacheStrategy use the non-creating `sessionStates.get` so a background
+ * warmer can never materialize a phantom session. Do NOT call this from the
+ * warmer for that reason. `compressed === full` means "no compaction available"
+ * (collapses cool-bust into cool-full-write downstream).
  */
 export function setCacheSizeSnapshot(
   sessionID: string,
@@ -655,12 +661,13 @@ export function evaluateCacheStrategy(
 ): CacheEconomicsResult | null {
   const state = sessionStates.get(sessionID);
   if (!state || state.cacheSizeFull <= 0) return null;
-  const global = getCachePricing();
+  // Only fall back to the module-global pricing when no override is supplied
+  // (the override is the common path — callers SHOULD pass their own pricing).
   const result = decideCacheStrategy({
     fullBodyTokens: state.cacheSizeFull,
     compressedTokens: state.cacheSizeCompressed,
-    readPerToken: pricing?.readPerToken ?? global.read,
-    writePerToken: pricing?.writePerToken ?? global.write,
+    readPerToken: pricing?.readPerToken ?? getCachePricing().read,
+    writePerToken: pricing?.writePerToken ?? getCachePricing().write,
     pReturn: survival.pReturn,
     expectedCycles: survival.expectedCycles,
     expectedFutureTurns: survival.expectedFutureTurns,

--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -1192,19 +1192,13 @@ export function shouldWarm(
   // Session marked dead
   if (state.warmup?.disabled) return false;
 
-  // Session-level ROI guard: after enough warmups, if the observed hit
-  // rate is chronically low, stop warming. This prevents unlimited
-  // spending across many short breaks where each individual break passes
-  // the per-break checks but the aggregate ROI is deeply negative.
-  const lifetime = state.warmup?.totalWarmups ?? 0;
-  if (lifetime >= MIN_WARMUPS_FOR_ROI_CHECK) {
-    const hitRate = (state.warmup?.warmupHits ?? 0) / lifetime;
-    if (hitRate < MIN_SESSION_HIT_RATE) return false;
-  }
-  // Write-efficiency guard: stop warming a large/growing session whose
-  // full-body warms refresh only a tiny stable prefix (chronically low
-  // cacheRead/(read+write)). Independent of the return-rate guard above.
-  if (warmupWriteEfficiencyTooLow(state.warmup)) return false;
+  // NOTE: the survival computation + the shared cache-economics SHADOW eval are
+  // intentionally hoisted ABOVE the ROI and write-efficiency guards below. Those
+  // guards stop warming exactly the large/growing sessions the shared model is
+  // meant to reclassify as cool-bust, so evaluating after them would make the
+  // shadow blind to the population it exists to measure. The hoist is purely
+  // additive (survival fns are pure; only a log is emitted) — the returned
+  // decision is unchanged because the guards still run, just after the eval.
 
   // Compute commitment model signals
   const survivalAtIdle = survivalFunction(blendedHist, elapsed);
@@ -1282,6 +1276,21 @@ export function shouldWarm(
       );
     }
   }
+
+  // Session-level ROI guard: after enough warmups, if the observed hit
+  // rate is chronically low, stop warming. This prevents unlimited
+  // spending across many short breaks where each individual break passes
+  // the per-break checks but the aggregate ROI is deeply negative.
+  // (Runs after the shadow eval above so large sessions are still measured.)
+  const lifetime = state.warmup?.totalWarmups ?? 0;
+  if (lifetime >= MIN_WARMUPS_FOR_ROI_CHECK) {
+    const hitRate = (state.warmup?.warmupHits ?? 0) / lifetime;
+    if (hitRate < MIN_SESSION_HIT_RATE) return false;
+  }
+  // Write-efficiency guard: stop warming a large/growing session whose
+  // full-body warms refresh only a tiny stable prefix (chronically low
+  // cacheRead/(read+write)). Independent of the return-rate guard above.
+  if (warmupWriteEfficiencyTooLow(state.warmup)) return false;
 
   // Determine if this is the initial commitment or a continuation
   const cyclesSpent = state.warmup?.warmupCount ?? 0;


### PR DESCRIPTION
Follow-up from the final adversarial audit of the cache-economics work (#838/#841/#842/#844). The audit verdict was **SHIP-WITH-FOLLOWUPS** (model verified correct, no MUST-FIX); this addresses the top finding. All changes are **behavior-neutral**.

## Primary fix — shadow mode was blind to the sessions it targets
The audit's most important finding: in `shouldWarm`, the shared-economics SHADOW evaluation sat **after** the ROI and write-efficiency guards. Those guards stop warming exactly the large/growing sessions the shared model is meant to reclassify as `cool-bust` — so the shadow never evaluated them, and the measurement we're collecting before the PR2b flip would be dominated by small/healthy sessions and rarely emit `cool-bust`.

Fix: hoist the survival computation + shadow eval **above** the ROI/write-efficiency guards. The guards still run (identical returns) — just after the eval. Survival functions are pure and only a log line is emitted, so the warm/no-warm decision is unchanged (the full 172-test cache-warmer suite still passes).

## Tidy-ups from the audit (NITs)
- `evaluateCacheStrategy` no longer eagerly calls `getCachePricing()` when a pricing override is supplied (the common warmer path).
- Documented that `setCacheSizeSnapshot` is the writer side and intentionally **creates** state (transform/tests), whereas the read accessors and warmer-facing `evaluateCacheStrategy` use non-creating `get` to avoid phantom-session leaks.

## Deferred to PR2b (documented in code, not regressions)
- A real **compressed target for layer ≥ 1 paths** — today the tier-gate refine only fires at layer 0, so already-compressing sessions show `compressed == full` in shadow. PR2b must source this before acting on `cool-bust`.
- An **e2e test for the tier-gate `compressed < full` snapshot write** — reliably hitting that path needs calibration + distillation fixtures; PR2b is its natural home (it reworks that path anyway).

## Also noted by the audit (no code here)
- PR-body corrections (#842 test count 17→26, #844 7→9, soften #844's "no possibility of divergence" header) — applied to the merged PR descriptions directly.
- A stale lore-knowledge note claiming thinking-session 400s count as circuit-breaker failures — **verified false** against the code (non-2xx warmups are neutral; breaker is per-bucket).

## Verification
- typecheck (core+gateway) clean; lint clean (15 warnings, all pre-existing/non-touched); cache-warmer (172) + economics (26) + evaluator (9) = 207 pass.