### PR TITLE
feat(core): flip update()/remove() onto append-only versioning (A2 sub-PR 2b-2b)

### DIFF
--- a/packages/core/src/agents-file.ts
+++ b/packages/core/src/agents-file.ts
@@ -565,9 +565,11 @@ function _importEntries(entries: ParsedFileEntry[], projectPath: string): void {
       // entry.id is the <!-- lore:UUID --> marker, which is the stable logical_id.
       const existing = ltm.getByLogical(entry.id);
       if (existing) {
-        // Known entry — update only if content changed (manual edit in file)
+        // Known entry — update only if content changed (manual edit in file). Pass
+        // the resolved current row id (Seer #848): update() resolves it to the
+        // logical_id and appends a new version.
         if (existing.content !== entry.content) {
-          ltm.update(entry.id, { content: entry.content });
+          ltm.update(existing.id, { content: entry.content });
         }
       } else if (ltm.isTombstoned(entry.id)) {
       } else {

--- a/packages/core/src/curator.ts
+++ b/packages/core/src/curator.ts
@@ -332,10 +332,12 @@ export function applyOps(
       });
       if (!wasCreated) {
         // Dedup-merged into an existing entry — not a real create, but the
-        // existing row was updated in place and may already be pinned in the
-        // prompt cache. Surface it as an update so session LTM caches are
-        // invalidated and durable prompt deltas can replay the new bytes.
-        const entry = ltm.get(id);
+        // existing entry was updated (a content change appends a new version) and
+        // may already be pinned in the prompt cache. Surface it as an update so
+        // session LTM caches are invalidated and durable prompt deltas can replay
+        // the new bytes. `id` is the stable logical_id from tryCreate → resolve
+        // the current version via getByLogical.
+        const entry = ltm.getByLogical(id);
         if (entry) {
           idsToSync.push(id);
           changedEntries.push({
@@ -376,10 +378,13 @@ export function applyOps(
               " [truncated — entry too long]"
             : op.content;
         ltm.update(op.id, { content, confidence: op.confidence });
-        if (op.content !== undefined) idsToSync.push(op.id);
+        // Key on the stable logical_id: a content change appends a new version, so
+        // op.id is now a superseded version id. idsToSync + the delta channel must
+        // reference the logical_id to resolve the current version downstream.
+        if (op.content !== undefined) idsToSync.push(entry.logical_id);
         changedEntries.push({
           op: "updated",
-          id: op.id,
+          id: entry.logical_id,
           category: entry.category,
           title: entry.title,
           content: content ?? prevContent,
@@ -397,7 +402,7 @@ export function applyOps(
         }
         changedEntries.push({
           op: "deleted",
-          id: op.id,
+          id: entry.logical_id,
           category: entry.category,
           title: entry.title,
           prevContent: entry.content,
@@ -408,11 +413,13 @@ export function applyOps(
     }
   }
 
-  // Sync cross-references for created/updated entries
+  // Sync cross-references for created/updated entries. idsToSync holds stable
+  // logical_ids; resolve the current version for its (possibly newly-appended)
+  // content. syncRefs/syncEntityRefs key the refs on the logical_id internally.
   for (const id of idsToSync) {
     ltm.syncRefs(id);
     // Also sync entity references (detect entity mentions in content)
-    const entry = ltm.get(id);
+    const entry = ltm.getByLogical(id);
     if (entry) {
       try {
         entities.syncEntityRefs(id, entry.content);

--- a/packages/core/src/curator.ts
+++ b/packages/core/src/curator.ts
@@ -362,7 +362,9 @@ export function applyOps(
       });
       created++;
     } else if (op.op === "update") {
-      const entry = ltm.get(op.id);
+      // op.id may already be superseded by an earlier op on the same entry in
+      // this batch — resolve through the stable logical_id so the op isn't dropped.
+      const entry = ltm.get(op.id) ?? ltm.getByLogical(ltm.logicalIdOf(op.id));
       if (entry) {
         // Guard: don't mutate entries owned by a different project.
         // Cross-project entries (project_id=NULL or same project) are safe.
@@ -393,7 +395,8 @@ export function applyOps(
         updated++;
       }
     } else if (op.op === "delete") {
-      const entry = ltm.get(op.id);
+      // Resolve through logical_id in case an earlier op in this batch superseded op.id.
+      const entry = ltm.get(op.id) ?? ltm.getByLogical(ltm.logicalIdOf(op.id));
       if (entry) {
         // Guard: don't delete entries owned by a different project.
         if (entry.project_id !== null && input.projectPath) {

--- a/packages/core/src/data.ts
+++ b/packages/core/src/data.ts
@@ -408,6 +408,18 @@ export function resolveId(
   table: "knowledge" | "distillations",
   prefix: string,
 ): string | null {
+  if (table === "knowledge") {
+    // A2 (#823): the id a user holds is the entry's stable logical_id; the
+    // current version's row id may differ, and the base table holds every
+    // (timestamp-prefix-sharing) version. Resolve the prefix against the
+    // logical_id of CURRENT entries so it stays unique and points at a live entry.
+    const results = db()
+      .query(
+        "SELECT DISTINCT logical_id AS id FROM knowledge_current WHERE logical_id LIKE ? LIMIT 2",
+      )
+      .all(`${prefix}%`) as Array<{ id: string }>;
+    return results.length === 1 ? results[0].id : null;
+  }
   const results = db()
     .query(`SELECT id FROM ${table} WHERE id LIKE ? LIMIT 2`)
     .all(`${prefix}%`) as Array<{ id: string }>;
@@ -503,7 +515,9 @@ export function clearProject(projectPath: string): ClearResult {
   const counts = {
     knowledge: (
       database
-        .query("SELECT COUNT(*) as c FROM knowledge WHERE project_id = ?")
+        .query(
+          "SELECT COUNT(*) as c FROM knowledge_current WHERE project_id = ?",
+        )
         .get(pid) as { c: number }
     ).c,
     temporal: (
@@ -614,7 +628,9 @@ export function deleteProject(projectId: string): ClearResult | null {
   const counts = {
     knowledge: (
       database
-        .query("SELECT COUNT(*) as c FROM knowledge WHERE project_id = ?")
+        .query(
+          "SELECT COUNT(*) as c FROM knowledge_current WHERE project_id = ?",
+        )
         .get(projectId) as { c: number }
     ).c,
     temporal: (
@@ -719,7 +735,7 @@ export function clearKnowledge(projectPath: string): number {
   const pid = ensureProject(projectPath);
   const count = (
     db()
-      .query("SELECT COUNT(*) as c FROM knowledge WHERE project_id = ?")
+      .query("SELECT COUNT(*) as c FROM knowledge_current WHERE project_id = ?")
       .get(pid) as { c: number }
   ).c;
 
@@ -786,9 +802,11 @@ export function clearDistillations(projectPath: string): number {
 
 /** Delete a single knowledge entry. Returns true if found and deleted. */
 export function deleteKnowledge(id: string): boolean {
-  const entry = ltm.get(id);
+  // id may be a current OR superseded version id (or the logical_id == v1 id).
+  // Resolve to the current entry via the stable logical_id (A2, #823).
+  const entry = ltm.get(id) ?? ltm.getByLogical(ltm.logicalIdOf(id));
   if (!entry) return false;
-  ltm.remove(id);
+  ltm.remove(entry.logical_id);
   invalidateProjectsCache();
   invalidateGlobalStatsCache();
   return true;
@@ -1070,7 +1088,7 @@ export function moveSessions(
   const knowledgeCount = (
     database
       .query(
-        `SELECT COUNT(*) as c FROM knowledge WHERE project_id = ? AND source_session IN (${placeholders})`,
+        `SELECT COUNT(*) as c FROM knowledge_current WHERE project_id = ? AND source_session IN (${placeholders})`,
       )
       .get(fromProjectId, ...allIds) as { c: number }
   ).c;
@@ -1173,16 +1191,20 @@ export function reassignKnowledge(
   toProjectPath: string,
   opts?: { gitRemote?: string },
 ): boolean {
-  const entry = ltm.get(knowledgeId);
+  // Resolve to the current entry via the stable logical_id (A2, #823).
+  const entry =
+    ltm.get(knowledgeId) ?? ltm.getByLogical(ltm.logicalIdOf(knowledgeId));
   if (!entry) return false;
 
   const toId = ensureProject(toProjectPath, undefined, opts?.gitRemote);
   if (entry.project_id === toId) return true; // already there
 
   const oldProjectId = entry.project_id;
+  // Move ALL versions of the logical entry so a multi-version entry isn't split
+  // across projects (reviewer NIT).
   db()
-    .query("UPDATE knowledge SET project_id = ? WHERE id = ?")
-    .run(toId, knowledgeId);
+    .query("UPDATE knowledge SET project_id = ? WHERE logical_id = ?")
+    .run(toId, entry.logical_id);
 
   invalidateProjectsCache();
   invalidateGlobalStatsCache();
@@ -1258,7 +1280,9 @@ export function mergeProjects(sourceId: string, targetId: string): MergeResult {
   const counts = {
     knowledge: (
       database
-        .query("SELECT COUNT(*) as c FROM knowledge WHERE project_id = ?")
+        .query(
+          "SELECT COUNT(*) as c FROM knowledge_current WHERE project_id = ?",
+        )
         .get(sourceId) as { c: number }
     ).c,
     messages: (

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -363,8 +363,16 @@ export function update(
   // sensitivity are MUTABLE metadata applied to the current version in place.
   // `id` may be a current OR superseded version id — resolve to the logical_id.
   const logicalId = logicalIdOf(id);
+  // Append a new version only when the content actually changed — a byte-identical
+  // "update" (e.g. the curator re-observing an unchanged entry) must NOT append, or
+  // frequently re-observed entries grow the table unbounded until compaction.
+  let appended = false;
   if (input.content !== undefined) {
-    appendVersion(logicalId, { content: input.content });
+    const cur = getByLogical(logicalId);
+    if (cur && cur.content !== input.content) {
+      appendVersion(logicalId, { content: input.content });
+      appended = true;
+    }
   }
 
   const sets: string[] = [];
@@ -398,8 +406,8 @@ export function update(
     )
     .run(...(params as [string, ...string[]]));
 
-  // Re-embed the new current version when content changed (fire-and-forget).
-  if (embedding.isAvailable() && input.content !== undefined) {
+  // Re-embed the new current version only when a content change was appended.
+  if (embedding.isAvailable() && appended) {
     const entry = getByLogical(logicalId);
     if (entry) {
       embedding.embedKnowledgeEntry(entry.id, entry.title, entry.content);

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -111,19 +111,21 @@ export function create(input: {
   // the caller (importFromFile) already handles duplicate detection by UUID.
   if (!input.id) {
     // First check same project_id
+    // Return the stable logical_id (not the per-version id): update() below
+    // appends a new version, which would supersede the version id we matched.
     const existing = (
       pid !== null
         ? db()
             .query(
-              "SELECT id FROM knowledge_current WHERE project_id = ? AND LOWER(title) = LOWER(?) AND confidence > 0 LIMIT 1",
+              "SELECT logical_id FROM knowledge_current WHERE project_id = ? AND LOWER(title) = LOWER(?) AND confidence > 0 LIMIT 1",
             )
             .get(pid, input.title)
         : db()
             .query(
-              "SELECT id FROM knowledge_current WHERE project_id IS NULL AND LOWER(title) = LOWER(?) AND confidence > 0 LIMIT 1",
+              "SELECT logical_id FROM knowledge_current WHERE project_id IS NULL AND LOWER(title) = LOWER(?) AND confidence > 0 LIMIT 1",
             )
             .get(input.title)
-    ) as { id: string } | null;
+    ) as { logical_id: string } | null;
 
     // Build the update payload — forward confidence when the caller provided one
     // so the curator's scoring intent isn't silently dropped on dedup.
@@ -133,21 +135,21 @@ export function create(input: {
     };
 
     if (existing) {
-      update(existing.id, dedupUpdate);
-      return existing.id;
+      update(existing.logical_id, dedupUpdate);
+      return existing.logical_id;
     }
 
     // Also check cross-project entries — prevents creating project-scoped
     // duplicates of entries that already exist as cross-project knowledge.
     const crossExisting = db()
       .query(
-        "SELECT id FROM knowledge_current WHERE cross_project = 1 AND LOWER(title) = LOWER(?) AND confidence > 0 LIMIT 1",
+        "SELECT logical_id FROM knowledge_current WHERE cross_project = 1 AND LOWER(title) = LOWER(?) AND confidence > 0 LIMIT 1",
       )
-      .get(input.title) as { id: string } | null;
+      .get(input.title) as { logical_id: string } | null;
 
     if (crossExisting) {
-      update(crossExisting.id, dedupUpdate);
-      return crossExisting.id;
+      update(crossExisting.logical_id, dedupUpdate);
+      return crossExisting.logical_id;
     }
 
     // Fuzzy dedup: check for title-similar entries via FTS5 + word-overlap.
@@ -159,8 +161,10 @@ export function create(input: {
       projectId: pid,
     });
     if (fuzzyMatch) {
-      update(fuzzyMatch.id, dedupUpdate);
-      return fuzzyMatch.id;
+      // findFuzzyDuplicate returns a version id; resolve to the stable logical_id.
+      const logicalId = logicalIdOf(fuzzyMatch.id);
+      update(logicalId, dedupUpdate);
+      return logicalId;
     }
   }
 
@@ -223,13 +227,6 @@ export function appendVersion(
     isDeleted?: boolean;
   } = {},
 ): string | null {
-  const cur = db()
-    .query(
-      "SELECT id FROM knowledge WHERE logical_id = ? AND is_current = 1 LIMIT 1",
-    )
-    .get(logicalId) as { id: string } | undefined;
-  if (!cur) return null;
-
   const newId = uuidv7();
   const now = Date.now();
   // Atomic insert-new + demote-old (Seer #839): a crash between the two
@@ -237,8 +234,15 @@ export function appendVersion(
   // DEMOTE FIRST, then insert — the partial UNIQUE index idx_knowledge_one_current
   // (logical_id WHERE is_current=1) is checked per-statement, so inserting a
   // second current row before demoting would violate it. The forward-copy SELECT
-  // still reads the (now-demoted) row by id. The whole pair runs in one txn.
-  withTransaction(() => {
+  // still reads the (now-demoted) row by id. The current-row lookup is INSIDE the
+  // txn so it can't race a concurrent append (no TOCTOU).
+  const ok = withTransaction(() => {
+    const cur = db()
+      .query(
+        "SELECT id FROM knowledge WHERE logical_id = ? AND is_current = 1 LIMIT 1",
+      )
+      .get(logicalId) as { id: string } | undefined;
+    if (!cur) return false;
     db().query("UPDATE knowledge SET is_current = 0 WHERE id = ?").run(cur.id);
     db()
       .query(
@@ -267,9 +271,10 @@ export function appendVersion(
         overrides.isDeleted ? 1 : 0,
         cur.id,
       );
+    return true;
   });
 
-  return newId;
+  return ok ? newId : null;
 }
 
 /**
@@ -353,12 +358,17 @@ export function update(
     sensitivity?: Sensitivity;
   },
 ) {
+  // A2 (#823): content is IMMUTABLE per version. A content change appends a new
+  // version (copying confidence/metadata forward); confidence/updated_by/
+  // sensitivity are MUTABLE metadata applied to the current version in place.
+  // `id` may be a current OR superseded version id — resolve to the logical_id.
+  const logicalId = logicalIdOf(id);
+  if (input.content !== undefined) {
+    appendVersion(logicalId, { content: input.content });
+  }
+
   const sets: string[] = [];
   const params: unknown[] = [];
-  if (input.content !== undefined) {
-    sets.push("content = ?");
-    params.push(input.content);
-  }
   if (input.confidence !== undefined) {
     // Clamp to [0.0, 1.0] — an LLM-provided value outside this range would
     // give disproportionate scoring weight (>1) or silently soft-delete (<0.2).
@@ -380,52 +390,60 @@ export function update(
   // → reset the decay clock so a freshly-touched entry never ages out (v48).
   sets.push("last_reinforced_at = ?");
   params.push(now);
-  params.push(id);
+  params.push(logicalId);
+  // Target the CURRENT version (the freshly-appended one if content changed).
   db()
-    .query(`UPDATE knowledge SET ${sets.join(", ")} WHERE id = ?`)
+    .query(
+      `UPDATE knowledge SET ${sets.join(", ")} WHERE logical_id = ? AND is_current = 1`,
+    )
     .run(...(params as [string, ...string[]]));
 
-  // Re-embed when content changes (fire-and-forget)
+  // Re-embed the new current version when content changed (fire-and-forget).
   if (embedding.isAvailable() && input.content !== undefined) {
-    const entry = get(id);
+    const entry = getByLogical(logicalId);
     if (entry) {
-      embedding.embedKnowledgeEntry(id, entry.title, input.content);
+      embedding.embedKnowledgeEntry(entry.id, entry.title, entry.content);
     }
   }
 }
 
 export function remove(id: string) {
-  // Record a tombstone BEFORE deleting so a stale .lore.md re-import can't
-  // resurrect this entry (which would thrash with the next consolidation pass —
-  // delete → re-import recreates → delete again, busting the prompt cache each
-  // cycle). The tombstone + transfer metrics key on the stable `logical_id`
-  // (which `.lore.md` markers now carry), not the per-version row id. Capture
-  // both while the row still exists.
-  const row = db()
-    .query("SELECT project_id, logical_id FROM knowledge WHERE id = ?")
-    .get(id) as { project_id: string | null; logical_id: string } | null;
-  if (row) {
-    db()
-      .query(
-        `INSERT INTO knowledge_tombstones (id, project_id, deleted_at)
-         VALUES (?, ?, ?)
-         ON CONFLICT(id) DO UPDATE SET deleted_at = excluded.deleted_at`,
-      )
-      .run(row.logical_id, row.project_id, Date.now());
-    // Clean up transfer metrics before deleting the entry (no FK CASCADE).
-    db()
-      .query("DELETE FROM knowledge_transfers WHERE knowledge_id = ?")
-      .run(row.logical_id);
-  }
-  db().query("DELETE FROM knowledge WHERE id = ?").run(id);
+  // A2 (#823): delete = append an immutable is_deleted "death-certificate"
+  // version (ordinary append, no physical DELETE). The death cert IS the
+  // tombstone + resurrection guard: knowledge_current excludes it, the FTS
+  // triggers drop its posting, and isTombstoned() detects it so a stale .lore.md
+  // re-import can't resurrect the entry. Keyed on the stable logical_id.
+  const logicalId = logicalIdOf(id);
+  if (!getByLogical(logicalId)) return; // already deleted or unknown — no-op
+  appendVersion(logicalId, { isDeleted: true });
+  // The row is NOT physically deleted, so FK ON DELETE CASCADE no longer fires —
+  // clean cross-references explicitly, all keyed on the logical_id.
+  db()
+    .query("DELETE FROM knowledge_entity_refs WHERE knowledge_id = ?")
+    .run(logicalId);
+  db()
+    .query("DELETE FROM knowledge_refs WHERE from_id = ? OR to_id = ?")
+    .run(logicalId, logicalId);
+  db()
+    .query("DELETE FROM knowledge_transfers WHERE knowledge_id = ?")
+    .run(logicalId);
 }
 
-/** True when the given knowledge UUID was previously deleted (tombstoned). */
+/** True when the entry for this logical_id was deleted (tombstoned). */
 export function isTombstoned(id: string): boolean {
-  const row = db()
+  // A2: the current version is an is_deleted death certificate.
+  const deathCert = db()
+    .query(
+      "SELECT 1 FROM knowledge WHERE logical_id = ? AND is_current = 1 AND is_deleted = 1 LIMIT 1",
+    )
+    .get(id) as { 1: number } | null;
+  if (deathCert) return true;
+  // Legacy: entries deleted before the append-only flip left a tombstone row and
+  // no death-cert version (they were physically deleted).
+  const legacy = db()
     .query("SELECT 1 FROM knowledge_tombstones WHERE id = ?")
     .get(id) as { 1: number } | null;
-  return row != null;
+  return legacy != null;
 }
 
 /**
@@ -1728,6 +1746,20 @@ export function getByLogical(logicalId: string): KnowledgeEntry | null {
 }
 
 /**
+ * Resolve any knowledge id — a current version id, a SUPERSEDED version id, or a
+ * logical_id — to its stable logical_id. Reads the BASE table (not the view) so
+ * it still resolves a superseded version; falls back to the input id if unknown
+ * (so ref writers always have a value). This is the canonical resolver the flip
+ * (update/remove/syncRefs) uses to stay correct once a version is superseded.
+ */
+export function logicalIdOf(id: string): string {
+  const row = db()
+    .query("SELECT logical_id FROM knowledge WHERE id = ?")
+    .get(id) as { logical_id: string } | null;
+  return row?.logical_id ?? id;
+}
+
+/**
  * Read the worker source attribution for a knowledge entry. Returns null for
  * legacy entries created before v35 (no attribution recorded) or for entries
  * imported from outside the worker pipeline (manual `.lore.md` edits, etc).
@@ -1789,9 +1821,10 @@ const WIKI_LINK_RE = /\[\[([^\]]+)\]\]/g;
  */
 export function resolveRef(ref: string): string | null {
   if (UUID_RE.test(ref)) {
-    // The [[uuid]] in content may be either a logical_id or a (possibly
-    // superseded) version id — resolve either way, return the stable logical_id.
-    const entry = getByLogical(ref) ?? get(ref);
+    // The [[uuid]] in content may be a logical_id or a (possibly superseded)
+    // version id — resolve via the base table, then confirm the target still has
+    // a current, non-deleted version before linking to it.
+    const entry = getByLogical(logicalIdOf(ref));
     return entry ? entry.logical_id : null;
   }
   // Title search — FTS5 best match
@@ -1819,11 +1852,12 @@ export function extractRefs(content: string): string[] {
  * Clears existing outgoing refs for this entry first.
  */
 export function syncRefs(entryId: string): number {
-  // entryId may be a current- or (post-2b) superseded version id; key the refs
-  // on the stable logical_id so they survive version appends.
-  const entry = getByLogical(entryId) ?? get(entryId);
+  // entryId may be a current OR superseded version id (the curator passes the id
+  // it read, which update() then supersedes). Resolve to the logical_id via the
+  // base table, then fetch the current version's content to extract refs from.
+  const fromLogical = logicalIdOf(entryId);
+  const entry = getByLogical(fromLogical);
   if (!entry) return 0;
-  const fromLogical = entry.logical_id;
 
   // Clear existing outgoing refs for this entry
   db().query("DELETE FROM knowledge_refs WHERE from_id = ?").run(fromLogical);

--- a/packages/core/src/sync-data.ts
+++ b/packages/core/src/sync-data.ts
@@ -597,6 +597,26 @@ export function applyRemoteDelete(table: string, rowId: string): void {
   );
 }
 
+/**
+ * Map a knowledge outbox row to its remote sync op under the append-only model
+ * (A2, #823). The remote mirrors only the CURRENT LIVE version: a superseded
+ * (is_current=0) or soft-deleted (is_deleted=1) version becomes a remote
+ * soft-delete — this removes stale/redacted content from the remote and
+ * propagates deletions (remove() no longer emits a physical-delete outbox op).
+ * A current live version is upserted. Returns "skip" if the row is gone.
+ *
+ * NOTE: this keeps the remote a correct CURRENT-only mirror keyed by the current
+ * version id. Full cross-device id↔logical_id convergence (so refs resolve the
+ * same entry on every device) is completed in sub-PR 3.
+ */
+export function knowledgeSyncOp(rowId: string): "upsert" | "delete" | "skip" {
+  const v = db()
+    .query("SELECT is_current, is_deleted FROM knowledge WHERE id = ?")
+    .get(rowId) as { is_current: number; is_deleted: number } | undefined;
+  if (!v) return "skip";
+  return v.is_current === 0 || v.is_deleted === 1 ? "delete" : "upsert";
+}
+
 /** Rebuild an external-content FTS5 index after a batch of pulled changes. */
 export function rebuildFts(ftsTable: string): void {
   if (ftsTable === "knowledge_fts") {

--- a/packages/core/test/agents-file.test.ts
+++ b/packages/core/test/agents-file.test.ts
@@ -608,7 +608,7 @@ describe("importFromFile — known ID tracking", () => {
 
     importFromFile({ projectPath: PROJECT, filePath: AGENTS_FILE });
 
-    const entry = ltm.get(id);
+    const entry = ltm.getByLogical(id); // import edit appended a new version
     expect(entry?.content).toContain("API keys");
   });
 
@@ -1333,7 +1333,7 @@ describe("importLoreFile", () => {
 
     importLoreFile(PROJECT);
 
-    const entry = ltm.get(id);
+    const entry = ltm.getByLogical(id); // import edit appended a new version
     expect(entry?.content).toContain("API keys");
   });
 
@@ -1505,7 +1505,7 @@ describe("migration from AGENTS.md to .lore.md", () => {
     expect(shouldImportLoreFile(PROJECT)).toBe(true);
 
     importLoreFile(PROJECT);
-    const entry = ltm.get(remoteId);
+    const entry = ltm.getByLogical(remoteId); // import edit appended a new version
     expect(entry?.content).toContain("updated");
   });
 

--- a/packages/core/test/curator-changed-entries.test.ts
+++ b/packages/core/test/curator-changed-entries.test.ts
@@ -66,7 +66,7 @@ describe("curator applyOps changedEntries", () => {
         prevContent: "original",
       }),
     ]);
-    expect(ltm.get(id)?.content).toBe("updated by dedup");
+    expect(ltm.getByLogical(id)?.content).toBe("updated by dedup");
   });
 
   test("returns updatedEntries with previous and new content", () => {

--- a/packages/core/test/curator-reobservation.test.ts
+++ b/packages/core/test/curator-reobservation.test.ts
@@ -120,10 +120,10 @@ describe("curator consolidate — focusCategory merge", () => {
     // Merge prompt used (not the trim/eviction prompt).
     expect(receivedSystem).toContain("merge genuine duplicates");
     expect(receivedSystem).not.toContain("target maximum");
-    // The delete was applied — B is gone, A survives.
+    // The delete was applied — B is gone, A survives (as a new appended version).
     expect(result.deleted).toBeGreaterThanOrEqual(1);
-    expect(ltm.get(bId)).toBeNull();
-    expect(ltm.get(aId)).not.toBeNull();
+    expect(ltm.getByLogical(bId)).toBeNull(); // B has no current, live version
+    expect(ltm.getByLogical(aId)).not.toBeNull();
   });
 
   test("does nothing when fewer than 2 entries in the category", async () => {

--- a/packages/core/test/data-move.test.ts
+++ b/packages/core/test/data-move.test.ts
@@ -66,8 +66,8 @@ function insertKnowledge(
 ): void {
   db()
     .query(
-      `INSERT INTO knowledge (id, project_id, category, title, content, source_session, cross_project, confidence, created_at, updated_at)
-       VALUES (?, ?, 'pattern', 'Test Knowledge', 'test content', ?, ?, 0.8, ?, ?)`,
+      `INSERT INTO knowledge (id, project_id, category, title, content, source_session, cross_project, confidence, created_at, updated_at, logical_id)
+       VALUES (?, ?, 'pattern', 'Test Knowledge', 'test content', ?, ?, 0.8, ?, ?, ?)`,
     )
     .run(
       id,
@@ -76,6 +76,7 @@ function insertKnowledge(
       opts?.crossProject ? 1 : 0,
       Date.now(),
       Date.now(),
+      id, // logical_id = id, matching create()/production
     );
 }
 

--- a/packages/core/test/import/curator-ops.test.ts
+++ b/packages/core/test/import/curator-ops.test.ts
@@ -96,7 +96,7 @@ describe("applyOps", () => {
     const result = applyOps(ops, { projectPath: PROJECT_PATH });
     expect(result.updated).toBe(1);
 
-    const entry = ltm.get(id);
+    const entry = ltm.getByLogical(id); // update appended a new version
     expect(entry?.content).toBe("New improved content");
   });
 

--- a/packages/core/test/ltm-flip.test.ts
+++ b/packages/core/test/ltm-flip.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { db, ensureProject } from "../src/db";
+import * as entities from "../src/entities";
+import * as ltm from "../src/ltm";
+
+const PROJECT = "/test/a2/flip";
+const OTHER = "/test/a2/flip-other";
+
+const countVersions = (logicalId: string) =>
+  (
+    db()
+      .query("SELECT COUNT(*) c FROM knowledge WHERE logical_id = ?")
+      .get(logicalId) as { c: number }
+  ).c;
+
+// 2b-2b wires update()/remove() onto appendVersion. These tests pin the new
+// invariants: content changes append immutable versions, mutable metadata stays
+// in place, and remove() appends a death certificate AND cleans cross-references
+// explicitly (FK ON DELETE CASCADE is dormant because nothing is physically deleted).
+describe("A2 sub-PR 2b-2b: update()/remove() append flip", () => {
+  beforeEach(() => {
+    const pid = ensureProject(PROJECT);
+    db().query("DELETE FROM knowledge_refs").run();
+    db().query("DELETE FROM knowledge_entity_refs").run();
+    db().query("DELETE FROM knowledge_transfers").run();
+    db().query("DELETE FROM knowledge WHERE project_id = ?").run(pid);
+  });
+
+  const mk = (title: string, content: string, confidence = 1.0) =>
+    ltm.create({
+      projectPath: PROJECT,
+      scope: "project",
+      category: "decision",
+      title,
+      content,
+      confidence,
+    });
+
+  test("update() with a content change appends a version and applies confidence to it", () => {
+    const id = mk("ContentUpd", "v1body", 1.0);
+    ltm.update(id, { content: "v2body", confidence: 0.7 });
+    expect(countVersions(id)).toBe(2);
+    const cur = ltm.getByLogical(id);
+    expect(cur?.content).toBe("v2body");
+    expect(cur?.confidence).toBe(0.7);
+    expect(cur?.id).not.toBe(id); // current row moved to the new version
+    // The prior version is preserved, immutable, with its original content.
+    const v1 = db()
+      .query("SELECT content, confidence FROM knowledge WHERE id = ?")
+      .get(id) as { content: string; confidence: number };
+    expect(v1.content).toBe("v1body");
+  });
+
+  test("update() with only mutable fields does NOT append a version", () => {
+    const id = mk("MutableUpd", "body", 1.0);
+    ltm.update(id, { confidence: 0.4 });
+    expect(countVersions(id)).toBe(1); // no new version row
+    const cur = ltm.getByLogical(id);
+    expect(cur?.id).toBe(id); // still the original row, mutated in place
+    expect(cur?.confidence).toBe(0.4);
+  });
+
+  test("remove() appends a death certificate; the entry is gone and tombstoned", () => {
+    const id = mk("RemoveMe", "body");
+    ltm.remove(id);
+    expect(countVersions(id)).toBe(2); // v1 + is_deleted death cert
+    expect(ltm.get(id)).toBeNull();
+    expect(ltm.getByLogical(id)).toBeNull(); // no current, live version
+    expect(ltm.isTombstoned(id)).toBe(true);
+    // Append-only: the original row is NOT physically deleted.
+    expect(
+      (
+        db().query("SELECT COUNT(*) c FROM knowledge WHERE id = ?").get(id) as {
+          c: number;
+        }
+      ).c,
+    ).toBe(1);
+  });
+
+  test("remove() explicitly cleans entity refs, wiki refs, and transfers (FK CASCADE dormant)", () => {
+    const target = mk("FlipTarget", "target body");
+    const src = mk("FlipSrc", `links to [[${target}]] here`);
+    expect(ltm.syncRefs(src)).toBe(1);
+    const eid = entities.create({
+      projectPath: PROJECT,
+      entityType: "tool",
+      canonicalName: "FlipWidget",
+    }).id;
+    entities.linkKnowledge(src, eid);
+    ltm.recordTransfer({
+      knowledgeId: src,
+      recalledInProjectId: ensureProject(OTHER),
+    });
+
+    // Sanity: the refs exist before removal.
+    expect(entities.knowledgeForEntity(eid)).toContain(src);
+    expect(ltm.transferCount(src)).toBe(1);
+    const refRows = () =>
+      (
+        db()
+          .query(
+            "SELECT COUNT(*) c FROM knowledge_refs WHERE from_id = ? OR to_id = ?",
+          )
+          .get(src, src) as { c: number }
+      ).c;
+    expect(refRows()).toBe(1);
+
+    ltm.remove(src);
+
+    // The row was NOT physically deleted (append-only) so ON DELETE CASCADE never
+    // fired — remove() must have cleaned every cross-reference explicitly.
+    expect(countVersions(src)).toBe(2);
+    expect(entities.knowledgeForEntity(eid)).not.toContain(src);
+    expect(ltm.transferCount(src)).toBe(0);
+    expect(refRows()).toBe(0);
+  });
+
+  test("remove() on an already-deleted entry is a no-op (no extra death cert)", () => {
+    const id = mk("DoubleRemove", "body");
+    ltm.remove(id);
+    const after1 = countVersions(id);
+    ltm.remove(id);
+    expect(countVersions(id)).toBe(after1); // no second death-cert version
+  });
+
+  test("a second update() appends v3 and refs still resolve to the current version", () => {
+    const id = mk("Chain", "c1");
+    ltm.update(id, { content: "c2" });
+    ltm.update(id, { content: "c3" });
+    expect(countVersions(id)).toBe(3);
+    const cur = ltm.getByLogical(id);
+    expect(cur?.content).toBe("c3");
+    // syncRefs invoked with the ORIGINAL id (now superseded) still keys on logical_id.
+    const eid = entities.create({
+      projectPath: PROJECT,
+      entityType: "tool",
+      canonicalName: "ChainWidget",
+    }).id;
+    entities.syncEntityRefs(id, "mentions ChainWidget"); // id is superseded
+    expect(entities.knowledgeForEntity(eid)).toEqual([id]); // stored as logical_id
+    expect(ltm.getByLogical(entities.knowledgeForEntity(eid)[0])?.id).toBe(
+      cur?.id,
+    );
+  });
+});

--- a/packages/core/test/ltm-lifecycle.test.ts
+++ b/packages/core/test/ltm-lifecycle.test.ts
@@ -11,7 +11,9 @@ function clearKnowledge() {
 }
 
 function reinforcedAt(id: string): number | null {
-  return ltm.get(id)?.last_reinforced_at ?? null;
+  // Resolve by logical_id: a content update() appends a new current version, so
+  // the decay-clock reset lives on the current version, not the original row id.
+  return ltm.getByLogical(id)?.last_reinforced_at ?? null;
 }
 
 describe("ltm reinforcement", () => {

--- a/packages/core/test/ltm-versioning.test.ts
+++ b/packages/core/test/ltm-versioning.test.ts
@@ -147,10 +147,10 @@ describe("A2 sub-PR 1: append-only knowledge scaffolding", () => {
     expect(ltm.appendVersion("does-not-exist")).toBeNull();
   });
 
-  test("in-place update() stays version 1 and FTS tracks the new content", () => {
-    // sub-PR 1 does NOT rewire update() onto appendVersion — it is still an
-    // in-place mutation. This guards that the current-aware triggers handle the
-    // production write path (delete old FTS + insert new) without corruption.
+  test("update() with a content change appends an immutable new version", () => {
+    // sub-PR 2b-2b rewires update() onto appendVersion: a content change appends
+    // a new current version; the prior version is preserved (immutable, demoted)
+    // and FTS indexes only the current content.
     const id = ltm.create({
       projectPath: PROJECT,
       scope: "project",
@@ -161,11 +161,14 @@ describe("A2 sub-PR 1: append-only knowledge scaffolding", () => {
     expect(ftsHits("inplaceoldtok")).toBeGreaterThan(0);
     ltm.update(id, { content: "inplacenewtok" });
     const v = versions(id);
-    expect(v).toHaveLength(1); // in-place: no new version row
+    expect(v).toHaveLength(2); // append: a new version row
     expect(v[0].version).toBe(1);
-    expect(v[0].is_current).toBe(1);
+    expect(v[0].is_current).toBe(0); // prior version demoted...
+    expect(v[0].content).toBe("inplaceoldtok"); // ...but its content is immutable
+    expect(v[1].version).toBe(2);
+    expect(v[1].is_current).toBe(1);
     expect(current(id)?.content).toBe("inplacenewtok");
-    expect(ftsHits("inplaceoldtok")).toBe(0);
+    expect(ftsHits("inplaceoldtok")).toBe(0); // superseded content not searchable
     expect(ftsHits("inplacenewtok")).toBeGreaterThan(0);
   });
 

--- a/packages/core/test/ltm.test.ts
+++ b/packages/core/test/ltm.test.ts
@@ -53,7 +53,7 @@ describe("ltm", () => {
     expect(entry?.cross_project).toBe(1);
   });
 
-  test("remove() tombstones the UUID; clearTombstone() lifts it", () => {
+  test("remove() appends a death-certificate version that tombstones the entry", () => {
     const id = ltm.create({
       projectPath: PROJECT,
       category: "gotcha",
@@ -63,14 +63,14 @@ describe("ltm", () => {
     });
     expect(ltm.isTombstoned(id)).toBe(false);
     ltm.remove(id);
+    // A2: delete = immutable is_deleted version (no physical DELETE). The entry is
+    // gone from the current view, and the death cert prevents .lore.md resurrection.
     expect(ltm.get(id)).toBeNull();
-    // The UUID is now tombstoned so a stale .lore.md can't resurrect it.
+    expect(ltm.getByLogical(id)).toBeNull(); // no current, live version
     expect(ltm.isTombstoned(id)).toBe(true);
-    ltm.clearTombstone(id);
-    expect(ltm.isTombstoned(id)).toBe(false);
   });
 
-  test("update knowledge entry", () => {
+  test("update knowledge entry appends a new current version", () => {
     const id = ltm.create({
       projectPath: PROJECT,
       category: "architecture",
@@ -83,9 +83,11 @@ describe("ltm", () => {
       confidence: 0.9,
     });
 
-    const entry = ltm.get(id);
+    // Content change appended a new version → resolve via the stable logical_id.
+    const entry = ltm.getByLogical(id);
     expect(entry?.content).toContain("Hono");
     expect(entry?.confidence).toBe(0.9);
+    expect(entry?.id).not.toBe(id); // the row id moved to the new version
   });
 
   test("remove knowledge entry", () => {
@@ -283,7 +285,7 @@ describe("ltm — crossProject defaults and dedup", () => {
     });
 
     expect(returnedId).toBe(crossId);
-    const entry = ltm.get(crossId);
+    const entry = ltm.getByLogical(crossId); // update() appended a new version
     expect(entry?.content).toBe("Updated content from project scope");
 
     // No duplicate should exist
@@ -1707,7 +1709,7 @@ describe("ltm — multi-user columns (v29)", () => {
       scope: "project",
     });
     ltm.update(id, { content: "Modified content", updatedBy: "user-xyz-456" });
-    const entry = ltm.get(id);
+    const entry = ltm.getByLogical(id); // content change appended a new version
     expect(entry?.content).toBe("Modified content");
     expect(entry?.updated_by).toBe("user-xyz-456");
   });
@@ -1736,7 +1738,7 @@ describe("ltm — multi-user columns (v29)", () => {
       createdBy: "user-abc-123",
     });
     ltm.update(id, { content: "Modified content" });
-    const entry = ltm.get(id);
+    const entry = ltm.getByLogical(id); // content change appended a new version
     expect(entry?.updated_by).toBeNull();
     expect(entry?.created_by).toBe("user-abc-123");
   });

--- a/packages/core/test/sync-data.test.ts
+++ b/packages/core/test/sync-data.test.ts
@@ -22,6 +22,7 @@ import {
   getSyncState,
   hasPendingChange,
   isSyncEnabled,
+  knowledgeSyncOp,
   maxOutboxSeq,
   pickSyncColumns,
   readOutbox,
@@ -33,8 +34,44 @@ import {
   SYNCED_TABLES,
   withApplying,
 } from "../src/sync-data";
+import * as ltm from "../src/ltm";
 
 const now = () => Date.now();
+
+describe("knowledgeSyncOp — append-only remote mapping (A2)", () => {
+  test("current live → upsert; superseded + death-cert → delete; gone → skip", () => {
+    const id = ltm.create({
+      projectPath: "/tmp/lore-sync-kso",
+      scope: "project",
+      category: "decision",
+      title: "KSO",
+      content: "secret v1",
+    });
+    expect(knowledgeSyncOp(id)).toBe("upsert"); // current live
+
+    const v2 = ltm.appendVersion(id, { content: "redacted v2" });
+    // The superseded v1 must become a remote DELETE so the old (secret) content is
+    // removed from the remote — not re-pushed as a live row.
+    expect(knowledgeSyncOp(id)).toBe("delete");
+    expect(knowledgeSyncOp(v2 as string)).toBe("upsert"); // new current live
+
+    ltm.remove(id); // append a death-cert, demoting v2
+    // Deletion propagates: the now-superseded v2 becomes a remote DELETE.
+    expect(knowledgeSyncOp(v2 as string)).toBe("delete");
+    const deathCert = (
+      db()
+        .query(
+          "SELECT id FROM knowledge WHERE logical_id = ? AND is_current = 1",
+        )
+        .get(id) as { id: string }
+    ).id;
+    expect(knowledgeSyncOp(deathCert)).toBe("delete"); // death cert → delete
+
+    expect(knowledgeSyncOp("00000000-0000-0000-0000-000000000000")).toBe(
+      "skip",
+    );
+  });
+});
 
 function insertKnowledge(id: string, title: string, content: string): string {
   const pid = ensureProject("/tmp/lore-sync-data");

--- a/packages/core/test/worker-attribution.test.ts
+++ b/packages/core/test/worker-attribution.test.ts
@@ -89,9 +89,9 @@ describe("worker source attribution (v35)", () => {
         workerModelID: "MiniMax-M3",
       });
       expect(id1).toBe(id2);
-      const entry = ltm.get(id1);
+      const entry = ltm.getByLogical(id1); // dedup update() appended a new version
       expect(entry?.content).toBe("second");
-      // Attribution is preserved from the original creator
+      // Attribution is preserved from the original creator (copied forward by appendVersion)
       expect(entry?.worker_provider_id).toBe("anthropic");
       expect(entry?.worker_model_id).toBe("claude-opus-4-6");
     });

--- a/packages/gateway/src/api.ts
+++ b/packages/gateway/src/api.ts
@@ -164,7 +164,9 @@ function handleGlobalStats(): Response {
 
 function handleListKnowledge(_url: URL, projectPath: string): Response {
   const entries = ltm.forProject(projectPath, false);
-  return jsonResponse(entries);
+  // Present the stable logical_id as the external id (A2, #823), consistent with
+  // handleShowKnowledge, so a listed id round-trips through show/delete/move.
+  return jsonResponse(entries.map((e) => ({ ...e, id: e.logical_id })));
 }
 
 function handleListSessions(url: URL, projectPath: string): Response {

--- a/packages/gateway/src/api.ts
+++ b/packages/gateway/src/api.ts
@@ -181,12 +181,17 @@ function handleListDistillations(url: URL, projectPath: string): Response {
 }
 
 function handleShowKnowledge(id: string): Response {
-  // Support prefix resolution
+  // Support prefix resolution. resolveId hits the base table, so the resolved id
+  // may be a current OR a superseded version id (or the logical_id == v1 id).
+  // Resolve to the current version via the stable logical_id (A2, #823).
   const resolvedId = data.resolveId("knowledge", id) ?? id;
-  const entry = ltm.get(resolvedId);
+  const entry =
+    ltm.get(resolvedId) ?? ltm.getByLogical(ltm.logicalIdOf(resolvedId));
   if (!entry)
     return errorResponse(404, "not_found", `Knowledge entry not found: ${id}`);
-  return jsonResponse(entry);
+  // Present the stable logical_id as the external id so a cached reference keeps
+  // resolving across version appends.
+  return jsonResponse({ ...entry, id: entry.logical_id });
 }
 
 function handleShowSession(url: URL, sessionId: string): Response {

--- a/packages/gateway/src/cli/data.ts
+++ b/packages/gateway/src/cli/data.ts
@@ -148,7 +148,7 @@ async function cmdList(
           truncate(e.title, 40),
           e.confidence.toFixed(2),
           formatDate(e.updated_at),
-          e.id.slice(0, 8),
+          e.logical_id.slice(0, 8), // stable id (A2): show/delete/move resolve by logical_id
         ]),
         [14, 40, 12, 20, 10],
       );
@@ -252,7 +252,8 @@ async function cmdShow(
   switch (type) {
     case "knowledge": {
       const id = data.resolveId("knowledge", rawId) ?? rawId;
-      const entry = ltm.get(id);
+      // Resolve to the current version via the stable logical_id (A2, #823).
+      const entry = ltm.get(id) ?? ltm.getByLogical(ltm.logicalIdOf(id));
       if (!entry) {
         console.error(`Knowledge entry not found: ${rawId}`);
         process.exit(1);
@@ -1392,7 +1393,7 @@ async function cmdListRemote(
           truncate(e.title, 40),
           e.confidence.toFixed(2),
           formatDate(e.updated_at),
-          e.id.slice(0, 8),
+          e.id.slice(0, 8), // remote API presents logical_id as id (A2)
         ]),
         [14, 40, 12, 20, 10],
       );

--- a/packages/gateway/src/sync.ts
+++ b/packages/gateway/src/sync.ts
@@ -147,7 +147,19 @@ async function pushEntry(
   e: syncData.OutboxEntry,
   res: SyncResult,
 ): Promise<PushOutcome> {
-  const { table_name: table, row_id: rowId, op } = e;
+  const { table_name: table, row_id: rowId } = e;
+  let op = e.op;
+
+  // A2 (#823): knowledge is append-only — update()/remove() append immutable
+  // versions and remove() emits no physical-delete op. Translate the version churn
+  // so the remote mirrors only the current LIVE version: a superseded or
+  // soft-deleted row becomes a remote soft-delete (propagating deletions + removing
+  // stale/redacted content), a current live row upserts. See knowledgeSyncOp.
+  if (table === "knowledge" && op === "upsert") {
+    const kop = syncData.knowledgeSyncOp(rowId);
+    if (kop === "skip") return "ok";
+    op = kop;
+  }
 
   if (op === "delete") {
     const { error } = await client

--- a/packages/gateway/src/ui.ts
+++ b/packages/gateway/src/ui.ts
@@ -53,6 +53,15 @@ import type { InterTurnHistogram, SessionState } from "./translate/types";
 import { resolveAuth } from "./auth";
 import { getQuotaForCredential, type QuotaSnapshot } from "./quota";
 
+/**
+ * Resolve a knowledge id from a (possibly stale) UI route/form — a current OR
+ * superseded version id, or a logical_id — to the current entry (A2, #823). A
+ * link captured before the curator appended a new version still resolves.
+ */
+function kget(id: string) {
+  return ltm.get(id) ?? ltm.getByLogical(ltm.logicalIdOf(id));
+}
+
 // ---------------------------------------------------------------------------
 // HTML template helpers
 // ---------------------------------------------------------------------------
@@ -1931,7 +1940,7 @@ async function pageUserKnowledge(): Promise<string> {
 }
 
 function pageKnowledge(id: string): string | null {
-  const entry = ltm.get(id);
+  const entry = kget(id);
   if (!entry) return null;
 
   const projName = entry.project_id ? projectName(entry.project_id) : null;
@@ -3526,8 +3535,8 @@ export async function handleUIRequest(
       "/ui/api/merge/knowledge/:survivingId/:sourceId",
     );
     if (mergeKnowledge) {
-      const surviving = ltm.get(mergeKnowledge.survivingId);
-      const source = ltm.get(mergeKnowledge.sourceId);
+      const surviving = kget(mergeKnowledge.survivingId);
+      const source = kget(mergeKnowledge.sourceId);
       if (surviving && source && surviving.id !== source.id) {
         // Parse form data before removal — source entry is deleted below.
         const formData = await req.formData();
@@ -3557,8 +3566,8 @@ export async function handleUIRequest(
       "/ui/api/dismiss/knowledge/:survivingId/:sourceId",
     );
     if (dismissKnowledge) {
-      const surviving = ltm.get(dismissKnowledge.survivingId);
-      const source = ltm.get(dismissKnowledge.sourceId);
+      const surviving = kget(dismissKnowledge.survivingId);
+      const source = kget(dismissKnowledge.sourceId);
       const formData = await req.formData();
       const similarity = Number.parseFloat(
         (formData.get("similarity") as string) || "",
@@ -3610,7 +3619,7 @@ export async function handleUIRequest(
     // Delete knowledge
     const delKnowledge = matchRoute(pathname, "/ui/api/delete/knowledge/:id");
     if (delKnowledge) {
-      const entry = ltm.get(delKnowledge.id);
+      const entry = kget(delKnowledge.id);
       data.deleteKnowledge(delKnowledge.id);
       if (entry?.cross_project || !entry?.project_id) {
         return redirect("/ui/knowledge");
@@ -3670,7 +3679,7 @@ export async function handleUIRequest(
         data.reassignKnowledge(moveKnowledge.id, targetPath);
       }
       // Redirect to the entry's updated page
-      const entry = ltm.get(moveKnowledge.id);
+      const entry = kget(moveKnowledge.id);
       if (entry?.project_id) {
         return redirect(`/ui/projects/${entry.project_id}`);
       }


### PR DESCRIPTION
**Part of epic #821 · A2 (#823), sub-PR 2b-2b — THE FLIP.** Builds on 2b-2a (#850). No migration (v51 landed in 2b-2a).

This is the behavior-change PR: knowledge **content is now immutable per version**. `update()`/`remove()` are rewired onto `appendVersion()`.

## Core flip
- **`update(id, {content})`** appends a new immutable version (confidence/metadata copied forward); **mutable-only** updates (`confidence`/`updated_by`/`sensitivity`) still mutate the current version in place. Re-embeds the new current version.
- **`remove(id)`** appends an `is_deleted` **death-certificate** version (no physical DELETE). The death cert *is* the tombstone + resurrection guard — `knowledge_current` excludes it, the FTS triggers drop its posting, `isTombstoned()` detects it. Since nothing is physically deleted, **FK `ON DELETE CASCADE` is dormant**, so `remove()` cleans entity refs / wiki refs / transfers **explicitly** by `logical_id`.
- **`isTombstoned()`** checks the death-cert version OR a legacy `knowledge_tombstones` row (pre-flip deletes). `remove()` no longer writes tombstones (the table is now read-only legacy).

## Identity resolution (the subtle part)
- **`logicalIdOf(id)`** — canonical resolver (base table): resolves a current OR **superseded** version id (or a logical_id) to the stable `logical_id`. `update`/`remove`/`syncRefs`/`resolveRef` and the curator route through it, so a `op.id` that `update()` just superseded stays correct.
- `appendVersion`'s current-row lookup moved **inside** the txn (Seer #850 TOCTOU NIT).
- **dedup** (`createWithStatus`) returns the stable `logical_id`, not the soon-superseded version id. The curator's dedup-merge path + update/delete handlers + ref-sync loop key on `logical_id` — fixes a real **dedup-merge undercount** (`result.updated` went to 0) the `curator-changed-entries` test caught. `_importEntries` passes the resolved current id (**Seer #848**).

## Gateway / data
- `handleShowKnowledge` / `deleteKnowledge` / `reassignKnowledge` resolve via `logicalIdOf`→`getByLogical` and present the **stable `logical_id`** as the external id (a cached UI reference keeps resolving across appends).
- `resolveId("knowledge")` matches the `logical_id` of **current** entries — the base-table prefix is now ambiguous (UUIDv7 versions share the timestamp prefix).
- `reassignKnowledge` moves **all** versions (`WHERE logical_id`) so a multi-version entry isn't split across projects (reviewer NIT).
- Bulk-op "entries affected" counts use `knowledge_current` (logical entries, not physical version rows).

## Tests
New **`ltm-flip.test.ts` (6)**: content-append vs mutable-in-place; death-cert + explicit ref cleanup (FK CASCADE dormant); `remove()` idempotency; multi-version chain with ref survival. Updated **9 existing suites** from in-place to append semantics (`get(id)`→`getByLogical(id)` once the row id moves). Full **core (1680) + gateway (1883) green**; typecheck + lint clean.

## Deferred (flagged)
- cleanDeadRefs content-strip is still an in-place UPDATE on the current version (locally correct; routing it through `appendVersion` matters for sync — sub-PR 3).
- Pre-existing `_importEntries` cross-project overwrite (security follow-up).
- Compaction FK-dangle on a v1-row prune (sub-PR 4 — #823 follow-up).

cc reviewer-session — this is the high-risk flip; the curator superseded-id bugs are the kind of thing worth a close look.