### PR TITLE
fix(core): adaptive token cap for local embedding OOM recovery

### DIFF
--- a/packages/core/src/embedding-cap.ts
+++ b/packages/core/src/embedding-cap.ts
@@ -121,12 +121,23 @@ export function shouldReprobeEmbedCap(
 /**
  * Compute the next cap for an upward re-probe: one gentle step up (the inverse
  * of the ×0.7 backoff ≈ ×1.43), bounded by what the memory model says the now-
- * larger free pool supports. Never steps *down* — if the model ceiling is below
- * the current cap (shouldn't happen once the gate has fired), the cap is left
- * unchanged. A too-optimistic step is corrected by the OOM backoff.
+ * larger free pool supports. Never steps *down* — if the ceiling is below the
+ * current cap, the cap is left unchanged. A too-optimistic step is corrected by
+ * the OOM backoff.
+ *
+ * `knownBadCap` (the highest cap that has OOMed in this process, 0 = none) is a
+ * hard ceiling: a rising `os.freemem()` does not guarantee the WASM heap can
+ * actually grow that far (fragmentation, racing allocations), so we never
+ * re-probe *up to or past* a cap that already failed. A process restart
+ * re-evaluates from scratch and can exceed it if memory genuinely grew.
  */
-export function reprobeEmbedCap(cap: number, freeBytes: number): number {
+export function reprobeEmbedCap(
+  cap: number,
+  freeBytes: number,
+  knownBadCap = 0,
+): number {
   const stepped = Math.round(cap / EMBED_BACKOFF_FACTOR);
-  const ceiling = memoryModelEmbedCap(freeBytes);
+  let ceiling = memoryModelEmbedCap(freeBytes);
+  if (knownBadCap > 0) ceiling = Math.min(ceiling, knownBadCap - 1);
   return clampEmbedCap(Math.max(cap, Math.min(stepped, ceiling)));
 }

--- a/packages/core/src/embedding-cap.ts
+++ b/packages/core/src/embedding-cap.ts
@@ -1,0 +1,132 @@
+/**
+ * Adaptive token-cap math for local ONNX embedding inference.
+ *
+ * Local inference OOMs on long inputs: the O(L²) attention tensor for a long
+ * sequence blows the WASM heap, and because WASM linear memory never shrinks,
+ * an in-process retry cannot recover. We instead cap the input sequence length
+ * up-front and adapt that cap to the host — start from a memory-aware estimate,
+ * and on each OOM lower the cap ×0.7 and respawn the worker on a fresh heap.
+ *
+ * This module holds the pure, dependency-free math so it can be unit-tested in
+ * isolation. The stateful pieces (persistence, worker lifecycle, telemetry)
+ * live in embedding.ts.
+ */
+
+/** Floor token cap. Below this, an OOM means system-wide memory exhaustion (a
+ *  256-token attention tensor is only ~3 MB), not input size — so the caller
+ *  stops backing off and latches FTS-only. */
+export const MIN_EMBED_TOKENS = 256;
+
+/** Nomic v1.5 max sequence length. The adaptive cap never exceeds this. */
+export const MODEL_MAX_TOKENS = 8192;
+
+/** Multiplicative backoff applied to the token cap on each OOM respawn. 0.7 on
+ *  tokens ≈ ×0.49 on the O(L²) attention memory per step — gentle enough to
+ *  converge near the true sustainable cap without overshooting downward. */
+export const EMBED_BACKOFF_FACTOR = 0.7;
+
+/** Fraction of free memory the worker's total footprint (model + peak
+ *  attention) may use when sizing the initial cap. Deliberately conservative:
+ *  on a constrained host a higher value risks tipping into swap (the exact
+ *  event-loop stall we're avoiding), and because embedding quality plateaus
+ *  above ~2048 tokens (single-vector embeddings of long text are diluted, and
+ *  recall chunks long content), a low cap costs almost nothing in quality. A
+ *  box that genuinely has headroom recovers via the freemem-gated re-probe; an
+ *  optimistic start is corrected by the ×0.7 backoff. */
+export const EMBED_MEM_FRACTION = 0.5;
+
+/** Free-memory ratio above `freememAtLearn` that re-arms an upward re-probe.
+ *  We only climb when there's evidence more memory is genuinely available —
+ *  distinguishing transient starvation (recoverable) from a real hardware
+ *  limit (free memory never improves → never re-probe). */
+export const EMBED_REPROBE_RATIO = 1.3;
+
+/** Approximate resident baseline (model weights + ORT runtime) subtracted from
+ *  free memory before sizing the transient allocation. ~400 MB. */
+export const EMBED_MODEL_BASELINE_BYTES = 400 * 1024 * 1024;
+
+/** Peak attention bytes per token²: n_heads (12) × 4 bytes/float × ~4 buffer
+ *  overhead ≈ 192. The dominant inference allocation is the O(L²) attention
+ *  tensor, so peakBytes ≈ K · L². Physical constants with a conservative
+ *  overhead factor; the backoff corrects any residual estimation error. */
+export const EMBED_ATTENTION_BYTES_PER_TOKEN_SQ = 192;
+
+/** Free-memory ratio band within which a persisted learned cap is trusted
+ *  as-is (i.e. memory is "close enough" to learn-time to skip re-converging). */
+export const EMBED_CAP_TRUST_BAND = 0.25;
+
+/** Persisted learned cap + the free memory at learn time (kv_meta JSON). */
+export interface PersistedEmbedCap {
+  cap: number;
+  freeMemBytes: number;
+}
+
+/** Clamp a raw cap estimate into the valid [MIN, MODEL_MAX] range. */
+export function clampEmbedCap(n: number): number {
+  if (!Number.isFinite(n)) return MIN_EMBED_TOKENS;
+  return Math.max(MIN_EMBED_TOKENS, Math.min(MODEL_MAX_TOKENS, Math.round(n)));
+}
+
+/** Lower the cap one backoff step, never below the floor. */
+export function backoffEmbedCap(cap: number): number {
+  return Math.max(Math.round(cap * EMBED_BACKOFF_FACTOR), MIN_EMBED_TOKENS);
+}
+
+/** Size the token cap from free memory and the O(L²) attention model. */
+export function memoryModelEmbedCap(freeBytes: number): number {
+  const budget = Math.max(
+    freeBytes * EMBED_MEM_FRACTION - EMBED_MODEL_BASELINE_BYTES,
+    0,
+  );
+  return clampEmbedCap(Math.sqrt(budget / EMBED_ATTENTION_BYTES_PER_TOKEN_SQ));
+}
+
+/**
+ * Reconcile a freshly computed model cap with any persisted learned cap. When
+ * current free memory is close to what it was at learn time, trust the learned
+ * cap (avoids re-walking the backoff every restart — the "recurs on every
+ * restart" failure). When memory has materially grown, re-probe upward via the
+ * model; when it has materially shrunk, take the safer of model vs learned.
+ */
+export function reconcileEmbedCap(
+  freeBytes: number,
+  stored: PersistedEmbedCap | null,
+  modelCap: number,
+): number {
+  if (!stored) return modelCap;
+  const ratio = stored.freeMemBytes > 0 ? freeBytes / stored.freeMemBytes : 1;
+  if (ratio >= 1 - EMBED_CAP_TRUST_BAND && ratio <= 1 + EMBED_CAP_TRUST_BAND) {
+    return clampEmbedCap(stored.cap);
+  }
+  return freeBytes > stored.freeMemBytes
+    ? modelCap
+    : clampEmbedCap(Math.min(modelCap, stored.cap));
+}
+
+/**
+ * Whether free memory has recovered enough since the cap was learned to justify
+ * an upward re-probe. Guards against a non-positive learn-time baseline. This is
+ * the gate that prevents a cap learned during a transient RAM-starved moment
+ * from staying low forever within a long-running process.
+ */
+export function shouldReprobeEmbedCap(
+  freeBytes: number,
+  freememAtLearn: number,
+): boolean {
+  return (
+    freememAtLearn > 0 && freeBytes >= freememAtLearn * EMBED_REPROBE_RATIO
+  );
+}
+
+/**
+ * Compute the next cap for an upward re-probe: one gentle step up (the inverse
+ * of the ×0.7 backoff ≈ ×1.43), bounded by what the memory model says the now-
+ * larger free pool supports. Never steps *down* — if the model ceiling is below
+ * the current cap (shouldn't happen once the gate has fired), the cap is left
+ * unchanged. A too-optimistic step is corrected by the OOM backoff.
+ */
+export function reprobeEmbedCap(cap: number, freeBytes: number): number {
+  const stepped = Math.round(cap / EMBED_BACKOFF_FACTOR);
+  const ceiling = memoryModelEmbedCap(freeBytes);
+  return clampEmbedCap(Math.max(cap, Math.min(stepped, ceiling)));
+}

--- a/packages/core/src/embedding-worker-types.ts
+++ b/packages/core/src/embedding-worker-types.ts
@@ -25,6 +25,11 @@ export interface EmbedRequest {
   inputType: "document" | "query";
   /** "high" = recall queries (jump the queue), "normal" = backfill. */
   priority: "high" | "normal";
+  /** Per-request override of the worker's token cap. Lets the main thread
+   *  RAISE the cap (after a freemem-gated re-probe) without respawning the
+   *  worker. Falls back to the workerData cap when absent. OOM-driven cap
+   *  LOWERING still respawns (fresh heap); only upward nudges ride this. */
+  maxTokens?: number;
 }
 
 /** Ask the worker to exit cleanly. */
@@ -68,6 +73,20 @@ export interface InitError {
 export type WorkerOutbound = EmbedResult | EmbedError | InitError;
 
 // ---------------------------------------------------------------------------
+// Worker exit codes
+// ---------------------------------------------------------------------------
+
+/**
+ * Worker process exit code signalling an input-size-driven ONNX OOM that is
+ * recoverable by respawning with a lower token cap (fresh WASM heap). The main
+ * thread's `on("exit")` handler distinguishes this from a genuine fatal exit
+ * (code 1) and drives the halve-and-respawn backoff (see `LocalProvider` in
+ * embedding.ts) instead of latching the provider broken. Picked in the
+ * application-defined range, clear of Node's own conventions (0, 1, 128+n).
+ */
+export const EMBED_OOM_EXIT_CODE = 75;
+
+// ---------------------------------------------------------------------------
 // Error classification — shared between worker and main thread
 // ---------------------------------------------------------------------------
 // These functions classify ONNX/WASM error messages. Both the worker
@@ -96,10 +115,20 @@ export function isOomError(msg: string): boolean {
  *   - WASM `abort()` calls ("Aborted(). Build with -sASSERTIONS...")
  *   - WASM RuntimeError ("unreachable", "memory access out of bounds")
  *   - ONNX runtime allocation failures (opaque numeric error codes like
- *     "284792864" ≈ 271 MiB). These represent model-init allocations
- *     that cannot succeed with smaller input — retrying is futile.
+ *     "284792864" ≈ 271 MiB).
  *
- * After detecting a fatal error, the worker should exit so the main
+ * Note on OOM: numeric ORT allocation failures are predominantly
+ * *inference-time, input-size-driven* — a long sequence's O(L²) attention
+ * tensor blows the WASM heap. They are NOT model-init failures. They look
+ * unrecoverable to an *in-process* retry only because WASM linear memory
+ * never shrinks: once the first oversized allocation grows the heap, every
+ * smaller retry in the same worker also fails. The real recovery is to
+ * respawn the worker (fresh heap) at a lower token cap — driven by the
+ * `EMBED_OOM_EXIT_CODE` backoff in embedding.ts, not by in-process truncation.
+ * `isWasmFatalError` still returns true for OOM as a defensive backstop for
+ * any OOM that surfaces as a *posted* error rather than the exit-code path.
+ *
+ * After detecting a genuinely fatal error, the worker exits so the main
  * thread's `on("exit")` handler marks the provider as broken.
  */
 export function isWasmFatalError(msg: string): boolean {
@@ -113,8 +142,10 @@ export function isWasmFatalError(msg: string): boolean {
   // RuntimeError from WASM (e.g. "unreachable", "memory access out of bounds")
   if (/\bRuntimeError\b/.test(msg)) return true;
   // ONNX runtime allocation failures — opaque numeric codes (e.g. "284792864").
-  // These are model-init-time OOMs, not input-size-driven, so truncation
-  // retries cannot help. Treat as fatal to stop the event storm.
+  // Defensive backstop only: the primary OOM path exits with
+  // EMBED_OOM_EXIT_CODE and is handled by the halve-and-respawn backoff. This
+  // classifies any OOM that surfaces as a *posted* error as fatal so a stray
+  // OOM message still degrades cleanly instead of re-creating an event storm.
   if (isOomError(msg)) return true;
   // Callable-pattern failure safety net (LOREAI-GATEWAY-10):
   // @huggingface/transformers uses Object.setPrototypeOf to make pipeline
@@ -225,6 +256,14 @@ export interface WorkerInitData {
   /** Target embedding dimensions. For Nomic v1.5 with Matryoshka,
    *  this controls how many leading dims to keep (64–768). */
   dimensions: number;
+  /** Maximum input sequence length (in tokens) the worker will feed to the
+   *  model. Every batch is truncated to this ceiling (real tokenizer) before
+   *  the single inference attempt. Owned and adapted by the main thread
+   *  (LocalProvider): it starts at a memory-aware estimate and is lowered ×0.7
+   *  on each fresh-heap respawn after an OOM. Capping sequence length up-front
+   *  bounds the O(L²) attention allocation and keeps a constrained host out of
+   *  swap. */
+  maxTokens: number;
   /** Vendored model info for binary mode, or null for npm mode.
    *  In binary mode, model files are pre-extracted to a local dir
    *  and we point transformers.js at that path instead of downloading

--- a/packages/core/src/embedding-worker.ts
+++ b/packages/core/src/embedding-worker.ts
@@ -40,21 +40,27 @@ if (!parentPort) {
 }
 const port = parentPort;
 
-const { modelId, dimensions, vendorModel } = workerData as WorkerInitData;
+const init = workerData as WorkerInitData;
+const { modelId, dimensions, vendorModel } = init;
 
 /**
- * Token ceiling used when retrying after an ONNX OOM. We don't pre-truncate
- * every request — most texts are fine at their natural length. Instead, on
- * OOM we retry with progressively halved token limits starting from this
- * value. The pipeline's built-in `truncation: true` caps at model_max_length
- * (8192 for Nomic v1.5), which is too high for ONNX to allocate safely.
+ * Main-thread-owned input token cap (see `WorkerInitData.maxTokens`). Every
+ * batch is truncated to this ceiling (real tokenizer) before the single
+ * inference attempt, bounding the O(L²) attention allocation that drives ONNX
+ * OOMs. The main thread lowers it ×0.7 and respawns this worker (fresh heap)
+ * on each OOM. Falls back to a conservative default only if an older caller
+ * omits it.
  */
-const OOM_RETRY_START_TOKENS = 4096;
+const maxTokens = init.maxTokens ?? 2048;
 
-/** Maximum number of OOM retry attempts (including the initial full-length
- *  try). On OOM the token limit halves each retry: full → 4096 → 2048 → 1024.
- *  Three truncated retries covers extreme cases. */
-const OOM_MAX_RETRIES = 3;
+/**
+ * Worker exit code signalling an input-size-driven ONNX OOM that the main
+ * thread recovers from by respawning at a lower token cap (fresh WASM heap).
+ * Inlined here — kept in sync with embedding-worker-types.ts — because the
+ * worker is spawned by Node's native resolver, which can't map "./foo.js" →
+ * "./foo.ts" for runtime (value) imports.
+ */
+const EMBED_OOM_EXIT_CODE = 75;
 
 // ---------------------------------------------------------------------------
 // Error classifiers — inlined to keep the worker self-contained.
@@ -489,67 +495,43 @@ async function processEmbed(req: EmbedRequest): Promise<void> {
   try {
     await ensurePipeline();
 
-    // Try inference at full length first. On ONNX OOM, retry with
-    // progressively halved token limits using the real tokenizer.
-    // This preserves maximum semantic content for normal texts while
-    // handling dense-token content (code, CJK, base64) adaptively.
-    //
-    // attempt 0 = original texts (no truncation)
-    // attempt 1 = truncated to 4096 tokens
-    // attempt 2 = truncated to 2048 tokens
-    // attempt 3 = truncated to 1024 tokens
-    let texts = req.texts;
-    let lastError: Error | undefined;
-
-    for (let attempt = 0; attempt <= OOM_MAX_RETRIES; attempt++) {
-      try {
-        const vectors = await runInference(texts);
-        post({ type: "result", id: req.id, vectors });
-        return;
-      } catch (err) {
-        const raw = err instanceof Error ? err.message : String(err);
-        if (!isOomError(raw) || !tokenizer) throw err;
-        lastError = err instanceof Error ? err : new Error(raw);
-
-        // If all texts are already shorter than the smallest retry ceiling
-        // (1024 tokens ≈ chars at worst-case 1:1 ratio), truncation cannot
-        // help — the OOM is a model-init/runtime allocation failure, not
-        // input-size-driven. Throw immediately to reach the fatal exit path.
-        const smallestRetryLimit =
-          OOM_RETRY_START_TOKENS >> (OOM_MAX_RETRIES - 1); // 1024
-        const longestText = Math.max(...req.texts.map((t) => t.length));
-        if (longestText <= smallestRetryLimit) {
-          throw lastError;
-        }
-
-        // OOM — truncate texts and retry with fewer tokens.
-        // attempt 0 failed at full length → retry at 4096 tokens
-        // attempt 1 failed at 4096       → retry at 2048 tokens
-        // attempt 2 failed at 2048       → retry at 1024 tokens
-        // attempt 3 failed at 1024       → loop exits, throw below
-        if (attempt < OOM_MAX_RETRIES) {
-          const maxTokens = OOM_RETRY_START_TOKENS >> attempt; // 4096, 2048, 1024
-          texts = truncateTexts(req.texts, maxTokens);
-          console.warn(
-            `[lore] ONNX OOM on attempt ${attempt + 1}, retrying with ≤${maxTokens} tokens ` +
-              `(batch=${req.texts.length}, longest≈${Math.max(...req.texts.map((t) => t.length))} chars)`,
-          );
-        }
-      }
-    }
-
-    // All retries exhausted — report the last error.
-    throw lastError ?? new Error("ONNX OOM retries exhausted");
+    // Truncate to the main-thread-owned token cap BEFORE the single inference
+    // attempt. The cap is memory-aware and is lowered ×0.7 per fresh-heap
+    // respawn (see LocalProvider in embedding.ts). We deliberately do NOT
+    // retry in-process on OOM: WASM linear memory never shrinks, so a smaller
+    // retry in this same worker allocates against an already-exhausted/
+    // fragmented heap and fails too. Instead we exit with EMBED_OOM_EXIT_CODE
+    // so the main thread respawns us (fresh heap) at a lower cap and
+    // re-submits the request.
+    // Per-request cap (an upward re-probe) overrides the workerData default.
+    const effectiveMax = req.maxTokens ?? maxTokens;
+    const texts = truncateTexts(req.texts, effectiveMax);
+    const vectors = await runInference(texts);
+    post({ type: "result", id: req.id, vectors });
   } catch (err) {
     // Don't re-post init-error — it was already sent in ensurePipeline().
     if (!initFailed) {
       const raw = err instanceof Error ? err.message : String(err);
+      const longest = Math.max(...req.texts.map((t) => t.length));
+      const effectiveMax = req.maxTokens ?? maxTokens;
 
-      // Fatal WASM errors (e.g. "Aborted()") leave the ONNX runtime in an
-      // unrecoverable state — every subsequent request would also fail,
-      // generating unbounded Sentry events. Report the error for this
-      // request and exit the worker so the main thread marks the provider
-      // as broken and stops sending work.
+      // Input-size-driven OOM → recoverable. Exit with the dedicated code so
+      // the main thread drives the halve-and-respawn backoff (fresh heap,
+      // lower cap, then re-submit). We do NOT post an error first: that would
+      // reject the request before the backoff can re-submit it. The main
+      // thread reconstructs OOM context from the pending request for telemetry.
+      if (isOomError(raw)) {
+        console.warn(
+          `[lore] ONNX OOM at ≤${effectiveMax} tokens (batch=${req.texts.length}, ` +
+            `longest≈${longest} chars) — respawning worker at a lower cap`,
+        );
+        process.exit(EMBED_OOM_EXIT_CODE);
+        return; // unreachable, but makes intent clear
+      }
+
+      // Genuine fatal WASM error (Aborted/RuntimeError/non-callable) — not
+      // input-size-driven, so respawning won't help. Report this request and
+      // exit(1) so the main thread latches the provider broken.
       if (isWasmFatalError(raw)) {
         post({
           type: "error",
@@ -560,13 +542,8 @@ async function processEmbed(req: EmbedRequest): Promise<void> {
         return; // unreachable, but makes intent clear
       }
 
-      const msg = isOomError(raw)
-        ? `ONNX runtime out of memory after ${OOM_MAX_RETRIES} retries ` +
-          `(batch=${req.texts.length}, ` +
-          `longest≈${Math.max(...req.texts.map((t) => t.length))} chars). ` +
-          `Raw: ${raw}`
-        : raw;
-      post({ type: "error", id: req.id, error: msg });
+      // Non-fatal per-request error — reject just this request, keep serving.
+      post({ type: "error", id: req.id, error: raw });
     }
   } finally {
     inflight--;

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -419,6 +419,10 @@ class LocalProvider implements EmbeddingProvider {
   private capFreememAtLearn: number;
   /** Timestamp (ms) of the last upward re-probe check, for throttling. */
   private lastReprobeAt = 0;
+  /** Highest cap (tokens) that has OOMed in this process, or 0 if none. The
+   *  upward re-probe never climbs to or past it — a rising os.freemem() does not
+   *  prove the WASM heap can grow that far. Cleared only by a process restart. */
+  private lastOomCap = 0;
 
   constructor(modelId: string, dimensions: number) {
     this.modelId = modelId;
@@ -660,7 +664,7 @@ class LocalProvider implements EmbeddingProvider {
     this.lastReprobeAt = now;
     const free = freemem();
     if (!shouldReprobeEmbedCap(free, this.capFreememAtLearn)) return;
-    const next = reprobeEmbedCap(this.maxTokens, free);
+    const next = reprobeEmbedCap(this.maxTokens, free, this.lastOomCap);
     if (next <= this.maxTokens) return;
     const prev = this.maxTokens;
     this.maxTokens = next;
@@ -731,6 +735,10 @@ class LocalProvider implements EmbeddingProvider {
     const free = freemem();
     const capAfter = backoffEmbedCap(capBefore);
     this.maxTokens = capAfter;
+    // Remember the cap that just OOMed so the upward re-probe never climbs back
+    // to or past it within this process (a rising freemem doesn't prove the
+    // heap can grow that far).
+    this.lastOomCap = Math.max(this.lastOomCap, capBefore);
     // Anchor the re-probe baseline at OOM-time free memory: only climb back up
     // once memory has genuinely recovered (≥ EMBED_REPROBE_RATIO × this).
     this.capFreememAtLearn = free;
@@ -759,11 +767,24 @@ class LocalProvider implements EmbeddingProvider {
     try {
       await this.ensureWorker();
     } catch {
-      // Respawn failed — ensureWorker()'s handlers already rejected pending.
+      // A *synchronous* respawn failure (e.g. `new Worker(...)` throws) rejects
+      // initPromise before any worker event handler is attached, so nothing
+      // else will ever settle these requests. Reject them here to avoid a hung
+      // caller — the local embed path has no timeout. (Asynchronous spawn
+      // failures are already settled by the worker error/exit/init-error
+      // handlers, which clear the map, so this loop is then a no-op.)
+      for (const [, p] of this.pendingRequests) {
+        p.reject(
+          new LocalProviderUnavailableError(
+            "embedding worker respawn failed after OOM backoff",
+          ),
+        );
+      }
+      this.pendingRequests.clear();
       return;
     }
     const worker = this.worker;
-    if (!worker) return; // raced with another exit
+    if (!worker) return; // raced with another exit — that handler owns pending
     for (const [, p] of this.pendingRequests) {
       // Re-submit at the lowered cap so the retry doesn't re-OOM at the old one.
       p.payload.maxTokens = this.maxTokens;

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -13,12 +13,25 @@
  * back silently to FTS-only when unavailable.
  */
 
+import { freemem } from "node:os";
 import { db } from "./db";
 import { config } from "./config";
 import * as log from "./log";
 import { vendorModelInfo } from "./embedding-vendor";
 import {
+  MIN_EMBED_TOKENS,
+  MODEL_MAX_TOKENS,
+  backoffEmbedCap,
+  memoryModelEmbedCap,
+  reconcileEmbedCap,
+  reprobeEmbedCap,
+  shouldReprobeEmbedCap,
+  type PersistedEmbedCap,
+} from "./embedding-cap";
+import {
+  EMBED_OOM_EXIT_CODE,
   isWasmFatalError,
+  type EmbedRequest,
   type WorkerInbound,
   type WorkerOutbound,
   type WorkerInitData,
@@ -35,16 +48,91 @@ const EMBED_TIMEOUT_MS = 10_000;
  *  before it can exit — without this cap that could block process exit. */
 const WORKER_SHUTDOWN_TIMEOUT_MS = 1_500;
 
+// ---------------------------------------------------------------------------
+// Adaptive local-embedding token cap — persistence
+// ---------------------------------------------------------------------------
+// Pure cap math (memory model, clamp, backoff, reconcile) lives in
+// embedding-cap.ts so it can be unit-tested in isolation. Here we keep only the
+// db-backed persistence and the worker-lifecycle glue.
+
+/** kv_meta key for the persisted learned cap + the free memory at learn time. */
+const EMBED_CAP_KV_KEY = "lore:embedding_cap";
+
+/** Minimum interval between upward cap re-probe checks. Throttles the freemem
+ *  read + comparison so embed() stays cheap; the cap only needs to be right
+ *  when work is actively flowing, so checking on embed() is sufficient. */
+const EMBED_REPROBE_INTERVAL_MS = 5 * 60_000;
+
+function readPersistedEmbedCap(): PersistedEmbedCap | null {
+  try {
+    const row = db()
+      .query("SELECT value FROM kv_meta WHERE key = ?")
+      .get(EMBED_CAP_KV_KEY) as { value: string } | null;
+    if (!row) return null;
+    const parsed = JSON.parse(row.value) as Partial<PersistedEmbedCap>;
+    if (
+      typeof parsed.cap !== "number" ||
+      typeof parsed.freeMemBytes !== "number"
+    ) {
+      return null;
+    }
+    return { cap: parsed.cap, freeMemBytes: parsed.freeMemBytes };
+  } catch {
+    return null;
+  }
+}
+
+function persistEmbedCap(cap: number, freeMemBytes: number = freemem()): void {
+  try {
+    const value = JSON.stringify({
+      cap,
+      freeMemBytes,
+    } satisfies PersistedEmbedCap);
+    db()
+      .query(
+        "INSERT INTO kv_meta (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = ?",
+      )
+      .run(EMBED_CAP_KV_KEY, value, value);
+  } catch {
+    // Best-effort: a failure just means we re-derive the cap next start.
+  }
+}
+
 /**
- * Safe per-text character limit for local ONNX inference. The Nomic v1.5 model
- * supports up to 8192 tokens, but ONNX runtime OOMs on inputs near that ceiling
- * (error codes 284432024, 287180544, 144786472). Pre-truncating to ~4096 tokens
- * worth of characters keeps the tensor well within safe allocation bounds for
- * typical English text (~4 chars/token). For dense-token content (code, CJK,
- * base64) where the ratio is lower, the worker retries with token-level
- * truncation on OOM — see OOM_RETRY_START_TOKENS in embedding-worker.ts.
+ * Compute the token cap to (re)start a worker with. Prefers a learned,
+ * persisted cap when current free memory is close to what it was learned at —
+ * this avoids re-walking the backoff on every process restart (the "recurs on
+ * every restart" failure). Otherwise it sizes from the memory model and
+ * current free memory; a materially larger free pool lets the cap re-probe
+ * upward on restart (in lieu of continuous additive increase). Always clamped.
  */
-const LOCAL_MAX_CHARS = 4096 * 4; // ~4096 tokens × ~4 chars/token
+function computeInitialEmbedCap(): number {
+  const free = freemem();
+  return reconcileEmbedCap(
+    free,
+    readPersistedEmbedCap(),
+    memoryModelEmbedCap(free),
+  );
+}
+
+/** For tests: persist a learned embedding cap (kv_meta round-trip). */
+export function _persistEmbedCap(cap: number): void {
+  persistEmbedCap(cap);
+}
+
+/** For tests: read the persisted embedding cap (or null when absent/corrupt). */
+export function _readPersistedEmbedCap(): PersistedEmbedCap | null {
+  return readPersistedEmbedCap();
+}
+
+/**
+ * Coarse per-text character bound applied before a text is cloned across the
+ * worker boundary — only a payload-size guard. The real, memory-aware token
+ * cap is applied inside the worker (`WorkerInitData.maxTokens`). Sized at the
+ * model's max sequence length so it never caps below what a healthy host could
+ * embed.
+ */
+const LOCAL_MAX_CHARS = MODEL_MAX_TOKENS * 4; // ~8192 tokens × ~4 chars/token
 
 /**
  * Truncate a string to LOCAL_MAX_CHARS without splitting a UTF-16 surrogate pair.
@@ -56,6 +144,52 @@ function safeLocalTruncate(text: string): string {
   const code = text.charCodeAt(end - 1);
   if (code >= 0xd800 && code <= 0xdbff) end--; // don't split surrogate pair
   return text.slice(0, end);
+}
+
+// ---------------------------------------------------------------------------
+// Embedding failure telemetry hook (wired by the gateway to Sentry)
+// ---------------------------------------------------------------------------
+
+/** Context for an embedding-worker memory failure, surfaced to an optional host
+ *  telemetry hook. @loreai/core stays Sentry-free; the gateway wires this up. */
+export interface EmbeddingFailureInfo {
+  /** "oom-backoff" = recovered by lowering the cap + respawning;
+   *  "floor-latch" = hit MIN_EMBED_TOKENS and degraded to FTS-only. */
+  kind: "oom-backoff" | "floor-latch";
+  capBefore: number;
+  capAfter: number;
+  /** Number of in-flight requests at the time of the OOM. */
+  batchSize: number;
+  /** Longest input text (chars) among in-flight requests. */
+  longestChars: number;
+  freeMemBytes: number;
+  rssBytes: number;
+}
+
+let embeddingFailureHook: ((info: EmbeddingFailureInfo) => void) | null = null;
+
+/** Register a host telemetry hook fired on embedding-worker OOM backoff/latch.
+ *  Pass null to clear. The hook must not throw; errors are swallowed. */
+export function setEmbeddingFailureHook(
+  fn: ((info: EmbeddingFailureInfo) => void) | null,
+): void {
+  embeddingFailureHook = fn;
+}
+
+function fireEmbeddingFailure(
+  info: Omit<EmbeddingFailureInfo, "freeMemBytes" | "rssBytes">,
+): void {
+  const hook = embeddingFailureHook;
+  if (!hook) return;
+  try {
+    hook({
+      ...info,
+      freeMemBytes: freemem(),
+      rssBytes: process.memoryUsage().rss,
+    });
+  } catch {
+    // Telemetry must never break the embedding path.
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -265,16 +399,32 @@ class LocalProvider implements EmbeddingProvider {
     {
       resolve: (vectors: Float32Array[]) => void;
       reject: (error: Error) => void;
+      /** Original request payload, retained so it can be re-submitted to a
+       *  freshly respawned worker after an OOM backoff (fresh WASM heap). */
+      payload: EmbedRequest;
     }
   >();
   private nextRequestId = 0;
   private initPromise: Promise<void> | null = null;
   private modelId: string;
   private dimensions: number;
+  /** Memory-aware input token cap, owned by the main thread and passed to the
+   *  worker via workerData. Lowered ×0.7 per OOM respawn; persisted so restarts
+   *  start at the learned value instead of re-walking the backoff. */
+  private maxTokens: number;
+  /** Free memory (bytes) when `maxTokens` was last (re)learned. The upward
+   *  re-probe only fires when current free memory exceeds this by
+   *  EMBED_REPROBE_RATIO — i.e. when memory has genuinely recovered, which
+   *  distinguishes transient starvation from a real hardware limit. */
+  private capFreememAtLearn: number;
+  /** Timestamp (ms) of the last upward re-probe check, for throttling. */
+  private lastReprobeAt = 0;
 
   constructor(modelId: string, dimensions: number) {
     this.modelId = modelId;
     this.dimensions = dimensions;
+    this.maxTokens = computeInitialEmbedCap();
+    this.capFreememAtLearn = freemem();
   }
 
   /**
@@ -315,6 +465,7 @@ class LocalProvider implements EmbeddingProvider {
       const workerInitData: WorkerInitData = {
         modelId: this.modelId,
         dimensions: this.dimensions,
+        maxTokens: this.maxTokens,
         vendorModel: vendor ? { localModelPath: vendor.localModelPath } : null,
       };
 
@@ -442,19 +593,30 @@ class LocalProvider implements EmbeddingProvider {
       });
 
       this.worker.on("exit", (code) => {
-        if (code !== 0 && !this.workerInitError) {
-          this.workerInitError = `embedding worker exited with code ${code}`;
-          log.error(this.workerInitError, new Error(this.workerInitError));
-        }
-        // Latch the provider as permanently broken on non-zero exit so
-        // future ensureWorker() calls fast-fail instead of respawning a
-        // worker that will just OOM/crash again (event storm prevention).
-        if (code !== 0) {
-          localProviderKnownBroken = true;
-        }
         this.workerReady = false;
         this.worker = null;
         this.initPromise = null;
+
+        // Input-size-driven OOM: recover by respawning at a lower token cap on
+        // a fresh WASM heap (an in-process retry can't — WASM memory never
+        // shrinks), then re-submit the in-flight requests. Bounded: the cap
+        // backs off ×0.7 down to MIN_EMBED_TOKENS, at which point we latch
+        // FTS-only — so this can never loop unbounded (no event storm).
+        if (code === EMBED_OOM_EXIT_CODE) {
+          this.handleOomBackoff();
+          return;
+        }
+
+        // Any other non-zero exit is a genuine fatal crash — latch the
+        // provider broken so future ensureWorker() calls fast-fail instead of
+        // respawning a worker that will just crash again (event-storm guard).
+        if (code !== 0) {
+          if (!this.workerInitError) {
+            this.workerInitError = `embedding worker exited with code ${code}`;
+            log.error(this.workerInitError, new Error(this.workerInitError));
+          }
+          localProviderKnownBroken = true;
+        }
         for (const [, p] of this.pendingRequests) {
           p.reject(
             new LocalProviderUnavailableError(
@@ -486,11 +648,143 @@ class LocalProvider implements EmbeddingProvider {
     }
   }
 
+  /** Throttled upward re-probe: when free memory has recovered past
+   *  EMBED_REPROBE_RATIO × the level at which the current cap was learned, step
+   *  the cap up one notch (bounded by the memory model for the now-larger pool)
+   *  and persist. Applied via the per-request cap, so it takes effect on the
+   *  next request without respawning the worker. An optimistic step is
+   *  corrected by the OOM backoff. */
+  private maybeReprobeCap(): void {
+    const now = Date.now();
+    if (now - this.lastReprobeAt < EMBED_REPROBE_INTERVAL_MS) return;
+    this.lastReprobeAt = now;
+    const free = freemem();
+    if (!shouldReprobeEmbedCap(free, this.capFreememAtLearn)) return;
+    const next = reprobeEmbedCap(this.maxTokens, free);
+    if (next <= this.maxTokens) return;
+    const prev = this.maxTokens;
+    this.maxTokens = next;
+    this.capFreememAtLearn = free;
+    persistEmbedCap(next, free);
+    log.info(
+      `embedding cap re-probed up: ≤${prev} → ≤${next} tokens (free memory recovered)`,
+    );
+  }
+
+  /** Aggregate OOM context across in-flight requests for telemetry. We don't
+   *  know which request OOMed (the worker exits without posting), so report the
+   *  worst-case longest text and the in-flight count. */
+  private pendingOomContext(): { batchSize: number; longestChars: number } {
+    let batchSize = 0;
+    let longestChars = 0;
+    for (const [, p] of this.pendingRequests) {
+      batchSize++;
+      for (const t of p.payload.texts) {
+        if (t.length > longestChars) longestChars = t.length;
+      }
+    }
+    return { batchSize, longestChars };
+  }
+
+  /**
+   * Handle an OOM-signalled worker exit: lower the token cap ×0.7, persist it,
+   * and respawn (fresh heap) to re-run the in-flight requests. At the floor we
+   * give up and latch FTS-only. The worker is already nulled by the exit
+   * handler before this runs.
+   */
+  private handleOomBackoff(): void {
+    const capBefore = this.maxTokens;
+    const { batchSize, longestChars } = this.pendingOomContext();
+
+    if (capBefore <= MIN_EMBED_TOKENS) {
+      // Already at the floor and still OOMing → the host genuinely can't run
+      // local embeddings (system-wide exhaustion, not input size). Latch
+      // FTS-only and surface the remote-provider hint.
+      localProviderKnownBroken = true;
+      if (!localProviderErrorLogged) {
+        localProviderErrorLogged = true;
+        log.error(
+          `local embedding provider out of memory even at the ${MIN_EMBED_TOKENS}-token floor — ` +
+            `degrading to FTS-only search. Set search.embeddings.provider to 'voyage' or 'openai' ` +
+            `in .lore.json (with VOYAGE_API_KEY / OPENAI_API_KEY) for a remote provider.`,
+          new Error("embedding OOM at floor"),
+        );
+      }
+      fireEmbeddingFailure({
+        kind: "floor-latch",
+        capBefore,
+        capAfter: capBefore,
+        batchSize,
+        longestChars,
+      });
+      for (const [, p] of this.pendingRequests) {
+        p.reject(
+          new LocalProviderUnavailableError(
+            "embedding worker out of memory at the token floor",
+          ),
+        );
+      }
+      this.pendingRequests.clear();
+      return;
+    }
+
+    const free = freemem();
+    const capAfter = backoffEmbedCap(capBefore);
+    this.maxTokens = capAfter;
+    // Anchor the re-probe baseline at OOM-time free memory: only climb back up
+    // once memory has genuinely recovered (≥ EMBED_REPROBE_RATIO × this).
+    this.capFreememAtLearn = free;
+    persistEmbedCap(capAfter, free);
+    log.info(
+      `embedding worker OOM at ≤${capBefore} tokens — backing off to ≤${capAfter} ` +
+        `and respawning on a fresh heap (${batchSize} in-flight, longest≈${longestChars} chars)`,
+    );
+    fireEmbeddingFailure({
+      kind: "oom-backoff",
+      capBefore,
+      capAfter,
+      batchSize,
+      longestChars,
+    });
+
+    // Respawn and re-submit. Fire-and-forget: ensureWorker()'s own handlers
+    // reject pending if the respawn itself fails.
+    void this.resubmitPending();
+  }
+
+  /** Respawn the worker (at the already-lowered cap) and re-post every
+   *  in-flight request so the OOM backoff is transparent to callers. */
+  private async resubmitPending(): Promise<void> {
+    if (this.pendingRequests.size === 0) return;
+    try {
+      await this.ensureWorker();
+    } catch {
+      // Respawn failed — ensureWorker()'s handlers already rejected pending.
+      return;
+    }
+    const worker = this.worker;
+    if (!worker) return; // raced with another exit
+    for (const [, p] of this.pendingRequests) {
+      // Re-submit at the lowered cap so the retry doesn't re-OOM at the old one.
+      p.payload.maxTokens = this.maxTokens;
+      try {
+        worker.postMessage(p.payload satisfies WorkerInbound);
+      } catch {
+        // Worker died again between ensureWorker() and here — its exit handler
+        // drives the next backoff/latch. Leave pending in place.
+      }
+    }
+    this.updateWorkerRef();
+  }
+
   async embed(
     texts: string[],
     inputType: "document" | "query",
   ): Promise<Float32Array[]> {
     await this.ensureWorker();
+    // Opportunistically raise the cap if free memory has recovered (cheap,
+    // throttled). Takes effect via the per-request cap below — no respawn.
+    this.maybeReprobeCap();
 
     // Pre-truncate texts that exceed the safe ONNX inference limit.
     // This prevents OOM on single inputs near the model's 8192-token max.
@@ -507,17 +801,20 @@ class LocalProvider implements EmbeddingProvider {
     const priority =
       inputType === "query" && texts.length === 1 ? "high" : "normal";
 
+    const payload: EmbedRequest = {
+      type: "embed",
+      id,
+      texts: prefixed,
+      inputType,
+      priority,
+      maxTokens: this.maxTokens,
+    };
+
     return new Promise<Float32Array[]>((resolve, reject) => {
-      this.pendingRequests.set(id, { resolve, reject });
+      this.pendingRequests.set(id, { resolve, reject, payload });
       this.updateWorkerRef();
       try {
-        this.worker?.postMessage({
-          type: "embed",
-          id,
-          texts: prefixed,
-          inputType,
-          priority,
-        } satisfies WorkerInbound);
+        this.worker?.postMessage(payload satisfies WorkerInbound);
       } catch {
         // Worker may have been terminated between ensureWorker() and here
         // (race with process.exit(1) in the worker thread). Clean up and

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -755,6 +755,12 @@ class LocalProvider implements EmbeddingProvider {
       longestChars,
     });
 
+    // Clear any stale worker error so the deliberate respawn isn't fast-failed
+    // by ensureWorker() (mirrors shutdown()). The OOM exit is recoverable — a
+    // prior `error`/`init-error` could otherwise leave workerInitError set and
+    // block recovery.
+    this.workerInitError = null;
+
     // Respawn and re-submit. Fire-and-forget: ensureWorker()'s own handlers
     // reject pending if the respawn itself fails.
     void this.resubmitPending();

--- a/packages/core/test/embedding-cap-persistence.test.ts
+++ b/packages/core/test/embedding-cap-persistence.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { db } from "../src/db";
+import { _persistEmbedCap, _readPersistedEmbedCap } from "../src/embedding";
+
+// Mirrors EMBED_CAP_KV_KEY in embedding.ts (private). Only used to seed corrupt
+// rows for the guard tests below.
+const KV_KEY = "lore:embedding_cap";
+
+function writeRaw(value: string): void {
+  db()
+    .query(
+      "INSERT INTO kv_meta (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = ?",
+    )
+    .run(KV_KEY, value, value);
+}
+
+describe("embedding cap persistence", () => {
+  beforeEach(() => {
+    db().query("DELETE FROM kv_meta WHERE key = ?").run(KV_KEY);
+  });
+
+  it("returns null when no cap is persisted", () => {
+    expect(_readPersistedEmbedCap()).toBeNull();
+  });
+
+  it("round-trips a persisted cap and records free memory", () => {
+    _persistEmbedCap(1234);
+    const stored = _readPersistedEmbedCap();
+    expect(stored).not.toBeNull();
+    expect(stored?.cap).toBe(1234);
+    expect(stored?.freeMemBytes).toBeGreaterThan(0);
+  });
+
+  it("overwrites the previous cap (ON CONFLICT)", () => {
+    _persistEmbedCap(1000);
+    _persistEmbedCap(500);
+    expect(_readPersistedEmbedCap()?.cap).toBe(500);
+  });
+
+  it("returns null on corrupt persisted JSON (never throws)", () => {
+    writeRaw("not-json{");
+    expect(_readPersistedEmbedCap()).toBeNull();
+  });
+
+  it("returns null when persisted JSON is missing required fields", () => {
+    writeRaw(JSON.stringify({ cap: 1000 }));
+    expect(_readPersistedEmbedCap()).toBeNull();
+  });
+});

--- a/packages/core/test/embedding-cap.test.ts
+++ b/packages/core/test/embedding-cap.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from "vitest";
+import {
+  MIN_EMBED_TOKENS,
+  MODEL_MAX_TOKENS,
+  backoffEmbedCap,
+  clampEmbedCap,
+  memoryModelEmbedCap,
+  reconcileEmbedCap,
+  reprobeEmbedCap,
+  shouldReprobeEmbedCap,
+} from "../src/embedding-cap";
+
+const GB = 1024 * 1024 * 1024;
+
+describe("clampEmbedCap", () => {
+  it("clamps below the floor up to MIN_EMBED_TOKENS", () => {
+    expect(clampEmbedCap(0)).toBe(MIN_EMBED_TOKENS);
+    expect(clampEmbedCap(-100)).toBe(MIN_EMBED_TOKENS);
+    expect(clampEmbedCap(MIN_EMBED_TOKENS - 1)).toBe(MIN_EMBED_TOKENS);
+  });
+
+  it("clamps above the ceiling down to MODEL_MAX_TOKENS", () => {
+    expect(clampEmbedCap(MODEL_MAX_TOKENS + 1)).toBe(MODEL_MAX_TOKENS);
+    expect(clampEmbedCap(1_000_000)).toBe(MODEL_MAX_TOKENS);
+  });
+
+  it("rounds in-range values", () => {
+    expect(clampEmbedCap(1000)).toBe(1000);
+    expect(clampEmbedCap(1000.4)).toBe(1000);
+    expect(clampEmbedCap(1000.6)).toBe(1001);
+  });
+
+  it("treats non-finite input as the floor (never NaN/Infinity)", () => {
+    expect(clampEmbedCap(Number.NaN)).toBe(MIN_EMBED_TOKENS);
+    expect(clampEmbedCap(Number.POSITIVE_INFINITY)).toBe(MIN_EMBED_TOKENS);
+    expect(clampEmbedCap(Number.NEGATIVE_INFINITY)).toBe(MIN_EMBED_TOKENS);
+  });
+});
+
+describe("backoffEmbedCap", () => {
+  it("lowers the cap by ~0.7 each step", () => {
+    expect(backoffEmbedCap(MODEL_MAX_TOKENS)).toBe(Math.round(8192 * 0.7)); // 5734
+    expect(backoffEmbedCap(1000)).toBe(700);
+  });
+
+  it("never drops below the floor", () => {
+    expect(backoffEmbedCap(MIN_EMBED_TOKENS)).toBe(MIN_EMBED_TOKENS);
+    // 300 * 0.7 = 210 → clamped back up to the floor.
+    expect(backoffEmbedCap(300)).toBe(MIN_EMBED_TOKENS);
+  });
+
+  it("converges to the floor in a bounded number of steps and stays there", () => {
+    let cap = MODEL_MAX_TOKENS;
+    let steps = 0;
+    while (cap > MIN_EMBED_TOKENS && steps < 100) {
+      const next = backoffEmbedCap(cap);
+      expect(next).toBeLessThan(cap); // strictly monotonic until the floor
+      cap = next;
+      steps++;
+    }
+    expect(cap).toBe(MIN_EMBED_TOKENS);
+    expect(steps).toBeLessThan(15); // ~10 steps from 8192 → 256
+    // Idempotent at the floor — no infinite loop / event storm.
+    expect(backoffEmbedCap(cap)).toBe(MIN_EMBED_TOKENS);
+  });
+});
+
+describe("memoryModelEmbedCap", () => {
+  it("returns the floor when there is no usable memory budget", () => {
+    expect(memoryModelEmbedCap(0)).toBe(MIN_EMBED_TOKENS);
+    expect(memoryModelEmbedCap(100 * 1024 * 1024)).toBe(MIN_EMBED_TOKENS);
+  });
+
+  it("clamps to the model max on a large free pool", () => {
+    expect(memoryModelEmbedCap(64 * GB)).toBe(MODEL_MAX_TOKENS);
+  });
+
+  it("sizes a constrained host (~2.7 GB free, like Onur's box) well below 4096", () => {
+    const cap = memoryModelEmbedCap(2.7 * GB);
+    expect(cap).toBeGreaterThan(MIN_EMBED_TOKENS);
+    expect(cap).toBeLessThan(3000);
+    // Crucially below the 4096-token ceiling that OOMed on his hardware.
+    expect(cap).toBeLessThan(4096);
+  });
+
+  it("is monotonic in free memory", () => {
+    expect(memoryModelEmbedCap(8 * GB)).toBeGreaterThanOrEqual(
+      memoryModelEmbedCap(4 * GB),
+    );
+    expect(memoryModelEmbedCap(4 * GB)).toBeGreaterThanOrEqual(
+      memoryModelEmbedCap(2 * GB),
+    );
+  });
+
+  it("never returns a value outside [MIN, MODEL_MAX]", () => {
+    for (const free of [0, 0.5, 1, 2, 4, 8, 16, 32, 128]) {
+      const cap = memoryModelEmbedCap(free * GB);
+      expect(cap).toBeGreaterThanOrEqual(MIN_EMBED_TOKENS);
+      expect(cap).toBeLessThanOrEqual(MODEL_MAX_TOKENS);
+    }
+  });
+});
+
+describe("reconcileEmbedCap", () => {
+  it("uses the model cap when there is no persisted value", () => {
+    expect(reconcileEmbedCap(1 * GB, null, 2000)).toBe(2000);
+  });
+
+  it("trusts the learned cap when free memory is close to learn-time", () => {
+    const stored = { cap: 1500, freeMemBytes: 1 * GB };
+    expect(reconcileEmbedCap(1 * GB, stored, 2000)).toBe(1500); // ratio 1.0
+    expect(reconcileEmbedCap(1.1 * GB, stored, 2000)).toBe(1500); // ratio 1.1
+    expect(reconcileEmbedCap(0.8 * GB, stored, 2000)).toBe(1500); // ratio 0.8
+  });
+
+  it("re-probes upward via the model when memory has materially grown", () => {
+    const stored = { cap: 1500, freeMemBytes: 1 * GB };
+    // ratio 2.0 (> 1.25) → use the (larger) model cap, not the stale learned one.
+    expect(reconcileEmbedCap(2 * GB, stored, 4000)).toBe(4000);
+  });
+
+  it("takes the safer of model vs learned when memory has materially shrunk", () => {
+    const stored = { cap: 1500, freeMemBytes: 1 * GB };
+    // ratio 0.4 (< 0.75) → min(modelCap, learned).
+    expect(reconcileEmbedCap(0.4 * GB, stored, 800)).toBe(800);
+    expect(
+      reconcileEmbedCap(0.4 * GB, { cap: 600, freeMemBytes: 1 * GB }, 800),
+    ).toBe(600);
+  });
+
+  it("clamps a learned cap that is out of range", () => {
+    // Persisted cap below the floor → clamped up.
+    expect(
+      reconcileEmbedCap(1 * GB, { cap: 100, freeMemBytes: 1 * GB }, 2000),
+    ).toBe(MIN_EMBED_TOKENS);
+  });
+
+  it("trusts the learned cap when the stored free-memory is unknown (0)", () => {
+    expect(
+      reconcileEmbedCap(1 * GB, { cap: 1500, freeMemBytes: 0 }, 2000),
+    ).toBe(1500);
+  });
+});
+
+describe("shouldReprobeEmbedCap", () => {
+  it("fires only when free memory recovered ≥ 1.3× the learn-time level", () => {
+    expect(shouldReprobeEmbedCap(1.3 * GB, 1 * GB)).toBe(true);
+    expect(shouldReprobeEmbedCap(2 * GB, 1 * GB)).toBe(true);
+    expect(shouldReprobeEmbedCap(1.29 * GB, 1 * GB)).toBe(false);
+    expect(shouldReprobeEmbedCap(1 * GB, 1 * GB)).toBe(false);
+  });
+
+  it("never fires when the learn-time baseline is non-positive", () => {
+    expect(shouldReprobeEmbedCap(8 * GB, 0)).toBe(false);
+    expect(shouldReprobeEmbedCap(8 * GB, -1)).toBe(false);
+  });
+});
+
+describe("reprobeEmbedCap", () => {
+  it("steps the cap up by ~1.43× when memory allows", () => {
+    // Huge free pool → model ceiling is MODEL_MAX, so the gentle step wins.
+    expect(reprobeEmbedCap(1000, 64 * GB)).toBe(Math.round(1000 / 0.7)); // 1429
+  });
+
+  it("is bounded by the memory model for the current free pool", () => {
+    // cap 2000, ~2.7 GB free → model ≈ 2200; the ×1.43 step (2857) is capped.
+    const out = reprobeEmbedCap(2000, 2.7 * GB);
+    expect(out).toBeGreaterThan(2000);
+    expect(out).toBe(memoryModelEmbedCap(2.7 * GB));
+  });
+
+  it("never steps down (returns the cap unchanged if the model ceiling is lower)", () => {
+    // cap already above what 2.7 GB supports → unchanged, never reduced.
+    expect(reprobeEmbedCap(3000, 2.7 * GB)).toBe(3000);
+  });
+
+  it("stays clamped at the model max", () => {
+    expect(reprobeEmbedCap(MODEL_MAX_TOKENS, 64 * GB)).toBe(MODEL_MAX_TOKENS);
+  });
+});

--- a/packages/core/test/embedding-cap.test.ts
+++ b/packages/core/test/embedding-cap.test.ts
@@ -177,4 +177,13 @@ describe("reprobeEmbedCap", () => {
   it("stays clamped at the model max", () => {
     expect(reprobeEmbedCap(MODEL_MAX_TOKENS, 64 * GB)).toBe(MODEL_MAX_TOKENS);
   });
+
+  it("never re-probes up to or past a known-bad cap", () => {
+    // Huge free pool would step 2000 → 2857, but 2400 OOMed before → ceiling 2399.
+    expect(reprobeEmbedCap(2000, 64 * GB, 2400)).toBe(2399);
+    // The gentle step lands below the known-bad ceiling → unaffected.
+    expect(reprobeEmbedCap(1000, 64 * GB, 5000)).toBe(Math.round(1000 / 0.7));
+    // Already at ceiling−1 → no upward movement (never re-OOMs the same cap).
+    expect(reprobeEmbedCap(2399, 64 * GB, 2400)).toBe(2399);
+  });
 });

--- a/packages/gateway/src/sentry.ts
+++ b/packages/gateway/src/sentry.ts
@@ -7,7 +7,7 @@
  */
 
 import * as Sentry from "@sentry/bun";
-import { getInstanceId } from "@loreai/core";
+import { getInstanceId, embedding } from "@loreai/core";
 import { createHash } from "node:crypto";
 
 // ---------------------------------------------------------------------------
@@ -519,4 +519,43 @@ export function emitCurationMetrics(result: {
       attributes: { trigger: result.trigger },
     });
   }
+}
+
+// ---------------------------------------------------------------------------
+// Embedding worker OOM capture
+// ---------------------------------------------------------------------------
+
+/**
+ * Wire core's embedding-failure hook to Sentry. Called once at startup. The
+ * embedding worker's OOM backoff/latch events otherwise only hit stderr; this
+ * surfaces them — fingerprinted, with memory context (free memory, RSS, the
+ * cap before/after) — so a WASM-OOM thrash on a memory-constrained host is
+ * visible instead of only inferable from a coincidental crash.
+ */
+export function setupEmbeddingFailureCapture(): void {
+  embedding.setEmbeddingFailureHook((info: embedding.EmbeddingFailureInfo) => {
+    if (!Sentry.isInitialized()) return;
+    const isLatch = info.kind === "floor-latch";
+    Sentry.captureMessage(
+      isLatch
+        ? "Embedding worker OOM: degraded to FTS-only at the token floor"
+        : "Embedding worker OOM: backed off the token cap and respawned",
+      {
+        level: isLatch ? "error" : "warning",
+        // One grouped issue per kind — not one per session/event.
+        fingerprint: ["embedding-oom", info.kind],
+        contexts: {
+          embedding_oom: {
+            kind: info.kind,
+            cap_before: info.capBefore,
+            cap_after: info.capAfter,
+            batch_size: info.batchSize,
+            longest_chars: info.longestChars,
+            free_memory_bytes: info.freeMemBytes,
+            rss_bytes: info.rssBytes,
+          },
+        },
+      },
+    );
+  });
 }

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -357,7 +357,8 @@ export async function startServer(config: GatewayConfig): Promise<{
     bootstrapDailySpend();
   }
 
-  // Surface embedding-worker OOM backoff/latch events to Sentry (once per process).
+  // Wire embedding-worker OOM backoff/latch events to Sentry. Idempotent: the
+  // hook is assigned (not stacked), so a repeat startServer() is harmless.
   setupEmbeddingFailureCapture();
 
   // Shared fetch handler for all server instances.

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -20,6 +20,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { Readable } from "node:stream";
 import { DEFAULT_PORT, type GatewayConfig } from "./config";
 import { bootstrapDailySpend, getDailyBudget } from "./cost-tracker";
+import { setupEmbeddingFailureCapture } from "./sentry";
 import type { GatewayRequest } from "./translate/types";
 import { parseAnthropicRequest } from "./translate/anthropic";
 import { parseOpenAIRequest } from "./translate/openai";
@@ -355,6 +356,9 @@ export async function startServer(config: GatewayConfig): Promise<{
   if (getDailyBudget() > 0) {
     bootstrapDailySpend();
   }
+
+  // Surface embedding-worker OOM backoff/latch events to Sentry (once per process).
+  setupEmbeddingFailureCapture();
 
   // Shared fetch handler for all server instances.
   const fetch = async (req: Request): Promise<Response> => {


### PR DESCRIPTION
Closes #854.

## Problem

On a memory-constrained host (2-core / 8 GB), the local ONNX embedding worker OOM-crashes on long inputs (~4096 tokens / ~16 K chars), exits code 1, and latches the provider **permanently broken** (FTS-only) for the process lifetime — recurring on **every restart**. The in-process retry ladder (4096→2048→1024) is futile because **WASM linear memory never shrinks** after the first oversized allocation, so smaller retries in the same worker fail too. The multi-GB allocation also pressures the box toward swap, stalling the event loop.

## Fix — memory-aware adaptive token cap

**Initializer** (`embedding-cap.ts`, pure + unit-tested): `cap₀ = clamp(√((freemem·0.5 − 400 MB) / 192), 256, 8192)` from the O(L²) attention memory model. Conservative on purpose — embedding quality plateaus above ~2048 tokens and recall chunks long content, so a low cap costs ~nothing while avoiding swap.

**Halve-and-respawn recovery**: the worker truncates to the cap for one attempt; on OOM it exits with a dedicated code (`EMBED_OOM_EXIT_CODE`). The main thread lowers the cap ×0.7, persists `{cap, freememAtLearn}` to `kv_meta`, **respawns on a fresh heap**, and re-submits the in-flight requests. This is the key difference from the old ladder: each lower cap gets a clean heap. Bounded backoff to a **256-token floor**, where it latches FTS-only (the old behavior, now last-resort, with a "switch to voyage/openai" hint).

**Persistence** stops the "recurs on every restart" loop — restarts start at the learned cap instead of re-walking the backoff.

**Freemem-gated upward re-probe**: if a host started RAM-starved and memory later recovers (≥1.3× `freememAtLearn`), the cap steps back up — applied via a per-request cap override, **no respawn**. Evidence-gated (not blind additive increase), so no probe-thrash; the backoff backstops any overshoot.

**Telemetry**: OOM backoff/latch events are captured to Sentry (fingerprinted, with cap before/after, free memory, RSS) — previously log-only, so this class of failure was invisible.

Also corrects the (factually wrong) comment claiming numeric ORT OOM codes are "model-init allocations, truncation-futile" — they're inference-time / input-size-driven; the in-process futility was the WASM never-shrink artifact.

## Testing

- New `embedding-cap.ts` is fully unit-tested (26 tests): clamp bounds, backoff convergence to floor, memory-model sizing/monotonicity, persisted-cap reconciliation, re-probe gating + bounding.
- Persistence round-trip + corrupt-JSON guard (5 tests).
- typecheck (all 5 packages) ✔ · Biome lint ✔ · full suite **3606 passed / 32 skipped** ✔.

## Notes / follow-ups

- `K=192` and the 400 MB baseline are deliberately conservative estimates; the backoff makes their accuracy non-critical. Follow-up: measure both on the real WASM runtime and replace the constants.
- Instrumentation A/B/C (process RSS + event-loop-lag gauge, startup-backfill span, abort-under-pressure capture) and an optional idle worker-recycle land in follow-up PRs.