### PR TITLE
feat(gateway): process resource gauge + startup-backfill span

### DIFF
--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -1694,7 +1694,9 @@ export async function runStartupBackfill(): Promise<BackfillStats> {
   const dWithEmb = (
     db()
       .query(
-        "SELECT COUNT(*) as n FROM distillations WHERE embedding IS NOT NULL AND archived = 0",
+        // Mirror dTotal's predicate (incl. observations != '') so the coverage
+        // numerator is always a subset of the denominator (never reads "11/10").
+        "SELECT COUNT(*) as n FROM distillations WHERE embedding IS NOT NULL AND archived = 0 AND observations != ''",
       )
       .get() as { n: number }
   ).n;

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -1606,8 +1606,36 @@ const STARTUP_BACKFILL_DELAY_MS = 2_000;
  * Fire-and-forget: callers should `.catch()` — embedding failures must not
  * block plugin initialization.
  */
-export async function runStartupBackfill(): Promise<void> {
-  if (!isAvailable()) return;
+/** Outcome of a startup backfill pass, returned for host-side instrumentation
+ *  (the gateway wraps the call in a Sentry span). @loreai/core stays Sentry-free. */
+export interface BackfillStats {
+  pendingKnowledge: number;
+  pendingDistillations: number;
+  knowledgeEmbedded: number;
+  distillationEmbedded: number;
+  entityEmbedded: number;
+  knowledgeTotal: number;
+  knowledgeWithEmbedding: number;
+  distillationTotal: number;
+  distillationWithEmbedding: number;
+}
+
+function emptyBackfillStats(): BackfillStats {
+  return {
+    pendingKnowledge: 0,
+    pendingDistillations: 0,
+    knowledgeEmbedded: 0,
+    distillationEmbedded: 0,
+    entityEmbedded: 0,
+    knowledgeTotal: 0,
+    knowledgeWithEmbedding: 0,
+    distillationTotal: 0,
+    distillationWithEmbedding: 0,
+  };
+}
+
+export async function runStartupBackfill(): Promise<BackfillStats> {
+  if (!isAvailable()) return emptyBackfillStats();
 
   // Surface backlog up-front so a slow startup is self-explanatory in logs.
   // Counts use the same predicates the backfill loops use, so the two
@@ -1681,6 +1709,18 @@ export async function runStartupBackfill(): Promise<void> {
     `coverage: knowledge ${kWithEmb}/${kTotal}, distillations ${dWithEmb}/${dTotal}`,
   );
   log.info(`embedding startup: ${parts.join("; ")}`);
+
+  return {
+    pendingKnowledge,
+    pendingDistillations,
+    knowledgeEmbedded,
+    distillationEmbedded,
+    entityEmbedded,
+    knowledgeTotal: kTotal,
+    knowledgeWithEmbedding: kWithEmb,
+    distillationTotal: dTotal,
+    distillationWithEmbedding: dWithEmb,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/test/embedding.test.ts
+++ b/packages/core/test/embedding.test.ts
@@ -13,6 +13,7 @@ import {
   _saveAndClearProvider,
   _restoreProvider,
   embed,
+  runStartupBackfill,
   LocalProviderUnavailableError,
   pickRemoteFallback,
   _resetLocalProviderProbe,
@@ -170,6 +171,22 @@ describe("local provider unavailable fallback", () => {
       LocalProviderUnavailableError,
     );
     expect(isAvailable()).toBe(false);
+  });
+
+  test("runStartupBackfill returns zeroed stats when the provider is unavailable", async () => {
+    _markLocalProviderUnavailable();
+    const stats = await runStartupBackfill();
+    expect(stats).toEqual({
+      pendingKnowledge: 0,
+      pendingDistillations: 0,
+      knowledgeEmbedded: 0,
+      distillationEmbedded: 0,
+      entityEmbedded: 0,
+      knowledgeTotal: 0,
+      knowledgeWithEmbedding: 0,
+      distillationTotal: 0,
+      distillationWithEmbedding: 0,
+    });
   });
 });
 

--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -74,6 +74,8 @@ import {
   emitWarmupMetric,
   emitSessionCostMetrics,
   emitCurationMetrics,
+  startResourceMonitor,
+  emitResourceGauge,
 } from "./sentry";
 import {
   getSessionCosts,
@@ -219,9 +221,16 @@ export function startIdleScheduler(
   // gateway was down), then at most once per GLOBAL_DEAD_SWEEP_INTERVAL_MS.
   let lastGlobalDeadSweepAt = 0;
 
+  // Begin sampling event-loop delay for the periodic resource gauge below.
+  startResourceMonitor();
+
   const timer = setInterval(() => {
     const now = Date.now();
     const timeoutMs = config.idleTimeoutSeconds * 1000;
+
+    // Periodic process-resource + event-loop-lag gauge (~30s). Cheap, gated on
+    // Sentry being initialized, and never throws.
+    emitResourceGauge();
 
     // Scale background concurrency to the live session count before scheduling
     // this tick's work. The idle scheduler owns the sessions Map, so doing it

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -221,6 +221,7 @@ import {
   emitCacheBustMetric,
   emitWarmupHitMetric,
   emitCurationMetrics,
+  spanStartupBackfill,
   type AnthropicUsage,
 } from "./sentry";
 import {
@@ -1573,7 +1574,7 @@ async function initIfNeeded(
     log.info("metric backfill failed:", e);
   }
   if (process.env.NODE_ENV !== "test") {
-    embedding.runStartupBackfill().catch((e) => {
+    spanStartupBackfill(() => embedding.runStartupBackfill()).catch((e) => {
       log.error("embedding backfill failed:", e);
     });
   }

--- a/packages/gateway/src/sentry.ts
+++ b/packages/gateway/src/sentry.ts
@@ -9,6 +9,7 @@
 import * as Sentry from "@sentry/bun";
 import { getInstanceId, embedding } from "@loreai/core";
 import { createHash } from "node:crypto";
+import { monitorEventLoopDelay, type IntervalHistogram } from "node:perf_hooks";
 
 // ---------------------------------------------------------------------------
 // Scope enrichment
@@ -558,4 +559,101 @@ export function setupEmbeddingFailureCapture(): void {
       },
     );
   });
+}
+
+// ---------------------------------------------------------------------------
+// Process resource gauge + event-loop lag (periodic, from the idle tick)
+// ---------------------------------------------------------------------------
+
+let eventLoopDelayHist: IntervalHistogram | null = null;
+
+/**
+ * Begin sampling event-loop delay. Cheap libuv-backed histogram; idempotent and
+ * a no-op when Sentry is off. Called once when the idle scheduler starts.
+ */
+export function startResourceMonitor(): void {
+  if (!Sentry.isInitialized() || eventLoopDelayHist) return;
+  eventLoopDelayHist = monitorEventLoopDelay({ resolution: 20 });
+  eventLoopDelayHist.enable();
+}
+
+/**
+ * Emit a periodic process-resource gauge — RSS / heap / external / arrayBuffers
+ * (bytes) and the event-loop-delay p99 (ms) since the previous emit. Called from
+ * the idle scheduler tick (~30s). Never throws (telemetry must not break idle).
+ */
+export function emitResourceGauge(): void {
+  if (!Sentry.isInitialized()) return;
+  try {
+    const mem = process.memoryUsage();
+    Sentry.metrics.distribution("lore.process.rss_bytes", mem.rss, {
+      unit: "byte",
+    });
+    Sentry.metrics.distribution("lore.process.heap_used_bytes", mem.heapUsed, {
+      unit: "byte",
+    });
+    Sentry.metrics.distribution("lore.process.external_bytes", mem.external, {
+      unit: "byte",
+    });
+    Sentry.metrics.distribution(
+      "lore.process.array_buffers_bytes",
+      mem.arrayBuffers,
+      { unit: "byte" },
+    );
+    if (eventLoopDelayHist) {
+      // percentile() returns nanoseconds; report milliseconds, then reset so
+      // the next emit reflects only the elapsed interval.
+      Sentry.metrics.distribution(
+        "lore.event_loop.lag_p99_ms",
+        eventLoopDelayHist.percentile(99) / 1e6,
+        { unit: "millisecond" },
+      );
+      eventLoopDelayHist.reset();
+    }
+  } catch {
+    // Telemetry must never break the idle loop.
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Startup embedding-backfill span
+// ---------------------------------------------------------------------------
+
+/**
+ * Wrap the one-shot startup embedding backfill in a Sentry span, recording how
+ * much was embedded and the RSS delta across the pass (the backfill is the
+ * prime suspect for startup memory growth). Falls back to running `run` plainly
+ * when Sentry is off. Errors propagate to the caller's existing `.catch()`.
+ */
+export async function spanStartupBackfill(
+  run: () => Promise<embedding.BackfillStats>,
+): Promise<void> {
+  if (!Sentry.isInitialized()) {
+    await run();
+    return;
+  }
+  const rssBefore = process.memoryUsage().rss;
+  await Sentry.startSpan(
+    { name: "lore.embedding.startup_backfill", op: "embedding.backfill" },
+    async (span) => {
+      const stats = await run();
+      const rssAfter = process.memoryUsage().rss;
+      span.setAttribute("knowledge_embedded", stats.knowledgeEmbedded);
+      span.setAttribute("distillation_embedded", stats.distillationEmbedded);
+      span.setAttribute("entity_embedded", stats.entityEmbedded);
+      span.setAttribute("pending_knowledge", stats.pendingKnowledge);
+      span.setAttribute("pending_distillations", stats.pendingDistillations);
+      span.setAttribute(
+        "knowledge_coverage",
+        `${stats.knowledgeWithEmbedding}/${stats.knowledgeTotal}`,
+      );
+      span.setAttribute(
+        "distillation_coverage",
+        `${stats.distillationWithEmbedding}/${stats.distillationTotal}`,
+      );
+      span.setAttribute("rss_before_bytes", rssBefore);
+      span.setAttribute("rss_after_bytes", rssAfter);
+      span.setAttribute("rss_delta_bytes", rssAfter - rssBefore);
+    },
+  );
 }

--- a/packages/gateway/src/sentry.ts
+++ b/packages/gateway/src/sentry.ts
@@ -573,8 +573,14 @@ let eventLoopDelayHist: IntervalHistogram | null = null;
  */
 export function startResourceMonitor(): void {
   if (!Sentry.isInitialized() || eventLoopDelayHist) return;
-  eventLoopDelayHist = monitorEventLoopDelay({ resolution: 20 });
-  eventLoopDelayHist.enable();
+  try {
+    eventLoopDelayHist = monitorEventLoopDelay({ resolution: 20 });
+    eventLoopDelayHist.enable();
+  } catch {
+    // perf_hooks/monitorEventLoopDelay unavailable on this runtime — skip the
+    // loop-lag metric rather than break idle-scheduler startup.
+    eventLoopDelayHist = null;
+  }
 }
 
 /**

--- a/packages/gateway/test/sentry-instrumentation.test.ts
+++ b/packages/gateway/test/sentry-instrumentation.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import {
+  spanStartupBackfill,
+  emitResourceGauge,
+  startResourceMonitor,
+} from "../src/sentry";
+
+const stats = {
+  pendingKnowledge: 0,
+  pendingDistillations: 0,
+  knowledgeEmbedded: 0,
+  distillationEmbedded: 0,
+  entityEmbedded: 0,
+  knowledgeTotal: 0,
+  knowledgeWithEmbedding: 0,
+  distillationTotal: 0,
+  distillationWithEmbedding: 0,
+};
+
+// Sentry is not initialized in the test process, so these exercise the
+// Sentry-off fallback paths — which must always run the work and never throw.
+describe("embedding/resource instrumentation helpers", () => {
+  it("spanStartupBackfill runs the backfill and resolves", async () => {
+    let called = 0;
+    await expect(
+      spanStartupBackfill(async () => {
+        called++;
+        return stats;
+      }),
+    ).resolves.toBeUndefined();
+    expect(called).toBe(1);
+  });
+
+  it("spanStartupBackfill propagates an error from the backfill", async () => {
+    await expect(
+      spanStartupBackfill(async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+  });
+
+  it("emitResourceGauge is a safe no-op", () => {
+    expect(() => emitResourceGauge()).not.toThrow();
+  });
+
+  it("startResourceMonitor is a safe, idempotent no-op", () => {
+    expect(() => startResourceMonitor()).not.toThrow();
+    expect(() => startResourceMonitor()).not.toThrow();
+  });
+});


### PR DESCRIPTION
Observability follow-up to #854 / #855 (embedding OOM). Two additive, Sentry-gated instruments to make the startup-memory / event-loop-stall behavior on constrained hosts visible (Onur's box showed RSS ~778 MB → ~3.7 GB and `ConnectTimeoutError`s with no in-process signal).

## A — periodic resource gauge (idle tick, ~30s)
`emitResourceGauge()` emits `lore.process.{rss,heap_used,external,array_buffers}_bytes` and `lore.event_loop.lag_p99_ms` (via `perf_hooks.monitorEventLoopDelay`, sampled + reset each tick). Wired into the existing idle scheduler tick; `startResourceMonitor()` enables the histogram once at scheduler start. Cheap, gated on `Sentry.isInitialized()`, never throws (telemetry must not break the idle loop).

## B — startup embedding-backfill span
`runStartupBackfill()` now returns `BackfillStats` (counts + coverage). The gateway wraps the one-shot call in `Sentry.startSpan("lore.embedding.startup_backfill")`, recording the embedded counts, coverage, and **RSS before/after/delta** — the backfill is the prime suspect for startup memory growth.

`@loreai/core` stays Sentry-free — it only returns the stats struct; all Sentry wiring is in the gateway (`sentry.ts`).

## Testing
- core: `runStartupBackfill` returns zeroed `BackfillStats` on the provider-unavailable early-return.
- gateway: `spanStartupBackfill` runs the work + propagates errors on the Sentry-off path; `emitResourceGauge` / `startResourceMonitor` are safe no-ops.
- typecheck ✔ · lint ✔ · full suite **3613 passed / 32 skipped** ✔.

Follow-up: instrumentation C (client-abort-under-pressure capture) lands next.