### PR TITLE
fix(sync): reconcile re-syncs a row recreated across a disable/enable boundary

### DIFF
--- a/packages/core/src/sync-data.ts
+++ b/packages/core/src/sync-data.ts
@@ -425,10 +425,16 @@ function rowIdExpr(m: SyncTableMeta): string {
 }
 
 /**
- * Enqueue an `upsert` for every live row of the synced tables. Idempotent — a
- * row that already has a pending outbox entry is skipped, so repeated calls
- * (e.g. re-enable) don't pile up duplicates. The push path further skips rows
- * whose `content_hash` is unchanged, so a redundant upsert costs nothing.
+ * Enqueue an `upsert` for every live row whose LATEST pending outbox op is not
+ * already an `upsert` — i.e. rows with no pending entry, or rows whose newest
+ * pending entry is a `delete`. This stays idempotent (a row already queued as an
+ * upsert is not re-queued) while guaranteeing a live row always has a TRAILING
+ * upsert. Without that guarantee, a row deleted-then-recreated across a sync
+ * disable/enable boundary keeps only its stale (coalesced) `delete` — `seedOutbox`
+ * would skip it on re-enable, the delete would push (a no-op on a row never
+ * uploaded), and the live row would be silently orphaned, never synced. The push
+ * path further skips rows whose `content_hash` is unchanged, so a redundant upsert
+ * costs nothing.
  */
 export function seedOutbox(tier: SyncTier = "basic"): void {
   const now = Date.now();
@@ -442,9 +448,12 @@ export function seedOutbox(tier: SyncTier = "basic"): void {
       .query(
         `INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
          SELECT ?, ${idExpr}, 'upsert', ? FROM ${m.table} t
-         WHERE NOT EXISTS (
-           SELECT 1 FROM sync_outbox o WHERE o.table_name = ? AND o.row_id = ${idExpr}
-         )`,
+         WHERE COALESCE(
+           (SELECT o.op FROM sync_outbox o
+            WHERE o.table_name = ? AND o.row_id = ${idExpr}
+            ORDER BY o.seq DESC LIMIT 1),
+           'none'
+         ) <> 'upsert' `,
       )
       .run(m.table, now, m.table);
   }

--- a/packages/core/src/sync-data.ts
+++ b/packages/core/src/sync-data.ts
@@ -706,8 +706,10 @@ export function isSyncEnabled(): boolean {
 /**
  * Enable change-capture and reconcile the outbox against current state, so both
  * first-enable (uploads pre-existing rows) and re-enable (catches edits/deletes
- * made while sync was OFF) are captured. Idempotent — `reconcile` skips rows
- * that already have a pending outbox entry.
+ * made while sync was OFF) are captured. Idempotent — `reconcile` only adds an
+ * upsert for a live row whose latest pending entry isn't already an upsert (so a
+ * row recreated after a pending delete still gets a trailing upsert; see
+ * `seedOutbox`).
  */
 export function enableSync(tier: SyncTier = "basic"): void {
   setTeamConfig(ENABLED_KEY, "1");

--- a/packages/gateway/test/sync.test.ts
+++ b/packages/gateway/test/sync.test.ts
@@ -376,6 +376,26 @@ describe("pushOnce — happy path", () => {
     // The tombstone must carry a NULL content_hash on the wire (the contract).
     expect(remote?.content_hash).toBeNull();
   });
+
+  test("a row deleted then RE-CREATED while sync was OFF is re-synced on enable (not orphaned)", async () => {
+    // While enabled, insert+delete leaves a coalesced delete in the outbox. Then
+    // sync goes OFF and the row is re-created (no capture). On re-enable, reconcile
+    // must re-enqueue the LIVE row — otherwise seedOutbox skips it (it still has the
+    // stale pending delete), the coalesced delete pushes (a no-op on a row that was
+    // never uploaded), and the re-created row is silently never synced.
+    syncData.enableSync("basic");
+    insertKnowledge("kr", "v1");
+    db().query("DELETE FROM knowledge WHERE id='kr'").run(); // outbox: upsert, delete
+    syncData.disableSync();
+    insertKnowledge("kr", "v2"); // re-created while OFF — not captured
+    syncData.enableSync("basic"); // reconcile must catch the live row
+    const r = await pushOnce(makeClient() as never);
+    expect(r.pushed).toBeGreaterThan(0);
+    const remote = tableRows("knowledge").find((x) => x.id === "kr");
+    expect(remote).toBeDefined(); // the re-created row reached the remote…
+    expect(remote?.is_deleted).not.toBe(true); // …live, not tombstoned…
+    expect(remote?.content).toBe("v2"); // …with the re-created content.
+  });
 });
 
 describe("BLOCKER regressions", () => {


### PR DESCRIPTION
## The bug (found by the #833 property tests)
`seedOutbox` (`packages/core/src/sync-data.ts`) skipped **any** live row that already had a pending outbox entry:

```sql
... WHERE NOT EXISTS (SELECT 1 FROM sync_outbox o WHERE o.table_name = ? AND o.row_id = ...)
```

That assumes the pending entry will push the row's current state. It breaks when a row is **deleted and then re-created while sync is OFF**:
1. enabled: `insert k` then `delete k` → outbox has a coalesced `delete`.
2. sync disabled; `k` re-created (no capture trigger).
3. re-enable → `reconcile`: `seedOutbox` sees the pending delete and **skips** the live `k`. `pushOnce` coalesces to the `delete` (a no-op on a row never uploaded). The re-created `k` is **silently orphaned — never synced**, and `syncOnce` only push/pulls (it never re-reconciles), so it stays lost.

## The fix
`seedOutbox` enqueues an upsert for a live row whose **latest** pending op is *not already an `upsert`* (no entry, or a trailing `delete`). This guarantees a live row always carries a **trailing upsert**, which coalesces to win the push — while staying idempotent (a row already queued as an upsert isn't re-queued).

## How it was found
The #833 convergence property (`insert → delete → disable → insert` never converged: local kept the row, remote tombstoned it). This is the **second** real engine bug that property battery surfaced (the first: #856 tombstone delete propagation). Adds a deterministic regression test (fails on the old code, passes on the fix).

## Validation
Regression test fails-before/passes-after; full suite **3609 passed**; typecheck, lint, build green. The #833 convergence property is stable with this fix in place.