### PR TITLE
feat(gateway): capture client aborts that coincide with host pressure

### DIFF
--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -222,6 +222,7 @@ import {
   emitWarmupHitMetric,
   emitCurationMetrics,
   spanStartupBackfill,
+  captureClientAbortUnderPressure,
   type AnthropicUsage,
 } from "./sentry";
 import {
@@ -3095,6 +3096,9 @@ function buildStreamingResponse(
   const accumulator: StreamAccumulator =
     recallAccum ?? createStreamAccumulator({ scaleClientUsage: true });
   const encoder = new TextEncoder();
+  // Start of the client-facing stream — used to flag aborts that happen after
+  // a long in-flight time (a host-pressure signal; see the abort catch below).
+  const streamStartMs = Date.now();
 
   // Client-disconnect detection: shared between start() and cancel()
   let cancelled = false;
@@ -3510,6 +3514,12 @@ function buildStreamingResponse(
           err instanceof DOMException && err.name === "AbortError";
         if (isAbort) {
           log.info("streaming pipeline aborted (client disconnect)");
+          // Only surfaces to Sentry if the host was under pressure at abort time.
+          captureClientAbortUnderPressure({
+            startMs: streamStartMs,
+            route: "stream",
+            sessionID: recallContext?.sessionState.sessionID,
+          });
         } else {
           log.error("streaming pipeline error:", err);
         }
@@ -7603,6 +7613,7 @@ export async function handleRequest(
   req: GatewayRequest,
   config: GatewayConfig,
 ): Promise<Response> {
+  const requestStartMs = Date.now();
   try {
     // Guard against malformed invocations (e.g. fuzzers / direct module calls
     // that pass an undefined or header-less request). The real server path
@@ -7675,6 +7686,11 @@ export async function handleRequest(
     const isAbort = err instanceof DOMException && err.name === "AbortError";
     if (isAbort) {
       log.info("pipeline aborted (client disconnect)");
+      // Only surfaces to Sentry if the host was under pressure at abort time.
+      captureClientAbortUnderPressure({
+        startMs: requestStartMs,
+        route: "request",
+      });
     } else {
       log.error("pipeline error:", err);
     }

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -3089,6 +3089,9 @@ function buildStreamingResponse(
   },
   /** When set, prepend a synthetic warning content block to the stream. */
   warningText?: string,
+  /** Session id, for telemetry (abort-under-pressure capture). Passed
+   *  independently of recallContext so non-recall turns are still attributable. */
+  sessionID?: string,
 ): Response {
   const recallAccum = recallContext
     ? createRecallAwareAccumulator(RECALL_TOOL_NAME, { scaleClientUsage: true })
@@ -3518,7 +3521,7 @@ function buildStreamingResponse(
           captureClientAbortUnderPressure({
             startMs: streamStartMs,
             route: "stream",
-            sessionID: recallContext?.sessionState.sessionID,
+            sessionID,
           });
         } else {
           log.error("streaming pipeline error:", err);
@@ -6964,6 +6967,7 @@ async function handleConversationTurn(
         ? { modifiedReq, config, sessionState, cacheOptions }
         : undefined,
       warningText,
+      sessionState.sessionID,
     );
     // Translate to client's wire format if needed. When the upstream is
     // Anthropic but the client speaks OpenAI, wrap the Anthropic SSE stream.

--- a/packages/gateway/src/sentry.ts
+++ b/packages/gateway/src/sentry.ts
@@ -683,18 +683,28 @@ export function getEventLoopLagP99Ms(): number {
 /** A client abort is only worth a Sentry event when it coincides with host
  *  pressure: a long in-flight time or a stalled event loop. Below these,
  *  disconnects are normal connection lifecycle and must not be captured. */
-const ABORT_PRESSURE_INFLIGHT_MS = 10_000;
+/** Event-loop p99 at/above this (ms) means the loop is stalled — swap/CPU
+ *  pressure, the ConnectTimeout symptom. */
 const ABORT_PRESSURE_LAG_MS = 1_000;
+/** Free memory at/below this is critically low — the host is near swap/OOM
+ *  (the embedding worker baseline alone is ~400 MB). Coarse floor; gates a
+ *  telemetry event only, not behavior. */
+const ABORT_PRESSURE_FREEMEM_BYTES = 512 * 1024 * 1024;
 
-/** True when an abort coincides with host pressure: a long in-flight time OR a
- *  stalled event loop. Pure (no Sentry/process state) for unit testing. */
+/**
+ * True when the HOST is under pressure: the event loop is stalled OR free
+ * memory is critically low. Deliberately based on host state, not request
+ * duration — a long-lived stream cancelled on a healthy host is a normal abort,
+ * not pressure (in-flight time is recorded as context, never as the gate). Pure
+ * for unit testing.
+ */
 export function isAbortUnderPressure(
-  timeInFlightMs: number,
   lagP99Ms: number,
+  freeMemBytes: number,
 ): boolean {
   return (
-    timeInFlightMs >= ABORT_PRESSURE_INFLIGHT_MS ||
-    lagP99Ms >= ABORT_PRESSURE_LAG_MS
+    lagP99Ms >= ABORT_PRESSURE_LAG_MS ||
+    freeMemBytes <= ABORT_PRESSURE_FREEMEM_BYTES
   );
 }
 
@@ -711,12 +721,14 @@ export function captureClientAbortUnderPressure(ctx: {
   route: string;
   sessionID?: string;
 }): void {
-  if (!Sentry.isInitialized()) return;
+  // Whole body in try — even Sentry.isInitialized() must not throw out of a
+  // request-path catch and turn a clean error response into a rejected promise.
   try {
-    const timeInFlightMs = Date.now() - ctx.startMs;
+    if (!Sentry.isInitialized()) return;
     const lagP99Ms = getEventLoopLagP99Ms();
-    if (!isAbortUnderPressure(timeInFlightMs, lagP99Ms)) {
-      return; // normal abort, not under pressure
+    const freeMemBytes = freemem();
+    if (!isAbortUnderPressure(lagP99Ms, freeMemBytes)) {
+      return; // healthy host — a normal abort, not worth an event
     }
     const mem = process.memoryUsage();
     Sentry.captureMessage("Client abort under host pressure", {
@@ -727,10 +739,10 @@ export function captureClientAbortUnderPressure(ctx: {
         abort_pressure: {
           route: ctx.route,
           session_id: ctx.sessionID ?? "unknown",
-          time_in_flight_ms: timeInFlightMs,
+          time_in_flight_ms: Date.now() - ctx.startMs,
           event_loop_lag_p99_ms: Math.round(lagP99Ms),
           rss_bytes: mem.rss,
-          free_memory_bytes: freemem(),
+          free_memory_bytes: freeMemBytes,
         },
       },
     });

--- a/packages/gateway/src/sentry.ts
+++ b/packages/gateway/src/sentry.ts
@@ -9,6 +9,7 @@
 import * as Sentry from "@sentry/bun";
 import { getInstanceId, embedding } from "@loreai/core";
 import { createHash } from "node:crypto";
+import { freemem } from "node:os";
 import { monitorEventLoopDelay, type IntervalHistogram } from "node:perf_hooks";
 
 // ---------------------------------------------------------------------------
@@ -662,4 +663,78 @@ export async function spanStartupBackfill(
       span.setAttribute("rss_delta_bytes", rssAfter - rssBefore);
     },
   );
+}
+
+// ---------------------------------------------------------------------------
+// Client-abort-under-pressure capture
+// ---------------------------------------------------------------------------
+
+/** Current event-loop-delay p99 in ms — a *peek* that does NOT reset the
+ *  window (unlike emitResourceGauge). 0 when the monitor isn't running. */
+export function getEventLoopLagP99Ms(): number {
+  if (!eventLoopDelayHist) return 0;
+  try {
+    return eventLoopDelayHist.percentile(99) / 1e6;
+  } catch {
+    return 0;
+  }
+}
+
+/** A client abort is only worth a Sentry event when it coincides with host
+ *  pressure: a long in-flight time or a stalled event loop. Below these,
+ *  disconnects are normal connection lifecycle and must not be captured. */
+const ABORT_PRESSURE_INFLIGHT_MS = 10_000;
+const ABORT_PRESSURE_LAG_MS = 1_000;
+
+/** True when an abort coincides with host pressure: a long in-flight time OR a
+ *  stalled event loop. Pure (no Sentry/process state) for unit testing. */
+export function isAbortUnderPressure(
+  timeInFlightMs: number,
+  lagP99Ms: number,
+): boolean {
+  return (
+    timeInFlightMs >= ABORT_PRESSURE_INFLIGHT_MS ||
+    lagP99Ms >= ABORT_PRESSURE_LAG_MS
+  );
+}
+
+/**
+ * Capture a client-abort event ONLY when it coincides with host pressure
+ * (in-flight ≥ 10s OR event-loop p99 ≥ 1s), with memory + loop-lag context, so
+ * client disconnects can be correlated with the embedding-OOM / swap stalls
+ * that manifest upstream as ConnectTimeout. Normal aborts are dropped to avoid
+ * Sentry noise. Gated on Sentry; never throws (called from request-path catch
+ * blocks).
+ */
+export function captureClientAbortUnderPressure(ctx: {
+  startMs: number;
+  route: string;
+  sessionID?: string;
+}): void {
+  if (!Sentry.isInitialized()) return;
+  try {
+    const timeInFlightMs = Date.now() - ctx.startMs;
+    const lagP99Ms = getEventLoopLagP99Ms();
+    if (!isAbortUnderPressure(timeInFlightMs, lagP99Ms)) {
+      return; // normal abort, not under pressure
+    }
+    const mem = process.memoryUsage();
+    Sentry.captureMessage("Client abort under host pressure", {
+      level: "warning",
+      // One grouped issue per route, not one per disconnect.
+      fingerprint: ["client-abort-under-pressure", ctx.route],
+      contexts: {
+        abort_pressure: {
+          route: ctx.route,
+          session_id: ctx.sessionID ?? "unknown",
+          time_in_flight_ms: timeInFlightMs,
+          event_loop_lag_p99_ms: Math.round(lagP99Ms),
+          rss_bytes: mem.rss,
+          free_memory_bytes: freemem(),
+        },
+      },
+    });
+  } catch {
+    // Telemetry must never break the request path.
+  }
 }

--- a/packages/gateway/test/sentry-instrumentation.test.ts
+++ b/packages/gateway/test/sentry-instrumentation.test.ts
@@ -3,6 +3,9 @@ import {
   spanStartupBackfill,
   emitResourceGauge,
   startResourceMonitor,
+  isAbortUnderPressure,
+  getEventLoopLagP99Ms,
+  captureClientAbortUnderPressure,
 } from "../src/sentry";
 
 const stats = {
@@ -46,5 +49,35 @@ describe("embedding/resource instrumentation helpers", () => {
   it("startResourceMonitor is a safe, idempotent no-op", () => {
     expect(() => startResourceMonitor()).not.toThrow();
     expect(() => startResourceMonitor()).not.toThrow();
+  });
+});
+
+describe("client-abort-under-pressure", () => {
+  it("fires only above the in-flight (10s) OR loop-lag (1s) thresholds", () => {
+    // Below both → normal abort, not captured.
+    expect(isAbortUnderPressure(5_000, 500)).toBe(false);
+    expect(isAbortUnderPressure(9_999, 999)).toBe(false);
+    // In-flight threshold (boundary inclusive).
+    expect(isAbortUnderPressure(10_000, 0)).toBe(true);
+    expect(isAbortUnderPressure(60_000, 0)).toBe(true);
+    // Loop-lag threshold (boundary inclusive).
+    expect(isAbortUnderPressure(0, 1_000)).toBe(true);
+    expect(isAbortUnderPressure(0, 5_000)).toBe(true);
+  });
+
+  it("getEventLoopLagP99Ms returns a non-negative number", () => {
+    const lag = getEventLoopLagP99Ms();
+    expect(typeof lag).toBe("number");
+    expect(lag).toBeGreaterThanOrEqual(0);
+  });
+
+  it("captureClientAbortUnderPressure is a safe no-op when Sentry is off", () => {
+    expect(() =>
+      captureClientAbortUnderPressure({
+        startMs: Date.now() - 30_000,
+        route: "stream",
+        sessionID: "abc",
+      }),
+    ).not.toThrow();
   });
 });

--- a/packages/gateway/test/sentry-instrumentation.test.ts
+++ b/packages/gateway/test/sentry-instrumentation.test.ts
@@ -53,16 +53,19 @@ describe("embedding/resource instrumentation helpers", () => {
 });
 
 describe("client-abort-under-pressure", () => {
-  it("fires only above the in-flight (10s) OR loop-lag (1s) thresholds", () => {
-    // Below both → normal abort, not captured.
-    expect(isAbortUnderPressure(5_000, 500)).toBe(false);
-    expect(isAbortUnderPressure(9_999, 999)).toBe(false);
-    // In-flight threshold (boundary inclusive).
-    expect(isAbortUnderPressure(10_000, 0)).toBe(true);
-    expect(isAbortUnderPressure(60_000, 0)).toBe(true);
-    // Loop-lag threshold (boundary inclusive).
-    expect(isAbortUnderPressure(0, 1_000)).toBe(true);
-    expect(isAbortUnderPressure(0, 5_000)).toBe(true);
+  const MB = 1024 * 1024;
+  const GB = 1024 * MB;
+  it("fires only when the loop is stalled (>=1s) or free memory is critically low (<=512MB)", () => {
+    // Healthy host (fast loop, plenty of memory) → normal abort, not captured —
+    // even a long-lived stream cancellation is dropped.
+    expect(isAbortUnderPressure(200, 4 * GB)).toBe(false);
+    expect(isAbortUnderPressure(999, 513 * MB)).toBe(false);
+    // Event-loop stalled (boundary inclusive).
+    expect(isAbortUnderPressure(1_000, 8 * GB)).toBe(true);
+    expect(isAbortUnderPressure(5_000, 8 * GB)).toBe(true);
+    // Free memory critically low (boundary inclusive).
+    expect(isAbortUnderPressure(0, 512 * MB)).toBe(true);
+    expect(isAbortUnderPressure(0, 100 * MB)).toBe(true);
   });
 
   it("getEventLoopLagP99Ms returns a non-negative number", () => {


### PR DESCRIPTION
Final observability piece (C) for the embedding-OOM / event-loop-stall investigation (#854, after #855/#860).

## Why
Client disconnects are normally benign (logged at info, deliberately kept out of Sentry). But on a memory-constrained host, a swap/OOM stall freezes the event loop and surfaces as client aborts + upstream `ConnectTimeoutError`s — with no in-process signal tying the two together. Onur's box showed exactly this.

## What
`captureClientAbortUnderPressure()` fires a Sentry event **only when an abort coincides with host pressure** — `time_in_flight ≥ 10s` **OR** `event_loop_lag_p99 ≥ 1s` — attaching `time_in_flight_ms`, `event_loop_lag_p99_ms`, `rss_bytes`, and `free_memory_bytes` (fingerprinted per route). Normal aborts are dropped, so no added Sentry noise.

- Wired into **both** abort catch sites: streaming (`buildStreamingResponse`) and top-level (`handleRequest`), each with a captured start timestamp.
- `getEventLoopLagP99Ms()` *peeks* the event-loop histogram added in #860 (no reset, so it doesn't disturb the 30s gauge window).
- The threshold check is extracted as a pure, unit-tested `isAbortUnderPressure()`.
- The capture lives entirely in the abort `catch` blocks, gated on `Sentry.isInitialized()`, and never throws — zero effect on the success path.

## Testing
- Pure threshold tests (boundary-inclusive at 10s / 1s).
- `getEventLoopLagP99Ms` non-negative; `captureClientAbortUnderPressure` safe no-op when Sentry is off.
- typecheck ✔ · lint ✔ · full suite **3616 passed / 32 skipped** ✔.

Note: in-flight request *count* was intentionally omitted — counting it correctly across the streaming lifecycle needs lifecycle plumbing in the hot path; loop-lag p99 already proxies system load. Can follow up if the captured data shows it's needed.