### PR TITLE
perf(sync): index sync_outbox(table_name,row_id,seq) for seedOutbox's latest-op probe

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1338,6 +1338,16 @@ const MIGRATIONS: string[] = [
   CREATE INDEX IF NOT EXISTS idx_knowledge_project_current
     ON knowledge(project_id) WHERE is_current = 1 AND is_deleted = 0;
   `,
+  `
+  -- Version 52: widen the sync_outbox per-row lookup index to include seq, so
+  -- seedOutbox's "latest pending op for this row" probe (ORDER BY seq DESC LIMIT 1)
+  -- is a pure index seek instead of a sort within the (table_name,row_id) group.
+  -- Same name as before (a superset prefix), so the by-name IF NOT EXISTS ensures
+  -- elsewhere see it as present and never revert it.
+  DROP INDEX IF EXISTS idx_sync_outbox_table_row;
+  CREATE INDEX IF NOT EXISTS idx_sync_outbox_table_row
+    ON sync_outbox (table_name, row_id, seq);
+  `,
 ];
 
 /**

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -58,7 +58,7 @@ describe("db", () => {
     const row = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(row.version).toBe(51);
+    expect(row.version).toBe(52);
   });
 
   test("session_prompt_deltas persist ordered selector/content rows (v42)", () => {

--- a/packages/core/test/ltm-versioning.test.ts
+++ b/packages/core/test/ltm-versioning.test.ts
@@ -39,11 +39,11 @@ function ftsHits(token: string): number {
 }
 
 describe("A2 sub-PR 1: append-only knowledge scaffolding", () => {
-  test("schema version is 51", () => {
+  test("schema version is 52", () => {
     const v = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(v.version).toBe(51);
+    expect(v.version).toBe(52);
   });
 
   test("create() defaults logical_id = id, version 1, current, not deleted", () => {


### PR DESCRIPTION
Addresses the Seer comment + review NIT on #861 (the `seedOutbox` reconcile fix).

`seedOutbox`'s "latest pending op for this row" subquery —
`SELECT op FROM sync_outbox WHERE table_name=? AND row_id=? ORDER BY seq DESC LIMIT 1` —
used `idx_sync_outbox_table_row (table_name, row_id)` for the lookup but then sorted the
matched group by `seq`. Migration **v52** widens that index to `(table_name, row_id, seq)`
so the probe is a **pure index seek** (verified via `EXPLAIN QUERY PLAN`: no temp B-tree / sort).

- Same index **name** (the old 2-col index is a prefix), so the by-name `IF NOT EXISTS` guards in `MIGRATIONS[0]` and the runtime schema-ensure still see it as present and never revert it.
- `DROP INDEX IF EXISTS` + `CREATE` is idempotent and re-run safe.
- Cold path (only `enableSync` calls `seedOutbox`), so this is hardening, not a hot-path win — but it removes the only flagged spot.

Schema version → **52**; both schema-version test assertions bumped.

Full suite **3614 passed**; typecheck, lint, build green.