### PR TITLE
perf(sync): recoverMissingObjects recreates the 3-col outbox index (v52 consistency)

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1737,7 +1737,7 @@ function recoverMissingObjects(database: Database) {
       changed_at INTEGER NOT NULL
     );
     CREATE INDEX IF NOT EXISTS idx_sync_outbox_table_row
-      ON sync_outbox (table_name, row_id);
+      ON sync_outbox (table_name, row_id, seq);
     CREATE INDEX IF NOT EXISTS idx_sync_outbox_table_seq
       ON sync_outbox (table_name, seq);
     CREATE TABLE IF NOT EXISTS sync_state (


### PR DESCRIPTION
Follow-up implementing the SHOULD-FIX from the #863 review (it merged before this 1-liner landed).

After #863, `idx_sync_outbox_table_row` is `(table_name, row_id, seq)`. But `recoverMissingObjects()` (`db.ts`) — which recreates dropped objects on every init via by-name `CREATE INDEX IF NOT EXISTS` — still defined the old 2-col form. It's a no-op while the index exists, but in the (essentially unreachable) recovery case where the index is genuinely missing on a v52 DB, recovery would restore the **2-col** index — a silent perf downgrade (the seedOutbox probe would sort again). This keeps the recovery definition consistent with the v52 schema. `MIGRATIONS[0]` is intentionally left 2-col (history; v52 supersedes it).

1-line change; db.test.ts green, typecheck/lint clean.