### PR TITLE
fix(sync): reconcile tombstones a deleted row even when a stale upsert outlived it

### DIFF
--- a/packages/core/src/sync-data.ts
+++ b/packages/core/src/sync-data.ts
@@ -461,9 +461,15 @@ export function seedOutbox(tier: SyncTier = "basic"): void {
 
 /**
  * Re-enqueue the full local delta for a tier — used on enable AND re-enable:
- *  - upserts for every live row (idempotent seed; push skips unchanged ones), and
- *  - `delete` tombstones for rows present in `sync_state` but no longer live
- *    (deleted while sync was OFF, which the capture triggers couldn't see).
+ *  - an upsert for every live row whose latest pending op isn't already an upsert
+ *    (see seedOutbox), and
+ *  - a `delete` tombstone for every row present in `sync_state` but no longer live
+ *    whose latest pending op isn't already a `delete` (deleted while sync was OFF,
+ *    which the capture triggers couldn't see). The "isn't already a delete" guard
+ *    (rather than "has no pending entry") matters when a stale UPSERT outlived the
+ *    row — e.g. it survived pruning because the prune floor was pinned by a lower-
+ *    seq table (#828). Without the trailing delete, that upsert pushes as a no-op
+ *    (row gone) and the delete would never reach the remote.
  * This is why enable does NOT just seed once: it reconciles, so changes made
  * while sync was disabled are not silently dropped from the push queue.
  */
@@ -482,10 +488,12 @@ export function reconcile(tier: SyncTier = "basic"): void {
            FROM sync_state s
           WHERE s.table_name = ?
             AND NOT EXISTS (SELECT 1 FROM ${m.table} t WHERE ${idExpr} = s.row_id)
-            AND NOT EXISTS (
-              SELECT 1 FROM sync_outbox o
-               WHERE o.table_name = s.table_name AND o.row_id = s.row_id
-            )`,
+            AND COALESCE(
+              (SELECT o.op FROM sync_outbox o
+                WHERE o.table_name = s.table_name AND o.row_id = s.row_id
+                ORDER BY o.seq DESC LIMIT 1),
+              'none'
+            ) <> 'delete'`,
       )
       .run(now, m.table);
   }

--- a/packages/gateway/test/sync.test.ts
+++ b/packages/gateway/test/sync.test.ts
@@ -396,6 +396,32 @@ describe("pushOnce — happy path", () => {
     expect(remote?.is_deleted).not.toBe(true); // …live, not tombstoned…
     expect(remote?.content).toBe("v2"); // …with the re-created content.
   });
+
+  test("a delete still propagates when a STALE upsert outlived the row (reconcile tombstone)", async () => {
+    // A row's upsert can survive pruning when the prune floor is pinned by a
+    // lower-seq table (#828): minCursor = min push cursor across tables-with-
+    // entries, so a higher-seq table's entry isn't reclaimed. If that row is then
+    // deleted while sync is OFF, reconcile's delete-tombstone must STILL fire —
+    // otherwise the stale upsert pushes as a no-op (row gone) and the delete never
+    // reaches the remote. Symmetric to the live-row seedOutbox fix (#861).
+    syncData.enableSync("basic");
+    insertKnowledge("k1", "v1"); // outbox upsert@1 (knowledge)
+    insertEntity("e1"); // outbox upsert@2 (entities)
+    await pushOnce(makeClient() as never);
+    // prune floor = min(knowledge=1, entities=2) = 1 → knowledge@1 reclaimed,
+    // entities@2 survives as the stale upsert; both rows are now in sync_state.
+    expect(
+      syncData
+        .readOutbox(0)
+        .some((e) => e.table_name === "entities" && e.row_id === "e1"),
+    ).toBe(true);
+    syncData.disableSync();
+    db().query("DELETE FROM entities WHERE id='e1'").run(); // deleted while OFF
+    syncData.enableSync("basic"); // reconcile must tombstone e1 despite the stale upsert
+    await pushOnce(makeClient() as never);
+    const remoteE = tableRows("entities").find((r) => r.id === "e1");
+    expect(remoteE?.is_deleted).toBe(true); // delete propagated to the remote
+  });
 });
 
 describe("BLOCKER regressions", () => {


### PR DESCRIPTION
## The bug (flagged out-of-scope by the #861 review)
`reconcile`'s delete-tombstone step (`packages/core/src/sync-data.ts`) enqueued a `delete` for a row in `sync_state` but no longer live — **only if it had no pending outbox entry**:

```sql
AND NOT EXISTS (SELECT 1 FROM sync_outbox o WHERE o.table_name = s.table_name AND o.row_id = s.row_id)
```

But a row's `upsert` can survive pruning: `pushOnce` prunes `seq <= min push cursor across tables-with-entries` (#828), so a higher-seq table's entry isn't reclaimed when a lower-seq table pins the floor. If that row is then **deleted while sync is OFF**, on re-enable the stale upsert **suppressed the delete-tombstone**, then pushed as a no-op (`getRowById` is null → row gone) — so the delete **never reached the remote**. Local deleted, remote still live: a silent, convergence-breaking divergence.

This is the exact mirror of #861 (which fixed the *live*-row side of `seedOutbox`); this fixes the *deleted*-row side of the same reconcile pass.

## The fix
Enqueue the delete-tombstone unless the row's **latest** pending op is already a `delete` (no entry, or a trailing stale `upsert` → append the `delete`, which coalesces to win the push). Both reconcile branches now share the same "latest pending op" guard:
- live row, latest ≠ upsert → trailing upsert (#861)
- deleted row, latest ≠ delete → trailing delete (this PR)

## How it was found / validation
Flagged by the #861 adversarial review as a future hardening item. Adds a **deterministic regression test** that drives the real prune-floor scenario (knowledge@1 + entities@2 → prune floor 1 reclaims knowledge, entities@2 survives as the stale upsert; delete the entity while OFF; re-enable) — it fails on `main` (`expected false to be true`: remote keeps the row) and passes on the fix.

Full suite **3623 passed**; typecheck, lint, build green.