### PR TITLE
fix(sync): seedOutbox re-seeds by content so a stale upsert can't mask an edit

### DIFF
--- a/packages/core/src/sync-data.ts
+++ b/packages/core/src/sync-data.ts
@@ -24,6 +24,7 @@ import {
   setKV,
   setTeamConfig,
   withSyncApplying,
+  withTransaction,
 } from "./db";
 
 /**
@@ -458,32 +459,39 @@ export function seedOutbox(tier: SyncTier = "basic"): void {
       WHERE table_name = ? AND row_id = ? AND seq > ?
       ORDER BY seq DESC LIMIT 1`,
   );
-  for (const m of syncedTables(tier)) {
-    // Pull-only tables are never pushed — enqueuing them would create outbox
-    // entries that pushOnce skips forever, pinning their push cursor at 0 and
-    // (via the prune floor) permanently disabling outbox pruning for ALL tables.
-    if (m.pullOnly) continue;
-    const pushCursor = Number(getKV(`sync.push.${m.table}`) ?? "0");
-    const rows = db()
-      .query(`SELECT * FROM ${m.table}`)
-      .all() as Record<string, unknown>[];
-    for (const row of rows) {
-      const rowId = rowIdOf(m.table, row);
-      const pending =
-        (
-          latestUnpushed.get(m.table, rowId, pushCursor) as {
-            op: string;
-          } | null
-        )?.op ?? null;
-      if (pending === "upsert") continue; // unpushed upsert already carries it
-      if (pending === null) {
-        // No unpushed op — re-seed only when the content actually changed.
-        const synced = getSyncState(m.table, rowId)?.content_hash ?? null;
-        if (contentHash(m.table, row) === synced) continue;
+  // One transaction for the whole seed: the per-row loop does N inserts, and
+  // without it WAL + synchronous=FULL would fsync once PER ROW — a multi-second
+  // stall on `lore sync enable` for a large knowledge base. (Safe: seedOutbox is
+  // only ever reached via enableSync, never from within another transaction.)
+  withTransaction(() => {
+    for (const m of syncedTables(tier)) {
+      // Pull-only tables are never pushed — enqueuing them would create outbox
+      // entries that pushOnce skips forever, pinning their push cursor at 0 and
+      // (via the prune floor) permanently disabling outbox pruning for ALL tables.
+      if (m.pullOnly) continue;
+      const pushCursor = Number(getKV(`sync.push.${m.table}`) ?? "0");
+      const rows = db().query(`SELECT * FROM ${m.table}`).all() as Record<
+        string,
+        unknown
+      >[];
+      for (const row of rows) {
+        const rowId = rowIdOf(m.table, row);
+        const pending =
+          (
+            latestUnpushed.get(m.table, rowId, pushCursor) as {
+              op: string;
+            } | null
+          )?.op ?? null;
+        if (pending === "upsert") continue; // unpushed upsert already carries it
+        if (pending === null) {
+          // No unpushed op — re-seed only when the content actually changed.
+          const synced = getSyncState(m.table, rowId)?.content_hash ?? null;
+          if (contentHash(m.table, row) === synced) continue;
+        }
+        enqueue.run(m.table, rowId, now);
       }
-      enqueue.run(m.table, rowId, now);
     }
-  }
+  });
 }
 
 /**

--- a/packages/core/src/sync-data.ts
+++ b/packages/core/src/sync-data.ts
@@ -19,6 +19,7 @@ import { createHash } from "node:crypto";
 import {
   db,
   deleteTeamConfig,
+  getKV,
   getTeamConfig,
   setKV,
   setTeamConfig,
@@ -425,44 +426,70 @@ function rowIdExpr(m: SyncTableMeta): string {
 }
 
 /**
- * Enqueue an `upsert` for every live row whose LATEST pending outbox op is not
- * already an `upsert` — i.e. rows with no pending entry, or rows whose newest
- * pending entry is a `delete`. This stays idempotent (a row already queued as an
- * upsert is not re-queued) while guaranteeing a live row always has a TRAILING
- * upsert. Without that guarantee, a row deleted-then-recreated across a sync
- * disable/enable boundary keeps only its stale (coalesced) `delete` — `seedOutbox`
- * would skip it on re-enable, the delete would push (a no-op on a row never
- * uploaded), and the live row would be silently orphaned, never synced. The push
- * path further skips rows whose `content_hash` is unchanged, so a redundant upsert
- * costs nothing.
+ * Enqueue an `upsert` for every live row whose CURRENT content isn't already
+ * correctly queued for the remote. Content-addressed, and aware of which outbox
+ * entries the push hasn't consumed yet (seq > the table's push cursor), so for
+ * each live row:
+ *  - latest UNPUSHED op is an `upsert` → skip: it already carries the current
+ *    content when pushed (getRowById), so re-enqueue would just pile up (this is
+ *    what keeps reconcile idempotent);
+ *  - latest UNPUSHED op is a `delete` → enqueue a trailing upsert: the row is live
+ *    again (recreated across a disable/enable boundary), so the delete must lose;
+ *  - no unpushed op → the remote reflects `sync_state`; enqueue only on a real
+ *    content change (`contentHash != sync_state.content_hash`), skipping unchanged
+ *    rows so reconcile doesn't churn.
+ * The "unpushed" qualifier is load-bearing: a stale already-pushed upsert can
+ * survive pruning (the prune floor was pinned by a lower-seq table, #828) and sits
+ * below the push cursor where it is NEVER re-read. A latest-op guard would treat it
+ * as "already queued" and silently drop a since-made edit; the content check sees
+ * the divergence (current content != the hash that stale upsert synced) and
+ * re-seeds it.
  */
 export function seedOutbox(tier: SyncTier = "basic"): void {
   const now = Date.now();
+  const enqueue = db().query(
+    `INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
+     VALUES (?, ?, 'upsert', ?)`,
+  );
+  // Latest pending op for a row among entries the push hasn't consumed yet. An
+  // already-pushed (seq <= cursor) entry is stale — never re-read — so excluded.
+  const latestUnpushed = db().query(
+    `SELECT op FROM sync_outbox
+      WHERE table_name = ? AND row_id = ? AND seq > ?
+      ORDER BY seq DESC LIMIT 1`,
+  );
   for (const m of syncedTables(tier)) {
     // Pull-only tables are never pushed — enqueuing them would create outbox
     // entries that pushOnce skips forever, pinning their push cursor at 0 and
     // (via the prune floor) permanently disabling outbox pruning for ALL tables.
     if (m.pullOnly) continue;
-    const idExpr = rowIdExpr(m);
-    db()
-      .query(
-        `INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
-         SELECT ?, ${idExpr}, 'upsert', ? FROM ${m.table} t
-         WHERE COALESCE(
-           (SELECT o.op FROM sync_outbox o
-            WHERE o.table_name = ? AND o.row_id = ${idExpr}
-            ORDER BY o.seq DESC LIMIT 1),
-           'none'
-         ) <> 'upsert' `,
-      )
-      .run(m.table, now, m.table);
+    const pushCursor = Number(getKV(`sync.push.${m.table}`) ?? "0");
+    const rows = db()
+      .query(`SELECT * FROM ${m.table}`)
+      .all() as Record<string, unknown>[];
+    for (const row of rows) {
+      const rowId = rowIdOf(m.table, row);
+      const pending =
+        (
+          latestUnpushed.get(m.table, rowId, pushCursor) as {
+            op: string;
+          } | null
+        )?.op ?? null;
+      if (pending === "upsert") continue; // unpushed upsert already carries it
+      if (pending === null) {
+        // No unpushed op — re-seed only when the content actually changed.
+        const synced = getSyncState(m.table, rowId)?.content_hash ?? null;
+        if (contentHash(m.table, row) === synced) continue;
+      }
+      enqueue.run(m.table, rowId, now);
+    }
   }
 }
 
 /**
  * Re-enqueue the full local delta for a tier — used on enable AND re-enable:
- *  - an upsert for every live row whose latest pending op isn't already an upsert
- *    (see seedOutbox), and
+ *  - an upsert for every live row whose current content isn't already correctly
+ *    queued (see seedOutbox), and
  *  - a `delete` tombstone for every row present in `sync_state` but no longer live
  *    whose latest pending op isn't already a `delete` (deleted while sync was OFF,
  *    which the capture triggers couldn't see). The "isn't already a delete" guard

--- a/packages/gateway/test/sync.test.ts
+++ b/packages/gateway/test/sync.test.ts
@@ -441,7 +441,9 @@ describe("pushOnce — happy path", () => {
         .some((e) => e.table_name === "entities" && e.row_id === "e1"),
     ).toBe(true);
     syncData.disableSync();
-    db().query("UPDATE entities SET canonical_name='RENAMED' WHERE id='e1'").run(); // modified while OFF
+    db()
+      .query("UPDATE entities SET canonical_name='RENAMED' WHERE id='e1'")
+      .run(); // modified while OFF
     syncData.enableSync("basic"); // reconcile must re-seed e1 by content
     await pushOnce(makeClient() as never);
     const remoteE = tableRows("entities").find((r) => r.id === "e1");

--- a/packages/gateway/test/sync.test.ts
+++ b/packages/gateway/test/sync.test.ts
@@ -422,6 +422,31 @@ describe("pushOnce — happy path", () => {
     const remoteE = tableRows("entities").find((r) => r.id === "e1");
     expect(remoteE?.is_deleted).toBe(true); // delete propagated to the remote
   });
+
+  test("a content change still propagates when a STALE upsert outlived the prune floor (reconcile seed)", async () => {
+    // The upsert mirror of the tombstone case above: a row's upsert can survive
+    // pruning (floor pinned by a lower-seq table, #828). If the row is then
+    // MODIFIED while sync is OFF, reconcile must re-seed it BY CONTENT — the stale
+    // already-pushed upsert won't carry the new content and (being below the push
+    // cursor) is never re-read, so a latest-op guard would skip it and lose the edit.
+    syncData.enableSync("basic");
+    insertKnowledge("k1", "v1"); // outbox upsert@1 (knowledge)
+    insertEntity("e1"); // outbox upsert@2 (entities), canonical_name 'X'
+    await pushOnce(makeClient() as never);
+    // prune floor = min(knowledge=1, entities=2) = 1 → knowledge@1 reclaimed,
+    // entities@2 survives as the stale (already-pushed) upsert.
+    expect(
+      syncData
+        .readOutbox(0)
+        .some((e) => e.table_name === "entities" && e.row_id === "e1"),
+    ).toBe(true);
+    syncData.disableSync();
+    db().query("UPDATE entities SET canonical_name='RENAMED' WHERE id='e1'").run(); // modified while OFF
+    syncData.enableSync("basic"); // reconcile must re-seed e1 by content
+    await pushOnce(makeClient() as never);
+    const remoteE = tableRows("entities").find((r) => r.id === "e1");
+    expect(remoteE?.canonical_name).toBe("RENAMED"); // edit propagated to the remote
+  });
 });
 
 describe("BLOCKER regressions", () => {


### PR DESCRIPTION
## The bug (the upsert mirror of #866, found by its review)
`seedOutbox` skipped a live row whose latest pending op was an `upsert`. But that upsert can be **stale** — already pushed, surviving pruning because the prune floor was pinned by a lower-seq table (#828) — sitting **below the push cursor where it is never re-read**. If the row is then **modified while sync is OFF**, on re-enable `seedOutbox` treated the stale upsert as "already queued" and skipped re-seeding, so the edit was **silently never pushed** (remote kept the old content).

This is the upsert-side mirror of #866 (delete side) and completes the stale-upsert family with #856/#861.

## The fix
Make `seedOutbox` content-addressed and aware of which entries the push hasn't consumed (`seq > push cursor`). For each live row:
- latest **unpushed** op is an `upsert` → **skip** (it carries the current content when pushed → keeps reconcile idempotent);
- latest **unpushed** op is a `delete` → **enqueue** a trailing upsert (row is live again — recreate);
- **no** unpushed op → enqueue only on a real content change (`contentHash != sync_state.content_hash`) — which also stops reconcile churning over unchanged rows.

The "unpushed" qualifier is load-bearing: the stale upsert is below the cursor and never re-read, so a latest-op guard wrongly treats it as queued; the content check sees the divergence and re-seeds. `sync-data.ts` already reads cursor KV keys (e.g. `sync.pull.profiles`), so reading `sync.push.<table>` is consistent — no new layering.

## Validation
New deterministic regression test drives the real prune-floor scenario (knowledge@1 + entities@2 → floor 1 reclaims knowledge, entities@2 survives stale; modify the entity while OFF; re-enable) — fails on `main` (`expected 'X' to be 'RENAMED'`), passes on the fix. #861 + #866 regression tests and both `seedOutbox` idempotency tests still pass. Full suite **3624 passed**; property tests **0/10** failures; typecheck, lint, build green.