### PR TITLE
test(core): worker-mock tests for embedding OOM recovery flow

### DIFF
--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -359,6 +359,23 @@ export function _markLocalProviderUnavailable(): void {
   localProviderErrorLogged = true; // suppress the info log in tests
 }
 
+/** Test seam: when set, `ensureWorker()` uses this factory instead of spawning
+ *  a real `node:worker_threads` Worker, so the OOM-recovery lifecycle (exit-75
+ *  backoff → respawn → re-submit, floor latch, synchronous respawn failure) can
+ *  be driven deterministically. Never set in production. */
+let testWorkerFactory:
+  | ((data: WorkerInitData) => import("node:worker_threads").Worker)
+  | null = null;
+
+/** For tests: install the worker factory seam above (null clears it). */
+export function _setTestWorkerFactory(
+  factory:
+    | ((data: WorkerInitData) => import("node:worker_threads").Worker)
+    | null,
+): void {
+  testWorkerFactory = factory;
+}
+
 /** True iff the local provider has been probed and found broken. */
 function localProviderKnownUnavailable(): boolean {
   return localProviderKnownBroken;
@@ -473,7 +490,11 @@ class LocalProvider implements EmbeddingProvider {
         vendorModel: vendor ? { localModelPath: vendor.localModelPath } : null,
       };
 
-      if (workerSource !== undefined) {
+      if (testWorkerFactory) {
+        // Test seam (never set in production): a deterministic fake worker so
+        // the OOM-recovery lifecycle can be exercised without a real runtime.
+        this.worker = testWorkerFactory(workerInitData);
+      } else if (workerSource !== undefined) {
         const { join } = await import("node:path");
         const { homedir } = await import("node:os");
         const opts: Record<string, unknown> = {

--- a/packages/core/test/embedding-oom-recovery.test.ts
+++ b/packages/core/test/embedding-oom-recovery.test.ts
@@ -1,0 +1,211 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { EventEmitter } from "node:events";
+import type { Worker } from "node:worker_threads";
+import {
+  embed,
+  isAvailable,
+  LocalProviderUnavailableError,
+  _persistEmbedCap,
+  _readPersistedEmbedCap,
+  _resetLocalProviderProbe,
+  _restoreProvider,
+  _saveAndClearProvider,
+  _setTestWorkerFactory,
+} from "../src/embedding";
+import { backoffEmbedCap, MIN_EMBED_TOKENS } from "../src/embedding-cap";
+import { EMBED_OOM_EXIT_CODE } from "../src/embedding-worker-types";
+
+// Exercises the stateful OOM-recovery lifecycle in LocalProvider that the pure
+// cap math can't reach: the worker on("exit") OOM branch → handleOomBackoff →
+// resubmitPending, the floor latch, and a synchronous respawn failure (#858).
+// A fake worker (the _setTestWorkerFactory seam) lets us drive worker exit/
+// message events deterministically without a real ONNX runtime.
+
+type EmbedMsg = { type: string; id: number; maxTokens: number };
+
+/** Minimal stand-in for a node:worker_threads Worker. Captures posted messages
+ *  and lets a test emit "message"/"error"/"exit" via EventEmitter. */
+class FakeWorker extends EventEmitter {
+  readonly posted: EmbedMsg[] = [];
+  terminated = false;
+  postMessage(msg: unknown): void {
+    // Snapshot: the production payload object is mutated in place on re-submit
+    // (p.payload.maxTokens = lowered), so storing the reference would let a
+    // later backoff retroactively change an earlier captured message.
+    this.posted.push({ ...(msg as EmbedMsg) });
+  }
+  ref(): void {}
+  unref(): void {}
+  terminate(): Promise<number> {
+    this.terminated = true;
+    return Promise.resolve(0);
+  }
+  lastPosted(): EmbedMsg {
+    const m = this.posted.at(-1);
+    if (!m) throw new Error("fake worker received no message");
+    return m;
+  }
+}
+
+/** Install the factory and collect every fake worker it hands out. */
+function installFakeWorkers(): FakeWorker[] {
+  const fakes: FakeWorker[] = [];
+  _setTestWorkerFactory(() => {
+    const f = new FakeWorker();
+    fakes.push(f);
+    return f as unknown as Worker;
+  });
+  return fakes;
+}
+
+/** Flush pending microtasks + one macrotask so the async respawn/re-submit
+ *  chain (resubmitPending → ensureWorker → re-post) settles. */
+async function flush(): Promise<void> {
+  for (let i = 0; i < 5; i++) await Promise.resolve();
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+/** Attach handlers immediately so a rejection that fires while we drive the
+ *  worker (well before we assert on it) is never flagged as "unhandled". */
+function settle<T>(
+  p: Promise<T>,
+): Promise<{ ok: true; value: T } | { ok: false; err: unknown }> {
+  return p.then(
+    (value) => ({ ok: true as const, value }),
+    (err) => ({ ok: false as const, err }),
+  );
+}
+
+describe("embedding OOM recovery (worker-mock)", () => {
+  let savedProvider: unknown;
+  let savedVoyage: string | undefined;
+  let savedOpenAI: string | undefined;
+
+  beforeEach(() => {
+    // Force the local provider (no remote fallback) and a fresh instance.
+    savedVoyage = process.env.VOYAGE_API_KEY;
+    savedOpenAI = process.env.OPENAI_API_KEY;
+    delete process.env.VOYAGE_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    _resetLocalProviderProbe();
+    savedProvider = _saveAndClearProvider();
+  });
+
+  afterEach(() => {
+    _setTestWorkerFactory(null);
+    _resetLocalProviderProbe();
+    _restoreProvider(savedProvider);
+    if (savedVoyage !== undefined) process.env.VOYAGE_API_KEY = savedVoyage;
+    if (savedOpenAI !== undefined) process.env.OPENAI_API_KEY = savedOpenAI;
+  });
+
+  it("OOM exit lowers the cap ×0.7, persists it, respawns, and re-submits the in-flight request at the lowered cap", async () => {
+    _persistEmbedCap(8192); // fresh provider starts at the model max
+    const fakes = installFakeWorkers();
+
+    const promise = embed(["hello world"], "query");
+    await flush();
+
+    expect(fakes).toHaveLength(1);
+    const first = fakes[0].lastPosted();
+    expect(first.type).toBe("embed");
+    expect(first.maxTokens).toBe(8192);
+
+    // The worker OOMs on the oversized input → exits with the OOM code.
+    fakes[0].emit("exit", EMBED_OOM_EXIT_CODE);
+    await flush();
+
+    // Respawned on a fresh worker; same request re-submitted at the ×0.7 cap.
+    expect(fakes).toHaveLength(2);
+    const resubmitted = fakes[1].lastPosted();
+    expect(resubmitted.id).toBe(first.id);
+    expect(resubmitted.maxTokens).toBe(backoffEmbedCap(8192)); // 5734
+    expect(resubmitted.maxTokens).toBeLessThan(first.maxTokens);
+    // The lowered cap was persisted so a restart doesn't re-walk the backoff.
+    expect(_readPersistedEmbedCap()?.cap).toBe(resubmitted.maxTokens);
+
+    // The respawned worker succeeds → the caller's original promise resolves.
+    fakes[1].emit("message", {
+      type: "result",
+      id: resubmitted.id,
+      vectors: [new Float32Array([0.1, 0.2, 0.3])],
+    });
+    const vectors = await promise;
+    expect(vectors).toHaveLength(1);
+  });
+
+  it("OOM at the floor latches FTS-only and rejects the pending request (no respawn)", async () => {
+    _persistEmbedCap(MIN_EMBED_TOKENS); // fresh provider starts at the floor
+    const fakes = installFakeWorkers();
+
+    const result = settle(embed(["hello world"], "query"));
+    await flush();
+    expect(fakes).toHaveLength(1);
+    expect(fakes[0].lastPosted().maxTokens).toBe(MIN_EMBED_TOKENS);
+
+    // OOM at the floor can't back off further → latch instead of respawning.
+    fakes[0].emit("exit", EMBED_OOM_EXIT_CODE);
+    await flush();
+
+    expect(fakes).toHaveLength(1); // did NOT respawn
+    const r = await result;
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.err).toBeInstanceOf(LocalProviderUnavailableError);
+    expect(isAvailable()).toBe(false); // degraded to FTS-only
+  });
+
+  it("rejects pending requests when the respawn itself fails synchronously", async () => {
+    _persistEmbedCap(8192);
+    let calls = 0;
+    const fakes: FakeWorker[] = [];
+    _setTestWorkerFactory(() => {
+      calls += 1;
+      // The respawn (2nd spawn) throws synchronously, before any worker event
+      // handler is attached — nothing else will ever settle the pending request.
+      if (calls >= 2) throw new Error("synthetic spawn failure");
+      const f = new FakeWorker();
+      fakes.push(f);
+      return f as unknown as Worker;
+    });
+
+    const result = settle(embed(["hello world"], "query"));
+    await flush();
+    expect(fakes).toHaveLength(1);
+
+    fakes[0].emit("exit", EMBED_OOM_EXIT_CODE);
+    await flush();
+
+    expect(calls).toBe(2); // respawn was attempted
+    const r = await result;
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.err).toBeInstanceOf(LocalProviderUnavailableError);
+  });
+
+  it("descends the full backoff ladder to the floor across repeated OOMs, then latches", async () => {
+    _persistEmbedCap(8192);
+    const fakes = installFakeWorkers();
+
+    const result = settle(embed(["hello world"], "query"));
+    await flush();
+
+    let lastCap = Number.POSITIVE_INFINITY;
+    let latched = false;
+    for (let i = 0; i < 30 && !latched; i++) {
+      const before = fakes.length;
+      const current = fakes[fakes.length - 1];
+      const cap = current.lastPosted().maxTokens;
+      expect(cap).toBeLessThanOrEqual(lastCap); // monotone non-increasing
+      lastCap = cap;
+      current.emit("exit", EMBED_OOM_EXIT_CODE);
+      await flush();
+      if (fakes.length === before) latched = true; // no respawn → latched
+    }
+
+    expect(latched).toBe(true);
+    expect(lastCap).toBe(MIN_EMBED_TOKENS); // bottomed out at the floor before latching
+    const r = await result;
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.err).toBeInstanceOf(LocalProviderUnavailableError);
+    expect(isAvailable()).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #858. Follow-up to #855 — closes the coverage gap on the stateful OOM-recovery orchestration (Codecov flagged ~35% on `embedding.ts`; both Seer/adversarial findings on #855 lived in this untested flow).

## Approach
A minimal **test seam** — `_setTestWorkerFactory()` (module-level, never set in production) — lets `ensureWorker()` use a controllable fake Worker instead of spawning a real `node:worker_threads` Worker. The seam is a single new branch in `ensureWorker`; production behavior is unchanged (factory defaults null).

A `FakeWorker` (EventEmitter) captures posted messages and lets each test emit `exit`/`message` events, driving the lifecycle deterministically without a real ONNX runtime.

## Coverage added (4 tests)
- **OOM exit** → cap ×0.7 + persisted + respawn + in-flight request re-submitted at the lowered cap → succeeds on the respawned worker.
- **OOM at the floor** → FTS-only latch, pending rejected, **no respawn**.
- **Synchronous respawn failure** → pending rejected (the finding-A hang guard; no timeout on the local path).
- **Full backoff ladder** → monotone descent to the floor across repeated OOMs, then latch (proves the recovery is bounded — no event storm).

## Notes
- Two test artifacts worth calling out (handled): the production payload object is **mutated in place** on re-submit, so the fake snapshots each posted message; and a floor-latch rejection that fires mid-drive is attached early via a `settle()` helper to avoid a spurious unhandled-rejection.
- typecheck ✔ · lint ✔ · full suite **3627 passed**.