### PR TITLE
fix(gradient): clamp escalated compression-stage budgets to layer-0 ceiling

### DIFF
--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -2367,6 +2367,15 @@ function transformInner(input: {
   // the always-returns emergency tail) instead of overflowing the model. This
   // is only the stage-loop acceptance gate (the layer-0 / tier-gate paths use
   // their own `maxInput * HARD_CEILING_MARGIN` checks against expectedInput).
+  //
+  // The layer-1 stable window is effectively bounded to ~0.65*usable (prefix
+  // 0.25 + raw 0.4), so `total * 1.5 = 0.975*usable <= maxInput` and layer 1
+  // is never falsely rejected in the normal regime. The stable-window
+  // hysteresis (up to 1.15x raw) can push the worst case to ~0.71*usable, which
+  // exceeds maxInput only when overhead+LTM is a tiny (<~6%) slice of the
+  // window — and in that regime the real (1.5x) size genuinely approaches the
+  // ceiling, so escalating one layer is the correct, safe response, not a
+  // spurious reject.
   function fitsWithSafetyMargin(
     result: { totalTokens: number } | null,
   ): boolean {
@@ -2677,22 +2686,28 @@ function transformInner(input: {
     if (effectiveMinLayer > stageLayer) continue;
 
     const stage = COMPRESSION_STAGES[s];
-    // Escalated stages (rawFrac/distFrac non-null) scale off `stageBudgetUsable`
-    // (clamped to the layer-0 cost ceiling), NOT raw `usable` — see the
-    // "Escalated-stage budget ceiling" note above. Without the clamp,
-    // `usable * 0.5` on a 1M-token model targets ~400K raw, larger than the
-    // ~200K cap that triggered compression AND larger than the layer-1 window,
-    // so escalating layers GREW the window and overflowed the model. Stage 0
-    // (layer 1, rawFrac=null) falls through to the unclamped base rawBudget /
-    // distilledBudget so the cache-stable raw-window pin keeps its full budget.
-    const stageRawBudget =
-      stage.rawFrac !== null
-        ? Math.floor(stageBudgetUsable * stage.rawFrac)
-        : rawBudget;
-    const stageDistBudget =
-      stage.distFrac !== null
-        ? Math.floor(stageBudgetUsable * stage.distFrac)
-        : distilledBudget;
+    // Budget scaling by layer:
+    //   - Layer 1 (stage 0): keep the FULL unclamped base budgets (usable*raw,
+    //     usable*distilled). The cost cap governs WHEN to compress, not the
+    //     layer-1 window size; clamping it would starve the cache-stable
+    //     raw-window pin (its chunked eviction needs headroom).
+    //   - Escalated layers (2-3): clamp BOTH raw AND distilled to the layer-0
+    //     cost ceiling (`stageBudgetUsable`). On a 1M-token model `usable*0.5`
+    //     ≈ 400K — far LARGER than the ~200K cap that triggered compression AND
+    //     larger than the layer-1 window — so escalating GREW the context until
+    //     the model overflowed (wedged session 0AVWKugtmhBKqLOX9). Both
+    //     dimensions must be clamped: clamping only raw still lets the distilled
+    //     prefix balloon to usable*0.25 (~242K on 1M), so the total would not
+    //     actually shrink toward the cap. A null fraction on an escalated stage
+    //     (e.g. layer 2's distFrac) falls back to the configured base fraction,
+    //     still clamped to the ceiling.
+    const isEscalated = stageLayer > 1;
+    const stageRawBudget = isEscalated
+      ? Math.floor(stageBudgetUsable * (stage.rawFrac ?? cfg.budget.raw))
+      : rawBudget;
+    const stageDistBudget = isEscalated
+      ? Math.floor(stageBudgetUsable * (stage.distFrac ?? cfg.budget.distilled))
+      : distilledBudget;
 
     // Determine prefix: if distLimit is finite, re-render with trimmed distillations.
     // Otherwise use the cached prefix (Approach C, byte-identical for cache).

--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -2299,6 +2299,30 @@ function transformInner(input: {
   // Base raw budget. May be overridden below for post-idle compact mode.
   let rawBudget = Math.floor(usable * cfg.budget.raw);
 
+  // --- Escalated-stage budget ceiling (layers 2-3 only) ---
+  // The ESCALATED compression stages (layer 2: rawFrac 0.5; layer 3: rawFrac
+  // 0.55) size their raw/distilled windows as a fraction of `usable`. On a
+  // high-context model (e.g. a 1M-token opus → usable ~800K) `usable * 0.5` ≈
+  // 400K — far LARGER than the ~200K cost cap (maxLayer0Tokens) whose breach
+  // triggered compression, AND larger than the layer-1 window itself. So
+  // escalating to a "more aggressive" layer paradoxically GREW the context,
+  // unbounded, until the model's real limit overflowed. (This wedged session
+  // 0AVWKugtmhBKqLOX9 at layer 2: layer-1 200K → layer-2 356K → 461K, then
+  // "prompt is too long".) Clamp the ESCALATED-stage budgets to the layer-0
+  // cost ceiling so each higher layer actually shrinks the window toward the
+  // cap. NOTE: the layer-1 stable window (stage 0, rawFrac=null) deliberately
+  // keeps the full `usable * raw` budget — the cost cap governs WHEN to
+  // compress, not the layer-1 window size, and shrinking it would defeat the
+  // cache-stable raw-window pin (its chunked eviction needs headroom).
+  //   - maxLayer0Tokens === 0 (cost cap disabled): stageBudgetUsable === usable,
+  //     a no-op preserving the explicit "use the model's full context" opt-out.
+  //   - small-context models: usable < ceiling, so this is also a no-op.
+  const stageBudgetCeiling =
+    maxLayer0Tokens > 0
+      ? Math.min(contextLimit - outputReserved, maxLayer0Tokens)
+      : contextLimit - outputReserved;
+  const stageBudgetUsable = Math.min(usable, stageBudgetCeiling);
+
   // --- Force escalation (reactive error recovery) ---
   // When the API previously rejected with "prompt is too long", skip layers
   // below the forced minimum to ensure enough trimming on the next attempt.
@@ -2326,13 +2350,27 @@ function transformInner(input: {
   // API limit — exceeding it causes an unrecoverable 400.
   const HARD_CEILING_MARGIN = 0.95;
 
-  // Returns true if the tryFit result is safe to use: either we have calibrated
-  // data (exact) or the estimated total * safety factor fits within maxInput.
+  // Returns true if a rebuilt compression-stage window is safe to ship.
+  //
+  // A rebuilt window's `totalTokens` is a FRESH chars/3 estimate of the WHOLE
+  // window — it is NOT anchored to the API's last real count the way the
+  // layer-0 delta path (expectedInput = lastKnownInput + delta) is. So being
+  // "calibrated" does NOT make a rebuilt window exact: chars/3 undercounts the
+  // real tokenizer ~1.5-3x. Previously this returned `true` unconditionally for
+  // calibrated sessions, so a stage whose real size exceeded the model's
+  // context window was shipped anyway → unrecoverable "prompt is too long"
+  // (this, with the unclamped budgets, wedged session 0AVWKugtmhBKqLOX9).
+  //
+  // Validate every rebuilt window — calibrated or not — against the hard API
+  // ceiling with the same undercount safety multiplier. Rejecting an
+  // over-ceiling stage makes the loop escalate to a tighter layer (ultimately
+  // the always-returns emergency tail) instead of overflowing the model. This
+  // is only the stage-loop acceptance gate (the layer-0 / tier-gate paths use
+  // their own `maxInput * HARD_CEILING_MARGIN` checks against expectedInput).
   function fitsWithSafetyMargin(
     result: { totalTokens: number } | null,
   ): boolean {
     if (!result) return false;
-    if (calibrated) return true;
     return result.totalTokens * UNCALIBRATED_SAFETY <= maxInput;
   }
 
@@ -2639,11 +2677,21 @@ function transformInner(input: {
     if (effectiveMinLayer > stageLayer) continue;
 
     const stage = COMPRESSION_STAGES[s];
+    // Escalated stages (rawFrac/distFrac non-null) scale off `stageBudgetUsable`
+    // (clamped to the layer-0 cost ceiling), NOT raw `usable` — see the
+    // "Escalated-stage budget ceiling" note above. Without the clamp,
+    // `usable * 0.5` on a 1M-token model targets ~400K raw, larger than the
+    // ~200K cap that triggered compression AND larger than the layer-1 window,
+    // so escalating layers GREW the window and overflowed the model. Stage 0
+    // (layer 1, rawFrac=null) falls through to the unclamped base rawBudget /
+    // distilledBudget so the cache-stable raw-window pin keeps its full budget.
     const stageRawBudget =
-      stage.rawFrac !== null ? Math.floor(usable * stage.rawFrac) : rawBudget;
+      stage.rawFrac !== null
+        ? Math.floor(stageBudgetUsable * stage.rawFrac)
+        : rawBudget;
     const stageDistBudget =
       stage.distFrac !== null
-        ? Math.floor(usable * stage.distFrac)
+        ? Math.floor(stageBudgetUsable * stage.distFrac)
         : distilledBudget;
 
     // Determine prefix: if distLimit is finite, re-render with trimmed distillations.

--- a/packages/core/test/gradient.test.ts
+++ b/packages/core/test/gradient.test.ts
@@ -4225,6 +4225,43 @@ describe("tier-based context management", () => {
       expect(result.usable).toBeGreaterThan(900_000);
     });
 
+    test("escalated-stage DISTILLED prefix is clamped too (layer 2 distFrac fallthrough)", () => {
+      // Layer 2 has distFrac=null, so before the fix its distilled budget fell
+      // through to the UNCLAMPED base distilledBudget = usable*0.25 (~242K on a
+      // 1M model) — letting the prefix balloon above the cap even though the raw
+      // window was clamped. The escalated stages must clamp BOTH dimensions:
+      // layer-2 distilled budget = stageBudgetUsable*0.25 = 200K*0.25 = 50K.
+      setModelLimits({ context: 1_000_000, output: 32_000 });
+      setMaxLayer0Tokens(200_000);
+      calibrate(0);
+
+      // ~150K tokens of distillate — far above the clamped 50K layer-2 distilled
+      // budget, but below the unclamped base (~242K) so a missing clamp would
+      // NOT trim it. Keep raw tiny so the window is dominated by the prefix.
+      seedDistillations(25, 18_000); // 25 × 6K tokens = 150K tokens
+      const msgs = Array.from({ length: 6 }, (_, i) =>
+        makeMsg(
+          `dist-${i}`,
+          i % 2 === 0 ? "user" : "assistant",
+          "d".repeat(500),
+          SID,
+        ),
+      );
+
+      setForceMinLayer(2, SID);
+      const result = transform({
+        messages: msgs,
+        projectPath: `/test/${PID_KEY}`,
+        sessionID: SID,
+      });
+
+      expect(result.layer).toBeGreaterThanOrEqual(2);
+      // Clamped: distilled prefix trimmed to ~50K. Pre-fix (unclamped base) it
+      // would stay ~150K (no trim, since 150K < usable*0.25 ≈ 242K).
+      expect(result.distilledTokens).toBeLessThan(100_000);
+      expect(result.usable).toBeGreaterThan(900_000);
+    });
+
     test("hard-ceiling guard: a rebuilt over-ceiling window escalates instead of shipping (calibrated)", () => {
       // Cost cap disabled on a 200K model so budgetUsable === usable === maxInput
       // (168K). A forced layer-2 window fills prefix (0.25) + raw (0.5) ≈ 0.75 ×

--- a/packages/core/test/gradient.test.ts
+++ b/packages/core/test/gradient.test.ts
@@ -4003,6 +4003,9 @@ describe("tier-based context management", () => {
       // distilled+raw budget (~0.65*usable ≈ 620K) genuinely exceeds the clamp
       // target (layer0Ceiling = 200K). If usable here collapses (e.g. overhead
       // pollution), the test would pass for the wrong reason — so assert it.
+      // (The base distilled/raw budgets returned here are intentionally NOT
+      // clamped — they feed the layer-1 stable window; only the ESCALATED-stage
+      // builders and the tier gate's compressedEstimate clamp to the ceiling.)
       expect(result.usable).toBeGreaterThan(900_000);
       expect(result.distilledBudget + result.rawBudget).toBeGreaterThan(
         300_000,
@@ -4086,6 +4089,185 @@ describe("tier-based context management", () => {
       expect(result.unsustainable).toBe(true);
       // Restore pricing for sibling tests.
       setCachePricing(6.25 / 1_000_000, 0.5 / 1_000_000);
+    });
+  });
+
+  // Regression for the high-context overflow that wedged opencode session
+  // ses_14b9bf3d4ffeEaA95V1pK9b6Nj (lore 0AVWKugtmhBKqLOX9): on a 1M-token model
+  // the ESCALATED compression-stage budgets were scaled off the full `usable`
+  // (~800K), so `usable * rawFrac` (0.5) produced a ~400K raw window — LARGER
+  // than the ~200K cost cap whose breach triggered compression, AND larger than
+  // the layer-1 window. Escalating to a higher layer GREW the window (logs:
+  // layer-1 200K → layer-2 356K → 461K) until the real request overflowed the
+  // model. Two fixes:
+  //   1. clamp the ESCALATED-stage budgets (layers 2-3) to the layer-0 cost
+  //      ceiling — the layer-1 stable-window budget is deliberately left at the
+  //      full `usable * raw` so its cache-stable pin keeps eviction headroom, and
+  //   2. validate every rebuilt window against the hard ceiling (no free pass
+  //      for calibrated sessions, whose rebuilt windows are still chars/3
+  //      estimates that undercount the real tokenizer).
+  describe("gradient — high-context compression budget clamp (overflow fix)", () => {
+    const SID = "overflow-fix-sess";
+    const PID_KEY = "overflow-fix-project";
+    let projectId: string;
+    let createdCounter = 0;
+
+    function seedDistillations(count: number, charsEach: number) {
+      for (let i = 0; i < count; i++) {
+        db()
+          .query(
+            `INSERT INTO distillations (id, project_id, session_id, narrative, facts, observations, source_ids, generation, token_count, archived, created_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          )
+          .run(
+            crypto.randomUUID(),
+            projectId,
+            SID,
+            "",
+            "[]",
+            `Distillation ${i}: ${"o".repeat(charsEach)}`,
+            "[]",
+            0,
+            Math.ceil(charsEach / 3),
+            0,
+            Date.now() + createdCounter++,
+          );
+      }
+    }
+
+    beforeAll(() => {
+      projectId = ensureProject(`/test/${PID_KEY}`);
+    });
+
+    beforeEach(() => {
+      resetCalibration(SID);
+      resetPrefixCache(SID);
+      resetRawWindowCache(SID);
+      resetDistillationSnapshot(SID);
+      createdCounter = 0;
+      db()
+        .query("DELETE FROM distillations WHERE project_id = ?")
+        .run(projectId);
+      db().query("DELETE FROM session_state WHERE session_id = ?").run(SID);
+    });
+
+    afterAll(() => {
+      setModelLimits({ context: 10_000, output: 2_000 });
+      setMaxLayer0Tokens(0);
+      resetCalibration(SID);
+      calibrate(0);
+      db()
+        .query("DELETE FROM distillations WHERE project_id = ?")
+        .run(projectId);
+      db().query("DELETE FROM session_state WHERE session_id = ?").run(SID);
+    });
+
+    test("layer-1 base budgets are NOT clamped to the cost cap (cache-stable window keeps headroom)", () => {
+      // The narrow fix must clamp ONLY the escalated stages (layers 2-3). The
+      // layer-1 stable-window budget (returned as result.rawBudget/distilledBudget)
+      // MUST stay at the full `usable * fraction`. Clamping it to the cost cap
+      // (an earlier over-broad fix) shrank the raw-window pin so it marched every
+      // turn and busted the cache (regression caught by cache-stability.e2e).
+      // 1M context + a deliberately LOW 40K cost cap (mirrors that e2e test).
+      setModelLimits({ context: 1_000_000, output: 32_000 });
+      setMaxLayer0Tokens(40_000);
+      calibrate(0);
+
+      const result = transform({
+        messages: [
+          makeMsg("l1-1", "user", "hi", SID),
+          makeMsg("l1-2", "assistant", "ok", SID),
+        ],
+        projectPath: `/test/${PID_KEY}`,
+        sessionID: SID,
+      });
+
+      // usable stays the full ~968K (LTM / economics read this).
+      expect(result.usable).toBeGreaterThan(900_000);
+      // Base budgets scale off the full usable — NOT the 40K cap (which would
+      // give rawBudget = 40K*0.4 = 16K, starving the layer-1 pin).
+      expect(result.rawBudget).toBe(Math.floor(result.usable * 0.4));
+      expect(result.distilledBudget).toBe(Math.floor(result.usable * 0.25));
+      expect(result.rawBudget).toBeGreaterThan(40_000);
+    });
+
+    test("escalating to layer 2 on a 1M model stays bounded near the cap (does NOT grow)", () => {
+      setModelLimits({ context: 1_000_000, output: 32_000 });
+      setMaxLayer0Tokens(200_000);
+      calibrate(0);
+
+      // ~500K tokens of raw conversation — far more than any single stage
+      // budget, so the window size is determined by the BUDGET, not message
+      // scarcity. Pre-fix the layer-2 raw budget was usable*0.5 ≈ 476K, so the
+      // window grew to ~476K (and the real token count overflowed the model).
+      const msgs = Array.from({ length: 300 }, (_, i) =>
+        makeMsg(
+          `big-${i}`,
+          i % 2 === 0 ? "user" : "assistant",
+          "w".repeat(5_000),
+          SID,
+        ),
+      );
+
+      setForceMinLayer(2, SID); // jump straight to the layer that overflowed
+      const result = transform({
+        messages: msgs,
+        projectPath: `/test/${PID_KEY}`,
+        sessionID: SID,
+      });
+
+      expect(result.layer).toBeGreaterThanOrEqual(2);
+      // Post-fix the layer-2 raw budget = stageBudgetUsable*0.5 = 200K*0.5 =
+      // 100K, so the rebuilt window is ~100K — bounded by the cap, not a
+      // fraction of the 1M usable (pre-fix ~476K).
+      expect(result.totalTokens).toBeLessThan(200_000);
+      // `usable` itself is untouched (only the compression budgets are clamped).
+      expect(result.usable).toBeGreaterThan(900_000);
+    });
+
+    test("hard-ceiling guard: a rebuilt over-ceiling window escalates instead of shipping (calibrated)", () => {
+      // Cost cap disabled on a 200K model so budgetUsable === usable === maxInput
+      // (168K). A forced layer-2 window fills prefix (0.25) + raw (0.5) ≈ 0.75 ×
+      // 168K ≈ 126K; its chars/3 estimate undercounts the real tokenizer ~1.5×,
+      // so 126K*1.5 = 189K > 168K maxInput. Pre-fix, a CALIBRATED session got a
+      // free pass (`fitsWithSafetyMargin` returned true unconditionally) and
+      // shipped that over-ceiling window → "prompt is too long". Post-fix the
+      // guard rejects it and the loop escalates to a tighter layer.
+      setModelLimits({ context: 200_000, output: 32_000 }); // maxInput = 168K
+      setMaxLayer0Tokens(0); // disabled → budgetUsable === usable === 168K
+      calibrate(0);
+
+      // Prefix budget at layer 2 = 0.25*168K = 42K tokens; seed well past it so
+      // the prefix fills its budget after the binary-search trim.
+      seedDistillations(10, 18_000); // 10 × 6K tokens = 60K tokens of distillate
+      // Raw budget at layer 2 = 0.5*168K = 84K tokens; provide far more.
+      const msgs = Array.from({ length: 150 }, (_, i) =>
+        makeMsg(
+          `hc-${i}`,
+          i % 2 === 0 ? "user" : "assistant",
+          "h".repeat(3_000),
+          SID,
+        ),
+      );
+
+      // Mark the session calibrated WITHOUT a prior transform (so the shared
+      // overhead EMA is not perturbed and usable stays at the true 168K). This
+      // is the exact condition the pre-fix free pass applied to.
+      calibrate(120_000, SID, msgs.length);
+      setForceMinLayer(2, SID);
+
+      const result = transform({
+        messages: msgs,
+        projectPath: `/test/${PID_KEY}`,
+        sessionID: SID,
+      });
+
+      const maxInput = 200_000 - 32_000; // 168K
+      // The guard rejected the over-ceiling layer-2 window and escalated past
+      // the forced layer (pre-fix this stayed at layer 2 and overflowed).
+      expect(result.layer).toBeGreaterThanOrEqual(3);
+      // Whatever layer it lands on, the SHIPPED window must fit the hard ceiling.
+      expect(result.totalTokens).toBeLessThanOrEqual(maxInput);
     });
   });
 


### PR DESCRIPTION
## Problem

opencode session \`ses_14b9bf3d4ffeEaA95V1pK9b6Nj\` (lore \`0AVWKugtmhBKqLOX9\`, model \`claude-opus-4-8\` on the 1M-context beta) overflowed its context window and got wedged.

The escalated compression stages size their raw/distilled windows as a fraction of \`usable\` (the full model context):

| Layer | rawFrac | budget on a 1M model (usable ≈ 800K) |
|---|---|---|
| 1 (base) | 0.4 | ~320K |
| 2 | **0.5** | **~400K** |
| 3 | **0.55** | **~440K** |

These are **larger than the ~200K cost cap (\`l0cap\` = maxLayer0Tokens) whose breach triggers compression — and larger than the layer-1 window itself.** So escalating to a "more aggressive" layer paradoxically *grew* the context. Observed in the logs for the wedged session:

\`\`\`
22:33 layer=1 tokens=200415 (raw=166646) usable=635904 l0cap=200000
22:40 layer=2 tokens=356384 (raw=317357) usable=635088 l0cap=200000   <- grew
23:04 layer=2 tokens=461895 (raw=422127) usable=845835 l0cap=200000   <- grew more
\`\`\`

Compounded by the gradient's chars/3 token undercount (calibration proof: gradient estimate \`200,415\` → real \`last_known_input 380,577\`, ~1.9×), the real request reached ~840K–1.4M tokens → \`prompt is too long\`. The reactive \`force_min_layer=2\` then pinned the session to the broken layer, so every retry re-overflowed.

## Fix

1. **Clamp the escalated-stage budgets (layers 2-3) to the layer-0 cost ceiling** — \`stageBudgetUsable = min(usable, min(maxInput, maxLayer0Tokens))\` — so each higher layer actually shrinks the window toward the cap. The **layer-1 stable window** (stage 0, \`rawFrac=null\`) deliberately keeps the full \`usable * raw\` budget: the cost cap governs *when* to compress, not the layer-1 window size, and shrinking it would defeat the cache-stable raw-window pin (its chunked eviction needs headroom). No-op when the cost cap is disabled (\`maxLayer0Tokens=0\`) or on small-context models (\`usable < ceiling\`).
2. **Hard-ceiling guard:** \`fitsWithSafetyMargin()\` no longer gives calibrated sessions an unconditional pass. A rebuilt compression window is a fresh chars/3 estimate (not anchored to the API's last real count), so it is validated against the hard API ceiling with the undercount safety multiplier and escalates to a tighter layer (ultimately the always-returns emergency tail) if it would overflow.

## Tests

3 new regression tests, each **mutation-verified** load-bearing (reverting the fix makes them fail — the escalation test reproduces the production overflow at \`totalTokens=482,482\`):
- escalated layer-2 window stays bounded near the cap (does not grow) on a 1M model;
- layer-1 base budget is **not** clamped (guards against over-broad clamping that broke \`cache-stability.e2e\`);
- hard-ceiling guard escalates an over-ceiling rebuilt window instead of shipping it.

## Verification
- Full suite green (3626 passed, 0 failed); typecheck + lint clean.
- No behavior change for small-context models or when the cost cap is disabled.