### PR TITLE
fix(cache-warmer): preserve real cache_control breakpoints in warmup body

### DIFF
--- a/packages/gateway/src/cache-analytics.ts
+++ b/packages/gateway/src/cache-analytics.ts
@@ -506,8 +506,10 @@ export function analyzeCacheTurn(
   if (analytics.lastRequestBody !== null) {
     // lastRequestBody is stored RAW (with cache_control intact) for the warmer;
     // normalize on read so the divergence comparison stays apples-to-apples.
-    // normalizeBodyForComparison is idempotent, so this equals the old stored
-    // normalized form byte-for-byte — the comparison result is unchanged.
+    // Byte-identical to the old path: both apply normalizeBodyForComparison
+    // exactly once to the same raw bytes (old: normalize-then-store; now:
+    // store-then-normalize) — so prevBody, and every value derived from it, is
+    // unchanged.
     const prevBody = normalizeBodyForComparison(
       decompressBody(analytics.lastRequestBody),
     );
@@ -592,14 +594,24 @@ export function analyzeCacheTurn(
 
   // Store the RAW (as-sent) compressed body for next turn. Two consumers read
   // it: (1) the divergence comparison above, which normalizes on read so it
-  // stays apples-to-apples; (2) the cache warmer, which REPLAYS it and must see
-  // the real `cache_control` breakpoint layout. Previously we stored the
-  // normalized body (cache_control stripped), so the warmer collapsed to a
-  // single end-of-body breakpoint (ensureCacheBreakpoint) — large multi-
-  // breakpoint sessions then never matched the cached prefix (cacheRead=0 + full
-  // rewrite every warmup). lastRequestBodyLength stays the NORMALIZED length: it
-  // is only the divergence-ratio denominator (prefixMatchBytes is measured on
-  // normalized bodies).
+  // stays apples-to-apples; (2) the cache warmer, which REPLAYS it upstream.
+  //
+  // Why raw (this fixes the large-session cacheRead=0 bug): the warmer replays
+  // exactly what it reads here. The normalized form must NEVER go upstream — it
+  // rewrites the billing header in system[0] into NON-HEX placeholders
+  // (CCH_REPLACEMENT "cch=__", CC_VERSION_SUFFIX_REPLACEMENT ".___;"; see the
+  // "never re-parsed or sent upstream" note at CACHE_CONTROL_PATTERN). Anthropic
+  // strips a VALID-hex cch/cc_version before hashing the cache key (which is why
+  // real turns hit 92-100% despite cch changing every turn), but it does NOT
+  // strip the non-hex artifacts — so the old warmup's system[0] diverged from
+  // the cached prefix BEFORE the first breakpoint => guaranteed cacheRead=0 +
+  // full rewrite. Normalization also stripped every cache_control, so the warmup
+  // additionally collapsed to one end-of-body breakpoint (ensureCacheBreakpoint)
+  // instead of the real system[1]/tools/conversation layout. Storing raw fixes
+  // BOTH: the warmer replays the exact upstream bytes (valid-hex header via
+  // resignBody + real breakpoints). lastRequestBodyLength stays the NORMALIZED
+  // length — it is only the divergence-ratio denominator (prefixMatchBytes is
+  // measured on normalized bodies).
   analytics.lastRequestBody = compressBody(currentBody);
   analytics.lastRequestBodyLength = normalizedBody.length;
   analytics.lastCacheRead = cacheRead;

--- a/packages/gateway/src/cache-analytics.ts
+++ b/packages/gateway/src/cache-analytics.ts
@@ -504,7 +504,13 @@ export function analyzeCacheTurn(
 
   // Compare with previous body if available
   if (analytics.lastRequestBody !== null) {
-    const prevBody = decompressBody(analytics.lastRequestBody);
+    // lastRequestBody is stored RAW (with cache_control intact) for the warmer;
+    // normalize on read so the divergence comparison stays apples-to-apples.
+    // normalizeBodyForComparison is idempotent, so this equals the old stored
+    // normalized form byte-for-byte — the comparison result is unchanged.
+    const prevBody = normalizeBodyForComparison(
+      decompressBody(analytics.lastRequestBody),
+    );
     const prevLength = prevBody.length;
     const currLength = normalizedBody.length;
 
@@ -584,10 +590,17 @@ export function analyzeCacheTurn(
     }
   }
 
-  // Store normalized + compressed body for next turn. We store the normalized
-  // version so the next turn's comparison is apples-to-apples (both sides
-  // have volatile metadata stripped).
-  analytics.lastRequestBody = compressBody(normalizedBody);
+  // Store the RAW (as-sent) compressed body for next turn. Two consumers read
+  // it: (1) the divergence comparison above, which normalizes on read so it
+  // stays apples-to-apples; (2) the cache warmer, which REPLAYS it and must see
+  // the real `cache_control` breakpoint layout. Previously we stored the
+  // normalized body (cache_control stripped), so the warmer collapsed to a
+  // single end-of-body breakpoint (ensureCacheBreakpoint) — large multi-
+  // breakpoint sessions then never matched the cached prefix (cacheRead=0 + full
+  // rewrite every warmup). lastRequestBodyLength stays the NORMALIZED length: it
+  // is only the divergence-ratio denominator (prefixMatchBytes is measured on
+  // normalized bodies).
+  analytics.lastRequestBody = compressBody(currentBody);
   analytics.lastRequestBodyLength = normalizedBody.length;
   analytics.lastCacheRead = cacheRead;
   analytics.lastCacheCreation = cacheCreation;

--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -1882,11 +1882,17 @@ export async function executeWarmup(
       totalInput > 0
         ? `${((cacheReadTokens / totalInput) * 100).toFixed(0)}%`
         : "N/A";
+    // Diagnostic: number of cache_control breakpoints in the body we actually
+    // sent. Real turns place several (system[1], tools, conversation); a warmup
+    // that collapsed to a single end-of-body breakpoint is the body-divergence
+    // bug. Correlating this with the outcome confirms the breakpoint-preserving
+    // fix (raw stored body) is working: UNCACHED with breakpoints=1 was the bug.
+    const breakpoints = (signedBody.match(/"cache_control"/g) ?? []).length;
 
     if (cacheReadTokens > 0 && cacheCreationTokens === 0) {
       log.info(
         `cache-warmer: ✓ refresh session=${sid} ` +
-          `input=${totalInput} cacheRead=${cacheReadTokens} hit=${hitRate} cost=${costStr}`,
+          `input=${totalInput} cacheRead=${cacheReadTokens} hit=${hitRate} breakpoints=${breakpoints} cost=${costStr}`,
       );
     } else if (cacheReadTokens > 0 && cacheCreationTokens > 0) {
       // Partial hit — some breakpoints read, some written (e.g. conversation
@@ -1894,7 +1900,7 @@ export async function executeWarmup(
       log.info(
         `cache-warmer: ~ partial session=${sid} ` +
           `input=${totalInput} cacheRead=${cacheReadTokens} cacheWrite=${cacheCreationTokens} ` +
-          `hit=${hitRate} cost=${costStr}`,
+          `hit=${hitRate} breakpoints=${breakpoints} cost=${costStr}`,
       );
     } else {
       // cacheRead=0: the warmup wrote a fresh cache instead of refreshing an
@@ -1920,7 +1926,7 @@ export async function executeWarmup(
           // wire; signedBody.length would count UTF-16 code units and underreport
           // for multi-byte content (prose/code-heavy bodies — exactly the ones
           // this diagnostic targets).
-          `bodyBytes=${Buffer.byteLength(signedBody, "utf8")}` +
+          `bodyBytes=${Buffer.byteLength(signedBody, "utf8")} breakpoints=${breakpoints}` +
           (cacheLikelyAlive
             ? " — DIVERGENCE: cache should have been live but warmup missed " +
               "(warmup body ≠ cached prefix)"

--- a/packages/gateway/test/cache-analytics.test.ts
+++ b/packages/gateway/test/cache-analytics.test.ts
@@ -397,6 +397,76 @@ describe("analyzeCacheTurn", () => {
     expect(analytics.bustCount).toBe(0);
   });
 
+  test("stores the RAW body (cache_control retained) so the warmer replays breakpoints", () => {
+    const analytics = makeCacheAnalytics();
+    const body = JSON.stringify({
+      model: "opus",
+      system: [
+        { type: "text", text: "host" },
+        {
+          type: "text",
+          text: "stableLtm",
+          cache_control: { type: "ephemeral" },
+        },
+      ],
+      tools: [{ name: "t", cache_control: { type: "ephemeral" } }],
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "hi", cache_control: { type: "ephemeral" } },
+          ],
+        },
+      ],
+    });
+
+    analyzeCacheTurn(analytics, body, makeUsage());
+
+    // The warmer replays decompressBody(lastRequestBody); it MUST see the real
+    // multi-breakpoint layout, not a normalized (stripped) body that collapses
+    // to a single end-of-body breakpoint (the cacheRead=0 bug on large sessions).
+    const compressed = analytics.lastRequestBody;
+    if (!compressed) throw new Error("lastRequestBody should be set");
+    const stored = decompressBody(compressed);
+    expect((stored.match(/"cache_control"/g) ?? []).length).toBe(3);
+    // The divergence-ratio denominator stays the NORMALIZED length (< raw).
+    expect(analytics.lastRequestBodyLength).toBeLessThan(body.length);
+  });
+
+  test("comparison normalizes on read: a cache_control-only change is not divergence", () => {
+    const analytics = makeCacheAnalytics();
+    const withCC = JSON.stringify({
+      model: "opus",
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "hello world",
+              cache_control: { type: "ephemeral" },
+            },
+          ],
+        },
+      ],
+    });
+    const withoutCC = JSON.stringify({
+      model: "opus",
+      messages: [
+        { role: "user", content: [{ type: "text", text: "hello world" }] },
+      ],
+    });
+
+    analyzeCacheTurn(analytics, withCC, makeUsage()); // stores RAW (with cc)
+    const result = analyzeCacheTurn(analytics, withoutCC, makeUsage());
+
+    // prevBody is normalized on read, so the only difference (cache_control)
+    // vanishes on both sides → identical, NOT a false divergence. (Without the
+    // normalize-on-read this would diverge at the cache_control offset.)
+    expect(result.prefixMatchPercent).toBe(1);
+    expect(result.divergencePoint).toBe("<identical>");
+  });
+
   test("identical request bodies → 100% prefix match", () => {
     const analytics = makeCacheAnalytics();
     const body = JSON.stringify({

--- a/packages/gateway/test/cache-warmer.test.ts
+++ b/packages/gateway/test/cache-warmer.test.ts
@@ -408,13 +408,14 @@ describe("prepareAnthropicWarmupBody", () => {
     expect(result.messages).toHaveLength(3);
   });
 
-  // Integration: the warmer's ONLY body source is cache-analytics'
-  // `lastRequestBody`, which is stored AFTER `normalizeBodyForComparison`
-  // (cache-analytics strips `cache_control` markers so breakpoint movement
-  // doesn't pollute divergence analysis). A warmup with no breakpoint writes
-  // NOTHING to the cache — silently neutering warmups while the result
-  // classifier still reports success. The warmer must re-add a breakpoint.
-  test("re-adds a cache breakpoint after analytics normalization strips it", () => {
+  // ensureCacheBreakpoint is a DEFENSIVE fallback. cache-analytics now stores the
+  // RAW body (cache_control retained — see cache-analytics.test.ts), so the warmer
+  // normally replays the real multi-breakpoint layout. But a body that somehow
+  // arrives with NO breakpoint would write NOTHING to the cache — silently
+  // neutering the warmup while the classifier still reports success — so
+  // prepareAnthropicWarmupBody re-adds one as a safety net. This test exercises
+  // that fallback by feeding it a stripped body.
+  test("re-adds a cache breakpoint when a body has none (defensive fallback)", () => {
     const wireBody = JSON.stringify({
       model: "claude-sonnet-4-20250514",
       max_tokens: 16384,
@@ -432,8 +433,8 @@ describe("prepareAnthropicWarmupBody", () => {
       ],
     });
 
-    // Reproduce the real storage path: cache-analytics normalizes before
-    // persisting, which removes the breakpoint.
+    // Simulate a breakpoint-less body to exercise the fallback. (The normal
+    // path now stores the raw body with its breakpoints intact.)
     const stored = normalizeBodyForComparison(wireBody);
     expect(stored).not.toContain("cache_control");
 


### PR DESCRIPTION
The #838 diagnostic paid off — it confirmed the root cause of the circuit-breaker trips, and it's a concrete warmup bug, not the economics.

## Evidence from production logs
On the running gateway (which has #838's diagnostic), large sessions log **every** warmup as:
```
✗ UNCACHED ... cacheLikelyAlive=true ageSinceCacheTouch=284s ttl=300s — DIVERGENCE (warmup body ≠ cached prefix)
```
`cacheRead=0`, full rewrite, **$1–5 each** (158K–814K-token sessions). Small sessions refresh fine. `cacheLikelyAlive=true` + age < TTL ⇒ genuine **body divergence, not expiry**.

## Root cause (refined after review)
The warmer replays `cache-analytics.lastRequestBody`, which was stored as the **normalized** body. Two distinct faults, both from replaying a normalized body upstream:

1. **Content divergence in `system[0]` (dominant).** `normalizeBodyForComparison` rewrites the Claude Code billing header into **non-hex** placeholders — `cch=<hex>`→`cch=__`, `cc_version=…<3hex>`→`cc_version=…___`. Anthropic strips a *valid-hex* cch/cc_version before hashing the cache key (which is why real turns hit 92–100% despite cch changing every turn), but it does **not** strip the non-hex artifacts. Since they live in `system[0]` — **before** the first (`system[1]`) breakpoint — the replayed prefix diverged immediately ⇒ guaranteed `cacheRead=0`. This violated normalization's own documented invariant: *"never re-parsed or sent upstream."*
2. **Breakpoint collapse (secondary).** Normalization also strips every `cache_control`, so `ensureCacheBreakpoint` re-added a single end-of-body breakpoint instead of the real `system[1]`/tools/conversation layout.

Small single-block sessions (no stableLtm, less header surface) happened to survive both.

## Fix
Store the **raw as-sent body** (billing header + `cache_control` intact) and **normalize on read** for the divergence comparison. This restores the "normalized body never goes upstream" invariant: the warmer now replays the exact upstream bytes (valid-hex header re-signed by `resignBody`, real breakpoints). The comparison result is **byte-identical** to before — both paths apply `normalizeBodyForComparison` exactly once to the same raw bytes (old: normalize-then-store; now: store-then-normalize). `lastRequestBodyLength` stays the normalized length (only the divergence-ratio denominator).

## Diagnostic (same patch)
Adds `breakpoints=N` to all three warmup outcome logs. **Falsification signal:** if post-deploy we still see `UNCACHED` with `breakpoints>1`, the breakpoint-count theory is wrong and the residual cause is content divergence — useful either way.

## Tests
- cache-analytics: stored body **retains** `cache_control`; a `cache_control`-only change is **not** a divergence (guards normalize-on-read; non-vacuous — fails without the fix).
- cache-warmer: reframed the `ensureCacheBreakpoint` test as the defensive fallback it now is.

## Verification
typecheck (5 pkgs) clean; lint clean (15 warnings, all pre-existing); full suite **3625 passed**; `pnpm build` clean. Adversarial review: APPROVE-WITH-NITS, no MUST-FIX.

## Known residual (separate issue, not this PR)
`lastRequestBody` is invalidated on `/compact` and model/provider switches, but **not** on lore's own idle-time prefix mutations (meta-distill rewriting `messages[1]`, post-idle gradient compaction). For sessions lore aggressively compresses — often the large ones — the stored body can be stale, so this PR **reduces but may not fully eliminate** large-session misses. Tracked for follow-up.

## Note
The running gateway predates the shadow-economics wiring (#844/#846) — redeploying `main` after this lands brings **both** the breakpoint fix and the economics shadow data live.