### PR TITLE
feat(gateway): `lore start --bg` daemon mode + `lore stop`

### DIFF
--- a/packages/gateway/src/cli/help.ts
+++ b/packages/gateway/src/cli/help.ts
@@ -17,6 +17,8 @@ Commands:
                        Remote-gateway mode is also ON by default for long-running
                        setups — path-less sessions route to per-session buckets
                        so unrelated projects never merge onto the gateway cwd.
+                       Use --bg to run it detached in the background.
+  stop                Stop a background gateway started with \`lore start --bg\`
   setup [app]         Configure an AI app to route through lore
                        Supported: codex, opencode, claude-code
   logs                Show lore activity log
@@ -41,6 +43,8 @@ Options:
   -l, --local         Disable hosted mode AND remote-gateway mode for
                       \`lore start\` (keep FS ops active; bucket cwd fallback)
                       (env: LORE_HOSTED_MODE=0)
+      --bg, --daemon  \`lore start\`: run the gateway detached in the background,
+                      then print its address, PID, and log path and exit
   -d, --debug         Enable debug logging (env: LORE_DEBUG=1)
       --no-plugin     Skip auto-install of the @loreai/<app> plugin
                       for \`lore setup <app>\` (use on CI, air-gapped
@@ -122,6 +126,8 @@ Examples:
   lore -- --verbose --debug                  # Use -- to forward lore-like flags
   lore run --remote http://remote:3207  # Use a remote gateway
   lore start                    # Start gateway (hosted mode, FS ops disabled)
+  lore start --bg               # Start gateway in the background, then exit
+  lore stop                     # Stop a background gateway
   lore start --local            # Start gateway with FS ops enabled (local use)
   lore start -p 8080            # Start gateway on a custom port
   lore start -H 127.0.0.1 -H 100.69.65.125  # Bind to multiple interfaces

--- a/packages/gateway/src/cli/main.ts
+++ b/packages/gateway/src/cli/main.ts
@@ -118,6 +118,9 @@ const OPTIONS = {
   all: { type: "boolean" as const },
   // `lore start --local` — disable hosted mode (keep FS ops active)
   local: { type: "boolean" as const, short: "l" },
+  // `lore start --bg` / `--daemon` — run the gateway detached in the background
+  bg: { type: "boolean" as const },
+  daemon: { type: "boolean" as const },
   // `lore login` / `lore whoami` flags
   email: { type: "string" as const },
   verify: { type: "boolean" as const },
@@ -155,6 +158,8 @@ function buildStartOptions(values: {
   debug?: boolean;
   remote?: string;
   local?: boolean;
+  bg?: boolean;
+  daemon?: boolean;
 }): StartOptions {
   // Flatten: each --host value may itself be comma-separated
   const hosts = values.host?.flatMap((h) =>
@@ -169,6 +174,7 @@ function buildStartOptions(values: {
     debug: values.debug ?? undefined,
     remoteUrl: values.remote ?? undefined,
     local: values.local ?? undefined,
+    bg: values.bg || values.daemon || undefined,
   };
 }
 
@@ -266,6 +272,8 @@ export async function _cli(): Promise<void> {
       debug?: boolean;
       remote?: string;
       local?: boolean;
+      bg?: boolean;
+      daemon?: boolean;
     },
   );
 
@@ -281,6 +289,12 @@ export async function _cli(): Promise<void> {
       case "start":
         await commandStart(startOpts);
         break;
+
+      case "stop": {
+        const { commandStop } = await import("./stop");
+        await commandStop();
+        break;
+      }
 
       case "run": {
         // Lazy-import to avoid pulling in child_process + agent detection
@@ -378,6 +392,7 @@ export async function _cli(): Promise<void> {
             // Not a known agent — likely a typo. Show a helpful error.
             const knownCommands = [
               "start",
+              "stop",
               "run",
               "setup",
               "data",

--- a/packages/gateway/src/cli/start.ts
+++ b/packages/gateway/src/cli/start.ts
@@ -121,27 +121,85 @@ export function daemonSpawnSpec(opts: StartOptions): {
 }
 
 /**
- * Daemonize: re-spawn `lore start` detached with stdio redirected to a log
- * file, poll until the gateway is healthy, print where it's listening, and
- * exit 0. On timeout, point the user at the log file and exit non-zero.
+ * The host the daemon parent should probe. The detached child binds to
+ * `opts.hosts` (default 127.0.0.1), so a hardcoded 127.0.0.1 probe would time
+ * out when the user started with a non-loopback `--host` (e.g. a Tailscale or
+ * LAN address). Use the first configured host, falling back to loopback.
  */
-async function startDaemon(opts: StartOptions): Promise<never> {
+export function daemonProbeHost(opts: StartOptions): string {
+  const host = opts.hosts?.find((h) => h && h.length > 0);
+  return host ?? "127.0.0.1";
+}
+
+/** Injectable IO for the daemon orchestration, so `runDaemon` is testable. */
+export interface DaemonIO {
+  readPort: () => number | null;
+  probe: (url: string) => Promise<boolean>;
+  /** Spawn the detached child gateway; returns its pid (or undefined). */
+  spawnDaemon: () => number | undefined;
+  sleep: (ms: number) => Promise<void>;
+  now: () => number;
+  logInfo: (msg: string) => void;
+  logError: (msg: string) => void;
+  /** Health-poll budget in ms (default 10s). */
+  timeoutMs?: number;
+  /** Poll interval in ms (default 250). */
+  intervalMs?: number;
+}
+
+/**
+ * Daemon orchestration: reuse an already-running gateway, else spawn the
+ * detached child and poll until it's serving. Returns the process exit code
+ * (0 = healthy/reused, 1 = timed out). Pure of `process.exit` so it is
+ * unit-testable; `startDaemon` is the thin shell that wires real IO + exit.
+ */
+export async function runDaemon(
+  opts: StartOptions,
+  io: DaemonIO,
+): Promise<number> {
+  const host = daemonProbeHost(opts);
+
   // If a gateway is already up on the preferred port, don't start a second one.
-  const existingPort = readPortFile();
+  const existingPort = io.readPort();
   if (existingPort) {
-    const url = `http://127.0.0.1:${existingPort}`;
-    if (await probeGateway(url)) {
-      console.log(`[lore] Gateway already running on ${url}`);
-      console.log(`[lore] Dashboard: ${url}/ui`);
-      console.log(`[lore] Stop it with: lore stop`);
-      safeExit(0);
+    const url = `http://${host}:${existingPort}`;
+    if (await io.probe(url)) {
+      io.logInfo(`Gateway already running on ${url}`);
+      io.logInfo(`Dashboard: ${url}/ui`);
+      io.logInfo(`Stop it with: lore stop`);
+      return 0;
     }
   }
 
+  const pid = io.spawnDaemon();
+  const timeout = io.timeoutMs ?? 10_000;
+  const interval = io.intervalMs ?? 250;
+  const deadline = io.now() + timeout;
+  while (io.now() < deadline) {
+    await io.sleep(interval);
+    const port = io.readPort();
+    if (port && (await io.probe(`http://${host}:${port}`))) {
+      const url = `http://${host}:${port}`;
+      io.logInfo(`Gateway started in the background (pid ${pid})`);
+      io.logInfo(`Listening on ${url}`);
+      io.logInfo(`Dashboard: ${url}/ui`);
+      io.logInfo(`Logs: ${daemonLogPath()}`);
+      io.logInfo(`Stop it with: lore stop`);
+      return 0;
+    }
+  }
+
+  io.logError(
+    `Gateway did not become healthy within ${timeout}ms. Check the log: ${daemonLogPath()}`,
+  );
+  return 1;
+}
+
+/** Spawn the detached child gateway with stdio redirected to the log file. */
+function spawnDetachedGateway(opts: StartOptions): number | undefined {
   const logPath = daemonLogPath();
   mkdirSync(dataDir(), { recursive: true });
   const logFd = openSync(logPath, "a");
-
   const { command, args } = daemonSpawnSpec(opts);
   const child = spawn(command, args, {
     detached: true,
@@ -149,29 +207,30 @@ async function startDaemon(opts: StartOptions): Promise<never> {
     env: process.env,
   });
   child.unref();
+  return child.pid;
+}
 
-  // Poll the port file → probe, until the detached gateway is serving.
-  const deadline = Date.now() + 10_000;
-  while (Date.now() < deadline) {
-    await new Promise((r) => setTimeout(r, 250));
-    const port = readPortFile();
-    if (port && (await probeGateway(`http://127.0.0.1:${port}`))) {
-      const url = `http://127.0.0.1:${port}`;
-      console.log(
-        `[lore] Gateway started in the background (pid ${child.pid})`,
-      );
-      console.log(`[lore] Listening on ${url}`);
-      console.log(`[lore] Dashboard: ${url}/ui`);
-      console.log(`[lore] Logs: ${logPath}`);
-      console.log(`[lore] Stop it with: lore stop`);
-      safeExit(0);
-    }
-  }
+/** Build the real (production) IO for {@link runDaemon}. */
+export function realDaemonIO(opts: StartOptions): DaemonIO {
+  return {
+    readPort: readPortFile,
+    probe: probeGateway,
+    spawnDaemon: () => spawnDetachedGateway(opts),
+    sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+    now: Date.now,
+    logInfo: (msg) => console.log(`[lore] ${msg}`),
+    logError: (msg) => console.error(`[lore] ${msg}`),
+  };
+}
 
-  console.error(
-    `[lore] Gateway did not become healthy within 10s. Check the log: ${logPath}`,
-  );
-  safeExit(1);
+/**
+ * Daemonize: re-spawn `lore start` detached with stdio redirected to a log
+ * file, poll until the gateway is healthy, print where it's listening, and
+ * exit. Thin shell around `runDaemon` that supplies real IO and calls
+ * `safeExit`.
+ */
+async function startDaemon(opts: StartOptions): Promise<never> {
+  safeExit(await runDaemon(opts, realDaemonIO(opts)));
 }
 
 /**

--- a/packages/gateway/src/cli/start.ts
+++ b/packages/gateway/src/cli/start.ts
@@ -3,11 +3,15 @@
  *
  * Extracted from the old top-level index.ts boot logic.
  */
+import { spawn } from "node:child_process";
+import { openSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
 import { loadConfig, DEFAULT_PORTS, type GatewayConfig } from "../config";
 import { startServer } from "../server";
 import { resetPipelineState } from "../pipeline";
-import { writePortFile, removePortFile } from "../portfile";
-import { embedding } from "@loreai/core";
+import { writePortFile, removePortFile, readPortFile } from "../portfile";
+import { writePidFile, removePidFile } from "../pidfile";
+import { dataDir, embedding } from "@loreai/core";
 import { safeExit } from "./exit";
 import { installSignalShutdown } from "./shutdown";
 
@@ -25,6 +29,12 @@ export interface StartOptions {
    * CLI: `--local` / `-l`.
    */
   local?: boolean;
+  /**
+   * When true, `lore start` daemonizes: it re-spawns itself detached, polls
+   * the gateway until healthy, prints the address + PID + log path, and exits 0.
+   * CLI: `--bg` / `--daemon`.
+   */
+  bg?: boolean;
 }
 
 export interface GatewayHandle {
@@ -55,6 +65,113 @@ export async function probeGateway(
   } catch {
     return false;
   }
+}
+
+/** Path to the daemon's combined stdout/stderr log. */
+export function daemonLogPath(): string {
+  return join(dataDir(), "gateway.log");
+}
+
+/**
+ * Reconstruct the argv for the detached child of `lore start --bg`.
+ *
+ * The child runs a plain foreground `start` with the same effective options,
+ * MINUS the daemonize flag (or it would fork forever). Building from the typed
+ * options — rather than mangling `process.argv` — keeps this deterministic and
+ * unit-testable across the npm and standalone-binary invocation forms.
+ */
+export function buildStartChildArgs(opts: StartOptions): string[] {
+  const args: string[] = ["start"];
+  if (opts.port !== undefined) args.push("--port", String(opts.port));
+  if (opts.hosts?.length) {
+    for (const h of opts.hosts) args.push("--host", h);
+  }
+  if (opts.debug) args.push("--debug");
+  if (opts.local) args.push("--local");
+  if (opts.remoteUrl) args.push("--remote", opts.remoteUrl);
+  return args;
+}
+
+/**
+ * Whether we are running as a packaged single-executable (SEA) binary, in
+ * which case `process.execPath` IS the lore program and no script path is
+ * needed. In dev/npm mode `process.execPath` is node/bun and we must pass the
+ * script (`process.argv[1]`) as the first arg.
+ */
+function isSeaBinary(): boolean {
+  try {
+    const sea = require("node:sea") as { isSea?: () => boolean };
+    return typeof sea.isSea === "function" ? sea.isSea() : false;
+  } catch {
+    return false;
+  }
+}
+
+/** Build the `{ command, args }` used to re-spawn lore detached. */
+export function daemonSpawnSpec(opts: StartOptions): {
+  command: string;
+  args: string[];
+} {
+  const childArgs = buildStartChildArgs(opts);
+  if (isSeaBinary()) {
+    return { command: process.execPath, args: childArgs };
+  }
+  // Dev/npm: prepend the script path (node/bun <script> start …).
+  return { command: process.execPath, args: [process.argv[1], ...childArgs] };
+}
+
+/**
+ * Daemonize: re-spawn `lore start` detached with stdio redirected to a log
+ * file, poll until the gateway is healthy, print where it's listening, and
+ * exit 0. On timeout, point the user at the log file and exit non-zero.
+ */
+async function startDaemon(opts: StartOptions): Promise<never> {
+  // If a gateway is already up on the preferred port, don't start a second one.
+  const existingPort = readPortFile();
+  if (existingPort) {
+    const url = `http://127.0.0.1:${existingPort}`;
+    if (await probeGateway(url)) {
+      console.log(`[lore] Gateway already running on ${url}`);
+      console.log(`[lore] Dashboard: ${url}/ui`);
+      console.log(`[lore] Stop it with: lore stop`);
+      safeExit(0);
+    }
+  }
+
+  const logPath = daemonLogPath();
+  mkdirSync(dataDir(), { recursive: true });
+  const logFd = openSync(logPath, "a");
+
+  const { command, args } = daemonSpawnSpec(opts);
+  const child = spawn(command, args, {
+    detached: true,
+    stdio: ["ignore", logFd, logFd],
+    env: process.env,
+  });
+  child.unref();
+
+  // Poll the port file → probe, until the detached gateway is serving.
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 250));
+    const port = readPortFile();
+    if (port && (await probeGateway(`http://127.0.0.1:${port}`))) {
+      const url = `http://127.0.0.1:${port}`;
+      console.log(
+        `[lore] Gateway started in the background (pid ${child.pid})`,
+      );
+      console.log(`[lore] Listening on ${url}`);
+      console.log(`[lore] Dashboard: ${url}/ui`);
+      console.log(`[lore] Logs: ${logPath}`);
+      console.log(`[lore] Stop it with: lore stop`);
+      safeExit(0);
+    }
+  }
+
+  console.error(
+    `[lore] Gateway did not become healthy within 10s. Check the log: ${logPath}`,
+  );
+  safeExit(1);
 }
 
 /**
@@ -147,6 +264,8 @@ export async function startGateway(
 
       // Write port file so plugins can discover us (even on random port).
       writePortFile(actualPort);
+      // Write pid file so `lore stop` can find and signal this process.
+      writePidFile();
 
       const boundServer = server;
       let shutdownStarted = false;
@@ -156,6 +275,7 @@ export async function startGateway(
         console.error("[lore] Shutting down…");
         boundServer.stop();
         removePortFile(actualPort);
+        removePidFile();
         // `fast`: skip the synchronous batch-queue LLM drain on process exit —
         // replaying queued background prompts through retries is what made
         // Ctrl+C hang for minutes. They resume next session.
@@ -231,6 +351,11 @@ export async function startGateway(
  * SIGINT/SIGTERM.
  */
 export async function commandStart(opts: StartOptions): Promise<never> {
+  // Background mode: re-spawn detached, report status, and exit.
+  if (opts.bg) {
+    return startDaemon(opts);
+  }
+
   const { config, port, owned, shutdown } = await startGateway(opts);
 
   const addrs = config.hosts.map((h) => `http://${h}:${port}`);

--- a/packages/gateway/src/cli/stop.ts
+++ b/packages/gateway/src/cli/stop.ts
@@ -1,0 +1,108 @@
+/**
+ * `lore stop` — stop a gateway started in the background (`lore start --bg`)
+ * or any foreground `lore start` that wrote a PID file.
+ *
+ * Resolution order:
+ *   1. Live PID file       → SIGTERM the process, wait for it to exit.
+ *   2. No live PID but a reachable gateway (port file) → it's a foreground
+ *      process we can't signal by PID; tell the user to Ctrl+C it.
+ *   3. Stale PID file (process already gone) → clean it up, report nothing.
+ *   4. Nothing running     → no-op message.
+ */
+import { readPidFile, removePidFile, isProcessAlive } from "../pidfile";
+import { readPortFile } from "../portfile";
+import { probeGateway } from "./start";
+import { SHUTDOWN_DEADLINE_MS } from "./shutdown";
+
+export type StopPlan =
+  | { action: "signal"; pid: number }
+  | { action: "foreground"; port: number }
+  | { action: "stale"; pid: number }
+  | { action: "none" };
+
+/**
+ * Decide what `lore stop` should do given the observed pid/port state.
+ * Pure and unit-testable — no process signalling or IO here.
+ */
+export function planStop(input: {
+  pid: number | null;
+  pidAlive: boolean;
+  port: number | null;
+  portAlive: boolean;
+}): StopPlan {
+  // A live PID always wins — we can signal it directly.
+  if (input.pid !== null && input.pidAlive) {
+    return { action: "signal", pid: input.pid };
+  }
+  // No signallable PID, but a gateway is still answering — it's a foreground
+  // process (or one started without a PID file) we can't kill by PID.
+  if (input.port !== null && input.portAlive) {
+    return { action: "foreground", port: input.port };
+  }
+  // A PID file is present but the process is gone and nothing is serving.
+  if (input.pid !== null) {
+    return { action: "stale", pid: input.pid };
+  }
+  return { action: "none" };
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+export async function commandStop(): Promise<void> {
+  const pid = readPidFile();
+  const port = readPortFile();
+  const portAlive = port
+    ? await probeGateway(`http://127.0.0.1:${port}`)
+    : false;
+  const plan = planStop({
+    pid,
+    pidAlive: pid !== null && isProcessAlive(pid),
+    port,
+    portAlive,
+  });
+
+  switch (plan.action) {
+    case "signal": {
+      try {
+        process.kill(plan.pid, "SIGTERM");
+      } catch {
+        // Raced with exit — fall through to cleanup.
+      }
+      // Wait for the process to exit (bounded a bit beyond its own shutdown
+      // deadline so a clean graceful shutdown has time to finish).
+      const deadline = Date.now() + SHUTDOWN_DEADLINE_MS + 3000;
+      while (Date.now() < deadline) {
+        if (!isProcessAlive(plan.pid)) break;
+        await sleep(200);
+      }
+      if (isProcessAlive(plan.pid)) {
+        console.error(
+          `[lore] Gateway (pid ${plan.pid}) did not stop within the deadline.`,
+        );
+        process.exitCode = 1;
+        return;
+      }
+      removePidFile(plan.pid);
+      console.log(`[lore] Gateway stopped (pid ${plan.pid}).`);
+      return;
+    }
+    case "foreground":
+      console.error(
+        `[lore] A gateway is running on port ${plan.port} but no PID file was found.`,
+      );
+      console.error(
+        `[lore] It's likely a foreground \`lore start\` — stop it with Ctrl+C in its terminal.`,
+      );
+      process.exitCode = 1;
+      return;
+    case "stale":
+      removePidFile(plan.pid);
+      console.log(
+        `[lore] No running gateway found (cleaned up stale PID file).`,
+      );
+      return;
+    case "none":
+      console.log(`[lore] No running gateway found.`);
+      return;
+  }
+}

--- a/packages/gateway/src/cli/stop.ts
+++ b/packages/gateway/src/cli/stop.ts
@@ -46,17 +46,35 @@ export function planStop(input: {
   return { action: "none" };
 }
 
-const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+/** Injectable IO for the stop orchestration, so `runStop` is testable. */
+export interface StopIO {
+  readPid: () => number | null;
+  readPort: () => number | null;
+  probe: (url: string) => Promise<boolean>;
+  isAlive: (pid: number) => boolean;
+  kill: (pid: number) => void;
+  removePid: (pid: number) => void;
+  sleep: (ms: number) => Promise<void>;
+  now: () => number;
+  logInfo: (msg: string) => void;
+  logError: (msg: string) => void;
+  /** How long to wait for the signalled process to exit (ms). */
+  timeoutMs?: number;
+}
 
-export async function commandStop(): Promise<void> {
-  const pid = readPidFile();
-  const port = readPortFile();
-  const portAlive = port
-    ? await probeGateway(`http://127.0.0.1:${port}`)
-    : false;
+/**
+ * Stop orchestration: resolve the running gateway, signal it, and wait for it
+ * to exit. Returns the process exit code (0 = stopped/nothing-running,
+ * 1 = foreground or stuck). Pure of `process.exit`/real IO so it is
+ * unit-testable; `commandStop` is the thin shell that wires real IO.
+ */
+export async function runStop(io: StopIO): Promise<number> {
+  const pid = io.readPid();
+  const port = io.readPort();
+  const portAlive = port ? await io.probe(`http://127.0.0.1:${port}`) : false;
   const plan = planStop({
     pid,
-    pidAlive: pid !== null && isProcessAlive(pid),
+    pidAlive: pid !== null && io.isAlive(pid),
     port,
     portAlive,
   });
@@ -64,45 +82,62 @@ export async function commandStop(): Promise<void> {
   switch (plan.action) {
     case "signal": {
       try {
-        process.kill(plan.pid, "SIGTERM");
+        io.kill(plan.pid);
       } catch {
         // Raced with exit — fall through to cleanup.
       }
       // Wait for the process to exit (bounded a bit beyond its own shutdown
       // deadline so a clean graceful shutdown has time to finish).
-      const deadline = Date.now() + SHUTDOWN_DEADLINE_MS + 3000;
-      while (Date.now() < deadline) {
-        if (!isProcessAlive(plan.pid)) break;
-        await sleep(200);
+      const deadline = io.now() + (io.timeoutMs ?? SHUTDOWN_DEADLINE_MS + 3000);
+      while (io.now() < deadline) {
+        if (!io.isAlive(plan.pid)) break;
+        await io.sleep(200);
       }
-      if (isProcessAlive(plan.pid)) {
-        console.error(
-          `[lore] Gateway (pid ${plan.pid}) did not stop within the deadline.`,
+      if (io.isAlive(plan.pid)) {
+        io.logError(
+          `Gateway (pid ${plan.pid}) did not stop within the deadline.`,
         );
-        process.exitCode = 1;
-        return;
+        return 1;
       }
-      removePidFile(plan.pid);
-      console.log(`[lore] Gateway stopped (pid ${plan.pid}).`);
-      return;
+      io.removePid(plan.pid);
+      io.logInfo(`Gateway stopped (pid ${plan.pid}).`);
+      return 0;
     }
     case "foreground":
-      console.error(
-        `[lore] A gateway is running on port ${plan.port} but no PID file was found.`,
+      io.logError(
+        `A gateway is running on port ${plan.port} but no PID file was found.`,
       );
-      console.error(
-        `[lore] It's likely a foreground \`lore start\` — stop it with Ctrl+C in its terminal.`,
+      io.logError(
+        `It's likely a foreground \`lore start\` — stop it with Ctrl+C in its terminal.`,
       );
-      process.exitCode = 1;
-      return;
+      return 1;
     case "stale":
-      removePidFile(plan.pid);
-      console.log(
-        `[lore] No running gateway found (cleaned up stale PID file).`,
-      );
-      return;
+      io.removePid(plan.pid);
+      io.logInfo(`No running gateway found (cleaned up stale PID file).`);
+      return 0;
     case "none":
-      console.log(`[lore] No running gateway found.`);
-      return;
+      io.logInfo(`No running gateway found.`);
+      return 0;
   }
+}
+
+/** Build the real (production) IO for {@link runStop}. */
+export function realStopIO(): StopIO {
+  return {
+    readPid: readPidFile,
+    readPort: readPortFile,
+    probe: probeGateway,
+    isAlive: isProcessAlive,
+    kill: (pid) => process.kill(pid, "SIGTERM"),
+    removePid: removePidFile,
+    sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+    now: Date.now,
+    logInfo: (msg) => console.log(`[lore] ${msg}`),
+    logError: (msg) => console.error(`[lore] ${msg}`),
+  };
+}
+
+export async function commandStop(): Promise<void> {
+  const code = await runStop(realStopIO());
+  if (code !== 0) process.exitCode = code;
 }

--- a/packages/gateway/src/pidfile.ts
+++ b/packages/gateway/src/pidfile.ts
@@ -1,0 +1,70 @@
+/**
+ * PID file management — lets `lore stop` find a gateway started in the
+ * background (`lore start --bg`) or foreground.
+ *
+ * When the gateway starts and owns the server, it writes its own PID to
+ * `~/.local/share/lore/gateway.pid`. `lore stop` reads this file to send the
+ * process a SIGTERM. The file is removed on clean shutdown; a stale file (from
+ * a crash) is harmless — `lore stop` verifies the process is actually alive
+ * before signalling, and treats a dead PID as "nothing running."
+ *
+ * Mirrors `portfile.ts` semantics (write/read/remove-if-matches).
+ */
+import { join } from "node:path";
+import { writeFileSync, unlinkSync, readFileSync, mkdirSync } from "node:fs";
+import { dataDir } from "@loreai/core";
+
+const PIDFILE_NAME = "gateway.pid";
+
+function pidfilePath(): string {
+  return join(dataDir(), PIDFILE_NAME);
+}
+
+/** Write the current process PID to disk so `lore stop` can find us. */
+export function writePidFile(pid: number = process.pid): void {
+  const dir = dataDir();
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(pidfilePath(), String(pid), "utf8");
+}
+
+/**
+ * Remove the PID file on shutdown — but only if it still contains the PID
+ * this instance wrote. Prevents a concurrent gateway from losing its PID file
+ * when a different instance shuts down.
+ */
+export function removePidFile(expectedPid: number = process.pid): void {
+  try {
+    const current = readPidFile();
+    if (current === expectedPid) {
+      unlinkSync(pidfilePath());
+    }
+  } catch {
+    /* already gone or unreadable */
+  }
+}
+
+/** Read the PID file. Returns the PID or null if not found/invalid. */
+export function readPidFile(): number | null {
+  try {
+    const content = readFileSync(pidfilePath(), "utf8").trim();
+    const pid = Number.parseInt(content, 10);
+    return pid > 0 ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check whether a process with the given PID is alive. Uses signal 0, which
+ * performs error checking without actually sending a signal. Returns false for
+ * a dead PID (ESRCH) and true for a live one (including EPERM — the process
+ * exists but we lack permission to signal it).
+ */
+export function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    return (e as NodeJS.ErrnoException).code === "EPERM";
+  }
+}

--- a/packages/gateway/test/daemon-args.test.ts
+++ b/packages/gateway/test/daemon-args.test.ts
@@ -1,5 +1,40 @@
-import { describe, it, expect } from "vitest";
-import { buildStartChildArgs } from "../src/cli/start";
+import { describe, it, expect, vi } from "vitest";
+import {
+  buildStartChildArgs,
+  daemonProbeHost,
+  daemonSpawnSpec,
+  daemonLogPath,
+  runDaemon,
+  realDaemonIO,
+  type DaemonIO,
+} from "../src/cli/start";
+import { readPortFile } from "../src/portfile";
+
+/** Build a DaemonIO with sensible defaults, overridable per test. */
+function makeDaemonIO(overrides: Partial<DaemonIO> = {}): {
+  io: DaemonIO;
+  info: string[];
+  errors: string[];
+  spawned: () => number;
+} {
+  const info: string[] = [];
+  const errors: string[] = [];
+  let spawnCount = 0;
+  const io: DaemonIO = {
+    readPort: () => null,
+    probe: async () => false,
+    spawnDaemon: () => {
+      spawnCount++;
+      return 4242;
+    },
+    sleep: async () => {},
+    now: () => 0,
+    logInfo: (m) => info.push(m),
+    logError: (m) => errors.push(m),
+    ...overrides,
+  };
+  return { io, info, errors, spawned: () => spawnCount };
+}
 
 describe("buildStartChildArgs", () => {
   it("always starts with the `start` command", () => {
@@ -72,5 +107,110 @@ describe("buildStartChildArgs", () => {
 
   it("emits just `start` for empty options", () => {
     expect(buildStartChildArgs({})).toEqual(["start"]);
+  });
+});
+
+describe("daemonProbeHost", () => {
+  it("defaults to loopback when no host is configured", () => {
+    expect(daemonProbeHost({})).toBe("127.0.0.1");
+    expect(daemonProbeHost({ hosts: [] })).toBe("127.0.0.1");
+  });
+
+  it("uses the first configured host (Seer #875: non-loopback bind)", () => {
+    expect(daemonProbeHost({ hosts: ["100.64.0.1"] })).toBe("100.64.0.1");
+  });
+
+  it("skips empty host entries", () => {
+    expect(daemonProbeHost({ hosts: ["", "10.0.0.5"] })).toBe("10.0.0.5");
+  });
+});
+
+describe("daemonSpawnSpec", () => {
+  it("uses process.execPath and includes the reconstructed start args", () => {
+    const spec = daemonSpawnSpec({ port: 3299 });
+    expect(spec.command).toBe(process.execPath);
+    // In dev/test (not a SEA binary) the script path is prepended.
+    expect(spec.args[0]).toBe(process.argv[1]);
+    expect(spec.args).toContain("start");
+    expect(spec.args).toContain("3299");
+    expect(spec.args).not.toContain("--bg");
+  });
+});
+
+describe("daemonLogPath", () => {
+  it("points at gateway.log in the data dir", () => {
+    expect(daemonLogPath().endsWith("gateway.log")).toBe(true);
+  });
+});
+
+describe("runDaemon", () => {
+  it("reuses an already-running gateway without spawning", async () => {
+    const { io, info, spawned } = makeDaemonIO({
+      readPort: () => 3207,
+      probe: async () => true,
+    });
+    const code = await runDaemon({}, io);
+    expect(code).toBe(0);
+    expect(spawned()).toBe(0);
+    expect(info.join("\n")).toContain("already running");
+  });
+
+  it("probes the configured non-loopback host (Seer #875)", async () => {
+    const { io, info } = makeDaemonIO({
+      readPort: () => 3207,
+      probe: async (url) => url.includes("100.64.0.1"),
+    });
+    const code = await runDaemon({ hosts: ["100.64.0.1"] }, io);
+    expect(code).toBe(0);
+    expect(info.join("\n")).toContain("100.64.0.1:3207");
+  });
+
+  it("spawns, polls, and reports the healthy gateway", async () => {
+    let portCalls = 0;
+    const { io, info, spawned } = makeDaemonIO({
+      // existing-check → no port yet; first poll → port present
+      readPort: () => (portCalls++ === 0 ? null : 3299),
+      probe: async () => true,
+    });
+    const code = await runDaemon({ port: 3299 }, io);
+    expect(code).toBe(0);
+    expect(spawned()).toBe(1);
+    expect(info.join("\n")).toContain("pid 4242");
+    expect(info.join("\n")).toContain("3299");
+  });
+
+  it("returns 1 and logs an error on health-poll timeout", async () => {
+    let t = 0;
+    const { io, errors, spawned } = makeDaemonIO({
+      readPort: () => 3299,
+      probe: async () => false, // never healthy
+      now: () => (t += 5000), // 5000, 10000, 15000 → past the 10s deadline
+      timeoutMs: 10_000,
+    });
+    const code = await runDaemon({}, io);
+    expect(code).toBe(1);
+    expect(spawned()).toBe(1);
+    expect(errors.join("\n")).toContain("did not become healthy");
+  });
+});
+
+describe("realDaemonIO", () => {
+  it("wires real dependencies (without spawning)", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const io = realDaemonIO({ port: 3299 });
+      expect(io.readPort).toBe(readPortFile);
+      expect(typeof io.spawnDaemon).toBe("function"); // not invoked here
+      expect(io.now()).toBeGreaterThan(0);
+      await io.sleep(0);
+      io.logInfo("hello");
+      io.logError("oops");
+      expect(log).toHaveBeenCalledWith("[lore] hello");
+      expect(err).toHaveBeenCalledWith("[lore] oops");
+    } finally {
+      log.mockRestore();
+      err.mockRestore();
+    }
   });
 });

--- a/packages/gateway/test/daemon-args.test.ts
+++ b/packages/gateway/test/daemon-args.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { buildStartChildArgs } from "../src/cli/start";
+
+describe("buildStartChildArgs", () => {
+  it("always starts with the `start` command", () => {
+    expect(buildStartChildArgs({})[0]).toBe("start");
+  });
+
+  it("never includes the daemonize flag (--bg / --daemon)", () => {
+    // Even though the parent was invoked with --bg, the detached child must
+    // run a plain foreground `start` or it would fork forever.
+    const args = buildStartChildArgs({ bg: true, port: 3207 });
+    expect(args).not.toContain("--bg");
+    expect(args).not.toContain("--daemon");
+  });
+
+  it("reconstructs --port", () => {
+    expect(buildStartChildArgs({ port: 8080 })).toEqual([
+      "start",
+      "--port",
+      "8080",
+    ]);
+  });
+
+  it("reconstructs multiple --host flags (one per host)", () => {
+    const args = buildStartChildArgs({ hosts: ["127.0.0.1", "100.64.0.1"] });
+    expect(args).toEqual([
+      "start",
+      "--host",
+      "127.0.0.1",
+      "--host",
+      "100.64.0.1",
+    ]);
+  });
+
+  it("reconstructs --debug only when true", () => {
+    expect(buildStartChildArgs({ debug: true })).toContain("--debug");
+    expect(buildStartChildArgs({ debug: false })).not.toContain("--debug");
+  });
+
+  it("reconstructs --local only when true", () => {
+    expect(buildStartChildArgs({ local: true })).toContain("--local");
+    expect(buildStartChildArgs({ local: false })).not.toContain("--local");
+  });
+
+  it("reconstructs --remote", () => {
+    expect(buildStartChildArgs({ remoteUrl: "http://remote:3207" })).toEqual([
+      "start",
+      "--remote",
+      "http://remote:3207",
+    ]);
+  });
+
+  it("combines all options in a stable order", () => {
+    const args = buildStartChildArgs({
+      bg: true,
+      port: 3207,
+      hosts: ["127.0.0.1"],
+      debug: true,
+      local: true,
+    });
+    expect(args).toEqual([
+      "start",
+      "--port",
+      "3207",
+      "--host",
+      "127.0.0.1",
+      "--debug",
+      "--local",
+    ]);
+  });
+
+  it("emits just `start` for empty options", () => {
+    expect(buildStartChildArgs({})).toEqual(["start"]);
+  });
+});

--- a/packages/gateway/test/pidfile.test.ts
+++ b/packages/gateway/test/pidfile.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  writePidFile,
+  readPidFile,
+  removePidFile,
+  isProcessAlive,
+} from "../src/pidfile";
+
+// Clean up any pid file we wrote during tests.
+afterEach(() => {
+  try {
+    writePidFile(999999);
+    removePidFile(999999);
+  } catch {
+    /* best effort */
+  }
+});
+
+describe("pidfile", () => {
+  it("readPidFile returns null when no file exists", () => {
+    writePidFile(999999);
+    removePidFile(999999);
+    expect(readPidFile()).toBeNull();
+  });
+
+  it("writePidFile + readPidFile round-trips a pid", () => {
+    writePidFile(4242);
+    expect(readPidFile()).toBe(4242);
+  });
+
+  it("writePidFile overwrites an existing pid file", () => {
+    writePidFile(4242);
+    writePidFile(5353);
+    expect(readPidFile()).toBe(5353);
+  });
+
+  it("removePidFile deletes the file when pid matches", () => {
+    writePidFile(4242);
+    removePidFile(4242);
+    expect(readPidFile()).toBeNull();
+  });
+
+  it("removePidFile does NOT delete the file when pid differs", () => {
+    writePidFile(5353);
+    removePidFile(4242); // wrong pid — should not remove
+    expect(readPidFile()).toBe(5353);
+  });
+
+  it("removePidFile is a no-op when no file exists", () => {
+    removePidFile(4242);
+    expect(readPidFile()).toBeNull();
+  });
+
+  it("readPidFile rejects invalid content", () => {
+    writePidFile(0);
+    expect(readPidFile()).toBeNull();
+    writePidFile(-5);
+    expect(readPidFile()).toBeNull();
+  });
+
+  it("isProcessAlive returns true for the current process", () => {
+    expect(isProcessAlive(process.pid)).toBe(true);
+  });
+
+  it("isProcessAlive returns false for a non-existent pid", () => {
+    // PID 2^31-1 is effectively never a live process.
+    expect(isProcessAlive(2147483646)).toBe(false);
+  });
+});

--- a/packages/gateway/test/stop-plan.test.ts
+++ b/packages/gateway/test/stop-plan.test.ts
@@ -1,5 +1,33 @@
-import { describe, it, expect } from "vitest";
-import { planStop } from "../src/cli/stop";
+import { describe, it, expect, vi } from "vitest";
+import { planStop, runStop, realStopIO, type StopIO } from "../src/cli/stop";
+import { readPidFile } from "../src/pidfile";
+
+function makeStopIO(overrides: Partial<StopIO> = {}): {
+  io: StopIO;
+  info: string[];
+  errors: string[];
+  killed: () => number[];
+  removed: () => number[];
+} {
+  const info: string[] = [];
+  const errors: string[] = [];
+  const killed: number[] = [];
+  const removed: number[] = [];
+  const io: StopIO = {
+    readPid: () => null,
+    readPort: () => null,
+    probe: async () => false,
+    isAlive: () => false,
+    kill: (pid) => killed.push(pid),
+    removePid: (pid) => removed.push(pid),
+    sleep: async () => {},
+    now: () => 0,
+    logInfo: (m) => info.push(m),
+    logError: (m) => errors.push(m),
+    ...overrides,
+  };
+  return { io, info, errors, killed: () => killed, removed: () => removed };
+}
 
 describe("planStop", () => {
   it("signals a live PID", () => {
@@ -43,5 +71,84 @@ describe("planStop", () => {
     expect(
       planStop({ pid: null, pidAlive: false, port: null, portAlive: false }),
     ).toEqual({ action: "none" });
+  });
+});
+
+describe("runStop", () => {
+  it("signals a live PID and reports success once it exits", async () => {
+    let aliveChecks = 0;
+    const { io, info, killed, removed } = makeStopIO({
+      readPid: () => 4242,
+      // planStop sees it alive; the wait loop then sees it die.
+      isAlive: () => aliveChecks++ < 1,
+    });
+    const code = await runStop(io);
+    expect(code).toBe(0);
+    expect(killed()).toEqual([4242]);
+    expect(removed()).toEqual([4242]);
+    expect(info.join("\n")).toContain("Gateway stopped (pid 4242)");
+  });
+
+  it("returns 1 when the signalled process never exits", async () => {
+    let t = 0;
+    const { io, errors } = makeStopIO({
+      readPid: () => 4242,
+      isAlive: () => true, // never dies
+      now: () => (t += 4000),
+      timeoutMs: 5000,
+    });
+    const code = await runStop(io);
+    expect(code).toBe(1);
+    expect(errors.join("\n")).toContain("did not stop");
+  });
+
+  it("reports a foreground gateway (live port, no PID) and returns 1", async () => {
+    const { io, errors } = makeStopIO({
+      readPid: () => null,
+      readPort: () => 3207,
+      probe: async () => true,
+    });
+    const code = await runStop(io);
+    expect(code).toBe(1);
+    expect(errors.join("\n")).toContain("no PID file");
+  });
+
+  it("cleans up a stale PID file and returns 0", async () => {
+    const { io, info, removed } = makeStopIO({
+      readPid: () => 4242,
+      isAlive: () => false, // dead
+    });
+    const code = await runStop(io);
+    expect(code).toBe(0);
+    expect(removed()).toEqual([4242]);
+    expect(info.join("\n")).toContain("stale PID file");
+  });
+
+  it("reports nothing running and returns 0", async () => {
+    const { io, info } = makeStopIO();
+    const code = await runStop(io);
+    expect(code).toBe(0);
+    expect(info.join("\n")).toContain("No running gateway found");
+  });
+});
+
+describe("realStopIO", () => {
+  it("wires real dependencies (without killing anything)", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const io = realStopIO();
+      expect(io.readPid).toBe(readPidFile);
+      expect(typeof io.kill).toBe("function"); // not invoked here
+      expect(io.now()).toBeGreaterThan(0);
+      await io.sleep(0);
+      io.logInfo("hi");
+      io.logError("no");
+      expect(log).toHaveBeenCalledWith("[lore] hi");
+      expect(err).toHaveBeenCalledWith("[lore] no");
+    } finally {
+      log.mockRestore();
+      err.mockRestore();
+    }
   });
 });

--- a/packages/gateway/test/stop-plan.test.ts
+++ b/packages/gateway/test/stop-plan.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { planStop } from "../src/cli/stop";
+
+describe("planStop", () => {
+  it("signals a live PID", () => {
+    expect(
+      planStop({ pid: 4242, pidAlive: true, port: 3207, portAlive: true }),
+    ).toEqual({ action: "signal", pid: 4242 });
+  });
+
+  it("prefers signalling the PID even when the port is also alive", () => {
+    expect(
+      planStop({ pid: 4242, pidAlive: true, port: 3207, portAlive: true })
+        .action,
+    ).toBe("signal");
+  });
+
+  it("reports a foreground gateway when the PID is dead but the port answers", () => {
+    expect(
+      planStop({ pid: 4242, pidAlive: false, port: 3207, portAlive: true }),
+    ).toEqual({ action: "foreground", port: 3207 });
+  });
+
+  it("reports a foreground gateway when there is no PID file but the port answers", () => {
+    expect(
+      planStop({ pid: null, pidAlive: false, port: 3207, portAlive: true }),
+    ).toEqual({ action: "foreground", port: 3207 });
+  });
+
+  it("treats a dead PID with no live port as stale", () => {
+    expect(
+      planStop({ pid: 4242, pidAlive: false, port: null, portAlive: false }),
+    ).toEqual({ action: "stale", pid: 4242 });
+  });
+
+  it("treats a dead PID with a dead port as stale", () => {
+    expect(
+      planStop({ pid: 4242, pidAlive: false, port: 3207, portAlive: false }),
+    ).toEqual({ action: "stale", pid: 4242 });
+  });
+
+  it("reports nothing running when there is no PID and no live port", () => {
+    expect(
+      planStop({ pid: null, pidAlive: false, port: null, portAlive: false }),
+    ).toEqual({ action: "none" });
+  });
+});


### PR DESCRIPTION
## What

Adds a background/daemon mode for the gateway and a `lore stop` command.

- **`lore start --bg`** (alias `--daemon`): re-spawns the gateway detached with stdio redirected to `~/.local/share/lore/gateway.log`, polls `/health` until it's serving, then prints the address, PID, and log path and exits 0. On a 10s timeout it points at the log and exits non-zero.
- **`lore stop`**: finds the gateway via a new PID file and sends `SIGTERM` (falls back to a clear message for a foreground gateway that has no PID file).

## Why

`lore setup` writes a persistent global redirect with no lifecycle coupling — if the gateway is down, the configured agent can't connect. Until now there was no way to keep a gateway running in the background (`lore start` blocks the foreground forever). This makes the "setup + persistent gateway" path viable.

## Details

- New `pidfile.ts` mirrors `portfile.ts` (write / read / remove-if-matches) plus `isProcessAlive` (signal `0`). Written in `startGateway`'s owned-server branch, removed on shutdown.
- `cli/stop.ts` factors a pure `planStop` decision function (signal / foreground / stale / none).
- `buildStartChildArgs` reconstructs the detached child's argv deterministically from typed options (never re-passes `--bg`), so it works in both npm and SEA-binary forms.

## Tests

- `pidfile.test.ts`, `daemon-args.test.ts`, `stop-plan.test.ts` (TDD).
- Verified end-to-end via the CJS bundle in an isolated data dir: `start --bg` came up detached and `stop` cleanly terminated it.

Part of the setup-UX hardening from user feedback. A follow-up PR (setup hardening: liveness probe at setup, `lore setup undo`, run-first guidance) stacks on this. Related: #869, #870.
