### PR TITLE
feat(gateway): harden `lore setup` — liveness, undo, run-first guidance

### DIFF
--- a/packages/gateway/src/cli/help.ts
+++ b/packages/gateway/src/cli/help.ts
@@ -19,8 +19,12 @@ Commands:
                        so unrelated projects never merge onto the gateway cwd.
                        Use --bg to run it detached in the background.
   stop                Stop a background gateway started with \`lore start --bg\`
-  setup [app]         Configure an AI app to route through lore
+  setup [app]         Configure an AI app to route through lore. Prefer \`lore run\`
+                       for terminal agents; use setup for GUI/IDE agents lore can't
+                       launch, paired with a background gateway (\`lore start --bg\`).
                        Supported: codex, opencode, claude-code
+                       \`setup undo [app]\` reverts a previous setup (restores
+                       the backup lore saved before it changed your config)
   logs                Show lore activity log
   import              Import knowledge from prior AI agent conversations
   data <subcommand>   Manage stored data (list, show, clear, delete)
@@ -136,6 +140,8 @@ Examples:
   lore setup codex              # Configure Codex to use lore
   lore setup codex -r http://remote:3207  # Configure Codex with a remote gateway
   lore setup opencode --no-plugin  # Configure OpenCode without installing the @loreai/opencode plugin
+  lore setup undo               # Undo setup for all configured apps
+  lore setup undo claude-code   # Undo setup for Claude Code only
   lore upgrade                  # Upgrade to latest version
   lore upgrade --check          # Check for updates without installing
   lore upgrade --force          # Force re-download even if up to date

--- a/packages/gateway/src/cli/run.ts
+++ b/packages/gateway/src/cli/run.ts
@@ -103,6 +103,12 @@ async function resolveLaunchTarget(
       "[lore] Install one of: Claude Code (claude), Codex (codex), Pi (pi), OpenCode (opencode), Hermes (hermes)",
     );
     console.error(`[lore] Or run with an explicit command: lore run <command>`);
+    console.error(
+      `[lore] Using a GUI/IDE agent (Claude Desktop, an IDE extension)? Run`,
+    );
+    console.error(
+      `[lore]   \`lore setup <app>\` and keep a gateway up with \`lore start --bg\`.`,
+    );
     return null;
   }
 

--- a/packages/gateway/src/cli/setup-backup.ts
+++ b/packages/gateway/src/cli/setup-backup.ts
@@ -204,6 +204,10 @@ const TOML_BACKUP_HEADER =
   "# lore setup backup — original values (run `lore setup undo codex` to restore):";
 const TOML_BACKUP_FOOTER = "# end lore setup backup";
 const TOML_UNSET = "(was unset)";
+// Separates the (uncommentable) prior value from the value lore wrote. Restore
+// compares the current value against the lore-set value and only reverts when
+// they still match — mirroring the JSON "revert-only-if-unchanged" guarantee.
+const TOML_LORE_SET = " # lore-set ";
 
 /** Extract the raw value text of a top-level TOML key, or null if absent. */
 export function getTomlTopLevelValue(
@@ -250,22 +254,26 @@ export function deleteTomlTopLevelKey(content: string, key: string): string {
 }
 
 /**
- * Build the commented backup block for the given keys from the *original*
- * content. Returns null if a block already exists (preserve the true original)
- * or if there are no keys.
+ * Build the commented backup block from the *original* content and the values
+ * lore is about to write (`loreValues`: key → raw TOML value, e.g.
+ * `{ openai_base_url: '"http://…/v1"' }`). Each entry records the prior value
+ * (uncommentable to restore) plus the lore-set value, so undo can revert only
+ * when the file still holds lore's value. Returns null if a block already
+ * exists (preserve the true original) or there are no keys.
  */
 export function buildTomlBackupBlock(
   content: string,
-  keys: string[],
+  loreValues: Record<string, string>,
 ): string | null {
   if (content.includes(TOML_BACKUP_HEADER)) return null;
+  const keys = Object.keys(loreValues);
   if (keys.length === 0) return null;
   const lines = [TOML_BACKUP_HEADER];
   for (const key of keys) {
     const prior = getTomlTopLevelValue(content, key);
-    lines.push(
-      prior === null ? `#   ${key} ${TOML_UNSET}` : `#   ${key} = ${prior}`,
-    );
+    const priorPart =
+      prior === null ? `${key} ${TOML_UNSET}` : `${key} = ${prior}`;
+    lines.push(`#   ${priorPart}${TOML_LORE_SET}${loreValues[key]}`);
   }
   lines.push(TOML_BACKUP_FOOTER);
   return lines.join("\n");
@@ -278,8 +286,9 @@ export function prependTomlBackupBlock(content: string, block: string): string {
 
 /**
  * Restore a Codex TOML file from its commented backup block. For each recorded
- * key: restore the prior value, or delete the key if it was originally unset.
- * Removes the backup block. Returns the new content + summary.
+ * key: revert to the prior value (or delete it if originally unset) **only when
+ * the file still holds the value lore wrote** — a value the user changed after
+ * setup is left untouched and reported as skipped. Removes the backup block.
  */
 export function restoreTomlBackup(content: string): {
   content: string;
@@ -297,29 +306,45 @@ export function restoreTomlBackup(content: string): {
   while (end < lines.length && lines[end].trim() !== TOML_BACKUP_FOOTER) end++;
 
   const restored: string[] = [];
+  const skipped: string[] = [];
   const entryLines = lines.slice(start + 1, end);
   // Remove the block first so subsequent set/delete operate on clean content.
   let result = [...lines.slice(0, start), ...lines.slice(end + 1)].join("\n");
 
   for (const raw of entryLines) {
-    const body = raw.replace(/^#\s*/, "").trim();
-    if (body.endsWith(TOML_UNSET)) {
-      const key = body.slice(0, -TOML_UNSET.length).trim();
-      result = deleteTomlTopLevelKey(result, key);
-      restored.push(key);
+    const body = raw.replace(/^#\s*/, "");
+    const sepIdx = body.indexOf(TOML_LORE_SET);
+    if (sepIdx === -1) continue; // not a recognized entry line
+    const priorPart = body.slice(0, sepIdx).trim();
+    const loreValue = body.slice(sepIdx + TOML_LORE_SET.length).trim();
+
+    let key: string;
+    let priorValue: string | null;
+    if (priorPart.endsWith(TOML_UNSET)) {
+      key = priorPart.slice(0, -TOML_UNSET.length).trim();
+      priorValue = null; // was unset → undo should delete it
+    } else {
+      const eq = priorPart.indexOf("=");
+      if (eq <= 0) continue;
+      key = priorPart.slice(0, eq).trim();
+      priorValue = priorPart.slice(eq + 1).trim();
+    }
+
+    // Revert-only-if-unchanged: skip if the user changed the value after setup.
+    if (getTomlTopLevelValue(result, key) !== loreValue) {
+      skipped.push(key);
       continue;
     }
-    const eq = body.indexOf("=");
-    if (eq <= 0) continue;
-    const key = body.slice(0, eq).trim();
-    const value = body.slice(eq + 1).trim();
-    result = setTomlTopLevelKeyRaw(result, key, value);
+    result =
+      priorValue === null
+        ? deleteTomlTopLevelKey(result, key)
+        : setTomlTopLevelKeyRaw(result, key, priorValue);
     restored.push(key);
   }
 
   return {
     content: result,
-    summary: { hadBackup: true, restored, skipped: [] },
+    summary: { hadBackup: true, restored, skipped },
   };
 }
 

--- a/packages/gateway/src/cli/setup-backup.ts
+++ b/packages/gateway/src/cli/setup-backup.ts
@@ -1,0 +1,360 @@
+/**
+ * Provenance + backup helpers for `lore setup` / `lore setup undo`.
+ *
+ * `lore setup` rewrites third-party config files. To make the change
+ * reversible (and visible) we record what was there before:
+ *
+ *  - JSON agents (Claude Code, OpenCode): a top-level `_loreBackup` sidecar
+ *    key. We can't use literal `//` comments — the files are strict JSON and
+ *    our own `readJsonConfig` does `JSON.parse`, which would throw on comments.
+ *  - TOML agent (Codex): a `#`-commented backup block at the top of the file
+ *    (TOML supports native comments — this is the inline-visible backup).
+ *
+ * Undo is **revert-only-if-unchanged** for JSON: a managed key is only reverted
+ * when its current value still equals what lore wrote, so a value the user
+ * changed later is never clobbered.
+ *
+ * All functions here are pure (string/object in, string/object out) so the
+ * logic is unit-testable without touching the filesystem.
+ */
+
+export const LORE_BACKUP_KEY = "_loreBackup";
+
+// ---------------------------------------------------------------------------
+// JSON dot-path helpers
+// ---------------------------------------------------------------------------
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/** Read a dot-path (e.g. `env.ANTHROPIC_BASE_URL`). Returns undefined if any
+ * segment is missing. */
+export function getPath(obj: Record<string, unknown>, path: string): unknown {
+  const parts = path.split(".");
+  let cur: unknown = obj;
+  for (const p of parts) {
+    if (!isPlainObject(cur)) return undefined;
+    cur = cur[p];
+  }
+  return cur;
+}
+
+/** Set a dot-path, creating intermediate plain objects as needed. */
+export function setPath(
+  obj: Record<string, unknown>,
+  path: string,
+  value: unknown,
+): void {
+  const parts = path.split(".");
+  let cur: Record<string, unknown> = obj;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const p = parts[i];
+    if (!isPlainObject(cur[p])) cur[p] = {};
+    cur = cur[p] as Record<string, unknown>;
+  }
+  cur[parts[parts.length - 1]] = value;
+}
+
+/** Delete a dot-path leaf, then prune any parent objects left empty. */
+export function deletePath(obj: Record<string, unknown>, path: string): void {
+  const parts = path.split(".");
+  // Walk down, remembering the chain so we can prune empties on the way back.
+  const chain: Record<string, unknown>[] = [obj];
+  let cur: Record<string, unknown> = obj;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const next = cur[parts[i]];
+    if (!isPlainObject(next)) return; // path doesn't exist — nothing to delete
+    cur = next;
+    chain.push(cur);
+  }
+  delete cur[parts[parts.length - 1]];
+  // Prune empty ancestor objects (e.g. a now-empty `env` lore created).
+  for (let i = chain.length - 1; i >= 1; i--) {
+    if (Object.keys(chain[i]).length === 0) {
+      delete chain[i - 1][parts[i - 1]];
+    } else {
+      break;
+    }
+  }
+}
+
+function jsonEqual(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+// ---------------------------------------------------------------------------
+// JSON backup (Claude Code, OpenCode)
+// ---------------------------------------------------------------------------
+
+export interface JsonBackupEntry {
+  path: string;
+  loreValue: unknown;
+  hadPrior: boolean;
+  priorValue?: unknown;
+}
+
+export interface JsonBackup {
+  version: 1;
+  savedAt: string;
+  entries: JsonBackupEntry[];
+  /** OpenCode only: lore appended `@loreai/opencode` to the `plugin` array. */
+  pluginAdded?: boolean;
+}
+
+/**
+ * Capture a backup from the *pre-modification* config and the map of values
+ * lore is about to set (path → value). Records, per path, what lore will set
+ * and the prior value (if any).
+ */
+export function captureJsonBackup(
+  existing: Record<string, unknown>,
+  loreValues: Record<string, unknown>,
+  opts: { pluginAdded?: boolean; now?: () => Date } = {},
+): JsonBackup {
+  const entries: JsonBackupEntry[] = [];
+  for (const [path, loreValue] of Object.entries(loreValues)) {
+    const prior = getPath(existing, path);
+    entries.push(
+      prior === undefined
+        ? { path, loreValue, hadPrior: false }
+        : { path, loreValue, hadPrior: true, priorValue: prior },
+    );
+  }
+  const backup: JsonBackup = {
+    version: 1,
+    savedAt: (opts.now?.() ?? new Date()).toISOString(),
+    entries,
+  };
+  if (opts.pluginAdded !== undefined) backup.pluginAdded = opts.pluginAdded;
+  return backup;
+}
+
+/**
+ * Attach a backup to a config — but only if one isn't already present, so
+ * re-running setup never overwrites the *true* original with lore's own
+ * values. Mutates and returns `config`.
+ */
+export function attachJsonBackup(
+  config: Record<string, unknown>,
+  backup: JsonBackup,
+): Record<string, unknown> {
+  if (LORE_BACKUP_KEY in config) return config;
+  config[LORE_BACKUP_KEY] = backup;
+  return config;
+}
+
+export interface RestoreSummary {
+  hadBackup: boolean;
+  restored: string[];
+  skipped: string[];
+}
+
+/**
+ * Restore a JSON config from its `_loreBackup` sidecar. Revert-only-if-
+ * unchanged: a path is reverted only when its current value still equals what
+ * lore wrote. Removes the sidecar key on completion. Mutates `config`.
+ */
+export function restoreJsonBackup(
+  config: Record<string, unknown>,
+): RestoreSummary {
+  const raw = config[LORE_BACKUP_KEY];
+  if (!isPlainObject(raw) || !Array.isArray(raw.entries)) {
+    return { hadBackup: false, restored: [], skipped: [] };
+  }
+  const backup = raw as unknown as JsonBackup;
+  const restored: string[] = [];
+  const skipped: string[] = [];
+
+  for (const entry of backup.entries) {
+    const current = getPath(config, entry.path);
+    if (!jsonEqual(current, entry.loreValue)) {
+      // The user changed (or removed) this value after setup — leave it.
+      skipped.push(entry.path);
+      continue;
+    }
+    if (entry.hadPrior) {
+      setPath(config, entry.path, entry.priorValue);
+    } else {
+      deletePath(config, entry.path);
+    }
+    restored.push(entry.path);
+  }
+
+  // OpenCode: drop the plugin lore appended (only if still present).
+  if (backup.pluginAdded && Array.isArray(config.plugin)) {
+    const arr = config.plugin as unknown[];
+    const idx = arr.indexOf("@loreai/opencode");
+    if (idx !== -1) {
+      arr.splice(idx, 1);
+      restored.push("plugin[@loreai/opencode]");
+      if (arr.length === 0) delete config.plugin;
+    }
+  }
+
+  delete config[LORE_BACKUP_KEY];
+  return { hadBackup: true, restored, skipped };
+}
+
+// ---------------------------------------------------------------------------
+// TOML backup (Codex) — `#`-commented block at the top of the file
+// ---------------------------------------------------------------------------
+
+const TOML_BACKUP_HEADER =
+  "# lore setup backup — original values (run `lore setup undo codex` to restore):";
+const TOML_BACKUP_FOOTER = "# end lore setup backup";
+const TOML_UNSET = "(was unset)";
+
+/** Extract the raw value text of a top-level TOML key, or null if absent. */
+export function getTomlTopLevelValue(
+  content: string,
+  key: string,
+): string | null {
+  const lines = content.split("\n");
+  const keyPattern = new RegExp(
+    `^\\s*${key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*=\\s*(.*?)\\s*$`,
+  );
+  for (let i = 0; i < lines.length; i++) {
+    const m = keyPattern.exec(lines[i]);
+    if (m && isTopLevelLine(lines, i)) return m[1];
+  }
+  return null;
+}
+
+/** Whether the line at `index` is outside any `[section]`. */
+function isTopLevelLine(lines: string[], index: number): boolean {
+  for (let i = index - 1; i >= 0; i--) {
+    const line = lines[i].trim();
+    if (line === "" || line.startsWith("#")) continue;
+    if (/^\[/.test(line)) return false;
+  }
+  return true;
+}
+
+/** Delete a top-level TOML key line. */
+export function deleteTomlTopLevelKey(content: string, key: string): string {
+  const lines = content.split("\n");
+  const keyPattern = new RegExp(
+    `^\\s*${key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*=`,
+  );
+  const out: string[] = [];
+  let removed = false;
+  for (let i = 0; i < lines.length; i++) {
+    if (!removed && keyPattern.test(lines[i]) && isTopLevelLine(lines, i)) {
+      removed = true;
+      continue;
+    }
+    out.push(lines[i]);
+  }
+  return out.join("\n");
+}
+
+/**
+ * Build the commented backup block for the given keys from the *original*
+ * content. Returns null if a block already exists (preserve the true original)
+ * or if there are no keys.
+ */
+export function buildTomlBackupBlock(
+  content: string,
+  keys: string[],
+): string | null {
+  if (content.includes(TOML_BACKUP_HEADER)) return null;
+  if (keys.length === 0) return null;
+  const lines = [TOML_BACKUP_HEADER];
+  for (const key of keys) {
+    const prior = getTomlTopLevelValue(content, key);
+    lines.push(
+      prior === null ? `#   ${key} ${TOML_UNSET}` : `#   ${key} = ${prior}`,
+    );
+  }
+  lines.push(TOML_BACKUP_FOOTER);
+  return lines.join("\n");
+}
+
+/** Prepend a backup block to the content (block already includes no trailing newline). */
+export function prependTomlBackupBlock(content: string, block: string): string {
+  return content ? `${block}\n${content}` : `${block}\n`;
+}
+
+/**
+ * Restore a Codex TOML file from its commented backup block. For each recorded
+ * key: restore the prior value, or delete the key if it was originally unset.
+ * Removes the backup block. Returns the new content + summary.
+ */
+export function restoreTomlBackup(content: string): {
+  content: string;
+  summary: RestoreSummary;
+} {
+  const lines = content.split("\n");
+  const start = lines.findIndex((l) => l.trim() === TOML_BACKUP_HEADER);
+  if (start === -1) {
+    return {
+      content,
+      summary: { hadBackup: false, restored: [], skipped: [] },
+    };
+  }
+  let end = start;
+  while (end < lines.length && lines[end].trim() !== TOML_BACKUP_FOOTER) end++;
+
+  const restored: string[] = [];
+  const entryLines = lines.slice(start + 1, end);
+  // Remove the block first so subsequent set/delete operate on clean content.
+  let result = [...lines.slice(0, start), ...lines.slice(end + 1)].join("\n");
+
+  for (const raw of entryLines) {
+    const body = raw.replace(/^#\s*/, "").trim();
+    if (body.endsWith(TOML_UNSET)) {
+      const key = body.slice(0, -TOML_UNSET.length).trim();
+      result = deleteTomlTopLevelKey(result, key);
+      restored.push(key);
+      continue;
+    }
+    const eq = body.indexOf("=");
+    if (eq <= 0) continue;
+    const key = body.slice(0, eq).trim();
+    const value = body.slice(eq + 1).trim();
+    result = setTomlTopLevelKeyRaw(result, key, value);
+    restored.push(key);
+  }
+
+  return {
+    content: result,
+    summary: { hadBackup: true, restored, skipped: [] },
+  };
+}
+
+/**
+ * Minimal top-level TOML key setter used by restore (replaces in place or
+ * inserts before the first section). Kept separate from setup.ts's
+ * `setTopLevelKey` to avoid a circular import; behavior matches for these
+ * simple cases.
+ */
+function setTomlTopLevelKeyRaw(
+  content: string,
+  key: string,
+  value: string,
+): string {
+  const newLine = `${key} = ${value}`;
+  const lines = content.split("\n");
+  const keyPattern = new RegExp(
+    `^\\s*${key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*=`,
+  );
+  for (let i = 0; i < lines.length; i++) {
+    if (keyPattern.test(lines[i]) && isTopLevelLine(lines, i)) {
+      lines[i] = newLine;
+      return lines.join("\n");
+    }
+  }
+  const firstSectionIdx = lines.findIndex((line) => /^\s*\[/.test(line));
+  if (firstSectionIdx === -1) {
+    const trimmed = content.trimEnd();
+    return trimmed ? `${trimmed}\n${newLine}\n` : `${newLine}\n`;
+  }
+  const before = lines.slice(0, firstSectionIdx);
+  const after = lines.slice(firstSectionIdx);
+  while (before.length > 0 && before[before.length - 1].trim() === "") {
+    before.pop();
+  }
+  const beforeStr = before.length > 0 ? `${before.join("\n")}\n` : "";
+  return `${beforeStr}${newLine}\n\n${after.join("\n")}`;
+}

--- a/packages/gateway/src/cli/setup-backup.ts
+++ b/packages/gateway/src/cli/setup-backup.ts
@@ -304,6 +304,14 @@ export function restoreTomlBackup(content: string): {
   }
   let end = start;
   while (end < lines.length && lines[end].trim() !== TOML_BACKUP_FOOTER) end++;
+  if (end >= lines.length) {
+    // Footer missing (block hand-edited/corrupted). Refuse to touch the file —
+    // otherwise we'd treat the entire remainder as the block and delete it.
+    return {
+      content,
+      summary: { hadBackup: false, restored: [], skipped: [] },
+    };
+  }
 
   const restored: string[] = [];
   const skipped: string[] = [];

--- a/packages/gateway/src/cli/setup-backup.ts
+++ b/packages/gateway/src/cli/setup-backup.ts
@@ -192,7 +192,12 @@ export function restoreJsonBackup(
     }
   }
 
-  delete config[LORE_BACKUP_KEY];
+  // Consume the backup only when everything was reverted. If some keys were
+  // skipped (the user changed them after setup), keep the sidecar so their
+  // original values remain recoverable — never silently drop that metadata.
+  if (skipped.length === 0) {
+    delete config[LORE_BACKUP_KEY];
+  }
   return { hadBackup: true, restored, skipped };
 }
 
@@ -288,7 +293,9 @@ export function prependTomlBackupBlock(content: string, block: string): string {
  * Restore a Codex TOML file from its commented backup block. For each recorded
  * key: revert to the prior value (or delete it if originally unset) **only when
  * the file still holds the value lore wrote** — a value the user changed after
- * setup is left untouched and reported as skipped. Removes the backup block.
+ * setup is left untouched and reported as skipped. The backup block is removed
+ * only when every key was reverted; if any were skipped it is kept so their
+ * original values stay recoverable.
  */
 export function restoreTomlBackup(content: string): {
   content: string;
@@ -316,8 +323,10 @@ export function restoreTomlBackup(content: string): {
   const restored: string[] = [];
   const skipped: string[] = [];
   const entryLines = lines.slice(start + 1, end);
-  // Remove the block first so subsequent set/delete operate on clean content.
-  let result = [...lines.slice(0, start), ...lines.slice(end + 1)].join("\n");
+  // Restore against the FULL content — the block lines are comments, so they
+  // never match a top-level key pattern. The block is stripped afterwards, but
+  // only when nothing was skipped (see below).
+  let result = content;
 
   for (const raw of entryLines) {
     const body = raw.replace(/^#\s*/, "");
@@ -348,6 +357,17 @@ export function restoreTomlBackup(content: string): {
         ? deleteTomlTopLevelKey(result, key)
         : setTomlTopLevelKeyRaw(result, key, priorValue);
     restored.push(key);
+  }
+
+  // Strip the backup block only when everything was reverted. If some keys were
+  // skipped (the user changed them), keep the block so their original values
+  // remain recoverable — never silently drop that metadata.
+  if (skipped.length === 0) {
+    const out = result.split("\n");
+    const s = out.findIndex((l) => l.trim() === TOML_BACKUP_HEADER);
+    let e = s;
+    while (e < out.length && out[e].trim() !== TOML_BACKUP_FOOTER) e++;
+    result = [...out.slice(0, s), ...out.slice(e + 1)].join("\n");
   }
 
   return {

--- a/packages/gateway/src/cli/setup.ts
+++ b/packages/gateway/src/cli/setup.ts
@@ -720,8 +720,9 @@ function setupOpencode(baseUrl: string, noPlugin: boolean): void {
   }
 
   // Finalize the backup now that the (possibly config-rewriting) plugin install
-  // has run. `installPlugin` returns true only when it actually added the
-  // plugin to the array, so this attribution is accurate.
+  // has run. `installPlugin` returns true on full success (both npm install and
+  // registration of the plugin in the config), so `pluginInstalled && !pluginAlreadyPresent`
+  // accurately reflects whether lore actually added the plugin.
   const finalConfig = readJsonConfig(configPath);
   const backup = captureJsonBackup(existing, loreValues, {
     pluginAdded: pluginInstalled && !pluginAlreadyPresent,

--- a/packages/gateway/src/cli/setup.ts
+++ b/packages/gateway/src/cli/setup.ts
@@ -477,11 +477,12 @@ function setupCodex(baseUrl: string): void {
   }
 
   // Capture a commented backup block from the ORIGINAL content (before lore's
-  // writes), then apply lore's changes and prepend the block.
-  const backupBlock = buildTomlBackupBlock(content, [
-    "openai_base_url",
-    "model_auto_compact_token_limit",
-  ]);
+  // writes), recording the values lore is about to set so undo can revert only
+  // if the file still holds them. Then apply lore's changes and prepend it.
+  const backupBlock = buildTomlBackupBlock(content, {
+    openai_base_url: `"${baseUrl}"`,
+    model_auto_compact_token_limit: String(CODEX_COMPACT_DISABLE_LIMIT),
+  });
   const updated = updateCodexConfig(content, baseUrl);
   const final = backupBlock
     ? prependTomlBackupBlock(updated, backupBlock)

--- a/packages/gateway/src/cli/setup.ts
+++ b/packages/gateway/src/cli/setup.ts
@@ -677,8 +677,8 @@ function setupOpencode(baseUrl: string, noPlugin: boolean): void {
 
   const existing = readJsonConfig(configPath);
 
-  // Capture a backup of the values lore is about to set (provider baseURLs +
-  // compaction) and whether lore will add its plugin to the array.
+  // Values lore is about to set (provider baseURLs + compaction), captured from
+  // the ORIGINAL config for the backup's prior values.
   const loreValues: Record<string, unknown> = { "compaction.auto": false };
   for (const id of OPENCODE_SETUP_PROVIDER_IDS) {
     loreValues[`provider.${id}.options.baseURL`] = baseUrl;
@@ -687,12 +687,12 @@ function setupOpencode(baseUrl: string, noPlugin: boolean): void {
   const pluginAlreadyPresent =
     Array.isArray(existingPlugins) &&
     existingPlugins.includes("@loreai/opencode");
-  const backup = captureJsonBackup(existing, loreValues, {
-    pluginAdded: !noPlugin && !pluginAlreadyPresent,
-  });
 
+  // Write the provider/compaction config first WITHOUT a backup. The backup is
+  // finalized at the end, after the plugin install, so `pluginAdded` reflects
+  // what actually happened (a failed install must NOT later cause undo to
+  // remove a plugin the user added themselves).
   const updated = updateOpencodeConfig(existing, baseUrl);
-  attachJsonBackup(updated, backup);
   writeFileSync(configPath, `${JSON.stringify(updated, null, 2)}\n`, "utf8");
 
   console.log(`[lore] OpenCode configured to use Lore gateway.`);
@@ -703,8 +703,8 @@ function setupOpencode(baseUrl: string, noPlugin: boolean): void {
   console.log(`[lore]   Config: ${configPath}`);
   console.log(`[lore]`);
 
+  let pluginInstalled = false;
   if (noPlugin) {
-    console.log(`[lore]`);
     console.log(
       `[lore] Skipped @loreai/opencode plugin install (--no-plugin).`,
     );
@@ -714,12 +714,24 @@ function setupOpencode(baseUrl: string, noPlugin: boolean): void {
     console.log(
       `[lore] "@loreai/opencode" to the "plugin" array in ${configPath}.`,
     );
-    return;
+  } else {
+    pluginInstalled = installPlugin(opencodePluginSpec, configPath);
+    if (!pluginInstalled) process.exitCode = 1;
   }
 
-  if (!installPlugin(opencodePluginSpec, configPath)) {
-    process.exitCode = 1;
-  }
+  // Finalize the backup now that the (possibly config-rewriting) plugin install
+  // has run. `installPlugin` returns true only when it actually added the
+  // plugin to the array, so this attribution is accurate.
+  const finalConfig = readJsonConfig(configPath);
+  const backup = captureJsonBackup(existing, loreValues, {
+    pluginAdded: pluginInstalled && !pluginAlreadyPresent,
+  });
+  attachJsonBackup(finalConfig, backup);
+  writeFileSync(
+    configPath,
+    `${JSON.stringify(finalConfig, null, 2)}\n`,
+    "utf8",
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/src/cli/setup.ts
+++ b/packages/gateway/src/cli/setup.ts
@@ -18,7 +18,18 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { CLAUDE_CODE_FIRST_PARTY_ENV } from "../cch";
+import { readPortFile } from "../portfile";
 import { detectAgents } from "./agents";
+import { probeGateway } from "./start";
+import {
+  captureJsonBackup,
+  attachJsonBackup,
+  restoreJsonBackup,
+  buildTomlBackupBlock,
+  prependTomlBackupBlock,
+  restoreTomlBackup,
+  type RestoreSummary,
+} from "./setup-backup";
 
 // ---------------------------------------------------------------------------
 // Supported apps and their setup handlers
@@ -48,6 +59,8 @@ interface AppSetup {
   run: (baseUrl: string, noPlugin: boolean) => void;
   /** Optional plugin install + registration */
   plugin?: PluginSpec;
+  /** Undo a previous `lore setup` for this app, restoring the saved backup. */
+  undo: () => RestoreSummary;
 }
 
 /**
@@ -78,6 +91,7 @@ const SUPPORTED_APPS: AppSetup[] = [
     agentName: "codex",
     displayName: "Codex",
     run: (baseUrl) => setupCodex(baseUrl),
+    undo: undoCodex,
     // No Lore plugin for Codex — the gateway URL + DISABLE_AUTO_COMPACT in
     // the TOML is the full integration. There's no plugin host in Codex.
   },
@@ -86,11 +100,13 @@ const SUPPORTED_APPS: AppSetup[] = [
     displayName: "OpenCode",
     run: (baseUrl, noPlugin) => setupOpencode(baseUrl, noPlugin),
     plugin: opencodePluginSpec,
+    undo: undoOpencode,
   },
   {
     agentName: "claude-code",
     displayName: "Claude Code",
     run: (baseUrl) => setupClaudeCode(baseUrl),
+    undo: undoClaudeCode,
     // No Lore plugin for Claude Code — Anthropic controls the API surface
     // and there's no plugin host. The ANTHROPIC_BASE_URL env var is the
     // only integration point.
@@ -213,6 +229,86 @@ function installPlugin(spec: PluginSpec, configPath: string): boolean {
 
 /** Default gateway port (matches DEFAULT_PORTS[0] in start.ts) */
 const DEFAULT_PORT = 3207;
+
+/**
+ * Decide which port `lore setup` should bake into the written config.
+ *
+ * - Remote setup ignores the port entirely (the remote URL is authoritative).
+ * - An explicit `--port` always wins (the user knows what they want).
+ * - Otherwise, prefer a *detected live* gateway port. This fixes the mismatch
+ *   where setup hardcoded 3207 but the gateway had fallen back to 5673 or a
+ *   random port (`start.ts` DEFAULT_PORTS chain).
+ * - When nothing is detected, return undefined so `normalizeBaseUrl` falls
+ *   back to the default port.
+ */
+export function chooseSetupPort(input: {
+  explicitPort?: number;
+  remoteUrl?: string;
+  livePort?: number | null;
+}): number | undefined {
+  if (input.remoteUrl) return undefined;
+  if (input.explicitPort !== undefined) return input.explicitPort;
+  if (input.livePort != null) return input.livePort;
+  return undefined;
+}
+
+/**
+ * Build the post-setup liveness notice. Pure so the PASS/WARN copy is
+ * unit-testable. `origin` is the gateway base URL without the `/v1` suffix
+ * (what `probeGateway` hits).
+ */
+export function formatLivenessNotice(input: {
+  alive: boolean;
+  origin: string;
+  remote: boolean;
+}): { ok: boolean; lines: string[] } {
+  if (input.alive) {
+    return {
+      ok: true,
+      lines: [`[lore] ✓ Gateway is reachable at ${input.origin}.`],
+    };
+  }
+  const lines = [
+    `[lore] ⚠ Gateway is not reachable at ${input.origin}.`,
+    `[lore]   ${input.remote ? "The agent will fail to connect until the remote gateway is running." : "The agent will fail to connect until a gateway is running."}`,
+  ];
+  if (input.remote) {
+    lines.push(
+      `[lore]   Ensure the remote gateway is up and reachable, then try again.`,
+    );
+  } else {
+    lines.push(
+      `[lore]   Start one in the background:  lore start --bg`,
+      `[lore]   …then re-run this setup so the live port is written.`,
+      `[lore]   Or skip the global redirect entirely and use:  lore run`,
+    );
+  }
+  return { ok: false, lines };
+}
+
+/**
+ * Post-setup guidance steering terminal users toward `lore run` (no global
+ * redirect, gateway lifecycle tied to the agent) and framing `lore setup` as
+ * the path for GUI/IDE agents that lore can't launch. Pure for testing.
+ */
+export function formatSetupGuidance(): string[] {
+  return [
+    `[lore] Tip: for terminal use, \`lore run\` (or just \`lore\`) launches your agent`,
+    `[lore]   through the gateway with no global config, and stops it automatically`,
+    `[lore]   on exit. \`lore setup\` is best for GUI/IDE agents lore can't launch`,
+    `[lore]   (Claude Desktop, IDE extensions) — keep a gateway up with \`lore start --bg\`.`,
+  ];
+}
+
+/**
+ * Detect a running local gateway and return its port, or null. Reads the port
+ * file written by a running gateway, then verifies it actually answers.
+ */
+async function detectLiveGatewayPort(): Promise<number | null> {
+  const port = readPortFile();
+  if (!port) return null;
+  return (await probeGateway(`http://127.0.0.1:${port}`)) ? port : null;
+}
 
 /**
  * Normalize a gateway URL for use as a provider base URL.
@@ -380,8 +476,17 @@ function setupCodex(baseUrl: string): void {
     if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
   }
 
+  // Capture a commented backup block from the ORIGINAL content (before lore's
+  // writes), then apply lore's changes and prepend the block.
+  const backupBlock = buildTomlBackupBlock(content, [
+    "openai_base_url",
+    "model_auto_compact_token_limit",
+  ]);
   const updated = updateCodexConfig(content, baseUrl);
-  writeFileSync(configPath, updated, "utf8");
+  const final = backupBlock
+    ? prependTomlBackupBlock(updated, backupBlock)
+    : updated;
+  writeFileSync(configPath, final, "utf8");
 
   console.log(`[lore] Codex configured to use Lore gateway.`);
   console.log(`[lore]   openai_base_url = "${baseUrl}"`);
@@ -389,10 +494,6 @@ function setupCodex(baseUrl: string): void {
     `[lore]   model_auto_compact_token_limit = ${CODEX_COMPACT_DISABLE_LIMIT} (auto-compaction disabled)`,
   );
   console.log(`[lore]   Config: ${configPath}`);
-  console.log(`[lore]`);
-  console.log(
-    `[lore] Make sure the gateway is running (lore start) before using Codex.`,
-  );
 }
 
 // ---------------------------------------------------------------------------
@@ -574,7 +675,23 @@ function setupOpencode(baseUrl: string, noPlugin: boolean): void {
   mkdirSync(configDir, { recursive: true });
 
   const existing = readJsonConfig(configPath);
+
+  // Capture a backup of the values lore is about to set (provider baseURLs +
+  // compaction) and whether lore will add its plugin to the array.
+  const loreValues: Record<string, unknown> = { "compaction.auto": false };
+  for (const id of OPENCODE_SETUP_PROVIDER_IDS) {
+    loreValues[`provider.${id}.options.baseURL`] = baseUrl;
+  }
+  const existingPlugins = existing.plugin;
+  const pluginAlreadyPresent =
+    Array.isArray(existingPlugins) &&
+    existingPlugins.includes("@loreai/opencode");
+  const backup = captureJsonBackup(existing, loreValues, {
+    pluginAdded: !noPlugin && !pluginAlreadyPresent,
+  });
+
   const updated = updateOpencodeConfig(existing, baseUrl);
+  attachJsonBackup(updated, backup);
   writeFileSync(configPath, `${JSON.stringify(updated, null, 2)}\n`, "utf8");
 
   console.log(`[lore] OpenCode configured to use Lore gateway.`);
@@ -659,7 +776,13 @@ function setupClaudeCode(baseUrl: string): void {
     : baseUrl;
 
   const existing = readJsonConfig(configPath);
+  const backup = captureJsonBackup(existing, {
+    "env.ANTHROPIC_BASE_URL": anthropicBaseUrl,
+    "env.DISABLE_AUTO_COMPACT": "1",
+    [`env.${CLAUDE_CODE_FIRST_PARTY_ENV}`]: "1",
+  });
   const updated = updateClaudeCodeSettings(existing, anthropicBaseUrl);
+  attachJsonBackup(updated, backup);
   writeFileSync(configPath, `${JSON.stringify(updated, null, 2)}\n`, "utf8");
 
   console.log(`[lore] Claude Code configured to use Lore gateway.`);
@@ -671,10 +794,96 @@ function setupClaudeCode(baseUrl: string): void {
     `[lore]   env.${CLAUDE_CODE_FIRST_PARTY_ENV} = "1" (keeps cch billing flowing through the gateway)`,
   );
   console.log(`[lore]   Config: ${configPath}`);
-  console.log(`[lore]`);
+}
+
+// ---------------------------------------------------------------------------
+// Undo (`lore setup undo [app]`)
+// ---------------------------------------------------------------------------
+
+/** Restore a JSON-config app (Claude Code, OpenCode) from its `_loreBackup`. */
+function undoJsonApp(configPath: string): RestoreSummary {
+  const cfg = readJsonConfig(configPath);
+  const summary = restoreJsonBackup(cfg);
+  if (summary.hadBackup) {
+    writeFileSync(configPath, `${JSON.stringify(cfg, null, 2)}\n`, "utf8");
+  }
+  return summary;
+}
+
+function undoClaudeCode(): RestoreSummary {
+  return undoJsonApp(claudeCodeSettingsPath());
+}
+
+function undoOpencode(): RestoreSummary {
+  return undoJsonApp(opencodeConfigPath());
+}
+
+function undoCodex(): RestoreSummary {
+  const configPath = codexConfigPath();
+  let content: string;
+  try {
+    content = readFileSync(configPath, "utf8");
+  } catch (e: unknown) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") {
+      return { hadBackup: false, restored: [], skipped: [] };
+    }
+    throw e;
+  }
+  const { content: restored, summary } = restoreTomlBackup(content);
+  if (summary.hadBackup) writeFileSync(configPath, restored, "utf8");
+  return summary;
+}
+
+/** Print the result of one app's undo. */
+function reportUndo(app: AppSetup, summary: RestoreSummary, explicit: boolean) {
+  if (!summary.hadBackup) {
+    if (explicit) {
+      console.log(
+        `[lore] ${app.displayName}: no lore backup found — nothing to undo.`,
+      );
+    }
+    return;
+  }
   console.log(
-    `[lore] Make sure the gateway is running (lore start) before using Claude Code.`,
+    `[lore] ${app.displayName}: restored ${summary.restored.length} setting(s) from backup.`,
   );
+  if (summary.skipped.length > 0) {
+    console.log(
+      `[lore]   Left ${summary.skipped.length} value(s) you changed after setup untouched: ${summary.skipped.join(", ")}`,
+    );
+  }
+}
+
+async function commandUndo(args: string[]): Promise<void> {
+  const appName = args[0]?.toLowerCase();
+  let targets: AppSetup[];
+  if (appName) {
+    const app = SUPPORTED_APPS.find(
+      (a) => a.agentName === appName || a.displayName.toLowerCase() === appName,
+    );
+    if (!app) {
+      const supported = SUPPORTED_APPS.map((a) => a.agentName).join(", ");
+      console.error(
+        `[lore] Unknown app "${args[0]}". Supported apps: ${supported}`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+    targets = [app];
+  } else {
+    targets = SUPPORTED_APPS;
+  }
+
+  let restoredAny = false;
+  for (const app of targets) {
+    const summary = app.undo();
+    if (summary.hadBackup) restoredAny = true;
+    reportUndo(app, summary, Boolean(appName));
+  }
+
+  if (!restoredAny && !appName) {
+    console.log(`[lore] No lore setup backups found — nothing to undo.`);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -685,13 +894,29 @@ export async function commandSetup(
   args: string[],
   values: Record<string, unknown>,
 ): Promise<void> {
+  // `lore setup undo [app]` — restore the backup written by a prior setup.
+  if (args[0]?.toLowerCase() === "undo") {
+    await commandUndo(args.slice(1));
+    return;
+  }
+
   const remoteUrl = values.remote as string | undefined;
-  const port = values.port ? Number(values.port) : undefined;
+  const explicitPort = values.port ? Number(values.port) : undefined;
   const noPlugin = values.noPlugin === true;
+
+  // Detect a running local gateway so we write its actual port (handles the
+  // 3207 → 5673 → random fallback chain) rather than blindly assuming 3207.
+  const livePort =
+    remoteUrl || explicitPort !== undefined
+      ? null
+      : await detectLiveGatewayPort();
 
   let baseUrl: string;
   try {
-    baseUrl = normalizeBaseUrl(remoteUrl, port);
+    baseUrl = normalizeBaseUrl(
+      remoteUrl,
+      chooseSetupPort({ explicitPort, remoteUrl, livePort }),
+    );
   } catch (e) {
     console.error(`[lore] ${e instanceof Error ? e.message : e}`);
     process.exitCode = 1;
@@ -724,6 +949,7 @@ export async function commandSetup(
     }
 
     app.run(baseUrl, noPlugin);
+    await reportLiveness(baseUrl, remoteUrl, livePort);
     return;
   }
 
@@ -749,4 +975,29 @@ export async function commandSetup(
   for (const app of setupTargets) {
     app.run(baseUrl, noPlugin);
   }
+  await reportLiveness(baseUrl, remoteUrl, livePort);
+}
+
+/**
+ * Probe the configured gateway and print a PASS/WARN notice. Reuses the
+ * already-probed `livePort` result for the default-local case to avoid a
+ * second network round-trip.
+ */
+async function reportLiveness(
+  baseUrl: string,
+  remoteUrl: string | undefined,
+  livePort: number | null,
+): Promise<void> {
+  const origin = baseUrl.replace(/\/v1$/, "");
+  // If we already confirmed a live local port, we know it's reachable.
+  const alive = livePort != null ? true : await probeGateway(origin);
+  const notice = formatLivenessNotice({
+    alive,
+    origin,
+    remote: Boolean(remoteUrl),
+  });
+  console.log(`[lore]`);
+  for (const line of notice.lines) console.log(line);
+  console.log(`[lore]`);
+  for (const line of formatSetupGuidance()) console.log(line);
 }

--- a/packages/gateway/test/setup-backup.test.ts
+++ b/packages/gateway/test/setup-backup.test.ts
@@ -150,6 +150,9 @@ describe("restoreJsonBackup", () => {
     expect(getPath(cfg, "env.ANTHROPIC_BASE_URL")).toBe(
       "http://user-changed:9999",
     );
+    // A key was skipped → the sidecar is KEPT so its prior value stays
+    // recoverable (Seer #876 — no metadata loss).
+    expect(LORE_BACKUP_KEY in cfg).toBe(true);
   });
 
   it("reports no backup when the sidecar is missing", () => {
@@ -276,8 +279,12 @@ describe("TOML backup block round-trip", () => {
     expect(restored).toContain(
       'openai_base_url = "http://user-changed:9999/v1"',
     );
-    // The block is still removed.
-    expect(restored).not.toContain("lore setup backup");
+    // Because a key was skipped, the backup block is KEPT so the skipped key's
+    // original value stays recoverable (Seer #876 — no metadata loss).
+    expect(restored).toContain("lore setup backup");
+    expect(restored).toContain(
+      '#   openai_base_url = "https://api.openai.com/v1"',
+    );
   });
 
   it("reports no backup when the block is absent", () => {

--- a/packages/gateway/test/setup-backup.test.ts
+++ b/packages/gateway/test/setup-backup.test.ts
@@ -212,41 +212,71 @@ describe("getTomlTopLevelValue", () => {
 });
 
 describe("TOML backup block round-trip", () => {
-  const KEYS = ["openai_base_url", "model_auto_compact_token_limit"];
+  // key → raw TOML value lore writes
+  const LORE_VALUES = {
+    openai_base_url: '"http://127.0.0.1:3299/v1"',
+    model_auto_compact_token_limit: "999999999",
+  };
 
-  it("captures prior values and unset markers", () => {
+  it("captures prior values, unset markers, and the lore-set value", () => {
     const original = 'openai_base_url = "https://api.openai.com/v1"\n';
-    const block = buildTomlBackupBlock(original, KEYS);
+    const block = buildTomlBackupBlock(original, LORE_VALUES);
     expect(block).not.toBeNull();
     expect(block).toContain(
-      '#   openai_base_url = "https://api.openai.com/v1"',
+      '#   openai_base_url = "https://api.openai.com/v1" # lore-set "http://127.0.0.1:3299/v1"',
     );
-    expect(block).toContain("#   model_auto_compact_token_limit (was unset)");
+    expect(block).toContain(
+      "#   model_auto_compact_token_limit (was unset) # lore-set 999999999",
+    );
   });
 
   it("does not build a second block when one already exists", () => {
     const original = 'openai_base_url = "https://api.openai.com/v1"\n';
-    const block = buildTomlBackupBlock(original, KEYS) as string;
+    const block = buildTomlBackupBlock(original, LORE_VALUES) as string;
     const withBlock = prependTomlBackupBlock(original, block);
-    expect(buildTomlBackupBlock(withBlock, KEYS)).toBeNull();
+    expect(buildTomlBackupBlock(withBlock, LORE_VALUES)).toBeNull();
   });
 
   it("restores prior value and deletes originally-unset keys", () => {
     const original = 'openai_base_url = "https://api.openai.com/v1"\n';
     // Real setup order: capture the block from the ORIGINAL, apply lore's
     // writes to the original, then prepend the block to the updated content.
-    const block = buildTomlBackupBlock(original, KEYS) as string;
+    const block = buildTomlBackupBlock(original, LORE_VALUES) as string;
     const updated =
-      'openai_base_url = "http://127.0.0.1:3207/v1"\nmodel_auto_compact_token_limit = 999999999\n';
+      'openai_base_url = "http://127.0.0.1:3299/v1"\nmodel_auto_compact_token_limit = 999999999\n';
     const content = prependTomlBackupBlock(updated, block);
 
     const { content: restored, summary } = restoreTomlBackup(content);
     expect(summary.hadBackup).toBe(true);
+    expect(summary.restored.sort()).toEqual([
+      "model_auto_compact_token_limit",
+      "openai_base_url",
+    ]);
     expect(restored).toContain('openai_base_url = "https://api.openai.com/v1"');
-    expect(restored).not.toContain("http://127.0.0.1:3207/v1");
+    expect(restored).not.toContain("http://127.0.0.1:3299/v1");
     // Originally-unset key is removed entirely.
     expect(restored).not.toContain("model_auto_compact_token_limit");
     // Backup block removed.
+    expect(restored).not.toContain("lore setup backup");
+  });
+
+  it("skips a value the user changed after setup (revert-only-if-unchanged)", () => {
+    const original = 'openai_base_url = "https://api.openai.com/v1"\n';
+    const block = buildTomlBackupBlock(original, LORE_VALUES) as string;
+    // The user later changed openai_base_url away from lore's value; the limit
+    // still holds lore's value.
+    const updated =
+      'openai_base_url = "http://user-changed:9999/v1"\nmodel_auto_compact_token_limit = 999999999\n';
+    const content = prependTomlBackupBlock(updated, block);
+
+    const { content: restored, summary } = restoreTomlBackup(content);
+    expect(summary.skipped).toContain("openai_base_url");
+    expect(summary.restored).toContain("model_auto_compact_token_limit");
+    // The user's value is preserved.
+    expect(restored).toContain(
+      'openai_base_url = "http://user-changed:9999/v1"',
+    );
+    // The block is still removed.
     expect(restored).not.toContain("lore setup backup");
   });
 

--- a/packages/gateway/test/setup-backup.test.ts
+++ b/packages/gateway/test/setup-backup.test.ts
@@ -283,6 +283,20 @@ describe("TOML backup block round-trip", () => {
   it("reports no backup when the block is absent", () => {
     expect(restoreTomlBackup('model = "gpt"\n').summary.hadBackup).toBe(false);
   });
+
+  it("leaves the file untouched when the footer is missing (no data loss)", () => {
+    // A hand-edited/corrupted block with a header but no footer must NOT cause
+    // the rest of the file to be truncated (Seer #876 HIGH).
+    const block = buildTomlBackupBlock(
+      'openai_base_url = "https://api.openai.com/v1"\n',
+      LORE_VALUES,
+    ) as string;
+    const headerOnly = block.split("\n").slice(0, -1).join("\n"); // drop footer
+    const content = `${headerOnly}\nmodel = "gpt-5"\nopenai_base_url = "http://127.0.0.1:3299/v1"\n`;
+    const { content: result, summary } = restoreTomlBackup(content);
+    expect(summary.hadBackup).toBe(false);
+    expect(result).toBe(content); // byte-identical — nothing deleted
+  });
 });
 
 describe("deleteTomlTopLevelKey", () => {

--- a/packages/gateway/test/setup-backup.test.ts
+++ b/packages/gateway/test/setup-backup.test.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect } from "vitest";
+import {
+  getPath,
+  setPath,
+  deletePath,
+  captureJsonBackup,
+  attachJsonBackup,
+  restoreJsonBackup,
+  LORE_BACKUP_KEY,
+  getTomlTopLevelValue,
+  deleteTomlTopLevelKey,
+  buildTomlBackupBlock,
+  prependTomlBackupBlock,
+  restoreTomlBackup,
+} from "../src/cli/setup-backup";
+
+// ---------------------------------------------------------------------------
+// JSON dot-path helpers
+// ---------------------------------------------------------------------------
+
+describe("dot-path helpers", () => {
+  it("getPath reads nested values and returns undefined for missing", () => {
+    const o = { env: { A: "1" } };
+    expect(getPath(o, "env.A")).toBe("1");
+    expect(getPath(o, "env.B")).toBeUndefined();
+    expect(getPath(o, "x.y.z")).toBeUndefined();
+  });
+
+  it("setPath creates intermediate objects", () => {
+    const o: Record<string, unknown> = {};
+    setPath(o, "a.b.c", 42);
+    expect(o).toEqual({ a: { b: { c: 42 } } });
+  });
+
+  it("deletePath removes the leaf and prunes emptied ancestors", () => {
+    const o: Record<string, unknown> = { env: { A: "1" } };
+    deletePath(o, "env.A");
+    expect(o).toEqual({}); // env pruned because it became empty
+  });
+
+  it("deletePath keeps ancestors that still have other keys", () => {
+    const o: Record<string, unknown> = { env: { A: "1", B: "2" } };
+    deletePath(o, "env.A");
+    expect(o).toEqual({ env: { B: "2" } });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// JSON backup capture / attach / restore
+// ---------------------------------------------------------------------------
+
+const CLAUDE_LORE_VALUES = {
+  "env.ANTHROPIC_BASE_URL": "http://127.0.0.1:3207",
+  "env.DISABLE_AUTO_COMPACT": "1",
+};
+
+describe("captureJsonBackup", () => {
+  it("records prior values and absence per managed path", () => {
+    const existing = {
+      env: { ANTHROPIC_BASE_URL: "https://api.anthropic.com" },
+    };
+    const backup = captureJsonBackup(existing, CLAUDE_LORE_VALUES, {
+      now: () => new Date("2026-06-21T00:00:00Z"),
+    });
+    expect(backup.savedAt).toBe("2026-06-21T00:00:00.000Z");
+    const byPath = Object.fromEntries(backup.entries.map((e) => [e.path, e]));
+    expect(byPath["env.ANTHROPIC_BASE_URL"]).toEqual({
+      path: "env.ANTHROPIC_BASE_URL",
+      loreValue: "http://127.0.0.1:3207",
+      hadPrior: true,
+      priorValue: "https://api.anthropic.com",
+    });
+    expect(byPath["env.DISABLE_AUTO_COMPACT"]).toEqual({
+      path: "env.DISABLE_AUTO_COMPACT",
+      loreValue: "1",
+      hadPrior: false,
+    });
+  });
+});
+
+describe("attachJsonBackup", () => {
+  it("attaches when absent", () => {
+    const cfg: Record<string, unknown> = {};
+    attachJsonBackup(cfg, captureJsonBackup({}, CLAUDE_LORE_VALUES));
+    expect(cfg[LORE_BACKUP_KEY]).toBeDefined();
+  });
+
+  it("does NOT overwrite an existing backup (preserves the true original)", () => {
+    const original = captureJsonBackup(
+      { env: { ANTHROPIC_BASE_URL: "https://api.anthropic.com" } },
+      CLAUDE_LORE_VALUES,
+    );
+    const cfg: Record<string, unknown> = {};
+    attachJsonBackup(cfg, original);
+    // Second setup run: prior now looks like lore's own value — must be ignored.
+    const second = captureJsonBackup(
+      { env: { ANTHROPIC_BASE_URL: "http://127.0.0.1:3207" } },
+      CLAUDE_LORE_VALUES,
+    );
+    attachJsonBackup(cfg, second);
+    expect(cfg[LORE_BACKUP_KEY]).toBe(original);
+  });
+});
+
+describe("restoreJsonBackup", () => {
+  it("restores prior values and deletes keys that were originally unset", () => {
+    // Simulate the post-setup config.
+    const cfg: Record<string, unknown> = {
+      env: {
+        ANTHROPIC_BASE_URL: "http://127.0.0.1:3207",
+        DISABLE_AUTO_COMPACT: "1",
+      },
+    };
+    attachJsonBackup(
+      cfg,
+      captureJsonBackup(
+        { env: { ANTHROPIC_BASE_URL: "https://api.anthropic.com" } },
+        CLAUDE_LORE_VALUES,
+      ),
+    );
+    const summary = restoreJsonBackup(cfg);
+    expect(summary.hadBackup).toBe(true);
+    expect(summary.restored.sort()).toEqual([
+      "env.ANTHROPIC_BASE_URL",
+      "env.DISABLE_AUTO_COMPACT",
+    ]);
+    expect(cfg).toEqual({
+      env: { ANTHROPIC_BASE_URL: "https://api.anthropic.com" },
+    });
+  });
+
+  it("does NOT revert a value the user changed after setup (revert-only-if-unchanged)", () => {
+    const cfg: Record<string, unknown> = {
+      env: {
+        ANTHROPIC_BASE_URL: "http://user-changed:9999", // user edited this
+        DISABLE_AUTO_COMPACT: "1",
+      },
+    };
+    attachJsonBackup(
+      cfg,
+      captureJsonBackup(
+        { env: { ANTHROPIC_BASE_URL: "https://api.anthropic.com" } },
+        CLAUDE_LORE_VALUES,
+      ),
+    );
+    const summary = restoreJsonBackup(cfg);
+    expect(summary.skipped).toContain("env.ANTHROPIC_BASE_URL");
+    expect(summary.restored).toContain("env.DISABLE_AUTO_COMPACT");
+    // The user's value is preserved.
+    expect(getPath(cfg, "env.ANTHROPIC_BASE_URL")).toBe(
+      "http://user-changed:9999",
+    );
+  });
+
+  it("reports no backup when the sidecar is missing", () => {
+    expect(restoreJsonBackup({ env: {} }).hadBackup).toBe(false);
+  });
+
+  it("removes a plugin lore appended (OpenCode)", () => {
+    const cfg: Record<string, unknown> = {
+      plugin: ["@other/plugin", "@loreai/opencode"],
+    };
+    attachJsonBackup(cfg, captureJsonBackup({}, {}, { pluginAdded: true }));
+    const summary = restoreJsonBackup(cfg);
+    expect(summary.restored).toContain("plugin[@loreai/opencode]");
+    expect(cfg.plugin).toEqual(["@other/plugin"]);
+  });
+
+  it("leaves a plugin the user already had (pluginAdded=false)", () => {
+    const cfg: Record<string, unknown> = {
+      plugin: ["@loreai/opencode"],
+    };
+    attachJsonBackup(cfg, captureJsonBackup({}, {}, { pluginAdded: false }));
+    restoreJsonBackup(cfg);
+    expect(cfg.plugin).toEqual(["@loreai/opencode"]);
+  });
+
+  it("survives a full round-trip and leaves no _loreBackup key", () => {
+    const cfg: Record<string, unknown> = {
+      env: {
+        ANTHROPIC_BASE_URL: "http://127.0.0.1:3207",
+        DISABLE_AUTO_COMPACT: "1",
+      },
+    };
+    attachJsonBackup(cfg, captureJsonBackup({}, CLAUDE_LORE_VALUES));
+    restoreJsonBackup(cfg);
+    expect(LORE_BACKUP_KEY in cfg).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TOML backup (Codex)
+// ---------------------------------------------------------------------------
+
+describe("getTomlTopLevelValue", () => {
+  it("reads a top-level value", () => {
+    expect(
+      getTomlTopLevelValue('openai_base_url = "x"\n', "openai_base_url"),
+    ).toBe('"x"');
+  });
+
+  it("returns null for an absent key", () => {
+    expect(
+      getTomlTopLevelValue('model = "gpt"\n', "openai_base_url"),
+    ).toBeNull();
+  });
+
+  it("ignores a key nested inside a section", () => {
+    const c = '[tui]\nopenai_base_url = "nested"\n';
+    expect(getTomlTopLevelValue(c, "openai_base_url")).toBeNull();
+  });
+});
+
+describe("TOML backup block round-trip", () => {
+  const KEYS = ["openai_base_url", "model_auto_compact_token_limit"];
+
+  it("captures prior values and unset markers", () => {
+    const original = 'openai_base_url = "https://api.openai.com/v1"\n';
+    const block = buildTomlBackupBlock(original, KEYS);
+    expect(block).not.toBeNull();
+    expect(block).toContain(
+      '#   openai_base_url = "https://api.openai.com/v1"',
+    );
+    expect(block).toContain("#   model_auto_compact_token_limit (was unset)");
+  });
+
+  it("does not build a second block when one already exists", () => {
+    const original = 'openai_base_url = "https://api.openai.com/v1"\n';
+    const block = buildTomlBackupBlock(original, KEYS) as string;
+    const withBlock = prependTomlBackupBlock(original, block);
+    expect(buildTomlBackupBlock(withBlock, KEYS)).toBeNull();
+  });
+
+  it("restores prior value and deletes originally-unset keys", () => {
+    const original = 'openai_base_url = "https://api.openai.com/v1"\n';
+    // Real setup order: capture the block from the ORIGINAL, apply lore's
+    // writes to the original, then prepend the block to the updated content.
+    const block = buildTomlBackupBlock(original, KEYS) as string;
+    const updated =
+      'openai_base_url = "http://127.0.0.1:3207/v1"\nmodel_auto_compact_token_limit = 999999999\n';
+    const content = prependTomlBackupBlock(updated, block);
+
+    const { content: restored, summary } = restoreTomlBackup(content);
+    expect(summary.hadBackup).toBe(true);
+    expect(restored).toContain('openai_base_url = "https://api.openai.com/v1"');
+    expect(restored).not.toContain("http://127.0.0.1:3207/v1");
+    // Originally-unset key is removed entirely.
+    expect(restored).not.toContain("model_auto_compact_token_limit");
+    // Backup block removed.
+    expect(restored).not.toContain("lore setup backup");
+  });
+
+  it("reports no backup when the block is absent", () => {
+    expect(restoreTomlBackup('model = "gpt"\n').summary.hadBackup).toBe(false);
+  });
+});
+
+describe("deleteTomlTopLevelKey", () => {
+  it("removes only the top-level occurrence", () => {
+    const c = 'openai_base_url = "x"\n[tui]\nopenai_base_url = "nested"\n';
+    const out = deleteTomlTopLevelKey(c, "openai_base_url");
+    expect(out).not.toContain('openai_base_url = "x"');
+    expect(out).toContain('openai_base_url = "nested"');
+  });
+});

--- a/packages/gateway/test/setup-io.test.ts
+++ b/packages/gateway/test/setup-io.test.ts
@@ -1,0 +1,184 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  vi,
+  type MockInstance,
+} from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { commandSetup } from "../src/cli/setup";
+import { writePortFile } from "../src/portfile";
+
+// Integration coverage for the setup.ts IO surface (backup capture on setup,
+// `lore setup undo`, liveness reporting, port detection). Everything is scoped
+// to a throwaway HOME / XDG_DATA_HOME so we never touch the real config or the
+// running gateway. No gateway is listening on the test port, so the liveness
+// probe always reports "not reachable" — which is what we want to exercise.
+
+let home: string;
+let origHome: string | undefined;
+let origXdg: string | undefined;
+let logSpy: MockInstance;
+let errSpy: MockInstance;
+
+function logged(): string {
+  return [...logSpy.mock.calls, ...errSpy.mock.calls]
+    .map((c) => c.join(" "))
+    .join("\n");
+}
+
+beforeEach(() => {
+  origHome = process.env.HOME;
+  origXdg = process.env.XDG_DATA_HOME;
+  home = mkdtempSync(join(tmpdir(), "lore-setup-io-"));
+  process.env.HOME = home;
+  process.env.XDG_DATA_HOME = join(home, "data");
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  logSpy.mockRestore();
+  errSpy.mockRestore();
+  if (origHome === undefined) delete process.env.HOME;
+  else process.env.HOME = origHome;
+  if (origXdg === undefined) delete process.env.XDG_DATA_HOME;
+  else process.env.XDG_DATA_HOME = origXdg;
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe("commandSetup — Claude Code", () => {
+  const claudePath = () => join(home, ".claude", "settings.json");
+
+  it("configures, writes a backup, warns when the gateway is down, then undoes", async () => {
+    mkdirSync(join(home, ".claude"), { recursive: true });
+    writeFileSync(
+      claudePath(),
+      JSON.stringify({
+        env: { ANTHROPIC_BASE_URL: "https://api.anthropic.com" },
+      }),
+    );
+
+    await commandSetup(["claude-code"], { port: 3299 });
+
+    const cfg = JSON.parse(readFileSync(claudePath(), "utf8"));
+    expect(cfg.env.ANTHROPIC_BASE_URL).toBe("http://127.0.0.1:3299");
+    expect(cfg.env.DISABLE_AUTO_COMPACT).toBe("1");
+    expect(cfg._loreBackup).toBeDefined();
+    // Liveness probe failed (no gateway) → WARN with remediation.
+    expect(logged()).toContain("not reachable");
+    expect(logged()).toContain("lore start --bg");
+
+    await commandSetup(["undo", "claude-code"], {});
+
+    const restored = JSON.parse(readFileSync(claudePath(), "utf8"));
+    expect(restored.env.ANTHROPIC_BASE_URL).toBe("https://api.anthropic.com");
+    expect(restored.env.DISABLE_AUTO_COMPACT).toBeUndefined();
+    expect(restored._loreBackup).toBeUndefined();
+  });
+
+  it("detects the live gateway port from the port file (falls back when down)", async () => {
+    // Seed a port file; the probe will fail (nothing listening) so setup falls
+    // back to the default port. Exercises detectLiveGatewayPort's probe path.
+    writePortFile(5673);
+    await commandSetup(["claude-code"], {});
+    const cfg = JSON.parse(readFileSync(claudePath(), "utf8"));
+    expect(cfg.env.ANTHROPIC_BASE_URL).toBe("http://127.0.0.1:3207");
+  });
+});
+
+describe("commandSetup — Codex", () => {
+  const codexPath = () => join(home, ".codex", "config.toml");
+
+  it("configures with an inline backup block and undoes it", async () => {
+    mkdirSync(join(home, ".codex"), { recursive: true });
+    writeFileSync(
+      codexPath(),
+      'openai_base_url = "https://api.openai.com/v1"\n',
+    );
+
+    await commandSetup(["codex"], { port: 3299 });
+
+    let toml = readFileSync(codexPath(), "utf8");
+    expect(toml).toContain("lore setup backup");
+    expect(toml).toContain('openai_base_url = "http://127.0.0.1:3299/v1"');
+
+    await commandSetup(["undo", "codex"], {});
+
+    toml = readFileSync(codexPath(), "utf8");
+    expect(toml).toContain('openai_base_url = "https://api.openai.com/v1"');
+    expect(toml).not.toContain("lore setup backup");
+  });
+});
+
+describe("commandSetup — OpenCode", () => {
+  const ocPath = () => join(home, ".config", "opencode", "opencode.json");
+
+  it("configures providers (no plugin) with a backup and undoes it", async () => {
+    await commandSetup(["opencode"], { port: 3299, noPlugin: true });
+
+    const cfg = JSON.parse(readFileSync(ocPath(), "utf8"));
+    expect(cfg.provider.anthropic.options.baseURL).toBe(
+      "http://127.0.0.1:3299/v1",
+    );
+    expect(cfg.compaction).toEqual({ auto: false });
+    expect(cfg._loreBackup).toBeDefined();
+
+    await commandSetup(["undo", "opencode"], {});
+
+    const restored = JSON.parse(readFileSync(ocPath(), "utf8"));
+    // Provider baseURLs + compaction were lore-set on an empty config → undo
+    // removes them entirely (prunes emptied objects).
+    expect(restored.provider).toBeUndefined();
+    expect(restored.compaction).toBeUndefined();
+    expect(restored._loreBackup).toBeUndefined();
+  });
+});
+
+describe("commandSetup — undo with nothing to restore", () => {
+  it("reports nothing to undo across all apps", async () => {
+    await commandSetup(["undo"], {});
+    expect(logged()).toContain("No lore setup backups found");
+  });
+
+  it("reports nothing to undo for a single named app", async () => {
+    await commandSetup(["undo", "claude-code"], {});
+    expect(logged().toLowerCase()).toContain("no lore backup");
+  });
+
+  it("rejects an unknown app", async () => {
+    await commandSetup(["undo", "bogus"], {});
+    expect(logged()).toContain('Unknown app "bogus"');
+    expect(process.exitCode).toBe(1);
+    process.exitCode = 0; // reset for the runner
+  });
+});
+
+describe("commandSetup — argument handling", () => {
+  it("rejects an unknown app for setup", async () => {
+    await commandSetup(["bogus"], { port: 3299 });
+    expect(logged()).toContain('Unknown app "bogus"');
+    expect(process.exitCode).toBe(1);
+    process.exitCode = 0;
+  });
+
+  it("auto-detects installed apps (or reports none) without throwing", async () => {
+    // Environment-dependent: on a box with claude/codex/opencode on PATH this
+    // exercises the auto-detect loop + liveness report; on a clean CI box it
+    // hits the "no supported apps detected" branch. Either way it must not throw.
+    await expect(
+      commandSetup([], { port: 3299, noPlugin: true }),
+    ).resolves.toBeUndefined();
+    process.exitCode = 0;
+  });
+});

--- a/packages/gateway/test/setup-io.test.ts
+++ b/packages/gateway/test/setup-io.test.ts
@@ -143,6 +143,24 @@ describe("commandSetup — OpenCode", () => {
     expect(restored.compaction).toBeUndefined();
     expect(restored._loreBackup).toBeUndefined();
   });
+
+  it("does NOT remove a plugin lore never added (Seer #876)", async () => {
+    // --no-plugin means lore does not add @loreai/opencode, so pluginAdded is
+    // false in the backup. If the user adds it themselves afterwards, undo must
+    // leave it alone.
+    await commandSetup(["opencode"], { port: 3299, noPlugin: true });
+    const cfg = JSON.parse(readFileSync(ocPath(), "utf8"));
+    expect(cfg._loreBackup.pluginAdded).toBe(false);
+
+    // User manually adds the plugin after setup.
+    cfg.plugin = ["@loreai/opencode"];
+    writeFileSync(ocPath(), JSON.stringify(cfg, null, 2));
+
+    await commandSetup(["undo", "opencode"], {});
+
+    const restored = JSON.parse(readFileSync(ocPath(), "utf8"));
+    expect(restored.plugin).toEqual(["@loreai/opencode"]); // preserved
+  });
 });
 
 describe("commandSetup — undo with nothing to restore", () => {

--- a/packages/gateway/test/setup-liveness.test.ts
+++ b/packages/gateway/test/setup-liveness.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import {
+  chooseSetupPort,
+  formatLivenessNotice,
+  formatSetupGuidance,
+} from "../src/cli/setup";
+
+describe("chooseSetupPort", () => {
+  it("returns undefined for the remote path (port is irrelevant)", () => {
+    expect(
+      chooseSetupPort({ remoteUrl: "http://remote:3207", livePort: 5673 }),
+    ).toBeUndefined();
+  });
+
+  it("honors an explicit --port over a detected live port", () => {
+    expect(chooseSetupPort({ explicitPort: 8080, livePort: 5673 })).toBe(8080);
+  });
+
+  it("uses a detected live gateway port when no explicit port is given", () => {
+    // This is the fix for the 3207 → 5673 → random fallback mismatch.
+    expect(chooseSetupPort({ livePort: 5673 })).toBe(5673);
+  });
+
+  it("returns undefined (→ default port) when nothing is detected", () => {
+    expect(chooseSetupPort({ livePort: null })).toBeUndefined();
+    expect(chooseSetupPort({})).toBeUndefined();
+  });
+});
+
+describe("formatLivenessNotice", () => {
+  it("reports OK when the gateway is reachable", () => {
+    const r = formatLivenessNotice({
+      alive: true,
+      origin: "http://127.0.0.1:3207",
+      remote: false,
+    });
+    expect(r.ok).toBe(true);
+    expect(r.lines.join("\n")).toContain("http://127.0.0.1:3207");
+  });
+
+  it("warns with local remediation when a local gateway is down", () => {
+    const r = formatLivenessNotice({
+      alive: false,
+      origin: "http://127.0.0.1:3207",
+      remote: false,
+    });
+    expect(r.ok).toBe(false);
+    const text = r.lines.join("\n");
+    expect(text).toContain("not reachable");
+    expect(text).toContain("lore start --bg");
+    expect(text).toContain("lore run");
+  });
+
+  it("warns without the local-start hint for a remote gateway", () => {
+    const r = formatLivenessNotice({
+      alive: false,
+      origin: "http://remote:3207",
+      remote: true,
+    });
+    expect(r.ok).toBe(false);
+    const text = r.lines.join("\n");
+    expect(text).toContain("not reachable");
+    expect(text).not.toContain("lore start --bg");
+  });
+});
+
+describe("formatSetupGuidance", () => {
+  it("recommends `lore run` for terminal use and frames setup as the GUI/IDE path", () => {
+    const text = formatSetupGuidance().join("\n");
+    expect(text).toContain("lore run");
+    expect(text).toContain("lore start --bg");
+    expect(text.toLowerCase()).toContain("gui");
+  });
+});


### PR DESCRIPTION
> **Stacked on #875** (daemon mode) so `help.ts` doesn't conflict. Review/merge #875 first, then this retargets to `main`.

## What

Hardens `lore setup`, prompted by user feedback: someone ran `lore setup claude-code` before starting the gateway (with a leftover Bedrock config) and Claude Code silently stopped connecting — with no way to see what changed or to undo it.

1. **Liveness + real port detection.** Setup detects a running gateway via the port file and writes its *actual* port (fixes the hardcoded `3207` vs the `3207 → 5673 → random` fallback mismatch). After writing, it probes the target and prints a PASS/WARN notice with concrete remediation, replacing the static "make sure the gateway is running" line.
2. **`lore setup undo [app]`.** Reversible setup. Before changing anything, lore records a backup: JSON agents (Claude Code, OpenCode) get a top-level `_loreBackup` sidecar key (literal comments can't be used — the files are strict JSON and our own reader does `JSON.parse`); Codex gets a `#`-commented backup block at the top of `config.toml`. Undo is **revert-only-if-unchanged** — a value you edited after setup is left alone and reported.
3. **Run-first guidance.** Setup output and `--help` now recommend `lore run` for terminal agents and frame `lore setup` as the path for GUI/IDE agents lore can't launch, paired with a background gateway (`lore start --bg`).

## Details

- New `cli/setup-backup.ts`: pure dot-path helpers + JSON capture/attach/restore + TOML backup-block build/restore. No filesystem IO — fully unit-tested.
- Backup capture is idempotent: re-running setup never overwrites the *true* original.

## Tests

- `setup-backup.test.ts` (21), `setup-liveness.test.ts` (8) — TDD.
- Verified end-to-end via the CJS bundle in an isolated `HOME`: Claude Code (JSON) and Codex (TOML) setup→undo round-trips restored the original byte-faithfully, preserving user-set keys; the WARN path emits the `lore start --bg` / `lore run` remediation.

Related: #869 (`lore doctor`/`setup status`), #870 (Bedrock/Vertex support).
