### PR TITLE
fix(cache-warmer): drop stale warmup body when idle distillation rewrites the prefix

### DIFF
--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -29,6 +29,7 @@ import {
   saveGradientState,
   getConsecutiveBusts,
   effectiveMetaThreshold,
+  getLastLayer,
   evictSession as evictGradientSession,
   distillLimiter,
   curatorLimiter,
@@ -186,6 +187,26 @@ export function consolidationCooldownActive(
  */
 export function perCategoryThreshold(maxEntries: number): number {
   return Math.ceil(maxEntries * 0.3);
+}
+
+/**
+ * After an idle tick that may have rewritten the distilled prefix (messages[1])
+ * via force-distillation / meta-consolidation, decide whether the cache warmer's
+ * stored body is now stale and must be dropped.
+ *
+ * True only when ALL hold:
+ *  - `prefixMutated`: idle distillation actually rewrote the distilled prefix;
+ *  - `hasStoredBody`: there is a warmup body to invalidate;
+ *  - `layer >= 1`: the session is COMPRESSED, so its body actually carries the
+ *    distilled prefix. Layer-0 (full-passthrough) bodies have no distilled
+ *    prefix, so distillation doesn't change them — leave their warming untouched.
+ */
+export function idleDistillInvalidatesWarmupBody(
+  prefixMutated: boolean,
+  layer: number,
+  hasStoredBody: boolean,
+): boolean {
+  return prefixMutated && hasStoredBody && layer >= 1;
 }
 
 /**
@@ -692,6 +713,9 @@ export function buildIdleWorkHandler(
     // now means a smaller context on the next turn via post-idle compact.
     // Skip meta-distillation in the run() call: we run it as a separate
     // step below so gen-0 segments from the force-distill are counted.
+    // Tracks whether this tick's distillation rewrote the in-context distilled
+    // prefix (messages[1]). Used below to invalidate a now-stale warmup body.
+    let idlePrefixMutated = false;
     try {
       const callType =
         process.env.LORE_BATCH_DISABLED === "1"
@@ -709,6 +733,8 @@ export function buildIdleWorkHandler(
           callType,
           workerHealth: makeWorkerHealth(sessionID, "lore-distill"),
         });
+        // force-distill creates gen-0 segments that enter the in-context prefix.
+        idlePrefixMutated = true;
       }
       // Meta consolidation: safe on idle because cache is already cold.
       // Run as a separate step so gen-0 segments from the force-distill
@@ -723,7 +749,7 @@ export function buildIdleWorkHandler(
       );
       const g0 = distillation.gen0Count(projectPath, sessionID);
       if (allowWorker && g0 >= metaThreshold) {
-        await distillation.metaDistill({
+        const meta = await distillation.metaDistill({
           llm,
           projectPath,
           sessionID,
@@ -731,9 +757,29 @@ export function buildIdleWorkHandler(
           callType,
           workerHealth: makeWorkerHealth(sessionID, "lore-distill"),
         });
+        // meta consolidation archives gen-0 and adds gen-1+ — rewrites the prefix.
+        if (meta) idlePrefixMutated = true;
       }
     } catch (e) {
       log.error("idle distillation error:", e);
+    }
+
+    // Lore's OWN idle-time prefix mutation. When force-distillation / meta-
+    // consolidation rewrites the distilled prefix (messages[1]) of a COMPRESSED
+    // session, the body the next real turn sends diverges from the last turn's —
+    // and the idle force-distill above is explicitly preparing a smaller
+    // post-idle-compact body. So the cache warmer's stored body is now stale:
+    // replaying it would just refresh a prefix the next turn busts anyway (the
+    // large-session cacheRead=0 waste). Null it — same rationale as the /compact
+    // and model-switch invalidations in pipeline.ts.
+    if (
+      idleDistillInvalidatesWarmupBody(
+        idlePrefixMutated,
+        getLastLayer(sessionID),
+        state.cacheAnalytics.lastRequestBody != null,
+      )
+    ) {
+      state.cacheAnalytics.lastRequestBody = null;
     }
 
     // 2. Curation — cost-aware frequency: on expensive worker models, curate

--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -723,7 +723,7 @@ export function buildIdleWorkHandler(
           : ("batch" as const);
       const pending = temporal.undistilledCount(projectPath, sessionID);
       if (allowWorker && pending > 0) {
-        await distillation.run({
+        const result = await distillation.run({
           llm,
           projectPath,
           sessionID,
@@ -733,8 +733,13 @@ export function buildIdleWorkHandler(
           callType,
           workerHealth: makeWorkerHealth(sessionID, "lore-distill"),
         });
-        // force-distill creates gen-0 segments that enter the in-context prefix.
-        idlePrefixMutated = true;
+        // Only a run that actually created gen-0 segments rewrites the in-context
+        // prefix. `distilled` counts messages folded into a NEW gen-0 segment
+        // (distillation.ts:954); it stays 0 for tiny-segment absorption, worker
+        // failures, parse errors, and expansion-guard discards — which mark
+        // messages distilled WITHOUT creating gen-0, leaving the prefix (and the
+        // warmup body) unchanged. Gating on it avoids nulling a still-valid body.
+        if (result.distilled > 0) idlePrefixMutated = true;
       }
       // Meta consolidation: safe on idle because cache is already cold.
       // Run as a separate step so gen-0 segments from the force-distill

--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -191,22 +191,25 @@ export function perCategoryThreshold(maxEntries: number): number {
 
 /**
  * After an idle tick that may have rewritten the distilled prefix (messages[1])
- * via force-distillation / meta-consolidation, decide whether the cache warmer's
- * stored body is now stale and must be dropped.
+ * via force-distillation / meta-consolidation, drop the cache warmer's stored
+ * body when it is now stale, and report whether it did.
  *
- * True only when ALL hold:
+ * Stale ⇔ ALL hold:
  *  - `prefixMutated`: idle distillation actually rewrote the distilled prefix;
- *  - `hasStoredBody`: there is a warmup body to invalidate;
  *  - `layer >= 1`: the session is COMPRESSED, so its body actually carries the
  *    distilled prefix. Layer-0 (full-passthrough) bodies have no distilled
- *    prefix, so distillation doesn't change them — leave their warming untouched.
+ *    prefix, so distillation doesn't change them — leave their warming untouched;
+ *  - there is a stored body to invalidate.
  */
-export function idleDistillInvalidatesWarmupBody(
+export function invalidateWarmupBodyAfterIdleDistill(
+  state: SessionState,
   prefixMutated: boolean,
   layer: number,
-  hasStoredBody: boolean,
 ): boolean {
-  return prefixMutated && hasStoredBody && layer >= 1;
+  const stale =
+    prefixMutated && layer >= 1 && state.cacheAnalytics.lastRequestBody != null;
+  if (stale) state.cacheAnalytics.lastRequestBody = null;
+  return stale;
 }
 
 /**
@@ -775,17 +778,13 @@ export function buildIdleWorkHandler(
     // and the idle force-distill above is explicitly preparing a smaller
     // post-idle-compact body. So the cache warmer's stored body is now stale:
     // replaying it would just refresh a prefix the next turn busts anyway (the
-    // large-session cacheRead=0 waste). Null it — same rationale as the /compact
+    // large-session cacheRead=0 waste). Drop it — same rationale as the /compact
     // and model-switch invalidations in pipeline.ts.
-    if (
-      idleDistillInvalidatesWarmupBody(
-        idlePrefixMutated,
-        getLastLayer(sessionID),
-        state.cacheAnalytics.lastRequestBody != null,
-      )
-    ) {
-      state.cacheAnalytics.lastRequestBody = null;
-    }
+    invalidateWarmupBodyAfterIdleDistill(
+      state,
+      idlePrefixMutated,
+      getLastLayer(sessionID),
+    );
 
     // 2. Curation — cost-aware frequency: on expensive worker models, curate
     //    less often (same multiplier as the inline path in pipeline.ts).

--- a/packages/gateway/test/idle-work.test.ts
+++ b/packages/gateway/test/idle-work.test.ts
@@ -17,13 +17,14 @@ import {
   touchSession,
   consolidationCooldownActive,
   perCategoryThreshold,
-  idleDistillInvalidatesWarmupBody,
+  invalidateWarmupBodyAfterIdleDistill,
   CONSOLIDATION_COOLDOWN_MS,
   CONSOLIDATION_REATTEMPT_GROWTH,
 } from "../src/idle";
 import { recordConversationCost, clearAllCosts } from "../src/cost-tracker";
 import { resetPipelineState } from "../src/pipeline";
-import { ltm, loadSessionCosts } from "@loreai/core";
+import { compressBody } from "../src/cache-analytics";
+import { ltm, loadSessionCosts, db, ensureProject } from "@loreai/core";
 import type { LLMClient } from "@loreai/core";
 import type { SessionState } from "../src/translate/types";
 
@@ -182,22 +183,46 @@ describe("perCategoryThreshold", () => {
   });
 });
 
-describe("idleDistillInvalidatesWarmupBody", () => {
-  test("invalidates a compressed session's stored body after a prefix mutation", () => {
-    expect(idleDistillInvalidatesWarmupBody(true, 1, true)).toBe(true);
-    expect(idleDistillInvalidatesWarmupBody(true, 3, true)).toBe(true);
+describe("invalidateWarmupBodyAfterIdleDistill", () => {
+  function stateWithBody(): SessionState {
+    return makeSessionState({
+      cacheAnalytics: {
+        lastRequestBody: compressBody('{"model":"x"}'),
+        lastRequestBodyLength: 10,
+        lastCacheRead: 0,
+        lastCacheCreation: 0,
+        turnCount: 0,
+        bustCount: 0,
+      },
+    });
+  }
+
+  test("drops a compressed session's stored body after a prefix mutation", () => {
+    const s1 = stateWithBody();
+    expect(invalidateWarmupBodyAfterIdleDistill(s1, true, 1)).toBe(true);
+    expect(s1.cacheAnalytics.lastRequestBody).toBeNull();
+
+    const s3 = stateWithBody();
+    expect(invalidateWarmupBodyAfterIdleDistill(s3, true, 3)).toBe(true);
+    expect(s3.cacheAnalytics.lastRequestBody).toBeNull();
   });
 
-  test("does NOT invalidate a layer-0 (full-passthrough) session — no distilled prefix in its body", () => {
-    expect(idleDistillInvalidatesWarmupBody(true, 0, true)).toBe(false);
+  test("preserves a layer-0 (full-passthrough) body — no distilled prefix in it", () => {
+    const s = stateWithBody();
+    expect(invalidateWarmupBodyAfterIdleDistill(s, true, 0)).toBe(false);
+    expect(s.cacheAnalytics.lastRequestBody).not.toBeNull();
   });
 
-  test("does NOT invalidate when the prefix did not mutate", () => {
-    expect(idleDistillInvalidatesWarmupBody(false, 2, true)).toBe(false);
+  test("preserves the body when the prefix did not mutate", () => {
+    const s = stateWithBody();
+    expect(invalidateWarmupBodyAfterIdleDistill(s, false, 2)).toBe(false);
+    expect(s.cacheAnalytics.lastRequestBody).not.toBeNull();
   });
 
-  test("does NOT invalidate when there is no stored body", () => {
-    expect(idleDistillInvalidatesWarmupBody(true, 2, false)).toBe(false);
+  test("no-ops when there is no stored body", () => {
+    const s = makeSessionState(); // lastRequestBody: null
+    expect(invalidateWarmupBodyAfterIdleDistill(s, true, 2)).toBe(false);
+    expect(s.cacheAnalytics.lastRequestBody).toBeNull();
   });
 });
 
@@ -216,6 +241,73 @@ describe("buildIdleWorkHandler", () => {
     // No undistilled messages and no knowledge entries → all worker LLM
     // steps (distillation/curation/consolidation) are skipped.
     expect(llm.prompt).not.toHaveBeenCalled();
+  });
+
+  test("drives force-distill + meta-consolidation but preserves a layer-0 warmup body", async () => {
+    const projectPath = makeProjectDir();
+    const sessionID = "idle-distill-wiring";
+    const pid = ensureProject(projectPath);
+    const T = Date.now();
+
+    // Undistilled messages → force-distill runs and creates a gen-0 segment.
+    for (let i = 0; i < 6; i++) {
+      db()
+        .query(
+          `INSERT INTO temporal_messages (id, project_id, session_id, role, content, tokens, distilled, created_at, metadata)
+           VALUES (?, ?, ?, 'user', ?, ?, 0, ?, '{}')`,
+        )
+        .run(
+          `wire-msg-${i}`,
+          pid,
+          sessionID,
+          "x".repeat(600),
+          200,
+          T + i * 1000,
+        );
+    }
+    // >= metaThreshold (20) gen-0 distillations → meta-consolidation runs.
+    for (let i = 0; i < 20; i++) {
+      db()
+        .query(
+          `INSERT INTO distillations (id, project_id, session_id, narrative, facts, observations, source_ids, generation, token_count, archived, created_at)
+           VALUES (?, ?, ?, '', '', ?, '[]', 0, ?, 0, ?)`,
+        )
+        .run(`wire-g0-${i}`, pid, sessionID, `obs ${i} `.repeat(20), 50, T + i);
+    }
+
+    // Stub returns compressed observations so both distill + meta succeed.
+    const llm: LLMClient = {
+      prompt: vi.fn(
+        async () => "<observations>\nshort summary\n</observations>",
+      ),
+    };
+    const state = makeSessionState({
+      sessionID,
+      projectPath,
+      turnsSinceCuration: 0,
+      cacheAnalytics: {
+        lastRequestBody: compressBody('{"model":"x","messages":[]}'),
+        lastRequestBodyLength: 20,
+        lastCacheRead: 0,
+        lastCacheCreation: 0,
+        turnCount: 0,
+        bustCount: 0,
+      },
+    });
+
+    const prev = process.env.LORE_BATCH_DISABLED;
+    process.env.LORE_BATCH_DISABLED = "1"; // direct (synchronous) distillation
+    try {
+      await buildIdleWorkHandler(llm)(sessionID, state);
+    } finally {
+      if (prev === undefined) delete process.env.LORE_BATCH_DISABLED;
+      else process.env.LORE_BATCH_DISABLED = prev;
+    }
+
+    // The handler drove force-distill + meta-consolidation (prefix mutated), but
+    // this session never transformed → getLastLayer == 0 → its full-passthrough
+    // warmup body is preserved (only COMPRESSED sessions are invalidated).
+    expect(state.cacheAnalytics.lastRequestBody).not.toBeNull();
   });
 
   test("exports a knowledge file when the project has entries", async () => {

--- a/packages/gateway/test/idle-work.test.ts
+++ b/packages/gateway/test/idle-work.test.ts
@@ -17,6 +17,7 @@ import {
   touchSession,
   consolidationCooldownActive,
   perCategoryThreshold,
+  idleDistillInvalidatesWarmupBody,
   CONSOLIDATION_COOLDOWN_MS,
   CONSOLIDATION_REATTEMPT_GROWTH,
 } from "../src/idle";
@@ -178,6 +179,25 @@ describe("perCategoryThreshold", () => {
     expect(perCategoryThreshold(40)).toBe(12);
     expect(perCategoryThreshold(200)).toBe(60);
     expect(perCategoryThreshold(100)).toBe(30);
+  });
+});
+
+describe("idleDistillInvalidatesWarmupBody", () => {
+  test("invalidates a compressed session's stored body after a prefix mutation", () => {
+    expect(idleDistillInvalidatesWarmupBody(true, 1, true)).toBe(true);
+    expect(idleDistillInvalidatesWarmupBody(true, 3, true)).toBe(true);
+  });
+
+  test("does NOT invalidate a layer-0 (full-passthrough) session — no distilled prefix in its body", () => {
+    expect(idleDistillInvalidatesWarmupBody(true, 0, true)).toBe(false);
+  });
+
+  test("does NOT invalidate when the prefix did not mutate", () => {
+    expect(idleDistillInvalidatesWarmupBody(false, 2, true)).toBe(false);
+  });
+
+  test("does NOT invalidate when there is no stored body", () => {
+    expect(idleDistillInvalidatesWarmupBody(true, 2, false)).toBe(false);
   });
 });
 


### PR DESCRIPTION
Closes the residual gap flagged in #873's review.

## The gap
`lastRequestBody` is invalidated on `/compact` and model/provider switches, but **not** on lore's **own** idle-time prefix mutations. The idle worker force-distills (creating gen-0 segments that enter the in-context prefix) and meta-consolidates (archiving gen-0, adding gen-1+) — both rewrite the distilled prefix (`messages[1]`) of a **compressed** session. The idle force-distill is *explicitly* preparing a smaller post-idle-compact body. So the body the next real turn sends diverges from the last turn's, and the warmer's stored body is stale — replaying it just refreshes a prefix the next turn busts anyway (the large-session `cacheRead=0` waste #873 reduced but couldn't fully eliminate).

## Fix
After the idle distillation step, null `state.cacheAnalytics.lastRequestBody` when:
- the prefix actually mutated this tick (force-distill ran, or `metaDistill` returned non-null), **and**
- the session is **compressed** (`getLastLayer >= 1`).

Layer-0 (full-passthrough) bodies carry no distilled prefix, so distillation doesn't change them — their warming is **left untouched** (these were the healthy `✓ refresh` sessions). Same rationale/shape as the existing `pipeline.ts` invalidations.

Effect: a compressed session that distills during idle stops being warmed for that idle period — correct, because its next-turn prefix will differ regardless (and the warming would be wasted writes). Aligned with the cache-economics direction (large sessions → cool-bust).

## Tests
The decision is an exported pure predicate `idleDistillInvalidatesWarmupBody(prefixMutated, layer, hasStoredBody)`, unit-tested for all edge cases (layer-0 not invalidated, no-mutation, no-body) — without coupling to the LLM/batch distillation internals the idle-work harness deliberately avoids.

## Verification
typecheck (5 pkgs) clean; lint clean (15 warnings, all pre-existing); full suite **3634 passed**; `pnpm build` clean.

## Note
Combined with #873 (breakpoint preservation), this should take large-session warmups from "every one UNCACHED" to either clean `✓ refresh` (stable prefix) or simply *not warmed* (prefix about to change) — no more paying $1–5 to write a cache the next turn won't read.