### PR TITLE
perf(sync): memoize syncedColumns per connection (kills the push/pull PRAGMA N+1)

### DIFF
--- a/packages/core/src/sync-data.ts
+++ b/packages/core/src/sync-data.ts
@@ -252,14 +252,37 @@ function meta(table: string): SyncTableMeta {
  * Push, hashing, and apply all use this — never the raw local column set, which
  * has local-only columns the remote rejects (PGRST204).
  */
-export function syncedColumns(table: string): string[] {
+// Memoize the synced-column list per DB connection. syncedColumns runs a
+// `PRAGMA table_info`, and is reached once per row (via contentHash /
+// pickSyncColumns / getRowById) on every push and pull — an N+1 over a batch. A
+// table's columns are fixed once migrations finish (they run on the raw connection
+// before it's ever returned by db(), so before any sync), making the result stable
+// for a connection's lifetime. Keying on the db instance auto-invalidates when the
+// connection is replaced (close()/tests). The cached array is frozen: it is shared,
+// and all callers only read it (filter/iterate), so a stray mutation is a bug.
+const syncedColumnsCache = new WeakMap<
+  object,
+  Map<string, readonly string[]>
+>();
+
+export function syncedColumns(table: string): readonly string[] {
+  const conn = db();
+  let perConn = syncedColumnsCache.get(conn);
+  if (!perConn) {
+    perConn = new Map();
+    syncedColumnsCache.set(conn, perConn);
+  }
+  const cached = perConn.get(table);
+  if (cached) return cached;
   const m = meta(table);
   const local = new Set(
     (
-      db().query(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>
+      conn.query(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>
     ).map((r) => r.name),
   );
-  return m.syncColumns.filter((c) => local.has(c));
+  const result = Object.freeze(m.syncColumns.filter((c) => local.has(c)));
+  perConn.set(table, result);
+  return result;
 }
 
 /** Pick only the synced data columns from a row (for the push payload). */
@@ -275,7 +298,7 @@ export function pickSyncColumns(
 }
 
 /** Local column names of a synced table (validated against the registry). */
-function columns(table: string): string[] {
+function columns(table: string): readonly string[] {
   return syncedColumns(table);
 }
 
@@ -317,7 +340,10 @@ export function contentHash(
  * Lets hot loops resolve the columns ONCE (the `PRAGMA table_info` in `columns`)
  * and hash many rows without re-querying per row.
  */
-function hashRowColumns(cols: string[], row: Record<string, unknown>): string {
+function hashRowColumns(
+  cols: readonly string[],
+  row: Record<string, unknown>,
+): string {
   const hashCols = cols.filter((c) => !HASH_EXCLUDE.has(c)).sort();
   const canonical = hashCols
     .map((c) => `${c}=${serializeValue(row[c])}`)

--- a/packages/gateway/test/sync.test.ts
+++ b/packages/gateway/test/sync.test.ts
@@ -6,7 +6,7 @@ import {
   setKV,
   deleteTeamConfig,
 } from "@loreai/core";
-import { syncData } from "@loreai/core";
+import { log, syncData } from "@loreai/core";
 
 // --- Fake Supabase client ----------------------------------------------------
 // In-memory per-table store with the PostgREST surface the engine uses, PLUS
@@ -448,6 +448,39 @@ describe("pushOnce — happy path", () => {
     await pushOnce(makeClient() as never);
     const remoteE = tableRows("entities").find((r) => r.id === "e1");
     expect(remoteE?.canonical_name).toBe("RENAMED"); // edit propagated to the remote
+  });
+
+  test("pushOnce resolves a table's synced columns once, not per row (no PRAGMA N+1)", async () => {
+    // pushEntry hits syncedColumns 3x per row (getRowById + contentHash +
+    // pickSyncColumns), each a `PRAGMA table_info`. Unmemoized that is an N+1 over
+    // the whole push batch. Count the PRAGMAs the push actually executes (via the
+    // DB-tracing seam, the only reliable interception — a db().query monkeypatch is
+    // shadowed by the tracing Proxy).
+    syncData.enableSync("basic");
+    for (let i = 0; i < 20; i++) insertEntity(`e${i}`);
+    let pragma = 0;
+    const noop = () => {};
+    const passthrough: log.LogSink = {
+      info: noop,
+      warn: noop,
+      error: noop,
+      captureException: noop,
+    };
+    log.registerSink({
+      ...passthrough,
+      withDbSpan<T>(sql: string, fn: () => T): T {
+        if (/PRAGMA table_info\(entities\)/.test(sql)) pragma++;
+        return fn();
+      },
+    });
+    try {
+      await pushOnce(makeClient() as never);
+    } finally {
+      log.registerSink(passthrough); // restore pass-through (no withDbSpan)
+    }
+    expect(tableRows("entities")).toHaveLength(20); // sanity: rows really pushed
+    // 20 rows × 3 unmemoized PRAGMAs ≈ 60 before; O(1) per connection after.
+    expect(pragma).toBeLessThan(5);
   });
 });
 


### PR DESCRIPTION
Picks up the pre-existing N+1 #874 explicitly left out of scope.

## The N+1
`syncedColumns` runs `PRAGMA table_info(<table>)` on every call, and it's reached **once per row** via `contentHash`, `pickSyncColumns`, and `getRowById`:
- `pushEntry` (`gateway/src/sync.ts`) calls all three → **3 PRAGMAs per pushed row** (~60 for a 20-row push, measured).
- `applyRemote` calls `getRowById` per pulled row → 1 PRAGMA per row.

## The fix
Memoize `syncedColumns` in a `WeakMap` **keyed by the db instance**. A table's synced columns are fixed once migrations finish — and migrations run on the **raw** connection before `db()` ever returns it (the wrap/return happens after `migrate()`), so the cache only ever populates post-migration and is stable for the connection's lifetime. Keying on the instance **auto-invalidates** when the connection is replaced (`close()`/tests) — no manual schema-change invalidation needed. The only synced-table `ALTER`s live in migrations; no test mutates a synced table's schema mid-sync.

- Cached array is **frozen** and the return type is `readonly string[]` (every caller only `filter`/iterate — verified; the `readonly` change caused zero ripple under typecheck).
- Behavior-preserving: same column list, so identical hashes/payloads. The seed-time/push-time/`sync_state` hash consistency is unchanged.

## Validation
New deterministic regression test counts `PRAGMA table_info(entities)` during `pushOnce` via the **DB tracing seam** (a `db().query` monkeypatch is shadowed by the tracing Proxy — the `withDbSpan` hook is the only reliable interception): **60 → <5** (fails on `main`, passes here). Full suite **3635 passed**; property tests **0/5** failures; typecheck, lint, build green.