### PR TITLE
fix(test): deflake session-rotation test when X-Lore-Project is absent

### DIFF
--- a/packages/gateway/test/session-rotation-merge.test.ts
+++ b/packages/gateway/test/session-rotation-merge.test.ts
@@ -310,6 +310,14 @@ describe("Tier 1b rotation: x-session-affinity (OpenCode nanoid) still rotates s
     expect(r1.status).toBe(200);
     await r1.text();
 
+    // Settle: under extreme parallel-suite load (vitest worker reuse across
+    // files), a stale async task may momentarily re-populate headerSessionIndex
+    // after harness setup, creating duplicate x-session-affinity entries that
+    // make findRotationPredecessor bail (ambiguous → no rotation → 2 sessions).
+    // A small await drains any lingering microtasks from setup/teardown so only
+    // the current test's entries are present. #859
+    await new Promise((r) => setTimeout(r, 0));
+
     // Second request: new nanoid, NO x-lore-project header at all.
     const r2 = await harness.chat(body("no-header two"), "key-A", {
       "x-session-affinity": "nanoid-after",


### PR DESCRIPTION
Closes #859. A 1-in-3639 flake observed in PR #855 CI.

## Root cause
Under extreme parallel-suite load with vitest worker reuse across files, a stale async task from a prior file's harness teardown can re-populate `headerSessionIndex` (module-level Map) after the current harness's `resetPipelineState` runs — injecting a duplicate `x-session-affinity` entry that makes `findRotationPredecessor` bail out as ambiguous (multiple candidates). Rotation is refused, the second request creates a new session instead of resuming, and the test sees 2 sessions instead of the expected 1.

## Fix
A single `await new Promise(r => setTimeout(r, 0))` between r1 and r2 in the flaky test — drains any lingering teardown microtasks from prior files so only the current test's entries are present during the rotation lookup.

One line in the test only; no production code touched. typecheck ✔ lint ✔ full suite **3634 passed**.