### PR TITLE
test(sync): make the seedOutbox PRAGMA-count test non-vacuous

### DIFF
--- a/packages/gateway/test/sync.test.ts
+++ b/packages/gateway/test/sync.test.ts
@@ -459,6 +459,7 @@ describe("pushOnce — happy path", () => {
     syncData.enableSync("basic");
     for (let i = 0; i < 20; i++) insertEntity(`e${i}`);
     let pragma = 0;
+    let totalSpans = 0;
     const noop = () => {};
     const passthrough: log.LogSink = {
       info: noop,
@@ -469,6 +470,7 @@ describe("pushOnce — happy path", () => {
     log.registerSink({
       ...passthrough,
       withDbSpan<T>(sql: string, fn: () => T): T {
+        totalSpans++;
         if (/PRAGMA table_info\(entities\)/.test(sql)) pragma++;
         return fn();
       },
@@ -479,7 +481,11 @@ describe("pushOnce — happy path", () => {
       log.registerSink(passthrough); // restore pass-through (no withDbSpan)
     }
     expect(tableRows("entities")).toHaveLength(20); // sanity: rows really pushed
-    // 20 rows × 3 unmemoized PRAGMAs ≈ 60 before; O(1) per connection after.
+    // Non-vacuity guard: the tracing sink must actually fire — otherwise a future
+    // break in withDbSpan would silently leave pragma at 0 and pass the bound below.
+    expect(totalSpans).toBeGreaterThan(0);
+    // 20 rows × 3 unmemoized PRAGMAs ≈ 60 before; O(1) per connection after
+    // (here 0 — enableSync's seed already warmed the per-connection cache).
     expect(pragma).toBeLessThan(5);
   });
 });


### PR DESCRIPTION
Implements the SHOULD-FIX from the #878 review.

The push PRAGMA-count test observes **0** `PRAGMA table_info(entities)` during `pushOnce` — because `enableSync`'s seed pre-warms the per-connection `syncedColumns` cache before the push. That means the `expect(pragma).toBeLessThan(5)` bound would pass **vacuously** if the `withDbSpan` tracing sink ever stopped firing (a silent false-negative).

Fix: track `totalSpans` (all `withDbSpan` invocations) and `expect(totalSpans).toBeGreaterThan(0)` so the test proves the tracing seam actually fired before trusting the PRAGMA count. The `< 5` bound still cleanly separates the memoized path (0–1) from the unmemoized N+1 (~60, proven by the #878 mutant).

Test-only; `sync.test.ts` 24 passed, typecheck + lint (exit 0) green.