### PR TITLE
fix(cache-economics): source compressed size from the actual rebuilt window (layer ≥ 1)

### DIFF
--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -2953,8 +2953,20 @@ export function transform(input: {
     // the real compressed body size (distilled + raw, same body-scale as the tier
     // gate's compressedEstimate). Set it here from result.layer so EVERY path is
     // correct: layer 0 = no compaction (compressed == full); layer >= 1 = the
-    // actual compressed window (clamped to full as a guard). Authoritative — this
-    // overwrites the transformInner seed.
+    // actual compressed window (clamped to full as a guard — hitting the clamp
+    // yields the SAFE degenerate compressed == full, never fabricated savings).
+    // Authoritative: this overwrites the transformInner seed.
+    //
+    // SCALE CAVEAT (PR2b prerequisite, NOT a bug today): `cacheSizeFull` is
+    // INPUT-scale (layer0Input — includes overhead + LTM, and is ×UNCALIBRATED_
+    // SAFETY-inflated on first-sight-large turns), while `result.totalTokens` is
+    // BODY-scale (distilled + raw). This matches the pre-existing convention (the
+    // old tier-gate refine used body-scale compressedEstimate vs input-scale full)
+    // so the full-vs-compressed RATIO over-reports savings by the overhead+LTM
+    // floor (which compaction does NOT remove). Harmless while the evaluator is
+    // shadow/log-only; PR2b MUST normalize both sides to the cache-input scale
+    // (lift compressed to body + overhead + LTM, reconcile the uncalibrated factor
+    // on full) before acting on cool-bust.
     state.cacheSizeCompressed =
       result.layer >= 1
         ? Math.max(0, Math.min(result.totalTokens, state.cacheSizeFull))

--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -2966,7 +2966,7 @@ export function transform(input: {
     // floor (which compaction does NOT remove). Harmless while the evaluator is
     // shadow/log-only; PR2b MUST normalize both sides to the cache-input scale
     // (lift compressed to body + overhead + LTM, reconcile the uncalibrated factor
-    // on full) before acting on cool-bust.
+    // on full) before acting on cool-bust. Tracked in issue #886.
     state.cacheSizeCompressed =
       result.layer >= 1
         ? Math.max(0, Math.min(result.totalTokens, state.cacheSizeFull))

--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -2514,18 +2514,14 @@ function transformInner(input: {
     sid,
   );
 
-  // Record the gradient's own size estimate so the shared cache-economics
-  // evaluator (and therefore the warmer) reads identical full/compressed sizes
-  // from one place. Baseline assumes no compaction (compressed === full); the
-  // tier gate below refines `cacheSizeCompressed` when it actually evaluates a
-  // compression target.
-  //
-  // KNOWN GAP (shadow-only, PR2a): the refine ONLY fires on the layer-0 tier
-  // gate. Sessions held at layer >= 1 by the sticky/prefix-floor/post-idle/
-  // first-sight-large guards below bypass it, so for an already-compressing
-  // session `cacheSizeCompressed` stays == full and the shadow under-reports
-  // real compaction savings. Harmless while we only LOG; PR2b MUST source a real
-  // compressed target for the layer >= 1 paths before it acts on cool-bust.
+  // Record the gradient's own full-body size estimate so the shared cache-
+  // economics evaluator (and therefore the warmer) read identical sizes from one
+  // place. `cacheSizeCompressed` is set AUTHORITATIVELY from the actual rebuilt
+  // window at the single transform() exit (issue #881) — see transform() — so it
+  // is correct on EVERY layer path (including layer >= 1 sessions held by the
+  // sticky/prefix-floor/post-idle/first-sight-large guards, which bypass the tier
+  // gate below). Seed it to full here as the no-compaction default; the exit
+  // overwrites it with the real compressed size whenever result.layer >= 1.
   if (sid) {
     sessState.cacheSizeFull = Math.max(0, Math.round(layer0Input));
     sessState.cacheSizeCompressed = sessState.cacheSizeFull;
@@ -2606,13 +2602,13 @@ function transformInner(input: {
       distilledBudget + rawBudget,
       layer0Ceiling,
     );
-    // Refine the shared-economics snapshot with the real compression target so
-    // the warmer's cool-bust math uses the same compressed size this gate does.
-    // (Already inside a `… && sid` block, so the session state exists.)
-    sessState.cacheSizeCompressed = Math.max(
-      0,
-      Math.min(compressedEstimate, sessState.cacheSizeFull),
-    );
+    // NOTE: `cacheSizeCompressed` is NOT set here. It used to be refined to
+    // `compressedEstimate` at this point, but (a) when shouldCompress() below
+    // returns false the session stays at layer 0 with NO compaction, so leaving
+    // compressed < full wrongly implied savings, and (b) it covered only this
+    // layer-0 gate. transform() now sets it authoritatively from the actual
+    // rebuilt window on every layer path (issue #881). `compressedEstimate` is
+    // still the input to shouldCompress() (the bust-vs-continue decision).
     if (
       !shouldCompress(Math.round(layer0Input), compressedEstimate, busts, {
         freeWrite,
@@ -2947,6 +2943,22 @@ export function transform(input: {
     state.lastTransformEstimate = result.totalTokens;
     state.lastLayer = result.layer;
     state.lastWindowMessageIDs = new Set(result.messages.map((m) => m.info.id));
+
+    // Source the shared cache-economics compressed size from the ACTUAL rebuilt
+    // window (issue #881). transformInner seeds cacheSizeCompressed = cacheSizeFull
+    // (no-compaction default) and refines it only inside the layer-0 tier gate;
+    // sessions HELD at layer >= 1 by the sticky / prefix-floor / post-idle /
+    // first-sight-large guards bypass that gate, so compressed stayed == full and
+    // the evaluator under-reported real compaction savings. result.totalTokens is
+    // the real compressed body size (distilled + raw, same body-scale as the tier
+    // gate's compressedEstimate). Set it here from result.layer so EVERY path is
+    // correct: layer 0 = no compaction (compressed == full); layer >= 1 = the
+    // actual compressed window (clamped to full as a guard). Authoritative — this
+    // overwrites the transformInner seed.
+    state.cacheSizeCompressed =
+      result.layer >= 1
+        ? Math.max(0, Math.min(result.totalTokens, state.cacheSizeFull))
+        : state.cacheSizeFull;
     // Mark wall-clock for onIdleResume() — must record on every transform()
     // so the next-turn idle check has an accurate baseline. Done after the
     // result fields above so a thrown transformInner doesn't update it.

--- a/packages/core/test/cache-strategy-evaluator.test.ts
+++ b/packages/core/test/cache-strategy-evaluator.test.ts
@@ -190,4 +190,43 @@ describe("transform writes the size snapshot end-to-end", () => {
 
     evictSession(session);
   });
+
+  test("a layer >= 1 transform reports compressed < full (issue #881)", () => {
+    const session = `econ-e2e-compress-${Date.now()}`;
+    // Tiny context + a large UNCALIBRATED (first-turn) conversation triggers the
+    // first-sight-large path → effectiveMinLayer >= 1, which BYPASSES the layer-0
+    // tier gate. This is exactly one of the layer >= 1 paths that used to leave
+    // cacheSizeCompressed == cacheSizeFull (under-reporting compaction savings).
+    setModelLimits({ context: 2_000, output: 500 });
+    try {
+      const messages = Array.from({ length: 30 }, (_, i) =>
+        makeMsg(
+          `cmp-${i}`,
+          i % 2 === 0 ? "user" : "assistant",
+          "A".repeat(1_000),
+          session,
+        ),
+      );
+      const result = transform({
+        messages,
+        projectPath: PROJECT,
+        sessionID: session,
+      });
+      expect(result.layer).toBeGreaterThanOrEqual(1);
+
+      const snap = getCacheSizeSnapshot(session);
+      expect(snap).not.toBeNull();
+      // The fix: compressed reflects the ACTUAL rebuilt window, strictly below
+      // full. Mutation guard: sourcing it from the full size (the old layer >= 1
+      // behavior) would make these EQUAL — so `<` would fail.
+      expect(snap?.compressed).toBeLessThan(snap?.full ?? 0);
+      // ...and it is exactly the clamped actual rebuilt-window size.
+      expect(snap?.compressed).toBe(
+        Math.max(0, Math.min(result.totalTokens, snap?.full ?? 0)),
+      );
+    } finally {
+      setModelLimits({ context: 10_000, output: 2_000 });
+      evictSession(session);
+    }
+  });
 });


### PR DESCRIPTION
Closes #881.

## Problem
The shared cache-economics snapshot (`gradient.ts`) under-reports compaction savings for sessions that are **already compressing** (held at layer ≥ 1). `cacheSizeCompressed` was only refined inside the **layer-0 tier gate**, so sessions held at layer ≥ 1 by the sticky-layer / prefix-floor / post-idle / first-sight-large guards **bypass it** and keep `cacheSizeCompressed == cacheSizeFull`. Harmless today (shadow/log-only — #844/#846), but wrong once PR2b flips consumers to act on the model (cool-bust / opportunistic flush) — exactly the divergence the unification exists to prevent.

## Fix
Set `cacheSizeCompressed` **authoritatively at the single `transform()` exit** from the actual result:
- `result.layer === 0` → `compressed == full` (no compaction happened).
- `result.layer >= 1` → `min(result.totalTokens, full)` — the **actual rebuilt window** (`distilled + raw`, the same body-scale the tier gate's `compressedEstimate` already uses).

This covers **every** layer path in one place. It also **removes the tier-gate write**, which was:
1. **superseded** by the authoritative exit, and
2. **buggy**: when `shouldCompress()` returned false the session stayed at layer 0 with *no* compaction, yet `cacheSizeCompressed` had already been set `< full` — falsely implying savings for a non-compacted session.

`transformInner` now only **seeds** the no-compaction default (`compressed = full`); `transform()` overwrites it. `shouldCompress()` still receives `compressedEstimate` unchanged (the bust-vs-continue decision is untouched).

## Why `result.totalTokens` is the right source
`cacheSizeFull = layer0Input` (full input estimate). `usable = context − outputReserved − overhead − ltm`, and `distilledBudget`/`rawBudget`/`result.totalTokens` are all **body-scale** — the same scale the tier gate's `compressedEstimate` uses, so this is consistent with the existing economics. For an overflowing (layer ≥ 1) session `result.totalTokens ≪ cacheSizeFull`, so the delta is non-degenerate.

## Acceptance criteria
- [x] Every `transform()` path landing at layer ≥ 1 sets `cacheSizeCompressed` to the actual rebuilt window size.
- [x] `evaluateCacheStrategy()` returns a non-degenerate full-vs-compressed delta for already-compressing sessions.
- [x] Regression test: a layer ≥ 1 session (first-sight-large path, which bypasses the tier gate) reports `compressed < full` **and** equals the clamped actual rebuilt-window size — mutation-guarded (sourcing from full would make them equal).
- [x] Wired/verified **before** PR2b flips any consumer.

## Verification
typecheck (5 pkgs) clean; lint clean (15 warnings, all pre-existing); full suite **3642 passed**; `pnpm build` clean.