### PR TITLE
fix(test): scope session-rotation counts by header (proper #859 fix)

### DIFF
--- a/packages/gateway/test/session-rotation-merge.test.ts
+++ b/packages/gateway/test/session-rotation-merge.test.ts
@@ -85,8 +85,16 @@ describe("Tier 1b session-merge regression (x-claude-code-session-id)", () => {
     expect(r2.status).toBe(200);
     await r2.text();
 
+    // Scope to this test's session header. Background tasks (curator / idle /
+    // gradient) call saveSessionTracking(), whose INSERT OR IGNORE writes a
+    // header-NULL row. Under parallel-suite load an in-flight background write
+    // from a prior harness can land in this harness's DB (shared db() singleton
+    // across harnesses) → a phantom row that inflates an unscoped count. Filter
+    // by header_name so we count only real rotation-relevant sessions; a genuine
+    // rotation refusal still writes a header_name row, so this never masks the
+    // bug under test. #859
     const sessions = harness.queryDB<SessionRow>(
-      "SELECT session_id, header_session_id, header_name, project_path, project_path_provisional FROM session_state ORDER BY rowid",
+      "SELECT session_id, header_session_id, header_name, project_path, project_path_provisional FROM session_state WHERE header_name = 'x-claude-code-session-id' ORDER BY rowid",
     );
 
     // TWO distinct internal sessions — the core regression assertion. Pre-fix
@@ -152,8 +160,9 @@ describe("Tier 1b session-merge regression (x-claude-code-session-id)", () => {
     await r2.text();
 
     // Same header value across turns → ONE session (legitimate resumption).
+    // Scoped by header_name to ignore phantom header-NULL rows (see #859 note above).
     const sessions = harness.queryDB<SessionRow>(
-      "SELECT session_id, project_path FROM session_state",
+      "SELECT session_id, project_path FROM session_state WHERE header_name = 'x-claude-code-session-id'",
     );
     expect(sessions.length).toBe(1);
     expect(sessions[0].project_path).toBe("/proj/gamma");
@@ -193,8 +202,9 @@ describe("Tier 1b session-merge regression (x-claude-code-session-id)", () => {
       await r.text();
     }
 
+    // Scoped by header_name to ignore phantom header-NULL rows (see #859 note above).
     const sessions = harness.queryDB<SessionRow>(
-      "SELECT session_id, header_session_id, project_path FROM session_state",
+      "SELECT session_id, header_session_id, project_path FROM session_state WHERE header_name = 'x-claude-code-session-id'",
     );
     // Three distinct sessions, each on its own project (pre-fix: 1 session).
     expect(sessions.length).toBe(3);
@@ -243,8 +253,9 @@ describe("Tier 1b rotation: x-session-affinity (OpenCode nanoid) still rotates s
     expect(r2.status).toBe(200);
     await r2.text();
 
+    // Scoped by header_name to ignore phantom header-NULL rows (see #859 note above).
     const sessions = harness.queryDB<SessionRow>(
-      "SELECT session_id, project_path FROM session_state",
+      "SELECT session_id, project_path FROM session_state WHERE header_name = 'x-session-affinity'",
     );
     // Two distinct sessions — the rotation was refused due to project mismatch.
     expect(sessions.length).toBe(2);
@@ -281,8 +292,9 @@ describe("Tier 1b rotation: x-session-affinity (OpenCode nanoid) still rotates s
     expect(r2.status).toBe(200);
     await r2.text();
 
+    // Scoped by header_name to ignore phantom header-NULL rows (see #859 note above).
     const sessions = harness.queryDB<SessionRow>(
-      "SELECT session_id, project_path FROM session_state",
+      "SELECT session_id, project_path FROM session_state WHERE header_name = 'x-session-affinity'",
     );
     // ONE session — the rotation resumed the original (same project).
     expect(sessions.length).toBe(1);
@@ -310,14 +322,6 @@ describe("Tier 1b rotation: x-session-affinity (OpenCode nanoid) still rotates s
     expect(r1.status).toBe(200);
     await r1.text();
 
-    // Settle: under extreme parallel-suite load (vitest worker reuse across
-    // files), a stale async task may momentarily re-populate headerSessionIndex
-    // after harness setup, creating duplicate x-session-affinity entries that
-    // make findRotationPredecessor bail (ambiguous → no rotation → 2 sessions).
-    // A small await drains any lingering microtasks from setup/teardown so only
-    // the current test's entries are present. #859
-    await new Promise((r) => setTimeout(r, 0));
-
     // Second request: new nanoid, NO x-lore-project header at all.
     const r2 = await harness.chat(body("no-header two"), "key-A", {
       "x-session-affinity": "nanoid-after",
@@ -326,8 +330,11 @@ describe("Tier 1b rotation: x-session-affinity (OpenCode nanoid) still rotates s
     expect(r2.status).toBe(200);
     await r2.text();
 
+    // Scoped by header_name to ignore phantom header-NULL rows (see #859 note
+    // above). This is what previously flaked: an unscoped count picked up a
+    // phantom row from a leaked background write and read 2 instead of 1.
     const sessions = harness.queryDB<SessionRow>(
-      "SELECT session_id, project_path FROM session_state",
+      "SELECT session_id, project_path FROM session_state WHERE header_name = 'x-session-affinity'",
     );
     // ONE session — rotation proceeded (Fix 2 was a no-op, no incoming project).
     expect(sessions.length).toBe(1);
@@ -370,8 +377,9 @@ describe("Tier 1b: x-lore-session-id isolation (Lore plugin stable ID)", () => {
     expect(r2.status).toBe(200);
     await r2.text();
 
+    // Scoped by header_name to ignore phantom header-NULL rows (see #859 note above).
     const sessions = harness.queryDB<SessionRow>(
-      "SELECT session_id, project_path FROM session_state",
+      "SELECT session_id, project_path FROM session_state WHERE header_name = 'x-lore-session-id'",
     );
     // Two distinct sessions — x-lore-session-id never rotates.
     expect(sessions.length).toBe(2);


### PR DESCRIPTION
Follow-up to #879. An adversarial review of #879 showed it **misdiagnosed** the flake and only narrowed the window with a `setTimeout(0)` that had no causal mechanism. This replaces it with the real fix.

## Real root cause
The assertions used an **unscoped** `SELECT ... FROM session_state` and counted *every* row. Background tasks (curator / idle / gradient) call `saveSessionTracking()`, whose `INSERT OR IGNORE` writes a **header-NULL** row. Under parallel-suite load, an in-flight background write from a *prior* harness can land in the *next* harness's DB — the core `db()` connection is a process-global singleton shared across harnesses, and reset/teardown doesn't drain in-flight background work before swapping `LORE_DB_PATH`. That phantom row inflates the count from 1 to 2 (a ~1/3639 event — needs a background task mid-flight at the exact teardown→setup boundary).

The original "ambiguous rotation predecessor" theory in #879 is impossible by construction: `loadHeaderSessionIndex` filters `header_session_id/header_name IS NOT NULL`, and `getCandidate` returns null for any prior-harness sid, so a phantom row can never become a rotation candidate.

## Fix
Scope every count assertion in the file to `WHERE header_name = '<the test's session header>'`. This:
- counts only real rotation-relevant sessions → immune to phantom header-NULL rows (deterministic);
- does **not** mask the bug under test — a genuine rotation refusal writes a row **with** `header_name` (pipeline.ts:2716), so a real regression still surfaces as 2 rows.

Removes the `setTimeout` band-aid. Test-only change. typecheck ✔ lint ✔ full suite **3641 passed**.

## Deeper follow-up (not in this PR)
The underlying harness-isolation defect — background tasks/idle ticks leaking writes across harnesses via the shared `db()` singleton — is worth fixing separately (drain in-flight background/idle work before `closeDB()` in `resetPipelineState`/teardown). Filing as a separate issue; scoping the assertions makes the tests correct and deterministic regardless.