### PR TITLE
fix(cache-economics): normalize cacheSizeCompressed to cacheSizeFull's input scale

### DIFF
--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -445,6 +445,15 @@ type SessionState = {
   cacheSizeFull: number;
   /** Compacted-body token target from the most recent transform(); === cacheSizeFull when no compaction is available. */
   cacheSizeCompressed: number;
+  /** Non-message floor (system/tools overhead + LTM) of the most recent
+   *  transform(), in the SAME estimate basis as the message body (un-inflated).
+   *  Compaction never removes this; it is added back to the compressed body so
+   *  cacheSizeCompressed lands on the same scale as cacheSizeFull (issue #886). */
+  cacheNonBodyTokens: number;
+  /** Multiplier that maps the gradient's un-inflated (chars/3) body estimate onto
+   *  cacheSizeFull's scale: 1 when calibrated, UNCALIBRATED_SAFETY when not — the
+   *  same factor layer0Bounds applies to cacheSizeFull. (issue #886) */
+  cacheBodySafety: number;
   /** The single stored strategy decision + when it was computed (null until first evaluated). */
   cacheStrategy: { result: CacheEconomicsResult; decidedAt: number } | null;
 };
@@ -473,6 +482,8 @@ function makeSessionState(): SessionState {
     dedupDecisions: new Map(),
     cacheSizeFull: 0,
     cacheSizeCompressed: 0,
+    cacheNonBodyTokens: 0,
+    cacheBodySafety: 1,
     cacheStrategy: null,
   };
 }
@@ -612,6 +623,36 @@ export interface CacheSurvivalInputs {
   expectedCycles: number;
   /** Expected turns the resumed session runs (the "ongoing cost" horizon). */
   expectedFutureTurns: number;
+}
+
+/**
+ * Compute the cache-economics compressed size on the SAME scale as cacheSizeFull
+ * (issue #886). cacheSizeFull is INPUT-scale: it includes the non-message floor
+ * (system/tools overhead + LTM) and is ×UNCALIBRATED_SAFETY-inflated on
+ * uncalibrated turns. A compacted prompt still carries that whole floor — only
+ * the message body shrinks — so the compressed cache size is:
+ *
+ *   (nonBodyFloor + rebuiltWindowBody) × bodySafety   (clamped to full)
+ *
+ * where `rebuiltWindowBody` (result.totalTokens) and `nonBodyFloor` are the
+ * gradient's un-inflated estimates and `bodySafety` is the same factor applied to
+ * full. This keeps the full-vs-compressed DELTA = the message tokens removed by
+ * compaction (the floor cancels), with both sizes on the input scale the warmer
+ * cross-checks against the real API token count. Layer 0 = no compaction → full.
+ */
+export function computeCompressedCacheSize(
+  layer: number,
+  rebuiltWindowTokens: number,
+  nonBodyTokens: number,
+  bodySafety: number,
+  fullTokens: number,
+): number {
+  if (layer < 1) return fullTokens;
+  const compressed = Math.round(
+    (Math.max(0, nonBodyTokens) + Math.max(0, rebuiltWindowTokens)) *
+      Math.max(1, bodySafety),
+  );
+  return Math.max(0, Math.min(compressed, fullTokens));
 }
 
 /**
@@ -2525,6 +2566,14 @@ function transformInner(input: {
   if (sid) {
     sessState.cacheSizeFull = Math.max(0, Math.round(layer0Input));
     sessState.cacheSizeCompressed = sessState.cacheSizeFull;
+    // Capture the inputs transform() needs to lift the compressed size onto the
+    // same INPUT scale as cacheSizeFull (issue #886): the non-message floor
+    // (overhead + LTM, which compaction never removes) and the safety factor
+    // layer0Bounds applied to cacheSizeFull (1 when calibrated, else
+    // UNCALIBRATED_SAFETY). Stored un-inflated; transform() inflates both the
+    // floor and the rebuilt-window body together via computeCompressedCacheSize.
+    sessState.cacheNonBodyTokens = Math.max(0, overhead + sessLtmTokens);
+    sessState.cacheBodySafety = calibrated ? 1 : UNCALIBRATED_SAFETY;
   }
 
   // First-sight large session → skip the Layer-0 cold full-write. An
@@ -2945,32 +2994,25 @@ export function transform(input: {
     state.lastWindowMessageIDs = new Set(result.messages.map((m) => m.info.id));
 
     // Source the shared cache-economics compressed size from the ACTUAL rebuilt
-    // window (issue #881). transformInner seeds cacheSizeCompressed = cacheSizeFull
-    // (no-compaction default) and refines it only inside the layer-0 tier gate;
+    // window (issue #881), lifted onto the same INPUT scale as cacheSizeFull
+    // (issue #886). transformInner seeds cacheSizeCompressed = cacheSizeFull (the
+    // no-compaction default) and refined it only inside the layer-0 tier gate;
     // sessions HELD at layer >= 1 by the sticky / prefix-floor / post-idle /
-    // first-sight-large guards bypass that gate, so compressed stayed == full and
-    // the evaluator under-reported real compaction savings. result.totalTokens is
-    // the real compressed body size (distilled + raw, same body-scale as the tier
-    // gate's compressedEstimate). Set it here from result.layer so EVERY path is
-    // correct: layer 0 = no compaction (compressed == full); layer >= 1 = the
-    // actual compressed window (clamped to full as a guard — hitting the clamp
-    // yields the SAFE degenerate compressed == full, never fabricated savings).
-    // Authoritative: this overwrites the transformInner seed.
-    //
-    // SCALE CAVEAT (PR2b prerequisite, NOT a bug today): `cacheSizeFull` is
-    // INPUT-scale (layer0Input — includes overhead + LTM, and is ×UNCALIBRATED_
-    // SAFETY-inflated on first-sight-large turns), while `result.totalTokens` is
-    // BODY-scale (distilled + raw). This matches the pre-existing convention (the
-    // old tier-gate refine used body-scale compressedEstimate vs input-scale full)
-    // so the full-vs-compressed RATIO over-reports savings by the overhead+LTM
-    // floor (which compaction does NOT remove). Harmless while the evaluator is
-    // shadow/log-only; PR2b MUST normalize both sides to the cache-input scale
-    // (lift compressed to body + overhead + LTM, reconcile the uncalibrated factor
-    // on full) before acting on cool-bust. Tracked in issue #886.
-    state.cacheSizeCompressed =
-      result.layer >= 1
-        ? Math.max(0, Math.min(result.totalTokens, state.cacheSizeFull))
-        : state.cacheSizeFull;
+    // first-sight-large guards bypass that gate. We set it authoritatively here
+    // from result.layer so EVERY path is correct, and via computeCompressedCacheSize
+    // so the compressed size keeps the non-message floor (overhead + LTM, which
+    // compaction does NOT remove) and the same UNCALIBRATED_SAFETY factor as full
+    // — i.e. the full-vs-compressed delta is exactly the message tokens compaction
+    // removed, on the input scale the warmer cross-checks against apiActual.
+    // Layer 0 = no compaction (compressed == full); the clamp to full yields the
+    // SAFE degenerate (no fabricated savings) if a rebuilt window ever exceeds it.
+    state.cacheSizeCompressed = computeCompressedCacheSize(
+      result.layer,
+      result.totalTokens,
+      state.cacheNonBodyTokens,
+      state.cacheBodySafety,
+      state.cacheSizeFull,
+    );
     // Mark wall-clock for onIdleResume() — must record on every transform()
     // so the next-turn idle check has an accurate baseline. Done after the
     // result fields above so a thrown transformInner doesn't update it.

--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -126,7 +126,7 @@ const FREE_WRITE_LAYER0_FRACTION = 0.65;
  * layer-0 sizing helper (and isLargeColdStart) share one definition with the
  * transform path.
  */
-const UNCALIBRATED_SAFETY = 1.5;
+export const UNCALIBRATED_SAFETY = 1.5;
 
 /**
  * True when the session's upstream has reported zero cache_creation_input_tokens
@@ -636,9 +636,19 @@ export interface CacheSurvivalInputs {
  *
  * where `rebuiltWindowBody` (result.totalTokens) and `nonBodyFloor` are the
  * gradient's un-inflated estimates and `bodySafety` is the same factor applied to
- * full. This keeps the full-vs-compressed DELTA = the message tokens removed by
- * compaction (the floor cancels), with both sizes on the input scale the warmer
- * cross-checks against the real API token count. Layer 0 = no compaction → full.
+ * full. Layer 0 = no compaction → full.
+ *
+ * EXACT for UNCALIBRATED turns: cacheSizeFull there is `(msgBody+overhead+ltm)·s`
+ * built from the SAME `overhead+ltm` expression, so the floor cancels and the
+ * delta is exactly `(msgBody−rebuiltBody)·s` (the removed message tokens).
+ * APPROXIMATE for CALIBRATED turns: cacheSizeFull is the API-measured
+ * `lastKnownInput`, whose embedded floor is the real tokenizer count, while this
+ * floor is the gradient's `overhead+ltm` estimate (and `overhead` is an EMA that
+ * already absorbs LTM + the chars/3 body undercount — the same entanglement as
+ * `usable`). The mismatch errs toward a LARGER compressed (under-reports savings;
+ * the clamp to `full` keeps it safe). Fully reconciling the calibrated basis is
+ * the remaining PR2b normalization work; harmless while the evaluator is
+ * shadow-only.
  */
 export function computeCompressedCacheSize(
   layer: number,
@@ -3001,11 +3011,12 @@ export function transform(input: {
     // first-sight-large guards bypass that gate. We set it authoritatively here
     // from result.layer so EVERY path is correct, and via computeCompressedCacheSize
     // so the compressed size keeps the non-message floor (overhead + LTM, which
-    // compaction does NOT remove) and the same UNCALIBRATED_SAFETY factor as full
-    // — i.e. the full-vs-compressed delta is exactly the message tokens compaction
-    // removed, on the input scale the warmer cross-checks against apiActual.
-    // Layer 0 = no compaction (compressed == full); the clamp to full yields the
-    // SAFE degenerate (no fabricated savings) if a rebuilt window ever exceeds it.
+    // compaction does NOT remove) and the same UNCALIBRATED_SAFETY factor as full.
+    // The full-vs-compressed delta is then the message tokens compaction removed,
+    // on the input scale the warmer cross-checks against apiActual — EXACT for
+    // uncalibrated turns, APPROXIMATE (conservative, clamp-guarded) for calibrated
+    // turns where full is API-measured (see computeCompressedCacheSize). Layer 0 =
+    // no compaction (compressed == full).
     state.cacheSizeCompressed = computeCompressedCacheSize(
       result.layer,
       result.totalTokens,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -167,6 +167,7 @@ export {
   effectiveMetaThreshold,
   isLargeColdStart,
   setCacheSizeSnapshot,
+  computeCompressedCacheSize,
   evaluateCacheStrategy,
   getCacheStrategy,
   getCacheSizeSnapshot,

--- a/packages/core/test/cache-strategy-evaluator.test.ts
+++ b/packages/core/test/cache-strategy-evaluator.test.ts
@@ -7,10 +7,13 @@ import {
   evictSession,
   getCacheSizeSnapshot,
   getCacheStrategy,
+  getOverhead,
   setCacheSizeSnapshot,
   setCachePricing,
+  setLtmTokens,
   setModelLimits,
   transform,
+  UNCALIBRATED_SAFETY,
 } from "../src/gradient";
 import type { LoreMessage, LoreMessageWithParts } from "../src/types";
 
@@ -259,6 +262,100 @@ describe("transform writes the size snapshot end-to-end", () => {
       expect(snap?.compressed).toBeGreaterThan(result.totalTokens);
     } finally {
       setModelLimits({ context: 10_000, output: 2_000 });
+      evictSession(session);
+    }
+  });
+
+  test("layer >= 1 carries the non-message floor (overhead + LTM) end-to-end — uncalibrated (#886)", () => {
+    const session = `econ-e2e-floor-${Date.now()}`;
+    // A NON-ZERO floor: inject LTM so transform() must add it back to compressed.
+    // (The test above has overhead=0 and no LTM, so its floor is 0 — it could not
+    // catch a regression that drops the floor capture.)
+    const ltm = 6_000;
+    setModelLimits({ context: 20_000, output: 2_000 });
+    setLtmTokens(ltm, session);
+    try {
+      const messages = Array.from({ length: 30 }, (_, i) =>
+        makeMsg(
+          `flr-${i}`,
+          i % 2 === 0 ? "user" : "assistant",
+          "A".repeat(1_000),
+          session,
+        ),
+      );
+      const result = transform({
+        messages,
+        projectPath: PROJECT,
+        sessionID: session,
+      });
+      expect(result.layer).toBeGreaterThanOrEqual(1);
+
+      const snap = getCacheSizeSnapshot(session);
+      expect(snap).not.toBeNull();
+      // Exact: transform() must feed the captured floor (overhead + LTM) and the
+      // uncalibrated safety factor into the helper. Dropping the floor capture or
+      // flipping the safety selection changes this value.
+      const expected = computeCompressedCacheSize(
+        result.layer,
+        result.totalTokens,
+        getOverhead() + ltm,
+        UNCALIBRATED_SAFETY,
+        snap?.full ?? 0,
+      );
+      expect(snap?.compressed).toBe(expected);
+      // The floor (≥ ltm) lifts compressed well above the body-only ×safety value.
+      expect(snap?.compressed).toBeGreaterThan(
+        Math.round(result.totalTokens * UNCALIBRATED_SAFETY),
+      );
+      expect(snap?.compressed).toBeLessThan(snap?.full ?? 0);
+    } finally {
+      setModelLimits({ context: 10_000, output: 2_000 });
+      setLtmTokens(0, session);
+      evictSession(session);
+    }
+  });
+
+  test("layer >= 1 uses safety=1 once calibrated — floor without inflation (#886)", () => {
+    const session = `econ-e2e-cal-${Date.now()}`;
+    const ltm = 4_000;
+    setModelLimits({ context: 20_000, output: 2_000 });
+    setLtmTokens(ltm, session);
+    try {
+      const messages = Array.from({ length: 30 }, (_, i) =>
+        makeMsg(
+          `cal-${i}`,
+          i % 2 === 0 ? "user" : "assistant",
+          "A".repeat(1_000),
+          session,
+        ),
+      );
+      // Turn 1 (uncalibrated) establishes a transform estimate, then calibrate
+      // with a real API input count flips the session to calibrated (safety = 1).
+      transform({ messages, projectPath: PROJECT, sessionID: session });
+      calibrate(40_000, session);
+
+      const result = transform({
+        messages,
+        projectPath: PROJECT,
+        sessionID: session,
+      });
+      expect(result.layer).toBeGreaterThanOrEqual(1);
+
+      const snap = getCacheSizeSnapshot(session);
+      expect(snap).not.toBeNull();
+      // Calibrated → bodySafety === 1: compressed is floor + body with NO ×1.5.
+      const expected = computeCompressedCacheSize(
+        result.layer,
+        result.totalTokens,
+        getOverhead() + ltm,
+        1,
+        snap?.full ?? 0,
+      );
+      expect(snap?.compressed).toBe(expected);
+      expect(snap?.compressed).toBeLessThan(snap?.full ?? 0);
+    } finally {
+      setModelLimits({ context: 10_000, output: 2_000 });
+      setLtmTokens(0, session);
       evictSession(session);
     }
   });

--- a/packages/core/test/cache-strategy-evaluator.test.ts
+++ b/packages/core/test/cache-strategy-evaluator.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeAll, describe, expect, test } from "vitest";
 import { ensureProject } from "../src/db";
 import {
   calibrate,
+  computeCompressedCacheSize,
   evaluateCacheStrategy,
   evictSession,
   getCacheSizeSnapshot,
@@ -158,6 +159,38 @@ describe("cache-strategy evaluator (single entry point)", () => {
   });
 });
 
+describe("computeCompressedCacheSize (input-scale normalization, issue #886)", () => {
+  test("layer 0 → no compaction → compressed == full", () => {
+    expect(computeCompressedCacheSize(0, 5_000, 2_000, 1.5, 100_000)).toBe(
+      100_000,
+    );
+  });
+
+  test("layer >= 1 keeps the non-message floor (overhead + LTM)", () => {
+    // calibrated (safety 1): compressed = floor + body, NOT body-only.
+    // body=8_000, floor=12_000 → 20_000 (vs the old body-only 8_000).
+    expect(computeCompressedCacheSize(1, 8_000, 12_000, 1, 200_000)).toBe(
+      20_000,
+    );
+  });
+
+  test("layer >= 1 applies the uncalibrated safety factor to floor AND body", () => {
+    // uncalibrated (safety 1.5): (floor 4_000 + body 8_000) * 1.5 = 18_000.
+    expect(computeCompressedCacheSize(2, 8_000, 4_000, 1.5, 200_000)).toBe(
+      18_000,
+    );
+  });
+
+  test("clamps to full (never fabricates savings) and floors at 0", () => {
+    expect(computeCompressedCacheSize(1, 9_999, 9_999, 1.5, 5_000)).toBe(5_000);
+    expect(computeCompressedCacheSize(1, 0, 0, 1.5, 10_000)).toBe(0);
+  });
+
+  test("treats a safety factor below 1 as 1 (never deflates below the estimate)", () => {
+    expect(computeCompressedCacheSize(1, 1_000, 500, 0.4, 100_000)).toBe(1_500);
+  });
+});
+
 describe("transform writes the size snapshot end-to-end", () => {
   beforeAll(() => {
     ensureProject(PROJECT);
@@ -216,14 +249,14 @@ describe("transform writes the size snapshot end-to-end", () => {
 
       const snap = getCacheSizeSnapshot(session);
       expect(snap).not.toBeNull();
-      // The fix: compressed reflects the ACTUAL rebuilt window, strictly below
-      // full. Mutation guard: sourcing it from the full size (the old layer >= 1
+      // #881: compressed reflects the rebuilt window, strictly below full.
+      // Mutation guard: sourcing it from the full size (the old layer >= 1
       // behavior) would make these EQUAL — so `<` would fail.
       expect(snap?.compressed).toBeLessThan(snap?.full ?? 0);
-      // ...and it is exactly the clamped actual rebuilt-window size.
-      expect(snap?.compressed).toBe(
-        Math.max(0, Math.min(result.totalTokens, snap?.full ?? 0)),
-      );
+      // #886: it is lifted onto cacheSizeFull's INPUT scale (floor + body, ×the
+      // uncalibrated safety factor), so it is STRICTLY GREATER than the raw
+      // body-only rebuilt-window size. Guards against the #881 body-only value.
+      expect(snap?.compressed).toBeGreaterThan(result.totalTokens);
     } finally {
       setModelLimits({ context: 10_000, output: 2_000 });
       evictSession(session);


### PR DESCRIPTION
Closes #886 (the PR2b prerequisite surfaced by the adversarial review of #883).

## Problem
`cacheSizeFull` is **INPUT-scale**: it includes the non-message floor (system/tools overhead + LTM) and is ×`UNCALIBRATED_SAFETY` (1.5) inflated on uncalibrated turns — deliberately, so it tracks the real API token count the warmer cross-checks against (`gradFull` vs `apiActual`). But `cacheSizeCompressed` was set from the raw **body-only** rebuilt window (`result.totalTokens`) — body-scale, no floor, never inflated. So the full-vs-compressed delta **over-reported savings** by:
1. the overhead + LTM **floor** (which compaction never removes — the system prompt + LTM persist in the compacted prompt too), and
2. the **uncalibrated** ×1.5 factor (on full but not compressed).

Both bias `decideCacheStrategy` toward cool-bust. Shadow/log-only today, but wrong once PR2b acts on the model.

## Fix
A compacted prompt still carries the whole floor — only the message body shrinks. So:

```
cacheSizeCompressed = (nonBodyFloor + rebuiltWindowBody) × bodySafety   (clamped to full)
```

- `transformInner` captures the un-inflated **non-body floor** (`overhead + sessLtmTokens`) and the **safety factor** (`1` when calibrated, else `UNCALIBRATED_SAFETY`) alongside `cacheSizeFull`.
- `transform()` computes the compressed size via a new pure helper **`computeCompressedCacheSize`**, inflating floor + body together onto `cacheSizeFull`'s scale.

The full-vs-compressed **delta is now exactly the message tokens compaction removed** (the floor cancels), on the input scale `full` uses. `cacheSizeFull` is unchanged (keeps the `apiActual` cross-check intact).

## No behavior change
Both consumers (`evaluateCacheStrategy` shadow log in the warmer; `getCacheSizeSnapshot`) are still measure-only. This only makes the shadow data faithful.

## Tests
- `computeCompressedCacheSize` unit tests: layer-0 → `== full`; floor retained (calibrated); safety applied to floor+body (uncalibrated); clamp-to-full; safety < 1 treated as 1.
- The #881 e2e test now asserts compressed is **lifted above** the body-only value **and** still `< full` (mutation-guarded both ways).

## Verification
typecheck (5 pkgs) clean; lint clean (15 warnings, pre-existing); full suite **3647 passed**; `pnpm build` clean.

## Follow-on
With this landed, the layer ≥ 1 shadow data is faithful end-to-end — clears the last prerequisite before PR2b flips the warmer/compaction consumers onto the unified `evaluateCacheStrategy`.