### PR TITLE
fix(gateway): drain in-flight background work on pipeline reset

### DIFF
--- a/packages/gateway/src/background-limiter.ts
+++ b/packages/gateway/src/background-limiter.ts
@@ -322,7 +322,9 @@ export async function drainBackground(timeoutMs = 5000): Promise<void> {
   if (activeTasks.size === 0) return;
   let timer: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<void>((resolve) => {
+    // unref so the timer can never independently hold the event loop open.
     timer = setTimeout(resolve, timeoutMs);
+    timer.unref?.();
   });
   try {
     await Promise.race([Promise.allSettled([...activeTasks]), timeout]);
@@ -404,11 +406,17 @@ export function backgroundLimiterStats(): {
  * Note: `clearQueue()` only removes pending (queued) tasks — in-flight
  * tasks (up to the current concurrency cap) will continue to completion. Pending tasks resolve
  * as `undefined`, consistent with the circuit breaker skip behavior.
+ *
+ * `activeTasks` is cleared too so a started-but-unawaited task from one test
+ * can't pollute the next test's `drainBackground()` (the running task still
+ * finishes; we just stop tracking it). The drain itself empties this set via
+ * each task's `finally`, so this is belt-and-suspenders for test isolation.
  */
 export function resetBackgroundLimiter(): void {
   limiter.clearQueue();
   limiter.concurrency = MIN_BACKGROUND_CONCURRENCY;
   breakers.clear();
+  activeTasks.clear();
 }
 
 /**

--- a/packages/gateway/src/background-limiter.ts
+++ b/packages/gateway/src/background-limiter.ts
@@ -88,6 +88,14 @@ const LOAD_BOOST_THRESHOLD = 0.5;
 
 const limiter = pLimit(MIN_BACKGROUND_CONCURRENCY);
 
+/**
+ * In-flight (already-started) background tasks, so `drainBackground()` can await
+ * them. Only STARTED tasks are tracked — queued tasks are discarded by
+ * `clearQueue()` and would otherwise strand the drain on a promise that never
+ * settles. See `drainBackground`.
+ */
+const activeTasks = new Set<Promise<unknown>>();
+
 // ---------------------------------------------------------------------------
 // Circuit breaker (per-provider)
 // ---------------------------------------------------------------------------
@@ -286,8 +294,41 @@ export async function runBackground<T>(
       }
       return undefined as T | undefined;
     }
-    return fn();
+    // Track the actually-running task so drainBackground() can await it. Only
+    // started tasks are tracked (queued tasks aren't), so a later clearQueue()
+    // can never strand the drain on a task that will never run.
+    const task = fn();
+    activeTasks.add(task);
+    try {
+      return await task;
+    } finally {
+      activeTasks.delete(task);
+    }
   });
+}
+
+/**
+ * Await all in-flight (started) background tasks, discarding anything still
+ * queued. Used by `resetPipelineState()` on config reload / test teardown to
+ * quiesce background work before the DB is swapped — a late distillation /
+ * curation / idle `saveSessionTracking()` write must not land in the next
+ * process's (or test harness's) database as a phantom row. Bounded by
+ * `timeoutMs` so a genuinely stuck task can never hang a reset; the leak it
+ * guards against is test-only (production has a single, stable DB), so the
+ * timeout is a safety valve, not a correctness boundary. See #885.
+ */
+export async function drainBackground(timeoutMs = 5000): Promise<void> {
+  limiter.clearQueue(); // discard not-yet-started tasks — they never write
+  if (activeTasks.size === 0) return;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<void>((resolve) => {
+    timer = setTimeout(resolve, timeoutMs);
+  });
+  try {
+    await Promise.race([Promise.allSettled([...activeTasks]), timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 /**

--- a/packages/gateway/src/background-limiter.ts
+++ b/packages/gateway/src/background-limiter.ts
@@ -319,7 +319,22 @@ export async function runBackground<T>(
  */
 export async function drainBackground(timeoutMs = 5000): Promise<void> {
   limiter.clearQueue(); // discard not-yet-started tasks — they never write
-  if (activeTasks.size === 0) return;
+  await boundedSettle(activeTasks, timeoutMs);
+}
+
+/**
+ * `Promise.allSettled` over `promises`, but bounded by `timeoutMs` so a stalled
+ * promise can never hang the caller. Resolves on whichever comes first. Shared
+ * by `drainBackground` (limiter tasks) and `resetPipelineState` (the direct
+ * urgent-distillation / curation chains in `inFlightBackground`) so BOTH drains
+ * carry the same hang guard. See #885.
+ */
+export async function boundedSettle(
+  promises: Iterable<Promise<unknown>>,
+  timeoutMs = 5000,
+): Promise<void> {
+  const arr = [...promises];
+  if (arr.length === 0) return;
   let timer: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<void>((resolve) => {
     // unref so the timer can never independently hold the event loop open.
@@ -327,7 +342,7 @@ export async function drainBackground(timeoutMs = 5000): Promise<void> {
     timer.unref?.();
   });
   try {
-    await Promise.race([Promise.allSettled([...activeTasks]), timeout]);
+    await Promise.race([Promise.allSettled(arr), timeout]);
   } finally {
     if (timer) clearTimeout(timer);
   }

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -166,6 +166,7 @@ import {
   resetBackgroundLimiter,
   isBackgroundPaused,
   drainBackground,
+  boundedSettle,
 } from "./background-limiter";
 import {
   extractAuth,
@@ -474,7 +475,9 @@ export async function resetPipelineState(opts?: {
       stopIdleScheduler = null;
     }
     await drainBackground();
-    await Promise.allSettled([...inFlightBackground]);
+    // Bound this drain too (Seer) — a stalled urgent distillation / curation
+    // chain must not hang the reset, matching drainBackground's guarantee.
+    await boundedSettle(inFlightBackground);
     inFlightBackground.clear();
   }
   initialized = false;

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -456,12 +456,16 @@ export function setUpstreamInterceptor(
 export async function resetPipelineState(opts?: {
   fast?: boolean;
 }): Promise<void> {
-  // Quiesce background work before tearing anything down (config reload / test
-  // teardown only — the fast process-exit path skips this to keep Ctrl+C
-  // snappy). Stop the idle scheduler FIRST so no new ticks schedule work, then
-  // await every in-flight distillation / curation / idle task. This is done
-  // while llmClient + the upstream interceptor are still live, so the drained
-  // tasks complete cleanly. The point: a late `saveSessionTracking()` write
+  // Quiesce background work before tearing anything down. Only the non-fast
+  // path drains — today that's test/eval teardown (the fast process-exit path,
+  // the sole production caller, skips this to keep Ctrl+C snappy). Stop the
+  // idle scheduler FIRST so no new ticks schedule work, then await every
+  // in-flight distillation / curation / idle task. Done while llmClient + the
+  // upstream interceptor are still live so DIRECT-callType tasks (incl. the
+  // always-scheduled urgent distillation) complete cleanly; a batch-callType
+  // task can't flush until llmClient.shutdown below, so it falls back to the
+  // bounded drain timeout (rare in tests — incremental distill/curation seldom
+  // trigger in short runs). The point: a late `saveSessionTracking()` write
   // must land in THIS process's DB, not leak into the next one's as a phantom
   // row — the cross-harness contamination behind the #859 flake. See #885.
   if (!opts?.fast) {
@@ -4585,52 +4589,59 @@ function scheduleBackgroundWork(
     })
   ) {
     sessionState.curationScheduled = true;
-    runBackground(
-      () =>
-        Sentry.startSpan(
-          {
-            name: "lore.curator",
-            op: "lore.curation",
-            attributes: { trigger: "in-flight" },
-          },
-          () =>
-            curator.run({
-              llm,
-              projectPath,
-              sessionID,
-              model,
-              workerHealth: makeWorkerHealth(sessionID, "lore-curator"),
-            }),
-        ),
-      `in-flight-curation session=${sessionID.slice(0, 16)}`,
-      workerProviderID,
-    )
-      .then((result) => {
-        if (!result) return; // skipped by circuit breaker
-        sessionState.turnsSinceCuration = 0;
-        saveSessionTracking(sessionID, { turnsSinceCuration: 0 });
-        if (
-          result.created > 0 ||
-          result.updated > 0 ||
-          result.deleted > 0 ||
-          result.changedEntries?.length > 0
-        ) {
-          // Invalidate LTM cache only when curation actually changed entries
-          ltmSessionCache.delete(sessionID);
-          saveSessionTracking(sessionID, {
-            ltmCacheText: null,
-            ltmCacheTokens: null,
-          });
-          log.info(
-            `curation: ${result.created} created, ${result.updated} updated, ${result.deleted} deleted`,
-          );
-          emitCurationMetrics({ ...result, trigger: "in-flight" });
-        }
-      })
-      .catch((e) => log.error("background curation failed:", e))
-      .finally(() => {
-        sessionState.curationScheduled = false;
-      });
+    // Track the FULL chain (not just the limiter task) so resetPipelineState's
+    // drain also awaits the post-completion saveSessionTracking writes in the
+    // .then below — those run a few microtasks after the inner task settles and
+    // would otherwise escape the drain. (Latent today since in-flight curation
+    // is off by default, but keeps the leak closed if it's ever enabled.) #885
+    trackBackground(
+      runBackground(
+        () =>
+          Sentry.startSpan(
+            {
+              name: "lore.curator",
+              op: "lore.curation",
+              attributes: { trigger: "in-flight" },
+            },
+            () =>
+              curator.run({
+                llm,
+                projectPath,
+                sessionID,
+                model,
+                workerHealth: makeWorkerHealth(sessionID, "lore-curator"),
+              }),
+          ),
+        `in-flight-curation session=${sessionID.slice(0, 16)}`,
+        workerProviderID,
+      )
+        .then((result) => {
+          if (!result) return; // skipped by circuit breaker
+          sessionState.turnsSinceCuration = 0;
+          saveSessionTracking(sessionID, { turnsSinceCuration: 0 });
+          if (
+            result.created > 0 ||
+            result.updated > 0 ||
+            result.deleted > 0 ||
+            result.changedEntries?.length > 0
+          ) {
+            // Invalidate LTM cache only when curation actually changed entries
+            ltmSessionCache.delete(sessionID);
+            saveSessionTracking(sessionID, {
+              ltmCacheText: null,
+              ltmCacheTokens: null,
+            });
+            log.info(
+              `curation: ${result.created} created, ${result.updated} updated, ${result.deleted} deleted`,
+            );
+            emitCurationMetrics({ ...result, trigger: "in-flight" });
+          }
+        })
+        .catch((e) => log.error("background curation failed:", e))
+        .finally(() => {
+          sessionState.curationScheduled = false;
+        }),
+    );
   }
 }
 

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -165,6 +165,7 @@ import {
   runBackground,
   resetBackgroundLimiter,
   isBackgroundPaused,
+  drainBackground,
 } from "./background-limiter";
 import {
   extractAuth,
@@ -455,6 +456,23 @@ export function setUpstreamInterceptor(
 export async function resetPipelineState(opts?: {
   fast?: boolean;
 }): Promise<void> {
+  // Quiesce background work before tearing anything down (config reload / test
+  // teardown only — the fast process-exit path skips this to keep Ctrl+C
+  // snappy). Stop the idle scheduler FIRST so no new ticks schedule work, then
+  // await every in-flight distillation / curation / idle task. This is done
+  // while llmClient + the upstream interceptor are still live, so the drained
+  // tasks complete cleanly. The point: a late `saveSessionTracking()` write
+  // must land in THIS process's DB, not leak into the next one's as a phantom
+  // row — the cross-harness contamination behind the #859 flake. See #885.
+  if (!opts?.fast) {
+    if (stopIdleScheduler) {
+      stopIdleScheduler();
+      stopIdleScheduler = null;
+    }
+    await drainBackground();
+    await Promise.allSettled([...inFlightBackground]);
+    inFlightBackground.clear();
+  }
   initialized = false;
   sessions.clear();
   cwdWarned.clear();
@@ -4391,6 +4409,18 @@ function postResponse(
 /**
  * Schedule background distillation and curation (fire-and-forget).
  */
+/**
+ * In-flight DIRECT (non-limiter) background promises — currently just the
+ * urgent distillation, which bypasses `runBackground`. Tracked so
+ * `resetPipelineState()` can await it before the DB is swapped, alongside the
+ * limiter's `drainBackground()`. See #885.
+ */
+const inFlightBackground = new Set<Promise<unknown>>();
+function trackBackground(p: Promise<unknown>): void {
+  inFlightBackground.add(p);
+  void p.finally(() => inFlightBackground.delete(p));
+}
+
 function scheduleBackgroundWork(
   sessionState: SessionState,
   config: GatewayConfig,
@@ -4445,23 +4475,25 @@ function scheduleBackgroundWork(
     saveSessionTracking(sessionID, { compactionAnomalyPending: false });
   }
   if (urgentFromGradient || urgentFromCompaction) {
-    distillation
-      .run({
-        llm,
-        projectPath,
-        sessionID,
-        model,
-        force: true,
-        urgent: true,
-        callType: "direct",
-        // Never run meta-distillation while the conversation cache is warm.
-        // Meta archives gen-0 rows and creates a gen-1 row, rewriting the
-        // synthetic distilled prefix at messages[0/1] on the next turn. That
-        // early-message rewrite is a real prompt-cache bust. Idle-time meta in
-        // idle.ts remains enabled because the cache is already cold there.
-        skipMeta: true,
-      })
-      .catch((e) => log.error("background distillation failed:", e));
+    trackBackground(
+      distillation
+        .run({
+          llm,
+          projectPath,
+          sessionID,
+          model,
+          force: true,
+          urgent: true,
+          callType: "direct",
+          // Never run meta-distillation while the conversation cache is warm.
+          // Meta archives gen-0 rows and creates a gen-1 row, rewriting the
+          // synthetic distilled prefix at messages[0/1] on the next turn. That
+          // early-message rewrite is a real prompt-cache bust. Idle-time meta in
+          // idle.ts remains enabled because the cache is already cold there.
+          skipMeta: true,
+        })
+        .catch((e) => log.error("background distillation failed:", e)),
+    );
   } else if (
     !isBackgroundPaused(workerProviderID) &&
     !quotaPaused &&

--- a/packages/gateway/test/background-limiter.test.ts
+++ b/packages/gateway/test/background-limiter.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, beforeEach, afterEach } from "vitest";
 import {
   runBackground,
+  drainBackground,
   isBackgroundPaused,
   tripCircuitBreaker,
   resetBackgroundLimiter,
@@ -502,5 +503,84 @@ describe("background-limiter", () => {
 
     resolve();
     await Promise.all([active1, active2, ...queued]);
+  });
+
+  describe("drainBackground", () => {
+    test("resolves immediately when nothing is in flight", async () => {
+      await expect(drainBackground()).resolves.toBeUndefined();
+    });
+
+    test("awaits an in-flight (started) task before resolving", async () => {
+      let completed = false;
+      let release: () => void = () => {};
+      const gate = new Promise<void>((r) => {
+        release = r;
+      });
+      const task = runBackground(async () => {
+        await gate;
+        completed = true;
+      });
+      await new Promise((r) => setTimeout(r, 10)); // let it start
+      expect(completed).toBe(false);
+
+      const drain = drainBackground();
+      let drainResolved = false;
+      void drain.then(() => {
+        drainResolved = true;
+      });
+      await new Promise((r) => setTimeout(r, 10));
+      // The drain must NOT resolve while the task is still running.
+      expect(drainResolved).toBe(false);
+
+      release();
+      await drain;
+      expect(completed).toBe(true);
+      await task;
+    });
+
+    test("discards queued (not-yet-started) tasks without hanging", async () => {
+      _setConcurrencyForTest(1);
+      let started2 = false;
+      let release1: () => void = () => {};
+      const gate1 = new Promise<void>((r) => {
+        release1 = r;
+      });
+      const t1 = runBackground(async () => {
+        await gate1;
+      });
+      // Queued behind t1 (concurrency 1). It must never run after the drain.
+      const t2 = runBackground(async () => {
+        started2 = true;
+      });
+      void t2.catch(() => {}); // queued task may stay pending after clearQueue
+      await new Promise((r) => setTimeout(r, 10));
+      expect(started2).toBe(false);
+
+      const drain = drainBackground();
+      release1();
+      await drain; // must not hang on the discarded t2
+      await t1;
+      expect(started2).toBe(false); // t2 was discarded, never executed
+    });
+
+    test("returns after the timeout instead of hanging on a slow task", async () => {
+      let release: () => void = () => {};
+      const gate = new Promise<void>((r) => {
+        release = r;
+      });
+      const task = runBackground(async () => {
+        await gate;
+      });
+      await new Promise((r) => setTimeout(r, 10)); // let it start
+
+      const start = Date.now();
+      await drainBackground(50);
+      const elapsed = Date.now() - start;
+      expect(elapsed).toBeGreaterThanOrEqual(40);
+      expect(elapsed).toBeLessThan(1500);
+
+      release(); // let the task finish so it leaves the in-flight set
+      await task;
+    });
   });
 });

--- a/packages/gateway/test/background-limiter.test.ts
+++ b/packages/gateway/test/background-limiter.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect, beforeEach, afterEach } from "vitest";
 import {
   runBackground,
   drainBackground,
+  boundedSettle,
   isBackgroundPaused,
   tripCircuitBreaker,
   resetBackgroundLimiter,
@@ -581,6 +582,31 @@ describe("background-limiter", () => {
 
       release(); // let the task finish so it leaves the in-flight set
       await task;
+    });
+  });
+
+  describe("boundedSettle", () => {
+    test("resolves immediately on empty input", async () => {
+      await expect(boundedSettle([])).resolves.toBeUndefined();
+    });
+
+    test("awaits settled promises", async () => {
+      let done = false;
+      const p = (async () => {
+        await new Promise((r) => setTimeout(r, 20));
+        done = true;
+      })();
+      await boundedSettle([p]);
+      expect(done).toBe(true);
+    });
+
+    test("returns after the timeout if a promise never settles", async () => {
+      const stuck = new Promise<void>(() => {}); // never resolves
+      const start = Date.now();
+      await boundedSettle([stuck], 50);
+      const elapsed = Date.now() - start;
+      expect(elapsed).toBeGreaterThanOrEqual(40);
+      expect(elapsed).toBeLessThan(1500);
     });
   });
 });


### PR DESCRIPTION
Closes #885. The deeper fix behind the #859 flake (PR #884 made the rotation assertions robust to phantom rows; this removes the phantom-row leak at its source).

## Root cause
Background tasks — idle distillation/curation (via `runBackground`) and the direct **urgent** distillation — call `saveSessionTracking()`, whose `INSERT OR IGNORE` writes a header-NULL row. The core `db()` connection is a **process-global singleton** shared across test harnesses. `resetPipelineState()` did not drain in-flight background work before the next harness swapped `LORE_DB_PATH`, so a late write could land in the *next* harness's DB as a phantom row — inflating unscoped `session_state` counts (the ~1/3639 flake).

## Fix
- **background-limiter.ts**: track *started* tasks in a set; add `drainBackground()` — clears the queue (discards not-yet-started tasks, which never write) and awaits the active ones, bounded by a `timeoutMs` so it can never hang a reset. Only started tasks are tracked, so `clearQueue()` can't strand the drain on a promise that never settles.
- **pipeline.ts**: track the direct urgent distillation in an `inFlightBackground` set; in `resetPipelineState` (**non-fast only**), stop the idle scheduler first (no new ticks), then `await drainBackground()` + the urgent set — while `llmClient` + the upstream interceptor are still live, so drained tasks complete cleanly. The **fast** process-exit path skips the drain to keep Ctrl+C snappy.

## Notes
- Production is unaffected — single, stable DB, so there's nothing to leak into; this is purely test-isolation hardening (a config-reload could pay up to the bounded drain timeout if batch work is mid-flight, but `batchQueueEnabled` is off in tests so distillations are direct and drain fast).
- 4 new `drainBackground` unit tests (awaits in-flight, discards queued without hanging, no-op when idle, honors timeout). typecheck ✔ lint ✔ full suite **3646 passed**.