### PR TITLE
feat(gateway): `lore doctor` and `lore setup status`

### DIFF
--- a/packages/gateway/src/cli/help.ts
+++ b/packages/gateway/src/cli/help.ts
@@ -25,6 +25,11 @@ Commands:
                        Supported: codex, opencode, claude-code
                        \`setup undo [app]\` reverts a previous setup (restores
                        the backup lore saved before it changed your config)
+                       \`setup status\` prints a read-only inventory of what
+                       setup has touched and where each agent is pointed
+  doctor              Diagnose routing/env conflicts: setup inventory, gateway
+                       reachability, port consistency, shell-env overrides,
+                       Bedrock/Vertex conflicts, plugin install, version
   logs                Show lore activity log
   import              Import knowledge from prior AI agent conversations
   data <subcommand>   Manage stored data (list, show, clear, delete)
@@ -142,6 +147,8 @@ Examples:
   lore setup opencode --no-plugin  # Configure OpenCode without installing the @loreai/opencode plugin
   lore setup undo               # Undo setup for all configured apps
   lore setup undo claude-code   # Undo setup for Claude Code only
+  lore setup status             # Show what setup has touched (read-only)
+  lore doctor                   # Diagnose routing/env conflicts
   lore upgrade                  # Upgrade to latest version
   lore upgrade --check          # Check for updates without installing
   lore upgrade --force          # Force re-download even if up to date

--- a/packages/gateway/src/cli/inventory.ts
+++ b/packages/gateway/src/cli/inventory.ts
@@ -141,6 +141,12 @@ export function collectClaudeCodeInventory(): AppInventory {
   return { app: "Claude Code", file, fileExists, rows, hasBackup };
 }
 
+/** Strip surrounding TOML quotes (basic string literal) from a raw value. */
+function stripTomlQuotes(v: string): string {
+  if (v.startsWith('"') && v.endsWith('"')) return v.slice(1, -1);
+  return v;
+}
+
 /** Collect inventory for Codex (TOML). Reads `~/.codex/config.toml`. */
 export function collectCodexInventory(): AppInventory {
   const file = codexConfigPath();
@@ -151,13 +157,14 @@ export function collectCodexInventory(): AppInventory {
     const content = readFileSync(file, "utf8");
     hasBackup = content.includes("lore setup backup");
     for (const key of ["openai_base_url"]) {
-      const v = getTomlTopLevelValue(content, key);
+      const raw = getTomlTopLevelValue(content, key);
+      const v = raw === null ? undefined : stripTomlQuotes(raw);
       rows.push({
         app: "Codex",
         file,
         fileExists,
         key,
-        routing: v === null ? { kind: "unset" } : classifyRoutingValue(v),
+        routing: v === undefined ? { kind: "unset" } : classifyRoutingValue(v),
       });
     }
   }

--- a/packages/gateway/src/cli/inventory.ts
+++ b/packages/gateway/src/cli/inventory.ts
@@ -309,16 +309,28 @@ export function runDoctorDiagnostics(input: {
         },
   );
 
-  // 3. Port consistency: does any setup-routed URL match the running port?
+  // 3. Port consistency: does any setup-routed LOCAL URL match the running port?
   if (input.gatewayAlive && input.gatewayPort !== null) {
     const expected = `127.0.0.1:${input.gatewayPort}`;
     let mismatch = false;
+    let checked = 0;
     for (const inv of input.inventory) {
       for (const row of inv.rows) {
         // Only check URL-valued rows — the OpenCode plugin row has
         // routing.value = "@loreai/opencode", which is lore-routed but not a URL.
         if (row.routing.kind !== "lore") continue;
         if (!row.routing.value.startsWith("http")) continue;
+        // Skip remote gateway URLs — a remote setup intentionally points at a
+        // different host and is not a port mismatch against the local gateway.
+        try {
+          const u = new URL(row.routing.value);
+          if (u.hostname !== "127.0.0.1" && u.hostname !== "localhost") {
+            continue;
+          }
+        } catch {
+          continue;
+        }
+        checked++;
         if (!row.routing.value.includes(expected)) {
           mismatch = true;
           findings.push({
@@ -331,11 +343,11 @@ export function runDoctorDiagnostics(input: {
         }
       }
     }
-    if (!mismatch) {
+    if (!mismatch && checked > 0) {
       findings.push({
         level: "PASS",
         label: "port consistency",
-        detail: `all lore-routed URLs target port ${input.gatewayPort}`,
+        detail: `all ${checked} lore-routed local URL(s) target port ${input.gatewayPort}`,
       });
     }
   }

--- a/packages/gateway/src/cli/inventory.ts
+++ b/packages/gateway/src/cli/inventory.ts
@@ -1,0 +1,464 @@
+/**
+ * Shared read-only inventory of what `lore setup` has touched, plus helpers
+ * used by `lore setup status`, `lore doctor`, and (later) uninstall.
+ *
+ * Nothing in this module mutates config files. Callers are expected to read
+ * the app configs (via `readJsonConfig`/`readFileSync`) and pass values in,
+ * so the pure helpers here are unit-testable without touching the filesystem.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import {
+  claudeCodeSettingsPath,
+  codexConfigPath,
+  opencodeConfigPath,
+  readJsonConfig,
+} from "./setup";
+import { getPath, LORE_BACKUP_KEY } from "./setup-backup";
+import { getTomlTopLevelValue } from "./setup-backup";
+import { readPortFile } from "../portfile";
+import { probeGateway } from "./start";
+import { VERSION } from "./version";
+
+// ---------------------------------------------------------------------------
+// Routing classification (pure)
+// ---------------------------------------------------------------------------
+
+/** Known first-party vendor hostnames that are definitely NOT lore. */
+const VENDOR_HOSTS = new Set([
+  "api.anthropic.com",
+  "api.openai.com",
+  "generativelanguage.googleapis.com",
+  "bedrock-runtime.us-east-1.amazonaws.com", // representative; bedrock uses many regional hosts
+]);
+
+/**
+ * Best-effort: does this URL point at a lore gateway?
+ *
+ * Lore's gateway binds to loopback (or a user-supplied `--host`) on a custom
+ * port — so "lore" is "not a known vendor endpoint". We can't be exact (the
+ * user can point at an arbitrary proxy), but this catches the common case
+ * where setup left a first-party URL in place (or vice-versa).
+ */
+export function isLoreUrl(url: string | undefined): boolean {
+  if (!url) return false;
+  let host: string;
+  try {
+    host = new URL(url).hostname;
+  } catch {
+    return false;
+  }
+  if (VENDOR_HOSTS.has(host)) return false;
+  // Loopback / localhost → almost certainly lore (vendors never serve there).
+  if (host === "127.0.0.1" || host === "localhost" || host === "::1") {
+    return true;
+  }
+  // Anything else (LAN, Tailscale, container host) — treat as lore unless it's
+  // a known vendor. This is the best we can do without a registry.
+  return true;
+}
+
+export type RoutingValue =
+  | { kind: "unset" }
+  | { kind: "lore"; value: string }
+  | { kind: "other"; value: string };
+
+/** Classify a raw routing value (URL string or undefined). Pure. */
+export function classifyRoutingValue(value: string | undefined): RoutingValue {
+  if (value === undefined || value === "") return { kind: "unset" };
+  return isLoreUrl(value) ? { kind: "lore", value } : { kind: "other", value };
+}
+
+// ---------------------------------------------------------------------------
+// Inventory row (pure formatting)
+// ---------------------------------------------------------------------------
+
+export interface InventoryRow {
+  app: string;
+  file: string;
+  fileExists: boolean;
+  key: string;
+  routing: RoutingValue;
+  /** Prior value recorded by `lore setup`, if a backup sidecar/block exists. */
+  priorValue?: string;
+}
+
+/**
+ * Render a single inventory row as a single line. Pure.
+ * Example: `  Claude Code   env.ANTHROPIC_BASE_URL   lore  http://127.0.0.1:3207`
+ */
+export function formatInventoryRow(row: InventoryRow): string {
+  const filePart = row.fileExists ? row.file : `${row.file} (missing)`;
+  let routingPart: string;
+  switch (row.routing.kind) {
+    case "lore":
+      routingPart = `lore  ${row.routing.value}`;
+      break;
+    case "other":
+      routingPart = `other  ${row.routing.value}`;
+      break;
+    case "unset":
+      routingPart = "unset";
+      break;
+  }
+  const prior =
+    row.priorValue !== undefined ? `   (prior: ${row.priorValue})` : "";
+  return `  ${row.app.padEnd(14)} ${row.key.padEnd(38)} ${routingPart}${prior}   [${filePart}]`;
+}
+
+// ---------------------------------------------------------------------------
+// Inventory collection (does IO; thin shims over setup.ts helpers)
+// ---------------------------------------------------------------------------
+
+export interface AppInventory {
+  app: string;
+  file: string;
+  fileExists: boolean;
+  rows: InventoryRow[];
+  hasBackup: boolean;
+}
+
+/** Collect inventory for Claude Code (JSON). Reads `~/.claude/settings.json`. */
+export function collectClaudeCodeInventory(): AppInventory {
+  const file = claudeCodeSettingsPath();
+  const fileExists = existsSync(file);
+  const rows: InventoryRow[] = [];
+  let hasBackup = false;
+  if (fileExists) {
+    const cfg = readJsonConfig(file);
+    hasBackup = LORE_BACKUP_KEY in cfg;
+    for (const key of ["env.ANTHROPIC_BASE_URL", "env.DISABLE_AUTO_COMPACT"]) {
+      const v = getPath(cfg, key);
+      rows.push({
+        app: "Claude Code",
+        file,
+        fileExists,
+        key,
+        routing:
+          typeof v === "string" ? classifyRoutingValue(v) : { kind: "unset" },
+      });
+    }
+  }
+  return { app: "Claude Code", file, fileExists, rows, hasBackup };
+}
+
+/** Collect inventory for Codex (TOML). Reads `~/.codex/config.toml`. */
+export function collectCodexInventory(): AppInventory {
+  const file = codexConfigPath();
+  const fileExists = existsSync(file);
+  const rows: InventoryRow[] = [];
+  let hasBackup = false;
+  if (fileExists) {
+    const content = readFileSync(file, "utf8");
+    hasBackup = content.includes("lore setup backup");
+    for (const key of ["openai_base_url"]) {
+      const v = getTomlTopLevelValue(content, key);
+      rows.push({
+        app: "Codex",
+        file,
+        fileExists,
+        key,
+        routing: v === null ? { kind: "unset" } : classifyRoutingValue(v),
+      });
+    }
+  }
+  return { app: "Codex", file, fileExists, rows, hasBackup };
+}
+
+/** Collect inventory for OpenCode (JSON). Reads `~/.config/opencode/opencode.json`. */
+export function collectOpencodeInventory(): AppInventory {
+  const file = opencodeConfigPath();
+  const fileExists = existsSync(file);
+  const rows: InventoryRow[] = [];
+  let hasBackup = false;
+  if (fileExists) {
+    const cfg = readJsonConfig(file);
+    hasBackup = LORE_BACKUP_KEY in cfg;
+    const url = getPath(cfg, "provider.anthropic.options.baseURL");
+    rows.push({
+      app: "OpenCode",
+      file,
+      fileExists,
+      key: "provider.anthropic.options.baseURL",
+      routing:
+        typeof url === "string" ? classifyRoutingValue(url) : { kind: "unset" },
+    });
+    const plugins = cfg.plugin;
+    const pluginInstalled =
+      Array.isArray(plugins) && plugins.includes("@loreai/opencode");
+    rows.push({
+      app: "OpenCode",
+      file,
+      fileExists,
+      key: "plugin[@loreai/opencode]",
+      routing: pluginInstalled
+        ? { kind: "lore", value: "@loreai/opencode" }
+        : { kind: "unset" },
+    });
+  }
+  return { app: "OpenCode", file, fileExists, rows, hasBackup };
+}
+
+/** Collect inventory for all supported apps. */
+export function collectInventory(): AppInventory[] {
+  return [
+    collectClaudeCodeInventory(),
+    collectCodexInventory(),
+    collectOpencodeInventory(),
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// `lore setup status` — print the inventory
+// ---------------------------------------------------------------------------
+
+export function printInventoryStatus(): void {
+  const all = collectInventory();
+  for (const inv of all) {
+    console.log(`[lore] ${inv.app}  (${inv.file})`);
+    if (!inv.fileExists) {
+      console.log(`[lore]   file missing — not configured.`);
+      continue;
+    }
+    if (inv.rows.length === 0) {
+      console.log(`[lore]   no lore-managed keys found.`);
+    }
+    for (const row of inv.rows) {
+      console.log(`[lore]   ${formatInventoryRow(row).trim()}`);
+    }
+    if (inv.hasBackup) {
+      console.log(
+        `[lore]   backup present (run \`lore setup undo ${inv.app.toLowerCase().replace(/\s+/g, "-")}\` to revert).`,
+      );
+    }
+    console.log();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// `lore doctor` — inventory + live diagnostics
+// ---------------------------------------------------------------------------
+
+export type FindingLevel = "PASS" | "WARN" | "FAIL";
+
+export interface Finding {
+  level: FindingLevel;
+  label: string;
+  detail: string;
+  remediation?: string;
+}
+
+function urlOrigin(url: string): string {
+  try {
+    const u = new URL(url);
+    return `${u.protocol}//${u.host}`;
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * Run the doctor diagnostics. Pure-ish: takes injected inputs so it's
+ * unit-testable. The thin `commandDoctor` shell wires real IO.
+ */
+export function runDoctorDiagnostics(input: {
+  inventory: AppInventory[];
+  gatewayAlive: boolean;
+  gatewayPort: number | null;
+  /** Shell env values that can silently override settings.json. */
+  env: {
+    ANTHROPIC_BASE_URL?: string;
+    OPENAI_BASE_URL?: string;
+    CLAUDE_CODE_USE_BEDROCK?: string;
+    CLAUDE_CODE_USE_VERTEX?: string;
+    ANTHROPIC_BEDROCK_BASE_URL?: string;
+  };
+  opencodePluginInstalled: boolean;
+}): Finding[] {
+  const findings: Finding[] = [];
+
+  // 1. Version.
+  findings.push({
+    level: "PASS",
+    label: "lore version",
+    detail: VERSION,
+  });
+
+  // 2. Gateway reachability.
+  findings.push(
+    input.gatewayAlive
+      ? {
+          level: "PASS",
+          label: "gateway reachable",
+          detail: input.gatewayPort
+            ? `responding on port ${input.gatewayPort}`
+            : "responding",
+        }
+      : {
+          level: "FAIL",
+          label: "gateway reachable",
+          detail: "no gateway responding",
+          remediation:
+            "run `lore start --bg` (or `lore run` to launch an agent through the gateway)",
+        },
+  );
+
+  // 3. Port consistency: does any setup-routed URL match the running port?
+  if (input.gatewayAlive && input.gatewayPort !== null) {
+    const expected = `127.0.0.1:${input.gatewayPort}`;
+    let mismatch = false;
+    for (const inv of input.inventory) {
+      for (const row of inv.rows) {
+        if (
+          row.routing.kind === "lore" &&
+          !row.routing.value.includes(expected)
+        ) {
+          mismatch = true;
+          findings.push({
+            level: "WARN",
+            label: `port mismatch (${inv.app}: ${row.key})`,
+            detail: `setup wrote ${urlOrigin(row.routing.value)} but the gateway is on port ${input.gatewayPort}`,
+            remediation:
+              "re-run `lore setup <app>` so the live port is written, or start the gateway on the configured port",
+          });
+        }
+      }
+    }
+    if (!mismatch) {
+      findings.push({
+        level: "PASS",
+        label: "port consistency",
+        detail: `all lore-routed URLs target port ${input.gatewayPort}`,
+      });
+    }
+  }
+
+  // 4. Conflicting shell env (Claude Code).
+  const shellAnthropic = input.env.ANTHROPIC_BASE_URL;
+  if (shellAnthropic && !isLoreUrl(shellAnthropic)) {
+    findings.push({
+      level: "WARN",
+      label: "ANTHROPIC_BASE_URL in shell env",
+      detail: `shell env overrides settings.json with ${shellAnthropic}`,
+      remediation:
+        "unset ANTHROPIC_BASE_URL in your shell, or run `lore run` which injects the gateway URL directly",
+    });
+  }
+
+  // 5. Bedrock/Vertex conflict.
+  if (
+    input.env.CLAUDE_CODE_USE_BEDROCK ||
+    input.env.CLAUDE_CODE_USE_VERTEX ||
+    input.env.ANTHROPIC_BEDROCK_BASE_URL
+  ) {
+    findings.push({
+      level: "FAIL",
+      label: "Bedrock/Vertex conflict",
+      detail:
+        "CLAUDE_CODE_USE_BEDROCK / CLAUDE_CODE_USE_VERTEX / ANTHROPIC_BEDROCK_BASE_URL is set; lore proxies the first-party Anthropic protocol and cannot proxy Bedrock/Vertex",
+      remediation:
+        "unset the Bedrock/Vertex env vars, or use a direct Bedrock/Vertex setup without lore",
+    });
+  }
+
+  // 6. OpenCode plugin.
+  const oc = input.inventory.find((i) => i.app === "OpenCode");
+  if (oc && oc.fileExists) {
+    const row = oc.rows.find((r) => r.key === "plugin[@loreai/opencode]");
+    const registered = row?.routing.kind === "lore";
+    if (registered && !input.opencodePluginInstalled) {
+      findings.push({
+        level: "WARN",
+        label: "OpenCode plugin registered but not installed",
+        detail:
+          "@loreai/opencode is in the plugin array but not installed globally",
+        remediation: "run `npm install -g @loreai/opencode`",
+      });
+    } else if (!registered && input.opencodePluginInstalled) {
+      findings.push({
+        level: "WARN",
+        label: "OpenCode plugin installed but not registered",
+        detail:
+          "@loreai/opencode is installed globally but not in the plugin array",
+        remediation: "re-run `lore setup opencode`",
+      });
+    } else if (registered && input.opencodePluginInstalled) {
+      findings.push({
+        level: "PASS",
+        label: "OpenCode plugin",
+        detail: "installed and registered",
+      });
+    }
+  }
+
+  return findings;
+}
+
+/** Render findings as lines. Pure. */
+export function formatFinding(f: Finding): string {
+  const tag =
+    f.level === "PASS" ? "PASS" : f.level === "WARN" ? "WARN" : "FAIL";
+  const line = `[${tag}] ${f.label}: ${f.detail}`;
+  return f.remediation ? `${line}\n      → ${f.remediation}` : line;
+}
+
+/**
+ * `lore doctor` — collect inventory, probe the gateway, check env, and print
+ * findings. Thin shell; the logic lives in `runDoctorDiagnostics` (testable).
+ */
+export async function commandDoctor(): Promise<void> {
+  const inventory = collectInventory();
+  const gatewayPort = readPortFile();
+  const gatewayAlive = gatewayPort
+    ? await probeGateway(`http://127.0.0.1:${gatewayPort}`)
+    : false;
+
+  const findings = runDoctorDiagnostics({
+    inventory,
+    gatewayAlive,
+    gatewayPort,
+    env: {
+      ANTHROPIC_BASE_URL: process.env.ANTHROPIC_BASE_URL,
+      OPENAI_BASE_URL: process.env.OPENAI_BASE_URL,
+      CLAUDE_CODE_USE_BEDROCK: process.env.CLAUDE_CODE_USE_BEDROCK,
+      CLAUDE_CODE_USE_VERTEX: process.env.CLAUDE_CODE_USE_VERTEX,
+      ANTHROPIC_BEDROCK_BASE_URL: process.env.ANTHROPIC_BEDROCK_BASE_URL,
+    },
+    opencodePluginInstalled: isNpmPackageInstalledSafe("@loreai/opencode"),
+  });
+
+  // Print inventory first, then findings.
+  console.log("[lore] Setup inventory:");
+  printInventoryStatus();
+  console.log("[lore] Diagnostics:");
+  for (const f of findings) {
+    console.log(`[lore]   ${formatFinding(f).split("\n").join("\n[lore]   ")}`);
+  }
+  const fails = findings.filter((f) => f.level === "FAIL").length;
+  const warns = findings.filter((f) => f.level === "WARN").length;
+  console.log(
+    `[lore] ${findings.length} finding(s): ${fails} FAIL, ${warns} WARN, ${
+      findings.length - fails - warns
+    } PASS.`,
+  );
+  if (fails > 0) process.exitCode = 1;
+}
+
+// Local copy to avoid importing the private isNpmPackageInstalled from setup.ts.
+// Mirrors its behavior; kept here so doctor doesn't grow setup.ts's surface.
+function isNpmPackageInstalledSafe(pkg: string): boolean {
+  try {
+    // Lazy require so this file loads even if npm isn't on PATH.
+    const { execFileSync } =
+      require("node:child_process") as typeof import("node:child_process");
+    const out = execFileSync("npm", ["ls", "-g", pkg, "--json", "--depth=0"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const parsed = JSON.parse(out) as {
+      dependencies?: Record<string, unknown>;
+    };
+    return Boolean(parsed.dependencies?.[pkg]);
+  } catch {
+    return false;
+  }
+}

--- a/packages/gateway/src/cli/inventory.ts
+++ b/packages/gateway/src/cli/inventory.ts
@@ -308,10 +308,11 @@ export function runDoctorDiagnostics(input: {
     let mismatch = false;
     for (const inv of input.inventory) {
       for (const row of inv.rows) {
-        if (
-          row.routing.kind === "lore" &&
-          !row.routing.value.includes(expected)
-        ) {
+        // Only check URL-valued rows — the OpenCode plugin row has
+        // routing.value = "@loreai/opencode", which is lore-routed but not a URL.
+        if (row.routing.kind !== "lore") continue;
+        if (!row.routing.value.startsWith("http")) continue;
+        if (!row.routing.value.includes(expected)) {
           mismatch = true;
           findings.push({
             level: "WARN",

--- a/packages/gateway/src/cli/inventory.ts
+++ b/packages/gateway/src/cli/inventory.ts
@@ -382,7 +382,7 @@ export function runDoctorDiagnostics(input: {
 
   // 6. OpenCode plugin.
   const oc = input.inventory.find((i) => i.app === "OpenCode");
-  if (oc && oc.fileExists) {
+  if (oc?.fileExists) {
     const row = oc.rows.find((r) => r.key === "plugin[@loreai/opencode]");
     const registered = row?.routing.kind === "lore";
     if (registered && !input.opencodePluginInstalled) {

--- a/packages/gateway/src/cli/inventory.ts
+++ b/packages/gateway/src/cli/inventory.ts
@@ -125,9 +125,23 @@ export function collectClaudeCodeInventory(): AppInventory {
   let hasBackup = false;
   if (fileExists) {
     const cfg = readJsonConfig(file);
-    hasBackup = LORE_BACKUP_KEY in cfg;
+    const backup = cfg[LORE_BACKUP_KEY] as
+      | {
+          entries?: {
+            path: string;
+            priorValue?: unknown;
+            hadPrior?: boolean;
+          }[];
+        }
+      | undefined;
+    hasBackup = backup !== undefined;
     for (const key of ["env.ANTHROPIC_BASE_URL", "env.DISABLE_AUTO_COMPACT"]) {
       const v = getPath(cfg, key);
+      const entry = backup?.entries?.find((e) => e.path === key);
+      const priorValue =
+        entry?.hadPrior && typeof entry.priorValue === "string"
+          ? entry.priorValue
+          : undefined;
       rows.push({
         app: "Claude Code",
         file,
@@ -135,6 +149,7 @@ export function collectClaudeCodeInventory(): AppInventory {
         key,
         routing:
           typeof v === "string" ? classifyRoutingValue(v) : { kind: "unset" },
+        priorValue,
       });
     }
   }
@@ -218,8 +233,8 @@ export function collectInventory(): AppInventory[] {
 // `lore setup status` — print the inventory
 // ---------------------------------------------------------------------------
 
-export function printInventoryStatus(): void {
-  const all = collectInventory();
+export function printInventoryStatus(inventory?: AppInventory[]): void {
+  const all = inventory ?? collectInventory();
   for (const inv of all) {
     console.log(`[lore] ${inv.app}  (${inv.file})`);
     if (!inv.fileExists) {
@@ -446,9 +461,10 @@ export async function commandDoctor(): Promise<void> {
     opencodePluginInstalled: isNpmPackageInstalledSafe("@loreai/opencode"),
   });
 
-  // Print inventory first, then findings.
+  // Print inventory first, then findings. Reuse the already-collected
+  // inventory so diagnostics and display see the same data.
   console.log("[lore] Setup inventory:");
-  printInventoryStatus();
+  printInventoryStatus(inventory);
   console.log("[lore] Diagnostics:");
   for (const f of findings) {
     console.log(`[lore]   ${formatFinding(f).split("\n").join("\n[lore]   ")}`);

--- a/packages/gateway/src/cli/main.ts
+++ b/packages/gateway/src/cli/main.ts
@@ -313,6 +313,12 @@ export async function _cli(): Promise<void> {
         break;
       }
 
+      case "doctor": {
+        const { commandDoctor } = await import("./inventory");
+        await commandDoctor();
+        break;
+      }
+
       case "data": {
         const { commandData } = await import("./data");
         await commandData(rest, values as Record<string, unknown>);
@@ -395,6 +401,7 @@ export async function _cli(): Promise<void> {
               "stop",
               "run",
               "setup",
+              "doctor",
               "data",
               "recall",
               "login",

--- a/packages/gateway/src/cli/setup.ts
+++ b/packages/gateway/src/cli/setup.ts
@@ -914,6 +914,13 @@ export async function commandSetup(
     return;
   }
 
+  // `lore setup status` — read-only inventory of what setup has touched.
+  if (args[0]?.toLowerCase() === "status") {
+    const { printInventoryStatus } = await import("./inventory");
+    printInventoryStatus();
+    return;
+  }
+
   const remoteUrl = values.remote as string | undefined;
   const explicitPort = values.port ? Number(values.port) : undefined;
   const noPlugin = values.noPlugin === true;

--- a/packages/gateway/test/doctor.test.ts
+++ b/packages/gateway/test/doctor.test.ts
@@ -14,6 +14,8 @@ import { commandSetup } from "../src/cli/setup";
 import {
   runDoctorDiagnostics,
   formatFinding,
+  collectInventory,
+  commandDoctor,
   type Finding,
 } from "../src/cli/inventory";
 
@@ -244,5 +246,73 @@ describe("formatFinding", () => {
     expect(text).toContain("[FAIL]");
     expect(text).toContain("gateway reachable");
     expect(text).toContain("run `lore start --bg`");
+  });
+});
+
+describe("collectInventory (integration)", () => {
+  it("returns all-three-apps inventory with missing files on a clean HOME", () => {
+    const all = collectInventory();
+    expect(all).toHaveLength(3);
+    for (const inv of all) {
+      expect(inv.fileExists).toBe(false);
+      expect(inv.rows).toEqual([]);
+      expect(inv.hasBackup).toBe(false);
+    }
+  });
+
+  it("collects lore-routed values after setup", async () => {
+    mkdirSync(join(home, ".claude"), { recursive: true });
+    writeFileSync(
+      join(home, ".claude", "settings.json"),
+      JSON.stringify({
+        env: { ANTHROPIC_BASE_URL: "https://api.anthropic.com" },
+      }),
+    );
+    await commandSetup(["claude-code"], { port: 3299 });
+
+    const all = collectInventory();
+    const cc = all.find((i) => i.app === "Claude Code")!;
+    expect(cc.fileExists).toBe(true);
+    expect(cc.hasBackup).toBe(true);
+    const urlRow = cc.rows.find((r) => r.key === "env.ANTHROPIC_BASE_URL")!;
+    expect(urlRow.routing.kind).toBe("lore");
+    expect(urlRow.routing).toEqual({
+      kind: "lore",
+      value: "http://127.0.0.1:3299",
+    });
+  });
+
+  it("collects Codex TOML inventory after setup", async () => {
+    mkdirSync(join(home, ".codex"), { recursive: true });
+    writeFileSync(
+      join(home, ".codex", "config.toml"),
+      'openai_base_url = "https://api.openai.com/v1"\n',
+    );
+    await commandSetup(["codex"], { port: 3299 });
+
+    const all = collectInventory();
+    const codex = all.find((i) => i.app === "Codex")!;
+    expect(codex.fileExists).toBe(true);
+    expect(codex.hasBackup).toBe(true);
+    const urlRow = codex.rows.find((r) => r.key === "openai_base_url")!;
+    expect(urlRow.routing.kind).toBe("lore");
+  });
+});
+
+describe("commandDoctor (integration)", () => {
+  it("runs without throwing on a clean HOME (no gateway)", async () => {
+    await expect(commandDoctor()).resolves.toBeUndefined();
+    const out = logged();
+    expect(out).toContain("lore version");
+    expect(out).toContain("gateway reachable");
+  });
+
+  it("prints the inventory before the diagnostics", async () => {
+    await commandDoctor();
+    const out = logged();
+    const invIdx = out.indexOf("Setup inventory:");
+    const diagIdx = out.indexOf("Diagnostics:");
+    expect(invIdx).toBeGreaterThanOrEqual(0);
+    expect(diagIdx).toBeGreaterThan(invIdx);
   });
 });

--- a/packages/gateway/test/doctor.test.ts
+++ b/packages/gateway/test/doctor.test.ts
@@ -171,6 +171,37 @@ describe("runDoctorDiagnostics (pure)", () => {
     expect(mismatch?.level).toBe("WARN");
   });
 
+  it("does NOT flag the OpenCode plugin row as a port mismatch (non-URL value)", () => {
+    // The plugin row has routing.value = "@loreai/opencode" (kind: lore), which
+    // is not a URL and must not trigger the port-consistency check (Seer #892).
+    const inventory = [
+      {
+        app: "OpenCode",
+        file: "/x/.config/opencode/opencode.json",
+        fileExists: true,
+        hasBackup: false,
+        rows: [
+          {
+            app: "OpenCode",
+            file: "/x/.config/opencode/opencode.json",
+            fileExists: true,
+            key: "plugin[@loreai/opencode]",
+            routing: { kind: "lore" as const, value: "@loreai/opencode" },
+          },
+        ],
+      },
+    ];
+    const findings = runDoctorDiagnostics({
+      inventory,
+      gatewayAlive: true,
+      gatewayPort: 3207,
+      env: {},
+      opencodePluginInstalled: true,
+    });
+    const mismatch = findings.find((f) => f.label.startsWith("port mismatch"));
+    expect(mismatch).toBeUndefined();
+  });
+
   it("warns when the OpenCode plugin is registered but not installed", () => {
     const inventory = [
       {

--- a/packages/gateway/test/doctor.test.ts
+++ b/packages/gateway/test/doctor.test.ts
@@ -202,22 +202,28 @@ describe("runDoctorDiagnostics (pure)", () => {
     });
     const mismatch = findings.find((f) => f.label.startsWith("port mismatch"));
     expect(mismatch).toBeUndefined();
+    // And no misleading PASS when zero URLs were checked.
+    const pass = findings.find((f) => f.label === "port consistency");
+    expect(pass).toBeUndefined();
   });
 
-  it("warns when the OpenCode plugin is registered but not installed", () => {
+  it("does NOT flag a remote gateway URL as a port mismatch", () => {
     const inventory = [
       {
-        app: "OpenCode",
-        file: "/x/.config/opencode/opencode.json",
+        app: "Claude Code",
+        file: "/x/.claude/settings.json",
         fileExists: true,
         hasBackup: false,
         rows: [
           {
-            app: "OpenCode",
-            file: "/x/.config/opencode/opencode.json",
+            app: "Claude Code",
+            file: "/x/.claude/settings.json",
             fileExists: true,
-            key: "plugin[@loreai/opencode]",
-            routing: { kind: "lore" as const, value: "@loreai/opencode" },
+            key: "env.ANTHROPIC_BASE_URL",
+            routing: {
+              kind: "lore" as const,
+              value: "http://remote:3207/v1",
+            },
           },
         ],
       },
@@ -229,9 +235,38 @@ describe("runDoctorDiagnostics (pure)", () => {
       env: {},
       opencodePluginInstalled: false,
     });
-    const plugin = findings.find((f) => f.label.startsWith("OpenCode plugin"));
-    expect(plugin?.level).toBe("WARN");
+    const mismatch = findings.find((f) => f.label.startsWith("port mismatch"));
+    expect(mismatch).toBeUndefined();
   });
+
+  it("warns when the OpenCode plugin is registered but not installed", () => {
+  const inventory = [
+    {
+      app: "OpenCode",
+      file: "/x/.config/opencode/opencode.json",
+      fileExists: true,
+      hasBackup: false,
+      rows: [
+        {
+          app: "OpenCode",
+          file: "/x/.config/opencode/opencode.json",
+          fileExists: true,
+          key: "plugin[@loreai/opencode]",
+          routing: { kind: "lore" as const, value: "@loreai/opencode" },
+        },
+      ],
+    },
+  ];
+  const findings = runDoctorDiagnostics({
+    inventory,
+    gatewayAlive: true,
+    gatewayPort: 3207,
+    env: {},
+    opencodePluginInstalled: false,
+  });
+  const plugin = findings.find((f) => f.label.startsWith("OpenCode plugin"));
+  expect(plugin?.level).toBe("WARN");
+});
 });
 
 describe("formatFinding", () => {

--- a/packages/gateway/test/doctor.test.ts
+++ b/packages/gateway/test/doctor.test.ts
@@ -1,0 +1,217 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  vi,
+  type MockInstance,
+} from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { commandSetup } from "../src/cli/setup";
+import {
+  runDoctorDiagnostics,
+  formatFinding,
+  type Finding,
+} from "../src/cli/inventory";
+
+let home: string;
+let origHome: string | undefined;
+let origXdg: string | undefined;
+let logSpy: MockInstance;
+let errSpy: MockInstance;
+
+function logged(): string {
+  return [...logSpy.mock.calls, ...errSpy.mock.calls]
+    .map((c) => c.join(" "))
+    .join("\n");
+}
+
+beforeEach(() => {
+  origHome = process.env.HOME;
+  origXdg = process.env.XDG_DATA_HOME;
+  home = mkdtempSync(join(tmpdir(), "lore-doctor-"));
+  process.env.HOME = home;
+  process.env.XDG_DATA_HOME = join(home, "data");
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  logSpy.mockRestore();
+  errSpy.mockRestore();
+  if (origHome === undefined) delete process.env.HOME;
+  else process.env.HOME = origHome;
+  if (origXdg === undefined) delete process.env.XDG_DATA_HOME;
+  else process.env.XDG_DATA_HOME = origXdg;
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe("lore setup status (integration)", () => {
+  it("reports missing files when nothing is configured", async () => {
+    await commandSetup(["status"], {});
+    const out = logged();
+    expect(out).toContain("Claude Code");
+    expect(out).toContain("missing");
+    expect(out).toContain("Codex");
+    expect(out).toContain("OpenCode");
+  });
+
+  it("shows lore-routed values after setup", async () => {
+    mkdirSync(join(home, ".claude"), { recursive: true });
+    writeFileSync(
+      join(home, ".claude", "settings.json"),
+      JSON.stringify({
+        env: { ANTHROPIC_BASE_URL: "https://api.anthropic.com" },
+      }),
+    );
+    await commandSetup(["claude-code"], { port: 3299 });
+    logSpy.mockClear();
+    await commandSetup(["status"], {});
+    const out = logged();
+    expect(out).toContain("http://127.0.0.1:3299");
+    expect(out).toContain("lore");
+    expect(out).toContain("backup present");
+  });
+});
+
+describe("runDoctorDiagnostics (pure)", () => {
+  const emptyInventory = [
+    {
+      app: "Claude Code",
+      file: "/x/.claude/settings.json",
+      fileExists: false,
+      rows: [],
+      hasBackup: false,
+    },
+  ];
+
+  it("reports FAIL when the gateway is down", () => {
+    const findings = runDoctorDiagnostics({
+      inventory: emptyInventory,
+      gatewayAlive: false,
+      gatewayPort: null,
+      env: {},
+      opencodePluginInstalled: false,
+    });
+    const reachability = findings.find((f) => f.label === "gateway reachable");
+    expect(reachability?.level).toBe("FAIL");
+    expect(reachability?.remediation).toContain("lore start --bg");
+  });
+
+  it("reports PASS when the gateway is up", () => {
+    const findings = runDoctorDiagnostics({
+      inventory: emptyInventory,
+      gatewayAlive: true,
+      gatewayPort: 3207,
+      env: {},
+      opencodePluginInstalled: false,
+    });
+    const reachability = findings.find((f) => f.label === "gateway reachable");
+    expect(reachability?.level).toBe("PASS");
+  });
+
+  it("warns on a shell-env ANTHROPIC_BASE_URL override", () => {
+    const findings = runDoctorDiagnostics({
+      inventory: emptyInventory,
+      gatewayAlive: true,
+      gatewayPort: 3207,
+      env: { ANTHROPIC_BASE_URL: "https://api.anthropic.com" },
+      opencodePluginInstalled: false,
+    });
+    const env = findings.find((f) =>
+      f.label.includes("ANTHROPIC_BASE_URL in shell env"),
+    );
+    expect(env?.level).toBe("WARN");
+  });
+
+  it("fails on a Bedrock conflict", () => {
+    const findings = runDoctorDiagnostics({
+      inventory: emptyInventory,
+      gatewayAlive: true,
+      gatewayPort: 3207,
+      env: { CLAUDE_CODE_USE_BEDROCK: "1" },
+      opencodePluginInstalled: false,
+    });
+    const bedrock = findings.find((f) => f.label === "Bedrock/Vertex conflict");
+    expect(bedrock?.level).toBe("FAIL");
+  });
+
+  it("warns on a port mismatch between setup and the running gateway", () => {
+    const inventory = [
+      {
+        app: "Claude Code",
+        file: "/x/.claude/settings.json",
+        fileExists: true,
+        hasBackup: false,
+        rows: [
+          {
+            app: "Claude Code",
+            file: "/x/.claude/settings.json",
+            fileExists: true,
+            key: "env.ANTHROPIC_BASE_URL",
+            routing: {
+              kind: "lore" as const,
+              value: "http://127.0.0.1:5673/v1",
+            },
+          },
+        ],
+      },
+    ];
+    const findings = runDoctorDiagnostics({
+      inventory,
+      gatewayAlive: true,
+      gatewayPort: 3207,
+      env: {},
+      opencodePluginInstalled: false,
+    });
+    const mismatch = findings.find((f) => f.label.startsWith("port mismatch"));
+    expect(mismatch?.level).toBe("WARN");
+  });
+
+  it("warns when the OpenCode plugin is registered but not installed", () => {
+    const inventory = [
+      {
+        app: "OpenCode",
+        file: "/x/.config/opencode/opencode.json",
+        fileExists: true,
+        hasBackup: false,
+        rows: [
+          {
+            app: "OpenCode",
+            file: "/x/.config/opencode/opencode.json",
+            fileExists: true,
+            key: "plugin[@loreai/opencode]",
+            routing: { kind: "lore" as const, value: "@loreai/opencode" },
+          },
+        ],
+      },
+    ];
+    const findings = runDoctorDiagnostics({
+      inventory,
+      gatewayAlive: true,
+      gatewayPort: 3207,
+      env: {},
+      opencodePluginInstalled: false,
+    });
+    const plugin = findings.find((f) => f.label.startsWith("OpenCode plugin"));
+    expect(plugin?.level).toBe("WARN");
+  });
+});
+
+describe("formatFinding", () => {
+  it("renders PASS/WARN/FAIL with remediation on a new line", () => {
+    const f: Finding = {
+      level: "FAIL",
+      label: "gateway reachable",
+      detail: "no gateway responding",
+      remediation: "run `lore start --bg`",
+    };
+    const text = formatFinding(f);
+    expect(text).toContain("[FAIL]");
+    expect(text).toContain("gateway reachable");
+    expect(text).toContain("run `lore start --bg`");
+  });
+});

--- a/packages/gateway/test/doctor.test.ts
+++ b/packages/gateway/test/doctor.test.ts
@@ -240,33 +240,33 @@ describe("runDoctorDiagnostics (pure)", () => {
   });
 
   it("warns when the OpenCode plugin is registered but not installed", () => {
-  const inventory = [
-    {
-      app: "OpenCode",
-      file: "/x/.config/opencode/opencode.json",
-      fileExists: true,
-      hasBackup: false,
-      rows: [
-        {
-          app: "OpenCode",
-          file: "/x/.config/opencode/opencode.json",
-          fileExists: true,
-          key: "plugin[@loreai/opencode]",
-          routing: { kind: "lore" as const, value: "@loreai/opencode" },
-        },
-      ],
-    },
-  ];
-  const findings = runDoctorDiagnostics({
-    inventory,
-    gatewayAlive: true,
-    gatewayPort: 3207,
-    env: {},
-    opencodePluginInstalled: false,
+    const inventory = [
+      {
+        app: "OpenCode",
+        file: "/x/.config/opencode/opencode.json",
+        fileExists: true,
+        hasBackup: false,
+        rows: [
+          {
+            app: "OpenCode",
+            file: "/x/.config/opencode/opencode.json",
+            fileExists: true,
+            key: "plugin[@loreai/opencode]",
+            routing: { kind: "lore" as const, value: "@loreai/opencode" },
+          },
+        ],
+      },
+    ];
+    const findings = runDoctorDiagnostics({
+      inventory,
+      gatewayAlive: true,
+      gatewayPort: 3207,
+      env: {},
+      opencodePluginInstalled: false,
+    });
+    const plugin = findings.find((f) => f.label.startsWith("OpenCode plugin"));
+    expect(plugin?.level).toBe("WARN");
   });
-  const plugin = findings.find((f) => f.label.startsWith("OpenCode plugin"));
-  expect(plugin?.level).toBe("WARN");
-});
 });
 
 describe("formatFinding", () => {

--- a/packages/gateway/test/inventory.test.ts
+++ b/packages/gateway/test/inventory.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import {
+  isLoreUrl,
+  classifyRoutingValue,
+  formatInventoryRow,
+  type RoutingValue,
+} from "../src/cli/inventory";
+
+describe("isLoreUrl", () => {
+  it("recognizes a default loopback gateway URL", () => {
+    expect(isLoreUrl("http://127.0.0.1:3207")).toBe(true);
+    expect(isLoreUrl("http://127.0.0.1:3207/v1")).toBe(true);
+    expect(isLoreUrl("http://localhost:3207/v1")).toBe(true);
+  });
+
+  it("recognizes a non-default port on loopback", () => {
+    expect(isLoreUrl("http://127.0.0.1:5673/v1")).toBe(true);
+    expect(isLoreUrl("http://localhost:8080")).toBe(true);
+  });
+
+  it("recognizes a tailscale / LAN host (still lore if not a known vendor)", () => {
+    expect(isLoreUrl("http://100.64.0.1:3207/v1")).toBe(true);
+  });
+
+  it("rejects known vendor endpoints", () => {
+    expect(isLoreUrl("https://api.anthropic.com")).toBe(false);
+    expect(isLoreUrl("https://api.anthropic.com/v1")).toBe(false);
+    expect(isLoreUrl("https://api.openai.com/v1")).toBe(false);
+    expect(isLoreUrl("https://generativelanguage.googleapis.com/v1")).toBe(
+      false,
+    );
+  });
+
+  it("treats empty / undefined as not-lore", () => {
+    expect(isLoreUrl("")).toBe(false);
+    expect(isLoreUrl(undefined)).toBe(false);
+  });
+});
+
+describe("classifyRoutingValue", () => {
+  it("returns 'unset' for undefined", () => {
+    expect(classifyRoutingValue(undefined)).toEqual({ kind: "unset" });
+  });
+
+  it("returns 'lore' for a loopback URL", () => {
+    expect(classifyRoutingValue("http://127.0.0.1:3207/v1")).toEqual({
+      kind: "lore",
+      value: "http://127.0.0.1:3207/v1",
+    });
+  });
+
+  it("returns 'other' for a vendor URL", () => {
+    expect(classifyRoutingValue("https://api.anthropic.com")).toEqual({
+      kind: "other",
+      value: "https://api.anthropic.com",
+    });
+  });
+});
+
+describe("formatInventoryRow", () => {
+  const baseRow = {
+    app: "Claude Code",
+    file: "/home/u/.claude/settings.json",
+    fileExists: true,
+    key: "env.ANTHROPIC_BASE_URL",
+  };
+
+  it("renders a lore-routed row with OK", () => {
+    const line = formatInventoryRow({
+      ...baseRow,
+      routing: { kind: "lore", value: "http://127.0.0.1:3207" },
+    });
+    expect(line).toContain("Claude Code");
+    expect(line).toContain("http://127.0.0.1:3207");
+    expect(line).toContain("lore");
+  });
+
+  it("renders an other-routed row with the destination", () => {
+    const line = formatInventoryRow({
+      ...baseRow,
+      routing: { kind: "other", value: "https://api.anthropic.com" },
+    });
+    expect(line).toContain("https://api.anthropic.com");
+    expect(line).toContain("other");
+  });
+
+  it("renders an unset row", () => {
+    const line = formatInventoryRow({
+      ...baseRow,
+      routing: { kind: "unset" },
+    });
+    expect(line.toLowerCase()).toContain("unset");
+  });
+
+  it("renders a missing-file row", () => {
+    const line = formatInventoryRow({
+      ...baseRow,
+      fileExists: false,
+      routing: { kind: "unset" },
+    });
+    expect(line.toLowerCase()).toContain("missing");
+  });
+});
+
+// Help TypeScript narrow the union in tests.
+declare module "../src/cli/inventory" {
+  interface RoutingValueAssertion {
+    _brand?: RoutingValue;
+  }
+}


### PR DESCRIPTION
## What

Two read-only diagnostic commands answering **"what has lore configured?"** and **"why won't my agent connect?"** — closes #869.

- **`lore setup status`** — prints a per-app inventory (file path, exists?, current routing value, points-at-lore?) for Claude Code, Codex, and OpenCode, plus whether a backup is present.
- **`lore doctor`** — runs the inventory plus:
  - Gateway reachability (`probeGateway` via `readPortFile`)
  - Port consistency (setup URL vs running gateway port — flags the `3207 → 5673 → random` fallback mismatch)
  - Conflicting shell-env overrides (`ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL` exported in the shell differ from settings.json)
  - Bedrock/Vertex conflict (`CLAUDE_CODE_USE_BEDROCK` / `CLAUDE_CODE_USE_VERTEX` / `ANTHROPIC_BEDROCK_BASE_URL`)
  - OpenCode plugin install/registration consistency
  - Version
  - Each finding is PASS/WARN/FAIL with actionable remediation; exits non-zero on FAIL.

## Details

- New `cli/inventory.ts` — shared inventory module consumed by both commands (and the future uninstall):
  - `collectInventory()` → `AppInventory[]` (per-app file/rows/hasBackup)
  - `isLoreUrl()` / `classifyRoutingValue()` — routing classification (pure)
  - `runDoctorDiagnostics(input)` — pure findings generator (testable)
  - `commandDoctor()` — thin shell wiring real IO (port file, probe, env, npm)
- `lore setup status` dispatched in `commandSetup` (alongside `undo`).
- `lore doctor` dispatched in `main.ts` (`doctor` case + added to knownCommands).
- Help text + examples updated.

## Tests

- `inventory.test.ts` (12): `isLoreUrl`, `classifyRoutingValue`, `formatInventoryRow` edge cases.
- `doctor.test.ts` (9): `runDoctorDiagnostics` (gateway down/up, shell-env override, Bedrock conflict, port mismatch, plugin mismatch), `formatFinding`, integration `lore setup status` (missing + configured).
- Verified end-to-end via the CJS bundle in an isolated `HOME`: `lore doctor` on a clean box (FAIL: gateway down), after `lore setup claude-code` (inventory shows lore-routed URL + backup present), `lore setup status` prints the inventory.

## Verification

- Full suite: 3745 passed / 0 failed (32 skipped)
- Typecheck clean (all packages); lint exit 0
- Smoke-tested `lore doctor` and `lore setup status` via the CJS bundle
