### PR TITLE
fix(core): append-only id-resolution + import scoping follow-ups (#823)

### DIFF
--- a/packages/core/src/agents-file.ts
+++ b/packages/core/src/agents-file.ts
@@ -564,6 +564,19 @@ function _importEntries(entries: ParsedFileEntry[], projectPath: string): void {
 
       // entry.id is the <!-- lore:UUID --> marker, which is the stable logical_id.
       const existing = ltm.getByLogical(entry.id);
+      // Security (A2, #823): a marker that resolves to a DIFFERENT project's
+      // project-scoped entry is foreign — e.g. a .lore.md copied between projects,
+      // or a crafted file carrying another project's UUID. Never overwrite another
+      // project's private knowledge; skip it. (Cross-project / global entries are
+      // intentionally shared, so they stay updatable.)
+      if (
+        existing &&
+        existing.cross_project === 0 &&
+        existing.project_id !== null &&
+        existing.project_id !== ensureProject(projectPath)
+      ) {
+        continue;
+      }
       if (existing) {
         // Known entry — update only if content changed (manual edit in file). Pass
         // the resolved current row id (Seer #848): update() resolves it to the

--- a/packages/core/src/agents-file.ts
+++ b/packages/core/src/agents-file.ts
@@ -555,6 +555,7 @@ export function shouldImport(input: {
  */
 function _importEntries(entries: ParsedFileEntry[], projectPath: string): void {
   const seenIds = new Set<string>();
+  const pid = ensureProject(projectPath); // loop-invariant — resolve once
 
   for (const entry of entries) {
     if (entry.id !== null) {
@@ -573,7 +574,7 @@ function _importEntries(entries: ParsedFileEntry[], projectPath: string): void {
         existing &&
         existing.cross_project === 0 &&
         existing.project_id !== null &&
-        existing.project_id !== ensureProject(projectPath)
+        existing.project_id !== pid
       ) {
         continue;
       }
@@ -590,7 +591,6 @@ function _importEntries(entries: ParsedFileEntry[], projectPath: string): void {
         // Check for a fuzzy title match before creating — prevents duplicates
         // when two machines independently create entries for the same concept
         // with different UUIDs but similar titles.
-        const pid = ensureProject(projectPath);
         const fuzzyMatch = ltm.findFuzzyDuplicate({
           title: entry.title,
           projectId: pid,

--- a/packages/core/src/recall.ts
+++ b/packages/core/src/recall.ts
@@ -1243,7 +1243,9 @@ export function recallById(id: string): string {
   switch (prefix) {
     case "k":
     case "xk": {
-      const entry = ltm.get(rawId);
+      // Resolve a current OR superseded version id / logical_id to the current
+      // entry (A2, #823) — a recalled id may be the stable logical_id.
+      const entry = ltm.get(rawId) ?? ltm.getByLogical(ltm.logicalIdOf(rawId));
       if (!entry) return `No entry found for id: ${id}`;
       return [
         `## Recall Detail: ${id}`,

--- a/packages/core/test/agents-file.test.ts
+++ b/packages/core/test/agents-file.test.ts
@@ -612,6 +612,35 @@ describe("importFromFile — known ID tracking", () => {
     expect(entry?.content).toContain("API keys");
   });
 
+  test("import does not overwrite another project's private entry (foreign marker)", () => {
+    // Project A owns a private entry.
+    const aPath = join(TMP_DIR, "proj-a");
+    const idA = ltm.create({
+      projectPath: aPath,
+      scope: "project",
+      category: "decision",
+      title: "A secret",
+      content: "A-private-content",
+    });
+    // Project B's .lore.md carries A's marker with different content (a file copied
+    // between projects, or a crafted one). Importing it must NOT touch A's entry.
+    const bPath = join(TMP_DIR, "proj-b");
+    const bFile = join(TMP_DIR, "B-AGENTS.md");
+    writeFile(
+      loreSectionWithEntries([
+        {
+          id: idA,
+          category: "decision",
+          title: "A secret",
+          content: "HIJACKED",
+        },
+      ]),
+      bFile,
+    );
+    importFromFile({ projectPath: bPath, filePath: bFile });
+    expect(ltm.getByLogical(idA)?.content).toBe("A-private-content"); // untouched
+  });
+
   test("creates hand-written entries (no marker) with new UUIDs", () => {
     writeFile(
       `${LORE_SECTION_START}\n\n## Long-term Knowledge\n\n### Pattern\n\n* **Middleware pattern**: Using Hono\n\n${LORE_SECTION_END}\n`,

--- a/packages/core/test/recall-entity.test.ts
+++ b/packages/core/test/recall-entity.test.ts
@@ -1,7 +1,38 @@
 import { beforeEach, describe, expect, test } from "vitest";
 import { db, ensureProject } from "../src/db";
 import * as entities from "../src/entities";
+import * as ltm from "../src/ltm";
 import { recallById, runRecall, searchRecall } from "../src/recall";
+
+describe("recallById('k:..') — append-only logical_id resolution (A2, #823)", () => {
+  const PROJECT = "/test/recall/k-a2";
+  beforeEach(() => {
+    const pid = ensureProject(PROJECT);
+    db().query("DELETE FROM knowledge WHERE project_id = ?").run(pid);
+  });
+
+  test("resolves a logical_id whose current version has a different row id", () => {
+    const id = ltm.create({
+      projectPath: PROJECT,
+      scope: "project",
+      category: "decision",
+      title: "RecallA2",
+      content: "v1 detail body",
+    });
+    ltm.update(id, { content: "v2 detail body" }); // appends → id is now superseded
+    // id is the stable logical_id; without the getByLogical fallback this returns
+    // "No entry found" because get(id) misses the superseded v1 row.
+    const detail = recallById(`k:${id}`);
+    expect(detail).not.toContain("No entry found");
+    expect(detail).toContain("v2 detail body"); // current version content
+  });
+
+  test("returns not-found for an unknown knowledge id", () => {
+    expect(recallById("k:019eac47-0000-0000-0000-000000000000")).toContain(
+      "No entry found",
+    );
+  });
+});
 
 const PROJECT = "/test/recall-entity/project";
 


### PR DESCRIPTION
Small, well-scoped follow-ups flagged by the 2b-2b (#853) adversarial reviews — landed separately to keep the flip PR focused.

- **`recall.ts` by-id detail (`k:` / `xk:`)** now resolves through the stable `logical_id` (`get ?? getByLogical(logicalIdOf)`). A recalled `logical_id` whose current version has a different row id (any curator-updated entry) no longer returns "not found". (Review NIT.)
- **`_importEntries` cross-project guard:** a `.lore.md` marker that resolves to a **different** project's project-scoped entry is now treated as foreign and skipped — never overwriting another project's private knowledge. Pre-existing gap (the old `get(id)` had the same unscoped behavior); cross-project / global entries stay shared/updatable. (Security follow-up flagged by both 2b-1 and 2b-2b security reviews.)

**Test:** importing a foreign-marker `.lore.md` leaves the other project's entry untouched (fails without the guard). Core **1730 green**; typecheck + lint clean.

Part of epic #821 · A2 (#823). The local append-only model (sub-PRs 1, 2a, 2b-1, 2b-2a, 2b-2b) is fully merged; next is sub-PR 3 (remote-sync rework — re-key knowledge on `logical_id`).