### PR TITLE
fix(gateway): skip background work when worker model's provider has no credential

### DIFF
--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -337,7 +337,11 @@ export function startIdleScheduler(
       // resolveAuth/getSessionAuth warns once on the mismatch, then stays quiet.
       // Resumes once a turn uses a credentialed provider. #894
       const idleWorkerModel = getWorkerModel(state.lastUpstream);
+      // Exempt the dedicated-worker-key setup (LORE_WORKER_API_KEY): the worker
+      // uses its own credential and bypasses resolveAuth, so a session-auth miss
+      // must NOT disable background work there.
       if (
+        !config.workerApiKey &&
         idleWorkerModel &&
         !resolveAuth(sessionID, idleWorkerModel.providerID)
       ) {

--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -331,10 +331,26 @@ export function startIdleScheduler(
       // Dropping idle work is safe.
       if (shouldShedLowPriority()) continue;
 
+      // Provider-aware auth guard (mirror of scheduleBackgroundWork): skip when
+      // the worker model's provider has no usable credential for this session.
+      // A no-auth worker call just degrades worker-health every idle tick;
+      // resolveAuth/getSessionAuth warns once on the mismatch, then stays quiet.
+      // Resumes once a turn uses a credentialed provider. #894
+      const idleWorkerModel = getWorkerModel(state.lastUpstream);
+      if (
+        idleWorkerModel &&
+        !resolveAuth(sessionID, idleWorkerModel.providerID)
+      ) {
+        continue;
+      }
+
       inProgress.add(sessionID);
       // Scope the circuit-breaker check to the provider this session's worker
       // will call — a 429 from a different provider must not pause this work.
-      const idleProviderID = getWorkerModel(state.lastUpstream)?.providerID;
+      // (idleWorkerModel may be undefined — getWorkerModel returns undefined
+      // when no provider can be resolved; the guard above only skips when it IS
+      // defined but unauthed, so preserve the undefined-safe access here.)
+      const idleProviderID = idleWorkerModel?.providerID;
       runBackground(
         () => doIdleWork(sessionID, state),
         `idle session=${sessionID.slice(0, 16)}`,

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -4447,6 +4447,19 @@ function scheduleBackgroundWork(
   // work. Undefined when the worker model can't be resolved (→ global breaker).
   const workerProviderID = model?.providerID;
 
+  // Provider-aware auth guard: if the resolved worker model's provider has no
+  // usable credential for this session, every background worker call to it just
+  // returns no-auth and degrades worker-health each tick. This mirrors the
+  // worker's own resolution (resolveAuth with the model's provider, incl. the
+  // cross-provider fail-closed). The provider-agnostic guard above misses this:
+  // a session can hold a credential under provider A while lastUpstream points
+  // at provider B (e.g. a turn declared x-lore-provider:anthropic but stored no
+  // anthropic key). Skip instead of flooding — getSessionAuth emits the
+  // store-key/lookup-key mismatch warning once, then we stay quiet, and work
+  // resumes automatically once a turn uses a provider we hold a credential for.
+  // Gates urgent distillation too: a no-auth call can never succeed. #894
+  if (model && !resolveAuth(sessionID, model.providerID)) return;
+
   // When the OAuth account is near quota exhaustion, skip non-urgent
   // background work to preserve remaining entitlement for user-facing turns.
   // Urgent distillation is exempt (it unblocks the next user turn).

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -4458,7 +4458,17 @@ function scheduleBackgroundWork(
   // store-key/lookup-key mismatch warning once, then we stay quiet, and work
   // resumes automatically once a turn uses a provider we hold a credential for.
   // Gates urgent distillation too: a no-auth call can never succeed. #894
-  if (model && !resolveAuth(sessionID, model.providerID)) return;
+  // Exempt the dedicated-worker-key setup (LORE_WORKER_API_KEY): there the
+  // worker uses its own credential and bypasses resolveAuth (getWorkerAuth,
+  // ~1697), so a session-auth miss must NOT disable background work — that
+  // cross-provider config (e.g. MiniMax workers, Anthropic sessions) is exactly
+  // when model.providerID legitimately differs from the session's credential.
+  if (
+    !config.workerApiKey &&
+    model &&
+    !resolveAuth(sessionID, model.providerID)
+  )
+    return;
 
   // When the OAuth account is near quota exhaustion, skip non-urgent
   // background work to preserve remaining entitlement for user-facing turns.

--- a/packages/gateway/test/eviction.test.ts
+++ b/packages/gateway/test/eviction.test.ts
@@ -637,6 +637,59 @@ describe("startIdleScheduler", () => {
     }
   });
 
+  test("does NOT skip on a provider mismatch when a dedicated worker key is set (#894)", async () => {
+    vi.useFakeTimers();
+    try {
+      distillLimiter.clear();
+      curatorLimiter.clear();
+      // Dedicated worker key (LORE_WORKER_API_KEY): the worker uses its own
+      // credential and bypasses resolveAuth, so the provider-mismatch skip must
+      // NOT apply — this cross-provider config (e.g. MiniMax workers while
+      // sessions use Anthropic) is exactly when the mismatch is intentional.
+      const config = makeConfig({ workerApiKey: "dedicated-worker-key" });
+      const sessions = new Map<string, SessionState>();
+
+      // Same mismatch as the skip test: lastUpstream=anthropic, cred=openrouter.
+      sessions.set(
+        "mismatch-but-keyed",
+        makeSessionState({
+          sessionID: "mismatch-but-keyed",
+          lastRequestTime: Date.now() - 10 * 60 * 1000,
+          lastStopReason: "end_turn",
+          lastUpstream: {
+            url: "",
+            protocol: "anthropic",
+            providerID: "anthropic",
+            model: "claude-opus-4-8",
+            headers: {},
+          },
+        }),
+      );
+      setSessionAuth(
+        "mismatch-but-keyed",
+        { scheme: "bearer", value: "or-key" },
+        "openrouter",
+      );
+
+      const ran: string[] = [];
+      const stop = startIdleScheduler(config, sessions, async (sid) => {
+        ran.push(sid);
+      });
+
+      await vi.advanceTimersByTimeAsync(31_000);
+
+      // The dedicated worker key means the worker would authenticate despite the
+      // mismatch — background work must run, not be skipped by the auth guard.
+      expect(ran).toContain("mismatch-but-keyed");
+
+      stop();
+    } finally {
+      vi.useRealTimers();
+      distillLimiter.clear();
+      curatorLimiter.clear();
+    }
+  });
+
   test("runs the global dead-knowledge sweep on the first tick, with no active session", async () => {
     vi.useFakeTimers();
     try {

--- a/packages/gateway/test/eviction.test.ts
+++ b/packages/gateway/test/eviction.test.ts
@@ -562,6 +562,81 @@ describe("startIdleScheduler", () => {
     }
   });
 
+  test("skips background work when the worker model's provider has no credential (#894)", async () => {
+    vi.useFakeTimers();
+    try {
+      distillLimiter.clear();
+      curatorLimiter.clear();
+      const config = makeConfig();
+      const sessions = new Map<string, SessionState>();
+
+      // Session A: lastUpstream points at anthropic, but the only stored
+      // credential is under openrouter → resolveAuth(sid, "anthropic") is null
+      // (cross-provider fail-closed) → background work must be SKIPPED instead
+      // of firing a doomed no-auth worker call every tick.
+      sessions.set(
+        "no-cred-sess",
+        makeSessionState({
+          sessionID: "no-cred-sess",
+          lastRequestTime: Date.now() - 10 * 60 * 1000,
+          lastStopReason: "end_turn",
+          lastUpstream: {
+            url: "",
+            protocol: "anthropic",
+            providerID: "anthropic",
+            model: "claude-opus-4-8",
+            headers: {},
+          },
+        }),
+      );
+      setSessionAuth(
+        "no-cred-sess",
+        { scheme: "bearer", value: "or-key" },
+        "openrouter",
+      );
+
+      // Session B (control): lastUpstream provider matches the stored
+      // credential → resolveAuth succeeds → background work runs. Proves the
+      // skip above is the auth guard, not some unrelated idle-loop condition.
+      sessions.set(
+        "has-cred-sess",
+        makeSessionState({
+          sessionID: "has-cred-sess",
+          lastRequestTime: Date.now() - 10 * 60 * 1000,
+          lastStopReason: "end_turn",
+          lastUpstream: {
+            url: "",
+            protocol: "openai",
+            providerID: "openrouter",
+            model: "z-ai/glm-5.2",
+            headers: {},
+          },
+        }),
+      );
+      setSessionAuth(
+        "has-cred-sess",
+        { scheme: "bearer", value: "or-key" },
+        "openrouter",
+      );
+
+      const ran: string[] = [];
+      const stop = startIdleScheduler(config, sessions, async (sid) => {
+        ran.push(sid);
+      });
+
+      await vi.advanceTimersByTimeAsync(31_000);
+
+      expect(ran).toContain("has-cred-sess"); // control ran
+      expect(ran).not.toContain("no-cred-sess"); // skipped by the auth guard
+
+      stop();
+    } finally {
+      vi.useRealTimers();
+      distillLimiter.clear();
+      curatorLimiter.clear();
+    }
+  });
+
   test("runs the global dead-knowledge sweep on the first tick, with no active session", async () => {
     vi.useFakeTimers();
     try {


### PR DESCRIPTION
Closes #894.

## Problem
After a restart, a session that switched providers across turns floods the logs every ~30s:
```
WARN: no auth credentials available for worker call
[worker-health] lore-distill degraded: N failures in 5min (reasons: no-auth)
```

## Root cause
`scheduleBackgroundWork` (pipeline.ts) and the idle loop (idle.ts) guard auth **provider-agnostically** (`isAuthStale(sid) && !resolveAuth(sid)`). They don't check the *worker model's* provider. When a session holds a credential under provider A (e.g. `openrouter`) but `lastUpstream.providerID` points at provider B (e.g. a `claude-opus` turn declared `x-lore-provider: anthropic` but stored no Anthropic key), the worker resolves `resolveAuth(sid, "anthropic")` → null (the cross-provider fail-closed in auth.ts), gets no-auth, and degrades worker-health every tick.

## Fix
Add a **provider-aware** guard mirroring the worker's own resolution: after resolving the worker model, if `resolveAuth(sessionID, model.providerID)` is null, skip background work for this tick instead of firing a doomed no-auth call. Applied to both `scheduleBackgroundWork` and the idle loop.

- Gates urgent distillation too (a no-auth call can never succeed).
- **Cold-start safe**: `resolveAuth` still returns the global fallback when the session has no provider store yet, so new sessions aren't wrongly skipped — the skip only triggers when the session has *some* provider credential but none for the worker's provider (the actual mismatch).
- `getSessionAuth` emits the store-key/lookup-key mismatch warning once (deduped), then stays quiet; work resumes automatically once a turn uses a credentialed provider.

## Test
Behavioral test driving `startIdleScheduler` with fake timers: a session whose `lastUpstream` provider lacks a credential is **skipped**, while a control session with a matching credential **runs** (proving the skip is the auth guard, not an unrelated idle-loop condition).

typecheck ✔ lint ✔ full suite **3746 passed**.

## Out of scope (separate follow-up)
The free-model worker **504s** are a distinct bug: OpenRouter wraps an upstream 504 as HTTP 200 + `{"error":{"code":504}}`, and lore's status-keyed retry never sees it — miscounting it as an empty/incapable response instead of retrying. Fix: detect body-level provider error envelopes as transient; add 504 to `TRANSIENT_CODES`. Will file/PR separately.