### PR TITLE
feat(cache-economics): PR2b — flip warmer + compaction onto unified strategy

### DIFF
--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -33,6 +33,7 @@ import {
   evaluateCacheStrategy,
   strategyWantsWarming,
   getCacheSizeSnapshot,
+  getCacheStrategy,
 } from "@loreai/core";
 import type {
   InterTurnHistogram,
@@ -1233,12 +1234,13 @@ export function shouldWarm(
     cacheMissCostPerMTok,
   );
 
-  // --- Shared cache-economics: SHADOW evaluation (measure-only, PR2a) ---
-  // Run the single core entry point and LOG the unified strategy next to the
-  // legacy decision. No behavior change: shouldWarm still returns its existing
-  // result below. This lets us watch, on real sessions, whether the shared model
-  // agrees with reality (and cross-check the gradient size estimate against the
-  // real API token count) before PR2b hands it the wheel.
+  // --- Shared cache-economics: PRIMARY evaluation (PR2b flip) ---
+  // The unified strategy is now the PRIMARY warm/no-warm decision (legacy
+  // pReturns/threshold is the fallback for non-confident cases — no snapshot,
+  // non-finite inputs). evaluateCacheStrategy stores the result on the core
+  // session state; the Phase A/B block below reads it via getCacheStrategy.
+  // The LOG is still gated to the warmup margin for volume; the decision reads
+  // the stored strategy regardless of when it was last logged.
   {
     const expectedCycles = expectedWarmupCycles(
       blendedHist,
@@ -1247,7 +1249,7 @@ export function shouldWarm(
       maxCycles,
     );
     const expectedFutureTurns = Math.min(totalTurns, SHADOW_FUTURE_TURNS_CAP);
-    const shadow = evaluateCacheStrategy(
+    const result = evaluateCacheStrategy(
       state.sessionID,
       { pReturn: pReturns, expectedCycles, expectedFutureTurns },
       {
@@ -1255,24 +1257,21 @@ export function shouldWarm(
         writePerToken: cacheMissCostPerMTok / 1_000_000,
       },
     );
-    // Only log near a real warm decision (within the warmup margin of the
-    // current TTL window), not on every tick while the cache is still fresh —
-    // keeps the shadow measurement readable without dropping any decision point.
     const inWarmupMargin = elapsed % ttlMs >= ttlMs - warmupMarginMs;
-    if (shadow?.confident && inWarmupMargin) {
+    if (result?.confident && inWarmupMargin) {
       const snap = getCacheSizeSnapshot(state.sessionID);
       const apiActual =
         (state.cacheAnalytics?.lastCacheRead ?? 0) +
         (state.cacheAnalytics?.lastCacheCreation ?? 0);
       log.info(
-        `cache-economics shadow: session=${state.sessionID.slice(0, 16)} ` +
-          `strategy=${shadow.strategy} wouldWarm=${strategyWantsWarming(shadow.strategy)} ` +
+        `cache-economics: session=${state.sessionID.slice(0, 16)} ` +
+          `strategy=${result.strategy} wouldWarm=${strategyWantsWarming(result.strategy)} ` +
           `gradFull=${snap?.full ?? "?"} gradCompressed=${snap?.compressed ?? "?"} ` +
           `apiActual=${apiActual} pReturn=${pReturns.toFixed(2)} ` +
           `cycles=${expectedCycles.toFixed(1)} futureTurns=${expectedFutureTurns} ` +
-          `costs[hold=${shadow.holdWarmCost.toFixed(4)} ` +
-          `coolBust=${shadow.coolBustCost.toFixed(4)} ` +
-          `coolFull=${shadow.coolFullWriteCost.toFixed(4)}]`,
+          `costs[hold=${result.holdWarmCost.toFixed(4)} ` +
+          `coolBust=${result.coolBustCost.toFixed(4)} ` +
+          `coolFull=${result.coolFullWriteCost.toFixed(4)}]`,
       );
     }
   }
@@ -1292,6 +1291,15 @@ export function shouldWarm(
   // cacheRead/(read+write)). Independent of the return-rate guard above.
   if (warmupWriteEfficiencyTooLow(state.warmup)) return false;
 
+  // Read the unified strategy (stored by the eval block above). When confident,
+  // this is the PRIMARY warm/no-warm decision (PR2b flip): `hold-warm` → warm,
+  // `cool-bust`/`cool-full-write` → don't. Non-confident (no snapshot, non-finite
+  // inputs) falls back to the legacy pReturns/threshold mechanics.
+  const econ = getCacheStrategy(state.sessionID);
+  const econConfident = econ?.result.confident === true;
+  const econWantsWarming =
+    econConfident && strategyWantsWarming(econ!.result.strategy);
+
   // Determine if this is the initial commitment or a continuation
   const cyclesSpent = state.warmup?.warmupCount ?? 0;
   const isFirstWindow = elapsed < ttlMs;
@@ -1303,8 +1311,14 @@ export function shouldWarm(
     // Cache still fresh — no warmup needed yet
     if (elapsed < ttlMs - warmupMarginMs) return false;
 
-    // P(returns) too low to justify even one warmup
-    if (pReturns <= threshold) {
+    // PRIMARY: unified strategy says don't warm (cool-bust or cool-full-write).
+    if (econConfident && !econWantsWarming) {
+      markDeadIfSurvivalLow(state, survivalAtIdle);
+      return false;
+    }
+
+    // FALLBACK (no confident strategy): legacy pReturns/threshold gate.
+    if (!econConfident && pReturns <= threshold) {
       markDeadIfSurvivalLow(state, survivalAtIdle);
       return false;
     }
@@ -1327,20 +1341,24 @@ export function shouldWarm(
       return false;
     }
 
-    // Rising cost threshold: after k cycles, the accumulated warmup cost
-    // means we need a higher P(returns) to justify the next one.
-    // k=1: 8.7%, k=3: 26%, k=5: 43%, k=6: 52% for Opus 5m.
-    // NOTE: intentionally does NOT use MIN_RETURN_PROBABILITY_FLOOR — the
-    // floor only gates the initial commitment (Phase A). Once committed,
-    // the rising threshold handles profitability based on sunk costs.
-    const risingThreshold = cumulativeCostThreshold(
-      cyclesSpent + 1, // +1 because we're deciding whether to do the NEXT cycle
-      cacheReadCostPerMTok,
-      cacheMissCostPerMTok,
-    );
-    if (pReturns <= risingThreshold) {
+    // PRIMARY: unified strategy no longer wants warming (flipped from hold-warm
+    // to cool-bust/full-write mid-break, e.g. after recalibration). Stop.
+    if (econConfident && !econWantsWarming) {
       markDeadIfSurvivalLow(state, survivalAtIdle);
       return false;
+    }
+
+    // FALLBACK: rising cost threshold (only when no confident strategy).
+    if (!econConfident) {
+      const risingThreshold = cumulativeCostThreshold(
+        cyclesSpent + 1, // +1 because we're deciding whether to do the NEXT cycle
+        cacheReadCostPerMTok,
+        cacheMissCostPerMTok,
+      );
+      if (pReturns <= risingThreshold) {
+        markDeadIfSurvivalLow(state, survivalAtIdle);
+        return false;
+      }
     }
 
     // Re-evaluate: expected remaining cycles must keep total under maxCycles

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -50,6 +50,7 @@ import {
   onIdleResume,
   getCacheStrategy,
   strategyWantsWarming,
+  type CacheStrategy,
   consumeCameOutOfIdle,
   needsUrgentDistillation,
   formatKnowledge,
@@ -5254,6 +5255,29 @@ function isCacheWarm(state: SessionState): boolean {
   return Date.now() - warmup.lastWarmupAt < profile.ttlMs;
 }
 
+/**
+ * Decide whether to skip post-idle compaction (PR2b). The unified cache-economics
+ * strategy provides the INTENT (hold-warm → protect the warm prefix by skipping
+ * compaction; cool-bust/cool-full-write → let it compact), but the cache must
+ * ACTUALLY still be live (`cacheIsLive` — the `isCacheWarm` time check) — a stale
+ * hold-warm strategy whose cache has expired must NOT skip compaction (the cache
+ * is cold; compaction is free and reduces ongoing read cost). Non-confident
+ * strategy → `cacheIsLive` alone (the legacy behavior, byte-identical).
+ */
+export function decideSkipCompact(
+  econ: {
+    result: { strategy: CacheStrategy; confident: boolean };
+    decidedAt: number;
+  } | null,
+  cacheIsLive: boolean,
+): boolean {
+  if (!econ || !econ.result.confident) return cacheIsLive;
+  // Confident hold-warm wants to skip, but ONLY if the cache is actually live.
+  if (strategyWantsWarming(econ.result.strategy)) return cacheIsLive;
+  // cool-bust / cool-full-write: don't skip — let it compact.
+  return false;
+}
+
 // ---------------------------------------------------------------------------
 // Case 3: Normal conversation turn — full pipeline
 // ---------------------------------------------------------------------------
@@ -5718,17 +5742,15 @@ async function handleConversationTurn(
       ? 60
       : cfg.idleResumeMinutes;
   const thresholdMs = effectiveIdleMinutes * 60_000;
-  // If the cache warmer recently refreshed this session's prompt cache,
-  // skip post-idle compaction — compacting would produce a different prompt
-  // body that doesn't match the warmed prefix, causing a cache bust.
-  // PR2b: when the unified cache-economics strategy is confident, IT decides
-  // skipCompact (hold-warm → skip; cool-bust/cool-full-write → don't skip).
-  // Falls back to the legacy isCacheWarm signal when no confident strategy.
+  // PR2b: the unified cache-economics strategy decides whether to skip
+  // post-idle compaction. When confident AND the cache is actually still live
+  // (isCacheWarm time check), hold-warm → skip compaction (protect the warm
+  // prefix); cool-bust/cool-full-write → don't skip (let it compact). The
+  // isCacheWarm liveness floor is ALWAYS required — a stale hold-warm strategy
+  // with an expired cache must NOT skip compaction (the cache is cold, compaction
+  // is free and beneficial). Falls back to isCacheWarm when non-confident.
   const econ = getCacheStrategy(sessionID);
-  const econConfident = econ?.result.confident === true;
-  const cacheWarm = econConfident
-    ? strategyWantsWarming(econ!.result.strategy)
-    : isCacheWarm(sessionState);
+  const cacheWarm = decideSkipCompact(econ, isCacheWarm(sessionState));
   const idleResult = onIdleResume(
     sessionID,
     thresholdMs,
@@ -5752,15 +5774,15 @@ async function handleConversationTurn(
     log.info(
       `session idle ${Math.round(idleResult.idleMs / 60_000)}min — refreshing caches` +
         (cacheWarm ? " (cache warm — skipping compact)" : "") +
-        (econConfident
-          ? ` (strategy=${econ!.result.strategy})`
+        (econ?.result.confident
+          ? ` (strategy=${econ.result.strategy})`
           : " (legacy isCacheWarm)"),
     );
     if (econ) {
       log.info(
         `cache-economics (compaction): session=${sessionID.slice(0, 16)} ` +
           `strategy=${econ.result.strategy} skipCompact=${cacheWarm} ` +
-          `confident=${econConfident} strategyAgeMs=${Date.now() - econ.decidedAt}`,
+          `confident=${econ.result.confident === true} strategyAgeMs=${Date.now() - econ.decidedAt}`,
       );
     }
   }

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -5721,7 +5721,14 @@ async function handleConversationTurn(
   // If the cache warmer recently refreshed this session's prompt cache,
   // skip post-idle compaction — compacting would produce a different prompt
   // body that doesn't match the warmed prefix, causing a cache bust.
-  const cacheWarm = isCacheWarm(sessionState);
+  // PR2b: when the unified cache-economics strategy is confident, IT decides
+  // skipCompact (hold-warm → skip; cool-bust/cool-full-write → don't skip).
+  // Falls back to the legacy isCacheWarm signal when no confident strategy.
+  const econ = getCacheStrategy(sessionID);
+  const econConfident = econ?.result.confident === true;
+  const cacheWarm = econConfident
+    ? strategyWantsWarming(econ!.result.strategy)
+    : isCacheWarm(sessionState);
   const idleResult = onIdleResume(
     sessionID,
     thresholdMs,
@@ -5744,19 +5751,16 @@ async function handleConversationTurn(
     // newly-curated preferences are picked up by the NEXT session, not mid-session.
     log.info(
       `session idle ${Math.round(idleResult.idleMs / 60_000)}min — refreshing caches` +
-        (cacheWarm ? " (cache warm — skipping compact)" : ""),
+        (cacheWarm ? " (cache warm — skipping compact)" : "") +
+        (econConfident
+          ? ` (strategy=${econ!.result.strategy})`
+          : " (legacy isCacheWarm)"),
     );
-    // --- Shared cache-economics: SHADOW compaction decision (measure-only) ---
-    // Compare what the unified strategy WOULD do (skip compaction iff hold-warm)
-    // against the legacy isCacheWarm-driven skipCompact. No behavior change —
-    // onIdleResume above still used the legacy `cacheWarm`.
-    const econ = getCacheStrategy(sessionID);
     if (econ) {
-      const wouldSkipCompact = strategyWantsWarming(econ.result.strategy);
       log.info(
-        `cache-economics shadow (compaction): session=${sessionID.slice(0, 16)} ` +
-          `strategy=${econ.result.strategy} wouldSkipCompact=${wouldSkipCompact} ` +
-          `actualSkipCompact=${cacheWarm} strategyAgeMs=${Date.now() - econ.decidedAt}`,
+        `cache-economics (compaction): session=${sessionID.slice(0, 16)} ` +
+          `strategy=${econ.result.strategy} skipCompact=${cacheWarm} ` +
+          `confident=${econConfident} strategyAgeMs=${Date.now() - econ.decidedAt}`,
       );
     }
   }

--- a/packages/gateway/test/cache-warmer.test.ts
+++ b/packages/gateway/test/cache-warmer.test.ts
@@ -54,11 +54,10 @@ import {
 import { getKV, setKV } from "@loreai/core";
 import {
   setCacheSizeSnapshot,
-  evaluateCacheStrategy,
   setCachePricing,
   evictSession,
 } from "@loreai/core";
-
+import { decideSkipCompact } from "../src/pipeline";
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -488,6 +487,51 @@ describe("prepareAnthropicWarmupBody", () => {
     expect(breakpoints).toHaveLength(1);
     expect(result.messages[0].content[0].cache_control).toEqual({
       type: "ephemeral",
+    });
+  });
+
+  describe("decideSkipCompact (pipeline compaction flip, PR2b)", () => {
+    function econ(
+      strategy: "hold-warm" | "cool-bust" | "cool-full-write",
+      confident: boolean,
+    ) {
+      return {
+        result: { strategy, confident },
+        decidedAt: Date.now(),
+      };
+    }
+
+    test("hold-warm + cache live → skip compaction (protect warm prefix)", () => {
+      expect(decideSkipCompact(econ("hold-warm", true), true)).toBe(true);
+    });
+
+    test("hold-warm + cache EXPIRED → do NOT skip (stale strategy, cold cache)", () => {
+      // The MUST-FIX regression: a stale hold-warm whose cache expired must NOT
+      // skip compaction — isCacheWarm liveness floor is always required.
+      expect(decideSkipCompact(econ("hold-warm", true), false)).toBe(false);
+    });
+
+    test("cool-bust → never skip (let it compact), regardless of cache liveness", () => {
+      expect(decideSkipCompact(econ("cool-bust", true), true)).toBe(false);
+      expect(decideSkipCompact(econ("cool-bust", true), false)).toBe(false);
+    });
+
+    test("cool-full-write → never skip, regardless of cache liveness", () => {
+      expect(decideSkipCompact(econ("cool-full-write", true), true)).toBe(
+        false,
+      );
+      expect(decideSkipCompact(econ("cool-full-write", true), false)).toBe(
+        false,
+      );
+    });
+
+    test("non-confident strategy → fall back to isCacheWarm (cacheIsLive) alone", () => {
+      // Byte-identical to the legacy behavior: skipCompact = isCacheWarm.
+      expect(decideSkipCompact(econ("hold-warm", false), true)).toBe(true);
+      expect(decideSkipCompact(econ("hold-warm", false), false)).toBe(false);
+      expect(decideSkipCompact(econ("cool-bust", false), true)).toBe(true);
+      expect(decideSkipCompact(null, true)).toBe(true);
+      expect(decideSkipCompact(null, false)).toBe(false);
     });
   });
 });
@@ -3224,8 +3268,8 @@ describe("shouldWarm unified cache-economics flip (PR2b)", () => {
 
   beforeEach(() => {
     _resetForTest();
-    // Pricing: read=$0.30/MTok, write=$3.75/MTok (Anthropic 5m cache, Opus-ish).
-    setCachePricing(0.3, 3.75);
+    // Pricing: write=$3.75/MTok, read=$0.30/MTok (Anthropic 5m cache, Opus-ish).
+    setCachePricing(3.75, 0.3);
   });
 
   // Build a state with a stored body, in the warmup margin of the first TTL

--- a/packages/gateway/test/cache-warmer.test.ts
+++ b/packages/gateway/test/cache-warmer.test.ts
@@ -52,6 +52,12 @@ import {
   normalizeBodyForComparison,
 } from "../src/cache-analytics";
 import { getKV, setKV } from "@loreai/core";
+import {
+  setCacheSizeSnapshot,
+  evaluateCacheStrategy,
+  setCachePricing,
+  evictSession,
+} from "@loreai/core";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -3206,5 +3212,113 @@ describe("creditWarmupHit", () => {
     const warmup = makeWarmup({ lastWarmupAt: 0 });
     expect(creditWarmupHit(warmup, 30_000, 300_000).hit).toBe(false);
     expect(warmup.warmupHits).toBe(0);
+  });
+});
+
+describe("shouldWarm unified cache-economics flip (PR2b)", () => {
+  const SESSION_PREFIX = "econ-flip-";
+  let counter = 0;
+  function freshSession(): string {
+    return `${SESSION_PREFIX}${Date.now()}-${counter++}`;
+  }
+
+  beforeEach(() => {
+    _resetForTest();
+    // Pricing: read=$0.30/MTok, write=$3.75/MTok (Anthropic 5m cache, Opus-ish).
+    setCachePricing(0.3, 3.75);
+  });
+
+  // Build a state with a stored body, in the warmup margin of the first TTL
+  // window, with enough turns/input to pass the legacy guards.
+  function makeWarmeableState(sessionID: string) {
+    const now = Date.now();
+    return makeSessionState({
+      sessionID,
+      lastRequestTime: now - 270_000, // 4.5 min — inside the 5m warmup margin
+      messageCount: 20, // ≥ MIN_TURNS_FOR_WARMING * 2
+      lastInputTokens: 100_000, // ≥ MIN_INPUT_TOKENS_FOR_WARMING
+      cacheAnalytics: {
+        ...makeCacheAnalytics(),
+        lastRequestBody: compressBody(
+          '{"model":"claude-sonnet-4-20250514","max_tokens":16384,"stream":true,' +
+            '"messages":[{"role":"user","content":"test"}]}',
+        ),
+      },
+    });
+  }
+
+  function goodHist() {
+    const hist = createHistogram();
+    for (let i = 0; i < 50; i++) recordGap(hist, 360_000); // 6m — users return
+    return hist;
+  }
+
+  test("hold-warm strategy overrides a below-threshold pReturns — warms", () => {
+    const sid = freshSession();
+    // Small body, high return → hold-warm is cheaper than cooling.
+    setCacheSizeSnapshot(sid, 10_000, 10_000);
+    const state = makeWarmeableState(sid);
+
+    // Survive the safety guards (not subagent, warming enabled, etc.).
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+    const result = shouldWarm(state, profile, goodHist());
+    expect(result).toBe(true);
+
+    evictSession(sid);
+  });
+
+  test("cool-bust strategy blocks warming even when pReturns is high", () => {
+    const sid = freshSession();
+    // Large body, compaction available → cool-bust (cheap compact-on-return).
+    setCacheSizeSnapshot(sid, 800_000, 100_000);
+    const state = makeWarmeableState(sid);
+
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+    // Even with a good histogram (high pReturns), cool-bust must block warming.
+    expect(shouldWarm(state, profile, goodHist(), Date.now())).toBe(false);
+
+    evictSession(sid);
+  });
+
+  test("cool-full-write strategy blocks warming (low return, large body, no compaction)", () => {
+    const sid = freshSession();
+    // Large body, no compaction (compressed == full). With a LOW-return
+    // histogram, hold-warm's ongoing keepalive cost exceeds the rare cold
+    // rewrite → cool-full-write (don't warm, don't compact).
+    setCacheSizeSnapshot(sid, 800_000, 800_000);
+    const now = Date.now();
+    const state = makeSessionState({
+      sessionID: sid,
+      lastRequestTime: now - 270_000,
+      messageCount: 20,
+      lastInputTokens: 100_000,
+      cacheAnalytics: {
+        ...makeCacheAnalytics(),
+        lastRequestBody: compressBody(
+          '{"model":"claude-sonnet-4-20250514","max_tokens":16384,"stream":true,' +
+            '"messages":[{"role":"user","content":"test"}]}',
+        ),
+      },
+    });
+
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+    // Low-return histogram: users rarely come back → cool-full-write.
+    const hist = createHistogram();
+    for (let i = 0; i < 50; i++) recordGap(hist, 3_600_000); // 60m gaps
+    expect(shouldWarm(state, profile, hist, now)).toBe(false);
+
+    evictSession(sid);
+  });
+
+  test("falls back to legacy pReturns/threshold when no snapshot (non-confident)", () => {
+    const sid = freshSession();
+    // No snapshot → evaluateCacheStrategy returns null → legacy path.
+    const state = makeWarmeableState(sid);
+
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+    // Good histogram → legacy would warm. Confirm the fallback still works.
+    expect(shouldWarm(state, profile, goodHist(), Date.now())).toBe(true);
+
+    evictSession(sid);
   });
 });


### PR DESCRIPTION
The behavior flip. The unified cache-economics model (`evaluateCacheStrategy`) now **drives** both the warmer and the compaction decision; legacy heuristics become the fallback for non-confident cases (no snapshot / non-finite inputs). All safety guards are unchanged.

## What changes

### `shouldWarm` (cache-warmer.ts)
The unified strategy is now the **PRIMARY** warm/no-warm decision:
- **Phase A (initial commitment):** confident `cool-bust`/`cool-full-write` → don't warm (was: `pReturns ≤ threshold`). Non-confident → legacy threshold.
- **Phase B (continuation):** confident strategy flips away from `hold-warm` mid-break → stop (was: rising cumulative threshold). Non-confident → legacy rising threshold.

All safety guards (circuit breaker, subagent, cooldown, ROI, write-efficiency, `maxCycles`, `pFinished>0.95`, margin window) are **unchanged** and still run.

### `onIdleResume` (pipeline.ts)
`skipCompact` now reads `strategyWantsWarming(strategy)` when confident:
- `hold-warm` → skip compaction (keep the warm prefix)
- `cool-bust`/`cool-full-write` → don't skip (let it compact)

Falls back to `isCacheWarm` when non-confident. The shadow compaction log is replaced with a real decision log.

## Why now
Shadow data (post-deploy) confirmed the model produces sane strategies on real sessions:
- `0IJUAT4UePvYD6V4` (859K, pReturn=0.55) → `cool-bust` ($8.05 vs $18.10 hold) — correctly stops warming this 800K session
- `0QsIRMDXDbSDNcOc` (407K, pReturn=0.08) → `cool-full-write` — don't warm, barely returns
- `gradCompressed < gradFull` confirms #883/#887 are working

## Tests
4 new `shouldWarm` tests:
- `hold-warm` overrides a below-threshold `pReturns` → warms
- `cool-bust` blocks warming despite high `pReturns`
- `cool-full-write` blocks warming (low return + large body, no compaction)
- Legacy fallback when no snapshot (non-confident)

## Verification
typecheck (5 pkgs) clean; lint clean (19 warnings, all pre-existing/non-touched); full suite **3742 passed**; `pnpm build` clean.

## Follow-on
PR3: gate deferred LTM/distillation flush on the `cool-bust` event (independent schedule, bust as preferred trigger, urgency override).