### PR TITLE
feat(sync): re-key remote knowledge sync on logical_id (A2 sub-PR 3)

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1488,12 +1488,21 @@ function installSyncCapture(database: Database) {
     "entity_relations",
   ]) {
     for (const [evt, suffix, ref, op] of ops) {
+      // Knowledge is remote-keyed by logical_id (A2 sub-PR 3, #823). INSERT/UPDATE
+      // capture the version id (op=upsert; the push plan resolves it to the current
+      // logical row while the row still exists). DELETE must capture the logical_id
+      // NOW — the row is gone afterward, so the push can't resolve it, and a delete
+      // keyed by a version id would never match the logical_id-keyed remote row.
+      const rowExpr =
+        t === "knowledge" && op === "delete"
+          ? `COALESCE(${ref}.logical_id, ${ref}.id)`
+          : `${ref}.id`;
       sql += `
         CREATE TEMP TRIGGER IF NOT EXISTS ${t}_outbox_${suffix}
         AFTER ${evt} ON ${t} WHEN (${gate})
         BEGIN
           INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
-          VALUES ('${t}', ${ref}.id, '${op}', ${ts});
+          VALUES ('${t}', ${rowExpr}, '${op}', ${ts});
         END;`;
     }
   }

--- a/packages/core/src/sync-data.ts
+++ b/packages/core/src/sync-data.ts
@@ -526,6 +526,41 @@ export function seedOutbox(tier: SyncTier = "basic"): void {
       // (via the prune floor) permanently disabling outbox pruning for ALL tables.
       if (m.pullOnly) continue;
       const pushCursor = Number(getKV(`sync.push.${m.table}`) ?? "0");
+
+      // Knowledge is remote-keyed by logical_id (A2 sub-PR 3, #823): seed ONE entry
+      // per CURRENT live logical entry — NOT every physical version — keyed + hashed
+      // by logical_id to match the push plan + sync_state. Iterating physical rows
+      // and checking sync_state by version id would miss every v2+ entry (sync_state
+      // is keyed by logical_id) and re-enqueue it (outbox bloat). Deleted entries
+      // (no live current) are NOT seeded here — reconcile's tombstone pass emits the
+      // delete (its liveness check is also knowledge_current-based).
+      if (m.table === "knowledge") {
+        const latestForLogical = db().query(
+          `SELECT o.op FROM sync_outbox o JOIN knowledge k ON k.id = o.row_id
+            WHERE o.table_name = 'knowledge' AND o.seq > ?
+              AND COALESCE(k.logical_id, k.id) = ?
+            ORDER BY o.seq DESC LIMIT 1`,
+        );
+        const lids = db()
+          .query(
+            "SELECT DISTINCT COALESCE(logical_id, id) AS lid FROM knowledge_current",
+          )
+          .all() as { lid: string }[];
+        for (const { lid } of lids) {
+          const pending =
+            (latestForLogical.get(pushCursor, lid) as { op: string } | null)
+              ?.op ?? null;
+          if (pending === "upsert") continue; // already queued
+          if (pending === null) {
+            const synced = getSyncState("knowledge", lid)?.content_hash ?? null;
+            const row = currentKnowledgeRow(lid);
+            if (row && contentHash("knowledge", row) === synced) continue;
+          }
+          enqueue.run("knowledge", lid, now);
+        }
+        continue;
+      }
+
       // Resolve the synced columns ONCE per table (one PRAGMA table_info) — not
       // per row, which is what `contentHash` would do (an N+1 on large tables).
       const cols = columns(m.table);
@@ -574,14 +609,21 @@ export function reconcile(tier: SyncTier = "basic"): void {
     // Pull-only tables are never pushed (see seedOutbox) — also skip the
     // delete-tombstone reconciliation so no `profiles` outbox entry is created.
     if (m.pullOnly) continue;
-    const idExpr = rowIdExpr(m);
+    // Knowledge is keyed by logical_id and append-only: "live" means a CURRENT live
+    // version exists (knowledge_current), NOT merely a physical row — a deleted
+    // entry keeps its demoted/death-cert version rows, so an `id = logical_id`
+    // existence check would never tombstone a delete made while sync was OFF (#823).
+    const livenessNotExists =
+      m.table === "knowledge"
+        ? "NOT EXISTS (SELECT 1 FROM knowledge_current t WHERE COALESCE(t.logical_id, t.id) = s.row_id)"
+        : `NOT EXISTS (SELECT 1 FROM ${m.table} t WHERE ${rowIdExpr(m)} = s.row_id)`;
     db()
       .query(
         `INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
          SELECT s.table_name, s.row_id, 'delete', ?
            FROM sync_state s
           WHERE s.table_name = ?
-            AND NOT EXISTS (SELECT 1 FROM ${m.table} t WHERE ${idExpr} = s.row_id)
+            AND ${livenessNotExists}
             AND COALESCE(
               (SELECT o.op FROM sync_outbox o
                 WHERE o.table_name = s.table_name AND o.row_id = s.row_id

--- a/packages/core/src/sync-data.ts
+++ b/packages/core/src/sync-data.ts
@@ -16,6 +16,7 @@
  *    (prevents push<->pull echo).
  */
 import { createHash } from "node:crypto";
+import { uuidv7 } from "uuidv7";
 import {
   db,
   deleteTeamConfig,
@@ -434,6 +435,28 @@ export function hasPendingChange(
   return row != null;
 }
 
+/**
+ * Knowledge-aware pending check (A2, #823): the remote keys knowledge by
+ * `logical_id`, but the outbox holds per-VERSION row ids — so resolve every
+ * unpushed knowledge outbox row to its logical_id. Without this, the pull path
+ * would miss an unpushed local edit to a versioned entry (its outbox id ≠
+ * logical_id) and silently let a remote change win without logging the conflict.
+ */
+export function hasPendingKnowledgeChange(
+  logicalId: string,
+  sinceSeq: number,
+): boolean {
+  const row = db()
+    .query(
+      `SELECT 1 FROM sync_outbox o
+         JOIN knowledge k ON k.id = o.row_id
+        WHERE o.table_name = 'knowledge' AND o.seq > ?
+          AND COALESCE(k.logical_id, k.id) = ? LIMIT 1`,
+    )
+    .get(sinceSeq, logicalId);
+  return row != null;
+}
+
 /** True when the outbox has at least one entry for `table`. */
 export function hasOutboxEntries(table: string): boolean {
   return (
@@ -656,21 +679,13 @@ export function applyRemoteUpsert(
       ? `DO UPDATE SET ${nonPk.map((c) => `${c}=excluded.${c}`).join(", ")}`
       : "DO NOTHING";
   const sql = `INSERT INTO ${table} (${cols.join(", ")}) VALUES (${placeholders}) ON CONFLICT(${conflict}) ${onConflict}`;
+  // NOTE: knowledge is NOT applied here — it routes through applyRemoteKnowledge
+  // (append-only, version-aware). This generic upsert serves the entity graph
+  // (entities / aliases / relations / refs), which are not versioned.
   withApplying(() => {
     db()
       .query(sql)
       .run(...cols.map((c) => row[c] as never));
-    // A2 (#823): the remote knowledge table has no logical_id column yet (sub-PR
-    // 3 adds it), so a pulled row lands with logical_id = NULL. Backfill it to id
-    // (the v1 identity) so the local cross-reference model (refs / getByLogical)
-    // resolves the row. Idempotent: only touches NULLs, never an existing value.
-    if (table === "knowledge" && !("logical_id" in row)) {
-      db()
-        .query(
-          "UPDATE knowledge SET logical_id = id WHERE id = ? AND logical_id IS NULL",
-        )
-        .run(row.id as never);
-    }
   });
 }
 
@@ -685,24 +700,183 @@ export function applyRemoteDelete(table: string, rowId: string): void {
   );
 }
 
+/** Insert one knowledge version row from a synced-column source `src`. */
+function insertKnowledgeVersion(
+  src: Record<string, unknown>,
+  syncCols: string[],
+  ident: { id: string; logicalId: string; version: number; isDeleted: 0 | 1 },
+): void {
+  const vals: Record<string, unknown> = {};
+  for (const c of syncCols) vals[c] = src[c];
+  vals.id = ident.id;
+  vals.logical_id = ident.logicalId;
+  vals.version = ident.version;
+  vals.is_current = 1;
+  vals.is_deleted = ident.isDeleted;
+  const cols = Object.keys(vals);
+  db()
+    .query(
+      `INSERT INTO knowledge (${cols.join(", ")}) VALUES (${cols.map(() => "?").join(", ")})`,
+    )
+    .run(...cols.map((c) => vals[c] as never));
+}
+
 /**
- * Map a knowledge outbox row to its remote sync op under the append-only model
- * (A2, #823). The remote mirrors only the CURRENT LIVE version: a superseded
- * (is_current=0) or soft-deleted (is_deleted=1) version becomes a remote
- * soft-delete — this removes stale/redacted content from the remote and
- * propagates deletions (remove() no longer emits a physical-delete outbox op).
- * A current live version is upserted. Returns "skip" if the row is gone.
- *
- * NOTE: this keeps the remote a correct CURRENT-only mirror keyed by the current
- * version id. Full cross-device id↔logical_id convergence (so refs resolve the
- * same entry on every device) is completed in sub-PR 3.
+ * Apply a pulled knowledge row (keyed by `logical_id` = `row.id`) into the local
+ * APPEND-ONLY model (A2, #823). The remote is a current-only mirror, so a content
+ * change is "the same concern, new value" arriving from another device → append a
+ * new current version (mirrors a local update()); a metadata-only change converges
+ * in place; a brand-new entry inserts v1. Idempotency: re-pulling our own pushed
+ * content matches the current version → no new version. Runs under apply-
+ * suppression (no re-push) and a transaction (single-current invariant: demote
+ * before insert). NOTE: superseded/death-cert version history stays LOCAL — only
+ * current content converges across devices.
  */
-export function knowledgeSyncOp(rowId: string): "upsert" | "delete" | "skip" {
-  const v = db()
-    .query("SELECT is_current, is_deleted FROM knowledge WHERE id = ?")
-    .get(rowId) as { is_current: number; is_deleted: number } | undefined;
-  if (!v) return "skip";
-  return v.is_current === 0 || v.is_deleted === 1 ? "delete" : "upsert";
+export function applyRemoteKnowledge(row: Record<string, unknown>): void {
+  const logicalId = String(row.id);
+  const syncCols = columns("knowledge").filter(
+    (c) => !PAYLOAD_EXCLUDE.has(c) && c in row,
+  );
+  withApplying(() =>
+    withTransaction(() => {
+      const agg = db()
+        .query(
+          "SELECT MAX(version) AS maxV, COUNT(*) AS n FROM knowledge WHERE COALESCE(logical_id, id) = ?",
+        )
+        .get(logicalId) as { maxV: number | null; n: number };
+      const cur = db()
+        .query(
+          "SELECT content FROM knowledge_current WHERE COALESCE(logical_id, id) = ?",
+        )
+        .get(logicalId) as { content: string } | undefined;
+
+      if (agg.n === 0) {
+        // Brand-new entry: v1 carries the remote id AS the logical_id (id == logical_id).
+        insertKnowledgeVersion(row, syncCols, {
+          id: logicalId,
+          logicalId,
+          version: 1,
+          isDeleted: 0,
+        });
+        return;
+      }
+      if (cur && cur.content === row.content) {
+        // Content already converged — update the other (hashed) synced fields on the
+        // current version in place so the local hash matches the remote (no re-push),
+        // without minting a new version. content/identity/version cols are excluded.
+        const skip = new Set([
+          "id",
+          "logical_id",
+          "version",
+          "is_current",
+          "is_deleted",
+          "content",
+        ]);
+        const setCols = syncCols.filter((c) => !skip.has(c));
+        if (setCols.length > 0) {
+          db()
+            .query(
+              `UPDATE knowledge SET ${setCols.map((c) => `${c} = ?`).join(", ")} WHERE COALESCE(logical_id, id) = ? AND is_current = 1`,
+            )
+            .run(...setCols.map((c) => row[c] as never), logicalId);
+        }
+        return;
+      }
+      // Content differs (or no live current → revive) → append a new current version.
+      db()
+        .query(
+          "UPDATE knowledge SET is_current = 0 WHERE COALESCE(logical_id, id) = ? AND is_current = 1",
+        )
+        .run(logicalId);
+      insertKnowledgeVersion(row, syncCols, {
+        id: uuidv7(),
+        logicalId,
+        version: (agg.maxV ?? 0) + 1,
+        isDeleted: 0,
+      });
+    }),
+  );
+}
+
+/**
+ * Apply a pulled knowledge DELETE (remote soft-delete of `logicalId`) into the
+ * local append-only model: append a death-certificate version (preserving the
+ * current content) if a live current exists; otherwise a no-op. Apply-suppressed
+ * + transactional (single-current invariant).
+ */
+export function applyRemoteKnowledgeDelete(logicalId: string): void {
+  withApplying(() =>
+    withTransaction(() => {
+      const cur = db()
+        .query(
+          "SELECT * FROM knowledge_current WHERE COALESCE(logical_id, id) = ?",
+        )
+        .get(logicalId) as Record<string, unknown> | undefined;
+      if (!cur) return; // already no live current — nothing to delete
+      const maxV = (
+        db()
+          .query(
+            "SELECT MAX(version) AS m FROM knowledge WHERE COALESCE(logical_id, id) = ?",
+          )
+          .get(logicalId) as { m: number }
+      ).m;
+      db()
+        .query(
+          "UPDATE knowledge SET is_current = 0 WHERE COALESCE(logical_id, id) = ? AND is_current = 1",
+        )
+        .run(logicalId);
+      const syncCols = columns("knowledge").filter(
+        (c) => !PAYLOAD_EXCLUDE.has(c) && c in cur,
+      );
+      insertKnowledgeVersion(cur, syncCols, {
+        id: uuidv7(),
+        logicalId,
+        version: maxV + 1,
+        isDeleted: 1,
+      });
+    }),
+  );
+}
+
+export type KnowledgePushPlan =
+  | { op: "skip" }
+  | { op: "delete"; logicalId: string }
+  | { op: "upsert"; logicalId: string; row: Record<string, unknown> };
+
+/**
+ * Plan the remote push for a knowledge outbox row under the append-only model
+ * (A2, #823). The remote is a CURRENT-only mirror keyed by `logical_id` — exactly
+ * ONE row per logical entry:
+ *   - live current version → upsert the current content under `id = logical_id`.
+ *     Every version's outbox row for the same entry coalesces to this single
+ *     upsert; the content_hash dedup makes the redundant ones no-ops.
+ *   - no live current (every version superseded or a death-cert) → soft-delete
+ *     `id = logical_id` (propagates deletions + removes stale/redacted content).
+ *   - logical entry physically gone → skip.
+ *
+ * The returned `row` carries the synced columns of the CURRENT version with `id`
+ * overridden to `logical_id` (the remote row key). This coalesces all versions to
+ * one remote row and converges `id`↔`logical_id` across devices.
+ */
+export function knowledgePushPlan(outboxRowId: string): KnowledgePushPlan {
+  // COALESCE(logical_id, id): production always sets logical_id, but be robust to a
+  // legacy/unmigrated NULL (a v1 row IS its own logical entity).
+  const lid = db()
+    .query(
+      "SELECT COALESCE(logical_id, id) AS logical_id FROM knowledge WHERE id = ?",
+    )
+    .get(outboxRowId) as { logical_id: string } | undefined;
+  if (!lid) return { op: "skip" }; // physical row gone (not expected post-flip)
+  const logicalId = lid.logical_id;
+  const cols = columns("knowledge").filter((c) => !PAYLOAD_EXCLUDE.has(c));
+  const row = db()
+    .query(
+      `SELECT ${cols.join(", ")} FROM knowledge_current WHERE COALESCE(logical_id, id) = ?`,
+    )
+    .get(logicalId) as Record<string, unknown> | undefined;
+  if (!row) return { op: "delete", logicalId }; // no live current → soft-delete
+  row.id = logicalId; // re-key the remote row on the stable logical_id
+  return { op: "upsert", logicalId, row };
 }
 
 /** Rebuild an external-content FTS5 index after a batch of pulled changes. */

--- a/packages/core/src/sync-data.ts
+++ b/packages/core/src/sync-data.ts
@@ -858,9 +858,30 @@ export type KnowledgePushPlan =
  * overridden to `logical_id` (the remote row key). This coalesces all versions to
  * one remote row and converges `id`↔`logical_id` across devices.
  */
+/**
+ * The CURRENT live version's synced columns for a logical entry, re-keyed
+ * `id = logical_id` — i.e. the exact remote-row shape that {@link knowledgePushPlan}
+ * pushes (and {@link contentHash} hashes). Null if the entry has no live current.
+ * Use this (not getRowById, which addresses the physical/demoted row) whenever the
+ * remote is keyed by logical_id — push, conflict classification, conflict snapshot.
+ * COALESCE(logical_id, id): production always sets logical_id; be robust to a
+ * legacy/unmigrated NULL (a v1 row IS its own logical entity).
+ */
+export function currentKnowledgeRow(
+  logicalId: string,
+): Record<string, unknown> | null {
+  const cols = columns("knowledge").filter((c) => !PAYLOAD_EXCLUDE.has(c));
+  const row = db()
+    .query(
+      `SELECT ${cols.join(", ")} FROM knowledge_current WHERE COALESCE(logical_id, id) = ?`,
+    )
+    .get(logicalId) as Record<string, unknown> | undefined;
+  if (!row) return null;
+  row.id = logicalId; // re-key on the stable logical_id (the remote row key)
+  return row;
+}
+
 export function knowledgePushPlan(outboxRowId: string): KnowledgePushPlan {
-  // COALESCE(logical_id, id): production always sets logical_id, but be robust to a
-  // legacy/unmigrated NULL (a v1 row IS its own logical entity).
   const lid = db()
     .query(
       "SELECT COALESCE(logical_id, id) AS logical_id FROM knowledge WHERE id = ?",
@@ -868,14 +889,8 @@ export function knowledgePushPlan(outboxRowId: string): KnowledgePushPlan {
     .get(outboxRowId) as { logical_id: string } | undefined;
   if (!lid) return { op: "skip" }; // physical row gone (not expected post-flip)
   const logicalId = lid.logical_id;
-  const cols = columns("knowledge").filter((c) => !PAYLOAD_EXCLUDE.has(c));
-  const row = db()
-    .query(
-      `SELECT ${cols.join(", ")} FROM knowledge_current WHERE COALESCE(logical_id, id) = ?`,
-    )
-    .get(logicalId) as Record<string, unknown> | undefined;
+  const row = currentKnowledgeRow(logicalId);
   if (!row) return { op: "delete", logicalId }; // no live current → soft-delete
-  row.id = logicalId; // re-key the remote row on the stable logical_id
   return { op: "upsert", logicalId, row };
 }
 
@@ -925,7 +940,15 @@ export function classifyRemoteRow(
   remoteHash: string | null,
   opts: { pendingLocalChange?: boolean } = {},
 ): RemoteClass {
-  const local = getRowById(table, rowId);
+  // Knowledge is append-only and remote-keyed by logical_id: the local CURRENT
+  // content lives in knowledge_current (a fresh version row), NOT the physical row
+  // addressed by getRowById(id=logical_id) — which is the demoted v1 after any
+  // update. Reading the demoted row here mis-hashes every versioned entry, turning
+  // clean fast-forwards/echoes into false conflicts (Seer + review, #823).
+  const local =
+    table === "knowledge"
+      ? currentKnowledgeRow(rowId)
+      : getRowById(table, rowId);
   const localHash = local ? contentHash(table, local) : null;
   if (remoteHash !== null && localHash === remoteHash) return "skip";
 

--- a/packages/core/test/sync-data.test.ts
+++ b/packages/core/test/sync-data.test.ts
@@ -9,6 +9,8 @@ import {
 } from "../src/db";
 import {
   applyRemoteDelete,
+  applyRemoteKnowledge,
+  applyRemoteKnowledgeDelete,
   applyRemoteUpsert,
   assertSyncInvariants,
   classifyRemoteRow,
@@ -22,7 +24,7 @@ import {
   getSyncState,
   hasPendingChange,
   isSyncEnabled,
-  knowledgeSyncOp,
+  knowledgePushPlan,
   maxOutboxSeq,
   pickSyncColumns,
   readOutbox,
@@ -38,26 +40,174 @@ import * as ltm from "../src/ltm";
 
 const now = () => Date.now();
 
-describe("knowledgeSyncOp — append-only remote mapping (A2)", () => {
-  test("current live → upsert; superseded + death-cert → delete; gone → skip", () => {
+describe("applyRemoteKnowledge — append-only pull apply (A2, #823)", () => {
+  const PROJ = "/tmp/lore-apply-knowledge";
+  const remoteRow = (
+    id: string,
+    content: string,
+    extra: Record<string, unknown> = {},
+  ) => ({
+    id,
+    project_id: ensureProject(PROJ),
+    category: "decision",
+    title: "AK",
+    content,
+    created_at: now(),
+    updated_at: now(),
+    ...extra,
+  });
+  const versions = (lid: string) =>
+    db()
+      .query(
+        "SELECT id, version, is_current, is_deleted, content FROM knowledge WHERE COALESCE(logical_id, id) = ? ORDER BY version",
+      )
+      .all(lid) as Array<{
+      id: string;
+      version: number;
+      is_current: number;
+      is_deleted: number;
+      content: string;
+    }>;
+  const curContent = (lid: string) =>
+    (
+      db()
+        .query(
+          "SELECT content FROM knowledge_current WHERE COALESCE(logical_id, id) = ?",
+        )
+        .get(lid) as { content: string } | undefined
+    )?.content;
+
+  test("new entry → v1 with id = logical_id", () => {
+    applyRemoteKnowledge(remoteRow("n1", "hello"));
+    const v = versions("n1");
+    expect(v).toHaveLength(1);
+    expect(v[0].id).toBe("n1");
+    expect(v[0].version).toBe(1);
+    expect(v[0].is_current).toBe(1);
+    expect(curContent("n1")).toBe("hello");
+  });
+
+  test("content change → appends a new current version; prior preserved + demoted", () => {
+    applyRemoteKnowledge(remoteRow("c1", "v1"));
+    applyRemoteKnowledge(remoteRow("c1", "v2"));
+    const v = versions("c1");
+    expect(v).toHaveLength(2);
+    expect(v[0].content).toBe("v1");
+    expect(v[0].is_current).toBe(0); // prior demoted, immutably preserved
+    expect(v[1].content).toBe("v2");
+    expect(v[1].is_current).toBe(1);
+    expect(v[1].id).not.toBe("c1"); // new version row gets a fresh id
+    expect(curContent("c1")).toBe("v2");
+  });
+
+  test("identical content → no new version (idempotent re-pull / echo)", () => {
+    applyRemoteKnowledge(remoteRow("i1", "same"));
+    applyRemoteKnowledge(remoteRow("i1", "same"));
+    expect(versions("i1")).toHaveLength(1);
+  });
+
+  test("metadata-only change (same content) converges in place, no new version", () => {
+    applyRemoteKnowledge(remoteRow("m1", "body", { confidence: 0.5 }));
+    applyRemoteKnowledge(remoteRow("m1", "body", { confidence: 0.9 }));
+    expect(versions("m1")).toHaveLength(1);
+    expect(
+      (
+        db()
+          .query(
+            "SELECT confidence FROM knowledge_current WHERE COALESCE(logical_id, id) = ?",
+          )
+          .get("m1") as { confidence: number }
+      ).confidence,
+    ).toBe(0.9);
+  });
+
+  test("delete → death-cert (no live current); re-delete is a no-op", () => {
+    applyRemoteKnowledge(remoteRow("d1", "body"));
+    applyRemoteKnowledgeDelete("d1");
+    expect(curContent("d1")).toBeUndefined();
+    const v = versions("d1");
+    expect(v).toHaveLength(2);
+    expect(v[1].is_deleted).toBe(1);
+    applyRemoteKnowledgeDelete("d1"); // idempotent
+    expect(versions("d1")).toHaveLength(2);
+  });
+
+  test("revive: a remote upsert after a delete appends a new live current", () => {
+    applyRemoteKnowledge(remoteRow("r1", "body"));
+    applyRemoteKnowledgeDelete("r1");
+    expect(curContent("r1")).toBeUndefined();
+    applyRemoteKnowledge(remoteRow("r1", "revived"));
+    expect(curContent("r1")).toBe("revived");
+    expect(versions("r1")).toHaveLength(3); // v1 live, v2 death-cert, v3 revived
+  });
+
+  test("round-trip: A's multi-version entry coalesces to ONE version on peer B", () => {
+    // Device A: create + update → two local versions, current content "final".
     const id = ltm.create({
-      projectPath: "/tmp/lore-sync-kso",
+      projectPath: PROJ,
       scope: "project",
       category: "decision",
-      title: "KSO",
+      title: "RT",
+      content: "first",
+    });
+    ltm.update(id, { content: "final" });
+    expect(versions(id)).toHaveLength(2); // A has v1 + v2
+
+    // Push coalesces both versions to ONE remote row keyed by logical_id.
+    const plan = knowledgePushPlan(id);
+    expect(plan.op).toBe("upsert");
+    if (plan.op !== "upsert") return;
+    expect(plan.row.id).toBe(id);
+    expect(plan.row.content).toBe("final");
+
+    // Device B (simulated as a peer with none of A's local version history).
+    db()
+      .query("DELETE FROM knowledge WHERE COALESCE(logical_id, id) = ?")
+      .run(id);
+    applyRemoteKnowledge(plan.row);
+    const vB = versions(id);
+    expect(vB).toHaveLength(1); // ONE coalesced version, not A's two
+    expect(vB[0].id).toBe(id); // v1 keyed by the shared logical_id
+    expect(curContent(id)).toBe("final");
+
+    // Re-pulling the same row (echo) is idempotent.
+    applyRemoteKnowledge(plan.row);
+    expect(versions(id)).toHaveLength(1);
+  });
+});
+
+describe("knowledgePushPlan — append-only remote mapping keyed by logical_id (A2)", () => {
+  test("coalesces versions to one logical-keyed upsert; no live current → delete; gone → skip", () => {
+    const id = ltm.create({
+      projectPath: "/tmp/lore-sync-kpp",
+      scope: "project",
+      category: "decision",
+      title: "KPP",
       content: "secret v1",
     });
-    expect(knowledgeSyncOp(id)).toBe("upsert"); // current live
+    const p1 = knowledgePushPlan(id);
+    expect(p1.op).toBe("upsert");
+    if (p1.op === "upsert") {
+      expect(p1.logicalId).toBe(id);
+      expect(p1.row.id).toBe(id); // re-keyed on logical_id
+      expect(p1.row.content).toBe("secret v1");
+    }
 
-    const v2 = ltm.appendVersion(id, { content: "redacted v2" });
-    // The superseded v1 must become a remote DELETE so the old (secret) content is
-    // removed from the remote — not re-pushed as a live row.
-    expect(knowledgeSyncOp(id)).toBe("delete");
-    expect(knowledgeSyncOp(v2 as string)).toBe("upsert"); // new current live
+    const v2 = ltm.appendVersion(id, { content: "redacted v2" }) as string;
+    // Both the (now superseded) v1 outbox row AND the new v2 row coalesce to ONE
+    // upsert keyed by logical_id carrying the CURRENT content — the old secret is
+    // never pushed as a live row.
+    for (const outboxId of [id, v2]) {
+      const p = knowledgePushPlan(outboxId);
+      expect(p.op).toBe("upsert");
+      if (p.op === "upsert") {
+        expect(p.logicalId).toBe(id);
+        expect(p.row.id).toBe(id);
+        expect(p.row.content).toBe("redacted v2");
+      }
+    }
 
-    ltm.remove(id); // append a death-cert, demoting v2
-    // Deletion propagates: the now-superseded v2 becomes a remote DELETE.
-    expect(knowledgeSyncOp(v2 as string)).toBe("delete");
+    ltm.remove(id); // append a death-cert → no live current
     const deathCert = (
       db()
         .query(
@@ -65,9 +215,13 @@ describe("knowledgeSyncOp — append-only remote mapping (A2)", () => {
         )
         .get(id) as { id: string }
     ).id;
-    expect(knowledgeSyncOp(deathCert)).toBe("delete"); // death cert → delete
+    for (const outboxId of [id, v2, deathCert]) {
+      const p = knowledgePushPlan(outboxId);
+      expect(p.op).toBe("delete");
+      if (p.op === "delete") expect(p.logicalId).toBe(id);
+    }
 
-    expect(knowledgeSyncOp("00000000-0000-0000-0000-000000000000")).toBe(
+    expect(knowledgePushPlan("00000000-0000-0000-0000-000000000000").op).toBe(
       "skip",
     );
   });
@@ -401,20 +555,20 @@ describe("applyRemoteUpsert / applyRemoteDelete", () => {
     rebuildFts("knowledge_fts"); // must not throw
   });
 
-  test("backfills logical_id = id for a pulled knowledge row, scoped to that row only", () => {
-    // Remote has no logical_id column yet (sub-PR 3), so pulled rows land NULL;
-    // applyRemoteUpsert backfills each row's OWN id and touches nothing else.
+  test("applyRemoteKnowledge inserts a pulled entry as v1 with logical_id = id, scoped per row", () => {
+    // A pulled knowledge row is keyed by logical_id (= id); a brand-new entry
+    // lands as v1 with logical_id = id, isolated per row.
     setTeamConfig("sync.enabled", "1");
     const pid = ensureProject("/tmp/lore-sync-backfill");
     const base = { project_id: pid, category: "pattern", content: "c" };
-    applyRemoteUpsert("knowledge", {
+    applyRemoteKnowledge({
       id: "kA",
       title: "A",
       created_at: now(),
       updated_at: now(),
       ...base,
     });
-    applyRemoteUpsert("knowledge", {
+    applyRemoteKnowledge({
       id: "kB",
       title: "B",
       created_at: now(),

--- a/packages/core/test/sync-data.test.ts
+++ b/packages/core/test/sync-data.test.ts
@@ -17,6 +17,7 @@ import {
   clearProfileMirror,
   clearSyncState,
   contentHash,
+  currentKnowledgeRow,
   currentTier,
   disableSync,
   enableSync,
@@ -224,6 +225,37 @@ describe("knowledgePushPlan — append-only remote mapping keyed by logical_id (
     expect(knowledgePushPlan("00000000-0000-0000-0000-000000000000").op).toBe(
       "skip",
     );
+  });
+
+  test("seedOutbox skips an already-synced versioned (v2) entry — no re-enqueue bloat (#823)", () => {
+    setTeamConfig("sync.enabled", "1");
+    const id = ltm.create({
+      projectPath: "/tmp/lore-seed-bloat",
+      scope: "project",
+      category: "decision",
+      title: "SB",
+      content: "v1",
+    });
+    ltm.appendVersion(id, { content: "v2" }); // versioned: current id ≠ logical_id
+    // Mark synced exactly as push would: sync_state keyed by logical_id, hashing the
+    // current row re-keyed id=logical_id.
+    const row = currentKnowledgeRow(id) as Record<string, unknown>;
+    setSyncState("knowledge", id, {
+      content_hash: contentHash("knowledge", row),
+      revision: 1,
+      remote_updated_at: null,
+    });
+    db().exec("DELETE FROM sync_outbox"); // clear capture from create/append
+    setKV("sync.push.knowledge", "0");
+    seedOutbox("basic");
+    const n = (
+      db()
+        .query(
+          "SELECT COUNT(*) AS n FROM sync_outbox WHERE table_name = 'knowledge'",
+        )
+        .get() as { n: number }
+    ).n;
+    expect(n).toBe(0); // already synced (by logical_id) → not re-enqueued
   });
 });
 

--- a/packages/gateway/src/sync.ts
+++ b/packages/gateway/src/sync.ts
@@ -149,16 +149,24 @@ async function pushEntry(
 ): Promise<PushOutcome> {
   const { table_name: table, row_id: rowId } = e;
   let op = e.op;
+  // The remote row key. For knowledge the remote is a CURRENT-only mirror keyed by
+  // logical_id (not the per-version row id), so sync_state + the upsert/delete both
+  // operate on the logical_id. For every other table this stays the outbox rowId.
+  let effectiveId = rowId;
+  // For a knowledge upsert, the row to push is the CURRENT version (id=logical_id),
+  // not the outbox version row — resolved by the push plan.
+  let knowledgeRow: Record<string, unknown> | undefined;
 
   // A2 (#823): knowledge is append-only — update()/remove() append immutable
-  // versions and remove() emits no physical-delete op. Translate the version churn
-  // so the remote mirrors only the current LIVE version: a superseded or
-  // soft-deleted row becomes a remote soft-delete (propagating deletions + removing
-  // stale/redacted content), a current live row upserts. See knowledgeSyncOp.
+  // versions and remove() emits no physical-delete op. The plan coalesces all of an
+  // entry's versions to ONE remote row keyed by logical_id: a live current → upsert
+  // that content; no live current (every version superseded/deleted) → soft-delete.
   if (table === "knowledge" && op === "upsert") {
-    const kop = syncData.knowledgeSyncOp(rowId);
-    if (kop === "skip") return "ok";
-    op = kop;
+    const plan = syncData.knowledgePushPlan(rowId);
+    if (plan.op === "skip") return "ok";
+    effectiveId = plan.logicalId;
+    op = plan.op;
+    if (plan.op === "upsert") knowledgeRow = plan.row;
   }
 
   if (op === "delete") {
@@ -169,13 +177,15 @@ async function pushEntry(
     const { error } = await client
       .from(table)
       .update({ is_deleted: true, content_hash: null })
-      .match(decomposeId(table, rowId));
+      .match(decomposeId(table, effectiveId));
     if (error) {
-      console.error(`sync: push delete ${table}/${rowId}: ${error.message}`);
+      console.error(
+        `sync: push delete ${table}/${effectiveId}: ${error.message}`,
+      );
       return "stop"; // transient; keep pending so the delete isn't lost
     }
-    const prev = syncData.getSyncState(table, rowId);
-    syncData.setSyncState(table, rowId, {
+    const prev = syncData.getSyncState(table, effectiveId);
+    syncData.setSyncState(table, effectiveId, {
       content_hash: null,
       revision: (prev?.revision ?? 0) + 1,
       remote_updated_at: prev?.remote_updated_at ?? null,
@@ -184,11 +194,11 @@ async function pushEntry(
     return "ok";
   }
 
-  // upsert
-  const row = syncData.getRowById(table, rowId);
+  // upsert — for knowledge, `knowledgeRow` is the CURRENT version keyed by logical_id.
+  const row = knowledgeRow ?? syncData.getRowById(table, rowId);
   if (!row) return "ok"; // row gone; a later delete entry (if any) handles it
   const hash = syncData.contentHash(table, row);
-  const state = syncData.getSyncState(table, rowId);
+  const state = syncData.getSyncState(table, effectiveId);
   if (state?.content_hash === hash) {
     res.pushed++; // already in sync — no-op
     return "ok";
@@ -226,22 +236,24 @@ async function pushEntry(
       // pause the table (that would wedge it forever) — record it and advance
       // past it so the rest of the table keeps syncing.
       console.error(
-        `sync: dropping unsyncable ${table}/${rowId}: ${error.message}`,
+        `sync: dropping unsyncable ${table}/${effectiveId}: ${error.message}`,
       );
-      syncData.recordConflict(table, rowId, "rejected_unsyncable", row);
+      syncData.recordConflict(table, effectiveId, "rejected_unsyncable", row);
       // Mark as "synced" to this hash so we don't retry the same poison row.
-      syncData.setSyncState(table, rowId, {
+      syncData.setSyncState(table, effectiveId, {
         content_hash: hash,
         revision,
         remote_updated_at: state?.remote_updated_at ?? null,
       });
       return "ok";
     }
-    console.error(`sync: push upsert ${table}/${rowId}: ${error.message}`);
+    console.error(
+      `sync: push upsert ${table}/${effectiveId}: ${error.message}`,
+    );
     return "stop"; // transient — keep pending so we retry (never lose a write)
   }
 
-  syncData.setSyncState(table, rowId, {
+  syncData.setSyncState(table, effectiveId, {
     content_hash: hash,
     revision,
     remote_updated_at: state?.remote_updated_at ?? null,
@@ -432,11 +444,12 @@ function applyRemote(
   // Unpushed local intent for this row (push runs first, but a quota-paused or
   // failed push can leave one pending) → never fast-forward over it.
   const pushCursor = Number(getKV(pushKey(meta.table)) ?? "0");
-  const pendingLocalChange = syncData.hasPendingChange(
-    meta.table,
-    rowId,
-    pushCursor,
-  );
+  // Knowledge is keyed by logical_id on the remote but per-version in the outbox,
+  // so resolve pending edits by logical_id (A2, #823).
+  const pendingLocalChange =
+    meta.table === "knowledge"
+      ? syncData.hasPendingKnowledgeChange(rowId, pushCursor)
+      : syncData.hasPendingChange(meta.table, rowId, pushCursor);
   // Pull-only tables are server-authoritative — the client never writes them, so
   // local divergence (a "conflict") is impossible by construction. classifyRemoteRow
   // would otherwise flag every change as a conflict: these tables carry no remote
@@ -463,11 +476,23 @@ function applyRemote(
   }
 
   if (isDeleted) {
-    syncData.applyRemoteDelete(meta.table, rowId);
+    // Knowledge applies a remote delete as a death-cert version (append-only),
+    // not a physical row delete (A2, #823).
+    if (meta.table === "knowledge") {
+      syncData.applyRemoteKnowledgeDelete(rowId);
+    } else {
+      syncData.applyRemoteDelete(meta.table, rowId);
+    }
     syncData.clearSyncState(meta.table, rowId);
     for (const fts of meta.ftsTables) touchedFts.add(fts);
   } else {
-    syncData.applyRemoteUpsert(meta.table, stripSyncCols(remote));
+    // Knowledge applies a remote content change as a new version (append-only),
+    // never an in-place upsert of an immutable version (A2, #823).
+    if (meta.table === "knowledge") {
+      syncData.applyRemoteKnowledge(stripSyncCols(remote));
+    } else {
+      syncData.applyRemoteUpsert(meta.table, stripSyncCols(remote));
+    }
     syncData.setSyncState(meta.table, rowId, {
       content_hash: remoteHash,
       revision: typeof remote.revision === "number" ? remote.revision : 0,

--- a/packages/gateway/src/sync.ts
+++ b/packages/gateway/src/sync.ts
@@ -161,12 +161,30 @@ async function pushEntry(
   // versions and remove() emits no physical-delete op. The plan coalesces all of an
   // entry's versions to ONE remote row keyed by logical_id: a live current → upsert
   // that content; no live current (every version superseded/deleted) → soft-delete.
-  if (table === "knowledge" && op === "upsert") {
-    const plan = syncData.knowledgePushPlan(rowId);
-    if (plan.op === "skip") return "ok";
-    effectiveId = plan.logicalId;
-    op = plan.op;
-    if (plan.op === "upsert") knowledgeRow = plan.row;
+  if (table === "knowledge") {
+    if (op === "upsert") {
+      const plan = syncData.knowledgePushPlan(rowId);
+      if (plan.op === "skip") return "ok";
+      effectiveId = plan.logicalId;
+      op = plan.op;
+      if (plan.op === "upsert") knowledgeRow = plan.row;
+    } else {
+      // op === "delete" (a physical-delete capture, keyed by logical_id). Re-validate
+      // liveness: if the entry STILL has a live current version — i.e. a SUPERSEDED
+      // version was physically deleted while the entry lives on — this is NOT a
+      // deletion; re-push the current content instead. Only a genuinely dead entry
+      // (no live current) propagates as a remote delete. Guards a future compaction
+      // (sub-PR 4) that prunes superseded versions from falsely deleting a live remote
+      // entry. (We re-validate directly, NOT via knowledgePushPlan, because the plan
+      // would "skip" a dead entry whose v1 anchor row was also pruned — dropping the
+      // delete.)
+      const live = syncData.currentKnowledgeRow(rowId);
+      if (live) {
+        op = "upsert";
+        knowledgeRow = live;
+      }
+      // effectiveId stays rowId (= logical_id, the remote key) for both branches.
+    }
   }
 
   if (op === "delete") {

--- a/packages/gateway/src/sync.ts
+++ b/packages/gateway/src/sync.ts
@@ -179,14 +179,16 @@ async function pushEntry(
       is_deleted: true,
       content_hash: null,
     };
-    // Erasure completeness (#823): scrub the deleted knowledge content/title from
-    // the remote tombstone so the bytes don't linger server-side until the sub-PR 4
-    // reaper. The LOCAL death-cert preserves content, and applyRemoteKnowledgeDelete
-    // rebuilds a peer's death-cert from its OWN current row, so peers are unaffected.
-    // (Remote content/title are NOT NULL — scrub to '' not null.)
+    // Erasure completeness (#823): scrub the deleted knowledge content-bearing
+    // columns from the remote tombstone so the bytes don't linger server-side until
+    // the sub-PR 4 reaper. The LOCAL death-cert preserves them, and
+    // applyRemoteKnowledgeDelete rebuilds a peer's death-cert from its OWN current
+    // row, so peers are unaffected. (Remote content/title are NOT NULL → ''; metadata
+    // is nullable → null.)
     if (table === "knowledge") {
       tombstone.content = "";
       tombstone.title = "";
+      tombstone.metadata = null;
     }
     const { error } = await client
       .from(table)

--- a/packages/gateway/src/sync.ts
+++ b/packages/gateway/src/sync.ts
@@ -174,9 +174,23 @@ async function pushEntry(
     // "remoteHash is null for a tombstone" contract on the wire. The pull side
     // (applyRemote) already treats is_deleted rows as hash-null, but this also
     // protects un-upgraded readers during a rollout.
+    // Null the remote content_hash too (tombstone "remoteHash is null" contract).
+    const tombstone: Record<string, unknown> = {
+      is_deleted: true,
+      content_hash: null,
+    };
+    // Erasure completeness (#823): scrub the deleted knowledge content/title from
+    // the remote tombstone so the bytes don't linger server-side until the sub-PR 4
+    // reaper. The LOCAL death-cert preserves content, and applyRemoteKnowledgeDelete
+    // rebuilds a peer's death-cert from its OWN current row, so peers are unaffected.
+    // (Remote content/title are NOT NULL — scrub to '' not null.)
+    if (table === "knowledge") {
+      tombstone.content = "";
+      tombstone.title = "";
+    }
     const { error } = await client
       .from(table)
-      .update({ is_deleted: true, content_hash: null })
+      .update(tombstone)
       .match(decomposeId(table, effectiveId));
     if (error) {
       console.error(
@@ -465,8 +479,14 @@ function applyRemote(
   if (cls === "skip") return;
   if (cls === "conflict") {
     res.conflicts++;
-    // Preserve the local row we're about to overwrite (LWW = remote wins).
-    const localBefore = syncData.getRowById(meta.table, rowId);
+    // Preserve the local row we're about to overwrite (LWW = remote wins). For
+    // knowledge, snapshot the CURRENT version (keyed by logical_id) — not the
+    // demoted physical row getRowById would return — so the discarded edit is
+    // actually recoverable from sync_conflicts.local_content (#823).
+    const localBefore =
+      meta.table === "knowledge"
+        ? syncData.currentKnowledgeRow(rowId)
+        : syncData.getRowById(meta.table, rowId);
     syncData.recordConflict(
       meta.table,
       rowId,

--- a/packages/gateway/test/sync.property.test.ts
+++ b/packages/gateway/test/sync.property.test.ts
@@ -15,6 +15,7 @@ import {
   db,
   deleteTeamConfig,
   ensureProject,
+  ltm,
   setKV,
   syncData,
 } from "@loreai/core";
@@ -227,29 +228,26 @@ type Op =
 async function apply(op: Op): Promise<void> {
   const pid = ensureProject(PROJECT);
   switch (op.t) {
+    // Drive local knowledge through the REAL append-only ops (ltm), so the engine
+    // is exercised against versioned (v2+) entries — the case sub-PR 3 exists to
+    // handle. A raw in-place UPDATE / physical DELETE would only ever produce v1
+    // (id == logical_id) rows and silently skip the append-only code paths.
     case "insert":
       if (!exists(op.id)) {
+        // Unique title per id so create()'s fuzzy-dedup can't merge entries.
         db()
           .query(
-            `INSERT INTO knowledge (id, project_id, category, title, content, created_at, updated_at)
-             VALUES (?, ?, 'pattern', 'T', ?, ?, ?)`,
+            `INSERT INTO knowledge (id, logical_id, project_id, category, title, content, created_at, updated_at)
+             VALUES (?, ?, ?, 'pattern', ?, ?, ?, ?)`,
           )
-          .run(op.id, pid, op.content, Date.now(), Date.now());
+          .run(op.id, op.id, pid, op.id, op.content, Date.now(), Date.now());
       }
       break;
     case "update":
-      if (exists(op.id)) {
-        db()
-          .query(
-            "UPDATE knowledge SET content = ?, updated_at = ? WHERE id = ?",
-          )
-          .run(op.content, Date.now(), op.id);
-      }
+      if (exists(op.id)) ltm.update(op.id, { content: op.content }); // appends a version
       break;
     case "delete":
-      if (exists(op.id)) {
-        db().query("DELETE FROM knowledge WHERE id = ?").run(op.id);
-      }
+      if (exists(op.id)) ltm.remove(op.id); // appends a death-cert (no physical delete)
       break;
     case "enable":
       syncData.enableSync("basic");
@@ -382,11 +380,17 @@ describe("sync engine — property/sequence tests (#833)", () => {
         for (const op of ops) await apply(op);
         syncData.enableSync("basic"); // reconcile + push so there ARE pushed rows
         await pushOnce(client());
-        await pullOnce(client());
+        // Pulling our OWN just-pushed rows must never self-conflict — even for
+        // versioned (v2+) entries, whose current content lives in a fresh version
+        // row keyed by logical_id (#823, Seer): a stale by-id hash here would
+        // mis-classify every echo as a conflict.
+        const r1 = await pullOnce(client());
+        expect(r1.conflicts).toBe(0);
         // A second pull of our OWN just-pushed rows must apply nothing (they
         // classify as skip), and a re-push of unchanged rows must upload nothing.
         const r2 = await pullOnce(client());
         expect(r2.pulled).toBe(0);
+        expect(r2.conflicts).toBe(0);
         const r3 = await pushOnce(client());
         expect(r3.pushed).toBe(0);
       }),

--- a/packages/gateway/test/sync.property.test.ts
+++ b/packages/gateway/test/sync.property.test.ts
@@ -286,10 +286,18 @@ const opArb: fc.Arbitrary<Op> = fc.oneof(
 const seqArb = fc.array(opArb, { minLength: 1, maxLength: 14 });
 
 function localIds(): Set<string> {
+  // Append-only (A2, #823): the live set is the CURRENT live versions, identified
+  // by the synced logical_id. Superseded + death-cert versions are local-only
+  // history and must not count toward convergence with the remote (which mirrors
+  // one row per logical entry).
   return new Set(
-    (db().query("SELECT id FROM knowledge").all() as Array<{ id: string }>).map(
-      (r) => r.id,
-    ),
+    (
+      db()
+        .query(
+          "SELECT COALESCE(logical_id, id) AS id FROM knowledge WHERE is_current = 1 AND is_deleted = 0",
+        )
+        .all() as Array<{ id: string }>
+    ).map((r) => r.id),
   );
 }
 function remoteLiveIds(): Set<string> {

--- a/packages/gateway/test/sync.test.ts
+++ b/packages/gateway/test/sync.test.ts
@@ -799,6 +799,30 @@ describe("pullOnce", () => {
       )?.is_deleted,
     ).toBe(true);
   });
+
+  test("physically deleting a SUPERSEDED version of a live entry does NOT delete the remote (#823, sub-PR 4 guard)", async () => {
+    // A physical delete of a non-current version fires op=delete keyed by logical_id.
+    // The push delete branch must re-validate liveness: the entry still has a live
+    // current version, so this is NOT a deletion — re-push current, don't tombstone.
+    syncData.enableSync("basic");
+    const id = ltm.create({
+      projectPath: "/tmp/lore-sync-engine",
+      scope: "project",
+      category: "pattern",
+      title: "SV",
+      content: "v1",
+    });
+    ltm.update(id, { content: "v2" }); // v2 current; v1 (id=id) demoted
+    await pushOnce(makeClient() as never); // remote live, content v2
+    // Physically delete only the SUPERSEDED v1 row — the entry lives on at v2.
+    db().query("DELETE FROM knowledge WHERE id = ? AND is_current = 0").run(id);
+    await pushOnce(makeClient() as never);
+    const remote = tableRows("knowledge").find((r) => r.id === id) as
+      | Record<string, unknown>
+      | undefined;
+    expect(remote?.is_deleted).toBeFalsy(); // still live → NOT deleted
+    expect(remote?.content).toBe("v2"); // current content retained
+  });
 });
 
 describe("profiles (pull-only mirror)", () => {

--- a/packages/gateway/test/sync.test.ts
+++ b/packages/gateway/test/sync.test.ts
@@ -763,6 +763,42 @@ describe("pullOnce", () => {
       | undefined;
     expect(remote?.is_deleted).toBe(true); // delete propagated via logical_id
   });
+
+  test("a versioned entry deleted while sync is OFF tombstones on re-enable (#823)", async () => {
+    // reconcile() must tombstone by knowledge_current liveness, not physical-row
+    // existence — a deleted entry keeps its demoted/death-cert version rows, so an
+    // id=logical_id existence check would never reconcile a delete made while OFF.
+    syncData.enableSync("basic");
+    const id = ltm.create({
+      projectPath: "/tmp/lore-sync-engine",
+      scope: "project",
+      category: "pattern",
+      title: "DW",
+      content: "v1",
+    });
+    ltm.update(id, { content: "v2" }); // versioned
+    await pushOnce(makeClient() as never); // remote live
+    expect(
+      (
+        tableRows("knowledge").find((r) => r.id === id) as Record<
+          string,
+          unknown
+        >
+      )?.is_deleted,
+    ).toBeFalsy();
+    syncData.disableSync();
+    ltm.remove(id); // death-cert while OFF → capture trigger doesn't fire
+    syncData.enableSync("basic"); // reconcile enqueues the missed delete
+    await pushOnce(makeClient() as never);
+    expect(
+      (
+        tableRows("knowledge").find((r) => r.id === id) as Record<
+          string,
+          unknown
+        >
+      )?.is_deleted,
+    ).toBe(true);
+  });
 });
 
 describe("profiles (pull-only mirror)", () => {

--- a/packages/gateway/test/sync.test.ts
+++ b/packages/gateway/test/sync.test.ts
@@ -732,6 +732,37 @@ describe("pullOnce", () => {
       .get(id) as { local_content: string };
     expect(JSON.parse(row.local_content).content).toBe("local-v2"); // current v2, not v1
   });
+
+  test("a physical delete of a non-v1 version propagates to the remote by logical_id (#823, Seer)", async () => {
+    // The DELETE capture trigger must record the logical_id, not the version id —
+    // otherwise a delete of a version whose id ≠ logical_id targets a remote row
+    // that doesn't exist (remote is keyed by logical_id) and silently no-ops.
+    syncData.enableSync("basic");
+    const id = ltm.create({
+      projectPath: "/tmp/lore-sync-engine",
+      scope: "project",
+      category: "pattern",
+      title: "PD",
+      content: "v1",
+    });
+    ltm.update(id, { content: "v2" }); // current version's id is a fresh uuid ≠ id
+    const currentId = (
+      db()
+        .query(
+          "SELECT id FROM knowledge_current WHERE COALESCE(logical_id, id) = ?",
+        )
+        .get(id) as { id: string }
+    ).id;
+    expect(currentId).not.toBe(id);
+    await pushOnce(makeClient() as never); // remote row keyed by logical_id (= id)
+    // Physically delete the current version by its (non-logical) id.
+    db().query("DELETE FROM knowledge WHERE id = ?").run(currentId);
+    await pushOnce(makeClient() as never);
+    const remote = tableRows("knowledge").find((r) => r.id === id) as
+      | Record<string, unknown>
+      | undefined;
+    expect(remote?.is_deleted).toBe(true); // delete propagated via logical_id
+  });
 });
 
 describe("profiles (pull-only mirror)", () => {

--- a/packages/gateway/test/sync.test.ts
+++ b/packages/gateway/test/sync.test.ts
@@ -6,7 +6,7 @@ import {
   setKV,
   deleteTeamConfig,
 } from "@loreai/core";
-import { log, syncData } from "@loreai/core";
+import { ltm, log, syncData } from "@loreai/core";
 
 // --- Fake Supabase client ----------------------------------------------------
 // In-memory per-table store with the PostgREST surface the engine uses, PLUS
@@ -670,6 +670,35 @@ describe("pullOnce", () => {
       .query("SELECT local_content FROM sync_conflicts WHERE row_id='kc'")
       .get() as { local_content: string };
     expect(JSON.parse(row.local_content).content).toBe("local-edit");
+  });
+
+  test("a versioned (v2+) entry echo-pulls as skip — NO false conflict (#823, Seer)", async () => {
+    // BLOCKER regression: classifyRemoteRow must hash the CURRENT version
+    // (knowledge_current, keyed by logical_id), not the demoted v1 base row that
+    // getRowById(id=logical_id) returns. Reverting that fix makes this fail with
+    // conflicts=1 / pulled=1 and a stale (v1) sync_conflicts.local_content.
+    syncData.enableSync("basic");
+    const id = ltm.create({
+      projectPath: "/tmp/lore-sync-engine",
+      scope: "project",
+      category: "pattern",
+      title: "V",
+      content: "v1",
+    });
+    ltm.update(id, { content: "v2" }); // append v2 → current row id ≠ logical_id (id)
+    await pushOnce(makeClient() as never);
+    // Pulling our OWN just-pushed current content must classify skip, not conflict.
+    const r = await pullOnce(makeClient() as never);
+    expect(r.conflicts).toBe(0);
+    expect(r.pulled).toBe(0);
+    expect(currentContent(id)).toBe("v2");
+    expect(
+      (
+        db()
+          .query("SELECT COUNT(*) AS n FROM sync_conflicts WHERE row_id = ?")
+          .get(id) as { n: number }
+      ).n,
+    ).toBe(0); // no false conflict recorded
   });
 });
 

--- a/packages/gateway/test/sync.test.ts
+++ b/packages/gateway/test/sync.test.ts
@@ -700,6 +700,38 @@ describe("pullOnce", () => {
       ).n,
     ).toBe(0); // no false conflict recorded
   });
+
+  test("conflict on a versioned (v2) entry snapshots the CURRENT version, not stale v1 (#823)", async () => {
+    // Guards the conflict-snapshot half of the classify fix: localBefore must read
+    // knowledge_current (current version), not getRowById (the demoted v1 row), so
+    // the discarded edit recoverable from sync_conflicts.local_content is the real
+    // superseded content. Reverting that branch to getRowById makes this fail.
+    syncData.enableSync("basic");
+    const id = ltm.create({
+      projectPath: "/tmp/lore-sync-engine",
+      scope: "project",
+      category: "pattern",
+      title: "VC",
+      content: "v1",
+    });
+    await pushOnce(makeClient() as never); // remote synced at v1
+    ltm.update(id, { content: "local-v2" }); // append v2, UNPUSHED → pending local change
+    // A divergent remote edit on the same logical_id (remote is keyed by id=logical_id).
+    const remoteRow = tableRows("knowledge").find((r) => r.id === id) as Record<
+      string,
+      unknown
+    >;
+    remoteRow.content = "remote-v2";
+    remoteRow.content_hash = "remotehash-v2";
+    remoteRow.updated_at = new Date(9_000_000).toISOString();
+    const r = await pullOnce(makeClient() as never);
+    expect(r.conflicts).toBe(1);
+    expect(currentContent(id)).toBe("remote-v2"); // LWW: remote wins
+    const row = db()
+      .query("SELECT local_content FROM sync_conflicts WHERE row_id = ?")
+      .get(id) as { local_content: string };
+    expect(JSON.parse(row.local_content).content).toBe("local-v2"); // current v2, not v1
+  });
 });
 
 describe("profiles (pull-only mirror)", () => {

--- a/packages/gateway/test/sync.test.ts
+++ b/packages/gateway/test/sync.test.ts
@@ -257,6 +257,18 @@ function insertKnowledge(id: string, content: string): void {
     )
     .run(id, pid, content, now(), now());
 }
+
+// Knowledge is append-only (A2): a pulled change appends a new version and a
+// pulled delete appends a death-cert, so the CURRENT live content is in
+// knowledge_current keyed by logical_id — not the base row addressed by getRowById.
+function currentContent(logicalId: string): string | null {
+  const r = db()
+    .query(
+      "SELECT content FROM knowledge_current WHERE COALESCE(logical_id, id) = ?",
+    )
+    .get(logicalId) as { content: string } | undefined;
+  return r?.content ?? null;
+}
 function insertEntity(id: string): void {
   const pid = ensureProject("/tmp/lore-sync-engine");
   db()
@@ -597,7 +609,7 @@ describe("pullOnce", () => {
       updated_at: new Date(2_000_000).toISOString(),
     });
     await pullOnce(makeClient() as never);
-    expect(syncData.getRowById("knowledge", "kr")?.content).toBe("from server");
+    expect(currentContent("kr")).toBe("from server");
 
     syncData.withApplying(() => insertKnowledge("kd", "x"));
     tableRows("knowledge").push({
@@ -608,7 +620,7 @@ describe("pullOnce", () => {
       updated_at: new Date(3_000_000).toISOString(),
     } as never);
     await pullOnce(makeClient() as never);
-    expect(syncData.getRowById("knowledge", "kd")).toBeNull();
+    expect(currentContent("kd")).toBeNull(); // death-cert applied → no live current
   });
 
   test("a remote tombstone that RETAINED its content_hash still deletes a content-identical local row", async () => {
@@ -629,7 +641,7 @@ describe("pullOnce", () => {
     remoteRow.updated_at = new Date(9_000_000).toISOString(); // past the pull cursor
     expect(typeof remoteRow.content_hash).toBe("string"); // hash intact (the trap)
     const r = await pullOnce(makeClient() as never);
-    expect(syncData.getRowById("knowledge", "kt")).toBeNull(); // delete propagated
+    expect(currentContent("kt")).toBeNull(); // delete propagated (death-cert)
     expect(r.pulled).toBe(1); // a clean apply…
     expect(r.conflicts).toBe(0); // …not a conflict
   });
@@ -652,7 +664,7 @@ describe("pullOnce", () => {
     });
     const r = await pullOnce(makeClient() as never);
     expect(r.conflicts).toBe(1);
-    expect(syncData.getRowById("knowledge", "kc")?.content).toBe("remote-edit");
+    expect(currentContent("kc")).toBe("remote-edit"); // remote wins → new current version
     // The discarded local edit is recoverable from sync_conflicts.local_content.
     const row = db()
       .query("SELECT local_content FROM sync_conflicts WHERE row_id='kc'")


### PR DESCRIPTION
**Epic #821 · A2 (#823), sub-PR 3.** Completes the append-only knowledge story across the sync boundary. **Client-only — no remote migration** (pre-flip rows were keyed `id == logical_id` (v1) already, and sync is release-gated so the remote has no real data to migrate).

Makes the remote a **CURRENT-only mirror, ONE row per logical entry keyed by `logical_id`** — coalescing all of an entry's versions to a single remote row and converging `id`↔`logical_id` across devices.

## Model (settled)
A remote content change to an existing `logical_id` is "same concern, new value" arriving from another device → **append a new local version** (mirrors a local `update()`). Idempotency comes from `content_hash` (re-pulling your own pushed content is a no-op → no ping-pong). Version *history* stays local; only *current content* converges.

## Push — `knowledgePushPlan` (replaces `knowledgeSyncOp`)
Resolve the outbox version row → `logical_id`; push the **current** version's content under `id = logical_id`, or **soft-delete** `id = logical_id` when there's no live current. `sync_state` keyed by `logical_id`, so an entry's version churn coalesces to one upsert (`content_hash` dedups the rest). `pushEntry` drives upsert/delete by the `logical_id` (`effectiveId`).

## Pull — `applyRemoteKnowledge` / `applyRemoteKnowledgeDelete`
Apply a `logical_id`-keyed remote row into the local **append-only** model (under apply-suppression + a txn for the single-current invariant):

| local state for L | remote live (upsert) | remote deleted |
|---|---|---|
| none | INSERT v1 (id=L) | no-op |
| live, content == remote | converge metadata in place | death-cert |
| live, content != remote | append new current version | death-cert |
| only superseded/death-cert | append new current (revive) | no-op |

`hasPendingKnowledgeChange` resolves pending edits **by `logical_id`** (the outbox holds version ids), so a pull never silently overwrites an unpushed local edit without logging the conflict. `applyRemoteUpsert` no longer special-cases knowledge (entity graph only).

## Why no engine-behavior change
v1 entries (`id == logical_id`) push/apply exactly as before, so the existing engine + property suites keep their semantics; only the live-set comparison in the convergence property moves to `logical_id` over current-live versions.

## Tests
- `applyRemoteKnowledge` matrix: new / append-on-change / idempotent / metadata-only / delete→death-cert / revive.
- **Round-trip**: device A's multi-version entry → push plan → peer-apply on B → **ONE coalesced version** on B (proves convergence).
- `knowledgePushPlan` coalescing (superseded + current → one logical-keyed upsert).
- Property **convergence** now compares the live set by `logical_id` over current-live versions — **8/8 stable**, 60 random op-sequences each.
- Core **1741** + gateway **1996** green; typecheck + lint clean.

## Resolves / unblocks
Remote row accumulation, residual-byte persistence, cross-device `id`↔`logical_id` divergence → **lifts the release gate** on `lore sync enable`. Follow-ups: knowledge_meta convergent confidence (sub-PR 3b), compaction/GC (sub-PR 4).