### PR TITLE
fix(gateway): retry provider error envelopes wrapped in HTTP 200 worker responses

### DIFF
--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -1214,6 +1214,28 @@ export function createGatewayLLMClient(
                       `worker=${opts?.workerID ?? "unknown"} ` +
                       `session=${opts?.sessionID?.slice(0, 16) ?? "none"}`,
                   );
+                  // Enrich the span with retry metadata, matching the HTTP-level
+                  // exhaustion path — this path retries up to maxRetries times, so
+                  // those attempts must not be invisible in tracing. The wire
+                  // status was a misleading 200, so also surface the embedded code.
+                  if (retryCount > 0) {
+                    span.setAttribute("lore.retry.count", retryCount);
+                    span.setAttribute(
+                      "lore.retry.total_delay_ms",
+                      totalDelayMs,
+                    );
+                    if (lastRetryAfterMs != null) {
+                      span.setAttribute(
+                        "lore.retry.last_retry_after_ms",
+                        lastRetryAfterMs,
+                      );
+                    }
+                    span.setAttribute("lore.retry.final_status", finalStatus);
+                    span.setAttribute(
+                      "lore.retry.body_error_code",
+                      bodyErrCode,
+                    );
+                  }
                   recordWorkerFailure(
                     opts?.sessionID ?? "_unknown",
                     opts?.workerID ?? "unknown",

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -1205,41 +1205,61 @@ export function createGatewayLLMClient(
                     await sleep(delay);
                     continue;
                   }
-                  // Exhausted: a persistent upstream transient, NOT a model
-                  // capability fact — record no-response (not worker-incapable)
-                  // so a flaky upstream never marks a capable model incapable.
+                  // Exhausted. Mirror the HTTP-level exhaustion path for full
+                  // observability parity (Seer): log, capture to Sentry for
+                  // alerting, enrich the span with retry metadata, and mark the
+                  // span errored. This path retries up to maxRetries times, so
+                  // those attempts must not be invisible in tracing. Worker-health
+                  // reason matches the HTTP transient path (rate-limit/upstream-
+                  // error) — NEVER worker-incapable: the upstream responded with a
+                  // transient error, which must not mark a capable model incapable.
                   log.warn(
                     `worker upstream embedded ${bodyErrCode} error persisted after ` +
                       `${maxRetries + 1} attempts — model=${model.providerID}/${model.modelID} ` +
                       `worker=${opts?.workerID ?? "unknown"} ` +
                       `session=${opts?.sessionID?.slice(0, 16) ?? "none"}`,
                   );
-                  // Enrich the span with retry metadata, matching the HTTP-level
-                  // exhaustion path — this path retries up to maxRetries times, so
-                  // those attempts must not be invisible in tracing. The wire
-                  // status was a misleading 200, so also surface the embedded code.
-                  if (retryCount > 0) {
-                    span.setAttribute("lore.retry.count", retryCount);
-                    span.setAttribute(
-                      "lore.retry.total_delay_ms",
-                      totalDelayMs,
-                    );
-                    if (lastRetryAfterMs != null) {
-                      span.setAttribute(
-                        "lore.retry.last_retry_after_ms",
+                  Sentry.captureException(
+                    new Error(
+                      `Worker upstream exhausted ${maxRetries + 1} retries: HTTP 200 embedded ${bodyErrCode}`,
+                    ),
+                    {
+                      fingerprint: [
+                        "LOREAI-GATEWAY",
+                        "worker-retry-exhausted",
+                        String(bodyErrCode),
+                      ],
+                      extra: {
+                        // Wire status was a misleading 200; the embedded code is
+                        // the real failure signal.
+                        status: 200,
+                        bodyErrorCode: bodyErrCode,
+                        attempts: maxRetries + 1,
+                        totalDelayMs,
                         lastRetryAfterMs,
-                      );
-                    }
-                    span.setAttribute("lore.retry.final_status", finalStatus);
+                        model: model.modelID,
+                        workerID: opts?.workerID ?? "unknown",
+                      },
+                    },
+                  );
+                  span.setAttribute("lore.retry.count", retryCount);
+                  span.setAttribute("lore.retry.total_delay_ms", totalDelayMs);
+                  if (lastRetryAfterMs != null) {
                     span.setAttribute(
-                      "lore.retry.body_error_code",
-                      bodyErrCode,
+                      "lore.retry.last_retry_after_ms",
+                      lastRetryAfterMs,
                     );
                   }
+                  span.setAttribute("lore.retry.final_status", finalStatus);
+                  span.setAttribute("lore.retry.body_error_code", bodyErrCode);
+                  span.setStatus({
+                    code: 2,
+                    message: "embedded error exhausted retries",
+                  });
                   recordWorkerFailure(
                     opts?.sessionID ?? "_unknown",
                     opts?.workerID ?? "unknown",
-                    "no-response",
+                    bodyErrCode === 429 ? "rate-limit" : "upstream-error",
                   );
                   return null;
                 }

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -61,8 +61,10 @@ export const activeWorkerCalls = new Set<string>();
 // Retry helpers (exported for testing)
 // ---------------------------------------------------------------------------
 
-/** HTTP status codes that are transient and worth retrying. */
-const TRANSIENT_CODES = new Set([429, 500, 502, 503, 529]);
+/** HTTP status codes that are transient and worth retrying. 504 (Gateway
+ *  Timeout) is included: upstream gateways (esp. OpenRouter fronting slow free
+ *  models) return it on transient upstream timeouts — a retry usually clears. */
+const TRANSIENT_CODES = new Set([429, 500, 502, 503, 504, 529]);
 
 /** HTTP status codes indicating permanent auth failure. */
 export const AUTH_ERROR_CODES = new Set([401, 403]);
@@ -870,6 +872,27 @@ function extractFinishReason(rawData: unknown): string | undefined {
   }
 }
 
+/**
+ * Detect a provider error envelope embedded in an otherwise-2xx body and return
+ * its numeric status code, if any. Gateways such as OpenRouter surface an
+ * UPSTREAM failure as an HTTP 200 whose body is `{"error":{"code":504,...}}`
+ * instead of propagating the status line — so the status-keyed transient retry
+ * never sees it and the body parses as a "successful but empty" completion.
+ * Returns the embedded code (number) when present, else null. Only the shape
+ * `{ error: { code: <number|numeric-string> } }` is recognized; a normal
+ * completion has no top-level `error` object, so false positives are unlikely.
+ * See #899.
+ */
+function extractBodyErrorCode(rawData: unknown): number | null {
+  if (!rawData || typeof rawData !== "object") return null;
+  const err = (rawData as { error?: unknown }).error;
+  if (!err || typeof err !== "object") return null;
+  const code = (err as { code?: unknown }).code;
+  if (typeof code === "number" && Number.isFinite(code)) return code;
+  if (typeof code === "string" && /^\d+$/.test(code)) return Number(code);
+  return null;
+}
+
 function describeEmptyWorkerResponse(rawData: unknown): string {
   const fields: string[] = [];
   let finishReason: string | undefined;
@@ -1146,6 +1169,58 @@ export function createGatewayLLMClient(
                 const rawData = ct.includes("text/event-stream")
                   ? await extractJSONFromSSE(response)
                   : await response.json();
+
+                // A 2xx whose body is a provider error envelope (e.g. OpenRouter
+                // surfacing an upstream timeout as HTTP 200 + {error:{code:504}})
+                // is NOT a usable completion. The status-keyed transient handling
+                // below never sees it, and parseWorkerResponse would yield no text
+                // → it would be miscounted as an empty/incapable response. Route a
+                // transient embedded code into the SAME retry/backoff ladder as a
+                // real HTTP-level transient. Non-transient embedded codes fall
+                // through to the normal empty-response handling (no regression). #899
+                const bodyErrCode = extractBodyErrorCode(rawData);
+                if (bodyErrCode != null && TRANSIENT_CODES.has(bodyErrCode)) {
+                  // Trip the breaker once on an embedded 429, matching the
+                  // HTTP-level 429 path (background work to this provider pauses
+                  // while this call rides out the limit; other providers drain).
+                  if (bodyErrCode === 429 && !breakerTripped) {
+                    breakerTripped = true;
+                    const cbRetryAfter = parseRetryAfter(response);
+                    tripCircuitBreaker(
+                      cbRetryAfter ? Math.ceil(cbRetryAfter / 1000) : undefined,
+                      model.providerID,
+                    );
+                  }
+                  if (attempt < maxRetries) {
+                    const retryAfter = parseRetryAfter(response);
+                    const delay = backoffMs(attempt, retryAfter);
+                    retryCount++;
+                    totalDelayMs += delay;
+                    if (retryAfter != null) lastRetryAfterMs = retryAfter;
+                    log.warn(
+                      `worker upstream returned HTTP 200 with an embedded ${bodyErrCode} ` +
+                        `error (attempt ${attempt + 1}/${maxRetries + 1}), retrying in ${delay}ms ` +
+                        `— model=${model.providerID}/${model.modelID} worker=${opts?.workerID ?? "unknown"}`,
+                    );
+                    await sleep(delay);
+                    continue;
+                  }
+                  // Exhausted: a persistent upstream transient, NOT a model
+                  // capability fact — record no-response (not worker-incapable)
+                  // so a flaky upstream never marks a capable model incapable.
+                  log.warn(
+                    `worker upstream embedded ${bodyErrCode} error persisted after ` +
+                      `${maxRetries + 1} attempts — model=${model.providerID}/${model.modelID} ` +
+                      `worker=${opts?.workerID ?? "unknown"} ` +
+                      `session=${opts?.sessionID?.slice(0, 16) ?? "none"}`,
+                  );
+                  recordWorkerFailure(
+                    opts?.sessionID ?? "_unknown",
+                    opts?.workerID ?? "unknown",
+                    "no-response",
+                  );
+                  return null;
+                }
 
                 // Parse response based on protocol
                 const parsed = parseWorkerResponse(target.protocol, rawData);

--- a/packages/gateway/test/llm-adapter.test.ts
+++ b/packages/gateway/test/llm-adapter.test.ts
@@ -386,6 +386,132 @@ describe("worker 429 trips the circuit breaker (urgent included)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Provider error envelopes wrapped in HTTP 200 bodies (#899)
+// ---------------------------------------------------------------------------
+
+describe("worker handles provider error envelopes in HTTP 200 bodies (#899)", () => {
+  const mockFetch = vi.mocked(upstreamFetch);
+  const realMaxRetries = process.env.LORE_MAX_RETRIES;
+  const UPSTREAMS = {
+    anthropic: "https://api.anthropic.com",
+    openai: "https://api.openai.com",
+  };
+
+  beforeEach(() => {
+    process.env.LORE_MAX_RETRIES = "3";
+    resetBackgroundLimiter();
+    vi.mocked(recordWorkerFailure).mockClear();
+  });
+  afterEach(() => {
+    mockFetch.mockReset();
+    clearAllCosts();
+    resetBackgroundLimiter();
+    if (realMaxRetries === undefined) delete process.env.LORE_MAX_RETRIES;
+    else process.env.LORE_MAX_RETRIES = realMaxRetries;
+  });
+
+  // HTTP 200 whose body is a provider error envelope. retry-after:0 keeps the
+  // retries instant so the loop runs to exhaustion without real waits.
+  function envelope200(code: number) {
+    return new Response(
+      JSON.stringify({ error: { message: "Provider returned error", code } }),
+      {
+        status: 200,
+        headers: { "content-type": "application/json", "retry-after": "0" },
+      },
+    );
+  }
+  function anthropicSuccess() {
+    return new Response(
+      JSON.stringify({
+        content: [{ type: "text", text: "recovered" }],
+        model: "claude-test",
+        usage: { input_tokens: 1, output_tokens: 1 },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  }
+  function client() {
+    return createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "sk-ant-test" }),
+      { providerID: "anthropic", modelID: "claude-test" },
+    );
+  }
+
+  test("retries a 200 + embedded 504 and recovers when the retry succeeds", async () => {
+    mockFetch
+      .mockResolvedValueOnce(envelope200(504))
+      .mockResolvedValueOnce(anthropicSuccess());
+    const text = await client().prompt("system", "user", {
+      sessionID: "s-recover",
+      workerID: "lore-distill",
+    });
+    expect(text).toBe("recovered");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  test("retries to exhaustion on a persistent 200 + embedded 504 → null, records no-response (not incapable)", async () => {
+    // mockImplementation (not mockResolvedValue): each retry needs a FRESH
+    // Response — a body can only be read once.
+    mockFetch.mockImplementation(async () => envelope200(504));
+    const text = await client().prompt("system", "user", {
+      sessionID: "s-exhaust",
+      workerID: "lore-distill",
+    });
+    expect(text).toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(4); // maxRetries(3) + 1
+    expect(recordWorkerFailure).toHaveBeenCalledWith(
+      "s-exhaust",
+      "lore-distill",
+      "no-response",
+    );
+    // A flaky upstream must never mark a capable model incapable.
+    expect(recordWorkerFailure).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      "worker-incapable",
+    );
+  });
+
+  test("does NOT retry a 200 + embedded NON-transient (400) error", async () => {
+    mockFetch.mockResolvedValue(envelope200(400));
+    const text = await client().prompt("system", "user", {
+      sessionID: "s-400",
+      workerID: "lore-distill",
+    });
+    expect(text).toBeNull();
+    // Falls through to the existing empty-response handling — no retry.
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test("an embedded 429 trips the provider circuit breaker", async () => {
+    mockFetch.mockImplementation(async () => envelope200(429));
+    await client().prompt("system", "user", {
+      sessionID: "s-429",
+      workerID: "lore-distill",
+    });
+    expect(getConsecutiveTrips("anthropic")).toBe(1);
+  });
+
+  test("a real HTTP 504 is now transient and retried (was a hard fail)", async () => {
+    mockFetch.mockImplementation(
+      async () =>
+        new Response("gateway timeout", {
+          status: 504,
+          headers: { "retry-after": "0" },
+        }),
+    );
+    const text = await client().prompt("system", "user", {
+      sessionID: "s-http504",
+      workerID: "lore-distill",
+    });
+    expect(text).toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(4); // maxRetries(3) + 1
+  });
+});
+
+// ---------------------------------------------------------------------------
 // createGatewayLLMClient.prompt() — request building, success, and guards
 // ---------------------------------------------------------------------------
 

--- a/packages/gateway/test/llm-adapter.test.ts
+++ b/packages/gateway/test/llm-adapter.test.ts
@@ -451,7 +451,7 @@ describe("worker handles provider error envelopes in HTTP 200 bodies (#899)", ()
     expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 
-  test("retries to exhaustion on a persistent 200 + embedded 504 → null, records no-response (not incapable)", async () => {
+  test("retries to exhaustion on a persistent 200 + embedded 504 → null, records upstream-error (not incapable)", async () => {
     // mockImplementation (not mockResolvedValue): each retry needs a FRESH
     // Response — a body can only be read once.
     mockFetch.mockImplementation(async () => envelope200(504));
@@ -461,10 +461,11 @@ describe("worker handles provider error envelopes in HTTP 200 bodies (#899)", ()
     });
     expect(text).toBeNull();
     expect(mockFetch).toHaveBeenCalledTimes(4); // maxRetries(3) + 1
+    // Mirrors the HTTP-level transient exhaustion reason (504 → upstream-error).
     expect(recordWorkerFailure).toHaveBeenCalledWith(
       "s-exhaust",
       "lore-distill",
-      "no-response",
+      "upstream-error",
     );
     // A flaky upstream must never mark a capable model incapable.
     expect(recordWorkerFailure).not.toHaveBeenCalledWith(

--- a/packages/gateway/test/llm-adapter.test.ts
+++ b/packages/gateway/test/llm-adapter.test.ts
@@ -475,6 +475,10 @@ describe("worker handles provider error envelopes in HTTP 200 bodies (#899)", ()
   });
 
   test("does NOT retry a 200 + embedded NON-transient (400) error", async () => {
+    // Guards the TRANSIENT_CODES gate: a non-transient embedded code must fall
+    // through to the normal empty-response path (single call, no retry), not be
+    // treated as retryable. (A 400 envelope took the same null path pre-PR too,
+    // so this asserts the gate condition, not the block's existence.)
     mockFetch.mockResolvedValue(envelope200(400));
     const text = await client().prompt("system", "user", {
       sessionID: "s-400",


### PR DESCRIPTION
Closes #899. The third fix from the worker-failure diagnosis (after #894's provider-aware no-auth skip).

## Root cause
Gateways like OpenRouter surface an **upstream** transient failure as an **HTTP 200** whose body is a provider error envelope:
```
{"error":{"message":"Provider returned error","code":504}}
```
The worker retry loop keyed transient detection on `response.status`, so a 200 took the success path, `parseWorkerResponse` found no `text`, and it was miscounted as an **empty/incapable** completion — never retried. Non-streaming worker calls hit this constantly on slow free models (the gateway must buffer the whole generation before responding; streaming user turns don't).

## Fix
- `extractBodyErrorCode()`: detect `{error:{code}}` in a 2xx body (only that shape — a normal completion has no top-level `error` object, so false positives are unlikely).
- In the `response.ok` branch, before treating the body as a successful-but-empty completion, route a **transient** embedded code (in `TRANSIENT_CODES`) into the **same** retry/backoff ladder as a real HTTP-level transient: honor `Retry-After`, trip the breaker once on an embedded `429`, and record `no-response` (**not** `worker-incapable`) on exhaustion so a flaky upstream never marks a capable model incapable.
- Add `504` to `TRANSIENT_CODES` so HTTP-level 504s also retry (it was hard-failing on the first attempt).

Non-transient embedded codes fall through to the existing empty-response handling — **no regression**. Provider-general (any OpenRouter-style gateway wrapping upstream errors in 200s).

## Tests (5)
recovery-on-retry · retry-to-exhaustion (asserts `no-response`, **not** `worker-incapable`) · non-transient (400) not retried · embedded-429 trips the breaker · real HTTP 504 retried.

typecheck ✔ lint ✔ full suite **3794 passed**.