### PR TITLE
feat(core): outcome-reward — adjust knowledge confidence by verifier results (#497)

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -270,11 +270,23 @@ export const LoreConfig = z.object({
         .describe(
           "Auto-create gotcha entries from recurring tool failures. Default false (noisy; can churn the LTM cache).",
         ),
+      /** Adjust knowledge confidence by within-session verifier outcomes (#497):
+       *  an entry injected into a session whose test/build/typecheck/lint runs
+       *  passed gets a small (capped) confidence boost; one present while they
+       *  failed gets a larger penalty. Applied once per entry per session on
+       *  idle. cross_project (shared) entries are never adjusted. Default true. */
+      outcomeReward: z
+        .boolean()
+        .default(true)
+        .describe(
+          "Adjust knowledge confidence by within-session verifier (test/build/typecheck/lint) outcomes. Default: true.",
+        ),
     })
     .default({
       enabled: true,
       maxEntityInject: 30,
       autoToolFailureGotchas: false,
+      outcomeReward: true,
     })
     .describe("Long-term knowledge (curator, entity injection) controls."),
   curator: z

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1888,6 +1888,17 @@ function recoverMissingObjects(database: Database) {
       );
     }
   }
+  // Version 53: tool_calls.verifier (outcome-reward, #497). Recover the column
+  // independently — the CREATE TABLE IF NOT EXISTS above is a no-op on an
+  // existing tool_calls table and cannot add a missing column to it.
+  {
+    const tcols = database
+      .query("PRAGMA table_info(tool_calls)")
+      .all() as Array<{ name: string }>;
+    if (!tcols.some((c) => c.name === "verifier")) {
+      database.exec("ALTER TABLE tool_calls ADD COLUMN verifier INTEGER;");
+    }
+  }
 }
 
 /**

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1348,6 +1348,31 @@ const MIGRATIONS: string[] = [
   CREATE INDEX IF NOT EXISTS idx_sync_outbox_table_row
     ON sync_outbox (table_name, row_id, seq);
   `,
+
+  `
+  -- Version 53: outcome-reward loop (#497). Two additions:
+  --  (a) tool_calls.verifier — 1 when the tool call was a test/build/typecheck/
+  --      lint runner, so a session's verifier outcome can be derived precisely
+  --      (a failing 'pnpm test' vs an incidental 'grep' miss). NULL = unknown.
+  --  (b) knowledge_session_injections — which knowledge entries were injected
+  --      into a session, keyed by logical_id (A2 stable identity, survives
+  --      version edits). The idle pass credits each entry's confidence by the
+  --      session's verifier verdict; 'credited' makes that idempotent (at most
+  --      once per session per entry). Project-scoped only — cross_project
+  --      entries are never recorded (the loop must never auto-demote shared
+  --      knowledge).
+  ALTER TABLE tool_calls ADD COLUMN verifier INTEGER;
+  CREATE TABLE IF NOT EXISTS knowledge_session_injections (
+    session_id  TEXT NOT NULL,
+    logical_id  TEXT NOT NULL,
+    project_id  TEXT NOT NULL,
+    created_at  INTEGER NOT NULL,
+    credited    INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (session_id, logical_id)
+  );
+  CREATE INDEX IF NOT EXISTS idx_ksi_session_uncredited
+    ON knowledge_session_injections (session_id, credited);
+  `,
 ];
 
 /**
@@ -1702,12 +1727,23 @@ function recoverMissingObjects(database: Database) {
       error_type    TEXT,
       error_message TEXT,
       duration_ms   INTEGER,
-      created_at    INTEGER NOT NULL
+      created_at    INTEGER NOT NULL,
+      verifier      INTEGER
     );
     CREATE INDEX IF NOT EXISTS idx_tool_calls_project_tool_status
       ON tool_calls (project_id, tool, status);
     CREATE INDEX IF NOT EXISTS idx_tool_calls_project_session
       ON tool_calls (project_id, session_id);
+    CREATE TABLE IF NOT EXISTS knowledge_session_injections (
+      session_id  TEXT NOT NULL,
+      logical_id  TEXT NOT NULL,
+      project_id  TEXT NOT NULL,
+      created_at  INTEGER NOT NULL,
+      credited    INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (session_id, logical_id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_ksi_session_uncredited
+      ON knowledge_session_injections (session_id, credited);
     CREATE TABLE IF NOT EXISTS knowledge_transfers (
       knowledge_id           TEXT NOT NULL,
       recalled_in_project_id TEXT NOT NULL,

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -883,12 +883,16 @@ export function recordSessionInjections(
      VALUES (?, ?, ?, ?, 0)
      ON CONFLICT(session_id, logical_id) DO NOTHING`,
   );
-  for (const e of entries) {
-    if (!e.logical_id) continue;
-    if (e.cross_project === 1) continue;
-    if (e.category === "lat.md") continue;
-    stmt.run(sessionID, e.logical_id, pid, now);
-  }
+  // One transaction for the whole batch (matches markInjected's single write and
+  // avoids a per-entry auto-commit on the request hot path).
+  withTransaction(() => {
+    for (const e of entries) {
+      if (!e.logical_id) continue;
+      if (e.cross_project === 1) continue;
+      if (e.category === "lat.md") continue;
+      stmt.run(sessionID, e.logical_id, pid, now);
+    }
+  });
 }
 
 /** Outcome of crediting one session's injected entries. */
@@ -932,42 +936,48 @@ export function creditSessionOutcome(
   const ids = uncredited.map((r) => r.logical_id);
   const placeholders = ids.map(() => "?").join(",");
   const now = Date.now();
-  // Adjust the current version of each injected logical entry. The cross_project
-  // = 0 guard is a backstop (injections already exclude shared entries).
-  if (verdict === "pass") {
-    db()
-      .query(
-        `UPDATE knowledge
-         SET confidence = MIN(?, confidence + ?), last_reinforced_at = ?
-         WHERE is_current = 1 AND cross_project = 0 AND project_id = ?
-           AND confidence < ? AND logical_id IN (${placeholders})`,
-      )
-      .run(
-        OUTCOME_BOOST_CEILING,
-        OUTCOME_REWARD,
-        now,
-        pid,
-        OUTCOME_BOOST_CEILING,
-        ...ids,
-      );
-  } else {
-    db()
-      .query(
-        `UPDATE knowledge
-         SET confidence = MAX(0, confidence - ?), last_reinforced_at = ?
-         WHERE is_current = 1 AND cross_project = 0 AND project_id = ?
-           AND logical_id IN (${placeholders})`,
-      )
-      .run(OUTCOME_PENALTY, now, pid, ...ids);
-  }
+  // Apply the confidence adjustment and the credited-flag write atomically, so a
+  // crash between them can't re-credit (double-adjust) on restart.
+  withTransaction(() => {
+    // Adjust the current, live version of each injected logical entry. The
+    // cross_project = 0 guard is a real backstop (a PROMOTED entry keeps its
+    // origin project_id but has cross_project = 1 — it must never be adjusted);
+    // is_deleted = 0 skips death-certificate versions.
+    if (verdict === "pass") {
+      db()
+        .query(
+          `UPDATE knowledge
+           SET confidence = MIN(?, confidence + ?), last_reinforced_at = ?
+           WHERE is_current = 1 AND is_deleted = 0 AND cross_project = 0
+             AND project_id = ? AND confidence < ? AND logical_id IN (${placeholders})`,
+        )
+        .run(
+          OUTCOME_BOOST_CEILING,
+          OUTCOME_REWARD,
+          now,
+          pid,
+          OUTCOME_BOOST_CEILING,
+          ...ids,
+        );
+    } else {
+      db()
+        .query(
+          `UPDATE knowledge
+           SET confidence = MAX(0, confidence - ?), last_reinforced_at = ?
+           WHERE is_current = 1 AND is_deleted = 0 AND cross_project = 0
+             AND project_id = ? AND logical_id IN (${placeholders})`,
+        )
+        .run(OUTCOME_PENALTY, now, pid, ...ids);
+    }
 
-  // Mark this session's injections credited so a later idle tick is a no-op.
-  db()
-    .query(
-      `UPDATE knowledge_session_injections SET credited = 1
-       WHERE session_id = ? AND project_id = ? AND credited = 0`,
-    )
-    .run(sessionID, pid);
+    // Mark this session's injections credited so a later idle tick is a no-op.
+    db()
+      .query(
+        `UPDATE knowledge_session_injections SET credited = 1
+         WHERE session_id = ? AND project_id = ? AND credited = 0`,
+      )
+      .run(sessionID, pid);
+  });
 
   return { verdict, credited: ids.length };
 }

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -10,6 +10,7 @@ import {
   runRelaxedSearch,
 } from "./search";
 import * as embedding from "./embedding";
+import { sessionVerifierVerdict } from "./tool-trace";
 import * as latReader from "./lat-reader";
 import * as log from "./log";
 
@@ -809,6 +810,22 @@ export const DECAY_GRACE_MS = 7 * 24 * 60 * 60 * 1000; // 7d
 /** Confidence removed per decay pass for an unreinforced entry. */
 export const DECAY_STEP = 0.1;
 
+// --- Outcome-reward loop (#497) --------------------------------------------
+// Within-session co-occurrence: an entry injected into a session is credited
+// by that session's verifier verdict. Deliberately asymmetric and bounded:
+//  - the boost is SMALL and CAPPED at a ceiling, so co-occurrence with passing
+//    verifiers can lift an under-confident-but-useful entry without ever
+//    manufacturing the 0.9–1.0 cluster (mere selection ≠ proven certainty);
+//  - the penalty is LARGER and uncapped (down to 0), because an entry present
+//    while verifiers fail is the more decisive signal.
+/** Confidence added to an injected entry when the session's verifiers passed. */
+export const OUTCOME_REWARD = 0.02;
+/** Confidence removed from an injected entry when the session's verifiers failed. */
+export const OUTCOME_PENALTY = 0.05;
+/** The outcome boost never lifts confidence above this — it only rescues
+ *  under-confident entries; the high band stays reserved for explicit signals. */
+export const OUTCOME_BOOST_CEILING = 0.8;
+
 /**
  * Mark entries as injected into a prompt this turn: reset the decay clock
  * WITHOUT changing confidence. Selection by forSession means "still relevant",
@@ -841,6 +858,118 @@ export function reinforce(id: string, delta: number = REINFORCE_STEP): void {
        WHERE id = ? AND is_current = 1`,
     )
     .run(delta, Date.now(), id);
+}
+
+/**
+ * Record which knowledge entries were injected into a session, for the
+ * outcome-reward loop (#497). Keyed by `logical_id` (the A2 stable identity), so
+ * crediting survives a version edit between injection and the idle credit pass.
+ * Idempotent per (session, entry) via the PK — re-injection across turns does
+ * NOT reset the `credited` flag, so an entry is credited at most once per
+ * session. cross_project (shared) and synthetic (lat.md) entries are skipped:
+ * the loop must never auto-adjust shared knowledge, and synthetics aren't rows.
+ */
+export function recordSessionInjections(
+  sessionID: string | undefined,
+  projectPath: string,
+  entries: { logical_id?: string; cross_project?: number; category?: string }[],
+): void {
+  if (!sessionID) return;
+  const pid = ensureProject(projectPath);
+  const now = Date.now();
+  const stmt = db().query(
+    `INSERT INTO knowledge_session_injections
+       (session_id, logical_id, project_id, created_at, credited)
+     VALUES (?, ?, ?, ?, 0)
+     ON CONFLICT(session_id, logical_id) DO NOTHING`,
+  );
+  for (const e of entries) {
+    if (!e.logical_id) continue;
+    if (e.cross_project === 1) continue;
+    if (e.category === "lat.md") continue;
+    stmt.run(sessionID, e.logical_id, pid, now);
+  }
+}
+
+/** Outcome of crediting one session's injected entries. */
+export type OutcomeCreditResult = {
+  verdict: "pass" | "fail" | "none";
+  /** Number of injected entries whose confidence was adjusted. */
+  credited: number;
+};
+
+/**
+ * Credit a session's injected knowledge entries by its verifier verdict (#497).
+ * Runs at idle. Within-session co-occurrence: entries that were in-context when
+ * the session's verifiers passed get a small (capped) boost; entries in-context
+ * when verifiers failed get a larger penalty. Applied at most once per entry per
+ * session (the `credited` flag), so a later idle tick won't re-credit.
+ *
+ * Invariants:
+ *  - `none` verdict (no verifier ran) is a no-op — never guess.
+ *  - cross_project (shared) entries are never touched (the injection log already
+ *    excludes them; the UPDATE re-asserts `cross_project = 0` as a backstop).
+ *  - the boost is clamped to OUTCOME_BOOST_CEILING; the penalty floors at 0.
+ *  - both write `last_reinforced_at` (the entry was demonstrably in use), so a
+ *    credited entry won't also be aged out by decay this cycle.
+ */
+export function creditSessionOutcome(
+  sessionID: string,
+  projectPath: string,
+): OutcomeCreditResult {
+  const pid = ensureProject(projectPath);
+  const uncredited = db()
+    .query(
+      `SELECT logical_id FROM knowledge_session_injections
+       WHERE session_id = ? AND project_id = ? AND credited = 0`,
+    )
+    .all(sessionID, pid) as { logical_id: string }[];
+  if (uncredited.length === 0) return { verdict: "none", credited: 0 };
+
+  const verdict = sessionVerifierVerdict(projectPath, sessionID);
+  if (verdict === "none") return { verdict, credited: 0 };
+
+  const ids = uncredited.map((r) => r.logical_id);
+  const placeholders = ids.map(() => "?").join(",");
+  const now = Date.now();
+  // Adjust the current version of each injected logical entry. The cross_project
+  // = 0 guard is a backstop (injections already exclude shared entries).
+  if (verdict === "pass") {
+    db()
+      .query(
+        `UPDATE knowledge
+         SET confidence = MIN(?, confidence + ?), last_reinforced_at = ?
+         WHERE is_current = 1 AND cross_project = 0 AND project_id = ?
+           AND confidence < ? AND logical_id IN (${placeholders})`,
+      )
+      .run(
+        OUTCOME_BOOST_CEILING,
+        OUTCOME_REWARD,
+        now,
+        pid,
+        OUTCOME_BOOST_CEILING,
+        ...ids,
+      );
+  } else {
+    db()
+      .query(
+        `UPDATE knowledge
+         SET confidence = MAX(0, confidence - ?), last_reinforced_at = ?
+         WHERE is_current = 1 AND cross_project = 0 AND project_id = ?
+           AND logical_id IN (${placeholders})`,
+      )
+      .run(OUTCOME_PENALTY, now, pid, ...ids);
+  }
+
+  // Mark this session's injections credited so a later idle tick is a no-op.
+  db()
+    .query(
+      `UPDATE knowledge_session_injections SET credited = 1
+       WHERE session_id = ? AND project_id = ? AND credited = 0`,
+    )
+    .run(sessionID, pid);
+
+  return { verdict, credited: ids.length };
 }
 
 /**
@@ -1194,6 +1323,7 @@ export async function forSession(
     // deleting an actively-used directive. Resets the decay clock only.
     try {
       markInjected(result.map((e) => e.id));
+      recordSessionInjections(sessionID, projectPath, result);
     } catch (err) {
       log.warn(
         "forSession(preference): reinforcement failed (non-fatal):",
@@ -1458,6 +1588,7 @@ export async function forSession(
     markInjected(
       result.filter((e) => e.category !== "lat.md").map((e) => e.id),
     );
+    recordSessionInjections(sessionID, projectPath, result);
   } catch (err) {
     log.warn("forSession: reinforcement failed (non-fatal):", err);
   }

--- a/packages/core/src/temporal.ts
+++ b/packages/core/src/temporal.ts
@@ -2,7 +2,11 @@ import { db, ensureProject } from "./db";
 import { runRelaxedSearch } from "./search";
 import { sanitizeSurrogates } from "./markdown";
 import * as embedding from "./embedding";
-import { classifyToolError, MAX_ERROR_MESSAGE_LEN } from "./tool-trace";
+import {
+  classifyToolError,
+  isVerifierCall,
+  MAX_ERROR_MESSAGE_LEN,
+} from "./tool-trace";
 import type { LoreMessage, LorePart, LoreToolState } from "./types";
 import { isTextPart, isReasoningPart, isToolPart } from "./types";
 
@@ -162,13 +166,16 @@ export function recordToolCalls(input: {
   // revert a resolved row back to pending on a re-seed (retry / re-delivery).
   const seedStmt = db().query(
     `INSERT INTO tool_calls
-       (call_id, message_id, project_id, session_id, tool, status, error_type, error_message, duration_ms, created_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       (call_id, message_id, project_id, session_id, tool, status, error_type, error_message, duration_ms, created_at, verifier)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT(call_id) DO UPDATE SET
        status = CASE WHEN tool_calls.status = 'pending' THEN excluded.status ELSE tool_calls.status END,
        error_type = CASE WHEN tool_calls.status = 'pending' THEN excluded.error_type ELSE tool_calls.error_type END,
        error_message = CASE WHEN tool_calls.status = 'pending' THEN excluded.error_message ELSE tool_calls.error_message END,
-       duration_ms = COALESCE(excluded.duration_ms, tool_calls.duration_ms)`,
+       duration_ms = COALESCE(excluded.duration_ms, tool_calls.duration_ms),
+       -- verifier is derived from the tool_use input (stable across re-seeds);
+       -- keep the first non-null classification.
+       verifier = COALESCE(tool_calls.verifier, excluded.verifier)`,
   );
   // Phase B: user tool_result parts — update outcome by call_id, preserving
   // the previously-seeded tool name and message_id.
@@ -205,6 +212,7 @@ export function recordToolCalls(input: {
       outcome.errorMessage,
       outcome.duration,
       createdAt,
+      isVerifierCall(st.input) ? 1 : 0,
     );
   }
 }

--- a/packages/core/src/tool-trace.ts
+++ b/packages/core/src/tool-trace.ts
@@ -104,6 +104,87 @@ export function classifyToolError(_tool: string, error: string): string {
 }
 
 // ---------------------------------------------------------------------------
+// Verifier classification (outcome-reward loop, #497)
+// ---------------------------------------------------------------------------
+
+/**
+ * Recognizes test / build / typecheck / lint runner invocations. Deliberately
+ * conservative — it must match clear runner tokens so a session's verifier
+ * verdict is high-precision (a failing `pnpm test` is a real signal; an
+ * incidental `grep` miss is not). Unmatched commands are simply not verifiers
+ * (no signal), which is the safe default for a confidence-adjusting loop.
+ */
+const VERIFIER_COMMAND = new RegExp(
+  [
+    // package-manager script runners: (npm|pnpm|yarn|bun) [run] test|build|typecheck|lint|check|tsc
+    String.raw`\b(?:npm|pnpm|yarn|bun)\s+(?:run\s+)?(?:test|build|typecheck|type-check|lint|tsc|check)\b`,
+    // direct test runners
+    String.raw`\b(?:vitest|jest|mocha|ava|pytest|rspec|phpunit|gotestsum)\b`,
+    String.raw`\b(?:go|cargo|gradle|mvn|dotnet)\s+test\b`,
+    // typecheck / compile
+    String.raw`\b(?:tsc|tsgo)\b`,
+    String.raw`\b(?:go|cargo)\s+build\b`,
+    // linters / formatters used as gates
+    String.raw`\b(?:eslint|biome|ruff|flake8|mypy|clippy|golangci-lint)\b`,
+  ].join("|"),
+  "i",
+);
+
+/**
+ * Best-effort extraction of a shell command string from a tool call's `input`
+ * (host-shaped, hence `unknown`). Handles the common bash shape
+ * (`{ command: string }` / `{ cmd: string }`) and a bare string; returns null
+ * when no command is recoverable (the call is then treated as a non-verifier).
+ */
+export function extractCommand(input: unknown): string | null {
+  if (typeof input === "string") return input;
+  if (input && typeof input === "object") {
+    const o = input as Record<string, unknown>;
+    if (typeof o.command === "string") return o.command;
+    if (typeof o.cmd === "string") return o.cmd;
+  }
+  return null;
+}
+
+/** True when a tool call's `input` is a recognized verifier invocation. */
+export function isVerifierCall(input: unknown): boolean {
+  const cmd = extractCommand(input);
+  if (!cmd) return false;
+  return VERIFIER_COMMAND.test(cmd);
+}
+
+export type SessionVerifierVerdict = "pass" | "fail" | "none";
+
+/**
+ * Derive a session's verifier verdict from its recorded tool calls:
+ *  - `fail` if ANY verifier call errored (status='error'); a failing verifier is
+ *    a decisive negative signal regardless of later passes.
+ *  - `pass` if ≥1 verifier call completed and none errored.
+ *  - `none` if the session ran no verifier calls — no outcome signal.
+ *
+ * Only `verifier = 1` calls count, so incidental command failures (a missing
+ * file, a `grep` miss) never move knowledge confidence.
+ */
+export function sessionVerifierVerdict(
+  projectPath: string,
+  sessionID: string,
+): SessionVerifierVerdict {
+  const pid = ensureProject(projectPath);
+  const row = db()
+    .query(
+      `SELECT
+         SUM(CASE WHEN status = 'error' THEN 1 ELSE 0 END) AS fails,
+         SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS passes
+       FROM tool_calls
+       WHERE project_id = ? AND session_id = ? AND verifier = 1`,
+    )
+    .get(pid, sessionID) as { fails: number | null; passes: number | null };
+  if ((row?.fails ?? 0) > 0) return "fail";
+  if ((row?.passes ?? 0) > 0) return "pass";
+  return "none";
+}
+
+// ---------------------------------------------------------------------------
 // Aggregation accessors
 // ---------------------------------------------------------------------------
 

--- a/packages/core/src/tool-trace.ts
+++ b/packages/core/src/tool-trace.ts
@@ -108,25 +108,31 @@ export function classifyToolError(_tool: string, error: string): string {
 // ---------------------------------------------------------------------------
 
 /**
- * Recognizes test / build / typecheck / lint runner invocations. Deliberately
- * conservative — it must match clear runner tokens so a session's verifier
- * verdict is high-precision (a failing `pnpm test` is a real signal; an
- * incidental `grep` miss is not). Unmatched commands are simply not verifiers
- * (no signal), which is the safe default for a confidence-adjusting loop.
+ * Recognizes a test / build / typecheck / lint runner at the START of a command
+ * segment. Anchoring to command position (rather than matching the token
+ * anywhere) is what makes the verdict high-precision: `pnpm test` matches, but
+ * `cat vitest.config.ts`, `vim biome.json`, and `echo 'run mypy'` do NOT — they
+ * merely mention a runner. Optional benign prefixes (sudo/env/time/npx/…) are
+ * skipped so `npx vitest` / `sudo pnpm test` still match. A non-match means "not
+ * a verifier" (no signal), the safe default for a confidence-adjusting loop.
  */
-const VERIFIER_COMMAND = new RegExp(
-  [
-    // package-manager script runners: (npm|pnpm|yarn|bun) [run] test|build|typecheck|lint|check|tsc
-    String.raw`\b(?:npm|pnpm|yarn|bun)\s+(?:run\s+)?(?:test|build|typecheck|type-check|lint|tsc|check)\b`,
-    // direct test runners
-    String.raw`\b(?:vitest|jest|mocha|ava|pytest|rspec|phpunit|gotestsum)\b`,
-    String.raw`\b(?:go|cargo|gradle|mvn|dotnet)\s+test\b`,
-    // typecheck / compile
-    String.raw`\b(?:tsc|tsgo)\b`,
-    String.raw`\b(?:go|cargo)\s+build\b`,
-    // linters / formatters used as gates
-    String.raw`\b(?:eslint|biome|ruff|flake8|mypy|clippy|golangci-lint)\b`,
-  ].join("|"),
+const VERIFIER_LEADING = new RegExp(
+  // optional leading prefixes that precede the real command
+  String.raw`^\s*(?:(?:sudo|time|npx|bunx)\s+|\w+=\S+\s+|env\s+)*` +
+    "(?:" +
+    [
+      // package-manager script runners
+      String.raw`(?:npm|pnpm|yarn|bun)\s+(?:run\s+)?(?:test|build|typecheck|type-check|lint|tsc|check)\b`,
+      // direct test runners
+      String.raw`(?:vitest|jest|mocha|ava|pytest|rspec|phpunit|gotestsum)\b`,
+      String.raw`(?:go|cargo|gradle|mvn|dotnet)\s+test\b`,
+      // typecheck / compile
+      String.raw`(?:tsc|tsgo)\b`,
+      String.raw`(?:go|cargo)\s+build\b`,
+      // linters / formatters used as gates
+      String.raw`(?:eslint|biome|ruff|flake8|mypy|clippy|golangci-lint)\b`,
+    ].join("|") +
+    ")",
   "i",
 );
 
@@ -146,11 +152,19 @@ export function extractCommand(input: unknown): string | null {
   return null;
 }
 
-/** True when a tool call's `input` is a recognized verifier invocation. */
+/**
+ * True when a tool call's `input` invokes a recognized verifier. The command is
+ * split into segments on the shell chaining/pipe operators (`&&`, `||`, `;`,
+ * `|`, newline) and a segment counts only when a runner leads it — so
+ * `cd pkg && pnpm test` matches (2nd segment) while `cat vitest.config.ts` and
+ * `grep biome .` do not.
+ */
 export function isVerifierCall(input: unknown): boolean {
   const cmd = extractCommand(input);
   if (!cmd) return false;
-  return VERIFIER_COMMAND.test(cmd);
+  return cmd
+    .split(/&&|\|\||[;\n|]/)
+    .some((segment) => VERIFIER_LEADING.test(segment));
 }
 
 export type SessionVerifierVerdict = "pass" | "fail" | "none";

--- a/packages/core/test/config.test.ts
+++ b/packages/core/test/config.test.ts
@@ -52,6 +52,14 @@ describe("LoreConfig — knowledge schema", () => {
     expect(cfg.knowledge.enabled).toBe(true);
   });
 
+  test("knowledge.outcomeReward defaults to true and is overridable", () => {
+    expect(LoreConfig.parse({}).knowledge.outcomeReward).toBe(true);
+    expect(
+      LoreConfig.parse({ knowledge: { outcomeReward: false } }).knowledge
+        .outcomeReward,
+    ).toBe(false);
+  });
+
   test("knowledge.enabled can be set to false", () => {
     const cfg = LoreConfig.parse({ knowledge: { enabled: false } });
     expect(cfg.knowledge.enabled).toBe(false);

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -58,7 +58,7 @@ describe("db", () => {
     const row = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(row.version).toBe(52);
+    expect(row.version).toBe(53);
   });
 
   test("session_prompt_deltas persist ordered selector/content rows (v42)", () => {

--- a/packages/core/test/ltm-outcome-reward.test.ts
+++ b/packages/core/test/ltm-outcome-reward.test.ts
@@ -1,0 +1,335 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { db, ensureProject } from "../src/db";
+import * as ltm from "../src/ltm";
+import {
+  extractCommand,
+  isVerifierCall,
+  sessionVerifierVerdict,
+} from "../src/tool-trace";
+
+const PROJECT = "/test/outcome-reward";
+
+let callSeq = 0;
+function insertToolCall(
+  pid: string,
+  opts: {
+    session: string;
+    tool?: string;
+    status: "completed" | "error" | "pending";
+    verifier?: 0 | 1 | null;
+  },
+): void {
+  callSeq++;
+  db()
+    .query(
+      `INSERT INTO tool_calls
+         (call_id, message_id, project_id, session_id, tool, status, error_type, error_message, duration_ms, created_at, verifier)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      `call-${callSeq}`,
+      `msg-${callSeq}`,
+      pid,
+      opts.session,
+      opts.tool ?? "bash",
+      opts.status,
+      opts.status === "error" ? "command_failed" : null,
+      null,
+      0,
+      1000 + callSeq,
+      opts.verifier ?? null,
+    );
+}
+
+function getEntry(id: string): {
+  logical_id: string;
+  confidence: number;
+  cross_project: number;
+  category: string;
+} {
+  return db()
+    .query(
+      "SELECT logical_id, confidence, cross_project, category FROM knowledge WHERE id = ?",
+    )
+    .get(id) as {
+    logical_id: string;
+    confidence: number;
+    cross_project: number;
+    category: string;
+  };
+}
+
+function makeProjectEntry(title: string, confidence: number): string {
+  return ltm.create({
+    projectPath: PROJECT,
+    category: "pattern",
+    title,
+    content: `content for ${title}`,
+    scope: "project",
+    confidence,
+  });
+}
+
+describe("outcome-reward: verifier detection (tool-trace)", () => {
+  test("extractCommand handles bash shapes and bare strings", () => {
+    expect(extractCommand({ command: "pnpm test" })).toBe("pnpm test");
+    expect(extractCommand({ cmd: "tsc" })).toBe("tsc");
+    expect(extractCommand("vitest run")).toBe("vitest run");
+    expect(extractCommand({})).toBeNull();
+    expect(extractCommand(null)).toBeNull();
+    expect(extractCommand(42)).toBeNull();
+  });
+
+  test("isVerifierCall recognizes test/build/typecheck/lint runners", () => {
+    for (const cmd of [
+      "pnpm test",
+      "pnpm run test",
+      "npm test",
+      "yarn build",
+      "bun run typecheck",
+      "tsc --noEmit",
+      "vitest run packages/core",
+      "go test ./...",
+      "cargo test",
+      "eslint . --fix",
+      "biome check src",
+      "pytest -q",
+      "ruff check",
+    ]) {
+      expect(isVerifierCall({ command: cmd })).toBe(true);
+    }
+  });
+
+  test("isVerifierCall ignores incidental commands (no false positives)", () => {
+    for (const cmd of [
+      "grep -r foo .",
+      "ls -la",
+      "cat package.json",
+      "git status",
+      "cd packages/core",
+      "echo testing", // 'test' only as a substring of a word → not matched
+      "mkdir build-output",
+    ]) {
+      expect(isVerifierCall({ command: cmd })).toBe(false);
+    }
+    // Non-extractable input is never a verifier.
+    expect(isVerifierCall({ filePath: "x" })).toBe(false);
+    expect(isVerifierCall(undefined)).toBe(false);
+  });
+});
+
+describe("outcome-reward: sessionVerifierVerdict", () => {
+  let pid: string;
+  beforeEach(() => {
+    pid = ensureProject(PROJECT);
+    db().query("DELETE FROM tool_calls WHERE project_id = ?").run(pid);
+  });
+
+  test("no verifier calls → none (incidental failures ignored)", () => {
+    // A non-verifier command that failed must NOT register as a verifier fail.
+    insertToolCall(pid, { session: "s1", status: "error", verifier: 0 });
+    insertToolCall(pid, { session: "s1", status: "completed", verifier: null });
+    expect(sessionVerifierVerdict(PROJECT, "s1")).toBe("none");
+  });
+
+  test("verifier completed → pass", () => {
+    insertToolCall(pid, { session: "s2", status: "completed", verifier: 1 });
+    expect(sessionVerifierVerdict(PROJECT, "s2")).toBe("pass");
+  });
+
+  test("verifier errored → fail", () => {
+    insertToolCall(pid, { session: "s3", status: "error", verifier: 1 });
+    expect(sessionVerifierVerdict(PROJECT, "s3")).toBe("fail");
+  });
+
+  test("any verifier failure makes the session fail (fail dominates a later pass)", () => {
+    insertToolCall(pid, { session: "s4", status: "error", verifier: 1 });
+    insertToolCall(pid, { session: "s4", status: "completed", verifier: 1 });
+    expect(sessionVerifierVerdict(PROJECT, "s4")).toBe("fail");
+  });
+});
+
+describe("outcome-reward: recordSessionInjections", () => {
+  let pid: string;
+  beforeEach(() => {
+    pid = ensureProject(PROJECT);
+    db().query("DELETE FROM knowledge WHERE project_id = ?").run(pid);
+    db()
+      .query("DELETE FROM knowledge_session_injections WHERE project_id = ?")
+      .run(pid);
+  });
+
+  test("records project entries; skips cross_project and lat.md synthetics", () => {
+    const e = makeProjectEntry("inj-1", 0.5);
+    const entry = getEntry(e);
+    ltm.recordSessionInjections("sess-rec", PROJECT, [
+      { logical_id: entry.logical_id, cross_project: 0, category: "pattern" },
+      { logical_id: "shared-x", cross_project: 1, category: "pattern" },
+      { logical_id: "lat-x", cross_project: 0, category: "lat.md" },
+      { logical_id: undefined, cross_project: 0, category: "pattern" },
+    ]);
+    const rows = db()
+      .query(
+        "SELECT logical_id FROM knowledge_session_injections WHERE session_id = ?",
+      )
+      .all("sess-rec") as { logical_id: string }[];
+    expect(rows.map((r) => r.logical_id)).toEqual([entry.logical_id]);
+  });
+
+  test("is idempotent and never resets the credited flag on re-injection", () => {
+    const e = makeProjectEntry("inj-2", 0.5);
+    const lid = getEntry(e).logical_id;
+    const inj = [{ logical_id: lid, cross_project: 0, category: "pattern" }];
+    ltm.recordSessionInjections("sess-idem", PROJECT, inj);
+    // Simulate a credit having happened.
+    db()
+      .query(
+        "UPDATE knowledge_session_injections SET credited = 1 WHERE session_id = ?",
+      )
+      .run("sess-idem");
+    // Re-inject the same entry on a later turn.
+    ltm.recordSessionInjections("sess-idem", PROJECT, inj);
+    const row = db()
+      .query(
+        "SELECT COUNT(*) AS n, MAX(credited) AS credited FROM knowledge_session_injections WHERE session_id = ?",
+      )
+      .get("sess-idem") as { n: number; credited: number };
+    expect(row.n).toBe(1); // no duplicate
+    expect(row.credited).toBe(1); // not reset to 0
+  });
+
+  test("no-op when sessionID is undefined", () => {
+    ltm.recordSessionInjections(undefined, PROJECT, [
+      { logical_id: "x", cross_project: 0, category: "pattern" },
+    ]);
+    const n = db()
+      .query(
+        "SELECT COUNT(*) AS n FROM knowledge_session_injections WHERE logical_id = 'x'",
+      )
+      .get() as { n: number };
+    expect(n.n).toBe(0);
+  });
+});
+
+describe("outcome-reward: creditSessionOutcome", () => {
+  let pid: string;
+  beforeEach(() => {
+    pid = ensureProject(PROJECT);
+    db().query("DELETE FROM knowledge WHERE project_id = ?").run(pid);
+    db().query("DELETE FROM tool_calls WHERE project_id = ?").run(pid);
+    db()
+      .query("DELETE FROM knowledge_session_injections WHERE project_id = ?")
+      .run(pid);
+  });
+
+  function inject(session: string, id: string): void {
+    const entry = getEntry(id);
+    ltm.recordSessionInjections(session, PROJECT, [
+      {
+        logical_id: entry.logical_id,
+        cross_project: entry.cross_project,
+        category: entry.category,
+      },
+    ]);
+  }
+
+  test("PASS verdict boosts injected entries by OUTCOME_REWARD (capped at ceiling)", () => {
+    const e = makeProjectEntry("c-pass", 0.5);
+    inject("sp", e);
+    insertToolCall(pid, { session: "sp", status: "completed", verifier: 1 });
+    const res = ltm.creditSessionOutcome("sp", PROJECT);
+    expect(res.verdict).toBe("pass");
+    expect(res.credited).toBe(1);
+    expect(getEntry(e).confidence).toBeCloseTo(0.5 + ltm.OUTCOME_REWARD, 6);
+  });
+
+  test("PASS does not boost an entry already at/above the ceiling", () => {
+    const e = makeProjectEntry("c-ceil", ltm.OUTCOME_BOOST_CEILING);
+    inject("sc", e);
+    insertToolCall(pid, { session: "sc", status: "completed", verifier: 1 });
+    ltm.creditSessionOutcome("sc", PROJECT);
+    expect(getEntry(e).confidence).toBeCloseTo(ltm.OUTCOME_BOOST_CEILING, 6);
+  });
+
+  test("PASS boost is clamped to the ceiling (near-ceiling entry)", () => {
+    const e = makeProjectEntry("c-near", ltm.OUTCOME_BOOST_CEILING - 0.005);
+    inject("sn", e);
+    insertToolCall(pid, { session: "sn", status: "completed", verifier: 1 });
+    ltm.creditSessionOutcome("sn", PROJECT);
+    expect(getEntry(e).confidence).toBeCloseTo(ltm.OUTCOME_BOOST_CEILING, 6);
+  });
+
+  test("FAIL verdict penalizes injected entries by OUTCOME_PENALTY (floored at 0)", () => {
+    const e = makeProjectEntry("c-fail", 0.5);
+    inject("sf", e);
+    insertToolCall(pid, { session: "sf", status: "error", verifier: 1 });
+    const res = ltm.creditSessionOutcome("sf", PROJECT);
+    expect(res.verdict).toBe("fail");
+    expect(getEntry(e).confidence).toBeCloseTo(0.5 - ltm.OUTCOME_PENALTY, 6);
+  });
+
+  test("FAIL floors confidence at 0, never negative", () => {
+    const e = makeProjectEntry("c-floor", 0.02);
+    inject("sfl", e);
+    insertToolCall(pid, { session: "sfl", status: "error", verifier: 1 });
+    ltm.creditSessionOutcome("sfl", PROJECT);
+    expect(getEntry(e).confidence).toBe(0);
+  });
+
+  test("NONE verdict is a no-op (no verifier ran)", () => {
+    const e = makeProjectEntry("c-none", 0.5);
+    inject("snone", e);
+    insertToolCall(pid, { session: "snone", status: "error", verifier: 0 }); // non-verifier
+    const res = ltm.creditSessionOutcome("snone", PROJECT);
+    expect(res.verdict).toBe("none");
+    expect(res.credited).toBe(0);
+    expect(getEntry(e).confidence).toBe(0.5);
+    // injections stay uncredited so a later verifier outcome can still credit them.
+    const credited = db()
+      .query(
+        "SELECT credited FROM knowledge_session_injections WHERE session_id = 'snone'",
+      )
+      .get() as { credited: number };
+    expect(credited.credited).toBe(0);
+  });
+
+  test("is idempotent — a second credit pass does nothing", () => {
+    const e = makeProjectEntry("c-idem", 0.5);
+    inject("si", e);
+    insertToolCall(pid, { session: "si", status: "completed", verifier: 1 });
+    ltm.creditSessionOutcome("si", PROJECT);
+    const afterFirst = getEntry(e).confidence;
+    const second = ltm.creditSessionOutcome("si", PROJECT);
+    expect(second.credited).toBe(0);
+    expect(getEntry(e).confidence).toBe(afterFirst);
+  });
+
+  test("never touches cross_project (shared) entries even if an injection row exists", () => {
+    const e = ltm.create({
+      category: "pattern",
+      title: "c-shared",
+      content: "shared knowledge",
+      scope: "global",
+      confidence: 0.5,
+    });
+    const entry = getEntry(e);
+    expect(entry.cross_project).toBe(1);
+    // Force an injection row (recordSessionInjections would normally skip it).
+    db()
+      .query(
+        `INSERT INTO knowledge_session_injections (session_id, logical_id, project_id, created_at, credited)
+         VALUES (?, ?, ?, ?, 0)`,
+      )
+      .run("sx", entry.logical_id, pid, Date.now());
+    insertToolCall(pid, { session: "sx", status: "error", verifier: 1 });
+    ltm.creditSessionOutcome("sx", PROJECT);
+    expect(getEntry(e).confidence).toBe(0.5); // unchanged — shared knowledge protected
+  });
+
+  test("no injections → none verdict, zero credited", () => {
+    insertToolCall(pid, { session: "empty", status: "completed", verifier: 1 });
+    const res = ltm.creditSessionOutcome("empty", PROJECT);
+    expect(res.verdict).toBe("none");
+    expect(res.credited).toBe(0);
+  });
+});

--- a/packages/core/test/ltm-outcome-reward.test.ts
+++ b/packages/core/test/ltm-outcome-reward.test.ts
@@ -46,16 +46,18 @@ function getEntry(id: string): {
   confidence: number;
   cross_project: number;
   category: string;
+  project_id: string | null;
 } {
   return db()
     .query(
-      "SELECT logical_id, confidence, cross_project, category FROM knowledge WHERE id = ?",
+      "SELECT logical_id, confidence, cross_project, category, project_id FROM knowledge WHERE id = ?",
     )
     .get(id) as {
     logical_id: string;
     confidence: number;
     cross_project: number;
     category: string;
+    project_id: string | null;
   };
 }
 
@@ -109,12 +111,33 @@ describe("outcome-reward: verifier detection (tool-trace)", () => {
       "cd packages/core",
       "echo testing", // 'test' only as a substring of a word → not matched
       "mkdir build-output",
+      // Merely MENTIONING a runner (not invoking it) must not count — the token
+      // is not at command position. These are the high-frequency false-positives.
+      "cat vitest.config.ts",
+      "vim biome.json",
+      "ls eslint.config.js",
+      "grep ruff pyproject.toml",
+      "echo 'run mypy soon'",
+      "git checkout -- pytest.ini",
     ]) {
       expect(isVerifierCall({ command: cmd })).toBe(false);
     }
     // Non-extractable input is never a verifier.
     expect(isVerifierCall({ filePath: "x" })).toBe(false);
     expect(isVerifierCall(undefined)).toBe(false);
+  });
+
+  test("isVerifierCall matches a runner that leads any command segment or benign prefix", () => {
+    for (const cmd of [
+      "cd packages/core && pnpm test", // runner leads the 2nd segment
+      "rm -rf dist; pnpm build", // after a semicolon
+      "npx vitest run", // benign npx prefix
+      "sudo cargo test", // sudo prefix
+      "CI=1 pnpm test", // leading env assignment
+      "env FOO=bar tsc --noEmit", // env prefix
+    ]) {
+      expect(isVerifierCall({ command: cmd })).toBe(true);
+    }
   });
 });
 
@@ -243,12 +266,25 @@ describe("outcome-reward: creditSessionOutcome", () => {
     expect(getEntry(e).confidence).toBeCloseTo(0.5 + ltm.OUTCOME_REWARD, 6);
   });
 
-  test("PASS does not boost an entry already at/above the ceiling", () => {
+  test("PASS does not boost an entry already at the ceiling", () => {
     const e = makeProjectEntry("c-ceil", ltm.OUTCOME_BOOST_CEILING);
     inject("sc", e);
     insertToolCall(pid, { session: "sc", status: "completed", verifier: 1 });
     ltm.creditSessionOutcome("sc", PROJECT);
     expect(getEntry(e).confidence).toBeCloseTo(ltm.OUTCOME_BOOST_CEILING, 6);
+  });
+
+  test("PASS NEVER demotes a high-confidence entry above the ceiling (anti-deflation)", () => {
+    // The `confidence < ceiling` guard's critical second job: an entry already
+    // ABOVE the ceiling (e.g. a curator-minted 0.95) injected into a passing
+    // session must be left UNTOUCHED — not flattened to the ceiling by MIN().
+    // Without the guard this would silently collapse the whole 0.8–1.0 band to
+    // 0.8 on every passing session (top entries are injected nearly always).
+    const e = makeProjectEntry("c-above", 0.95);
+    inject("sa", e);
+    insertToolCall(pid, { session: "sa", status: "completed", verifier: 1 });
+    ltm.creditSessionOutcome("sa", PROJECT);
+    expect(getEntry(e).confidence).toBe(0.95);
   });
 
   test("PASS boost is clamped to the ceiling (near-ceiling entry)", () => {
@@ -304,16 +340,17 @@ describe("outcome-reward: creditSessionOutcome", () => {
     expect(getEntry(e).confidence).toBe(afterFirst);
   });
 
-  test("never touches cross_project (shared) entries even if an injection row exists", () => {
-    const e = ltm.create({
-      category: "pattern",
-      title: "c-shared",
-      content: "shared knowledge",
-      scope: "global",
-      confidence: 0.5,
-    });
+  test("never touches a PROMOTED entry (project_id set, cross_project=1) — the cross_project=0 backstop", () => {
+    // A promoted entry keeps its origin project_id but is cross_project=1. The
+    // `project_id = pid` guard alone would NOT protect it (project_id matches),
+    // so this exercises the `cross_project = 0` backstop specifically — a global
+    // (project_id=NULL) entry would be masked by the project_id guard and leave
+    // the backstop unverified.
+    const e = makeProjectEntry("c-promoted", 0.5);
     const entry = getEntry(e);
-    expect(entry.cross_project).toBe(1);
+    db().query("UPDATE knowledge SET cross_project = 1 WHERE id = ?").run(e);
+    expect(getEntry(e).cross_project).toBe(1);
+    expect(entry.project_id).not.toBeNull();
     // Force an injection row (recordSessionInjections would normally skip it).
     db()
       .query(
@@ -324,6 +361,15 @@ describe("outcome-reward: creditSessionOutcome", () => {
     insertToolCall(pid, { session: "sx", status: "error", verifier: 1 });
     ltm.creditSessionOutcome("sx", PROJECT);
     expect(getEntry(e).confidence).toBe(0.5); // unchanged — shared knowledge protected
+  });
+
+  test("does not adjust a deleted current version (is_deleted = 1)", () => {
+    const e = makeProjectEntry("c-deleted", 0.5);
+    inject("sd", e);
+    db().query("UPDATE knowledge SET is_deleted = 1 WHERE id = ?").run(e);
+    insertToolCall(pid, { session: "sd", status: "error", verifier: 1 });
+    ltm.creditSessionOutcome("sd", PROJECT);
+    expect(getEntry(e).confidence).toBe(0.5); // tombstoned → left alone
   });
 
   test("no injections → none verdict, zero credited", () => {

--- a/packages/core/test/ltm-versioning.test.ts
+++ b/packages/core/test/ltm-versioning.test.ts
@@ -39,11 +39,11 @@ function ftsHits(token: string): number {
 }
 
 describe("A2 sub-PR 1: append-only knowledge scaffolding", () => {
-  test("schema version is 52", () => {
+  test("schema version is 53", () => {
     const v = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(v.version).toBe(52);
+    expect(v.version).toBe(53);
   });
 
   test("create() defaults logical_id = id, version 1, current, not deleted", () => {

--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -858,6 +858,17 @@ export function buildIdleWorkHandler(
     //    count and the curator's existing-entries context lean.
     if (cfg.knowledge.enabled) {
       try {
+        // Credit injected entries by this session's verifier outcome (#497)
+        // BEFORE decay/prune, so a penalty that reaches the relevance floor is
+        // reaped in the same pass. Once-per-session (idempotent).
+        if (cfg.knowledge.outcomeReward) {
+          const credit = ltm.creditSessionOutcome(sessionID, projectPath);
+          if (credit.credited > 0) {
+            log.info(
+              `outcome (${credit.verdict}): adjusted ${credit.credited} injected knowledge entries`,
+            );
+          }
+        }
         const decayed = ltm.decayProject(projectPath);
         if (decayed > 0) {
           log.info(`decayed ${decayed} unreinforced knowledge entries`);

--- a/packages/gateway/test/idle-work.test.ts
+++ b/packages/gateway/test/idle-work.test.ts
@@ -243,6 +243,80 @@ describe("buildIdleWorkHandler", () => {
     expect(llm.prompt).not.toHaveBeenCalled();
   });
 
+  // #497: the idle knowledge-lifecycle step credits injected entries by the
+  // session's verifier outcome. These drive the real handler end-to-end.
+  function seedInjectedEntry(
+    projectPath: string,
+    sessionID: string,
+    confidence: number,
+  ): string {
+    const pid = ensureProject(projectPath);
+    const id = ltm.create({
+      projectPath,
+      category: "pattern",
+      title: `wire-${sessionID}`,
+      content: "knowledge in context",
+      scope: "project",
+      confidence,
+    });
+    const logicalId = (
+      db().query("SELECT logical_id FROM knowledge WHERE id = ?").get(id) as {
+        logical_id: string;
+      }
+    ).logical_id;
+    ltm.recordSessionInjections(sessionID, projectPath, [
+      { logical_id: logicalId, cross_project: 0, category: "pattern" },
+    ]);
+    // A verifier tool call; the caller sets its final status (completed/error).
+    db()
+      .query(
+        `INSERT INTO tool_calls
+           (call_id, message_id, project_id, session_id, tool, status, error_type, error_message, duration_ms, created_at, verifier)
+         VALUES (?, ?, ?, ?, 'bash', 'pending', NULL, NULL, 0, ?, 1)`,
+      )
+      .run(`tc-${sessionID}`, `m-${sessionID}`, pid, sessionID, Date.now());
+    return id;
+  }
+
+  test("idle credits injected knowledge on a PASS verifier outcome (boost)", async () => {
+    const projectPath = makeProjectDir();
+    const sessionID = "idle-outcome-pass";
+    const id = seedInjectedEntry(projectPath, sessionID, 0.5);
+    // Mark the verifier tool call as completed (PASS).
+    db()
+      .query("UPDATE tool_calls SET status = 'completed' WHERE session_id = ?")
+      .run(sessionID);
+
+    const handler = buildIdleWorkHandler(makeLLM());
+    await handler(sessionID, makeSessionState({ sessionID, projectPath }));
+
+    const conf = (
+      db().query("SELECT confidence FROM knowledge WHERE id = ?").get(id) as {
+        confidence: number;
+      }
+    ).confidence;
+    expect(conf).toBeCloseTo(0.5 + ltm.OUTCOME_REWARD, 6);
+  });
+
+  test("idle credits injected knowledge on a FAIL verifier outcome (penalty)", async () => {
+    const projectPath = makeProjectDir();
+    const sessionID = "idle-outcome-fail";
+    const id = seedInjectedEntry(projectPath, sessionID, 0.5);
+    db()
+      .query("UPDATE tool_calls SET status = 'error' WHERE session_id = ?")
+      .run(sessionID);
+
+    const handler = buildIdleWorkHandler(makeLLM());
+    await handler(sessionID, makeSessionState({ sessionID, projectPath }));
+
+    const conf = (
+      db().query("SELECT confidence FROM knowledge WHERE id = ?").get(id) as {
+        confidence: number;
+      }
+    ).confidence;
+    expect(conf).toBeCloseTo(0.5 - ltm.OUTCOME_PENALTY, 6);
+  });
+
   test("drives force-distill + meta-consolidation but preserves a layer-0 warmup body", async () => {
     const projectPath = makeProjectDir();
     const sessionID = "idle-distill-wiring";

--- a/packages/website/src/content/docs/docs/configuration.md
+++ b/packages/website/src/content/docs/docs/configuration.md
@@ -119,6 +119,7 @@ Long-term knowledge (curator, entity injection) controls.
 | `enabled` | boolean | `true` |  | Enable long-term knowledge storage and system-prompt injection. When false, the curator is disabled but recall and context management remain active. Default: true. |
 | `maxEntityInject` | number | `30` | min 0 | Max entities to inject into the agent system prompt. Set to 0 to disable. Default: 30. |
 | `autoToolFailureGotchas` | boolean | `false` |  | Auto-create gotcha entries from recurring tool failures. Default false (noisy; can churn the LTM cache). |
+| `outcomeReward` | boolean | `true` |  | Adjust knowledge confidence by within-session verifier (test/build/typecheck/lint) outcomes. Default: true. |
 
 
 ## `curator`


### PR DESCRIPTION
Closes #497. Wires the `reinforce()` seam (#816) to a real signal.

## Approach (confirmed with maintainer)
- **Within-session co-occurrence** (not cross-session causal inference — avoids the spurious-correlation trap the issue flags).
- **Acts immediately** on confidence, conservatively + anti-inflation.

## How it works
1. **Precise verifier detection** — `temporal.recordToolCalls` flags a tool call as a verifier (`tool_calls.verifier`) when its command matches a test/build/typecheck/lint runner. A failing `pnpm test` is a real signal; an incidental `grep` miss is not. (Absence of a precise signal can't distinguish "passed" from "no verifier ran", so this precision is what lets the loop *reward*, not just penalize.)
2. **Verdict** — `sessionVerifierVerdict(project, session)` → `pass` / `fail` / `none` (a failing verifier dominates).
3. **Injection log** — `forSession` records which entries it injected into a session (`knowledge_session_injections`, keyed by A2 `logical_id`, idempotent per session, excludes cross_project + lat.md).
4. **Credit (idle, once per session)** — `creditSessionOutcome`:
   - `PASS` → `+OUTCOME_REWARD` (0.02), **capped at `OUTCOME_BOOST_CEILING` (0.8)** — lifts under-confident-but-useful entries without manufacturing the 0.9–1.0 cluster (mere selection ≠ proven certainty).
   - `FAIL` → `−OUTCOME_PENALTY` (0.05, the decisive signal), floored at 0.
   - `NONE` → no-op (never guess).
   - Runs **before** decay/prune so a penalty that reaches the floor is reaped the same pass. **cross_project (shared) entries are never adjusted** (honors "never auto-demote shared knowledge").

## Schema / config
- Migration **v53**: `tool_calls.verifier` + `knowledge_session_injections` (both also in `recoverMissingObjects`).
- `knowledge.outcomeReward` config (default `true`); docs regenerated.

## Tests
`ltm-outcome-reward.test.ts` (19): verifier detection (pos/neg), verdict, boost+cap, penalty+floor, NONE no-op, cross_project protection, idempotency, `recordSessionInjections` filtering. Plus 2 end-to-end idle-handler wiring tests (PASS boost / FAIL penalty) and a config-default test. Full suite **3811**; typecheck, lint, build green.

## Follow-ups (out of scope)
- Higher verifier recall (a failing test that exits non-zero without a "type error" string buckets as `command_failed`; v1 keys off the precise `verifier` flag, which covers the runner invocation regardless).
- "Knowledge impact" surfacing in `lore data show`; feeding outcome into curator consolidation.

## Note on CI
A pre-existing intermittent harness-isolation flake (#885, `session-rotation-merge.test.ts`) surfaced once across 5 full-suite runs; passes 7/7 in isolation. This change adds **no** fire-and-forget background work (`creditSessionOutcome` runs synchronously inside the already-awaited idle handler), so it is not the cause.