### PR TITLE
fix(gateway): tolerate unavailable bind hosts (EADDRNOTAVAIL)

### DIFF
--- a/packages/gateway/src/cli/start.ts
+++ b/packages/gateway/src/cli/start.ts
@@ -347,6 +347,11 @@ export async function startGateway(
       server = await startServer(config);
       await server.ready; // already resolved by startServer; kept for clarity
       const actualPort = server.port;
+      // startServer() may drop hosts that aren't currently bindable (e.g. a
+      // stale Tailscale IP → EADDRNOTAVAIL). Reflect the hosts we actually
+      // bound so the "listening on …" log and /health probes don't advertise
+      // an interface that's down.
+      if (server.hosts.length) config.hosts = server.hosts;
 
       // Write port file so plugins can discover us (even on random port).
       writePortFile(actualPort);

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -498,6 +498,7 @@ export async function startServer(config: GatewayConfig): Promise<{
   // the same actual port. node:http's listen() is async, so we must
   // await each bind; Array#map can't await, hence the for-of loop.
   const servers: Server[] = [];
+  const boundHosts: string[] = [];
   let resolvedPort = config.port;
   try {
     for (const host of config.hosts) {
@@ -552,7 +553,29 @@ export async function startServer(config: GatewayConfig): Promise<{
       // Wait for the first bind so we learn the OS-assigned port (when
       // resolvedPort started as 0). Subsequent hosts then bind to the
       // same port to share it.
-      await ready;
+      try {
+        await ready;
+      } catch (e) {
+        // A configured host may not be assigned to any local interface right
+        // now — e.g. a Tailscale/LAN IP from a tailnet you've left, or an
+        // interface that hasn't come up yet at boot. Binding it fails with
+        // EADDRNOTAVAIL (or EADDRNOTFOUND on some platforms). Such hosts are
+        // OPTIONAL: skip them and keep binding the rest, so the gateway still
+        // comes up on loopback. Real conflicts (EADDRINUSE) and any other
+        // error still propagate to startGateway()'s port-fallback/reuse logic.
+        if (isUnavailableAddressError(e)) {
+          // Close this never-listening server to avoid leaking the handle.
+          s.close();
+          // Always warn (not just in debug): silently degrading to loopback-only
+          // when an explicitly-configured host is dropped is surprising, and the
+          // event is low-frequency and actionable.
+          console.error(
+            `[lore] configured host ${host} is unavailable (${addressErrorCode(e)}); skipping it and serving on the remaining hosts`,
+          );
+          continue;
+        }
+        throw e;
+      }
       if (resolvedPort === 0) {
         const addr = s.address();
         if (addr && typeof addr === "object") {
@@ -560,6 +583,7 @@ export async function startServer(config: GatewayConfig): Promise<{
         }
       }
       servers.push(s);
+      boundHosts.push(host);
     }
   } catch (e) {
     // A later host failed to bind (e.g. EADDRINUSE) after earlier hosts
@@ -567,6 +591,14 @@ export async function startServer(config: GatewayConfig): Promise<{
     // file descriptors, then re-throw for startGateway() to handle.
     for (const s of servers) s.close();
     throw e;
+  }
+
+  // Every configured host was unavailable (nothing bound). That's a genuine
+  // failure — surface it rather than returning a gateway that listens nowhere.
+  if (servers.length === 0) {
+    throw new Error(
+      `Failed to bind: none of the configured hosts are available (${config.hosts.join(", ")}).`,
+    );
   }
 
   // Collect all ready promises so startGateway() can await them.
@@ -579,7 +611,9 @@ export async function startServer(config: GatewayConfig): Promise<{
       for (const s of servers) s.close();
     },
     port: resolvedPort,
-    hosts: config.hosts,
+    // Report the hosts we actually bound (unavailable ones were skipped), so
+    // callers and /health probes don't reference an interface that's down.
+    hosts: boundHosts,
     ready: Promise.all(readyPromises).then(() => {}),
   };
 
@@ -605,6 +639,29 @@ export async function startServer(config: GatewayConfig): Promise<{
   }
 
   return promise;
+}
+
+/**
+ * Extract the errno code (e.g. "EADDRINUSE", "EADDRNOTAVAIL") from a Node
+ * socket error, if present.
+ */
+function addressErrorCode(err: unknown): string | undefined {
+  if (err && typeof err === "object" && "code" in err) {
+    const code = (err as { code?: unknown }).code;
+    if (typeof code === "string") return code;
+  }
+  return undefined;
+}
+
+/**
+ * True when a bind failed because the address isn't assigned to any local
+ * interface (so the host is absent/optional), as opposed to a real conflict
+ * (EADDRINUSE) or permission error. EADDRNOTAVAIL is the common case;
+ * EADDRNOTFOUND appears on some platforms for unresolvable hosts.
+ */
+function isUnavailableAddressError(err: unknown): boolean {
+  const code = addressErrorCode(err);
+  return code === "EADDRNOTAVAIL" || code === "EADDRNOTFOUND";
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/test/server.test.ts
+++ b/packages/gateway/test/server.test.ts
@@ -161,4 +161,53 @@ describe("startServer configuration", () => {
       s.stop();
     }
   });
+
+  // Regression: a configured host that isn't assigned to any local interface
+  // (e.g. a Tailscale IP from a tailnet you've left) used to fail the whole
+  // bind with EADDRNOTAVAIL, which startGateway() then misreported as a port
+  // conflict ("Port N in use … Failed to bind to any port"). Such hosts must
+  // be treated as optional: skipped with a warning while the reachable hosts
+  // (loopback) still bind and serve. 192.0.2.1 is TEST-NET-1 (RFC 5737) — it
+  // is guaranteed not assigned to any interface, so binding it yields
+  // EADDRNOTAVAIL deterministically and hermetically.
+  test("skips an unavailable host (EADDRNOTAVAIL) and still serves on loopback", async () => {
+    const s = await startServer(
+      makeConfig({ hosts: ["127.0.0.1", "192.0.2.1"] }),
+    );
+    try {
+      // The unavailable host is dropped; only the bound host remains.
+      expect(s.hosts).toEqual(["127.0.0.1"]);
+      const res = await fetch(`http://127.0.0.1:${s.port}/health`);
+      expect(res.status).toBe(200);
+    } finally {
+      s.stop();
+    }
+  });
+
+  // The unavailable host appearing FIRST must not prevent binding the
+  // reachable host that follows it (adversarial ordering — the resolved port
+  // must come from the first host that actually binds).
+  test("skips a leading unavailable host and binds the reachable one", async () => {
+    const s = await startServer(
+      makeConfig({ hosts: ["192.0.2.1", "127.0.0.1"] }),
+    );
+    try {
+      expect(s.hosts).toEqual(["127.0.0.1"]);
+      expect(s.port).toBeGreaterThan(0);
+      const res = await fetch(`http://127.0.0.1:${s.port}/health`);
+      expect(res.status).toBe(200);
+    } finally {
+      s.stop();
+    }
+  });
+
+  // If EVERY configured host is unavailable, that is a genuine failure — the
+  // gateway must throw rather than silently bind nothing. Assert the specific
+  // "none available" message (not the raw EADDRNOTAVAIL the base branch threw)
+  // so this is a real guard for the new behavior, not an incidental match.
+  test("throws when all configured hosts are unavailable", async () => {
+    await expect(
+      startServer(makeConfig({ hosts: ["192.0.2.1", "203.0.113.1"] })),
+    ).rejects.toThrow(/none of the configured hosts are available/);
+  });
 });


### PR DESCRIPTION
## Problem

When `LORE_LISTEN_HOST` includes an address that isn't currently assigned to any local interface — e.g. a Tailscale/LAN IP from a tailnet you've left, or an interface that hasn't come up yet at boot — the gateway failed to start entirely with a **misleading** error:

```
[lore] Port 3207 in use (not a lore gateway), trying 5673…
[lore] Port 5673 in use (not a lore gateway), trying random port…
[lore] failed to start gateway in-process: Failed to bind to any port.
```

No port was actually in use. The multi-host bind loop in `server.ts` binds each host sequentially; when one host failed with `EADDRNOTAVAIL` it closed the already-bound loopback server and re-threw. `startGateway()` then matched the error against its EADDRINUSE classifier, walked the whole `3207 → 5673 → 0` fallback (each failing the same way, since the unavailable host can't bind at *any* port), and gave up with "Failed to bind to any port."

This is **REQ-003 condition 3** (the per-host bind resilience explicitly deferred from #903).

## Fix

Treat a configured host that fails with `EADDRNOTAVAIL` / `EADDRNOTFOUND` as **optional**: skip it (with a debug log) and keep binding the rest, so the gateway still comes up on the reachable hosts (e.g. loopback). This lets you keep a Tailscale IP in `LORE_LISTEN_HOST` that comes and goes without breaking startup — no need to switch to `0.0.0.0` (which would drag in remote-gateway mode under the opencode plugin).

Preserved behavior:
- Real conflicts (`EADDRINUSE`) and any other bind error still propagate to `startGateway()`'s probe/reuse/port-fallback logic — unchanged.
- If **every** configured host is unavailable, `startServer()` throws (the gateway must not silently listen nowhere).
- The returned `hosts` now reflect the hosts actually bound, so `/health` probes and logs don't reference a down interface.

## Tests

Added to `packages/gateway/test/server.test.ts` (using `192.0.2.1` / `203.0.113.1`, RFC 5737 TEST-NET addresses that deterministically yield `EADDRNOTAVAIL`):
- skips an unavailable host and still serves on loopback (`hosts: ["127.0.0.1", "192.0.2.1"]`)
- skips a **leading** unavailable host and binds the reachable one (adversarial ordering — resolved port comes from the first host that actually binds)
- throws when **all** configured hosts are unavailable

The two "skip" tests fail on the base branch with the exact `EADDRNOTAVAIL` this PR fixes, and pass with the fix (verified).

## Verification

- `pnpm run typecheck` — clean
- `pnpm run lint` (changed files) — clean
- Full gateway suite — 2057 passed / 26 skipped
- New tests stable ×10 (they bind real sockets)

Closes REQ-003 condition 3.
