### PR TITLE
feat(idle): PR3 — defer prefix-rewriting idle work on hold-warm sessions (D6′)

### DIFF
--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -1086,6 +1086,19 @@ export function setLastTurnAtForTest(sessionID: string, ms: number): void {
 }
 
 /**
+ * For testing only — set the session's consecutiveBusts count. Used to drive
+ * bust-pressure code paths (e.g. the idle handler's deferred-prefix-work
+ * override) without replaying real cache-bust turns. Creates the session state
+ * if not present.
+ */
+export function setConsecutiveBustsForTest(
+  sessionID: string,
+  busts: number,
+): void {
+  getSessionState(sessionID).consecutiveBusts = busts;
+}
+
+/**
  * Persist gradient calibration state to the session_state table.
  *
  * Designed to be called periodically (e.g. every 30s from the idle scheduler

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -161,6 +161,7 @@ export {
   // Test-only — exposed at the barrel so host-package tests can simulate idle
   // gaps without sleeping. Not part of the public API.
   setLastTurnAtForTest,
+  setConsecutiveBustsForTest,
   inspectSessionState,
   getConsecutiveBusts,
   BUST_PRESSURE_THRESHOLD,

--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -29,6 +29,7 @@ import {
   saveGradientState,
   getConsecutiveBusts,
   effectiveMetaThreshold,
+  BUST_PRESSURE_THRESHOLD,
   getCacheStrategy,
   strategyWantsWarming,
   getLastLayer,
@@ -761,15 +762,17 @@ export function buildIdleWorkHandler(
     // (pruning, export, lat refresh, cost metrics) are unaffected.
     const allowWorker = allowWorkerProbe(sessionID);
 
-    // Bust pressure: effectiveMetaThreshold lowers the meta bar once the session
-    // crosses BUST_PRESSURE_THRESHOLD consecutive busts. Reuse that exact signal
-    // (no separate constant) as the "session is churning cache anyway" override.
+    // Bust pressure: the session has bust the cache on enough consecutive turns
+    // that it's churning regardless of intent — flushing deferred prefix work is
+    // free. Use the same BUST_PRESSURE_THRESHOLD that effectiveMetaThreshold uses
+    // to lower the meta bar (single source of truth; deriving it from the lowered
+    // threshold value degenerates to "never" at metaThreshold == 3).
     const busts = getConsecutiveBusts(sessionID);
     const metaThreshold = effectiveMetaThreshold(
       busts,
       cfg.distillation.metaThreshold,
     );
-    const bustPressure = metaThreshold < cfg.distillation.metaThreshold;
+    const bustPressure = busts >= BUST_PRESSURE_THRESHOLD;
 
     // D6′ deferred prefix work (PR2b follow-on): the idle force-distill below was
     // written assuming "idle ⇒ cache going cold." That is no longer true — when

--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -29,12 +29,14 @@ import {
   saveGradientState,
   getConsecutiveBusts,
   effectiveMetaThreshold,
+  getCacheStrategy,
+  strategyWantsWarming,
   getLastLayer,
   evictSession as evictGradientSession,
   distillLimiter,
   curatorLimiter,
 } from "@loreai/core";
-import type { ChangedEntry, LLMClient } from "@loreai/core";
+import type { CacheStrategy, ChangedEntry, LLMClient } from "@loreai/core";
 import {
   makeWorkerHealth,
   allowWorkerProbe,
@@ -210,6 +212,34 @@ export function invalidateWarmupBodyAfterIdleDistill(
     prefixMutated && layer >= 1 && state.cacheAnalytics.lastRequestBody != null;
   if (stale) state.cacheAnalytics.lastRequestBody = null;
   return stale;
+}
+
+/**
+ * D6′ deferred prefix work (PR2b follow-on): should the idle handler DEFER its
+ * prefix-rewriting steps (force-distillation, meta-consolidation) to avoid
+ * busting a cache the warmer is deliberately keeping warm?
+ *
+ * Defer ⇔ the unified cache-economics strategy confidently wants to keep this
+ * session warm (`hold-warm`) AND the session is NOT under bust pressure. A
+ * cool-bust / cool-full-write / non-confident session is busting (or letting go
+ * of) its prefix anyway, so flushing now is free. Bust pressure overrides
+ * hold-warm: a churning session is busting cache regardless of intent, so the
+ * deferred work is free at that point too.
+ *
+ * This only biases the SCHEDULE — it never starves distillation/LTM. The
+ * existing urgency thresholds still fire: distillation falls back to the
+ * `minMessages` gate (a ≥minMessages backlog distills even while held warm), and
+ * meta-consolidation keeps its `gen0 >= metaThreshold` gate.
+ */
+export function shouldHoldPrefixWarm(
+  econ: { result: { strategy: CacheStrategy; confident: boolean } } | null,
+  bustPressure: boolean,
+): boolean {
+  if (bustPressure) return false;
+  return (
+    econ?.result.confident === true &&
+    strategyWantsWarming(econ.result.strategy)
+  );
 }
 
 /**
@@ -731,9 +761,36 @@ export function buildIdleWorkHandler(
     // (pruning, export, lat refresh, cost metrics) are unaffected.
     const allowWorker = allowWorkerProbe(sessionID);
 
-    // 1. Distillation — force-distill ALL pending messages on idle, even
-    // below minMessages. The cache is going cold; aggressive distillation
-    // now means a smaller context on the next turn via post-idle compact.
+    // Bust pressure: effectiveMetaThreshold lowers the meta bar once the session
+    // crosses BUST_PRESSURE_THRESHOLD consecutive busts. Reuse that exact signal
+    // (no separate constant) as the "session is churning cache anyway" override.
+    const busts = getConsecutiveBusts(sessionID);
+    const metaThreshold = effectiveMetaThreshold(
+      busts,
+      cfg.distillation.metaThreshold,
+    );
+    const bustPressure = metaThreshold < cfg.distillation.metaThreshold;
+
+    // D6′ deferred prefix work (PR2b follow-on): the idle force-distill below was
+    // written assuming "idle ⇒ cache going cold." That is no longer true — when
+    // the unified cache-economics strategy is `hold-warm`, the warmer is (or will
+    // be) paying to keep this session's prompt prefix alive. Force-distilling /
+    // meta-consolidating then rewrites the very prefix we're paying to keep warm
+    // (busting the cache and forcing the warmer to re-WRITE instead of re-READ).
+    // So on hold-warm we DEFER the prefix-rewriting steps; cool-bust /
+    // cool-full-write / non-confident sessions still flush aggressively (the
+    // prefix is busting anyway — flushing is free). See shouldHoldPrefixWarm.
+    const holdingWarm = shouldHoldPrefixWarm(
+      getCacheStrategy(sessionID),
+      bustPressure,
+    );
+
+    // 1. Distillation. When NOT holding the cache warm, force-distill ALL pending
+    // messages even below minMessages — the cache is going cold, so aggressive
+    // distillation now means a smaller context on the next turn via post-idle
+    // compact. When holding warm, defer: pass force=false so distillation runs
+    // only once enough has piled up (the existing minMessages gate is the natural
+    // urgency override — a ≥minMessages backlog warrants the rewrite regardless).
     // Skip meta-distillation in the run() call: we run it as a separate
     // step below so gen-0 segments from the force-distill are counted.
     // Tracks whether this tick's distillation rewrote the in-context distilled
@@ -751,7 +808,7 @@ export function buildIdleWorkHandler(
           projectPath,
           sessionID,
           model,
-          force: true,
+          force: !holdingWarm,
           skipMeta: true,
           callType,
           workerHealth: makeWorkerHealth(sessionID, "lore-distill"),
@@ -764,19 +821,13 @@ export function buildIdleWorkHandler(
         // warmup body) unchanged. Gating on it avoids nulling a still-valid body.
         if (result.distilled > 0) idlePrefixMutated = true;
       }
-      // Meta consolidation: safe on idle because cache is already cold.
-      // Run as a separate step so gen-0 segments from the force-distill
-      // above are counted toward the threshold.
-      // Under bust pressure (3+ consecutive busts), lower the threshold
-      // to consolidate earlier — shrinks the distilled prefix before the
-      // session becomes unsustainable.
-      const busts = getConsecutiveBusts(sessionID);
-      const metaThreshold = effectiveMetaThreshold(
-        busts,
-        cfg.distillation.metaThreshold,
-      );
+      // Meta consolidation — also a prefix rewrite (archives gen-0, adds gen-1+),
+      // so it's deferred under the same hold-warm bias. Run as a separate step so
+      // gen-0 segments from the force-distill above are counted toward the
+      // threshold. Under bust pressure the threshold is already lowered AND
+      // holdingWarm is false, so a churning session consolidates earlier.
       const g0 = distillation.gen0Count(projectPath, sessionID);
-      if (allowWorker && g0 >= metaThreshold) {
+      if (allowWorker && g0 >= metaThreshold && !holdingWarm) {
         const meta = await distillation.metaDistill({
           llm,
           projectPath,

--- a/packages/gateway/test/idle-work.test.ts
+++ b/packages/gateway/test/idle-work.test.ts
@@ -33,6 +33,7 @@ import {
   setCacheSizeSnapshot,
   evaluateCacheStrategy,
   setCachePricing,
+  setConsecutiveBustsForTest,
   evictSession,
 } from "@loreai/core";
 import type { LLMClient } from "@loreai/core";
@@ -423,81 +424,128 @@ describe("buildIdleWorkHandler", () => {
     expect(state.cacheAnalytics.lastRequestBody).not.toBeNull();
   });
 
-  // D6′: hold-warm sessions DEFER the idle force-distill (the existing minMessages
-  // gate is the urgency override). cool-bust sessions still force-distill below
-  // minMessages. Drive both through the real handler and assert via the
-  // distillation LLM call: with a sub-minMessages backlog, only the cool-bust
-  // session reaches the LLM.
-  test("hold-warm defers idle distillation below minMessages; cool-bust flushes (D6′)", async () => {
+  // D6′ deferred prefix work — drive the real handler and assert via the worker
+  // LLM call. Shared helpers below.
+  const D6_PRICE = {
+    readPerToken: 0.3 / 1_000_000,
+    writePerToken: 3.75 / 1_000_000,
+  };
+  const D6_INPUTS = {
+    pReturn: 0.9,
+    expectedCycles: 4,
+    expectedFutureTurns: 50,
+  };
+
+  // Store a confident strategy for the session. (10k/10k → hold-warm;
+  // 800k/100k → cool-bust, verified by the assertions at each call site.)
+  function d6SetStrategy(sessionID: string, full: number, compressed: number) {
     setCachePricing(3.75, 0.3);
-    const T = Date.now();
-    const PRICE = {
-      readPerToken: 0.3 / 1_000_000,
-      writePerToken: 3.75 / 1_000_000,
-    };
-    const INPUTS = { pReturn: 0.9, expectedCycles: 4, expectedFutureTurns: 50 };
+    setCacheSizeSnapshot(sessionID, full, compressed);
+    return evaluateCacheStrategy(sessionID, D6_INPUTS, D6_PRICE)?.strategy;
+  }
 
-    // 3 undistilled messages — below the default minMessages (5).
-    function seed(sessionID: string): string {
-      const projectPath = makeProjectDir();
-      const pid = ensureProject(projectPath);
-      for (let i = 0; i < 3; i++) {
-        db()
-          .query(
-            `INSERT INTO temporal_messages (id, project_id, session_id, role, content, tokens, distilled, created_at, metadata)
-             VALUES (?, ?, ?, 'user', ?, ?, 0, ?, '{}')`,
-          )
-          .run(
-            `${sessionID}-m${i}`,
-            pid,
-            sessionID,
-            "x".repeat(600),
-            200,
-            T + i,
-          );
-      }
-      return projectPath;
+  function d6SeedMessages(sessionID: string, n: number): string {
+    const projectPath = makeProjectDir();
+    const pid = ensureProject(projectPath);
+    for (let i = 0; i < n; i++) {
+      db()
+        .query(
+          `INSERT INTO temporal_messages (id, project_id, session_id, role, content, tokens, distilled, created_at, metadata)
+           VALUES (?, ?, ?, 'user', ?, ?, 0, ?, '{}')`,
+        )
+        .run(`${sessionID}-m${i}`, pid, sessionID, "x".repeat(600), 200, i);
     }
+    return projectPath;
+  }
 
-    async function runIdle(sessionID: string, projectPath: string) {
-      const llm: LLMClient = {
-        prompt: vi.fn(async () => "<observations>x</observations>"),
-      };
-      const prev = process.env.LORE_BATCH_DISABLED;
-      process.env.LORE_BATCH_DISABLED = "1"; // direct (synchronous) distillation
-      try {
-        await buildIdleWorkHandler(llm)(
+  // Seed >= metaThreshold (20) gen-0 distillations on an already-distilled
+  // project (no undistilled messages), so the meta-consolidation gate is the
+  // ONLY step that can call the worker LLM.
+  function d6SeedGen0(sessionID: string): string {
+    const projectPath = makeProjectDir();
+    const pid = ensureProject(projectPath);
+    for (let i = 0; i < 20; i++) {
+      db()
+        .query(
+          `INSERT INTO distillations (id, project_id, session_id, narrative, facts, observations, source_ids, generation, token_count, archived, created_at)
+           VALUES (?, ?, ?, '', '', ?, '[]', 0, ?, 0, ?)`,
+        )
+        .run(
+          `${sessionID}-g0-${i}`,
+          pid,
           sessionID,
-          makeSessionState({ sessionID, projectPath, turnsSinceCuration: 0 }),
+          `obs ${i} `.repeat(20),
+          50,
+          i,
         );
-      } finally {
-        if (prev === undefined) delete process.env.LORE_BATCH_DISABLED;
-        else process.env.LORE_BATCH_DISABLED = prev;
-      }
-      return llm;
     }
+    return projectPath;
+  }
 
-    // hold-warm (small body, high return) → defer → distillation never runs.
-    const warm = "idle-d6-holdwarm";
-    const warmPath = seed(warm);
-    setCacheSizeSnapshot(warm, 10_000, 10_000);
-    expect(evaluateCacheStrategy(warm, INPUTS, PRICE)?.strategy).toBe(
-      "hold-warm",
-    );
-    const warmLLM = await runIdle(warm, warmPath);
-    expect(warmLLM.prompt).not.toHaveBeenCalled();
+  async function d6RunIdle(sessionID: string, projectPath: string) {
+    const llm: LLMClient = {
+      prompt: vi.fn(async () => "<observations>x</observations>"),
+    };
+    const prev = process.env.LORE_BATCH_DISABLED;
+    process.env.LORE_BATCH_DISABLED = "1"; // direct (synchronous) distillation
+    try {
+      await buildIdleWorkHandler(llm)(
+        sessionID,
+        makeSessionState({ sessionID, projectPath, turnsSinceCuration: 0 }),
+      );
+    } finally {
+      if (prev === undefined) delete process.env.LORE_BATCH_DISABLED;
+      else process.env.LORE_BATCH_DISABLED = prev;
+    }
+    return llm;
+  }
+
+  // Distillation gate: a sub-minMessages backlog is deferred on hold-warm but
+  // force-distilled on cool-bust. The worker LLM is reached only for cool-bust.
+  test("D6′: hold-warm defers idle distillation below minMessages; cool-bust flushes", async () => {
+    const warm = "idle-d6-distill-holdwarm";
+    const warmPath = d6SeedMessages(warm, 3); // < minMessages (5)
+    expect(d6SetStrategy(warm, 10_000, 10_000)).toBe("hold-warm");
+    expect((await d6RunIdle(warm, warmPath)).prompt).not.toHaveBeenCalled();
     evictSession(warm);
 
-    // cool-bust (large body, compaction available) → flush → distillation runs.
-    const cool = "idle-d6-coolbust";
-    const coolPath = seed(cool);
-    setCacheSizeSnapshot(cool, 800_000, 100_000);
-    expect(evaluateCacheStrategy(cool, INPUTS, PRICE)?.strategy).toBe(
-      "cool-bust",
-    );
-    const coolLLM = await runIdle(cool, coolPath);
-    expect(coolLLM.prompt).toHaveBeenCalled();
+    const cool = "idle-d6-distill-coolbust";
+    const coolPath = d6SeedMessages(cool, 3);
+    expect(d6SetStrategy(cool, 800_000, 100_000)).toBe("cool-bust");
+    expect((await d6RunIdle(cool, coolPath)).prompt).toHaveBeenCalled();
     evictSession(cool);
+  });
+
+  // Meta gate: with >= metaThreshold gen-0 and no undistilled messages, the
+  // `g0 >= metaThreshold && !holdingWarm` gate is the only LLM caller. hold-warm
+  // defers meta-consolidation; cool-bust runs it. (Kills the `&& !holdingWarm`
+  // mutation — the distillation gate can't reach this branch.)
+  test("D6′: hold-warm defers meta-consolidation; cool-bust runs it", async () => {
+    const warm = "idle-d6-meta-holdwarm";
+    const warmPath = d6SeedGen0(warm);
+    expect(d6SetStrategy(warm, 10_000, 10_000)).toBe("hold-warm");
+    expect((await d6RunIdle(warm, warmPath)).prompt).not.toHaveBeenCalled();
+    evictSession(warm);
+
+    const cool = "idle-d6-meta-coolbust";
+    const coolPath = d6SeedGen0(cool);
+    expect(d6SetStrategy(cool, 800_000, 100_000)).toBe("cool-bust");
+    expect((await d6RunIdle(cool, coolPath)).prompt).toHaveBeenCalled();
+    evictSession(cool);
+  });
+
+  // Urgency override: a hold-warm session under bust pressure
+  // (consecutiveBusts >= BUST_PRESSURE_THRESHOLD) flushes anyway — a churning
+  // session is busting cache regardless of intent. Same sub-minMessages backlog
+  // that the first test deferred now force-distills because of the bust pressure.
+  test("D6′: bust pressure overrides hold-warm and force-distills", async () => {
+    const sessionID = "idle-d6-bust-override";
+    const projectPath = d6SeedMessages(sessionID, 3); // < minMessages
+    expect(d6SetStrategy(sessionID, 10_000, 10_000)).toBe("hold-warm");
+    // Mark the session as churning AFTER the strategy is stored.
+    setConsecutiveBustsForTest(sessionID, 3); // >= BUST_PRESSURE_THRESHOLD
+    expect((await d6RunIdle(sessionID, projectPath)).prompt).toHaveBeenCalled();
+    evictSession(sessionID);
   });
 
   test("exports a knowledge file when the project has entries", async () => {

--- a/packages/gateway/test/idle-work.test.ts
+++ b/packages/gateway/test/idle-work.test.ts
@@ -18,13 +18,23 @@ import {
   consolidationCooldownActive,
   perCategoryThreshold,
   invalidateWarmupBodyAfterIdleDistill,
+  shouldHoldPrefixWarm,
   CONSOLIDATION_COOLDOWN_MS,
   CONSOLIDATION_REATTEMPT_GROWTH,
 } from "../src/idle";
 import { recordConversationCost, clearAllCosts } from "../src/cost-tracker";
 import { resetPipelineState } from "../src/pipeline";
 import { compressBody } from "../src/cache-analytics";
-import { ltm, loadSessionCosts, db, ensureProject } from "@loreai/core";
+import {
+  ltm,
+  loadSessionCosts,
+  db,
+  ensureProject,
+  setCacheSizeSnapshot,
+  evaluateCacheStrategy,
+  setCachePricing,
+  evictSession,
+} from "@loreai/core";
 import type { LLMClient } from "@loreai/core";
 import type { SessionState } from "../src/translate/types";
 
@@ -226,6 +236,35 @@ describe("invalidateWarmupBodyAfterIdleDistill", () => {
   });
 });
 
+describe("shouldHoldPrefixWarm (D6′ defer decision)", () => {
+  function econ(
+    strategy: "hold-warm" | "cool-bust" | "cool-full-write",
+    confident: boolean,
+  ) {
+    return { result: { strategy, confident }, decidedAt: Date.now() };
+  }
+
+  test("hold-warm + no bust pressure → defer prefix rewrites", () => {
+    expect(shouldHoldPrefixWarm(econ("hold-warm", true), false)).toBe(true);
+  });
+
+  test("hold-warm + bust pressure → flush (churning busts cache anyway)", () => {
+    expect(shouldHoldPrefixWarm(econ("hold-warm", true), true)).toBe(false);
+  });
+
+  test("cool-bust / cool-full-write → never defer (prefix busting anyway)", () => {
+    expect(shouldHoldPrefixWarm(econ("cool-bust", true), false)).toBe(false);
+    expect(shouldHoldPrefixWarm(econ("cool-full-write", true), false)).toBe(
+      false,
+    );
+  });
+
+  test("non-confident strategy or null → flush (legacy aggressive behavior)", () => {
+    expect(shouldHoldPrefixWarm(econ("hold-warm", false), false)).toBe(false);
+    expect(shouldHoldPrefixWarm(null, false)).toBe(false);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // buildIdleWorkHandler
 // ---------------------------------------------------------------------------
@@ -382,6 +421,83 @@ describe("buildIdleWorkHandler", () => {
     // this session never transformed → getLastLayer == 0 → its full-passthrough
     // warmup body is preserved (only COMPRESSED sessions are invalidated).
     expect(state.cacheAnalytics.lastRequestBody).not.toBeNull();
+  });
+
+  // D6′: hold-warm sessions DEFER the idle force-distill (the existing minMessages
+  // gate is the urgency override). cool-bust sessions still force-distill below
+  // minMessages. Drive both through the real handler and assert via the
+  // distillation LLM call: with a sub-minMessages backlog, only the cool-bust
+  // session reaches the LLM.
+  test("hold-warm defers idle distillation below minMessages; cool-bust flushes (D6′)", async () => {
+    setCachePricing(3.75, 0.3);
+    const T = Date.now();
+    const PRICE = {
+      readPerToken: 0.3 / 1_000_000,
+      writePerToken: 3.75 / 1_000_000,
+    };
+    const INPUTS = { pReturn: 0.9, expectedCycles: 4, expectedFutureTurns: 50 };
+
+    // 3 undistilled messages — below the default minMessages (5).
+    function seed(sessionID: string): string {
+      const projectPath = makeProjectDir();
+      const pid = ensureProject(projectPath);
+      for (let i = 0; i < 3; i++) {
+        db()
+          .query(
+            `INSERT INTO temporal_messages (id, project_id, session_id, role, content, tokens, distilled, created_at, metadata)
+             VALUES (?, ?, ?, 'user', ?, ?, 0, ?, '{}')`,
+          )
+          .run(
+            `${sessionID}-m${i}`,
+            pid,
+            sessionID,
+            "x".repeat(600),
+            200,
+            T + i,
+          );
+      }
+      return projectPath;
+    }
+
+    async function runIdle(sessionID: string, projectPath: string) {
+      const llm: LLMClient = {
+        prompt: vi.fn(async () => "<observations>x</observations>"),
+      };
+      const prev = process.env.LORE_BATCH_DISABLED;
+      process.env.LORE_BATCH_DISABLED = "1"; // direct (synchronous) distillation
+      try {
+        await buildIdleWorkHandler(llm)(
+          sessionID,
+          makeSessionState({ sessionID, projectPath, turnsSinceCuration: 0 }),
+        );
+      } finally {
+        if (prev === undefined) delete process.env.LORE_BATCH_DISABLED;
+        else process.env.LORE_BATCH_DISABLED = prev;
+      }
+      return llm;
+    }
+
+    // hold-warm (small body, high return) → defer → distillation never runs.
+    const warm = "idle-d6-holdwarm";
+    const warmPath = seed(warm);
+    setCacheSizeSnapshot(warm, 10_000, 10_000);
+    expect(evaluateCacheStrategy(warm, INPUTS, PRICE)?.strategy).toBe(
+      "hold-warm",
+    );
+    const warmLLM = await runIdle(warm, warmPath);
+    expect(warmLLM.prompt).not.toHaveBeenCalled();
+    evictSession(warm);
+
+    // cool-bust (large body, compaction available) → flush → distillation runs.
+    const cool = "idle-d6-coolbust";
+    const coolPath = seed(cool);
+    setCacheSizeSnapshot(cool, 800_000, 100_000);
+    expect(evaluateCacheStrategy(cool, INPUTS, PRICE)?.strategy).toBe(
+      "cool-bust",
+    );
+    const coolLLM = await runIdle(cool, coolPath);
+    expect(coolLLM.prompt).toHaveBeenCalled();
+    evictSession(cool);
   });
 
   test("exports a knowledge file when the project has entries", async () => {


### PR DESCRIPTION
The final piece of the cache-economics roadmap. The idle handler force-distilled (and meta-consolidated) on **every** idle tick — it was written assuming "idle ⇒ cache going cold." Under the unified model that's wrong for **hold-warm** sessions: the warmer is paying to keep that exact prefix alive, and rewriting it busts the cache (forcing a re-WRITE instead of a re-READ) — the same waste PR #877 had to band-aid by nulling the warmup body afterward.

## D6′: gate prefix-rewriting idle work on the stored strategy

- **hold-warm** (confident) + no bust pressure → **DEFER**: distillation runs with `force=false` (falls back to the existing `minMessages` gate); meta-consolidation is skipped. The prefix stays byte-stable so the warmer keeps hitting cache.
- **cool-bust / cool-full-write / non-confident** → **flush** aggressively as before (the prefix is busting/cooling anyway — the work is free now).
- **Bust pressure overrides** hold-warm (a churning session busts cache regardless), derived from the existing `effectiveMetaThreshold` signal — **no new constant**.

## Never starves distillation/LTM
The urgency thresholds still fire: the `minMessages` backlog gate (distillation), the `gen0 >= metaThreshold` gate (meta), and bust pressure (flips back to flush). A held-warm session that accumulates a real backlog still distills.

## Scope
Strictly **deferred prefix work**: distillation + meta-consolidation. LTM curation/consolidation are *not* prefix rewrites (system[1] is frozen for the session's life), so they're out of scope.

## Implementation
Decision extracted as the pure exported `shouldHoldPrefixWarm(econ, bustPressure)` helper (same pattern as PR #896's `decideSkipCompact`).

## Tests
- 4-case helper matrix: hold-warm+no-bust → defer; hold-warm+bust → flush; cool-bust/cool-full-write → flush; non-confident/null → flush.
- Handler integration test: seeds a sub-`minMessages` backlog, sets a real strategy via `evaluateCacheStrategy`, drives the full handler, and asserts the distillation LLM is called **only** for the cool-bust session — proving hold-warm defers and cool-bust flushes end-to-end.

## Verification
typecheck (5 pkgs) clean; lint clean (19 warnings, all pre-existing, none in touched files); full suite **3847 passed**; `pnpm build` clean.