### PR TITLE
feat(core): surface knowledge "outcome impact" in lore data show (#497 follow-up)

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1373,6 +1373,17 @@ const MIGRATIONS: string[] = [
   CREATE INDEX IF NOT EXISTS idx_ksi_session_uncredited
     ON knowledge_session_injections (session_id, credited);
   `,
+
+  `
+  -- Version 54: record the session's verifier verdict on each injection at
+  -- credit time (#497 follow-up). Enables per-entry "knowledge impact" stats
+  -- (how many passing vs failing sessions an entry co-occurred with) surfaced in
+  -- 'lore data show'. NULL until the injection is credited (or the session had
+  -- no verifier signal).
+  ALTER TABLE knowledge_session_injections ADD COLUMN verdict TEXT;
+  CREATE INDEX IF NOT EXISTS idx_ksi_logical_verdict
+    ON knowledge_session_injections (logical_id, verdict);
+  `,
 ];
 
 /**
@@ -1749,10 +1760,13 @@ function recoverMissingObjects(database: Database) {
       project_id  TEXT NOT NULL,
       created_at  INTEGER NOT NULL,
       credited    INTEGER NOT NULL DEFAULT 0,
+      verdict     TEXT,
       PRIMARY KEY (session_id, logical_id)
     );
     CREATE INDEX IF NOT EXISTS idx_ksi_session_uncredited
       ON knowledge_session_injections (session_id, credited);
+    CREATE INDEX IF NOT EXISTS idx_ksi_logical_verdict
+      ON knowledge_session_injections (logical_id, verdict);
     CREATE TABLE IF NOT EXISTS knowledge_transfers (
       knowledge_id           TEXT NOT NULL,
       recalled_in_project_id TEXT NOT NULL,
@@ -1906,6 +1920,17 @@ function recoverMissingObjects(database: Database) {
       .all() as Array<{ name: string }>;
     if (!tcols.some((c) => c.name === "verifier")) {
       database.exec("ALTER TABLE tool_calls ADD COLUMN verifier INTEGER;");
+    }
+  }
+  // Version 54: knowledge_session_injections.verdict (outcome impact, #497).
+  {
+    const icols = database
+      .query("PRAGMA table_info(knowledge_session_injections)")
+      .all() as Array<{ name: string }>;
+    if (icols.length && !icols.some((c) => c.name === "verdict")) {
+      database.exec(
+        "ALTER TABLE knowledge_session_injections ADD COLUMN verdict TEXT;",
+      );
     }
   }
 }

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1765,8 +1765,6 @@ function recoverMissingObjects(database: Database) {
     );
     CREATE INDEX IF NOT EXISTS idx_ksi_session_uncredited
       ON knowledge_session_injections (session_id, credited);
-    CREATE INDEX IF NOT EXISTS idx_ksi_logical_verdict
-      ON knowledge_session_injections (logical_id, verdict);
     CREATE TABLE IF NOT EXISTS knowledge_transfers (
       knowledge_id           TEXT NOT NULL,
       recalled_in_project_id TEXT NOT NULL,
@@ -1923,13 +1921,21 @@ function recoverMissingObjects(database: Database) {
     }
   }
   // Version 54: knowledge_session_injections.verdict (outcome impact, #497).
+  // The verdict-keyed index MUST be created here, AFTER the column is ensured —
+  // never in the big exec above, which runs before this ALTER and would throw
+  // `no such column: verdict` while recovering a pre-v54 (verdict-less) table.
   {
     const icols = database
       .query("PRAGMA table_info(knowledge_session_injections)")
       .all() as Array<{ name: string }>;
-    if (icols.length && !icols.some((c) => c.name === "verdict")) {
+    if (icols.length) {
+      if (!icols.some((c) => c.name === "verdict")) {
+        database.exec(
+          "ALTER TABLE knowledge_session_injections ADD COLUMN verdict TEXT;",
+        );
+      }
       database.exec(
-        "ALTER TABLE knowledge_session_injections ADD COLUMN verdict TEXT;",
+        "CREATE INDEX IF NOT EXISTS idx_ksi_logical_verdict ON knowledge_session_injections (logical_id, verdict);",
       );
     }
   }

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -970,16 +970,57 @@ export function creditSessionOutcome(
         .run(OUTCOME_PENALTY, now, pid, ...ids);
     }
 
-    // Mark this session's injections credited so a later idle tick is a no-op.
+    // Mark this session's injections credited (so a later idle tick is a no-op)
+    // and record the verdict for per-entry "knowledge impact" stats (#497).
     db()
       .query(
-        `UPDATE knowledge_session_injections SET credited = 1
+        `UPDATE knowledge_session_injections SET credited = 1, verdict = ?
          WHERE session_id = ? AND project_id = ? AND credited = 0`,
       )
-      .run(sessionID, pid);
+      .run(verdict, sessionID, pid);
   });
 
   return { verdict, credited: ids.length };
+}
+
+/** Per-entry outcome co-occurrence stats for the reward loop (#497). */
+export type OutcomeImpact = {
+  /** Sessions this entry was injected into that ended with passing verifiers. */
+  passes: number;
+  /** Sessions this entry was injected into that ended with failing verifiers. */
+  fails: number;
+  /** The most recent recorded verdict ('pass'|'fail'), or null if never credited. */
+  lastVerdict: "pass" | "fail" | null;
+};
+
+/**
+ * Aggregate the verifier outcomes a knowledge entry has co-occurred with, by its
+ * stable `logical_id` (A2). Reads credited injection rows; 'none' verdicts are
+ * not recorded (no signal), so only pass/fail are counted. Read-only — surfaced
+ * by `lore data show` so the reward loop's effect is observable.
+ */
+export function outcomeImpact(logicalId: string): OutcomeImpact {
+  const rows = db()
+    .query(
+      `SELECT verdict, COUNT(*) AS n, MAX(created_at) AS last_at
+       FROM knowledge_session_injections
+       WHERE logical_id = ? AND verdict IN ('pass','fail')
+       GROUP BY verdict`,
+    )
+    .all(logicalId) as { verdict: string; n: number; last_at: number }[];
+  let passes = 0;
+  let fails = 0;
+  let lastVerdict: "pass" | "fail" | null = null;
+  let lastAt = -1;
+  for (const r of rows) {
+    if (r.verdict === "pass") passes = r.n;
+    else if (r.verdict === "fail") fails = r.n;
+    if (r.last_at > lastAt) {
+      lastAt = r.last_at;
+      lastVerdict = r.verdict as "pass" | "fail";
+    }
+  }
+  return { passes, fails, lastVerdict };
 }
 
 /**

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -989,7 +989,9 @@ export type OutcomeImpact = {
   passes: number;
   /** Sessions this entry was injected into that ended with failing verifiers. */
   fails: number;
-  /** The most recent recorded verdict ('pass'|'fail'), or null if never credited. */
+  /** Verdict of the most-recently-injected credited session ('pass'|'fail'), or
+   *  null if never credited. Ordered by injection time (created_at), not credit
+   *  time — there is no credit-time column; this is an observability hint only. */
   lastVerdict: "pass" | "fail" | null;
 };
 

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -1572,6 +1572,45 @@ describe("db", () => {
       ).toBe(true);
     });
 
+    test("recoverMissingObjects re-adds knowledge_session_injections.verdict without throwing on the index", () => {
+      // Regression: the (logical_id, verdict) index must be created AFTER the
+      // verdict column is ensured. Dropping the column (SQLite also drops the
+      // dependent index) then reopening must self-heal — not throw
+      // `no such column: verdict` while recovering a pre-v54 table.
+      const d = db();
+      // SQLite refuses to drop a column an index depends on — drop the index
+      // first, reproducing a pre-v54 table (no verdict column, no verdict index).
+      d.exec("DROP INDEX IF EXISTS idx_ksi_logical_verdict");
+      d.exec("ALTER TABLE knowledge_session_injections DROP COLUMN verdict");
+      expect(
+        (
+          d
+            .query("PRAGMA table_info(knowledge_session_injections)")
+            .all() as Array<{
+            name: string;
+          }>
+        ).some((c) => c.name === "verdict"),
+      ).toBe(false);
+
+      close();
+      const fresh = db(); // must not throw
+      expect(
+        (
+          fresh
+            .query("PRAGMA table_info(knowledge_session_injections)")
+            .all() as Array<{ name: string }>
+        ).some((c) => c.name === "verdict"),
+      ).toBe(true);
+      // The verdict-keyed index is restored too.
+      expect(
+        (
+          fresh
+            .query("PRAGMA index_list(knowledge_session_injections)")
+            .all() as Array<{ name: string }>
+        ).some((i) => i.name === "idx_ksi_logical_verdict"),
+      ).toBe(true);
+    });
+
     test("findSessionStatesByFingerprint returns only matching non-empty fingerprints", () => {
       const sidA = `adopt-a-${crypto.randomUUID()}`;
       const sidB = `adopt-b-${crypto.randomUUID()}`;

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -58,7 +58,7 @@ describe("db", () => {
     const row = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(row.version).toBe(53);
+    expect(row.version).toBe(54);
   });
 
   test("session_prompt_deltas persist ordered selector/content rows (v42)", () => {

--- a/packages/core/test/ltm-outcome-reward.test.ts
+++ b/packages/core/test/ltm-outcome-reward.test.ts
@@ -379,3 +379,72 @@ describe("outcome-reward: creditSessionOutcome", () => {
     expect(res.credited).toBe(0);
   });
 });
+
+describe("outcome-reward: outcomeImpact (observability, #497 follow-up)", () => {
+  let pid: string;
+  beforeEach(() => {
+    pid = ensureProject(PROJECT);
+    db().query("DELETE FROM knowledge WHERE project_id = ?").run(pid);
+    db().query("DELETE FROM tool_calls WHERE project_id = ?").run(pid);
+    db()
+      .query("DELETE FROM knowledge_session_injections WHERE project_id = ?")
+      .run(pid);
+  });
+
+  /** Credit one entry in a fresh session with the given verdict. */
+  function creditOnce(
+    logicalId: string,
+    session: string,
+    verdict: "pass" | "fail",
+  ): void {
+    db()
+      .query(
+        `INSERT INTO knowledge_session_injections (session_id, logical_id, project_id, created_at, credited)
+         VALUES (?, ?, ?, ?, 0)`,
+      )
+      .run(session, logicalId, pid, Date.now());
+    insertToolCall(pid, {
+      session,
+      status: verdict === "pass" ? "completed" : "error",
+      verifier: 1,
+    });
+    ltm.creditSessionOutcome(session, PROJECT);
+  }
+
+  test("aggregates pass/fail co-occurrence counts and the last verdict", () => {
+    const e = makeProjectEntry("imp-1", 0.5);
+    const lid = getEntry(e).logical_id;
+    creditOnce(lid, "i-a", "pass");
+    creditOnce(lid, "i-b", "pass");
+    creditOnce(lid, "i-c", "fail");
+
+    const impact = ltm.outcomeImpact(lid);
+    expect(impact.passes).toBe(2);
+    expect(impact.fails).toBe(1);
+    expect(impact.lastVerdict).toBe("fail"); // most recent credited session
+  });
+
+  test("zero for an entry that has never been credited", () => {
+    const e = makeProjectEntry("imp-2", 0.5);
+    const impact = ltm.outcomeImpact(getEntry(e).logical_id);
+    expect(impact).toEqual({ passes: 0, fails: 0, lastVerdict: null });
+  });
+
+  test("a NONE-verdict session records no verdict (uncredited, not counted)", () => {
+    const e = makeProjectEntry("imp-3", 0.5);
+    const lid = getEntry(e).logical_id;
+    db()
+      .query(
+        `INSERT INTO knowledge_session_injections (session_id, logical_id, project_id, created_at, credited)
+         VALUES (?, ?, ?, ?, 0)`,
+      )
+      .run("i-none", lid, pid, Date.now());
+    // No verifier tool call → verdict 'none' → nothing recorded.
+    ltm.creditSessionOutcome("i-none", PROJECT);
+    expect(ltm.outcomeImpact(lid)).toEqual({
+      passes: 0,
+      fails: 0,
+      lastVerdict: null,
+    });
+  });
+});

--- a/packages/core/test/ltm-outcome-reward.test.ts
+++ b/packages/core/test/ltm-outcome-reward.test.ts
@@ -424,6 +424,28 @@ describe("outcome-reward: outcomeImpact (observability, #497 follow-up)", () => 
     expect(impact.lastVerdict).toBe("fail"); // most recent credited session
   });
 
+  test("ignores uncredited (NULL-verdict) rows even when more recently injected", () => {
+    // Pins the `verdict IN ('pass','fail')` filter: a later-injected but
+    // still-uncredited (NULL verdict) row must NOT clobber lastVerdict or be
+    // counted. Without the filter, the NULL group's MAX(created_at) wins and
+    // lastVerdict collapses to null.
+    const e = makeProjectEntry("imp-null", 0.5);
+    const lid = getEntry(e).logical_id;
+    creditOnce(lid, "i-pass", "pass");
+    // An uncredited injection in a LATER session (higher created_at, verdict NULL).
+    db()
+      .query(
+        `INSERT INTO knowledge_session_injections (session_id, logical_id, project_id, created_at, credited, verdict)
+         VALUES (?, ?, ?, ?, 0, NULL)`,
+      )
+      .run("i-later-uncredited", lid, pid, Date.now() + 60_000);
+
+    const impact = ltm.outcomeImpact(lid);
+    expect(impact.passes).toBe(1);
+    expect(impact.fails).toBe(0);
+    expect(impact.lastVerdict).toBe("pass"); // NULL row excluded
+  });
+
   test("zero for an entry that has never been credited", () => {
     const e = makeProjectEntry("imp-2", 0.5);
     const impact = ltm.outcomeImpact(getEntry(e).logical_id);

--- a/packages/core/test/ltm-versioning.test.ts
+++ b/packages/core/test/ltm-versioning.test.ts
@@ -39,11 +39,11 @@ function ftsHits(token: string): number {
 }
 
 describe("A2 sub-PR 1: append-only knowledge scaffolding", () => {
-  test("schema version is 53", () => {
+  test("schema version is 54", () => {
     const v = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(v.version).toBe(53);
+    expect(v.version).toBe(54);
   });
 
   test("create() defaults logical_id = id, version 1, current, not deleted", () => {

--- a/packages/gateway/src/cli/data.ts
+++ b/packages/gateway/src/cli/data.ts
@@ -266,6 +266,13 @@ async function cmdShow(
       console.log(`Category:    ${entry.category}`);
       console.log(`Title:       ${entry.title}`);
       console.log(`Confidence:  ${entry.confidence}`);
+      const impact = ltm.outcomeImpact(entry.logical_id);
+      if (impact.passes || impact.fails) {
+        console.log(
+          `Outcome:     ${impact.passes} passed / ${impact.fails} failed sessions` +
+            (impact.lastVerdict ? ` (last: ${impact.lastVerdict})` : ""),
+        );
+      }
       console.log(`Project ID:  ${entry.project_id ?? "(global)"}`);
       console.log(`Cross-proj:  ${entry.cross_project ? "yes" : "no"}`);
       console.log(`Session:     ${entry.source_session ?? "(none)"}`);


### PR DESCRIPTION
Follow-up to #902 (outcome-reward, #497). The reward loop was adjusting confidence with no way to observe whether it's doing anything sensible — this makes its effect visible.

## Changes
- **Migration v54**: `knowledge_session_injections.verdict` (recorded at credit time) + `(logical_id, verdict)` index. `recoverMissingObjects` updated (CREATE + explicit PRAGMA/ALTER recovery, matching the v53 `verifier` precedent).
- **`creditSessionOutcome`** now writes the session verdict (`pass`/`fail`) onto the rows it marks `credited`. `NONE` sessions record nothing (no signal — they stay uncredited so a later verifier outcome can still credit them).
- **`ltm.outcomeImpact(logicalId)`** → `{ passes, fails, lastVerdict }`, aggregated across sessions by the A2-stable `logical_id`.
- **`lore data show knowledge <id>`** renders `Outcome: N passed / M failed sessions (last: …)` when there's any signal. (Only the local handler — remote API entries have no local injection stats.)

## Tests
`outcomeImpact` aggregation (pass/fail counts + last verdict, never-credited → zero, NONE → records nothing). Schema-version assertions bumped to 54. Full suite **3845**; typecheck, lint, build green.

## Notes
- A2-safe: verdict lives on the existing `knowledge_session_injections` table keyed by `logical_id` — nothing added to the append-only `knowledge` table.
- Remaining #497 follow-ups (separate PRs): feed outcome verdicts into curator consolidation; raise verifier recall.