### PR TITLE
fix(gateway): per-model client usage cap + message_delta usage leak

### DIFF
--- a/packages/gateway/src/compaction.ts
+++ b/packages/gateway/src/compaction.ts
@@ -78,33 +78,75 @@ export function estimateTokens(text: string): number {
 // ---------------------------------------------------------------------------
 
 /**
- * Claude Code's auto-compact threshold for a 200K context model:
+ * Claude Code's auto-compact arithmetic (mirrors `freecodexyz/free-code`
+ * `src/services/compact/autoCompact.ts`, which is a faithful reimplementation):
  *   effectiveContextWindow = contextWindow - min(maxOutputTokens, 20_000)
- *   autoCompactThreshold  = effectiveContextWindow - 13_000
+ *   autoCompactThreshold   = effectiveContextWindow - 13_000
  *
- * For 200K context → 167K.  We report at most TARGET_RATIO × 167K ≈ 150K
- * so the client's "X% until auto-compact" UI grows naturally but never
- * triggers the compaction.
+ * The client's context meter and auto-compact trigger both read API-reported
+ * usage (`input_tokens + cache_creation + cache_read + output_tokens` from the
+ * last response). We report at most `USAGE_REPORT_RATIO × autoCompactThreshold`
+ * so the client's "X% until auto-compact" UI grows naturally but never trips.
+ *
+ * The cap is **per-model**: it must be derived from the model's real context
+ * window, not hardcoded. A hardcoded 200K cap (the old behavior) reports ~150K
+ * for every model, which on a 1M-context model is wrong by ~6× and on smaller
+ * models can trigger premature compaction.
+ */
+export const AUTOCOMPACT_BUFFER_TOKENS = 13_000;
+/** Tokens Claude Code reserves for the compaction summary output. */
+export const MAX_OUTPUT_RESERVE = 20_000;
+/** Report at most this fraction of the auto-compact threshold. */
+export const USAGE_REPORT_RATIO = 0.9;
+
+/**
+ * Auto-compact threshold for a 200K-context model (effective 180K − 13K).
+ * Retained for cost-tracker's counterfactual "avoided compactions" estimate.
+ * TODO: make cost-tracker per-model too (low blast radius — dashboard estimate).
  */
 export const AUTOCOMPACT_THRESHOLD = 167_000;
-const TARGET_RATIO = 0.9;
-const MAX_REPORTED_USAGE = Math.floor(AUTOCOMPACT_THRESHOLD * TARGET_RATIO);
+
+/**
+ * Largest client-reported usage total for a model with the given context window
+ * and max-output budget. Mirrors `0.9 × (effectiveWindow − 13_000)`.
+ */
+export function maxReportedUsageForModel(
+  contextWindow: number,
+  maxOutputTokens: number,
+): number {
+  const effective =
+    contextWindow - Math.min(maxOutputTokens, MAX_OUTPUT_RESERVE);
+  const threshold = effective - AUTOCOMPACT_BUFFER_TOKENS;
+  return Math.max(0, Math.floor(threshold * USAGE_REPORT_RATIO));
+}
+
+/**
+ * Cap used when the model's real window is unknown — preserves the historical
+ * 200K-model behavior (floor(167_000 × 0.9) = 150_300).
+ */
+export const DEFAULT_MAX_REPORTED_USAGE = maxReportedUsageForModel(
+  200_000,
+  MAX_OUTPUT_RESERVE,
+);
 
 /**
  * Scale usage fields proportionally so the client's total
  * (`input_tokens + cache_creation + cache_read + output_tokens`) stays
- * below `MAX_REPORTED_USAGE`.
+ * below `maxReportedUsage` (per-model; defaults to the 200K-model cap).
  *
  * Returns the original usage unchanged when the total is already safe.
  * Internal Lore systems (calibrate, bustRate) must use the **real** values
  * — only the client-facing response should carry the scaled values.
  */
-export function scaleUsageForClient(usage: {
-  input_tokens: number;
-  output_tokens: number;
-  cache_read_input_tokens?: number;
-  cache_creation_input_tokens?: number;
-}): {
+export function scaleUsageForClient(
+  usage: {
+    input_tokens: number;
+    output_tokens: number;
+    cache_read_input_tokens?: number;
+    cache_creation_input_tokens?: number;
+  },
+  maxReportedUsage: number = DEFAULT_MAX_REPORTED_USAGE,
+): {
   input_tokens: number;
   output_tokens: number;
   cache_read_input_tokens?: number;
@@ -116,9 +158,9 @@ export function scaleUsageForClient(usage: {
     (usage.cache_creation_input_tokens ?? 0) +
     usage.output_tokens;
 
-  if (total <= MAX_REPORTED_USAGE) return usage;
+  if (total <= maxReportedUsage) return usage;
 
-  const scale = MAX_REPORTED_USAGE / total;
+  const scale = maxReportedUsage / total;
   return {
     input_tokens: Math.floor(usage.input_tokens * scale),
     output_tokens: Math.floor(usage.output_tokens * scale),

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -122,6 +122,9 @@ import {
   buildCompactionResponse,
   assembleOfflineCompaction,
   scaleUsageForClient,
+  maxReportedUsageForModel,
+  MAX_OUTPUT_RESERVE,
+  DEFAULT_MAX_REPORTED_USAGE,
 } from "./compaction";
 import {
   buildAnthropicRequest,
@@ -3094,6 +3097,21 @@ async function forwardToUpstream(
 // ---------------------------------------------------------------------------
 
 /**
+ * Per-model cap for client usage scaling. Derives the model's real context
+ * window and max-output budget (models.dev-backed) and mirrors Claude Code's
+ * `0.9 × (effectiveWindow − 13k)`. An empty/missing model id falls back to the
+ * conservative default cap; unknown models use `getModelEntrySync`'s 200K-window
+ * fallback entry (still well under a real 200K client's compaction threshold).
+ */
+function maxReportedUsageForModelID(modelID: string): number {
+  if (!modelID) return DEFAULT_MAX_REPORTED_USAGE;
+  const entry = getModelEntrySync(modelID);
+  const contextWindow = entry.limit?.context ?? 200_000;
+  const maxOutput = entry.limit?.output ?? MAX_OUTPUT_RESERVE;
+  return maxReportedUsageForModel(contextWindow, maxOutput);
+}
+
+/**
  * Create a streaming SSE response from upstream with parallel accumulation.
  *
  * When `recallContext` is provided, uses a recall-aware accumulator that
@@ -3118,12 +3136,18 @@ function buildStreamingResponse(
   /** Session id, for telemetry (abort-under-pressure capture). Passed
    *  independently of recallContext so non-recall turns are still attributable. */
   sessionID?: string,
+  /** Per-model client-usage cap (anti-compaction). Defaults to the 200K cap. */
+  maxReportedUsage: number = DEFAULT_MAX_REPORTED_USAGE,
 ): Response {
   const recallAccum = recallContext
-    ? createRecallAwareAccumulator(RECALL_TOOL_NAME, { scaleClientUsage: true })
+    ? createRecallAwareAccumulator(RECALL_TOOL_NAME, {
+        scaleClientUsage: true,
+        maxReportedUsage,
+      })
     : null;
   const accumulator: StreamAccumulator =
-    recallAccum ?? createStreamAccumulator({ scaleClientUsage: true });
+    recallAccum ??
+    createStreamAccumulator({ scaleClientUsage: true, maxReportedUsage });
   const encoder = new TextEncoder();
   // Start of the client-facing stream — used to flag aborts that happen after
   // a long in-flight time (a host-pressure signal; see the abort catch below).
@@ -3473,6 +3497,8 @@ function buildStreamingResponse(
             const contBlockOffset =
               currentAccum.clientBlockCount() + currentBlockOffset + 1;
             const contAccum = createRecallAwareAccumulator(RECALL_TOOL_NAME, {
+              scaleClientUsage: true,
+              maxReportedUsage,
               blockOffset: contBlockOffset,
               suppressMessageStart: true,
             });
@@ -3905,12 +3931,17 @@ function nonStreamHttpResponse(
 
   // Scale usage so the client's token total stays below auto-compact threshold.
   // postResponse() has already consumed the real values for calibration/bustRate.
-  const scaledUsage = scaleUsageForClient({
-    input_tokens: usage.inputTokens,
-    output_tokens: usage.outputTokens,
-    cache_read_input_tokens: usage.cacheReadInputTokens,
-    cache_creation_input_tokens: usage.cacheCreationInputTokens,
-  });
+  // Cap is per-model (from the response's model), so a 1M-context model isn't
+  // throttled to the 200K cap.
+  const scaledUsage = scaleUsageForClient(
+    {
+      input_tokens: usage.inputTokens,
+      output_tokens: usage.outputTokens,
+      cache_read_input_tokens: usage.cacheReadInputTokens,
+      cache_creation_input_tokens: usage.cacheCreationInputTokens,
+    },
+    maxReportedUsageForModelID(resp.model),
+  );
   const scaledResp: GatewayResponse = {
     ...resp,
     usage: {
@@ -7063,6 +7094,9 @@ async function handleConversationTurn(
         : undefined,
       warningText,
       sessionState.sessionID,
+      // Cap usage against the model the CLIENT meters against (its requested
+      // model), so a 1M-context model isn't throttled to the 200K cap.
+      maxReportedUsageForModelID(req.model),
     );
     // Translate to client's wire format if needed. When the upstream is
     // Anthropic but the client speaks OpenAI, wrap the Anthropic SSE stream.

--- a/packages/gateway/src/stream/anthropic.ts
+++ b/packages/gateway/src/stream/anthropic.ts
@@ -17,7 +17,11 @@ import {
   type GatewayResponse,
   type GatewayUsage,
 } from "../translate/types";
-import { scaleUsageForClient, estimateTokens } from "../compaction";
+import {
+  DEFAULT_MAX_REPORTED_USAGE,
+  estimateTokens,
+  scaleUsageForClient,
+} from "../compaction";
 
 // ---------------------------------------------------------------------------
 // SSE formatting
@@ -122,12 +126,77 @@ export interface StreamAccumulator {
   isDone(): boolean;
 }
 
+/**
+ * Scale the `usage` block of a terminal `message_delta` for the client.
+ *
+ * Anthropic's `message_delta` carries the FULL cumulative usage (input + cache
+ * + output), not just `output_tokens`. We scale every field it carries so the
+ * client's last-write-wins total stays under the cap. The delta's own fields
+ * are authoritative for the scale basis (falling back to the internally
+ * accumulated values only when a field is absent), so the basis can never
+ * under-count and re-leak a raw, unscaled value. We never write back a raw
+ * delta value — only the scaled result (0 if the scaler dropped the field).
+ */
+export function scaleMessageDeltaUsage(
+  deltaUsage: Record<string, number>,
+  accumulated: {
+    inputTokens: number;
+    cacheReadInputTokens?: number;
+    cacheCreationInputTokens?: number;
+  },
+  maxReportedUsage: number,
+): Record<string, number> {
+  const basisInput =
+    typeof deltaUsage.input_tokens === "number"
+      ? deltaUsage.input_tokens
+      : accumulated.inputTokens;
+  const basisCacheRead =
+    typeof deltaUsage.cache_read_input_tokens === "number"
+      ? deltaUsage.cache_read_input_tokens
+      : accumulated.cacheReadInputTokens;
+  const basisCacheCreation =
+    typeof deltaUsage.cache_creation_input_tokens === "number"
+      ? deltaUsage.cache_creation_input_tokens
+      : accumulated.cacheCreationInputTokens;
+
+  const scaled = scaleUsageForClient(
+    {
+      input_tokens: basisInput,
+      output_tokens: deltaUsage.output_tokens,
+      cache_read_input_tokens: basisCacheRead,
+      cache_creation_input_tokens: basisCacheCreation,
+    },
+    maxReportedUsage,
+  );
+
+  const newUsage: Record<string, number> = {
+    ...deltaUsage,
+    output_tokens: scaled.output_tokens,
+  };
+  if (typeof deltaUsage.input_tokens === "number") {
+    newUsage.input_tokens = scaled.input_tokens;
+  }
+  if (typeof deltaUsage.cache_read_input_tokens === "number") {
+    newUsage.cache_read_input_tokens = scaled.cache_read_input_tokens ?? 0;
+  }
+  if (typeof deltaUsage.cache_creation_input_tokens === "number") {
+    newUsage.cache_creation_input_tokens =
+      scaled.cache_creation_input_tokens ?? 0;
+  }
+  return newUsage;
+}
+
 export function createStreamAccumulator(options?: {
   /** When true, scale usage fields in client-facing SSE events so Claude Code's
    *  auto-compact threshold is never reached.  Internal accumulation is unaffected. */
   scaleClientUsage?: boolean;
+  /** Per-model usage cap (from `maxReportedUsageForModel`). Defaults to the
+   *  200K-model cap when unknown. */
+  maxReportedUsage?: number;
 }): StreamAccumulator {
   const shouldScale = options?.scaleClientUsage ?? false;
+  const maxReportedUsage =
+    options?.maxReportedUsage ?? DEFAULT_MAX_REPORTED_USAGE;
 
   let id = "";
   let model = "";
@@ -162,12 +231,15 @@ export function createStreamAccumulator(options?: {
       const msgUsage = message?.usage as Record<string, number> | undefined;
       if (!msgUsage) return null;
 
-      const scaled = scaleUsageForClient({
-        input_tokens: msgUsage.input_tokens ?? 0,
-        output_tokens: msgUsage.output_tokens ?? 0,
-        cache_read_input_tokens: msgUsage.cache_read_input_tokens,
-        cache_creation_input_tokens: msgUsage.cache_creation_input_tokens,
-      });
+      const scaled = scaleUsageForClient(
+        {
+          input_tokens: msgUsage.input_tokens ?? 0,
+          output_tokens: msgUsage.output_tokens ?? 0,
+          cache_read_input_tokens: msgUsage.cache_read_input_tokens,
+          cache_creation_input_tokens: msgUsage.cache_creation_input_tokens,
+        },
+        maxReportedUsage,
+      );
       // Only rewrite if scaling actually changed something
       if (scaled === msgUsage) return null;
 
@@ -183,20 +255,19 @@ export function createStreamAccumulator(options?: {
       if (!deltaUsage || typeof deltaUsage.output_tokens !== "number")
         return null;
 
-      // For message_delta, the usage only carries output_tokens.  We need to
-      // scale based on the *total* accumulated so far (input from message_start
-      // + output from this delta) so the proportional scaling is consistent.
-      const scaled = scaleUsageForClient({
-        input_tokens: usage.inputTokens,
-        output_tokens: deltaUsage.output_tokens,
-        cache_read_input_tokens: usage.cacheReadInputTokens,
-        cache_creation_input_tokens: usage.cacheCreationInputTokens,
-      });
-      const rewritten = {
-        ...parsed,
-        usage: { ...deltaUsage, output_tokens: scaled.output_tokens },
-      };
-      return JSON.stringify(rewritten);
+      // See scaleMessageDeltaUsage: the terminal message_delta carries the full
+      // cumulative usage, so scale every field it carries (client usage is
+      // last-write-wins) using the delta's own values as the authoritative basis.
+      const newUsage = scaleMessageDeltaUsage(
+        deltaUsage,
+        {
+          inputTokens: usage.inputTokens,
+          cacheReadInputTokens: usage.cacheReadInputTokens,
+          cacheCreationInputTokens: usage.cacheCreationInputTokens,
+        },
+        maxReportedUsage,
+      );
+      return JSON.stringify({ ...parsed, usage: newUsage });
     }
 
     return null;
@@ -860,6 +931,7 @@ export interface RecallAwareAccumulator extends StreamAccumulator {
  *
  * @param recallToolName - The name of the recall tool to intercept (default: "recall")
  * @param options.scaleClientUsage - Scale usage numbers for the client (anti-compaction)
+ * @param options.maxReportedUsage - Per-model usage cap (from `maxReportedUsageForModel`)
  * @param options.blockOffset - Added to all emitted block indices (for continuation streams
  *   that must continue the client's block numbering from where a previous stream left off)
  * @param options.suppressMessageStart - Suppress message_start events (continuation streams
@@ -869,11 +941,14 @@ export function createRecallAwareAccumulator(
   recallToolName = "recall",
   options?: {
     scaleClientUsage?: boolean;
+    maxReportedUsage?: number;
     blockOffset?: number;
     suppressMessageStart?: boolean;
   },
 ): RecallAwareAccumulator {
   const shouldScale = options?.scaleClientUsage ?? false;
+  const maxReportedUsage =
+    options?.maxReportedUsage ?? DEFAULT_MAX_REPORTED_USAGE;
   const baseOffset = options?.blockOffset ?? 0;
   const suppressMsgStart = options?.suppressMessageStart ?? false;
   // Delegate to the standard accumulator for actual accumulation (never scales — internal only)
@@ -905,12 +980,15 @@ export function createRecallAwareAccumulator(
       const message = parsed.message as Record<string, unknown> | undefined;
       const msgUsage = message?.usage as Record<string, number> | undefined;
       if (!msgUsage) return null;
-      const scaled = scaleUsageForClient({
-        input_tokens: msgUsage.input_tokens ?? 0,
-        output_tokens: msgUsage.output_tokens ?? 0,
-        cache_read_input_tokens: msgUsage.cache_read_input_tokens,
-        cache_creation_input_tokens: msgUsage.cache_creation_input_tokens,
-      });
+      const scaled = scaleUsageForClient(
+        {
+          input_tokens: msgUsage.input_tokens ?? 0,
+          output_tokens: msgUsage.output_tokens ?? 0,
+          cache_read_input_tokens: msgUsage.cache_read_input_tokens,
+          cache_creation_input_tokens: msgUsage.cache_creation_input_tokens,
+        },
+        maxReportedUsage,
+      );
       if (scaled === msgUsage) return null;
       return JSON.stringify({
         ...parsed,
@@ -922,19 +1000,21 @@ export function createRecallAwareAccumulator(
       const deltaUsage = parsed.usage as Record<string, number> | undefined;
       if (!deltaUsage || typeof deltaUsage.output_tokens !== "number")
         return null;
-      // Scale based on total accumulated in the inner accumulator
-      const innerResp = inner.getResponse();
-      const iu = innerResp.usage ?? ZERO_USAGE;
-      const scaled = scaleUsageForClient({
-        input_tokens: iu.inputTokens,
-        output_tokens: deltaUsage.output_tokens,
-        cache_read_input_tokens: iu.cacheReadInputTokens,
-        cache_creation_input_tokens: iu.cacheCreationInputTokens,
-      });
-      return JSON.stringify({
-        ...parsed,
-        usage: { ...deltaUsage, output_tokens: scaled.output_tokens },
-      });
+      // The terminal message_delta carries the full cumulative usage; scale
+      // every field it carries (not just output_tokens) so the client's
+      // last-write-wins usage stays under the cap. Base the factor on the
+      // delta's own values, falling back to the inner accumulator's real totals.
+      const iu = inner.getResponse().usage ?? ZERO_USAGE;
+      const newUsage = scaleMessageDeltaUsage(
+        deltaUsage,
+        {
+          inputTokens: iu.inputTokens,
+          cacheReadInputTokens: iu.cacheReadInputTokens,
+          cacheCreationInputTokens: iu.cacheCreationInputTokens,
+        },
+        maxReportedUsage,
+      );
+      return JSON.stringify({ ...parsed, usage: newUsage });
     }
 
     return null;

--- a/packages/gateway/test/compaction.test.ts
+++ b/packages/gateway/test/compaction.test.ts
@@ -10,6 +10,9 @@ import {
   assembleOfflineCompaction,
   COMPACTION_SYSTEM_PATTERNS,
   COMPACTION_USER_PATTERNS,
+  maxReportedUsageForModel,
+  DEFAULT_MAX_REPORTED_USAGE,
+  scaleUsageForClient,
 } from "../src/compaction";
 import type { GatewayRequest } from "../src/translate/types";
 
@@ -841,5 +844,81 @@ describe("detectCompactionRequest", () => {
         isCompactionRequest(req),
       );
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-model client usage scaling
+// ---------------------------------------------------------------------------
+
+describe("maxReportedUsageForModel", () => {
+  test("200K model reproduces the historical 150,300 cap", () => {
+    // effective = 200_000 - min(64_000, 20_000) = 180_000
+    // threshold = 180_000 - 13_000 = 167_000; cap = floor(167_000 * 0.9)
+    expect(maxReportedUsageForModel(200_000, 64_000)).toBe(150_300);
+    expect(DEFAULT_MAX_REPORTED_USAGE).toBe(150_300);
+  });
+
+  test("1M model yields a proportionally larger cap", () => {
+    // effective = 1_000_000 - 20_000 = 980_000
+    // threshold = 980_000 - 13_000 = 967_000; cap = floor(967_000 * 0.9)
+    expect(maxReportedUsageForModel(1_000_000, 64_000)).toBe(870_300);
+  });
+
+  test("max-output below the 20K reserve is used as-is", () => {
+    // effective = 200_000 - 8_000 = 192_000
+    // threshold = 192_000 - 13_000 = 179_000; cap = floor(179_000 * 0.9)
+    expect(maxReportedUsageForModel(200_000, 8_000)).toBe(161_100);
+  });
+
+  test("never returns negative for tiny windows", () => {
+    expect(maxReportedUsageForModel(1_000, 20_000)).toBe(0);
+  });
+});
+
+describe("scaleUsageForClient", () => {
+  test("returns the original object unchanged when total is within the cap", () => {
+    const usage = { input_tokens: 100, output_tokens: 50 };
+    expect(scaleUsageForClient(usage, 150_300)).toBe(usage);
+  });
+
+  test("scales proportionally when total exceeds the cap; new total ≤ cap", () => {
+    const scaled = scaleUsageForClient(
+      {
+        input_tokens: 5,
+        output_tokens: 95,
+        cache_read_input_tokens: 900_000,
+        cache_creation_input_tokens: 100_000,
+      },
+      150_300,
+    );
+    const total =
+      scaled.input_tokens +
+      scaled.output_tokens +
+      (scaled.cache_read_input_tokens ?? 0) +
+      (scaled.cache_creation_input_tokens ?? 0);
+    expect(total).toBeLessThanOrEqual(150_300);
+    expect(scaled.cache_read_input_tokens).toBeLessThan(900_000);
+  });
+
+  test("per-model cap is honored — a 1M cap is NOT throttled to the 200K cap", () => {
+    // 1,000,000 real input tokens, scaled against the 1M-model cap.
+    const cap1M = maxReportedUsageForModel(1_000_000, 64_000); // 870_300
+    const scaled = scaleUsageForClient(
+      { input_tokens: 1_000_000, output_tokens: 0 },
+      cap1M,
+    );
+    // Mutation guard: if the cap were hardcoded to 150_300 (the old 200K
+    // behavior), this would scale to 150_300 and the assertion would fail.
+    expect(scaled.input_tokens).toBe(870_300);
+    expect(scaled.input_tokens).toBeGreaterThan(DEFAULT_MAX_REPORTED_USAGE);
+  });
+
+  test("200K cap regression-lock: scales 1M tokens down to 150,300", () => {
+    const scaled = scaleUsageForClient(
+      { input_tokens: 1_000_000, output_tokens: 0 },
+      maxReportedUsageForModel(200_000, 64_000),
+    );
+    expect(scaled.input_tokens).toBe(150_300);
   });
 });

--- a/packages/gateway/test/recall-stream.test.ts
+++ b/packages/gateway/test/recall-stream.test.ts
@@ -10,6 +10,7 @@
  */
 import { describe, test, expect } from "vitest";
 import { createRecallAwareAccumulator } from "../src/stream/anthropic";
+import { DEFAULT_MAX_REPORTED_USAGE } from "../src/compaction";
 import {
   findRecallToolUse,
   replaceRecallWithMarker,
@@ -1137,5 +1138,100 @@ describe("Case 2 integration — mixed tools end-to-end", () => {
     expect((userMsg.content[2] as { toolUseId: string }).toolUseId).toBe(
       "toolu_bash_1",
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: client usage scaling (anti-compaction) on the recall accumulator
+// ---------------------------------------------------------------------------
+
+describe("RecallAwareAccumulator — usage scaling", () => {
+  const bigCacheRead = 10_000_000;
+
+  function bigMessageStart(): { event: string; data: string } {
+    return {
+      event: "message_start",
+      data: JSON.stringify({
+        type: "message_start",
+        message: {
+          id: "msg_scale",
+          type: "message",
+          role: "assistant",
+          content: [],
+          model: "claude-sonnet-4-20250514",
+          stop_reason: null,
+          stop_sequence: null,
+          usage: {
+            input_tokens: 5,
+            output_tokens: 1,
+            cache_read_input_tokens: bigCacheRead,
+            cache_creation_input_tokens: 0,
+          },
+        },
+      }),
+    };
+  }
+
+  // Terminal delta carrying the full cumulative usage (as the real API sends).
+  function fullMessageDelta(): { event: string; data: string } {
+    return {
+      event: "message_delta",
+      data: JSON.stringify({
+        type: "message_delta",
+        delta: { stop_reason: "end_turn", stop_sequence: null },
+        usage: {
+          input_tokens: 5,
+          output_tokens: 500,
+          cache_read_input_tokens: bigCacheRead,
+          cache_creation_input_tokens: 0,
+        },
+      }),
+    };
+  }
+
+  function deltaTotal(usage: Record<string, number>): number {
+    return (
+      usage.input_tokens +
+      usage.output_tokens +
+      usage.cache_read_input_tokens +
+      usage.cache_creation_input_tokens
+    );
+  }
+
+  test("scales the terminal message_delta on a non-recall stream", () => {
+    const accum = createRecallAwareAccumulator("recall", {
+      scaleClientUsage: true,
+    });
+    const sse = processAll(accum, [bigMessageStart(), fullMessageDelta()]);
+    const delta = parseForwardedEvents(sse).find(
+      (e) => e.event === "message_delta",
+    );
+    expect(delta).toBeDefined();
+    const usage = delta!.data.usage as Record<string, number>;
+    expect(usage.cache_read_input_tokens).toBeLessThan(bigCacheRead);
+    expect(deltaTotal(usage)).toBeLessThanOrEqual(DEFAULT_MAX_REPORTED_USAGE);
+    // Internal accumulation stays real (used by calibration/bustRate).
+    expect(accum.getResponse().usage?.cacheReadInputTokens).toBe(bigCacheRead);
+  });
+
+  test("scales the held-back message_delta on a recall (continuation) stream", () => {
+    const accum = createRecallAwareAccumulator("recall", {
+      scaleClientUsage: true,
+    });
+    processAll(accum, [
+      bigMessageStart(),
+      toolUseBlockStart(0, "recall"),
+      inputJsonDelta(0, "{}"),
+      contentBlockStop(0),
+      fullMessageDelta(),
+    ]);
+    expect(accum.hasRecall()).toBe(true);
+    const held = parseForwardedEvents(accum.heldBackEvents()).find(
+      (e) => e.event === "message_delta",
+    );
+    expect(held).toBeDefined();
+    const usage = held!.data.usage as Record<string, number>;
+    expect(usage.cache_read_input_tokens).toBeLessThan(bigCacheRead);
+    expect(deltaTotal(usage)).toBeLessThanOrEqual(DEFAULT_MAX_REPORTED_USAGE);
   });
 });

--- a/packages/gateway/test/stream-anthropic.test.ts
+++ b/packages/gateway/test/stream-anthropic.test.ts
@@ -11,10 +11,15 @@ import {
   formatSSEEvent,
   parseSSEStream,
   createStreamAccumulator,
+  scaleMessageDeltaUsage,
   buildSSEMessageStart,
   buildSSETextResponse,
   accumulateSSEResponse,
 } from "../src/stream/anthropic";
+import {
+  DEFAULT_MAX_REPORTED_USAGE,
+  maxReportedUsageForModel,
+} from "../src/compaction";
 import type { GatewayResponse } from "../src/translate/types";
 
 // ---------------------------------------------------------------------------
@@ -235,6 +240,154 @@ describe("createStreamAccumulator", () => {
 
     // Internal accumulation keeps the real (unscaled) token count.
     expect(acc.getResponse().usage?.inputTokens).toBe(bigInput);
+  });
+
+  test("scaleClientUsage scales ALL fields in the terminal message_delta", () => {
+    // Anthropic's terminal message_delta carries the full cumulative usage
+    // (input + cache), not just output_tokens. If only output_tokens is scaled,
+    // the client's last-write-wins usage is overwritten with the real total and
+    // the meter spoof is defeated. (Regression guard for the message_delta leak.)
+    const acc = createStreamAccumulator({ scaleClientUsage: true });
+    const bigCacheRead = 10_000_000;
+
+    acc.processEvent(
+      "message_start",
+      JSON.stringify({
+        type: "message_start",
+        message: {
+          id: "m",
+          model: "x",
+          usage: {
+            input_tokens: 5,
+            output_tokens: 1,
+            cache_read_input_tokens: bigCacheRead,
+            cache_creation_input_tokens: 0,
+          },
+        },
+      }),
+    );
+
+    const forwarded = acc.processEvent(
+      "message_delta",
+      JSON.stringify({
+        type: "message_delta",
+        delta: { stop_reason: "end_turn", stop_sequence: null },
+        usage: {
+          input_tokens: 5,
+          output_tokens: 500,
+          cache_read_input_tokens: bigCacheRead,
+          cache_creation_input_tokens: 0,
+        },
+      }),
+    );
+
+    const usage = parseEventData(forwarded, "message_delta").usage as Record<
+      string,
+      number
+    >;
+    // The leaked field must be scaled down, not passed through unchanged.
+    expect(usage.cache_read_input_tokens).toBeLessThan(bigCacheRead);
+    const clientTotal =
+      usage.input_tokens +
+      usage.output_tokens +
+      usage.cache_read_input_tokens +
+      usage.cache_creation_input_tokens;
+    expect(clientTotal).toBeLessThanOrEqual(DEFAULT_MAX_REPORTED_USAGE);
+
+    // Internal accumulation still reflects the real (unscaled) cache read.
+    expect(acc.getResponse().usage?.cacheReadInputTokens).toBe(bigCacheRead);
+  });
+
+  test("maxReportedUsage cap is per-model (1M not throttled to 200K)", () => {
+    const cap1M = maxReportedUsageForModel(1_000_000, 64_000); // 870_300
+    const acc = createStreamAccumulator({
+      scaleClientUsage: true,
+      maxReportedUsage: cap1M,
+    });
+    const forwarded = acc.processEvent(
+      "message_start",
+      JSON.stringify({
+        type: "message_start",
+        message: {
+          id: "m",
+          model: "x",
+          usage: {
+            input_tokens: 1,
+            output_tokens: 1,
+            cache_read_input_tokens: 1_000_000,
+            cache_creation_input_tokens: 0,
+          },
+        },
+      }),
+    );
+    const usage = parseEventData(forwarded, "message_start").message as {
+      usage: Record<string, number>;
+    };
+    // ~1M total scaled to the 1M cap (870_300), NOT the 200K cap (150_300).
+    expect(usage.usage.cache_read_input_tokens).toBeGreaterThan(
+      DEFAULT_MAX_REPORTED_USAGE,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scaleMessageDeltaUsage
+// ---------------------------------------------------------------------------
+
+describe("scaleMessageDeltaUsage", () => {
+  test("scales all cumulative fields the delta carries; total ≤ cap", () => {
+    const out = scaleMessageDeltaUsage(
+      {
+        input_tokens: 5,
+        output_tokens: 500,
+        cache_read_input_tokens: 900_000,
+        cache_creation_input_tokens: 100_000,
+      },
+      {
+        inputTokens: 5,
+        cacheReadInputTokens: 900_000,
+        cacheCreationInputTokens: 100_000,
+      },
+      150_300,
+    );
+    const total =
+      out.input_tokens +
+      out.output_tokens +
+      out.cache_read_input_tokens +
+      out.cache_creation_input_tokens;
+    expect(total).toBeLessThanOrEqual(150_300);
+    expect(out.cache_read_input_tokens).toBeLessThan(900_000);
+  });
+
+  test("only scales output_tokens when the delta carries nothing else", () => {
+    const out = scaleMessageDeltaUsage(
+      { output_tokens: 500 },
+      { inputTokens: 1_000_000, cacheReadInputTokens: 0 },
+      150_300,
+    );
+    // input/cache keys must NOT be invented when the delta omits them.
+    expect("input_tokens" in out).toBe(false);
+    expect("cache_read_input_tokens" in out).toBe(false);
+    expect(out.output_tokens).toBeLessThan(500);
+  });
+
+  test("no re-leak when message_start omitted a cache field the delta carries", () => {
+    // The asymmetric case: the accumulated basis (from message_start) lacks
+    // cache_read, but the terminal delta reports a huge cache_read. The delta's
+    // own value must drive the scale basis — never fall back to the raw value.
+    const out = scaleMessageDeltaUsage(
+      {
+        input_tokens: 5,
+        output_tokens: 10,
+        cache_read_input_tokens: 10_000_000,
+      },
+      { inputTokens: 5 }, // no cacheReadInputTokens — message_start didn't report it
+      150_300,
+    );
+    const total =
+      out.input_tokens + out.output_tokens + out.cache_read_input_tokens;
+    expect(total).toBeLessThanOrEqual(150_300);
+    expect(out.cache_read_input_tokens).toBeLessThan(10_000_000);
   });
 });
 


### PR DESCRIPTION
## Problem

Lore spoofs the `usage` it reports to the downstream agent (Claude Code) so the client's context meter / auto-compact trigger never fire prematurely. Two bugs made this misbehave — most visibly, a 1M-context session (`claude-opus-4-8`) that grew to ~960K, showed "2% remaining", and hard-locked.

**How the client actually counts** (verified against `freecodexyz/free-code`, a faithful Claude Code reimplementation): the meter and auto-compact trigger read **API-reported usage** — `input_tokens + cache_creation + cache_read + output_tokens` from the last response (`tokenCountWithEstimation` → `getTokenCountFromUsage`) — over a **per-model** context window. So the spoof targets the right fields; it was just miscalibrated and leaking.

### (a) The cap was hardcoded to a 200K model
`AUTOCOMPACT_THRESHOLD = 167_000` → cap `150,300` for **every** model. On a 1M-context model that's wrong by ~6×; on smaller models it can trigger premature compaction. (Flagged previously for a MiniMax 200K model — "is this threshold correct for ALL models?")

### (b) `message_delta` leaked the real usage
Anthropic's **terminal `message_delta` carries the full cumulative usage** (`input_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens`), but only `output_tokens` was scaled. Since the client's stored usage is **last-write-wins**, the real ~960K from `message_delta` overwrote the scaled `message_start` — defeating the spoof even on 200K models. Existing fixtures only ever put `{output_tokens}` in `message_delta`, so no test caught it.

## Changes

- **Per-model cap** (`compaction.ts`): pure `maxReportedUsageForModel(contextWindow, maxOutput)` = `floor(0.9 × ((window − min(maxOutput, 20k)) − 13k))`, mirroring Claude Code's `autoCompact.ts`. `scaleUsageForClient(usage, cap)` now takes the cap; `DEFAULT_MAX_REPORTED_USAGE` (= 150,300) preserves 200K behavior. Threaded via `maxReportedUsageForModelID` (models.dev window lookup) into both stream accumulators and `nonStreamHttpResponse`. **200K models are unchanged.**
- **`message_delta` fix** (`stream/anthropic.ts`): shared `scaleMessageDeltaUsage()` scales **every** field the delta carries, in `createStreamAccumulator`, `createRecallAwareAccumulator`, and the recall **continuation** stream (which previously didn't scale at all). The delta's own fields are the authoritative scale basis, so an asymmetric `message_start` (multi-provider translation) can never re-leak a raw value.
- `cost-tracker.ts` keeps the 200K `AUTOCOMPACT_THRESHOLD` constant (dashboard estimate) with a TODO.

## Out of scope (follow-up)
`DISABLE_AUTO_COMPACT`: with auto-compact disabled, the threshold becomes the full effective window and a session can still grow to the blocking limit. A correct meter only delays that — at the true ceiling something must reset the buffer.

## Testing
- New unit tests: per-model cap (200K regression-lock at 150,300; 1M → 870,300), `scaleMessageDeltaUsage` (full-field scaling, output-only delta, **asymmetric no-re-leak**), and recall-accumulator scaling (forward + held-back continuation).
- **Mutation-verified** every new test (revert the fix → test fails): per-model cap, `message_delta` field scaling (both accumulators), and the asymmetric re-leak guard.
- `typecheck` + `lint` clean. Full suite green (**3857 passed**), 3× for flakiness.

🤖 Adversarial-reviewed (READ-ONLY): SHIP-WITH-FOLLOWUPS, no blockers; both SHOULD-FIX items (recall coverage gap, asymmetric re-leak) addressed in this PR.