### PR TITLE
feat(sync): key the knowledge outbox by logical_id for all ops (#909 prereq)

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1524,13 +1524,14 @@ function installSyncCapture(database: Database) {
     "entity_relations",
   ]) {
     for (const [evt, suffix, ref, op] of ops) {
-      // Knowledge is remote-keyed by logical_id (A2 sub-PR 3, #823). INSERT/UPDATE
-      // capture the version id (op=upsert; the push plan resolves it to the current
-      // logical row while the row still exists). DELETE must capture the logical_id
-      // NOW — the row is gone afterward, so the push can't resolve it, and a delete
-      // keyed by a version id would never match the logical_id-keyed remote row.
+      // Knowledge is remote-keyed by logical_id (A2, #823), so capture the
+      // logical_id for ALL ops (not the per-version row id). This makes the outbox
+      // uniformly logical_id-keyed: the push plan + pending checks read the row_id
+      // directly with no join back to a physical version row — so they survive
+      // compaction that prunes the v1 anchor (#909). DELETE must capture it anyway
+      // (the row is gone afterward); INSERT/UPDATE capture it for uniformity.
       const rowExpr =
-        t === "knowledge" && op === "delete"
+        t === "knowledge"
           ? `COALESCE(${ref}.logical_id, ${ref}.id)`
           : `${ref}.id`;
       sql += `

--- a/packages/core/src/sync-data.ts
+++ b/packages/core/src/sync-data.ts
@@ -877,7 +877,6 @@ export function applyRemoteKnowledgeDelete(logicalId: string): void {
 }
 
 export type KnowledgePushPlan =
-  | { op: "skip" }
   | { op: "delete"; logicalId: string }
   | { op: "upsert"; logicalId: string; row: Record<string, unknown> };
 

--- a/packages/core/src/sync-data.ts
+++ b/packages/core/src/sync-data.ts
@@ -436,11 +436,10 @@ export function hasPendingChange(
 }
 
 /**
- * Knowledge-aware pending check (A2, #823): the remote keys knowledge by
- * `logical_id`, but the outbox holds per-VERSION row ids — so resolve every
- * unpushed knowledge outbox row to its logical_id. Without this, the pull path
- * would miss an unpushed local edit to a versioned entry (its outbox id ≠
- * logical_id) and silently let a remote change win without logging the conflict.
+ * Knowledge-aware pending check (A2, #823): the knowledge outbox is logical_id-
+ * keyed (#909), so an unpushed edit to a logical entry is simply a row whose
+ * `row_id` equals the logical_id. The pull path uses this so it never silently
+ * lets a remote change win over an unpushed local edit (it logs a conflict).
  */
 export function hasPendingKnowledgeChange(
   logicalId: string,
@@ -448,10 +447,8 @@ export function hasPendingKnowledgeChange(
 ): boolean {
   const row = db()
     .query(
-      `SELECT 1 FROM sync_outbox o
-         JOIN knowledge k ON k.id = o.row_id
-        WHERE o.table_name = 'knowledge' AND o.seq > ?
-          AND COALESCE(k.logical_id, k.id) = ? LIMIT 1`,
+      `SELECT 1 FROM sync_outbox
+        WHERE table_name = 'knowledge' AND seq > ? AND row_id = ? LIMIT 1`,
     )
     .get(sinceSeq, logicalId);
   return row != null;
@@ -536,10 +533,9 @@ export function seedOutbox(tier: SyncTier = "basic"): void {
       // delete (its liveness check is also knowledge_current-based).
       if (m.table === "knowledge") {
         const latestForLogical = db().query(
-          `SELECT o.op FROM sync_outbox o JOIN knowledge k ON k.id = o.row_id
-            WHERE o.table_name = 'knowledge' AND o.seq > ?
-              AND COALESCE(k.logical_id, k.id) = ?
-            ORDER BY o.seq DESC LIMIT 1`,
+          `SELECT op FROM sync_outbox
+            WHERE table_name = 'knowledge' AND seq > ? AND row_id = ?
+            ORDER BY seq DESC LIMIT 1`,
         );
         const lids = db()
           .query(
@@ -924,13 +920,10 @@ export function currentKnowledgeRow(
 }
 
 export function knowledgePushPlan(outboxRowId: string): KnowledgePushPlan {
-  const lid = db()
-    .query(
-      "SELECT COALESCE(logical_id, id) AS logical_id FROM knowledge WHERE id = ?",
-    )
-    .get(outboxRowId) as { logical_id: string } | undefined;
-  if (!lid) return { op: "skip" }; // physical row gone (not expected post-flip)
-  const logicalId = lid.logical_id;
+  // The knowledge outbox is logical_id-keyed for every op (#909 capture triggers),
+  // so the row_id IS the logical_id — resolve the current row directly, with no
+  // join back to a physical version row (survives compaction of the v1 anchor).
+  const logicalId = outboxRowId;
   const row = currentKnowledgeRow(logicalId);
   if (!row) return { op: "delete", logicalId }; // no live current → soft-delete
   return { op: "upsert", logicalId, row };

--- a/packages/core/test/sync-data.test.ts
+++ b/packages/core/test/sync-data.test.ts
@@ -178,7 +178,9 @@ describe("applyRemoteKnowledge — append-only pull apply (A2, #823)", () => {
 });
 
 describe("knowledgePushPlan — append-only remote mapping keyed by logical_id (A2)", () => {
-  test("coalesces versions to one logical-keyed upsert; no live current → delete; gone → skip", () => {
+  test("live current → upsert by logical_id (current content); no live current → delete", () => {
+    // The knowledge outbox is logical_id-keyed for every op (#909), so the plan's
+    // input IS the logical_id (= id for v1). No version ids ever reach it.
     const id = ltm.create({
       projectPath: "/tmp/lore-sync-kpp",
       scope: "project",
@@ -186,45 +188,53 @@ describe("knowledgePushPlan — append-only remote mapping keyed by logical_id (
       title: "KPP",
       content: "secret v1",
     });
-    const p1 = knowledgePushPlan(id);
-    expect(p1.op).toBe("upsert");
-    if (p1.op === "upsert") {
-      expect(p1.logicalId).toBe(id);
-      expect(p1.row.id).toBe(id); // re-keyed on logical_id
-      expect(p1.row.content).toBe("secret v1");
+    let p = knowledgePushPlan(id);
+    expect(p.op).toBe("upsert");
+    if (p.op === "upsert") {
+      expect(p.logicalId).toBe(id);
+      expect(p.row.id).toBe(id); // keyed on the stable logical_id
+      expect(p.row.content).toBe("secret v1");
     }
 
-    const v2 = ltm.appendVersion(id, { content: "redacted v2" }) as string;
-    // Both the (now superseded) v1 outbox row AND the new v2 row coalesce to ONE
-    // upsert keyed by logical_id carrying the CURRENT content — the old secret is
-    // never pushed as a live row.
-    for (const outboxId of [id, v2]) {
-      const p = knowledgePushPlan(outboxId);
-      expect(p.op).toBe("upsert");
-      if (p.op === "upsert") {
-        expect(p.logicalId).toBe(id);
-        expect(p.row.id).toBe(id);
-        expect(p.row.content).toBe("redacted v2");
-      }
+    ltm.appendVersion(id, { content: "redacted v2" });
+    // Same logical_id → the plan now carries the CURRENT content; the old secret
+    // is never pushed as a live row.
+    p = knowledgePushPlan(id);
+    expect(p.op).toBe("upsert");
+    if (p.op === "upsert") {
+      expect(p.logicalId).toBe(id);
+      expect(p.row.id).toBe(id);
+      expect(p.row.content).toBe("redacted v2");
     }
 
-    ltm.remove(id); // append a death-cert → no live current
-    const deathCert = (
+    ltm.remove(id); // death-cert → no live current
+    expect(knowledgePushPlan(id).op).toBe("delete");
+    // An unknown logical_id has no live current → a (harmless, idempotent) delete.
+    expect(knowledgePushPlan("00000000-0000-0000-0000-000000000000").op).toBe(
+      "delete",
+    );
+  });
+
+  test("capture triggers key the knowledge outbox by logical_id for every op (#909)", () => {
+    setTeamConfig("sync.enabled", "1");
+    db().exec("DELETE FROM sync_outbox");
+    const id = ltm.create({
+      projectPath: "/tmp/lore-kpp-triggers",
+      scope: "project",
+      category: "decision",
+      title: "TRIG",
+      content: "v1",
+    });
+    ltm.appendVersion(id, { content: "v2" }); // demote (UPDATE) + insert (INSERT)
+    ltm.remove(id); // demote + death-cert insert (+ the remove's internal ops)
+    const rowIds = (
       db()
         .query(
-          "SELECT id FROM knowledge WHERE logical_id = ? AND is_current = 1",
+          "SELECT DISTINCT row_id FROM sync_outbox WHERE table_name = 'knowledge'",
         )
-        .get(id) as { id: string }
-    ).id;
-    for (const outboxId of [id, v2, deathCert]) {
-      const p = knowledgePushPlan(outboxId);
-      expect(p.op).toBe("delete");
-      if (p.op === "delete") expect(p.logicalId).toBe(id);
-    }
-
-    expect(knowledgePushPlan("00000000-0000-0000-0000-000000000000").op).toBe(
-      "skip",
-    );
+        .all() as { row_id: string }[]
+    ).map((r) => r.row_id);
+    expect(rowIds).toEqual([id]); // every knowledge op coalesced to the logical_id
   });
 
   test("seedOutbox skips an already-synced versioned (v2) entry — no re-enqueue bloat (#823)", () => {

--- a/packages/core/test/sync-data.test.ts
+++ b/packages/core/test/sync-data.test.ts
@@ -24,6 +24,7 @@ import {
   getRowById,
   getSyncState,
   hasPendingChange,
+  hasPendingKnowledgeChange,
   isSyncEnabled,
   knowledgePushPlan,
   maxOutboxSeq,
@@ -922,6 +923,44 @@ describe("mutation gap coverage (#832)", () => {
     seedOutbox();
     expect(hasPendingChange("knowledge", "k1", 0)).toBe(true);
     expect(hasPendingChange("knowledge", "absent", 0)).toBe(false);
+  });
+
+  test("hasPendingKnowledgeChange survives compaction of ALL version rows (#909 anchor-free contract)", () => {
+    setTeamConfig("sync.enabled", "1");
+    const id = ltm.create({
+      projectPath: "/tmp/lore-anchor-free",
+      scope: "project",
+      category: "decision",
+      title: "AF",
+      content: "v1",
+    });
+    // A pending (unpushed) edit captured in the outbox, keyed by logical_id (#909).
+    db().exec("DELETE FROM sync_outbox");
+    db()
+      .query(
+        "INSERT INTO sync_outbox (table_name, row_id, op, changed_at) VALUES ('knowledge', ?, 'upsert', ?)",
+      )
+      .run(id, Date.now());
+    // Future compaction physically removes EVERY version row — including the v1
+    // anchor (id == logical_id). Under apply-suppression so the DELETE triggers add
+    // no outbox entries of their own.
+    withApplying(() =>
+      db()
+        .query("DELETE FROM knowledge WHERE COALESCE(logical_id, id) = ?")
+        .run(id),
+    );
+    expect(
+      (
+        db()
+          .query(
+            "SELECT COUNT(*) AS n FROM knowledge WHERE COALESCE(logical_id, id) = ?",
+          )
+          .get(id) as { n: number }
+      ).n,
+    ).toBe(0);
+    // STILL detected — the outbox row_id IS the logical_id, with no dependency on a
+    // surviving version row to JOIN through (the old JOIN form returned false here).
+    expect(hasPendingKnowledgeChange(id, 0)).toBe(true);
   });
 
   test("seedOutbox builds a composite row_id for the join table", () => {

--- a/packages/gateway/src/sync.ts
+++ b/packages/gateway/src/sync.ts
@@ -149,12 +149,13 @@ async function pushEntry(
 ): Promise<PushOutcome> {
   const { table_name: table, row_id: rowId } = e;
   let op = e.op;
-  // The remote row key. For knowledge the remote is a CURRENT-only mirror keyed by
-  // logical_id (not the per-version row id), so sync_state + the upsert/delete both
-  // operate on the logical_id. For every other table this stays the outbox rowId.
+  // The remote row key. For knowledge the outbox is logical_id-keyed (#909) and the
+  // remote is a CURRENT-only mirror keyed by logical_id, so the outbox rowId already
+  // IS the remote key — sync_state + the upsert/delete operate on it directly. For
+  // every other table this also stays the outbox rowId.
   let effectiveId = rowId;
-  // For a knowledge upsert, the row to push is the CURRENT version (id=logical_id),
-  // not the outbox version row — resolved by the push plan.
+  // For a knowledge upsert, the row to push is the CURRENT version's content
+  // (re-keyed id=logical_id) — resolved by the push plan.
   let knowledgeRow: Record<string, unknown> | undefined;
 
   // A2 (#823): knowledge is append-only — update()/remove() append immutable
@@ -163,8 +164,9 @@ async function pushEntry(
   // that content; no live current (every version superseded/deleted) → soft-delete.
   if (table === "knowledge") {
     if (op === "upsert") {
+      // rowId is the logical_id (the outbox is logical_id-keyed, #909): a live
+      // current → upsert that content; no live current → delete.
       const plan = syncData.knowledgePushPlan(rowId);
-      if (plan.op === "skip") return "ok";
       effectiveId = plan.logicalId;
       op = plan.op;
       if (plan.op === "upsert") knowledgeRow = plan.row;
@@ -175,9 +177,8 @@ async function pushEntry(
       // deletion; re-push the current content instead. Only a genuinely dead entry
       // (no live current) propagates as a remote delete. Guards a future compaction
       // (sub-PR 4) that prunes superseded versions from falsely deleting a live remote
-      // entry. (We re-validate directly, NOT via knowledgePushPlan, because the plan
-      // would "skip" a dead entry whose v1 anchor row was also pruned — dropping the
-      // delete.)
+      // entry. (We re-validate directly rather than reusing the upsert plan to keep
+      // the delete-vs-revive decision explicit on this branch.)
       const live = syncData.currentKnowledgeRow(rowId);
       if (live) {
         op = "upsert";
@@ -478,8 +479,8 @@ function applyRemote(
   // Unpushed local intent for this row (push runs first, but a quota-paused or
   // failed push can leave one pending) → never fast-forward over it.
   const pushCursor = Number(getKV(pushKey(meta.table)) ?? "0");
-  // Knowledge is keyed by logical_id on the remote but per-version in the outbox,
-  // so resolve pending edits by logical_id (A2, #823).
+  // Knowledge is keyed by logical_id everywhere (remote + outbox, #909), so the
+  // pending check matches the remote rowId (= logical_id) directly (A2, #823).
   const pendingLocalChange =
     meta.table === "knowledge"
       ? syncData.hasPendingKnowledgeChange(rowId, pushCursor)


### PR DESCRIPTION
**Prereq for #909 (A2 sub-PR 4 compaction).** Makes the knowledge change-capture uniformly **`logical_id`-keyed** so compaction can prune any version — including the v1 anchor — without breaking sync.

## Problem
Today INSERT/UPDATE capture the *version id* and only DELETE captures `COALESCE(logical_id, id)`. So `knowledgePushPlan`, `seedOutbox.latestForLogical`, and `hasPendingKnowledgeChange` resolve a logical entry via `JOIN knowledge k ON k.id = o.row_id`, which **relies on the v1 anchor row (`id == logical_id`) physically existing**. sub-PR 4 compaction prunes superseded versions (potentially the anchor) → those lookups would silently return null (dropped pushes / missed pending edits). Flagged by the #897 final review + Seer (LOW, forward-looking).

## Change
- **`db.ts` `installSyncCapture`** — knowledge captures `COALESCE(logical_id, id)` for **INSERT/UPDATE/DELETE** (was the version id for INSERT/UPDATE). Every knowledge outbox `row_id` is now the logical_id.
- **`knowledgePushPlan(rowId)`** — `rowId` IS the logical_id → `currentKnowledgeRow(rowId)` directly, no anchor resolve. Live → upsert (current content); no live current → delete.
- **`hasPendingKnowledgeChange` / `seedOutbox.latestForLogical`** — drop the JOIN; match `row_id = logical_id` directly.

## Why it's safe today
Behavior-equivalent for current code: v1 entries have `COALESCE(logical_id,id) = id`, so the outbox keys are unchanged; the only difference is versioned entries now coalesce at capture time instead of via the JOIN. The win is **compaction-safety** for sub-PR 4.

## Tests
- Rewrote the `knowledgePushPlan` unit test for the logical_id contract (no version ids reach it; unknown id → idempotent delete).
- Added a trigger test: `create + appendVersion + remove` coalesce to a **single** logical_id outbox `row_id` (**verified red** against the version-id trigger).
- Core **1766** + gateway **2057** green; property suite stable; typecheck + lint clean.

> Branched off #904 (last green) to stay clear of the in-flight #905 idle red; will rebase onto green main before merge.