### PR TITLE
docs: position .lore.md as git-native, PR-reviewable team memory (#915)

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,16 @@ The assistant gets a `recall` tool that searches across stored messages, distill
 
 Search results are ranked using Reciprocal Rank Fusion across multiple sources: knowledge entries, distillation observations, temporal messages, recency-biased temporal, cross-project knowledge, and lat.md sections.
 
+## Team memory
+
+Lore's long-term knowledge is local-first, but it's most valuable shared. Curated facts are exported to a `.lore.md` file at your project root — plain Markdown, committed to your repo, and designed to be reviewed in pull requests.
+
+- **Diffable & merge-friendly** — entries are sorted alphabetically by title within each category and carry stable `<!-- lore:UUID -->` markers, so a new fact is a minimal diff, not a reshuffle.
+- **Reviewable** — `git diff` shows what the agent learned; a reviewer can reject a wrong fact before it becomes shared truth. Knowledge history is your git history.
+- **Hand-editable** — fix, delete, or add facts by hand; they're imported on the next run.
+
+This is the team path that works today with your existing git workflow. **Folk Lore** (coming soon) adds live, continuous team sync on top — see [withlore.ai](https://withlore.ai/different/#waitlist).
+
 ## Configuration
 
 Create a `.lore.json` file in your project root to customize behavior. All fields are optional — defaults are shown below:

--- a/packages/website/astro.config.mjs
+++ b/packages/website/astro.config.mjs
@@ -56,6 +56,7 @@ export default defineConfig({
             { label: "Overview", slug: "docs" },
             { label: "Install", slug: "docs/install" },
             { label: "Architecture", slug: "docs/architecture" },
+            { label: "Team memory", slug: "docs/team-memory" },
           ],
         },
         {

--- a/packages/website/src/content/docs/docs/team-memory.md
+++ b/packages/website/src/content/docs/docs/team-memory.md
@@ -1,0 +1,54 @@
+---
+title: Team memory & review
+description: Share project knowledge with your team as version-controlled .lore.md, reviewed in pull requests — and how that relates to Folk Lore.
+sidebar:
+  order: 3
+---
+
+Lore's long-term knowledge is local-first: every decision, pattern, preference, and gotcha lives in a local SQLite database. But project knowledge is most valuable when the whole team shares it. Lore makes that sharing a **git artifact you review like code**, not a hidden database.
+
+## `.lore.md` — memory that moves with the code
+
+When the curator records a durable fact, Lore exports it to a `.lore.md` file at your project root. The file is plain Markdown, committed to your repository, and designed to be reviewed in pull requests.
+
+- **Human-readable.** Each entry is a Markdown bullet under its category — decision, pattern, preference, architecture, or gotcha.
+- **Diffable.** Entries are sorted alphabetically by title within each category, so the file has a stable, deterministic order. A new or changed fact shows up as a minimal, readable diff — not a reshuffle.
+- **Merge-friendly.** That deterministic ordering keeps conflicts rare and legible. Each entry carries a stable `<!-- lore:UUID -->` marker, so edits map to the right entry regardless of position.
+- **Reviewable.** Because it lives in the repo, knowledge changes ride through the same PR review your code does. Your team approves what the agent learned the same way it approves a code change.
+
+### How it round-trips
+
+- **Export.** After curation, Lore writes `.lore.md` — skipping the write entirely when nothing changed, so it never churns your working tree.
+- **Import.** On the next session, Lore reads `.lore.md` back. A teammate's merged entry — or a hand-written one — is imported into the local database and injected into the agent's context. A known marker with changed content updates that entry; an unknown marker creates a new one.
+- **Hand edits are first-class.** Edit `.lore.md` directly: fix a wrong fact, delete a stale one, or add a convention by hand. It's imported on the next run.
+
+This is the team-memory path that works **today**, with nothing but your existing git workflow.
+
+## Reviewing memory changes
+
+Because `.lore.md` is just a tracked file:
+
+- `git diff` shows exactly what the agent learned this session.
+- A reviewer can reject a wrong or premature fact in a PR before it becomes shared truth.
+- Knowledge history is your git history — `git blame` and `git log` work on individual facts.
+
+## Configuration
+
+`.lore.md` export/import is on by default. See [`loreFile`](/docs/configuration/#loreFile) to disable it — knowledge then stays in the local database and is still injected into context — and [`crossProject`](/docs/configuration/#crossProject) for how knowledge that recurs across projects is promoted.
+
+To keep shared knowledge inside an existing `AGENTS.md` instead of a standalone file, pair `loreFile.enabled=false` with `agentsFile.enabled=true`.
+
+## Folk Lore — live team sync (coming soon)
+
+`.lore.md` shares knowledge through git: reviewable and durable, but it converges at the speed of commits and merges. **Folk Lore** is the upcoming hosted layer for teams that want **live** shared memory — knowledge that converges across every teammate's machine continuously, with promotion workflows for deciding what becomes shared truth, and integration with your existing team structure (GitHub Teams, repo collaborators).
+
+The two are complementary:
+
+| | `.lore.md` (today) | Folk Lore (coming soon) |
+|---|---|---|
+| Transport | Git (commit + PR) | Live hosted sync |
+| Review | Pull request | Promotion workflow |
+| Convergence | At merge time | Continuous |
+| Where it lives | Your repo | Your repo + hosted team store |
+
+You don't have to choose: git-native `.lore.md` is the reviewable record; Folk Lore adds live convergence on top. [Folk Lore early access &rarr;](/different/#waitlist)

--- a/packages/website/src/pages/index.astro
+++ b/packages/website/src/pages/index.astro
@@ -380,6 +380,20 @@ const base = import.meta.env.BASE_URL;
       </div>
       <div class="bc bc-3 sr">
         <div>
+          <p class="bc-tag">Team</p>
+          <h3 class="bc-t">Memory your team reviews</h3>
+          <p class="bc-b">Curated knowledge is exported to <code class="code-inline">.lore.md</code> —
+            plain Markdown in your repo, sorted for clean diffs and tagged with stable IDs. Your team
+            reviews what the AI learned in a pull request, the same way it reviews code. No private
+            database, no black box. Live team sync is coming with Folk Lore.
+            <a href={`${base}docs/team-memory/`} style="border-bottom:1px solid var(--g4);color:var(--g2)">How team memory works &rarr;</a></p>
+        </div>
+        <div class="code-block">
+          <code><span class="ck"># Review what your AI learned</span><br><span class="cv">$</span> git diff .lore.md<br><br><span class="ck">+ * **Auth**: refresh tokens in the</span><br><span class="ck">+   middleware, never per route.</span></code>
+        </div>
+      </div>
+      <div class="bc bc-3 sr">
+        <div>
           <p class="bc-tag">Migration</p>
           <h3 class="bc-t">Import your history, start smart</h3>
           <p class="bc-b">Lore imports conversations from Claude Code, Codex, Aider, Cline, Continue,


### PR DESCRIPTION
Closes #915.

Positions `.lore.md` as Lore's **git-native, PR-reviewable team-memory** path — the team story that works today — with Folk Lore framed as the complementary, coming-soon live-sync layer (never presented as currently available).

## Changes

- **New docs page** `docs/team-memory.md` ("Team memory & review"): how `.lore.md` is diffable, merge-friendly (alphabetical-by-title ordering + stable `<!-- lore:UUID -->` markers), PR-reviewable, and round-trips (export skips no-op writes; import upserts known/unknown markers; hand edits are first-class). Links to `loreFile`/`crossProject` config. Closes with a `.lore.md`-today vs Folk-Lore-coming-soon comparison table.
- **Sidebar**: add "Team memory" under the Lore group in `astro.config.mjs`.
- **README**: new "Team memory" section after the recall tool.

## Verification

- `pnpm --filter @loreai/website build` succeeds; `/docs/team-memory/` is generated (19 pages built).
- Biome check clean on `astro.config.mjs`.
- Internal links resolve to existing config anchors (`#loreFile`, `#crossProject`).
- Folk Lore is consistently labeled coming-soon; nothing claims it ships today.
- `.lore.md` restored to `origin/main` before branching — not in this diff.

Docs/positioning only — no code or behavior changes. (Item 5 from the mex competitive analysis.)
