### PR TITLE
fix(core): drop outcomeImpact.lastVerdict — inaccurate recency hint (Seer #906)

### DIFF
--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -989,40 +989,34 @@ export type OutcomeImpact = {
   passes: number;
   /** Sessions this entry was injected into that ended with failing verifiers. */
   fails: number;
-  /** Verdict of the most-recently-injected credited session ('pass'|'fail'), or
-   *  null if never credited. Ordered by injection time (created_at), not credit
-   *  time — there is no credit-time column; this is an observability hint only. */
-  lastVerdict: "pass" | "fail" | null;
 };
 
 /**
  * Aggregate the verifier outcomes a knowledge entry has co-occurred with, by its
- * stable `logical_id` (A2). Reads credited injection rows; 'none' verdicts are
- * not recorded (no signal), so only pass/fail are counted. Read-only — surfaced
- * by `lore data show` so the reward loop's effect is observable.
+ * stable `logical_id` (A2). Counts credited injection rows by verdict; 'none'
+ * verdicts are not recorded (no signal), so only pass/fail are counted (the
+ * `verdict IN ('pass','fail')` filter also excludes still-uncredited NULL rows).
+ * Read-only — surfaced by `lore data show` so the reward loop's effect is
+ * observable. (A recency / "last verdict" hint is intentionally omitted: the
+ * only available timestamp is injection time, not credit time, so it would
+ * misreport when an old session is credited late.)
  */
 export function outcomeImpact(logicalId: string): OutcomeImpact {
   const rows = db()
     .query(
-      `SELECT verdict, COUNT(*) AS n, MAX(created_at) AS last_at
+      `SELECT verdict, COUNT(*) AS n
        FROM knowledge_session_injections
        WHERE logical_id = ? AND verdict IN ('pass','fail')
        GROUP BY verdict`,
     )
-    .all(logicalId) as { verdict: string; n: number; last_at: number }[];
+    .all(logicalId) as { verdict: string; n: number }[];
   let passes = 0;
   let fails = 0;
-  let lastVerdict: "pass" | "fail" | null = null;
-  let lastAt = -1;
   for (const r of rows) {
     if (r.verdict === "pass") passes = r.n;
     else if (r.verdict === "fail") fails = r.n;
-    if (r.last_at > lastAt) {
-      lastAt = r.last_at;
-      lastVerdict = r.verdict as "pass" | "fail";
-    }
   }
-  return { passes, fails, lastVerdict };
+  return { passes, fails };
 }
 
 /**

--- a/packages/core/test/ltm-outcome-reward.test.ts
+++ b/packages/core/test/ltm-outcome-reward.test.ts
@@ -411,7 +411,7 @@ describe("outcome-reward: outcomeImpact (observability, #497 follow-up)", () => 
     ltm.creditSessionOutcome(session, PROJECT);
   }
 
-  test("aggregates pass/fail co-occurrence counts and the last verdict", () => {
+  test("aggregates pass/fail co-occurrence counts across sessions", () => {
     const e = makeProjectEntry("imp-1", 0.5);
     const lid = getEntry(e).logical_id;
     creditOnce(lid, "i-a", "pass");
@@ -421,18 +421,14 @@ describe("outcome-reward: outcomeImpact (observability, #497 follow-up)", () => 
     const impact = ltm.outcomeImpact(lid);
     expect(impact.passes).toBe(2);
     expect(impact.fails).toBe(1);
-    expect(impact.lastVerdict).toBe("fail"); // most recent credited session
   });
 
-  test("ignores uncredited (NULL-verdict) rows even when more recently injected", () => {
-    // Pins the `verdict IN ('pass','fail')` filter: a later-injected but
-    // still-uncredited (NULL verdict) row must NOT clobber lastVerdict or be
-    // counted. Without the filter, the NULL group's MAX(created_at) wins and
-    // lastVerdict collapses to null.
+  test("does not count uncredited (NULL-verdict) rows", () => {
+    // Pins the `verdict IN ('pass','fail')` filter: a still-uncredited (NULL
+    // verdict) injection must not be counted toward passes/fails.
     const e = makeProjectEntry("imp-null", 0.5);
     const lid = getEntry(e).logical_id;
     creditOnce(lid, "i-pass", "pass");
-    // An uncredited injection in a LATER session (higher created_at, verdict NULL).
     db()
       .query(
         `INSERT INTO knowledge_session_injections (session_id, logical_id, project_id, created_at, credited, verdict)
@@ -443,13 +439,12 @@ describe("outcome-reward: outcomeImpact (observability, #497 follow-up)", () => 
     const impact = ltm.outcomeImpact(lid);
     expect(impact.passes).toBe(1);
     expect(impact.fails).toBe(0);
-    expect(impact.lastVerdict).toBe("pass"); // NULL row excluded
   });
 
   test("zero for an entry that has never been credited", () => {
     const e = makeProjectEntry("imp-2", 0.5);
     const impact = ltm.outcomeImpact(getEntry(e).logical_id);
-    expect(impact).toEqual({ passes: 0, fails: 0, lastVerdict: null });
+    expect(impact).toEqual({ passes: 0, fails: 0 });
   });
 
   test("a NONE-verdict session records no verdict (uncredited, not counted)", () => {
@@ -463,10 +458,6 @@ describe("outcome-reward: outcomeImpact (observability, #497 follow-up)", () => 
       .run("i-none", lid, pid, Date.now());
     // No verifier tool call → verdict 'none' → nothing recorded.
     ltm.creditSessionOutcome("i-none", PROJECT);
-    expect(ltm.outcomeImpact(lid)).toEqual({
-      passes: 0,
-      fails: 0,
-      lastVerdict: null,
-    });
+    expect(ltm.outcomeImpact(lid)).toEqual({ passes: 0, fails: 0 });
   });
 });

--- a/packages/gateway/src/cli/data.ts
+++ b/packages/gateway/src/cli/data.ts
@@ -269,8 +269,7 @@ async function cmdShow(
       const impact = ltm.outcomeImpact(entry.logical_id);
       if (impact.passes || impact.fails) {
         console.log(
-          `Outcome:     ${impact.passes} passed / ${impact.fails} failed sessions` +
-            (impact.lastVerdict ? ` (last: ${impact.lastVerdict})` : ""),
+          `Outcome:     ${impact.passes} passed / ${impact.fails} failed sessions`,
         );
       }
       console.log(`Project ID:  ${entry.project_id ?? "(global)"}`);


### PR DESCRIPTION
Addresses the Seer comment on #906 (also raised by the adversarial review).

**Issue:** `outcomeImpact.lastVerdict` ordered by `created_at` (injection time), not credit time, so it misreports the "last" verdict when an old session is credited late.

**Fix:** Removed `lastVerdict` rather than add a `credited_at` column/migration for a display-only recency hint. The `passes`/`fails` counts — the real signal — are accurate and retained. The `verdict IN ('pass','fail')` filter stays (excludes still-uncredited NULL rows from counts). CLI drops the `(last: …)` suffix.

Full suite **3869**; typecheck, lint, build green.