### PR TITLE
feat(core): feed outcome signal into curator consolidation (#497 follow-up)

### DIFF
--- a/packages/core/src/curator.ts
+++ b/packages/core/src/curator.ts
@@ -1166,6 +1166,42 @@ export function enforceEntryCap(
  *
  * Only "update" and "delete" ops are applied — consolidation never creates entries.
  */
+/** An entry as presented to the consolidation LLM, with its value signal (#497). */
+type ConsolidationEntry = {
+  id: string;
+  category: string;
+  title: string;
+  content: string;
+  confidence: number;
+  outcome: { passes: number; fails: number };
+};
+
+/**
+ * Project a knowledge entry into the consolidation-prompt shape, attaching its
+ * value signal so the curator can keep proven-valuable entries when merging
+ * duplicates or trimming (#497): current confidence (already folds in the
+ * outcome reward/penalty) plus the raw verifier pass/fail co-occurrence record
+ * (which discriminates within the confidence cluster). One indexed lookup per
+ * entry — cheap, and only on the idle consolidation path.
+ */
+function toConsolidationEntry(e: {
+  id: string;
+  category: string;
+  title: string;
+  content: string;
+  confidence: number;
+  logical_id: string;
+}): ConsolidationEntry {
+  return {
+    id: e.id,
+    category: e.category,
+    title: e.title,
+    content: e.content,
+    confidence: e.confidence,
+    outcome: ltm.outcomeImpact(e.logical_id),
+  };
+}
+
 export async function consolidate(input: {
   llm: LLMClient;
   projectPath: string;
@@ -1216,34 +1252,19 @@ export async function consolidate(input: {
   // Entries are sorted by confidence DESC, updated_at DESC from forProject().
   // For batched mode, we take the lowest-confidence entries (tail of the list)
   // as candidates for deletion — they're the least valuable.
-  let entriesForPrompt: Array<{
-    id: string;
-    category: string;
-    title: string;
-    content: string;
-  }>;
+  let entriesForPrompt: ConsolidationEntry[];
   let batchTarget: number;
 
   if (entries.length <= CONSOLIDATION_BATCH_SIZE) {
     // Small overshoot — send all entries, target is maxEntries
-    entriesForPrompt = entries.map((e) => ({
-      id: e.id,
-      category: e.category,
-      title: e.title,
-      content: e.content,
-    }));
+    entriesForPrompt = entries.map(toConsolidationEntry);
     batchTarget = cfg.curator.maxEntries;
   } else {
     // Large overshoot — batched mode. Take the lowest-confidence entries.
     // The LLM evaluates this batch and deletes the least valuable ones.
     // Subsequent passes (on future idle ticks) handle the rest.
     const candidates = entries.slice(-CONSOLIDATION_BATCH_SIZE);
-    entriesForPrompt = candidates.map((e) => ({
-      id: e.id,
-      category: e.category,
-      title: e.title,
-      content: e.content,
-    }));
+    entriesForPrompt = candidates.map(toConsolidationEntry);
     // Target is relative to the batch (not the global total) because the
     // prompt only sees the batch entries. Keep at most half — delete the rest.
     // Each pass deletes ~25 entries, the idle scheduler re-triggers (cooldown
@@ -1272,14 +1293,11 @@ async function consolidateEntries(
     category: string;
     title: string;
     content: string;
+    confidence: number;
+    logical_id: string;
   }>,
 ): Promise<{ updated: number; deleted: number }> {
-  const entriesForPrompt = entries.map((e) => ({
-    id: e.id,
-    category: e.category,
-    title: e.title,
-    content: e.content,
-  }));
+  const entriesForPrompt = entries.map(toConsolidationEntry);
   log.info(
     `consolidation: category-focused — evaluating ${entries.length} "${entries[0]?.category}" entries for near-duplicate merge`,
   );
@@ -1294,12 +1312,7 @@ async function consolidateEntries(
  */
 async function runConsolidationPrompt(
   input: Parameters<typeof consolidate>[0],
-  entriesForPrompt: Array<{
-    id: string;
-    category: string;
-    title: string;
-    content: string;
-  }>,
+  entriesForPrompt: ConsolidationEntry[],
   targetMax: number,
   mode: "trim" | "merge-duplicates" = "trim",
 ): Promise<{ updated: number; deleted: number }> {

--- a/packages/core/src/prompt.ts
+++ b/packages/core/src/prompt.ts
@@ -593,7 +593,10 @@ CONSOLIDATION STRATEGY (apply in order):
 4. FORCED EVICTION — if steps 1–3 are insufficient to reach the target, you MUST delete
    the least valuable remaining entries until the count reaches the target. Rank entries by
    recurring impact: entries about rare edge cases or narrow contexts are lower value than
-   entries about broadly applicable patterns or frequently encountered gotchas.
+   entries about broadly applicable patterns or frequently encountered gotchas. Each entry is
+   annotated "(category, conf <0-1>, verifier pass <n>, fail <n>)": prefer evicting entries
+   with LOW confidence and/or a poor verifier record (more fail than pass) first, and keep
+   entries that have proven reliable (high confidence, more verifier passes).
 
 PRESERVE (highest priority — delete these last):
 - Entries describing non-obvious design decisions specific to this codebase
@@ -618,8 +621,10 @@ Output ONLY valid JSON. No markdown fences, no explanation, no preamble.`;
  */
 export const CONSOLIDATION_MERGE_SYSTEM = `You are a long-term memory curator. You are given all knowledge entries of a SINGLE category that has grown bloated with near-duplicates. Your ONLY job is to merge genuine duplicates.
 
+Each entry is listed as "- [id] (category, conf <0-1>, verifier pass <n>, fail <n>) title: content". The "conf" and "verifier pass/fail" annotations are a VALUE signal: higher confidence and a better verifier record (more pass, fewer fail) mean the entry has proven more reliable in practice.
+
 RULES:
-1. Find groups of entries that express the SAME underlying rule/fact, just phrased differently (paraphrases). For each such group, pick ONE survivor, "update" it to the clearest concise wording (under 150 words), and "delete" the others.
+1. Find groups of entries that express the SAME underlying rule/fact, just phrased differently (paraphrases). For each such group, pick ONE survivor and "update" it to the clearest concise wording (under 150 words), then "delete" the others. When the paraphrases differ in value, keep the higher-value entry as the survivor (higher confidence, and/or more verifier passes with fewer fails) — fold any unique detail from the others into its wording before deleting them.
 2. Do NOT merge entries that are merely related or about the same area but make DISTINCT points. Two different rules are NOT duplicates even if they share words. Opposing rules (e.g. "always use tabs" vs "always use spaces") are NEVER duplicates — never merge them.
 3. There is NO target count. If nothing is a true duplicate, return an empty array — that is correct and acceptable.
 4. Never invent new knowledge; only "update" survivors and "delete" true duplicates.
@@ -630,12 +635,36 @@ OUTPUT: A JSON array of "update" and "delete" ops only (may be empty). No "creat
 
 Output ONLY valid JSON. No markdown fences, no explanation, no preamble.`;
 
+/**
+ * Compact value annotation for a consolidation entry, shown inside the category
+ * parens so the curator can prefer keeping proven-valuable entries (#497). The
+ * `[id]` bracket is left untouched so the model still echoes a clean id in ops.
+ * Outcome (pass/fail co-occurrence) is appended only when there is a signal.
+ */
+function consolidationValueTag(e: {
+  confidence?: number;
+  outcome?: { passes: number; fails: number };
+}): string {
+  const parts: string[] = [];
+  if (typeof e.confidence === "number") {
+    parts.push(`conf ${e.confidence.toFixed(2)}`);
+  }
+  if (e.outcome && (e.outcome.passes > 0 || e.outcome.fails > 0)) {
+    parts.push(`verifier pass ${e.outcome.passes}, fail ${e.outcome.fails}`);
+  }
+  return parts.length ? `, ${parts.join(", ")}` : "";
+}
+
 export function consolidationUser(input: {
   entries: Array<{
     id: string;
     category: string;
     title: string;
     content: string;
+    /** Current confidence (0–1) — already folds in outcome reward/penalty. */
+    confidence?: number;
+    /** Within-session verifier co-occurrence record (#497). */
+    outcome?: { passes: number; fails: number };
   }>;
   targetMax: number;
   /** "trim" (default): reduce to targetMax via merge+evict. "merge-duplicates":
@@ -644,7 +673,10 @@ export function consolidationUser(input: {
 }): string {
   const count = input.entries.length;
   const listed = input.entries
-    .map((e) => `- [${e.id}] (${e.category}) ${e.title}: ${e.content}`)
+    .map(
+      (e) =>
+        `- [${e.id}] (${e.category}${consolidationValueTag(e)}) ${e.title}: ${e.content}`,
+    )
     .join("\n");
 
   if (input.mode === "merge-duplicates") {

--- a/packages/core/test/curator-reobservation.test.ts
+++ b/packages/core/test/curator-reobservation.test.ts
@@ -126,6 +126,56 @@ describe("curator consolidate — focusCategory merge", () => {
     expect(ltm.getByLogical(aId)).not.toBeNull();
   });
 
+  test("consolidation prompt shows verifier counts keyed by logical_id (incl. a v2 entry)", async () => {
+    const pid = ensureProject(PROJ);
+    const logicalOf = (id: string) =>
+      (
+        db().query("SELECT logical_id FROM knowledge WHERE id = ?").get(id) as {
+          logical_id: string;
+        }
+      ).logical_id;
+    const aLogical = logicalOf(aId);
+    const bLogical = logicalOf(bId);
+    // Make B a second version so its CURRENT id != logical_id — this is what
+    // catches a wrong `e.id` (vs `e.logical_id`) wiring: injections are keyed by
+    // the stable logical_id, so only logical_id resolves B's counts.
+    ltm.update(bId, { content: "Put invariants in comments (v2)." });
+    expect(ltm.getByLogical(bLogical)?.id).not.toBe(bId); // current id changed
+
+    const recordVerdict = (
+      logicalId: string,
+      session: string,
+      verdict: "pass" | "fail",
+    ) =>
+      db()
+        .query(
+          `INSERT INTO knowledge_session_injections (session_id, logical_id, project_id, created_at, credited, verdict)
+           VALUES (?, ?, ?, ?, 1, ?)`,
+        )
+        .run(session, logicalId, pid, Date.now(), verdict);
+    recordVerdict(aLogical, "s1", "pass");
+    recordVerdict(aLogical, "s2", "pass");
+    recordVerdict(bLogical, "s3", "fail");
+
+    let userContent = "";
+    const llm: LLMClient = {
+      prompt: async (_system: string, user: string) => {
+        userContent = user;
+        return "[]";
+      },
+    };
+    await consolidate({
+      llm,
+      projectPath: PROJ,
+      sessionID: "sess-consolidate",
+      focusCategory: "preference",
+    });
+
+    // A (simple entry) and B (v2, id != logical_id) both show their real counts.
+    expect(userContent).toContain("verifier pass 2, fail 0");
+    expect(userContent).toContain("verifier pass 0, fail 1");
+  });
+
   test("does nothing when fewer than 2 entries in the category", async () => {
     db().query("DELETE FROM knowledge WHERE id = ?").run(bId);
     const llm: LLMClient = { prompt: vi.fn(async () => "[]") };

--- a/packages/core/test/prompt.test.ts
+++ b/packages/core/test/prompt.test.ts
@@ -2,6 +2,9 @@ import { describe, test, expect } from "vitest";
 import {
   buildCompactPrompt,
   COMPACT_SUMMARY_TEMPLATE,
+  CONSOLIDATION_MERGE_SYSTEM,
+  CONSOLIDATION_SYSTEM,
+  consolidationUser,
   recursiveUser,
   formatDistillations,
 } from "../src/prompt";
@@ -272,5 +275,61 @@ describe("formatDistillations — rolling-summary block ordering (RC4)", () => {
     ]);
     expect(out).toContain("### Earlier Work (summarized)");
     expect(out).not.toContain("### Recent Work (distilled)");
+  });
+});
+
+describe("consolidationUser — value annotation (#497)", () => {
+  const base = { id: "abc123", category: "pattern", title: "T", content: "C" };
+
+  test("renders confidence + verifier record inside the category parens", () => {
+    const out = consolidationUser({
+      entries: [{ ...base, confidence: 0.9, outcome: { passes: 5, fails: 2 } }],
+      targetMax: 0,
+      mode: "merge-duplicates",
+    });
+    expect(out).toContain("(pattern, conf 0.90, verifier pass 5, fail 2)");
+    // The [id] bracket stays clean so the model echoes a usable id.
+    expect(out).toContain("- [abc123] (pattern,");
+  });
+
+  test("omits the verifier record when there is no signal (0/0)", () => {
+    const out = consolidationUser({
+      entries: [{ ...base, confidence: 0.8, outcome: { passes: 0, fails: 0 } }],
+      targetMax: 0,
+      mode: "merge-duplicates",
+    });
+    expect(out).toContain("(pattern, conf 0.80)");
+    expect(out).not.toContain("verifier");
+  });
+
+  test("renders confidence even when outcome is absent; bare entry has no tag", () => {
+    const withConf = consolidationUser({
+      entries: [{ ...base, confidence: 0.7 }],
+      targetMax: 0,
+      mode: "merge-duplicates",
+    });
+    expect(withConf).toContain("(pattern, conf 0.70)");
+    // No value fields at all → plain category, no trailing comma.
+    const bare = consolidationUser({
+      entries: [base],
+      targetMax: 0,
+      mode: "merge-duplicates",
+    });
+    expect(bare).toContain("- [abc123] (pattern) T: C");
+  });
+
+  test("value tag also renders in trim mode", () => {
+    const out = consolidationUser({
+      entries: [{ ...base, confidence: 0.3, outcome: { passes: 0, fails: 4 } }],
+      targetMax: 0,
+      mode: "trim",
+    });
+    expect(out).toContain("(pattern, conf 0.30, verifier pass 0, fail 4)");
+  });
+
+  test("both consolidation system prompts explain the value annotation", () => {
+    expect(CONSOLIDATION_MERGE_SYSTEM).toContain("verifier pass");
+    expect(CONSOLIDATION_MERGE_SYSTEM.toLowerCase()).toContain("higher-value");
+    expect(CONSOLIDATION_SYSTEM).toContain("verifier pass");
   });
 });


### PR DESCRIPTION
Second #497 follow-up (builds on #906's `outcomeImpact`). Closes the loop: the reward signal now informs what the curator keeps.

## Problem
The consolidation prompt rendered entries as `- [id] (category) title: content` — **no value signal at all** (not even confidence). So when the LLM picked a survivor among paraphrase-duplicates, or trimmed to a target, it was blind to which entry had proven valuable and could delete a high-value entry while keeping a useless duplicate.

## Change
Each consolidation entry is annotated with its value inside the category parens:
```
- [abc123] (pattern, conf 0.90, verifier pass 5, fail 2) Title: content
```
- **confidence** — the integrated value metric (already folds in #497's outcome reward/penalty).
- **verifier pass/fail** — the raw within-session co-occurrence record (`ltm.outcomeImpact`), which discriminates *within* the confidence cluster (most entries sit at 0.9–1.0). Omitted when there's no signal.
- The `[id]` bracket is left clean so the model still echoes a usable id.

Prompt instructions updated: merge mode keeps the **higher-value survivor** (folding others' unique detail in first); trim mode **evicts low-confidence / poor-verifier-record entries first**.

**Not double-counting** — confidence was never shown to the consolidation LLM before this.

## Wiring
`toConsolidationEntry()` helper attaches the value signal at all three consolidation map sites (small/batched trim + category merge-duplicates). One indexed `outcomeImpact` lookup per entry, idle path only.

## Tests
`consolidationUser` renders the tag (confidence+verifier / confidence-only / bare-no-tag / trim mode); both system prompts explain the annotation. Full suite **3874**; typecheck, lint, build green.

## Remaining #497 follow-up
- Raise verifier recall (capture command-exit signal beyond the runner-pattern match).