### PR TITLE
feat(core): teach curator to capture recurring procedures as runbooks (#914)

### DIFF
--- a/packages/core/src/prompt.ts
+++ b/packages/core/src/prompt.ts
@@ -339,6 +339,43 @@ INCLUDE THE "WHY" — decisions and gotchas without rationale get undone:
 - Any standard or rule without its rationale is vulnerable to being optimized away by
   a session that doesn't know what problem it was solving.
 
+PROCEDURAL PATTERNS — recurring procedures get a runbook shape, not a flat fact:
+- When the captured pattern is a recurring *procedure* (deploy, release, review,
+  debug-X, setup, migration, hand-off), structure the content as:
+    Steps:
+    1. <action> — <one-line rationale>
+    2. ...
+    Gotchas:
+    - <trap>: <one-line fix>
+    Verify:
+    - [ ] <observable check>
+    - [ ] ...
+- Use plain Markdown (numbered steps, dashed bullets, dash-bracket checkboxes) so the
+  entry renders cleanly in .lore.md and PR diffs.
+- Keep the entry within the 1200-character content cap (and the curator's ~150-word
+  brevity budget). A runbook with more than ~5 steps or ~3 gotchas is probably
+  multiple patterns scoped to a phase — split it (e.g. "Deploy: pre-flight",
+  "Deploy: cutover", "Deploy: rollback") rather than truncating mid-procedure.
+- FLAT (non-procedural) patterns stay as a 1-3 sentence fact — do NOT force the
+  runbook shape onto one-line insights.
+
+Example procedural pattern (release cutover):
+  Title: Release: cut over to a new version
+  Category: pattern
+  Content:
+    Steps:
+    1. Merge release branch to main — gates the deploy on PR review.
+    2. Tag the merge commit vX.Y.Z — releases are pinned to immutable tags.
+    3. Trigger deploy-prod workflow on the tag — pins the deploy to the audited
+       artifact.
+    Gotchas:
+    - Skipping the tag and running from main: workflow can't reproduce which
+      commit shipped; rollback becomes guesswork.
+    Verify:
+    - [ ] git tag --list vX.Y.Z shows the new tag.
+    - [ ] deploy-prod workflow run for the tag has status "success".
+    - [ ] GET /health on production returns 200.
+
 BREVITY IS CRITICAL — each entry must be concise:
 - content MUST be under 150 words (~600 characters). Capture ONE specific actionable
   insight in 2-3 sentences. Prefer terse technical language.

--- a/packages/core/src/prompt.ts
+++ b/packages/core/src/prompt.ts
@@ -352,10 +352,11 @@ PROCEDURAL PATTERNS — recurring procedures get a runbook shape, not a flat fac
     - [ ] ...
 - Use plain Markdown (numbered steps, dashed bullets, dash-bracket checkboxes) so the
   entry renders cleanly in .lore.md and PR diffs.
-- Keep the entry within the 1200-character content cap (and the curator's ~150-word
-  brevity budget). A runbook with more than ~5 steps or ~3 gotchas is probably
-  multiple patterns scoped to a phase — split it (e.g. "Deploy: pre-flight",
-  "Deploy: cutover", "Deploy: rollback") rather than truncating mid-procedure.
+- A runbook is the ONE exception to the ~150-word brevity budget below: it may use up
+  to the full 1200-character content cap so the Steps/Gotchas/Verify stay intact. A
+  procedure with more than ~5 steps or ~3 gotchas is probably multiple patterns scoped
+  to a phase — split it (e.g. "Deploy: pre-flight", "Deploy: cutover", "Deploy:
+  rollback") rather than truncating mid-procedure.
 - FLAT (non-procedural) patterns stay as a 1-3 sentence fact — do NOT force the
   runbook shape onto one-line insights.
 
@@ -377,12 +378,16 @@ Example procedural pattern (release cutover):
     - [ ] GET /health on production returns 200.
 
 BREVITY IS CRITICAL — each entry must be concise:
-- content MUST be under 150 words (~600 characters). Capture ONE specific actionable
-  insight in 2-3 sentences. Prefer terse technical language.
+- content MUST be under 150 words (~600 characters) — EXCEPT a procedural pattern
+  (runbook), which may extend to the 1200-character cap to keep Steps/Gotchas/Verify
+  intact. Capture ONE specific actionable insight in 2-3 sentences. Prefer terse
+  technical language.
 - Each "gotcha": one specific trap + WHY it looks right + its fix in 2-3 sentences
 - Each "architecture": one design decision and its key constraint
 - Focus on the actionable insight, not the full story behind it
-- If a pattern requires more detail, split into multiple focused entries (each under 150 words)
+- If a FLAT pattern requires more detail, split into multiple focused entries (each
+  under 150 words); a procedural runbook stays a single entry but splits by PHASE when
+  it outgrows 1200 characters
 - Omit code examples unless a single short snippet is essential
 - Never include full file contents, large diffs, or complete command outputs
 

--- a/packages/core/test/prompt.test.ts
+++ b/packages/core/test/prompt.test.ts
@@ -5,6 +5,7 @@ import {
   CONSOLIDATION_MERGE_SYSTEM,
   CONSOLIDATION_SYSTEM,
   consolidationUser,
+  CURATOR_SYSTEM,
   recursiveUser,
   formatDistillations,
 } from "../src/prompt";
@@ -331,5 +332,47 @@ describe("consolidationUser — value annotation (#497)", () => {
     expect(CONSOLIDATION_MERGE_SYSTEM).toContain("verifier pass");
     expect(CONSOLIDATION_MERGE_SYSTEM.toLowerCase()).toContain("higher-value");
     expect(CONSOLIDATION_SYSTEM).toContain("verifier pass");
+  });
+});
+
+describe("CURATOR_SYSTEM — procedural pattern runbooks (#914)", () => {
+  test("declares a PROCEDURAL PATTERNS section heading", () => {
+    expect(CURATOR_SYSTEM).toContain("PROCEDURAL PATTERNS");
+  });
+
+  test("requires Steps / Gotchas / Verify headings for procedural entries", () => {
+    // Each must appear as a label the curator is told to emit.
+    expect(CURATOR_SYSTEM).toMatch(/\bSteps\s*:/);
+    expect(CURATOR_SYSTEM).toMatch(/\bGotchas\s*:/);
+    expect(CURATOR_SYSTEM).toMatch(/\bVerify\s*:/);
+  });
+
+  test("mentions the 1200-character content cap so curators know when to split", () => {
+    expect(CURATOR_SYSTEM).toContain("1200");
+  });
+
+  test("does not force the runbook shape onto flat (non-procedural) patterns", () => {
+    // The guidance must explicitly carve out a flat-pattern path. Pin a phrase
+    // that pins the "FLAT / 1-3 sentence" carve-out so it can't regress to
+    // "always emit Steps/Gotchas/Verify".
+    expect(CURATOR_SYSTEM).toMatch(/FLAT/i);
+    expect(CURATOR_SYSTEM).toMatch(/non-?procedural/i);
+  });
+
+  test("includes a golden example showing the runbook shape", () => {
+    // A worked example lets the model pattern-match the structure. Pin that
+    // the example contains a numbered step, a dashed gotcha, and a checkbox.
+    expect(CURATOR_SYSTEM).toMatch(/^\s*\d+\.\s/m);
+    expect(CURATOR_SYSTEM).toContain("[ ]");
+  });
+
+  test("PROCEDURAL PATTERNS section appears between INCLUDE THE WHY and BREVITY", () => {
+    const whyIdx = CURATOR_SYSTEM.indexOf('INCLUDE THE "WHY"');
+    const procIdx = CURATOR_SYSTEM.indexOf("PROCEDURAL PATTERNS");
+    const brevIdx = CURATOR_SYSTEM.indexOf("BREVITY IS CRITICAL");
+
+    expect(whyIdx).toBeGreaterThan(-1);
+    expect(procIdx).toBeGreaterThan(whyIdx);
+    expect(brevIdx).toBeGreaterThan(procIdx);
   });
 });

--- a/packages/core/test/prompt.test.ts
+++ b/packages/core/test/prompt.test.ts
@@ -375,4 +375,18 @@ describe("CURATOR_SYSTEM — procedural pattern runbooks (#914)", () => {
     expect(procIdx).toBeGreaterThan(whyIdx);
     expect(brevIdx).toBeGreaterThan(procIdx);
   });
+
+  test("brevity cap exempts procedural runbooks — no 600-vs-1200 contradiction (#923 Seer)", () => {
+    // Seer flagged that the 1200-char runbook cap contradicted the blanket
+    // ~600-char (150-word) brevity cap, which could make the model truncate
+    // runbooks. The brevity mandate MUST carve out procedural patterns up to
+    // 1200 chars; this pins the two sections so they can't silently diverge.
+    expect(CURATOR_SYSTEM).toMatch(
+      /under 150 words[^\n]*EXCEPT[^\n]*procedural[\s\S]{0,120}1200/i,
+    );
+    // And the split-on-overflow rule must not tell runbooks to split at 150 words.
+    expect(CURATOR_SYSTEM).toMatch(
+      /procedural runbook stays a single entry but splits by PHASE/i,
+    );
+  });
 });


### PR DESCRIPTION
Closes #914.

Teach the curator to capture **recurring procedures** as structured runbooks (`Steps` / `Gotchas` / `Verify`) instead of flat facts — inspired by [mex](https://github.com/mex-memory/mex)'s `patterns/` (item 4 from the mex competitive analysis).

## Design

- **Content convention inside the existing `pattern` category** — same approach gotcha already uses for its `Trap: ... Fix: ...` shape. No schema change, no migration, no new category. Renders cleanly in `.lore.md` via the existing Markdown pipeline.
- **PROCEDURAL PATTERNS section added to `CURATOR_SYSTEM`** instructing the curator to detect recurring *procedures* (deploy, release, review, debug-X, setup, migration, hand-off) and emit them as:
  ```
  Steps:
  1. <action> — <one-line rationale>
  2. ...
  Gotchas:
  - <trap>: <one-line fix>
  Verify:
  - [ ] <observable check>
  - [ ] ...
  ```
- **1200-character content cap called out explicitly** so curators split multi-phase procedures (e.g. `Deploy: pre-flight` / `Deploy: cutover` / `Deploy: rollback`) rather than truncating mid-procedure.
- **FLAT (non-procedural) patterns explicitly remain as 1–3 sentence facts** — the runbook shape is additive, not forced onto one-line insights.
- **One golden example** (release cutover) included so the model has a template.

## TDD discipline followed

- **Red phase**: added 6 tests in `packages/core/test/prompt.test.ts` (`CURATOR_SYSTEM — procedural pattern runbooks (#914)`); confirmed all 6 fail before any prompt change.
- **Green phase**: added the prompt section; confirmed all 6 pass.
- **Mutation check**: reverted `prompt.ts` → 6 fail; restored via SHA-256-verified byte-identical copy → 6 pass. Tests are non-vacuous.

## Verification

- `pnpm vitest run packages/core/test/prompt.test.ts` — **32/32 pass** (6 new + 26 pre-existing).
- Broader curator regression safety — `pnpm vitest run packages/core/test/curator-* packages/core/test/ltm-curator-budget.test.ts packages/core/test/pattern-extract.test.ts` — **101/101 pass**.
- **3 consecutive runs** (per flakiness discipline) — **133/133 pass** all three runs, no flake.
- `pnpm run typecheck` — clean across all 5 packages.
- Biome lint on changed files — clean (1 quote-style autofix applied).

## Files

- `packages/core/src/prompt.ts` (+37)
- `packages/core/test/prompt.test.ts` (+43)

## Follow-up

- The `preferences`/`recall` eval dimensions should be re-run after merge to confirm no regression in fact-style pattern capture — per the issue's acceptance criteria.
- If the curator under-uses the runbook shape in practice, follow-up tuning of the example or guidance wording is straightforward (it's all in one string).

## Notes

Pure prompt change — no schema, no migration, no behaviour change for existing entries. Reversible by deleting the PROCEDURAL PATTERNS section from `CURATOR_SYSTEM`.