### PR TITLE
feat: surface budget-overflow knowledge as a recall-by-id ToC (#917)

### DIFF
--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -1235,6 +1235,18 @@ export type ForSessionOptions = {
    * wins, but ties and minor fluctuations don't reshuffle the selected set.
    */
   stickyIds?: Set<string>;
+  /**
+   * Optional sink for the budget-overflow tail (#917). When provided,
+   * `forSession` pushes the entries that were relevance-scored but did NOT fit
+   * the token budget into this array, in the same score-descending order it
+   * uses internally. Lets a caller surface a compact "these also exist — recall
+   * by id for detail" table of contents without re-querying. Invariants:
+   * selected (returned) entries are never included; lat.md synthetics are never
+   * included (they are not knowledge rows and carry no recall id). Ordering is
+   * deterministic (matches the internal `allScored` sort) so the rendered ToC is
+   * byte-stable across turns.
+   */
+  overflowSink?: KnowledgeEntry[];
 };
 
 /**
@@ -1638,6 +1650,20 @@ export async function forSession(
     recordSessionInjections(sessionID, projectPath, result);
   } catch (err) {
     log.warn("forSession: reinforcement failed (non-fatal):", err);
+  }
+
+  // --- 9. Surface the budget-overflow tail (#917) ---
+  // Entries that were relevance-scored (`allScored`) but didn't make the
+  // budget cut. `allScored` is already sorted score-desc (with id tiebreak), so
+  // pushing in iteration order yields deterministic, byte-stable ordering for
+  // the caller's recall-on-demand ToC. `allScored` contains only knowledge rows
+  // (lat.md synthetics are packed separately in step 6), so this never leaks a
+  // lat.md row, which has no recall id.
+  if (options?.overflowSink) {
+    const selectedIds = new Set(result.map((e) => e.id));
+    for (const { entry } of allScored) {
+      if (!selectedIds.has(entry.id)) options.overflowSink.push(entry);
+    }
   }
 
   return result;

--- a/packages/core/test/ltm.test.ts
+++ b/packages/core/test/ltm.test.ts
@@ -571,6 +571,53 @@ describe("ltm.forSession", () => {
     expect(result.length).toBeGreaterThan(0);
   });
 
+  test("overflowSink collects scored entries that did not fit the budget (#917)", async () => {
+    // 10 entries (~100 tokens each); a budget that fits only a couple. The rest
+    // are relevance-scored but over-budget — they must surface in overflowSink
+    // so the caller can advertise them for recall-on-demand without re-querying.
+    const ids: string[] = [];
+    for (let i = 0; i < 10; i++) {
+      ids.push(
+        ltm.create({
+          projectPath: PROJ,
+          category: "pattern",
+          title: `Overflow pattern ${i}`,
+          content: "C ".repeat(150),
+          scope: "project",
+          crossProject: false,
+        }),
+      );
+    }
+
+    const overflow: ltm.KnowledgeEntry[] = [];
+    const selected = await ltm.forSession(PROJ, SESSION, 250, {
+      overflowSink: overflow,
+    });
+
+    // Some fit, some didn't.
+    expect(selected.length).toBeGreaterThan(0);
+    expect(selected.length).toBeLessThan(10);
+    expect(overflow.length).toBeGreaterThan(0);
+
+    // Selected and overflow are disjoint, and every overflow entry is a seeded
+    // entry (never a phantom).
+    const selectedIds = new Set(selected.map((e) => e.id));
+    for (const e of overflow) {
+      expect(selectedIds.has(e.id)).toBe(false);
+      expect(ids).toContain(e.id);
+    }
+
+    // No id appears in both lists.
+    const union = new Set([...selectedIds, ...overflow.map((e) => e.id)]);
+    expect(union.size).toBe(selectedIds.size + overflow.length);
+
+    // Overflow is ranked (score desc), same order forSession uses internally —
+    // pin determinism so the rendered ToC is byte-stable across turns.
+    const rerun: ltm.KnowledgeEntry[] = [];
+    await ltm.forSession(PROJ, SESSION, 250, { overflowSink: rerun });
+    expect(rerun.map((e) => e.id)).toEqual(overflow.map((e) => e.id));
+  });
+
   test("includes relevant cross-project entries when session context matches", async () => {
     // Create a cross-project entry about TypeScript
     ltm.create({

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -721,6 +721,40 @@ export function sameEntryKeys(
 
 const KNOWLEDGE_DELTA_TOKEN_BUDGET = 400;
 
+/** Max entries listed in the "Other relevant knowledge" overflow ToC (#917).
+ *  Each line is just `[id] title (category)` (~15-20 tokens), so 12 lines is a
+ *  ~200-token index — small enough to ride the frozen delta without crowding
+ *  out the rendered changed-entry content above it. */
+const OVERFLOW_TOC_MAX = 12;
+
+/** Max entries listed in the frozen system[1] project-knowledge catalog (#917,
+ *  the "A" floor). Present from turn 1 (before system[2] / any delta exists) so
+ *  the agent always knows what project knowledge exists and can recall it. */
+const STABLE_KNOWLEDGE_TOC_MAX = 15;
+
+/**
+ * Build a compact, recall-by-id catalog of project knowledge titles (#917 "A").
+ * Folded into the frozen system[1] baseline so it is present from turn 1 and
+ * byte-stable for the session's life (mirrors the entities partial-list block).
+ * Entries must be pre-sorted deterministically (forProject orders by confidence
+ * desc, updated_at desc) so the frozen bytes never depend on call order.
+ */
+export function buildKnowledgeCatalogText(
+  entries: Array<{ id: string; category: string; title: string }>,
+  max: number,
+): string {
+  if (!entries.length) return "";
+  const lines = entries
+    .slice(0, max)
+    .map((e) => `* [${e.id.slice(0, 8)}] ${e.title} (${e.category})`)
+    .join("\n");
+  const more =
+    entries.length > max
+      ? `\n* ${entries.length - max} more — use recall with an id for detail.`
+      : "";
+  return `## Project knowledge (recall by id for detail)\n\n${lines}${more}`;
+}
+
 type MessageInsertSelector = {
   target: "messages";
   insertAt: number;
@@ -1038,7 +1072,7 @@ function hasMaterialLtmDelta(input: {
   );
 }
 
-function buildKnowledgeDeltaMessage(
+export function buildKnowledgeDeltaMessage(
   entries: Array<{
     id: string;
     category: string;
@@ -1046,6 +1080,11 @@ function buildKnowledgeDeltaMessage(
     content: string;
   }>,
   removedIds: string[],
+  overflow?: Array<{
+    id: string;
+    category: string;
+    title: string;
+  }>,
 ): GatewayMessage | null {
   if (!entries.length && !removedIds.length) return null;
   const renderedIds: string[] = [];
@@ -1101,6 +1140,32 @@ function buildKnowledgeDeltaMessage(
   const removals = removedIds.length
     ? `\n\n## Superseded Long-term Knowledge\n\nIgnore any older pinned system[2] entries with these IDs; they are no longer in the current selected knowledge set:\n${removedIds.map((id) => `* [${id.slice(0, 8)}]`).join("\n")}`
     : "";
+  // #917 overflow ToC: a compact index of relevance-scored entries that didn't
+  // fit the system[2] budget, so the agent can recall them on demand. Exclude
+  // ids already shown above (changed/rendered) or listed as superseded — listing
+  // a "recall this" id that's also "ignore this" would contradict. Sort by id
+  // (NOT relevance order, which churns per turn) so the section is byte-stable
+  // across turns and only changes when the overflow SET changes — same cache-
+  // stability rationale as the "Additional Changed Knowledge" slice above. The
+  // section never appears alone: the early return above bails when there is no
+  // material change, so overflow only ever rides a delta that already exists.
+  const shownOrRemoved = new Set<string>([
+    ...entries.map((e) => e.id),
+    ...removedIds,
+  ]);
+  const tocEntries = (overflow ?? [])
+    .filter((e) => !shownOrRemoved.has(e.id))
+    .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+  const tocRendered = tocEntries.length
+    ? `\n\n## Other relevant knowledge (recall by id for detail)\n\n${tocEntries
+        .slice(0, OVERFLOW_TOC_MAX)
+        .map((e) => `* [${e.id.slice(0, 8)}] ${e.title} (${e.category})`)
+        .join("\n")}${
+        tocEntries.length > OVERFLOW_TOC_MAX
+          ? `\n* ${tocEntries.length - OVERFLOW_TOC_MAX} more — use recall with an id for detail.`
+          : ""
+      }`
+    : "";
   return {
     role: "user",
     content: [
@@ -1110,7 +1175,8 @@ function buildKnowledgeDeltaMessage(
           "[Lore knowledge update: durable prompt delta. This message is inserted by Lore and replayed byte-identically on later turns until an intentional cache reset.]\n\n" +
           rendered +
           skippedRendered +
-          removals,
+          removals +
+          tocRendered,
       },
     ],
   };
@@ -1128,6 +1194,7 @@ function appendKnowledgePromptDelta(input: {
     title: string;
     content: string;
   }>;
+  overflow?: Array<{ id: string; category: string; title: string }>;
 }): boolean {
   const entries = changedLtmEntries(
     input.entries,
@@ -1137,6 +1204,7 @@ function appendKnowledgePromptDelta(input: {
   const message = buildKnowledgeDeltaMessage(
     entries,
     removedLtmEntryIds(input.previousKeys, input.nextKeys),
+    input.overflow,
   );
   if (!message) return false;
 
@@ -6047,6 +6115,9 @@ async function handleConversationTurn(
           title: string;
           content: string;
         }>;
+        // #917: relevance-scored entries that didn't fit the system[2] budget,
+        // surfaced as a recall-by-id ToC inside the (frozen) knowledge delta.
+        overflow?: Array<{ id: string; category: string; title: string }>;
       }
     | undefined;
   if (cfg.knowledge.enabled) {
@@ -6120,7 +6191,31 @@ async function handleConversationTurn(
           }
         }
 
-        const formatted = [prefText, entitiesText].filter(Boolean).join("\n\n");
+        // Project-knowledge catalog (#917 "A") — a compact, recall-by-id index
+        // of this project's knowledge titles, folded into the frozen system[1]
+        // baseline so it is present from turn 1 (system[2] full content is
+        // deferred to turn 2+). Conservative visibility mirrors the entities
+        // block: project-owned entries only (includeCross=false), preferences
+        // excluded (already shown above). Frozen with the rest of the baseline,
+        // so it never churns the cache; the dynamic relevance-overflow tail is
+        // handled separately by the knowledge delta (#917 "B").
+        let knowledgeTocText = "";
+        try {
+          const catalog = ltm
+            .forProject(projectPath, false)
+            .filter((e) => e.category !== "preference")
+            .map((e) => ({ id: e.id, category: e.category, title: e.title }));
+          knowledgeTocText = buildKnowledgeCatalogText(
+            catalog,
+            STABLE_KNOWLEDGE_TOC_MAX,
+          );
+        } catch (err) {
+          log.warn("knowledge catalog injection failed (non-fatal):", err);
+        }
+
+        const formatted = [prefText, entitiesText, knowledgeTocText]
+          .filter(Boolean)
+          .join("\n\n");
         // Freeze this baseline durably (v45) — INCLUDING an empty result. The
         // in-memory cache is lost on process restart / session eviction;
         // persisting lets getOrCreateSession restore the exact bytes so system[1]
@@ -6186,6 +6281,11 @@ async function handleConversationTurn(
               content: string;
             }>
           | undefined;
+        // #917: the budget-overflow tail from this turn's forSession, mapped to
+        // the ToC shape. Threaded into the knowledge delta below.
+        let freshContextOverflow:
+          | Array<{ id: string; category: string; title: string }>
+          | undefined;
 
         if (!cached) {
           // Full context-bound budget — preferences have their own dedicated budget.
@@ -6198,6 +6298,7 @@ async function handleConversationTurn(
             ltmPinnedText.get(sessionID)?.entryKeys,
           );
           // Exclude preferences — they're already in system[1]
+          const overflowSink: ltm.KnowledgeEntry[] = [];
           const contextEntries = await ltm.forSession(
             projectPath,
             sessionID,
@@ -6206,9 +6307,15 @@ async function handleConversationTurn(
               excludeCategories: ["preference"],
               ...(contextHint ? { contextHint } : {}),
               ...(stickyIds.size ? { stickyIds } : {}),
+              overflowSink,
             },
           );
           freshContextEntries = contextEntries;
+          freshContextOverflow = overflowSink.map((e) => ({
+            id: e.id,
+            category: e.category,
+            title: e.title,
+          }));
           if (contextEntries.length) {
             const renderedIds: string[] = [];
             const formatted = formatKnowledge(
@@ -6320,6 +6427,7 @@ async function handleConversationTurn(
               previousKeys: pinned.entryKeys,
               nextKeys: cachedKeys,
               entries: freshContextEntries,
+              overflow: freshContextOverflow,
             };
             ltmPinnedText.set(sessionID, {
               formatted: pinned.formatted,
@@ -6439,6 +6547,7 @@ async function handleConversationTurn(
       // Stability hint: keep the previously-pinned set sticky so consecutive
       // Layer-4 turns don't churn the selection (see step-6).
       const stickyIds = entryKeyIds(ltmPinnedText.get(sessionID)?.entryKeys);
+      const overflowSink: ltm.KnowledgeEntry[] = [];
       const contextEntries = await ltm.forSession(
         projectPath,
         sessionID,
@@ -6447,8 +6556,14 @@ async function handleConversationTurn(
           excludeCategories: ["preference"],
           ...(contextHint ? { contextHint } : {}),
           ...(stickyIds.size ? { stickyIds } : {}),
+          overflowSink,
         },
       );
+      const contextOverflow = overflowSink.map((e) => ({
+        id: e.id,
+        category: e.category,
+        title: e.title,
+      }));
       let refreshed = false;
 
       if (contextEntries.length) {
@@ -6509,6 +6624,7 @@ async function handleConversationTurn(
               previousKeys: frozenKeys,
               nextKeys: entryKeys,
               entries: contextEntries,
+              overflow: contextOverflow,
             };
             ltmPinnedText.set(sessionID, {
               formatted: pinned.formatted,

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -738,6 +738,13 @@ const STABLE_KNOWLEDGE_TOC_MAX = 15;
  * byte-stable for the session's life (mirrors the entities partial-list block).
  * Entries must be pre-sorted deterministically (forProject orders by confidence
  * desc, updated_at desc) so the frozen bytes never depend on call order.
+ *
+ * Each line renders the FULL id with a `k:` prefix (`[k:<uuid>]`) — that exact
+ * token is what the agent passes to the recall tool's `id` param. Do NOT shorten
+ * it: `recallById` (recall.ts) resolves `k:`/`xk:` by EXACT `ltm.get(id)` /
+ * `getByLogical(logicalIdOf(id))` with no prefix matching, so an 8-char slice is
+ * unresolvable ("No entry found"). `k:` and `xk:` resolve identically (both hit
+ * `ltm.get`), so `k:` is safe for project-owned and promoted rows alike.
  */
 export function buildKnowledgeCatalogText(
   entries: Array<{ id: string; category: string; title: string }>,
@@ -746,7 +753,7 @@ export function buildKnowledgeCatalogText(
   if (!entries.length) return "";
   const lines = entries
     .slice(0, max)
-    .map((e) => `* [${e.id.slice(0, 8)}] ${e.title} (${e.category})`)
+    .map((e) => `* [k:${e.id}] ${e.title} (${e.category})`)
     .join("\n");
   const more =
     entries.length > max
@@ -1159,7 +1166,7 @@ export function buildKnowledgeDeltaMessage(
   const tocRendered = tocEntries.length
     ? `\n\n## Other relevant knowledge (recall by id for detail)\n\n${tocEntries
         .slice(0, OVERFLOW_TOC_MAX)
-        .map((e) => `* [${e.id.slice(0, 8)}] ${e.title} (${e.category})`)
+        .map((e) => `* [k:${e.id}] ${e.title} (${e.category})`)
         .join("\n")}${
         tocEntries.length > OVERFLOW_TOC_MAX
           ? `\n* ${tocEntries.length - OVERFLOW_TOC_MAX} more — use recall with an id for detail.`

--- a/packages/gateway/test/cache-stability.e2e.test.ts
+++ b/packages/gateway/test/cache-stability.e2e.test.ts
@@ -13,6 +13,7 @@
  * token injected into a cached block, etc.), the divergence offset jumps out of
  * the tail and these tests fail — turning whack-a-mole into a guardrail.
  */
+import { mkdirSync, writeFileSync } from "node:fs";
 import { describe, it, expect, afterEach } from "vitest";
 import { log } from "@loreai/core";
 import type { Harness } from "./helpers/harness";
@@ -602,6 +603,157 @@ describe("cache stability (e2e)", () => {
     expect(Number.isInteger(selector.insertAt)).toBe(true);
     expect(rows[0].content).toContain("Updated context-bound knowledge");
     expect(rows[0].content).toContain("Changed huge durable delta marker");
+  });
+
+  it("budget-overflow knowledge surfaces as a recall-by-id ToC in system[1] (A) and the delta (B) [#917]", async () => {
+    // End-to-end proof of the #917 wiring: knowledge that is relevance-scored
+    // but doesn't fit the system[2] injection budget must reach the wire as a
+    // recall-by-id table of contents — A in the frozen system[1] baseline
+    // (present from turn 1), B in the durable knowledge delta (on material
+    // change). The LTM budget floors at LTM_BUDGET_STEP (8000 tokens), so we
+    // seed ~30 entries (~9K tokens total) to force a real overflow tail.
+    //
+    // Each entry's content stays UNDER the 1200-char knowledge cap: the pipeline
+    // runs `ltm.pruneOversized(1200)` on every turn, which zeroes the confidence
+    // of any oversized entry — pruned entries fall below the `confidence > 0.2`
+    // floor and vanish from forSession/forProject, so oversized seeds never
+    // reach the ToC at all.
+    const turns = Array.from({ length: 4 }, (_, i) => ({
+      // Mention the shared topic ("dashboard") so forSession's relevance scoring
+      // keeps the whole seeded set in play — otherwise it filters to a handful
+      // that all fit the budget and there is no overflow tail to surface.
+      userMessage: `Turn ${i}: tell me more about the dashboard subsystem and its dashboard internals.`,
+      assistantText: `Working on the dashboard ${i}.`,
+    }));
+    harness = await createHarness({
+      fixtures: makeConversationFixtures(turns),
+    });
+
+    const projectPath = `/tmp/lore-overflow-toc-${Date.now()}`;
+    const clientSessionID = `overflow-toc-client-${Date.now()}`;
+    const headers = {
+      "x-lore-project": projectPath,
+      "x-lore-session-id": clientSessionID,
+    };
+
+    const { ltm } = await import("@loreai/core");
+
+    // Per-project config: a near-zero idle-resume threshold so that the small
+    // real delay between turns counts as an "idle resume". Idle resume busts the
+    // in-memory LTM session cache (gradient.onIdleResume → ltmSessionCache delete)
+    // and forces a forSession recompute on the next turn — the path that turns a
+    // pinned-system[2] knowledge change into a durable message delta (where B's
+    // overflow ToC rides) instead of a direct system[2] rewrite.
+    mkdirSync(projectPath, { recursive: true });
+    writeFileSync(
+      `${projectPath}/.lore.json`,
+      JSON.stringify({ idleResumeMinutes: 0.0005 }),
+    );
+
+    // Seed 30 project entries BEFORE the first request so they exist when
+    // system[1] is first built (and frozen) on turn 0. ~310 tokens each ×30 ≈
+    // 9.3K tokens > the 8000-token budget floor → guaranteed overflow tail when
+    // forSession scores by confidence (no/sparse session context).
+    const SEED_COUNT = 30;
+    const seededIds: string[] = [];
+    for (let i = 0; i < SEED_COUNT; i++) {
+      seededIds.push(
+        ltm.create({
+          projectPath,
+          scope: "project",
+          crossProject: false,
+          category: i % 2 ? "gotcha" : "pattern",
+          title: `Dashboard subsystem note ${String(i).padStart(2, "0")}`,
+          // ~900 chars (under the 1200-char prune cap), saturated with the
+          // shared "dashboard" topic so every entry scores relevant to the
+          // conversation and the full set competes for the budget.
+          content:
+            `Dashboard subsystem detail ${i}. ` +
+            "The dashboard internals and dashboard pipeline matter here. ".repeat(
+              15,
+            ),
+        }),
+      );
+    }
+
+    const history: unknown[] = [];
+    let sessionID = "";
+    for (let i = 0; i < turns.length; i++) {
+      // A small real delay so each turn (after the first) clears the near-zero
+      // idle threshold → idle-resume recompute on the next turn.
+      if (i > 0) await new Promise((r) => setTimeout(r, 80));
+
+      const resp = await harness.chat(
+        makeBody(turns[i].userMessage, history),
+        "test-key",
+        headers,
+      );
+      expect(resp.status).toBe(200);
+      await resp.json();
+      history.push({ role: "user", content: turns[i].userMessage });
+      history.push({
+        role: "assistant",
+        content: [{ type: "text", text: turns[i].assistantText }],
+      });
+
+      if (i === 0) {
+        const rows = harness.queryDB<{ session_id: string }>(
+          "SELECT session_id FROM session_state ORDER BY updated_at DESC LIMIT 1",
+        );
+        sessionID = rows[0]?.session_id ?? "";
+        expect(sessionID).not.toBe("");
+      }
+
+      if (i === 1) {
+        // Material change to a pinned entry. The next turn's idle-resume recompute
+        // detects the change and carries it (plus the #917 overflow tail) as a
+        // durable message delta instead of rewriting the cached system[2] block.
+        ltm.update(seededIds[0], {
+          content:
+            "Changed body that must arrive as a durable delta. " +
+            "More filler to keep it material. ".repeat(20),
+        });
+      }
+    }
+
+    const bodies = harness.upstreamBodies();
+    expect(bodies.length).toBe(turns.length);
+
+    // --- A: frozen system[1] catalog, present from turn 0, byte-stable ---
+    // The catalog lives in its own system block (system[1]); isolate it rather
+    // than joining all blocks, since system[2] (full context-bound LTM) appears
+    // from turn 2 and would otherwise pollute the comparison.
+    const catalogBlock = (body: string): string | undefined =>
+      systemBlocks(body).find((b) =>
+        b.includes("Project knowledge (recall by id for detail)"),
+      );
+    const cat0 = catalogBlock(bodies[0]);
+    expect(cat0).toBeDefined();
+    // Renders a FULL recall-ready id (k:<uuid>), never an 8-char slice.
+    expect(cat0 as string).toMatch(/\[k:[0-9a-f]{8}-[0-9a-f-]{27,}\]/);
+    // 30 seeded, cap 15 → the remainder is summarized as "15 more".
+    expect(cat0 as string).toMatch(/\b15 more\b/);
+    // Frozen: the catalog block is byte-identical on a later turn.
+    expect(catalogBlock(bodies[bodies.length - 1])).toEqual(cat0);
+
+    // --- B: overflow ToC rides the durable knowledge delta after the material
+    // change. Assert against the persisted session_prompt_deltas row (the source
+    // of truth) rather than the replayed window, which Layer-4 compaction may
+    // strip down. ---
+    const deltaRows = harness.queryDB<{ content: string }>(
+      "SELECT content FROM session_prompt_deltas WHERE session_id = ? ORDER BY seq",
+      [sessionID],
+    );
+    const deltaText = deltaRows.map((r) => r.content).join("\n---\n");
+    expect(deltaText).toContain(
+      "## Other relevant knowledge (recall by id for detail)",
+    );
+    // The id in the B section is a full recall-ready k:<uuid> (the 8-char slice
+    // handle used by the changed-entry section above it would not match this
+    // pattern anchored at the B heading).
+    expect(deltaText).toMatch(
+      /Other relevant knowledge \(recall by id for detail\)[\s\S]*?\[k:[0-9a-f]{8}-[0-9a-f-]{27,}\]/,
+    );
   });
 
   it("coalesces MULTIPLE successive knowledge changes into ONE position-stable delta row", async () => {

--- a/packages/gateway/test/knowledge-delta-overflow.test.ts
+++ b/packages/gateway/test/knowledge-delta-overflow.test.ts
@@ -1,0 +1,150 @@
+import { describe, test, expect } from "vitest";
+import {
+  buildKnowledgeDeltaMessage,
+  buildKnowledgeCatalogText,
+} from "../src/pipeline";
+import type { GatewayMessage } from "../src/translate/types";
+
+// Extract the single text part of a delta message.
+function text(msg: GatewayMessage | null): string {
+  if (!msg) return "";
+  const part = msg.content[0] as { type: string; text: string };
+  return part.text;
+}
+
+const id = (prefix: string) => `${prefix}-1111-7111-8111-111111111111`;
+const changed = (p: string, title: string, category = "pattern") => ({
+  id: id(p),
+  category,
+  title,
+  content: `content for ${title}`,
+});
+const toc = (p: string, title: string, category = "pattern") => ({
+  id: id(p),
+  category,
+  title,
+});
+
+const HEADING = "## Other relevant knowledge (recall by id for detail)";
+
+describe("buildKnowledgeDeltaMessage — overflow ToC (#917)", () => {
+  test("renders an overflow section listing titles, short ids, and categories", () => {
+    const msg = buildKnowledgeDeltaMessage(
+      [changed("019aaaaa", "Changed entry")],
+      [],
+      [
+        toc("019bbbbb", "Overflow one"),
+        toc("019ccccc", "Overflow two", "gotcha"),
+      ],
+    );
+    const t = text(msg);
+    expect(t).toContain(HEADING);
+    expect(t).toContain("[019bbbbb] Overflow one (pattern)");
+    expect(t).toContain("[019ccccc] Overflow two (gotcha)");
+  });
+
+  test("overflow alone (no changes/removals) does NOT create a delta — rides existing cadence", () => {
+    // Cache-stability invariant: a delta is only created on material change.
+    // Overflow must never trigger one on its own, or it would add cache churn.
+    const msg = buildKnowledgeDeltaMessage([], [], [toc("019bbbbb", "Lonely")]);
+    expect(msg).toBeNull();
+  });
+
+  test("overflow is id-sorted (byte-stable across per-turn relevance re-ranking)", () => {
+    const msg = buildKnowledgeDeltaMessage(
+      [changed("019aaaaa", "Changed")],
+      [],
+      // Deliberately out of id order.
+      [
+        toc("019ccccc", "Gamma"),
+        toc("019aaaab", "Alpha"),
+        toc("019bbbbb", "Beta"),
+      ],
+    );
+    const t = text(msg);
+    const a = t.indexOf("Alpha");
+    const b = t.indexOf("Beta");
+    const g = t.indexOf("Gamma");
+    expect(a).toBeGreaterThan(-1);
+    expect(a).toBeLessThan(b);
+    expect(b).toBeLessThan(g);
+  });
+
+  test("caps the list and reports the remainder", () => {
+    const overflow = Array.from({ length: 15 }, (_, i) =>
+      toc(`019d${String(i).padStart(4, "0")}`, `Entry ${i}`),
+    );
+    const msg = buildKnowledgeDeltaMessage(
+      [changed("019aaaaa", "Changed")],
+      [],
+      overflow,
+    );
+    const t = text(msg);
+    // 12 shown, 3 more reported.
+    expect(t).toMatch(/3 more/);
+    expect(t).toContain("recall");
+  });
+
+  test("excludes ids already shown as changed or listed as superseded (no dup/contradiction)", () => {
+    const msg = buildKnowledgeDeltaMessage(
+      [changed("019aaaaa", "Changed entry")],
+      [id("019eeeee")],
+      [
+        toc("019aaaaa", "Should be excluded (changed)"),
+        toc("019eeeee", "Should be excluded (removed)"),
+        toc("019fffff", "Should appear"),
+      ],
+    );
+    const t = text(msg);
+    expect(t).toContain("Should appear");
+    expect(t).not.toContain("Should be excluded (changed)");
+    expect(t).not.toContain("Should be excluded (removed)");
+  });
+
+  test("no overflow arg → no overflow section (back-compat)", () => {
+    const msg = buildKnowledgeDeltaMessage(
+      [changed("019aaaaa", "Changed entry")],
+      [],
+    );
+    expect(text(msg)).not.toContain(HEADING);
+  });
+});
+
+describe("buildKnowledgeCatalogText — frozen system[1] catalog (#917 A)", () => {
+  test("renders a recall-by-id catalog of titles + short ids + categories", () => {
+    const out = buildKnowledgeCatalogText(
+      [
+        toc("019aaaaa", "Auth flow", "architecture"),
+        toc("019bbbbb", "DB gotcha", "gotcha"),
+      ],
+      15,
+    );
+    expect(out).toContain("## Project knowledge (recall by id for detail)");
+    expect(out).toContain("* [019aaaaa] Auth flow (architecture)");
+    expect(out).toContain("* [019bbbbb] DB gotcha (gotcha)");
+  });
+
+  test("empty input → empty string (keeps system[1] absent — no array-grow cache bust)", () => {
+    expect(buildKnowledgeCatalogText([], 15)).toBe("");
+  });
+
+  test("caps the catalog and reports the remainder", () => {
+    const entries = Array.from({ length: 20 }, (_, i) =>
+      toc(`019c${String(i).padStart(4, "0")}`, `Entry ${i}`),
+    );
+    const out = buildKnowledgeCatalogText(entries, 15);
+    expect(out).toMatch(/5 more/);
+    expect(out).toContain("recall");
+    // Only 15 lines + the "more" line.
+    expect(out.split("\n").filter((l) => l.startsWith("* ")).length).toBe(16);
+  });
+
+  test("preserves caller order (forProject confidence-desc) — byte-stable freeze", () => {
+    const out = buildKnowledgeCatalogText(
+      [toc("019ffff0", "First"), toc("019aaaa0", "Second")],
+      15,
+    );
+    // First listed first even though its id sorts later — order is the caller's.
+    expect(out.indexOf("First")).toBeLessThan(out.indexOf("Second"));
+  });
+});

--- a/packages/gateway/test/knowledge-delta-overflow.test.ts
+++ b/packages/gateway/test/knowledge-delta-overflow.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect } from "vitest";
+import { ltm, recallById } from "@loreai/core";
 import {
   buildKnowledgeDeltaMessage,
   buildKnowledgeCatalogText,
@@ -28,7 +29,7 @@ const toc = (p: string, title: string, category = "pattern") => ({
 const HEADING = "## Other relevant knowledge (recall by id for detail)";
 
 describe("buildKnowledgeDeltaMessage — overflow ToC (#917)", () => {
-  test("renders an overflow section listing titles, short ids, and categories", () => {
+  test("renders an overflow section listing titles, recall-ready ids, and categories", () => {
     const msg = buildKnowledgeDeltaMessage(
       [changed("019aaaaa", "Changed entry")],
       [],
@@ -39,8 +40,10 @@ describe("buildKnowledgeDeltaMessage — overflow ToC (#917)", () => {
     );
     const t = text(msg);
     expect(t).toContain(HEADING);
-    expect(t).toContain("[019bbbbb] Overflow one (pattern)");
-    expect(t).toContain("[019ccccc] Overflow two (gotcha)");
+    // Full id with a `k:` recall prefix — NOT an 8-char slice (recallById is
+    // exact-match, so a slice is unresolvable).
+    expect(t).toContain(`[k:${id("019bbbbb")}] Overflow one (pattern)`);
+    expect(t).toContain(`[k:${id("019ccccc")}] Overflow two (gotcha)`);
   });
 
   test("overflow alone (no changes/removals) does NOT create a delta — rides existing cadence", () => {
@@ -111,7 +114,7 @@ describe("buildKnowledgeDeltaMessage — overflow ToC (#917)", () => {
 });
 
 describe("buildKnowledgeCatalogText — frozen system[1] catalog (#917 A)", () => {
-  test("renders a recall-by-id catalog of titles + short ids + categories", () => {
+  test("renders a recall-by-id catalog of titles + recall-ready ids + categories", () => {
     const out = buildKnowledgeCatalogText(
       [
         toc("019aaaaa", "Auth flow", "architecture"),
@@ -120,8 +123,8 @@ describe("buildKnowledgeCatalogText — frozen system[1] catalog (#917 A)", () =
       15,
     );
     expect(out).toContain("## Project knowledge (recall by id for detail)");
-    expect(out).toContain("* [019aaaaa] Auth flow (architecture)");
-    expect(out).toContain("* [019bbbbb] DB gotcha (gotcha)");
+    expect(out).toContain(`* [k:${id("019aaaaa")}] Auth flow (architecture)`);
+    expect(out).toContain(`* [k:${id("019bbbbb")}] DB gotcha (gotcha)`);
   });
 
   test("empty input → empty string (keeps system[1] absent — no array-grow cache bust)", () => {
@@ -146,5 +149,56 @@ describe("buildKnowledgeCatalogText — frozen system[1] catalog (#917 A)", () =
     );
     // First listed first even though its id sorts later — order is the caller's.
     expect(out.indexOf("First")).toBeLessThan(out.indexOf("Second"));
+  });
+});
+
+// The whole point of the ToC is recall-on-demand: the rendered id MUST be
+// resolvable by the recall tool. recallById is exact-match, so this round-trip
+// guards against regressing to a non-resolvable short id (the #930 review B1).
+describe("ToC ids are recall-resolvable (#917 round-trip)", () => {
+  const RTPROJ = "/test/overflow-toc-roundtrip";
+  const RECALL_ID_RE = /\[(k:[0-9a-f-]+)\]/;
+
+  test("catalog (A) id renders the exact token recallById resolves", () => {
+    const realId = ltm.create({
+      projectPath: RTPROJ,
+      category: "gotcha",
+      title: "Round-trip catalog entry",
+      content: "Body content that recall should surface in full.",
+      scope: "project",
+      crossProject: false,
+    });
+    const out = buildKnowledgeCatalogText(
+      [{ id: realId, category: "gotcha", title: "Round-trip catalog entry" }],
+      15,
+    );
+    const token = out.match(RECALL_ID_RE)?.[1];
+    expect(token).toBe(`k:${realId}`);
+    const detail = recallById(token as string);
+    expect(detail).not.toMatch(/No entry found/);
+    expect(detail).toContain("Round-trip catalog entry");
+  });
+
+  test("overflow (B) id renders the exact token recallById resolves", () => {
+    const realId = ltm.create({
+      projectPath: RTPROJ,
+      category: "pattern",
+      title: "Round-trip overflow entry",
+      content: "Overflow body content that recall should surface in full.",
+      scope: "project",
+      crossProject: false,
+    });
+    const msg = buildKnowledgeDeltaMessage(
+      [changed("019aaaaa", "A changed entry")],
+      [],
+      [{ id: realId, category: "pattern", title: "Round-trip overflow entry" }],
+    );
+    const token = text(msg).match(RECALL_ID_RE)?.[1];
+    // The changed-entry section uses an 8-char correlation handle; ensure we
+    // matched the overflow ToC's full recall id, not that.
+    expect(token).toBe(`k:${realId}`);
+    const detail = recallById(token as string);
+    expect(detail).not.toMatch(/No entry found/);
+    expect(detail).toContain("Round-trip overflow entry");
   });
 });


### PR DESCRIPTION
Closes #917.

Knowledge entries that are relevance-scored but don't fit the injection budget are dropped silently (`forSession` Pass 2 `continue`), and the delta's "Additional Changed Knowledge" overflow only covers *changed* entries. So entries that exist but rank below the cut are **invisible** — the agent can't `recall` what it doesn't know exists. This surfaces them as a compact **recall-by-id ToC**, extending the existing entities partial-list pattern (`pipeline.ts` entities block) to knowledge.

Per discussion on #917 — shipping **A + B, no flag** (always on).

## A — turn-1 catalog floor (frozen system[1])

`buildKnowledgeCatalogText()` renders a confidence-ranked, capped (`STABLE_KNOWLEDGE_TOC_MAX=15`) project-knowledge catalog (`forProject(path, false)`, preferences excluded), folded into the frozen system[1] baseline next to the entities block. Present from turn 1 (before system[2]/any delta exists), byte-stable for the session's life, conservative visibility (project-owned only).

## B — relevance overflow (frozen knowledge delta)

- `forSession()` gains an opt-in `overflowSink?: KnowledgeEntry[]` option: it pushes the relevance-scored entries that didn't fit the budget (`allScored − result`), in deterministic score order. **Return type is unchanged** (`KnowledgeEntry[]`), so all ~33 existing call sites are untouched.
- The two system[2] call sites (normal + layer-4) capture the sink and thread it through `pendingKnowledgeDelta.overflow` → `appendKnowledgePromptDelta` → `buildKnowledgeDeltaMessage`, which renders `## Other relevant knowledge (recall by id for detail)` (`OVERFLOW_TOC_MAX=12`).
- **Cache-safe by construction:** B rides the *existing* durable-delta freeze cadence — a delta is only built on material change and replayed byte-identically thereafter (`applySessionPromptDeltas`, #747). The overflow is id-sorted (not relevance-order) and excludes ids already shown/superseded, so it adds **zero new cache-bust events**; the frozen delta is just slightly larger. The early-return guard is unchanged, so overflow **never** triggers a delta on its own.

## Why recall-by-id is actionable

The `recall` tool already accepts an `id` param (`k:`/`xk:` prefixes, `recall.ts:60`); recall.ts:422 uses the same "use recall with id parameter" pattern for truncated results.

## Tests

- **forSession overflow sink** (`ltm.test.ts`): selected/overflow disjoint, overflow ⊆ seeded, deterministic order across runs. (red→green proven)
- **buildKnowledgeDeltaMessage overflow** (`knowledge-delta-overflow.test.ts`, 6): heading + id/category render, id-sort byte-stability, cap + remainder, dedup vs changed/removed, **never-alone cadence** (overflow without material change → `null`), back-compat (no arg → no section). (red→green: 4 failed before render)
- **buildKnowledgeCatalogText** (4): render, empty→`""`, cap + remainder, caller-order preservation. **Mutation-checked** (forced `return ""` → 3 fail → restored byte-identical).
- Typecheck clean (core + gateway). Cache-stability e2e (14) and delta/prompt-delta regression (72) unchanged. Affected unit suite green 3× (no flake).

## Coverage gaps / follow-ups (called out for the reviewer)

1. **No end-to-end test of the wiring.** Both A→system[1] and B→delta wiring are low-logic data-passing, unit-covered at both ends + typechecked + no e2e regression. A dedicated e2e for B needs overflow forcing, which the gateway test harness can't express today (`budget` option exposes only `maxLayer0Tokens`, not `budget.ltm`). Recommend adding a harness `budget.ltm` knob + a B-overflow e2e as a fast-follow.
2. **Value eval deferred to #916.** Whether the agent *actually recalls* a ToC'd title is an empirical question requiring a **live LLM** run (real API spend) and a seeded N≫budget scenario. This belongs with the planned from-scratch eval rerun (#916), not this correctness PR. If the agent ignores the ToC there, we revisit.

## Adversarial review

Requesting a READ-ONLY adversarial correctness review before merge (per project policy), with particular scrutiny on the B wiring across the 4 `pendingKnowledgeDelta` sites and the cache-stability invariants.
