### PR TITLE
feat(core): sync knowledge_meta as a convergent PN-counter register (A2 3b-2)

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1409,7 +1409,6 @@ const MIGRATIONS: string[] = [
   -- migrate() by KNOWLEDGE_META_MIGRATION_INDEX — the same pattern VACUUM uses.
   -- This string is intentionally a no-op marker so MIGRATIONS.length still counts.
   `,
-
   `
 
   -- Version 56: reference-validity validator (#627 Phase 0). Two additions:
@@ -1531,7 +1530,6 @@ const MIGRATIONS: string[] = [
   -- dropped/empty rollup) and reuse the canonical rebuild query in tests/recovery.
   -- This string is intentionally a no-op marker so MIGRATIONS.length still counts.
   `,
-
   `
   -- Version 61: persist the per-session cache-warmup COST bucket separately.
   -- session_state already stores warmup_savings / warmup_hits, but the warmup
@@ -1565,6 +1563,30 @@ const MIGRATIONS: string[] = [
   );
   CREATE INDEX IF NOT EXISTS idx_knowledge_contradictions_status
     ON knowledge_contradictions (status);
+  `,
+
+  `
+  -- Version 63: make knowledge_meta.confidence a CONVERGENT register (A2 sub-PR
+  -- 3b-2, #823). confidence becomes a materialized cache derived from a PN-counter
+  -- CRDT: per-replica grow-only positive/negative delta accumulators, summed onto
+  -- an immutable per-entry base. This lets two devices' independent reinforce/decay
+  -- both survive a merge (max per replica counter) instead of last-writer-wins
+  -- clobbering the whole value. base_confidence is the create-time value the deltas
+  -- accumulate relative to (backfilled from the current confidence).
+  ALTER TABLE knowledge_meta ADD COLUMN base_confidence REAL NOT NULL DEFAULT 1.0;
+  UPDATE knowledge_meta SET base_confidence = confidence;
+  -- Grow-only counters keyed by (logical_id, replica_id). value(entry) =
+  -- clamp(base_confidence + SUM(pos) - SUM(neg), 0, 1), clamped at materialize time.
+  -- Merge across devices is per-key max(pos)/max(neg) — a join-semilattice, so it is
+  -- commutative/associative/idempotent and a stale lower counter never lowers value.
+  CREATE TABLE IF NOT EXISTS knowledge_meta_crdt (
+    logical_id  TEXT NOT NULL,
+    replica_id  TEXT NOT NULL,
+    pos         REAL NOT NULL DEFAULT 0,
+    neg         REAL NOT NULL DEFAULT 0,
+    updated_at  INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (logical_id, replica_id)
+  );
   `,
 ];
 
@@ -2202,6 +2224,44 @@ function installSyncCapture(database: Database) {
       INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
       VALUES ('knowledge_entity_refs', old.knowledge_id || char(31) || old.entity_id, 'delete', ${ts});
     END;`;
+  // A2 sub-PR 3b-2: knowledge_meta base register, keyed by logical_id. Only the
+  // IMMUTABLE base_confidence syncs, so the UPDATE trigger fires ONLY when it
+  // actually changes — the frequent per-op confidence re-materialization (which
+  // only writes the local-derived confidence/updated_at) must NOT churn the outbox.
+  // No DELETE (a register row outlives the knowledge entry's death-cert).
+  sql += `
+    CREATE TEMP TRIGGER IF NOT EXISTS knowledge_meta_outbox_ins
+    AFTER INSERT ON knowledge_meta WHEN (${gate})
+    BEGIN
+      INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
+      VALUES ('knowledge_meta', new.logical_id, 'upsert', ${ts});
+    END;
+    CREATE TEMP TRIGGER IF NOT EXISTS knowledge_meta_outbox_upd
+    AFTER UPDATE ON knowledge_meta
+    WHEN ((${gate}) AND new.base_confidence IS NOT old.base_confidence)
+    BEGIN
+      INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
+      VALUES ('knowledge_meta', new.logical_id, 'upsert', ${ts});
+    END;`;
+  // A2 sub-PR 3b-2: knowledge_meta_crdt grow-only counters, composite key
+  // (logical_id || US || replica_id). Single-owner per (logical_id, replica_id):
+  // local applyConfidenceDelta only ever writes THIS device's replica row, and
+  // pulled peer rows arrive under apply-suppression — so the outbox only carries
+  // this device's counters. INSERT + UPDATE (pos/neg grow); no DELETE.
+  sql += `
+    CREATE TEMP TRIGGER IF NOT EXISTS knowledge_meta_crdt_outbox_ins
+    AFTER INSERT ON knowledge_meta_crdt WHEN (${gate})
+    BEGIN
+      INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
+      VALUES ('knowledge_meta_crdt', new.logical_id || char(31) || new.replica_id, 'upsert', ${ts});
+    END;
+    CREATE TEMP TRIGGER IF NOT EXISTS knowledge_meta_crdt_outbox_upd
+    AFTER UPDATE ON knowledge_meta_crdt
+    WHEN (${gate} AND (new.pos > old.pos OR new.neg > old.neg))
+    BEGIN
+      INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
+      VALUES ('knowledge_meta_crdt', new.logical_id || char(31) || new.replica_id, 'upsert', ${ts});
+    END;`;
   database.exec(sql);
 }
 
@@ -2594,6 +2654,29 @@ function recoverMissingObjects(database: Database) {
       if (hasMessages || hasDistill) rebuildAllSessionRollups(database);
     }
   }
+  // Version 63: knowledge_meta CRDT register (A2 sub-PR 3b-2). Recover the
+  // base_confidence column (backfilled from the materialized confidence) and the
+  // grow-only counter table independently of the forward migration.
+  {
+    const mcols = database
+      .query("PRAGMA table_info(knowledge_meta)")
+      .all() as Array<{ name: string }>;
+    if (!mcols.some((c) => c.name === "base_confidence")) {
+      database.exec(
+        "ALTER TABLE knowledge_meta ADD COLUMN base_confidence REAL NOT NULL DEFAULT 1.0;",
+      );
+      database.exec("UPDATE knowledge_meta SET base_confidence = confidence;");
+    }
+    database.exec(`CREATE TABLE IF NOT EXISTS knowledge_meta_crdt (
+      logical_id  TEXT NOT NULL,
+      replica_id  TEXT NOT NULL,
+      pos         REAL NOT NULL DEFAULT 0,
+      neg         REAL NOT NULL DEFAULT 0,
+      updated_at  INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (logical_id, replica_id)
+    );`);
+  }
+
   // Version 36: session project binding. Recover each column independently in
   // case a partial ALTER (e.g. the first succeeded, the second was skipped on a
   // prior failure) left the table missing a column.

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -160,16 +160,88 @@ function insertMeta(
   lastReinforcedAt: number | null,
   now: number,
 ): void {
+  // A2 3b-2: `base_confidence` is the create-time value the PN-counter deltas
+  // accumulate relative to (immutable after create). A fresh entry has no deltas,
+  // so its materialized `confidence` equals the base.
   db()
     .query(
-      `INSERT INTO knowledge_meta (logical_id, confidence, last_reinforced_at, updated_at)
-       VALUES (?, ?, ?, ?)
+      `INSERT INTO knowledge_meta (logical_id, confidence, base_confidence, last_reinforced_at, updated_at)
+       VALUES (?, ?, ?, ?, ?)
        ON CONFLICT(logical_id) DO UPDATE SET
          confidence = excluded.confidence,
          last_reinforced_at = excluded.last_reinforced_at,
          updated_at = excluded.updated_at`,
     )
-    .run(logicalId, confidence, lastReinforcedAt, now);
+    .run(logicalId, confidence, confidence, lastReinforcedAt, now);
+}
+
+// ── A2 sub-PR 3b-2: confidence is a convergent PN-counter register ────────────
+// `knowledge_meta.confidence` is a MATERIALIZED cache, never written directly by
+// the lifecycle ops. Each op records a signed delta into THIS replica's grow-only
+// (pos,neg) accumulators in `knowledge_meta_crdt`, then re-materializes
+// `confidence = clamp(base_confidence + Σpos − Σneg, 0, 1)`. Merge across devices
+// is per-(logical_id,replica_id) max — so two devices' independent reinforce/decay
+// both survive. Clamp is applied ONLY at materialize time: counters may accumulate
+// past [0,1], producing intentional boundary hysteresis (a long-reinforced entry
+// resists a single penalty) — the accepted cost of a faithful additive CRDT.
+
+/** Stable per-device replica id (UUIDv7), minted once into KV. Not cached: the
+ *  test suite swaps the DB between cases, so always read it from the live DB. */
+function replicaId(): string {
+  let id = getKV("sync.replica_id");
+  if (!id) {
+    id = uuidv7();
+    setKV("sync.replica_id", id);
+  }
+  return id;
+}
+
+/** Re-derive the materialized `confidence` cache for a logical entry from its
+ *  immutable base plus the summed PN-counters. Clamp is HERE (read time) only.
+ *  Exported so the sync apply path (3b-2b) can re-materialize after merging a
+ *  pulled base / peer counter into the register. Idempotent; no-op if the entry
+ *  has no knowledge_meta row yet. */
+export function rematerializeConfidence(logicalId: string, now: number): void {
+  db()
+    .query(
+      `UPDATE knowledge_meta
+         SET confidence = MAX(0.0, MIN(1.0,
+               base_confidence
+               + COALESCE((SELECT SUM(pos) FROM knowledge_meta_crdt WHERE logical_id = ?), 0)
+               - COALESCE((SELECT SUM(neg) FROM knowledge_meta_crdt WHERE logical_id = ?), 0))),
+             updated_at = ?
+       WHERE logical_id = ?`,
+    )
+    .run(logicalId, logicalId, now, logicalId);
+}
+
+/** Record a signed confidence delta on the LOCAL replica's grow-only counters,
+ *  then re-materialize. Positive → pos, negative → neg (a faithful PN-counter). */
+function applyConfidenceDelta(
+  logicalId: string,
+  delta: number,
+  now: number,
+): void {
+  if (delta === 0) return;
+  const pos = delta > 0 ? delta : 0;
+  const neg = delta < 0 ? -delta : 0;
+  db()
+    .query(
+      `INSERT INTO knowledge_meta_crdt (logical_id, replica_id, pos, neg, updated_at)
+       VALUES (?, ?, ?, ?, ?)
+       ON CONFLICT(logical_id, replica_id) DO UPDATE SET
+         pos = pos + excluded.pos, neg = neg + excluded.neg, updated_at = excluded.updated_at`,
+    )
+    .run(logicalId, replicaId(), pos, neg, now);
+  rematerializeConfidence(logicalId, now);
+}
+
+/** Current materialized confidence of a logical entry (default 1.0 if no row). */
+function currentConfidence(logicalId: string): number {
+  const row = db()
+    .query("SELECT confidence FROM knowledge_meta WHERE logical_id = ?")
+    .get(logicalId) as { confidence: number } | undefined;
+  return row?.confidence ?? 1.0;
 }
 
 export function create(input: {
@@ -534,22 +606,19 @@ export function update(
     .run(...(params as [string, ...string[]]));
 
   // Metric register (A2 3b): any update is a re-confirmation → reset the decay
-  // clock so a freshly-touched entry never ages out (v48). Bump the register's
-  // sync clock (updated_at) ONLY when the synced metric (confidence) actually
-  // changed — a content-only edit must not churn metric sync. Clamp confidence to
-  // [0,1] (an out-of-range LLM value would over-weight scoring or silently delete).
-  const metaSets: string[] = ["last_reinforced_at = ?"];
-  const metaParams: unknown[] = [now];
-  if (input.confidence !== undefined) {
-    metaSets.push("confidence = ?", "updated_at = ?");
-    metaParams.push(Math.max(0, Math.min(1, input.confidence)), now);
-  }
-  metaParams.push(logicalId);
+  // clock so a freshly-touched entry never ages out (v48). last_reinforced_at is
+  // local (does NOT bump the register's sync clock on its own).
   db()
     .query(
-      `UPDATE knowledge_meta SET ${metaSets.join(", ")} WHERE logical_id = ?`,
+      "UPDATE knowledge_meta SET last_reinforced_at = ? WHERE logical_id = ?",
     )
-    .run(...(metaParams as [unknown, ...unknown[]]));
+    .run(now, logicalId);
+  // A confidence "set" (A2 3b-2) becomes a delta to the target on the local replica
+  // (clamped to [0,1]); applyConfidenceDelta re-materializes + bumps updated_at.
+  if (input.confidence !== undefined) {
+    const target = Math.max(0, Math.min(1, input.confidence));
+    applyConfidenceDelta(logicalId, target - currentConfidence(logicalId), now);
+  }
 
   // Re-embed the new current version only when a content change was appended.
   if (embedding.isAvailable() && appended) {
@@ -1110,16 +1179,16 @@ export function markInjected(ids: string[]): void {
  * reward (#497: test/build pass → boost).
  */
 export function reinforce(id: string, delta: number = REINFORCE_STEP): void {
-  // Metric register (A2 3b): a confidence change bumps the register's sync clock.
-  // `id` may be any version id — resolve to the stable logical_id.
+  // A2 3b-2: record the delta on the local replica's PN-counter (re-materializes
+  // confidence). `id` may be any version id — resolve to the stable logical_id.
   const now = Date.now();
+  const logicalId = logicalIdOf(id);
+  applyConfidenceDelta(logicalId, delta, now);
   db()
     .query(
-      `UPDATE knowledge_meta
-       SET confidence = MAX(0, MIN(1, confidence + ?)), last_reinforced_at = ?, updated_at = ?
-       WHERE logical_id = (SELECT logical_id FROM knowledge WHERE id = ?)`,
+      "UPDATE knowledge_meta SET last_reinforced_at = ? WHERE logical_id = ?",
     )
-    .run(delta, now, now, id);
+    .run(now, logicalId);
 }
 
 /**
@@ -1137,13 +1206,12 @@ export function penalizeStaleReferences(
   logicalId: string,
   delta: number = REFERENCE_DRIFT_PENALTY,
 ): void {
-  db()
-    .query(
-      `UPDATE knowledge_meta
-       SET confidence = MAX(0, confidence - ?), updated_at = ?
-       WHERE logical_id = ?`,
-    )
-    .run(delta, Date.now(), logicalId);
+  // confidence is a materialized cache over the PN-counter register (A2 3b-2):
+  // a direct `UPDATE knowledge_meta SET confidence = …` would be WIPED by the next
+  // rematerializeConfidence (any reinforce/decay/credit/update/prune). Record the
+  // penalty as a signed delta on this replica's counter so it is durable AND
+  // converges across devices — mirrors decayProject / creditSessionOutcome.
+  applyConfidenceDelta(logicalId, -delta, Date.now());
 }
 
 /** Outcome of a reference-validity pass over one project. */
@@ -1478,40 +1546,45 @@ export function creditSessionOutcome(
     // cross_project = 0 guard is a real backstop (a PROMOTED entry keeps its
     // origin project_id but has cross_project = 1 — it must never be adjusted);
     // is_deleted = 0 skips death-certificate versions.
-    // Confidence lives on the register (A2 3b); the eligibility filters
+    // Confidence is a PN-counter register (A2 3b-2): record a per-entry delta on
+    // the local replica, then re-materialize. The eligibility filters
     // (is_current/is_deleted/cross_project/project_id) are knowledge-row facts, so
-    // gate via a knowledge_current subquery (it already pins is_current=1 AND
-    // is_deleted=0 and exposes confidence via the JOIN). A confidence change bumps
-    // the register's sync clock (updated_at).
-    if (verdict === "pass") {
+    // gate via knowledge_current (pins is_current=1 AND is_deleted=0, exposes the
+    // materialized confidence). cross_project = 0 is a real backstop (a PROMOTED
+    // entry keeps its origin project_id but has cross_project = 1 — never adjust it).
+    // PASS additionally only rescues under-confident entries (confidence <
+    // OUTCOME_BOOST_CEILING) and the delta is capped so the boost never lifts an
+    // entry above that ceiling — preserved by computing min(REWARD, CEILING−conf)
+    // per entry. FAIL drives down by OUTCOME_PENALTY (materialize clamps at 0).
+    const eligible = (
+      verdict === "pass"
+        ? db()
+            .query(
+              `SELECT logical_id, confidence FROM knowledge_current
+                WHERE cross_project = 0 AND project_id = ? AND confidence < ?
+                  AND logical_id IN (${placeholders})`,
+            )
+            .all(pid, OUTCOME_BOOST_CEILING, ...ids)
+        : db()
+            .query(
+              `SELECT logical_id, confidence FROM knowledge_current
+                WHERE cross_project = 0 AND project_id = ?
+                  AND logical_id IN (${placeholders})`,
+            )
+            .all(pid, ...ids)
+    ) as { logical_id: string; confidence: number }[];
+    for (const e of eligible) {
+      const delta =
+        verdict === "pass"
+          ? Math.min(OUTCOME_REWARD, OUTCOME_BOOST_CEILING - e.confidence)
+          : -OUTCOME_PENALTY;
+      applyConfidenceDelta(e.logical_id, delta, now);
+      // Both verdicts reset the decay clock (the entry was demonstrably in use).
       db()
         .query(
-          `UPDATE knowledge_meta
-           SET confidence = MIN(?, confidence + ?), last_reinforced_at = ?, updated_at = ?
-           WHERE logical_id IN (
-             SELECT logical_id FROM knowledge_current
-              WHERE cross_project = 0 AND project_id = ? AND confidence < ?
-                AND logical_id IN (${placeholders}))`,
+          "UPDATE knowledge_meta SET last_reinforced_at = ? WHERE logical_id = ?",
         )
-        .run(
-          OUTCOME_BOOST_CEILING,
-          OUTCOME_REWARD,
-          now,
-          now,
-          pid,
-          OUTCOME_BOOST_CEILING,
-          ...ids,
-        );
-    } else {
-      db()
-        .query(
-          `UPDATE knowledge_meta
-           SET confidence = MAX(0, confidence - ?), last_reinforced_at = ?, updated_at = ?
-           WHERE logical_id IN (
-             SELECT logical_id FROM knowledge_current
-              WHERE cross_project = 0 AND project_id = ? AND logical_id IN (${placeholders}))`,
-        )
-        .run(OUTCOME_PENALTY, now, now, pid, ...ids);
+        .run(now, e.logical_id);
     }
 
     // Mark this session's injections credited (so a later idle tick is a no-op)
@@ -1620,28 +1693,26 @@ export function decayProject(
   // (<= floor) are invisible everywhere and reaped by pruneDeadEntries; matching
   // them here would re-apply a no-op MAX(0, …) and inflate the returned/logged
   // count with rows whose confidence didn't actually change. (Seer review.)
-  // Confidence is a register field (A2 3b); the eligibility facts (project_id,
-  // cross_project, confidence floor, grace window) come from knowledge_current
-  // (which pins is_current=1 and exposes confidence/last_reinforced_at via the
-  // JOIN; `updated_at` here is the content row's, NOT the register's, so the bump
-  // below can't feed back into the grace check). Decay does NOT reset
-  // last_reinforced_at; it bumps the register's sync clock (updated_at).
-  const res = db()
+  // Confidence is a PN-counter register (A2 3b-2): record a −DECAY_STEP delta per
+  // eligible entry on the local replica, then re-materialize. The eligibility facts
+  // (project_id, cross_project, confidence floor, grace window) come from
+  // knowledge_current (pins is_current=1, exposes the materialized confidence +
+  // last_reinforced_at; `updated_at` here is the CONTENT row's, NOT the register's,
+  // so the bump can't feed back into the grace check). Decay does NOT reset
+  // last_reinforced_at.
+  const eligible = db()
     .query(
-      `UPDATE knowledge_meta
-       SET confidence = MAX(0, confidence - ?), updated_at = ?
-       WHERE logical_id IN (
-         SELECT logical_id FROM knowledge_current
-          WHERE project_id = ? AND cross_project = 0 AND confidence > ?
-            AND COALESCE(last_reinforced_at, updated_at) < ?)`,
+      `SELECT logical_id FROM knowledge_current
+        WHERE project_id = ? AND cross_project = 0 AND confidence > ?
+          AND COALESCE(last_reinforced_at, updated_at) < ?`,
     )
-    .run(DECAY_STEP, now, pid, DEAD_CONFIDENCE_FLOOR, cutoff) as {
-    changes?: number | bigint;
-  };
+    .all(pid, DEAD_CONFIDENCE_FLOOR, cutoff) as { logical_id: string }[];
+  for (const e of eligible)
+    applyConfidenceDelta(e.logical_id, -DECAY_STEP, now);
   db()
     .query("UPDATE projects SET last_decay_at = ? WHERE id = ?")
     .run(now, pid);
-  return Number(res.changes ?? 0);
+  return eligible.length;
 }
 
 /**
@@ -2715,18 +2786,35 @@ export function getWorkerSource(
  * @returns Number of entries pruned
  */
 export function pruneOversized(maxLength: number): number {
-  // confidence is a register field (A2 3b); the size filter is a knowledge-row
-  // fact, so gate via knowledge_current (current+live, exposes content+confidence).
-  const result = db()
+  // confidence is a PN-counter register (A2 3b-2); the size filter is a
+  // knowledge-row fact, so gate via knowledge_current (current+live, exposes
+  // content + materialized confidence). Drive each oversized entry to 0 with a
+  // delta of −(its RAW unclamped confidence) on the local replica, so that
+  // CRDT hysteresis doesn't prevent full zeroing.
+  const now = Date.now();
+  // INNER JOIN knowledge_meta is DELIBERATE (not the reads' LEFT JOIN + COALESCE):
+  // pruning drives the raw counter to 0 via applyConfidenceDelta, which UPDATEs
+  // knowledge_meta WHERE logical_id — a meta-less row has nothing to write, so
+  // rematerializeConfidence would no-op and the entry would read 1.0 forever while
+  // being counted as "pruned". Only rows with a register row can actually be zeroed,
+  // so we select exactly those. The A2 3b invariant (every current entry has a
+  // register row — create/pull-mint/recover all uphold it) makes this lossless.
+  const oversized = db()
     .query(
-      `UPDATE knowledge_meta SET confidence = 0, updated_at = ?
-        WHERE logical_id IN (
-          SELECT logical_id FROM knowledge_current
-           WHERE LENGTH(content) > ? AND confidence > 0)`,
+      `SELECT k.logical_id,
+              m.base_confidence
+              + COALESCE((SELECT SUM(pos) FROM knowledge_meta_crdt WHERE logical_id = k.logical_id), 0)
+              - COALESCE((SELECT SUM(neg) FROM knowledge_meta_crdt WHERE logical_id = k.logical_id), 0)
+              AS raw_confidence
+         FROM knowledge k
+         JOIN knowledge_meta m ON m.logical_id = k.logical_id
+         WHERE k.is_current = 1 AND k.is_deleted = 0
+           AND LENGTH(k.content) > ? AND m.confidence > 0`,
     )
-    .run(Date.now(), maxLength);
-  // node:sqlite returns `changes` as `number | bigint`; coerce for cross-runtime parity.
-  return Number(result.changes);
+    .all(maxLength) as { logical_id: string; raw_confidence: number }[];
+  for (const e of oversized)
+    applyConfidenceDelta(e.logical_id, -e.raw_confidence, now);
+  return oversized.length;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/sync-data.ts
+++ b/packages/core/src/sync-data.ts
@@ -27,6 +27,7 @@ import {
   withSyncApplying,
   withTransaction,
 } from "./db";
+import { rematerializeConfidence } from "./ltm";
 
 /**
  * Run `fn` with this connection's sync capture suppressed (re-entrant,
@@ -125,6 +126,39 @@ export const SYNCED_TABLES: Record<SyncTier, SyncTableMeta[]> = {
         "created_at",
         "updated_at",
       ],
+    },
+    {
+      // A2 sub-PR 3b-2 (#823): the per-entry metric register, keyed by the stable
+      // logical_id. Only the IMMUTABLE base_confidence syncs (set once at create;
+      // the materialized `confidence` is local-derived from base + the CRDT counters,
+      // and last_reinforced_at is a local decay clock — neither is in syncColumns).
+      // hash-LWW (versioned) is safe because base is immutable AFTER create: the
+      // only divergence is a one-time seam where two devices backfill base from
+      // their own pre-sync LWW confidence (v63 migration) — hash-LWW picks one
+      // winner and, since the CRDT counters MAX-merge independently, both sides
+      // still CONVERGE. Applied via applyRemoteMeta (upsert base + re-materialize).
+      // (No created_at: the local knowledge_meta table has none — syncedColumns()
+      // would silently drop it; listing it only mis-leads remote migration 0009.)
+      table: "knowledge_meta",
+      idColumns: ["logical_id"],
+      ftsTables: [],
+      syncColumns: ["logical_id", "base_confidence", "updated_at"],
+    },
+    {
+      // A2 sub-PR 3b-2: the convergent PN-counter state. Grow-only per
+      // (logical_id, replica_id); each row is SINGLE-OWNER (a device only ever
+      // increments its OWN replica's counter via applyConfidenceDelta, and pulled
+      // peer rows arrive under apply-suppression) — so the remote overwrite-upsert
+      // is monotonic and the outbox only ever carries this device's rows. Merge on
+      // the PULL side is per-key max (applyRemoteMetaCrdt), a join-semilattice.
+      // versioned:false: no content_hash/revision remotely (the local sync_state
+      // still hashes pos/neg to skip no-op pushes). Always-applied on pull (max-
+      // merge is idempotent/monotonic — never a "conflict").
+      table: "knowledge_meta_crdt",
+      idColumns: ["logical_id", "replica_id"],
+      ftsTables: [],
+      versioned: false,
+      syncColumns: ["logical_id", "replica_id", "pos", "neg"],
     },
     {
       table: "entities",
@@ -744,6 +778,61 @@ export function applyRemoteDelete(table: string, rowId: string): void {
   );
 }
 
+/**
+ * Apply a pulled `knowledge_meta` base row (A2 sub-PR 3b-2). Upserts the IMMUTABLE
+ * `base_confidence` (the only synced field) keyed by `logical_id`, then re-
+ * materializes the local `confidence` cache from base + the PN-counters. The
+ * materialized `confidence` and the local `last_reinforced_at` decay clock are
+ * local-derived/local-only and are NEVER overwritten by the pull. Runs under
+ * apply-suppression (the base write is not re-pushed). A NEW row seeds
+ * `confidence = base`; re-materialize then folds in any counters already present.
+ */
+export function applyRemoteMeta(row: Record<string, unknown>): void {
+  const logicalId = String(row.logical_id);
+  const base = Number(row.base_confidence ?? 1.0);
+  withApplying(() => {
+    db()
+      .query(
+        `INSERT INTO knowledge_meta (logical_id, base_confidence, confidence, updated_at)
+         VALUES (?, ?, ?, ?)
+         ON CONFLICT(logical_id) DO UPDATE SET base_confidence = excluded.base_confidence`,
+      )
+      .run(logicalId, base, base, Number(row.updated_at ?? 0));
+    rematerializeConfidence(logicalId, Date.now());
+  });
+}
+
+/**
+ * Apply a pulled `knowledge_meta_crdt` counter row (A2 sub-PR 3b-2) via per-key
+ * MAX merge (a grow-only join-semilattice), then re-materialize the entry's
+ * confidence. ALWAYS safe to apply — idempotent and monotonic: a stale lower
+ * counter never lowers the local value — so the engine applies it unconditionally
+ * (no hash classify). Runs under apply-suppression so the merged PEER counter is
+ * not re-pushed (this device only ever pushes its OWN replica's rows).
+ */
+export function applyRemoteMetaCrdt(row: Record<string, unknown>): void {
+  const logicalId = String(row.logical_id);
+  withApplying(() => {
+    db()
+      .query(
+        `INSERT INTO knowledge_meta_crdt (logical_id, replica_id, pos, neg, updated_at)
+         VALUES (?, ?, ?, ?, ?)
+         ON CONFLICT(logical_id, replica_id) DO UPDATE SET
+           pos = MAX(pos, excluded.pos),
+           neg = MAX(neg, excluded.neg),
+           updated_at = MAX(updated_at, excluded.updated_at)`,
+      )
+      .run(
+        logicalId,
+        String(row.replica_id),
+        Number(row.pos ?? 0),
+        Number(row.neg ?? 0),
+        Number(row.updated_at ?? 0),
+      );
+    rematerializeConfidence(logicalId, Number(row.updated_at ?? 0));
+  });
+}
+
 /** Insert one knowledge version row from a synced-column source `src`. */
 function insertKnowledgeVersion(
   src: Record<string, unknown>,
@@ -767,14 +856,42 @@ function insertKnowledgeVersion(
   // knowledge_meta register row, so subsequent local reinforce/decay/update —
   // which UPDATE knowledge_meta WHERE logical_id=… — affect a row instead of
   // silently no-op'ing. INSERT OR IGNORE never clobbers an existing (possibly
-  // converged) confidence on re-pull/version-append. confidence is NOT a synced
-  // knowledge column in 3b-1, so a pulled entry defaults to 1.0 here until the
-  // register itself syncs (3b-2). updated_at=0 marks it as never-locally-changed.
+  // converged) register on re-pull/version-append.
+  const hadMeta =
+    db()
+      .query("SELECT 1 FROM knowledge_meta WHERE logical_id = ?")
+      .get(ident.logicalId) != null;
+  // Seed last_reinforced_at to NOW (a local first-appearance touch), NOT NULL:
+  // decayProject grace-checks COALESCE(last_reinforced_at, k.updated_at), and a
+  // just-pulled entry's k.updated_at is the AUTHOR's (possibly old) content clock —
+  // NULL would make it instantly decay-eligible on this device, and since decay now
+  // records a CRDT counter, that local decay would sync back and spuriously lower the
+  // entry for every replica. last_reinforced_at is local-only (not a syncColumn), so
+  // this does not affect the placeholder base-guard hash below. updated_at stays 0
+  // (the register's sync clock) until the real base arrives via applyRemoteMeta.
   db()
     .query(
-      "INSERT OR IGNORE INTO knowledge_meta (logical_id, confidence, last_reinforced_at, updated_at) VALUES (?, 1.0, NULL, 0)",
+      "INSERT OR IGNORE INTO knowledge_meta (logical_id, confidence, last_reinforced_at, updated_at) VALUES (?, 1.0, ?, 0)",
     )
-    .run(ident.logicalId);
+    .run(ident.logicalId, Date.now());
+  if (!hadMeta) {
+    // The real base_confidence is whatever the entry's AUTHOR set; it only reaches
+    // this device once knowledge_meta itself syncs (a separate per-table cursor, so
+    // it can lag the knowledge pull arbitrarily). The 1.0 minted just above is a
+    // PLACEHOLDER this device did NOT author. Record its sync_state so a later
+    // disable→enable's seedOutbox treats it as already-in-sync and NEVER pushes the
+    // fabricated default — which would otherwise overwrite the author's real base on
+    // the (scope_id, logical_id)-keyed remote and permanently clobber it for every
+    // replica (base is immutable, so no one re-corrects it). When the real base
+    // arrives, applyRemoteMeta overwrites it and re-records sync_state from it.
+    const minted = getRowById("knowledge_meta", ident.logicalId);
+    if (minted)
+      setSyncState("knowledge_meta", ident.logicalId, {
+        content_hash: contentHash("knowledge_meta", minted),
+        revision: 0,
+        remote_updated_at: "",
+      });
+  }
 }
 
 /**

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -59,7 +59,7 @@ describe("db", () => {
     const row = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(row.version).toBe(62);
+    expect(row.version).toBe(63);
   });
 
   test("v55: confidence/last_reinforced_at moved to knowledge_meta, exposed via view", () => {
@@ -116,7 +116,7 @@ describe("db", () => {
     const ver = fresh.query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(ver.version).toBe(62);
+    expect(ver.version).toBe(63);
     // Register + JOIN view were rebuilt and are queryable (confidence exposed).
     expect(
       fresh

--- a/packages/core/test/ltm-confidence-crdt.test.ts
+++ b/packages/core/test/ltm-confidence-crdt.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { db, ensureProject, getKV } from "../src/db";
+import * as ltm from "../src/ltm";
+
+// A2 sub-PR 3b-2a: confidence is a materialized cache over a per-replica PN-counter
+// CRDT. These tests pin the LOCAL mechanics (3b-2b adds the remote sync/merge):
+//   value = clamp(base_confidence + Σpos − Σneg, 0, 1)  [clamp only at read]
+//   each lifecycle op records a signed delta on THIS replica's grow-only counters.
+const PROJECT = "/test/a2/conf-crdt";
+
+const meta = (logicalId: string) =>
+  db()
+    .query(
+      "SELECT confidence, base_confidence FROM knowledge_meta WHERE logical_id = ?",
+    )
+    .get(logicalId) as { confidence: number; base_confidence: number };
+
+const crdtRows = (logicalId: string) =>
+  db()
+    .query(
+      "SELECT replica_id, pos, neg FROM knowledge_meta_crdt WHERE logical_id = ? ORDER BY replica_id",
+    )
+    .all(logicalId) as Array<{ replica_id: string; pos: number; neg: number }>;
+
+const mk = (title: string, confidence = 1.0) =>
+  ltm.create({
+    projectPath: PROJECT,
+    scope: "project",
+    category: "decision",
+    title,
+    content: `body ${title}`,
+    confidence,
+  });
+
+describe("A2 3b-2a: confidence PN-counter register", () => {
+  beforeEach(() => {
+    const pid = ensureProject(PROJECT);
+    db().query("DELETE FROM knowledge WHERE project_id = ?").run(pid);
+    db().query("DELETE FROM knowledge_meta").run();
+    db().query("DELETE FROM knowledge_meta_crdt").run();
+  });
+
+  test("create() sets base = confidence and records NO counters", () => {
+    const id = mk("Created", 0.8);
+    const m = meta(id);
+    expect(m.base_confidence).toBeCloseTo(0.8, 6);
+    expect(m.confidence).toBeCloseTo(0.8, 6);
+    expect(crdtRows(id)).toHaveLength(0);
+  });
+
+  test("reinforce records a positive delta on the local replica and re-materializes", () => {
+    const id = mk("Reinforced", 0.5);
+    ltm.reinforce(id, 0.05);
+    const rows = crdtRows(id);
+    expect(rows).toHaveLength(1); // exactly one (local) replica
+    expect(rows[0].pos).toBeCloseTo(0.05, 6);
+    expect(rows[0].neg).toBe(0);
+    expect(meta(id).confidence).toBeCloseTo(0.55, 6); // base 0.5 + 0.05
+  });
+
+  test("a negative delta accumulates into neg; interior values match step-clamping", () => {
+    const id = mk("Decayed", 0.5);
+    ltm.reinforce(id, -0.1); // negative delta = a decrement
+    const rows = crdtRows(id);
+    expect(rows[0].neg).toBeCloseTo(0.1, 6);
+    expect(meta(id).confidence).toBeCloseTo(0.4, 6);
+  });
+
+  test("clamp is applied only at read — value floors at 0, counters keep the overshoot", () => {
+    const id = mk("Floored", 0.3);
+    ltm.reinforce(id, -0.5); // unclamped 0.3 − 0.5 = −0.2
+    expect(meta(id).confidence).toBe(0); // clamped at read
+    expect(crdtRows(id)[0].neg).toBeCloseTo(0.5, 6); // full overshoot retained
+  });
+
+  test("ACCEPTED hysteresis: excess banked past the ceiling absorbs a later decrement", () => {
+    const banked = mk("Banked", 1.0); // base 1.0
+    ltm.reinforce(banked, 0.2); // unclamped 1.2 → reads 1.0, banks +0.2
+    expect(meta(banked).confidence).toBe(1.0);
+    ltm.reinforce(banked, -0.1); // unclamped 1.1 → STILL reads 1.0 (hysteresis)
+    expect(meta(banked).confidence).toBe(1.0);
+
+    // Contrast: an un-banked entry at the ceiling drops immediately.
+    const plain = mk("Plain", 1.0);
+    ltm.reinforce(plain, -0.1);
+    expect(meta(plain).confidence).toBeCloseTo(0.9, 6);
+  });
+
+  test("all local ops share ONE stable replica_id (KV-backed)", () => {
+    const a = mk("A", 0.5);
+    const b = mk("B", 0.5);
+    ltm.reinforce(a, 0.05);
+    ltm.reinforce(b, 0.05);
+    const rid = getKV("sync.replica_id");
+    expect(rid).toBeTruthy();
+    expect(crdtRows(a)[0].replica_id).toBe(rid);
+    expect(crdtRows(b)[0].replica_id).toBe(rid);
+  });
+
+  test("materialization SUMS across replicas (the convergent core of the CRDT)", () => {
+    const id = mk("Converged", 0.5);
+    ltm.reinforce(id, 0.05); // local replica pos = 0.05
+    // Simulate a counter pulled from a second device (3b-2b merge installs these).
+    db()
+      .query(
+        "INSERT INTO knowledge_meta_crdt (logical_id, replica_id, pos, neg, updated_at) VALUES (?, 'replica-B', 0.2, 0, 0)",
+      )
+      .run(id);
+    // Any subsequent local op re-materializes over ALL replicas' counters.
+    ltm.reinforce(id, 0.05); // local pos now 0.10
+    // base 0.5 + (local 0.10 + B 0.20) = 0.80
+    expect(meta(id).confidence).toBeCloseTo(0.8, 6);
+    expect(crdtRows(id)).toHaveLength(2);
+  });
+
+  test("update(confidence) sets the value via a delta-to-target on the local replica", () => {
+    const id = mk("Set", 1.0); // base 1.0
+    ltm.update(id, { confidence: 0.4 });
+    expect(meta(id).confidence).toBeCloseTo(0.4, 6);
+    // delta = 0.4 − 1.0 = −0.6 recorded as neg.
+    expect(crdtRows(id)[0].neg).toBeCloseTo(0.6, 6);
+  });
+
+  test("ACCEPTED hysteresis: update(confidence) on a BANKED entry lands above target, converges on a 2nd pass", () => {
+    const id = mk("BankedSet", 1.0); // base 1.0
+    ltm.reinforce(id, 0.2); // banks +0.2 (reads 1.0)
+    ltm.update(id, { confidence: 0.4 }); // delta = 0.4 − read(1.0) = −0.6 → neg 0.6
+    // clamp(1.0 + 0.2 − 0.6) = 0.6: the banked +0.2 absorbs part of the cut, so the
+    // value lands ABOVE the requested 0.4 — the accepted cost of a faithful additive
+    // CRDT (counters clamp only at read), NOT a per-step clamp. A re-apply converges.
+    expect(meta(id).confidence).toBeCloseTo(0.6, 6);
+    ltm.update(id, { confidence: 0.4 }); // delta = 0.4 − read(0.6) = −0.2 → neg 0.8
+    expect(meta(id).confidence).toBeCloseTo(0.4, 6); // now exact
+  });
+
+  test("penalizeStaleReferences records a DURABLE counter delta (survives re-materialization)", () => {
+    const id = mk("Stale", 0.8); // base 0.8
+    ltm.penalizeStaleReferences(id, 0.1);
+    expect(meta(id).confidence).toBeCloseTo(0.7, 6);
+    // The penalty must be a neg COUNTER, not a direct confidence write — a direct
+    // `UPDATE knowledge_meta SET confidence` (the pre-CRDT #627 code) records no row.
+    const rows = crdtRows(id);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].neg).toBeCloseTo(0.1, 6);
+    // A later re-materialization (triggered by ANY subsequent confidence op) recomputes
+    // confidence = base + Σpos − Σneg. The penalty must PERSIST — a direct write would
+    // have been wiped back to base 0.8 here (the exact rebase-integration bug).
+    ltm.rematerializeConfidence(id, Date.now());
+    expect(meta(id).confidence).toBeCloseTo(0.7, 6);
+  });
+
+  test("pruneOversized drives confidence to 0 via a delta of −(current)", () => {
+    const id = mk("Oversized", 0.7);
+    db()
+      .query("UPDATE knowledge SET content = ? WHERE logical_id = ?")
+      .run("x".repeat(5000), id);
+    const pruned = ltm.pruneOversized(1000);
+    expect(pruned).toBe(1);
+    expect(meta(id).confidence).toBe(0);
+  });
+
+  test("pruneOversized zeroes a BANKED entry using RAW (not clamped) confidence", () => {
+    // Discriminates the hysteresis fix: a delta of −(clamped read) would leave the
+    // banked overshoot behind. base 1.0 + banked +0.5 → raw 1.5, reads 1.0.
+    const id = mk("BankedOversized", 1.0);
+    ltm.reinforce(id, 0.5); // unclamped 1.5 → reads 1.0, banks +0.5
+    expect(meta(id).confidence).toBe(1.0);
+    db()
+      .query("UPDATE knowledge SET content = ? WHERE logical_id = ?")
+      .run("x".repeat(5000), id);
+
+    const pruned = ltm.pruneOversized(1000);
+    expect(pruned).toBe(1);
+    // −(clamped 1.0) would leave raw 0.5 (reads 0.5); only −(raw 1.5) reaches 0.
+    expect(meta(id).confidence).toBe(0);
+    const rows = crdtRows(id);
+    // The prune's negative delta must fully cancel the +0.5 pos bank: raw = 0.
+    const raw =
+      meta(id).base_confidence + rows.reduce((s, r) => s + r.pos - r.neg, 0);
+    expect(raw).toBeCloseTo(0, 6);
+  });
+});

--- a/packages/core/test/ltm-versioning.test.ts
+++ b/packages/core/test/ltm-versioning.test.ts
@@ -39,11 +39,11 @@ function ftsHits(token: string): number {
 }
 
 describe("A2 sub-PR 1: append-only knowledge scaffolding", () => {
-  test("schema version is 62", () => {
+  test("schema version is 63", () => {
     const v = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(v.version).toBe(62);
+    expect(v.version).toBe(63);
   });
 
   test("create() defaults logical_id = id, version 1, current, not deleted", () => {
@@ -87,7 +87,9 @@ describe("A2 sub-PR 1: append-only knowledge scaffolding", () => {
 
     const v = versions(id);
     expect(v).toHaveLength(2); // append-only: both physically present
+    // biome-ignore lint/style/noNonNullAssertion: known-safe after toHaveLength(2) check above
     const v1 = v.find((x) => x.version === 1)!;
+    // biome-ignore lint/style/noNonNullAssertion: known-safe after toHaveLength(2) check above
     const v2 = v.find((x) => x.version === 2)!;
     expect(v1.is_current).toBe(0); // demoted
     expect(v2.is_current).toBe(1);

--- a/packages/core/test/sync-data.test.ts
+++ b/packages/core/test/sync-data.test.ts
@@ -11,6 +11,8 @@ import {
   applyRemoteDelete,
   applyRemoteKnowledge,
   applyRemoteKnowledgeDelete,
+  applyRemoteMeta,
+  applyRemoteMetaCrdt,
   applyRemoteUpsert,
   assertSyncInvariants,
   classifyRemoteRow,
@@ -1012,5 +1014,154 @@ describe("mutation gap coverage (#832)", () => {
     expect(isSyncEnabled()).toBe(false);
     enableSync();
     expect(isSyncEnabled()).toBe(true);
+  });
+});
+
+describe("applyRemoteMeta / applyRemoteMetaCrdt — convergent confidence (A2 3b-2b)", () => {
+  const PROJ = "/tmp/lore-meta-sync";
+  const mk = (confidence: number): string =>
+    ltm.create({
+      projectPath: PROJ,
+      scope: "project",
+      category: "decision",
+      title: `T-${Math.random()}`,
+      content: "body",
+      confidence,
+    });
+  const conf = (logicalId: string): number =>
+    (
+      db()
+        .query("SELECT confidence FROM knowledge_meta WHERE logical_id = ?")
+        .get(logicalId) as { confidence: number }
+    ).confidence;
+  const base = (logicalId: string): number =>
+    (
+      db()
+        .query(
+          "SELECT base_confidence FROM knowledge_meta WHERE logical_id = ?",
+        )
+        .get(logicalId) as { base_confidence: number }
+    ).base_confidence;
+  const crdtCount = (logicalId: string, replicaId: string): number =>
+    (
+      db()
+        .query(
+          "SELECT COUNT(*) n FROM knowledge_meta_crdt WHERE logical_id = ? AND replica_id = ?",
+        )
+        .get(logicalId, replicaId) as { n: number }
+    ).n;
+
+  beforeEach(() => {
+    const pid = ensureProject(PROJ);
+    db().query("DELETE FROM knowledge WHERE project_id = ?").run(pid);
+    db().query("DELETE FROM knowledge_meta").run();
+    db().query("DELETE FROM knowledge_meta_crdt").run();
+  });
+
+  test("applyRemoteMeta upserts the immutable base and re-materializes confidence", () => {
+    const id = mk(1.0); // local base 1.0
+    applyRemoteMeta({ logical_id: id, base_confidence: 0.7, updated_at: 1 });
+    expect(base(id)).toBeCloseTo(0.7, 6);
+    expect(conf(id)).toBeCloseTo(0.7, 6); // clamp(0.7 + 0 − 0)
+  });
+
+  test("applyRemoteMeta does NOT overwrite the local materialized confidence/decay clock", () => {
+    const id = mk(0.5);
+    ltm.reinforce(id, 0.1); // local counter pos=0.1 → conf 0.6
+    // A re-pulled base (same value) must not clobber the locally-accumulated value.
+    applyRemoteMeta({ logical_id: id, base_confidence: 0.5, updated_at: 2 });
+    expect(conf(id)).toBeCloseTo(0.6, 6); // base 0.5 + local 0.1, NOT reset to base
+  });
+
+  test("applyRemoteMetaCrdt max-merges a peer counter and converges (A reinforce + B decay)", () => {
+    const id = mk(0.5); // base 0.5
+    ltm.reinforce(id, 0.1); // local replica pos=0.1 → 0.6
+    applyRemoteMetaCrdt({ logical_id: id, replica_id: "B", pos: 0, neg: 0.2 });
+    // clamp(0.5 + 0.1(local) − 0.2(B)) = 0.4 — both devices' deltas survive.
+    expect(conf(id)).toBeCloseTo(0.4, 6);
+  });
+
+  test("stale lower counter never lowers the value (per-key MAX)", () => {
+    const id = mk(0.5);
+    applyRemoteMetaCrdt({ logical_id: id, replica_id: "B", pos: 0.3, neg: 0 });
+    expect(conf(id)).toBeCloseTo(0.8, 6);
+    // A stale re-delivery of B with a LOWER pos must be absorbed by MAX → no change.
+    applyRemoteMetaCrdt({ logical_id: id, replica_id: "B", pos: 0.1, neg: 0 });
+    expect(conf(id)).toBeCloseTo(0.8, 6);
+  });
+
+  test("re-pulling the same counter is idempotent (one row, value unchanged)", () => {
+    const id = mk(0.5);
+    applyRemoteMetaCrdt({ logical_id: id, replica_id: "B", pos: 0.2, neg: 0 });
+    applyRemoteMetaCrdt({ logical_id: id, replica_id: "B", pos: 0.2, neg: 0 });
+    expect(conf(id)).toBeCloseTo(0.7, 6);
+    expect(crdtCount(id, "B")).toBe(1);
+  });
+
+  test("three replicas' independent deltas all sum into the converged value", () => {
+    const id = mk(0.5);
+    ltm.reinforce(id, 0.1); // local
+    applyRemoteMetaCrdt({ logical_id: id, replica_id: "B", pos: 0.2, neg: 0 });
+    applyRemoteMetaCrdt({ logical_id: id, replica_id: "C", pos: 0, neg: 0.05 });
+    // clamp(0.5 + 0.1 + 0.2 − 0.05) = clamp(0.75) = 0.75
+    expect(conf(id)).toBeCloseTo(0.75, 6);
+  });
+
+  test("a pull-minted register's placeholder base is NEVER pushed on (re-)enable — no peer-base clobber", () => {
+    setTeamConfig("sync.enabled", "1");
+    const pid = ensureProject(PROJ);
+    // Pull a brand-new entry authored on ANOTHER device: only the knowledge content
+    // lands here; knowledge_meta syncs on its own (laggable) cursor — so this mints a
+    // PLACEHOLDER register row at the default base 1.0 (the real base is unknown yet).
+    applyRemoteKnowledge({
+      id: "kpeer",
+      title: "peer entry",
+      content: "peer body",
+      category: "decision",
+      project_id: pid,
+      created_at: 1,
+      updated_at: 1,
+    });
+    expect(base("kpeer")).toBeCloseTo(1.0, 6); // fabricated placeholder
+
+    // A later disable→enable re-seeds the outbox from all existing rows.
+    seedOutbox("basic");
+    // The placeholder must NOT be enqueued: pushing the fabricated 1.0 would overwrite
+    // the author's REAL base on the (scope_id, logical_id)-keyed remote and permanently
+    // clobber it for every replica (base is immutable → no one re-corrects it). The
+    // mint records sync_state so seedOutbox sees it as already-in-sync.
+    const pushed = readOutbox(0).filter(
+      (e) => e.table_name === "knowledge_meta" && e.row_id === "kpeer",
+    );
+    expect(pushed).toHaveLength(0);
+  });
+
+  test("a pull-minted register seeds last_reinforced_at to NOW (not NULL) — no premature decay", () => {
+    const pid = ensureProject(PROJ);
+    const before = Date.now();
+    // Pull an entry authored long ago on another device (old content clock).
+    applyRemoteKnowledge({
+      id: "kold",
+      title: "old peer entry",
+      content: "old body",
+      category: "decision",
+      project_id: pid,
+      created_at: 1,
+      updated_at: 1, // author's ancient content clock
+    });
+    // The minted register's decay clock must be a local first-appearance touch, NOT
+    // NULL: decayProject grace-checks COALESCE(last_reinforced_at, k.updated_at), and
+    // NULL would fall back to updated_at=1 (1970) → instantly decay-eligible → a local
+    // decay that (now being a CRDT counter) would sync back and spuriously lower the
+    // entry for every replica.
+    const lra = (
+      db()
+        .query(
+          "SELECT last_reinforced_at FROM knowledge_meta WHERE logical_id = ?",
+        )
+        .get("kold") as { last_reinforced_at: number | null }
+    ).last_reinforced_at;
+    expect(lra).not.toBeNull();
+    expect(lra as number).toBeGreaterThanOrEqual(before);
   });
 });

--- a/packages/gateway/src/sync.ts
+++ b/packages/gateway/src/sync.ts
@@ -460,6 +460,27 @@ function applyRemote(
   touchedFts: Set<string>,
 ): void {
   const rowId = syncData.rowIdOf(meta.table, remote);
+
+  // A2 sub-PR 3b-2: the CRDT counter table is a grow-only join-semilattice — its
+  // per-key MAX merge is idempotent + monotonic, so a remote row is ALWAYS safe to
+  // apply (a stale lower counter never lowers the local value). Apply unconditionally
+  // (no hash classify, never a skip/conflict). Track sync_state from the MERGED LOCAL
+  // row so the push side sees the post-merge value as in-sync and never re-pushes a
+  // peer's counter (this device only pushes its OWN replica's rows).
+  if (meta.table === "knowledge_meta_crdt") {
+    syncData.applyRemoteMetaCrdt(stripSyncCols(remote));
+    const localRow = syncData.getRowById(meta.table, rowId);
+    syncData.setSyncState(meta.table, rowId, {
+      content_hash: localRow
+        ? syncData.contentHash(meta.table, localRow)
+        : null,
+      revision: 0,
+      remote_updated_at: String(remote.updated_at ?? ""),
+    });
+    res.pulled++;
+    return;
+  }
+
   const isDeleted = remote.is_deleted === true || remote.is_deleted === 1;
   // classifyRemoteRow's contract: "remoteHash is null for a tombstone". A delete
   // has no content to compare, so a tombstone is NEVER a content-match "skip".
@@ -527,6 +548,10 @@ function applyRemote(
     // never an in-place upsert of an immutable version (A2, #823).
     if (meta.table === "knowledge") {
       syncData.applyRemoteKnowledge(stripSyncCols(remote));
+    } else if (meta.table === "knowledge_meta") {
+      // A2 3b-2: upsert the immutable base_confidence + re-materialize confidence
+      // (the materialized value & local decay clock are never overwritten by pull).
+      syncData.applyRemoteMeta(stripSyncCols(remote));
     } else {
       syncData.applyRemoteUpsert(meta.table, stripSyncCols(remote));
     }

--- a/packages/gateway/test/sync.property.test.ts
+++ b/packages/gateway/test/sync.property.test.ts
@@ -188,6 +188,13 @@ function resetAll(): void {
   db().exec("DELETE FROM temp._sync_applying");
   db().exec("DELETE FROM knowledge_entity_refs");
   db().exec("DELETE FROM knowledge");
+  // The knowledge_meta register + CRDT counters (A2 3b-2) are synced tables but are
+  // NOT cascade-deleted by the hard `DELETE FROM knowledge` (no FK CASCADE). A
+  // pulled entry mints a register row (insertKnowledgeVersion), so without clearing
+  // them an orphan row survives resetAll, gets re-seeded at a low outbox seq, and
+  // transiently pins the prune floor below this run's knowledge entries.
+  db().exec("DELETE FROM knowledge_meta");
+  db().exec("DELETE FROM knowledge_meta_crdt");
   db().exec("DELETE FROM entities");
   db().exec("DELETE FROM profiles");
   db().exec("DELETE FROM sync_outbox");
@@ -325,23 +332,31 @@ describe("sync engine — property/sequence tests (#833)", () => {
     );
   });
 
-  test("the outbox fully drains after a push (the prune floor never wedges)", async () => {
+  test("the outbox fully drains after repeated pushes (the prune floor never wedges)", async () => {
     await fc.assert(
       fc.asyncProperty(seqArb, async (ops) => {
         resetAll();
         syncData.enableSync("basic");
         for (const op of ops) await apply(op);
-        await pushOnce(client());
-        // pushOnce prunes seq <= min push cursor across tables-with-entries. Only
-        // `knowledge` is ever mutated here, so after a (mock: always-succeeds)
-        // push, EVERY entry is fully pushed and pruned -> the outbox is empty.
-        // A wedged prune floor (e.g. min cursor pinned at 0 by an empty/pull-only
-        // table — the #828 bug) would leave pushed entries stranded here.
-        const remaining = (
-          db().query("SELECT COUNT(*) AS n FROM sync_outbox").get() as {
-            n: number;
-          }
-        ).n;
+        // pushOnce prunes seq <= the MIN push cursor across tables-with-entries
+        // (the #828 safety floor). When several synced tables interleave in the
+        // global outbox seq — e.g. a knowledge entry AND its knowledge_meta register
+        // row (minted on pull, re-seeded on enable, A2 3b-2) — a single push prunes
+        // only up to the lowest cursor; the higher-seq entries of another table are
+        // PUSHED but reclaimed on a later pass. So full draining is EVENTUAL, not
+        // single-shot. A real wedge (#828: a cursor permanently pinned at 0 by an
+        // empty/pull-only table) would never drain no matter how many passes.
+        let remaining = Number.POSITIVE_INFINITY;
+        const maxPasses = syncData.syncedTables("basic").length + 1;
+        for (let pass = 0; pass < maxPasses; pass++) {
+          await pushOnce(client());
+          remaining = (
+            db().query("SELECT COUNT(*) AS n FROM sync_outbox").get() as {
+              n: number;
+            }
+          ).n;
+          if (remaining === 0) break;
+        }
         expect(remaining).toBe(0);
       }),
       { numRuns: 60 },

--- a/packages/gateway/test/sync.test.ts
+++ b/packages/gateway/test/sync.test.ts
@@ -291,6 +291,13 @@ beforeEach(() => {
   deleteTeamConfig("sync.enabled");
   db().exec("DELETE FROM temp._sync_applying");
   db().exec("DELETE FROM knowledge");
+  // The knowledge_meta register + CRDT counters are now synced tables (A2 3b-2)
+  // and are NOT cascade-deleted by the hard `DELETE FROM knowledge` above (no FK
+  // CASCADE; production deletes via append-only death-certs, not a hard delete).
+  // Clear them too so orphaned register rows don't accumulate across tests and get
+  // re-seeded into the outbox by enableSync.
+  db().exec("DELETE FROM knowledge_meta");
+  db().exec("DELETE FROM knowledge_meta_crdt");
   db().exec("DELETE FROM entities");
   db().exec("DELETE FROM profiles");
   db().exec("DELETE FROM sync_outbox");
@@ -971,5 +978,56 @@ describe("syncOnce", () => {
     // Echo-pull of our own row is a no-op (hash matches) — pulled stays 0.
     expect(r.pulled).toBe(0);
     expect(tableRows("knowledge").find((x) => x.id === "k1")).toBeTruthy();
+  });
+});
+
+describe("knowledge_meta register sync (A2 3b-2)", () => {
+  test("pushOnce uploads the base register row AND the CRDT counters", async () => {
+    syncData.enableSync("basic");
+    // Capture triggers fire on these local writes (sync enabled) → outbox.
+    db()
+      .query(
+        "INSERT INTO knowledge_meta (logical_id, confidence, base_confidence, updated_at) VALUES ('k1', 0.6, 0.6, ?)",
+      )
+      .run(now());
+    db()
+      .query(
+        "INSERT INTO knowledge_meta_crdt (logical_id, replica_id, pos, neg, updated_at) VALUES ('k1', 'rA', 0.1, 0, ?)",
+      )
+      .run(now());
+    await pushOnce(makeClient() as never);
+    // Base: the IMMUTABLE base_confidence is uploaded (NOT the local-derived confidence).
+    const baseRow = tableRows("knowledge_meta").find(
+      (x) => x.logical_id === "k1",
+    );
+    expect(baseRow?.base_confidence).toBeCloseTo(0.6, 6);
+    expect("confidence" in (baseRow ?? {})).toBe(false); // local-derived, never synced
+    // Counters: the local replica's grow-only row is uploaded.
+    const crdtRow = tableRows("knowledge_meta_crdt").find(
+      (x) => x.logical_id === "k1" && x.replica_id === "rA",
+    );
+    expect(crdtRow?.pos).toBeCloseTo(0.1, 6);
+    expect(crdtRow?.neg).toBe(0);
+  });
+
+  test("the per-op confidence re-materialization does NOT churn the base outbox", () => {
+    syncData.enableSync("basic");
+    db()
+      .query(
+        "INSERT INTO knowledge_meta (logical_id, confidence, base_confidence, updated_at) VALUES ('k1', 0.6, 0.6, ?)",
+      )
+      .run(now());
+    db().exec("DELETE FROM sync_outbox"); // ignore the INSERT capture
+    // A materialization-style write (confidence/updated_at only, base unchanged)
+    // must NOT enqueue a knowledge_meta push (the UPDATE trigger is base-gated).
+    db()
+      .query(
+        "UPDATE knowledge_meta SET confidence = 0.55, updated_at = ? WHERE logical_id = 'k1'",
+      )
+      .run(now() + 1);
+    expect(
+      syncData.readOutbox(0).filter((e) => e.table_name === "knowledge_meta")
+        .length,
+    ).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

Makes knowledge `confidence` **converge across devices** instead of last-writer-wins, and wires the **local** sync plumbing for it. Part of the A2 immutable-knowledge epic (#823).

> Scope: this is the **local half**. The remote Supabase migration (RLS + quota for the two new tables) and its dedicated **security review** land in a stacked follow-up. Cross-device sync is not armed until then.

## Changes

**3b-2a — local CRDT mechanics**
- `confidence` becomes a per-`(logical_id, replica_id)` **PN-counter**: every lifecycle op (`create`/`reinforce`/`update`/`decay`/`outcome`/`prune`/`penalizeStaleReferences`) records a *signed delta* on **this device's own** grow-only `(pos, neg)` accumulators.
- Materialized `confidence = clamp(base_confidence + Σpos − Σneg, 0, 1)`, clamped **only at read**. `base_confidence` is immutable (set once at create).
- `v63` migration adds `base_confidence` + the `knowledge_meta_crdt` table.

**3b-2b — local sync wiring**
- `knowledge_meta` (immutable base, hash-LWW) and `knowledge_meta_crdt` (grow-only, `versioned:false`) become synced tables.
- Pull merge is **per-key MAX** over the counters (a join-semilattice) — applied unconditionally (idempotent/monotonic, never a conflict). Base is upserted **without** overwriting the local materialized value or decay clock.
- **Single-owner counters**: a device only ever pushes its *own* replica's rows; pulled peer rows arrive under apply-suppression and are never re-pushed.
- The `knowledge_meta` capture trigger is **base-gated** and the `knowledge_meta_crdt` UPDATE trigger is **growth-gated** (`pos>old.pos OR neg>old.neg`), so the frequent per-op re-materialization of `confidence` and no-op MAX-merges never churn the outbox.

## Review

Passed two adversarial correctness reviews (initial + final pre-merge), no blockers. Fixes folded in:
- **base_confidence immutability**: `insertMeta` ON CONFLICT no longer overwrites the immutable base on an explicit-id re-create.
- **`pruneOversized` hysteresis**: drives the **raw** (unclamped) confidence to 0, so a banked overshoot past the ceiling can't survive a prune. Now covered by a **mutation-verified discriminating test**.
- **`applyRemoteMetaCrdt`** uses the remote row's `updated_at`, not `Date.now()`.
- A pull-minted register row no longer pushes its **placeholder default base**. Regression test added.
- Dropped the non-existent `created_at` from `knowledge_meta` `syncColumns`.

**Rebase-integration fixes** (caught by Sentry after rebasing onto `main`, which had landed #627 reference-validity on the old confidence-on-`knowledge_meta` model):
- **`penalizeStaleReferences`** wrote `confidence` directly → would be **wiped by the next re-materialization**. Rewired through `applyConfidenceDelta` (durable + convergent), like `decayProject`. Mutation-verified regression test added.
- **Pull-mint decay clock**: a freshly-pulled register seeds `last_reinforced_at` to *now* (a local first-appearance touch), not `NULL` — otherwise `decayProject`'s `COALESCE(last_reinforced_at, k.updated_at)` fell back to the author's ancient content clock and made the entry instantly decay-eligible (which, now that decay is a CRDT counter, would sync back and spuriously lower it for every replica). Regression test added.
- **`pruneOversized` INNER JOIN** documented as deliberate (a LEFT JOIN would inflate the prune count with meta-less rows it can't actually zero).

## Verification

- typecheck 0 (all packages); Biome lint 0 errors
- full monorepo suite green after rebase onto `main` (v62): **253 files, 5143 passed / 32 skipped**
- `sync.property` stable across repeated runs; format clean
