### PR TITLE
fix(gateway): tag the global auth fallback from the upstream URL when header-less (#942)

### DIFF
--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -548,6 +548,69 @@ export function extractProviderHeader(
   return sanitized;
 }
 
+/**
+ * Reverse map: normalized upstream base URL → provider id.
+ *
+ * Built once from PROVIDER_ROUTES at module load. Each route's `url` is run
+ * through `extractUpstreamUrlHeader` so the keys are normalized byte-for-byte
+ * the same way an incoming `x-lore-upstream-url` header is — there is no second
+ * normalization path that could drift. Providers with a `null` url
+ * (local/self-hosted, aggregators the user must configure) are skipped: their
+ * real upstream is user-specific and never matches a static table entry.
+ *
+ * First definition wins on the (currently impossible) chance two routes
+ * normalize to the same base, keeping the mapping deterministic.
+ */
+const UPSTREAM_URL_TO_PROVIDER: ReadonlyMap<string, string> = (() => {
+  const m = new Map<string, string>();
+  for (const [id, route] of Object.entries(PROVIDER_ROUTES)) {
+    if (!route.url) continue;
+    const norm = extractUpstreamUrlHeader({ "x-lore-upstream-url": route.url });
+    if (norm && !m.has(norm)) m.set(norm, id);
+  }
+  return m;
+})();
+
+/**
+ * Derive the provider id from a request's `x-lore-upstream-url` header by
+ * matching the upstream destination against PROVIDER_ROUTES.
+ *
+ * This is the fallback used to tag the global fallback credential (#829/#942)
+ * for credentialed requests that bypass the per-turn `chat.headers` hook and
+ * therefore carry NO `x-lore-provider` header (title/summary generation, etc.).
+ * Tagging by the ACTUAL destination — not a stale "last-seen provider" guess —
+ * is what prevents reintroducing the #829 cross-contamination from the other
+ * direction (e.g. tagging an OpenAI-bound key as `anthropic` because the last
+ * foreground turn was Anthropic).
+ *
+ * Returns `undefined` when the header is absent, malformed, or points at a host
+ * not in the static route table (custom/self-hosted) — in which case the
+ * credential stays untagged, exactly as before.
+ */
+export function providerFromUpstreamUrl(
+  headers: Record<string, string>,
+): string | undefined {
+  const base = extractUpstreamUrlHeader(headers);
+  if (!base) return undefined;
+  return UPSTREAM_URL_TO_PROVIDER.get(base);
+}
+
+/**
+ * Resolve the provider id used to tag the global fallback credential
+ * (`setLastSeenAuth`). The explicit `x-lore-provider` header is authoritative
+ * (the plugin set it deliberately for this turn); only when it is absent or
+ * invalid do we fall back to deriving it from the upstream destination URL.
+ *
+ * Returning `undefined` means "unknown/agnostic" — the credential is served to
+ * any provider lookup, which is load-bearing for legacy single-provider clients
+ * that send neither header.
+ */
+export function resolveLastSeenProvider(
+  headers: Record<string, string>,
+): string | undefined {
+  return extractProviderHeader(headers) ?? providerFromUpstreamUrl(headers);
+}
+
 // ---------------------------------------------------------------------------
 // Project path inference
 // ---------------------------------------------------------------------------

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -553,10 +553,14 @@ export function extractProviderHeader(
  *
  * Built once from PROVIDER_ROUTES at module load. Each route's `url` is run
  * through `extractUpstreamUrlHeader` so the keys are normalized byte-for-byte
- * the same way an incoming `x-lore-upstream-url` header is — there is no second
- * normalization path that could drift. Providers with a `null` url
- * (local/self-hosted, aggregators the user must configure) are skipped: their
- * real upstream is user-specific and never matches a static table entry.
+ * the same way an incoming `x-lore-upstream-url` header is — the normalization
+ * itself cannot drift between the two sides. (The incoming value is the
+ * interceptor-derived `upstreamBase`, which for a provider whose API path lacks
+ * a `/v1/` segment — e.g. google's `/v1beta/openai/...` — does not equal the
+ * route key; that simply yields a lookup miss → `undefined`, i.e. an untagged
+ * credential, never a WRONG tag.) Providers with a `null` url (local/self-
+ * hosted, aggregators the user must configure) are skipped: their real upstream
+ * is user-specific and never matches a static table entry.
  *
  * First definition wins on the (currently impossible) chance two routes
  * normalize to the same base, keeping the mapping deterministic.

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -101,6 +101,7 @@ import {
   resolveUpstreamRoute,
   extractUpstreamUrlHeader,
   extractProviderHeader,
+  resolveLastSeenProvider,
   resolveProviderRoute,
   unattributedBucketPath,
   type ProjectPathResult,
@@ -5588,8 +5589,11 @@ async function handleConversationTurn(
   const cred = extractAuth(req.rawHeaders);
   if (cred) {
     // Tag the global fallback with the request's provider so a worker for a
-    // different provider can't borrow this credential (cross-contamination, #829).
-    setLastSeenAuth(cred, extractProviderHeader(req.rawHeaders) || undefined);
+    // different provider can't borrow this credential (cross-contamination,
+    // #829). Falls back to the upstream destination URL when no x-lore-provider
+    // header is present — e.g. credentialed title/summary-gen requests that
+    // bypass the per-turn chat.headers hook (#942).
+    setLastSeenAuth(cred, resolveLastSeenProvider(req.rawHeaders));
   }
 
   // --- 3. Session identification ---
@@ -8040,13 +8044,12 @@ export async function handleRequest(
       return errorResponse(400, "Malformed request: missing headers");
     }
 
-    // Capture auth credentials early for background workers
+    // Capture auth credentials early for background workers. Tag by the
+    // explicit x-lore-provider header, falling back to the upstream URL for
+    // header-less credentialed requests (#829/#942).
     const earlyAuth = extractAuth(req.rawHeaders);
     if (earlyAuth) {
-      setLastSeenAuth(
-        earlyAuth,
-        extractProviderHeader(req.rawHeaders) || undefined,
-      );
+      setLastSeenAuth(earlyAuth, resolveLastSeenProvider(req.rawHeaders));
     }
 
     // --- Quick Tier-1 session lookup for structural compaction detection ---

--- a/packages/gateway/test/lastseen-provider-tag.e2e.test.ts
+++ b/packages/gateway/test/lastseen-provider-tag.e2e.test.ts
@@ -1,0 +1,92 @@
+/**
+ * End-to-end wiring guard for #942 (follow-up to #829/#940).
+ *
+ * These drive the FULL pipeline (handleRequest → handleConversationTurn →
+ * setLastSeenAuth) over HTTP, then observe the global fallback credential via
+ * getLastSeenAuth(). They pin the BEHAVIOR — not just the pure helper — so a
+ * revert of the two `setLastSeenAuth(..., resolveLastSeenProvider(...))` call
+ * sites back to `extractProviderHeader(...) || undefined` fails here (the
+ * unit tests in upstream-routes.test.ts would still pass on such a revert).
+ *
+ * The credential and the upstream destination are built together by the SDK on
+ * the same outbound request, so deriving the tag from `x-lore-upstream-url`
+ * always names the credential's true owner — closing the null-tag cross-borrow
+ * window without reintroducing the #829 cross-contamination.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import type { Harness } from "./helpers/harness";
+import { createHarness } from "./helpers/harness";
+import {
+  makeConversationFixtures,
+  STANDARD_TOOLS,
+  DEFAULT_MODEL,
+  DEFAULT_SYSTEM,
+} from "./helpers/fixtures";
+import { getLastSeenAuth } from "../src/auth";
+
+function body(userMessage: string): Record<string, unknown> {
+  return {
+    model: DEFAULT_MODEL,
+    max_tokens: 1024,
+    stream: false,
+    system: DEFAULT_SYSTEM,
+    messages: [{ role: "user", content: userMessage }],
+    tools: STANDARD_TOOLS,
+  };
+}
+
+describe("global fallback provider tag derived from upstream URL (#942)", () => {
+  let harness: Harness | undefined;
+
+  afterEach(async () => {
+    await harness?.teardown();
+    harness = undefined;
+  });
+
+  it("tags the global from x-lore-upstream-url when no x-lore-provider header is sent", async () => {
+    harness = await createHarness({
+      fixtures: makeConversationFixtures([
+        { userMessage: "header-less credentialed turn", assistantText: "ok" },
+      ]),
+    });
+
+    // A credentialed request that carries NO x-lore-provider (the shape
+    // produced by title/summary-gen calls bypassing chat.headers), but whose
+    // upstream destination is recognizable.
+    const r = await harness.chat(
+      body("header-less credentialed turn"),
+      "anthropic-key-942",
+      { "x-lore-upstream-url": "https://api.anthropic.com" },
+    );
+    expect(r.status).toBe(200);
+    await r.text();
+
+    // The global is now tagged "anthropic" (derived from the URL) — a worker
+    // for a DIFFERENT provider must NOT be able to borrow it (#829 guard).
+    expect(getLastSeenAuth("openai")).toBeNull();
+    // The credential's OWN provider still resolves it.
+    expect(getLastSeenAuth("anthropic")).toEqual({
+      scheme: "api-key",
+      value: "anthropic-key-942",
+    });
+  });
+
+  it("leaves the global agnostic (legacy) when neither provider nor upstream-url header is present", async () => {
+    harness = await createHarness({
+      fixtures: makeConversationFixtures([
+        { userMessage: "plain legacy turn", assistantText: "ok" },
+      ]),
+    });
+
+    // No x-lore-provider AND no x-lore-upstream-url → null/agnostic tag, which
+    // every provider lookup may borrow. This is the load-bearing single-
+    // provider legacy path the fix must NOT break.
+    const r = await harness.chat(body("plain legacy turn"), "legacy-key-942");
+    expect(r.status).toBe(200);
+    await r.text();
+
+    const cred = { scheme: "api-key", value: "legacy-key-942" };
+    expect(getLastSeenAuth("openai")).toEqual(cred);
+    expect(getLastSeenAuth("anthropic")).toEqual(cred);
+  });
+});

--- a/packages/gateway/test/upstream-routes.test.ts
+++ b/packages/gateway/test/upstream-routes.test.ts
@@ -3,6 +3,8 @@ import {
   resolveUpstreamRoute,
   resolveProviderRoute,
   extractProviderHeader,
+  providerFromUpstreamUrl,
+  resolveLastSeenProvider,
 } from "../src/config";
 
 // ---------------------------------------------------------------------------
@@ -334,5 +336,133 @@ describe("extractProviderHeader", () => {
     expect(extractProviderHeader({ "x-lore-provider": "mini\x00max" })).toBe(
       "minimax",
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// providerFromUpstreamUrl (#942 — derive the provider tag from the actual
+// upstream destination when no x-lore-provider header was sent)
+// ---------------------------------------------------------------------------
+
+describe("providerFromUpstreamUrl", () => {
+  test("maps a known Anthropic upstream base to its provider id", () => {
+    expect(
+      providerFromUpstreamUrl({
+        "x-lore-upstream-url": "https://api.anthropic.com",
+      }),
+    ).toBe("anthropic");
+  });
+
+  test("maps a known OpenAI upstream base to its provider id", () => {
+    expect(
+      providerFromUpstreamUrl({
+        "x-lore-upstream-url": "https://api.openai.com",
+      }),
+    ).toBe("openai");
+  });
+
+  test("matches a path-prefixed upstream base (minimax /anthropic)", () => {
+    expect(
+      providerFromUpstreamUrl({
+        "x-lore-upstream-url": "https://api.minimax.io/anthropic",
+      }),
+    ).toBe("minimax");
+  });
+
+  test("distinguishes providers that share a host by path (minimax vs minimax-cn)", () => {
+    expect(
+      providerFromUpstreamUrl({
+        "x-lore-upstream-url": "https://api.minimaxi.com/anthropic",
+      }),
+    ).toBe("minimax-cn");
+  });
+
+  test("distinguishes opencode vs opencode-go by path prefix", () => {
+    expect(
+      providerFromUpstreamUrl({
+        "x-lore-upstream-url": "https://opencode.ai/zen",
+      }),
+    ).toBe("opencode");
+    expect(
+      providerFromUpstreamUrl({
+        "x-lore-upstream-url": "https://opencode.ai/zen/go",
+      }),
+    ).toBe("opencode-go");
+  });
+
+  test("normalizes a trailing slash before matching", () => {
+    expect(
+      providerFromUpstreamUrl({
+        "x-lore-upstream-url": "https://api.openai.com/",
+      }),
+    ).toBe("openai");
+  });
+
+  test("normalizes a trailing /v1 before matching", () => {
+    expect(
+      providerFromUpstreamUrl({
+        "x-lore-upstream-url": "https://api.anthropic.com/v1",
+      }),
+    ).toBe("anthropic");
+  });
+
+  test("returns undefined for an unrecognized host (custom/self-hosted)", () => {
+    expect(
+      providerFromUpstreamUrl({
+        "x-lore-upstream-url": "https://my-llm.internal.example.com",
+      }),
+    ).toBeUndefined();
+  });
+
+  test("returns undefined when the upstream header is absent", () => {
+    expect(providerFromUpstreamUrl({})).toBeUndefined();
+  });
+
+  test("returns undefined for a malformed upstream url", () => {
+    expect(
+      providerFromUpstreamUrl({ "x-lore-upstream-url": "not a url" }),
+    ).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveLastSeenProvider (#942 — header-wins-over-URL precedence for tagging
+// the global fallback credential)
+// ---------------------------------------------------------------------------
+
+describe("resolveLastSeenProvider", () => {
+  test("prefers the explicit x-lore-provider header over the upstream url", () => {
+    expect(
+      resolveLastSeenProvider({
+        "x-lore-provider": "anthropic",
+        "x-lore-upstream-url": "https://api.openai.com",
+      }),
+    ).toBe("anthropic");
+  });
+
+  test("falls back to the upstream url when no provider header is present", () => {
+    expect(
+      resolveLastSeenProvider({
+        "x-lore-upstream-url": "https://api.openai.com",
+      }),
+    ).toBe("openai");
+  });
+
+  test("falls back to the upstream url when the provider header is invalid", () => {
+    expect(
+      resolveLastSeenProvider({
+        "x-lore-provider": "bad provider!",
+        "x-lore-upstream-url": "https://api.anthropic.com",
+      }),
+    ).toBe("anthropic");
+  });
+
+  test("returns undefined when neither header identifies a provider", () => {
+    expect(resolveLastSeenProvider({})).toBeUndefined();
+    expect(
+      resolveLastSeenProvider({
+        "x-lore-upstream-url": "https://my-llm.internal.example.com",
+      }),
+    ).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
Follow-up to #829 / #940. Closes #942.

Credentialed requests that bypass the per-turn `chat.headers` hook (title/summary generation, etc.) arrive with **no `x-lore-provider` header**, so `setLastSeenAuth` tagged the global fallback credential with a **null** provider. In a genuine multi-provider setup this opens a transient, last-writer-wins window: if such a header-less request is the most-recent writer of the single global slot, a session-less worker for a *different* provider can borrow it via the load-bearing null-tag path.

## Approach (decided over the issue's literal proposal)
The issue proposed setting `x-lore-provider` in the interceptor `getHeaders()` fallback. But `getHeaders()` has **no per-request context** — it would have to emit a *last-seen* provider global, which can **mistag** a bypass request whose true provider differs from the last foreground turn (e.g. an OpenAI `small_model` title-gen tagged `anthropic`). A wrong tag reintroduces #829 cross-contamination from the other direction — strictly worse than a null tag.

Instead, the gateway already receives `x-lore-upstream-url` on **every** intercepted request, and `upstreamBase` matches `PROVIDER_ROUTES[*].url` essentially exactly. So we derive the provider from the **actual destination**:

- `providerFromUpstreamUrl(headers)` — reverse-maps the normalized upstream base URL → provider id (built once from `PROVIDER_ROUTES`; keys normalized through the *same* `extractUpstreamUrlHeader` so there's no drift; `url: null` providers skipped).
- `resolveLastSeenProvider(headers)` — `extractProviderHeader(h) ?? providerFromUpstreamUrl(h)`; the explicit header stays authoritative, URL is the fallback.

Both `setLastSeenAuth` call sites (`handleConversationTurn`, `handleRequest`) now use `resolveLastSeenProvider`.

This is **adapter-agnostic** (fixes opencode, pi, claude-code, codex at once with no plugin-global plumbing) and has **no mistag risk**. Providers with a `null` route url (local/self-hosted, aggregators) stay null-tagged — no worse than today, and that's the load-bearing single-provider legacy case anyway.

## Tests
14 new unit tests in `upstream-routes.test.ts` (written first, confirmed RED → GREEN):
- `providerFromUpstreamUrl`: known hosts, path-prefixed bases (minimax `/anthropic`), host-shared disambiguation (minimax vs minimax-cn, opencode vs opencode-go), trailing `/` and `/v1` normalization, unknown host → undefined, absent/malformed → undefined.
- `resolveLastSeenProvider`: header-wins-over-URL precedence, URL fallback, invalid-header fallback, neither → undefined.

## Verification
- Full suite: 3974 passed | 32 skipped
- Typecheck: clean · Lint (touched files): clean · Build: clean