### PR TITLE
perf(core): index the costs-page assistant-message scan (v56)

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1402,6 +1402,34 @@ const MIGRATIONS: string[] = [
   -- migrate() by KNOWLEDGE_META_MIGRATION_INDEX — the same pattern VACUUM uses.
   -- This string is intentionally a no-op marker so MIGRATIONS.length still counts.
   `,
+
+  `
+  -- Version 56: index the /ui/costs "first assistant message per session" scan.
+  --
+  -- The costs page runs three cross-project bulk aggregates (#561):
+  -- listAllRecentSessions, aggregateTokensBySessionAll and
+  -- aggregateDistillationsBySessionAll. The expensive one is the metadata lookup
+  -- inside aggregateTokensBySessionAll: a subquery that filters role='assistant'
+  -- AND created_at>=? and groups by session_id to find each session's earliest
+  -- assistant message. With only single-column indexes, SQLite full-SCANs
+  -- idx_temporal_session for that subquery (~360ms at ~200K messages).
+  --
+  --   idx_temporal_role_session_created on temporal_messages(role, session_id, created_at)
+  --   turns it into a covering equality seek on role='assistant' that streams the
+  --   GROUP BY in (session_id, created_at) order — measured ~8x faster (~360ms -> ~42ms).
+  --
+  -- Deliberately NOT added: a (created_at, session_id) index for the token-sum,
+  -- distillation and recent-session aggregates. EXPLAIN QUERY PLAN was measured at
+  -- both low and high created_at selectivity (young DB vs years of history) and the
+  -- planner always prefers the session-ordered idx_temporal_session /
+  -- idx_distillation_session scan there: session ordering lets it stream the
+  -- GROUP BY without a temp b-tree, and the token-sum / distillation projections
+  -- (SUM(tokens), call_type, token_count) aren't covered anyway. A (created_at,
+  -- session_id) index would be pure write amplification on the two hottest tables
+  -- with no read benefit, so it is intentionally omitted. (See cost-bulk-queries.test.ts.)
+  CREATE INDEX IF NOT EXISTS idx_temporal_role_session_created
+    ON temporal_messages (role, session_id, created_at);
+  `,
 ];
 
 // Index of the migration whose work is performed by a column-presence-aware JS
@@ -1978,6 +2006,13 @@ function recoverMissingObjects(database: Database) {
   // so a fully-migrated DB self-heals a missing register/view and a partial apply
   // is finished here too.
   applyKnowledgeMetaRegister(database);
+  // Version 56: costs-page metadata-scan index. Self-heal a fully-migrated DB
+  // that spontaneously lost it (re-creation is a no-op when present). Missing it
+  // is latency-only, but recovering it keeps parity with the sibling index blocks.
+  database.exec(`
+    CREATE INDEX IF NOT EXISTS idx_temporal_role_session_created
+      ON temporal_messages(role, session_id, created_at);
+  `);
   // Version 36: session project binding. Recover each column independently in
   // case a partial ALTER (e.g. the first succeeded, the second was skipped on a
   // prior failure) left the table missing a column.

--- a/packages/core/test/cost-bulk-queries.test.ts
+++ b/packages/core/test/cost-bulk-queries.test.ts
@@ -1,0 +1,232 @@
+import { describe, test, expect, beforeAll } from "vitest";
+import { db, ensureProject } from "../src/db";
+import * as temporal from "../src/temporal";
+import * as data from "../src/data";
+
+// The /ui/costs page runs three cross-project bulk aggregates (#561):
+// aggregateTokensBySessionAll, aggregateDistillationsBySessionAll and
+// listAllRecentSessions. The expensive one is the "earliest assistant message
+// per session" lookup inside aggregateTokensBySessionAll: a subquery that
+// filters role='assistant' AND created_at>=? and groups by session_id. With
+// only single-column indexes SQLite full-SCANs idx_temporal_session for it
+// (~360ms at ~200K messages).
+//
+// v56 adds a SINGLE index for exactly that access pattern:
+//   idx_temporal_role_session_created ON temporal_messages(role, session_id, created_at)
+// → a covering equality seek on role='assistant' that streams the GROUP BY in
+// (session_id, created_at) order. Measured ~8x faster on that query.
+//
+// We deliberately do NOT add a (created_at, session_id) index for the token-sum,
+// distillation or recent-session aggregates: EXPLAIN QUERY PLAN (measured at both
+// low and high created_at selectivity) shows the planner always prefers the
+// session-ordered idx_temporal_session / idx_distillation_session scan there, so
+// such an index would be pure write amplification with no read benefit. The
+// "deliberately unindexed" tests below pin that decision so it isn't quietly
+// reverted by a future contributor adding write-amplification-only indexes.
+//
+// The SQL strings asserted in the plan tests are kept byte-identical to the
+// production queries (temporal.ts: aggregateTokensBySessionAll,
+// data.ts: aggregateDistillationsBySessionAll). The correctness tests drive the
+// real exported functions so the path under test cannot silently drift.
+
+const PROJECT = "/test/cost-bulk-queries/project";
+
+// --- verbatim copies of the production SQL (keep in sync) ---------------------
+// temporal.ts aggregateTokensBySessionAll, step 1 (token sums per session)
+const SQL_TOKEN_SUMS = `SELECT session_id, SUM(tokens) as total_tokens
+   FROM temporal_messages
+   WHERE created_at >= ?
+   GROUP BY session_id`;
+// temporal.ts aggregateTokensBySessionAll, step 2 inner subquery (earliest
+// assistant message per session) — the hot path this migration targets.
+const SQL_META_SUBQUERY = `SELECT session_id, MIN(created_at) AS min_at
+   FROM temporal_messages
+   WHERE role = 'assistant' AND created_at >= ?
+   GROUP BY session_id`;
+// temporal.ts aggregateTokensBySessionAll, step 2 full query.
+const SQL_META_FULL = `SELECT t.session_id, t.metadata
+   FROM temporal_messages t
+   JOIN (
+     SELECT session_id, MIN(created_at) AS min_at
+     FROM temporal_messages
+     WHERE role = 'assistant' AND created_at >= ?
+     GROUP BY session_id
+   ) m ON m.session_id = t.session_id AND t.created_at = m.min_at
+   WHERE t.role = 'assistant'
+   GROUP BY t.session_id`;
+// data.ts aggregateDistillationsBySessionAll (full projection: call_type +
+// token_count are NOT covered by any (created_at, session_id) index — this is
+// why such an index is not worth adding).
+const SQL_DISTILL = `SELECT
+     session_id,
+     COUNT(*) as total_calls,
+     SUM(CASE WHEN call_type = 'batch' THEN 1 ELSE 0 END) as batch_calls,
+     SUM(token_count) as total_tokens,
+     SUM(CASE WHEN call_type = 'batch' THEN token_count ELSE 0 END) as batch_tokens
+   FROM distillations
+   WHERE created_at >= ?
+   GROUP BY session_id`;
+
+function explainPlan(sql: string, ...params: unknown[]): string {
+  const rows = db()
+    .query(`EXPLAIN QUERY PLAN ${sql}`)
+    .all(...params) as Array<{ detail: string }>;
+  return rows.map((r) => r.detail).join(" | ");
+}
+
+function listIndexNames(table: string): Set<string> {
+  const rows = db()
+    .query(`SELECT name FROM sqlite_master WHERE type='index' AND tbl_name=?`)
+    .all(table) as Array<{ name: string }>;
+  return new Set(rows.map((r) => r.name));
+}
+
+const SINCE_MS = () => Date.now() - 90 * 86_400_000;
+
+describe("cost-page bulk query indexes (migration v56)", () => {
+  beforeAll(() => {
+    const pid = ensureProject(PROJECT);
+    const insertMsg = db().query(
+      `INSERT INTO temporal_messages
+         (id, project_id, session_id, role, content, tokens, distilled, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, 0, ?)`,
+    );
+    const insertDistill = db().query(
+      `INSERT INTO distillations
+         (id, project_id, session_id, narrative, facts, observations, source_ids,
+          generation, token_count, call_type, created_at, archived)
+       VALUES (?, ?, ?, '', '', ?, '[]', 0, ?, ?, ?, 0)`,
+    );
+    const dayMs = 86_400_000;
+    const now = Date.now();
+    db().exec("BEGIN");
+    try {
+      // 50 sessions, 200 messages each, spread across 60 days. Enough rows for
+      // the optimizer to make realistic index choices once ANALYZE has run.
+      for (let s = 0; s < 50; s++) {
+        const sid = `cqb-sess-${s}`;
+        for (let m = 0; m < 200; m++) {
+          const role = m % 2 === 0 ? "user" : "assistant";
+          insertMsg.run(
+            `${sid}-m${m}`,
+            pid,
+            sid,
+            role,
+            `m-${m}`,
+            100,
+            now - ((s + m) % 60) * dayMs,
+          );
+        }
+        for (let d = 0; d < 5; d++) {
+          insertDistill.run(
+            `${sid}-d${d}`,
+            pid,
+            sid,
+            `obs-${d}`,
+            1000,
+            d % 2 === 0 ? "batch" : "direct",
+            now - ((s + d) % 60) * dayMs,
+          );
+        }
+      }
+      db().exec("COMMIT");
+    } catch (e) {
+      db().exec("ROLLBACK");
+      throw e;
+    }
+    db().exec("ANALYZE");
+  });
+
+  describe("index existence", () => {
+    test("v56 added idx_temporal_role_session_created", () => {
+      expect(
+        listIndexNames("temporal_messages").has(
+          "idx_temporal_role_session_created",
+        ),
+      ).toBe(true);
+    });
+
+    test("no (created_at, session_id) write-amplification index was added", () => {
+      // Guards the deliberate decision documented in migration v56: these
+      // indexes were measured to be unused by every costs-page query, so they
+      // must NOT exist. If a future migration adds one, prove its value first.
+      expect(
+        listIndexNames("temporal_messages").has("idx_temporal_created_session"),
+      ).toBe(false);
+      expect(
+        listIndexNames("distillations").has("idx_distillation_created_session"),
+      ).toBe(false);
+    });
+  });
+
+  describe("query plan selection", () => {
+    test("metadata subquery uses idx_temporal_role_session_created as a covering seek", () => {
+      // The hot subquery: role='assistant' equality seek covering the GROUP BY
+      // and MIN(created_at). Must use the new index, NOT a full role scan of
+      // idx_temporal_session. Dropping the index flips both assertions red.
+      const plan = explainPlan(SQL_META_SUBQUERY, SINCE_MS());
+      expect(plan).toContain("idx_temporal_role_session_created");
+      expect(plan).not.toMatch(
+        /SCAN temporal_messages USING INDEX idx_temporal_session/,
+      );
+    });
+
+    test("full metadata query (aggregateTokensBySessionAll step 2) uses the new index", () => {
+      const plan = explainPlan(SQL_META_FULL, SINCE_MS());
+      expect(plan).toContain("idx_temporal_role_session_created");
+      // The inner subquery in particular must not fall back to a full scan.
+      expect(plan).not.toMatch(
+        /SCAN temporal_messages USING INDEX idx_temporal_session/,
+      );
+    });
+
+    test("token-sum and distillation aggregates run index-backed (no full heap scan)", () => {
+      // These intentionally have no (created_at, session_id) index — the planner
+      // uses the session-ordered index to stream the GROUP BY. This pins that
+      // they remain index-backed rather than regressing to a brute table scan.
+      const tokenPlan = explainPlan(SQL_TOKEN_SUMS, SINCE_MS());
+      expect(tokenPlan).toContain("USING INDEX");
+      expect(tokenPlan).not.toMatch(/SCAN temporal_messages(?! USING)/);
+
+      const distillPlan = explainPlan(SQL_DISTILL, SINCE_MS());
+      expect(distillPlan).toContain("USING INDEX");
+      expect(distillPlan).not.toMatch(/SCAN distillations(?! USING)/);
+    });
+  });
+
+  describe("query correctness (real exported functions)", () => {
+    test("aggregateTokensBySessionAll groups token sums by session", () => {
+      const result = temporal.aggregateTokensBySessionAll({
+        sinceMs: SINCE_MS(),
+      });
+      // 200 messages × 100 tokens = 20_000 tokens per session.
+      const sess0 = result.get("cqb-sess-0");
+      expect(sess0).toBeDefined();
+      expect(sess0?.total_tokens).toBe(200 * 100);
+    });
+
+    test("aggregateTokensBySessionAll surfaces first assistant metadata field", () => {
+      const result = temporal.aggregateTokensBySessionAll({
+        sinceMs: SINCE_MS(),
+      });
+      // Assistant messages carry no metadata in this fixture; the per-session
+      // row still exists and the field is present (null).
+      const sess0 = result.get("cqb-sess-0");
+      expect(sess0).toBeDefined();
+      expect(sess0?.first_assistant_metadata).toBeNull();
+    });
+
+    test("aggregateDistillationsBySessionAll groups calls and tokens by session", () => {
+      const result = data.aggregateDistillationsBySessionAll({
+        sinceMs: SINCE_MS(),
+      });
+      const sess0 = result.get("cqb-sess-0");
+      expect(sess0).toBeDefined();
+      expect(sess0?.total_calls).toBe(5);
+      expect(sess0?.total_tokens).toBe(5 * 1000);
+      // Distillations d0/d2/d4 are batch-type (d % 2 === 0).
+      expect(sess0?.batch_calls).toBe(3);
+      expect(sess0?.batch_tokens).toBe(3 * 1000);
+    });
+  });
+});

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -59,7 +59,7 @@ describe("db", () => {
     const row = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(row.version).toBe(55);
+    expect(row.version).toBe(56);
   });
 
   test("v55: confidence/last_reinforced_at moved to knowledge_meta, exposed via view", () => {
@@ -109,13 +109,14 @@ describe("db", () => {
     d.exec("DROP VIEW IF EXISTS knowledge_current");
     d.exec("DROP TABLE IF EXISTS knowledge_meta");
 
-    // Re-open — migrate() re-runs the v55 step. Must NOT throw.
+    // Re-open — migrate() re-runs the v55 step (and any later migrations). Must
+    // NOT throw, and the version normalizes to MIGRATIONS.length.
     close();
     const fresh = db();
     const ver = fresh.query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(ver.version).toBe(55);
+    expect(ver.version).toBe(56);
     // Register + JOIN view were rebuilt and are queryable (confidence exposed).
     expect(
       fresh

--- a/packages/core/test/ltm-versioning.test.ts
+++ b/packages/core/test/ltm-versioning.test.ts
@@ -39,11 +39,11 @@ function ftsHits(token: string): number {
 }
 
 describe("A2 sub-PR 1: append-only knowledge scaffolding", () => {
-  test("schema version is 55", () => {
+  test("schema version is 56", () => {
     const v = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(v.version).toBe(55);
+    expect(v.version).toBe(56);
   });
 
   test("create() defaults logical_id = id, version 1, current, not deleted", () => {


### PR DESCRIPTION
## What

Adds DB migration **v56** with a single index targeting the slowest query on the `/ui/costs` page:

```sql
CREATE INDEX idx_temporal_role_session_created
  ON temporal_messages (role, session_id, created_at);
```

## Why

The costs page runs three cross-project bulk aggregates (#561): `listAllRecentSessions`, `aggregateTokensBySessionAll`, `aggregateDistillationsBySessionAll`. The expensive one is the *earliest assistant message per session* lookup inside `aggregateTokensBySessionAll` — a subquery filtering `role='assistant' AND created_at>=?` grouped by `session_id`. With only single-column indexes, SQLite full-SCANs `idx_temporal_session` (~360ms at ~200K messages).

The new index turns that into a **covering equality seek** on `role='assistant'` that streams the `GROUP BY` in `(session_id, created_at)` order — **measured ~8x faster (~360ms → ~42ms)**.

## Why only one index

The first cut added three `(created_at, session_id)` compound indexes. Adversarial review + an `EXPLAIN QUERY PLAN` probe at **both** low and high `created_at` selectivity (young DB vs years of history) showed the planner **never** uses a `(created_at, session_id)` index for the token-sum / distillation / recent-session aggregates — it prefers the session-ordered `idx_temporal_session` / `idx_distillation_session` scan (session ordering streams the `GROUP BY` without a temp b-tree; the `SUM(tokens)` / `call_type` / `token_count` projections aren't covered anyway).

So those two indexes were **pure write amplification on the two hottest tables with zero read benefit** — and would have made `idx_temporal_created` / `idx_distillation_created` redundant prefixes, against the repo's own drop-redundant convention. They are deliberately omitted; the decision is pinned by a test so it isn't quietly reverted.

## Tests

`packages/core/test/cost-bulk-queries.test.ts`:
- **Plan selection** via verbatim production SQL — the metadata subquery + full query must use `idx_temporal_role_session_created` (and must not fall back to a full `idx_temporal_session` scan).
- **Deliberate non-indexing** guard — the `(created_at, session_id)` indexes must not exist; token-sum/distillation aggregates stay index-backed (no brute heap scan).
- **Correctness** via the real exported functions.

Mutation-verified: dropping the index flips the existence + both plan tests red while everything else stays green.

## Review routine

- `pnpm test` — **3 consecutive clean full-suite runs** (3968 passed / 32 skipped / 0 failed).
- `pnpm run typecheck` — clean across all 5 packages.
- `pnpm run lint` — clean (exit 0; only pre-existing warnings).
- Adversarial correctness review (REVIEW.md §6, migrations require it): verdict **SHIP-WITH-FOLLOWUPS**; both SHOULD-FIX findings (D: unused indexes / hand-rolled SQL drift, E: redundant prefix indexes) and the NIT (B-1: `recoverMissingObjects` self-heal) addressed in this PR.

## Migration safety

- Appended at array index 55 → schema version normalizes to `MIGRATIONS.length = 56`. Does not shift the special-cased `KNOWLEDGE_META_MIGRATION_INDEX = 54` (v55) JS step.
- `CREATE INDEX IF NOT EXISTS` — idempotent, no `ALTER`, boot-loop-proof on partial apply.
- Recovered in `recoverMissingObjects` for self-heal parity.