### PR TITLE
test(references): guard Windows backslash path normalization

### DIFF
--- a/packages/core/test/references.test.ts
+++ b/packages/core/test/references.test.ts
@@ -8,6 +8,8 @@ import {
   extractReferences,
   NoopResolver,
   type Reference,
+  type RepoView,
+  resolveRefAgainstView,
   SyntheticProbeResolver,
 } from "../src/references";
 
@@ -304,6 +306,44 @@ describe("DirectFsResolver", () => {
     } finally {
       rmSync(noMake, { recursive: true, force: true });
     }
+  });
+});
+
+// Regression (#939 Seer HIGH): on Windows `path.normalize` emits backslash
+// separators, but `view.files` is built with forward slashes on every platform,
+// so the resolver must `.replace(/\\/g, "/")` the normalized path or a valid file
+// ref would wrongly resolve "missing" (and get penalized). We can't run on Windows
+// here, so we drive resolveRefAgainstView with a path that already contains literal
+// backslashes (plus one forward slash to clear the multi-segment branch gate) and
+// a forward-slash view — exactly what the `.replace` reconciles. Mutation-verified:
+// dropping the `.replace`, or its `/g` flag, makes this resolve "missing".
+describe("resolveRefAgainstView (Windows backslash normalization)", () => {
+  const view: RepoView = {
+    files: new Set(["a/b/c/d.ts"]),
+    basenames: new Map([["d.ts", ["a/b/c/d.ts"]]]),
+    scripts: null,
+    makeTargets: null,
+    lineCount: (rel) => (rel === "a/b/c/d.ts" ? 5 : null),
+  };
+
+  test("file ref with backslash separators matches the forward-slash view → ok", () => {
+    const ref: Reference = {
+      kind: "file",
+      path: "a/b\\c\\d.ts",
+      line: 3,
+      raw: "a/b\\c\\d.ts:3",
+    };
+    expect(resolveRefAgainstView(ref, view)).toBe("ok");
+  });
+
+  test("backslash separators still honor the line bound → missing when out of range", () => {
+    const ref: Reference = {
+      kind: "file",
+      path: "a/b\\c\\d.ts",
+      line: 99,
+      raw: "a/b\\c\\d.ts:99",
+    };
+    expect(resolveRefAgainstView(ref, view)).toBe("missing");
   });
 });
 


### PR DESCRIPTION
## What

Adds a **mutation-verified** regression test for the Windows path-separator fix that Seer flagged HIGH on #939 (`resolveRefAgainstView` at `references.ts:302`).

On Windows, `path.normalize` emits backslash separators, but `view.files`/`basenames` are built with forward slashes on every platform (FS walk and probe snapshot alike). Without the `.replace(/\\/g, "/")`, a perfectly valid file reference would resolve `"missing"` against the forward-slash view — and get penalized as drift. The fix shipped in #939 but had **no test**.

## Why it was non-trivial

The naive test (a `src\foo.ts` reference) is **vacuous** on Linux:
- the multi-segment branch gate is `ref.path.includes("/")`, which is false for a pure-backslash path, and
- `path.normalize` (posix) never introduces backslashes,

so it resolves `"missing"` with *or without* the fix.

Instead the test drives the exported `resolveRefAgainstView` directly with a controlled forward-slash `RepoView` and a path that carries literal backslashes **plus** one forward slash (to clear the branch gate) — exactly what `.replace(/\\/g, "/")` reconciles.

## Mutation verification (apply-fail-restore)

| Mutant | Result |
|---|---|
| remove `.replace(/\\/g, "/")` entirely | test FAILS (`missing` ≠ `ok`) ✅ killed |
| drop the `/g` flag (`.replace(/\\/, "/")`) | test FAILS (`missing` ≠ `ok`) ✅ killed |

Source restored byte-identically (SHA-256 verified) after each mutation.

## Tests

- `packages/core/test/references.test.ts`: 74 passed (2 new)
- full `@loreai/core` suite: 1936 passed / 6 skipped
- typecheck clean, lint clean