### PR TITLE
fix(gateway): persist nudged insertAt so steady-layer-1 drift stops recurring (Bug 2)

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -3125,6 +3125,29 @@ export function upsertSessionPromptDelta(input: {
 }
 
 /**
+ * Rewrite the persisted `selector` JSON for a single delta block, identified by
+ * (sessionID, seq). Content is left untouched — only the placement metadata
+ * moves. Used by the steady-layer-1 drift fix (Bug 2): when safeDeltaInsertIndex
+ * nudges a once-safe insertAt because the compressed array below it slid,
+ * persist the new safe index so subsequent replays use it verbatim and the
+ * delta block stays at a byte-identical position across turns. No-op if no
+ * matching row exists.
+ */
+export function updateSessionPromptDeltaSelector(
+  sessionID: string,
+  seq: number,
+  selector: string,
+): void {
+  db()
+    .query(
+      `UPDATE session_prompt_deltas
+          SET selector = ?
+        WHERE session_id = ? AND seq = ?`,
+    )
+    .run(selector, sessionID, seq);
+}
+
+/**
  * Delete all persisted prompt-delta rows for a session.
  *
  * Used when the gradient compresses (a cache-busting layer change): the

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -109,6 +109,7 @@ export {
   upsertSessionPromptDelta,
   deleteSessionPromptDelta,
   listSessionPromptDeltas,
+  updateSessionPromptDeltaSelector,
   recordCacheBustObservation,
   getCacheBustStats,
   summarizeCacheBustStats,

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -70,6 +70,7 @@ import {
   appendSessionPromptDelta,
   deleteSessionPromptDelta,
   listSessionPromptDeltas,
+  updateSessionPromptDeltaSelector,
   loadHeaderSessionIndex,
   isHostedMode,
   enableHostedMode,
@@ -1024,31 +1025,38 @@ export function applySessionPromptDeltas(
     return byPosition !== 0 ? byPosition : b.seq - a.seq;
   });
 
-  for (const { selector, message } of parsed) {
+  // Bug 2: when safeDeltaInsertIndex nudges a stored insertAt because the
+  // compressed array below it slid (steady-layer-1 layout shifts), persist
+  // the new safe index so subsequent replays use it verbatim. Without this,
+  // every turn the nudge re-fires and the delta block drifts +N/turn, busting
+  // `messages[0]` (production session 1GYu, k:019ece09). Batched at the end so
+  // each drift = one DB write, not one per turn.
+  const reanchored: Array<{ seq: number; selector: MessageInsertSelector }> =
+    [];
+  for (const { seq, selector, message } of parsed) {
     // Selector positions are defined against the transformed upstream message
     // array at the time the delta is created (where they were already made
     // tool-pair-safe via safeDeltaInsertIndex). Re-inserting at the SAME index
     // on subsequent turns is intentional: #747 requires the delta to stay at a
     // byte-identical position to preserve the conversation prompt cache.
     //
-    // We re-run safeDeltaInsertIndex ONLY as a tool-pair guard, not a general
-    // re-placement: when the persisted index still points at a safe boundary
-    // (the common case) it returns the index unchanged → byte-identical replay,
-    // preserving the cache exactly as before. But the conversation grows and the
-    // raw-window/distilled-prefix boundary below the delta slides, so a once-safe
-    // absolute index can later land BETWEEN an assistant(tool_use) and its
-    // user(tool_result). Previously the splice went in anyway and
-    // removeOrphanedToolResults DESTRUCTIVELY stripped both blocks every turn —
-    // silently deleting a real tool call from history (and firing on every turn,
-    // not "rarely" as assumed). Nudging to the nearest safe boundary preserves
-    // the tool pair. The nudge is deterministic and layout-stable turn-over-turn
-    // (the messages below the delta are themselves stable until they change), so
-    // it does not introduce per-turn churn; at worst it shifts ONCE when the
-    // split first appears — strictly better than rewriting two historical
-    // messages every turn.
+    // safeDeltaInsertIndex is run as a tool-pair guard: when the persisted
+    // index still points at a safe boundary (the common case) it returns the
+    // index unchanged → byte-identical replay. When the layout below the
+    // stored index has shifted (compressed layer-1 array slides) and the
+    // persisted index now lands BETWEEN an assistant(tool_use) and its
+    // user(tool_result), the function walks back before the assistant. We
+    // persist that nudge so the next turn does NOT re-fire the same nudge
+    // (the new persisted index is byte-stable until the next layout shift).
     const clamped = Math.min(selector.insertAt, out.length);
     const insertAt = safeDeltaInsertIndex(out, clamped);
+    if (insertAt !== clamped) {
+      reanchored.push({ seq, selector: { ...selector, insertAt } });
+    }
     out.splice(insertAt, 0, message);
+  }
+  for (const { seq, selector } of reanchored) {
+    updateSessionPromptDeltaSelector(sessionID, seq, JSON.stringify(selector));
   }
   return out;
 }

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -1004,9 +1004,16 @@ export function applySessionPromptDeltas(
   if (!deltas.length) return messages;
 
   const out = messages.slice();
+  // We carry the raw selector JSON alongside the validated `insertAt` so the
+  // re-anchor path can preserve unknown fields (notably `mut`, the per-block
+  // mutation signature used by advanceSurfacedKeys). parseMessageInsertSelector
+  // returns ONLY {target, insertAt} — spreading that loses every other field
+  // and reintroduces the bug #958 fixed in session 1LYkXZ7jkiHHnqPl. Use the
+  // same raw-JSON mutate pattern as reanchorExistingDelta below.
   const parsed: Array<{
     seq: number;
-    selector: MessageInsertSelector;
+    rawSelector: string;
+    insertAt: number;
     message: GatewayMessage;
   }> = [];
   for (const delta of deltas) {
@@ -1018,10 +1025,15 @@ export function applySessionPromptDeltas(
       );
       continue;
     }
-    parsed.push({ seq: delta.seq, selector, message });
+    parsed.push({
+      seq: delta.seq,
+      rawSelector: delta.selector,
+      insertAt: selector.insertAt,
+      message,
+    });
   }
   parsed.sort((a, b) => {
-    const byPosition = b.selector.insertAt - a.selector.insertAt;
+    const byPosition = b.insertAt - a.insertAt;
     return byPosition !== 0 ? byPosition : b.seq - a.seq;
   });
 
@@ -1031,9 +1043,13 @@ export function applySessionPromptDeltas(
   // every turn the nudge re-fires and the delta block drifts +N/turn, busting
   // `messages[0]` (production session 1GYu, k:019ece09). Batched at the end so
   // each drift = one DB write, not one per turn.
-  const reanchored: Array<{ seq: number; selector: MessageInsertSelector }> =
-    [];
-  for (const { seq, selector, message } of parsed) {
+  const reanchored: Array<{ seq: number; selector: string }> = [];
+  for (const {
+    seq,
+    rawSelector,
+    insertAt: storedInsertAt,
+    message,
+  } of parsed) {
     // Selector positions are defined against the transformed upstream message
     // array at the time the delta is created (where they were already made
     // tool-pair-safe via safeDeltaInsertIndex). Re-inserting at the SAME index
@@ -1048,15 +1064,24 @@ export function applySessionPromptDeltas(
     // user(tool_result), the function walks back before the assistant. We
     // persist that nudge so the next turn does NOT re-fire the same nudge
     // (the new persisted index is byte-stable until the next layout shift).
-    const clamped = Math.min(selector.insertAt, out.length);
-    const insertAt = safeDeltaInsertIndex(out, clamped);
-    if (insertAt !== clamped) {
-      reanchored.push({ seq, selector: { ...selector, insertAt } });
+    const clamped = Math.min(storedInsertAt, out.length);
+    const safe = safeDeltaInsertIndex(out, clamped);
+    if (safe !== clamped) {
+      // Mutate the raw JSON to preserve unknown fields (mut, etc.) — do NOT
+      // spread the typed MessageInsertSelector (only carries target+insertAt).
+      let rawSelectorObj: Record<string, unknown>;
+      try {
+        rawSelectorObj = JSON.parse(rawSelector) as Record<string, unknown>;
+      } catch {
+        rawSelectorObj = { target: "messages" };
+      }
+      rawSelectorObj.insertAt = safe;
+      reanchored.push({ seq, selector: JSON.stringify(rawSelectorObj) });
     }
-    out.splice(insertAt, 0, message);
+    out.splice(safe, 0, message);
   }
   for (const { seq, selector } of reanchored) {
-    updateSessionPromptDeltaSelector(sessionID, seq, JSON.stringify(selector));
+    updateSessionPromptDeltaSelector(sessionID, seq, selector);
   }
   return out;
 }
@@ -1319,11 +1344,15 @@ export function buildKnowledgeDeltaMessage(
 
 /**
  * The mutation signature an appended delta block surfaced, stashed in the
- * block's selector JSON. `parseMessageInsertSelector` ignores unknown fields,
- * so this rides alongside `insertAt` without affecting replay. It lets a later
- * turn reconstruct the ADVANCING surfaced set (frozen pin baseline + every
- * block's increment) purely from the persisted blocks — no extra state, durable
- * across restart for free.
+ * block's selector JSON. `parseMessageInsertSelector` only VALIDATES the
+ * `{target, insertAt}` shape and discards every other field on read, so this
+ * rides alongside `insertAt` without affecting replay — but callers that need
+ * to WRITE back a re-anchored selector (e.g. applySessionPromptDeltas' drift
+ * fix) MUST go through the raw JSON, not the typed return, or `mut` is lost
+ * (re-introduces the bug #958 fixed in session 1LYkXZ7jkiHHnqPl). Lets a
+ * later turn reconstruct the ADVANCING surfaced set (frozen pin baseline +
+ * every block's increment) purely from the persisted blocks — no extra state,
+ * durable across restart for free.
  */
 type DeltaMutation = {
   /** ids whose content was surfaced as changed, with the surfaced hash. */

--- a/packages/gateway/test/delta-compress-reanchor.test.ts
+++ b/packages/gateway/test/delta-compress-reanchor.test.ts
@@ -544,11 +544,21 @@ describe("steady-layer-1 insertAt drift — nudge is persisted", () => {
     );
 
     // Persist a delta whose stored insertAt (2) is safe in the CURRENT layout
-    // (assistant has only a text block, no tool_use).
+    // (assistant has only a text block, no tool_use). Include a `mut` field so
+    // we can assert it survives the re-anchor — `parseMessageInsertSelector`
+    // returns only {target, insertAt} and a typed spread would silently drop
+    // mut, breaking advanceSurfacedKeys downstream.
     appendSessionPromptDelta({
       sessionID,
       projectID,
-      selector: JSON.stringify({ target: "messages", insertAt: 2 }),
+      selector: JSON.stringify({
+        target: "messages",
+        insertAt: 2,
+        mut: {
+          changed: [{ id: "k1", h: "h1" }],
+          removed: ["k2"],
+        },
+      }),
       content: JSON.stringify({
         role: "user",
         content: [{ type: "text", text: "Lore knowledge update" }],
@@ -591,13 +601,19 @@ describe("steady-layer-1 insertAt drift — nudge is persisted", () => {
     expect(deltaIdx2).toBeLessThan(2); // nudged before the assistant(tool_use)
     expect(deltaIdx2).toBeGreaterThanOrEqual(0);
 
-    // THE FIX: the new safe index is now PERSISTED — without this, every
-    // subsequent turn would re-compute the same nudge and the position would
-    // drift by 1+ per turn (the Bug 2 production pattern).
+    // THE FIX (blocker): the new safe index is PERSISTED AND `mut` IS
+    // PRESERVED. Without the raw-JSON write-back, the typed selector spread
+    // would silently drop `mut`, advanceSurfacedKeys would re-surface the
+    // original mutations every turn, and we'd append a fresh block per turn
+    // — exactly the bug #958 fixed in session 1LYkXZ7jkiHHnqPl.
     const rows = listSessionPromptDeltas(sessionID);
     expect(rows.length).toBe(1);
     const persistedSelector = JSON.parse(rows[0].selector);
     expect(persistedSelector.insertAt).toBe(deltaIdx2);
+    expect(persistedSelector.mut).toEqual({
+      changed: [{ id: "k1", h: "h1" }],
+      removed: ["k2"],
+    });
 
     // Turn 3: SAME drifted layout — replay must be byte-identical to turn 2.
     // The persisted insertAt is used verbatim (no further nudge).

--- a/packages/gateway/test/delta-compress-reanchor.test.ts
+++ b/packages/gateway/test/delta-compress-reanchor.test.ts
@@ -522,3 +522,99 @@ describe("reanchorExistingDelta — recomputes a persisted delta against the cur
     expect(listSessionPromptDeltas(sessionID).length).toBe(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Bug 2 — steady-layer-1 frozen insertAt drift (k:019ece09)
+// ---------------------------------------------------------------------------
+// Production (session 1GYu, post-#958): the persisted delta's stored insertAt
+// stays frozen across turns, but the compressed layer-1 array slides as the
+// raw window re-evicts. When the message BELOW the stored insertAt becomes
+// assistant(tool_use), safeDeltaInsertIndex nudges the delta up by 1 — and
+// keeps nudging every turn the layout shifts, so the delta block's position
+// drifts +N/turn and `messages[0]`/the prefix busts on every replay.
+//
+// The fix: when the nudge fires, PERSIST the new safe index so subsequent
+// replays use it verbatim (byte-identical position turn-over-turn, modulo
+// further shifts which trigger another nudge-and-persist).
+describe("steady-layer-1 insertAt drift — nudge is persisted", () => {
+  test("nudged insertAt is written back to DB so replays are byte-identical", () => {
+    const sessionID = `delta-drift-${Date.now()}-${Math.random()}`;
+    const projectID = ensureProject(
+      `/tmp/lore-delta-drift-${Date.now()}-${Math.random()}`,
+    );
+
+    // Persist a delta whose stored insertAt (2) is safe in the CURRENT layout
+    // (assistant has only a text block, no tool_use).
+    appendSessionPromptDelta({
+      sessionID,
+      projectID,
+      selector: JSON.stringify({ target: "messages", insertAt: 2 }),
+      content: JSON.stringify({
+        role: "user",
+        content: [{ type: "text", text: "Lore knowledge update" }],
+      }),
+    });
+
+    // Turn 1: layout is safe at stored insertAt=2.
+    const layoutSafe: GatewayMessage[] = [
+      user(text("hi")),
+      assistant(text("ok")), // no tool_use — stored insertAt=2 is safe
+      user(text("continue")),
+    ];
+    const out1 = applySessionPromptDeltas(layoutSafe, sessionID);
+    removeOrphanedToolResults(out1);
+    // Delta was placed at the stored position (no nudge on this layout).
+    const deltaIdx1 = out1.findIndex((m) =>
+      m.content.some(
+        (b) => b.type === "text" && b.text === "Lore knowledge update",
+      ),
+    );
+    expect(deltaIdx1).toBe(2);
+
+    // Turn 2: LAYOUT SHIFTS — the assistant now carries a tool_use. Stored
+    // insertAt=2 would land BETWEEN the tool_use and its tool_result (orphaning
+    // the pair). safeDeltaInsertIndex nudges to a safe index < 2.
+    const layoutDrifts: GatewayMessage[] = [
+      user(text("hi")),
+      assistant(toolUse("X")),
+      user(toolResult("X")),
+      user(text("next turn")),
+    ];
+    const out2 = applySessionPromptDeltas(layoutDrifts, sessionID);
+    removeOrphanedToolResults(out2);
+    assertNoOrphanedTools(out2);
+    const deltaIdx2 = out2.findIndex((m) =>
+      m.content.some(
+        (b) => b.type === "text" && b.text === "Lore knowledge update",
+      ),
+    );
+    expect(deltaIdx2).toBeLessThan(2); // nudged before the assistant(tool_use)
+    expect(deltaIdx2).toBeGreaterThanOrEqual(0);
+
+    // THE FIX: the new safe index is now PERSISTED — without this, every
+    // subsequent turn would re-compute the same nudge and the position would
+    // drift by 1+ per turn (the Bug 2 production pattern).
+    const rows = listSessionPromptDeltas(sessionID);
+    expect(rows.length).toBe(1);
+    const persistedSelector = JSON.parse(rows[0].selector);
+    expect(persistedSelector.insertAt).toBe(deltaIdx2);
+
+    // Turn 3: SAME drifted layout — replay must be byte-identical to turn 2.
+    // The persisted insertAt is used verbatim (no further nudge).
+    const out3 = applySessionPromptDeltas(layoutDrifts, sessionID);
+    removeOrphanedToolResults(out3);
+    assertNoOrphanedTools(out3);
+    const deltaIdx3 = out3.findIndex((m) =>
+      m.content.some(
+        (b) => b.type === "text" && b.text === "Lore knowledge update",
+      ),
+    );
+    expect(deltaIdx3).toBe(deltaIdx2);
+    // DB still has exactly one row (no spurious new block created).
+    expect(listSessionPromptDeltas(sessionID).length).toBe(1);
+    // The persisted insertAt is unchanged from turn 2 (no re-write needed).
+    expect(
+      JSON.parse(listSessionPromptDeltas(sessionID)[0].selector).insertAt,
+    ).toBe(deltaIdx2);
+  });
+});


### PR DESCRIPTION
## Symptom

Production (session 1GYu, post-#958): the persisted delta's stored `insertAt` stays frozen across turns, but the compressed layer-1 array slides as the raw window re-evicts. When the message BELOW the stored `insertAt` becomes `assistant(tool_use)`, `safeDeltaInsertIndex` nudges the delta up by 1 — and keeps nudging every turn the layout shifts, so the delta block drifts +N/turn and `messages[0]`/the prefix busts on every replay (k:019ece09).

The existing comment in `applySessionPromptDeltas` claims "at worst it shifts ONCE when the split first appears" — but that's only true when the layout below the delta is stable. On a steady-layer-1 session the compressed array slides on every turn, so the nudge fires on every turn, and the delta drifts by one per turn.

## Fix

When the tool-pair guard (`safeDeltaInsertIndex`) nudges a stored `insertAt`, persist the new safe index so subsequent replays use it verbatim — byte-identical position turn-over-turn, with **one DB write per layout-shift event** (not per turn).

- New core/db primitive `updateSessionPromptDeltaSelector(sessionID, seq, selector)` rewrites the selector column for a single delta block. Content stays immutable (the append-only invariant from #958). Exported from `@loreai/core` barrel.
- `applySessionPromptDeltas` collects nudges into a `reanchored` array, splices each delta at its safe position, then persists all re-anchored selectors in one batched pass. The selector spread keeps the `parseMessageInsertSelector` shape intact (target/insertAt/mutation/etc.).

## Tests

`packages/gateway/test/delta-compress-reanchor.test.ts` — new test `nudged insertAt is written back to DB so replays are byte-identical`. Three turns on the same session:
1. **Turn 1**: stored `insertAt=2` is safe (assistant has only text) — no nudge. Delta lands at position 2.
2. **Turn 2**: assistant gains `tool_use`, layout drifts — `safeDeltaInsertIndex` nudges to a safe index `< 2`. Asserts the persisted selector's `insertAt` is now that safe index.
3. **Turn 3**: same drifted layout — replay uses the persisted index verbatim (byte-identical position to turn 2). DB still has one row; no spurious re-write.

Mutation: removing the `updateSessionPromptDeltaSelector` call kills the new test. Restored byte-identical.

## Validation

- Target file + cache-stability e2e: **68/68 pass** (delta files + cache-stability e2e).
- Gateway suite: **2198 passed | 29 skipped** (98 files).
- Full suite: **4194 passed | 35 skipped, 0 failures** (223s).
- Typecheck (4 packages): clean.
- Lint: clean (19 pre-existing non-null-assertion warnings, unrelated).

## Follow-ups (separate PRs / issues)

- **PR C** (separate PR): `creditWarmupHit` warming over-count (k:019edc02).
- **Issue (plan-only, do NOT implement per prior directive)**: dynamic `AUTOCOMPACT_THRESHOLD` based on model's max context length.

Closes k:019ece09.