### PR TITLE
feat(core): log sqlite-vec native-vs-fallback path at startup

### DIFF
--- a/packages/core/src/db/vec.ts
+++ b/packages/core/src/db/vec.ts
@@ -24,6 +24,7 @@
 
 import type { Database } from "#db/driver";
 import * as sqliteVec from "sqlite-vec";
+import * as log from "../log";
 
 let vecAvailable = false;
 let attempted = false;
@@ -60,10 +61,26 @@ export function loadVecExtension(database: Database): void {
   // test seam for the JS fallback. Set before the first `db()` call — once
   // attempted=true is sticky for the connection lifetime, the env var won't be
   // re-read until resetVecState() runs (in close()).
-  if (process.env.LORE_DISABLE_VEC === "1") return; // kill-switch → JS fallback
+  if (process.env.LORE_DISABLE_VEC === "1") {
+    log.info(
+      "sqlite-vec: disabled via LORE_DISABLE_VEC — using JS brute-force vector search",
+    );
+    return; // kill-switch → JS fallback
+  }
+  // Capture success details and emit the "enabled" line OUTSIDE the try block,
+  // so a misbehaving log sink can never flip vecAvailable back to false after a
+  // genuine load. The loader's contract (never throw, fall back on failure)
+  // stays intact.
+  let loadedPath: string | null = null;
+  let version = "unknown";
   try {
     const path = resolveExtensionPath();
-    if (!path) return;
+    if (!path) {
+      log.warn(
+        "sqlite-vec: no native binary for this platform/runtime — using JS brute-force vector search",
+      );
+      return;
+    }
     // node:sqlite gates the loadExtension() C-API behind enableLoadExtension();
     // bun:sqlite has no such method (extensions enabled by default on Linux).
     const conn = database as unknown as {
@@ -76,11 +93,22 @@ export function loadVecExtension(database: Database): void {
     // the loaded functions stay available for the connection's lifetime.
     conn.enableLoadExtension?.(false);
     // Confirm registration before trusting the fast path.
-    database.query("SELECT vec_version()").get();
+    const row = database.query("SELECT vec_version() AS v").get() as
+      | { v?: string }
+      | undefined;
+    version = row?.v ?? "unknown";
+    loadedPath = path;
     vecAvailable = true;
-  } catch {
+  } catch (e) {
     vecAvailable = false;
+    log.warn(
+      `sqlite-vec: native extension failed to load (${(e as Error).message}) — using JS brute-force vector search`,
+    );
+    return;
   }
+  log.info(
+    `sqlite-vec: native vector search enabled (${version}, ${loadedPath})`,
+  );
 }
 
 /** Whether sqlite-vec loaded successfully on the active connection. */

--- a/packages/core/test/vec-search.test.ts
+++ b/packages/core/test/vec-search.test.ts
@@ -1,6 +1,15 @@
-import { afterAll, beforeEach, describe, expect, test } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from "vitest";
 import { close, db, ensureProject } from "../src/db";
 import { isVecAvailable } from "../src/db/vec";
+import * as log from "../src/log";
 import {
   toBlob,
   vectorSearch,
@@ -67,6 +76,44 @@ describe("sqlite-vec extension loading", () => {
     const hits = vectorSearch(new Float32Array([1, 0, 0]), 1);
     expect(hits.length).toBe(1);
     expect(hits[0].similarity).toBeCloseTo(1.0, 5); // vec (normalized), not 2.0 (raw dot)
+  });
+});
+
+// The loader emits exactly one status line per connection so a deploy can be
+// verified from `journalctl` (LORE_DEBUG=1) without a manual probe: an "enabled"
+// line on the native path, or a reason on each fallback. These tests pin those
+// lines so the diagnostic can't silently regress.
+describe("loadVecExtension startup logging", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.LORE_DISABLE_VEC;
+    close(); // fresh connection (+ reset vec state) for the next test/suite
+  });
+
+  function infoLines(spy: ReturnType<typeof vi.spyOn>): string[] {
+    return spy.mock.calls.map((c: unknown[]) => c.map(String).join(" "));
+  }
+
+  test("logs the enabled line on supported runtimes", () => {
+    if (!nodeSupportsVec()) return; // JS-only runtime: see the kill-switch leg
+    close(); // drop the connection opened by earlier suites + reset vec state
+    const info = vi.spyOn(log, "info");
+    ensureProject(PROJECT); // opens a fresh connection → runs loadVecExtension
+    expect(isVecAvailable()).toBe(true);
+    expect(
+      infoLines(info).some((l) => l.includes("native vector search enabled")),
+    ).toBe(true);
+  });
+
+  test("logs the disabled reason under the LORE_DISABLE_VEC kill-switch", () => {
+    close(); // reset vec state so the env var is re-read on the next open
+    process.env.LORE_DISABLE_VEC = "1";
+    const info = vi.spyOn(log, "info");
+    ensureProject(PROJECT);
+    expect(isVecAvailable()).toBe(false);
+    expect(infoLines(info).some((l) => l.includes("LORE_DISABLE_VEC"))).toBe(
+      true,
+    );
   });
 });
 


### PR DESCRIPTION
## Problem

`loadVecExtension` (added in #967) is completely silent — no log on success, no log on any fallback branch, and no DB schema artifact (we query `vec_distance_cosine()` over BLOB columns rather than creating `vec0` virtual tables). So after a deploy there's no way to tell whether vector search is running the **native sqlite-vec fast path** or the **JS brute-force fallback** without a manual probe (resolving the binary path + calling `vec_version()` by hand).

## Change

Emit exactly one status line per connection from `loadVecExtension`, visible in `journalctl` (the production service runs with `LORE_DEBUG=1`):

| Outcome | Level | Message |
|---|---|---|
| native loaded | `info` | `sqlite-vec: native vector search enabled (<version>, <path>)` |
| kill-switch | `info` | `sqlite-vec: disabled via LORE_DISABLE_VEC — using JS brute-force vector search` |
| no platform binary | `warn` | `sqlite-vec: no native binary for this platform/runtime — using JS brute-force vector search` |
| load error | `warn` | `sqlite-vec: native extension failed to load (<msg>) — using JS brute-force vector search` |

The `<path>` tells you *which* binary loaded (npm optional-dep cache vs SEA-embedded), which is the exact thing you'd want when diagnosing a stale-bundle deploy.

## Safety

The success line is emitted **outside** the `try` block, so a misbehaving log sink can never flip `vecAvailable` back to `false` after a genuine load. The loader's contract — never throw, fall back on failure — is unchanged.

## Tests

Added `loadVecExtension startup logging` to `vec-search.test.ts`:
- logs the enabled line on supported runtimes (Node ≥23.5 / Bun)
- logs the disabled reason under the `LORE_DISABLE_VEC` kill-switch

Both verified load-bearing via mutation testing (break the success string → enabled test fails; remove the kill-switch log → disabled test fails). Core suite 2023 passed / gateway suite 2218 passed; typecheck + lint clean.