### PR TITLE
feat(ltm): refresh provenance metadata on update/remove (#627 Phase 2)

### DIFF
--- a/packages/core/src/curator.ts
+++ b/packages/core/src/curator.ts
@@ -282,7 +282,11 @@ export function applyOps(
     detectedRelations?: DetectedRelation[];
     /** Worker model that produced these ops (for v35 source attribution). */
     workerModel?: { providerID: string; modelID: string };
-    /** #627 Phase 1: per-entry metadata stamped on every "create" op. */
+    /**
+     * #627: per-entry provenance for this run. Phase 1 stamps it on "create" ops;
+     * Phase 2 also threads it through "update" (content changes) and "delete"
+     * (death certs). Absent/empty → prior commit anchor is forward-copied.
+     */
     metadata?: KnowledgeMetadata;
   },
 ): {
@@ -386,7 +390,13 @@ export function applyOps(
             ? op.content.slice(0, MAX_ENTRY_CONTENT_LENGTH) +
               " [truncated — entry too long]"
             : op.content;
-        ltm.update(op.id, { content, confidence: op.confidence });
+        // #627 Phase 2: stamp the edit with the session's commit anchor so a
+        // content change refreshes provenance (a no-op when metadata is absent).
+        ltm.update(op.id, {
+          content,
+          confidence: op.confidence,
+          metadata: input.metadata,
+        });
         // Key on the stable logical_id: a content change appends a new version, so
         // op.id is now a superseded version id. idsToSync + the delta channel must
         // reference the logical_id to resolve the current version downstream.
@@ -417,7 +427,8 @@ export function applyOps(
           title: entry.title,
           prevContent: entry.content,
         });
-        ltm.remove(op.id);
+        // #627 Phase 2: record the delete-time commit anchor on the death cert.
+        ltm.remove(op.id, input.metadata);
         deleted++;
       }
     }

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -319,6 +319,14 @@ export function appendVersion(
     content?: string;
     category?: string;
     isDeleted?: boolean;
+    /**
+     * #627 Phase 2: stamp the NEW version with fresh provenance (the commit the
+     * edit/delete happened at). When omitted — or empty (`{}` → NULL via
+     * stringifyMetadata) — the prior version's metadata is forward-copied via
+     * `COALESCE(?, metadata)`, so a caller with no session gitHead (CLI import,
+     * dashboard delete) never wipes a previously-recorded commit anchor.
+     */
+    metadata?: KnowledgeMetadata;
   } = {},
 ): string | null {
   const newId = uuidv7();
@@ -351,7 +359,7 @@ export function appendVersion(
            logical_id, version, is_deleted, is_current)
          SELECT
            ?, project_id, COALESCE(?, category), COALESCE(?, title), COALESCE(?, content),
-           source_session, cross_project, created_at, ?, metadata, NULL,
+           source_session, cross_project, created_at, ?, COALESCE(?, metadata), NULL,
            created_by, updated_by, sensitivity, promotion_status, promoted_at,
            approval_status, approved_by, approved_at, source_user_id, source_entry_id,
            last_accessed_at, worker_provider_id, worker_model_id,
@@ -364,6 +372,9 @@ export function appendVersion(
         overrides.title ?? null,
         overrides.content ?? null,
         now,
+        // #627 Phase 2: a non-empty override stamps the new version; NULL (absent
+        // or `{}`) makes COALESCE forward-copy the prior version's metadata.
+        stringifyMetadata(overrides.metadata),
         overrides.isDeleted ? 1 : 0,
         cur.id,
       );
@@ -452,6 +463,12 @@ export function update(
     confidence?: number;
     updatedBy?: string;
     sensitivity?: Sensitivity;
+    /**
+     * #627 Phase 2: provenance for the edit. Applied ONLY when a content change
+     * appends a new version — a metric/sensitivity-only update mutates no version
+     * row (A2 rows are immutable), so the existing gitHead correctly stands.
+     */
+    metadata?: KnowledgeMetadata;
   },
 ) {
   // A2 (#823): content is IMMUTABLE per version. A content change appends a new
@@ -466,7 +483,10 @@ export function update(
   if (input.content !== undefined) {
     const cur = getByLogical(logicalId);
     if (cur && cur.content !== input.content) {
-      appendVersion(logicalId, { content: input.content });
+      appendVersion(logicalId, {
+        content: input.content,
+        metadata: input.metadata,
+      });
       appended = true;
     }
   }
@@ -519,15 +539,17 @@ export function update(
   }
 }
 
-export function remove(id: string) {
+export function remove(id: string, metadata?: KnowledgeMetadata) {
   // A2 (#823): delete = append an immutable is_deleted "death-certificate"
   // version (ordinary append, no physical DELETE). The death cert IS the
   // tombstone + resurrection guard: knowledge_current excludes it, the FTS
   // triggers drop its posting, and isTombstoned() detects it so a stale .lore.md
   // re-import can't resurrect the entry. Keyed on the stable logical_id.
+  // #627 Phase 2: the death cert records the delete-time gitHead (provenance for
+  // `lore why`); absent → forward-copies the entry's last commit anchor.
   const logicalId = logicalIdOf(id);
   if (!getByLogical(logicalId)) return; // already deleted or unknown — no-op
-  appendVersion(logicalId, { isDeleted: true });
+  appendVersion(logicalId, { isDeleted: true, metadata });
   // The row is NOT physically deleted, so FK ON DELETE CASCADE no longer fires —
   // clean cross-references explicitly, all keyed on the logical_id.
   db()

--- a/packages/core/test/import/curator-ops.test.ts
+++ b/packages/core/test/import/curator-ops.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest";
-import { ensureProject } from "../../src/db";
+import { db, ensureProject } from "../../src/db";
 import * as ltm from "../../src/ltm";
 import { parseOps, applyOps, type CuratorOp } from "../../src/curator";
 
@@ -177,5 +177,56 @@ describe("applyOps", () => {
 
     const result = applyOps(ops, { projectPath: PROJECT_PATH });
     expect(result.deleted).toBe(0);
+  });
+
+  // #627 Phase 2: applyOps threads the session's commit anchor into the
+  // update/delete paths (not just create) so a content edit refreshes provenance.
+  test("update op stamps the session gitHead onto a content change", () => {
+    const id = ltm.create({
+      projectPath: PROJECT_PATH,
+      category: "decision",
+      title: "Phase 2 update wiring",
+      content: "minted at commit A",
+      scope: "project",
+      metadata: { gitHead: "aaaaaaa" },
+    });
+    const ops: CuratorOp[] = [
+      { op: "update", id, content: "revised at commit B", confidence: 0.7 },
+    ];
+    const result = applyOps(ops, {
+      projectPath: PROJECT_PATH,
+      metadata: { gitHead: "bbbbbbb" },
+    });
+    expect(result.updated).toBe(1);
+    const after = ltm.getByLogical(ltm.logicalIdOf(id));
+    expect(after?.content).toBe("revised at commit B");
+    expect(after?.metadata).toEqual({ gitHead: "bbbbbbb" });
+  });
+
+  test("delete op stamps the session gitHead onto the death cert", () => {
+    const id = ltm.create({
+      projectPath: PROJECT_PATH,
+      category: "decision",
+      title: "Phase 2 delete wiring",
+      content: "minted at commit A",
+      scope: "project",
+      metadata: { gitHead: "aaaaaaa" },
+    });
+    const logicalId = ltm.logicalIdOf(id);
+    const ops: CuratorOp[] = [
+      { op: "delete", id, reason: "superseded at commit B" },
+    ];
+    const result = applyOps(ops, {
+      projectPath: PROJECT_PATH,
+      metadata: { gitHead: "bbbbbbb" },
+    });
+    expect(result.deleted).toBe(1);
+    expect(ltm.getByLogical(logicalId)).toBeNull();
+    const row = db()
+      .query(
+        "SELECT metadata FROM knowledge WHERE logical_id = ? AND is_current = 1 LIMIT 1",
+      )
+      .get(logicalId) as { metadata: string | null } | undefined;
+    expect(row?.metadata).toBe(JSON.stringify({ gitHead: "bbbbbbb" }));
   });
 });

--- a/packages/core/test/ltm-metadata.test.ts
+++ b/packages/core/test/ltm-metadata.test.ts
@@ -7,8 +7,10 @@ import {
   getByLogical,
   hydrateKnowledgeEntry,
   logicalIdOf,
+  remove,
   searchScored,
   searchScoredOtherProjects,
+  update,
   type KnowledgeMetadata,
 } from "../src/ltm";
 
@@ -342,5 +344,143 @@ describe("scored search hydrates metadata (Seer #14860239, #627 Phase 1)", () =>
     expect(hit).toBeDefined();
     expect(typeof hit!.metadata).toBe("object");
     expect(hit!.metadata).toEqual({ gitHead: "0ther9999cafe" });
+  });
+});
+
+describe("update()/remove() refresh metadata on new versions (#627 Phase 2)", () => {
+  // Helper: read the metadata column straight off the current base-table row
+  // (including is_deleted death certs, which knowledge_current hides).
+  const rawCurrentMetadata = (logicalId: string): string | null => {
+    const row = db()
+      .query(
+        "SELECT metadata FROM knowledge WHERE logical_id = ? AND is_current = 1 LIMIT 1",
+      )
+      .get(logicalId) as { metadata: string | null } | undefined;
+    return row ? row.metadata : null;
+  };
+
+  test("content-changing update stamps the new version with fresh gitHead", () => {
+    const projectPath = nextProject();
+    const id = create({
+      projectPath,
+      category: "decision",
+      title: "Index strategy",
+      content: "original content at commit A",
+      scope: "project",
+      metadata: { gitHead: "aaaaaaa" },
+    });
+    update(id, {
+      content: "revised content at commit B",
+      metadata: { gitHead: "bbbbbbb" },
+    });
+    const after = getByLogical(logicalIdOf(id));
+    expect(after?.content).toBe("revised content at commit B");
+    // The bug (Phase 1): appendVersion forward-copied the mint-time gitHead.
+    expect(after?.metadata).toEqual({ gitHead: "bbbbbbb" });
+  });
+
+  test("content-changing update with NO metadata forward-copies prior gitHead", () => {
+    const projectPath = nextProject();
+    const id = create({
+      projectPath,
+      category: "decision",
+      title: "Forward-copy entry",
+      content: "v1 content",
+      scope: "project",
+      metadata: { gitHead: "ccccccc" },
+    });
+    // No metadata supplied (e.g. a CLI/.lore.md caller with no session gitHead).
+    update(id, { content: "v2 content" });
+    const after = getByLogical(logicalIdOf(id));
+    expect(after?.content).toBe("v2 content");
+    expect(after?.metadata).toEqual({ gitHead: "ccccccc" });
+  });
+
+  test("content-changing update with empty metadata forward-copies (never wipes)", () => {
+    const projectPath = nextProject();
+    const id = create({
+      projectPath,
+      category: "decision",
+      title: "Empty-meta entry",
+      content: "v1 content",
+      scope: "project",
+      metadata: { gitHead: "ddddddd" },
+    });
+    // An empty session metadata must not erase a previously-recorded gitHead.
+    update(id, { content: "v2 content", metadata: {} });
+    const after = getByLogical(logicalIdOf(id));
+    expect(after?.metadata).toEqual({ gitHead: "ddddddd" });
+  });
+
+  test("metric-only update (no content change) leaves metadata untouched", () => {
+    const projectPath = nextProject();
+    const id = create({
+      projectPath,
+      category: "decision",
+      title: "Metric-only entry",
+      content: "stable content",
+      scope: "project",
+      metadata: { gitHead: "eeeeeee" },
+    });
+    // No content change → no new version → metadata stays on the v1 row even
+    // though a fresh gitHead is supplied. Version rows are immutable (A2).
+    update(id, { confidence: 0.9, metadata: { gitHead: "fffffff" } });
+    const after = getByLogical(logicalIdOf(id));
+    expect(after?.metadata).toEqual({ gitHead: "eeeeeee" });
+  });
+
+  test("byte-identical re-observation does not append → metadata untouched", () => {
+    const projectPath = nextProject();
+    const id = create({
+      projectPath,
+      category: "decision",
+      title: "Re-observed entry",
+      content: "unchanged content",
+      scope: "project",
+      metadata: { gitHead: "1111111" },
+    });
+    update(id, {
+      content: "unchanged content",
+      metadata: { gitHead: "2222222" },
+    });
+    const after = getByLogical(logicalIdOf(id));
+    expect(after?.metadata).toEqual({ gitHead: "1111111" });
+  });
+
+  test("remove() stamps the death-cert version with the delete-time gitHead", () => {
+    const projectPath = nextProject();
+    const id = create({
+      projectPath,
+      category: "decision",
+      title: "Doomed entry",
+      content: "about to be deleted",
+      scope: "project",
+      metadata: { gitHead: "3333333" },
+    });
+    const logicalId = logicalIdOf(id);
+    remove(id, { gitHead: "4444444" });
+    // The entry is gone from the live view…
+    expect(getByLogical(logicalId)).toBeNull();
+    // …but the immutable death-cert version records where it was deleted.
+    expect(rawCurrentMetadata(logicalId)).toBe(
+      JSON.stringify({ gitHead: "4444444" }),
+    );
+  });
+
+  test("remove() with no metadata forward-copies the entry's last gitHead", () => {
+    const projectPath = nextProject();
+    const id = create({
+      projectPath,
+      category: "decision",
+      title: "Doomed entry (forward-copy)",
+      content: "about to be deleted",
+      scope: "project",
+      metadata: { gitHead: "5555555" },
+    });
+    const logicalId = logicalIdOf(id);
+    remove(id);
+    expect(rawCurrentMetadata(logicalId)).toBe(
+      JSON.stringify({ gitHead: "5555555" }),
+    );
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #627 **Phase 1** (gitHead capture, PR #977). Phase 1 deliberately
left `ltm.update()`/`ltm.remove()` forward-copying the original **mint-time**
`metadata.gitHead`. This PR refreshes the commit anchor when an entry actually
changes, so provenance tracks the commit a version was **written/confirmed** at —
exactly what staleness detection (#627 Phase 3) wants.

In the append-only knowledge model (A2/#823) every `knowledge` row is an
immutable version: `update()` appends a new version on a content change,
`remove()` appends an `is_deleted` death-certificate version. Previously
`appendVersion()` forward-copied the `metadata` column verbatim.

## What changed

- **`appendVersion()`** gains an optional `metadata` override, applied via
  `COALESCE(?, metadata)`:
  - a non-empty value **stamps the new version**;
  - absent or empty (`{}` → `NULL` via `stringifyMetadata`) **forward-copies**
    the prior version — a caller with no session gitHead (CLI import, dashboard
    delete) never wipes a previously-recorded anchor.
- **`update()`** refreshes metadata **only when a content change appends a
  version**. A metric/sensitivity-only update mutates no version row (A2
  immutability), so the existing gitHead correctly stands.
- **`remove(id, metadata?)`** records the delete-time anchor on the death cert
  (provenance for a future `lore why`); absent → forward-copy.
- **`curator.applyOps`** threads `input.metadata` into the update/delete paths
  (Phase 1 already did so for create).

All other `update`/`remove` callers (`agents-file.ts` import, `data.ts`,
`cli/data.ts`, `ui.ts`) pass no metadata → forward-copy, i.e. no behavior change.

## Testing

- New tests in `ltm-metadata.test.ts` (content-change refresh, absent/empty
  forward-copy, metric-only no-op, byte-identical no-op, remove death-cert
  stamp + forward-copy) and `curator-ops.test.ts` (update/delete wiring).
- **Mutation-verified — 6 mutants, all killed**: appendVersion always-forward-copy (4 tests), update passthrough drop (2), remove param drop (2), curator update/delete wiring (1 each), and a `COALESCE`→bare-`?` mutant killed by the 3 forward-copy guards (proves never-wipe is non-vacuous).
- Full core (2030) + gateway (2218) suites green; affected suites run 3× (no flakiness); typecheck + biome clean.

## Notes / non-blocking followups

- Consolidation-driven content rewrites (`curator.consolidate`) and `.lore.md`
  import carry no commit context, so they forward-copy by design.
- `metadata` is a synced column and part of `content_hash`, but a content edit
  already changes the hash, so refreshing metadata adds **zero** extra sync
  events. Death-cert metadata is local-only (delete pushes by `logical_id`,
  payload carries no metadata).

Refs #627.

🤖 Adversarial correctness review: SHIP-WITH-FOLLOWUPS (no BLOCKERs).