### PR TITLE
feat(gateway): support Claude via Google Vertex AI (#870 part 2)

### DIFF
--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.58.0",
+    "google-auth-library": "^10.9.0",
     "p-limit": "7",
     "qrcode-terminal": "^0.12.0",
     "semver": "^7.7.3",

--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -1897,7 +1897,9 @@ export async function executeWarmup(
   //    (Vertex is not a Claude Code billing endpoint). The session credential
   //    is irrelevant — Vertex auth is the GCP token lore mints.
   //  - Anthropic (default): the session credential + cch re-sign to /v1/messages.
-  const headers: Record<string, string> = { "content-type": "application/json" };
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
   let requestUrl: string;
   let signedBody: string;
 

--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -50,6 +50,7 @@ import { resolveUpstreamRoute } from "./config";
 import { isBedrockMantleHost } from "./translate/bedrock";
 import {
   isVertexHost,
+  toVertexBody,
   toVertexModelId,
   vertexRawPredictUrl,
   vertexRegionFromUrl,
@@ -976,10 +977,26 @@ export function buildVertexProfile(
   upstreamBase: string,
 ): CacheWarmingProfile {
   const region = vertexRegionFromUrl(upstreamBase) ?? "global";
+  const base = buildAnthropicProfile(model, ttl);
   return {
-    ...buildAnthropicProfile(model, ttl),
+    ...base,
     upstreamUrl: `https://${region}-aiplatform.googleapis.com`,
     authMode: "vertex",
+    // prepareAnthropicWarmupBody re-adds `stream:false` and (for billing
+    // sessions) leaves the body shaped for Anthropic. Vertex rejects a body
+    // `stream` field (the URL verb selects streaming) and needs `model` absent
+    // + `anthropic_version` present — so run the prepared body back through the
+    // canonical Vertex transform. The stored body is already the Vertex body,
+    // so this only re-strips the `stream` that prepareWarmupBody re-injected.
+    prepareWarmupBody: (storedBody: string) =>
+      JSON.stringify(
+        toVertexBody(
+          JSON.parse(base.prepareWarmupBody(storedBody)) as Record<
+            string,
+            unknown
+          >,
+        ),
+      ),
   };
 }
 

--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -46,7 +46,7 @@ import { decompressBody } from "./cache-analytics";
 import { resolveAuth, authHeaders, markAuthStale } from "./auth";
 import { recordWorkerFailure, recordWorkerSuccess } from "./worker-health";
 import { resignBody } from "./cch";
-import { resolveUpstreamRoute } from "./config";
+import { loadConfig, resolveUpstreamRoute } from "./config";
 import { isBedrockMantleHost } from "./translate/bedrock";
 import {
   isVertexHost,
@@ -1925,7 +1925,12 @@ export async function executeWarmup(
     if (!model) return noResult;
     const region = vertexRegionFromUrl(profile.upstreamUrl) ?? "global";
     try {
-      const project = await resolveVertexProject("");
+      // Thread the configured project (LORE_VERTEX_PROJECT / GOOGLE_CLOUD_PROJECT)
+      // explicitly: after a restart the warmer can fire before any live
+      // conversation turn has populated resolveVertexProject's cache, and ADC's
+      // getProjectId() does NOT see LORE_VERTEX_PROJECT — so passing "" here
+      // would skip warmups ("no GCP project") for LORE_VERTEX_PROJECT-only users.
+      const project = await resolveVertexProject(loadConfig().vertexProject);
       if (!project) {
         log.warn(
           `cache-warmer: no GCP project for vertex session=${state.sessionID.slice(0, 16)}, skipping`,

--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -52,6 +52,7 @@ import {
   isVertexHost,
   toVertexBody,
   toVertexModelId,
+  vertexHost,
   vertexRawPredictUrl,
   vertexRegionFromUrl,
 } from "./translate/vertex";
@@ -980,7 +981,7 @@ export function buildVertexProfile(
   const base = buildAnthropicProfile(model, ttl);
   return {
     ...base,
-    upstreamUrl: `https://${region}-aiplatform.googleapis.com`,
+    upstreamUrl: `https://${vertexHost(region)}`,
     authMode: "vertex",
     // prepareAnthropicWarmupBody re-adds `stream:false` and (for billing
     // sessions) leaves the body shaped for Anthropic. Vertex rejects a body

--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -48,6 +48,13 @@ import { recordWorkerFailure, recordWorkerSuccess } from "./worker-health";
 import { resignBody } from "./cch";
 import { resolveUpstreamRoute } from "./config";
 import { isBedrockMantleHost } from "./translate/bedrock";
+import {
+  isVertexHost,
+  toVertexModelId,
+  vertexRawPredictUrl,
+  vertexRegionFromUrl,
+} from "./translate/vertex";
+import { getVertexAccessToken, resolveVertexProject } from "./vertex-auth";
 import { getModelEntrySync, getWorkerModel } from "./worker-model";
 import { recordWarmupCost } from "./cost-tracker";
 import { upstreamFetch } from "./fetch";
@@ -831,8 +838,13 @@ export type CacheWarmingProfile = {
   warmupMarginMs: number;
   /** Prepare the stored body for a warmup request. */
   prepareWarmupBody: (storedBody: string) => string;
-  /** Upstream URL to send the warmup to. */
+  /** Upstream URL to send the warmup to. For Vertex (authMode "vertex") this is
+   *  the region BASE host (`https://{region}-aiplatform.googleapis.com`);
+   *  executeWarmup rebuilds the per-model `:rawPredict` URL from it. */
   upstreamUrl: string;
+  /** Auth/transport mode. Default (undefined) = Anthropic: session credential +
+   *  cch re-sign. "vertex" = GCP OAuth2 bearer (ADC), no cch, rawPredict URL. */
+  authMode?: "vertex";
 };
 
 /**
@@ -950,6 +962,28 @@ export function buildAnthropicProfile(
 }
 
 /**
+ * Build a warming profile for a Google Vertex AI (Claude) session. Vertex
+ * supports Anthropic prompt caching, and warming hits the SESSION's own Vertex
+ * host with lore's GCP credentials (the same auth real turns use), so it is
+ * safe to warm (unlike foreign anthropic-compat hosts). Pricing reuses the
+ * Anthropic profile (Vertex Claude pricing tracks the Anthropic API). The
+ * stored `upstreamUrl` is the region base — executeWarmup rebuilds the
+ * per-model `:rawPredict` URL and attaches the OAuth2 bearer.
+ */
+export function buildVertexProfile(
+  model: string,
+  ttl: "5m" | "1h",
+  upstreamBase: string,
+): CacheWarmingProfile {
+  const region = vertexRegionFromUrl(upstreamBase) ?? "global";
+  return {
+    ...buildAnthropicProfile(model, ttl),
+    upstreamUrl: `https://${region}-aiplatform.googleapis.com`,
+    authMode: "vertex",
+  };
+}
+
+/**
  * True only for Anthropic's first-party API host. Anthropic-compatible
  * providers (MiniMax `api.minimax.io/anthropic`, Fireworks, Kimi, …) report
  * `protocol:"anthropic"` but do NOT support Anthropic prompt-cache warming and
@@ -978,6 +1012,17 @@ export function resolveProfile(
   providerID?: string,
 ): CacheWarmingProfile | null {
   if (!model || !protocol) return null;
+
+  // Google Vertex AI (Claude): supports Anthropic prompt caching. The warmup
+  // hits the session's own Vertex host with lore's GCP credentials, so it is
+  // always safe to warm (no foreign-key-to-anthropic.com hazard). Detected by
+  // the explicit vertex provider id OR a vertex aiplatform host.
+  if (protocol === "vertex") {
+    const vRoute = resolveUpstreamRoute(model);
+    const vHost = upstreamBase || vRoute?.url;
+    if (!vHost || !isVertexHost(vHost)) return null;
+    return buildVertexProfile(model, ttl ?? "5m", vHost);
+  }
 
   // Only Anthropic protocol for now — OpenAI has automatic prefix caching with
   // no explicit warming API. (Bedrock rides the anthropic protocol via mantle.)
@@ -1846,42 +1891,87 @@ export async function executeWarmup(
   // Prepare for warmup (max_tokens:0, strip incompatible fields)
   const warmupBody = profile.prepareWarmupBody(storedBody);
 
-  // Resolve auth for this session — use the provider from lastUpstream
-  // to avoid cross-contamination when the session uses multiple providers.
-  const cred = resolveAuth(state.sessionID, state.lastUpstream?.providerID);
-  if (!cred) {
-    log.warn(
-      `cache-warmer: no auth for session=${state.sessionID.slice(0, 16)}, skipping`,
-    );
-    recordWorkerFailure(state.sessionID, "cache-warmer", "no-auth");
-    return noResult;
+  // Build URL + headers + body. Two modes:
+  //  - Vertex (authMode "vertex"): GCP OAuth2 bearer (ADC), a per-model
+  //    :rawPredict URL rebuilt from the region base, and NO cch re-sign
+  //    (Vertex is not a Claude Code billing endpoint). The session credential
+  //    is irrelevant — Vertex auth is the GCP token lore mints.
+  //  - Anthropic (default): the session credential + cch re-sign to /v1/messages.
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  let requestUrl: string;
+  let signedBody: string;
+
+  if (profile.authMode === "vertex") {
+    const model = state.lastUpstream?.model;
+    if (!model) return noResult;
+    const region = vertexRegionFromUrl(profile.upstreamUrl) ?? "global";
+    try {
+      const project = await resolveVertexProject("");
+      if (!project) {
+        log.warn(
+          `cache-warmer: no GCP project for vertex session=${state.sessionID.slice(0, 16)}, skipping`,
+        );
+        recordWorkerFailure(state.sessionID, "cache-warmer", "no-auth");
+        return noResult;
+      }
+      const token = await getVertexAccessToken();
+      headers.Authorization = `Bearer ${token}`;
+      requestUrl = vertexRawPredictUrl(
+        region,
+        project,
+        toVertexModelId(model),
+        false,
+      );
+    } catch (err) {
+      // ADC unavailable / token mint failed — skip this tick rather than
+      // crashing the warmer loop. Telemetry must never break the idle loop.
+      log.warn(
+        `cache-warmer: vertex auth failed for session=${state.sessionID.slice(0, 16)}: ${(err as Error).message}`,
+      );
+      recordWorkerFailure(state.sessionID, "cache-warmer", "no-auth");
+      return noResult;
+    }
+    // No cch re-sign for Vertex (no billing header) — send the warmup as-is.
+    signedBody = warmupBody;
+    // Apply user-supplied LORE_UPSTREAM_EXTRA_HEADERS as the final overlay.
+    for (const [key, value] of Object.entries(upstreamExtraHeaders)) {
+      headers[key] = value;
+    }
+  } else {
+    // Resolve auth for this session — use the provider from lastUpstream
+    // to avoid cross-contamination when the session uses multiple providers.
+    const cred = resolveAuth(state.sessionID, state.lastUpstream?.providerID);
+    if (!cred) {
+      log.warn(
+        `cache-warmer: no auth for session=${state.sessionID.slice(0, 16)}, skipping`,
+      );
+      recordWorkerFailure(state.sessionID, "cache-warmer", "no-auth");
+      return noResult;
+    }
+    headers["anthropic-version"] = "2023-06-01";
+    Object.assign(headers, authHeaders(cred));
+
+    // Forward anthropic-beta from the last real request so beta-gated body
+    // fields (e.g. context_management) are accepted by the upstream API.
+    const betaHeader = state.lastUpstream?.headers["anthropic-beta"];
+    if (betaHeader) {
+      headers["anthropic-beta"] = betaHeader;
+    }
+
+    // Apply user-supplied LORE_UPSTREAM_EXTRA_HEADERS as the final overlay so
+    // corporate-proxy / LiteLLM / Cloudflare AI Gateway / service-account
+    // scenarios work for cache-warming calls too.
+    for (const [key, value] of Object.entries(upstreamExtraHeaders)) {
+      headers[key] = value;
+    }
+
+    // Re-sign the cch billing header. The cch hash covers the entire
+    // serialized body, and we changed max_tokens/stream. The cch is
+    // billing verification only — NOT part of the cache key.
+    const firstUserText = extractFirstUserText(storedBody);
+    signedBody = resignBody(warmupBody, firstUserText);
+    requestUrl = profile.upstreamUrl;
   }
-
-  const headers: Record<string, string> = {
-    "content-type": "application/json",
-    "anthropic-version": "2023-06-01",
-    ...authHeaders(cred),
-  };
-
-  // Forward anthropic-beta from the last real request so beta-gated body
-  // fields (e.g. context_management) are accepted by the upstream API.
-  const betaHeader = state.lastUpstream?.headers["anthropic-beta"];
-  if (betaHeader) {
-    headers["anthropic-beta"] = betaHeader;
-  }
-
-  // Apply user-supplied LORE_UPSTREAM_EXTRA_HEADERS as the final overlay so
-  // corporate-proxy / LiteLLM / Cloudflare AI Gateway / service-account
-  // scenarios work for cache-warming calls too.
-  for (const [key, value] of Object.entries(upstreamExtraHeaders)) {
-    headers[key] = value;
-  }
-
-  // Re-sign the cch billing header. The cch hash covers the entire
-  // serialized body, and we changed max_tokens/stream. The cch is
-  // billing verification only — NOT part of the cache key.
-  const firstUserText = extractFirstUserText(storedBody);
-  const signedBody = resignBody(warmupBody, firstUserText);
 
   log.info(
     `cache-warmer: sending warmup for session=${state.sessionID.slice(0, 16)} ` +
@@ -1889,7 +1979,7 @@ export async function executeWarmup(
   );
 
   try {
-    const response = await upstreamFetch(profile.upstreamUrl, {
+    const response = await upstreamFetch(requestUrl, {
       method: "POST",
       headers,
       body: signedBody,

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -48,9 +48,11 @@ export interface GatewayConfig {
   /** AWS Bedrock region (selects the bedrock-mantle endpoint). Default: from
    *  AWS_REGION/AWS_DEFAULT_REGION env or "us-east-1". */
   bedrockRegion: string;
-  /** Google Vertex AI project ID. Required. From GOOGLE_CLOUD_PROJECT env. */
+  /** Google Vertex AI project ID. From GOOGLE_CLOUD_PROJECT env; when empty it
+   *  is derived from Application Default Credentials at request time. */
   vertexProject: string;
-  /** Google Vertex AI region. Default: from GOOGLE_CLOUD_REGION/GOOGLE_CLOUD_LOCATION env or "us-central1" */
+  /** Google Vertex AI region/endpoint. Default "global" (the recommended global
+   *  endpoint — no regional premium). From GOOGLE_CLOUD_REGION/GOOGLE_CLOUD_LOCATION env. */
   vertexRegion: string;
   /** Idle timeout in seconds before triggering background work. Default: 60 */
   idleTimeoutSeconds: number;
@@ -220,7 +222,7 @@ export function loadConfig(): GatewayConfig {
       env.LORE_VERTEX_REGION ??
       env.GOOGLE_CLOUD_REGION ??
       env.GOOGLE_CLOUD_LOCATION ??
-      "us-central1",
+      "global",
     // Hosted mode is always a remote gateway (no shared filesystem with clients).
     // Auto-detect from bind address when neither flag is explicitly set.
     remoteGateway: remoteGatewayEnv || hostedModeEnv || autoDetected,
@@ -501,14 +503,24 @@ const PROVIDER_ROUTES: Record<string, ProviderRoute> = {
     protocol: "anthropic",
     bedrockMantle: true,
   },
-  // --- Google Vertex AI ---
-  // NOTE: Vertex AI support is part 2 of issue #870 and is NOT yet implemented.
-  // The vertex protocol is registered in the type system for forward compatibility,
-  // but PROVIDER_ROUTES deliberately does NOT include vertex/vertex-anthropic
-  // entries. Adding them here would let X-Lore-Provider: vertex requests reach
-  // forwardToUpstream and fall through to the default Anthropic handler (wrong
-  // auth + wrong body), silently breaking requests. The entries will be added
-  // when the Vertex handler lands in part 2.
+  // --- Google Vertex AI (Claude via :rawPredict, GCP OAuth2/ADC) ---
+  // url is null because the region-specific Vertex URL is built at request time
+  // (`{region}-aiplatform.googleapis.com/.../publishers/anthropic/models/…`).
+  // The `vertex` protocol triggers pipeline.ts's self-URL-building branch (like
+  // bedrock-mantle) — it must NOT fall through to the Anthropic handler.
+  // `google-vertex` / `google-vertex-anthropic` are opencode's provider ids.
+  vertex: {
+    url: null,
+    protocol: "vertex",
+  },
+  "google-vertex": {
+    url: null,
+    protocol: "vertex",
+  },
+  "google-vertex-anthropic": {
+    url: null,
+    protocol: "vertex",
+  },
 };
 
 /**

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -1081,16 +1081,6 @@ export function createGatewayLLMClient(
         return null;
       }
 
-      const cred = getAuth(opts?.sessionID, model.providerID);
-      if (!cred) {
-        log.warn("no auth credentials available for worker call");
-        recordWorkerFailure(
-          opts?.sessionID ?? "_unknown",
-          opts?.workerID ?? "unknown",
-          "no-auth",
-        );
-        return null;
-      }
       const upstreamOverride = opts?.upstreamUrl;
       // The explicit protocol hint comes from the SESSION's upstream. Only
       // honor it when the worker model belongs to the same provider as the
@@ -1106,6 +1096,30 @@ export function createGatewayLLMClient(
         model.providerID,
         sameProviderAsSession ? opts?.protocol : undefined,
       );
+
+      // Vertex authenticates with lore's own GCP OAuth2 bearer token (minted
+      // inside buildVertexWorkerRequest); the client credential is IGNORED on
+      // the wire. A Vertex client legitimately sends NO key — the
+      // gateway-holds-credentials model, identical to the conversation and
+      // warmer paths — so we must NOT fail-closed on a missing client
+      // credential for the vertex worker path (doing so silently disabled ALL
+      // background distillation/curation for such sessions). Synthesize a
+      // placeholder so the shared worker pipeline proceeds; it is never sent
+      // upstream (the vertex builder constructs its own headers and ignores it).
+      const cred =
+        getAuth(opts?.sessionID, model.providerID) ??
+        (protocol === "vertex"
+          ? ({ scheme: "bearer", value: "" } as AuthCredential)
+          : null);
+      if (!cred) {
+        log.warn("no auth credentials available for worker call");
+        recordWorkerFailure(
+          opts?.sessionID ?? "_unknown",
+          opts?.workerID ?? "unknown",
+          "no-auth",
+        );
+        return null;
+      }
       const target = resolveTarget(
         upstreams,
         protocol,

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -43,6 +43,13 @@ import { upstreamFetch } from "./fetch";
 import { extractJSONFromSSE } from "./translate/types";
 import { isBedrockMantleHost, toMantleModelId } from "./translate/bedrock";
 import {
+  toVertexBody,
+  toVertexModelId,
+  vertexRawPredictUrl,
+  vertexRegionFromUrl,
+} from "./translate/vertex";
+import { getVertexAccessToken, resolveVertexProject } from "./vertex-auth";
+import {
   recordWorkerFailure,
   markWorkerPaused,
   isWorkerIncapable,
@@ -317,7 +324,11 @@ export function normalizeOpenAIUsage(
  * `/backend-api` serves ONLY the Responses API (`/codex/responses`), so it gets
  * a dedicated `"openai-codex-responses"` worker protocol that speaks Responses.
  */
-type WorkerProtocol = "anthropic" | "openai" | "openai-codex-responses";
+type WorkerProtocol =
+  | "anthropic"
+  | "openai"
+  | "openai-codex-responses"
+  | "vertex";
 
 /** Upstream URL, wire protocol, and provider label for a resolved target. */
 type ProviderTarget = {
@@ -352,23 +363,22 @@ export function resolveWorkerProtocol(
   }
   // 1. Explicit protocol from caller (threaded from UpstreamSnapshot)
   if (explicit) {
-    // Vertex collapses to "anthropic" for worker calls (same wire shape).
-    // NOTE: AWS Bedrock is NOT a distinct worker protocol — it is reached via
-    // the bedrock-mantle endpoint, whose snapshot protocol is already
-    // "anthropic" (the provider route carries `bedrockMantle: true`, protocol
-    // "anthropic"). Bedrock worker calls therefore route to the session's
-    // mantle upstream over the normal Anthropic path with the client's Bedrock
-    // API key — no SigV4, no separate LORE_WORKER_UPSTREAM workaround.
-    return explicit === "anthropic" || explicit === "vertex"
-      ? "anthropic"
-      : "openai";
+    // Vertex is a DISTINCT worker protocol: it speaks the Anthropic Messages
+    // body but to a :rawPredict URL (model in the path) authenticated with a
+    // GCP OAuth2 token — buildVertexWorkerRequest handles all three. It must
+    // NOT collapse to "anthropic" (that would POST to /v1/messages with an
+    // x-api-key). NOTE: AWS Bedrock is NOT a distinct worker protocol — it is
+    // reached via the bedrock-mantle endpoint, whose snapshot protocol is
+    // already "anthropic" (route carries `bedrockMantle: true`), so Bedrock
+    // worker calls route to the mantle upstream over the normal Anthropic path.
+    if (explicit === "vertex") return "vertex";
+    return explicit === "anthropic" ? "anthropic" : "openai";
   }
   // 2. Route table lookup
   const route = resolveProviderRoute(providerID);
   if (route?.protocol) {
-    return route.protocol === "anthropic" || route.protocol === "vertex"
-      ? "anthropic"
-      : "openai";
+    if (route.protocol === "vertex") return "vertex";
+    return route.protocol === "anthropic" ? "anthropic" : "openai";
   }
   // 3. Default: anthropic (safest for unknown/aggregator providers)
   return "anthropic";
@@ -799,10 +809,73 @@ function parseResponsesWorkerResponse(data: {
 }
 
 /**
+ * Build a Google Vertex AI (Claude) worker request: an Anthropic Messages body
+ * POSTed to the `:rawPredict` URL (model in the path, non-streaming) and
+ * authenticated with a GCP OAuth2 bearer token (ADC). Async because minting the
+ * token and resolving the project are async.
+ *
+ * The region is read from the session's vertex base URL (`target.url`, the
+ * authoritative endpoint); the project prefers the threaded config value, else
+ * derives from ADC. No client credential reaches the wire — Vertex auth is the
+ * GCP token, so `cred` is intentionally ignored. No billing block (Vertex is
+ * not a Claude Code billing endpoint).
+ */
+async function buildVertexWorkerRequest(
+  target: ProviderTarget,
+  model: { providerID: string; modelID: string },
+  system: string,
+  user: string,
+  maxTokens: number,
+  vertexProject?: string,
+  temperature?: number,
+): Promise<{ url: string; headers: Record<string, string>; body: string }> {
+  const region = vertexRegionFromUrl(target.url) ?? "global";
+  const project = await resolveVertexProject(vertexProject ?? "");
+  if (!project) {
+    throw new Error(
+      "Vertex worker: no GCP project. Set GOOGLE_CLOUD_PROJECT (or " +
+        "LORE_VERTEX_PROJECT), or ensure Application Default Credentials " +
+        "provide a project.",
+    );
+  }
+  const vertexModel = toVertexModelId(model.modelID);
+  const token = await getVertexAccessToken();
+  // Worker system prompt is static across bursts → cache it. Use bare ephemeral
+  // (5m) rather than the 1h extended-ttl beta of uncertain Vertex support.
+  const systemBlocks = system
+    ? [
+        {
+          type: "text" as const,
+          text: system,
+          cache_control: { type: "ephemeral" as const },
+        },
+      ]
+    : undefined;
+  const body = JSON.stringify(
+    toVertexBody({
+      max_tokens: maxTokens,
+      ...(temperature != null && { temperature }),
+      system: systemBlocks,
+      messages: [{ role: "user", content: user }],
+    }),
+  );
+  return {
+    url: vertexRawPredictUrl(region, project, vertexModel, false),
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body,
+  };
+}
+
+/**
  * Dispatch to the correct worker request builder for a resolved target.
  * Single source of truth so adding a protocol touches exactly one place.
+ * Async: the Vertex builder mints a GCP OAuth2 token; the other builders are
+ * synchronous and resolve immediately.
  */
-function buildWorkerRequest(
+async function buildWorkerRequest(
   target: ProviderTarget,
   cred: AuthCredential,
   model: { providerID: string; modelID: string },
@@ -811,7 +884,8 @@ function buildWorkerRequest(
   maxTokens: number,
   sessionID?: string,
   temperature?: number,
-): { url: string; headers: Record<string, string>; body: string } {
+  vertexProject?: string,
+): Promise<{ url: string; headers: Record<string, string>; body: string }> {
   switch (target.protocol) {
     case "openai-codex-responses":
       // Codex omits max_output_tokens (rejected by ChatGPT) — no maxTokens arg.
@@ -832,6 +906,16 @@ function buildWorkerRequest(
         system,
         user,
         maxTokens,
+        temperature,
+      );
+    case "vertex":
+      return buildVertexWorkerRequest(
+        target,
+        model,
+        system,
+        user,
+        maxTokens,
+        vertexProject,
         temperature,
       );
     default:
@@ -979,9 +1063,13 @@ export function createGatewayLLMClient(
   upstreams: { anthropic: string; openai: string },
   getAuth: (sessionID?: string, providerID?: string) => AuthCredential | null,
   defaultModel: { providerID: string; modelID: string },
-  opts?: { dedicatedWorkerKey?: boolean },
+  opts?: { dedicatedWorkerKey?: boolean; vertexProject?: string },
 ): LLMClient {
   const hasDedicatedKey = opts?.dedicatedWorkerKey === true;
+  // Configured GCP project for Vertex workers (else derived from ADC at call
+  // time). Threaded so an explicit LORE_VERTEX_PROJECT (without GOOGLE_CLOUD_*)
+  // is honored — the session base URL carries the region but never the project.
+  const factoryVertexProject = opts?.vertexProject;
   return {
     async prompt(system, user, opts) {
       const model = opts?.model ?? defaultModel;
@@ -1100,7 +1188,7 @@ export function createGatewayLLMClient(
       }
 
       // Build protocol-specific request
-      let req = buildWorkerRequest(
+      let req = await buildWorkerRequest(
         target,
         cred,
         model,
@@ -1109,6 +1197,7 @@ export function createGatewayLLMClient(
         maxTokens,
         opts?.sessionID,
         opts?.temperature,
+        factoryVertexProject,
       );
 
       // Track this call so temporal capture can skip it
@@ -1422,7 +1511,7 @@ export function createGatewayLLMClient(
                   log.info(
                     `worker auth error ${response.status}, credential refreshed — retrying: ${text.slice(0, 200)}`,
                   );
-                  req = buildWorkerRequest(
+                  req = await buildWorkerRequest(
                     target,
                     freshCred,
                     model,
@@ -1431,6 +1520,7 @@ export function createGatewayLLMClient(
                     maxTokens,
                     opts?.sessionID,
                     opts?.temperature,
+                    factoryVertexProject,
                   );
                   retryCount++;
                   continue;

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -861,6 +861,12 @@ async function buildVertexWorkerRequest(
   );
   return {
     url: vertexRawPredictUrl(region, project, vertexModel, false),
+    // The documented Vertex rawPredict header set is exactly these two (see
+    // https://docs.claude.com/en/api/claude-on-vertex-ai). NEVER add
+    // `anthropic-beta` here: it's an api.anthropic.com-only header. Worker
+    // prompt caching is driven by the cache_control block on `systemBlocks`
+    // above (a GA Vertex feature), NOT a beta header — so its absence does not
+    // disable caching, while forwarding it would risk a Vertex 400.
     headers: {
       "Content-Type": "application/json",
       Authorization: `Bearer ${token}`,

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -144,6 +144,12 @@ import {
   toMantleModelId,
 } from "./translate/bedrock";
 import {
+  toVertexBody,
+  toVertexModelId,
+  vertexRawPredictUrl,
+} from "./translate/vertex";
+import { getVertexAccessToken, resolveVertexProject } from "./vertex-auth";
+import {
   buildOpenAIUpstreamRequest,
   buildOpenAIResponse,
 } from "./translate/openai";
@@ -3406,14 +3412,43 @@ async function forwardToUpstream(
     headers = result.headers;
     body = result.body;
   } else if (effectiveProtocol === "vertex") {
-    // Vertex AI is part 2 of issue #870 and has no upstream builder yet. Fail
-    // LOUD rather than silently falling through to the Anthropic builder below
-    // (which would POST Anthropic-shaped, x-api-key-authed requests to a Vertex
-    // URL). No PROVIDER_ROUTES entry produces "vertex" today, so this is a
-    // forward guard for when the route lands without its handler.
-    throw new Error(
-      "Vertex AI upstream is not yet implemented (issue #870 part 2)",
+    // Google Vertex AI (Claude): the native Anthropic Messages API over GCP
+    // OAuth2. Reuse buildAnthropicRequest (incl. cache_control), then apply the
+    // three Vertex transforms — model id in the URL path (+ the :rawPredict vs
+    // :streamRawPredict verb selects streaming), `anthropic_version` in the body
+    // (toVertexBody), and a GCP bearer token for auth (replacing the client
+    // x-api-key). The 1h extended-cache-ttl is an Anthropic beta of uncertain
+    // Vertex support, so downgrade to 5m — the same safe default used for other
+    // non-native Anthropic hosts (mantle / MiniMax / Fireworks).
+    const effectiveCache = cache
+      ? { ...cache, systemTTL: "5m" as const, conversationTTL: "5m" as const }
+      : cache;
+    const result = buildAnthropicRequest(req, effectiveCache);
+
+    const project = await resolveVertexProject(config.vertexProject);
+    if (!project) {
+      throw new Error(
+        "Vertex: no GCP project configured. Set GOOGLE_CLOUD_PROJECT (or " +
+          "LORE_VERTEX_PROJECT), or ensure Application Default Credentials " +
+          "provide a project.",
+      );
+    }
+    url = vertexRawPredictUrl(
+      config.vertexRegion,
+      project,
+      toVertexModelId(req.model),
+      req.stream,
     );
+    body = toVertexBody(result.body as Record<string, unknown>);
+    // Auth: GCP OAuth2 bearer (ADC) replaces the client credential. Drop the
+    // x-api-key and the anthropic-version HTTP header (version is in the body
+    // now). cch billing re-signing is gated on effectiveProtocol==="anthropic"
+    // below, so it never fires for Vertex.
+    const token = await getVertexAccessToken();
+    headers = { ...result.headers };
+    delete headers["x-api-key"];
+    delete headers["anthropic-version"];
+    headers.Authorization = `Bearer ${token}`;
   } else {
     // For non-native-Anthropic upstreams (MiniMax, Fireworks, etc.), downgrade
     // extended cache TTL ("1h") to standard 5-minute ephemeral — the "1h" TTL

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -2084,7 +2084,10 @@ function getLLMClient(config: GatewayConfig): LLMClient {
       workerUpstreams,
       getWorkerAuth,
       defaultModel,
-      { dedicatedWorkerKey: !!workerApiKey, vertexProject: config.vertexProject },
+      {
+        dedicatedWorkerKey: !!workerApiKey,
+        vertexProject: config.vertexProject,
+      },
     );
 
     // Workers always use the same provider as the session. Route worker

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -2084,7 +2084,7 @@ function getLLMClient(config: GatewayConfig): LLMClient {
       workerUpstreams,
       getWorkerAuth,
       defaultModel,
-      { dedicatedWorkerKey: !!workerApiKey },
+      { dedicatedWorkerKey: !!workerApiKey, vertexProject: config.vertexProject },
     );
 
     // Workers always use the same provider as the session. Route worker

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -143,12 +143,7 @@ import {
   isBedrockMantleDispatch,
   toMantleModelId,
 } from "./translate/bedrock";
-import {
-  toVertexBody,
-  toVertexModelId,
-  vertexHost,
-  vertexRawPredictUrl,
-} from "./translate/vertex";
+import { buildVertexUpstream, vertexHost } from "./translate/vertex";
 import { getVertexAccessToken, resolveVertexProject } from "./vertex-auth";
 import {
   buildOpenAIUpstreamRequest,
@@ -3437,22 +3432,26 @@ async function forwardToUpstream(
           "provide a project.",
       );
     }
-    url = vertexRawPredictUrl(
-      config.vertexRegion,
-      project,
-      toVertexModelId(req.model),
-      req.stream,
-    );
-    body = toVertexBody(result.body as Record<string, unknown>);
-    // Auth: GCP OAuth2 bearer (ADC) replaces the client credential. Drop the
-    // x-api-key and the anthropic-version HTTP header (version is in the body
-    // now). cch billing re-signing is gated on effectiveProtocol==="anthropic"
-    // below, so it never fires for Vertex.
+    // Auth: GCP OAuth2 bearer (ADC) replaces the client credential. cch billing
+    // re-signing is gated on effectiveProtocol==="anthropic" below, so it never
+    // fires for Vertex. The transport rewrite (region from an X-Lore-Upstream-URL
+    // override else config, rawPredict URL, toVertexBody, and stripping the
+    // api.anthropic.com-only headers + setting the bearer) is a pure helper so
+    // it can be unit-tested in isolation — see buildVertexUpstream.
     const token = await getVertexAccessToken();
-    headers = { ...result.headers };
-    delete headers["x-api-key"];
-    delete headers["anthropic-version"];
-    headers.Authorization = `Bearer ${token}`;
+    const vt = buildVertexUpstream({
+      anthropicHeaders: result.headers,
+      anthropicBody: result.body as Record<string, unknown>,
+      effectiveUpstreamBase,
+      configRegion: config.vertexRegion,
+      project,
+      model: req.model,
+      stream: req.stream,
+      token,
+    });
+    url = vt.url;
+    headers = vt.headers;
+    body = vt.body;
   } else {
     // For non-native-Anthropic upstreams (MiniMax, Fireworks, etc.), downgrade
     // extended cache TTL ("1h") to standard 5-minute ephemeral — the "1h" TTL

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -146,6 +146,7 @@ import {
 import {
   toVertexBody,
   toVertexModelId,
+  vertexHost,
   vertexRawPredictUrl,
 } from "./translate/vertex";
 import { getVertexAccessToken, resolveVertexProject } from "./vertex-auth";
@@ -3327,7 +3328,7 @@ async function forwardToUpstream(
   const selfBuiltUpstreamUrl = bedrockMantle
     ? bedrockMantleUrl(config.bedrockRegion)
     : effectiveProtocol === "vertex"
-      ? `https://${config.vertexRegion}-aiplatform.googleapis.com`
+      ? `https://${vertexHost(config.vertexRegion)}`
       : null;
   const effectiveUpstreamBase =
     headerUpstream ??
@@ -4901,7 +4902,7 @@ function postResponse(
     const lpSelfBuiltUrl = lpBedrockMantle
       ? bedrockMantleUrl(config.bedrockRegion)
       : snapshotProtocol === "vertex"
-        ? `https://${config.vertexRegion}-aiplatform.googleapis.com`
+        ? `https://${vertexHost(config.vertexRegion)}`
         : null;
 
     const upstreamSnapshot: UpstreamSnapshot = {

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -5794,10 +5794,21 @@ async function handlePassthrough(
   const { response: upstreamResponse, effectiveProtocol } =
     await forwardToUpstream(req, config);
 
+  // Vertex speaks the native Anthropic wire format (Anthropic SSE for streaming
+  // and the native Anthropic JSON shape for non-streaming), so for passthrough
+  // routing it is wire-equivalent to "anthropic". Without this mapping a
+  // streaming meta request (title-gen/summary) on a Vertex session would take
+  // the cross-protocol branch below and get drained through extractJSONFromSSE,
+  // which returns only the last SSE data line ({"type":"message_stop"}) → an
+  // EMPTY response. Collapse vertex→anthropic here so a same-wire client
+  // (anthropic) streams through unchanged.
+  const wireProtocol: typeof effectiveProtocol =
+    effectiveProtocol === "vertex" ? "anthropic" : effectiveProtocol;
+
   // When upstream and client use the same protocol, pass through unchanged.
   // Cross-protocol translation is only needed when provider routing maps
   // to a different protocol (e.g., OpenAI client → Anthropic upstream).
-  if (effectiveProtocol === req.protocol) {
+  if (wireProtocol === req.protocol) {
     if (req.stream && upstreamResponse.body) {
       return new Response(upstreamResponse.body, {
         status: upstreamResponse.status,
@@ -5818,8 +5829,8 @@ async function handlePassthrough(
   // client's wire format (reuses the same translation infrastructure as
   // conversation turns).
   if (req.stream && upstreamResponse.body) {
-    if (effectiveProtocol === "anthropic") {
-      // Anthropic SSE upstream → translate to client's format
+    if (wireProtocol === "anthropic") {
+      // Anthropic SSE upstream (incl. Vertex) → translate to client's format
       const anthropicSSE = new Response(upstreamResponse.body, {
         status: upstreamResponse.status,
         headers: {
@@ -5838,7 +5849,7 @@ async function handlePassthrough(
     // Other cross-protocol streaming combos: accumulate + re-emit
     const resp = await accumulateNonStreamResponse(
       upstreamResponse,
-      effectiveProtocol,
+      wireProtocol,
     );
     return nonStreamHttpResponse(resp, req.protocol, req.stream);
   }
@@ -5846,7 +5857,7 @@ async function handlePassthrough(
   // Non-streaming cross-protocol: accumulate + re-emit
   const resp = await accumulateNonStreamResponse(
     upstreamResponse,
-    effectiveProtocol,
+    wireProtocol,
   );
   return nonStreamHttpResponse(resp, req.protocol, req.stream);
 }

--- a/packages/gateway/src/translate/vertex.ts
+++ b/packages/gateway/src/translate/vertex.ts
@@ -71,7 +71,14 @@ export function vertexRawPredictUrl(
   stream: boolean,
 ): string {
   const verb = stream ? "streamRawPredict" : "rawPredict";
-  const encodedModel = encodeURIComponent(model);
+  // Encode the model id for safe path use, but PRESERVE a literal "@": Vertex
+  // model ids carry an "@YYYYMMDD" date suffix, and every published Vertex
+  // example (and Google's own SDK) puts the unencoded "@" in the path — it is a
+  // valid RFC 3986 `pchar`, so no encoding is required. Emitting "%40" instead
+  // risks a 404 on every dated model id; the literal "@" is the doc-matching,
+  // round-trip-safe form. (`encodeURIComponent` would otherwise turn "@"→"%40";
+  // nothing else in a Claude model id needs encoding.)
+  const encodedModel = encodeURIComponent(model).replace(/%40/g, "@");
   return `https://${region}-aiplatform.googleapis.com/v1/projects/${project}/locations/${region}/publishers/anthropic/models/${encodedModel}:${verb}`;
 }
 

--- a/packages/gateway/src/translate/vertex.ts
+++ b/packages/gateway/src/translate/vertex.ts
@@ -1,0 +1,121 @@
+/**
+ * Google Vertex AI (Claude) ↔ Gateway translation helpers.
+ *
+ * Claude on Vertex speaks the native Anthropic Messages API with three
+ * differences from `api.anthropic.com` (see
+ * https://docs.claude.com/en/api/claude-on-vertex-ai):
+ *   1. the model id is in the URL path (NOT the body);
+ *   2. `anthropic_version: "vertex-2023-10-16"` goes in the BODY (not a header);
+ *   3. streaming vs non-streaming is selected by the URL verb
+ *      (`:streamRawPredict` vs `:rawPredict`), NOT a body `stream` field.
+ *
+ * Auth is GCP OAuth2 (Application Default Credentials) — see vertex-auth.ts.
+ * The streaming wire format is plain Anthropic SSE and the non-streaming
+ * response is the native Anthropic JSON shape, so both reuse the existing
+ * Anthropic parsers — Vertex needs only the URL build, the body transform, and
+ * the model-id remap below.
+ */
+
+/** Body field carrying the Vertex API version (replaces the HTTP header). */
+export const VERTEX_ANTHROPIC_VERSION = "vertex-2023-10-16";
+
+/**
+ * Explicit client-model → Vertex-model-id overrides for models whose Vertex id
+ * is NOT simply the client id. Sourced from the "Vertex AI API model ID" column
+ * of https://docs.claude.com/en/api/claude-on-vertex-ai — Vertex pins some
+ * models to a dated id (`@YYYYMMDD`) while the client sends the short id.
+ * Newest models (opus-4-8/4-7/4-6, sonnet-4-6, fable-5) use the short id on
+ * Vertex too and pass through. Verified against the published table; revisit
+ * once we have live Vertex access to confirm exact strings.
+ */
+const VERTEX_MODEL_ALIASES: Record<string, string> = {
+  "claude-haiku-4-5": "claude-haiku-4-5@20251001",
+  "claude-sonnet-4-5": "claude-sonnet-4-5@20250929",
+  "claude-opus-4-5": "claude-opus-4-5@20251101",
+  "claude-sonnet-4": "claude-sonnet-4@20250514",
+  "claude-opus-4-1": "claude-opus-4-1@20250805",
+  "claude-opus-4": "claude-opus-4@20250514",
+  "claude-3-5-haiku": "claude-3-5-haiku@20241022",
+};
+
+/**
+ * Map a client Anthropic model id to a Vertex AI model id. Resolution order:
+ *   1. explicit alias (own-key only — Object.hasOwn guards against a model
+ *      literally named "valueOf"/"toString" resolving a prototype member);
+ *   2. already a Vertex-dated id (`…@YYYYMMDD`) → unchanged;
+ *   3. an Anthropic-dated id (`…-YYYYMMDD`) → convert the dash-date to Vertex's
+ *      `@`-date form (`claude-sonnet-4-5-20250929` → `claude-sonnet-4-5@20250929`);
+ *   4. otherwise unchanged (short ids like `claude-opus-4-8` pass through).
+ */
+export function toVertexModelId(model: string): string {
+  if (Object.hasOwn(VERTEX_MODEL_ALIASES, model))
+    return VERTEX_MODEL_ALIASES[model];
+  if (model.includes("@")) return model;
+  const dated = model.match(/^(.*)-(\d{8})$/);
+  if (dated) return `${dated[1]}@${dated[2]}`;
+  return model;
+}
+
+/**
+ * Build the Vertex AI `rawPredict`/`streamRawPredict` URL.
+ *
+ * Format (regional and global both use the `{region}-aiplatform` host; for the
+ * recommended `global` endpoint this is `global-aiplatform.googleapis.com` with
+ * `locations/global`):
+ *   https://{region}-aiplatform.googleapis.com/v1/projects/{project}/locations/{region}/publishers/anthropic/models/{model}:{verb}
+ */
+export function vertexRawPredictUrl(
+  region: string,
+  project: string,
+  model: string,
+  stream: boolean,
+): string {
+  const verb = stream ? "streamRawPredict" : "rawPredict";
+  const encodedModel = encodeURIComponent(model);
+  return `https://${region}-aiplatform.googleapis.com/v1/projects/${project}/locations/${region}/publishers/anthropic/models/${encodedModel}:${verb}`;
+}
+
+/**
+ * Transform an Anthropic Messages body (as built by `buildAnthropicRequest`)
+ * into the Vertex shape: drop `model` (it's in the URL path) and `stream` (the
+ * URL verb controls streaming — a body `stream` field is rejected), and inject
+ * `anthropic_version`. Returns a new object; the input is not mutated. All
+ * other fields (system, messages, tools, cache_control, thinking, …) are
+ * Vertex-compatible verbatim.
+ */
+export function toVertexBody(
+  anthropicBody: Record<string, unknown>,
+): Record<string, unknown> {
+  const { model: _model, stream: _stream, ...rest } = anthropicBody;
+  return { anthropic_version: VERTEX_ANTHROPIC_VERSION, ...rest };
+}
+
+/** Matches a Vertex aiplatform host and captures the region/endpoint segment. */
+const VERTEX_HOST_RE = /^([a-z0-9-]+)-aiplatform\.googleapis\.com$/;
+
+/**
+ * Extract the Vertex region/endpoint segment from a base URL or host
+ * (`https://us-east1-aiplatform.googleapis.com` → `"us-east1"`,
+ * `global-aiplatform.googleapis.com` → `"global"`). Returns null when the host
+ * is not a Vertex aiplatform endpoint. Authoritative source of a worker's
+ * region — it's the session's actual upstream host.
+ */
+export function vertexRegionFromUrl(url: string): string | null {
+  try {
+    const host = url.includes("://") ? new URL(url).hostname : url;
+    const m = host.match(VERTEX_HOST_RE);
+    return m ? m[1] : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * True if `url` (a base URL or host) is a Vertex AI aiplatform endpoint
+ * (`{region}-aiplatform.googleapis.com`, including `global-aiplatform…`). Used
+ * to recognize a Vertex session for worker/warmer model remapping when routing
+ * was set via `LORE_UPSTREAM_*` rather than the provider header.
+ */
+export function isVertexHost(url: string): boolean {
+  return vertexRegionFromUrl(url) !== null;
+}

--- a/packages/gateway/src/translate/vertex.ts
+++ b/packages/gateway/src/translate/vertex.ts
@@ -57,12 +57,26 @@ export function toVertexModelId(model: string): string {
 }
 
 /**
+ * Resolve the Vertex aiplatform host for a region. The `global` endpoint is
+ * special-cased: it is served from the BARE `aiplatform.googleapis.com` host
+ * (NOT `global-aiplatform.googleapis.com`, which resolves but 404s on the
+ * rawPredict path — verified live against a real project). Every regional
+ * endpoint uses the `{region}-aiplatform.googleapis.com` prefix form. The URL
+ * path still carries `locations/global` for the global endpoint.
+ */
+export function vertexHost(region: string): string {
+  return region === "global"
+    ? "aiplatform.googleapis.com"
+    : `${region}-aiplatform.googleapis.com`;
+}
+
+/**
  * Build the Vertex AI `rawPredict`/`streamRawPredict` URL.
  *
- * Format (regional and global both use the `{region}-aiplatform` host; for the
- * recommended `global` endpoint this is `global-aiplatform.googleapis.com` with
- * `locations/global`):
- *   https://{region}-aiplatform.googleapis.com/v1/projects/{project}/locations/{region}/publishers/anthropic/models/{model}:{verb}
+ * Format:
+ *   https://{host}/v1/projects/{project}/locations/{region}/publishers/anthropic/models/{model}:{verb}
+ * where {host} is `aiplatform.googleapis.com` for the global endpoint and
+ * `{region}-aiplatform.googleapis.com` for regional endpoints (see vertexHost).
  */
 export function vertexRawPredictUrl(
   region: string,
@@ -79,7 +93,7 @@ export function vertexRawPredictUrl(
   // round-trip-safe form. (`encodeURIComponent` would otherwise turn "@"→"%40";
   // nothing else in a Claude model id needs encoding.)
   const encodedModel = encodeURIComponent(model).replace(/%40/g, "@");
-  return `https://${region}-aiplatform.googleapis.com/v1/projects/${project}/locations/${region}/publishers/anthropic/models/${encodedModel}:${verb}`;
+  return `https://${vertexHost(region)}/v1/projects/${project}/locations/${region}/publishers/anthropic/models/${encodedModel}:${verb}`;
 }
 
 /**
@@ -97,31 +111,40 @@ export function toVertexBody(
   return { anthropic_version: VERTEX_ANTHROPIC_VERSION, ...rest };
 }
 
-/** Matches a Vertex aiplatform host and captures the region/endpoint segment. */
-const VERTEX_HOST_RE = /^([a-z0-9-]+)-aiplatform\.googleapis\.com$/;
+/**
+ * Matches a Vertex aiplatform host and captures the region segment. The region
+ * prefix is OPTIONAL: the bare `aiplatform.googleapis.com` is the global
+ * endpoint (region segment absent → treated as `"global"`), while
+ * `{region}-aiplatform.googleapis.com` carries an explicit region. The legacy
+ * `global-aiplatform.googleapis.com` form also parses (captures `"global"`) so a
+ * manually-configured upstream self-heals to the bare host on the next rebuild.
+ */
+const VERTEX_HOST_RE = /^(?:([a-z0-9-]+)-)?aiplatform\.googleapis\.com$/;
 
 /**
  * Extract the Vertex region/endpoint segment from a base URL or host
  * (`https://us-east1-aiplatform.googleapis.com` → `"us-east1"`,
- * `global-aiplatform.googleapis.com` → `"global"`). Returns null when the host
- * is not a Vertex aiplatform endpoint. Authoritative source of a worker's
- * region — it's the session's actual upstream host.
+ * `aiplatform.googleapis.com` → `"global"`). Returns null when the host is not a
+ * Vertex aiplatform endpoint. Authoritative source of a worker's region — it's
+ * the session's actual upstream host.
  */
 export function vertexRegionFromUrl(url: string): string | null {
   try {
     const host = url.includes("://") ? new URL(url).hostname : url;
     const m = host.match(VERTEX_HOST_RE);
-    return m ? m[1] : null;
+    // m[1] is undefined for the bare `aiplatform.googleapis.com` global host.
+    return m ? (m[1] ?? "global") : null;
   } catch {
     return null;
   }
 }
 
 /**
- * True if `url` (a base URL or host) is a Vertex AI aiplatform endpoint
- * (`{region}-aiplatform.googleapis.com`, including `global-aiplatform…`). Used
- * to recognize a Vertex session for worker/warmer model remapping when routing
- * was set via `LORE_UPSTREAM_*` rather than the provider header.
+ * True if `url` (a base URL or host) is a Vertex AI aiplatform endpoint — the
+ * bare `aiplatform.googleapis.com` (global) or `{region}-aiplatform.googleapis.com`
+ * (regional, including the legacy `global-aiplatform…`). Used to recognize a
+ * Vertex session for worker/warmer model remapping when routing was set via
+ * `LORE_UPSTREAM_*` rather than the provider header.
  */
 export function isVertexHost(url: string): boolean {
   return vertexRegionFromUrl(url) !== null;

--- a/packages/gateway/src/translate/vertex.ts
+++ b/packages/gateway/src/translate/vertex.ts
@@ -149,3 +149,67 @@ export function vertexRegionFromUrl(url: string): string | null {
 export function isVertexHost(url: string): boolean {
   return vertexRegionFromUrl(url) !== null;
 }
+
+/** HTTP headers that only `api.anthropic.com` understands. They MUST be removed
+ * before forwarding to Vertex's rawPredict endpoint:
+ *   - `x-api-key`: replaced by the GCP OAuth2 bearer (set by the caller);
+ *   - `anthropic-version`: carried in the body (`anthropic_version`) on Vertex;
+ *   - `anthropic-beta`: an api.anthropic.com-only header. Prompt caching on
+ *     Vertex is driven by `cache_control` body blocks (a GA feature), NOT a beta
+ *     header, so dropping it never disables caching — but forwarding an
+ *     unrecognized beta token (e.g. `extended-cache-ttl-…`) risks a 400. The
+ *     documented Vertex header set is exactly content-type + Authorization (see
+ *     https://docs.claude.com/en/api/claude-on-vertex-ai).
+ */
+const ANTHROPIC_ONLY_HEADERS = [
+  "x-api-key",
+  "anthropic-version",
+  "anthropic-beta",
+] as const;
+
+/**
+ * Apply the Vertex transport rewrite to an already-built Anthropic upstream
+ * request (the `{ headers, body }` from `buildAnthropicRequest`). Pure and
+ * synchronous so it is unit-testable in isolation — the caller supplies the
+ * async-resolved GCP `project` and OAuth2 `token`. Produces the final Vertex
+ * `:rawPredict` / `:streamRawPredict` request:
+ *   - region: parsed from `effectiveUpstreamBase` so an explicit
+ *     `X-Lore-Upstream-URL` regional endpoint (chosen for latency/compliance)
+ *     wins, falling back to `configRegion`. In the no-override case
+ *     `effectiveUpstreamBase` is the self-built `https://<vertexHost(configRegion)>`,
+ *     so `vertexRegionFromUrl` round-trips `configRegion`;
+ *   - url: the per-model rawPredict URL for that region/project (the verb
+ *     selects streaming);
+ *   - body: the Anthropic body with `model`/`stream` dropped and
+ *     `anthropic_version` injected (`toVertexBody`);
+ *   - headers: the forwarded Anthropic headers with the api.anthropic.com-only
+ *     headers stripped (see `ANTHROPIC_ONLY_HEADERS`) and the GCP bearer set.
+ */
+export function buildVertexUpstream(opts: {
+  anthropicHeaders: Record<string, string>;
+  anthropicBody: Record<string, unknown>;
+  effectiveUpstreamBase: string;
+  configRegion: string;
+  project: string;
+  model: string;
+  stream: boolean;
+  token: string;
+}): {
+  url: string;
+  headers: Record<string, string>;
+  body: Record<string, unknown>;
+} {
+  const region =
+    vertexRegionFromUrl(opts.effectiveUpstreamBase) ?? opts.configRegion;
+  const url = vertexRawPredictUrl(
+    region,
+    opts.project,
+    toVertexModelId(opts.model),
+    opts.stream,
+  );
+  const body = toVertexBody(opts.anthropicBody);
+  const headers = { ...opts.anthropicHeaders };
+  for (const h of ANTHROPIC_ONLY_HEADERS) delete headers[h];
+  headers.Authorization = `Bearer ${opts.token}`;
+  return { url, headers, body };
+}

--- a/packages/gateway/src/vertex-auth.ts
+++ b/packages/gateway/src/vertex-auth.ts
@@ -1,0 +1,90 @@
+/**
+ * Google Vertex AI authentication — GCP OAuth2 access tokens via Application
+ * Default Credentials (ADC).
+ *
+ * Claude on Vertex is authenticated with a short-lived GCP OAuth2 bearer token
+ * (NOT an API key). lore holds the GCP credentials (the gateway-holds-credentials
+ * model, consistent with how it carries provider keys) and mints/refreshes
+ * tokens via `google-auth-library`, so the client speaks plain Anthropic to lore.
+ *
+ * ADC resolves credentials from (in order): GOOGLE_APPLICATION_CREDENTIALS
+ * (service-account key JSON), `gcloud auth application-default login` creds,
+ * GCE/Cloud Run metadata server, and workload-identity federation —
+ * google-auth-library picks the right source automatically. The library caches
+ * the access token and refreshes it before expiry, so `getVertexAccessToken`
+ * is cheap to call per request.
+ */
+import { GoogleAuth } from "google-auth-library";
+
+/** OAuth2 scope required to call Vertex AI (aiplatform). */
+const VERTEX_SCOPE = "https://www.googleapis.com/auth/cloud-platform";
+
+let auth: GoogleAuth | null = null;
+let cachedProject: string | null = null;
+
+// Test seam (NEVER set in production): inject a deterministic token provider so
+// the Vertex routing/worker/warmer paths can be exercised without real GCP
+// credentials (CI has none). `null` restores real ADC behavior.
+let testTokenProvider: (() => Promise<string>) | null = null;
+
+/** @internal test-only: inject (or clear with null) a fake access-token source. */
+export function _setTestVertexTokenProvider(
+  fn: (() => Promise<string>) | null,
+): void {
+  testTokenProvider = fn;
+  cachedProject = null;
+}
+
+function getAuth(): GoogleAuth {
+  if (!auth) auth = new GoogleAuth({ scopes: VERTEX_SCOPE });
+  return auth;
+}
+
+/**
+ * Obtain a GCP OAuth2 access token via ADC. The library caches + auto-refreshes,
+ * so this is safe to call per request. Throws an actionable error when ADC is
+ * unavailable (the request path surfaces it rather than sending an unauthorized
+ * call upstream).
+ */
+export async function getVertexAccessToken(): Promise<string> {
+  if (testTokenProvider) return testTokenProvider();
+  let token: string | null | undefined;
+  try {
+    token = await getAuth().getAccessToken();
+  } catch (err) {
+    throw new Error(
+      "Vertex: failed to obtain a GCP access token via Application Default " +
+        "Credentials. Run `gcloud auth application-default login`, or set " +
+        "GOOGLE_APPLICATION_CREDENTIALS to a service-account key JSON. " +
+        `(${(err as Error).message})`,
+    );
+  }
+  if (!token) {
+    throw new Error(
+      "Vertex: Application Default Credentials returned no access token. Run " +
+        "`gcloud auth application-default login`, or set " +
+        "GOOGLE_APPLICATION_CREDENTIALS to a service-account key JSON.",
+    );
+  }
+  return token;
+}
+
+/**
+ * Resolve the GCP project id: prefer the explicitly-configured value
+ * (GOOGLE_CLOUD_PROJECT / LORE_VERTEX_PROJECT), else derive it from ADC (e.g. a
+ * service-account key's project, or the gcloud quota project). The derived
+ * value is cached. Returns "" when neither is available (the request path then
+ * fails with a clear "project not set" error).
+ */
+export async function resolveVertexProject(
+  configured: string,
+): Promise<string> {
+  if (configured) return configured;
+  if (cachedProject !== null) return cachedProject;
+  try {
+    cachedProject = (await getAuth().getProjectId()) ?? "";
+  } catch {
+    cachedProject = "";
+  }
+  return cachedProject;
+}

--- a/packages/gateway/src/vertex-auth.ts
+++ b/packages/gateway/src/vertex-auth.ts
@@ -79,7 +79,14 @@ export async function getVertexAccessToken(): Promise<string> {
 export async function resolveVertexProject(
   configured: string,
 ): Promise<string> {
-  if (configured) return configured;
+  // Cache the configured project too: the conversation path resolves it with
+  // config.vertexProject on the first turn, so a later warmer call (which has
+  // no config in scope and passes "") reuses it — covers a LORE_VERTEX_PROJECT
+  // that ADC's getProjectId() would not see.
+  if (configured) {
+    cachedProject = configured;
+    return configured;
+  }
   if (cachedProject !== null) return cachedProject;
   try {
     cachedProject = (await getAuth().getProjectId()) ?? "";

--- a/packages/gateway/src/vertex-auth.ts
+++ b/packages/gateway/src/vertex-auth.ts
@@ -52,11 +52,19 @@ export async function getVertexAccessToken(): Promise<string> {
   try {
     token = await getAuth().getAccessToken();
   } catch (err) {
+    // Log the raw ADC failure to stderr so the operator can debug it, but do
+    // NOT embed it in the thrown message: this Error can propagate to the
+    // client (the conversation path surfaces it), and the raw ADC error may
+    // reveal local file paths / project hints. Keep the client message generic
+    // but actionable.
+    console.error(
+      "[lore] Vertex ADC token mint failed:",
+      (err as Error).message,
+    );
     throw new Error(
       "Vertex: failed to obtain a GCP access token via Application Default " +
         "Credentials. Run `gcloud auth application-default login`, or set " +
-        "GOOGLE_APPLICATION_CREDENTIALS to a service-account key JSON. " +
-        `(${(err as Error).message})`,
+        "GOOGLE_APPLICATION_CREDENTIALS to a service-account key JSON.",
     );
   }
   if (!token) {
@@ -87,11 +95,18 @@ export async function resolveVertexProject(
     cachedProject = configured;
     return configured;
   }
-  if (cachedProject !== null) return cachedProject;
+  // Only short-circuit on a CACHED NON-EMPTY value. A previous empty/failed
+  // ADC lookup must NEVER be cached as "" — that would permanently disable
+  // Vertex for the process lifetime after a single transient metadata-server
+  // hiccup. On empty/error we return "" without caching, so the next call
+  // re-probes (the caller fails this turn with a clear "project not set" error
+  // and recovers automatically once ADC provides a project).
+  if (cachedProject) return cachedProject;
   try {
-    cachedProject = (await getAuth().getProjectId()) ?? "";
+    const derived = (await getAuth().getProjectId()) ?? "";
+    if (derived) cachedProject = derived;
+    return derived;
   } catch {
-    cachedProject = "";
+    return "";
   }
-  return cachedProject;
 }

--- a/packages/gateway/test/llm-adapter.test.ts
+++ b/packages/gateway/test/llm-adapter.test.ts
@@ -720,6 +720,8 @@ describe("createGatewayLLMClient.prompt", () => {
       const text = await client.prompt("system", "user", {
         sessionID: "sess-vertex",
         workerID: "lore-distill",
+        // Legacy global-aiplatform base — the worker must self-heal it to the
+        // bare aiplatform host when it rebuilds the rawPredict URL.
         upstreamUrl: "https://global-aiplatform.googleapis.com",
         upstreamProviderID: "vertex",
         protocol: "vertex",
@@ -728,7 +730,7 @@ describe("createGatewayLLMClient.prompt", () => {
       expect(text).toBe("hello from worker");
       const [url, init] = mockFetch.mock.calls[0];
       expect(url).toBe(
-        "https://global-aiplatform.googleapis.com/v1/projects/test-vertex-project/locations/global/publishers/anthropic/models/claude-opus-4-8:rawPredict",
+        "https://aiplatform.googleapis.com/v1/projects/test-vertex-project/locations/global/publishers/anthropic/models/claude-opus-4-8:rawPredict",
       );
       const headers = init?.headers as Record<string, string>;
       expect(headers.Authorization).toBe("Bearer test-vertex-token");
@@ -760,7 +762,7 @@ describe("createGatewayLLMClient.prompt", () => {
       const text = await client.prompt("system", "user", {
         sessionID: "sess-vertex-nokey",
         workerID: "lore-distill",
-        upstreamUrl: "https://global-aiplatform.googleapis.com",
+        upstreamUrl: "https://aiplatform.googleapis.com",
         upstreamProviderID: "vertex",
         protocol: "vertex",
       });

--- a/packages/gateway/test/llm-adapter.test.ts
+++ b/packages/gateway/test/llm-adapter.test.ts
@@ -30,6 +30,7 @@ import { upstreamFetch } from "../src/fetch";
 import { clearAllCosts, getSessionCosts } from "../src/cost-tracker";
 import { recordWorkerFailure, markWorkerPaused } from "../src/worker-health";
 import { captureSessionHeaders, captureBillingPrefix } from "../src/cch";
+import { _setTestVertexTokenProvider } from "../src/vertex-auth";
 
 // Claude Code billing-header system prompt — marks a session as an OAuth
 // billing session so worker calls replay its sniffed anthropic-beta header.
@@ -698,6 +699,82 @@ describe("createGatewayLLMClient.prompt", () => {
     expect(url).toContain("api.anthropic.com");
     const body = JSON.parse(init?.body as string) as Record<string, unknown>;
     expect(body.model).toBe("claude-haiku-4-5");
+  });
+
+  test("vertex worker posts to :rawPredict with a GCP bearer and strips the client key", async () => {
+    // A Vertex session's worker (distillation/curation) must POST the Anthropic
+    // body to the per-model :rawPredict URL authenticated with lore's GCP OAuth2
+    // bearer — NEVER the client x-api-key / anthropic-version header. Guards the
+    // credential swap (a regression that forwarded the client key would leak it
+    // to GCP and 401 every background call).
+    _setTestVertexTokenProvider(() => Promise.resolve("test-vertex-token"));
+    try {
+      mockFetch.mockResolvedValue(anthropicResponse());
+      const client = createGatewayLLMClient(
+        UPSTREAMS,
+        () => ({ scheme: "api-key", value: "client-key-ignored-for-vertex" }),
+        { providerID: "vertex", modelID: "claude-opus-4-8" },
+        { vertexProject: "test-vertex-project" },
+      );
+
+      const text = await client.prompt("system", "user", {
+        sessionID: "sess-vertex",
+        workerID: "lore-distill",
+        upstreamUrl: "https://global-aiplatform.googleapis.com",
+        upstreamProviderID: "vertex",
+        protocol: "vertex",
+      });
+
+      expect(text).toBe("hello from worker");
+      const [url, init] = mockFetch.mock.calls[0];
+      expect(url).toBe(
+        "https://global-aiplatform.googleapis.com/v1/projects/test-vertex-project/locations/global/publishers/anthropic/models/claude-opus-4-8:rawPredict",
+      );
+      const headers = init?.headers as Record<string, string>;
+      expect(headers.Authorization).toBe("Bearer test-vertex-token");
+      expect(headers["x-api-key"]).toBeUndefined();
+      expect(headers["anthropic-version"]).toBeUndefined();
+      const body = JSON.parse(init?.body as string) as Record<string, unknown>;
+      expect(body.anthropic_version).toBe("vertex-2023-10-16");
+      expect("model" in body).toBe(false);
+      expect("stream" in body).toBe(false);
+    } finally {
+      _setTestVertexTokenProvider(null);
+    }
+  });
+
+  test("vertex worker proceeds even when the client sends NO credential", async () => {
+    // Vertex auth is lore's GCP token, so a client sending no x-api-key is the
+    // legitimate gateway-holds-credentials case. Background distillation/curation
+    // must still run (a missing client key must NOT disable it for vertex).
+    _setTestVertexTokenProvider(() => Promise.resolve("test-vertex-token"));
+    try {
+      mockFetch.mockResolvedValue(anthropicResponse());
+      const client = createGatewayLLMClient(
+        UPSTREAMS,
+        () => null, // client provided no credential
+        { providerID: "vertex", modelID: "claude-opus-4-8" },
+        { vertexProject: "test-vertex-project" },
+      );
+
+      const text = await client.prompt("system", "user", {
+        sessionID: "sess-vertex-nokey",
+        workerID: "lore-distill",
+        upstreamUrl: "https://global-aiplatform.googleapis.com",
+        upstreamProviderID: "vertex",
+        protocol: "vertex",
+      });
+
+      expect(text).toBe("hello from worker");
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url, init] = mockFetch.mock.calls[0];
+      expect(url).toContain(":rawPredict");
+      expect((init?.headers as Record<string, string>).Authorization).toBe(
+        "Bearer test-vertex-token",
+      );
+    } finally {
+      _setTestVertexTokenProvider(null);
+    }
   });
 
   test("returns null without calling upstream when no auth is available", async () => {

--- a/packages/gateway/test/vertex-routing.test.ts
+++ b/packages/gateway/test/vertex-routing.test.ts
@@ -127,7 +127,9 @@ describe("X-Lore-Provider: vertex routing (Vertex AI Claude)", () => {
     expect(text).toContain("hi from vertex");
 
     // The UpstreamSnapshot must record protocol "vertex" + the Vertex base URL.
-    const vertexBase = "https://global-aiplatform.googleapis.com";
+    // Region "global" → the BARE aiplatform host (NOT global-aiplatform, which
+    // 404s on rawPredict — verified live).
+    const vertexBase = "https://aiplatform.googleapis.com";
     let snapshotProtocol: string | undefined;
     let snapshotUrl: string | undefined;
     for (let i = 0; i < 20; i++) {

--- a/packages/gateway/test/vertex-routing.test.ts
+++ b/packages/gateway/test/vertex-routing.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Integration test: `X-Lore-Provider: vertex` routes Claude to Google Vertex AI
+ * over the `:rawPredict` path with a GCP OAuth2 bearer.
+ *
+ * The provider route carries `protocol: "vertex"` (url null — the region URL is
+ * built at request time), so the request takes pipeline.ts's self-URL-building
+ * vertex branch: reuse the Anthropic body, then strip `model`/`stream`, inject
+ * `anthropic_version: "vertex-2023-10-16"`, and swap the client key for a GCP
+ * bearer. A test seam provides the token (CI has no GCP credentials).
+ *
+ * We drive a non-streaming Anthropic client request with `X-Lore-Provider:
+ * vertex` and assert: (1) the upstream body carries `anthropic_version` and has
+ * NO `model`/`stream` (proof the vertex transform fired), and (2) the
+ * UpstreamSnapshot records protocol "vertex" + the regional Vertex base URL
+ * (the single source of truth workers/warmer/idle consume).
+ */
+import { describe, test, expect, afterEach } from "vitest";
+import { existsSync, unlinkSync } from "node:fs";
+
+/** A non-streaming Anthropic message response (Vertex returns native shape). */
+function vertexJSONResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      id: "msg_vertex",
+      type: "message",
+      role: "assistant",
+      content: [{ type: "text", text: "hi from vertex" }],
+      model: "claude-opus-4-8",
+      stop_reason: "end_turn",
+      usage: { input_tokens: 10, output_tokens: 5 },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+let teardownFn: (() => void) | undefined;
+
+afterEach(() => {
+  teardownFn?.();
+  teardownFn = undefined;
+});
+
+describe("X-Lore-Provider: vertex routing (Vertex AI Claude)", () => {
+  test("routes to Vertex over the rawPredict path with a transformed body", async () => {
+    const dbPath = `/tmp/lore-vertex-route-${Date.now()}-${Math.random().toString(36).slice(2)}.db`;
+    process.env.LORE_DB_PATH = dbPath;
+    // Port 0 = OS-assigned ephemeral port (avoids EADDRINUSE flake, #931).
+    process.env.LORE_LISTEN_PORT = "0";
+    // GCP project for the rawPredict URL (no ADC project lookup in CI).
+    process.env.GOOGLE_CLOUD_PROJECT = "test-vertex-project";
+    // Region default is "global"; pin it so the snapshot URL is deterministic.
+    process.env.GOOGLE_CLOUD_REGION = "global";
+    if (!process.env.LORE_DEBUG) process.env.LORE_DEBUG = "false";
+
+    const { setUpstreamInterceptor, resetPipelineState, getActiveSessions } =
+      await import("../src/pipeline");
+    const { startServer } = await import("../src/server");
+    const { loadConfig } = await import("../src/config");
+    const { _setTestVertexTokenProvider } = await import("../src/vertex-auth");
+    const { close: closeDB } = await import("@loreai/core");
+
+    // Inject a fake GCP token so the vertex branch never hits real ADC.
+    _setTestVertexTokenProvider(() => Promise.resolve("test-vertex-token"));
+
+    closeDB();
+    await resetPipelineState();
+
+    let capturedBody: Record<string, unknown> | undefined;
+    let capturedModel: string | undefined;
+    setUpstreamInterceptor(async (body, model) => {
+      capturedBody = body as Record<string, unknown>;
+      capturedModel = model;
+      return vertexJSONResponse();
+    });
+
+    const config = loadConfig();
+    const server = await startServer(config);
+    const baseURL = `http://127.0.0.1:${server.port}`;
+
+    teardownFn = () => {
+      server.stop();
+      closeDB();
+      setUpstreamInterceptor(undefined);
+      _setTestVertexTokenProvider(null);
+      delete process.env.GOOGLE_CLOUD_PROJECT;
+      delete process.env.GOOGLE_CLOUD_REGION;
+      for (const suffix of ["", "-shm", "-wal"]) {
+        const f = `${dbPath}${suffix}`;
+        try {
+          if (existsSync(f)) unlinkSync(f);
+        } catch {
+          // best-effort
+        }
+      }
+    };
+
+    const resp = await fetch(`${baseURL}/v1/messages`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": "client-key-ignored-for-vertex",
+        "anthropic-version": "2023-06-01",
+        // X-Lore-Provider: vertex is THE path under test.
+        "x-lore-provider": "vertex",
+        "x-lore-agent": "coder",
+      },
+      body: JSON.stringify({
+        model: "claude-opus-4-8",
+        max_tokens: 1024,
+        stream: false,
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    });
+
+    expect(resp.ok).toBe(true);
+
+    // The OUTGOING body must be the Vertex shape — proof the vertex branch ran.
+    expect(capturedBody).toBeDefined();
+    expect(capturedBody?.anthropic_version).toBe("vertex-2023-10-16");
+    // model + stream are removed (model is in the URL; the verb selects stream).
+    expect("model" in (capturedBody ?? {})).toBe(false);
+    expect("stream" in (capturedBody ?? {})).toBe(false);
+    // req.model (client-facing id) is unchanged for session/cache tracking.
+    expect(capturedModel).toBe("claude-opus-4-8");
+
+    const text = await resp.text();
+    expect(text).toContain("hi from vertex");
+
+    // The UpstreamSnapshot must record protocol "vertex" + the Vertex base URL.
+    const vertexBase = "https://global-aiplatform.googleapis.com";
+    let snapshotProtocol: string | undefined;
+    let snapshotUrl: string | undefined;
+    for (let i = 0; i < 20; i++) {
+      for (const s of getActiveSessions().values()) {
+        if (s.lastUpstream?.url === vertexBase) {
+          snapshotProtocol = s.lastUpstream.protocol;
+          snapshotUrl = s.lastUpstream.url;
+        }
+      }
+      if (snapshotUrl) break;
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    expect(snapshotProtocol).toBe("vertex");
+    expect(snapshotUrl).toBe(vertexBase);
+  });
+});

--- a/packages/gateway/test/vertex.test.ts
+++ b/packages/gateway/test/vertex.test.ts
@@ -15,6 +15,7 @@ import {
   toVertexBody,
   toVertexModelId,
   VERTEX_ANTHROPIC_VERSION,
+  vertexHost,
   vertexRawPredictUrl,
   vertexRegionFromUrl,
 } from "../src/translate/vertex";
@@ -68,12 +69,21 @@ describe("toVertexModelId", () => {
 });
 
 describe("vertexRawPredictUrl", () => {
-  test("builds the global :streamRawPredict URL", () => {
-    expect(
-      vertexRawPredictUrl("global", "my-proj", "claude-opus-4-8", true),
-    ).toBe(
-      "https://global-aiplatform.googleapis.com/v1/projects/my-proj/locations/global/publishers/anthropic/models/claude-opus-4-8:streamRawPredict",
+  test("builds the global :streamRawPredict URL on the bare aiplatform host", () => {
+    // The global endpoint is served from the BARE `aiplatform.googleapis.com`
+    // host — NOT `global-aiplatform.googleapis.com` (which resolves but 404s on
+    // the rawPredict path, verified live). The path still carries
+    // `locations/global`. Regression guard for that live-confirmed bug.
+    const url = vertexRawPredictUrl(
+      "global",
+      "my-proj",
+      "claude-opus-4-8",
+      true,
     );
+    expect(url).toBe(
+      "https://aiplatform.googleapis.com/v1/projects/my-proj/locations/global/publishers/anthropic/models/claude-opus-4-8:streamRawPredict",
+    );
+    expect(url).not.toContain("global-aiplatform.googleapis.com");
   });
 
   test("builds a regional :rawPredict URL (non-streaming)", () => {
@@ -129,11 +139,27 @@ describe("toVertexBody", () => {
   });
 });
 
+describe("vertexHost", () => {
+  test("global → bare aiplatform host; regional → prefixed host", () => {
+    expect(vertexHost("global")).toBe("aiplatform.googleapis.com");
+    expect(vertexHost("us-east5")).toBe("us-east5-aiplatform.googleapis.com");
+    // Regression: global must NEVER produce the dead global-aiplatform host.
+    expect(vertexHost("global")).not.toBe("global-aiplatform.googleapis.com");
+  });
+});
+
 describe("vertexRegionFromUrl / isVertexHost", () => {
   test("extracts the region from base URL or bare host", () => {
     expect(
       vertexRegionFromUrl("https://us-east1-aiplatform.googleapis.com"),
     ).toBe("us-east1");
+    // The bare host is the global endpoint.
+    expect(vertexRegionFromUrl("https://aiplatform.googleapis.com")).toBe(
+      "global",
+    );
+    expect(vertexRegionFromUrl("aiplatform.googleapis.com")).toBe("global");
+    // Legacy global-aiplatform host still parses to "global" so a manually
+    // configured upstream self-heals to the bare host on the next rebuild.
     expect(vertexRegionFromUrl("global-aiplatform.googleapis.com")).toBe(
       "global",
     );
@@ -179,7 +205,8 @@ describe("resolveWorkerProtocol — vertex (distinct, not collapsed)", () => {
 });
 
 describe("resolveProfile — vertex warming", () => {
-  const vertexBase = "https://global-aiplatform.googleapis.com";
+  // Bare host = the global endpoint (NOT global-aiplatform; see vertexHost).
+  const vertexBase = "https://aiplatform.googleapis.com";
 
   test("warms a vertex session (provider id + host)", () => {
     const profile = resolveProfile(
@@ -193,6 +220,17 @@ describe("resolveProfile — vertex warming", () => {
     expect(profile?.authMode).toBe("vertex");
     // upstreamUrl is the region base — executeWarmup rebuilds the rawPredict URL.
     expect(profile?.upstreamUrl).toBe(vertexBase);
+  });
+
+  test("normalizes a legacy global-aiplatform base to the bare host", () => {
+    const profile = resolveProfile(
+      "claude-opus-4-8",
+      "vertex",
+      "5m",
+      "https://global-aiplatform.googleapis.com",
+      "google-vertex",
+    );
+    expect(profile?.upstreamUrl).toBe("https://aiplatform.googleapis.com");
   });
 
   test("skips a vertex protocol with a non-vertex host (no leak)", () => {

--- a/packages/gateway/test/vertex.test.ts
+++ b/packages/gateway/test/vertex.test.ts
@@ -11,6 +11,7 @@
  */
 import { afterEach, describe, expect, test } from "vitest";
 import {
+  buildVertexUpstream,
   isVertexHost,
   toVertexBody,
   toVertexModelId,
@@ -285,5 +286,120 @@ describe("vertex-auth — ADC token seam", () => {
   test("resolveVertexProject prefers the configured project (no ADC call)", async () => {
     _setTestVertexTokenProvider(() => Promise.resolve("t"));
     expect(await resolveVertexProject("explicit-proj")).toBe("explicit-proj");
+  });
+});
+
+describe("buildVertexUpstream — conversation transport rewrite", () => {
+  // A representative `buildAnthropicRequest` result: Claude Code forwards
+  // x-api-key, anthropic-version, AND anthropic-beta (prompt-caching/extended-
+  // cache-ttl/context-1m beta tokens); the body carries model + stream.
+  const baseOpts = () => ({
+    anthropicHeaders: {
+      "content-type": "application/json",
+      "x-api-key": "sk-ant-client-key",
+      "anthropic-version": "2023-06-01",
+      "anthropic-beta":
+        "prompt-caching-2024-07-31,extended-cache-ttl-2025-04-11",
+      "user-agent": "claude-cli/2.0",
+    } as Record<string, string>,
+    anthropicBody: {
+      model: "claude-opus-4-5",
+      stream: true,
+      max_tokens: 1024,
+      messages: [{ role: "user", content: "hi" }],
+    } as Record<string, unknown>,
+    configRegion: "global",
+    project: "my-proj",
+    model: "claude-opus-4-5",
+    stream: true,
+    token: "gcp-oauth-token",
+  });
+
+  test("strips x-api-key, anthropic-version AND anthropic-beta; sets the bearer", () => {
+    // Regression for Seer #14881922/0: anthropic-beta is an api.anthropic.com-
+    // only header; forwarding it to Vertex risks a 400. It must be removed, like
+    // x-api-key and anthropic-version already were.
+    const { headers } = buildVertexUpstream({
+      ...baseOpts(),
+      effectiveUpstreamBase: "https://aiplatform.googleapis.com",
+    });
+    expect("x-api-key" in headers).toBe(false);
+    expect("anthropic-version" in headers).toBe(false);
+    expect("anthropic-beta" in headers).toBe(false);
+    expect(headers.Authorization).toBe("Bearer gcp-oauth-token");
+    // Non-Anthropic forwarded headers (e.g. content-type, user-agent) survive.
+    expect(headers["content-type"]).toBe("application/json");
+    expect(headers["user-agent"]).toBe("claude-cli/2.0");
+  });
+
+  test("does not mutate the caller's header object", () => {
+    const opts = {
+      ...baseOpts(),
+      effectiveUpstreamBase: "https://aiplatform.googleapis.com",
+    };
+    buildVertexUpstream(opts);
+    // The source headers are untouched (a fresh copy is rewritten).
+    expect(opts.anthropicHeaders["anthropic-beta"]).toBe(
+      "prompt-caching-2024-07-31,extended-cache-ttl-2025-04-11",
+    );
+    expect(opts.anthropicHeaders["x-api-key"]).toBe("sk-ant-client-key");
+  });
+
+  test("transforms the body: drops model/stream, injects anthropic_version", () => {
+    const { body } = buildVertexUpstream({
+      ...baseOpts(),
+      effectiveUpstreamBase: "https://aiplatform.googleapis.com",
+    });
+    expect(body.anthropic_version).toBe(VERTEX_ANTHROPIC_VERSION);
+    expect("model" in body).toBe(false);
+    expect("stream" in body).toBe(false);
+    expect(body.max_tokens).toBe(1024);
+  });
+
+  test("honors an X-Lore-Upstream-URL regional override for the URL region", () => {
+    // Regression for Seer #14881922/1: a regional X-Lore-Upstream-URL must win
+    // over config.vertexRegion (which here is "global"). The override host's
+    // region is parsed and threaded into the rawPredict URL.
+    const { url } = buildVertexUpstream({
+      ...baseOpts(),
+      effectiveUpstreamBase: "https://us-east1-aiplatform.googleapis.com",
+    });
+    expect(url).toBe(
+      "https://us-east1-aiplatform.googleapis.com/v1/projects/my-proj/locations/us-east1/publishers/anthropic/models/claude-opus-4-5@20251101:streamRawPredict",
+    );
+  });
+
+  test("falls back to configRegion when the base is the self-built global host", () => {
+    // No header override → effectiveUpstreamBase is the self-built global host;
+    // vertexRegionFromUrl round-trips configRegion ("global" → bare host + path).
+    const { url } = buildVertexUpstream({
+      ...baseOpts(),
+      configRegion: "global",
+      effectiveUpstreamBase: "https://aiplatform.googleapis.com",
+    });
+    expect(url).toBe(
+      "https://aiplatform.googleapis.com/v1/projects/my-proj/locations/global/publishers/anthropic/models/claude-opus-4-5@20251101:streamRawPredict",
+    );
+  });
+
+  test("falls back to configRegion when the base is not a Vertex host", () => {
+    // A non-Vertex effectiveUpstreamBase (e.g. a proxy/multi-region endpoint
+    // vertexRegionFromUrl can't parse) → configRegion is used, never null/"".
+    const { url } = buildVertexUpstream({
+      ...baseOpts(),
+      configRegion: "europe-west1",
+      effectiveUpstreamBase: "https://aiplatform.eu.rep.googleapis.com",
+    });
+    expect(url).toContain("https://europe-west1-aiplatform.googleapis.com/");
+    expect(url).toContain("/locations/europe-west1/");
+  });
+
+  test("selects the :rawPredict verb for a non-streaming request", () => {
+    const { url } = buildVertexUpstream({
+      ...baseOpts(),
+      stream: false,
+      effectiveUpstreamBase: "https://aiplatform.googleapis.com",
+    });
+    expect(url.endsWith(":rawPredict")).toBe(true);
   });
 });

--- a/packages/gateway/test/vertex.test.ts
+++ b/packages/gateway/test/vertex.test.ts
@@ -82,10 +82,17 @@ describe("vertexRawPredictUrl", () => {
     );
   });
 
-  test("URL-encodes the model id (the @ in a dated id)", () => {
-    expect(
-      vertexRawPredictUrl("global", "p", "claude-haiku-4-5@20251001", false),
-    ).toContain("models/claude-haiku-4-5%4020251001:rawPredict");
+  test("keeps a literal @ in a dated model id (no %40 encoding)", () => {
+    // Vertex (and Google's SDK) expect the unencoded "@" in the path; "%40"
+    // risks a 404. Guard against a regression back to encodeURIComponent's "%40".
+    const url = vertexRawPredictUrl(
+      "global",
+      "p",
+      "claude-haiku-4-5@20251001",
+      false,
+    );
+    expect(url).toContain("models/claude-haiku-4-5@20251001:rawPredict");
+    expect(url).not.toContain("%40");
   });
 });
 

--- a/packages/gateway/test/vertex.test.ts
+++ b/packages/gateway/test/vertex.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Unit tests for the Google Vertex AI (Claude) integration.
+ *
+ * Vertex speaks the native Anthropic Messages body but to a `:rawPredict` URL
+ * (model in the path), with `anthropic_version` in the body and GCP OAuth2
+ * auth. The Vertex-specific code is: the model-id remap (`toVertexModelId`),
+ * the URL builder (`vertexRawPredictUrl`), the body transform (`toVertexBody`),
+ * the host/region helpers, the provider routes, the worker protocol, the warmer
+ * profile, and the ADC token seam. End-to-end routing is covered in
+ * `vertex-routing.test.ts`.
+ */
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  isVertexHost,
+  toVertexBody,
+  toVertexModelId,
+  VERTEX_ANTHROPIC_VERSION,
+  vertexRawPredictUrl,
+  vertexRegionFromUrl,
+} from "../src/translate/vertex";
+import { resolveProviderRoute } from "../src/config";
+import { resolveWorkerProtocol } from "../src/llm-adapter";
+import { resolveProfile } from "../src/cache-warmer";
+import {
+  _setTestVertexTokenProvider,
+  getVertexAccessToken,
+  resolveVertexProject,
+} from "../src/vertex-auth";
+
+describe("toVertexModelId", () => {
+  test("passes through short ids that Vertex uses verbatim", () => {
+    expect(toVertexModelId("claude-opus-4-8")).toBe("claude-opus-4-8");
+    expect(toVertexModelId("claude-sonnet-4-6")).toBe("claude-sonnet-4-6");
+    expect(toVertexModelId("claude-fable-5")).toBe("claude-fable-5");
+  });
+
+  test("maps short ids that Vertex pins to a dated id", () => {
+    expect(toVertexModelId("claude-haiku-4-5")).toBe(
+      "claude-haiku-4-5@20251001",
+    );
+    expect(toVertexModelId("claude-sonnet-4-5")).toBe(
+      "claude-sonnet-4-5@20250929",
+    );
+  });
+
+  test("converts an Anthropic dash-date id to Vertex @-date form", () => {
+    expect(toVertexModelId("claude-3-5-haiku-20241022")).toBe(
+      "claude-3-5-haiku@20241022",
+    );
+    expect(toVertexModelId("claude-opus-4-1-20250805")).toBe(
+      "claude-opus-4-1@20250805",
+    );
+  });
+
+  test("leaves an already-Vertex-dated id unchanged (idempotent)", () => {
+    expect(toVertexModelId("claude-sonnet-4-5@20250929")).toBe(
+      "claude-sonnet-4-5@20250929",
+    );
+    expect(toVertexModelId(toVertexModelId("claude-sonnet-4-5"))).toBe(
+      "claude-sonnet-4-5@20250929",
+    );
+  });
+
+  test("does not resolve inherited Object.prototype members", () => {
+    expect(toVertexModelId("valueOf")).toBe("valueOf");
+    expect(toVertexModelId("toString")).toBe("toString");
+  });
+});
+
+describe("vertexRawPredictUrl", () => {
+  test("builds the global :streamRawPredict URL", () => {
+    expect(
+      vertexRawPredictUrl("global", "my-proj", "claude-opus-4-8", true),
+    ).toBe(
+      "https://global-aiplatform.googleapis.com/v1/projects/my-proj/locations/global/publishers/anthropic/models/claude-opus-4-8:streamRawPredict",
+    );
+  });
+
+  test("builds a regional :rawPredict URL (non-streaming)", () => {
+    expect(
+      vertexRawPredictUrl("us-east1", "p", "claude-opus-4-8", false),
+    ).toBe(
+      "https://us-east1-aiplatform.googleapis.com/v1/projects/p/locations/us-east1/publishers/anthropic/models/claude-opus-4-8:rawPredict",
+    );
+  });
+
+  test("URL-encodes the model id (the @ in a dated id)", () => {
+    expect(
+      vertexRawPredictUrl("global", "p", "claude-haiku-4-5@20251001", false),
+    ).toContain("models/claude-haiku-4-5%4020251001:rawPredict");
+  });
+});
+
+describe("toVertexBody", () => {
+  test("strips model + stream and injects anthropic_version", () => {
+    const out = toVertexBody({
+      model: "claude-opus-4-8",
+      stream: true,
+      max_tokens: 100,
+      messages: [{ role: "user", content: "hi" }],
+    });
+    expect(out.anthropic_version).toBe(VERTEX_ANTHROPIC_VERSION);
+    expect("model" in out).toBe(false);
+    expect("stream" in out).toBe(false);
+    expect(out.max_tokens).toBe(100);
+    expect(out.messages).toEqual([{ role: "user", content: "hi" }]);
+  });
+
+  test("preserves system + tools + cache_control verbatim", () => {
+    const system = [
+      { type: "text", text: "sys", cache_control: { type: "ephemeral" } },
+    ];
+    const tools = [{ name: "t", input_schema: { type: "object" } }];
+    const out = toVertexBody({ model: "m", system, tools });
+    expect(out.system).toEqual(system);
+    expect(out.tools).toEqual(tools);
+  });
+
+  test("does not mutate the input object", () => {
+    const input = { model: "m", stream: false, max_tokens: 1 };
+    const snapshot = JSON.stringify(input);
+    toVertexBody(input);
+    expect(JSON.stringify(input)).toBe(snapshot);
+  });
+});
+
+describe("vertexRegionFromUrl / isVertexHost", () => {
+  test("extracts the region from base URL or bare host", () => {
+    expect(
+      vertexRegionFromUrl("https://us-east1-aiplatform.googleapis.com"),
+    ).toBe("us-east1");
+    expect(vertexRegionFromUrl("global-aiplatform.googleapis.com")).toBe(
+      "global",
+    );
+    expect(
+      vertexRegionFromUrl(
+        "https://global-aiplatform.googleapis.com/v1/projects/p/locations/global/publishers/anthropic/models/claude-opus-4-8:rawPredict",
+      ),
+    ).toBe("global");
+  });
+
+  test("rejects non-Vertex and spoofed hosts", () => {
+    expect(vertexRegionFromUrl("https://api.anthropic.com")).toBeNull();
+    expect(isVertexHost("https://api.anthropic.com")).toBe(false);
+    // Spoof: aiplatform as a subdomain of an attacker host.
+    expect(
+      isVertexHost("https://global-aiplatform.googleapis.com.evil.com"),
+    ).toBe(false);
+    expect(isVertexHost("")).toBe(false);
+  });
+});
+
+describe("resolveProviderRoute — vertex (self-URL-building, OAuth2)", () => {
+  for (const id of ["vertex", "google-vertex", "google-vertex-anthropic"]) {
+    test(`"${id}" routes via the vertex protocol with null url`, () => {
+      const route = resolveProviderRoute(id);
+      expect(route).not.toBeNull();
+      // url is null — the region URL is built at request time.
+      expect(route?.url).toBeNull();
+      expect(route?.protocol).toBe("vertex");
+    });
+  }
+});
+
+describe("resolveWorkerProtocol — vertex (distinct, not collapsed)", () => {
+  test("a vertex session keeps the vertex worker protocol", () => {
+    // Vertex must NOT collapse to anthropic — workers need the rawPredict URL
+    // + OAuth2, handled by buildVertexWorkerRequest.
+    expect(resolveWorkerProtocol("google-vertex", "vertex")).toBe("vertex");
+    expect(resolveWorkerProtocol("vertex", "vertex")).toBe("vertex");
+    // Route-table lookup (no explicit hint) also resolves to vertex.
+    expect(resolveWorkerProtocol("google-vertex")).toBe("vertex");
+  });
+});
+
+describe("resolveProfile — vertex warming", () => {
+  const vertexBase = "https://global-aiplatform.googleapis.com";
+
+  test("warms a vertex session (provider id + host)", () => {
+    const profile = resolveProfile(
+      "claude-opus-4-8",
+      "vertex",
+      "5m",
+      vertexBase,
+      "google-vertex",
+    );
+    expect(profile).not.toBeNull();
+    expect(profile?.authMode).toBe("vertex");
+    // upstreamUrl is the region base — executeWarmup rebuilds the rawPredict URL.
+    expect(profile?.upstreamUrl).toBe(vertexBase);
+  });
+
+  test("skips a vertex protocol with a non-vertex host (no leak)", () => {
+    const profile = resolveProfile(
+      "claude-opus-4-8",
+      "vertex",
+      "5m",
+      "https://api.anthropic.com",
+      undefined,
+    );
+    expect(profile).toBeNull();
+  });
+});
+
+describe("vertex-auth — ADC token seam", () => {
+  afterEach(() => _setTestVertexTokenProvider(null));
+
+  test("getVertexAccessToken returns the injected test token", async () => {
+    _setTestVertexTokenProvider(() => Promise.resolve("test-token-123"));
+    expect(await getVertexAccessToken()).toBe("test-token-123");
+  });
+
+  test("resolveVertexProject prefers the configured project (no ADC call)", async () => {
+    _setTestVertexTokenProvider(() => Promise.resolve("t"));
+    expect(await resolveVertexProject("explicit-proj")).toBe("explicit-proj");
+  });
+});

--- a/packages/gateway/test/vertex.test.ts
+++ b/packages/gateway/test/vertex.test.ts
@@ -77,9 +77,7 @@ describe("vertexRawPredictUrl", () => {
   });
 
   test("builds a regional :rawPredict URL (non-streaming)", () => {
-    expect(
-      vertexRawPredictUrl("us-east1", "p", "claude-opus-4-8", false),
-    ).toBe(
+    expect(vertexRawPredictUrl("us-east1", "p", "claude-opus-4-8", false)).toBe(
       "https://us-east1-aiplatform.googleapis.com/v1/projects/p/locations/us-east1/publishers/anthropic/models/claude-opus-4-8:rawPredict",
     );
   });

--- a/packages/gateway/test/vertex.test.ts
+++ b/packages/gateway/test/vertex.test.ts
@@ -198,6 +198,35 @@ describe("resolveProfile — vertex warming", () => {
     );
     expect(profile).toBeNull();
   });
+
+  test("warmup body strips stream/model and keeps anthropic_version", () => {
+    // Regression: prepareAnthropicWarmupBody re-adds `stream:false`, which
+    // Vertex rejects. The vertex profile must re-strip it (and `model`).
+    const profile = resolveProfile(
+      "claude-opus-4-8",
+      "vertex",
+      "5m",
+      vertexBase,
+      "google-vertex",
+    );
+    expect(profile).not.toBeNull();
+    // A stored Vertex body (as lastRequestBody would hold) carrying a stray
+    // stream/model — the warmup transform must remove both.
+    const stored = JSON.stringify({
+      anthropic_version: "vertex-2023-10-16",
+      model: "claude-opus-4-8",
+      stream: true,
+      max_tokens: 1024,
+      system: [
+        { type: "text", text: "s", cache_control: { type: "ephemeral" } },
+      ],
+      messages: [{ role: "user", content: "hi" }],
+    });
+    const warmup = JSON.parse(profile?.prepareWarmupBody(stored) ?? "{}");
+    expect("stream" in warmup).toBe(false);
+    expect("model" in warmup).toBe(false);
+    expect(warmup.anthropic_version).toBe("vertex-2023-10-16");
+  });
 });
 
 describe("vertex-auth — ADC token seam", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
       '@supabase/supabase-js':
         specifier: ^2.58.0
         version: 2.108.1
+      google-auth-library:
+        specifier: ^10.9.0
+        version: 10.9.0
       p-limit:
         specifier: '7'
         version: 7.3.0
@@ -2410,6 +2413,10 @@ packages:
 
   google-auth-library@10.7.0:
     resolution: {integrity: sha512-QpTAbNJ36TliZLx3TTtahR8HG0hN9RllL1e3FymOvQSIKK8JmgV58H924ub2wa2DsS3ANjjP1Aw1N+Ramc8hqQ==}
+    engines: {node: '>=18'}
+
+  google-auth-library@10.9.0:
+    resolution: {integrity: sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==}
     engines: {node: '>=18'}
 
   google-logging-utils@1.1.3:
@@ -6737,6 +6744,17 @@ snapshots:
       gopd: 1.2.0
 
   google-auth-library@10.7.0:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.5
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-auth-library@10.9.0:
     dependencies:
       base64-js: 1.5.1
       ecdsa-sig-formatter: 1.0.11


### PR DESCRIPTION
feat(gateway): support Claude via Google Vertex AI (#870 part 2)

Adds **Google Vertex AI (Claude)** support to the gateway — part 2 of #870 (part 1, AWS Bedrock, already merged).

## How it works
Claude on Vertex is the native Anthropic Messages API with three differences ([docs](https://docs.claude.com/en/api/claude-on-vertex-ai)):
1. the model id is in the **URL path** (not the body);
2. `anthropic_version: "vertex-2023-10-16"` goes **in the body** (not a header);
3. streaming is selected by the URL **verb** (`:streamRawPredict` vs `:rawPredict`), not a body `stream` field.

Streaming is plain Anthropic SSE and the response is native Anthropic JSON, so both reuse the existing parsers. Auth is a **GCP OAuth2 bearer** via Application Default Credentials (lore holds the GCP creds and mints/refreshes tokens with `google-auth-library`; the client speaks plain Anthropic to lore).

Reachable via `X-Lore-Provider: vertex` / `google-vertex` / `google-vertex-anthropic`. Config uses the standard Google env vars (`GOOGLE_APPLICATION_CREDENTIALS`, `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_REGION`/`LOCATION`); region defaults to the recommended **global** endpoint (no regional premium).

## What's included (all-in-one)
- **Conversation path** (`pipeline.ts` + the pure `buildVertexUpstream` helper): reuses `buildAnthropicRequest` (incl. `cache_control`), strips `model`/`stream`, injects `anthropic_version`, builds the `:rawPredict`/`:streamRawPredict` URL, swaps `x-api-key` → GCP bearer, and strips the anthropic-only headers (`x-api-key`, `anthropic-version`, `anthropic-beta`) that Vertex does not accept. 5m cache-TTL downgrade for the non-native host (mantle precedent). cch billing re-sign never fires (gated on the anthropic protocol).
- **Worker path** (`llm-adapter.ts`): a distinct `"vertex"` worker protocol + `buildVertexWorkerRequest` (Anthropic body → rawPredict URL + OAuth bearer) so background distillation/curation run on Vertex. `buildWorkerRequest` is now async. Caching is driven by a `cache_control` block (GA on Vertex), not the `anthropic-beta` header.
- **Cache warming** (`cache-warmer.ts`): an `authMode: "vertex"` discriminator + `buildVertexProfile`; `executeWarmup` branches to use the GCP bearer + per-model rawPredict URL, no cch. The warmup body is routed through `toVertexBody` so `stream` is never sent and no `anthropic-beta` is forwarded.
- **`vertex-auth.ts`** (ADC token mint/refresh + project resolution, with a test seam) and **`translate/vertex.ts`** (URL/body/model-id/host helpers; `global` and regional hosts normalized consistently).
- Tests: `vertex.test.ts` (helpers, routes, worker protocol, warmer profile + body, auth seam, header-strip + region-override regressions) and `vertex-routing.test.ts` (`X-Lore-Provider: vertex` E2E).

## New dependency
`google-auth-library` (gateway) — the standard GCP ADC token library.

## Testing
- Full suite: **4295 passed**, 32 skipped, 0 failures. Typecheck + Biome lint clean.
- No live GCP credentials yet, so the request path is exercised via an interceptor + a token test seam (same approach as the Bedrock PR). A live smoke test is the remaining validation once a GCP project with Claude enabled is available.
- Two adversarial read-only reviews were run. The pre-open pass caught a warmup-body `stream` re-injection bug and a project-threading gap (both fixed + regression-tested). The Seer review pass led to stripping `anthropic-beta` before forwarding to Vertex and honoring an explicit `X-Lore-Upstream-URL` regional override; both fixes ship with regression tests proven non-vacuous via mutation (mutants killed on apply-then-revert).

## Follow-ups (non-blocking)
- Live-validate against an entitled Vertex project: model-id `@`-date encoding in the URL and the `anthropic-beta` strip (confirm Vertex behaves as the docs imply once Claude access is granted).
- `X-Lore-Upstream-URL` for Vertex is **region-only**: the region is extracted from the override host and the URL is rebuilt against the Google endpoint. A non-Vertex override host (e.g. a corporate proxy) is therefore discarded rather than used as the base — unlike the anthropic/openai paths. Document or extend if proxying Vertex becomes a requirement.
- Model-id alias map (`toVertexModelId`) is verified against the published table but untested live; `-latest` ids are not mapped.
