### PR TITLE
feat(references): validate cited code symbols (#911)

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1486,6 +1486,24 @@ const MIGRATIONS: string[] = [
   DROP INDEX IF EXISTS idx_temporal_session;
   DROP INDEX IF EXISTS idx_temporal_project_session;
   `,
+
+  `
+  -- Version 59: knowledge_symbol_presence — per-entry record that a cited code
+  -- symbol was once confirmed present in the repo (#911). The symbol
+  -- reference-validity check only DECAYS confidence when a symbol that was
+  -- previously present goes absent (genuine rename/removal drift). An
+  -- external/historical/rejected-alternative mention that was never present here
+  -- never gets a row, so it can never be penalized — this is what keeps symbol
+  -- validation on the safe side of the "cannot verify ≠ broken" invariant.
+  -- Keyed by the stable logical_id (matches knowledge_ref_validity /
+  -- knowledge_session_injections / knowledge_meta) so it survives version edits.
+  CREATE TABLE IF NOT EXISTS knowledge_symbol_presence (
+    logical_id      TEXT NOT NULL,
+    symbol          TEXT NOT NULL,
+    last_present_at INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (logical_id, symbol)
+  );
+  `,
 ];
 
 // Index of the migration whose work is performed by a column-presence-aware JS
@@ -1956,6 +1974,12 @@ function recoverMissingObjects(database: Database) {
       broken     INTEGER NOT NULL DEFAULT 0,
       total      INTEGER NOT NULL DEFAULT 0,
       checked_at INTEGER NOT NULL DEFAULT 0
+    );
+    CREATE TABLE IF NOT EXISTS knowledge_symbol_presence (
+      logical_id      TEXT NOT NULL,
+      symbol          TEXT NOT NULL,
+      last_present_at INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (logical_id, symbol)
     );
     CREATE TABLE IF NOT EXISTS knowledge_transfers (
       knowledge_id           TEXT NOT NULL,

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -1124,6 +1124,20 @@ export async function validateProjectReferences(
 
   let checked = 0;
   let penalized = 0;
+  // Symbol drift uses a presence HISTORY (#911): a symbol only counts as broken
+  // when it was previously confirmed present in this repo and is now absent (a
+  // genuine rename/removal). A symbol that was NEVER present here (external lib,
+  // historical/renamed-away mention, rejected alternative) never gets a row, so
+  // it can never penalize — this is what keeps symbol validation on the safe
+  // side of "cannot verify ≠ broken".
+  const recordSymbolPresent = db().query(
+    `INSERT INTO knowledge_symbol_presence (logical_id, symbol, last_present_at)
+       VALUES (?, ?, ?)
+     ON CONFLICT(logical_id, symbol) DO UPDATE SET last_present_at = excluded.last_present_at`,
+  );
+  const wasSymbolPresent = db().query(
+    `SELECT 1 FROM knowledge_symbol_presence WHERE logical_id = ? AND symbol = ?`,
+  );
   // Stamp the 24h gate in a `finally`, OUTSIDE the penalty transaction. If a
   // write inside the transaction throws, `withTransaction` rolls back the whole
   // batch — but the gate MUST still advance, otherwise the next idle tick re-runs
@@ -1137,6 +1151,24 @@ export async function validateProjectReferences(
         let total = 0; // refs with a DEFINITIVE status (ok|missing); excludes unknown
         for (const ref of refs) {
           const st = statusMap.get(ref.raw);
+          if (ref.kind === "symbol") {
+            if (st === "ok") {
+              // Confirmed present now — record so a later disappearance reads as
+              // drift. Counts as a definitive (verifiable) ref, never broken.
+              recordSymbolPresent.run(logicalId, ref.name, now);
+              total++;
+            } else if (st === "missing") {
+              // Confirmed ABSENT. Only drift (broken) if we have proof it was
+              // present before; otherwise a strict no-op (never-present mention).
+              if (wasSymbolPresent.get(logicalId, ref.name)) {
+                broken++;
+                total++;
+              }
+            }
+            // "unknown" → neutral, not counted
+            continue;
+          }
+          // file / command refs: a definitive "missing" is directly broken.
           if (st === "missing") {
             broken++;
             total++;

--- a/packages/core/src/references.ts
+++ b/packages/core/src/references.ts
@@ -20,6 +20,7 @@
 // `SyntheticProbeResolver` via a single `RepoView` + `resolveRefAgainstView`, so
 // the two modes can never silently diverge.
 
+import { spawnSync } from "node:child_process";
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { isAbsolute, join, normalize } from "node:path";
 
@@ -34,6 +35,19 @@ export type Reference =
        *  A bare `pnpm X` is ambiguous with a noun phrase ("npm registry") and is
        *  resolved confirm-only (never "missing"). `make` is always false. */
       explicit: boolean;
+      raw: string;
+    }
+  | {
+      /** A cited code identifier (function / const / class / type name) that the
+       *  entry claims still exists — e.g. "`evaluateCacheStrategy` called only
+       *  from `cache-warmer.ts:1252`" (#911). Only extracted when (a) inside a
+       *  backtick span, (b) the entry ALSO has a file ref (the adjacency bound),
+       *  and (c) the token is "codey" (PascalCase / camelCase / has `_` / was
+       *  call-like). Resolution is presence-only (grep), never AST: present
+       *  anywhere in tracked source → ok; searched-and-absent repo-wide →
+       *  missing; grep unavailable → unknown. */
+      kind: "symbol";
+      name: string;
       raw: string;
     };
 
@@ -124,6 +138,27 @@ const PM_BUILTINS = new Set([
 const PM_CMD_RE = /\b(pnpm|npm|yarn)\s+(run\s+)?([A-Za-z][A-Za-z0-9:_-]*)/g;
 const MAKE_CMD_RE = /\bmake\s+([A-Za-z][A-Za-z0-9:_-]*)/g;
 
+// Candidate code identifiers inside a backtick span (#911). The charset is the
+// grep-safe identifier set `[A-Za-z_][A-Za-z0-9_]*` ON PURPOSE — every extracted
+// name must be safe to embed in `git grep -F -- <name>` and in the client probe
+// without any escaping, and a name we can't grep must never be coined (it would
+// resolve "missing" on a Set absence). `$`-bearing identifiers are simply not
+// extracted (false negative, the safe direction). Group 1 is the identifier; the
+// trailing `\(?` lets us tell a call-site (`foo(`) from a bare token.
+const SYMBOL_CAND_RE = /([A-Za-z_][A-Za-z0-9_]*)(\()?/g;
+
+// A token is treated as a cited *symbol* (not prose) only when it carries a code
+// marker: it was call-like (`foo(`), PascalCase/camelCase (an internal case
+// change), or snake/CONSTANT_CASE (an `_`). Bare marker-free lowercase words
+// (`run`, `total`, `state`, `file`) read as prose and are rejected — this gate is
+// the load-bearing false-positive killer for the 🔴 never-penalize invariant.
+function isCodeySymbol(name: string, callLike: boolean): boolean {
+  if (callLike) return true;
+  if (name.includes("_")) return true;
+  // mixed case covers both camelCase (`sessionID`) and PascalCase (`RepoView`).
+  return /[a-z]/.test(name) && /[A-Z]/.test(name);
+}
+
 // Inline-code / fenced-code spans (the inner text between backtick runs).
 // Command references are extracted ONLY from inside code spans, and only ever
 // per single line (see codeLines). Knowledge entries consistently backtick-wrap
@@ -204,6 +239,11 @@ export function extractReferences(text: string): Reference[] {
     });
   }
 
+  // Symbol refs are only meaningful when the entry also anchors a file (the
+  // adjacency bound from #911): a backtick identifier with no co-cited file is
+  // too unmoored to act on. Computed once, before the code-span scan.
+  const hasFileRef = out.some((r) => r.kind === "file");
+
   // Commands only from inside backtick code spans, matched PER LINE (see
   // codeLines rationale) so neither separate spans nor separate lines can fuse
   // a runner with an unrelated following token into a phantom command.
@@ -231,6 +271,19 @@ export function extractReferences(text: string): Reference[] {
         explicit: false,
         raw,
       });
+    }
+
+    // Symbols: only when the entry anchors a file (adjacency bound) and the
+    // token passes the codey-shape gate. `raw` is the bare name (a `foo` and a
+    // `foo(` citation dedupe to one resolve).
+    if (!hasFileRef) continue;
+    for (const m of line.matchAll(SYMBOL_CAND_RE)) {
+      const name = m[1];
+      const callLike = m[2] !== undefined;
+      if (!isCodeySymbol(name, callLike)) continue;
+      if (seen.has(name)) continue;
+      seen.add(name);
+      out.push({ kind: "symbol", name, raw: name });
     }
   }
 
@@ -281,6 +334,14 @@ export interface RepoView {
   scripts: Set<string> | null;
   /** Makefile target names, or null if no Makefile. */
   makeTargets: Set<string> | null;
+  /** Cited symbol names confirmed to occur somewhere in tracked source
+   *  (word-boundary grep). `null` when symbol presence couldn't be determined
+   *  (non-git repo, `find` fallback, grep unavailable) — every symbol ref then
+   *  resolves "unknown" (neutral). When non-null, membership IS the answer: a
+   *  cited symbol absent from this set was searched-for and not found → repo-wide
+   *  absent → "missing". Presence-only (any occurrence, incl. usages/comments);
+   *  the asymmetry keeps us from ever emitting a false "missing" (#911). */
+  presentSymbols: Set<string> | null;
   /** Line count for a repo-relative file, or null if it can't be determined. */
   lineCount(relpath: string): number | null;
   /** True when the file walk was truncated by WALK_FILE_CAP — file-not-found is
@@ -294,6 +355,16 @@ export function resolveRefAgainstView(
   ref: Reference,
   view: RepoView,
 ): RefStatus {
+  if (ref.kind === "symbol") {
+    // Presence-only resolution (#911). null → couldn't grep → neutral. Otherwise
+    // membership decides: found anywhere → ok; searched-and-absent → missing. We
+    // deliberately accept usage/comment occurrences as "ok" — declining
+    // definition-vs-usage precision keeps us off the dangerous (false-"missing")
+    // side of the 🔴 invariant.
+    if (view.presentSymbols == null) return "unknown";
+    return view.presentSymbols.has(ref.name) ? "ok" : "missing";
+  }
+
   if (ref.kind === "command") {
     // `make` has no `run` verb and "make X" reads as prose ("make sense"); it is
     // confirm-only — an absent target is UNKNOWN (neutral), never "missing".
@@ -409,10 +480,53 @@ export class DirectFsResolver implements ReferenceResolver {
 
   // biome-ignore lint/suspicious/useAwait: async to satisfy the ReferenceResolver interface
   async resolve(refs: Reference[]): Promise<Map<string, RefStatus> | null> {
-    const view = this.repoView();
+    // The file/command view is ref-independent and cached. Symbol presence IS
+    // ref-dependent (we grep for exactly the cited names), so compute it per
+    // batch and overlay it onto a fresh view for this call (#911).
+    const names = [
+      ...new Set(refs.flatMap((r) => (r.kind === "symbol" ? [r.name] : []))),
+    ];
+    const view: RepoView = {
+      ...this.repoView(),
+      presentSymbols: this.symbolPresence(names),
+    };
     const map = new Map<string, RefStatus>();
     for (const ref of refs) map.set(ref.raw, resolveRefAgainstView(ref, view));
     return map;
+  }
+
+  /** Which of `names` occur (word-boundary) anywhere in tracked source. Returns
+   *  null when symbol presence can't be determined (root isn't a git work tree /
+   *  git unavailable) so every symbol ref stays "unknown" (neutral). An empty
+   *  input yields an empty Set (nothing to search), which is irrelevant since
+   *  there are then no symbol refs to resolve. */
+  private symbolPresence(names: string[]): Set<string> | null {
+    if (names.length === 0) return new Set();
+    const inTree = spawnSync(
+      "git",
+      ["-C", this.root, "rev-parse", "--is-inside-work-tree"],
+      { encoding: "utf8" },
+    );
+    if (inTree.status !== 0 || inTree.stdout.trim() !== "true") return null;
+    const present = new Set<string>();
+    for (const name of names) {
+      // Defense-in-depth: extraction already guarantees this charset, but assert
+      // again so a future regex change can't turn a name into a grep argument we
+      // can't reason about. A non-conforming name is left ABSENT-but-unsearched,
+      // so it must resolve neutral — but since it can't be extracted, this never
+      // fires in practice.
+      if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) continue;
+      // `-q` short-circuits on first hit (bounded output, fast on common ids);
+      // `-w` whole word (so `foo` never matches `foobar`); `-F` fixed string;
+      // `--` so a name can't be read as a flag.
+      const r = spawnSync(
+        "git",
+        ["-C", this.root, "grep", "-qwF", "--", name],
+        { encoding: "utf8" },
+      );
+      if (r.status === 0) present.add(name);
+    }
+    return present;
   }
 
   private repoView(): RepoView {
@@ -424,6 +538,9 @@ export class DirectFsResolver implements ReferenceResolver {
       filesLower: walk.filesLower,
       basenames: walk.basenames,
       truncated: walk.truncated,
+      // Placeholder — symbol presence is computed per batch in resolve() and
+      // overlaid; the cached file/command view never carries it.
+      presentSymbols: null,
       scripts: readScripts(safeRead(join(root, "package.json"))),
       makeTargets: readMakeTargets(
         safeRead(join(root, "Makefile")) ??
@@ -510,6 +627,12 @@ export class NoopResolver implements ReferenceResolver {
 const PROBE_PKG = "===LORE-PKG===";
 const PROBE_MAKE = "===LORE-MAKE===";
 const PROBE_LINES = "===LORE-LINES===";
+// #911 symbol section. PROBE_SYMS opens it; PROBE_SYMS_OK is emitted ONLY inside
+// the `git`-present branch, so the parser can tell "grep ran, found none" (→ an
+// empty Set, real misses) from "grep didn't run" (→ null, neutral). Without this
+// marker an empty section would be ambiguous and could mass-penalize.
+const PROBE_SYMS = "===LORE-SYMS===";
+const PROBE_SYMS_OK = "===LORE-SYMS-OK===";
 
 /**
  * Build the read-only shell probe that emits a repo snapshot: the tracked file
@@ -533,6 +656,20 @@ export function buildRefcheckProbeScript(refs: Reference[]): string {
   }
   // `|a.ts|b.ts|` — a glob-case membership test; basenames are metachar-free.
   const refset = `|${[...basenames].join("|")}|`;
+
+  // Cited symbols (#911), identifier-charset only (single-quote-safe; assert
+  // again as defense-in-depth). One `git grep -qwF` per symbol, emitted as a
+  // literal command list (no shell `for … in` so an empty list is a non-issue);
+  // a matched symbol echoes its own name back. The grep runs from the repo root
+  // (the leading `cd` subshell) so it agrees with Direct-FS.
+  const symbols = new Set<string>();
+  for (const ref of refs) {
+    if (ref.kind !== "symbol") continue;
+    if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(ref.name)) symbols.add(ref.name);
+  }
+  const symbolLines = [...symbols].map(
+    (s) => `git grep -qwF -- '${s}' 2>/dev/null && printf '%s\\n' '${s}'`,
+  );
   // Run the snapshot from the REPO ROOT, not the client's CWD. `git ls-files`
   // (and the `find` fallback) emit paths relative to the working directory, but
   // knowledge refs are repo-root-relative (`packages/core/src/db.ts:42`). An
@@ -552,6 +689,19 @@ export function buildRefcheckProbeScript(refs: Reference[]): string {
     `printf '%s\\n' '${PROBE_LINES}'`,
     `__refset='${refset}'`,
     `printf '%s\\n' "$__f" | while IFS= read -r f; do bn=$(printf '%s' "\${f##*/}" | tr '[:upper:]' '[:lower:]'); case "$__refset" in *"|$bn|"*) printf '%s\\t%s\\n' "$f" "$(wc -l < "$f" 2>/dev/null)";; esac; done`,
+    // Symbol section: the OK marker is printed ONLY when this IS a git work tree,
+    // so the parser distinguishes "ran, none found" from "couldn't run".
+    `printf '%s\\n' '${PROBE_SYMS}'`,
+    `if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then`,
+    `printf '%s\\n' '${PROBE_SYMS_OK}'`,
+    ...symbolLines,
+    `fi`,
+    // Force a 0 exit: the last `git grep -q` returns 1 when a symbol is absent,
+    // which would otherwise make the whole probe exit non-zero → the client's
+    // tool marks it `isError` → the ENTIRE refcheck batch goes neutral (no
+    // penalties at all). A trailing `true` keeps a legitimately-missing symbol
+    // a "missing", not a silent batch abort.
+    `true`,
     `)`,
   ].join("\n");
 }
@@ -565,10 +715,16 @@ export function parseProbeSnapshot(text: string): RepoView | null {
   const linesAt = text.indexOf(PROBE_LINES);
   if (makeAt === -1 || linesAt === -1) return null;
 
+  // The symbol section (if any) follows PROBE_LINES, so the lines block ends
+  // where it begins. Older probes have no PROBE_SYMS — lines run to EOF.
+  const symsAt = text.indexOf(PROBE_SYMS);
   const fileBlock = text.slice(0, pkgAt);
   const pkgBlock = text.slice(pkgAt + PROBE_PKG.length, makeAt);
   const makeBlock = text.slice(makeAt + PROBE_MAKE.length, linesAt);
-  const linesBlock = text.slice(linesAt + PROBE_LINES.length);
+  const linesBlock = text.slice(
+    linesAt + PROBE_LINES.length,
+    symsAt === -1 ? text.length : symsAt,
+  );
 
   const files = new Set<string>();
   const filesLower = new Map<string, string[]>();
@@ -598,10 +754,30 @@ export function parseProbeSnapshot(text: string): RepoView | null {
     if (path && !Number.isNaN(n)) lineCounts.set(path, n + 1); // +1: trailing-newline lenience, mirrors Direct-FS split
   }
 
+  // Symbol presence (#911): null unless the section exists AND carries the OK
+  // marker (= the client ran `git grep`). "Ran, found none" is a real empty Set
+  // (genuine misses); "didn't run" / "old probe" is null (neutral).
+  let presentSymbols: Set<string> | null = null;
+  if (symsAt !== -1) {
+    const symsBlock = text.slice(symsAt + PROBE_SYMS.length);
+    const okAt = symsBlock.indexOf(PROBE_SYMS_OK);
+    if (okAt !== -1) {
+      const set = new Set<string>();
+      for (const raw of symsBlock
+        .slice(okAt + PROBE_SYMS_OK.length)
+        .split("\n")) {
+        const s = raw.trim();
+        if (s && /^[A-Za-z_][A-Za-z0-9_]*$/.test(s)) set.add(s);
+      }
+      presentSymbols = set;
+    }
+  }
+
   return {
     files,
     filesLower,
     basenames,
+    presentSymbols,
     scripts: readScripts(pkgBlock.trim() || null),
     makeTargets: readMakeTargets(makeBlock.trim() || null),
     lineCount: (rel) => lineCounts.get(rel) ?? null,

--- a/packages/core/src/references.ts
+++ b/packages/core/src/references.ts
@@ -334,14 +334,19 @@ export interface RepoView {
   scripts: Set<string> | null;
   /** Makefile target names, or null if no Makefile. */
   makeTargets: Set<string> | null;
-  /** Cited symbol names confirmed to occur somewhere in tracked source
-   *  (word-boundary grep). `null` when symbol presence couldn't be determined
-   *  (non-git repo, `find` fallback, grep unavailable) — every symbol ref then
-   *  resolves "unknown" (neutral). When non-null, membership IS the answer: a
-   *  cited symbol absent from this set was searched-for and not found → repo-wide
-   *  absent → "missing". Presence-only (any occurrence, incl. usages/comments);
-   *  the asymmetry keeps us from ever emitting a false "missing" (#911). */
+  /** Cited symbol names confirmed PRESENT (word-boundary occurrence anywhere in
+   *  tracked source, incl. usages/comments). `null` when symbol presence is
+   *  entirely unavailable (non-git repo, `find` fallback) — every symbol ref then
+   *  resolves "unknown" (neutral). Subset of `searchedSymbols`. (#911) */
   presentSymbols: Set<string> | null;
+  /** Cited symbol names the resolver DEFINITIVELY searched for (grep ran and
+   *  returned found/not-found). A symbol in `searchedSymbols` but not
+   *  `presentSymbols` is confirmed-ABSENT → "missing"; a symbol that was NOT
+   *  searched (grep errored, e.g. exit 128) is omitted from both sets → "unknown"
+   *  (neutral), never a false "missing". `null` whenever `presentSymbols` is null.
+   *  This is what keeps a transient grep error off the dangerous side of the 🔴
+   *  invariant. (#911) */
+  searchedSymbols: Set<string> | null;
   /** Line count for a repo-relative file, or null if it can't be determined. */
   lineCount(relpath: string): number | null;
   /** True when the file walk was truncated by WALK_FILE_CAP — file-not-found is
@@ -356,13 +361,20 @@ export function resolveRefAgainstView(
   view: RepoView,
 ): RefStatus {
   if (ref.kind === "symbol") {
-    // Presence-only resolution (#911). null → couldn't grep → neutral. Otherwise
-    // membership decides: found anywhere → ok; searched-and-absent → missing. We
-    // deliberately accept usage/comment occurrences as "ok" — declining
-    // definition-vs-usage precision keeps us off the dangerous (false-"missing")
-    // side of the 🔴 invariant.
+    // Presence resolution (#911), three-way so a grep error is never a false
+    // "missing": no presence info at all → neutral; found → ok; searched and not
+    // found → missing (confirmed absent); searched-set present but this name not
+    // in it (grep errored for it) → neutral. "Found anywhere" (incl.
+    // usage/comment) counts as ok — declining definition-vs-usage precision keeps
+    // us off the dangerous side of the 🔴 invariant. NOTE: a "missing" here is
+    // only ACTED ON by validateProjectReferences when the symbol was previously
+    // confirmed present (drift); a never-present external/historical mention is a
+    // no-op. The pure verdict stays presence-shaped so both modes agree.
     if (view.presentSymbols == null) return "unknown";
-    return view.presentSymbols.has(ref.name) ? "ok" : "missing";
+    if (view.presentSymbols.has(ref.name)) return "ok";
+    if (view.searchedSymbols != null && !view.searchedSymbols.has(ref.name))
+      return "unknown"; // not definitively searched (grep error) → neutral
+    return "missing"; // searched and absent
   }
 
   if (ref.kind === "command") {
@@ -486,47 +498,65 @@ export class DirectFsResolver implements ReferenceResolver {
     const names = [
       ...new Set(refs.flatMap((r) => (r.kind === "symbol" ? [r.name] : []))),
     ];
+    const sym = this.symbolPresence(names);
     const view: RepoView = {
       ...this.repoView(),
-      presentSymbols: this.symbolPresence(names),
+      presentSymbols: sym?.present ?? null,
+      searchedSymbols: sym?.searched ?? null,
     };
     const map = new Map<string, RefStatus>();
     for (const ref of refs) map.set(ref.raw, resolveRefAgainstView(ref, view));
     return map;
   }
 
-  /** Which of `names` occur (word-boundary) anywhere in tracked source. Returns
-   *  null when symbol presence can't be determined (root isn't a git work tree /
-   *  git unavailable) so every symbol ref stays "unknown" (neutral). An empty
-   *  input yields an empty Set (nothing to search), which is irrelevant since
-   *  there are then no symbol refs to resolve. */
-  private symbolPresence(names: string[]): Set<string> | null {
-    if (names.length === 0) return new Set();
-    const inTree = spawnSync(
+  /** Which of `names` are present vs definitively searched, via `git grep`.
+   *  Returns null when symbol presence can't be determined at all (root isn't a
+   *  git work tree / git unavailable) → every symbol ref stays "unknown". An
+   *  empty input yields empty sets (irrelevant — no symbol refs to resolve).
+   *
+   *  Greps from the repo TOPLEVEL (not `this.root`) so a symbol defined in a
+   *  sibling package of a monorepo still resolves — matching the synthetic
+   *  probe's `cd $(git rev-parse --show-toplevel)` so the two modes agree (SF3).
+   *  `GIT_*` env is scrubbed so a gateway launched under a stray `GIT_DIR` /
+   *  `GIT_INDEX_FILE` can't grep the wrong repo and mass-false-miss (SF2).
+   *  A grep exit of 0=present, 1=absent; ANY other status (128 error, signal)
+   *  leaves the name UNSEARCHED → "unknown" (SF1) — never a false "missing". */
+  private symbolPresence(
+    names: string[],
+  ): { present: Set<string>; searched: Set<string> } | null {
+    if (names.length === 0) return { present: new Set(), searched: new Set() };
+    const env = scrubbedGitEnv();
+    const top = spawnSync(
       "git",
-      ["-C", this.root, "rev-parse", "--is-inside-work-tree"],
-      { encoding: "utf8" },
+      ["-C", this.root, "rev-parse", "--show-toplevel"],
+      { encoding: "utf8", env },
     );
-    if (inTree.status !== 0 || inTree.stdout.trim() !== "true") return null;
+    if (top.status !== 0) return null;
+    const cwd = top.stdout.trim();
+    if (!cwd) return null;
     const present = new Set<string>();
+    const searched = new Set<string>();
     for (const name of names) {
       // Defense-in-depth: extraction already guarantees this charset, but assert
       // again so a future regex change can't turn a name into a grep argument we
-      // can't reason about. A non-conforming name is left ABSENT-but-unsearched,
-      // so it must resolve neutral — but since it can't be extracted, this never
-      // fires in practice.
+      // can't reason about. A non-conforming name is left UNSEARCHED → neutral.
       if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) continue;
-      // `-q` short-circuits on first hit (bounded output, fast on common ids);
-      // `-w` whole word (so `foo` never matches `foobar`); `-F` fixed string;
-      // `--` so a name can't be read as a flag.
-      const r = spawnSync(
-        "git",
-        ["-C", this.root, "grep", "-qwF", "--", name],
-        { encoding: "utf8" },
-      );
-      if (r.status === 0) present.add(name);
+      // `-q` short-circuits on first hit (bounded, fast); `-w` whole word (so
+      // `foo` never matches `foobar`); `-F` fixed string; `--` so a name can't be
+      // read as a flag.
+      const r = spawnSync("git", ["-C", cwd, "grep", "-qwF", "--", name], {
+        encoding: "utf8",
+        env,
+      });
+      if (r.status === 0) {
+        present.add(name);
+        searched.add(name);
+      } else if (r.status === 1) {
+        searched.add(name); // definitively absent
+      }
+      // any other status (e.g. 128 / null) → unsearched → "unknown" (neutral)
     }
-    return present;
+    return { present, searched };
   }
 
   private repoView(): RepoView {
@@ -538,9 +568,10 @@ export class DirectFsResolver implements ReferenceResolver {
       filesLower: walk.filesLower,
       basenames: walk.basenames,
       truncated: walk.truncated,
-      // Placeholder — symbol presence is computed per batch in resolve() and
+      // Placeholders — symbol presence is computed per batch in resolve() and
       // overlaid; the cached file/command view never carries it.
       presentSymbols: null,
+      searchedSymbols: null,
       scripts: readScripts(safeRead(join(root, "package.json"))),
       makeTargets: readMakeTargets(
         safeRead(join(root, "Makefile")) ??
@@ -628,11 +659,32 @@ const PROBE_PKG = "===LORE-PKG===";
 const PROBE_MAKE = "===LORE-MAKE===";
 const PROBE_LINES = "===LORE-LINES===";
 // #911 symbol section. PROBE_SYMS opens it; PROBE_SYMS_OK is emitted ONLY inside
-// the `git`-present branch, so the parser can tell "grep ran, found none" (→ an
-// empty Set, real misses) from "grep didn't run" (→ null, neutral). Without this
-// marker an empty section would be ambiguous and could mass-penalize.
+// the `git`-present branch (so "grep ran" is distinguishable from "git absent");
+// PROBE_SYMS_DONE is emitted ONLY after every per-symbol grep completed, so a
+// truncated probe (output cut mid-section) yields a NULL set instead of a partial
+// one that would false-"missing" the un-emitted symbols (SF4). Between OK and
+// DONE, each searched symbol emits `name\t1` (present) or `name\t0` (absent); a
+// grep that errored emits nothing → the name stays UNSEARCHED → "unknown".
 const PROBE_SYMS = "===LORE-SYMS===";
 const PROBE_SYMS_OK = "===LORE-SYMS-OK===";
+const PROBE_SYMS_DONE = "===LORE-SYMS-DONE===";
+
+/** A copy of the process env with git context-overrides removed, so a `git grep`
+ *  the gateway spawns can't be redirected to the wrong repo (or a `/dev/null`
+ *  index) by an inherited `GIT_DIR` / `GIT_INDEX_FILE` / `GIT_WORK_TREE` and
+ *  mass-false-miss every symbol (#911 SF2). */
+function scrubbedGitEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  for (const k of [
+    "GIT_DIR",
+    "GIT_INDEX_FILE",
+    "GIT_WORK_TREE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_COMMON_DIR",
+  ])
+    delete env[k];
+  return env;
+}
 
 /**
  * Build the read-only shell probe that emits a repo snapshot: the tracked file
@@ -658,17 +710,20 @@ export function buildRefcheckProbeScript(refs: Reference[]): string {
   const refset = `|${[...basenames].join("|")}|`;
 
   // Cited symbols (#911), identifier-charset only (single-quote-safe; assert
-  // again as defense-in-depth). One `git grep -qwF` per symbol, emitted as a
-  // literal command list (no shell `for … in` so an empty list is a non-issue);
-  // a matched symbol echoes its own name back. The grep runs from the repo root
-  // (the leading `cd` subshell) so it agrees with Direct-FS.
+  // again as defense-in-depth). One grep per symbol, emitted as a literal command
+  // list (no shell `for … in`, so an empty list is a non-issue). Each emits
+  // `name\t1` (present) or `name\t0` (absent); a grep that ERRORED (exit 128, not
+  // 0/1) emits nothing → the parser leaves it UNSEARCHED → "unknown" (SF1). The
+  // grep runs from the repo root (leading `cd` subshell) so it agrees with the
+  // toplevel-scoped Direct-FS grep.
   const symbols = new Set<string>();
   for (const ref of refs) {
     if (ref.kind !== "symbol") continue;
     if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(ref.name)) symbols.add(ref.name);
   }
   const symbolLines = [...symbols].map(
-    (s) => `git grep -qwF -- '${s}' 2>/dev/null && printf '%s\\n' '${s}'`,
+    (s) =>
+      `git grep -qwF -- '${s}' 2>/dev/null; case $? in 0) printf '%s\\t1\\n' '${s}';; 1) printf '%s\\t0\\n' '${s}';; esac`,
   );
   // Run the snapshot from the REPO ROOT, not the client's CWD. `git ls-files`
   // (and the `find` fallback) emit paths relative to the working directory, but
@@ -689,18 +744,20 @@ export function buildRefcheckProbeScript(refs: Reference[]): string {
     `printf '%s\\n' '${PROBE_LINES}'`,
     `__refset='${refset}'`,
     `printf '%s\\n' "$__f" | while IFS= read -r f; do bn=$(printf '%s' "\${f##*/}" | tr '[:upper:]' '[:lower:]'); case "$__refset" in *"|$bn|"*) printf '%s\\t%s\\n' "$f" "$(wc -l < "$f" 2>/dev/null)";; esac; done`,
-    // Symbol section: the OK marker is printed ONLY when this IS a git work tree,
-    // so the parser distinguishes "ran, none found" from "couldn't run".
+    // Symbol section: OK is printed only inside a git work tree (so the parser
+    // tells "ran" from "git absent"); DONE is printed only after EVERY per-symbol
+    // grep completed, so a truncated probe → no DONE → neutral (SF4), never a
+    // partial set that false-misses the un-emitted symbols.
     `printf '%s\\n' '${PROBE_SYMS}'`,
     `if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then`,
     `printf '%s\\n' '${PROBE_SYMS_OK}'`,
     ...symbolLines,
+    `printf '%s\\n' '${PROBE_SYMS_DONE}'`,
     `fi`,
-    // Force a 0 exit: the last `git grep -q` returns 1 when a symbol is absent,
-    // which would otherwise make the whole probe exit non-zero → the client's
-    // tool marks it `isError` → the ENTIRE refcheck batch goes neutral (no
-    // penalties at all). A trailing `true` keeps a legitimately-missing symbol
-    // a "missing", not a silent batch abort.
+    // Force a 0 exit: a per-symbol `git grep -q` returns 1 when absent, which
+    // would otherwise make the whole probe exit non-zero → the client tool marks
+    // it `isError` → the ENTIRE refcheck batch goes neutral. A trailing `true`
+    // keeps a legitimately-absent symbol a real signal, not a silent batch abort.
     `true`,
     `)`,
   ].join("\n");
@@ -754,22 +811,38 @@ export function parseProbeSnapshot(text: string): RepoView | null {
     if (path && !Number.isNaN(n)) lineCounts.set(path, n + 1); // +1: trailing-newline lenience, mirrors Direct-FS split
   }
 
-  // Symbol presence (#911): null unless the section exists AND carries the OK
-  // marker (= the client ran `git grep`). "Ran, found none" is a real empty Set
-  // (genuine misses); "didn't run" / "old probe" is null (neutral).
+  // Symbol presence (#911): both sets are null unless the section is bounded by
+  // BOTH the OK marker (client ran `git grep`) AND the DONE marker (every grep
+  // completed — output not truncated). Each `name\t1` line is present+searched;
+  // `name\t0` is searched-absent; an errored grep emitted nothing → unsearched →
+  // "unknown". Missing OK (git absent) / missing DONE (truncated) / old probe →
+  // null (neutral), so a degenerate or cut-off probe can never false-"missing".
   let presentSymbols: Set<string> | null = null;
+  let searchedSymbols: Set<string> | null = null;
   if (symsAt !== -1) {
     const symsBlock = text.slice(symsAt + PROBE_SYMS.length);
     const okAt = symsBlock.indexOf(PROBE_SYMS_OK);
-    if (okAt !== -1) {
-      const set = new Set<string>();
+    const doneAt = symsBlock.indexOf(PROBE_SYMS_DONE);
+    if (okAt !== -1 && doneAt !== -1 && doneAt > okAt) {
+      const present = new Set<string>();
+      const searched = new Set<string>();
       for (const raw of symsBlock
-        .slice(okAt + PROBE_SYMS_OK.length)
+        .slice(okAt + PROBE_SYMS_OK.length, doneAt)
         .split("\n")) {
-        const s = raw.trim();
-        if (s && /^[A-Za-z_][A-Za-z0-9_]*$/.test(s)) set.add(s);
+        const tab = raw.indexOf("\t");
+        if (tab === -1) continue;
+        const name = raw.slice(0, tab).trim();
+        const bit = raw.slice(tab + 1).trim();
+        if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) continue;
+        if (bit === "1") {
+          present.add(name);
+          searched.add(name);
+        } else if (bit === "0") {
+          searched.add(name);
+        }
       }
-      presentSymbols = set;
+      presentSymbols = present;
+      searchedSymbols = searched;
     }
   }
 
@@ -778,6 +851,7 @@ export function parseProbeSnapshot(text: string): RepoView | null {
     filesLower,
     basenames,
     presentSymbols,
+    searchedSymbols,
     scripts: readScripts(pkgBlock.trim() || null),
     makeTargets: readMakeTargets(makeBlock.trim() || null),
     lineCount: (rel) => lineCounts.get(rel) ?? null,

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -59,7 +59,7 @@ describe("db", () => {
     const row = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(row.version).toBe(58);
+    expect(row.version).toBe(59);
   });
 
   test("v55: confidence/last_reinforced_at moved to knowledge_meta, exposed via view", () => {
@@ -116,7 +116,7 @@ describe("db", () => {
     const ver = fresh.query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(ver.version).toBe(58);
+    expect(ver.version).toBe(59);
     // Register + JOIN view were rebuilt and are queryable (confidence exposed).
     expect(
       fresh

--- a/packages/core/test/ltm-reference-validity.test.ts
+++ b/packages/core/test/ltm-reference-validity.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -186,3 +187,48 @@ describe("validateProjectReferences (#627 Phase 0)", () => {
     expect(row).toMatchObject({ broken: 1, total: 2 });
   });
 });
+
+// Cited-symbol validation end-to-end (#911): a symbol miss must flow through the
+// SAME penalty machinery as a file miss (one flat −0.1, neutral when
+// unverifiable). Needs a real git work tree (`git grep`), so these git-init the
+// per-test root.
+describe.skipIf(process.platform === "win32")(
+  "validateProjectReferences — cited symbols (#911)",
+  () => {
+    const gitInit = (): void => {
+      execFileSync("git", ["init", "-q"], { cwd: root });
+      execFileSync("git", ["add", "-A"], { cwd: root });
+    };
+
+    test("absent symbol (file:line still valid) → penalized once", async () => {
+      // real.ts exists and line 3 is in range, so Phase-0's file/line check says
+      // "ok" — only the symbol check catches that `removedHelperFn` is gone.
+      const id = seed("`removedHelperFn` lives in src/real.ts:3");
+      gitInit();
+      const res = await ltm.validateProjectReferences(root, resolver());
+      expect(res.penalized).toBe(1);
+      expect(conf(id)).toBeCloseTo(1.0 - ltm.REFERENCE_DRIFT_PENALTY, 5);
+    });
+
+    test("present symbol → no penalty", async () => {
+      writeFileSync(
+        join(root, "src", "real.ts"),
+        "export const keptHelper = 1;\n",
+      );
+      const id = seed("`keptHelper` lives in src/real.ts:1");
+      gitInit();
+      const res = await ltm.validateProjectReferences(root, resolver());
+      expect(res.penalized).toBe(0);
+      expect(conf(id)).toBe(1.0);
+    });
+
+    test("non-git repo → symbol unverifiable, never penalizes (neutral)", async () => {
+      // No gitInit(): presentSymbols is null → symbol "unknown" → no signal. The
+      // co-cited file ref is valid, so the entry is checked but not penalized.
+      const id = seed("`removedHelperFn` lives in src/real.ts:3");
+      const res = await ltm.validateProjectReferences(root, resolver());
+      expect(res.penalized).toBe(0);
+      expect(conf(id)).toBe(1.0);
+    });
+  },
+);

--- a/packages/core/test/ltm-reference-validity.test.ts
+++ b/packages/core/test/ltm-reference-validity.test.ts
@@ -188,10 +188,11 @@ describe("validateProjectReferences (#627 Phase 0)", () => {
   });
 });
 
-// Cited-symbol validation end-to-end (#911): a symbol miss must flow through the
-// SAME penalty machinery as a file miss (one flat −0.1, neutral when
-// unverifiable). Needs a real git work tree (`git grep`), so these git-init the
-// per-test root.
+// Cited-symbol validation end-to-end (#911): symbols use a presence HISTORY. A
+// symbol only decays confidence when it was PREVIOUSLY confirmed present and is
+// now absent (genuine rename/removal drift). A never-present mention (external
+// lib, historical/renamed-away name, rejected alternative) is a strict no-op.
+// Needs a real git work tree (`git grep`), so these git-init the per-test root.
 describe.skipIf(process.platform === "win32")(
   "validateProjectReferences — cited symbols (#911)",
   () => {
@@ -200,17 +201,49 @@ describe.skipIf(process.platform === "win32")(
       execFileSync("git", ["add", "-A"], { cwd: root });
     };
 
-    test("absent symbol (file:line still valid) → penalized once", async () => {
-      // real.ts exists and line 3 is in range, so Phase-0's file/line check says
-      // "ok" — only the symbol check catches that `removedHelperFn` is gone.
-      const id = seed("`removedHelperFn` lives in src/real.ts:3");
+    test("drift: a symbol once present, now absent → penalized once", async () => {
+      writeFileSync(
+        join(root, "src", "real.ts"),
+        "export function keptHelper() {}\na\nb\nc\n",
+      );
+      const id = seed("`keptHelper` lives in src/real.ts:1");
       gitInit();
-      const res = await ltm.validateProjectReferences(root, resolver());
-      expect(res.penalized).toBe(1);
+      const t0 = Date.now();
+      // Pass 1: symbol present → records presence, no penalty.
+      const p1 = await ltm.validateProjectReferences(root, resolver(), t0);
+      expect(p1.penalized).toBe(0);
+      expect(conf(id)).toBe(1.0);
+      // The symbol is removed from the repo.
+      writeFileSync(join(root, "src", "real.ts"), "a\nb\nc\nd\n");
+      execFileSync("git", ["add", "-A"], { cwd: root });
+      // Pass 2, after the 24h gate: absent + prior presence → drift → penalize.
+      const p2 = await ltm.validateProjectReferences(
+        root,
+        resolver(),
+        t0 + ltm.REFCHECK_INTERVAL_MS + 1,
+      );
+      expect(p2.penalized).toBe(1);
       expect(conf(id)).toBeCloseTo(1.0 - ltm.REFERENCE_DRIFT_PENALTY, 5);
     });
 
-    test("present symbol → no penalty", async () => {
+    // 🔴 BLOCKER regression: an absent symbol that was NEVER present here (React's
+    // useState, a rejected alternative, a renamed-away name) must NOT penalize a
+    // perfectly valid entry — "cannot verify ≠ broken".
+    test("never-present mention (external/historical) absent → neutral", async () => {
+      writeFileSync(
+        join(root, "src", "real.ts"),
+        "export const keptHelper = 1;\n",
+      );
+      const id = seed(
+        "Unlike React's `useState`, we use signals. See src/real.ts:1",
+      );
+      gitInit();
+      const res = await ltm.validateProjectReferences(root, resolver());
+      expect(res.penalized).toBe(0);
+      expect(conf(id)).toBe(1.0);
+    });
+
+    test("present symbol → no penalty, and presence is recorded", async () => {
       writeFileSync(
         join(root, "src", "real.ts"),
         "export const keptHelper = 1;\n",
@@ -220,12 +253,19 @@ describe.skipIf(process.platform === "win32")(
       const res = await ltm.validateProjectReferences(root, resolver());
       expect(res.penalized).toBe(0);
       expect(conf(id)).toBe(1.0);
+      const lid = ltm.get(id)?.logical_id;
+      const row = db()
+        .query(
+          "SELECT 1 FROM knowledge_symbol_presence WHERE logical_id = ? AND symbol = ?",
+        )
+        .get(lid, "keptHelper");
+      expect(row).toBeTruthy();
     });
 
     test("non-git repo → symbol unverifiable, never penalizes (neutral)", async () => {
-      // No gitInit(): presentSymbols is null → symbol "unknown" → no signal. The
+      // No gitInit(): presence is null → symbol "unknown" → no signal. The
       // co-cited file ref is valid, so the entry is checked but not penalized.
-      const id = seed("`removedHelperFn` lives in src/real.ts:3");
+      const id = seed("`keptHelper` lives in src/real.ts:3");
       const res = await ltm.validateProjectReferences(root, resolver());
       expect(res.penalized).toBe(0);
       expect(conf(id)).toBe(1.0);

--- a/packages/core/test/ltm-versioning.test.ts
+++ b/packages/core/test/ltm-versioning.test.ts
@@ -39,11 +39,11 @@ function ftsHits(token: string): number {
 }
 
 describe("A2 sub-PR 1: append-only knowledge scaffolding", () => {
-  test("schema version is 58", () => {
+  test("schema version is 59", () => {
     const v = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(v.version).toBe(58);
+    expect(v.version).toBe(59);
   });
 
   test("create() defaults logical_id = id, version 1, current, not deleted", () => {

--- a/packages/core/test/references.test.ts
+++ b/packages/core/test/references.test.ts
@@ -354,6 +354,7 @@ describe("resolveRefAgainstView (Windows backslash normalization)", () => {
     filesLower: new Map([["a/b/c/d.ts", ["a/b/c/d.ts"]]]),
     basenames: new Map([["d.ts", ["a/b/c/d.ts"]]]),
     presentSymbols: null,
+    searchedSymbols: null,
     scripts: null,
     makeTargets: null,
     lineCount: (rel) => (rel === "a/b/c/d.ts" ? 5 : null),
@@ -399,6 +400,7 @@ describe("resolveRefAgainstView (case-insensitive file resolution, #969)", () =>
       ["readme.md", ["readme.md"]],
     ]),
     presentSymbols: null,
+    searchedSymbols: null,
     scripts: null,
     makeTargets: null,
     lineCount: (rel) =>
@@ -443,6 +445,7 @@ describe("resolveRefAgainstView (case-insensitive file resolution, #969)", () =>
       filesLower: new Map([["src/foo.ts", ["src/Foo.ts", "src/foo.ts"]]]),
       basenames: new Map([["foo.ts", ["src/Foo.ts", "src/foo.ts"]]]),
       presentSymbols: null,
+      searchedSymbols: null,
       scripts: null,
       makeTargets: null,
       lineCount: () => 1,
@@ -460,6 +463,7 @@ describe("resolveRefAgainstView (case-insensitive file resolution, #969)", () =>
       filesLower: new Map([["src/foo.ts", ["src/Foo.ts", "src/foo.ts"]]]),
       basenames: new Map([["foo.ts", ["src/Foo.ts", "src/foo.ts"]]]),
       presentSymbols: null,
+      searchedSymbols: null,
       scripts: null,
       makeTargets: null,
       lineCount: () => 1,
@@ -480,6 +484,7 @@ describe("resolveRefAgainstView (case-insensitive file resolution, #969)", () =>
       ]),
       basenames: new Map([["foo.ts", ["a/Foo.ts", "b/foo.ts"]]]),
       presentSymbols: null,
+      searchedSymbols: null,
       scripts: null,
       makeTargets: null,
       lineCount: () => 5,
@@ -500,6 +505,7 @@ describe("resolveRefAgainstView (case-insensitive file resolution, #969)", () =>
       ]),
       basenames: new Map([["foo.ts", ["a/Foo.ts", "b/FOO.ts"]]]),
       presentSymbols: null,
+      searchedSymbols: null,
       scripts: null,
       makeTargets: null,
       lineCount: () => 5,
@@ -841,11 +847,15 @@ describe("extractReferences — cited symbols (#911)", () => {
 });
 
 describe("resolveRefAgainstView (symbol presence, #911)", () => {
-  const mk = (presentSymbols: Set<string> | null): RepoView => ({
+  const mk = (
+    present: Set<string> | null,
+    searched: Set<string> | null = present,
+  ): RepoView => ({
     files: new Set(),
     filesLower: new Map(),
     basenames: new Map(),
-    presentSymbols,
+    presentSymbols: present,
+    searchedSymbols: searched,
     scripts: null,
     makeTargets: null,
     lineCount: () => null,
@@ -860,12 +870,20 @@ describe("resolveRefAgainstView (symbol presence, #911)", () => {
     expect(resolveRefAgainstView(sym("foo"), mk(new Set(["foo"])))).toBe("ok");
   });
   test("searched and absent repo-wide → missing", () => {
-    expect(resolveRefAgainstView(sym("foo"), mk(new Set(["bar"])))).toBe(
-      "missing",
-    );
+    // searched contains foo (it was looked for) but present does not.
+    expect(
+      resolveRefAgainstView(sym("foo"), mk(new Set(), new Set(["foo"]))),
+    ).toBe("missing");
   });
   test("presence unavailable (null) → unknown (neutral)", () => {
-    expect(resolveRefAgainstView(sym("foo"), mk(null))).toBe("unknown");
+    expect(resolveRefAgainstView(sym("foo"), mk(null, null))).toBe("unknown");
+  });
+  // SF1: a grep that errored leaves the name out of BOTH sets → unsearched →
+  // unknown, never a false "missing".
+  test("not in the searched set (grep errored) → unknown (neutral)", () => {
+    expect(
+      resolveRefAgainstView(sym("foo"), mk(new Set(["bar"]), new Set(["bar"]))),
+    ).toBe("unknown");
   });
 });
 
@@ -925,19 +943,73 @@ describe.skipIf(process.platform === "win32")(
         rmSync(plain, { recursive: true, force: true });
       }
     });
+
+    // SF3: resolving with a SUBDIRECTORY root must still find a symbol defined in
+    // a SIBLING package, because the grep runs from the git TOPLEVEL — matching
+    // the probe's `cd $(git rev-parse --show-toplevel)`. (Pre-fix, Direct-FS
+    // greped `git -C <subdir>`, scoped to that subtree → false "missing" on a
+    // sibling-defined symbol + a silent divergence from the probe. Verified:
+    // `git -C pkgA grep <pkgB-only-symbol>` exits 1.)
+    test("subdirectory root greps from the toplevel → sibling-package symbol → ok", async () => {
+      const repo = mkdtempSync(join(tmpdir(), "lore-symsub-"));
+      try {
+        mkdirSync(join(repo, "pkgA"), { recursive: true });
+        mkdirSync(join(repo, "pkgB"), { recursive: true });
+        // The symbol is defined ONLY in pkgB; pkgA never mentions it.
+        writeFileSync(join(repo, "pkgA", "a.ts"), "const x = 1;\n");
+        writeFileSync(
+          join(repo, "pkgB", "b.ts"),
+          "export const siblingOnlySymbol = 1;\n",
+        );
+        execFileSync("git", ["init", "-q"], { cwd: repo });
+        execFileSync("git", ["add", "-A"], { cwd: repo });
+        const refs = extractReferences("`siblingOnlySymbol` in pkgA/a.ts:1");
+        const sym = refs.find((r) => r.kind === "symbol") as { raw: string };
+        // Resolver root is the pkgA subdir; the symbol lives in the pkgB sibling.
+        const map = await new DirectFsResolver(join(repo, "pkgA")).resolve(
+          refs,
+        );
+        expect(map?.get(sym.raw)).toBe("ok");
+      } finally {
+        rmSync(repo, { recursive: true, force: true });
+      }
+    });
+
+    // SF2: an inherited GIT_DIR / GIT_INDEX_FILE must not redirect the grep to the
+    // wrong repo (which would mass-false-miss). The env is scrubbed, so a present
+    // symbol still resolves ok even with a bogus GIT_DIR set.
+    test("inherited bogus GIT_DIR does not cause a false missing (env scrubbed)", async () => {
+      const prevDir = process.env.GIT_DIR;
+      const prevIdx = process.env.GIT_INDEX_FILE;
+      process.env.GIT_DIR = join(tmpdir(), "lore-bogus-gitdir-does-not-exist");
+      process.env.GIT_INDEX_FILE = "/dev/null";
+      try {
+        expect(
+          await symStatus("`evaluateCacheStrategy` in src/code.ts:1"),
+        ).toBe("ok");
+      } finally {
+        if (prevDir === undefined) delete process.env.GIT_DIR;
+        else process.env.GIT_DIR = prevDir;
+        if (prevIdx === undefined) delete process.env.GIT_INDEX_FILE;
+        else process.env.GIT_INDEX_FILE = prevIdx;
+      }
+    });
   },
 );
 
 describe("buildRefcheckProbeScript symbol section (#911)", () => {
-  test("emits the symbol section, git guard, OK marker, and one grep per symbol", () => {
+  test("emits the symbol section, git guard, OK+DONE markers, and a per-symbol grep", () => {
     const script = buildRefcheckProbeScript(
       extractReferences("`evaluateCacheStrategy` and `RepoView` in refs.ts:1"),
     );
     expect(script).toContain("===LORE-SYMS===");
     expect(script).toContain("git rev-parse --is-inside-work-tree");
     expect(script).toContain("===LORE-SYMS-OK===");
+    expect(script).toContain("===LORE-SYMS-DONE===");
+    // per-symbol grep that emits `name\t1` / `name\t0` based on exit status.
     expect(script).toContain("git grep -qwF -- 'evaluateCacheStrategy'");
     expect(script).toContain("git grep -qwF -- 'RepoView'");
+    expect(script).toContain("case $? in 0)");
   });
 
   // Defense-in-depth: a symbol name outside the identifier charset must never be
@@ -965,24 +1037,48 @@ describe("parseProbeSnapshot symbol section (#911)", () => {
     "src/foo.ts\t5",
   ];
 
-  test("OK marker + listed symbols → presentSymbols set with exactly those names", () => {
+  test("OK+DONE with name\\t1 / name\\t0 → present and searched populated correctly", () => {
     const text = [
       ...base,
       "===LORE-SYMS===",
       "===LORE-SYMS-OK===",
-      "evaluateCacheStrategy",
+      "evaluateCacheStrategy\t1",
+      "removedFn\t0",
+      "===LORE-SYMS-DONE===",
+    ].join("\n");
+    const view = parseProbeSnapshot(text);
+    expect(view?.presentSymbols?.has("evaluateCacheStrategy")).toBe(true);
+    expect(view?.presentSymbols?.has("removedFn")).toBe(false);
+    // both were definitively searched
+    expect(view?.searchedSymbols?.has("evaluateCacheStrategy")).toBe(true);
+    expect(view?.searchedSymbols?.has("removedFn")).toBe(true);
+  });
+
+  test("OK+DONE with no symbol lines → empty sets (real misses, NOT neutral)", () => {
+    const text = [
+      ...base,
+      "===LORE-SYMS===",
+      "===LORE-SYMS-OK===",
+      "===LORE-SYMS-DONE===",
     ].join("\n");
     const view = parseProbeSnapshot(text);
     expect(view?.presentSymbols).not.toBeNull();
-    expect(view?.presentSymbols?.has("evaluateCacheStrategy")).toBe(true);
-    expect(view?.presentSymbols?.has("removedFn")).toBe(false);
+    expect(view?.searchedSymbols).not.toBeNull();
+    expect(view?.presentSymbols?.size).toBe(0);
   });
 
-  test("OK marker but no symbols listed → empty Set (real misses, NOT neutral)", () => {
-    const text = [...base, "===LORE-SYMS===", "===LORE-SYMS-OK==="].join("\n");
+  // SF4: OK but NO DONE → output was truncated mid-section → null (neutral), so
+  // an un-emitted symbol is never falsely read as absent.
+  test("OK but NO DONE marker (truncated) → null (neutral)", () => {
+    const text = [
+      ...base,
+      "===LORE-SYMS===",
+      "===LORE-SYMS-OK===",
+      "evaluateCacheStrategy\t1",
+    ].join("\n");
     const view = parseProbeSnapshot(text);
-    expect(view?.presentSymbols).not.toBeNull();
-    expect(view?.presentSymbols?.size).toBe(0);
+    expect(view?.presentSymbols).toBeNull();
+    expect(view?.searchedSymbols).toBeNull();
   });
 
   test("section present but NO OK marker (git absent) → null (neutral)", () => {

--- a/packages/core/test/references.test.ts
+++ b/packages/core/test/references.test.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -8,6 +8,7 @@ import {
   DirectFsResolver,
   extractReferences,
   NoopResolver,
+  parseProbeSnapshot,
   type Reference,
   type RepoView,
   resolveRefAgainstView,
@@ -352,6 +353,7 @@ describe("resolveRefAgainstView (Windows backslash normalization)", () => {
     files: new Set(["a/b/c/d.ts"]),
     filesLower: new Map([["a/b/c/d.ts", ["a/b/c/d.ts"]]]),
     basenames: new Map([["d.ts", ["a/b/c/d.ts"]]]),
+    presentSymbols: null,
     scripts: null,
     makeTargets: null,
     lineCount: (rel) => (rel === "a/b/c/d.ts" ? 5 : null),
@@ -396,6 +398,7 @@ describe("resolveRefAgainstView (case-insensitive file resolution, #969)", () =>
       ["db.ts", ["packages/core/src/db.ts"]],
       ["readme.md", ["readme.md"]],
     ]),
+    presentSymbols: null,
     scripts: null,
     makeTargets: null,
     lineCount: (rel) =>
@@ -439,6 +442,7 @@ describe("resolveRefAgainstView (case-insensitive file resolution, #969)", () =>
       files: new Set(["src/Foo.ts", "src/foo.ts"]),
       filesLower: new Map([["src/foo.ts", ["src/Foo.ts", "src/foo.ts"]]]),
       basenames: new Map([["foo.ts", ["src/Foo.ts", "src/foo.ts"]]]),
+      presentSymbols: null,
       scripts: null,
       makeTargets: null,
       lineCount: () => 1,
@@ -455,6 +459,7 @@ describe("resolveRefAgainstView (case-insensitive file resolution, #969)", () =>
       files: new Set(["src/Foo.ts", "src/foo.ts"]),
       filesLower: new Map([["src/foo.ts", ["src/Foo.ts", "src/foo.ts"]]]),
       basenames: new Map([["foo.ts", ["src/Foo.ts", "src/foo.ts"]]]),
+      presentSymbols: null,
       scripts: null,
       makeTargets: null,
       lineCount: () => 1,
@@ -474,6 +479,7 @@ describe("resolveRefAgainstView (case-insensitive file resolution, #969)", () =>
         ["b/foo.ts", ["b/foo.ts"]],
       ]),
       basenames: new Map([["foo.ts", ["a/Foo.ts", "b/foo.ts"]]]),
+      presentSymbols: null,
       scripts: null,
       makeTargets: null,
       lineCount: () => 5,
@@ -493,6 +499,7 @@ describe("resolveRefAgainstView (case-insensitive file resolution, #969)", () =>
         ["b/foo.ts", ["b/FOO.ts"]],
       ]),
       basenames: new Map([["foo.ts", ["a/Foo.ts", "b/FOO.ts"]]]),
+      presentSymbols: null,
       scripts: null,
       makeTargets: null,
       lineCount: () => 5,
@@ -781,6 +788,268 @@ describe.skipIf(process.platform === "win32")(
       )?.get(key);
       expect(direct).toBe(expected);
       expect(synthetic).toBe(expected);
+    });
+  },
+);
+
+// --- #911 cited-symbol validation ------------------------------------------
+
+describe("extractReferences — cited symbols (#911)", () => {
+  const syms = (text: string): string[] =>
+    extractReferences(text)
+      .filter((r) => r.kind === "symbol")
+      .map((r) => (r as { name: string }).name);
+
+  test("a codey symbol co-cited with a file ref is extracted", () => {
+    expect(
+      syms("`evaluateCacheStrategy` called from cache-warmer.ts:1252"),
+    ).toContain("evaluateCacheStrategy");
+  });
+
+  test("PascalCase / snake_case / call-like all qualify as codey", () => {
+    const s = syms(
+      "see refs.ts:1 — `RepoView`, `last_reinforced_at`, `walk()`",
+    );
+    expect(s).toEqual(
+      expect.arrayContaining(["RepoView", "last_reinforced_at", "walk"]),
+    );
+  });
+
+  // Gate B (adjacency bound): a backtick identifier with NO co-cited file ref is
+  // too unmoored to act on — never a symbol ref.
+  test("a backtick identifier WITHOUT any co-cited file ref is NOT a symbol", () => {
+    expect(syms("`shouldHoldPrefixWarm` is a pure helper")).toEqual([]);
+  });
+
+  // Gate C (codey shape): the false-positive killer. Bare marker-free lowercase
+  // prose words in backticks must never become symbol refs.
+  test("bare lowercase prose words in backticks are rejected (codey gate)", () => {
+    const s = syms("the `total` and `run` of src/foo.ts:1");
+    expect(s).not.toContain("total");
+    expect(s).not.toContain("run");
+  });
+
+  test("`foo` and `foo()` dedupe to a single symbol", () => {
+    const s = syms("`fooBar` then `fooBar()` near src/a.ts:1");
+    expect(s.filter((n) => n === "fooBar")).toHaveLength(1);
+  });
+
+  test("a command token is not also captured as a symbol", () => {
+    const refs = extractReferences("run `pnpm run lint` in src/a.ts:1");
+    expect(refs.some((r) => r.kind === "symbol")).toBe(false);
+  });
+});
+
+describe("resolveRefAgainstView (symbol presence, #911)", () => {
+  const mk = (presentSymbols: Set<string> | null): RepoView => ({
+    files: new Set(),
+    filesLower: new Map(),
+    basenames: new Map(),
+    presentSymbols,
+    scripts: null,
+    makeTargets: null,
+    lineCount: () => null,
+  });
+  const sym = (name: string): Reference => ({
+    kind: "symbol",
+    name,
+    raw: name,
+  });
+
+  test("present anywhere → ok", () => {
+    expect(resolveRefAgainstView(sym("foo"), mk(new Set(["foo"])))).toBe("ok");
+  });
+  test("searched and absent repo-wide → missing", () => {
+    expect(resolveRefAgainstView(sym("foo"), mk(new Set(["bar"])))).toBe(
+      "missing",
+    );
+  });
+  test("presence unavailable (null) → unknown (neutral)", () => {
+    expect(resolveRefAgainstView(sym("foo"), mk(null))).toBe("unknown");
+  });
+});
+
+// Symbol presence needs a real git work tree (`git grep`). Build a git fixture so
+// both the "ok"/"missing" verdicts AND the non-git → neutral path are exercised.
+describe.skipIf(process.platform === "win32")(
+  "DirectFsResolver symbol resolution (#911)",
+  () => {
+    let root: string;
+    beforeAll(() => {
+      root = mkdtempSync(join(tmpdir(), "lore-sym-"));
+      mkdirSync(join(root, "src"), { recursive: true });
+      writeFileSync(
+        join(root, "src", "code.ts"),
+        "export function evaluateCacheStrategy() {\n  return 1;\n}\nconst fooBarBaz = 2;\n",
+      );
+      execFileSync("git", ["init", "-q"], { cwd: root });
+      execFileSync("git", ["add", "-A"], { cwd: root });
+    });
+    afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+    const symStatus = async (raw: string): Promise<string | undefined> => {
+      const refs = extractReferences(raw);
+      const sym = refs.find((r) => r.kind === "symbol");
+      expect(sym).toBeDefined();
+      const map = await new DirectFsResolver(root).resolve(refs);
+      return map?.get((sym as { raw: string }).raw);
+    };
+
+    test("present symbol → ok", async () => {
+      expect(await symStatus("`evaluateCacheStrategy` in src/code.ts:1")).toBe(
+        "ok",
+      );
+    });
+    test("absent symbol → missing", async () => {
+      expect(await symStatus("`removedHelperFn` in src/code.ts:1")).toBe(
+        "missing",
+      );
+    });
+    // `git grep -w` is a whole-word match, so a camelCase token present only as a
+    // substring (`fooBar` inside `fooBarBaz`) is genuinely absent → missing.
+    test("camelCase token present only as a substring → missing (word boundary)", async () => {
+      expect(await symStatus("`fooBar` in src/code.ts:1")).toBe("missing");
+    });
+    test("non-git root → symbol unknown (neutral), never a false missing", async () => {
+      const plain = mkdtempSync(join(tmpdir(), "lore-nogit-"));
+      try {
+        mkdirSync(join(plain, "src"), { recursive: true });
+        writeFileSync(join(plain, "src", "code.ts"), "nope\n");
+        const refs = extractReferences(
+          "`evaluateCacheStrategy` in src/code.ts:1",
+        );
+        const sym = refs.find((r) => r.kind === "symbol") as { raw: string };
+        const map = await new DirectFsResolver(plain).resolve(refs);
+        expect(map?.get(sym.raw)).toBe("unknown");
+      } finally {
+        rmSync(plain, { recursive: true, force: true });
+      }
+    });
+  },
+);
+
+describe("buildRefcheckProbeScript symbol section (#911)", () => {
+  test("emits the symbol section, git guard, OK marker, and one grep per symbol", () => {
+    const script = buildRefcheckProbeScript(
+      extractReferences("`evaluateCacheStrategy` and `RepoView` in refs.ts:1"),
+    );
+    expect(script).toContain("===LORE-SYMS===");
+    expect(script).toContain("git rev-parse --is-inside-work-tree");
+    expect(script).toContain("===LORE-SYMS-OK===");
+    expect(script).toContain("git grep -qwF -- 'evaluateCacheStrategy'");
+    expect(script).toContain("git grep -qwF -- 'RepoView'");
+  });
+
+  // Defense-in-depth: a symbol name outside the identifier charset must never be
+  // coined into a grep argument (extraction guarantees the charset; assert the
+  // interpolation-site guard independently).
+  test("never coins a grep arg outside the identifier charset", () => {
+    const malicious: Reference[] = [
+      { kind: "symbol", name: "a';rm -rf ~;'", raw: "x" },
+      { kind: "symbol", name: "okName", raw: "y" },
+    ];
+    const script = buildRefcheckProbeScript(malicious);
+    expect(script).toContain("'okName'");
+    expect(script).not.toContain("rm -rf");
+  });
+});
+
+describe("parseProbeSnapshot symbol section (#911)", () => {
+  const base = [
+    "src/foo.ts",
+    "===LORE-PKG===",
+    "{}",
+    "===LORE-MAKE===",
+    "",
+    "===LORE-LINES===",
+    "src/foo.ts\t5",
+  ];
+
+  test("OK marker + listed symbols → presentSymbols set with exactly those names", () => {
+    const text = [
+      ...base,
+      "===LORE-SYMS===",
+      "===LORE-SYMS-OK===",
+      "evaluateCacheStrategy",
+    ].join("\n");
+    const view = parseProbeSnapshot(text);
+    expect(view?.presentSymbols).not.toBeNull();
+    expect(view?.presentSymbols?.has("evaluateCacheStrategy")).toBe(true);
+    expect(view?.presentSymbols?.has("removedFn")).toBe(false);
+  });
+
+  test("OK marker but no symbols listed → empty Set (real misses, NOT neutral)", () => {
+    const text = [...base, "===LORE-SYMS===", "===LORE-SYMS-OK==="].join("\n");
+    const view = parseProbeSnapshot(text);
+    expect(view?.presentSymbols).not.toBeNull();
+    expect(view?.presentSymbols?.size).toBe(0);
+  });
+
+  test("section present but NO OK marker (git absent) → null (neutral)", () => {
+    const text = [...base, "===LORE-SYMS==="].join("\n");
+    expect(parseProbeSnapshot(text)?.presentSymbols).toBeNull();
+  });
+
+  test("old probe with no symbol section → null (neutral, back-compat)", () => {
+    expect(parseProbeSnapshot(base.join("\n"))?.presentSymbols).toBeNull();
+  });
+});
+
+// End-to-end: EXECUTE the generated probe under a POSIX shell against a git
+// fixture so the real `git grep -qwF` runs, feed the output through
+// SyntheticProbeResolver, and confirm it agrees with DirectFsResolver ref-by-ref.
+describe.skipIf(process.platform === "win32")(
+  "symbol probe real-shell ↔ Direct-FS parity (#911)",
+  () => {
+    let root: string;
+    beforeAll(() => {
+      root = mkdtempSync(join(tmpdir(), "lore-symparity-"));
+      mkdirSync(join(root, "src"), { recursive: true });
+      writeFileSync(
+        join(root, "src", "code.ts"),
+        "export function evaluateCacheStrategy() {}\nconst fooBarBaz = 1;\n",
+      );
+      execFileSync("git", ["init", "-q"], { cwd: root });
+      execFileSync("git", ["add", "-A"], { cwd: root });
+    });
+    afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+    test.each([
+      ["`evaluateCacheStrategy` in src/code.ts:1", "ok"],
+      ["`removedHelper` in src/code.ts:1", "missing"],
+      ["`fooBar` in src/code.ts:1", "missing"], // substring only → word-boundary miss
+    ])("real probe and Direct-FS agree on %j (symbol → %s)", async (raw, expected) => {
+      const refs = extractReferences(raw);
+      const sym = refs.find((r) => r.kind === "symbol") as { raw: string };
+      const direct = (await new DirectFsResolver(root).resolve(refs))?.get(
+        sym.raw,
+      );
+      const probeOut = execFileSync(
+        "sh",
+        ["-c", buildRefcheckProbeScript(refs)],
+        {
+          cwd: root,
+          encoding: "utf8",
+        },
+      );
+      const synthetic = (
+        await new SyntheticProbeResolver(probeOut).resolve(refs)
+      )?.get(sym.raw);
+      expect(direct).toBe(expected);
+      expect(synthetic).toBe(expected);
+    });
+
+    // The probe must exit 0 even when the last symbol grep finds nothing —
+    // otherwise the client tool flags `isError` and the WHOLE batch goes neutral.
+    test("probe exits 0 when a symbol is absent (no silent batch abort)", () => {
+      const refs = extractReferences(
+        "`definitelyNotPresentXyz` in src/code.ts:1",
+      );
+      const r = spawnSync("sh", ["-c", buildRefcheckProbeScript(refs)], {
+        cwd: root,
+        encoding: "utf8",
+      });
+      expect(r.status).toBe(0);
     });
   },
 );


### PR DESCRIPTION
Closes #911. Follow-up to the #627 Phase 0 reference-validity validator. Phase 0 checks `file:line` and `pnpm/npm/yarn/make` command refs; this adds the third type: **cited code symbols** (function / const / class / type names). When a symbol is renamed/removed, the `file:line` often still resolves while the *claim* is wrong — symbol validation is the only check that catches that drift.

## Design — presence-history drift signal

A cited symbol only **decays** confidence when it was **previously confirmed present** in this repo and is **now absent** (genuine rename/removal). A symbol that was never present here (external lib, historical/renamed-away mention, rejected alternative) never gets a presence row, so it can never penalize. This is what keeps symbol validation on the safe side of the 🔴 "cannot verify ≠ broken" invariant — and makes the check a real drift detector rather than a false-positive generator.

- **`knowledge_symbol_presence(logical_id, symbol, last_present_at)`** (migration v59). `validateProjectReferences` records a symbol on a confirmed `ok`; a later `missing` is drift only if a prior row exists.
- **Extraction (precision-first):** `{kind:"symbol"}` only when (a) inside a backtick span, (b) the entry also has a file ref (adjacency bound), (c) the token is *codey* (PascalCase/camelCase/`_`/call-like).
- **Resolution (presence by `git grep -wF`, no AST):** present anywhere → `ok`; definitively searched-and-absent → `missing`; grep unavailable/errored → `unknown`. `RepoView.searchedSymbols` distinguishes "absent" from "couldn't search" so a grep error is never a false `missing`.
- **Direct-FS** greps from the **git toplevel** with a **scrubbed `GIT_*` env**. Non-git repo → neutral.
- **Synthetic-probe** emits per-symbol `name\t0|1` bounded by `OK`…`DONE` markers; a truncated probe → neutral (never a partial false-missing set). Subshell forces `exit 0`.

A symbol drift folds into `knowledge_ref_validity(broken,total)` and the same one-shot `−REFERENCE_DRIFT_PENALTY`, floored, never deleting.

## History
First cut resolved absent→`missing` directly; adversarial review found that false-penalizes valid external/historical/rejected mentions (🔴 violation). Reworked to presence-history; all 4 SHOULD-FIX hardenings (grep exit-128, `GIT_*` env, subdir/probe divergence, truncation) landed too. See the review-response comment for the point-by-point.

## Verification
- Core 2061 / 6 skipped; gateway 2218 / 26 skipped. Typecheck + biome clean.
- Mutation battery on both cuts: extraction gates, codey gate, resolution, both `-w` sites, probe `exit 0`, presence-gate, presence-record, searched-distinction, OK/DONE marker, toplevel-grep, env-scrub — all killed.

## Deferred (per #911)
AST/definition-shape precision, symbol hit-location ("moved" vs "removed"), per-kind observability split.