### PR TITLE
feat(core): off-thread vector search via read-worker pool (#966)

### DIFF
--- a/packages/core/script/build.ts
+++ b/packages/core/script/build.ts
@@ -89,7 +89,17 @@ async function buildTarget(target: "node" | "bun") {
     outfile: join(outdir, "embedding-worker.js"),
   });
 
-  console.log(`✓ built dist/${target}/index.js + embedding-worker.js`);
+  // Vector-search worker bundle — same rationale as the embedding worker.
+  // Spawned by the read-worker pool (vector-pool.ts) via `new Worker(url)`.
+  await esbuild.build({
+    ...targetOptions,
+    entryPoints: [join(packageDir, "src/vector-worker.ts")],
+    outfile: join(outdir, "vector-worker.js"),
+  });
+
+  console.log(
+    `✓ built dist/${target}/index.js + embedding-worker.js + vector-worker.js`,
+  );
 }
 
 console.log("Building @loreai/core (node + bun targets)...");

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -516,12 +516,35 @@ export const LoreConfig = z.object({
             .describe(
               "Embedding dimensions. Default: 768 (local) / 1024 (voyage) / 1536 (openai). Local Nomic v1.5 supports Matryoshka: 64, 128, 256, 512, 768.",
             ),
+          /** Run vector searches on a read-worker pool (off the main event
+           *  loop) instead of synchronously on the main thread. Default: true.
+           *  This is a kill switch, not opt-in — set to false to force the
+           *  in-process path if the pool ever misbehaves. */
+          workerOffload: z
+            .boolean()
+            .default(true)
+            .describe(
+              "Run vector searches on a read-worker pool off the main event loop. Kill switch (default true); set false to force the in-process path.",
+            ),
+          /** Number of read-worker threads in the vector-search pool. Each owns
+           *  its own read-only DB connection. Default: 2. */
+          workerPoolSize: z
+            .number()
+            .int()
+            .min(1)
+            .max(16)
+            .default(2)
+            .describe(
+              "Number of read-worker threads for off-thread vector search. Default: 2.",
+            ),
         })
         .default({
           enabled: true,
           provider: "local",
           model: "nomic-ai/nomic-embed-text-v1.5",
           dimensions: 768,
+          workerOffload: true,
+          workerPoolSize: 2,
         })
         .describe("Vector embedding search provider, model, and dimensions."),
       /** Recall output formatting — controls how search results are presented to the agent. */
@@ -588,6 +611,8 @@ export const LoreConfig = z.object({
         provider: "local" as const,
         model: "nomic-ai/nomic-embed-text-v1.5",
         dimensions: 768,
+        workerOffload: true,
+        workerPoolSize: 2,
       },
       recall: {
         charBudget: 12000,

--- a/packages/core/src/db/reader.ts
+++ b/packages/core/src/db/reader.ts
@@ -1,0 +1,45 @@
+// Read-only SQLite connection factory for the vector-search worker pool.
+//
+// Each worker in the pool opens its OWN connection to the same WAL database
+// file via this factory. SQLite WAL mode supports one writer (the main thread)
+// plus many concurrent readers, so these connections read a consistent
+// snapshot without contending with the main thread's writes.
+//
+// Crucially this is NOT the `db()` singleton path: it runs NO migrations and
+// installs NO sync-capture triggers (the main thread owns the schema and is the
+// sole writer). It only:
+//   1. opens the connection,
+//   2. sets a busy timeout (so a brief writer lock retries instead of throwing),
+//   3. sets `query_only = TRUE` — a hard SQLite-level guarantee that this
+//      connection can never write. This also sidesteps the read-only-open
+//      WAL/-shm creation quirk (a true `readonly` open can't create the -shm
+//      file; here we open read/write but forbid writes), and
+//   4. loads sqlite-vec on this connection (independent of the main thread's
+//      loader state) so the worker can use the native fast path when available.
+
+import { Database } from "#db/driver";
+import { loadVecForConnection } from "./vec";
+
+export interface ReaderConnection {
+  /** The read-only connection. Only SELECTs are permitted (query_only). */
+  db: Database;
+  /** Whether sqlite-vec loaded on THIS connection (native fast path usable). */
+  vecAvailable: boolean;
+}
+
+/**
+ * Open a query-only reader connection to the database at `path` and load
+ * sqlite-vec on it. Never runs migrations or installs triggers. The caller
+ * owns the returned connection's lifetime (close it on worker shutdown).
+ */
+export function openReaderConnection(path: string): ReaderConnection {
+  const database = new Database(path);
+  // Retry briefly when the main thread holds the write lock instead of
+  // throwing SQLITE_BUSY immediately.
+  database.exec("PRAGMA busy_timeout = 5000");
+  // We only ever SELECT. Make that a hard guarantee and avoid the read-only
+  // open WAL/-shm quirk (see file header).
+  database.exec("PRAGMA query_only = TRUE");
+  const vecAvailable = loadVecForConnection(database);
+  return { db: database, vecAvailable };
+}

--- a/packages/core/src/db/vec.ts
+++ b/packages/core/src/db/vec.ts
@@ -111,6 +111,37 @@ export function loadVecExtension(database: Database): void {
   );
 }
 
+/**
+ * Load sqlite-vec into an ARBITRARY connection and report whether it took.
+ *
+ * Unlike {@link loadVecExtension} this is pure per-connection: it does NOT
+ * touch the module-level `attempted`/`vecAvailable` singleton state and does
+ * not log. Used by read-worker reader connections (vector-pool.ts), each of
+ * which loads the extension independently on its own connection and tracks its
+ * own availability. Never throws — a failure returns `false` and the caller
+ * routes to the JS brute-force fallback.
+ */
+export function loadVecForConnection(database: Database): boolean {
+  if (process.env.LORE_DISABLE_VEC === "1") return false;
+  try {
+    const path = resolveExtensionPath();
+    if (!path) return false;
+    const conn = database as unknown as {
+      loadExtension: (p: string) => void;
+      enableLoadExtension?: (on: boolean) => void;
+    };
+    conn.enableLoadExtension?.(true);
+    conn.loadExtension(path);
+    conn.enableLoadExtension?.(false);
+    const row = database.query("SELECT vec_version() AS v").get() as
+      | { v?: string }
+      | undefined;
+    return typeof row?.v === "string" && row.v.length > 0;
+  } catch {
+    return false;
+  }
+}
+
 /** Whether sqlite-vec loaded successfully on the active connection. */
 export function isVecAvailable(): boolean {
   return vecAvailable;

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -42,7 +42,9 @@ import {
   toBlob,
   type DistillationVectorHit,
   type VectorHit,
+  type VectorQuerySpec,
 } from "./vector-query";
+import { tryPoolVectorSearch } from "./vector-pool";
 
 // The cosine/BLOB helpers moved to ./vector-query (a leaf module the read
 // worker can import without pulling in the provider chain). Re-exported here so
@@ -1261,30 +1263,43 @@ export function l2Normalize(vec: Float32Array): Float32Array {
  *   Useful when preferences are injected in a separate system block and
  *   shouldn't compete for vector search slots with context-bound entries.
  */
-export function vectorSearch(
+/**
+ * Run `spec` on the read-worker pool when it's enabled and healthy (off the
+ * main event loop), otherwise synchronously in-process. The pool call never
+ * throws — it returns null when unavailable so we transparently fall back.
+ */
+async function poolOrInProcess(
+  spec: VectorQuerySpec,
+  queryEmbedding: Float32Array,
+): Promise<VectorHit[] | DistillationVectorHit[]> {
+  const pooled = await tryPoolVectorSearch(spec, queryEmbedding);
+  if (pooled !== null) return pooled;
+  return runVectorQuery(db(), isVecAvailable(), queryEmbedding, spec);
+}
+
+export async function vectorSearch(
   queryEmbedding: Float32Array,
   limit = 10,
   excludeCategories?: string[],
-): VectorHit[] {
-  return runVectorQuery(db(), isVecAvailable(), queryEmbedding, {
-    kind: "knowledge",
-    limit,
-    excludeCategories,
-  }) as VectorHit[];
+): Promise<VectorHit[]> {
+  return (await poolOrInProcess(
+    { kind: "knowledge", limit, excludeCategories },
+    queryEmbedding,
+  )) as VectorHit[];
 }
 
 /**
  * Search all entities with embeddings by cosine similarity.
  * Returns top-k entities sorted by similarity descending.
  */
-export function vectorSearchEntities(
+export async function vectorSearchEntities(
   queryEmbedding: Float32Array,
   limit = 10,
-): VectorHit[] {
-  return runVectorQuery(db(), isVecAvailable(), queryEmbedding, {
-    kind: "entities",
-    limit,
-  }) as VectorHit[];
+): Promise<VectorHit[]> {
+  return (await poolOrInProcess(
+    { kind: "entities", limit },
+    queryEmbedding,
+  )) as VectorHit[];
 }
 
 // ---------------------------------------------------------------------------
@@ -1295,14 +1310,14 @@ export function vectorSearchEntities(
  * Search non-archived distillations with embeddings by cosine similarity.
  * Returns top-k entries sorted by similarity descending.
  */
-export function vectorSearchDistillations(
+export async function vectorSearchDistillations(
   queryEmbedding: Float32Array,
   limit = 10,
-): VectorHit[] {
-  return runVectorQuery(db(), isVecAvailable(), queryEmbedding, {
-    kind: "distillations",
-    limit,
-  }) as VectorHit[];
+): Promise<VectorHit[]> {
+  return (await poolOrInProcess(
+    { kind: "distillations", limit },
+    queryEmbedding,
+  )) as VectorHit[];
 }
 
 // ---------------------------------------------------------------------------
@@ -1322,16 +1337,15 @@ export function vectorSearchDistillations(
  * Pure brute-force — fine for ~200 entries per project. Safety-capped
  * at 500 rows to prevent excessive CPU on long-running projects.
  */
-export function vectorSearchAllDistillations(
+export async function vectorSearchAllDistillations(
   queryEmbedding: Float32Array,
   projectId: string,
   limit = 20,
-): DistillationVectorHit[] {
-  return runVectorQuery(db(), isVecAvailable(), queryEmbedding, {
-    kind: "allDistillations",
-    projectId,
-    limit,
-  }) as DistillationVectorHit[];
+): Promise<DistillationVectorHit[]> {
+  return (await poolOrInProcess(
+    { kind: "allDistillations", projectId, limit },
+    queryEmbedding,
+  )) as DistillationVectorHit[];
 }
 
 // ---------------------------------------------------------------------------
@@ -1458,18 +1472,16 @@ export function embedTemporalMessage(id: string, content: string): void {
  *
  * Scoped to a single project. Optionally scoped to a single session.
  */
-export function vectorSearchTemporal(
+export async function vectorSearchTemporal(
   queryEmbedding: Float32Array,
   projectId: string,
   limit = 10,
   sessionId?: string,
-): VectorHit[] {
-  return runVectorQuery(db(), isVecAvailable(), queryEmbedding, {
-    kind: "temporal",
-    projectId,
-    limit,
-    sessionId,
-  }) as VectorHit[];
+): Promise<VectorHit[]> {
+  return (await poolOrInProcess(
+    { kind: "temporal", projectId, limit, sessionId },
+    queryEmbedding,
+  )) as VectorHit[];
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -37,6 +37,24 @@ import {
   type WorkerOutbound,
   type WorkerInitData,
 } from "./embedding-worker-types";
+import {
+  runVectorQuery,
+  toBlob,
+  type DistillationVectorHit,
+  type VectorHit,
+} from "./vector-query";
+
+// The cosine/BLOB helpers moved to ./vector-query (a leaf module the read
+// worker can import without pulling in the provider chain). Re-exported here so
+// existing `embedding.toBlob` / `embedding.cosineSimilarity` / `embedding.fromBlob`
+// call sites across the codebase keep working unchanged.
+export {
+  cosineSimilarity,
+  fromBlob,
+  toBlob,
+  type DistillationVectorHit,
+  type VectorHit,
+} from "./vector-query";
 
 /** Timeout for embedding API fetch calls (ms). Prevents a hanging API from
  *  blocking the recall tool indefinitely. 10s is generous for typical 100-500ms
@@ -1197,22 +1215,6 @@ export async function embed(
 // ---------------------------------------------------------------------------
 
 /**
- * Cosine similarity between two L2-normalized Float32Array vectors.
- * All vectors in the system (local ONNX, Voyage, OpenAI) are L2-normalized
- * at embedding time, so dot product === cosine similarity. This skips the
- * per-vector norm accumulations and sqrt calls (~2× faster).
- * Returns -1.0 to 1.0 where 1.0 = identical direction.
- */
-export function cosineSimilarity(a: Float32Array, b: Float32Array): number {
-  const len = a.length;
-  let dot = 0;
-  for (let i = 0; i < len; i++) {
-    dot += a[i] * b[i];
-  }
-  return dot;
-}
-
-/**
  * Return an L2-normalized (unit-length) copy of a vector.
  *
  * System-wide invariant: every vector produced by {@link embed} is
@@ -1245,54 +1247,8 @@ export function l2Normalize(vec: Float32Array): Float32Array {
 }
 
 // ---------------------------------------------------------------------------
-// Top-k selection (avoids full sort of the scored array)
-// ---------------------------------------------------------------------------
-
-/**
- * Maintain a bounded descending-sorted array of the top k items by score.
- * For small k (10–50) and moderate n (200–500), the O(n*k) insert is faster
- * than O(n log n) sort due to lower constant factors and no allocation.
- */
-function topKInsert<T extends { similarity: number }>(
-  topK: T[],
-  item: T,
-  k: number,
-): void {
-  const score = item.similarity;
-  const len = topK.length;
-  if (len >= k && score <= topK[len - 1].similarity) return;
-  // Binary search for insert position in the descending-sorted array
-  let lo = 0;
-  let hi = len;
-  while (lo < hi) {
-    const mid = (lo + hi) >>> 1;
-    if (topK[mid].similarity > score) lo = mid + 1;
-    else hi = mid;
-  }
-  topK.splice(lo, 0, item);
-  if (topK.length > k) topK.length = k;
-}
-
-// ---------------------------------------------------------------------------
-// BLOB conversion
-// ---------------------------------------------------------------------------
-
-/** Convert Float32Array to Buffer for SQLite BLOB storage. */
-export function toBlob(arr: Float32Array): Buffer {
-  return Buffer.from(arr.buffer, arr.byteOffset, arr.byteLength);
-}
-
-/** Convert SQLite BLOB (Buffer/Uint8Array) back to Float32Array. */
-export function fromBlob(blob: Buffer | Uint8Array): Float32Array {
-  const bytes = new Uint8Array(blob);
-  return new Float32Array(bytes.buffer, bytes.byteOffset, bytes.byteLength / 4);
-}
-
-// ---------------------------------------------------------------------------
 // Vector search — knowledge
 // ---------------------------------------------------------------------------
-
-type VectorHit = { id: string; similarity: number };
 
 /**
  * Search all knowledge entries with embeddings by cosine similarity.
@@ -1310,42 +1266,11 @@ export function vectorSearch(
   limit = 10,
   excludeCategories?: string[],
 ): VectorHit[] {
-  if (isVecAvailable()) {
-    try {
-      let sql =
-        "SELECT id, 1 - vec_distance_cosine(embedding, ?) AS similarity FROM knowledge_current WHERE embedding IS NOT NULL AND confidence > 0.2";
-      const params: unknown[] = [toBlob(queryEmbedding)];
-      if (excludeCategories?.length) {
-        sql += ` AND category NOT IN (${excludeCategories.map(() => "?").join(",")})`;
-        params.push(...excludeCategories);
-      }
-      sql += " ORDER BY similarity DESC LIMIT ?";
-      params.push(limit);
-      return db()
-        .query(sql)
-        .all(...params) as VectorHit[];
-    } catch {
-      // fall through to JS brute-force
-    }
-  }
-  let sql =
-    "SELECT id, embedding FROM knowledge_current WHERE embedding IS NOT NULL AND confidence > 0.2";
-  const params: string[] = [];
-  if (excludeCategories?.length) {
-    sql += ` AND category NOT IN (${excludeCategories.map(() => "?").join(",")})`;
-    params.push(...excludeCategories);
-  }
-  const rows = db()
-    .query(sql)
-    .all(...params) as Array<{ id: string; embedding: Buffer }>;
-
-  const topK: VectorHit[] = [];
-  for (const row of rows) {
-    const vec = fromBlob(row.embedding);
-    const sim = cosineSimilarity(queryEmbedding, vec);
-    topKInsert(topK, { id: row.id, similarity: sim }, limit);
-  }
-  return topK;
+  return runVectorQuery(db(), isVecAvailable(), queryEmbedding, {
+    kind: "knowledge",
+    limit,
+    excludeCategories,
+  }) as VectorHit[];
 }
 
 /**
@@ -1356,28 +1281,10 @@ export function vectorSearchEntities(
   queryEmbedding: Float32Array,
   limit = 10,
 ): VectorHit[] {
-  if (isVecAvailable()) {
-    try {
-      return db()
-        .query(
-          "SELECT id, 1 - vec_distance_cosine(embedding, ?) AS similarity FROM entities WHERE embedding IS NOT NULL ORDER BY similarity DESC LIMIT ?",
-        )
-        .all(toBlob(queryEmbedding), limit) as VectorHit[];
-    } catch {
-      // fall through to JS brute-force
-    }
-  }
-  const rows = db()
-    .query("SELECT id, embedding FROM entities WHERE embedding IS NOT NULL")
-    .all() as Array<{ id: string; embedding: Buffer }>;
-
-  const topK: VectorHit[] = [];
-  for (const row of rows) {
-    const vec = fromBlob(row.embedding);
-    const sim = cosineSimilarity(queryEmbedding, vec);
-    topKInsert(topK, { id: row.id, similarity: sim }, limit);
-  }
-  return topK;
+  return runVectorQuery(db(), isVecAvailable(), queryEmbedding, {
+    kind: "entities",
+    limit,
+  }) as VectorHit[];
 }
 
 // ---------------------------------------------------------------------------
@@ -1392,41 +1299,15 @@ export function vectorSearchDistillations(
   queryEmbedding: Float32Array,
   limit = 10,
 ): VectorHit[] {
-  if (isVecAvailable()) {
-    try {
-      return db()
-        .query(
-          "SELECT id, 1 - vec_distance_cosine(embedding, ?) AS similarity FROM distillations WHERE embedding IS NOT NULL AND archived = 0 ORDER BY similarity DESC LIMIT ?",
-        )
-        .all(toBlob(queryEmbedding), limit) as VectorHit[];
-    } catch {
-      // fall through to JS brute-force
-    }
-  }
-  const rows = db()
-    .query(
-      "SELECT id, embedding FROM distillations WHERE embedding IS NOT NULL AND archived = 0",
-    )
-    .all() as Array<{ id: string; embedding: Buffer }>;
-
-  const topK: VectorHit[] = [];
-  for (const row of rows) {
-    const vec = fromBlob(row.embedding);
-    const sim = cosineSimilarity(queryEmbedding, vec);
-    topKInsert(topK, { id: row.id, similarity: sim }, limit);
-  }
-  return topK;
+  return runVectorQuery(db(), isVecAvailable(), queryEmbedding, {
+    kind: "distillations",
+    limit,
+  }) as VectorHit[];
 }
 
 // ---------------------------------------------------------------------------
 // Vector search — all distillations (including archived)
 // ---------------------------------------------------------------------------
-
-export type DistillationVectorHit = {
-  id: string;
-  session_id: string;
-  similarity: number;
-};
 
 /**
  * Search ALL distillations (including archived) with embeddings by cosine
@@ -1441,52 +1322,16 @@ export type DistillationVectorHit = {
  * Pure brute-force — fine for ~200 entries per project. Safety-capped
  * at 500 rows to prevent excessive CPU on long-running projects.
  */
-const MAX_DISTILLATION_VECTOR_ROWS = 500;
-
 export function vectorSearchAllDistillations(
   queryEmbedding: Float32Array,
   projectId: string,
   limit = 20,
 ): DistillationVectorHit[] {
-  if (isVecAvailable()) {
-    try {
-      // Rank by similarity within the same most-recent candidate window the JS
-      // path uses (created_at DESC, capped at MAX_DISTILLATION_VECTOR_ROWS).
-      return db()
-        .query(
-          "SELECT id, session_id, 1 - vec_distance_cosine(embedding, ?) AS similarity FROM (SELECT id, session_id, embedding FROM distillations WHERE embedding IS NOT NULL AND project_id = ? ORDER BY created_at DESC LIMIT ?) ORDER BY similarity DESC LIMIT ?",
-        )
-        .all(
-          toBlob(queryEmbedding),
-          projectId,
-          MAX_DISTILLATION_VECTOR_ROWS,
-          limit,
-        ) as DistillationVectorHit[];
-    } catch {
-      // fall through to JS brute-force
-    }
-  }
-  const rows = db()
-    .query(
-      "SELECT id, session_id, embedding FROM distillations WHERE embedding IS NOT NULL AND project_id = ? ORDER BY created_at DESC LIMIT ?",
-    )
-    .all(projectId, MAX_DISTILLATION_VECTOR_ROWS) as Array<{
-    id: string;
-    session_id: string;
-    embedding: Buffer;
-  }>;
-
-  const topK: DistillationVectorHit[] = [];
-  for (const row of rows) {
-    const vec = fromBlob(row.embedding);
-    const sim = cosineSimilarity(queryEmbedding, vec);
-    topKInsert(
-      topK,
-      { id: row.id, session_id: row.session_id, similarity: sim },
-      limit,
-    );
-  }
-  return topK;
+  return runVectorQuery(db(), isVecAvailable(), queryEmbedding, {
+    kind: "allDistillations",
+    projectId,
+    limit,
+  }) as DistillationVectorHit[];
 }
 
 // ---------------------------------------------------------------------------
@@ -1619,37 +1464,12 @@ export function vectorSearchTemporal(
   limit = 10,
   sessionId?: string,
 ): VectorHit[] {
-  if (isVecAvailable()) {
-    try {
-      const vsql = sessionId
-        ? "SELECT id, 1 - vec_distance_cosine(embedding, ?) AS similarity FROM temporal_messages WHERE embedding IS NOT NULL AND project_id = ? AND session_id = ? ORDER BY similarity DESC LIMIT ?"
-        : "SELECT id, 1 - vec_distance_cosine(embedding, ?) AS similarity FROM temporal_messages WHERE embedding IS NOT NULL AND project_id = ? ORDER BY similarity DESC LIMIT ?";
-      const vparams: unknown[] = sessionId
-        ? [toBlob(queryEmbedding), projectId, sessionId, limit]
-        : [toBlob(queryEmbedding), projectId, limit];
-      return db()
-        .query(vsql)
-        .all(...vparams) as VectorHit[];
-    } catch {
-      // fall through to JS brute-force
-    }
-  }
-  const sql = sessionId
-    ? "SELECT id, embedding FROM temporal_messages WHERE embedding IS NOT NULL AND project_id = ? AND session_id = ?"
-    : "SELECT id, embedding FROM temporal_messages WHERE embedding IS NOT NULL AND project_id = ?";
-  const params = sessionId ? [projectId, sessionId] : [projectId];
-
-  const rows = db()
-    .query(sql)
-    .all(...params) as Array<{ id: string; embedding: Buffer }>;
-
-  const topK: VectorHit[] = [];
-  for (const row of rows) {
-    const vec = fromBlob(row.embedding);
-    const sim = cosineSimilarity(queryEmbedding, vec);
-    topKInsert(topK, { id: row.id, similarity: sim }, limit);
-  }
-  return topK;
+  return runVectorQuery(db(), isVecAvailable(), queryEmbedding, {
+    kind: "temporal",
+    projectId,
+    limit,
+    sessionId,
+  }) as VectorHit[];
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/instruction-detect.ts
+++ b/packages/core/src/instruction-detect.ts
@@ -188,7 +188,7 @@ export async function findRepeatedInstructions(input: {
 
     // Path A: Vector search (when embeddings succeeded)
     if (candidateEmbeddings.length > i) {
-      const hits = embedding.vectorSearchAllDistillations(
+      const hits = await embedding.vectorSearchAllDistillations(
         candidateEmbeddings[i],
         pid,
         20,

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -769,7 +769,7 @@ export async function findSemanticDuplicate(input: {
   }
   // Search a few nearest neighbors, then keep only those visible to this
   // project (same project or cross-project) — vectorSearch is global.
-  const hits = embedding.vectorSearch(vec, 10);
+  const hits = await embedding.vectorSearch(vec, 10);
   for (const hit of hits) {
     if (hit.similarity < threshold) break; // sorted desc
     const row = db()
@@ -1824,7 +1824,7 @@ export async function forSession(
     let vectorScores: Map<string, number>;
     try {
       const [contextVec] = await embedding.embed([sessionContext], "query");
-      const hits = embedding.vectorSearch(contextVec, 50, excludeFilter);
+      const hits = await embedding.vectorSearch(contextVec, 50, excludeFilter);
       vectorScores = new Map(hits.map((h) => [h.id, h.similarity]));
     } catch (err) {
       log.warn("Vector scoring failed, falling back to FTS5:", err);

--- a/packages/core/src/pattern-echo.ts
+++ b/packages/core/src/pattern-echo.ts
@@ -118,7 +118,11 @@ async function _detect(input: {
 
   // Step 2: Search for similar distillations across the project (wide net)
   const pid = ensureProject(input.projectPath);
-  const hits = embedding.vectorSearchAllDistillations(vec, pid, MAX_CANDIDATES);
+  const hits = await embedding.vectorSearchAllDistillations(
+    vec,
+    pid,
+    MAX_CANDIDATES,
+  );
 
   // Step 3: Filter candidates — above lower threshold, exclude self
   const candidates = hits.filter(

--- a/packages/core/src/recall.ts
+++ b/packages/core/src/recall.ts
@@ -860,7 +860,7 @@ export async function searchRecall(
 
       // Knowledge vector search
       if (knowledgeEnabled) {
-        const vectorHits = embedding.vectorSearch(queryVec, limit);
+        const vectorHits = await embedding.vectorSearch(queryVec, limit);
         const vectorTagged: TaggedResult[] = [];
         for (const hit of vectorHits) {
           const entry = ltm.get(hit.id);
@@ -886,7 +886,7 @@ export async function searchRecall(
 
       // Distillation vector search
       if (scope !== "knowledge") {
-        const distVectorHits = embedding.vectorSearchDistillations(
+        const distVectorHits = await embedding.vectorSearchDistillations(
           queryVec,
           limit,
         );
@@ -916,7 +916,7 @@ export async function searchRecall(
       // Temporal vector search (includes distilled — embeddings preserved by markDistilled)
       if (scope !== "knowledge") {
         const pid = ensureProject(projectPath);
-        const temporalVectorHits = embedding.vectorSearchTemporal(
+        const temporalVectorHits = await embedding.vectorSearchTemporal(
           queryVec,
           pid,
           limit,
@@ -956,7 +956,7 @@ export async function searchRecall(
         // user references by name from another project resolves semantically
         // too. `infra` stays project-scoped.
         const entPid = ensureProject(projectPath);
-        const entityVectorHits = embedding.vectorSearchEntities(
+        const entityVectorHits = await embedding.vectorSearchEntities(
           queryVec,
           limit,
         );

--- a/packages/core/src/vector-pool.ts
+++ b/packages/core/src/vector-pool.ts
@@ -44,6 +44,13 @@ const VECTOR_SEARCH_TIMEOUT_MS = 5_000;
  *  unblock the main loop, not to parallelize an infrequent, sub-ms scan. */
 const DEFAULT_POOL_SIZE = 2;
 
+/** Consecutive structural failures (worker death / load failure / reader-open
+ *  failure) — with no healthy reply in between — that latch the pool broken.
+ *  A persistently unresolvable worker (missing bundle, bad DB path) would
+ *  otherwise respawn on every call; latching makes it fall back to the
+ *  in-process path for the rest of the process. */
+const MAX_STRUCTURAL_FAILURES = 6;
+
 type Hits = VectorHit[] | DistillationVectorHit[];
 
 interface Pending {
@@ -62,6 +69,11 @@ let workers: PoolWorker[] = [];
 let nextRequestId = 0;
 /** Latched true after spawning fails — stops per-call retry storms. */
 let poolBroken = false;
+/** Consecutive structural failures since the last healthy reply. */
+let structuralFailures = 0;
+/** True while shutting the pool down, so terminate()-induced exits aren't
+ *  counted as structural failures. */
+let shuttingDown = false;
 
 /** Test seam: when set, the pool builds workers with this factory instead of
  *  spawning a real `node:worker_threads` Worker. Never set in production. */
@@ -152,6 +164,42 @@ function failAll(pw: PoolWorker, err: Error): void {
   pw.inflight.clear();
 }
 
+/**
+ * Count a structural failure (worker death / load failure / reader-open
+ * failure). After MAX_STRUCTURAL_FAILURES in a row with no healthy reply, latch
+ * the pool broken and terminate any survivors so callers fall back to the
+ * in-process path for the rest of the process instead of respawn-storming.
+ */
+function recordStructuralFailure(): void {
+  if (shuttingDown || poolBroken) return;
+  structuralFailures++;
+  if (structuralFailures < MAX_STRUCTURAL_FAILURES) return;
+  poolBroken = true;
+  log.info(
+    "vector worker pool disabled (repeated worker failures) — using in-process vector search",
+  );
+  for (const w of workers) {
+    try {
+      void w.worker.terminate();
+    } catch {
+      // best-effort
+    }
+  }
+  workers = [];
+}
+
+/**
+ * Mark a worker dead exactly once: reject its in-flight work and count it
+ * toward the structural-failure latch. Idempotent — a worker that posts an
+ * init-error and then exits is counted a single time.
+ */
+function markDead(pw: PoolWorker, err: Error): void {
+  if (pw.dead) return;
+  pw.dead = true;
+  failAll(pw, err);
+  recordStructuralFailure();
+}
+
 function makeWorker(): PoolWorker | null {
   try {
     const worker = spawnWorker({ dbPath: dbPath() });
@@ -162,6 +210,8 @@ function makeWorker(): PoolWorker | null {
     worker.on("message", (msg: VectorWorkerOutbound) => {
       switch (msg.type) {
         case "result": {
+          // A healthy reply clears the structural-failure streak.
+          structuralFailures = 0;
           const pending = pw.inflight.get(msg.id);
           if (pending) {
             pw.inflight.delete(msg.id);
@@ -171,6 +221,8 @@ function makeWorker(): PoolWorker | null {
           break;
         }
         case "error": {
+          // Per-request failure (NOT a worker death) — reject just this
+          // request; the worker keeps serving. Caller falls back in-process.
           const pending = pw.inflight.get(msg.id);
           if (pending) {
             pw.inflight.delete(msg.id);
@@ -180,9 +232,8 @@ function makeWorker(): PoolWorker | null {
           break;
         }
         case "init-error": {
-          // Reader connection failed to open — this worker is useless.
-          pw.dead = true;
-          failAll(pw, new Error(`vector worker init failed: ${msg.error}`));
+          // Reader connection failed to open — the worker is structurally dead.
+          markDead(pw, new Error(`vector worker init failed: ${msg.error}`));
           break;
         }
         // "ready" is informational; nothing to do.
@@ -190,13 +241,11 @@ function makeWorker(): PoolWorker | null {
     });
 
     worker.on("error", (err: Error) => {
-      pw.dead = true;
-      failAll(pw, err instanceof Error ? err : new Error(String(err)));
+      markDead(pw, err instanceof Error ? err : new Error(String(err)));
     });
 
     worker.on("exit", () => {
-      pw.dead = true;
-      failAll(pw, new Error("vector worker exited"));
+      markDead(pw, new Error("vector worker exited"));
     });
 
     return pw;
@@ -215,7 +264,17 @@ function makeWorker(): PoolWorker | null {
 /** Ensure the pool is populated with live workers; replace dead slots. Returns
  *  the live workers (possibly empty if spawning failed). */
 function ensurePool(): PoolWorker[] {
-  // Drop dead workers.
+  // Terminate and drop dead workers. A worker that hit init-error keeps its
+  // message loop alive, so we must terminate it explicitly or it leaks a thread.
+  for (const w of workers) {
+    if (w.dead) {
+      try {
+        void w.worker.terminate();
+      } catch {
+        // best-effort
+      }
+    }
+  }
   workers = workers.filter((w) => !w.dead);
   const target = desiredPoolSize();
   while (workers.length < target) {
@@ -258,8 +317,21 @@ export async function tryPoolVectorSearch(
         reject(new Error("vector worker search timed out"));
       }, VECTOR_SEARCH_TIMEOUT_MS);
       pw.inflight.set(id, { resolve, reject, timer });
-      const msg: VectorWorkerInbound = { type: "search", id, spec, embedding };
-      pw.worker.postMessage(msg);
+      try {
+        const msg: VectorWorkerInbound = {
+          type: "search",
+          id,
+          spec,
+          embedding,
+        };
+        pw.worker.postMessage(msg);
+      } catch (err) {
+        // The worker died in the window after leastBusy() picked it. Clean up
+        // the timer + inflight entry (don't leak them) and fall back.
+        clearTimeout(timer);
+        pw.inflight.delete(id);
+        reject(err instanceof Error ? err : new Error(String(err)));
+      }
     });
   } catch (err) {
     log.info(
@@ -270,8 +342,11 @@ export async function tryPoolVectorSearch(
   }
 }
 
-/** Tear down the pool (test teardown + process reset). Idempotent. */
+/** Tear down the pool (test teardown + process reset). Idempotent. The
+ *  shuttingDown guard keeps the terminate()-induced worker exits below from
+ *  being counted as structural failures. */
 export function shutdownVectorPool(): void {
+  shuttingDown = true;
   for (const pw of workers) {
     failAll(pw, new Error("vector pool shutting down"));
     try {
@@ -288,9 +363,11 @@ export function shutdownVectorPool(): void {
   workers = [];
 }
 
-/** For tests: reset all pool state (workers, broken latch, request ids). */
+/** For tests: reset all pool state (workers, latches, counters, request ids). */
 export function _resetVectorPoolForTest(): void {
   shutdownVectorPool();
   poolBroken = false;
   nextRequestId = 0;
+  structuralFailures = 0;
+  shuttingDown = false;
 }

--- a/packages/core/src/vector-pool.ts
+++ b/packages/core/src/vector-pool.ts
@@ -1,0 +1,295 @@
+/**
+ * Vector-search read-worker pool.
+ *
+ * Offloads the synchronous, O(n) cosine-similarity scans behind every
+ * `vectorSearch*` call (recall, the per-turn LTM/delta injection path, dedup,
+ * and the background scanners) onto a small pool of worker threads, each with
+ * its own read-only WAL connection (see db/reader.ts). The goal is to keep the
+ * main event loop free: one session's heavy vector work runs in a worker while
+ * the main thread keeps serving other sessions' streams.
+ *
+ * Safety model (this is shipped behind a DEFAULT-ON kill switch, not opt-in):
+ *   - `search.embeddings.workerOffload` (config, default true) and the
+ *     `LORE_DISABLE_VEC_WORKER=1` env var both gate the pool off → callers run
+ *     the in-process path (current behavior).
+ *   - `tryPoolVectorSearch()` NEVER throws: any spawn failure, worker death,
+ *     timeout, or per-request error resolves to `null`, and the caller falls
+ *     back to the in-process `runVectorQuery`. Repeated structural failure
+ *     latches the pool broken so we don't retry-storm.
+ *   - In tests the pool is inert unless a worker factory is installed via
+ *     `_setTestVectorWorkerFactory` (so unit tests keep pure in-process
+ *     behavior and never spawn a real worker).
+ */
+
+import { Worker } from "node:worker_threads";
+import { config } from "./config";
+import { dbPath } from "./db";
+import * as log from "./log";
+import type {
+  DistillationVectorHit,
+  VectorHit,
+  VectorQuerySpec,
+} from "./vector-query";
+import type {
+  VectorWorkerInbound,
+  VectorWorkerInitData,
+  VectorWorkerOutbound,
+} from "./vector-worker-types";
+
+/** Per-request timeout. A hung worker must never hang recall — on timeout we
+ *  reject (→ caller falls back in-process). Generous vs. a sub-ms vec scan. */
+const VECTOR_SEARCH_TIMEOUT_MS = 5_000;
+
+/** Default worker count when config doesn't specify. Small: the goal is to
+ *  unblock the main loop, not to parallelize an infrequent, sub-ms scan. */
+const DEFAULT_POOL_SIZE = 2;
+
+type Hits = VectorHit[] | DistillationVectorHit[];
+
+interface Pending {
+  resolve: (hits: Hits) => void;
+  reject: (err: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+interface PoolWorker {
+  worker: Worker;
+  inflight: Map<number, Pending>;
+  dead: boolean;
+}
+
+let workers: PoolWorker[] = [];
+let nextRequestId = 0;
+/** Latched true after spawning fails — stops per-call retry storms. */
+let poolBroken = false;
+
+/** Test seam: when set, the pool builds workers with this factory instead of
+ *  spawning a real `node:worker_threads` Worker. Never set in production. */
+let testWorkerFactory: ((data: VectorWorkerInitData) => Worker) | null = null;
+
+/** For tests: install (or clear with null) the worker factory seam. */
+export function _setTestVectorWorkerFactory(
+  factory: ((data: VectorWorkerInitData) => Worker) | null,
+): void {
+  testWorkerFactory = factory;
+}
+
+/** Whether the pool should be used at all. */
+function poolEnabled(): boolean {
+  if (poolBroken) return false;
+  if (process.env.LORE_DISABLE_VEC_WORKER === "1") return false;
+  // With a test factory installed the pool is explicitly under test.
+  if (testWorkerFactory) return true;
+  // Otherwise inert in tests so unit suites keep pure in-process behavior and
+  // never attempt a real spawn (which can't resolve the .ts worker in vitest).
+  if (process.env.NODE_ENV === "test") return false;
+  return config().search.embeddings.workerOffload !== false;
+}
+
+function desiredPoolSize(): number {
+  if (testWorkerFactory) return 1;
+  const n = config().search.embeddings.workerPoolSize;
+  return typeof n === "number" && n >= 1 ? Math.floor(n) : DEFAULT_POOL_SIZE;
+}
+
+/**
+ * Resolve how to spawn the vector worker, mirroring LocalProvider.ensureWorker
+ * in embedding.ts:
+ *   - test factory seam (deterministic fake), else
+ *   - SEA binary: source string via `globalThis.__LORE_VECTOR_WORKER_SOURCE__`
+ *     (set by sea-entry.ts) → `new Worker(src, { eval: true, filename, ... })`,
+ *   - npm/dev: sibling `./vector-worker.{ts,cjs,js}` next to this module.
+ */
+function spawnWorker(initData: VectorWorkerInitData): Worker {
+  if (testWorkerFactory) return testWorkerFactory(initData);
+
+  const workerSource = (globalThis as Record<string, unknown>)
+    .__LORE_VECTOR_WORKER_SOURCE__ as string | undefined;
+  if (workerSource !== undefined) {
+    const { join } = require("node:path") as typeof import("node:path");
+    const { homedir } = require("node:os") as typeof import("node:os");
+    // `filename` (sets the worker's __filename under eval:true) isn't in node's
+    // WorkerOptions type but is honored at runtime — same loose-options pattern
+    // as LocalProvider.ensureWorker in embedding.ts.
+    const opts: Record<string, unknown> = {
+      eval: true,
+      filename: join(homedir(), ".cache", "lore", "vector-worker.cjs"),
+      workerData: initData,
+    };
+    return new Worker(workerSource, opts);
+  }
+
+  // npm bundle / dev: sibling file. CJS uses __filename; ESM uses import.meta.url.
+  let workerUrl: string | URL;
+  if (typeof __filename === "string") {
+    const { pathToFileURL } = require("node:url") as typeof import("node:url");
+    const workerExt = __filename.endsWith(".ts")
+      ? ".ts"
+      : __filename.endsWith(".cjs")
+        ? ".cjs"
+        : ".js";
+    workerUrl = new URL(
+      `./vector-worker${workerExt}`,
+      pathToFileURL(__filename),
+    );
+  } else {
+    const selfUrl = import.meta.url;
+    workerUrl = new URL(
+      `./vector-worker${selfUrl.endsWith(".ts") ? ".ts" : ".js"}`,
+      selfUrl,
+    );
+  }
+  return new Worker(workerUrl, { workerData: initData });
+}
+
+/** Reject and clear every in-flight request on a worker (death/timeout). */
+function failAll(pw: PoolWorker, err: Error): void {
+  for (const [, p] of pw.inflight) {
+    clearTimeout(p.timer);
+    p.reject(err);
+  }
+  pw.inflight.clear();
+}
+
+function makeWorker(): PoolWorker | null {
+  try {
+    const worker = spawnWorker({ dbPath: dbPath() });
+    const pw: PoolWorker = { worker, inflight: new Map(), dead: false };
+    // Don't keep the process alive for a background read worker.
+    worker.unref();
+
+    worker.on("message", (msg: VectorWorkerOutbound) => {
+      switch (msg.type) {
+        case "result": {
+          const pending = pw.inflight.get(msg.id);
+          if (pending) {
+            pw.inflight.delete(msg.id);
+            clearTimeout(pending.timer);
+            pending.resolve(msg.hits);
+          }
+          break;
+        }
+        case "error": {
+          const pending = pw.inflight.get(msg.id);
+          if (pending) {
+            pw.inflight.delete(msg.id);
+            clearTimeout(pending.timer);
+            pending.reject(new Error(msg.error));
+          }
+          break;
+        }
+        case "init-error": {
+          // Reader connection failed to open — this worker is useless.
+          pw.dead = true;
+          failAll(pw, new Error(`vector worker init failed: ${msg.error}`));
+          break;
+        }
+        // "ready" is informational; nothing to do.
+      }
+    });
+
+    worker.on("error", (err: Error) => {
+      pw.dead = true;
+      failAll(pw, err instanceof Error ? err : new Error(String(err)));
+    });
+
+    worker.on("exit", () => {
+      pw.dead = true;
+      failAll(pw, new Error("vector worker exited"));
+    });
+
+    return pw;
+  } catch (err) {
+    // Synchronous spawn failure (e.g. unresolvable worker URL). Latch broken so
+    // we stop trying — callers fall back to in-process for the process lifetime.
+    poolBroken = true;
+    log.info(
+      "vector worker pool disabled (spawn failed):",
+      err instanceof Error ? err.message : String(err),
+    );
+    return null;
+  }
+}
+
+/** Ensure the pool is populated with live workers; replace dead slots. Returns
+ *  the live workers (possibly empty if spawning failed). */
+function ensurePool(): PoolWorker[] {
+  // Drop dead workers.
+  workers = workers.filter((w) => !w.dead);
+  const target = desiredPoolSize();
+  while (workers.length < target) {
+    const pw = makeWorker();
+    if (!pw) break; // poolBroken latched
+    workers.push(pw);
+  }
+  return workers;
+}
+
+/** Pick the live worker with the fewest in-flight requests. */
+function leastBusy(live: PoolWorker[]): PoolWorker | null {
+  let best: PoolWorker | null = null;
+  for (const w of live) {
+    if (w.dead) continue;
+    if (!best || w.inflight.size < best.inflight.size) best = w;
+  }
+  return best;
+}
+
+/**
+ * Run a vector search on the pool. Resolves to the hits, or to `null` when the
+ * pool is disabled/unavailable/failed (the caller then runs the in-process
+ * path). Never rejects.
+ */
+export async function tryPoolVectorSearch(
+  spec: VectorQuerySpec,
+  embedding: Float32Array,
+): Promise<Hits | null> {
+  if (!poolEnabled()) return null;
+  const live = ensurePool();
+  const pw = leastBusy(live);
+  if (!pw) return null;
+
+  const id = nextRequestId++;
+  try {
+    return await new Promise<Hits>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        pw.inflight.delete(id);
+        reject(new Error("vector worker search timed out"));
+      }, VECTOR_SEARCH_TIMEOUT_MS);
+      pw.inflight.set(id, { resolve, reject, timer });
+      const msg: VectorWorkerInbound = { type: "search", id, spec, embedding };
+      pw.worker.postMessage(msg);
+    });
+  } catch (err) {
+    log.info(
+      "vector worker search failed; using in-process fallback:",
+      err instanceof Error ? err.message : String(err),
+    );
+    return null;
+  }
+}
+
+/** Tear down the pool (test teardown + process reset). Idempotent. */
+export function shutdownVectorPool(): void {
+  for (const pw of workers) {
+    failAll(pw, new Error("vector pool shutting down"));
+    try {
+      pw.worker.postMessage({ type: "shutdown" } as VectorWorkerInbound);
+    } catch {
+      // worker may already be gone
+    }
+    try {
+      void pw.worker.terminate();
+    } catch {
+      // best-effort
+    }
+  }
+  workers = [];
+}
+
+/** For tests: reset all pool state (workers, broken latch, request ids). */
+export function _resetVectorPoolForTest(): void {
+  shutdownVectorPool();
+  poolBroken = false;
+  nextRequestId = 0;
+}

--- a/packages/core/src/vector-pool.ts
+++ b/packages/core/src/vector-pool.ts
@@ -87,7 +87,6 @@ function poolEnabled(): boolean {
 }
 
 function desiredPoolSize(): number {
-  if (testWorkerFactory) return 1;
   const n = config().search.embeddings.workerPoolSize;
   return typeof n === "number" && n >= 1 ? Math.floor(n) : DEFAULT_POOL_SIZE;
 }

--- a/packages/core/src/vector-pool.ts
+++ b/packages/core/src/vector-pool.ts
@@ -305,12 +305,15 @@ export async function tryPoolVectorSearch(
   embedding: Float32Array,
 ): Promise<Hits | null> {
   if (!poolEnabled()) return null;
-  const live = ensurePool();
-  const pw = leastBusy(live);
-  if (!pw) return null;
-
-  const id = nextRequestId++;
+  // Everything below is wrapped so the "never throws" contract holds by
+  // construction — any unexpected throw (e.g. from ensurePool) resolves to null
+  // and the caller runs the in-process path.
   try {
+    const live = ensurePool();
+    const pw = leastBusy(live);
+    if (!pw) return null;
+
+    const id = nextRequestId++;
     return await new Promise<Hits>((resolve, reject) => {
       const timer = setTimeout(() => {
         pw.inflight.delete(id);

--- a/packages/core/src/vector-pool.ts
+++ b/packages/core/src/vector-pool.ts
@@ -77,6 +77,8 @@ export function _setTestVectorWorkerFactory(
 /** Whether the pool should be used at all. */
 function poolEnabled(): boolean {
   if (poolBroken) return false;
+  // Kill switch: force the in-process vector-search path, disabling the
+  // off-thread read-worker pool. Default-on escape hatch, not opt-in.
   if (process.env.LORE_DISABLE_VEC_WORKER === "1") return false;
   // With a test factory installed the pool is explicitly under test.
   if (testWorkerFactory) return true;

--- a/packages/core/src/vector-query.ts
+++ b/packages/core/src/vector-query.ts
@@ -30,8 +30,9 @@ export type DistillationVectorHit = {
 };
 
 /** Discriminated description of one of the five vector searches. The query
- *  embedding is passed separately (so it can be transferred zero-copy across
- *  the worker boundary). */
+ *  embedding is passed separately and STRUCTURED-CLONED across the worker
+ *  boundary (~3 KB for 768 dims) — never transferred: a transfer would detach
+ *  the caller's buffer and corrupt the in-process fallback that reuses it. */
 export type VectorQuerySpec =
   | { kind: "knowledge"; limit: number; excludeCategories?: string[] }
   | { kind: "entities"; limit: number }

--- a/packages/core/src/vector-query.ts
+++ b/packages/core/src/vector-query.ts
@@ -1,0 +1,352 @@
+// Pure, dependency-light vector-search query logic.
+//
+// This module is the single source of truth for the cosine-similarity SQL and
+// the JS brute-force fallback. It is imported by BOTH:
+//   1. the main thread (embedding.ts), which runs it against the `db()`
+//      singleton, and
+//   2. the read-worker pool (vector-worker.ts), which runs it against each
+//      worker's own read-only connection — off the main event loop.
+//
+// It MUST stay leaf-level: no transformers.js, no provider chain, no `db()`
+// singleton, no config. The caller supplies the connection and a flag telling
+// us whether sqlite-vec is loaded on THAT connection (the two threads load the
+// extension independently). Keeping this self-contained is what lets the worker
+// bundle stay tiny — see build plumbing in packages/gateway/script.
+
+/** A minimal structural view of a SQLite connection — just what the vector
+ *  queries need. Satisfied by both node:sqlite and bun:sqlite connections. */
+export interface VectorQueryConn {
+  query(sql: string): {
+    all(...params: unknown[]): unknown[];
+  };
+}
+
+export type VectorHit = { id: string; similarity: number };
+
+export type DistillationVectorHit = {
+  id: string;
+  session_id: string;
+  similarity: number;
+};
+
+/** Discriminated description of one of the five vector searches. The query
+ *  embedding is passed separately (so it can be transferred zero-copy across
+ *  the worker boundary). */
+export type VectorQuerySpec =
+  | { kind: "knowledge"; limit: number; excludeCategories?: string[] }
+  | { kind: "entities"; limit: number }
+  | { kind: "distillations"; limit: number }
+  | { kind: "allDistillations"; projectId: string; limit: number }
+  | {
+      kind: "temporal";
+      projectId: string;
+      limit: number;
+      sessionId?: string;
+    };
+
+/**
+ * Pure brute-force cap for `allDistillations` — fine for ~200 entries per
+ * project. Safety-capped to prevent excessive CPU on long-running projects.
+ */
+export const MAX_DISTILLATION_VECTOR_ROWS = 500;
+
+// ---------------------------------------------------------------------------
+// Math + BLOB helpers (moved here from embedding.ts so the worker can share
+// them without pulling in the provider chain). Re-exported from embedding.ts
+// for backwards compatibility with existing `embedding.toBlob` call sites.
+// ---------------------------------------------------------------------------
+
+/**
+ * Cosine similarity between two L2-normalized Float32Array vectors.
+ * All vectors in the system (local ONNX, Voyage, OpenAI) are L2-normalized
+ * at embedding time, so dot product === cosine similarity. This skips the
+ * per-vector norm accumulations and sqrt calls (~2× faster).
+ * Returns -1.0 to 1.0 where 1.0 = identical direction.
+ */
+export function cosineSimilarity(a: Float32Array, b: Float32Array): number {
+  const len = a.length;
+  let dot = 0;
+  for (let i = 0; i < len; i++) {
+    dot += a[i] * b[i];
+  }
+  return dot;
+}
+
+/**
+ * Maintain a bounded descending-sorted array of the top k items by score.
+ * For small k (10–50) and moderate n (200–500), the O(n*k) insert is faster
+ * than O(n log n) sort due to lower constant factors and no allocation.
+ */
+export function topKInsert<T extends { similarity: number }>(
+  topK: T[],
+  item: T,
+  k: number,
+): void {
+  const score = item.similarity;
+  const len = topK.length;
+  if (len >= k && score <= topK[len - 1].similarity) return;
+  // Binary search for insert position in the descending-sorted array
+  let lo = 0;
+  let hi = len;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (topK[mid].similarity > score) lo = mid + 1;
+    else hi = mid;
+  }
+  topK.splice(lo, 0, item);
+  if (topK.length > k) topK.length = k;
+}
+
+/** Convert Float32Array to Buffer for SQLite BLOB storage. */
+export function toBlob(arr: Float32Array): Buffer {
+  return Buffer.from(arr.buffer, arr.byteOffset, arr.byteLength);
+}
+
+/** Convert SQLite BLOB (Buffer/Uint8Array) back to Float32Array. */
+export function fromBlob(blob: Buffer | Uint8Array): Float32Array {
+  const bytes = new Uint8Array(blob);
+  return new Float32Array(bytes.buffer, bytes.byteOffset, bytes.byteLength / 4);
+}
+
+// ---------------------------------------------------------------------------
+// Query runner
+// ---------------------------------------------------------------------------
+
+/**
+ * Run one of the five vector searches against `conn`.
+ *
+ * `vecAvailable` indicates whether sqlite-vec is loaded on `conn`. When true we
+ * use the native `vec_distance_cosine()` scan; on any error (or when false) we
+ * fall back to the pure-JS brute force. Both paths return the same ordering and
+ * scores for L2-normalized vectors (the system-wide invariant) — see db/vec.ts.
+ *
+ * Returns `DistillationVectorHit[]` for `kind === "allDistillations"` and
+ * `VectorHit[]` for every other kind. The two share the same row shape minus
+ * `session_id`, so callers narrow by spec.kind.
+ */
+export function runVectorQuery(
+  conn: VectorQueryConn,
+  vecAvailable: boolean,
+  queryEmbedding: Float32Array,
+  spec: VectorQuerySpec,
+): VectorHit[] | DistillationVectorHit[] {
+  switch (spec.kind) {
+    case "knowledge":
+      return runKnowledge(conn, vecAvailable, queryEmbedding, spec);
+    case "entities":
+      return runEntities(conn, vecAvailable, queryEmbedding, spec.limit);
+    case "distillations":
+      return runDistillations(conn, vecAvailable, queryEmbedding, spec.limit);
+    case "allDistillations":
+      return runAllDistillations(
+        conn,
+        vecAvailable,
+        queryEmbedding,
+        spec.projectId,
+        spec.limit,
+      );
+    case "temporal":
+      return runTemporal(
+        conn,
+        vecAvailable,
+        queryEmbedding,
+        spec.projectId,
+        spec.limit,
+        spec.sessionId,
+      );
+  }
+}
+
+function runKnowledge(
+  conn: VectorQueryConn,
+  vecAvailable: boolean,
+  queryEmbedding: Float32Array,
+  spec: { limit: number; excludeCategories?: string[] },
+): VectorHit[] {
+  const { limit, excludeCategories } = spec;
+  if (vecAvailable) {
+    try {
+      let sql =
+        "SELECT id, 1 - vec_distance_cosine(embedding, ?) AS similarity FROM knowledge_current WHERE embedding IS NOT NULL AND confidence > 0.2";
+      const params: unknown[] = [toBlob(queryEmbedding)];
+      if (excludeCategories?.length) {
+        sql += ` AND category NOT IN (${excludeCategories.map(() => "?").join(",")})`;
+        params.push(...excludeCategories);
+      }
+      sql += " ORDER BY similarity DESC LIMIT ?";
+      params.push(limit);
+      return conn.query(sql).all(...params) as VectorHit[];
+    } catch {
+      // fall through to JS brute-force
+    }
+  }
+  let sql =
+    "SELECT id, embedding FROM knowledge_current WHERE embedding IS NOT NULL AND confidence > 0.2";
+  const params: string[] = [];
+  if (excludeCategories?.length) {
+    sql += ` AND category NOT IN (${excludeCategories.map(() => "?").join(",")})`;
+    params.push(...excludeCategories);
+  }
+  const rows = conn.query(sql).all(...params) as Array<{
+    id: string;
+    embedding: Buffer;
+  }>;
+
+  const topK: VectorHit[] = [];
+  for (const row of rows) {
+    const vec = fromBlob(row.embedding);
+    const sim = cosineSimilarity(queryEmbedding, vec);
+    topKInsert(topK, { id: row.id, similarity: sim }, limit);
+  }
+  return topK;
+}
+
+function runEntities(
+  conn: VectorQueryConn,
+  vecAvailable: boolean,
+  queryEmbedding: Float32Array,
+  limit: number,
+): VectorHit[] {
+  if (vecAvailable) {
+    try {
+      return conn
+        .query(
+          "SELECT id, 1 - vec_distance_cosine(embedding, ?) AS similarity FROM entities WHERE embedding IS NOT NULL ORDER BY similarity DESC LIMIT ?",
+        )
+        .all(toBlob(queryEmbedding), limit) as VectorHit[];
+    } catch {
+      // fall through to JS brute-force
+    }
+  }
+  const rows = conn
+    .query("SELECT id, embedding FROM entities WHERE embedding IS NOT NULL")
+    .all() as Array<{ id: string; embedding: Buffer }>;
+
+  const topK: VectorHit[] = [];
+  for (const row of rows) {
+    const vec = fromBlob(row.embedding);
+    const sim = cosineSimilarity(queryEmbedding, vec);
+    topKInsert(topK, { id: row.id, similarity: sim }, limit);
+  }
+  return topK;
+}
+
+function runDistillations(
+  conn: VectorQueryConn,
+  vecAvailable: boolean,
+  queryEmbedding: Float32Array,
+  limit: number,
+): VectorHit[] {
+  if (vecAvailable) {
+    try {
+      return conn
+        .query(
+          "SELECT id, 1 - vec_distance_cosine(embedding, ?) AS similarity FROM distillations WHERE embedding IS NOT NULL AND archived = 0 ORDER BY similarity DESC LIMIT ?",
+        )
+        .all(toBlob(queryEmbedding), limit) as VectorHit[];
+    } catch {
+      // fall through to JS brute-force
+    }
+  }
+  const rows = conn
+    .query(
+      "SELECT id, embedding FROM distillations WHERE embedding IS NOT NULL AND archived = 0",
+    )
+    .all() as Array<{ id: string; embedding: Buffer }>;
+
+  const topK: VectorHit[] = [];
+  for (const row of rows) {
+    const vec = fromBlob(row.embedding);
+    const sim = cosineSimilarity(queryEmbedding, vec);
+    topKInsert(topK, { id: row.id, similarity: sim }, limit);
+  }
+  return topK;
+}
+
+function runAllDistillations(
+  conn: VectorQueryConn,
+  vecAvailable: boolean,
+  queryEmbedding: Float32Array,
+  projectId: string,
+  limit: number,
+): DistillationVectorHit[] {
+  if (vecAvailable) {
+    try {
+      // Rank by similarity within the same most-recent candidate window the JS
+      // path uses (created_at DESC, capped at MAX_DISTILLATION_VECTOR_ROWS).
+      return conn
+        .query(
+          "SELECT id, session_id, 1 - vec_distance_cosine(embedding, ?) AS similarity FROM (SELECT id, session_id, embedding FROM distillations WHERE embedding IS NOT NULL AND project_id = ? ORDER BY created_at DESC LIMIT ?) ORDER BY similarity DESC LIMIT ?",
+        )
+        .all(
+          toBlob(queryEmbedding),
+          projectId,
+          MAX_DISTILLATION_VECTOR_ROWS,
+          limit,
+        ) as DistillationVectorHit[];
+    } catch {
+      // fall through to JS brute-force
+    }
+  }
+  const rows = conn
+    .query(
+      "SELECT id, session_id, embedding FROM distillations WHERE embedding IS NOT NULL AND project_id = ? ORDER BY created_at DESC LIMIT ?",
+    )
+    .all(projectId, MAX_DISTILLATION_VECTOR_ROWS) as Array<{
+    id: string;
+    session_id: string;
+    embedding: Buffer;
+  }>;
+
+  const topK: DistillationVectorHit[] = [];
+  for (const row of rows) {
+    const vec = fromBlob(row.embedding);
+    const sim = cosineSimilarity(queryEmbedding, vec);
+    topKInsert(
+      topK,
+      { id: row.id, session_id: row.session_id, similarity: sim },
+      limit,
+    );
+  }
+  return topK;
+}
+
+function runTemporal(
+  conn: VectorQueryConn,
+  vecAvailable: boolean,
+  queryEmbedding: Float32Array,
+  projectId: string,
+  limit: number,
+  sessionId?: string,
+): VectorHit[] {
+  if (vecAvailable) {
+    try {
+      const vsql = sessionId
+        ? "SELECT id, 1 - vec_distance_cosine(embedding, ?) AS similarity FROM temporal_messages WHERE embedding IS NOT NULL AND project_id = ? AND session_id = ? ORDER BY similarity DESC LIMIT ?"
+        : "SELECT id, 1 - vec_distance_cosine(embedding, ?) AS similarity FROM temporal_messages WHERE embedding IS NOT NULL AND project_id = ? ORDER BY similarity DESC LIMIT ?";
+      const vparams: unknown[] = sessionId
+        ? [toBlob(queryEmbedding), projectId, sessionId, limit]
+        : [toBlob(queryEmbedding), projectId, limit];
+      return conn.query(vsql).all(...vparams) as VectorHit[];
+    } catch {
+      // fall through to JS brute-force
+    }
+  }
+  const sql = sessionId
+    ? "SELECT id, embedding FROM temporal_messages WHERE embedding IS NOT NULL AND project_id = ? AND session_id = ?"
+    : "SELECT id, embedding FROM temporal_messages WHERE embedding IS NOT NULL AND project_id = ?";
+  const params = sessionId ? [projectId, sessionId] : [projectId];
+
+  const rows = conn.query(sql).all(...params) as Array<{
+    id: string;
+    embedding: Buffer;
+  }>;
+
+  const topK: VectorHit[] = [];
+  for (const row of rows) {
+    const vec = fromBlob(row.embedding);
+    const sim = cosineSimilarity(queryEmbedding, vec);
+    topKInsert(topK, { id: row.id, similarity: sim }, limit);
+  }
+  return topK;
+}

--- a/packages/core/src/vector-worker-types.ts
+++ b/packages/core/src/vector-worker-types.ts
@@ -1,0 +1,43 @@
+// Message protocol for the vector-search read-worker pool.
+//
+// The pool (vector-pool.ts) on the main thread posts `VectorWorkerInbound`
+// messages; the worker (vector-worker.ts) replies with `VectorWorkerOutbound`.
+// Kept in a dedicated, dependency-light module so both sides share one
+// definition (the worker imports these as types only — erased at compile —
+// because it is spawned by the runtime's native resolver).
+
+import type {
+  DistillationVectorHit,
+  VectorHit,
+  VectorQuerySpec,
+} from "./vector-query";
+
+/** Passed to the worker via `workerData` at construction time. */
+export interface VectorWorkerInitData {
+  /** Absolute path to the SQLite database file (same file the main thread
+   *  writes; opened read-only here). */
+  dbPath: string;
+}
+
+/** Main thread → worker. */
+export type VectorWorkerInbound =
+  | {
+      type: "search";
+      /** Correlation id, echoed back in the result/error reply. */
+      id: number;
+      spec: VectorQuerySpec;
+      /** Query embedding. Sent by structured clone (≈3 KB for 768 dims). */
+      embedding: Float32Array;
+    }
+  | { type: "shutdown" };
+
+/** Worker → main thread. */
+export type VectorWorkerOutbound =
+  | { type: "ready"; vecAvailable: boolean }
+  | {
+      type: "result";
+      id: number;
+      hits: VectorHit[] | DistillationVectorHit[];
+    }
+  | { type: "error"; id: number; error: string }
+  | { type: "init-error"; error: string };

--- a/packages/core/src/vector-worker.ts
+++ b/packages/core/src/vector-worker.ts
@@ -49,6 +49,10 @@ try {
     type: "init-error",
     error: err instanceof Error ? err.message : String(err),
   });
+  // A failed reader open is persistent — don't linger as an idle thread waiting
+  // for searches we can't serve. Exit so the pool reclaims us (its exit handler
+  // is idempotent with the init-error above). Deferred so the message flushes.
+  setTimeout(() => process.exit(1), 0);
 }
 
 let shutdownRequested = false;

--- a/packages/core/src/vector-worker.ts
+++ b/packages/core/src/vector-worker.ts
@@ -1,0 +1,101 @@
+/**
+ * Vector-search worker thread — runs the cosine-similarity SQL (native
+ * sqlite-vec when available, JS brute-force otherwise) off the main thread.
+ *
+ * This is the entry point for a `node:worker_threads` Worker spawned by the
+ * pool in `vector-pool.ts`. Each worker opens its OWN read-only connection to
+ * the same WAL database (see db/reader.ts) and answers `search` requests by
+ * running the shared `runVectorQuery()` against that connection. Moving the
+ * O(n) scan + BLOB marshalling here keeps the main thread's event loop free so
+ * one session's recall/LTM vector work never stalls other sessions' streams.
+ *
+ * Communication uses `parentPort` structured-clone message passing. The query
+ * embedding (~3 KB) is cloned per request; results are plain arrays.
+ *
+ * @see vector-worker-types.ts for the message protocol.
+ */
+
+import { parentPort, workerData } from "node:worker_threads";
+import { openReaderConnection, type ReaderConnection } from "./db/reader";
+import { runVectorQuery } from "./vector-query";
+import type {
+  VectorWorkerInbound,
+  VectorWorkerInitData,
+  VectorWorkerOutbound,
+} from "./vector-worker-types";
+
+// Only ever loaded as a worker entry point, so `parentPort` is always present.
+if (!parentPort) {
+  throw new Error("vector-worker must be run as a worker thread");
+}
+const port = parentPort;
+
+const init = workerData as VectorWorkerInitData;
+
+function post(msg: VectorWorkerOutbound): void {
+  port.postMessage(msg);
+}
+
+// Open the reader connection eagerly. A failure here (corrupt path, missing
+// driver, locked file) is reported as `init-error` so the pool latches this
+// worker dead and the main thread falls back to the in-process path — never a
+// crash. `reader` stays null on failure and every search replies with an error.
+let reader: ReaderConnection | null = null;
+try {
+  reader = openReaderConnection(init.dbPath);
+  post({ type: "ready", vecAvailable: reader.vecAvailable });
+} catch (err) {
+  post({
+    type: "init-error",
+    error: err instanceof Error ? err.message : String(err),
+  });
+}
+
+let shutdownRequested = false;
+
+port.on("message", (msg: VectorWorkerInbound) => {
+  switch (msg.type) {
+    case "search": {
+      if (shutdownRequested) return;
+      const conn = reader;
+      if (!conn) {
+        post({
+          type: "error",
+          id: msg.id,
+          error: "reader connection unavailable",
+        });
+        return;
+      }
+      try {
+        const hits = runVectorQuery(
+          conn.db,
+          conn.vecAvailable,
+          msg.embedding,
+          msg.spec,
+        );
+        post({ type: "result", id: msg.id, hits });
+      } catch (err) {
+        // Per-request failure — reject just this request, keep serving. The
+        // pool resolves it via the in-process fallback.
+        post({
+          type: "error",
+          id: msg.id,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+      break;
+    }
+    case "shutdown": {
+      shutdownRequested = true;
+      try {
+        (reader?.db as unknown as { close?: () => void })?.close?.();
+      } catch {
+        // best-effort
+      }
+      reader = null;
+      // Defer exit so the in-flight reply postMessage flushes first.
+      setTimeout(() => process.exit(0), 0);
+      break;
+    }
+  }
+});

--- a/packages/core/test/curator-preference-dedup.test.ts
+++ b/packages/core/test/curator-preference-dedup.test.ts
@@ -37,7 +37,7 @@ describe("curator dedupePreferenceCreates", () => {
     // below the global 0.935.
     vectorSpy = vi
       .spyOn(embedding, "vectorSearch")
-      .mockImplementation(() => [{ id: existingId, similarity: 0.9 }]);
+      .mockImplementation(async () => [{ id: existingId, similarity: 0.9 }]);
   });
 
   afterEach(() => {

--- a/packages/core/test/embedding.test.ts
+++ b/packages/core/test/embedding.test.ts
@@ -331,7 +331,7 @@ describe("vectorSearch", () => {
     db().query("DELETE FROM knowledge").run();
   });
 
-  test("returns entries sorted by similarity descending", () => {
+  test("returns entries sorted by similarity descending", async () => {
     const pid = ensureProject(PROJECT);
     const now = Date.now();
 
@@ -391,7 +391,7 @@ describe("vectorSearch", () => {
       );
 
     const query = new Float32Array([1, 0, 0]);
-    const results = vectorSearch(query, 10);
+    const results = await vectorSearch(query, 10);
 
     expect(results.length).toBe(3);
     expect(results[0].id).toBe("embed-a");
@@ -402,7 +402,7 @@ describe("vectorSearch", () => {
     expect(results[2].similarity).toBeCloseTo(0.0, 3);
   });
 
-  test("respects limit parameter", () => {
+  test("respects limit parameter", async () => {
     const pid = ensureProject(PROJECT);
     const now = Date.now();
 
@@ -426,11 +426,11 @@ describe("vectorSearch", () => {
     }
 
     const query = new Float32Array([1, 0, 0]);
-    const results = vectorSearch(query, 2);
+    const results = await vectorSearch(query, 2);
     expect(results.length).toBe(2);
   });
 
-  test("skips entries without embeddings", () => {
+  test("skips entries without embeddings", async () => {
     const pid = ensureProject(PROJECT);
     const now = Date.now();
 
@@ -466,13 +466,13 @@ describe("vectorSearch", () => {
       );
 
     const query = new Float32Array([1, 0, 0]);
-    const results = vectorSearch(query, 10);
+    const results = await vectorSearch(query, 10);
 
     expect(results.length).toBe(1);
     expect(results[0].id).toBe("embed-yes");
   });
 
-  test("skips low-confidence entries", () => {
+  test("skips low-confidence entries", async () => {
     const pid = ensureProject(PROJECT);
     const now = Date.now();
 
@@ -516,7 +516,7 @@ describe("vectorSearch", () => {
       .run("embed-low", 0.1, now, now);
 
     const query = new Float32Array([1, 0, 0]);
-    const results = vectorSearch(query, 10);
+    const results = await vectorSearch(query, 10);
 
     expect(results.length).toBe(1);
     expect(results[0].id).toBe("embed-high");
@@ -541,17 +541,17 @@ describe("vectorSearchEntities", () => {
       .run(id, pid, name, now, now, toBlob(vec));
   }
 
-  test("returns entities sorted by similarity descending", () => {
+  test("returns entities sorted by similarity descending", async () => {
     insertEntity("ent-a", "Exact", new Float32Array([1, 0, 0]));
     insertEntity("ent-b", "Orthogonal", new Float32Array([0, 1, 0]));
     insertEntity("ent-c", "Close", new Float32Array([0.9, 0.1, 0]));
 
-    const results = vectorSearchEntities(new Float32Array([1, 0, 0]), 10);
+    const results = await vectorSearchEntities(new Float32Array([1, 0, 0]), 10);
     expect(results.map((r) => r.id)).toEqual(["ent-a", "ent-c", "ent-b"]);
     expect(results[0].similarity).toBeCloseTo(1, 5);
   });
 
-  test("ignores entities with no embedding and respects limit", () => {
+  test("ignores entities with no embedding and respects limit", async () => {
     insertEntity("ent-x", "Has vec", new Float32Array([1, 0, 0]));
     const pid = ensureProject(PROJECT);
     const now = Date.now();
@@ -561,7 +561,7 @@ describe("vectorSearchEntities", () => {
       )
       .run(pid, now, now);
 
-    const results = vectorSearchEntities(new Float32Array([1, 0, 0]), 1);
+    const results = await vectorSearchEntities(new Float32Array([1, 0, 0]), 1);
     expect(results.length).toBe(1);
     expect(results[0].id).toBe("ent-x");
   });
@@ -663,7 +663,7 @@ describeLocalProvider("LocalProvider integration", () => {
     }
 
     const [queryVec] = await embed(["database schema changes"], "query");
-    const results = vectorSearch(queryVec, 3);
+    const results = await vectorSearch(queryVec, 3);
 
     expect(results.length).toBe(3);
     // The PostgreSQL entry should be most relevant

--- a/packages/core/test/ltm.test.ts
+++ b/packages/core/test/ltm.test.ts
@@ -324,7 +324,7 @@ describe("ltm.findSemanticDuplicate — preference-specific threshold", () => {
     // preference threshold, but BELOW the conservative global 0.935.
     vectorSpy = vi
       .spyOn(embedding, "vectorSearch")
-      .mockImplementation(() => [{ id: existingId, similarity: 0.9 }]);
+      .mockImplementation(async () => [{ id: existingId, similarity: 0.9 }]);
   });
 
   afterEach(() => {
@@ -1124,12 +1124,14 @@ describe("ltm.forSession — vector-path set stability (regression #727)", () =>
       .spyOn(embedding, "embed")
       .mockResolvedValue([new Float32Array([1, 0, 0])]);
     // vectorSearch returns the current turn's per-entry similarities.
-    vectorSpy = vi.spyOn(embedding, "vectorSearch").mockImplementation(() =>
-      [...currentScores.entries()].map(([id, similarity]) => ({
-        id,
-        similarity,
-      })),
-    );
+    vectorSpy = vi
+      .spyOn(embedding, "vectorSearch")
+      .mockImplementation(async () =>
+        [...currentScores.entries()].map(([id, similarity]) => ({
+          id,
+          similarity,
+        })),
+      );
   });
 
   afterEach(() => {

--- a/packages/core/test/vec-search.test.ts
+++ b/packages/core/test/vec-search.test.ts
@@ -56,7 +56,7 @@ describe("sqlite-vec extension loading", () => {
   // normalizes internally while the JS dot product does not. Stored [2,0,0]
   // vs query [1,0,0]: vec → cosine 1.0; JS → raw dot 2.0. Asserting ~1.0 fails
   // if the vec branch is removed.
-  test("vec branch is exercised when available (not silent fallback)", () => {
+  test("vec branch is exercised when available (not silent fallback)", async () => {
     if (!isVecAvailable()) return; // JS-only runtime: nothing to prove here
     const pid = ensureProject(PROJECT);
     db().query("DELETE FROM knowledge").run();
@@ -73,7 +73,7 @@ describe("sqlite-vec extension loading", () => {
         toBlob(new Float32Array([2, 0, 0])),
         "k-nonnorm",
       );
-    const hits = vectorSearch(new Float32Array([1, 0, 0]), 1);
+    const hits = await vectorSearch(new Float32Array([1, 0, 0]), 1);
     expect(hits.length).toBe(1);
     expect(hits[0].similarity).toBeCloseTo(1.0, 5); // vec (normalized), not 2.0 (raw dot)
   });
@@ -148,27 +148,27 @@ describe("vectorSearch excludeCategories", () => {
     );
   }
 
-  test("excludes the named category on the vec path", () => {
+  test("excludes the named category on the vec path", async () => {
     if (!isVecAvailable()) return; // JS leg below covers the fallback branch
     const pid = ensureProject(PROJECT);
     seedTwoCategories(pid);
-    const ids = vectorSearch(new Float32Array([1, 0, 0]), 10, [
-      "preference",
-    ]).map((h) => h.id);
+    const ids = (
+      await vectorSearch(new Float32Array([1, 0, 0]), 10, ["preference"])
+    ).map((h) => h.id);
     expect(ids).toContain("k-keep");
     expect(ids).not.toContain("k-drop");
   });
 
-  test("excludes the named category on the JS fallback path", () => {
+  test("excludes the named category on the JS fallback path", async () => {
     const pid = ensureProject(PROJECT);
     seedTwoCategories(pid);
     close();
     process.env.LORE_DISABLE_VEC = "1";
     try {
       expect(isVecAvailable()).toBe(false);
-      const ids = vectorSearch(new Float32Array([1, 0, 0]), 10, [
-        "preference",
-      ]).map((h) => h.id);
+      const ids = (
+        await vectorSearch(new Float32Array([1, 0, 0]), 10, ["preference"])
+      ).map((h) => h.id);
       expect(ids).toContain("k-keep");
       expect(ids).not.toContain("k-drop");
     } finally {
@@ -204,14 +204,17 @@ describe("vectorSearchDistillations / vectorSearchAllDistillations", () => {
       );
   }
 
-  test("ranks by similarity and excludes archived", () => {
+  test("ranks by similarity and excludes archived", async () => {
     const pid = ensureProject(PROJECT);
     insertDistillation("d-near", pid, unit([1, 0, 0]));
     insertDistillation("d-mid", pid, unit([0.6, 0.4, 0]));
     insertDistillation("d-far", pid, unit([0, 1, 0]));
     insertDistillation("d-archived", pid, unit([1, 0, 0]), { archived: 1 });
 
-    const hits = vectorSearchDistillations(new Float32Array([1, 0, 0]), 10);
+    const hits = await vectorSearchDistillations(
+      new Float32Array([1, 0, 0]),
+      10,
+    );
     const ids = hits.map((h) => h.id);
     expect(ids).toEqual(["d-near", "d-mid", "d-far"]);
     expect(ids).not.toContain("d-archived");
@@ -219,7 +222,7 @@ describe("vectorSearchDistillations / vectorSearchAllDistillations", () => {
     expect(hits[1].similarity).toBeGreaterThan(hits[2].similarity);
   });
 
-  test("allDistillations includes archived and returns session_id", () => {
+  test("allDistillations includes archived and returns session_id", async () => {
     const pid = ensureProject(PROJECT);
     insertDistillation("a-near", pid, unit([1, 0, 0]), {
       archived: 1,
@@ -227,7 +230,7 @@ describe("vectorSearchDistillations / vectorSearchAllDistillations", () => {
     });
     insertDistillation("a-far", pid, unit([0, 1, 0]), { session: "sY" });
 
-    const hits = vectorSearchAllDistillations(
+    const hits = await vectorSearchAllDistillations(
       new Float32Array([1, 0, 0]),
       pid,
       10,
@@ -257,21 +260,25 @@ describe("vectorSearchTemporal", () => {
       .run(id, pid, session, now, toBlob(vec));
   }
 
-  test("ranks by similarity, scoped to project", () => {
+  test("ranks by similarity, scoped to project", async () => {
     const pid = ensureProject(PROJECT);
     insertTemporal("t-near", pid, "s1", unit([1, 0, 0]));
     insertTemporal("t-far", pid, "s1", unit([0, 1, 0]));
 
-    const hits = vectorSearchTemporal(new Float32Array([1, 0, 0]), pid, 10);
+    const hits = await vectorSearchTemporal(
+      new Float32Array([1, 0, 0]),
+      pid,
+      10,
+    );
     expect(hits.map((h) => h.id)).toEqual(["t-near", "t-far"]);
   });
 
-  test("optional session scoping", () => {
+  test("optional session scoping", async () => {
     const pid = ensureProject(PROJECT);
     insertTemporal("t-s1", pid, "s1", unit([1, 0, 0]));
     insertTemporal("t-s2", pid, "s2", unit([1, 0, 0]));
 
-    const hits = vectorSearchTemporal(
+    const hits = await vectorSearchTemporal(
       new Float32Array([1, 0, 0]),
       pid,
       10,
@@ -291,7 +298,7 @@ describe("vec path vs JS fallback parity", () => {
     close();
   });
 
-  test("identical top-k from vec and JS paths on the same data", () => {
+  test("identical top-k from vec and JS paths on the same data", async () => {
     const pid = ensureProject(PROJECT);
     db().query("DELETE FROM knowledge").run();
     // 40 deterministic pseudo-random normalized vectors in 8 dims.
@@ -314,13 +321,13 @@ describe("vec path vs JS fallback parity", () => {
 
     // Vec path (only meaningful when the extension is actually loaded).
     const skipVecLeg = !isVecAvailable();
-    const vecHits = vectorSearch(query, 10);
+    const vecHits = await vectorSearch(query, 10);
 
     // Force the JS fallback: kill-switch + fresh connection.
     close();
     process.env.LORE_DISABLE_VEC = "1";
     expect(isVecAvailable()).toBe(false);
-    const jsHits = vectorSearch(query, 10);
+    const jsHits = await vectorSearch(query, 10);
 
     // Restore vec for the rest of the suite.
     delete process.env.LORE_DISABLE_VEC;

--- a/packages/core/test/vector-pool.test.ts
+++ b/packages/core/test/vector-pool.test.ts
@@ -181,6 +181,51 @@ describe("vector-pool health", () => {
   });
 });
 
+describe("vector-pool structural-failure latch (review #989)", () => {
+  it("latches broken after repeated worker deaths (no respawn storm)", async () => {
+    // Every dispatched worker dies — a stand-in for a broken bundle / a worker
+    // that crashes on load (which surfaces asynchronously as exit).
+    _setTestVectorWorkerFactory(factoryReturning((w) => w.die()));
+    for (let i = 0; i < 12; i++) {
+      expect(await tryPoolVectorSearch(KNOWLEDGE, QUERY)).toBeNull();
+    }
+    const spawnedAtLatch = FakeWorker.instances.length;
+    // Latched: further calls neither spawn a worker nor throw.
+    expect(await tryPoolVectorSearch(KNOWLEDGE, QUERY)).toBeNull();
+    expect(FakeWorker.instances.length).toBe(spawnedAtLatch);
+  });
+
+  it("terminates a dead worker instead of leaking its thread", async () => {
+    _setTestVectorWorkerFactory(
+      factoryReturning((w, msg) => w.reply(msg.id, [])),
+    );
+    await tryPoolVectorSearch(KNOWLEDGE, QUERY);
+    const victim = FakeWorker.instances[0];
+    victim.die();
+    expect(victim.terminated).toBe(false);
+    // The next search runs ensurePool, which must terminate the dead worker.
+    await tryPoolVectorSearch(KNOWLEDGE, QUERY);
+    expect(victim.terminated).toBe(true);
+  });
+
+  it("clears the timer when postMessage throws (no leaked timer)", async () => {
+    // A throw in the Promise executor rejects regardless, so asserting null is
+    // vacuous — the actual S2 bug is the 5 s ref'd timer left armed. Assert it
+    // was cleared (pre-fix: 1 leaked timer; post-fix: 0).
+    vi.useFakeTimers();
+    _setTestVectorWorkerFactory((() => {
+      const w = new FakeWorker(() => {});
+      // Simulate the worker dying between leastBusy() and postMessage().
+      w.postMessage = (() => {
+        throw new Error("dead pipe");
+      }) as never;
+      return w;
+    }) as never);
+    expect(await tryPoolVectorSearch(KNOWLEDGE, QUERY)).toBeNull();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});
+
 describe("embedding.vectorSearch routes through the pool", () => {
   it("returns the pool's hits, not the in-process scan", async () => {
     _setTestVectorWorkerFactory(

--- a/packages/core/test/vector-pool.test.ts
+++ b/packages/core/test/vector-pool.test.ts
@@ -1,0 +1,195 @@
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  _resetVectorPoolForTest,
+  _setTestVectorWorkerFactory,
+  shutdownVectorPool,
+  tryPoolVectorSearch,
+} from "../src/vector-pool";
+import type {
+  VectorWorkerInbound,
+  VectorWorkerInitData,
+} from "../src/vector-worker-types";
+
+// A deterministic stand-in for a node:worker_threads Worker. `onSearch` decides
+// how the fake responds to each "search" message, so each test drives the pool
+// through a specific path (result / error / timeout / death).
+class FakeWorker extends EventEmitter {
+  static instances: FakeWorker[] = [];
+  terminated = false;
+  readonly index: number;
+
+  constructor(readonly onSearch: (w: FakeWorker, msg: { id: number }) => void) {
+    super();
+    this.index = FakeWorker.instances.length;
+    FakeWorker.instances.push(this);
+  }
+  unref(): void {}
+  postMessage(msg: VectorWorkerInbound): void {
+    if (msg.type === "search") this.onSearch(this, msg);
+  }
+  terminate(): Promise<number> {
+    this.terminated = true;
+    this.emit("exit", 0);
+    return Promise.resolve(0);
+  }
+  reply(id: number, hits: unknown[]): void {
+    this.emit("message", { type: "result", id, hits });
+  }
+  replyError(id: number, error: string): void {
+    this.emit("message", { type: "error", id, error });
+  }
+  die(code = 1): void {
+    this.emit("exit", code);
+  }
+}
+
+function factoryReturning(
+  onSearch: (w: FakeWorker, msg: { id: number }) => void,
+): (d: VectorWorkerInitData) => never {
+  return (() => new FakeWorker(onSearch)) as unknown as (
+    d: VectorWorkerInitData,
+  ) => never;
+}
+
+const QUERY = new Float32Array([1, 0, 0]);
+const KNOWLEDGE = { kind: "knowledge" as const, limit: 10 };
+
+beforeEach(() => {
+  FakeWorker.instances = [];
+  _resetVectorPoolForTest();
+});
+
+afterEach(() => {
+  _setTestVectorWorkerFactory(null);
+  _resetVectorPoolForTest();
+  delete process.env.LORE_DISABLE_VEC_WORKER;
+  vi.useRealTimers();
+});
+
+describe("vector-pool dispatch", () => {
+  it("routes a search through the pool and returns its hits", async () => {
+    _setTestVectorWorkerFactory(
+      factoryReturning((w, msg) =>
+        w.reply(msg.id, [{ id: "pooled", similarity: 0.9 }]),
+      ),
+    );
+    const hits = await tryPoolVectorSearch(KNOWLEDGE, QUERY);
+    expect(hits).toEqual([{ id: "pooled", similarity: 0.9 }]);
+  });
+
+  it("spawns a worker only once across multiple searches", async () => {
+    _setTestVectorWorkerFactory(
+      factoryReturning((w, msg) => w.reply(msg.id, [])),
+    );
+    await tryPoolVectorSearch(KNOWLEDGE, QUERY);
+    const afterFirst = FakeWorker.instances.length;
+    await tryPoolVectorSearch(KNOWLEDGE, QUERY);
+    expect(FakeWorker.instances.length).toBe(afterFirst);
+  });
+});
+
+describe("vector-pool kill switch / disable", () => {
+  it("returns null when LORE_DISABLE_VEC_WORKER=1 (never spawns)", async () => {
+    process.env.LORE_DISABLE_VEC_WORKER = "1";
+    _setTestVectorWorkerFactory(
+      factoryReturning((w, msg) =>
+        w.reply(msg.id, [{ id: "x", similarity: 1 }]),
+      ),
+    );
+    const hits = await tryPoolVectorSearch(KNOWLEDGE, QUERY);
+    expect(hits).toBeNull();
+    expect(FakeWorker.instances.length).toBe(0);
+  });
+});
+
+describe("vector-pool fallback paths (resolve null, never throw)", () => {
+  it("returns null when the worker reports a per-request error", async () => {
+    _setTestVectorWorkerFactory(
+      factoryReturning((w, msg) => w.replyError(msg.id, "boom")),
+    );
+    expect(await tryPoolVectorSearch(KNOWLEDGE, QUERY)).toBeNull();
+  });
+
+  it("returns null when the worker never replies (timeout)", async () => {
+    vi.useFakeTimers();
+    _setTestVectorWorkerFactory(factoryReturning(() => {}));
+    const p = tryPoolVectorSearch(KNOWLEDGE, QUERY);
+    await vi.advanceTimersByTimeAsync(5_001);
+    expect(await p).toBeNull();
+  });
+
+  it("returns null and latches broken when spawning throws (no retry)", async () => {
+    let calls = 0;
+    _setTestVectorWorkerFactory((() => {
+      calls++;
+      throw new Error("spawn failed");
+    }) as never);
+    expect(await tryPoolVectorSearch(KNOWLEDGE, QUERY)).toBeNull();
+    const afterFirst = calls;
+    expect(afterFirst).toBeGreaterThan(0);
+    // Broken latch: the factory is not invoked again.
+    expect(await tryPoolVectorSearch(KNOWLEDGE, QUERY)).toBeNull();
+    expect(calls).toBe(afterFirst);
+  });
+});
+
+describe("vector-pool health", () => {
+  it("respawns fresh workers after the live ones die", async () => {
+    _setTestVectorWorkerFactory(
+      factoryReturning((w, msg) =>
+        w.reply(msg.id, [{ id: "ok", similarity: 1 }]),
+      ),
+    );
+    expect(await tryPoolVectorSearch(KNOWLEDGE, QUERY)).toEqual([
+      { id: "ok", similarity: 1 },
+    ]);
+    const spawnedBefore = FakeWorker.instances.length;
+    // Kill every worker.
+    for (const w of FakeWorker.instances) w.die();
+    // Next search must spawn new workers and still succeed.
+    expect(await tryPoolVectorSearch(KNOWLEDGE, QUERY)).toEqual([
+      { id: "ok", similarity: 1 },
+    ]);
+    expect(FakeWorker.instances.length).toBeGreaterThan(spawnedBefore);
+  });
+
+  it("dispatches a concurrent second search to a less-busy worker", async () => {
+    const received: number[] = [];
+    _setTestVectorWorkerFactory(
+      factoryReturning((w, msg) => {
+        received.push(w.index);
+        // Only worker #1 answers; worker #0 holds its request open.
+        if (w.index === 1) w.reply(msg.id, [{ id: "from1", similarity: 1 }]);
+      }),
+    );
+    const held = tryPoolVectorSearch(KNOWLEDGE, QUERY); // → worker 0, never replies
+    held.catch(() => {}); // resolved/cleared on teardown; don't leak rejection
+    const second = await tryPoolVectorSearch(KNOWLEDGE, QUERY); // → worker 1
+    expect(received).toEqual([0, 1]);
+    expect(second).toEqual([{ id: "from1", similarity: 1 }]);
+  });
+
+  it("shutdownVectorPool terminates every spawned worker", async () => {
+    _setTestVectorWorkerFactory(
+      factoryReturning((w, msg) => w.reply(msg.id, [])),
+    );
+    await tryPoolVectorSearch(KNOWLEDGE, QUERY);
+    expect(FakeWorker.instances.length).toBeGreaterThan(0);
+    shutdownVectorPool();
+    expect(FakeWorker.instances.every((w) => w.terminated)).toBe(true);
+  });
+});
+
+describe("embedding.vectorSearch routes through the pool", () => {
+  it("returns the pool's hits, not the in-process scan", async () => {
+    _setTestVectorWorkerFactory(
+      factoryReturning((w, msg) =>
+        w.reply(msg.id, [{ id: "via-pool", similarity: 0.42 }]),
+      ),
+    );
+    const { vectorSearch } = await import("../src/embedding");
+    const hits = await vectorSearch(QUERY, 5);
+    expect(hits).toEqual([{ id: "via-pool", similarity: 0.42 }]);
+  });
+});

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -41,7 +41,9 @@
     "dist/index.cjs",
     "dist/index.d.cts",
     "dist/ort-wasm-simd-threaded.mjs",
-    "dist/ort-wasm-simd-threaded.wasm"
+    "dist/ort-wasm-simd-threaded.wasm",
+    "dist/vector-worker.cjs",
+    "dist/vector-worker.js"
   ],
   "engines": {
     "node": ">=22.15"

--- a/packages/gateway/script/build-binary-sea.ts
+++ b/packages/gateway/script/build-binary-sea.ts
@@ -545,6 +545,40 @@ async function buildBinary() {
   renameSync(workerBundlePath, workerAssetPath);
 
   // -------------------------------------------------------------------------
+  // Step 1c: esbuild vector-search worker bundle
+  // -------------------------------------------------------------------------
+  // The read-worker pool (core/vector-pool.ts) spawns this off the main thread.
+  // Tiny and self-contained: node:sqlite (via the "node" condition) + the pure
+  // runVectorQuery logic. No ONNX/transformers/WASM. sqlite-vec is stubbed (same
+  // as the main SEA bundle), so the worker uses the JS brute-force fallback —
+  // the off-thread benefit holds regardless of the native fast path.
+  const vectorWorkerBundlePath = join(stagingDir, "sea-vector-worker.cjs");
+  const vectorWorkerSrc = join(repoRoot, "packages/core/src/vector-worker.ts");
+
+  await esbuild.build({
+    entryPoints: [vectorWorkerSrc],
+    bundle: true,
+    format: "cjs",
+    target: "node22",
+    platform: "node",
+    conditions: ["node"],
+    external: ["sharp"],
+    plugins: [binaryExternalsPlugin(), stubSqliteVecPlugin()],
+    outfile: vectorWorkerBundlePath,
+    sourcemap: "linked",
+    minify: true,
+    logLevel: "info",
+    legalComments: "none",
+  });
+
+  console.log(`✓ esbuild vector worker: ${vectorWorkerBundlePath}`);
+
+  // Rename to `vector-worker.cjs` so the fossilize asset key matches what
+  // sea-entry.ts reads at runtime (`vector-worker.cjs`).
+  const vectorWorkerAssetPath = join(stagingDir, "vector-worker.cjs");
+  renameSync(vectorWorkerBundlePath, vectorWorkerAssetPath);
+
+  // -------------------------------------------------------------------------
   // Post-process: patch createRequire in both bundles
   // -------------------------------------------------------------------------
   // In CJS output, esbuild shims import.meta to {}, making
@@ -696,6 +730,10 @@ async function buildBinary() {
       src: "ort-wasm-simd-threaded.wasm",
     },
     "worker.cjs": { file: "worker.cjs", src: "worker.cjs" },
+    "vector-worker.cjs": {
+      file: "vector-worker.cjs",
+      src: "vector-worker.cjs",
+    },
   };
   if (vendorModelDir) {
     for (const rel of MODEL_FILES) {

--- a/packages/gateway/script/build.ts
+++ b/packages/gateway/script/build.ts
@@ -69,6 +69,7 @@ async function buildLibrary() {
       "embedding-worker.js",
       'export * from "../../core/src/embedding-worker.ts";\n',
     ],
+    ["vector-worker.js", 'export * from "../../core/src/vector-worker.ts";\n'],
   ];
 
   for (const [filename, content] of shims) {

--- a/packages/gateway/script/bundle.ts
+++ b/packages/gateway/script/bundle.ts
@@ -244,6 +244,55 @@ await esbuild.build({
 });
 
 // ---------------------------------------------------------------------------
+// Vector-search worker — separate CJS file next to index.cjs
+// ---------------------------------------------------------------------------
+// The vector-search read-worker pool (core/vector-pool.ts) spawns this via
+// node:worker_threads. Tiny by design: SQLite driver (node:sqlite via the
+// "node" condition) + sqlite-vec (external native extension) + the pure
+// runVectorQuery logic. No ONNX/transformers, so no ort-web redirect or WASM.
+
+await esbuild.build({
+  entryPoints: [join(packageDir, "..", "core", "src", "vector-worker.ts")],
+  bundle: true,
+  format: "cjs",
+  target: "node22",
+  platform: "node",
+  // Resolve #db/driver → driver.node.ts (node:sqlite)
+  conditions: ["node"],
+  external: ["node:*", "sqlite-vec"],
+  outfile: join(distDir, "vector-worker.cjs"),
+  sourcemap: false,
+  minify: true,
+  logLevel: "info",
+  legalComments: "none",
+  inject: [importMetaUrlShim],
+  define: {
+    "import.meta.url": "import_meta_url",
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Vector-search worker (ESM) — for the Bun ESM bundle
+// ---------------------------------------------------------------------------
+// Resolved by the pool via import.meta.url → ./vector-worker.js under Bun.
+// conditions: ["bun"] so #db/driver resolves to driver.bun.ts (bun:sqlite).
+
+await esbuild.build({
+  entryPoints: [join(packageDir, "..", "core", "src", "vector-worker.ts")],
+  bundle: true,
+  format: "esm",
+  target: "esnext",
+  platform: "node",
+  conditions: ["bun"],
+  external: ["bun:*", "node:*", "sqlite-vec"],
+  outfile: join(distDir, "vector-worker.js"),
+  sourcemap: false,
+  minify: true,
+  logLevel: "info",
+  legalComments: "none",
+});
+
+// ---------------------------------------------------------------------------
 // Ship onnxruntime-web WASM runtime next to the worker bundles
 // ---------------------------------------------------------------------------
 // The worker bundles redirect onnxruntime-node → onnxruntime-web (WASM). At
@@ -475,6 +524,8 @@ console.log(`  dist/index.cjs            — CJS bundle (Node.js, node:sqlite)`)
 console.log(`  dist/index.bun.js         — ESM bundle (Bun, bun:sqlite)`);
 console.log(`  dist/embedding-worker.cjs — embedding worker CJS (Node.js)`);
 console.log(`  dist/embedding-worker.js  — embedding worker ESM (Bun)`);
+console.log(`  dist/vector-worker.cjs    — vector-search worker CJS (Node.js)`);
+console.log(`  dist/vector-worker.js     — vector-search worker ESM (Bun)`);
 console.log(`  dist/ort-wasm-simd-threaded.{mjs,wasm} — ONNX WASM runtime`);
 console.log(`  dist/bin.cjs              — CLI wrapper`);
 console.log(`  dist/index.d.cts          — type declarations`);

--- a/packages/gateway/src/cli/sea-entry.ts
+++ b/packages/gateway/src/cli/sea-entry.ts
@@ -51,6 +51,13 @@ const data = sea.getRawAsset("worker.cjs");
 (globalThis as Record<string, unknown>).__LORE_WORKER_SOURCE__ =
   Buffer.from(data).toString("utf8");
 
+// Vector-search worker source (read-worker pool, core/vector-pool.ts). Same
+// pattern as the embedding worker above: the pool reads this global and spawns
+// `new Worker(src, { eval: true, ... })`.
+const vectorWorkerData = sea.getRawAsset("vector-worker.cjs");
+(globalThis as Record<string, unknown>).__LORE_VECTOR_WORKER_SOURCE__ =
+  Buffer.from(vectorWorkerData).toString("utf8");
+
 // ---------------------------------------------------------------------------
 // 2. Vendor model materialization
 // ---------------------------------------------------------------------------

--- a/packages/website/src/content/docs/docs/configuration.md
+++ b/packages/website/src/content/docs/docs/configuration.md
@@ -159,7 +159,7 @@ Recall and search pipeline tuning: FTS weights, query expansion, vector boost, e
 | `queryExpansionMaxTerms` | number | `8` | min 2, max 20 | Max query terms (after stopword removal) for LLM expansion. Longer queries skip expansion. Default: 8. |
 | `vectorBoostWeight` | number | `1.5` | min 1, max 5 | RRF weight multiplier for vector search lists (when query has enough terms). Set to 1.0 to disable. Default: 1.5. |
 | `vectorBoostMinTerms` | number | `2` | min 1, max 10 | Minimum meaningful query terms (after stopword removal) to activate vector boost. Default: 2. |
-| `embeddings` | object | `{"enabled":true,"provider":"local","model":"nomic-ai/nomic-embed-text-v1.5","dimensions":768}` |  | Vector embedding search provider, model, and dimensions. |
+| `embeddings` | object | `{"enabled":true,"provider":"local","model":"nomic-ai/nomic-embed-text-v1.5","dimensions":768,"workerOffload":true,"workerPoolSize":2}` |  | Vector embedding search provider, model, and dimensions. |
 | `recall` | object | `{"charBudget":12000,"relevanceFloor":0.15,"maxResults":15,"absoluteFloor":0}` |  | Recall output formatting and result-count limits. |
 
 ### `search.ftsWeights`
@@ -182,6 +182,8 @@ Vector embedding search provider, model, and dimensions.
 | `provider` | enum | `"local"` |  | Embedding provider. "local" (no API key, on-device), "voyage" (VOYAGE_API_KEY), "openai" (OPENAI_API_KEY). Default: "local". |
 | `model` | string | `"nomic-ai/nomic-embed-text-v1.5"` |  | Model ID for the embedding provider. Default depends on provider. |
 | `dimensions` | number | `768` | min 64, max 2048 | Embedding dimensions. Default: 768 (local) / 1024 (voyage) / 1536 (openai). Local Nomic v1.5 supports Matryoshka: 64, 128, 256, 512, 768. |
+| `workerOffload` | boolean | `true` |  | Run vector searches on a read-worker pool off the main event loop. Kill switch (default true); set false to force the in-process path. |
+| `workerPoolSize` | number | `2` | min 1, max 16 | Number of read-worker threads for off-thread vector search. Default: 2. |
 
 ### `search.recall`
 

--- a/packages/website/src/content/docs/docs/environment.md
+++ b/packages/website/src/content/docs/docs/environment.md
@@ -71,6 +71,7 @@ Env vars override `.lore.json` for the same setting. To override a `.lore.json` 
 |---|---|
 | `LORE_DB_PATH` | Resolved path of the SQLite database file. Reads `LORE_DB_PATH` first; falls back to `${dataDir}/lore.db` (typically `~/.local/share/lore/lore.db`). The test preload (`packages/core/test/setup.ts`) sets `LORE_DB_PATH` to a temp directory so tests never touch the production DB. Setting it to a non-existent path will create the file on first use. The gateway itself does not set this — it expects a stable location for the DB so the SQLite WAL and FTS5 indices persist across restarts. Env: `LORE_DB_PATH`. |
 | `LORE_DISABLE_VEC` | LORE_DISABLE_VEC=1 forces the JS brute-force vector-search path. Useful as a production kill-switch if the native extension causes issues, and as a test seam for the JS fallback. Set before the first `db()` call — once attempted=true is sticky for the connection lifetime, the env var won't be re-read until resetVecState() runs (in close()). |
+| `LORE_DISABLE_VEC_WORKER` | Kill switch: force the in-process vector-search path, disabling the off-thread read-worker pool. Default-on escape hatch, not opt-in. |
 | `LORE_NO_DB_TRACING` | LORE_NO_DB_TRACING=1 returns the raw connection instead of the query-tracing Proxy (disables automatic per-query DB spans). |
 
 ## How variables are evaluated


### PR DESCRIPTION
Closes part of #966 (worker-offload investigation): **A** — move all synchronous vector-search work off the main event loop, behind a default-on kill switch.

## Why
Every `vectorSearch*` call ran an O(n) cosine scan + BLOB marshalling **synchronously on the main thread** — not just the recall tool, but the per-turn LTM/delta system-prompt injection (`forSession`), semantic dedup, and the background scanners. One session's heavy scan stalled every other session's stream. This moves that work to a small pool of read-worker threads so the event loop stays free.

## What (A)
- **`vector-pool.ts`** — lazy-spawned worker pool; least-busy dispatch; per-request timeout; health + respawn; **default-on kill switch** (`search.embeddings.workerOffload`, default `true`, + `LORE_DISABLE_VEC_WORKER=1`). `tryPoolVectorSearch()` **never throws** — any spawn failure / worker death / timeout / per-request error resolves to `null` and the caller runs the in-process path. Repeated structural failure latches the pool broken (no retry-storm). Inert in tests unless a worker factory is installed.
- **`vector-worker.ts` + `vector-worker-types.ts`** — worker entry + message protocol. Each worker opens its **own read-only WAL connection** (`db/reader.ts`, `query_only=TRUE`, no migrations / no sync triggers) and runs the shared `runVectorQuery` against it. The main thread stays the sole writer.
- **`vector-query.ts`** (extracted first, behavior-identical) — single source of truth for the cosine SQL + JS fallback + `toBlob`/`fromBlob`/`cosineSimilarity`, shared by the main thread and the worker.
- **`embedding.ts`** — the five `vectorSearch*` functions are now `async` and route to the pool when healthy, else in-process. All callers updated to `await` (every caller already awaited `embed()` first, so this is an await-only change).

## Scope notes
- This is **A** from the A/B plan. **B** (generalize the pool to arbitrary heavy sync DB reads — FTS scans, hydration, packing) is a follow-up.
- The native `sqlite-vec` fast path is used inside workers when available; in the SEA binary it's stubbed (as today) so the worker uses the JS brute force — the off-thread benefit holds regardless.

## Build plumbing (all runtimes)
Wired the worker through every runtime shape, mirroring the embedding worker:
- core build → `dist/{node,bun}/vector-worker.js` (opencode/Bun path)
- gateway bundle → `vector-worker.cjs` (Node) + `vector-worker.js` (Bun)
- SEA binary → `vector-worker.cjs` asset + `__LORE_VECTOR_WORKER_SOURCE__` in `sea-entry.ts`
- `package.json` `files` updated.

## Validation
- Full monorepo suite green: **4280 passed / 0 failed**; new-code flakiness check 3×.
- **Mutation testing** of the new pool logic — 7 mutations (least-busy compare, kill switch, broken latch, dead-worker filter, result/error/timeout handling) all **KILLED**; file restored byte-identical.
- **SEA validated on linux-x64**: `--prepare-only` stages + manifests the worker; a real fossilize binary runs (`--version`, embedded source bytes present); spawning the SEA-staged worker against a seeded DB returns correct top-k with the confidence filter applied. (darwin/windows rely on CI matrix, same as the embedding worker.)
- Typecheck (all packages), lint (0 new warnings), docs regenerated.

🤖 Generated with [opencode](https://opencode.ai)