### PR TITLE
fix(vector-pool): unref the per-request timeout timer (#989 review)

### DIFF
--- a/packages/core/src/vector-pool.ts
+++ b/packages/core/src/vector-pool.ts
@@ -319,6 +319,11 @@ export async function tryPoolVectorSearch(
         pw.inflight.delete(id);
         reject(new Error("vector worker search timed out"));
       }, VECTOR_SEARCH_TIMEOUT_MS);
+      // The worker is already unref'd (makeWorker), so an in-flight search must
+      // not be the thing that keeps the event loop alive: unref the timeout too,
+      // or a pending request delays process exit by up to
+      // VECTOR_SEARCH_TIMEOUT_MS on shutdown. (review #989)
+      timer.unref();
       pw.inflight.set(id, { resolve, reject, timer });
       try {
         const msg: VectorWorkerInbound = {

--- a/packages/core/test/vector-pool.test.ts
+++ b/packages/core/test/vector-pool.test.ts
@@ -42,6 +42,12 @@ class FakeWorker extends EventEmitter {
   die(code = 1): void {
     this.emit("exit", code);
   }
+  initError(error: string): void {
+    this.emit("message", { type: "init-error", error });
+  }
+  crash(err: Error): void {
+    this.emit("error", err);
+  }
 }
 
 function factoryReturning(
@@ -204,6 +210,70 @@ describe("vector-pool structural-failure latch (review #989)", () => {
     victim.die();
     expect(victim.terminated).toBe(false);
     // The next search runs ensurePool, which must terminate the dead worker.
+    await tryPoolVectorSearch(KNOWLEDGE, QUERY);
+    expect(victim.terminated).toBe(true);
+  });
+
+  it("unref()'s the per-request timeout timer so a pending search can't delay exit", async () => {
+    // The actual review-#989 bug: the 5 s timeout timer was ref'd, so an
+    // in-flight search would hold the event loop open on shutdown even though
+    // the worker is unref'd. Spy on the real timer object's unref() — asserting
+    // it's called is the only non-vacuous check (removing the source line fails
+    // this). The worker replies synchronously, so the timer is also cleared and
+    // never leaks.
+    const realSetTimeout = globalThis.setTimeout;
+    const unref = vi.fn();
+    const spy = vi.spyOn(globalThis, "setTimeout").mockImplementation(((
+      handler: () => void,
+      ms?: number,
+      ...rest: unknown[]
+    ) => {
+      const t = realSetTimeout(handler, ms, ...rest);
+      (t as unknown as { unref: () => void }).unref = unref;
+      return t;
+    }) as never);
+    try {
+      _setTestVectorWorkerFactory(
+        factoryReturning((w, msg) =>
+          w.reply(msg.id, [{ id: "ok", similarity: 1 }]),
+        ),
+      );
+      await tryPoolVectorSearch(KNOWLEDGE, QUERY);
+      expect(unref).toHaveBeenCalledTimes(1);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("treats a worker init-error message as a structural death", async () => {
+    // A reader connection that fails to open surfaces as an init-error message,
+    // marking the worker structurally dead. Asserting only null would be vacuous
+    // (the 5s timeout fallback also resolves null); instead assert the dead
+    // worker is terminated on the next ensurePool — a side effect the timeout
+    // path never produces. Pre-fix mutation (init-error → no markDead): the
+    // victim stays alive and this fails.
+    _setTestVectorWorkerFactory(
+      factoryReturning((w, msg) => w.reply(msg.id, [])),
+    );
+    await tryPoolVectorSearch(KNOWLEDGE, QUERY); // healthy worker spawned
+    const victim = FakeWorker.instances[0];
+    victim.initError("reader open failed"); // init-error message → markDead
+    expect(victim.terminated).toBe(false);
+    // The next search runs ensurePool, which must terminate the dead worker.
+    await tryPoolVectorSearch(KNOWLEDGE, QUERY);
+    expect(victim.terminated).toBe(true);
+  });
+
+  it("treats a worker 'error' event as a structural death", async () => {
+    // Same non-vacuous shape as above: a crashed worker must be recognized as
+    // dead and terminated on the next ensurePool, not merely produce a null.
+    _setTestVectorWorkerFactory(
+      factoryReturning((w, msg) => w.reply(msg.id, [])),
+    );
+    await tryPoolVectorSearch(KNOWLEDGE, QUERY); // healthy worker spawned
+    const victim = FakeWorker.instances[0];
+    victim.crash(new Error("worker thread crashed")); // error event → markDead
+    expect(victim.terminated).toBe(false);
     await tryPoolVectorSearch(KNOWLEDGE, QUERY);
     expect(victim.terminated).toBe(true);
   });


### PR DESCRIPTION
Forward-fix for a MEDIUM Seer finding on #989 (merged in \`05116f71\`):
https://github.com/BYK/loreai/pull/989#discussion_r3474996042

## The bug
The 5 s search-timeout timer created in \`tryPoolVectorSearch\` was **ref'd**, so a single in-flight vector search would keep the Node event loop alive on shutdown for up to \`VECTOR_SEARCH_TIMEOUT_MS\` (5 s) — even though the worker thread itself is already \`unref()\`'d in \`makeWorker\`. The timer is the lone thing pinning the loop open.

## The fix
\`unref()\` the timeout timer immediately after creation (one line), matching the existing \`worker.unref()\` pattern in the same module. A pending request can no longer delay process exit; on a real reply the timer is still \`clearTimeout\`'d as before, so nothing leaks.

## Coverage
The Seer-flagged patch landed a smidge under the 80 % target. This PR's own patch is fully exercised, and I added three tests that lift \`vector-pool.ts\` from **85.6 % → 88.1 % lines / 94.7 % → 100 % funcs**:
- \`unref()\` assertion on the timeout timer (the fix; mutation-verified below)
- \`init-error\` message → structural-death → null fallback (was uncovered)
- worker \`error\` event → structural-death → null fallback (was uncovered)

Remaining uncovered lines (\`spawnWorker\` SEA/npm real-spawn paths, \`poolEnabled\` production config branch) require spawning real OS worker threads / resolving bundle files absent under vitest — by the module's own design ("inert in tests… never attempt a real spawn"). Left untested deliberately rather than adding flaky real-thread spawns; mirrors the already-shipped \`embedding.ts\` \`LocalProvider.ensureWorker\` pattern.

## Verification
- Mutation test: removing \`timer.unref();\` makes the new \`unref()\` test **fail** (isolated detached worktree) → non-vacuous.
- Full core suite green (2079 passed / 6 skipped); typecheck + biome clean.