### PR TITLE
perf(core): materialized per-session rollup for /ui/costs aggregates (#981)

### DIFF
--- a/packages/core/src/data.ts
+++ b/packages/core/src/data.ts
@@ -23,6 +23,7 @@ import {
   onProjectMutation,
   loadParentChildMap,
   invalidateParentChildCache,
+  rebuildDirtySessionRollups,
 } from "./db";
 import { getGitRemote } from "./git";
 import * as ltm from "./ltm";
@@ -387,6 +388,78 @@ export function aggregateDistillationsBySessionAll(opts?: {
     });
   }
   return result;
+}
+
+/**
+ * One materialized session row from `session_rollup`, joined to its project, with
+ * everything the costs page needs in a single read (#981). Replaces the three
+ * O(N temporal_messages) bulk aggregates (`listAllRecentSessions`,
+ * `aggregateTokensBySessionAll`, `aggregateDistillationsBySessionAll`).
+ */
+export type SessionRollupSummary = {
+  project_id: string;
+  project_path: string;
+  project_name: string | null;
+  session_id: string;
+  message_count: number;
+  first_message_at: number;
+  last_message_at: number;
+  /** Whole-session SUM(tokens). */
+  total_tokens: number;
+  /** Metadata of the earliest assistant message (for model detection), or null. */
+  first_assistant_metadata: string | null;
+  distill_total_calls: number;
+  distill_batch_calls: number;
+  distill_total_tokens: number;
+  distill_batch_tokens: number;
+};
+
+/**
+ * List per-session rollup rows (across ALL projects) for the costs page. Reads the
+ * materialized `session_rollup` table — O(sessions), independent of the total
+ * `temporal_messages` count — instead of scanning every message row.
+ *
+ * `sinceMs` scopes to sessions last active on/after the cutoff (filters
+ * `last_message_at`); unlike the old per-message `created_at >= sinceMs` filter,
+ * the token/count totals are whole-session. With the 90-day costs window and
+ * short-lived sessions these are equivalent (a session is effectively always
+ * entirely inside or outside the window), and the whole-session total no longer
+ * splits a boundary-straddling session.
+ *
+ * Resolves any `dirty` rollup rows from source first (a delete of an extreme row
+ * defers the MIN/MAX/earliest-assistant recompute to read time), so the returned
+ * values always match a full recompute.
+ */
+export function listSessionRollups(opts?: {
+  sinceMs?: number;
+  limit?: number;
+}): SessionRollupSummary[] {
+  const sinceMs = opts?.sinceMs ?? 0;
+  const limit = opts?.limit ?? 50_000;
+  rebuildDirtySessionRollups(db());
+  return db()
+    .query(
+      `SELECT
+         sr.project_id,
+         p.path AS project_path,
+         p.name AS project_name,
+         sr.session_id,
+         sr.message_count,
+         sr.first_message_at,
+         sr.last_message_at,
+         sr.token_sum AS total_tokens,
+         sr.first_assistant_metadata,
+         sr.distill_calls AS distill_total_calls,
+         sr.distill_batch_calls,
+         sr.distill_token_sum AS distill_total_tokens,
+         sr.distill_batch_token_sum AS distill_batch_tokens
+       FROM session_rollup sr
+       JOIN projects p ON p.id = sr.project_id
+       WHERE sr.message_count > 0 AND sr.last_message_at >= ?
+       ORDER BY sr.last_message_at DESC
+       LIMIT ?`,
+    )
+    .all(sinceMs, limit) as SessionRollupSummary[];
 }
 
 /** Get a single distillation by ID (or resolved prefix). */
@@ -1142,6 +1215,15 @@ export function moveSessions(
     database
       .query(
         `UPDATE distillations SET project_id = ? WHERE project_id = ? AND session_id IN (${placeholders})`,
+      )
+      .run(toId, fromProjectId, ...allIds);
+
+    // Re-point the session rollup set-based: the project_id UPDATEs above do NOT
+    // fire the rollup triggers (scoped to content/tokens/metadata + insert/delete),
+    // so move the rows here. session_id is globally unique ⇒ no PK collision.
+    database
+      .query(
+        `UPDATE session_rollup SET project_id = ? WHERE project_id = ? AND session_id IN (${placeholders})`,
       )
       .run(toId, fromProjectId, ...allIds);
 

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1882,20 +1882,21 @@ export function rebuildDirtySessionRollups(database: Database = db()): void {
     .query("SELECT project_id, session_id FROM session_rollup WHERE dirty = 1")
     .all() as Array<{ project_id: string; session_id: string }>;
   // Fast path: nothing dirty. This is the common case on the /ui/costs read
-  // path, so don't open a (write-locking) transaction when there's no work.
+  // path, so don't open a transaction when there's no work.
   if (dirty.length === 0) return;
   // A bulk prune/clear can flag many sessions dirty at once; recomputing each in
   // its own auto-commit on this read path is N fsyncs of write-amplification
-  // (cf. the ~23x seedOutbox slowdown). Batch the whole rebuild into ONE
-  // transaction on this same handle. Reached only via listSessionRollups (read
-  // path) / recovery / tests — never from within another transaction.
-  database.exec("BEGIN IMMEDIATE");
+  // (cf. the ~23x seedOutbox slowdown). Batch the whole rebuild into ONE unit.
+  // A SAVEPOINT (not BEGIN) makes this safe whether called at top level (the
+  // /ui/costs read path) OR nested inside an existing transaction.
+  database.exec("SAVEPOINT rebuild_dirty_rollups");
   try {
     for (const r of dirty)
       recomputeSessionRollupRow(database, r.project_id, r.session_id);
-    database.exec("COMMIT");
+    database.exec("RELEASE rebuild_dirty_rollups");
   } catch (e) {
-    database.exec("ROLLBACK");
+    database.exec("ROLLBACK TO rebuild_dirty_rollups");
+    database.exec("RELEASE rebuild_dirty_rollups");
     throw e;
   }
 }
@@ -1906,54 +1907,66 @@ export function rebuildDirtySessionRollups(database: Database = db()): void {
  * passes that benefit from the v57/v58 covering indexes (#981).
  */
 export function rebuildAllSessionRollups(database: Database = db()): void {
-  database.exec("DELETE FROM session_rollup");
-  // Pass 1: per-session message_count / token_sum / first/last_message_at.
-  database.exec(`
-    INSERT INTO session_rollup (
-      project_id, session_id, message_count, token_sum, first_message_at, last_message_at
-    )
-    SELECT project_id, session_id, COUNT(*), COALESCE(SUM(tokens), 0),
-           MIN(created_at), MAX(created_at)
-      FROM temporal_messages
-     GROUP BY project_id, session_id;
-  `);
-  // Pass 2: earliest assistant row per session (tie-break created_at ASC, rowid ASC).
-  // Every session with an assistant message already has a row from pass 1, so the
-  // ON CONFLICT branch always applies.
-  database.exec(`
-    INSERT INTO session_rollup (
-      project_id, session_id, first_assistant_rowid, first_assistant_at, first_assistant_metadata
-    )
-    SELECT project_id, session_id, rid, created_at, metadata FROM (
-      SELECT project_id, session_id, rowid AS rid, created_at, metadata,
-             ROW_NUMBER() OVER (
-               PARTITION BY project_id, session_id ORDER BY created_at ASC, rowid ASC
-             ) AS rn
-        FROM temporal_messages WHERE role = 'assistant'
-    ) WHERE rn = 1
-    ON CONFLICT(project_id, session_id) DO UPDATE SET
-      first_assistant_rowid = excluded.first_assistant_rowid,
-      first_assistant_at = excluded.first_assistant_at,
-      first_assistant_metadata = excluded.first_assistant_metadata;
-  `);
-  // Pass 3: distillation counts/tokens per session (may create distill-only rows).
-  database.exec(`
-    INSERT INTO session_rollup (
-      project_id, session_id, distill_calls, distill_batch_calls,
-      distill_token_sum, distill_batch_token_sum
-    )
-    SELECT project_id, session_id, COUNT(*),
-           COALESCE(SUM(CASE WHEN call_type = 'batch' THEN 1 ELSE 0 END), 0),
-           COALESCE(SUM(token_count), 0),
-           COALESCE(SUM(CASE WHEN call_type = 'batch' THEN token_count ELSE 0 END), 0)
-      FROM distillations
-     GROUP BY project_id, session_id
-    ON CONFLICT(project_id, session_id) DO UPDATE SET
-      distill_calls = excluded.distill_calls,
-      distill_batch_calls = excluded.distill_batch_calls,
-      distill_token_sum = excluded.distill_token_sum,
-      distill_batch_token_sum = excluded.distill_batch_token_sum;
-  `);
+  // Atomic truncate+repopulate: a crash between the DELETE and the final INSERT
+  // would otherwise leave the table empty/partial. A SAVEPOINT (not BEGIN) keeps
+  // this safe whether called at top level (migration runs in autocommit) OR
+  // nested inside an existing transaction.
+  database.exec("SAVEPOINT rebuild_all_rollups");
+  try {
+    database.exec("DELETE FROM session_rollup");
+    // Pass 1: per-session message_count / token_sum / first/last_message_at.
+    database.exec(`
+      INSERT INTO session_rollup (
+        project_id, session_id, message_count, token_sum, first_message_at, last_message_at
+      )
+      SELECT project_id, session_id, COUNT(*), COALESCE(SUM(tokens), 0),
+             MIN(created_at), MAX(created_at)
+        FROM temporal_messages
+       GROUP BY project_id, session_id;
+    `);
+    // Pass 2: earliest assistant row per session (tie-break created_at ASC, rowid ASC).
+    // Every session with an assistant message already has a row from pass 1, so the
+    // ON CONFLICT branch always applies.
+    database.exec(`
+      INSERT INTO session_rollup (
+        project_id, session_id, first_assistant_rowid, first_assistant_at, first_assistant_metadata
+      )
+      SELECT project_id, session_id, rid, created_at, metadata FROM (
+        SELECT project_id, session_id, rowid AS rid, created_at, metadata,
+               ROW_NUMBER() OVER (
+                 PARTITION BY project_id, session_id ORDER BY created_at ASC, rowid ASC
+               ) AS rn
+          FROM temporal_messages WHERE role = 'assistant'
+      ) WHERE rn = 1
+      ON CONFLICT(project_id, session_id) DO UPDATE SET
+        first_assistant_rowid = excluded.first_assistant_rowid,
+        first_assistant_at = excluded.first_assistant_at,
+        first_assistant_metadata = excluded.first_assistant_metadata;
+    `);
+    // Pass 3: distillation counts/tokens per session (may create distill-only rows).
+    database.exec(`
+      INSERT INTO session_rollup (
+        project_id, session_id, distill_calls, distill_batch_calls,
+        distill_token_sum, distill_batch_token_sum
+      )
+      SELECT project_id, session_id, COUNT(*),
+             COALESCE(SUM(CASE WHEN call_type = 'batch' THEN 1 ELSE 0 END), 0),
+             COALESCE(SUM(token_count), 0),
+             COALESCE(SUM(CASE WHEN call_type = 'batch' THEN token_count ELSE 0 END), 0)
+        FROM distillations
+       GROUP BY project_id, session_id
+      ON CONFLICT(project_id, session_id) DO UPDATE SET
+        distill_calls = excluded.distill_calls,
+        distill_batch_calls = excluded.distill_batch_calls,
+        distill_token_sum = excluded.distill_token_sum,
+        distill_batch_token_sum = excluded.distill_batch_token_sum;
+    `);
+    database.exec("RELEASE rebuild_all_rollups");
+  } catch (e) {
+    database.exec("ROLLBACK TO rebuild_all_rollups");
+    database.exec("RELEASE rebuild_all_rollups");
+    throw e;
+  }
 }
 
 /** v60 migration step: create the rollup objects then backfill from source. */

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1609,12 +1609,12 @@ function applyKnowledgeMetaRegister(database: Database): void {
 }
 
 // ---------------------------------------------------------------------------
-// session_rollup — materialized per-session aggregates for /ui/costs (v59, #981)
+// session_rollup — materialized per-session aggregates for /ui/costs (v60, #981)
 // ---------------------------------------------------------------------------
 
 /**
  * Schema + maintenance triggers for `session_rollup`, all `IF NOT EXISTS` so it
- * can run from the v59 migration AND self-heal from `recoverMissingObjects`.
+ * can run from the v60 migration AND self-heal from `recoverMissingObjects`.
  *
  * One row per `(project_id, session_id)` holds exactly the costs-page inputs:
  *   - temporal_messages: message_count, token_sum, first/last_message_at, and the
@@ -1887,7 +1887,7 @@ export function rebuildDirtySessionRollups(database: Database = db()): void {
 
 /**
  * Reconstruct the entire session_rollup table from the source tables. Used by the
- * v59 backfill and by recovery. Idempotent (truncate + repopulate). Three grouped
+ * v60 backfill and by recovery. Idempotent (truncate + repopulate). Three grouped
  * passes that benefit from the v57/v58 covering indexes (#981).
  */
 export function rebuildAllSessionRollups(database: Database = db()): void {
@@ -1941,7 +1941,7 @@ export function rebuildAllSessionRollups(database: Database = db()): void {
   `);
 }
 
-/** v59 migration step: create the rollup objects then backfill from source. */
+/** v60 migration step: create the rollup objects then backfill from source. */
 function applySessionRollup(database: Database): void {
   ensureSessionRollup(database);
   rebuildAllSessionRollups(database);

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1881,8 +1881,23 @@ export function rebuildDirtySessionRollups(database: Database = db()): void {
   const dirty = database
     .query("SELECT project_id, session_id FROM session_rollup WHERE dirty = 1")
     .all() as Array<{ project_id: string; session_id: string }>;
-  for (const r of dirty)
-    recomputeSessionRollupRow(database, r.project_id, r.session_id);
+  // Fast path: nothing dirty. This is the common case on the /ui/costs read
+  // path, so don't open a (write-locking) transaction when there's no work.
+  if (dirty.length === 0) return;
+  // A bulk prune/clear can flag many sessions dirty at once; recomputing each in
+  // its own auto-commit on this read path is N fsyncs of write-amplification
+  // (cf. the ~23x seedOutbox slowdown). Batch the whole rebuild into ONE
+  // transaction on this same handle. Reached only via listSessionRollups (read
+  // path) / recovery / tests — never from within another transaction.
+  database.exec("BEGIN IMMEDIATE");
+  try {
+    for (const r of dirty)
+      recomputeSessionRollupRow(database, r.project_id, r.session_id);
+    database.exec("COMMIT");
+  } catch (e) {
+    database.exec("ROLLBACK");
+    throw e;
+  }
 }
 
 /**

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1504,6 +1504,27 @@ const MIGRATIONS: string[] = [
     PRIMARY KEY (logical_id, symbol)
   );
   `,
+
+  `
+  -- Version 60: materialized per-session rollup for the /ui/costs page (#981).
+  --
+  -- v57/v58 made the three costs-page bulk aggregates index-only, but they are
+  -- still O(N temporal_messages) scans that re-degrade as the table outgrows the
+  -- page cache. This migration introduces session_rollup — one row per
+  -- (project_id, session_id) holding the costs-page inputs (token_sum,
+  -- message_count, first/last_message_at, earliest-assistant metadata, and the
+  -- distillation call_type counts/tokens). It is maintained incrementally by
+  -- triggers on temporal_messages and distillations, so the costs page reads
+  -- ~hundreds of session rows instead of scanning ~200K message rows
+  -- (O(sessions) not O(messages)).
+  --
+  -- The table, its indexes, the maintenance triggers AND the one-time backfill
+  -- from existing rows are all performed by a JS step (applySessionRollup),
+  -- special-cased in migrate() by SESSION_ROLLUP_MIGRATION_INDEX. Doing it in JS
+  -- lets the SAME idempotent routine run from recoverMissingObjects (self-heal a
+  -- dropped/empty rollup) and reuse the canonical rebuild query in tests/recovery.
+  -- This string is intentionally a no-op marker so MIGRATIONS.length still counts.
+  `,
 ];
 
 // Index of the migration whose work is performed by a column-presence-aware JS
@@ -1512,6 +1533,12 @@ const MIGRATIONS: string[] = [
 // apply would throw "no such column" and boot-loop (mirrors VACUUM's special
 // casing). The MIGRATIONS entry at this index is a no-op documentation marker.
 const KNOWLEDGE_META_MIGRATION_INDEX = 54; // 0-based index of version-55
+
+// Index of the migration whose work (create session_rollup + triggers + backfill)
+// is performed by a JS step instead of plain SQL, so the same idempotent routine
+// can run from recoverMissingObjects and reuse the canonical rebuild query. The
+// MIGRATIONS entry at this index is a no-op documentation marker.
+const SESSION_ROLLUP_MIGRATION_INDEX = 59; // 0-based index of version-60
 
 /**
  * Idempotent, column-presence-aware application of the v55 knowledge_meta register
@@ -1579,6 +1606,345 @@ function applyKnowledgeMetaRegister(database: Database): void {
       FROM knowledge k
       LEFT JOIN knowledge_meta m ON m.logical_id = k.logical_id
      WHERE k.is_current = 1 AND k.is_deleted = 0;`);
+}
+
+// ---------------------------------------------------------------------------
+// session_rollup — materialized per-session aggregates for /ui/costs (v59, #981)
+// ---------------------------------------------------------------------------
+
+/**
+ * Schema + maintenance triggers for `session_rollup`, all `IF NOT EXISTS` so it
+ * can run from the v59 migration AND self-heal from `recoverMissingObjects`.
+ *
+ * One row per `(project_id, session_id)` holds exactly the costs-page inputs:
+ *   - temporal_messages: message_count, token_sum, first/last_message_at, and the
+ *     earliest-assistant row (identity + created_at + metadata, for model detection);
+ *   - distillations: call/token counts split by call_type.
+ *
+ * Maintenance invariants (see #981 plan):
+ *   - token_sum / message_count / distill_* are EXACT O(1) deltas on every write.
+ *   - The only values that cannot be maintained by a pure delta are the MIN/MAX
+ *     (first/last_message_at) and the earliest-assistant row when the extreme row
+ *     is DELETED. Those mark `dirty=1`; the read path / rebuild recomputes the
+ *     session lazily — so even bulk prune/clear stays O(1) per source row.
+ *   - The UPDATE trigger is scoped `AFTER UPDATE OF content, tokens, metadata`,
+ *     which fires ONLY for `temporal.store()`'s re-store. project_id/session_id/
+ *     created_at/role are immutable on that path; the project_id moves done by
+ *     mergeProjectInternal / moveSessions intentionally do NOT fire it and instead
+ *     re-point the rollup rows set-based.
+ *   - distillations.call_type / token_count are immutable after insert, so there
+ *     is no distillation UPDATE trigger (archived/embedding changes don't count).
+ *   - Earliest-assistant tie-break is (created_at ASC, rowid ASC) everywhere
+ *     (insert trigger, recompute, full rebuild) so incremental == recompute.
+ */
+const SESSION_ROLLUP_SCHEMA_SQL = `
+  CREATE TABLE IF NOT EXISTS session_rollup (
+    project_id               TEXT NOT NULL REFERENCES projects(id),
+    session_id               TEXT NOT NULL,
+    message_count            INTEGER NOT NULL DEFAULT 0,
+    token_sum                INTEGER NOT NULL DEFAULT 0,
+    first_message_at         INTEGER,
+    last_message_at          INTEGER,
+    first_assistant_rowid    INTEGER,
+    first_assistant_at       INTEGER,
+    first_assistant_metadata TEXT,
+    distill_calls            INTEGER NOT NULL DEFAULT 0,
+    distill_batch_calls      INTEGER NOT NULL DEFAULT 0,
+    distill_token_sum        INTEGER NOT NULL DEFAULT 0,
+    distill_batch_token_sum  INTEGER NOT NULL DEFAULT 0,
+    dirty                    INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (project_id, session_id)
+  );
+  CREATE INDEX IF NOT EXISTS idx_session_rollup_last  ON session_rollup(last_message_at);
+  CREATE INDEX IF NOT EXISTS idx_session_rollup_dirty ON session_rollup(dirty) WHERE dirty = 1;
+
+  -- temporal_messages INSERT: extend the running aggregates; adopt the new row as
+  -- earliest-assistant when it is an assistant strictly earlier than the current
+  -- one (tie-break: smaller rowid). All RHS expressions in the DO UPDATE see the
+  -- pre-update row values (SQLite UPSERT semantics), so the three first_assistant_*
+  -- assignments share one consistent comparison.
+  CREATE TRIGGER IF NOT EXISTS temporal_rollup_insert
+  AFTER INSERT ON temporal_messages
+  BEGIN
+    INSERT INTO session_rollup (
+      project_id, session_id, message_count, token_sum,
+      first_message_at, last_message_at,
+      first_assistant_rowid, first_assistant_at, first_assistant_metadata, dirty
+    ) VALUES (
+      NEW.project_id, NEW.session_id, 1, COALESCE(NEW.tokens, 0),
+      NEW.created_at, NEW.created_at,
+      CASE WHEN NEW.role = 'assistant' THEN NEW.rowid END,
+      CASE WHEN NEW.role = 'assistant' THEN NEW.created_at END,
+      CASE WHEN NEW.role = 'assistant' THEN NEW.metadata END,
+      0
+    )
+    ON CONFLICT(project_id, session_id) DO UPDATE SET
+      message_count = message_count + 1,
+      token_sum = token_sum + COALESCE(NEW.tokens, 0),
+      -- COALESCE first: the row may have been seeded by a distillation insert
+      -- (message-less), leaving first/last_message_at NULL; scalar MIN/MAX would
+      -- otherwise propagate that NULL forever once a distill-only row exists.
+      first_message_at = MIN(COALESCE(first_message_at, NEW.created_at), NEW.created_at),
+      last_message_at = MAX(COALESCE(last_message_at, NEW.created_at), NEW.created_at),
+      first_assistant_rowid = CASE
+        WHEN NEW.role = 'assistant' AND (
+          first_assistant_at IS NULL OR NEW.created_at < first_assistant_at
+          OR (NEW.created_at = first_assistant_at AND NEW.rowid < first_assistant_rowid)
+        ) THEN NEW.rowid ELSE first_assistant_rowid END,
+      first_assistant_at = CASE
+        WHEN NEW.role = 'assistant' AND (
+          first_assistant_at IS NULL OR NEW.created_at < first_assistant_at
+          OR (NEW.created_at = first_assistant_at AND NEW.rowid < first_assistant_rowid)
+        ) THEN NEW.created_at ELSE first_assistant_at END,
+      first_assistant_metadata = CASE
+        WHEN NEW.role = 'assistant' AND (
+          first_assistant_at IS NULL OR NEW.created_at < first_assistant_at
+          OR (NEW.created_at = first_assistant_at AND NEW.rowid < first_assistant_rowid)
+        ) THEN NEW.metadata ELSE first_assistant_metadata END;
+  END;
+
+  -- temporal_messages re-store (only content/tokens/metadata change): apply the
+  -- token delta and refresh the earliest-assistant metadata iff THIS row is it.
+  CREATE TRIGGER IF NOT EXISTS temporal_rollup_update
+  AFTER UPDATE OF content, tokens, metadata ON temporal_messages
+  BEGIN
+    UPDATE session_rollup SET
+      token_sum = token_sum - COALESCE(OLD.tokens, 0) + COALESCE(NEW.tokens, 0),
+      first_assistant_metadata = CASE
+        WHEN NEW.rowid = first_assistant_rowid THEN NEW.metadata
+        ELSE first_assistant_metadata END
+    WHERE project_id = NEW.project_id AND session_id = NEW.session_id;
+  END;
+
+  -- temporal_messages DELETE: exact count/token deltas; mark dirty when an extreme
+  -- (first/last message or the earliest-assistant row) is removed so the session is
+  -- recomputed lazily. Drop the rollup row once the session has no rows at all.
+  CREATE TRIGGER IF NOT EXISTS temporal_rollup_delete
+  AFTER DELETE ON temporal_messages
+  BEGIN
+    UPDATE session_rollup SET
+      message_count = message_count - 1,
+      token_sum = token_sum - COALESCE(OLD.tokens, 0),
+      dirty = CASE
+        WHEN OLD.rowid = first_assistant_rowid
+          OR OLD.created_at = first_message_at
+          OR OLD.created_at = last_message_at
+        THEN 1 ELSE dirty END
+    WHERE project_id = OLD.project_id AND session_id = OLD.session_id;
+    DELETE FROM session_rollup
+    WHERE project_id = OLD.project_id AND session_id = OLD.session_id
+      AND message_count <= 0 AND distill_calls <= 0;
+  END;
+
+  -- distillations INSERT/DELETE: pure SUM/COUNT deltas (no extremes → never dirty).
+  CREATE TRIGGER IF NOT EXISTS distillation_rollup_insert
+  AFTER INSERT ON distillations
+  BEGIN
+    INSERT INTO session_rollup (
+      project_id, session_id,
+      distill_calls, distill_batch_calls, distill_token_sum, distill_batch_token_sum
+    ) VALUES (
+      NEW.project_id, NEW.session_id, 1,
+      CASE WHEN NEW.call_type = 'batch' THEN 1 ELSE 0 END,
+      COALESCE(NEW.token_count, 0),
+      CASE WHEN NEW.call_type = 'batch' THEN COALESCE(NEW.token_count, 0) ELSE 0 END
+    )
+    ON CONFLICT(project_id, session_id) DO UPDATE SET
+      distill_calls = distill_calls + 1,
+      distill_batch_calls = distill_batch_calls
+        + CASE WHEN NEW.call_type = 'batch' THEN 1 ELSE 0 END,
+      distill_token_sum = distill_token_sum + COALESCE(NEW.token_count, 0),
+      distill_batch_token_sum = distill_batch_token_sum
+        + CASE WHEN NEW.call_type = 'batch' THEN COALESCE(NEW.token_count, 0) ELSE 0 END;
+  END;
+
+  CREATE TRIGGER IF NOT EXISTS distillation_rollup_delete
+  AFTER DELETE ON distillations
+  BEGIN
+    UPDATE session_rollup SET
+      distill_calls = distill_calls - 1,
+      distill_batch_calls = distill_batch_calls
+        - CASE WHEN OLD.call_type = 'batch' THEN 1 ELSE 0 END,
+      distill_token_sum = distill_token_sum - COALESCE(OLD.token_count, 0),
+      distill_batch_token_sum = distill_batch_token_sum
+        - CASE WHEN OLD.call_type = 'batch' THEN COALESCE(OLD.token_count, 0) ELSE 0 END
+    WHERE project_id = OLD.project_id AND session_id = OLD.session_id;
+    DELETE FROM session_rollup
+    WHERE project_id = OLD.project_id AND session_id = OLD.session_id
+      AND message_count <= 0 AND distill_calls <= 0;
+  END;
+`;
+
+/** Create the session_rollup table + maintenance triggers if missing (idempotent). */
+export function ensureSessionRollup(database: Database): void {
+  database.exec(SESSION_ROLLUP_SCHEMA_SQL);
+}
+
+/**
+ * Recompute one session's rollup row from the source tables and clear its dirty
+ * flag. Bounded by the session's own row count (uses the session-scoped indexes).
+ * If the session has neither messages nor distillations, the row is removed.
+ */
+function recomputeSessionRollupRow(
+  database: Database,
+  projectId: string,
+  sessionId: string,
+): void {
+  const t = database
+    .query(
+      `SELECT COUNT(*) AS c, COALESCE(SUM(tokens), 0) AS toks,
+              MIN(created_at) AS first_at, MAX(created_at) AS last_at
+         FROM temporal_messages WHERE project_id = ? AND session_id = ?`,
+    )
+    .get(projectId, sessionId) as {
+    c: number;
+    toks: number;
+    first_at: number | null;
+    last_at: number | null;
+  };
+  const fa = database
+    .query(
+      `SELECT rowid AS rid, created_at, metadata
+         FROM temporal_messages
+        WHERE project_id = ? AND session_id = ? AND role = 'assistant'
+        ORDER BY created_at ASC, rowid ASC LIMIT 1`,
+    )
+    .get(projectId, sessionId) as {
+    rid: number;
+    created_at: number;
+    metadata: string | null;
+  } | null;
+  const d = database
+    .query(
+      `SELECT COUNT(*) AS calls,
+              COALESCE(SUM(CASE WHEN call_type = 'batch' THEN 1 ELSE 0 END), 0) AS batch_calls,
+              COALESCE(SUM(token_count), 0) AS toks,
+              COALESCE(SUM(CASE WHEN call_type = 'batch' THEN token_count ELSE 0 END), 0) AS batch_toks
+         FROM distillations WHERE project_id = ? AND session_id = ?`,
+    )
+    .get(projectId, sessionId) as {
+    calls: number;
+    batch_calls: number;
+    toks: number;
+    batch_toks: number;
+  };
+
+  if (t.c === 0 && d.calls === 0) {
+    database
+      .query(
+        "DELETE FROM session_rollup WHERE project_id = ? AND session_id = ?",
+      )
+      .run(projectId, sessionId);
+    return;
+  }
+  database
+    .query(
+      `INSERT INTO session_rollup (
+         project_id, session_id, message_count, token_sum,
+         first_message_at, last_message_at,
+         first_assistant_rowid, first_assistant_at, first_assistant_metadata,
+         distill_calls, distill_batch_calls, distill_token_sum, distill_batch_token_sum, dirty
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)
+       ON CONFLICT(project_id, session_id) DO UPDATE SET
+         message_count = excluded.message_count,
+         token_sum = excluded.token_sum,
+         first_message_at = excluded.first_message_at,
+         last_message_at = excluded.last_message_at,
+         first_assistant_rowid = excluded.first_assistant_rowid,
+         first_assistant_at = excluded.first_assistant_at,
+         first_assistant_metadata = excluded.first_assistant_metadata,
+         distill_calls = excluded.distill_calls,
+         distill_batch_calls = excluded.distill_batch_calls,
+         distill_token_sum = excluded.distill_token_sum,
+         distill_batch_token_sum = excluded.distill_batch_token_sum,
+         dirty = 0`,
+    )
+    .run(
+      projectId,
+      sessionId,
+      t.c,
+      t.toks,
+      t.first_at,
+      t.last_at,
+      fa?.rid ?? null,
+      fa?.created_at ?? null,
+      fa?.metadata ?? null,
+      d.calls,
+      d.batch_calls,
+      d.toks,
+      d.batch_toks,
+    );
+}
+
+/** Recompute every session_rollup row currently flagged dirty. */
+export function rebuildDirtySessionRollups(database: Database = db()): void {
+  const dirty = database
+    .query("SELECT project_id, session_id FROM session_rollup WHERE dirty = 1")
+    .all() as Array<{ project_id: string; session_id: string }>;
+  for (const r of dirty)
+    recomputeSessionRollupRow(database, r.project_id, r.session_id);
+}
+
+/**
+ * Reconstruct the entire session_rollup table from the source tables. Used by the
+ * v59 backfill and by recovery. Idempotent (truncate + repopulate). Three grouped
+ * passes that benefit from the v57/v58 covering indexes (#981).
+ */
+export function rebuildAllSessionRollups(database: Database = db()): void {
+  database.exec("DELETE FROM session_rollup");
+  // Pass 1: per-session message_count / token_sum / first/last_message_at.
+  database.exec(`
+    INSERT INTO session_rollup (
+      project_id, session_id, message_count, token_sum, first_message_at, last_message_at
+    )
+    SELECT project_id, session_id, COUNT(*), COALESCE(SUM(tokens), 0),
+           MIN(created_at), MAX(created_at)
+      FROM temporal_messages
+     GROUP BY project_id, session_id;
+  `);
+  // Pass 2: earliest assistant row per session (tie-break created_at ASC, rowid ASC).
+  // Every session with an assistant message already has a row from pass 1, so the
+  // ON CONFLICT branch always applies.
+  database.exec(`
+    INSERT INTO session_rollup (
+      project_id, session_id, first_assistant_rowid, first_assistant_at, first_assistant_metadata
+    )
+    SELECT project_id, session_id, rid, created_at, metadata FROM (
+      SELECT project_id, session_id, rowid AS rid, created_at, metadata,
+             ROW_NUMBER() OVER (
+               PARTITION BY project_id, session_id ORDER BY created_at ASC, rowid ASC
+             ) AS rn
+        FROM temporal_messages WHERE role = 'assistant'
+    ) WHERE rn = 1
+    ON CONFLICT(project_id, session_id) DO UPDATE SET
+      first_assistant_rowid = excluded.first_assistant_rowid,
+      first_assistant_at = excluded.first_assistant_at,
+      first_assistant_metadata = excluded.first_assistant_metadata;
+  `);
+  // Pass 3: distillation counts/tokens per session (may create distill-only rows).
+  database.exec(`
+    INSERT INTO session_rollup (
+      project_id, session_id, distill_calls, distill_batch_calls,
+      distill_token_sum, distill_batch_token_sum
+    )
+    SELECT project_id, session_id, COUNT(*),
+           COALESCE(SUM(CASE WHEN call_type = 'batch' THEN 1 ELSE 0 END), 0),
+           COALESCE(SUM(token_count), 0),
+           COALESCE(SUM(CASE WHEN call_type = 'batch' THEN token_count ELSE 0 END), 0)
+      FROM distillations
+     GROUP BY project_id, session_id
+    ON CONFLICT(project_id, session_id) DO UPDATE SET
+      distill_calls = excluded.distill_calls,
+      distill_batch_calls = excluded.distill_batch_calls,
+      distill_token_sum = excluded.distill_token_sum,
+      distill_batch_token_sum = excluded.distill_batch_token_sum;
+  `);
+}
+
+/** v59 migration step: create the rollup objects then backfill from source. */
+function applySessionRollup(database: Database): void {
+  ensureSessionRollup(database);
+  rebuildAllSessionRollups(database);
 }
 
 /**
@@ -1814,6 +2180,10 @@ function migrate(database: Database) {
       // Destructive (DROP COLUMN) + non-idempotent-as-SQL: run the column-aware
       // JS step so a partial apply can't boot-loop on re-run (see the fn doc).
       applyKnowledgeMetaRegister(database);
+    } else if (i === SESSION_ROLLUP_MIGRATION_INDEX) {
+      // Create session_rollup + maintenance triggers, then backfill from source.
+      // Done in JS so the same idempotent routine self-heals from recovery (#981).
+      applySessionRollup(database);
     } else {
       try {
         database.exec(MIGRATIONS[i]);
@@ -2113,6 +2483,25 @@ function recoverMissingObjects(database: Database) {
     CREATE INDEX IF NOT EXISTS idx_temporal_project_session_created
       ON temporal_messages(project_id, session_id, created_at);
   `);
+  // Version 60: session_rollup table + maintenance triggers. Recreate them if a
+  // fully-migrated DB lost them (no-op when present). If the table came back empty
+  // while the source still has rows, the backfill was lost too — rebuild it once.
+  // (A genuinely empty DB skips the rebuild: no source rows ⇒ nothing to do.)
+  ensureSessionRollup(database);
+  {
+    const hasRollup = database
+      .query("SELECT 1 FROM session_rollup LIMIT 1")
+      .get() as unknown;
+    if (!hasRollup) {
+      const hasMessages = database
+        .query("SELECT 1 FROM temporal_messages LIMIT 1")
+        .get() as unknown;
+      const hasDistill = database
+        .query("SELECT 1 FROM distillations LIMIT 1")
+        .get() as unknown;
+      if (hasMessages || hasDistill) rebuildAllSessionRollups(database);
+    }
+  }
   // Version 36: session project binding. Recover each column independently in
   // case a partial ALTER (e.g. the first succeeded, the second was skipped on a
   // prior failure) left the table missing a column.
@@ -2213,6 +2602,13 @@ export function mergeProjectInternal(sourceId: string, targetId: string): void {
       targetId,
       sourceId,
     );
+    // Re-point the session rollup set-based: the temporal/distillation project_id
+    // UPDATEs above do NOT fire the rollup triggers (scoped to content/tokens/
+    // metadata + insert/delete), so move the rows here. session_id is globally
+    // unique ⇒ no (target, session_id) PK collision.
+    d.query(
+      "UPDATE session_rollup SET project_id = ? WHERE project_id = ?",
+    ).run(targetId, sourceId);
     d.query("UPDATE lat_sections SET project_id = ? WHERE project_id = ?").run(
       targetId,
       sourceId,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -131,6 +131,9 @@ export {
   getInstanceId,
   runUpsert,
   withTransaction,
+  ensureSessionRollup,
+  rebuildDirtySessionRollups,
+  rebuildAllSessionRollups,
   close,
 } from "./db";
 export {

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -59,7 +59,7 @@ describe("db", () => {
     const row = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(row.version).toBe(59);
+    expect(row.version).toBe(60);
   });
 
   test("v55: confidence/last_reinforced_at moved to knowledge_meta, exposed via view", () => {
@@ -116,7 +116,7 @@ describe("db", () => {
     const ver = fresh.query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(ver.version).toBe(59);
+    expect(ver.version).toBe(60);
     // Register + JOIN view were rebuilt and are queryable (confidence exposed).
     expect(
       fresh

--- a/packages/core/test/ltm-versioning.test.ts
+++ b/packages/core/test/ltm-versioning.test.ts
@@ -39,11 +39,11 @@ function ftsHits(token: string): number {
 }
 
 describe("A2 sub-PR 1: append-only knowledge scaffolding", () => {
-  test("schema version is 59", () => {
+  test("schema version is 60", () => {
     const v = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(v.version).toBe(59);
+    expect(v.version).toBe(60);
   });
 
   test("create() defaults logical_id = id, version 1, current, not deleted", () => {

--- a/packages/core/test/session-rollup.test.ts
+++ b/packages/core/test/session-rollup.test.ts
@@ -329,6 +329,48 @@ describe("session_rollup", () => {
       assertConsistent(pid);
     });
 
+    test("a single rebuild resolves many sessions dirtied at once", () => {
+      // Mirrors a bulk prune/clear: many sessions get an extreme deleted in one
+      // burst, so all are flagged dirty before any rebuild runs. The batched
+      // rebuild (one transaction) must resolve every one of them.
+      const pid = ensureProject("/test/session-rollup/batch-dirty");
+      const N = 12;
+      for (let i = 0; i < N; i++) {
+        const sid = `s${i}`;
+        // earliest assistant + a later message, then delete the earliest
+        // assistant → defers a recompute (dirty=1) without touching the others.
+        const a = insertMsg(pid, sid, "assistant", 10, 100 + i, `a-${i}`);
+        insertMsg(pid, sid, "assistant", 20, 1000 + i, `keep-${i}`);
+        deleteMsg(a);
+      }
+      const dirtyCount = (
+        db()
+          .query(
+            "SELECT COUNT(*) AS c FROM session_rollup WHERE project_id=? AND dirty=1",
+          )
+          .get(pid) as { c: number }
+      ).c;
+      expect(dirtyCount).toBe(N); // all dirty, none rebuilt yet
+
+      rebuildDirtySessionRollups(db());
+
+      // No dirty rows remain and every session matches a full recompute.
+      expect(
+        (
+          db()
+            .query(
+              "SELECT COUNT(*) AS c FROM session_rollup WHERE project_id=? AND dirty=1",
+            )
+            .get(pid) as { c: number }
+        ).c,
+      ).toBe(0);
+      const got = materializedRollups(pid);
+      const ref = referenceRollups(pid);
+      expect(got.size).toBe(N);
+      for (const [sid, row] of ref)
+        expect(got.get(sid), `rollup row for ${sid}`).toEqual(row);
+    });
+
     test("re-store changes token_sum by the delta only", () => {
       const pid = ensureProject("/test/session-rollup/restore");
       const sid = "s1";

--- a/packages/core/test/session-rollup.test.ts
+++ b/packages/core/test/session-rollup.test.ts
@@ -1,0 +1,537 @@
+import { describe, test, expect } from "vitest";
+import {
+  db,
+  ensureProject,
+  rebuildDirtySessionRollups,
+  rebuildAllSessionRollups,
+} from "../src/db";
+import * as data from "../src/data";
+
+// session_rollup (#981) is a materialized per-(project_id, session_id) cache of
+// the /ui/costs aggregates, maintained incrementally by triggers on
+// temporal_messages and distillations. The central correctness property: the
+// incrementally-maintained rollup MUST equal a full GROUP BY recompute from
+// source across ANY sequence of inserts / re-store edits / deletes — including
+// deletes of an extreme row (first/last message, earliest assistant), which the
+// triggers defer to a lazy dirty-rebuild.
+
+// ---- low-level source mutators (fire the triggers directly) -----------------
+
+let msgSeq = 0;
+let distSeq = 0;
+
+function insertMsg(
+  pid: string,
+  sid: string,
+  role: "user" | "assistant",
+  tokens: number,
+  createdAt: number,
+  metadata: string | null,
+): string {
+  const id = `srm-${++msgSeq}`;
+  db()
+    .query(
+      `INSERT INTO temporal_messages
+         (id, project_id, session_id, role, content, tokens, distilled, created_at, metadata)
+       VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?)`,
+    )
+    .run(id, pid, sid, role, `content-${id}`, tokens, createdAt, metadata);
+  return id;
+}
+
+function editMsg(id: string, tokens: number, metadata: string | null): void {
+  // Mirrors temporal.store()'s re-store UPDATE (SET content, tokens, metadata).
+  db()
+    .query(
+      "UPDATE temporal_messages SET content = ?, tokens = ?, metadata = ? WHERE id = ?",
+    )
+    .run(`edited-${id}`, tokens, metadata, id);
+}
+
+function deleteMsg(id: string): void {
+  db().query("DELETE FROM temporal_messages WHERE id = ?").run(id);
+}
+
+function insertDistill(
+  pid: string,
+  sid: string,
+  tokenCount: number,
+  callType: "batch" | "direct",
+  createdAt: number,
+): string {
+  const id = `srd-${++distSeq}`;
+  db()
+    .query(
+      `INSERT INTO distillations
+         (id, project_id, session_id, narrative, facts, observations, source_ids,
+          generation, token_count, call_type, created_at, archived)
+       VALUES (?, ?, ?, '', '', 'obs', '[]', 0, ?, ?, ?, 0)`,
+    )
+    .run(id, pid, sid, tokenCount, callType, createdAt);
+  return id;
+}
+
+function deleteDistill(id: string): void {
+  db().query("DELETE FROM distillations WHERE id = ?").run(id);
+}
+
+// ---- canonical per-session row (the thing both sides must agree on) ---------
+
+type RollupRow = {
+  message_count: number;
+  token_sum: number;
+  first_message_at: number | null;
+  last_message_at: number | null;
+  first_assistant_metadata: string | null;
+  distill_calls: number;
+  distill_batch_calls: number;
+  distill_token_sum: number;
+  distill_batch_token_sum: number;
+};
+
+/** Full GROUP BY recompute from source for one project — the reference oracle. */
+function referenceRollups(pid: string): Map<string, RollupRow> {
+  const out = new Map<string, RollupRow>();
+  const get = (sid: string): RollupRow => {
+    let r = out.get(sid);
+    if (!r) {
+      r = {
+        message_count: 0,
+        token_sum: 0,
+        first_message_at: null,
+        last_message_at: null,
+        first_assistant_metadata: null,
+        distill_calls: 0,
+        distill_batch_calls: 0,
+        distill_token_sum: 0,
+        distill_batch_token_sum: 0,
+      };
+      out.set(sid, r);
+    }
+    return r;
+  };
+
+  for (const m of db()
+    .query(
+      `SELECT session_id, COUNT(*) AS c, COALESCE(SUM(tokens),0) AS toks,
+              MIN(created_at) AS first_at, MAX(created_at) AS last_at
+         FROM temporal_messages WHERE project_id = ? GROUP BY session_id`,
+    )
+    .all(pid) as Array<{
+    session_id: string;
+    c: number;
+    toks: number;
+    first_at: number;
+    last_at: number;
+  }>) {
+    const r = get(m.session_id);
+    r.message_count = m.c;
+    r.token_sum = m.toks;
+    r.first_message_at = m.first_at;
+    r.last_message_at = m.last_at;
+  }
+
+  // Earliest assistant: tie-break (created_at ASC, rowid ASC) — must match the
+  // trigger / recompute / full-rebuild tie-break exactly.
+  for (const fa of db()
+    .query(
+      `SELECT session_id, metadata FROM (
+         SELECT session_id, metadata,
+                ROW_NUMBER() OVER (
+                  PARTITION BY session_id ORDER BY created_at ASC, rowid ASC
+                ) AS rn
+           FROM temporal_messages WHERE project_id = ? AND role = 'assistant'
+       ) WHERE rn = 1`,
+    )
+    .all(pid) as Array<{ session_id: string; metadata: string | null }>) {
+    get(fa.session_id).first_assistant_metadata = fa.metadata;
+  }
+
+  for (const d of db()
+    .query(
+      `SELECT session_id, COUNT(*) AS calls,
+              COALESCE(SUM(CASE WHEN call_type='batch' THEN 1 ELSE 0 END),0) AS bc,
+              COALESCE(SUM(token_count),0) AS tt,
+              COALESCE(SUM(CASE WHEN call_type='batch' THEN token_count ELSE 0 END),0) AS bt
+         FROM distillations WHERE project_id = ? GROUP BY session_id`,
+    )
+    .all(pid) as Array<{
+    session_id: string;
+    calls: number;
+    bc: number;
+    tt: number;
+    bt: number;
+  }>) {
+    const r = get(d.session_id);
+    r.distill_calls = d.calls;
+    r.distill_batch_calls = d.bc;
+    r.distill_token_sum = d.tt;
+    r.distill_batch_token_sum = d.bt;
+  }
+
+  return out;
+}
+
+/** Read the materialized rollup rows for one project. */
+function materializedRollups(pid: string): Map<string, RollupRow> {
+  const out = new Map<string, RollupRow>();
+  for (const r of db()
+    .query(
+      `SELECT session_id, message_count, token_sum, first_message_at, last_message_at,
+              first_assistant_metadata, distill_calls, distill_batch_calls,
+              distill_token_sum, distill_batch_token_sum
+         FROM session_rollup WHERE project_id = ?`,
+    )
+    .all(pid) as Array<RollupRow & { session_id: string }>) {
+    const { session_id, ...rest } = r;
+    out.set(session_id, rest);
+  }
+  return out;
+}
+
+/** Assert the materialized table equals the recompute, after resolving dirty. */
+function assertConsistent(pid: string): void {
+  rebuildDirtySessionRollups(db());
+  const ref = referenceRollups(pid);
+  const got = materializedRollups(pid);
+  const keys = new Set([...ref.keys(), ...got.keys()]);
+  for (const sid of keys) {
+    expect(got.get(sid), `rollup row for ${sid}`).toEqual(ref.get(sid));
+  }
+}
+
+// ---- deterministic RNG ------------------------------------------------------
+
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+describe("session_rollup", () => {
+  describe("property: incremental == full recompute", () => {
+    for (const seed of [1, 7, 42, 1337, 90210]) {
+      test(`random op sequence (seed ${seed})`, () => {
+        const pid = ensureProject(`/test/session-rollup/prop-${seed}`);
+        const rand = mulberry32(seed);
+        const pick = <T>(arr: T[]): T => arr[Math.floor(rand() * arr.length)];
+        const sids = ["s-a", "s-b", "s-c"];
+        // A small created_at range FORCES ties so the tie-break is exercised.
+        const baseTime = 1_700_000_000_000;
+        const liveMsgs: string[] = [];
+        const liveDistills: string[] = [];
+
+        for (let step = 0; step < 120; step++) {
+          const op = rand();
+          if (op < 0.42) {
+            const role = rand() < 0.5 ? "assistant" : "user";
+            liveMsgs.push(
+              insertMsg(
+                pid,
+                pick(sids),
+                role,
+                Math.floor(rand() * 500),
+                baseTime + Math.floor(rand() * 6) * 1000,
+                `meta-${msgSeq + 1}-${role}`,
+              ),
+            );
+          } else if (op < 0.6 && liveMsgs.length) {
+            editMsg(
+              pick(liveMsgs),
+              Math.floor(rand() * 500),
+              `edited-meta-${Math.floor(rand() * 1000)}`,
+            );
+          } else if (op < 0.78 && liveMsgs.length) {
+            const idx = Math.floor(rand() * liveMsgs.length);
+            deleteMsg(liveMsgs[idx]);
+            liveMsgs.splice(idx, 1);
+          } else if (op < 0.92) {
+            liveDistills.push(
+              insertDistill(
+                pid,
+                pick(sids),
+                Math.floor(rand() * 2000),
+                rand() < 0.5 ? "batch" : "direct",
+                baseTime + Math.floor(rand() * 6) * 1000,
+              ),
+            );
+          } else if (liveDistills.length) {
+            const idx = Math.floor(rand() * liveDistills.length);
+            deleteDistill(liveDistills[idx]);
+            liveDistills.splice(idx, 1);
+          }
+
+          // Check consistency periodically (and at the end).
+          if (step % 17 === 0) assertConsistent(pid);
+        }
+        assertConsistent(pid);
+      });
+    }
+  });
+
+  describe("targeted edge cases", () => {
+    test("delete earliest assistant marks dirty and rebuild restores metadata", () => {
+      const pid = ensureProject("/test/session-rollup/earliest-assistant");
+      const sid = "s1";
+      insertMsg(pid, sid, "user", 10, 1000, "u0");
+      const a1 = insertMsg(pid, sid, "assistant", 20, 1100, "first-assistant");
+      insertMsg(pid, sid, "assistant", 30, 1200, "second-assistant");
+
+      let row = db()
+        .query(
+          "SELECT first_assistant_metadata, dirty FROM session_rollup WHERE project_id=? AND session_id=?",
+        )
+        .get(pid, sid) as { first_assistant_metadata: string; dirty: number };
+      expect(row.first_assistant_metadata).toBe("first-assistant");
+      expect(row.dirty).toBe(0);
+
+      deleteMsg(a1);
+      row = db()
+        .query(
+          "SELECT first_assistant_metadata, dirty FROM session_rollup WHERE project_id=? AND session_id=?",
+        )
+        .get(pid, sid) as { first_assistant_metadata: string; dirty: number };
+      expect(row.dirty).toBe(1); // deferred recompute
+
+      rebuildDirtySessionRollups(db());
+      row = db()
+        .query(
+          "SELECT first_assistant_metadata, dirty FROM session_rollup WHERE project_id=? AND session_id=?",
+        )
+        .get(pid, sid) as { first_assistant_metadata: string; dirty: number };
+      expect(row.first_assistant_metadata).toBe("second-assistant");
+      expect(row.dirty).toBe(0);
+      assertConsistent(pid);
+    });
+
+    test("delete MIN/MAX message recomputes first/last_message_at", () => {
+      const pid = ensureProject("/test/session-rollup/minmax");
+      const sid = "s1";
+      const lo = insertMsg(pid, sid, "user", 5, 100, null);
+      insertMsg(pid, sid, "user", 5, 200, null);
+      const hi = insertMsg(pid, sid, "user", 5, 300, null);
+
+      deleteMsg(lo);
+      deleteMsg(hi);
+      rebuildDirtySessionRollups(db());
+      const row = db()
+        .query(
+          "SELECT first_message_at, last_message_at FROM session_rollup WHERE project_id=? AND session_id=?",
+        )
+        .get(pid, sid) as { first_message_at: number; last_message_at: number };
+      expect(row.first_message_at).toBe(200);
+      expect(row.last_message_at).toBe(200);
+      assertConsistent(pid);
+    });
+
+    test("re-store changes token_sum by the delta only", () => {
+      const pid = ensureProject("/test/session-rollup/restore");
+      const sid = "s1";
+      const m = insertMsg(pid, sid, "user", 100, 100, "m0");
+      insertMsg(pid, sid, "user", 50, 200, "m1");
+      const before = db()
+        .query(
+          "SELECT token_sum FROM session_rollup WHERE project_id=? AND session_id=?",
+        )
+        .get(pid, sid) as { token_sum: number };
+      expect(before.token_sum).toBe(150);
+      editMsg(m, 400, "m0-edited");
+      const after = db()
+        .query(
+          "SELECT token_sum FROM session_rollup WHERE project_id=? AND session_id=?",
+        )
+        .get(pid, sid) as { token_sum: number };
+      expect(after.token_sum).toBe(450); // 150 - 100 + 400
+      assertConsistent(pid);
+    });
+
+    test("re-store of the earliest-assistant row refreshes its metadata", () => {
+      const pid = ensureProject("/test/session-rollup/restore-assistant");
+      const sid = "s1";
+      const a = insertMsg(pid, sid, "assistant", 10, 100, "orig");
+      insertMsg(pid, sid, "assistant", 10, 200, "later");
+      editMsg(a, 10, "updated");
+      const row = db()
+        .query(
+          "SELECT first_assistant_metadata FROM session_rollup WHERE project_id=? AND session_id=?",
+        )
+        .get(pid, sid) as { first_assistant_metadata: string };
+      expect(row.first_assistant_metadata).toBe("updated");
+      assertConsistent(pid);
+    });
+
+    test("tie at equal created_at picks the smaller rowid (insertion order)", () => {
+      const pid = ensureProject("/test/session-rollup/tie");
+      const sid = "s1";
+      insertMsg(pid, sid, "assistant", 10, 500, "earlier-rowid");
+      insertMsg(pid, sid, "assistant", 10, 500, "later-rowid");
+      const row = db()
+        .query(
+          "SELECT first_assistant_metadata FROM session_rollup WHERE project_id=? AND session_id=?",
+        )
+        .get(pid, sid) as { first_assistant_metadata: string };
+      expect(row.first_assistant_metadata).toBe("earlier-rowid");
+      assertConsistent(pid);
+    });
+
+    test("removing all rows deletes the rollup row", () => {
+      const pid = ensureProject("/test/session-rollup/empty");
+      const sid = "s1";
+      const m1 = insertMsg(pid, sid, "user", 10, 100, null);
+      const m2 = insertMsg(pid, sid, "assistant", 10, 200, "a");
+      const d1 = insertDistill(pid, sid, 100, "batch", 150);
+      deleteMsg(m1);
+      deleteMsg(m2);
+      // Distillation still present → row kept.
+      expect(
+        db()
+          .query(
+            "SELECT 1 FROM session_rollup WHERE project_id=? AND session_id=?",
+          )
+          .get(pid, sid),
+      ).toBeTruthy();
+      deleteDistill(d1);
+      // Now nothing left → row removed.
+      expect(
+        db()
+          .query(
+            "SELECT 1 FROM session_rollup WHERE project_id=? AND session_id=?",
+          )
+          .get(pid, sid),
+      ).toBeFalsy();
+      assertConsistent(pid);
+    });
+
+    test("distill-only session is excluded from listSessionRollups", () => {
+      const pid = ensureProject("/test/session-rollup/distill-only");
+      ensureProject("/test/session-rollup/distill-only"); // idempotent
+      const withMsg = "s-msg";
+      const distillOnly = "s-distill-only";
+      insertMsg(pid, withMsg, "assistant", 10, 1_700_000_500_000, "m");
+      insertDistill(pid, distillOnly, 100, "batch", 1_700_000_500_000);
+
+      // The distill-only row exists in the table…
+      expect(
+        db()
+          .query(
+            "SELECT 1 FROM session_rollup WHERE project_id=? AND session_id=?",
+          )
+          .get(pid, distillOnly),
+      ).toBeTruthy();
+      // …but listSessionRollups (message_count>0 filter) skips it.
+      const listed = data
+        .listSessionRollups({ sinceMs: 0 })
+        .filter((r) => r.project_id === pid)
+        .map((r) => r.session_id);
+      expect(listed).toContain(withMsg);
+      expect(listed).not.toContain(distillOnly);
+      assertConsistent(pid);
+    });
+  });
+
+  describe("UPDATE trigger is scoped to content/tokens/metadata", () => {
+    test("a `distilled` flag flip does not change token_sum", () => {
+      const pid = ensureProject("/test/session-rollup/update-scope");
+      const sid = "s1";
+      const m = insertMsg(pid, sid, "user", 100, 100, null);
+      db()
+        .query("UPDATE temporal_messages SET distilled = 1 WHERE id = ?")
+        .run(m);
+      const row = db()
+        .query(
+          "SELECT token_sum, message_count FROM session_rollup WHERE project_id=? AND session_id=?",
+        )
+        .get(pid, sid) as { token_sum: number; message_count: number };
+      expect(row.token_sum).toBe(100);
+      expect(row.message_count).toBe(1);
+      assertConsistent(pid);
+    });
+  });
+
+  describe("rebuild path reconstructs from source", () => {
+    test("rebuildAllSessionRollups repairs a corrupted table", () => {
+      const pid = ensureProject("/test/session-rollup/rebuild");
+      insertMsg(pid, "s1", "assistant", 10, 100, "a1");
+      insertMsg(pid, "s1", "user", 20, 200, null);
+      insertMsg(pid, "s2", "assistant", 30, 300, "a2");
+      insertDistill(pid, "s1", 500, "batch", 150);
+
+      // Corrupt every numeric aggregate.
+      db()
+        .query(
+          "UPDATE session_rollup SET token_sum = 999999, message_count = 0, distill_calls = 77 WHERE project_id = ?",
+        )
+        .run(pid);
+
+      rebuildAllSessionRollups(db());
+      assertConsistent(pid);
+    });
+  });
+
+  describe("project moves re-point rollup rows", () => {
+    test("moveSessions carries the rollup to the target project", () => {
+      const from = ensureProject("/test/session-rollup/move-from");
+      const toPath = "/test/session-rollup/move-to";
+      const to = ensureProject(toPath);
+      const sid = "move-s1";
+      insertMsg(from, sid, "assistant", 40, 100, "model-meta");
+      insertMsg(from, sid, "user", 60, 200, null);
+      insertDistill(from, sid, 300, "direct", 150);
+
+      data.moveSessions([sid], from, toPath, { includeChildren: false });
+
+      // Source no longer holds the rollup row; target does, with totals intact.
+      expect(
+        db()
+          .query(
+            "SELECT 1 FROM session_rollup WHERE project_id=? AND session_id=?",
+          )
+          .get(from, sid),
+      ).toBeFalsy();
+      const moved = db()
+        .query(
+          "SELECT message_count, token_sum, distill_calls FROM session_rollup WHERE project_id=? AND session_id=?",
+        )
+        .get(to, sid) as {
+        message_count: number;
+        token_sum: number;
+        distill_calls: number;
+      };
+      expect(moved).toEqual({
+        message_count: 2,
+        token_sum: 100,
+        distill_calls: 1,
+      });
+      assertConsistent(from);
+      assertConsistent(to);
+    });
+  });
+
+  describe("read cost is independent of temporal_messages size", () => {
+    test("listSessionRollups query plan does not scan temporal_messages", () => {
+      const plan = (
+        db()
+          .query(
+            `EXPLAIN QUERY PLAN
+             SELECT sr.project_id, p.path, sr.session_id, sr.message_count,
+                    sr.first_message_at, sr.last_message_at, sr.token_sum
+               FROM session_rollup sr
+               JOIN projects p ON p.id = sr.project_id
+              WHERE sr.message_count > 0 AND sr.last_message_at >= ?
+              ORDER BY sr.last_message_at DESC
+              LIMIT ?`,
+          )
+          .all(0, 100) as Array<{ detail: string }>
+      )
+        .map((r) => r.detail)
+        .join(" | ");
+      expect(plan).toContain("session_rollup");
+      expect(plan).not.toMatch(/temporal_messages/);
+    });
+  });
+});

--- a/packages/core/test/session-rollup.test.ts
+++ b/packages/core/test/session-rollup.test.ts
@@ -371,6 +371,42 @@ describe("session_rollup", () => {
         expect(got.get(sid), `rollup row for ${sid}`).toEqual(row);
     });
 
+    test("dirty rebuild is safe inside an existing transaction", () => {
+      // The rebuild uses a SAVEPOINT (not BEGIN), so a future caller that
+      // invokes it from within an open transaction must not crash with
+      // "cannot start a transaction within a transaction".
+      const pid = ensureProject("/test/session-rollup/nested-dirty");
+      const sid = "s1";
+      const a = insertMsg(pid, sid, "assistant", 10, 100, "first");
+      insertMsg(pid, sid, "assistant", 20, 200, "second");
+      deleteMsg(a); // earliest assistant deleted → session is dirty
+
+      db().exec("BEGIN");
+      expect(() => rebuildDirtySessionRollups(db())).not.toThrow();
+      db().exec("COMMIT");
+
+      const row = db()
+        .query(
+          "SELECT first_assistant_metadata, dirty FROM session_rollup WHERE project_id=? AND session_id=?",
+        )
+        .get(pid, sid) as { first_assistant_metadata: string; dirty: number };
+      expect(row.first_assistant_metadata).toBe("second");
+      expect(row.dirty).toBe(0);
+    });
+
+    test("full rebuild is safe (and atomic) inside an existing transaction", () => {
+      const pid = ensureProject("/test/session-rollup/nested-all");
+      const sid = "s1";
+      insertMsg(pid, sid, "assistant", 10, 100, "a");
+      insertDistill(pid, sid, 100, "batch", 150);
+
+      db().exec("BEGIN");
+      expect(() => rebuildAllSessionRollups(db())).not.toThrow();
+      db().exec("COMMIT");
+
+      assertConsistent(pid);
+    });
+
     test("re-store changes token_sum by the delta only", () => {
       const pid = ensureProject("/test/session-rollup/restore");
       const sid = "s1";

--- a/packages/gateway/src/cost-tracker.ts
+++ b/packages/gateway/src/cost-tracker.ts
@@ -15,7 +15,6 @@ import { AUTOCOMPACT_THRESHOLD } from "./compaction";
 import {
   log,
   data,
-  temporal,
   loadAllSessionCosts,
   getKV,
   setKV,
@@ -1088,14 +1087,11 @@ export function computeHistoricalEstimates(
       projectById.set(p.id, p);
     }
 
-    // Bulk queries: 4 total instead of 3P+2 (one per table across all projects).
-    const allSessions = data.listAllRecentSessions({
-      sinceMs: scanCutoffMs,
-    });
-    const tokenAggs = temporal.aggregateTokensBySessionAll({
-      sinceMs: scanCutoffMs,
-    });
-    const distillAggs = data.aggregateDistillationsBySessionAll({
+    // Single bulk read from the materialized session_rollup table (#981):
+    // O(sessions), independent of total temporal_messages count. Replaces the
+    // three O(N-messages) bulk aggregates (recent sessions + token sums +
+    // distillation counts) with one row-per-session lookup.
+    const allSessions = data.listSessionRollups({
       sinceMs: scanCutoffMs,
     });
 
@@ -1109,26 +1105,23 @@ export function computeHistoricalEstimates(
       totals.sessionCount++;
       totals.messageCount += sess.message_count;
 
-      const tokenAgg = tokenAggs.get(sess.session_id);
-      const distillAgg = distillAggs.get(sess.session_id);
-
       // --- Determine model for this session ---
       // Use the earliest assistant message's metadata (user messages have
       // "unknown"). Falls back to the default estimation model.
       let model = DEFAULT_ESTIMATION_MODEL;
-      const m = extractModelFromMetadata(tokenAgg?.first_assistant_metadata);
+      const m = extractModelFromMetadata(sess.first_assistant_metadata);
       if (m) model = m;
 
       // --- 1. Estimate distillation overhead ---
       // Use worker model pricing — distillations run on the worker, not
-      // conversation model. The grouped aggregate gives total token_count
-      // split by call_type, so the batch discount (50%) is applied to the
-      // actual batch token sum — equivalent to the old per-row loop.
-      const totalDistillCalls = distillAgg?.total_calls ?? 0;
-      const sessionBatchCalls = distillAgg?.batch_calls ?? 0;
+      // conversation model. The rollup gives total token_count split by
+      // call_type, so the batch discount (50%) is applied to the actual batch
+      // token sum — equivalent to the old per-row loop.
+      const totalDistillCalls = sess.distill_total_calls;
+      const sessionBatchCalls = sess.distill_batch_calls;
       const sessionDirectCalls = totalDistillCalls - sessionBatchCalls;
-      const batchTokens = distillAgg?.batch_tokens ?? 0;
-      const directTokens = (distillAgg?.total_tokens ?? 0) - batchTokens;
+      const batchTokens = sess.distill_batch_tokens;
+      const directTokens = sess.distill_total_tokens - batchTokens;
       const perTokenCost = (estOut: number, mult: number) =>
         ((estOut * 3) / 1_000_000) * workerPricing.input * mult +
         (estOut / 1_000_000) * workerPricing.output * mult;
@@ -1147,7 +1140,7 @@ export function computeHistoricalEstimates(
       // are discarded in the per-message sim but counted by the division).
       // This is only a fallback — sessions with persisted snapshots (the common
       // case) use real data from live tracking.
-      const sessionTokens = tokenAgg?.total_tokens ?? 0;
+      const sessionTokens = sess.total_tokens;
       let avoidedCompactions = 0;
       if (sessionTokens > AUTOCOMPACT_THRESHOLD) {
         // First compaction at AUTOCOMPACT_THRESHOLD, then every

--- a/packages/gateway/test/cost-tracker-historical.test.ts
+++ b/packages/gateway/test/cost-tracker-historical.test.ts
@@ -1,0 +1,162 @@
+import { describe, test, expect, beforeEach } from "vitest";
+import { db, ensureProject } from "@loreai/core";
+import {
+  computeHistoricalEstimates,
+  invalidateHistoricalCache,
+} from "../src/cost-tracker";
+
+// computeHistoricalEstimates() is the single production consumer of the
+// materialized session_rollup table (#981). It reads one row per
+// (project_id, session_id) and derives the /ui/costs "intelligence" estimate:
+// session/message counts, the model (from the earliest assistant message's
+// metadata), and distillation overhead split by call_type. These tests pin the
+// field mapping from a SessionRollupSummary row onto the HistoricalEstimates
+// output — the rollup rewiring is otherwise only validated by typecheck.
+
+let seq = 0;
+
+function insertMsg(
+  pid: string,
+  sid: string,
+  role: "user" | "assistant",
+  tokens: number,
+  createdAt: number,
+  metadata: string | null,
+): void {
+  db()
+    .query(
+      `INSERT INTO temporal_messages
+         (id, project_id, session_id, role, content, tokens, distilled, created_at, metadata)
+       VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?)`,
+    )
+    .run(
+      `hm-${++seq}`,
+      pid,
+      sid,
+      role,
+      `c-${seq}`,
+      tokens,
+      createdAt,
+      metadata,
+    );
+}
+
+function insertDistill(
+  pid: string,
+  sid: string,
+  tokenCount: number,
+  callType: "batch" | "direct",
+  createdAt: number,
+): void {
+  db()
+    .query(
+      `INSERT INTO distillations
+         (id, project_id, session_id, narrative, facts, observations, source_ids,
+          generation, token_count, call_type, created_at, archived)
+       VALUES (?, ?, ?, '', '', 'obs', '[]', 0, ?, ?, ?, 0)`,
+    )
+    .run(`hd-${++seq}`, pid, sid, tokenCount, callType, createdAt);
+}
+
+describe("computeHistoricalEstimates (session_rollup read path #981)", () => {
+  beforeEach(() => {
+    // The core test harness creates ONE DB per file (not per test), so rows
+    // accumulate across tests; computeHistoricalEstimates aggregates EVERY
+    // session in the DB. Wipe the source + rollup tables so each test's totals
+    // are deterministic. Deleting the source rows fires the rollup DELETE
+    // triggers; the explicit session_rollup wipe is belt-and-suspenders.
+    db().exec(
+      "DELETE FROM temporal_messages; DELETE FROM distillations; DELETE FROM session_rollup;",
+    );
+    // The estimate is memoized for 5 min in module state — clear it or a later
+    // test would read the previous test's result.
+    invalidateHistoricalCache();
+  });
+
+  test("aggregates one session from the rollup: counts, model, distill split", () => {
+    const pid = ensureProject("/test/cost-historical/a", "hist-a");
+    const sid = "hist-sess-a";
+    const now = Date.now();
+    const model = "claude-opus-4-20250514";
+
+    // 3 messages; the earliest assistant carries the model metadata.
+    insertMsg(pid, sid, "user", 100, now, null);
+    insertMsg(
+      pid,
+      sid,
+      "assistant",
+      200,
+      now + 1,
+      JSON.stringify({ modelID: model, providerID: "anthropic" }),
+    );
+    insertMsg(pid, sid, "user", 150, now + 2, null);
+
+    // 1 batch + 1 direct distillation.
+    insertDistill(pid, sid, 5000, "batch", now + 3);
+    insertDistill(pid, sid, 3000, "direct", now + 4);
+
+    const est = computeHistoricalEstimates();
+
+    expect(est.totals.sessionCount).toBe(1);
+    expect(est.totals.messageCount).toBe(3);
+    expect(est.totals.distillationCalls).toBe(2);
+    expect(est.totals.distillationBatchCalls).toBe(1);
+    expect(est.totals.distillationDirectCalls).toBe(1);
+    expect(est.totals.distillationCost).toBeGreaterThan(0);
+
+    expect(est.sessions).toHaveLength(1);
+    const s = est.sessions[0];
+    expect(s.sessionId).toBe(sid);
+    expect(s.projectId).toBe(pid);
+    expect(s.messageCount).toBe(3);
+    expect(s.model).toBe(model);
+    expect(s.distillationBatchCalls).toBe(1);
+    expect(s.distillationDirectCalls).toBe(1);
+  });
+
+  test("distill cost honors the batch discount (more batch tokens ⇒ cheaper)", () => {
+    const pid = ensureProject("/test/cost-historical/b", "hist-b");
+    const now = Date.now();
+
+    // Same total distill tokens (8000) in two sessions, but one is all-batch
+    // (50% priced) and the other all-direct. Each session needs ≥1 message to
+    // appear in the rollup read (message_count > 0 filter).
+    insertMsg(pid, "sess-batch", "assistant", 10, now, null);
+    insertDistill(pid, "sess-batch", 8000, "batch", now + 1);
+
+    insertMsg(pid, "sess-direct", "assistant", 10, now, null);
+    insertDistill(pid, "sess-direct", 8000, "direct", now + 1);
+
+    const est = computeHistoricalEstimates();
+    expect(est.totals.sessionCount).toBe(2);
+
+    const batch = est.sessions.find((s) => s.sessionId === "sess-batch");
+    const direct = est.sessions.find((s) => s.sessionId === "sess-direct");
+    expect(batch).toBeDefined();
+    expect(direct).toBeDefined();
+    if (!batch || !direct) throw new Error("seeded sessions missing");
+    // Batch tokens are priced at 0.5×, so the all-batch session is strictly
+    // cheaper than the all-direct one with identical token volume.
+    expect(batch.distillationCost).toBeGreaterThan(0);
+    expect(batch.distillationCost).toBeCloseTo(direct.distillationCost * 0.5);
+  });
+
+  test("excludes distill-only sessions and respects the 90-day scan window", () => {
+    const pid = ensureProject("/test/cost-historical/c", "hist-c");
+    const now = Date.now();
+
+    // (1) Distill-only session: no messages ⇒ message_count = 0 ⇒ excluded.
+    insertDistill(pid, "sess-distill-only", 1000, "direct", now);
+
+    // (2) Stale session older than HISTORICAL_SCAN_DAYS (90d) ⇒ excluded.
+    const old = now - 91 * 86_400_000;
+    insertMsg(pid, "sess-old", "assistant", 50, old, null);
+
+    // (3) In-window session with messages ⇒ included.
+    insertMsg(pid, "sess-live", "assistant", 50, now, null);
+
+    const est = computeHistoricalEstimates();
+    expect(est.totals.sessionCount).toBe(1);
+    expect(est.sessions[0].sessionId).toBe("sess-live");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #981. Adds a materialized **`session_rollup`** table (migration **v60**) so the `/ui/costs` page reads one row per `(project_id, session_id)` instead of running three `O(N temporal_messages)` bulk aggregates. The costs page now scans ~hundreds of session rows rather than ~200K message rows → **O(sessions), not O(messages)**.

This is the next tier after #980 (v58 covering indexes): those made the three aggregates index-only, but they still degrade as `temporal_messages` outgrows the page cache.

## What changed

- **`session_rollup` (v60)** — one row per session holding all costs-page inputs: `message_count`, `token_sum`, `first/last_message_at`, earliest-assistant identity + metadata, and distillation `call_type` counts/tokens.
- **Maintained incrementally by SQLite triggers** on `temporal_messages` (INSERT / `UPDATE OF content,tokens,metadata` / DELETE) and `distillations` (INSERT / DELETE). Triggers are atomic, in-transaction, and cannot be bypassed by any of the 6+ delete paths or the re-store UPDATE.
- **O(1) write path:** `token_sum` / `message_count` / `distill_*` are exact deltas on every write. Only the MIN/MAX/first-assistant *extremes* on a delete-of-an-extreme defer to a `dirty` flag + lazy per-session recompute — so even bulk prune/clear stays O(1) per source row.
- **`UPDATE OF content, tokens, metadata`** scoping is load-bearing: it fires for the `store()` re-store only; `distilled` / `embedding` / `project_id` updates never fire it. The two `project_id` moves (`mergeProjectInternal`, `moveSessions`) re-point rollup rows set-based instead (also required for FK-safety on source-project deletion).
- **Recovery / backfill:** `rebuildAllSessionRollups()` reconstructs the table from source (v60 backfill + `recoverMissingObjects` self-heal when the table comes back empty while source has rows). `rebuildDirtySessionRollups()` resolves deferred rows at read time **in a single batched transaction**, with a no-op fast path when nothing is dirty — so a bulk-prune-then-load resolves all newly-dirty sessions in one transaction rather than fanning out into N auto-commits on the read path.
- **`cost-tracker.ts`** rewired from 3 aggregates to a single `data.listSessionRollups({ sinceMs })`.

## Semantic note (intentional)

Rollup totals are **whole-session** sums filtered by `last_message_at >= sinceMs`, vs the old per-message `created_at >= sinceMs` window. With a 90-day window and short-lived coding sessions a session is effectively always entirely in or out of the window, so results are equivalent — and the whole-session total no longer splits a boundary-straddling session.

## Tests

`packages/core/test/session-rollup.test.ts` (19 tests):
- **Property test** (5 seeds): incremental trigger result == full `GROUP BY` recompute across randomized insert / re-store / delete / distill / prune / deleteSession sequences, asserting **every** field.
- Targeted edges: delete earliest-assistant → dirty → rebuild restores metadata; delete MIN/MAX; out-of-order inserts; re-store token delta; equal-`created_at` tie → min-rowid; count→0 removes row; distill-only session excluded; message+distill share one row.
- **Batched dirty rebuild:** many sessions dirtied in one burst (bulk-prune shape) all resolve in a single `rebuildDirtySessionRollups` call and match a full recompute (guards the batched-transaction path).
- **Nest-safety:** both `rebuildDirtySessionRollups` and `rebuildAllSessionRollups` use a `SAVEPOINT` (not `BEGIN`), so each is safe and atomic whether called at top level or from inside an existing transaction; tests call each from within an open transaction (both fail under `BEGIN IMMEDIATE`).
- Rebuild-from-corruption, project-move (moveSessions / mergeProject), and an EXPLAIN-QUERY-PLAN independence pin (read uses `session_rollup` + `idx_session_rollup_last`, never scans `temporal_messages`).

The property test caught a real bug during development (`MIN(NULL, created_at)` propagating NULL when a distillation seeds a rollup row before any message; fixed with COALESCE). Vacuity/mutation checked: each guarding test fails when its trigger/logic is reverted (incl. the batched-rebuild test, which fails when the transaction is rolled back instead of committed).

## Validation

- Full suite green (core + gateway); typecheck clean (4 pkgs); lint exit 0.
- Rebased onto current `main`; the migration collided with #988's v59 (`knowledge_symbol_presence`) and was renumbered to **v60** (`SESSION_ROLLUP_MIGRATION_INDEX = 59`, `schema_version` normalized to `MIGRATIONS.length`).
