### PR TITLE
fix(ltm): purge per-entry validation bookkeeping on knowledge delete (#990)

### DIFF
--- a/packages/core/src/data.ts
+++ b/packages/core/src/data.ts
@@ -562,6 +562,15 @@ export function clearProject(projectPath: string): ClearResult {
         "DELETE FROM knowledge_transfers WHERE recalled_in_project_id = ? OR knowledge_id IN (SELECT logical_id FROM knowledge WHERE project_id = ?)",
       )
       .run(pid, pid);
+    // Per-entry validation bookkeeping keyed on logical_id (no FK CASCADE) —
+    // delete BEFORE knowledge so the subquery still sees the rows (#990).
+    for (const table of ltm.LOGICAL_ID_BOOKKEEPING_TABLES) {
+      database
+        .query(
+          `DELETE FROM ${table} WHERE logical_id IN (SELECT logical_id FROM knowledge WHERE project_id = ?)`,
+        )
+        .run(pid);
+    }
     database.query("DELETE FROM knowledge WHERE project_id = ?").run(pid);
     database
       .query("DELETE FROM temporal_messages WHERE project_id = ?")
@@ -676,6 +685,15 @@ export function deleteProject(projectId: string): ClearResult | null {
         "DELETE FROM knowledge_transfers WHERE recalled_in_project_id = ? OR knowledge_id IN (SELECT logical_id FROM knowledge WHERE project_id = ?)",
       )
       .run(projectId, projectId);
+    // Per-entry validation bookkeeping keyed on logical_id (no FK CASCADE) —
+    // delete BEFORE knowledge so the subquery still sees the rows (#990).
+    for (const table of ltm.LOGICAL_ID_BOOKKEEPING_TABLES) {
+      database
+        .query(
+          `DELETE FROM ${table} WHERE logical_id IN (SELECT logical_id FROM knowledge WHERE project_id = ?)`,
+        )
+        .run(projectId);
+    }
     database.query("DELETE FROM knowledge WHERE project_id = ?").run(projectId);
     database
       .query("DELETE FROM temporal_messages WHERE project_id = ?")
@@ -745,6 +763,15 @@ export function clearKnowledge(projectPath: string): number {
       "DELETE FROM knowledge_transfers WHERE knowledge_id IN (SELECT logical_id FROM knowledge WHERE project_id = ?)",
     )
     .run(pid);
+  // Per-entry validation bookkeeping keyed on logical_id (no FK CASCADE) —
+  // delete BEFORE knowledge so the subquery still sees the rows (#990).
+  for (const table of ltm.LOGICAL_ID_BOOKKEEPING_TABLES) {
+    db()
+      .query(
+        `DELETE FROM ${table} WHERE logical_id IN (SELECT logical_id FROM knowledge WHERE project_id = ?)`,
+      )
+      .run(pid);
+  }
   db().query("DELETE FROM knowledge WHERE project_id = ?").run(pid);
 
   invalidateProjectsCache();

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -539,6 +539,26 @@ export function update(
   }
 }
 
+/**
+ * Per-entry bookkeeping tables that have a `logical_id` column and no FK
+ * CASCADE to the `knowledge` row. Under A2 (#823) a deleted entry's row is never
+ * physically removed (delete = append a death-cert version), so CASCADE never
+ * fires; and the bulk data-purge paths (clearProject / deleteProject /
+ * clearKnowledge) physically delete `knowledge` rows while bypassing remove().
+ * Every knowledge hard-delete path must purge these explicitly or their rows
+ * orphan. Centralized here so a new such table is wired into all delete paths by
+ * editing one list. (#990; introduced by #911 / PR #988.)
+ *
+ * This is the LOCAL-ONLY purge registry: only add tables whose rows are pure
+ * local derived state. Do NOT add synced convergent registers (e.g.
+ * knowledge_meta) — a local DELETE there would diverge from tombstone semantics
+ * once team sync lands.
+ */
+export const LOGICAL_ID_BOOKKEEPING_TABLES = [
+  "knowledge_ref_validity",
+  "knowledge_symbol_presence",
+] as const;
+
 export function remove(id: string, metadata?: KnowledgeMetadata) {
   // A2 (#823): delete = append an immutable is_deleted "death-certificate"
   // version (ordinary append, no physical DELETE). The death cert IS the
@@ -561,6 +581,11 @@ export function remove(id: string, metadata?: KnowledgeMetadata) {
   db()
     .query("DELETE FROM knowledge_transfers WHERE knowledge_id = ?")
     .run(logicalId);
+  // Per-entry validation bookkeeping (no FK CASCADE) — purge so it doesn't
+  // orphan once the entry is tombstoned. Table names are compile-time constants.
+  for (const table of LOGICAL_ID_BOOKKEEPING_TABLES) {
+    db().query(`DELETE FROM ${table} WHERE logical_id = ?`).run(logicalId);
+  }
 }
 
 /** True when the entry for this logical_id was deleted (tombstoned). */

--- a/packages/core/test/ltm-bookkeeping-cleanup.test.ts
+++ b/packages/core/test/ltm-bookkeeping-cleanup.test.ts
@@ -1,0 +1,123 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import * as data from "../src/data";
+import { db, ensureProject } from "../src/db";
+import * as ltm from "../src/ltm";
+
+// #990: every knowledge hard-delete path must purge the per-entry validation
+// bookkeeping tables (knowledge_ref_validity + knowledge_symbol_presence), which
+// are keyed on the stable logical_id and have no FK CASCADE. An UPDATE (new
+// version, same logical_id) must NOT purge them — they survive version edits.
+
+let root: string;
+let seedCounter = 0;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "lore-bookkeep-"));
+});
+afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+function seed(): { id: string; logicalId: string } {
+  const id = ltm.create({
+    projectPath: root,
+    scope: "project",
+    crossProject: false,
+    category: "gotcha",
+    title: `Bookkeeping entry ${++seedCounter}`,
+    content: "an entry that cites src/real.ts:1 and `someSymbol`",
+  });
+  const logicalId = ltm.get(id)?.logical_id;
+  if (!logicalId) throw new Error("seed failed");
+  return { id, logicalId };
+}
+
+// Seed one row in each bookkeeping table for this logical_id. Direct inserts
+// keep the test deterministic — the cleanup is under test, not the validator.
+function seedBookkeeping(logicalId: string): void {
+  db()
+    .query(
+      "INSERT OR REPLACE INTO knowledge_ref_validity (logical_id, broken, total, checked_at) VALUES (?, 1, 2, ?)",
+    )
+    .run(logicalId, Date.now());
+  db()
+    .query(
+      "INSERT OR REPLACE INTO knowledge_symbol_presence (logical_id, symbol, last_present_at) VALUES (?, 'someSymbol', ?)",
+    )
+    .run(logicalId, Date.now());
+}
+
+function bookkeepingCount(logicalId: string): number {
+  const rv = db()
+    .query(
+      "SELECT COUNT(*) AS c FROM knowledge_ref_validity WHERE logical_id = ?",
+    )
+    .get(logicalId) as { c: number };
+  const sp = db()
+    .query(
+      "SELECT COUNT(*) AS c FROM knowledge_symbol_presence WHERE logical_id = ?",
+    )
+    .get(logicalId) as { c: number };
+  return rv.c + sp.c;
+}
+
+describe("orphan bookkeeping cleanup on knowledge delete (#990)", () => {
+  test("remove() purges ref_validity + symbol_presence for the entry", () => {
+    const { logicalId } = seed();
+    seedBookkeeping(logicalId);
+    expect(bookkeepingCount(logicalId)).toBe(2);
+
+    ltm.remove(logicalId);
+
+    expect(bookkeepingCount(logicalId)).toBe(0);
+  });
+
+  test("update() (new version) PRESERVES bookkeeping — survives version edits", () => {
+    const { id, logicalId } = seed();
+    seedBookkeeping(logicalId);
+
+    // A content change appends a new version; the logical_id is unchanged, so the
+    // logical_id-keyed bookkeeping must stay (it intentionally outlives versions).
+    // NB: `id` is now a superseded version, so resolve via logical_id — get()
+    // only exposes the current version.
+    ltm.update(id, {
+      content: "changed content forces a brand new version row",
+    });
+
+    const current = ltm.getByLogical(logicalId);
+    expect(current?.logical_id).toBe(logicalId); // entry still present
+    expect(current?.content).toContain("brand new version"); // update materialized
+    expect(bookkeepingCount(logicalId)).toBe(2); // not purged
+  });
+
+  test("clearKnowledge() purges bookkeeping for the project's entries", () => {
+    const { logicalId } = seed();
+    seedBookkeeping(logicalId);
+    expect(bookkeepingCount(logicalId)).toBe(2);
+
+    data.clearKnowledge(root);
+
+    expect(bookkeepingCount(logicalId)).toBe(0);
+  });
+
+  test("clearProject() purges bookkeeping for the project's entries", () => {
+    const { logicalId } = seed();
+    seedBookkeeping(logicalId);
+    expect(bookkeepingCount(logicalId)).toBe(2);
+
+    data.clearProject(root);
+
+    expect(bookkeepingCount(logicalId)).toBe(0);
+  });
+
+  test("deleteProject() purges bookkeeping for the project's entries", () => {
+    const { logicalId } = seed();
+    seedBookkeeping(logicalId);
+    expect(bookkeepingCount(logicalId)).toBe(2);
+
+    data.deleteProject(ensureProject(root));
+
+    expect(bookkeepingCount(logicalId)).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #990 Part 1 (orphan cleanup). Part 2 (\`last_present_at\` TTL) stays open as a reserved follow-up.

## Problem
\`knowledge_ref_validity\` (PK \`logical_id\`) and \`knowledge_symbol_presence\` (PK \`logical_id, symbol\`) are keyed on the stable \`logical_id\` and have **no FK CASCADE** to the \`knowledge\` row. They orphaned on every delete path:
- **\`ltm.remove()\`** — under A2 (#823) a delete *appends* an \`is_deleted\` death-cert version; the \`logical_id\` row is never physically deleted, so CASCADE never fires.
- **\`clearProject\` / \`deleteProject\` / \`clearKnowledge\`** (data.ts) — these physically \`DELETE FROM knowledge\` but bypass \`remove()\`, and only cleaned \`knowledge_transfers\`.

Impact is **bounded growth only — zero correctness change** (a tombstoned/absent entry is never re-validated, so stale rows are inert), exactly as scoped in #990.

## Fix
Centralized the table list in **\`ltm.LOGICAL_ID_BOOKKEEPING_TABLES\`** and purge it on all four hard-delete paths:
- \`remove()\` → \`DELETE … WHERE logical_id = ?\`
- the three bulk purges → \`DELETE … WHERE logical_id IN (SELECT logical_id FROM knowledge WHERE project_id = ?)\`, placed **before** the \`DELETE FROM knowledge\` (so the subquery still sees the rows — same ordering as the existing \`knowledge_transfers\` cleanup).

One list means a future bookkeeping table is wired into every delete path by editing one line — no per-site divergence. \`deleteKnowledge(id)\` is covered transitively (it delegates to \`remove()\`); \`mergeProjects\` only reparents (\`UPDATE project_id\`), so logical_ids survive and nothing orphans.

🔴 **\`update()\` intentionally does NOT purge** — these rows are keyed on \`logical_id\` precisely so they outlive version edits. There's an explicit regression test for this.

## Tests (\`ltm-bookkeeping-cleanup.test.ts\`, 5)
\`remove()\`, \`clearProject()\`, \`deleteProject()\`, \`clearKnowledge()\` each purge both tables; \`update()\` preserves both (and the new version actually materialized).

## Mutation verification
- Empty \`LOGICAL_ID_BOOKKEEPING_TABLES\` → all **4 delete tests fail**, \`update()\`-preserves **passes** (confirms each delete test guards the cleanup and the update test is a true non-purge assertion).
- Remove only the \`clearKnowledge\` loop → **only** its test fails → the three bulk sites are independent, not sharing one purge.
- Full core suite green (2081 passed / 6 skipped); typecheck + biome clean.