### PR TITLE
fix: stop distilled-prefix churn (warming gate + overhead scale fix)

### DIFF
--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -143,6 +143,27 @@ const FREE_WRITE_LAYER0_FRACTION = 0.65;
 export const UNCALIBRATED_SAFETY = 1.5;
 
 /**
+ * Empirical ratio of REAL provider tokens to the gradient's chars/3 body
+ * estimate (validated ~1.63–1.68 across 200+ turn-pairs). Used to keep the
+ * budget math on a single, consistent scale (issue: distilled-prefix churn from
+ * usable-collapse):
+ *
+ *  - calibrate(): overhead = actualInput(REAL) − messageEstimate×RATIO − ltm, so
+ *    `overhead` is TRUE system+tools and does NOT silently absorb the body
+ *    undercount. Previously overhead absorbed ~0.40·body_real, which for large
+ *    growing sessions inflated overhead to ~125K on a 200K model, collapsed
+ *    `usable` to ~25K, and forced the session to Layer 4 where the distilled
+ *    prefix is re-rendered every turn (the messages[1] cache bust).
+ *  - body budgets: a body of B_real real tokens has a chars/3 estimate
+ *    B_real/RATIO, so a REAL-token budget is converted to the chars/3 scale the
+ *    body estimates are measured in by dividing by RATIO (so the body occupies
+ *    at most `fraction × usable` REAL tokens).
+ *  - fitsWithSafetyMargin(): the acceptance gate inflates the chars/3 body back
+ *    to real and adds overhead+ltm before comparing to maxInput.
+ */
+export const BODY_TOKEN_RATIO = 1.68;
+
+/**
  * True when the session's upstream has reported zero cache_creation_input_tokens
  * for at least {@link NO_CACHE_WRITE_THRESHOLD} consecutive turns.  Covers both
  * free-write-cache providers (e.g. MiniMax passive caching) and non-caching
@@ -1072,7 +1093,17 @@ export function calibrate(
   // to compare against). Allow when both are 0 (test setup to zero overhead) or
   // when we have a real transform estimate.
   if (messageEstimate > 0 || actualInput === 0) {
-    const overhead = Math.max(0, actualInput - messageEstimate - ltm);
+    // Scale fix: `actualInput` is REAL provider tokens but `messageEstimate`
+    // (lastTransformEstimate) is the chars/3 body estimate, which undercounts by
+    // ~BODY_TOKEN_RATIO. Subtracting the un-inflated estimate leaked
+    // ~0.40·body_real into `overhead`, so for large/growing sessions overhead
+    // ballooned (~125K on a 200K model), `usable` collapsed (~25K), the session
+    // was forced to Layer 4, and the distilled prefix re-rendered every turn
+    // (the messages[1] cache bust). Inflate the body estimate to the real scale
+    // first so `overhead` is TRUE system+tools only and stays stable as the body
+    // grows. (messageEstimate===0 ⇒ overhead = actualInput − ltm, unchanged.)
+    const realMessageEstimate = Math.round(messageEstimate * BODY_TOKEN_RATIO);
+    const overhead = Math.max(0, actualInput - realMessageEstimate - ltm);
     // Lever 2 (Bug 1): the per-session EMA is authoritative — getOverhead()
     // prefers it. The module-global EMA is still updated, but only serves as
     // the first-turn seed / no-session fallback. A single shared global blended
@@ -2843,9 +2874,19 @@ function transformInner(input: {
   // at quality boundaries.
   const usable = usableRaw;
 
-  const distilledBudget = Math.floor(usable * cfg.budget.distilled);
+  // `usable` is REAL provider tokens (contextLimit/overhead/ltm are all real,
+  // and `overhead` is now TRUE system+tools — it no longer absorbs the chars/3
+  // body undercount). The body budgets below are compared against chars/3 body
+  // estimates (estimateMessage), so convert the real body space to the chars/3
+  // scale by dividing by BODY_TOKEN_RATIO. This makes the distilled/raw windows
+  // occupy at most `fraction × usable` REAL tokens — honoring cfg.budget.* — and
+  // keeps the comparison apples-to-apples. (Overflow is guarded separately by
+  // fitsWithSafetyMargin, which inflates back to real and adds overhead+ltm.)
+  const bodyUsable = Math.floor(usable / BODY_TOKEN_RATIO);
+
+  const distilledBudget = Math.floor(bodyUsable * cfg.budget.distilled);
   // Base raw budget. May be overridden below for post-idle compact mode.
-  let rawBudget = Math.floor(usable * cfg.budget.raw);
+  let rawBudget = Math.floor(bodyUsable * cfg.budget.raw);
 
   // --- Escalated-stage budget ceiling (layers 2-3 only) ---
   // The ESCALATED compression stages (layer 2: rawFrac 0.5; layer 3: rawFrac
@@ -2916,19 +2957,26 @@ function transformInner(input: {
   // is only the stage-loop acceptance gate (the layer-0 / tier-gate paths use
   // their own `maxInput * HARD_CEILING_MARGIN` checks against expectedInput).
   //
-  // The layer-1 stable window is effectively bounded to ~0.65*usable (prefix
-  // 0.25 + raw 0.4), so `total * 1.5 = 0.975*usable <= maxInput` and layer 1
-  // is never falsely rejected in the normal regime. The stable-window
-  // hysteresis (up to 1.15x raw) can push the worst case to ~0.71*usable, which
-  // exceeds maxInput only when overhead+LTM is a tiny (<~6%) slice of the
-  // window — and in that regime the real (1.5x) size genuinely approaches the
-  // ceiling, so escalating one layer is the correct, safe response, not a
-  // spurious reject.
+  // Scale-correct check: inflate the chars/3 body (result.totalTokens) back to
+  // REAL tokens via BODY_TOKEN_RATIO and add the real overhead + LTM (which are
+  // NOT in result.totalTokens — it is the message body only). Compare to
+  // maxInput. This is exact: it is the same quantity the API counts. Body
+  // budgets are now sized as fractions of `usable` REAL tokens (bodyUsable =
+  // usable/RATIO chars/3), so the layer-1 window real-total is
+  // 0.65*(maxInput−overhead−ltm) + overhead + ltm = 0.65*maxInput +
+  // 0.35*(overhead+ltm) < maxInput — never falsely rejected in the normal
+  // regime, even with the 1.15x stable-window hysteresis (~0.71). The old check
+  // (`totalTokens * 1.5 <= maxInput`) ignored overhead+ltm; with the bigger
+  // post-fix budgets it would have under-counted and risked shipping an
+  // over-ceiling window.
   function fitsWithSafetyMargin(
     result: { totalTokens: number } | null,
   ): boolean {
     if (!result) return false;
-    return result.totalTokens * UNCALIBRATED_SAFETY <= maxInput;
+    return (
+      result.totalTokens * BODY_TOKEN_RATIO + overhead + sessLtmTokens <=
+      maxInput
+    );
   }
 
   // --- Sticky layer guard (Option C) ---
@@ -3005,11 +3053,12 @@ function transformInner(input: {
     sessState.postIdleCompact = false;
     // Skip layer 0 — don't pass through all raw messages on a cold cache.
     effectiveMinLayer = Math.max(effectiveMinLayer, 1) as SafetyLayer;
-    // Use a tighter raw budget on cold cache to limit write cost.
-    rawBudget = Math.floor(usable * 0.2);
+    // Use a tighter raw budget on cold cache to limit write cost. chars/3 scale
+    // (bodyUsable) to match the body estimates, same as the base rawBudget.
+    rawBudget = Math.floor(bodyUsable * 0.2);
     log.info(
       `post-idle compact: session=${sid} rawBudget=${rawBudget}` +
-        ` (${Math.floor(usable * cfg.budget.raw)}→${rawBudget})`,
+        ` (${Math.floor(bodyUsable * cfg.budget.raw)}→${rawBudget})`,
     );
   }
 
@@ -3246,12 +3295,22 @@ function transformInner(input: {
     //     actually shrink toward the cap. A null fraction on an escalated stage
     //     (e.g. layer 2's distFrac) falls back to the configured base fraction,
     //     still clamped to the ceiling.
+    // `stageBudgetUsable` is REAL tokens (min of real usable and the real cost
+    // ceiling); divide by BODY_TOKEN_RATIO so the escalated body budgets land on
+    // the same chars/3 scale as the body estimates (matching distilledBudget/
+    // rawBudget above).
     const isEscalated = stageLayer > 1;
     const stageRawBudget = isEscalated
-      ? Math.floor(stageBudgetUsable * (stage.rawFrac ?? cfg.budget.raw))
+      ? Math.floor(
+          (stageBudgetUsable * (stage.rawFrac ?? cfg.budget.raw)) /
+            BODY_TOKEN_RATIO,
+        )
       : rawBudget;
     const stageDistBudget = isEscalated
-      ? Math.floor(stageBudgetUsable * (stage.distFrac ?? cfg.budget.distilled))
+      ? Math.floor(
+          (stageBudgetUsable * (stage.distFrac ?? cfg.budget.distilled)) /
+            BODY_TOKEN_RATIO,
+        )
       : distilledBudget;
 
     // Determine prefix: if distLimit is finite, re-render with trimmed distillations.
@@ -3415,10 +3474,12 @@ function transformInner(input: {
     0,
   );
 
-  // Token budget for the raw tail. clamp(usable * 0.25, 2K, 8K).
+  // Token budget for the raw tail. clamp(bodyUsable * 0.25, 2K, 8K) — chars/3
+  // scale (bodyUsable) to match estimateMessage; the 2K/8K clamp dominates
+  // except on very small contexts.
   const tailBudget = Math.max(
     2_000,
-    Math.min(8_000, Math.floor(usable * 0.25)),
+    Math.min(8_000, Math.floor(bodyUsable * 0.25)),
   );
 
   // Current turn is always included (non-negotiable — dropping it causes

--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -115,6 +115,20 @@ const LTM_BUDGET_STEP = 8_000;
 /** Consecutive zero-cache-write turns before treating the session as free-write. */
 const NO_CACHE_WRITE_THRESHOLD = 3;
 
+/** EMA smoothing for the per-session prefix-churn rate (fraction of recent real
+ *  turns that were `prefix-rewrite` busts). 0.35 ≈ a ~3-turn effective window:
+ *  rewrites every ≤3 turns hold the EMA above PREFIX_CHURN_WARM_BLOCK, while a
+ *  single one-off rewrite bumps to ~0.35 then decays below it within ~2 clean
+ *  turns. */
+export const PREFIX_CHURN_ALPHA = 0.35;
+
+/** Prefix-churn rate at/above which the cache warmer suppresses warming. While
+ *  the distilled prefix is being rewritten this often, every warmup lands as a
+ *  partial (it refreshes a prefix the next real turn replaces) — pure waste.
+ *  Warming re-arms automatically once real turns stop rewriting the prefix and
+ *  the EMA decays below this threshold. */
+export const PREFIX_CHURN_WARM_BLOCK = 0.35;
+
 /** Layer-0 ceiling fraction for free-write sessions.
  *  65% of maxInput ≈ 109k for 200k context → ~59k headroom for tool-heavy turns. */
 const FREE_WRITE_LAYER0_FRACTION = 0.65;
@@ -362,6 +376,22 @@ export function recordCacheUsage(
       );
     }
 
+    // Prefix-churn EMA: a FREE, per-real-turn signal of how often the distilled
+    // prefix (messages[0/1]) is being rewritten by meta-distillation. Updated on
+    // every real cache event (total>0): 1 when this turn was a prefix-rewrite
+    // bust, 0 otherwise — so it decays on clean/incremental turns. The cache
+    // warmer reads it (getPrefixChurnRate) to suppress warming while the prefix
+    // is actively churning: warming a prefix that the next real turn will rewrite
+    // is pure waste (the warmup refreshes a prefix that is about to be replaced).
+    // A one-off rewrite (e.g. a single compaction) bumps the EMA once and decays;
+    // only SUSTAINED churn (rewrites every few turns) holds it above the block
+    // threshold. `idle-resume` busts are NOT churn (indicator 0) — a cold-cache
+    // re-warm is unrelated to prefix rewriting.
+    const prefixRewriteIndicator = bustCause === "prefix-rewrite" ? 1 : 0;
+    state.prefixChurnEma =
+      PREFIX_CHURN_ALPHA * prefixRewriteIndicator +
+      (1 - PREFIX_CHURN_ALPHA) * state.prefixChurnEma;
+
     // Free-write detection: track consecutive turns with zero cache writes.
     // Covers providers with free passive caching (e.g. MiniMax) and
     // non-caching providers. Both produce the same observable signal.
@@ -508,6 +538,12 @@ type SessionState = {
    *  Not persisted to DB — rebuilds from live API responses (same rationale as
    *  consecutiveBusts: stale values from a prior process would be incorrect). */
   zeroCacheWriteTurns: number;
+  /** EMA (0..1) of how often recent real turns were `prefix-rewrite` busts —
+   *  i.e. how actively meta-distillation is rewriting the distilled prefix
+   *  (messages[0/1]). Read by the cache warmer (getPrefixChurnRate) to suppress
+   *  warming a churning prefix. Not persisted (rebuilds from live API responses,
+   *  same rationale as consecutiveBusts). */
+  prefixChurnEma: number;
   /** Number of transform() calls observed for this session in the current
    *  process. Starts at 0 for a freshly-tracked session and is NOT restored
    *  from the DB (same rationale as consecutiveBusts). Drives the cold-start
@@ -588,6 +624,7 @@ function makeSessionState(): SessionState {
     consecutiveHighLayer: 0,
     consecutiveBusts: 0,
     zeroCacheWriteTurns: 0,
+    prefixChurnEma: 0,
     transformCount: 0,
     bustSpiralAlerted: false,
     bustSpiralColdStartLogged: false,
@@ -1205,6 +1242,7 @@ export function inspectSessionState(sessionID: string): {
   distillationSnapshot: DistillationSnapshot | null;
   consecutiveBusts: number;
   zeroCacheWriteTurns: number;
+  prefixChurnEma: number;
   lastKnownMessageCount: number;
   transformCount: number;
   bustSpiralAlerted: boolean;
@@ -1223,6 +1261,7 @@ export function inspectSessionState(sessionID: string): {
     distillationSnapshot: state.distillationSnapshot,
     consecutiveBusts: state.consecutiveBusts,
     zeroCacheWriteTurns: state.zeroCacheWriteTurns,
+    prefixChurnEma: state.prefixChurnEma,
     lastKnownMessageCount: state.lastKnownMessageCount,
     transformCount: state.transformCount,
     bustSpiralAlerted: state.bustSpiralAlerted,
@@ -1230,6 +1269,19 @@ export function inspectSessionState(sessionID: string): {
     overheadEma: state.overheadEma,
     distilledBudgetHighWater: state.distilledBudgetHighWater,
   };
+}
+
+/**
+ * Return the prefix-churn rate (0..1 EMA) for a session (read-only). High values
+ * mean meta-distillation is actively rewriting the distilled prefix, so warming
+ * the prefix is wasteful (the next real turn will replace it). Returns 0 when the
+ * session has no in-memory state — the safe default (no churn → warming allowed).
+ *
+ * Uses Map.get() (not getSessionState) to avoid creating phantom SessionState
+ * entries — same rationale as getConsecutiveBusts.
+ */
+export function getPrefixChurnRate(sessionID: string): number {
+  return sessionStates.get(sessionID)?.prefixChurnEma ?? 0;
 }
 
 /**
@@ -1473,6 +1525,15 @@ export function setConsecutiveBustsForTest(
   busts: number,
 ): void {
   getSessionState(sessionID).consecutiveBusts = busts;
+}
+
+/**
+ * For testing only — set the session's prefix-churn EMA (0..1). Used to drive the
+ * cache warmer's prefix-churn gate without replaying real prefix-rewrite turns.
+ * Creates the session state if not present.
+ */
+export function setPrefixChurnForTest(sessionID: string, churn: number): void {
+  getSessionState(sessionID).prefixChurnEma = churn;
 }
 
 /**

--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -116,18 +116,21 @@ const LTM_BUDGET_STEP = 8_000;
 const NO_CACHE_WRITE_THRESHOLD = 3;
 
 /** EMA smoothing for the per-session prefix-churn rate (fraction of recent real
- *  turns that were `prefix-rewrite` busts). 0.35 ≈ a ~3-turn effective window:
- *  rewrites every ≤3 turns hold the EMA above PREFIX_CHURN_WARM_BLOCK, while a
- *  single one-off rewrite bumps to ~0.35 then decays below it within ~2 clean
- *  turns. */
+ *  turns that were `prefix-rewrite` busts). ~3-turn effective window. */
 export const PREFIX_CHURN_ALPHA = 0.35;
 
 /** Prefix-churn rate at/above which the cache warmer suppresses warming. While
  *  the distilled prefix is being rewritten this often, every warmup lands as a
  *  partial (it refreshes a prefix the next real turn replaces) — pure waste.
  *  Warming re-arms automatically once real turns stop rewriting the prefix and
- *  the EMA decays below this threshold. */
-export const PREFIX_CHURN_WARM_BLOCK = 0.35;
+ *  the EMA decays below this threshold.
+ *
+ *  🔴 Set STRICTLY ABOVE PREFIX_CHURN_ALPHA so a SINGLE one-off rewrite (which
+ *  bumps the from-zero EMA to exactly ALPHA) does NOT block — that warmup would
+ *  land as a clean refresh because the prefix is now stable again. Only SUSTAINED
+ *  churn trips it: two consecutive rewrites give EMA ≈ 0.58, and a rewrite every
+ *  ≤2 turns holds the EMA above this threshold. */
+export const PREFIX_CHURN_WARM_BLOCK = 0.4;
 
 /** Layer-0 ceiling fraction for free-write sessions.
  *  65% of maxInput ≈ 109k for 200k context → ~59k headroom for tool-heavy turns. */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -177,9 +177,13 @@ export {
   // gaps without sleeping. Not part of the public API.
   setLastTurnAtForTest,
   setConsecutiveBustsForTest,
+  setPrefixChurnForTest,
   setTransformCountForTest,
   inspectSessionState,
   getConsecutiveBusts,
+  getPrefixChurnRate,
+  PREFIX_CHURN_ALPHA,
+  PREFIX_CHURN_WARM_BLOCK,
   BUST_PRESSURE_THRESHOLD,
   DEEP_IDLE_MS,
   COLD_START_GRACE_TURNS,

--- a/packages/core/test/gradient.test.ts
+++ b/packages/core/test/gradient.test.ts
@@ -4648,12 +4648,18 @@ describe("tier-based context management", () => {
       });
 
       const maxInput = 200_000 - 32_000; // 168K
-      // The window ships at the forced layer (no escalation needed — the budgets
-      // already keep it under the ceiling).
-      expect(result.layer).toBeGreaterThanOrEqual(2);
-      // 🔴 The SHIPPED window must fit the REAL ceiling — assert in REAL tokens
-      // (chars/3 × BODY_TOKEN_RATIO + overhead 0 + ltm 0), the same quantity the
-      // API counts. This is STRICTLY STRONGER than the old chars/3-only check.
+      // 🔴 Ships at EXACTLY the forced layer 2 — NO escalation. This is the
+      // discriminating assertion: the budget fix keeps the layer-2 window under
+      // the real ceiling, so fitsWithSafetyMargin accepts it and the loop does
+      // NOT escalate. Reverting the budget /RATIO makes the layer-2 window
+      // overflow → fitsWithSafetyMargin rejects → the loop escalates all the way
+      // to the Layer-4 emergency tail (a tiny window). `toBe(2)` fails on that
+      // revert; `toBeGreaterThanOrEqual(2)` would NOT (Layer 4 satisfies it),
+      // making the test vacuous.
+      expect(result.layer).toBe(2);
+      // The SHIPPED window also fits the REAL ceiling — assert in REAL tokens
+      // (chars/3 × BODY_TOKEN_RATIO + overhead 0 + ltm 0), the quantity the API
+      // counts. Strictly stronger than the old chars/3-only check.
       expect(result.totalTokens * BODY_TOKEN_RATIO).toBeLessThanOrEqual(
         maxInput,
       );

--- a/packages/core/test/gradient.test.ts
+++ b/packages/core/test/gradient.test.ts
@@ -52,6 +52,7 @@ import {
   getOverhead,
   getLastTransformEstimate,
   effectiveDistilledBudget,
+  BODY_TOKEN_RATIO,
   type ModelBudget,
 } from "../src/gradient";
 import type { LoreMessage, LorePart, LoreMessageWithParts } from "../src/types";
@@ -410,10 +411,14 @@ describe("gradient — lazy raw window eviction (Approach B)", () => {
   test("raw window advances only when the new message forces eviction", () => {
     resetRawWindowCache();
 
-    // context=3000, output=500 → usable=2500, rawBudget=floor(2500*0.4)=1000
-    // Each 400-char message ≈ 154 tokens (400 chars/3 + 20 overhead).
-    // 22 messages ≈ 3388 > 2500 → gradient fires.
-    setModelLimits({ context: 3_000, output: 500 });
+    // context=4000, output=500 → usable=3500, bodyUsable=floor(3500/1.68)=2083,
+    // rawBudget=floor(2083*0.4)=833. Each 400-char message ≈ 154 chars/3 tokens
+    // (400/3 + 20). 22 messages ≈ 3388; uncalibrated layer decision inflates by
+    // 1.5 → 5082 > maxInput 3500 → gradient fires (Layer 1). The huge C(2000)
+    // current turn ≈ 687 chars/3 fits within rawBudget 833, so it stays at Layer
+    // 1 (does not escalate on the current-turn guard). Sized post the
+    // chars/3→real scale fix (budgets divide by BODY_TOKEN_RATIO).
+    setModelLimits({ context: 4_000, output: 500 });
     calibrate(0);
 
     const SESS2 = "lazy-evict-tight";
@@ -2206,16 +2211,20 @@ describe("gradient — usable/overhead oscillation (Bug 1)", () => {
       // Seed transform estimates so calibrate() has a baseline to subtract.
       transform({ messages: msgsA, projectPath: PROJECT, sessionID: A });
       transform({ messages: msgsB, projectPath: PROJECT, sessionID: B });
-      // A: small overhead (10K). B: huge overhead (500K).
-      calibrate(getLastTransformEstimate(A) + 10_000, A, msgsA.length);
-      calibrate(getLastTransformEstimate(B) + 500_000, B, msgsB.length);
+      // A: small overhead (10K). B: huge overhead (500K). actualInput is REAL
+      // tokens, so the body term is the REAL body (chars/3 estimate × ratio);
+      // calibrate inflates the estimate the same way, leaving overhead = +N.
+      const realBody = (sid: string) =>
+        Math.round(getLastTransformEstimate(sid) * BODY_TOKEN_RATIO);
+      calibrate(realBody(A) + 10_000, A, msgsA.length);
+      calibrate(realBody(B) + 500_000, B, msgsB.length);
       expect(getOverhead(A)).toBe(10_000);
       expect(getOverhead(B)).toBe(500_000);
       // B keeps calibrating high — must NOT drag A toward a shared blend.
       transform({ messages: msgsB, projectPath: PROJECT, sessionID: B });
-      calibrate(getLastTransformEstimate(B) + 500_000, B, msgsB.length);
+      calibrate(realBody(B) + 500_000, B, msgsB.length);
       transform({ messages: msgsB, projectPath: PROJECT, sessionID: B });
-      calibrate(getLastTransformEstimate(B) + 500_000, B, msgsB.length);
+      calibrate(realBody(B) + 500_000, B, msgsB.length);
       // Pre-fix (global EMA, sessionID ignored): getOverhead(A) is dragged
       // toward B's 500K and is no longer 10K.
       expect(getOverhead(A)).toBe(10_000);
@@ -2273,11 +2282,17 @@ describe("gradient — usable/overhead oscillation (Bug 1)", () => {
       setLtmTokens(20_000, SID);
       transform({ messages: msgs, projectPath: PROJECT, sessionID: SID });
       const est = getLastTransformEstimate(SID);
-      // Real input = body(est) + host/tools(50K) + injected LTM(20K).
-      calibrate(est + 50_000 + 20_000, SID, msgs.length);
+      // Real input = body(REAL = est×ratio) + host/tools(50K) + injected
+      // LTM(20K). calibrate inflates the chars/3 estimate by the same ratio, so
+      // overhead nets out to host/tools (50K) only.
+      calibrate(
+        Math.round(est * BODY_TOKEN_RATIO) + 50_000 + 20_000,
+        SID,
+        msgs.length,
+      );
       // Overhead must be host/tools ONLY — LTM is NOT part of "overhead"
       // (the comment at the `usable` computation says LTM is subtracted
-      // separately). Pre-fix it was actualInput - bodyEstimate = 70K.
+      // separately).
       expect(getOverhead(SID)).toBe(50_000);
       // usable subtracts LTM exactly once (via sessLtmTokens), not twice.
       const r = transform({
@@ -2377,6 +2392,69 @@ describe("gradient — usable/overhead oscillation (Bug 1)", () => {
       setModelLimits({ context: 10_000, output: 2_000 });
       calibrate(0);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Overhead/body scale decoupling — the usable-collapse root cause
+// ---------------------------------------------------------------------------
+// `calibrate` computes overhead = actualInput(REAL) − messageEstimate(chars/3) ×
+// BODY_TOKEN_RATIO − ltm. Before the scale fix it subtracted the UN-inflated
+// chars/3 estimate, so ~0.40·body_real leaked into `overhead`. For a large body
+// that ballooned overhead, collapsed `usable`, and forced the session to Layer 4
+// where the distilled prefix re-renders every turn (the messages[1] every-turn
+// cache bust). These guard that overhead is TRUE system+tools and stays stable
+// as the body grows, so usable does NOT collapse.
+describe("gradient — overhead/body scale decoupling (usable-collapse fix)", () => {
+  const SID = "overhead-scale-sess";
+
+  test("overhead stays at TRUE system+tools (does not absorb the body) → usable does not collapse", () => {
+    setModelLimits({ context: 200_000, output: 32_000 }); // maxInput = 168K
+    resetCalibration(SID);
+    const TRUE_OVERHEAD = 48_000;
+    // A large conversation whose chars/3 estimate undercounts the real body.
+    const msgs = Array.from({ length: 40 }, (_, i) =>
+      makeMsg(
+        `os-${i}`,
+        i % 2 === 0 ? "user" : "assistant",
+        "w".repeat(3_000),
+        SID,
+      ),
+    );
+    // Several turns: the per-session overhead EMA must SETTLE at the true
+    // overhead, not ratchet up with the body (the production collapse signature).
+    let est = 0;
+    for (let t = 0; t < 6; t++) {
+      transform({ messages: msgs, projectPath: PROJECT, sessionID: SID });
+      est = getLastTransformEstimate(SID);
+      // actualInput is REAL: the model saw the real body (est × ratio) plus the
+      // true 48K system+tools. calibrate must inflate the estimate the same way.
+      calibrate(
+        Math.round(est * BODY_TOKEN_RATIO) + TRUE_OVERHEAD,
+        SID,
+        msgs.length,
+      );
+    }
+    // Sanity: the body estimate is large enough that a pre-fix leak (~0.4×body)
+    // would be a big fraction of usable — i.e. this scenario actually exercises
+    // the collapse, so the assertions below are not vacuous.
+    expect(est).toBeGreaterThan(20_000);
+
+    // Overhead settled at ~true system+tools, NOT inflated by the body.
+    expect(getOverhead(SID)).toBe(TRUE_OVERHEAD);
+    // usable stays near the real available context (168K − 48K = 120K), NOT
+    // collapsed to ~25K. (Reverting the calibrate inflation drives overhead to
+    // ~TRUE_OVERHEAD + 0.4·body and usable well below 100K → this fails.)
+    const r = transform({
+      messages: msgs,
+      projectPath: PROJECT,
+      sessionID: SID,
+    });
+    expect(r.usable).toBeGreaterThan(100_000);
+
+    resetCalibration(SID);
+    setModelLimits({ context: 10_000, output: 2_000 });
+    calibrate(0);
   });
 });
 
@@ -4410,9 +4488,12 @@ describe("tier-based context management", () => {
       // usable stays the full ~968K (LTM / economics read this).
       expect(result.usable).toBeGreaterThan(900_000);
       // Base budgets scale off the full usable — NOT the 40K cap (which would
-      // give rawBudget = 40K*0.4 = 16K).
-      expect(result.rawBudget).toBe(Math.floor(result.usable * 0.4));
-      expect(result.distilledBudget).toBe(Math.floor(result.usable * 0.25));
+      // give rawBudget = 40K*0.4 = 16K). They are on the chars/3 body scale
+      // (bodyUsable = usable / BODY_TOKEN_RATIO) so they compare apples-to-apples
+      // with the chars/3 message estimates.
+      const bodyUsable = Math.floor(result.usable / BODY_TOKEN_RATIO);
+      expect(result.rawBudget).toBe(Math.floor(bodyUsable * 0.4));
+      expect(result.distilledBudget).toBe(Math.floor(bodyUsable * 0.25));
       expect(result.rawBudget).toBeGreaterThan(40_000);
     });
 
@@ -4527,22 +4608,24 @@ describe("tier-based context management", () => {
       expect(result.usable).toBeGreaterThan(900_000);
     });
 
-    test("hard-ceiling guard: a rebuilt over-ceiling window escalates instead of shipping (calibrated)", () => {
+    test("scale-correct budgets prevent an over-ceiling window: the SHIPPED window fits the REAL ceiling", () => {
       // Cost cap disabled on a 200K model so budgetUsable === usable === maxInput
-      // (168K). A forced layer-2 window fills prefix (0.25) + raw (0.5) ≈ 0.75 ×
-      // 168K ≈ 126K; its chars/3 estimate undercounts the real tokenizer ~1.5×,
-      // so 126K*1.5 = 189K > 168K maxInput. Pre-fix, a CALIBRATED session got a
-      // free pass (`fitsWithSafetyMargin` returned true unconditionally) and
-      // shipped that over-ceiling window → "prompt is too long". Post-fix the
-      // guard rejects it and the loop escalates to a tighter layer.
+      // (168K). A forced layer-2 window is sized as fractions of `usable` REAL
+      // tokens: prefix 0.25 + raw 0.5 = 0.75 × usable REAL. Pre-scale-fix the
+      // budgets were chars/3 fractions of usable, so the window's REAL size
+      // (×1.68) was 0.75×168K×1.68 = 212K > 168K and overflowed ("prompt is too
+      // long"; the old `fitsWithSafetyMargin` free-passed calibrated sessions).
+      // Post-fix the BODY budgets divide by BODY_TOKEN_RATIO, so the window's
+      // REAL size is at most 0.75×usable = 126K < 168K — the overflow is
+      // prevented at the budget level, and `fitsWithSafetyMargin` (now real-scale
+      // with overhead+ltm) remains a backstop for un-evictable oversized turns.
       setModelLimits({ context: 200_000, output: 32_000 }); // maxInput = 168K
       setMaxLayer0Tokens(0); // disabled → budgetUsable === usable === 168K
       calibrate(0);
 
-      // Prefix budget at layer 2 = 0.25*168K = 42K tokens; seed well past it so
-      // the prefix fills its budget after the binary-search trim.
+      // Seed distillate well past the layer-2 prefix budget and provide far more
+      // raw than the layer-2 raw budget, so both windows fill their budgets.
       seedDistillations(10, 18_000); // 10 × 6K tokens = 60K tokens of distillate
-      // Raw budget at layer 2 = 0.5*168K = 84K tokens; provide far more.
       const msgs = Array.from({ length: 150 }, (_, i) =>
         makeMsg(
           `hc-${i}`,
@@ -4552,9 +4635,9 @@ describe("tier-based context management", () => {
         ),
       );
 
-      // Mark the session calibrated WITHOUT a prior transform (so the shared
-      // overhead EMA is not perturbed and usable stays at the true 168K). This
-      // is the exact condition the pre-fix free pass applied to.
+      // Mark the session calibrated WITHOUT a prior transform (lastTransformEstimate
+      // stays 0, so calibrate does not move overhead) — overhead stays 0 and
+      // usable stays the true 168K.
       calibrate(120_000, SID, msgs.length);
       setForceMinLayer(2, SID);
 
@@ -4565,11 +4648,15 @@ describe("tier-based context management", () => {
       });
 
       const maxInput = 200_000 - 32_000; // 168K
-      // The guard rejected the over-ceiling layer-2 window and escalated past
-      // the forced layer (pre-fix this stayed at layer 2 and overflowed).
-      expect(result.layer).toBeGreaterThanOrEqual(3);
-      // Whatever layer it lands on, the SHIPPED window must fit the hard ceiling.
-      expect(result.totalTokens).toBeLessThanOrEqual(maxInput);
+      // The window ships at the forced layer (no escalation needed — the budgets
+      // already keep it under the ceiling).
+      expect(result.layer).toBeGreaterThanOrEqual(2);
+      // 🔴 The SHIPPED window must fit the REAL ceiling — assert in REAL tokens
+      // (chars/3 × BODY_TOKEN_RATIO + overhead 0 + ltm 0), the same quantity the
+      // API counts. This is STRICTLY STRONGER than the old chars/3-only check.
+      expect(result.totalTokens * BODY_TOKEN_RATIO).toBeLessThanOrEqual(
+        maxInput,
+      );
     });
   });
 

--- a/packages/core/test/gradient.test.ts
+++ b/packages/core/test/gradient.test.ts
@@ -31,6 +31,9 @@ import {
   setBustSpiralHook,
   prefixPresentFloorApplies,
   recordCacheUsage,
+  getPrefixChurnRate,
+  PREFIX_CHURN_ALPHA,
+  PREFIX_CHURN_WARM_BLOCK,
   setCachePricing,
   effectiveMetaThreshold,
   BUST_PRESSURE_THRESHOLD,
@@ -6572,5 +6575,55 @@ describe("issue #796: isLargeColdStart + cold-start force-compress", () => {
       // And below pressure, the 3-arg shape returns config.
       expect(effectiveMetaThreshold(0, DEFAULT_CONFIG, 1)).toBe(DEFAULT_CONFIG);
     });
+  });
+});
+
+describe("prefix-churn EMA (recordCacheUsage → getPrefixChurnRate)", () => {
+  // A prefix-rewrite bust: cacheWrite dominates (bustRatio > 0.5) and the
+  // gateway has classified the cause as a distilled-prefix rewrite.
+  const prefixRewrite = (sid: string) =>
+    recordCacheUsage(120_000, 40_000, 2, sid, false, "prefix-rewrite");
+  // A clean/incremental turn: a real cache read, small write.
+  const cleanTurn = (sid: string) =>
+    recordCacheUsage(500, 160_000, 2, sid, false, "incremental");
+
+  test("getPrefixChurnRate is 0 for an unknown session (non-creating, safe default)", () => {
+    expect(getPrefixChurnRate("prefix-churn-unknown-sess")).toBe(0);
+    // Must NOT have created phantom state (mirrors getConsecutiveBusts).
+    expect(inspectSessionState("prefix-churn-unknown-sess")).toBeNull();
+  });
+
+  test("one prefix-rewrite bust raises the EMA from 0 to exactly PREFIX_CHURN_ALPHA", () => {
+    const sid = "prefix-churn-exact-sess";
+    prefixRewrite(sid);
+    expect(getPrefixChurnRate(sid)).toBeCloseTo(PREFIX_CHURN_ALPHA, 10);
+  });
+
+  test("sustained prefix-rewrite busts hold the EMA above the warm-block threshold", () => {
+    const sid = "prefix-churn-sustained-sess";
+    for (let i = 0; i < 4; i++) prefixRewrite(sid);
+    expect(getPrefixChurnRate(sid)).toBeGreaterThanOrEqual(
+      PREFIX_CHURN_WARM_BLOCK,
+    );
+  });
+
+  test("the EMA decays below the threshold after enough clean turns", () => {
+    const sid = "prefix-churn-decay-sess";
+    for (let i = 0; i < 5; i++) prefixRewrite(sid);
+    expect(getPrefixChurnRate(sid)).toBeGreaterThanOrEqual(
+      PREFIX_CHURN_WARM_BLOCK,
+    );
+    // Clean turns must pull it back down so warming re-arms.
+    for (let i = 0; i < 5; i++) cleanTurn(sid);
+    expect(getPrefixChurnRate(sid)).toBeLessThan(PREFIX_CHURN_WARM_BLOCK);
+  });
+
+  test("idle-resume busts do NOT raise churn (a cold re-warm is not prefix churn)", () => {
+    const sid = "prefix-churn-idle-sess";
+    // Many cold-cache re-warms classified as idle-resume — indicator 0.
+    for (let i = 0; i < 5; i++) {
+      recordCacheUsage(200_000, 0, 2, sid, true, "idle-resume");
+    }
+    expect(getPrefixChurnRate(sid)).toBe(0);
   });
 });

--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -35,6 +35,8 @@ import {
   getCacheSizeSnapshot,
   getCacheStrategy,
   estimateMetaDistillCostPerCall,
+  getPrefixChurnRate,
+  PREFIX_CHURN_WARM_BLOCK,
 } from "@loreai/core";
 import type {
   InterTurnHistogram,
@@ -138,13 +140,6 @@ export const MIN_WARMUPS_FOR_ROI_CHECK = 5;
  *  1 in 4 warmups must result in a confirmed user return. */
 export const MIN_SESSION_HIT_RATE = 0.25;
 
-/** Minimum cache-WRITE efficiency (cacheRead / (cacheRead + cacheWrite), from
- *  each warmup's own response) to continue warming. Below this, the warmup is
- *  writing far more than it reuses — e.g. a large, actively-growing session
- *  whose full-body warm refreshes only the ~37K stable prefix (efficiency ~6%)
- *  while writing ~550K every time. Distinct from MIN_SESSION_HIT_RATE, which
- *  measures user-return probability, not write efficiency. */
-export const MIN_WRITE_EFFICIENCY = 0.2;
 /**
  * Shadow-mode (PR2a) cap on the `expectedFutureTurns` proxy fed into the shared
  * cache-economics evaluator. Until PR2b derives a principled mean-residual-life
@@ -153,11 +148,6 @@ export const MIN_WRITE_EFFICIENCY = 0.2;
  * dominate the ongoing-cost term while we are only MEASURING. Behavior-neutral.
  */
 export const SHADOW_FUTURE_TURNS_CAP = 50;
-/** Minimum number of recorded warmup-efficiency samples before the
- *  write-efficiency gate engages (avoid acting on one noisy sample). */
-export const MIN_WARMUPS_FOR_EFFICIENCY_CHECK = 3;
-/** Rolling window size for per-session warmup write-efficiency samples. */
-export const WRITE_EFFICIENCY_WINDOW = 5;
 
 /** Minimum total input tokens (input + cache_read + cache_creation) before
  *  warming is eligible. Below this threshold the absolute savings per hit
@@ -363,12 +353,15 @@ export function pruneExpiredCircuitBreakers(now: number = Date.now()): number {
 /**
  * Record a warmup result for a bucket and check its circuit breaker.
  *
- * A "failure" is a warmup where cacheCreationTokens > 0 AND cacheReadTokens === 0
- * AND the cached prefix should still have been alive (`cacheLikelyAlive`). When
- * the cache had already expired, a fresh write is the warmer legitimately
- * re-priming a cold cache — NOT a body/prefix mismatch — so it is neutral
- * (neither increments nor resets the counter). Likewise non-2xx responses
- * (`result.ok === false`, e.g. thinking-session 400s) are neutral.
+ * 🔴 All-or-nothing: a warmup replays the stored body during idle (no tail
+ * growth), so a healthy warmup is 100% cacheRead / 0 cacheCreation. ANY
+ * cacheCreation > 0 while the cached prefix should still have been alive
+ * (`cacheLikelyAlive`) is a body-divergence DEFECT — whether a partial
+ * (cacheRead > 0 too) or a full miss (cacheRead === 0). Both count as failures;
+ * a partial is NOT "fine". Only a CLEAN refresh (cacheRead > 0 AND
+ * cacheCreation === 0) clears accumulated failures. When the cache had already
+ * expired (`!cacheLikelyAlive`), a write is the warmer legitimately re-priming a
+ * cold cache — neutral. Non-2xx responses (`result.ok === false`) are neutral.
  *
  * Returns true if the bucket's breaker is tripped (warming should stop).
  */
@@ -381,12 +374,7 @@ export function checkCircuitBreaker(
   ensureCircuitBreakersLoaded();
   if (isCircuitBreakerTripped(bucketKey, now)) return true;
 
-  if (
-    result.ok &&
-    result.cacheCreationTokens > 0 &&
-    result.cacheReadTokens === 0 &&
-    cacheLikelyAlive
-  ) {
+  if (result.ok && result.cacheCreationTokens > 0 && cacheLikelyAlive) {
     const entry = circuitBreakers.get(bucketKey) ?? {
       failures: 0,
       tripped: false,
@@ -394,8 +382,9 @@ export function checkCircuitBreaker(
     };
     entry.failures++;
     circuitBreakers.set(bucketKey, entry);
+    const kind = result.cacheReadTokens > 0 ? "partial" : "uncached";
     log.error(
-      `cache-warmer CIRCUIT BREAKER: warmup caused uncached write for ` +
+      `cache-warmer CIRCUIT BREAKER: warmup caused ${kind} write for ` +
         `bucket=${bucketKey.slice(0, 24)} ` +
         `(${entry.failures}/${CIRCUIT_BREAKER_MAX_FAILURES}). ` +
         `cacheCreation=${result.cacheCreationTokens} cacheRead=${result.cacheReadTokens}`,
@@ -407,15 +396,20 @@ export function checkCircuitBreaker(
       emitWarmupCircuitBreakerMetric();
       log.error(
         `cache-warmer CIRCUIT BREAKER TRIPPED for bucket=${bucketKey.slice(0, 24)}: ` +
-          `${CIRCUIT_BREAKER_MAX_FAILURES} uncached warmups detected. Warming disabled for ` +
-          `this (session, model, upstream) until it decays in ` +
+          `${CIRCUIT_BREAKER_MAX_FAILURES} divergent (partial/uncached) warmups detected. ` +
+          `Warming disabled for this (session, model, upstream) until it decays in ` +
           `${Math.round(CIRCUIT_BREAKER_DECAY_MS / 3_600_000)}h or is reset. This indicates ` +
           `warmup bodies don't match the cached prefix — investigate cache key assumptions.`,
       );
       return true;
     }
-  } else if (result.ok && result.cacheReadTokens > 0) {
-    // Confirmed cache read — clear any accumulated (non-tripped) failures.
+  } else if (
+    result.ok &&
+    result.cacheReadTokens > 0 &&
+    result.cacheCreationTokens === 0
+  ) {
+    // Clean 100% refresh — clear any accumulated (non-tripped) failures. A
+    // partial (cacheCreation > 0) does NOT reach here; it is a failure above.
     const entry = circuitBreakers.get(bucketKey);
     if (entry && !entry.tripped) circuitBreakers.delete(bucketKey);
   }
@@ -865,12 +859,15 @@ export function prepareAnthropicWarmupBody(storedBody: string): string {
   // Strip structured output format (incompatible with max_tokens: 0)
   delete body.output_config;
 
-  // Ensure a cache breakpoint is present. The stored body comes from
-  // cache-analytics' normalized copy, which strips `cache_control` markers (so
-  // breakpoint movement doesn't pollute divergence analysis). Without a
-  // breakpoint the warmup writes NOTHING to the cache — silently neutering
-  // every warmup — so we re-add one on the last content block of the last
-  // message (Anthropic's standard placement, and what the real turns used).
+  // Ensure a cache breakpoint is present. NOTE: since the #943 raw-body fix,
+  // lastRequestBody stores the RAW as-sent body, which already carries the real
+  // turn's FULL multi-breakpoint layout (system[1] stableLtm, tools,
+  // conversation) — so ensureCacheBreakpoint is a NO-OP here (it returns early
+  // when any breakpoint is present). It remains only as a defensive backstop for
+  // the degenerate case of a stored body with zero breakpoints (which would
+  // otherwise write NOTHING to the cache), re-adding one on the last block of the
+  // last message. Replaying the real breakpoints verbatim is what makes a healthy
+  // warmup a 100% refresh.
   ensureCacheBreakpoint(body);
 
   return JSON.stringify(body);
@@ -1044,34 +1041,6 @@ export function resolveProfile(
  *  - Initial commitment (first TTL window): full ROI analysis
  *  - Continuation (subsequent windows): check break-even cap + re-evaluate
  */
-/**
- * Chronically-low cache-WRITE efficiency guard. Returns true when the session
- * has enough warmup-efficiency samples AND their average is below
- * MIN_WRITE_EFFICIENCY — i.e. the full-body warm keeps re-writing a prefix that
- * won't survive to the next real turn (large/growing session), wasting spend
- * the return-rate guard cannot detect. Returns false (do not block) when there
- * are too few samples to judge.
- */
-export function warmupWriteEfficiencyTooLow(
-  warmup: WarmupState | undefined,
-): boolean {
-  const samples = warmup?.writeEfficiencySamples ?? [];
-  if (samples.length < MIN_WARMUPS_FOR_EFFICIENCY_CHECK) return false;
-  const avg = samples.reduce((a, b) => a + b, 0) / samples.length;
-  return avg < MIN_WRITE_EFFICIENCY;
-}
-
-/** Human-readable dashboard reason for the write-efficiency gate. */
-export function warmupWriteEfficiencyReason(
-  warmup: WarmupState | undefined,
-): string {
-  const samples = warmup?.writeEfficiencySamples ?? [];
-  const avg = samples.length
-    ? (samples.reduce((a, b) => a + b, 0) / samples.length) * 100
-    : 0;
-  return `Write efficiency too low (${avg.toFixed(0)}% < ${(MIN_WRITE_EFFICIENCY * 100).toFixed(0)}%) — full-body warm refreshes only a small stable prefix`;
-}
-
 export function shouldWarm(
   state: SessionState,
   profile: CacheWarmingProfile,
@@ -1090,6 +1059,25 @@ export function shouldWarm(
 
   // No stored body to replay — nothing to warm
   if (!state.cacheAnalytics.lastRequestBody) return false;
+
+  // Prefix-churn gate. While meta-distillation is actively rewriting the
+  // distilled prefix (messages[0/1]), a warmup is pure waste: it replays the
+  // stored body and refreshes a prefix the very next real turn will REPLACE, so
+  // it lands as a partial (reads only the stable system+tools prefix, rewrites
+  // everything after). The real turns themselves bust at messages[1] every turn
+  // in this regime, so no warmup can help. Suppress warming until real turns stop
+  // rewriting the prefix (the EMA decays below the threshold) — then warmups land
+  // as clean 100% refreshes. Applies to ALL paths, including forced
+  // /lore:warm:keep, since warming a churning prefix never pays off. Independent
+  // of the circuit breaker (which trips on uncached WRITES, a lagging signal).
+  if (getPrefixChurnRate(state.sessionID) >= PREFIX_CHURN_WARM_BLOCK) {
+    log.info(
+      `cache-warmer: skip warmup for session=${state.sessionID.slice(0, 16)} — ` +
+        `distilled prefix churning (churn=${getPrefixChurnRate(state.sessionID).toFixed(2)} >= ` +
+        `${PREFIX_CHURN_WARM_BLOCK}); warmups would land as partials`,
+    );
+    return false;
+  }
 
   const elapsed = now - state.lastRequestTime;
   const { ttlMs, warmupMarginMs, cacheReadCostPerMTok, cacheMissCostPerMTok } =
@@ -1151,19 +1139,11 @@ export function shouldWarm(
     );
     const cyclesSpent = state.warmup?.warmupCount ?? 0;
 
-    // Write-efficiency guard: stop warming a large/growing session whose
-    // full-body warms refresh only a tiny stable prefix (chronically low
-    // cacheRead/(read+write)). Independent of the return-rate guard above.
-    // 🔴 Gated on `cyclesSpent >= 1`: the FIRST warmup of every break
-    // (cyclesSpent === 0) must ALWAYS be funded — it is the irreducible probe
-    // that REFRESHES writeEfficiencySamples. writeEfficiencySamples is lifetime/
-    // durable (not reset per-break, persists across restart), so blocking the
-    // first probe on stale samples would permanently lock out a session whose
-    // prefix has since re-stabilized (it could never record a fresh, higher
-    // sample). Matches the evidence-gate invariant below.
-    if (cyclesSpent >= 1 && warmupWriteEfficiencyTooLow(state.warmup)) {
-      return false;
-    }
+    // (Write-efficiency averaging guard removed — superseded by the prefix-churn
+    // gate at the top of shouldWarm, which predicts partials from the FREE
+    // real-turn prefix-rewrite signal instead of paying a partial warmup to
+    // learn. Any residual partial-while-alive is now a circuit-breaker DEFECT,
+    // not a tolerated cost.)
 
     // 🔴 Evidence gate (Bug C): ALWAYS fund the first warmup of a break
     // (cyclesSpent === 0 — the probe that learns if this slow tool returns
@@ -1336,10 +1316,8 @@ export function shouldWarm(
     const hitRate = (state.warmup?.warmupHits ?? 0) / lifetime;
     if (hitRate < MIN_SESSION_HIT_RATE) return false;
   }
-  // Write-efficiency guard: stop warming a large/growing session whose
-  // full-body warms refresh only a tiny stable prefix (chronically low
-  // cacheRead/(read+write)). Independent of the return-rate guard above.
-  if (warmupWriteEfficiencyTooLow(state.warmup)) return false;
+  // (Write-efficiency averaging guard removed — superseded by the prefix-churn
+  // gate at the top of shouldWarm. See note in the tool-call path above.)
 
   // Read the unified strategy (stored by the eval block above). When confident,
   // this is the PRIMARY warm/no-warm decision (PR2b flip): `hold-warm` → warm,
@@ -1605,6 +1583,8 @@ export function computeWarmingSnapshot(
       notWarmingReason = "Warming disabled in config";
     } else if (!state.cacheAnalytics.lastRequestBody) {
       notWarmingReason = "No stored request body";
+    } else if (getPrefixChurnRate(state.sessionID) >= PREFIX_CHURN_WARM_BLOCK) {
+      notWarmingReason = `Distilled prefix churning (churn=${getPrefixChurnRate(state.sessionID).toFixed(2)} >= ${PREFIX_CHURN_WARM_BLOCK}) — warmups would land as partials`;
     } else if (!profile) {
       notWarmingReason = "No warming profile (non-Anthropic or unknown model)";
     } else if (state.warmup?.forceKeepWarm) {
@@ -1643,13 +1623,6 @@ export function computeWarmingSnapshot(
           100
         ).toFixed(0);
         notWarmingReason = `Tool call: session hit rate too low (${hitRate}% < ${(MIN_SESSION_HIT_RATE * 100).toFixed(0)}%)`;
-      } else if (
-        // Mirror shouldWarm: the efficiency gate skips the first probe of a
-        // break (cyclesSpent===0), so the snapshot must too.
-        (state.warmup?.warmupCount ?? 0) >= 1 &&
-        warmupWriteEfficiencyTooLow(state.warmup)
-      ) {
-        notWarmingReason = warmupWriteEfficiencyReason(state.warmup);
       } else if (
         (state.warmup?.warmupCount ?? 0) >= 1 &&
         (state.warmup?.warmupHits ?? 0) < TOOL_CALL_MIN_HITS_FOR_CONTINUATION
@@ -1695,8 +1668,6 @@ export function computeWarmingSnapshot(
         100
       ).toFixed(0);
       notWarmingReason = `Session hit rate too low (${hitRate}% < ${(MIN_SESSION_HIT_RATE * 100).toFixed(0)}% after ${state.warmup?.totalWarmups} warmups)`;
-    } else if (warmupWriteEfficiencyTooLow(state.warmup)) {
-      notWarmingReason = warmupWriteEfficiencyReason(state.warmup);
     } else if (isFirstWindow && idleMs < ttlMs - warmupMarginMs) {
       notWarmingReason = "Cache still fresh";
     } else if (pReturns <= thresholdVal) {
@@ -1963,12 +1934,25 @@ export async function executeWarmup(
           `input=${totalInput} cacheRead=${cacheReadTokens} hit=${hitRate} breakpoints=${breakpoints} cost=${costStr}`,
       );
     } else if (cacheReadTokens > 0 && cacheCreationTokens > 0) {
-      // Partial hit — some breakpoints read, some written (e.g. conversation
-      // breakpoint expired but system/tools still cached). This is fine.
-      log.info(
+      // Partial — read the stable prefix but rewrote the rest. On an idle replay
+      // of the stored body this should NOT happen: a healthy warmup is 100%
+      // read. A partial while the cache should still be alive is a body-divergence
+      // DEFECT (here, almost always the distilled prefix churning) — NOT "fine".
+      // checkCircuitBreaker (below) treats it as a failure when cacheLikelyAlive.
+      const ageSec =
+        lastCacheTouch > 0
+          ? Math.round((Date.now() - lastCacheTouch) / 1000)
+          : -1;
+      const logFn = cacheLikelyAlive ? log.warn : log.info;
+      logFn(
         `cache-warmer: ~ partial session=${sid} ` +
           `input=${totalInput} cacheRead=${cacheReadTokens} cacheWrite=${cacheCreationTokens} ` +
-          `hit=${hitRate} breakpoints=${breakpoints} cost=${costStr}`,
+          `hit=${hitRate} breakpoints=${breakpoints} cost=${costStr} ` +
+          `cacheLikelyAlive=${cacheLikelyAlive} ageSinceCacheTouch=${ageSec}s` +
+          (cacheLikelyAlive
+            ? " — DIVERGENCE: cache should have been live but warmup only partially " +
+              "matched (warmup body ≠ cached prefix; usually distilled-prefix churn)"
+            : " — partial expired-cache re-prime (some breakpoints aged out)"),
       );
     } else {
       // cacheRead=0: the warmup wrote a fresh cache instead of refreshing an
@@ -2036,23 +2020,10 @@ export async function executeWarmup(
     // attribution to prevent phantom savings.
     state.warmup.lastWarmupRefreshTokens = cacheReadTokens;
 
-    // Record this warmup's cache-WRITE efficiency = read / (read + write) into
-    // a bounded rolling window. A chronically low average means the full-body
-    // warm is mostly re-writing a prefix that won't survive to the next real
-    // turn (large/growing session); shouldWarm uses it to stop wasteful warming.
-    // Skip when the denominator is 0 (uncached/error — no signal).
-    if (cacheReadTokens + cacheCreationTokens > 0) {
-      const efficiency =
-        cacheReadTokens / (cacheReadTokens + cacheCreationTokens);
-      const samples = state.warmup.writeEfficiencySamples ?? [];
-      samples.push(efficiency);
-      if (samples.length > WRITE_EFFICIENCY_WINDOW) {
-        samples.splice(0, samples.length - WRITE_EFFICIENCY_WINDOW);
-      }
-      state.warmup.writeEfficiencySamples = samples;
-    }
-
-    // Check circuit breaker for this (session, model, upstream) bucket.
+    // Check circuit breaker for this (session, model, upstream) bucket. A
+    // partial OR uncached write while the cache should have been alive is a
+    // divergence DEFECT (all-or-nothing): it trips the breaker after
+    // CIRCUIT_BREAKER_MAX_FAILURES, and only a clean 100% refresh clears it.
     checkCircuitBreaker(result, breakerBucket, cacheLikelyAlive);
 
     // Clear worker-health failure state on successful warmup.

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -2621,9 +2621,6 @@ function getOrCreateSession(
         if ((state.warmup.totalWarmups ?? 0) === 0) {
           state.warmup.lastWarmupAt = 0;
           state.warmup.lastWarmupRefreshTokens = 0;
-          // Scrub write-efficiency samples too — they must never bleed across a
-          // session-identity change (inherited blob), same as refresh tokens.
-          state.warmup.writeEfficiencySamples = [];
         }
       } catch {
         log.warn(

--- a/packages/gateway/src/translate/types.ts
+++ b/packages/gateway/src/translate/types.ts
@@ -620,21 +620,6 @@ export type WarmupState = {
    * attribution to prevent phantom savings.
    */
   lastWarmupRefreshTokens?: number;
-  /**
-   * Rolling window (FIFO — oldest evicted from the front, capped at
-   * WRITE_EFFICIENCY_WINDOW) of per-warmup cache-WRITE efficiency =
-   * cacheRead / (cacheRead + cacheWrite)
-   * from each warmup's own response usage. This is the fraction of the warmed
-   * prefix that was already cached (cheap read) vs freshly written (expensive).
-   *
-   * 🔴 Distinct from `warmupHits/totalWarmups` (USER-RETURN probability): a
-   * large, actively-growing session reliably returns (return-rate ~1.0) yet
-   * each full-body warm writes ~550K to refresh only the ~37K stable prefix
-   * (efficiency ~6%) — pure waste the return-rate guard cannot see. shouldWarm
-   * stops warming when this stays chronically low. Scrubbed on session-identity
-   * change alongside lastWarmupRefreshTokens (no cross-session bleed).
-   */
-  writeEfficiencySamples?: number[];
 };
 
 /** Result from a warmup request — used for circuit breaker and metrics. */

--- a/packages/gateway/test/cache-stability.e2e.test.ts
+++ b/packages/gateway/test/cache-stability.e2e.test.ts
@@ -1597,15 +1597,21 @@ describe("cache stability (e2e)", () => {
         JSON.stringify({ budget: { maxLayer0Tokens: 40000 } }),
       );
 
-      // Large messages so the raw window overflows rawBudget and the gradient
-      // pins a layer-1 SUB-window at the ceiling. Each message ≈ 8K tokens
-      // (~24K chars), so a single user+assistant pair (~16K tokens) is a large
-      // fraction of rawBudget — enough that one turn's growth trips the pin's
-      // 15% hysteresis on its own. Pre-fix that forces a re-pin at the ceiling
-      // and a boundary advance EVERY turn; the fix evicts a chunk so the
-      // boundary holds for many turns between steps.
+      // A large BASE history (forces compression to layer 1 via the 40K cost
+      // cap) plus SMALL per-turn messages. Decoupling base size from per-turn
+      // growth is deliberate: the raw-window pin's chunked eviction can only be
+      // meaningfully tested when one turn's growth is a MODERATE fraction of the
+      // eviction chunk (~0.4 × rawBudget) — so the boundary holds for a few turns
+      // then advances in a step. Sized for the scale-correct budgets (Part B:
+      // body budgets divide by BODY_TOKEN_RATIO, so rawBudget is ~1.68× smaller
+      // than the pre-fix value; the old fixture used 8K-token messages whose
+      // single-pair growth (~16K) exceeded the post-fix eviction chunk, forcing a
+      // re-pin every turn — that was a knife-edge calibration to the old scale,
+      // not a real per-turn-march regression).
       const big = (label: string) =>
         `${label} ${"lorem ipsum dolor ".repeat(1_350)}`;
+      const small = (label: string) =>
+        `${label} ${"lorem ipsum dolor ".repeat(180)}`;
       const TOTAL_TURNS = 14;
       const BASE_PAIRS = 14; // ~28 base messages × ~8K ≈ 224K → well over budget
 
@@ -1613,11 +1619,12 @@ describe("cache stability (e2e)", () => {
         makeFixtureEntry({
           seq: i,
           requestMessages: [],
-          responseText: big(`assistant reply ${i}`),
+          responseText: small(`assistant reply ${i}`),
           model: DEFAULT_MODEL,
-          // Realistic growing large input so calibrate() tracks the true body
-          // size and the gradient pins a real layer-1 sub-window.
-          inputTokens: 120_000 + i * 8_000,
+          // The layer-1 window is pinned (bounded by rawBudget), so the real
+          // input is ~constant turn-over-turn — a small drift keeps calibrate()
+          // tracking a stable overhead without collapsing usable.
+          inputTokens: 120_000 + i * 1_000,
           outputTokens: 1_200,
         }),
       );
@@ -1653,7 +1660,7 @@ describe("cache stability (e2e)", () => {
       const observedLayers: number[] = [];
       for (let turn = 0; turn < TOTAL_TURNS; turn++) {
         history.push(
-          toGatewayMessage(textTurn("user", big(`turnuser${turn}end`))),
+          toGatewayMessage(textTurn("user", small(`turnuser${turn}end`))),
         );
         const resp = await harness.chat(
           makeGatewayBody(history),
@@ -1663,7 +1670,7 @@ describe("cache stability (e2e)", () => {
         expect(resp.status).toBe(200);
         await resp.json();
         history.push(
-          toGatewayMessage(textTurn("assistant", big(`turnasst${turn}end`))),
+          toGatewayMessage(textTurn("assistant", small(`turnasst${turn}end`))),
         );
 
         if (turn === 0) {
@@ -1727,6 +1734,16 @@ describe("cache stability (e2e)", () => {
         `raw-window start boundary marched on every steady-state turn — ${detail}. ` +
           `The layer-1 pin must hold the boundary on at least some turns, evicting ` +
           `only in occasional chunks (regression: per-turn window march).`,
+      ).toBeGreaterThan(0);
+      // Non-vacuity guard: the window must ALSO advance at least once over the
+      // run, proving chunked eviction genuinely happens (the pin is not simply
+      // frozen because the messages never fill it). A frozen window that never
+      // evicts would grow unbounded — so this guards the opposite failure mode
+      // too. Together with `holds > 0`, this asserts true CHUNKED eviction.
+      expect(
+        advances,
+        `raw-window never advanced — the test is not exercising eviction at all ` +
+          `(vacuous): ${detail}`,
       ).toBeGreaterThan(0);
     } finally {
       if (prevIdleTimeout === undefined) delete process.env.LORE_IDLE_TIMEOUT;

--- a/packages/gateway/test/cache-warmer.test.ts
+++ b/packages/gateway/test/cache-warmer.test.ts
@@ -9,10 +9,6 @@ import {
   buildAnthropicProfile,
   resolveProfile,
   shouldWarm,
-  warmupWriteEfficiencyTooLow,
-  MIN_WRITE_EFFICIENCY,
-  MIN_WARMUPS_FOR_EFFICIENCY_CHECK,
-  WRITE_EFFICIENCY_WINDOW,
   checkCircuitBreaker,
   isCircuitBreakerTripped,
   getCircuitBreakerStatus,
@@ -56,6 +52,8 @@ import {
   setCacheSizeSnapshot,
   setCachePricing,
   evictSession,
+  setPrefixChurnForTest,
+  PREFIX_CHURN_WARM_BLOCK,
 } from "@loreai/core";
 import { decideSkipCompact } from "../src/pipeline";
 // ---------------------------------------------------------------------------
@@ -644,7 +642,7 @@ describe("circuit breaker", () => {
     expect(getCircuitBreakerStatus(BUCKET).failures).toBe(0);
   });
 
-  test("partial hits (read > 0 + creation > 0) reset counter", () => {
+  test("partial hits (read > 0 + creation > 0) do NOT reset — they are failures (all-or-nothing)", () => {
     const bad = makeWarmupResult({
       cacheReadTokens: 0,
       cacheCreationTokens: 50000,
@@ -654,9 +652,27 @@ describe("circuit breaker", () => {
       cacheCreationTokens: 20000,
     });
 
+    // A partial is a body-divergence DEFECT, not a recovery: it must NOT clear
+    // accumulated failures. Two uncached + one partial = 3 failures → tripped.
+    checkCircuitBreaker(bad, BUCKET, true); // failure 1
+    checkCircuitBreaker(bad, BUCKET, true); // failure 2
+    checkCircuitBreaker(partial, BUCKET, true); // failure 3 (NOT a reset)
+    expect(isCircuitBreakerTripped(BUCKET)).toBe(true);
+  });
+
+  test("a clean 100% refresh (read > 0, creation === 0) DOES reset the counter", () => {
+    const bad = makeWarmupResult({
+      cacheReadTokens: 0,
+      cacheCreationTokens: 50000,
+    });
+    const refresh = makeWarmupResult({
+      cacheReadTokens: 168000,
+      cacheCreationTokens: 0,
+    });
+
     checkCircuitBreaker(bad, BUCKET, true); // 1
     checkCircuitBreaker(bad, BUCKET, true); // 2
-    checkCircuitBreaker(partial, BUCKET, true); // has reads → reset
+    checkCircuitBreaker(refresh, BUCKET, true); // clean refresh → reset to 0
     checkCircuitBreaker(bad, BUCKET, true); // 1
     expect(isCircuitBreakerTripped(BUCKET)).toBe(false);
   });
@@ -907,54 +923,112 @@ describe("circuit breaker persistence", () => {
 // shouldWarm decision function
 // ---------------------------------------------------------------------------
 
-describe("warmupWriteEfficiencyTooLow", () => {
-  test("false when fewer than the minimum samples (insufficient evidence)", () => {
-    const samples = Array(MIN_WARMUPS_FOR_EFFICIENCY_CHECK - 1).fill(0.01);
+describe("circuit breaker — all-or-nothing divergence (partial counts as failure)", () => {
+  const alive = true;
+  beforeEach(() => resetCircuitBreaker());
+
+  test("a PARTIAL warmup while the cache is alive counts as a failure (not 'fine')", () => {
+    const bucket = "cb-partial-alive";
+    // 3 partials (cacheRead>0 AND cacheCreation>0) → tripped. Under the old
+    // model these hit the recovery branch and were ignored.
+    for (let i = 0; i < 2; i++) {
+      expect(
+        checkCircuitBreaker(
+          { ok: true, cacheReadTokens: 40_000, cacheCreationTokens: 100_000 },
+          bucket,
+          alive,
+        ),
+      ).toBe(false);
+    }
     expect(
-      warmupWriteEfficiencyTooLow({
-        lastWarmupAt: 0,
-        warmupCount: 0,
-        totalWarmups: samples.length,
-        warmupHits: 0,
-        disabled: false,
-        writeEfficiencySamples: samples,
-      }),
-    ).toBe(false);
+      checkCircuitBreaker(
+        { ok: true, cacheReadTokens: 40_000, cacheCreationTokens: 100_000 },
+        bucket,
+        alive,
+      ),
+    ).toBe(true); // 3rd → tripped
+    expect(isCircuitBreakerTripped(bucket)).toBe(true);
   });
 
-  test("true when avg efficiency is below the threshold over enough samples", () => {
+  test("a full UNCACHED warmup while alive also counts (read=0)", () => {
+    const bucket = "cb-uncached-alive";
+    for (let i = 0; i < 3; i++) {
+      checkCircuitBreaker(
+        { ok: true, cacheReadTokens: 0, cacheCreationTokens: 200_000 },
+        bucket,
+        alive,
+      );
+    }
+    expect(isCircuitBreakerTripped(bucket)).toBe(true);
+  });
+
+  test("a PARTIAL does NOT clear accumulated failures (only a clean refresh does)", () => {
+    const bucket = "cb-partial-no-clear";
+    // 2 partials → 2 failures (not tripped)
+    checkCircuitBreaker(
+      { ok: true, cacheReadTokens: 30_000, cacheCreationTokens: 90_000 },
+      bucket,
+      alive,
+    );
+    checkCircuitBreaker(
+      { ok: true, cacheReadTokens: 30_000, cacheCreationTokens: 90_000 },
+      bucket,
+      alive,
+    );
+    // Another partial must NOT reset; it is the 3rd failure → trips.
     expect(
-      warmupWriteEfficiencyTooLow({
-        lastWarmupAt: 0,
-        warmupCount: 0,
-        totalWarmups: 3,
-        warmupHits: 0,
-        disabled: false,
-        writeEfficiencySamples: [0.06, 0.06, 0.06],
-      }),
+      checkCircuitBreaker(
+        { ok: true, cacheReadTokens: 30_000, cacheCreationTokens: 90_000 },
+        bucket,
+        alive,
+      ),
     ).toBe(true);
   });
 
-  test("false when avg efficiency is at/above the threshold", () => {
-    const atThreshold = MIN_WRITE_EFFICIENCY + 0.01;
+  test("a CLEAN 100% refresh (write=0) clears accumulated failures", () => {
+    const bucket = "cb-clean-clears";
+    checkCircuitBreaker(
+      { ok: true, cacheReadTokens: 30_000, cacheCreationTokens: 90_000 },
+      bucket,
+      alive,
+    );
+    checkCircuitBreaker(
+      { ok: true, cacheReadTokens: 30_000, cacheCreationTokens: 90_000 },
+      bucket,
+      alive,
+    );
+    // Clean refresh clears the 2 accumulated failures.
+    checkCircuitBreaker(
+      { ok: true, cacheReadTokens: 150_000, cacheCreationTokens: 0 },
+      bucket,
+      alive,
+    );
+    // Two more partials must NOT trip (counter was reset to 0).
+    checkCircuitBreaker(
+      { ok: true, cacheReadTokens: 30_000, cacheCreationTokens: 90_000 },
+      bucket,
+      alive,
+    );
     expect(
-      warmupWriteEfficiencyTooLow({
-        lastWarmupAt: 0,
-        warmupCount: 0,
-        totalWarmups: 3,
-        warmupHits: 0,
-        disabled: false,
-        writeEfficiencySamples: [atThreshold, atThreshold, atThreshold],
-      }),
+      checkCircuitBreaker(
+        { ok: true, cacheReadTokens: 30_000, cacheCreationTokens: 90_000 },
+        bucket,
+        alive,
+      ),
     ).toBe(false);
+    expect(isCircuitBreakerTripped(bucket)).toBe(false);
   });
 
-  test("false for undefined warmup / no samples", () => {
-    expect(warmupWriteEfficiencyTooLow(undefined)).toBe(false);
-  });
-
-  test("window size constant is positive (rolling window bounded)", () => {
-    expect(WRITE_EFFICIENCY_WINDOW).toBeGreaterThan(0);
+  test("a write while the cache had EXPIRED (!cacheLikelyAlive) is neutral", () => {
+    const bucket = "cb-expired-neutral";
+    for (let i = 0; i < 5; i++) {
+      checkCircuitBreaker(
+        { ok: true, cacheReadTokens: 0, cacheCreationTokens: 200_000 },
+        bucket,
+        /* cacheLikelyAlive */ false,
+      );
+    }
+    expect(isCircuitBreakerTripped(bucket)).toBe(false);
   });
 });
 
@@ -1053,13 +1127,16 @@ describe("shouldWarm", () => {
     expect(shouldWarm(state, profile, hist, now)).toBe(false);
   });
 
-  test("returns FALSE when write-efficiency is chronically low, even with a perfect return rate", () => {
-    // Regression: a large/growing session reliably returns (return-rate ~1.0,
-    // passes MIN_SESSION_HIT_RATE) but each full-body warm refreshes only the
-    // ~37K stable prefix (efficiency ~6%) while writing ~550K — pure waste. The
-    // return-rate guard cannot see this; the write-efficiency guard must block.
+  test("returns FALSE when the distilled prefix is churning, even with a perfect return rate", () => {
+    // Root cause: the distilled prefix (messages[1]) is rewritten by
+    // meta-distillation nearly every turn, so a warmup that replays the stored
+    // body lands as a partial (refreshes a prefix the next real turn replaces).
+    // The session reliably returns (return-rate ~1.0, passes MIN_SESSION_HIT_RATE)
+    // yet warming is pure waste — the prefix-churn gate must block it.
+    const sid = "churn-gate-block-session";
     const now = Date.now();
     const state = makeSessionState({
+      sessionID: sid,
       lastRequestTime: now - 270_000,
       warmup: {
         lastWarmupAt: 0,
@@ -1067,7 +1144,6 @@ describe("shouldWarm", () => {
         totalWarmups: 10,
         warmupHits: 10, // perfect RETURN rate — return-guard would pass
         disabled: false,
-        writeEfficiencySamples: [0.06, 0.06, 0.06, 0.08, 0.06], // ~6% WRITE efficiency
       },
       cacheAnalytics: {
         ...makeCacheAnalytics(),
@@ -1076,16 +1152,20 @@ describe("shouldWarm", () => {
         ),
       },
     });
+    setPrefixChurnForTest(sid, PREFIX_CHURN_WARM_BLOCK + 0.1);
     const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
     const hist = createHistogram();
     for (let i = 0; i < 50; i++) recordGap(hist, 360_000);
 
     expect(shouldWarm(state, profile, hist, now)).toBe(false);
+    setPrefixChurnForTest(sid, 0); // cleanup (shared process-global core state)
   });
 
-  test("returns TRUE when write-efficiency is healthy (gate does not over-block)", () => {
+  test("returns TRUE when the prefix is stable (churn below threshold)", () => {
+    const sid = "churn-gate-allow-session";
     const now = Date.now();
     const state = makeSessionState({
+      sessionID: sid,
       lastRequestTime: now - 270_000,
       warmup: {
         lastWarmupAt: 0,
@@ -1093,7 +1173,6 @@ describe("shouldWarm", () => {
         totalWarmups: 10,
         warmupHits: 10,
         disabled: false,
-        writeEfficiencySamples: [0.9, 0.85, 0.95, 0.88, 0.92], // healthy
       },
       cacheAnalytics: {
         ...makeCacheAnalytics(),
@@ -1102,11 +1181,13 @@ describe("shouldWarm", () => {
         ),
       },
     });
+    setPrefixChurnForTest(sid, PREFIX_CHURN_WARM_BLOCK - 0.1);
     const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
     const hist = createHistogram();
     for (let i = 0; i < 50; i++) recordGap(hist, 360_000);
 
     expect(shouldWarm(state, profile, hist, now)).toBe(true);
+    setPrefixChurnForTest(sid, 0); // cleanup
   });
 
   test("returns false when session has too few turns", () => {
@@ -2286,44 +2367,27 @@ describe("shouldWarm tool-call warming", () => {
     expect(shouldWarm(state, profile, hist, now)).toBe(false);
   });
 
-  test("ALWAYS funds the FIRST warmup of a break (cyclesSpent=0) even when write-efficiency is chronically low", () => {
-    // 🔴 The first probe of every break refreshes writeEfficiencySamples (which
-    // is lifetime/durable). Blocking it on stale low samples would permanently
-    // lock the session out (it could never record a fresh sample). The
-    // efficiency gate must be skipped when warmupCount===0.
+  test("BLOCKS tool-call warming when the distilled prefix is churning (gate applies to ALL paths)", () => {
+    // The prefix-churn gate sits at the top of shouldWarm, so it suppresses even
+    // the tool-call fast path (which otherwise bypasses survival analysis).
+    const sid = "churn-gate-toolcall-session";
     const now = Date.now();
     const state = makeToolCallState({
+      sessionID: sid,
       warmup: {
         lastWarmupAt: 0,
-        warmupCount: 0, // first probe of THIS break
+        warmupCount: 0, // first probe of the break — normally funded
         totalWarmups: 10,
         warmupHits: 10,
         disabled: false,
-        writeEfficiencySamples: [0.06, 0.06, 0.06, 0.06, 0.06], // chronically low
       },
     });
-    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
-    const hist = createHistogram();
-
-    expect(shouldWarm(state, profile, hist, now)).toBe(true);
-  });
-
-  test("BLOCKS a continuation warmup (cyclesSpent>=1) when write-efficiency is chronically low", () => {
-    const now = Date.now();
-    const state = makeToolCallState({
-      warmup: {
-        lastWarmupAt: 0,
-        warmupCount: 1, // continuation within the break
-        totalWarmups: 10,
-        warmupHits: 10,
-        disabled: false,
-        writeEfficiencySamples: [0.06, 0.06, 0.06, 0.06, 0.06],
-      },
-    });
+    setPrefixChurnForTest(sid, PREFIX_CHURN_WARM_BLOCK + 0.1);
     const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
     const hist = createHistogram();
 
     expect(shouldWarm(state, profile, hist, now)).toBe(false);
+    setPrefixChurnForTest(sid, 0); // cleanup
   });
 
   test("returns false after MAX_TOOL_CALL_WARMING_MS exceeded", () => {
@@ -2590,22 +2654,25 @@ describe("shouldWarm tool-call warming", () => {
     expect(snap.notWarmingReason).toBeNull();
   });
 
-  test("snapshot reports the write-efficiency reason when chronically low (continuation)", () => {
+  test("snapshot reports the prefix-churn reason when the prefix is churning", () => {
+    const sid = "churn-gate-snapshot-session";
     const now = Date.now();
     const state = makeToolCallState({
+      sessionID: sid,
       lastRequestTime: now - 270_000,
       warmup: {
         lastWarmupAt: now - 270_000, // past cooldown
-        warmupCount: 1, // continuation — past the first-probe carve-out
+        warmupCount: 1,
         totalWarmups: 10,
         warmupHits: 10, // clears the return-rate guard
         disabled: false,
-        writeEfficiencySamples: [0.06, 0.06, 0.06, 0.06, 0.06],
       },
     });
+    setPrefixChurnForTest(sid, PREFIX_CHURN_WARM_BLOCK + 0.1);
     const snap = computeWarmingSnapshot(state, now);
     expect(snap.shouldWarmNow).toBe(false);
-    expect(snap.notWarmingReason).toContain("Write efficiency too low");
+    expect(snap.notWarmingReason).toContain("Distilled prefix churning");
+    setPrefixChurnForTest(sid, 0); // cleanup
   });
 
   test("Bug C: snapshot falls through to cycle-cap reason past the gate branch", () => {

--- a/packages/gateway/test/warmup-execute.test.ts
+++ b/packages/gateway/test/warmup-execute.test.ts
@@ -23,7 +23,9 @@ vi.mock("../src/fetch", () => ({
 import {
   executeWarmup,
   buildAnthropicProfile,
-  WRITE_EFFICIENCY_WINDOW,
+  isCircuitBreakerTripped,
+  warmupBucketKey,
+  resetCircuitBreaker,
 } from "../src/cache-warmer";
 import { setSessionAuth, _resetAuthForTest } from "../src/auth";
 import { clearAllCosts } from "../src/cost-tracker";
@@ -151,69 +153,57 @@ describe("executeWarmup → lastWarmupRefreshTokens (Bug B producer)", () => {
   });
 });
 
-describe("executeWarmup → writeEfficiencySamples (efficiency gate producer)", () => {
-  test("records read/(read+write) efficiency on a partial warmup", async () => {
-    globalThis.fetch = fetchReturningUsage({
-      input_tokens: 5,
-      cache_read_input_tokens: 30_000,
-      cache_creation_input_tokens: 470_000, // 30k/(30k+470k) = 0.06
-    }) as unknown as typeof fetch;
+describe("executeWarmup → all-or-nothing circuit breaker (partial-while-alive is a DEFECT)", () => {
+  beforeEach(() => resetCircuitBreaker());
 
-    const state = makeState();
+  const partialUsage = {
+    input_tokens: 5,
+    cache_read_input_tokens: 30_000,
+    cache_creation_input_tokens: 470_000, // partial: read>0 AND write>0
+  };
+  const refreshUsage = {
+    input_tokens: 5,
+    cache_read_input_tokens: 168_000,
+    cache_creation_input_tokens: 0, // clean 100% refresh
+  };
+
+  test("3 partial-while-alive warmups trip the breaker (a partial is NOT 'fine')", async () => {
+    const state = makeState(); // lastRequestTime 4.5min ago → cacheLikelyAlive
     const profile = buildAnthropicProfile(MODEL, "5m");
-    await executeWarmup(state, profile);
+    const bucket = warmupBucketKey(state);
 
-    const samples = state.warmup?.writeEfficiencySamples ?? [];
-    expect(samples).toHaveLength(1);
-    expect(samples[0]).toBeCloseTo(0.06, 2);
+    globalThis.fetch = fetchReturningUsage(
+      partialUsage,
+    ) as unknown as typeof fetch;
+    await executeWarmup(state, profile);
+    await executeWarmup(state, profile);
+    expect(isCircuitBreakerTripped(bucket)).toBe(false); // 2 failures
+    await executeWarmup(state, profile);
+    expect(isCircuitBreakerTripped(bucket)).toBe(true); // 3rd → tripped
   });
 
-  test("records 1.0 on a perfect refresh (cacheWrite=0) — keeps the average healthy", async () => {
-    globalThis.fetch = fetchReturningUsage({
-      input_tokens: 5,
-      cache_read_input_tokens: 168_000,
-      cache_creation_input_tokens: 0,
-    }) as unknown as typeof fetch;
-
+  test("a clean 100% refresh clears accumulated partial failures", async () => {
     const state = makeState();
     const profile = buildAnthropicProfile(MODEL, "5m");
+    const bucket = warmupBucketKey(state);
+
+    globalThis.fetch = fetchReturningUsage(
+      partialUsage,
+    ) as unknown as typeof fetch;
+    await executeWarmup(state, profile); // failure 1
+    await executeWarmup(state, profile); // failure 2
+
+    globalThis.fetch = fetchReturningUsage(
+      refreshUsage,
+    ) as unknown as typeof fetch;
+    await executeWarmup(state, profile); // clean refresh → clears
+
+    globalThis.fetch = fetchReturningUsage(
+      partialUsage,
+    ) as unknown as typeof fetch;
     await executeWarmup(state, profile);
-
-    const samples = state.warmup?.writeEfficiencySamples ?? [];
-    expect(samples).toHaveLength(1);
-    expect(samples[0]).toBe(1);
-  });
-
-  test("does NOT record a sample when read+write is 0 (no signal)", async () => {
-    globalThis.fetch = fetchReturningUsage({
-      input_tokens: 5,
-      cache_read_input_tokens: 0,
-      cache_creation_input_tokens: 0,
-    }) as unknown as typeof fetch;
-
-    const state = makeState();
-    const profile = buildAnthropicProfile(MODEL, "5m");
     await executeWarmup(state, profile);
-
-    expect(state.warmup?.writeEfficiencySamples ?? []).toHaveLength(0);
-  });
-
-  test("rolling window is capped at WRITE_EFFICIENCY_WINDOW (oldest evicted)", async () => {
-    globalThis.fetch = fetchReturningUsage({
-      input_tokens: 5,
-      cache_read_input_tokens: 30_000,
-      cache_creation_input_tokens: 470_000,
-    }) as unknown as typeof fetch;
-
-    const profile = buildAnthropicProfile(MODEL, "5m");
-    const state = makeState();
-    // Fire more warmups than the window size; cooldown is bypassed because
-    // executeWarmup itself does not gate on cooldown (shouldWarm does).
-    for (let i = 0; i < WRITE_EFFICIENCY_WINDOW + 3; i++) {
-      await executeWarmup(state, profile);
-    }
-    expect(state.warmup?.writeEfficiencySamples ?? []).toHaveLength(
-      WRITE_EFFICIENCY_WINDOW,
-    );
+    // Only 2 failures since the clear → not tripped.
+    expect(isCircuitBreakerTripped(bucket)).toBe(false);
   });
 });


### PR DESCRIPTION
## Problem

Production sessions whose distilled conversation prefix (`messages[1]`) is rewritten by meta-distillation **every turn** were burning money two ways (from `journalctl -u opencode`):

- **Real turns** bust at `messages[1]` (`hit=30%`, `prefixMatch=42.7%`, cause `"meta-distillation rewrite"`) — rewriting ~100–150K tokens/turn at cache-write price.
- **Warmups** land as **partials** — a warmup replays the stored body during idle and refreshes a prefix the very next real turn replaces (reading only the stable ~40–53K system+tools prefix). The warmup `cacheRead` matched the real-turn stable-prefix read **exactly** per session (48836 / 44250 / 53412 / …), proving the warmups faithfully mirror a real-turn problem — they are not independently buggy. Cost: ~$0.5–3 per warmup, many/hour, across ~6 concurrent sessions.

**Root cause (confirmed):** the chars/3 token estimator undercounts real tokens by ~1.68×, and `calibrate()` subtracted the *un-inflated* estimate from the *real* `actualInput`, so ~0.40·body leaked into `overhead`. For large/growing sessions that inflated `overhead` to ~125K on a 200K model, collapsed `usable` to ~25K (observed shrinking `30033→24327` turn-over-turn on session `1I2KAbo2`), and forced the session to **Layer 4**, where the distilled prefix is re-rendered every turn. (The warm-freeze `distilledPrefixCached` only runs at Layer 1, so it never got the chance to hold the prefix stable.)

## Fix — two parts (separate commits)

### Part A — stop warming a churning prefix + make warmups all-or-nothing
- New **free** per-real-turn signal `prefixChurnEma` (core), updated in `recordCacheUsage` from the existing `prefix-rewrite` bust cause (idle-resume does **not** count). `shouldWarm` gates on it (`>= PREFIX_CHURN_WARM_BLOCK`) at the top, covering all paths incl. forced `/lore:warm:keep`. Re-arms automatically as the EMA decays once real turns stop rewriting the prefix.
- Removed the lenient `MIN_WRITE_EFFICIENCY` (0.20 average) tolerance entirely. A healthy idle replay is **100% read / 0 write**, so any `cacheCreation > 0` while the cache was alive (partial **or** full miss) is now a **divergence defect** that counts toward the circuit breaker; only a clean 100% refresh clears it. Partials are no longer logged as "fine".

### Part B — decouple overhead from the chars/3 undercount
- `BODY_TOKEN_RATIO = 1.68`. `calibrate()` inflates the body estimate to real tokens before subtracting, so `overhead` is **true system+tools** and stays stable as the body grows → `usable` no longer collapses → sessions stay at Layer 0/1 where `distilledPrefixCached` freezes `messages[1]`.
- Body budgets (distilled/raw, post-idle, escalated stages, layer-4 tail) derive from `bodyUsable = usable / BODY_TOKEN_RATIO` so each window occupies at most `fraction × usable` **real** tokens (honoring `cfg.budget.*`).
- `fitsWithSafetyMargin` is now real-scale (`totalTokens × RATIO + overhead + ltm ≤ maxInput`) — exact, and accounts for overhead+ltm which the old `× 1.5` ignored.

**Tradeoff (accepted):** correctly-sized budgets give healthy sessions ~1.68× less raw-window pin headroom (necessary for overflow-safety; production impact modest — ~8 vs ~14 turns between chunked evictions). This trades a small increase in *occasional* `messages[N]` chunked marching for eliminating the *every-turn* `messages[1]` bust.

## Tests
- New: prefix-churn EMA (rise/decay/idle-resume/non-creating getter), all-or-nothing circuit breaker (partial-while-alive trips; clean refresh clears; expired neutral), end-to-end usable-collapse regression.
- Updated: 5 gradient tests that hard-coded the old un-inflated formulas / knife-edge scale; the `cache-stability.e2e` raw-window test rescaled to still assert genuine **chunked** eviction (holds **and** advances).
- Mutation-tested: reverting the calibrate inflation kills 3 tests; reverting the budget `/RATIO` makes the over-ceiling test escalate to Layer 4 (`layer === 2` catches it). Full core (2085) + gateway (2213) green; typecheck + lint clean.

## Review
Independent adversarial review surfaced two SHOULD-FIX (S1 vacuous over-ceiling assertion, S2 one-off-rewrite blocking at the threshold boundary) — both fixed in the third commit and re-verified.