### PR TITLE
fix(ltm): purge knowledge_session_injections on knowledge/session delete (#996)

### DIFF
--- a/packages/core/src/data.ts
+++ b/packages/core/src/data.ts
@@ -1180,6 +1180,17 @@ export function moveSessions(
       )
       .run(toId, fromProjectId, ...allIds);
 
+    // Outcome-reward injection log (#497) is keyed on session_id and scoped by
+    // project_id; creditSessionOutcome filters on the session's CURRENT project,
+    // so the rows must follow the session to the target or its credits are
+    // silently dropped (and the rows orphan if the source project is later
+    // deleted). Mirror the per-session re-point above. (#996)
+    database
+      .query(
+        `UPDATE knowledge_session_injections SET project_id = ? WHERE project_id = ? AND session_id IN (${placeholders})`,
+      )
+      .run(toId, fromProjectId, ...allIds);
+
     // Re-bind session_state to the target project path (confident, not provisional).
     database
       .query(

--- a/packages/core/src/data.ts
+++ b/packages/core/src/data.ts
@@ -571,6 +571,12 @@ export function clearProject(projectPath: string): ClearResult {
         )
         .run(pid);
     }
+    // Outcome-reward injection log (#497) carries a project_id column, so sweep
+    // it by project scope directly — this also reclaims any rows already
+    // orphaned by a prior delete that predates this fix (#996).
+    database
+      .query("DELETE FROM knowledge_session_injections WHERE project_id = ?")
+      .run(pid);
     database.query("DELETE FROM knowledge WHERE project_id = ?").run(pid);
     database
       .query("DELETE FROM temporal_messages WHERE project_id = ?")
@@ -694,6 +700,12 @@ export function deleteProject(projectId: string): ClearResult | null {
         )
         .run(projectId);
     }
+    // Outcome-reward injection log (#497) carries a project_id column, so sweep
+    // it by project scope directly — this also reclaims any rows already
+    // orphaned by a prior delete that predates this fix (#996).
+    database
+      .query("DELETE FROM knowledge_session_injections WHERE project_id = ?")
+      .run(projectId);
     database.query("DELETE FROM knowledge WHERE project_id = ?").run(projectId);
     database
       .query("DELETE FROM temporal_messages WHERE project_id = ?")
@@ -772,6 +784,12 @@ export function clearKnowledge(projectPath: string): number {
       )
       .run(pid);
   }
+  // Outcome-reward injection log (#497) carries a project_id column, so sweep
+  // it by project scope directly — this also reclaims any rows already orphaned
+  // by a prior delete that predates this fix (#996).
+  db()
+    .query("DELETE FROM knowledge_session_injections WHERE project_id = ?")
+    .run(pid);
   db().query("DELETE FROM knowledge WHERE project_id = ?").run(pid);
 
   invalidateProjectsCache();
@@ -894,6 +912,11 @@ export function deleteSession(
     .run(pid, sessionId);
   database
     .query("DELETE FROM session_state WHERE session_id = ?")
+    .run(sessionId);
+  // Outcome-reward injection log (#497) is keyed on session_id — purge it here
+  // or its rows orphan once the session's messages are gone (#996).
+  database
+    .query("DELETE FROM knowledge_session_injections WHERE session_id = ?")
     .run(sessionId);
 
   invalidateProjectsCache();

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -2225,6 +2225,14 @@ export function mergeProjectInternal(sourceId: string, targetId: string): void {
       targetId,
       sourceId,
     );
+    // Outcome-reward injection log (#497): carries a project_id that must follow
+    // the entries to the target, or its rows orphan once the source project row
+    // is deleted below AND crediting breaks (creditSessionOutcome queries by the
+    // session's current project). A plain UPDATE is safe — the PK is
+    // (session_id, logical_id), so re-pointing project_id can't conflict. (#996)
+    d.query(
+      "UPDATE knowledge_session_injections SET project_id = ? WHERE project_id = ?",
+    ).run(targetId, sourceId);
     // knowledge_transfers: re-point the "recalled in" foreign project. A plain
     // UPDATE would violate the composite PK when a (knowledge_id, targetId) row
     // already exists, so merge the counts via UPSERT then delete the leftover

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -587,6 +587,14 @@ export function remove(id: string, metadata?: KnowledgeMetadata) {
   for (const table of LOGICAL_ID_BOOKKEEPING_TABLES) {
     db().query(`DELETE FROM ${table} WHERE logical_id = ?`).run(logicalId);
   }
+  // Outcome-reward injection log (#497): same orphan class, but keyed on a
+  // composite (session_id, logical_id) PK + carries a project_id, so it can't
+  // ride LOGICAL_ID_BOOKKEEPING_TABLES (uniform single logical_id shape). Purge
+  // by logical_id here; the project/session bulk-delete paths sweep it by their
+  // own scope. (#996)
+  db()
+    .query("DELETE FROM knowledge_session_injections WHERE logical_id = ?")
+    .run(logicalId);
 }
 
 /** True when the entry for this logical_id was deleted (tombstoned). */

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -552,8 +552,10 @@ export function update(
  *
  * This is the LOCAL-ONLY purge registry: only add tables whose rows are pure
  * local derived state. Do NOT add synced convergent registers (e.g.
- * knowledge_meta) — a local DELETE there would diverge from tombstone semantics
- * once team sync lands.
+ * knowledge_meta) — a local DELETE there would diverge from its
+ * convergent-register sync/merge semantics (confidence LWW->merge) once team
+ * sync lands. (Note: "tombstone" elsewhere in this file means the A2 is_deleted
+ * death-cert version, not the retired knowledge_tombstones table.)
  */
 export const LOGICAL_ID_BOOKKEEPING_TABLES = [
   "knowledge_ref_validity",

--- a/packages/core/test/data-move.test.ts
+++ b/packages/core/test/data-move.test.ts
@@ -87,6 +87,19 @@ function insertKnowledge(
     .run(id, 0.8, now, now);
 }
 
+function insertInjection(
+  projectId: string,
+  sessionId: string,
+  logicalId: string,
+): void {
+  db()
+    .query(
+      `INSERT INTO knowledge_session_injections (session_id, logical_id, project_id, created_at, credited)
+       VALUES (?, ?, ?, ?, 0)`,
+    )
+    .run(sessionId, logicalId, projectId, Date.now());
+}
+
 function countInProject(table: string, projectId: string): number {
   return (
     db()
@@ -112,6 +125,7 @@ describe("moveSessions", () => {
     database.query("DELETE FROM session_prompt_deltas").run();
     database.query("DELETE FROM knowledge WHERE embedding IS NOT NULL").run();
     database.query("DELETE FROM knowledge").run();
+    database.query("DELETE FROM knowledge_session_injections").run();
     database.query("DELETE FROM session_state").run();
 
     pidA = ensureProject(PROJECT_A);
@@ -185,6 +199,21 @@ describe("moveSessions", () => {
     expect(countInProject("knowledge", pidB)).toBe(1);
     // Unlinked knowledge stayed
     expect(countInProject("knowledge", pidA)).toBe(1);
+  });
+
+  test("moves outcome-reward injection log rows with the session (#996)", () => {
+    insertMessage(pidA, SESSION_1, "msg-inj-1");
+    insertInjection(pidA, SESSION_1, "k-inj-moved");
+    insertInjection(pidA, SESSION_2, "k-inj-stay"); // other session — stays
+
+    data.moveSessions([SESSION_1], pidA, PROJECT_B);
+
+    // The moved session's injections must follow it: creditSessionOutcome filters
+    // on the session's CURRENT project, so leaving them under A silently drops the
+    // credits (and orphans the rows if A is later deleted).
+    expect(countInProject("knowledge_session_injections", pidB)).toBe(1);
+    // The unmoved session's injection stayed in A.
+    expect(countInProject("knowledge_session_injections", pidA)).toBe(1);
   });
 
   test("updates session_state project_path and provisional flag", () => {

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -764,6 +764,14 @@ describe("db", () => {
         Date.now(),
       );
 
+    // Outcome-reward injection log row scoped to the source project (#996): it
+    // must follow the entries to the target, not orphan when source is deleted.
+    db()
+      .query(
+        "INSERT INTO knowledge_session_injections (session_id, logical_id, project_id, created_at, credited) VALUES (?, ?, ?, ?, 0)",
+      )
+      .run("session-merge", crypto.randomUUID(), sourceId, Date.now());
+
     // Verify source has data
     const sourceMsgsBefore = (
       db()
@@ -806,6 +814,26 @@ describe("db", () => {
         .get(targetId) as { c: number }
     ).c;
     expect(targetKnowledge).toBe(1);
+
+    // Injection log must have moved to target — none left orphaned under source
+    // (#996). If unmoved, these rows become permanently unreachable once the
+    // source project row is deleted, and outcome-reward crediting breaks.
+    const sourceInjections = (
+      db()
+        .query(
+          "SELECT COUNT(*) as c FROM knowledge_session_injections WHERE project_id = ?",
+        )
+        .get(sourceId) as { c: number }
+    ).c;
+    expect(sourceInjections).toBe(0);
+    const targetInjections = (
+      db()
+        .query(
+          "SELECT COUNT(*) as c FROM knowledge_session_injections WHERE project_id = ?",
+        )
+        .get(targetId) as { c: number }
+    ).c;
+    expect(targetInjections).toBe(1);
 
     // Source path should be registered as alias of target
     const alias = db()

--- a/packages/core/test/ltm-injections-cleanup.test.ts
+++ b/packages/core/test/ltm-injections-cleanup.test.ts
@@ -1,0 +1,185 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import * as data from "../src/data";
+import { db, ensureProject } from "../src/db";
+import * as ltm from "../src/ltm";
+
+// #996: the outcome-reward injection log (knowledge_session_injections, #497) is
+// the same orphan-leak class the #990 fix addressed — keyed on logical_id, no FK
+// CASCADE — but it has a composite (session_id, logical_id) PK and a project_id,
+// so it can't ride LOGICAL_ID_BOOKKEEPING_TABLES. Every knowledge hard-delete
+// path must purge it by logical_id/project_id, and deleteSession by session_id.
+// An UPDATE (new version, same logical_id) must NOT purge it — the loop reads it
+// once per session, so it has to survive mid-session version edits.
+
+let root: string;
+let seedCounter = 0;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "lore-inj-"));
+});
+afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+function seed(): { id: string; logicalId: string } {
+  const id = ltm.create({
+    projectPath: root,
+    scope: "project",
+    crossProject: false,
+    category: "gotcha",
+    title: `Injection entry ${++seedCounter}`,
+    content: "an entry whose confidence the outcome loop credits",
+  });
+  const logicalId = ltm.get(id)?.logical_id;
+  if (!logicalId) throw new Error("seed failed");
+  return { id, logicalId };
+}
+
+// Direct insert — the cleanup is under test, not recordSessionInjections().
+function seedInjection(args: {
+  sessionId: string;
+  logicalId: string;
+  projectId: string;
+}): void {
+  db()
+    .query(
+      `INSERT OR REPLACE INTO knowledge_session_injections
+         (session_id, logical_id, project_id, created_at, credited)
+       VALUES (?, ?, ?, ?, 0)`,
+    )
+    .run(args.sessionId, args.logicalId, args.projectId, Date.now());
+}
+
+function injByLogical(logicalId: string): number {
+  return (
+    db()
+      .query(
+        "SELECT COUNT(*) AS c FROM knowledge_session_injections WHERE logical_id = ?",
+      )
+      .get(logicalId) as { c: number }
+  ).c;
+}
+
+function injBySession(sessionId: string): number {
+  return (
+    db()
+      .query(
+        "SELECT COUNT(*) AS c FROM knowledge_session_injections WHERE session_id = ?",
+      )
+      .get(sessionId) as { c: number }
+  ).c;
+}
+
+function injByProject(projectId: string): number {
+  return (
+    db()
+      .query(
+        "SELECT COUNT(*) AS c FROM knowledge_session_injections WHERE project_id = ?",
+      )
+      .get(projectId) as { c: number }
+  ).c;
+}
+
+describe("orphan injection-log cleanup on knowledge/session delete (#996)", () => {
+  test("remove() purges injections for the entry, leaving siblings", () => {
+    const a = seed();
+    const b = seed();
+    const pid = ensureProject(root);
+    seedInjection({ sessionId: "s1", logicalId: a.logicalId, projectId: pid });
+    seedInjection({ sessionId: "s1", logicalId: b.logicalId, projectId: pid });
+    expect(injByLogical(a.logicalId)).toBe(1);
+    expect(injByLogical(b.logicalId)).toBe(1);
+
+    ltm.remove(a.logicalId);
+
+    expect(injByLogical(a.logicalId)).toBe(0);
+    expect(injByLogical(b.logicalId)).toBe(1); // sibling entry untouched
+  });
+
+  test("update() (new version) PRESERVES injections — survives version edits", () => {
+    const { id, logicalId } = seed();
+    const pid = ensureProject(root);
+    seedInjection({ sessionId: "s1", logicalId, projectId: pid });
+
+    // A content change appends a new version with the same logical_id; the
+    // injection log must stay so the idle pass can still credit the session.
+    ltm.update(id, {
+      content: "changed content forces a brand new version row",
+    });
+
+    expect(ltm.getByLogical(logicalId)?.logical_id).toBe(logicalId);
+    expect(injByLogical(logicalId)).toBe(1); // not purged
+  });
+
+  test("clearKnowledge() purges injections for the project (incl. orphans)", () => {
+    const { logicalId } = seed();
+    const pid = ensureProject(root);
+    seedInjection({ sessionId: "s1", logicalId, projectId: pid });
+    // A row whose knowledge entry is already gone — only a project_id sweep
+    // reclaims it; a `logical_id IN (SELECT ... FROM knowledge)` shape would not.
+    seedInjection({ sessionId: "s2", logicalId: "ghost", projectId: pid });
+    expect(injByProject(pid)).toBe(2);
+
+    data.clearKnowledge(root);
+
+    expect(injByProject(pid)).toBe(0);
+  });
+
+  test("clearProject() purges injections for the project (incl. orphans)", () => {
+    const { logicalId } = seed();
+    const pid = ensureProject(root);
+    seedInjection({ sessionId: "s1", logicalId, projectId: pid });
+    seedInjection({ sessionId: "s2", logicalId: "ghost", projectId: pid });
+    expect(injByProject(pid)).toBe(2);
+
+    data.clearProject(root);
+
+    expect(injByProject(pid)).toBe(0);
+  });
+
+  test("clearProject() leaves another project's injections untouched", () => {
+    const { logicalId } = seed();
+    const pid = ensureProject(root);
+    const root2 = mkdtempSync(join(tmpdir(), "lore-inj-other-"));
+    const pid2 = ensureProject(root2);
+    seedInjection({ sessionId: "s1", logicalId, projectId: pid });
+    seedInjection({ sessionId: "s9", logicalId: "other", projectId: pid2 });
+
+    data.clearProject(root);
+
+    expect(injByProject(pid)).toBe(0);
+    expect(injByProject(pid2)).toBe(1); // different project untouched
+    rmSync(root2, { recursive: true, force: true });
+  });
+
+  test("deleteProject() purges injections for the project (incl. orphans)", () => {
+    const { logicalId } = seed();
+    const pid = ensureProject(root);
+    seedInjection({ sessionId: "s1", logicalId, projectId: pid });
+    seedInjection({ sessionId: "s2", logicalId: "ghost", projectId: pid });
+    expect(injByProject(pid)).toBe(2);
+
+    data.deleteProject(pid);
+
+    expect(injByProject(pid)).toBe(0);
+  });
+
+  test("deleteSession() purges injections for that session only", () => {
+    const { logicalId } = seed();
+    const pid = ensureProject(root);
+    // session_id is global (not project-scoped); the DB persists across tests in
+    // this file, so use ids unique to this test to keep injBySession() exact.
+    const s1 = `del-keep-${++seedCounter}`;
+    const s2 = `del-drop-${++seedCounter}`;
+    seedInjection({ sessionId: s2, logicalId, projectId: pid });
+    seedInjection({ sessionId: s1, logicalId, projectId: pid });
+    expect(injBySession(s2)).toBe(1);
+    expect(injBySession(s1)).toBe(1);
+
+    data.deleteSession(root, s2);
+
+    expect(injBySession(s2)).toBe(0);
+    expect(injBySession(s1)).toBe(1); // sibling session untouched
+  });
+});


### PR DESCRIPTION
Closes #996.

## Problem
`knowledge_session_injections` (outcome-reward log, #497; PK `(session_id, logical_id)`, local-only, **not** synced) is the **same orphan-leak class** the #990/#994 fix addressed for `knowledge_ref_validity` / `knowledge_symbol_presence`: keyed on `logical_id`, **no FK CASCADE**, purged **nowhere**. It orphans on:
- `ltm.remove()` — A2 delete is a death-cert append, no physical `DELETE` → CASCADE never fires
- `clearProject` / `deleteProject` / `clearKnowledge` — physical `DELETE FROM knowledge`, rows keyed by `project_id` survive
- `deleteSession` — rows keyed by `session_id` survive
- `mergeProjectInternal` — re-points `project_id` for knowledge + sibling tables but missed this one (found in review; see below)

Bounded growth + a behavioral hole on merge — otherwise **zero correctness impact** on the steady state (read once per session by `creditSessionOutcome` with a `credited` idempotency flag; stale rows are inert).

## Why not just add it to `LOGICAL_ID_BOOKKEEPING_TABLES`
That registry assumes a single `logical_id` column and a uniform `WHERE logical_id = ?` / `logical_id IN (...)` shape. `knowledge_session_injections` has a composite PK and is also session-scoped, so it needs bespoke cleanup on the knowledge-delete paths **and** `deleteSession`.

## Fix
- `ltm.remove()`: `DELETE … WHERE logical_id = ?` (matches the existing inline cleanup for the other composite-shaped aux tables right above it)
- `clearProject` / `deleteProject` / `clearKnowledge`: `DELETE … WHERE project_id = ?` — the table carries a `project_id`, so a direct scope sweep also **reclaims rows already orphaned by deletes predating this fix** (a `logical_id IN (SELECT … FROM knowledge)` shape would miss those)
- `deleteSession`: `DELETE … WHERE session_id = ?`
- `mergeProjectInternal`: `UPDATE … SET project_id = target WHERE project_id = source` — re-point alongside the existing per-table reassignments. Plain UPDATE is safe (PK is `(session_id, logical_id)`, not `project_id`). Without it, merged entries' injections orphan permanently when the source project row is deleted **and** crediting breaks across merges.

`knowledge_meta` is **intentionally left alone** — it is a synced convergent register, so a local `DELETE` would violate tombstone semantics once team sync lands (tracked separately).

## Tests
`packages/core/test/ltm-injections-cleanup.test.ts` (7 cases):
- `remove()` purges by `logical_id`, leaves sibling entries
- `update()` (new version) **preserves** injections — must survive mid-session version edits
- `clearProject` / `deleteProject` / `clearKnowledge` purge by project (incl. a **pre-existing orphan** row whose knowledge entry is already gone — proves the `project_id` sweep over the registry's subquery shape)
- `clearProject` leaves **another project's** injections untouched
- `deleteSession` purges that session only (sibling session survives)

`packages/core/test/db.test.ts` — extended the existing `mergeProjectInternal` test to assert the injection row moves source→target (none orphaned under source).

## Verification
- Related suites (ltm / bookkeeping-cleanup / outcome-reward / data / db) all green
- Full core suite 2097 passed / 6 skipped, stable across runs
- `typecheck` clean; `biome check` clean on changed files
- **Mutation battery: 9/9 killed** — neuter + drop-scope for each of the 5 DELETEs (drop-scope mutants caught by the sibling-entry / cross-project / sibling-session negatives), plus the merge-reassignment no-op caught by the extended merge test
- Independent adversarial review verdict: MERGE (the merge-path gap was its one finding, now folded in)