### PR TITLE
fix(gateway): drop transient upstream network errors from Sentry

### DIFF
--- a/packages/gateway/instrument.ts
+++ b/packages/gateway/instrument.ts
@@ -45,6 +45,10 @@ setMaxListeners(15);
 import * as Sentry from "@sentry/bun";
 import { log } from "@loreai/core";
 import { VERSION } from "./src/cli/version";
+import {
+  eventHasTransientError,
+  isTransientErrorMessage,
+} from "./src/transient-errors";
 
 /**
  * Build-time debug ID for sourcemap resolution, injected by esbuild.
@@ -115,32 +119,6 @@ const sentryEnabled = isTestRunner
     : false;
 
 if (sentryEnabled && !Sentry.isInitialized()) {
-  // Transient network errors that are expected in a long-running LLM proxy.
-  // These are not actionable bugs — they occur when clients disconnect,
-  // upstreams are temporarily unavailable, or network conditions degrade.
-  const TRANSIENT_ERROR_PATTERNS = [
-    /\bEPIPE\b/,
-    /socket connection was closed unexpectedly/i,
-    /ZlibError/,
-    /The operation timed out/i,
-    /Worker upstream exhausted \d+ retries/,
-    /Worker upstream auth error/,
-    /embedding worker/i,
-    /WASM fatal error/,
-    /LocalProviderUnavailableError/,
-    /ECONNRESET\b/,
-    /ECONNREFUSED\b/,
-    // Remote embedding fallback with invalid/placeholder API key (OpenAI SDK format)
-    /Incorrect API key provided/i,
-    // ONNX runtime init failures on various platforms
-    /Cannot find package 'onnxruntime-node'/,
-    /LoadLibrary failed/,
-    /Protobuf parsing failed/,
-    // Bun doesn't implement getSystemErrorMap from node:util —
-    // this crashes the Sentry SDK itself during error processing
-    /getSystemErrorMap/,
-  ];
-
   Sentry.init({
     dsn: "https://0282201d6a3df3bc46423e61012ae62b@o275100.ingest.us.sentry.io/4511355222622208",
 
@@ -170,16 +148,7 @@ if (sentryEnabled && !Sentry.isInitialized()) {
     // Each exception in the chain is tested independently so a real bug
     // wrapping a transient cause isn't accidentally silenced.
     beforeSend(event) {
-      const values = event.exception?.values;
-      if (
-        values?.some((v) => {
-          const msg = `${v.type}: ${v.value}`;
-          return TRANSIENT_ERROR_PATTERNS.some((re) => re.test(msg));
-        })
-      ) {
-        return null;
-      }
-      return event;
+      return eventHasTransientError(event) ? null : event;
     },
   });
 
@@ -191,7 +160,7 @@ if (sentryEnabled && !Sentry.isInitialized()) {
     info: (message, attrs) => Sentry.logger.info(message, attrs),
     warn: (message, attrs) => Sentry.logger.warn(message, attrs),
     error: (message, attrs) => {
-      if (!TRANSIENT_ERROR_PATTERNS.some((re) => re.test(message))) {
+      if (!isTransientErrorMessage(message)) {
         Sentry.logger.error(message, attrs);
       }
     },

--- a/packages/gateway/src/transient-errors.ts
+++ b/packages/gateway/src/transient-errors.ts
@@ -1,0 +1,78 @@
+/**
+ * Transient error classification for Sentry.
+ *
+ * A long-running LLM proxy routinely hits network and runtime conditions that
+ * are expected and not actionable bugs: clients disconnect, upstreams close
+ * sockets, DNS blips, ONNX/embedding init fails on exotic hosts, etc. Reporting
+ * these to Sentry creates noise that buries real bugs.
+ *
+ * These patterns are shared by `instrument.ts`'s Sentry `beforeSend` filter
+ * (which inspects each exception in an event's chain) and its structured-log
+ * error gate (which inspects the log message string). They live in their own
+ * module so the classification is unit-testable without importing
+ * `instrument.ts`, which runs `Sentry.init()` as an import side effect.
+ */
+
+/**
+ * Messages matching any of these are considered transient and dropped.
+ *
+ * NOTE: prefer matching the *inner* network cause (e.g. `ECONNRESET`,
+ * `ENETUNREACH`, `other side closed`) over the generic undici wrapper
+ * (`fetch failed` / `terminated`). `beforeSend` tests every exception in the
+ * chain, so matching the inner cause is sufficient to drop the event — while
+ * leaving the generic wrapper unmatched ensures a genuine bug that merely wraps
+ * a fetch is never silenced.
+ */
+export const TRANSIENT_ERROR_PATTERNS: RegExp[] = [
+  /\bEPIPE\b/,
+  /socket connection was closed unexpectedly/i,
+  /ZlibError/,
+  /The operation timed out/i,
+  /Worker upstream exhausted \d+ retries/,
+  /Worker upstream auth error/,
+  /embedding worker/i,
+  /WASM fatal error/,
+  /LocalProviderUnavailableError/,
+  /ECONNRESET\b/,
+  /ECONNREFUSED\b/,
+  // Connection-layer transients to upstream LLM providers. These surface as
+  // undici `TypeError: fetch failed` / `TypeError: terminated` wrapping a
+  // network cause; matching the inner cause drops the whole event.
+  /\bENETUNREACH\b/,
+  /\bETIMEDOUT\b/,
+  /\bEHOSTUNREACH\b/,
+  /\bEAI_AGAIN\b/, // DNS resolution timeout
+  /other side closed/i, // undici SocketError behind "terminated"
+  // Remote embedding fallback with invalid/placeholder API key (OpenAI SDK format)
+  /Incorrect API key provided/i,
+  // ONNX runtime init failures on various platforms
+  /Cannot find package 'onnxruntime-node'/,
+  /LoadLibrary failed/,
+  /Protobuf parsing failed/,
+  // Bun doesn't implement getSystemErrorMap from node:util —
+  // this crashes the Sentry SDK itself during error processing
+  /getSystemErrorMap/,
+];
+
+/** True if `text` matches any transient-error pattern. */
+export function isTransientErrorMessage(text: string): boolean {
+  return TRANSIENT_ERROR_PATTERNS.some((re) => re.test(text));
+}
+
+/** Minimal shape of the Sentry event fields this module inspects. */
+export interface TransientCheckEvent {
+  exception?: {
+    values?: Array<{ type?: string; value?: string }>;
+  };
+}
+
+/**
+ * True if any exception in the event's chain is transient. Each exception is
+ * tested independently (as `"<type>: <value>"`) so a real bug wrapping a
+ * transient cause is only dropped if the real bug *itself* matches.
+ */
+export function eventHasTransientError(event: TransientCheckEvent): boolean {
+  const values = event.exception?.values;
+  if (!values) return false;
+  return values.some((v) => isTransientErrorMessage(`${v.type}: ${v.value}`));
+}

--- a/packages/gateway/test/transient-errors.test.ts
+++ b/packages/gateway/test/transient-errors.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import {
+  TRANSIENT_ERROR_PATTERNS,
+  isTransientErrorMessage,
+  eventHasTransientError,
+  type TransientCheckEvent,
+} from "../src/transient-errors";
+
+/** Build a Sentry-event-ish object from a chain of `[type, value]` pairs. */
+function eventFromChain(
+  chain: Array<[string, string | undefined]>,
+): TransientCheckEvent {
+  return {
+    exception: { values: chain.map(([type, value]) => ({ type, value })) },
+  };
+}
+
+describe("isTransientErrorMessage", () => {
+  it("matches the connection-layer causes added for fetch-failed/terminated noise", () => {
+    // These are the inner causes seen in LOREAI-GATEWAY-2W/31/34 (undici).
+    expect(
+      isTransientErrorMessage("Error: connect ENETUNREACH 2607:6bc0::10:443"),
+    ).toBe(true);
+    expect(
+      isTransientErrorMessage("Error: connect ETIMEDOUT 160.79.104.10:443"),
+    ).toBe(true);
+    expect(
+      isTransientErrorMessage("Error: connect EHOSTUNREACH 10.0.0.1:443"),
+    ).toBe(true);
+    expect(
+      isTransientErrorMessage("Error: getaddrinfo EAI_AGAIN api.anthropic.com"),
+    ).toBe(true);
+    expect(isTransientErrorMessage("SocketError: other side closed")).toBe(
+      true,
+    );
+  });
+
+  it("still matches the pre-existing transient patterns", () => {
+    expect(isTransientErrorMessage("Error: read ECONNRESET")).toBe(true);
+    expect(
+      isTransientErrorMessage("Error: Worker upstream auth error: 403"),
+    ).toBe(true);
+    expect(isTransientErrorMessage("Error: Protobuf parsing failed.")).toBe(
+      true,
+    );
+    expect(isTransientErrorMessage("Error: write EPIPE")).toBe(true);
+  });
+
+  it("does NOT match the generic undici wrappers on their own", () => {
+    // We deliberately match the inner cause, not the wrapper, so a real bug
+    // that merely wraps a fetch is never silenced.
+    expect(isTransientErrorMessage("TypeError: fetch failed")).toBe(false);
+    expect(isTransientErrorMessage("TypeError: terminated")).toBe(false);
+  });
+
+  it("does NOT match genuine application bugs", () => {
+    expect(
+      isTransientErrorMessage(
+        "TypeError: Cannot read properties of undefined (reading 'id')",
+      ),
+    ).toBe(false);
+    expect(
+      isTransientErrorMessage("Error: recall follow-up upstream 400"),
+    ).toBe(false);
+    expect(isTransientErrorMessage("ReferenceError: x is not defined")).toBe(
+      false,
+    );
+  });
+});
+
+describe("eventHasTransientError", () => {
+  it("drops the real-world fetch-failed chain via its inner ENETUNREACH/ETIMEDOUT cause", () => {
+    // Mirrors LOREAI-GATEWAY-2W: inner network errors wrapped by `fetch failed`.
+    const event = eventFromChain([
+      ["Error", "connect ENETUNREACH 2607:6bc0::10:443 - Local (:::0)"],
+      ["Error", "connect ETIMEDOUT 160.79.104.10:443"],
+      ["AggregateError", undefined],
+      ["TypeError", "fetch failed"],
+    ]);
+    expect(eventHasTransientError(event)).toBe(true);
+  });
+
+  it("drops the real-world terminated chain via `other side closed`", () => {
+    // Mirrors LOREAI-GATEWAY-34.
+    const event = eventFromChain([
+      ["SocketError", "other side closed"],
+      ["TypeError", "terminated"],
+    ]);
+    expect(eventHasTransientError(event)).toBe(true);
+  });
+
+  it("keeps a real bug whose chain contains only the generic wrapper", () => {
+    // A `fetch failed` with no transient inner cause is NOT dropped.
+    const event = eventFromChain([["TypeError", "fetch failed"]]);
+    expect(eventHasTransientError(event)).toBe(false);
+  });
+
+  it("keeps genuine application errors", () => {
+    const event = eventFromChain([["Error", "recall follow-up upstream 400"]]);
+    expect(eventHasTransientError(event)).toBe(false);
+  });
+
+  it("returns false for events with no exception payload", () => {
+    expect(eventHasTransientError({})).toBe(false);
+    expect(eventHasTransientError({ exception: {} })).toBe(false);
+    expect(eventHasTransientError({ exception: { values: [] } })).toBe(false);
+  });
+});
+
+describe("TRANSIENT_ERROR_PATTERNS", () => {
+  it("every pattern is a RegExp (guards against accidental string entries)", () => {
+    for (const p of TRANSIENT_ERROR_PATTERNS) {
+      expect(p).toBeInstanceOf(RegExp);
+    }
+  });
+});


### PR DESCRIPTION
## What

Part of a pre-0.34.0 Sentry triage of `byk/loreai-gateway`. The largest noise source is the recurring **`TypeError: fetch failed`** / **`TypeError: terminated`** clusters (LOREAI-GATEWAY-1N, -34, and ~9 fingerprint duplicates). Their latest events show the real cause is transient connection-layer failures to upstream LLM providers:

- `Error: connect ENETUNREACH …`
- `Error: connect ETIMEDOUT …`
- `Error: getaddrinfo EAI_AGAIN …` (DNS)
- `SocketError: other side closed` (behind undici `TypeError: terminated`)

None are actionable bugs, but they weren't in `TRANSIENT_ERROR_PATTERNS`, so they reopened on every release.

## Changes

- **Extend the transient-error filter** with the inner network causes above. We deliberately match the **inner cause**, not the generic `fetch failed` / `terminated` wrapper — `beforeSend` tests every exception in the chain, so matching the inner cause is enough to drop the event while leaving the generic wrapper unmatched (a genuine bug that merely wraps a fetch is never silenced).
- **Extract** `TRANSIENT_ERROR_PATTERNS` + classification helpers (`isTransientErrorMessage`, `eventHasTransientError`) from `instrument.ts` into a new unit-testable `src/transient-errors.ts`. `instrument.ts` runs `Sentry.init()` as an import side effect and its init block is skipped under `NODE_ENV=test`, so the patterns were previously untestable.
- **Tests** (`test/transient-errors.test.ts`): each new pattern drops a representative event; the real-world fetch-failed and terminated chains are dropped via their inner cause; the generic wrapper alone and genuine app bugs (e.g. `recall follow-up upstream 400`) are **not** dropped.

## Verification

- `pnpm run typecheck` ✅ · `pnpm run lint` ✅ (changed files clean)
- Full gateway suite: 2263 passed, 0 failed
- Vacuity/mutation check: removing `/other side closed/i` fails the terminated-chain test (it has no other transient cause); restored byte-identical.

Once this ships in 0.34.0 the fetch-failed/terminated clusters stop, so the corresponding Sentry issues are being resolved "in next release".