### PR TITLE
fix(gateway): scale 5m warmup margin by prefix size to avoid TTL-race partials

### DIFF
--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -170,6 +170,21 @@ export const MIN_INPUT_TOKENS_FOR_WARMING = 50_000;
  *  ensures at least 30% return probability before the first warmup. */
 export const MIN_RETURN_PROBABILITY_FLOOR = 0.3;
 
+/** Size-proportional warmup-margin scaling (5m TTL only). The headroom a prefix
+ *  needs to clear its largest block's per-block TTL boundary is ABSOLUTE (a
+ *  function of prefix size), not a fraction of the TTL — so the 45s base gets a
+ *  per-token term. ~0.27ms/token puts a 164K prefix at ~44s of added headroom
+ *  (→ ~89s total margin), matching observed warmup round-trip + boundary jitter
+ *  for large multi-block prefixes. See computeWarmupMargin. */
+export const MARGIN_PER_TOKEN_MS = 0.27;
+
+/** Absolute cap on the size-driven margin term. Bounds the margin with a fixed
+ *  tail instead of a fraction of the TTL: a fraction would balloon the 1h margin
+ *  to 24min (warm with 36min of life left = thrash), and even on 5m would warm
+ *  too early. With this cap the 5m margin tops out at 45s + 90s = 135s (the cap
+ *  bites only past ~333K-token prefixes). */
+export const MAX_SIZE_MARGIN_MS = 90_000;
+
 // ---------------------------------------------------------------------------
 // Per-bucket circuit breaker
 // ---------------------------------------------------------------------------
@@ -925,12 +940,50 @@ function ensureCacheBreakpoint(body: {
 }
 
 /**
+ * How early before TTL expiry to fire the warmup, scaled by prefix size.
+ *
+ * The 5m base of 45s is too tight for LARGE multi-block prefixes: a big
+ * conversation block sitting against the 5-minute wall can cross its per-block
+ * TTL boundary inside the headroom window, so the warmup lands as a partial
+ * (head block refreshed, large block rewritten). The headroom needed to clear
+ * that boundary is ABSOLUTE (a function of prefix size), not a fraction of the
+ * TTL, so we add a size-proportional term capped by an absolute tail
+ * (MAX_SIZE_MARGIN_MS).
+ *
+ * The 1h base of 300s already dwarfs the headroom any realistic prefix needs,
+ * so 1h stays flat — only the 5m path scales. `prefixTokens` is the session's
+ * last input-token count (state.lastInputTokens); 0 (the default for callers
+ * without a session, e.g. unit tests) reproduces the original flat base.
+ */
+export function computeWarmupMargin(ttlMs: number, prefixTokens = 0): number {
+  const base = ttlMs === 3_600_000 ? 300_000 : 45_000;
+  // 1h base already covers any prefix's boundary headroom — keep it flat.
+  if (ttlMs === 3_600_000) return base;
+  // Guard non-finite/negative prefixTokens: a NaN would propagate through the
+  // arithmetic to a NaN margin, which silently bypasses BOTH the cooldown and
+  // window gates (`x < ttlMs - NaN` is false) → warm on every idle tick.
+  const safeTokens = Number.isFinite(prefixTokens)
+    ? Math.max(0, prefixTokens)
+    : 0;
+  const sizeTerm = Math.min(
+    safeTokens * MARGIN_PER_TOKEN_MS,
+    MAX_SIZE_MARGIN_MS,
+  );
+  return base + sizeTerm;
+}
+
+/**
  * Build an Anthropic warming profile for a given model and TTL.
+ *
+ * `prefixTokens` (the session's last input-token count) scales the 5m warmup
+ * margin so large prefixes fire earlier; see computeWarmupMargin. Defaults to 0
+ * (flat base) for callers without a live session.
  */
 export function buildAnthropicProfile(
   model: string,
   ttl: "5m" | "1h",
   upstreamBase?: string,
+  prefixTokens = 0,
 ): CacheWarmingProfile {
   const route = resolveUpstreamRoute(model);
   // || (not ??): an empty-string upstreamBase (header-less Anthropic sessions)
@@ -946,9 +999,11 @@ export function buildAnthropicProfile(
   const cacheWriteCost = ttl === "1h" ? baseCacheWrite * 2 : baseCacheWrite;
 
   const ttlMs = ttl === "1h" ? 3_600_000 : 300_000;
-  // For 5m TTL: warm in the last 45s (4:15–5:00)
-  // For 1h TTL: warm in the last 5m (55:00–60:00)
-  const warmupMarginMs = ttl === "1h" ? 300_000 : 45_000;
+  // Size-aware margin: the 5m base (45s) is too tight for large multi-block
+  // prefixes, which can cross a per-block TTL boundary inside the headroom
+  // window and land the warmup as a partial. 1h stays flat at 300s. See
+  // computeWarmupMargin.
+  const warmupMarginMs = computeWarmupMargin(ttlMs, prefixTokens);
 
   return {
     ttlMs,
@@ -973,9 +1028,13 @@ export function buildVertexProfile(
   model: string,
   ttl: "5m" | "1h",
   upstreamBase: string,
+  prefixTokens = 0,
 ): CacheWarmingProfile {
   const region = vertexRegionFromUrl(upstreamBase) ?? "global";
-  const base = buildAnthropicProfile(model, ttl);
+  // Vertex Claude uses Anthropic prompt caching, so it is exposed to the same
+  // large-prefix TTL-race partial — thread prefixTokens so the 5m margin scales
+  // (computeWarmupMargin), matching the first-party/proxied/bedrock paths.
+  const base = buildAnthropicProfile(model, ttl, undefined, prefixTokens);
   return {
     ...base,
     upstreamUrl: `https://${vertexHost(region)}`,
@@ -1025,6 +1084,7 @@ export function resolveProfile(
   ttl: "5m" | "1h" | undefined,
   upstreamBase?: string,
   providerID?: string,
+  prefixTokens = 0,
 ): CacheWarmingProfile | null {
   if (!model || !protocol) return null;
 
@@ -1036,7 +1096,7 @@ export function resolveProfile(
     const vRoute = resolveUpstreamRoute(model);
     const vHost = upstreamBase || vRoute?.url;
     if (!vHost || !isVertexHost(vHost)) return null;
-    return buildVertexProfile(model, ttl ?? "5m", vHost);
+    return buildVertexProfile(model, ttl ?? "5m", vHost, prefixTokens);
   }
 
   // Only Anthropic protocol for now — OpenAI has automatic prefix caching with
@@ -1075,7 +1135,12 @@ export function resolveProfile(
     providerID === "amazon-bedrock" ||
     (!!warmupHost && isBedrockMantleHost(warmupHost));
   if (isBedrockMantle) {
-    return buildAnthropicProfile(model, ttl ?? "5m", upstreamBase);
+    return buildAnthropicProfile(
+      model,
+      ttl ?? "5m",
+      upstreamBase,
+      prefixTokens,
+    );
   }
 
   const isAnthropic =
@@ -1083,7 +1148,34 @@ export function resolveProfile(
     (!!warmupHost && isAnthropicFirstPartyHost(warmupHost));
   if (!isAnthropic) return null;
 
-  return buildAnthropicProfile(model, ttl ?? "5m", upstreamBase);
+  return buildAnthropicProfile(model, ttl ?? "5m", upstreamBase, prefixTokens);
+}
+
+/**
+ * Resolve a warming profile from a live session's state. Single seam shared by
+ * the live warming loop (idle.ts) and the dashboard snapshot so the upstream
+ * routing AND the size-aware warmup margin (state.lastInputTokens →
+ * computeWarmupMargin) can never diverge between "what we report" and "what we
+ * actually warm". Keep both call sites routed through here.
+ */
+export function resolveProfileForSession(
+  state: SessionState,
+): CacheWarmingProfile | null {
+  return resolveProfile(
+    state.lastUpstream?.model,
+    state.lastUpstream?.protocol,
+    state.resolvedConversationTTL,
+    // Pass the session's real upstream URL + providerID so the warmer warms
+    // only true-Anthropic sessions (first-party host OR providerID "anthropic",
+    // incl. proxied Anthropic) and never sends a compat provider's key to
+    // api.anthropic.com (MiniMax 401 loop).
+    state.lastUpstream?.url,
+    state.lastUpstream?.providerID,
+    // Size-aware warmup margin: large prefixes fire earlier so a big
+    // conversation block doesn't cross its per-block TTL boundary before the
+    // warmup lands (computeWarmupMargin).
+    state.lastInputTokens ?? 0,
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -1572,16 +1664,8 @@ export function computeWarmingSnapshot(
   // Survival & return probability
   const survivalAtIdle = survivalFunction(blendedHist, idleMs);
 
-  const profile = resolveProfile(
-    state.lastUpstream?.model,
-    state.lastUpstream?.protocol,
-    state.resolvedConversationTTL,
-    state.lastUpstream?.url,
-    // Match the live warming path (idle.ts) so the dashboard snapshot doesn't
-    // under-report a profile for proxied-Anthropic sessions (providerID
-    // "anthropic" + non-first-party host).
-    state.lastUpstream?.providerID,
-  );
+  // Shared seam with the live warming path (idle.ts) — see resolveProfileForSession.
+  const profile = resolveProfileForSession(state);
   const ttlMs = profile?.ttlMs ?? 300_000;
   const warmupMarginMs = profile?.warmupMarginMs ?? 45_000;
 

--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -57,7 +57,7 @@ import {
   warmupBucketKey,
   isWarmupAuthDisabled,
   clearWarmupAuthDisabled,
-  resolveProfile,
+  resolveProfileForSession,
   blendedHistogramForSession,
   shouldWarm,
   executeWarmup,
@@ -551,17 +551,10 @@ export function startIdleScheduler(
       // Ensure global histograms are loaded from SQLite for this project
       loadGlobalHistograms(state.projectPath);
 
-      const profile = resolveProfile(
-        state.lastUpstream?.model,
-        state.lastUpstream?.protocol,
-        state.resolvedConversationTTL,
-        // Pass the session's real upstream URL + providerID so the warmer warms
-        // only true-Anthropic sessions (first-party host OR providerID
-        // "anthropic", incl. proxied Anthropic) and never sends a compat
-        // provider's key to api.anthropic.com (MiniMax 401 loop).
-        state.lastUpstream?.url,
-        state.lastUpstream?.providerID,
-      );
+      // Shared seam with the dashboard snapshot (computeWarmingSnapshot) so the
+      // upstream routing + size-aware warmup margin never diverge. See
+      // resolveProfileForSession.
+      const profile = resolveProfileForSession(state);
       if (!profile) continue;
 
       // Skip only this session's tripped (model, upstream) bucket — other

--- a/packages/gateway/test/bedrock.test.ts
+++ b/packages/gateway/test/bedrock.test.ts
@@ -193,4 +193,26 @@ describe("resolveProfile — bedrock-mantle warming", () => {
       resolveProfile("gpt-5.5", "openai", "5m", undefined, "openai"),
     ).toBeNull();
   });
+
+  test("threads prefixTokens through to a size-scaled 5m margin", () => {
+    // Bedrock-mantle rides the Anthropic profile, so it must scale the 5m margin
+    // for large prefixes like the first-party/vertex paths (computeWarmupMargin).
+    const flat = resolveProfile(
+      "claude-haiku-4-5",
+      "anthropic",
+      "5m",
+      mantleBase,
+      "bedrock",
+    );
+    const scaled = resolveProfile(
+      "claude-haiku-4-5",
+      "anthropic",
+      "5m",
+      mantleBase,
+      "bedrock",
+      164_807,
+    );
+    expect(flat?.warmupMarginMs).toBe(45_000);
+    expect(scaled?.warmupMarginMs).toBeCloseTo(89_497.89, 2);
+  });
 });

--- a/packages/gateway/test/cache-warmer.test.ts
+++ b/packages/gateway/test/cache-warmer.test.ts
@@ -7,7 +7,11 @@ import {
   blendHistograms,
   prepareAnthropicWarmupBody,
   buildAnthropicProfile,
+  computeWarmupMargin,
+  MARGIN_PER_TOKEN_MS,
+  MAX_SIZE_MARGIN_MS,
   resolveProfile,
+  resolveProfileForSession,
   shouldWarm,
   checkCircuitBreaker,
   isCircuitBreakerTripped,
@@ -1457,6 +1461,50 @@ describe("shouldWarm", () => {
     expect(shouldWarm(stateRecent, profile, hist, now)).toBe(false);
   });
 
+  test("size-scaled margin warms EARLIER in the live gate than a flat margin would", () => {
+    // End-to-end proof that the size-scaled margin is load-bearing in the
+    // actual warm/no-warm decision (not just in computeWarmupMargin): with the
+    // SAME session state, a large-prefix profile (capped 135s margin → window
+    // threshold = 300s − 135s = 165s) warms, while a flat-45s profile (threshold
+    // 255s) does NOT — the ONLY difference is the margin. intoWindow is 200s.
+    const now = Date.now();
+    const baseState = () =>
+      makeSessionState({
+        lastRequestTime: now - 200_000, // intoWindow = 200_000 % 300_000 = 200s
+        warmup: {
+          lastWarmupAt: now - 260_000, // 260s ago — past BOTH cooldowns (165s & 255s)
+          warmupCount: 1,
+          totalWarmups: 1,
+          warmupHits: 1, // ROI gate: hit rate >= 20%
+          disabled: false,
+        },
+        cacheAnalytics: {
+          ...makeCacheAnalytics(),
+          lastRequestBody: compressBody(
+            '{"model":"claude-sonnet-4-20250514","max_tokens":16384,"stream":true,"messages":[{"role":"user","content":"test"}]}',
+          ),
+        },
+      });
+    const hist = createHistogram();
+    for (let i = 0; i < 50; i++) recordGap(hist, 360_000);
+
+    // Large prefix → margin caps at 45s + 90s = 135s → threshold 165s.
+    const scaled = buildAnthropicProfile(
+      "claude-sonnet-4-20250514",
+      "5m",
+      undefined,
+      400_000,
+    );
+    expect(scaled.warmupMarginMs).toBe(135_000);
+    // 200s >= 165s → in margin → warms.
+    expect(shouldWarm(baseState(), scaled, hist, now)).toBe(true);
+
+    // Flat margin 45s → threshold 255s. 200s < 255s → NOT in margin → no warm.
+    const flat = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+    expect(flat.warmupMarginMs).toBe(45_000);
+    expect(shouldWarm(baseState(), flat, hist, now)).toBe(false);
+  });
+
   test("forceKeepWarm still respects circuit breaker", () => {
     const now = Date.now();
     const state = makeSessionState({
@@ -1595,6 +1643,152 @@ describe("resolveProfile — Anthropic first-party host gate (cross-provider 401
       resolveProfile("gpt-5", "openai", "5m", "https://api.openai.com"),
     ).toBeNull();
   });
+
+  test("threads prefixTokens through to a size-scaled 5m margin", () => {
+    // resolveProfile is the function both the live warming path (idle.ts) and
+    // the dashboard snapshot call — it must forward prefixTokens to
+    // buildAnthropicProfile so large prefixes fire earlier.
+    const flat = resolveProfile(
+      "claude-sonnet-4-20250514",
+      "anthropic",
+      "5m",
+      "https://api.anthropic.com",
+      "anthropic",
+    );
+    const scaled = resolveProfile(
+      "claude-sonnet-4-20250514",
+      "anthropic",
+      "5m",
+      "https://api.anthropic.com",
+      "anthropic",
+      164_807,
+    );
+    expect(flat?.warmupMarginMs).toBe(45_000);
+    expect(scaled?.warmupMarginMs).toBeCloseTo(89_497.89, 2);
+  });
+});
+
+describe("resolveProfileForSession — shared idle/snapshot seam", () => {
+  // resolveProfileForSession is the SINGLE seam both the live warming loop
+  // (idle.ts — the path that actually pays for warmups) and the dashboard
+  // snapshot route through. This test guards state.lastInputTokens →
+  // computeWarmupMargin for BOTH consumers at once: mutating the one
+  // `state.lastInputTokens ?? 0` inside the seam makes the scaled case fail.
+  test("threads state.lastInputTokens through to a size-scaled 5m margin", () => {
+    const flat = resolveProfileForSession(
+      makeSessionState({ lastInputTokens: 0 }),
+    );
+    const scaled = resolveProfileForSession(
+      makeSessionState({ lastInputTokens: 164_807 }),
+    );
+    expect(flat?.warmupMarginMs).toBe(45_000);
+    expect(scaled?.warmupMarginMs).toBeCloseTo(89_497.89, 2);
+    expect(scaled?.warmupMarginMs).toBeGreaterThan(flat?.warmupMarginMs ?? 0);
+  });
+
+  test("returns null for a non-warmable session (preserves routing gate)", () => {
+    // A foreign anthropic-compat host must still be skipped — the seam must not
+    // weaken the routing gate while adding the margin term.
+    const profile = resolveProfileForSession(
+      makeSessionState({
+        lastInputTokens: 200_000,
+        lastUpstream: {
+          url: "https://api.minimax.io/anthropic",
+          protocol: "anthropic" as const,
+          model: "MiniMax-M3",
+          headers: {},
+          providerID: "minimax-coding-plan",
+        },
+      }),
+    );
+    expect(profile).toBeNull();
+  });
+});
+
+describe("computeWarmupMargin — size-scaled 5m warmup margin", () => {
+  test("5m base: no prefix (default) reproduces the original flat 45s base", () => {
+    // Back-compat: callers without a live session pass nothing → flat base.
+    expect(computeWarmupMargin(300_000)).toBe(45_000);
+    expect(computeWarmupMargin(300_000, 0)).toBe(45_000);
+  });
+
+  test("1h stays flat at 300s regardless of prefix size", () => {
+    expect(computeWarmupMargin(3_600_000)).toBe(300_000);
+    expect(computeWarmupMargin(3_600_000, 0)).toBe(300_000);
+    // Even a huge prefix must not move the 1h margin (would warm 24min early).
+    expect(computeWarmupMargin(3_600_000, 1_000_000)).toBe(300_000);
+  });
+
+  test("5m scales linearly with prefix size below the cap (pins the constant)", () => {
+    // Literal expectation pins MARGIN_PER_TOKEN_MS (0.27) and the 45s base:
+    // 100_000 × 0.27 = 27_000 added → 72_000 total.
+    expect(computeWarmupMargin(300_000, 100_000)).toBeCloseTo(72_000, 3);
+    // Same value expressed via the constants (readability / intent).
+    expect(computeWarmupMargin(300_000, 100_000)).toBeCloseTo(
+      45_000 + 100_000 * MARGIN_PER_TOKEN_MS,
+      6,
+    );
+  });
+
+  test("5m: the 164K production-incident prefix gets ~44s of extra headroom", () => {
+    // Session 1F4OWImUH0Nhn4x3: 164_807-token prefix landed a 27% partial with
+    // the flat 45s margin. Size term = 164_807 × 0.27 ≈ 44_498ms → ~89.5s total.
+    expect(computeWarmupMargin(300_000, 164_807)).toBeCloseTo(89_497.89, 2);
+  });
+
+  test("5m: size term is capped at MAX_SIZE_MARGIN_MS (absolute tail, not a TTL fraction)", () => {
+    // Cap bites past ~333K tokens (333_333 × 0.27 ≈ 90_000). A 1M-token prefix
+    // is clamped: 45_000 + min(270_000, 90_000) = 135_000.
+    expect(computeWarmupMargin(300_000, 1_000_000)).toBe(45_000 + 90_000);
+    expect(computeWarmupMargin(300_000, 1_000_000)).toBe(
+      45_000 + MAX_SIZE_MARGIN_MS,
+    );
+    // Cap is monotone-flat above the knee: 2M tokens gives the same value.
+    expect(computeWarmupMargin(300_000, 2_000_000)).toBe(135_000);
+  });
+
+  test("5m: margin is monotonically non-decreasing in prefix size", () => {
+    const sizes = [0, 50_000, 100_000, 164_807, 333_333, 500_000, 1_000_000];
+    for (let i = 1; i < sizes.length; i++) {
+      expect(computeWarmupMargin(300_000, sizes[i])).toBeGreaterThanOrEqual(
+        computeWarmupMargin(300_000, sizes[i - 1]),
+      );
+    }
+  });
+
+  test("5m: margin never reaches the TTL (cooldown ttlMs - margin stays positive)", () => {
+    // Hard invariant: cooldownMs = max(ttlMs - warmupMarginMs, 0) must stay > 0,
+    // otherwise warming would fire continuously. Max 5m margin = 135_000 < 300_000.
+    for (const tokens of [0, 164_807, 333_333, 1_000_000, 10_000_000]) {
+      expect(computeWarmupMargin(300_000, tokens)).toBeLessThan(300_000);
+    }
+  });
+
+  test("negative / non-finite prefixTokens is clamped to the flat base", () => {
+    expect(computeWarmupMargin(300_000, -100)).toBe(45_000);
+    expect(computeWarmupMargin(300_000, -1_000_000)).toBe(45_000);
+    // NaN/Infinity must NOT propagate to the margin: a NaN margin makes both
+    // `cooldownMs = max(ttlMs - NaN, 0)` and every `x < ttlMs - NaN` window gate
+    // misbehave (the comparison is false) → warming would fire every idle tick.
+    expect(computeWarmupMargin(300_000, Number.NaN)).toBe(45_000);
+    expect(computeWarmupMargin(300_000, Number.POSITIVE_INFINITY)).toBe(45_000);
+  });
+
+  test("INVARIANT: max 5m margin stays below ttlMs/2 (no two warmups per window)", () => {
+    // A warmup fires when intoWindow >= ttlMs - margin, with cooldown
+    // ttlMs - margin. Two warmups can land in one 5m window only if
+    // margin >= ttlMs - margin ⟺ margin >= ttlMs/2 = 150_000. The size cap must
+    // keep the worst-case margin strictly under that, or a larger cap would
+    // silently reintroduce the double-warm cost regression this PR fixes.
+    const maxMargin = 45_000 + MAX_SIZE_MARGIN_MS;
+    expect(maxMargin).toBeLessThan(300_000 / 2);
+    // And computeWarmupMargin can never exceed that worst case, for any input.
+    for (const tokens of [0, 333_333, 1_000_000, Number.MAX_SAFE_INTEGER]) {
+      expect(computeWarmupMargin(300_000, tokens)).toBeLessThanOrEqual(
+        maxMargin,
+      );
+    }
+  });
 });
 
 describe("buildAnthropicProfile", () => {
@@ -1608,9 +1802,32 @@ describe("buildAnthropicProfile", () => {
     );
   });
 
+  test("5m TTL: prefixTokens threads through to a size-scaled margin", () => {
+    const flat = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+    const scaled = buildAnthropicProfile(
+      "claude-sonnet-4-20250514",
+      "5m",
+      undefined,
+      164_807,
+    );
+    expect(flat.warmupMarginMs).toBe(45_000);
+    expect(scaled.warmupMarginMs).toBeCloseTo(89_497.89, 2);
+    expect(scaled.warmupMarginMs).toBeGreaterThan(flat.warmupMarginMs);
+  });
+
   test("1h TTL has correct parameters", () => {
     const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "1h");
     expect(profile.ttlMs).toBe(3_600_000);
+    expect(profile.warmupMarginMs).toBe(300_000);
+  });
+
+  test("1h TTL: prefixTokens does NOT scale the margin (stays flat 300s)", () => {
+    const profile = buildAnthropicProfile(
+      "claude-sonnet-4-20250514",
+      "1h",
+      undefined,
+      1_000_000,
+    );
     expect(profile.warmupMarginMs).toBe(300_000);
   });
 
@@ -2672,6 +2889,46 @@ describe("shouldWarm tool-call warming", () => {
     const snap = computeWarmingSnapshot(state, now);
     expect(snap.shouldWarmNow).toBe(false);
     expect(snap.notWarmingReason).toContain("Distilled prefix churning");
+    setPrefixChurnForTest(sid, 0); // cleanup
+  });
+
+  test("WIRING: a large prefix opens the warmup window earlier (state.lastInputTokens → snapshot margin)", () => {
+    // End-to-end wiring proof: computeWarmingSnapshot builds the profile
+    // internally from state.lastInputTokens, so a large prefix scales the 5m
+    // margin and opens the window earlier. At idleMs=200s the SAME session
+    // warms with a 300K prefix (margin 126s → window opens at 174s) but is
+    // "still too early" with a 60K prefix (margin 61.2s → window opens at
+    // 238.8s). A mutation passing 0 (flat 45s margin → window at 255s) would
+    // make the 300K case fail. Tool-call path is used because it bypasses the
+    // survival/return-probability model, isolating the window decision.
+    const sid = "margin-wiring-session";
+    setPrefixChurnForTest(sid, 0); // defensive: no churn suppression
+    const now = Date.now();
+    const warmup = {
+      lastWarmupAt: now - 270_000,
+      warmupCount: 1,
+      totalWarmups: 10,
+      warmupHits: 10, // clears ROI + evidence gates
+      disabled: false,
+    };
+    // idleMs = 200s, between the two window-open thresholds.
+    const big = makeToolCallState({
+      sessionID: sid,
+      lastRequestTime: now - 200_000,
+      lastInputTokens: 300_000,
+      warmup,
+    });
+    expect(computeWarmingSnapshot(big, now).shouldWarmNow).toBe(true);
+
+    const small = makeToolCallState({
+      sessionID: sid,
+      lastRequestTime: now - 200_000,
+      lastInputTokens: 60_000, // still ≥ MIN_INPUT_TOKENS_FOR_WARMING
+      warmup,
+    });
+    const snap = computeWarmingSnapshot(small, now);
+    expect(snap.shouldWarmNow).toBe(false);
+    expect(snap.notWarmingReason).toContain("not in warmup window");
     setPrefixChurnForTest(sid, 0); // cleanup
   });
 

--- a/packages/gateway/test/vertex.test.ts
+++ b/packages/gateway/test/vertex.test.ts
@@ -273,6 +273,39 @@ describe("resolveProfile — vertex warming", () => {
     expect("model" in warmup).toBe(false);
     expect(warmup.anthropic_version).toBe("vertex-2023-10-16");
   });
+
+  test("threads prefixTokens through to a size-scaled 5m margin", () => {
+    // Vertex Claude uses Anthropic prompt caching, so it is exposed to the same
+    // large-prefix TTL-race partial as the first-party path — the size-aware
+    // margin must apply here too (computeWarmupMargin).
+    const flat = resolveProfile(
+      "claude-opus-4-8",
+      "vertex",
+      "5m",
+      vertexBase,
+      "google-vertex",
+    );
+    const scaled = resolveProfile(
+      "claude-opus-4-8",
+      "vertex",
+      "5m",
+      vertexBase,
+      "google-vertex",
+      164_807,
+    );
+    expect(flat?.warmupMarginMs).toBe(45_000);
+    expect(scaled?.warmupMarginMs).toBeCloseTo(89_497.89, 2);
+    // 1h vertex stays flat regardless of prefix size.
+    const oneHour = resolveProfile(
+      "claude-opus-4-8",
+      "vertex",
+      "1h",
+      vertexBase,
+      "google-vertex",
+      1_000_000,
+    );
+    expect(oneHour?.warmupMarginMs).toBe(300_000);
+  });
 });
 
 describe("vertex-auth — ADC token seam", () => {


### PR DESCRIPTION
## Problem

A partial warmup was observed in production (session `1F4OWImUH0Nhn4x3`):
input=164,807 tokens, cacheRead=44,153, cacheWrite=120,652 → **27% hit, \$0.78 cost**, with `ageSinceCacheTouch=281s` against a 300s TTL (only 19s headroom).

A 164K prefix spans 3 cache blocks, each with its own effective TTL boundary. The flat **45s** warmup margin is insufficient for large multi-block prefixes: a big conversation block sitting against the 5-minute wall crosses its per-block boundary inside the headroom window, so the warmup lands as a partial (head block refreshed, large block rewritten).

## Fix

The headroom a prefix needs to clear its largest block's boundary is **absolute** (a function of prefix size), **not a fraction of the TTL** (a fraction would balloon the 1h margin to 24 min = thrash).

New pure function `computeWarmupMargin(ttlMs, prefixTokens)`:
- **5m TTL**: `45s + prefixTokens × 0.27ms`, capped at `+90s` → tops out at **135s** (cap bites past ~333K tokens), always well under the 300s TTL.
- **1h TTL**: stays **flat at 300s** (already dwarfs any realistic prefix's headroom).
- `prefixTokens=0` (callers without a live session) reproduces the original flat base — **byte-identical back-compat**.

`state.lastInputTokens` is threaded through `resolveProfile` at every Anthropic-cache warming path:
- live warming loop (`idle.ts`)
- dashboard snapshot (`computeWarmingSnapshot`)
- `buildVertexProfile` — Vertex Claude also uses Anthropic prompt caching, so it gets the same fix (it would otherwise stay on the flat margin).

## Tests

- 8 `computeWarmupMargin` unit tests: 5m base/back-compat, 1h flat (incl. huge prefix), linear scaling (literal-pinned constant), the 164K incident value, cap behavior, monotonicity, margin-never-reaches-TTL invariant, negative-guard.
- `buildAnthropicProfile` + `resolveProfile` + Vertex `resolveProfile` threading tests.
- End-to-end **WIRING** test through `computeWarmingSnapshot`: a 300K prefix opens the warmup window at idle=200s while a 60K prefix is still "too early" — proving `state.lastInputTokens` flows into the internally-built margin.

### Mutation testing
- **M1** (snapshot call site → `0`): killed by the WIRING test.
- **M2** (`MARGIN_PER_TOKEN_MS` 0.27→0.30): killed by 4 tests.
- **M3** (`MAX_SIZE_MARGIN_MS` cap 90k→100k): killed by the cap test.
- **M4** (Vertex branch drops `prefixTokens`): killed by the Vertex threading test.
- All baselines restored byte-identical (sha256-verified).

## Verification
- Full gateway suite: 2263 passed / 29 skipped.
- Typecheck clean (all 5 packages); Biome clean on changed files.
- New tests stable across 3 consecutive runs (no flakiness).