### PR TITLE
docs(website): "Why memory is not enough" blog post + mobile hamburger nav

### DIFF
--- a/packages/website/public/theme.css
+++ b/packages/website/public/theme.css
@@ -1082,3 +1082,79 @@ footer {
   body { cursor: auto; }
   .cursor { display: none; }
 }
+
+/* Mobile navigation (hamburger) for the marketing pages.
+   Hidden on desktop; the existing .nav-links handle wide viewports. */
+.nav-mobile { display: none; }
+
+.nav-burger {
+  list-style: none;
+  display: inline-flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 5px;
+  width: 2.6rem;
+  height: 2.6rem;
+  padding: 0 .55rem;
+  border: 1px solid rgba(196, 221, 199, .28);
+  border-radius: 4px;
+  cursor: pointer;
+  box-sizing: border-box;
+}
+.nav-burger::-webkit-details-marker { display: none; }
+.nav-burger span {
+  display: block;
+  height: 2px;
+  width: 100%;
+  background: var(--c0);
+  border-radius: 2px;
+  transition: transform .25s var(--ease), opacity .2s ease;
+}
+.nav-mobile[open] .nav-burger span:nth-child(1) { transform: translateY(7px) rotate(45deg); }
+.nav-mobile[open] .nav-burger span:nth-child(2) { opacity: 0; }
+.nav-mobile[open] .nav-burger span:nth-child(3) { transform: translateY(-7px) rotate(-45deg); }
+
+.nav-mobile-panel { display: none; }
+.nav-mobile[open] .nav-mobile-panel {
+  display: flex;
+  flex-direction: column;
+  position: absolute;
+  top: calc(100% + .7rem);
+  right: 0;
+  min-width: 220px;
+  padding: .7rem;
+  background: var(--ink);
+  border: 1px solid rgba(255, 255, 255, .08);
+  border-radius: 6px;
+  box-shadow: 0 14px 34px rgba(0, 0, 0, .38);
+}
+.nav-mobile-panel ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+.nav-mobile-panel li a {
+  display: block;
+  padding: .6rem .5rem;
+  font-family: var(--sans);
+  font-size: 1rem;
+  color: rgba(247, 242, 232, .85);
+  transition: color .2s ease;
+}
+.nav-mobile-panel li a:hover { color: var(--c0); }
+.nav-mobile-cta {
+  margin-top: .5rem;
+  text-align: center;
+  font-size: .95rem;
+  padding: .6rem 1rem;
+}
+
+@media (max-width: 900px) {
+  /* Show the hamburger and declutter the bar; links live in the panel. */
+  .nav-mobile { display: block; position: relative; }
+  .nav-right > .nav-socials,
+  .nav-right > .nav-btn { display: none; }
+  .nav-right { gap: 1rem; }
+}

--- a/packages/website/src/components/MobileNav.astro
+++ b/packages/website/src/components/MobileNav.astro
@@ -1,0 +1,31 @@
+---
+const base = import.meta.env.BASE_URL;
+
+const links = [
+  { label: "The Problem", href: `${base}#problem` },
+  { label: "How It Works", href: `${base}#how` },
+  { label: "Features", href: `${base}#features` },
+  { label: "Why Lore", href: `${base}different/` },
+  { label: "Docs", href: `${base}docs/` },
+  { label: "Blog", href: `${base}blog/` },
+  { label: "Folk Lore", href: `${base}#waitlist` },
+];
+---
+
+<details class="nav-mobile">
+  <summary class="nav-burger" aria-label="Toggle navigation menu">
+    <span></span><span></span><span></span>
+  </summary>
+  <div class="nav-mobile-panel">
+    <ul>
+      {
+        links.map((link) => (
+          <li>
+            <a href={link.href}>{link.label}</a>
+          </li>
+        ))
+      }
+    </ul>
+    <a href={`${base}docs/`} class="nav-btn nav-mobile-cta">Get Started</a>
+  </div>
+</details>

--- a/packages/website/src/content.config.ts
+++ b/packages/website/src/content.config.ts
@@ -13,6 +13,7 @@ const blog = defineCollection({
   loader: glob({ pattern: "**/*.{md,mdx}", base: "./src/content/blog" }),
   schema: z.object({
     title: z.string(),
+    subtitle: z.string().optional(),
     description: z.string(),
     pubDate: z.date(),
     updatedDate: z.date().optional(),

--- a/packages/website/src/content/blog/why-memory-is-not-enough.md
+++ b/packages/website/src/content/blog/why-memory-is-not-enough.md
@@ -1,5 +1,6 @@
 ---
-title: "Why memory is not enough: you need context management"
+title: "Why memory is not enough"
+subtitle: "You need context management"
 description: A long-term memory store remembers what you said last week. It can't manage the context window that's overflowing right now. Those are two different problems, and only one of them is getting solved.
 pubDate: 2026-06-26
 author: Lore Team

--- a/packages/website/src/content/blog/why-memory-is-not-enough.md
+++ b/packages/website/src/content/blog/why-memory-is-not-enough.md
@@ -1,0 +1,218 @@
+---
+title: "Why memory is not enough: you need context management"
+description: A long-term memory store remembers what you said last week. It can't manage the context window that's overflowing right now. Those are two different problems, and only one of them is getting solved.
+pubDate: 2026-06-26
+author: Lore Team
+tags:
+  - memory
+  - context management
+  - agents
+---
+
+Ask anyone building agents what "memory" means and you'll get the same answer: a place to
+store facts and decisions so the agent can retrieve them later. A vector DB, a knowledge
+graph, a directory of notes, take your pick. It remembers what you discussed last week.
+That part is real, it's useful, and there are now solid tools that do it well.
+
+Now ask a different question. What happens when the session you're in *right now* crosses
+180K tokens and the agent starts forgetting how it began?
+
+The answer you tend to get is a list of chores.
+
+Spin up a background agent so the heavy work stays off your main thread. Write the plan to
+a file. Then a second plan, and a third, stacked on top of each other. Open a trail of
+GitHub issues. Leave notes in scratch markdown files. Keep a tidy `AGENTS.md`, and prompt
+more carefully while you're at it. Every one of these is the same move: manually push state
+*out* of the window and hope it finds its way back when it matters. That isn't managing
+your context. It's you doing the filing.
+
+Maybe your tools handle that filing for you now, pulling it straight from the conversation
+so you never lift a finger. Better, but capture was never the hard part. What gets written
+down isn't the question. What stays in the window *this turn* is, and saving it off to a
+store, by hand or automatically, doesn't decide that.
+
+And when the filing isn't enough, when the window actually fills mid-task, the one
+automatic mechanism every major agent ships finally kicks in: compaction. The client
+summarizes the older turns into a lossy blob, drops the originals from the window, and hands
+you back an agent that was a genius a minute ago and now can't quite remember its own name.
+
+This is the fix we all quietly accepted, or got talked into, for something that happens
+*every single session*. Often more than once in the same one. Sit with that for a second:
+the most predictable failure in agentic coding, the one you can set your watch by, and the
+state of the art is a guillotine that drops the moment you fall behind. Nobody set out to
+confuse context management with memory. We just decided the window was your problem to
+babysit, and moved on. So why has nobody built the thing that actually keeps up?
+
+## Two problems hiding behind one word
+
+| What you say | What it actually needs |
+|---|---|
+| "What did we decide about auth last week?" | A long-term memory store. |
+| "Wait, what was the other thing you said we should do after this?" | Active context-window management. |
+
+These are not the same layer. A long-term store sits *beside* your conversation, like a
+notebook you keep open on the desk. It only holds what you bothered to write down, and it
+only helps when you reach for it. That's exactly right for what carries across sessions: a
+decision, a preference, a constraint from days ago. This part has had real product
+attention, and it shows.
+
+The live window is the other half, and it's the one you're left to manage by hand, mid-task.
+People do this well, but it's a tax: every note you set down pulls your focus off the actual
+problem, and you have to remember to pick it back up later. And every tool for it is the
+same shape: static (a markdown file the model may or may not read), offline (an indexer you
+run between sessions), or just advice ("prompt better"). None of it is in the loop at the one
+moment that matters, when the window is overflowing *while you work*. The one mechanism that
+does fire on its own is compaction.
+
+## A store on the sidelines can't intervene
+
+That compaction step is triage with a blunt instrument: it runs whether or not it's about to
+drop something you still need, with no idea what's worth keeping. Now bolt the best long-term
+memory store on the planet onto the same session. What changes? Nothing. The store can answer
+a question *if you ask it*, but compaction doesn't ask questions. It just runs. The store
+never gets a vote on what survives. So you can have flawless recall of last week and still
+watch the agent get amnesia at 200K tokens.
+
+Some tools go further than a hand-fed store: they keep the entire conversation and let you
+search over it. That's genuinely better, and it's worth saying so. But searching is
+something *you* have to do, after you've already noticed something went missing, and
+whatever you pull back lands in the same window that was overflowing in the first place.
+You found the needle, and the haystack is still on fire. And automating the search doesn't
+save it: async, agent-native retrieval still drops what it finds into the same window, and
+still never decides what *leaves* it.
+
+There's a quieter cost on top of that: models use what's already in the window far more
+reliably than what they have to go fetch. Hand a model the relevant text in-context and it
+beats retrieving the same text on quality
+([Li et al.](https://arxiv.org/abs/2407.16833)), and what it does hold, it reads best at the
+front and back of the window, not buried in the middle
+([*Lost in the Middle*](https://arxiv.org/abs/2307.03172)). Retrieval does have one honest
+advantage worth naming: it can be cheaper, because pulling a few relevant snippets into the
+prompt costs less than carrying the whole history. But that discount only exists if a small
+slice can stand in for everything else, and an agent session doesn't work that way. The
+window only grows as you go, the conversation *is* the context, and against a closed model
+from OpenAI or Anthropic you can't reach in and swap it for a slice. Retrieval can only add
+to the window, never stand in for it. The cheap version of RAG isn't on the table; the one
+you can run just makes the window bigger.
+
+## What managing the window actually looks like
+
+Two hundred turns deep, that means keeping the auth decision and the path of the file you're
+editing, and dropping the stale 4,000-token test dump, without anyone having to ask. To make
+that call on every turn, instead of letting a blunt summarizer maul the whole thing at the
+boundary, a few things have to be true:
+
+- **A distilled prefix, not a flattened summary.** Compress the early conversation into a
+  dense, structured record of what was established: the decisions, the shape of the work,
+  the constraints. Keep that record at the *front* of the window where the model can always
+  see it. Not "a paragraph about the first hour". The load-bearing facts, kept.
+- **Gradual, layered compression, not a cliff.** Full passthrough while there's room. As
+  pressure builds, compress the raw turns behind the distilled prefix. Under more pressure,
+  strip what ages worst first: stale tool output, redundant dumps. Emergency compression is
+  the last resort, not the opening move.
+- **Calibrated from real token counts, not guesses.** The window is a hard budget. What
+  gets cut should follow the actual token counts the API reports back, and what each
+  model's real context and pricing are. Not a character cap hardcoded once and forgotten.
+- **Some things are never cut.** The most recent turns stay intact, always. Whatever
+  happens upstream, the live edge of the conversation is protected. That's where the work
+  is happening.
+
+The point isn't cleverness. It's that *something is actively deciding what stays in the
+window on every turn*, in the loop, instead of a one-shot summarizer flattening the session
+the moment it overflows.
+
+## Two layers, one stack
+
+This isn't memory *versus* context management. You need both, and they stack:
+
+1. **Temporal storage.** Everything that's said, captured and indexed, so nothing is truly
+   lost even after it leaves the window.
+2. **Distillation.** That history compressed into a dense prefix, so the established facts
+   survive context pressure and stay in front of the model.
+3. **Long-term knowledge.** The durable decisions, patterns, and preferences pulled out and
+   carried across sessions, retrievable on demand.
+
+That store, layer 3, is what people mean today when they say "memory". It's the top of the
+stack, not the whole stack. Without the two layers under it, it's a filing cabinet next to
+a conversation that's quietly falling apart.
+
+## The work this is built on
+
+We didn't invent this architecture, and we want to be clear about that. Two teams got here
+first and proved it works. Sanity's
+[Nuum](https://www.sanity.io/blog/how-we-solved-the-agent-memory-problem) gave us the
+framing we still use, "distillation, not summarization", and showed a three-tier memory
+staying coherent across thousands of messages. (Simen Svale's description of compaction as
+"JPEG compression of memory management" is hard to forget once you've read it.) Mastra's
+[Observational Memory](https://mastra.ai/research/observational-memory) worked out the
+observer/reflector loop and the move from rigid JSON to plain, timestamped observation
+logs. Lore is built on both, and it's better for it. Their write-ups are worth your time.
+
+There's a catch, though. Both teams shipped this architecture *inside their own agent*.
+Nuum is a standalone REPL (Anthropic-only, yolo-mode, built to power Sanity's Miriad).
+Observational Memory lives inside the Mastra framework. The memory is excellent. The
+packaging is the constraint. Almost no one is going to replace the coding agent they
+already rely on just to get a context-management layer.
+
+## A layer, not a harness
+
+So that's the gap: take the same ideas and unhook them from the harness. Deliver them as a
+layer that works with whatever agent you're already using, on whatever provider you're
+already paying for.
+
+Here's the distinction that actually matters, and it's easy to miss now that everything
+calls itself memory. A store is a tool the agent reaches for: it sits off to the side and
+answers when it's asked, however clever the asking has gotten. A layer sits *in the request
+path*. Every turn flows through it, and it can reshape that turn before the model ever sees
+it. That position, in the path instead of beside it, is the only one from which you can
+manage the live window at all.
+
+It's also the most invasive seat in the system, and that's worth being honest about. A
+thing that sees every token of every session only earns that seat if it's *yours*: a single
+file on your own disk, no account to create, no database to run, nothing leaving your
+machine unless you choose to share it. It's also why this is
+[Fair Source](https://fair.io) (FSL-1.1-Apache-2.0): the code that touches your tokens is
+right there to read, and it turns into Apache 2.0 on a timer. That last part is hard for a
+cloud service to follow you into. Routing every token through someone else's box is a lot to
+ask, and a lot for that box to be responsible for. The seat really only makes sense when
+you're the one sitting in it.
+
+That same vantage point, seeing every request as it happens, is also the right home for a
+lot more than distillation:
+
+- **Warm the cache automatically**, so you're not paying full price for a cold context at
+  the start of every session.
+- **Extract long-term knowledge on its own**: decisions, conventions, gotchas, without you
+  remembering to save anything.
+- **Recognize patterns** in how you and your agent actually work, and act on them.
+- **Track token spend** day to day, across every agent you run.
+
+That last one is quietly becoming the point. As model and token costs climb, the layer that
+sees every request is exactly where cost control belongs, and because it runs on your own
+machine, there's no infrastructure bill and no per-request meter to feed. A store on the
+sidelines can't do any of this. Plenty of them run the other way: a server you're renting,
+an extra model call to extract and index every exchange, and a metered fee on top of the
+requests you were already paying for.
+
+And once memory lives in that layer instead of inside one agent, it stops belonging to any
+single agent. Your context follows you. Move from Claude Code to Codex to OpenCode, or reach
+for a different agent on a different task, and the same memory comes along. A team running a
+mix shares one knowledge base instead of three separate silos. That portability isn't the
+trick. It's just what falls out once the memory no longer lives inside the harness.
+
+Memory is the wedge. The layer is the platform.
+
+## The one question worth asking
+
+Next time something is pitched to you as agent "memory", ask one question:
+
+> **What happens at 200K tokens?**
+
+If the answer is some version of "you can search what we stored", or worse, "write a better
+context file", then it's a storage tool, and the part that actually breaks mid-session is
+still yours to handle. That's fine, and a good store is genuinely worth having. But it has
+no answer for the session that's overflowing right now, which is the problem you'll hit
+today, not next week.
+
+Memory is table stakes. Managing the window, in the loop, while it fills, is the part
+nobody wants to build. Make sure you know which one you're being sold.

--- a/packages/website/src/pages/blog/[slug].astro
+++ b/packages/website/src/pages/blog/[slug].astro
@@ -17,6 +17,7 @@ const { Content } = await render(post);
     <header>
       <p class="eyebrow">{post.data.author}</p>
       <h1>{post.data.title}</h1>
+      {post.data.subtitle && <p class="blog-subtitle">{post.data.subtitle}</p>}
       <time datetime={post.data.pubDate.toISOString()}>
         {post.data.pubDate.toLocaleDateString("en", { month: "long", day: "numeric", year: "numeric" })}
       </time>

--- a/packages/website/src/pages/different.astro
+++ b/packages/website/src/pages/different.astro
@@ -1,6 +1,7 @@
 ---
 import siteJs from "../scripts/site.js?raw";
 import Logo from "../components/Logo.astro";
+import MobileNav from "../components/MobileNav.astro";
 import SocialMeta from "../components/SocialMeta.astro";
 
 const base = import.meta.env.BASE_URL;
@@ -53,6 +54,7 @@ const base = import.meta.env.BASE_URL;
         <a href="https://github.com/byk/loreai" target="_blank" rel="noopener noreferrer" class="social-link" aria-label="Lore.AI on GitHub"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.043-1.61-4.043-1.61-.546-1.387-1.333-1.757-1.333-1.757-1.09-.745.083-.73.083-.73 1.205.085 1.84 1.237 1.84 1.237 1.07 1.835 2.807 1.305 3.492.998.108-.776.418-1.305.762-1.605-2.665-.3-5.467-1.332-5.467-5.93 0-1.31.468-2.38 1.235-3.22-.123-.303-.535-1.523.118-3.176 0 0 1.008-.322 3.3 1.23a11.48 11.48 0 0 1 3.003-.404c1.02.005 2.045.138 3.003.404 2.29-1.552 3.295-1.23 3.295-1.23.655 1.653.243 2.873.12 3.176.77.84 1.233 1.91 1.233 3.22 0 4.61-2.807 5.625-5.48 5.922.43.372.823 1.102.823 2.222 0 1.605-.015 2.898-.015 3.293 0 .32.218.695.825.577C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" /></svg></a>
       </div>
       <a href={`${base}docs/`} class="nav-btn">Get Started</a>
+      <MobileNav />
     </div>
   </nav>
 

--- a/packages/website/src/pages/index.astro
+++ b/packages/website/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import siteJs from "../scripts/site.js?raw";
 import Logo from "../components/Logo.astro";
+import MobileNav from "../components/MobileNav.astro";
 import SocialMeta from "../components/SocialMeta.astro";
 
 const base = import.meta.env.BASE_URL;
@@ -54,6 +55,7 @@ const base = import.meta.env.BASE_URL;
         <a href="https://github.com/byk/loreai" target="_blank" rel="noopener noreferrer" class="social-link" aria-label="Lore.AI on GitHub"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.043-1.61-4.043-1.61-.546-1.387-1.333-1.757-1.333-1.757-1.09-.745.083-.73.083-.73 1.205.085 1.84 1.237 1.84 1.237 1.07 1.835 2.807 1.305 3.492.998.108-.776.418-1.305.762-1.605-2.665-.3-5.467-1.332-5.467-5.93 0-1.31.468-2.38 1.235-3.22-.123-.303-.535-1.523.118-3.176 0 0 1.008-.322 3.3 1.23a11.48 11.48 0 0 1 3.003-.404c1.02.005 2.045.138 3.003.404 2.29-1.552 3.295-1.23 3.295-1.23.655 1.653.243 2.873.12 3.176.77.84 1.233 1.91 1.233 3.22 0 4.61-2.807 5.625-5.48 5.922.43.372.823 1.102.823 2.222 0 1.605-.015 2.898-.015 3.293 0 .32.218.695.825.577C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" /></svg></a>
       </div>
       <a href={`${base}docs/`} class="nav-btn">Get Started</a>
+      <MobileNav />
     </div>
   </nav>
 

--- a/packages/website/src/styles/blog.css
+++ b/packages/website/src/styles/blog.css
@@ -111,27 +111,151 @@
 }
 
 .blog-post {
+  width: min(720px, calc(100% - 3rem));
   padding: 5rem 0 7rem;
 }
 
 .blog-post header {
-  margin: 2rem 0 3rem;
+  margin: 2rem 0 3.5rem;
 }
 
 .blog-post h1 {
-  max-width: 820px;
-  font-size: clamp(2.4rem, 5vw, 4.5rem);
+  font-size: clamp(2.4rem, 5vw, 4rem);
   line-height: 1.08;
 }
 
+.blog-post .blog-subtitle {
+  margin: .8rem 0 0;
+  max-width: none;
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: clamp(1.3rem, 3vw, 1.9rem);
+  line-height: 1.2;
+  color: var(--g2);
+}
+
+.blog-post time {
+  display: block;
+  margin: 1.6rem 0 .5rem;
+}
+
+.blog-post header p:not(.blog-subtitle) {
+  margin: 0;
+  font-size: 1.1rem;
+  line-height: 1.6;
+}
+
 .blog-prose {
-  max-width: 760px;
+  max-width: none;
 }
 
 .blog-prose p,
 .blog-prose li {
   color: var(--ink);
   font-size: 1.05rem;
+  line-height: 1.75;
+}
+
+.blog-prose p,
+.blog-prose ul,
+.blog-prose ol,
+.blog-prose blockquote,
+.blog-prose pre,
+.blog-prose table {
+  margin: 0 0 1.4rem;
+}
+
+.blog-prose > :first-child {
+  margin-top: 0;
+}
+
+.blog-prose h2 {
+  margin: 2.8rem 0 1rem;
+  font-family: var(--serif);
+  font-weight: 500;
+  font-size: 1.75rem;
+  line-height: 1.2;
+  color: var(--g0);
+}
+
+.blog-prose h3 {
+  margin: 2.2rem 0 .8rem;
+  font-family: var(--serif);
+  font-weight: 500;
+  font-size: 1.3rem;
+  line-height: 1.25;
+  color: var(--g0);
+}
+
+.blog-prose ul,
+.blog-prose ol {
+  padding-left: 1.3rem;
+}
+
+.blog-prose li {
+  margin-bottom: .5rem;
+}
+
+.blog-prose li:last-child {
+  margin-bottom: 0;
+}
+
+.blog-prose a {
+  color: var(--g1);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+
+.blog-prose a:hover {
+  color: var(--g0);
+}
+
+.blog-prose :not(pre) > code {
+  padding: .12em .35em;
+  border-radius: 3px;
+  background: var(--c1);
+  font-size: .9em;
+}
+
+.blog-prose blockquote {
+  padding: .4rem 0 .4rem 1.3rem;
+  border-left: 3px solid var(--g3);
+  color: var(--g1);
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 1.45rem;
+  line-height: 1.3;
+}
+
+.blog-prose blockquote p {
+  margin: 0;
+}
+
+.blog-prose table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 1rem;
+}
+
+.blog-prose th,
+.blog-prose td {
+  padding: .7rem .9rem;
+  border: 1px solid var(--c2);
+  text-align: left;
+  vertical-align: top;
+  line-height: 1.55;
+}
+
+.blog-prose thead th {
+  background: var(--c1);
+  color: var(--g0);
+  font-weight: 600;
+}
+
+.blog-prose tbody tr:nth-child(even) td {
+  background: var(--c1);
 }
 
 .blog-prose pre {


### PR DESCRIPTION
Publishes the memory-vs-context-management post to the website blog (`packages/website/src/content/blog/why-memory-is-not-enough.md`).

The post argues that "memory" (a long-term store of facts/decisions) and **context-window management** (deciding what stays in the live window mid-session) are two different layers, and only the first is well-served today. It walks the three-tier stack (temporal storage → distillation → long-term knowledge), credits Sanity's Nuum and Mastra's Observational Memory for the architecture, and frames Lore as a *layer in the request path* rather than a harness.

This is the final draft from the long review thread on #663 (rev 9), moved out of the GitHub comment and onto the site.

### Notes
- No banner image: the site uses a single global OG image, so no per-post asset is needed.
- Title renders from frontmatter as `<h1>`; in-body sections are `<h2>`.
- All citations are external links (arXiv, Sanity, Mastra, fair.io); no internal links to prefix.
- Verified `astro build` succeeds and the page generates at `/blog/why-memory-is-not-enough/`.

Closes #663