### PR TITLE
fix(core): don't re-run vector scan on main thread after pool timeout

### DIFF
--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -1266,7 +1266,10 @@ export function l2Normalize(vec: Float32Array): Float32Array {
 /**
  * Run `spec` on the read-worker pool when it's enabled and healthy (off the
  * main event loop), otherwise synchronously in-process. The pool call never
- * throws — it returns null when unavailable so we transparently fall back.
+ * throws: it returns null when unavailable (disabled/broken/errored) so we
+ * transparently fall back in-process, or the VECTOR_SEARCH_TIMED_OUT sentinel
+ * when the worker is alive but slow — in which case we return an empty result
+ * rather than re-running the scan on the main thread.
  */
 async function poolOrInProcess(
   spec: VectorQuerySpec,

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -44,7 +44,7 @@ import {
   type VectorHit,
   type VectorQuerySpec,
 } from "./vector-query";
-import { tryPoolVectorSearch } from "./vector-pool";
+import { tryPoolVectorSearch, VECTOR_SEARCH_TIMED_OUT } from "./vector-pool";
 
 // The cosine/BLOB helpers moved to ./vector-query (a leaf module the read
 // worker can import without pulling in the provider chain). Re-exported here so
@@ -1273,6 +1273,11 @@ async function poolOrInProcess(
   queryEmbedding: Float32Array,
 ): Promise<VectorHit[] | DistillationVectorHit[]> {
   const pooled = await tryPoolVectorSearch(spec, queryEmbedding);
+  // Timed out: the worker is alive but slow. Return empty — degrading this one
+  // recall — rather than re-running the O(n) scan on the main thread, which
+  // re-blocks the event loop (the stall bug). Worker-query cancellation and a
+  // recency cap on the scan land in follow-up PRs.
+  if (pooled === VECTOR_SEARCH_TIMED_OUT) return [];
   if (pooled !== null) return pooled;
   return runVectorQuery(db(), isVecAvailable(), queryEmbedding, spec);
 }

--- a/packages/core/src/vector-pool.ts
+++ b/packages/core/src/vector-pool.ts
@@ -50,10 +50,13 @@ const DEFAULT_VECTOR_SEARCH_TIMEOUT_MS = 10_000;
  *  an empty result and leave the main thread free. */
 export const VECTOR_SEARCH_TIMED_OUT = Symbol("vector-search-timed-out");
 
-/** Resolve the per-request timeout, honoring LORE_VEC_SEARCH_TIMEOUT_MS (a
- *  positive integer in ms). Falls back to {@link DEFAULT_VECTOR_SEARCH_TIMEOUT_MS}
- *  when unset or invalid. Read per call to match the kill-switch env pattern. */
+/** Resolve the per-request vector-search timeout. Read per call (not cached)
+ *  to match the kill-switch env pattern. */
 export function vectorSearchTimeoutMs(): number {
+  // LORE_VEC_SEARCH_TIMEOUT_MS overrides the per-request vector-search timeout
+  // (a positive integer in milliseconds; invalid or non-positive values are
+  // ignored). Defaults to 10000 (10s). On timeout, recall degrades to an empty
+  // result instead of re-running the O(n) scan on the main thread.
   const raw = process.env.LORE_VEC_SEARCH_TIMEOUT_MS;
   if (raw !== undefined) {
     const n = Number(raw);

--- a/packages/core/src/vector-pool.ts
+++ b/packages/core/src/vector-pool.ts
@@ -36,9 +36,31 @@ import type {
   VectorWorkerOutbound,
 } from "./vector-worker-types";
 
-/** Per-request timeout. A hung worker must never hang recall — on timeout we
- *  reject (→ caller falls back in-process). Generous vs. a sub-ms vec scan. */
-const VECTOR_SEARCH_TIMEOUT_MS = 5_000;
+/** Per-request timeout. A hung/slow worker must never hang recall. On timeout
+ *  we resolve {@link VECTOR_SEARCH_TIMED_OUT} (NOT reject, NOT in-process
+ *  fallback): the worker is alive but slow, so re-running the same O(n) scan on
+ *  the main thread would just re-block the event loop — that was the stall bug.
+ *  Generous vs. a sub-ms vec scan; override with LORE_VEC_SEARCH_TIMEOUT_MS. */
+const DEFAULT_VECTOR_SEARCH_TIMEOUT_MS = 10_000;
+
+/** Resolved (never rejected) by {@link tryPoolVectorSearch} when the pool was
+ *  used but the request exceeded {@link vectorSearchTimeoutMs}. Distinct from
+ *  `null` — which means the pool was disabled / broken / errored and the caller
+ *  SHOULD run the in-process path. On a timeout the caller must instead return
+ *  an empty result and leave the main thread free. */
+export const VECTOR_SEARCH_TIMED_OUT = Symbol("vector-search-timed-out");
+
+/** Resolve the per-request timeout, honoring LORE_VEC_SEARCH_TIMEOUT_MS (a
+ *  positive integer in ms). Falls back to {@link DEFAULT_VECTOR_SEARCH_TIMEOUT_MS}
+ *  when unset or invalid. Read per call to match the kill-switch env pattern. */
+export function vectorSearchTimeoutMs(): number {
+  const raw = process.env.LORE_VEC_SEARCH_TIMEOUT_MS;
+  if (raw !== undefined) {
+    const n = Number(raw);
+    if (Number.isFinite(n) && n > 0) return Math.floor(n);
+  }
+  return DEFAULT_VECTOR_SEARCH_TIMEOUT_MS;
+}
 
 /** Default worker count when config doesn't specify. Small: the goal is to
  *  unblock the main loop, not to parallelize an infrequent, sub-ms scan. */
@@ -296,14 +318,18 @@ function leastBusy(live: PoolWorker[]): PoolWorker | null {
 }
 
 /**
- * Run a vector search on the pool. Resolves to the hits, or to `null` when the
- * pool is disabled/unavailable/failed (the caller then runs the in-process
- * path). Never rejects.
+ * Run a vector search on the pool. Resolves to:
+ *   - the hits, on success;
+ *   - `null` when the pool is disabled/unavailable/failed → the caller runs the
+ *     in-process path;
+ *   - {@link VECTOR_SEARCH_TIMED_OUT} when the request timed out → the caller
+ *     returns an empty result WITHOUT re-running the scan on the main thread.
+ * Never rejects.
  */
 export async function tryPoolVectorSearch(
   spec: VectorQuerySpec,
   embedding: Float32Array,
-): Promise<Hits | null> {
+): Promise<Hits | null | typeof VECTOR_SEARCH_TIMED_OUT> {
   if (!poolEnabled()) return null;
   // Everything below is wrapped so the "never throws" contract holds by
   // construction — any unexpected throw (e.g. from ensurePool) resolves to null
@@ -314,33 +340,43 @@ export async function tryPoolVectorSearch(
     if (!pw) return null;
 
     const id = nextRequestId++;
-    return await new Promise<Hits>((resolve, reject) => {
-      const timer = setTimeout(() => {
-        pw.inflight.delete(id);
-        reject(new Error("vector worker search timed out"));
-      }, VECTOR_SEARCH_TIMEOUT_MS);
-      // The worker is already unref'd (makeWorker), so an in-flight search must
-      // not be the thing that keeps the event loop alive: unref the timeout too,
-      // or a pending request delays process exit by up to
-      // VECTOR_SEARCH_TIMEOUT_MS on shutdown. (review #989)
-      timer.unref();
-      pw.inflight.set(id, { resolve, reject, timer });
-      try {
-        const msg: VectorWorkerInbound = {
-          type: "search",
-          id,
-          spec,
-          embedding,
-        };
-        pw.worker.postMessage(msg);
-      } catch (err) {
-        // The worker died in the window after leastBusy() picked it. Clean up
-        // the timer + inflight entry (don't leak them) and fall back.
-        clearTimeout(timer);
-        pw.inflight.delete(id);
-        reject(err instanceof Error ? err : new Error(String(err)));
-      }
-    });
+    const timeoutMs = vectorSearchTimeoutMs();
+    return await new Promise<Hits | typeof VECTOR_SEARCH_TIMED_OUT>(
+      (resolve, reject) => {
+        const timer = setTimeout(() => {
+          pw.inflight.delete(id);
+          // Resolve a sentinel (don't reject → don't fall back in-process):
+          // the worker is alive but slow; re-running this scan on the main
+          // thread re-blocks the event loop. The abandoned worker query keeps
+          // running until it finishes (cancellation lands in a follow-up).
+          log.info(
+            `vector worker search timed out after ${timeoutMs}ms — returning empty (not re-running in-process)`,
+          );
+          resolve(VECTOR_SEARCH_TIMED_OUT);
+        }, timeoutMs);
+        // The worker is already unref'd (makeWorker), so an in-flight search must
+        // not be the thing that keeps the event loop alive: unref the timeout too,
+        // or a pending request delays process exit by up to the timeout on
+        // shutdown. (review #989)
+        timer.unref();
+        pw.inflight.set(id, { resolve, reject, timer });
+        try {
+          const msg: VectorWorkerInbound = {
+            type: "search",
+            id,
+            spec,
+            embedding,
+          };
+          pw.worker.postMessage(msg);
+        } catch (err) {
+          // The worker died in the window after leastBusy() picked it. Clean up
+          // the timer + inflight entry (don't leak them) and fall back.
+          clearTimeout(timer);
+          pw.inflight.delete(id);
+          reject(err instanceof Error ? err : new Error(String(err)));
+        }
+      },
+    );
   } catch (err) {
     log.info(
       "vector worker search failed; using in-process fallback:",

--- a/packages/core/test/vector-pool.test.ts
+++ b/packages/core/test/vector-pool.test.ts
@@ -72,6 +72,7 @@ afterEach(() => {
   _setTestVectorWorkerFactory(null);
   _resetVectorPoolForTest();
   delete process.env.LORE_DISABLE_VEC_WORKER;
+  delete process.env.LORE_VEC_SEARCH_TIMEOUT_MS;
   vi.useRealTimers();
 });
 
@@ -108,6 +109,40 @@ describe("vector-pool kill switch / disable", () => {
     const hits = await tryPoolVectorSearch(KNOWLEDGE, QUERY);
     expect(hits).toBeNull();
     expect(FakeWorker.instances.length).toBe(0);
+  });
+});
+
+describe("vectorSearchTimeoutMs env override", () => {
+  const DEFAULT_MS = 10_000;
+
+  it("uses the 10s default when unset", () => {
+    delete process.env.LORE_VEC_SEARCH_TIMEOUT_MS;
+    expect(vectorSearchTimeoutMs()).toBe(DEFAULT_MS);
+  });
+
+  it("honors a valid positive integer override", () => {
+    process.env.LORE_VEC_SEARCH_TIMEOUT_MS = "2500";
+    expect(vectorSearchTimeoutMs()).toBe(2500);
+  });
+
+  it("floors a fractional value", () => {
+    process.env.LORE_VEC_SEARCH_TIMEOUT_MS = "100.9";
+    expect(vectorSearchTimeoutMs()).toBe(100);
+  });
+
+  it.each([
+    "abc",
+    "",
+    "  ",
+    "0",
+    "-5",
+    "Infinity",
+    "NaN",
+  ])("ignores invalid/non-positive value %j and falls back to the default", (raw) => {
+    // Guards the setTimeout(Infinity)/NaN foot-gun: a bad value must never
+    // arm a never-firing (or immediately-firing) timer.
+    process.env.LORE_VEC_SEARCH_TIMEOUT_MS = raw;
+    expect(vectorSearchTimeoutMs()).toBe(DEFAULT_MS);
   });
 });
 
@@ -221,7 +256,7 @@ describe("vector-pool structural-failure latch (review #989)", () => {
   });
 
   it("unref()'s the per-request timeout timer so a pending search can't delay exit", async () => {
-    // The actual review-#989 bug: the 5 s timeout timer was ref'd, so an
+    // The actual review-#989 bug: the per-request timeout timer was ref'd, so an
     // in-flight search would hold the event loop open on shutdown even though
     // the worker is unref'd. Spy on the real timer object's unref() — asserting
     // it's called is the only non-vacuous check (removing the source line fails
@@ -254,7 +289,7 @@ describe("vector-pool structural-failure latch (review #989)", () => {
   it("treats a worker init-error message as a structural death", async () => {
     // A reader connection that fails to open surfaces as an init-error message,
     // marking the worker structurally dead. Asserting only null would be vacuous
-    // (the 5s timeout fallback also resolves null); instead assert the dead
+    // (the timeout fallback also resolves the sentinel); instead assert the dead
     // worker is terminated on the next ensurePool — a side effect the timeout
     // path never produces. Pre-fix mutation (init-error → no markDead): the
     // victim stays alive and this fails.
@@ -286,7 +321,7 @@ describe("vector-pool structural-failure latch (review #989)", () => {
 
   it("clears the timer when postMessage throws (no leaked timer)", async () => {
     // A throw in the Promise executor rejects regardless, so asserting null is
-    // vacuous — the actual S2 bug is the 5 s ref'd timer left armed. Assert it
+    // vacuous — the actual S2 bug is the per-request ref'd timer left armed. Assert it
     // was cleared (pre-fix: 1 leaked timer; post-fix: 0).
     vi.useFakeTimers();
     _setTestVectorWorkerFactory((() => {

--- a/packages/core/test/vector-pool.test.ts
+++ b/packages/core/test/vector-pool.test.ts
@@ -5,6 +5,8 @@ import {
   _setTestVectorWorkerFactory,
   shutdownVectorPool,
   tryPoolVectorSearch,
+  VECTOR_SEARCH_TIMED_OUT,
+  vectorSearchTimeoutMs,
 } from "../src/vector-pool";
 import type {
   VectorWorkerInbound,
@@ -117,12 +119,16 @@ describe("vector-pool fallback paths (resolve null, never throw)", () => {
     expect(await tryPoolVectorSearch(KNOWLEDGE, QUERY)).toBeNull();
   });
 
-  it("returns null when the worker never replies (timeout)", async () => {
+  it("resolves the timeout sentinel (NOT null) when the worker never replies", async () => {
+    // The sentinel is what tells the caller "the worker is slow — return empty,
+    // don't re-run the scan in-process". Asserting the sentinel (not null) is
+    // the non-vacuous guard: pre-fix the timeout rejected → caught → null, so
+    // this would fail. (null is reserved for pool disabled/broken/errored.)
     vi.useFakeTimers();
     _setTestVectorWorkerFactory(factoryReturning(() => {}));
     const p = tryPoolVectorSearch(KNOWLEDGE, QUERY);
-    await vi.advanceTimersByTimeAsync(5_001);
-    expect(await p).toBeNull();
+    await vi.advanceTimersByTimeAsync(vectorSearchTimeoutMs() + 1);
+    expect(await p).toBe(VECTOR_SEARCH_TIMED_OUT);
   });
 
   it("returns null and latches broken when spawning throws (no retry)", async () => {
@@ -306,5 +312,27 @@ describe("embedding.vectorSearch routes through the pool", () => {
     const { vectorSearch } = await import("../src/embedding");
     const hits = await vectorSearch(QUERY, 5);
     expect(hits).toEqual([{ id: "via-pool", similarity: 0.42 }]);
+  });
+
+  it("returns empty on pool timeout and does NOT re-run the scan in-process", async () => {
+    // The stall bug: on a pool timeout the consumer used to fall back to the
+    // synchronous O(n) scan on the main thread. Spy on the in-process query so
+    // the guard is non-vacuous — pre-fix this spy WOULD be called (and its
+    // result returned); post-fix the consumer returns [] without touching it.
+    const vq = await import("../src/vector-query");
+    const { vectorSearch } = await import("../src/embedding");
+    const spy = vi
+      .spyOn(vq, "runVectorQuery")
+      .mockReturnValue([{ id: "IN-PROCESS", similarity: 1 }]);
+    try {
+      _setTestVectorWorkerFactory(factoryReturning(() => {})); // never replies
+      vi.useFakeTimers();
+      const p = vectorSearch(QUERY, 5);
+      await vi.advanceTimersByTimeAsync(vectorSearchTimeoutMs() + 1);
+      expect(await p).toEqual([]);
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/packages/website/src/content/docs/docs/environment.md
+++ b/packages/website/src/content/docs/docs/environment.md
@@ -73,6 +73,7 @@ Env vars override `.lore.json` for the same setting. To override a `.lore.json` 
 | `LORE_DISABLE_VEC` | LORE_DISABLE_VEC=1 forces the JS brute-force vector-search path. Useful as a production kill-switch if the native extension causes issues, and as a test seam for the JS fallback. Set before the first `db()` call — once attempted=true is sticky for the connection lifetime, the env var won't be re-read until resetVecState() runs (in close()). |
 | `LORE_DISABLE_VEC_WORKER` | Kill switch: force the in-process vector-search path, disabling the off-thread read-worker pool. Default-on escape hatch, not opt-in. |
 | `LORE_NO_DB_TRACING` | LORE_NO_DB_TRACING=1 returns the raw connection instead of the query-tracing Proxy (disables automatic per-query DB spans). |
+| `LORE_VEC_SEARCH_TIMEOUT_MS` | LORE_VEC_SEARCH_TIMEOUT_MS overrides the per-request vector-search timeout (a positive integer in milliseconds; invalid or non-positive values are ignored). Defaults to 10000 (10s). On timeout, recall degrades to an empty result instead of re-running the O(n) scan on the main thread. |
 
 ## How variables are evaluated
 


### PR DESCRIPTION
## Problem

Production Lore was periodically pegging CPU/RSS and stalling the event loop — symptom: 15 back-to-back `GET /health` requests landing in the same second, ~33 vector-worker timeouts over 6h on a 1.4GB DB.

Root cause: the temporal vector search is an **O(n) full-table scan** over ~106K embeddings (~320MB of BLOBs). It runs in a read-worker pool, but when the pool **timed out** (5s), `tryPoolVectorSearch` resolved `null`, and `poolOrInProcess` (`embedding.ts`) interpreted `null` as "pool unavailable → run in-process" and **re-ran the identical scan synchronously on the main thread**. So a query that was already too slow to finish in 5s got double-paid on the event loop.

## Fix

- On timeout, resolve a dedicated `VECTOR_SEARCH_TIMED_OUT` sentinel instead of `null`. The consumer treats the sentinel as "give up, return `[]`" — never falling back in-process.
- `null` semantics are **unchanged**: pool disabled (`LORE_DISABLE_VEC_WORKER`) or structurally broken still falls back to the in-process path, so the kill switch keeps working.
- Raise the pool timeout **5s → 10s**, overridable via `LORE_VEC_SEARCH_TIMEOUT_MS`.

This is the first of a short series to "stop the bleeding"; a follow-up bounds the scan itself by recency, and another cancels timed-out worker queries so the pool recovers.

## Tests

- `vector-pool.test.ts`: timeout now asserts the sentinel; new consumer test spies on `runVectorQuery` and asserts `vectorSearch` returns `[]` on timeout **without** touching the in-process path.
- Mutation-checked (red/green): reverting to the in-process fallback flips the consumer test to the `IN-PROCESS` result → fails. Non-vacuous.
- Full `@loreai/core` suite green.

## Known follow-up (next PR)

Adversarial review noted that during the interim window — before worker-query cancellation lands — a timed-out worker keeps running its scan, and because we `delete` its inflight entry on timeout, `leastBusy` can keep dispatching new searches to that still-busy worker (they queue behind the slow scan). This is **strictly better** than the old behavior (which blocked the *main* loop) and degrades gracefully (FTS/BM25 still flow), but the real fix is **PR2: cancel timed-out worker queries so the pool recovers**, which removes the wedged-worker condition at its root.