### PR TITLE
perf(core): cap the temporal vector scan by recency

### DIFF
--- a/packages/core/src/vector-query.ts
+++ b/packages/core/src/vector-query.ts
@@ -51,6 +51,33 @@ export type VectorQuerySpec =
  */
 export const MAX_DISTILLATION_VECTOR_ROWS = 500;
 
+/**
+ * Recency cap for the `temporal` brute-force scan — the most-recent N raw
+ * messages (per project, or per session when session-scoped) that a vector
+ * search will score.
+ *
+ * STOPGAP — remove once an ANN index replaces brute-force scanning.
+ * ----------------------------------------------------------------------------
+ * `temporal_messages` is the rawest, highest-cardinality tier (100K+ rows on
+ * busy installs), and every `vectorSearch*` over it was an UNBOUNDED O(n)
+ * cosine scan — the dominant cost behind the pathological recall latency in
+ * issue #999. This cap bounds the expensive cosine work to a fixed window.
+ *
+ * Capping by `created_at DESC` (rather than randomly) is architecturally
+ * coherent, not just a perf hack: the temporal tier is "recent raw context",
+ * while older messages are distilled into the distillation tier, which recall
+ * searches separately (see {@link MAX_DISTILLATION_VECTOR_ROWS}). So old
+ * content stays reachable via distillations even though it ages out of the
+ * temporal vector window.
+ *
+ * 🔴 This cap exists ONLY because we brute-force every row. Once a real ANN
+ * index lands (DiskANN via sqlite-vec ≥0.1.10's `vec0`, tracked under #999),
+ * search becomes sublinear and there is no reason to hide older rows from it —
+ * DELETE this constant and the `ORDER BY created_at DESC LIMIT` it drives, and
+ * let the index see the whole corpus.
+ */
+export const MAX_TEMPORAL_VECTOR_ROWS = 4000;
+
 // ---------------------------------------------------------------------------
 // Math + BLOB helpers (moved here from embedding.ts so the worker can share
 // them without pulling in the provider chain). Re-exported from embedding.ts
@@ -322,21 +349,34 @@ function runTemporal(
 ): VectorHit[] {
   if (vecAvailable) {
     try {
+      // Score only the most-recent MAX_TEMPORAL_VECTOR_ROWS rows (the same
+      // candidate window the JS path uses below). STOPGAP — see
+      // MAX_TEMPORAL_VECTOR_ROWS: drop the inner ORDER BY/LIMIT once an ANN
+      // index replaces brute-force scanning (#999).
       const vsql = sessionId
-        ? "SELECT id, 1 - vec_distance_cosine(embedding, ?) AS similarity FROM temporal_messages WHERE embedding IS NOT NULL AND project_id = ? AND session_id = ? ORDER BY similarity DESC LIMIT ?"
-        : "SELECT id, 1 - vec_distance_cosine(embedding, ?) AS similarity FROM temporal_messages WHERE embedding IS NOT NULL AND project_id = ? ORDER BY similarity DESC LIMIT ?";
+        ? "SELECT id, 1 - vec_distance_cosine(embedding, ?) AS similarity FROM (SELECT id, embedding FROM temporal_messages WHERE embedding IS NOT NULL AND project_id = ? AND session_id = ? ORDER BY created_at DESC LIMIT ?) ORDER BY similarity DESC LIMIT ?"
+        : "SELECT id, 1 - vec_distance_cosine(embedding, ?) AS similarity FROM (SELECT id, embedding FROM temporal_messages WHERE embedding IS NOT NULL AND project_id = ? ORDER BY created_at DESC LIMIT ?) ORDER BY similarity DESC LIMIT ?";
       const vparams: unknown[] = sessionId
-        ? [toBlob(queryEmbedding), projectId, sessionId, limit]
-        : [toBlob(queryEmbedding), projectId, limit];
+        ? [
+            toBlob(queryEmbedding),
+            projectId,
+            sessionId,
+            MAX_TEMPORAL_VECTOR_ROWS,
+            limit,
+          ]
+        : [toBlob(queryEmbedding), projectId, MAX_TEMPORAL_VECTOR_ROWS, limit];
       return conn.query(vsql).all(...vparams) as VectorHit[];
     } catch {
       // fall through to JS brute-force
     }
   }
+  // STOPGAP recency cap — see MAX_TEMPORAL_VECTOR_ROWS (#999).
   const sql = sessionId
-    ? "SELECT id, embedding FROM temporal_messages WHERE embedding IS NOT NULL AND project_id = ? AND session_id = ?"
-    : "SELECT id, embedding FROM temporal_messages WHERE embedding IS NOT NULL AND project_id = ?";
-  const params = sessionId ? [projectId, sessionId] : [projectId];
+    ? "SELECT id, embedding FROM temporal_messages WHERE embedding IS NOT NULL AND project_id = ? AND session_id = ? ORDER BY created_at DESC LIMIT ?"
+    : "SELECT id, embedding FROM temporal_messages WHERE embedding IS NOT NULL AND project_id = ? ORDER BY created_at DESC LIMIT ?";
+  const params = sessionId
+    ? [projectId, sessionId, MAX_TEMPORAL_VECTOR_ROWS]
+    : [projectId, MAX_TEMPORAL_VECTOR_ROWS];
 
   const rows = conn.query(sql).all(...params) as Array<{
     id: string;

--- a/packages/core/test/vec-search.test.ts
+++ b/packages/core/test/vec-search.test.ts
@@ -310,11 +310,20 @@ describe("vectorSearchTemporal", () => {
     });
 
     const assertCapped = async () => {
-      const ids = (
+      // Project-only path (the shape the sole production caller uses).
+      const projIds = (
         await vectorSearchTemporal(new Float32Array([1, 0, 0]), pid, 10)
       ).map((h) => h.id);
-      expect(ids).toContain("t-recent"); // newest match survives the cap
-      expect(ids).not.toContain("t-old"); // oldest match aged out of the window
+      expect(projIds).toContain("t-recent"); // newest match survives the cap
+      expect(projIds).not.toContain("t-old"); // oldest match aged out of window
+      // Session-scoped path exercises the separate session cap params (the
+      // 5-tuple vec / 3-tuple JS bindings). All rows live in session "s1", so
+      // the recency window — and thus the result — is identical.
+      const sessIds = (
+        await vectorSearchTemporal(new Float32Array([1, 0, 0]), pid, 10, "s1")
+      ).map((h) => h.id);
+      expect(sessIds).toContain("t-recent");
+      expect(sessIds).not.toContain("t-old");
     };
 
     // Default path (vec when the runtime supports it).

--- a/packages/core/test/vec-search.test.ts
+++ b/packages/core/test/vec-search.test.ts
@@ -7,7 +7,7 @@ import {
   test,
   vi,
 } from "vitest";
-import { close, db, ensureProject } from "../src/db";
+import { close, db, ensureProject, withTransaction } from "../src/db";
 import { isVecAvailable } from "../src/db/vec";
 import * as log from "../src/log";
 import {
@@ -17,6 +17,7 @@ import {
   vectorSearchDistillations,
   vectorSearchTemporal,
 } from "../src/embedding";
+import { MAX_TEMPORAL_VECTOR_ROWS } from "../src/vector-query";
 
 // Whether the running Node build supports the sqlite-vec extension. `node:sqlite`
 // gained `allowExtension` in Node 23.5; below that we expect the JS fallback.
@@ -251,13 +252,13 @@ describe("vectorSearchTemporal", () => {
     pid: string,
     session: string,
     vec: Float32Array,
+    createdAt?: number,
   ): void {
-    const now = Date.now();
     db()
       .query(
         "INSERT INTO temporal_messages (id, project_id, session_id, role, content, tokens, distilled, created_at, embedding) VALUES (?, ?, ?, 'user', 'msg', 0, 0, ?, ?)",
       )
-      .run(id, pid, session, now, toBlob(vec));
+      .run(id, pid, session, createdAt ?? Date.now(), toBlob(vec));
   }
 
   test("ranks by similarity, scoped to project", async () => {
@@ -285,6 +286,50 @@ describe("vectorSearchTemporal", () => {
       "s1",
     );
     expect(hits.map((h) => h.id)).toEqual(["t-s1"]);
+  });
+
+  // Stopgap recency cap (MAX_TEMPORAL_VECTOR_ROWS): only the most-recent N rows
+  // are scored, so a vector search can never fan out across an unbounded
+  // temporal_messages table. Guards both the vec subquery and the JS LIMIT.
+  test("recency cap ages the oldest rows out of the temporal vector window", async () => {
+    const pid = ensureProject(PROJECT);
+    db().query("DELETE FROM temporal_messages").run();
+    const match = unit([1, 0, 0]);
+    const noMatch = unit([0, 1, 0]);
+    // The oldest row uniquely matches the query but sits one slot *beyond* the
+    // window: cap non-matching rows sit on top of it, and a newest row also
+    // matches. With the cap, only "t-recent" comes back; "t-old" is invisible.
+    // Without the cap both matches would tie for #1 — that's the regression
+    // this guards (revert the cap → "t-old" reappears → this fails).
+    withTransaction(() => {
+      insertTemporal("t-old", pid, "s1", match, 1);
+      for (let i = 0; i < MAX_TEMPORAL_VECTOR_ROWS; i++) {
+        insertTemporal(`t-mid-${i}`, pid, "s1", noMatch, 1_000 + i);
+      }
+      insertTemporal("t-recent", pid, "s1", match, 9_000_000);
+    });
+
+    const assertCapped = async () => {
+      const ids = (
+        await vectorSearchTemporal(new Float32Array([1, 0, 0]), pid, 10)
+      ).map((h) => h.id);
+      expect(ids).toContain("t-recent"); // newest match survives the cap
+      expect(ids).not.toContain("t-old"); // oldest match aged out of the window
+    };
+
+    // Default path (vec when the runtime supports it).
+    await assertCapped();
+
+    // Force the JS brute-force fallback over the SAME rows and re-check.
+    close();
+    process.env.LORE_DISABLE_VEC = "1";
+    try {
+      expect(isVecAvailable()).toBe(false);
+      await assertCapped();
+    } finally {
+      delete process.env.LORE_DISABLE_VEC;
+      close(); // re-enable vec for subsequent suites
+    }
   });
 });
 


### PR DESCRIPTION
## Problem

Every `vectorSearch*` over `temporal_messages` was an **unbounded O(n) cosine scan**. `temporal_messages` is the rawest, highest-cardinality tier — 100K+ rows / ~320MB of embedding BLOBs on busy installs — so this scan is the dominant cost behind the pathological recall latency and event-loop stalls tracked in #999. (Companion to #1006, which stopped the timed-out scan from also re-running on the main thread.)

## Fix

Bound the expensive cosine work to the most-recent `MAX_TEMPORAL_VECTOR_ROWS` (**4000**) rows — per project, or per session when session-scoped — on **both** paths:

- **vec fast path**: inner `SELECT ... ORDER BY created_at DESC LIMIT ?` subquery selects the candidate window, the outer query ranks it by `vec_distance_cosine` and applies the final `LIMIT`.
- **JS brute-force fallback**: same `ORDER BY created_at DESC LIMIT ?`, so we never materialize the whole table's BLOBs into JS.

Capping by recency is **architecturally coherent**, not just a perf hack: the temporal tier is "recent raw context", while older messages are distilled into the distillation tier, which recall searches separately (`MAX_DISTILLATION_VECTOR_ROWS`). Aged-out content stays reachable via distillations.

## Explicit stopgap

This cap exists **only** because we brute-force every row. A 🔴 comment on the constant spells out that once a real ANN index lands (DiskANN via sqlite-vec ≥0.1.10's `vec0`, tracked under #999), search becomes sublinear and there's no reason to hide older rows — the constant and the `ORDER BY/LIMIT` it drives should be **deleted** so the index sees the whole corpus.

## Tests

`vec-search.test.ts` guards both paths: 4002 rows (oldest match + 4000 non-matching + newest match), `limit=10`. With the cap, only `t-recent` returns and `t-old` ages out; the JS fallback is forced over the same rows via `LORE_DISABLE_VEC=1` and re-checked.

- **Mutation-verified (red/green)**: neutralizing the runtime cap makes `t-old` reappear (`expected [ 't-recent', 't-old', … ] to not include 't-old'`) → test fails. Restored byte-identical (sha256 verified).
- Full `@loreai/core` suite green (2135 passed).

## Follow-ups (out of scope here)

- **Session-scoped coverage added**: the cap test now also exercises the session-scoped query shape (the 5-tuple vec / 3-tuple JS bindings), mutation-verified independently.
- **Project-only candidate selection still sorts via a TEMP B-TREE**: `EXPLAIN QUERY PLAN` on the production project-only path shows `SEARCH USING idx_temporal_project` + `USE TEMP B-TREE FOR ORDER BY` (no `(project_id, created_at)` composite exists; `idx_temporal_project_distilled_created` can't satisfy the order because `distilled` sits between). This PR still delivers the dominant win — bounding the BLOB cosine work and JS materialization to 4000 rows — but the candidate ordering is an all-project-rows sort. A partial index `CREATE INDEX idx_temporal_project_created ON temporal_messages(project_id, created_at) WHERE embedding IS NOT NULL` would turn it into a bounded index walk. Deferred: it's a separate schema migration and is itself mooted once the ANN index (#999) replaces the cap entirely.