### PR TITLE
fix(core): cancel timed-out vector worker queries so the pool recovers

### DIFF
--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -1278,8 +1278,8 @@ async function poolOrInProcess(
   const pooled = await tryPoolVectorSearch(spec, queryEmbedding);
   // Timed out: the worker is alive but slow. Return empty — degrading this one
   // recall — rather than re-running the O(n) scan on the main thread, which
-  // re-blocks the event loop (the stall bug). Worker-query cancellation and a
-  // recency cap on the scan land in follow-up PRs.
+  // re-blocks the event loop (the stall bug). The pool cancels the timed-out
+  // worker query (terminates + respawns) so it recovers for the next caller.
   if (pooled === VECTOR_SEARCH_TIMED_OUT) return [];
   if (pooled !== null) return pooled;
   return runVectorQuery(db(), isVecAvailable(), queryEmbedding, spec);

--- a/packages/core/src/vector-pool.ts
+++ b/packages/core/src/vector-pool.ts
@@ -193,12 +193,15 @@ function failAll(pw: PoolWorker, err: Error): void {
  * Cancel a timed-out search by retiring its worker.
  *
  * A worker runs `runVectorQuery` synchronously, so a query that blew the
- * timeout can't be interrupted from JS — the only way to stop the doomed scan
- * (and free the thread it's pinning) is to terminate the worker. Leaving it
- * running while we delete the in-flight entry — the pre-cancellation behavior —
- * made the still-busy worker look idle to {@link leastBusy}, so new searches
- * piled up behind the stuck scan in its message queue. {@link ensurePool}
- * respawns a fresh worker on the next call, restoring capacity.
+ * timeout can't be interrupted from JS — terminating the worker is the only way
+ * to reclaim the thread it's pinning (V8 tears it down once the in-progress
+ * native call returns). The immediate, guaranteed effect is de-routing: marking
+ * it `dead` drops it from {@link leastBusy} and {@link ensurePool} right away.
+ * Leaving it running while we delete the in-flight entry — the pre-cancellation
+ * behavior — made the still-busy worker look idle to {@link leastBusy}, so new
+ * searches piled up behind the stuck scan in its message queue.
+ * {@link ensurePool} respawns a fresh worker on the next call, restoring
+ * capacity.
  *
  * Crucially this is NOT counted as a structural failure: a timeout is slowness,
  * not a broken worker, and latching the pool broken after repeated timeouts

--- a/packages/core/src/vector-pool.ts
+++ b/packages/core/src/vector-pool.ts
@@ -190,6 +190,36 @@ function failAll(pw: PoolWorker, err: Error): void {
 }
 
 /**
+ * Cancel a timed-out search by retiring its worker.
+ *
+ * A worker runs `runVectorQuery` synchronously, so a query that blew the
+ * timeout can't be interrupted from JS — the only way to stop the doomed scan
+ * (and free the thread it's pinning) is to terminate the worker. Leaving it
+ * running while we delete the in-flight entry — the pre-cancellation behavior —
+ * made the still-busy worker look idle to {@link leastBusy}, so new searches
+ * piled up behind the stuck scan in its message queue. {@link ensurePool}
+ * respawns a fresh worker on the next call, restoring capacity.
+ *
+ * Crucially this is NOT counted as a structural failure: a timeout is slowness,
+ * not a broken worker, and latching the pool broken after repeated timeouts
+ * would send every caller back to the in-process path — reintroducing the very
+ * main-thread stall the timeout exists to prevent. Setting `dead` first makes
+ * the terminate()-induced `exit` handler's {@link markDead} a no-op, so the
+ * structural-failure latch is never touched. Collateral in-flight requests on
+ * the same worker are rejected so their callers fall back in-process.
+ */
+function retireTimedOutWorker(pw: PoolWorker): void {
+  if (pw.dead) return;
+  pw.dead = true;
+  failAll(pw, new Error("vector worker terminated after search timeout"));
+  try {
+    void pw.worker.terminate();
+  } catch {
+    // best-effort — the exit handler (markDead) is already a no-op via `dead`.
+  }
+}
+
+/**
  * Count a structural failure (worker death / load failure / reader-open
  * failure). After MAX_STRUCTURAL_FAILURES in a row with no healthy reply, latch
  * the pool broken and terminate any survivors so callers fall back to the
@@ -350,12 +380,14 @@ export async function tryPoolVectorSearch(
           pw.inflight.delete(id);
           // Resolve a sentinel (don't reject → don't fall back in-process):
           // the worker is alive but slow; re-running this scan on the main
-          // thread re-blocks the event loop. The abandoned worker query keeps
-          // running until it finishes (cancellation lands in a follow-up).
+          // thread re-blocks the event loop. Then cancel the doomed query by
+          // terminating its (uninterruptible, synchronously-scanning) worker so
+          // the pool recovers instead of piling new work behind the stuck scan.
           log.info(
-            `vector worker search timed out after ${timeoutMs}ms — returning empty (not re-running in-process)`,
+            `vector worker search timed out after ${timeoutMs}ms — terminating the wedged worker, returning empty (not re-running in-process)`,
           );
           resolve(VECTOR_SEARCH_TIMED_OUT);
+          retireTimedOutWorker(pw);
         }, timeoutMs);
         // The worker is already unref'd (makeWorker), so an in-flight search must
         // not be the thing that keeps the event loop alive: unref the timeout too,

--- a/packages/core/test/vector-pool.test.ts
+++ b/packages/core/test/vector-pool.test.ts
@@ -353,26 +353,34 @@ describe("vector-pool timeout cancellation (#1006 follow-up)", () => {
     expect(served?.terminated).toBe(true);
   });
 
-  it("recovers after a timeout: the next search runs on a live worker", async () => {
+  it("recovers after a timeout: the next search is NOT routed to the wedged worker", async () => {
     vi.useFakeTimers();
     let mode: "hang" | "reply" = "hang";
+    // Tag each reply with the serving worker's index so we can prove which
+    // worker handled the recovery search.
     _setTestVectorWorkerFactory(
       factoryReturning((w, msg) => {
-        if (mode === "reply") w.reply(msg.id, [{ id: "ok", similarity: 1 }]);
+        if (mode === "reply") {
+          w.reply(msg.id, [{ id: `from-${w.index}`, similarity: 1 }]);
+        }
       }),
     );
+    // First search lands on worker 0 (leastBusy tie → first) and hangs.
     const timedOut = tryPoolVectorSearch(KNOWLEDGE, QUERY);
     await vi.advanceTimersByTimeAsync(vectorSearchTimeoutMs() + 1);
     expect(await timedOut).toBe(VECTOR_SEARCH_TIMED_OUT);
+    const wedged = FakeWorker.instances[0];
+    expect(wedged.index).toBe(0);
+    expect(wedged.terminated).toBe(true);
 
     mode = "reply";
     vi.useRealTimers();
-    // Pool must recover: the next search is served by a live worker (not stuck
-    // behind the wedged one, not the in-process-fallback null).
-    expect(await tryPoolVectorSearch(KNOWLEDGE, QUERY)).toEqual([
-      { id: "ok", similarity: 1 },
-    ]);
-    expect(FakeWorker.instances.some((w) => !w.terminated)).toBe(true);
+    // The follow-up must be served by a different, live worker — NOT the wedged
+    // one. Pre-cancellation (worker 0 left alive, in-flight deleted), leastBusy
+    // sees worker 0 as idle and reuses it → the result would be tagged "from-0".
+    const hits = await tryPoolVectorSearch(KNOWLEDGE, QUERY);
+    expect(hits).toHaveLength(1);
+    expect(hits).not.toContainEqual({ id: "from-0", similarity: 1 });
   });
 
   it("never latches the pool broken on repeated timeouts (slowness != structural failure)", async () => {

--- a/packages/core/test/vector-pool.test.ts
+++ b/packages/core/test/vector-pool.test.ts
@@ -290,9 +290,8 @@ describe("vector-pool structural-failure latch (review #989)", () => {
     // A reader connection that fails to open surfaces as an init-error message,
     // marking the worker structurally dead. Asserting only null would be vacuous
     // (the timeout fallback also resolves the sentinel); instead assert the dead
-    // worker is terminated on the next ensurePool — a side effect the timeout
-    // path never produces. Pre-fix mutation (init-error → no markDead): the
-    // victim stays alive and this fails.
+    // worker is terminated on the next ensurePool. Pre-fix mutation (init-error
+    // -> no markDead): the victim stays alive and this fails.
     _setTestVectorWorkerFactory(
       factoryReturning((w, msg) => w.reply(msg.id, [])),
     );
@@ -334,6 +333,95 @@ describe("vector-pool structural-failure latch (review #989)", () => {
     }) as never);
     expect(await tryPoolVectorSearch(KNOWLEDGE, QUERY)).toBeNull();
     expect(vi.getTimerCount()).toBe(0);
+  });
+});
+
+describe("vector-pool timeout cancellation (#1006 follow-up)", () => {
+  it("terminates the wedged worker on timeout (cancelling its uninterruptible scan)", async () => {
+    vi.useFakeTimers();
+    let served: FakeWorker | undefined;
+    _setTestVectorWorkerFactory(
+      factoryReturning((w) => {
+        served = w; // receive the search but never reply → force a timeout
+      }),
+    );
+    const p = tryPoolVectorSearch(KNOWLEDGE, QUERY);
+    await vi.advanceTimersByTimeAsync(vectorSearchTimeoutMs() + 1);
+    expect(await p).toBe(VECTOR_SEARCH_TIMED_OUT);
+    // The worker running the doomed synchronous scan is terminated so its thread
+    // is freed and leastBusy() stops routing new work behind the stuck scan.
+    expect(served?.terminated).toBe(true);
+  });
+
+  it("recovers after a timeout: the next search runs on a live worker", async () => {
+    vi.useFakeTimers();
+    let mode: "hang" | "reply" = "hang";
+    _setTestVectorWorkerFactory(
+      factoryReturning((w, msg) => {
+        if (mode === "reply") w.reply(msg.id, [{ id: "ok", similarity: 1 }]);
+      }),
+    );
+    const timedOut = tryPoolVectorSearch(KNOWLEDGE, QUERY);
+    await vi.advanceTimersByTimeAsync(vectorSearchTimeoutMs() + 1);
+    expect(await timedOut).toBe(VECTOR_SEARCH_TIMED_OUT);
+
+    mode = "reply";
+    vi.useRealTimers();
+    // Pool must recover: the next search is served by a live worker (not stuck
+    // behind the wedged one, not the in-process-fallback null).
+    expect(await tryPoolVectorSearch(KNOWLEDGE, QUERY)).toEqual([
+      { id: "ok", similarity: 1 },
+    ]);
+    expect(FakeWorker.instances.some((w) => !w.terminated)).toBe(true);
+  });
+
+  it("never latches the pool broken on repeated timeouts (slowness != structural failure)", async () => {
+    vi.useFakeTimers();
+    let mode: "hang" | "reply" = "hang";
+    _setTestVectorWorkerFactory(
+      factoryReturning((w, msg) => {
+        if (mode === "reply") w.reply(msg.id, [{ id: "ok", similarity: 1 }]);
+      }),
+    );
+    // Far more consecutive timeouts than MAX_STRUCTURAL_FAILURES (6). If a
+    // timeout counted as a structural failure, the pool would latch broken and
+    // every later caller would get null (the in-process fallback) — exactly the
+    // main-thread stall the worker offload exists to avoid.
+    for (let i = 0; i < 10; i++) {
+      const p = tryPoolVectorSearch(KNOWLEDGE, QUERY);
+      await vi.advanceTimersByTimeAsync(vectorSearchTimeoutMs() + 1);
+      expect(await p).toBe(VECTOR_SEARCH_TIMED_OUT);
+    }
+    mode = "reply";
+    vi.useRealTimers();
+    // Still alive: a replying worker is served rather than bypassed.
+    expect(await tryPoolVectorSearch(KNOWLEDGE, QUERY)).toEqual([
+      { id: "ok", similarity: 1 },
+    ]);
+  });
+
+  it("rejects collateral in-flight requests on a terminated worker (they fall back to null)", async () => {
+    vi.useFakeTimers();
+    // Pool size is 2 (DEFAULT_POOL_SIZE). Park a request on each worker, then a
+    // third lands back on worker 0 (leastBusy tie → first). When worker 0's first
+    // request times out, worker 0 is terminated, so the THIRD request — collateral,
+    // which never itself exceeded the timeout — is rejected → null (in-process
+    // fallback), NOT resolved as the timeout sentinel.
+    const seen: number[] = [];
+    _setTestVectorWorkerFactory(
+      factoryReturning((w) => {
+        seen.push(w.index); // never reply
+      }),
+    );
+    const first = tryPoolVectorSearch(KNOWLEDGE, QUERY); // → worker 0
+    first.catch(() => {});
+    const filler = tryPoolVectorSearch(KNOWLEDGE, QUERY); // → worker 1
+    filler.catch(() => {});
+    const collateral = tryPoolVectorSearch(KNOWLEDGE, QUERY); // → worker 0 (2 in-flight)
+    expect(seen).toEqual([0, 1, 0]);
+    await vi.advanceTimersByTimeAsync(vectorSearchTimeoutMs() + 1);
+    expect(await first).toBe(VECTOR_SEARCH_TIMED_OUT);
+    expect(await collateral).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Problem

Follow-up to #1006 (which stopped a timed-out scan from re-running on the main thread). After that fix, on timeout we resolved the empty sentinel but **left the worker running**. A worker executes `runVectorQuery` **synchronously**, so the doomed O(n) scan can't be interrupted from JS — and because we `delete`d the in-flight entry, `leastBusy()` saw the still-busy worker as idle and kept dispatching new searches to it. Those new searches **queued behind the stuck scan** in the worker's message loop, so a single slow query could back up the whole worker.

(#1006's adversarial review explicitly flagged this interim window; this PR closes it.)

## Fix

Cancel the query by **terminating its worker on timeout** — the only way to free a thread pinned on a synchronous SQLite call. `ensurePool()` respawns a fresh worker on the next call, restoring capacity.

The key subtlety: a timeout is **slowness, not a broken worker**, so it must **not** count toward the structural-failure latch (`MAX_STRUCTURAL_FAILURES`). If it did, repeated timeouts would latch the pool broken and send every caller back to the in-process path — reintroducing the exact main-thread stall the timeout exists to prevent. `retireTimedOutWorker()` sets `dead` **before** `terminate()`, so the `terminate()`-induced `exit` handler's `markDead` is a no-op and the latch is never touched. Collateral in-flight requests on the same worker are rejected so their callers fall back in-process (same semantics as an ordinary worker death).

## Tests (mutation-verified red/green)

- **terminates the wedged worker on timeout** → drop the `retireTimedOutWorker(pw)` call ⇒ red.
- **recovers**: the next search runs on a live worker (not stuck behind the wedged one, not the null fallback).
- **never latches the pool broken** across 10× `MAX_STRUCTURAL_FAILURES` consecutive timeouts → drop the `dead`-first line ⇒ the pool latches broken and the test goes red (`expected null to be Symbol(...)`).
- **collateral in-flight requests** on a terminated worker resolve `null` (in-process fallback), not the timeout sentinel.

Full `@loreai/core` suite green (2139 passed); cancellation suite run 3× for flakiness (clean).

## Review notes

- Adversarial review found **no blockers** (verdict: SHIP-WITH-FOLLOWUPS). It flagged the `recovers` test as vacuous; that's fixed in the follow-up commit (now index-tags replies and asserts the wedged worker isn't reused — reverting the retire call reds it).
- **Deferred NIT (pre-existing, safe direction):** the `result` handler resets `structuralFailures = 0` before the `pending` check, so a late `result` from a just-terminated worker could reset the shared streak. It can't cause the stall (safe direction) and pre-dates this PR; left out here to keep the change focused and avoid an untested edit to the shared handler. Worth a tiny follow-up to move the reset inside `if (pending)`.