### PR TITLE
fix(core): arm pattern-echo cooldown unconditionally

### DIFF
--- a/packages/core/src/pattern-echo.ts
+++ b/packages/core/src/pattern-echo.ts
@@ -106,15 +106,26 @@ async function _detect(input: {
   model?: { providerID: string; modelID: string };
   metadata?: KnowledgeMetadata;
 }): Promise<void> {
-  // Rate limit check
-  const lastTime = lastExtraction.get(input.sessionID) ?? 0;
-  if (Date.now() - lastTime < PATTERN_COOLDOWN_MS) return;
-
-  // Step 1: Embed the new distillation (awaited, not fire-and-forget)
+  // Step 1: Embed the new distillation and store it. This is the
+  // embedDistillation() replacement at the gen-0 hook (see distillation.ts), so
+  // it MUST run for every segment — independent of the pattern-detection rate
+  // limit below — or the segment is never vector-searchable. (Previously the
+  // rate-limit check sat above this, so a segment arriving within the cooldown
+  // got no embedding stored at all: a latent recall gap.)
   const [vec] = await embedding.embed([input.observations], "document");
   db()
     .query("UPDATE distillations SET embedding = ? WHERE id = ?")
     .run(embedding.toBlob(vec), input.distillId);
+
+  // Rate limit the EXPENSIVE pattern detection that follows (project-wide vector
+  // search + clustering + an LLM extraction call): at most one attempt per
+  // session per 10 minutes. Arm the cooldown UNCONDITIONALLY the moment we
+  // commit to an attempt — it used to be set only after a successful
+  // ltm.create() (below), so the common "no pattern this time" outcome never
+  // armed it and the full search + cluster ran on every gen-0 distillation.
+  const lastTime = lastExtraction.get(input.sessionID) ?? 0;
+  if (Date.now() - lastTime < PATTERN_COOLDOWN_MS) return;
+  lastExtraction.set(input.sessionID, Date.now());
 
   // Step 2: Search for similar distillations across the project (wide net)
   const pid = ensureProject(input.projectPath);
@@ -237,7 +248,6 @@ async function _detect(input: {
       metadata: input.metadata,
     });
     log.info(`pattern echo created preference: "${pattern.title}"`);
-    lastExtraction.set(input.sessionID, Date.now());
   } catch {
     // ltm.create() dedup guard handles duplicates — swallow
   }

--- a/packages/core/src/pattern-echo.ts
+++ b/packages/core/src/pattern-echo.ts
@@ -62,6 +62,12 @@ export const PATTERN_COOLDOWN_MS = 10 * 60 * 1000;
 
 const lastExtraction = new Map<string, number>();
 
+/** Test seam: clear the per-session cooldown state so suites don't leak the
+ *  module-global map across cases. Never called in production. */
+export function _resetPatternEchoCooldownForTest(): void {
+  lastExtraction.clear();
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------

--- a/packages/core/src/pattern-echo.ts
+++ b/packages/core/src/pattern-echo.ts
@@ -54,7 +54,7 @@ const MAX_ECHO_SEGMENTS = 5;
 const MAX_CANDIDATES = 20;
 
 /** Rate limit: at most 1 pattern extraction per session per 10 minutes. */
-const PATTERN_COOLDOWN_MS = 10 * 60 * 1000;
+export const PATTERN_COOLDOWN_MS = 10 * 60 * 1000;
 
 // ---------------------------------------------------------------------------
 // Rate limit state
@@ -123,9 +123,18 @@ async function _detect(input: {
   // commit to an attempt — it used to be set only after a successful
   // ltm.create() (below), so the common "no pattern this time" outcome never
   // armed it and the full search + cluster ran on every gen-0 distillation.
+  const now = Date.now();
   const lastTime = lastExtraction.get(input.sessionID) ?? 0;
-  if (Date.now() - lastTime < PATTERN_COOLDOWN_MS) return;
-  lastExtraction.set(input.sessionID, Date.now());
+  if (now - lastTime < PATTERN_COOLDOWN_MS) return;
+  // Arm the cooldown, and opportunistically evict entries that have already aged
+  // out of the window. A stale entry is a no-op for the check above, so eviction
+  // is behavior-neutral — it just keeps this per-session map from growing without
+  // bound now that we write one entry per distilling session (not only per
+  // pattern created). This runs at most once per session per cooldown.
+  for (const [sid, ts] of lastExtraction) {
+    if (now - ts >= PATTERN_COOLDOWN_MS) lastExtraction.delete(sid);
+  }
+  lastExtraction.set(input.sessionID, now);
 
   // Step 2: Search for similar distillations across the project (wide net)
   const pid = ensureProject(input.projectPath);

--- a/packages/core/test/pattern-echo.test.ts
+++ b/packages/core/test/pattern-echo.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { db, ensureProject } from "../src/db";
 import * as embedding from "../src/embedding";
-import { detectPatternEchoes } from "../src/pattern-echo";
+import { detectPatternEchoes, PATTERN_COOLDOWN_MS } from "../src/pattern-echo";
 import type { LLMClient } from "../src/types";
 
 // pattern-echo runs two jobs at the gen-0 distillation hook: (1) embed + store
@@ -94,5 +94,58 @@ describe("pattern-echo cooldown", () => {
     // Distinct sessions each get their own attempt — the cooldown is keyed by
     // sessionID, so session B is not blocked by session A.
     expect(searchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("allows a fresh attempt once the cooldown expires", async () => {
+    vi.useFakeTimers();
+    try {
+      const pid = ensureProject(PROJECT);
+      insertDistill("e1", pid, "s-exp");
+      insertDistill("e2", pid, "s-exp");
+      const base = {
+        observations: "obs",
+        projectPath: PROJECT,
+        sessionID: "s-exp",
+        llm: stubLLM(),
+      };
+
+      await detectPatternEchoes({ ...base, distillId: "e1" });
+      expect(searchSpy).toHaveBeenCalledTimes(1);
+
+      // Still within the cooldown → skipped.
+      await detectPatternEchoes({ ...base, distillId: "e2" });
+      expect(searchSpy).toHaveBeenCalledTimes(1);
+
+      // Past the cooldown → a new attempt runs.
+      vi.advanceTimersByTime(PATTERN_COOLDOWN_MS + 1);
+      await detectPatternEchoes({ ...base, distillId: "e2" });
+      expect(searchSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not arm the cooldown when the embed fails (a transient error doesn't suppress 10 min)", async () => {
+    const pid = ensureProject(PROJECT);
+    insertDistill("f1", pid, "s-fail");
+    insertDistill("f2", pid, "s-fail");
+    const base = {
+      observations: "obs",
+      projectPath: PROJECT,
+      sessionID: "s-fail",
+      llm: stubLLM(),
+    };
+
+    // First attempt: the embed throws (job 1) before the cooldown is armed, so
+    // the failure is swallowed by detectPatternEchoes' .catch and the session is
+    // NOT suppressed. (Guards the embed-before-arm ordering: arming first would
+    // wrongly block the session for 10 min after one provider hiccup.)
+    embedSpy.mockRejectedValueOnce(new Error("embed boom"));
+    await detectPatternEchoes({ ...base, distillId: "f1" });
+    expect(searchSpy).not.toHaveBeenCalled();
+
+    // The embed recovers on the next segment → detection runs (not rate-limited).
+    await detectPatternEchoes({ ...base, distillId: "f2" });
+    expect(searchSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/core/test/pattern-echo.test.ts
+++ b/packages/core/test/pattern-echo.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { db, ensureProject } from "../src/db";
 import * as embedding from "../src/embedding";
-import { detectPatternEchoes, PATTERN_COOLDOWN_MS } from "../src/pattern-echo";
+import {
+  _resetPatternEchoCooldownForTest,
+  detectPatternEchoes,
+  PATTERN_COOLDOWN_MS,
+} from "../src/pattern-echo";
 import type { LLMClient } from "../src/types";
 
 // pattern-echo runs two jobs at the gen-0 distillation hook: (1) embed + store
@@ -31,6 +35,9 @@ describe("pattern-echo cooldown", () => {
   let searchSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
+    // Clear the module-global cooldown map so cases never leak into each other
+    // (isolation no longer relies on each test using a unique session ID).
+    _resetPatternEchoCooldownForTest();
     // A deterministic embedding so the embed + store step succeeds without ONNX.
     embedSpy = vi
       .spyOn(embedding, "embed")

--- a/packages/core/test/pattern-echo.test.ts
+++ b/packages/core/test/pattern-echo.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { db, ensureProject } from "../src/db";
+import * as embedding from "../src/embedding";
+import { detectPatternEchoes } from "../src/pattern-echo";
+import type { LLMClient } from "../src/types";
+
+// pattern-echo runs two jobs at the gen-0 distillation hook: (1) embed + store
+// the segment (the embedDistillation() replacement — must always run so recall
+// can find it), and (2) the EXPENSIVE pattern detection (project-wide vector
+// search + clustering + an LLM call), which is rate-limited to once per session
+// per cooldown. The bug these tests guard: the cooldown was armed only AFTER a
+// successful ltm.create(), so the common "no pattern this time" outcome never
+// armed it and the full search + cluster ran on every single distillation.
+
+const PROJECT = "/test/pattern-echo";
+
+function insertDistill(id: string, pid: string, session: string): void {
+  db()
+    .query(
+      "INSERT INTO distillations (id, project_id, session_id, narrative, facts, source_ids, generation, token_count, created_at, embedding) VALUES (?, ?, ?, '', '', '', 0, 0, ?, NULL)",
+    )
+    .run(id, pid, session, Date.now());
+}
+
+function stubLLM(): LLMClient {
+  return { prompt: vi.fn() } as unknown as LLMClient;
+}
+
+describe("pattern-echo cooldown", () => {
+  let embedSpy: ReturnType<typeof vi.spyOn>;
+  let searchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // A deterministic embedding so the embed + store step succeeds without ONNX.
+    embedSpy = vi
+      .spyOn(embedding, "embed")
+      .mockResolvedValue([new Float32Array([1, 0, 0])]);
+    // Return no candidates so the detection short-circuits before clustering /
+    // the LLM — we only care here about WHETHER the search ran.
+    searchSpy = vi
+      .spyOn(embedding, "vectorSearchAllDistillations")
+      .mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("rate-limits the pattern search to once per session per cooldown, yet always stores the embedding", async () => {
+    const pid = ensureProject(PROJECT);
+    insertDistill("d1", pid, "s-cool");
+    insertDistill("d2", pid, "s-cool");
+    const base = {
+      observations: "obs",
+      projectPath: PROJECT,
+      sessionID: "s-cool",
+      llm: stubLLM(),
+    };
+
+    // First attempt: embeds + stores AND runs the (mocked) project-wide search.
+    await detectPatternEchoes({ ...base, distillId: "d1" });
+    expect(embedSpy).toHaveBeenCalledTimes(1);
+    expect(searchSpy).toHaveBeenCalledTimes(1);
+
+    // Second attempt within the cooldown: STILL embeds + stores the segment, but
+    // the expensive search is skipped — the cooldown was armed unconditionally on
+    // the first attempt even though it created nothing.
+    await detectPatternEchoes({ ...base, distillId: "d2" });
+    expect(embedSpy).toHaveBeenCalledTimes(2); // embedding always runs (job 1)
+    expect(searchSpy).toHaveBeenCalledTimes(1); // search rate-limited (job 2)
+
+    // The rate-limited segment still got its embedding — no recall gap. (Guards
+    // against gating the embed behind the cooldown: pre-this-fix, a rate-limited
+    // segment was returned before the embed and stored nothing.)
+    const row = db()
+      .query("SELECT embedding FROM distillations WHERE id = 'd2'")
+      .get() as { embedding: Buffer | null };
+    expect(row.embedding).not.toBeNull();
+  });
+
+  it("rate-limits per session, not globally", async () => {
+    const pid = ensureProject(PROJECT);
+    insertDistill("a1", pid, "s-A");
+    insertDistill("b1", pid, "s-B");
+    const common = {
+      observations: "obs",
+      projectPath: PROJECT,
+      llm: stubLLM(),
+    };
+
+    await detectPatternEchoes({ ...common, sessionID: "s-A", distillId: "a1" });
+    await detectPatternEchoes({ ...common, sessionID: "s-B", distillId: "b1" });
+
+    // Distinct sessions each get their own attempt — the cooldown is keyed by
+    // sessionID, so session B is not blocked by session A.
+    expect(searchSpy).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Problem

pattern-echo's 10-minute per-session cooldown (`PATTERN_COOLDOWN_MS`) was armed **only after a successful `ltm.create()`** (`lastExtraction.set(...)` lived at the very end, inside the create block). But most gen-0 distillations don't produce a pattern, so in the common path the cooldown was **never armed** — and the expensive pattern detection (project-wide vector search + clustering, and sometimes an LLM extraction call) ran on **every single distillation**. This is a significant contributor to the periodic CPU pegging that motivated this series.

There was also a latent bug hiding behind it: the rate-limit check sat **above** the embed+store step, so on the rare occasions the cooldown *was* armed, a segment arriving within the window got **no embedding stored at all** — a silent recall gap (the segment isn't vector-searchable until the startup backfill catches it).

## Fix

Separate the two jobs `detectPatternEchoes` does and rate-limit only the expensive one:

- **Job 1 — embed + store** (the `embedDistillation()` replacement at the gen-0 hook) now **always runs**, moved above the rate-limit check. Every segment gets its embedding, regardless of the cooldown.
- **Job 2 — project-wide search + clustering + extraction** is gated by the cooldown, which is now armed **unconditionally** the moment we commit to an attempt (right after the check passes), not only after a create. A "no pattern this time" outcome now correctly arms the cooldown.

Semantics now match the documented intent: *at most one pattern-extraction attempt per session per 10 minutes*. A pattern that would have formed on the next distillation isn't lost — it's just deferred until the cooldown expires (the distillations persist and are re-evaluated).

## Tests

pattern-echo had **zero** test coverage — which is precisely why this slipped through. This PR adds the first tests:

- The search runs **once** per session per cooldown across two back-to-back distillations, while the rate-limited segment **still gets its embedding stored** (no recall gap).
- The cooldown is **per-session**, not global (two sessions each get an attempt).

Mutation-verified red/green:
- Drop the unconditional arm ⇒ search runs twice ⇒ red.
- Gate the embed behind the cooldown ⇒ the rate-limited segment isn't embedded ⇒ red.

Full `@loreai/core` suite green (2141 passed).

## Review notes

Adversarial review found **no blockers** (SHIP-WITH-FOLLOWUPS). Addressed in the follow-up commit:
- **Bounded the `lastExtraction` map** — this PR shifted its growth from per-pattern-created to per-distilling-session, so aged-out entries are now evicted on arm (behavior-neutral: a stale entry is already a no-op for the cooldown check).
- **Added cooldown-expiry and embed-failure-doesn't-arm tests** (both mutation-verified).

Deferred (reasonable future addition, tests pre-existing/unchanged detection logic): a full cluster → LLM → `ltm.create` end-to-end test. The cooldown semantics this PR changes are fully covered by the four tests here; the happy-path detection pipeline past `candidates.length < 2` is unchanged by this PR.