### PR TITLE
perf(core): batch curator entity-ref sync to load registry once

### DIFF
--- a/packages/core/src/curator.ts
+++ b/packages/core/src/curator.ts
@@ -437,18 +437,17 @@ export function applyOps(
   // Sync cross-references for created/updated entries. idsToSync holds stable
   // logical_ids; resolve the current version for its (possibly newly-appended)
   // content. syncRefs/syncEntityRefs key the refs on the logical_id internally.
+  const entityRefItems: Array<{ id: string; content: string }> = [];
   for (const id of idsToSync) {
     ltm.syncRefs(id);
-    // Also sync entity references (detect entity mentions in content)
+    // Collect content for a single batched entity-ref sync — syncEntityRefsBatch
+    // loads the entities/aliases registry once instead of once per entry (#1010).
     const entry = ltm.getByLogical(id);
-    if (entry) {
-      try {
-        entities.syncEntityRefs(id, entry.content);
-      } catch (err) {
-        log.warn(`entity ref sync failed for ${id}:`, err);
-      }
-    }
+    if (entry) entityRefItems.push({ id, content: entry.content });
   }
+  // Batch handles per-item errors internally (logs + skips), mirroring the prior
+  // per-entry try/catch so one bad entry can't abort the rest.
+  entities.syncEntityRefsBatch(entityRefItems);
 
   // Create detected entities (metadata merged on dedup via create())
   if (input.detectedEntities?.length) {

--- a/packages/core/src/entities.ts
+++ b/packages/core/src/entities.ts
@@ -1439,28 +1439,50 @@ export function formatForPrompt(entities: EntityWithAliases[]): string {
  *
  * Called after knowledge entry create/update in the curator pipeline.
  */
-export function syncEntityRefs(knowledgeId: string, content: string): number {
+/**
+ * The full entity + alias registry used to match entity mentions in content.
+ * Loading this is two full-table scans, so callers that re-sync many entries in
+ * a loop (the curator) should load it ONCE via {@link syncEntityRefsBatch}
+ * rather than once per entry.
+ */
+export interface EntityMatchRegistry {
+  entities: Array<{ id: string; canonical_name: string }>;
+  aliases: Array<{ entity_id: string; alias_value: string }>;
+}
+
+/** Load the entity + alias registry (two full-table scans). */
+function loadEntityMatchRegistry(): EntityMatchRegistry {
+  const entities = db()
+    .query("SELECT id, canonical_name FROM entities")
+    .all() as Array<{ id: string; canonical_name: string }>;
+  const aliases = db()
+    .query("SELECT entity_id, alias_value FROM entity_aliases")
+    .all() as Array<{ entity_id: string; alias_value: string }>;
+  return { entities, aliases };
+}
+
+export function syncEntityRefs(
+  knowledgeId: string,
+  content: string,
+  registry?: EntityMatchRegistry,
+): number {
   // Entity refs key on the stable logical_id (A2, #823) so they survive version
   // appends. The FK to knowledge(id) stays satisfied because logical_id equals
   // the never-physically-deleted first version's id.
   const logicalId = logicalIdOf(knowledgeId);
 
-  // Clear existing refs for this knowledge entry
+  // Clear existing refs for this knowledge entry. Runs even when the registry is
+  // empty so stale refs are purged after all matching entities are removed.
   db()
     .query("DELETE FROM knowledge_entity_refs WHERE knowledge_id = ?")
     .run(logicalId);
 
-  // Get all entities for fast matching
-  const allEntities = db()
-    .query("SELECT id, canonical_name FROM entities")
-    .all() as Array<{ id: string; canonical_name: string }>;
+  // Load the entities + aliases for matching. A batch caller passes a preloaded
+  // registry so this isn't re-read once per entry (the curator N+1, #1010).
+  const { entities: allEntities, aliases: allAliases } =
+    registry ?? loadEntityMatchRegistry();
 
   if (!allEntities.length) return 0;
-
-  // Also load all aliases for matching
-  const allAliases = db()
-    .query("SELECT entity_id, alias_value FROM entity_aliases")
-    .all() as Array<{ entity_id: string; alias_value: string }>;
 
   const contentLower = content.toLowerCase();
   const linkedEntityIds = new Set<string>();
@@ -1505,6 +1527,32 @@ export function syncEntityRefs(knowledgeId: string, content: string): number {
   }
 
   return count;
+}
+
+/**
+ * Re-sync entity refs for many entries while loading the entity/alias registry
+ * exactly ONCE for the whole batch (the per-entry reload was the curator's N+1,
+ * #1010). Per-item failures are logged and skipped so one bad entry can't abort
+ * the rest — mirroring the curator's prior per-entry try/catch.
+ *
+ * @returns Total number of (knowledge, entity) links written across all items.
+ */
+export function syncEntityRefsBatch(
+  items: ReadonlyArray<{ id: string; content: string }>,
+): number {
+  if (!items.length) return 0;
+  // Load once. New entities are only created AFTER the curator's ref-sync loop,
+  // so this snapshot stays authoritative for the whole batch.
+  const registry = loadEntityMatchRegistry();
+  let total = 0;
+  for (const item of items) {
+    try {
+      total += syncEntityRefs(item.id, item.content, registry);
+    } catch (err) {
+      log.warn(`entity ref sync failed for ${item.id}:`, err);
+    }
+  }
+  return total;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/test/curator-entity-ref-batch.test.ts
+++ b/packages/core/test/curator-entity-ref-batch.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { applyOps } from "../src/curator";
+import { db, ensureProject } from "../src/db";
+import * as entities from "../src/entities";
+import { type LogSink, registerSink } from "../src/log";
+
+const PROJECT = "/tmp/lore-curator-entity-ref-batch/project";
+
+// A LogSink whose withDbSpan tallies how many times specific SQL statements are
+// executed. Everything else is a no-op. withDbSpan MUST stay a pass-through
+// (call fn() once, return its value) so query behavior is unchanged.
+function countingSink(counts: Record<string, number>): LogSink {
+  return {
+    info() {},
+    warn() {},
+    error() {},
+    captureException() {},
+    withDbSpan<T>(sql: string, fn: () => T): T {
+      if (sql.includes("canonical_name FROM entities")) {
+        counts.entities = (counts.entities ?? 0) + 1;
+      }
+      if (sql.includes("FROM entity_aliases")) {
+        counts.aliases = (counts.aliases ?? 0) + 1;
+      }
+      return fn();
+    },
+  };
+}
+
+const NOOP_SINK: LogSink = {
+  info() {},
+  warn() {},
+  error() {},
+  captureException() {},
+};
+
+describe("curator entity-ref sync is batched (no N+1 registry reload)", () => {
+  beforeEach(() => {
+    const pid = ensureProject(PROJECT);
+    db().query("DELETE FROM knowledge_entity_refs").run();
+    db().query("DELETE FROM knowledge WHERE project_id = ?").run(pid);
+    db().query("DELETE FROM entities").run();
+    db().query("DELETE FROM entity_aliases").run();
+  });
+
+  afterEach(() => {
+    // Restore a benign sink (no withDbSpan → pass-through) so the counting sink
+    // can't leak into later tests in this file.
+    registerSink(NOOP_SINK);
+  });
+
+  test("entities/aliases tables load once per curator pass, not once per entry", () => {
+    // Three entities the knowledge entries will mention by canonical name.
+    const alpha = entities.create({
+      projectPath: PROJECT,
+      entityType: "tool",
+      canonicalName: "AlphaWidget",
+    }).id;
+    const bravo = entities.create({
+      projectPath: PROJECT,
+      entityType: "tool",
+      canonicalName: "BravoWidget",
+    }).id;
+    const charlie = entities.create({
+      projectPath: PROJECT,
+      entityType: "tool",
+      canonicalName: "CharlieWidget",
+    }).id;
+
+    const counts: Record<string, number> = {};
+    registerSink(countingSink(counts));
+
+    // Curator applies three genuine creates, each mentioning a distinct entity.
+    const result = applyOps(
+      [
+        {
+          op: "create",
+          category: "decision",
+          title: "Entry One",
+          content: "We rely on AlphaWidget for the first thing.",
+          scope: "project",
+        },
+        {
+          op: "create",
+          category: "decision",
+          title: "Entry Two",
+          content: "BravoWidget powers the second thing.",
+          scope: "project",
+        },
+        {
+          op: "create",
+          category: "decision",
+          title: "Entry Three",
+          content: "CharlieWidget handles the third thing.",
+          scope: "project",
+        },
+      ],
+      { projectPath: PROJECT, sessionID: "sess-batch" },
+    );
+
+    expect(result.created).toBe(3);
+
+    // The N+1: before batching, syncEntityRefs reloaded both tables once per
+    // entry → 3 loads each. Batching loads them exactly once for the whole pass.
+    expect(counts.entities).toBe(1);
+    expect(counts.aliases).toBe(1);
+
+    // Behavioral equivalence guard: each entity is still linked to its entry.
+    expect(entities.knowledgeForEntity(alpha)).toHaveLength(1);
+    expect(entities.knowledgeForEntity(bravo)).toHaveLength(1);
+    expect(entities.knowledgeForEntity(charlie)).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Fixes #1010.

## Problem

The curator's `applyOps` re-synced entity references **once per changed entry** via `entities.syncEntityRefs(id, content)` (curator.ts:446). Each call re-ran two full-table scans:

```sql
SELECT id, canonical_name FROM entities
SELECT entity_id, alias_value FROM entity_aliases
```

So a curator pass touching **N** entries reloaded both tables **N** times — a classic N+1 amplified by table size. Surfaced by Sentry perf issues on `lore.curator` (**LOREAI-GATEWAY-30** + the repeated registry loads in that span).

## Fix

Hoist the registry load out of the per-entry path:

- `syncEntityRefs(id, content, registry?)` — accepts an optional preloaded `EntityMatchRegistry`. When omitted it loads the registry itself, so existing single-entry callers (pattern-extract, tests) are unchanged.
- `syncEntityRefsBatch(items)` — loads the entities/aliases registry **once** and re-syncs every item. Per-item failures are logged and skipped, preserving the curator's prior per-entry resilience (one bad entry can't abort the rest).
- `applyOps` collects `{id, content}` in the `idsToSync` loop and calls `syncEntityRefsBatch` once.

The registry snapshot is safe for the whole batch: entities detected by the curator are created **after** the ref-sync loop. Per-ref `INSERT OR IGNORE` stays per-row to preserve FK-violation skip semantics.

## Result

Entities/aliases tables load **once per curator pass** instead of once per entry.

## Test / red-green

`curator-entity-ref-batch.test.ts` counts query executions via a `LogSink.withDbSpan` tracer and asserts both tables load exactly once across a 3-entry `applyOps` pass. Verified red→green:

- **Before fix:** `counts.entities === 3` ❌
- **After fix:** `counts.entities === 1` ✅

It also asserts each entity is still linked to its entry (behavioral equivalence guard).

Full monorepo suite green (4467 passed, 0 failed); typecheck + lint clean.

## Out of scope (separate follow-ups, see #1010)
- Per-entry dedup-guard `SELECT … knowledge_current` in `ltm.create()` (LOREAI-GATEWAY-2Y/2Z).
- Per-pair `dedup_feedback` INSERT during consolidation (LOREAI-GATEWAY-2Q/2R).
