### PR TITLE
fix(gateway): trim mid-session knowledge delta to additive-only

### DIFF
--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -1261,7 +1261,16 @@ export function buildKnowledgeDeltaMessage(
     title: string;
   }>,
 ): GatewayMessage | null {
-  if (!entries.length && !removedIds.length) return null;
+  // Emit ONLY when there is genuine new/changed knowledge to surface. A
+  // removals-only diff (a pinned entry deleted/superseded by background
+  // consolidation, or dropped from the selected set) no longer injects a
+  // mid-session message: a "## Superseded — ignore these ids" list is content
+  // the model cannot reliably act on, and its per-turn churn was the dominant
+  // cache-bust driver on long sessions (read floored, deep-prefix rewritten
+  // every turn). The removal is still recorded in the block's `mut` signature
+  // by the caller (advanceSurfacedKeys), so the surfaced set still advances;
+  // the stale pin is simply left for the next session start to refresh.
+  if (!entries.length) return null;
   const renderedIds: string[] = [];
   let rendered = formatKnowledge(
     entries.map((entry) => ({
@@ -1285,52 +1294,25 @@ export function buildKnowledgeDeltaMessage(
     renderedIds.push(entry.id);
   }
   rendered ??= "";
-  const renderedIDSet = new Set(renderedIds);
-  // Sort the overflow ("Additional Changed Knowledge") deterministically by id
-  // before slicing. `entries` arrives in forSession() ranking order, which is
-  // volatile per turn (relevance scoring), so an unsorted slice could pick a
-  // different 3 entries / different order across turns → a byte-different delta
-  // even when nothing materially changed → a needless cache bust. The primary
-  // `rendered` section is already order-stabilized by formatKnowledge; this
-  // makes the overflow section byte-stable too.
-  const skipped = entries
-    .filter((entry) => !renderedIDSet.has(entry.id))
-    .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
-  const skippedRendered = skipped.length
-    ? `\n\n## Additional Changed Knowledge (truncated)\n\n${skipped
-        .slice(0, 3)
-        .map((entry) => {
-          const truncated =
-            entry.content.length > 500
-              ? `${entry.content.slice(0, 500)}...`
-              : entry.content;
-          return `* **[${entry.id.slice(0, 8)}]${entry.title}**: ${truncated}`;
-        })
-        .join("\n")}${
-        skipped.length > 3
-          ? `\n* ${skipped.length - 3} more changed entr${skipped.length - 3 === 1 ? "y" : "ies"} omitted; older pinned system[2] entries for those IDs are stale.`
-          : ""
-      }`
-    : "";
-  const removals = removedIds.length
-    ? `\n\n## Superseded Long-term Knowledge\n\nIgnore any older pinned system[2] entries with these IDs; they are no longer in the current selected knowledge set:\n${removedIds.map((id) => `* [${id.slice(0, 8)}]`).join("\n")}`
-    : "";
-  // #917 overflow ToC: a compact index of relevance-scored entries that didn't
-  // fit the system[2] budget, so the agent can recall them on demand. Exclude
-  // ids already shown above (changed/rendered) or listed as superseded — listing
-  // a "recall this" id that's also "ignore this" would contradict. Sort by id
-  // (NOT relevance order, which churns per turn) so the section is byte-stable
-  // across turns and only changes when the overflow SET changes — same cache-
-  // stability rationale as the "Additional Changed Knowledge" slice above. The
-  // section never appears alone: the early return above bails when there is no
-  // material change, so overflow only ever rides a delta that already exists.
-  const shownOrRemoved = new Set<string>([
-    ...entries.map((e) => e.id),
-    ...removedIds,
-  ]);
-  const tocEntries = (overflow ?? [])
-    .filter((e) => !shownOrRemoved.has(e.id))
-    .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+  // Fold two groups into ONE compact, ACTIONABLE recall-by-id index:
+  //  (1) changed entries that overflowed the full-render budget above —
+  //      surfaced as `[k:id]` hints instead of the old "Additional Changed
+  //      Knowledge (truncated)" dump (3 cut-off entries + "N more omitted",
+  //      which the model couldn't act on);
+  //  (2) #917 relevance-scored overflow that didn't fit system[2].
+  // Sort by id (NOT relevance order, which churns per turn) so the section is
+  // byte-stable across turns and only changes when the SET changes — preserving
+  // the conversation prompt cache. Skip ids already fully rendered above, and
+  // any removed id (a tombstoned entry must never be suggested for recall).
+  const removedSet = new Set(removedIds);
+  const tocSeen = new Set<string>(renderedIds);
+  const tocEntries: Array<{ id: string; title: string; category: string }> = [];
+  for (const e of [...entries, ...(overflow ?? [])]) {
+    if (tocSeen.has(e.id) || removedSet.has(e.id)) continue;
+    tocSeen.add(e.id);
+    tocEntries.push({ id: e.id, title: e.title, category: e.category });
+  }
+  tocEntries.sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
   const tocRendered = tocEntries.length
     ? `\n\n## Other relevant knowledge (recall by id for detail)\n\n${tocEntries
         .slice(0, OVERFLOW_TOC_MAX)
@@ -1349,8 +1331,6 @@ export function buildKnowledgeDeltaMessage(
         text:
           "[Lore knowledge update: durable prompt delta. This message is inserted by Lore and replayed byte-identically on later turns until an intentional cache reset.]\n\n" +
           rendered +
-          skippedRendered +
-          removals +
           tocRendered,
       },
     ],

--- a/packages/gateway/test/cache-stability.e2e.test.ts
+++ b/packages/gateway/test/cache-stability.e2e.test.ts
@@ -577,13 +577,19 @@ describe("cache stability (e2e)", () => {
     expect(turn3Messages).toContain(
       "Updated context-bound knowledge that must arrive as a durable prompt delta",
     );
-    expect(turn3Messages).toContain("Additional Changed Knowledge");
-    expect(turn3Messages).toContain("Changed huge durable delta marker");
+    // The large changed entry overflows the delta render budget. It is no longer
+    // dumped as a truncated half-entry ("Additional Changed Knowledge"); instead
+    // it is folded into the actionable recall-by-id index so it is referenced
+    // (not silently dropped) and the model can recall its full current content.
+    expect(turn3Messages).not.toContain("Additional Changed Knowledge");
+    expect(turn3Messages).not.toContain("Superseded");
+    expect(turn3Messages).toContain("Other relevant knowledge");
+    expect(turn3Messages).toContain(`[k:${largeContextID}]`);
     expect(turn4Messages).toContain("Lore knowledge update");
     expect(turn4Messages).toContain(
       "Updated context-bound knowledge that must arrive as a durable prompt delta",
     );
-    expect(turn4Messages).toContain("Changed huge durable delta marker");
+    expect(turn4Messages).toContain(`[k:${largeContextID}]`);
 
     const rows = harness.queryDB<{
       seq: number;
@@ -602,7 +608,7 @@ describe("cache stability (e2e)", () => {
     expect(selector.target).toBe("messages");
     expect(Number.isInteger(selector.insertAt)).toBe(true);
     expect(rows[0].content).toContain("Updated context-bound knowledge");
-    expect(rows[0].content).toContain("Changed huge durable delta marker");
+    expect(rows[0].content).toContain(`[k:${largeContextID}]`);
   });
 
   it("budget-overflow knowledge surfaces as a recall-by-id ToC in system[1] (A) and the delta (B) [#917]", async () => {
@@ -983,17 +989,14 @@ describe("cache stability (e2e)", () => {
     expect(rows[0].content).toBe(block0First?.content);
   });
 
-  it("supersessions on different turns are ALL preserved across the appended block sequence (incl. restart)", async () => {
-    // Append-only correctness: two entries superseded on two different turns
-    // must BOTH remain surfaced. In the append-only model each removal appends
-    // its own immutable block, so the supersessions live across the SEQUENCE of
-    // blocks (not one rewritten row). The advancing surfaced-set reconstruction
-    // — frozen pin baseline + each block's stashed mutation signature — is what
-    // keeps the earlier supersession from being dropped AND keeps the later one
-    // from re-surfacing the earlier (already-surfaced) entry. The reconstruction
-    // is durable: it is rebuilt purely from the persisted blocks, so it survives
-    // a restart with no extra state. We exercise force layer 4 + a restart
-    // between the two removals to prove it.
+  it("genuine supersessions on different turns surface NO delta and keep system[2] byte-stable (incl. restart)", async () => {
+    // Trim (quality + cost): a removals-only diff no longer injects a mid-session
+    // "Superseded — ignore these ids" delta — that list was content the model
+    // could not reliably act on, and its per-turn churn was the dominant
+    // cache-bust driver. Here two entries are genuinely removed on two different
+    // turns (with a restart between them) under forced layer 4: NO delta block is
+    // appended, and the frozen system[2] pin stays byte-identical the whole time
+    // (the stale entries are simply left pinned until the next session refresh).
     const turns = Array.from({ length: 7 }, (_, i) => ({
       userMessage: `Cumulative turn ${i}: continue.`,
       assistantText: `Cumulative response ${i}.`,
@@ -1072,43 +1075,31 @@ describe("cache stability (e2e)", () => {
       "SELECT seq, content FROM session_prompt_deltas WHERE session_id = ? ORDER BY seq",
       [sessionID],
     );
-    // Two distinct removals on two turns → two appended blocks (A's, then B's).
+    // Removals-only → NOTHING is appended. (A removal still advances the surfaced
+    // set when it rides a genuine content change, but on its own it never
+    // produces a delta block.)
     expect(
       rows.length,
-      `expected two appended supersession blocks, got seqs=${rows
+      `expected NO appended delta blocks for removals-only, got seqs=${rows
         .map((r) => r.seq)
         .join(",")}`,
-    ).toBe(2);
+    ).toBe(0);
 
-    // Across the WHOLE block sequence, BOTH A and B must be surfaced as
-    // superseded — exactly once each (no drop, no duplicate re-surface despite
-    // the restart between the two removals).
-    const allText = rows
-      .map((r) =>
-        (JSON.parse(r.content) as { content: Array<{ text?: string }> }).content
-          .map((b) => b.text ?? "")
-          .join(""),
-      )
-      .join("\n");
-    for (const r of rows) {
-      const blockText = (
-        JSON.parse(r.content) as { content: Array<{ text?: string }> }
-      ).content
-        .map((b) => b.text ?? "")
-        .join("");
-      expect(blockText).toContain("Superseded Long-term Knowledge");
+    // The frozen system[2] pin must stay byte-identical across every turn after
+    // it froze — the genuine removals (and the restart between them) must never
+    // rewrite or recompute it.
+    const bodies = harness.upstreamBodies();
+    const steadySystem = systemBlocks(bodies[1]);
+    for (let i = 2; i < bodies.length; i++) {
+      expect(
+        systemBlocks(bodies[i]),
+        `system blocks changed on turn ${i + 1} after a genuine removal — the ` +
+          `frozen system[2] pin must never be rewritten by a removal`,
+      ).toEqual(steadySystem);
     }
-    const bulletCount = (allText.match(/\n\* \[/g) ?? []).length;
-    expect(
-      bulletCount,
-      `expected 2 superseded bullets across the block sequence (A on turn 2, ` +
-        `B on turn 4), got ${bulletCount}. A count of 1 means a supersession ` +
-        `was dropped; >2 means an already-surfaced removal re-fired (the ` +
-        `advancing surfaced-set didn't survive the restart). Blocks: ${allText}`,
-    ).toBe(2);
   });
 
-  it("removed LTM entries are replayed as durable superseded deltas without rewriting system[2]", async () => {
+  it("removed LTM entries surface NO mid-session delta and keep system[2] byte-stable", async () => {
     const turns = Array.from({ length: 4 }, (_, i) => ({
       userMessage: `Removal delta turn ${i}: continue the work.`,
       assistantText: `Removal delta response ${i}.`,
@@ -1174,18 +1165,17 @@ describe("cache stability (e2e)", () => {
 
     const turn3Messages = serializedMessages(bodies[2]);
     const turn4Messages = serializedMessages(bodies[3]);
-    expect(turn3Messages).toContain("Superseded Long-term Knowledge");
-    expect(turn3Messages).toContain(contextID.slice(0, 8));
-    expect(turn4Messages).toContain("Superseded Long-term Knowledge");
-    expect(turn4Messages).toContain(contextID.slice(0, 8));
+    // Removals-only no longer surface a mid-session message: the deleted entry
+    // is left pinned (stale) in the frozen system[2] until the next session
+    // refresh, and no "Superseded" delta is injected to bust the cache.
+    expect(turn3Messages).not.toContain("Superseded");
+    expect(turn4Messages).not.toContain("Superseded");
 
     const rows = harness.queryDB<{ content: string }>(
       "SELECT content FROM session_prompt_deltas WHERE session_id = ? ORDER BY seq",
       [sessionID],
     );
-    expect(rows).toHaveLength(1);
-    expect(rows[0].content).toContain("Superseded Long-term Knowledge");
-    expect(rows[0].content).toContain(contextID.slice(0, 8));
+    expect(rows).toHaveLength(0);
   });
 
   it("frozen system[1] survives a mid-session preference DELETE across a restart (ses_14b9bf3d… incident)", async () => {
@@ -1357,7 +1347,7 @@ describe("cache stability (e2e)", () => {
     expect(bodies[2]).not.toContain("Mid-session minted preference");
   });
 
-  it("normal LTM refresh preserves system[2] and emits durable removal deltas", async () => {
+  it("normal LTM refresh preserves system[2] and surfaces NO removal delta", async () => {
     const turns = Array.from({ length: 4 }, (_, i) => ({
       userMessage: `Normal removal delta turn ${i}: continue the work.`,
       assistantText: `Normal removal delta response ${i}.`,
@@ -1422,8 +1412,15 @@ describe("cache stability (e2e)", () => {
     expect(systemBlocks(bodies[3])).toEqual(steadySystem);
 
     const turn3Messages = serializedMessages(bodies[2]);
-    expect(turn3Messages).toContain("Superseded Long-term Knowledge");
-    expect(turn3Messages).toContain(contextID.slice(0, 8));
+    // A removal during a normal (non-emergency) refresh must keep system[2]
+    // byte-stable (asserted above) and must NOT inject a "Superseded" delta —
+    // removals-only no longer surface mid-session.
+    expect(turn3Messages).not.toContain("Superseded");
+    const rows = harness.queryDB<{ content: string }>(
+      "SELECT content FROM session_prompt_deltas WHERE session_id = ? ORDER BY seq",
+      [sessionID],
+    );
+    expect(rows).toHaveLength(0);
   });
 
   it("cached system blocks stay byte-stable across gradient compression layers", async () => {

--- a/packages/gateway/test/prompt-delta-append-only.test.ts
+++ b/packages/gateway/test/prompt-delta-append-only.test.ts
@@ -111,7 +111,13 @@ describe("append-only durable knowledge deltas", () => {
     expect(contents[1]).toContain("B AFTER — changed.");
   });
 
-  it("a persistent removal, once surfaced, does NOT re-fire on later turns (the 1LYkXZ fix)", () => {
+  it("a persistent removal-only surfaces NO block, ever (removals are not injected mid-session; supersedes the 1LYkXZ fix)", () => {
+    // Trim (quality + cost): a removals-only diff no longer injects a mid-session
+    // delta at all. The old "Superseded — ignore these ids" list was content the
+    // model could not reliably act on, and even surfacing it ONCE per genuine
+    // removal added cache churn. The 1LYkXZ bust (re-detecting + re-writing the
+    // same removal every turn) is now trivially impossible: the removal produces
+    // zero writes on turn 1 AND every later turn.
     const doomed = ltm.create({
       projectPath: PROJECT,
       scope: "project",
@@ -126,7 +132,7 @@ describe("append-only durable knowledge deltas", () => {
 
     ltm.remove(doomed); // genuine, permanent deletion
 
-    // Turn 1: the removal is surfaced.
+    // Turn 1: a removal alone surfaces nothing.
     const wrote1 = appendKnowledgePromptDelta({
       sessionID,
       projectPath: PROJECT,
@@ -135,8 +141,8 @@ describe("append-only durable knowledge deltas", () => {
       nextKeys: [],
       entries: [],
     });
-    // Turn 2..N: the pin baseline still lists the (gone) entry, but it was
-    // already surfaced — the advanced surfaced set drops it, so no new block.
+    // Turn 2..N: the pin baseline still lists the (gone) entry every turn (the
+    // original bug condition), but it must never produce a block.
     const laterWrites: boolean[] = [];
     for (let turn = 0; turn < 5; turn++) {
       laterWrites.push(
@@ -151,10 +157,10 @@ describe("append-only durable knowledge deltas", () => {
       );
     }
 
-    expect(wrote1).toBe(true);
+    expect(wrote1).toBe(false);
     expect(laterWrites).toEqual([false, false, false, false, false]);
-    // Exactly ONE block total, ever — not one per turn.
-    expect(listSessionPromptDeltas(sessionID)).toHaveLength(1);
+    // Zero blocks, ever — a removal-only never busts the cache.
+    expect(listSessionPromptDeltas(sessionID)).toHaveLength(0);
   });
 
   it("an appended block is immutable — a later append never rewrites earlier blocks", () => {

--- a/packages/gateway/test/prompt-delta-mutation-trigger.test.ts
+++ b/packages/gateway/test/prompt-delta-mutation-trigger.test.ts
@@ -221,7 +221,13 @@ describe("detectSurfacedMutations — genuine DB mutation, not ranking churn", (
     expect(listSessionPromptDeltas(sessionID)).toHaveLength(0);
   });
 
-  it("WIRING: genuine deletion of a pinned entry → superseded delta IS written", () => {
+  it("WIRING: genuine deletion of a pinned entry ALONE → NO delta (removals-only not surfaced)", () => {
+    // Trim (quality + cost): a removals-only diff no longer injects a mid-session
+    // message. A "## Superseded — ignore these ids" list is content the model
+    // cannot reliably act on, and the per-turn churn of that list was the
+    // dominant cache-bust driver on long sessions. The deletion is left for the
+    // next session's pin refresh; if a genuine CHANGE later rides through, the
+    // removal is folded into that block's `mut` signature (next test).
     const id = ltm.create({
       projectPath: PROJECT,
       scope: "project",
@@ -247,8 +253,63 @@ describe("detectSurfacedMutations — genuine DB mutation, not ranking churn", (
       entries: [],
     });
 
+    expect(wrote).toBe(false);
+    expect(listSessionPromptDeltas(sessionID)).toHaveLength(0);
+  });
+
+  it("WIRING: deletion that rides a genuine change → delta written, removal in mut (advances surfaced set), no 'Superseded' text", () => {
+    // The removal still has to ADVANCE the surfaced set so it isn't re-detected
+    // forever. When it rides a real content change, the appended block records
+    // it in `mut.removed` (consumed by advanceSurfacedKeys) even though the
+    // rendered text no longer carries a "Superseded" section.
+    const changedId = ltm.create({
+      projectPath: PROJECT,
+      scope: "project",
+      category: "gotcha",
+      title: "Pinned then edited (rides)",
+      content: "Before.",
+    });
+    const deletedId = ltm.create({
+      projectPath: PROJECT,
+      scope: "project",
+      category: "gotcha",
+      title: "Pinned then deleted (rides)",
+      content: "Will be removed alongside a change.",
+    });
+    const sessionID = `wiring-ride-${Date.now()}`;
+    const changedKey = keyOf(
+      changedId,
+      "Pinned then edited (rides)",
+      "Before.",
+    );
+    const deletedKey = keyOf(
+      deletedId,
+      "Pinned then deleted (rides)",
+      "Will be removed alongside a change.",
+    );
+
+    ltm.update(changedId, { content: "After — materially changed." });
+    ltm.remove(deletedId);
+
+    const wrote = appendKnowledgePromptDelta({
+      sessionID,
+      projectPath: PROJECT,
+      insertAt: 5,
+      previousKeys: [changedKey, deletedKey],
+      nextKeys: [changedKey],
+      entries: [],
+    });
+
     expect(wrote).toBe(true);
-    expect(deltaText(sessionID)).toContain("Superseded Long-term Knowledge");
+    const text = deltaText(sessionID);
+    expect(text).toContain("After — materially changed.");
+    expect(text).not.toContain("Superseded");
+    // The removal must be recorded in the block's mutation signature.
+    const [row] = listSessionPromptDeltas(sessionID);
+    const selector = JSON.parse(row.selector) as {
+      mut?: { removed?: string[] };
+    };
+    expect(selector.mut?.removed ?? []).toContain(deletedId);
   });
 
   it("WIRING: genuine content change of a pinned entry → changed delta IS written", () => {


### PR DESCRIPTION
## Problem
The durable mid-session knowledge-delta ("[Lore knowledge update]") injected three sections, two of which the agent could not reliably act on and which drove cache busts on long sessions. In a real dogfood session the cache `read` was floored at 48,975 tokens for 7 consecutive turns while a deep-prefix message was rewritten each turn.

Inspecting the live DB, the delta was dominated by:
- **`## Superseded Long-term Knowledge`** — a wall of ~41 opaque ids telling the model to *"ignore pinned entries with these IDs."* Asking an LLM to mentally diff-and-exclude pinned content by id is unreliable, and worse, it asks it to suppress *still-valid* knowledge that mere background ranking/consolidation deprioritized. This list churns every time background consolidation merges duplicates — **the dominant cache-bust driver**, unrelated to the task.
- **`## Additional Changed Knowledge (truncated)`** — 3 entries cut to 500 chars + an "N more omitted" line. Truncated half-entries the model can't use.

This matches a prior agent's verdict that "the information update is irrelevant."

## Change
The delta is now **additive-only**:
- **Emit only on genuine new/changed knowledge** (`if (!entries.length) return null`). A removals-only diff no longer injects a mid-session message.
- **Drop the `Superseded` section** entirely.
- **Fold changed-overflow into the existing recall-by-id index** instead of a truncated dump — every changed entry that overflows the render budget is referenced as an actionable `[k:id]` hint rather than silently dropped or half-rendered.

Removals are still recorded in the block's `mut` signature, so the advancing surfaced set still drops them when a genuine change rides through; the stale pin is simply left for the next session start to refresh. This trades a rare mid-session staleness for the cache stability it was busting.

## Tests
- Updated the unit + e2e suites to the new contract (removals-only → no delta + byte-stable `system[2]`; changed-overflow → recall hint).
- Added: deletion-rides-a-change surfaces the change, carries no "Superseded" text, and still records the removal in `mut`.
- **Mutation-verified (red-green):** reverting the emission gate fails the removal tests; restoring the `Superseded` render fails the "no Superseded" guard. File restored byte-identical after.
- Full suite green (4457 passed); changed files run 3× with no flakiness.

🤖 Generated with [opencode](https://opencode.ai)