### PR TITLE
fix(core): emit read-path timing on forSession empty-knowledge fast path

### DIFF
--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -1809,7 +1809,15 @@ export async function forSession(
     hydrateKnowledgeEntry,
   ) as KnowledgeEntry[];
 
-  if (!crossEntries.length && !projectEntries.length) return [];
+  if (!crossEntries.length && !projectEntries.length) {
+    // Empty-knowledge fast path (new project, or all entries below the
+    // confidence floor). Emit before returning so the FASTEST path is
+    // represented in the read-path metrics — otherwise the distribution is
+    // skewed toward slower, non-empty turns and #966 B is decided on biased
+    // data. Mirrors the timeout early return above (Seer, PR #993).
+    timer.emit("forSession", 0);
+    return [];
+  }
 
   // --- Preference-only fast path ---
   // Preferences are unconditional user directives — relevance scoring harms them.

--- a/packages/core/test/read-telemetry.test.ts
+++ b/packages/core/test/read-telemetry.test.ts
@@ -87,4 +87,25 @@ describe("forSession fires the read-path timing hook", () => {
     expect((t as ReadPathTiming).totalMs).toBeGreaterThanOrEqual(0);
     expect((t as ReadPathTiming).syncBlockingMs).toBeGreaterThanOrEqual(0);
   });
+
+  it("emits op=forSession (candidateCount 0) on the empty-knowledge fast path (Seer #993)", async () => {
+    // A project with NO knowledge entries hits the `!crossEntries && !
+    // projectEntries` early return — the FASTEST path. It must still emit, or
+    // the read-path distribution is skewed toward slower, non-empty turns.
+    const PROJECT = `/test/read-telemetry/forsession-empty-${Date.now()}`;
+
+    const seen: ReadPathTiming[] = [];
+    setReadPathTimingHook((t) => seen.push(t));
+
+    const out = await ltm.forSession(PROJECT, "s-empty", 4000);
+    expect(out).toEqual([]);
+
+    const t = seen.find((x) => x.op === "forSession");
+    expect(
+      t,
+      "empty-knowledge forSession must still emit timing",
+    ).toBeDefined();
+    expect((t as ReadPathTiming).candidateCount).toBe(0);
+    expect((t as ReadPathTiming).syncBlockingMs).toBeGreaterThanOrEqual(0);
+  });
 });


### PR DESCRIPTION
## Problem
Addresses the Seer review on #993 (https://github.com/BYK/loreai/pull/993#discussion_r3476391749).

`forSession()` constructs a `ReadPathTimer`, but the empty-knowledge early return —

```ts
if (!crossEntries.length && !projectEntries.length) return [];
```

— returned *without* calling `timer.emit()`. That path is the **fastest possible execution** (new projects, or projects whose entries all sit below the confidence floor), so its timings were silently dropped. The result is a read-path distribution skewed toward slower, non-empty turns — biasing the exact #966 B "is further offloading worth it?" decision the instrumentation exists to inform.

## Fix
Emit `op=forSession`, `candidateCount=0` before the early return, mirroring the sibling worker-timeout early return already at this site (which correctly emits).

## Test
- Added a regression test: `forSession` on a project with no entries still fires the timing hook with `candidateCount=0`.
- **Mutation-verified:** reverting to the bare `return []` makes the new test fail; restored byte-identical.
- `read-telemetry` + `ltm` suites green (90 passed).

🤖 Generated with [opencode](https://opencode.ai)