### PR TITLE
perf(core): batch dedup_feedback inserts into one transaction

### DIFF
--- a/packages/core/src/entities.ts
+++ b/packages/core/src/entities.ts
@@ -6,7 +6,7 @@
  * formatting for system prompt injection and recall query expansion.
  */
 import { uuidv7 } from "uuidv7";
-import { db, ensureProject, getKV, setKV } from "./db";
+import { db, ensureProject, getKV, setKV, withTransaction } from "./db";
 import { ftsQuery, ftsQueryOr, EMPTY_QUERY, filterTerms } from "./search";
 import { config } from "./config";
 import { getGitUser } from "./git";
@@ -2045,18 +2045,24 @@ export function recordEntityAutoSignals(
   );
   const capped = signals.slice(0, ENTITY_AUTO_SIGNAL_MAX_PAIRS);
 
-  pruneEntityDedupFeedback(projectId);
+  // Prune + insert atomically in one transaction. Without this each
+  // recordEntityDedupFeedback() below auto-commits on its own (up to
+  // ENTITY_AUTO_SIGNAL_MAX_PAIRS write-lock cycles per sweep); wrapping
+  // collapses the sweep into a single commit and keeps prune+insert consistent.
+  withTransaction(() => {
+    pruneEntityDedupFeedback(projectId);
 
-  for (const s of capped) {
-    recordEntityDedupFeedback({
-      projectId,
-      entryATitle: s.entryATitle,
-      entryBTitle: s.entryBTitle,
-      similarity: s.similarity,
-      accepted: false,
-      source: "auto_dedup",
-    });
-  }
+    for (const s of capped) {
+      recordEntityDedupFeedback({
+        projectId,
+        entryATitle: s.entryATitle,
+        entryBTitle: s.entryBTitle,
+        similarity: s.similarity,
+        accepted: false,
+        source: "auto_dedup",
+      });
+    }
+  });
 }
 
 /** Get all entity feedback for a project (for calibration). */

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -3278,22 +3278,27 @@ export function recordDedupResultFeedback(
   accepted: boolean,
   source: DedupFeedbackSource,
 ): void {
-  for (const cluster of result.clusters) {
-    for (const merged of cluster.merged) {
-      const pk = dedupPairKey(cluster.surviving.id, merged.id);
-      const similarity = result.pairSimilarities.get(pk);
-      if (similarity != null && similarity > 0) {
-        recordDedupFeedback({
-          projectId,
-          entryATitle: cluster.surviving.title,
-          entryBTitle: merged.title,
-          similarity,
-          accepted,
-          source,
-        });
+  // Batch every row into a single transaction: each recordDedupFeedback() is a
+  // standalone INSERT that would otherwise auto-commit on its own (one write
+  // lock cycle per merged pair). Wrapping makes the whole signal set atomic.
+  withTransaction(() => {
+    for (const cluster of result.clusters) {
+      for (const merged of cluster.merged) {
+        const pk = dedupPairKey(cluster.surviving.id, merged.id);
+        const similarity = result.pairSimilarities.get(pk);
+        if (similarity != null && similarity > 0) {
+          recordDedupFeedback({
+            projectId,
+            entryATitle: cluster.surviving.title,
+            entryBTitle: merged.title,
+            similarity,
+            accepted,
+            source,
+          });
+        }
       }
     }
-  }
+  });
 }
 
 /**
@@ -3362,19 +3367,25 @@ export function recordAutoSignals(
   );
   const capped = signals.slice(0, AUTO_SIGNAL_MAX_PAIRS);
 
-  // Prune old feedback to prevent unbounded table growth
-  pruneDedupFeedback(projectId);
+  // Prune + insert atomically in a single transaction. Without this each
+  // recordDedupFeedback() below auto-commits on its own (up to
+  // AUTO_SIGNAL_MAX_PAIRS write-lock cycles per sweep); wrapping collapses the
+  // whole sweep into one commit and keeps prune+insert consistent.
+  withTransaction(() => {
+    // Prune old feedback to prevent unbounded table growth
+    pruneDedupFeedback(projectId);
 
-  for (const s of capped) {
-    recordDedupFeedback({
-      projectId,
-      entryATitle: s.entryATitle,
-      entryBTitle: s.entryBTitle,
-      similarity: s.similarity,
-      accepted: false,
-      source: "auto_dedup",
-    });
-  }
+    for (const s of capped) {
+      recordDedupFeedback({
+        projectId,
+        entryATitle: s.entryATitle,
+        entryBTitle: s.entryBTitle,
+        similarity: s.similarity,
+        accepted: false,
+        source: "auto_dedup",
+      });
+    }
+  });
 }
 
 /** Get all feedback for a project (for calibration). */

--- a/packages/core/test/dedup.test.ts
+++ b/packages/core/test/dedup.test.ts
@@ -451,6 +451,50 @@ describe("dedup — feedback recording", () => {
     expect(feedback[0].source).toBe("auto_dedup");
   });
 
+  test("recordAutoSignals batches all feedback inserts in one transaction (#1010)", () => {
+    const pid = ensureProject(PROJECT);
+    // Three high-similarity, non-merged pairs → three reject signals → three
+    // INSERTs. `clusters` is empty so none is treated as a merged pair, and
+    // titles come straight from `entryTitles`. The N+1 being guarded here is
+    // one auto-commit per inserted row; the fix wraps the whole sweep in a
+    // single transaction.
+    const result = {
+      clusters: [],
+      totalRemoved: 0,
+      pairSimilarities: new Map([
+        [dedupPairKey("a", "b"), 0.85],
+        [dedupPairKey("a", "c"), 0.9],
+        [dedupPairKey("b", "c"), 0.88],
+      ]),
+      entryTitles: new Map([
+        ["a", "Reject signal title A"],
+        ["b", "Reject signal title B"],
+        ["c", "Reject signal title C"],
+      ]),
+    } satisfies ltm.DedupResult;
+
+    // Spy on the live connection's exec() to count BEGIN statements. Inserts go
+    // through query().run(), so the only BEGIN can come from withTransaction().
+    const conn = db() as unknown as { exec(sql: string): unknown };
+    const realExec = conn.exec.bind(conn);
+    let begins = 0;
+    conn.exec = (sql: string) => {
+      if (/^\s*BEGIN/i.test(sql)) begins++;
+      return realExec(sql);
+    };
+    try {
+      ltm.recordAutoSignals(pid, result);
+    } finally {
+      conn.exec = realExec;
+    }
+
+    // All three signals are recorded...
+    expect(ltm.getDedupFeedbackCount(pid)).toBe(3);
+    // ...inside exactly one transaction (would be 0 BEGINs before the fix:
+    // every recordDedupFeedback() auto-committed on its own).
+    expect(begins).toBe(1);
+  });
+
   test("recordAutoSignals filters out pairs below 0.80 similarity", async () => {
     const id1 = createEntry({ title: "Unique entry for low sim alpha" });
     const id2 = createEntry({ title: "Unique entry for low sim beta" });

--- a/packages/core/test/entity-dedup.test.ts
+++ b/packages/core/test/entity-dedup.test.ts
@@ -306,6 +306,47 @@ describe("entity dedup — adaptive calibration (kind='entity')", () => {
     expect(entities.getEntityDedupFeedbackCount(pid)).toBe(1);
   });
 
+  test("recordEntityAutoSignals batches all inserts in one transaction (#1010)", () => {
+    const pid = ensureProject(PROJECT);
+    // Three high-similarity, undecided pairs → three reject signals → three
+    // INSERTs that must land inside a single transaction. `merged`/`suggested`
+    // are empty so no pair is treated as decided; names come from `names`.
+    const result = {
+      merged: [],
+      suggested: [],
+      pairSimilarities: new Map([
+        [entities.entityPairKey("a", "b"), 0.85],
+        [entities.entityPairKey("a", "c"), 0.9],
+        [entities.entityPairKey("b", "c"), 0.88],
+      ]),
+      names: new Map([
+        ["a", "Entity A"],
+        ["b", "Entity B"],
+        ["c", "Entity C"],
+      ]),
+    } satisfies entities.EntityDedupResult;
+
+    // Spy on the live connection's exec() to count BEGIN statements. Inserts go
+    // through query().run(), so the only BEGIN can come from withTransaction().
+    const conn = db() as unknown as { exec(sql: string): unknown };
+    const realExec = conn.exec.bind(conn);
+    let begins = 0;
+    conn.exec = (sql: string) => {
+      if (/^\s*BEGIN/i.test(sql)) begins++;
+      return realExec(sql);
+    };
+    try {
+      entities.recordEntityAutoSignals(pid, result);
+    } finally {
+      conn.exec = realExec;
+    }
+
+    // All three signals are recorded...
+    expect(entities.getEntityDedupFeedbackCount(pid)).toBe(3);
+    // ...inside exactly one transaction (would be 0 BEGINs before the fix).
+    expect(begins).toBe(1);
+  });
+
   test("calibrateEntityDedupThreshold returns null below 20 samples", () => {
     const pid = ensureProject(PROJECT);
     for (let i = 0; i < 5; i++) {


### PR DESCRIPTION
## What

Picks up one of the deferred N+1 follow-ups from #1010 (LOREAI-GATEWAY-2Q/2R): the per-pair `dedup_feedback` INSERT loops in the post-curation calibration sweeps.

`recordAutoSignals` (knowledge) and `recordEntityAutoSignals` (entity) each emit up to `AUTO_SIGNAL_MAX_PAIRS` (50) standalone INSERTs — one auto-commit per row — preceded by a separate `prune` DELETE. `recordDedupResultFeedback` does the same, one INSERT per merged pair. Each sweep wraps prune+insert in a single `withTransaction`, collapsing N write-lock cycles into one commit and making the batch atomic (a crash mid-loop no longer leaves a partial, calibration-skewing signal set).

Magnitude: the DB only sets `journal_mode=WAL` (db.ts:2050) and never touches `synchronous`, so it runs at the SQLite default `synchronous=FULL`. Under WAL + `FULL`, every commit fsyncs the WAL — so batching a sweep of N rows into one transaction removes ~N−1 fsyncs (not just write-lock acquire/commit cycles) per sweep, on top of prune+insert atomicity. This is the same rationale the codebase already documents for `seedOutbox` (sync-data.ts:522: "without it WAL + synchronous=FULL would fsync once PER ROW").

## Scope / safety

- `dedup_feedback` is a **separate calibration table**, untouched by the upcoming knowledge/entities append-only refactor (#467/#495), so this is safe to land now.
- All three call sites (`curator.ts` post-curation block ×2, `data.ts` CLI) are confirmed non-nested, so `BEGIN IMMEDIATE` cannot nest-throw. `prune*DedupFeedback` opens no transaction of its own. The curator calls run after `await deduplicate(...)`/`await deduplicateEntities(...)` have returned (their own `merge()` transactions already committed), and `withTransaction` is fully synchronous, so no `await` can split the transaction.
- The `self_merge` audit loop in `entities.ts` (interleaved with `merge()`, which opens its own `BEGIN IMMEDIATE`) is intentionally **not** wrapped — wrapping it would nest-throw.

## Explicitly deferred

The sibling create-time dedup N+1 (`SELECT … FROM knowledge_current WHERE LOWER(title)=…` in `ltm.create()`, LOREAI-GATEWAY-2Y/2Z) is **not** addressed here. It is intrinsic to the current mutable `knowledge` table; the only effective fixes are an index migration on `knowledge` or in-memory dedup batching — both of which the append-only refactor would rework. Deferred to the append-only refactor (#823); full reasoning + file:line inventory tracked in #1016.

## Tests

New tests in `dedup.test.ts` and `entity-dedup.test.ts` assert exactly one transaction wraps the inserts (BEGIN-count spy on the live connection) and that all rows still land. Both mutation-verified: revert the `withTransaction` wrap → `begins=0` → red. Full core suite green (2168 passed); dedup files clean across 3 consecutive runs.

Refs #1010
