### PR TITLE
fix(gateway): re-anchor durable delta on compression instead of deleting

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -3658,15 +3658,17 @@ export function updateSessionPromptDeltaSelector(
 }
 
 /**
- * Delete all persisted prompt-delta rows for a session.
+ * Delete all persisted prompt-delta rows for a session. No-op when no rows
+ * exist.
  *
- * Used when the gradient compresses (a cache-busting layer change): the
- * durable delta's `insertAt` is a frozen absolute index into the
- * gradient-transformed message array, which is non-stationary — compression
- * reshuffles what sits at each index, so a once-safe index can drift into a
- * tool_use/tool_result pair. Rather than tracking/validating the frozen index,
- * we delete the row on compression so the same turn recomputes the delta
- * (position + content) fresh against the new array. No-op when no rows exist.
+ * NOTE: this is no longer the compression-reset action. A compressing turn now
+ * RE-ANCHORS the blocks — preserving their content and `mut` surfaced-set
+ * history — via the gateway's `reanchorExistingDelta`, rather than deleting
+ * them. (Deleting on every compression wiped that history and forced a full
+ * pin→DB re-derive each turn, a growing cache-bust wall.) This primitive is
+ * still used (a) internally by that re-anchor as its delete-then-re-append
+ * step, and (b) by the bounded `MAX_DELTA_BLOCKS` coalesce that intentionally
+ * collapses accumulated blocks back into one cumulative block.
  */
 export function deleteSessionPromptDelta(sessionID: string): void {
   db()

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -2791,6 +2791,41 @@ export function withTransaction<T>(fn: () => T): T {
   }
 }
 
+/**
+ * Run `fn` inside a named SAVEPOINT, releasing it on success and (on error)
+ * rolling back to then releasing it before re-throwing. Returns the callback's
+ * value.
+ *
+ * Unlike {@link withTransaction} (`BEGIN IMMEDIATE`, which throws if a
+ * transaction is already open), a SAVEPOINT is safe whether called at top level
+ * OR nested inside an existing transaction — SQLite permits nested savepoints
+ * but not nested `BEGIN`s. At top level the first SAVEPOINT implicitly opens a
+ * transaction, so this is also atomic when called standalone. Use this for a
+ * write unit that may, now or in a future refactor, run inside an outer
+ * transaction (see `rebuildDirtySessionRollups`/`rebuildAllSessionRollups`).
+ *
+ * `name` must be a bare SQL identifier (it is interpolated into the statement,
+ * never a bind parameter); a non-identifier is rejected to prevent injection.
+ */
+export function withSavepoint<T>(name: string, fn: () => T): T {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+    throw new Error(
+      `withSavepoint: invalid savepoint name ${JSON.stringify(name)}`,
+    );
+  }
+  const d = db();
+  d.exec(`SAVEPOINT ${name}`);
+  try {
+    const result = fn();
+    d.exec(`RELEASE ${name}`);
+    return result;
+  } catch (e) {
+    d.exec(`ROLLBACK TO ${name}`);
+    d.exec(`RELEASE ${name}`);
+    throw e;
+  }
+}
+
 // Project management
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -131,6 +131,7 @@ export {
   getInstanceId,
   runUpsert,
   withTransaction,
+  withSavepoint,
   ensureSessionRollup,
   rebuildDirtySessionRollups,
   rebuildAllSessionRollups,

--- a/packages/core/test/db-helpers.test.ts
+++ b/packages/core/test/db-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach } from "vitest";
-import { db, runUpsert, withTransaction } from "../src/db";
+import { db, runUpsert, withTransaction, withSavepoint } from "../src/db";
 
 describe("runUpsert", () => {
   beforeEach(() => {
@@ -92,5 +92,74 @@ describe("withTransaction", () => {
       c: number;
     };
     expect(count.c).toBe(0);
+  });
+});
+
+describe("withSavepoint", () => {
+  beforeEach(() => {
+    db().exec("CREATE TABLE IF NOT EXISTS _t_sp (k TEXT PRIMARY KEY)");
+    db().query("DELETE FROM _t_sp").run();
+  });
+
+  const count = () =>
+    (db().query("SELECT COUNT(*) c FROM _t_sp").get() as { c: number }).c;
+
+  test("commits on success and returns the callback value (top level)", () => {
+    const result = withSavepoint("sp_ok", () => {
+      db().query("INSERT INTO _t_sp (k) VALUES (?)").run("a");
+      return 42;
+    });
+    expect(result).toBe(42);
+    expect(count()).toBe(1);
+  });
+
+  test("rolls back on throw (row absent) and re-throws", () => {
+    expect(() =>
+      withSavepoint("sp_boom", () => {
+        db().query("INSERT INTO _t_sp (k) VALUES (?)").run("a");
+        throw new Error("boom");
+      }),
+    ).toThrow("boom");
+    expect(count()).toBe(0);
+  });
+
+  test("is safe nested INSIDE an open transaction (the BEGIN-nesting trap)", () => {
+    // This is the property withTransaction lacks: a nested BEGIN throws
+    // "cannot start a transaction within a transaction". A SAVEPOINT does not.
+    const result = withTransaction(() => {
+      db().query("INSERT INTO _t_sp (k) VALUES (?)").run("outer");
+      return withSavepoint("sp_nested", () => {
+        db().query("INSERT INTO _t_sp (k) VALUES (?)").run("inner");
+        return "ok";
+      });
+    });
+    expect(result).toBe("ok");
+    expect(count()).toBe(2);
+  });
+
+  test("inner savepoint rollback does not abort the outer transaction", () => {
+    withTransaction(() => {
+      db().query("INSERT INTO _t_sp (k) VALUES (?)").run("outer");
+      // Inner unit fails and is rolled back to its savepoint; the outer txn
+      // (and its "outer" row) must survive and commit.
+      expect(() =>
+        withSavepoint("sp_inner_fail", () => {
+          db().query("INSERT INTO _t_sp (k) VALUES (?)").run("inner");
+          throw new Error("inner boom");
+        }),
+      ).toThrow("inner boom");
+    });
+    const rows = db().query("SELECT k FROM _t_sp ORDER BY k").all() as Array<{
+      k: string;
+    }>;
+    expect(rows.map((r) => r.k)).toEqual(["outer"]);
+  });
+
+  test("rejects a non-identifier savepoint name (injection guard)", () => {
+    expect(() => withSavepoint("bad; DROP TABLE _t_sp", () => 1)).toThrow(
+      /invalid savepoint name/,
+    );
+    // The guard fires before any SQL runs, so the table is untouched.
+    expect(count()).toBe(0);
   });
 });

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -71,6 +71,7 @@ import {
   deleteSessionPromptDelta,
   listSessionPromptDeltas,
   updateSessionPromptDeltaSelector,
+  withTransaction,
   loadHeaderSessionIndex,
   isHostedMode,
   enableHostedMode,
@@ -908,15 +909,22 @@ export function reanchorExistingDelta(
     selectorObj.insertAt = reInsertAt;
     return { content: b.content, selector: JSON.stringify(selectorObj) };
   });
-  deleteSessionPromptDelta(sessionID);
-  for (const p of preserved) {
-    appendSessionPromptDelta({
-      sessionID,
-      projectID,
-      selector: p.selector,
-      content: p.content,
-    });
-  }
+  // Atomic delete + re-append so a crash mid-rewrite can never leave the
+  // session with a partial block set (which would drop surfaced-set history and
+  // force a one-time full re-derive). Runs on every compressing turn now, so
+  // crash-safety is cheap insurance. No nesting risk: the delete/append helpers
+  // are single-statement and this is never called inside another transaction.
+  withTransaction(() => {
+    deleteSessionPromptDelta(sessionID);
+    for (const p of preserved) {
+      appendSessionPromptDelta({
+        sessionID,
+        projectID,
+        selector: p.selector,
+        content: p.content,
+      });
+    }
+  });
   return reInsertAt;
 }
 

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -71,7 +71,7 @@ import {
   deleteSessionPromptDelta,
   listSessionPromptDeltas,
   updateSessionPromptDeltaSelector,
-  withTransaction,
+  withSavepoint,
   loadHeaderSessionIndex,
   isHostedMode,
   enableHostedMode,
@@ -912,9 +912,9 @@ export function reanchorExistingDelta(
   // Atomic delete + re-append so a crash mid-rewrite can never leave the
   // session with a partial block set (which would drop surfaced-set history and
   // force a one-time full re-derive). Runs on every compressing turn now, so
-  // crash-safety is cheap insurance. No nesting risk: the delete/append helpers
-  // are single-statement and this is never called inside another transaction.
-  withTransaction(() => {
+  // crash-safety is cheap insurance. Uses a SAVEPOINT (not BEGIN) so it stays
+  // safe if a future refactor ever calls this from inside an outer transaction.
+  withSavepoint("reanchor_delta", () => {
     deleteSessionPromptDelta(sessionID);
     for (const p of preserved) {
       appendSessionPromptDelta({

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -825,18 +825,21 @@ function parseDeltaMessage(raw: string): GatewayMessage | null {
  * @internal Exported for tests.
  */
 /**
- * Decide whether the durable knowledge-delta must be reset (deleted +
- * recomputed) on THIS turn because the gradient compressed the conversation.
+ * Decide whether the durable knowledge-delta must be re-anchored on THIS turn
+ * because the gradient compressed the conversation.
  *
  * The delta's persisted `insertAt` is a frozen absolute index into the
  * gradient-transformed message array. That array is non-stationary: when the
  * gradient compresses (raw-window eviction / layer escalation), the content at
  * each absolute index shifts, so a once-tool-pair-safe index can drift into a
  * tool_use/tool_result pair. A compressing turn ALSO busts the conversation
- * prompt cache anyway, so this is the right moment to throw the stale delta
- * away and recompute a fresh, tool-pair-safe, near-tail position — paying the
- * (already-incurred) bust once instead of destructively stripping a real tool
- * pair every subsequent turn.
+ * prompt cache anyway, so this is the right moment to re-anchor the blocks to a
+ * fresh, tool-pair-safe, near-tail position (preserving their content AND `mut`
+ * signatures via reanchorExistingDelta) — paying the (already-incurred) bust
+ * once instead of destructively stripping a real tool pair every subsequent
+ * turn. Re-anchoring (not deleting) keeps the advancing surfaced set intact, so
+ * a fresh delta this same turn appends only its new increment rather than
+ * re-deriving the full cumulative pin→DB wall.
  *
  * Layer-only predicate: a compressing turn is any turn at a compressed layer
  * (>= 1) whose layer DIFFERS from the previous turn (entering, escalating, or
@@ -915,6 +918,38 @@ export function reanchorExistingDelta(
     });
   }
   return reInsertAt;
+}
+
+/**
+ * Compression-reset action for the durable knowledge delta — the single
+ * call-site decision behind a testable seam. On a turn where the gradient
+ * reshuffled the message array (`shouldResetDeltaOnCompression`), the persisted
+ * blocks' frozen absolute `insertAt` can drift into a tool pair, so the blocks
+ * are re-anchored to a fresh tool-pair-safe near-tail index against the CURRENT
+ * array. No-op (returns null) when this is not a compressing turn or there is
+ * no delta to move.
+ *
+ * 🔴 Re-anchors (via reanchorExistingDelta, preserving each block's content AND
+ * its `mut` signature) — it does NOT delete. Deleting the blocks here wiped the
+ * surfaced-set history, so a fresh delta produced on the SAME turn re-derived
+ * the ENTIRE cumulative pin→DB wall from the frozen baseline. As background
+ * consolidation tombstoned/edited more pinned entries over a session, that wall
+ * kept growing, so every compression+change turn re-rendered a larger
+ * deep-prefix block and busted the conversation cache — the regrowth churn
+ * #1013 only trimmed. Re-anchoring keeps advanceSurfacedKeys intact, so the
+ * append that follows contributes ONLY the genuinely-new increment (or nothing).
+ *
+ * @internal Exported for tests (guards the reanchor-not-delete call-site
+ * choice, which the inline form left un-testable).
+ */
+export function reanchorDeltaOnCompression(
+  sessionID: string,
+  projectPath: string,
+  messages: GatewayMessage[],
+  deltaCompressed: boolean,
+): number | null {
+  if (!deltaCompressed) return null;
+  return reanchorExistingDelta(sessionID, projectPath, messages);
 }
 
 export function safeDeltaInsertIndex(
@@ -7251,27 +7286,22 @@ async function handleConversationTurn(
     result.layer,
     sessionState.lastTurnWasIdle ?? false,
   );
-  if (deltaCompressed) {
-    if (pendingKnowledgeDelta) {
-      // New knowledge delta is being produced this turn anyway — drop the stale
-      // row so appendKnowledgePromptDelta computes a FRESH insertAt below
-      // (no persisted row to reuse) instead of re-freezing the drifted index.
-      deleteSessionPromptDelta(sessionID);
-    } else {
-      // No new knowledge this turn, but the array reshuffled: re-anchor the
-      // EXISTING delta (same content) to a fresh tool-pair-safe near-tail index
-      // so it doesn't replay at a drifted position.
-      const reInsertAt = reanchorExistingDelta(
-        sessionID,
-        projectPath,
-        modifiedReq.messages,
-      );
-      if (reInsertAt !== null) {
-        log.info(
-          `prompt-delta: re-anchored durable delta for session ${sessionID.slice(0, 16)} after compression (layer ${sessionState.lastDeltaLayer ?? 0}→${result.layer}, insertAt=${reInsertAt})`,
-        );
-      }
-    }
+  // On a compressing turn the gradient reshuffled the array; re-anchor the
+  // durable delta blocks (preserving content + `mut`) to a fresh tool-pair-safe
+  // index. 🔴 Re-anchor — NOT delete — even when a fresh knowledge delta is
+  // produced this turn (see reanchorDeltaOnCompression): deleting wiped the
+  // surfaced-set history, so the append below re-derived the full cumulative
+  // pin→DB wall every compression+change turn (the regrowth #1013 only trimmed).
+  const reInsertAt = reanchorDeltaOnCompression(
+    sessionID,
+    projectPath,
+    modifiedReq.messages,
+    deltaCompressed,
+  );
+  if (reInsertAt !== null) {
+    log.info(
+      `prompt-delta: re-anchored durable delta for session ${sessionID.slice(0, 16)} after compression (layer ${sessionState.lastDeltaLayer ?? 0}→${result.layer}, insertAt=${reInsertAt})`,
+    );
   }
 
   if (pendingKnowledgeDelta) {

--- a/packages/gateway/test/delta-compress-reanchor.test.ts
+++ b/packages/gateway/test/delta-compress-reanchor.test.ts
@@ -11,11 +11,12 @@
  *
  *   1. `safeDeltaInsertIndex` must NEVER return an index immediately after an
  *      assistant containing a tool_use (it walks back before the assistant).
- *   2. On a compressing/layer-changing turn the caller deletes the stored
- *      delta (`deleteSessionPromptDelta`) and recomputes a fresh index; on a
- *      stable turn the stored index is left frozen.
+ *   2. On a compressing/layer-changing turn the caller RE-ANCHORS the stored
+ *      delta blocks to a fresh index (preserving content + `mut`) — it does NOT
+ *      delete them; on a stable turn the stored index is left frozen.
  *   3. `shouldResetDeltaOnCompression(prevLayer, curLayer)` is the pure
- *      predicate gating that delete/recompute decision.
+ *      predicate gating that re-anchor decision; `reanchorDeltaOnCompression`
+ *      is the call-site action it gates.
  *
  * Some of these APIs are not implemented yet — tests that exercise an
  * unimplemented symbol fail cleanly (typeof check) rather than crashing
@@ -36,12 +37,16 @@ import {
   removeOrphanedToolResults,
   shouldResetDeltaOnCompression,
   reanchorExistingDelta,
+  reanchorDeltaOnCompression,
+  appendKnowledgePromptDelta,
+  fnv1a,
 } from "../src/pipeline";
 import {
   appendSessionPromptDelta,
   deleteSessionPromptDelta,
   listSessionPromptDeltas,
   ensureProject,
+  ltm,
 } from "@loreai/core";
 import type {
   GatewayContentBlock,
@@ -837,5 +842,267 @@ describe("multi-block re-anchor — placement across distinct + shared positions
     // Stable on replay.
     const b = applySessionPromptDeltas(layout, sessionID);
     expect(snapshot(b)).toBe(snapshot(a));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. reanchorDeltaOnCompression — the call-site reset action (reanchor, not delete)
+//
+// The regrowth churn #1013 only trimmed: on a compressing turn that ALSO
+// produced a fresh knowledge delta, the call site DELETED the persisted blocks
+// and let the append below re-derive the FULL cumulative pin→DB wall from the
+// frozen baseline. As consolidation tombstoned/edited more pinned entries over
+// a session, that wall grew, so every compression+change turn re-rendered a
+// larger deep-prefix block and busted the cache. The fix re-anchors the blocks
+// (preserving their `mut` signatures) so the surfaced set stays advanced and
+// the append contributes only the genuinely-new increment.
+// ---------------------------------------------------------------------------
+describe("reanchorDeltaOnCompression — re-anchors (never deletes) on a compressing turn", () => {
+  const PROJECT = "/tmp/lore-delta-reset-action";
+  const keyOf = (id: string, title: string, content: string): string =>
+    `${id}:${fnv1a(`${title}\x1f${content}`)}`;
+
+  test("is exported as a function", () => {
+    expect(typeof reanchorDeltaOnCompression).toBe("function");
+  });
+
+  test("NOT compressing (deltaCompressed=false): no-op, returns null, blocks untouched", () => {
+    const sessionID = `reset-noop-${Date.now()}-${Math.random()}`;
+    const projectID = ensureProject(PROJECT);
+    appendSessionPromptDelta({
+      sessionID,
+      projectID,
+      selector: JSON.stringify({
+        target: "messages",
+        insertAt: 2,
+        mut: { changed: [{ id: "k1", h: "h1" }], removed: [] },
+      }),
+      content: JSON.stringify({
+        role: "user",
+        content: [{ type: "text", text: "block" }],
+      }),
+    });
+
+    const result = reanchorDeltaOnCompression(
+      sessionID,
+      PROJECT,
+      [user(text("u0")), assistant(text("a1")), user(text("u2"))],
+      false,
+    );
+
+    expect(result).toBeNull();
+    const rows = listSessionPromptDeltas(sessionID);
+    expect(rows).toHaveLength(1);
+    // insertAt left frozen, mut preserved.
+    expect(JSON.parse(rows[0].selector)).toMatchObject({
+      insertAt: 2,
+      mut: { changed: [{ id: "k1", h: "h1" }] },
+    });
+  });
+
+  test("compressing (deltaCompressed=true): re-anchors the blocks AND preserves their mut (does not delete)", () => {
+    const sessionID = `reset-reanchor-${Date.now()}-${Math.random()}`;
+    const projectID = ensureProject(PROJECT);
+    appendSessionPromptDelta({
+      sessionID,
+      projectID,
+      // Stale frozen index (99) far past the post-compact array end.
+      selector: JSON.stringify({
+        target: "messages",
+        insertAt: 99,
+        mut: { changed: [{ id: "k7", h: "hh" }], removed: ["k8"] },
+      }),
+      content: JSON.stringify({
+        role: "user",
+        content: [{ type: "text", text: "surfaced block" }],
+      }),
+    });
+
+    const messages = [
+      user(text("u0")),
+      assistant(text("a1")),
+      user(text("u2")),
+    ];
+    const reInsertAt = reanchorDeltaOnCompression(
+      sessionID,
+      PROJECT,
+      messages,
+      true,
+    );
+
+    // Re-anchored to a fresh in-bounds index, NOT the stale 99.
+    expect(reInsertAt).not.toBeNull();
+    expect(reInsertAt).not.toBe(99);
+    expect(reInsertAt).toBeLessThanOrEqual(messages.length);
+
+    // The block SURVIVES (was re-anchored, not deleted) and keeps its mut.
+    const rows = listSessionPromptDeltas(sessionID);
+    expect(rows).toHaveLength(1);
+    const selector = JSON.parse(rows[0].selector) as {
+      insertAt: number;
+      mut?: { changed?: Array<{ id: string }>; removed?: string[] };
+    };
+    expect(selector.insertAt).toBe(reInsertAt);
+    expect(selector.mut?.changed).toEqual([{ id: "k7", h: "hh" }]);
+    expect(selector.mut?.removed).toEqual(["k8"]);
+  });
+
+  test("returns null when there is no delta to re-anchor", () => {
+    const sessionID = `reset-empty-${Date.now()}-${Math.random()}`;
+    ensureProject(PROJECT);
+    expect(
+      reanchorDeltaOnCompression(sessionID, PROJECT, [user(text("hi"))], true),
+    ).toBeNull();
+    expect(listSessionPromptDeltas(sessionID)).toHaveLength(0);
+  });
+
+  // THE regression guard for #1013's root cause: fire-once ACROSS compression
+  // resets. A surfaced change must not be re-derived every compressing turn.
+  test("an already-surfaced change is NOT re-derived across repeated compression resets (fire-once)", () => {
+    const id = ltm.create({
+      projectPath: PROJECT,
+      scope: "project",
+      category: "gotcha",
+      title: "Regrowth guard entry",
+      content: "v1 original.",
+    });
+    const pinKey = keyOf(id, "Regrowth guard entry", "v1 original.");
+    const sessionID = `reset-fireonce-${Date.now()}-${Math.random()}`;
+
+    // A genuine content edit (curator/consolidation) lands in the DB.
+    ltm.update(id, { content: "v2 materially changed." });
+
+    // Turn 1 (no compression): the change is surfaced once → one block appended.
+    const wrote1 = appendKnowledgePromptDelta({
+      sessionID,
+      projectPath: PROJECT,
+      insertAt: 2,
+      previousKeys: [pinKey],
+      nextKeys: [pinKey],
+      entries: [],
+    });
+    expect(wrote1).toBe(true);
+    expect(listSessionPromptDeltas(sessionID)).toHaveLength(1);
+    expect(
+      JSON.parse(listSessionPromptDeltas(sessionID)[0].content).content[0].text,
+    ).toContain("v2 materially changed.");
+
+    // Turns 2..6: each is a COMPRESSION turn that ALSO carries a pending delta.
+    // Replicate the pipeline call-site order exactly: re-anchor, then append.
+    // With the fix the surfaced set stays advanced past the block, so NOTHING
+    // new is derived. With the old delete-on-reset, the wiped mut history makes
+    // appendKnowledgePromptDelta re-derive the v1→v2 change EVERY turn.
+    const messages = [
+      user(text("u0")),
+      assistant(text("a1")),
+      user(text("u2")),
+    ];
+    const reFires: boolean[] = [];
+    for (let turn = 0; turn < 5; turn++) {
+      reanchorDeltaOnCompression(sessionID, PROJECT, messages, true);
+      reFires.push(
+        appendKnowledgePromptDelta({
+          sessionID,
+          projectPath: PROJECT,
+          insertAt: 2,
+          previousKeys: [pinKey],
+          nextKeys: [pinKey],
+          entries: [],
+        }),
+      );
+    }
+
+    // Fire-once: the change was surfaced on turn 1 only; every reset thereafter
+    // re-anchors the existing block and appends nothing.
+    expect(reFires).toEqual([false, false, false, false, false]);
+    // Exactly one block ever exists (no per-reset re-derivation / accumulation).
+    const finalRows = listSessionPromptDeltas(sessionID);
+    expect(finalRows).toHaveLength(1);
+    // It still records the surfaced change in its mut (surfaced set advanced).
+    const mut = JSON.parse(finalRows[0].selector).mut as {
+      changed: Array<{ id: string }>;
+    };
+    expect(mut.changed.map((c) => c.id)).toContain(id);
+  });
+
+  // Across a reset, a NEW genuine mutation (different entry) still surfaces —
+  // the fix preserves fire-once WITHOUT muting real new changes.
+  test("a genuinely-new change after a reset still surfaces (only its increment)", () => {
+    const a = ltm.create({
+      projectPath: PROJECT,
+      scope: "project",
+      category: "gotcha",
+      title: "Entry A (surfaced first)",
+      content: "a-v1.",
+    });
+    const b = ltm.create({
+      projectPath: PROJECT,
+      scope: "project",
+      category: "gotcha",
+      title: "Entry B (changes after reset)",
+      content: "b-v1.",
+    });
+    const aKey = keyOf(a, "Entry A (surfaced first)", "a-v1.");
+    const bKey = keyOf(b, "Entry B (changes after reset)", "b-v1.");
+    const sessionID = `reset-newchange-${Date.now()}-${Math.random()}`;
+    const pin = [aKey, bKey];
+    const messages = [
+      user(text("u0")),
+      assistant(text("a1")),
+      user(text("u2")),
+    ];
+
+    // A changes and is surfaced (block 1).
+    ltm.update(a, { content: "a-v2." });
+    expect(
+      appendKnowledgePromptDelta({
+        sessionID,
+        projectPath: PROJECT,
+        insertAt: 2,
+        previousKeys: pin,
+        nextKeys: pin,
+        entries: [],
+      }),
+    ).toBe(true);
+
+    // Compression reset; A must NOT re-fire (already surfaced).
+    reanchorDeltaOnCompression(sessionID, PROJECT, messages, true);
+    expect(
+      appendKnowledgePromptDelta({
+        sessionID,
+        projectPath: PROJECT,
+        insertAt: 2,
+        previousKeys: pin,
+        nextKeys: pin,
+        entries: [],
+      }),
+    ).toBe(false);
+
+    // Now B genuinely changes; after another reset it SHOULD surface as a new
+    // increment (block 2) — its delta text carries only B, not A.
+    ltm.update(b, { content: "b-v2 changed." });
+    reanchorDeltaOnCompression(sessionID, PROJECT, messages, true);
+    expect(
+      appendKnowledgePromptDelta({
+        sessionID,
+        projectPath: PROJECT,
+        insertAt: 2,
+        previousKeys: pin,
+        nextKeys: pin,
+        entries: [],
+      }),
+    ).toBe(true);
+
+    const rows = listSessionPromptDeltas(sessionID);
+    expect(rows).toHaveLength(2);
+    // The newest block surfaces B's new content and only B in its mut.
+    const newest = rows[rows.length - 1];
+    expect(JSON.parse(newest.content).content[0].text).toContain(
+      "b-v2 changed.",
+    );
+    const newestMut = JSON.parse(newest.selector).mut as {
+      changed: Array<{ id: string }>;
+    };
+    expect(newestMut.changed.map((c) => c.id)).toEqual([b]);
   });
 });

--- a/packages/gateway/test/delta-compress-reanchor.test.ts
+++ b/packages/gateway/test/delta-compress-reanchor.test.ts
@@ -339,7 +339,13 @@ describe("persisted delta + backstop keeps the tool pair intact", () => {
 // ---------------------------------------------------------------------------
 // 5. Stable turn keeps insertAt frozen; compressing turn re-anchors
 // ---------------------------------------------------------------------------
-describe("layer-transition gates the delete/recompute of the persisted delta", () => {
+// These exercise the PREDICATE (shouldResetDeltaOnCompression) and the
+// deleteSessionPromptDelta PRIMITIVE directly. The call-site action that the
+// predicate gates is now reanchorDeltaOnCompression (re-anchor, never delete) —
+// covered end-to-end in §7. deleteSessionPromptDelta is still a real primitive
+// (used by reanchorExistingDelta + the MAX_DELTA_BLOCKS coalesce), so these
+// remain valid contract tests for it.
+describe("layer-transition predicate + deleteSessionPromptDelta primitive", () => {
   test("STABLE turn (1,1): predicate false => row left frozen at insertAt=5", () => {
     expect(typeof shouldResetDeltaOnCompression).toBe("function");
     expect(typeof listSessionPromptDeltas).toBe("function");


### PR DESCRIPTION
## Root cause

#1013 trimmed the mid-session knowledge delta to additive-only, which stopped the per-turn removals churn. But it left the **regrowth** path: on a *compressing* turn that **also** produced a fresh knowledge delta, the call site **deleted** the persisted delta blocks:

```ts
if (deltaCompressed) {
  if (pendingKnowledgeDelta) {
    deleteSessionPromptDelta(sessionID); // <- wipes the mut history
  } else {
    reanchorExistingDelta(...);          // no-pending case already re-anchored
  }
}
```

Deleting the blocks wiped the per-block `mut` history that `advanceSurfacedKeys` uses to reconstruct the *advancing* surfaced set. With the blocks gone, the append below saw an empty block list and re-derived the **entire cumulative pin→DB delta** from the frozen baseline. As background consolidation tombstoned/edited more pinned entries over a session, that wall kept growing, so **every compression+change turn re-rendered a larger deep-prefix block and busted the conversation cache** — exactly the read-floored / deep-prefix-rewritten symptom on long churny sessions.

## Fix

Re-anchor the blocks instead of deleting them — even when a fresh delta is produced this turn. `reanchorExistingDelta` already computes the same fresh tool-pair-safe near-tail index the delete path wanted, but **preserves each block's content AND `mut` signature**. So `advanceSurfacedKeys` stays intact, and the append that follows contributes **only the genuinely-new increment** (or nothing). The position move is the only cost, and it's already paid by the compression that triggered the reset.

The call-site choice was inline in `handleConversationTurn` and therefore untestable (a revert to `delete` would fail no test). Extracted it into `reanchorDeltaOnCompression(sessionID, projectPath, messages, deltaCompressed)` so the **reanchor-not-delete** behavior is covered.

## Tests

6 new tests in `delta-compress-reanchor.test.ts`:
- seam guards (exported, `deltaCompressed=false` no-op, no-delta no-op)
- re-anchors + **preserves `mut`** on a compressing turn (does not delete)
- **fire-once across repeated compression resets**: an already-surfaced change is not re-derived over 5 consecutive compression+append cycles (`[false×5]`)
- a genuinely-new change after a reset still surfaces — only its increment

**Vacuity check:** mutating the helper back to `deleteSessionPromptDelta` fails the 3 behavioral tests (the 3 trivial guards correctly stay green). Restored → green.

- Full gateway suite: 2288 passed / 26 skipped
- Full repo suite: 4476 passed / 32 skipped
- typecheck + biome clean

Follow-up to #1013.