### PR TITLE
perf(core): batch entitiesForSession ref-count ranking into one query

### DIFF
--- a/packages/core/src/entities.ts
+++ b/packages/core/src/entities.ts
@@ -1492,6 +1492,35 @@ export function knowledgeForEntity(entityId: string): string[] {
   return rows.map((r) => r.knowledge_id);
 }
 
+/**
+ * Batch-count knowledge references for a set of entities in a single query.
+ * Avoids the N+1 of calling `knowledgeForEntity().length` per entity when
+ * relevance-ranking a large entity registry. Entities with no refs are absent
+ * from the returned map (callers should default to 0).
+ */
+export function knowledgeRefCounts(entityIds: string[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  if (!entityIds.length) return counts;
+  // Chunk the IN list to stay under SQLite's bound-variable ceiling (matches
+  // countMatchingTemporalIds in db.ts). Counts are per-entity, so results across
+  // chunks are disjoint and simply unioned into the map.
+  const CHUNK = 900;
+  for (let i = 0; i < entityIds.length; i += CHUNK) {
+    const chunk = entityIds.slice(i, i + CHUNK);
+    const placeholders = chunk.map(() => "?").join(",");
+    const rows = db()
+      .query(
+        `SELECT entity_id, COUNT(*) AS n
+         FROM knowledge_entity_refs
+         WHERE entity_id IN (${placeholders})
+         GROUP BY entity_id`,
+      )
+      .all(...chunk) as Array<{ entity_id: string; n: number }>;
+    for (const r of rows) counts.set(r.entity_id, r.n);
+  }
+  return counts;
+}
+
 // ---------------------------------------------------------------------------
 // Session injection — hybrid cap-based entity selection
 // ---------------------------------------------------------------------------
@@ -1535,12 +1564,14 @@ export function entitiesForSession(
     return guaranteed.slice(0, cap);
   }
 
-  // Relevance-rank remaining by knowledge ref count (more refs = more relevant)
+  // Relevance-rank remaining by knowledge ref count (more refs = more relevant).
+  // Batch-load all ref counts in one query instead of one query per entity.
   const slots = cap - guaranteed.length;
-  const scored = remaining.map((e) => {
-    const refCount = knowledgeForEntity(e.id).length;
-    return { entity: e, score: refCount };
-  });
+  const refCounts = knowledgeRefCounts(remaining.map((e) => e.id));
+  const scored = remaining.map((e) => ({
+    entity: e,
+    score: refCounts.get(e.id) ?? 0,
+  }));
   scored.sort((a, b) => b.score - a.score);
 
   return [...guaranteed, ...scored.slice(0, slots).map((s) => s.entity)];

--- a/packages/core/test/entities-session-batch.test.ts
+++ b/packages/core/test/entities-session-batch.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { db, ensureProject } from "../src/db";
+import * as entities from "../src/entities";
+import { type LogSink, registerSink } from "../src/log";
+import * as ltm from "../src/ltm";
+
+const PROJECT = "/tmp/lore-entities-session-batch/project";
+
+// A LogSink whose withDbSpan tallies how many times knowledge_entity_refs is
+// read. withDbSpan MUST stay a pass-through (call fn() once, return its value)
+// so query behavior is unchanged.
+function countingSink(counts: Record<string, number>): LogSink {
+  return {
+    info() {},
+    warn() {},
+    error() {},
+    captureException() {},
+    withDbSpan<T>(sql: string, fn: () => T): T {
+      if (sql.includes("knowledge_entity_refs")) {
+        counts.refs = (counts.refs ?? 0) + 1;
+      }
+      return fn();
+    },
+  };
+}
+
+const NOOP_SINK: LogSink = {
+  info() {},
+  warn() {},
+  error() {},
+  captureException() {},
+};
+
+let knowledgeSeq = 0;
+
+// Create `count` real knowledge entries (FK target) and link each to `entityId`,
+// so the entity has exactly `count` references in knowledge_entity_refs.
+function linkRefs(entityId: string, count: number): void {
+  for (let i = 0; i < count; i++) {
+    knowledgeSeq++;
+    const kid = ltm.create({
+      projectPath: PROJECT,
+      category: "decision",
+      title: `Batch knowledge ${knowledgeSeq}`,
+      content: `Body for batch knowledge ${knowledgeSeq}.`,
+      scope: "project",
+    });
+    entities.linkKnowledge(kid, entityId);
+  }
+}
+
+describe("entitiesForSession ref-count ranking is batched (no N+1)", () => {
+  beforeEach(() => {
+    const pid = ensureProject(PROJECT);
+    db().query("DELETE FROM knowledge_entity_refs").run();
+    db().query("DELETE FROM knowledge WHERE project_id = ?").run(pid);
+    db().query("DELETE FROM entities").run();
+    db().query("DELETE FROM entity_aliases").run();
+    db().query("DELETE FROM entity_relations").run();
+  });
+
+  afterEach(() => {
+    // Restore a benign sink (no withDbSpan → pass-through) so the counting sink
+    // can't leak into later tests.
+    registerSink(NOOP_SINK);
+  });
+
+  test("reads knowledge_entity_refs once for the whole batch, not once per entity", () => {
+    // Self entity (always included, no relations → guaranteed = {self}).
+    entities.create({
+      projectPath: PROJECT,
+      entityType: "self",
+      canonicalName: "BatchSelf",
+    });
+
+    // Four unrelated persons; with cap 2 and one guaranteed slot taken by self,
+    // exactly one remaining slot is filled by relevance (knowledge ref count).
+    const p1 = entities.create({
+      projectPath: PROJECT,
+      entityType: "person",
+      canonicalName: "BatchP1",
+    }).id;
+    const p2 = entities.create({
+      projectPath: PROJECT,
+      entityType: "person",
+      canonicalName: "BatchP2",
+    }).id;
+    const p3 = entities.create({
+      projectPath: PROJECT,
+      entityType: "person",
+      canonicalName: "BatchP3",
+    }).id;
+    entities.create({
+      projectPath: PROJECT,
+      entityType: "person",
+      canonicalName: "BatchP4",
+    });
+
+    // p2 is the most-referenced → should win the single remaining slot.
+    linkRefs(p1, 1);
+    linkRefs(p2, 3);
+    linkRefs(p3, 1);
+
+    const counts: Record<string, number> = {};
+    registerSink(countingSink(counts));
+
+    const result = entities.entitiesForSession(PROJECT, 2);
+
+    // The N+1: before batching, ranking called knowledgeForEntity() once per
+    // remaining entity → 4 reads of knowledge_entity_refs. Batching reads the
+    // table exactly once for the whole pass.
+    expect(counts.refs).toBe(1);
+
+    // Behavioral guard: self + the most-referenced remaining entity (p2).
+    expect(result.length).toBe(2);
+    const ids = result.map((e) => e.id);
+    expect(result.some((e) => e.entity_type === "self")).toBe(true);
+    expect(ids).toContain(p2);
+  });
+});


### PR DESCRIPTION
## Problem

`entitiesForSession()` (the system-prompt entity selector) relevance-ranks the over-cap remainder by knowledge reference count. It calls `knowledgeForEntity(e.id).length` **once per remaining entity** — an N+1 over `knowledge_entity_refs`. This fires only when a project's entity registry exceeds `maxEntityInject` (default 30), but at that point it's one `SELECT … WHERE entity_id = ?` per entity over the cap.

Surfaced during the Sentry triage that produced #1011 (`syncEntityRefs` registry N+1) and #1015 (`dedup_feedback` insert N+1). Note: Sentry itself does **not** flag these — DB spans use `onlyIfParent: true` and this runs sub-millisecond on local SQLite — so they're found by static audit, not the N+1 detector.

## Fix

Add `knowledgeRefCounts(entityIds)`: a single `GROUP BY entity_id` IN-query (mirroring the existing batch-load in `deduplicateEntities`, `entities.ts:1708`). `entitiesForSession` now loads all ref counts once and scores in memory.

Touches only the `knowledge_entity_refs` join table — **no `knowledge`/`entities` schema change**, so it's safe under the append-only refactor freeze (#823).

## Test

`packages/core/test/entities-session-batch.test.ts` — registers a `withDbSpan` counting sink and asserts `knowledge_entity_refs` is read **exactly once** for a 4-entity over-cap batch (the batch), with a behavioral guard that the most-referenced entity still wins the remaining slot.

Mutation-verified: reverting the fix to the per-entity form makes the test fail with `expected 4 to be 1`.

- Full `@loreai/core` suite green (2179 passed)
- typecheck + biome clean

Refs #1010