### PR TITLE
perf(core): batch mergeSelfPersonDuplicates alias lookup into one query

### DIFF
--- a/packages/core/src/entities.ts
+++ b/packages/core/src/entities.ts
@@ -522,6 +522,12 @@ export function mergeSelfPersonDuplicates(
     .query(`SELECT ${ENTITY_COLS} FROM entities WHERE entity_type = 'person'`)
     .all() as Entity[];
 
+  // Batch-load every person's aliases in a single query instead of one query
+  // per person. Behaviorally equivalent to per-iteration reads: a person's own
+  // aliases never change as we merge *other* persons into self, and the self
+  // match set (selfIdentityValues) is already a frozen pre-loop snapshot.
+  const personAliasMap = batchLoadAliases(persons.map((p) => p.id));
+
   // For each person, check for an identity match against self.
   let mergedCount = 0;
   for (const person of persons) {
@@ -530,14 +536,7 @@ export function mergeSelfPersonDuplicates(
       matched = `name:${person.canonical_name}`;
     } else {
       // Check identity-typed alias overlap only.
-      const personAliases = db()
-        .query(
-          "SELECT alias_type, alias_value FROM entity_aliases WHERE entity_id = ?",
-        )
-        .all(person.id) as Array<{
-        alias_type: AliasType;
-        alias_value: string;
-      }>;
+      const personAliases = personAliasMap.get(person.id) ?? [];
       const hit = personAliases.find(
         (a) =>
           IDENTITY_ALIAS_TYPES.has(a.alias_type) &&
@@ -834,15 +833,22 @@ function batchLoadAliases(entityIds: string[]): Map<string, EntityAlias[]> {
   if (!entityIds.length) return map;
   // Initialize empty arrays for all IDs
   for (const id of entityIds) map.set(id, []);
-  // Single query to fetch all aliases for the given entities
-  const placeholders = entityIds.map(() => "?").join(",");
-  const allAliases = db()
-    .query(
-      `SELECT * FROM entity_aliases WHERE entity_id IN (${placeholders}) ORDER BY alias_type, alias_value`,
-    )
-    .all(...entityIds) as EntityAlias[];
-  for (const a of allAliases) {
-    map.get(a.entity_id)?.push(a);
+  // Chunk the IN list to stay under SQLite's bound-variable ceiling (matches
+  // countMatchingTemporalIds in db.ts). Chunks partition entityIds, so every
+  // alias of a given entity lands in exactly one chunk — per-entity ordering
+  // from the per-chunk ORDER BY is preserved.
+  const CHUNK = 900;
+  for (let i = 0; i < entityIds.length; i += CHUNK) {
+    const chunk = entityIds.slice(i, i + CHUNK);
+    const placeholders = chunk.map(() => "?").join(",");
+    const allAliases = db()
+      .query(
+        `SELECT * FROM entity_aliases WHERE entity_id IN (${placeholders}) ORDER BY alias_type, alias_value`,
+      )
+      .all(...chunk) as EntityAlias[];
+    for (const a of allAliases) {
+      map.get(a.entity_id)?.push(a);
+    }
   }
   return map;
 }

--- a/packages/core/test/entities-self-merge-batch.test.ts
+++ b/packages/core/test/entities-self-merge-batch.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { db } from "../src/db";
+import * as entities from "../src/entities";
+import { type LogSink, registerSink } from "../src/log";
+
+// A LogSink whose withDbSpan tallies how many times entity_aliases is read.
+// withDbSpan MUST stay a pass-through (call fn() once, return its value) so
+// query behavior is unchanged.
+function countingSink(counts: Record<string, number>): LogSink {
+  return {
+    info() {},
+    warn() {},
+    error() {},
+    captureException() {},
+    withDbSpan<T>(sql: string, fn: () => T): T {
+      if (sql.includes("FROM entity_aliases")) {
+        counts.aliases = (counts.aliases ?? 0) + 1;
+      }
+      return fn();
+    },
+  };
+}
+
+const NOOP_SINK: LogSink = {
+  info() {},
+  warn() {},
+  error() {},
+  captureException() {},
+};
+
+describe("mergeSelfPersonDuplicates alias lookup is batched (no N+1)", () => {
+  beforeEach(() => {
+    db().query("DELETE FROM entity_aliases").run();
+    db().query("DELETE FROM entities").run();
+  });
+
+  afterEach(() => {
+    // Restore a benign sink (no withDbSpan → pass-through) so the counting sink
+    // can't leak into later tests.
+    registerSink(NOOP_SINK);
+  });
+
+  test("reads entity_aliases once for the whole person scan, not once per person", () => {
+    // Self entity with no overlapping identity → no person will merge, so the
+    // merge() write path never runs and only the alias *reads* are counted.
+    const self = entities.create({
+      entityType: "self",
+      canonicalName: "MergeSelf",
+      aliases: [{ type: "email", value: "self@example.com", source: "config" }],
+      crossProject: true,
+    });
+
+    // Four unrelated persons (names and aliases disjoint from self) — each one
+    // forces the per-person alias lookup in the unbatched code.
+    for (let i = 1; i <= 4; i++) {
+      entities.create({
+        entityType: "person",
+        canonicalName: `MergePerson${i}`,
+        aliases: [
+          { type: "github", value: `unrelated-handle-${i}`, source: "curator" },
+        ],
+        crossProject: true,
+      });
+    }
+
+    // biome-ignore lint/style/noNonNullAssertion: just created
+    const selfEntity = entities.getWithAliases(self.id)!;
+
+    const counts: Record<string, number> = {};
+    registerSink(countingSink(counts));
+
+    const merged = entities.mergeSelfPersonDuplicates(selfEntity);
+
+    // No matches → no merges (so no merge-path entity_aliases writes inflate
+    // the count).
+    expect(merged).toBe(0);
+
+    // The N+1: before batching, the loop read entity_aliases once per person
+    // → 4 reads. Batching reads the table exactly once for the whole scan.
+    expect(counts.aliases).toBe(1);
+  });
+});


### PR DESCRIPTION
## Problem

`mergeSelfPersonDuplicates()` runs on **every curator invocation** (via `ensureSelfEntity` → `finalizeSelfEntity`). For each `person` entity whose canonical name doesn't match the self entity, it issued a separate `SELECT … FROM entity_aliases WHERE entity_id = ?` — an N+1 over the entire person registry.

Part of the static-audit N+1 series (#1011, #1015, #1018). Not visible in Sentry — these DB spans use `onlyIfParent: true` and run on the background curator path.

## Fix

Preload all person aliases once via the existing `batchLoadAliases()` helper (one `WHERE entity_id IN (…)` query) and match in memory.

**Behaviorally equivalent**: a person's own aliases never change as we merge *other* persons into self, and the self match set (`selfIdentityValues`) is already a frozen pre-loop snapshot — see the function's existing NOTE about transitive overlaps converging across sessions. Touches only the `entity_aliases` side-table — **no `knowledge`/`entities` schema change**, safe under the append-only freeze (#823).

## Test

`packages/core/test/entities-self-merge-batch.test.ts` — counting `withDbSpan` sink asserts `entity_aliases` is read **exactly once** for a 4-person scan (the batch). Self has no overlapping identity so no merges occur, keeping the count isolated to reads.

Mutation-verified: reintroducing the per-person query makes the test fail (`expected 5 to be 1`). Existing `mergeSelfPersonDuplicates` behavior tests (entities.test.ts, 11 cases) continue to pass.

- `@loreai/core` entities/dedup suites green (82 passed)
- typecheck + biome clean

Refs #1010