### PR TITLE
perf(core): resolve project id once in applyOps, not per op

### DIFF
--- a/packages/core/src/curator.ts
+++ b/packages/core/src/curator.ts
@@ -304,6 +304,26 @@ export function applyOps(
   const idsToSync: string[] = [];
   const changedEntries: ChangedEntry[] = [];
 
+  // Resolve the owning project id at most once, lazily. input.projectPath is
+  // loop-invariant, so the per-op ownership guards below must not re-query the
+  // projects table on every update/delete op. Resolved lazily — not eagerly —
+  // so a batch that never reaches an ownership guard (create-only, cross-project
+  // creates, or empty ops) keeps the prior behavior of never touching the
+  // projects table here. ensureProject is a get-or-create side effect, so an
+  // eager call could mint a project row for a batch that the per-op path would
+  // have left untouched.
+  let projectIdResolved = false;
+  let projectIdCache: string | null = null;
+  const ownerProjectId = (): string | null => {
+    if (!projectIdResolved) {
+      projectIdCache = input.projectPath
+        ? ensureProject(input.projectPath)
+        : null;
+      projectIdResolved = true;
+    }
+    return projectIdCache;
+  };
+
   for (const op of ops) {
     if (op.op === "create") {
       if (input.skipCreate) continue;
@@ -380,8 +400,7 @@ export function applyOps(
         // Guard: don't mutate entries owned by a different project.
         // Cross-project entries (project_id=NULL or same project) are safe.
         if (entry.project_id !== null && input.projectPath) {
-          const pid = ensureProject(input.projectPath);
-          if (entry.project_id !== pid) continue;
+          if (entry.project_id !== ownerProjectId()) continue;
         }
         const prevContent = entry.content;
         const content =
@@ -417,8 +436,7 @@ export function applyOps(
       if (entry) {
         // Guard: don't delete entries owned by a different project.
         if (entry.project_id !== null && input.projectPath) {
-          const pid = ensureProject(input.projectPath);
-          if (entry.project_id !== pid) continue;
+          if (entry.project_id !== ownerProjectId()) continue;
         }
         changedEntries.push({
           op: "deleted",

--- a/packages/core/test/curator-ensureproject-hoist.test.ts
+++ b/packages/core/test/curator-ensureproject-hoist.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { applyOps } from "../src/curator";
+import { db, ensureProject } from "../src/db";
+import { type LogSink, registerSink } from "../src/log";
+import * as ltm from "../src/ltm";
+
+const PROJECT = "/tmp/lore-curator-ensureproject-hoist/project";
+const OTHER_PROJECT = "/tmp/lore-curator-ensureproject-hoist/other-project";
+
+// ensureProject()'s fast-path lookup. Counting this exact statement isolates
+// project-resolution calls from any other `projects` access.
+const ENSURE_PROJECT_SQL = "SELECT id, git_remote FROM projects WHERE path = ?";
+
+function countingSink(counts: Record<string, number>): LogSink {
+  return {
+    info() {},
+    warn() {},
+    error() {},
+    captureException() {},
+    withDbSpan<T>(sql: string, fn: () => T): T {
+      if (sql.includes(ENSURE_PROJECT_SQL)) {
+        counts.projects = (counts.projects ?? 0) + 1;
+      }
+      return fn();
+    },
+  };
+}
+
+const NOOP_SINK: LogSink = {
+  info() {},
+  warn() {},
+  error() {},
+  captureException() {},
+};
+
+describe("applyOps resolves the project id once (no per-op ensureProject N+1)", () => {
+  beforeEach(() => {
+    const pid = ensureProject(PROJECT);
+    db().query("DELETE FROM knowledge WHERE project_id = ?").run(pid);
+    const otherPid = ensureProject(OTHER_PROJECT);
+    db().query("DELETE FROM knowledge WHERE project_id = ?").run(otherPid);
+  });
+
+  afterEach(() => {
+    registerSink(NOOP_SINK);
+  });
+
+  test("project table is resolved once for a multi-op update+delete batch", () => {
+    // Five project-scoped entries. Created before the sink is registered so
+    // setup's ensureProject calls aren't counted.
+    const ids: string[] = [];
+    for (let i = 1; i <= 5; i++) {
+      ids.push(
+        ltm.create({
+          projectPath: PROJECT,
+          category: "decision",
+          title: `Hoist entry ${i}`,
+          content: `Original content ${i}.`,
+          scope: "project",
+        }),
+      );
+    }
+
+    const counts: Record<string, number> = {};
+    registerSink(countingSink(counts));
+
+    // Exercise BOTH per-op ownership guards (update branch + delete branch).
+    const result = applyOps(
+      [
+        { op: "update" as const, id: ids[0], content: "Updated 0." },
+        { op: "update" as const, id: ids[1], content: "Updated 1." },
+        { op: "update" as const, id: ids[2], content: "Updated 2." },
+        { op: "delete" as const, id: ids[3], reason: "obsolete" },
+        { op: "delete" as const, id: ids[4], reason: "obsolete" },
+      ],
+      { projectPath: PROJECT, sessionID: "sess-hoist" },
+    );
+
+    expect(result.updated).toBe(3);
+    expect(result.deleted).toBe(2);
+
+    // The N+1: before hoisting, each update/delete ownership guard called
+    // ensureProject() → one project lookup per op (5 total). Hoisting resolves
+    // the project id exactly once for the whole batch.
+    expect(counts.projects).toBe(1);
+  });
+
+  test("cross-project ownership guard still skips foreign entries with a single resolve", () => {
+    // One entry owned by THIS project, one owned by a DIFFERENT project. The
+    // ownership guard must skip the foreign entry (no mutate/delete) — and the
+    // resolved project id must still be reused across the skip path, so the
+    // projects table is read exactly once even though the guard fires on both
+    // an own-project op and a foreign-project op.
+    const ownId = ltm.create({
+      projectPath: PROJECT,
+      category: "decision",
+      title: "Own entry",
+      content: "Own original.",
+      scope: "project",
+    });
+    const foreignId = ltm.create({
+      projectPath: OTHER_PROJECT,
+      category: "decision",
+      title: "Foreign entry",
+      content: "Foreign original.",
+      scope: "project",
+    });
+
+    const counts: Record<string, number> = {};
+    registerSink(countingSink(counts));
+
+    const result = applyOps(
+      [
+        { op: "update" as const, id: ownId, content: "Own updated." },
+        { op: "update" as const, id: foreignId, content: "Foreign updated." },
+        { op: "delete" as const, id: foreignId, reason: "obsolete" },
+      ],
+      { projectPath: PROJECT, sessionID: "sess-hoist-foreign" },
+    );
+
+    // Only the own-project update is applied; the foreign update + delete are
+    // both skipped by the ownership guard.
+    expect(result.updated).toBe(1);
+    expect(result.deleted).toBe(0);
+
+    // The foreign entry is untouched (not mutated, not deleted).
+    const foreign = ltm.get(foreignId) ?? ltm.getByLogical(foreignId);
+    expect(foreign?.content).toBe("Foreign original.");
+
+    // Resolved once and reused across both guard hits (own + foreign).
+    expect(counts.projects).toBe(1);
+  });
+});


### PR DESCRIPTION
## Problem

`applyOps()`'s two per-op ownership guards (the `update` and `delete` branches) each called `ensureProject(input.projectPath)` **inside the op loop** — a `SELECT … FROM projects WHERE path = ?` per op. `input.projectPath` is loop-invariant, so a consolidation batch (up to ~50 ops) could issue up to ~50 redundant project lookups.

Last of the static-audit N+1 series (#1011, #1015, #1018, #1020). Not visible in Sentry — background curator path, DB spans are `onlyIfParent: true`.

## Fix

Resolve the project id **at most once** via a lazily-memoized helper, reused by both guards.

**Strict equivalence — lazy, not eager.** `ensureProject` is a get-or-create *side effect* (it can mint a `projects` row / backfill git-remote). The create branch only resolves the project for project-scoped creates (`tryCreate` with `op.scope === "project"`). So an *eager* hoist would call `ensureProject` for batches the per-op path never touched it on — create-only, cross-project-scope creates, or empty ops — minting a project row the old code wouldn't. The memoized helper resolves lazily on the **first ownership-guard hit**, which is exactly when the old per-op code first called it. Net effect: identical observable behavior, with the per-op lookups collapsed to one. No schema change; safe under the append-only freeze (#823).

## Test

`packages/core/test/curator-ensureproject-hoist.test.ts` (a counting `withDbSpan` sink isolates the `ensureProject` fast-path SQL):

1. **multi-op update+delete batch** — 3 updates + 2 deletes on own-project entries; asserts the project SQL runs **exactly once**, exercising **both** changed guard sites.
2. **cross-project skip path** — own-project + foreign-project entries in one batch; asserts the foreign update/delete are skipped (`updated===1`, `deleted===0`, foreign content untouched) **and** the project id is still resolved exactly once across the skip path.

Mutation-verified (defeat memoization → re-resolve per guard hit):
- test 1 → `expected 5 to be 1`
- test 2 → `expected 3 to be 1`

- Full `@loreai/core` suite green (2180 passed, 6 skipped)
- typecheck + biome clean

Refs #1010