### PR TITLE
fix(gateway): declare @loreai/core as a runtime dependency (#998)

### DIFF
--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -27,6 +27,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
+    "@loreai/core": "workspace:*",
     "@supabase/supabase-js": "^2.58.0",
     "google-auth-library": "^10.9.0",
     "p-limit": "7",
@@ -68,7 +69,6 @@
   ],
   "author": "BYK",
   "devDependencies": {
-    "@loreai/core": "workspace:*",
     "@sentry/bun": "^10.52.0",
     "@types/bun": "^1.2.0",
     "@types/qrcode-terminal": "^0.12.2",

--- a/packages/gateway/script/bundle.ts
+++ b/packages/gateway/script/bundle.ts
@@ -148,6 +148,13 @@ await esbuild.build({
   // fetch.ts) so it is never bundled or evaluated under Bun — real undici@7
   // hangs on streaming response reads under Bun, so the Bun path uses native
   // fetch instead and never touches undici.
+  //
+  // NOTE: undici is external here but only a devDependency — the same shape
+  // that broke @loreai/core in #998. It stays safe ONLY because the Bun path
+  // never imports it (the undici import is Node-only and lazy). If the Bun
+  // path ever imports undici, it must become a runtime dependency. By
+  // contrast, @loreai/core IS imported under Bun, so it is a runtime
+  // dependency (guarded by test/bundle-exports.test.ts).
   external: [
     "bun:*",
     "node:*",

--- a/packages/gateway/test/bundle-exports.test.ts
+++ b/packages/gateway/test/bundle-exports.test.ts
@@ -116,6 +116,52 @@ describe("dependency manifest invariants (#998)", () => {
     expect(pkgJson.devDependencies?.["@loreai/core"]).toBeUndefined();
   });
 
+  // Internal packages each consumer imports at RUNTIME. #998 happened in the
+  // plugin's dependency chain (@loreai/opencode → @loreai/gateway → external
+  // @loreai/core), so presence — not just spec correctness — is asserted for
+  // every link. devDependencies are never installed for a transitively-
+  // consumed published package, which is exactly how #998 manifested.
+  const requiredInternalDeps: Record<string, string[]> = {
+    gateway: ["@loreai/core"],
+    opencode: ["@loreai/core", "@loreai/gateway"],
+    pi: ["@loreai/core", "@loreai/gateway"],
+  };
+
+  test("internal @loreai/* deps are present runtime deps, never devDeps", () => {
+    for (const [name, required] of Object.entries(requiredInternalDeps)) {
+      const manifest = JSON.parse(
+        readFileSync(join(packageDir, "..", name, "package.json"), "utf8"),
+      ) as {
+        name: string;
+        dependencies?: Record<string, string>;
+        devDependencies?: Record<string, string>;
+      };
+      const deps = manifest.dependencies ?? {};
+      const devDeps = manifest.devDependencies ?? {};
+
+      // (a) Every internal package consumed at runtime MUST be a declared
+      //     runtime dependency. This is the core #998 invariant: the package
+      //     that exhibited the bug (@loreai/opencode) is presence-checked, not
+      //     merely spec-checked, so moving a link back into devDependencies
+      //     fails here even if no externalized-import scan covers it.
+      for (const dep of required) {
+        expect(
+          deps[dep],
+          `${manifest.name} consumes ${dep} at runtime; it MUST be in "dependencies"`,
+        ).toBeDefined();
+      }
+
+      // (b) No internal @loreai/* package may hide in devDependencies — that
+      //     is the exact shape of #998 (runtime use + devDependency declaration).
+      for (const dep of Object.keys(devDeps)) {
+        expect(
+          dep.startsWith("@loreai/"),
+          `${manifest.name} declares ${dep} in devDependencies; internal @loreai/* packages must be runtime deps (#998)`,
+        ).toBe(false);
+      }
+    }
+  });
+
   test("internal @loreai/* deps use workspace:* across gateway, opencode, pi", () => {
     // A single shared @loreai/core instance is only guaranteed when every
     // consumer references the internal packages at the same version.
@@ -123,7 +169,7 @@ describe("dependency manifest invariants (#998)", () => {
     // time, keeping all packages unified per release. A pinned/divergent
     // version could install two @loreai/core copies → two _originalFetch
     // values → infinite fetch loop (gateway → interceptor → gateway → …).
-    for (const name of ["gateway", "opencode", "pi"]) {
+    for (const name of Object.keys(requiredInternalDeps)) {
       const manifest = JSON.parse(
         readFileSync(join(packageDir, "..", name, "package.json"), "utf8"),
       ) as {

--- a/packages/gateway/test/bundle-exports.test.ts
+++ b/packages/gateway/test/bundle-exports.test.ts
@@ -52,4 +52,90 @@ describe.skipIf(!hasBundle)("bundle exports", () => {
     expect(content).toContain("node:sqlite");
     expect(content).not.toContain("bun:sqlite");
   });
+
+  // -------------------------------------------------------------------------
+  // Layer 2: Externalized workspace imports must be runtime dependencies
+  // (regression guard for issue #998)
+  // -------------------------------------------------------------------------
+
+  test("externalized @loreai/* imports in the Bun bundle are runtime deps", () => {
+    // The Bun ESM bundle keeps @loreai/core external on purpose (see
+    // script/bundle.ts) so the plugin and the in-process gateway share one
+    // module instance of @loreai/core. For that external import to resolve in
+    // published / standalone installs (e.g. OpenCode's embedded Bun loading
+    // the plugin directly), every externalized @loreai/* package MUST be a
+    // runtime dependency — not a devDependency, which consumers never install.
+    // Issue #998 regressed exactly this: @loreai/core was external + devDep.
+    const content = readFileSync(join(distDir, "index.bun.js"), "utf8");
+
+    // Dev shim (`export * from "../src/index.ts";`) does not exercise the
+    // externalized-core artifact, so there is nothing to assert. The real
+    // minified bundle is present under `pnpm test` because the root `pretest`
+    // runs `pnpm --filter @loreai/gateway run bundle`.
+    if (content.trimStart().startsWith("export *")) return;
+
+    // Match import CONTEXTS only — static `from "@loreai/x"` and dynamic
+    // `import("@loreai/x")`. A bare-string scan would false-match the bundle's
+    // embedded package.json (self-name "@loreai/gateway") and the doctor/setup
+    // string literals mentioning "@loreai/opencode"; requiring those as deps
+    // would be a self-dependency or a dependency cycle.
+    const importContext = /(?:from|import)\s*\(?\s*["'](@loreai\/[\w-]+)["']/g;
+    const specifiers = new Set<string>();
+    for (const match of content.matchAll(importContext)) {
+      specifiers.add(match[1]);
+    }
+
+    // Non-vacuous guard: @loreai/core is externalized by design (the shared
+    // _originalFetch invariant), so the scan must actually find it. If this
+    // ever fails, either the bundle stopped externalizing core (revisit the
+    // fetch-loop invariant in script/bundle.ts) or the regex needs updating.
+    expect(specifiers.has("@loreai/core")).toBe(true);
+
+    const deps = (pkgJson.dependencies ?? {}) as Record<string, string>;
+    for (const specifier of specifiers) {
+      expect(
+        deps[specifier],
+        `${specifier} is externalized in index.bun.js and must be declared in "dependencies"`,
+      ).toBeDefined();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dependency manifest invariants (regression guards for issue #998)
+//
+// These are bundle-independent — they assert the package.json manifests
+// directly, so they run in every environment (including dev checkouts where
+// only the bun shim exists).
+// ---------------------------------------------------------------------------
+
+describe("dependency manifest invariants (#998)", () => {
+  test("@loreai/core is a runtime dependency, not a devDependency", () => {
+    // The on-disk source manifest — NOT the copy embedded in the bundle text.
+    expect(pkgJson.dependencies?.["@loreai/core"]).toBeDefined();
+    expect(pkgJson.devDependencies?.["@loreai/core"]).toBeUndefined();
+  });
+
+  test("internal @loreai/* deps use workspace:* across gateway, opencode, pi", () => {
+    // A single shared @loreai/core instance is only guaranteed when every
+    // consumer references the internal packages at the same version.
+    // `workspace:*` is rewritten to the exact release version at `pnpm pack`
+    // time, keeping all packages unified per release. A pinned/divergent
+    // version could install two @loreai/core copies → two _originalFetch
+    // values → infinite fetch loop (gateway → interceptor → gateway → …).
+    for (const name of ["gateway", "opencode", "pi"]) {
+      const manifest = JSON.parse(
+        readFileSync(join(packageDir, "..", name, "package.json"), "utf8"),
+      ) as {
+        name: string;
+        dependencies?: Record<string, string>;
+      };
+      const deps = manifest.dependencies ?? {};
+      for (const [dep, spec] of Object.entries(deps)) {
+        if (dep.startsWith("@loreai/")) {
+          expect(spec, `${manifest.name} → ${dep}`).toBe("workspace:*");
+        }
+      }
+    }
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
 
   packages/gateway:
     dependencies:
+      '@loreai/core':
+        specifier: workspace:*
+        version: link:../core
       '@supabase/supabase-js':
         specifier: ^2.58.0
         version: 2.108.1
@@ -118,9 +121,6 @@ importers:
         specifier: 0.1.9
         version: 0.1.9
     devDependencies:
-      '@loreai/core':
-        specifier: workspace:*
-        version: link:../core
       '@sentry/bun':
         specifier: ^10.52.0
         version: 10.56.0


### PR DESCRIPTION
## Summary

Fixes #998. When OpenCode's embedded Bun loads the published `@loreai/opencode` plugin **directly** (without `lore run`), the plugin's `startInProcess()` does `await import("@loreai/gateway")` → Bun resolves the `"bun"` export to `dist/index.bun.js`. That bundle keeps `@loreai/core` **external** (so the plugin and the in-process gateway share one module instance of `_originalFetch` — bundling it causes an infinite fetch loop). But `@loreai/core` was declared only as a **devDependency** of `@loreai/gateway`, and devDependencies are never installed for a transitively-consumed published package. So the externalized `import("@loreai/core")` cannot resolve:

```
[lore] ERROR: Lore failed to start — memory features are unavailable.
```

### Root cause
A manifest-classification bug: the gateway's Bun entry has a **runtime** dependency on `@loreai/core` that wasn't **declared** as one. The externalization itself is correct (PR #620, to preserve the single-`_originalFetch` invariant); the standalone-resolution gap has existed since that externalization and was never closed. It slipped through dev/CI because the dev checkout uses a `dist/index.bun.js` shim that never exercises the real externalized-core bundle, and npm/flat installs mask it via `@loreai/opencode`'s hoisted copy. (PR #668 fixed a *different*, related stale-in-process-bundle symptom.)

This is **not on main** — verified `origin/main` still has core in `devDependencies`.

## Fix
Promote `@loreai/core` from `devDependencies` → `dependencies` in `packages/gateway/package.json` (kept `workspace:*`, rewritten to the exact version at `pnpm pack` time). The Bun bundle **keeps core external**, so the single-instance fetch-interceptor invariant is preserved. The CJS bundle already inlines core, so the `lore` CLI / SEA binary is unaffected by double-instance issues.

**Tradeoff:** standalone npm installs of `@loreai/gateway` now also install core's transitive runtime tree (`@huggingface/transformers`, `@huggingface/hub`, `remark`, `micromark`, `zod`, `uuidv7`). The CJS gateway never `require`s the installed core (it inlines its own copy), so this is install-size weight rather than a correctness change. The recommended CLI path is the standalone SEA binary, which bundles everything and is unaffected; the plugin and `@loreai/pi` already pulled core transitively.

## Prevention — "this can never happen again"
Regression guards in `test/bundle-exports.test.ts`, each mutation-tested (revert the invariant → guard fails):

1. **Static manifest:** `@loreai/core` ∈ `dependencies` and ∉ `devDependencies` (gateway).
2. **Bundle scan:** every `@loreai/*` *import context* in the real `index.bun.js` must be a runtime dependency. Uses an import-context regex (`from`/`import()`), not a bare-string grep, to avoid false-matching the bundle's embedded `package.json` self-name and `@loreai/opencode` doctor strings. Includes a non-vacuous assertion that the scan actually finds `@loreai/core` (the by-design external).
3. **Consumer presence + classification:** driven by a per-package table of required runtime internal deps (gateway→core; opencode/pi→core+gateway), assert each is **present** in `dependencies` — the package that exhibited #998 (`@loreai/opencode`) is presence-checked, not merely spec-checked — and that **no** internal `@loreai/*` package appears in `devDependencies` (the exact #998 shape).
4. **Version unification:** gateway/opencode/pi reference internal `@loreai/*` deps via `workspace:*`, so per-release versions stay unified (a divergent version could install two core copies → two `_originalFetch` values → fetch loop).

Also documented the dormant same-shape case for `undici` in `script/bundle.ts`.

## Testing
- Full suite: **4519 passed, 32 skipped, 0 failed**; `bundle-exports.test.ts`: 7 passed.
- Mutation tests (red phase) confirmed:
  - Move core back to `devDependencies` → guards (1) and (2) fail.
  - Move `@loreai/gateway` into opencode's `devDependencies` (the #998 shape) → guard (3) fails.
  - Pin a `workspace:*` to `^0.33.0` → guard (4) fails.
- `pnpm run typecheck` ✓, `pnpm run lint` ✓.
- Confirmed the rebuilt `dist/index.bun.js` still externalizes `@loreai/core` and the scan regex matches only `@loreai/core` (verified against the real minified artifact).

## Review
Adversarial subagent review (read-only, branch-isolated): verdict **SHIP** after the two SHOULD-FIX items it raised were addressed in-PR — (F1) consumer presence guard above; (F2) the install-size wording in this description.

## Out of scope
`@loreai/pi` already declares core + gateway as runtime deps and inlines core (externalizes only gateway) — unaffected; covered by guards (3)/(4).