### PR TITLE
feat(gateway): ship native sqlite-vec in the standalone binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: .vendor-build
-          key: vendor-${{ hashFiles('packages/core/package.json', 'packages/gateway/script/vendor-embeddings.ts', 'packages/gateway/script/vendor-paths.ts') }}
+          key: vendor-${{ hashFiles('packages/core/package.json', 'packages/gateway/script/vendor-embeddings.ts', 'packages/gateway/script/vendor-paths.ts', 'packages/gateway/script/vendor-sqlite-vec.ts') }}
 
       - name: Populate vendor staging (cache miss)
         if: steps.vendor-cache.outputs.cache-hit != 'true'
@@ -322,6 +322,14 @@ jobs:
           # registration check alone wouldn't surface.
           ./packages/gateway/dist-bin/lore-linux-x64 --check-embeddings \
             || (echo "::error::--check-embeddings failed in linux-x64 binary"; exit 1)
+
+          # Verify the embedded sqlite-vec extension actually loads (native
+          # vector search), not the JS brute-force fallback. Catches a broken
+          # asset-embed / extraction chain in the SEA binary.
+          vec=$(./packages/gateway/dist-bin/lore-linux-x64 --check-vec)
+          echo "Vec info: $vec"
+          echo "$vec" | grep -q '^ok vec_version=' \
+            || (echo "::error::native sqlite-vec not loaded in linux-x64 binary: $vec"; exit 1)
 
           # Start gateway, hit health endpoint, shut down
           ./packages/gateway/dist-bin/lore-linux-x64 start -p 7991 &
@@ -666,7 +674,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: .vendor-build
-          key: vendor-${{ hashFiles('packages/core/package.json', 'packages/gateway/script/vendor-embeddings.ts', 'packages/gateway/script/vendor-paths.ts') }}
+          key: vendor-${{ hashFiles('packages/core/package.json', 'packages/gateway/script/vendor-embeddings.ts', 'packages/gateway/script/vendor-paths.ts', 'packages/gateway/script/vendor-sqlite-vec.ts') }}
 
       - name: Populate vendor staging (cache miss)
         if: steps.vendor-cache.outputs.cache-hit != 'true'
@@ -701,6 +709,19 @@ jobs:
             || (echo "::error::vendor not embedded in ${{ matrix.target }} binary"; exit 1)
           "$BIN" --check-embeddings \
             || (echo "::error::--check-embeddings failed in ${{ matrix.target }} binary"; exit 1)
+          # Verify the embedded sqlite-vec extension loads. On macOS, loading an
+          # unsigned extracted .dylib from a codesigned binary may be blocked by
+          # library validation — treat darwin as a non-fatal warning until that
+          # is resolved (it degrades to the JS fallback, never crashes).
+          vec=$("$BIN" --check-vec)
+          echo "Vec info: $vec"
+          if echo "$vec" | grep -q '^ok vec_version='; then
+            echo "native sqlite-vec OK (${{ matrix.target }})"
+          elif [ "${{ matrix.target }}" = "darwin-arm64" ]; then
+            echo "::warning::native sqlite-vec not loaded in darwin-arm64 (dylib codesigning?) — JS fallback in use: $vec"
+          else
+            echo "::error::native sqlite-vec not loaded in ${{ matrix.target }} binary: $vec"; exit 1
+          fi
 
   # ---------------------------------------------------------------------------
   # Nightly: build all platforms, generate patches, publish to GHCR
@@ -739,7 +760,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: .vendor-build
-          key: vendor-${{ hashFiles('packages/core/package.json', 'packages/gateway/script/vendor-embeddings.ts', 'packages/gateway/script/vendor-paths.ts') }}
+          key: vendor-${{ hashFiles('packages/core/package.json', 'packages/gateway/script/vendor-embeddings.ts', 'packages/gateway/script/vendor-paths.ts', 'packages/gateway/script/vendor-sqlite-vec.ts') }}
 
       - name: Populate vendor staging (cache miss)
         if: steps.vendor-cache.outputs.cache-hit != 'true'
@@ -847,6 +868,13 @@ jobs:
             || (echo "::error::vendor not embedded in darwin-arm64 binary"; exit 1)
           "$BIN" --check-embeddings \
             || (echo "::error::--check-embeddings failed in darwin-arm64 binary"; exit 1)
+          # Non-fatal on macOS (see binary-smoke-native): unsigned extracted
+          # .dylib may be blocked by library validation; degrades to JS fallback.
+          vec=$("$BIN" --check-vec)
+          echo "Vec info: $vec"
+          echo "$vec" | grep -q '^ok vec_version=' \
+            && echo "native sqlite-vec OK (darwin-arm64)" \
+            || echo "::warning::native sqlite-vec not loaded in darwin-arm64 (dylib codesigning?) — JS fallback in use: $vec"
 
       - name: Verify code signature
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,7 +328,7 @@ jobs:
           # asset-embed / extraction chain in the SEA binary.
           vec=$(./packages/gateway/dist-bin/lore-linux-x64 --check-vec)
           echo "Vec info: $vec"
-          echo "$vec" | grep -q '^ok vec_version=' \
+          echo "$vec" | grep -q '^ok vec_version=v' \
             || (echo "::error::native sqlite-vec not loaded in linux-x64 binary: $vec"; exit 1)
 
           # Start gateway, hit health endpoint, shut down
@@ -715,7 +715,7 @@ jobs:
           # is resolved (it degrades to the JS fallback, never crashes).
           vec=$("$BIN" --check-vec)
           echo "Vec info: $vec"
-          if echo "$vec" | grep -q '^ok vec_version='; then
+          if echo "$vec" | grep -q '^ok vec_version=v'; then
             echo "native sqlite-vec OK (${{ matrix.target }})"
           elif [ "${{ matrix.target }}" = "darwin-arm64" ]; then
             echo "::warning::native sqlite-vec not loaded in darwin-arm64 (dylib codesigning?) — JS fallback in use: $vec"
@@ -872,7 +872,7 @@ jobs:
           # .dylib may be blocked by library validation; degrades to JS fallback.
           vec=$("$BIN" --check-vec)
           echo "Vec info: $vec"
-          echo "$vec" | grep -q '^ok vec_version=' \
+          echo "$vec" | grep -q '^ok vec_version=v' \
             && echo "native sqlite-vec OK (darwin-arm64)" \
             || echo "::warning::native sqlite-vec not loaded in darwin-arm64 (dylib codesigning?) — JS fallback in use: $vec"
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -75,6 +75,7 @@ export type {
 export { isTextPart, isReasoningPart, isToolPart } from "./types";
 
 export { dataDir } from "./data-dir";
+export { isVecAvailable } from "./db/vec";
 export { load, config, type LoreConfig } from "./config";
 export {
   db,

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -74,6 +74,7 @@
     "@types/qrcode-terminal": "^0.12.2",
     "@types/semver": "^7.7.1",
     "fossilize": "^0.10.1",
+    "tar": "^7.4.3",
     "undici": "^7.28.0"
   }
 }

--- a/packages/gateway/script/build-binary-sea.ts
+++ b/packages/gateway/script/build-binary-sea.ts
@@ -47,6 +47,7 @@ import { parseArgs } from "node:util";
 import { PLACEHOLDER_DEBUG_ID, injectDebugId } from "./debug-id";
 import { MODEL_DIR_NAME, MODEL_FILES } from "./vendor-paths";
 import { findOrtWebDir, ortWebRedirectPlugin } from "./ort-web-plugin";
+import { ensureVecBinaries, vecAssetKey } from "./vendor-sqlite-vec";
 import { fossilize } from "fossilize";
 
 const require = createRequire(import.meta.url);
@@ -204,15 +205,21 @@ function binaryExternalsPlugin(): esbuild.Plugin {
 }
 
 // ---------------------------------------------------------------------------
-// esbuild: stub `sqlite-vec` in the SEA bundle
+// esbuild: stub `sqlite-vec`'s path resolver in the SEA bundle
 // ---------------------------------------------------------------------------
-// The `sqlite-vec` npm package resolves its native loadable extension from a
+// The `sqlite-vec` npm wrapper resolves its native loadable extension from a
 // platform optionalDependency in node_modules — which doesn't exist inside the
-// fossilize binary. We stub it to a no-op so the bundle builds; the SEA path
-// loads the extension from an embedded asset instead (it sets
-// `globalThis.__LORE_VEC_EXTENSION_PATH__`, which db/vec.ts prefers). Until
-// that asset is embedded, the binary transparently uses the JS brute-force
-// fallback. See #956.
+// fossilize binary, so its `getLoadablePath()` can't work there. We replace the
+// wrapper with a no-op so the bundle builds without dragging in (or failing to
+// resolve) the platform package.
+//
+// This does NOT disable native vector search: the extension is embedded as a
+// per-target SEA asset (`vec0-<target>.<ext>`, staged below) and extracted at
+// runtime by native-loader.cjs, which sets `globalThis.__LORE_VEC_EXTENSION_PATH__`.
+// `db/vec.ts` prefers that global over `getLoadablePath()`, so the stubbed
+// fallback is simply never reached in the SEA. If the asset is somehow missing,
+// `getLoadablePath()` returns undefined and the binary transparently uses the JS
+// brute-force fallback. See #956 / #999.
 function stubSqliteVecPlugin(): esbuild.Plugin {
   return {
     name: "stub-sqlite-vec",
@@ -549,9 +556,14 @@ async function buildBinary() {
   // -------------------------------------------------------------------------
   // The read-worker pool (core/vector-pool.ts) spawns this off the main thread.
   // Tiny and self-contained: node:sqlite (via the "node" condition) + the pure
-  // runVectorQuery logic. No ONNX/transformers/WASM. sqlite-vec is stubbed (same
-  // as the main SEA bundle), so the worker uses the JS brute-force fallback —
-  // the off-thread benefit holds regardless of the native fast path.
+  // runVectorQuery logic. No ONNX/transformers/WASM.
+  //
+  // It injects native-loader.cjs like the other bundles so that — inside the
+  // SEA — each worker thread extracts the embedded sqlite-vec extension and sets
+  // `globalThis.__LORE_VEC_EXTENSION_PATH__` in its own thread. Worker threads
+  // don't share globalThis with the main process, so without this the pool's
+  // `loadVecForConnection` would find no path and fall back to the JS scan,
+  // defeating native vector search on the hot (off-thread) path.
   const vectorWorkerBundlePath = join(stagingDir, "sea-vector-worker.cjs");
   const vectorWorkerSrc = join(repoRoot, "packages/core/src/vector-worker.ts");
 
@@ -564,6 +576,7 @@ async function buildBinary() {
     conditions: ["node"],
     external: ["sharp"],
     plugins: [binaryExternalsPlugin(), stubSqliteVecPlugin()],
+    inject: [join(here, "native-loader.cjs")],
     outfile: vectorWorkerBundlePath,
     sourcemap: "linked",
     minify: true,
@@ -712,6 +725,16 @@ async function buildBinary() {
     }
   }
 
+  // Stage the native sqlite-vec loadable extension for every target in this
+  // build. fossilize embeds a single shared asset set into each platform
+  // binary, so we key each one as `vec0-<target>.<ext>`; at runtime
+  // native-loader.cjs extracts only the one matching the running platform.
+  // The binaries are tiny (~160 KB each), so embedding all targets is cheap.
+  const vecBinaries = await ensureVecBinaries(targets);
+  for (const [target, binPath] of vecBinaries) {
+    stageAsset(vecAssetKey(target), binPath);
+  }
+
   // Write a Vite-style manifest. Fossilize uses `entry.file` as the
   // SEA asset key and joins the manifest's dir to locate the file.
   interface ManifestEntry {
@@ -740,6 +763,10 @@ async function buildBinary() {
       const key = `model/${rel}`;
       manifest[key] = { file: key, src: key };
     }
+  }
+  for (const target of vecBinaries.keys()) {
+    const key = vecAssetKey(target);
+    manifest[key] = { file: key, src: key };
   }
 
   const manifestPath = join(stagingDir, "asset-manifest.json");

--- a/packages/gateway/script/bundle.ts
+++ b/packages/gateway/script/bundle.ts
@@ -60,9 +60,9 @@ mkdirSync(distDir, { recursive: true });
 // onnxruntime-node: .node native binaries that esbuild can't handle.
 // sharp: image processing for vision models, not needed for text embeddings.
 // sqlite-vec: resolves a native loadable extension (vec0.{so,dylib,dll}) at
-//   runtime via its platform optionalDependency — must stay external. (The SEA
-//   binary stubs it and uses the JS fallback for now; embedding the extension
-//   as an asset is deferred — see #956.)
+//   runtime via its platform optionalDependency — must stay external on the npm
+//   path. (The SEA binary embeds the extension per-target as an asset and sets
+//   __LORE_VEC_EXTENSION_PATH__ at runtime — see build-binary-sea.ts / #956.)
 const external = ["node:*", "onnxruntime-node", "sharp", "sqlite-vec"];
 
 // Remap @sentry/bun → @sentry/node so the CJS bundle gets Node-native

--- a/packages/gateway/script/native-loader.cjs
+++ b/packages/gateway/script/native-loader.cjs
@@ -117,6 +117,37 @@ if (globalThis.__LORE_WASM_READY__) {
       wasm: wasmPath,
     };
 
+    // sqlite-vec native loadable extension. The build embeds one binary per
+    // target as `vec0-<target>.<ext>` (see vendor-sqlite-vec.ts /
+    // build-binary-sea.ts). Extract only the one matching this platform and
+    // register its path; `db/vec.ts` prefers globalThis.__LORE_VEC_EXTENSION_PATH__
+    // over the (stubbed) npm wrapper. Runs in worker threads too (the vector
+    // pool's reader connections load it) — each thread has its own globalThis.
+    try {
+      const vecOs = process.platform === "win32" ? "windows" : process.platform;
+      const vecExt =
+        process.platform === "win32"
+          ? "dll"
+          : process.platform === "darwin"
+            ? "dylib"
+            : "so";
+      const vecKey = `vec0-${vecOs}-${process.arch}.${vecExt}`;
+      const vecPath = path.join(targetDir, `vec0.${vecExt}`);
+      // The main thread runs first (at startup, before any worker spawns) and
+      // (re)writes unconditionally — overwriting any stale file from a reused
+      // pid. Worker threads share the pid/tmp dir, so they skip the write when
+      // the main thread already produced it: this avoids a concurrent-write
+      // race on the shared path while still self-healing if it's somehow absent.
+      const { isMainThread } = require("node:worker_threads");
+      if (isMainThread || !fs.existsSync(vecPath)) {
+        fs.writeFileSync(vecPath, Buffer.from(sea.getRawAsset(vecKey)));
+      }
+      globalThis.__LORE_VEC_EXTENSION_PATH__ = vecPath;
+    } catch {
+      // Asset absent (build without vec staging) or extraction failed — leave
+      // the global unset so db/vec.ts uses the JS brute-force fallback.
+    }
+
     globalThis.__LORE_WASM_READY__ = true;
   }
 }

--- a/packages/gateway/script/vendor-sqlite-vec.ts
+++ b/packages/gateway/script/vendor-sqlite-vec.ts
@@ -1,0 +1,238 @@
+/**
+ * Vendor the native `sqlite-vec` loadable extension for every build target.
+ *
+ * The SEA (fossilize) binary has no `node_modules`, so the `sqlite-vec` npm
+ * wrapper's `getLoadablePath()` — which resolves the per-platform optional
+ * dependency at runtime — can't find the extension inside the binary. Instead
+ * we embed the extension as a SEA asset (one per target) and extract it at
+ * runtime (see `native-loader.cjs`, which sets
+ * `globalThis.__LORE_VEC_EXTENSION_PATH__`, the path `db/vec.ts` prefers).
+ *
+ * This script produces the per-target binaries the build embeds. Lore's SEA
+ * builds are cross-platform: a single Linux host builds linux/windows (and
+ * stages darwin for the macOS `--from-staging` job), so we can't rely on the
+ * host's own `sqlite-vec-<platform>` package being the right one. For each
+ * requested target we:
+ *   1. reuse the locally-installed package when the target IS the host, else
+ *   2. download the `sqlite-vec-<os>-<arch>` tarball from the npm registry and
+ *      extract its single `vec0.<ext>` file.
+ * Results are cached under `.vendor-build/sqlite-vec/<version>/<target>/` so
+ * repeat builds (and CI, which caches `.vendor-build/`) skip the network.
+ *
+ * The vendored version is pinned to the resolved `sqlite-vec` dependency, so
+ * bumping the npm dep (e.g. the upcoming DiskANN 0.1.10 vendored build, #999)
+ * automatically re-vendors matching binaries.
+ *
+ * Runs under Node (via tsx) — no Bun runtime required. Safe to import for its
+ * path helpers (no side effects until `ensureVecBinaries` / the CLI runs).
+ */
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseArgs } from "node:util";
+import { x as tarExtract } from "tar";
+import { VENDOR_TARGETS, type VendorTarget } from "./vendor-paths";
+
+const require = createRequire(import.meta.url);
+
+const here = dirname(fileURLToPath(import.meta.url));
+const packageDir = dirname(here);
+const repoRoot = dirname(dirname(packageDir));
+
+/** Per-target sqlite-vec platform package + loadable-extension file suffix.
+ *  Mirrors the `sqlite-vec` wrapper's own `platformPackageName()` /
+ *  `extensionSuffix()` (win32 → "windows"/"dll", darwin → "dylib", else "so"). */
+const VEC_TARGET_INFO: Record<VendorTarget, { pkg: string; ext: string }> = {
+  "darwin-arm64": { pkg: "sqlite-vec-darwin-arm64", ext: "dylib" },
+  "linux-arm64": { pkg: "sqlite-vec-linux-arm64", ext: "so" },
+  "linux-x64": { pkg: "sqlite-vec-linux-x64", ext: "so" },
+  "windows-x64": { pkg: "sqlite-vec-windows-x64", ext: "dll" },
+};
+
+/** The SEA asset key under which a target's extension is embedded. The runtime
+ *  loader (`native-loader.cjs`) computes the same key from `process.platform`/
+ *  `process.arch` and extracts only the matching one. Keep the two in sync. */
+export function vecAssetKey(target: VendorTarget): string {
+  return `vec0-${target}.${VEC_TARGET_INFO[target].ext}`;
+}
+
+/** Host target string in VendorTarget form (e.g. "linux-x64", "windows-x64"). */
+function hostTarget(): string {
+  const os = process.platform === "win32" ? "windows" : process.platform;
+  return `${os}-${process.arch}`;
+}
+
+/** Resolve the sqlite-vec version from the installed package, falling back to
+ *  the gateway's declared dependency. Keeps vendored binaries ABI-matched to
+ *  the wrapper the rest of the code loads. */
+export function sqliteVecVersion(): string {
+  try {
+    const pjPath = require.resolve("sqlite-vec/package.json", {
+      paths: [packageDir, join(repoRoot, "packages/core")],
+    });
+    const v = JSON.parse(readFileSync(pjPath, "utf8")).version;
+    if (typeof v === "string" && v.length > 0) return v;
+  } catch {
+    // fall through to the declared-dependency fallback
+  }
+  const gw = JSON.parse(
+    readFileSync(join(packageDir, "package.json"), "utf8"),
+  ) as { dependencies?: Record<string, string> };
+  const declared = gw.dependencies?.["sqlite-vec"] ?? "";
+  const cleaned = declared.replace(/[^\d.]/g, "");
+  if (!cleaned) {
+    throw new Error(
+      "vendor-sqlite-vec: could not determine sqlite-vec version (not " +
+        "resolvable and no declared dependency in packages/gateway/package.json)",
+    );
+  }
+  return cleaned;
+}
+
+function cacheDirFor(version: string): string {
+  return join(repoRoot, ".vendor-build", "sqlite-vec", version);
+}
+
+/** Absolute path to a target's cached `vec0.<ext>` (may not exist yet). */
+export function vecBinaryCachePath(
+  target: VendorTarget,
+  version: string,
+): string {
+  return join(
+    cacheDirFor(version),
+    target,
+    `vec0.${VEC_TARGET_INFO[target].ext}`,
+  );
+}
+
+async function downloadAndExtract(
+  target: VendorTarget,
+  version: string,
+  dest: string,
+): Promise<void> {
+  const { pkg, ext } = VEC_TARGET_INFO[target];
+  const url = `https://registry.npmjs.org/${pkg}/-/${pkg}-${version}.tgz`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(
+      `vendor-sqlite-vec: download failed for ${pkg}@${version} ` +
+        `(${res.status} ${res.statusText}) — ${url}`,
+    );
+  }
+  const buf = Buffer.from(await res.arrayBuffer());
+  const destDir = dirname(dest);
+  const tmpTgz = join(destDir, `${pkg}-${version}.tgz`);
+  writeFileSync(tmpTgz, buf);
+  try {
+    // npm tarballs nest everything under `package/`; strip:1 drops it, and the
+    // filter keeps only the single loadable-extension file.
+    await tarExtract({
+      file: tmpTgz,
+      cwd: destDir,
+      strip: 1,
+      filter: (p) => p === `package/vec0.${ext}`,
+    });
+  } finally {
+    try {
+      unlinkSync(tmpTgz);
+    } catch {
+      // best-effort
+    }
+  }
+  if (!existsSync(dest)) {
+    throw new Error(
+      `vendor-sqlite-vec: extracted ${pkg}@${version} but vec0.${ext} not found at ${dest}`,
+    );
+  }
+}
+
+/**
+ * Ensure the loadable extension for `target` exists in the vendor cache and
+ * return its absolute path. Cache hit → no work. Cache miss → reuse the
+ * locally-installed package when `target` is the host, else download.
+ */
+export async function ensureVecBinary(
+  target: VendorTarget,
+  version = sqliteVecVersion(),
+): Promise<string> {
+  const dest = vecBinaryCachePath(target, version);
+  if (existsSync(dest)) return dest;
+
+  mkdirSync(dirname(dest), { recursive: true });
+
+  const { pkg, ext } = VEC_TARGET_INFO[target];
+
+  // Fast path: the host's own platform package is already installed.
+  if (target === hostTarget()) {
+    try {
+      const installed = require.resolve(`${pkg}/vec0.${ext}`, {
+        paths: [packageDir, join(repoRoot, "packages/core")],
+      });
+      copyFileSync(installed, dest);
+      return dest;
+    } catch {
+      // not installed / not resolvable — fall through to download
+    }
+  }
+
+  await downloadAndExtract(target, version, dest);
+  return dest;
+}
+
+/** Ensure binaries for several targets; returns target → absolute path. */
+export async function ensureVecBinaries(
+  targets: readonly VendorTarget[],
+  version = sqliteVecVersion(),
+): Promise<Map<VendorTarget, string>> {
+  const out = new Map<VendorTarget, string>();
+  for (const t of targets) {
+    out.set(t, await ensureVecBinary(t, version));
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// CLI: `tsx script/vendor-sqlite-vec.ts [--platforms a,b,c]`
+// ---------------------------------------------------------------------------
+async function main(): Promise<void> {
+  const { values } = parseArgs({
+    args: process.argv.slice(2),
+    options: { platforms: { type: "string" } },
+    allowPositionals: false,
+    strict: true,
+  });
+  const targets = (
+    values.platforms
+      ? values.platforms
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean)
+      : VENDOR_TARGETS
+  ) as VendorTarget[];
+  for (const t of targets) {
+    if (!VENDOR_TARGETS.includes(t)) {
+      console.error(`Invalid target: ${t}`);
+      console.error(`Valid targets: ${VENDOR_TARGETS.join(", ")}`);
+      process.exit(1);
+    }
+  }
+  const version = sqliteVecVersion();
+  console.log(`→ vendor sqlite-vec ${version}: ${targets.join(", ")}`);
+  for (const t of targets) {
+    const p = await ensureVecBinary(t, version);
+    console.log(`✓ ${t}: ${p}`);
+  }
+}
+
+// Run only when invoked directly (not when imported by build-binary-sea.ts).
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  await main();
+}

--- a/packages/gateway/script/vendor-sqlite-vec.ts
+++ b/packages/gateway/script/vendor-sqlite-vec.ts
@@ -31,6 +31,8 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
+  renameSync,
+  rmSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
@@ -113,6 +115,29 @@ export function vecBinaryCachePath(
   );
 }
 
+/** Place a file at `dest` atomically: `produce` writes to a temp path in the
+ *  same directory, then we rename it into place. A rename on the same
+ *  filesystem is atomic, so an interrupted run (CI cancel / OOM / SIGTERM)
+ *  never leaves a truncated `vec0.*` at the cache-key path — which the next
+ *  build (and the persisted `.vendor-build/` CI cache) would otherwise treat
+ *  as a valid cache hit and embed, silently breaking native vector search. */
+function placeAtomically(
+  dest: string,
+  produce: (tmpPath: string) => void,
+): void {
+  const tmp = `${dest}.tmp-${process.pid}`;
+  try {
+    produce(tmp);
+    renameSync(tmp, dest);
+  } finally {
+    try {
+      if (existsSync(tmp)) unlinkSync(tmp);
+    } catch {
+      // best-effort cleanup
+    }
+  }
+}
+
 async function downloadAndExtract(
   target: VendorTarget,
   version: string,
@@ -128,29 +153,34 @@ async function downloadAndExtract(
     );
   }
   const buf = Buffer.from(await res.arrayBuffer());
-  const destDir = dirname(dest);
-  const tmpTgz = join(destDir, `${pkg}-${version}.tgz`);
-  writeFileSync(tmpTgz, buf);
+  // Stage the download + extraction in a temp dir so a partial result never
+  // lands at the cache path; only the finished file is renamed into place.
+  const stage = join(dirname(dest), `.tmp-${process.pid}-${target}`);
+  mkdirSync(stage, { recursive: true });
   try {
+    const tmpTgz = join(stage, `${pkg}-${version}.tgz`);
+    writeFileSync(tmpTgz, buf);
     // npm tarballs nest everything under `package/`; strip:1 drops it, and the
     // filter keeps only the single loadable-extension file.
     await tarExtract({
       file: tmpTgz,
-      cwd: destDir,
+      cwd: stage,
       strip: 1,
       filter: (p) => p === `package/vec0.${ext}`,
     });
+    const extracted = join(stage, `vec0.${ext}`);
+    if (!existsSync(extracted)) {
+      throw new Error(
+        `vendor-sqlite-vec: extracted ${pkg}@${version} but vec0.${ext} not found`,
+      );
+    }
+    renameSync(extracted, dest);
   } finally {
     try {
-      unlinkSync(tmpTgz);
+      rmSync(stage, { recursive: true, force: true });
     } catch {
-      // best-effort
+      // best-effort cleanup
     }
-  }
-  if (!existsSync(dest)) {
-    throw new Error(
-      `vendor-sqlite-vec: extracted ${pkg}@${version} but vec0.${ext} not found at ${dest}`,
-    );
   }
 }
 
@@ -168,16 +198,24 @@ export async function ensureVecBinary(
 
   mkdirSync(dirname(dest), { recursive: true });
 
-  const { pkg, ext } = VEC_TARGET_INFO[target];
-
-  // Fast path: the host's own platform package is already installed.
+  // Fast path: when building for the host, reuse the already-installed
+  // extension instead of hitting the network. The per-platform package
+  // (`sqlite-vec-<os>-<arch>`) is a *transitive* optionalDependency, so under
+  // pnpm it isn't resolvable from packages/gateway|core — only the wrapper's
+  // `getLoadablePath()` finds it (it resolves its own sibling in `.pnpm/`).
   if (target === hostTarget()) {
     try {
-      const installed = require.resolve(`${pkg}/vec0.${ext}`, {
+      const wrapper = require.resolve("sqlite-vec", {
         paths: [packageDir, join(repoRoot, "packages/core")],
       });
-      copyFileSync(installed, dest);
-      return dest;
+      const { getLoadablePath } = require(wrapper) as {
+        getLoadablePath?: () => string;
+      };
+      const installed = getLoadablePath?.();
+      if (installed && existsSync(installed)) {
+        placeAtomically(dest, (tmp) => copyFileSync(installed, tmp));
+        return dest;
+      }
     } catch {
       // not installed / not resolvable — fall through to download
     }

--- a/packages/gateway/src/cli/main.ts
+++ b/packages/gateway/src/cli/main.ts
@@ -134,6 +134,11 @@ const OPTIONS = {
   // or the failure reason. Used by CI to catch model-load regressions
   // that --print-vendor-info alone wouldn't surface.
   "check-embeddings": { type: "boolean" as const },
+  // Hidden diagnostic: verifies the native sqlite-vec extension actually
+  // loaded (prints `ok vec_version=...`) or that the binary fell back to the
+  // JS brute-force path (`fallback ...`). Used by CI to confirm the SEA binary
+  // embeds + loads the vec0 extension.
+  "check-vec": { type: "boolean" as const },
 } as const;
 
 // Populate the set used by extractAgentArgs to distinguish lore's own flags
@@ -250,6 +255,37 @@ export async function _cli(): Promise<void> {
         console.error(
           `  cause: ${cause instanceof Error ? (cause.stack ?? cause.message) : String(cause)}`,
         );
+      process.exit(1);
+    }
+    return;
+  }
+
+  // --check-vec (hidden). Confirms the native sqlite-vec extension loaded on
+  // the main DB connection — inside the SEA it's extracted from the embedded
+  // per-target asset by native-loader.cjs. Prints `ok vec_version=<v>` when
+  // native search is active, or `fallback (...)` when the JS brute-force path
+  // is in use. Used by CI to verify the embed-asset → load chain.
+  if (values["check-vec"]) {
+    const { db, isVecAvailable } = await import("@loreai/core");
+    const { safeExit } = await import("./exit");
+    try {
+      const conn = db();
+      if (!isVecAvailable()) {
+        console.log(
+          "fallback (native sqlite-vec not loaded — using JS brute-force)",
+        );
+        safeExit(0);
+        return;
+      }
+      const row = conn.query("SELECT vec_version() AS v").get() as
+        | { v?: string }
+        | undefined;
+      console.log(`ok vec_version=${row?.v ?? "unknown"}`);
+      safeExit(0);
+    } catch (err: unknown) {
+      console.error(
+        `✗ check-vec failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
       process.exit(1);
     }
     return;

--- a/packages/gateway/src/cli/main.ts
+++ b/packages/gateway/src/cli/main.ts
@@ -268,26 +268,29 @@ export async function _cli(): Promise<void> {
   if (values["check-vec"]) {
     const { db, isVecAvailable } = await import("@loreai/core");
     const { safeExit } = await import("./exit");
+    let ok = false;
     try {
       const conn = db();
       if (!isVecAvailable()) {
         console.log(
           "fallback (native sqlite-vec not loaded — using JS brute-force)",
         );
-        safeExit(0);
-        return;
+      } else {
+        const row = conn.query("SELECT vec_version() AS v").get() as
+          | { v?: string }
+          | undefined;
+        console.log(`ok vec_version=${row?.v ?? "unknown"}`);
       }
-      const row = conn.query("SELECT vec_version() AS v").get() as
-        | { v?: string }
-        | undefined;
-      console.log(`ok vec_version=${row?.v ?? "unknown"}`);
-      safeExit(0);
+      ok = true;
     } catch (err: unknown) {
       console.error(
         `✗ check-vec failed: ${err instanceof Error ? err.message : String(err)}`,
       );
-      process.exit(1);
     }
+    // Exit outside the try so a throw on the success path can't be mis-reported
+    // as a check failure; safeExit (not process.exit) on both paths avoids the
+    // Bun NAPI teardown hang.
+    safeExit(ok ? 0 : 1);
     return;
   }
 

--- a/packages/gateway/test/cli-check-vec.test.ts
+++ b/packages/gateway/test/cli-check-vec.test.ts
@@ -113,11 +113,11 @@ describe("--check-vec CLI diagnostic", () => {
   test("db error: prints failure and exits 1", async () => {
     state.dbThrows = true;
 
-    await expect(_cli()).rejects.toThrow("__exit:1");
+    await _cli();
 
     expect(errSpy).toHaveBeenCalledWith(
       expect.stringContaining("✗ check-vec failed: db boom"),
     );
-    expect(safeExit).not.toHaveBeenCalled();
+    expect(safeExit).toHaveBeenCalledWith(1);
   });
 });

--- a/packages/gateway/test/cli-check-vec.test.ts
+++ b/packages/gateway/test/cli-check-vec.test.ts
@@ -1,0 +1,123 @@
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from "vitest";
+
+// Mutable state driving the @loreai/core mock, so each test can steer the
+// `--check-vec` handler down a specific branch (native / fallback / error)
+// without a real DB or the native extension.
+// Hoisted alongside vi.mock (which is lifted to the top of the file) so both
+// the state and the safeExit spy exist when the mock factories run.
+const { state, safeExit } = vi.hoisted(() => ({
+  state: {
+    vecAvailable: true,
+    // `undefined` simulates `SELECT vec_version()` returning a row with no `v`.
+    vecVersion: "v0.1.9" as string | undefined,
+    dbThrows: false,
+  },
+  safeExit: vi.fn(),
+}));
+
+// Partial mock: keep every real export (main.ts → start.ts → config.ts pulls
+// several at module load) and override only the two the handler calls.
+vi.mock("@loreai/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@loreai/core")>();
+  return {
+    ...actual,
+    isVecAvailable: () => state.vecAvailable,
+    db: () => {
+      if (state.dbThrows) throw new Error("db boom");
+      return {
+        query: (_sql: string) => ({
+          get: () =>
+            state.vecVersion === undefined ? {} : { v: state.vecVersion },
+        }),
+      };
+    },
+  };
+});
+
+// `safeExit` normally terminates the process; here it's a no-op so the handler
+// returns and the test runner survives. Resolves to the same module file that
+// main.ts imports via `./exit`.
+vi.mock("../src/cli/exit", () => ({ safeExit }));
+
+import { _cli } from "../src/cli/main";
+
+describe("--check-vec CLI diagnostic", () => {
+  const origArgv = process.argv;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    state.vecAvailable = true;
+    state.vecVersion = "v0.1.9";
+    state.dbThrows = false;
+    safeExit.mockClear();
+    process.argv = ["node", "lore", "--check-vec"];
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`__exit:${code}`);
+    }) as never);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    process.argv = origArgv;
+  });
+
+  test("native available: prints vec_version and exits 0", async () => {
+    state.vecAvailable = true;
+    state.vecVersion = "v0.1.9";
+
+    await _cli();
+
+    expect(logSpy).toHaveBeenCalledWith("ok vec_version=v0.1.9");
+    expect(safeExit).toHaveBeenCalledWith(0);
+    expect(errSpy).not.toHaveBeenCalled();
+  });
+
+  test("native available but version row empty: prints 'unknown'", async () => {
+    state.vecAvailable = true;
+    state.vecVersion = undefined;
+
+    await _cli();
+
+    expect(logSpy).toHaveBeenCalledWith("ok vec_version=unknown");
+    expect(safeExit).toHaveBeenCalledWith(0);
+  });
+
+  test("native unavailable: reports JS fallback and exits 0", async () => {
+    state.vecAvailable = false;
+
+    await _cli();
+
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining("fallback (native sqlite-vec not loaded"),
+    );
+    expect(safeExit).toHaveBeenCalledWith(0);
+  });
+
+  test("db error: prints failure and exits 1", async () => {
+    state.dbThrows = true;
+
+    await expect(_cli()).rejects.toThrow("__exit:1");
+
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringContaining("✗ check-vec failed: db boom"),
+    );
+    expect(safeExit).not.toHaveBeenCalled();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,6 +136,9 @@ importers:
       fossilize:
         specifier: ^0.10.1
         version: 0.10.1
+      tar:
+        specifier: ^7.4.3
+        version: 7.5.16
       undici:
         specifier: ^7.28.0
         version: 7.28.0


### PR DESCRIPTION
## What & why

The SEA (fossilize) standalone binary **stubbed `sqlite-vec`** and fell back to the pure-JS brute-force cosine scan for all vector search (deferred in #956). Distributed binaries therefore *never* got the native fast path — only the npm/dev/self-hosted-gateway path did.

This un-stubs it: the loadable extension is now **embedded as a SEA asset** (per target) and loaded at runtime. First step of the DiskANN switchover (#999) — it lands the native-vec distribution plumbing that the 0.1.10/DiskANN bump will reuse.

## How

- **`vendor-sqlite-vec.ts`** (new): vendors the per-target `vec0.{so,dylib,dll}`. When building for the host it reuses the already-installed extension via the `sqlite-vec` wrapper's `getLoadablePath()` (the per-platform package is a *transitive* optionalDep, so under pnpm it's only resolvable through the wrapper, not a direct `require.resolve`); otherwise it downloads + extracts the npm tarball. Results are cached under `.vendor-build/sqlite-vec/<version>/` (CI caches this) and written **atomically** (temp + rename) so an interrupted build can't poison the cache with a truncated binary. Cross-platform builds (one Linux host → linux/windows; darwin via `--from-staging`) get every target's binary.
- **`build-binary-sea.ts`**: stages each target's extension as `vec0-<target>.<ext>` in the fossilize asset manifest, and **injects `native-loader.cjs` into the vector-worker bundle** so the off-thread read pool also loads native vec (worker threads don't share `globalThis`).
- **`native-loader.cjs`**: extracts the matching extension inside the SEA and sets `globalThis.__LORE_VEC_EXTENSION_PATH__` (which `db/vec.ts` already prefers). Main thread (re)writes unconditionally (overwrites stale on pid reuse); worker threads reuse it to avoid a concurrent-write race.
- The esbuild **stub stays** — it only neuters the unused `getLoadablePath()` fallback inside the binary; the embedded-asset global wins. If the asset is ever missing, the binary still degrades gracefully to the JS fallback (never crashes).
- Hidden **`--check-vec`** diagnostic + CI smoke asserting native vec loads (grep `^ok vec_version=v`, so a `vec_version=unknown` fails the hard gate on linux/windows). Exit happens outside the handler's try and uses `safeExit` on both success and error.

## Storage / version

The vendored version tracks the `sqlite-vec` dependency (currently `0.1.9`), so the upcoming **DiskANN 0.1.10 vendored build** (#999) re-vendors matching binaries automatically through the same seam.

## Tests

- `packages/gateway/test/cli-check-vec.test.ts` (new): drives `_cli(["--check-vec"])` through all branches (native / empty-version / JS fallback / error) for real Codecov credit on the otherwise smoke-only handler. Red-phase verified (mutating the printed string and the error exit code both fail the suite).

## Verification

- Built `lore-linux-x64` locally → `--check-vec` ⇒ `ok vec_version=v0.1.9`, exit 0, new gate passes; log `sqlite-vec: native vector search enabled (v0.1.9, …)`.
- Host fast-path verified offline: vendoring the host target succeeds with `fetch` stubbed to throw (previously it always hit npm).
- Verified the download+extract path produces correct binaries for all 4 targets (Mach-O arm64, ELF aarch64, ELF x86-64, PE32+ DLL).
- All 3 SEA bundles (main, embedding-worker, vector-worker) carry the vec-extraction logic; manifest includes the vec asset.
- `vec-search` (12/12), `bundle-exports`, `cli-check-vec` (4/4) pass; typecheck + Biome clean.

## Known risk / follow-ups

- macOS may block loading an unsigned extracted `.dylib` from a codesigned binary (library validation). The darwin smoke is therefore **non-fatal** (warns, degrades to JS fallback) until dylib signing is addressed in a follow-up. linux/windows are hard-failed.
- `--check-vec` verifies the **main-thread** load path; the production off-thread read-pool path relies on the same `getRawAsset`-in-worker mechanism the embedding worker already proves, but isn't independently asserted by the smoke. Tracked as a follow-up.