### PR TITLE
feat(website): add full-content RSS feed for the blog

### DIFF
--- a/packages/website/astro.config.mjs
+++ b/packages/website/astro.config.mjs
@@ -111,6 +111,16 @@ export default defineConfig({
             href: `${base}apple-touch-icon.png`,
           },
         },
+        // RSS feed autodiscovery
+        {
+          tag: "link",
+          attrs: {
+            rel: "alternate",
+            type: "application/rss+xml",
+            title: "Lore Blog",
+            href: `https://withlore.ai${base}rss.xml`,
+          },
+        },
         // Open Graph
         {
           tag: "meta",

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -10,6 +10,8 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.4",
+    "@astrojs/mdx": "^5.0.6",
+    "@astrojs/rss": "^4.0.18",
     "@astrojs/starlight": "^0.39.3",
     "astro": "^6.4.6",
     "sharp": "^0.34.0",

--- a/packages/website/src/components/SocialMeta.astro
+++ b/packages/website/src/components/SocialMeta.astro
@@ -43,3 +43,11 @@ const imageUrl = `${site}${base}${ogImageManifest.filename}`;
 <meta name="twitter:description" content={description} />
 <meta name="twitter:image" content={imageUrl} />
 <meta name="twitter:site" content="@withLoreAI" />
+
+<!-- RSS feed autodiscovery -->
+<link
+  rel="alternate"
+  type="application/rss+xml"
+  title="Lore Blog"
+  href={`${site}${base}rss.xml`}
+/>

--- a/packages/website/src/layouts/BlogLayout.astro
+++ b/packages/website/src/layouts/BlogLayout.astro
@@ -45,6 +45,7 @@ const ogType = path === "blog/" ? "website" : "article";
         <a href={`${import.meta.env.BASE_URL}docs/`}>Docs</a>
         <a href={`${import.meta.env.BASE_URL}blog/`}>Blog</a>
         <a href={`${import.meta.env.BASE_URL}different/`}>Why Lore</a>
+        <a href={`${import.meta.env.BASE_URL}rss.xml`}>RSS</a>
         <a href="https://github.com/byk/loreai" target="_blank" rel="noopener noreferrer">GitHub</a>
       </nav>
     </header>

--- a/packages/website/src/pages/rss.xml.ts
+++ b/packages/website/src/pages/rss.xml.ts
@@ -1,0 +1,80 @@
+import rss from "@astrojs/rss";
+import mdxRenderer from "@astrojs/mdx/server.js";
+import type { APIContext } from "astro";
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { getCollection, render } from "astro:content";
+
+const MAX_ITEMS = 20;
+const SITE = "https://withlore.ai";
+
+// RSS readers need absolute URLs. Posts currently have no images, but bodies
+// may contain root-relative links (e.g. /docs/...); rewrite them to absolute.
+// Only double-quoted href/src are handled (Astro's output form); srcset and
+// single-quoted attributes are not — extend if a post ever needs them.
+// We intentionally do NOT use a global `build.assetsPrefix` (the guide's
+// approach) because it would break the /_preview/pr-<n>/ base path and rewrite
+// every docs asset to the production domain.
+function absolutize(html: string): string {
+  return html.replace(/(href|src)="\/(?!\/)/g, `$1="${SITE}/`);
+}
+
+// Minimal escaping for raw text we inject into customData (which @astrojs/rss
+// does not escape for us). Author values come from trusted frontmatter, but
+// escaping keeps the feed well-formed regardless.
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+export async function GET(context: APIContext) {
+  // The Container API lets us render a post's compiled `Content` component to
+  // an HTML string outside the page pipeline, so the feed carries full content.
+  // Registering the MDX renderer is a no-op for the current `.md` posts and
+  // keeps the feed working if a future post is authored as `.mdx`.
+  // Note: this path surfaces an Astro-internal `markdown.gfm`/`markdown.smartypants`
+  // deprecation warning (markdown-remark still reads the deprecated top-level
+  // config); it is upstream, non-blocking, and not introduced by our code.
+  const container = await AstroContainer.create();
+  container.addServerRenderer({ renderer: mdxRenderer });
+
+  const site = context.site ?? new URL(SITE);
+
+  const posts = (await getCollection("blog"))
+    .filter((post) => !post.data.draft)
+    .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf())
+    .slice(0, MAX_ITEMS);
+
+  return rss({
+    title: "Lore Blog",
+    description:
+      "Product notes, engineering updates, and memory architecture deep dives from Lore.",
+    site,
+    xmlns: {
+      atom: "http://www.w3.org/2005/Atom",
+      dc: "http://purl.org/dc/elements/1.1/",
+    },
+    items: await Promise.all(
+      posts.map(async (post) => {
+        const { Content } = await render(post);
+        const body = await container.renderToString(Content);
+        return {
+          title: post.data.title,
+          pubDate: post.data.pubDate,
+          description: post.data.description,
+          link: new URL(`blog/${post.id}/`, site).toString(),
+          categories: post.data.tags,
+          content: absolutize(body),
+          // RSS <author> expects an email address; a display name belongs in
+          // Dublin Core's dc:creator.
+          customData: `<dc:creator>${escapeXml(post.data.author)}</dc:creator>`,
+        };
+      }),
+    ),
+    customData: [
+      "<language>en-us</language>",
+      `<atom:link href="${new URL("rss.xml", site).toString()}" rel="self" type="application/rss+xml"/>`,
+    ].join(""),
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,6 +180,12 @@ importers:
       '@astrojs/check':
         specifier: ^0.9.4
         version: 0.9.9(prettier@3.8.3)(typescript@5.9.3)
+      '@astrojs/mdx':
+        specifier: ^5.0.6
+        version: 5.0.6(astro@6.4.6(@types/node@25.3.2)(jiti@2.7.0)(rollup@4.62.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@astrojs/rss':
+        specifier: ^4.0.18
+        version: 4.0.18
       '@astrojs/starlight':
         specifier: ^0.39.3
         version: 0.39.3(astro@6.4.6(@types/node@25.3.2)(jiti@2.7.0)(rollup@4.62.0)(tsx@4.22.4)(yaml@2.9.0))(typescript@5.9.3)
@@ -252,6 +258,9 @@ packages:
   '@astrojs/prism@4.0.2':
     resolution: {integrity: sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA==}
     engines: {node: '>=22.12.0'}
+
+  '@astrojs/rss@4.0.18':
+    resolution: {integrity: sha512-wc5DwKlbTEdgVAWnHy8krFTeQ42t1v/DJqeq5HtulYK3FYHE4krtRGjoyhS3eXXgfdV6Raoz2RU3wrMTFAitRg==}
 
   '@astrojs/sitemap@3.7.3':
     resolution: {integrity: sha512-f8euLVsyeAmAkSm/1M2Kb8sL8byQmfgbvBNaHFItCheTj/IpiJYSEWVcqDHZ/yEHxiS7+w87mQkzwZaPHmk5GA==}
@@ -4304,6 +4313,12 @@ snapshots:
   '@astrojs/prism@4.0.2':
     dependencies:
       prismjs: 1.30.0
+
+  '@astrojs/rss@4.0.18':
+    dependencies:
+      fast-xml-parser: 5.7.3
+      piccolore: 0.1.3
+      zod: 4.4.3
 
   '@astrojs/sitemap@3.7.3':
     dependencies:


### PR DESCRIPTION
## What

Adds an RSS feed at `/rss.xml` for the Lore blog, following the approach in [Having a Good Ol' RSS Feed in Astro](https://byk.im/posts/good-old-rss-feed-in-astro/) and the reference implementation in `byk.github.io`.

The blog previously had **no feed** and `@astrojs/rss` was not installed.

## Changes

- **New endpoint** `packages/website/src/pages/rss.xml.ts` — renders **full post content** via the experimental Container API (uppercase `GET`), sorted newest-first, draft-filtered, capped at 20 items.
- **Item metadata**: each item carries `<category>` elements (post `tags`) and `<dc:creator>` (post `author` — a display name belongs in Dublin Core's `dc:creator`, since RSS `<author>` expects an email). The channel advertises an `<atom:link rel="self">` (W3C-recommended) and `<language>`.
- **Deps**: add `@astrojs/rss@^4.0.18` and `@astrojs/mdx@^5.0.6` as direct devDependencies. `@astrojs/mdx` was previously only a *transitive* (Starlight) dep, resolving to the same `5.0.6`; it's needed to import the server renderer under pnpm's strict resolution. Registering the MDX renderer is a no-op for the current `.md` posts and keeps the feed working if a post is later authored as `.mdx`.
- **Site-wide autodiscovery**: `<link rel="alternate" type="application/rss+xml">` added to `SocialMeta.astro` (homepage, Why Lore, all blog pages) and the Starlight `head:` array (docs pages).
- **Visible link**: an `RSS` link in the blog nav (`BlogLayout.astro`).

## Notable decisions

- **No global `build.assetsPrefix`.** The guide uses it to absolutize image URLs, but doing so globally here would break the `/_preview/pr-<n>/` base-path machinery and rewrite every docs asset to the production domain. Posts currently have no images; root-relative links in post bodies are absolutized inside the endpoint instead. (The `absolutize` helper handles double-quoted `href`/`src` only — Astro's output form; `srcset`/single-quoted forms are documented as out of scope until a post needs them.)
- **`vite.ssr.external` not needed.** That workaround in the guide was an Astro **v5** issue; this site is on Astro **v6.4.6** (byk.im itself dropped it after upgrading to v6).
- Feed item links and the `atom:self` href use the canonical production origin (`https://withlore.ai`), which is correct for RSS regardless of build environment. Autodiscovery `<link>` hrefs follow the site's existing `${site}${base}${path}` convention (production resolves to `https://withlore.ai/rss.xml`).

## Verification

- `pnpm --filter @loreai/website build` succeeds; `dist/rss.xml` generated with 2 items, newest-first, full `<content:encoded>`, absolute links, per-item `<category>`/`<dc:creator>`, and a channel `atom:self` link; `xmlns:content`, `xmlns:atom`, `xmlns:dc` all declared on the root.
- Autodiscovery `<link>` confirmed in built HTML (count = 1) for homepage, blog index, blog posts, Why Lore, and docs pages — no duplicates.
- `astro check`: 0 errors / 0 warnings (2 pre-existing, unrelated hints). Biome: clean.

### Known warning (upstream, non-blocking)

The Container API render path emits an Astro-internal `markdown.gfm`/`markdown.smartypants` deprecation warning during `/rss.xml` generation (markdown-remark still reads the deprecated top-level markdown config). It originates upstream, is **not** introduced by this PR's code, and does not fail the build. It's documented in a code comment so we revisit the Container API path on the next Astro major. (The "0 warnings" above refers to `astro check`, not the production build.)