### PR TITLE
fix(pi): stop the extension from corrupting Pi's TUI

### DIFF
--- a/packages/core/src/log.ts
+++ b/packages/core/src/log.ts
@@ -72,7 +72,14 @@ export function traceDbQuery<T>(sql: string, fn: () => T): T {
 // Helpers
 // ---------------------------------------------------------------------------
 
-const isDebug = !!process.env.LORE_DEBUG;
+// Match the gateway config's `isTruthy` semantics: only "1" or "true" enable
+// debug. The naive `!!process.env.LORE_DEBUG` treated `LORE_DEBUG=0` and
+// `LORE_DEBUG=false` as ENABLED (non-empty strings are truthy), which meant a
+// user who set `LORE_DEBUG=0` to silence Lore still got `[lore]` status lines
+// printed to stderr — fatal inside a full-screen TUI (e.g. the Pi agent).
+const isDebug =
+  process.env.LORE_DEBUG === "1" ||
+  process.env.LORE_DEBUG?.toLowerCase() === "true";
 
 /** Format variadic args into a single string for the sink. */
 function formatArgs(args: unknown[]): string {

--- a/packages/gateway/src/cli/start.ts
+++ b/packages/gateway/src/cli/start.ts
@@ -11,7 +11,7 @@ import { startServer, bracketHost } from "../server";
 import { resetPipelineState } from "../pipeline";
 import { writePortFile, removePortFile, readPortFile } from "../portfile";
 import { writePidFile, removePidFile } from "../pidfile";
-import { dataDir, embedding } from "@loreai/core";
+import { dataDir, embedding, log } from "@loreai/core";
 import { safeExit } from "./exit";
 import { installSignalShutdown } from "./shutdown";
 
@@ -300,6 +300,18 @@ export async function startGateway(
 ): Promise<GatewayHandle> {
   const config = loadConfig();
 
+  // In-process callers (OpenCode plugin, Pi extension) pass `quiet: true`.
+  // They run inside the host agent's full-screen TUI, where ANY stdout/stderr
+  // write corrupts the rendered screen. Route the gateway's own startup/
+  // shutdown notices through the core `log` module (file-based, terminal-
+  // suppressed) when quiet; otherwise keep the visible `console.error` notices
+  // for the `lore start` CLI.
+  const quiet = opts.quiet === true;
+  const notify = (msg: string): void => {
+    if (quiet) log.warn(msg);
+    else console.error(`[lore] ${msg}`);
+  };
+
   // CLI overrides
   if (opts.port !== undefined) {
     config.port = opts.port;
@@ -420,7 +432,7 @@ export async function startGateway(
       const shutdown = async () => {
         if (shutdownStarted) return;
         shutdownStarted = true;
-        console.error("[lore] Shutting down…");
+        notify("Shutting down…");
         boundServer.stop();
         removePortFile(actualPort);
         removePidFile();
@@ -436,8 +448,8 @@ export async function startGateway(
       };
 
       if (candidatePort === 0) {
-        console.error(
-          `[lore] Preferred ports (${DEFAULT_PORTS.join(", ")}) were unavailable; using port ${actualPort}`,
+        notify(
+          `Preferred ports (${DEFAULT_PORTS.join(", ")}) were unavailable; using port ${actualPort}`,
         );
       }
 
@@ -499,8 +511,8 @@ export async function startGateway(
       if (nextIdx < portsToTry.length) {
         const nextPort = portsToTry[nextIdx];
         const nextLabel = nextPort === 0 ? "random port" : String(nextPort);
-        console.error(
-          `[lore] Port ${candidatePort} in use (not a lore gateway), trying ${nextLabel}…`,
+        notify(
+          `Port ${candidatePort} in use (not a lore gateway), trying ${nextLabel}…`,
         );
       }
     }

--- a/packages/gateway/test/start-gateway-quiet.test.ts
+++ b/packages/gateway/test/start-gateway-quiet.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Regression test for the `startGateway({ quiet })` flag.
+ *
+ * In-process callers (the OpenCode plugin and the Pi extension) start the
+ * gateway with `{ quiet: true, local: true }` because they run inside the host
+ * agent's full-screen TUI, where ANY stdout/stderr write corrupts the rendered
+ * screen. Before the fix, `startGateway()` ignored `quiet` entirely and printed
+ * its startup/shutdown notices via `console.error`, leaking into the TUI (part
+ * of the Pi breakage Daniel Griesser reported).
+ *
+ * These tests pin the contract:
+ *   - quiet:true  → no `[lore] Shutting down…` on stderr (routed to file log).
+ *   - quiet:false → the message is still printed (preserves `lore start` CLI).
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("startGateway quiet flag", () => {
+  const teardowns: Array<() => void | Promise<void>> = [];
+  const savedXdg = process.env.XDG_DATA_HOME;
+
+  afterEach(async () => {
+    while (teardowns.length) {
+      const fn = teardowns.pop();
+      try {
+        await fn?.();
+      } catch {
+        /* best-effort cleanup */
+      }
+    }
+    if (savedXdg === undefined) delete process.env.XDG_DATA_HOME;
+    else process.env.XDG_DATA_HOME = savedXdg;
+  });
+
+  /** Start an owned gateway with port/pid/log files isolated to a temp dir. */
+  async function startOwned(quiet: boolean) {
+    // Isolate gateway.port / lore.pid writes so we never clobber a real
+    // running gateway's discovery files.
+    const dataHome = mkdtempSync(join(tmpdir(), "lore-quiet-test-"));
+    process.env.XDG_DATA_HOME = dataHome;
+    teardowns.push(() => rmSync(dataHome, { recursive: true, force: true }));
+
+    const { startGateway } = await import("../src/cli/start");
+    const handle = await startGateway({ port: 0, local: true, quiet });
+    expect(handle.owned).toBe(true);
+    return handle;
+  }
+
+  it("does not print the shutdown notice to stderr when quiet", async () => {
+    const handle = await startOwned(true);
+    const errSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    try {
+      await handle.shutdown();
+    } finally {
+      const printedShutdown = errSpy.mock.calls.some((args) =>
+        args.some((a) => typeof a === "string" && a.includes("Shutting down")),
+      );
+      errSpy.mockRestore();
+      expect(printedShutdown).toBe(false);
+    }
+  });
+
+  it("prints the shutdown notice to stderr when not quiet", async () => {
+    const handle = await startOwned(false);
+    const errSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    try {
+      await handle.shutdown();
+    } finally {
+      const printedShutdown = errSpy.mock.calls.some((args) =>
+        args.some((a) => typeof a === "string" && a.includes("Shutting down")),
+      );
+      errSpy.mockRestore();
+      expect(printedShutdown).toBe(true);
+    }
+  });
+});

--- a/packages/pi/src/index.ts
+++ b/packages/pi/src/index.ts
@@ -22,7 +22,7 @@
  *   pi install npm:@loreai/pi
  */
 import { createHash } from "node:crypto";
-import { getGitRemote, installFetchInterceptor } from "@loreai/core";
+import { getGitRemote, installFetchInterceptor, log } from "@loreai/core";
 import type {
   ExtensionAPI,
   SessionBeforeCompactEvent,
@@ -143,7 +143,7 @@ async function resolveGatewayUrl(): Promise<string | null> {
   if (process.env.LORE_REMOTE_URL) {
     const url = process.env.LORE_REMOTE_URL.replace(/\/$/, "");
     if (await probeGateway(url)) return url;
-    console.info(
+    log.info(
       `pi: remote gateway at ${url} not reachable, falling through to local discovery`,
     );
   }
@@ -196,13 +196,13 @@ async function startInProcess(): Promise<string | null> {
     const url = `http://127.0.0.1:${handle.port}`;
 
     if (!handle.owned) {
-      console.info(`pi: reusing existing gateway at ${url}`);
+      log.info(`pi: reusing existing gateway at ${url}`);
     }
 
     return url;
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
-    console.info("pi: failed to start gateway in-process:", msg);
+    log.warn("pi: failed to start gateway in-process:", msg);
     return null;
   }
 }
@@ -227,21 +227,28 @@ export default async function lorePiExtension(pi: ExtensionAPI): Promise<void> {
   let loreActive = false;
   const loreDisabled =
     process.env.LORE_DISABLED === "1" || process.env.LORE_DISABLED === "true";
-  const inTestEnv = process.env.NODE_ENV === "test";
+  // The extension is inert under `NODE_ENV=test` so unrelated package test
+  // suites don't accidentally probe/start a gateway. Tests that need the
+  // extension active set `LORE_PI_FORCE_ACTIVE=1` and point it at a controlled
+  // in-process gateway via `LORE_GATEWAY_URL`. This keeps `NODE_ENV=test` (so
+  // `log` stays file-suppressed and the DB stays isolated) while exercising the
+  // real wiring.
+  const inTestEnv =
+    process.env.NODE_ENV === "test" && process.env.LORE_PI_FORCE_ACTIVE !== "1";
 
   if (!loreDisabled && !inTestEnv) {
     // Try to find a running gateway first (probes port file + known ports).
     const existingUrl = await resolveGatewayUrl();
     if (existingUrl) {
-      console.info(`pi: gateway detected at ${existingUrl}`);
+      log.info(`pi: gateway detected at ${existingUrl}`);
       gatewayBase = existingUrl;
       loreActive = true;
     } else {
       // No running gateway — start one in-process (handles fallback chain).
-      console.info("pi: starting gateway in-process…");
+      log.info("pi: starting gateway in-process…");
       const startedUrl = await startInProcess();
       if (startedUrl) {
-        console.info(`pi: gateway started in-process at ${startedUrl}`);
+        log.info(`pi: gateway started in-process at ${startedUrl}`);
         gatewayBase = startedUrl;
         loreActive = true;
       }
@@ -252,13 +259,13 @@ export default async function lorePiExtension(pi: ExtensionAPI): Promise<void> {
     const msg =
       "Lore failed to start — memory features are unavailable. " +
       "Ensure @loreai/gateway is installed.";
-    console.error("pi:", msg);
+    log.error("pi:", msg);
     return;
   }
 
   if (!loreActive) return;
 
-  console.info(`pi: routing providers through ${gatewayBase}`);
+  log.info(`pi: routing providers through ${gatewayBase}`);
 
   // ---------------------------------------------------------------------------
   // Session tracking — used for provider header injection and compaction.
@@ -388,13 +395,13 @@ export default async function lorePiExtension(pi: ExtensionAPI): Promise<void> {
           // websocket-only transport that bypassed the gateway). That's not a
           // failure — log it quietly and let Pi's default compaction run.
           if (res.status === 404 && errBody.includes("session_not_found")) {
-            console.info(
+            log.info(
               "pi: lore compaction unavailable — this session was not routed " +
                 "through Lore; falling back to Pi compaction.",
             );
             return undefined;
           }
-          console.error(
+          log.warn(
             `pi: compaction endpoint returned ${res.status}: ${errBody}`,
           );
           return undefined;
@@ -411,10 +418,7 @@ export default async function lorePiExtension(pi: ExtensionAPI): Promise<void> {
           },
         };
       } catch (err) {
-        console.error(
-          "pi: custom compaction failed, falling back to default:",
-          err,
-        );
+        log.warn("pi: custom compaction failed, falling back to default:", err);
         return undefined;
       }
     },

--- a/packages/pi/test/no-tui-output.test.ts
+++ b/packages/pi/test/no-tui-output.test.ts
@@ -1,0 +1,155 @@
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  test,
+  vi,
+} from "vitest";
+import lorePiExtension from "../src/index";
+
+/**
+ * Regression test for the Pi TUI-corruption bug reported by Daniel Griesser
+ * (Slack, 2026-06-28): the extension "completely broke the output in the shell
+ * of Pi" because it wrote routine status through raw console.* calls. Pi runs a
+ * full-screen TUI, so ANY stdout/stderr write corrupts the rendered screen.
+ *
+ * The fix routes all routine/expected-fallback messages through the core `log`
+ * module (file-based, terminal-suppressed). This test pins that invariant:
+ * across extension load → session_start → a compaction that the gateway rejects
+ * with 404 `session_not_found` (Daniel's "couldn't find the session"), the
+ * extension must write NOTHING to stdout/stderr.
+ *
+ * Mutation check: revert any `console.*`→`log.*` change in src/index.ts and this
+ * test fails (the spied console method is called).
+ */
+
+type AnyHandler = (...args: unknown[]) => unknown;
+
+function createMockPi() {
+  const providers: Array<{ name: string; config: unknown }> = [];
+  const handlers = new Map<string, AnyHandler>();
+  const pi = {
+    registerProvider(name: string, config: unknown): void {
+      providers.push({ name, config });
+    },
+    on(event: string, handler: AnyHandler): void {
+      handlers.set(event, handler);
+    },
+  };
+  return { pi, providers, handlers };
+}
+
+describe("pi extension — no TUI (stdout/stderr) output", () => {
+  let server: Server;
+  let baseUrl: string;
+  const originalFetch = globalThis.fetch;
+  const originalEnv = { ...process.env };
+
+  beforeAll(async () => {
+    // Minimal fake gateway: healthy, but rejects compaction as a session that
+    // never routed through Lore — the exact path that used to dump to stdout.
+    server = createServer((req, res) => {
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
+      if (url.pathname === "/health") {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ status: "ok" }));
+        return;
+      }
+      if (url.pathname === "/v1/compact") {
+        res.writeHead(404, { "content-type": "application/json" });
+        res.end(
+          JSON.stringify({
+            error: "session_not_found",
+            message: "No active session found for the given headers.",
+          }),
+        );
+        return;
+      }
+      res.writeHead(404);
+      res.end("not found");
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  });
+
+  afterAll(async () => {
+    globalThis.fetch = originalFetch;
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    globalThis.fetch = originalFetch;
+  });
+
+  test("stays silent across load, session_start, and compaction-404", async () => {
+    // Activate the otherwise-inert-in-test extension against the fake gateway.
+    process.env.LORE_PI_FORCE_ACTIVE = "1";
+    process.env.LORE_GATEWAY_URL = baseUrl;
+    delete process.env.LORE_DISABLED;
+    delete process.env.LORE_REMOTE_URL;
+
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    const consoleSpies = (
+      ["log", "info", "warn", "error", "debug"] as const
+    ).map((method) =>
+      vi.spyOn(console, method).mockImplementation(() => undefined),
+    );
+
+    try {
+      const { pi, handlers } = createMockPi();
+
+      await lorePiExtension(
+        pi as unknown as Parameters<typeof lorePiExtension>[0],
+      );
+
+      // The extension must have wired up its hooks (i.e. it went active).
+      const onStart = handlers.get("session_start");
+      const onCompact = handlers.get("session_before_compact");
+      expect(onStart).toBeTypeOf("function");
+      expect(onCompact).toBeTypeOf("function");
+
+      // session_start: updates the session id and re-registers providers.
+      await onStart?.(
+        {} as never,
+        {
+          cwd: process.cwd(),
+          sessionManager: { getSessionFile: () => "/tmp/lore-pi-session" },
+        } as never,
+      );
+
+      // Compaction → gateway returns 404 session_not_found → graceful fallback.
+      const result = await onCompact?.(
+        {
+          preparation: {
+            previousSummary: "",
+            firstKeptEntryId: "entry-1",
+            tokensBefore: 100,
+          },
+        } as never,
+        {} as never,
+      );
+      expect(result).toBeUndefined();
+
+      // The whole point: zero raw terminal writes on success + fallback paths.
+      expect(stdoutSpy).not.toHaveBeenCalled();
+      expect(stderrSpy).not.toHaveBeenCalled();
+      for (const spy of consoleSpies) {
+        expect(spy).not.toHaveBeenCalled();
+      }
+    } finally {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+      for (const spy of consoleSpies) {
+        spy.mockRestore();
+      }
+    }
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
       "packages/core/test/**/*.test.ts",
       "packages/gateway/test/**/*.test.ts",
       "packages/opencode/test/**/*.test.ts",
+      "packages/pi/test/**/*.test.ts",
     ],
     // Preload test setup for DB isolation
     setupFiles: ["./packages/core/test/setup.ts"],


### PR DESCRIPTION
## Problem

A user (Daniel Griesser) tried Lore with the **Pi** coding agent and it "completely broke the output in the shell of Pi" — node errors and the `session_not_found` fallback dumping on every compaction, to the point it "bricked it kinda so had to remove it" (he was on Windows).

**Root cause:** the Pi extension wrote routine status through raw `console.info`/`console.error` (11 call sites). Pi runs a full-screen TUI, so *any* stdout/stderr write corrupts the rendered screen. The OpenCode plugin already routes through the core `log` module (file-based, terminal-suppressed) — the Pi extension was the outlier. Two amplifiers: the in-process gateway leaked its own notices (`startGateway` ignored its `quiet` flag), and `LORE_DEBUG=0` didn't actually silence the logger.

There were **zero tests** for `packages/pi/`, so none of this was caught.

## Changes

- **pi**: replace all `console.*` with `log.info`/`log.warn`/`log.error`. Routine and expected-fallback paths now write **nothing** to the terminal; only the fatal "Lore failed to start" stays visible (via `log.error`, matching the OpenCode plugin).
- **gateway**: make `startGateway` honor its `quiet` flag. In-process callers (Pi extension + OpenCode plugin) pass `quiet: true`, but `startGateway` still leaked startup/shutdown notices via `console.error` into the host TUI. Routed through `log` when quiet; the `lore start` CLI output is unchanged.
- **core**: fix `log.ts` `isDebug` parsing. `!!process.env.LORE_DEBUG` treated `LORE_DEBUG=0`/`false` as **enabled** (non-empty strings are truthy), so setting `LORE_DEBUG=0` to silence Lore still printed `[lore]` lines to stderr. Now matches the gateway config's `isTruthy` semantics (`"1"`/`"true"` only).

## Tests

- `packages/pi/test/no-tui-output.test.ts` — the regression that would have caught this: asserts **zero raw stdout/stderr/console writes** across extension load → `session_start` → a compaction the gateway rejects with `404 session_not_found`. Wires `packages/pi/test/**` into `vitest.config.ts`.
- `packages/gateway/test/start-gateway-quiet.test.ts` — `quiet:true` suppresses the shutdown notice; `quiet:false` still prints it (CLI preserved).
- Both are **mutation-verified** (revert the fix → the test fails).
- A test-only `LORE_PI_FORCE_ACTIVE` seam activates the otherwise-inert-in-test extension against a controlled in-process gateway.

Full suite: 4527 passed, 0 failures. New tests run 3× with no flakiness.

## Follow-ups (separate PRs)

- Broaden basic e2e/smoke coverage for opencode + pi (routing through a live in-process gateway).
- Wire the hermes (Python) plugin tests into CI.
- Windows hardening (idiomatic data dir; in-process gateway native-module robustness).