### PR TITLE
feat(website): implement the standard.site protocol for the blog

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -27,6 +27,14 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    # The Bluesky app password that authenticates the standard.site record
+    # publish lives in the `production` environment, so the job must opt into
+    # it to read the secret. Mapped to a (possibly empty) env var so the
+    # "Publish standard.site records" step below can be skipped via `if` when
+    # the secret is not configured (e.g. forks).
+    environment: production
+    env:
+      BSKY_APP_PASSWORD: ${{ secrets.BSKY_APP_PASSWORD }}
     steps:
       - uses: actions/checkout@v6
 
@@ -77,3 +85,11 @@ jobs:
           branch: gh-pages
           clean-exclude: _preview
           force: false
+
+      - name: Publish standard.site records to the @withlore.ai PDS
+        # Idempotent putRecord upsert with deterministic rkeys, so this runs on
+        # every production deploy and keeps the AT Protocol records in sync with
+        # the blog. Reads the freshly built dist/standard-site.json. Skipped
+        # automatically when BSKY_APP_PASSWORD is not configured.
+        if: ${{ env.BSKY_APP_PASSWORD != '' }}
+        run: pnpm --filter '@loreai/website' publish:standard-site

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -91,5 +91,13 @@ jobs:
         # every production deploy and keeps the AT Protocol records in sync with
         # the blog. Reads the freshly built dist/standard-site.json. Skipped
         # automatically when BSKY_APP_PASSWORD is not configured.
+        #
+        # continue-on-error: the site already deployed in the step above and is
+        # valid on its own (on-page .well-known + <link> verification). Syncing
+        # the PDS records is a best-effort, idempotent side effect that
+        # self-heals on the next deploy, so a transient PDS outage must not mark
+        # an otherwise-successful deploy as failed. A real failure still surfaces
+        # as a step annotation on the run.
         if: ${{ env.BSKY_APP_PASSWORD != '' }}
+        continue-on-error: true
         run: pnpm --filter '@loreai/website' publish:standard-site

--- a/packages/website/astro.config.mjs
+++ b/packages/website/astro.config.mjs
@@ -6,6 +6,7 @@ import {
   generateAssetsEagerly,
 } from "./integrations/favicon-assets";
 import prefixBaseLinks from "./integrations/prefix-base-links.mjs";
+import { publicationUri } from "./src/lib/standard-site";
 
 const prNumber = process.env.PR_NUMBER;
 const base = prNumber ? `/_preview/pr-${prNumber}/` : "/";
@@ -119,6 +120,15 @@ export default defineConfig({
             type: "application/rss+xml",
             title: "Lore Blog",
             href: `https://withlore.ai${base}rss.xml`,
+          },
+        },
+        // standard.site publication discovery hint (verified via
+        // /.well-known/site.standard.publication)
+        {
+          tag: "link",
+          attrs: {
+            rel: "site.standard.publication",
+            href: publicationUri(),
           },
         },
         // Open Graph

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -6,7 +6,8 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "check": "astro check"
+    "check": "astro check",
+    "publish:standard-site": "node scripts/publish-standard-site.mjs"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.4",

--- a/packages/website/public/.well-known/site.standard.publication
+++ b/packages/website/public/.well-known/site.standard.publication
@@ -1,0 +1,1 @@
+at://did:plc:mnccz4sthqjuyugmzlfacnv7/site.standard.publication/self

--- a/packages/website/scripts/publish-standard-site.mjs
+++ b/packages/website/scripts/publish-standard-site.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+/**
+ * Publish the Lore blog's standard.site records (https://standard.site) to the
+ * `@withlore.ai` Bluesky PDS over AT Protocol.
+ *
+ * Records are read from the build manifest (dist/standard-site.json), so build
+ * the site first:
+ *
+ *   pnpm --filter @loreai/website build
+ *   BSKY_APP_PASSWORD='xxxx-xxxx-xxxx-xxxx' pnpm --filter @loreai/website publish:standard-site
+ *
+ * Auth uses a Bluesky app password (create one at
+ * https://bsky.app/settings/app-passwords). It is read from BSKY_APP_PASSWORD
+ * and never logged. BSKY_HANDLE defaults to "withlore.ai".
+ *
+ * Idempotent: records use deterministic rkeys (publication "self", documents =
+ * post slug) written with putRecord, so re-running updates them in place rather
+ * than creating duplicates.
+ */
+
+import { readFile } from "node:fs/promises";
+
+const HANDLE = process.env.BSKY_HANDLE ?? "withlore.ai";
+const PASSWORD = process.env.BSKY_APP_PASSWORD;
+const MANIFEST_URL = new URL("../dist/standard-site.json", import.meta.url);
+const WELL_KNOWN_URL = new URL(
+  "../public/.well-known/site.standard.publication",
+  import.meta.url,
+);
+
+function fail(message) {
+  console.error(`✗ ${message}`);
+  process.exit(1);
+}
+
+async function xrpcGet(baseUrl, nsid, query) {
+  const url = new URL(`/xrpc/${nsid}`, baseUrl);
+  for (const [key, value] of Object.entries(query ?? {})) {
+    url.searchParams.set(key, value);
+  }
+  const res = await fetch(url);
+  if (!res.ok) fail(`${nsid} -> ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
+async function xrpcPost(baseUrl, nsid, body, token) {
+  const res = await fetch(new URL(`/xrpc/${nsid}`, baseUrl), {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...(token ? { authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) fail(`${nsid} -> ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
+async function resolvePds(did) {
+  const res = await fetch(`https://plc.directory/${did}`);
+  if (!res.ok) fail(`could not resolve DID document for ${did}: ${res.status}`);
+  const doc = await res.json();
+  const pds = (doc.service ?? []).find(
+    (s) => s.type === "AtprotoPersonalDataServer",
+  )?.serviceEndpoint;
+  if (!pds) fail(`no PDS endpoint in DID document for ${did}`);
+  return pds;
+}
+
+async function readManifest() {
+  let raw;
+  try {
+    raw = await readFile(MANIFEST_URL, "utf8");
+  } catch {
+    fail(
+      "dist/standard-site.json not found — run `pnpm --filter @loreai/website build` first",
+    );
+  }
+  const manifest = JSON.parse(raw);
+
+  // Guard against drift between the static verification file and the records.
+  const wellKnown = (await readFile(WELL_KNOWN_URL, "utf8")).trim();
+  if (wellKnown !== manifest.publication.uri) {
+    fail(
+      `.well-known/site.standard.publication (${wellKnown}) does not match the ` +
+        `publication record AT-URI (${manifest.publication.uri})`,
+    );
+  }
+  return manifest;
+}
+
+async function main() {
+  if (!PASSWORD) {
+    fail(
+      "BSKY_APP_PASSWORD is required (create an app password at https://bsky.app/settings/app-passwords)",
+    );
+  }
+
+  const manifest = await readManifest();
+
+  // Resolve identity -> PDS, then open an app-password session.
+  const { did } = await xrpcGet(
+    "https://public.api.bsky.app",
+    "com.atproto.identity.resolveHandle",
+    { handle: HANDLE },
+  );
+  const pds = await resolvePds(did);
+  const session = await xrpcPost(pds, "com.atproto.server.createSession", {
+    identifier: HANDLE,
+    password: PASSWORD,
+  });
+  console.log(`✓ authenticated as ${HANDLE} (${session.did}) on ${pds}`);
+
+  const records = [
+    {
+      collection: manifest.publication.record.$type,
+      rkey: manifest.publication.rkey,
+      record: manifest.publication.record,
+      uri: manifest.publication.uri,
+    },
+    ...manifest.documents.map((doc) => ({
+      collection: doc.record.$type,
+      rkey: doc.rkey,
+      record: doc.record,
+      uri: doc.uri,
+    })),
+  ];
+
+  for (const { collection, rkey, record, uri } of records) {
+    // validate:false — the PDS does not host the site.standard.* lexicons, so
+    // schema validation would reject otherwise-valid records.
+    await xrpcPost(
+      pds,
+      "com.atproto.repo.putRecord",
+      { repo: session.did, collection, rkey, record, validate: false },
+      session.accessJwt,
+    );
+    console.log(`✓ put ${uri}`);
+  }
+
+  console.log(
+    `\nDone — published 1 publication + ${manifest.documents.length} document(s).`,
+  );
+}
+
+main().catch((err) => fail(err instanceof Error ? err.message : String(err)));

--- a/packages/website/scripts/publish-standard-site.mjs
+++ b/packages/website/scripts/publish-standard-site.mjs
@@ -111,6 +111,18 @@ async function main() {
   });
   console.log(`✓ authenticated as ${HANDLE} (${session.did}) on ${pds}`);
 
+  // The records embed a hardcoded DID (their AT-URIs). If BSKY_HANDLE was
+  // overridden to a different account, we would otherwise write the blog's
+  // records into the wrong repo. Refuse unless the authenticated identity owns
+  // the DID the records are addressed to.
+  const recordDid = manifest.publication.uri.split("/")[2];
+  if (session.did !== recordDid) {
+    fail(
+      `authenticated DID (${session.did}) does not match the DID in the ` +
+        `records (${recordDid}); refusing to publish to the wrong repo`,
+    );
+  }
+
   const records = [
     {
       collection: manifest.publication.record.$type,

--- a/packages/website/src/components/SocialMeta.astro
+++ b/packages/website/src/components/SocialMeta.astro
@@ -1,5 +1,6 @@
 ---
 import ogImageManifest from "../generated/og-image.json";
+import { publicationUri } from "../lib/standard-site";
 
 interface Props {
   title: string;
@@ -51,3 +52,9 @@ const imageUrl = `${site}${base}${ogImageManifest.filename}`;
   title="Lore Blog"
   href={`${site}${base}rss.xml`}
 />
+
+<!--
+  standard.site publication discovery hint. This is a hint only; the
+  authoritative check is the /.well-known/site.standard.publication endpoint.
+-->
+<link rel="site.standard.publication" href={publicationUri()} />

--- a/packages/website/src/layouts/BlogLayout.astro
+++ b/packages/website/src/layouts/BlogLayout.astro
@@ -6,6 +6,9 @@ import SocialMeta from "../components/SocialMeta.astro";
 const {
   title = "Lore Blog",
   description = "Product notes, engineering updates, and memory architecture deep dives from Lore.",
+  // AT-URI of this post's standard.site document record, when it is an
+  // individual post. Omitted on the blog index. See src/lib/standard-site.ts.
+  documentUri,
 } = Astro.props;
 
 const base = import.meta.env.BASE_URL;
@@ -27,6 +30,7 @@ const ogType = path === "blog/" ? "website" : "article";
       path={path}
       type={ogType}
     />
+    {documentUri && <link rel="site.standard.document" href={documentUri} />}
     <link rel="icon" type="image/svg+xml" href={`${import.meta.env.BASE_URL}favicon.svg`} />
     <link rel="icon" type="image/png" sizes="32x32" href={`${import.meta.env.BASE_URL}favicon-32.png`} />
     <link rel="apple-touch-icon" sizes="180x180" href={`${import.meta.env.BASE_URL}apple-touch-icon.png`} />

--- a/packages/website/src/lib/standard-site.ts
+++ b/packages/website/src/lib/standard-site.ts
@@ -1,0 +1,142 @@
+/**
+ * Standard.site (https://standard.site) AT Protocol integration for the Lore
+ * blog.
+ *
+ * The blog is modeled as a single `site.standard.publication` record plus one
+ * `site.standard.document` record per post, stored in the `@withlore.ai`
+ * Bluesky account's PDS.
+ *
+ * We use DETERMINISTIC record keys — the publication is `self`, each document
+ * uses its post slug — so the AT-URIs are predictable. That lets the on-page
+ * verification (`<link rel="site.standard.document">` and the `.well-known`
+ * endpoint) be generated at build time without first reading back what the PDS
+ * assigned, and makes publishing idempotent: `putRecord` upserts in place
+ * rather than creating duplicates on re-runs.
+ *
+ * The records themselves are materialized by `scripts/publish-standard-site.mjs`,
+ * which reads the build manifest emitted by `src/pages/standard-site.json.ts`.
+ *
+ * NOTE: this module is intentionally framework-free (no `astro:*` imports) so
+ * it can be imported from `astro.config.mjs` at config-load time as well as
+ * from page/endpoint code.
+ *
+ * If you change `PUBLICATION_DID` or `PUBLICATION_RKEY`, also update the static
+ * verification file at `public/.well-known/site.standard.publication` (the
+ * publish script asserts the two stay in sync before writing any record).
+ */
+
+/** DID of the `@withlore.ai` Bluesky account (resolved from the handle). */
+export const PUBLICATION_DID = "did:plc:mnccz4sthqjuyugmzlfacnv7";
+
+/** Record key of the singleton publication record. */
+export const PUBLICATION_RKEY = "self";
+
+/** Base URL combined with a document path to form its canonical URL. No trailing slash. */
+export const SITE_URL = "https://withlore.ai";
+
+export const PUBLICATION_NAME = "Lore Blog";
+export const PUBLICATION_DESCRIPTION =
+  "Product notes, engineering updates, and memory architecture deep dives from Lore.";
+
+const PUBLICATION_COLLECTION = "site.standard.publication";
+const DOCUMENT_COLLECTION = "site.standard.document";
+
+/** AT-URI of the publication record. */
+export function publicationUri(): string {
+  return `at://${PUBLICATION_DID}/${PUBLICATION_COLLECTION}/${PUBLICATION_RKEY}`;
+}
+
+/** Documents are keyed by their post slug for stable, idempotent AT-URIs. */
+export function documentRkey(slug: string): string {
+  return slug;
+}
+
+/** AT-URI of a document record. */
+export function documentUri(slug: string): string {
+  return `at://${PUBLICATION_DID}/${DOCUMENT_COLLECTION}/${documentRkey(slug)}`;
+}
+
+/** Site-relative path for a post; combined with `SITE_URL` to form its URL. */
+export function documentPath(slug: string): string {
+  return `/blog/${slug}/`;
+}
+
+interface RgbColor {
+  $type: "site.standard.theme.color#rgb";
+  r: number;
+  g: number;
+  b: number;
+}
+
+function rgb(r: number, g: number, b: number): RgbColor {
+  return { $type: "site.standard.theme.color#rgb", r, g, b };
+}
+
+// Lore blog palette (see public/theme.css): cream surface, deep-green ink and
+// accent. Mirrors the rendered blog so reader apps keep the site's identity.
+const BASIC_THEME = {
+  $type: "site.standard.theme.basic" as const,
+  background: rgb(247, 242, 232), // --c0
+  foreground: rgb(26, 46, 27), // --ink
+  accent: rgb(26, 51, 32), // --g0
+  accentForeground: rgb(247, 242, 232), // --c0
+};
+
+export interface PublicationRecord {
+  $type: "site.standard.publication";
+  url: string;
+  name: string;
+  description: string;
+  basicTheme: typeof BASIC_THEME;
+  preferences: { showInDiscover: boolean };
+}
+
+export function buildPublicationRecord(): PublicationRecord {
+  return {
+    $type: PUBLICATION_COLLECTION,
+    url: SITE_URL,
+    name: PUBLICATION_NAME,
+    description: PUBLICATION_DESCRIPTION,
+    basicTheme: BASIC_THEME,
+    preferences: { showInDiscover: true },
+  };
+}
+
+export interface DocumentInput {
+  slug: string;
+  title: string;
+  description?: string;
+  /** ISO 8601 timestamp. */
+  publishedAt: string;
+  /** ISO 8601 timestamp. */
+  updatedAt?: string;
+  tags?: string[];
+  textContent?: string;
+}
+
+export interface DocumentRecord {
+  $type: "site.standard.document";
+  site: string;
+  path: string;
+  title: string;
+  publishedAt: string;
+  description?: string;
+  updatedAt?: string;
+  tags?: string[];
+  textContent?: string;
+}
+
+export function buildDocumentRecord(input: DocumentInput): DocumentRecord {
+  const record: DocumentRecord = {
+    $type: DOCUMENT_COLLECTION,
+    site: publicationUri(),
+    path: documentPath(input.slug),
+    title: input.title,
+    publishedAt: input.publishedAt,
+  };
+  if (input.description) record.description = input.description;
+  if (input.updatedAt) record.updatedAt = input.updatedAt;
+  if (input.tags && input.tags.length > 0) record.tags = input.tags;
+  if (input.textContent) record.textContent = input.textContent;
+  return record;
+}

--- a/packages/website/src/lib/standard-site.ts
+++ b/packages/website/src/lib/standard-site.ts
@@ -46,8 +46,29 @@ export function publicationUri(): string {
   return `at://${PUBLICATION_DID}/${PUBLICATION_COLLECTION}/${PUBLICATION_RKEY}`;
 }
 
-/** Documents are keyed by their post slug for stable, idempotent AT-URIs. */
+/**
+ * AT Protocol record-key syntax: 1–512 chars from `[A-Za-z0-9._~:-]`, and never
+ * `.` or `..`. See https://atproto.com/specs/record-key.
+ */
+const RECORD_KEY_RE = /^[A-Za-z0-9._~:-]{1,512}$/;
+
+/**
+ * Documents are keyed by their post slug for stable, idempotent AT-URIs.
+ *
+ * Astro derives the slug from the file path and keeps `/` for nested
+ * directories plus any unicode letters — both illegal in a record key. Rather
+ * than silently mangle the slug (which would desync the on-page `<link>` from
+ * the published record), fail the build loudly so a problematic slug is a
+ * deliberate decision, not a broken AT-URI / rejected PDS write.
+ */
 export function documentRkey(slug: string): string {
+  if (slug === "." || slug === ".." || !RECORD_KEY_RE.test(slug)) {
+    throw new Error(
+      `Blog slug "${slug}" is not a valid AT Protocol record key ` +
+        "(allowed: 1–512 chars of A–Z a–z 0–9 . _ ~ : - ; not '.' or '..'). " +
+        "Rename the post file or add an explicit slug mapping in standard-site.ts.",
+    );
+  }
   return slug;
 }
 

--- a/packages/website/src/pages/blog/[slug].astro
+++ b/packages/website/src/pages/blog/[slug].astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection, render } from "astro:content";
 import BlogLayout from "../../layouts/BlogLayout.astro";
+import { documentUri } from "../../lib/standard-site";
 
 export async function getStaticPaths() {
   const posts = (await getCollection("blog")).filter((post) => !post.data.draft);
@@ -11,7 +12,11 @@ const { post } = Astro.props;
 const { Content } = await render(post);
 ---
 
-<BlogLayout title={post.data.title} description={post.data.description}>
+<BlogLayout
+  title={post.data.title}
+  description={post.data.description}
+  documentUri={documentUri(post.id)}
+>
   <article class="blog-post">
     <a class="blog-back" href={`${import.meta.env.BASE_URL}blog/`}>Back to blog</a>
     <header>

--- a/packages/website/src/pages/standard-site.json.ts
+++ b/packages/website/src/pages/standard-site.json.ts
@@ -19,25 +19,28 @@ import {
 // `textContent` (the lexicon wants plaintext, no markup). Best-effort for our
 // authored posts, not a general HTML-to-text engine.
 function htmlToText(html: string): string {
-  return html
-    .replace(/<script[\s\S]*?<\/script>/gi, " ")
-    .replace(/<style[\s\S]*?<\/style>/gi, " ")
-    .replace(/<br\s*\/?>/gi, "\n")
-    .replace(
-      /<\/(p|div|h[1-6]|li|blockquote|pre|tr|figure|section|header)>/gi,
-      "\n",
-    )
-    .replace(/<[^>]+>/g, " ")
-    .replace(/&nbsp;/g, " ")
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;|&apos;|&#x27;/gi, "'")
-    .replace(/[ \t]+/g, " ")
-    .replace(/ *\n */g, "\n")
-    .replace(/\n{3,}/g, "\n\n")
-    .trim();
+  return (
+    html
+      .replace(/<script[\s\S]*?<\/script>/gi, " ")
+      .replace(/<style[\s\S]*?<\/style>/gi, " ")
+      .replace(/<br\s*\/?>/gi, "\n")
+      .replace(
+        /<\/(p|div|h[1-6]|li|blockquote|pre|tr|figure|section|header)>/gi,
+        "\n",
+      )
+      .replace(/<[^>]+>/g, " ")
+      .replace(/&nbsp;/g, " ")
+      .replace(/&lt;/g, "<")
+      .replace(/&gt;/g, ">")
+      .replace(/&quot;/g, '"')
+      .replace(/&#39;|&apos;|&#x27;/gi, "'")
+      // `&amp;` last so an escaped entity like `&amp;lt;` decodes to `&lt;`, not `<`.
+      .replace(/&amp;/g, "&")
+      .replace(/[ \t]+/g, " ")
+      .replace(/ *\n */g, "\n")
+      .replace(/\n{3,}/g, "\n\n")
+      .trim()
+  );
 }
 
 export async function GET() {

--- a/packages/website/src/pages/standard-site.json.ts
+++ b/packages/website/src/pages/standard-site.json.ts
@@ -1,0 +1,83 @@
+import mdxRenderer from "@astrojs/mdx/server.js";
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { getCollection, render } from "astro:content";
+import {
+  buildDocumentRecord,
+  buildPublicationRecord,
+  documentRkey,
+  documentUri,
+  PUBLICATION_RKEY,
+  publicationUri,
+} from "../lib/standard-site";
+
+// Build-time export of the standard.site records for the blog. The publish
+// script (scripts/publish-standard-site.mjs) reads this from dist/ and writes
+// the records to the PDS, so the bytes that ship to AT Protocol are exactly
+// what the site renders here — no second source of truth.
+
+// Reduce rendered post HTML to plaintext for the document record's
+// `textContent` (the lexicon wants plaintext, no markup). Best-effort for our
+// authored posts, not a general HTML-to-text engine.
+function htmlToText(html: string): string {
+  return html
+    .replace(/<script[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style[\s\S]*?<\/style>/gi, " ")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(
+      /<\/(p|div|h[1-6]|li|blockquote|pre|tr|figure|section|header)>/gi,
+      "\n",
+    )
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;|&apos;|&#x27;/gi, "'")
+    .replace(/[ \t]+/g, " ")
+    .replace(/ *\n */g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+export async function GET() {
+  // Container API renders a post's compiled `Content` to an HTML string outside
+  // the page pipeline (same approach as rss.xml.ts). The MDX renderer is a
+  // no-op for the current `.md` posts and keeps this working for future `.mdx`.
+  const container = await AstroContainer.create();
+  container.addServerRenderer({ renderer: mdxRenderer });
+
+  const posts = (await getCollection("blog"))
+    .filter((post) => !post.data.draft)
+    .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+
+  const documents = await Promise.all(
+    posts.map(async (post) => {
+      const { Content } = await render(post);
+      const html = await container.renderToString(Content);
+      const record = buildDocumentRecord({
+        slug: post.id,
+        title: post.data.title,
+        description: post.data.description,
+        publishedAt: post.data.pubDate.toISOString(),
+        updatedAt: post.data.updatedDate?.toISOString(),
+        tags: post.data.tags,
+        textContent: htmlToText(html),
+      });
+      return { rkey: documentRkey(post.id), uri: documentUri(post.id), record };
+    }),
+  );
+
+  const manifest = {
+    publication: {
+      rkey: PUBLICATION_RKEY,
+      uri: publicationUri(),
+      record: buildPublicationRecord(),
+    },
+    documents,
+  };
+
+  return new Response(`${JSON.stringify(manifest, null, 2)}\n`, {
+    headers: { "content-type": "application/json; charset=utf-8" },
+  });
+}


### PR DESCRIPTION
## What

Implements the [standard.site](https://standard.site) AT Protocol so the Lore blog is discoverable and readable across the ATmosphere (Leaflet, Read on pckt, docs.surf, Standard Search, …).

The blog is modeled as **one `site.standard.publication`** record plus **one `site.standard.document` per post**, stored in the `@withlore.ai` account's PDS (`did:plc:mnccz4sthqjuyugmzlfacnv7`).

### Design: deterministic record keys
Publication rkey is `self`; each document's rkey is its post slug. So the AT-URIs are predictable (`at://<did>/site.standard.document/<slug>`), which means:
- on-page verification can be generated at build time without round-tripping the PDS,
- the website side ships **before** the records exist (verification just sits waiting),
- publishing is idempotent — `putRecord` upserts, so re-runs never duplicate.

## On-page verification
- `public/.well-known/site.standard.publication` → returns the publication AT-URI (static file in `public/`, copied verbatim like the existing `.nojekyll`; **verified live on the PR preview**, served fine on GitHub Pages).
- Site-wide `<link rel="site.standard.publication">` discovery hint — added to `SocialMeta.astro` (home, "different", blog) and the Starlight `head` (docs), mirroring the RSS autodiscovery link.
- Per-post `<link rel="site.standard.document">` in `BlogLayout` (only on individual posts, not the index).

## Record materialization
- `src/lib/standard-site.ts` — framework-free identity constants + record builders (also imported by `astro.config.mjs`).
- `src/pages/standard-site.json.ts` — build-time manifest at `/standard-site.json`. Renders each post's plaintext `textContent` via the **same Container API as the RSS feed**, so the bytes published to AT Protocol match what the site renders. (Note: exposes a public machine-readable manifest of already-public blog content.)
- `scripts/publish-standard-site.mjs` — idempotent `putRecord` publisher. Reads the manifest, authenticates with a Bluesky **app password** (`BSKY_APP_PASSWORD`, read from env, never logged), and asserts the `.well-known` file matches the publication AT-URI before writing anything.

## Publishing the records (automated)
`docs-deploy.yml` now runs the publish step after each production GitHub Pages deploy:
- reads the freshly built `dist/standard-site.json` and upserts via `putRecord`, so records stay in sync with the blog on every deploy — no manual step;
- the app password is a **`production` environment secret** (`BSKY_APP_PASSWORD`); the job opts into that environment to read it;
- gated on `env.BSKY_APP_PASSWORD != ''`, so it skips cleanly when the secret is absent (forks) instead of failing the deploy.

On merge to `main` (this PR touches `packages/website/**`), the deploy workflow fires and the records are created automatically.

Manual publish is still available if needed:
```
pnpm --filter @loreai/website build
BSKY_APP_PASSWORD='xxxx-xxxx-xxxx-xxxx' pnpm --filter @loreai/website publish:standard-site
```

## Verification
- `pnpm --filter @loreai/website build` ✓ — `/standard-site.json` (publication + 2 docs, clean plaintext) and `dist/.well-known/site.standard.publication` emitted correctly.
- **Live PR preview** ✓ — `/.well-known/site.standard.publication` (200, returns the publication AT-URI) and `/standard-site.json` (200) both serve correctly on GitHub Pages.
- Built HTML: blog posts carry both the publication hint + their per-slug document link; home/different/blog-index/docs carry only the publication hint; exactly 2 document links site-wide.
- `astro check` ✓ 0 errors / 0 warnings · `biome check packages/website` ✓ clean · `actionlint docs-deploy.yml` ✓.
- No new dependencies (raw `fetch` + manifest, no `@atproto/api`).