### PR TITLE
test(pi,opencode): basic e2e tests for the plugin adapters

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -161,6 +161,26 @@ function reapStaleProjectState(): void {
 /** Memoized lore init promise — ensures concurrent plugin calls don't race. */
 let loreInitPromise: Promise<string | null> | null = null;
 
+/**
+ * Whether the plugin should stay inert (skip gateway probe/start and the
+ * process-wide fetch interceptor). True under test runners — `NODE_ENV=test`
+ * or a `.test.` argv entry — so unrelated package suites don't accidentally
+ * spin up a gateway or patch `globalThis.fetch`.
+ *
+ * Tests that need the active discovery → interceptor → routing path set
+ * `LORE_OPENCODE_FORCE_ACTIVE=1` and point the plugin at a controlled
+ * in-process gateway via `LORE_GATEWAY_URL`. The force flag keeps
+ * `NODE_ENV=test` (so `log` stays file-suppressed and the DB isolated) while
+ * exercising the real wiring. Mirrors the Pi extension's `LORE_PI_FORCE_ACTIVE`.
+ */
+function isInertTestEnv(): boolean {
+  if (process.env.LORE_OPENCODE_FORCE_ACTIVE === "1") return false;
+  return (
+    process.env.NODE_ENV === "test" ||
+    process.argv.some((a) => a.includes(".test."))
+  );
+}
+
 export const LorePlugin: Plugin = async (ctx) => {
   // Initialize lore — only probe/start once per process.
   const loreDisabled =
@@ -168,9 +188,7 @@ export const LorePlugin: Plugin = async (ctx) => {
   let loreActive = processLoreActive;
   let gatewayBase = processLoreBase;
   if (!processInitDone) {
-    const inTestEnv =
-      process.env.NODE_ENV === "test" ||
-      process.argv.some((a) => a.includes(".test."));
+    const inTestEnv = isInertTestEnv();
 
     if (!loreDisabled && !inTestEnv) {
       // Memoize so concurrent LorePlugin calls don't race on probe→spawn.
@@ -203,9 +221,7 @@ export const LorePlugin: Plugin = async (ctx) => {
   }
 
   if (!loreActive && !loreDisabled) {
-    const inTestEnv =
-      process.env.NODE_ENV === "test" ||
-      process.argv.some((a) => a.includes(".test."));
+    const inTestEnv = isInertTestEnv();
     if (!inTestEnv) {
       const base = "Lore failed to start — memory features are unavailable.";
       const msg = lastGatewayStartError
@@ -386,8 +402,12 @@ export const LorePlugin: Plugin = async (ctx) => {
             return headers;
           },
         });
-        process.stderr.write(`[lore] routing through ${gatewayBase}\n`);
-        process.stderr.write(`[lore] dashboard: ${gatewayBase}/ui\n`);
+        // Suppressed in test env (mirrors the `[lore] active:` banner above)
+        // so the force-active e2e path doesn't pollute vitest output.
+        if (process.env.NODE_ENV !== "test") {
+          process.stderr.write(`[lore] routing through ${gatewayBase}\n`);
+          process.stderr.write(`[lore] dashboard: ${gatewayBase}/ui\n`);
+        }
       }
 
       processInitDone = true;

--- a/packages/opencode/test/routing.e2e.test.ts
+++ b/packages/opencode/test/routing.e2e.test.ts
@@ -1,0 +1,186 @@
+/**
+ * End-to-end test: the OpenCode plugin's routing config against a REAL
+ * in-process Lore gateway (upstream mocked — no real API call).
+ *
+ * Proves that:
+ *   - `applyLoreProviderConfig` pins a provider's `options.baseURL` to the
+ *     gateway, and
+ *   - the gateway actually serves `/v1/messages` and returns a response when
+ *     called with the `x-lore-*` headers the plugin's `chat.headers` hook
+ *     injects.
+ *
+ * Complements the existing config-hook units (index.test.ts), per-project
+ * header units (session-state.test.ts), and the gateway startup smoke test
+ * (gateway-smoke.test.ts).
+ */
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import type { Hooks, PluginInput } from "@opencode-ai/plugin";
+import { LorePlugin } from "../src/index";
+import { applyLoreProviderConfig } from "../src/internal";
+
+function createMockClient() {
+  return {
+    tui: { showToast: () => Promise.resolve() },
+    session: {
+      get: () => Promise.resolve({ data: {} }),
+      list: () => Promise.resolve({ data: [] }),
+      create: () => Promise.resolve({ data: { id: "worker_1" } }),
+      messages: () => Promise.resolve({ data: [] }),
+      message: () => Promise.resolve({ data: null }),
+      prompt: () => Promise.resolve({ data: {} }),
+    },
+  } as unknown as PluginInput["client"];
+}
+
+function cannedAnthropicResponse(text: string): Response {
+  return new Response(
+    JSON.stringify({
+      id: "msg_oc_e2e_0",
+      type: "message",
+      role: "assistant",
+      content: [{ type: "text", text }],
+      model: "claude-sonnet-4-20250514",
+      stop_reason: "end_turn",
+      stop_sequence: null,
+      usage: { input_tokens: 100, output_tokens: 10 },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+describe("opencode plugin — e2e routing against a real gateway", () => {
+  let baseURL: string;
+  let stopServer: () => void;
+  let hooks: Hooks;
+  let upstreamCalls = 0;
+
+  beforeAll(async () => {
+    const gwPkg = "@loreai/gateway";
+    const gw = (await import(gwPkg)) as unknown as {
+      loadConfig: () => { port: number } & Record<string, unknown>;
+      startServer: (c: unknown) => Promise<{ stop: () => void; port: number }>;
+      resetPipelineState: () => Promise<void>;
+    };
+    const { close: closeDB } = (await import("@loreai/core")) as unknown as {
+      close: () => void;
+    };
+    const { setUpstreamInterceptor } = (await import(
+      "../../gateway/src/pipeline"
+    )) as unknown as {
+      setUpstreamInterceptor: (
+        fn:
+          | ((
+              body: unknown,
+              model: string,
+              streaming: boolean,
+              makeReal: () => Promise<Response>,
+            ) => Promise<Response>)
+          | undefined,
+      ) => void;
+    };
+
+    closeDB();
+    await gw.resetPipelineState();
+    setUpstreamInterceptor(async () => {
+      upstreamCalls += 1;
+      return cannedAnthropicResponse("hello from mock upstream");
+    });
+
+    const config = gw.loadConfig();
+    config.port = 0;
+    config.hosts = ["127.0.0.1"];
+    const server = await gw.startServer(config);
+    stopServer = () => server.stop();
+    baseURL = `http://127.0.0.1:${server.port}`;
+
+    hooks = await LorePlugin({
+      client: createMockClient(),
+      project: { id: "proj-e2e" } as unknown as PluginInput["project"],
+      directory: process.cwd(),
+      worktree: process.cwd(),
+      serverUrl: new URL("http://localhost:0"),
+      $: {} as unknown as PluginInput["$"],
+    } as PluginInput);
+  });
+
+  afterAll(async () => {
+    stopServer?.();
+    // Mirror the gateway harness teardown so no pipeline timers / interceptor
+    // state leak into other tests sharing this worker.
+    try {
+      const { setUpstreamInterceptor, resetPipelineState } = (await import(
+        "../../gateway/src/pipeline"
+      )) as unknown as {
+        setUpstreamInterceptor: (fn: undefined) => void;
+        resetPipelineState: (opts?: { fast?: boolean }) => Promise<void>;
+      };
+      const { close: closeDB } = (await import("@loreai/core")) as unknown as {
+        close: () => void;
+      };
+      setUpstreamInterceptor(undefined);
+      closeDB();
+      await resetPipelineState({ fast: true });
+    } catch {
+      /* best-effort */
+    }
+  });
+
+  test("applyLoreProviderConfig pins provider baseURL to the gateway /v1", () => {
+    const cfg: Record<string, unknown> = {
+      provider: { anthropic: { options: { apiKey: "x" } } },
+    };
+    applyLoreProviderConfig(cfg, baseURL);
+    const provider = (
+      cfg.provider as Record<string, { options: { baseURL: string } }>
+    ).anthropic;
+    expect(provider.options.baseURL).toBe(`${baseURL}/v1`);
+    // Existing options are preserved.
+    expect((provider.options as unknown as { apiKey: string }).apiKey).toBe(
+      "x",
+    );
+  });
+
+  test("chat.headers injects x-lore attribution headers", async () => {
+    const input = {
+      sessionID: "oc-sess-1",
+      agent: "build",
+      model: { providerID: "anthropic", modelID: "claude-3-5-sonnet" },
+      provider: { id: "anthropic" },
+      message: { id: "msg-1" },
+    } as unknown as Parameters<NonNullable<Hooks["chat.headers"]>>[0];
+    const output = { headers: {} as Record<string, string> } as Parameters<
+      NonNullable<Hooks["chat.headers"]>
+    >[1];
+
+    await hooks["chat.headers"]?.(input, output);
+    expect(output.headers["x-lore-session-id"]).toBe("oc-sess-1");
+    expect(output.headers["x-lore-agent"]).toBe("build");
+    expect(output.headers["x-lore-provider"]).toBe("anthropic");
+  });
+
+  test("the gateway serves /v1/messages and returns the mocked response", async () => {
+    const res = await fetch(`${baseURL}/v1/messages`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": "test-key",
+        "anthropic-version": "2023-06-01",
+        "x-lore-session-id": "oc-sess-1",
+        "x-lore-agent": "build",
+        "x-lore-provider": "anthropic",
+        "x-lore-project": process.cwd(),
+      },
+      body: JSON.stringify({
+        model: "claude-sonnet-4-20250514",
+        max_tokens: 64,
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+    expect(res.ok).toBe(true);
+    const body = (await res.json()) as {
+      content: Array<{ type: string; text: string }>;
+    };
+    expect(body.content[0].text).toBe("hello from mock upstream");
+    expect(upstreamCalls).toBeGreaterThan(0);
+  });
+});

--- a/packages/opencode/test/routing.e2e.test.ts
+++ b/packages/opencode/test/routing.e2e.test.ts
@@ -1,22 +1,35 @@
 /**
- * End-to-end test: the OpenCode plugin's routing config against a REAL
+ * End-to-end test: the OpenCode plugin's REAL active path against a REAL
  * in-process Lore gateway (upstream mocked — no real API call).
  *
- * Proves that:
- *   - `applyLoreProviderConfig` pins a provider's `options.baseURL` to the
- *     gateway, and
- *   - the gateway actually serves `/v1/messages` and returns a response when
- *     called with the `x-lore-*` headers the plugin's `chat.headers` hook
- *     injects.
+ * Unlike the config-hook units (index.test.ts) and per-project header units
+ * (session-state.test.ts) — which run with the plugin inert under
+ * `NODE_ENV=test` — this test forces the plugin active via
+ * `LORE_OPENCODE_FORCE_ACTIVE=1` and points it at a controlled gateway via
+ * `LORE_GATEWAY_URL`, then proves the wiring the whole #1036/#1039 series
+ * exists to guard:
+ *   1. the plugin DISCOVERS the gateway (gatewayBase is resolved, not ""),
+ *      so its `config` hook actually pins provider baseURLs to it,
+ *   2. the `chat.headers` hook injects the `x-lore-*` attribution headers, and
+ *   3. the process-wide fetch interceptor it installs transparently reroutes a
+ *      provider call (`api.anthropic.com`) through the gateway to the upstream.
  *
- * Complements the existing config-hook units (index.test.ts), per-project
- * header units (session-state.test.ts), and the gateway startup smoke test
- * (gateway-smoke.test.ts).
+ * If discovery or interceptor install regressed, gatewayBase would stay "" and
+ * `applyLoreProviderConfig` would no-op (test 1 fails) and `globalThis.fetch`
+ * would stay un-patched so the provider call would escape to the real network
+ * (test 3 fails) — i.e. these assertions are non-vacuous against the failure
+ * mode this series guards.
  */
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import type { Hooks, PluginInput } from "@opencode-ai/plugin";
 import { LorePlugin } from "../src/index";
-import { applyLoreProviderConfig } from "../src/internal";
+
+// Capture the pristine fetch BEFORE the plugin installs its interceptor so we
+// can restore it in afterAll. The interceptor patches `globalThis.fetch`
+// process-wide; leaving it patched would corrupt every other test in this
+// worker. (The plugin only installs once per process and never under
+// NODE_ENV=test unless LORE_OPENCODE_FORCE_ACTIVE=1.)
+const originalFetch = globalThis.fetch;
 
 function createMockClient() {
   return {
@@ -53,6 +66,8 @@ describe("opencode plugin — e2e routing against a real gateway", () => {
   let stopServer: () => void;
   let hooks: Hooks;
   let upstreamCalls = 0;
+  // Snapshot the env vars we mutate so we restore the process exactly.
+  const savedEnv: Record<string, string | undefined> = {};
 
   beforeAll(async () => {
     const gwPkg = "@loreai/gateway";
@@ -93,6 +108,22 @@ describe("opencode plugin — e2e routing against a real gateway", () => {
     stopServer = () => server.stop();
     baseURL = `http://127.0.0.1:${server.port}`;
 
+    // Force the plugin's ACTIVE path while keeping NODE_ENV=test, and point
+    // discovery at the gateway we just started. Clearing the remote/disabled
+    // vars guarantees discovery resolves to LORE_GATEWAY_URL deterministically.
+    for (const key of [
+      "LORE_OPENCODE_FORCE_ACTIVE",
+      "LORE_GATEWAY_URL",
+      "LORE_REMOTE_URL",
+      "LORE_DISABLED",
+    ]) {
+      savedEnv[key] = process.env[key];
+    }
+    process.env.LORE_OPENCODE_FORCE_ACTIVE = "1";
+    process.env.LORE_GATEWAY_URL = baseURL;
+    delete process.env.LORE_REMOTE_URL;
+    delete process.env.LORE_DISABLED;
+
     hooks = await LorePlugin({
       client: createMockClient(),
       project: { id: "proj-e2e" } as unknown as PluginInput["project"],
@@ -105,6 +136,14 @@ describe("opencode plugin — e2e routing against a real gateway", () => {
 
   afterAll(async () => {
     stopServer?.();
+    // Restore the pristine fetch the plugin's interceptor patched — otherwise
+    // every later test in this worker routes through a now-dead gateway.
+    globalThis.fetch = originalFetch;
+    // Restore env vars exactly as they were.
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
     // Mirror the gateway harness teardown so no pipeline timers / interceptor
     // state leak into other tests sharing this worker.
     try {
@@ -125,19 +164,32 @@ describe("opencode plugin — e2e routing against a real gateway", () => {
     }
   });
 
-  test("applyLoreProviderConfig pins provider baseURL to the gateway /v1", () => {
+  test("the plugin discovered the gateway and installed the fetch interceptor", () => {
+    // If discovery/interceptor-install regressed, the plugin would have stayed
+    // inert (gatewayBase "") and never patched fetch.
+    expect(globalThis.fetch).not.toBe(originalFetch);
+  });
+
+  test("the plugin's config hook pins provider baseURL to the discovered gateway", async () => {
     const cfg: Record<string, unknown> = {
       provider: { anthropic: { options: { apiKey: "x" } } },
     };
-    applyLoreProviderConfig(cfg, baseURL);
+    // Drive the REAL plugin hook (not applyLoreProviderConfig directly): this
+    // only pins a baseURL if the plugin actually resolved gatewayBase via
+    // discovery. An inert plugin (gatewayBase "") would no-op and leave the
+    // user's provider config untouched.
+    await hooks.config?.(cfg);
     const provider = (
-      cfg.provider as Record<string, { options: { baseURL: string } }>
+      cfg.provider as Record<
+        string,
+        { options: { baseURL: string; apiKey: string } }
+      >
     ).anthropic;
     expect(provider.options.baseURL).toBe(`${baseURL}/v1`);
-    // Existing options are preserved.
-    expect((provider.options as unknown as { apiKey: string }).apiKey).toBe(
-      "x",
-    );
+    // Existing user options are preserved through the merge.
+    expect(provider.options.apiKey).toBe("x");
+    // And built-in compaction is disabled by the same hook.
+    expect(cfg.compaction).toEqual({ auto: false, prune: false });
   });
 
   test("chat.headers injects x-lore attribution headers", async () => {
@@ -158,8 +210,14 @@ describe("opencode plugin — e2e routing against a real gateway", () => {
     expect(output.headers["x-lore-provider"]).toBe("anthropic");
   });
 
-  test("the gateway serves /v1/messages and returns the mocked response", async () => {
-    const res = await fetch(`${baseURL}/v1/messages`, {
+  test("the installed interceptor reroutes a provider call through the gateway to the upstream", async () => {
+    const before = upstreamCalls;
+    // A bare provider call (as the @ai-sdk would make) to a REMOTE host. The
+    // interceptor the plugin installed rewrites api.anthropic.com → gateway,
+    // which forwards to the mocked upstream. The x-lore-* headers mimic what
+    // chat.headers would have attached on a real turn (the interceptor
+    // preserves all original headers and adds x-lore-upstream-url).
+    const res = await fetch("https://api.anthropic.com/v1/messages", {
       method: "POST",
       headers: {
         "content-type": "application/json",
@@ -181,6 +239,8 @@ describe("opencode plugin — e2e routing against a real gateway", () => {
       content: Array<{ type: string; text: string }>;
     };
     expect(body.content[0].text).toBe("hello from mock upstream");
-    expect(upstreamCalls).toBeGreaterThan(0);
+    // The call to the remote provider host was rerouted to the in-process
+    // gateway (not the real network), which hit the mocked upstream.
+    expect(upstreamCalls).toBeGreaterThan(before);
   });
 });

--- a/packages/pi/src/index.ts
+++ b/packages/pi/src/index.ts
@@ -14,206 +14,37 @@
  * and becomes inert — no hooks are registered and Pi runs without
  * memory features.
  *
+ * Routine status is logged through the core `log` module (file-based,
+ * terminal-suppressed) — NEVER via console/stdout/stderr — because Pi
+ * runs a full-screen TUI that any raw terminal write would corrupt.
+ *
  * Installation (in user's `~/.pi/agent/extensions/`):
  *   import lore from "@loreai/pi";
  *   export default lore;
  *
  * Or as a Pi package:
  *   pi install npm:@loreai/pi
+ *
+ * Pure/testable logic (gateway discovery, provider-registration shaping,
+ * session-id derivation, the compaction request) lives in `./internal.ts`.
  */
-import { createHash } from "node:crypto";
 import { getGitRemote, installFetchInterceptor, log } from "@loreai/core";
 import type {
   ExtensionAPI,
   SessionBeforeCompactEvent,
   SessionStartEvent,
 } from "@earendil-works/pi-coding-agent";
-
-// Pi doesn't re-export these event result types at the top level — inline their
-// minimal shape here to avoid depending on an internal package path.
-type SessionBeforeCompactResult = {
-  cancel?: boolean;
-  compaction?: {
-    summary: string;
-    firstKeptEntryId: string;
-    tokensBefore: number;
-    details?: unknown;
-  };
-};
-
-/**
- * Providers whose wire protocol the Lore gateway can proxy, split by SDK
- * protocol so we can set the correct `baseUrl` for each group.
- *
- * - Anthropic SDK appends `/v1/messages` to baseURL → pass gateway root.
- * - OpenAI SDK appends `/chat/completions` or `/responses` to baseURL
- *   and expects it to already include `/v1` → pass `${gateway}/v1`.
- *
- * Providers using other protocols (Google SDK, AWS Bedrock SDK,
- * Mistral conversations) are not redirected.
- *
- * For local/self-hosted providers, set `LORE_UPSTREAM_<PROVIDER>=<url>`
- * (e.g. `LORE_UPSTREAM_VLLM=http://localhost:8000`) so the gateway knows
- * where to forward requests. Cloud providers are routed automatically by
- * model name prefix.
- */
-
-/** Anthropic-messages API → gateway POST /v1/messages */
-const ANTHROPIC_PROVIDERS = [
-  "anthropic",
-  "fireworks",
-  "minimax",
-  "minimax-cn",
-  "kimi-coding",
-] as const;
-
-/** OpenAI-completions / OpenAI-responses API → gateway POST /v1/chat/completions or /v1/responses */
-const OPENAI_PROVIDERS = [
-  // openai-completions API
-  "github-copilot",
-  "deepseek",
-  "xai",
-  "groq",
-  "cerebras",
-  "openrouter",
-  "huggingface",
-  "zai",
-  "opencode",
-  "opencode-go",
-  "vercel-ai-gateway",
-  // openai-responses API
-  "openai",
-  // Codex (ChatGPT) — OpenAI Responses wire format. Registered with the
-  // standard `${gatewayBase}/v1` baseUrl; the Codex provider appends
-  // `/codex/responses` itself, landing on the gateway's `/v1/codex/responses`
-  // route. The Codex WSS attempt targets the same baseUrl and is rejected by
-  // the HTTP-only gateway, so Pi falls back to SSE through Lore (no bypass).
-  "openai-codex",
-  // Local / self-hosted (OpenAI-compatible)
-  "vllm",
-  "llamacpp",
-  "ollama",
-  "lmstudio",
-  "jan",
-  "localai",
-  "tgi",
-  "tabbyml",
-  "litellm",
-] as const;
-
-/** All providers that can be routed through the gateway. */
-const GATEWAY_PROVIDERS: readonly string[] = [
-  ...ANTHROPIC_PROVIDERS,
-  ...OPENAI_PROVIDERS,
-];
-
-/** Default ports to probe when looking for a running gateway (must match gateway defaults). */
-const KNOWN_GATEWAY_PORTS = [3207, 5673];
+import {
+  buildProviderRegistrations,
+  resolveGatewayUrl,
+  runCompaction,
+  type SessionBeforeCompactResult,
+  sessionIDFor,
+  startInProcess,
+} from "./internal";
 
 /** Guard against double-installing the fetch interceptor if Pi re-initializes. */
 let fetchInterceptorInstalled = false;
-
-/**
- * Check if the Lore gateway is reachable at the given base URL.
- * Short timeout so this doesn't delay Pi startup noticeably.
- */
-async function probeGateway(
-  baseURL: string,
-  timeoutMs = 1500,
-): Promise<boolean> {
-  try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
-    const res = await fetch(`${baseURL}/health`, { signal: controller.signal });
-    clearTimeout(timer);
-    return res.ok;
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Resolve the gateway URL by probing known ports and reading the port file.
- *
- * Order: LORE_GATEWAY_URL env var → port file → known default ports (3207, 5673).
- * Returns the URL of a running gateway, or null if none found.
- */
-async function resolveGatewayUrl(): Promise<string | null> {
-  // 0. Remote gateway — skip local discovery/startup entirely.
-  if (process.env.LORE_REMOTE_URL) {
-    const url = process.env.LORE_REMOTE_URL.replace(/\/$/, "");
-    if (await probeGateway(url)) return url;
-    log.info(
-      `pi: remote gateway at ${url} not reachable, falling through to local discovery`,
-    );
-  }
-
-  // 1. Explicit env var — probe it to verify it's actually reachable.
-  if (process.env.LORE_GATEWAY_URL) {
-    const url = process.env.LORE_GATEWAY_URL.replace(/\/$/, "");
-    if (await probeGateway(url)) return url;
-    // env var set but gateway unreachable — fall through to discovery
-  }
-
-  // 2. Build probe list: port file first (handles random port), then known defaults.
-  const probePorts = new Set<number>();
-  try {
-    const gw = "@loreai/gateway";
-    const { readPortFile } = await import(/* webpackIgnore: true */ gw);
-    const portfilePort = readPortFile();
-    if (portfilePort) probePorts.add(portfilePort);
-  } catch {
-    /* gateway package not available — skip port file */
-  }
-  for (const p of KNOWN_GATEWAY_PORTS) probePorts.add(p);
-
-  // 3. Probe each port.
-  for (const port of probePorts) {
-    const url = `http://127.0.0.1:${port}`;
-    if (await probeGateway(url)) return url;
-  }
-
-  return null;
-}
-
-/**
- * Start the gateway server in-process by importing @loreai/gateway as a library.
- * The published CJS bundle includes Node.js polyfills that shim Bun.serve()
- * to node:http.createServer(), so this works under both Bun and Node.js.
- *
- * Uses startGateway() which handles the full port fallback chain
- * (3207 → 5673 → random) and port file management automatically.
- * Returns the URL of the started gateway, or null on failure.
- */
-async function startInProcess(): Promise<string | null> {
-  try {
-    // Dynamic import — the gateway may be resolved from src (workspace) or
-    // dist/index.cjs (npm). Use a variable to prevent tsc from resolving the
-    // module at compile time (the .d.cts only exists after building).
-    const gw = "@loreai/gateway";
-    const { startGateway } = await import(/* webpackIgnore: true */ gw);
-    const handle = await startGateway({ quiet: true, local: true });
-    const url = `http://127.0.0.1:${handle.port}`;
-
-    if (!handle.owned) {
-      log.info(`pi: reusing existing gateway at ${url}`);
-    }
-
-    return url;
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    log.warn("pi: failed to start gateway in-process:", msg);
-    return null;
-  }
-}
-
-/**
- * Derive a stable session identifier from Pi's current session file path.
- */
-function sessionIDFor(sessionFile: string | undefined): string {
-  if (!sessionFile) return `pi-ephemeral-${process.pid}`;
-  return `pi-${createHash("sha256").update(sessionFile).digest("hex").slice(0, 24)}`;
-}
 
 /**
  * Pi extension entry point.
@@ -307,39 +138,15 @@ export default async function lorePiExtension(pi: ExtensionAPI): Promise<void> {
    * once the real session ID is known.
    */
   function registerProviders(): void {
-    const baseHeaders: Record<string, string> = {
-      "x-lore-session-id": currentSessionID,
-      "x-lore-project": projectPath,
-    };
-    // Inject git remote so the gateway can group worktrees/clones of the
-    // same repo without filesystem access (important for remote gateways).
-    const remote = getGitRemote(projectPath);
-    if (remote) baseHeaders["x-lore-git-remote"] = remote;
-
-    // Anthropic SDK appends `/v1/messages` to baseURL — pass gateway root.
-    const anthropicBase = gatewayBase;
-    // OpenAI SDK expects baseURL to already include `/v1` — it only appends
-    // `/chat/completions` or `/responses`. Matches the pattern in agents.ts.
-    const openaiBase = `${gatewayBase}/v1`;
-
-    const anthropicSet: ReadonlySet<string> = new Set(ANTHROPIC_PROVIDERS);
-
-    for (const provider of GATEWAY_PROVIDERS) {
-      const headers: Record<string, string> = {
-        ...baseHeaders,
-        // Inject provider ID so the gateway uses provider-based routing
-        // (correct protocol + upstream URL) instead of model-prefix guessing.
-        "x-lore-provider": provider,
-      };
-      // For local/custom providers, inject the original upstream URL so the
-      // gateway can forward requests to the correct endpoint. The user sets
-      // LORE_UPSTREAM_<PROVIDER>=<url> in their environment.
-      const envKey = `LORE_UPSTREAM_${provider.toUpperCase().replace(/-/g, "_")}`;
-      const upstream = process.env[envKey];
-      if (upstream) {
-        headers["x-lore-upstream-url"] = upstream;
-      }
-      const baseUrl = anthropicSet.has(provider) ? anthropicBase : openaiBase;
+    const registrations = buildProviderRegistrations({
+      gatewayBase,
+      sessionID: currentSessionID,
+      projectPath,
+      // Resolve the git remote for the CURRENT project path so worktrees that
+      // switch on session_start get the right remote.
+      gitRemote: getGitRemote(projectPath) ?? undefined,
+    });
+    for (const { provider, baseUrl, headers } of registrations) {
       pi.registerProvider(provider, { baseUrl, headers });
     }
   }
@@ -373,55 +180,15 @@ export default async function lorePiExtension(pi: ExtensionAPI): Promise<void> {
     async (
       event: SessionBeforeCompactEvent,
       _ctx,
-    ): Promise<SessionBeforeCompactResult | undefined> => {
-      try {
-        const res = await fetch(`${gatewayBase}/v1/compact`, {
-          method: "POST",
-          headers: {
-            "content-type": "application/json",
-            "x-lore-session-id": currentSessionID,
-          },
-          body: JSON.stringify({
-            project_path: projectPath,
-            previous_summary: event.preparation.previousSummary,
-          }),
-        });
-
-        if (!res.ok) {
-          // Gateway returned an error — fall back to Pi's default compaction.
-          const errBody = await res.text().catch(() => "");
-          // A 404 `session_not_found` is expected when this session was never
-          // routed through Lore (e.g. a provider Lore doesn't proxy, or a
-          // websocket-only transport that bypassed the gateway). That's not a
-          // failure — log it quietly and let Pi's default compaction run.
-          if (res.status === 404 && errBody.includes("session_not_found")) {
-            log.info(
-              "pi: lore compaction unavailable — this session was not routed " +
-                "through Lore; falling back to Pi compaction.",
-            );
-            return undefined;
-          }
-          log.warn(
-            `pi: compaction endpoint returned ${res.status}: ${errBody}`,
-          );
-          return undefined;
-        }
-
-        const { summary } = (await res.json()) as { summary: string };
-        if (!summary) return undefined;
-
-        return {
-          compaction: {
-            summary,
-            firstKeptEntryId: event.preparation.firstKeptEntryId,
-            tokensBefore: event.preparation.tokensBefore,
-          },
-        };
-      } catch (err) {
-        log.warn("pi: custom compaction failed, falling back to default:", err);
-        return undefined;
-      }
-    },
+    ): Promise<SessionBeforeCompactResult | undefined> =>
+      runCompaction({
+        gatewayBase,
+        sessionID: currentSessionID,
+        projectPath,
+        previousSummary: event.preparation.previousSummary,
+        firstKeptEntryId: event.preparation.firstKeptEntryId,
+        tokensBefore: event.preparation.tokensBefore,
+      }),
   );
 }
 

--- a/packages/pi/src/internal.ts
+++ b/packages/pi/src/internal.ts
@@ -1,0 +1,342 @@
+/**
+ * Internal helpers for the Lore Pi extension.
+ *
+ * These functions are intentionally kept OUT of the extension entry module
+ * (`./index.ts`) so they can be unit-tested directly. The entry module's
+ * default export is the extension factory; Pi loads it and only that. Keeping
+ * the pure, side-effect-light logic here (provider-registration shaping,
+ * gateway discovery, session-id derivation, the compaction request) lets tests
+ * exercise the real behavior without driving the whole factory — and without
+ * relying on the `NODE_ENV=test` inert path.
+ */
+import { createHash } from "node:crypto";
+import { log } from "@loreai/core";
+
+/**
+ * Pi-side shape of a `session_before_compact` result. Pi doesn't re-export
+ * these event result types at the top level, so we inline the minimal shape.
+ */
+export type SessionBeforeCompactResult = {
+  cancel?: boolean;
+  compaction?: {
+    summary: string;
+    firstKeptEntryId: string;
+    tokensBefore: number;
+    details?: unknown;
+  };
+};
+
+/**
+ * Providers whose wire protocol the Lore gateway can proxy, split by SDK
+ * protocol so we can set the correct `baseUrl` for each group.
+ *
+ * - Anthropic SDK appends `/v1/messages` to baseURL → pass gateway root.
+ * - OpenAI SDK appends `/chat/completions` or `/responses` to baseURL and
+ *   expects it to already include `/v1` → pass `${gateway}/v1`.
+ *
+ * Providers using other protocols (Google SDK, AWS Bedrock SDK, Mistral
+ * conversations) are not redirected.
+ *
+ * For local/self-hosted providers, set `LORE_UPSTREAM_<PROVIDER>=<url>` (e.g.
+ * `LORE_UPSTREAM_VLLM=http://localhost:8000`) so the gateway knows where to
+ * forward requests. Cloud providers are routed automatically by model name
+ * prefix.
+ */
+
+/** Anthropic-messages API → gateway POST /v1/messages */
+export const ANTHROPIC_PROVIDERS = [
+  "anthropic",
+  "fireworks",
+  "minimax",
+  "minimax-cn",
+  "kimi-coding",
+] as const;
+
+/** OpenAI-completions / OpenAI-responses API → gateway POST /v1/chat/completions or /v1/responses */
+export const OPENAI_PROVIDERS = [
+  // openai-completions API
+  "github-copilot",
+  "deepseek",
+  "xai",
+  "groq",
+  "cerebras",
+  "openrouter",
+  "huggingface",
+  "zai",
+  "opencode",
+  "opencode-go",
+  "vercel-ai-gateway",
+  // openai-responses API
+  "openai",
+  // Codex (ChatGPT) — OpenAI Responses wire format. Registered with the
+  // standard `${gatewayBase}/v1` baseUrl; the Codex provider appends
+  // `/codex/responses` itself, landing on the gateway's `/v1/codex/responses`
+  // route. The Codex WSS attempt targets the same baseUrl and is rejected by
+  // the HTTP-only gateway, so Pi falls back to SSE through Lore (no bypass).
+  "openai-codex",
+  // Local / self-hosted (OpenAI-compatible)
+  "vllm",
+  "llamacpp",
+  "ollama",
+  "lmstudio",
+  "jan",
+  "localai",
+  "tgi",
+  "tabbyml",
+  "litellm",
+] as const;
+
+/** All providers that can be routed through the gateway. */
+export const GATEWAY_PROVIDERS: readonly string[] = [
+  ...ANTHROPIC_PROVIDERS,
+  ...OPENAI_PROVIDERS,
+];
+
+/** Default ports to probe when looking for a running gateway (must match gateway defaults). */
+export const KNOWN_GATEWAY_PORTS = [3207, 5673];
+
+/** A provider registration as passed to `pi.registerProvider`. */
+export interface ProviderRegistration {
+  provider: string;
+  baseUrl: string;
+  headers: Record<string, string>;
+}
+
+/**
+ * Check if the Lore gateway is reachable at the given base URL.
+ * Short timeout so this doesn't delay Pi startup noticeably.
+ */
+export async function probeGateway(
+  baseURL: string,
+  timeoutMs = 1500,
+): Promise<boolean> {
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    const res = await fetch(`${baseURL}/health`, { signal: controller.signal });
+    clearTimeout(timer);
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve the gateway URL by probing known ports and reading the port file.
+ *
+ * Order: LORE_REMOTE_URL → LORE_GATEWAY_URL → port file → known default
+ * ports (3207, 5673). Returns the URL of a running gateway, or null if none
+ * found.
+ */
+export async function resolveGatewayUrl(): Promise<string | null> {
+  // 0. Remote gateway — skip local discovery/startup entirely.
+  if (process.env.LORE_REMOTE_URL) {
+    const url = process.env.LORE_REMOTE_URL.replace(/\/$/, "");
+    if (await probeGateway(url)) return url;
+    log.info(
+      `pi: remote gateway at ${url} not reachable, falling through to local discovery`,
+    );
+  }
+
+  // 1. Explicit env var — probe it to verify it's actually reachable.
+  if (process.env.LORE_GATEWAY_URL) {
+    const url = process.env.LORE_GATEWAY_URL.replace(/\/$/, "");
+    if (await probeGateway(url)) return url;
+    // env var set but gateway unreachable — fall through to discovery
+  }
+
+  // 2. Build probe list: port file first (handles random port), then known defaults.
+  const probePorts = new Set<number>();
+  try {
+    const gw = "@loreai/gateway";
+    const { readPortFile } = await import(/* webpackIgnore: true */ gw);
+    const portfilePort = readPortFile();
+    if (portfilePort) probePorts.add(portfilePort);
+  } catch {
+    /* gateway package not available — skip port file */
+  }
+  for (const p of KNOWN_GATEWAY_PORTS) probePorts.add(p);
+
+  // 3. Probe each port.
+  for (const port of probePorts) {
+    const url = `http://127.0.0.1:${port}`;
+    if (await probeGateway(url)) return url;
+  }
+
+  return null;
+}
+
+/**
+ * Start the gateway server in-process by importing @loreai/gateway as a
+ * library. The published CJS bundle includes Node.js polyfills that shim
+ * Bun.serve() to node:http.createServer(), so this works under both Bun and
+ * Node.js.
+ *
+ * Uses startGateway() which handles the full port fallback chain
+ * (3207 → 5673 → random) and port file management automatically.
+ * Returns the URL of the started gateway, or null on failure.
+ */
+export async function startInProcess(): Promise<string | null> {
+  try {
+    // Dynamic import — the gateway may be resolved from src (workspace) or
+    // dist/index.cjs (npm). Use a variable to prevent tsc from resolving the
+    // module at compile time (the .d.cts only exists after building).
+    const gw = "@loreai/gateway";
+    const { startGateway } = await import(/* webpackIgnore: true */ gw);
+    const handle = await startGateway({ quiet: true, local: true });
+    const url = `http://127.0.0.1:${handle.port}`;
+
+    if (!handle.owned) {
+      log.info(`pi: reusing existing gateway at ${url}`);
+    }
+
+    return url;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    log.warn("pi: failed to start gateway in-process:", msg);
+    return null;
+  }
+}
+
+/**
+ * Derive a stable session identifier from Pi's current session file path.
+ * Falls back to an ephemeral, per-process id when no session file is known.
+ */
+export function sessionIDFor(sessionFile: string | undefined): string {
+  if (!sessionFile) return `pi-ephemeral-${process.pid}`;
+  return `pi-${createHash("sha256").update(sessionFile).digest("hex").slice(0, 24)}`;
+}
+
+/**
+ * Build the provider registrations for every gateway-routable provider.
+ *
+ * Pure: given the gateway base, the current session/project, the resolved git
+ * remote, and the environment, it returns the `{ provider, baseUrl, headers }`
+ * tuples to hand to `pi.registerProvider`. Anthropic-protocol providers get the
+ * gateway root; OpenAI-protocol providers get `${gateway}/v1`. Each carries the
+ * `x-lore-*` attribution headers and, for local/custom providers, the
+ * `x-lore-upstream-url` from `LORE_UPSTREAM_<PROVIDER>`.
+ */
+export function buildProviderRegistrations(opts: {
+  gatewayBase: string;
+  sessionID: string;
+  projectPath: string;
+  gitRemote?: string;
+  env?: NodeJS.ProcessEnv;
+}): ProviderRegistration[] {
+  const {
+    gatewayBase,
+    sessionID,
+    projectPath,
+    gitRemote,
+    env = process.env,
+  } = opts;
+
+  // Anthropic SDK appends `/v1/messages` to baseURL — pass gateway root.
+  const anthropicBase = gatewayBase;
+  // OpenAI SDK expects baseURL to already include `/v1` — it only appends
+  // `/chat/completions` or `/responses`. Matches the pattern in agents.ts.
+  const openaiBase = `${gatewayBase}/v1`;
+  const anthropicSet: ReadonlySet<string> = new Set(ANTHROPIC_PROVIDERS);
+
+  const registrations: ProviderRegistration[] = [];
+  for (const provider of GATEWAY_PROVIDERS) {
+    const headers: Record<string, string> = {
+      "x-lore-session-id": sessionID,
+      "x-lore-project": projectPath,
+      // Inject provider ID so the gateway uses provider-based routing
+      // (correct protocol + upstream URL) instead of model-prefix guessing.
+      "x-lore-provider": provider,
+    };
+    // Inject git remote so the gateway can group worktrees/clones of the
+    // same repo without filesystem access (important for remote gateways).
+    if (gitRemote) headers["x-lore-git-remote"] = gitRemote;
+    // For local/custom providers, inject the original upstream URL so the
+    // gateway can forward requests to the correct endpoint. The user sets
+    // LORE_UPSTREAM_<PROVIDER>=<url> in their environment.
+    const envKey = `LORE_UPSTREAM_${provider.toUpperCase().replace(/-/g, "_")}`;
+    const upstream = env[envKey];
+    if (upstream) headers["x-lore-upstream-url"] = upstream;
+
+    const baseUrl = anthropicSet.has(provider) ? anthropicBase : openaiBase;
+    registrations.push({ provider, baseUrl, headers });
+  }
+  return registrations;
+}
+
+/**
+ * Call the gateway's `POST /v1/compact` endpoint and shape the result for Pi's
+ * `session_before_compact` hook.
+ *
+ * Returns a compaction result on success, or `undefined` to fall back to Pi's
+ * default compaction on ANY error path:
+ *   - 404 `session_not_found` (this session never routed through Lore),
+ *   - any other non-2xx response,
+ *   - a thrown/network error,
+ *   - a 2xx with an empty summary.
+ *
+ * Never throws and never writes to stdout/stderr — all diagnostics go through
+ * the core `log` module (file-based, TUI-safe). `fetchImpl` is injectable for
+ * testing.
+ */
+export async function runCompaction(opts: {
+  gatewayBase: string;
+  sessionID: string;
+  projectPath: string;
+  previousSummary: string | undefined;
+  firstKeptEntryId: string;
+  tokensBefore: number;
+  fetchImpl?: typeof fetch;
+}): Promise<SessionBeforeCompactResult | undefined> {
+  const {
+    gatewayBase,
+    sessionID,
+    projectPath,
+    previousSummary,
+    firstKeptEntryId,
+    tokensBefore,
+    fetchImpl = fetch,
+  } = opts;
+
+  try {
+    const res = await fetchImpl(`${gatewayBase}/v1/compact`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-lore-session-id": sessionID,
+      },
+      body: JSON.stringify({
+        project_path: projectPath,
+        previous_summary: previousSummary,
+      }),
+    });
+
+    if (!res.ok) {
+      // Gateway returned an error — fall back to Pi's default compaction.
+      const errBody = await res.text().catch(() => "");
+      // A 404 `session_not_found` is expected when this session was never
+      // routed through Lore (e.g. a provider Lore doesn't proxy, or a
+      // websocket-only transport that bypassed the gateway). That's not a
+      // failure — log it quietly and let Pi's default compaction run.
+      if (res.status === 404 && errBody.includes("session_not_found")) {
+        log.info(
+          "pi: lore compaction unavailable — this session was not routed " +
+            "through Lore; falling back to Pi compaction.",
+        );
+        return undefined;
+      }
+      log.warn(`pi: compaction endpoint returned ${res.status}: ${errBody}`);
+      return undefined;
+    }
+
+    const { summary } = (await res.json()) as { summary: string };
+    if (!summary) return undefined;
+
+    return {
+      compaction: { summary, firstKeptEntryId, tokensBefore },
+    };
+  } catch (err) {
+    log.warn("pi: custom compaction failed, falling back to default:", err);
+    return undefined;
+  }
+}

--- a/packages/pi/test/extension.e2e.test.ts
+++ b/packages/pi/test/extension.e2e.test.ts
@@ -1,0 +1,230 @@
+import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
+import lorePiExtension from "../src/index";
+import { ANTHROPIC_PROVIDERS, OPENAI_PROVIDERS } from "../src/internal";
+
+/**
+ * End-to-end test: the Pi extension wired against a REAL in-process Lore
+ * gateway. Proves the extension goes active, registers every gateway-routable
+ * provider with the correct base URL + attribution headers, re-registers with
+ * the real session id on `session_start`, gracefully falls back when the
+ * gateway can't compact an unrouted session, and that the gateway actually
+ * serves the `/v1/messages` route the extension points providers at (upstream
+ * mocked — no real API call).
+ */
+
+// --- Mock Pi ExtensionAPI (captures registerProvider calls + event handlers) ---
+type AnyHandler = (...args: unknown[]) => unknown;
+interface Registration {
+  name: string;
+  config: { baseUrl: string; headers: Record<string, string> };
+}
+function createMockPi() {
+  const registrations: Registration[] = [];
+  const handlers = new Map<string, AnyHandler>();
+  const pi = {
+    registerProvider(
+      name: string,
+      config: { baseUrl: string; headers: Record<string, string> },
+    ): void {
+      registrations.push({ name, config });
+    },
+    on(event: string, handler: AnyHandler): void {
+      handlers.set(event, handler);
+    },
+  };
+  return { pi, registrations, handlers };
+}
+
+/** Minimal non-streaming Anthropic response (what the mocked upstream returns). */
+function cannedAnthropicResponse(text: string): Response {
+  return new Response(
+    JSON.stringify({
+      id: "msg_e2e_0",
+      type: "message",
+      role: "assistant",
+      content: [{ type: "text", text }],
+      model: "claude-sonnet-4-20250514",
+      stop_reason: "end_turn",
+      stop_sequence: null,
+      usage: { input_tokens: 100, output_tokens: 10 },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+describe("pi extension — e2e against a real gateway", () => {
+  let baseURL: string;
+  let stopServer: () => void;
+  let mock: ReturnType<typeof createMockPi>;
+  const originalFetch = globalThis.fetch;
+  const originalEnv = { ...process.env };
+  // Upstream request bodies the gateway forwarded (proves a turn reached it).
+  const upstreamSessions: Array<string | undefined> = [];
+
+  beforeAll(async () => {
+    const gwPkg = "@loreai/gateway";
+    const gw = (await import(gwPkg)) as unknown as {
+      loadConfig: () => { port: number } & Record<string, unknown>;
+      startServer: (c: unknown) => Promise<{ stop: () => void; port: number }>;
+      resetPipelineState: () => Promise<void>;
+    };
+    const { close: closeDB } = (await import("@loreai/core")) as unknown as {
+      close: () => void;
+    };
+    const { setUpstreamInterceptor } = (await import(
+      "../../gateway/src/pipeline"
+    )) as unknown as {
+      setUpstreamInterceptor: (
+        fn:
+          | ((
+              body: unknown,
+              model: string,
+              streaming: boolean,
+              makeReal: () => Promise<Response>,
+            ) => Promise<Response>)
+          | undefined,
+      ) => void;
+    };
+
+    closeDB();
+    await gw.resetPipelineState();
+
+    // Mock upstream: never hit a real API; capture the x-lore session routing.
+    setUpstreamInterceptor(async (body) => {
+      const b = body as { metadata?: { user_id?: string } } | undefined;
+      upstreamSessions.push(b?.metadata?.user_id);
+      return cannedAnthropicResponse("hello from mock upstream");
+    });
+
+    const config = gw.loadConfig();
+    config.port = 0;
+    config.hosts = ["127.0.0.1"];
+    const server = await gw.startServer(config);
+    stopServer = () => server.stop();
+    baseURL = `http://127.0.0.1:${server.port}`;
+
+    // Activate the extension against the real gateway.
+    process.env.LORE_PI_FORCE_ACTIVE = "1";
+    process.env.LORE_GATEWAY_URL = baseURL;
+    delete process.env.LORE_DISABLED;
+    delete process.env.LORE_REMOTE_URL;
+
+    mock = createMockPi();
+    await lorePiExtension(
+      mock.pi as unknown as Parameters<typeof lorePiExtension>[0],
+    );
+  });
+
+  afterAll(async () => {
+    globalThis.fetch = originalFetch;
+    process.env = { ...originalEnv };
+    stopServer?.();
+    // Mirror the gateway harness teardown so no pipeline timers / interceptor
+    // state leak into other tests sharing this worker.
+    try {
+      const { setUpstreamInterceptor, resetPipelineState } = (await import(
+        "../../gateway/src/pipeline"
+      )) as unknown as {
+        setUpstreamInterceptor: (fn: undefined) => void;
+        resetPipelineState: (opts?: { fast?: boolean }) => Promise<void>;
+      };
+      const { close: closeDB } = (await import("@loreai/core")) as unknown as {
+        close: () => void;
+      };
+      setUpstreamInterceptor(undefined);
+      closeDB();
+      await resetPipelineState({ fast: true });
+    } catch {
+      /* best-effort */
+    }
+  });
+
+  test("goes active and registers every gateway-routable provider", () => {
+    const names = mock.registrations.map((r) => r.name);
+    for (const p of [...ANTHROPIC_PROVIDERS, ...OPENAI_PROVIDERS]) {
+      expect(names).toContain(p);
+    }
+    // Wired up its lifecycle hooks.
+    expect(mock.handlers.get("session_start")).toBeTypeOf("function");
+    expect(mock.handlers.get("session_before_compact")).toBeTypeOf("function");
+  });
+
+  test("points Anthropic providers at the gateway root and OpenAI at /v1", () => {
+    const byName = new Map(mock.registrations.map((r) => [r.name, r.config]));
+    expect(byName.get("anthropic")?.baseUrl).toBe(baseURL);
+    expect(byName.get("openai")?.baseUrl).toBe(`${baseURL}/v1`);
+    // Attribution header present on every registration.
+    for (const r of mock.registrations) {
+      expect(r.config.headers["x-lore-provider"]).toBe(r.name);
+      expect(r.config.headers["x-lore-session-id"]).toBeTypeOf("string");
+    }
+  });
+
+  test("re-registers with the derived session id on session_start", async () => {
+    const before = mock.registrations.length;
+    const onStart = mock.handlers.get("session_start");
+    await onStart?.(
+      {} as never,
+      {
+        cwd: process.cwd(),
+        sessionManager: {
+          getSessionFile: () => "/tmp/lore-pi-e2e-session.json",
+        },
+      } as never,
+    );
+    const after = mock.registrations.slice(before);
+    expect(after.length).toBeGreaterThan(0);
+    // The new registrations carry the derived (non-ephemeral) session id.
+    const sid = after[0].config.headers["x-lore-session-id"];
+    expect(sid).toMatch(/^pi-[0-9a-f]{24}$/);
+  });
+
+  test("compaction for an unrouted session falls back gracefully (real /v1/compact)", async () => {
+    const onCompact = mock.handlers.get("session_before_compact");
+    const result = await onCompact?.(
+      {
+        preparation: {
+          previousSummary: "",
+          firstKeptEntryId: "e1",
+          tokensBefore: 100,
+        },
+      } as never,
+      {} as never,
+    );
+    // The gateway returns 404 session_not_found for a session that never sent
+    // a turn; the handler must return undefined (use Pi's default compaction).
+    expect(result).toBeUndefined();
+  });
+
+  test("the gateway serves /v1/messages at the registered Anthropic baseUrl", async () => {
+    const anthropic = mock.registrations.find((r) => r.name === "anthropic");
+    expect(anthropic).toBeDefined();
+    // POST to the exact base URL + headers the extension configured for Pi.
+    const res = await originalFetch(
+      `${anthropic?.config.baseUrl}/v1/messages`,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-api-key": "test-key",
+          "anthropic-version": "2023-06-01",
+          ...anthropic?.config.headers,
+        },
+        body: JSON.stringify({
+          model: "claude-sonnet-4-20250514",
+          max_tokens: 64,
+          messages: [{ role: "user", content: "hi" }],
+        }),
+      },
+    );
+    expect(res.ok).toBe(true);
+    const body = (await res.json()) as {
+      content: Array<{ type: string; text: string }>;
+    };
+    // The response is the mocked upstream — proving the turn flowed through the
+    // gateway pipeline, not a real Anthropic endpoint.
+    expect(body.content[0].text).toBe("hello from mock upstream");
+    // The gateway forwarded under the extension's session attribution.
+    expect(upstreamSessions.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/pi/test/gateway-discovery.test.ts
+++ b/packages/pi/test/gateway-discovery.test.ts
@@ -1,0 +1,76 @@
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "vitest";
+import { probeGateway, resolveGatewayUrl } from "../src/internal";
+
+/**
+ * Unit coverage for the Pi extension's gateway discovery: `probeGateway` and
+ * the env-var resolution order of `resolveGatewayUrl`. A real loopback HTTP
+ * server stands in for a gateway (answers `/health`).
+ */
+describe("pi gateway discovery", () => {
+  let healthy: Server;
+  let unhealthy: Server;
+  let healthyUrl: string;
+  let unhealthyUrl: string;
+  const savedEnv = { ...process.env };
+
+  beforeAll(async () => {
+    healthy = createServer((req, res) => {
+      if ((req.url ?? "").startsWith("/health")) {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ status: "ok" }));
+      } else {
+        res.writeHead(404);
+        res.end();
+      }
+    });
+    unhealthy = createServer((_req, res) => {
+      res.writeHead(500);
+      res.end("nope");
+    });
+    await Promise.all([
+      new Promise<void>((r) => healthy.listen(0, "127.0.0.1", () => r())),
+      new Promise<void>((r) => unhealthy.listen(0, "127.0.0.1", () => r())),
+    ]);
+    healthyUrl = `http://127.0.0.1:${(healthy.address() as AddressInfo).port}`;
+    unhealthyUrl = `http://127.0.0.1:${(unhealthy.address() as AddressInfo).port}`;
+  });
+
+  afterAll(async () => {
+    await Promise.all([
+      new Promise<void>((r) => healthy.close(() => r())),
+      new Promise<void>((r) => unhealthy.close(() => r())),
+    ]);
+  });
+
+  afterEach(() => {
+    process.env = { ...savedEnv };
+  });
+
+  describe("probeGateway", () => {
+    test("true when /health answers 2xx", async () => {
+      expect(await probeGateway(healthyUrl, 2000)).toBe(true);
+    });
+    test("false when the endpoint returns non-2xx", async () => {
+      expect(await probeGateway(unhealthyUrl, 2000)).toBe(false);
+    });
+    test("false when nothing is listening", async () => {
+      expect(await probeGateway("http://127.0.0.1:1", 500)).toBe(false);
+    });
+  });
+
+  describe("resolveGatewayUrl env-var order", () => {
+    test("returns LORE_REMOTE_URL when reachable (trailing slash stripped)", async () => {
+      process.env.LORE_REMOTE_URL = `${healthyUrl}/`;
+      delete process.env.LORE_GATEWAY_URL;
+      expect(await resolveGatewayUrl()).toBe(healthyUrl);
+    });
+
+    test("falls through to LORE_GATEWAY_URL when reachable", async () => {
+      delete process.env.LORE_REMOTE_URL;
+      process.env.LORE_GATEWAY_URL = healthyUrl;
+      expect(await resolveGatewayUrl()).toBe(healthyUrl);
+    });
+  });
+});

--- a/packages/pi/test/internal.test.ts
+++ b/packages/pi/test/internal.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, test, vi } from "vitest";
+import {
+  ANTHROPIC_PROVIDERS,
+  buildProviderRegistrations,
+  GATEWAY_PROVIDERS,
+  OPENAI_PROVIDERS,
+  runCompaction,
+  sessionIDFor,
+} from "../src/internal";
+
+const GW = "http://127.0.0.1:31234";
+
+describe("buildProviderRegistrations", () => {
+  test("routes Anthropic providers to the gateway root, OpenAI to /v1", () => {
+    const regs = buildProviderRegistrations({
+      gatewayBase: GW,
+      sessionID: "sess-1",
+      projectPath: "/proj",
+      env: {},
+    });
+    const byProvider = new Map(regs.map((r) => [r.provider, r]));
+
+    // One registration per gateway-routable provider.
+    expect(regs).toHaveLength(GATEWAY_PROVIDERS.length);
+
+    for (const p of ANTHROPIC_PROVIDERS) {
+      expect(byProvider.get(p)?.baseUrl).toBe(GW);
+    }
+    for (const p of OPENAI_PROVIDERS) {
+      expect(byProvider.get(p)?.baseUrl).toBe(`${GW}/v1`);
+    }
+  });
+
+  test("every registration carries session/project/provider attribution headers", () => {
+    const regs = buildProviderRegistrations({
+      gatewayBase: GW,
+      sessionID: "sess-2",
+      projectPath: "/work/repo",
+      env: {},
+    });
+    for (const reg of regs) {
+      expect(reg.headers["x-lore-session-id"]).toBe("sess-2");
+      expect(reg.headers["x-lore-project"]).toBe("/work/repo");
+      expect(reg.headers["x-lore-provider"]).toBe(reg.provider);
+    }
+  });
+
+  test("injects git remote only when provided", () => {
+    const withRemote = buildProviderRegistrations({
+      gatewayBase: GW,
+      sessionID: "s",
+      projectPath: "/p",
+      gitRemote: "git@github.com:acme/repo.git",
+      env: {},
+    });
+    expect(withRemote[0].headers["x-lore-git-remote"]).toBe(
+      "git@github.com:acme/repo.git",
+    );
+
+    const withoutRemote = buildProviderRegistrations({
+      gatewayBase: GW,
+      sessionID: "s",
+      projectPath: "/p",
+      env: {},
+    });
+    for (const reg of withoutRemote) {
+      expect(reg.headers["x-lore-git-remote"]).toBeUndefined();
+    }
+  });
+
+  test("injects x-lore-upstream-url from LORE_UPSTREAM_<PROVIDER> on that provider only", () => {
+    const regs = buildProviderRegistrations({
+      gatewayBase: GW,
+      sessionID: "s",
+      projectPath: "/p",
+      env: { LORE_UPSTREAM_VLLM: "http://localhost:8000" },
+    });
+    const byProvider = new Map(regs.map((r) => [r.provider, r]));
+    expect(byProvider.get("vllm")?.headers["x-lore-upstream-url"]).toBe(
+      "http://localhost:8000",
+    );
+    // A different provider must NOT pick up vllm's upstream.
+    expect(
+      byProvider.get("ollama")?.headers["x-lore-upstream-url"],
+    ).toBeUndefined();
+  });
+});
+
+describe("sessionIDFor", () => {
+  test("returns an ephemeral, per-process id when no session file", () => {
+    expect(sessionIDFor(undefined)).toBe(`pi-ephemeral-${process.pid}`);
+  });
+
+  test("derives a stable pi-<24hex> id from the session file path", () => {
+    const a = sessionIDFor("/home/u/.pi/sessions/abc.json");
+    const b = sessionIDFor("/home/u/.pi/sessions/abc.json");
+    expect(a).toBe(b); // stable
+    expect(a).toMatch(/^pi-[0-9a-f]{24}$/);
+    // Different files → different ids.
+    expect(sessionIDFor("/home/u/.pi/sessions/def.json")).not.toBe(a);
+  });
+});
+
+describe("runCompaction", () => {
+  const base = {
+    gatewayBase: GW,
+    sessionID: "sess-c",
+    projectPath: "/proj",
+    previousSummary: "prev",
+    firstKeptEntryId: "entry-7",
+    tokensBefore: 4242,
+  };
+
+  test("POSTs to /v1/compact with session header + body, returns shaped result", async () => {
+    const fetchImpl = vi.fn(
+      async (_url: string | URL | Request, _init?: RequestInit) =>
+        new Response(JSON.stringify({ summary: "fresh summary" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    const result = await runCompaction({ ...base, fetchImpl });
+
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    const [url, init] = fetchImpl.mock.calls[0];
+    expect(url).toBe(`${GW}/v1/compact`);
+    expect((init?.headers as Record<string, string>)["x-lore-session-id"]).toBe(
+      "sess-c",
+    );
+    expect(JSON.parse(init?.body as string)).toEqual({
+      project_path: "/proj",
+      previous_summary: "prev",
+    });
+
+    expect(result).toEqual({
+      compaction: {
+        summary: "fresh summary",
+        firstKeptEntryId: "entry-7",
+        tokensBefore: 4242,
+      },
+    });
+  });
+
+  test("returns undefined on 404 session_not_found (graceful fallback)", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ error: "session_not_found" }), {
+          status: 404,
+        }),
+    );
+    expect(await runCompaction({ ...base, fetchImpl })).toBeUndefined();
+  });
+
+  test("returns undefined on a non-2xx error", async () => {
+    const fetchImpl = vi.fn(async () => new Response("boom", { status: 500 }));
+    expect(await runCompaction({ ...base, fetchImpl })).toBeUndefined();
+  });
+
+  test("returns undefined when the request throws", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("ECONNREFUSED");
+    });
+    expect(await runCompaction({ ...base, fetchImpl })).toBeUndefined();
+  });
+
+  test("returns undefined on a 2xx with an empty summary", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ summary: "" }), { status: 200 }),
+    );
+    expect(await runCompaction({ ...base, fetchImpl })).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Why

Follow-up to #1036. Neither the **Pi** nor the **OpenCode** adapter had an end-to-end test that drove a request through a real in-process gateway, so a broken adapter could ship undetected — which is exactly what happened with the Pi TUI breakage. This adds e2e/smoke coverage so we stop shipping broken plugins.

## Changes

**Pi — extract testable logic** (`packages/pi/src/internal.ts`, mirroring the OpenCode plugin's `internal.ts`): gateway discovery (`probeGateway`, `resolveGatewayUrl`, `startInProcess`), `sessionIDFor`, the pure `buildProviderRegistrations`, and the injectable-`fetch` `runCompaction`. The entry module is now a thin wiring shell.

**Pi tests:**
- `internal.test.ts` — `buildProviderRegistrations` (Anthropic→gateway root, OpenAI→`/v1`, `x-lore-*` attribution, `LORE_UPSTREAM_*`→`x-lore-upstream-url`), `sessionIDFor`, and `runCompaction` across all branches (200 / 404 `session_not_found` / 5xx / throw / empty summary).
- `extension.e2e.test.ts` — the extension wired against a **real in-process gateway** (upstream mocked, no real API): goes active, registers every provider with the correct base URL + headers, re-registers on `session_start`, falls back gracefully when the gateway 404s an unrouted session, and the gateway actually serves `/v1/messages` at the registered base URL.
- `gateway-discovery.test.ts` — `probeGateway` truth table + `resolveGatewayUrl` env-var order.

**OpenCode — force-active hatch + genuine e2e:** the plugin is inert under `NODE_ENV=test`, so the routing e2e previously only exercised `applyLoreProviderConfig` directly plus a gateway smoke — a broken discovery/interceptor would still pass. Added a `LORE_OPENCODE_FORCE_ACTIVE` escape hatch (mirroring Pi's `LORE_PI_FORCE_ACTIVE`; both inert checks now route through one `isInertTestEnv()` helper so they can't drift). `routing.e2e.test.ts` now drives the plugin's **real active path** against a real in-process gateway (upstream mocked): it asserts the plugin discovers the gateway and installs its fetch interceptor, the `config` hook pins provider `baseURL` to the **discovered** gateway, `chat.headers` injects `x-lore-*`, and the installed interceptor transparently reroutes an `api.anthropic.com` call through the gateway to the mocked upstream. `afterAll` restores `globalThis.fetch` so the process-wide interceptor can't leak into sibling tests.

e2e `afterAll` mirrors the gateway harness teardown (stop → clear interceptor → `closeDB` → `resetPipelineState`) so no pipeline state leaks between tests.

## Verification

Full suite green across 3 consecutive runs. New tests run repeatedly with no flakiness. The OpenCode active-path assertions are **mutation-verified**: disabling the force-active hatch (so the plugin stays inert) fails the interceptor-install, config-pin, and interceptor-reroute assertions — confirming they guard the real failure mode, not a tautology.

## Note on coverage

`packages/pi/**` remains in the vitest coverage `exclude`. Fully covering `internal.ts` requires exercising `startInProcess` (which starts a real in-process gateway) and the port-file/known-ports discovery fallback — heavy/flaky to test deterministically — so un-excluding it now would risk the 80% patch gate. Tracked as a follow-up.

## Follow-up

- PR3 (#1040): wire the hermes (Python) plugin tests into CI.