### PR TITLE
ci(hermes): run the lore-hermes Python plugin tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1334,10 +1334,33 @@ jobs:
           LORE_INTEGRATION: '1'
           NODE_NO_WARNINGS: '1'
 
+  # ---------------------------------------------------------------------------
+  # Hermes (Python) plugin tests.
+  #
+  # The lore-hermes plugin is Python; its pytest suite is not covered by the
+  # Node/Vitest `test` job. Run it on a Python runtime so a broken Hermes
+  # adapter can't ship undetected. Gated on the code path filter like the
+  # other heavy jobs.
+  # ---------------------------------------------------------------------------
+  hermes-test:
+    name: Hermes plugin tests (Python)
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install lore-hermes with test extras
+        run: pip install -e "packages/hermes[test]"
+      - name: Run hermes tests
+        run: python -m pytest packages/hermes/tests/ -q
+
   ci-status:
     name: CI Status
     if: always()
-    needs: [changes, test, binary-smoke-native, check-docs, check-links, check-preview-links, check-social, check-patches, actionlint, sync-integration]
+    needs: [changes, test, binary-smoke-native, check-docs, check-links, check-preview-links, check-social, check-patches, actionlint, sync-integration, hermes-test]
     runs-on: ubuntu-latest
     steps:
       - name: Check CI result
@@ -1398,6 +1421,15 @@ jobs:
             syncItResult="${{ needs.sync-integration.result }}"
             if [ "$syncItResult" != "success" ]; then
               echo "::error::sync-integration did not succeed (result: $syncItResult)"
+              exit 1
+            fi
+          fi
+          # hermes-test is required whenever code changed (self-gates on the
+          # code path filter); "skipped" on unrelated changes is treated as pass.
+          if [ "${{ needs.changes.outputs.code }}" == "true" ]; then
+            hermesResult="${{ needs.hermes-test.result }}"
+            if [ "$hermesResult" != "success" ]; then
+              echo "::error::hermes-test did not succeed (result: $hermesResult)"
               exit 1
             fi
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,9 @@ actionlint
 # Mutation testing (Stryker) — issue #832
 reports/
 .stryker-tmp/
+
+# Python (lore-hermes plugin tests)
+__pycache__/
+*.py[cod]
+.pytest_cache/
+*.egg-info/

--- a/packages/hermes/pyproject.toml
+++ b/packages/hermes/pyproject.toml
@@ -8,6 +8,9 @@ license = {text = "FSL-1.1-Apache-2.0"}
 authors = [{name = "Burak Yigit Kaya", email = "ben@byk.im"}]
 dependencies = ["httpx>=0.27"]
 
+[project.optional-dependencies]
+test = ["pytest>=8"]
+
 [project.urls]
 Homepage = "https://withlore.ai"
 Repository = "https://github.com/BYK/loreai"

--- a/packages/hermes/tests/conftest.py
+++ b/packages/hermes/tests/conftest.py
@@ -1,0 +1,34 @@
+"""Pytest configuration for the lore-hermes test suite.
+
+`lore_hermes.engine.LoreContextEngine` subclasses Hermes's
+`agent.context_engine.ContextEngine`, which is an external Hermes dependency
+that is NOT vendored in this monorepo. Importing `lore_hermes` (its
+`__init__.py` eagerly imports the engine) therefore fails with
+`ModuleNotFoundError: No module named 'agent'` outside a full Hermes install.
+
+We inject a minimal stub of the `agent.context_engine` module into
+`sys.modules` before any test imports `lore_hermes`, so the plugin's own logic
+(passthrough engine, gateway discovery, session-id derivation) can be unit
+tested in isolation. This is test-only scaffolding — production runs against
+the real Hermes `ContextEngine`.
+"""
+
+import sys
+import types
+
+if "agent.context_engine" not in sys.modules:
+    agent_mod = types.ModuleType("agent")
+    context_engine_mod = types.ModuleType("agent.context_engine")
+
+    class ContextEngine:
+        """Minimal stand-in for the Hermes ContextEngine ABC."""
+
+        def __init__(self, **kwargs):  # noqa: D401 - permissive base
+            pass
+
+    context_engine_mod.ContextEngine = ContextEngine
+    # Expose the submodule as an attribute so `import agent` + attribute access
+    # and `from agent.context_engine import ContextEngine` both resolve.
+    agent_mod.context_engine = context_engine_mod
+    sys.modules["agent"] = agent_mod
+    sys.modules["agent.context_engine"] = context_engine_mod


### PR DESCRIPTION
## Why

Final follow-up to #1036 / #1039. The **lore-hermes** plugin is Python, and its pytest suite was **never wired into CI** — so a broken Hermes adapter could ship undetected. (In fact the suite couldn't even run: see below.)

## Changes

- **`.github/workflows/ci.yml`** — new `hermes-test` job: `actions/setup-python@v5` (3.11) → `pip install -e "packages/hermes[test]"` → `python -m pytest packages/hermes/tests/`. Gated on the existing `code` path filter like `sync-integration`, and added to the required `ci-status` gate with a matching result check.
- **`packages/hermes/pyproject.toml`** — add a `test` optional-dependency extra (`pytest>=8`); `httpx` is already a runtime dep.
- **`packages/hermes/tests/conftest.py`** — stub the external `agent.context_engine` module. `lore_hermes.engine.LoreContextEngine` subclasses Hermes's `ContextEngine` ABC, which isn't vendored in this monorepo, so importing `lore_hermes` failed with `ModuleNotFoundError: No module named 'agent'`. **The suite never actually ran before this** — the stub makes the plugin's own logic testable in isolation.
- **`.gitignore`** — ignore Python bytecode/cache artifacts.

## Verification

All **18** hermes tests pass via the exact CI invocation (`pip install -e "packages/hermes[test]"` + `pytest`), confirmed in a fresh venv. `actionlint` passes on all workflows.

## Series recap

- #1036 (merged) — fix the Pi TUI corruption (the actual bug Daniel hit) + regression tests.
- #1039 — basic e2e tests for the Pi and OpenCode adapters.
- This PR — wire the Hermes (Python) plugin tests into CI.

## Follow-up

- #1042 — make the conftest stub an `abc.ABC` (or add a real-Hermes import smoke job) so the job also catches `ContextEngine` ABC drift; tighten `test_returns_existing_gateway` to assert no subprocess spawn.
