### PR TITLE
fix(website): cap standard.site document textContent size

### DIFF
--- a/packages/website/src/lib/standard-site.ts
+++ b/packages/website/src/lib/standard-site.ts
@@ -123,6 +123,51 @@ export function buildPublicationRecord(): PublicationRecord {
   };
 }
 
+/**
+ * Upper bound on a document record's `textContent`, in UTF-8 bytes.
+ *
+ * `textContent` is supplementary — the canonical post lives on the site at the
+ * record's `path` — so it is safe to truncate. The AT Protocol repository spec
+ * delegates the hard maximum record size to PDS implementations rather than
+ * fixing a number (see https://atproto.com/specs/repository, "Security
+ * Considerations"), so we impose a conservative self-bound: generous enough
+ * that no realistic post is trimmed (the largest current post is ~11.5 KB),
+ * while keeping records and firehose events from growing without limit.
+ */
+export const MAX_TEXT_CONTENT_BYTES = 64 * 1024;
+
+const TRUNCATION_MARKER = "\n[truncated]";
+
+/**
+ * Clamp `text` to at most `maxBytes` UTF-8 bytes for use as a record's
+ * `textContent`. Never splits a multi-byte code point, prefers a whitespace
+ * boundary so it does not cut mid-word, and appends a marker so consumers can
+ * tell the text was trimmed. The result is always <= `maxBytes` bytes.
+ */
+export function capTextContent(
+  text: string,
+  maxBytes = MAX_TEXT_CONTENT_BYTES,
+): string {
+  const encoder = new TextEncoder();
+  const encoded = encoder.encode(text);
+  if (encoded.length <= maxBytes) return text;
+
+  const budget = Math.max(
+    0,
+    maxBytes - encoder.encode(TRUNCATION_MARKER).length,
+  );
+  // Decode the byte-prefix; a trailing partial code point becomes U+FFFD, which
+  // we drop so the output is always valid UTF-8 within budget.
+  let head = new TextDecoder("utf-8").decode(encoded.subarray(0, budget));
+  if (head.endsWith("\uFFFD")) head = head.slice(0, -1);
+  // Back off to a whitespace boundary when one is close, so we cut between words
+  // rather than mid-word; keep the hard cut if the tail has no late whitespace
+  // (e.g. one enormous token) so we never collapse to near-empty.
+  const atBoundary = head.replace(/\S+$/, "").trimEnd();
+  if (atBoundary.length >= head.length * 0.8) head = atBoundary;
+  return `${head.trimEnd()}${TRUNCATION_MARKER}`;
+}
+
 export interface DocumentInput {
   slug: string;
   title: string;
@@ -158,6 +203,6 @@ export function buildDocumentRecord(input: DocumentInput): DocumentRecord {
   if (input.description) record.description = input.description;
   if (input.updatedAt) record.updatedAt = input.updatedAt;
   if (input.tags && input.tags.length > 0) record.tags = input.tags;
-  if (input.textContent) record.textContent = input.textContent;
+  if (input.textContent) record.textContent = capTextContent(input.textContent);
   return record;
 }


### PR DESCRIPTION
Closes #1041 (item 2 of 2 — the `textContent` size-cap NIT from the #1037 review). Item 1 (orphan reconciliation) ships in #1043.

## Problem
`src/pages/standard-site.json.ts` embeds the full post plaintext in each document record's `textContent` with no upper bound. The [AT Protocol repository spec](https://atproto.com/specs/repository) leaves the hard maximum record size to PDS implementations ("Security Considerations" → "a maximum serialized object size"), so an unusually long post could grow the record — and its firehose events — without limit and risk a `putRecord` rejection.

## Change
`textContent` is supplementary: the canonical post lives on the site at the record's `path`, so it is safe to truncate. Added `capTextContent` and applied it in `buildDocumentRecord` — the single chokepoint every caller flows through.

The clamp is byte-accurate and code-point-safe:
- caps at a conservative **64 KiB** UTF-8 (the largest current post is ~11.5 KB, so no realistic post is trimmed);
- never splits a multi-byte code point — a trailing partial sequence is dropped rather than emitted as `U+FFFD`, so output is always valid UTF-8;
- backs off to a whitespace boundary when one is close, but never collapses a whitespace-free run to near-empty;
- appends a `[truncated]` marker, with its bytes accounted for inside the budget so the result is always `<= maxBytes`.

## Testing
`capTextContent` is exported and pure; verified via Node type-stripping across:
- short / exactly-at-limit → unchanged;
- over-limit → `<= 64 KiB`, marker appended, cut on a word boundary;
- emoji-heavy (4-byte code points) → within budget, no `U+FFFD`, no split code point;
- single giant whitespace-free token → capped but not collapsed;
- `buildDocumentRecord` applies the cap end-to-end.

`astro check`: 0 errors / 0 warnings (2 pre-existing `index.astro` hints). Biome clean.

(The website package has no test runner and is excluded from the root vitest scope, hence the exported-helper + local-verification approach.)