### PR TITLE
feat(core): traverse the entity graph during recall (entity-graph fan-in)

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -471,6 +471,32 @@ export const LoreConfig = z.object({
         .describe(
           "Minimum meaningful query terms (after stopword removal) to activate vector boost. Default: 2.",
         ),
+      /** Enable entity-graph fan-in for the recall tool. Default: true.
+       *  When an entity matches the query, recall traverses the entity graph
+       *  (knowledge_entity_refs + entity_relations) to also surface knowledge
+       *  linked to that entity and its 1-hop relation neighbors, scored by
+       *  depth-decay. Emitted as supplemental RRF lists: graph reachability only
+       *  ADDS fusion weight to a result, never removes a keyword/vector match's
+       *  own contribution (though a strongly graph-boosted item can still outrank
+       *  a weak keyword-only one). */
+      graphExpansion: z
+        .boolean()
+        .default(true)
+        .describe(
+          "Enable entity-graph fan-in (linked knowledge + 1-hop relation neighbors) for the recall tool. Default: true.",
+        ),
+      /** RRF weight multiplier for the entity-graph fan-in lists. Higher values
+       *  give graph-reachable knowledge/entities more influence in fusion. Set
+       *  to 0 to neutralize the graph signal without disabling traversal.
+       *  Default: 1.0. */
+      graphBoostWeight: z
+        .number()
+        .min(0)
+        .max(5)
+        .default(1.0)
+        .describe(
+          "RRF weight multiplier for entity-graph fan-in lists. Set to 0 to neutralize. Default: 1.0.",
+        ),
       /** Vector embedding search.
        *  Supports multiple providers:
        *  - "local" (default): @huggingface/transformers + nomic-embed-text-v1.5, no API key needed.
@@ -606,6 +632,8 @@ export const LoreConfig = z.object({
       queryExpansionMaxTerms: 8,
       vectorBoostWeight: 1.5,
       vectorBoostMinTerms: 2,
+      graphExpansion: true,
+      graphBoostWeight: 1.0,
       embeddings: {
         enabled: true,
         provider: "local" as const,

--- a/packages/core/src/entities.ts
+++ b/packages/core/src/entities.ts
@@ -1528,6 +1528,206 @@ export function knowledgeRefCounts(entityIds: string[]): Map<string, number> {
 }
 
 // ---------------------------------------------------------------------------
+// Graph traversal — entity-graph fan-in for recall
+// ---------------------------------------------------------------------------
+
+/**
+ * Batch-load the knowledge logical_ids that reference each of the given
+ * entities, in a single query. Returns a map keyed by entity id; entities with
+ * no refs map to an empty array. `knowledge_entity_refs.knowledge_id` stores the
+ * STABLE logical_id (A2, #823) — callers resolve the current entry via
+ * `ltm.getByLogical`, never `ltm.get`.
+ */
+function knowledgeRefsForEntities(entityIds: string[]): Map<string, string[]> {
+  const map = new Map<string, string[]>();
+  if (!entityIds.length) return map;
+  for (const id of entityIds) map.set(id, []);
+  // Chunk to stay under SQLite's bound-variable ceiling (matches the other
+  // batch helpers). Each entity's refs land in exactly one chunk.
+  const CHUNK = 900;
+  for (let i = 0; i < entityIds.length; i += CHUNK) {
+    const chunk = entityIds.slice(i, i + CHUNK);
+    const placeholders = chunk.map(() => "?").join(",");
+    const rows = db()
+      .query(
+        `SELECT entity_id, knowledge_id FROM knowledge_entity_refs WHERE entity_id IN (${placeholders})`,
+      )
+      .all(...chunk) as Array<{ entity_id: string; knowledge_id: string }>;
+    for (const r of rows) map.get(r.entity_id)?.push(r.knowledge_id);
+  }
+  return map;
+}
+
+/**
+ * Batch-load the 1-hop relation neighbors of each given entity, in a single
+ * query. Returns a map keyed by the input entity id → the ids of entities it is
+ * directly related to (either side of `entity_relations`). Input ids with no
+ * relations map to an empty array.
+ *
+ * A relation may connect two input ids in different chunks, so the same row can
+ * be returned by more than one chunk's query; pushing the neighbor twice is
+ * harmless because {@link graphExpand} deduplicates neighbors before use.
+ */
+function neighborsForEntities(entityIds: string[]): Map<string, string[]> {
+  const map = new Map<string, string[]>();
+  if (!entityIds.length) return map;
+  for (const id of entityIds) map.set(id, []);
+  const inputSet = new Set(entityIds);
+  // Each id is bound twice (entity_a IN, entity_b IN), so halve the chunk size
+  // relative to the single-bind helpers to stay under the variable ceiling.
+  const CHUNK = 450;
+  for (let i = 0; i < entityIds.length; i += CHUNK) {
+    const chunk = entityIds.slice(i, i + CHUNK);
+    const placeholders = chunk.map(() => "?").join(",");
+    const rows = db()
+      .query(
+        `SELECT entity_a, entity_b FROM entity_relations
+         WHERE entity_a IN (${placeholders}) OR entity_b IN (${placeholders})`,
+      )
+      .all(...chunk, ...chunk) as Array<{
+      entity_a: string;
+      entity_b: string;
+    }>;
+    for (const r of rows) {
+      if (inputSet.has(r.entity_a)) map.get(r.entity_a)?.push(r.entity_b);
+      if (inputSet.has(r.entity_b)) map.get(r.entity_b)?.push(r.entity_a);
+    }
+  }
+  return map;
+}
+
+/** A knowledge entry reached by traversing the entity graph from the seeds. */
+export type GraphKnowledgeHit = {
+  /** Stable logical_id (resolve with `ltm.getByLogical`). */
+  logicalId: string;
+  /** Smallest hop distance from any seed (0 = directly linked to a seed). */
+  depth: number;
+  /** Number of distinct seeds/neighbors in the matched subgraph that reference
+   *  this entry — a local centrality signal for THIS query. */
+  reach: number;
+  /** Ordering score: `1/(1+depth) · (1+ln(reach))`. Only the induced order is
+   *  consumed (recall fuses by list position via RRF). */
+  score: number;
+};
+
+/** A 1-hop neighbor entity reached by traversing the relation graph. */
+export type GraphEntityHit = {
+  id: string;
+  /** Hop distance from the nearest seed (always 1 today). */
+  depth: number;
+  /** Ordering score: `1/(1+depth) · (1+ln(1+globalRefCount))`. */
+  score: number;
+};
+
+export type GraphExpansion = {
+  knowledge: GraphKnowledgeHit[];
+  entities: GraphEntityHit[];
+};
+
+const GRAPH_DEFAULTS = {
+  maxSeeds: 8,
+  maxNeighbors: 12,
+  maxKnowledge: 20,
+} as const;
+
+/**
+ * Entity-graph fan-in for recall.
+ *
+ * Lore builds an entity graph — `knowledge_entity_refs` (entity ↔ knowledge) and
+ * `entity_relations` (entity ↔ entity) — but historically only the dashboard
+ * traversed it; search never did. This walks that graph from a set of seed
+ * entities (the entities a query matched lexically/semantically) and surfaces:
+ *
+ *   1. Knowledge entries linked to the seeds (depth 0) and to their 1-hop
+ *      relation neighbors (depth 1).
+ *   2. The 1-hop neighbor entities themselves.
+ *
+ * Results are scored with depth-decay × log-centrality and returned in score
+ * order. The scores exist only to ORDER the lists — recall feeds them to RRF,
+ * which fuses by list position, so absolute magnitudes are irrelevant. Ordering
+ * ties break deterministically by id so the output is stable across runs.
+ *
+ * Pure read-only graph traversal: bounded by `maxSeeds`/`maxNeighbors`/
+ * `maxKnowledge`, no visibility filtering (the caller applies project
+ * visibility when hydrating, mirroring `search()`/`ltm.searchScored()`).
+ */
+export function graphExpand(
+  seedEntityIds: string[],
+  opts?: { maxSeeds?: number; maxNeighbors?: number; maxKnowledge?: number },
+): GraphExpansion {
+  const maxSeeds = opts?.maxSeeds ?? GRAPH_DEFAULTS.maxSeeds;
+  const maxNeighbors = opts?.maxNeighbors ?? GRAPH_DEFAULTS.maxNeighbors;
+  const maxKnowledge = opts?.maxKnowledge ?? GRAPH_DEFAULTS.maxKnowledge;
+
+  // Dedupe + cap seeds, preserving caller order (best matches first).
+  const seeds: string[] = [];
+  const seedSet = new Set<string>();
+  for (const id of seedEntityIds) {
+    if (seedSet.has(id)) continue;
+    seedSet.add(id);
+    seeds.push(id);
+    if (seeds.length >= maxSeeds) break;
+  }
+  if (!seeds.length) return { knowledge: [], entities: [] };
+
+  // Depth-1 neighbors via the relation graph. A seed is depth 0, so neighbors
+  // that are themselves seeds are excluded from the neighbor set.
+  const neighborMap = neighborsForEntities(seeds);
+  const neighborSet = new Set<string>();
+  for (const nbrs of neighborMap.values()) {
+    for (const nbr of nbrs) {
+      if (!seedSet.has(nbr)) neighborSet.add(nbr);
+    }
+  }
+  // Cap neighbors deterministically (sorted by id) so the bound is stable.
+  const neighbors = [...neighborSet].sort().slice(0, maxNeighbors);
+
+  // Entity depth map: seeds = 0, neighbors = 1.
+  const entityDepth = new Map<string, number>();
+  for (const s of seeds) entityDepth.set(s, 0);
+  for (const n of neighbors) entityDepth.set(n, 1);
+
+  // Knowledge fan-in: every logical_id referenced by any seed or neighbor.
+  // Track the shallowest reaching depth and how many distinct entities reach it.
+  const refMap = knowledgeRefsForEntities([...entityDepth.keys()]);
+  const kAgg = new Map<string, { depth: number; reach: number }>();
+  for (const [entId, logicalIds] of refMap) {
+    const depth = entityDepth.get(entId) ?? 0;
+    for (const lid of logicalIds) {
+      const cur = kAgg.get(lid);
+      if (cur) {
+        cur.reach += 1;
+        if (depth < cur.depth) cur.depth = depth;
+      } else {
+        kAgg.set(lid, { depth, reach: 1 });
+      }
+    }
+  }
+  const knowledge: GraphKnowledgeHit[] = [...kAgg.entries()]
+    .map(([logicalId, { depth, reach }]) => ({
+      logicalId,
+      depth,
+      reach,
+      score: (1 / (1 + depth)) * (1 + Math.log(reach)),
+    }))
+    .sort((a, b) => b.score - a.score || (a.logicalId < b.logicalId ? -1 : 1))
+    .slice(0, maxKnowledge);
+
+  // Neighbor-entity scoring: depth-decay × log of the neighbor's global
+  // knowledge-ref count (a well-connected neighbor is more likely relevant).
+  const refCounts = knowledgeRefCounts(neighbors);
+  const entitiesScored: GraphEntityHit[] = neighbors
+    .map((id) => ({
+      id,
+      depth: 1,
+      score: (1 / (1 + 1)) * (1 + Math.log(1 + (refCounts.get(id) ?? 0))),
+    }))
+    .sort((a, b) => b.score - a.score || (a.id < b.id ? -1 : 1));
+
+  return { knowledge, entities: entitiesScored };
+}
+
+// ---------------------------------------------------------------------------
 // Session injection — hybrid cap-based entity selection
 // ---------------------------------------------------------------------------
 

--- a/packages/core/src/recall.ts
+++ b/packages/core/src/recall.ts
@@ -1154,6 +1154,109 @@ export async function searchRecall(
     }
   }
 
+  // Entity-graph fan-in: Lore builds an entity graph (knowledge_entity_refs +
+  // entity_relations) but search historically never traversed it — only the
+  // dashboard did. Walk that graph from the entities this query already matched
+  // (collected into the entity-tagged lists above) and surface (a) knowledge
+  // entries linked to those entities and their 1-hop relation neighbors, and
+  // (b) the neighbor entities themselves. Emitted as supplemental RRF lists with
+  // the same `k:`/`e:` keys, so graph-reachable items merge with (and are
+  // boosted by) the keyword/vector lists, while items reachable ONLY via the
+  // graph enter as fresh candidates. Gated to scopes that surface entities.
+  if (
+    (searchConfig?.graphExpansion ?? true) &&
+    (scope === "all" || scope === "project")
+  ) {
+    try {
+      // Seeds = entities matched lexically/semantically (entity FTS + vector +
+      // cross-repo). They were already visibility-filtered at their source, so
+      // seeding from them never leaks another project's project-scoped entity.
+      const seedIds = new Set<string>();
+      for (const list of allRrfLists) {
+        for (const it of list.items) {
+          if (it.source === "entity") seedIds.add(it.item.id);
+        }
+      }
+
+      if (seedIds.size) {
+        const expansion = entities.graphExpand([...seedIds], {
+          maxSeeds: 8,
+          maxNeighbors: 12,
+          maxKnowledge: limit * 2,
+        });
+        const graphWeight = searchConfig?.graphBoostWeight ?? 1.0;
+        const gpid = ensureProject(projectPath);
+
+        // (a) Graph-linked knowledge, ordered by graph score (depth-decay ×
+        // local reach). Hydrated via getByLogical (refs store logical_ids) and
+        // visibility-filtered to mirror ltm.searchScored — a knowledge entry
+        // linked to a shared entity may belong to another project. Same `k:`
+        // key as the BM25/vector knowledge lists so RRF merges, not duplicates.
+        if (knowledgeEnabled && expansion.knowledge.length) {
+          const graphKnowledge: TaggedResult[] = [];
+          for (const gk of expansion.knowledge) {
+            const entry = ltm.getByLogical(gk.logicalId);
+            if (!entry) continue;
+            const visible =
+              entry.project_id === gpid ||
+              entry.project_id === null ||
+              entry.cross_project === 1;
+            if (!visible) continue;
+            graphKnowledge.push({
+              source: "knowledge",
+              item: { ...entry, rank: -gk.score },
+            });
+          }
+          if (graphKnowledge.length) {
+            // Apply the same session-aware knowledge downweight the other
+            // knowledge lists use, so graph knowledge is deprioritized
+            // consistently when session-specific content exists.
+            const kgWeight = scope === "all" && hasSessionResults ? 0.6 : 1.0;
+            allRrfLists.push({
+              items: graphKnowledge,
+              key: (r) => `k:${r.item.id}`,
+              weight: graphWeight * kgWeight,
+            });
+          }
+        }
+
+        // (b) 1-hop neighbor entities, ordered by graph score. Hydrated +
+        // visibility-filtered (same predicate entities.search uses). Same `e:`
+        // key as the entity FTS/vector lists so RRF merges them.
+        if (expansion.entities.length) {
+          const neighborMap = await timer.await(
+            entities.getManyWithAliasesOffloaded(
+              expansion.entities.map((e) => e.id),
+            ),
+          );
+          const graphEntities: TaggedResult[] = [];
+          for (const ge of expansion.entities) {
+            const ent = neighborMap.get(ge.id);
+            if (!ent) continue;
+            const visible =
+              ent.project_id === gpid ||
+              ent.project_id === null ||
+              ent.cross_project === 1;
+            if (!visible) continue;
+            graphEntities.push({
+              source: "entity",
+              item: { ...ent, rank: -ge.score },
+            });
+          }
+          if (graphEntities.length) {
+            allRrfLists.push({
+              items: graphEntities,
+              key: (r) => `e:${r.item.id}`,
+              weight: graphWeight,
+            });
+          }
+        }
+      }
+    } catch (err) {
+      log.info("recall: entity-graph expansion failed (non-fatal):", err);
+    }
+  }
+
   // Distillation quality list: rank distillation candidates by a quality score
   // that combines temporal clustering (c_norm) and age. Segments with low c_norm
   // (uniformly distributed timestamps) are considered higher quality than bursty

--- a/packages/core/test/recall-graph.test.ts
+++ b/packages/core/test/recall-graph.test.ts
@@ -1,0 +1,387 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { LoreConfig } from "../src/config";
+import { db, ensureProject } from "../src/db";
+import * as entities from "../src/entities";
+import * as ltm from "../src/ltm";
+import { searchRecall } from "../src/recall";
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+function cleanup() {
+  const d = db();
+  d.exec("DELETE FROM entity_relations");
+  d.exec("DELETE FROM knowledge_entity_refs");
+  d.exec("DELETE FROM entity_aliases");
+  d.exec("DELETE FROM entities");
+  d.exec("DELETE FROM knowledge");
+}
+
+/** Create a project-scoped knowledge entry and link it to an entity. Returns
+ *  the stable logical_id. The title/content intentionally avoid the entity's
+ *  name so the entry is reachable ONLY through the entity graph. */
+function seedLinkedKnowledge(input: {
+  projectPath: string;
+  entityId: string;
+  title: string;
+  content: string;
+  crossProject?: boolean;
+}): string {
+  const id = ltm.create({
+    projectPath: input.projectPath,
+    scope: "project",
+    category: "decision",
+    title: input.title,
+    content: input.content,
+    crossProject: input.crossProject,
+  });
+  entities.linkKnowledge(id, input.entityId);
+  return id;
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests — entities.graphExpand
+// ---------------------------------------------------------------------------
+
+describe("entities.graphExpand — graph traversal scoring", () => {
+  const PROJECT = "/test/recall-graph/unit";
+
+  beforeEach(() => {
+    cleanup();
+    ensureProject(PROJECT);
+  });
+
+  test("empty seeds yield an empty expansion", () => {
+    expect(entities.graphExpand([])).toEqual({ knowledge: [], entities: [] });
+  });
+
+  test("a seed's directly-linked knowledge is depth 0, reach 1", () => {
+    const e = entities.create({
+      entityType: "person",
+      canonicalName: "Seed Person",
+      crossProject: true,
+    });
+    const k = seedLinkedKnowledge({
+      projectPath: PROJECT,
+      entityId: e.id,
+      title: "Anniversary dinner",
+      content: "Reserve the corner table by the window.",
+    });
+
+    const exp = entities.graphExpand([e.id]);
+    const hit = exp.knowledge.find((x) => x.logicalId === k);
+    expect(hit).toBeDefined();
+    expect(hit?.depth).toBe(0);
+    expect(hit?.reach).toBe(1);
+  });
+
+  test("a 1-hop relation neighbor surfaces as a depth-1 entity, and its knowledge as depth-1 knowledge", () => {
+    const a = entities.create({
+      entityType: "person",
+      canonicalName: "Alpha",
+      crossProject: true,
+    });
+    const b = entities.create({
+      entityType: "person",
+      canonicalName: "Bravo",
+      crossProject: true,
+    });
+    entities.addRelation(a.id, b.id, "colleague", { source: "test" });
+    const kb = seedLinkedKnowledge({
+      projectPath: PROJECT,
+      entityId: b.id,
+      title: "Deploy checklist",
+      content: "Restart the worker after pulling.",
+    });
+
+    const exp = entities.graphExpand([a.id]);
+
+    const neighbor = exp.entities.find((x) => x.id === b.id);
+    expect(neighbor).toBeDefined();
+    expect(neighbor?.depth).toBe(1);
+
+    const kHit = exp.knowledge.find((x) => x.logicalId === kb);
+    expect(kHit).toBeDefined();
+    expect(kHit?.depth).toBe(1);
+  });
+
+  test("depth-0 knowledge outranks depth-1 knowledge", () => {
+    const a = entities.create({
+      entityType: "person",
+      canonicalName: "Root",
+      crossProject: true,
+    });
+    const n = entities.create({
+      entityType: "person",
+      canonicalName: "Neighbor",
+      crossProject: true,
+    });
+    entities.addRelation(a.id, n.id, "colleague", { source: "test" });
+    const kDirect = seedLinkedKnowledge({
+      projectPath: PROJECT,
+      entityId: a.id,
+      title: "Direct fact",
+      content: "Linked straight to the seed.",
+    });
+    const kNeighbor = seedLinkedKnowledge({
+      projectPath: PROJECT,
+      entityId: n.id,
+      title: "Neighbor fact",
+      content: "Linked only to the neighbor.",
+    });
+
+    const exp = entities.graphExpand([a.id]);
+    const direct = exp.knowledge.find((x) => x.logicalId === kDirect);
+    const neighbor = exp.knowledge.find((x) => x.logicalId === kNeighbor);
+    expect(direct).toBeDefined();
+    expect(neighbor).toBeDefined();
+    expect((direct?.score ?? 0) > (neighbor?.score ?? 0)).toBe(true);
+    // Ordering must reflect the scores: direct appears before neighbor.
+    const di = exp.knowledge.findIndex((x) => x.logicalId === kDirect);
+    const ni = exp.knowledge.findIndex((x) => x.logicalId === kNeighbor);
+    expect(di).toBeLessThan(ni);
+  });
+
+  test("knowledge reached by multiple seeds outranks single-seed knowledge at the same depth", () => {
+    const s1 = entities.create({
+      entityType: "person",
+      canonicalName: "S One",
+      crossProject: true,
+    });
+    const s2 = entities.create({
+      entityType: "person",
+      canonicalName: "S Two",
+      crossProject: true,
+    });
+    const shared = seedLinkedKnowledge({
+      projectPath: PROJECT,
+      entityId: s1.id,
+      title: "Shared fact",
+      content: "Referenced by two seeds.",
+    });
+    entities.linkKnowledge(shared, s2.id); // now reach 2
+    const lone = seedLinkedKnowledge({
+      projectPath: PROJECT,
+      entityId: s1.id,
+      title: "Lone fact",
+      content: "Referenced by one seed.",
+    });
+
+    const exp = entities.graphExpand([s1.id, s2.id]);
+    const sharedHit = exp.knowledge.find((x) => x.logicalId === shared);
+    const loneHit = exp.knowledge.find((x) => x.logicalId === lone);
+    expect(sharedHit?.reach).toBe(2);
+    expect(loneHit?.reach).toBe(1);
+    expect((sharedHit?.score ?? 0) > (loneHit?.score ?? 0)).toBe(true);
+  });
+
+  test("maxNeighbors caps the neighbor set", () => {
+    const root = entities.create({
+      entityType: "person",
+      canonicalName: "Hub",
+      crossProject: true,
+    });
+    for (let i = 0; i < 5; i++) {
+      const nbr = entities.create({
+        entityType: "person",
+        canonicalName: `Spoke ${i}`,
+        crossProject: true,
+      });
+      entities.addRelation(root.id, nbr.id, "colleague", { source: "test" });
+    }
+    const exp = entities.graphExpand([root.id], { maxNeighbors: 2 });
+    expect(exp.entities.length).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests — searchRecall entity-graph fan-in
+// ---------------------------------------------------------------------------
+
+describe("searchRecall — entity-graph fan-in", () => {
+  const PROJECT = "/test/recall-graph/integration";
+
+  beforeEach(() => {
+    cleanup();
+    ensureProject(PROJECT);
+  });
+
+  test("a query matching an entity surfaces knowledge linked ONLY via the graph (#1)", async () => {
+    const e = entities.create({
+      entityType: "person",
+      canonicalName: "Seylan Çinar Kaya",
+      aliases: [{ type: "nickname", value: "Seylan" }],
+      crossProject: true,
+    });
+    // Knowledge whose text never mentions "Seylan" — unreachable by FTS/vector.
+    const k = seedLinkedKnowledge({
+      projectPath: PROJECT,
+      entityId: e.id,
+      title: "Anniversary reservation",
+      content: "Book the riverside restaurant in Vienna for the celebration.",
+    });
+
+    const withGraph = await searchRecall({
+      query: "Seylan",
+      projectPath: PROJECT,
+      scope: "all",
+    });
+    const found = withGraph.find(
+      (r) => r.item.source === "knowledge" && r.item.item.logical_id === k,
+    );
+    expect(found).toBeDefined();
+
+    // Red/green guard: disabling graph expansion makes the same entry
+    // unreachable, proving the fan-in (not some other path) surfaced it.
+    const cfg = LoreConfig.parse({}).search;
+    cfg.graphExpansion = false;
+    const withoutGraph = await searchRecall({
+      query: "Seylan",
+      projectPath: PROJECT,
+      scope: "all",
+      searchConfig: cfg,
+    });
+    expect(
+      withoutGraph.some(
+        (r) => r.item.source === "knowledge" && r.item.item.logical_id === k,
+      ),
+    ).toBe(false);
+  });
+
+  test("a 1-hop relation neighbor's knowledge surfaces, and the neighbor entity too (#2)", async () => {
+    const a = entities.create({
+      entityType: "person",
+      canonicalName: "Onur Temizkan",
+      crossProject: true,
+    });
+    const b = entities.create({
+      entityType: "person",
+      canonicalName: "Fatih Arslan",
+      crossProject: true,
+    });
+    entities.addRelation(a.id, b.id, "colleague", { source: "test" });
+    // Linked to B, never mentions the query term "Onur".
+    const k = seedLinkedKnowledge({
+      projectPath: PROJECT,
+      entityId: b.id,
+      title: "Release ritual",
+      content: "Always tag the build before publishing.",
+    });
+
+    const results = await searchRecall({
+      query: "Onur",
+      projectPath: PROJECT,
+      scope: "all",
+    });
+
+    // Neighbor knowledge surfaces via depth-1 traversal.
+    expect(
+      results.some(
+        (r) => r.item.source === "knowledge" && r.item.item.logical_id === k,
+      ),
+    ).toBe(true);
+    // The neighbor entity itself surfaces too.
+    expect(
+      results.some(
+        (r) => r.item.source === "entity" && r.item.item.id === b.id,
+      ),
+    ).toBe(true);
+  });
+
+  test("does not leak another project's project-scoped knowledge linked to a shared entity", async () => {
+    const OTHER = "/test/recall-graph/other";
+    ensureProject(OTHER);
+    // Cross-project entity is visible everywhere…
+    const e = entities.create({
+      entityType: "person",
+      canonicalName: "Seylan Çinar Kaya",
+      aliases: [{ type: "nickname", value: "Seylan" }],
+      crossProject: true,
+    });
+    // …but the knowledge linked to it is project-scoped to OTHER (cross_project
+    // = 0), so it must NOT surface when recalling from PROJECT.
+    const k = seedLinkedKnowledge({
+      projectPath: OTHER,
+      entityId: e.id,
+      title: "Other-project secret",
+      content: "Sensitive detail confined to the other project.",
+      crossProject: false,
+    });
+
+    const results = await searchRecall({
+      query: "Seylan",
+      projectPath: PROJECT,
+      scope: "all",
+    });
+    expect(
+      results.some(
+        (r) => r.item.source === "knowledge" && r.item.item.logical_id === k,
+      ),
+    ).toBe(false);
+  });
+
+  test("does not leak another project's project-scoped neighbor entity related to a shared entity", async () => {
+    const OTHER = "/test/recall-graph/other-entity";
+    ensureProject(OTHER);
+    // Cross-project seed entity — visible everywhere, matches the query.
+    const seed = entities.create({
+      entityType: "person",
+      canonicalName: "Seylan Çinar Kaya",
+      aliases: [{ type: "nickname", value: "Seylan" }],
+      crossProject: true,
+    });
+    // A 1-hop relation neighbor that is project-scoped to OTHER (cross_project
+    // = 0). graphExpand reaches it through the relation, so the ONLY thing
+    // keeping it out of a PROJECT recall is recall's visibility filter — which
+    // this test exists to guard against silent regression.
+    const neighbor = entities.create({
+      projectPath: OTHER,
+      entityType: "person",
+      canonicalName: "Private Other Person",
+      crossProject: false,
+    });
+    entities.addRelation(seed.id, neighbor.id, "colleague", { source: "test" });
+
+    const results = await searchRecall({
+      query: "Seylan",
+      projectPath: PROJECT,
+      scope: "all",
+    });
+    // The neighbor entity belongs to OTHER and is not cross-project, so it must
+    // not surface from PROJECT even though the graph reaches it.
+    expect(
+      results.some(
+        (r) => r.item.source === "entity" && r.item.item.id === neighbor.id,
+      ),
+    ).toBe(false);
+  });
+
+  test("no entity seeds (knowledge scope) means no graph fan-in", async () => {
+    const e = entities.create({
+      entityType: "person",
+      canonicalName: "Seylan Çinar Kaya",
+      aliases: [{ type: "nickname", value: "Seylan" }],
+      crossProject: true,
+    });
+    const k = seedLinkedKnowledge({
+      projectPath: PROJECT,
+      entityId: e.id,
+      title: "Anniversary reservation",
+      content: "Book the riverside restaurant in Vienna for the celebration.",
+    });
+
+    const results = await searchRecall({
+      query: "Seylan",
+      projectPath: PROJECT,
+      scope: "knowledge",
+    });
+    // Entity search is gated out of "knowledge" scope, so there are no seeds and
+    // the graph-only entry stays unreachable.
+    expect(
+      results.some(
+        (r) => r.item.source === "knowledge" && r.item.item.logical_id === k,
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/website/src/content/docs/docs/configuration.md
+++ b/packages/website/src/content/docs/docs/configuration.md
@@ -159,6 +159,8 @@ Recall and search pipeline tuning: FTS weights, query expansion, vector boost, e
 | `queryExpansionMaxTerms` | number | `8` | min 2, max 20 | Max query terms (after stopword removal) for LLM expansion. Longer queries skip expansion. Default: 8. |
 | `vectorBoostWeight` | number | `1.5` | min 1, max 5 | RRF weight multiplier for vector search lists (when query has enough terms). Set to 1.0 to disable. Default: 1.5. |
 | `vectorBoostMinTerms` | number | `2` | min 1, max 10 | Minimum meaningful query terms (after stopword removal) to activate vector boost. Default: 2. |
+| `graphExpansion` | boolean | `true` |  | Enable entity-graph fan-in (linked knowledge + 1-hop relation neighbors) for the recall tool. Default: true. |
+| `graphBoostWeight` | number | `1` | min 0, max 5 | RRF weight multiplier for entity-graph fan-in lists. Set to 0 to neutralize. Default: 1.0. |
 | `embeddings` | object | `{"enabled":true,"provider":"local","model":"nomic-ai/nomic-embed-text-v1.5","dimensions":768,"workerOffload":true,"workerPoolSize":2}` |  | Vector embedding search provider, model, and dimensions. |
 | `recall` | object | `{"charBudget":12000,"relevanceFloor":0.15,"maxResults":15,"absoluteFloor":0}` |  | Recall output formatting and result-count limits. |
 


### PR DESCRIPTION
## What

Lore builds an entity graph — `knowledge_entity_refs` (entity ↔ knowledge) and `entity_relations` (entity ↔ entity) — but **search never traversed it**; only the dashboard did. When a query matched an entity, the knowledge linked to that entity (and its relation neighbors) stayed unreachable unless it *also* matched by keyword or vector.

This closes that gap with an entity-graph **fan-in** during recall.

## How

New `entities.graphExpand(seedEntityIds, opts)` — a bounded, read-only walk from the entities a query already matched (the existing entity FTS / vector / cross-repo seeds) that surfaces:

1. **knowledge entries linked to those seeds** (depth 0) and to their **1-hop relation neighbors** (depth 1), and
2. **the neighbor entities themselves**,

scored by depth-decay × log-centrality: `1/(1+depth) · (1+ln(reach))`. Scores only *order* the lists — `searchRecall` feeds them to RRF, which fuses by list position, so magnitudes are irrelevant. Ordering ties break by id for deterministic output.

`searchRecall` emits the results as **supplemental RRF lists** keyed `k:`/`e:`, so graph-reachable items merge with (and are boosted by) the keyword/vector lists, while items reachable *only* via the graph enter as fresh candidates. Graph reachability only ever **adds** fusion weight to a result — it never removes a keyword/vector match's own contribution (though a strongly graph-boosted item can still re-rank above a weak keyword-only one under the result cap).

### Invariants preserved
- **Project visibility**: graph-linked knowledge and neighbor entities are filtered to the current project's visible set (`project_id == pid || project_id IS NULL || cross_project == 1`), mirroring `ltm.searchScored` / `entities.search`. A shared cross-project entity never leaks another project's project-scoped knowledge **or** project-scoped neighbor entity. (Both paths covered by dedicated, mutation-verified regression tests.)
- **Forward-compat with append-only knowledge (#823)**: refs store `logical_id`, so hydration goes through `ltm.getByLogical`, not `get(id)`.
- **Bounded**: `maxSeeds=8`, `maxNeighbors=12`, `maxKnowledge=2×recallLimit`; batched graph queries (`knowledgeRefsForEntities`, `neighborsForEntities`).
- **Scope-gated**: active only in `all`/`project` scopes (the scopes that surface entities). No entity seeds in `knowledge`/`session` scope ⇒ no fan-in.

## Config
- `search.graphExpansion` (default `true`) — kill switch.
- `search.graphBoostWeight` (default `1.0`) — RRF weight multiplier; `0` neutralizes the graph signal without disabling traversal.

## Tests
`packages/core/test/recall-graph.test.ts` (11 tests): unit coverage of `graphExpand` (depth/reach scoring, ordering, neighbor cap, empty seeds) + integration through `searchRecall` (graph-only knowledge surfaces; 1-hop neighbor knowledge + neighbor entity surface; cross-project **knowledge** leak guard; cross-project **neighbor-entity** leak guard; scope gate).

**Red-green verified** (each mutation reverts a specific guard and is confirmed to fail the corresponding test):
- `#1`/`#2` integration tests fail when `graphExpansion` is disabled (entries unreachable by any other path).
- depth-decay unit test fails when the `1/(1+depth)` factor is mutated out.
- knowledge-leak test fails when the knowledge visibility filter is removed.
- neighbor-entity-leak test fails when the entity visibility filter is removed.

- Full `@loreai/core` suite: **2245 passed, 6 skipped**.
- Typecheck + Biome + generated-docs check clean.

## Follow-up
- #1048 — batch + offload the graph-knowledge hydration (replace the synchronous `getByLogical` loop with a `getManyByLogicalOffloaded` variant), to match the #966 off-thread read pattern. Perf-only; tracked separately.