### PR TITLE
fix(plugins): keep the in-process gateway from corrupting the host TUI

### DIFF
--- a/packages/core/src/data-dir.ts
+++ b/packages/core/src/data-dir.ts
@@ -9,6 +9,7 @@
 import { existsSync, renameSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
+import { isStderrSilenced } from "./log";
 
 const OLD_DIR_NAME = "opencode-lore";
 const NEW_DIR_NAME = "lore";
@@ -48,8 +49,14 @@ function migrateDataDir(): void {
   try {
     if (existsSync(oldDir) && !existsSync(newDir)) {
       renameSync(oldDir, newDir);
-      // Can't use the lore logger here (circular dep), so use stderr.
-      console.error(`[lore] migrated data directory: ${oldDir} → ${newDir}`);
+      // The full logger would re-enter dataDir() (it resolves the log-file path
+      // through here), so we still write to stderr directly — but honor the
+      // embedded/TUI silence flag so this one-time notice can never corrupt a
+      // host TUI. `isStderrSilenced()` is a side-effect-free getter, so the
+      // log↔data-dir module cycle stays safe.
+      if (!isStderrSilenced()) {
+        console.error(`[lore] migrated data directory: ${oldDir} → ${newDir}`);
+      }
     }
   } catch {
     // Permission error, cross-device rename, concurrent process already

--- a/packages/core/src/log.ts
+++ b/packages/core/src/log.ts
@@ -99,7 +99,21 @@ const isDebug =
 // operators read embedded-gateway logs with `lore logs` or by running the
 // gateway standalone. Standalone `lore`/CLI processes never call this, so they
 // keep full stderr visibility.
-let stderrSilenced = false;
+//
+// 🔴 The flag lives on `globalThis`, NOT a module-level `let`. The in-process
+// gateway can be a SECOND copy of @loreai/core: the gateway's Node/CJS bundle
+// (`dist/index.cjs`) bundles core in, so it is a distinct module instance from
+// the one the plugin imports (only the Bun bundle keeps core external — see
+// gateway `script/bundle.ts`). A module-level flag set by the plugin's core
+// instance would NOT be seen by the gateway's bundled core instance, leaving
+// the in-process gateway's own `[lore]` lines writing to the TUI. `globalThis`
+// is the single object shared across every core instance in the main thread,
+// so one `silenceStderr()` call silences them all.
+const STDERR_SILENCED_KEY = "__loreStderrSilenced";
+
+function readStderrSilenced(): boolean {
+  return (globalThis as Record<string, unknown>)[STDERR_SILENCED_KEY] === true;
+}
 
 /**
  * Silence ALL stderr output from the logger (`info`/`warn`/`notice`/`error`),
@@ -107,15 +121,16 @@ let stderrSilenced = false;
  * registered {@link LogSink} keep receiving everything, so nothing is lost.
  *
  * Call this from a host that runs the gateway in-process inside a full-screen
- * TUI (the Pi extension, the OpenCode plugin). Idempotent.
+ * TUI (the Pi extension, the OpenCode plugin). Process-global and idempotent,
+ * so it is honored even by a separately-bundled core instance.
  */
 export function silenceStderr(silenced = true): void {
-  stderrSilenced = silenced;
+  (globalThis as Record<string, unknown>)[STDERR_SILENCED_KEY] = silenced;
 }
 
 /** Whether stderr output is currently silenced (embedded/TUI mode). */
 export function isStderrSilenced(): boolean {
-  return stderrSilenced;
+  return readStderrSilenced();
 }
 
 /** Format variadic args into a single string for the sink. */
@@ -212,7 +227,7 @@ function writeToFile(level: string, message: string): void {
 
 /** Log an informational status message. Suppressed unless LORE_DEBUG=1. */
 export function info(...args: unknown[]): void {
-  if (isDebug && !stderrSilenced) console.error("[lore]", ...args);
+  if (isDebug && !readStderrSilenced()) console.error("[lore]", ...args);
   const msg = formatArgs(args);
   sink?.info(msg);
   writeToFile("info", msg);
@@ -220,7 +235,7 @@ export function info(...args: unknown[]): void {
 
 /** Log a warning. Suppressed unless LORE_DEBUG=1. */
 export function warn(...args: unknown[]): void {
-  if (isDebug && !stderrSilenced) console.error("[lore] WARN:", ...args);
+  if (isDebug && !readStderrSilenced()) console.error("[lore] WARN:", ...args);
   const msg = formatArgs(args);
   sink?.warn(msg);
   writeToFile("warn", msg);
@@ -235,7 +250,7 @@ export function warn(...args: unknown[]): void {
  * silenced on stderr in embedded/TUI mode but still hits the file and sink.
  */
 export function notice(...args: unknown[]): void {
-  if (!stderrSilenced) console.error("[lore]", ...args);
+  if (!readStderrSilenced()) console.error("[lore]", ...args);
   const msg = formatArgs(args);
   sink?.warn(msg);
   writeToFile("warn", msg);
@@ -243,7 +258,7 @@ export function notice(...args: unknown[]): void {
 
 /** Log an error. Always visible — these indicate real failures. */
 export function error(...args: unknown[]): void {
-  if (!stderrSilenced) console.error("[lore]", ...args);
+  if (!readStderrSilenced()) console.error("[lore]", ...args);
   const msg = formatArgs(args);
   sink?.error(msg);
   writeToFile("error", msg);

--- a/packages/core/src/log.ts
+++ b/packages/core/src/log.ts
@@ -81,6 +81,43 @@ const isDebug =
   process.env.LORE_DEBUG === "1" ||
   process.env.LORE_DEBUG?.toLowerCase() === "true";
 
+// ---------------------------------------------------------------------------
+// Embedded / TUI-safe mode
+// ---------------------------------------------------------------------------
+
+// When the gateway runs *in-process* inside a host that owns a full-screen TUI
+// — the Pi extension and the OpenCode plugin both `import("@loreai/gateway")`
+// and call `startGateway()` rather than spawning a separate process — ANY byte
+// written to stdout/stderr corrupts that TUI. This is the exact class of bug
+// that broke Pi on Windows (raw `console.*` lines bleeding into the render),
+// and `log.error` is just as fatal there as a stray `console.log`.
+//
+// The host enables this switch once, on activation, via `silenceStderr()`.
+// From then on the logger writes ONLY to the persistent log file and the
+// registered {@link LogSink} (e.g. Sentry) — NEVER to stderr, for every level
+// including `error`, and even when `LORE_DEBUG=1`. The TUI is sacrosanct;
+// operators read embedded-gateway logs with `lore logs` or by running the
+// gateway standalone. Standalone `lore`/CLI processes never call this, so they
+// keep full stderr visibility.
+let stderrSilenced = false;
+
+/**
+ * Silence ALL stderr output from the logger (`info`/`warn`/`notice`/`error`),
+ * unconditionally — including when `LORE_DEBUG=1`. The file sink and the
+ * registered {@link LogSink} keep receiving everything, so nothing is lost.
+ *
+ * Call this from a host that runs the gateway in-process inside a full-screen
+ * TUI (the Pi extension, the OpenCode plugin). Idempotent.
+ */
+export function silenceStderr(silenced = true): void {
+  stderrSilenced = silenced;
+}
+
+/** Whether stderr output is currently silenced (embedded/TUI mode). */
+export function isStderrSilenced(): boolean {
+  return stderrSilenced;
+}
+
 /** Format variadic args into a single string for the sink. */
 function formatArgs(args: unknown[]): string {
   return args
@@ -175,7 +212,7 @@ function writeToFile(level: string, message: string): void {
 
 /** Log an informational status message. Suppressed unless LORE_DEBUG=1. */
 export function info(...args: unknown[]): void {
-  if (isDebug) console.error("[lore]", ...args);
+  if (isDebug && !stderrSilenced) console.error("[lore]", ...args);
   const msg = formatArgs(args);
   sink?.info(msg);
   writeToFile("info", msg);
@@ -183,7 +220,22 @@ export function info(...args: unknown[]): void {
 
 /** Log a warning. Suppressed unless LORE_DEBUG=1. */
 export function warn(...args: unknown[]): void {
-  if (isDebug) console.error("[lore] WARN:", ...args);
+  if (isDebug && !stderrSilenced) console.error("[lore] WARN:", ...args);
+  const msg = formatArgs(args);
+  sink?.warn(msg);
+  writeToFile("warn", msg);
+}
+
+/**
+ * Log a user-facing notice — a warning the user likely needs to act on (e.g.
+ * data misattribution, an ignored malformed env var). Unlike {@link warn} it
+ * is NOT debug-gated, so it stays visible on a standalone CLI/terminal; unlike
+ * {@link error} it is reported to the sink at *warning* severity (these are not
+ * failures, so they must not inflate the error stream). Like every level it is
+ * silenced on stderr in embedded/TUI mode but still hits the file and sink.
+ */
+export function notice(...args: unknown[]): void {
+  if (!stderrSilenced) console.error("[lore]", ...args);
   const msg = formatArgs(args);
   sink?.warn(msg);
   writeToFile("warn", msg);
@@ -191,7 +243,7 @@ export function warn(...args: unknown[]): void {
 
 /** Log an error. Always visible — these indicate real failures. */
 export function error(...args: unknown[]): void {
-  console.error("[lore]", ...args);
+  if (!stderrSilenced) console.error("[lore]", ...args);
   const msg = formatArgs(args);
   sink?.error(msg);
   writeToFile("error", msg);

--- a/packages/core/test/log.test.ts
+++ b/packages/core/test/log.test.ts
@@ -107,6 +107,26 @@ describe("log stderr silencing (embedded/TUI mode)", () => {
     expect(sink.captureException).not.toHaveBeenCalled();
   });
 
+  it("shares the silence flag across SEPARATE core module instances (bundled-gateway safety)", async () => {
+    // The in-process gateway can be a second, independently-bundled copy of
+    // @loreai/core (its Node/CJS bundle inlines core). The plugin silences via
+    // its own copy; the gateway logs via its bundled copy. A module-level flag
+    // would not cross that boundary — so the flag must be process-global.
+    const first = await freshLog(undefined);
+    first.silenceStderr(true);
+
+    // A genuinely different module instance (as the gateway's bundled core is
+    // at runtime) must observe the flag set by the first instance.
+    vi.resetModules();
+    const second = await import("../src/log");
+    expect(second).not.toBe(first);
+    expect(second.isStderrSilenced()).toBe(true);
+
+    // ...and clearing it from the second instance is seen by the first.
+    second.silenceStderr(false);
+    expect(first.isStderrSilenced()).toBe(false);
+  });
+
   it("silenceStderr(false) restores stderr visibility", async () => {
     const log = await freshLog(undefined);
     log.silenceStderr(true);

--- a/packages/core/test/log.test.ts
+++ b/packages/core/test/log.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Import a fresh copy of the log module with a controlled `LORE_DEBUG` value.
+ *
+ * `isDebug` (and the `stderrSilenced` flag) are module-level state captured at
+ * import time, so each test resets the module registry to get a clean,
+ * deterministic instance regardless of the ambient environment.
+ */
+async function freshLog(debug: string | undefined) {
+  if (debug === undefined) delete process.env.LORE_DEBUG;
+  else process.env.LORE_DEBUG = debug;
+  vi.resetModules();
+  return import("../src/log");
+}
+
+function makeSink() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    captureException: vi.fn(),
+  };
+}
+
+describe("log stderr silencing (embedded/TUI mode)", () => {
+  let stderr: ReturnType<typeof vi.spyOn>;
+  const savedDebug = process.env.LORE_DEBUG;
+
+  beforeEach(() => {
+    stderr = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    stderr.mockRestore();
+    if (savedDebug === undefined) delete process.env.LORE_DEBUG;
+    else process.env.LORE_DEBUG = savedDebug;
+    vi.resetModules();
+  });
+
+  it("writes errors and notices to stderr by default", async () => {
+    const log = await freshLog(undefined);
+    expect(log.isStderrSilenced()).toBe(false);
+
+    log.error("boom");
+    log.notice("heads up");
+
+    expect(stderr).toHaveBeenCalledWith("[lore]", "boom");
+    expect(stderr).toHaveBeenCalledWith("[lore]", "heads up");
+  });
+
+  it("silenceStderr() suppresses stderr for EVERY level, even with LORE_DEBUG=1", async () => {
+    // LORE_DEBUG=1 would normally let info/warn through too — silencing wins.
+    const log = await freshLog("1");
+    log.silenceStderr();
+    expect(log.isStderrSilenced()).toBe(true);
+
+    log.info("i");
+    log.warn("w");
+    log.notice("n");
+    log.error("e");
+
+    expect(stderr).not.toHaveBeenCalled();
+  });
+
+  it("keeps forwarding to the file/sink while stderr is silenced", async () => {
+    const log = await freshLog("1");
+    const sink = makeSink();
+    log.registerSink(sink);
+    log.silenceStderr();
+
+    log.info("i");
+    log.warn("w");
+    log.notice("n");
+    log.error("e");
+
+    // Nothing reached the TUI...
+    expect(stderr).not.toHaveBeenCalled();
+    // ...but the sink (Sentry/file bridge) still received everything.
+    expect(sink.info).toHaveBeenCalledWith("i");
+    expect(sink.warn).toHaveBeenCalledWith("w");
+    expect(sink.warn).toHaveBeenCalledWith("n"); // notice -> warn severity
+    expect(sink.error).toHaveBeenCalledWith("e");
+  });
+
+  it("notice is NOT debug-gated (visible on a standalone CLI), unlike warn", async () => {
+    const log = await freshLog(undefined); // LORE_DEBUG unset -> isDebug false
+    expect(log.isStderrSilenced()).toBe(false);
+
+    log.warn("should-be-hidden");
+    log.notice("should-be-visible");
+
+    // warn is suppressed without debug; notice is always visible.
+    expect(stderr).not.toHaveBeenCalledWith("[lore] WARN:", "should-be-hidden");
+    expect(stderr).toHaveBeenCalledWith("[lore]", "should-be-visible");
+  });
+
+  it("notice reports to the sink at WARNING severity, not error", async () => {
+    const log = await freshLog(undefined);
+    const sink = makeSink();
+    log.registerSink(sink);
+
+    log.notice("misattribution warning");
+
+    expect(sink.warn).toHaveBeenCalledWith("misattribution warning");
+    expect(sink.error).not.toHaveBeenCalled();
+    expect(sink.captureException).not.toHaveBeenCalled();
+  });
+
+  it("silenceStderr(false) restores stderr visibility", async () => {
+    const log = await freshLog(undefined);
+    log.silenceStderr(true);
+    expect(log.isStderrSilenced()).toBe(true);
+    log.silenceStderr(false);
+    expect(log.isStderrSilenced()).toBe(false);
+
+    log.error("now visible");
+    expect(stderr).toHaveBeenCalledWith("[lore]", "now visible");
+  });
+});

--- a/packages/core/test/setup.ts
+++ b/packages/core/test/setup.ts
@@ -1,8 +1,9 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { afterAll } from "vitest";
+import { afterAll, afterEach } from "vitest";
 import { close } from "../src/db";
+import { silenceStderr } from "../src/log";
 
 // Create an isolated temporary database for the entire test run.
 // This prevents test fixtures from leaking into the live lore DB
@@ -78,6 +79,15 @@ globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
   }
   return realFetch(input, init);
 }) as typeof globalThis.fetch;
+
+// The Pi/OpenCode plugins flip `log.silenceStderr()` when they activate inside
+// their TUI host. A force-active plugin test (LORE_*_FORCE_ACTIVE=1) would
+// otherwise leave stderr silenced for the rest of the fork — hiding logs from,
+// or vacuating "no output" assertions in, unrelated test files that share it.
+// Reset after every test so silenced state never crosses a test boundary.
+afterEach(() => {
+  silenceStderr(false);
+});
 
 afterAll(() => {
   close();

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -9,6 +9,7 @@ import {
   discoverWorkspaceRoot,
   UNATTRIBUTED_PROJECT_PREFIX,
   isUnattributedProjectPath,
+  log,
 } from "@loreai/core";
 
 // ---------------------------------------------------------------------------
@@ -875,9 +876,7 @@ function parsePort(value: string | undefined, fallback: number): number {
   if (!value) return fallback;
   const n = Number.parseInt(value, 10);
   if (Number.isNaN(n) || n < 0 || n > 65535) {
-    console.error(
-      `[lore] warning: invalid port "${value}", using default ${fallback}`,
-    );
+    log.notice(`warning: invalid port "${value}", using default ${fallback}`);
     return fallback;
   }
   return n;
@@ -887,9 +886,7 @@ function parsePositiveInt(value: string | undefined, fallback: number): number {
   if (!value) return fallback;
   const n = Number.parseInt(value, 10);
   if (Number.isNaN(n) || n <= 0) {
-    console.error(
-      `[lore] warning: invalid value "${value}", using default ${fallback}`,
-    );
+    log.notice(`warning: invalid value "${value}", using default ${fallback}`);
     return fallback;
   }
   return n;
@@ -903,9 +900,7 @@ function parseNonNegativeInt(
   if (!value) return fallback;
   const n = Number.parseInt(value, 10);
   if (Number.isNaN(n) || n < 0) {
-    console.error(
-      `[lore] warning: invalid value "${value}", using default ${fallback}`,
-    );
+    log.notice(`warning: invalid value "${value}", using default ${fallback}`);
     return fallback;
   }
   return n;
@@ -976,8 +971,8 @@ export function parseCurlHeaders(
     if (!line) continue;
     const colonIdx = line.indexOf(":");
     if (colonIdx <= 0) {
-      console.error(
-        `[lore] warning: ignoring malformed LORE_UPSTREAM_EXTRA_HEADERS line: ${JSON.stringify(line)}`,
+      log.notice(
+        `warning: ignoring malformed LORE_UPSTREAM_EXTRA_HEADERS line: ${JSON.stringify(line)}`,
       );
       continue;
     }
@@ -989,8 +984,8 @@ export function parseCurlHeaders(
     // biome-ignore lint/suspicious/noControlCharactersInRegex: intentional control-character sanitization
     const value = rawValue.replace(/[\x00-\x1f\x7f]/g, "").trim();
     if (!name || !/^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/.test(name)) {
-      console.error(
-        `[lore] warning: ignoring invalid header name in LORE_UPSTREAM_EXTRA_HEADERS: ${JSON.stringify(rawName)}`,
+      log.notice(
+        `warning: ignoring invalid header name in LORE_UPSTREAM_EXTRA_HEADERS: ${JSON.stringify(rawName)}`,
       );
       continue;
     }

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -2277,8 +2277,8 @@ export function resolveSessionProjectPath(
       !staleHeaderWarned.has(sessionState.sessionID)
     ) {
       staleHeaderWarned.add(sessionState.sessionID);
-      console.error(
-        `[lore] warning: session ${sessionState.sessionID.slice(0, 16)} sent ` +
+      log.notice(
+        `warning: session ${sessionState.sessionID.slice(0, 16)} sent ` +
           `X-Lore-Project header "${result.overrodeHeaderPath}" but its system ` +
           `prompt's working directory is "${projectPath}" — trusting the ` +
           `inferred path. A stale/static X-Lore-Project header (e.g. a fixed ` +
@@ -2366,8 +2366,8 @@ export function resolveSessionProjectPath(
     const detail = config.remoteGateway
       ? `routed to provisional bucket ${projectPath}`
       : `falling back to process.cwd() (${projectPath})`;
-    console.error(
-      `[lore] warning: could not determine project for session ` +
+    log.notice(
+      `warning: could not determine project for session ` +
         `${sessionState.sessionID.slice(0, 16)} — ${detail}. ` +
         `Data may be misattributed. Fix: launch your agent via \`lore run\`, ` +
         `or have your client send the "X-Lore-Project: /path/to/project" header ` +

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -18,6 +18,7 @@ import { createServer as createHttpServer } from "node:http";
 import type { Server } from "node:http";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { Readable } from "node:stream";
+import { log } from "@loreai/core";
 import { DEFAULT_PORT, type GatewayConfig } from "./config";
 import { bootstrapDailySpend, getDailyBudget } from "./cost-tracker";
 import {
@@ -175,7 +176,7 @@ async function handleAnthropicMessages(
     return withCors(result);
   } catch (e) {
     const msg = e instanceof Error ? e.message : "Pipeline error";
-    console.error(`[lore] pipeline error: ${msg}`);
+    log.error(`pipeline error: ${msg}`);
     return errorResponse(502, "api_error", `Gateway pipeline error: ${msg}`);
   }
 }
@@ -257,7 +258,7 @@ async function handleOpenAIChatCompletions(
     return withCors(await handleRequest(gatewayReq, config));
   } catch (e) {
     const msg = e instanceof Error ? e.message : "Pipeline error";
-    console.error(`[lore] pipeline error: ${msg}`);
+    log.error(`pipeline error: ${msg}`);
     return errorResponse(502, "api_error", `Gateway pipeline error: ${msg}`);
   }
 }
@@ -291,7 +292,7 @@ async function handleOpenAIResponses(
     return withCors(await handleRequest(gatewayReq, config));
   } catch (e) {
     const msg = e instanceof Error ? e.message : "Pipeline error";
-    console.error(`[lore] pipeline error: ${msg}`);
+    log.error(`pipeline error: ${msg}`);
     return errorResponse(502, "api_error", `Gateway pipeline error: ${msg}`);
   }
 }
@@ -326,7 +327,7 @@ async function handleOpenAICodexResponses(
     return withCors(await handleRequest(gatewayReq, config));
   } catch (e) {
     const msg = e instanceof Error ? e.message : "Pipeline error";
-    console.error(`[lore] pipeline error: ${msg}`);
+    log.error(`pipeline error: ${msg}`);
     return errorResponse(502, "api_error", `Gateway pipeline error: ${msg}`);
   }
 }
@@ -346,8 +347,8 @@ export async function startServer(config: GatewayConfig): Promise<{
   // loadConfig() always provides these, but startServer is a public export.
   config = config ?? ({} as GatewayConfig);
   if (!config.hosts?.length) {
-    console.error(
-      `[lore] warning: config.hosts is empty or missing, defaulting to ["127.0.0.1"]. ` +
+    log.notice(
+      `warning: config.hosts is empty or missing, defaulting to ["127.0.0.1"]. ` +
         `Use loadConfig() or startGateway() for a fully-populated config.`,
     );
     config = { ...config, hosts: ["127.0.0.1"] };
@@ -384,7 +385,7 @@ export async function startServer(config: GatewayConfig): Promise<{
       return withCors(new Response(null, { status: 204 }));
     }
 
-    if (config.debug) {
+    if (config.debug && !log.isStderrSilenced()) {
       console.error(`[lore] ${method} ${pathname}`);
     }
 
@@ -393,7 +394,7 @@ export async function startServer(config: GatewayConfig): Promise<{
     // definitively rather than returning a misleading 404 (which caused
     // repeated upgrade attempts and noisy logs).
     if (isWebSocketUpgrade(req)) {
-      if (config.debug) {
+      if (config.debug && !log.isStderrSilenced()) {
         console.error(
           `[lore] rejecting WebSocket upgrade for ${pathname} (HTTP-only gateway)`,
         );
@@ -496,7 +497,7 @@ export async function startServer(config: GatewayConfig): Promise<{
       );
     } catch (e) {
       const msg = e instanceof Error ? e.message : "Internal server error";
-      console.error(`[lore] uncaught error: ${msg}`);
+      log.error(`uncaught error: ${msg}`);
       return errorResponse(500, "api_error", msg);
     }
   };
@@ -530,7 +531,7 @@ export async function startServer(config: GatewayConfig): Promise<{
       // install a dedicated listener that writes a 426 + closes the socket.
       // Mirrors the `isWebSocketUpgrade` rejection in the fetch handler.
       s.on("upgrade", (req, socket) => {
-        if (config.debug) {
+        if (config.debug && !log.isStderrSilenced()) {
           console.error(
             `[lore] rejecting WebSocket upgrade for ${req.url ?? "/"} (HTTP-only gateway)`,
           );
@@ -581,8 +582,8 @@ export async function startServer(config: GatewayConfig): Promise<{
           // Always warn (not just in debug): silently degrading to loopback-only
           // when an explicitly-configured host is dropped is surprising, and the
           // event is low-frequency and actionable.
-          console.error(
-            `[lore] configured host ${host} is unavailable (${addressErrorCode(e)}); skipping it and serving on the remaining hosts`,
+          log.notice(
+            `configured host ${host} is unavailable (${addressErrorCode(e)}); skipping it and serving on the remaining hosts`,
           );
           continue;
         }
@@ -785,7 +786,7 @@ async function handleNodeRequest(
     }
     nodeRes.end();
   } catch (err) {
-    console.error("[lore] request handler error:", err);
+    log.error("request handler error:", err);
     if (!nodeRes.headersSent) {
       nodeRes.writeHead(500, { "content-type": "application/json" });
     }

--- a/packages/gateway/src/stream/openai-responses.ts
+++ b/packages/gateway/src/stream/openai-responses.ts
@@ -14,6 +14,7 @@
  * Reuses `parseSSEStream` from the Anthropic stream module since the
  * underlying SSE wire format is the same.
  */
+import { log } from "@loreai/core";
 import {
   ZERO_USAGE,
   type GatewayContentBlock,
@@ -695,7 +696,7 @@ export function translateAnthropicStreamToResponses(
           }
         }
       } catch (err) {
-        console.error("[lore] openai-responses stream translation error:", err);
+        log.error("openai-responses stream translation error:", err);
         // Emit a response.failed event so clients don't hang waiting
         try {
           controller.enqueue(

--- a/packages/gateway/src/stream/openai.ts
+++ b/packages/gateway/src/stream/openai.ts
@@ -17,6 +17,7 @@
  * events, and `createStreamAccumulator` to build the internal GatewayResponse
  * (for pipeline post-processing that may read it).
  */
+import { log } from "@loreai/core";
 import { ZERO_USAGE } from "../translate/types";
 import { parseSSEStream, createStreamAccumulator } from "./anthropic";
 
@@ -312,7 +313,7 @@ export function translateAnthropicStreamToOpenAI(
         } catch {
           // Controller may already be closed
         }
-        console.error("[lore] openai stream translation error:", err);
+        log.error("openai stream translation error:", err);
       } finally {
         try {
           controller.close();

--- a/packages/gateway/src/sync.ts
+++ b/packages/gateway/src/sync.ts
@@ -22,7 +22,7 @@
  *                          skipped).
  */
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { syncData, getKV, setKV } from "@loreai/core";
+import { syncData, getKV, setKV, log } from "@loreai/core";
 import { getAuthedClient } from "./supabase";
 
 const PAGE = 200;
@@ -214,9 +214,7 @@ async function pushEntry(
       .update(tombstone)
       .match(decomposeId(table, effectiveId));
     if (error) {
-      console.error(
-        `sync: push delete ${table}/${effectiveId}: ${error.message}`,
-      );
+      log.notice(`sync: push delete ${table}/${effectiveId}: ${error.message}`);
       return "stop"; // transient; keep pending so the delete isn't lost
     }
     const prev = syncData.getSyncState(table, effectiveId);
@@ -263,14 +261,14 @@ async function pushEntry(
     const kind = classifyPushError(error);
     if (kind === "quota") {
       if (!res.quotaHit) res.quotaHit = { table, message: error.message };
-      console.error(`sync: quota on ${table} — ${error.message}`);
+      log.notice(`sync: quota on ${table} — ${error.message}`);
       return "stop"; // pause THIS table; keep the row pending (a delete frees it)
     }
     if (kind === "poison") {
       // The row violates a size/other CHECK and can NEVER be uploaded. Do NOT
       // pause the table (that would wedge it forever) — record it and advance
       // past it so the rest of the table keeps syncing.
-      console.error(
+      log.notice(
         `sync: dropping unsyncable ${table}/${effectiveId}: ${error.message}`,
       );
       syncData.recordConflict(table, effectiveId, "rejected_unsyncable", row);
@@ -282,9 +280,7 @@ async function pushEntry(
       });
       return "ok";
     }
-    console.error(
-      `sync: push upsert ${table}/${effectiveId}: ${error.message}`,
-    );
+    log.notice(`sync: push upsert ${table}/${effectiveId}: ${error.message}`);
     return "stop"; // transient — keep pending so we retry (never lose a write)
   }
 
@@ -346,7 +342,7 @@ export async function pullOnce(client: SupabaseClient): Promise<SyncResult> {
       q = q.gte("updated_at", sinceIso);
       const { data, error } = await q;
       if (error) {
-        console.error(`sync: pull ${meta.table}: ${error.message}`);
+        log.notice(`sync: pull ${meta.table}: ${error.message}`);
         break;
       }
       const rows = (data ?? []) as Array<Record<string, unknown>>;
@@ -419,7 +415,7 @@ async function drainTimestamp(
     for (const c of cols) q = q.order(c, { ascending: true });
     const { data, error } = await q.limit(PAGE);
     if (error) {
-      console.error(`sync: pull drain ${meta.table}: ${error.message}`);
+      log.notice(`sync: pull drain ${meta.table}: ${error.message}`);
       break;
     }
     let rows = (data ?? []) as Array<Record<string, unknown>>;
@@ -438,7 +434,7 @@ async function drainTimestamp(
         .order(cols[1], { ascending: true })
         .limit(PAGE);
       if (nextErr) {
-        console.error(`sync: pull drain ${meta.table}: ${nextErr.message}`);
+        log.notice(`sync: pull drain ${meta.table}: ${nextErr.message}`);
         break;
       }
       rows = (next ?? []) as Array<Record<string, unknown>>;
@@ -587,13 +583,13 @@ export function startSyncScheduler(
     inflight = syncOnce()
       .then((r) => {
         if (r.quotaHit) {
-          console.error(
+          log.notice(
             `sync: quota reached on ${r.quotaHit.table}; that table paused until next change`,
           );
         }
       })
       .catch((e) =>
-        console.error(`sync: background cycle failed: ${(e as Error).message}`),
+        log.error(`sync: background cycle failed: ${(e as Error).message}`),
       )
       .finally(() => {
         inflight = null;

--- a/packages/gateway/src/vertex-auth.ts
+++ b/packages/gateway/src/vertex-auth.ts
@@ -14,6 +14,7 @@
  * the access token and refreshes it before expiry, so `getVertexAccessToken`
  * is cheap to call per request.
  */
+import { log } from "@loreai/core";
 import { GoogleAuth } from "google-auth-library";
 
 /** OAuth2 scope required to call Vertex AI (aiplatform). */
@@ -57,10 +58,7 @@ export async function getVertexAccessToken(): Promise<string> {
     // client (the conversation path surfaces it), and the raw ADC error may
     // reveal local file paths / project hints. Keep the client message generic
     // but actionable.
-    console.error(
-      "[lore] Vertex ADC token mint failed:",
-      (err as Error).message,
-    );
+    log.error("Vertex ADC token mint failed:", (err as Error).message);
     throw new Error(
       "Vertex: failed to obtain a GCP access token via Application Default " +
         "Credentials. Run `gcloud auth application-default login`, or set " +

--- a/packages/gateway/test/sync.test.ts
+++ b/packages/gateway/test/sync.test.ts
@@ -592,6 +592,51 @@ describe("BLOCKER regressions", () => {
   });
 });
 
+// The sync scheduler runs IN-PROCESS inside the Pi/OpenCode plugins, which own
+// a full-screen TUI. Its background error notices used to be raw `console.error`
+// — any byte of which corrupts the render (the class of bug that broke Pi on
+// Windows). They now route through `@loreai/core`'s `log`, so the host's
+// `silenceStderr()` switch suppresses them. This drives a REAL migrated site (a
+// transient push-upsert error → `log.notice("sync: push upsert …")`).
+describe("sync — in-process TUI safety", () => {
+  let stderr: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    stderr = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    stderr.mockRestore();
+    // Never leak silenced state into other files sharing this worker.
+    log.silenceStderr(false);
+  });
+
+  async function pushWithTransientError(): Promise<void> {
+    syncData.enableSync("basic");
+    insertKnowledge("k1", "hello");
+    // Non-quota, non-poison → falls through to the transient `log.notice`.
+    upsertError = { code: "08006", message: "network" };
+    await pushOnce(makeClient() as never);
+  }
+
+  test("a sync error is visible on a standalone CLI (the leak we guard)", async () => {
+    log.silenceStderr(false);
+    await pushWithTransientError();
+    const wrote = stderr.mock.calls.some((args: unknown[]) =>
+      args.join(" ").includes("sync: push upsert"),
+    );
+    expect(wrote).toBe(true);
+  });
+
+  test("silenceStderr() suppresses sync's stderr writes (in-process/TUI mode)", async () => {
+    log.silenceStderr(true);
+    await pushWithTransientError();
+    // Raw `console.error` would ignore the switch and still corrupt the TUI;
+    // routing through `log` is what makes this silence-able.
+    expect(stderr).not.toHaveBeenCalled();
+  });
+});
+
 describe("pullOnce", () => {
   test("applies a new remote row and a tombstone", async () => {
     syncData.enableSync("basic");

--- a/packages/gateway/test/tui-safety.test.ts
+++ b/packages/gateway/test/tui-safety.test.ts
@@ -13,8 +13,11 @@ import { parseCurlHeaders } from "../src/config";
  * in config.ts emits a `[lore]` warning on a malformed header line) to prove:
  *   1. the site routes through `@loreai/core`'s `log`, not raw `console.*`;
  *   2. `silenceStderr()` called via the `@loreai/core` barrel reaches code in
- *      the *gateway* package — i.e. both packages share one `log` instance,
- *      which is exactly the cross-package wiring the plugins rely on.
+ *      the *gateway* package. (Under vitest both resolve to the same `core`
+ *      source module. In PRODUCTION the bundled gateway inlines its OWN copy of
+ *      `core`, so the flag instead bridges the two copies via a process-global
+ *      on `globalThis` — that separate bundled-boundary case is covered by
+ *      core/test/log.test.ts's cross-instance test, not this one.)
  */
 describe("in-process gateway TUI safety", () => {
   let stderr: ReturnType<typeof vi.spyOn>;

--- a/packages/gateway/test/tui-safety.test.ts
+++ b/packages/gateway/test/tui-safety.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { log } from "@loreai/core";
+import { parseCurlHeaders } from "../src/config";
+
+/**
+ * When the gateway runs *in-process* inside a host that owns a full-screen TUI
+ * (the Pi extension, the OpenCode plugin), the host flips `log.silenceStderr()`
+ * once on activation. From then on NOTHING the gateway logs — not warnings, not
+ * errors — may reach the terminal, or it corrupts the TUI (the class of bug
+ * that broke Pi on Windows).
+ *
+ * These tests exercise a *real* migrated gateway log site (`parseCurlHeaders`
+ * in config.ts emits a `[lore]` warning on a malformed header line) to prove:
+ *   1. the site routes through `@loreai/core`'s `log`, not raw `console.*`;
+ *   2. `silenceStderr()` called via the `@loreai/core` barrel reaches code in
+ *      the *gateway* package — i.e. both packages share one `log` instance,
+ *      which is exactly the cross-package wiring the plugins rely on.
+ */
+describe("in-process gateway TUI safety", () => {
+  let stderr: ReturnType<typeof vi.spyOn>;
+  const MALFORMED = "this-header-line-has-no-colon";
+
+  beforeEach(() => {
+    stderr = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    stderr.mockRestore();
+    // Never leak silenced state into other files sharing this worker.
+    log.silenceStderr(false);
+  });
+
+  it("emits a [lore] warning to stderr by default (the leak we are guarding)", () => {
+    log.silenceStderr(false);
+
+    parseCurlHeaders(MALFORMED);
+
+    const wroteLore = stderr.mock.calls.some((args: unknown[]) =>
+      args.join(" ").includes("[lore]"),
+    );
+    expect(wroteLore).toBe(true);
+  });
+
+  it("silenceStderr() via @loreai/core suppresses the gateway's own [lore] writes", () => {
+    log.silenceStderr(true);
+
+    parseCurlHeaders(MALFORMED);
+
+    expect(stderr).not.toHaveBeenCalled();
+  });
+});

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -10,7 +10,11 @@ import {
 // exported from the entry module as a plugin; leaking these helpers pushed
 // `undefined` into the host hooks array and crashed it on event dispatch
 // (`undefined is not an object (evaluating 'A.event')`). See ./internal.ts.
-import { applyLoreProviderConfig, probeGateway } from "./internal";
+import {
+  applyLoreProviderConfig,
+  probeGateway,
+  surfaceGatewayUnavailable,
+} from "./internal";
 
 /**
  * Lore plugin for OpenCode — transparent LLM proxy routing.
@@ -191,8 +195,9 @@ export const LorePlugin: Plugin = async (ctx) => {
     const inTestEnv = isInertTestEnv();
 
     // We're loaded by a real OpenCode process, which owns a full-screen TUI:
-    // any byte on stdout/stderr corrupts the render. Silence stderr for the
-    // core logger — shared with the in-process gateway — so NOTHING (not even
+    // any byte on stdout/stderr corrupts the render. Flip the core logger's
+    // process-global silence flag — which the in-process gateway's own (bundled)
+    // copy of `core` reads off `globalThis` too — so NOTHING (not even
     // `log.error` or gateway warnings) reaches the terminal. Everything still
     // lands in the log file + Sentry sink (`lore logs`). Skipped under inert
     // test mode so unrelated suites keep their console.
@@ -242,7 +247,10 @@ export const LorePlugin: Plugin = async (ctx) => {
               " (or `run build` for a dev checkout)."
             : "")
         : `${base} Ensure @loreai/gateway is installed.`;
-      log.error(msg);
+      // `log.error` is silenced on stderr in embedded/TUI mode, so it alone is
+      // invisible to a user in the OpenCode TUI. Also raise a TUI-safe toast so
+      // a totally-failed gateway isn't a silent no-op (Daniel's Windows report).
+      surfaceGatewayUnavailable(ctx.client, msg);
     }
   }
 

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -190,6 +190,14 @@ export const LorePlugin: Plugin = async (ctx) => {
   if (!processInitDone) {
     const inTestEnv = isInertTestEnv();
 
+    // We're loaded by a real OpenCode process, which owns a full-screen TUI:
+    // any byte on stdout/stderr corrupts the render. Silence stderr for the
+    // core logger — shared with the in-process gateway — so NOTHING (not even
+    // `log.error` or gateway warnings) reaches the terminal. Everything still
+    // lands in the log file + Sentry sink (`lore logs`). Skipped under inert
+    // test mode so unrelated suites keep their console.
+    if (!inTestEnv) log.silenceStderr();
+
     if (!loreDisabled && !inTestEnv) {
       // Memoize so concurrent LorePlugin calls don't race on probe→spawn.
       if (!loreInitPromise) {
@@ -234,7 +242,6 @@ export const LorePlugin: Plugin = async (ctx) => {
               " (or `run build` for a dev checkout)."
             : "")
         : `${base} Ensure @loreai/gateway is installed.`;
-      process.stderr.write(`[lore] ERROR: ${msg}\n`);
       log.error(msg);
     }
   }
@@ -376,13 +383,12 @@ export const LorePlugin: Plugin = async (ctx) => {
       },
     };
 
-    // Startup banner — visible in stderr so silent failures are obvious.
-    // Suppressed in test env to keep vitest output clean.
+    // Startup banner. Routed through `log` (file + sink, stderr only when not
+    // silenced) — NEVER a raw stderr write: OpenCode owns a full-screen TUI and
+    // any stray byte corrupts it. Visible via `lore logs`.
     if (!processInitDone) {
       const projectPath = discoverWorkspaceRoot(ctx.worktree || ctx.directory);
-      if (process.env.NODE_ENV !== "test") {
-        process.stderr.write(`[lore] active: ${projectPath}\n`);
-      }
+      log.info(`active: ${projectPath}`);
 
       if (loreActive) {
         // Install the fetch interceptor once per process. It transparently
@@ -402,12 +408,8 @@ export const LorePlugin: Plugin = async (ctx) => {
             return headers;
           },
         });
-        // Suppressed in test env (mirrors the `[lore] active:` banner above)
-        // so the force-active e2e path doesn't pollute vitest output.
-        if (process.env.NODE_ENV !== "test") {
-          process.stderr.write(`[lore] routing through ${gatewayBase}\n`);
-          process.stderr.write(`[lore] dashboard: ${gatewayBase}/ui\n`);
-        }
+        log.info(`routing through ${gatewayBase}`);
+        log.info(`dashboard: ${gatewayBase}/ui`);
       }
 
       processInitDone = true;
@@ -417,8 +419,10 @@ export const LorePlugin: Plugin = async (ctx) => {
   } catch (e) {
     // Log the full error before re-throwing so OpenCode's plugin loader
     // (which catches and swallows the error) doesn't hide the root cause.
+    // `log.error` captures it to the file + Sentry sink even when stderr is
+    // silenced for the TUI, so the cause survives in `lore logs`.
     const detail = e instanceof Error ? e.stack || e.message : String(e);
-    process.stderr.write(`[lore] init failed: ${detail}\n`);
+    log.error(`init failed: ${detail}`);
     throw e;
   }
 };

--- a/packages/opencode/src/internal.ts
+++ b/packages/opencode/src/internal.ts
@@ -10,9 +10,12 @@
  * `applyLoreProviderConfig` returns `undefined`, so the host crashed on the
  * first hook dispatch with `undefined is not an object (evaluating 'A.event')`
  * (the `?.` guards the `.event` property, not the `undefined` hook element).
- * Keeping them in a separate module means the entry module exposes only the
- * plugin function itself, while tests can still import them here.
+ *  Keeping them in a separate module means the entry module exposes only the
+ *  plugin function itself, while tests can still import them here.
  */
+
+import type { PluginInput } from "@opencode-ai/plugin";
+import { log } from "@loreai/core";
 
 /**
  * Pin every opencode provider's `options.baseURL` to the Lore gateway.
@@ -75,5 +78,44 @@ export async function probeGateway(
     return res.ok;
   } catch {
     return false;
+  }
+}
+
+/**
+ * Surface a fatal "Lore is unavailable" condition to the user.
+ *
+ * In embedded/TUI mode the core logger's stderr is hard-silenced (see
+ * `log.silenceStderr()` at plugin activation), so `log.error` alone lands only
+ * in the log file + Sentry sink — invisible to a user sitting inside OpenCode's
+ * full-screen TUI. A toast is the one channel that is BOTH user-visible and
+ * TUI-safe: `showToast` posts to the OpenCode server over HTTP and is rendered
+ * inside the TUI's own render loop, so it never writes a raw byte to the
+ * terminal and cannot corrupt the screen (unlike the `process.stderr.write`
+ * this replaced).
+ *
+ * Fire-and-forget and swallow EVERY failure: a missing/headless TUI, or an
+ * older server without the `/tui/show-toast` route, must never turn a
+ * degraded-but-running session into a crash.
+ */
+export function surfaceGatewayUnavailable(
+  client: PluginInput["client"] | undefined,
+  message: string,
+): void {
+  // File + Sentry sink (silenced on stderr in embedded mode).
+  log.error(message);
+  try {
+    const pending = client?.tui?.showToast({
+      body: { title: "Lore", message, variant: "error" },
+    });
+    // The SDK call defaults to throwOnError=false (resolves rather than
+    // rejects), but guard `.catch` defensively in case a mock/older client
+    // returns a bare promise — a rejected toast must never bubble up.
+    (
+      pending as
+        | { catch?: (cb: (reason: unknown) => void) => unknown }
+        | undefined
+    )?.catch?.(() => {});
+  } catch {
+    // showToast threw synchronously — never propagate a notification failure.
   }
 }

--- a/packages/opencode/test/internal.test.ts
+++ b/packages/opencode/test/internal.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { PluginInput } from "@opencode-ai/plugin";
+import { log } from "@loreai/core";
+import { surfaceGatewayUnavailable } from "../src/internal";
+
+/**
+ * `surfaceGatewayUnavailable` is the one user-visible signal left when the
+ * in-process gateway fails to start. In embedded/TUI mode `log.error` is
+ * silenced on stderr (so it can't corrupt the render), which would otherwise
+ * make a totally-failed gateway a silent no-op (Daniel's Windows report). The
+ * helper raises a TUI-safe toast instead — and must NEVER let a missing,
+ * throwing, or rejecting toast turn a degraded session into a crash.
+ */
+describe("surfaceGatewayUnavailable", () => {
+  const MSG = "Lore failed to start — memory features are unavailable.";
+  let stderr: ReturnType<typeof vi.spyOn>;
+
+  function clientWith(showToast: (...args: unknown[]) => unknown) {
+    return {
+      tui: { showToast },
+    } as unknown as PluginInput["client"];
+  }
+
+  beforeEach(() => {
+    stderr = vi.spyOn(console, "error").mockImplementation(() => {});
+    // log.error only reaches stderr when NOT silenced; assert that path here.
+    log.silenceStderr(false);
+  });
+
+  afterEach(() => {
+    stderr.mockRestore();
+    log.silenceStderr(false);
+  });
+
+  test("raises a TUI-safe error toast carrying the message", () => {
+    const showToast = vi.fn(() => Promise.resolve());
+    surfaceGatewayUnavailable(clientWith(showToast), MSG);
+
+    expect(showToast).toHaveBeenCalledTimes(1);
+    expect(showToast).toHaveBeenCalledWith({
+      body: { title: "Lore", message: MSG, variant: "error" },
+    });
+  });
+
+  test("still records the failure via log.error (file + Sentry sink)", () => {
+    surfaceGatewayUnavailable(
+      clientWith(() => Promise.resolve()),
+      MSG,
+    );
+    const logged = stderr.mock.calls.some((args: unknown[]) =>
+      args.join(" ").includes(MSG),
+    );
+    expect(logged).toBe(true);
+  });
+
+  test("swallows a synchronously throwing showToast (no crash)", () => {
+    const showToast = vi.fn(() => {
+      throw new Error("no TUI attached");
+    });
+    expect(() =>
+      surfaceGatewayUnavailable(clientWith(showToast), MSG),
+    ).not.toThrow();
+  });
+
+  test("swallows a rejected toast promise (no unhandled rejection)", async () => {
+    const showToast = vi.fn(() => Promise.reject(new Error("no /tui route")));
+    expect(() =>
+      surfaceGatewayUnavailable(clientWith(showToast), MSG),
+    ).not.toThrow();
+    // Let the swallowed rejection settle — the helper attaches a `.catch`.
+    await Promise.resolve();
+  });
+
+  test("tolerates a client without a TUI toast capability", () => {
+    expect(() =>
+      surfaceGatewayUnavailable({} as unknown as PluginInput["client"], MSG),
+    ).not.toThrow();
+    expect(() => surfaceGatewayUnavailable(undefined, MSG)).not.toThrow();
+  });
+});

--- a/packages/opencode/test/tui-silence.test.ts
+++ b/packages/opencode/test/tui-silence.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, test } from "vitest";
+import type { PluginInput } from "@opencode-ai/plugin";
+import { log } from "@loreai/core";
+import { LorePlugin } from "../src/index";
+
+/**
+ * The OpenCode plugin runs inside OpenCode's full-screen TUI, where any byte on
+ * stdout/stderr corrupts the render. On activation it must flip
+ * `log.silenceStderr()` so neither the plugin nor the in-process gateway it
+ * hosts can ever write `[lore]` to the terminal.
+ *
+ * `LORE_DISABLED=1` keeps activation from probing/starting a real gateway while
+ * still exercising the (pre-gateway) silence switch. The global test setup
+ * resets the flag after each test.
+ */
+describe("opencode plugin — TUI stderr silencing on activation", () => {
+  const saved: Record<string, string | undefined> = {};
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    log.silenceStderr(false);
+  });
+
+  test("activating the plugin silences stderr so [lore] can't reach the TUI", async () => {
+    for (const k of ["LORE_OPENCODE_FORCE_ACTIVE", "LORE_DISABLED"]) {
+      saved[k] = process.env[k];
+    }
+    log.silenceStderr(false);
+    expect(log.isStderrSilenced()).toBe(false);
+
+    process.env.LORE_OPENCODE_FORCE_ACTIVE = "1";
+    process.env.LORE_DISABLED = "1";
+
+    await LorePlugin({
+      client: {
+        tui: { showToast: () => Promise.resolve() },
+      } as unknown as PluginInput["client"],
+      project: { id: "tui-silence" } as unknown as PluginInput["project"],
+      directory: process.cwd(),
+      worktree: process.cwd(),
+      serverUrl: new URL("http://localhost:0"),
+      $: {} as unknown as PluginInput["$"],
+    } as PluginInput);
+
+    expect(log.isStderrSilenced()).toBe(true);
+  });
+});

--- a/packages/pi/src/index.ts
+++ b/packages/pi/src/index.ts
@@ -67,6 +67,15 @@ export default async function lorePiExtension(pi: ExtensionAPI): Promise<void> {
   const inTestEnv =
     process.env.NODE_ENV === "test" && process.env.LORE_PI_FORCE_ACTIVE !== "1";
 
+  // We're being loaded by a real Pi process, which owns a full-screen TUI: any
+  // byte on stdout/stderr corrupts the render. Silence stderr for the core
+  // logger — which the in-process gateway shares — so NOTHING (not even
+  // `log.error` or gateway warnings) can reach the terminal. Everything still
+  // lands in the log file and Sentry sink; read it with `lore logs`. Skipped
+  // under inert test mode so unrelated suites in the same worker keep their
+  // console.
+  if (!inTestEnv) log.silenceStderr();
+
   if (!loreDisabled && !inTestEnv) {
     // Try to find a running gateway first (probes port file + known ports).
     const existingUrl = await resolveGatewayUrl();

--- a/packages/pi/src/index.ts
+++ b/packages/pi/src/index.ts
@@ -68,8 +68,9 @@ export default async function lorePiExtension(pi: ExtensionAPI): Promise<void> {
     process.env.NODE_ENV === "test" && process.env.LORE_PI_FORCE_ACTIVE !== "1";
 
   // We're being loaded by a real Pi process, which owns a full-screen TUI: any
-  // byte on stdout/stderr corrupts the render. Silence stderr for the core
-  // logger — which the in-process gateway shares — so NOTHING (not even
+  // byte on stdout/stderr corrupts the render. Flip the core logger's
+  // process-global silence flag — which the in-process gateway's own (bundled)
+  // copy of `core` reads off `globalThis` too — so NOTHING (not even
   // `log.error` or gateway warnings) can reach the terminal. Everything still
   // lands in the log file and Sentry sink; read it with `lore logs`. Skipped
   // under inert test mode so unrelated suites in the same worker keep their

--- a/packages/pi/test/extension.e2e.test.ts
+++ b/packages/pi/test/extension.e2e.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import lorePiExtension from "../src/index";
 import { ANTHROPIC_PROVIDERS, OPENAI_PROVIDERS } from "../src/internal";
 

--- a/packages/pi/test/tui-silence.test.ts
+++ b/packages/pi/test/tui-silence.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, test } from "vitest";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { log } from "@loreai/core";
+import lorePiExtension from "../src/index";
+
+/**
+ * The Pi extension runs inside Pi's full-screen TUI, where any byte on
+ * stdout/stderr corrupts the render (the bug Daniel hit on Windows). On
+ * activation it must flip `log.silenceStderr()` so neither the extension nor
+ * the in-process gateway it hosts can ever write `[lore]` to the terminal.
+ *
+ * `LORE_DISABLED=1` returns the extension inert right after the silence switch,
+ * so no gateway is probed/started. The global test setup resets the flag.
+ */
+describe("pi extension — TUI stderr silencing on activation", () => {
+  const saved: Record<string, string | undefined> = {};
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    log.silenceStderr(false);
+  });
+
+  test("activating the extension silences stderr so [lore] can't reach the TUI", async () => {
+    for (const k of ["LORE_PI_FORCE_ACTIVE", "LORE_DISABLED"]) {
+      saved[k] = process.env[k];
+    }
+    log.silenceStderr(false);
+    expect(log.isStderrSilenced()).toBe(false);
+
+    process.env.LORE_PI_FORCE_ACTIVE = "1";
+    process.env.LORE_DISABLED = "1";
+
+    const mockPi = {
+      registerProvider: () => {},
+      on: () => {},
+    } as unknown as ExtensionAPI;
+    await lorePiExtension(mockPi);
+
+    expect(log.isStderrSilenced()).toBe(true);
+  });
+});


### PR DESCRIPTION
## The bug

The Pi extension and OpenCode plugin run the gateway **in-process** (`startGateway({ quiet: true })` inside the agent's own process). But `quiet` only routes the 3 `notify()` sites in `start.ts`. Everything else that writes to stderr bypasses that flag and lands in the host's full-screen TUI — the same corruption class that broke Pi on Windows (Daniel's report):

- **`core/log.error`** always wrote `console.error("[lore]", …)` to stderr (correct for the CLI, fatal in a TUI).
- **~16 raw `console.error('[lore] …')` calls** on the request hot path bypassed `log` entirely: `pipeline.ts` (the X-Lore-Project / project-attribution warnings — **observed leaking in the Pi real-runtime e2e**), `server.ts`, `config.ts`, `stream/openai*.ts`, `vertex-auth.ts`.
- **9 raw `console.error('sync: …')` calls** in `sync.ts` — the background cloud-sync scheduler runs **in-process**, so a sync push/pull/quota failure corrupts the TUI too. (Missed by a `[lore]`-only sweep because they carry a `sync:` prefix; any byte corrupts a TUI.)
- **5 raw `process.stderr.write('[lore] …')` calls in the OpenCode plugin** (startup banners + both failure paths). The `routing through`/`dashboard` banners were only gated against `NODE_ENV==="test"`, so they **leaked in production**. The startup-failure paths are exactly Daniel's "gateway fails to start" scenario corrupting the TUI.

## The fix

- **`core/log`**: add `silenceStderr()` / `isStderrSilenced()`. When enabled, *every* level (incl. `error`, incl. `LORE_DEBUG=1`) skips stderr but still writes the log file + Sentry sink — nothing is lost (`lore logs`). Add a `notice()` level: an always-visible-in-CLI warning that respects the switch and reports to the sink at *warning* severity (so these don't inflate Sentry's error stream).
- **gateway**: route every in-process-reachable stderr write (server, pipeline, config, streams, vertex-auth, **sync**) through `log.notice`/`log.error`.
- **opencode + pi**: flip `silenceStderr()` on activation. The switch is a process-global on `globalThis` (see below), so the plugin's `core` and the in-process gateway's **separately-bundled** `core` both see it. Drop all 5 raw `process.stderr.write` calls.
- **opencode fatal-failure signal**: once stderr is hard-silenced, a *totally-failed* gateway init left the user with **no** terminal signal. `surfaceGatewayUnavailable()` keeps the `log.error` (file + Sentry) **and** raises a TUI-safe toast (`client.tui.showToast`) — it posts to the OpenCode server over HTTP and renders inside the TUI's own loop, so it never writes a raw byte. Fire-and-forget; a missing/headless TUI or older server can never turn a degraded session into a crash.
- **data-dir**: gate the one-time migration notice on the silence flag (via the side-effect-free getter, so the `log`↔`data-dir` cycle stays safe).

### Why `globalThis`, not a module-level flag (Seer review)

The gateway's npm bundle **inlines its own copy of `@loreai/core`** (the Bun bundle keeps it external per #998; the CJS bundle does not). So the plugin and the in-process gateway do **not** share one `core` instance — a module-level `let` set by the plugin would be invisible to the gateway's logger. The flag therefore lives on `globalThis.__LORE_STDERR_SILENCED__`, which every core copy in the main thread reads. (This is why the docstrings/comments no longer say "shared instance.")

## Verification

- 2× full suite green (4596 passed). Typecheck + lint clean.
- **Mutation-verified (6/6 killed)**: break the `notice`/`error` silence guard → log + gateway tests fail; revert a `config.ts` migration → gateway suppression test fails; remove either plugin's `silenceStderr()` call → that plugin's wiring test fails; revert a `sync.ts` site to `console.error` → the sync silence test fails; remove the `showToast` call → the toast test fails. All files restored byte-identically.

Also drops an unused `vi` import that biome 2.4.16 flags as an error (pre-existing; blocks lint on every PR).

## Follow-ups
- **Worker-thread stderr** (separate PR, in progress): `embedding-worker.ts` writes a `[lore] ONNX OOM …` line via `console.warn` from a `worker_threads` worker spawned without `stderr:true`, so it auto-pipes to the host stderr. A worker has its own `globalThis`, so this PR's flag can't reach it — it needs the worker spawned with `stderr:true` + drain (or the flag propagated via `workerData`). Distinct mechanism, shipped on its own.
- Tighten the Pi real-runtime e2e (#1046) to also forbid `[lore]` once it lands.
- Separate PR for a flaky `embedding-oom-recovery` test (#1054).
