### PR TITLE
feat(core): cut vector storage over to FLAT vec0 with partition keys

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1,5 +1,10 @@
 import { Database } from "#db/driver";
-import { loadVecExtension, resetVecState } from "./db/vec";
+import { isVecAvailable, loadVecExtension, resetVecState } from "./db/vec";
+import {
+  ensureVec0Store,
+  readStorageMode,
+  readVecDimension,
+} from "./db/vec-store";
 import { join, dirname } from "node:path";
 import { chmodSync, mkdirSync } from "node:fs";
 import { getGitRemote } from "./git";
@@ -2062,6 +2067,16 @@ export function db(): Database {
   // before the tracing Proxy wrap. Never throws — when unavailable, vector
   // search falls back to the pure-JS brute-force path (see db/vec.ts).
   loadVecExtension(database);
+  // For an already-vec0 DB on a capable runtime, ensure the vec0 tables exist
+  // BEFORE any read can reach them — the blob→vec0 cutover only runs later, in
+  // runStartupBackfill. Recovery uses the persisted dimension (set at cutover);
+  // a fresh DB stays blob until that cutover, and an incapable runtime (vec
+  // unavailable → reads degrade to []) skips this. vec0 tables are local,
+  // non-synced derived data, so creating them after installSyncCapture is safe.
+  if (isVecAvailable() && readStorageMode(database) === "vec0") {
+    const dim = readVecDimension(database);
+    if (dim !== null) ensureVec0Store(database, dim);
+  }
   // Wrap the connection in the query-tracing Proxy AFTER migrate() and sync
   // change-capture are installed on the RAW connection, so (a) migration and
   // TEMP-trigger setup queries are never traced / re-entrant, and (b) the

--- a/packages/core/src/db/vec-store.ts
+++ b/packages/core/src/db/vec-store.ts
@@ -51,6 +51,14 @@ export type EmbeddingTable =
 /** `kv_meta` key recording this DB file's {@link VecStorageMode}. */
 export const VEC_STORAGE_MODE_KEY = "vec.storage_mode";
 
+/**
+ * `kv_meta` key recording the vector dimension the `vec0` tables were created
+ * with. vec0 fixes the dimension at DDL time (`float[N]`), but the embedding
+ * dimension is configurable (768 local / 1024 voyage / 1536 openai). On a
+ * dimension change {@link ensureVec0Store} drops + recreates the tables.
+ */
+export const VEC_DIMENSION_KEY = "vec.dimension";
+
 /** Logical table → physical base table name. */
 const BASE_TABLE: Record<EmbeddingTable, string> = {
   knowledge: "knowledge",
@@ -59,14 +67,60 @@ const BASE_TABLE: Record<EmbeddingTable, string> = {
   temporal: "temporal_messages",
 };
 
+/** Logical table → `vec0` virtual table name. */
+const VEC_TABLE: Record<EmbeddingTable, string> = {
+  knowledge: "knowledge_vec",
+  entities: "entity_vec",
+  distillations: "distillation_vec",
+  temporal: "temporal_vec",
+};
+
+/**
+ * DDL for the four `vec0` tables at vector dimension `dim`. Uses the FLAT
+ * (default float) vec0 index — EXACT recall (1.0) with PARTITION KEY filter
+ * pushdown. (DiskANN was evaluated and rejected: in this vendored build it
+ * supports neither partition keys nor metadata columns, inserts ~400× slower,
+ * and is only approximate — see PR4 notes.) Partition keys shard the index so a
+ * session/project-scoped query touches only the matching rows; `temporal_vec`
+ * is chunk-keyed (`chunk_id`, `+message_id`) ahead of multi-vector chunking
+ * (single-vector era writes exactly one chunk per message: `chunk_id = id#0`).
+ * `CREATE … IF NOT EXISTS` so the routine is idempotent / re-runnable.
+ */
+export function vec0Ddl(dim: number): string[] {
+  return [
+    `CREATE VIRTUAL TABLE IF NOT EXISTS knowledge_vec USING vec0(id TEXT PRIMARY KEY, embedding float[${dim}] distance_metric=cosine)`,
+    `CREATE VIRTUAL TABLE IF NOT EXISTS entity_vec USING vec0(id TEXT PRIMARY KEY, embedding float[${dim}] distance_metric=cosine)`,
+    `CREATE VIRTUAL TABLE IF NOT EXISTS distillation_vec USING vec0(id TEXT PRIMARY KEY, project_id TEXT PARTITION KEY, +session_id TEXT, embedding float[${dim}] distance_metric=cosine)`,
+    `CREATE VIRTUAL TABLE IF NOT EXISTS temporal_vec USING vec0(chunk_id TEXT PRIMARY KEY, +message_id TEXT, project_id TEXT PARTITION KEY, session_id TEXT PARTITION KEY, embedding float[${dim}] distance_metric=cosine)`,
+  ];
+}
+
+/** The four `vec0` virtual table names, in dependency-free order. */
+export const VEC_TABLES = Object.freeze([
+  "knowledge_vec",
+  "entity_vec",
+  "distillation_vec",
+  "temporal_vec",
+]) as readonly string[];
+
 /** Minimal connection shape for reading the stored storage mode. */
 export interface StorageModeConn {
   query(sql: string): { get(...params: unknown[]): unknown };
 }
 
-/** Minimal connection shape for writing embeddings. */
+/**
+ * Connection shape for writing embeddings and managing the vec0 store. The
+ * vec0 write paths additionally need `get` (look up a row's partition values /
+ * the stored dimension) and `all` (none today, kept for symmetry), so this is a
+ * superset of {@link StorageModeConn}. Satisfied by both node:sqlite and
+ * bun:sqlite connections (and the traced `db()` Proxy).
+ */
 export interface EmbeddingWriteConn {
-  query(sql: string): { run(...params: unknown[]): unknown };
+  query(sql: string): {
+    run(...params: unknown[]): unknown;
+    get(...params: unknown[]): unknown;
+    all(...params: unknown[]): unknown[];
+  };
 }
 
 /**
@@ -105,10 +159,13 @@ export function resolveReadMode(
  * Persist one embedding for `id` on `table`.
  *
  * Centralizes the previously-scattered `UPDATE … SET embedding = ?` sites so the
- * vec0 write path lands in exactly one place later. Today (blob layout) it
- * writes the Float32 vector as a BLOB on the base row. Uses `conn.query()` so
- * the prepared statement is driver-cached across backfill-loop calls (same cost
- * as the dedicated prepared statement the loops used before).
+ * write layout lives in one place. Branches on this DB's {@link VecStorageMode}:
+ *   - `blob` → write the Float32 vector as a BLOB on the base row;
+ *   - `vec0` → `INSERT OR REPLACE` into the table's `vec0` index (partition/aux
+ *     values are read from the base row, which the caller has already inserted).
+ *
+ * Uses `conn.query()` so the prepared statement is driver-cached across
+ * backfill-loop calls.
  */
 export function storeEmbedding(
   conn: EmbeddingWriteConn,
@@ -116,20 +173,346 @@ export function storeEmbedding(
   id: string,
   vec: Float32Array,
 ): void {
+  if (readStorageMode(conn) === "vec0") {
+    storeEmbeddingVec0(conn, table, id, vec);
+    return;
+  }
   conn
     .query(`UPDATE ${BASE_TABLE[table]} SET embedding = ? WHERE id = ?`)
     .run(toBlob(vec), id);
 }
 
 /**
+ * `vec0` write path for {@link storeEmbedding}. `knowledge`/`entities` key
+ * directly on `id`; `distillations`/`temporal` read their immutable partition
+ * (and aux) values from the just-written base row. If the base row is gone (a
+ * delete raced the fire-and-forget embed), there is nothing to index — skip.
+ */
+function storeEmbeddingVec0(
+  conn: EmbeddingWriteConn,
+  table: EmbeddingTable,
+  id: string,
+  vec: Float32Array,
+): void {
+  const blob = toBlob(vec);
+  switch (table) {
+    case "knowledge":
+      conn
+        .query(
+          "INSERT OR REPLACE INTO knowledge_vec(id, embedding) VALUES (?, ?)",
+        )
+        .run(id, blob);
+      return;
+    case "entities":
+      conn
+        .query("INSERT OR REPLACE INTO entity_vec(id, embedding) VALUES (?, ?)")
+        .run(id, blob);
+      return;
+    case "distillations": {
+      const row = conn
+        .query("SELECT project_id, session_id FROM distillations WHERE id = ?")
+        .get(id) as
+        | { project_id: string; session_id: string }
+        | null
+        | undefined;
+      if (!row) return;
+      conn
+        .query(
+          "INSERT OR REPLACE INTO distillation_vec(id, project_id, session_id, embedding) VALUES (?, ?, ?, ?)",
+        )
+        .run(id, row.project_id, row.session_id, blob);
+      return;
+    }
+    case "temporal": {
+      const row = conn
+        .query(
+          "SELECT project_id, session_id FROM temporal_messages WHERE id = ?",
+        )
+        .get(id) as
+        | { project_id: string; session_id: string }
+        | null
+        | undefined;
+      if (!row) return;
+      conn
+        .query(
+          "INSERT OR REPLACE INTO temporal_vec(chunk_id, message_id, project_id, session_id, embedding) VALUES (?, ?, ?, ?, ?)",
+        )
+        .run(`${id}#0`, id, row.project_id, row.session_id, blob);
+      return;
+    }
+  }
+}
+
+/**
+ * Delete the embeddings for `ids` on `table`.
+ *
+ * NO-OP in blob layout: the embedding lives on the base row, so whatever deleted
+ * the base row already removed it. Only the `vec0` layout keeps a separate index
+ * row that must be deleted explicitly. `temporal_vec` is chunk-keyed, so it is
+ * deleted by the aux `message_id` column (removes every chunk of each message).
+ * Chunked under SQLite's bound-variable ceiling.
+ */
+export function deleteEmbeddings(
+  conn: EmbeddingWriteConn,
+  table: EmbeddingTable,
+  ids: string[],
+): void {
+  if (!ids.length) return;
+  if (readStorageMode(conn) !== "vec0") return;
+  const vt = VEC_TABLE[table];
+  const keyCol = table === "temporal" ? "message_id" : "id";
+  const CHUNK = 900;
+  for (let i = 0; i < ids.length; i += CHUNK) {
+    const batch = ids.slice(i, i + CHUNK);
+    const ph = batch.map(() => "?").join(",");
+    conn.query(`DELETE FROM ${vt} WHERE ${keyCol} IN (${ph})`).run(...batch);
+  }
+}
+
+/**
  * Clear ALL embeddings across all four tables — used when the embedding config
- * changes (provider/model/dimension swap) and every stored vector becomes
- * incompatible. Today (blob layout) it NULLs the base BLOB columns; the vec0
- * layout will instead empty the vec0 tables.
+ * changes (provider/model swap, same dimension) and every stored vector becomes
+ * incompatible. Blob layout NULLs the base BLOB columns; vec0 layout empties the
+ * `vec0` tables. (A *dimension* change additionally requires recreating the
+ * fixed-width vec0 tables — see {@link ensureVec0Store}.)
  */
 export function clearAllEmbeddings(conn: EmbeddingWriteConn): void {
+  if (readStorageMode(conn) === "vec0") {
+    for (const vt of VEC_TABLES) conn.query(`DELETE FROM ${vt}`).run();
+    return;
+  }
   conn.query("UPDATE knowledge SET embedding = NULL").run();
   conn.query("UPDATE distillations SET embedding = NULL").run();
   conn.query("UPDATE temporal_messages SET embedding = NULL").run();
   conn.query("UPDATE entities SET embedding = NULL").run();
+}
+
+// ---------------------------------------------------------------------------
+// vec0 store lifecycle (DDL + kv_meta bookkeeping)
+// ---------------------------------------------------------------------------
+
+/**
+ * Read the dimension the `vec0` tables were created with (kv_meta
+ * {@link VEC_DIMENSION_KEY}), or `null` when unset / unparseable. Mirrors
+ * {@link readStorageMode}'s defensive read.
+ */
+export function readVecDimension(conn: StorageModeConn): number | null {
+  try {
+    const row = conn
+      .query("SELECT value FROM kv_meta WHERE key = ?")
+      .get(VEC_DIMENSION_KEY) as { value?: string } | null | undefined;
+    const n = row?.value != null ? Number(row.value) : Number.NaN;
+    return Number.isInteger(n) && n > 0 ? n : null;
+  } catch {
+    return null;
+  }
+}
+
+function setKv(conn: EmbeddingWriteConn, key: string, value: string): void {
+  conn
+    .query(
+      "INSERT INTO kv_meta (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = ?",
+    )
+    .run(key, value, value);
+}
+
+/** Persist this DB file's {@link VecStorageMode}. */
+export function setStorageMode(
+  conn: EmbeddingWriteConn,
+  mode: VecStorageMode,
+): void {
+  setKv(conn, VEC_STORAGE_MODE_KEY, mode);
+}
+
+/**
+ * Idempotently ensure the four `vec0` tables exist at vector dimension `dim`.
+ *
+ * - First call / already at `dim`: `CREATE … IF NOT EXISTS` (no-op if present).
+ * - Stored dimension differs from `dim` (provider/model dimension swap): DROP +
+ *   recreate at `dim`. The fixed-width vec0 tables cannot hold the new width;
+ *   callers clear + re-embed around this, so dropping the rows is expected.
+ *
+ * Records `dim` under {@link VEC_DIMENSION_KEY}. Does NOT flip the storage mode
+ * or backfill — see the cutover in embedding.ts. Re-runnable: a crash between
+ * the DROP and the CREATE just re-runs both next time (`IF (NOT) EXISTS`).
+ */
+export function ensureVec0Store(conn: EmbeddingWriteConn, dim: number): void {
+  const storedDim = readVecDimension(conn);
+  if (storedDim !== null && storedDim !== dim) {
+    for (const vt of VEC_TABLES) conn.query(`DROP TABLE IF EXISTS ${vt}`).run();
+  }
+  for (const ddl of vec0Ddl(dim)) conn.query(ddl).run();
+  setKv(conn, VEC_DIMENSION_KEY, String(dim));
+}
+
+// ---------------------------------------------------------------------------
+// blob → vec0 cutover helpers (pure SQL relocation; no re-embedding)
+// ---------------------------------------------------------------------------
+
+/** Whether the base table for `table` still has its `embedding` BLOB column.
+ *  The cutover drops it per table; this gates the per-table copy so a re-run
+ *  after a partial cutover skips already-migrated tables (the v55 boot-loop
+ *  lesson — never read a dropped column). */
+export function embeddingColumnExists(
+  conn: EmbeddingWriteConn,
+  table: EmbeddingTable,
+): boolean {
+  try {
+    const rows = conn
+      .query(`PRAGMA table_info(${BASE_TABLE[table]})`)
+      .all() as Array<{ name: string }>;
+    return rows.some((r) => r.name === "embedding");
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Copy existing blob embeddings on `table` into its `vec0` index via a single
+ * idempotent `INSERT OR REPLACE … SELECT` (FLAT vec0 inserts at ~0.12 ms/vec, so
+ * even 106K temporal rows finish in ~13 s). Pure relocation — no re-embedding.
+ * Knowledge copies from `knowledge_current` so only current-version ids land in
+ * `knowledge_vec` (matching the read-path join); temporal derives the
+ * single-vector-era `chunk_id` (`id || '#0'`) and carries partition + aux values.
+ */
+export function copyBlobsToVec0(
+  conn: EmbeddingWriteConn,
+  table: EmbeddingTable,
+): void {
+  switch (table) {
+    case "knowledge":
+      conn
+        .query(
+          "INSERT OR REPLACE INTO knowledge_vec(id, embedding) SELECT id, embedding FROM knowledge_current WHERE embedding IS NOT NULL",
+        )
+        .run();
+      return;
+    case "entities":
+      conn
+        .query(
+          "INSERT OR REPLACE INTO entity_vec(id, embedding) SELECT id, embedding FROM entities WHERE embedding IS NOT NULL",
+        )
+        .run();
+      return;
+    case "distillations":
+      conn
+        .query(
+          "INSERT OR REPLACE INTO distillation_vec(id, project_id, session_id, embedding) SELECT id, project_id, session_id, embedding FROM distillations WHERE embedding IS NOT NULL",
+        )
+        .run();
+      return;
+    case "temporal":
+      conn
+        .query(
+          "INSERT OR REPLACE INTO temporal_vec(chunk_id, message_id, project_id, session_id, embedding) SELECT id || '#0', id, project_id, session_id, embedding FROM temporal_messages WHERE embedding IS NOT NULL",
+        )
+        .run();
+      return;
+  }
+}
+
+/** Drop the base `embedding` BLOB column for `table` (reclaims its space via
+ *  SQLite's table rewrite). Presence-aware: a re-run after the column is gone
+ *  swallows the "no such column" error. The `knowledge_current` view's `k.*`
+ *  expands at query time, so it adapts automatically. */
+export function dropEmbeddingColumn(
+  conn: EmbeddingWriteConn,
+  table: EmbeddingTable,
+): void {
+  try {
+    conn.query(`ALTER TABLE ${BASE_TABLE[table]} DROP COLUMN embedding`).run();
+  } catch {
+    // already dropped on a prior (crashed) cutover run — idempotent.
+  }
+}
+
+/**
+ * Reclaim dangling `vec0` rows whose backing base row no longer exists — a bulk
+ * project / session / prune delete removes base rows but not the separate vec0
+ * rows. These rows are already HARMLESS for correctness (recall hydration drops
+ * a hit whose base row is missing, and a deleted project's rows live in their
+ * own partition), so this is a bloat / recall-quality backstop, not a fix. Run
+ * once at startup in vec0 mode. `knowledge_vec` is pinned to CURRENT versions
+ * (the read path joins `knowledge_current`); `temporal_vec` keys on the aux
+ * `message_id`. One bounded pass per table.
+ */
+export function gcVec0DanglingRows(conn: EmbeddingWriteConn): void {
+  conn
+    .query(
+      "DELETE FROM knowledge_vec WHERE id NOT IN (SELECT id FROM knowledge_current)",
+    )
+    .run();
+  conn
+    .query("DELETE FROM entity_vec WHERE id NOT IN (SELECT id FROM entities)")
+    .run();
+  conn
+    .query(
+      "DELETE FROM distillation_vec WHERE id NOT IN (SELECT id FROM distillations)",
+    )
+    .run();
+  conn
+    .query(
+      "DELETE FROM temporal_vec WHERE message_id NOT IN (SELECT id FROM temporal_messages)",
+    )
+    .run();
+}
+
+// ---------------------------------------------------------------------------
+// Mode-aware "missing/has embedding" predicates for backfill detection
+// ---------------------------------------------------------------------------
+
+function vecKeyCol(table: EmbeddingTable): string {
+  return table === "temporal" ? "message_id" : "id";
+}
+
+/**
+ * WHERE fragment selecting rows of `table` that are MISSING an embedding under
+ * `mode`: blob → `embedding IS NULL`; vec0 → `id NOT IN (SELECT <key> FROM
+ * <t>_vec)` (the blob column no longer exists in vec0 mode). `alias` prefixes
+ * the base column reference (e.g. `"e"` → `e.id …`).
+ */
+export function missingEmbeddingSql(
+  table: EmbeddingTable,
+  mode: VecStorageMode,
+  alias = "",
+): string {
+  const p = alias ? `${alias}.` : "";
+  if (mode === "vec0") {
+    return `${p}id NOT IN (SELECT ${vecKeyCol(table)} FROM ${VEC_TABLE[table]})`;
+  }
+  return `${p}embedding IS NULL`;
+}
+
+/** WHERE fragment selecting rows of `table` that HAVE an embedding under `mode`
+ *  — the complement of {@link missingEmbeddingSql}. */
+export function hasEmbeddingSql(
+  table: EmbeddingTable,
+  mode: VecStorageMode,
+  alias = "",
+): string {
+  const p = alias ? `${alias}.` : "";
+  if (mode === "vec0") {
+    return `${p}id IN (SELECT ${vecKeyCol(table)} FROM ${VEC_TABLE[table]})`;
+  }
+  return `${p}embedding IS NOT NULL`;
+}
+
+/**
+ * Resolve the FROM table + presence filter for a by-id embedding POINT read
+ * (`… WHERE id IN (…)`, NOT a KNN — vec0 supports primary-key SELECTs without
+ * `MATCH`, returning the stored vector as the same float32 BLOB). blob layout
+ * reads the base table/view + `AND embedding IS NOT NULL`; vec0 layout reads the
+ * `vec0` table (every row has a vector → no filter). The caller supplies its
+ * blob-mode source (e.g. `knowledge_current`). Only the `id`, `embedding`, and —
+ * for distillations — `session_id` columns are guaranteed on both layouts.
+ * Id-keyed tables only (knowledge/entities/distillations); temporal is
+ * chunk-keyed and not point-read this way.
+ */
+export function embeddingByIdSource(
+  table: EmbeddingTable,
+  mode: VecStorageMode,
+  blobTable: string,
+): { table: string; presenceFilter: string } {
+  if (mode === "vec0") return { table: VEC_TABLE[table], presenceFilter: "" };
+  return { table: blobTable, presenceFilter: " AND embedding IS NOT NULL" };
 }

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -1625,28 +1625,49 @@ const EMBEDDING_TABLES: readonly EmbeddingTable[] = [
  * column — the v55 boot-loop lesson). The storage mode flips LAST, only once
  * every table's blobs have been relocated and dropped.
  */
-function maybeCutoverToVec0(): void {
+export function maybeCutoverToVec0(): void {
   if (!isVecAvailable()) return;
-  if (readStorageMode(db()) !== "blob") return;
 
-  const dim = config().search.embeddings.dimensions;
-  ensureVec0Store(db(), dim);
-
-  for (const table of EMBEDDING_TABLES) {
-    if (!embeddingColumnExists(db(), table)) continue; // already migrated
-    copyBlobsToVec0(db(), table);
-    dropEmbeddingColumn(db(), table);
+  if (readStorageMode(db()) === "blob") {
+    const dim = config().search.embeddings.dimensions;
+    ensureVec0Store(db(), dim);
+    // Relocate every existing blob into vec0 BEFORE flipping the mode. The copy
+    // is idempotent (INSERT OR REPLACE) and does NOT drop anything, so a crash
+    // here leaves mode="blob" with the base columns still INTACT — the copy
+    // simply re-runs next startup. 🔴 INVARIANT: columns are dropped only AFTER
+    // the flip below, so mode==="blob" always implies the embedding columns
+    // still exist; no blob-mode query can ever read a half-dropped column (the
+    // v55 boot-loop hazard).
+    for (const table of EMBEDDING_TABLES) {
+      if (embeddingColumnExists(db(), table)) copyBlobsToVec0(db(), table);
+    }
+    // Flip once vec0 is fully populated and authoritative.
+    setStorageMode(db(), "vec0");
+    log.info(`vec0 storage cutover complete (dim=${dim})`);
   }
 
-  setStorageMode(db(), "vec0");
-  try {
-    // Best-effort: return the pages freed by the dropped blob columns (notably
-    // ~320MB of temporal vectors) to the OS. No-op unless auto_vacuum is on.
-    db().query("PRAGMA incremental_vacuum").run();
-  } catch {
-    // ignore — space is already reclaimed within the DB file by DROP COLUMN.
+  // Reclaim: drop any leftover base embedding columns. Runs STRICTLY in vec0
+  // mode (mode never reverts to blob), so no blob-mode reader can observe a
+  // half-dropped column. Presence-aware + idempotent → resumable across a crash
+  // mid-drop (the next startup finishes the remaining columns).
+  if (readStorageMode(db()) === "vec0") {
+    let droppedAny = false;
+    for (const table of EMBEDDING_TABLES) {
+      if (embeddingColumnExists(db(), table)) {
+        dropEmbeddingColumn(db(), table);
+        droppedAny = true;
+      }
+    }
+    if (droppedAny) {
+      try {
+        // Best-effort: return the freed pages (notably ~320MB of temporal
+        // vectors) to the OS. No-op unless auto_vacuum is on.
+        db().query("PRAGMA incremental_vacuum").run();
+      } catch {
+        // ignore — space is already reclaimed within the DB file by DROP COLUMN.
+      }
+    }
   }
-  log.info(`vec0 storage cutover complete (dim=${dim})`);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -18,8 +18,17 @@ import { db } from "./db";
 import { isVecAvailable } from "./db/vec";
 import {
   clearAllEmbeddings,
+  copyBlobsToVec0,
+  dropEmbeddingColumn,
+  type EmbeddingTable,
+  embeddingColumnExists,
+  ensureVec0Store,
+  gcVec0DanglingRows,
+  hasEmbeddingSql,
+  missingEmbeddingSql,
   readStorageMode,
   resolveReadMode,
+  setStorageMode,
   storeEmbedding,
 } from "./db/vec-store";
 import { config } from "./config";
@@ -1288,7 +1297,19 @@ async function poolOrInProcess(
   if (pooled === VECTOR_SEARCH_TIMED_OUT) return [];
   if (pooled !== null) return pooled;
   const readMode = resolveReadMode(readStorageMode(db()), isVecAvailable());
-  return runVectorQuery(db(), readMode, queryEmbedding, spec);
+  try {
+    return runVectorQuery(db(), readMode, queryEmbedding, spec);
+  } catch (err) {
+    // Safety net for the vec0 read path, which (unlike the blob paths) has no
+    // in-line JS fallback: a vec0 `MATCH` can throw transiently — e.g. during a
+    // dimension change, when the query embedding's width no longer matches the
+    // vec0 table — and we must degrade THIS recall to empty (FTS/keyword recall
+    // still answers) rather than crash, per the never-crash contract. The pool
+    // already logged any worker-path failure; log the in-process one too so a
+    // systematic break stays visible.
+    log.error("in-process vector search failed; returning empty:", err);
+    return [];
+  }
 }
 
 export async function vectorSearch(
@@ -1523,33 +1544,30 @@ export function checkConfigChange(): boolean {
 
   if (stored && stored.value === current) return false;
 
+  const mode = readStorageMode(db());
+
+  // A vec0-store DB whose extension didn't load (degraded) cannot manage its
+  // embeddings — it can neither count/clear the unreadable vec0 tables nor
+  // recreate them. Leave the stored fingerprint UNCHANGED so the change is
+  // re-detected and handled the next time the DB opens on a capable runtime.
+  if (mode === "vec0" && !isVecAvailable()) return false;
+
   // Config changed (or first run) — clear all embeddings in all tables
   if (stored) {
-    const knowledgeCount = db()
-      .query(
-        "SELECT COUNT(*) as n FROM knowledge_current WHERE embedding IS NOT NULL",
-      )
-      .get() as { n: number };
-    const distillCount = db()
-      .query(
-        "SELECT COUNT(*) as n FROM distillations WHERE embedding IS NOT NULL",
-      )
-      .get() as { n: number };
-    const temporalCount = db()
-      .query(
-        "SELECT COUNT(*) as n FROM temporal_messages WHERE embedding IS NOT NULL",
-      )
-      .get() as { n: number };
-    const entityCount = db()
-      .query("SELECT COUNT(*) as n FROM entities WHERE embedding IS NOT NULL")
-      .get() as { n: number };
     const total =
-      knowledgeCount.n + distillCount.n + temporalCount.n + entityCount.n;
+      mode === "vec0" ? countVec0Embeddings() : countBlobEmbeddings();
     if (total > 0) {
       clearAllEmbeddings(db());
       log.info(
         `embedding config changed (${stored.value} → ${current}), cleared ${total} stale embeddings`,
       );
+    }
+    // A *dimension* change makes the fixed-width vec0 tables incompatible:
+    // recreate them at the new dimension (clearAllEmbeddings emptied the old
+    // rows; ensureVec0Store drops + recreates when the stored dim differs, and
+    // is a no-op for a same-dimension model/provider swap).
+    if (mode === "vec0") {
+      ensureVec0Store(db(), config().search.embeddings.dimensions);
     }
   }
 
@@ -1561,6 +1579,74 @@ export function checkConfigChange(): boolean {
     .run(EMBEDDING_CONFIG_KEY, current, current);
 
   return true;
+}
+
+/** Count blob-layout embeddings across all four tables (config-change logging). */
+function countBlobEmbeddings(): number {
+  const n = (sql: string) => (db().query(sql).get() as { n: number }).n;
+  return (
+    n(
+      "SELECT COUNT(*) as n FROM knowledge_current WHERE embedding IS NOT NULL",
+    ) +
+    n("SELECT COUNT(*) as n FROM distillations WHERE embedding IS NOT NULL") +
+    n(
+      "SELECT COUNT(*) as n FROM temporal_messages WHERE embedding IS NOT NULL",
+    ) +
+    n("SELECT COUNT(*) as n FROM entities WHERE embedding IS NOT NULL")
+  );
+}
+
+/** Count vec0-layout embeddings across all four `vec0` tables. Only reached on a
+ *  capable runtime (degraded short-circuits earlier). */
+function countVec0Embeddings(): number {
+  const n = (sql: string) => (db().query(sql).get() as { n: number }).n;
+  return (
+    n("SELECT COUNT(*) as n FROM knowledge_vec") +
+    n("SELECT COUNT(*) as n FROM distillation_vec") +
+    n("SELECT COUNT(*) as n FROM temporal_vec") +
+    n("SELECT COUNT(*) as n FROM entity_vec")
+  );
+}
+
+/** The four embedding-bearing logical tables, in cutover order. */
+const EMBEDDING_TABLES: readonly EmbeddingTable[] = [
+  "knowledge",
+  "entities",
+  "distillations",
+  "temporal",
+];
+
+/**
+ * One-time blob→vec0 cutover. NO-OP unless sqlite-vec is loadable on this
+ * runtime AND the DB is still in blob layout (so an already-vec0 DB, or an
+ * incapable runtime, skips). Idempotent / resumable: each table's
+ * copy-then-drop is gated on the base `embedding` column still existing, so a
+ * crash mid-cutover re-runs only the unfinished tables (never reads a dropped
+ * column — the v55 boot-loop lesson). The storage mode flips LAST, only once
+ * every table's blobs have been relocated and dropped.
+ */
+function maybeCutoverToVec0(): void {
+  if (!isVecAvailable()) return;
+  if (readStorageMode(db()) !== "blob") return;
+
+  const dim = config().search.embeddings.dimensions;
+  ensureVec0Store(db(), dim);
+
+  for (const table of EMBEDDING_TABLES) {
+    if (!embeddingColumnExists(db(), table)) continue; // already migrated
+    copyBlobsToVec0(db(), table);
+    dropEmbeddingColumn(db(), table);
+  }
+
+  setStorageMode(db(), "vec0");
+  try {
+    // Best-effort: return the pages freed by the dropped blob columns (notably
+    // ~320MB of temporal vectors) to the OS. No-op unless auto_vacuum is on.
+    db().query("PRAGMA incremental_vacuum").run();
+  } catch {
+    // ignore — space is already reclaimed within the DB file by DROP COLUMN.
+  }
+  log.info(`vec0 storage cutover complete (dim=${dim})`);
 }
 
 // ---------------------------------------------------------------------------
@@ -1622,20 +1708,42 @@ function emptyBackfillStats(): BackfillStats {
 export async function runStartupBackfill(): Promise<BackfillStats> {
   if (!isAvailable()) return emptyBackfillStats();
 
+  // Handle an embedding-config change, then attempt the one-time blob→vec0
+  // cutover (both no-ops in the steady state). Order matters: a config change
+  // clears stale blobs BEFORE the cutover relocates the survivors, so the vec0
+  // tables are never seeded with vectors from a since-changed model/dimension.
+  checkConfigChange();
+  maybeCutoverToVec0();
+
+  const mode = readStorageMode(db());
+
+  // A vec0-store DB on a runtime that cannot load sqlite-vec: the blob columns
+  // are gone and the vec0 tables are unreadable. No backfill is possible — vector
+  // recall degrades to empty (FTS still answers) and re-converges when the DB is
+  // next opened on a capable runtime.
+  if (resolveReadMode(mode, isVecAvailable()) === "degraded") {
+    log.warn(
+      "vec0 storage but sqlite-vec unavailable — skipping embedding backfill " +
+        "(vector recall is FTS-only until reopened on a capable runtime)",
+    );
+    return emptyBackfillStats();
+  }
+
   // Surface backlog up-front so a slow startup is self-explanatory in logs.
-  // Counts use the same predicates the backfill loops use, so the two
-  // numbers always match what we're about to do.
+  // Counts use the same mode-aware predicates the backfill loops use, so the
+  // two numbers always match what we're about to do. (In vec0 mode the blob
+  // column is gone — "pending" means a base row absent from the vec0 index.)
   const pendingKnowledge = (
     db()
       .query(
-        "SELECT COUNT(*) as n FROM knowledge_current WHERE embedding IS NULL AND confidence > 0.2",
+        `SELECT COUNT(*) as n FROM knowledge_current WHERE ${missingEmbeddingSql("knowledge", mode)} AND confidence > 0.2`,
       )
       .get() as { n: number }
   ).n;
   const pendingDistillations = (
     db()
       .query(
-        "SELECT COUNT(*) as n FROM distillations WHERE embedding IS NULL AND archived = 0 AND observations != ''",
+        `SELECT COUNT(*) as n FROM distillations WHERE ${missingEmbeddingSql("distillations", mode)} AND archived = 0 AND observations != ''`,
       )
       .get() as { n: number }
   ).n;
@@ -1654,6 +1762,10 @@ export async function runStartupBackfill(): Promise<BackfillStats> {
   const distillationEmbedded = await backfillDistillationEmbeddings();
   const entityEmbedded = await backfillEntityEmbeddings();
 
+  // Startup backstop: reclaim vec0 rows orphaned by bulk base-row deletes
+  // (project/session/prune) since the last run. Harmless if there are none.
+  if (mode === "vec0") gcVec0DanglingRows(db());
+
   // Coverage stats — always log to stderr so the problem is visible.
   const kTotal = (
     db()
@@ -1665,7 +1777,7 @@ export async function runStartupBackfill(): Promise<BackfillStats> {
   const kWithEmb = (
     db()
       .query(
-        "SELECT COUNT(*) as n FROM knowledge_current WHERE embedding IS NOT NULL AND confidence > 0.2",
+        `SELECT COUNT(*) as n FROM knowledge_current WHERE ${hasEmbeddingSql("knowledge", mode)} AND confidence > 0.2`,
       )
       .get() as { n: number }
   ).n;
@@ -1681,7 +1793,7 @@ export async function runStartupBackfill(): Promise<BackfillStats> {
       .query(
         // Mirror dTotal's predicate (incl. observations != '') so the coverage
         // numerator is always a subset of the denominator (never reads "11/10").
-        "SELECT COUNT(*) as n FROM distillations WHERE embedding IS NOT NULL AND archived = 0 AND observations != ''",
+        `SELECT COUNT(*) as n FROM distillations WHERE ${hasEmbeddingSql("distillations", mode)} AND archived = 0 AND observations != ''`,
       )
       .get() as { n: number }
   ).n;
@@ -1780,9 +1892,10 @@ export async function backfillEmbeddings(): Promise<number> {
   const provider = getProvider();
   if (!provider) return 0;
 
+  const mode = readStorageMode(db());
   const rows = db()
     .query(
-      "SELECT id, title, content FROM knowledge_current WHERE embedding IS NULL AND confidence > 0.2",
+      `SELECT id, title, content FROM knowledge_current WHERE ${missingEmbeddingSql("knowledge", mode)} AND confidence > 0.2`,
     )
     .all() as Array<{ id: string; title: string; content: string }>;
 
@@ -1843,9 +1956,10 @@ export async function backfillDistillationEmbeddings(): Promise<number> {
   const provider = getProvider();
   if (!provider) return 0;
 
+  const mode = readStorageMode(db());
   const rows = db()
     .query(
-      "SELECT id, observations FROM distillations WHERE embedding IS NULL AND archived = 0 AND observations != ''",
+      `SELECT id, observations FROM distillations WHERE ${missingEmbeddingSql("distillations", mode)} AND archived = 0 AND observations != ''`,
     )
     .all() as Array<{ id: string; observations: string }>;
 
@@ -1923,6 +2037,7 @@ export async function backfillEntityEmbeddings(): Promise<number> {
   // Bun's bun:sqlite rejects GROUP_CONCAT(DISTINCT col, separator) with two
   // arguments when DISTINCT is used ("DISTINCT aggregates must have exactly
   // one argument"). Use a subquery to deduplicate aliases instead.
+  const mode = readStorageMode(db());
   const rows = db()
     .query(
       `SELECT e.id AS id, e.canonical_name AS canonical_name,
@@ -1930,7 +2045,7 @@ export async function backfillEntityEmbeddings(): Promise<number> {
                FROM (SELECT DISTINCT alias_value FROM entity_aliases WHERE entity_id = e.id) da
               ) AS aliases
        FROM entities e
-       WHERE e.embedding IS NULL`,
+       WHERE ${missingEmbeddingSql("entities", mode, "e")}`,
     )
     .all() as Array<{
     id: string;

--- a/packages/core/src/entities.ts
+++ b/packages/core/src/entities.ts
@@ -7,6 +7,7 @@
  */
 import { uuidv7 } from "uuidv7";
 import { db, ensureProject, getKV, setKV, withTransaction } from "./db";
+import { embeddingByIdSource, readStorageMode } from "./db/vec-store";
 import { ftsQuery, ftsQueryOr, EMPTY_QUERY, filterTerms } from "./search";
 import { offloadAll } from "./read-offload";
 import { config } from "./config";
@@ -1908,9 +1909,15 @@ export async function deduplicateEntities(
   {
     const ids = entities.map((e) => e.id);
     const placeholders = ids.map(() => "?").join(",");
+    // vec0 layout keeps entity vectors in entity_vec, not the base column.
+    const src = embeddingByIdSource(
+      "entities",
+      readStorageMode(db()),
+      "entities",
+    );
     const rows = db()
       .query(
-        `SELECT id, embedding FROM entities WHERE embedding IS NOT NULL AND id IN (${placeholders})`,
+        `SELECT id, embedding FROM ${src.table} WHERE id IN (${placeholders})${src.presenceFilter}`,
       )
       .all(...ids) as Array<{ id: string; embedding: Buffer }>;
     for (const row of rows) {

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -1,5 +1,10 @@
 import { uuidv7 } from "uuidv7";
 import { db, ensureProject, getKV, setKV, withTransaction } from "./db";
+import {
+  deleteEmbeddings,
+  embeddingByIdSource,
+  readStorageMode,
+} from "./db/vec-store";
 import { config } from "./config";
 import {
   ftsQuery,
@@ -352,22 +357,30 @@ export function appendVersion(
       )
       .get(logicalId) as { id: string } | undefined;
     if (!cur) return false;
+    // vec0 layout has no `embedding` column on `knowledge` (dropped at cutover):
+    // omit it from the forward-copy, and drop the demoted version's vec0 row so
+    // knowledge_vec holds only current versions (the new version is re-embedded
+    // by the caller). Both are no-ops in blob layout.
+    const mode = readStorageMode(db());
+    const embCol = mode === "vec0" ? "" : "embedding, ";
+    const embSel = mode === "vec0" ? "" : "NULL, ";
     db().query("UPDATE knowledge SET is_current = 0 WHERE id = ?").run(cur.id);
+    deleteEmbeddings(db(), "knowledge", [cur.id]);
     db()
       .query(
         // confidence/last_reinforced_at are NOT copied — they live on the register
         // (knowledge_meta), keyed by the stable logical_id, unchanged by an append.
         `INSERT INTO knowledge (
            id, project_id, category, title, content, source_session, cross_project,
-           created_at, updated_at, metadata, embedding, created_by,
+           created_at, updated_at, metadata, ${embCol}created_by,
            updated_by, sensitivity, promotion_status, promoted_at, approval_status,
            approved_by, approved_at, source_user_id, source_entry_id, last_accessed_at,
            worker_provider_id, worker_model_id,
            logical_id, version, is_deleted, is_current)
          SELECT
            ?, project_id, COALESCE(?, category), COALESCE(?, title), COALESCE(?, content),
-           source_session, cross_project, created_at, ?, COALESCE(?, metadata), NULL,
-           created_by, updated_by, sensitivity, promotion_status, promoted_at,
+           source_session, cross_project, created_at, ?, COALESCE(?, metadata), ${embSel}created_by,
+           updated_by, sensitivity, promotion_status, promoted_at,
            approval_status, approved_by, approved_at, source_user_id, source_entry_id,
            last_accessed_at, worker_provider_id, worker_model_id,
            logical_id, version + 1, ?, 1
@@ -2917,9 +2930,14 @@ function _dedup(
     const entryIds = entries.map((e) => e.id);
     // Build parameterized IN clause for the entry IDs
     const placeholders = entryIds.map(() => "?").join(",");
+    const src = embeddingByIdSource(
+      "knowledge",
+      readStorageMode(db()),
+      "knowledge_current",
+    );
     const rows = db()
       .query(
-        `SELECT id, embedding FROM knowledge_current WHERE embedding IS NOT NULL AND id IN (${placeholders})`,
+        `SELECT id, embedding FROM ${src.table} WHERE id IN (${placeholders})${src.presenceFilter}`,
       )
       .all(...entryIds) as Array<{ id: string; embedding: Buffer }>;
     for (const row of rows) {
@@ -3147,9 +3165,14 @@ export function promoteCrossProject(opts?: {
   {
     const ids = candidates.map((e) => e.id);
     const placeholders = ids.map(() => "?").join(",");
+    const src = embeddingByIdSource(
+      "knowledge",
+      readStorageMode(db()),
+      "knowledge_current",
+    );
     const rows = db()
       .query(
-        `SELECT id, embedding FROM knowledge_current WHERE embedding IS NOT NULL AND id IN (${placeholders})`,
+        `SELECT id, embedding FROM ${src.table} WHERE id IN (${placeholders})${src.presenceFilter}`,
       )
       .all(...ids) as Array<{ id: string; embedding: Buffer }>;
     for (const row of rows) {

--- a/packages/core/src/pattern-echo.ts
+++ b/packages/core/src/pattern-echo.ts
@@ -14,7 +14,11 @@
  */
 
 import { db, ensureProject } from "./db";
-import { storeEmbedding } from "./db/vec-store";
+import {
+  embeddingByIdSource,
+  readStorageMode,
+  storeEmbedding,
+} from "./db/vec-store";
 import * as embedding from "./embedding";
 import * as ltm from "./ltm";
 import type { KnowledgeMetadata } from "./ltm";
@@ -296,9 +300,16 @@ function clusterBySimilarity(
   // Load embeddings for all candidates
   const ids = candidates.map((c) => c.id);
   const placeholders = ids.map(() => "?").join(",");
+  // vec0 layout keeps distillation vectors (and the session_id aux column) in
+  // distillation_vec, not the base table — read from whichever holds them.
+  const src = embeddingByIdSource(
+    "distillations",
+    readStorageMode(db()),
+    "distillations",
+  );
   const rows = db()
     .query(
-      `SELECT id, session_id, embedding FROM distillations WHERE id IN (${placeholders}) AND embedding IS NOT NULL`,
+      `SELECT id, session_id, embedding FROM ${src.table} WHERE id IN (${placeholders})${src.presenceFilter}`,
     )
     .all(...ids) as Array<{
     id: string;

--- a/packages/core/src/vector-query.ts
+++ b/packages/core/src/vector-query.ts
@@ -81,6 +81,27 @@ export const MAX_DISTILLATION_VECTOR_ROWS = 500;
  */
 export const MAX_TEMPORAL_VECTOR_ROWS = 4000;
 
+/**
+ * Over-fetch multiplier for `vec0` KNN reads that are post-filtered by a JOIN to
+ * the base table (knowledge: `confidence`/`category`; distillations: `archived`
+ * — mutable/cross-table predicates that can't be pushed into the vec0 `MATCH`).
+ *
+ * A vec0 `MATCH … AND k = N` returns exactly the N nearest rows; post-filter
+ * attrition then drops the ones that fail the predicate, which could leave fewer
+ * than `limit`. So we ask the index for {@link overfetchK}`(limit)` candidates
+ * and re-`LIMIT` to `limit` after filtering. Reads with no post-filter
+ * (entities, allDistillations, temporal) request `k = limit` directly.
+ *
+ * Unlike the blob {@link MAX_TEMPORAL_VECTOR_ROWS} / {@link MAX_DISTILLATION_VECTOR_ROWS}
+ * recency caps, this is NOT a corpus-visibility limit — the vec0 index always
+ * sees the whole corpus; this only widens the KNN candidate window.
+ */
+export const VEC0_FILTER_OVERFETCH = 4;
+
+function overfetchK(limit: number): number {
+  return Math.max(limit * VEC0_FILTER_OVERFETCH, limit + 50);
+}
+
 // ---------------------------------------------------------------------------
 // Math + BLOB helpers (moved here from embedding.ts so the worker can share
 // them without pulling in the provider chain). Re-exported from embedding.ts
@@ -196,16 +217,14 @@ export function runVectorQuery(
 }
 
 /**
- * Guard the `vec0` read mode out of the blob helpers: the DiskANN read path
- * lands in the cutover PR, and `vec0` is unreachable today because no DB is ever
- * flipped to the vec0 storage mode. Throwing (rather than silently scanning the
- * wrong layout) makes a premature cutover loud. Each helper handles `degraded`
- * inline with an early `return []`; after that and this guard, `readMode` is
- * always `blob-native` or `blob-js`.
+ * Defensive guard reached only after each helper has handled `degraded` (early
+ * `return []`) and `vec0` (the FLAT-vec0 KNN branch) inline — so `readMode` here
+ * is always `blob-native` or `blob-js`. If some future mode ever reaches it
+ * unhandled it throws loudly rather than silently scanning the wrong layout.
  */
 function assertBlobReadMode(readMode: VecReadMode): void {
   if (readMode === "vec0") {
-    throw new Error("vec0 read path is not implemented until the cutover PR");
+    throw new Error("vec0 read path must be handled before assertBlobReadMode");
   }
 }
 
@@ -216,8 +235,25 @@ function runKnowledge(
   spec: { limit: number; excludeCategories?: string[] },
 ): VectorHit[] {
   if (readMode === "degraded") return [];
-  assertBlobReadMode(readMode);
   const { limit, excludeCategories } = spec;
+  if (readMode === "vec0") {
+    // DiskANN-free FLAT vec0: exact KNN over the whole corpus (no recency cap).
+    // Post-filter confidence/category (mutable / per-version) by joining the
+    // current-version view; over-fetch so attrition leaves >= limit survivors.
+    let sql =
+      "WITH knn AS (SELECT id, distance FROM knowledge_vec WHERE embedding MATCH ? AND k = ?) " +
+      "SELECT knn.id AS id, 1 - knn.distance AS similarity " +
+      "FROM knn JOIN knowledge_current c ON c.id = knn.id WHERE c.confidence > 0.2";
+    const params: unknown[] = [toBlob(queryEmbedding), overfetchK(limit)];
+    if (excludeCategories?.length) {
+      sql += ` AND c.category NOT IN (${excludeCategories.map(() => "?").join(",")})`;
+      params.push(...excludeCategories);
+    }
+    sql += " ORDER BY knn.distance LIMIT ?";
+    params.push(limit);
+    return conn.query(sql).all(...params) as VectorHit[];
+  }
+  assertBlobReadMode(readMode);
   if (readMode === "blob-native") {
     try {
       let sql =
@@ -262,6 +298,13 @@ function runEntities(
   limit: number,
 ): VectorHit[] {
   if (readMode === "degraded") return [];
+  if (readMode === "vec0") {
+    return conn
+      .query(
+        "SELECT id, 1 - distance AS similarity FROM entity_vec WHERE embedding MATCH ? AND k = ? ORDER BY distance",
+      )
+      .all(toBlob(queryEmbedding), limit) as VectorHit[];
+  }
   assertBlobReadMode(readMode);
   if (readMode === "blob-native") {
     try {
@@ -294,6 +337,18 @@ function runDistillations(
   limit: number,
 ): VectorHit[] {
   if (readMode === "degraded") return [];
+  if (readMode === "vec0") {
+    // `archived` flips on meta-distillation (mutable) → post-filter via join,
+    // over-fetching so attrition leaves >= limit non-archived survivors.
+    return conn
+      .query(
+        "WITH knn AS (SELECT id, distance FROM distillation_vec WHERE embedding MATCH ? AND k = ?) " +
+          "SELECT knn.id AS id, 1 - knn.distance AS similarity " +
+          "FROM knn JOIN distillations d ON d.id = knn.id WHERE d.archived = 0 " +
+          "ORDER BY knn.distance LIMIT ?",
+      )
+      .all(toBlob(queryEmbedding), overfetchK(limit), limit) as VectorHit[];
+  }
   assertBlobReadMode(readMode);
   if (readMode === "blob-native") {
     try {
@@ -329,6 +384,17 @@ function runAllDistillations(
   limit: number,
 ): DistillationVectorHit[] {
   if (readMode === "degraded") return [];
+  if (readMode === "vec0") {
+    // Project is a PARTITION KEY → the index scans only this project's rows.
+    // No post-filter (includes archived, by contract) → k = limit. session_id
+    // is an aux column returned straight from the index. Cap removed: the index
+    // sees every distillation in the project, not a recency window.
+    return conn
+      .query(
+        "SELECT id, session_id, 1 - distance AS similarity FROM distillation_vec WHERE embedding MATCH ? AND k = ? AND project_id = ? ORDER BY distance",
+      )
+      .all(toBlob(queryEmbedding), limit, projectId) as DistillationVectorHit[];
+  }
   assertBlobReadMode(readMode);
   if (readMode === "blob-native") {
     try {
@@ -380,6 +446,21 @@ function runTemporal(
   sessionId?: string,
 ): VectorHit[] {
   if (readMode === "degraded") return [];
+  if (readMode === "vec0") {
+    // project_id (and session_id when scoped) are PARTITION KEYs → the index
+    // scans only the matching shard (session-scoped is ~sub-ms). Cap removed:
+    // the index sees the full history, not a recency window. `temporal_vec` is
+    // chunk-keyed; in the single-vector era there is exactly one chunk per
+    // message, so `k = limit` yields `limit` distinct messages and `message_id`
+    // (aux) is the message id callers hydrate by.
+    const vsql = sessionId
+      ? "SELECT message_id AS id, 1 - distance AS similarity FROM temporal_vec WHERE embedding MATCH ? AND k = ? AND project_id = ? AND session_id = ? ORDER BY distance"
+      : "SELECT message_id AS id, 1 - distance AS similarity FROM temporal_vec WHERE embedding MATCH ? AND k = ? AND project_id = ? ORDER BY distance";
+    const vparams: unknown[] = sessionId
+      ? [toBlob(queryEmbedding), limit, projectId, sessionId]
+      : [toBlob(queryEmbedding), limit, projectId];
+    return conn.query(vsql).all(...vparams) as VectorHit[];
+  }
   assertBlobReadMode(readMode);
   if (readMode === "blob-native") {
     try {

--- a/packages/core/src/vector-query.ts
+++ b/packages/core/src/vector-query.ts
@@ -98,8 +98,19 @@ export const MAX_TEMPORAL_VECTOR_ROWS = 4000;
  */
 export const VEC0_FILTER_OVERFETCH = 4;
 
+/**
+ * sqlite-vec's hard ceiling on a KNN `k` (`SQLITE_VEC_VEC0_K_MAX`): a `MATCH …
+ * AND k = N` with N > 4096 errors. Every vec0 `k` we bind is clamped to this.
+ */
+export const VEC0_MAX_K = 4096;
+
+/** Clamp a desired KNN candidate count to {@link VEC0_MAX_K}. */
+function vecK(n: number): number {
+  return Math.min(n, VEC0_MAX_K);
+}
+
 function overfetchK(limit: number): number {
-  return Math.max(limit * VEC0_FILTER_OVERFETCH, limit + 50);
+  return vecK(Math.max(limit * VEC0_FILTER_OVERFETCH, limit + 50));
 }
 
 // ---------------------------------------------------------------------------
@@ -239,19 +250,27 @@ function runKnowledge(
   if (readMode === "vec0") {
     // DiskANN-free FLAT vec0: exact KNN over the whole corpus (no recency cap).
     // Post-filter confidence/category (mutable / per-version) by joining the
-    // current-version view; over-fetch so attrition leaves >= limit survivors.
-    let sql =
-      "WITH knn AS (SELECT id, distance FROM knowledge_vec WHERE embedding MATCH ? AND k = ?) " +
-      "SELECT knn.id AS id, 1 - knn.distance AS similarity " +
-      "FROM knn JOIN knowledge_current c ON c.id = knn.id WHERE c.confidence > 0.2";
-    const params: unknown[] = [toBlob(queryEmbedding), overfetchK(limit)];
-    if (excludeCategories?.length) {
-      sql += ` AND c.category NOT IN (${excludeCategories.map(() => "?").join(",")})`;
-      params.push(...excludeCategories);
-    }
-    sql += " ORDER BY knn.distance LIMIT ?";
-    params.push(limit);
-    return conn.query(sql).all(...params) as VectorHit[];
+    // current-version view; over-fetch so attrition leaves >= limit survivors,
+    // and widen to a full scan if that still under-fills (blob-mode parity).
+    const run = (k: number): VectorHit[] => {
+      let sql =
+        "WITH knn AS (SELECT id, distance FROM knowledge_vec WHERE embedding MATCH ? AND k = ?) " +
+        "SELECT knn.id AS id, 1 - knn.distance AS similarity " +
+        "FROM knn JOIN knowledge_current c ON c.id = knn.id WHERE c.confidence > 0.2";
+      const params: unknown[] = [toBlob(queryEmbedding), k];
+      if (excludeCategories?.length) {
+        sql += ` AND c.category NOT IN (${excludeCategories.map(() => "?").join(",")})`;
+        params.push(...excludeCategories);
+      }
+      sql += " ORDER BY knn.distance LIMIT ?";
+      params.push(limit);
+      return conn.query(sql).all(...params) as VectorHit[];
+    };
+    const k0 = overfetchK(limit);
+    const hits = run(k0);
+    // Post-filter attrition can leave < limit even when more valid rows exist
+    // deeper; widen to the max KNN window (blob-mode parity, capped at 4096).
+    return hits.length >= limit || k0 >= VEC0_MAX_K ? hits : run(VEC0_MAX_K);
   }
   assertBlobReadMode(readMode);
   if (readMode === "blob-native") {
@@ -303,7 +322,7 @@ function runEntities(
       .query(
         "SELECT id, 1 - distance AS similarity FROM entity_vec WHERE embedding MATCH ? AND k = ? ORDER BY distance",
       )
-      .all(toBlob(queryEmbedding), limit) as VectorHit[];
+      .all(toBlob(queryEmbedding), vecK(limit)) as VectorHit[];
   }
   assertBlobReadMode(readMode);
   if (readMode === "blob-native") {
@@ -339,15 +358,20 @@ function runDistillations(
   if (readMode === "degraded") return [];
   if (readMode === "vec0") {
     // `archived` flips on meta-distillation (mutable) → post-filter via join,
-    // over-fetching so attrition leaves >= limit non-archived survivors.
-    return conn
-      .query(
-        "WITH knn AS (SELECT id, distance FROM distillation_vec WHERE embedding MATCH ? AND k = ?) " +
-          "SELECT knn.id AS id, 1 - knn.distance AS similarity " +
-          "FROM knn JOIN distillations d ON d.id = knn.id WHERE d.archived = 0 " +
-          "ORDER BY knn.distance LIMIT ?",
-      )
-      .all(toBlob(queryEmbedding), overfetchK(limit), limit) as VectorHit[];
+    // over-fetching so attrition leaves >= limit non-archived survivors, and
+    // widening to a full scan if that still under-fills (blob-mode parity).
+    const run = (k: number): VectorHit[] =>
+      conn
+        .query(
+          "WITH knn AS (SELECT id, distance FROM distillation_vec WHERE embedding MATCH ? AND k = ?) " +
+            "SELECT knn.id AS id, 1 - knn.distance AS similarity " +
+            "FROM knn JOIN distillations d ON d.id = knn.id WHERE d.archived = 0 " +
+            "ORDER BY knn.distance LIMIT ?",
+        )
+        .all(toBlob(queryEmbedding), k, limit) as VectorHit[];
+    const k0 = overfetchK(limit);
+    const hits = run(k0);
+    return hits.length >= limit || k0 >= VEC0_MAX_K ? hits : run(VEC0_MAX_K);
   }
   assertBlobReadMode(readMode);
   if (readMode === "blob-native") {
@@ -393,7 +417,11 @@ function runAllDistillations(
       .query(
         "SELECT id, session_id, 1 - distance AS similarity FROM distillation_vec WHERE embedding MATCH ? AND k = ? AND project_id = ? ORDER BY distance",
       )
-      .all(toBlob(queryEmbedding), limit, projectId) as DistillationVectorHit[];
+      .all(
+        toBlob(queryEmbedding),
+        vecK(limit),
+        projectId,
+      ) as DistillationVectorHit[];
   }
   assertBlobReadMode(readMode);
   if (readMode === "blob-native") {
@@ -457,8 +485,8 @@ function runTemporal(
       ? "SELECT message_id AS id, 1 - distance AS similarity FROM temporal_vec WHERE embedding MATCH ? AND k = ? AND project_id = ? AND session_id = ? ORDER BY distance"
       : "SELECT message_id AS id, 1 - distance AS similarity FROM temporal_vec WHERE embedding MATCH ? AND k = ? AND project_id = ? ORDER BY distance";
     const vparams: unknown[] = sessionId
-      ? [toBlob(queryEmbedding), limit, projectId, sessionId]
-      : [toBlob(queryEmbedding), limit, projectId];
+      ? [toBlob(queryEmbedding), vecK(limit), projectId, sessionId]
+      : [toBlob(queryEmbedding), vecK(limit), projectId];
     return conn.query(vsql).all(...vparams) as VectorHit[];
   }
   assertBlobReadMode(readMode);

--- a/packages/core/test/vec-store.test.ts
+++ b/packages/core/test/vec-store.test.ts
@@ -75,10 +75,10 @@ describe("readStorageMode", () => {
 });
 
 // ---------------------------------------------------------------------------
-// runVectorQuery — contract for the two non-BLOB read modes (PR3 placeholders)
+// runVectorQuery — "degraded" short-circuits before touching the connection
 // ---------------------------------------------------------------------------
 
-describe("runVectorQuery non-blob read modes", () => {
+describe("runVectorQuery degraded read mode", () => {
   const specs: VectorQuerySpec[] = [
     { kind: "knowledge", limit: 5 },
     { kind: "entities", limit: 5 },
@@ -88,7 +88,7 @@ describe("runVectorQuery non-blob read modes", () => {
   ];
 
   // A connection that explodes if touched — proves "degraded" short-circuits
-  // before running any SQL (no blobs exist to scan in the vec0 layout).
+  // before running any SQL (vec0 tables are unreadable without the extension).
   const explodingConn = {
     query(): { all(): unknown[] } {
       throw new Error("degraded must not query the connection");
@@ -101,12 +101,6 @@ describe("runVectorQuery non-blob read modes", () => {
     test(`degraded → [] without querying (${spec.kind})`, () => {
       expect(runVectorQuery(explodingConn, "degraded", query, spec)).toEqual(
         [],
-      );
-    });
-
-    test(`vec0 → throws (not implemented until cutover) (${spec.kind})`, () => {
-      expect(() => runVectorQuery(explodingConn, "vec0", query, spec)).toThrow(
-        /vec0 read path is not implemented/,
       );
     });
   }

--- a/packages/core/test/vec0-cutover.test.ts
+++ b/packages/core/test/vec0-cutover.test.ts
@@ -16,6 +16,7 @@ import {
   copyBlobsToVec0,
   deleteEmbeddings,
   dropEmbeddingColumn,
+  embeddingByIdSource,
   embeddingColumnExists,
   ensureVec0Store,
   gcVec0DanglingRows,
@@ -26,6 +27,7 @@ import {
   setStorageMode,
   storeEmbedding,
 } from "../src/db/vec-store";
+import { maybeCutoverToVec0 } from "../src/embedding";
 import * as ltm from "../src/ltm";
 import {
   fromBlob,
@@ -226,20 +228,29 @@ describeVec("blob → vec0 cutover", () => {
       .run(toBlob(v(0, 0, 1, 0)));
   }
 
-  /** Mirror maybeCutoverToVec0() using the exported helpers. */
+  const TABLES = [
+    "knowledge",
+    "entities",
+    "distillations",
+    "temporal",
+  ] as const;
+
+  /** Mirror maybeCutoverToVec0() at the test dimension: flip BEFORE drop, then
+   *  reclaim — so mode==="blob" never coexists with a dropped column. */
   function runCutover(): void {
-    ensureVec0Store(db(), DIM);
-    for (const table of [
-      "knowledge",
-      "entities",
-      "distillations",
-      "temporal",
-    ] as const) {
-      if (!embeddingColumnExists(db(), table)) continue;
-      copyBlobsToVec0(db(), table);
-      dropEmbeddingColumn(db(), table);
+    if (readStorageMode(db()) === "blob") {
+      ensureVec0Store(db(), DIM);
+      for (const table of TABLES) {
+        if (embeddingColumnExists(db(), table)) copyBlobsToVec0(db(), table);
+      }
+      setStorageMode(db(), "vec0");
     }
-    setStorageMode(db(), "vec0");
+    if (readStorageMode(db()) === "vec0") {
+      for (const table of TABLES) {
+        if (embeddingColumnExists(db(), table))
+          dropEmbeddingColumn(db(), table);
+      }
+    }
   }
 
   test("relocates blobs, drops base columns, flips the mode, and reads from vec0", () => {
@@ -454,6 +465,136 @@ describeVec("delete maintenance + GC", () => {
         }
       ).n,
     ).toBe(0);
+  });
+});
+
+describeVec("maybeCutoverToVec0 (real orchestration, config dim = 768)", () => {
+  const TABLES = [
+    "knowledge",
+    "entities",
+    "distillations",
+    "temporal",
+  ] as const;
+  // The real function uses the configured embedding dimension (768 in tests),
+  // so seed blobs at that width.
+  function v768(lead: number): Float32Array {
+    const a = new Float32Array(768);
+    a[lead] = 1; // already unit-norm
+    return a;
+  }
+
+  test("full cutover: flips mode, drops every column, populates vec0; idempotent", () => {
+    insKnowledge("k1");
+    insTemporal("t1", "s", 1);
+    db()
+      .query("UPDATE knowledge SET embedding = ? WHERE id='k1'")
+      .run(toBlob(v768(0)));
+    db()
+      .query("UPDATE temporal_messages SET embedding = ? WHERE id='t1'")
+      .run(toBlob(v768(1)));
+    expect(readStorageMode(db())).toBe("blob");
+
+    maybeCutoverToVec0();
+
+    expect(readStorageMode(db())).toBe("vec0");
+    for (const t of TABLES) expect(embeddingColumnExists(db(), t)).toBe(false);
+    expect(
+      (
+        db().query("SELECT COUNT(*) n FROM knowledge_vec").get() as {
+          n: number;
+        }
+      ).n,
+    ).toBe(1);
+    // idempotent re-run is a no-op (mode already vec0, columns already gone)
+    expect(() => maybeCutoverToVec0()).not.toThrow();
+    expect(readStorageMode(db())).toBe("vec0");
+  });
+
+  test("B1: resumes a crash mid-reclaim (mode=vec0, only some columns dropped)", () => {
+    // Simulate the post-flip / partial-drop state a crash can leave behind.
+    ensureVec0Store(db(), 768);
+    setStorageMode(db(), "vec0");
+    dropEmbeddingColumn(db(), "knowledge"); // knowledge dropped; others remain
+    expect(embeddingColumnExists(db(), "entities")).toBe(true);
+
+    maybeCutoverToVec0(); // reclaim finishes the remaining drops
+
+    expect(readStorageMode(db())).toBe("vec0");
+    for (const t of TABLES) expect(embeddingColumnExists(db(), t)).toBe(false);
+  });
+});
+
+describeVec("post-filter over-fetch widening (S1)", () => {
+  test("distillations: returns `limit` non-archived even when nearer rows are all archived", () => {
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    // 60 archived rows nearest the query (beyond the initial over-fetch window
+    // of overfetchK(3)=53), and 3 non-archived rows slightly farther. The first
+    // KNN window is all-archived → 0 survivors → must widen to a full scan.
+    for (let i = 0; i < 60; i++) {
+      insDistillation(`arch${i}`, "s", 1);
+      storeEmbedding(db(), "distillations", `arch${i}`, v(1, 0, 0, 0));
+    }
+    for (let i = 0; i < 3; i++) {
+      insDistillation(`live${i}`, "s", 0);
+      storeEmbedding(db(), "distillations", `live${i}`, v(0.9, 0.1, 0, 0));
+    }
+    const hits = runVectorQuery(db(), "vec0", v(1, 0, 0, 0), {
+      kind: "distillations",
+      limit: 3,
+    }) as VectorHit[];
+    expect(hits.length).toBe(3);
+    expect(hits.every((h) => h.id.startsWith("live"))).toBe(true);
+  });
+});
+
+describeVec("by-id vector point reads in vec0 mode (S2)", () => {
+  test("embeddingByIdSource reads vectors (and the distillation session_id aux) back from vec0", () => {
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    insKnowledge("k1");
+    insDistillation("d1", "sess-A", 0);
+    db()
+      .query(
+        "INSERT INTO entities (id, project_id, entity_type, canonical_name, cross_project, created_at, updated_at) VALUES ('e1', ?, 'tool', 'E', 0, ?, ?)",
+      )
+      .run(pid, Date.now(), Date.now());
+    storeEmbedding(db(), "knowledge", "k1", v(1, 0, 0, 0));
+    storeEmbedding(db(), "entities", "e1", v(0, 1, 0, 0));
+    storeEmbedding(db(), "distillations", "d1", v(0, 0, 1, 0));
+
+    // knowledge (mirrors the ltm.ts by-id reads, source view knowledge_current)
+    const ks = embeddingByIdSource("knowledge", "vec0", "knowledge_current");
+    const krow = db()
+      .query(
+        `SELECT id, embedding FROM ${ks.table} WHERE id IN ('k1')${ks.presenceFilter}`,
+      )
+      .get() as { embedding: Uint8Array };
+    expect(Array.from(fromBlob(krow.embedding))).toEqual(
+      Array.from(v(1, 0, 0, 0)),
+    );
+
+    // entities (mirrors entities.ts dedup)
+    const es = embeddingByIdSource("entities", "vec0", "entities");
+    expect(
+      db()
+        .query(
+          `SELECT id FROM ${es.table} WHERE id IN ('e1')${es.presenceFilter}`,
+        )
+        .all().length,
+    ).toBe(1);
+
+    // distillations WITH session_id aux (mirrors pattern-echo.ts)
+    const ds = embeddingByIdSource("distillations", "vec0", "distillations");
+    const drow = db()
+      .query(
+        `SELECT id, session_id, embedding FROM ${ds.table} WHERE id IN ('d1')${ds.presenceFilter}`,
+      )
+      .get() as { session_id: string; embedding: Uint8Array };
+    expect(drow.session_id).toBe("sess-A");
+    expect(Array.from(fromBlob(drow.embedding))).toEqual(
+      Array.from(v(0, 0, 1, 0)),
+    );
   });
 });
 

--- a/packages/core/test/vec0-cutover.test.ts
+++ b/packages/core/test/vec0-cutover.test.ts
@@ -1,0 +1,475 @@
+// End-to-end tests for the FLAT-vec0 storage layout: write/read round-trip,
+// the blob→vec0 cutover (backfill + DROP COLUMN + flip, idempotent/resumable),
+// vec0↔blob exact parity, partition pushdown + recency-cap removal, dimension
+// change, delete maintenance, and the dangling-row GC backstop.
+//
+// All run against the real vec0-capable test connection (the vendored sqlite-vec
+// loads in the node test runtime). The suite is skipped if the extension is
+// somehow unavailable so a vec-less CI lane stays green.
+import { afterAll, beforeEach, describe, expect, test } from "vitest";
+import { close, db, ensureProject } from "../src/db";
+import { isVecAvailable } from "../src/db/vec";
+import {
+  VEC_DIMENSION_KEY,
+  VEC_STORAGE_MODE_KEY,
+  clearAllEmbeddings,
+  copyBlobsToVec0,
+  deleteEmbeddings,
+  dropEmbeddingColumn,
+  embeddingColumnExists,
+  ensureVec0Store,
+  gcVec0DanglingRows,
+  hasEmbeddingSql,
+  missingEmbeddingSql,
+  readStorageMode,
+  readVecDimension,
+  setStorageMode,
+  storeEmbedding,
+} from "../src/db/vec-store";
+import * as ltm from "../src/ltm";
+import {
+  fromBlob,
+  runVectorQuery,
+  toBlob,
+  type VectorHit,
+} from "../src/vector-query";
+
+const PROJECT = "/test/vec0-cutover";
+const DIM = 4;
+const BASE = ["knowledge", "entities", "distillations", "temporal_messages"];
+const VEC = ["knowledge_vec", "entity_vec", "distillation_vec", "temporal_vec"];
+
+function v(...xs: number[]): Float32Array {
+  const a = new Float32Array(DIM);
+  let n = 0;
+  for (let i = 0; i < DIM; i++) {
+    a[i] = xs[i] ?? 0;
+    n += a[i] * a[i];
+  }
+  n = Math.sqrt(n) || 1;
+  for (let i = 0; i < DIM; i++) a[i] /= n; // L2-normalize (system invariant)
+  return a;
+}
+
+let pid: string;
+
+/** Return every test to a clean blob-layout state: drop vec0 tables, re-add any
+ *  base `embedding` column a cutover test dropped, clear kv flags + base rows. */
+function resetToBlob(): void {
+  for (const vt of VEC) db().query(`DROP TABLE IF EXISTS ${vt}`).run();
+  for (const t of BASE) {
+    const cols = db().query(`PRAGMA table_info(${t})`).all() as Array<{
+      name: string;
+    }>;
+    if (!cols.some((c) => c.name === "embedding")) {
+      db().query(`ALTER TABLE ${t} ADD COLUMN embedding BLOB`).run();
+    }
+  }
+  db()
+    .query("DELETE FROM kv_meta WHERE key IN (?, ?)")
+    .run(VEC_STORAGE_MODE_KEY, VEC_DIMENSION_KEY);
+  for (const t of BASE) db().query(`DELETE FROM ${t}`).run();
+}
+
+beforeEach(() => {
+  pid = ensureProject(PROJECT);
+  resetToBlob();
+});
+
+afterAll(() => {
+  close();
+});
+
+// --- fixture inserters (base rows; embeddings stored separately) ------------
+function insKnowledge(id: string, title = "", content = "", conf = 1.0): void {
+  const now = Date.now();
+  db()
+    .query(
+      "INSERT INTO knowledge (id, project_id, category, title, content, created_at, updated_at, logical_id) VALUES (?, ?, 'test', ?, ?, ?, ?, ?)",
+    )
+    .run(id, pid, title, content, now, now, id);
+  if (conf !== 1.0) {
+    db()
+      .query(
+        "INSERT INTO knowledge_meta (logical_id, confidence) VALUES (?, ?) ON CONFLICT(logical_id) DO UPDATE SET confidence = ?",
+      )
+      .run(id, conf, conf);
+  }
+}
+function insDistillation(id: string, sess = "s", archived = 0): void {
+  db()
+    .query(
+      "INSERT INTO distillations (id, project_id, session_id, narrative, facts, observations, source_ids, generation, token_count, created_at, archived) VALUES (?, ?, ?, '', '', 'obs', '', 0, 0, ?, ?)",
+    )
+    .run(id, pid, sess, Date.now(), archived);
+}
+function insTemporal(id: string, sess: string, createdAt: number): void {
+  db()
+    .query(
+      "INSERT INTO temporal_messages (id, project_id, session_id, role, content, tokens, distilled, created_at) VALUES (?, ?, ?, 'user', 'm', 0, 0, ?)",
+    )
+    .run(id, pid, sess, createdAt);
+}
+
+// Open the connection so the vendored sqlite-vec extension loads before we read
+// its availability (isVecAvailable() reflects the global set at first open).
+db();
+const describeVec = isVecAvailable() ? describe : describe.skip;
+
+describeVec("vec0 write + read round-trip", () => {
+  test("storeEmbedding writes to the vec0 table (not the base column)", () => {
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    insKnowledge("k1", "t", "c");
+    storeEmbedding(db(), "knowledge", "k1", v(1, 0, 0, 0));
+
+    // base column untouched, vec0 table populated
+    const base = db()
+      .query("SELECT embedding FROM knowledge WHERE id = 'k1'")
+      .get() as { embedding: Buffer | null };
+    expect(base.embedding).toBeNull();
+    const vecRow = db()
+      .query("SELECT embedding FROM knowledge_vec WHERE id = 'k1'")
+      .get() as { embedding: Uint8Array };
+    expect(Array.from(fromBlob(vecRow.embedding))).toEqual(
+      Array.from(v(1, 0, 0, 0)),
+    );
+  });
+
+  test("runVectorQuery vec0 returns hits ranked by cosine, post-filtering confidence", () => {
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    insKnowledge("near", "t", "c", 1.0);
+    insKnowledge("far", "t", "c", 1.0);
+    insKnowledge("lowconf", "t", "c", 0.1); // below the 0.2 floor → filtered out
+    storeEmbedding(db(), "knowledge", "near", v(1, 0, 0, 0));
+    storeEmbedding(db(), "knowledge", "far", v(0, 1, 0, 0));
+    storeEmbedding(db(), "knowledge", "lowconf", v(1, 0, 0, 0)); // identical to query
+
+    const hits = runVectorQuery(db(), "vec0", v(1, 0, 0, 0), {
+      kind: "knowledge",
+      limit: 10,
+    }) as VectorHit[];
+    const ids = hits.map((h) => h.id);
+    expect(ids).toContain("near");
+    expect(ids).toContain("far");
+    expect(ids).not.toContain("lowconf"); // confidence post-filter
+    expect(ids.indexOf("near")).toBeLessThan(ids.indexOf("far")); // closer first
+  });
+
+  test("temporal vec0 read scopes by project + session partition and returns message ids", () => {
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    insTemporal("a", "sX", 1000);
+    insTemporal("b", "sY", 2000);
+    storeEmbedding(db(), "temporal", "a", v(1, 0, 0, 0));
+    storeEmbedding(db(), "temporal", "b", v(1, 0, 0, 0));
+
+    const scoped = runVectorQuery(db(), "vec0", v(1, 0, 0, 0), {
+      kind: "temporal",
+      projectId: pid,
+      sessionId: "sX",
+      limit: 10,
+    }) as VectorHit[];
+    expect(scoped.map((h) => h.id)).toEqual(["a"]); // partition pushdown excludes sY
+  });
+});
+
+describeVec("vec0 ↔ blob exact parity (FLAT is exact)", () => {
+  test("knowledge: vec0 and blob-js return identical ranking under the same filters", () => {
+    // Seed identical data; store both blob (base column) and vec0 rows.
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    const vectors: Array<[string, Float32Array]> = [
+      ["k1", v(1, 0.2, 0, 0)],
+      ["k2", v(0.2, 1, 0, 0)],
+      ["k3", v(0, 0, 1, 0)],
+      ["k4", v(0.9, 0.1, 0.1, 0)],
+    ];
+    for (const [id, vec] of vectors) {
+      insKnowledge(id, "t", "c");
+      storeEmbedding(db(), "knowledge", id, vec); // vec0 write
+      db()
+        .query("UPDATE knowledge SET embedding = ? WHERE id = ?")
+        .run(toBlob(vec), id); // blob write (parallel)
+    }
+    const q = v(1, 0, 0, 0);
+    const vec0Hits = runVectorQuery(db(), "vec0", q, {
+      kind: "knowledge",
+      limit: 4,
+    }) as VectorHit[];
+    const blobHits = runVectorQuery(db(), "blob-js", q, {
+      kind: "knowledge",
+      limit: 4,
+    }) as VectorHit[];
+    expect(vec0Hits.map((h) => h.id)).toEqual(blobHits.map((h) => h.id));
+    // Similarities match too (exact), within float tolerance.
+    for (let i = 0; i < vec0Hits.length; i++) {
+      expect(vec0Hits[i].similarity).toBeCloseTo(blobHits[i].similarity, 5);
+    }
+  });
+});
+
+describeVec("blob → vec0 cutover", () => {
+  function seedBlobs(): void {
+    insKnowledge("k1", "t", "c");
+    insDistillation("d1", "s", 0);
+    insTemporal("t1", "s", 1000);
+    db()
+      .query("UPDATE knowledge SET embedding = ? WHERE id='k1'")
+      .run(toBlob(v(1, 0, 0, 0)));
+    db()
+      .query("UPDATE distillations SET embedding = ? WHERE id='d1'")
+      .run(toBlob(v(0, 1, 0, 0)));
+    db()
+      .query("UPDATE temporal_messages SET embedding = ? WHERE id='t1'")
+      .run(toBlob(v(0, 0, 1, 0)));
+  }
+
+  /** Mirror maybeCutoverToVec0() using the exported helpers. */
+  function runCutover(): void {
+    ensureVec0Store(db(), DIM);
+    for (const table of [
+      "knowledge",
+      "entities",
+      "distillations",
+      "temporal",
+    ] as const) {
+      if (!embeddingColumnExists(db(), table)) continue;
+      copyBlobsToVec0(db(), table);
+      dropEmbeddingColumn(db(), table);
+    }
+    setStorageMode(db(), "vec0");
+  }
+
+  test("relocates blobs, drops base columns, flips the mode, and reads from vec0", () => {
+    seedBlobs();
+    runCutover();
+
+    // mode flipped + every base embedding column dropped
+    expect(readStorageMode(db())).toBe("vec0");
+    for (const t of [
+      "knowledge",
+      "entities",
+      "distillations",
+      "temporal",
+    ] as const) {
+      expect(embeddingColumnExists(db(), t)).toBe(false);
+    }
+    // vec0 tables carry the relocated vectors
+    expect(
+      (
+        db().query("SELECT COUNT(*) n FROM knowledge_vec").get() as {
+          n: number;
+        }
+      ).n,
+    ).toBe(1);
+    expect(
+      (db().query("SELECT COUNT(*) n FROM temporal_vec").get() as { n: number })
+        .n,
+    ).toBe(1);
+    // and a vec0 read finds the relocated knowledge row
+    const hits = runVectorQuery(db(), "vec0", v(1, 0, 0, 0), {
+      kind: "knowledge",
+      limit: 5,
+    }) as VectorHit[];
+    expect(hits.map((h) => h.id)).toContain("k1");
+  });
+
+  test("is idempotent / resumable (re-running copy never duplicates)", () => {
+    seedBlobs();
+    ensureVec0Store(db(), DIM);
+    copyBlobsToVec0(db(), "knowledge");
+    copyBlobsToVec0(db(), "knowledge"); // re-run (crash-resume)
+    expect(
+      (
+        db().query("SELECT COUNT(*) n FROM knowledge_vec").get() as {
+          n: number;
+        }
+      ).n,
+    ).toBe(1);
+    // a full second cutover pass after columns are dropped is a no-op (skips
+    // already-migrated tables rather than reading a dropped column)
+    runCutover();
+    expect(() => runCutover()).not.toThrow();
+    expect(readStorageMode(db())).toBe("vec0");
+  });
+
+  test("appendVersion works after the column is dropped, and demotes the old vec0 row", () => {
+    // Seed a knowledge entry with a vec0 row, then cut over.
+    insKnowledge("k1", "title", "v1");
+    db()
+      .query("UPDATE knowledge SET embedding = ? WHERE id='k1'")
+      .run(toBlob(v(1, 0, 0, 0)));
+    runCutover();
+    expect(embeddingColumnExists(db(), "knowledge")).toBe(false);
+
+    // appendVersion must NOT reference the dropped `embedding` column.
+    const newId = ltm.appendVersion("k1", { content: "v2" });
+    expect(newId).toBeTruthy();
+    expect(newId).not.toBe("k1");
+    // the demoted version's vec0 row is gone (knowledge_vec holds current only)
+    const oldVec = db()
+      .query("SELECT COUNT(*) n FROM knowledge_vec WHERE id = 'k1'")
+      .get() as { n: number };
+    expect(oldVec.n).toBe(0);
+  });
+});
+
+describeVec("recency-cap removal (vec0 sees the whole corpus)", () => {
+  test("a relevant temporal message older than the blob window still surfaces in vec0", () => {
+    // Exceed the blob recency cap so the OLDEST row is outside the blob window.
+    const N = 4010; // > MAX_TEMPORAL_VECTOR_ROWS (4000)
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    // Oldest row (created_at=0) is the perfect match; the rest are orthogonal.
+    insTemporal("oldest", "s", 0);
+    storeEmbedding(db(), "temporal", "oldest", v(1, 0, 0, 0));
+    db().query("BEGIN").run();
+    for (let i = 1; i < N; i++) {
+      insTemporal(`m${i}`, "s", i); // newer
+      storeEmbedding(db(), "temporal", `m${i}`, v(0, 1, 0, 0));
+    }
+    db().query("COMMIT").run();
+
+    const hits = runVectorQuery(db(), "vec0", v(1, 0, 0, 0), {
+      kind: "temporal",
+      projectId: pid,
+      limit: 5,
+    }) as VectorHit[];
+    // The perfect match is the oldest row — outside the former 4000-row window,
+    // yet vec0 (uncapped) surfaces it first.
+    expect(hits[0]?.id).toBe("oldest");
+  });
+});
+
+describeVec("dimension change", () => {
+  test("ensureVec0Store drops + recreates the tables at the new dimension", () => {
+    ensureVec0Store(db(), DIM);
+    setStorageMode(db(), "vec0");
+    insKnowledge("k1");
+    storeEmbedding(db(), "knowledge", "k1", v(1, 0, 0, 0));
+    expect(
+      (
+        db().query("SELECT COUNT(*) n FROM knowledge_vec").get() as {
+          n: number;
+        }
+      ).n,
+    ).toBe(1);
+    expect(readVecDimension(db())).toBe(DIM);
+
+    // A larger dimension makes the fixed-width tables incompatible → recreate.
+    ensureVec0Store(db(), 8);
+    expect(readVecDimension(db())).toBe(8);
+    expect(
+      (
+        db().query("SELECT COUNT(*) n FROM knowledge_vec").get() as {
+          n: number;
+        }
+      ).n,
+    ).toBe(0); // recreated empty
+    // and it now accepts 8-dim vectors
+    const eight = new Float32Array([1, 0, 0, 0, 0, 0, 0, 0]);
+    expect(() =>
+      db()
+        .query("INSERT INTO knowledge_vec(id, embedding) VALUES ('x', ?)")
+        .run(toBlob(eight)),
+    ).not.toThrow();
+  });
+});
+
+describeVec("delete maintenance + GC", () => {
+  test("deleteEmbeddings removes vec0 rows in vec0 mode and is a no-op in blob mode", () => {
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    insKnowledge("k1");
+    insTemporal("t1", "s", 1);
+    storeEmbedding(db(), "knowledge", "k1", v(1, 0, 0, 0));
+    storeEmbedding(db(), "temporal", "t1", v(1, 0, 0, 0));
+
+    deleteEmbeddings(db(), "knowledge", ["k1"]);
+    deleteEmbeddings(db(), "temporal", ["t1"]); // by message_id (aux)
+    expect(
+      (
+        db().query("SELECT COUNT(*) n FROM knowledge_vec").get() as {
+          n: number;
+        }
+      ).n,
+    ).toBe(0);
+    expect(
+      (db().query("SELECT COUNT(*) n FROM temporal_vec").get() as { n: number })
+        .n,
+    ).toBe(0);
+
+    // blob mode: no-op (no vec0 tables to touch)
+    setStorageMode(db(), "blob");
+    expect(() =>
+      deleteEmbeddings(db(), "knowledge", ["whatever"]),
+    ).not.toThrow();
+  });
+
+  test("gcVec0DanglingRows reclaims vec0 rows whose base row is gone", () => {
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    insKnowledge("keep");
+    insTemporal("keepT", "s", 1);
+    storeEmbedding(db(), "knowledge", "keep", v(1, 0, 0, 0));
+    storeEmbedding(db(), "temporal", "keepT", v(1, 0, 0, 0));
+    // orphan rows: vec0 entries with no backing base row
+    db()
+      .query("INSERT INTO knowledge_vec(id, embedding) VALUES ('orphan', ?)")
+      .run(toBlob(v(0, 1, 0, 0)));
+    db()
+      .query(
+        "INSERT INTO temporal_vec(chunk_id, message_id, project_id, session_id, embedding) VALUES ('orphanT#0','orphanT',?, 's', ?)",
+      )
+      .run(pid, toBlob(v(0, 1, 0, 0)));
+
+    gcVec0DanglingRows(db());
+
+    expect(
+      db()
+        .query("SELECT id FROM knowledge_vec ORDER BY id")
+        .all()
+        .map((r) => (r as { id: string }).id),
+    ).toEqual(["keep"]);
+    expect(
+      db()
+        .query("SELECT message_id FROM temporal_vec")
+        .all()
+        .map((r) => (r as { message_id: string }).message_id),
+    ).toEqual(["keepT"]);
+  });
+
+  test("clearAllEmbeddings empties vec0 tables in vec0 mode", () => {
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    insKnowledge("k1");
+    storeEmbedding(db(), "knowledge", "k1", v(1, 0, 0, 0));
+    clearAllEmbeddings(db());
+    expect(
+      (
+        db().query("SELECT COUNT(*) n FROM knowledge_vec").get() as {
+          n: number;
+        }
+      ).n,
+    ).toBe(0);
+  });
+});
+
+describe("mode-aware detection predicates", () => {
+  test("missingEmbeddingSql / hasEmbeddingSql switch on storage mode", () => {
+    expect(missingEmbeddingSql("knowledge", "blob")).toBe("embedding IS NULL");
+    expect(hasEmbeddingSql("knowledge", "blob")).toBe("embedding IS NOT NULL");
+    expect(missingEmbeddingSql("knowledge", "vec0")).toBe(
+      "id NOT IN (SELECT id FROM knowledge_vec)",
+    );
+    expect(hasEmbeddingSql("entities", "vec0", "e")).toBe(
+      "e.id IN (SELECT id FROM entity_vec)",
+    );
+    // temporal keys vec0 by message_id, not id
+    expect(missingEmbeddingSql("temporal", "vec0")).toBe(
+      "id NOT IN (SELECT message_id FROM temporal_vec)",
+    );
+  });
+});


### PR DESCRIPTION
## What

PR4 of the vec0 cutover. Switches the embedding store from per-row `embedding` BLOB columns to sqlite-vec **`vec0` virtual tables**, eliminating the O(n) brute-force cosine scan behind #999 (awaited p50 ~23s / p95 ~128s) and removing the `MAX_*_VECTOR_ROWS` recency-cap stopgaps.

Builds on PR #1030 (native sqlite-vec in the SEA binary), #1038 (vendored 0.1.10-alpha.4), and #1044 (the capability/read-mode seam). Plan: `.opencode/plans/1782503960000-diskann-ann-switchover.md`.

## Index choice — FLAT vec0, not DiskANN (empirically overturns the locked plan)

A spike against the vendored `v0.1.10-alpha.4` binary disqualified DiskANN for this workload:

| | DiskANN (int8) | **FLAT vec0 + partition keys** |
|---|---|---|
| `PARTITION KEY` / metadata filter pushdown | ❌ *"not supported with DiskANN"* | ✅ |
| insert cost | ~48 ms/vec → **~85 min** / 106K backfill | 0.12 ms/vec → **~13 s** |
| recall@10 | ~0.82 (approximate) | **1.0 (exact)** |
| session-scoped read (partition pushdown) | n/a (can't filter) | **~0.9 ms** |
| project-wide read (106K, off-thread) | sub-linear but can't scope project | **~308 ms** exact |

DiskANN in this build supports only a PK + the vector (no project/session filtering at all); `rescore` also rejects partition keys. **FLAT** is exact, supports partition pushdown, has cheap inserts, and still lets us drop the recency caps. The user confirmed this change before implementation.

## How

- **`db/vec-store.ts`** — vec0 DDL for the 4 tables at the configured dim (`temporal_vec` chunk-keyed `chunk_id`+`+message_id` ahead of multi-vector chunking); `storeEmbedding`/`deleteEmbeddings`/`clearAllEmbeddings` vec0 branches; `ensureVec0Store` (create + drop/recreate on a dimension change); `copyBlobsToVec0` + `dropEmbeddingColumn` cutover helpers; mode-aware `missing/hasEmbeddingSql`; `embeddingByIdSource`; `gcVec0DanglingRows`.
- **`vector-query.ts`** — a `vec0` KNN branch per helper: partition pushdown for temporal/allDistillations, CTE-KNN + JOIN post-filter + over-fetch for knowledge (confidence/category) and distillations (archived). Recency cap removed **on the vec0 path only** (blob paths keep it).
- **`embedding.ts`** — one-time blob→vec0 cutover (backfill via `INSERT…SELECT` → `DROP COLUMN` → flip `vec.storage_mode` last → `incremental_vacuum`), idempotent/resumable and column-presence-aware (the v55 boot-loop lesson); mode-aware backfill detection; dimension-change handling; **degraded short-circuit**; a resilient in-process read fallback; a startup GC sweep.
- **`db.ts`** — ensure the vec0 tables exist on open for an already-vec0 DB (reads work before the cutover runs).
- **`ltm.ts` / `entities.ts` / `pattern-echo.ts`** — read stored vectors by id from the vec0 table in vec0 mode (vec0 returns the same float32 bytes; `distillation_vec` even carries `session_id` as an aux column). `appendVersion` omits the dropped `embedding` column and demotes the old vec0 row so `knowledge_vec` holds only current versions.

## Degrade contract (preserved)

A vec0-store DB opened on a runtime that can't load sqlite-vec (Bun-on-macOS, Node without `allowExtension`, or `LORE_DISABLE_VEC=1`) → vector recall returns `[]` (FTS/keyword recall still answers), **never crashes**, and re-converges when next opened on a capable runtime. Storage stays net-neutral (blob columns dropped at cutover; no doubling).

## Tests

- New `packages/core/test/vec0-cutover.test.ts` (13 tests, real vec0-capable connection): write/read round-trip, vec0↔blob **exact parity**, end-to-end cutover (relocate + DROP COLUMN + flip + idempotent re-run), `appendVersion` after the column is dropped + demote, **recency-cap removal** (4010 rows; the oldest perfect-match still surfaces), dimension change, delete maintenance + GC, mode-aware predicates.
- Updated the obsolete PR3 placeholder (`vec0 → throws`) to the implemented behavior.
- Full core suite green (97 files / 2242 tests); typecheck + Biome clean. Key guards mutation-tested non-vacuous (confidence post-filter, knowledge demote-delete).

## Follow-ups (not blocking)

- Eager bulk-delete maintenance at project/session/prune sites (today dangling rows are harmless — recall hydration drops a hit whose base row is gone, partitions isolate deleted projects — and the startup GC sweep reclaims them).
- PR5: rollout smoke guards, telemetry (storage_mode / coverage / KNN p50-p95), kill-switch hardening.