### PR TITLE
test(core): de-flake embedding OOM recovery (env-independent start cap)

### DIFF
--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -141,9 +141,19 @@ function computeInitialEmbedCap(): number {
   );
 }
 
-/** For tests: persist a learned embedding cap (kv_meta round-trip). */
-export function _persistEmbedCap(cap: number): void {
-  persistEmbedCap(cap);
+/**
+ * For tests: persist a learned embedding cap (kv_meta round-trip).
+ *
+ * `freeMemBytes` defaults to the live `freemem()`. Tests that need a
+ * deterministic start cap pass `0`: `reconcileEmbedCap` treats a non-positive
+ * learn-time baseline as ratio = 1, so the persisted cap is always trusted
+ * as-is — independent of how much free memory the host happens to have. Without
+ * this, a host whose free memory swings >25% between persist and provider
+ * construction (e.g. a CI box running the full suite in parallel) reconciles to
+ * the freemem-derived model cap instead, making the start cap non-deterministic.
+ */
+export function _persistEmbedCap(cap: number, freeMemBytes?: number): void {
+  persistEmbedCap(cap, freeMemBytes);
 }
 
 /** For tests: read the persisted embedding cap (or null when absent/corrupt). */

--- a/packages/core/test/embedding-oom-recovery.test.ts
+++ b/packages/core/test/embedding-oom-recovery.test.ts
@@ -100,7 +100,11 @@ describe("embedding OOM recovery (worker-mock)", () => {
   });
 
   it("OOM exit lowers the cap ×0.7, persists it, respawns, and re-submits the in-flight request at the lowered cap", async () => {
-    _persistEmbedCap(8192); // fresh provider starts at the model max
+    // freeMemBytes=0 → reconcileEmbedCap trusts this cap as-is regardless of
+    // host free memory, so the provider deterministically starts at the model
+    // max (otherwise a freemem swing under parallel CI load reconciles down to
+    // the memory-model cap and this test flakes).
+    _persistEmbedCap(8192, 0);
     const fakes = installFakeWorkers();
 
     const promise = embed(["hello world"], "query");
@@ -135,7 +139,9 @@ describe("embedding OOM recovery (worker-mock)", () => {
   });
 
   it("OOM at the floor latches FTS-only and rejects the pending request (no respawn)", async () => {
-    _persistEmbedCap(MIN_EMBED_TOKENS); // fresh provider starts at the floor
+    // freeMemBytes=0 → trusted as-is (see the model-max test), so the provider
+    // deterministically starts at the floor regardless of host free memory.
+    _persistEmbedCap(MIN_EMBED_TOKENS, 0);
     const fakes = installFakeWorkers();
 
     const result = settle(embed(["hello world"], "query"));
@@ -155,7 +161,7 @@ describe("embedding OOM recovery (worker-mock)", () => {
   });
 
   it("rejects pending requests when the respawn itself fails synchronously", async () => {
-    _persistEmbedCap(8192);
+    _persistEmbedCap(8192, 0);
     let calls = 0;
     const fakes: FakeWorker[] = [];
     _setTestWorkerFactory(() => {
@@ -182,7 +188,7 @@ describe("embedding OOM recovery (worker-mock)", () => {
   });
 
   it("descends the full backoff ladder to the floor across repeated OOMs, then latches", async () => {
-    _persistEmbedCap(8192);
+    _persistEmbedCap(8192, 0);
     const fakes = installFakeWorkers();
 
     const result = settle(embed(["hello world"], "query"));


### PR DESCRIPTION
## The flake

`embedding-oom-recovery.test.ts` failed intermittently under the full parallel suite (passes in isolation):

```
× OOM exit lowers the cap ×0.7, persists it, respawns... 3716ms
  AssertionError: expected 2532 to be 8192
```

The tests seed a start cap via `_persistEmbedCap(8192)`, expecting the provider to begin at the model max. But the provider's `computeInitialEmbedCap()` runs `reconcileEmbedCap(free, stored, memoryModelEmbedCap(free))`, which only trusts the persisted cap when `freemem()@construct / freemem()@persist ∈ [0.75, 1.25]`. Under heavy parallel CI load, free memory swings >25% between those two reads, so the provider instead starts at the **freemem-derived** memory-model cap (~2.3K tokens on a 2.6 GB-free box) — failing `expect(first.maxTokens).toBe(8192)`. (All four tests in the file share this latent dependency.)

## The fix

Seed with `freeMemBytes = 0`. `reconcileEmbedCap` already treats a non-positive learn-time baseline as `ratio = 1` (always trust the stored cap), so the start cap becomes **independent of host free memory** — exactly the determinism these tests need. The `_persistEmbedCap` test seam gains an optional `freeMemBytes` param (default unchanged: live `freemem()`); production code is untouched.

## Verification

- **Reproduced deterministically** by skewing the stored `freeMemBytes` so the ratio falls out of the trust band → `expected 2532 to be 8192` (the exact production failure mode).
- Fixed test green; **full `packages/core` suite passes (2234 tests) under parallel load** — the condition that triggered the flake.
- Robust by construction: with `stored.freeMemBytes = 0`, `reconcileEmbedCap` returns `clampEmbedCap(stored.cap)` regardless of current `freemem()`.