### PR TITLE
fix(embedding): keep the worker thread's stderr off the host TUI

### DIFF
--- a/packages/core/src/embedding-worker-types.ts
+++ b/packages/core/src/embedding-worker-types.ts
@@ -273,4 +273,12 @@ export interface WorkerInitData {
      *  (config.json, tokenizer.json, onnx/model_quantized.onnx, …). */
     localModelPath: string;
   } | null;
+  /** Snapshot of the host's stderr-silence state at spawn time. A worker thread
+   *  has its OWN `globalThis`, so the main thread's `log.silenceStderr()`
+   *  process-global can't reach it — we pass the value explicitly instead. When
+   *  true (the plugin/in-process-gateway TUI mode), the worker must not write a
+   *  single byte to stderr, which would corrupt the host's full-screen render.
+   *  The worker gates its `console.warn` diagnostics on this flag inline (it runs
+   *  as raw .ts and can't value-import siblings — see embedding-worker.ts). */
+  stderrSilenced?: boolean;
 }

--- a/packages/core/src/embedding-worker.ts
+++ b/packages/core/src/embedding-worker.ts
@@ -42,6 +42,9 @@ const port = parentPort;
 
 const init = workerData as WorkerInitData;
 const { modelId, dimensions, vendorModel } = init;
+// Snapshot of the host's stderr-silence state (see WorkerInitData). When true,
+// every diagnostic below stays off stderr so it can't corrupt the host's TUI.
+const stderrSilenced = init.stderrSilenced ?? false;
 
 /**
  * Main-thread-owned input token cap (see `WorkerInitData.maxTokens`). Every
@@ -208,9 +211,14 @@ async function ensurePipeline(): Promise<void> {
             // localProviderKnownBroken=true), which would brick the provider
             // even though we're about to retry successfully. Only the .catch
             // below (a genuine final failure) may post init-error.
-            console.warn(
-              `[embedding-worker] model corrupt (${msg}); purged cache, retrying download once`,
-            );
+            // Gate on the host's stderr-silence flag (see WorkerInitData) — in a
+            // host TUI any raw byte corrupts the render. The flag is inlined here
+            // because the worker runs as raw .ts and can't value-import siblings.
+            if (!stderrSilenced) {
+              console.warn(
+                `[embedding-worker] model corrupt (${msg}); purged cache, retrying download once`,
+              );
+            }
             // Retry once. If this throws, it propagates to the .catch below and
             // marks the worker permanently failed.
             await loadPipeline();
@@ -521,10 +529,14 @@ async function processEmbed(req: EmbedRequest): Promise<void> {
       // reject the request before the backoff can re-submit it. The main
       // thread reconstructs OOM context from the pending request for telemetry.
       if (isOomError(raw)) {
-        console.warn(
-          `[lore] ONNX OOM at ≤${effectiveMax} tokens (batch=${req.texts.length}, ` +
-            `longest≈${longest} chars) — respawning worker at a lower cap`,
-        );
+        // Silenced in host-TUI mode (see WorkerInitData.stderrSilenced); the
+        // main thread reconstructs OOM telemetry, so nothing diagnostic is lost.
+        if (!stderrSilenced) {
+          console.warn(
+            `[lore] ONNX OOM at ≤${effectiveMax} tokens (batch=${req.texts.length}, ` +
+              `longest≈${longest} chars) — respawning worker at a lower cap`,
+          );
+        }
         process.exit(EMBED_OOM_EXIT_CODE);
         return; // unreachable, but makes intent clear
       }

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -533,6 +533,9 @@ class LocalProvider implements EmbeddingProvider {
         dimensions: this.dimensions,
         maxTokens: this.maxTokens,
         vendorModel: vendor ? { localModelPath: vendor.localModelPath } : null,
+        // Snapshot the host's silence state — the worker's own `globalThis`
+        // can't see the main thread's flag (re-read on every OOM respawn).
+        stderrSilenced: log.isStderrSilenced(),
       };
 
       if (testWorkerFactory) {

--- a/packages/core/test/embedding-oom-recovery.test.ts
+++ b/packages/core/test/embedding-oom-recovery.test.ts
@@ -14,6 +14,7 @@ import {
 } from "../src/embedding";
 import { backoffEmbedCap, MIN_EMBED_TOKENS } from "../src/embedding-cap";
 import { EMBED_OOM_EXIT_CODE } from "../src/embedding-worker-types";
+import { isStderrSilenced, silenceStderr } from "../src/log";
 
 // Exercises the stateful OOM-recovery lifecycle in LocalProvider that the pure
 // cap math can't reach: the worker on("exit") OOM branch → handleOomBackoff →
@@ -213,5 +214,26 @@ describe("embedding OOM recovery (worker-mock)", () => {
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.err).toBeInstanceOf(LocalProviderUnavailableError);
     expect(isAvailable()).toBe(false);
+  });
+
+  it("snapshots the host's stderr-silence flag into workerData on every spawn", async () => {
+    // A worker thread has its OWN globalThis, so the main thread's
+    // log.silenceStderr() can't reach it — the value must ride in via workerData
+    // or the worker's [lore] OOM line corrupts the host TUI. The global test
+    // setup resets the silence flag after each test.
+    _persistEmbedCap(8192, 0);
+    const seen: Array<boolean | undefined> = [];
+    _setTestWorkerFactory((initData) => {
+      seen.push(initData.stderrSilenced);
+      return new FakeWorker() as unknown as Worker;
+    });
+
+    silenceStderr(true);
+    expect(isStderrSilenced()).toBe(true);
+    void settle(embed(["hello world"], "query"));
+    await flush();
+
+    // The spawn captured the live silence state (true), not a hardcoded default.
+    expect(seen.at(-1)).toBe(true);
   });
 });

--- a/packages/core/test/embedding-worker-types.test.ts
+++ b/packages/core/test/embedding-worker-types.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from "vitest";
+import { describe, expect, test } from "vitest";
 import {
   isOomError,
   isWasmFatalError,


### PR DESCRIPTION
## The leak

The embedding worker emits two diagnostics via `console.warn`:

- `embedding-worker.ts` — `[embedding-worker] model corrupt …; retrying download once`
- `embedding-worker.ts` — `[lore] ONNX OOM at ≤N tokens … respawning worker at a lower cap`

It runs as a `node:worker_threads` Worker spawned **without `stderr:true`**, so a worker's `process.stderr` writes auto-pipe to the **host process's** stderr. Inside a full-screen TUI (the Pi extension / OpenCode plugin running the gateway in-process) any such byte corrupts the render — the same bug class as #1050.

#1050 closed the in-process leaks by flipping `log.silenceStderr()` (a process-global on `globalThis`). **That switch can't reach this path:** a worker thread has its **own** `globalThis`, so the main thread's flag is invisible to it. (Found during the #1050 self-review; split out as its own PR per the distinct mechanism.)

## The fix

- Snapshot the host's silence state into `workerData.stderrSilenced` at spawn — re-read on **every** OOM respawn, so a worker that respawns mid-session inherits the current state.
- Gate both `console.warn` calls on that flag **inline**. The gate is inlined rather than a shared helper because the worker runs as **raw `.ts`** and must not value-import siblings — only `node:` builtins resolve at runtime (this is exactly why the worker already duplicates `isOomError`/`isCorruptModelError` locally rather than importing them).
- Nothing diagnostic is lost: the OOM telemetry is already reconstructed on the main thread, and a genuine model-load failure still posts `init-error`.

Only the `embedding` worker writes to stderr; the `vector` worker has no raw writes, so it's untouched.

## Verification

- **Reproduced the real worker locally** (`LORE_LOCAL_MODEL_PATH=…/.vendor-build/.model-cache`) so `embedding.test.ts`'s `LocalProvider integration` + `worker thread` suites actually spawn the worker — the path a CI-only run exercises. (A first attempt that imported a shared helper crashed every worker with `ERR_MODULE_NOT_FOUND`; that's now caught by running this suite locally.)
- 3× full suite green (4658 passed) with the model present. Typecheck clean (only the pre-existing `@loreai/sqlite-vec-vendored` local-resolution error CI resolves). Lint clean.
- **Mutation-verified**: hardcoding `stderrSilenced: false` at spawn → the "snapshots the host's stderr-silence flag into workerData on every spawn" propagation test fails (file restored byte-identically).

Follows #1036 → #1039 → #1040 → #1046 → #1050 → #1054 in the TUI-safety series.
