### PR TITLE
perf(core): offload entity-graph knowledge hydration in recall (#1048)

### DIFF
--- a/packages/core/src/entities.ts
+++ b/packages/core/src/entities.ts
@@ -1654,11 +1654,20 @@ const GRAPH_DEFAULTS = {
  */
 export function graphExpand(
   seedEntityIds: string[],
-  opts?: { maxSeeds?: number; maxNeighbors?: number; maxKnowledge?: number },
+  opts?: {
+    maxSeeds?: number;
+    maxNeighbors?: number;
+    maxKnowledge?: number;
+    includeKnowledge?: boolean;
+  },
 ): GraphExpansion {
   const maxSeeds = opts?.maxSeeds ?? GRAPH_DEFAULTS.maxSeeds;
   const maxNeighbors = opts?.maxNeighbors ?? GRAPH_DEFAULTS.maxNeighbors;
   const maxKnowledge = opts?.maxKnowledge ?? GRAPH_DEFAULTS.maxKnowledge;
+  // When the caller won't surface knowledge (recall with knowledge disabled),
+  // skip the knowledge fan-in entirely — no point issuing the
+  // `knowledge_entity_refs` query just to discard the result (F4, #1048).
+  const includeKnowledge = opts?.includeKnowledge ?? true;
 
   // Dedupe + cap seeds, preserving caller order (best matches first).
   const seeds: string[] = [];
@@ -1690,29 +1699,34 @@ export function graphExpand(
 
   // Knowledge fan-in: every logical_id referenced by any seed or neighbor.
   // Track the shallowest reaching depth and how many distinct entities reach it.
-  const refMap = knowledgeRefsForEntities([...entityDepth.keys()]);
-  const kAgg = new Map<string, { depth: number; reach: number }>();
-  for (const [entId, logicalIds] of refMap) {
-    const depth = entityDepth.get(entId) ?? 0;
-    for (const lid of logicalIds) {
-      const cur = kAgg.get(lid);
-      if (cur) {
-        cur.reach += 1;
-        if (depth < cur.depth) cur.depth = depth;
-      } else {
-        kAgg.set(lid, { depth, reach: 1 });
+  // Skipped wholesale when the caller doesn't surface knowledge (F4, #1048) so
+  // the `knowledge_entity_refs` query never runs for a discarded result.
+  let knowledge: GraphKnowledgeHit[] = [];
+  if (includeKnowledge) {
+    const refMap = knowledgeRefsForEntities([...entityDepth.keys()]);
+    const kAgg = new Map<string, { depth: number; reach: number }>();
+    for (const [entId, logicalIds] of refMap) {
+      const depth = entityDepth.get(entId) ?? 0;
+      for (const lid of logicalIds) {
+        const cur = kAgg.get(lid);
+        if (cur) {
+          cur.reach += 1;
+          if (depth < cur.depth) cur.depth = depth;
+        } else {
+          kAgg.set(lid, { depth, reach: 1 });
+        }
       }
     }
+    knowledge = [...kAgg.entries()]
+      .map(([logicalId, { depth, reach }]) => ({
+        logicalId,
+        depth,
+        reach,
+        score: (1 / (1 + depth)) * (1 + Math.log(reach)),
+      }))
+      .sort((a, b) => b.score - a.score || (a.logicalId < b.logicalId ? -1 : 1))
+      .slice(0, maxKnowledge);
   }
-  const knowledge: GraphKnowledgeHit[] = [...kAgg.entries()]
-    .map(([logicalId, { depth, reach }]) => ({
-      logicalId,
-      depth,
-      reach,
-      score: (1 / (1 + depth)) * (1 + Math.log(reach)),
-    }))
-    .sort((a, b) => b.score - a.score || (a.logicalId < b.logicalId ? -1 : 1))
-    .slice(0, maxKnowledge);
 
   // Neighbor-entity scoring: depth-decay × log of the neighbor's global
   // knowledge-ref count (a well-connected neighbor is more likely relevant).

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -2528,6 +2528,37 @@ export function getByLogical(logicalId: string): KnowledgeEntry | null {
 }
 
 /**
+ * Batch-hydrate current knowledge entries by stable `logical_id` (A2, #823),
+ * offloaded (#966/#1048). The `logical_id` analogue of {@link getManyOffloaded}:
+ * cross-reference consumers (entity refs, wiki-links, `.lore.md` markers) store
+ * `logical_id`, so recall's entity-graph fan-in hydrates through this rather than
+ * N synchronous `getByLogical()` calls on the hot path. `knowledge_current` holds
+ * exactly one row per `logical_id`, so the map keys are unique. `KNOWLEDGE_COLS`
+ * excludes the embedding BLOB, keeping rows structured-clone-safe across the
+ * worker boundary. `logical_id`s with no current/live row are absent from the map
+ * (callers drop them, matching `getByLogical()` returning null). A worker timeout
+ * degrades to an empty map (see {@link offloadAll}) — graph knowledge is a
+ * supplemental RRF list, so a degraded turn simply omits it rather than re-block
+ * the event loop with an in-process re-query.
+ */
+export async function getManyByLogicalOffloaded(
+  logicalIds: string[],
+): Promise<Map<string, KnowledgeEntry>> {
+  const map = new Map<string, KnowledgeEntry>();
+  if (!logicalIds.length) return map;
+  const placeholders = logicalIds.map(() => "?").join(",");
+  const rows = (await offloadAll(
+    `SELECT ${KNOWLEDGE_COLS} FROM knowledge_current WHERE logical_id IN (${placeholders})`,
+    logicalIds,
+  )) as Record<string, unknown>[];
+  for (const row of rows) {
+    const entry = hydrateKnowledgeEntry(row) as KnowledgeEntry;
+    map.set(entry.logical_id, entry);
+  }
+  return map;
+}
+
+/**
  * Resolve any knowledge id — a current version id, a SUPERSEDED version id, or a
  * logical_id — to its stable logical_id. Reads the BASE table (not the view) so
  * it still resolves a superseded version; falls back to the input id if unknown

--- a/packages/core/src/recall.ts
+++ b/packages/core/src/recall.ts
@@ -1183,19 +1183,31 @@ export async function searchRecall(
           maxSeeds: 8,
           maxNeighbors: 12,
           maxKnowledge: limit * 2,
+          // Skip the knowledge fan-in (and its refs query) when this recall
+          // won't surface knowledge anyway (F4, #1048).
+          includeKnowledge: knowledgeEnabled,
         });
         const graphWeight = searchConfig?.graphBoostWeight ?? 1.0;
         const gpid = ensureProject(projectPath);
 
         // (a) Graph-linked knowledge, ordered by graph score (depth-decay ×
-        // local reach). Hydrated via getByLogical (refs store logical_ids) and
-        // visibility-filtered to mirror ltm.searchScored — a knowledge entry
-        // linked to a shared entity may belong to another project. Same `k:`
-        // key as the BM25/vector knowledge lists so RRF merges, not duplicates.
-        if (knowledgeEnabled && expansion.knowledge.length) {
+        // local reach). Batch-hydrated by logical_id on the read-worker pool
+        // (#1048) — refs store logical_ids, and this replaces N synchronous
+        // getByLogical() calls on the hot path, mirroring the neighbor-entity
+        // offload below and the #966 read path. Visibility-filtered to mirror
+        // ltm.searchScored — a knowledge entry linked to a shared entity may
+        // belong to another project. Same `k:` key as the BM25/vector knowledge
+        // lists so RRF merges, not duplicates. The list is already empty when
+        // knowledge is disabled (gated via includeKnowledge at graphExpand).
+        if (expansion.knowledge.length) {
+          const knowledgeMap = await timer.await(
+            ltm.getManyByLogicalOffloaded(
+              expansion.knowledge.map((gk) => gk.logicalId),
+            ),
+          );
           const graphKnowledge: TaggedResult[] = [];
           for (const gk of expansion.knowledge) {
-            const entry = ltm.getByLogical(gk.logicalId);
+            const entry = knowledgeMap.get(gk.logicalId);
             if (!entry) continue;
             const visible =
               entry.project_id === gpid ||

--- a/packages/core/test/recall-graph.test.ts
+++ b/packages/core/test/recall-graph.test.ts
@@ -193,6 +193,35 @@ describe("entities.graphExpand — graph traversal scoring", () => {
     const exp = entities.graphExpand([root.id], { maxNeighbors: 2 });
     expect(exp.entities.length).toBe(2);
   });
+
+  test("includeKnowledge:false skips the knowledge fan-in (F4) but still returns neighbors", () => {
+    const seed = entities.create({
+      entityType: "person",
+      canonicalName: "Hub Person",
+      crossProject: true,
+    });
+    const neighbor = entities.create({
+      entityType: "person",
+      canonicalName: "Spoke Person",
+      crossProject: true,
+    });
+    entities.addRelation(seed.id, neighbor.id, "colleague", { source: "test" });
+    seedLinkedKnowledge({
+      projectPath: PROJECT,
+      entityId: seed.id,
+      title: "Linked fact",
+      content: "Reachable only through the entity graph.",
+    });
+
+    // Default (includeKnowledge true) surfaces the linked knowledge.
+    expect(entities.graphExpand([seed.id]).knowledge.length).toBeGreaterThan(0);
+
+    // includeKnowledge:false drops knowledge entirely (the refs query is never
+    // issued); neighbor-entity expansion is unaffected.
+    const exp = entities.graphExpand([seed.id], { includeKnowledge: false });
+    expect(exp.knowledge).toEqual([]);
+    expect(exp.entities.some((e) => e.id === neighbor.id)).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -383,5 +412,67 @@ describe("searchRecall — entity-graph fan-in", () => {
         (r) => r.item.source === "knowledge" && r.item.item.logical_id === k,
       ),
     ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests — ltm.getManyByLogicalOffloaded (batch graph-knowledge hydration)
+// ---------------------------------------------------------------------------
+
+describe("ltm.getManyByLogicalOffloaded — batch logical-id hydration", () => {
+  const PROJECT = "/test/recall-graph/offload";
+
+  beforeEach(() => {
+    cleanup();
+    ensureProject(PROJECT);
+  });
+
+  test("hydrates current entries keyed by logical_id, resolving through a superseded version", async () => {
+    const a = ltm.create({
+      projectPath: PROJECT,
+      scope: "project",
+      category: "decision",
+      title: "Alpha entry",
+      content: "alpha v1 body",
+    });
+    const b = ltm.create({
+      projectPath: PROJECT,
+      scope: "project",
+      category: "decision",
+      title: "Bravo entry",
+      content: "bravo original body",
+    });
+    // Supersede A: appendVersion mints a fresh id, so the CURRENT row's id no
+    // longer equals the logical_id — the case `get(id)` would miss but keying by
+    // logical_id must still resolve.
+    ltm.update(a, { content: "alpha v2 updated body" });
+
+    const map = await ltm.getManyByLogicalOffloaded([a, b]);
+    expect(map.size).toBe(2);
+    // Keyed by the stable logical_id (a/b ARE logical_ids), not the version id.
+    expect(map.get(a)?.logical_id).toBe(a);
+    expect(map.get(a)?.id).not.toBe(a); // current version superseded v1
+    expect(map.get(a)?.content).toContain("v2"); // returns CURRENT content
+    expect(map.get(b)?.content).toContain("bravo");
+  });
+
+  test("absent logical_ids are dropped; empty input yields an empty map", async () => {
+    const live = ltm.create({
+      projectPath: PROJECT,
+      scope: "project",
+      category: "decision",
+      title: "Live entry",
+      content: "present body",
+    });
+
+    const map = await ltm.getManyByLogicalOffloaded([
+      live,
+      "missing-logical-id",
+    ]);
+    expect(map.size).toBe(1);
+    expect(map.has(live)).toBe(true);
+    expect(map.has("missing-logical-id")).toBe(false);
+
+    expect((await ltm.getManyByLogicalOffloaded([])).size).toBe(0);
   });
 });


### PR DESCRIPTION
Closes #1048.

## What

The recall entity-graph fan-in (`searchRecall`) hydrated graph-linked knowledge with up to `limit*2` **synchronous** `ltm.getByLogical()` calls on the hot path — reversing the off-thread read pattern established in #966 (and already used by the sibling neighbor-entity path via `getManyWithAliasesOffloaded`).

This PR:

1. **Adds `ltm.getManyByLogicalOffloaded(logicalIds)`** — the `logical_id` analogue of `getManyOffloaded` (#966). Batch-hydrates `knowledge_current` with a single `WHERE logical_id IN (...)` scan on the read-worker pool. `KNOWLEDGE_COLS` excludes the embedding BLOB, so rows are structured-clone-safe across the worker boundary. A worker timeout degrades to an empty map (via `offloadAll`) — graph knowledge is a supplemental RRF list, so a degraded turn simply omits it rather than re-blocking the event loop with an in-process re-query.
2. **Rewires the recall graph-knowledge block** to use that batch path. Iteration order over `expansion.knowledge` (graph score) is preserved, so RRF list position is unchanged — behavioural parity.
3. **Folds in F4 from the #1047 review**: adds an `includeKnowledge` option to `entities.graphExpand` and passes `includeKnowledge: knowledgeEnabled` from recall, so the `knowledge_entity_refs` query is never issued when the recall won't surface knowledge.

## Why

Keeps the recall hot path off the main thread, consistent with #966/#1005. The graph-knowledge hydration was the last synchronous per-hit read in the fan-in.

## Tests

`packages/core/test/recall-graph.test.ts`:
- `ltm.getManyByLogicalOffloaded` — batch hydration keyed by `logical_id`, **resolving through a superseded version** (after an update, `current.id !== logical_id`); absent ids dropped; empty input → empty map.
- `graphExpand` `includeKnowledge:false` (F4) — knowledge fan-in skipped, neighbor entities still returned.

Both new guards were **red-green mutation-verified** (keying by `entry.id` fails the logical-id test; neutralizing the `includeKnowledge` guard fails the F4 test).

- Full `@loreai/core` suite: **2268 passed / 6 skipped**, green 3× consecutively on the graph file.
- Typecheck: `core`, `gateway`, `opencode`, `pi` all clean.