### PR TITLE
test(gateway): cover the off-thread read-worker vec path in --check-vec (#1033)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,11 +325,16 @@ jobs:
 
           # Verify the embedded sqlite-vec extension actually loads (native
           # vector search), not the JS brute-force fallback. Catches a broken
-          # asset-embed / extraction chain in the SEA binary.
+          # asset-embed / extraction chain in the SEA binary. Two assertions:
+          # the main DB connection AND the off-thread read-worker pool (the path
+          # production vector search runs on) must both load the extension —
+          # the worker thread extracts/loads it independently (#1033).
           vec=$(./packages/gateway/dist-bin/lore-linux-x64 --check-vec)
           echo "Vec info: $vec"
           echo "$vec" | grep -q '^ok vec_version=v' \
             || (echo "::error::native sqlite-vec not loaded in linux-x64 binary: $vec"; exit 1)
+          echo "$vec" | grep -q '^ok worker vec_available=true' \
+            || (echo "::error::native sqlite-vec not loaded on the read-worker path in linux-x64 binary: $vec"; exit 1)
 
           # Start gateway, hit health endpoint, shut down
           ./packages/gateway/dist-bin/lore-linux-x64 start -p 7991 &
@@ -722,6 +727,17 @@ jobs:
           else
             echo "::error::native sqlite-vec not loaded in ${{ matrix.target }} binary: $vec"; exit 1
           fi
+          # Same assertion for the off-thread read-worker pool — the path
+          # production vector search actually runs on. The worker thread
+          # extracts and loads the extension independently of the main thread
+          # (#1033), so a green main-thread line above does not prove it.
+          if echo "$vec" | grep -q '^ok worker vec_available=true'; then
+            echo "native sqlite-vec read-worker path OK (${{ matrix.target }})"
+          elif [ "${{ matrix.target }}" = "darwin-arm64" ]; then
+            echo "::warning::native sqlite-vec not loaded on the read-worker path in darwin-arm64 (dylib codesigning?) — JS fallback in use: $vec"
+          else
+            echo "::error::native sqlite-vec not loaded on the read-worker path in ${{ matrix.target }} binary: $vec"; exit 1
+          fi
 
   # ---------------------------------------------------------------------------
   # Nightly: build all platforms, generate patches, publish to GHCR
@@ -875,6 +891,11 @@ jobs:
           echo "$vec" | grep -q '^ok vec_version=v' \
             && echo "native sqlite-vec OK (darwin-arm64)" \
             || echo "::warning::native sqlite-vec not loaded in darwin-arm64 (dylib codesigning?) — JS fallback in use: $vec"
+          # Read-worker pool path (#1033). Non-fatal on macOS for the same
+          # dylib-codesigning reason — degrades to the JS fallback, never crashes.
+          echo "$vec" | grep -q '^ok worker vec_available=true' \
+            && echo "native sqlite-vec read-worker path OK (darwin-arm64)" \
+            || echo "::warning::native sqlite-vec not loaded on the read-worker path in darwin-arm64 (dylib codesigning?) — JS fallback in use: $vec"
 
       - name: Verify code signature
         run: |

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -76,6 +76,7 @@ export { isTextPart, isReasoningPart, isToolPart } from "./types";
 
 export { dataDir } from "./data-dir";
 export { isVecAvailable } from "./db/vec";
+export { checkVecWorker, type VecWorkerCheck } from "./vector-pool";
 export { load, config, type LoreConfig } from "./config";
 export {
   db,

--- a/packages/core/src/vector-pool.ts
+++ b/packages/core/src/vector-pool.ts
@@ -543,6 +543,108 @@ export async function tryPoolRead(
   return { rows: r.value };
 }
 
+/** Outcome of {@link checkVecWorker}: a one-shot probe of the off-thread
+ *  read-pool path that production vector search actually runs on. */
+export interface VecWorkerCheck {
+  /** - `"ready"`       → the worker opened its reader connection; then
+   *                      `vecAvailable` reports whether native sqlite-vec
+   *                      loaded ON THE WORKER THREAD.
+   *  - `"init-error"`  → the worker failed to open its reader connection.
+   *  - `"timeout"`     → no `ready`/`init-error` arrived within the deadline.
+   *  - `"spawn-error"` → the worker couldn't be spawned, errored, or exited
+   *                      before reporting readiness. */
+  status: "ready" | "init-error" | "timeout" | "spawn-error";
+  /** Native sqlite-vec availability on the worker's own connection. Only
+   *  meaningful when `status === "ready"`; `false` for every failure status. */
+  vecAvailable: boolean;
+  /** Diagnostic detail for the non-`ready` statuses. */
+  error?: string;
+}
+
+/**
+ * One-shot diagnostic: spawn a SINGLE read-pool worker exactly the way
+ * production does (via {@link spawnWorker} — same SEA
+ * `__LORE_VECTOR_WORKER_SOURCE__` / npm sibling-file resolution), wait for its
+ * `ready` (or `init-error`) message, and report whether native sqlite-vec
+ * loaded ON THE WORKER THREAD.
+ *
+ * This is the off-thread analogue of the main-thread `isVecAvailable()` check.
+ * `--check-vec` alone only proves the main DB connection's extract+load works;
+ * it never spawns the pool, so it can't prove the worker-thread path that recall
+ * actually uses. Each worker opens its own reader connection and runs
+ * `loadVecForConnection`, which inside the SEA resolves the embedded extension
+ * via the worker thread's OWN `__LORE_VEC_EXTENSION_PATH__` handshake (set by
+ * native-loader.cjs under the `isMainThread`/exists-skip guard). A `ready` reply
+ * with `vecAvailable === true` proves that whole worker-thread chain (#1033).
+ *
+ * Independent of the live pool: it spawns a throwaway worker and never touches
+ * the shared `workers[]`, the `poolBroken` latch, or the structural-failure
+ * counter. Honors the test worker-factory seam. Never throws — failures surface
+ * as a non-`ready` status. The probe worker is always terminated before
+ * resolving.
+ */
+export async function checkVecWorker(
+  timeoutMs = DEFAULT_VECTOR_SEARCH_TIMEOUT_MS,
+): Promise<VecWorkerCheck> {
+  let worker: Worker;
+  try {
+    worker = spawnWorker({ dbPath: dbPath() });
+  } catch (err) {
+    return {
+      status: "spawn-error",
+      vecAvailable: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  return await new Promise<VecWorkerCheck>((resolve) => {
+    let settled = false;
+    const finish = (result: VecWorkerCheck): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      try {
+        // Tear down the throwaway probe worker. The terminate()-induced `exit`
+        // re-enters `finish`, but the `settled` guard makes it a no-op.
+        void worker.terminate();
+      } catch {
+        // best-effort
+      }
+      resolve(result);
+    };
+
+    const timer = setTimeout(
+      () => finish({ status: "timeout", vecAvailable: false }),
+      timeoutMs,
+    );
+
+    worker.on("message", (msg: VectorWorkerOutbound) => {
+      if (msg.type === "ready") {
+        finish({ status: "ready", vecAvailable: msg.vecAvailable });
+      } else if (msg.type === "init-error") {
+        finish({ status: "init-error", vecAvailable: false, error: msg.error });
+      }
+      // result/read-result/error can't occur — the probe never posts a request.
+    });
+    worker.on("error", (err: Error) => {
+      finish({
+        status: "spawn-error",
+        vecAvailable: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+    worker.on("exit", () => {
+      // An exit before `ready`/`init-error` is a structural probe failure. After
+      // `finish` the terminate()-induced exit is a no-op (settled guard above).
+      finish({
+        status: "spawn-error",
+        vecAvailable: false,
+        error: "worker exited before reporting readiness",
+      });
+    });
+  });
+}
+
 /** Tear down the pool (test teardown + process reset). Idempotent. The
  *  shuttingDown guard keeps the terminate()-induced worker exits below from
  *  being counted as structural failures. */

--- a/packages/core/test/vector-pool.test.ts
+++ b/packages/core/test/vector-pool.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   _resetVectorPoolForTest,
   _setTestVectorWorkerFactory,
+  checkVecWorker,
   READ_JOB_TIMED_OUT,
   shutdownVectorPool,
   tryPoolRead,
@@ -42,6 +43,9 @@ class FakeWorker extends EventEmitter {
     this.terminated = true;
     this.emit("exit", 0);
     return Promise.resolve(0);
+  }
+  ready(vecAvailable: boolean): void {
+    this.emit("message", { type: "ready", vecAvailable });
   }
   reply(id: number, hits: unknown[]): void {
     this.emit("message", { type: "result", id, hits });
@@ -594,5 +598,97 @@ describe("embedding.vectorSearch routes through the pool", () => {
     } finally {
       spy.mockRestore();
     }
+  });
+});
+
+describe("checkVecWorker (off-thread read-pool vec probe, #1033)", () => {
+  // The real worker posts `ready` at construction; checkVecWorker attaches its
+  // listeners synchronously after spawn, so the fake must emit on a macrotask
+  // (after the listeners exist) — emitting synchronously in the constructor
+  // would be missed, exactly unlike a real worker_threads MessagePort which
+  // buffers until a listener is attached.
+  function factoryEmitting(
+    action: (w: FakeWorker) => void,
+  ): (d: VectorWorkerInitData) => never {
+    return (() => {
+      const w = new FakeWorker(() => {});
+      setTimeout(() => action(w), 0);
+      return w;
+    }) as unknown as (d: VectorWorkerInitData) => never;
+  }
+
+  it("reports ready + vecAvailable=true when the worker loads native vec", async () => {
+    _setTestVectorWorkerFactory(factoryEmitting((w) => w.ready(true)));
+    const r = await checkVecWorker();
+    expect(r).toEqual({ status: "ready", vecAvailable: true });
+    // The probe worker is always torn down before resolving.
+    expect(FakeWorker.instances[0]?.terminated).toBe(true);
+  });
+
+  it("reports ready + vecAvailable=false when the worker falls back to JS", async () => {
+    _setTestVectorWorkerFactory(factoryEmitting((w) => w.ready(false)));
+    const r = await checkVecWorker();
+    expect(r).toEqual({ status: "ready", vecAvailable: false });
+  });
+
+  it("reports init-error when the worker's reader connection fails to open", async () => {
+    _setTestVectorWorkerFactory(
+      factoryEmitting((w) => w.initError("open boom")),
+    );
+    const r = await checkVecWorker();
+    expect(r).toEqual({
+      status: "init-error",
+      vecAvailable: false,
+      error: "open boom",
+    });
+  });
+
+  it("reports spawn-error when the worker emits 'error'", async () => {
+    _setTestVectorWorkerFactory(
+      factoryEmitting((w) => w.crash(new Error("crash boom"))),
+    );
+    const r = await checkVecWorker();
+    expect(r).toEqual({
+      status: "spawn-error",
+      vecAvailable: false,
+      error: "crash boom",
+    });
+  });
+
+  it("reports spawn-error when the worker exits before reporting readiness", async () => {
+    _setTestVectorWorkerFactory(factoryEmitting((w) => w.die(1)));
+    const r = await checkVecWorker();
+    expect(r.status).toBe("spawn-error");
+    expect(r.vecAvailable).toBe(false);
+    expect(r.error).toContain("exited before reporting readiness");
+  });
+
+  it("reports spawn-error when spawning throws synchronously", async () => {
+    _setTestVectorWorkerFactory((() => {
+      throw new Error("no worker");
+    }) as unknown as (d: VectorWorkerInitData) => never);
+    const r = await checkVecWorker();
+    expect(r).toEqual({
+      status: "spawn-error",
+      vecAvailable: false,
+      error: "no worker",
+    });
+  });
+
+  it("reports timeout when the worker never reports readiness", async () => {
+    // Worker that never emits ready/init-error/exit (stays silent).
+    _setTestVectorWorkerFactory(factoryEmitting(() => {}));
+    const r = await checkVecWorker(20);
+    expect(r).toEqual({ status: "timeout", vecAvailable: false });
+    // The wedged probe worker is terminated so it can't leak a thread.
+    expect(FakeWorker.instances[0]?.terminated).toBe(true);
+  });
+
+  it("spawns exactly one probe worker via the factory seam", async () => {
+    // Guards against accidental real-worker spawns in unit tests: with a factory
+    // installed, exactly one fake is created per probe.
+    _setTestVectorWorkerFactory(factoryEmitting((w) => w.ready(true)));
+    await checkVecWorker();
+    expect(FakeWorker.instances.length).toBe(1);
   });
 });

--- a/packages/gateway/src/cli/main.ts
+++ b/packages/gateway/src/cli/main.ts
@@ -260,13 +260,22 @@ export async function _cli(): Promise<void> {
     return;
   }
 
-  // --check-vec (hidden). Confirms the native sqlite-vec extension loaded on
-  // the main DB connection — inside the SEA it's extracted from the embedded
-  // per-target asset by native-loader.cjs. Prints `ok vec_version=<v>` when
-  // native search is active, or `fallback (...)` when the JS brute-force path
-  // is in use. Used by CI to verify the embed-asset → load chain.
+  // --check-vec (hidden). Confirms the native sqlite-vec extension loads on
+  // BOTH connection paths — inside the SEA each is extracted from the embedded
+  // per-target asset by native-loader.cjs.
+  //
+  //   1. Main DB connection: prints `ok vec_version=<v>` when native search is
+  //      active, or `fallback (...)` when the JS brute-force path is in use.
+  //   2. Off-thread read-worker pool (the path production vector search runs
+  //      on): spawns one probe worker that opens its OWN reader connection in
+  //      its OWN worker_threads thread and loads the extension there. Prints
+  //      `ok worker vec_available=true` / `worker fallback (...)`. A green
+  //      main-thread line does NOT prove this worker-thread chain — #1033.
+  //
+  // The exit code stays tied only to an unexpected throw (matching the
+  // main-thread `fallback` being exit 0); CI greps these lines per platform.
   if (values["check-vec"]) {
-    const { db, isVecAvailable } = await import("@loreai/core");
+    const { db, isVecAvailable, checkVecWorker } = await import("@loreai/core");
     const { safeExit } = await import("./exit");
     let ok = false;
     try {
@@ -280,6 +289,24 @@ export async function _cli(): Promise<void> {
           | { v?: string }
           | undefined;
         console.log(`ok vec_version=${row?.v ?? "unknown"}`);
+      }
+
+      // Independently verify the off-thread read-pool path (#1033). `db()` above
+      // has created/migrated the file, so the worker's reader open will find it.
+      const w = await checkVecWorker();
+      if (w.status === "ready" && w.vecAvailable) {
+        console.log("ok worker vec_available=true");
+      } else if (w.status === "ready") {
+        console.log(
+          "worker fallback (native sqlite-vec not loaded in worker — using JS brute-force)",
+        );
+      } else {
+        // Structural probe failure (spawn/init/timeout). Surface it on stdout so
+        // the captured `--check-vec` output shows why the worker assertion fails,
+        // without changing the exit code — CI's grep is the per-platform gate.
+        console.log(
+          `worker check failed: ${w.status}${w.error ? ` (${w.error})` : ""}`,
+        );
       }
       ok = true;
     } catch (err: unknown) {

--- a/packages/gateway/test/cli-check-vec.test.ts
+++ b/packages/gateway/test/cli-check-vec.test.ts
@@ -19,6 +19,14 @@ const { state, safeExit } = vi.hoisted(() => ({
     // `undefined` simulates `SELECT vec_version()` returning a row with no `v`.
     vecVersion: "v0.1.9" as string | undefined,
     dbThrows: false,
+    // Drives the off-thread read-pool probe (checkVecWorker). Defaults to a
+    // healthy native worker so the main-thread assertions in existing tests
+    // keep exiting 0.
+    worker: {
+      status: "ready" as "ready" | "init-error" | "timeout" | "spawn-error",
+      vecAvailable: true,
+      error: undefined as string | undefined,
+    },
   },
   safeExit: vi.fn(),
 }));
@@ -39,6 +47,11 @@ vi.mock("@loreai/core", async (importOriginal) => {
         }),
       };
     },
+    checkVecWorker: async () => ({
+      status: state.worker.status,
+      vecAvailable: state.worker.vecAvailable,
+      error: state.worker.error,
+    }),
   };
 });
 
@@ -59,6 +72,7 @@ describe("--check-vec CLI diagnostic", () => {
     state.vecAvailable = true;
     state.vecVersion = "v0.1.9";
     state.dbThrows = false;
+    state.worker = { status: "ready", vecAvailable: true, error: undefined };
     safeExit.mockClear();
     process.argv = ["node", "lore", "--check-vec"];
     logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
@@ -87,6 +101,47 @@ describe("--check-vec CLI diagnostic", () => {
     expect(logSpy).toHaveBeenCalledWith("ok vec_version=v0.1.9");
     expect(safeExit).toHaveBeenCalledWith(0);
     expect(errSpy).not.toHaveBeenCalled();
+  });
+
+  test("worker native available: prints the off-thread worker line", async () => {
+    state.worker = { status: "ready", vecAvailable: true, error: undefined };
+
+    await _cli();
+
+    expect(logSpy).toHaveBeenCalledWith("ok vec_version=v0.1.9");
+    expect(logSpy).toHaveBeenCalledWith("ok worker vec_available=true");
+    expect(safeExit).toHaveBeenCalledWith(0);
+    expect(errSpy).not.toHaveBeenCalled();
+  });
+
+  test("worker fallback: prints worker fallback, still exits 0", async () => {
+    state.worker = { status: "ready", vecAvailable: false, error: undefined };
+
+    await _cli();
+
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining("worker fallback (native sqlite-vec not loaded"),
+    );
+    // A worker fallback is platform-expected (e.g. darwin dylib codesigning) —
+    // exit 0, exactly like the main-thread fallback. CI's grep is the gate.
+    expect(safeExit).toHaveBeenCalledWith(0);
+  });
+
+  test("worker structural failure: prints reason on stdout, still exits 0", async () => {
+    state.worker = {
+      status: "init-error",
+      vecAvailable: false,
+      error: "open boom",
+    };
+
+    await _cli();
+
+    expect(logSpy).toHaveBeenCalledWith(
+      "worker check failed: init-error (open boom)",
+    );
+    // Exit code is unchanged (only an unexpected throw flips it); CI's
+    // `grep ^ok worker` is what fails the smoke on a real regression.
+    expect(safeExit).toHaveBeenCalledWith(0);
   });
 
   test("native available but version row empty: prints 'unknown'", async () => {


### PR DESCRIPTION
Closes #1033.

## Gap

`--check-vec` (and the CI native-vec smoke that greps its output) only exercised the **main DB connection**: it calls `db()` → `loadVecExtension` on the main thread and never spawns the read-worker pool.

Production vector search runs on the off-thread pool (`vector-pool.ts` → `reader.ts` `loadVecForConnection`), where each worker loads the extension in its own `worker_threads` thread and — inside the SEA — extracts the embedded asset via its own `__LORE_VEC_EXTENSION_PATH__` handshake (set by `native-loader.cjs` under the `isMainThread`/exists-skip guard).

So a green `ok vec_version=v…` proved the main-thread extract+load works, but did **not** independently prove the worker-thread path production actually uses.

## Change

- **`checkVecWorker()`** in `@loreai/core` (`vector-pool.ts`): a one-shot diagnostic that spawns a single throwaway read-pool worker exactly the way production does (reusing `spawnWorker` → same SEA `__LORE_VECTOR_WORKER_SOURCE__` / npm sibling-file resolution), waits for its `ready`/`init-error` message, and reports whether native sqlite-vec loaded **on the worker thread**. It is independent of the live pool (never touches `workers[]`, the `poolBroken` latch, or the structural-failure counter), honors the test worker-factory seam, never throws, and always terminates the probe worker.
- **`--check-vec` handler** (`gateway/src/cli/main.ts`): after the main-thread line, it now also prints `ok worker vec_available=true` / `worker fallback (...)`. The exit code stays tied only to an unexpected throw (mirroring the main-thread `fallback` being exit 0) — CI's grep is the per-platform gate.
- **CI** (`ci.yml`): the three `--check-vec` smoke blocks now also assert `^ok worker vec_available=true` — fatal on linux-x64, non-fatal warning on darwin-arm64 (unsigned extracted `.dylib` may be blocked by library validation, degrading to the JS fallback).

Closing this gap also de-risks the off-thread read path under scrutiny in #999 (pathological vector-read latency), which exercises this same worker pool.

## Output

```
ok vec_version=v0.1.9
ok worker vec_available=true
```

## Tests

- **core** (`vector-pool.test.ts`): `checkVecWorker` covered for `ready`+native, `ready`+fallback, `init-error`, `spawn-error` (crash / early-exit / synchronous spawn throw), and `timeout`, all via the worker-factory seam (no real worker spawned).
- **gateway** (`cli-check-vec.test.ts`): new cases for the worker native / worker fallback / worker structural-failure output paths.
- Red-green verified both new test files via mutation (worker `vecAvailable` hardcoded → core test fails; worker output line changed → gateway test fails).
- `pnpm typecheck`, Biome check on touched files, `actionlint` on `ci.yml`, and the full core (2216) + gateway (2301) suites all green.
