### PR TITLE
feat(core): embed part-selective text for temporal messages

### DIFF
--- a/packages/core/src/embedding-cap.ts
+++ b/packages/core/src/embedding-cap.ts
@@ -29,8 +29,11 @@ export const EMBED_BACKOFF_FACTOR = 0.7;
  *  attention) may use when sizing the initial cap. Deliberately conservative:
  *  on a constrained host a higher value risks tipping into swap (the exact
  *  event-loop stall we're avoiding), and because embedding quality plateaus
- *  above ~2048 tokens (single-vector embeddings of long text are diluted, and
- *  recall chunks long content), a low cap costs almost nothing in quality. A
+ *  above ~2048 tokens (a single vector over long text is a diluted mean-pool
+ *  centroid regardless of cap; temporal-message embeddings additionally drop
+ *  bulky tool-output bodies before embedding via buildEmbeddingUnits, and the
+ *  full text stays keyword-searchable in FTS), a low cap costs almost nothing
+ *  in quality. A
  *  box that genuinely has headroom recovers via the freemem-gated re-probe; an
  *  optimistic start is corrected by the ×0.7 backoff. */
 export const EMBED_MEM_FRACTION = 0.5;

--- a/packages/core/src/embedding-units.ts
+++ b/packages/core/src/embedding-units.ts
@@ -1,0 +1,121 @@
+// Part-aware splitter for temporal-message embedding text.
+//
+// A `temporal_messages.content` value is the concatenation of a message's parts
+// joined by `"\n" + CHUNK_TERMINATOR` (see `partsToText` in temporal.ts). Each
+// part renders as one of:
+//   plain text          → "<text>"
+//   reasoning part      → "[reasoning] <text>"
+//   completed tool call → "[tool:<name>] <output>"
+//
+// `buildEmbeddingUnits` recovers those parts from the stored content string —
+// the part boundaries are already there, so no access to the original parts
+// array is needed — and classifies each. Text and reasoning are high-value
+// signal and pass through verbatim. Tool envelopes are LOW semantic value and,
+// when large, dominate the message: a single read/diff/log can be tens of KB,
+// which both blows past the embedding token cap (tail-truncated away) and
+// dilutes the mean-pooled vector so it matches no sub-topic well. So a tool unit
+// keeps only its `[tool:<name>]` header + the FIRST LINE of output (a path, an
+// error, a summary) and drops the body. The full content stays in
+// `temporal_messages.content` + FTS, so tool output remains keyword-recallable.
+//
+// This is the shared "splitter" between Phase 1 (single part-selective vector —
+// `buildEmbeddingText` joins the units and embeds once) and a future Phase 2
+// (multi-vector chunking — embed each unit into the chunk-keyed `temporal_vec`).
+//
+// MUST stay a dependency-free leaf: it does NOT import temporal.ts (which would
+// create an embedding → embedding-units → temporal → embedding import cycle, as
+// temporal.ts imports embedding.ts). The chunk separator is re-declared locally
+// and pinned against `partsToText` by a producer/consumer round-trip test.
+
+/** ASCII Unit Separator — mirrors `CHUNK_TERMINATOR` in temporal.ts. Re-declared
+ *  here (rather than imported) to keep this module cycle-free; the round-trip
+ *  test in `embedding-units.test.ts` fails if the two ever drift apart. */
+const CHUNK_TERMINATOR = "\x1f";
+
+/** The boundary `partsToText` inserts between parts: a newline then the
+ *  terminator. Splitting content on this recovers the original parts. */
+const CHUNK_SEPARATOR = `\n${CHUNK_TERMINATOR}`;
+
+/** Prefix `partsToText` uses for reasoning parts. */
+const REASONING_PREFIX = "[reasoning] ";
+
+/**
+ * Max characters of a tool output's first line kept in the embedding text.
+ * "First line" is normally short (a file path, an error message, a one-line
+ * summary), but a single-line megabyte dump (minified JSON, a one-line log)
+ * would otherwise re-introduce exactly the head-eviction/dilution we are
+ * removing — so the first line is itself bounded. Generous enough to retain a
+ * meaningful path or error.
+ */
+export const TOOL_FIRST_LINE_MAX = 200;
+
+export type EmbedUnitKind = "text" | "reasoning" | "tool";
+
+export interface EmbedUnit {
+  kind: EmbedUnitKind;
+  /** The text to embed for this unit — already reduced for tool units. */
+  text: string;
+  /** Tool name; present only when `kind === "tool"`. */
+  tool?: string;
+}
+
+/**
+ * Reduce a single `[tool:<name>] <output>` envelope to its header + the first
+ * (bounded) line of output. Returns `null` when `chunk` is not a well-formed
+ * tool envelope, so the caller can treat it as plain text. Parsing mirrors
+ * `truncateSingleChunk` in distillation.ts (`"[tool:".length === 6`; the
+ * `"] "` delimiter separates name from payload) for consistency.
+ */
+function reduceToolChunk(chunk: string): EmbedUnit | null {
+  if (!chunk.startsWith("[tool:")) return null;
+  const closeBracket = chunk.indexOf("] ");
+  if (closeBracket < 0) return null; // malformed envelope → leave to caller
+  const tool = chunk.slice(6, closeBracket);
+  const payload = chunk.slice(closeBracket + 2);
+  const nl = payload.indexOf("\n");
+  let firstLine = (nl >= 0 ? payload.slice(0, nl) : payload).trimEnd();
+  if (firstLine.length > TOOL_FIRST_LINE_MAX) {
+    firstLine = firstLine.slice(0, TOOL_FIRST_LINE_MAX);
+  }
+  const text = firstLine ? `[tool:${tool}] ${firstLine}` : `[tool:${tool}]`;
+  return { kind: "tool", tool, text };
+}
+
+/**
+ * Split stored temporal-message `content` into part-aware embedding units.
+ *
+ * Splits ONLY on the structural `"\n" + CHUNK_TERMINATOR` boundary, never on a
+ * bare `[tool:` — so a `[tool:...]`-looking line *inside* a tool output (e.g.
+ * the agent reading a file that documents this very format) stays part of its
+ * owning envelope and is dropped with the rest of the body, never promoted to
+ * its own unit.
+ */
+export function buildEmbeddingUnits(content: string): EmbedUnit[] {
+  const units: EmbedUnit[] = [];
+  for (const chunk of content.split(CHUNK_SEPARATOR)) {
+    const tool = reduceToolChunk(chunk);
+    if (tool) {
+      units.push(tool);
+      continue;
+    }
+    if (chunk.startsWith(REASONING_PREFIX)) {
+      units.push({ kind: "reasoning", text: chunk });
+      continue;
+    }
+    units.push({ kind: "text", text: chunk });
+  }
+  return units;
+}
+
+/**
+ * Phase 1 collapse: join the part-selective units back into one string to embed
+ * as a single vector. Tool bodies are already dropped by {@link buildEmbeddingUnits},
+ * so prose and reasoning can no longer be evicted from the head by a large tool
+ * dump. (Phase 2 will instead embed each unit separately into `temporal_vec`.)
+ */
+export function buildEmbeddingText(content: string): string {
+  return buildEmbeddingUnits(content)
+    .map((u) => u.text)
+    .join("\n")
+    .trim();
+}

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -33,6 +33,7 @@ import {
 } from "./db/vec-store";
 import { config } from "./config";
 import * as log from "./log";
+import { buildEmbeddingText } from "./embedding-units";
 import { vendorModelInfo } from "./embedding-vendor";
 import {
   MIN_EMBED_TOKENS,
@@ -1487,7 +1488,14 @@ export function embedTemporalMessage(id: string, content: string): void {
   // to be useful in vector search and would waste embedding capacity.
   if (content.length < 50) return;
 
-  embed([content], "document")
+  // Embed a part-selective reduction of the content rather than the raw text:
+  // large `[tool:…]` outputs are dropped (header + first line kept) so they can
+  // no longer evict prose/reasoning from the head or dilute the mean-pooled
+  // vector. The full content stays in `content` + FTS for keyword recall.
+  const text = buildEmbeddingText(content);
+  if (!text) return;
+
+  embed([text], "document")
     .then(([vec]) => {
       storeEmbedding(db(), "temporal", id, vec);
     })

--- a/packages/core/test/embedding-units.test.ts
+++ b/packages/core/test/embedding-units.test.ts
@@ -1,0 +1,200 @@
+import { describe, test, expect } from "vitest";
+import {
+  buildEmbeddingUnits,
+  buildEmbeddingText,
+  TOOL_FIRST_LINE_MAX,
+} from "../src/embedding-units";
+import { partsToText } from "../src/temporal";
+import type { LorePart } from "../src/types";
+import {
+  embedTemporalMessage,
+  _saveAndClearProvider,
+  _restoreProvider,
+} from "../src/embedding";
+
+// Part fixtures — mirror the producers in temporal.partsToText (and the helpers
+// in distillation.test.ts) so content strings are byte-identical to production.
+function textPart(text: string): LorePart {
+  return { type: "text", text } as LorePart;
+}
+function reasoningPart(text: string): LorePart {
+  return { type: "reasoning", text } as LorePart;
+}
+function toolPart(tool: string, output: string): LorePart {
+  return {
+    type: "tool",
+    tool,
+    state: { status: "completed", output },
+  } as unknown as LorePart;
+}
+
+describe("buildEmbeddingUnits", () => {
+  test("keeps a plain-text part verbatim", () => {
+    expect(buildEmbeddingUnits("hello world")).toEqual([
+      { kind: "text", text: "hello world" },
+    ]);
+  });
+
+  test("keeps a reasoning part verbatim (with its prefix)", () => {
+    expect(buildEmbeddingUnits("[reasoning] thinking it through")).toEqual([
+      { kind: "reasoning", text: "[reasoning] thinking it through" },
+    ]);
+  });
+
+  test("reduces a tool envelope to header + first line, dropping the body", () => {
+    const content = partsToText([
+      textPart("Investigating the crash."),
+      toolPart("read", `src/server.ts\n${"BODY ".repeat(2000)}`),
+    ]);
+    const units = buildEmbeddingUnits(content);
+    expect(units).toHaveLength(2);
+    expect(units[0]).toEqual({
+      kind: "text",
+      text: "Investigating the crash.",
+    });
+    expect(units[1]).toEqual({
+      kind: "tool",
+      tool: "read",
+      text: "[tool:read] src/server.ts",
+    });
+  });
+
+  test("handles an empty tool output (header only, no trailing space)", () => {
+    // partsToText renders this as "[tool:bash] " (trailing space, empty body).
+    const units = buildEmbeddingUnits(partsToText([toolPart("bash", "")]));
+    expect(units).toEqual([
+      { kind: "tool", tool: "bash", text: "[tool:bash]" },
+    ]);
+  });
+
+  test("does NOT promote a [tool:...] line embedded inside another tool's output", () => {
+    // A read of a file that documents this very format: the embedded
+    // "[tool:bash]" line lives inside the read envelope and must be dropped
+    // with the body, never split into its own unit.
+    const adversarial = [
+      "reading AGENTS.md",
+      "[tool:bash] this is INSIDE the payload, not a real envelope",
+      "still inside the read output",
+    ].join("\n");
+    const content = partsToText([
+      textPart("Searching for the format spec."),
+      toolPart("read", adversarial),
+      textPart("Found it."),
+    ]);
+    const units = buildEmbeddingUnits(content);
+    expect(units).toHaveLength(3);
+    expect(units[1]).toEqual({
+      kind: "tool",
+      tool: "read",
+      text: "[tool:read] reading AGENTS.md",
+    });
+    // The embedded bash line never becomes a unit of its own.
+    expect(units.some((u) => u.tool === "bash")).toBe(false);
+  });
+
+  test("caps an oversized single-line tool output at TOOL_FIRST_LINE_MAX", () => {
+    const giant = "A".repeat(TOOL_FIRST_LINE_MAX + 500); // one line, no newline
+    const units = buildEmbeddingUnits(partsToText([toolPart("bash", giant)]));
+    expect(units).toHaveLength(1);
+    const [u] = units;
+    expect(u.text.startsWith("[tool:bash] AAAA")).toBe(true);
+    expect(u.text.length).toBe("[tool:bash] ".length + TOOL_FIRST_LINE_MAX);
+  });
+
+  test("leaves a malformed tool envelope (no '] ' delimiter) as text", () => {
+    expect(buildEmbeddingUnits("[tool:weird")).toEqual([
+      { kind: "text", text: "[tool:weird" },
+    ]);
+  });
+});
+
+describe("buildEmbeddingText", () => {
+  test("preserves prose and reasoning but drops bulky tool bodies", () => {
+    const body = "SECRET_BODY ".repeat(3000); // ~36 KB that must not be embedded
+    const content = partsToText([
+      textPart("Prose stays."),
+      reasoningPart("Reasoning stays."),
+      toolPart("read", `path/to/file.ts\n${body}`),
+    ]);
+    const text = buildEmbeddingText(content);
+    expect(text).toContain("Prose stays.");
+    expect(text).toContain("[reasoning] Reasoning stays.");
+    expect(text).toContain("[tool:read] path/to/file.ts");
+    // The dominant body is gone — both as a substring and by total size.
+    expect(text).not.toContain("SECRET_BODY");
+    expect(text.length).toBeLessThan(200);
+  });
+
+  test("returns empty string for empty content", () => {
+    expect(buildEmbeddingText("")).toBe("");
+  });
+});
+
+describe("partsToText → buildEmbeddingUnits round trip", () => {
+  // Pins the local CHUNK separator against temporal.partsToText: if the
+  // producer's terminator ever changes, this split returns one fused unit and
+  // the kind sequence below no longer matches.
+  test("recovers one unit per part with the correct kinds and reductions", () => {
+    const content = partsToText([
+      textPart("alpha"),
+      reasoningPart("beta"),
+      toolPart("grep", "gamma\nmore output lines"),
+      textPart("delta"),
+    ]);
+    const units = buildEmbeddingUnits(content);
+    expect(units.map((u) => u.kind)).toEqual([
+      "text",
+      "reasoning",
+      "tool",
+      "text",
+    ]);
+    expect(units.map((u) => u.text)).toEqual([
+      "alpha",
+      "[reasoning] beta",
+      "[tool:grep] gamma",
+      "delta",
+    ]);
+  });
+});
+
+describe("embedTemporalMessage wiring", () => {
+  test("embeds the reduced text, not the raw content", async () => {
+    const body = "X".repeat(5000);
+    const content = partsToText([
+      textPart("Debugging the failing test."),
+      toolPart("read", `src/foo.ts\n${body}`),
+    ]);
+
+    let captured: string[] | null = null;
+    let resolveCaptured!: () => void;
+    const captureDone = new Promise<void>((r) => (resolveCaptured = r));
+
+    const token = _saveAndClearProvider();
+    try {
+      _restoreProvider({
+        provider: {
+          maxBatchSize: 8,
+          async embed(texts: string[]) {
+            captured = texts;
+            resolveCaptured();
+            return texts.map(() => new Float32Array([1, 0, 0]));
+          },
+        },
+      });
+      embedTemporalMessage("wiring-msg-1", content);
+      await captureDone;
+
+      expect(captured).not.toBeNull();
+      const sent = captured?.[0];
+      // Exactly the part-selective reduction — embed() passes text through
+      // untouched, so this is byte-identical to buildEmbeddingText(content).
+      expect(sent).toBe(buildEmbeddingText(content));
+      expect(sent).toContain("Debugging the failing test.");
+      expect(sent).toContain("[tool:read] src/foo.ts");
+      // The 5 KB tool body never reaches the embedder (it stays in FTS only).
+      expect(sent).not.toContain("XX");
+    } finally {
+      _restoreProvider(token);
+    }
+  });
+});


### PR DESCRIPTION
## What

Temporal-message vectors were computed from the full `partsToText` content, which inlines **uncapped** `[tool:…]` outputs. A single `read`/`diff`/log (tens of KB) both:

1. **blew past the embedding token cap** → silently tail-truncated, and
2. **dominated the mean-pooled vector** → diluted so it matched no sub-topic well.

This is the highest-frequency truncation/dilution case in the corpus (knowledge ≤1200 chars and entities are already well under the cap and unaffected).

`embedTemporalMessage` now embeds a **part-selective reduction** built by a new `buildEmbeddingUnits` splitter:

- recovers the message's parts from the stored content (split on the `\n\x1f` part boundary — no need for the original parts array),
- keeps **text** and **reasoning** verbatim,
- reduces each **tool envelope** to its `[tool:<name>]` header + the **first line** of output (bounded by `TOOL_FIRST_LINE_MAX = 200`), dropping the bulky body.

The full content is **untouched** in `temporal_messages.content` + FTS, so tool output stays keyword-recallable; only the semantic vector changes.

## Why this shape

The splitter is the shared seam for a planned multi-vector phase (embed each unit into the **chunk-keyed `temporal_vec`** that already shipped in #1051), so nothing here is throwaway: Phase 1 joins the units → one vector; Phase 2 would `units.map(embed)` → N chunks. Splitting only on the structural `\x1f` boundary (never on a bare `[tool:`) means a `[tool:…]`-looking line *inside* a tool output is dropped with the body, never promoted to its own unit (mirrors `truncateSingleChunk` in distillation.ts).

Also corrects the stale `embedding-cap.ts` comment that claimed *"recall chunks long content"* — it does not, for stored documents.

## Tests

`packages/core/test/embedding-units.test.ts` (11 cases): unit classification, tool-body reduction, first-line cap, empty/malformed envelopes, the adversarial embedded-`[tool:]` case, a `partsToText → buildEmbeddingUnits` round-trip that pins the separator against drift, and a wiring test (via the provider seam) asserting `embedTemporalMessage` embeds the reduced text — not the raw content.

**Mutation-verified (red-green):** reverting the wiring (embed raw `content`) and reverting the body reduction each make the suite fail.

## Verification

- `pnpm --filter @loreai/core run typecheck` ✅
- `biome check` (my files) ✅
- Full core suite: **2280 passed, 6 skipped, 0 failures** ✅