### PR TITLE
fix(gateway): scope upstream re-compression by destination origin (#1032)

### DIFF
--- a/packages/gateway/src/fetch.ts
+++ b/packages/gateway/src/fetch.ts
@@ -30,6 +30,9 @@
  */
 import * as https from "node:https";
 import * as http from "node:http";
+// Type-only import: erased at compile time, so it never pulls undici into the
+// Bun bundle (where undici is marked external and the Bun path is used instead).
+import type { Dispatcher } from "undici";
 
 type UndiciModule = typeof import("undici");
 type UndiciHandles = {
@@ -42,6 +45,26 @@ const isBun = typeof (globalThis as { Bun?: unknown }).Bun !== "undefined";
 
 /** Memoized undici fetch + shared timeout-disabled dispatcher (Node path only). */
 let undiciHandles: UndiciHandles | null = null;
+
+/**
+ * Test-only override for the upstream undici dispatcher (Node path).
+ *
+ * `upstreamFetch` passes an *explicit* `dispatcher` to undici's `fetch`, which
+ * overrides `setGlobalDispatcher` — so a `MockAgent` cannot intercept upstream
+ * calls via the global. This seam lets a test inject a `MockAgent` (or any
+ * dispatcher) so it can capture/assert the exact bytes and headers the gateway
+ * writes to the wire — fully in-process, with no real network, DNS, or TLS.
+ * Mirrors the `setUpstreamInterceptor` test seam in pipeline.ts. Pass `null` to
+ * restore the default timeout-disabled Agent. No effect under Bun.
+ */
+let dispatcherOverride: Dispatcher | null = null;
+
+/** Inject (or clear, with `null`) the upstream dispatcher. Tests only. */
+export function setUpstreamDispatcherForTest(
+  dispatcher: Dispatcher | null,
+): void {
+  dispatcherOverride = dispatcher;
+}
 
 /**
  * Lazily load undici and build a dispatcher with body/header timeouts disabled.
@@ -171,6 +194,9 @@ export async function upstreamFetch(
   const { fetch: undiciFetch, dispatcher } = await getUndici();
   return undiciFetch(
     input as Parameters<UndiciModule["fetch"]>[0],
-    { ...init, dispatcher } as Parameters<UndiciModule["fetch"]>[1],
+    {
+      ...init,
+      dispatcher: dispatcherOverride ?? dispatcher,
+    } as Parameters<UndiciModule["fetch"]>[1],
   ) as unknown as Promise<Response>;
 }

--- a/packages/gateway/src/http-body.ts
+++ b/packages/gateway/src/http-body.ts
@@ -174,29 +174,62 @@ export interface UpstreamRouteContext {
   ingressProtocol: string;
   /** The wire protocol actually used upstream after routing/translation. */
   effectiveProtocol: string;
+  /** Origin (`scheme://host[:port]`) of the ingress protocol's native upstream. */
+  ingressOrigin: string;
+  /** Origin of the destination actually used after routing/translation. */
+  effectiveOrigin: string;
+}
+
+/** Raw routing facts the forwarding path already computed, pre-derivation. */
+export interface UpstreamRouteFacts {
+  /** Raw `X-Lore-Upstream-URL` header value (truthy ⇒ explicit URL override). */
+  upstreamUrlHeader: string | null | undefined;
+  /** Raw `X-Lore-Provider` header value (truthy ⇒ explicit provider override). */
+  providerHeader: string | null | undefined;
+  /** The wire protocol the request arrived as (`req.protocol`). */
+  ingressProtocol: string;
+  /** The wire protocol actually used upstream after routing/translation. */
+  effectiveProtocol: string;
+  /** Base URL of the ingress protocol's native upstream (config default). */
+  ingressUpstreamBase: string;
+  /** Base URL of the destination actually used after routing/translation. */
+  effectiveUpstreamBase: string;
+}
+
+/**
+ * Parse a base URL to its origin (`scheme://host[:port]`). Falls back to the
+ * raw string when it is not a parseable URL — two distinct unparseable bases
+ * then still compare as "changed", which biases to the safe (uncompressed)
+ * branch.
+ */
+function originOf(base: string): string {
+  try {
+    return new URL(base).origin;
+  } catch {
+    return base;
+  }
 }
 
 /**
  * Build an {@link UpstreamRouteContext} from the raw routing facts the
  * forwarding path already computed.
  *
- * Centralizing the derivation here (the `!!` header coercions and the field
- * placement) keeps it pure and unit-testable: the call site forwards the four
- * values it already has instead of re-deriving booleans in an inline object
- * literal that no test can reach. See the `buildUpstreamRouteContext` tests for
- * the locked truth table.
+ * Centralizing the derivation here (the `!!` header coercions and the
+ * base-URL → origin parsing) keeps it pure and unit-testable: the call site
+ * forwards the values it already has instead of re-deriving them in an inline
+ * object literal that no test can reach. See the `buildUpstreamRouteContext`
+ * tests for the locked truth table.
  */
 export function buildUpstreamRouteContext(
-  upstreamUrlHeader: string | null | undefined,
-  providerHeader: string | null | undefined,
-  ingressProtocol: string,
-  effectiveProtocol: string,
+  facts: UpstreamRouteFacts,
 ): UpstreamRouteContext {
   return {
-    hasUpstreamUrlOverride: !!upstreamUrlHeader,
-    hasProviderOverride: !!providerHeader,
-    ingressProtocol,
-    effectiveProtocol,
+    hasUpstreamUrlOverride: !!facts.upstreamUrlHeader,
+    hasProviderOverride: !!facts.providerHeader,
+    ingressProtocol: facts.ingressProtocol,
+    effectiveProtocol: facts.effectiveProtocol,
+    ingressOrigin: originOf(facts.ingressUpstreamBase),
+    effectiveOrigin: originOf(facts.effectiveUpstreamBase),
   };
 }
 
@@ -214,28 +247,34 @@ export function buildUpstreamRouteContext(
  *   - an explicit `X-Lore-Provider` override (the plugin/user named the
  *     provider — this is how the real Codex path routes to openai-codex).
  *
- * When the gateway itself AUTO-translates the wire protocol with no explicit
- * destination (e.g. a bare Anthropic client whose model-prefix route resolves
- * to an OpenAI backend), the request is being sent to a backend family the
- * client never targeted, which may reject the encoding. In that case forward
- * uncompressed — an uncompressed body is accepted by every endpoint. (#1032
- * follow-up: scope re-compression so a gateway-translated route never replays
- * the client's encoding.)
+ * When the gateway itself AUTO-routes to a destination the client never
+ * targeted with no explicit override — either by translating the wire protocol
+ * (e.g. a bare Anthropic client whose model-prefix route resolves to an OpenAI
+ * backend) OR by re-routing to a different provider host on the same protocol
+ * (e.g. a bare OpenAI client whose `deepseek-*` model resolves to
+ * `api.deepseek.com`) — that backend may reject the encoding. In that case
+ * forward uncompressed; an uncompressed body is accepted by every endpoint.
  *
- * Note: the signal is wire-protocol translation, not provider identity. A
- * same-protocol re-route to a different concrete provider (e.g. an OpenAI-
- * protocol client whose model route resolves to another OpenAI-protocol
- * backend) is treated as a native passthrough and stays trusted. This is safe
- * today because the only client that compresses requests is Codex, which is
- * `openai-responses` in/out AND provider-tagged; if a future client compresses
- * over a same-protocol auto-route, this would need to also distrust on provider
- * change.
+ * The trust signal is therefore the DESTINATION: re-encode only when the
+ * upstream origin equals the ingress protocol's native upstream origin (a true
+ * native passthrough), or when the destination was explicitly chosen
+ * (`X-Lore-Upstream-URL` / `X-Lore-Provider`). The protocol-inequality term is
+ * kept as a belt-and-suspenders fallback for the (impossible-in-practice) case
+ * where an origin fails to parse. This also makes Vertex/Bedrock a non-issue:
+ * both are reachable only via the explicit `X-Lore-Provider` override, so they
+ * short-circuit to trusted and never reach the origin comparison.
+ *
+ * No live behavior change today: the only client that compresses requests is
+ * Codex, which is always provider-tagged → trusted before this check. This is
+ * the faithful completion of the "trust explicit overrides, distrust gateway
+ * auto-routing" design (#1032 follow-up).
  */
 export function mayReencodeUpstream(route: UpstreamRouteContext): boolean {
   const autoCrossRouted =
     !route.hasUpstreamUrlOverride &&
     !route.hasProviderOverride &&
-    route.effectiveProtocol !== route.ingressProtocol;
+    (route.effectiveProtocol !== route.ingressProtocol ||
+      route.effectiveOrigin !== route.ingressOrigin);
   return !autoCrossRouted;
 }
 
@@ -243,8 +282,9 @@ export function mayReencodeUpstream(route: UpstreamRouteContext): boolean {
  * Route-aware wrapper around {@link encodeUpstreamBody}: re-applies the
  * client's `Content-Encoding` only when {@link mayReencodeUpstream} permits it
  * for the resolved route; otherwise forwards the body uncompressed (always
- * safe). This is the single chokepoint every forwarding path calls so the
- * protocol-scoped re-encoding can never be bypassed at an individual call site.
+ * safe). Both forwarding call sites (the main upstream forward and the
+ * compaction passthrough) route through this single chokepoint so the
+ * destination-scoped re-encoding cannot be bypassed at an individual call site.
  */
 export function encodeUpstreamBodyForRoute(
   serializedBody: string,

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -3553,21 +3553,29 @@ async function forwardToUpstream(
   // cache analytics / the cache-warmer keep comparing uncompressed prefixes.
   //
   // Scope re-encoding to the destination the client targeted: only replay the
-  // encoding on a native passthrough (no protocol translation) or an explicit
-  // destination override (X-Lore-Upstream-URL / X-Lore-Provider). If the gateway
-  // auto-translated the wire protocol with no explicit destination, the upstream
-  // is a backend the client never targeted and may reject the encoding — forward
-  // uncompressed (always accepted). See mayReencodeUpstream for the rationale,
-  // including why the signal is protocol translation, not provider id (#1032).
+  // encoding on a native passthrough (the upstream origin equals the ingress
+  // protocol's native upstream) or an explicit destination override
+  // (X-Lore-Upstream-URL / X-Lore-Provider). If the gateway auto-routed to a
+  // different destination with no explicit override — by translating the wire
+  // protocol OR re-routing to a different provider host on the same protocol —
+  // the upstream is a backend the client never targeted and may reject the
+  // encoding, so forward uncompressed (always accepted). See mayReencodeUpstream
+  // for the rationale (#1032).
+  const ingressUpstreamBase =
+    req.protocol === "anthropic"
+      ? config.upstreamAnthropic
+      : config.upstreamOpenAI;
   const { body: upstreamBody, contentEncoding } = encodeUpstreamBodyForRoute(
     serializedBody,
     req.rawHeaders["content-encoding"],
-    buildUpstreamRouteContext(
-      headerUpstream,
-      providerID,
-      req.protocol,
+    buildUpstreamRouteContext({
+      upstreamUrlHeader: headerUpstream,
+      providerHeader: providerID,
+      ingressProtocol: req.protocol,
       effectiveProtocol,
-    ),
+      ingressUpstreamBase,
+      effectiveUpstreamBase,
+    }),
   );
   if (contentEncoding) headers["content-encoding"] = contentEncoding;
 
@@ -5816,12 +5824,14 @@ async function passthroughResponsesCompact(
   const { body: passthroughBody, contentEncoding } = encodeUpstreamBodyForRoute(
     bodyText,
     rawHeaders["content-encoding"],
-    buildUpstreamRouteContext(
-      undefined,
-      undefined,
-      "openai-responses",
-      "openai-responses",
-    ),
+    buildUpstreamRouteContext({
+      upstreamUrlHeader: undefined,
+      providerHeader: undefined,
+      ingressProtocol: "openai-responses",
+      effectiveProtocol: "openai-responses",
+      ingressUpstreamBase: config.upstreamOpenAI,
+      effectiveUpstreamBase: config.upstreamOpenAI,
+    }),
   );
   if (contentEncoding) headers["content-encoding"] = contentEncoding;
 

--- a/packages/gateway/test/http-body.test.ts
+++ b/packages/gateway/test/http-body.test.ts
@@ -173,35 +173,44 @@ describe("encodeUpstreamBody", () => {
   });
 });
 
+// Shared origins for the route-context truth table.
+const OPENAI = "https://api.openai.com";
+const ANTHROPIC = "https://api.anthropic.com";
+const DEEPSEEK = "https://api.deepseek.com";
+
 describe("mayReencodeUpstream", () => {
-  test("permits re-encoding on a native passthrough (no overrides, same protocol)", () => {
-    // The Codex native path: openai-responses in, openai-responses out, with an
-    // explicit X-Lore-Provider (openai-codex) — and also the bare same-protocol
-    // case. Both are trusted destinations.
+  test("permits re-encoding on a native passthrough (no overrides, same protocol + origin)", () => {
+    // The Codex native path: openai-responses in, openai-responses out, same
+    // upstream origin — a trusted destination.
     expect(
       mayReencodeUpstream({
         hasUpstreamUrlOverride: false,
         hasProviderOverride: false,
         ingressProtocol: "openai-responses",
         effectiveProtocol: "openai-responses",
+        ingressOrigin: OPENAI,
+        effectiveOrigin: OPENAI,
       }),
     ).toBe(true);
   });
 
-  test("permits re-encoding when X-Lore-Provider is set even if the protocol is translated", () => {
+  test("permits re-encoding when X-Lore-Provider is set even if the destination differs", () => {
     // Explicit provider override → the user/plugin chose the destination, so we
-    // trust it accepts the client's encoding (e.g. Codex → openai-codex).
+    // trust it accepts the client's encoding (e.g. Codex → openai-codex; this is
+    // also how Vertex/Bedrock are reached — always provider-tagged).
     expect(
       mayReencodeUpstream({
         hasUpstreamUrlOverride: false,
         hasProviderOverride: true,
         ingressProtocol: "anthropic",
         effectiveProtocol: "openai",
+        ingressOrigin: ANTHROPIC,
+        effectiveOrigin: OPENAI,
       }),
     ).toBe(true);
   });
 
-  test("permits re-encoding when X-Lore-Upstream-URL is set even if the protocol is translated", () => {
+  test("permits re-encoding when X-Lore-Upstream-URL is set even if the destination differs", () => {
     // Explicit URL override → the user owns the destination.
     expect(
       mayReencodeUpstream({
@@ -209,11 +218,13 @@ describe("mayReencodeUpstream", () => {
         hasProviderOverride: false,
         ingressProtocol: "anthropic",
         effectiveProtocol: "openai",
+        ingressOrigin: ANTHROPIC,
+        effectiveOrigin: "https://up.example",
       }),
     ).toBe(true);
   });
 
-  test("withholds re-encoding when the gateway auto-translates with no explicit destination", () => {
+  test("withholds re-encoding when the gateway auto-translates the protocol with no override", () => {
     // Bare Anthropic client whose model-prefix route resolves to an OpenAI
     // backend: the gateway re-routed to a different provider family the client
     // never targeted — its Content-Encoding may not be accepted there.
@@ -223,68 +234,147 @@ describe("mayReencodeUpstream", () => {
         hasProviderOverride: false,
         ingressProtocol: "anthropic",
         effectiveProtocol: "openai",
+        ingressOrigin: ANTHROPIC,
+        effectiveOrigin: OPENAI,
+      }),
+    ).toBe(false);
+  });
+
+  test("withholds re-encoding on a SAME-protocol re-route to a different host (F3 gap)", () => {
+    // Bare OpenAI client whose `deepseek-*` model resolves to api.deepseek.com:
+    // same wire protocol but a provider host the client never targeted. The
+    // protocol-only predicate wrongly trusted this; the origin check distrusts.
+    expect(
+      mayReencodeUpstream({
+        hasUpstreamUrlOverride: false,
+        hasProviderOverride: false,
+        ingressProtocol: "openai",
+        effectiveProtocol: "openai",
+        ingressOrigin: OPENAI,
+        effectiveOrigin: DEEPSEEK,
       }),
     ).toBe(false);
   });
 });
 
 describe("buildUpstreamRouteContext", () => {
+  const facts = (
+    over: Partial<Parameters<typeof buildUpstreamRouteContext>[0]>,
+  ) =>
+    buildUpstreamRouteContext({
+      upstreamUrlHeader: null,
+      providerHeader: null,
+      ingressProtocol: "openai",
+      effectiveProtocol: "openai",
+      ingressUpstreamBase: OPENAI,
+      effectiveUpstreamBase: OPENAI,
+      ...over,
+    });
+
   test("derives hasUpstreamUrlOverride from header truthiness", () => {
     expect(
-      buildUpstreamRouteContext("https://up.example", null, "a", "b")
-        .hasUpstreamUrlOverride,
+      facts({ upstreamUrlHeader: "https://up.example" }).hasUpstreamUrlOverride,
     ).toBe(true);
     for (const empty of [null, undefined, ""]) {
-      expect(
-        buildUpstreamRouteContext(empty, null, "a", "b").hasUpstreamUrlOverride,
-      ).toBe(false);
+      expect(facts({ upstreamUrlHeader: empty }).hasUpstreamUrlOverride).toBe(
+        false,
+      );
     }
   });
 
   test("derives hasProviderOverride from header truthiness", () => {
-    expect(
-      buildUpstreamRouteContext(null, "openai-codex", "a", "b")
-        .hasProviderOverride,
-    ).toBe(true);
+    expect(facts({ providerHeader: "openai-codex" }).hasProviderOverride).toBe(
+      true,
+    );
     for (const empty of [null, undefined, ""]) {
-      expect(
-        buildUpstreamRouteContext(null, empty, "a", "b").hasProviderOverride,
-      ).toBe(false);
+      expect(facts({ providerHeader: empty }).hasProviderOverride).toBe(false);
     }
   });
 
   test("maps ingress/effective protocols to the right fields (not swapped)", () => {
     // Distinct sentinel values catch an ingress/effective swap — the exact
     // mis-wiring that would silently disable the auto-cross-route guard.
-    const ctx = buildUpstreamRouteContext(null, null, "INGRESS", "EFFECTIVE");
+    const ctx = facts({
+      ingressProtocol: "INGRESS",
+      effectiveProtocol: "EFFECTIVE",
+    });
     expect(ctx.ingressProtocol).toBe("INGRESS");
     expect(ctx.effectiveProtocol).toBe("EFFECTIVE");
   });
 
+  test("derives origins from the base URLs (right fields, path/query stripped)", () => {
+    const ctx = facts({
+      ingressUpstreamBase: `${ANTHROPIC}/v1/messages`,
+      effectiveUpstreamBase: `${DEEPSEEK}/v1/chat/completions?x=1`,
+    });
+    expect(ctx.ingressOrigin).toBe(ANTHROPIC);
+    expect(ctx.effectiveOrigin).toBe(DEEPSEEK);
+  });
+
+  test("falls back to the raw base string when it is not a parseable URL", () => {
+    const ctx = facts({
+      ingressUpstreamBase: "not a url",
+      effectiveUpstreamBase: "also not a url",
+    });
+    expect(ctx.ingressOrigin).toBe("not a url");
+    expect(ctx.effectiveOrigin).toBe("also not a url");
+  });
+
   test("composes with mayReencodeUpstream into the full route truth table", () => {
     // Lock the raw-inputs → decision path end to end (the wiring the call site
-    // depends on), not just the boolean already-derived context.
+    // depends on), not just the already-derived context.
     const decide = (
       url: string | null,
       provider: string | null,
-      ingress: string,
-      effective: string,
+      ingressProtocol: string,
+      effectiveProtocol: string,
+      ingressUpstreamBase: string,
+      effectiveUpstreamBase: string,
     ) =>
       mayReencodeUpstream(
-        buildUpstreamRouteContext(url, provider, ingress, effective),
+        buildUpstreamRouteContext({
+          upstreamUrlHeader: url,
+          providerHeader: provider,
+          ingressProtocol,
+          effectiveProtocol,
+          ingressUpstreamBase,
+          effectiveUpstreamBase,
+        }),
       );
     // Auto cross-route (no overrides, protocol translated) → distrust.
-    expect(decide(null, null, "anthropic", "openai")).toBe(false);
-    // Native passthrough (no overrides, same protocol) → trust.
-    expect(decide(null, null, "openai-responses", "openai-responses")).toBe(
-      true,
+    expect(decide(null, null, "anthropic", "openai", ANTHROPIC, OPENAI)).toBe(
+      false,
     );
-    // Explicit URL override, even when translated → trust.
-    expect(decide("https://up.example", null, "anthropic", "openai")).toBe(
-      true,
+    // Same-protocol re-route to a different host (F3 gap) → distrust.
+    expect(decide(null, null, "openai", "openai", OPENAI, DEEPSEEK)).toBe(
+      false,
     );
-    // Explicit provider override (real Codex path), even translated → trust.
-    expect(decide(null, "openai-codex", "anthropic", "openai")).toBe(true);
+    // Native passthrough (no overrides, same protocol + origin) → trust.
+    expect(
+      decide(
+        null,
+        null,
+        "openai-responses",
+        "openai-responses",
+        OPENAI,
+        OPENAI,
+      ),
+    ).toBe(true);
+    // Explicit URL override, even when re-routed → trust.
+    expect(
+      decide(
+        "https://up.example",
+        null,
+        "anthropic",
+        "openai",
+        ANTHROPIC,
+        OPENAI,
+      ),
+    ).toBe(true);
+    // Explicit provider override (real Codex/Vertex/Bedrock path) → trust.
+    expect(
+      decide(null, "openai-codex", "anthropic", "openai", ANTHROPIC, OPENAI),
+    ).toBe(true);
   });
 });
 
@@ -294,18 +384,32 @@ describe("encodeUpstreamBodyForRoute", () => {
     hasProviderOverride: false,
     ingressProtocol: "openai-responses",
     effectiveProtocol: "openai-responses",
+    ingressOrigin: OPENAI,
+    effectiveOrigin: OPENAI,
   };
   const AUTO_CROSS_ROUTED = {
     hasUpstreamUrlOverride: false,
     hasProviderOverride: false,
     ingressProtocol: "anthropic",
     effectiveProtocol: "openai",
+    ingressOrigin: ANTHROPIC,
+    effectiveOrigin: OPENAI,
+  };
+  const SAME_PROTO_FOREIGN_HOST = {
+    hasUpstreamUrlOverride: false,
+    hasProviderOverride: false,
+    ingressProtocol: "openai",
+    effectiveProtocol: "openai",
+    ingressOrigin: OPENAI,
+    effectiveOrigin: DEEPSEEK,
   };
   const EXPLICIT_URL_TRANSLATED = {
     hasUpstreamUrlOverride: true,
     hasProviderOverride: false,
     ingressProtocol: "anthropic",
     effectiveProtocol: "openai",
+    ingressOrigin: ANTHROPIC,
+    effectiveOrigin: "https://up.example",
   };
 
   test("re-applies the client's encoding on a trusted (native) route", () => {
@@ -337,6 +441,14 @@ describe("encodeUpstreamBodyForRoute", () => {
     // never targeted must NOT have its Content-Encoding replayed upstream.
     expect(
       encodeUpstreamBodyForRoute(SAMPLE, "zstd", AUTO_CROSS_ROUTED),
+    ).toEqual({ body: SAMPLE, contentEncoding: null });
+  });
+
+  test("forwards UNCOMPRESSED on a same-protocol re-route to a foreign host (F3 gap)", () => {
+    // A same-protocol model-prefix re-route to a different provider host (e.g.
+    // openai client → deepseek backend) must also forward uncompressed.
+    expect(
+      encodeUpstreamBodyForRoute(SAMPLE, "zstd", SAME_PROTO_FOREIGN_HOST),
     ).toEqual({ body: SAMPLE, contentEncoding: null });
   });
 

--- a/packages/gateway/test/recompress-scope.test.ts
+++ b/packages/gateway/test/recompress-scope.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Wire-level e2e for the #1032 re-compression SCOPING (the distrust branch).
+ *
+ * The decision unit-tests (http-body.test.ts) lock `mayReencodeUpstream`, but
+ * they never exercise the construction of the route context inside
+ * `forwardToUpstream` — the exact wiring the adversarial review flagged: a
+ * call-site mutation (e.g. passing `req.protocol` instead of `effectiveProtocol`,
+ * or the wrong upstream base) fully disables the feature yet ships green, because
+ * the only other wire e2e (codex-compression Test 3) is double-trusted
+ * (`x-lore-upstream-url` + same protocol).
+ *
+ * These tests drive a real gateway and capture the ACTUAL bytes written upstream
+ * for a model that AUTO-routes (no `x-lore-upstream-url` / `x-lore-provider`
+ * override) to a host the client never targeted. Capturing those bytes without
+ * `x-lore-upstream-url` (which would force the trusted path) needs the upstream
+ * destination — a hardcoded `https://` model-route URL — to resolve in-process.
+ * We do that with an undici `MockAgent` injected via `setUpstreamDispatcherForTest`
+ * (upstreamFetch passes an explicit dispatcher, so `setGlobalDispatcher` can't
+ * intercept it). Fully hermetic: no real network, DNS/hosts, or TLS.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { MockAgent } from "undici";
+import { zstdCompressSync, zstdDecompressSync } from "node:zlib";
+import type { Harness } from "./helpers/harness";
+import { createHarness } from "./helpers/harness";
+import { setUpstreamInterceptor } from "../src/pipeline";
+import { setUpstreamDispatcherForTest } from "../src/fetch";
+import { makeConversationFixtures } from "./helpers/fixtures";
+
+interface Captured {
+  headers: Record<string, string>;
+  body: Buffer;
+}
+
+function toBuffer(body: unknown): Buffer {
+  if (Buffer.isBuffer(body)) return body;
+  if (typeof body === "string") return Buffer.from(body);
+  if (body instanceof Uint8Array) return Buffer.from(body);
+  return Buffer.from(String(body ?? ""));
+}
+
+describe("upstream re-compression scoping (#1032 follow-up, wire-level)", () => {
+  let harness: Harness | undefined;
+  let mock: MockAgent | undefined;
+
+  afterEach(async () => {
+    setUpstreamDispatcherForTest(null);
+    await mock?.close();
+    mock = undefined;
+    harness?.teardown();
+    harness = undefined;
+  });
+
+  /**
+   * Send a zstd-compressed OpenAI chat-completions request for `model` (which
+   * model-prefix routes to `origin`) through a real gateway, and return what the
+   * gateway actually wrote to that upstream origin.
+   */
+  async function forwardZstdChat(
+    model: string,
+    origin: string,
+    marker: string,
+  ): Promise<Captured | undefined> {
+    let captured: Captured | undefined;
+
+    mock = new MockAgent();
+    mock.disableNetConnect();
+    mock
+      .get(origin)
+      .intercept({ path: () => true, method: "POST" })
+      .reply((opts) => {
+        captured = {
+          headers: (opts.headers ?? {}) as Record<string, string>,
+          body: toBuffer(opts.body),
+        };
+        return {
+          statusCode: 200,
+          data: JSON.stringify({
+            id: "chatcmpl-scope",
+            object: "chat.completion",
+            created: 0,
+            model,
+            choices: [
+              {
+                index: 0,
+                message: { role: "assistant", content: "ok" },
+                finish_reason: "stop",
+              },
+            ],
+            usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+          }),
+          responseOptions: { headers: { "content-type": "application/json" } },
+        };
+      })
+      .persist();
+    setUpstreamDispatcherForTest(mock);
+
+    harness = await createHarness({
+      fixtures: makeConversationFixtures([
+        { userMessage: marker, assistantText: "ok" },
+      ]),
+    });
+    // Genuinely forward to the (mocked) upstream so the real upstreamFetch path
+    // — and thus the real route-context construction — runs.
+    setUpstreamInterceptor((_body, _model, _streaming, makeReal) => makeReal());
+
+    const compressed = zstdCompressSync(
+      Buffer.from(
+        JSON.stringify({
+          model,
+          stream: false,
+          messages: [{ role: "user", content: marker }],
+        }),
+      ),
+    );
+    await fetch(`${harness.baseURL}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "content-encoding": "zstd",
+        authorization: "Bearer test-key",
+        "x-lore-project": process.cwd(),
+      },
+      body: compressed,
+    });
+
+    return captured;
+  }
+
+  it("forwards UNCOMPRESSED when auto-routing to a different provider host (openai → deepseek)", async () => {
+    // deepseek-* model-prefix routes to api.deepseek.com on the SAME (openai)
+    // wire protocol — a host the client never targeted. The protocol-only
+    // predicate wrongly trusted this; the origin-aware predicate distrusts it.
+    const marker = "scope-distrust-marker-9c1f";
+    const cap = await forwardZstdChat(
+      "deepseek-chat",
+      "https://api.deepseek.com",
+      marker,
+    );
+
+    expect(cap).toBeDefined();
+    const c = cap as Captured;
+    // No content-encoding replayed to the foreign host.
+    expect(c.headers["content-encoding"]).toBeUndefined();
+    // The body is genuinely plain JSON (decodes as JSON, contains the marker),
+    // NOT zstd.
+    const text = c.body.toString("utf8");
+    expect(() => JSON.parse(text)).not.toThrow();
+    expect(text).toContain(marker);
+  });
+
+  it("re-compresses (zstd) when forwarding to the client's native provider host (openai → openai)", async () => {
+    // gpt-* routes to api.openai.com — the openai ingress's native upstream. A
+    // true native passthrough, so the client's zstd encoding is replayed.
+    const marker = "scope-trust-marker-4a7e";
+    const cap = await forwardZstdChat(
+      "gpt-4o",
+      "https://api.openai.com",
+      marker,
+    );
+
+    expect(cap).toBeDefined();
+    const c = cap as Captured;
+    // The gateway re-applied the client's zstd encoding.
+    expect(c.headers["content-encoding"]).toBe("zstd");
+    // Raw bytes are genuine zstd (decode back to JSON containing the marker),
+    // NOT plain JSON.
+    expect(() => JSON.parse(c.body.toString("utf8"))).toThrow();
+    expect(zstdDecompressSync(c.body).toString("utf8")).toContain(marker);
+  });
+});


### PR DESCRIPTION
Follow-up to #1049 / #1059. Closes the remaining adversarial-review findings from the #1059 review: the latent **F3** correctness gap, the **F4** nit, and the missing wire-level e2e for the distrust branch.

## What & why

### F3 — trust the destination, not the wire protocol
The merged predicate compared *protocols*, so a **same-protocol re-route to a different provider host** was trusted: a bare `openai` client whose `deepseek-*` model resolves to `api.deepseek.com` would have its `Content-Encoding` (zstd) replayed to DeepSeek — the exact #1032 failure class the PR is meant to scope out.

`mayReencodeUpstream` now distrusts when the **effective upstream origin** differs from the **ingress protocol's native upstream origin** (unless an explicit override is present). Content-encoding acceptance is a property of the destination server, not the body schema — so origin is the faithful "client never targeted this destination" signal. The protocol-inequality term is kept as a belt-and-suspenders fallback for the (impossible-in-practice) case where an origin fails to parse.

| route | before | after |
|---|---|---|
| `claude-*` via anthropic → api.anthropic.com | trust | trust |
| `gpt-*` via openai → api.openai.com | trust | trust |
| `gpt-*` via anthropic → api.openai.com | distrust | distrust |
| **`deepseek-*` via openai → api.deepseek.com** | **trust** ❌ | **distrust** ✅ |
| vertex/bedrock (always `X-Lore-Provider`) | trust | trust |

### F4 — vertex/bedrock
Reachable only via the explicit `X-Lore-Provider` override, so they short-circuit to *trusted* and never reach the origin comparison. No special-casing needed.

### API
`buildUpstreamRouteContext` now takes an options object carrying the two upstream base URLs (origins derived via a safe `new URL().origin`). Both forwarding call sites (main forward + compaction passthrough) pass them.

**No live behavior change today**: the only client that compresses requests is Codex, which is always provider-tagged → trusted before this check. This is the faithful completion of the confirmed "trust explicit overrides, distrust auto-routing" design.

## Testing — the distrust branch now has wire-level coverage

The #1059 review flagged that the call-site construction of the route context was untested: a one-line mis-wiring (e.g. passing `req.protocol` instead of `effectiveProtocol`, or the wrong upstream base) **fully disables the feature yet ships green**, because the only other wire e2e (codex Test 3) is double-trusted (`x-lore-upstream-url` + same protocol).

`new recompress-scope.test.ts` drives a real gateway and captures the **actual bytes** written upstream for a model that auto-routes (no override) to a host the client never targeted. Doing that without `x-lore-upstream-url` (which would force the trusted path) requires the hardcoded `https://` model-route URL to resolve in-process — done with an undici **`MockAgent`** injected via a new `setUpstreamDispatcherForTest` seam in `fetch.ts` (`upstreamFetch` passes an *explicit* dispatcher, so `setGlobalDispatcher` can't intercept it). **Fully hermetic: no real network, DNS/`/etc/hosts`, or TLS.**

- auto-route to a foreign host (`deepseek-chat` → `api.deepseek.com`): asserts **no `content-encoding`** + plain-JSON bytes.
- native passthrough (`gpt-4o` → `api.openai.com`): asserts **`content-encoding: zstd`** + zstd-magic bytes.

### Mutation-verified
- remove the origin clause from the predicate → deepseek distrust (unit + e2e) RED, trust green.
- call site wires the wrong `effectiveUpstreamBase` → deepseek e2e RED (origin wiring is load-bearing — the W4-class gap).
- force `mayReencodeUpstream` to always distrust → trust e2e RED (the trust test is not vacuous).

## Verification
- `tsc --noEmit`: clean
- full gateway suite: 2355 passed / 26 skipped, 0 failures
- e2e + codex-compression: 5× consecutive runs green (no flakiness)