### PR TITLE
fix(gateway): forward github-copilot to its real /chat/completions endpoint (#1052)

### DIFF
--- a/packages/core/src/fetch-interceptor.ts
+++ b/packages/core/src/fetch-interceptor.ts
@@ -177,7 +177,21 @@ export function detectProtocolFromBody(bodyStr: string): BodyProtocol | null {
   }
 }
 
-type Rewrite = { gatewayUrl: string; upstreamBase: string };
+type Rewrite = {
+  gatewayUrl: string;
+  upstreamBase: string;
+  /**
+   * The client's ORIGINAL upstream endpoint pathname (e.g. `/chat/completions`,
+   * `/v1/messages`, or a prefixed `/api/v1/chat/completions`). Forwarded to the
+   * gateway as `x-lore-upstream-path` so it can POST to the exact endpoint the
+   * SDK intended instead of synthesizing a canonical `/v1/...` path. This is the
+   * full pathname (NOT the post-base suffix) so the gateway can reconstruct the
+   * original URL as `origin(base) + pathname` regardless of any base prefix —
+   * required for providers whose endpoint omits `/v1` (GitHub Copilot's
+   * `/chat/completions`, issue #1052) or uses a non-standard prefix.
+   */
+  upstreamPath: string;
+};
 
 /**
  * Rewrite an intercepted URL to the gateway, handling both standard /v1/...
@@ -192,6 +206,7 @@ function interceptUrl(upstream: URL, gateway: URL): Rewrite | null {
     return {
       gatewayUrl: `${gateway.origin}${upstream.pathname.slice(v1Idx)}${upstream.search}`,
       upstreamBase: upstream.origin + upstream.pathname.slice(0, v1Idx),
+      upstreamPath: upstream.pathname,
     };
   }
   // Try non-standard path rewrites (e.g. /codex/responses → /v1/codex/responses)
@@ -203,6 +218,7 @@ function interceptUrl(upstream: URL, gateway: URL): Rewrite | null {
         gatewayUrl: `${gateway.origin}${canonical}${upstream.search}`,
         upstreamBase:
           upstream.origin + upstream.pathname.slice(0, -suffix.length),
+        upstreamPath: upstream.pathname,
       };
     }
   }
@@ -239,6 +255,7 @@ export function interceptUrlForProtocol(
   return {
     gatewayUrl: `${gateway.origin}${gatewayPath}${upstream.search}`,
     upstreamBase,
+    upstreamPath: upstream.pathname,
   };
 }
 
@@ -290,7 +307,8 @@ export function shouldIntercept(url: string, gatewayBase: string): boolean {
  * The interceptor:
  * 1. Checks if the outgoing URL matches a known LLM API path
  * 2. Rewrites the URL to the gateway, preserving the path
- * 3. Adds `X-Lore-Upstream-URL` with the original upstream base
+ * 3. Adds `X-Lore-Upstream-URL` (base) and `X-Lore-Upstream-Path` (original
+ *    endpoint pathname, for verbatim forwarding)
  * 4. Injects dynamic `X-Lore-*` context headers from `getHeaders()`
  * 5. Preserves ALL original headers (auth, content-type, etc.)
  *
@@ -322,7 +340,8 @@ export function getOriginalFetch(): typeof globalThis.fetch {
 /**
  * Build the gateway-bound headers for an intercepted request: preserve all
  * original headers (auth, content-type, etc.), set `X-Lore-Upstream-URL` to
- * the resolved upstream base, and inject dynamic `X-Lore-*` context headers.
+ * the resolved upstream base, `X-Lore-Upstream-Path` to the original endpoint
+ * pathname, and inject dynamic `X-Lore-*` context headers.
  *
  * Shared by both the URL-matched path (Path 1) and the body-detected path
  * (Path 2) so header handling can never drift between them.
@@ -331,6 +350,7 @@ function buildGatewayHeaders(
   input: RequestInfo | URL,
   init: RequestInit | undefined,
   upstreamBase: string,
+  upstreamPath: string,
   config: FetchInterceptorConfig,
 ): Headers {
   // Handle both `fetch(url, {headers})` and `fetch(new Request(url, {headers}))`.
@@ -344,6 +364,15 @@ function buildGatewayHeaders(
   // Pass the original upstream base URL (everything before the API path).
   // The gateway uses this as the highest-priority routing signal.
   headers.set("x-lore-upstream-url", upstreamBase);
+
+  // Pass the client's ORIGINAL endpoint pathname so the gateway can forward
+  // verbatim instead of synthesizing a canonical `/v1/...` path. This is what
+  // lets providers whose endpoint omits `/v1` (GitHub Copilot's
+  // `/chat/completions`, issue #1052) or uses a non-standard prefix work as a
+  // pure passthrough. Only set when it's a sane absolute path.
+  if (upstreamPath.startsWith("/")) {
+    headers.set("x-lore-upstream-path", upstreamPath);
+  }
 
   // Inject dynamic context headers (session ID, project, git remote, etc.).
   // Only set if not already present — per-request hooks may have set them.
@@ -434,6 +463,7 @@ export function installFetchInterceptor(
         input,
         init,
         rewrite.upstreamBase,
+        rewrite.upstreamPath,
         config,
       );
       log.info(
@@ -456,6 +486,7 @@ export function installFetchInterceptor(
           input,
           init,
           rewrite.upstreamBase,
+          rewrite.upstreamPath,
           config,
         );
         log.info(

--- a/packages/core/test/fetch-interceptor-install.test.ts
+++ b/packages/core/test/fetch-interceptor-install.test.ts
@@ -181,6 +181,53 @@ describe("installFetchInterceptor — end-to-end routing", () => {
     });
   });
 
+  describe("x-lore-upstream-path — original endpoint preservation (#1052)", () => {
+    test("GitHub Copilot /chat/completions (no /v1) preserves the bare path", async () => {
+      // Body-detected (Path 2): Copilot's endpoint has no /v1/ segment, so the
+      // URL patterns miss and we fall back to body-shape detection.
+      await fetch("https://api.githubcopilot.com/chat/completions", {
+        method: "POST",
+        body: JSON.stringify({ model: "gpt-4", messages: [] }),
+      });
+      expect(captured?.url).toBe(`${GATEWAY}/v1/chat/completions`);
+      expect(headerVal("x-lore-upstream-url")).toBe(
+        "https://api.githubcopilot.com",
+      );
+      // The crux of #1052: the gateway must learn the real endpoint omits /v1/.
+      expect(headerVal("x-lore-upstream-path")).toBe("/chat/completions");
+    });
+
+    test("standard /v1/chat/completions carries the full /v1 path", async () => {
+      await fetch("https://api.openai.com/v1/chat/completions", {
+        method: "POST",
+        body: JSON.stringify({ model: "gpt-4", messages: [] }),
+      });
+      expect(headerVal("x-lore-upstream-path")).toBe("/v1/chat/completions");
+    });
+
+    test("aggregator /api/v1/... carries the FULL pathname (incl. prefix)", async () => {
+      await fetch("https://openrouter.ai/api/v1/chat/completions", {
+        method: "POST",
+        body: JSON.stringify({ model: "x", messages: [] }),
+      });
+      // Full pathname (not the post-base suffix) so the gateway reconstructs the
+      // original URL as origin + pathname without doubling the /api prefix.
+      expect(headerVal("x-lore-upstream-path")).toBe(
+        "/api/v1/chat/completions",
+      );
+    });
+
+    test("Codex /backend-api/codex/responses carries the full pathname", async () => {
+      await fetch("https://chatgpt.com/backend-api/codex/responses", {
+        method: "POST",
+        body: JSON.stringify({ model: "gpt-5", input: [] }),
+      });
+      expect(headerVal("x-lore-upstream-path")).toBe(
+        "/backend-api/codex/responses",
+      );
+    });
+  });
+
   describe("non-interception cases", () => {
     test("does not touch non-LLM URLs", async () => {
       await fetch("https://registry.npmjs.org/some-package");
@@ -208,6 +255,18 @@ describe("interceptUrlForProtocol", () => {
     );
     expect(r.gatewayUrl).toBe(`${GATEWAY}/v1/chat/completions`);
     expect(r.upstreamBase).toBe("https://api.example.com/v2");
+    // upstreamPath is the FULL original pathname (for verbatim forwarding).
+    expect(r.upstreamPath).toBe("/v2/chat/completions");
+  });
+
+  test("upstreamPath preserves a Copilot-style bare /chat/completions", () => {
+    const r = interceptUrlForProtocol(
+      new URL("https://api.githubcopilot.com/chat/completions"),
+      gateway,
+      "openai",
+    );
+    expect(r.upstreamBase).toBe("https://api.githubcopilot.com");
+    expect(r.upstreamPath).toBe("/chat/completions");
   });
 
   test("maps anthropic → /v1/messages", () => {

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -375,6 +375,92 @@ export function extractUpstreamUrlHeader(
   }
 }
 
+/** Maximum allowed length for an upstream path header value. */
+const MAX_UPSTREAM_PATH_LENGTH = 512;
+
+/**
+ * Extract and validate the `X-Lore-Upstream-Path` header from a request.
+ *
+ * Set by the fetch interceptor to the client's ORIGINAL endpoint pathname (the
+ * full pathname, e.g. `/chat/completions`, `/v1/messages`, or a prefixed
+ * `/api/v1/chat/completions`). Lets the gateway forward to the exact endpoint
+ * the SDK intended instead of synthesizing a canonical `/v1/...` path — required
+ * for providers whose endpoint omits `/v1` (GitHub Copilot, issue #1052).
+ *
+ * Returns the sanitized absolute path, or `undefined` when absent/invalid. The
+ * value is only ever appended to an already-resolved upstream origin (see
+ * `verbatimUpstreamUrl`), so it can never change the destination host; these
+ * checks are defense-in-depth against a malformed/hostile header.
+ */
+export function extractUpstreamPathHeader(
+  headers: Record<string, string>,
+): string | undefined {
+  const raw = headers["x-lore-upstream-path"];
+  if (!raw) return undefined;
+
+  // Sanitize: strip control characters, trim.
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: intentional control-character sanitization
+  const sanitized = raw.replace(/[\x00-\x1f\x7f]/g, "").trim();
+  if (!sanitized || sanitized.length > MAX_UPSTREAM_PATH_LENGTH)
+    return undefined;
+  // Must be a single absolute path: one leading slash (reject protocol-relative
+  // `//host`), no whitespace, no `..` traversal.
+  if (!sanitized.startsWith("/") || sanitized.startsWith("//"))
+    return undefined;
+  if (sanitized.includes("..") || /\s/.test(sanitized)) return undefined;
+  return sanitized;
+}
+
+/**
+ * Decide the final upstream URL, preferring verbatim passthrough of the client's
+ * original endpoint over the gateway-reconstructed canonical path.
+ *
+ * Returns `origin(effectiveUpstreamBase) + upstreamPath` (the client's original
+ * URL) when ALL hold; otherwise returns `reconstructedUrl` unchanged:
+ *  - `headerUpstream` is present — the base came from the original host via
+ *    `X-Lore-Upstream-URL` (the highest-priority routing tier), so we are NOT
+ *    rerouting to a different provider;
+ *  - `upstreamPath` is present — the interceptor preserved the endpoint;
+ *  - `effectiveProtocol === ingressProtocol` — we are NOT translating wire
+ *    protocols (which would change the endpoint shape; e.g. anthropic↔openai),
+ *    and the path belongs to the protocol we're actually speaking. This also
+ *    excludes `vertex` (a distinct effectiveProtocol with its own URL shape).
+ *
+ * Anchoring at the base ORIGIN (not the base string) reproduces the original URL
+ * exactly even when the base carries a prefix already contained in the full
+ * pathname (OpenRouter `/api`, Fireworks `/inference`) — never doubling it.
+ */
+export function verbatimUpstreamUrl(params: {
+  reconstructedUrl: string;
+  effectiveUpstreamBase: string;
+  headerUpstream: string | undefined;
+  upstreamPath: string | undefined;
+  effectiveProtocol: "anthropic" | "openai" | "openai-responses" | "vertex";
+  ingressProtocol: "anthropic" | "openai" | "openai-responses" | "vertex";
+}): string {
+  const {
+    reconstructedUrl,
+    effectiveUpstreamBase,
+    headerUpstream,
+    upstreamPath,
+    effectiveProtocol,
+    ingressProtocol,
+  } = params;
+  if (!headerUpstream || !upstreamPath) return reconstructedUrl;
+  // Only forward verbatim on a standard wire protocol whose endpoint we did NOT
+  // translate. `vertex` builds a distinct `:rawPredict` URL (model in the path)
+  // and must never be overridden; the equality check below also rejects any
+  // translated turn (e.g. anthropic ingress → openai egress).
+  if (effectiveProtocol === "vertex" || effectiveProtocol !== ingressProtocol) {
+    return reconstructedUrl;
+  }
+  try {
+    return new URL(effectiveUpstreamBase).origin + upstreamPath;
+  } catch {
+    return reconstructedUrl;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Provider-ID-based routing
 // ---------------------------------------------------------------------------
@@ -408,7 +494,12 @@ export type ProviderRoute = {
  * header, this table is consulted BEFORE the model-prefix UPSTREAM_ROUTES.
  *
  * URLs must NOT include `/v1` — the gateway appends `/v1/messages`,
- * `/v1/chat/completions`, or `/v1/responses` itself.
+ * `/v1/chat/completions`, or `/v1/responses` itself. The exception is providers
+ * whose API omits the `/v1` segment (GitHub Copilot serves chat completions at
+ * `/chat/completions`, issue #1052): foreground requests forward verbatim to the
+ * client's original endpoint (see `verbatimUpstreamUrl`), and reconstructed
+ * paths (background workers) are handled host-aware by
+ * `buildOpenAIChatCompletionsUrl` in `translate/openai.ts`.
  *
  * Data sourced from models.dev provider database (https://models.dev/providers).
  * Protocol derived from the provider's SDK package: `@ai-sdk/anthropic` →

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -41,6 +41,7 @@ import {
 import { recordWorkerCost } from "./cost-tracker";
 import { upstreamFetch } from "./fetch";
 import { extractJSONFromSSE } from "./translate/types";
+import { buildOpenAIChatCompletionsUrl } from "./translate/openai";
 import { isBedrockMantleHost, toMantleModelId } from "./translate/bedrock";
 import {
   toVertexBody,
@@ -639,7 +640,9 @@ function buildOpenAIWorkerRequest(
   messages.push({ role: "user", content: user });
 
   return {
-    url: `${target.url}/v1/chat/completions`,
+    // Background workers have no original request to forward verbatim, so the
+    // URL is reconstructed host-aware (GitHub Copilot omits `/v1`, issue #1052).
+    url: buildOpenAIChatCompletionsUrl(target.url),
     headers: {
       "Content-Type": "application/json",
       ...authHeaders(cred),

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -105,6 +105,8 @@ import {
   extractProjectHeader,
   resolveUpstreamRoute,
   extractUpstreamUrlHeader,
+  extractUpstreamPathHeader,
+  verbatimUpstreamUrl,
   extractProviderHeader,
   resolveLastSeenProvider,
   resolveProviderRoute,
@@ -3291,6 +3293,9 @@ async function forwardToUpstream(
   // Preserve "openai-responses" from ingress — model prefix routing returns
   // "openai" for OpenAI models, but we must not downgrade the wire protocol.
   const headerUpstream = extractUpstreamUrlHeader(req.rawHeaders);
+  // The client's ORIGINAL endpoint pathname (set by the fetch interceptor), used
+  // below to forward verbatim instead of synthesizing a canonical `/v1/...` path.
+  const headerUpstreamPath = extractUpstreamPathHeader(req.rawHeaders);
   const providerID = extractProviderHeader(req.rawHeaders);
   let providerRoute = providerID ? resolveProviderRoute(providerID) : null;
   // Dynamic fallback: look up unknown providers from models.dev cache.
@@ -3506,6 +3511,24 @@ async function forwardToUpstream(
       (body as { model?: string }).model = toMantleModelId(req.model);
     }
   }
+
+  // Verbatim endpoint passthrough (#1052): when the fetch interceptor preserved
+  // the client's original endpoint path (x-lore-upstream-path) AND we are a pure
+  // passthrough — same host (headerUpstream is the highest-priority base, so it
+  // equals effectiveUpstreamBase) and same wire protocol (no translation) — POST
+  // to the exact original endpoint instead of the reconstructed canonical path.
+  // This is what lets providers whose endpoint omits `/v1` (GitHub Copilot's
+  // `/chat/completions`) or uses a non-standard prefix work without an allowlist.
+  // No-ops for the standard `/v1/...` case (verbatim == reconstructed), and the
+  // protocol-equality guard excludes vertex/bedrock and any translated turn.
+  url = verbatimUpstreamUrl({
+    reconstructedUrl: url,
+    effectiveUpstreamBase,
+    headerUpstream,
+    upstreamPath: headerUpstreamPath,
+    effectiveProtocol,
+    ingressProtocol: req.protocol,
+  });
 
   // Apply user-supplied LORE_UPSTREAM_EXTRA_HEADERS as the final overlay so
   // corporate proxies, LiteLLM team-routing tokens, Cloudflare AI Gateway

--- a/packages/gateway/src/translate/openai.ts
+++ b/packages/gateway/src/translate/openai.ts
@@ -473,6 +473,42 @@ function buildOpenAIStreamResponse(resp: GatewayResponse): Response {
 // GatewayRequest → OpenAI upstream request
 // ---------------------------------------------------------------------------
 
+/**
+ * Hosts whose OpenAI-compatible Chat Completions endpoint is served WITHOUT the
+ * conventional `/v1` path segment. GitHub Copilot serves chat completions at
+ * `https://api.githubcopilot.com/chat/completions`; prepending `/v1` yields
+ * `404 page not found` (issue #1052). Keyed by hostname so it holds regardless
+ * of which routing tier produced the base URL.
+ *
+ * Foreground requests that come through the fetch interceptor forward verbatim
+ * to the client's original endpoint (see `verbatimUpstreamUrl`); this allowlist
+ * covers the paths the gateway must RECONSTRUCT from scratch — background worker
+ * requests (which have no original request) and any provider configured via
+ * `LORE_UPSTREAM_<PROVIDER>` with no preserved endpoint path.
+ */
+const OPENAI_ROOT_PATH_HOSTS: ReadonlySet<string> = new Set([
+  "api.githubcopilot.com",
+]);
+
+/**
+ * Build the OpenAI Chat Completions upstream URL for an upstream base.
+ *
+ * Most OpenAI-compatible providers serve at `<base>/v1/chat/completions`, so the
+ * route tables store a bare origin and the gateway appends `/v1/...`. Hosts in
+ * `OPENAI_ROOT_PATH_HOSTS` omit the `/v1` segment. Falls back to the `/v1` form
+ * when `base` cannot be parsed as a URL.
+ */
+export function buildOpenAIChatCompletionsUrl(base: string): string {
+  let hostname: string | null = null;
+  try {
+    hostname = new URL(base).hostname;
+  } catch {
+    hostname = null;
+  }
+  const prefix = hostname && OPENAI_ROOT_PATH_HOSTS.has(hostname) ? "" : "/v1";
+  return `${base}${prefix}/chat/completions`;
+}
+
 export function buildOpenAIUpstreamRequest(
   req: GatewayRequest,
   upstreamBase: string,
@@ -538,7 +574,7 @@ export function buildOpenAIUpstreamRequest(
   }
 
   return {
-    url: `${upstreamBase}/v1/chat/completions`,
+    url: buildOpenAIChatCompletionsUrl(upstreamBase),
     headers,
     body,
   };

--- a/packages/gateway/src/translate/types.ts
+++ b/packages/gateway/src/translate/types.ts
@@ -657,6 +657,7 @@ const GATEWAY_MANAGED_HEADERS = new Set([
   // Lore-specific (injected by fetch interceptor / plugin hooks)
   "x-lore-provider",
   "x-lore-upstream-url",
+  "x-lore-upstream-path",
   "x-lore-session-id",
   "x-lore-project",
   "x-lore-git-remote",

--- a/packages/gateway/test/github-copilot-url.e2e.test.ts
+++ b/packages/gateway/test/github-copilot-url.e2e.test.ts
@@ -1,0 +1,108 @@
+/**
+ * End-to-end wiring guard for #1052.
+ *
+ * Drives a real `POST /v1/chat/completions` through the full gateway pipeline
+ * (handleRequest → forwardToUpstream) and captures the exact URL the gateway
+ * forwards to upstream. This pins the BEHAVIOR — not just the pure helpers — so
+ * a revert of the `verbatimUpstreamUrl(...)` wiring in forwardToUpstream fails
+ * here even though the unit tests would still pass.
+ *
+ * Mechanism: `upstreamFetch` is mocked to capture its URL, and the upstream
+ * interceptor is overridden to invoke `makeRealRequest()` (whose closure holds
+ * the resolved url) so the mocked fetch runs and records the destination.
+ */
+import { describe, test, expect, afterEach, vi } from "vitest";
+
+vi.mock("../src/fetch", () => ({ upstreamFetch: vi.fn() }));
+
+import { upstreamFetch } from "../src/fetch";
+import type { Harness } from "./helpers/harness";
+import { createHarness } from "./helpers/harness";
+
+const mockFetch = vi.mocked(upstreamFetch);
+
+function openAIResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      id: "chatcmpl-x",
+      object: "chat.completion",
+      model: "gpt-4.1",
+      choices: [
+        {
+          index: 0,
+          message: { role: "assistant", content: "ok" },
+          finish_reason: "stop",
+        },
+      ],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+/** Send an OpenAI chat-completions request and return the captured upstream URL. */
+async function captureUpstreamUrl(
+  harness: Harness,
+  headers: Record<string, string>,
+): Promise<string> {
+  const { setUpstreamInterceptor } = await import("../src/pipeline");
+  // Replace the harness replay interceptor with one that performs the REAL
+  // (mocked) upstream call, so the resolved URL flows into mockFetch.
+  setUpstreamInterceptor(async (_body, _model, _stream, makeReal) =>
+    makeReal(),
+  );
+  mockFetch.mockReset();
+  mockFetch.mockResolvedValue(openAIResponse());
+
+  const res = await fetch(`${harness.baseURL}/v1/chat/completions`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: "Bearer gho_test",
+      "x-lore-project": "/tmp/copilot-e2e",
+      ...headers,
+    },
+    body: JSON.stringify({
+      model: "gpt-4.1",
+      stream: false,
+      messages: [{ role: "user", content: "hi" }],
+    }),
+  });
+  await res.text().catch(() => undefined);
+
+  expect(mockFetch).toHaveBeenCalled();
+  return String(mockFetch.mock.calls[0][0]);
+}
+
+describe("github-copilot upstream URL — full pipeline wiring (#1052)", () => {
+  let harness: Harness | undefined;
+
+  afterEach(async () => {
+    await harness?.teardown();
+    harness = undefined;
+  });
+
+  test("forwards verbatim to /chat/completions (no /v1) for github-copilot", async () => {
+    harness = await createHarness({ fixtures: [] });
+    const url = await captureUpstreamUrl(harness, {
+      "x-lore-provider": "github-copilot",
+      "x-lore-upstream-url": "https://api.githubcopilot.com",
+      "x-lore-upstream-path": "/chat/completions",
+    });
+    expect(url).toBe("https://api.githubcopilot.com/chat/completions");
+  });
+
+  test("preserves a non-/v1 prefix verbatim (Google /v1beta/openai/...)", async () => {
+    // Demonstrates verbatim's general value: the host-aware helper would
+    // reconstruct `/v1/chat/completions` here, but the preserved path wins.
+    harness = await createHarness({ fixtures: [] });
+    const url = await captureUpstreamUrl(harness, {
+      "x-lore-provider": "google",
+      "x-lore-upstream-url": "https://generativelanguage.googleapis.com",
+      "x-lore-upstream-path": "/v1beta/openai/chat/completions",
+    });
+    expect(url).toBe(
+      "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions",
+    );
+  });
+});

--- a/packages/gateway/test/github-copilot-url.test.ts
+++ b/packages/gateway/test/github-copilot-url.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Regression tests for issue #1052 — the `github-copilot` provider returned
+ * `404 page not found` because the gateway unconditionally prepended `/v1/` when
+ * forwarding upstream, but GitHub Copilot serves chat completions at the root
+ * (`/chat/completions`, no `/v1` segment).
+ *
+ * Two mechanisms cooperate:
+ *  1. `verbatimUpstreamUrl` — forwards foreground requests to the client's exact
+ *     original endpoint (preserved by the fetch interceptor) when not
+ *     translating/rerouting.
+ *  2. `buildOpenAIChatCompletionsUrl` — host-aware reconstruction for paths with
+ *     no original request (background workers / env-var providers).
+ */
+import { describe, test, expect } from "vitest";
+import { extractUpstreamPathHeader, verbatimUpstreamUrl } from "../src/config";
+import {
+  buildOpenAIChatCompletionsUrl,
+  buildOpenAIUpstreamRequest,
+} from "../src/translate/openai";
+import type { GatewayRequest } from "../src/translate/types";
+
+// ---------------------------------------------------------------------------
+// extractUpstreamPathHeader
+// ---------------------------------------------------------------------------
+
+describe("extractUpstreamPathHeader", () => {
+  test("returns undefined when header is absent", () => {
+    expect(extractUpstreamPathHeader({})).toBeUndefined();
+    expect(
+      extractUpstreamPathHeader({ "x-api-key": "sk-abc" }),
+    ).toBeUndefined();
+  });
+
+  test("accepts a bare /chat/completions path", () => {
+    expect(
+      extractUpstreamPathHeader({
+        "x-lore-upstream-path": "/chat/completions",
+      }),
+    ).toBe("/chat/completions");
+  });
+
+  test("accepts a prefixed /api/v1/chat/completions path", () => {
+    expect(
+      extractUpstreamPathHeader({
+        "x-lore-upstream-path": "/api/v1/chat/completions",
+      }),
+    ).toBe("/api/v1/chat/completions");
+  });
+
+  test("rejects non-absolute paths", () => {
+    expect(
+      extractUpstreamPathHeader({ "x-lore-upstream-path": "chat/completions" }),
+    ).toBeUndefined();
+  });
+
+  test("rejects protocol-relative //host (would imply a different host)", () => {
+    expect(
+      extractUpstreamPathHeader({ "x-lore-upstream-path": "//evil.com/x" }),
+    ).toBeUndefined();
+  });
+
+  test("rejects path traversal", () => {
+    expect(
+      extractUpstreamPathHeader({ "x-lore-upstream-path": "/a/../b" }),
+    ).toBeUndefined();
+  });
+
+  test("rejects whitespace", () => {
+    expect(
+      extractUpstreamPathHeader({ "x-lore-upstream-path": "/a b" }),
+    ).toBeUndefined();
+  });
+
+  test("rejects over-length values", () => {
+    expect(
+      extractUpstreamPathHeader({
+        "x-lore-upstream-path": `/${"a".repeat(600)}`,
+      }),
+    ).toBeUndefined();
+  });
+
+  test("strips control characters then validates", () => {
+    expect(
+      extractUpstreamPathHeader({
+        "x-lore-upstream-path": "/chat/completions\n",
+      }),
+    ).toBe("/chat/completions");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verbatimUpstreamUrl
+// ---------------------------------------------------------------------------
+
+describe("verbatimUpstreamUrl", () => {
+  const base = {
+    reconstructedUrl: "https://api.githubcopilot.com/v1/chat/completions",
+    effectiveUpstreamBase: "https://api.githubcopilot.com",
+    headerUpstream: "https://api.githubcopilot.com",
+    upstreamPath: "/chat/completions",
+    effectiveProtocol: "openai" as const,
+    ingressProtocol: "openai" as const,
+  };
+
+  test("forwards verbatim to Copilot's bare /chat/completions", () => {
+    expect(verbatimUpstreamUrl(base)).toBe(
+      "https://api.githubcopilot.com/chat/completions",
+    );
+  });
+
+  test("anchors at the ORIGIN so a base prefix is never doubled", () => {
+    // OpenRouter: base carries `/api`, and the full pathname already includes it.
+    expect(
+      verbatimUpstreamUrl({
+        reconstructedUrl: "https://openrouter.ai/api/v1/chat/completions",
+        effectiveUpstreamBase: "https://openrouter.ai/api",
+        headerUpstream: "https://openrouter.ai/api",
+        upstreamPath: "/api/v1/chat/completions",
+        effectiveProtocol: "openai",
+        ingressProtocol: "openai",
+      }),
+    ).toBe("https://openrouter.ai/api/v1/chat/completions");
+  });
+
+  test("standard /v1 path is unchanged (verbatim == reconstructed)", () => {
+    expect(
+      verbatimUpstreamUrl({
+        reconstructedUrl: "https://api.openai.com/v1/chat/completions",
+        effectiveUpstreamBase: "https://api.openai.com",
+        headerUpstream: "https://api.openai.com",
+        upstreamPath: "/v1/chat/completions",
+        effectiveProtocol: "openai",
+        ingressProtocol: "openai",
+      }),
+    ).toBe("https://api.openai.com/v1/chat/completions");
+  });
+
+  test("does NOT forward verbatim when translating protocols", () => {
+    // anthropic ingress → openai egress: the original path is for the wrong wire.
+    expect(
+      verbatimUpstreamUrl({
+        ...base,
+        effectiveProtocol: "openai",
+        ingressProtocol: "anthropic",
+        upstreamPath: "/v1/messages",
+      }),
+    ).toBe(base.reconstructedUrl);
+  });
+
+  test("never overrides a vertex turn", () => {
+    expect(
+      verbatimUpstreamUrl({
+        ...base,
+        effectiveProtocol: "vertex",
+        ingressProtocol: "vertex",
+      }),
+    ).toBe(base.reconstructedUrl);
+  });
+
+  test("reconstructs when there is no preserved path (worker/env-var)", () => {
+    expect(verbatimUpstreamUrl({ ...base, upstreamPath: undefined })).toBe(
+      base.reconstructedUrl,
+    );
+  });
+
+  test("reconstructs when there is no upstream-url header (rerouted)", () => {
+    expect(verbatimUpstreamUrl({ ...base, headerUpstream: undefined })).toBe(
+      base.reconstructedUrl,
+    );
+  });
+
+  test("reconstructs when the base is not a parseable URL", () => {
+    expect(
+      verbatimUpstreamUrl({ ...base, effectiveUpstreamBase: "not a url" }),
+    ).toBe(base.reconstructedUrl);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildOpenAIChatCompletionsUrl + buildOpenAIUpstreamRequest
+// ---------------------------------------------------------------------------
+
+describe("buildOpenAIChatCompletionsUrl", () => {
+  test("GitHub Copilot host omits the /v1 segment", () => {
+    expect(buildOpenAIChatCompletionsUrl("https://api.githubcopilot.com")).toBe(
+      "https://api.githubcopilot.com/chat/completions",
+    );
+  });
+
+  test("standard provider keeps the /v1 segment", () => {
+    expect(buildOpenAIChatCompletionsUrl("https://api.openai.com")).toBe(
+      "https://api.openai.com/v1/chat/completions",
+    );
+  });
+
+  test("provider base with a path prefix keeps /v1 appended", () => {
+    expect(buildOpenAIChatCompletionsUrl("https://api.groq.com/openai")).toBe(
+      "https://api.groq.com/openai/v1/chat/completions",
+    );
+  });
+
+  test("falls back to the /v1 form when the base is not a URL", () => {
+    expect(buildOpenAIChatCompletionsUrl("not a url")).toBe(
+      "not a url/v1/chat/completions",
+    );
+  });
+});
+
+describe("buildOpenAIUpstreamRequest — reconstructed URL is host-aware", () => {
+  function makeReq(): GatewayRequest {
+    return {
+      protocol: "openai",
+      model: "gpt-4",
+      stream: false,
+      maxTokens: 1000,
+      metadata: {
+        projectId: "test",
+        projectPath: "/test",
+        gitRemote: "test",
+        gitRoot: "/test",
+      },
+      system: "system prompt",
+      messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      tools: [],
+      rawHeaders: {},
+    };
+  }
+
+  test("github-copilot base → no /v1 (issue #1052)", () => {
+    expect(
+      buildOpenAIUpstreamRequest(makeReq(), "https://api.githubcopilot.com")
+        .url,
+    ).toBe("https://api.githubcopilot.com/chat/completions");
+  });
+
+  test("openai base → /v1/chat/completions", () => {
+    expect(
+      buildOpenAIUpstreamRequest(makeReq(), "https://api.openai.com").url,
+    ).toBe("https://api.openai.com/v1/chat/completions");
+  });
+});

--- a/packages/gateway/test/worker-github-copilot.test.ts
+++ b/packages/gateway/test/worker-github-copilot.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Issue #1052 — background worker requests routed to the `github-copilot`
+ * provider must target `https://api.githubcopilot.com/chat/completions` (NO
+ * `/v1` segment). Workers build prompts from scratch (no original request to
+ * forward verbatim), so the URL is reconstructed host-aware by
+ * `buildOpenAIChatCompletionsUrl`.
+ */
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("../src/fetch", () => ({ upstreamFetch: vi.fn() }));
+
+import { createGatewayLLMClient } from "../src/llm-adapter";
+import { upstreamFetch } from "../src/fetch";
+import { clearAllCosts } from "../src/cost-tracker";
+import { resetBackgroundLimiter } from "../src/background-limiter";
+
+const mockFetch = vi.mocked(upstreamFetch);
+
+const UPSTREAMS = {
+  anthropic: "https://api.anthropic.com",
+  openai: "https://api.openai.com",
+};
+
+function okResponse() {
+  return new Response(
+    JSON.stringify({
+      choices: [{ message: { content: "ok" } }],
+      model: "m",
+      usage: { prompt_tokens: 1, completion_tokens: 1 },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+describe("worker github-copilot URL (#1052)", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue(okResponse());
+  });
+  afterEach(() => {
+    mockFetch.mockReset();
+    clearAllCosts();
+    resetBackgroundLimiter();
+  });
+
+  test("forwards to /chat/completions with no /v1 prefix", async () => {
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      (_sid, providerID) =>
+        providerID === "github-copilot"
+          ? { scheme: "bearer", value: "gho_worker" }
+          : null,
+      { providerID: "github-copilot", modelID: "gpt-4.1" },
+    );
+
+    await client.prompt("system", "user", {
+      sessionID: "sess-copilot",
+      workerID: "lore-distill",
+      model: { providerID: "github-copilot", modelID: "gpt-4.1" },
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const url = String(mockFetch.mock.calls[0][0]);
+    expect(url).toBe("https://api.githubcopilot.com/chat/completions");
+    expect(url).not.toContain("/v1/chat/completions");
+  });
+});


### PR DESCRIPTION
Fixes #1052.

## Problem

GitHub Copilot's OpenAI-compatible API serves chat completions at
`https://api.githubcopilot.com/chat/completions` — **no `/v1` segment**. The
gateway unconditionally synthesized `${base}/v1/chat/completions` from the
protocol alone, so Copilot requests 404'd (`404 page not found`). The fetch
interceptor actually *had* the real endpoint at interception time but discarded
the path, forwarding only the **base** in `X-Lore-Upstream-URL`.

## Fix — preserve the real endpoint and forward verbatim

When we're a pure passthrough (same host, same wire protocol), forward to the
client's exact original endpoint instead of reconstructing a canonical `/v1/...`
path. Two cooperating mechanisms:

1. **Verbatim passthrough (foreground).** The fetch interceptor now sets
   `x-lore-upstream-path` to the client's full original pathname. In
   `forwardToUpstream`, `verbatimUpstreamUrl()` forwards to
   `origin(base) + path` when `headerUpstream` is present (no rerouting) **and**
   `effectiveProtocol === ingressProtocol` (no translation). This is general —
   it also fixes non-standard foreground paths like Google's
   `/v1beta/openai/...` and Z.AI's `/v4/...`.
2. **Host-aware reconstruction (worker / fallback).** Background workers build
   prompts from scratch (no original request), so the worker URL is
   reconstructed by `buildOpenAIChatCompletionsUrl()`, which drops `/v1` for
   `api.githubcopilot.com`.

### Key correctness detail
The interceptor stores the **full** pathname and the gateway anchors at the base
**origin** (`new URL(base).origin + path`), never `base + path` — so prefixed
bases (OpenRouter `/api`, Fireworks `/inference`) reproduce the original URL
exactly with no doubling. The verbatim guard auto-excludes `vertex` (distinct
`:rawPredict` URL) and bedrock-mantle (no `headerUpstream`), and any translated
turn.

### Out of scope (verified)
- Cache-warmer is Anthropic-only (`/v1/messages`) — never warms Copilot.
- `batch-queue` `/v1/chat/completions` is the OpenAI Batch spec field, not a
  forwarding URL.

## Tests
- `fetch-interceptor-install.test.ts`: `x-lore-upstream-path` set to the full
  original pathname (Copilot bare path, standard `/v1`, prefixed `/api/v1`, Codex).
- `github-copilot-url.test.ts`: `extractUpstreamPathHeader`,
  `verbatimUpstreamUrl` (origin-anchoring, translation/vertex/no-header/no-path
  guards), `buildOpenAIChatCompletionsUrl`, and the foreground builder.
- `worker-github-copilot.test.ts`: worker URL drops `/v1` via the real
  `createGatewayLLMClient` path.
- `github-copilot-url.e2e.test.ts`: full-pipeline wiring guard — captures the
  actual upstream URL (Copilot + Google verbatim).

All four bug surfaces were mutation-verified red→green (reverting each fix makes
the corresponding test fail). Full `typecheck`, `lint` (changed files), and the
core (2293) + gateway (2371) + opencode/pi (56) suites pass.