### PR TITLE
perf(core): chunk unbounded IN in offloaded alias-batch helpers (#1022)

### DIFF
--- a/packages/core/src/entities.ts
+++ b/packages/core/src/entities.ts
@@ -879,13 +879,26 @@ async function batchLoadAliasesOffloaded(
   if (!entityIds.length) return map;
   // Initialize empty arrays for all IDs (mirrors batchLoadAliases)
   for (const id of entityIds) map.set(id, []);
-  const placeholders = entityIds.map(() => "?").join(",");
-  const allAliases = (await offloadAll(
-    `SELECT * FROM entity_aliases WHERE entity_id IN (${placeholders}) ORDER BY alias_type, alias_value`,
-    entityIds,
-  )) as EntityAlias[];
-  for (const a of allAliases) {
-    map.get(a.entity_id)?.push(a);
+  // Chunk the IN list to stay under SQLite's bound-variable ceiling (mirrors the
+  // sync batchLoadAliases). Chunks partition entityIds, so every alias of a given
+  // entity lands in exactly one chunk — per-entity ordering from the per-chunk
+  // ORDER BY is preserved. One offloadAll round-trip per chunk.
+  const CHUNK = 900;
+  const chunks: Promise<unknown[]>[] = [];
+  for (let i = 0; i < entityIds.length; i += CHUNK) {
+    const chunk = entityIds.slice(i, i + CHUNK);
+    const placeholders = chunk.map(() => "?").join(",");
+    chunks.push(
+      offloadAll(
+        `SELECT * FROM entity_aliases WHERE entity_id IN (${placeholders}) ORDER BY alias_type, alias_value`,
+        chunk,
+      ),
+    );
+  }
+  for (const rows of await Promise.all(chunks)) {
+    for (const a of rows as EntityAlias[]) {
+      map.get(a.entity_id)?.push(a);
+    }
   }
   return map;
 }
@@ -911,11 +924,23 @@ export async function getManyWithAliasesOffloaded(
 ): Promise<Map<string, EntityWithAliases>> {
   const map = new Map<string, EntityWithAliases>();
   if (!ids.length) return map;
-  const placeholders = ids.map(() => "?").join(",");
-  const rows = (await offloadAll(
-    `SELECT ${ENTITY_COLS} FROM entities WHERE id IN (${placeholders})`,
-    ids,
-  )) as Entity[];
+  // Chunk the IN list at 900 (mirrors batchLoadAliasesOffloaded). Chunks
+  // partition ids, so each entity row comes back from exactly one chunk; the
+  // unioned set is order-independent here (callers key by id). One offloadAll
+  // round-trip per chunk.
+  const CHUNK = 900;
+  const chunks: Promise<unknown[]>[] = [];
+  for (let i = 0; i < ids.length; i += CHUNK) {
+    const chunk = ids.slice(i, i + CHUNK);
+    const placeholders = chunk.map(() => "?").join(",");
+    chunks.push(
+      offloadAll(
+        `SELECT ${ENTITY_COLS} FROM entities WHERE id IN (${placeholders})`,
+        chunk,
+      ),
+    );
+  }
+  const rows = (await Promise.all(chunks)).flat() as Entity[];
   for (const e of await withAliasesOffloaded(rows)) {
     map.set(e.id, e);
   }

--- a/packages/core/test/entities-offloaded-chunk.test.ts
+++ b/packages/core/test/entities-offloaded-chunk.test.ts
@@ -1,0 +1,153 @@
+import { EventEmitter } from "node:events";
+import { uuidv7 } from "uuidv7";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { db, ensureProject } from "../src/db";
+import { getManyWithAliasesOffloaded } from "../src/entities";
+import { runReadJob } from "../src/read-job";
+import {
+  _resetVectorPoolForTest,
+  _setTestVectorWorkerFactory,
+} from "../src/vector-pool";
+import type {
+  VectorWorkerInbound,
+  VectorWorkerInitData,
+} from "../src/vector-worker-types";
+
+// #1022: the offloaded alias-batch helpers (batchLoadAliasesOffloaded /
+// getManyWithAliasesOffloaded) built a single unbounded `IN (...)` over every
+// id, unlike their sync siblings which chunk at 900. SQLite's bound-variable
+// ceiling is 32766, so the bug is latent at small sizes — these tests assert the
+// chunking *behaviour* (no read job ever binds more than 900 params), which is
+// what the unbounded mutation violates. A recording read-worker captures every
+// dispatched read job's bind-param count and executes it against the real DB so
+// correctness is checked in the same pass.
+
+const CHUNK = 900;
+
+/** Read-worker fake: records every dispatched read spec, then answers it by
+ *  running the job against the live in-process DB. */
+class RecordingReadWorker extends EventEmitter {
+  static specs: Array<{ sql: string; params: unknown[] }> = [];
+  unref(): void {}
+  postMessage(msg: VectorWorkerInbound): void {
+    if (msg.type === "read") {
+      RecordingReadWorker.specs.push({
+        sql: msg.spec.sql,
+        params: msg.spec.params,
+      });
+      const rows = runReadJob(db(), msg.spec);
+      this.emit("message", { type: "read-result", id: msg.id, rows });
+    }
+  }
+  terminate(): Promise<number> {
+    this.emit("exit", 0);
+    return Promise.resolve(0);
+  }
+}
+
+function installRecordingFactory(): void {
+  _setTestVectorWorkerFactory(
+    (() => new RecordingReadWorker()) as unknown as (
+      d: VectorWorkerInitData,
+    ) => never,
+  );
+}
+
+const PROJECT = "/test/entities-offloaded-chunk";
+
+beforeEach(() => {
+  RecordingReadWorker.specs = [];
+  _resetVectorPoolForTest();
+  installRecordingFactory();
+  const pid = ensureProject(PROJECT);
+  db().query("DELETE FROM entities WHERE project_id = ?").run(pid);
+});
+
+afterEach(() => {
+  _setTestVectorWorkerFactory(null);
+  _resetVectorPoolForTest();
+});
+
+/** Insert `n` entities (every other one carrying a single alias) in one
+ *  transaction. Returns the ordered list of inserted ids. */
+function seedEntities(n: number): string[] {
+  const pid = ensureProject(PROJECT);
+  const ids: string[] = [];
+  const now = Date.now();
+  const database = db();
+  database.query("BEGIN").run();
+  try {
+    for (let i = 0; i < n; i++) {
+      const id = uuidv7();
+      ids.push(id);
+      database
+        .query(
+          "INSERT INTO entities (id, project_id, entity_type, canonical_name, metadata, cross_project, created_at, updated_at) VALUES (?, ?, 'tool', ?, '{}', 0, ?, ?)",
+        )
+        .run(id, pid, `Entity ${i}`, now, now);
+      if (i % 2 === 0) {
+        database
+          .query(
+            "INSERT INTO entity_aliases (id, entity_id, alias_type, alias_value, source, created_at) VALUES (?, ?, 'name', ?, 'test', ?)",
+          )
+          .run(uuidv7(), id, `alias-${id}`, now);
+      }
+    }
+    database.query("COMMIT").run();
+  } catch (e) {
+    database.query("ROLLBACK").run();
+    throw e;
+  }
+  return ids;
+}
+
+describe("getManyWithAliasesOffloaded chunks unbounded IN (#1022)", () => {
+  it("hydrates every entity + alias across the 900 boundary with no oversized bind list", async () => {
+    // 1801 ids → ceil(1801/900) = 3 chunks for the entities scan AND 3 for the
+    // alias scan (every id has a live row, so the alias load sees all 1801).
+    const ids = seedEntities(1801);
+
+    const map = await getManyWithAliasesOffloaded(ids);
+
+    // Correctness: all rows hydrated; aliases attached to the even-index entities.
+    expect(map.size).toBe(1801);
+    let withAlias = 0;
+    for (const id of ids) {
+      const ent = map.get(id);
+      expect(ent).toBeDefined();
+      if (ent && ent.aliases.length > 0) {
+        withAlias++;
+        expect(ent.aliases[0].alias_value).toBe(`alias-${id}`);
+      }
+    }
+    expect(withAlias).toBe(Math.ceil(1801 / 2)); // 901 even-index entities
+
+    // Chunking invariant: NO dispatched read job may bind more than CHUNK
+    // params. The unbounded mutation binds all 1801 at once → this fails.
+    expect(RecordingReadWorker.specs.length).toBeGreaterThan(0);
+    for (const spec of RecordingReadWorker.specs) {
+      expect(spec.params.length).toBeLessThanOrEqual(CHUNK);
+    }
+
+    // Both scans must actually have split into multiple chunks.
+    const entityScans = RecordingReadWorker.specs.filter((s) =>
+      /FROM entities WHERE id IN/.test(s.sql),
+    );
+    const aliasScans = RecordingReadWorker.specs.filter((s) =>
+      /FROM entity_aliases WHERE entity_id IN/.test(s.sql),
+    );
+    expect(entityScans.length).toBe(Math.ceil(1801 / CHUNK)); // 3
+    expect(aliasScans.length).toBe(Math.ceil(1801 / CHUNK)); // 3
+
+    // Chunks must partition the id set: union of entity-scan params === all ids.
+    const scanned = new Set(entityScans.flatMap((s) => s.params as string[]));
+    expect(scanned.size).toBe(1801);
+    for (const id of ids) expect(scanned.has(id)).toBe(true);
+  });
+
+  it("returns an empty map without dispatching any read for no ids", async () => {
+    const map = await getManyWithAliasesOffloaded([]);
+    expect(map.size).toBe(0);
+    expect(RecordingReadWorker.specs.length).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #1022.

## Problem

`batchLoadAliasesOffloaded()` (`entities.ts`) and `getManyWithAliasesOffloaded()` built a single unbounded `IN (${placeholders})` over every `entity_id`/`id`. Their **sync** siblings (`batchLoadAliases`, `knowledgeRefCounts`, etc.) already chunk at 900 to stay under SQLite's bound-variable ceiling (32766). Once the offloaded list crossed that ceiling — reachable via recall's entity vector hydration — the query would throw `too many SQL variables`. Latent today (the recall path is `limit`-bounded) but a correctness landmine, flagged in the #1018/#1020 Seer review.

## Fix

Chunk `entityIds`/`ids` at 900 in both helpers, one `offloadAll` round-trip per chunk (dispatched together via `Promise.all`), aggregating the results. Chunks partition the id set, so:
- every alias of a given entity lands in exactly one chunk → per-entity `ORDER BY` ordering is preserved;
- entity rows are unioned and keyed by id (order-independent for callers).

Mirrors the existing sync chunking exactly.

## Tests

`packages/core/test/entities-offloaded-chunk.test.ts`: a recording read-worker (installed via the `_setTestVectorWorkerFactory` seam) captures every dispatched read job's bind-param count and answers it against the live DB. Drives 1801 ids through `getManyWithAliasesOffloaded` and asserts:
- all 1801 entities hydrate with their aliases (correctness);
- **no** read job binds more than 900 params (the unbounded mutation binds all 1801 → fails);
- both the `entities` scan and the `entity_aliases` scan split into 3 chunks and partition the id set.

Red-green verified by mutation: reverting either helper to the single unbounded `IN` fails the bind-count assertion. Full `@loreai/core` suite green (2300 passed).

Refs #1010, #1018, #1020