### PR TITLE
perf(core): batch action-tag session counts into one distillations scan (#1023)

### DIFF
--- a/packages/core/src/distillation.ts
+++ b/packages/core/src/distillation.ts
@@ -1203,26 +1203,47 @@ async function distillSegment(input: {
     // Action tag counting: extract tags from this segment, then count
     // how many distinct sessions contain the same tag across the project.
     // When a tag appears in 3+ sessions, it's a strong behavioral signal.
-    const tags = extractActionTags(result.observations);
-    if (tags.length > 0) {
+    // Only mint preferences for curated tags we have a deliberate canonical
+    // title for. `tagToTitle` title-cases any string, so without this gate a
+    // spurious regex match becomes a garbage entry (e.g. "A Z" from a literal
+    // `[a-z]` range) that pollutes system[1] and busts the prompt cache when
+    // later deleted by consolidation (ses_14b9bf3d… incident).
+    const knownTags = extractActionTags(result.observations).filter(
+      isKnownActionTag,
+    );
+    if (knownTags.length > 0) {
       const pid = ensureProject(input.projectPath);
-      for (const tag of tags) {
-        // Only mint preferences for curated tags we have a deliberate canonical
-        // title for. `tagToTitle` title-cases any string, so without this gate a
-        // spurious regex match becomes a garbage entry (e.g. "A Z" from a literal
-        // `[a-z]` range) that pollutes system[1] and busts the prompt cache when
-        // later deleted by consolidation (ses_14b9bf3d… incident).
-        if (!isKnownActionTag(tag)) continue;
-        try {
-          const tagPattern = `%[${tag}]%`;
-          const rows = db()
-            .query(
-              `SELECT COUNT(DISTINCT session_id) as cnt FROM distillations
-               WHERE project_id = ? AND observations LIKE ?`,
-            )
-            .get(pid, tagPattern) as { cnt: number } | null;
-          const sessionCount = rows?.cnt ?? 0;
-          if (sessionCount >= 3) {
+      // #1023: compute every tag's distinct-session count in ONE scan instead
+      // of one leading-wildcard `observations LIKE` full-scan per tag. The
+      // per-tag `COUNT(DISTINCT CASE WHEN … THEN session_id END)` columns are
+      // evaluated in a single pass and are mutually independent (a NULL CASE
+      // result is ignored by COUNT(DISTINCT …)), so each cN matches what the
+      // old per-tag query returned. (The `distillations` table is NOT under the
+      // knowledge append-only freeze — #1016 — so this scan is safe to batch;
+      // the per-survivor `knowledge_current` LOWER(title) lookup below stays
+      // per-tag and is deferred until the freeze lifts.)
+      let counts: Record<string, number> | null = null;
+      try {
+        const countCols = knownTags
+          .map(
+            (_, i) =>
+              `COUNT(DISTINCT CASE WHEN observations LIKE ? THEN session_id END) AS c${i}`,
+          )
+          .join(", ");
+        const patterns = knownTags.map((tag) => `%[${tag}]%`);
+        counts = db()
+          .query(`SELECT ${countCols} FROM distillations WHERE project_id = ?`)
+          .get(...patterns, pid) as Record<string, number> | null;
+      } catch {
+        // Count scan failed — skip minting this run.
+        counts = null;
+      }
+      if (counts) {
+        for (let i = 0; i < knownTags.length; i++) {
+          const tag = knownTags[i];
+          const sessionCount = (counts[`c${i}`] as number | undefined) ?? 0;
+          if (sessionCount < 3) continue;
+          try {
             const prefTitle = tagToTitle(tag);
             // Pre-check: same dedup-silent return issue as the gotcha branch
             // above — ltm.create() returns the existing ID on dedup but
@@ -1253,9 +1274,9 @@ async function distillSegment(input: {
             log.info(
               `action tag '${tag}' found in ${sessionCount} sessions — created preference`,
             );
+          } catch {
+            // Dedup guard or DB error — swallow
           }
-        } catch {
-          // Dedup guard or DB error — swallow
         }
       }
     }

--- a/packages/core/test/distillation-action-tags.test.ts
+++ b/packages/core/test/distillation-action-tags.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { db, ensureProject } from "../src/db";
+import { run } from "../src/distillation";
+import { registerSink, type LogSink } from "../src/log";
+import type { LLMClient } from "../src/types";
+
+// #1023: the action-tag preference-minting loop ran one leading-wildcard
+// `observations LIKE '%[tag]%'` COUNT(DISTINCT session_id) full scan of
+// `distillations` PER known tag. The fix collapses those K scans into ONE pass
+// of mutually-independent `COUNT(DISTINCT CASE WHEN … THEN session_id END)`
+// columns. These tests pin (a) the single-pass behaviour via the DB query
+// tracer and (b) that per-tag counts stay independent and the 3-session
+// threshold holds.
+
+const PROJECT = "/test/distillation/action-tags";
+const RUN_SESSION = "action-tags-run-sess";
+// Deterministic base timestamp so segment detection yields one segment.
+const T = new Date("2026-05-01T10:00:00Z").getTime();
+
+const passthroughSink: LogSink = {
+  info() {},
+  warn() {},
+  error() {},
+  captureException() {},
+};
+
+/** Sink that records every traced SQL string (get/run/all execution). */
+function recordingSink(calls: string[]): LogSink {
+  return {
+    ...passthroughSink,
+    withDbSpan<T>(sql: string, fn: () => T): T {
+      calls.push(sql);
+      return fn();
+    },
+  };
+}
+
+function insertTemporalMessages(n: number, tokensEach: number): string[] {
+  const pid = ensureProject(PROJECT);
+  const ids: string[] = [];
+  const content = "x".repeat(tokensEach * 3);
+  for (let i = 0; i < n; i++) {
+    const id = `at-msg-${crypto.randomUUID()}`;
+    ids.push(id);
+    db()
+      .query(
+        `INSERT INTO temporal_messages (id, project_id, session_id, role, content, tokens, distilled, created_at, metadata)
+         VALUES (?, ?, ?, 'user', ?, ?, 0, ?, '{}')`,
+      )
+      .run(id, pid, RUN_SESSION, content, tokensEach, T + i * 1000);
+  }
+  return ids;
+}
+
+/** Seed a gen-0 distillation row carrying `observations` for a given session. */
+function seedDistillation(sessionID: string, observations: string): void {
+  const pid = ensureProject(PROJECT);
+  db()
+    .query(
+      `INSERT INTO distillations (id, project_id, session_id, narrative, facts, observations, source_ids, generation, token_count, archived, created_at)
+       VALUES (?, ?, ?, '', '[]', ?, '[]', 0, ?, 0, ?)`,
+    )
+    .run(
+      crypto.randomUUID(),
+      pid,
+      sessionID,
+      observations,
+      Math.ceil(observations.length / 3),
+      Date.now(),
+    );
+}
+
+function makeStubLLM(response: string): LLMClient & {
+  prompts: Array<{ system: string; user: string }>;
+} {
+  const prompts: Array<{ system: string; user: string }> = [];
+  return {
+    prompts,
+    prompt: async (system: string, user: string) => {
+      prompts.push({ system, user });
+      return response;
+    },
+  };
+}
+
+function prefExists(title: string): boolean {
+  const pid = ensureProject(PROJECT);
+  const row = db()
+    .query(
+      `SELECT id FROM knowledge_current
+       WHERE project_id = ? AND LOWER(title) = LOWER(?)
+       AND category = 'preference' AND confidence > 0 LIMIT 1`,
+    )
+    .get(pid, title) as { id: string } | null;
+  return row != null;
+}
+
+beforeEach(() => {
+  const pid = ensureProject(PROJECT);
+  db().query("DELETE FROM temporal_messages WHERE project_id = ?").run(pid);
+  db().query("DELETE FROM distillations WHERE project_id = ?").run(pid);
+  db().query("DELETE FROM knowledge WHERE project_id = ?").run(pid);
+});
+
+afterEach(() => {
+  // Reset to a tracer-less sink so other tests see pass-through behavior.
+  registerSink(passthroughSink);
+});
+
+describe("action-tag minting batches per-tag session counts (#1023)", () => {
+  test("counts every tag in a single distillations scan, with independent per-tag thresholds", async () => {
+    // requested-tests: present in 2 OTHER sessions; enforced-workflow: 1 other.
+    // The run stores this segment's distillation (carrying BOTH tags) under
+    // RUN_SESSION → requested-tests reaches 3 distinct sessions (mints),
+    // enforced-workflow reaches 2 (does NOT mint).
+    seedDistillation(
+      "sess-A",
+      "did things [requested-tests] [enforced-workflow]",
+    );
+    seedDistillation("sess-B", "more things [requested-tests]");
+
+    insertTemporalMessages(6, 200);
+    const observations =
+      "user behaviour this segment [requested-tests] and [enforced-workflow] noted";
+    const llm = makeStubLLM(`<observations>\n${observations}\n</observations>`);
+
+    // Record SQL only for the run() under test.
+    const calls: string[] = [];
+    registerSink(recordingSink(calls));
+
+    await run({
+      llm,
+      projectPath: PROJECT,
+      sessionID: RUN_SESSION,
+      force: true,
+    });
+
+    // Single-pass invariant: the per-tag count scan over `distillations` (the
+    // one carrying `observations LIKE`) runs exactly ONCE, regardless of how
+    // many known tags the segment had. The old per-tag loop ran it once per
+    // tag (here: 2×) → this assertion fails under that mutation.
+    const countScans = calls.filter(
+      (sql) => /FROM distillations/.test(sql) && /observations LIKE/.test(sql),
+    );
+    expect(countScans.length).toBe(1);
+
+    // Correctness: independent per-tag thresholds.
+    expect(prefExists("Always write tests alongside implementation")).toBe(
+      true,
+    );
+    expect(
+      prefExists("Follow the established git workflow (branch, PR, review)"),
+    ).toBe(false);
+  });
+
+  test("a tag below the 3-session threshold is not minted", async () => {
+    // requested-tests in only 1 other session; +this run = 2 < 3.
+    seedDistillation("sess-A", "did things [requested-tests]");
+
+    insertTemporalMessages(6, 200);
+    const llm = makeStubLLM(
+      "<observations>\nthis run [requested-tests] only\n</observations>",
+    );
+
+    await run({
+      llm,
+      projectPath: PROJECT,
+      sessionID: RUN_SESSION,
+      force: true,
+    });
+
+    expect(prefExists("Always write tests alongside implementation")).toBe(
+      false,
+    );
+  });
+});


### PR DESCRIPTION
Partially addresses #1023 (the freeze-independent half).

## Problem

The action-tag preference-minting loop in `distillation.run()` ran, **per known action tag**, a `SELECT COUNT(DISTINCT session_id) … WHERE project_id = ? AND observations LIKE '%[tag]%'` over `distillations`. The leading-wildcard `LIKE` is unindexable, so each tag triggered a full scan — K full scans per distill run, on a hot background path with no Sentry span (found via static analysis, #1010 audit).

## Fix

Collapse the K scans into **one** pass: a single `SELECT` over `distillations WHERE project_id = ?` with one `COUNT(DISTINCT CASE WHEN observations LIKE ? THEN session_id END) AS cN` column per known tag. `COUNT(DISTINCT …)` ignores the `NULL` a non-matching `CASE` yields, so each `cN` equals exactly what the old per-tag query returned. Same `≥ 3`-session threshold, same mint/skip behaviour.

### Deferred (freeze)

The per-survivor `knowledge_current` `LOWER(title)` dedup lookup stays per-qualifying-tag — that's the same dedup-guard SELECT pattern blocked by the knowledge append-only refactor freeze (#1016/#823), and it only runs for tags that already cleared the ≥3 threshold (rare). `distillations` is **not** under that freeze, so the LIKE-scan half is safe to batch now. Issue stays open, scope narrowed to the deferred half.

## Tests

`packages/core/test/distillation-action-tags.test.ts`, driven through `run()` with a stub LLM and the `registerSink`/`withDbSpan` DB query tracer:
- **Single-pass**: with 2 known tags in the segment, the count scan over `distillations` (the one carrying `observations LIKE`) executes **exactly once**. Reverting to the per-tag loop makes it 2 → fails.
- **Per-tag independence + threshold**: `requested-tests` (3 distinct sessions) mints its preference; `enforced-workflow` (2 sessions) does not. Collapsing the per-tag counts to a shared column makes `enforced-workflow` mint → fails.

Red-green verified by mutation on both axes. Full `@loreai/core` suite green (2300 passed).

Refs #1010, #1016