### PR TITLE
fix(core): make temporal.prune resilient to db()-swap missing-table race (#1001)

### DIFF
--- a/packages/core/src/temporal.ts
+++ b/packages/core/src/temporal.ts
@@ -2,6 +2,7 @@ import { db, ensureProject } from "./db";
 import { runRelaxedSearch, runRelaxedSearchAsync } from "./search";
 import { offloadAllOrTimeout, READ_JOB_TIMED_OUT } from "./read-offload";
 import { sanitizeSurrogates } from "./markdown";
+import * as log from "./log";
 import * as embedding from "./embedding";
 import {
   classifyToolError,
@@ -684,6 +685,15 @@ export type PruneResult = {
  * until under the cap.
  *
  * Invariant: undistilled messages (distilled=0) are NEVER deleted by either pass.
+ *
+ * Resilience (#1001): the active `db()` connection is reset/rebuilt several
+ * times per process run (overflow-recovery / split / magnet maintenance) and an
+ * idle prune can race that window, observing a connection where a table is
+ * momentarily absent (`SQLiteError: no such table: distillations`). Each pass is
+ * therefore wrapped so a *missing-object* error is a no-op for that tick (the
+ * next idle tick reruns it) instead of aborting the remaining passes. Any other
+ * error still propagates to the caller. Root-causing/serializing the swap itself
+ * and recovering missing base tables are tracked follow-ups.
  */
 export function prune(input: {
   projectPath: string;
@@ -697,71 +707,106 @@ export function prune(input: {
   // Pass 1: TTL — delete distilled messages older than the retention window.
   // Note: result.changes is inflated by FTS trigger side-effects, so we count
   // eligible rows before deletion to get the accurate number deleted.
-  const ttlEligible = (
-    database
-      .query(
-        "SELECT COUNT(*) as c FROM temporal_messages WHERE project_id = ? AND distilled = 1 AND created_at < ?",
-      )
-      .get(pid, cutoff) as { c: number }
-  ).c;
-  if (ttlEligible > 0) {
-    database
-      .query(
-        "DELETE FROM temporal_messages WHERE project_id = ? AND distilled = 1 AND created_at < ?",
-      )
-      .run(pid, cutoff);
+  let ttlDeleted = 0;
+  try {
+    const ttlEligible = (
+      database
+        .query(
+          "SELECT COUNT(*) as c FROM temporal_messages WHERE project_id = ? AND distilled = 1 AND created_at < ?",
+        )
+        .get(pid, cutoff) as { c: number }
+    ).c;
+    if (ttlEligible > 0) {
+      database
+        .query(
+          "DELETE FROM temporal_messages WHERE project_id = ? AND distilled = 1 AND created_at < ?",
+        )
+        .run(pid, cutoff);
+    }
+    ttlDeleted = ttlEligible;
+  } catch (e) {
+    if (!isMissingObjectError(e)) throw e;
+    log.info(
+      "temporal.prune Pass 1 (TTL) skipped — object missing during db maintenance window (transient):",
+      e,
+    );
   }
-  const ttlDeleted = ttlEligible;
 
   // Pass 2: Size cap — check if total storage for this project exceeds the
   // limit and if so, evict the oldest distilled messages until under the cap.
-  const maxBytes = input.maxStorageMB * 1024 * 1024;
-  const totalBytes =
-    (
-      database
-        .query(
-          "SELECT SUM(LENGTH(content)) as b FROM temporal_messages WHERE project_id = ?",
-        )
-        .get(pid) as { b: number | null }
-    ).b ?? 0;
-
   let capDeleted = 0;
-  if (totalBytes > maxBytes) {
-    // Collect oldest distilled messages until we've accounted for enough bytes
-    // to drop below the cap. Delete them in a single batch.
-    const candidates = database
-      .query(
-        "SELECT id, LENGTH(content) as size FROM temporal_messages WHERE project_id = ? AND distilled = 1 ORDER BY created_at ASC",
-      )
-      .all(pid) as { id: string; size: number }[];
+  try {
+    const maxBytes = input.maxStorageMB * 1024 * 1024;
+    const totalBytes =
+      (
+        database
+          .query(
+            "SELECT SUM(LENGTH(content)) as b FROM temporal_messages WHERE project_id = ?",
+          )
+          .get(pid) as { b: number | null }
+      ).b ?? 0;
 
-    const toDelete: string[] = [];
-    let freed = 0;
-    const excess = totalBytes - maxBytes;
-    for (const row of candidates) {
-      if (freed >= excess) break;
-      toDelete.push(row.id);
-      freed += row.size;
-    }
+    if (totalBytes > maxBytes) {
+      // Collect oldest distilled messages until we've accounted for enough bytes
+      // to drop below the cap. Delete them in a single batch.
+      const candidates = database
+        .query(
+          "SELECT id, LENGTH(content) as size FROM temporal_messages WHERE project_id = ? AND distilled = 1 ORDER BY created_at ASC",
+        )
+        .all(pid) as { id: string; size: number }[];
 
-    if (toDelete.length) {
-      const placeholders = toDelete.map(() => "?").join(",");
-      database
-        .query(`DELETE FROM temporal_messages WHERE id IN (${placeholders})`)
-        .run(...toDelete);
-      // toDelete.length is the accurate count — result.changes is inflated by FTS triggers.
-      capDeleted = toDelete.length;
+      const toDelete: string[] = [];
+      let freed = 0;
+      const excess = totalBytes - maxBytes;
+      for (const row of candidates) {
+        if (freed >= excess) break;
+        toDelete.push(row.id);
+        freed += row.size;
+      }
+
+      if (toDelete.length) {
+        const placeholders = toDelete.map(() => "?").join(",");
+        database
+          .query(`DELETE FROM temporal_messages WHERE id IN (${placeholders})`)
+          .run(...toDelete);
+        // toDelete.length is the accurate count — result.changes is inflated by FTS triggers.
+        capDeleted = toDelete.length;
+      }
     }
+  } catch (e) {
+    if (!isMissingObjectError(e)) throw e;
+    log.info(
+      "temporal.prune Pass 2 (size cap) skipped — object missing during db maintenance window (transient):",
+      e,
+    );
   }
 
   // Pass 3: Prune archived distillations older than the retention window.
   // Archived gen-0 distillations are kept for recall search but don't need
   // to live forever — they follow the same retention policy as temporal messages.
-  database
-    .query(
-      "DELETE FROM distillations WHERE project_id = ? AND archived = 1 AND created_at < ?",
-    )
-    .run(pid, cutoff);
+  try {
+    database
+      .query(
+        "DELETE FROM distillations WHERE project_id = ? AND archived = 1 AND created_at < ?",
+      )
+      .run(pid, cutoff);
+  } catch (e) {
+    if (!isMissingObjectError(e)) throw e;
+    log.info(
+      "temporal.prune Pass 3 (archived distillations) skipped — object missing during db maintenance window (transient):",
+      e,
+    );
+  }
 
   return { ttlDeleted, capDeleted };
+}
+
+/**
+ * True when a thrown DB error is a transient missing-object error (`no such
+ * table` / `no such column`), the symptom of racing a `db()` reset/rebuild
+ * maintenance window (#1001). Such errors are swallowed per-pass in `prune()`;
+ * everything else propagates.
+ */
+function isMissingObjectError(err: unknown): boolean {
+  return err instanceof Error && /no such (table|column)/i.test(err.message);
 }

--- a/packages/core/src/temporal.ts
+++ b/packages/core/src/temporal.ts
@@ -689,20 +689,41 @@ export type PruneResult = {
  * Resilience (#1001): the active `db()` connection is reset/rebuilt several
  * times per process run (overflow-recovery / split / magnet maintenance) and an
  * idle prune can race that window, observing a connection where a table is
- * momentarily absent (`SQLiteError: no such table: distillations`). Each pass is
- * therefore wrapped so a *missing-object* error is a no-op for that tick (the
- * next idle tick reruns it) instead of aborting the remaining passes. Any other
- * error still propagates to the caller. Root-causing/serializing the swap itself
- * and recovering missing base tables are tracked follow-ups.
+ * momentarily absent (`SQLiteError: no such table: distillations`). The
+ * connection/project setup and each pass are therefore wrapped so a
+ * *missing-object* error is a no-op for that tick (the next idle tick reruns it)
+ * instead of aborting the remaining passes. Any other error still propagates to
+ * the caller. A *persistent* run of such skips (>= MISSING_OBJECT_ESCALATE_TICKS
+ * consecutive ticks) escalates from info to warn, since a sustained miss points
+ * at a real schema problem rather than a transient swap. Root-causing/serializing
+ * the swap itself and recovering missing base tables are tracked follow-ups.
  */
 export function prune(input: {
   projectPath: string;
   retentionDays: number;
   maxStorageMB: number;
 }): PruneResult {
-  const database = db();
-  const pid = ensureProject(input.projectPath);
+  // Resolving the connection and project row can itself race the swap window
+  // (e.g. `no such table: projects` from ensureProject's lookup); treat that the
+  // same as a per-pass miss — skip this tick and let the next one retry (#1001).
+  let database: ReturnType<typeof db>;
+  let pid: string;
+  try {
+    database = db();
+    pid = ensureProject(input.projectPath);
+  } catch (e) {
+    if (!isMissingObjectError(e)) throw e;
+    log.info(
+      "temporal.prune setup (db/ensureProject) skipped — object missing during db maintenance window (transient):",
+      e,
+    );
+    noteMissingObjectTick();
+    return { ttlDeleted: 0, capDeleted: 0 };
+  }
   const cutoff = Date.now() - input.retentionDays * 24 * 60 * 60 * 1000;
+  // Tracks whether any pass skipped on a missing object this tick, so a sustained
+  // run of skips can escalate from info to warn (see noteMissingObjectTick).
+  let sawMissingObject = false;
 
   // Pass 1: TTL — delete distilled messages older than the retention window.
   // Note: result.changes is inflated by FTS trigger side-effects, so we count
@@ -726,6 +747,7 @@ export function prune(input: {
     ttlDeleted = ttlEligible;
   } catch (e) {
     if (!isMissingObjectError(e)) throw e;
+    sawMissingObject = true;
     log.info(
       "temporal.prune Pass 1 (TTL) skipped — object missing during db maintenance window (transient):",
       e,
@@ -775,6 +797,7 @@ export function prune(input: {
     }
   } catch (e) {
     if (!isMissingObjectError(e)) throw e;
+    sawMissingObject = true;
     log.info(
       "temporal.prune Pass 2 (size cap) skipped — object missing during db maintenance window (transient):",
       e,
@@ -792,12 +815,17 @@ export function prune(input: {
       .run(pid, cutoff);
   } catch (e) {
     if (!isMissingObjectError(e)) throw e;
+    sawMissingObject = true;
     log.info(
       "temporal.prune Pass 3 (archived distillations) skipped — object missing during db maintenance window (transient):",
       e,
     );
   }
 
+  // A clean tick (no missing-object skip) clears the consecutive-skip streak so
+  // only a *sustained* run of skips escalates to warn.
+  if (sawMissingObject) noteMissingObjectTick();
+  else consecutiveMissingObjectSkipTicks = 0;
   return { ttlDeleted, capDeleted };
 }
 
@@ -809,4 +837,30 @@ export function prune(input: {
  */
 function isMissingObjectError(err: unknown): boolean {
   return err instanceof Error && /no such (table|column)/i.test(err.message);
+}
+
+/**
+ * Number of consecutive prune() ticks that skipped one or more passes on a
+ * missing object before we escalate from info to warn. A single skip is the
+ * expected, benign symptom of racing a db() maintenance swap (#1001); a sustained
+ * run instead points at a persistent schema problem (a dropped/renamed object,
+ * an un-run migration) that would otherwise let prune silently no-op forever
+ * while temporal storage grows past its cap.
+ */
+const MISSING_OBJECT_ESCALATE_TICKS = 3;
+let consecutiveMissingObjectSkipTicks = 0;
+
+/**
+ * Record a prune() tick that skipped at least one pass on a missing object,
+ * escalating from info to warn once the skip becomes persistent rather than
+ * transient. Called at most once per prune() tick.
+ */
+function noteMissingObjectTick(): void {
+  consecutiveMissingObjectSkipTicks++;
+  if (consecutiveMissingObjectSkipTicks >= MISSING_OBJECT_ESCALATE_TICKS) {
+    log.warn(
+      `temporal.prune has skipped passes on missing DB objects for ${consecutiveMissingObjectSkipTicks} consecutive ticks — ` +
+        "expected briefly during db() maintenance swaps, but a sustained recurrence indicates a persistent schema problem (#1001).",
+    );
+  }
 }

--- a/packages/core/test/temporal-prune-race.test.ts
+++ b/packages/core/test/temporal-prune-race.test.ts
@@ -36,6 +36,27 @@ function throwingSink(match: RegExp, err: Error): LogSink {
   };
 }
 
+/** Like `throwingSink` but also records every `warn` message into `warns`, so a
+ *  test can assert when a persistent miss escalates from info to warn. */
+function recordingThrowingSink(
+  match: RegExp,
+  err: Error,
+  warns: string[],
+): LogSink {
+  return {
+    info() {},
+    warn(...args: unknown[]) {
+      warns.push(args.map(String).join(" "));
+    },
+    error() {},
+    captureException() {},
+    withDbSpan<T>(sql: string, fn: () => T): T {
+      if (match.test(sql)) throw err;
+      return fn();
+    },
+  };
+}
+
 function seedDistilledMessage(ageMs: number): string {
   const pid = ensureProject(PROJECT);
   const id = `prune-msg-${crypto.randomUUID()}`;
@@ -140,6 +161,80 @@ describe("temporal.prune resilience to a db()-swap missing-table race (#1001)", 
     registerSink(passthroughSink);
     expect(temporalCount()).toBe(1); // Pass 1 delete never ran
     expect(distillationExists(arch)).toBe(false); // Pass 3 ran despite Pass 1 failing
+  });
+
+  test("a missing-object error while resolving the project (setup) skips the whole tick", () => {
+    const msg = seedDistilledMessage(10 * DAY); // Pass 1 would delete this if prune proceeded
+    expect(msg).toBeTruthy();
+
+    // ensureProject's `SELECT … FROM projects` races the swap and throws
+    // no-such-table *before* any pass runs. The whole tick must no-op, not abort.
+    registerSink(
+      throwingSink(
+        /FROM projects WHERE path/,
+        new Error("no such table: projects"),
+      ),
+    );
+
+    let result: { ttlDeleted: number; capDeleted: number } | undefined;
+    expect(() => {
+      result = prune({
+        projectPath: PROJECT,
+        retentionDays: 1,
+        maxStorageMB: 999_999,
+      });
+    }).not.toThrow();
+
+    expect(result).toEqual({ ttlDeleted: 0, capDeleted: 0 });
+    registerSink(passthroughSink);
+    expect(temporalCount()).toBe(1); // setup skipped → no pass deleted anything
+  });
+
+  test("a persistent missing-object skip escalates from info to warn after N consecutive ticks", () => {
+    const opts = {
+      projectPath: PROJECT,
+      retentionDays: 1,
+      maxStorageMB: 999_999,
+    };
+
+    // A clean prune first resets the consecutive-skip streak to a known 0, so
+    // this test is independent of whichever tests ran before it.
+    registerSink(passthroughSink);
+    prune(opts);
+
+    const warns: string[] = [];
+    registerSink(
+      recordingThrowingSink(
+        /DELETE FROM distillations/,
+        new Error("no such table: distillations"),
+        warns,
+      ),
+    );
+
+    // The first two consecutive missing-object ticks stay quiet (info only):
+    // a transient swap window must not spam warn.
+    prune(opts);
+    prune(opts);
+    expect(warns).toHaveLength(0);
+
+    // The third consecutive miss crosses the escalation threshold → warn.
+    prune(opts);
+    expect(warns.length).toBeGreaterThanOrEqual(1);
+    expect(warns[0]).toMatch(/consecutive/i);
+
+    // A subsequent clean tick clears the streak so warn does not persist.
+    registerSink(passthroughSink);
+    prune(opts);
+    const warnsAfterRecovery: string[] = [];
+    registerSink(
+      recordingThrowingSink(
+        /DELETE FROM distillations/,
+        new Error("no such table: distillations"),
+        warnsAfterRecovery,
+      ),
+    );
+    prune(opts);
+    expect(warnsAfterRecovery).toHaveLength(0);
   });
 
   test("a non-missing-object error propagates (not swallowed)", () => {

--- a/packages/core/test/temporal-prune-race.test.ts
+++ b/packages/core/test/temporal-prune-race.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { db, ensureProject } from "../src/db";
+import { registerSink, type LogSink } from "../src/log";
+import { prune } from "../src/temporal";
+
+// #1001: the active db() connection is rebuilt by maintenance (overflow /
+// split / magnet) several times per run; an idle prune can race that window and
+// hit a connection where a table is momentarily absent
+// (`SQLiteError: no such table: distillations`, observed in Pass 3). Each pass
+// is now wrapped so a missing-object error is a no-op for that tick while the
+// other passes still run; any other error propagates.
+//
+// We reproduce the symptom precisely without touching the schema: the DB query
+// tracer (`withDbSpan`) wraps every executed statement, so a sink can throw for
+// a chosen SQL string exactly as the live connection would during a swap.
+
+const PROJECT = "/test/temporal-prune-race";
+const DAY = 24 * 60 * 60 * 1000;
+
+const passthroughSink: LogSink = {
+  info() {},
+  warn() {},
+  error() {},
+  captureException() {},
+};
+
+/** Sink that throws `err` for any executed SQL matching `match`, else passes
+ *  through. Simulates the live connection failing on one pass mid-swap. */
+function throwingSink(match: RegExp, err: Error): LogSink {
+  return {
+    ...passthroughSink,
+    withDbSpan<T>(sql: string, fn: () => T): T {
+      if (match.test(sql)) throw err;
+      return fn();
+    },
+  };
+}
+
+function seedDistilledMessage(ageMs: number): string {
+  const pid = ensureProject(PROJECT);
+  const id = `prune-msg-${crypto.randomUUID()}`;
+  db()
+    .query(
+      `INSERT INTO temporal_messages (id, project_id, session_id, role, content, tokens, distilled, created_at, metadata)
+       VALUES (?, ?, 'sess', 'user', ?, 5, 1, ?, '{}')`,
+    )
+    .run(id, pid, "x".repeat(30), Date.now() - ageMs);
+  return id;
+}
+
+function seedArchivedDistillation(ageMs: number): string {
+  const pid = ensureProject(PROJECT);
+  const id = crypto.randomUUID();
+  db()
+    .query(
+      `INSERT INTO distillations (id, project_id, session_id, narrative, facts, observations, source_ids, generation, token_count, archived, created_at)
+       VALUES (?, ?, 'sess', '', '[]', 'obs', '[]', 0, 1, 1, ?)`,
+    )
+    .run(id, pid, Date.now() - ageMs);
+  return id;
+}
+
+function temporalCount(): number {
+  const pid = ensureProject(PROJECT);
+  return (
+    db()
+      .query("SELECT COUNT(*) as c FROM temporal_messages WHERE project_id = ?")
+      .get(pid) as { c: number }
+  ).c;
+}
+
+function distillationExists(id: string): boolean {
+  return (
+    db().query("SELECT id FROM distillations WHERE id = ?").get(id) != null
+  );
+}
+
+beforeEach(() => {
+  const pid = ensureProject(PROJECT);
+  db().query("DELETE FROM temporal_messages WHERE project_id = ?").run(pid);
+  db().query("DELETE FROM distillations WHERE project_id = ?").run(pid);
+});
+
+afterEach(() => {
+  registerSink(passthroughSink);
+});
+
+describe("temporal.prune resilience to a db()-swap missing-table race (#1001)", () => {
+  test("a missing-object error in Pass 3 is swallowed; Passes 1-2 still commit", () => {
+    seedDistilledMessage(10 * DAY); // older than retention → Pass 1 deletes
+    const arch = seedArchivedDistillation(10 * DAY); // Pass 3 would delete it
+
+    // Pass 3's DELETE throws no-such-table, as during a maintenance swap.
+    registerSink(
+      throwingSink(
+        /DELETE FROM distillations/,
+        new Error("no such table: distillations"),
+      ),
+    );
+
+    let result: { ttlDeleted: number; capDeleted: number } | undefined;
+    expect(() => {
+      result = prune({
+        projectPath: PROJECT,
+        retentionDays: 1,
+        maxStorageMB: 999_999,
+      });
+    }).not.toThrow();
+
+    // Pass 1 committed its delete (partial progress returned)…
+    expect(result?.ttlDeleted).toBe(1);
+    registerSink(passthroughSink);
+    expect(temporalCount()).toBe(0);
+    // …but Pass 3 was skipped, so the archived distillation survives this tick.
+    expect(distillationExists(arch)).toBe(true);
+  });
+
+  test("passes are independent: a Pass 1 missing-object error still lets Pass 3 run", () => {
+    seedDistilledMessage(10 * DAY);
+    const arch = seedArchivedDistillation(10 * DAY);
+
+    // Pass 1's COUNT throws no-such-table; Passes 2-3 must still execute.
+    registerSink(
+      throwingSink(
+        /SELECT COUNT\(\*\) as c FROM temporal_messages/,
+        new Error("no such table: temporal_messages"),
+      ),
+    );
+
+    let result: { ttlDeleted: number; capDeleted: number } | undefined;
+    expect(() => {
+      result = prune({
+        projectPath: PROJECT,
+        retentionDays: 1,
+        maxStorageMB: 999_999,
+      });
+    }).not.toThrow();
+
+    expect(result?.ttlDeleted).toBe(0); // Pass 1 skipped → nothing deleted there
+    registerSink(passthroughSink);
+    expect(temporalCount()).toBe(1); // Pass 1 delete never ran
+    expect(distillationExists(arch)).toBe(false); // Pass 3 ran despite Pass 1 failing
+  });
+
+  test("a non-missing-object error propagates (not swallowed)", () => {
+    seedArchivedDistillation(10 * DAY);
+    registerSink(
+      throwingSink(
+        /DELETE FROM distillations/,
+        new Error("database disk image is malformed"),
+      ),
+    );
+
+    expect(() =>
+      prune({
+        projectPath: PROJECT,
+        retentionDays: 1,
+        maxStorageMB: 999_999,
+      }),
+    ).toThrow(/disk image is malformed/);
+  });
+});


### PR DESCRIPTION
Closes #1001.

## Problem

`temporal.prune()` resolves one connection via `const database = db()` and runs three passes. The `db()` singleton is reset/rebuilt several times per process run by DB maintenance (overflow-recovery / split / magnet), and an idle prune can race that window — observing a connection where a table is momentarily absent. The symptom in production logs is a recurring (~1×/6h) `SQLiteError: no such table: distillations` thrown from Pass 3. The table genuinely exists; it's a transient swap race.

That throw aborted the **entire** prune for the tick (and an early throw in Pass 1/2 would skip the later passes too).

## Fix

Wrap each pass in its own try/catch via a small `isMissingObjectError()` helper (`/no such (table|column)/i`):
- a missing-object error → that pass is a **no-op for this tick** (the next idle tick reruns it), the other passes still run, and partial counts are returned;
- any **other** error still propagates to the caller's `idle pruning error` catch.

### Review-driven hardening (commit `c0f709b4`)

An adversarial self-review surfaced two gaps in the resilience boundary, both fixed here:

1. **Setup was outside the guard.** The top-level `db()` / `ensureProject()` resolution ran *before* all three try/catch blocks, so a `no such table: projects` from `ensureProject`'s `SELECT … FROM projects` during the *same* swap window would abort the whole prune — the exact failure mode this PR targets. It's now wrapped: a missing-object setup error skips the tick (returns zero counts) and retries next idle tick.
2. **`info` masked a *persistent* failure.** Per-pass swallows log at `info`, which is correct for the expected ~1×/6h transient — but if the missing object were ever persistent (a dropped/renamed column, an un-run migration), prune would silently no-op forever while temporal storage grows past its cap. We now track consecutive missing-object ticks and escalate `info → warn` once the skip is sustained (`>= MISSING_OBJECT_ESCALATE_TICKS` = 3); a clean tick resets the streak, so the transient stays quiet.

Out of scope (tracked follow-ups noted in #1001): root-causing/serializing the `db()` swap itself, and extending `recoverMissingObjects` to base tables.

## Tests

`packages/core/test/temporal-prune-race.test.ts` reproduces the symptom precisely **without touching the schema** — the DB query tracer (`registerSink`/`withDbSpan`) wraps every executed statement, so a sink can throw for a chosen SQL exactly as the live connection would mid-swap:
1. Pass 3 `no such table` is swallowed → prune returns Pass-1/2 counts, the archived distillation survives the tick.
2. Passes are independent: a Pass 1 `no such table` is swallowed and **Pass 3 still runs** (archived distillation deleted).
3. A non-missing-object error (`disk image is malformed`) **propagates**.
4. **(new)** A `no such table: projects` thrown from setup skips the whole tick — nothing is deleted, prune returns `{ ttlDeleted: 0, capDeleted: 0 }`.
5. **(new)** A persistent miss escalates `info → warn` only after 3 consecutive ticks; two ticks stay quiet, and a clean tick resets the streak.

Every test is red-green verified by mutation: forcing `isMissingObjectError` to `false`/`true` fails (1)–(3); removing the setup guard fails (4); disabling escalation fails (5). Full `@loreai/core` suite green (**2303 passed**).
