### PR TITLE
feat(core): split read-path awaited timer into embed vs vectorSearch (#999)

### DIFF
--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -1945,9 +1945,11 @@ export async function forSession(
     try {
       const [contextVec] = await timer.await(
         embedding.embed([sessionContext], "query"),
+        "embed",
       );
       const hits = await timer.await(
         embedding.vectorSearch(contextVec, 50, excludeFilter),
+        "vectorSearch",
       );
       vectorScores = new Map(hits.map((h) => [h.id, h.similarity]));
     } catch (err) {

--- a/packages/core/src/read-telemetry.ts
+++ b/packages/core/src/read-telemetry.ts
@@ -24,11 +24,20 @@ export interface ReadPathTiming {
   totalMs: number;
   /** Sum of awaited (off-thread / async) time: embed + pool vector search. */
   awaitedMs: number;
+  /** Awaited time spent in `embedding.embed(...)` (subset of awaitedMs). #999. */
+  embedMs: number;
+  /** Awaited time spent in `embedding.vectorSearch(...)` (subset of awaitedMs).
+   *  #999: split out so the next telemetry pass attributes the pathological
+   *  awaited latency to embed vs vector-search rather than one opaque bucket. */
+  vectorSearchMs: number;
   /** totalMs - awaitedMs — approximate main-thread blocking time. */
   syncBlockingMs: number;
   /** Number of candidate rows the call scored (context for the blocking cost). */
   candidateCount: number;
 }
+
+/** Named awaited sub-buckets attributed within {@link ReadPathTimer.await}. */
+export type AwaitBucket = "embed" | "vectorSearch";
 
 let readPathTimingHook: ((t: ReadPathTiming) => void) | null = null;
 
@@ -49,14 +58,26 @@ export function setReadPathTimingHook(
 export class ReadPathTimer {
   private readonly start = performance.now();
   awaited = 0;
+  /** Awaited time attributed to embed / vector-search sub-buckets (#999). Each
+   *  is a subset of `awaited`; the remainder (e.g. FTS / hydration awaits) is
+   *  counted in `awaited` only. */
+  embed = 0;
+  vectorSearch = 0;
 
-  /** Time the suspension across one awaited promise. */
-  async await<T>(p: Promise<T>): Promise<T> {
+  /**
+   * Time the suspension across one awaited promise. When `bucket` is given, the
+   * elapsed time is additionally attributed to that named sub-bucket (#999) on
+   * top of the total `awaited` accumulator.
+   */
+  async await<T>(p: Promise<T>, bucket?: AwaitBucket): Promise<T> {
     const s = performance.now();
     try {
       return await p;
     } finally {
-      this.awaited += performance.now() - s;
+      const dt = performance.now() - s;
+      this.awaited += dt;
+      if (bucket === "embed") this.embed += dt;
+      else if (bucket === "vectorSearch") this.vectorSearch += dt;
     }
   }
 
@@ -76,6 +97,8 @@ export class ReadPathTimer {
         scope,
         totalMs,
         awaitedMs: this.awaited,
+        embedMs: this.embed,
+        vectorSearchMs: this.vectorSearch,
         syncBlockingMs: Math.max(0, totalMs - this.awaited),
         candidateCount,
       });

--- a/packages/core/src/recall.ts
+++ b/packages/core/src/recall.ts
@@ -900,12 +900,16 @@ export async function searchRecall(
   // Vector search on the original query (not expansions — avoid redundant embeds).
   if (embedding.isAvailable() && scope !== "session") {
     try {
-      const [queryVec] = await timer.await(embedding.embed([query], "query"));
+      const [queryVec] = await timer.await(
+        embedding.embed([query], "query"),
+        "embed",
+      );
 
       // Knowledge vector search
       if (knowledgeEnabled) {
         const vectorHits = await timer.await(
           embedding.vectorSearch(queryVec, limit),
+          "vectorSearch",
         );
         // Batch-hydrate hits off-thread (#966) instead of N per-hit ltm.get().
         const entryMap = await timer.await(
@@ -938,6 +942,7 @@ export async function searchRecall(
       if (scope !== "knowledge") {
         const distVectorHits = await timer.await(
           embedding.vectorSearchDistillations(queryVec, limit),
+          "vectorSearch",
         );
         // Batch-hydrate hits off-thread (#966) instead of N per-hit point reads.
         const distMap = await timer.await(
@@ -970,6 +975,7 @@ export async function searchRecall(
         const pid = ensureProject(projectPath);
         const temporalVectorHits = await timer.await(
           embedding.vectorSearchTemporal(queryVec, pid, limit),
+          "vectorSearch",
         );
         // Batch-hydrate hits off-thread (#966) instead of N per-hit point reads.
         const temporalMap = await timer.await(
@@ -1011,6 +1017,7 @@ export async function searchRecall(
         const entPid = ensureProject(projectPath);
         const entityVectorHits = await timer.await(
           embedding.vectorSearchEntities(queryVec, limit),
+          "vectorSearch",
         );
         // Batch-hydrate hits off-thread (#966) instead of N per-hit
         // getWithAliases() calls (entity row + alias load each).

--- a/packages/core/test/read-telemetry.test.ts
+++ b/packages/core/test/read-telemetry.test.ts
@@ -62,6 +62,41 @@ describe("ReadPathTimer", () => {
     });
     expect(() => new ReadPathTimer().emit("forSession", 1)).not.toThrow();
   });
+
+  it("attributes embed and vectorSearch awaits to their sub-buckets (#999)", async () => {
+    let captured: ReadPathTiming | undefined;
+    setReadPathTimingHook((t) => {
+      captured = t;
+    });
+
+    const timer = new ReadPathTimer();
+    await timer.await(sleep(20), "embed");
+    await timer.await(sleep(20), "vectorSearch");
+    await timer.await(sleep(20)); // unlabeled — counted in awaited only
+    timer.emit("forSession", 3);
+
+    const t = captured as ReadPathTiming;
+    // Each labeled await lands in its own bucket (~20ms; allow scheduling slack).
+    expect(t.embedMs).toBeGreaterThanOrEqual(10);
+    expect(t.vectorSearchMs).toBeGreaterThanOrEqual(10);
+    // Both buckets are subsets of awaited…
+    expect(t.embedMs + t.vectorSearchMs).toBeLessThanOrEqual(t.awaitedMs + 1);
+    // …and the unlabeled await is in awaited but in NEITHER bucket, so awaited
+    // exceeds the bucket sum by roughly the third (~20ms) suspension.
+    expect(t.awaitedMs).toBeGreaterThanOrEqual(
+      t.embedMs + t.vectorSearchMs + 10,
+    );
+  });
+
+  it("embedMs/vectorSearchMs are 0 when no sub-bucket awaits occur", () => {
+    let captured: ReadPathTiming | undefined;
+    setReadPathTimingHook((t) => {
+      captured = t;
+    });
+    new ReadPathTimer().emit("recall", 0);
+    expect((captured as ReadPathTiming).embedMs).toBe(0);
+    expect((captured as ReadPathTiming).vectorSearchMs).toBe(0);
+  });
 });
 
 describe("forSession fires the read-path timing hook", () => {

--- a/packages/gateway/src/sentry.ts
+++ b/packages/gateway/src/sentry.ts
@@ -595,6 +595,17 @@ export function setupReadPathTimingCapture(): void {
         unit: "millisecond",
         attributes,
       });
+      // #999: split the awaited bucket into embed vs vector-search so the next
+      // telemetry pass can attribute the pathological awaited latency.
+      Sentry.metrics.distribution("lore.readpath.embed_ms", t.embedMs, {
+        unit: "millisecond",
+        attributes,
+      });
+      Sentry.metrics.distribution(
+        "lore.readpath.vector_search_ms",
+        t.vectorSearchMs,
+        { unit: "millisecond", attributes },
+      );
       Sentry.metrics.distribution(
         "lore.readpath.candidates",
         t.candidateCount,

--- a/packages/gateway/test/readpath-capture.test.ts
+++ b/packages/gateway/test/readpath-capture.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock @sentry/bun BEFORE importing the module under test (mirrors
+// sentry-bust-spiral.test.ts). A full factory replaces the shared instance for
+// both this test and src/sentry.ts, so we can drive isInitialized() and assert
+// the exact distributions emitted.
+vi.mock("@sentry/bun", () => ({
+  isInitialized: vi.fn(() => false),
+  metrics: {
+    distribution: vi.fn(),
+    count: vi.fn(),
+  },
+}));
+
+import * as core from "@loreai/core";
+import * as Sentry from "@sentry/bun";
+import { setupReadPathTimingCapture } from "../src/sentry";
+
+type ReadPathHook = (t: core.ReadPathTiming) => void;
+
+function installAndGetHook(): ReadPathHook {
+  const setterSpy = vi.spyOn(core, "setReadPathTimingHook");
+  try {
+    setupReadPathTimingCapture();
+    expect(setterSpy).toHaveBeenCalledOnce();
+    return setterSpy.mock.calls[0][0] as ReadPathHook;
+  } finally {
+    setterSpy.mockRestore();
+  }
+}
+
+const sample = (
+  over: Partial<core.ReadPathTiming> = {},
+): core.ReadPathTiming => ({
+  op: "forSession",
+  totalMs: 100,
+  awaitedMs: 80,
+  embedMs: 30,
+  vectorSearchMs: 45,
+  syncBlockingMs: 20,
+  candidateCount: 7,
+  ...over,
+});
+
+function distNames(): string[] {
+  return vi
+    .mocked(Sentry.metrics.distribution)
+    .mock.calls.map((c) => c[0] as string);
+}
+
+describe("read-path timing Sentry capture (#999)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(Sentry.isInitialized).mockReturnValue(true);
+    core.setReadPathTimingHook(null);
+  });
+
+  it("forwards embed_ms and vector_search_ms as their own distributions", () => {
+    const hook = installAndGetHook();
+    hook(sample());
+
+    const calls = vi.mocked(Sentry.metrics.distribution).mock.calls;
+    const embed = calls.find((c) => c[0] === "lore.readpath.embed_ms");
+    const vector = calls.find((c) => c[0] === "lore.readpath.vector_search_ms");
+
+    expect(embed).toBeDefined();
+    expect(embed?.[1]).toBe(30);
+    expect((embed?.[2] as { unit?: string })?.unit).toBe("millisecond");
+    expect(
+      (embed?.[2] as { attributes?: Record<string, string> })?.attributes?.op,
+    ).toBe("forSession");
+
+    expect(vector).toBeDefined();
+    expect(vector?.[1]).toBe(45);
+    expect((vector?.[2] as { unit?: string })?.unit).toBe("millisecond");
+
+    // The pre-existing aggregate buckets are still emitted alongside.
+    expect(distNames()).toEqual(
+      expect.arrayContaining([
+        "lore.readpath.total_ms",
+        "lore.readpath.awaited_ms",
+        "lore.readpath.embed_ms",
+        "lore.readpath.vector_search_ms",
+      ]),
+    );
+  });
+
+  it("emits nothing when Sentry is not initialized", () => {
+    vi.mocked(Sentry.isInitialized).mockReturnValue(false);
+    const hook = installAndGetHook();
+    hook(sample());
+    expect(Sentry.metrics.distribution).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Refs #999 (kept open — measurement only; see below).

## Why

#999 surfaced pathologically high **awaited** latency on the `forSession` / `recall` read path (~23s p50, ~98–128s p95 — off-thread, not main-thread blocking). But the telemetry only records one opaque `awaitedMs`, which folds together the local ONNX embed and the pool vector search. Its top diagnostic ask is to split those so the next pass knows which half dominates.

## Change

- `read-telemetry.ts`: `ReadPathTimer.await(p, bucket?)` gains an optional `"embed" | "vectorSearch"` label; the elapsed time is attributed to that sub-bucket **in addition to** the total `awaited` accumulator. `ReadPathTiming` gains `embedMs` / `vectorSearchMs` (each a subset of `awaitedMs`); unlabeled awaits (FTS / hydration) stay counted in `awaitedMs` only.
- `ltm.ts` (`forSession`) and `recall.ts`: label the `embedding.embed(...)` and `embedding.vectorSearch*(...)` awaits.
- `gateway/sentry.ts`: forward two new distributions — `lore.readpath.embed_ms` and `lore.readpath.vector_search_ms` — alongside the existing ones.

Pure measurement — **no behavior change**. The issue stays **open** pending the Sentry re-evaluation now that the #966 offload stack + FLAT vec0 (#1051) have landed; this PR just makes that re-evaluation possible.

## Tests

- `read-telemetry.test.ts`: labeled embed/vectorSearch awaits land in their buckets; both are subsets of `awaitedMs`; an unlabeled await is in `awaitedMs` but neither bucket; buckets are 0 with no labeled awaits. Mutation-verified (drop attribution → fails; wrong emit field → fails).
- `gateway/test/readpath-capture.test.ts`: the capture hook forwards `embed_ms` (30ms) and `vector_search_ms` (45ms) as their own `millisecond` distributions with the `op` attribute, and emits nothing when Sentry is uninitialized.

Full `@loreai/core` (2300) and `@loreai/gateway` (2357) suites green.

Refs #993, #966