### PR TITLE
fix(gateway): route reconstructed openai requests host-aware for Google (#1070)

### DIFF
--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -495,10 +495,11 @@ export type ProviderRoute = {
  *
  * URLs must NOT include `/v1` — the gateway appends `/v1/messages`,
  * `/v1/chat/completions`, or `/v1/responses` itself. The exception is providers
- * whose API omits the `/v1` segment (GitHub Copilot serves chat completions at
- * `/chat/completions`, issue #1052): foreground requests forward verbatim to the
- * client's original endpoint (see `verbatimUpstreamUrl`), and reconstructed
- * paths (background workers) are handled host-aware by
+ * whose Chat Completions API is served at a non-`/v1` path (GitHub Copilot at
+ * `/chat/completions`, issue #1052; Google Gemini's OpenAI layer at
+ * `/v1beta/openai/chat/completions`, issue #1070): foreground requests forward
+ * verbatim to the client's original endpoint (see `verbatimUpstreamUrl`), and
+ * reconstructed paths (background workers) are handled host-aware by
  * `buildOpenAIChatCompletionsUrl` in `translate/openai.ts`.
  *
  * Data sourced from models.dev provider database (https://models.dev/providers).

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -641,7 +641,8 @@ function buildOpenAIWorkerRequest(
 
   return {
     // Background workers have no original request to forward verbatim, so the
-    // URL is reconstructed host-aware (GitHub Copilot omits `/v1`, issue #1052).
+    // URL is reconstructed host-aware (GitHub Copilot omits `/v1`, issue #1052;
+    // Google Gemini serves `/v1beta/openai/...`, issue #1070).
     url: buildOpenAIChatCompletionsUrl(target.url),
     headers: {
       "Content-Type": "application/json",

--- a/packages/gateway/src/translate/openai.ts
+++ b/packages/gateway/src/translate/openai.ts
@@ -474,39 +474,56 @@ function buildOpenAIStreamResponse(resp: GatewayResponse): Response {
 // ---------------------------------------------------------------------------
 
 /**
- * Hosts whose OpenAI-compatible Chat Completions endpoint is served WITHOUT the
- * conventional `/v1` path segment. GitHub Copilot serves chat completions at
- * `https://api.githubcopilot.com/chat/completions`; prepending `/v1` yields
- * `404 page not found` (issue #1052). Keyed by hostname so it holds regardless
- * of which routing tier produced the base URL.
+ * Default Chat Completions path appended to a bare provider origin. Most
+ * OpenAI-compatible providers serve at `<base>/v1/chat/completions`.
+ */
+const DEFAULT_OPENAI_CHAT_COMPLETIONS_PATH = "/v1/chat/completions";
+
+/**
+ * Hosts whose OpenAI-compatible Chat Completions endpoint is NOT served at the
+ * conventional `<base>/v1/chat/completions`. Maps hostname → the exact path the
+ * gateway must append to the provider origin instead:
+ *
+ *  - GitHub Copilot omits the `/v1` segment entirely (`/chat/completions`);
+ *    prepending `/v1` yields `404 page not found` (issue #1052).
+ *  - Google's Gemini OpenAI-compatibility layer serves under
+ *    `/v1beta/openai/chat/completions`; `/v1/chat/completions` 404s (issue
+ *    #1070).
+ *
+ * Keyed by hostname so the override holds regardless of which routing tier
+ * produced the base URL.
  *
  * Foreground requests that come through the fetch interceptor forward verbatim
- * to the client's original endpoint (see `verbatimUpstreamUrl`); this allowlist
- * covers the paths the gateway must RECONSTRUCT from scratch — background worker
- * requests (which have no original request) and any provider configured via
- * `LORE_UPSTREAM_<PROVIDER>` with no preserved endpoint path.
+ * to the client's original endpoint (see `verbatimUpstreamUrl`); this map covers
+ * the paths the gateway must RECONSTRUCT from scratch — background worker
+ * requests (which have no original request to forward) and any provider invoked
+ * purely via its `X-Lore-Provider` route with no preserved endpoint path.
  */
-const OPENAI_ROOT_PATH_HOSTS: ReadonlySet<string> = new Set([
-  "api.githubcopilot.com",
-]);
+const OPENAI_HOST_CHAT_COMPLETIONS_PATHS: ReadonlyMap<string, string> = new Map(
+  [
+    ["api.githubcopilot.com", "/chat/completions"],
+    ["generativelanguage.googleapis.com", "/v1beta/openai/chat/completions"],
+  ],
+);
 
 /**
  * Build the OpenAI Chat Completions upstream URL for an upstream base.
  *
  * Most OpenAI-compatible providers serve at `<base>/v1/chat/completions`, so the
  * route tables store a bare origin and the gateway appends `/v1/...`. Hosts in
- * `OPENAI_ROOT_PATH_HOSTS` omit the `/v1` segment. Falls back to the `/v1` form
- * when `base` cannot be parsed as a URL.
+ * `OPENAI_HOST_CHAT_COMPLETIONS_PATHS` use a different endpoint path (e.g. no
+ * `/v1` segment, or a `/v1beta/openai/...` prefix). Falls back to the default
+ * `/v1` form when `base` cannot be parsed as a URL.
  */
 export function buildOpenAIChatCompletionsUrl(base: string): string {
-  let hostname: string | null = null;
+  let path = DEFAULT_OPENAI_CHAT_COMPLETIONS_PATH;
   try {
-    hostname = new URL(base).hostname;
+    const hostname = new URL(base).hostname;
+    path = OPENAI_HOST_CHAT_COMPLETIONS_PATHS.get(hostname) ?? path;
   } catch {
-    hostname = null;
+    // Unparseable base (e.g. a bare placeholder) — keep the default `/v1` path.
   }
-  const prefix = hostname && OPENAI_ROOT_PATH_HOSTS.has(hostname) ? "" : "/v1";
-  return `${base}${prefix}/chat/completions`;
+  return `${base}${path}`;
 }
 
 export function buildOpenAIUpstreamRequest(

--- a/packages/gateway/test/github-copilot-url.test.ts
+++ b/packages/gateway/test/github-copilot-url.test.ts
@@ -187,6 +187,16 @@ describe("buildOpenAIChatCompletionsUrl", () => {
     );
   });
 
+  test("Google Gemini host uses the /v1beta/openai path (issue #1070)", () => {
+    expect(
+      buildOpenAIChatCompletionsUrl(
+        "https://generativelanguage.googleapis.com",
+      ),
+    ).toBe(
+      "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions",
+    );
+  });
+
   test("standard provider keeps the /v1 segment", () => {
     expect(buildOpenAIChatCompletionsUrl("https://api.openai.com")).toBe(
       "https://api.openai.com/v1/chat/completions",

--- a/packages/gateway/test/worker-google-openai-path.test.ts
+++ b/packages/gateway/test/worker-google-openai-path.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Issue #1070 — background worker requests routed to the `google` provider must
+ * target Google's OpenAI-compatibility endpoint
+ * `https://generativelanguage.googleapis.com/v1beta/openai/chat/completions`,
+ * NOT the conventional `/v1/chat/completions` (which 404s). Workers build
+ * prompts from scratch (no original request to forward verbatim), so the URL is
+ * reconstructed host-aware by `buildOpenAIChatCompletionsUrl`.
+ */
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("../src/fetch", () => ({ upstreamFetch: vi.fn() }));
+
+import { createGatewayLLMClient } from "../src/llm-adapter";
+import { upstreamFetch } from "../src/fetch";
+import { clearAllCosts } from "../src/cost-tracker";
+import { resetBackgroundLimiter } from "../src/background-limiter";
+
+const mockFetch = vi.mocked(upstreamFetch);
+
+const UPSTREAMS = {
+  anthropic: "https://api.anthropic.com",
+  openai: "https://api.openai.com",
+};
+
+function okResponse() {
+  return new Response(
+    JSON.stringify({
+      choices: [{ message: { content: "ok" } }],
+      model: "m",
+      usage: { prompt_tokens: 1, completion_tokens: 1 },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+describe("worker google URL (#1070)", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue(okResponse());
+  });
+  afterEach(() => {
+    mockFetch.mockReset();
+    clearAllCosts();
+    resetBackgroundLimiter();
+  });
+
+  test("forwards to /v1beta/openai/chat/completions", async () => {
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      (_sid, providerID) =>
+        providerID === "google"
+          ? { scheme: "bearer", value: "g_worker" }
+          : null,
+      { providerID: "google", modelID: "gemini-2.5-flash" },
+    );
+
+    await client.prompt("system", "user", {
+      sessionID: "sess-google",
+      workerID: "lore-distill",
+      model: { providerID: "google", modelID: "gemini-2.5-flash" },
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const url = String(mockFetch.mock.calls[0][0]);
+    expect(url).toBe(
+      "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions",
+    );
+    expect(url).not.toContain("/v1/chat/completions");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1070. Background workers (and any provider invoked purely via its `X-Lore-Provider` route) have no original request to forward verbatim, so the gateway must **reconstruct** the upstream URL via `buildOpenAIChatCompletionsUrl`. That helper only special-cased GitHub Copilot's missing `/v1` segment (#1052); every other `openai`-protocol provider got `<base>/v1/chat/completions`.

Google's Gemini OpenAI-compatibility layer serves chat completions at `/v1beta/openai/chat/completions` (confirmed: the OpenAI SDK base URL is `https://generativelanguage.googleapis.com/v1beta/openai/`). So worker requests routed to the `google` provider hit `.../v1/chat/completions` → **404**.

## Change

Generalize the host special-case from a boolean `Set` (`OPENAI_ROOT_PATH_HOSTS`) into a host→path `Map` (`OPENAI_HOST_CHAT_COMPLETIONS_PATHS`) consumed by `buildOpenAIChatCompletionsUrl`:

| Host | Reconstructed path |
|---|---|
| `api.githubcopilot.com` | `/chat/completions` (#1052) |
| `generativelanguage.googleapis.com` | `/v1beta/openai/chat/completions` (#1070) |
| _everything else_ | `/v1/chat/completions` (default) |

`base + suffix` semantics are preserved, so path-prefixed bases (e.g. groq's `https://api.groq.com/openai`) still correctly append `/v1/chat/completions`. The foreground path is unaffected — it already forwards verbatim via `verbatimUpstreamUrl` (#1052/#1066).

Scope is limited to the one in-table `openai` provider that was broken (Google). `zai` is `url: null` (user-configured via `LORE_UPSTREAM_ZAI`) with a non-fixed host/path, so it's out of scope for a static host map.

## Tests

- Unit: `buildOpenAIChatCompletionsUrl` → `/v1beta/openai/chat/completions` for the Google host.
- Worker e2e (`worker-google-openai-path.test.ts`): a `google` worker model targets `/v1beta/openai/chat/completions`.

Both new tests verified **red** (received `/v1/chat/completions`) when the Google map entry is removed — non-vacuous. Copilot tests stay green. Full gateway suite: 2379 passed, 0 failed. Typecheck + lint clean.