### PR TITLE
perf(cache-analytics): memoize normalized previous body across turns

### DIFF
--- a/packages/gateway/src/cache-analytics.ts
+++ b/packages/gateway/src/cache-analytics.ts
@@ -515,15 +515,21 @@ export function analyzeCacheTurn(
 
   // Compare with previous body if available
   if (analytics.lastRequestBody !== null) {
-    // lastRequestBody is stored RAW (with cache_control intact) for the warmer;
-    // normalize on read so the divergence comparison stays apples-to-apples.
-    // Byte-identical to the old path: both apply normalizeBodyForComparison
-    // exactly once to the same raw bytes (old: normalize-then-store; now:
-    // store-then-normalize) — so prevBody, and every value derived from it, is
-    // unchanged.
-    const prevBody = normalizeBodyForComparison(
-      decompressBody(analytics.lastRequestBody),
-    );
+    // We need the previous turn's NORMALIZED body for an apples-to-apples
+    // divergence comparison. That exact string was already computed last turn
+    // (it was that turn's `normalizedBody`), so reuse the memoized copy and
+    // skip a full re-normalization of the whole previous body. The memo is
+    // stored zstd-compressed and written together with `lastRequestBody` (see
+    // the write site below); `lastRequestBody` is assigned a non-null value in
+    // exactly one place, so whenever this guard passes the memo reflects the
+    // same body. The fallback branch covers callers/fixtures that built this
+    // analytics object without the optional memo field; `lastRequestBody`
+    // keeps the RAW (cache_control intact) body for the warmer, so
+    // normalize-on-read stays byte-identical to storing the normalized form
+    // directly.
+    const prevBody = analytics.lastNormalizedBody
+      ? decompressBody(analytics.lastNormalizedBody)
+      : normalizeBodyForComparison(decompressBody(analytics.lastRequestBody));
     const prevLength = prevBody.length;
     const currLength = normalizedBody.length;
 
@@ -624,6 +630,15 @@ export function analyzeCacheTurn(
   // length — it is only the divergence-ratio denominator (prefixMatchBytes is
   // measured on normalized bodies).
   analytics.lastRequestBody = compressBody(currentBody);
+  // Memoize the normalized form for next turn's divergence comparison. Stored
+  // compressed (these bodies compress ~99.9%, so the extra blob is a few
+  // hundred bytes) and written here alongside the raw body. This is the ONLY
+  // place `lastRequestBody` is assigned a non-null value, and the divergence
+  // reader above only consults `lastNormalizedBody` under the `!== null` guard,
+  // so the two never desync — the reset sites that set `lastRequestBody = null`
+  // simply skip the guard, and the stale memo (never read) is overwritten here
+  // on the next analyzed turn. No reset-site changes required.
+  analytics.lastNormalizedBody = compressBody(normalizedBody);
   analytics.lastRequestBodyLength = normalizedBody.length;
   analytics.lastCacheRead = cacheRead;
   analytics.lastCacheCreation = cacheCreation;

--- a/packages/gateway/src/translate/types.ts
+++ b/packages/gateway/src/translate/types.ts
@@ -378,6 +378,15 @@ export type CacheTurnAnalysis = {
 export type CacheAnalytics = {
   /** Deflate-compressed serialized request body from the last turn. */
   lastRequestBody: Uint8Array | null;
+  /**
+   * zstd-compressed NORMALIZED form of `lastRequestBody`, memoized so the next
+   * turn's divergence comparison can skip re-running `normalizeBodyForComparison`
+   * over the whole previous body. Optional so callers/fixtures that build this
+   * object without it still type-check; when absent the reader falls back to
+   * decompress + normalize. Written together with `lastRequestBody`, which is
+   * assigned a non-null value in exactly one place, so it stays consistent
+   * under the non-null guard. */
+  lastNormalizedBody?: Uint8Array | null;
   /** Uncompressed byte length of lastRequestBody (for prefix match %). */
   lastRequestBodyLength: number;
   /** cache_read_input_tokens from last API response. */

--- a/packages/gateway/test/cache-analytics.test.ts
+++ b/packages/gateway/test/cache-analytics.test.ts
@@ -629,6 +629,134 @@ describe("analyzeCacheTurn", () => {
 });
 
 // ---------------------------------------------------------------------------
+// analyzeCacheTurn — normalized-body memoization (#1078)
+// ---------------------------------------------------------------------------
+
+describe("analyzeCacheTurn — normalized-body memoization", () => {
+  // A body that carries volatile tokens (cch + cache_control) so that
+  // normalizeBodyForComparison actually transforms it — otherwise the memo and
+  // a fresh normalize would be trivially equal even if the memo were ignored.
+  function turnBody(userText: string): string {
+    return JSON.stringify({
+      model: "opus",
+      max_tokens: 1000,
+      system: [
+        { type: "text", text: "host cch=deadbeef;" },
+        {
+          type: "text",
+          text: "stable ltm",
+          cache_control: { type: "ephemeral" },
+        },
+      ],
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: userText,
+              cache_control: { type: "ephemeral" },
+            },
+          ],
+        },
+      ],
+    });
+  }
+
+  test("stores the NORMALIZED body compressed, alongside the RAW body", () => {
+    const analytics = makeCacheAnalytics();
+    const body = turnBody("hello");
+
+    analyzeCacheTurn(analytics, body, makeUsage());
+
+    // Raw body retains cache_control for the warmer …
+    const rawStored = analytics.lastRequestBody;
+    if (!rawStored) throw new Error("lastRequestBody should be set");
+    expect(decompressBody(rawStored)).toBe(body);
+    // … while the memo holds exactly the normalized form (cache_control + cch
+    // stripped), i.e. what a re-normalization would have produced.
+    const memoStored = analytics.lastNormalizedBody;
+    if (!memoStored) throw new Error("lastNormalizedBody should be set");
+    expect(decompressBody(memoStored)).toBe(normalizeBodyForComparison(body));
+  });
+
+  test("memoized path is byte-identical to the decompress+normalize fallback", () => {
+    const body1 = turnBody("hello");
+    const body2 = turnBody("hello there, how are you today");
+
+    // Path A: normal flow — turn 2 reuses the memo from turn 1.
+    const a = makeCacheAnalytics();
+    analyzeCacheTurn(a, body1, makeUsage());
+    const withMemo = analyzeCacheTurn(a, body2, makeUsage());
+
+    // Path B: identical inputs, but drop the memo after turn 1 so turn 2 is
+    // forced down the legacy decompress(raw)+normalize fallback.
+    const b = makeCacheAnalytics();
+    analyzeCacheTurn(b, body1, makeUsage());
+    b.lastNormalizedBody = undefined;
+    const withFallback = analyzeCacheTurn(b, body2, makeUsage());
+
+    // Every divergence-derived field must match — the memo is a pure
+    // performance shortcut with no behavioral effect.
+    expect(withMemo.prefixMatchBytes).toBe(withFallback.prefixMatchBytes);
+    expect(withMemo.prefixMatchPercent).toBe(withFallback.prefixMatchPercent);
+    expect(withMemo.divergencePoint).toBe(withFallback.divergencePoint);
+    expect(withMemo.divergenceReason).toBe(withFallback.divergenceReason);
+    expect(a.lastRequestBodyLength).toBe(b.lastRequestBodyLength);
+  });
+
+  test("the memo actually drives the comparison (mutation guard)", () => {
+    // If the reader ignored lastNormalizedBody and always re-normalized the raw
+    // body, corrupting the memo would have no effect. Prove it is consulted: a
+    // corrupted memo makes an otherwise-identical turn report divergence.
+    const analytics = makeCacheAnalytics();
+    const body = turnBody("hello");
+
+    analyzeCacheTurn(analytics, body, makeUsage());
+    analytics.lastNormalizedBody = compressBody(
+      normalizeBodyForComparison(turnBody("a completely different message")),
+    );
+
+    const result = analyzeCacheTurn(analytics, body, makeUsage());
+
+    // Same raw body twice would normally be <identical>; the poisoned memo
+    // forces an early divergence instead.
+    expect(result.divergencePoint).not.toBe("<identical>");
+    expect(result.prefixMatchPercent).toBeLessThan(1);
+  });
+
+  test("a stale memo left after a reset is never consulted", () => {
+    // Reset-safety invariant: `lastRequestBody === null` is the guard, so a
+    // stale `lastNormalizedBody` left behind by an earlier turn must NOT leak
+    // into a later comparison. Simulate a mid-session cache reset that nulls the
+    // raw body but (adversarially) leaves a poisoned memo behind.
+    const analytics = makeCacheAnalytics();
+    analyzeCacheTurn(analytics, turnBody("first epoch"), makeUsage());
+
+    // Reset the raw body (what every reset site does) but keep a poisoned memo.
+    analytics.lastRequestBody = null;
+    analytics.lastNormalizedBody = compressBody(
+      normalizeBodyForComparison(turnBody("poison from a previous epoch")),
+    );
+
+    // Next turn: the null guard must skip comparison entirely (first-turn),
+    // never touching the stale memo, and re-establish fresh state.
+    const afterReset = analyzeCacheTurn(
+      analytics,
+      turnBody("second"),
+      makeUsage(),
+    );
+    expect(afterReset.divergencePoint).toBe("<first-turn>");
+
+    // The turn after that repeats the same body: it must be identical, proving
+    // the memo now in effect is the fresh one from `afterReset`, not the poison.
+    const repeat = analyzeCacheTurn(analytics, turnBody("second"), makeUsage());
+    expect(repeat.divergencePoint).toBe("<identical>");
+    expect(repeat.prefixMatchPercent).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // normalizeBodyForComparison
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

`analyzeCacheTurn` runs on **every turn** and, to do its byte-level prefix
divergence comparison, needs the previous turn's **normalized** request body.
Today it re-derives that from scratch each turn:

```
decompressBody(lastRequestBody)            // zstd decompress of the raw body
  → normalizeBodyForComparison(...)        // 4 regex passes over the whole body
```

But that exact normalized string was **already computed last turn** — it was that
turn's `normalizedBody`. We throw it away and recompute it. On real sessions the
request body runs to hundreds of KB, so this is a full extra normalization (4
global-regex passes) of a large string on the hot path, every single turn.

This PR memoizes it: store the normalized body **zstd-compressed** alongside the
raw body, and reuse it next turn. One full-body normalization per turn is removed.

Part of #1077 (move per-turn work off the gateway main thread). Closes #1078.

## How it stays correct (and why no reset-site churn)

- New **optional** field `CacheAnalytics.lastNormalizedBody` (compressed). Optional
  purely so callers/fixtures that build the analytics object without it still
  type-check — the reader falls back to `decompress(raw) + normalize` when it's
  absent. (`cacheAnalytics` is not persisted; every session builds it fresh with
  `lastRequestBody: null`, so there are no "old" objects on disk — the fallback is
  defensive, not a migration path.)
- It's written in exactly one place — the same spot that assigns
  `analytics.lastRequestBody` — and `lastRequestBody` is the **only** field
  assigned a non-null value there (every other site only sets it to `null`). The
  divergence reader only consults the memo **inside** the existing
  `if (analytics.lastRequestBody !== null)` guard. So whenever the guard passes,
  the memo reflects the same body; the `… = null` reset sites (idle resume +
  several pipeline reset points) just skip the guard, and the stale memo (never
  read) is overwritten on the next analyzed turn. **No reset-site changes needed.**
- Output is provably byte-identical: zstd is lossless and `normalizeBodyForComparison`
  is deterministic, so the cached string equals what a fresh normalize would yield.
- The raw body storage is untouched — the cache warmer still replays the exact
  as-sent bytes (cache_control + valid-hex billing header intact).

## Cost / benefit

- **Saved:** one `normalizeBodyForComparison` (4 full-body regex passes) per turn.
- **Added:** one extra `compressBody(normalizedBody)` per turn. These bodies
  compress ~99% (highly repetitive JSON), so the extra stored blob is a few
  hundred bytes — negligible per-session memory. Microbenchmark on a ~200 KB body:
  net ~0.67 ms/turn faster (removes ~1.2 ms normalize, adds ~0.53 ms compress).

## Tests

`packages/gateway/test/cache-analytics.test.ts` — new `normalized-body memoization`
block (4 tests):

1. stores the normalized body compressed alongside the raw body (and the memo
   equals `normalizeBodyForComparison(raw)`).
2. **parity:** memoized path is byte-identical to the decompress+normalize
   fallback (same `prefixMatchBytes` / `prefixMatchPercent` / `divergencePoint` /
   `divergenceReason` / length) — proves the memo is a pure perf shortcut.
3. **mutation guard:** poisoning the memo makes an otherwise-identical turn report
   divergence — proves the memo actually drives the comparison.
4. **reset safety:** a stale memo left behind after a `lastRequestBody = null`
   reset is never consulted — the next turn is `<first-turn>` and re-establishes
   fresh state, so the poison never leaks into a later comparison.

Mutation-verified (isolated worktree): reverting the reader to always re-normalize
(ignoring the memo) fails the mutation-guard test; storing the raw body instead of
the normalized one fails 9 tests. Restored, all 91 file tests + full cache suite
pass. Typecheck + biome clean.
