### PR TITLE
feat(gateway): resolve worker model to newest in family

### DIFF
--- a/packages/gateway/src/worker-model.ts
+++ b/packages/gateway/src/worker-model.ts
@@ -115,6 +115,15 @@ const FALLBACK_PRICING: Array<{
   },
   // Worker model defaults
   {
+    prefix: "claude-sonnet-5",
+    input: 2,
+    output: 10,
+    cache_read: 0.2,
+    cache_write: 2.5,
+    context: 1_000_000,
+    outputLimit: 128_000,
+  },
+  {
     prefix: "claude-sonnet-4",
     input: 3,
     output: 15,

--- a/packages/gateway/src/worker-model.ts
+++ b/packages/gateway/src/worker-model.ts
@@ -41,6 +41,14 @@ const SUPPORTED_PROVIDERS = ["anthropic", "openai"] as const;
 /** Shape of a model entry in the models.dev JSON API. */
 export type ModelsDevEntry = {
   id: string;
+  /**
+   * models.dev model family (e.g. "claude-sonnet", "gpt-mini", "gpt-codex").
+   * Groups successive generations of the same tier so worker defaults can
+   * track the newest member instead of pinning a hardcoded ID that goes stale.
+   */
+  family?: string;
+  /** ISO `YYYY-MM-DD` release date — lexicographically sortable == chronological. */
+  release_date?: string;
   cost?: {
     input?: number;
     output?: number;
@@ -419,13 +427,20 @@ export function clearModelDataCache(): void {
  * Find a cheaper model from the same provider using models.dev pricing data.
  *
  * For providers without hardcoded WORKER_DEFAULTS (Google, MiniMax, xAI, etc.),
- * this searches the cached models.dev data for a model that:
- *   1. Belongs to the same provider
- *   2. Costs less than the session model (input price)
- *   3. Has the lowest input cost among candidates (cheapest available)
- *   4. Is not the session model itself
+ * this is family-aware so a discovered worker tracks new generations the same
+ * way the hardcoded WORKER_DEFAULTS do (via `resolveNewestInFamily`):
  *
- * Returns the model ID of the cheapest alternative, or undefined if none found.
+ *   1. Pass 1 — find the absolute cheapest same-provider model strictly cheaper
+ *      than the session (input price). Its family identifies the cheapest TIER.
+ *   2. Pass 2 — within that cheapest family, return the NEWEST member that is
+ *      still cheaper than the session. This avoids pinning an obsolete model
+ *      just because it's a few cents cheaper than its modern sibling (e.g.
+ *      gemini-2.5-flash-lite over a newer gemini-3-flash-lite), while staying
+ *      in the same cost tier and never exceeding the session price.
+ *
+ * Falls back to the Pass-1 cheapest when the cheapest model has no family
+ * metadata (preserving the original cheapest-by-cost behavior offline).
+ * Returns undefined if no cheaper model exists.
  */
 function findCheaperSameProviderModel(
   providerID: string,
@@ -435,29 +450,115 @@ function findCheaperSameProviderModel(
   const providerModelIds = cachedProviderModels?.get(providerID);
   if (!providerModelIds || !cachedModelData) return undefined;
 
+  // Pass 1: cheapest same-provider model cheaper than the session.
   let cheapestId: string | undefined;
   let cheapestCost = sessionInputCost;
-
+  let cheapestFamily: string | undefined;
   for (const modelId of providerModelIds) {
     if (modelId === sessionModelID) continue;
     const entry = cachedModelData.get(modelId);
     if (entry?.cost?.input == null) continue;
-    // Must be cheaper than the session model AND cheaper than any
-    // candidate we've found so far
     if (entry.cost.input < cheapestCost) {
       cheapestCost = entry.cost.input;
       cheapestId = modelId;
+      cheapestFamily = entry.family;
+    }
+  }
+  if (!cheapestId) return undefined;
+
+  // Pass 2: within the cheapest family, prefer the newest member that is still
+  // cheaper than the session (release_date desc, then id desc tie-break).
+  let resolvedId = cheapestId;
+  if (cheapestFamily) {
+    let bestDate = cachedModelData.get(cheapestId)?.release_date ?? "";
+    for (const modelId of providerModelIds) {
+      if (modelId === sessionModelID) continue;
+      const entry = cachedModelData.get(modelId);
+      if (entry?.family !== cheapestFamily) continue;
+      if (entry.cost?.input == null || entry.cost.input >= sessionInputCost) {
+        continue;
+      }
+      const date = entry.release_date ?? "";
+      if (date > bestDate || (date === bestDate && modelId > resolvedId)) {
+        bestDate = date;
+        resolvedId = modelId;
+      }
     }
   }
 
-  if (cheapestId) {
-    log.info(
-      `dynamic worker model: ${providerID}/${cheapestId} ($${cheapestCost}/M) ` +
-        `instead of ${sessionModelID} ($${sessionInputCost}/M)`,
-    );
+  const resolvedCost = cachedModelData.get(resolvedId)?.cost?.input;
+  log.info(
+    `dynamic worker model: ${providerID}/${resolvedId} ($${resolvedCost}/M` +
+      `${cheapestFamily ? `, family ${cheapestFamily}` : ""}) ` +
+      `instead of ${sessionModelID} ($${sessionInputCost}/M)`,
+  );
+
+  return resolvedId;
+}
+
+/**
+ * Resolve the NEWEST model in a target family from models.dev data.
+ *
+ * Replaces a hardcoded worker model ID (e.g. "claude-sonnet-4-6") with the
+ * freshest equivalent the provider currently ships (e.g. "claude-sonnet-5"),
+ * so worker defaults don't go stale as new model generations land.
+ *
+ * A candidate qualifies when it:
+ *   1. Belongs to `providerID` (per the models.dev provider→models index).
+ *   2. Has models.dev `family === family`.
+ *   3. Passes `isCheapVariant(id)` — the SAME predicate that decides whether a
+ *      session model is "already cheap". Within a family this discriminates the
+ *      cheap tier from the full tier. This is the codex caveat: family
+ *      "gpt-codex" contains both gpt-5.x-codex AND gpt-5.x-codex-mini; only the
+ *      mini is a valid worker, so "newest in family" must never upgrade to the
+ *      full codex.
+ *   4. Costs strictly less than `maxInputCost` ($/M) when pricing is known — a
+ *      defensive cost-aware guard so a newer family member can never be pricier
+ *      than the session model. Unknown pricing is allowed through (it already
+ *      passed the family + cheap-variant filters).
+ *
+ * Returns the newest qualifying model ID (release_date desc, then id desc as a
+ * deterministic tie-break), or undefined when none qualify / the cache is cold
+ * — in which case the caller falls back to the hardcoded `WORKER_DEFAULTS` ID.
+ */
+function resolveNewestInFamily(
+  providerID: string,
+  family: string,
+  isCheapVariant: (id: string) => boolean,
+  maxInputCost: number,
+): string | undefined {
+  const providerModelIds = cachedProviderModels?.get(providerID);
+  if (!providerModelIds || !cachedModelData) return undefined;
+
+  let bestId: string | undefined;
+  let bestDate = "";
+  for (const id of providerModelIds) {
+    const entry = cachedModelData.get(id);
+    if (!entry || entry.family !== family) continue;
+    if (!isCheapVariant(id)) continue;
+    // Cost guard: skip family members priced at/above the session model.
+    // Missing pricing is permitted — it already cleared the cheap-variant gate.
+    const input = entry.cost?.input;
+    if (input != null && input >= maxInputCost) continue;
+
+    // release_date is ISO YYYY-MM-DD, so string comparison is chronological.
+    const date = entry.release_date ?? "";
+    if (
+      bestId === undefined ||
+      date > bestDate ||
+      (date === bestDate && id > bestId)
+    ) {
+      bestId = id;
+      bestDate = date;
+    }
   }
 
-  return cheapestId;
+  if (bestId) {
+    log.info(
+      `worker model: newest in family ${providerID}/${family} → ${bestId}`,
+    );
+  }
+  return bestId;
 }
 
 // ---------------------------------------------------------------------------
@@ -484,32 +585,57 @@ function findCheaperSameProviderModel(
  */
 const WORKER_DEFAULTS: Record<
   string,
-  { providerID: string; modelID: string; alreadyCheap: (id: string) => boolean }
+  {
+    providerID: string;
+    modelID: string;
+    /**
+     * models.dev family the worker should track. When set, the cost-aware
+     * default resolves to the NEWEST cheap-tier member of this family
+     * (via `resolveNewestInFamily`), and `modelID` becomes the offline
+     * fallback used only when models.dev data is unavailable or yields
+     * no qualifying candidate.
+     */
+    family?: string;
+    alreadyCheap: (id: string) => boolean;
+  }
 > = {
-  // Anthropic: sonnet-4-6 matches opus quality on distillation at 40% lower cost
+  // Anthropic: sonnet matches opus quality on distillation at lower cost.
+  // family "claude-sonnet" tracks the newest sonnet live from models.dev; the
+  // modelID is only the OFFLINE fallback, so keep it on the current newest
+  // (claude-sonnet-5, $2/$10 — cheaper AND newer than the old sonnet-4-6 pin).
   anthropic: {
     providerID: "anthropic",
-    modelID: "claude-sonnet-4-6",
+    modelID: "claude-sonnet-5",
+    family: "claude-sonnet",
     alreadyCheap: (id) => id.includes("sonnet") || id.includes("haiku"),
   },
-  // OpenAI: gpt-5.4-mini matched gpt-5.4 exactly (24 obs each) at 70% lower cost
+  // OpenAI: gpt-5.4-mini matched gpt-5.4 exactly (24 obs each) at 70% lower cost.
+  // family "gpt-mini" tracks the newest mini (gpt-5.x-mini, gpt-4.1-mini, ...).
   openai: {
     providerID: "openai",
     modelID: "gpt-5.4-mini",
+    family: "gpt-mini",
     alreadyCheap: (id) => id.includes("mini") || id.includes("nano"),
   },
   // Codex (ChatGPT): the backend serves cheaper models on the same endpoint.
   // gpt-5.1-codex-mini ($0.25/$2) vs gpt-5.5 ($5/$30) — ~20x cheaper input,
   // same provider, same OAuth credential, same /codex/responses endpoint.
+  // CAVEAT: family "gpt-codex" also contains the FULL gpt-5.x-codex models;
+  // the `alreadyCheap` (mini/spark) filter inside resolveNewestInFamily keeps
+  // us on the mini tier so "newest in family" never upgrades to full codex.
   "openai-codex": {
     providerID: "openai-codex",
     modelID: "gpt-5.1-codex-mini",
+    family: "gpt-codex",
     alreadyCheap: (id) => id.includes("mini") || id.includes("spark"),
   },
-  // GitHub Copilot proxies multiple providers — match by model ID prefix
+  // GitHub Copilot proxies multiple providers — match by model ID prefix.
+  // No `family`: Copilot's family resolution is handled by
+  // resolveGitHubCopilotWorker (model IDs use different formatting, e.g.
+  // "claude-sonnet-4.6"), so this entry serves only as a last-resort fallback.
   "github-copilot": {
     providerID: "github-copilot",
-    modelID: "gpt-5.4-mini", // default; overridden by _resolveGitHubCopilotWorker
+    modelID: "gpt-5.4-mini", // default; overridden by resolveGitHubCopilotWorker
     alreadyCheap: (id) =>
       id.includes("mini") ||
       id.includes("nano") ||
@@ -618,9 +744,20 @@ export function getWorkerModel(session?: {
       } else {
         const mapping = WORKER_DEFAULTS[effectiveProvider];
         if (mapping && !mapping.alreadyCheap(effectiveModelID)) {
+          // Prefer the newest cheap-tier member of the target family from
+          // models.dev (so the worker tracks new generations automatically);
+          // fall back to the hardcoded modelID when data is cold/unavailable.
+          const newest = mapping.family
+            ? resolveNewestInFamily(
+                mapping.providerID,
+                mapping.family,
+                mapping.alreadyCheap,
+                inputCost,
+              )
+            : undefined;
           costAwareDefault = {
             providerID: mapping.providerID,
-            modelID: mapping.modelID,
+            modelID: newest ?? mapping.modelID,
           };
         }
         // Unknown providers: try to find a cheaper model from the same

--- a/packages/gateway/src/worker-model.ts
+++ b/packages/gateway/src/worker-model.ts
@@ -476,7 +476,8 @@ function findCheaperSameProviderModel(
   if (!cheapestId) return undefined;
 
   // Pass 2: within the cheapest family, prefer the newest member that is still
-  // cheaper than the session (release_date desc, then id desc tie-break).
+  // cheaper than the session (release_date desc, then numeric-aware id desc so
+  // "-10" sorts after "-9").
   let resolvedId = cheapestId;
   if (cheapestFamily) {
     let bestDate = cachedModelData.get(cheapestId)?.release_date ?? "";
@@ -488,7 +489,11 @@ function findCheaperSameProviderModel(
         continue;
       }
       const date = entry.release_date ?? "";
-      if (date > bestDate || (date === bestDate && modelId > resolvedId)) {
+      if (
+        date > bestDate ||
+        (date === bestDate &&
+          modelId.localeCompare(resolvedId, "en", { numeric: true }) > 0)
+      ) {
         bestDate = date;
         resolvedId = modelId;
       }
@@ -521,14 +526,16 @@ function findCheaperSameProviderModel(
  *      "gpt-codex" contains both gpt-5.x-codex AND gpt-5.x-codex-mini; only the
  *      mini is a valid worker, so "newest in family" must never upgrade to the
  *      full codex.
- *   4. Costs strictly less than `maxInputCost` ($/M) when pricing is known — a
- *      defensive cost-aware guard so a newer family member can never be pricier
- *      than the session model. Unknown pricing is allowed through (it already
- *      passed the family + cheap-variant filters).
+ *   4. Has KNOWN pricing that costs strictly less than `maxInputCost` ($/M) — a
+ *      cost-aware guard so a worker is never pricier than the session model.
+ *      Members with unknown pricing are skipped: we cannot prove they clear the
+ *      cap, so the caller falls back to the known-cheap hardcoded default rather
+ *      than guessing.
  *
- * Returns the newest qualifying model ID (release_date desc, then id desc as a
- * deterministic tie-break), or undefined when none qualify / the cache is cold
- * — in which case the caller falls back to the hardcoded `WORKER_DEFAULTS` ID.
+ * Returns the newest qualifying model ID (release_date desc, then numeric-aware
+ * id desc as a deterministic tie-break), or undefined when none qualify / the
+ * cache is cold — in which case the caller falls back to the hardcoded
+ * `WORKER_DEFAULTS` ID.
  */
 function resolveNewestInFamily(
   providerID: string,
@@ -545,17 +552,20 @@ function resolveNewestInFamily(
     const entry = cachedModelData.get(id);
     if (!entry || entry.family !== family) continue;
     if (!isCheapVariant(id)) continue;
-    // Cost guard: skip family members priced at/above the session model.
-    // Missing pricing is permitted — it already cleared the cheap-variant gate.
+    // Cost guard: skip family members priced at/above the session model, and
+    // members with unknown pricing — we cannot prove they clear the cap, so we
+    // fall back to the known-cheap hardcoded default instead of guessing.
     const input = entry.cost?.input;
-    if (input != null && input >= maxInputCost) continue;
+    if (input == null || input >= maxInputCost) continue;
 
     // release_date is ISO YYYY-MM-DD, so string comparison is chronological.
+    // Tie-break on id with numeric awareness so "-10" sorts after "-9".
     const date = entry.release_date ?? "";
     if (
       bestId === undefined ||
       date > bestDate ||
-      (date === bestDate && id > bestId)
+      (date === bestDate &&
+        id.localeCompare(bestId, "en", { numeric: true }) > 0)
     ) {
       bestId = id;
       bestDate = date;

--- a/packages/gateway/test/worker-model.test.ts
+++ b/packages/gateway/test/worker-model.test.ts
@@ -655,6 +655,19 @@ describe("getModelEntrySync", () => {
     expect(entry.limit?.context).toBe(1_000_000);
   });
 
+  test("offline fallback prices claude-sonnet-5 at its real cost, not the generic default", () => {
+    // claude-sonnet-5 is the anthropic worker default + a common session model.
+    // Its FALLBACK_PRICING prefix must NOT collide with claude-sonnet-4 and must
+    // resolve to the real $2/$10 instead of the generic $3/$15 unknown default.
+    const entry = getModelEntrySync("claude-sonnet-5");
+    expect(entry.cost?.input).toBe(2);
+    expect(entry.cost?.output).toBe(10);
+    expect(entry.cost?.cache_read).toBe(0.2);
+    expect(entry.cost?.cache_write).toBe(2.5);
+    expect(entry.limit?.context).toBe(1_000_000);
+    expect(entry.limit?.output).toBe(128_000);
+  });
+
   test("returns cached data after fetchModelData populates cache", async () => {
     globalThis.fetch = vi.fn(() =>
       Promise.resolve(

--- a/packages/gateway/test/worker-model.test.ts
+++ b/packages/gateway/test/worker-model.test.ts
@@ -955,6 +955,302 @@ describe("dynamic cheaper-model discovery", () => {
 });
 
 // ---------------------------------------------------------------------------
+// family-based worker resolution (newest cheap-tier member of a family)
+// ---------------------------------------------------------------------------
+
+describe("family-based worker resolution", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    resetWorkerModelState();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    resetWorkerModelState();
+  });
+
+  const LIMIT = { context: 200_000, output: 64_000 };
+
+  /** Warm the models.dev cache with a raw response carrying family metadata. */
+  async function warmCache(response: unknown): Promise<void> {
+    globalThis.fetch = vi.fn(() =>
+      Promise.resolve(new Response(JSON.stringify(response), { status: 200 })),
+    ) as unknown as typeof fetch;
+    resetWorkerModelState();
+    await fetchModelData();
+  }
+
+  test("anthropic expensive session resolves to the NEWEST sonnet in family (not the stale hardcoded id)", async () => {
+    await warmCache({
+      anthropic: {
+        api: "https://api.anthropic.com/v1",
+        models: {
+          "claude-opus-4-6": {
+            id: "claude-opus-4-6",
+            family: "claude-opus",
+            release_date: "2026-01-05",
+            cost: { input: 5, output: 25, cache_read: 0.5 },
+            limit: LIMIT,
+          },
+          "claude-sonnet-4-6": {
+            id: "claude-sonnet-4-6",
+            family: "claude-sonnet",
+            release_date: "2026-02-17",
+            cost: { input: 3, output: 15, cache_read: 0.3 },
+            limit: LIMIT,
+          },
+          // Newer sonnet generation — this is what the worker should track.
+          "claude-sonnet-5": {
+            id: "claude-sonnet-5",
+            family: "claude-sonnet",
+            release_date: "2026-06-01",
+            cost: { input: 3, output: 15, cache_read: 0.3 },
+            limit: LIMIT,
+          },
+          // Same cheap tier, DIFFERENT family — must be excluded.
+          "claude-haiku-4-5": {
+            id: "claude-haiku-4-5",
+            family: "claude-haiku",
+            release_date: "2025-10-15",
+            cost: { input: 1, output: 5, cache_read: 0.1 },
+            limit: LIMIT,
+          },
+        },
+      },
+    });
+
+    const result = getWorkerModel({
+      providerID: "anthropic",
+      model: "claude-opus-4-6",
+    });
+
+    expect(result?.providerID).toBe("anthropic");
+    // Newest in the claude-sonnet family, NOT the hardcoded claude-sonnet-4-6.
+    expect(result?.modelID).toBe("claude-sonnet-5");
+  });
+
+  test("codex: tracks the newest MINI in family, never upgrades to the full codex (codex caveat)", async () => {
+    await warmCache({
+      anthropic: { api: "https://api.anthropic.com/v1", models: {} },
+      "openai-codex": {
+        api: "https://api.openai.com/v1",
+        models: {
+          "gpt-5.5": {
+            id: "gpt-5.5",
+            family: "gpt",
+            release_date: "2026-03-01",
+            cost: { input: 5, output: 30, cache_read: 1.25 },
+            limit: LIMIT,
+          },
+          "gpt-5.1-codex": {
+            id: "gpt-5.1-codex",
+            family: "gpt-codex",
+            release_date: "2025-11-13",
+            cost: { input: 1.25, output: 10, cache_read: 0.125 },
+            limit: LIMIT,
+          },
+          "gpt-5.1-codex-mini": {
+            id: "gpt-5.1-codex-mini",
+            family: "gpt-codex",
+            release_date: "2025-11-13",
+            cost: { input: 0.25, output: 2, cache_read: 0.025 },
+            limit: LIMIT,
+          },
+          // NEWER full codex — cheaper than the session but NOT a mini; the
+          // cheap-variant filter must exclude it so we never upgrade tier.
+          "gpt-5.3-codex": {
+            id: "gpt-5.3-codex",
+            family: "gpt-codex",
+            release_date: "2026-02-05",
+            cost: { input: 1.25, output: 10, cache_read: 0.125 },
+            limit: LIMIT,
+          },
+          // NEWER mini — this is the one the worker should track.
+          "gpt-5.4-codex-mini": {
+            id: "gpt-5.4-codex-mini",
+            family: "gpt-codex",
+            release_date: "2026-04-01",
+            cost: { input: 0.3, output: 2.5, cache_read: 0.03 },
+            limit: LIMIT,
+          },
+        },
+      },
+    });
+
+    const result = getWorkerModel({
+      providerID: "openai-codex",
+      model: "gpt-5.5",
+    });
+
+    expect(result?.providerID).toBe("openai-codex");
+    // Newest cheap-variant in gpt-codex: NOT the newer full gpt-5.3-codex,
+    // NOT the stale hardcoded gpt-5.1-codex-mini.
+    expect(result?.modelID).toBe("gpt-5.4-codex-mini");
+  });
+
+  test("cost guard: a newer family member priced at/above the session is rejected for an older cheaper one", async () => {
+    await warmCache({
+      anthropic: {
+        api: "https://api.anthropic.com/v1",
+        models: {
+          // Session model priced at $2/M (above the $1.50 downgrade threshold).
+          "claude-opus-4-6": {
+            id: "claude-opus-4-6",
+            family: "claude-opus",
+            release_date: "2026-01-05",
+            cost: { input: 2, output: 10, cache_read: 0.2 },
+            limit: LIMIT,
+          },
+          "claude-sonnet-4-6": {
+            id: "claude-sonnet-4-6",
+            family: "claude-sonnet",
+            release_date: "2026-02-17",
+            cost: { input: 1.5, output: 7.5, cache_read: 0.15 },
+            limit: LIMIT,
+          },
+          // Newer sonnet but PRICIER than the session ($2.5 ≥ $2) — the cost
+          // guard must skip it, leaving the older, cheaper sonnet-4-6.
+          "claude-sonnet-5": {
+            id: "claude-sonnet-5",
+            family: "claude-sonnet",
+            release_date: "2026-06-01",
+            cost: { input: 2.5, output: 12, cache_read: 0.25 },
+            limit: LIMIT,
+          },
+        },
+      },
+    });
+
+    const result = getWorkerModel({
+      providerID: "anthropic",
+      model: "claude-opus-4-6",
+    });
+
+    expect(result?.providerID).toBe("anthropic");
+    // sonnet-5 is newer but pricier than the $2 session → rejected by the
+    // cost guard; the older but cheaper sonnet-4-6 wins.
+    expect(result?.modelID).toBe("claude-sonnet-4-6");
+  });
+
+  test("offline fallback: with no models.dev data, uses the hardcoded WORKER_DEFAULTS id", async () => {
+    // Fetch fails → cachedModelData stays null → family resolution returns
+    // undefined → caller falls back to the hardcoded modelID.
+    globalThis.fetch = vi.fn(() =>
+      Promise.reject(new Error("offline")),
+    ) as unknown as typeof fetch;
+    resetWorkerModelState();
+    await fetchModelData();
+    expect(isModelDataLoaded()).toBe(false);
+
+    const result = getWorkerModel({
+      providerID: "anthropic",
+      model: "claude-opus-4-6",
+    });
+
+    expect(result?.providerID).toBe("anthropic");
+    // Hardcoded WORKER_DEFAULTS offline fallback (current newest sonnet).
+    expect(result?.modelID).toBe("claude-sonnet-5");
+  });
+
+  test("unknown provider: family-aware pick favors the NEWEST member of the cheapest family", async () => {
+    // google isn't in WORKER_DEFAULTS → findCheaperSameProviderModel path.
+    // The absolute-cheapest is an OLD flash-lite; a NEWER flash-lite is still
+    // cheaper than the session. Family-aware resolution must pick the newer one.
+    await warmCache({
+      anthropic: { api: "https://api.anthropic.com/v1", models: {} },
+      google: {
+        api: "https://generativelanguage.googleapis.com/v1beta",
+        models: {
+          "gemini-3.1-pro": {
+            id: "gemini-3.1-pro",
+            family: "gemini-pro",
+            release_date: "2026-05-01",
+            cost: { input: 4, output: 20 },
+            limit: LIMIT,
+          },
+          // Cheapest model overall, but an OLD generation.
+          "gemini-2.5-flash-lite": {
+            id: "gemini-2.5-flash-lite",
+            family: "gemini-flash-lite",
+            release_date: "2025-06-01",
+            cost: { input: 0.1, output: 0.4 },
+            limit: LIMIT,
+          },
+          // Same (cheapest) family, NEWER, still far cheaper than the session.
+          "gemini-3-flash-lite": {
+            id: "gemini-3-flash-lite",
+            family: "gemini-flash-lite",
+            release_date: "2026-04-01",
+            cost: { input: 0.15, output: 0.6 },
+            limit: LIMIT,
+          },
+          // Cheaper than session but a DIFFERENT (pricier) family — must lose
+          // to the flash-lite family chosen by lowest cost.
+          "gemini-3-flash": {
+            id: "gemini-3-flash",
+            family: "gemini-flash",
+            release_date: "2026-04-15",
+            cost: { input: 1, output: 5 },
+            limit: LIMIT,
+          },
+        },
+      },
+    });
+
+    const result = getWorkerModel({
+      providerID: "google",
+      model: "gemini-3.1-pro",
+    });
+
+    expect(result?.providerID).toBe("google");
+    // Newest in the cheapest (flash-lite) family — NOT the older
+    // gemini-2.5-flash-lite, NOT the pricier gemini-3-flash family.
+    expect(result?.modelID).toBe("gemini-3-flash-lite");
+  });
+
+  test("unknown provider: without family metadata, falls back to absolute cheapest", async () => {
+    // No family fields → Pass 2 is skipped → original cheapest-by-cost behavior.
+    await warmCache({
+      anthropic: { api: "https://api.anthropic.com/v1", models: {} },
+      google: {
+        api: "https://generativelanguage.googleapis.com/v1beta",
+        models: {
+          "gemini-3.1-pro": {
+            id: "gemini-3.1-pro",
+            release_date: "2026-05-01",
+            cost: { input: 4, output: 20 },
+            limit: LIMIT,
+          },
+          "gemini-3-flash": {
+            id: "gemini-3-flash",
+            release_date: "2026-04-15",
+            cost: { input: 1, output: 5 },
+            limit: LIMIT,
+          },
+          "gemini-3-flash-lite": {
+            id: "gemini-3-flash-lite",
+            release_date: "2026-04-01",
+            cost: { input: 0.15, output: 0.6 },
+            limit: LIMIT,
+          },
+        },
+      },
+    });
+
+    const result = getWorkerModel({
+      providerID: "google",
+      model: "gemini-3.1-pro",
+    });
+
+    expect(result?.providerID).toBe("google");
+    // Absolute cheapest, since there is no family metadata to refine on.
+    expect(result?.modelID).toBe("gemini-3-flash-lite");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // resetWorkerModelState
 // ---------------------------------------------------------------------------
 

--- a/packages/gateway/test/worker-model.test.ts
+++ b/packages/gateway/test/worker-model.test.ts
@@ -1007,16 +1007,20 @@ describe("family-based worker resolution", () => {
             cost: { input: 5, output: 25, cache_read: 0.5 },
             limit: LIMIT,
           },
-          "claude-sonnet-4-6": {
-            id: "claude-sonnet-4-6",
+          // Hardcoded WORKER_DEFAULTS offline fallback id.
+          "claude-sonnet-5": {
+            id: "claude-sonnet-5",
             family: "claude-sonnet",
             release_date: "2026-02-17",
             cost: { input: 3, output: 15, cache_read: 0.3 },
             limit: LIMIT,
           },
           // Newer sonnet generation — this is what the worker should track.
-          "claude-sonnet-5": {
-            id: "claude-sonnet-5",
+          // Deliberately DISTINCT from the hardcoded fallback (claude-sonnet-5)
+          // so a disabled/cold resolver (which returns the fallback) fails this
+          // assertion instead of coincidentally passing.
+          "claude-sonnet-6": {
+            id: "claude-sonnet-6",
             family: "claude-sonnet",
             release_date: "2026-06-01",
             cost: { input: 3, output: 15, cache_read: 0.3 },
@@ -1040,8 +1044,9 @@ describe("family-based worker resolution", () => {
     });
 
     expect(result?.providerID).toBe("anthropic");
-    // Newest in the claude-sonnet family, NOT the hardcoded claude-sonnet-4-6.
-    expect(result?.modelID).toBe("claude-sonnet-5");
+    // Newest in the claude-sonnet family (claude-sonnet-6), NOT the hardcoded
+    // fallback claude-sonnet-5 — proving the resolver read models.dev.
+    expect(result?.modelID).toBe("claude-sonnet-6");
   });
 
   test("codex: tracks the newest MINI in family, never upgrades to the full codex (codex caveat)", async () => {
@@ -1088,6 +1093,17 @@ describe("family-based worker resolution", () => {
             cost: { input: 0.3, output: 2.5, cache_read: 0.03 },
             limit: LIMIT,
           },
+          // NEWEST full codex overall (newer than the newest mini) and still
+          // cheaper than the $5 session. Only the cheap-variant filter keeps the
+          // worker off this tier — without it, "newest in family" would pick
+          // this. Guards SHOULD-FIX #2: makes the codex-caveat test non-vacuous.
+          "gpt-5.6-codex": {
+            id: "gpt-5.6-codex",
+            family: "gpt-codex",
+            release_date: "2026-08-01",
+            cost: { input: 1.25, output: 10, cache_read: 0.125 },
+            limit: LIMIT,
+          },
         },
       },
     });
@@ -1098,8 +1114,8 @@ describe("family-based worker resolution", () => {
     });
 
     expect(result?.providerID).toBe("openai-codex");
-    // Newest cheap-variant in gpt-codex: NOT the newer full gpt-5.3-codex,
-    // NOT the stale hardcoded gpt-5.1-codex-mini.
+    // Newest cheap-variant in gpt-codex: NOT the NEWER full gpt-5.6-codex,
+    // NOT the older full gpt-5.3-codex, NOT the stale hardcoded gpt-5.1-codex-mini.
     expect(result?.modelID).toBe("gpt-5.4-codex-mini");
   });
 
@@ -1145,6 +1161,94 @@ describe("family-based worker resolution", () => {
     // sonnet-5 is newer but pricier than the $2 session → rejected by the
     // cost guard; the older but cheaper sonnet-4-6 wins.
     expect(result?.modelID).toBe("claude-sonnet-4-6");
+  });
+
+  test("cost guard: a NEWER family member with UNKNOWN pricing is skipped for a known-cheap older one", async () => {
+    // A member with no cost.input cannot be proven to clear the price cap, so it
+    // must not be selected over a known-cheap sibling (guards NIT #3 — an
+    // unknown-price member must never bypass "never pricier than session").
+    await warmCache({
+      anthropic: {
+        api: "https://api.anthropic.com/v1",
+        models: {
+          "claude-opus-4-6": {
+            id: "claude-opus-4-6",
+            family: "claude-opus",
+            release_date: "2026-01-05",
+            cost: { input: 5, output: 25, cache_read: 0.5 },
+            limit: LIMIT,
+          },
+          // Older, but with KNOWN cheap pricing.
+          "claude-sonnet-5": {
+            id: "claude-sonnet-5",
+            family: "claude-sonnet",
+            release_date: "2026-02-17",
+            cost: { input: 3, output: 15, cache_read: 0.3 },
+            limit: LIMIT,
+          },
+          // NEWER, but pricing is UNKNOWN (no cost field) → must be skipped.
+          "claude-sonnet-6": {
+            id: "claude-sonnet-6",
+            family: "claude-sonnet",
+            release_date: "2026-06-01",
+            limit: LIMIT,
+          },
+        },
+      },
+    });
+
+    const result = getWorkerModel({
+      providerID: "anthropic",
+      model: "claude-opus-4-6",
+    });
+
+    expect(result?.providerID).toBe("anthropic");
+    // The unknown-price claude-sonnet-6 is skipped; the known-cheap
+    // claude-sonnet-5 wins even though it is older.
+    expect(result?.modelID).toBe("claude-sonnet-5");
+  });
+
+  test("tie-break: same release_date picks the numerically newer generation (-10 > -9)", async () => {
+    // Two same-family members share a release_date; the id tie-break must be
+    // numeric-aware so "claude-sonnet-4-10" beats "claude-sonnet-4-9" (plain
+    // string compare would wrongly pick -9). Guards NIT #4.
+    await warmCache({
+      anthropic: {
+        api: "https://api.anthropic.com/v1",
+        models: {
+          "claude-opus-4-6": {
+            id: "claude-opus-4-6",
+            family: "claude-opus",
+            release_date: "2026-01-05",
+            cost: { input: 5, output: 25, cache_read: 0.5 },
+            limit: LIMIT,
+          },
+          "claude-sonnet-4-9": {
+            id: "claude-sonnet-4-9",
+            family: "claude-sonnet",
+            release_date: "2026-05-01",
+            cost: { input: 3, output: 15, cache_read: 0.3 },
+            limit: LIMIT,
+          },
+          "claude-sonnet-4-10": {
+            id: "claude-sonnet-4-10",
+            family: "claude-sonnet",
+            release_date: "2026-05-01",
+            cost: { input: 3, output: 15, cache_read: 0.3 },
+            limit: LIMIT,
+          },
+        },
+      },
+    });
+
+    const result = getWorkerModel({
+      providerID: "anthropic",
+      model: "claude-opus-4-6",
+    });
+
+    expect(result?.providerID).toBe("anthropic");
+    // Numeric-aware tie-break: -10 is newer than -9 despite string ordering.
+    expect(result?.modelID).toBe("claude-sonnet-4-10");
   });
 
   test("offline fallback: with no models.dev data, uses the hardcoded WORKER_DEFAULTS id", async () => {


### PR DESCRIPTION
## Problem

Worker defaults pin a hardcoded model ID per provider (e.g. \`claude-sonnet-4-6\`), which goes stale as new model generations ship. The offline anthropic fallback was a generation behind.

## Change

Resolve the cost-aware worker default to the **newest cheap-tier member of a target models.dev family** instead of a fixed ID, with the hardcoded ID kept only as an offline fallback.

- **Type**: extend \`ModelsDevEntry\` with \`family\` + \`release_date\` (carried through the existing \`fetchModelData\` spread).
- **Known providers**: each \`WORKER_DEFAULTS\` entry gains a \`family\` target. \`resolveNewestInFamily\` picks the newest member that passes the existing cheap-variant predicate and a per-candidate **cost guard** (never pricier than the session model).
  - **Codex caveat**: family \`gpt-codex\` contains both full and \`-mini\` tiers; the cheap-variant filter keeps the worker on the mini tier so "newest in family" never upgrades to full codex.
- **Offline fallbacks**: refreshed the stale \`claude-sonnet-4-6\` → \`claude-sonnet-5\` (newer *and* cheaper). Verified against models.dev that \`gpt-5.4-mini\` and \`gpt-5.1-codex-mini\` are already the newest in their tiers, and Copilot's \`claude-sonnet-4.6\` is the newest sonnet Copilot offers — so those are unchanged.
- **Unknown-provider path** (\`findCheaperSameProviderModel\`) is now family-aware: pick the cheapest family, then the newest member within it, instead of a possibly-obsolete absolute-cheapest model. Falls back to absolute-cheapest when no family metadata exists.

## Tests

Adds focused tests for: newest-in-family resolution, the codex caveat, the cost guard, the offline fallback, and the unknown-provider family-aware path (incl. the no-family fallback). All assertions mutation-tested non-vacuous. Full gateway suite green (2361 passed); typecheck + Biome clean.