### PR TITLE
perf(ltm): offload forProject() scans to the read-worker pool

### DIFF
--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -21,6 +21,7 @@ import {
   offloadAllOrTimeout,
   READ_JOB_TIMED_OUT,
 } from "./read-offload";
+import type { ReadParam } from "./read-job";
 import { ReadPathTimer } from "./read-telemetry";
 import { sessionVerifierVerdict } from "./tool-trace";
 import * as latReader from "./lat-reader";
@@ -838,31 +839,79 @@ export async function findSemanticDuplicate(input: {
   return null;
 }
 
+/**
+ * Build the `knowledge_current` candidate query shared by {@link forProject}
+ * and its off-thread twin {@link forProjectOffloaded}, so both paths run
+ * byte-identical SQL + params and only the execution thread differs.
+ */
+function forProjectQuery(
+  pid: string,
+  includeCross: boolean,
+): { sql: string; params: ReadParam[] } {
+  const sql = includeCross
+    ? `SELECT ${KNOWLEDGE_COLS} FROM knowledge_current
+         WHERE (project_id = ? OR (project_id IS NULL) OR (cross_project = 1))
+         AND confidence > 0.2
+         ORDER BY confidence DESC, updated_at DESC`
+    : `SELECT ${KNOWLEDGE_COLS} FROM knowledge_current
+         WHERE project_id = ?
+         AND confidence > 0.2
+         ORDER BY confidence DESC, updated_at DESC`;
+  return { sql, params: [pid] };
+}
+
 export function forProject(
   projectPath: string,
   includeCross = true,
 ): KnowledgeEntry[] {
   const pid = ensureProject(projectPath);
-  if (includeCross) {
+  const { sql, params } = forProjectQuery(pid, includeCross);
+  return db()
+    .query(sql)
+    .all(...params)
+    .map(hydrateKnowledgeEntry) as KnowledgeEntry[];
+}
+
+/**
+ * Off-thread twin of {@link forProject}: runs the identical `knowledge_current`
+ * scan through the read-worker pool so this unbounded scan doesn't block the
+ * main event loop on the first-turn / compaction critical path. #1080.
+ *
+ * The result is ALWAYS the same set `forProject` would return — this is purely
+ * a "run the same query off-thread when possible" optimization, never a
+ * behavior change:
+ *   - pool available   → a worker runs the scan; we hydrate its rows.
+ *   - pool unavailable → `offloadAllOrTimeout` falls back to the identical
+ *                        in-process query (same SQL + params).
+ *   - worker TIMEOUT   → we re-run the scan IN-PROCESS rather than degrade to
+ *                        an empty set. This is deliberate and differs from the
+ *                        per-turn `forSession` path (which drops to [] on
+ *                        timeout, #1006): `forProject` feeds the DURABLY FROZEN
+ *                        system[1] knowledge catalog and the offline-compaction
+ *                        summary. A spuriously-empty result there would be
+ *                        frozen for the whole session / baked into the summary,
+ *                        so correctness wins over the "never re-block on
+ *                        timeout" rule for this small, once-per-session scan.
+ *
+ * `ensureProject()` may write, so it stays on the main thread (as read-offload
+ * requires); only the read itself is offloaded.
+ */
+export async function forProjectOffloaded(
+  projectPath: string,
+  includeCross = true,
+): Promise<KnowledgeEntry[]> {
+  const pid = ensureProject(projectPath);
+  const { sql, params } = forProjectQuery(pid, includeCross);
+  const rows = await offloadAllOrTimeout(sql, params);
+  if (rows === READ_JOB_TIMED_OUT) {
     return db()
-      .query(
-        `SELECT ${KNOWLEDGE_COLS} FROM knowledge_current
-         WHERE (project_id = ? OR (project_id IS NULL) OR (cross_project = 1))
-         AND confidence > 0.2
-         ORDER BY confidence DESC, updated_at DESC`,
-      )
-      .all(pid)
+      .query(sql)
+      .all(...params)
       .map(hydrateKnowledgeEntry) as KnowledgeEntry[];
   }
-  return db()
-    .query(
-      `SELECT ${KNOWLEDGE_COLS} FROM knowledge_current
-       WHERE project_id = ?
-       AND confidence > 0.2
-       ORDER BY confidence DESC, updated_at DESC`,
-    )
-    .all(pid)
-    .map(hydrateKnowledgeEntry) as KnowledgeEntry[];
+  return (rows as Record<string, unknown>[]).map(
+    hydrateKnowledgeEntry,
+  ) as KnowledgeEntry[];
 }
 
 /**

--- a/packages/core/test/ltm.test.ts
+++ b/packages/core/test/ltm.test.ts
@@ -1149,6 +1149,178 @@ describe("ltm.forSession", () => {
 });
 
 // ---------------------------------------------------------------------------
+// forProjectOffloaded — off-thread twin of forProject (#1080)
+// ---------------------------------------------------------------------------
+
+describe("ltm.forProjectOffloaded (#1080)", () => {
+  const PROJ = "/test/ltm/forproject-offload";
+  // Track every logical_id we mint so cleanup is SURGICAL: this block seeds a
+  // global cross-project entry (project_id IS NULL) which sibling blocks' by
+  // project_id cleanups would NOT reap, so a broad delete here would either
+  // leak into later blocks (e.g. #727's forSession budget) or clobber their
+  // globals. Deleting exactly what we created avoids both.
+  const created: string[] = [];
+
+  function cleanup(): void {
+    if (!created.length) return;
+    const placeholders = created.map(() => "?").join(",");
+    db()
+      .query(`DELETE FROM knowledge WHERE logical_id IN (${placeholders})`)
+      .run(...created);
+    created.length = 0;
+  }
+
+  beforeEach(() => {
+    ensureProject(PROJ);
+    cleanup();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    _setTestVectorWorkerFactory(null);
+    _resetVectorPoolForTest();
+    cleanup();
+  });
+
+  function seed(): void {
+    created.push(
+      ltm.create({
+        projectPath: PROJ,
+        category: "decision",
+        title: "Project-scoped decision",
+        content: "belongs to this project only",
+        scope: "project",
+        crossProject: false,
+        // Non-null metadata so hydrateKnowledgeEntry (JSON string → object) is
+        // an OBSERVABLE transform — the pool-rows test would miss a dropped
+        // hydration otherwise (a null-metadata row hydrates to itself).
+        metadata: { gitHead: "deadbee" },
+      }),
+    );
+    created.push(
+      ltm.create({
+        category: "preference",
+        title: "Global preference",
+        content: "shared across all projects",
+        scope: "global",
+        crossProject: true,
+      }),
+    );
+    // Below the confidence floor — must be excluded by BOTH paths.
+    const lowId = ltm.create({
+      projectPath: PROJ,
+      category: "pattern",
+      title: "Decayed entry",
+      content: "should never surface",
+      scope: "project",
+      crossProject: false,
+    });
+    created.push(lowId);
+    ltm.update(lowId, { confidence: 0.1 });
+  }
+
+  test("with the pool inert, returns exactly what the sync forProject returns", async () => {
+    seed();
+    for (const includeCross of [true, false]) {
+      const sync = ltm.forProject(PROJ, includeCross);
+      const offloaded = await ltm.forProjectOffloaded(PROJ, includeCross);
+      // Same rows, same deterministic order (confidence DESC, updated_at DESC).
+      expect(offloaded.map((e) => e.id)).toEqual(sync.map((e) => e.id));
+      expect(offloaded).toEqual(sync);
+      // Sanity: the below-floor entry is filtered out; the visible one is present.
+      expect(offloaded.some((e) => e.title === "Decayed entry")).toBe(false);
+      expect(offloaded.some((e) => e.title === "Project-scoped decision")).toBe(
+        true,
+      );
+    }
+  });
+
+  test("prefers the pool's result over the in-process scan when the pool serves it", async () => {
+    seed();
+    // A worker that answers every read with an EMPTY set. The DB genuinely has
+    // rows, so an empty result can ONLY come from the pool — proving the offload
+    // path is actually taken (not silently re-queried in-process).
+    class EmptyPoolWorker extends EventEmitter {
+      unref(): void {}
+      terminate(): Promise<number> {
+        this.emit("exit", 0);
+        return Promise.resolve(0);
+      }
+      postMessage(msg: { type: string; id: number }): void {
+        if (msg.type !== "read") return;
+        this.emit("message", { type: "read-result", id: msg.id, rows: [] });
+      }
+    }
+    _resetVectorPoolForTest();
+    _setTestVectorWorkerFactory((() => new EmptyPoolWorker()) as never);
+
+    expect(ltm.forProject(PROJ, true).length).toBeGreaterThan(0);
+    expect(await ltm.forProjectOffloaded(PROJ, true)).toEqual([]);
+  });
+
+  test("hydrates the pool's real rows in order (offloaded == in-process)", async () => {
+    // The positive path: a worker that actually SERVES the query (running it
+    // against the same db() from the fake worker) must produce entries that are
+    // byte-for-byte equal to the in-process scan — proving the offloaded rows
+    // are hydrated and ordered identically, not just that empty/timeout degrade.
+    seed();
+    const expected = ltm.forProject(PROJ, true);
+    expect(expected.length).toBeGreaterThan(0);
+
+    class ServingWorker extends EventEmitter {
+      unref(): void {}
+      terminate(): Promise<number> {
+        this.emit("exit", 0);
+        return Promise.resolve(0);
+      }
+      postMessage(msg: {
+        type: string;
+        id: number;
+        spec?: { sql: string; params: unknown[] };
+      }): void {
+        if (msg.type !== "read" || !msg.spec) return;
+        // Run the real parameterized query so the pool returns genuine rows.
+        const rows = db()
+          .query(msg.spec.sql)
+          .all(...msg.spec.params);
+        this.emit("message", { type: "read-result", id: msg.id, rows });
+      }
+    }
+    _resetVectorPoolForTest();
+    _setTestVectorWorkerFactory((() => new ServingWorker()) as never);
+
+    const offloaded = await ltm.forProjectOffloaded(PROJ, true);
+    expect(offloaded).toEqual(expected);
+  });
+
+  test("on a worker TIMEOUT falls back to the full in-process scan (never a spurious empty)", async () => {
+    // The frozen system[1] catalog / compaction summary must reflect the real
+    // knowledge set. A pool timeout must NOT yield [] (which would be frozen for
+    // the whole session) — forProjectOffloaded re-runs the scan in-process.
+    seed();
+    const expected = ltm.forProject(PROJ, true);
+    expect(expected.length).toBeGreaterThan(0);
+
+    class HangingWorker extends EventEmitter {
+      unref(): void {}
+      terminate(): Promise<number> {
+        this.emit("exit", 0);
+        return Promise.resolve(0);
+      }
+      postMessage(): void {
+        // never reply → forces the per-request timeout
+      }
+    }
+    _resetVectorPoolForTest();
+    _setTestVectorWorkerFactory((() => new HangingWorker()) as never);
+    vi.useFakeTimers();
+    const p = ltm.forProjectOffloaded(PROJ, true);
+    await vi.advanceTimersByTimeAsync(vectorSearchTimeoutMs() + 1);
+    expect((await p).map((e) => e.id)).toEqual(expected.map((e) => e.id));
+  });
+});
+
+// ---------------------------------------------------------------------------
 // REGRESSION: system[2] cache-bust via vector-scored set churn (#727).
 //
 // The cache-bust bug only manifests on the VECTOR scoring path (embeddings

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -5419,7 +5419,7 @@ export async function generateCompactionSummary(opts: {
   const distillations = distillation.loadForSession(projectPath, sessionID);
   const cfg = loreConfig();
   const entries = cfg.knowledge.enabled
-    ? ltm.forProject(projectPath, cfg.crossProject)
+    ? await ltm.forProjectOffloaded(projectPath, cfg.crossProject)
     : [];
   const knowledge = entries.length
     ? formatKnowledge(
@@ -6688,8 +6688,7 @@ async function handleConversationTurn(
         // handled separately by the knowledge delta (#917 "B").
         let knowledgeTocText = "";
         try {
-          const catalog = ltm
-            .forProject(projectPath, false)
+          const catalog = (await ltm.forProjectOffloaded(projectPath, false))
             .filter((e) => e.category !== "preference")
             .map((e) => ({ id: e.id, category: e.category, title: e.title }));
           knowledgeTocText = buildKnowledgeCatalogText(


### PR DESCRIPTION
## What

`ltm.forProject()` (`packages/core/src/ltm.ts`) is an **unbounded synchronous
scan** of `knowledge_current` (`ORDER BY confidence DESC`, no `LIMIT`). It runs
on the **main thread** on two already-async hot paths:

- the per-session **frozen system[1] knowledge catalog** (`pipeline.ts` turn
  baseline), and
- the **offline-compaction** summary assembler.

Its per-turn `forSession` siblings already offload their `knowledge_current`
scans to the read-worker pool (`offloadAllOrTimeout`); `forProject` did not.
Part of #1077 (Workstream B — offload synchronous DB reads). Closes #1080.

## How

- Extract a single `forProjectQuery(pid, includeCross)` builder so the sync and
  offloaded paths run **byte-identical SQL + params**.
- Add async `forProjectOffloaded()` that runs that query through
  `offloadAllOrTimeout`, and route the two async callers (frozen system[1]
  catalog + offline-compaction) through it. `ensureProject()` stays on the main
  thread (it may write); only the read is offloaded.

## The one subtlety: timeout must NOT degrade to `[]`

The per-turn `forSession` path degrades to `[]` on a worker timeout (#1006) —
fine, because it recomputes every turn. `forProject` is different: its result
feeds the **durably frozen** system[1] catalog and the compaction summary, so a
spuriously-empty result would be **frozen for the whole session** / baked into
the summary.

So on a worker `TIMEOUT`, `forProjectOffloaded` **re-runs the scan in-process**
instead of returning `[]`. The result is therefore **always** the exact set
`forProject` would return — this is purely "run the same scan off-thread when
possible", never a behavior change:

| pool state | behavior |
|---|---|
| available | worker runs the scan; we hydrate its rows |
| unavailable | `offloadAllOrTimeout` falls back to the identical in-process query |
| worker timeout | re-run the scan in-process (never a spurious empty) |

Because it's identical-result-always, no caller needed behavior changes — just
`await`. The 12 background/synchronous callers keep the sync `forProject`; only
the two async hot-path callers were switched.

## Tests

`packages/core/test/ltm.test.ts` — new `ltm.forProjectOffloaded (#1080)` block:

1. **parity** — with the pool inert, returns exactly what sync `forProject`
   returns (same rows, same deterministic order) for both `includeCross`
   values; the below-floor entry is filtered out on both paths.
2. **pool preferred** — a worker that serves an empty set makes
   `forProjectOffloaded` return `[]` while `forProject` (in-process) returns the
   seeded rows — proving the offload path is actually taken.
3. **pool rows hydrated in order** — a fake worker that actually serves the
   query returns genuine rows; the offloaded result is byte-equal to the
   in-process scan (one seeded entry carries `metadata` so the JSON→object
   hydration is an observable transform, not a no-op).
4. **timeout fallback** — a hanging worker (fake timers advanced past the
   per-request timeout) makes `forProjectOffloaded` return the **full
   in-process set**, not `[]`.

Mutation-verified (isolated worktree): reverting the timeout branch to
`return []` fails only the timeout test; deleting the offload (always
in-process) fails only the pool-preferred test; dropping the pool-path
hydration fails the parity + pool-rows tests. All 87 `ltm.test.ts` tests pass
(main is 83 → +4, zero sibling breakage); core
read-offload/vector-pool suites (142) and the gateway compaction + cache- 
stability + entity-injection + anthropic-caching suites (145) pass. Typecheck +
biome clean.
