### PR TITLE
perf(entities): offload the project entity-catalog scan to the read-worker pool

### DIFF
--- a/packages/core/src/entities.ts
+++ b/packages/core/src/entities.ts
@@ -9,7 +9,12 @@ import { uuidv7 } from "uuidv7";
 import { db, ensureProject, getKV, setKV, withTransaction } from "./db";
 import { embeddingByIdSource, readStorageMode } from "./db/vec-store";
 import { ftsQuery, ftsQueryOr, EMPTY_QUERY, filterTerms } from "./search";
-import { offloadAll } from "./read-offload";
+import {
+  offloadAll,
+  offloadAllOrTimeout,
+  READ_JOB_TIMED_OUT,
+} from "./read-offload";
+import type { ReadParam } from "./read-job";
 import { config } from "./config";
 import { getGitUser } from "./git";
 import * as log from "./log";
@@ -947,31 +952,75 @@ export async function getManyWithAliasesOffloaded(
   return map;
 }
 
+/**
+ * Build the `entities` catalog query shared by {@link forProject} and its
+ * off-thread twin {@link forProjectOffloaded}, so both paths run byte-identical
+ * SQL + params and only the execution thread differs.
+ */
+function forProjectEntityQuery(
+  pid: string,
+  includeCross: boolean,
+): { sql: string; params: ReadParam[] } {
+  const sql = includeCross
+    ? `SELECT ${ENTITY_COLS} FROM entities
+         WHERE project_id = ? OR project_id IS NULL OR cross_project = 1
+         ORDER BY entity_type, canonical_name`
+    : `SELECT ${ENTITY_COLS} FROM entities
+         WHERE project_id = ?
+         ORDER BY entity_type, canonical_name`;
+  return { sql, params: [pid] };
+}
+
 /** List entities for a project, optionally including cross-project entities. */
 export function forProject(
   projectPath: string,
   includeCross = true,
 ): EntityWithAliases[] {
   const pid = ensureProject(projectPath);
-  let rows: Entity[];
-  if (includeCross) {
-    rows = db()
-      .query(
-        `SELECT ${ENTITY_COLS} FROM entities
-         WHERE project_id = ? OR project_id IS NULL OR cross_project = 1
-         ORDER BY entity_type, canonical_name`,
-      )
-      .all(pid) as Entity[];
-  } else {
-    rows = db()
-      .query(
-        `SELECT ${ENTITY_COLS} FROM entities
-         WHERE project_id = ?
-         ORDER BY entity_type, canonical_name`,
-      )
-      .all(pid) as Entity[];
-  }
+  const { sql, params } = forProjectEntityQuery(pid, includeCross);
+  const rows = db()
+    .query(sql)
+    .all(...params) as Entity[];
+  return withAliases(rows);
+}
 
+/**
+ * Off-thread twin of {@link forProject}: runs the identical (unbounded)
+ * `entities` catalog scan through the read-worker pool so it doesn't block the
+ * main event loop on the first-turn stable-block critical path. #1081 (mirrors
+ * ltm.forProjectOffloaded / #1080).
+ *
+ * The result is ALWAYS the same set `forProject` would return — purely "run the
+ * same scan off-thread when possible", never a behavior change:
+ *   - pool available   → a worker runs the entity scan; we hydrate its rows.
+ *   - pool unavailable → `offloadAllOrTimeout` falls back to the identical
+ *                        in-process query.
+ *   - worker TIMEOUT   → we re-run the entity scan IN-PROCESS rather than
+ *                        degrade to []. This feeds the DURABLY FROZEN system[1]
+ *                        entities block; a spuriously-empty result there would
+ *                        be frozen for the whole session, so correctness wins
+ *                        over the "never re-block on timeout" rule for this
+ *                        small, once-per-session scan (same rationale as #1080).
+ *
+ * Only the heaviest (unbounded) entity scan is offloaded; the bounded alias
+ * load stays in-process via `withAliases`, so aliases are always attached
+ * exactly as the sync path would (no per-chunk alias-timeout degradation).
+ * `ensureProject()` may write, so it stays on the main thread.
+ */
+export async function forProjectOffloaded(
+  projectPath: string,
+  includeCross = true,
+): Promise<EntityWithAliases[]> {
+  const pid = ensureProject(projectPath);
+  const { sql, params } = forProjectEntityQuery(pid, includeCross);
+  const offloaded = await offloadAllOrTimeout(sql, params);
+  const rows = (
+    offloaded === READ_JOB_TIMED_OUT
+      ? db()
+          .query(sql)
+          .all(...params)
+      : offloaded
+  ) as Entity[];
   return withAliases(rows);
 }
 
@@ -1782,14 +1831,18 @@ export function graphExpand(
  *
  * The curator always uses `forProject()` directly (needs the full list).
  */
-export function entitiesForSession(
-  projectPath: string,
-  maxInject?: number,
+/**
+ * Relevance-rank a project's entity catalog down to `cap` for injection. Shared
+ * by {@link entitiesForSession} and {@link entitiesForSessionOffloaded} so the
+ * two differ ONLY in how the catalog is fetched (in-process vs offloaded); the
+ * ranking is byte-identical. `relationsFor` / `knowledgeRefCounts` are bounded
+ * (self relations, then a batched IN over the overflow set) and only run when
+ * the catalog exceeds `cap`, so they stay in-process.
+ */
+function rankEntitiesForSession(
+  all: EntityWithAliases[],
+  cap: number,
 ): EntityWithAliases[] {
-  const cap = maxInject ?? config().knowledge.maxEntityInject;
-  if (cap === 0) return [];
-
-  const all = forProject(projectPath);
   if (all.length <= cap) return all;
 
   // Always include self entity + entities related to self
@@ -1821,6 +1874,31 @@ export function entitiesForSession(
   scored.sort((a, b) => b.score - a.score);
 
   return [...guaranteed, ...scored.slice(0, slots).map((s) => s.entity)];
+}
+
+export function entitiesForSession(
+  projectPath: string,
+  maxInject?: number,
+): EntityWithAliases[] {
+  const cap = maxInject ?? config().knowledge.maxEntityInject;
+  if (cap === 0) return [];
+  return rankEntitiesForSession(forProject(projectPath), cap);
+}
+
+/**
+ * Off-thread twin of {@link entitiesForSession}: fetches the project entity
+ * catalog via {@link forProjectOffloaded} (worker pool) and applies the exact
+ * same ranking. Returns the same set `entitiesForSession` would — the offload
+ * is purely to keep the first-turn stable-block build off the main thread.
+ * #1081.
+ */
+export async function entitiesForSessionOffloaded(
+  projectPath: string,
+  maxInject?: number,
+): Promise<EntityWithAliases[]> {
+  const cap = maxInject ?? config().knowledge.maxEntityInject;
+  if (cap === 0) return [];
+  return rankEntitiesForSession(await forProjectOffloaded(projectPath), cap);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/test/entities-forproject-offload.test.ts
+++ b/packages/core/test/entities-forproject-offload.test.ts
@@ -1,0 +1,180 @@
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { db, ensureProject } from "../src/db";
+import * as entities from "../src/entities";
+import { runReadJob } from "../src/read-job";
+import {
+  _resetVectorPoolForTest,
+  _setTestVectorWorkerFactory,
+  vectorSearchTimeoutMs,
+} from "../src/vector-pool";
+import type {
+  VectorWorkerInbound,
+  VectorWorkerInitData,
+} from "../src/vector-worker-types";
+
+// #1081: entities.forProjectOffloaded / entitiesForSessionOffloaded are
+// off-thread twins of the sync catalog scans used to build the frozen system[1]
+// entities block. They must return EXACTLY what the sync path returns — the
+// offload is a pure "run the same scan off-thread when possible" optimization,
+// with an in-process fallback on worker timeout (never a spurious empty, which
+// would be frozen for the session).
+
+const PROJECT = "/test/entities-forproject-offload";
+
+/** Read-worker fake that answers each read by running it against the live DB —
+ *  so the pool path returns genuine rows (proves hydration + ordering). Records
+ *  every dispatched read SQL so a test can prove the pool was actually used. */
+class ServingReadWorker extends EventEmitter {
+  static sqls: string[] = [];
+  unref(): void {}
+  postMessage(msg: VectorWorkerInbound): void {
+    if (msg.type === "read") {
+      ServingReadWorker.sqls.push(msg.spec.sql);
+      const rows = runReadJob(db(), msg.spec);
+      this.emit("message", { type: "read-result", id: msg.id, rows });
+    }
+  }
+  terminate(): Promise<number> {
+    this.emit("exit", 0);
+    return Promise.resolve(0);
+  }
+}
+
+/** Read-worker fake that never replies → forces the per-request timeout. */
+class HangingReadWorker extends EventEmitter {
+  unref(): void {}
+  postMessage(): void {}
+  terminate(): Promise<number> {
+    this.emit("exit", 0);
+    return Promise.resolve(0);
+  }
+}
+
+function installFactory(make: () => EventEmitter): void {
+  _resetVectorPoolForTest();
+  _setTestVectorWorkerFactory(
+    make as unknown as (d: VectorWorkerInitData) => never,
+  );
+}
+
+beforeEach(() => {
+  ServingReadWorker.sqls = [];
+  const pid = ensureProject(PROJECT);
+  db().query("DELETE FROM entities WHERE project_id = ?").run(pid);
+  db()
+    .query(
+      "DELETE FROM entities WHERE project_id IN (SELECT id FROM projects WHERE path LIKE '/test/%') OR (cross_project = 1 AND project_id IS NULL)",
+    )
+    .run();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  _setTestVectorWorkerFactory(null);
+  _resetVectorPoolForTest();
+});
+
+function seed(): void {
+  // Two project-scoped entities (with an alias) + one genuinely-global one, so
+  // includeCross visibility and the ORDER BY (entity_type, canonical_name) both
+  // matter, and withAliases attaches a real alias.
+  entities.create({
+    projectPath: PROJECT,
+    entityType: "repo",
+    canonicalName: "acme-service",
+    aliases: [{ type: "name", value: "acme" }],
+  });
+  entities.create({
+    projectPath: PROJECT,
+    entityType: "infra",
+    canonicalName: "prod-cluster",
+  });
+  entities.create({
+    entityType: "org",
+    canonicalName: "Globex",
+    crossProject: true,
+  });
+}
+
+describe("entities.forProjectOffloaded (#1081)", () => {
+  it("with the pool serving, returns exactly what the sync forProject returns", async () => {
+    seed();
+    installFactory(() => new ServingReadWorker());
+    for (const includeCross of [true, false]) {
+      const sync = entities.forProject(PROJECT, includeCross);
+      const offloaded = await entities.forProjectOffloaded(
+        PROJECT,
+        includeCross,
+      );
+      expect(offloaded.map((e) => e.id)).toEqual(sync.map((e) => e.id));
+      expect(offloaded).toEqual(sync);
+    }
+    // Aliases are attached (in-process withAliases), and cross-project scoping
+    // holds: the global org appears only with includeCross.
+    const withCross = await entities.forProjectOffloaded(PROJECT, true);
+    expect(withCross.some((e) => e.canonical_name === "Globex")).toBe(true);
+    expect(
+      withCross.find((e) => e.canonical_name === "acme-service")?.aliases
+        .length,
+    ).toBeGreaterThan(0);
+    const noCross = await entities.forProjectOffloaded(PROJECT, false);
+    expect(noCross.some((e) => e.canonical_name === "Globex")).toBe(false);
+    // The entity scan was actually dispatched to the worker pool (not silently
+    // run in-process) — proves the offload path is taken.
+    expect(ServingReadWorker.sqls.some((s) => /FROM entities\b/.test(s))).toBe(
+      true,
+    );
+  });
+
+  it("with the pool inert, falls back to the identical in-process query", async () => {
+    seed();
+    // No factory installed → pool inert → offloadAllOrTimeout runs in-process.
+    const sync = entities.forProject(PROJECT, true);
+    const offloaded = await entities.forProjectOffloaded(PROJECT, true);
+    expect(offloaded).toEqual(sync);
+  });
+
+  it("on a worker TIMEOUT falls back to the full in-process scan (never a spurious empty)", async () => {
+    seed();
+    const expected = entities.forProject(PROJECT, true);
+    expect(expected.length).toBeGreaterThan(0);
+
+    installFactory(() => new HangingReadWorker());
+    vi.useFakeTimers();
+    const p = entities.forProjectOffloaded(PROJECT, true);
+    await vi.advanceTimersByTimeAsync(vectorSearchTimeoutMs() + 1);
+    const got = await p;
+    expect(got.map((e) => e.id)).toEqual(expected.map((e) => e.id));
+    // Aliases still attached on the fallback path.
+    expect(
+      got.find((e) => e.canonical_name === "acme-service")?.aliases.length,
+    ).toBeGreaterThan(0);
+  });
+});
+
+describe("entities.entitiesForSessionOffloaded (#1081)", () => {
+  it("matches entitiesForSession under the injection cap (offloaded ranking parity)", async () => {
+    // Seed more entities than the cap so the ranking/overflow path runs, and
+    // assert the offloaded twin selects the identical ranked set.
+    for (let i = 0; i < 12; i++) {
+      entities.create({
+        projectPath: PROJECT,
+        entityType: "tool",
+        canonicalName: `tool-${String(i).padStart(2, "0")}`,
+      });
+    }
+    installFactory(() => new ServingReadWorker());
+    const cap = 5;
+    const sync = entities.entitiesForSession(PROJECT, cap);
+    const offloaded = await entities.entitiesForSessionOffloaded(PROJECT, cap);
+    expect(sync.length).toBe(cap);
+    expect(offloaded.map((e) => e.id)).toEqual(sync.map((e) => e.id));
+  });
+
+  it("returns [] for a zero injection cap without touching the pool", async () => {
+    seed();
+    installFactory(() => new HangingReadWorker()); // would hang if consulted
+    expect(await entities.entitiesForSessionOffloaded(PROJECT, 0)).toEqual([]);
+  });
+});

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -6662,7 +6662,7 @@ async function handleConversationTurn(
         let entitiesText = "";
         if (cfg.knowledge.maxEntityInject > 0) {
           try {
-            const sessionEntities = entities.entitiesForSession(
+            const sessionEntities = await entities.entitiesForSessionOffloaded(
               projectPath,
               cfg.knowledge.maxEntityInject,
             );


### PR DESCRIPTION
## What

The frozen system[1] **entities block** (turn-1 baseline in `pipeline.ts`) is
built via `entitiesForSession()` → `entities.forProject()`, an **unbounded
synchronous scan** of the `entities` table (`ORDER BY entity_type,
canonical_name`) on the **main thread**. `entities.ts` already offloads its
alias-batch helpers to the read-worker pool but not this project-catalog scan.

Mirror of #1080 for entities. Part of #1077 (Workstream B). Closes #1081.

## How

- Extract `forProjectEntityQuery(pid, includeCross)` so the sync and offloaded
  paths run **byte-identical SQL + params**.
- Add async `forProjectOffloaded()` — the same scan via `offloadAllOrTimeout`.
- Extract `rankEntitiesForSession(all, cap)` so `entitiesForSession` and the new
  async `entitiesForSessionOffloaded` share the **exact ranking** and differ
  only in how the catalog is fetched (in-process vs offloaded).
- Route the single frozen-baseline caller through `entitiesForSessionOffloaded`.

## Timeout must NOT degrade to `[]` (same as #1080)

On a worker `TIMEOUT`, `forProjectOffloaded` **re-runs the scan in-process**
rather than returning `[]`: the result feeds the **durably frozen** system[1]
entities block, so a spurious empty would be frozen for the whole session.

| pool state | behavior |
|---|---|
| available | worker runs the entity scan; rows hydrated |
| unavailable | falls back to the identical in-process query |
| worker timeout | re-runs the scan in-process (never a spurious empty) |

Only the **unbounded entity scan** is offloaded; the **bounded alias load**
stays in-process via `withAliases`, so aliases are always attached exactly as
the sync path would (no per-chunk alias-timeout degradation). Result is
therefore **always** identical to the sync path. The two background callers of
sync `forProject` (curator, entity-rebuild) are untouched.

## Tests

New `packages/core/test/entities-forproject-offload.test.ts`:

1. **pool serving** — a worker that runs each read against the live DB returns
   genuine rows; offloaded == sync `forProject` for both `includeCross` values,
   aliases attached, cross-project scoping holds; asserts an `entities` scan was
   actually dispatched to the worker (proves the offload path is taken).
2. **pool inert** — falls back to the identical in-process query.
3. **timeout fallback** — a hanging worker (fake timers past the timeout)
   returns the **full in-process set** with aliases, not `[]`.
4. **entitiesForSessionOffloaded parity** — with an over-cap catalog, the
   offloaded twin selects the identical ranked set as the sync version.
5. **cap=0** — returns `[]` without consulting the pool.

Mutation-verified (isolated): forcing the timeout branch to `[]` fails only test
3; making `forProjectOffloaded` always run in-process (never consult the pool)
fails only test 1 (the dispatch assertion). Full entities suites (81) + gateway
entity-injection/cache-stability (9) pass. Typecheck + biome clean.
