### PR TITLE
perf(gradient): pre-load the distillation snapshot off-thread before transform()

### DIFF
--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -15,6 +15,8 @@ import {
 import { config } from "./config";
 import { formatDistillations } from "./prompt";
 import { normalize } from "./markdown";
+import { offloadAllOrTimeout, READ_JOB_TIMED_OUT } from "./read-offload";
+import type { ReadParam } from "./read-job";
 import * as log from "./log";
 
 type MessageWithParts = LoreMessageWithParts;
@@ -1617,6 +1619,36 @@ type Distillation = {
   source_ids: string[];
 };
 
+// Build the non-archived distillation query shared by {@link loadDistillations}
+// and its off-thread twin {@link loadDistillationsOffloaded}, so both run
+// byte-identical SQL + params (only the execution thread differs).
+//
+// id tie-break — never let same-ms rows reorder and bust the cache.
+// created_at is Date.now() (ms precision); two rows written in the same
+// millisecond would otherwise have an undefined relative order across
+// queries, flipping the distilledPrefixCached validity anchor and forcing
+// an unnecessary full prefix re-render. Distillation ids are random
+// (crypto.randomUUID, v4), so (created_at, id) is NOT chronological for
+// same-ms rows — but it IS a stable, deterministic total order, which is
+// exactly what cache stability requires.
+function distillationsQuery(
+  pid: string,
+  sessionID?: string,
+): { sql: string; params: ReadParam[] } {
+  const sql = sessionID
+    ? "SELECT id, observations, generation, token_count, created_at, session_id, r_compression, c_norm, source_ids FROM distillations WHERE project_id = ? AND session_id = ? AND archived = 0 ORDER BY created_at ASC, id ASC"
+    : "SELECT id, observations, generation, token_count, created_at, session_id, r_compression, c_norm, source_ids FROM distillations WHERE project_id = ? AND archived = 0 ORDER BY created_at ASC, id ASC";
+  return { sql, params: sessionID ? [pid, sessionID] : [pid] };
+}
+
+type RawDistillationRow = Omit<Distillation, "source_ids"> & {
+  source_ids: string;
+};
+
+function hydrateDistillationRow(r: RawDistillationRow): Distillation {
+  return { ...r, source_ids: r.source_ids ? JSON.parse(r.source_ids) : [] };
+}
+
 // Load non-archived distillations for the in-context prefix.
 // Archived gen-0 entries (preserved after meta-distillation) are excluded here
 // but remain searchable via the recall tool's searchDistillations().
@@ -1625,27 +1657,30 @@ function loadDistillations(
   sessionID?: string,
 ): Distillation[] {
   const pid = ensureProject(projectPath);
-  // id tie-break — never let same-ms rows reorder and bust the cache.
-  // created_at is Date.now() (ms precision); two rows written in the same
-  // millisecond would otherwise have an undefined relative order across
-  // queries, flipping the distilledPrefixCached validity anchor and forcing
-  // an unnecessary full prefix re-render. Distillation ids are random
-  // (crypto.randomUUID, v4), so (created_at, id) is NOT chronological for
-  // same-ms rows — but it IS a stable, deterministic total order, which is
-  // exactly what cache stability requires.
-  const query = sessionID
-    ? "SELECT id, observations, generation, token_count, created_at, session_id, r_compression, c_norm, source_ids FROM distillations WHERE project_id = ? AND session_id = ? AND archived = 0 ORDER BY created_at ASC, id ASC"
-    : "SELECT id, observations, generation, token_count, created_at, session_id, r_compression, c_norm, source_ids FROM distillations WHERE project_id = ? AND archived = 0 ORDER BY created_at ASC, id ASC";
-  const params = sessionID ? [pid, sessionID] : [pid];
+  const { sql, params } = distillationsQuery(pid, sessionID);
   const rows = db()
-    .query(query)
-    .all(...params) as Array<
-    Omit<Distillation, "source_ids"> & { source_ids: string }
-  >;
-  return rows.map((r) => ({
-    ...r,
-    source_ids: r.source_ids ? JSON.parse(r.source_ids) : [],
-  }));
+    .query(sql)
+    .all(...params) as RawDistillationRow[];
+  return rows.map(hydrateDistillationRow);
+}
+
+// Off-thread twin of {@link loadDistillations}: runs the identical (unbounded,
+// session-length-growing) distillation scan through the read-worker pool so it
+// doesn't block the main event loop on the pre-upstream critical path. #1082.
+//
+// Returns the same rows `loadDistillations(projectPath, sessionID)` would, or
+// `null` on a worker TIMEOUT — the caller (prewarm) then leaves the snapshot
+// untouched so `transform()`'s in-process `loadDistillationsCached` does the
+// identical sync load (no behavior change, just no offload benefit that turn).
+async function loadDistillationsOffloaded(
+  projectPath: string,
+  sessionID: string,
+): Promise<Distillation[] | null> {
+  const pid = ensureProject(projectPath);
+  const { sql, params } = distillationsQuery(pid, sessionID);
+  const rows = await offloadAllOrTimeout(sql, params);
+  if (rows === READ_JOB_TIMED_OUT) return null;
+  return (rows as RawDistillationRow[]).map(hydrateDistillationRow);
 }
 
 // Cached distillation loader — avoids hitting the DB on every transform() call.
@@ -1660,14 +1695,9 @@ function loadDistillationsCached(
   messages: MessageWithParts[],
   sessState: SessionState,
 ): Distillation[] {
-  // Find the last user message ID in the input
-  let lastUserMsgId: string | null = null;
-  for (let i = messages.length - 1; i >= 0; i--) {
-    if (messages[i].info.role === "user") {
-      lastUserMsgId = messages[i].info.id;
-      break;
-    }
-  }
+  // Find the last user message ID in the input (shared with prewarm so both
+  // compute an identical turn-boundary cache key).
+  const lastUserMsgId = lastUserMessageId(messages);
 
   const snapshot = sessState.distillationSnapshot;
 
@@ -1686,6 +1716,65 @@ function loadDistillationsCached(
   );
 
   return rows;
+}
+
+/**
+ * Find the last user message id in `messages` — the turn-boundary cache key used
+ * by both {@link loadDistillationsCached} and {@link prewarmDistillationSnapshot}.
+ */
+function lastUserMessageId(messages: MessageWithParts[]): string | null {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].info.role === "user") return messages[i].info.id;
+  }
+  return null;
+}
+
+/**
+ * Pre-load the session's distillation snapshot OFF-THREAD before the (sync)
+ * `transform()` runs, so the unbounded distillation scan stays off the
+ * pre-upstream critical path. #1082 (part of #1077 workstream B).
+ *
+ * `transform()` is synchronous, so it cannot await the read itself. Instead the
+ * pipeline (which is async) calls this first: it runs the SAME turn-boundary
+ * cache-key check as `loadDistillationsCached` and, on a cache miss, loads the
+ * distillations via the read-worker pool and populates
+ * `sessState.distillationSnapshot`. `transform()`'s later
+ * `loadDistillationsCached` then finds a matching snapshot and returns it
+ * WITHOUT touching the DB.
+ *
+ * Zero behavior change — the rows and ordering are exactly what the sync load
+ * would produce:
+ *   - cache hit (same last user message → still in a tool-call chain): no-op.
+ *   - cache miss + pool serves/falls back in-process: snapshot populated.
+ *   - cache miss + worker TIMEOUT: snapshot left untouched, so `transform()`
+ *     does the identical in-process load (no offload benefit this turn).
+ *
+ * Uses the same `getSessionState(sessionID)` singleton `transform()` reads, so
+ * the populated snapshot is visible to it. `ensureProject()` runs on the main
+ * thread inside the offloaded loader; only the scan is offloaded.
+ */
+export async function prewarmDistillationSnapshot(
+  projectPath: string,
+  sessionID: string | undefined,
+  messages: MessageWithParts[],
+): Promise<void> {
+  if (!sessionID) return;
+  const sessState = getSessionState(sessionID);
+  const lastUserMsgId = lastUserMessageId(messages);
+
+  // Cache hit: same user message = still in the same tool-call chain → the sync
+  // loadDistillationsCached will reuse this snapshot; nothing to preload.
+  const snapshot = sessState.distillationSnapshot;
+  if (snapshot && snapshot.lastUserMsgId === lastUserMsgId) return;
+
+  const rows = await loadDistillationsOffloaded(projectPath, sessionID);
+  if (rows === null) return; // worker timeout → let transform() do the sync load
+
+  sessState.distillationSnapshot = { rows, lastUserMsgId };
+  log.info(
+    `distillation prewarm: ${rows.length} rows` +
+      ` (user msg ${lastUserMsgId?.substring(0, 16) ?? "none"})`,
+  );
 }
 
 // Strip all <system-reminder>...</system-reminder> blocks from message text.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -153,6 +153,7 @@ export {
 } from "./hosted";
 export {
   transform,
+  prewarmDistillationSnapshot,
   setModelLimits,
   setMaxLayer0Tokens,
   computeLayer0Cap,

--- a/packages/core/test/gradient-distillation-prewarm.test.ts
+++ b/packages/core/test/gradient-distillation-prewarm.test.ts
@@ -1,0 +1,358 @@
+import { EventEmitter } from "node:events";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { db, ensureProject } from "../src/db";
+import {
+  calibrate,
+  evictSession,
+  inspectSessionState,
+  prewarmDistillationSnapshot,
+  setModelLimits,
+  transform,
+} from "../src/gradient";
+import { runReadJob } from "../src/read-job";
+import {
+  _resetVectorPoolForTest,
+  _setTestVectorWorkerFactory,
+  vectorSearchTimeoutMs,
+} from "../src/vector-pool";
+import type {
+  VectorWorkerInbound,
+  VectorWorkerInitData,
+} from "../src/vector-worker-types";
+import type { LoreMessage, LoreMessageWithParts } from "../src/types";
+
+// #1082: prewarmDistillationSnapshot pre-loads the session's distillation
+// snapshot OFF-THREAD before the sync transform() runs. It must populate the
+// SAME per-session snapshot transform() reads with byte-identical rows, respect
+// the turn-boundary cache key, and — critically — leave the snapshot UNtouched
+// on a worker timeout so transform() falls back to the identical sync load
+// (never freeze an empty snapshot).
+
+const PROJECT = "/test/gradient-distill-prewarm";
+
+/** Read-worker fake: answers each read against the live DB, recording dispatched
+ *  SQL so a test can prove the offload path was taken. */
+class ServingReadWorker extends EventEmitter {
+  static sqls: string[] = [];
+  unref(): void {}
+  postMessage(msg: VectorWorkerInbound): void {
+    if (msg.type === "read") {
+      ServingReadWorker.sqls.push(msg.spec.sql);
+      const rows = runReadJob(db(), msg.spec);
+      this.emit("message", { type: "read-result", id: msg.id, rows });
+    }
+  }
+  terminate(): Promise<number> {
+    this.emit("exit", 0);
+    return Promise.resolve(0);
+  }
+}
+
+/** Read-worker fake that never replies → forces the per-request timeout. */
+class HangingReadWorker extends EventEmitter {
+  unref(): void {}
+  postMessage(): void {}
+  terminate(): Promise<number> {
+    this.emit("exit", 0);
+    return Promise.resolve(0);
+  }
+}
+
+function installFactory(make: () => EventEmitter): void {
+  _resetVectorPoolForTest();
+  _setTestVectorWorkerFactory(
+    make as unknown as (d: VectorWorkerInitData) => never,
+  );
+}
+
+let sessionCounter = 0;
+function freshSession(): string {
+  return `prewarm-sess-${sessionCounter++}`;
+}
+
+function userMsg(id: string, sessionID: string): LoreMessageWithParts {
+  const info: LoreMessage = {
+    id,
+    sessionID,
+    role: "user",
+    time: { created: Date.now() },
+    agent: "build",
+    model: { providerID: "anthropic", modelID: "claude-sonnet-4-20250514" },
+  };
+  return { info, parts: [] };
+}
+
+/** A message carrying `text` (for driving transform() past the Layer 0
+ *  passthrough so it actually reaches the distillation load). */
+function makeMsg(
+  id: string,
+  role: "user" | "assistant",
+  text: string,
+  sessionID: string,
+): LoreMessageWithParts {
+  const info: LoreMessage =
+    role === "user"
+      ? {
+          id,
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: "build",
+          model: {
+            providerID: "anthropic",
+            modelID: "claude-sonnet-4-20250514",
+          },
+        }
+      : {
+          id,
+          sessionID,
+          role: "assistant",
+          time: { created: Date.now() },
+          parentID: `parent-${id}`,
+          modelID: "claude-sonnet-4-20250514",
+          providerID: "anthropic",
+          mode: "build",
+          path: { cwd: "/test", root: "/test" },
+          cost: 0,
+          tokens: {
+            input: 100,
+            output: 50,
+            reasoning: 0,
+            cache: { read: 0, write: 0 },
+          },
+        };
+  return {
+    info,
+    parts: [
+      {
+        id: `part-${id}`,
+        sessionID,
+        messageID: id,
+        type: "text",
+        text,
+        time: { start: Date.now(), end: Date.now() },
+      },
+    ],
+  };
+}
+
+/** Insert a non-archived distillation. `createdAt`/`id` drive the (created_at
+ *  ASC, id ASC) cache-stability ordering. */
+function seedDistillation(
+  sessionID: string,
+  id: string,
+  observations: string,
+  createdAt: number,
+  sourceIds: string[] = [],
+): void {
+  const pid = ensureProject(PROJECT);
+  db()
+    .query(
+      `INSERT INTO distillations
+         (id, project_id, session_id, narrative, facts, observations, source_ids,
+          generation, token_count, call_type, created_at, archived)
+       VALUES (?, ?, ?, '', '', ?, ?, 0, 10, 'auto', ?, 0)`,
+    )
+    .run(
+      id,
+      pid,
+      sessionID,
+      observations,
+      JSON.stringify(sourceIds),
+      createdAt,
+    );
+}
+
+beforeAll(() => {
+  ensureProject(PROJECT);
+  // transform() needs model limits + zero overhead to run in a unit test.
+  setModelLimits({ context: 10_000, output: 2_000 });
+  calibrate(0);
+});
+
+beforeEach(() => {
+  ServingReadWorker.sqls = [];
+  const pid = ensureProject(PROJECT);
+  db().query("DELETE FROM distillations WHERE project_id = ?").run(pid);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  _setTestVectorWorkerFactory(null);
+  _resetVectorPoolForTest();
+});
+
+describe("prewarmDistillationSnapshot (#1082)", () => {
+  it("populates the snapshot off-thread with rows in (created_at, id) order", async () => {
+    const SESSION = freshSession();
+    // Out-of-insertion-order created_at + a same-ms id tie-break pair.
+    seedDistillation(SESSION, "d-b", "second", 2000, ["s2"]);
+    seedDistillation(SESSION, "d-a", "first", 1000, ["s1a", "s1b"]);
+    seedDistillation(SESSION, "d-c", "tie-2", 3000);
+    seedDistillation(SESSION, "d-aa", "tie-1", 3000); // same ms as d-c → id tie-break
+
+    installFactory(() => new ServingReadWorker());
+    await prewarmDistillationSnapshot(PROJECT, SESSION, [
+      userMsg("u1", SESSION),
+    ]);
+
+    const snap = inspectSessionState(SESSION)?.distillationSnapshot;
+    expect(snap).not.toBeNull();
+    expect(snap?.lastUserMsgId).toBe("u1");
+    // created_at ASC, id ASC: 1000(d-a), 2000(d-b), 3000(d-aa < d-c)
+    expect(snap?.rows.map((r) => r.id)).toEqual(["d-a", "d-b", "d-aa", "d-c"]);
+    // source_ids JSON is parsed back into arrays.
+    expect(snap?.rows.find((r) => r.id === "d-a")?.source_ids).toEqual([
+      "s1a",
+      "s1b",
+    ]);
+    expect(snap?.rows.find((r) => r.id === "d-c")?.source_ids).toEqual([]);
+    // The scan was actually dispatched to the worker pool.
+    expect(
+      ServingReadWorker.sqls.some((s) => /FROM distillations\b/.test(s)),
+    ).toBe(true);
+
+    evictSession(SESSION);
+  });
+
+  it("matches the in-process load exactly (pool served == pool inert)", async () => {
+    const SEED: Array<[string, string, number]> = [
+      ["p-1", "alpha", 100],
+      ["p-2", "beta", 200],
+      ["p-3", "gamma", 300],
+    ];
+    const A = freshSession();
+    const B = freshSession();
+    for (const [id, obs, ts] of SEED) {
+      seedDistillation(A, `${id}-a`, obs, ts, [id]);
+      seedDistillation(B, `${id}-b`, obs, ts, [id]);
+    }
+
+    // A: pool serves the read. B: no factory → in-process fallback.
+    installFactory(() => new ServingReadWorker());
+    await prewarmDistillationSnapshot(PROJECT, A, [userMsg("ua", A)]);
+    _setTestVectorWorkerFactory(null);
+    _resetVectorPoolForTest();
+    await prewarmDistillationSnapshot(PROJECT, B, [userMsg("ub", B)]);
+
+    const rowsA = inspectSessionState(A)?.distillationSnapshot?.rows ?? [];
+    const rowsB = inspectSessionState(B)?.distillationSnapshot?.rows ?? [];
+    // Same observations + parsed source_ids + numeric metadata in the same order
+    // (ids differ only by the per-session suffix).
+    const project = (r: (typeof rowsA)[number]) => [
+      r.observations,
+      r.source_ids,
+      r.generation,
+      r.token_count,
+      r.created_at,
+      r.r_compression,
+      r.c_norm,
+    ];
+    expect(rowsA.map(project)).toEqual(rowsB.map(project));
+    expect(rowsA.length).toBe(3);
+
+    evictSession(A);
+    evictSession(B);
+  });
+
+  it("is a no-op on a cache hit (same last user message)", async () => {
+    const SESSION = freshSession();
+    seedDistillation(SESSION, "h-1", "hi", 100);
+
+    installFactory(() => new ServingReadWorker());
+    await prewarmDistillationSnapshot(PROJECT, SESSION, [
+      userMsg("same", SESSION),
+    ]);
+    const firstRows = inspectSessionState(SESSION)?.distillationSnapshot?.rows;
+    expect(firstRows?.length).toBe(1);
+
+    // Swap in a worker that would HANG if consulted. A second prewarm for the
+    // SAME turn key must short-circuit (cache hit) and return without loading.
+    installFactory(() => new HangingReadWorker());
+    ServingReadWorker.sqls = [];
+    await prewarmDistillationSnapshot(PROJECT, SESSION, [
+      userMsg("same", SESSION),
+    ]);
+    // Snapshot unchanged; no new dispatch (it never reached the hanging worker).
+    expect(inspectSessionState(SESSION)?.distillationSnapshot?.rows).toBe(
+      firstRows,
+    );
+
+    evictSession(SESSION);
+  });
+
+  it("leaves the snapshot UNtouched on a worker timeout (transform falls back)", async () => {
+    const SESSION = freshSession();
+    seedDistillation(SESSION, "t-1", "would load if the pool answered", 100);
+
+    installFactory(() => new HangingReadWorker());
+    vi.useFakeTimers();
+    const p = prewarmDistillationSnapshot(PROJECT, SESSION, [
+      userMsg("u1", SESSION),
+    ]);
+    await vi.advanceTimersByTimeAsync(vectorSearchTimeoutMs() + 1);
+    await p;
+
+    // Snapshot NOT populated — a spurious empty snapshot would make transform()
+    // drop the distilled prefix for the whole turn.
+    expect(
+      inspectSessionState(SESSION)?.distillationSnapshot ?? null,
+    ).toBeNull();
+
+    evictSession(SESSION);
+  });
+
+  it("returns immediately for a session-less input", async () => {
+    installFactory(() => new HangingReadWorker()); // would hang if consulted
+    await expect(
+      prewarmDistillationSnapshot(PROJECT, undefined, []),
+    ).resolves.toBeUndefined();
+  });
+
+  it("transform() consumes the prewarmed snapshot without re-reading the DB (end-to-end seam)", async () => {
+    const SESSION = freshSession();
+    seedDistillation(SESSION, "e2e-1", "prewarmed observation", 100, ["x"]);
+    // Enough content to blow past the Layer 0 passthrough (context=10k tokens),
+    // so transformInner actually reaches loadDistillationsCached.
+    const messages: LoreMessageWithParts[] = [];
+    for (let i = 0; i < 20; i++) {
+      messages.push(
+        makeMsg(
+          `e2e-m${i}`,
+          i % 2 === 0 ? "user" : "assistant",
+          "C ".repeat(1200),
+          SESSION,
+        ),
+      );
+    }
+    messages.push(makeMsg("u-e2e", "user", "C ".repeat(1200), SESSION));
+
+    // Prewarm populates the snapshot from the DB.
+    await prewarmDistillationSnapshot(PROJECT, SESSION, messages);
+    expect(
+      inspectSessionState(SESSION)?.distillationSnapshot?.rows.length,
+    ).toBe(1);
+
+    // Now DELETE the rows from the DB. A cache MISS in transform() would re-run
+    // the sync loadDistillations against the (now empty) table and overwrite the
+    // snapshot with []. A cache HIT reuses the prewarmed rows and never reads.
+    db().query("DELETE FROM distillations WHERE session_id = ?").run(SESSION);
+
+    transform({ messages, projectPath: PROJECT, sessionID: SESSION });
+
+    // Snapshot still holds the prewarmed row → transform() cache-hit the
+    // prewarmed snapshot (and the prewarm/transform cache keys aligned).
+    const after = inspectSessionState(SESSION)?.distillationSnapshot;
+    expect(after?.rows.map((r) => r.id)).toEqual(["e2e-1"]);
+
+    evictSession(SESSION);
+  });
+});

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -33,6 +33,7 @@ import {
   curator,
   log,
   transform,
+  prewarmDistillationSnapshot,
   isLargeColdStart,
   setModelLimits,
   setLtmTokens,
@@ -6983,6 +6984,14 @@ async function handleConversationTurn(
   // --- 7. Gradient transform on messages ---
   // loreMessages was built + resolved once before the LTM block (step 6) so the
   // turn-1 LTM decision and this transform share identical input. Reuse it.
+  //
+  // Pre-load the session's distillation snapshot off-thread first (#1082): the
+  // sync transform() below would otherwise run an unbounded distillation scan on
+  // this pre-upstream critical path. prewarm populates the same per-session
+  // snapshot transform() reads, so its loadDistillationsCached hits the cache
+  // instead of the DB. On a pool timeout it's a no-op and transform() falls back
+  // to the identical in-process load.
+  await prewarmDistillationSnapshot(projectPath, sessionID, loreMessages);
   const result = transform({
     messages: loreMessages,
     projectPath,


### PR DESCRIPTION
## What

`gradient.transform()` runs on the **pre-upstream critical path**. On a turn
boundary it calls the synchronous `loadDistillations` — an **unbounded scan** of
the session's non-archived `distillations` (selecting `observations` blobs +
`JSON.parse(source_ids)`) that **grows with session length**. It's cached per
turn-boundary already, but it's the last heavy synchronous DB read still on the
pre-upstream path. Part of #1077 (Workstream B). Closes #1082.

## The seam

`transform()` is synchronous, so it can't `await` the read at the call site.
Rather than make the whole gradient path async (issue option 2), this uses
option 1 — pre-load off-thread and thread the result through the existing
per-session cache:

- New async `prewarmDistillationSnapshot(projectPath, sessionID, messages)`.
  The **async pipeline** calls it right before `transform()`.
- It runs the **same turn-boundary cache-key check** as `loadDistillationsCached`
  (shared `lastUserMessageId` helper) and, on a cache miss, loads the
  distillations via the read-worker pool and populates
  `sessState.distillationSnapshot`.
- `transform()`'s later `loadDistillationsCached` then finds a matching snapshot
  and returns it **without touching the DB** — the scan already happened
  off-thread.

## Zero behavior change

- Shared `distillationsQuery(pid, sessionID?)` builder → the offloaded SQL is
  **byte-identical** to the sync load, preserving the `(created_at ASC, id ASC)`
  tie-break that the cache-stability invariant depends on (comment at the query).
- Shared `lastUserMessageId` → prewarm and `loadDistillationsCached` compute an
  identical cache key, so prewarm's snapshot is always a cache hit for the turn.
- Uses the same `getSessionState(sessionID)` singleton `transform()` reads.

| pool state | behavior |
|---|---|
| cache hit (same last user msg → tool-call chain) | no-op |
| cache miss + pool serves / falls back in-process | snapshot populated off-thread |
| cache miss + worker **timeout** | **no-op** — snapshot left untouched, so `transform()` does the identical in-process load |

The timeout no-op is the key safety property: a spurious empty snapshot would
make `transform()` drop the distilled prefix for the turn, so on timeout we
simply don't prewarm and let the sync path run (no offload benefit that turn,
but identical output).

## Tests

New `packages/core/test/gradient-distillation-prewarm.test.ts` (observes the
snapshot via `inspectSessionState`):

1. populates the snapshot off-thread with rows in `(created_at, id)` order
   (incl. a same-ms id tie-break), `source_ids` parsed, and asserts a
   `FROM distillations` read was dispatched to the pool.
2. pool-served == pool-inert (in-process fallback) — identical rows.
3. cache hit is a no-op (a second prewarm for the same turn short-circuits
   before consulting a worker that would otherwise hang).
4. **worker timeout leaves the snapshot untouched** (fake timers past the
   timeout) — no frozen-empty hazard.
5. session-less input returns immediately.
6. **end-to-end seam** — after prewarm, the DB rows are DELETED and `transform()`
   is driven past Layer 0; it must still see the prewarmed rows (a cache miss
   would re-read the now-empty table). Proves `transform()` actually consumes
   the prewarmed snapshot and that the prewarm/transform cache keys align.

Mutation-verified (isolated worktree): making the offloaded loader return `[]`
instead of `null` on timeout fails only test 4; forcing `loadDistillationsCached`
to always cache-miss fails only test 6 (the seam). Full gradient + distillation
suites and the gateway cache-stability/compaction/caching suites pass. Typecheck
+ biome clean.
