### PR TITLE
perf(ltm): offload peekProjectRefs knowledge scan to the read-worker pool

### DIFF
--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -1311,33 +1311,79 @@ export async function validateProjectReferences(
  * (turn N+1) via `validateProjectReferences` with a `SyntheticProbeResolver`,
  * which re-gathers from the SAME query, so the two are consistent by construction.
  */
-export function peekProjectRefs(
-  projectPath: string,
-  now: number = Date.now(),
-): { gated: boolean; refs: Reference[] } {
-  const pid = ensureProject(projectPath);
+// Shared by peekProjectRefs and its off-thread twin so both scan byte-identical
+// SQL + params (only the execution thread differs).
+const PROJECT_REFS_SQL = `SELECT title, content FROM knowledge_current
+        WHERE project_id = ? AND cross_project = 0 AND confidence > ?`;
+
+/** True when the 24h reference-check rate gate is still closed for `pid`. */
+function refcheckGated(pid: string, now: number): boolean {
   const proj = db()
     .query("SELECT last_refcheck_at FROM projects WHERE id = ?")
     .get(pid) as { last_refcheck_at: number | null } | null;
   const last = proj?.last_refcheck_at ?? 0;
-  if (now - last < REFCHECK_INTERVAL_MS) return { gated: true, refs: [] };
+  return now - last < REFCHECK_INTERVAL_MS;
+}
 
-  const rows = db()
-    .query(
-      `SELECT title, content FROM knowledge_current
-        WHERE project_id = ? AND cross_project = 0 AND confidence > ?`,
-    )
-    .all(pid, DEAD_CONFIDENCE_FLOOR) as Array<{
-    title: string;
-    content: string;
-  }>;
+/** Dedupe extracted references from the scanned (title, content) rows into a
+ *  stable union keyed by `ref.raw` — shared by the sync and offloaded peeks. */
+function dedupeProjectRefs(
+  rows: Array<{ title: string; content: string }>,
+): Reference[] {
   const union = new Map<string, Reference>();
   for (const r of rows) {
     for (const ref of extractReferences(`${r.title}\n${r.content}`)) {
       if (!union.has(ref.raw)) union.set(ref.raw, ref);
     }
   }
-  return { gated: false, refs: [...union.values()] };
+  return [...union.values()];
+}
+
+export function peekProjectRefs(
+  projectPath: string,
+  now: number = Date.now(),
+): { gated: boolean; refs: Reference[] } {
+  const pid = ensureProject(projectPath);
+  if (refcheckGated(pid, now)) return { gated: true, refs: [] };
+
+  const rows = db()
+    .query(PROJECT_REFS_SQL)
+    .all(pid, DEAD_CONFIDENCE_FLOOR) as Array<{
+    title: string;
+    content: string;
+  }>;
+  return { gated: false, refs: dedupeProjectRefs(rows) };
+}
+
+/**
+ * Off-thread twin of {@link peekProjectRefs}: the (unbounded) `knowledge_current`
+ * scan runs through the read-worker pool so it doesn't block the main event loop
+ * on the pre-forward synthetic-probe path. #1083 (mirrors #1080 / #1081). The
+ * cheap single-row rate-gate read and the `extractReferences` CPU stay on the
+ * main thread (the pool only runs SQL).
+ *
+ * Returns the same result `peekProjectRefs` would: on a worker TIMEOUT the scan
+ * is re-run in-process rather than degrading to an empty ref set, so the
+ * synthetic-probe driver never silently skips a drift check because of a
+ * transient pool stall. `ensureProject()` (may write) stays on the main thread.
+ */
+export async function peekProjectRefsOffloaded(
+  projectPath: string,
+  now: number = Date.now(),
+): Promise<{ gated: boolean; refs: Reference[] }> {
+  const pid = ensureProject(projectPath);
+  if (refcheckGated(pid, now)) return { gated: true, refs: [] };
+
+  const params: ReadParam[] = [pid, DEAD_CONFIDENCE_FLOOR];
+  const offloaded = await offloadAllOrTimeout(PROJECT_REFS_SQL, params);
+  const rows = (
+    offloaded === READ_JOB_TIMED_OUT
+      ? db()
+          .query(PROJECT_REFS_SQL)
+          .all(...params)
+      : offloaded
+  ) as Array<{ title: string; content: string }>;
+  return { gated: false, refs: dedupeProjectRefs(rows) };
 }
 
 /**

--- a/packages/core/test/ltm-peek-refs-offload.test.ts
+++ b/packages/core/test/ltm-peek-refs-offload.test.ts
@@ -1,0 +1,152 @@
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { db, ensureProject } from "../src/db";
+import * as ltm from "../src/ltm";
+import { runReadJob } from "../src/read-job";
+import {
+  _resetVectorPoolForTest,
+  _setTestVectorWorkerFactory,
+  vectorSearchTimeoutMs,
+} from "../src/vector-pool";
+import type {
+  VectorWorkerInbound,
+  VectorWorkerInitData,
+} from "../src/vector-worker-types";
+
+// #1083: peekProjectRefsOffloaded runs the unbounded knowledge scan off-thread
+// (the cheap 24h rate-gate read and extractReferences CPU stay in-process). It
+// must return the same {gated, refs} peekProjectRefs would, offload the scan
+// only when NOT gated, and re-run in-process on a worker timeout (never a
+// spuriously-empty ref set).
+
+class ServingReadWorker extends EventEmitter {
+  static sqls: string[] = [];
+  unref(): void {}
+  postMessage(msg: VectorWorkerInbound): void {
+    if (msg.type === "read") {
+      ServingReadWorker.sqls.push(msg.spec.sql);
+      const rows = runReadJob(db(), msg.spec);
+      this.emit("message", { type: "read-result", id: msg.id, rows });
+    }
+  }
+  terminate(): Promise<number> {
+    this.emit("exit", 0);
+    return Promise.resolve(0);
+  }
+}
+
+class HangingReadWorker extends EventEmitter {
+  unref(): void {}
+  postMessage(): void {}
+  terminate(): Promise<number> {
+    this.emit("exit", 0);
+    return Promise.resolve(0);
+  }
+}
+
+function installFactory(make: () => EventEmitter): void {
+  _resetVectorPoolForTest();
+  _setTestVectorWorkerFactory(
+    make as unknown as (d: VectorWorkerInitData) => never,
+  );
+}
+
+let counter = 0;
+function freshProject(): string {
+  return `/test/peek-refs-offload-${counter++}`;
+}
+
+let titleCounter = 0;
+function seedRefEntry(projectPath: string, content: string): void {
+  ltm.create({
+    projectPath,
+    scope: "project",
+    crossProject: false,
+    category: "gotcha",
+    title: `Peek ref entry ${++titleCounter}`,
+    content,
+  });
+}
+
+function openGate(projectPath: string): void {
+  // A fresh project has last_refcheck_at NULL (→ 0) so the gate is already open;
+  // this is belt-and-suspenders for reused ids.
+  const pid = ensureProject(projectPath);
+  db().query("UPDATE projects SET last_refcheck_at = 0 WHERE id = ?").run(pid);
+}
+
+function closeGate(projectPath: string): void {
+  const pid = ensureProject(projectPath);
+  db()
+    .query("UPDATE projects SET last_refcheck_at = ? WHERE id = ?")
+    .run(Date.now(), pid);
+}
+
+beforeEach(() => {
+  ServingReadWorker.sqls = [];
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  _setTestVectorWorkerFactory(null);
+  _resetVectorPoolForTest();
+});
+
+describe("ltm.peekProjectRefsOffloaded (#1083)", () => {
+  it("with the pool serving, returns exactly what sync peekProjectRefs returns", async () => {
+    const PROJECT = freshProject();
+    openGate(PROJECT);
+    seedRefEntry(PROJECT, "the impl lives in src/alpha.ts:3 — see it");
+    seedRefEntry(PROJECT, "always `pnpm run build` before shipping");
+
+    installFactory(() => new ServingReadWorker());
+    const sync = ltm.peekProjectRefs(PROJECT);
+    const offloaded = await ltm.peekProjectRefsOffloaded(PROJECT);
+
+    expect(sync.gated).toBe(false);
+    expect(offloaded.gated).toBe(false);
+    expect(sync.refs.length).toBeGreaterThan(0);
+    // Same deduped reference set (order-independent — dedupe keys on ref.raw).
+    expect(new Set(offloaded.refs.map((r) => r.raw))).toEqual(
+      new Set(sync.refs.map((r) => r.raw)),
+    );
+    // The knowledge scan was actually dispatched to the worker pool.
+    expect(
+      ServingReadWorker.sqls.some((s) => /FROM knowledge_current\b/.test(s)),
+    ).toBe(true);
+  });
+
+  it("returns gated without offloading when the 24h gate is closed", async () => {
+    const PROJECT = freshProject();
+    seedRefEntry(PROJECT, "src/beta.ts:1 reference");
+    closeGate(PROJECT);
+
+    // A hanging worker would stall forever if the scan were dispatched — proving
+    // the gate short-circuits before the offload.
+    installFactory(() => new HangingReadWorker());
+    const res = await ltm.peekProjectRefsOffloaded(PROJECT);
+    expect(res).toEqual({ gated: true, refs: [] });
+    expect(
+      ServingReadWorker.sqls.some((s) => /FROM knowledge_current\b/.test(s)),
+    ).toBe(false);
+  });
+
+  it("on a worker TIMEOUT re-runs the scan in-process (never a spurious empty)", async () => {
+    const PROJECT = freshProject();
+    openGate(PROJECT);
+    seedRefEntry(PROJECT, "check src/gamma.ts:2 and run `pnpm run test`");
+    const expected = ltm.peekProjectRefs(PROJECT);
+    expect(expected.refs.length).toBeGreaterThan(0);
+
+    installFactory(() => new HangingReadWorker());
+    vi.useFakeTimers();
+    const p = ltm.peekProjectRefsOffloaded(PROJECT);
+    await vi.advanceTimersByTimeAsync(vectorSearchTimeoutMs() + 1);
+    const got = await p;
+
+    expect(got.gated).toBe(false);
+    expect(new Set(got.refs.map((r) => r.raw))).toEqual(
+      new Set(expected.refs.map((r) => r.raw)),
+    );
+  });
+});

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -7340,7 +7340,7 @@ async function handleConversationTurn(
           cfg.knowledge.enabled &&
           cfg.knowledge.referenceValidation
         ) {
-          const peek = ltm.peekProjectRefs(projectPath);
+          const peek = await ltm.peekProjectRefsOffloaded(projectPath);
           if (!peek.gated && peek.refs.length > 0) {
             block = buildCombinedResolveRefcheckBlock(
               target,


### PR DESCRIPTION
## What

`ltm.peekProjectRefs` (called pre-forward on the remote-gateway synthetic-probe
path, `pipeline.ts`) does a **synchronous unbounded scan** of `knowledge_current`
(title + content) plus `extractReferences` CPU on the **main thread**. It's
**24h-gated** by `projects.last_refcheck_at`, so it rarely fires — but when it
does it's an unbounded main-thread scan. Part of #1077 (Workstream B). Closes
#1083.

## How

- Extract shared `PROJECT_REFS_SQL`, `refcheckGated(pid, now)`, and
  `dedupeProjectRefs(rows)` helpers so the sync and offloaded peeks are
  byte-identical.
- Add async `peekProjectRefsOffloaded()`: the cheap **single-row rate-gate
  read** and the **`extractReferences` CPU** stay in-process (the pool only runs
  SQL); only the unbounded knowledge scan is offloaded via `offloadAllOrTimeout`.
- Route the single caller through it (`await`, inside the already-async
  `handleConversationTurn`).

## Behavior parity

| pool state | behavior |
|---|---|
| gated (within 24h) | returns `{ gated: true, refs: [] }` **without** offloading (early return before the scan) |
| pool available | worker runs the scan; refs deduped in-process |
| pool unavailable | falls back to the identical in-process query |
| worker timeout | re-runs the scan in-process (never a spurious empty ref set) |

The timeout re-run (rather than degrade-to-`[]`) means the synthetic-probe
driver never silently skips a drift check because of a transient pool stall.
Result is always identical to the sync path.

## Tests

New `packages/core/test/ltm-peek-refs-offload.test.ts`:

1. **pool serving** — offloaded `{gated, refs}` equals sync `peekProjectRefs`
   (same deduped `ref.raw` set), and a `FROM knowledge_current` scan was
   dispatched to the worker pool.
2. **gated** — with the 24h gate closed, returns `{ gated: true, refs: [] }`
   and does **not** dispatch a scan (a hanging worker would stall if it did).
3. **timeout fallback** — a hanging worker (fake timers past the timeout)
   returns the full ref set in-process, not `[]`.

Mutation-verified: forcing the timeout branch to `[]` fails only test 3. Full
`ltm` + reference-validity suites (108) and the gateway synthetic-tools suite
(69) pass. Typecheck + biome clean.
