### PR TITLE
perf(pipeline): batch post-response temporal writes into one transaction

### DIFF
--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -4690,6 +4690,109 @@ export function recordCacheTurnUsage(
 }
 
 /**
+ * Persist a turn's temporal messages — the latest user message + the assistant
+ * response — and their tool-call traces. Extracted from postResponse() as a
+ * testable seam (#1084).
+ *
+ * The four writes (user store + tool-calls, then assistant store + tool-calls)
+ * are batched into a SINGLE savepoint so the post-response phase commits ONCE
+ * instead of ~4 times, cutting SQLite writer + WAL contention. `resolveToolResults`
+ * is pure in-memory (temporal-adapter.ts) and MUST run BETWEEN the two stores —
+ * the user message is stored with its ORIGINAL tool_result content, before
+ * resolveToolResults strips it — so it stays inside the same savepoint. The
+ * stores are idempotent UPSERTs keyed by message id, so the all-or-nothing
+ * rollback on a mid-batch error is recoverable: the next turn re-includes and
+ * re-stores these messages.
+ *
+ * In no-store mode (amnesia / x-lore-no-store) ONLY the in-memory resolve runs;
+ * nothing is written (but resolveToolResults still mutates `loreMessages`, which
+ * downstream reconstruct-after-eviction relies on).
+ */
+export function storeTurnTemporal(input: {
+  loreMessages: LoreMessageWithParts[];
+  /** The upstream assistant response content blocks (resp.content). */
+  assistantContentBlocks: GatewayContentBlock[];
+  usage: GatewayUsage;
+  model: string;
+  projectPath: string;
+  sessionID: string;
+  noStore: boolean;
+}): void {
+  const { loreMessages, projectPath, sessionID, noStore } = input;
+
+  if (noStore) {
+    // Still resolve tool results in-memory (needed downstream), but write nothing.
+    resolveToolResults(loreMessages);
+    return;
+  }
+
+  // Resolve (and, if needed, lazily backfill/merge) the project OUTSIDE the
+  // savepoint. `ensureProject` can reach `mergeProjectInternal`'s raw
+  // `BEGIN IMMEDIATE` on the NULL-git_remote backfill-with-conflict path, which
+  // would nest inside the savepoint's transaction and throw "cannot start a
+  // transaction within a transaction". Warming it here makes the `ensureProject`
+  // calls inside temporal.store / recordToolCalls cheap cache hits. (#1084.)
+  ensureProject(projectPath);
+
+  withSavepoint("post_response_temporal", () => {
+    // Store the latest user message BEFORE resolveToolResults — we want the
+    // original content (including tool_result text), not the placeholder
+    // "[tool results provided]" that resolveToolResults creates after merging.
+    for (let i = loreMessages.length - 1; i >= 0; i--) {
+      if (loreMessages[i].info.role === "user") {
+        temporal.store({
+          projectPath,
+          info: loreMessages[i].info,
+          parts: loreMessages[i].parts,
+        });
+        // The latest user message carries tool_result blocks that resolve the
+        // PRIOR assistant turn's tool calls — record their outcomes
+        // (status/error/duration) keyed by call_id.
+        temporal.recordToolCalls({
+          projectPath,
+          info: loreMessages[i].info,
+          parts: loreMessages[i].parts,
+        });
+        break;
+      }
+    }
+
+    // Resolve tool results for gradient transform (merges tool_result into
+    // assistant parts, strips from user messages — needed for reconstruct-
+    // after-eviction pattern but not for temporal storage above).
+    resolveToolResults(loreMessages);
+
+    // Build and store the assistant response message.
+    // Strip recall marker text blocks — they contain the raw query string and
+    // pollute FTS results with self-referential noise.
+    const assistantContent = input.assistantContentBlocks.filter(
+      (b) => !(b.type === "text" && isRecallMarker(b.text)),
+    );
+    const assistantMsg = gatewayMessagesToLore(
+      [{ role: "assistant", content: assistantContent }],
+      sessionID,
+    )[0];
+    updateAssistantMessageTokens(assistantMsg, input.usage, input.model);
+    if (assistantContent.length > 0) {
+      temporal.store({
+        projectPath,
+        info: assistantMsg.info,
+        parts: assistantMsg.parts,
+      });
+    }
+    // Always record structured tool-call traces — even when the assistant
+    // content is empty after recall-marker stripping, or when partsToText would
+    // produce empty content (tool-only / all-failed turns). Tool parts survive
+    // the text-only recall-marker filter above.
+    temporal.recordToolCalls({
+      projectPath,
+      info: assistantMsg.info,
+      parts: assistantMsg.parts,
+    });
+  });
+}
+
+/**
  * Run after a successful response: calibrate, store temporal messages,
  * and schedule background work (distillation, curation).
  */
@@ -4774,64 +4877,18 @@ function postResponse(
     // tool_result UPDATE is a harmless no-op (no phantom 'pending' rows leak).
     const noStore =
       sessionState.amnesia || req.rawHeaders["x-lore-no-store"] === "true";
-    if (!noStore) {
-      // Store the latest user message BEFORE resolveToolResults — we want the
-      // original content (including tool_result text), not the placeholder
-      // "[tool results provided]" that resolveToolResults creates after merging.
-      for (let i = loreMessages.length - 1; i >= 0; i--) {
-        if (loreMessages[i].info.role === "user") {
-          temporal.store({
-            projectPath,
-            info: loreMessages[i].info,
-            parts: loreMessages[i].parts,
-          });
-          // The latest user message carries tool_result blocks that resolve
-          // the PRIOR assistant turn's tool calls — record their outcomes
-          // (status/error/duration) keyed by call_id.
-          temporal.recordToolCalls({
-            projectPath,
-            info: loreMessages[i].info,
-            parts: loreMessages[i].parts,
-          });
-          break;
-        }
-      }
-    }
 
-    // Resolve tool results for gradient transform (merges tool_result into
-    // assistant parts, strips from user messages — needed for reconstruct-
-    // after-eviction pattern but not for temporal storage above).
-    resolveToolResults(loreMessages);
-
-    if (!noStore) {
-      // Build and store the assistant response message.
-      // Strip recall marker text blocks — they contain the raw query string
-      // and pollute FTS results with self-referential noise.
-      const assistantContent = resp.content.filter(
-        (b) => !(b.type === "text" && isRecallMarker(b.text)),
-      );
-      const assistantMsg = gatewayMessagesToLore(
-        [{ role: "assistant", content: assistantContent }],
-        sessionID,
-      )[0];
-      updateAssistantMessageTokens(assistantMsg, usage, resp.model);
-      if (assistantContent.length > 0) {
-        temporal.store({
-          projectPath,
-          info: assistantMsg.info,
-          parts: assistantMsg.parts,
-        });
-      }
-      // Always record structured tool-call traces — even when the assistant
-      // content is empty after recall-marker stripping, or when partsToText
-      // would produce empty content (tool-only / all-failed turns). Tool parts
-      // survive the text-only recall-marker filter above.
-      temporal.recordToolCalls({
-        projectPath,
-        info: assistantMsg.info,
-        parts: assistantMsg.parts,
-      });
-    }
+    // Persist (and tool-trace) this turn's messages, batched into one savepoint.
+    // Extracted seam — see storeTurnTemporal (#1084).
+    storeTurnTemporal({
+      loreMessages,
+      assistantContentBlocks: resp.content,
+      usage,
+      model: resp.model,
+      projectPath,
+      sessionID,
+      noStore,
+    });
 
     // Update session state (persisted in the batched save after messageCount update)
     sessionState.turnsSinceCuration =

--- a/packages/gateway/test/store-turn-temporal.test.ts
+++ b/packages/gateway/test/store-turn-temporal.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { db, ensureProject } from "@loreai/core";
+import { storeTurnTemporal } from "../src/pipeline";
+import { gatewayMessagesToLore } from "../src/temporal-adapter";
+import type { GatewayContentBlock, GatewayUsage } from "../src/translate/types";
+
+// #1084: storeTurnTemporal batches a turn's four temporal writes (user store +
+// tool-calls, assistant store + tool-calls) into ONE savepoint. The rows written
+// must be identical to the pre-batch behavior; only the number of commits drops.
+
+const PROJECT = "/test/store-turn-temporal";
+const USAGE: GatewayUsage = {
+  inputTokens: 10,
+  outputTokens: 5,
+  cacheReadInputTokens: 0,
+  cacheCreationInputTokens: 0,
+};
+
+let sessionCounter = 0;
+function freshSession(): string {
+  return `stt-sess-${sessionCounter++}`;
+}
+
+function userMessages(sessionID: string, text: string) {
+  return gatewayMessagesToLore(
+    [{ role: "user", content: [{ type: "text", text }] }],
+    sessionID,
+  );
+}
+
+function rowsFor(sessionID: string) {
+  return db()
+    .query(
+      "SELECT role, content FROM temporal_messages WHERE session_id = ? ORDER BY created_at ASC, id ASC",
+    )
+    .all(sessionID) as Array<{ role: string; content: string }>;
+}
+
+beforeEach(() => {
+  ensureProject(PROJECT);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("storeTurnTemporal (#1084)", () => {
+  it("stores the user + assistant messages for a normal turn", () => {
+    const SESSION = freshSession();
+    const loreMessages = userMessages(SESSION, "hello from the user");
+    const assistantContentBlocks: GatewayContentBlock[] = [
+      { type: "text", text: "hello from the assistant" },
+    ];
+
+    storeTurnTemporal({
+      loreMessages,
+      assistantContentBlocks,
+      usage: USAGE,
+      model: "claude-sonnet-4-20250514",
+      projectPath: PROJECT,
+      sessionID: SESSION,
+      noStore: false,
+    });
+
+    const rows = rowsFor(SESSION);
+    expect(rows.map((r) => r.role)).toEqual(["user", "assistant"]);
+    expect(rows.find((r) => r.role === "user")?.content).toContain(
+      "hello from the user",
+    );
+    expect(rows.find((r) => r.role === "assistant")?.content).toContain(
+      "hello from the assistant",
+    );
+  });
+
+  it("writes NOTHING in no-store mode (but still resolves in-memory)", () => {
+    const SESSION = freshSession();
+    // A tool_result-bearing user message so resolveToolResults has an observable
+    // in-memory effect (it strips the tool_result → placeholder).
+    const loreMessages = gatewayMessagesToLore(
+      [
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              toolUseId: "tu-nostore",
+              content: [{ type: "text", text: "secret tool output" }],
+            },
+          ],
+        },
+      ],
+      SESSION,
+    );
+    const before = JSON.stringify(loreMessages);
+    const assistantContentBlocks: GatewayContentBlock[] = [
+      { type: "text", text: "secret assistant message" },
+    ];
+
+    storeTurnTemporal({
+      loreMessages,
+      assistantContentBlocks,
+      usage: USAGE,
+      model: "claude-sonnet-4-20250514",
+      projectPath: PROJECT,
+      sessionID: SESSION,
+      noStore: true,
+    });
+
+    // Nothing persisted …
+    expect(rowsFor(SESSION)).toEqual([]);
+    // … but resolveToolResults still ran (it mutated loreMessages in place —
+    // downstream reconstruct-after-eviction depends on this).
+    expect(JSON.stringify(loreMessages)).not.toBe(before);
+  });
+
+  it("stores the user message with its ORIGINAL tool_result content (before resolveToolResults strips it)", () => {
+    const SESSION = freshSession();
+    const loreMessages = gatewayMessagesToLore(
+      [
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              toolUseId: "tu-1",
+              content: [{ type: "text", text: "DISTINCTIVE_TOOL_OUTPUT_XYZ" }],
+            },
+          ],
+        },
+      ],
+      SESSION,
+    );
+
+    storeTurnTemporal({
+      loreMessages,
+      assistantContentBlocks: [{ type: "text", text: "ack" }],
+      usage: USAGE,
+      model: "claude-sonnet-4-20250514",
+      projectPath: PROJECT,
+      sessionID: SESSION,
+      noStore: false,
+    });
+
+    // The user row must carry the ORIGINAL tool output, NOT the
+    // "[tool results provided]" placeholder resolveToolResults produces — which
+    // proves the user store happened BEFORE the resolve (ordering invariant).
+    const userRow = rowsFor(SESSION).find((r) => r.role === "user");
+    expect(userRow?.content).toContain("DISTINCTIVE_TOOL_OUTPUT_XYZ");
+    expect(userRow?.content).not.toContain("tool results provided");
+  });
+
+  it("batches the writes into a single savepoint (one SAVEPOINT + one RELEASE)", () => {
+    const SESSION = freshSession();
+    const loreMessages = userMessages(SESSION, "batched turn");
+    const assistantContentBlocks: GatewayContentBlock[] = [
+      { type: "text", text: "batched reply" },
+    ];
+
+    const execSpy = vi.spyOn(db(), "exec");
+    storeTurnTemporal({
+      loreMessages,
+      assistantContentBlocks,
+      usage: USAGE,
+      model: "claude-sonnet-4-20250514",
+      projectPath: PROJECT,
+      sessionID: SESSION,
+      noStore: false,
+    });
+
+    const execs = execSpy.mock.calls.map((c) => String(c[0]));
+    expect(
+      execs.filter((s) => s === "SAVEPOINT post_response_temporal").length,
+    ).toBe(1);
+    expect(
+      execs.filter((s) => s === "RELEASE post_response_temporal").length,
+    ).toBe(1);
+    // Success path: no rollback.
+    expect(
+      execs.some((s) => s.startsWith("ROLLBACK TO post_response_temporal")),
+    ).toBe(false);
+    // And the rows landed.
+    expect(rowsFor(SESSION).length).toBe(2);
+    // Atomicity on a mid-batch throw (ROLLBACK TO) is guaranteed by
+    // withSavepoint's own contract/tests — this test only proves the four writes
+    // are wrapped in exactly one savepoint.
+  });
+});


### PR DESCRIPTION
## What

The post-response phase persists a turn's messages with **four separate
auto-commit writes** — user store + tool-calls, then assistant store +
tool-calls — each acquiring the single SQLite writer and committing to the WAL.
Per the issue: "each is µs-scale, but they accumulate and each contends for the
single SQLite writer + WAL." Part of #1077 (Workstream C). Closes #1084.

## How

- Extract the temporal-storage block out of `postResponse()` into a testable
  seam `storeTurnTemporal()` (mirrors the `recordCacheTurnUsage` #928
  extraction).
- Wrap the four writes in a single `withSavepoint("post_response_temporal", …)`
  so the phase commits **once** per turn instead of ~4 times.
- `resolveToolResults` is pure in-memory (`temporal-adapter.ts`, verified: 0 DB
  writes) and **must** run between the user and assistant stores — the user
  message is stored with its ORIGINAL `tool_result` content, before
  resolveToolResults strips it — so it stays inside the savepoint.
- **Resolve the project before the savepoint.** `ensureProject` can reach
  `mergeProjectInternal`'s raw `BEGIN IMMEDIATE` on the lazy NULL-`git_remote`
  backfill path; called *inside* the savepoint that would nest and throw
  "cannot start a transaction within a transaction". Warming `ensureProject`
  once before the savepoint makes the inner store calls cheap cache hits.
  (Caught by adversarial review; proven latent, narrow reachability.)
- No-store mode (amnesia / `x-lore-no-store`) is unchanged: only the in-memory
  resolve runs; nothing is written.

## Correctness

- **Same rows written** — this changes only how many commits happen, not what is
  persisted. The stores are idempotent UPSERTs keyed by message id.
- **Atomicity** — a turn's temporal writes are now all-or-nothing. On a rare
  mid-batch error `withSavepoint` issues `ROLLBACK TO` and rethrows into
  postResponse's best-effort try/catch. That turn's temporal writes are simply
  not persisted (they stay in the live conversation history, so nothing is lost
  to the model — but note they are NOT re-persisted on a later turn).
- **Dangling embeddings** — not a hazard: the fire-and-forget re-embed inside
  `temporal.store` is guarded on both storage modes (vec0 base-row existence
  check; blob `UPDATE … WHERE id=?` no-op), so a rolled-back row leaves no
  orphan vector.
- **Scope** — deliberately limited to the temporal-write batching (issue step
  3). The higher-risk `saveSessionTracking` coalescing (step 2, "correctness
  risk around which fields are persisted when") is **left for the measurement
  step 1 first**, as the issue instructs.

## Tests

New `packages/gateway/test/store-turn-temporal.test.ts`:

1. **parity** — a normal turn stores the user + assistant messages (roles +
   content).
2. **no-store** — writes nothing, but `resolveToolResults` still mutates
   `loreMessages` in-memory (guards the downstream reconstruct-after-eviction
   dependency).
3. **ordering** — a `tool_result`-bearing user message is stored with its
   ORIGINAL tool output, not the `[tool results provided]` placeholder — proving
   the user store runs BEFORE resolveToolResults.
4. **batching** — spies `db().exec` and asserts exactly one
   `SAVEPOINT post_response_temporal` + one `RELEASE` (no `ROLLBACK TO` on
   success).

Mutation-verified: removing the savepoint fails the batching test; moving
resolveToolResults before the user store fails the ordering test; skipping the
no-store resolve fails the no-store test. Atomicity on a mid-batch throw is
guaranteed transitively by `withSavepoint`'s own contract/tests. Full gateway
suite passes (2427; one unrelated `server.test.ts` network flake, green on
re-run). Typecheck + biome clean.
