### PR TITLE
perf(gateway): memoize worker-model resolution per models.dev snapshot

### DIFF
--- a/packages/gateway/src/worker-model.ts
+++ b/packages/gateway/src/worker-model.ts
@@ -35,6 +35,38 @@ let cachedModelDataAt = 0;
 let inflightFetch: Promise<Map<string, ModelsDevEntry>> | null = null;
 const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
 
+/**
+ * Memoized worker-model resolutions (both `resolveNewestInFamily` and
+ * `findCheaperSameProviderModel`).
+ *
+ * A resolution is a pure function of the models.dev snapshot — versioned by
+ * `cachedModelDataAt` — plus its query inputs, so the answer cannot change until
+ * the snapshot does. Reusing it skips the (cheap) rescan, but the real win is
+ * logging: `getWorkerModel()` runs on ~10 background hot paths (idle loop,
+ * cache-warmer, cost-tracker, pipeline), so without memoization each idle cycle
+ * re-emits the same INFO line ~4×. Memoizing collapses it to exactly one line
+ * per genuinely-new outcome, and correctly re-announces after a models.dev
+ * refresh changes the answer (new snapshot version → memo rebuilt).
+ *
+ * Keyed by a `\x1f`-joined tuple; stores `undefined` for memoized negative
+ * results (distinguished from "absent" via `Map.has`). Rebuilt lazily when the
+ * snapshot version advances and reset in `clearModelDataCache()`.
+ */
+let resolutionMemo = new Map<string, string | undefined>();
+let resolutionMemoVersion = -1;
+
+/**
+ * Return the resolution memo valid for the current models.dev snapshot,
+ * rebuilding it when the snapshot version (`cachedModelDataAt`) has advanced.
+ */
+function currentResolutionMemo(): Map<string, string | undefined> {
+  if (resolutionMemoVersion !== cachedModelDataAt) {
+    resolutionMemo = new Map();
+    resolutionMemoVersion = cachedModelDataAt;
+  }
+  return resolutionMemo;
+}
+
 /** Providers to fetch pricing data for from models.dev. */
 const SUPPORTED_PROVIDERS = ["anthropic", "openai"] as const;
 
@@ -426,6 +458,8 @@ export function clearModelDataCache(): void {
   cachedModelDataAt = 0;
   inflightFetch = null;
   lastReadyAttemptAt = 0;
+  resolutionMemo = new Map();
+  resolutionMemoVersion = -1;
 }
 
 // ---------------------------------------------------------------------------
@@ -459,6 +493,10 @@ function findCheaperSameProviderModel(
   const providerModelIds = cachedProviderModels?.get(providerID);
   if (!providerModelIds || !cachedModelData) return undefined;
 
+  const memo = currentResolutionMemo();
+  const memoKey = `cheaper\x1f${providerID}\x1f${sessionModelID}\x1f${sessionInputCost}`;
+  if (memo.has(memoKey)) return memo.get(memoKey);
+
   // Pass 1: cheapest same-provider model cheaper than the session.
   let cheapestId: string | undefined;
   let cheapestCost = sessionInputCost;
@@ -473,7 +511,10 @@ function findCheaperSameProviderModel(
       cheapestFamily = entry.family;
     }
   }
-  if (!cheapestId) return undefined;
+  if (!cheapestId) {
+    memo.set(memoKey, undefined);
+    return undefined;
+  }
 
   // Pass 2: within the cheapest family, prefer the newest member that is still
   // cheaper than the session (release_date desc, then numeric-aware id desc so
@@ -507,6 +548,7 @@ function findCheaperSameProviderModel(
       `instead of ${sessionModelID} ($${sessionInputCost}/M)`,
   );
 
+  memo.set(memoKey, resolvedId);
   return resolvedId;
 }
 
@@ -546,6 +588,10 @@ function resolveNewestInFamily(
   const providerModelIds = cachedProviderModels?.get(providerID);
   if (!providerModelIds || !cachedModelData) return undefined;
 
+  const memo = currentResolutionMemo();
+  const memoKey = `family\x1f${providerID}\x1f${family}\x1f${maxInputCost}`;
+  if (memo.has(memoKey)) return memo.get(memoKey);
+
   let bestId: string | undefined;
   let bestDate = "";
   for (const id of providerModelIds) {
@@ -577,6 +623,7 @@ function resolveNewestInFamily(
       `worker model: newest in family ${providerID}/${family} → ${bestId}`,
     );
   }
+  memo.set(memoKey, bestId);
   return bestId;
 }
 

--- a/packages/gateway/test/worker-model.test.ts
+++ b/packages/gateway/test/worker-model.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import { log } from "@loreai/core";
 
 // Bridge: upstreamFetch now uses undici's own fetch (not globalThis.fetch),
 // so tests that mock globalThis.fetch need this shim to intercept calls.
@@ -1364,6 +1365,192 @@ describe("family-based worker resolution", () => {
     expect(result?.providerID).toBe("google");
     // Absolute cheapest, since there is no family metadata to refine on.
     expect(result?.modelID).toBe("gemini-3-flash-lite");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolution memoization (skip rescan + collapse the per-call INFO log)
+// ---------------------------------------------------------------------------
+
+describe("worker-model resolution memoization", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    resetWorkerModelState();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    resetWorkerModelState();
+    vi.restoreAllMocks();
+  });
+
+  const LIMIT = { context: 200_000, output: 64_000 };
+
+  async function warmCache(response: unknown): Promise<void> {
+    globalThis.fetch = vi.fn(() =>
+      Promise.resolve(new Response(JSON.stringify(response), { status: 200 })),
+    ) as unknown as typeof fetch;
+    resetWorkerModelState();
+    await fetchModelData();
+  }
+
+  /** Anthropic snapshot whose newest cheap-tier sonnet is `newestSonnetId`. */
+  function anthropicSnapshot(newestSonnetId: string) {
+    return {
+      anthropic: {
+        api: "https://api.anthropic.com/v1",
+        models: {
+          "claude-opus-4-6": {
+            id: "claude-opus-4-6",
+            family: "claude-opus",
+            release_date: "2026-01-05",
+            cost: { input: 5, output: 25, cache_read: 0.5 },
+            limit: LIMIT,
+          },
+          "claude-sonnet-5": {
+            id: "claude-sonnet-5",
+            family: "claude-sonnet",
+            release_date: "2026-02-17",
+            cost: { input: 3, output: 15, cache_read: 0.3 },
+            limit: LIMIT,
+          },
+          [newestSonnetId]: {
+            id: newestSonnetId,
+            family: "claude-sonnet",
+            release_date: "2026-06-01",
+            cost: { input: 3, output: 15, cache_read: 0.3 },
+            limit: LIMIT,
+          },
+        },
+      },
+    };
+  }
+
+  const familyLines = (spy: ReturnType<typeof vi.spyOn>): unknown[][] =>
+    (spy.mock.calls as unknown[][]).filter(
+      (c) =>
+        typeof c[0] === "string" &&
+        c[0].includes("worker model: newest in family"),
+    );
+
+  test("family path: the 'newest in family' line is logged once per snapshot despite repeated getWorkerModel calls", async () => {
+    await warmCache(anthropicSnapshot("claude-sonnet-6"));
+
+    // Spy AFTER warming so we only observe resolution logs, not fetch logs.
+    const infoSpy = vi.spyOn(log, "info").mockImplementation(() => {});
+
+    for (let i = 0; i < 5; i++) {
+      const r = getWorkerModel({
+        providerID: "anthropic",
+        model: "claude-opus-4-6",
+      });
+      expect(r?.modelID).toBe("claude-sonnet-6");
+    }
+
+    // Without memoization this fires 5×; memoized it collapses to exactly 1.
+    expect(familyLines(infoSpy)).toHaveLength(1);
+  });
+
+  test("unknown-provider path: the 'dynamic worker model' line is logged once per snapshot despite repeated calls", async () => {
+    await warmCache({
+      anthropic: { api: "https://api.anthropic.com/v1", models: {} },
+      google: {
+        api: "https://generativelanguage.googleapis.com/v1beta",
+        models: {
+          "gemini-3.1-pro": {
+            id: "gemini-3.1-pro",
+            family: "gemini-pro",
+            release_date: "2026-05-01",
+            cost: { input: 4, output: 20 },
+            limit: LIMIT,
+          },
+          "gemini-3-flash-lite": {
+            id: "gemini-3-flash-lite",
+            family: "gemini-flash-lite",
+            release_date: "2026-04-01",
+            cost: { input: 0.15, output: 0.6 },
+            limit: LIMIT,
+          },
+        },
+      },
+    });
+
+    const infoSpy = vi.spyOn(log, "info").mockImplementation(() => {});
+
+    for (let i = 0; i < 5; i++) {
+      const r = getWorkerModel({
+        providerID: "google",
+        model: "gemini-3.1-pro",
+      });
+      expect(r?.modelID).toBe("gemini-3-flash-lite");
+    }
+
+    const dynamicLines = infoSpy.mock.calls.filter(
+      (c) => typeof c[0] === "string" && c[0].includes("dynamic worker model:"),
+    );
+    expect(dynamicLines).toHaveLength(1);
+  });
+
+  test("distinct query inputs are memoized independently (no cross-key collision)", async () => {
+    // One snapshot serving both the family path (anthropic) and the
+    // cheaper path (google) — repeated calls to each must each log once,
+    // proving the memo key discriminates rather than sharing one slot.
+    await warmCache({
+      anthropic: anthropicSnapshot("claude-sonnet-6").anthropic,
+      google: {
+        api: "https://generativelanguage.googleapis.com/v1beta",
+        models: {
+          "gemini-3.1-pro": {
+            id: "gemini-3.1-pro",
+            family: "gemini-pro",
+            release_date: "2026-05-01",
+            cost: { input: 4, output: 20 },
+            limit: LIMIT,
+          },
+          "gemini-3-flash-lite": {
+            id: "gemini-3-flash-lite",
+            family: "gemini-flash-lite",
+            release_date: "2026-04-01",
+            cost: { input: 0.15, output: 0.6 },
+            limit: LIMIT,
+          },
+        },
+      },
+    } as unknown);
+
+    const infoSpy = vi.spyOn(log, "info").mockImplementation(() => {});
+
+    getWorkerModel({ providerID: "anthropic", model: "claude-opus-4-6" });
+    getWorkerModel({ providerID: "anthropic", model: "claude-opus-4-6" });
+    getWorkerModel({ providerID: "google", model: "gemini-3.1-pro" });
+    getWorkerModel({ providerID: "google", model: "gemini-3.1-pro" });
+
+    expect(familyLines(infoSpy)).toHaveLength(1);
+    const dynamicLines = infoSpy.mock.calls.filter(
+      (c) => typeof c[0] === "string" && c[0].includes("dynamic worker model:"),
+    );
+    expect(dynamicLines).toHaveLength(1);
+  });
+
+  test("a new models.dev snapshot re-resolves (memo is snapshot-scoped, never permanently stale)", async () => {
+    await warmCache(anthropicSnapshot("claude-sonnet-6"));
+    expect(
+      getWorkerModel({ providerID: "anthropic", model: "claude-opus-4-6" })
+        ?.modelID,
+    ).toBe("claude-sonnet-6");
+
+    // A later refresh introduces an even newer sonnet. The memo must not pin
+    // the stale answer — resolution reflects the new snapshot and re-announces.
+    const infoSpy = vi.spyOn(log, "info").mockImplementation(() => {});
+    await warmCache(anthropicSnapshot("claude-sonnet-7"));
+
+    expect(
+      getWorkerModel({ providerID: "anthropic", model: "claude-opus-4-6" })
+        ?.modelID,
+    ).toBe("claude-sonnet-7");
+    expect(familyLines(infoSpy).length).toBeGreaterThanOrEqual(1);
   });
 });
 


### PR DESCRIPTION
## Problem

`getWorkerModel()` runs on ~10 background hot paths (idle loop, cache-warmer, cost-tracker, and ~6 pipeline sites). Each expensive-session call re-runs `resolveNewestInFamily` / `findCheaperSameProviderModel` **and** re-emits the same INFO line. In one idle cycle you see the same line ~4× (once per background worker):

```
worker model: newest in family anthropic/claude-sonnet → claude-sonnet-5
```

The scan itself is cheap (in-memory, no I/O — models.dev data is already cached), so this is primarily **log noise**, with a small redundant-recompute cost.

## Fix

A resolution is a pure function of the models.dev snapshot — versioned by `cachedModelDataAt` — plus its query inputs. Memoize it keyed on `(snapshot-version, provider, family/model, maxInputCost)`:

- On a hit: return the cached value, skipping **both** the rescan and the log.
- The memo is rebuilt lazily when the snapshot version advances, so a models.dev refresh that promotes a newer model **re-resolves and re-announces** correctly.
- Reset in `clearModelDataCache()` (the test/reset path).
- Negative results (`undefined`) are memoized too, distinguished from "absent" via `Map.has`.

Net effect: **exactly one INFO line per genuinely-new outcome.** Covers both the family path (`resolveNewestInFamily`) and the unknown-provider path (`findCheaperSameProviderModel`).

## Tests

4 new tests in `worker-model.test.ts`:
- family path: `newest in family` logged once per snapshot across repeated calls
- unknown-provider path: `dynamic worker model` logged once per snapshot across repeated calls
- distinct query inputs memoized independently (no cross-key collision)
- a new models.dev snapshot re-resolves (memo is snapshot-scoped, never permanently stale)

The three log-count tests are **mutation-verified**: they fail 5×/2× when the memo lookup is disabled.

Full gateway suite: 2402 passed / 0 failed. `tsc` clean. Biome clean.