### PR TITLE
feat(telemetry): p50/p95 vector KNN read-latency to confirm the vec0 win (#1065)

### DIFF
--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -14,6 +14,7 @@
  */
 
 import { freemem } from "node:os";
+import { performance } from "node:perf_hooks";
 import { db, getKV, setKV } from "./db";
 import { isVecAvailable } from "./db/vec";
 import {
@@ -34,6 +35,7 @@ import {
 } from "./db/vec-store";
 import { config } from "./config";
 import * as log from "./log";
+import { recordVecReadLatency } from "./vec-latency";
 import { buildEmbeddingText, buildEmbeddingUnits } from "./embedding-units";
 import { vendorModelInfo } from "./embedding-vendor";
 import {
@@ -1304,26 +1306,41 @@ async function poolOrInProcess(
   spec: VectorQuerySpec,
   queryEmbedding: Float32Array,
 ): Promise<VectorHit[] | DistillationVectorHit[]> {
-  const pooled = await tryPoolVectorSearch(spec, queryEmbedding);
-  // Timed out: the worker is alive but slow. Return empty — degrading this one
-  // recall — rather than re-running the O(n) scan on the main thread, which
-  // re-blocks the event loop (the stall bug). The pool cancels the timed-out
-  // worker query (terminates + respawns) so it recovers for the next caller.
-  if (pooled === VECTOR_SEARCH_TIMED_OUT) return [];
-  if (pooled !== null) return pooled;
-  const readMode = resolveReadMode(readStorageMode(db()), isVecAvailable());
+  // #1065: record the wall-clock latency of every vector KNN read (pool
+  // round-trip + IPC, or the in-process fallback scan) tagged by the DB's
+  // (storage layout × sqlite-vec availability) cohort, so the gateway can prove
+  // the vec0 latency win (p50/p95) and spot a silently degraded JS-fallback
+  // host. storage_mode is DB-global and vec availability is process-global (the
+  // main thread and the workers load the extension together), so this
+  // main-thread resolution faithfully labels the worker path too. The lookup is
+  // a single indexed kv_meta point read (microseconds). Purely additive: the
+  // query path below is unchanged — the fallback re-resolves its own readMode.
+  const started = performance.now();
+  const cohort = resolveReadMode(readStorageMode(db()), isVecAvailable());
   try {
-    return runVectorQuery(db(), readMode, queryEmbedding, spec);
-  } catch (err) {
-    // Safety net for the vec0 read path, which (unlike the blob paths) has no
-    // in-line JS fallback: a vec0 `MATCH` can throw transiently — e.g. during a
-    // dimension change, when the query embedding's width no longer matches the
-    // vec0 table — and we must degrade THIS recall to empty (FTS/keyword recall
-    // still answers) rather than crash, per the never-crash contract. The pool
-    // already logged any worker-path failure; log the in-process one too so a
-    // systematic break stays visible.
-    log.error("in-process vector search failed; returning empty:", err);
-    return [];
+    const pooled = await tryPoolVectorSearch(spec, queryEmbedding);
+    // Timed out: the worker is alive but slow. Return empty — degrading this one
+    // recall — rather than re-running the O(n) scan on the main thread, which
+    // re-blocks the event loop (the stall bug). The pool cancels the timed-out
+    // worker query (terminates + respawns) so it recovers for the next caller.
+    if (pooled === VECTOR_SEARCH_TIMED_OUT) return [];
+    if (pooled !== null) return pooled;
+    const readMode = resolveReadMode(readStorageMode(db()), isVecAvailable());
+    try {
+      return runVectorQuery(db(), readMode, queryEmbedding, spec);
+    } catch (err) {
+      // Safety net for the vec0 read path, which (unlike the blob paths) has no
+      // in-line JS fallback: a vec0 `MATCH` can throw transiently — e.g. during a
+      // dimension change, when the query embedding's width no longer matches the
+      // vec0 table — and we must degrade THIS recall to empty (FTS/keyword recall
+      // still answers) rather than crash, per the never-crash contract. The pool
+      // already logged any worker-path failure; log the in-process one too so a
+      // systematic break stays visible.
+      log.error("in-process vector search failed; returning empty:", err);
+      return [];
+    }
+  } finally {
+    recordVecReadLatency(cohort, performance.now() - started);
   }
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -265,6 +265,7 @@ export {
   type VecReadLatencyStat,
   vecReadLatencyStats,
   vecReadLatencyTotalSamples,
+  formatVecReadLatencyHeartbeat,
   _resetVecReadLatencyForTest,
 } from "./vec-latency";
 export { distillLimiter, curatorLimiter } from "./session-limiter";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -257,6 +257,16 @@ export {
   setReadPathTimingHook,
   type ReadPathTiming,
 } from "./read-telemetry";
+export {
+  recordVecReadLatency,
+  setVecReadLatencyHook,
+  VEC_LATENCY_WINDOW,
+  type VecReadLatencySample,
+  type VecReadLatencyStat,
+  vecReadLatencyStats,
+  vecReadLatencyTotalSamples,
+  _resetVecReadLatencyForTest,
+} from "./vec-latency";
 export { distillLimiter, curatorLimiter } from "./session-limiter";
 export {
   installFetchInterceptor,

--- a/packages/core/src/vec-latency.ts
+++ b/packages/core/src/vec-latency.ts
@@ -124,6 +124,24 @@ export function vecReadLatencyTotalSamples(): number {
   return totalRecorded;
 }
 
+/**
+ * Render the per-cohort rolling p50/p95 as a single heartbeat line for the
+ * gateway idle log, e.g. `vec0 p50=12ms p95=45ms n=203 | degraded p50=...`.
+ * Returns null when there are no samples yet (nothing to log). Latencies are
+ * rounded to whole milliseconds.
+ */
+export function formatVecReadLatencyHeartbeat(
+  stats: VecReadLatencyStat[] = vecReadLatencyStats(),
+): string | null {
+  if (stats.length === 0) return null;
+  return stats
+    .map(
+      (s) =>
+        `${s.readMode} p50=${Math.round(s.p50)}ms p95=${Math.round(s.p95)}ms n=${s.count}`,
+    )
+    .join(" | ");
+}
+
 /** Test-only: clear all windows, the total counter, and the hook. */
 export function _resetVecReadLatencyForTest(): void {
   windows.clear();

--- a/packages/core/src/vec-latency.ts
+++ b/packages/core/src/vec-latency.ts
@@ -1,0 +1,132 @@
+// Vector KNN read-latency telemetry (#1065).
+//
+// Post the vec0 cutover (#999 / #1051) the pathological O(n) blob scan is gone,
+// but we had no PRODUCTION signal proving the p50/p95 latency win on real DBs —
+// only spike-bench numbers. This module records the wall-clock latency of every
+// vector KNN read (the single `poolOrInProcess` chokepoint in embedding.ts) into
+// a small per-cohort rolling window so the gateway can:
+//   1. log a periodic p50/p95 heartbeat line (per-install visibility), and
+//   2. forward each sample to Sentry as a distribution (cross-install
+//      percentiles, incl. nightly).
+//
+// Samples are tagged by {@link VecReadMode} — the (storage layout × sqlite-vec
+// availability) cohort — so a healthy vec0 host (sub-second) is separable from a
+// silently degraded JS-fallback host (multi-second). That split is the whole
+// point: without it we could not tell a regression (a host that fell back to JS
+// brute force, or a pathological partition) from a healthy rollout.
+//
+// @loreai/core stays Sentry-free: the gateway registers the hook and owns the
+// SDK coupling (mirrors read-telemetry.ts).
+
+import type { VecReadMode } from "./db/vec-store";
+
+/** One recorded vector KNN read. */
+export interface VecReadLatencySample {
+  /** (storage layout × vec availability) cohort the read ran under. */
+  readMode: VecReadMode;
+  /** Wall-clock latency of the whole read job (pool queue + IPC + KNN, or the
+   *  in-process fallback scan), in milliseconds. */
+  elapsedMs: number;
+}
+
+/** Rolling-window p50/p95 latency for one cohort. */
+export interface VecReadLatencyStat {
+  readMode: VecReadMode;
+  /** Samples currently in the rolling window for this cohort. */
+  count: number;
+  /** Median read latency over the window, milliseconds. */
+  p50: number;
+  /** 95th-percentile read latency over the window, milliseconds. */
+  p95: number;
+}
+
+/** Per-cohort rolling window size. Bounds memory (≤ 4 cohorts × this many
+ *  numbers) and keeps the percentiles reflective of RECENT behavior rather than
+ *  the whole process lifetime. */
+export const VEC_LATENCY_WINDOW = 256;
+
+const windows = new Map<VecReadMode, number[]>();
+let totalRecorded = 0;
+let hook: ((s: VecReadLatencySample) => void) | null = null;
+
+/** Register a host telemetry hook fired once per recorded read. Pass null to
+ *  clear. The hook must not throw; errors are swallowed. */
+export function setVecReadLatencyHook(
+  fn: ((s: VecReadLatencySample) => void) | null,
+): void {
+  hook = fn;
+}
+
+/**
+ * Record one vector KNN read's latency into its cohort's rolling window and
+ * fire the host hook. Non-finite / negative values are ignored so a clock
+ * anomaly can never poison the percentiles. Never throws — telemetry must never
+ * break the read path.
+ */
+export function recordVecReadLatency(
+  readMode: VecReadMode,
+  elapsedMs: number,
+): void {
+  if (!Number.isFinite(elapsedMs) || elapsedMs < 0) return;
+  let buf = windows.get(readMode);
+  if (!buf) {
+    buf = [];
+    windows.set(readMode, buf);
+  }
+  buf.push(elapsedMs);
+  // Ring behaviour: drop the oldest sample once the window is full.
+  if (buf.length > VEC_LATENCY_WINDOW) buf.shift();
+  totalRecorded++;
+  const h = hook;
+  if (h) {
+    try {
+      h({ readMode, elapsedMs });
+    } catch {
+      // Telemetry must never break the read path.
+    }
+  }
+}
+
+/** Nearest-rank percentile of an ASC-sorted array. `p` in [0, 100]. */
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const rank = Math.ceil((p / 100) * sorted.length);
+  const idx = Math.min(sorted.length - 1, Math.max(0, rank - 1));
+  return sorted[idx];
+}
+
+/**
+ * Snapshot per-cohort rolling p50/p95. Cohorts with no samples are omitted.
+ * Sorted by `readMode` for a stable, deterministic heartbeat line.
+ */
+export function vecReadLatencyStats(): VecReadLatencyStat[] {
+  const out: VecReadLatencyStat[] = [];
+  for (const [readMode, buf] of windows) {
+    if (buf.length === 0) continue;
+    const sorted = [...buf].sort((a, b) => a - b);
+    out.push({
+      readMode,
+      count: sorted.length,
+      p50: percentile(sorted, 50),
+      p95: percentile(sorted, 95),
+    });
+  }
+  out.sort((a, b) => a.readMode.localeCompare(b.readMode));
+  return out;
+}
+
+/**
+ * Monotonic count of all reads ever recorded (across cohorts). The gateway
+ * heartbeat compares this between ticks so it only logs when new reads happened
+ * — no log spam during idle periods.
+ */
+export function vecReadLatencyTotalSamples(): number {
+  return totalRecorded;
+}
+
+/** Test-only: clear all windows, the total counter, and the hook. */
+export function _resetVecReadLatencyForTest(): void {
+  windows.clear();
+  totalRecorded = 0;
+  hook = null;
+}

--- a/packages/core/test/vec-latency-instrument.test.ts
+++ b/packages/core/test/vec-latency-instrument.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { ensureProject } from "../src/db";
+import { vectorSearch, vectorSearchTemporal } from "../src/embedding";
+import {
+  _resetVecReadLatencyForTest,
+  setVecReadLatencyHook,
+  type VecReadLatencySample,
+  vecReadLatencyStats,
+  vecReadLatencyTotalSamples,
+} from "../src/vec-latency";
+
+const PROJECT = "/test/vec-latency-instrument";
+
+// A query vector's exact dimension is irrelevant here: with an empty knowledge
+// table the blob path compares against zero rows, and even if a path throws it
+// is caught inside `poolOrInProcess` — the latency sample is recorded in the
+// `finally` either way, which is exactly what these tests pin down.
+const query = new Float32Array(768).fill(0.01);
+
+describe("vector search records a read-latency sample (#1065)", () => {
+  beforeEach(() => {
+    ensureProject(PROJECT);
+    _resetVecReadLatencyForTest();
+  });
+  afterEach(() => {
+    _resetVecReadLatencyForTest();
+  });
+
+  test("each vectorSearch call fires exactly one sample through the chokepoint", async () => {
+    const seen: VecReadLatencySample[] = [];
+    setVecReadLatencyHook((s) => seen.push(s));
+
+    await vectorSearch(query, 5);
+    expect(seen).toHaveLength(1);
+    expect(seen[0].elapsedMs).toBeGreaterThanOrEqual(0);
+
+    // A second, different vector search kind also routes through the same
+    // instrumented chokepoint.
+    await vectorSearchTemporal(query, PROJECT, 5);
+    expect(seen).toHaveLength(2);
+  });
+
+  test("recorded samples land in the rolling stats + total counter", async () => {
+    expect(vecReadLatencyTotalSamples()).toBe(0);
+    await vectorSearch(query, 5);
+    expect(vecReadLatencyTotalSamples()).toBe(1);
+    const stats = vecReadLatencyStats();
+    expect(stats.reduce((n, s) => n + s.count, 0)).toBe(1);
+  });
+});

--- a/packages/core/test/vec-latency.test.ts
+++ b/packages/core/test/vec-latency.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "vitest";
 import {
   _resetVecReadLatencyForTest,
+  formatVecReadLatencyHeartbeat,
   recordVecReadLatency,
   setVecReadLatencyHook,
   VEC_LATENCY_WINDOW,
@@ -100,6 +101,18 @@ describe("vec-latency rolling telemetry", () => {
     expect(() => recordVecReadLatency("vec0", 5)).not.toThrow();
     const [s] = vecReadLatencyStats();
     expect(s.count).toBe(1);
+  });
+
+  test("heartbeat line renders rounded per-cohort p50/p95, or null when empty", () => {
+    // Nothing recorded yet → nothing to log.
+    expect(formatVecReadLatencyHeartbeat()).toBeNull();
+
+    recordVecReadLatency("vec0", 12.6);
+    recordVecReadLatency("degraded", 9000);
+    // Sorted by readMode (degraded < vec0); latencies rounded to whole ms.
+    expect(formatVecReadLatencyHeartbeat()).toBe(
+      "degraded p50=9000ms p95=9000ms n=1 | vec0 p50=13ms p95=13ms n=1",
+    );
   });
 
   test("dropped hook stops receiving samples", () => {

--- a/packages/core/test/vec-latency.test.ts
+++ b/packages/core/test/vec-latency.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  _resetVecReadLatencyForTest,
+  recordVecReadLatency,
+  setVecReadLatencyHook,
+  VEC_LATENCY_WINDOW,
+  type VecReadLatencySample,
+  vecReadLatencyStats,
+  vecReadLatencyTotalSamples,
+} from "../src/vec-latency";
+
+afterEach(() => {
+  _resetVecReadLatencyForTest();
+});
+
+describe("vec-latency rolling telemetry", () => {
+  test("computes nearest-rank p50/p95 per cohort", () => {
+    // 10 samples 10..100; nearest-rank: p50 -> rank ceil(0.5*10)=5 -> 50,
+    // p95 -> rank ceil(0.95*10)=10 -> 100.
+    for (let v = 10; v <= 100; v += 10) recordVecReadLatency("vec0", v);
+    const stats = vecReadLatencyStats();
+    expect(stats).toHaveLength(1);
+    const s = stats[0];
+    expect(s.readMode).toBe("vec0");
+    expect(s.count).toBe(10);
+    expect(s.p50).toBe(50);
+    expect(s.p95).toBe(100);
+  });
+
+  test("a single sample reports itself as both p50 and p95", () => {
+    recordVecReadLatency("blob-native", 42);
+    const [s] = vecReadLatencyStats();
+    expect(s.count).toBe(1);
+    expect(s.p50).toBe(42);
+    expect(s.p95).toBe(42);
+  });
+
+  test("cohorts are isolated — vec0 vs degraded never mix", () => {
+    // Fast healthy vec0 reads vs slow degraded JS-fallback reads: the whole
+    // point of #1065 is that these are separable.
+    for (let i = 0; i < 20; i++) recordVecReadLatency("vec0", 5);
+    for (let i = 0; i < 20; i++) recordVecReadLatency("degraded", 9000);
+    const stats = vecReadLatencyStats();
+    // Sorted by readMode: "degraded" < "vec0".
+    expect(stats.map((s) => s.readMode)).toEqual(["degraded", "vec0"]);
+    const degraded = stats.find((s) => s.readMode === "degraded");
+    const vec0 = stats.find((s) => s.readMode === "vec0");
+    expect(vec0?.p95).toBe(5);
+    expect(degraded?.p95).toBe(9000);
+  });
+
+  test("rolling window is bounded — oldest samples drop out", () => {
+    // Fill past the window with a low baseline, then push a burst of highs.
+    for (let i = 0; i < VEC_LATENCY_WINDOW; i++) {
+      recordVecReadLatency("vec0", 1);
+    }
+    for (let i = 0; i < VEC_LATENCY_WINDOW; i++) {
+      recordVecReadLatency("vec0", 1000);
+    }
+    const [s] = vecReadLatencyStats();
+    // Window never exceeds its cap...
+    expect(s.count).toBe(VEC_LATENCY_WINDOW);
+    // ...and the low baseline has been fully evicted (percentiles reflect the
+    // recent highs only). Without the ring bound the old 1s samples would still
+    // be present and p50 would be 1, not 1000.
+    expect(s.p50).toBe(1000);
+    // Total counter still reflects every recorded read, not just the window.
+    expect(vecReadLatencyTotalSamples()).toBe(2 * VEC_LATENCY_WINDOW);
+  });
+
+  test("ignores non-finite and negative latencies", () => {
+    recordVecReadLatency("vec0", Number.NaN);
+    recordVecReadLatency("vec0", Number.POSITIVE_INFINITY);
+    recordVecReadLatency("vec0", -3);
+    expect(vecReadLatencyStats()).toHaveLength(0);
+    expect(vecReadLatencyTotalSamples()).toBe(0);
+    recordVecReadLatency("vec0", 7);
+    expect(vecReadLatencyTotalSamples()).toBe(1);
+  });
+
+  test("empty cohorts are omitted from the snapshot", () => {
+    expect(vecReadLatencyStats()).toEqual([]);
+  });
+
+  test("fires the host hook once per recorded read", () => {
+    const seen: VecReadLatencySample[] = [];
+    setVecReadLatencyHook((s) => seen.push(s));
+    recordVecReadLatency("blob-js", 12);
+    recordVecReadLatency("vec0", 34);
+    expect(seen).toEqual([
+      { readMode: "blob-js", elapsedMs: 12 },
+      { readMode: "vec0", elapsedMs: 34 },
+    ]);
+  });
+
+  test("a throwing hook never breaks recording", () => {
+    setVecReadLatencyHook(() => {
+      throw new Error("boom");
+    });
+    expect(() => recordVecReadLatency("vec0", 5)).not.toThrow();
+    const [s] = vecReadLatencyStats();
+    expect(s.count).toBe(1);
+  });
+
+  test("dropped hook stops receiving samples", () => {
+    let calls = 0;
+    setVecReadLatencyHook(() => calls++);
+    recordVecReadLatency("vec0", 1);
+    setVecReadLatencyHook(null);
+    recordVecReadLatency("vec0", 2);
+    expect(calls).toBe(1);
+    // Recording still works with no hook installed.
+    expect(vecReadLatencyStats()[0].count).toBe(2);
+  });
+});

--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -40,6 +40,8 @@ import {
   evictSession as evictGradientSession,
   distillLimiter,
   curatorLimiter,
+  vecReadLatencyStats,
+  vecReadLatencyTotalSamples,
 } from "@loreai/core";
 import type { CacheStrategy, ChangedEntry, LLMClient } from "@loreai/core";
 import {
@@ -364,6 +366,10 @@ export function startIdleScheduler(
   // tick after startup runs it once (catches entries that decayed while the
   // gateway was down), then at most once per GLOBAL_DEAD_SWEEP_INTERVAL_MS.
   let lastGlobalDeadSweepAt = 0;
+  // Cumulative vector-read count at the last heartbeat log (#1065). The
+  // heartbeat only logs when new reads happened since the last tick, so idle
+  // periods stay quiet instead of repeating a stale p50/p95 line every tick.
+  let lastVecLatencyLogged = 0;
 
   // Begin sampling event-loop delay for the periodic resource gauge below.
   startResourceMonitor();
@@ -375,6 +381,32 @@ export function startIdleScheduler(
     // Periodic process-resource + event-loop-lag gauge (~30s). Cheap, gated on
     // Sentry being initialized, and never throws.
     emitResourceGauge();
+
+    // Vector KNN read-latency heartbeat (#1065): log the rolling p50/p95 per
+    // (storage × vec) cohort so a healthy vec0 host (sub-second) is visibly
+    // separable from a degraded JS-fallback host (multi-second) in per-install
+    // logs — the local counterpart to the Sentry distribution. Gated on new
+    // reads since the last tick so idle periods stay quiet. Never throws out.
+    try {
+      const totalReads = vecReadLatencyTotalSamples();
+      if (totalReads > lastVecLatencyLogged) {
+        lastVecLatencyLogged = totalReads;
+        const stats = vecReadLatencyStats();
+        if (stats.length > 0) {
+          const summary = stats
+            .map(
+              (s) =>
+                `${s.readMode} p50=${Math.round(s.p50)}ms p95=${Math.round(
+                  s.p95,
+                )}ms n=${s.count}`,
+            )
+            .join(" | ");
+          log.info(`vec read latency (rolling): ${summary}`);
+        }
+      }
+    } catch {
+      // Telemetry must never break the idle loop.
+    }
 
     // Scale background concurrency to the live session count before scheduling
     // this tick's work. The idle scheduler owns the sessions Map, so doing it

--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -40,7 +40,7 @@ import {
   evictSession as evictGradientSession,
   distillLimiter,
   curatorLimiter,
-  vecReadLatencyStats,
+  formatVecReadLatencyHeartbeat,
   vecReadLatencyTotalSamples,
 } from "@loreai/core";
 import type { CacheStrategy, ChangedEntry, LLMClient } from "@loreai/core";
@@ -391,18 +391,8 @@ export function startIdleScheduler(
       const totalReads = vecReadLatencyTotalSamples();
       if (totalReads > lastVecLatencyLogged) {
         lastVecLatencyLogged = totalReads;
-        const stats = vecReadLatencyStats();
-        if (stats.length > 0) {
-          const summary = stats
-            .map(
-              (s) =>
-                `${s.readMode} p50=${Math.round(s.p50)}ms p95=${Math.round(
-                  s.p95,
-                )}ms n=${s.count}`,
-            )
-            .join(" | ");
-          log.info(`vec read latency (rolling): ${summary}`);
-        }
+        const summary = formatVecReadLatencyHeartbeat();
+        if (summary) log.info(`vec read latency (rolling): ${summary}`);
       }
     } catch {
       // Telemetry must never break the idle loop.

--- a/packages/gateway/src/sentry.ts
+++ b/packages/gateway/src/sentry.ts
@@ -567,6 +567,7 @@ export function setupEmbeddingFailureCapture(): void {
 // ---------------------------------------------------------------------------
 
 import { setReadPathTimingHook, type ReadPathTiming } from "@loreai/core";
+import { setVecReadLatencyHook, type VecReadLatencySample } from "@loreai/core";
 
 /**
  * Wire core's read-path timing hook to Sentry. Called once at startup. Emits a
@@ -611,6 +612,53 @@ export function setupReadPathTimingCapture(): void {
         t.candidateCount,
         { attributes },
       );
+    } catch {
+      // Telemetry must never break the read path.
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Vector KNN read-latency (#1065 — confirm the vec0 win in production)
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive the (storage_mode, vec_available) tag pair from a read cohort so a
+ * healthy vec0 host is separable from a silently degraded JS-fallback host:
+ *   - vec0         → storage=vec0, vec_available=true
+ *   - degraded     → storage=vec0, vec_available=false  (vec0 layout, no ext)
+ *   - blob-native  → storage=blob, vec_available=true
+ *   - blob-js      → storage=blob, vec_available=false
+ */
+export function vecCohortTags(readMode: VecReadLatencySample["readMode"]): {
+  read_mode: string;
+  storage_mode: string;
+  vec_available: string;
+} {
+  const storageVec = readMode === "vec0" || readMode === "degraded";
+  const native = readMode === "vec0" || readMode === "blob-native";
+  return {
+    read_mode: readMode,
+    storage_mode: storageVec ? "vec0" : "blob",
+    vec_available: native ? "true" : "false",
+  };
+}
+
+/**
+ * Wire core's vector-read-latency hook to Sentry. Called once at startup. Emits
+ * one distribution per vector KNN read (`poolOrInProcess`), tagged by cohort, so
+ * p50/p95 read latency is queryable across all installs (incl. nightly) —
+ * proving the #999/#1051 vec0 latency win on real DBs and surfacing a host that
+ * silently degraded to JS brute force. Never throws.
+ */
+export function setupVecReadLatencyCapture(): void {
+  setVecReadLatencyHook((s: VecReadLatencySample) => {
+    if (!Sentry.isInitialized()) return;
+    try {
+      Sentry.metrics.distribution("lore.vec.read_latency_ms", s.elapsedMs, {
+        unit: "millisecond",
+        attributes: vecCohortTags(s.readMode),
+      });
     } catch {
       // Telemetry must never break the read path.
     }

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -25,6 +25,7 @@ import {
   setupEmbeddingFailureCapture,
   setupBustSpiralCapture,
   setupReadPathTimingCapture,
+  setupVecReadLatencyCapture,
 } from "./sentry";
 import type { GatewayRequest } from "./translate/types";
 import { parseAnthropicRequest } from "./translate/anthropic";
@@ -382,6 +383,10 @@ export async function startServer(config: GatewayConfig): Promise<{
   // Wire read-path timing (forSession/recall) to Sentry (#966 B). Same
   // idempotency guarantee — the hook is assigned, not stacked.
   setupReadPathTimingCapture();
+
+  // Wire vector KNN read-latency to Sentry (#1065 — confirm the vec0 win). Same
+  // idempotency guarantee — the hook is assigned, not stacked.
+  setupVecReadLatencyCapture();
 
   // Shared fetch handler for all server instances.
   const fetch = async (req: Request): Promise<Response> => {

--- a/packages/gateway/test/vec-latency-capture.test.ts
+++ b/packages/gateway/test/vec-latency-capture.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock @sentry/bun BEFORE importing the module under test (mirrors
+// readpath-capture.test.ts). A full factory replaces the shared instance for
+// both this test and src/sentry.ts, so we can drive isInitialized() and assert
+// the exact distribution + attributes emitted.
+vi.mock("@sentry/bun", () => ({
+  isInitialized: vi.fn(() => false),
+  metrics: {
+    distribution: vi.fn(),
+    count: vi.fn(),
+  },
+}));
+
+import * as core from "@loreai/core";
+import * as Sentry from "@sentry/bun";
+import { setupVecReadLatencyCapture, vecCohortTags } from "../src/sentry";
+
+type VecHook = (s: core.VecReadLatencySample) => void;
+
+function installAndGetHook(): VecHook {
+  const setterSpy = vi.spyOn(core, "setVecReadLatencyHook");
+  try {
+    setupVecReadLatencyCapture();
+    expect(setterSpy).toHaveBeenCalledOnce();
+    return setterSpy.mock.calls[0][0] as VecHook;
+  } finally {
+    setterSpy.mockRestore();
+  }
+}
+
+describe("vecCohortTags", () => {
+  it("splits each read cohort into storage_mode × vec_available", () => {
+    expect(vecCohortTags("vec0")).toEqual({
+      read_mode: "vec0",
+      storage_mode: "vec0",
+      vec_available: "true",
+    });
+    // A vec0-layout host with no extension: the degraded JS-fallback we must be
+    // able to spot in production.
+    expect(vecCohortTags("degraded")).toEqual({
+      read_mode: "degraded",
+      storage_mode: "vec0",
+      vec_available: "false",
+    });
+    expect(vecCohortTags("blob-native")).toEqual({
+      read_mode: "blob-native",
+      storage_mode: "blob",
+      vec_available: "true",
+    });
+    expect(vecCohortTags("blob-js")).toEqual({
+      read_mode: "blob-js",
+      storage_mode: "blob",
+      vec_available: "false",
+    });
+  });
+});
+
+describe("vector read-latency Sentry capture (#1065)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(Sentry.isInitialized).mockReturnValue(true);
+    core.setVecReadLatencyHook(null);
+  });
+
+  it("forwards each sample as a cohort-tagged distribution", () => {
+    const hook = installAndGetHook();
+    hook({ readMode: "vec0", elapsedMs: 12 });
+
+    const calls = vi.mocked(Sentry.metrics.distribution).mock.calls;
+    const dist = calls.find((c) => c[0] === "lore.vec.read_latency_ms");
+    expect(dist).toBeDefined();
+    expect(dist?.[1]).toBe(12);
+    const opts = dist?.[2] as {
+      unit?: string;
+      attributes?: Record<string, string>;
+    };
+    expect(opts?.unit).toBe("millisecond");
+    expect(opts?.attributes).toEqual({
+      read_mode: "vec0",
+      storage_mode: "vec0",
+      vec_available: "true",
+    });
+  });
+
+  it("tags a degraded read distinctly from a healthy vec0 read", () => {
+    const hook = installAndGetHook();
+    hook({ readMode: "degraded", elapsedMs: 9000 });
+    const dist = vi
+      .mocked(Sentry.metrics.distribution)
+      .mock.calls.find((c) => c[0] === "lore.vec.read_latency_ms");
+    expect(
+      (dist?.[2] as { attributes?: Record<string, string> })?.attributes,
+    ).toEqual({
+      read_mode: "degraded",
+      storage_mode: "vec0",
+      vec_available: "false",
+    });
+  });
+
+  it("emits nothing when Sentry is not initialized", () => {
+    vi.mocked(Sentry.isInitialized).mockReturnValue(false);
+    const hook = installAndGetHook();
+    hook({ readMode: "vec0", elapsedMs: 5 });
+    expect(Sentry.metrics.distribution).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

Instruments the **single vector-search chokepoint** (`embedding.ts` `poolOrInProcess`, which all 5 vector searches route through) with per-read wall-clock latency, tagged by the `(storage layout × sqlite-vec availability)` cohort. Surfaces rolling **p50/p95** two ways, per the issue:

1. **Heartbeat log line** on the gateway idle tick (~30s) — per-install visibility, gated on new reads so idle periods stay quiet.
2. **Sentry distribution** per read (`lore.vec.read_latency_ms`) tagged with `storage_mode` + `vec_available` — cross-install percentiles (incl. nightly).

## Why

The vec0 cutover (#999 / #1051) should have crushed the pathological read latency (p50 ~20s / p95 ~98–128s), but we had **no production signal** proving the percentile win on real DBs — only spike-bench numbers. Without cohort-tagged p50/p95 we can't tell a regression (a host that silently fell back to JS brute force, or a pathological partition) from a healthy rollout. This closes that gap:

- **vec0** → `storage=vec0, vec_available=true` (healthy, sub-second)
- **degraded** → `storage=vec0, vec_available=false` (the JS-fallback host we must be able to spot)
- **blob-native** / **blob-js** → the pre-cutover cohorts

## Design

- New Sentry-free core module `vec-latency.ts` — bounded per-cohort rolling window (256 samples), nearest-rank p50/p95, per-sample host hook. Mirrors `read-telemetry.ts` (core stays SDK-free; the gateway owns the Sentry coupling).
- **Purely additive**: the vector query path is unchanged — the fallback still resolves its own `readMode`; instrumentation only adds an up-front cohort tag (one indexed `kv_meta` point read) and a `finally` that records the elapsed time. Never throws — telemetry must never break the read path.

## Tests

- `vec-latency.test.ts` (10) — percentiles, cohort isolation, ring-window bound, non-finite guard, hook lifecycle, heartbeat formatting.
- `vec-latency-instrument.test.ts` (2) — every `vectorSearch*` call fires exactly one sample through the chokepoint.
- `vec-latency-capture.test.ts` (4) — cohort→tag derivation + Sentry forwarding + Sentry-off no-op.
- Mutation-verified: dropping the record call, breaking the percentile/ring/guard, and swapping the cohort tags each fail a test.
- Full core + gateway suite green (4767 passed).

Closes #1065. #999 stays open until this confirms the percentile win on real DBs.
