### PR TITLE
fix(cost-tracker): per-model auto-compact threshold for the avoided-compactions estimate (#983)

### DIFF
--- a/packages/gateway/src/compaction.ts
+++ b/packages/gateway/src/compaction.ts
@@ -121,6 +121,25 @@ export function maxReportedUsageForModel(
 }
 
 /**
+ * The host agent's auto-compact TRIGGER point for a model with the given
+ * context window and max-output budget: the UNSCALED `effective − 13k`
+ * (`contextWindow − min(maxOutput, 20k) − 13k`), **not** the `0.9×` reporting
+ * cap. This is the point a host like Claude Code would auto-compact, which is
+ * what the cost-tracker's counterfactual "avoided compactions" estimate models
+ * — distinct from {@link maxReportedUsageForModel}, the client-usage cap.
+ *
+ * For a 200K-context model this returns 167_000 (== {@link AUTOCOMPACT_THRESHOLD}).
+ */
+export function autocompactThresholdForModel(
+  contextWindow: number,
+  maxOutputTokens: number,
+): number {
+  const effective =
+    contextWindow - Math.min(maxOutputTokens, MAX_OUTPUT_RESERVE);
+  return Math.max(0, effective - AUTOCOMPACT_BUFFER_TOKENS);
+}
+
+/**
  * Cap used when the model's real window is unknown — preserves the historical
  * 200K-model behavior (floor(167_000 × 0.9) = 150_300).
  */

--- a/packages/gateway/src/cost-tracker.ts
+++ b/packages/gateway/src/cost-tracker.ts
@@ -11,7 +11,11 @@
  */
 
 import { getModelEntrySync, getWorkerModel } from "./worker-model";
-import { AUTOCOMPACT_THRESHOLD } from "./compaction";
+import {
+  AUTOCOMPACT_THRESHOLD,
+  MAX_OUTPUT_RESERVE,
+  autocompactThresholdForModel,
+} from "./compaction";
 import {
   log,
   data,
@@ -738,6 +742,49 @@ export function recordWarmupCost(
 const POST_COMPACTION_CONTEXT = 30_000;
 
 /**
+ * Per-model auto-compact threshold for the counterfactual estimate. Mirrors
+ * pipeline.ts `maxReportedUsageForModelID`, but returns the UNSCALED auto-compact
+ * trigger point (what a host like Claude Code compacts at) rather than the 0.9×
+ * client-usage reporting cap. An empty/unknown model falls back to the historical
+ * 200K-model value ({@link AUTOCOMPACT_THRESHOLD}), preserving prior behavior.
+ *
+ * Fixes #983: the hardcoded 167K constant assumed a 200K-context model, so the
+ * "avoided compactions" estimate was wrong for other windows — e.g. a 1M-context
+ * model was counted as compacting ~5.8× too often.
+ */
+export function autocompactThresholdForModelID(modelID?: string): number {
+  if (!modelID) return AUTOCOMPACT_THRESHOLD;
+  const entry = getModelEntrySync(modelID);
+  const contextWindow = entry.limit?.context ?? 200_000;
+  const maxOutput = entry.limit?.output ?? MAX_OUTPUT_RESERVE;
+  return autocompactThresholdForModel(contextWindow, maxOutput);
+}
+
+/**
+ * Counterfactual "avoided compactions" for a session that reached
+ * `sessionTokens` uncompressed, given the host's per-model auto-compact
+ * `threshold` and its post-compaction context size. The host compacts once at
+ * `threshold`, then every `(threshold − postCompactionContext)` tokens of
+ * growth thereafter.
+ *
+ * Returns 0 when the model is too small to model meaningfully — i.e.
+ * `threshold ≤ postCompactionContext`, where the stride would be non-positive
+ * and the estimate would run away (#983). This keeps pathologically small
+ * windows conservative (0) rather than emitting an absurd count.
+ */
+export function estimateAvoidedCompactions(
+  sessionTokens: number,
+  threshold: number,
+  postCompactionContext: number,
+): number {
+  if (threshold <= postCompactionContext || sessionTokens <= threshold) {
+    return 0;
+  }
+  const stride = threshold - postCompactionContext;
+  return 1 + Math.floor((sessionTokens - threshold) / stride);
+}
+
+/**
  * Estimate the total cost of a single compaction event.
  *
  * Includes three components:
@@ -834,7 +881,16 @@ export function updateShadowContext(
   costs._lastActualInput = totalInputTokens;
   costs._lastOutputTokens = outputTokens;
 
-  if (costs._shadowContextTokens > AUTOCOMPACT_THRESHOLD) {
+  // Per-model auto-compact trigger (#983). The `> POST_COMPACTION_CONTEXT`
+  // guard skips pathologically small windows (threshold ≤ post-compaction
+  // size), where a shadow compaction would immediately re-trigger every turn —
+  // report 0 for those rather than a runaway count (matches the prior 167K
+  // constant's effective 0 for tiny models, while fixing large-window overcount).
+  const threshold = autocompactThresholdForModelID(conversationModel);
+  if (
+    threshold > POST_COMPACTION_CONTEXT &&
+    costs._shadowContextTokens > threshold
+  ) {
     costs.counterfactual.avoidedCompactions++;
     costs.counterfactual.avoidedCompactionCost += estimateCompactionCost(
       workerModel,
@@ -1141,17 +1197,13 @@ export function computeHistoricalEstimates(
       // This is only a fallback — sessions with persisted snapshots (the common
       // case) use real data from live tracking.
       const sessionTokens = sess.total_tokens;
-      let avoidedCompactions = 0;
-      if (sessionTokens > AUTOCOMPACT_THRESHOLD) {
-        // First compaction at AUTOCOMPACT_THRESHOLD, then every
-        // (AUTOCOMPACT_THRESHOLD - POST_COMPACTION_CONTEXT) tokens thereafter.
-        const stride = AUTOCOMPACT_THRESHOLD - POST_COMPACTION_CONTEXT;
-        avoidedCompactions =
-          1 +
-          Math.floor(
-            (sessionTokens - AUTOCOMPACT_THRESHOLD) / Math.max(stride, 1),
-          );
-      }
+      // Per-model auto-compact threshold (#983): the hardcoded 167K constant
+      // assumed a 200K-context model and over/under-counted for other windows.
+      const avoidedCompactions = estimateAvoidedCompactions(
+        sessionTokens,
+        autocompactThresholdForModelID(model),
+        POST_COMPACTION_CONTEXT,
+      );
 
       const sessionCompactionCost =
         avoidedCompactions * estimateCompactionCost(workerModelID, model);

--- a/packages/gateway/src/cost-tracker.ts
+++ b/packages/gateway/src/cost-tracker.ts
@@ -1199,9 +1199,17 @@ export function computeHistoricalEstimates(
       const sessionTokens = sess.total_tokens;
       // Per-model auto-compact threshold (#983): the hardcoded 167K constant
       // assumed a 200K-context model and over/under-counted for other windows.
+      // Pass the *extracted* model (`m`, null when the session has no usable
+      // metadata) — NOT the pricing-defaulted `model`. `model` falls back to
+      // DEFAULT_ESTIMATION_MODEL (a 1M-window model) purely to price the
+      // compaction cost; adopting its 967K trigger for metadata-less sessions
+      // would silently drop their historical "avoided compactions" ~7×. An
+      // unknown model must keep the historical 167K trigger, matching the live
+      // path (which passes `conversationModel`, undefined when unknown) and the
+      // documented `autocompactThresholdForModelID(undefined)` contract.
       const avoidedCompactions = estimateAvoidedCompactions(
         sessionTokens,
-        autocompactThresholdForModelID(model),
+        autocompactThresholdForModelID(m ?? undefined),
         POST_COMPACTION_CONTEXT,
       );
 

--- a/packages/gateway/test/compaction.test.ts
+++ b/packages/gateway/test/compaction.test.ts
@@ -11,6 +11,8 @@ import {
   COMPACTION_SYSTEM_PATTERNS,
   COMPACTION_USER_PATTERNS,
   maxReportedUsageForModel,
+  autocompactThresholdForModel,
+  AUTOCOMPACT_THRESHOLD,
   DEFAULT_MAX_REPORTED_USAGE,
   scaleUsageForClient,
 } from "../src/compaction";
@@ -873,6 +875,45 @@ describe("maxReportedUsageForModel", () => {
 
   test("never returns negative for tiny windows", () => {
     expect(maxReportedUsageForModel(1_000, 20_000)).toBe(0);
+  });
+});
+
+describe("autocompactThresholdForModel", () => {
+  test("200K model reproduces the historical 167K auto-compact point", () => {
+    // effective = 200_000 - min(64_000, 20_000) = 180_000; − 13_000 = 167_000.
+    expect(autocompactThresholdForModel(200_000, 64_000)).toBe(167_000);
+    // ...and equals the retained fallback constant exactly.
+    expect(autocompactThresholdForModel(200_000, 64_000)).toBe(
+      AUTOCOMPACT_THRESHOLD,
+    );
+  });
+
+  test("1M model triggers far higher than the old 167K constant", () => {
+    // effective = 1_000_000 - 20_000 = 980_000; − 13_000 = 967_000. This is the
+    // #983 fix: a 1M host does NOT auto-compact at 167K.
+    expect(autocompactThresholdForModel(1_000_000, 64_000)).toBe(967_000);
+  });
+
+  test("max-output below the 20K reserve is used as-is", () => {
+    // effective = 1_000_000 - 5_000 = 995_000; − 13_000 = 982_000.
+    expect(autocompactThresholdForModel(1_000_000, 5_000)).toBe(982_000);
+  });
+
+  test("is the unscaled sibling of maxReportedUsageForModel (no 0.9x)", () => {
+    for (const [cw, mo] of [
+      [200_000, 64_000],
+      [1_000_000, 64_000],
+      [400_000, 8_000],
+    ] as const) {
+      expect(maxReportedUsageForModel(cw, mo)).toBe(
+        Math.floor(0.9 * autocompactThresholdForModel(cw, mo)),
+      );
+    }
+  });
+
+  test("floors at 0 for windows too small to compact", () => {
+    // effective = 30_000 - 20_000 = 10_000; − 13_000 = −3_000 → 0.
+    expect(autocompactThresholdForModel(30_000, 20_000)).toBe(0);
   });
 });
 

--- a/packages/gateway/test/cost-tracker-historical.test.ts
+++ b/packages/gateway/test/cost-tracker-historical.test.ts
@@ -159,4 +159,81 @@ describe("computeHistoricalEstimates (session_rollup read path #981)", () => {
     expect(est.totals.sessionCount).toBe(1);
     expect(est.sessions[0].sessionId).toBe("sess-live");
   });
+
+  // --- #983: the batch "avoided compactions" estimate is per-model ---
+  // The counterfactual host compacts once at the model's auto-compact trigger,
+  // then every (trigger − 30K post-compaction) tokens thereafter. A 600K-token
+  // session therefore yields a model-dependent count:
+  //   • 1M-window model  → trigger 967K  → 600K < 967K            ⇒ 0
+  //   • 200K-window model → trigger 178808 → 1 + ⌊421192/148808⌋  ⇒ 3
+  //   • no usable metadata → trigger 167K (AUTOCOMPACT_THRESHOLD) ⇒ 4
+  // The pre-#983 hardcoded 167K constant would have reported 4 for every one.
+
+  test("batch estimate: a 1M-window model under its trigger avoids 0 compactions", () => {
+    const pid = ensureProject("/test/cost-historical/1m", "hist-1m");
+    const sid = "sess-1m";
+    const now = Date.now();
+    // 600K tokens, model = Sonnet 4 (1M window ⇒ 967K trigger).
+    insertMsg(
+      pid,
+      sid,
+      "assistant",
+      600_000,
+      now,
+      JSON.stringify({
+        modelID: "claude-sonnet-4-20250514",
+        providerID: "anthropic",
+      }),
+    );
+
+    const s = computeHistoricalEstimates().sessions.find(
+      (x) => x.sessionId === sid,
+    );
+    expect(s).toBeDefined();
+    // 600K is below the 967K trigger ⇒ the host would not have compacted at
+    // all. The old 167K constant would wrongly report 4. Kills the batch-site
+    // "revert to constant" mutation.
+    expect(s?.avoidedCompactions).toBe(0);
+  });
+
+  test("batch estimate: a 200K-window model over its trigger avoids several", () => {
+    const pid = ensureProject("/test/cost-historical/200k", "hist-200k");
+    const sid = "sess-200k";
+    const now = Date.now();
+    // 600K tokens, model = 3.5 Sonnet (200K window ⇒ 178808 trigger).
+    insertMsg(
+      pid,
+      sid,
+      "assistant",
+      600_000,
+      now,
+      JSON.stringify({
+        modelID: "claude-3-5-sonnet-20241022",
+        providerID: "anthropic",
+      }),
+    );
+
+    const s = computeHistoricalEstimates().sessions.find(
+      (x) => x.sessionId === sid,
+    );
+    expect(s).toBeDefined();
+    expect(s?.avoidedCompactions).toBe(3);
+  });
+
+  test("batch estimate: a session with no usable model metadata keeps the 167K trigger", () => {
+    const pid = ensureProject("/test/cost-historical/nomodel", "hist-nomodel");
+    const sid = "sess-nomodel";
+    const now = Date.now();
+    // 600K tokens, but no extractable model (null metadata). The threshold must
+    // fall back to AUTOCOMPACT_THRESHOLD (167K) — NOT the pricing-default
+    // DEFAULT_ESTIMATION_MODEL (a 1M-window model), which would drop the count
+    // to 0 and shift historical dashboards ~7× for untracked sessions.
+    insertMsg(pid, sid, "assistant", 600_000, now, null);
+
+    const s = computeHistoricalEstimates().sessions.find(
+      (x) => x.sessionId === sid,
+    );
+    expect(s).toBeDefined();
+    expect(s?.avoidedCompactions).toBe(4);
+  });
 });

--- a/packages/gateway/test/cost-tracker-per-model-compaction.test.ts
+++ b/packages/gateway/test/cost-tracker-per-model-compaction.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { AUTOCOMPACT_THRESHOLD } from "../src/compaction";
+import {
+  autocompactThresholdForModelID,
+  clearAllCosts,
+  estimateAvoidedCompactions,
+  getSessionCosts,
+  recordConversationCost,
+  resetDailyBudgetState,
+  updateShadowContext,
+} from "../src/cost-tracker";
+
+const WORKER = "__test_worker_model__";
+const PRICING_MODEL = "__test_fake_model__";
+const USAGE = {
+  input_tokens: 1,
+  output_tokens: 1,
+  cache_read_input_tokens: 0,
+  cache_creation_input_tokens: 0,
+};
+const POST_COMPACTION_CONTEXT = 30_000;
+
+beforeEach(() => {
+  clearAllCosts();
+  resetDailyBudgetState();
+});
+
+describe("estimateAvoidedCompactions (#983)", () => {
+  test("counts one compaction at the threshold, then one per stride", () => {
+    // 200K host: threshold 167K, stride 167K − 30K = 137K.
+    expect(
+      estimateAvoidedCompactions(167_000, 167_000, POST_COMPACTION_CONTEXT),
+    ).toBe(0);
+    expect(
+      estimateAvoidedCompactions(167_001, 167_000, POST_COMPACTION_CONTEXT),
+    ).toBe(1);
+    // 600K → 1 + floor((600K−167K)/137K) = 1 + 3 = 4.
+    expect(
+      estimateAvoidedCompactions(600_000, 167_000, POST_COMPACTION_CONTEXT),
+    ).toBe(4);
+  });
+
+  test("a 1M host at 600K tokens has not compacted yet", () => {
+    expect(
+      estimateAvoidedCompactions(600_000, 967_000, POST_COMPACTION_CONTEXT),
+    ).toBe(0);
+  });
+
+  test("windows too small to compact are guarded to 0 (no runaway)", () => {
+    // threshold ≤ post-compaction size ⇒ non-positive stride ⇒ 0, even for a
+    // huge token count. Without the guard the old formula would emit an absurd
+    // count here.
+    expect(
+      estimateAvoidedCompactions(5_000_000, 30_000, POST_COMPACTION_CONTEXT),
+    ).toBe(0);
+    expect(
+      estimateAvoidedCompactions(5_000_000, 7_000, POST_COMPACTION_CONTEXT),
+    ).toBe(0);
+  });
+});
+
+describe("autocompactThresholdForModelID (#983)", () => {
+  test("empty / missing model falls back to the historical 200K value", () => {
+    expect(autocompactThresholdForModelID(undefined)).toBe(
+      AUTOCOMPACT_THRESHOLD,
+    );
+    expect(autocompactThresholdForModelID("")).toBe(AUTOCOMPACT_THRESHOLD);
+    expect(AUTOCOMPACT_THRESHOLD).toBe(167_000);
+  });
+
+  test("a 1M-context model resolves to its own (much higher) trigger point", () => {
+    // claude-opus-4* fallback: context 1M, output 128K (capped at 20K reserve).
+    expect(autocompactThresholdForModelID("claude-opus-4-6")).toBe(967_000);
+  });
+
+  test("an unknown named model uses the 200K/8K fallback limits", () => {
+    // fallback entry: context 200K, output 8_192 → 200K − 8_192 − 13K.
+    expect(autocompactThresholdForModelID("totally-unknown-xyz")).toBe(178_808);
+  });
+});
+
+describe("updateShadowContext uses the per-model threshold (#983)", () => {
+  // Drive a session to ~600K uncompressed shadow tokens over two turns, then
+  // read the counterfactual compaction count. 600K sits between the 200K-model
+  // trigger (167K) and the 1M-model trigger (967K), so the model identity flips
+  // the outcome — proving the threshold is actually per-model, not hardcoded.
+  function driveTo600K(sessionID: string, conversationModel?: string): void {
+    recordConversationCost(sessionID, PRICING_MODEL, USAGE); // turns → 1
+    updateShadowContext(sessionID, 100_000, 500_000, WORKER, conversationModel);
+    recordConversationCost(sessionID, PRICING_MODEL, USAGE); // turns → 2
+    updateShadowContext(sessionID, 120_000, 10_000, WORKER, conversationModel);
+  }
+
+  test("a 200K-class (default) model counts a shadow compaction at 600K", () => {
+    driveTo600K("s-default", undefined);
+    expect(
+      getSessionCosts("s-default")?.counterfactual.avoidedCompactions,
+    ).toBe(1);
+  });
+
+  test("a 1M-context model has NOT compacted at 600K", () => {
+    driveTo600K("s-opus", "claude-opus-4-6");
+    // The old hardcoded 167K constant would have wrongly counted 1 here.
+    expect(getSessionCosts("s-opus")?.counterfactual.avoidedCompactions).toBe(
+      0,
+    );
+  });
+});


### PR DESCRIPTION
## What

The cost-tracker's counterfactual **"avoided compactions"** dashboard estimate hardcoded `AUTOCOMPACT_THRESHOLD = 167_000` (`compaction.ts`), which bakes in a **200K-context model** assumption. This makes the estimate per-model where it wasn't before.

## Why

For models whose real context window ≠ 200K the counterfactual was wrong:
- A **1M-context** model (e.g. Opus) was counted as auto-compacting at 167K when its real trigger is ~**967K** — roughly **5.8× too many** avoided compactions.
- Small-context local models were mis-estimated the other way.

The per-model formula already existed for the *real* usage cap (`maxReportedUsageForModel`); only the cost-tracker counterfactual still used the constant. The TODO at `compaction.ts` called this out directly.

## Change

- **`compaction.ts`** — new `autocompactThresholdForModel(contextWindow, maxOutput)`: the **unscaled** auto-compact trigger (`effective − 13k`), i.e. the sibling of `maxReportedUsageForModel` *without* the `0.9×` reporting scale (the counterfactual models the host's compaction trigger, not the client-usage cap). For a 200K model it returns `167_000` — exactly the retained `AUTOCOMPACT_THRESHOLD` fallback.
- **`cost-tracker.ts`** — resolve the threshold from the session's model at **both** counterfactual sites (the live shadow-context trigger in `updateShadowContext`, and the batch historical estimate), mirroring pipeline.ts's `maxReportedUsageForModelID`.
  - **Threshold fallback semantics** (`autocompactThresholdForModelID`): a session with **no usable model metadata** falls back to exactly `AUTOCOMPACT_THRESHOLD` (167K), preserving prior behavior; a recognized model uses its real per-model trigger; a model string that isn't in models.dev resolves to the 200K-window fallback (178808).
- **Guard** — new `estimateAvoidedCompactions()` helper returns 0 for pathologically small windows (`threshold ≤ post-compaction size`, where the stride would be non-positive), so a tiny model can't emit a runaway count.

**Blast radius:** the cost dashboard's "avoided compactions" counterfactual only — no request/compression/compaction path is touched.

## Review follow-up (commit `fcb08821`)

Adversarial re-review found the **batch historical** site defeated the 167K fallback: it passed the *pricing-defaulted* `model` (which falls back to `DEFAULT_ESTIMATION_MODEL`, a **1M-window** model) into the threshold, so metadata-less sessions silently adopted a 967K trigger and their historical "avoided compactions" dropped **~7×** — contradicting the stated fallback. Fixed by passing the **extracted** model (`undefined` when unknown), so unknown-model sessions keep the 167K trigger — consistent with the live path (which passes `conversationModel`, undefined when unknown). This batch conversion was previously **untested** (a "revert to constant" mutation survived); it now has dedicated regression coverage.

## Tests

- `compaction.test.ts` — `autocompactThresholdForModelID`: 200K→167K (== `AUTOCOMPACT_THRESHOLD`), 1M→967K, sub-reserve max-output, the `floor(0.9×)` relationship to `maxReportedUsageForModel`, tiny-window floor at 0.
- `cost-tracker-per-model-compaction.test.ts` — `estimateAvoidedCompactions` (threshold/stride/guard), `autocompactThresholdForModelID` (opus 1M / empty / unknown-fallback), and an integration test: a 600K-token session counts a shadow compaction on a 200K model but **not** on a 1M model (the old constant would wrongly count it).
- `cost-tracker-historical.test.ts` — **new** batch-site regression tests: a 600K-token session avoids **0** compactions on a 1M model, **3** on a 200K model, and **4** with no usable metadata (167K fallback). Mutation-verified: reverting the fallback fix kills the no-metadata test; reverting the batch site to the constant kills the 1M **and** 200K tests.
- Mutation-verified (site 1 / guard / 13k buffer) as before; full gateway suite green.

Closes #983.
