### PR TITLE
fix(gateway): reconstruct zai worker path under /v4 instead of doubling /v1 (#1093)

### DIFF
--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -494,13 +494,15 @@ export type ProviderRoute = {
  * header, this table is consulted BEFORE the model-prefix UPSTREAM_ROUTES.
  *
  * URLs must NOT include `/v1` — the gateway appends `/v1/messages`,
- * `/v1/chat/completions`, or `/v1/responses` itself. The exception is providers
- * whose Chat Completions API is served at a non-`/v1` path (GitHub Copilot at
- * `/chat/completions`, issue #1052; Google Gemini's OpenAI layer at
- * `/v1beta/openai/chat/completions`, issue #1070): foreground requests forward
- * verbatim to the client's original endpoint (see `verbatimUpstreamUrl`), and
- * reconstructed paths (background workers) are handled host-aware by
- * `buildOpenAIChatCompletionsUrl` in `translate/openai.ts`.
+ * `/v1/chat/completions`, or `/v1/responses` itself. There are exceptions whose
+ * Chat Completions API is served at a non-`/v1` path: GitHub Copilot at
+ * `/chat/completions` (issue #1052) and Google Gemini's OpenAI layer at
+ * `/v1beta/openai/chat/completions` (issue #1070), both keyed by host; and
+ * providers whose user-supplied base already carries a version segment (Z.AI's
+ * `.../api/paas/v4`, issue #1093), detected by the base pathname. In every case
+ * foreground requests forward verbatim to the client's original endpoint (see
+ * `verbatimUpstreamUrl`), and reconstructed paths (background workers) are
+ * handled by `buildOpenAIChatCompletionsUrl` in `translate/openai.ts`.
  *
  * Data sourced from models.dev provider database (https://models.dev/providers).
  * Protocol derived from the provider's SDK package: `@ai-sdk/anthropic` →
@@ -542,7 +544,12 @@ const PROVIDER_ROUTES: Record<string, ProviderRoute> = {
     url: "https://router.huggingface.co",
     protocol: "openai",
   },
-  zai: { url: null, protocol: "openai" }, // uses /v4 path — user sets LORE_UPSTREAM_ZAI
+  // Z.AI serves OpenAI-compat chat completions under `/v4` (not `/v1`). The user
+  // sets LORE_UPSTREAM_ZAI to Z.AI's documented base (e.g.
+  // `https://api.z.ai/api/paas/v4`), which already carries the `/v4` version
+  // segment; `buildOpenAIChatCompletionsUrl` appends only `/chat/completions`
+  // for a version-suffixed base so the worker path lands on `/v4/...` (#1093).
+  zai: { url: null, protocol: "openai" },
   "vercel-ai-gateway": { url: null, protocol: null },
   // --- OpenAI Responses protocol ---
   openai: {

--- a/packages/gateway/src/translate/openai.ts
+++ b/packages/gateway/src/translate/openai.ts
@@ -510,20 +510,40 @@ const OPENAI_HOST_CHAT_COMPLETIONS_PATHS: ReadonlyMap<string, string> = new Map(
  * Build the OpenAI Chat Completions upstream URL for an upstream base.
  *
  * Most OpenAI-compatible providers serve at `<base>/v1/chat/completions`, so the
- * route tables store a bare origin and the gateway appends `/v1/...`. Hosts in
- * `OPENAI_HOST_CHAT_COMPLETIONS_PATHS` use a different endpoint path (e.g. no
- * `/v1` segment, or a `/v1beta/openai/...` prefix). Falls back to the default
- * `/v1` form when `base` cannot be parsed as a URL.
+ * route tables store a bare origin and the gateway appends `/v1/...`. Two
+ * exceptions are handled, in priority order:
+ *
+ *  1. Hosts in `OPENAI_HOST_CHAT_COMPLETIONS_PATHS` use a fixed non-`/v1`
+ *     endpoint path (GitHub Copilot's `/chat/completions`, issue #1052; Google's
+ *     `/v1beta/openai/...`, issue #1070). These hosts' route bases are bare
+ *     origins, so the mapped path is simply appended.
+ *  2. A base whose pathname already ends in a version segment (e.g. Z.AI's
+ *     user-configured `.../api/paas/v4`, issue #1093) serves Chat Completions at
+ *     `<base>/chat/completions`; appending the default `/v1` would duplicate the
+ *     version (`.../v4/v1/chat/completions`) and 404. Such bases come from
+ *     user-supplied `LORE_UPSTREAM_<PROVIDER>` values (`url: null` routes) where
+ *     the host cannot be keyed in the static map above. Appending only
+ *     `/chat/completions` is also a no-op harmless normalization for a base that
+ *     already carries `/v1`.
+ *
+ * Falls back to the default `/v1` form when `base` cannot be parsed as a URL.
  */
 export function buildOpenAIChatCompletionsUrl(base: string): string {
-  let path = DEFAULT_OPENAI_CHAT_COMPLETIONS_PATH;
   try {
-    const hostname = new URL(base).hostname;
-    path = OPENAI_HOST_CHAT_COMPLETIONS_PATHS.get(hostname) ?? path;
+    const { hostname, pathname } = new URL(base);
+    const hostPath = OPENAI_HOST_CHAT_COMPLETIONS_PATHS.get(hostname);
+    if (hostPath !== undefined) {
+      return `${base}${hostPath}`;
+    }
+    // Base already ends in a version segment (`/v4`, `/v1`, …) → the API path is
+    // just `/chat/completions`; a `/v1` prefix would double the version.
+    if (/\/v\d+$/.test(pathname)) {
+      return `${base}/chat/completions`;
+    }
   } catch {
     // Unparseable base (e.g. a bare placeholder) — keep the default `/v1` path.
   }
-  return `${base}${path}`;
+  return `${base}${DEFAULT_OPENAI_CHAT_COMPLETIONS_PATH}`;
 }
 
 export function buildOpenAIUpstreamRequest(

--- a/packages/gateway/test/github-copilot-url.test.ts
+++ b/packages/gateway/test/github-copilot-url.test.ts
@@ -209,6 +209,36 @@ describe("buildOpenAIChatCompletionsUrl", () => {
     );
   });
 
+  test("version-suffixed base appends only /chat/completions — Z.AI (issue #1093)", () => {
+    // The user-supplied LORE_UPSTREAM_ZAI already carries the `/v4` version, so a
+    // `/v1` prefix would double it (`.../v4/v1/chat/completions`) and 404.
+    expect(buildOpenAIChatCompletionsUrl("https://api.z.ai/api/paas/v4")).toBe(
+      "https://api.z.ai/api/paas/v4/chat/completions",
+    );
+  });
+
+  test("version-suffixed base — Z.AI coding-plan prefix (issue #1093)", () => {
+    expect(
+      buildOpenAIChatCompletionsUrl("https://api.z.ai/api/coding/paas/v4"),
+    ).toBe("https://api.z.ai/api/coding/paas/v4/chat/completions");
+  });
+
+  test("base already ending in /v1 is not doubled", () => {
+    // A self-hosted server configured with an explicit `/v1` root: appending
+    // only `/chat/completions` yields the correct single-`/v1` URL.
+    expect(buildOpenAIChatCompletionsUrl("http://localhost:8000/v1")).toBe(
+      "http://localhost:8000/v1/chat/completions",
+    );
+  });
+
+  test("non-numeric version-like suffix does NOT trigger the rule", () => {
+    // `/v1beta` is not a bare `/vN` segment (regex boundary guard): a host not in
+    // the static map falls back to the conventional `/v1/chat/completions`.
+    expect(buildOpenAIChatCompletionsUrl("https://example.com/v1beta")).toBe(
+      "https://example.com/v1beta/v1/chat/completions",
+    );
+  });
+
   test("falls back to the /v1 form when the base is not a URL", () => {
     expect(buildOpenAIChatCompletionsUrl("not a url")).toBe(
       "not a url/v1/chat/completions",
@@ -247,5 +277,11 @@ describe("buildOpenAIUpstreamRequest — reconstructed URL is host-aware", () =>
     expect(
       buildOpenAIUpstreamRequest(makeReq(), "https://api.openai.com").url,
     ).toBe("https://api.openai.com/v1/chat/completions");
+  });
+
+  test("Z.AI versioned base → /v4/chat/completions (issue #1093)", () => {
+    expect(
+      buildOpenAIUpstreamRequest(makeReq(), "https://api.z.ai/api/paas/v4").url,
+    ).toBe("https://api.z.ai/api/paas/v4/chat/completions");
   });
 });

--- a/packages/gateway/test/worker-zai-openai-path.test.ts
+++ b/packages/gateway/test/worker-zai-openai-path.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Issue #1093 — background worker requests routed to the `zai` provider must
+ * target Z.AI's OpenAI-compat endpoint under its `/v4` version segment, NOT the
+ * conventional `/v1/chat/completions`. `zai` has `url: null` (host is
+ * user-supplied via LORE_UPSTREAM_ZAI, injected as the session's
+ * `x-lore-upstream-url`), so the worker resolves its target from the session
+ * override. Since the base already carries `/api/paas/v4`, prepending `/v1`
+ * would produce `.../v4/v1/chat/completions` and 404. Workers build prompts from
+ * scratch (no original request to forward verbatim), so the URL is reconstructed
+ * by `buildOpenAIChatCompletionsUrl`, which appends only `/chat/completions` for
+ * a version-suffixed base.
+ */
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("../src/fetch", () => ({ upstreamFetch: vi.fn() }));
+
+import { createGatewayLLMClient } from "../src/llm-adapter";
+import { upstreamFetch } from "../src/fetch";
+import { clearAllCosts } from "../src/cost-tracker";
+import { resetBackgroundLimiter } from "../src/background-limiter";
+
+const mockFetch = vi.mocked(upstreamFetch);
+
+const UPSTREAMS = {
+  anthropic: "https://api.anthropic.com",
+  openai: "https://api.openai.com",
+};
+
+const ZAI_BASE = "https://api.z.ai/api/paas/v4";
+
+function okResponse() {
+  return new Response(
+    JSON.stringify({
+      choices: [{ message: { content: "ok" } }],
+      model: "m",
+      usage: { prompt_tokens: 1, completion_tokens: 1 },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+describe("worker zai URL (#1093)", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue(okResponse());
+  });
+  afterEach(() => {
+    mockFetch.mockReset();
+    clearAllCosts();
+    resetBackgroundLimiter();
+  });
+
+  test("forwards to the /v4 base + /chat/completions, not a doubled /v1", async () => {
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      (_sid, providerID) =>
+        providerID === "zai" ? { scheme: "bearer", value: "zai_worker" } : null,
+      { providerID: "zai", modelID: "glm-4.6" },
+    );
+
+    await client.prompt("system", "user", {
+      sessionID: "sess-zai",
+      workerID: "lore-distill",
+      model: { providerID: "zai", modelID: "glm-4.6" },
+      // The session override carries the user's LORE_UPSTREAM_ZAI base.
+      upstreamUrl: ZAI_BASE,
+      upstreamProviderID: "zai",
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const url = String(mockFetch.mock.calls[0][0]);
+    expect(url).toBe(`${ZAI_BASE}/chat/completions`);
+    expect(url).not.toContain("/v4/v1/chat/completions");
+  });
+
+  test("tolerates a trailing slash on the configured base", async () => {
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      (_sid, providerID) =>
+        providerID === "zai" ? { scheme: "bearer", value: "zai_worker" } : null,
+      { providerID: "zai", modelID: "glm-4.6" },
+    );
+
+    await client.prompt("system", "user", {
+      sessionID: "sess-zai-slash",
+      workerID: "lore-distill",
+      model: { providerID: "zai", modelID: "glm-4.6" },
+      upstreamUrl: `${ZAI_BASE}/`,
+      upstreamProviderID: "zai",
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const url = String(mockFetch.mock.calls[0][0]);
+    expect(url).toBe(`${ZAI_BASE}/chat/completions`);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1093. Background-worker (and provider-header-only) requests to the `zai` provider reconstructed the upstream URL as `<base>/v1/chat/completions`. Z.AI's OpenAI-compat endpoint serves chat completions under its `/v4` version segment, and the user-supplied `LORE_UPSTREAM_ZAI` base already carries that segment (e.g. `https://api.z.ai/api/paas/v4`), so the `/v1` prefix produced `.../v4/v1/chat/completions` and **404**'d.

- **Foreground turns were unaffected** — the fetch interceptor preserves the real path and the gateway forwards it verbatim (`verbatimUpstreamUrl`). Only the **reconstruction** paths (background workers such as distillation/curation/warmer, and provider-header-only routing), which have no original request to forward, were broken.
- This is a **pre-existing gap**, not introduced by #1052 (GitHub Copilot) or #1070 (Google Gemini).

## Why not the host-map approach

`zai` is `{ url: null }` (`config.ts`) — its host is **user-supplied** via `LORE_UPSTREAM_ZAI`, so there is no fixed hostname to key an entry in `OPENAI_HOST_CHAT_COMPLETIONS_PATHS` (that map appends to a *bare origin*; zai's base carries a `/api/paas/v4` prefix, which a host-keyed append would double).

## Fix

`buildOpenAIChatCompletionsUrl` (`translate/openai.ts`) now, in priority order:

1. Uses a host-map override if the host matches (Copilot / Google) — unchanged.
2. **New:** if the base pathname already ends in a bare version segment (`/vN`, e.g. `/v4`), appends only `/chat/completions` instead of `/v1/chat/completions`.
3. Otherwise appends the conventional `/v1/chat/completions`.

Appending only `/chat/completions` to a `/vN` base is also a harmless no-op normalization for a base already carrying `/v1` (prevents an accidental `/v1/v1/...` double).

## Tests

- `github-copilot-url.test.ts`: added Z.AI versioned-base cases (`/api/paas/v4` and coding-plan `/api/coding/paas/v4`), a `/v1`-not-doubled case, and a `/v1beta` boundary guard (non-numeric suffix must NOT trigger the rule). Existing groq `/openai`-prefix and Copilot/Google host-map tests still pass (no regression).
- `worker-zai-openai-path.test.ts` (new): end-to-end worker guard through `createGatewayLLMClient` — a zai worker call lands on `.../paas/v4/chat/completions`, never `.../v4/v1/chat/completions`, including a trailing-slash base.

**Red-phase verified:** reverting the version-suffix branch fails 6 tests, each `Received` being the exact buggy `.../v4/v1/chat/completions` 404 URL.

Full gateway suite: 2405 passed / 30 skipped. Typecheck + Biome clean.