### PR TITLE
fix(core): skip stale-dimension blobs during vec0 cutover instead of aborting

### DIFF
--- a/packages/core/src/db/vec-store.ts
+++ b/packages/core/src/db/vec-store.ts
@@ -440,6 +440,7 @@ export function embeddingColumnExists(
 export function copyBlobsToVec0(
   conn: EmbeddingWriteConn,
   table: EmbeddingTable,
+  dim: number,
 ): void {
   // vec0 (our pinned sqlite-vec) has no `INSERT OR REPLACE`, so idempotence /
   // resumability comes from skipping ids already present in the vec0 table via
@@ -447,32 +448,48 @@ export function copyBlobsToVec0(
   // is empty so every eligible row copies; a re-run after a partial copy only
   // inserts the remainder. Embeddings are static during the one-time cutover, so
   // skipping an already-copied id (rather than replacing it) is equivalent.
+  //
+  // 🔴 Dimension guard (`length(embedding) = dim * 4`): a correctly-dimensioned
+  // embedding is exactly `dim * 4` bytes (Float32 = 4 bytes/element). A legacy
+  // blob written under a DIFFERENT embedding dimension (e.g. a short-lived
+  // 384-dim window among today's 768-dim rows) would make sqlite-vec's
+  // fixed-width vec0 INSERT throw "Expected N dimensions but received M" — and
+  // because the copy is one bulk `INSERT … SELECT`, a SINGLE stale row aborts the
+  // ENTIRE cutover, stranding the DB in blob mode on every subsequent startup.
+  // Skip stale-dim blobs here instead: the row is simply absent from vec0 after
+  // the copy, and the very next re-embed backfill in the same startup pass
+  // regenerates it at the correct dimension from its source text
+  // (knowledge/entities/distillations via `missingEmbeddingSql` = NOT IN <vec
+  // table>; temporal via the full re-chunk walk in backfillTemporalEmbeddings).
+  // Net effect: the stale vector is removed and recreated — one bad row can never
+  // brick the migration for the whole corpus.
+  const expectedBytes = dim * 4;
   switch (table) {
     case "knowledge":
       conn
         .query(
-          "INSERT INTO knowledge_vec(id, embedding) SELECT id, embedding FROM knowledge_current WHERE embedding IS NOT NULL AND id NOT IN (SELECT id FROM knowledge_vec)",
+          `INSERT INTO knowledge_vec(id, embedding) SELECT id, embedding FROM knowledge_current WHERE embedding IS NOT NULL AND length(embedding) = ${expectedBytes} AND id NOT IN (SELECT id FROM knowledge_vec)`,
         )
         .run();
       return;
     case "entities":
       conn
         .query(
-          "INSERT INTO entity_vec(id, embedding) SELECT id, embedding FROM entities WHERE embedding IS NOT NULL AND id NOT IN (SELECT id FROM entity_vec)",
+          `INSERT INTO entity_vec(id, embedding) SELECT id, embedding FROM entities WHERE embedding IS NOT NULL AND length(embedding) = ${expectedBytes} AND id NOT IN (SELECT id FROM entity_vec)`,
         )
         .run();
       return;
     case "distillations":
       conn
         .query(
-          "INSERT INTO distillation_vec(id, project_id, session_id, embedding) SELECT id, project_id, session_id, embedding FROM distillations WHERE embedding IS NOT NULL AND id NOT IN (SELECT id FROM distillation_vec)",
+          `INSERT INTO distillation_vec(id, project_id, session_id, embedding) SELECT id, project_id, session_id, embedding FROM distillations WHERE embedding IS NOT NULL AND length(embedding) = ${expectedBytes} AND id NOT IN (SELECT id FROM distillation_vec)`,
         )
         .run();
       return;
     case "temporal":
       conn
         .query(
-          "INSERT INTO temporal_vec(chunk_id, message_id, project_id, session_id, embedding) SELECT id || '#0', id, project_id, session_id, embedding FROM temporal_messages WHERE embedding IS NOT NULL AND (id || '#0') NOT IN (SELECT chunk_id FROM temporal_vec)",
+          `INSERT INTO temporal_vec(chunk_id, message_id, project_id, session_id, embedding) SELECT id || '#0', id, project_id, session_id, embedding FROM temporal_messages WHERE embedding IS NOT NULL AND length(embedding) = ${expectedBytes} AND (id || '#0') NOT IN (SELECT chunk_id FROM temporal_vec)`,
         )
         .run();
       return;

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -1763,7 +1763,7 @@ export function maybeCutoverToVec0(): void {
     // still exist; no blob-mode query can ever read a half-dropped column (the
     // v55 boot-loop hazard).
     for (const table of EMBEDDING_TABLES) {
-      if (embeddingColumnExists(db(), table)) copyBlobsToVec0(db(), table);
+      if (embeddingColumnExists(db(), table)) copyBlobsToVec0(db(), table, dim);
     }
     // Flip once vec0 is fully populated and authoritative.
     setStorageMode(db(), "vec0");

--- a/packages/core/test/vec0-cutover.test.ts
+++ b/packages/core/test/vec0-cutover.test.ts
@@ -411,7 +411,8 @@ describeVec("blob → vec0 cutover", () => {
     if (readStorageMode(db()) === "blob") {
       ensureVec0Store(db(), DIM);
       for (const table of TABLES) {
-        if (embeddingColumnExists(db(), table)) copyBlobsToVec0(db(), table);
+        if (embeddingColumnExists(db(), table))
+          copyBlobsToVec0(db(), table, DIM);
       }
       setStorageMode(db(), "vec0");
     }
@@ -460,8 +461,8 @@ describeVec("blob → vec0 cutover", () => {
   test("is idempotent / resumable (re-running copy never duplicates)", () => {
     seedBlobs();
     ensureVec0Store(db(), DIM);
-    copyBlobsToVec0(db(), "knowledge");
-    copyBlobsToVec0(db(), "knowledge"); // re-run (crash-resume)
+    copyBlobsToVec0(db(), "knowledge", DIM);
+    copyBlobsToVec0(db(), "knowledge", DIM); // re-run (crash-resume)
     expect(
       (
         db().query("SELECT COUNT(*) n FROM knowledge_vec").get() as {
@@ -494,6 +495,112 @@ describeVec("blob → vec0 cutover", () => {
       .query("SELECT COUNT(*) n FROM knowledge_vec WHERE id = 'k1'")
       .get() as { n: number };
     expect(oldVec.n).toBe(0);
+  });
+
+  test("skips a stale-dimension blob instead of aborting the whole cutover", () => {
+    // Valid DIM-dim blobs for k1 / d1 / t1.
+    seedBlobs();
+    // A temporal row whose blob was written under a DIFFERENT embedding
+    // dimension: 2 floats = 8 bytes, vs DIM*4 = 16. Before the guard, the single
+    // bulk `INSERT … SELECT` fed this into a fixed-width `float[DIM]` vec0 column,
+    // which sqlite-vec rejects ("Expected 4 dimensions but received 2"), aborting
+    // the ENTIRE cutover and stranding the DB in blob mode on every startup.
+    insTemporal("t_stale", "s", 2000);
+    db()
+      .query("UPDATE temporal_messages SET embedding = ? WHERE id='t_stale'")
+      .run(toBlob(new Float32Array([0.6, 0.8])));
+
+    // One bad row must not brick the migration for the whole corpus.
+    expect(() => runCutover()).not.toThrow();
+    expect(readStorageMode(db())).toBe("vec0");
+
+    // The valid-dim temporal row relocated; the stale-dim row was skipped.
+    const tids = (
+      db()
+        .query("SELECT message_id FROM temporal_vec ORDER BY message_id")
+        .all() as { message_id: string }[]
+    ).map((r) => r.message_id);
+    expect(tids).toEqual(["t1"]);
+    // Valid-dim blobs on the other tables still migrated normally.
+    expect(
+      (
+        db().query("SELECT COUNT(*) n FROM knowledge_vec").get() as {
+          n: number;
+        }
+      ).n,
+    ).toBe(1);
+    expect(
+      (
+        db().query("SELECT COUNT(*) n FROM distillation_vec").get() as {
+          n: number;
+        }
+      ).n,
+    ).toBe(1);
+  });
+
+  test("a skipped stale-dimension row is removed and then recreated by the re-embed backfill", async () => {
+    // The stale-dim row carries real content (>= 50 chars) so the full-corpus
+    // re-chunk backfill will re-embed it. The whole point: its wrong-dim vector
+    // is REMOVED by the cutover (skipped from the copy, base column dropped) and
+    // REGENERATED at the correct dimension from its source text.
+    const content =
+      "The parser regression needs a completely fresh embedding vector here.";
+    expect(content.length).toBeGreaterThanOrEqual(50);
+    db()
+      .query(
+        "INSERT INTO temporal_messages (id, project_id, session_id, role, content, tokens, distilled, created_at) VALUES ('t_stale', ?, 's', 'user', ?, 0, 0, 3000)",
+      )
+      .run(pid, content);
+    db()
+      .query("UPDATE temporal_messages SET embedding = ? WHERE id='t_stale'")
+      .run(toBlob(new Float32Array([0.6, 0.8]))); // wrong dim → skipped
+
+    runCutover();
+    expect(readStorageMode(db())).toBe("vec0");
+    // Removed: the stale-dim vector did not survive the copy.
+    expect(
+      (
+        db()
+          .query(
+            "SELECT COUNT(*) n FROM temporal_vec WHERE message_id='t_stale'",
+          )
+          .get() as { n: number }
+      ).n,
+    ).toBe(0);
+
+    // Recreated: backfillTemporalEmbeddings walks the full corpus and rebuilds
+    // the row's vectors from `content`. Clear the walk's KV flags so it is
+    // un-armed, then run it under a deterministic DIM-length mock provider.
+    db()
+      .query("DELETE FROM kv_meta WHERE key IN (?, ?, ?)")
+      .run(
+        "lore:temporal_rechunk.done",
+        "lore:temporal_rechunk.cursor",
+        "lore:temporal_rechunk.attempts",
+      );
+    const token = _saveAndClearProvider();
+    try {
+      _restoreProvider({
+        provider: {
+          maxBatchSize: 8,
+          async embed(texts: string[]) {
+            return texts.map(() => v(1, 0, 0, 0));
+          },
+        },
+      });
+      expect(await backfillTemporalEmbeddings()).toBe(1);
+    } finally {
+      _restoreProvider(token);
+    }
+
+    // The row now has a correctly-dimensioned vec0 chunk (DIM*4 bytes).
+    const rows = db()
+      .query(
+        "SELECT length(embedding) AS n FROM temporal_vec WHERE message_id='t_stale'",
+      )
+      .all() as { n: number }[];
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+    expect(rows.every((r) => r.n === DIM * 4)).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Problem

The blob → vec0 cutover (`maybeCutoverToVec0` → `copyBlobsToVec0`) relocates each table's embeddings into fixed-width `float[dim]` vec0 columns via a single bulk `INSERT … SELECT`.

If **any** legacy base `embedding` blob was written under a *different* embedding dimension than today's config (e.g. a short-lived 384-dim window among 768-dim rows), sqlite-vec rejects that insert:

```
Error: in prepare, ... Dimension mismatch for inserted vector for the "embedding" column. Expected 768 dimensions but received 384.
```

Because the copy is one bulk statement, a **single** stale row aborts the **entire** cutover. The DB stays in blob mode and retries the same failing copy on every startup — the migration is permanently bricked for the whole corpus, and vec0 search never comes online. (Observed on a real machine: a handful of stale-dim `temporal_messages` blobs among ~220K good rows.)

## Fix

Add a dimension guard — `length(embedding) = dim * 4` (Float32 = 4 bytes/element) — to every copy `SELECT` so stale-dimension blobs are **skipped** rather than fed to vec0.

A skipped row is simply absent from vec0 after the copy. The very next re-embed backfill in the **same** `runStartupBackfill` pass regenerates it at the correct dimension from its source text:
- knowledge / entities / distillations → their backfills embed rows where `missingEmbeddingSql` = `id NOT IN (SELECT … FROM <vec table>)`
- temporal → the full re-chunk walk in `backfillTemporalEmbeddings` (walks the whole corpus)

**Net effect: the stale vector is removed (skipped from the copy, base column dropped) and recreated at the correct dimension.** One bad row can never block the migration.

## Tests

Both new tests are **mutation-verified** — reverting the guard makes them fail with the real `Dimension mismatch … Expected 4 dimensions but received 2` error:

1. **skips a stale-dimension blob instead of aborting the whole cutover** — a 2-float (8-byte) temporal blob among valid `float[4]` rows; cutover no longer throws, flips to vec0, migrates the valid rows on every table, and the stale row is absent from `temporal_vec`.
2. **a skipped stale-dimension row is removed and then recreated by the re-embed backfill** — after cutover the stale row is gone from vec0; `backfillTemporalEmbeddings` (under a mock provider) regenerates it as a correctly-dimensioned (`DIM*4`-byte) chunk.

Full `@loreai/core` suite green (106 files, 2352 passed). `copyBlobsToVec0` now takes a `dim` argument; the one production caller and the test harness are updated.