### PR TITLE
fix(gateway): surface real batch item errors instead of 'error: undefined'

### DIFF
--- a/packages/gateway/src/batch-queue.ts
+++ b/packages/gateway/src/batch-queue.ts
@@ -178,6 +178,37 @@ function groupKey(cred: AuthCredential, providerID: string): string {
   return `${authFingerprint(cred)}|${providerID}`;
 }
 
+/**
+ * Extract a human-readable error string from an Anthropic batch errored result.
+ *
+ * Anthropic's `MessageBatchErroredResult.error` is an `ErrorResponse` envelope:
+ * `{ type: "error", request_id, error: { type, message } }`. The real cause is
+ * the nested `error.error` object; the envelope's own `type` is always the
+ * literal "error" and it carries no `message`. Reading the envelope directly is
+ * what produced the unhelpful `error: undefined` log lines.
+ *
+ * Falls back to a flattened `{ type, message }` shape (some proxies flatten the
+ * envelope) and finally to the outcome string, so the result is never
+ * `undefined`.
+ */
+export function extractAnthropicError(
+  error:
+    | {
+        type?: string;
+        request_id?: string | null;
+        error?: { type?: string; message?: string };
+        message?: string;
+      }
+    | undefined,
+  fallbackOutcome: string,
+): string {
+  const inner = error?.error;
+  if (inner?.message) return `${inner.type ?? "error"}: ${inner.message}`;
+  // Tolerate a flattened envelope where the message sits at the top level.
+  if (error?.message) return `${error.type ?? "error"}: ${error.message}`;
+  return fallbackOutcome;
+}
+
 // authDisableKey removed — batch disable tracking is now per-session, not per-credential.
 
 // ---------------------------------------------------------------------------
@@ -294,7 +325,19 @@ export function createAnthropicBatchProvider(
                 model?: string;
                 usage?: AnthropicUsage;
               };
-              error?: { type: string; message: string };
+              // Anthropic wraps errored results in an `ErrorResponse` envelope:
+              // `{ type: "error", request_id, error: { type, message } }`.
+              // The actual cause lives in the nested `error.error` object — the
+              // envelope's own `type` is always the literal string "error" and it
+              // has no `message`. Reading the envelope directly is what produced
+              // the useless "error: undefined" log lines.
+              error?: {
+                type?: string;
+                request_id?: string | null;
+                error?: { type?: string; message?: string };
+                // Some proxies flatten the envelope — tolerate a top-level message.
+                message?: string;
+              };
             };
           };
 
@@ -317,9 +360,7 @@ export function createAnthropicBatchProvider(
               text: null,
               usage: null,
               model: null,
-              error: row.result.error
-                ? `${row.result.error.type}: ${row.result.error.message}`
-                : row.result.type,
+              error: extractAnthropicError(row.result.error, row.result.type),
             });
           }
         } catch {
@@ -420,6 +461,7 @@ async function downloadOpenAIResults(
               completion_tokens?: number;
               prompt_tokens_details?: { cached_tokens?: number };
             };
+            error?: { message?: string; type?: string; code?: string | null };
           };
         };
       };
@@ -434,13 +476,16 @@ async function downloadOpenAIResults(
           model: body.model ?? null,
         });
       } else {
+        const errBody = row.response.body?.error;
         results.push({
           customId: row.custom_id,
           outcome: "errored",
           text: null,
           usage: null,
           model: null,
-          error: `HTTP ${row.response.status_code}`,
+          error: errBody?.message
+            ? `HTTP ${row.response.status_code} ${errBody.type ?? ""}: ${errBody.message}`.trim()
+            : `HTTP ${row.response.status_code}`,
         });
       }
     } catch {
@@ -940,6 +985,29 @@ export function createBatchLLMClient(
             log.error(
               `batch item ${result.customId} errored: ${result.error ?? "unknown"}`,
             );
+            // These are background jobs (distillation/curation/embeddings) that
+            // fail silently to the caller (resolved null). Capture so the real
+            // cause is tracked, not just logged. Grouped by provider to keep
+            // noise bounded; the actual error text is in `extra`.
+            if (Sentry.isInitialized()) {
+              Sentry.captureException(
+                new Error(`batch item errored: ${result.error ?? "unknown"}`),
+                {
+                  fingerprint: [
+                    "LOREAI-GATEWAY",
+                    "batch-item-errored",
+                    batch.provider.name,
+                  ],
+                  extra: {
+                    provider: batch.provider.name,
+                    customId: result.customId,
+                    model: pending.params.model,
+                    workerID: pending.workerID,
+                    error: result.error ?? "unknown",
+                  },
+                },
+              );
+            }
             break;
           case "canceled":
           case "expired":

--- a/packages/gateway/test/batch-queue.test.ts
+++ b/packages/gateway/test/batch-queue.test.ts
@@ -9,7 +9,10 @@
  *  - Shutdown drains the queue
  */
 import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
-import { createBatchLLMClient } from "../src/batch-queue";
+import {
+  createBatchLLMClient,
+  extractAnthropicError,
+} from "../src/batch-queue";
 
 // Bridge: upstreamFetch now uses undici's own fetch (not globalThis.fetch),
 // so tests that mock globalThis.fetch need this shim to intercept calls.
@@ -960,6 +963,286 @@ describe("BatchLLMClient", () => {
     // Restore original mock
     globalThis.fetch = prevFetch;
 
+    await client.shutdown();
+  });
+
+  // -------------------------------------------------------------------------
+  // Errored-result parsing (regression: "batch item … errored: error: undefined")
+  // -------------------------------------------------------------------------
+
+  describe("extractAnthropicError", () => {
+    test("reads the nested ErrorResponse envelope (real Anthropic shape)", () => {
+      // Anthropic wraps the cause in `{ type: "error", request_id, error: { type, message } }`.
+      expect(
+        extractAnthropicError(
+          {
+            type: "error",
+            request_id: "req_1",
+            error: {
+              type: "invalid_request_error",
+              message: "max_tokens: too large",
+            },
+          },
+          "errored",
+        ),
+      ).toBe("invalid_request_error: max_tokens: too large");
+    });
+
+    test("tolerates a flattened envelope ({ type, message } at top level)", () => {
+      expect(
+        extractAnthropicError(
+          { type: "overloaded_error", message: "Overloaded" },
+          "errored",
+        ),
+      ).toBe("overloaded_error: Overloaded");
+    });
+
+    test("falls back to the outcome string, never yields 'error: undefined'", () => {
+      // The old bug: reading `.type`/`.message` off the envelope produced
+      // "error: undefined". The fallback must be the outcome, not undefined.
+      expect(extractAnthropicError({ type: "error" }, "errored")).toBe(
+        "errored",
+      );
+      expect(extractAnthropicError(undefined, "canceled")).toBe("canceled");
+      expect(extractAnthropicError({ type: "error" }, "errored")).not.toContain(
+        "undefined",
+      );
+    });
+  });
+
+  test("anthropic errored result surfaces the real message, not 'error: undefined'", async () => {
+    const inner = createMockLLMClient();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    let capturedCustomId = "";
+    let callIndex = 0;
+    const prevFetch = globalThis.fetch;
+
+    // @ts-expect-error — mock fetch
+    globalThis.fetch = async (url: string, init?: RequestInit) => {
+      const u = String(url);
+      const method = init?.method ?? "GET";
+      const idx = callIndex++;
+
+      // 0: batch submit — capture the generated custom_id so results correlate
+      if (idx === 0) {
+        expect(u).toBe(`${UPSTREAMS.anthropic}/v1/messages/batches`);
+        expect(method).toBe("POST");
+        const body = JSON.parse(init?.body as string) as {
+          requests: Array<{ custom_id: string }>;
+        };
+        capturedCustomId = body.requests[0]?.custom_id ?? "";
+        return {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          text: async () => JSON.stringify({ id: "msgbatch_err" }),
+          json: async () => ({ id: "msgbatch_err" }),
+        };
+      }
+
+      // 1: poll — batch has ended
+      if (idx === 1) {
+        expect(u).toContain("/v1/messages/batches/msgbatch_err");
+        const pollBody = {
+          processing_status: "ended",
+          results_url: `${UPSTREAMS.anthropic}/v1/messages/batches/msgbatch_err/results`,
+        };
+        return {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          text: async () => JSON.stringify(pollBody),
+          json: async () => pollBody,
+        };
+      }
+
+      // 2: results — one errored row with the real nested envelope
+      if (idx === 2) {
+        expect(u).toContain("/results");
+        const jsonl = JSON.stringify({
+          custom_id: capturedCustomId,
+          result: {
+            type: "errored",
+            error: {
+              type: "error",
+              request_id: "req_1",
+              error: {
+                type: "invalid_request_error",
+                message: "max_tokens: too large",
+              },
+            },
+          },
+        });
+        return {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          text: async () => jsonl,
+          json: async () => JSON.parse(jsonl),
+        };
+      }
+
+      return {
+        ok: false,
+        status: 500,
+        statusText: "Error",
+        text: async () => "unexpected",
+        json: async () => ({}),
+      };
+    };
+
+    const client = createBatchLLMClient(
+      inner,
+      UPSTREAMS,
+      getTestAuth,
+      DEFAULT_MODEL,
+      { flushIntervalMs: 60_000, maxQueueSize: 1, pollIntervalMs: 50 },
+    );
+
+    const promise = client.prompt("sys", "user msg", {
+      workerID: "lore-distill",
+    });
+
+    await new Promise((r) => setTimeout(r, 300));
+    const result = await promise;
+
+    // Errored items resolve to null (background caller degrades gracefully)
+    expect(result).toBeNull();
+
+    const logged = errorSpy.mock.calls
+      .map((c) => c.map((a) => String(a)).join(" "))
+      .join("\n");
+    expect(logged).toContain("invalid_request_error: max_tokens: too large");
+    expect(logged).not.toContain("errored: error: undefined");
+
+    const s = client.stats();
+    expect(s.totalFailed).toBe(1);
+
+    errorSpy.mockRestore();
+    globalThis.fetch = prevFetch;
+    await client.shutdown();
+  });
+
+  test("openai errored result includes the response body error message", async () => {
+    const inner = createMockLLMClient();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    let capturedCustomId = "";
+    let callIndex = 0;
+    const prevFetch = globalThis.fetch;
+
+    // @ts-expect-error — mock fetch
+    globalThis.fetch = async (url: string, init?: RequestInit) => {
+      const u = String(url);
+      const idx = callIndex++;
+
+      // 0: file upload — capture custom_id from the uploaded JSONL
+      if (idx === 0) {
+        expect(u).toContain("/v1/files");
+        if (init?.body instanceof FormData) {
+          const file = init.body.get("file") as Blob;
+          const parsed = JSON.parse(await file.text());
+          capturedCustomId = parsed.custom_id;
+        }
+        return {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          text: async () => JSON.stringify({ id: "file-batch-err" }),
+          json: async () => ({ id: "file-batch-err" }),
+        };
+      }
+
+      // 1: batch create
+      if (idx === 1) {
+        expect(u).toContain("/v1/batches");
+        return {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          text: async () => JSON.stringify({ id: "batch_err" }),
+          json: async () => ({ id: "batch_err" }),
+        };
+      }
+
+      // 2: poll — completed
+      if (idx === 2) {
+        return {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          text: async () =>
+            JSON.stringify({
+              status: "completed",
+              output_file_id: "file-results",
+            }),
+          json: async () => ({
+            status: "completed",
+            output_file_id: "file-results",
+          }),
+        };
+      }
+
+      // 3: download results — errored row with a real error body
+      if (idx === 3) {
+        expect(u).toContain("/v1/files/file-results/content");
+        const jsonl = JSON.stringify({
+          custom_id: capturedCustomId,
+          response: {
+            status_code: 400,
+            body: {
+              error: {
+                type: "invalid_request_error",
+                message: "context_length_exceeded",
+              },
+            },
+          },
+        });
+        return {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          text: async () => jsonl,
+          json: async () => JSON.parse(jsonl),
+        };
+      }
+
+      return {
+        ok: false,
+        status: 500,
+        statusText: "Error",
+        text: async () => "unexpected",
+        json: async () => ({}),
+      };
+    };
+
+    const client = createBatchLLMClient(
+      inner,
+      UPSTREAMS,
+      getTestAuth,
+      DEFAULT_MODEL,
+      { flushIntervalMs: 60_000, maxQueueSize: 1, pollIntervalMs: 50 },
+    );
+
+    const promise = client.prompt("sys", "user msg", {
+      model: { providerID: "openai", modelID: "gpt-5.4-mini" },
+      workerID: "lore-distill",
+    });
+
+    await new Promise((r) => setTimeout(r, 300));
+    const result = await promise;
+
+    expect(result).toBeNull();
+
+    const logged = errorSpy.mock.calls
+      .map((c) => c.map((a) => String(a)).join(" "))
+      .join("\n");
+    expect(logged).toContain("HTTP 400");
+    expect(logged).toContain("context_length_exceeded");
+
+    errorSpy.mockRestore();
+    globalThis.fetch = prevFetch;
     await client.shutdown();
   });
 });


### PR DESCRIPTION
## Problem

Logs are full of unhelpful lines like:

```
[ERROR] batch item lore-mr230k7i-ed-bqpaqv errored: error: undefined
```

These come from `batch-queue.ts` when an Anthropic batch item errors. The error string is built as `` `${row.result.error.type}: ${row.result.error.message}` ``.

**Root cause:** Anthropic's `MessageBatchErroredResult.error` is an `ErrorResponse` **envelope** — `{ type: "error", request_id, error: { type, message } }` (confirmed in `@anthropic-ai/sdk`'s `shared.d.ts` and the fixture in `prompt-delta-tools.test.ts`). The code read `.type`/`.message` off the envelope, but the envelope's `type` is always the literal `"error"` and it has **no** `message` — so every errored item logged `error: undefined`. The real cause lives one level deeper at `error.error.{type,message}`.

The errored path had **no test coverage**, which is why it slipped through. These are background jobs (distillation/curation/embeddings) that resolve to `null` and fail silently, so the masked error meant the true cause was invisible.

## Changes

- **Fix Anthropic parsing** via a new exported `extractAnthropicError` helper that reads the nested `error.error`, with fallbacks to a flattened envelope and the outcome string so the result is **never** `undefined`.
- **Improve OpenAI detail** — include the response `body.error` message instead of only `HTTP <code>`.
- **Capture to Sentry** — errored items are now captured (grouped by provider, real error text in `extra`) so background failures are tracked, not just logged.
- **Regression tests** — unit tests for the helper (nested / flattened / fallback) plus end-to-end tests for both providers.

## Verification

- `vitest run packages/gateway/test/batch-queue.test.ts` — 24 pass.
- Full gateway suite: 2426 pass (the single `agents.test.ts` failure is environmental — jj workspace has no `.git` for git-remote resolution; passes with git available).
- `tsc --noEmit` and `biome check` clean.
- **Non-vacuous mutation check**: reverting the parser to the old envelope read makes the new tests fail, reproducing the exact reported line `batch item lore-... errored: error: undefined`.

## Note

This surfaces the real error; it does not itself stop the items from erroring. Once real messages appear in logs/Sentry, the underlying failing-request cause can be addressed as a targeted follow-up.