### PR TITLE
fix(gateway): drop deprecated temperature param on worker 400

### DIFF
--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -156,6 +156,68 @@ function isBetaRelated400(body: string): boolean {
 }
 
 /**
+ * Worker call sites set `temperature: 0` for reproducible distillation/curation.
+ * Newer models (e.g. Anthropic `claude-sonnet-5`) have DEPRECATED the sampling
+ * `temperature` param and reject any request that includes it with a 400
+ * ("`temperature` is deprecated for this model."), which breaks every worker on
+ * that model. We learn this fact at runtime — on the first such 400 — so
+ * subsequent worker calls omit `temperature` upfront instead of burning a
+ * wasted round-trip per call. The set is intentionally NOT seeded from a
+ * hardcoded model list: hardcoding drifts as models ship and risks both false
+ * positives (stripping from a model that supports it) and misses (a new model
+ * we forgot). Runtime learning is always correct and self-healing. Keyed by
+ * `providerID/modelID`; in-memory, so it re-learns at most once per model per
+ * gateway lifetime after a restart.
+ */
+const temperatureUnsupportedModels = new Set<string>();
+
+/** Stable key for the temperature-capability set. */
+function workerModelKey(model: {
+  providerID: string;
+  modelID: string;
+}): string {
+  return `${model.providerID}/${model.modelID}`;
+}
+
+/** Record that a model rejects the `temperature` param (learned from a 400). */
+export function markTemperatureUnsupported(model: {
+  providerID: string;
+  modelID: string;
+}): void {
+  temperatureUnsupportedModels.add(workerModelKey(model));
+}
+
+/** Has this model been observed to reject the `temperature` param? */
+export function isTemperatureUnsupportedModel(model: {
+  providerID: string;
+  modelID: string;
+}): boolean {
+  return temperatureUnsupportedModels.has(workerModelKey(model));
+}
+
+/** Test-only: clear the learned temperature-capability set. */
+export function _resetTemperatureUnsupportedModels(): void {
+  temperatureUnsupportedModels.clear();
+}
+
+/**
+ * Heuristic: does a 400 body indicate the request's `temperature` param is not
+ * accepted by this model? Matches Anthropic's "`temperature` is deprecated for
+ * this model." and OpenAI-style "Unsupported parameter: temperature" / "...
+ * not supported ..." shapes. Requires the word `temperature` AND a rejection
+ * verb so an unrelated 400 that merely mentions temperature can't trigger the
+ * one-shot temperature-stripped retry.
+ */
+function isTemperatureUnsupported400(body: string): boolean {
+  return (
+    /temperature/i.test(body) &&
+    /\b(deprecated|unsupported|not\s+supported|no\s+longer\s+supported|removed|not\s+allowed|cannot\s+be\s+(?:set|used|specified))\b/i.test(
+      body,
+    )
+  );
+}
+
+/**
  * Unified retry policy (modeled on Claude Code's `getRetryDelay`).
  *
  * A single policy governs every worker call — urgent or background, 429 or
@@ -1211,6 +1273,14 @@ export function createGatewayLLMClient(
         }
       }
 
+      // Resolve the effective sampling temperature. Models we've already
+      // observed to reject `temperature` (see markTemperatureUnsupported) get
+      // it omitted upfront so we don't burn a wasted 400 round-trip per call.
+      // A runtime-learned 400 below flips this to undefined for the retry.
+      let effectiveTemperature = isTemperatureUnsupportedModel(model)
+        ? undefined
+        : opts?.temperature;
+
       // Build protocol-specific request
       let req = await buildWorkerRequest(
         target,
@@ -1220,7 +1290,7 @@ export function createGatewayLLMClient(
         user,
         maxTokens,
         opts?.sessionID,
-        opts?.temperature,
+        effectiveTemperature,
         factoryVertexProject,
       );
 
@@ -1258,6 +1328,9 @@ export function createGatewayLLMClient(
             // Strip beta headers at most once per call (runtime fallback for a
             // beta-related 400 — see the non-transient block below).
             let betaStripped = false;
+            // Strip the temperature param at most once per call (runtime
+            // fallback for a "temperature is deprecated" 400 — see below).
+            let temperatureStripped = false;
             // Resolve the retry budget once per call (not per attempt) — the
             // value can't change mid-loop and re-reading the env each iteration
             // is wasteful.
@@ -1543,7 +1616,7 @@ export function createGatewayLLMClient(
                     user,
                     maxTokens,
                     opts?.sessionID,
-                    opts?.temperature,
+                    effectiveTemperature,
                     factoryVertexProject,
                   );
                   retryCount++;
@@ -1650,6 +1723,43 @@ export function createGatewayLLMClient(
                   req = { ...req, headers: stripBetaHeaders(req.headers) };
                   log.warn(
                     `worker 400 looks long-context-beta-related — retrying once without the context-1m beta ` +
+                      `(model=${model.providerID}/${model.modelID}, worker=${opts?.workerID ?? "unknown"}): ${text.slice(0, 160)}`,
+                  );
+                  retryCount++;
+                  continue;
+                }
+
+                // 400 + a "temperature is deprecated/unsupported" complaint →
+                // the request carries a `temperature` the model rejects (newer
+                // models like claude-sonnet-5 dropped the sampling param). Learn
+                // it so future calls omit temperature upfront, then rebuild THIS
+                // request without temperature and retry once. We rebuild via
+                // buildWorkerRequest rather than string-editing req.body so the
+                // OAuth billing signature is recomputed over the new body
+                // (mutating the serialized body would invalidate the cch hash).
+                // Bounded to one retry per call.
+                if (
+                  response.status === 400 &&
+                  !temperatureStripped &&
+                  effectiveTemperature != null &&
+                  isTemperatureUnsupported400(text)
+                ) {
+                  temperatureStripped = true;
+                  markTemperatureUnsupported(model);
+                  effectiveTemperature = undefined;
+                  req = await buildWorkerRequest(
+                    target,
+                    cred,
+                    model,
+                    system,
+                    user,
+                    maxTokens,
+                    opts?.sessionID,
+                    effectiveTemperature,
+                    factoryVertexProject,
+                  );
+                  log.warn(
+                    `worker 400 reports temperature is unsupported — retrying once without the temperature param ` +
                       `(model=${model.providerID}/${model.modelID}, worker=${opts?.workerID ?? "unknown"}): ${text.slice(0, 160)}`,
                   );
                   retryCount++;

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -211,7 +211,7 @@ export function _resetTemperatureUnsupportedModels(): void {
 function isTemperatureUnsupported400(body: string): boolean {
   return (
     /temperature/i.test(body) &&
-    /\b(deprecated|unsupported|not\s+supported|no\s+longer\s+supported|removed|not\s+allowed|cannot\s+be\s+(?:set|used|specified))\b/i.test(
+    /\b(deprecated|unsupported|no\s+longer\s+supported|not\s+(?:a\s+)?support(?:ed)?|removed|not\s+allowed|cannot\s+be\s+(?:set|used|specified))\b/i.test(
       body,
     )
   );
@@ -1281,10 +1281,17 @@ export function createGatewayLLMClient(
         ? undefined
         : opts?.temperature;
 
+      // The credential in effect for the CURRENT attempt. Starts as `cred`; an
+      // auth-error refresh reassigns it so every later rebuild in the retry loop
+      // (e.g. the temperature-strip rebuild) signs with the fresh key rather
+      // than the stale one that just 401'd. Typed non-null (assigned only from
+      // non-null values) so the closure keeps the `if (!cred)` guard's narrowing.
+      let activeCred: AuthCredential = cred;
+
       // Build protocol-specific request
       let req = await buildWorkerRequest(
         target,
-        cred,
+        activeCred,
         model,
         system,
         user,
@@ -1371,6 +1378,14 @@ export function createGatewayLLMClient(
               finalStatus = response.status;
 
               if (response.ok) {
+                // If a prior attempt stripped `temperature` and the request now
+                // succeeds (2xx), temperature really was the culprit — learn it
+                // so future calls to this model omit it upfront. Deferred to
+                // success (rather than marking on the 400 heuristic match) so a
+                // regex false-positive on an unrelated 400 can never permanently
+                // mislabel a model that actually supports temperature.
+                if (temperatureStripped) markTemperatureUnsupported(model);
+
                 // Guard: some providers return SSE even when stream: false
                 // was sent. Extract JSON from the data: lines instead.
                 const ct = response.headers.get("content-type") ?? "";
@@ -1604,13 +1619,16 @@ export function createGatewayLLMClient(
                 const credentialChanged =
                   !!freshCred && freshCred.value !== cred.value;
                 if (credentialChanged && attempt === 0) {
-                  // Credential changed — rebuild request and retry once
+                  // Credential changed — adopt it as the current credential so
+                  // any subsequent rebuild (e.g. the temperature-strip retry)
+                  // uses the fresh key, then rebuild request and retry once.
+                  activeCred = freshCred;
                   log.info(
                     `worker auth error ${response.status}, credential refreshed — retrying: ${text.slice(0, 200)}`,
                   );
                   req = await buildWorkerRequest(
                     target,
-                    freshCred,
+                    activeCred,
                     model,
                     system,
                     user,
@@ -1745,11 +1763,10 @@ export function createGatewayLLMClient(
                   isTemperatureUnsupported400(text)
                 ) {
                   temperatureStripped = true;
-                  markTemperatureUnsupported(model);
                   effectiveTemperature = undefined;
                   req = await buildWorkerRequest(
                     target,
-                    cred,
+                    activeCred,
                     model,
                     system,
                     user,
@@ -1758,6 +1775,16 @@ export function createGatewayLLMClient(
                     effectiveTemperature,
                     factoryVertexProject,
                   );
+                  // Rebuilding restores the freshly-built header set, which
+                  // resurrects a beta we may have already stripped at runtime
+                  // (the upfront capability filter KEEPS context-1m for a
+                  // 1M-capable model like sonnet-5, so a subscription-not-
+                  // entitled beta 400 is only cured by the runtime strip). If a
+                  // model needed BOTH fixes, re-apply the beta strip so the
+                  // temperature rebuild doesn't regress it into a beta-400 loop.
+                  if (betaStripped) {
+                    req = { ...req, headers: stripBetaHeaders(req.headers) };
+                  }
                   log.warn(
                     `worker 400 reports temperature is unsupported — retrying once without the temperature param ` +
                       `(model=${model.providerID}/${model.modelID}, worker=${opts?.workerID ?? "unknown"}): ${text.slice(0, 160)}`,

--- a/packages/gateway/test/llm-adapter.test.ts
+++ b/packages/gateway/test/llm-adapter.test.ts
@@ -1334,6 +1334,8 @@ describe("worker temperature capability", () => {
 
   beforeEach(() => {
     _resetTemperatureUnsupportedModels();
+    vi.mocked(recordWorkerFailure).mockClear();
+    vi.mocked(markWorkerPaused).mockClear();
   });
 
   afterEach(() => {
@@ -1348,6 +1350,16 @@ describe("worker temperature capability", () => {
     const raw = init?.body;
     if (typeof raw !== "string") return undefined;
     return JSON.parse(raw) as Record<string, unknown>;
+  }
+
+  function betaOf(callIndex: number): string | undefined {
+    const init = mockFetch.mock.calls[callIndex]?.[1];
+    const headers = init?.headers as Record<string, string> | undefined;
+    if (!headers) return undefined;
+    const key = Object.keys(headers).find(
+      (k) => k.toLowerCase() === "anthropic-beta",
+    );
+    return key ? headers[key] : undefined;
   }
 
   const TEMP_DEPRECATED_400 = JSON.stringify({
@@ -1427,6 +1439,10 @@ describe("worker temperature capability", () => {
         modelID: "claude-sonnet-5",
       }),
     ).toBe(true);
+    // A recovered temperature-strip retry is NOT a worker failure: the health
+    // ladder must not be incremented and the session must not be soft-paused.
+    expect(recordWorkerFailure).not.toHaveBeenCalled();
+    expect(markWorkerPaused).not.toHaveBeenCalled();
   });
 
   test("omits temperature upfront on the next call once a model is learned", async () => {
@@ -1503,5 +1519,208 @@ describe("worker temperature capability", () => {
         modelID: "claude-sonnet-5",
       }),
     ).toBe(false);
+  });
+
+  test("does not learn the model when the temperature-stripped retry still fails", async () => {
+    // call 1: temperature-deprecated 400 → strip + retry.
+    // call 2: an UNRELATED 400 → temperature was not the (only) cause, so the
+    // model must NOT be learned (learning is deferred to a successful retry).
+    let call = 0;
+    mockFetch.mockImplementation(async () => {
+      call++;
+      if (call === 1) {
+        return new Response(TEMP_DEPRECATED_400, { status: 400 });
+      }
+      return new Response(
+        JSON.stringify({
+          error: { type: "invalid_request_error", message: "bad max_tokens" },
+        }),
+        { status: 400 },
+      );
+    });
+
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "sk-ant-test" }),
+      { providerID: "anthropic", modelID: "claude-sonnet-5" },
+    );
+
+    const result = await client.prompt("system", "user", {
+      sessionID: "sess-temp-fail",
+      workerID: "lore-distill",
+      model: { providerID: "anthropic", modelID: "claude-sonnet-5" },
+      temperature: 0,
+    });
+
+    expect(result).toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(2); // stripped once, still failed
+    expect(bodyOf(1)).not.toHaveProperty("temperature"); // strip did happen
+    // But the model is NOT learned — the retry never confirmed the cure.
+    expect(
+      isTemperatureUnsupportedModel({
+        providerID: "anthropic",
+        modelID: "claude-sonnet-5",
+      }),
+    ).toBe(false);
+  });
+
+  test("temperature-strip rebuild uses the refreshed credential (not the stale one) after an auth refresh in the same call", async () => {
+    // call 1: 401 → auth refresh (getAuth now returns the fresh key), rebuild.
+    // call 2: temperature 400 → strip + rebuild. The rebuild MUST sign with the
+    //         refreshed key, not the original stale one that already 401'd.
+    // call 3: 200.
+    let call = 0;
+    mockFetch.mockImplementation(async () => {
+      call++;
+      if (call === 1) return new Response("unauthorized", { status: 401 });
+      if (call === 2) return new Response(TEMP_DEPRECATED_400, { status: 400 });
+      return new Response(
+        JSON.stringify({
+          content: [{ type: "text", text: "recovered" }],
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+
+    let authCall = 0;
+    const getAuth = () => {
+      authCall++;
+      return {
+        scheme: "api-key" as const,
+        value: authCall === 1 ? "sk-ant-stale" : "sk-ant-fresh",
+      };
+    };
+
+    const client = createGatewayLLMClient(UPSTREAMS, getAuth, {
+      providerID: "anthropic",
+      modelID: "claude-sonnet-5",
+    });
+
+    const result = await client.prompt("system", "user", {
+      sessionID: "sess-temp-authrefresh",
+      workerID: "lore-distill",
+      model: { providerID: "anthropic", modelID: "claude-sonnet-5" },
+      temperature: 0,
+    });
+
+    const keyOf = (i: number): string | undefined => {
+      const init = mockFetch.mock.calls[i]?.[1];
+      const headers = init?.headers as Record<string, string> | undefined;
+      return headers?.["x-api-key"];
+    };
+
+    expect(result).toBe("recovered");
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(keyOf(1)).toBe("sk-ant-fresh"); // auth rebuild adopted the fresh key
+    expect(keyOf(2)).toBe("sk-ant-fresh"); // temperature rebuild kept the fresh key
+    expect(bodyOf(2)).not.toHaveProperty("temperature");
+  });
+
+  test("strips temperature on the OpenAI Chat Completions worker path too", async () => {
+    let call = 0;
+    mockFetch.mockImplementation(async () => {
+      call++;
+      if (call === 1) {
+        return new Response(
+          JSON.stringify({
+            error: {
+              message: "Unsupported parameter: 'temperature' is not supported.",
+              type: "invalid_request_error",
+            },
+          }),
+          { status: 400 },
+        );
+      }
+      return new Response(
+        JSON.stringify({
+          choices: [{ message: { content: "recovered" } }],
+          usage: { prompt_tokens: 1, completion_tokens: 1 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "sk-openai-test" }),
+      { providerID: "openai", modelID: "gpt-5" },
+    );
+
+    const result = await client.prompt("system", "user", {
+      sessionID: "sess-temp-openai",
+      workerID: "lore-distill",
+      model: { providerID: "openai", modelID: "gpt-5" },
+      protocol: "openai",
+      temperature: 0,
+    });
+
+    expect(result).toBe("recovered");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(bodyOf(0)?.temperature).toBe(0);
+    expect(bodyOf(1)).toBeDefined();
+    expect(bodyOf(1)).not.toHaveProperty("temperature");
+  });
+
+  test("a model needing BOTH a beta strip AND a temperature strip recovers (temperature rebuild does not resurrect the stripped beta)", async () => {
+    // Server returns the beta error FIRST, then the temperature error — the
+    // adversarial order: the temperature rebuild goes through buildWorkerRequest
+    // whose upfront filter KEEPS context-1m for a 1M-capable model, so without
+    // re-applying the runtime beta strip the third attempt would carry the beta
+    // again and 400-loop (betaStripped already latched).
+    let call = 0;
+    mockFetch.mockImplementation(async () => {
+      call++;
+      if (call === 1) {
+        return new Response(
+          JSON.stringify({
+            error: {
+              type: "invalid_request_error",
+              message:
+                "The long context beta is not yet available for this subscription.",
+            },
+          }),
+          { status: 400 },
+        );
+      }
+      if (call === 2) {
+        return new Response(TEMP_DEPRECATED_400, { status: 400 });
+      }
+      return new Response(
+        JSON.stringify({
+          content: [{ type: "text", text: "recovered" }],
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+
+    // opus-4-8 is 1M-capable in the fallback table, so the upfront filter keeps
+    // context-1m; the OAuth session replays the beta + oauth gate.
+    captureBillingPrefix("sess-both", BILLING_SYSTEM);
+    captureSessionHeaders("sess-both", {
+      "anthropic-beta": "oauth-2025-04-20,context-1m-2025-08-07",
+    });
+
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "bearer", value: "oauth-token" }),
+      { providerID: "anthropic", modelID: "claude-opus-4-8" },
+    );
+
+    const result = await client.prompt("system", "user", {
+      sessionID: "sess-both",
+      workerID: "lore-distill",
+      model: { providerID: "anthropic", modelID: "claude-opus-4-8" },
+      temperature: 0,
+    });
+
+    expect(result).toBe("recovered");
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    // Final attempt: neither the context-1m beta nor temperature is present,
+    // and the OAuth gate is preserved so it still authenticates.
+    expect(betaOf(2)).not.toContain("context-1m");
+    expect(betaOf(2)).toContain("oauth-2025-04-20");
+    expect(bodyOf(2)).not.toHaveProperty("temperature");
   });
 });

--- a/packages/gateway/test/llm-adapter.test.ts
+++ b/packages/gateway/test/llm-adapter.test.ts
@@ -21,6 +21,8 @@ import {
   normalizeOpenAIUsage,
   resolveWorkerProtocol,
   AUTH_ERROR_CODES,
+  isTemperatureUnsupportedModel,
+  _resetTemperatureUnsupportedModels,
 } from "../src/llm-adapter";
 import {
   getConsecutiveTrips,
@@ -1308,5 +1310,198 @@ describe("worker beta capability validation", () => {
     expect(betaOf(1)).toBeDefined();
     expect(betaOf(1)).not.toContain("context-1m");
     expect(betaOf(1)).toContain("oauth-2025-04-20");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Temperature-vs-model capability + runtime 400-retry-without-temperature
+//
+// Worker call sites set `temperature: 0` for reproducible distillation/curation.
+// Newer models (e.g. claude-sonnet-5) DEPRECATED the sampling param and reject
+// any request carrying it with a 400 ("`temperature` is deprecated for this
+// model."), which broke every worker on that model. We (1) retry once with the
+// temperature param removed on such a 400, and (2) learn the fact so subsequent
+// worker calls to that model omit temperature upfront.
+// ---------------------------------------------------------------------------
+
+describe("worker temperature capability", () => {
+  const mockFetch = vi.mocked(upstreamFetch);
+
+  const UPSTREAMS = {
+    anthropic: "https://api.anthropic.com",
+    openai: "https://api.openai.com",
+  };
+
+  beforeEach(() => {
+    _resetTemperatureUnsupportedModels();
+  });
+
+  afterEach(() => {
+    mockFetch.mockReset();
+    clearAllCosts();
+    resetBackgroundLimiter();
+    _resetTemperatureUnsupportedModels();
+  });
+
+  function bodyOf(callIndex: number): Record<string, unknown> | undefined {
+    const init = mockFetch.mock.calls[callIndex]?.[1];
+    const raw = init?.body;
+    if (typeof raw !== "string") return undefined;
+    return JSON.parse(raw) as Record<string, unknown>;
+  }
+
+  const TEMP_DEPRECATED_400 = JSON.stringify({
+    type: "error",
+    error: {
+      type: "invalid_request_error",
+      message: "`temperature` is deprecated for this model.",
+    },
+  });
+
+  test("sends temperature upfront for a model not known to reject it", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          content: [{ type: "text", text: "ok" }],
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "sk-ant-test" }),
+      { providerID: "anthropic", modelID: "claude-opus-4-8" },
+    );
+
+    await client.prompt("system", "user", {
+      sessionID: "sess-temp-ok",
+      workerID: "lore-distill",
+      model: { providerID: "anthropic", modelID: "claude-opus-4-8" },
+      temperature: 0,
+    });
+
+    expect(bodyOf(0)?.temperature).toBe(0);
+  });
+
+  test("retries once without temperature on a deprecation 400, then succeeds", async () => {
+    let call = 0;
+    mockFetch.mockImplementation(async () => {
+      call++;
+      if (call === 1) {
+        return new Response(TEMP_DEPRECATED_400, { status: 400 });
+      }
+      return new Response(
+        JSON.stringify({
+          content: [{ type: "text", text: "recovered" }],
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "sk-ant-test" }),
+      { providerID: "anthropic", modelID: "claude-sonnet-5" },
+    );
+
+    const result = await client.prompt("system", "user", {
+      sessionID: "sess-temp-400",
+      workerID: "lore-distill",
+      model: { providerID: "anthropic", modelID: "claude-sonnet-5" },
+      temperature: 0,
+    });
+
+    expect(result).toBe("recovered");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    // First attempt carried temperature; the retry dropped it entirely.
+    expect(bodyOf(0)?.temperature).toBe(0);
+    expect(bodyOf(1)).toBeDefined();
+    expect(bodyOf(1)).not.toHaveProperty("temperature");
+    // The model is now learned as temperature-unsupported.
+    expect(
+      isTemperatureUnsupportedModel({
+        providerID: "anthropic",
+        modelID: "claude-sonnet-5",
+      }),
+    ).toBe(true);
+  });
+
+  test("omits temperature upfront on the next call once a model is learned", async () => {
+    // First call: 400 then recover (teaches the set).
+    let call = 0;
+    mockFetch.mockImplementation(async () => {
+      call++;
+      if (call === 1) {
+        return new Response(TEMP_DEPRECATED_400, { status: 400 });
+      }
+      return new Response(
+        JSON.stringify({
+          content: [{ type: "text", text: "ok" }],
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "sk-ant-test" }),
+      { providerID: "anthropic", modelID: "claude-sonnet-5" },
+    );
+
+    const opts = {
+      sessionID: "sess-temp-learn",
+      workerID: "lore-distill",
+      model: { providerID: "anthropic", modelID: "claude-sonnet-5" },
+      temperature: 0,
+    };
+
+    await client.prompt("system", "user", opts);
+    expect(mockFetch).toHaveBeenCalledTimes(2); // 400 + retry
+
+    // Second prompt to the same model: no wasted round-trip — temperature is
+    // omitted on the FIRST request, so a single 200 call suffices.
+    await client.prompt("system", "user", opts);
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(bodyOf(2)).toBeDefined();
+    expect(bodyOf(2)).not.toHaveProperty("temperature");
+  });
+
+  test("does not strip temperature for an unrelated 400", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          type: "error",
+          error: { type: "invalid_request_error", message: "bad max_tokens" },
+        }),
+        { status: 400 },
+      ),
+    );
+
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "sk-ant-test" }),
+      { providerID: "anthropic", modelID: "claude-sonnet-5" },
+    );
+
+    const result = await client.prompt("system", "user", {
+      sessionID: "sess-temp-unrelated",
+      workerID: "lore-distill",
+      model: { providerID: "anthropic", modelID: "claude-sonnet-5" },
+      temperature: 0,
+    });
+
+    // Unrelated 400 → no retry, no learning.
+    expect(result).toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(
+      isTemperatureUnsupportedModel({
+        providerID: "anthropic",
+        modelID: "claude-sonnet-5",
+      }),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Problem

After the sonnet-5 upgrade, every background worker started failing:

```
worker upstream request failed: 400 Bad Request — url=https://api.anthropic.com
model=anthropic/claude-sonnet-5 cred=api-key worker=lore-distill
— {"type":"error","error":{"type":"invalid_request_error",
"message":"`temperature` is deprecated for this model."}}
```

Worker call sites (distillation, curator, pattern-echo, entity-rebuild, search
expansion, import extract) all set `temperature: 0` for reproducible output.
Newer models (e.g. `claude-sonnet-5`) have **deprecated** the sampling
`temperature` param and reject any request carrying it with a 400 — which
breaks *every* worker on that model.

## Fix

Mirror the existing beta-capability defense (`applyModelBetaCapabilityFilter` +
runtime beta-strip retry):

1. **Runtime fallback (self-healing):** on a 400 whose body reports temperature
   is deprecated/unsupported, rebuild the request **without** temperature and
   retry once (bounded to one retry per call). Rebuild goes through
   `buildWorkerRequest` rather than string-editing `req.body`, so the OAuth
   billing signature (`cch` xxHash64) is recomputed over the new body.
2. **Runtime learning:** record `providerID/modelID` in an in-memory set once the
   stripped retry **succeeds**, so subsequent worker calls omit `temperature`
   upfront and don't burn a wasted round-trip per call.

The set is **not** seeded from a hardcoded model list — hardcoding drifts as
models ship and risks both false positives and misses. Runtime learning is
self-healing and correct for any current/future model that drops the param.
Model- and protocol-agnostic: the anthropic/openai/codex/vertex builders all
rebuild with temperature omitted.

## Post-review hardening (adversarial self-review)

- **Beta-strip preservation:** `buildWorkerRequest` re-runs the upfront filter,
  which KEEPS `context-1m` for a 1M-capable model — so a model needing BOTH a
  beta strip (subscription not entitled) and a temperature strip would regress
  into a beta-400 loop. The temperature rebuild now re-applies `stripBetaHeaders`
  when `betaStripped` is set.
- **Credential freshness:** an auth refresh mid-call previously rebuilt with a
  `freshCred` that was never adopted, so the temperature rebuild re-signed with
  the stale key and 401'd. The active credential is now tracked and the fresh
  one adopted on refresh.
- **Deferred learning:** the model is learned only after the stripped retry
  succeeds (2xx), not optimistically on the regex match, so a false-positive
  match on an unrelated 400 can't permanently mislabel a temperature-supporting
  model.
- **Regex hardening:** also matches `not a supported` / `does not support`.

## Tests

`worker temperature capability` suite in `llm-adapter.test.ts`:
- sends temperature upfront for a model not known to reject it
- retries once without temperature on a deprecation 400, then succeeds (and learns the model); asserts it is **not** counted as a worker failure
- omits temperature upfront on the next call once a model is learned (no wasted round-trip)
- does **not** strip temperature for an unrelated 400 (no false positives / spurious learning)
- does **not** learn the model when the stripped retry still fails (deferred learning)
- temperature-strip rebuild uses the **refreshed** credential after an auth refresh in the same call
- strips temperature on the **OpenAI Chat Completions** worker path
- a model needing **both** a beta strip and a temperature strip recovers (rebuild doesn't resurrect the stripped beta)

All behavioral tests verified **non-vacuous** via mutation testing (independent
subagent review reproduced this: disabling each guard kills exactly the intended
test; restored byte-identical after each mutation).

`pnpm run typecheck` ✅ · `pnpm run lint` ✅ · gateway suite green (one unrelated
flaky `replay.test.ts` "bad port" harness failure, passes in isolation).