### PR TITLE
fix(core): surface skipped-blob count + arm temporal walk on vec0 cutover

### DIFF
--- a/packages/core/src/db/vec-store.ts
+++ b/packages/core/src/db/vec-store.ts
@@ -441,7 +441,7 @@ export function copyBlobsToVec0(
   conn: EmbeddingWriteConn,
   table: EmbeddingTable,
   dim: number,
-): void {
+): number {
   // vec0 (our pinned sqlite-vec) has no `INSERT OR REPLACE`, so idempotence /
   // resumability comes from skipping ids already present in the vec0 table via
   // `WHERE … NOT IN (SELECT <pk> FROM <vec0>)`. On the first pass the vec0 table
@@ -458,41 +458,63 @@ export function copyBlobsToVec0(
   // ENTIRE cutover, stranding the DB in blob mode on every subsequent startup.
   // Skip stale-dim blobs here instead: the row is simply absent from vec0 after
   // the copy, and the very next re-embed backfill in the same startup pass
-  // regenerates it at the correct dimension from its source text
-  // (knowledge/entities/distillations via `missingEmbeddingSql` = NOT IN <vec
-  // table>; temporal via the full re-chunk walk in backfillTemporalEmbeddings).
-  // Net effect: the stale vector is removed and recreated — one bad row can never
-  // brick the migration for the whole corpus.
+  // regenerates every SEARCH-ELIGIBLE skipped row at the correct dimension from
+  // its source text (knowledge/entities/distillations via `missingEmbeddingSql`
+  // = NOT IN <vec table>; temporal via the full re-chunk walk in
+  // backfillTemporalEmbeddings). Rows outside a backfill's own eligibility filter
+  // (low-confidence knowledge, archived/empty distillations, sub-50-char
+  // temporal) simply lose an already-unsearchable stale vector — no search
+  // regression, since a wrong-dim blob is unusable in every mode anyway. Either
+  // way, one bad row can never brick the migration for the whole corpus.
+  //
+  // Returns the number of stale-dim blobs skipped so the caller can surface a
+  // one-time notice (this is rare corpus corruption an operator should see).
   const expectedBytes = dim * 4;
+  const staleSkipped = (source: string): number =>
+    (
+      conn
+        .query(
+          `SELECT COUNT(*) AS n FROM ${source} WHERE embedding IS NOT NULL AND length(embedding) <> ${expectedBytes}`,
+        )
+        .get() as { n: number }
+    ).n;
   switch (table) {
-    case "knowledge":
+    case "knowledge": {
+      const skipped = staleSkipped("knowledge_current");
       conn
         .query(
           `INSERT INTO knowledge_vec(id, embedding) SELECT id, embedding FROM knowledge_current WHERE embedding IS NOT NULL AND length(embedding) = ${expectedBytes} AND id NOT IN (SELECT id FROM knowledge_vec)`,
         )
         .run();
-      return;
-    case "entities":
+      return skipped;
+    }
+    case "entities": {
+      const skipped = staleSkipped("entities");
       conn
         .query(
           `INSERT INTO entity_vec(id, embedding) SELECT id, embedding FROM entities WHERE embedding IS NOT NULL AND length(embedding) = ${expectedBytes} AND id NOT IN (SELECT id FROM entity_vec)`,
         )
         .run();
-      return;
-    case "distillations":
+      return skipped;
+    }
+    case "distillations": {
+      const skipped = staleSkipped("distillations");
       conn
         .query(
           `INSERT INTO distillation_vec(id, project_id, session_id, embedding) SELECT id, project_id, session_id, embedding FROM distillations WHERE embedding IS NOT NULL AND length(embedding) = ${expectedBytes} AND id NOT IN (SELECT id FROM distillation_vec)`,
         )
         .run();
-      return;
-    case "temporal":
+      return skipped;
+    }
+    case "temporal": {
+      const skipped = staleSkipped("temporal_messages");
       conn
         .query(
           `INSERT INTO temporal_vec(chunk_id, message_id, project_id, session_id, embedding) SELECT id || '#0', id, project_id, session_id, embedding FROM temporal_messages WHERE embedding IS NOT NULL AND length(embedding) = ${expectedBytes} AND (id || '#0') NOT IN (SELECT chunk_id FROM temporal_vec)`,
         )
         .run();
-      return;
+      return skipped;
+    }
   }
 }
 

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -2049,11 +2049,29 @@ export function maybeCutoverToVec0(): void {
     // the flip below, so mode==="blob" always implies the embedding columns
     // still exist; no blob-mode query can ever read a half-dropped column (the
     // v55 boot-loop hazard).
+    let staleSkipped = 0;
     for (const table of EMBEDDING_TABLES) {
-      if (embeddingColumnExists(db(), table)) copyBlobsToVec0(db(), table, dim);
+      if (embeddingColumnExists(db(), table))
+        staleSkipped += copyBlobsToVec0(db(), table, dim);
     }
     // Flip once vec0 is fully populated and authoritative.
     setStorageMode(db(), "vec0");
+    // Arm the temporal re-chunk walk so backfillTemporalEmbeddings definitely
+    // runs this startup and re-embeds every row skipped above (plus every legacy
+    // single-vector row) at the correct dimension. This is a no-op today — the
+    // done flag can only be latched from INSIDE a vec0-mode run of that walk, so
+    // a machine transitioning from blob mode never has it set — but calling it at
+    // the exact blob->vec0 transition hard-guards that invariant against future
+    // refactors and self-documents that the walk is (re)armed here.
+    resetTemporalRechunkProgress();
+    if (staleSkipped > 0) {
+      // Rare corpus corruption (blobs written under a different dimension). The
+      // rows were skipped from the copy and will be re-embedded at `dim` by the
+      // backfills below; surface it so an operator can see it happened.
+      log.notice(
+        `vec0 cutover skipped ${staleSkipped} stale-dimension embedding blob(s) (not ${dim}-dim / ${dim * 4} bytes); they will be re-embedded by the startup backfills`,
+      );
+    }
     log.info(`vec0 storage cutover complete (dim=${dim})`);
   }
 
@@ -2693,6 +2711,13 @@ export async function backfillTemporalEmbeddings(
 
   // Multi-vector chunking only exists in vec0 mode. Skip WITHOUT latching done
   // so a later cutover to vec0 still triggers the walk.
+  //
+  // 🔴 Ordering invariant: this vec0-mode guard MUST come BEFORE the done-flag
+  // check below. Because the flag can therefore only ever be latched from inside
+  // a vec0-mode run, a blob-mode run can never set it — which is what guarantees
+  // the first walk after a blob->vec0 cutover is always armed and re-embeds the
+  // rows that cutover skipped. (maybeCutoverToVec0 also explicitly re-arms the
+  // walk on cutover as belt-and-suspenders.) Do not reorder these two lines.
   if (readStorageMode(db()) !== "vec0") return 0;
   if (getKV(TEMPORAL_RECHUNK_DONE_KEY) === "1") return 0;
 

--- a/packages/core/test/vec0-cutover.test.ts
+++ b/packages/core/test/vec0-cutover.test.ts
@@ -604,6 +604,29 @@ describeVec("blob → vec0 cutover", () => {
     expect(rows.length).toBeGreaterThanOrEqual(1);
     expect(rows.every((r) => r.n === DIM * 4)).toBe(true);
   });
+
+  test("copyBlobsToVec0 returns the count of stale-dimension blobs it skipped", () => {
+    ensureVec0Store(db(), DIM);
+    insTemporal("t_ok", "s", 1);
+    insTemporal("t_bad1", "s", 2);
+    insTemporal("t_bad2", "s", 3);
+    db()
+      .query("UPDATE temporal_messages SET embedding = ? WHERE id='t_ok'")
+      .run(toBlob(v(1, 0, 0, 0))); // valid DIM-dim
+    db()
+      .query("UPDATE temporal_messages SET embedding = ? WHERE id='t_bad1'")
+      .run(toBlob(new Float32Array([0.1, 0.2]))); // 2-dim → stale
+    db()
+      .query("UPDATE temporal_messages SET embedding = ? WHERE id='t_bad2'")
+      .run(toBlob(new Float32Array([0.1, 0.2, 0.3]))); // 3-dim → stale
+
+    // Two stale-dim blobs skipped; the one valid blob relocated.
+    expect(copyBlobsToVec0(db(), "temporal", DIM)).toBe(2);
+    expect(
+      (db().query("SELECT COUNT(*) n FROM temporal_vec").get() as { n: number })
+        .n,
+    ).toBe(1);
+  });
 });
 
 describeVec("recency-cap removal (vec0 sees the whole corpus)", () => {
@@ -800,6 +823,110 @@ describeVec("maybeCutoverToVec0 (real orchestration, config dim = 768)", () => {
 
     expect(readStorageMode(db())).toBe("vec0");
     for (const t of TABLES) expect(embeddingColumnExists(db(), t)).toBe(false);
+  });
+
+  test("the real cutover skips a stale-dimension blob (768) and still completes", () => {
+    // Exercises the real maybeCutoverToVec0 stale-skip path end-to-end (not just
+    // the test-dimension mirror): a valid 768-dim row alongside a legacy 384-dim
+    // (1536-byte) blob. (The operator notice is covered by the next test.)
+    insTemporal("t_ok", "s", 1);
+    insTemporal("t_stale", "s", 2);
+    db()
+      .query("UPDATE temporal_messages SET embedding = ? WHERE id='t_ok'")
+      .run(toBlob(v768(0)));
+    db()
+      .query("UPDATE temporal_messages SET embedding = ? WHERE id='t_stale'")
+      .run(toBlob(new Float32Array(384))); // wrong dim → skipped, not aborted
+    expect(readStorageMode(db())).toBe("blob");
+
+    expect(() => maybeCutoverToVec0()).not.toThrow();
+
+    expect(readStorageMode(db())).toBe("vec0");
+    const tids = (
+      db()
+        .query("SELECT message_id FROM temporal_vec ORDER BY message_id")
+        .all() as { message_id: string }[]
+    ).map((r) => r.message_id);
+    expect(tids).toEqual(["t_ok"]); // valid relocated; stale-dim skipped
+  });
+
+  test("re-arms the temporal re-chunk walk on cutover so skipped/legacy rows get re-embedded", () => {
+    // A stale done flag from a hypothetical prior state. The flag cannot actually
+    // latch in blob mode (see the ordering invariant in backfillTemporalEmbeddings),
+    // but the cutover must clear it regardless so a future refactor can never
+    // strand the post-cutover temporal walk — that walk is what recreates the
+    // stale-dim blobs this migration deliberately skips.
+    setKV("lore:temporal_rechunk.done", "1");
+    setKV("lore:temporal_rechunk.cursor", "some-old-cursor");
+    insKnowledge("k1");
+    db()
+      .query("UPDATE knowledge SET embedding = ? WHERE id='k1'")
+      .run(toBlob(v768(0)));
+    expect(readStorageMode(db())).toBe("blob");
+
+    maybeCutoverToVec0();
+
+    expect(readStorageMode(db())).toBe("vec0");
+    // Armed again: done cleared to "0", cursor reset to the start of the corpus.
+    expect(getKV("lore:temporal_rechunk.done")).toBe("0");
+    expect(getKV("lore:temporal_rechunk.cursor")).toBe("");
+  });
+
+  test("emits a single operator notice with the count SUMMED across tables", () => {
+    // Seed stale-dim (384-dim, 1536-byte) blobs in TWO different base tables so
+    // the notice must sum copyBlobsToVec0's per-table returns — a per-table-only
+    // count would report 1, not 2. Each table also gets a valid 768-dim row so
+    // the cutover relocates real data alongside the skips.
+    const stale = () => toBlob(new Float32Array(384));
+    insKnowledge("k_ok");
+    insKnowledge("k_stale");
+    insTemporal("t_ok", "s", 1);
+    insTemporal("t_stale", "s", 2);
+    db()
+      .query("UPDATE knowledge SET embedding = ? WHERE id='k_ok'")
+      .run(toBlob(v768(0)));
+    db()
+      .query("UPDATE knowledge SET embedding = ? WHERE id='k_stale'")
+      .run(stale());
+    db()
+      .query("UPDATE temporal_messages SET embedding = ? WHERE id='t_ok'")
+      .run(toBlob(v768(1)));
+    db()
+      .query("UPDATE temporal_messages SET embedding = ? WHERE id='t_stale'")
+      .run(stale());
+    expect(readStorageMode(db())).toBe("blob");
+
+    const noticeSpy = vi.spyOn(log, "notice").mockImplementation(() => {});
+    try {
+      maybeCutoverToVec0();
+      // Exactly one notice, carrying the SUM (2) across knowledge + temporal —
+      // not a per-table 1, and not silence (a forced sum of 0 would skip it).
+      expect(noticeSpy).toHaveBeenCalledTimes(1);
+      expect(noticeSpy.mock.calls[0][0]).toContain(
+        "2 stale-dimension embedding blob(s)",
+      );
+    } finally {
+      noticeSpy.mockRestore();
+    }
+    expect(readStorageMode(db())).toBe("vec0");
+  });
+
+  test("emits NO operator notice when the corpus has no stale-dim blobs", () => {
+    // Guards the `staleSkipped > 0` gate: a clean corpus must cut over silently.
+    insKnowledge("k_ok");
+    db()
+      .query("UPDATE knowledge SET embedding = ? WHERE id='k_ok'")
+      .run(toBlob(v768(0)));
+    expect(readStorageMode(db())).toBe("blob");
+
+    const noticeSpy = vi.spyOn(log, "notice").mockImplementation(() => {});
+    try {
+      maybeCutoverToVec0();
+      expect(noticeSpy).not.toHaveBeenCalled();
+    } finally {
+      noticeSpy.mockRestore();
+    }
+    expect(readStorageMode(db())).toBe("vec0");
   });
 });
 


### PR DESCRIPTION
Adversarial-review follow-ups to #1098 (which skips stale-dimension blobs during the blob → vec0 cutover instead of aborting the whole migration). #1098 was squash-merged before these landed; this is the same work stream, shipped separately.

No change to the guard's behavior — these harden observability and the recreation guarantee the reviewer flagged as SHOULD-FIX.

## Changes

1. **Observability** — `copyBlobsToVec0` now returns the number of stale-dimension blobs it skipped. `maybeCutoverToVec0` sums them across tables and emits a `log.notice` (always shown on stderr; `log.warn` is suppressed unless `LORE_DEBUG=1`). A rare real-corpus corruption is now visible to an operator instead of silently dropped.

2. **Hard-guard the recreation invariant** — explicitly call `resetTemporalRechunkProgress()` right after the blob → vec0 flip. It is a **no-op today** (the temporal re-chunk done-flag is structurally un-latchable in blob mode, since the vec0-mode guard returns before the done check), but calling it at the exact transition defends against a future refactor that could reorder those checks and strand the post-cutover walk — which is what recreates the rows the cutover skips. Documented the load-bearing "vec0 guard before done-check" ordering in `backfillTemporalEmbeddings`.

3. **Comment accuracy** — tightened the `copyBlobsToVec0` doc: recreation covers every **search-eligible** skipped row; rows outside a backfill's own eligibility filter (low-confidence knowledge, archived/empty distillations, sub-50-char temporal) merely lose an already-unsearchable stale vector (no search regression — a wrong-dim blob is unusable in every mode).

## Tests (both mutation-verified)

- `copyBlobsToVec0 returns the count of stale-dimension blobs it skipped` — 2 of 3 rows stale → returns 2, one valid row relocated. (Mutation: force count to 0 → fails.)
- `maybeCutoverToVec0 re-arms the temporal re-chunk walk on cutover` — sets a stale `done="1"`/cursor, runs the **real** `maybeCutoverToVec0()` at config dim 768, asserts `done→"0"`, `cursor→""`. (Mutation: remove the reset → fails.)

Full `@loreai/core` suite green (106 files, 2354 passed).

---

## Update (rebase + adversarial review)
- Rebased onto current `main` (was 18 commits behind; clean rebase, no conflicts).
- Adversarial pre-merge review across 9 focus areas → verdict **SHIP-WITH-FOLLOWUPS**, no BLOCKER. Count semantics, `knowledge_current` view-consistency, idempotence, mode monotonicity, `resetTemporalRechunkProgress()` placement (no-op today, blob-guarded so it can never wipe a live cursor), the ordering invariant, SQL safety, and the void→number caller ripple were all verified sound.
- Folded in its one SHOULD-FIX + two NITs:
  - The summed-count + `log.notice` path was untested (a mutation forcing the sum to 0 survived). Added two tests: one seeds stale-dim blobs in **two** tables and asserts a single notice carrying the **summed** count (2); one asserts a clean corpus cuts over **silently**. Mutation now killed.
  - Corrected a test comment that overclaimed "+ notice", and reworded the notice from "byte length != N dims" to "not N-dim / N*4 bytes".
