### PR TITLE
fix(core): preserve warm prefix caches across idle resume

### DIFF
--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -717,12 +717,18 @@ function getSessionState(sessionID: string): SessionState {
  * scored against the conversation context as it was on the previous turn,
  * which may have drifted significantly in N hours.
  *
- * On resume after `thresholdMs`:
+ * On resume after `thresholdMs` (cold cache — `skipCompact` false):
  *   - reset the distilled prefix cache (next turn re-renders from scratch)
  *   - reset the raw window pin cache (next turn picks a fresh cutoff)
  *   - set `cameOutOfIdle` so the OpenCode host can also clear `ltmSessionCache`
  *     and bypass the conversation-vs-LTM cost comparison in the LTM
  *     degraded-recovery branch
+ *
+ * When `skipCompact` is true the upstream cache is still warm, so the
+ * byte-identity caches (prefix, raw-window pin, distilled high-water, dedup
+ * memo) are PRESERVED — re-rendering/re-pinning them would bust the warm prefix
+ * the warmer paid to keep alive. `cameOutOfIdle` is still set (the host's LTM
+ * handling is unaffected) and `postIdleCompact` is left false.
  *
  * Importantly, this does NOT touch:
  *   - reasoning blocks (Anthropic's April 23 postmortem identifies dropping
@@ -737,12 +743,14 @@ function getSessionState(sessionID: string): SessionState {
  * Set `thresholdMs <= 0` to disable. Returns true if a reset fired so the
  * caller can log/observe.
  *
- * @param skipCompact  When true, perform all idle-resume housekeeping
- *   (clear caches, set cameOutOfIdle) but do NOT set postIdleCompact.
- *   Used when the caller knows the upstream prompt cache is still warm
- *   (e.g. cache warmer recently refreshed it) — compacting would produce
- *   a different prompt body that doesn't match the warmed prefix, causing
- *   a cache bust and wasting the warming cost.
+ * @param skipCompact  When true, the caller knows the upstream prompt cache is
+ *   still warm (e.g. the cache warmer recently refreshed it across the idle
+ *   gap). In that case onIdleResume PRESERVES the byte-identity caches (prefix,
+ *   raw-window pin, distilled high-water, dedup memo) and does NOT set
+ *   postIdleCompact — re-rendering the prefix or compacting would produce a
+ *   different prompt body that no longer matches the warmed prefix, busting the
+ *   cache and wasting the warming cost. It still drops the prewarm snapshot and
+ *   sets cameOutOfIdle. When false (cache provably cold) all caches are reset.
  */
 export function onIdleResume(
   sessionID: string,
@@ -755,15 +763,27 @@ export function onIdleResume(
   if (state.lastTurnAt === 0) return { triggered: false }; // first turn — nothing to refresh
   const idleMs = now - state.lastTurnAt;
   if (idleMs < thresholdMs) return { triggered: false };
-  state.prefixCache = null;
-  state.rawWindowCache = null;
-  // Cold cache → the prefix will be re-rendered/re-pinned, so drop the distilled
-  // high-water too (Bug 1, lever 1; same lifecycle as the raw-window pin).
-  state.distilledBudgetHighWater = 0;
+  // When the caller reports the upstream prompt cache is still warm
+  // (`skipCompact` — e.g. the cache warmer kept it alive across the idle gap),
+  // PRESERVE the byte-identity caches. Clearing them forces the next turn to
+  // re-render the distilled prefix (busts messages[0/1]) and re-pin the raw
+  // window (busts messages[2]) — throwing away the exact warm prefix the warmer
+  // paid to maintain, and turning a warm resume into a full cache write. Only
+  // when the cache is provably cold do we refresh them (a bust is unavoidable
+  // then, so we take the opportunity to fold in fresh distillations / re-pin).
+  if (!skipCompact) {
+    state.prefixCache = null;
+    state.rawWindowCache = null;
+    // Cold cache → the prefix will be re-rendered/re-pinned, so drop the distilled
+    // high-water too (Bug 1, lever 1; same lifecycle as the raw-window pin).
+    state.distilledBudgetHighWater = 0;
+    // Cache is cold after idle eviction — a fresh window will be rebuilt, so the
+    // stable-dedup memo can reset too (its purpose is warm-cache stability).
+    state.dedupDecisions.clear();
+  }
+  // The prewarm snapshot is a pure perf optimization (re-loaded on demand) and
+  // does not affect the frozen prefix bytes — safe to drop on any idle resume.
   state.distillationSnapshot = null;
-  // Cache is cold after idle eviction — a fresh window will be rebuilt, so the
-  // stable-dedup memo can reset too (its purpose is warm-cache stability).
-  state.dedupDecisions.clear();
   state.cameOutOfIdle = true;
   state.postIdleCompact = !skipCompact;
   return { triggered: true, idleMs };

--- a/packages/core/test/gradient.test.ts
+++ b/packages/core/test/gradient.test.ts
@@ -3548,7 +3548,7 @@ describe("onIdleResume", () => {
     expect(result.triggered).toBe(false);
   });
 
-  test("skipCompact=true skips postIdleCompact but still does housekeeping", () => {
+  test("skipCompact=true drops the snapshot, sets cameOutOfIdle, and skips compact", () => {
     const now = 1_000_000_000_000;
     setLastTurnAtForTest(SID, now - 2 * ONE_HOUR_MS);
 
@@ -3559,13 +3559,16 @@ describe("onIdleResume", () => {
     }
 
     const state = inspectSessionState(SID);
-    // Housekeeping still happens:
-    expect(state?.hasPrefixCache).toBe(false);
-    expect(state?.hasRawWindowCache).toBe(false);
-    expect(state?.cameOutOfIdle).toBe(true);
+    // Still-happening housekeeping on a warm resume: the prewarm snapshot is a
+    // perf-only artifact (re-loaded on demand), and the host's LTM handling
+    // still keys off cameOutOfIdle.
     expect(state?.distillationSnapshot).toBeNull();
-    // But compaction is skipped:
+    expect(state?.cameOutOfIdle).toBe(true);
+    // Compaction is skipped (cache is warm)...
     expect(state?.postIdleCompact).toBe(false);
+    // ...and the byte-identity caches are PRESERVED so the warm prefix survives.
+    // (Preservation of populated caches is proven end-to-end in the
+    // "distillation snapshot caching" describe; here nothing was populated.)
   });
 
   test("skipCompact=false (default) sets postIdleCompact when idle", () => {
@@ -3923,6 +3926,126 @@ describe("gradient — distillation snapshot caching", () => {
       .map((m) => m.parts.map((p) => ("text" in p ? p.text : "")).join())
       .join();
     expect(allText).toContain("Post-idle observation");
+  });
+
+  // Regression (warm idle resume): when the cache warmer keeps the upstream
+  // prompt cache alive across an idle gap, the caller passes skipCompact=true.
+  // The byte-identity caches (distilled prefix + raw-window pin) MUST survive so
+  // the next real turn replays the exact warm prefix. Clearing them re-renders
+  // messages[0/1] and re-pins the window at messages[2] — a full cache write
+  // that throws away the warming spend. This was the dominant divergence cause
+  // ("distilled conversation prefix changed (meta-distillation rewrite)").
+  test("warm idle resume (skipCompact) preserves the distilled prefix byte-for-byte", () => {
+    insertDistillation({
+      sessionID: SID,
+      observations: "- Warm-resume baseline observation",
+    });
+    const projectPath = `/test/${PID_KEY}`;
+    const messages1 = Array.from({ length: 16 }, (_, i) =>
+      makeMsg(
+        `warm-idle-${i}`,
+        i % 2 === 0 ? "user" : "assistant",
+        "X".repeat(1_000),
+        SID,
+      ),
+    );
+    setForceMinLayer(1, SID);
+    const result1 = transform({
+      messages: messages1,
+      projectPath,
+      sessionID: SID,
+    });
+    expect(result1.layer).toBeGreaterThanOrEqual(1);
+    expect(inspectSessionState(SID)?.hasPrefixCache).toBe(true);
+    expect(inspectSessionState(SID)?.hasRawWindowCache).toBe(true);
+
+    const prefixText1 = result1.messages
+      .filter((m) => m.info.id.startsWith("lore-distilled"))
+      .map((m) => m.parts.map((p) => ("text" in p ? p.text : "")).join())
+      .join();
+    expect(prefixText1).toContain("Warm-resume baseline observation");
+
+    // Background distillation lands during the idle gap.
+    insertDistillation({
+      sessionID: SID,
+      observations: "- Observation added while the user was idle",
+    });
+
+    // The warmer kept the cache alive → skipCompact=true. Caches must survive.
+    setLastTurnAtForTest(SID, Date.now() - 600_000);
+    const idle = onIdleResume(SID, 60_000, Date.now(), /* skipCompact */ true);
+    expect(idle.triggered).toBe(true);
+    expect(inspectSessionState(SID)?.hasPrefixCache).toBe(true);
+    expect(inspectSessionState(SID)?.hasRawWindowCache).toBe(true);
+
+    // Next turn appends a new user message; the frozen prefix must be
+    // byte-identical and must NOT fold in the idle-distilled row.
+    const messages2 = [
+      ...messages1,
+      makeMsg("warm-idle-return", "user", "Back after a break", SID),
+    ];
+    setForceMinLayer(1, SID);
+    const result2 = transform({
+      messages: messages2,
+      projectPath,
+      sessionID: SID,
+    });
+    const prefixText2 = result2.messages
+      .filter((m) => m.info.id.startsWith("lore-distilled"))
+      .map((m) => m.parts.map((p) => ("text" in p ? p.text : "")).join())
+      .join();
+    expect(prefixText2).toBe(prefixText1);
+    expect(prefixText2).not.toContain("while the user was idle");
+  });
+
+  // Companion guard: a provably-cold resume (skipCompact=false — no warmup kept
+  // the cache alive) must STILL reset the caches and fold in freshly-distilled
+  // rows. This guards against an over-eager "always preserve" regression.
+  test("cold idle resume (no skipCompact) resets caches and folds in new distillations", () => {
+    insertDistillation({
+      sessionID: SID,
+      observations: "- Cold-resume baseline observation",
+    });
+    const projectPath = `/test/${PID_KEY}`;
+    const messages1 = Array.from({ length: 16 }, (_, i) =>
+      makeMsg(
+        `cold-idle-${i}`,
+        i % 2 === 0 ? "user" : "assistant",
+        "X".repeat(1_000),
+        SID,
+      ),
+    );
+    setForceMinLayer(1, SID);
+    transform({ messages: messages1, projectPath, sessionID: SID });
+    expect(inspectSessionState(SID)?.hasPrefixCache).toBe(true);
+    expect(inspectSessionState(SID)?.hasRawWindowCache).toBe(true);
+
+    insertDistillation({
+      sessionID: SID,
+      observations: "- Observation added while the cache was cold",
+    });
+
+    // No warmup → cache provably cold → skipCompact=false (default).
+    setLastTurnAtForTest(SID, Date.now() - 600_000);
+    const idle = onIdleResume(SID, 60_000, Date.now(), /* skipCompact */ false);
+    expect(idle.triggered).toBe(true);
+    expect(inspectSessionState(SID)?.hasPrefixCache).toBe(false);
+    expect(inspectSessionState(SID)?.hasRawWindowCache).toBe(false);
+
+    const messages2 = [
+      ...messages1,
+      makeMsg("cold-idle-return", "user", "Back after a long break", SID),
+    ];
+    setForceMinLayer(1, SID);
+    const result2 = transform({
+      messages: messages2,
+      projectPath,
+      sessionID: SID,
+    });
+    const allText = result2.messages
+      .map((m) => m.parts.map((p) => ("text" in p ? p.text : "")).join())
+      .join();
+    expect(allText).toContain("while the cache was cold");
   });
 
   // Regression: loadDistillations orders by (created_at, id). Two rows written

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -6592,6 +6592,13 @@ async function handleConversationTurn(
   // is free and beneficial). Falls back to isCacheWarm when non-confident.
   const econ = getCacheStrategy(sessionID);
   const cacheWarm = decideSkipCompact(econ, isCacheWarm(sessionState));
+  // `cacheWarm` also tells onIdleResume to PRESERVE the byte-identity caches
+  // (distilled prefix + raw-window pin) so the warm prefix survives the resume.
+  // A false-positive here (isCacheWarm true but the warmed bytes actually
+  // diverged) is safe: preserving at worst defers folding idle-distilled rows
+  // into the prefix by one cold cycle — never a worse cache bust than clearing
+  // (both produce a full write on a genuine miss; the preserved body is ≤ the
+  // re-rendered one).
   const idleResult = onIdleResume(
     sessionID,
     thresholdMs,


### PR DESCRIPTION
## Problem

Investigating why cache-warmup costs far exceed savings (warmups net ≈ **−$113 / 2.5 days**, 78% of warmups landing as partial/uncached writes) turned up a shared root cause with the low prompt-cache hit rate (avg prefix match **70.6%**, hit **82.6%**, worst sessions 40–70%).

Production `lore.log` divergence reasons, ranked:

| count | reason |
|---|---|
| 619 | `distilled conversation prefix changed (meta-distillation rewrite)` → messages[0/1] front-bust |
| 327 | `new conversation message (normal turn progression)` (benign) |
| 262 | `earlier message modified at position 2 (window shift or content change)` → messages[2] |

## Root cause

`onIdleResume()` **always** cleared the byte-identity caches — `prefixCache`, `rawWindowCache`, `distilledBudgetHighWater`, `dedupDecisions` — even when the caller reported the upstream prompt cache was still warm (`skipCompact=true`, i.e. the cache warmer kept it alive across the idle gap; `decideSkipCompact` returns true only when `isCacheWarm` is true).

Clearing them forces the next real turn to:
- re-render the distilled prefix → **busts messages[0/1]** (the 619-turn "meta-distillation rewrite" reason), and
- re-pin the raw window → **busts messages[2]** (the 262-turn "position 2" reason).

So a *warm* resume becomes a full cache write, and the replayed warmup body no longer matches the re-rendered prefix → the warmup lands as a partial/uncached write. The two symptoms the investigation started from are the same bug.

## Fix

When `skipCompact` is true, **preserve** the byte-identity caches so the next turn replays the exact warm prefix. Only reset them when the cache is provably cold (`skipCompact=false`), where a bust is unavoidable anyway and folding in freshly-distilled rows is free. The prewarm snapshot (perf-only, re-loaded on demand) and the `cameOutOfIdle` / `postIdleCompact` flags are unchanged.

This extends the existing warm-freeze philosophy already in `distilledPrefixCached` (which freezes new gen-0 rows during a warm session) across a warm idle resume.

## Tests

- **Red-green**: `warm idle resume (skipCompact) preserves the distilled prefix byte-for-byte` — fails on the pre-fix code (verified by reverting the guard: prefix re-renders and folds in the idle-distilled row), passes after.
- **Companion guard**: `cold idle resume (no skipCompact) resets caches and folds in new distillations` — ensures we didn't over-freeze the cold path.
- Updated the existing unit test to the new contract (its old cache-cleared assertions were vacuous — the caches were never populated).
- Full core suite green (2364 tests), typecheck + lint clean.

## Scope

This is the first of a sequence (per plan): it eliminates the *expensive* warm-cache meta/window busts. Follow-ups: gate the compaction-path `distillation.run` with `skipMeta` while warm, reduce raw-window boundary hysteresis, fix the `messageCount` mislabel in divergence detection, then honest warmup accounting and an optional disable toggle.