### PR TITLE
refactor(core): share fetch-interceptor original-fetch via Symbol.for global

### DIFF
--- a/packages/core/src/fetch-interceptor.ts
+++ b/packages/core/src/fetch-interceptor.ts
@@ -315,13 +315,43 @@ export function shouldIntercept(url: string, gatewayBase: string): boolean {
  * Returns a cleanup function that restores the original `globalThis.fetch`.
  */
 /**
- * The original `globalThis.fetch` captured before any interceptor was
- * installed. The gateway (which may run in the same process) must use
- * this for its own upstream calls to avoid being intercepted in a loop.
+ * Process-global slot holding the original `globalThis.fetch` captured before
+ * any interceptor was installed. The gateway (which may run in the same
+ * process) must use this for its own upstream calls to avoid being intercepted
+ * in a loop.
  *
- * Null until `installFetchInterceptor()` is called.
+ * Keyed via `Symbol.for(...)` — a *process-global* registry — so that EVERY
+ * copy of this module in the process reads and writes the SAME handle, no
+ * matter how many times @loreai/core is bundled/instantiated (e.g. the
+ * OpenCode plugin's copy plus a copy inlined into the in-process gateway
+ * bundle). With a module-scoped variable instead, each copy keeps a private
+ * handle: one copy installs the interceptor (patching `globalThis.fetch`)
+ * while a second copy's `getOriginalFetch()` still reads `null` and falls back
+ * to `globalThis.fetch` — which IS the interceptor — producing an infinite
+ * request loop (gateway → interceptor → gateway → …). Sharing this handle is
+ * what makes it safe to inline core into the Bun bundle (issue #1027; see
+ * gateway `script/bundle.ts`).
+ *
+ * The slot is unset until `installFetchInterceptor()` is called, and released
+ * (set back to `null`) by its cleanup.
  */
-let _originalFetch: typeof globalThis.fetch | null = null;
+const ORIGINAL_FETCH_KEY = Symbol.for("lore.fetchInterceptor.originalFetch");
+
+/** Read the shared original-fetch handle. Returns `null` when unset. */
+function readOriginalFetchSlot(): typeof globalThis.fetch | null {
+  return (
+    (globalThis as Record<symbol, typeof globalThis.fetch | null | undefined>)[
+      ORIGINAL_FETCH_KEY
+    ] ?? null
+  );
+}
+
+/** Write (or, with `null`, release) the shared original-fetch handle. */
+function writeOriginalFetchSlot(fn: typeof globalThis.fetch | null): void {
+  (globalThis as Record<symbol, typeof globalThis.fetch | null>)[
+    ORIGINAL_FETCH_KEY
+  ] = fn;
+}
 
 /**
  * Return the original, un-intercepted `fetch` function.
@@ -334,7 +364,7 @@ let _originalFetch: typeof globalThis.fetch | null = null;
  * Returns `globalThis.fetch` if no interceptor has been installed.
  */
 export function getOriginalFetch(): typeof globalThis.fetch {
-  return _originalFetch ?? globalThis.fetch;
+  return readOriginalFetchSlot() ?? globalThis.fetch;
 }
 
 /**
@@ -390,15 +420,17 @@ function buildGatewayHeaders(
 export function installFetchInterceptor(
   config: FetchInterceptorConfig,
 ): () => void {
-  // Guard against double-install: if already installed, the second call
-  // would capture the *first* interceptor as _originalFetch, corrupting
-  // the chain. Return a no-op cleanup instead.
-  if (_originalFetch !== null) {
+  // Guard against double-install ACROSS ALL COPIES of this module in the
+  // process: a non-null shared slot means some copy already installed the
+  // interceptor. Installing again would capture the *first* interceptor as the
+  // "original", corrupting the chain (and, across copies, is the exact
+  // infinite-loop shape #1027 guards against). Return a no-op cleanup instead.
+  if (readOriginalFetchSlot() !== null) {
     return () => {};
   }
 
-  _originalFetch = globalThis.fetch;
-  const originalFetch = _originalFetch;
+  const originalFetch = globalThis.fetch;
+  writeOriginalFetchSlot(originalFetch);
 
   // Pre-parse the gateway URL once — avoids constructing a new URL object on
   // every fetch call in the process (tool executions, file downloads, etc.).
@@ -513,9 +545,10 @@ export function installFetchInterceptor(
   // on newer Node.js) so the patched function satisfies `typeof fetch`.
   globalThis.fetch = Object.assign(interceptor, originalFetch);
 
-  // Return cleanup function that restores the original fetch
+  // Return cleanup function that restores the original fetch and releases the
+  // shared slot so a later install can re-capture it.
   return () => {
     globalThis.fetch = originalFetch;
-    _originalFetch = null;
+    writeOriginalFetchSlot(null);
   };
 }

--- a/packages/core/test/fetch-interceptor-global.test.ts
+++ b/packages/core/test/fetch-interceptor-global.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Regression battery for the SHARED original-fetch handle (#1027).
+ *
+ * The fetch interceptor stores the pre-install `globalThis.fetch` in a
+ * process-global keyed by `Symbol.for(...)` so that EVERY copy of
+ * @loreai/core in the process agrees on the same original fetch — even when
+ * core is bundled/instantiated more than once (e.g. the OpenCode plugin's
+ * copy plus a copy inlined into the in-process gateway bundle).
+ *
+ * Without a shared handle, each module copy keeps a private module-scoped
+ * `_originalFetch`: one copy installs the interceptor (patching
+ * `globalThis.fetch`) while a second copy's `getOriginalFetch()` still reads
+ * `null` and falls back to `globalThis.fetch` — which IS the interceptor —
+ * producing an infinite request loop. These tests pin that invariant.
+ *
+ * Tests 3 and 4 load two *independent* module instances (via
+ * `vi.resetModules()` + dynamic import) to simulate the two-copies-in-one-
+ * process scenario. They FAIL against a module-scoped `_originalFetch` and
+ * PASS with the shared `Symbol.for` global.
+ */
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  installFetchInterceptor,
+  getOriginalFetch,
+} from "../src/fetch-interceptor";
+
+const ORIGINAL_FETCH_KEY = Symbol.for("lore.fetchInterceptor.originalFetch");
+const GATEWAY = "http://127.0.0.1:3207";
+const config = { gatewayBase: GATEWAY, getHeaders: () => ({}) };
+
+function slot(): unknown {
+  return (globalThis as Record<symbol, unknown>)[ORIGINAL_FETCH_KEY];
+}
+function clearSlot(): void {
+  delete (globalThis as Record<symbol, unknown>)[ORIGINAL_FETCH_KEY];
+}
+
+describe("fetch-interceptor — shared original-fetch global (#1027)", () => {
+  let trueOriginal: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    // Snapshot the live fetch (restored in afterEach) and start from a clean
+    // process-global slot so each test's install proceeds deterministically.
+    trueOriginal = globalThis.fetch;
+    clearSlot();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = trueOriginal;
+    clearSlot();
+  });
+
+  test("install captures the pre-install fetch into the shared Symbol.for slot", () => {
+    const cleanup = installFetchInterceptor(config);
+    try {
+      // The shared handle holds the REAL fetch, not the interceptor.
+      expect(slot()).toBe(trueOriginal);
+      // globalThis.fetch has been patched to the interceptor.
+      expect(globalThis.fetch).not.toBe(trueOriginal);
+      // getOriginalFetch reads the shared handle.
+      expect(getOriginalFetch()).toBe(trueOriginal);
+    } finally {
+      cleanup();
+    }
+    // Cleanup restores the live fetch and releases the shared handle.
+    expect(globalThis.fetch).toBe(trueOriginal);
+    expect(getOriginalFetch()).toBe(globalThis.fetch);
+  });
+
+  test("getOriginalFetch returns the real fetch, never the installed interceptor", () => {
+    const cleanup = installFetchInterceptor(config);
+    try {
+      const original = getOriginalFetch();
+      expect(original).toBe(trueOriginal);
+      // The crux: it must NOT resolve to globalThis.fetch (the interceptor),
+      // which would be self-referential and loop.
+      expect(original).not.toBe(globalThis.fetch);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("a second module copy resolves the same original fetch (cross-copy loop guard)", async () => {
+    // Two independently-evaluated module instances = two copies of core in
+    // one process. They share globalThis but have distinct module scopes.
+    vi.resetModules();
+    const modA = await import("../src/fetch-interceptor");
+    vi.resetModules();
+    const modB = await import("../src/fetch-interceptor");
+    // Sanity: genuinely distinct module instances.
+    expect(modB.installFetchInterceptor).not.toBe(modA.installFetchInterceptor);
+
+    const cleanup = modA.installFetchInterceptor(config);
+    try {
+      // Copy A patched globalThis.fetch to its interceptor.
+      expect(globalThis.fetch).not.toBe(trueOriginal);
+      // Copy B — separate module scope, empty private state — must still see
+      // the TRUE original via the shared global, not the interceptor. Under a
+      // module-scoped _originalFetch this returned globalThis.fetch (the
+      // interceptor) → infinite fetch loop.
+      expect(modB.getOriginalFetch()).toBe(trueOriginal);
+      expect(modB.getOriginalFetch()).not.toBe(globalThis.fetch);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("a second copy's install is a no-op while another copy owns the interceptor", async () => {
+    vi.resetModules();
+    const modA = await import("../src/fetch-interceptor");
+    vi.resetModules();
+    const modB = await import("../src/fetch-interceptor");
+
+    const cleanupA = modA.installFetchInterceptor(config);
+    try {
+      const interceptorA = globalThis.fetch;
+      expect(interceptorA).not.toBe(trueOriginal);
+
+      // Copy B must detect the shared slot is already set and NOT re-patch
+      // globalThis.fetch — re-patching would capture A's interceptor as B's
+      // "original", stacking a second interception layer.
+      const cleanupB = modB.installFetchInterceptor(config);
+      expect(globalThis.fetch).toBe(interceptorA); // unchanged by B
+      expect(modB.getOriginalFetch()).toBe(trueOriginal);
+
+      // B's cleanup is a no-op: it must not tear down A's interceptor nor
+      // release the shared handle A still owns.
+      cleanupB();
+      expect(globalThis.fetch).toBe(interceptorA);
+      expect(getOriginalFetch()).toBe(trueOriginal);
+    } finally {
+      cleanupA();
+    }
+    // Only A's cleanup restores; the process is back to the live fetch.
+    expect(getOriginalFetch()).toBe(globalThis.fetch);
+  });
+});


### PR DESCRIPTION
## What

Move the interceptor's captured original `globalThis.fetch` from a module-scoped `_originalFetch` to a **process-global** slot keyed by `Symbol.for("lore.fetchInterceptor.originalFetch")`, so every copy of `@loreai/core` in the process reads and writes the same handle.

## Why

This is the **prerequisite** for #1027 (inlining `@loreai/core` into the Bun bundle to drop the external-core dep + its ~480 MB ML tree). Today core is kept external specifically because a bundled gateway copy + the plugin copy would each keep a private module-scoped `_originalFetch`:

- Copy A (plugin) calls `installFetchInterceptor()` → patches `globalThis.fetch`, sets *its* `_originalFetch`.
- Copy B (gateway) calls `getOriginalFetch()` → reads *its own* `null` → returns `globalThis.fetch`, which **is** the interceptor → infinite request loop (gateway → interceptor → gateway → …).

The same split also defeats the double-install guard across copies (each copy's guard sees its own `null` and installs, stacking interceptors).

A single `Symbol.for` slot makes both copies agree, which is what makes two core copies safe.

## Change

- `fetch-interceptor.ts`: `_originalFetch` → shared slot via `readOriginalFetchSlot()` / `writeOriginalFetchSlot()` over `globalThis[Symbol.for(...)]`. `getOriginalFetch()`, the double-install guard, and cleanup all go through the shared slot.
- **Behavior is unchanged for the single-copy case** (all existing interceptor tests pass untouched).

## Tests

New `fetch-interceptor-global.test.ts` regression battery loads **two independent module instances** (`vi.resetModules()` + dynamic import) to simulate two core copies in one process:

1. install captures the pre-install fetch into the shared slot;
2. `getOriginalFetch()` returns the real fetch, never the interceptor;
3. **a second module copy resolves the same original fetch** (the cross-copy loop guard);
4. **a second copy's install is a no-op** while another copy owns the interceptor.

Tests 1/3/4 fail against the old module-scoped handle (verified by reverting the whole change). Per-line mutation checks: removing the slot read in `getOriginalFetch` kills all 4; removing the cross-copy install guard kills test 4.

Full `@loreai/core` (2368 passed) and `@loreai/gateway` (2442 passed) suites green. Typecheck + Biome clean.

## Follow-up

PR B will inline core into `index.bun.js`, drop the external-core dep, and flip the `bundle-exports.test.ts` #998 guards — that PR **closes #1027**.

Refs #1027