### PR TITLE
fix(core): checkpoint temporal re-chunk cursor per row + log backlog/progress

### DIFF
--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -2365,14 +2365,38 @@ export async function backfillTemporalEmbeddings(): Promise<number> {
 
   let cursor = getKV(TEMPORAL_RECHUNK_CURSOR_KEY) ?? "";
   let processed = 0;
+  let scanned = 0;
   // Resume point of the FIRST row that hit a transient error this pass. We keep
   // walking past it (so one hiccup never stalls the whole corpus) but rewind
   // here at the end so the next startup retries it rather than latching done
   // over the gap. Holds the cursor value from BEFORE that row (its predecessor),
   // so `id > retryFrom` re-includes the failed row.
   let retryFrom: string | null = null;
-  const PROGRESS_INTERVAL = 1000;
-  let nextProgressAt = PROGRESS_INTERVAL;
+
+  // Up-front backlog so a long walk is explainable from the logs. The corpus is
+  // 100k+ rows and, under embed-pool contention, converges at single-digit
+  // rows/min — without this line a multi-hour (or, across restarts, multi-day)
+  // walk is completely invisible. Counts rows still to scan from the resume
+  // cursor; runs once per process (the walk is one-shot per config).
+  const backlog = (
+    db()
+      .query(
+        `SELECT COUNT(*) AS n FROM temporal_messages
+         WHERE id > ? AND length(content) >= 50`,
+      )
+      .get(cursor) as { n: number }
+  ).n;
+  if (backlog > 0) {
+    log.info(
+      `temporal re-chunk: ${backlog} messages to scan${cursor ? " (resuming)" : ""}`,
+    );
+  }
+
+  // Wall-clock heartbeat rather than a per-N-rows milestone: at the observed
+  // throughput a 1000-row milestone can be hours away, so a time cadence keeps
+  // the walk visible regardless of speed.
+  const PROGRESS_INTERVAL_MS = 30_000;
+  let lastProgressAt = Date.now();
 
   for (;;) {
     // `length(content) >= 50` mirrors embedTemporalMessage's short-message skip,
@@ -2437,24 +2461,32 @@ export async function backfillTemporalEmbeddings(): Promise<number> {
         if (retryFrom === null) retryFrom = cursor;
       }
       cursor = row.id;
+      scanned++;
+
+      // Checkpoint after EVERY row, not once per page. At the observed
+      // throughput a 256-row page can take ~an hour; per-page checkpointing
+      // loses the whole page on any restart in that window, so on a machine
+      // that restarts more often than a page takes the walk never converges —
+      // it re-does the same leading rows forever. Once a row has failed this
+      // pass, pin the persisted cursor at the first failure (`retryFrom`) so a
+      // later crash still resumes there and retries it; the in-memory `cursor`
+      // keeps advancing so the current pass finishes the corpus. Re-doing a row
+      // is idempotent (storeTemporalChunks replaces the whole chunk set).
+      setKV(TEMPORAL_RECHUNK_CURSOR_KEY, retryFrom ?? cursor);
+
+      if (Date.now() - lastProgressAt >= PROGRESS_INTERVAL_MS) {
+        log.info(
+          `re-chunking temporal messages: ${processed} re-chunked, ${scanned} scanned…`,
+        );
+        lastProgressAt = Date.now();
+      }
     }
 
-    // Persist the page's end cursor. Once a row has failed this pass, pin the
-    // persisted cursor at the first failure (`retryFrom`) so a later stop or a
-    // crash still resumes there and retries it — the in-memory `cursor` keeps
-    // advancing so the current pass finishes the corpus. A crash mid-page redoes
-    // the page on the next run (idempotent via storeTemporalChunks).
-    setKV(TEMPORAL_RECHUNK_CURSOR_KEY, retryFrom ?? cursor);
     if (stop) break;
-
-    if (processed >= nextProgressAt) {
-      log.info(`re-chunking temporal messages: ${processed}…`);
-      nextProgressAt = processed + PROGRESS_INTERVAL;
-    }
   }
 
   if (processed > 0) {
-    log.info(`re-chunked ${processed} temporal messages`);
+    log.info(`re-chunked ${processed} temporal messages (${scanned} scanned)`);
   }
   return processed;
 }

--- a/packages/core/test/vec0-cutover.test.ts
+++ b/packages/core/test/vec0-cutover.test.ts
@@ -6,7 +6,7 @@
 // All run against the real vec0-capable test connection (the vendored sqlite-vec
 // loads in the node test runtime). The suite is skipped if the extension is
 // somehow unavailable so a vec-less CI lane stays green.
-import { afterAll, beforeEach, describe, expect, test } from "vitest";
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
 import { config } from "../src/config";
 import { close, db, ensureProject, getKV, setKV } from "../src/db";
 import { isVecAvailable } from "../src/db/vec";
@@ -35,10 +35,12 @@ import {
   backfillTemporalEmbeddings,
   checkConfigChange,
   embedTemporalMessage,
+  LocalProviderUnavailableError,
   MAX_TEMPORAL_CHUNKS_PER_MESSAGE,
   maybeCutoverToVec0,
   resetTemporalRechunkProgress,
 } from "../src/embedding";
+import * as log from "../src/log";
 import * as ltm from "../src/ltm";
 import { partsToText } from "../src/temporal";
 import type { LorePart } from "../src/types";
@@ -1223,6 +1225,15 @@ describeVec("temporal re-chunk backfill (backfillTemporalEmbeddings)", () => {
     "[tool:read] src/parse.ts",
   ];
 
+  // A single-unit message (one prose part, no reasoning/tool parts) comfortably
+  // over the 50-char embed floor, so each row triggers exactly ONE embed call —
+  // the per-embed cursor snapshots then line up one-to-one with rows.
+  const LONG = partsToText([
+    textPart(
+      "A single prose unit comfortably over the fifty character embed floor.",
+    ),
+  ]);
+
   function insTemporalContent(
     id: string,
     content: string,
@@ -1473,5 +1484,140 @@ describeVec("temporal re-chunk backfill (backfillTemporalEmbeddings)", () => {
       expect(await backfillTemporalEmbeddings()).toBe(0);
       expect(calls).toEqual([]);
     });
+  });
+
+  test("checkpoints the cursor after each row, not once per page (mid-page progress is durable)", async () => {
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    // Three single-unit rows land in one page (< TEMPORAL_RECHUNK_PAGE). Each
+    // embed call snapshots the persisted cursor: with per-row checkpointing,
+    // row K sees row K-1's id already durable; with per-page checkpointing all
+    // three snapshots would still be null (nothing is persisted until the page
+    // ends), so a restart mid-page would redo the whole page and — on a machine
+    // that restarts more often than a page takes — never converge.
+    insTemporalContent("r1", LONG);
+    insTemporalContent("r2", LONG);
+    insTemporalContent("r3", LONG);
+
+    const seen: (string | null)[] = [];
+    const token = _saveAndClearProvider();
+    try {
+      _restoreProvider({
+        provider: {
+          maxBatchSize: 8,
+          async embed(texts: string[]) {
+            seen.push(getKV(CURSOR_KEY));
+            return texts.map((_t, i) => v(1, i, 0, 0));
+          },
+        },
+      });
+      expect(await backfillTemporalEmbeddings()).toBe(3);
+    } finally {
+      _restoreProvider(token);
+    }
+
+    // By the time row K is embedded, row K-1's id is already durable.
+    expect(seen).toEqual([null, "r1", "r2"]);
+    expect(getKV(CURSOR_KEY)).toBe("r3");
+    expect(getKV(DONE_KEY)).toBe("1");
+  });
+
+  test("mid-page checkpoint pins at the retry point after a transient failure (crash-safe gap)", async () => {
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    insTemporalContent("p1", POISON); // transient-fails this pass
+    insTemporalContent("p2", LONG); // succeeds after the failure
+    insTemporalContent("p3", LONG); // succeeds
+
+    // Snapshot the persisted cursor at each embed. Once p1 fails, retryFrom is
+    // pinned at its predecessor (""), and EVERY subsequent per-row checkpoint
+    // must persist that retry point — not the advancing cursor — so a crash
+    // before the pass ends still resumes at the gap (p1) rather than skipping
+    // it. If the checkpoint wrote the bare `cursor`, p2/p3 would observe "p1"/
+    // "p2" and a crash would latch done over the un-retried gap.
+    const seen: (string | null)[] = [];
+    const token = _saveAndClearProvider();
+    try {
+      _restoreProvider({
+        provider: {
+          maxBatchSize: 8,
+          async embed(texts: string[]) {
+            seen.push(getKV(CURSOR_KEY));
+            if (texts.some((t) => t.includes("POISON"))) {
+              throw new Error("simulated remote 429");
+            }
+            return texts.map((_t, i) => v(1, i, 0, 0));
+          },
+        },
+      });
+      await backfillTemporalEmbeddings();
+    } finally {
+      _restoreProvider(token);
+    }
+
+    expect(seen).toEqual([null, "", ""]);
+    // End-of-pass rewind leaves the durable cursor at the gap, un-latched.
+    expect(getKV(CURSOR_KEY)).toBe("");
+    expect(getKV(DONE_KEY)).toBeNull();
+  });
+
+  test("a mid-page provider outage stops at the last completed row without latching done", async () => {
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    insTemporalContent("r1", LONG);
+    insTemporalContent("r2", LONG); // provider goes away on this row
+    insTemporalContent("r3", LONG);
+
+    // The per-row checkpoint moved WHERE the outage stop persists its cursor, so
+    // guard it directly: the break must fire before the row's cursor advance and
+    // before its checkpoint, leaving the durable cursor at the last COMPLETED row
+    // (r1) so the next startup resumes and retries the outage row — never latches
+    // done over the gap.
+    let call = 0;
+    const token = _saveAndClearProvider();
+    try {
+      _restoreProvider({
+        provider: {
+          maxBatchSize: 8,
+          async embed(texts: string[]) {
+            call++;
+            if (call === 2) throw new LocalProviderUnavailableError();
+            return texts.map((_t, i) => v(1, i, 0, 0));
+          },
+        },
+      });
+      expect(await backfillTemporalEmbeddings()).toBe(1); // only r1 completed
+    } finally {
+      _restoreProvider(token);
+    }
+
+    expect(getKV(CURSOR_KEY)).toBe("r1"); // not advanced past the outage row
+    expect(getKV(DONE_KEY)).toBeNull(); // walk didn't reach the end
+    expect(chunkIds("r1").length).toBe(1); // completed before the outage
+    expect(chunkIds("r2")).toEqual([]); // outage row — untouched
+    expect(chunkIds("r3")).toEqual([]); // never reached
+  });
+
+  test("logs the up-front backlog so a long walk is visible in the logs", async () => {
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    insTemporalContent("m1", MULTI);
+    insTemporalContent("m2", MULTI);
+    insTemporalContent("short", "tiny"); // < 50 chars — excluded from the count
+
+    const info = vi.spyOn(log, "info");
+    try {
+      await withProvider(async () => {
+        expect(await backfillTemporalEmbeddings()).toBe(2);
+      });
+      const lines = info.mock.calls.map((c: unknown[]) =>
+        c.map(String).join(" "),
+      );
+      expect(
+        lines.some((l) => /temporal re-chunk: 2 messages to scan/.test(l)),
+      ).toBe(true);
+    } finally {
+      info.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
## Problem

The temporal re-chunk walk (`backfillTemporalEmbeddings`, added in #1087) persisted its resume cursor **only once per 256-row page**. Under embed-pool contention the corpus re-chunks at single-digit rows/min, so one page can take **~an hour**. Any process restart in that window discards the whole page's in-memory progress — the persisted cursor never advanced. On a machine that restarts more often than a page takes to complete, the walk re-does the same leading rows forever and **never converges**.

At the same time the walk was operationally invisible: the only progress line fired every 1000 rows (hours away at this throughput), with no up-front signal that a large walk was even running.

## Changes (this PR = the first 2 of 3 requested changes)

1. **Per-row checkpoint** (`#1`) — persist the resume cursor after **every row**, not once per page. The persist still pins at `retryFrom` after a transient failure, so a crash mid-pass resumes at the retry gap and never latches `done` over it. Re-doing a row is idempotent (`storeTemporalChunks` replaces the whole chunk set). All resume/latch/rewind/give-up semantics are preserved exactly (verified by adversarial review + hand-trace of every path).
2. **Backlog + heartbeat logging** (`#3`) — log the up-front backlog (rows still to scan from the resume cursor) so a multi-hour / multi-day walk is explainable from the logs, and replace the per-1000-rows milestone with a **30s wall-clock heartbeat** so progress is visible regardless of throughput.

> Throttling the walk against live traffic (`#2`) ships as a **follow-up PR** — it's only safe *because* this PR makes progress durable (an idle-gated walk can now make incremental progress across restarts without losing work).

## Testing (red-green + mutation-verified)

Four new tests (all mutation-verified — reverting the fix makes each fail):
- **per-row checkpoint durability** — each embed snapshots the persisted cursor; per-row → `[null, "r1", "r2"]`. Per-page mutation → `[null, null, null]` (killed).
- **`retryFrom` pinning survives crash-after-transient-error** — after a transient failure every checkpoint persists the retry point, not the advancing cursor. `setKV(cursor)` mutation → observes advancing ids (killed).
- **mid-page provider outage** (`LocalProviderUnavailableError`) — stops at the last *completed* row, no `done` latch, outage row retried next startup. Mutation advancing the cursor past the outage row (killed).
- **up-front backlog line** emitted with the correct count (excludes <50-char rows). Drop-`length>=50` mutation (killed).

Full core suite: **108 files, 2367 passed, 0 failed**. Typecheck + Biome clean. All 10 pre-existing `backfillTemporalEmbeddings` tests pass unchanged (behavior parity).

An adversarial correctness-review pass returned **MERGE** — full resume/latch parity, all new tests mutation-tight; the only follow-up it raised (stop-path coverage) is included here.