### PR TITLE
fix(gateway): credit warmup hits pro-rata, not the full refreshed prefix

### DIFF
--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -2258,12 +2258,17 @@ export type WarmupHitOutcome = {
  * along in a restored/inherited warmupState blob, booking savings against a
  * session whose warmup cost lives elsewhere.
  *
- * 🔴 Savings token source (Bug B): when a hit is credited, the caller MUST
- * use `creditedTokens` (the prefix the warmup refreshed), NOT the returning
- * turn's cacheReadInputTokens — which is often ~10× smaller (tool-use
- * continuation / breakpoint shift). Known residual: when the returning turn
- * reads only PART of the warmed prefix (0 < read < refreshTokens), the full
- * `refreshTokens` is still credited — the gate below is binary, not pro-rata.
+ * 🔴 Savings token source (Bug B — pro-rata): when a hit is credited, the
+ * savings equal the tokens the returning turn ACTUALLY read from the warmed
+ * prefix, capped at what the warmup refreshed: `min(cacheReadTokens,
+ * refreshTokens)`. Unconditionally crediting the full `refreshTokens`
+ * overstated savings whenever the returning turn diverged from the warmed
+ * prefix and read only part of it (0 < read < refreshTokens) — e.g. a
+ * breakpoint shift or tool-use continuation — which inflated warmup ROI and
+ * warped the hit-rate gate for future warming. The cap also prevents crediting
+ * the warmup for reads it did not cause (read > refreshTokens from normal turn
+ * caching). A full-prefix read (read >= refreshTokens) still credits the full
+ * refreshTokens, so the common well-behaved case is unchanged.
  *
  * 🔴 Read-confirmation guard (Bug C): a hit is ONLY attributed when the
  * returning turn ACTUALLY READ the warmed cache (`cacheReadTokens > 0`). The
@@ -2315,7 +2320,12 @@ export function creditWarmupHit(
   if (cacheReadTokens <= 0) return noHit;
 
   warmup.warmupHits++;
-  return { hit: true, creditedTokens: refreshTokens };
+  // Pro-rata (Bug B): realized savings = what this turn actually read from the
+  // warmed prefix, capped at what the warmup refreshed. See the docstring.
+  return {
+    hit: true,
+    creditedTokens: Math.min(cacheReadTokens, refreshTokens),
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -2270,6 +2270,14 @@ export type WarmupHitOutcome = {
  * caching). A full-prefix read (read >= refreshTokens) still credits the full
  * refreshTokens, so the common well-behaved case is unchanged.
  *
+ * Residual (unavoidable): Anthropic reports only an AGGREGATE
+ * `cache_read_input_tokens`, not a per-breakpoint split. If the returning turn
+ * reads a small slice of the warmed prefix PLUS a separately-cached block whose
+ * combined total is still <= refreshTokens, the whole read is attributed to the
+ * warmup even though part of it wasn't the warmed prefix. The cap only rules out
+ * over-attribution when the aggregate read EXCEEDS refreshTokens. This is still
+ * strictly closer to reality than crediting the full refreshTokens.
+ *
  * 🔴 Read-confirmation guard (Bug C): a hit is ONLY attributed when the
  * returning turn ACTUALLY READ the warmed cache (`cacheReadTokens > 0`). The
  * warmup refreshes the prefix, but the returning turn can pivot to a different

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -4970,9 +4970,9 @@ function postResponse(
             sessionState.lastUpstream?.model ?? req.model,
             sessionState.resolvedConversationTTL ?? "5m",
           );
-          // Record counterfactual savings against the prefix the WARMUP
-          // refreshed — without warming these reads would have been a full
-          // cache write.
+          // Record counterfactual savings = the pro-rata credit
+          // min(returning-turn cache read, prefix the warmup refreshed) —
+          // without warming these reads would have been a full cache write.
           if (outcome.creditedTokens > 0) {
             recordWarmupHit(
               sessionID,
@@ -4984,7 +4984,7 @@ function postResponse(
           log.info(
             `cache-warmer: HIT session=${sessionID.slice(0, 16)} ` +
               `user returned ${(sinceWarmup / 1000).toFixed(0)}s after warmup ` +
-              `(refreshed=${outcome.creditedTokens} tokens)`,
+              `(credited=${outcome.creditedTokens} tokens)`,
           );
         }
       }

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -4952,8 +4952,8 @@ function postResponse(
       // Track warmup hit: user returned after THIS session warmed the cache.
       // creditWarmupHit consumes the warmup (clears lastWarmupAt + refresh
       // tokens), guards against phantom savings (Bug A: only credits when this
-      // session paid for the warmup), and returns the prefix the warmup
-      // refreshed for savings (Bug B: NOT the returning turn's smaller read).
+      // session paid for the warmup), and returns the pro-rata savings
+      // (Bug B: min(returning-turn cache read, prefix the warmup refreshed)).
       if (sessionState.warmup?.lastWarmupAt) {
         const ttlMs =
           sessionState.resolvedConversationTTL === "1h" ? 3_600_000 : 300_000;

--- a/packages/gateway/test/cache-warmer.test.ts
+++ b/packages/gateway/test/cache-warmer.test.ts
@@ -3522,12 +3522,33 @@ describe("creditWarmupHit", () => {
     };
   }
 
-  test("credits a hit using the warmup's refreshed prefix tokens (Bug B)", () => {
+  test("full-prefix read credits the full refreshed prefix (Bug B)", () => {
     const warmup = makeWarmup({ lastWarmupRefreshTokens: 168_000 });
+    // Returning turn read the ENTIRE warmed prefix → full credit.
     const outcome = creditWarmupHit(warmup, 30_000, 300_000, 168_000);
     expect(outcome.hit).toBe(true);
-    // Savings must be credited against the prefix the WARMUP refreshed,
-    // NOT a (smaller) returning-turn read.
+    expect(outcome.creditedTokens).toBe(168_000);
+    expect(warmup.warmupHits).toBe(1);
+  });
+
+  test("partial read credits pro-rata, not the full refreshed prefix (Bug B)", () => {
+    // The returning turn diverged from the warmed prefix (breakpoint shift /
+    // tool-use continuation) and only read 42K of the 168K warmup. Realized
+    // savings are 42K — crediting the full 168K would overstate ROI.
+    const warmup = makeWarmup({ lastWarmupRefreshTokens: 168_000 });
+    const outcome = creditWarmupHit(warmup, 30_000, 300_000, 42_000);
+    expect(outcome.hit).toBe(true);
+    expect(outcome.creditedTokens).toBe(42_000);
+    expect(warmup.warmupHits).toBe(1);
+  });
+
+  test("read larger than the warmed prefix is capped at refreshTokens (Bug B)", () => {
+    // The turn read 200K (extra came from normal turn caching, not the warmup).
+    // The warmup only refreshed 168K, so credit is capped there — never credit
+    // the warmup for reads it did not cause.
+    const warmup = makeWarmup({ lastWarmupRefreshTokens: 168_000 });
+    const outcome = creditWarmupHit(warmup, 30_000, 300_000, 200_000);
+    expect(outcome.hit).toBe(true);
     expect(outcome.creditedTokens).toBe(168_000);
     expect(warmup.warmupHits).toBe(1);
   });
@@ -3602,11 +3623,11 @@ describe("creditWarmupHit", () => {
 
   test("credits a hit when the returning turn DID read the warmed cache (cacheRead>0)", () => {
     // Positive case for the cacheRead gate — when the returning turn reads
-    // any amount of the warmed prefix, we credit as before.
+    // any amount of the warmed prefix, we credit a (pro-rata) hit.
     const warmup = makeWarmup({ lastWarmupRefreshTokens: 168_000 });
     const outcome = creditWarmupHit(warmup, 30_000, 300_000, 42_000);
     expect(outcome.hit).toBe(true);
-    expect(outcome.creditedTokens).toBe(168_000);
+    expect(outcome.creditedTokens).toBe(42_000);
     expect(warmup.warmupHits).toBe(1);
   });
 });


### PR DESCRIPTION
## Problem

`creditWarmupHit()` credited the **full** prefix a warmup refreshed (`refreshTokens`) on any confirmed hit — even when the returning turn diverged from the warmed prefix and only read part of it. The docstring already flagged this as a known residual:

> Known residual: when the returning turn reads only PART of the warmed prefix (0 < read < refreshTokens), the full `refreshTokens` is still credited — the gate below is binary, not pro-rata.

This overstates warmup savings and warps the hit-rate / ROI gate (`MIN_SESSION_HIT_RATE`) that decides whether to keep warming a session. In the production logs behind the cost investigation, credited warmup "savings" (`refreshed=N`) far exceeded the returning turns' actual cache reads, so warming kept firing on sessions where it was net-negative (≈ **−$113 / 2.5 days**, 78% of warmups landing as partial/uncached writes).

## Fix

Credit `min(cacheReadTokens, refreshTokens)`:
- **Full-prefix read** (`read >= refreshTokens`) → full `refreshTokens` (common well-behaved case, unchanged).
- **Partial read** (`0 < read < refreshTokens`, e.g. breakpoint shift / tool-use continuation) → credit only the realized savings.
- **Over-read** (`read > refreshTokens`, extra from normal turn caching) → capped at `refreshTokens`, so the warmup is never credited for reads it didn't cause.

The pipeline call site already threads the returning turn's `cache_read_input_tokens` (the Bug C gate), so **no call-site change** is needed. This refines Bug B (keeps `refreshTokens` as the cap) rather than reverting it.

## Tests

- `full-prefix read credits the full refreshed prefix` (168K read of 168K → 168K).
- `partial read credits pro-rata` (42K read of 168K → **42K**, was 168K) — red-green verified (fails on the pre-fix code).
- `read larger than the warmed prefix is capped at refreshTokens` (200K read, 168K warmup → 168K).
- Updated the existing partial-read positive case to the pro-rata contract.
- cache-warmer + cost-tracker-accumulation + warmup-execute suites green (226 tests); typecheck + lint clean.

## Context

Phase 2 of the warmup cost-overhead plan (Phase 1 = #1102, preserve warm prefix caches across idle resume). Makes the warmup accounting honest so the ROI gate reflects reality; a follow-up will surface `warmupNet = warmupSavings − warmup.cost` on the dashboard.