### PR TITLE
perf(gateway): inline @loreai/core into the Bun bundle, drop external-core dep

### DIFF
--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -27,7 +27,6 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@loreai/core": "workspace:*",
     "@supabase/supabase-js": "^2.58.0",
     "google-auth-library": "^10.9.0",
     "p-limit": "7",
@@ -69,6 +68,7 @@
   ],
   "author": "BYK",
   "devDependencies": {
+    "@loreai/core": "workspace:*",
     "@sentry/bun": "^10.52.0",
     "@types/bun": "^1.2.0",
     "@types/qrcode-terminal": "^0.12.2",

--- a/packages/gateway/script/bundle.ts
+++ b/packages/gateway/script/bundle.ts
@@ -134,27 +134,29 @@ await esbuild.build({
   target: "esnext",
   platform: "node",
   conditions: ["bun"],
-  // @loreai/core MUST be external in the Bun ESM bundle. When the gateway
-  // runs in-process alongside the OpenCode plugin, both must share a single
-  // module instance of @loreai/core — specifically the _originalFetch
-  // variable in fetch-interceptor.ts. If core is bundled into the gateway,
-  // installFetchInterceptor() (called by the plugin) sets _originalFetch
-  // on the plugin's copy while getOriginalFetch() (called by the gateway)
-  // reads from the bundled copy (always null → returns globalThis.fetch =
-  // the interceptor). This creates an infinite request loop: gateway →
-  // interceptor → gateway → interceptor → …
+  // @loreai/core is INLINED into the Bun ESM bundle (like the CJS bundle).
   //
-  // `undici` is external (and lazily imported only on the Node path in
+  // History: core used to be kept external here so the OpenCode plugin's copy
+  // of core and the in-process gateway's copy shared ONE module instance —
+  // specifically the `_originalFetch` handle in fetch-interceptor.ts. With two
+  // separate copies, installFetchInterceptor() (plugin) would set its copy's
+  // handle while getOriginalFetch() (gateway) read the other copy's null and
+  // fell back to globalThis.fetch = the interceptor → infinite request loop.
+  // Externalizing core is also what forced it to be a runtime dependency
+  // (#1024), dragging core's ~480 MB ML tree into raw-npm gateway installs.
+  //
+  // That invariant now lives in a process-global: fetch-interceptor.ts stores
+  // the original fetch under Symbol.for("lore.fetchInterceptor.originalFetch"),
+  // so every copy of core in the process agrees on one handle regardless of how
+  // many times core is bundled/instantiated (#1027). Inlining is therefore
+  // safe — and removes the external-core dep + its transitive weight.
+  //
+  // `undici` stays external (and is lazily imported only on the Node path in
   // fetch.ts) so it is never bundled or evaluated under Bun — real undici@7
   // hangs on streaming response reads under Bun, so the Bun path uses native
-  // fetch instead and never touches undici.
-  //
-  // NOTE: undici is external here but only a devDependency — the same shape
-  // that broke @loreai/core in #998. It stays safe ONLY because the Bun path
-  // never imports it (the undici import is Node-only and lazy). If the Bun
-  // path ever imports undici, it must become a runtime dependency. By
-  // contrast, @loreai/core IS imported under Bun, so it is a runtime
-  // dependency (guarded by test/bundle-exports.test.ts).
+  // fetch instead and never touches undici. It is safe as a devDependency ONLY
+  // because the Bun path never imports it (the undici import is Node-only and
+  // lazy); if the Bun path ever imports undici, it must become a runtime dep.
   external: [
     "bun:*",
     "node:*",
@@ -162,7 +164,6 @@ await esbuild.build({
     "onnxruntime-node",
     "sharp",
     "sqlite-vec",
-    "@loreai/core",
   ],
   outfile: join(distDir, "index.bun.js"),
   sourcemap: false,

--- a/packages/gateway/test/bundle-exports.test.ts
+++ b/packages/gateway/test/bundle-exports.test.ts
@@ -58,39 +58,39 @@ describe.skipIf(!hasBundle)("bundle exports", () => {
   // (regression guard for issue #998)
   // -------------------------------------------------------------------------
 
-  test("externalized @loreai/* imports in the Bun bundle are runtime deps", () => {
-    // The Bun ESM bundle keeps @loreai/core external on purpose (see
-    // script/bundle.ts) so the plugin and the in-process gateway share one
-    // module instance of @loreai/core. For that external import to resolve in
-    // published / standalone installs (e.g. OpenCode's embedded Bun loading
-    // the plugin directly), every externalized @loreai/* package MUST be a
-    // runtime dependency — not a devDependency, which consumers never install.
-    // Issue #998 regressed exactly this: @loreai/core was external + devDep.
+  test("@loreai/core is inlined (not externalized) in the Bun bundle (#1027)", () => {
+    // The Bun ESM bundle now INLINES @loreai/core (see script/bundle.ts): the
+    // shared-original-fetch invariant moved to a Symbol.for process-global, so
+    // multiple core copies in one process are safe and there is no longer a
+    // reason to keep core external. Inlining is what lets us drop the
+    // external-core runtime dep and its ~480 MB ML tree (#1024/#1026).
     const content = readFileSync(join(distDir, "index.bun.js"), "utf8");
 
-    // Dev shim (`export * from "../src/index.ts";`) does not exercise the
-    // externalized-core artifact, so there is nothing to assert. The real
-    // minified bundle is present under `pnpm test` because the root `pretest`
-    // runs `pnpm --filter @loreai/gateway run bundle`.
+    // Dev shim (`export * from "../src/index.ts";`) is not the real artifact,
+    // so there is nothing to assert. The real minified bundle is present under
+    // `pnpm test` because the root `pretest` runs
+    // `pnpm --filter @loreai/gateway run bundle`.
     if (content.trimStart().startsWith("export *")) return;
 
     // Match import CONTEXTS only — static `from "@loreai/x"` and dynamic
     // `import("@loreai/x")`. A bare-string scan would false-match the bundle's
     // embedded package.json (self-name "@loreai/gateway") and the doctor/setup
-    // string literals mentioning "@loreai/opencode"; requiring those as deps
-    // would be a self-dependency or a dependency cycle.
+    // string literals mentioning "@loreai/opencode".
     const importContext = /(?:from|import)\s*\(?\s*["'](@loreai\/[\w-]+)["']/g;
     const specifiers = new Set<string>();
     for (const match of content.matchAll(importContext)) {
       specifiers.add(match[1]);
     }
 
-    // Non-vacuous guard: @loreai/core is externalized by design (the shared
-    // _originalFetch invariant), so the scan must actually find it. If this
-    // ever fails, either the bundle stopped externalizing core (revisit the
-    // fetch-loop invariant in script/bundle.ts) or the regex needs updating.
-    expect(specifiers.has("@loreai/core")).toBe(true);
+    // Non-vacuous guard: core must be INLINED — the scan must NOT find it as an
+    // import specifier. If this fails, the bundle regressed to externalizing
+    // core, which would reintroduce the external-core runtime dependency and
+    // the shared-instance fetch-loop concern (revisit script/bundle.ts +
+    // fetch-interceptor.ts's Symbol.for global before changing this).
+    expect(specifiers.has("@loreai/core")).toBe(false);
 
+    // Any @loreai/* that IS still externalized (none today) must be a declared
+    // runtime dependency so it resolves in published installs (the #998 shape).
     const deps = (pkgJson.dependencies ?? {}) as Record<string, string>;
     for (const specifier of specifiers) {
       expect(
@@ -109,11 +109,17 @@ describe.skipIf(!hasBundle)("bundle exports", () => {
 // only the bun shim exists).
 // ---------------------------------------------------------------------------
 
-describe("dependency manifest invariants (#998)", () => {
-  test("@loreai/core is a runtime dependency, not a devDependency", () => {
+describe("dependency manifest invariants (#998, #1027)", () => {
+  test("@loreai/core is a build-only devDependency of gateway (inlined, #1027)", () => {
     // The on-disk source manifest — NOT the copy embedded in the bundle text.
-    expect(pkgJson.dependencies?.["@loreai/core"]).toBeDefined();
-    expect(pkgJson.devDependencies?.["@loreai/core"]).toBeUndefined();
+    // gateway inlines core into BOTH bundles (script/bundle.ts), so the
+    // published package never imports @loreai/core at runtime. It must NOT be a
+    // runtime dependency (that dragged core's ~480 MB ML tree into raw-npm
+    // gateway installs — #1024/#1026); it stays a devDependency because the
+    // bundle build needs core's source. Contrast opencode/pi below, which
+    // import core at runtime and therefore MUST keep it as a runtime dep.
+    expect(pkgJson.dependencies?.["@loreai/core"]).toBeUndefined();
+    expect(pkgJson.devDependencies?.["@loreai/core"]).toBe("workspace:*");
   });
 
   // Internal packages each consumer imports at RUNTIME. #998 happened in the
@@ -121,8 +127,10 @@ describe("dependency manifest invariants (#998)", () => {
   // @loreai/core), so presence — not just spec correctness — is asserted for
   // every link. devDependencies are never installed for a transitively-
   // consumed published package, which is exactly how #998 manifested.
+  //
+  // gateway is intentionally ABSENT here: it inlines core (build-only devDep,
+  // #1027), so it has no internal @loreai/* runtime dependency to guard.
   const requiredInternalDeps: Record<string, string[]> = {
-    gateway: ["@loreai/core"],
     opencode: ["@loreai/core", "@loreai/gateway"],
     pi: ["@loreai/core", "@loreai/gateway"],
   };
@@ -163,21 +171,25 @@ describe("dependency manifest invariants (#998)", () => {
   });
 
   test("internal @loreai/* deps use workspace:* across gateway, opencode, pi", () => {
-    // A single shared @loreai/core instance is only guaranteed when every
-    // consumer references the internal packages at the same version.
-    // `workspace:*` is rewritten to the exact release version at `pnpm pack`
-    // time, keeping all packages unified per release. A pinned/divergent
-    // version could install two @loreai/core copies → two _originalFetch
-    // values → infinite fetch loop (gateway → interceptor → gateway → …).
-    for (const name of Object.keys(requiredInternalDeps)) {
+    // Every internal @loreai/* reference — runtime OR build-only — must be
+    // `workspace:*`, which `pnpm pack` rewrites to the exact release version so
+    // all packages stay unified per release. Checks devDependencies too so
+    // gateway's build-only core reference (#1027) is covered. (The old
+    // "two copies → two _originalFetch → fetch loop" rationale no longer
+    // applies: the handle is a Symbol.for process-global shared by all copies.)
+    for (const name of ["gateway", "opencode", "pi"]) {
       const manifest = JSON.parse(
         readFileSync(join(packageDir, "..", name, "package.json"), "utf8"),
       ) as {
         name: string;
         dependencies?: Record<string, string>;
+        devDependencies?: Record<string, string>;
       };
-      const deps = manifest.dependencies ?? {};
-      for (const [dep, spec] of Object.entries(deps)) {
+      const allDeps = {
+        ...(manifest.dependencies ?? {}),
+        ...(manifest.devDependencies ?? {}),
+      };
+      for (const [dep, spec] of Object.entries(allDeps)) {
         if (dep.startsWith("@loreai/")) {
           expect(spec, `${manifest.name} → ${dep}`).toBe("workspace:*");
         }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,9 +99,6 @@ importers:
 
   packages/gateway:
     dependencies:
-      '@loreai/core':
-        specifier: workspace:*
-        version: link:../core
       '@supabase/supabase-js':
         specifier: ^2.58.0
         version: 2.108.1
@@ -121,6 +118,9 @@ importers:
         specifier: 0.1.9
         version: 0.1.9
     devDependencies:
+      '@loreai/core':
+        specifier: workspace:*
+        version: link:../core
       '@sentry/bun':
         specifier: ^10.52.0
         version: 10.56.0


### PR DESCRIPTION
Closes #1027. Builds on #1103 (the `Symbol.for` shared original-fetch global).

## What

Inline `@loreai/core` into the gateway's Bun ESM bundle (`index.bun.js`) — like the CJS bundle already does — and stop declaring core as a runtime dependency of `@loreai/gateway`.

## Why

The Bun bundle kept `@loreai/core` **external** for one reason: the OpenCode plugin's copy of core and the in-process gateway had to share one module instance of the `_originalFetch` handle. Externalizing core is what forced it to be a **runtime dependency** (#1024), which dragged core's ~480 MB ML tree (`onnxruntime-node`, `@huggingface/transformers`, `onnxruntime-web`) into every raw-npm `@loreai/gateway` install (#1026), and was the external-resolution fragility behind #998.

#1103 moved the original-fetch handle to a `Symbol.for("lore.fetchInterceptor.originalFetch")` process-global, so **all copies of core in a process share one handle**. Two core copies are now safe → there's no longer a reason to externalize core.

## Change

- **`script/bundle.ts`**: drop `@loreai/core` from the Bun bundle's `external` list; rewrite the invariant comment to point at the Symbol.for global. `undici` stays external/lazy (unchanged).
- **`package.json`**: move `@loreai/core` from `dependencies` → `devDependencies`. It's now needed **only at build time** to produce the inlined bundle; the published package never imports it at runtime. This removes the transitive ML weight from raw-npm gateway installs.
- **`test/bundle-exports.test.ts`** (#998 guards): 
  - flip the non-vacuous scan to assert core is **inlined** (`specifiers.has("@loreai/core") === false`);
  - assert core is a **build-only devDep** for gateway (not a runtime dep);
  - keep the full #998 runtime-dep guards for **opencode/pi**, which still import core+gateway at runtime;
  - the `workspace:*` guard now also covers devDependencies (so gateway's build-only core ref is checked).

## Verification

- `index.bun.js`: no `@loreai/core` import context; the inlined core carries the Symbol.for global (`lore.fetchInterceptor.originalFetch`). Bun bundle still uses `bun:sqlite` and keeps `sqlite-vec`/`undici` external.
- `bundle-exports.test.ts`: 7/7 green. Mutation-verified: re-externalizing core (rebuild) fails the "inlined" guard; moving core back to `dependencies` fails the "build-only devDep" guard.
- Gateway typecheck + Biome clean.

## Effect

`npm install @loreai/gateway` no longer pulls core's ~480 MB ML runtime. The SEA binary and the plugin/pi paths are unaffected (they build/consume core independently).