### PR TITLE
feat(gateway): idle-gate the temporal re-chunk backfill against live traffic

### DIFF
--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -1869,7 +1869,24 @@ function emptyBackfillStats(): BackfillStats {
   };
 }
 
-export async function runStartupBackfill(): Promise<BackfillStats> {
+/** Host-supplied knobs for {@link runStartupBackfill}. */
+export interface BackfillOptions {
+  /**
+   * Idle-gate for the heavy, resumable temporal re-chunk walk. Consulted before
+   * each row; while it returns `true` the walk parks (re-polling) and resumes
+   * once it clears. `@loreai/core` has no view of host activity, so the host
+   * supplies the policy — the gateway pauses while background work is paused
+   * (circuit breaker) or a session was active within the idle window. Progress
+   * is durable per-row, so a long park just resumes later from the last
+   * checkpoint. Only the temporal walk is gated; the small knowledge/
+   * distillation/entity backfills run unthrottled.
+   */
+  shouldPause?: () => boolean;
+}
+
+export async function runStartupBackfill(
+  opts: BackfillOptions = {},
+): Promise<BackfillStats> {
   if (!isAvailable()) return emptyBackfillStats();
 
   // Handle an embedding-config change, then attempt the one-time blob→vec0
@@ -1927,8 +1944,11 @@ export async function runStartupBackfill(): Promise<BackfillStats> {
   const entityEmbedded = await backfillEntityEmbeddings();
   // Re-chunk pre-multi-vector temporal survivors into the vec0 layout. Resumable
   // + done-flagged, so this is the heavy walk only on the first vec0 run (and
-  // again after a config change); a no-op in blob mode and once converged.
-  const temporalRechunked = await backfillTemporalEmbeddings();
+  // again after a config change); a no-op in blob mode and once converged. Idle-
+  // gated (opts.shouldPause) so it yields the shared embed pool to live traffic.
+  const temporalRechunked = await backfillTemporalEmbeddings({
+    shouldPause: opts.shouldPause,
+  });
 
   // Startup backstop: reclaim vec0 rows orphaned by bulk base-row deletes
   // (project/session/prune) since the last run. Harmless if there are none.
@@ -2305,6 +2325,47 @@ const TEMPORAL_RECHUNK_PAGE = 256;
  * forever (it keeps its legacy single vector + FTS, so recall still works).
  */
 const MAX_TEMPORAL_RECHUNK_RETRY_PASSES = 3;
+/**
+ * Poll interval while the temporal walk is parked waiting for the host to go
+ * idle. Short enough to resume promptly once traffic stops; a parked walk is
+ * otherwise idle (one predicate call + one timer per tick).
+ */
+const TEMPORAL_RECHUNK_PAUSE_POLL_MS = 250;
+
+/**
+ * Park while the host-supplied idle-gate says to defer to live traffic. Returns
+ * as soon as the gate clears (or immediately if no gate). A gate that throws is
+ * treated as "not paused" — a buggy host predicate must never wedge the walk.
+ */
+async function awaitBackfillIdle(
+  shouldPause: (() => boolean) | undefined,
+): Promise<void> {
+  if (!shouldPause) return;
+  // Edge-triggered logging: because this call blocks until the host is idle,
+  // one busy stretch (however many rows it spans) yields exactly one park/resume
+  // pair — so a long park is visible in the logs instead of looking like a wedge.
+  let parked = false;
+  for (;;) {
+    let paused = false;
+    try {
+      paused = shouldPause();
+    } catch {
+      break; // never let a throwing gate brick the walk
+    }
+    if (!paused) break;
+    if (!parked) {
+      parked = true;
+      log.info("temporal re-chunk parked — deferring to live traffic");
+    }
+    await new Promise<void>((resolve) => {
+      const t = setTimeout(resolve, TEMPORAL_RECHUNK_PAUSE_POLL_MS);
+      // Don't let a parked walk hold the process open on its own; the host's
+      // server keeps it alive, and if it doesn't, resuming next start is fine.
+      (t as { unref?: () => void }).unref?.();
+    });
+  }
+  if (parked) log.info("temporal re-chunk resumed");
+}
 
 /**
  * Reset the temporal re-chunk progress so the next {@link runStartupBackfill}
@@ -2354,7 +2415,9 @@ export function resetTemporalRechunkProgress(): void {
  *
  * Returns the number of messages re-chunked (successfully) in this invocation.
  */
-export async function backfillTemporalEmbeddings(): Promise<number> {
+export async function backfillTemporalEmbeddings(
+  opts: { shouldPause?: () => boolean } = {},
+): Promise<number> {
   const provider = getProvider();
   if (!provider) return 0;
 
@@ -2439,6 +2502,11 @@ export async function backfillTemporalEmbeddings(): Promise<number> {
 
     let stop = false;
     for (const row of rows) {
+      // Idle-gate before starting this row's embed so the walk yields the shared
+      // embed pool to live traffic. Parking here is safe: the previous row is
+      // already checkpointed, so a park (or a crash while parked) resumes from
+      // the last durable cursor.
+      await awaitBackfillIdle(opts.shouldPause);
       try {
         // Count only messages that actually got a chunk set written. A row that
         // reduces to zero embeddable units (store() never persists one, but the

--- a/packages/core/test/vec0-cutover.test.ts
+++ b/packages/core/test/vec0-cutover.test.ts
@@ -1598,6 +1598,59 @@ describeVec("temporal re-chunk backfill (backfillTemporalEmbeddings)", () => {
     expect(chunkIds("r3")).toEqual([]); // never reached
   });
 
+  test("idle-gate: parks before each row's embed and resumes when it clears", async () => {
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    insTemporalContent("r1", LONG);
+
+    // shouldPause is consulted BEFORE the embed and re-polled until it clears.
+    // Busy on the first check, idle after → the row parks once, then embeds.
+    const events: string[] = [];
+    let checks = 0;
+    const shouldPause = () => {
+      const paused = checks === 0;
+      checks++;
+      events.push(paused ? "pause" : "go");
+      return paused;
+    };
+    const token = _saveAndClearProvider();
+    try {
+      _restoreProvider({
+        provider: {
+          maxBatchSize: 8,
+          async embed(texts: string[]) {
+            events.push("embed");
+            return texts.map((_t, i) => v(1, i, 0, 0));
+          },
+        },
+      });
+      expect(await backfillTemporalEmbeddings({ shouldPause })).toBe(1);
+    } finally {
+      _restoreProvider(token);
+    }
+
+    // Gate checked → park → gate checked → clear → embed. Without gating the
+    // sequence would be just ["embed"].
+    expect(events).toEqual(["pause", "go", "embed"]);
+  });
+
+  test("idle-gate: a throwing shouldPause never bricks the walk", async () => {
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    insTemporalContent("r1", LONG);
+
+    // A buggy host predicate must be treated as "not paused" so the walk still
+    // converges (rather than rejecting out of the fire-and-forget backfill).
+    const shouldPause = () => {
+      throw new Error("host predicate blew up");
+    };
+    await withProvider(async () => {
+      expect(await backfillTemporalEmbeddings({ shouldPause })).toBe(1);
+    });
+    expect(chunkIds("r1").length).toBe(1);
+    expect(getKV(DONE_KEY)).toBe("1");
+  });
+
   test("logs the up-front backlog so a long walk is visible in the logs", async () => {
     setStorageMode(db(), "vec0");
     ensureVec0Store(db(), DIM);

--- a/packages/gateway/src/backfill-gate.ts
+++ b/packages/gateway/src/backfill-gate.ts
@@ -1,0 +1,47 @@
+/**
+ * Idle-gate for the heavy temporal re-chunk backfill walk.
+ *
+ * The walk (in `@loreai/core`'s `runStartupBackfill`) shares the embedding
+ * worker pool with request-path embeds and vector reads. Left unthrottled, a
+ * 100k+ row walk saturates that pool and inflates live recall latency. The core
+ * walk is signal-agnostic and simply calls a host-supplied `shouldPause()`
+ * before each row; this module supplies that policy.
+ *
+ * Policy: park the walk while background work is paused (a tripped circuit
+ * breaker signals the whole system is degraded) OR any session was active
+ * within `windowMs` (a request is likely in-flight or imminent). The walk
+ * resumes once the host is quiet. Because the walk checkpoints per row, parking
+ * for long stretches is free — it just resumes from the last durable cursor.
+ *
+ * Factored out of the wiring as a pure factory over injected dependencies so it
+ * is unit-testable without the pipeline's module state.
+ */
+export interface TemporalBackfillGateDeps {
+  /** Whether background LLM/embed work is currently paused (circuit breaker). */
+  isPaused: () => boolean;
+  /** Live view of tracked sessions; re-read on every gate call. */
+  activeSessions: () => Iterable<{ lastRequestTime: number }>;
+  /** A session touched more recently than this (ms) counts as "active". */
+  windowMs: number;
+  /** Clock injection point for tests. Defaults to `Date.now`. */
+  now?: () => number;
+}
+
+/**
+ * Build the `shouldPause` predicate handed to `runStartupBackfill`. Returns
+ * `true` when the temporal walk should park.
+ */
+export function makeTemporalBackfillGate(
+  deps: TemporalBackfillGateDeps,
+): () => boolean {
+  const now = deps.now ?? Date.now;
+  return () => {
+    if (deps.isPaused()) return true;
+    const t = now();
+    for (const s of deps.activeSessions()) {
+      // Strict `<`: activity exactly `windowMs` ago is no longer "active".
+      if (t - s.lastRequestTime < deps.windowMs) return true;
+    }
+    return false;
+  };
+}

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -78,6 +78,7 @@ import {
   enableHostedMode,
   importLoreFileAs,
   resolveWorkspaces,
+  DEEP_IDLE_MS,
 } from "@loreai/core";
 
 import type {
@@ -200,6 +201,7 @@ import {
 } from "./auth";
 import type { UpstreamInterceptor } from "./recorder";
 import { startIdleScheduler, buildIdleWorkHandler } from "./idle";
+import { makeTemporalBackfillGate } from "./backfill-gate";
 import { buildSessionMetadata } from "./session-metadata";
 import {
   makeWorkerHealth,
@@ -562,6 +564,24 @@ const subagentParentPendingLogged = new Set<string>();
 /** Read-only access to live session states (for dashboard rendering). */
 export function getActiveSessions(): ReadonlyMap<string, SessionState> {
   return sessions;
+}
+
+/**
+ * Build the idle-gate handed to the temporal re-chunk backfill, wired to live
+ * gateway state: park the walk while the background circuit breaker is tripped
+ * or any session was active within {@link DEEP_IDLE_MS}. Exported so the wiring
+ * (not just the pure {@link makeTemporalBackfillGate} policy) is unit-testable.
+ */
+export function buildTemporalBackfillGate(): () => boolean {
+  return makeTemporalBackfillGate({
+    // Global breaker: a coarse "system is degraded" backstop. It chiefly tracks
+    // remote LLM failures, so for a local embed provider the real gate is the
+    // session-activity check below; the breaker just avoids piling work on
+    // during an outage.
+    isPaused: () => isBackgroundPaused(),
+    activeSessions: () => getActiveSessions().values(),
+    windowMs: DEEP_IDLE_MS,
+  });
 }
 
 /**
@@ -1995,7 +2015,14 @@ async function initIfNeeded(
     log.info("metric backfill failed:", e);
   }
   if (process.env.NODE_ENV !== "test") {
-    spanStartupBackfill(() => embedding.runStartupBackfill()).catch((e) => {
+    // Idle-gate the heavy temporal re-chunk walk so it yields the shared embed
+    // pool to live traffic: park while the breaker is tripped or a session was
+    // active within DEEP_IDLE_MS, resume once the host is quiet.
+    spanStartupBackfill(() =>
+      embedding.runStartupBackfill({
+        shouldPause: buildTemporalBackfillGate(),
+      }),
+    ).catch((e) => {
       log.error("embedding backfill failed:", e);
     });
   }

--- a/packages/gateway/test/backfill-gate-wiring.test.ts
+++ b/packages/gateway/test/backfill-gate-wiring.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import {
+  resetBackgroundLimiter,
+  tripCircuitBreaker,
+} from "../src/background-limiter";
+import { buildTemporalBackfillGate } from "../src/pipeline";
+
+// The pure policy is covered in backfill-gate.test.ts; this pins the *wiring*
+// (`buildTemporalBackfillGate` → live gateway state), which the production call
+// site can't exercise because it's `NODE_ENV !== "test"`-gated.
+describe("buildTemporalBackfillGate (wiring)", () => {
+  beforeEach(() => resetBackgroundLimiter());
+  afterEach(() => resetBackgroundLimiter());
+
+  test("is wired to the background circuit breaker (idle → run, tripped → park)", () => {
+    const gate = buildTemporalBackfillGate();
+
+    // No active sessions + breaker clear → the walk runs (doesn't park). Guards
+    // against a wiring that spuriously pauses when the host is idle.
+    expect(gate()).toBe(false);
+
+    // Tripping the global breaker flips the same gate to "park" — proving it
+    // reads isBackgroundPaused() live rather than a stale snapshot.
+    tripCircuitBreaker(30);
+    expect(gate()).toBe(true);
+
+    // Clearing it resumes.
+    resetBackgroundLimiter();
+    expect(gate()).toBe(false);
+  });
+});

--- a/packages/gateway/test/backfill-gate.test.ts
+++ b/packages/gateway/test/backfill-gate.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "vitest";
+import { makeTemporalBackfillGate } from "../src/backfill-gate";
+
+describe("makeTemporalBackfillGate", () => {
+  test("parks when background work is paused (breaker tripped), regardless of sessions", () => {
+    const gate = makeTemporalBackfillGate({
+      isPaused: () => true,
+      activeSessions: () => [],
+      windowMs: 1000,
+      now: () => 10_000,
+    });
+    expect(gate()).toBe(true);
+  });
+
+  test("parks when a session was active within the window", () => {
+    const gate = makeTemporalBackfillGate({
+      isPaused: () => false,
+      activeSessions: () => [{ lastRequestTime: 9_600 }],
+      windowMs: 1000,
+      now: () => 10_000, // 400ms ago < 1000ms window
+    });
+    expect(gate()).toBe(true);
+  });
+
+  test("runs when all sessions are idle beyond the window and the breaker is clear", () => {
+    const gate = makeTemporalBackfillGate({
+      isPaused: () => false,
+      activeSessions: () => [
+        { lastRequestTime: 0 },
+        { lastRequestTime: 8_000 },
+      ],
+      windowMs: 1000,
+      now: () => 10_000, // most recent is 2000ms ago >= window
+    });
+    expect(gate()).toBe(false);
+  });
+
+  test("runs when there are no active sessions and the breaker is clear", () => {
+    const gate = makeTemporalBackfillGate({
+      isPaused: () => false,
+      activeSessions: () => [],
+      windowMs: 1000,
+      now: () => 10_000,
+    });
+    expect(gate()).toBe(false);
+  });
+
+  test("boundary: activity exactly windowMs ago does NOT park (strict <)", () => {
+    const gate = makeTemporalBackfillGate({
+      isPaused: () => false,
+      activeSessions: () => [{ lastRequestTime: 9_000 }],
+      windowMs: 1000,
+      now: () => 10_000, // exactly 1000ms ago
+    });
+    expect(gate()).toBe(false);
+  });
+
+  test("re-reads sessions live on every call (no snapshot)", () => {
+    let sessions: Array<{ lastRequestTime: number }> = [];
+    const gate = makeTemporalBackfillGate({
+      isPaused: () => false,
+      activeSessions: () => sessions,
+      windowMs: 1000,
+      now: () => 10_000,
+    });
+    expect(gate()).toBe(false); // idle
+    sessions = [{ lastRequestTime: 9_500 }]; // a request just arrived
+    expect(gate()).toBe(true); // reflected without rebuilding the gate
+  });
+});


### PR DESCRIPTION
**Stacked on #1104** (base is `fix/temporal-rechunk-checkpoint`; GitHub retargets to `main` once #1104 merges). Third of the 3 requested changes.

## Problem

The temporal re-chunk walk shares the embedding worker pool with request-path embeds and vector reads. Left unthrottled, the 100k+ row walk saturates that pool and inflates live recall latency (cf. the p50/p95 spikes in #999). It also runs **outside** all the throttling normal background work respects — a direct fire-and-forget from `pipeline.ts`, not routed through the background limiter — so nothing made it defer to live traffic.

## Change — idle-gate the walk

Policy: **breaker + recent-activity**. The walk parks while background work is paused (circuit breaker tripped) OR any session was active within `DEEP_IDLE_MS` (5 min), and resumes once the host is quiet. Safe now that #1104 makes progress durable per-row: a long park just resumes from the last checkpoint, so even a machine in near-constant use converges across idle gaps without losing work.

- **Core** (`embedding.ts`): `backfillTemporalEmbeddings` / `runStartupBackfill` take an optional `shouldPause` hook, consulted **before each row**; while it returns `true` the walk parks (250ms re-poll, `unref`'d timer) and resumes when it clears. Signal-agnostic — `@loreai/core` has no view of host activity, so the host owns the policy. A **throwing** predicate is treated as "not paused" so a buggy host can never wedge the walk. Only the heavy temporal walk is gated; the small knowledge/distillation/entity backfills stay unthrottled. **Edge-triggered `parked`/`resumed` log** (one pair per busy episode) so a long park is visible instead of looking like a wedge.
- **Gateway** (`backfill-gate.ts`): `makeTemporalBackfillGate` — a **pure, unit-tested** factory over injected deps (`isPaused`, `activeSessions`, `windowMs`, `now`). Wired via exported `buildTemporalBackfillGate()` (in `pipeline.ts`) at the single `runStartupBackfill` call site — one site that covers **both** the standalone gateway and the in-process opencode-plugin path (the plugin starts the gateway via `startGateway()`). The breaker is a coarse "system degraded" backstop; session activity is the real gate for local embed providers.

## Testing (mutation-verified)

- **core**: gate consulted before each embed, re-polled until clear (`["pause","go","embed"]`; remove-gate mutation → `["embed"]`, killed); a throwing predicate still converges (rethrow mutation killed).
- **gateway pure policy**: `makeTemporalBackfillGate` branch matrix — breaker, in-window activity, idle-beyond-window, no sessions, strict-`<` boundary, live re-read.
- **gateway wiring**: `buildTemporalBackfillGate()` wired to the live breaker (idle → run, `tripCircuitBreaker` → park, reset → run); neutralize-`isPaused` mutation killed. (Added in response to review — the production call site is `NODE_ENV!=="test"`-gated, so the wiring needed its own seam.)
- Full suites: **core 108 files / 2370 passed**, **gateway 120 files / 2449 passed**. Typecheck + Biome clean. Pre-existing `backfillTemporalEmbeddings` tests pass unchanged (hook defaults off).

An adversarial correctness review returned **SHIP-WITH-FOLLOWUPS** (no BLOCKERs, 5 mutants killed); its SHOULD-FIX (untested wiring) and the observability NIT (silent park) are both folded in here.