### PR TITLE
fix(gateway): stop sonnet-5 workers breaking (adaptive thinking + deprecated sampling), data-driven via models.dev

### DIFF
--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -218,6 +218,18 @@ function isTemperatureUnsupported400(body: string): boolean {
 }
 
 /**
+ * True when a worker model is a genuine Anthropic Claude model (not an
+ * anthropic-compat third party like MiniMax / vLLM served over the Anthropic
+ * wire protocol). Every real Claude model id contains "claude" — direct
+ * (`claude-sonnet-5`), Bedrock mantle (`anthropic.claude-…`), and Vertex
+ * (`claude-…`). Compat providers use their own model ids (e.g. `MiniMax-M1`),
+ * so they are naturally excluded.
+ */
+export function isAnthropicClaudeModel(modelID: string): boolean {
+  return /claude/i.test(modelID);
+}
+
+/**
  * Unified retry policy (modeled on Claude Code's `getRetryDelay`).
  *
  * A single policy governs every worker call — urgent or background, 429 or
@@ -602,10 +614,26 @@ function buildAnthropicWorkerRequest(
     ? toMantleModelId(model.modelID)
     : model.modelID;
 
+  // Explicitly disable extended/adaptive thinking for genuine Anthropic Claude
+  // workers. Workers do deterministic single-shot summarization (distillation /
+  // curation) and never benefit from thinking. Newer models (claude-sonnet-5+)
+  // use ADAPTIVE thinking that is silently activated by the replayed Claude Code
+  // OAuth fingerprint (`oauth-2025-04-20` beta on api.anthropic.com). When active,
+  // the model spends its budget on a thinking block and can return an EMPTY
+  // thinking block with no visible text — the worker then sees a "no usable text"
+  // empty response and the whole distill/curate loop degrades. `{type:"disabled"}`
+  // is accepted (and a no-op) by all current Claude models. Scoped OUT of the
+  // Bedrock mantle path (Bedrock is strict about request-body fields and never
+  // carries the OAuth fingerprint, so it can't hit this) and out of compat
+  // providers (model id lacks "claude").
+  const disableThinking =
+    isAnthropicClaudeModel(model.modelID) && !isBedrockMantleHost(target.url);
+
   let body = JSON.stringify({
     model: upstreamModelID,
     max_tokens: maxTokens,
     ...(temperature != null && { temperature }),
+    ...(disableThinking && { thinking: { type: "disabled" } }),
     system: systemPayload,
     messages: [{ role: "user", content: user }],
   });

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -230,6 +230,56 @@ export function isAnthropicClaudeModel(modelID: string): boolean {
 }
 
 /**
+ * Companion to the temperature-capability learning above, for the `thinking`
+ * param. Workers send `thinking:{type:"disabled"}` to genuine Anthropic Claude
+ * models to suppress adaptive thinking (see `buildAnthropicWorkerRequest`).
+ * Every current Claude model accepts it, but a model that predates the thinking
+ * API (older claude-3.x, still reachable on some accounts) can reject an unknown
+ * `thinking` field with a 400. We learn that at runtime — on the first such 400
+ * — so subsequent calls omit the param, exactly mirroring the temperature
+ * mechanism. In-memory; re-learns at most once per model per gateway lifetime.
+ */
+const thinkingUnsupportedModels = new Set<string>();
+
+/** Record that a model rejects the `thinking` param (learned from a 400). */
+export function markThinkingUnsupported(model: {
+  providerID: string;
+  modelID: string;
+}): void {
+  thinkingUnsupportedModels.add(workerModelKey(model));
+}
+
+/** Has this model been observed to reject the `thinking` param? */
+export function isThinkingUnsupportedModel(model: {
+  providerID: string;
+  modelID: string;
+}): boolean {
+  return thinkingUnsupportedModels.has(workerModelKey(model));
+}
+
+/** Test-only: clear the learned thinking-capability set. */
+export function _resetThinkingUnsupportedModels(): void {
+  thinkingUnsupportedModels.clear();
+}
+
+/**
+ * Heuristic: does a 400 body indicate the request's `thinking` param is not
+ * accepted by this model? Matches Anthropic param-rejection shapes for an
+ * unknown/unsupported field (e.g. "thinking: Extra inputs are not permitted",
+ * "thinking.type ... not supported"). Requires the word `thinking` AND a
+ * rejection verb so an unrelated 400 that merely mentions thinking can't trigger
+ * the one-shot thinking-stripped retry.
+ */
+function isThinkingUnsupported400(body: string): boolean {
+  return (
+    /thinking/i.test(body) &&
+    /\b(deprecated|unsupported|no\s+longer\s+supported|not\s+supported|not\s+permitted|not\s+allowed|unexpected|unrecognized|unknown|extra\s+inputs|removed|invalid)\b/i.test(
+      body,
+    )
+  );
+}
+
+/**
  * Unified retry policy (modeled on Claude Code's `getRetryDelay`).
  *
  * A single policy governs every worker call — urgent or background, 429 or
@@ -577,6 +627,7 @@ function buildAnthropicWorkerRequest(
   maxTokens: number,
   sessionID?: string,
   temperature?: number,
+  disableThinking = false,
 ): { url: string; headers: Record<string, string>; body: string } {
   // For bearer tokens (Claude Code OAuth), inject the billing header
   // as the first system block with a cch=00000 placeholder that gets
@@ -614,21 +665,18 @@ function buildAnthropicWorkerRequest(
     ? toMantleModelId(model.modelID)
     : model.modelID;
 
-  // Explicitly disable extended/adaptive thinking for genuine Anthropic Claude
-  // workers. Workers do deterministic single-shot summarization (distillation /
-  // curation) and never benefit from thinking. Newer models (claude-sonnet-5+)
-  // use ADAPTIVE thinking that is silently activated by the replayed Claude Code
-  // OAuth fingerprint (`oauth-2025-04-20` beta on api.anthropic.com). When active,
-  // the model spends its budget on a thinking block and can return an EMPTY
-  // thinking block with no visible text — the worker then sees a "no usable text"
-  // empty response and the whole distill/curate loop degrades. `{type:"disabled"}`
-  // is accepted (and a no-op) by all current Claude models. Scoped OUT of the
-  // Bedrock mantle path (Bedrock is strict about request-body fields and never
-  // carries the OAuth fingerprint, so it can't hit this) and out of compat
-  // providers (model id lacks "claude").
-  const disableThinking =
-    isAnthropicClaudeModel(model.modelID) && !isBedrockMantleHost(target.url);
-
+  // `disableThinking` (decided by the caller — see the retry loop) sends
+  // `thinking:{type:"disabled"}` for genuine Anthropic Claude workers. Workers
+  // do deterministic single-shot summarization (distillation / curation) and
+  // never benefit from thinking. Newer models (claude-sonnet-5+) use ADAPTIVE
+  // thinking that is silently activated by the replayed Claude Code OAuth
+  // fingerprint (`oauth-2025-04-20` beta on api.anthropic.com); when active the
+  // model can spend its budget on a thinking block and return an EMPTY thinking
+  // block with no visible text — the worker then sees a "no usable text" empty
+  // response and the whole distill/curate loop degrades. `{type:"disabled"}` is
+  // accepted (and a no-op) by all current Claude models; a rare model that
+  // rejects the param (older claude-3.x) is learned via a one-shot 400 retry in
+  // the loop, which then passes `disableThinking=false` here.
   let body = JSON.stringify({
     model: upstreamModelID,
     max_tokens: maxTokens,
@@ -985,6 +1033,7 @@ async function buildWorkerRequest(
   sessionID?: string,
   temperature?: number,
   vertexProject?: string,
+  disableThinking = false,
 ): Promise<{ url: string; headers: Record<string, string>; body: string }> {
   switch (target.protocol) {
     case "openai-codex-responses":
@@ -1028,6 +1077,7 @@ async function buildWorkerRequest(
         maxTokens,
         sessionID,
         temperature,
+        disableThinking,
       );
   }
 }
@@ -1309,6 +1359,16 @@ export function createGatewayLLMClient(
         ? undefined
         : opts?.temperature;
 
+      // Resolve whether to disable thinking. Genuine Anthropic Claude workers
+      // send `thinking:{type:"disabled"}` to suppress adaptive thinking (see
+      // buildAnthropicWorkerRequest); a model observed to reject the param gets
+      // it omitted upfront. A runtime-learned 400 below flips this to false for
+      // the retry. Excludes the Bedrock mantle path and compat providers.
+      let effectiveDisableThinking =
+        isAnthropicClaudeModel(model.modelID) &&
+        !isBedrockMantleHost(target.url) &&
+        !isThinkingUnsupportedModel(model);
+
       // The credential in effect for the CURRENT attempt. Starts as `cred`; an
       // auth-error refresh reassigns it so every later rebuild in the retry loop
       // (e.g. the temperature-strip rebuild) signs with the fresh key rather
@@ -1327,6 +1387,7 @@ export function createGatewayLLMClient(
         opts?.sessionID,
         effectiveTemperature,
         factoryVertexProject,
+        effectiveDisableThinking,
       );
 
       // Track this call so temporal capture can skip it
@@ -1366,6 +1427,9 @@ export function createGatewayLLMClient(
             // Strip the temperature param at most once per call (runtime
             // fallback for a "temperature is deprecated" 400 — see below).
             let temperatureStripped = false;
+            // Strip the thinking param at most once per call (runtime fallback
+            // for a "thinking is unsupported" 400 — see below).
+            let thinkingStripped = false;
             // Resolve the retry budget once per call (not per attempt) — the
             // value can't change mid-loop and re-reading the env each iteration
             // is wasteful.
@@ -1378,9 +1442,9 @@ export function createGatewayLLMClient(
                 response = await upstreamFetch(req.url, {
                   method: "POST",
                   headers: req.headers,
-                  // opts.thinking is intentionally not forwarded — this bare API
-                  // call never includes the `thinking` parameter so models
-                  // won't produce thinking tokens regardless.
+                  // The request body may carry `thinking:{type:"disabled"}` for
+                  // Claude workers (built above) to SUPPRESS thinking — it never
+                  // ENABLES it. opts.thinking is not forwarded.
                   body: req.body,
                 });
               } catch (e) {
@@ -1413,6 +1477,11 @@ export function createGatewayLLMClient(
                 // regex false-positive on an unrelated 400 can never permanently
                 // mislabel a model that actually supports temperature.
                 if (temperatureStripped) markTemperatureUnsupported(model);
+                // Same deferred-learning for the `thinking` param: only mark the
+                // model on a 2xx after stripping, so a regex false-positive on an
+                // unrelated 400 can't permanently mislabel a thinking-capable
+                // model.
+                if (thinkingStripped) markThinkingUnsupported(model);
 
                 // Guard: some providers return SSE even when stream: false
                 // was sent. Extract JSON from the data: lines instead.
@@ -1664,6 +1733,7 @@ export function createGatewayLLMClient(
                     opts?.sessionID,
                     effectiveTemperature,
                     factoryVertexProject,
+                    effectiveDisableThinking,
                   );
                   retryCount++;
                   continue;
@@ -1802,6 +1872,7 @@ export function createGatewayLLMClient(
                     opts?.sessionID,
                     effectiveTemperature,
                     factoryVertexProject,
+                    effectiveDisableThinking,
                   );
                   // Rebuilding restores the freshly-built header set, which
                   // resurrects a beta we may have already stripped at runtime
@@ -1815,6 +1886,48 @@ export function createGatewayLLMClient(
                   }
                   log.warn(
                     `worker 400 reports temperature is unsupported — retrying once without the temperature param ` +
+                      `(model=${model.providerID}/${model.modelID}, worker=${opts?.workerID ?? "unknown"}): ${text.slice(0, 160)}`,
+                  );
+                  retryCount++;
+                  continue;
+                }
+
+                // 400 + a "thinking is unsupported" complaint → the model rejects
+                // the `thinking:{type:"disabled"}` param we add for Claude workers
+                // (a model that predates the thinking API, e.g. older claude-3.x).
+                // Learn it so future calls omit the param upfront, then rebuild
+                // THIS request without it and retry once. Rebuilt via
+                // buildWorkerRequest (not string-editing req.body) so the OAuth
+                // billing signature is recomputed over the new body. Bounded to
+                // one retry per call; composes with the temperature/beta strips
+                // above (each rebuild uses the current effective values).
+                if (
+                  response.status === 400 &&
+                  !thinkingStripped &&
+                  effectiveDisableThinking &&
+                  isThinkingUnsupported400(text)
+                ) {
+                  thinkingStripped = true;
+                  effectiveDisableThinking = false;
+                  req = await buildWorkerRequest(
+                    target,
+                    activeCred,
+                    model,
+                    system,
+                    user,
+                    maxTokens,
+                    opts?.sessionID,
+                    effectiveTemperature,
+                    factoryVertexProject,
+                    effectiveDisableThinking,
+                  );
+                  // Preserve a runtime beta strip across this rebuild (same
+                  // reasoning as the temperature-strip path above).
+                  if (betaStripped) {
+                    req = { ...req, headers: stripBetaHeaders(req.headers) };
+                  }
+                  log.warn(
+                    `worker 400 reports thinking is unsupported — retrying once without the thinking param ` +
                       `(model=${model.providerID}/${model.modelID}, worker=${opts?.workerID ?? "unknown"}): ${text.slice(0, 160)}`,
                   );
                   retryCount++;

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -230,6 +230,44 @@ export function isAnthropicClaudeModel(modelID: string): boolean {
 }
 
 /**
+ * Decide whether a worker request to this model should carry
+ * `thinking:{type:"disabled"}`.
+ *
+ * PRIMARY (data-driven): models.dev `reasoning_options`. A `toggle` entry marks
+ * a model whose adaptive thinking is ON BY DEFAULT (claude-sonnet-5) and must be
+ * turned off explicitly. `effort`-only (claude-opus-4-8, gpt-5) and
+ * `budget_tokens` (claude-sonnet-4-5) models run WITHOUT thinking unless it is
+ * requested, so they need no opt-out — returning false avoids an unnecessary
+ * param. This generalizes across providers/generations with no hardcoded list.
+ *
+ * FALLBACK (offline-safe): when models.dev has NO reasoning data for the model
+ * (API outage, or an id newer than the models.dev snapshot), fall back to the
+ * Claude-id heuristic so an on-by-default Claude model is still covered when the
+ * data is unavailable — a models.dev outage must never silently re-break workers.
+ * Sending the param is a harmless no-op for off-by-default Claude models, and the
+ * runtime learning net strips it for any model that rejects it.
+ */
+export function workerThinkingOnByDefault(model: { modelID: string }): boolean {
+  const opts = getModelEntrySync(model.modelID).reasoning_options;
+  if (Array.isArray(opts) && opts.length > 0) {
+    return opts.some((o) => o?.type === "toggle");
+  }
+  return isAnthropicClaudeModel(model.modelID);
+}
+
+/**
+ * models.dev-driven check: does this model reject a non-default sampling
+ * `temperature`? True for the deprecated-sampling generation (claude-sonnet-5,
+ * claude-opus-4-7/4-8, gpt-5, o3, …) where `temperature` is `false`. Used to
+ * strip `temperature` PROACTIVELY (before the first 400); the runtime
+ * learning net (`isTemperatureUnsupportedModel`) remains the fallback for
+ * models absent from models.dev or during an outage.
+ */
+export function modelRejectsTemperatureByData(modelID: string): boolean {
+  return getModelEntrySync(modelID).temperature === false;
+}
+
+/**
  * Companion to the temperature-capability learning above, for the `thinking`
  * param. Workers send `thinking:{type:"disabled"}` to genuine Anthropic Claude
  * models to suppress adaptive thinking (see `buildAnthropicWorkerRequest`).
@@ -970,6 +1008,7 @@ async function buildVertexWorkerRequest(
   maxTokens: number,
   vertexProject?: string,
   temperature?: number,
+  disableThinking = false,
 ): Promise<{ url: string; headers: Record<string, string>; body: string }> {
   const region = vertexRegionFromUrl(target.url) ?? "global";
   const project = await resolveVertexProject(vertexProject ?? "");
@@ -997,6 +1036,11 @@ async function buildVertexWorkerRequest(
     toVertexBody({
       max_tokens: maxTokens,
       ...(temperature != null && { temperature }),
+      // Vertex serves Claude over the Anthropic Messages body shape, so the same
+      // adaptive-thinking-on-by-default applies (sonnet-5). `thinking:{type:
+      // "disabled"}` passes through toVertexBody and turns it off. See
+      // buildAnthropicWorkerRequest for the full rationale.
+      ...(disableThinking && { thinking: { type: "disabled" } }),
       system: systemBlocks,
       messages: [{ role: "user", content: user }],
     }),
@@ -1066,6 +1110,7 @@ async function buildWorkerRequest(
         maxTokens,
         vertexProject,
         temperature,
+        disableThinking,
       );
     default:
       return buildAnthropicWorkerRequest(
@@ -1351,22 +1396,31 @@ export function createGatewayLLMClient(
         }
       }
 
-      // Resolve the effective sampling temperature. Models we've already
-      // observed to reject `temperature` (see markTemperatureUnsupported) get
-      // it omitted upfront so we don't burn a wasted 400 round-trip per call.
-      // A runtime-learned 400 below flips this to undefined for the retry.
-      let effectiveTemperature = isTemperatureUnsupportedModel(model)
-        ? undefined
-        : opts?.temperature;
+      // Resolve the effective sampling temperature. It is omitted upfront when
+      // models.dev marks the model as not accepting a non-default `temperature`
+      // (the deprecated-sampling generation: sonnet-5, opus-4.7+, gpt-5, o3 …)
+      // OR when we've already learned it at runtime from a 400 — so we don't
+      // burn a wasted round-trip. A runtime-learned 400 below also flips this to
+      // undefined for the retry (the offline/models.dev-gap safety net).
+      let effectiveTemperature =
+        isTemperatureUnsupportedModel(model) ||
+        modelRejectsTemperatureByData(model.modelID)
+          ? undefined
+          : opts?.temperature;
 
-      // Resolve whether to disable thinking. Genuine Anthropic Claude workers
-      // send `thinking:{type:"disabled"}` to suppress adaptive thinking (see
-      // buildAnthropicWorkerRequest); a model observed to reject the param gets
-      // it omitted upfront. A runtime-learned 400 below flips this to false for
-      // the retry. Excludes the Bedrock mantle path and compat providers.
+      // Resolve whether to disable thinking. Adaptive thinking is ON BY DEFAULT
+      // on the newest generation (claude-sonnet-5 today) and otherwise burns the
+      // `max_tokens` budget on a thinking block, starving the visible text and
+      // yielding an empty worker response. `workerThinkingOnByDefault` decides
+      // this data-drivenly from models.dev `reasoning_options` (with a Claude-id
+      // fallback when the data is unavailable). Gated to the Anthropic Messages
+      // wire protocols — "anthropic" (direct + Bedrock mantle) and "vertex" —
+      // the only builders that emit the `thinking` field. A model observed to
+      // reject the param gets it omitted upfront; a runtime-learned 400 below
+      // flips this to false for the retry.
       let effectiveDisableThinking =
-        isAnthropicClaudeModel(model.modelID) &&
-        !isBedrockMantleHost(target.url) &&
+        (target.protocol === "anthropic" || target.protocol === "vertex") &&
+        workerThinkingOnByDefault(model) &&
         !isThinkingUnsupportedModel(model);
 
       // The credential in effect for the CURRENT attempt. Starts as `cred`; an

--- a/packages/gateway/src/worker-model.ts
+++ b/packages/gateway/src/worker-model.ts
@@ -88,6 +88,24 @@ export type ModelsDevEntry = {
     cache_write?: number;
   };
   limit?: { context?: number; output?: number };
+  /**
+   * Whether the model accepts a non-default sampling `temperature` (and
+   * `top_p`/`top_k`). `false` on the deprecated-sampling generation
+   * (claude-sonnet-5, claude-opus-4-7/4-8, gpt-5, o3, …), which 400s any
+   * request that sets it. Drives the proactive temperature strip on worker
+   * requests. Absent for models.dev entries that predate the field.
+   */
+  temperature?: boolean;
+  /** Whether the model has any extended/adaptive reasoning capability. */
+  reasoning?: boolean;
+  /**
+   * The reasoning control shapes the model exposes. The `toggle` type marks a
+   * model whose adaptive thinking is ON BY DEFAULT and is turned off with
+   * `thinking:{type:"disabled"}` (claude-sonnet-5). `effort`-only
+   * (claude-opus-4-8, gpt-5) and `budget_tokens` (claude-sonnet-4-5) models run
+   * WITHOUT thinking unless it is explicitly requested, so they need no opt-out.
+   */
+  reasoning_options?: Array<{ type?: string }>;
 };
 
 /** Shape of the models.dev JSON API response (subset we care about). */
@@ -458,6 +476,20 @@ export function clearModelDataCache(): void {
   cachedModelDataAt = 0;
   inflightFetch = null;
   lastReadyAttemptAt = 0;
+  resolutionMemo = new Map();
+  resolutionMemoVersion = -1;
+}
+
+/**
+ * Test-only: seed the models.dev cache directly (no network) so
+ * `getModelEntrySync` returns known capability entries. Bumps the snapshot
+ * version so any resolution memo is invalidated.
+ */
+export function _setModelDataForTest(
+  entries: Record<string, ModelsDevEntry>,
+): void {
+  cachedModelData = new Map(Object.entries(entries));
+  cachedModelDataAt = Date.now();
   resolutionMemo = new Map();
   resolutionMemoVersion = -1;
 }

--- a/packages/gateway/test/llm-adapter.test.ts
+++ b/packages/gateway/test/llm-adapter.test.ts
@@ -25,9 +25,12 @@ import {
   isAnthropicClaudeModel,
   isThinkingUnsupportedModel,
   markThinkingUnsupported,
+  workerThinkingOnByDefault,
+  modelRejectsTemperatureByData,
   _resetTemperatureUnsupportedModels,
   _resetThinkingUnsupportedModels,
 } from "../src/llm-adapter";
+import { _setModelDataForTest, clearModelDataCache } from "../src/worker-model";
 import {
   getConsecutiveTrips,
   resetBackgroundLimiter,
@@ -1871,7 +1874,7 @@ describe("worker thinking disabled for Anthropic Claude models", () => {
     expect(bodyOf(0)).not.toHaveProperty("thinking");
   });
 
-  test("bedrock mantle Claude worker does NOT send a thinking param (untested body field on mantle; cannot hit the OAuth thinking trigger)", async () => {
+  test("bedrock mantle Claude worker disables thinking (Anthropic Messages shape; sonnet-5-gen adaptive thinking is on by default on Bedrock too)", async () => {
     mockFetch.mockResolvedValue(okResponse());
     const client = createGatewayLLMClient(
       UPSTREAMS,
@@ -1887,9 +1890,135 @@ describe("worker thinking disabled for Anthropic Claude models", () => {
       protocol: "anthropic",
     });
 
-    expect(bodyOf(0)).not.toHaveProperty("thinking");
-    // Sanity: it IS a Claude model, just scoped out by the mantle-host guard.
+    expect(bodyOf(0)?.thinking).toEqual({ type: "disabled" });
+    // The body model is the mantle catalog id.
     expect(bodyOf(0)?.model).toBe("anthropic.claude-haiku-4-5");
+  });
+
+  // -------------------------------------------------------------------------
+  // Data-driven capability from models.dev (thinking + temperature).
+  // -------------------------------------------------------------------------
+  describe("driven by models.dev capability data", () => {
+    afterEach(() => {
+      clearModelDataCache();
+    });
+
+    test("workerThinkingOnByDefault: toggle → true; effort/budget_tokens/none → false", () => {
+      _setModelDataForTest({
+        "claude-sonnet-5": {
+          id: "claude-sonnet-5",
+          reasoning: true,
+          reasoning_options: [{ type: "toggle" }, { type: "effort" }],
+        },
+        "claude-opus-4-8": {
+          id: "claude-opus-4-8",
+          reasoning: true,
+          reasoning_options: [{ type: "effort" }],
+        },
+        "claude-sonnet-4-5": {
+          id: "claude-sonnet-4-5",
+          reasoning: true,
+          reasoning_options: [{ type: "budget_tokens" }],
+        },
+        "some-nonreasoning": { id: "some-nonreasoning", reasoning: false },
+      });
+      expect(workerThinkingOnByDefault({ modelID: "claude-sonnet-5" })).toBe(
+        true,
+      );
+      // On-by-default only for `toggle`; effort/budget_tokens run without
+      // thinking unless asked, so no opt-out param is needed.
+      expect(workerThinkingOnByDefault({ modelID: "claude-opus-4-8" })).toBe(
+        false,
+      );
+      expect(workerThinkingOnByDefault({ modelID: "claude-sonnet-4-5" })).toBe(
+        false,
+      );
+      expect(workerThinkingOnByDefault({ modelID: "some-nonreasoning" })).toBe(
+        false,
+      );
+    });
+
+    test("workerThinkingOnByDefault: falls back to the Claude-id heuristic when models.dev has no data (offline safety)", () => {
+      clearModelDataCache(); // no models.dev data available
+      // A models.dev outage must NOT stop us disabling thinking on Claude models.
+      expect(workerThinkingOnByDefault({ modelID: "claude-sonnet-5" })).toBe(
+        true,
+      );
+      expect(workerThinkingOnByDefault({ modelID: "MiniMax-M1" })).toBe(false);
+    });
+
+    test("effort-only model (opus-4-8) does NOT get a thinking param when models.dev data is present", async () => {
+      _setModelDataForTest({
+        "claude-opus-4-8": {
+          id: "claude-opus-4-8",
+          reasoning: true,
+          reasoning_options: [{ type: "effort" }],
+        },
+      });
+      mockFetch.mockResolvedValue(okResponse());
+      const client = createGatewayLLMClient(
+        UPSTREAMS,
+        () => ({ scheme: "api-key", value: "sk-ant-test" }),
+        { providerID: "anthropic", modelID: "claude-opus-4-8" },
+      );
+      await client.prompt("system", "user", {
+        sessionID: "sess-effort",
+        workerID: "lore-distill",
+        model: { providerID: "anthropic", modelID: "claude-opus-4-8" },
+      });
+      expect(bodyOf(0)).not.toHaveProperty("thinking");
+    });
+
+    test("modelRejectsTemperatureByData reflects the models.dev temperature flag", () => {
+      _setModelDataForTest({
+        "claude-sonnet-5": { id: "claude-sonnet-5", temperature: false },
+        "claude-sonnet-4-5": { id: "claude-sonnet-4-5", temperature: true },
+      });
+      expect(modelRejectsTemperatureByData("claude-sonnet-5")).toBe(true);
+      expect(modelRejectsTemperatureByData("claude-sonnet-4-5")).toBe(false);
+      // Unknown model (no data) → not proactively stripped (learning net covers).
+      expect(modelRejectsTemperatureByData("mystery-model")).toBe(false);
+    });
+
+    test("temperature is stripped upfront (no 400 needed) when models.dev marks the model temperature:false", async () => {
+      _setModelDataForTest({
+        "claude-sonnet-5": { id: "claude-sonnet-5", temperature: false },
+      });
+      mockFetch.mockResolvedValue(okResponse());
+      const client = createGatewayLLMClient(
+        UPSTREAMS,
+        () => ({ scheme: "api-key", value: "sk-ant-test" }),
+        { providerID: "anthropic", modelID: "claude-sonnet-5" },
+      );
+      await client.prompt("system", "user", {
+        sessionID: "sess-temp-data",
+        workerID: "lore-distill",
+        model: { providerID: "anthropic", modelID: "claude-sonnet-5" },
+        temperature: 0,
+      });
+      // Single attempt, no 400 round-trip — temperature omitted from the start.
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(bodyOf(0)).not.toHaveProperty("temperature");
+    });
+
+    test("temperature is kept when models.dev marks the model temperature:true", async () => {
+      _setModelDataForTest({
+        "claude-sonnet-4-5": { id: "claude-sonnet-4-5", temperature: true },
+      });
+      mockFetch.mockResolvedValue(okResponse());
+      const client = createGatewayLLMClient(
+        UPSTREAMS,
+        () => ({ scheme: "api-key", value: "sk-ant-test" }),
+        { providerID: "anthropic", modelID: "claude-sonnet-4-5" },
+      );
+      await client.prompt("system", "user", {
+        sessionID: "sess-temp-keep-data",
+        workerID: "lore-distill",
+        model: { providerID: "anthropic", modelID: "claude-sonnet-4-5" },
+        temperature: 0,
+      });
+      expect(bodyOf(0)?.temperature).toBe(0);
+    });
   });
 
   test("retries once without the thinking param on a thinking-unsupported 400, then succeeds and learns", async () => {

--- a/packages/gateway/test/llm-adapter.test.ts
+++ b/packages/gateway/test/llm-adapter.test.ts
@@ -22,6 +22,7 @@ import {
   resolveWorkerProtocol,
   AUTH_ERROR_CODES,
   isTemperatureUnsupportedModel,
+  isAnthropicClaudeModel,
   _resetTemperatureUnsupportedModels,
 } from "../src/llm-adapter";
 import {
@@ -1722,5 +1723,154 @@ describe("worker temperature capability", () => {
     expect(betaOf(2)).not.toContain("context-1m");
     expect(betaOf(2)).toContain("oauth-2025-04-20");
     expect(bodyOf(2)).not.toHaveProperty("temperature");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Worker thinking suppression.
+//
+// Workers do deterministic single-shot summarization (distillation/curation)
+// and never benefit from extended/adaptive thinking. Newer Claude models
+// (claude-sonnet-5+) use ADAPTIVE thinking that is silently activated by the
+// replayed Claude Code OAuth fingerprint (`oauth-2025-04-20` beta on
+// api.anthropic.com). When active, the model can return an EMPTY thinking block
+// with no visible text — the worker then sees a "no usable text" empty response
+// and the whole distill/curate loop degrades. We send `thinking:{type:"disabled"}`
+// on genuine Anthropic Claude worker requests to force plain text output.
+// ---------------------------------------------------------------------------
+describe("worker thinking disabled for Anthropic Claude models", () => {
+  const mockFetch = vi.mocked(upstreamFetch);
+
+  const UPSTREAMS = {
+    anthropic: "https://api.anthropic.com",
+    openai: "https://api.openai.com",
+  };
+
+  afterEach(() => {
+    mockFetch.mockReset();
+    clearAllCosts();
+    resetBackgroundLimiter();
+  });
+
+  function bodyOf(callIndex: number): Record<string, unknown> | undefined {
+    const raw = mockFetch.mock.calls[callIndex]?.[1]?.body;
+    if (typeof raw !== "string") return undefined;
+    return JSON.parse(raw) as Record<string, unknown>;
+  }
+
+  function betaOf(callIndex: number): string | undefined {
+    const headers = mockFetch.mock.calls[callIndex]?.[1]?.headers as
+      | Record<string, string>
+      | undefined;
+    if (!headers) return undefined;
+    const key = Object.keys(headers).find(
+      (k) => k.toLowerCase() === "anthropic-beta",
+    );
+    return key ? headers[key] : undefined;
+  }
+
+  const okResponse = () =>
+    new Response(
+      JSON.stringify({
+        content: [{ type: "text", text: "ok" }],
+        usage: { input_tokens: 1, output_tokens: 1 },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+
+  test("isAnthropicClaudeModel matches real Claude ids and excludes compat providers", () => {
+    expect(isAnthropicClaudeModel("claude-sonnet-5")).toBe(true);
+    expect(isAnthropicClaudeModel("claude-haiku-4-5")).toBe(true);
+    expect(isAnthropicClaudeModel("anthropic.claude-haiku-4-5")).toBe(true); // Bedrock mantle id
+    expect(isAnthropicClaudeModel("MiniMax-M1")).toBe(false);
+    expect(isAnthropicClaudeModel("gpt-5")).toBe(false);
+  });
+
+  test("genuine Anthropic Claude worker request disables thinking", async () => {
+    mockFetch.mockResolvedValue(okResponse());
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "sk-ant-test" }),
+      { providerID: "anthropic", modelID: "claude-sonnet-5" },
+    );
+
+    await client.prompt("system", "user", {
+      sessionID: "sess-think-basic",
+      workerID: "lore-distill",
+      model: { providerID: "anthropic", modelID: "claude-sonnet-5" },
+    });
+
+    expect(bodyOf(0)?.thinking).toEqual({ type: "disabled" });
+  });
+
+  test("OAuth-fingerprint Claude worker (the failing production path) disables thinking despite the replayed interleaved-thinking beta", async () => {
+    mockFetch.mockResolvedValue(okResponse());
+    // Simulate a Claude Code OAuth session: billing prefix marks it, and the
+    // sniffed anthropic-beta (with the interleaved-thinking flag that would
+    // otherwise let sonnet-5 emit an empty thinking block) is replayed onto
+    // worker calls.
+    captureBillingPrefix("sess-think-oauth", BILLING_SYSTEM);
+    captureSessionHeaders("sess-think-oauth", {
+      "anthropic-beta": "oauth-2025-04-20,interleaved-thinking-2025-05-14",
+    });
+
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "bearer", value: "oauth-token" }),
+      { providerID: "anthropic", modelID: "claude-sonnet-5" },
+    );
+
+    await client.prompt("system", "user", {
+      sessionID: "sess-think-oauth",
+      workerID: "lore-distill",
+      model: { providerID: "anthropic", modelID: "claude-sonnet-5" },
+    });
+
+    // The interleaved-thinking beta IS replayed (unchanged behavior)...
+    expect(betaOf(0)).toContain("interleaved-thinking");
+    // ...but thinking is explicitly disabled, so the model cannot burn its
+    // budget on an (empty) thinking block and starve the visible text.
+    expect(bodyOf(0)?.thinking).toEqual({ type: "disabled" });
+  });
+
+  test("anthropic-compat (non-Claude) worker does NOT send a thinking param", async () => {
+    mockFetch.mockResolvedValue(okResponse());
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "mm-key" }),
+      { providerID: "minimax", modelID: "MiniMax-M1" },
+    );
+
+    await client.prompt("system", "user", {
+      sessionID: "sess-think-mm",
+      workerID: "lore-distill",
+      model: { providerID: "minimax", modelID: "MiniMax-M1" },
+      protocol: "anthropic",
+      upstreamProviderID: "minimax",
+      upstreamUrl: "https://api.minimaxi.chat",
+    });
+
+    expect(bodyOf(0)).not.toHaveProperty("thinking");
+  });
+
+  test("bedrock mantle Claude worker does NOT send a thinking param (untested body field on mantle; cannot hit the OAuth thinking trigger)", async () => {
+    mockFetch.mockResolvedValue(okResponse());
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "bedrock-key" }),
+      { providerID: "bedrock", modelID: "claude-haiku-4-5" },
+    );
+
+    await client.prompt("system", "user", {
+      sessionID: "sess-think-bedrock",
+      workerID: "lore-distill",
+      upstreamUrl: "https://bedrock-mantle.us-east-1.api.aws/anthropic",
+      upstreamProviderID: "bedrock",
+      protocol: "anthropic",
+    });
+
+    expect(bodyOf(0)).not.toHaveProperty("thinking");
+    // Sanity: it IS a Claude model, just scoped out by the mantle-host guard.
+    expect(bodyOf(0)?.model).toBe("anthropic.claude-haiku-4-5");
   });
 });

--- a/packages/gateway/test/llm-adapter.test.ts
+++ b/packages/gateway/test/llm-adapter.test.ts
@@ -23,7 +23,10 @@ import {
   AUTH_ERROR_CODES,
   isTemperatureUnsupportedModel,
   isAnthropicClaudeModel,
+  isThinkingUnsupportedModel,
+  markThinkingUnsupported,
   _resetTemperatureUnsupportedModels,
+  _resetThinkingUnsupportedModels,
 } from "../src/llm-adapter";
 import {
   getConsecutiveTrips,
@@ -1746,10 +1749,25 @@ describe("worker thinking disabled for Anthropic Claude models", () => {
     openai: "https://api.openai.com",
   };
 
+  beforeEach(() => {
+    _resetThinkingUnsupportedModels();
+  });
+
   afterEach(() => {
     mockFetch.mockReset();
     clearAllCosts();
     resetBackgroundLimiter();
+    _resetThinkingUnsupportedModels();
+  });
+
+  // Anthropic-style 400 for a model that doesn't accept the `thinking` field
+  // (e.g. one that predates the thinking API).
+  const THINKING_UNSUPPORTED_400 = JSON.stringify({
+    type: "error",
+    error: {
+      type: "invalid_request_error",
+      message: "thinking: Extra inputs are not permitted",
+    },
   });
 
   function bodyOf(callIndex: number): Record<string, unknown> | undefined {
@@ -1872,5 +1890,102 @@ describe("worker thinking disabled for Anthropic Claude models", () => {
     expect(bodyOf(0)).not.toHaveProperty("thinking");
     // Sanity: it IS a Claude model, just scoped out by the mantle-host guard.
     expect(bodyOf(0)?.model).toBe("anthropic.claude-haiku-4-5");
+  });
+
+  test("retries once without the thinking param on a thinking-unsupported 400, then succeeds and learns", async () => {
+    let call = 0;
+    mockFetch.mockImplementation(async () => {
+      call++;
+      if (call === 1) {
+        return new Response(THINKING_UNSUPPORTED_400, { status: 400 });
+      }
+      return new Response(
+        JSON.stringify({
+          content: [{ type: "text", text: "recovered" }],
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+
+    const model = { providerID: "anthropic", modelID: "claude-legacy-3" };
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "sk-ant-test" }),
+      model,
+    );
+
+    const result = await client.prompt("system", "user", {
+      sessionID: "sess-think-400",
+      workerID: "lore-distill",
+      model,
+    });
+
+    expect(result).toBe("recovered");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    // First attempt carried thinking; the retry dropped it entirely.
+    expect(bodyOf(0)?.thinking).toEqual({ type: "disabled" });
+    expect(bodyOf(1)).toBeDefined();
+    expect(bodyOf(1)).not.toHaveProperty("thinking");
+    // The model is now learned as thinking-unsupported.
+    expect(isThinkingUnsupportedModel(model)).toBe(true);
+    // A recovered thinking-strip retry is NOT a worker failure.
+    expect(recordWorkerFailure).not.toHaveBeenCalled();
+    expect(markWorkerPaused).not.toHaveBeenCalled();
+  });
+
+  test("omits the thinking param upfront once a model is learned", async () => {
+    const model = { providerID: "anthropic", modelID: "claude-legacy-3" };
+    markThinkingUnsupported(model);
+    mockFetch.mockResolvedValue(okResponse());
+
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "sk-ant-test" }),
+      model,
+    );
+
+    await client.prompt("system", "user", {
+      sessionID: "sess-think-learned",
+      workerID: "lore-distill",
+      model,
+    });
+
+    // No wasted round-trip — thinking is omitted upfront on the first call.
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(bodyOf(0)).not.toHaveProperty("thinking");
+  });
+
+  test("does not strip thinking for an unrelated 400", async () => {
+    let call = 0;
+    mockFetch.mockImplementation(async () => {
+      call++;
+      return new Response(
+        JSON.stringify({
+          type: "error",
+          error: { type: "invalid_request_error", message: "bad request" },
+        }),
+        { status: 400 },
+      );
+    });
+
+    const model = { providerID: "anthropic", modelID: "claude-sonnet-5" };
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "sk-ant-test" }),
+      model,
+    );
+
+    const result = await client.prompt("system", "user", {
+      sessionID: "sess-think-unrelated",
+      workerID: "lore-distill",
+      model,
+    });
+
+    expect(result).toBeNull();
+    // No thinking-strip retry for an unrelated 400 — single attempt, not learned.
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(isThinkingUnsupportedModel(model)).toBe(false);
+    expect(call).toBe(1);
   });
 });


### PR DESCRIPTION
## Problem

Claude Code OAuth sessions on **claude-sonnet-5** saw background workers silently fail:

```
worker empty response (HTTP 200) — model=anthropic/claude-sonnet-5 worker=lore-distill
  fields=[block:thinking] finish_reason=n/a
  body={..."content":[{"type":"thinking","thinking":"","signature":"..."}]}
[worker-health] lore-distill degraded: 100+ failures in 5min (reasons: no-response)
```

HTTP 200 with a single **empty `thinking` block** and no visible text → the worker gets nothing usable and the whole distill/curate loop degrades ("background workers not working").

## Root cause (confirmed by the Sonnet 5 / Opus 4.8 docs)

Per [What's new in Claude Sonnet 5](https://platform.claude.com/docs/en/about-claude/models/whats-new-sonnet-5):
- **Adaptive thinking is ON BY DEFAULT** on sonnet-5. "To turn thinking off, pass `thinking: {type: "disabled"}`."
- `max_tokens` is a hard cap on **thinking + text**, so a thinking-heavy turn can return an empty thinking block with no text.
- Sampling params (`temperature`/`top_p`/`top_k`) now **400** (also on Opus 4.7/4.8).

So workers (deterministic single-shot summarization) must explicitly disable thinking; they never benefit from it.

## Fix (data-driven via models.dev)

models.dev exposes exactly the capability data we need, and it already backs worker model selection:

| signal | meaning | action |
|---|---|---|
| `reasoning_options` has `{type:"toggle"}` | adaptive thinking **on by default** (sonnet-5) | send `thinking:{type:"disabled"}` |
| `reasoning_options` `effort`/`budget_tokens` only | off by default (opus-4.8, sonnet-4.5) | nothing |
| `temperature: false` | deprecated sampling (sonnet-5, opus-4.7/4.8, gpt-5, o3) | strip `temperature` proactively |

- `workerThinkingOnByDefault()` reads `reasoning_options`, **falling back to the Claude-id heuristic only when models.dev has no data** (outage / brand-new id) — a models.dev outage must never silently re-break sonnet-5 workers. Sending `disabled` to an off-by-default model is a harmless no-op (verified against the live API).
- Applies across the Anthropic Messages wire protocols: **direct**, **Bedrock mantle** (`protocol: anthropic`), and **Vertex** (`buildVertexWorkerRequest` now honors the flag via `toVertexBody`).
- `temperature` is stripped proactively when `temperature: false`; the runtime learning net (from #1100) remains the fallback.
- **Learning net for thinking**: if a model rejects `thinking:{type:"disabled"}` (older claude-3.x), a one-shot 400 retry strips it and learns the model (deferred marking on the 2xx). Mirrors the temperature mechanism.

## Review bot findings addressed
- **Seer (no thinking fallback):** added the thinking learning/retry mechanism.
- **Seer (Vertex spurious retry):** Vertex builder now honors `disableThinking`; gate is data-driven so effort-only models never trigger it.

## Tests
New `worker thinking disabled` + `driven by models.dev capability data` blocks: toggle vs effort vs budget_tokens, offline fallback, effort-only no-op, OAuth-fingerprint path, Bedrock/Vertex, thinking learning retry, proactive temperature strip/keep. All red-phase verified via mutation. Full gateway suite green.