### PR TITLE
fix(gateway): extend worker temperature-deprecation handling to the batch path

### DIFF
--- a/packages/gateway/src/batch-queue.ts
+++ b/packages/gateway/src/batch-queue.ts
@@ -38,6 +38,7 @@ import {
   isTemperatureUnsupported400,
   isTemperatureUnsupportedModel,
   markTemperatureUnsupported,
+  modelRejectsTemperatureByData,
   normalizeOpenAIUsage,
 } from "./llm-adapter";
 import { upstreamFetch } from "./fetch";
@@ -526,8 +527,12 @@ function systemToText(
  * includes it. The single-request path retries-then-strips + learns the model
  * (see llm-adapter's `temperatureUnsupportedModels`), but a batch item has no
  * per-item retry — a submitted item that includes an unsupported `temperature`
- * just errors — so we must omit it UPFRONT here, consulting the same shared
- * learned set (also fed by this path's own errored-item handler below).
+ * just errors — so we must omit it UPFRONT here. We consult two sources: the
+ * models.dev capability data (`modelRejectsTemperatureByData` — proactive, so
+ * even the FIRST batch for a deprecated-sampling model omits it and never
+ * wastes a round-trip) and the shared runtime learned set
+ * (`isTemperatureUnsupportedModel` — the fallback for models absent from
+ * models.dev, also fed by this path's own errored-item handler below).
  *
  * Returns the original object (no copy) when `temperature` is absent or the
  * model is not known to reject it.
@@ -536,15 +541,14 @@ function paramsWithSupportedTemperature(item: {
   providerID: string;
   params: PendingRequest["params"];
 }): PendingRequest["params"] {
-  if (
-    item.params.temperature == null ||
-    !isTemperatureUnsupportedModel({
+  if (item.params.temperature == null) return item.params;
+  const rejectsTemperature =
+    modelRejectsTemperatureByData(item.params.model) ||
+    isTemperatureUnsupportedModel({
       providerID: item.providerID,
       modelID: item.params.model,
-    })
-  ) {
-    return item.params;
-  }
+    });
+  if (!rejectsTemperature) return item.params;
   const { temperature: _omit, ...rest } = item.params;
   return rest;
 }

--- a/packages/gateway/src/batch-queue.ts
+++ b/packages/gateway/src/batch-queue.ts
@@ -34,7 +34,12 @@ import {
   type AnthropicUsage,
 } from "./sentry";
 import { recordWorkerCost } from "./cost-tracker";
-import { normalizeOpenAIUsage } from "./llm-adapter";
+import {
+  isTemperatureUnsupported400,
+  isTemperatureUnsupportedModel,
+  markTemperatureUnsupported,
+  normalizeOpenAIUsage,
+} from "./llm-adapter";
 import { upstreamFetch } from "./fetch";
 
 // ---------------------------------------------------------------------------
@@ -77,7 +82,11 @@ export interface BatchProvider {
    */
   submit(
     auth: AuthCredential,
-    items: Array<{ customId: string; params: PendingRequest["params"] }>,
+    items: Array<{
+      customId: string;
+      providerID: string;
+      params: PendingRequest["params"];
+    }>,
   ): Promise<string | "auth-error" | "not-found" | null>;
   /** Poll a batch for completion. */
   poll(auth: AuthCredential, batchId: string): Promise<PollResult>;
@@ -234,7 +243,7 @@ export function createAnthropicBatchProvider(
     async submit(auth, items) {
       const requests = items.map((item) => ({
         custom_id: item.customId,
-        params: item.params,
+        params: paramsWithSupportedTemperature(item),
       }));
 
       const url = `${baseUrl}/v1/messages/batches`;
@@ -510,6 +519,36 @@ function systemToText(
   return system.map((b) => b.text).join("\n");
 }
 
+/**
+ * Return the item's Messages params with `temperature` omitted when the target
+ * model has been observed to reject it. Newer models (claude-sonnet-5, GPT-5 /
+ * o-series) DEPRECATE the sampling `temperature` param and 400 any request that
+ * includes it. The single-request path retries-then-strips + learns the model
+ * (see llm-adapter's `temperatureUnsupportedModels`), but a batch item has no
+ * per-item retry — a submitted item that includes an unsupported `temperature`
+ * just errors — so we must omit it UPFRONT here, consulting the same shared
+ * learned set (also fed by this path's own errored-item handler below).
+ *
+ * Returns the original object (no copy) when `temperature` is absent or the
+ * model is not known to reject it.
+ */
+function paramsWithSupportedTemperature(item: {
+  providerID: string;
+  params: PendingRequest["params"];
+}): PendingRequest["params"] {
+  if (
+    item.params.temperature == null ||
+    !isTemperatureUnsupportedModel({
+      providerID: item.providerID,
+      modelID: item.params.model,
+    })
+  ) {
+    return item.params;
+  }
+  const { temperature: _omit, ...rest } = item.params;
+  return rest;
+}
+
 /** Max batch age for OpenAI (4 hours). OpenAI allows up to 24h but we don't
  *  want to wait that long for background work results. */
 const OPENAI_MAX_BATCH_AGE_MS = 4 * 60 * 60 * 1000; // 4 hours
@@ -531,24 +570,25 @@ export function createOpenAIBatchProvider(upstreamUrl: string): BatchProvider {
     async submit(auth, items) {
       // 1. Build JSONL content — one line per request
       const lines = items.map((item) => {
+        const params = paramsWithSupportedTemperature(item);
         const messages: Array<{ role: string; content: string }> = [];
-        if (item.params.system) {
+        if (params.system) {
           messages.push({
             role: "system",
-            content: systemToText(item.params.system),
+            content: systemToText(params.system),
           });
         }
-        messages.push(...item.params.messages);
+        messages.push(...params.messages);
 
         return JSON.stringify({
           custom_id: item.customId,
           method: "POST",
           url: "/v1/chat/completions",
           body: {
-            model: item.params.model,
-            max_completion_tokens: item.params.max_tokens,
-            ...(item.params.temperature != null && {
-              temperature: item.params.temperature,
+            model: params.model,
+            max_completion_tokens: params.max_tokens,
+            ...(params.temperature != null && {
+              temperature: params.temperature,
             }),
             messages,
           },
@@ -765,7 +805,11 @@ export function createBatchLLMClient(
     try {
       const batchId = await provider.submit(
         auth,
-        items.map((item) => ({ customId: item.customId, params: item.params })),
+        items.map((item) => ({
+          customId: item.customId,
+          providerID: item.providerID,
+          params: item.params,
+        })),
       );
 
       if (!batchId || batchId === "auth-error" || batchId === "not-found") {
@@ -980,6 +1024,16 @@ export function createBatchLLMClient(
             break;
           }
           case "errored":
+            // Learn a "temperature is deprecated" rejection so subsequent
+            // submits (batch AND single-request) omit `temperature` upfront for
+            // this model instead of re-erroring every item. Feeds the same
+            // shared set consulted by paramsWithSupportedTemperature().
+            if (result.error && isTemperatureUnsupported400(result.error)) {
+              markTemperatureUnsupported({
+                providerID: pending.providerID,
+                modelID: pending.params.model,
+              });
+            }
             pending.resolve(null); // Match inner client behavior (null on error)
             totalFailed++;
             log.error(

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -208,7 +208,7 @@ export function _resetTemperatureUnsupportedModels(): void {
  * verb so an unrelated 400 that merely mentions temperature can't trigger the
  * one-shot temperature-stripped retry.
  */
-function isTemperatureUnsupported400(body: string): boolean {
+export function isTemperatureUnsupported400(body: string): boolean {
   return (
     /temperature/i.test(body) &&
     /\b(deprecated|unsupported|no\s+longer\s+supported|not\s+(?:a\s+)?support(?:ed)?|removed|not\s+allowed|cannot\s+be\s+(?:set|used|specified))\b/i.test(

--- a/packages/gateway/test/batch-queue.test.ts
+++ b/packages/gateway/test/batch-queue.test.ts
@@ -27,6 +27,7 @@ import {
   isTemperatureUnsupportedModel,
   markTemperatureUnsupported,
 } from "../src/llm-adapter";
+import { _setModelDataForTest, clearModelDataCache } from "../src/worker-model";
 
 const TEST_AUTH: AuthCredential = { scheme: "api-key", value: "test-key" };
 const getTestAuth = () => TEST_AUTH;
@@ -1267,9 +1268,11 @@ describe("BatchLLMClient", () => {
 describe("BatchLLMClient temperature capability", () => {
   beforeEach(() => {
     _resetTemperatureUnsupportedModels();
+    clearModelDataCache();
   });
   afterEach(() => {
     _resetTemperatureUnsupportedModels();
+    clearModelDataCache();
   });
 
   test("Anthropic batch omits temperature for a model learned to reject it", async () => {
@@ -1318,6 +1321,76 @@ describe("BatchLLMClient temperature capability", () => {
       UPSTREAMS,
       getTestAuth,
       DEFAULT_MODEL,
+      {
+        flushIntervalMs: 60_000,
+        maxQueueSize: 1,
+      },
+    );
+
+    client.prompt("sys", "msg", { workerID: "lore-distill", temperature: 0 });
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(fetchCalls[0]?.body?.requests[0]?.params.temperature).toBe(0);
+
+    await client.shutdown();
+  });
+
+  test("Anthropic batch omits temperature UPFRONT for a model models.dev marks temperature:false (no prior 400)", async () => {
+    const inner = createMockLLMClient();
+    // models.dev says this model dropped the sampling `temperature` param.
+    // The batch path must strip it on the FIRST submit — before any 400 — so
+    // it never wastes a round-trip on a guaranteed-to-error item.
+    _setModelDataForTest({
+      "claude-sonnet-5": { id: "claude-sonnet-5", temperature: false },
+    });
+    pushFetchResponse(true, 200, {
+      id: "msgbatch_datatempstrip",
+      processing_status: "in_progress",
+    });
+
+    const client = createBatchLLMClient(
+      inner,
+      UPSTREAMS,
+      getTestAuth,
+      { providerID: "anthropic", modelID: "claude-sonnet-5" },
+      {
+        flushIntervalMs: 60_000,
+        maxQueueSize: 1,
+      },
+    );
+
+    client.prompt("sys", "msg", { workerID: "lore-distill", temperature: 0 });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const params = fetchCalls[0]?.body?.requests[0]?.params;
+    expect(params).toBeDefined();
+    expect(params).not.toHaveProperty("temperature");
+    // Proactive strip came from models.dev data, NOT the runtime learning net.
+    expect(
+      isTemperatureUnsupportedModel({
+        providerID: "anthropic",
+        modelID: "claude-sonnet-5",
+      }),
+    ).toBe(false);
+
+    await client.shutdown();
+  });
+
+  test("Anthropic batch keeps temperature when models.dev marks the model temperature:true", async () => {
+    const inner = createMockLLMClient();
+    _setModelDataForTest({
+      "claude-sonnet-4-5": { id: "claude-sonnet-4-5", temperature: true },
+    });
+    pushFetchResponse(true, 200, {
+      id: "msgbatch_datatempkeep",
+      processing_status: "in_progress",
+    });
+
+    const client = createBatchLLMClient(
+      inner,
+      UPSTREAMS,
+      getTestAuth,
+      { providerID: "anthropic", modelID: "claude-sonnet-4-5" },
       {
         flushIntervalMs: 60_000,
         maxQueueSize: 1,

--- a/packages/gateway/test/batch-queue.test.ts
+++ b/packages/gateway/test/batch-queue.test.ts
@@ -1405,6 +1405,155 @@ describe("BatchLLMClient temperature capability", () => {
     await client.shutdown();
   });
 
+  test("OpenAI batch omits temperature UPFRONT for a model models.dev marks temperature:false", async () => {
+    // The OpenAI submit path builds JSONL (not the anthropic requests[] shape),
+    // so it needs its own coverage: the proactive strip must apply there too or
+    // every gpt-5/o3 batch item 400s. Capture the uploaded JSONL and assert the
+    // per-line body omits `temperature`.
+    const inner = createMockLLMClient();
+    _setModelDataForTest({ "gpt-5": { id: "gpt-5", temperature: false } });
+
+    let capturedJsonl = "";
+    const prevFetch = globalThis.fetch;
+    // @ts-expect-error — mock fetch to capture the FormData file upload
+    globalThis.fetch = async (url: string, init?: RequestInit) => {
+      const method = init?.method ?? "GET";
+      if (
+        typeof url === "string" &&
+        url.includes("/v1/files") &&
+        init?.body instanceof FormData
+      ) {
+        const file = (init.body as FormData).get("file") as Blob;
+        if (file) capturedJsonl = await file.text();
+        return {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          text: async () => JSON.stringify({ id: "file-temp" }),
+          json: async () => ({ id: "file-temp" }),
+        };
+      }
+      if (
+        typeof url === "string" &&
+        url.includes("/v1/batches") &&
+        method === "POST"
+      ) {
+        return {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          text: async () => JSON.stringify({ id: "batch-temp" }),
+          json: async () => ({ id: "batch-temp" }),
+        };
+      }
+      return {
+        ok: false,
+        status: 500,
+        text: async () => "unexpected",
+        json: async () => ({}),
+      };
+    };
+
+    const client = createBatchLLMClient(
+      inner,
+      UPSTREAMS,
+      getTestAuth,
+      DEFAULT_MODEL,
+      {
+        flushIntervalMs: 60_000,
+        maxQueueSize: 1,
+      },
+    );
+
+    client.prompt("sys", "msg", {
+      model: { providerID: "openai", modelID: "gpt-5" },
+      workerID: "lore-distill",
+      temperature: 0,
+    });
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(capturedJsonl).not.toBe("");
+    const line = JSON.parse(capturedJsonl) as { body: Record<string, unknown> };
+    expect(line.body.model).toBe("gpt-5");
+    expect(line.body).not.toHaveProperty("temperature");
+
+    globalThis.fetch = prevFetch;
+    await client.shutdown();
+  });
+
+  test("OpenAI batch keeps temperature for a model that supports it", async () => {
+    const inner = createMockLLMClient();
+    _setModelDataForTest({
+      "gpt-5.4-mini": { id: "gpt-5.4-mini", temperature: true },
+    });
+
+    let capturedJsonl = "";
+    const prevFetch = globalThis.fetch;
+    // @ts-expect-error — mock fetch to capture the FormData file upload
+    globalThis.fetch = async (url: string, init?: RequestInit) => {
+      const method = init?.method ?? "GET";
+      if (
+        typeof url === "string" &&
+        url.includes("/v1/files") &&
+        init?.body instanceof FormData
+      ) {
+        const file = (init.body as FormData).get("file") as Blob;
+        if (file) capturedJsonl = await file.text();
+        return {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          text: async () => JSON.stringify({ id: "file-keep" }),
+          json: async () => ({ id: "file-keep" }),
+        };
+      }
+      if (
+        typeof url === "string" &&
+        url.includes("/v1/batches") &&
+        method === "POST"
+      ) {
+        return {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          text: async () => JSON.stringify({ id: "batch-keep" }),
+          json: async () => ({ id: "batch-keep" }),
+        };
+      }
+      return {
+        ok: false,
+        status: 500,
+        text: async () => "unexpected",
+        json: async () => ({}),
+      };
+    };
+
+    const client = createBatchLLMClient(
+      inner,
+      UPSTREAMS,
+      getTestAuth,
+      DEFAULT_MODEL,
+      {
+        flushIntervalMs: 60_000,
+        maxQueueSize: 1,
+      },
+    );
+
+    client.prompt("sys", "msg", {
+      model: { providerID: "openai", modelID: "gpt-5.4-mini" },
+      workerID: "lore-distill",
+      temperature: 0,
+    });
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(capturedJsonl).not.toBe("");
+    const line = JSON.parse(capturedJsonl) as { body: Record<string, unknown> };
+    expect(line.body.temperature).toBe(0);
+
+    globalThis.fetch = prevFetch;
+    await client.shutdown();
+  });
+
   test("learns temperature-unsupported from a batch item that errors with a deprecation message", async () => {
     const inner = createMockLLMClient();
     const MODEL = { providerID: "anthropic", modelID: "claude-sonnet-5" };

--- a/packages/gateway/test/batch-queue.test.ts
+++ b/packages/gateway/test/batch-queue.test.ts
@@ -22,6 +22,11 @@ vi.mock("../src/fetch", () => ({
 }));
 import type { LLMClient } from "@loreai/core";
 import type { AuthCredential } from "../src/auth";
+import {
+  _resetTemperatureUnsupportedModels,
+  isTemperatureUnsupportedModel,
+  markTemperatureUnsupported,
+} from "../src/llm-adapter";
 
 const TEST_AUTH: AuthCredential = { scheme: "api-key", value: "test-key" };
 const getTestAuth = () => TEST_AUTH;
@@ -51,6 +56,7 @@ interface BatchCreateBody {
     params: {
       model: string;
       max_tokens: number;
+      temperature?: number;
       system: string | Array<{ type: string; text: string }>;
       messages: Array<{ role: string; content: string }>;
     };
@@ -1242,6 +1248,182 @@ describe("BatchLLMClient", () => {
     expect(logged).toContain("context_length_exceeded");
 
     errorSpy.mockRestore();
+    globalThis.fetch = prevFetch;
+    await client.shutdown();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Temperature capability on the batch path.
+//
+// Newer models (claude-sonnet-5, GPT-5 / o-series) DEPRECATE the sampling
+// `temperature` param and 400 any request carrying it. The single-request path
+// retries-then-strips + learns the model; a batch item has no per-item retry, so
+// a submitted item carrying an unsupported `temperature` just errors. The batch
+// submit must omit `temperature` upfront for models learned to reject it (shared
+// set with the single path), and it must LEARN from a batch item that errors
+// with a deprecation message so the next submit self-heals.
+// ---------------------------------------------------------------------------
+describe("BatchLLMClient temperature capability", () => {
+  beforeEach(() => {
+    _resetTemperatureUnsupportedModels();
+  });
+  afterEach(() => {
+    _resetTemperatureUnsupportedModels();
+  });
+
+  test("Anthropic batch omits temperature for a model learned to reject it", async () => {
+    const inner = createMockLLMClient();
+    // Model already learned as temperature-unsupported (e.g. from a prior
+    // single-request 400 or an earlier batch error).
+    markTemperatureUnsupported({
+      providerID: "anthropic",
+      modelID: "claude-sonnet-4-20250514",
+    });
+    pushFetchResponse(true, 200, {
+      id: "msgbatch_tempstrip",
+      processing_status: "in_progress",
+    });
+
+    const client = createBatchLLMClient(
+      inner,
+      UPSTREAMS,
+      getTestAuth,
+      DEFAULT_MODEL,
+      {
+        flushIntervalMs: 60_000,
+        maxQueueSize: 1,
+      },
+    );
+
+    client.prompt("sys", "msg", { workerID: "lore-distill", temperature: 0 });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const params = fetchCalls[0]?.body?.requests[0]?.params;
+    expect(params).toBeDefined();
+    expect(params).not.toHaveProperty("temperature");
+
+    await client.shutdown();
+  });
+
+  test("Anthropic batch keeps temperature for a model that supports it", async () => {
+    const inner = createMockLLMClient();
+    pushFetchResponse(true, 200, {
+      id: "msgbatch_tempkeep",
+      processing_status: "in_progress",
+    });
+
+    const client = createBatchLLMClient(
+      inner,
+      UPSTREAMS,
+      getTestAuth,
+      DEFAULT_MODEL,
+      {
+        flushIntervalMs: 60_000,
+        maxQueueSize: 1,
+      },
+    );
+
+    client.prompt("sys", "msg", { workerID: "lore-distill", temperature: 0 });
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(fetchCalls[0]?.body?.requests[0]?.params.temperature).toBe(0);
+
+    await client.shutdown();
+  });
+
+  test("learns temperature-unsupported from a batch item that errors with a deprecation message", async () => {
+    const inner = createMockLLMClient();
+    const MODEL = { providerID: "anthropic", modelID: "claude-sonnet-5" };
+
+    // Full Anthropic batch lifecycle, ordered: create → poll(ended) → results.
+    let capturedCustomId = "";
+    const prevFetch = globalThis.fetch;
+    let idx = 0;
+    // @ts-expect-error — mock fetch
+    globalThis.fetch = async (url: string, init?: RequestInit) => {
+      const i = idx++;
+      // 0: batch create — capture the generated custom_id for the results row.
+      if (i === 0) {
+        expect(String(url)).toContain("/v1/messages/batches");
+        const body = JSON.parse(init?.body as string);
+        capturedCustomId = body.requests[0].custom_id;
+        // Not-yet-learned model: temperature IS carried into the submit.
+        expect(body.requests[0].params.temperature).toBe(0);
+        return {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          text: async () => JSON.stringify({ id: "msgbatch_learn" }),
+          json: async () => ({ id: "msgbatch_learn" }),
+        };
+      }
+      // 1: poll — batch ended.
+      if (i === 1) {
+        const poll = {
+          processing_status: "ended",
+          results_url:
+            "https://api.anthropic.com/v1/messages/batches/msgbatch_learn/results",
+        };
+        return {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          text: async () => JSON.stringify(poll),
+          json: async () => poll,
+        };
+      }
+      // 2: results JSONL — one errored row with the temperature-deprecation message.
+      if (i === 2) {
+        const jsonl = JSON.stringify({
+          custom_id: capturedCustomId,
+          result: {
+            type: "errored",
+            error: {
+              type: "invalid_request_error",
+              message: "`temperature` is deprecated for this model.",
+            },
+          },
+        });
+        return {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          text: async () => jsonl,
+          json: async () => JSON.parse(jsonl),
+        };
+      }
+      return {
+        ok: false,
+        status: 500,
+        statusText: "Error",
+        text: async () => "unexpected",
+        json: async () => ({}),
+      };
+    };
+
+    const client = createBatchLLMClient(inner, UPSTREAMS, getTestAuth, MODEL, {
+      flushIntervalMs: 60_000,
+      maxQueueSize: 1,
+      pollIntervalMs: 50,
+    });
+
+    // Pre-condition: not yet learned.
+    expect(isTemperatureUnsupportedModel(MODEL)).toBe(false);
+
+    const promise = client.prompt("sys", "msg", {
+      workerID: "lore-distill",
+      model: MODEL,
+      temperature: 0,
+    });
+
+    await new Promise((r) => setTimeout(r, 300));
+
+    // Errored item resolves null (matches inner-client-on-error behavior)...
+    expect(await promise).toBeNull();
+    // ...and the model is now learned so the NEXT submit omits temperature.
+    expect(isTemperatureUnsupportedModel(MODEL)).toBe(true);
+
     globalThis.fetch = prevFetch;
     await client.shutdown();
   });


### PR DESCRIPTION
## Problem

Follow-up to #1100. That PR fixed the **single-request** worker path (retry-then-strip + learn) when a model rejects the deprecated `temperature` param. The **batch** submit path was missed, so Claude Code sessions using the Message Batches API kept failing every item:

```
batch item lore-... errored: invalid_request_error: `temperature` is deprecated for this model.
```

(Seen in production right alongside the sonnet-5 worker breakage — the batch path continued erroring after #1100 shipped.)

## Why the single-path fix doesn't cover it

A batch item has **no per-item retry** — a submitted item carrying an unsupported `temperature` just errors. So we must omit it **upfront** rather than reactively strip-and-retry.

## Fix

- `paramsWithSupportedTemperature()` omits `temperature` when the target model is in the shared learned set (`isTemperatureUnsupportedModel`), applied in **both** the Anthropic and OpenAI batch submit builders.
- The errored-item handler now **learns** from a temperature-deprecation message (`isTemperatureUnsupported400`, now exported) via `markTemperatureUnsupported`, so the first bad batch self-heals the next submit — and feeds the single path too (shared set).
- Threaded `providerID` through `BatchProvider.submit` items so the learned set is keyed by `providerID/modelID`, matching the single path.

## Tests

`packages/gateway/test/batch-queue.test.ts` — new `temperature capability` block:
- Anthropic batch omits `temperature` for a learned-unsupported model,
- Anthropic batch keeps `temperature` for a supported model,
- learns temperature-unsupported from a batch item that errors with a deprecation message (full create→poll→results lifecycle).

Red-phase verified (reverting the strip kills the omit test; reverting the learn call kills the learn test; the keep test stays green). Full gateway suite green (2449 passed).

Depends on nothing in #1109; independent files (merges cleanly in any order).