### PR TITLE
fix(gateway): gate temporal re-chunk backfill on embed-pool idle, not session activity

### DIFF
--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -898,8 +898,7 @@ class LocalProvider implements EmbeddingProvider {
     const id = this.nextRequestId++;
     // Recall queries (single query-type texts) get high priority so they
     // jump ahead of any queued backfill batches in the worker.
-    const priority =
-      inputType === "query" && texts.length === 1 ? "high" : "normal";
+    const priority = isRecallEmbed(texts, inputType) ? "high" : "normal";
 
     const payload: EmbedRequest = {
       type: "embed",
@@ -1218,6 +1217,55 @@ export function isAvailable(): boolean {
 // ---------------------------------------------------------------------------
 
 /**
+ * A single-text `query` embed is a recall lookup — the latency-sensitive
+ * request path (the recall tool and forSession LTM ranking), as opposed to
+ * batch/document writes. This is the single source of truth for that
+ * classification: the worker uses it to assign "high" priority (see
+ * {@link LocalProvider.embed}) and {@link embed} uses it to track in-flight
+ * recall load for the temporal backfill's idle-gate. Both sites call this one
+ * predicate so the "mirrors the worker" invariant can never silently drift.
+ */
+function isRecallEmbed(
+  texts: string[],
+  inputType: "document" | "query",
+): boolean {
+  return inputType === "query" && texts.length === 1;
+}
+
+/**
+ * Number of recall (single query-text) embeds currently in flight through
+ * {@link embed}. The temporal re-chunk backfill reads this (via
+ * {@link recallEmbedsInFlight}) to yield the shared embedding worker to
+ * latency-sensitive recall lookups: it parks a page while a recall embed is
+ * outstanding and resumes the instant the worker drains.
+ *
+ * Only single-text `query` embeds are counted — that is exactly the class the
+ * worker itself marks "high priority" (see LocalProvider.embed). Document/batch
+ * embeds (write-time message/knowledge/entity embeds AND the backfill's own
+ * embeds) are deliberately NOT counted, so the backfill never gates against its
+ * own load or against fire-and-forget background writes.
+ */
+let _recallEmbedsInFlight = 0;
+
+/**
+ * Live count of in-flight recall (single query-text) embeds — the temporal
+ * re-chunk backfill's idle signal. Read on every gate poll so it reflects the
+ * shared worker's current recall load, never a stale snapshot.
+ */
+export function recallEmbedsInFlight(): number {
+  return _recallEmbedsInFlight;
+}
+
+/**
+ * Test seam: force the in-flight recall-embed counter to a known value so the
+ * gateway's idle-gate wiring can be exercised deterministically without driving
+ * a real (async, provider-dependent) embed. Test-only.
+ */
+export function _setRecallEmbedsInFlightForTest(n: number): void {
+  _recallEmbedsInFlight = n;
+}
+
+/**
  * Generate embeddings for the given texts using the configured provider.
  *
  * Remote providers (voyage, openai) are explicit opt-in via
@@ -1236,11 +1284,23 @@ export async function embed(
 ): Promise<Float32Array[]> {
   const provider = getProvider();
   if (!provider) throw new Error("No embedding provider available");
-  const vecs = await provider.embed(texts, inputType);
-  // Enforce the L2-normalization invariant at the single chokepoint so the JS
-  // dot-product path and sqlite-vec's vec_distance_cosine() always agree. See
-  // l2Normalize() for the full rationale.
-  return vecs.map(l2Normalize);
+  // A single-text query embed is a recall lookup (see isRecallEmbed — the same
+  // predicate the worker uses for high priority). Track it in flight so the
+  // temporal re-chunk backfill can yield the shared worker while recall is
+  // active. The counter is decremented in `finally` so a rejected embed
+  // (provider gone, OOM, timeout) can never leak a permanent "busy" that would
+  // wedge the backfill forever.
+  const isRecall = isRecallEmbed(texts, inputType);
+  if (isRecall) _recallEmbedsInFlight++;
+  try {
+    const vecs = await provider.embed(texts, inputType);
+    // Enforce the L2-normalization invariant at the single chokepoint so the JS
+    // dot-product path and sqlite-vec's vec_distance_cosine() always agree. See
+    // l2Normalize() for the full rationale.
+    return vecs.map(l2Normalize);
+  } finally {
+    if (isRecall) _recallEmbedsInFlight--;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/test/embedding.test.ts
+++ b/packages/core/test/embedding.test.ts
@@ -14,6 +14,8 @@ import {
   _saveAndClearProvider,
   _restoreProvider,
   embed,
+  recallEmbedsInFlight,
+  _setRecallEmbedsInFlightForTest,
   runStartupBackfill,
   LocalProviderUnavailableError,
   pickRemoteFallback,
@@ -109,6 +111,114 @@ describe("embed() enforces the L2-normalization invariant", () => {
       expect(vec[1]).toBeCloseTo(0.8, 6);
     } finally {
       _restoreProvider(token);
+    }
+  });
+});
+
+describe("recallEmbedsInFlight (temporal backfill idle signal)", () => {
+  // A gated mock provider whose embed() blocks until the test releases it, so we
+  // can observe the in-flight counter WHILE an embed is outstanding.
+  function gatedProvider() {
+    let release!: () => void;
+    let reject!: (e: Error) => void;
+    const gate = new Promise<void>((res, rej) => {
+      release = res;
+      reject = rej;
+    });
+    return {
+      release,
+      reject,
+      token: {
+        provider: {
+          maxBatchSize: 8,
+          async embed(texts: string[], _inputType: "document" | "query") {
+            await gate;
+            return texts.map(() => new Float32Array([1, 0, 0]));
+          },
+        },
+      },
+    };
+  }
+
+  beforeEach(() => _setRecallEmbedsInFlightForTest(0));
+  afterEach(() => _setRecallEmbedsInFlightForTest(0));
+
+  test("counts a single-text query embed while in flight, clears after it settles", async () => {
+    const saved = _saveAndClearProvider();
+    const { release, token } = gatedProvider();
+    try {
+      _restoreProvider(token);
+      expect(recallEmbedsInFlight()).toBe(0);
+      const p = embed(["find the thing"], "query"); // recall lookup
+      // Increment happens synchronously before the first await inside embed().
+      expect(recallEmbedsInFlight()).toBe(1);
+      release();
+      await p;
+      expect(recallEmbedsInFlight()).toBe(0);
+    } finally {
+      _restoreProvider(saved);
+    }
+  });
+
+  test("does NOT count document embeds (write-time + the backfill's own load)", async () => {
+    const saved = _saveAndClearProvider();
+    const { release, token } = gatedProvider();
+    try {
+      _restoreProvider(token);
+      const p = embed(["a stored message"], "document");
+      expect(recallEmbedsInFlight()).toBe(0); // document embeds are not recall
+      release();
+      await p;
+      expect(recallEmbedsInFlight()).toBe(0);
+    } finally {
+      _restoreProvider(saved);
+    }
+  });
+
+  test("does NOT count a multi-text query embed (only single-text is a recall lookup)", async () => {
+    const saved = _saveAndClearProvider();
+    const { release, token } = gatedProvider();
+    try {
+      _restoreProvider(token);
+      const p = embed(["q1", "q2"], "query");
+      expect(recallEmbedsInFlight()).toBe(0);
+      release();
+      await p;
+      expect(recallEmbedsInFlight()).toBe(0);
+    } finally {
+      _restoreProvider(saved);
+    }
+  });
+
+  test("decrements even when the provider rejects (finally, not a leak)", async () => {
+    const saved = _saveAndClearProvider();
+    const { reject, token } = gatedProvider();
+    try {
+      _restoreProvider(token);
+      const p = embed(["boom"], "query");
+      expect(recallEmbedsInFlight()).toBe(1);
+      reject(new Error("provider blew up"));
+      await expect(p).rejects.toThrow("provider blew up");
+      // A leaked "busy" here would wedge the backfill forever.
+      expect(recallEmbedsInFlight()).toBe(0);
+    } finally {
+      _restoreProvider(saved);
+    }
+  });
+
+  test("tracks concurrent recall embeds additively", async () => {
+    const saved = _saveAndClearProvider();
+    const a = gatedProvider();
+    try {
+      _restoreProvider(a.token);
+      const p1 = embed(["one"], "query");
+      const p2 = embed(["two"], "query");
+      expect(recallEmbedsInFlight()).toBe(2);
+      a.release();
+      await Promise.all([p1, p2]);
+      expect(recallEmbedsInFlight()).toBe(0);
+    } finally {
+      _restoreProvider(saved);
     }
   });
 });

--- a/packages/gateway/src/backfill-gate.ts
+++ b/packages/gateway/src/backfill-gate.ts
@@ -8,10 +8,14 @@
  * before each row; this module supplies that policy.
  *
  * Policy: park the walk while background work is paused (a tripped circuit
- * breaker signals the whole system is degraded) OR any session was active
- * within `windowMs` (a request is likely in-flight or imminent). The walk
- * resumes once the host is quiet. Because the walk checkpoints per row, parking
- * for long stretches is free — it just resumes from the last durable cursor.
+ * breaker signals the whole system is degraded) OR the shared embedding worker
+ * is serving a live recall lookup (a single-query embed is in flight). Gating on
+ * the *actual shared resource* — not session activity — is what lets the walk
+ * make progress on a busy multi-session host: a session being "recently active"
+ * says nothing about whether the embed worker has spare capacity *right now*,
+ * whereas an empty recall-embed queue does. The walk resumes the instant the
+ * worker drains, and because it checkpoints per row, parking for long stretches
+ * is free — it just resumes from the last durable cursor.
  *
  * Factored out of the wiring as a pure factory over injected dependencies so it
  * is unit-testable without the pipeline's module state.
@@ -19,12 +23,12 @@
 export interface TemporalBackfillGateDeps {
   /** Whether background LLM/embed work is currently paused (circuit breaker). */
   isPaused: () => boolean;
-  /** Live view of tracked sessions; re-read on every gate call. */
-  activeSessions: () => Iterable<{ lastRequestTime: number }>;
-  /** A session touched more recently than this (ms) counts as "active". */
-  windowMs: number;
-  /** Clock injection point for tests. Defaults to `Date.now`. */
-  now?: () => number;
+  /**
+   * Whether the shared embedding worker is currently serving latency-sensitive
+   * recall work (≥1 single-query embed in flight). Re-read on every gate call so
+   * it reflects the worker's live load, never a stale snapshot.
+   */
+  isEmbedBusy: () => boolean;
 }
 
 /**
@@ -34,14 +38,5 @@ export interface TemporalBackfillGateDeps {
 export function makeTemporalBackfillGate(
   deps: TemporalBackfillGateDeps,
 ): () => boolean {
-  const now = deps.now ?? Date.now;
-  return () => {
-    if (deps.isPaused()) return true;
-    const t = now();
-    for (const s of deps.activeSessions()) {
-      // Strict `<`: activity exactly `windowMs` ago is no longer "active".
-      if (t - s.lastRequestTime < deps.windowMs) return true;
-    }
-    return false;
-  };
+  return () => deps.isPaused() || deps.isEmbedBusy();
 }

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -78,7 +78,6 @@ import {
   enableHostedMode,
   importLoreFileAs,
   resolveWorkspaces,
-  DEEP_IDLE_MS,
 } from "@loreai/core";
 
 import type {
@@ -569,18 +568,21 @@ export function getActiveSessions(): ReadonlyMap<string, SessionState> {
 /**
  * Build the idle-gate handed to the temporal re-chunk backfill, wired to live
  * gateway state: park the walk while the background circuit breaker is tripped
- * or any session was active within {@link DEEP_IDLE_MS}. Exported so the wiring
- * (not just the pure {@link makeTemporalBackfillGate} policy) is unit-testable.
+ * OR the shared embedding worker is serving a live recall lookup. Exported so
+ * the wiring (not just the pure {@link makeTemporalBackfillGate} policy) is
+ * unit-testable.
  */
 export function buildTemporalBackfillGate(): () => boolean {
   return makeTemporalBackfillGate({
     // Global breaker: a coarse "system is degraded" backstop. It chiefly tracks
-    // remote LLM failures, so for a local embed provider the real gate is the
-    // session-activity check below; the breaker just avoids piling work on
-    // during an outage.
+    // remote LLM failures, so it just avoids piling work on during an outage.
     isPaused: () => isBackgroundPaused(),
-    activeSessions: () => getActiveSessions().values(),
-    windowMs: DEEP_IDLE_MS,
+    // The real throttle: yield the shared embedding worker to latency-sensitive
+    // recall. Session activity was the old signal, but "a session pinged us
+    // recently" says nothing about the embed worker's spare capacity right now —
+    // on a busy multi-session host it kept the walk parked indefinitely. An
+    // empty recall-embed queue is the direct, live measure of that capacity.
+    isEmbedBusy: () => embedding.recallEmbedsInFlight() > 0,
   });
 }
 
@@ -2016,8 +2018,8 @@ async function initIfNeeded(
   }
   if (process.env.NODE_ENV !== "test") {
     // Idle-gate the heavy temporal re-chunk walk so it yields the shared embed
-    // pool to live traffic: park while the breaker is tripped or a session was
-    // active within DEEP_IDLE_MS, resume once the host is quiet.
+    // pool to live traffic: park while the breaker is tripped or a live recall
+    // embed is in flight, resume the instant the worker drains.
     spanStartupBackfill(() =>
       embedding.runStartupBackfill({
         shouldPause: buildTemporalBackfillGate(),

--- a/packages/gateway/test/backfill-gate-wiring.test.ts
+++ b/packages/gateway/test/backfill-gate-wiring.test.ts
@@ -1,3 +1,4 @@
+import { embedding } from "@loreai/core";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import {
   resetBackgroundLimiter,
@@ -6,16 +7,22 @@ import {
 import { buildTemporalBackfillGate } from "../src/pipeline";
 
 // The pure policy is covered in backfill-gate.test.ts; this pins the *wiring*
-// (`buildTemporalBackfillGate` → live gateway state), which the production call
-// site can't exercise because it's `NODE_ENV !== "test"`-gated.
+// (`buildTemporalBackfillGate` → live gateway/core state), which the production
+// call site can't exercise because it's `NODE_ENV !== "test"`-gated.
 describe("buildTemporalBackfillGate (wiring)", () => {
-  beforeEach(() => resetBackgroundLimiter());
-  afterEach(() => resetBackgroundLimiter());
+  beforeEach(() => {
+    resetBackgroundLimiter();
+    embedding._setRecallEmbedsInFlightForTest(0);
+  });
+  afterEach(() => {
+    resetBackgroundLimiter();
+    embedding._setRecallEmbedsInFlightForTest(0);
+  });
 
   test("is wired to the background circuit breaker (idle → run, tripped → park)", () => {
     const gate = buildTemporalBackfillGate();
 
-    // No active sessions + breaker clear → the walk runs (doesn't park). Guards
+    // No embed load + breaker clear → the walk runs (doesn't park). Guards
     // against a wiring that spuriously pauses when the host is idle.
     expect(gate()).toBe(false);
 
@@ -26,6 +33,23 @@ describe("buildTemporalBackfillGate (wiring)", () => {
 
     // Clearing it resumes.
     resetBackgroundLimiter();
+    expect(gate()).toBe(false);
+  });
+
+  test("is wired to the live recall-embed counter (in flight → park)", () => {
+    const gate = buildTemporalBackfillGate();
+
+    // Breaker clear, worker idle → runs.
+    expect(gate()).toBe(false);
+
+    // A live recall embed is in flight → park, even though the breaker is clear.
+    // Proves the gate reads embedding.recallEmbedsInFlight() live rather than a
+    // hardcoded false.
+    embedding._setRecallEmbedsInFlightForTest(1);
+    expect(gate()).toBe(true);
+
+    // Worker drains → resumes.
+    embedding._setRecallEmbedsInFlightForTest(0);
     expect(gate()).toBe(false);
   });
 });

--- a/packages/gateway/test/backfill-gate.test.ts
+++ b/packages/gateway/test/backfill-gate.test.ts
@@ -2,69 +2,65 @@ import { describe, expect, test } from "vitest";
 import { makeTemporalBackfillGate } from "../src/backfill-gate";
 
 describe("makeTemporalBackfillGate", () => {
-  test("parks when background work is paused (breaker tripped), regardless of sessions", () => {
+  test("parks when background work is paused (breaker tripped), regardless of embed load", () => {
     const gate = makeTemporalBackfillGate({
       isPaused: () => true,
-      activeSessions: () => [],
-      windowMs: 1000,
-      now: () => 10_000,
+      isEmbedBusy: () => false,
     });
     expect(gate()).toBe(true);
   });
 
-  test("parks when a session was active within the window", () => {
+  test("parks when the embed worker is serving a live recall lookup", () => {
     const gate = makeTemporalBackfillGate({
       isPaused: () => false,
-      activeSessions: () => [{ lastRequestTime: 9_600 }],
-      windowMs: 1000,
-      now: () => 10_000, // 400ms ago < 1000ms window
+      isEmbedBusy: () => true,
     });
     expect(gate()).toBe(true);
   });
 
-  test("runs when all sessions are idle beyond the window and the breaker is clear", () => {
+  test("runs when the breaker is clear and the embed worker is idle", () => {
     const gate = makeTemporalBackfillGate({
       isPaused: () => false,
-      activeSessions: () => [
-        { lastRequestTime: 0 },
-        { lastRequestTime: 8_000 },
-      ],
-      windowMs: 1000,
-      now: () => 10_000, // most recent is 2000ms ago >= window
+      isEmbedBusy: () => false,
     });
     expect(gate()).toBe(false);
   });
 
-  test("runs when there are no active sessions and the breaker is clear", () => {
+  test("parks when both signals are set", () => {
     const gate = makeTemporalBackfillGate({
-      isPaused: () => false,
-      activeSessions: () => [],
-      windowMs: 1000,
-      now: () => 10_000,
+      isPaused: () => true,
+      isEmbedBusy: () => true,
     });
-    expect(gate()).toBe(false);
+    expect(gate()).toBe(true);
   });
 
-  test("boundary: activity exactly windowMs ago does NOT park (strict <)", () => {
+  test("short-circuits: a tripped breaker parks without consulting embed load", () => {
+    let embedChecked = false;
     const gate = makeTemporalBackfillGate({
-      isPaused: () => false,
-      activeSessions: () => [{ lastRequestTime: 9_000 }],
-      windowMs: 1000,
-      now: () => 10_000, // exactly 1000ms ago
+      isPaused: () => true,
+      isEmbedBusy: () => {
+        embedChecked = true;
+        return false;
+      },
     });
-    expect(gate()).toBe(false);
+    expect(gate()).toBe(true);
+    expect(embedChecked).toBe(false);
   });
 
-  test("re-reads sessions live on every call (no snapshot)", () => {
-    let sessions: Array<{ lastRequestTime: number }> = [];
+  test("re-reads both signals live on every call (no snapshot)", () => {
+    let paused = false;
+    let busy = false;
     const gate = makeTemporalBackfillGate({
-      isPaused: () => false,
-      activeSessions: () => sessions,
-      windowMs: 1000,
-      now: () => 10_000,
+      isPaused: () => paused,
+      isEmbedBusy: () => busy,
     });
     expect(gate()).toBe(false); // idle
-    sessions = [{ lastRequestTime: 9_500 }]; // a request just arrived
+    busy = true; // a recall embed just started
     expect(gate()).toBe(true); // reflected without rebuilding the gate
+    busy = false;
+    paused = true; // breaker trips
+    expect(gate()).toBe(true);
+    paused = false;
+    expect(gate()).toBe(false); // both clear again
   });
 });


### PR DESCRIPTION
## Problem

The temporal re-chunk backfill (`backfillTemporalEmbeddings`) shares the single-threaded embedding worker with request-path embeds. Its idle-gate (#1108) parked the walk whenever **any session had been active within `DEEP_IDLE_MS`**. On a busy multi-session host that window is essentially never empty, so the walk never ran — the 200k+ row backlog on this machine made **zero progress**.

"A session pinged us recently" says nothing about whether the embed worker has spare capacity *right now*.

## Fix

Gate on the **actual shared resource** instead: park the walk only while a live recall lookup (a single-query embed) is in flight. An empty recall-embed queue is the direct, live measure of spare capacity, so the walk trickles through the gaps between recalls and drains the backlog.

Recall latency is protected on two fronts:
1. the gate stops a **fresh** backfill page from being dispatched while a recall is outstanding, and
2. the embedding worker's existing high-priority queue lets a recall **jump ahead of already-queued** backfill batches (recall = `high`, backfill/document = `normal`).

Because the gate is checked *before dispatch*, a recall arriving mid-embed still waits out the one in-flight document sub-batch on the single-threaded worker — bounded, and strictly better than before. The circuit-breaker backstop is unchanged.

### `@loreai/core`
- `embed()` now tracks in-flight **recall** embeds (single query-text). Exposes `recallEmbedsInFlight()` as the gate signal.
- Document/batch embeds (write-time writes **and the backfill's own load**) are deliberately **not** counted, so the walk never gates against itself.
- The counter is decremented in `finally`, so a rejected embed (provider gone, OOM, timeout) can't leak a permanent "busy" that would wedge the walk forever.
- The single-text-query classification is extracted into **one `isRecallEmbed` predicate** shared by the counter and the worker's high-priority rule, so the "mirrors the worker" invariant cannot silently drift.

### `@loreai/gateway`
- `makeTemporalBackfillGate` takes an `isEmbedBusy: () => boolean` predicate in place of the `activeSessions`/`windowMs` deps.
- `buildTemporalBackfillGate` wires it to `embedding.recallEmbedsInFlight() > 0`.
- `DEEP_IDLE_MS` is no longer needed in `pipeline.ts` (still used by `idle.ts`).

## Tests
- **core** `embedding.test.ts`: recall embed increments the counter while in flight and clears after it settles; document + multi-text query embeds are **not** counted; decrements on provider rejection (anti-leak); concurrent recalls count additively.
- **gateway** `backfill-gate.test.ts`: pure factory over `isPaused`/`isEmbedBusy` (park/run/short-circuit/live re-read).
- **gateway** `backfill-gate-wiring.test.ts`: pins the wiring to both the live breaker **and** the live recall-embed counter.
- Mutation-tested (all killed): drop `isEmbedBusy` from the factory; hardcode `isEmbedBusy: () => false` in the wiring; remove the `embed()` increment; remove the `finally` decrement.
- Full `packages/core` + `packages/gateway` suites: **4843 passed, 0 failed**.

## Review
Adversarial pre-merge review across 9 focus areas (counter-leak, signal semantics, self-gating, live wiring, dead-code, hot-path cost, test quality, concurrency, description accuracy) → verdict **MERGE**. Its two NITs are folded in: the `isRecallEmbed` DRY extraction above, and this description no longer claims "zero added latency".