### PR TITLE
fix(gateway): resolve worker capability from the canonical vendor (follow-up to #1109)

### DIFF
--- a/packages/gateway/src/worker-model.ts
+++ b/packages/gateway/src/worker-model.ts
@@ -70,6 +70,24 @@ function currentResolutionMemo(): Map<string, string | undefined> {
 /** Providers to fetch pricing data for from models.dev. */
 const SUPPORTED_PROVIDERS = ["anthropic", "openai"] as const;
 
+/**
+ * First-party model vendors whose models.dev entry is AUTHORITATIVE for a given
+ * bare model id.
+ *
+ * models.dev lists the same bare id (e.g. `claude-sonnet-5`, `gpt-5`) under many
+ * providers — the vendor plus aggregators/proxies (github-copilot, azure,
+ * opencode, llmgateway, …) — and their capability flags frequently disagree
+ * with the vendor's own. Because the flat model map is keyed by BARE id with
+ * last-writer-wins, an aggregator iterated after the vendor silently clobbers
+ * the vendor's correct data (real cases: github-copilot lists `claude-sonnet-5`
+ * with NO `toggle` reasoning option, so adaptive-thinking-on detection breaks;
+ * azure lists `claude-opus-4-8` as `temperature:true`, so proactive
+ * temperature-strip breaks). We re-apply these vendors LAST so their canonical
+ * entry wins regardless of provider ordering in the JSON. Later entries win, so
+ * order least→most authoritative.
+ */
+const CANONICAL_MODEL_PROVIDERS = ["openai", "anthropic"] as const;
+
 /** Shape of a model entry in the models.dev JSON API. */
 export type ModelsDevEntry = {
   id: string;
@@ -226,6 +244,68 @@ function fallbackEntry(modelID: string): ModelsDevEntry {
 }
 
 /**
+ * Normalize a raw models.dev model entry: stamp the id and derive `cache_write`
+ * cost when the source omits it (typically 1.25× input price). Returns a fresh
+ * object with a fresh `cost` so the source JSON is never mutated.
+ */
+function normalizeModelEntry(
+  modelId: string,
+  entry: ModelsDevEntry,
+): ModelsDevEntry {
+  const e: ModelsDevEntry = { ...entry, id: modelId };
+  if (e.cost && e.cost.cache_write == null && e.cost.input != null) {
+    e.cost = { ...e.cost, cache_write: e.cost.input * 1.25 };
+  }
+  return e;
+}
+
+/**
+ * Among map ids satisfying `pred`, pick the LONGEST (most specific); break
+ * length ties with a numeric-aware compare so the newest generation wins
+ * (`claude-opus-4-8` over `claude-opus-4-5`). This makes prefix resolution
+ * deterministic instead of returning the first hit in insertion order.
+ */
+function longestMatchingEntry(
+  map: Map<string, ModelsDevEntry>,
+  pred: (id: string) => boolean,
+): ModelsDevEntry | null {
+  let bestId: string | null = null;
+  let best: ModelsDevEntry | null = null;
+  for (const [id, entry] of map) {
+    if (!pred(id)) continue;
+    if (
+      bestId === null ||
+      id.length > bestId.length ||
+      (id.length === bestId.length &&
+        id.localeCompare(bestId, "en", { numeric: true }) > 0)
+    ) {
+      bestId = id;
+      best = entry;
+    }
+  }
+  return best;
+}
+
+/**
+ * Resolve a model id against the models.dev map: exact match, then the longest
+ * entry id that is a prefix of the requested id (dated/variant ids →
+ * most-specific base), then the longest entry id that the requested id is a
+ * prefix of (base/family id → most-specific known member). Deterministic
+ * regardless of provider/JSON ordering. Returns null when nothing matches.
+ */
+function matchModelEntry(
+  map: Map<string, ModelsDevEntry>,
+  modelID: string,
+): ModelsDevEntry | null {
+  const exact = map.get(modelID);
+  if (exact) return exact;
+  return (
+    longestMatchingEntry(map, (id) => modelID.startsWith(id)) ??
+    longestMatchingEntry(map, (id) => id.startsWith(modelID))
+  );
+}
+
+/**
  * Fetch model data from models.dev for supported providers.
  *
  * Single HTTP request, cached for 1 hour. Returns a map of
@@ -275,12 +355,7 @@ export function fetchModelData(): Promise<Map<string, ModelsDevEntry>> {
         if (providerModels && typeof providerModels === "object") {
           const modelIds: string[] = [];
           for (const [modelId, entry] of Object.entries(providerModels)) {
-            const e: ModelsDevEntry = { ...entry, id: modelId };
-            // Compute cache_write cost if not provided (typically 1.25× input price)
-            if (e.cost && e.cost.cache_write == null && e.cost.input != null) {
-              e.cost.cache_write = e.cost.input * 1.25;
-            }
-            modelData.set(modelId, e);
+            modelData.set(modelId, normalizeModelEntry(modelId, entry));
             modelIds.push(modelId);
           }
           providerModelsIndex.set(providerID, modelIds);
@@ -295,6 +370,21 @@ export function fetchModelData(): Promise<Map<string, ModelsDevEntry>> {
           // Strip trailing /v1 — gateway appends /v1/messages or /v1/chat/completions.
           const url = api.replace(/\/v1\/?$/, "");
           providerRoutes.set(providerID, { url, protocol });
+        }
+      }
+
+      // Second pass: re-apply first-party vendors so their canonical capability
+      // data (temperature, reasoning_options) wins over any aggregator/proxy
+      // that defined the same bare model id earlier in the JSON. See
+      // CANONICAL_MODEL_PROVIDERS. `.set()` on an existing key updates the value
+      // in place without changing insertion order, so prefix/index ordering is
+      // preserved — only the (previously order-dependent) capability flags are
+      // corrected.
+      for (const providerID of CANONICAL_MODEL_PROVIDERS) {
+        const providerModels = data[providerID]?.models;
+        if (!providerModels || typeof providerModels !== "object") continue;
+        for (const [modelId, entry] of Object.entries(providerModels)) {
+          modelData.set(modelId, normalizeModelEntry(modelId, entry));
         }
       }
 
@@ -371,22 +461,7 @@ export function lookupProviderRoute(providerID: string): ProviderRoute | null {
  */
 export async function getModelEntry(modelID: string): Promise<ModelsDevEntry> {
   const data = await fetchModelData();
-
-  // Exact match
-  const exact = data.get(modelID);
-  if (exact) return exact;
-
-  // Prefix match: find the entry whose ID is a prefix of the requested model
-  for (const [id, entry] of data) {
-    if (modelID.startsWith(id)) return entry;
-  }
-
-  // Reverse prefix: find if the requested model is a prefix of any entry
-  for (const [id, entry] of data) {
-    if (id.startsWith(modelID)) return entry;
-  }
-
-  return fallbackEntry(modelID);
+  return matchModelEntry(data, modelID) ?? fallbackEntry(modelID);
 }
 
 /**
@@ -399,22 +474,7 @@ export async function getModelEntry(modelID: string): Promise<ModelsDevEntry> {
  */
 export function getModelEntrySync(modelID: string): ModelsDevEntry {
   if (!cachedModelData) return fallbackEntry(modelID);
-
-  // Exact match
-  const exact = cachedModelData.get(modelID);
-  if (exact) return exact;
-
-  // Prefix match
-  for (const [id, entry] of cachedModelData) {
-    if (modelID.startsWith(id)) return entry;
-  }
-
-  // Reverse prefix
-  for (const [id, entry] of cachedModelData) {
-    if (id.startsWith(modelID)) return entry;
-  }
-
-  return fallbackEntry(modelID);
+  return matchModelEntry(cachedModelData, modelID) ?? fallbackEntry(modelID);
 }
 
 /** True when models.dev data has been loaded into the in-memory cache. */

--- a/packages/gateway/test/llm-adapter.test.ts
+++ b/packages/gateway/test/llm-adapter.test.ts
@@ -1895,6 +1895,45 @@ describe("worker thinking disabled for Anthropic Claude models", () => {
     expect(bodyOf(0)?.model).toBe("anthropic.claude-haiku-4-5");
   });
 
+  test("vertex Claude worker disables thinking (threads thinking:{type:disabled} through toVertexBody)", async () => {
+    // Vertex-served sonnet-5 has the same adaptive-thinking-on default; the
+    // disable flag must survive the vertex body transform. Guards against a
+    // silent regression where buildVertexWorkerRequest drops `disableThinking`.
+    _setModelDataForTest({
+      "claude-sonnet-5": {
+        id: "claude-sonnet-5",
+        reasoning: true,
+        reasoning_options: [{ type: "toggle" }, { type: "effort" }],
+      },
+    });
+    _setTestVertexTokenProvider(() => Promise.resolve("test-vertex-token"));
+    try {
+      mockFetch.mockResolvedValue(okResponse());
+      const client = createGatewayLLMClient(
+        UPSTREAMS,
+        () => ({ scheme: "api-key", value: "client-key-ignored-for-vertex" }),
+        { providerID: "vertex", modelID: "claude-sonnet-5" },
+        { vertexProject: "test-vertex-project" },
+      );
+
+      await client.prompt("system", "user", {
+        sessionID: "sess-vertex-think",
+        workerID: "lore-distill",
+        upstreamUrl: "https://aiplatform.googleapis.com",
+        upstreamProviderID: "vertex",
+        protocol: "vertex",
+      });
+
+      // toVertexBody preserves `thinking`, so the disabled flag reaches the wire.
+      expect(bodyOf(0)?.thinking).toEqual({ type: "disabled" });
+      // Vertex body never carries model/stream (belt-and-suspenders sanity).
+      expect("model" in (bodyOf(0) ?? {})).toBe(false);
+    } finally {
+      _setTestVertexTokenProvider(null);
+      clearModelDataCache();
+    }
+  });
+
   // -------------------------------------------------------------------------
   // Data-driven capability from models.dev (thinking + temperature).
   // -------------------------------------------------------------------------
@@ -2116,5 +2155,84 @@ describe("worker thinking disabled for Anthropic Claude models", () => {
     expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(isThinkingUnsupportedModel(model)).toBe(false);
     expect(call).toBe(1);
+  });
+
+  test("does not strip thinking for a 400 that mentions 'thinking' without a rejection verb", async () => {
+    // The word "thinking" alone must NOT trigger a strip — only a genuine
+    // rejection (deprecated/unsupported/not permitted/…) should. Guards the
+    // rejection-verb clause of isThinkingUnsupported400. NB: the body must avoid
+    // every verb, including "invalid" (so no `invalid_request_error` type here).
+    let call = 0;
+    mockFetch.mockImplementation(async () => {
+      call++;
+      return new Response(
+        JSON.stringify({
+          type: "error",
+          error: {
+            type: "bad_request",
+            message: "the thinking field value is too large",
+          },
+        }),
+        { status: 400 },
+      );
+    });
+
+    const model = { providerID: "anthropic", modelID: "claude-sonnet-5" };
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "sk-ant-test" }),
+      model,
+    );
+
+    const result = await client.prompt("system", "user", {
+      sessionID: "sess-think-verbless",
+      workerID: "lore-distill",
+      model,
+    });
+
+    expect(result).toBeNull();
+    // "thinking" present but no rejection verb → no strip retry, single attempt.
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(isThinkingUnsupportedModel(model)).toBe(false);
+    expect(call).toBe(1);
+  });
+
+  test("does not learn the model when the thinking-stripped retry still fails", async () => {
+    // call 1: thinking-unsupported 400 → strip + retry.
+    // call 2: an UNRELATED 400 → thinking was not the (only) cause, so the model
+    // must NOT be learned (learning is deferred to a successful retry). Mirror of
+    // the temperature-suite symmetry test.
+    let call = 0;
+    mockFetch.mockImplementation(async () => {
+      call++;
+      if (call === 1) {
+        return new Response(THINKING_UNSUPPORTED_400, { status: 400 });
+      }
+      return new Response(
+        JSON.stringify({
+          error: { type: "invalid_request_error", message: "bad max_tokens" },
+        }),
+        { status: 400 },
+      );
+    });
+
+    const model = { providerID: "anthropic", modelID: "claude-legacy-3" };
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "sk-ant-test" }),
+      model,
+    );
+
+    const result = await client.prompt("system", "user", {
+      sessionID: "sess-think-strip-fail",
+      workerID: "lore-distill",
+      model,
+    });
+
+    expect(result).toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(2); // stripped once, still failed
+    expect(bodyOf(1)).not.toHaveProperty("thinking"); // strip did happen
+    // But the model is NOT learned — the retry never confirmed the cure.
+    expect(isThinkingUnsupportedModel(model)).toBe(false);
   });
 });

--- a/packages/gateway/test/worker-model.test.ts
+++ b/packages/gateway/test/worker-model.test.ts
@@ -20,6 +20,13 @@ import {
   lookupProviderRoute,
   type ModelsDevEntry,
 } from "../src/worker-model";
+// Capability consumers — asserted end-to-end against the real merge so the
+// multi-provider last-writer-wins collision (fixed here) can't silently
+// re-disable the #1109 worker thinking/temperature behavior.
+import {
+  modelRejectsTemperatureByData,
+  workerThinkingOnByDefault,
+} from "../src/llm-adapter";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -708,6 +715,176 @@ describe("getModelEntrySync", () => {
     expect(entry.cost?.output).toBe(15);
     expect(entry.limit?.context).toBe(200_000);
     expect(entry.limit?.output).toBe(8_192);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Canonical-provider capability resolution (multi-provider collision)
+// ---------------------------------------------------------------------------
+
+describe("canonical-provider capability resolution", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    clearModelDataCache();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    resetWorkerModelState();
+    clearModelDataCache();
+  });
+
+  const mockResponse = (resp: unknown) => {
+    globalThis.fetch = vi.fn(() =>
+      Promise.resolve(new Response(JSON.stringify(resp), { status: 200 })),
+    ) as unknown as typeof fetch;
+  };
+
+  // Reproduces the REAL models.dev shape: the vendor (anthropic) defines the
+  // bare id FIRST, then aggregators/proxies redefine it later with divergent
+  // capability flags. Under naive last-writer-wins the aggregator clobbers the
+  // vendor — this fixture makes that failure mode observable.
+  const collisionResponse = {
+    anthropic: {
+      api: "https://api.anthropic.com",
+      npm: "@ai-sdk/anthropic",
+      models: {
+        "claude-sonnet-5": {
+          id: "claude-sonnet-5",
+          temperature: false,
+          reasoning: true,
+          reasoning_options: [{ type: "toggle" }, { type: "effort" }],
+          cost: { input: 3, output: 15, cache_read: 0.3 },
+          limit: { context: 1_000_000, output: 128_000 },
+        },
+        "claude-opus-4-8": {
+          id: "claude-opus-4-8",
+          temperature: false,
+          reasoning: true,
+          reasoning_options: [{ type: "effort" }],
+          cost: { input: 5, output: 25, cache_read: 0.5 },
+          limit: { context: 1_000_000, output: 128_000 },
+        },
+      },
+    },
+    // Iterated AFTER anthropic — would win the keys under last-writer-wins.
+    azure: {
+      models: {
+        // Wrong temperature flag (Anthropic says false).
+        "claude-opus-4-8": {
+          id: "claude-opus-4-8",
+          temperature: true,
+          reasoning: true,
+          reasoning_options: [{ type: "effort" }],
+        },
+      },
+    },
+    "github-copilot": {
+      models: {
+        // Missing the `toggle` reasoning option (Anthropic has it).
+        "claude-sonnet-5": {
+          id: "claude-sonnet-5",
+          temperature: false,
+          reasoning: true,
+          reasoning_options: [{ type: "effort" }],
+        },
+      },
+    },
+  };
+
+  test("vendor entry wins reasoning_options over a toggle-less aggregator (F1)", async () => {
+    mockResponse(collisionResponse);
+    await fetchModelData();
+
+    const opts = getModelEntrySync("claude-sonnet-5").reasoning_options;
+    expect(opts?.some((o) => o?.type === "toggle")).toBe(true);
+    // End-to-end: the #1109 headline behavior must engage with live data.
+    expect(workerThinkingOnByDefault({ modelID: "claude-sonnet-5" })).toBe(
+      true,
+    );
+  });
+
+  test("vendor entry wins temperature flag over an aggregator that reports temperature:true (F3)", async () => {
+    mockResponse(collisionResponse);
+    await fetchModelData();
+
+    expect(getModelEntrySync("claude-opus-4-8").temperature).toBe(false);
+    expect(modelRejectsTemperatureByData("claude-opus-4-8")).toBe(true);
+    // sonnet-5 is temperature:false at both vendor and aggregator — still true.
+    expect(modelRejectsTemperatureByData("claude-sonnet-5")).toBe(true);
+  });
+
+  test("re-apply does not disturb models only an aggregator defines", async () => {
+    mockResponse({
+      ...collisionResponse,
+      "some-aggregator": {
+        models: {
+          "exotic-model-9": {
+            id: "exotic-model-9",
+            temperature: false,
+            cost: { input: 1, output: 2, cache_read: 0.1 },
+            limit: { context: 100_000, output: 8_192 },
+          },
+        },
+      },
+    });
+    await fetchModelData();
+    expect(getModelEntrySync("exotic-model-9").temperature).toBe(false);
+    expect(getModelEntrySync("exotic-model-9").cost?.input).toBe(1);
+  });
+
+  test("forward-prefix resolves a dated id to the LONGEST (most specific) base (F4)", async () => {
+    mockResponse({
+      anthropic: {
+        models: {
+          // Ancestor id inserted FIRST — naive first-hit prefix would pick it.
+          "claude-opus-4": {
+            id: "claude-opus-4",
+            temperature: true,
+            reasoning_options: [{ type: "effort" }],
+          },
+          "claude-opus-4-8": {
+            id: "claude-opus-4-8",
+            temperature: false,
+            reasoning_options: [{ type: "effort" }],
+          },
+        },
+      },
+    });
+    await fetchModelData();
+
+    // Dated variant must resolve to claude-opus-4-8 (temp:false), not the
+    // shorter claude-opus-4 ancestor (temp:true) that was inserted first.
+    const entry = getModelEntrySync("claude-opus-4-8-20260101");
+    expect(entry.temperature).toBe(false);
+    expect(modelRejectsTemperatureByData("claude-opus-4-8-20260101")).toBe(
+      true,
+    );
+  });
+
+  test("reverse-prefix resolves a base/family id to the newest member deterministically (F4)", async () => {
+    mockResponse({
+      anthropic: {
+        models: {
+          "claude-opus-4-5": {
+            id: "claude-opus-4-5",
+            temperature: true,
+            reasoning_options: [{ type: "effort" }],
+          },
+          "claude-opus-4-8": {
+            id: "claude-opus-4-8",
+            temperature: false,
+            reasoning_options: [{ type: "effort" }],
+          },
+        },
+      },
+    });
+    await fetchModelData();
+
+    // "claude-opus-4-" is a prefix of both; newest (4-8) wins by numeric compare.
+    expect(getModelEntrySync("claude-opus-4-").id).toBe("claude-opus-4-8");
   });
 });
 


### PR DESCRIPTION
Follow-up to #1109. An adversarial review of the merged #1109 surfaced a **BLOCKER**: the headline fix (disable adaptive thinking on sonnet-5 workers) silently **does not engage when models.dev is reachable** — it only worked during an outage.

## Root cause
`fetchModelData` merges **all** models.dev providers into one flat map keyed by the **bare** model id with **last-writer-wins**. The same id (`claude-sonnet-5`, `gpt-5`, …) is defined by the vendor *and* by aggregators/proxies whose capability flags disagree. Verified against the live `models.dev/api.json`:

| model | providers defining it (iteration order) | last writer | correct (anthropic) |
|---|---|---|---|
| `claude-sonnet-5` | llmgateway, azure, **anthropic**, opencode, **github-copilot** | github-copilot `reasoning_options=[effort]` (no `toggle`) | `[toggle, effort]` |
| `claude-opus-4-8` | venice, …, **anthropic**, …, **azure-cognitive-services** | azure `temperature:true` | `temperature:false` |

Consequences:
- `workerThinkingOnByDefault("claude-sonnet-5")` → **false** with live data → `thinking:{type:"disabled"}` omitted → sonnet-5 keeps adaptive thinking → empty thinking block / "no usable text" → the exact worker degradation #1109 set out to fix. (**F1 — BLOCKER**)
- `modelRejectsTemperatureByData("claude-opus-4-8")` → **false** → proactive temperature strip disabled (self-heals via the learning net after one wasted 400). (**F3**)

## Fix
- Re-apply first-party vendors (`CANONICAL_MODEL_PROVIDERS = [openai, anthropic]`) **last** in `fetchModelData` so their canonical capability flags win regardless of JSON ordering. `.set()` on existing keys preserves insertion order — only the (previously order-dependent) flags change.
- Make prefix resolution deterministic: `getModelEntry`/`getModelEntrySync` pick the **longest** matching id (dated variant → most-specific base; base/family id → newest member via numeric-aware compare) instead of the first hit in insertion order. (**F4**)

## Tests (all mutation-verified non-vacuous)
- Multi-provider collision fixtures reproducing the real vendor-then-aggregator ordering, asserted end-to-end through `workerThinkingOnByDefault` / `modelRejectsTemperatureByData` (F1, F3).
- Longest-prefix determinism (F4).
- Coverage gaps the #1109 review flagged as surviving mutations: vertex thinking-disable (F2), `isThinkingUnsupported400` rejection-verb clause (F5), thinking-strip-retry-still-fails-not-learned symmetry (F6).

Mutation results: disabling the canonical re-apply kills F1+F3; reverting longest-match kills the two F4 tests; each llm-adapter test (F2/F5/F6) killed by its targeted mutation.

## Verification
- `pnpm --filter @loreai/gateway typecheck` clean.
- Full gateway suite: **4901 passed / 36 skipped / 0 failed**.