### PR TITLE
feat(gateway): runtime + UI toggle to disable cache warming

### DIFF
--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -1252,6 +1252,10 @@ export function shouldWarm(
   profile: CacheWarmingProfile,
   blendedHist: InterTurnHistogram,
   now: number = Date.now(),
+  // Runtime warming kill-switch. Defaults to a fresh resolve, but per-session
+  // loop callers (idle.ts) pass a value hoisted out of the loop so the KV read
+  // for this global flag happens once, not once per session (N+1).
+  warmingEnabled: boolean = isWarmingEnabled(),
 ): boolean {
   // Per-bucket kill switch — always respected, even with /lore:warm:keep.
   if (isCircuitBreakerTripped(warmupBucketKey(state), now)) return false;
@@ -1263,7 +1267,7 @@ export function shouldWarm(
   const cfg = loreConfig();
   // Runtime-settable (env / KV override / config default) so warming can be
   // disabled globally without a restart — see isWarmingEnabled().
-  if (!isWarmingEnabled()) return false;
+  if (!warmingEnabled) return false;
 
   // No stored body to replay — nothing to warm
   if (!state.cacheAnalytics.lastRequestBody) return false;
@@ -1703,6 +1707,9 @@ export type WarmingSnapshot = {
 export function computeWarmingSnapshot(
   state: SessionState,
   now: number = Date.now(),
+  // See shouldWarm(): loop callers (the dashboard pages) pass a hoisted value
+  // so the global warming-enabled KV read happens once, not once per session.
+  warmingEnabled: boolean = isWarmingEnabled(),
 ): WarmingSnapshot {
   const cfg = loreConfig();
   const idleMs = now - state.lastRequestTime;
@@ -1779,7 +1786,7 @@ export function computeWarmingSnapshot(
       notWarmingReason = "Circuit breaker tripped";
     } else if (state.isSubagent) {
       notWarmingReason = "Sub-agent session (ephemeral)";
-    } else if (!isWarmingEnabled()) {
+    } else if (!warmingEnabled) {
       notWarmingReason = "Warming disabled (config/override)";
     } else if (!state.cacheAnalytics.lastRequestBody) {
       notWarmingReason = "No stored request body";

--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -136,6 +136,57 @@ const CIRCUIT_BREAKER_MAX_FAILURES = 3;
  *  Buckets can also be cleared immediately via resetCircuitBreaker(). */
 export const CIRCUIT_BREAKER_DECAY_MS = 6 * 3_600_000; // 6 hours
 
+/** KV key for the runtime cache-warming on/off override (set via UI / slash). */
+const WARMING_ENABLED_KV_KEY = "warming_enabled";
+
+/**
+ * Whether cache warming is enabled. Resolution priority (highest first):
+ *   1. `LORE_WARMING_ENABLED` env var — "0"/"false"/"off"/"no" disable,
+ *      anything else enables (override for automation / CI).
+ *   2. DB-persisted KV override, set via the dashboard or `/lore:warm:on|off`
+ *      ("1" = on, "0" = off). Absent → fall through.
+ *   3. `cache.warming.enabled` from `.lore.json` (schema default: true).
+ *
+ * This makes the file-only config flag runtime-settable without a restart —
+ * mirroring the daily-budget toggle. The gate lives in `shouldWarm`, so warming
+ * can be turned off globally the moment it stops paying for itself.
+ */
+export function isWarmingEnabled(): boolean {
+  const env = process.env.LORE_WARMING_ENABLED;
+  if (env != null && env.trim() !== "") {
+    return !/^(0|false|off|no)$/i.test(env.trim());
+  }
+  try {
+    const kv = getKV(WARMING_ENABLED_KV_KEY);
+    if (kv === "0") return false;
+    if (kv === "1") return true;
+  } catch {
+    // DB not initialized yet (e.g. early startup) — fall through to config.
+  }
+  return loreConfig().cache.warming.enabled;
+}
+
+/**
+ * Read the runtime KV override directly (no env / config fallback). Returns
+ * `true`/`false` when an override is set, or `null` when unset (so the UI can
+ * show "following config default"). Used only for display.
+ */
+export function getWarmingEnabledOverride(): boolean | null {
+  try {
+    const kv = getKV(WARMING_ENABLED_KV_KEY);
+    if (kv === "0") return false;
+    if (kv === "1") return true;
+  } catch {
+    // DB not ready — treat as no override.
+  }
+  return null;
+}
+
+/** Persist the runtime warming on/off override (survives restarts). */
+export function setWarmingEnabled(enabled: boolean): void {
+  setKV(WARMING_ENABLED_KV_KEY, enabled ? "1" : "0");
+}
+
 /** Gap duration floor (ms) separating "active coding turns" from "breaks".
  *  3 minutes is well past typical agent think time (10s–60s) but before
  *  the 5m TTL warmup window (4:15–5:00). */
@@ -1210,7 +1261,9 @@ export function shouldWarm(
   if (state.isSubagent) return false;
 
   const cfg = loreConfig();
-  if (!cfg.cache.warming.enabled) return false;
+  // Runtime-settable (env / KV override / config default) so warming can be
+  // disabled globally without a restart — see isWarmingEnabled().
+  if (!isWarmingEnabled()) return false;
 
   // No stored body to replay — nothing to warm
   if (!state.cacheAnalytics.lastRequestBody) return false;
@@ -1726,8 +1779,8 @@ export function computeWarmingSnapshot(
       notWarmingReason = "Circuit breaker tripped";
     } else if (state.isSubagent) {
       notWarmingReason = "Sub-agent session (ephemeral)";
-    } else if (!cfg.cache.warming.enabled) {
-      notWarmingReason = "Warming disabled in config";
+    } else if (!isWarmingEnabled()) {
+      notWarmingReason = "Warming disabled (config/override)";
     } else if (!state.cacheAnalytics.lastRequestBody) {
       notWarmingReason = "No stored request body";
     } else if (getPrefixChurnRate(state.sessionID) >= PREFIX_CHURN_WARM_BLOCK) {

--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -62,6 +62,7 @@ import {
   resolveProfileForSession,
   blendedHistogramForSession,
   shouldWarm,
+  isWarmingEnabled,
   executeWarmup,
   loadGlobalHistograms,
   flushGlobalHistograms,
@@ -551,7 +552,13 @@ export function startIdleScheduler(
     // buckets whose session was evicted (never re-queried on the read path).
     pruneExpiredCircuitBreakers(now);
 
+    // Global kill-switch, hoisted out of the per-session loop so a disabled
+    // deployment doesn't do a getKV per session per tick for a global flag.
+    // shouldWarm() still re-checks isWarmingEnabled() on the per-request path.
+    const warmingGloballyEnabled = isWarmingEnabled();
+
     for (const [sessionID, state] of sessions) {
+      if (!warmingGloballyEnabled) break;
       if (warmupInProgress.has(sessionID)) continue;
 
       // Skip sessions with stale auth credentials — warmup would just 401

--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -591,7 +591,8 @@ export function startIdleScheduler(
       if (isCircuitBreakerTripped(warmupBucketKey(state), now)) continue;
 
       const blendedHist = blendedHistogramForSession(state);
-      if (!shouldWarm(state, profile, blendedHist, now)) continue;
+      if (!shouldWarm(state, profile, blendedHist, now, warmingGloballyEnabled))
+        continue;
 
       warmupInProgress.add(sessionID);
       executeWarmup(state, profile, config.upstreamExtraHeaders)

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -240,6 +240,7 @@ import {
   clearWarmupAuthDisabled,
   creditWarmupHit,
   resetCircuitBreaker,
+  setWarmingEnabled,
 } from "./cache-warmer";
 import {
   setSentryRequestContext,
@@ -8326,7 +8327,7 @@ async function handleLoreSlashCommand(
   log.warn(`unknown slash command: ${text}`);
   return slashResponse(
     req,
-    `Unknown command: ${text}. Available: /lore:curate, /lore:warm:stop|keep|auto, /lore:amnesia:on|off`,
+    `Unknown command: ${text}. Available: /lore:curate, /lore:warm:stop|keep|auto|on|off|reset, /lore:amnesia:on|off`,
     `msg_lore_${Date.now()}`,
   );
 }
@@ -8389,6 +8390,8 @@ function handleAmnesiaSlashCommand(
  * `/lore:warm:auto` — returns to normal survival-analysis-driven mode.
  * `/lore:warm:reset` — clears ALL tripped circuit-breaker buckets (re-enables
  *   warming that was disabled after repeated uncached warmups).
+ * `/lore:warm:off` — disables cache warming GLOBALLY (persisted override).
+ * `/lore:warm:on` — re-enables cache warming globally.
  *
  * Returns a synthetic Anthropic-format response if a command was matched,
  * or null to continue normal processing.
@@ -8404,7 +8407,9 @@ function handleWarmupSlashCommand(
   const isKeep = lower === "/lore:warm:keep";
   const isAuto = lower === "/lore:warm:auto";
   const isReset = lower === "/lore:warm:reset";
-  if (!isStop && !isKeep && !isAuto && !isReset) return null;
+  const isOff = lower === "/lore:warm:off";
+  const isOn = lower === "/lore:warm:on";
+  if (!isStop && !isKeep && !isAuto && !isReset && !isOff && !isOn) return null;
 
   // Reset is a breaker-wide admin action — clear every tripped bucket and
   // return immediately (it does not depend on resolving this session).
@@ -8416,6 +8421,22 @@ function handleWarmupSlashCommand(
     return slashResponse(
       req,
       "Cache warming circuit breaker reset.",
+      `msg_lore_${Date.now()}`,
+    );
+  }
+
+  // on/off are GLOBAL admin actions (persisted KV override) — apply and return
+  // immediately, independent of this session.
+  if (isOff || isOn) {
+    setWarmingEnabled(isOn);
+    log.info(
+      `cache-warmer: /lore:warm:${isOn ? "on" : "off"} received — warming globally ${isOn ? "enabled" : "disabled"}`,
+    );
+    return slashResponse(
+      req,
+      isOn
+        ? "Cache warming enabled globally."
+        : "Cache warming disabled globally.",
       `msg_lore_${Date.now()}`,
     );
   }

--- a/packages/gateway/src/ui.ts
+++ b/packages/gateway/src/ui.ts
@@ -44,6 +44,9 @@ import {
   computeWarmingSnapshot,
   getCircuitBreakerSummary,
   resetCircuitBreaker,
+  isWarmingEnabled,
+  getWarmingEnabledOverride,
+  setWarmingEnabled,
   getGlobalHistogramsSnapshot,
   HISTOGRAM_BINS,
   BLEND_PSEUDOCOUNT,
@@ -2441,6 +2444,31 @@ function pageWarming(): string {
   ]);
   body += `<h1>Cache Warming</h1>`;
 
+  // Global on/off toggle. Warming replays the last request to keep the prompt
+  // cache warm across breaks; when it stops paying for itself (see the net on
+  // the Costs page) it can be disabled globally here without a restart.
+  const warmingOn = isWarmingEnabled();
+  const warmingOverride = getWarmingEnabledOverride();
+  const warmingEnvOverride = process.env.LORE_WARMING_ENABLED;
+  body += `<div class="card" style="display:flex;align-items:center;gap:12px;flex-wrap:wrap">
+    <div>
+      <strong>Cache warming is ${warmingOn ? '<span style="color:var(--success,#10b981)">ON</span>' : '<span style="color:var(--danger)">OFF</span>'}</strong>
+      <div style="font-size:0.85em;color:var(--fg2)">${
+        warmingEnvOverride && warmingEnvOverride.trim() !== ""
+          ? `Forced by env var <code>LORE_WARMING_ENABLED=${esc(warmingEnvOverride)}</code>`
+          : warmingOverride === null
+            ? "Following config default (cache.warming.enabled)"
+            : "Runtime override active (overrides .lore.json)"
+      }</div>
+    </div>`;
+  if (!(warmingEnvOverride && warmingEnvOverride.trim() !== "")) {
+    body += `<form class="inline" method="POST" action="/ui/api/warming/enabled" style="margin-left:auto">
+      <input type="hidden" name="enabled" value="${warmingOn ? "0" : "1"}">
+      <button type="submit" class="btn">${warmingOn ? "Disable warming" : "Enable warming"}</button>
+    </form>`;
+  }
+  body += `</div>`;
+
   const activeSessions = getActiveSessions();
   const cbSummary = getCircuitBreakerSummary();
 
@@ -3747,6 +3775,15 @@ export async function handleUIRequest(
       resetCircuitBreaker();
       const referer = req.headers.get("referer");
       return redirect(referer ?? "/ui/warming");
+    }
+
+    // Global cache-warming on/off toggle (persisted KV override).
+    // Matched before the :sessionId/:mode route (single-segment path).
+    if (pathname === "/ui/api/warming/enabled") {
+      const formData = await req.formData();
+      const raw = formData.get("enabled");
+      setWarmingEnabled(raw === "1" || raw === "true" || raw === "on");
+      return redirect("/ui/warming");
     }
 
     // Set warming mode for a live session

--- a/packages/gateway/src/ui.ts
+++ b/packages/gateway/src/ui.ts
@@ -2472,10 +2472,12 @@ function pageWarming(): string {
   const activeSessions = getActiveSessions();
   const cbSummary = getCircuitBreakerSummary();
 
-  // Build warming snapshots once — used for both stat cards and table
+  // Build warming snapshots once — used for both stat cards and table.
+  // Pass the already-resolved warmingOn so the snapshot builder doesn't re-read
+  // the global warming-enabled flag from KV once per session (N+1).
   const snapshotMap = new Map<string, WarmingSnapshot>();
   for (const [sid, state] of activeSessions) {
-    snapshotMap.set(sid, computeWarmingSnapshot(state));
+    snapshotMap.set(sid, computeWarmingSnapshot(state, Date.now(), warmingOn));
   }
 
   // Build unified rows (shared with Costs page)
@@ -2895,9 +2897,14 @@ function pageCosts(): string {
 
     // Per-session table (unified: cost + warming columns)
     const activeSessions = getActiveSessions();
+    // Resolve the global warming-enabled flag once (avoid a per-session KV read).
+    const warmingOn = isWarmingEnabled();
     const snapshotMap = new Map<string, WarmingSnapshot>();
     for (const [sid, state] of activeSessions) {
-      snapshotMap.set(sid, computeWarmingSnapshot(state));
+      snapshotMap.set(
+        sid,
+        computeWarmingSnapshot(state, Date.now(), warmingOn),
+      );
     }
     body += `<h3>Per Session</h3>`;
     body += renderLiveSessionsTable(

--- a/packages/gateway/test/cache-warmer.test.ts
+++ b/packages/gateway/test/cache-warmer.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach } from "vitest";
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
 import {
   createHistogram,
   recordGap,
@@ -38,6 +38,9 @@ import {
   BREAK_FLOOR_MS,
   creditWarmupHit,
   computeWarmingSnapshot,
+  isWarmingEnabled,
+  getWarmingEnabledOverride,
+  setWarmingEnabled,
   _resetForTest,
   _forceReloadForTest,
 } from "../src/cache-warmer";
@@ -3887,5 +3890,83 @@ describe("shouldWarm Phase A freshness + Phase B continuation (PR2b coverage)", 
       shouldWarm(makeState(sid, now, 310_000), p, shortBreakHist(), now),
     ).toBe(false);
     evictSession(sid);
+  });
+});
+
+describe("global warming toggle (isWarmingEnabled / setWarmingEnabled)", () => {
+  const ENV_KEY = "LORE_WARMING_ENABLED";
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    _resetForTest();
+    savedEnv = process.env[ENV_KEY];
+    delete process.env[ENV_KEY];
+    // Clear any persisted KV override so each test starts from config default.
+    setKV("warming_enabled", "");
+  });
+
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = savedEnv;
+    setKV("warming_enabled", "");
+  });
+
+  test("defaults to enabled (config default) with no override", () => {
+    expect(getWarmingEnabledOverride()).toBeNull();
+    expect(isWarmingEnabled()).toBe(true);
+  });
+
+  test("setWarmingEnabled(false) persists a disabling KV override", () => {
+    setWarmingEnabled(false);
+    expect(getWarmingEnabledOverride()).toBe(false);
+    expect(isWarmingEnabled()).toBe(false);
+    setWarmingEnabled(true);
+    expect(getWarmingEnabledOverride()).toBe(true);
+    expect(isWarmingEnabled()).toBe(true);
+  });
+
+  test("env var overrides the KV override (off wins even when KV says on)", () => {
+    setWarmingEnabled(true);
+    process.env[ENV_KEY] = "off";
+    expect(isWarmingEnabled()).toBe(false);
+    // getWarmingEnabledOverride reflects only the KV layer (for display).
+    expect(getWarmingEnabledOverride()).toBe(true);
+  });
+
+  test("env var can force-enable even when KV says off", () => {
+    setWarmingEnabled(false);
+    for (const v of ["1", "true", "on"]) {
+      process.env[ENV_KEY] = v;
+      expect(isWarmingEnabled()).toBe(true);
+    }
+    for (const v of ["0", "false", "off", "no"]) {
+      process.env[ENV_KEY] = v;
+      expect(isWarmingEnabled()).toBe(false);
+    }
+  });
+
+  test("shouldWarm returns false when warming is globally disabled", () => {
+    const now = Date.now();
+    // Identical to the "returns true when in warmup window" positive case.
+    const makeWarmeable = () =>
+      makeSessionState({
+        lastRequestTime: now - 270_000,
+        cacheAnalytics: {
+          ...makeCacheAnalytics(),
+          lastRequestBody: compressBody(
+            '{"model":"claude-sonnet-4-20250514","max_tokens":16384,"stream":true,"messages":[{"role":"user","content":"test"}]}',
+          ),
+        },
+      });
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+    const hist = createHistogram();
+    for (let i = 0; i < 50; i++) recordGap(hist, 360_000);
+
+    // Sanity: warms when enabled (default).
+    expect(shouldWarm(makeWarmeable(), profile, hist, now)).toBe(true);
+
+    // Disabled globally → never warms, regardless of survival analysis.
+    setWarmingEnabled(false);
+    expect(shouldWarm(makeWarmeable(), profile, hist, now)).toBe(false);
   });
 });

--- a/packages/gateway/test/pipeline-slash.test.ts
+++ b/packages/gateway/test/pipeline-slash.test.ts
@@ -63,6 +63,21 @@ describe("Pipeline — /lore:* slash commands", () => {
     ).toContain("Cache warming set to auto");
   });
 
+  it("handles global /lore:warm:off and /lore:warm:on (persisted toggle)", async () => {
+    const { isWarmingEnabled } = await import("../src/cache-warmer");
+    harness = await createHarness({ fixtures: [] });
+
+    const off = await harness.chat(slashBody("/lore:warm:off"));
+    expect(off.status).toBe(200);
+    expect(await textOf(off)).toContain("Cache warming disabled globally");
+    expect(isWarmingEnabled()).toBe(false);
+
+    const on = await harness.chat(slashBody("/lore:warm:on"));
+    expect(on.status).toBe(200);
+    expect(await textOf(on)).toContain("Cache warming enabled globally");
+    expect(isWarmingEnabled()).toBe(true);
+  });
+
   it("returns a helpful error for an unknown /lore:* command", async () => {
     harness = await createHarness({ fixtures: [] });
 

--- a/packages/website/src/content/docs/docs/environment.md
+++ b/packages/website/src/content/docs/docs/environment.md
@@ -17,6 +17,15 @@ Env vars override `.lore.json` for the same setting. To override a `.lore.json` 
 |---|---|
 | `LORE_BACKGROUND_CONCURRENCY` | Resolve the upper bound for background concurrency. `LORE_BACKGROUND_CONCURRENCY` is a hard ceiling override (escape hatch for large multi-tenant hosts); otherwise the built-in MAX applies. Clamped to a sane [1, 32]. |
 
+## Upstream + worker pipeline
+
+| Variable | Description |
+|---|---|
+| `LORE_DAILY_BUDGET` | Get the effective daily budget in USD. Resolution priority: 1. `LORE_DAILY_BUDGET` env var (override for automation / CI) 2. DB-persisted value from `kv_meta` (set via UI) 3. 0 (disabled) |
+| `LORE_MAX_RETRIES` | Number of times a worker upstream call retries a transient failure before falling back to the caller's own handling (default: 8). Override with the LORE_MAX_RETRIES env var. |
+| `LORE_WARMING_ENABLED` | Whether cache warming is enabled. Resolution priority (highest first): 1. `LORE_WARMING_ENABLED` env var — "0"/"false"/"off"/"no" disable, anything else enables (override for automation / CI). 2. DB-persisted KV override, set via the dashboard or `/lore:warm:on\|off` ("1" = on, "0" = off). Absent → fall through. 3. `cache.warming.enabled` from `.lore.json` (schema default: true). This makes the file-only config flag runtime-settable without a restart — mirroring the daily-budget toggle. The gate lives in `shouldWarm`, so warming can be turned off globally the moment it stops paying for itself. |
+| `LORE_WORKER_MODEL` | Env var override — highest priority. Useful for global worker model configuration without per-project .lore.json (e.g. routing all workers to MiniMax). Format: "providerID/modelID" or just "modelID" (defaults to anthropic provider). |
+
 ## CLI / `lore` command
 
 | Variable | Description |
@@ -50,14 +59,6 @@ Env vars override `.lore.json` for the same setting. To override a `.lore.json` 
 | `LORE_VERTEX_REGION` | _no description in source_ |
 | `LORE_WORKER_API_KEY`<br>**Default:** `undefined` | Standalone API key for background worker calls (distillation, curation, consolidation, etc.). When set, workers authenticate with this key instead of the session's client credential — enabling workers to use a different provider (e.g. MiniMax) than the session's Anthropic key. Env: LORE_WORKER_API_KEY |
 | `LORE_WORKER_UPSTREAM` | Custom upstream URL for background worker calls. When set, all worker HTTP calls route to this URL instead of the default upstream URLs. Enables routing workers to a different provider (e.g. MiniMax's Anthropic-compatible endpoint) while sessions continue using Anthropic. Env: LORE_WORKER_UPSTREAM |
-
-## Upstream + worker pipeline
-
-| Variable | Description |
-|---|---|
-| `LORE_DAILY_BUDGET` | Get the effective daily budget in USD. Resolution priority: 1. `LORE_DAILY_BUDGET` env var (override for automation / CI) 2. DB-persisted value from `kv_meta` (set via UI) 3. 0 (disabled) |
-| `LORE_MAX_RETRIES` | Number of times a worker upstream call retries a transient failure before falling back to the caller's own handling (default: 8). Override with the LORE_MAX_RETRIES env var. |
-| `LORE_WORKER_MODEL` | Env var override — highest priority. Useful for global worker model configuration without per-project .lore.json (e.g. routing all workers to MiniMax). Format: "providerID/modelID" or just "modelID" (defaults to anthropic provider). |
 
 ## Pipeline + idle work
 


### PR DESCRIPTION
## Problem

`cache.warming.enabled` existed only in `.lore.json` — read once at the `shouldWarm` gate. There was no way to turn warming off without editing the file and restarting, and no global control in the dashboard. When warming stops paying for itself, operators need an immediate off switch.

## Changes

Runtime-settable global toggle, mirroring the daily-budget pattern:
- **`isWarmingEnabled()`** resolution: `LORE_WARMING_ENABLED` env var → persisted KV override (`warming_enabled`) → `cache.warming.enabled` config default (`true`).
- **`setWarmingEnabled()` / `getWarmingEnabledOverride()`** for the UI/slash layer.
- `shouldWarm()` and the not-warming diagnostic now gate on `isWarmingEnabled()`.
- **Warming dashboard**: an ON/OFF status card with a one-click enable/disable form (`POST /ui/api/warming/enabled`), showing when an env var or runtime override is in effect (hides the button when env-forced).
- **Slash commands**: `/lore:warm:off` and `/lore:warm:on` (global, persisted), alongside the existing per-session `stop|keep|auto` and `reset`.

**Default stays ON.** Per the plan ordering, Phase 1 (#1102, prefix stability) and Phase 2 (#1105 pro-rata crediting, #1112 net visibility) address the root cause and make the ROI honest, so warming should now pay off. This toggle is the safety valve if a deployment's measured net (now visible on the Costs page) stays negative — or to rip warming out instantly without a redeploy.

## Tests

- `isWarmingEnabled` precedence (env > KV > config), override round-trip, env force-enable/disable parsing.
- Integration: `shouldWarm` returns false when globally disabled (red-green verified against the gate — reverting to the config-only check fails this test).
- Full gateway suite green (2468 passed); typecheck + lint clean.

## Context

Phase 3 (final) of the warmup cost-overhead plan. Sequenced after the root-cause fixes so disabling is an informed, optional choice rather than the primary remedy.