### PR TITLE
fix(core): drain distillation background work in tests (#885 DB-isolation flake)

### DIFF
--- a/packages/core/src/distillation.ts
+++ b/packages/core/src/distillation.ts
@@ -31,6 +31,34 @@ export { workerSessionIDs };
 
 type TemporalMessage = temporal.TemporalMessage;
 
+// Non-urgent run() does NOT await pattern-echo detection (it must not slow the
+// caller's response), so the echo promise — which mints knowledge via
+// ltm.create() → ensureProject() — outlives run(). In tests that promise can
+// resolve AFTER the harness restores env / closes the DB, tripping the
+// production-DB guard in ensureProject (issue #885). Track it here so tests can
+// drain it at the test boundary via settleBackgroundWork(). No-op in production.
+const inFlightBackground = new Set<Promise<unknown>>();
+function trackBackground(p: Promise<unknown>): void {
+  const tracked = p.catch((err) => {
+    log.warn("distillation background work failed:", err);
+  });
+  inFlightBackground.add(tracked);
+  void tracked.finally(() => inFlightBackground.delete(tracked));
+}
+
+/**
+ * Await all in-flight fire-and-forget distillation background work (pattern-echo
+ * detection). Test-only drain hook — production never calls it. Also drains any
+ * document embeds spawned by the echo's ltm.create() calls, so no embedding
+ * promise resolves against a torn-down DB either.
+ */
+export async function settleBackgroundWork(): Promise<void> {
+  while (inFlightBackground.size > 0) {
+    await Promise.allSettled([...inFlightBackground]);
+  }
+  await embedding.settleDocumentEmbeds();
+}
+
 /**
  * Compression health ratio: k / √N.
  *
@@ -1169,6 +1197,7 @@ async function distillSegment(input: {
       metadata: input.metadata,
     });
     if (input.urgent) await echoPromise;
+    else trackBackground(echoPromise);
   } else if (embedding.isAvailable()) {
     embedding.embedDistillation(distillId, result.observations);
   }

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -1484,6 +1484,29 @@ export async function vectorSearchAllDistillations(
  * Fire-and-forget — errors are logged, never thrown.
  * The entry remains usable via FTS even if embedding fails.
  */
+// Fire-and-forget document embeds (knowledge, distillation, entity) must not
+// block the write path, so callers don't await them. They are tracked here so
+// tests can drain them at the test boundary via settleDocumentEmbeds(): a
+// promise that resolves AFTER the harness closes/swaps the DB would otherwise
+// write to the wrong DB or log spurious errors (issue #885). No-op in
+// production, which never calls the drain.
+const _docEmbedsInFlight = new Set<Promise<unknown>>();
+function trackDocEmbed(p: Promise<unknown>): void {
+  _docEmbedsInFlight.add(p);
+  void p.finally(() => _docEmbedsInFlight.delete(p));
+}
+
+/**
+ * Await all in-flight fire-and-forget document embeds (knowledge / distillation
+ * / entity). Test-only drain hook — production never calls it. Loops so embeds
+ * spawned while draining (rare) are also awaited.
+ */
+export async function settleDocumentEmbeds(): Promise<void> {
+  while (_docEmbedsInFlight.size > 0) {
+    await Promise.allSettled([..._docEmbedsInFlight]);
+  }
+}
+
 export function embedKnowledgeEntry(
   id: string,
   title: string,
@@ -1491,14 +1514,16 @@ export function embedKnowledgeEntry(
 ): void {
   if (!isAvailable()) return;
   const text = `${title}\n${content}`;
-  embed([text], "document")
-    .then(([vec]) => {
-      storeEmbedding(db(), "knowledge", id, vec);
-    })
-    .catch((err) => {
-      if (err instanceof LocalProviderUnavailableError) return;
-      log.error("embedding failed for knowledge entry", id, ":", err);
-    });
+  trackDocEmbed(
+    embed([text], "document")
+      .then(([vec]) => {
+        storeEmbedding(db(), "knowledge", id, vec);
+      })
+      .catch((err) => {
+        if (err instanceof LocalProviderUnavailableError) return;
+        log.error("embedding failed for knowledge entry", id, ":", err);
+      }),
+  );
 }
 
 /**
@@ -1527,14 +1552,16 @@ export function embedEntity(
   }
   const text = parts.join(" ");
   if (!text) return;
-  embed([text], "document")
-    .then(([vec]) => {
-      storeEmbedding(db(), "entities", id, vec);
-    })
-    .catch((err) => {
-      if (err instanceof LocalProviderUnavailableError) return;
-      log.error("embedding failed for entity", id, ":", err);
-    });
+  trackDocEmbed(
+    embed([text], "document")
+      .then(([vec]) => {
+        storeEmbedding(db(), "entities", id, vec);
+      })
+      .catch((err) => {
+        if (err instanceof LocalProviderUnavailableError) return;
+        log.error("embedding failed for entity", id, ":", err);
+      }),
+  );
 }
 
 /**
@@ -1544,14 +1571,16 @@ export function embedEntity(
  */
 export function embedDistillation(id: string, observations: string): void {
   if (!isAvailable()) return;
-  embed([observations], "document")
-    .then(([vec]) => {
-      storeEmbedding(db(), "distillations", id, vec);
-    })
-    .catch((err) => {
-      if (err instanceof LocalProviderUnavailableError) return;
-      log.error("embedding failed for distillation", id, ":", err);
-    });
+  trackDocEmbed(
+    embed([observations], "document")
+      .then(([vec]) => {
+        storeEmbedding(db(), "distillations", id, vec);
+      })
+      .catch((err) => {
+        if (err instanceof LocalProviderUnavailableError) return;
+        log.error("embedding failed for distillation", id, ":", err);
+      }),
+  );
 }
 
 /**

--- a/packages/core/test/background-drain.test.ts
+++ b/packages/core/test/background-drain.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { EventEmitter } from "node:events";
+import type { Worker } from "node:worker_threads";
+import {
+  embedKnowledgeEntry,
+  isAvailable,
+  settleDocumentEmbeds,
+  _persistEmbedCap,
+  _resetLocalProviderProbe,
+  _restoreProvider,
+  _saveAndClearProvider,
+  _setTestWorkerFactory,
+} from "../src/embedding";
+import { settleBackgroundWork } from "../src/distillation";
+
+// Guards the issue #885 fix: fire-and-forget document embeds (embedKnowledgeEntry
+// / embedDistillation / embedEntity) and non-urgent pattern-echo work must be
+// DRAINABLE so a promise can't resolve after the test harness closes/swaps the
+// DB (which trips the production-DB guard in ensureProject, or writes to the
+// wrong DB). We drive a fake embedding worker so the in-flight embed is pending
+// on demand and assert the drain actually waits for it.
+
+type EmbedMsg = { type: string; id: number; maxTokens: number };
+
+class FakeWorker extends EventEmitter {
+  readonly posted: EmbedMsg[] = [];
+  postMessage(msg: unknown): void {
+    this.posted.push({ ...(msg as EmbedMsg) });
+  }
+  ref(): void {}
+  unref(): void {}
+  terminate(): Promise<number> {
+    return Promise.resolve(0);
+  }
+  lastPosted(): EmbedMsg {
+    const m = this.posted.at(-1);
+    if (!m) throw new Error("fake worker received no message");
+    return m;
+  }
+}
+
+function installFakeWorkers(): FakeWorker[] {
+  const fakes: FakeWorker[] = [];
+  _setTestWorkerFactory(() => {
+    const f = new FakeWorker();
+    fakes.push(f);
+    return f as unknown as Worker;
+  });
+  return fakes;
+}
+
+async function flush(): Promise<void> {
+  for (let i = 0; i < 5; i++) await Promise.resolve();
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+describe("background-work drain (issue #885)", () => {
+  let savedProvider: unknown;
+  let savedVoyage: string | undefined;
+  let savedOpenAI: string | undefined;
+
+  beforeEach(() => {
+    // Force the local provider onto the fake worker (no remote fallback, fresh
+    // instance) so embed() is driven deterministically and never touches a real
+    // ONNX model.
+    savedVoyage = process.env.VOYAGE_API_KEY;
+    savedOpenAI = process.env.OPENAI_API_KEY;
+    delete process.env.VOYAGE_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    _resetLocalProviderProbe();
+    savedProvider = _saveAndClearProvider();
+  });
+
+  afterEach(() => {
+    _setTestWorkerFactory(null);
+    _resetLocalProviderProbe();
+    _restoreProvider(savedProvider);
+    if (savedVoyage !== undefined) process.env.VOYAGE_API_KEY = savedVoyage;
+    if (savedOpenAI !== undefined) process.env.OPENAI_API_KEY = savedOpenAI;
+  });
+
+  it("settleDocumentEmbeds awaits an in-flight fire-and-forget document embed", async () => {
+    _persistEmbedCap(8192, 0); // trust cap as-is regardless of host free memory
+    const fakes = installFakeWorkers();
+    expect(isAvailable()).toBe(true);
+
+    // Fire-and-forget: returns void, schedules an embed on the (fake) worker.
+    embedKnowledgeEntry("k-885", "title", "content");
+    await flush();
+    expect(fakes).toHaveLength(1);
+    expect(fakes[0].lastPosted().type).toBe("embed");
+
+    // The drain must NOT resolve while the embed is still pending — otherwise a
+    // promise leaks past the test boundary (the flake).
+    let drained = false;
+    const drain = settleDocumentEmbeds().then(() => {
+      drained = true;
+    });
+    await flush();
+    expect(drained).toBe(false);
+
+    // Worker replies → embed resolves → storeEmbedding runs → drain resolves.
+    fakes[0].emit("message", {
+      type: "result",
+      id: fakes[0].lastPosted().id,
+      vectors: [new Float32Array([0.1, 0.2, 0.3])],
+    });
+    await drain;
+    expect(drained).toBe(true);
+  });
+
+  it("settleBackgroundWork also drains in-flight document embeds", async () => {
+    _persistEmbedCap(8192, 0);
+    const fakes = installFakeWorkers();
+
+    embedKnowledgeEntry("k-885-b", "title", "content");
+    await flush();
+    expect(fakes).toHaveLength(1);
+
+    let drained = false;
+    const drain = settleBackgroundWork().then(() => {
+      drained = true;
+    });
+    await flush();
+    expect(drained).toBe(false);
+
+    fakes[0].emit("message", {
+      type: "result",
+      id: fakes[0].lastPosted().id,
+      vectors: [new Float32Array([0.1, 0.2, 0.3])],
+    });
+    await drain;
+    expect(drained).toBe(true);
+  });
+
+  it("drains are no-ops when nothing is in flight", async () => {
+    await expect(settleDocumentEmbeds()).resolves.toBeUndefined();
+    await expect(settleBackgroundWork()).resolves.toBeUndefined();
+  });
+});

--- a/packages/core/test/distillation.test.ts
+++ b/packages/core/test/distillation.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach } from "vitest";
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
 import {
   messagesToText,
   truncateToolOutputsInContent,
@@ -12,7 +12,21 @@ import {
   detectAssertions,
   detectToolFailures,
   run,
+  settleBackgroundWork,
 } from "../src/distillation";
+
+// run() does NOT await pattern-echo detection / document embeds when non-urgent
+// (they must not slow the caller). In this file that background work — which
+// mints knowledge via ltm.create() → ensureProject() — can otherwise resolve
+// after a test finishes and vitest restores env / the harness closes the DB,
+// tripping the production-DB guard in ensureProject (issue #885). Draining after
+// every test in THIS file keeps all distillation-originated background work
+// inside the test's temp-DB window. Scoped here (not global setup.ts) because
+// forcing embedding completion mid-suite changes vector-search results in
+// embedding-dependent tests (recall-graph / ltm.forSession).
+afterEach(async () => {
+  await settleBackgroundWork();
+});
 import { distillationUser } from "../src/prompt";
 import * as ltm from "../src/ltm";
 import type * as temporal from "../src/temporal";


### PR DESCRIPTION
## Problem

`packages/core/test/distillation.test.ts` intermittently failed in CI (the flake that hit PR #1114's run):

```
Error: Refusing to create project with test path "/test/distillation/run-metadata" in the production DB.
```

## Root cause

Non-urgent `distillation.run()` does **not** await pattern-echo detection (`detectPatternEchoes`) — it must not slow the caller's response. That echo mints knowledge via `ltm.create()` → `ensureProject()`, so the promise **outlives `run()`**. In tests it can resolve after vitest restores env / the harness closes the DB, at which point `ensureProject`'s production-DB guard (`!LORE_DB_PATH && /^\/test\//`) throws.

Same class of leak: the fire-and-forget document embeds `embedKnowledgeEntry` / `embedDistillation` / `embedEntity` (each `embed().then(store)` with no caller await) write to whatever `db()` resolves to when they land.

The guard firing is *correct* (it's stopping a write that would otherwise hit production during the teardown window) — so the fix is to stop the leak, not weaken the guard.

## Fix — make the background work drainable

- **embedding.ts**: track the three fire-and-forget document embeds in an in-flight set; add `settleDocumentEmbeds()` to await them. Production never drains (pure test hook); the only added cost is a `Set` add/remove per embed.
- **distillation.ts**: track the non-urgent pattern-echo promise; add `settleBackgroundWork()` that drains it plus the document embeds it spawns.
- **distillation.test.ts**: `afterEach(async () => await settleBackgroundWork())` so all distillation-originated background work settles inside the test's temp-DB window.

**Scoped to `distillation.test.ts`, not global `setup.ts`, on purpose:** an early global-drain attempt regressed `recall-graph` / `ltm.forSession` — forcing embedding completion suite-wide changes vector-search results in embedding-dependent tests.

## Tests

- `background-drain.test.ts` (new): drives a fake embedding worker (the `_setTestWorkerFactory` seam) so an embed is pending on demand, and asserts `settleDocumentEmbeds()` / `settleBackgroundWork()` actually **wait** for it. Red-green verified — no-op'ing the tracker makes the drain resolve early and both tests fail.
- Full core suite green (2382 passed); the previously-failing `recall-graph` / `ltm` tests pass; typecheck + lint clean.

## Context

Follow-up to the cache-warmup cost work (#1102/#1105/#1112/#1114) — this is the CI flake surfaced during that series.