### PR TITLE
fix(gateway): show historical cache-warming row when only a cost was incurred (Sentry bot)

### DIFF
--- a/packages/gateway/src/ui.ts
+++ b/packages/gateway/src/ui.ts
@@ -2962,7 +2962,7 @@ function pageCosts(): string {
     }
     body += `<tr class="section-header"><td colspan="2" style="padding-top:0.8em"><strong>Estimated Savings</strong></td></tr>
         <tr><td>Avoided compactions</td><td>${formatUSD(hist.avoidedCompactionCost)} <span style="color:var(--fg3);font-size:0.85em">(&times;${hist.avoidedCompactions})</span></td></tr>
-        ${hist.warmupSavings > 0 ? `<tr><td>Cache warming</td><td>${formatUSD(hist.warmupSavings)} <span style="color:var(--fg3);font-size:0.85em">(${hist.warmupHits} hits, cost ${formatUSD(hist.warmupCost)} above &rarr; net ${formatUSD(hist.warmupSavings - hist.warmupCost)})</span></td></tr>` : ""}
+        ${hist.warmupSavings > 0 || hist.warmupCost > 0 ? `<tr><td>Cache warming</td><td>${formatUSD(hist.warmupSavings)} <span style="color:var(--fg3);font-size:0.85em">(${hist.warmupHits} hits, cost ${formatUSD(hist.warmupCost)} above &rarr; net ${formatUSD(hist.warmupSavings - hist.warmupCost)})</span></td></tr>` : ""}
         ${hist.ttlSavings > 0 ? `<tr><td>1h TTL extension</td><td>${formatUSD(hist.ttlSavings)} <span style="color:var(--fg3);font-size:0.85em">(${hist.ttlHits} hits)</span></td></tr>` : ""}
         ${hist.batchSavings > 0 ? `<tr><td>Batch API discount</td><td>${formatUSD(hist.batchSavings)}</td></tr>` : ""}
         <tr style="border-top:1px solid var(--border)"><td><strong>${histNetSavings >= 0 ? "Net estimated savings" : "Net estimated overhead"}</strong></td><td><strong style="color:${histNetSavings >= 0 ? "#10b981" : "#e06c75"}">${histNetSavings >= 0 ? formatUSD(histNetSavings) : formatUSD(Math.abs(histNetSavings))}</strong></td></tr>


### PR DESCRIPTION
Follow-up to #1112 addressing a Sentry-bot finding (LOW) posted after merge: https://github.com/BYK/loreai/pull/1112#discussion_r3509949439

**Asymmetry:** the historical `/ui/costs` savings table rendered the "Cache warming" row only when `hist.warmupSavings > 0`. A period with a warming **cost** but zero confirmed savings therefore showed the cost in the worker-overhead sub-line (`— incl. cache warming`) but omitted the paired savings/net row in the Estimated Savings section — inconsistent with the live breakdown, which #1112 already renders on `liveWarmupCost > 0`.

**Fix:** gate the historical row on `hist.warmupSavings > 0 || hist.warmupCost > 0`, mirroring the live section. The row already shows `net = savings − cost`, so a cost-only period now reads e.g. `Cache warming: $0.00 (0 hits, cost $0.12 above → net -$0.12)`.

One-line HTML-string condition change; typecheck + lint clean.