### PR TITLE
refactor(core): remove unused getOriginalFetch() accessor

### DIFF
--- a/packages/core/src/fetch-interceptor.ts
+++ b/packages/core/src/fetch-interceptor.ts
@@ -316,21 +316,22 @@ export function shouldIntercept(url: string, gatewayBase: string): boolean {
  */
 /**
  * Process-global slot holding the original `globalThis.fetch` captured before
- * any interceptor was installed. The gateway (which may run in the same
- * process) must use this for its own upstream calls to avoid being intercepted
- * in a loop.
+ * any interceptor was installed. It backs the cross-copy double-install guard
+ * in `installFetchInterceptor()`: a non-null slot means some copy of this
+ * module already patched `globalThis.fetch`, so later installs no-op instead
+ * of stacking interceptors.
  *
  * Keyed via `Symbol.for(...)` — a *process-global* registry — so that EVERY
  * copy of this module in the process reads and writes the SAME handle, no
  * matter how many times @loreai/core is bundled/instantiated (e.g. the
  * OpenCode plugin's copy plus a copy inlined into the in-process gateway
  * bundle). With a module-scoped variable instead, each copy keeps a private
- * handle: one copy installs the interceptor (patching `globalThis.fetch`)
- * while a second copy's `getOriginalFetch()` still reads `null` and falls back
- * to `globalThis.fetch` — which IS the interceptor — producing an infinite
- * request loop (gateway → interceptor → gateway → …). Sharing this handle is
- * what makes it safe to inline core into the Bun bundle (issue #1027; see
- * gateway `script/bundle.ts`).
+ * handle, its guard sees `null`, and each installs its own interceptor —
+ * stacking them (copy B's interceptor captures copy A's as its "original"),
+ * which is the exact infinite-loop shape (gateway → interceptor → gateway → …)
+ * that once forced core to stay external. Sharing this handle is what makes it
+ * safe to inline core into the Bun bundle (issue #1027; see gateway
+ * `script/bundle.ts`).
  *
  * The slot is unset until `installFetchInterceptor()` is called, and released
  * (set back to `null`) by its cleanup.
@@ -351,20 +352,6 @@ function writeOriginalFetchSlot(fn: typeof globalThis.fetch | null): void {
   (globalThis as Record<symbol, typeof globalThis.fetch | null>)[
     ORIGINAL_FETCH_KEY
   ] = fn;
-}
-
-/**
- * Return the original, un-intercepted `fetch` function.
- *
- * When the gateway runs in-process alongside the plugin, it shares
- * `globalThis.fetch` — which the interceptor patches. The gateway must
- * use this function for its own upstream calls to avoid being caught by
- * the interceptor in an infinite loop.
- *
- * Returns `globalThis.fetch` if no interceptor has been installed.
- */
-export function getOriginalFetch(): typeof globalThis.fetch {
-  return readOriginalFetchSlot() ?? globalThis.fetch;
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -271,7 +271,6 @@ export {
 export { distillLimiter, curatorLimiter } from "./session-limiter";
 export {
   installFetchInterceptor,
-  getOriginalFetch,
   shouldIntercept,
   type FetchInterceptorConfig,
 } from "./fetch-interceptor";

--- a/packages/core/test/fetch-interceptor-global.test.ts
+++ b/packages/core/test/fetch-interceptor-global.test.ts
@@ -1,33 +1,34 @@
 /**
- * Regression battery for the SHARED original-fetch handle (#1027).
+ * Regression battery for the SHARED original-fetch handle (#1027, #1107).
  *
  * The fetch interceptor stores the pre-install `globalThis.fetch` in a
- * process-global keyed by `Symbol.for(...)` so that EVERY copy of
- * @loreai/core in the process agrees on the same original fetch — even when
- * core is bundled/instantiated more than once (e.g. the OpenCode plugin's
- * copy plus a copy inlined into the in-process gateway bundle).
+ * process-global keyed by `Symbol.for(...)`. It backs the cross-copy
+ * double-install guard so that EVERY copy of @loreai/core in the process
+ * agrees a single interceptor is installed — even when core is
+ * bundled/instantiated more than once (e.g. the OpenCode plugin's copy plus a
+ * copy inlined into the in-process gateway bundle).
  *
- * Without a shared handle, each module copy keeps a private module-scoped
- * `_originalFetch`: one copy installs the interceptor (patching
- * `globalThis.fetch`) while a second copy's `getOriginalFetch()` still reads
- * `null` and falls back to `globalThis.fetch` — which IS the interceptor —
- * producing an infinite request loop. These tests pin that invariant.
+ * Without a shared handle, each module copy keeps a private module-scoped slot:
+ * one copy installs the interceptor (patching `globalThis.fetch`) while a
+ * second copy's guard still sees `null` and installs AGAIN, stacking
+ * interceptors (copy B captures copy A's interceptor as its "original") — an
+ * infinite request loop (gateway → interceptor → gateway → …). These tests pin
+ * that invariant by observing the shared slot directly (the internal handle is
+ * not exported — see #1107).
  *
  * Tests 3 and 4 load two *independent* module instances (via
  * `vi.resetModules()` + dynamic import) to simulate the two-copies-in-one-
- * process scenario. They FAIL against a module-scoped `_originalFetch` and
- * PASS with the shared `Symbol.for` global.
+ * process scenario. They FAIL against a module-scoped slot and PASS with the
+ * shared `Symbol.for` global.
  */
 import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
-import {
-  installFetchInterceptor,
-  getOriginalFetch,
-} from "../src/fetch-interceptor";
+import { installFetchInterceptor } from "../src/fetch-interceptor";
 
 const ORIGINAL_FETCH_KEY = Symbol.for("lore.fetchInterceptor.originalFetch");
 const GATEWAY = "http://127.0.0.1:3207";
 const config = { gatewayBase: GATEWAY, getHeaders: () => ({}) };
 
+/** Read the process-global slot the interceptor stores the real fetch in. */
 function slot(): unknown {
   return (globalThis as Record<symbol, unknown>)[ORIGINAL_FETCH_KEY];
 }
@@ -53,36 +54,34 @@ describe("fetch-interceptor — shared original-fetch global (#1027)", () => {
   test("install captures the pre-install fetch into the shared Symbol.for slot", () => {
     const cleanup = installFetchInterceptor(config);
     try {
-      // The shared handle holds the REAL fetch, not the interceptor.
+      // The shared handle holds the REAL fetch...
       expect(slot()).toBe(trueOriginal);
-      // globalThis.fetch has been patched to the interceptor.
+      // ...and globalThis.fetch has been patched to the interceptor.
       expect(globalThis.fetch).not.toBe(trueOriginal);
-      // getOriginalFetch reads the shared handle.
-      expect(getOriginalFetch()).toBe(trueOriginal);
     } finally {
       cleanup();
     }
     // Cleanup restores the live fetch and releases the shared handle.
     expect(globalThis.fetch).toBe(trueOriginal);
-    expect(getOriginalFetch()).toBe(globalThis.fetch);
+    expect(slot() ?? null).toBeNull();
   });
 
-  test("getOriginalFetch returns the real fetch, never the installed interceptor", () => {
+  test("the shared slot holds the real fetch, never the installed interceptor", () => {
     const cleanup = installFetchInterceptor(config);
     try {
-      const original = getOriginalFetch();
-      expect(original).toBe(trueOriginal);
-      // The crux: it must NOT resolve to globalThis.fetch (the interceptor),
-      // which would be self-referential and loop.
-      expect(original).not.toBe(globalThis.fetch);
+      // The crux: the stored handle must be the true original, NOT
+      // globalThis.fetch (the interceptor). A self-referential handle is what
+      // loops.
+      expect(slot()).toBe(trueOriginal);
+      expect(slot()).not.toBe(globalThis.fetch);
     } finally {
       cleanup();
     }
   });
 
-  test("a second module copy resolves the same original fetch (cross-copy loop guard)", async () => {
-    // Two independently-evaluated module instances = two copies of core in
-    // one process. They share globalThis but have distinct module scopes.
+  test("a second module copy shares the slot and does not re-install (cross-copy loop guard)", async () => {
+    // Two independently-evaluated module instances = two copies of core in one
+    // process. They share globalThis but have distinct module scopes.
     vi.resetModules();
     const modA = await import("../src/fetch-interceptor");
     vi.resetModules();
@@ -90,22 +89,27 @@ describe("fetch-interceptor — shared original-fetch global (#1027)", () => {
     // Sanity: genuinely distinct module instances.
     expect(modB.installFetchInterceptor).not.toBe(modA.installFetchInterceptor);
 
-    const cleanup = modA.installFetchInterceptor(config);
+    const cleanupA = modA.installFetchInterceptor(config);
     try {
-      // Copy A patched globalThis.fetch to its interceptor.
-      expect(globalThis.fetch).not.toBe(trueOriginal);
-      // Copy B — separate module scope, empty private state — must still see
-      // the TRUE original via the shared global, not the interceptor. Under a
-      // module-scoped _originalFetch this returned globalThis.fetch (the
-      // interceptor) → infinite fetch loop.
-      expect(modB.getOriginalFetch()).toBe(trueOriginal);
-      expect(modB.getOriginalFetch()).not.toBe(globalThis.fetch);
+      const interceptorA = globalThis.fetch;
+      // Copy A patched globalThis.fetch and set the shared slot to the real fetch.
+      expect(interceptorA).not.toBe(trueOriginal);
+      expect(slot()).toBe(trueOriginal);
+
+      // Copy B — a SEPARATE module scope with its own (empty) private state —
+      // sees the shared slot as already set and MUST no-op: it must not
+      // re-patch globalThis.fetch (which would capture A's interceptor as B's
+      // "original" and stack a second layer → infinite loop). Under a
+      // module-scoped slot, B's guard sees null and re-patches here.
+      modB.installFetchInterceptor(config);
+      expect(globalThis.fetch).toBe(interceptorA); // unchanged by B
+      expect(slot()).toBe(trueOriginal); // shared slot untouched
     } finally {
-      cleanup();
+      cleanupA();
     }
   });
 
-  test("a second copy's install is a no-op while another copy owns the interceptor", async () => {
+  test("a second copy's cleanup is a no-op while another copy owns the interceptor", async () => {
     vi.resetModules();
     const modA = await import("../src/fetch-interceptor");
     vi.resetModules();
@@ -116,22 +120,18 @@ describe("fetch-interceptor — shared original-fetch global (#1027)", () => {
       const interceptorA = globalThis.fetch;
       expect(interceptorA).not.toBe(trueOriginal);
 
-      // Copy B must detect the shared slot is already set and NOT re-patch
-      // globalThis.fetch — re-patching would capture A's interceptor as B's
-      // "original", stacking a second interception layer.
+      // B's install no-ops (slot already set) and returns a no-op cleanup.
       const cleanupB = modB.installFetchInterceptor(config);
-      expect(globalThis.fetch).toBe(interceptorA); // unchanged by B
-      expect(modB.getOriginalFetch()).toBe(trueOriginal);
-
-      // B's cleanup is a no-op: it must not tear down A's interceptor nor
-      // release the shared handle A still owns.
+      // Calling it must NOT tear down A's interceptor nor release the shared
+      // handle A still owns.
       cleanupB();
       expect(globalThis.fetch).toBe(interceptorA);
-      expect(getOriginalFetch()).toBe(trueOriginal);
+      expect(slot()).toBe(trueOriginal);
     } finally {
       cleanupA();
     }
     // Only A's cleanup restores; the process is back to the live fetch.
-    expect(getOriginalFetch()).toBe(globalThis.fetch);
+    expect(globalThis.fetch).toBe(trueOriginal);
+    expect(slot() ?? null).toBeNull();
   });
 });

--- a/packages/gateway/script/bundle.ts
+++ b/packages/gateway/script/bundle.ts
@@ -138,16 +138,16 @@ await esbuild.build({
   //
   // History: core used to be kept external here so the OpenCode plugin's copy
   // of core and the in-process gateway's copy shared ONE module instance —
-  // specifically the `_originalFetch` handle in fetch-interceptor.ts. With two
-  // separate copies, installFetchInterceptor() (plugin) would set its copy's
-  // handle while getOriginalFetch() (gateway) read the other copy's null and
-  // fell back to globalThis.fetch = the interceptor → infinite request loop.
-  // Externalizing core is also what forced it to be a runtime dependency
-  // (#1024), dragging core's ~480 MB ML tree into raw-npm gateway installs.
+  // specifically the original-fetch handle in fetch-interceptor.ts. With two
+  // separate copies, installFetchInterceptor()'s double-install guard saw its
+  // own copy's empty handle and each copy installed its own interceptor,
+  // stacking them into an infinite request loop (gateway → interceptor →
+  // gateway → …). Externalizing core is also what forced it to be a runtime
+  // dependency (#1024), dragging core's ~480 MB ML tree into raw-npm installs.
   //
   // That invariant now lives in a process-global: fetch-interceptor.ts stores
   // the original fetch under Symbol.for("lore.fetchInterceptor.originalFetch"),
-  // so every copy of core in the process agrees on one handle regardless of how
+  // so every copy of core in the process shares one handle regardless of how
   // many times core is bundled/instantiated (#1027). Inlining is therefore
   // safe — and removes the external-core dep + its transitive weight.
   //

--- a/packages/gateway/test/llm-adapter.test.ts
+++ b/packages/gateway/test/llm-adapter.test.ts
@@ -1,9 +1,9 @@
 import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
 
 // Mock the upstream fetch wrapper so the adapter's retry loop is driven by our
-// stubbed responses regardless of whether a fetch interceptor is installed
-// (stubbing globalThis.fetch alone would silently break if `getOriginalFetch`
-// had captured the real fetch).
+// stubbed responses regardless of whether a fetch interceptor is installed on
+// globalThis.fetch (upstreamFetch is the gateway's own upstream path and does
+// not go through globalThis.fetch, so mocking it is the reliable seam).
 vi.mock("../src/fetch", () => ({ upstreamFetch: vi.fn() }));
 vi.mock("../src/worker-health", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../src/worker-health")>();


### PR DESCRIPTION
Closes #1107. Follow-up cleanup from #1027 / #1103 / #1106.

## What

Remove the exported `getOriginalFetch()` accessor from `fetch-interceptor.ts` and the `@loreai/core` barrel.

## Why

`getOriginalFetch()` was built for the in-process gateway to make its own upstream calls via an un-intercepted `globalThis.fetch`. But the gateway's `upstreamFetch` goes through **undici** (Node) / **`node:http`** (Bun) directly and never touches `globalThis.fetch` — so the accessor had **zero runtime callers** across the monorepo (only its definition, the barrel re-export, and comments referenced it).

## ⚠️ What is deliberately unchanged

The internal `Symbol.for("lore.fetchInterceptor.originalFetch")` slot and the **cross-copy double-install guard** in `installFetchInterceptor()` are untouched. That shared handle is the #1027 safety that makes it safe to inline core into the Bun bundle, and it is now the slot's only consumer. `installFetchInterceptor` keeps its live callers (opencode, pi).

## Change

- `fetch-interceptor.ts`: drop `getOriginalFetch()`; rewrite the slot doc-comment to describe the invariant via the double-install guard (it previously explained it through the removed accessor).
- `core/src/index.ts`: drop `getOriginalFetch` from the barrel export.
- `gateway/script/bundle.ts`: refresh the historical comment that described the loop via `getOriginalFetch()`.
- `gateway/test/llm-adapter.test.ts`: fix the stale comment referencing the removed symbol.
- `core/test/fetch-interceptor-global.test.ts` (the #1027 regression battery): rewrite to assert the invariant by observing the shared slot + double-install guard **directly** rather than through the accessor.

## Verification

- No `getOriginalFetch` references remain anywhere (`git grep` clean).
- Typecheck: core, gateway, opencode, pi all clean; Biome clean.
- Regression battery mutation-verified: neutering the double-install guard fails the cross-copy test; making the slot write a no-op fails all four.
- Full core suite green (2405 passed); touched gateway test files green.