### PR TITLE
fix(core): silence transformers.js input-tensor dump on expected embed OOM

### DIFF
--- a/packages/core/src/embedding-worker-types.ts
+++ b/packages/core/src/embedding-worker-types.ts
@@ -161,6 +161,41 @@ export function isWasmFatalError(msg: string): boolean {
 }
 
 /**
+ * The two leading strings transformers.js' `sessionRun()` (models.js) passes to
+ * `console.error` when `session.run` throws, before it re-throws: the error
+ * message, and a dump of every input tensor's metadata AND `.data`. For our
+ * feature-extraction pipeline that data is `input_ids` / `attention_mask` /
+ * `token_type_ids` — thousands of token IDs (~21K values at the 8192-token cap).
+ *
+ * A memory-driven OOM is an EXPECTED, recovered event in this worker (the main
+ * thread drives the ×0.7 cap backoff + fresh-heap respawn), so on a cold start
+ * this dumps ~60 lines of noise 1–2× before the cap converges. It is emitted by
+ * transformers.js — NOT the ORT C++ logger — so `logSeverityLevel` does not gate
+ * it; the only lever is filtering these lines. Matching is by leading string so
+ * the interpolated error text is irrelevant; if a future transformers release
+ * renames them the dump merely reappears (no functional change).
+ */
+export const TRANSFORMERS_INFERENCE_DUMP_PREFIXES = [
+  "An error occurred during model execution:",
+  "Inputs given to model:",
+] as const;
+
+/**
+ * True when `arg` is the first argument of one of transformers.js'
+ * inference-error `console.error` dump lines (see
+ * {@link TRANSFORMERS_INFERENCE_DUMP_PREFIXES}). Used by the worker to drop that
+ * dump for the duration of a single (expected-to-maybe-OOM) inference. Non-string
+ * args (e.g. the formatted-inputs object) never match — only the leading string
+ * line is tested, and dropping it takes its trailing object with it.
+ */
+export function isTransformersInferenceDumpLine(arg: unknown): boolean {
+  return (
+    typeof arg === "string" &&
+    TRANSFORMERS_INFERENCE_DUMP_PREFIXES.some((p) => arg.startsWith(p))
+  );
+}
+
+/**
  * Detect a corrupt / incomplete model file on disk. The most common cause is a
  * truncated HF Hub download (e.g. a 137MB ONNX model where only 87MB was written
  * before the connection dropped): the file header parses but the protobuf body

--- a/packages/core/src/embedding-worker.ts
+++ b/packages/core/src/embedding-worker.ts
@@ -450,6 +450,51 @@ function truncateTexts(texts: string[], maxTokens: number): string[] {
 // isOomError and isWasmFatalError are imported from embedding-worker-types.ts
 // (shared with the main thread to prevent classification drift).
 
+// transformers.js' sessionRun() (models.js) wraps `session.run` in a try/catch
+// that, on ANY inference error, does two console.error() calls before
+// re-throwing: the error message, and a dump of every input tensor INCLUDING
+// its `.data` — for us that's `input_ids`/`attention_mask`/`token_type_ids`,
+// thousands of token IDs (~21K values at the 8192-token cap). A memory-driven
+// OOM is an EXPECTED, recovered event here (the main thread drives the ×0.7 cap
+// backoff + fresh-heap respawn), so that dump is pure journal noise, emitted
+// 1–2× per cold start. It is NOT gated by ORT's logSeverityLevel (it's
+// transformers.js, not the ORT C++ logger — verified: setting logSeverityLevel:4
+// leaves the dump unchanged), so the only lever is filtering these two lines.
+// Nothing actionable is lost: transformers re-throws the error, and
+// processEmbed() below classifies+surfaces it (OOM → respawn+resubmit; otherwise
+// → posted error).
+//
+// Inlined here — kept in sync with the canonical
+// `isTransformersInferenceDumpLine` / `TRANSFORMERS_INFERENCE_DUMP_PREFIXES` in
+// embedding-worker-types.ts (unit-tested there) — for the same reason as
+// isOomError/isWasmFatalError above: the worker is spawned by Node's native
+// resolver, which can't map a runtime `.js` import back to this `.ts` source.
+const TRANSFORMERS_INFERENCE_DUMP_PREFIXES = [
+  "An error occurred during model execution:",
+  "Inputs given to model:",
+];
+
+/** Temporarily drop transformers.js' inference-error tensor dump; returns a
+ *  restore fn. Everything else on console.error passes through untouched. Safe
+ *  because the worker runs inferences strictly sequentially — there is never a
+ *  concurrent runInference to race the console.error swap. */
+function suppressTransformersInferenceDump(): () => void {
+  const original = console.error;
+  console.error = (...args: unknown[]): void => {
+    const first = args[0];
+    if (
+      typeof first === "string" &&
+      TRANSFORMERS_INFERENCE_DUMP_PREFIXES.some((p) => first.startsWith(p))
+    ) {
+      return;
+    }
+    original(...args);
+  };
+  return () => {
+    console.error = original;
+  };
+}
+
 /** Run inference on `texts` and return per-text vectors. */
 async function runInference(texts: string[]): Promise<Float32Array[]> {
   // `ensurePipeline()` (awaited by the caller) guarantees both `pipe` and
@@ -462,8 +507,16 @@ async function runInference(texts: string[]): Promise<Float32Array[]> {
 
   // Run feature extraction with mean pooling.
   // truncation: true caps each text at the model's max length (8192 tokens
-  // for Nomic v1.5) as a last-resort safety net.
-  const output = await pipeline(texts, { pooling: "mean", truncation: true });
+  // for Nomic v1.5) as a last-resort safety net. The console.error filter is
+  // installed only around this call (see suppressTransformersInferenceDump) to
+  // swallow transformers.js' input-tensor dump on the expected OOM path.
+  const restoreConsole = suppressTransformersInferenceDump();
+  let output: Awaited<ReturnType<typeof pipeline>>;
+  try {
+    output = await pipeline(texts, { pooling: "mean", truncation: true });
+  } finally {
+    restoreConsole();
+  }
 
   // Post-process following Nomic's recipe:
   //   1. Layer normalization over the full hidden dimension

--- a/packages/core/src/embedding-worker.ts
+++ b/packages/core/src/embedding-worker.ts
@@ -474,6 +474,18 @@ const TRANSFORMERS_INFERENCE_DUMP_PREFIXES = [
   "Inputs given to model:",
 ];
 
+// Byte-identical inline copy of the canonical `isTransformersInferenceDumpLine`
+// in embedding-worker-types.ts. Both the prefixes array AND this function body
+// are drift-guarded by embedding-worker-types.test.ts, so the worker's actual
+// filtering logic (not just the data) can't silently diverge from the
+// unit-tested canonical.
+function isTransformersInferenceDumpLine(arg: unknown): boolean {
+  return (
+    typeof arg === "string" &&
+    TRANSFORMERS_INFERENCE_DUMP_PREFIXES.some((p) => arg.startsWith(p))
+  );
+}
+
 /** Temporarily drop transformers.js' inference-error tensor dump; returns a
  *  restore fn. Everything else on console.error passes through untouched. Safe
  *  because the worker runs inferences strictly sequentially — there is never a
@@ -481,13 +493,7 @@ const TRANSFORMERS_INFERENCE_DUMP_PREFIXES = [
 function suppressTransformersInferenceDump(): () => void {
   const original = console.error;
   console.error = (...args: unknown[]): void => {
-    const first = args[0];
-    if (
-      typeof first === "string" &&
-      TRANSFORMERS_INFERENCE_DUMP_PREFIXES.some((p) => first.startsWith(p))
-    ) {
-      return;
-    }
+    if (isTransformersInferenceDumpLine(args[0])) return;
     original(...args);
   };
   return () => {

--- a/packages/core/test/embedding-worker-types.test.ts
+++ b/packages/core/test/embedding-worker-types.test.ts
@@ -140,18 +140,24 @@ describe("isTransformersInferenceDumpLine", () => {
 });
 
 describe("TRANSFORMERS_INFERENCE_DUMP_PREFIXES inline copy stays in sync", () => {
-  // embedding-worker.ts inlines a byte-identical copy of these prefixes because
-  // the worker is spawned by Node's native resolver and can't runtime-import
-  // this `.ts` (same constraint as isOomError/isWasmFatalError). The worker
-  // module executes top-level code on import (it throws when parentPort is
-  // absent), so we can't import its value — instead we parse the array literal
-  // out of the source and assert deep equality. This fails CI the moment the
-  // two copies drift, per the reviewer's request on PR #1120.
-  test("worker source literal matches the canonical array", () => {
-    const workerSrc = readFileSync(
-      fileURLToPath(new URL("../src/embedding-worker.ts", import.meta.url)),
-      "utf8",
-    );
+  // embedding-worker.ts inlines a byte-identical copy of both the prefixes AND
+  // the isTransformersInferenceDumpLine predicate, because the worker is spawned
+  // by Node's native resolver and can't runtime-import this `.ts` (same
+  // constraint as isOomError/isWasmFatalError). The worker module executes
+  // top-level code on import (it throws when parentPort is absent), so we can't
+  // import its values — instead we parse them out of the source and assert they
+  // match the canonical. This fails CI the moment the copies drift (data OR
+  // logic), per the reviewer's request on PR #1120.
+  const workerSrc = readFileSync(
+    fileURLToPath(new URL("../src/embedding-worker.ts", import.meta.url)),
+    "utf8",
+  );
+  const typesSrc = readFileSync(
+    fileURLToPath(new URL("../src/embedding-worker-types.ts", import.meta.url)),
+    "utf8",
+  );
+
+  test("worker source prefixes literal matches the canonical array", () => {
     const block = workerSrc.match(
       /const TRANSFORMERS_INFERENCE_DUMP_PREFIXES\s*=\s*\[([\s\S]*?)\]/,
     );
@@ -163,6 +169,26 @@ describe("TRANSFORMERS_INFERENCE_DUMP_PREFIXES inline copy stays in sync", () =>
       (m) => m[1].replace(/\\(.)/g, "$1"),
     );
     expect(inline).toEqual([...TRANSFORMERS_INFERENCE_DUMP_PREFIXES]);
+  });
+
+  test("worker inline predicate body matches the canonical function", () => {
+    // Extract the isTransformersInferenceDumpLine body from each source and
+    // compare whitespace-normalized (robust to formatting). Guards against the
+    // matching LOGIC drifting (e.g. startsWith→includes, dropping the typeof
+    // guard) even when the prefix DATA is unchanged.
+    const bodyOf = (src: string): string => {
+      const m = src.match(
+        /function isTransformersInferenceDumpLine\(arg: unknown\): boolean \{([\s\S]*?)\n\}/,
+      );
+      expect(
+        m,
+        "isTransformersInferenceDumpLine not found (worker or canonical)",
+      ).not.toBeNull();
+      return (m?.[1] ?? "").replace(/\s+/g, " ").trim();
+    };
+    const workerBody = bodyOf(workerSrc);
+    expect(workerBody.length).toBeGreaterThan(0);
+    expect(workerBody).toBe(bodyOf(typesSrc));
   });
 });
 

--- a/packages/core/test/embedding-worker-types.test.ts
+++ b/packages/core/test/embedding-worker-types.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { describe, expect, test } from "vitest";
 import {
   isOomError,
@@ -6,6 +8,7 @@ import {
   isTransformersInferenceDumpLine,
   resolveModelCacheDir,
   shouldHealCorruptModel,
+  TRANSFORMERS_INFERENCE_DUMP_PREFIXES,
 } from "../src/embedding-worker-types";
 
 describe("isCorruptModelError", () => {
@@ -133,6 +136,33 @@ describe("isTransformersInferenceDumpLine", () => {
     "",
   ])("does NOT match unrelated console.error output: %s", (line) => {
     expect(isTransformersInferenceDumpLine(line)).toBe(false);
+  });
+});
+
+describe("TRANSFORMERS_INFERENCE_DUMP_PREFIXES inline copy stays in sync", () => {
+  // embedding-worker.ts inlines a byte-identical copy of these prefixes because
+  // the worker is spawned by Node's native resolver and can't runtime-import
+  // this `.ts` (same constraint as isOomError/isWasmFatalError). The worker
+  // module executes top-level code on import (it throws when parentPort is
+  // absent), so we can't import its value — instead we parse the array literal
+  // out of the source and assert deep equality. This fails CI the moment the
+  // two copies drift, per the reviewer's request on PR #1120.
+  test("worker source literal matches the canonical array", () => {
+    const workerSrc = readFileSync(
+      fileURLToPath(new URL("../src/embedding-worker.ts", import.meta.url)),
+      "utf8",
+    );
+    const block = workerSrc.match(
+      /const TRANSFORMERS_INFERENCE_DUMP_PREFIXES\s*=\s*\[([\s\S]*?)\]/,
+    );
+    expect(
+      block,
+      "inline prefixes array not found in embedding-worker.ts",
+    ).not.toBeNull();
+    const inline = [...(block?.[1] ?? "").matchAll(/"((?:[^"\\]|\\.)*)"/g)].map(
+      (m) => m[1].replace(/\\(.)/g, "$1"),
+    );
+    expect(inline).toEqual([...TRANSFORMERS_INFERENCE_DUMP_PREFIXES]);
   });
 });
 

--- a/packages/core/test/embedding-worker-types.test.ts
+++ b/packages/core/test/embedding-worker-types.test.ts
@@ -3,6 +3,7 @@ import {
   isOomError,
   isWasmFatalError,
   isCorruptModelError,
+  isTransformersInferenceDumpLine,
   resolveModelCacheDir,
   shouldHealCorruptModel,
 } from "../src/embedding-worker-types";
@@ -98,6 +99,40 @@ describe("resolveModelCacheDir", () => {
     ["/cache", "/"],
   ])("returns null for unusable input cacheDir=%s id=%s", (dir, id) => {
     expect(resolveModelCacheDir(dir as string | null, id)).toBeNull();
+  });
+});
+
+describe("isTransformersInferenceDumpLine", () => {
+  test.each([
+    // The exact leading lines observed from transformers.js on a real WASM OOM
+    // (models.js sessionRun catch → console.error x2), 8192-token input.
+    'An error occurred during model execution: "286288496".',
+    'An error occurred during model execution: "Missing the following inputs: attention_mask.',
+    "Inputs given to model:",
+  ])("matches the transformers inference-error dump line: %s", (line) => {
+    expect(isTransformersInferenceDumpLine(line)).toBe(true);
+  });
+
+  test.each([
+    // Non-string first args (e.g. the formatted-inputs object logged as the
+    // SECOND console.error arg) must never match — only the leading string
+    // line is dropped, which takes its trailing object with it.
+    [{ input_ids: { data: new BigInt64Array(3) } }],
+    [12345],
+    [null],
+    [undefined],
+  ])("does NOT match a non-string arg: %s", (arg) => {
+    expect(isTransformersInferenceDumpLine(arg)).toBe(false);
+  });
+
+  test.each([
+    "[lore] ONNX OOM at ≤4962 tokens — respawning worker at a lower cap",
+    "An error occurred", // truncated — not the transformers prefix
+    "Error: something else entirely",
+    "inputs given to model:", // case-sensitive: real line is capitalized
+    "",
+  ])("does NOT match unrelated console.error output: %s", (line) => {
+    expect(isTransformersInferenceDumpLine(line)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Symptom

At cold start the local embedding worker OOMs 1–2× while backfilling long (7088/7309-token) messages during the temporal re-chunk backfill. **Recovery is correct** (×0.7 cap backoff → fresh-heap respawn → resubmit at the lower cap), but each OOM dumps ~60 lines of the full input tensors (~21K token IDs) to the journal. Pure cosmetic noise.

## Root cause (it is *not* ORT)

My first instinct — raise ORT's `logSeverityLevel` — is a **no-op**, confirmed by experiment. The dump is emitted by **transformers.js**, not the ORT C++ logger. `sessionRun()` (`models.js`) wraps `session.run` in a try/catch that, on *any* inference error, does two `console.error()` calls before re-throwing:

```js
console.error(`An error occurred during model execution: "${e}".`);
console.error('Inputs given to model:', formatted); // formatted includes each tensor's .data
```

For our feature-extraction pipeline that `.data` is `input_ids`/`attention_mask`/`token_type_ids` — thousands of token IDs at the 8192-token cap.

## Fix

Wrap **only** the single `pipeline()` inference call in `runInference` with a `console.error` filter that drops those two well-known lines, then restores in `finally`. Nothing actionable is lost: transformers re-throws, and `processEmbed()` already classifies + surfaces the error (OOM → exit-75 → respawn+resubmit; otherwise → posted error) plus our own one-line `[lore] ONNX OOM …` warning. Safe because the worker runs inferences strictly sequentially — no concurrent `runInference` to race the swap.

The match predicate + prefixes are added to `embedding-worker-types.ts` (`isTransformersInferenceDumpLine`) and unit-tested against the exact lines observed from a real OOM; the worker inlines a **byte-identical** copy for the same reason as `isOomError`/`isWasmFatalError` (the worker is spawned by Node's native resolver and can't runtime-import the `.ts`).

## Verification (real WASM OOM)

Reproduced the production WASM path in isolation — `onnxruntime-node`→`onnxruntime-web` redirect (same `ort.node.min.mjs` the binary uses), 8192-token input, real memory-driven OOM:

| Variant | stderr |
|---|---|
| baseline (today) | **61 lines** — `An error occurred during model execution: "286288496".` + full `input_ids`/`token_type_ids` dump |
| `session_options.logSeverityLevel: 4` | **61 lines** (unchanged — proves it's not ORT) |
| `console.error` filter (this fix) | **3 lines** — OOM still thrown (`286288496`), so the backoff/respawn path is untouched |

Also: `pnpm test` embedding + worker suites green, typecheck + lint clean.