### PR TITLE
fix(gateway): block cache warming for sessions under emergency compaction

### DIFF
--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -964,6 +964,21 @@ export function getCacheSizeSnapshot(
   return { full: state.cacheSizeFull, compressed: state.cacheSizeCompressed };
 }
 
+/**
+ * The gradient layer the session's most recent real transform() landed on
+ * (0 = raw passthrough … 4 = emergency). Returns null when the session has
+ * never been transformed in-process (gradient has no state for it) so callers
+ * fail open. Non-creating (`sessionStates.get`) so a background warmer can
+ * never materialize a phantom session. Warmups replay a stored body and do NOT
+ * call transform(), so this reflects the last genuine turn's compression state
+ * — the signal the warmer uses to skip sessions whose prefix is being
+ * aggressively re-rendered under emergency compaction.
+ */
+export function getLastTransformLayer(sessionID: string): number | null {
+  const state = sessionStates.get(sessionID);
+  return state ? state.lastLayer : null;
+}
+
 // LTM tokens injected via system transform hook this turn.
 // Per-session when a sessionID is provided (preferred), with a module-level
 // fallback for callers that don't have a session ID.
@@ -1590,6 +1605,19 @@ export function setConsecutiveBustsForTest(
  */
 export function setPrefixChurnForTest(sessionID: string, churn: number): void {
   getSessionState(sessionID).prefixChurnEma = churn;
+}
+
+/**
+ * Test-only: set the per-session `lastLayer` (the layer the most recent
+ * transform() landed on) that {@link getLastTransformLayer} reports. Lets the
+ * warmer's emergency-compaction gate be exercised without running a full
+ * transform() to force the session into an emergency layer.
+ */
+export function setLastTransformLayerForTest(
+  sessionID: string,
+  layer: SafetyLayer,
+): void {
+  getSessionState(sessionID).lastLayer = layer;
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -185,6 +185,7 @@ export {
   setLastTurnAtForTest,
   setConsecutiveBustsForTest,
   setPrefixChurnForTest,
+  setLastTransformLayerForTest,
   setTransformCountForTest,
   inspectSessionState,
   getConsecutiveBusts,
@@ -201,6 +202,7 @@ export {
   evaluateCacheStrategy,
   getCacheStrategy,
   getCacheSizeSnapshot,
+  getLastTransformLayer,
   // #797: bust-spiral alerting hook. The gateway registers this once at
   // startup (`setupBustSpiralCapture`) to surface cache-bust spirals to Sentry
   // (cold-start info-breadcrumb + past-grace error alert + recovery breadcrumb).

--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -33,6 +33,7 @@ import {
   evaluateCacheStrategy,
   strategyWantsWarming,
   getCacheSizeSnapshot,
+  getLastTransformLayer,
   getCacheStrategy,
   estimateMetaDistillCostPerCall,
   getPrefixChurnRate,
@@ -199,6 +200,19 @@ export const MIN_WARMUPS_FOR_ROI_CHECK = 5;
  *  warming is empirically unprofitable and we stop. 25% means at least
  *  1 in 4 warmups must result in a confirmed user return. */
 export const MIN_SESSION_HIT_RATE = 0.25;
+
+/**
+ * Gradient layer at/above which a session is treated as under *emergency
+ * compaction* and warming is hard-blocked. Layer 4 is the emergency tail and
+ * Layer 3 the heavy-compression band just below it; in both, the raw window is
+ * cut and re-cut every turn so the distilled prefix re-renders, and the stored
+ * body a warmup replays no longer matches the cached prefix — warmups land as
+ * expensive partial writes ($1-3 on large Opus contexts) that the next real
+ * turn immediately discards (observed Jul 2026: session under Layer 4 produced
+ * hit=4%/10% warmups at $3+). The prefix-churn EMA is the general signal but
+ * lags and dips between rewrites; the layer is a direct read of the session's
+ * current compression state. See getLastTransformLayer(). */
+export const EMERGENCY_COMPACTION_LAYER = 3;
 
 /**
  * Shadow-mode (PR2a) cap on the `expectedFutureTurns` proxy fed into the shared
@@ -1291,6 +1305,26 @@ export function shouldWarm(
     return false;
   }
 
+  // Emergency-compaction gate. A session at gradient Layer >= 3 is aggressively
+  // re-rendering its distilled prefix every turn (the raw window is cut and
+  // re-cut), so the stored body a warmup replays no longer matches the cached
+  // prefix — the warmup lands as an expensive partial write the next real turn
+  // discards. This is a DIRECT read of the session's current compression state,
+  // complementing the prefix-churn EMA above, which lags and can dip below its
+  // threshold between rewrites (how these sessions slip through). getLastTransformLayer
+  // reflects the last genuine turn (warmups don't call transform()); null =
+  // never transformed in-process → fail open. Blocks ALL paths (incl.
+  // /lore:warm:keep) — an emergency-compacted prefix never warms cleanly.
+  const lastLayer = getLastTransformLayer(state.sessionID);
+  if (lastLayer !== null && lastLayer >= EMERGENCY_COMPACTION_LAYER) {
+    log.info(
+      `cache-warmer: skip warmup for session=${state.sessionID.slice(0, 16)} — ` +
+        `session under emergency compaction (layer=${lastLayer} >= ${EMERGENCY_COMPACTION_LAYER}); ` +
+        `warmups would land as partials`,
+    );
+    return false;
+  }
+
   const elapsed = now - state.lastRequestTime;
   const { ttlMs, warmupMarginMs, cacheReadCostPerMTok, cacheMissCostPerMTok } =
     profile;
@@ -1792,6 +1826,11 @@ export function computeWarmingSnapshot(
       notWarmingReason = "No stored request body";
     } else if (getPrefixChurnRate(state.sessionID) >= PREFIX_CHURN_WARM_BLOCK) {
       notWarmingReason = `Distilled prefix churning (churn=${getPrefixChurnRate(state.sessionID).toFixed(2)} >= ${PREFIX_CHURN_WARM_BLOCK}) — warmups would land as partials`;
+    } else if (
+      (getLastTransformLayer(state.sessionID) ?? 0) >=
+      EMERGENCY_COMPACTION_LAYER
+    ) {
+      notWarmingReason = `Emergency compaction (layer=${getLastTransformLayer(state.sessionID)} >= ${EMERGENCY_COMPACTION_LAYER}) — prefix re-renders every turn, warmups would land as partials`;
     } else if (!profile) {
       notWarmingReason = "No warming profile (non-Anthropic or unknown model)";
     } else if (state.warmup?.forceKeepWarm) {

--- a/packages/gateway/test/cache-warmer.test.ts
+++ b/packages/gateway/test/cache-warmer.test.ts
@@ -31,6 +31,7 @@ import {
   maxProfitableCycles,
   MAX_TOOL_CALL_WARMING_MS,
   MIN_WARMUPS_FOR_ROI_CHECK,
+  EMERGENCY_COMPACTION_LAYER,
   MIN_RETURN_PROBABILITY_FLOOR,
   TOOL_CALL_MAX_CYCLES,
   TOOL_CALL_MIN_HITS_FOR_CONTINUATION,
@@ -60,6 +61,7 @@ import {
   setCachePricing,
   evictSession,
   setPrefixChurnForTest,
+  setLastTransformLayerForTest,
   PREFIX_CHURN_WARM_BLOCK,
 } from "@loreai/core";
 import { decideSkipCompact } from "../src/pipeline";
@@ -1195,6 +1197,74 @@ describe("shouldWarm", () => {
 
     expect(shouldWarm(state, profile, hist, now)).toBe(true);
     setPrefixChurnForTest(sid, 0); // cleanup
+  });
+
+  test("returns FALSE when the session is under emergency compaction (layer >= 3), even with a perfect return rate", () => {
+    // A session at gradient Layer 3/4 re-renders its distilled prefix every
+    // turn, so a warmup replaying the stored body lands as a partial the next
+    // real turn discards (observed: Layer 4 sessions produced hit=4%/10% $3+
+    // warmups). The prefix-churn EMA lags and can dip below threshold between
+    // rewrites; the layer is a direct read that must block regardless.
+    const sid = "emergency-layer-block-session";
+    const now = Date.now();
+    const state = makeSessionState({
+      sessionID: sid,
+      lastRequestTime: now - 270_000,
+      warmup: {
+        lastWarmupAt: 0,
+        warmupCount: 0,
+        totalWarmups: 10,
+        warmupHits: 10, // perfect RETURN rate — return-guard would pass
+        disabled: false,
+      },
+      cacheAnalytics: {
+        ...makeCacheAnalytics(),
+        lastRequestBody: compressBody(
+          '{"model":"claude-sonnet-4-20250514","max_tokens":16384,"stream":true,"messages":[{"role":"user","content":"test"}]}',
+        ),
+      },
+    });
+    // Churn EMA below threshold so ONLY the layer gate can block (isolates it).
+    setPrefixChurnForTest(sid, PREFIX_CHURN_WARM_BLOCK - 0.1);
+    setLastTransformLayerForTest(sid, EMERGENCY_COMPACTION_LAYER);
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+    const hist = createHistogram();
+    for (let i = 0; i < 50; i++) recordGap(hist, 360_000);
+
+    expect(shouldWarm(state, profile, hist, now)).toBe(false);
+    setPrefixChurnForTest(sid, 0); // cleanup (shared process-global core state)
+    setLastTransformLayerForTest(sid, 0);
+  });
+
+  test("returns TRUE when the session is below the emergency layer (layer < 3, prefix stable)", () => {
+    const sid = "emergency-layer-allow-session";
+    const now = Date.now();
+    const state = makeSessionState({
+      sessionID: sid,
+      lastRequestTime: now - 270_000,
+      warmup: {
+        lastWarmupAt: 0,
+        warmupCount: 0,
+        totalWarmups: 10,
+        warmupHits: 10,
+        disabled: false,
+      },
+      cacheAnalytics: {
+        ...makeCacheAnalytics(),
+        lastRequestBody: compressBody(
+          '{"model":"claude-sonnet-4-20250514","max_tokens":16384,"stream":true,"messages":[{"role":"user","content":"test"}]}',
+        ),
+      },
+    });
+    setPrefixChurnForTest(sid, PREFIX_CHURN_WARM_BLOCK - 0.1);
+    setLastTransformLayerForTest(sid, 2); // heavy compression but below emergency
+    const profile = buildAnthropicProfile("claude-sonnet-4-20250514", "5m");
+    const hist = createHistogram();
+    for (let i = 0; i < 50; i++) recordGap(hist, 360_000);
+
+    expect(shouldWarm(state, profile, hist, now)).toBe(true);
+    setPrefixChurnForTest(sid, 0); // cleanup
+    setLastTransformLayerForTest(sid, 0);
   });
 
   test("returns false when session has too few turns", () => {


### PR DESCRIPTION
## Motivation

Post-deploy production data (the warming series #1102/#1105/#1112/#1114) confirmed warmups **still** land as expensive partial writes on sessions under emergency compaction. First hour on the new build:

| | |
|---|---|
| Warmups sent | 4 |
| Partial writes | 3 — hit=4% ($3.22), hit=17% ($1.43), hit=10% ($2.94) |
| Full hits | 1 — hit=100% ($0.13) |
| Wasted on partials | **~$7.59** vs $0.13 on the one good refresh |

The culprit was session `12na8hXrpthm52Hlq`, running at **gradient Layer 4** (`rawBudget` repeatedly halved: 210022→105011, 192248→96124). At that layer the distilled prefix re-renders every turn, so the stored body a warmup replays no longer matches the cached prefix → the warmup writes 460–513K tokens the next real turn immediately discards.

## Why the existing gate missed it

`shouldWarm()` already has a prefix-churn gate (`prefixChurnEma >= PREFIX_CHURN_WARM_BLOCK=0.40`), but the EMA **lags and dips below threshold between rewrites**, so churning sessions slip through — caught only later by the circuit breaker, after $1–3 is already spent.

## Fix

Add a **direct, current** signal instead of the lagging EMA:

- **core** `getLastTransformLayer(sessionID)` — reports the layer the session's last real `transform()` landed on (`0` = raw … `4` = emergency). Non-creating (`sessionStates.get`) so a background warmer can't materialize a phantom session; warmups don't call `transform()`, so it reflects the last genuine turn. `null` (never transformed in-process) → callers fail open.
- **gateway** `shouldWarm()` hard-blocks when `lastLayer >= EMERGENCY_COMPACTION_LAYER` (3), placed right after the prefix-churn gate and applying to **all paths incl. `/lore:warm:keep`** (an emergency-compacted prefix never warms cleanly). Mirrored in `computeWarmingSnapshot`'s dashboard `notWarmingReason` ladder.

## Tests

- `shouldWarm` returns **FALSE** at layer ≥ 3 even with a perfect return rate (churn EMA held below threshold to isolate the new gate), and **TRUE** at layer 2 (stable). **Mutation-verified**: disabling the gate (`>= 999`) fails the block test.
- New `setLastTransformLayerForTest` seam mirrors the existing `setPrefixChurnForTest`.
- Full core+gateway affected suites green (451 tests across warmer/gradient/cache-strategy); typecheck + lint clean across all 4 packages.

Follow-up to the cache-warming cost series; the runtime toggle (#1114) remains the escape hatch if warming still doesn't pay off after this.