### PR TITLE
feat(gateway): binary smoke for the read-worker offload seam (#1029)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,6 +336,16 @@ jobs:
           echo "$vec" | grep -q '^ok worker vec_available=true' \
             || (echo "::error::native sqlite-vec not loaded on the read-worker path in linux-x64 binary: $vec"; exit 1)
 
+          # Round-trip a generic read job through the off-thread read-worker pool
+          # (recall / forSession fan-out rides on this). Guards the SEA seam that
+          # rode in on the vector-worker asset with zero build changes (#1029).
+          # Unlike --check-vec (native vec may legitimately fall back), the read
+          # path is pure JS + node:sqlite and MUST work everywhere — fatal.
+          ro=$(./packages/gateway/dist-bin/lore-linux-x64 --check-read-offload || true)
+          echo "Read-offload: $ro"
+          echo "$ro" | grep -q '^ok read-offload via worker' \
+            || (echo "::error::read-worker offload seam broken in linux-x64 binary: $ro"; exit 1)
+
           # Start gateway, hit health endpoint, shut down
           ./packages/gateway/dist-bin/lore-linux-x64 start -p 7991 &
           SERVER_PID=$!
@@ -738,6 +748,15 @@ jobs:
           else
             echo "::error::native sqlite-vec not loaded on the read-worker path in ${{ matrix.target }} binary: $vec"; exit 1
           fi
+          # Round-trip a generic read job through the off-thread read-worker pool
+          # — the seam recall / forSession fan-out rides on, which rode into the
+          # SEA on the vector-worker asset with zero build changes (#1029). Pure
+          # JS + node:sqlite (no native vec), so it is FATAL on every target,
+          # including darwin (unlike the --check-vec worker line above).
+          ro=$("$BIN" --check-read-offload || true)
+          echo "Read-offload: $ro"
+          echo "$ro" | grep -q '^ok read-offload via worker' \
+            || (echo "::error::read-worker offload seam broken in ${{ matrix.target }} binary: $ro"; exit 1)
 
   # ---------------------------------------------------------------------------
   # Nightly: build all platforms, generate patches, publish to GHCR
@@ -896,6 +915,12 @@ jobs:
           echo "$vec" | grep -q '^ok worker vec_available=true' \
             && echo "native sqlite-vec read-worker path OK (darwin-arm64)" \
             || echo "::warning::native sqlite-vec not loaded on the read-worker path in darwin-arm64 (dylib codesigning?) — JS fallback in use: $vec"
+          # Generic read-job round-trip through the read-worker pool (#1029).
+          # Pure JS + node:sqlite (no dylib), so it is FATAL here too.
+          ro=$("$BIN" --check-read-offload || true)
+          echo "Read-offload: $ro"
+          echo "$ro" | grep -q '^ok read-offload via worker' \
+            || (echo "::error::read-worker offload seam broken in darwin-arm64 binary: $ro"; exit 1)
 
       - name: Verify code signature
         run: |

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -76,7 +76,12 @@ export { isTextPart, isReasoningPart, isToolPart } from "./types";
 
 export { dataDir } from "./data-dir";
 export { isVecAvailable } from "./db/vec";
-export { checkVecWorker, type VecWorkerCheck } from "./vector-pool";
+export {
+  checkVecWorker,
+  type VecWorkerCheck,
+  checkReadOffload,
+  type ReadOffloadCheck,
+} from "./vector-pool";
 export { load, config, type LoreConfig } from "./config";
 export {
   db,

--- a/packages/core/src/vector-pool.ts
+++ b/packages/core/src/vector-pool.ts
@@ -645,6 +645,140 @@ export async function checkVecWorker(
   });
 }
 
+/** Outcome of {@link checkReadOffload}: a one-shot round-trip of a generic
+ *  read job through the off-thread read-pool worker. */
+export interface ReadOffloadCheck {
+  /** - `"ok"`          → the worker opened its reader connection, ran the read
+   *                      job, and returned the expected row off the main thread.
+   *  - `"init-error"`  → the worker failed to open its reader connection.
+   *  - `"read-error"`  → the worker received the job but threw running it.
+   *  - `"bad-result"`  → the worker replied but with an unexpected row shape.
+   *  - `"timeout"`     → no terminal reply arrived within the deadline.
+   *  - `"spawn-error"` → the worker couldn't be spawned, errored, or exited
+   *                      before replying. */
+  status:
+    | "ok"
+    | "init-error"
+    | "read-error"
+    | "bad-result"
+    | "timeout"
+    | "spawn-error";
+  /** Diagnostic detail for the non-`ok` statuses. */
+  error?: string;
+}
+
+/** Correlation id for the single probe read request. */
+const READ_OFFLOAD_PROBE_ID = 1;
+
+/**
+ * One-shot diagnostic: spawn a SINGLE read-pool worker exactly the way
+ * production does (via {@link spawnWorker} — same SEA
+ * `__LORE_VECTOR_WORKER_SOURCE__` / npm sibling-file resolution), wait for its
+ * `ready`, then dispatch a trivial parameterized `read` job and assert the
+ * `read-result` round-trips back off the main thread.
+ *
+ * This is the read-job analogue of {@link checkVecWorker}. Where `--check-vec`
+ * only proves the worker can OPEN its connection (`ready`), this proves the full
+ * generic read seam the recall + `forSession` fan-out actually rides on: the
+ * embedded `vector-worker.cjs` asset resolves, the worker boots, its transitive
+ * `read-job.ts` handler bundled, and a `{ sql, params, mode }` job executes on
+ * the worker's own query-only connection and returns a structured-cloned row.
+ * That whole chain rode in on the vector-worker asset with ZERO SEA-build
+ * changes when the read-pool generalized (#989/#1005/#1012/#1019) — this guards
+ * the otherwise-untested seam inside a built binary (#1029).
+ *
+ * The probe uses a fixed `SELECT 1` job, so it needs no schema and can't be
+ * perturbed by data; a `read-error`/`bad-result` therefore means the worker's
+ * read path itself is broken, not the query.
+ *
+ * Config-independent: it spawns the worker DIRECTLY, bypassing `poolEnabled()`
+ * (so neither `search.workerOffload` nor `LORE_DISABLE_VEC_WORKER` can mask a
+ * broken seam), and like {@link checkVecWorker} it never touches the shared
+ * `workers[]`, the `poolBroken` latch, or the structural-failure counter.
+ * Honors the test worker-factory seam. Never throws — failures surface as a
+ * non-`ok` status. The probe worker is always terminated before resolving.
+ */
+export async function checkReadOffload(
+  timeoutMs = DEFAULT_VECTOR_SEARCH_TIMEOUT_MS,
+): Promise<ReadOffloadCheck> {
+  let worker: Worker;
+  try {
+    worker = spawnWorker({ dbPath: dbPath() });
+  } catch (err) {
+    return {
+      status: "spawn-error",
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  return await new Promise<ReadOffloadCheck>((resolve) => {
+    let settled = false;
+    const finish = (result: ReadOffloadCheck): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      try {
+        // Tear down the throwaway probe worker. The terminate()-induced `exit`
+        // re-enters `finish`, but the `settled` guard makes it a no-op.
+        void worker.terminate();
+      } catch {
+        // best-effort
+      }
+      resolve(result);
+    };
+
+    const timer = setTimeout(() => finish({ status: "timeout" }), timeoutMs);
+
+    worker.on("message", (msg: VectorWorkerOutbound) => {
+      if (msg.type === "ready") {
+        // Reader connection opened — now exercise the read path itself. A fixed
+        // `SELECT 1` needs no schema and returns a known row.
+        try {
+          worker.postMessage({
+            type: "read",
+            id: READ_OFFLOAD_PROBE_ID,
+            spec: { sql: "SELECT 1 AS one", params: [], mode: "get" },
+          } as VectorWorkerInbound);
+        } catch (err) {
+          finish({
+            status: "spawn-error",
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      } else if (msg.type === "init-error") {
+        finish({ status: "init-error", error: msg.error });
+      } else if (
+        msg.type === "read-result" &&
+        msg.id === READ_OFFLOAD_PROBE_ID
+      ) {
+        const row = msg.rows as { one?: unknown } | null;
+        finish(
+          row && row.one === 1
+            ? { status: "ok" }
+            : { status: "bad-result", error: JSON.stringify(msg.rows) },
+        );
+      } else if (msg.type === "error" && msg.id === READ_OFFLOAD_PROBE_ID) {
+        finish({ status: "read-error", error: msg.error });
+      }
+      // A "result" (vector search) reply can't occur — the probe never posts one.
+    });
+    worker.on("error", (err: Error) => {
+      finish({
+        status: "spawn-error",
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+    worker.on("exit", () => {
+      // An exit before a terminal reply is a structural probe failure. After
+      // `finish` the terminate()-induced exit is a no-op (settled guard above).
+      finish({
+        status: "spawn-error",
+        error: "worker exited before returning a read result",
+      });
+    });
+  });
+}
+
 /** Tear down the pool (test teardown + process reset). Idempotent. The
  *  shuttingDown guard keeps the terminate()-induced worker exits below from
  *  being counted as structural failures. */

--- a/packages/core/test/vector-pool.test.ts
+++ b/packages/core/test/vector-pool.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   _resetVectorPoolForTest,
   _setTestVectorWorkerFactory,
+  checkReadOffload,
   checkVecWorker,
   READ_JOB_TIMED_OUT,
   shutdownVectorPool,
@@ -689,6 +690,127 @@ describe("checkVecWorker (off-thread read-pool vec probe, #1033)", () => {
     // installed, exactly one fake is created per probe.
     _setTestVectorWorkerFactory(factoryEmitting((w) => w.ready(true)));
     await checkVecWorker();
+    expect(FakeWorker.instances.length).toBe(1);
+  });
+});
+
+describe("checkReadOffload (off-thread read-job round-trip probe, #1029)", () => {
+  // Like the real worker, the fake must emit on a macrotask (after
+  // checkReadOffload attaches its listeners). `onReadReply` decides how the fake
+  // answers the `read` request checkReadOffload posts once it sees `ready`.
+  function factoryReadProbe(
+    onReadReply: (w: FakeWorker, id: number) => void,
+    vecAvailable = true,
+  ): (d: VectorWorkerInitData) => never {
+    return (() => {
+      const w = new FakeWorker(
+        () => {},
+        (worker, msg) => onReadReply(worker, msg.id),
+      );
+      setTimeout(() => w.ready(vecAvailable), 0);
+      return w;
+    }) as unknown as (d: VectorWorkerInitData) => never;
+  }
+
+  // A worker that emits an arbitrary lifecycle action (init-error / crash /
+  // silence) on a macrotask and never answers a read request.
+  function factoryEmitting(
+    action: (w: FakeWorker) => void,
+  ): (d: VectorWorkerInitData) => never {
+    return (() => {
+      const w = new FakeWorker(() => {});
+      setTimeout(() => action(w), 0);
+      return w;
+    }) as unknown as (d: VectorWorkerInitData) => never;
+  }
+
+  it("reports ok when the worker boots and round-trips the read job", async () => {
+    _setTestVectorWorkerFactory(
+      factoryReadProbe((w, id) => w.replyRead(id, { one: 1 })),
+    );
+    const r = await checkReadOffload();
+    expect(r).toEqual({ status: "ok" });
+    // The probe worker is always torn down before resolving.
+    expect(FakeWorker.instances[0]?.terminated).toBe(true);
+  });
+
+  it("reports init-error when the worker's reader connection fails to open", async () => {
+    _setTestVectorWorkerFactory(
+      factoryEmitting((w) => w.initError("open boom")),
+    );
+    const r = await checkReadOffload();
+    expect(r).toEqual({ status: "init-error", error: "open boom" });
+  });
+
+  it("reports read-error when the worker throws running the job", async () => {
+    _setTestVectorWorkerFactory(
+      factoryReadProbe((w, id) => w.replyError(id, "scan boom")),
+    );
+    const r = await checkReadOffload();
+    expect(r).toEqual({ status: "read-error", error: "scan boom" });
+  });
+
+  it("reports bad-result when the worker returns an unexpected row", async () => {
+    _setTestVectorWorkerFactory(
+      factoryReadProbe((w, id) => w.replyRead(id, { one: 2 })),
+    );
+    const r = await checkReadOffload();
+    expect(r.status).toBe("bad-result");
+    expect(r.error).toBe(JSON.stringify({ one: 2 }));
+  });
+
+  it("reports bad-result when the worker returns a null row", async () => {
+    _setTestVectorWorkerFactory(
+      factoryReadProbe((w, id) => w.replyRead(id, null)),
+    );
+    const r = await checkReadOffload();
+    expect(r.status).toBe("bad-result");
+  });
+
+  it("reports spawn-error when the worker emits 'error'", async () => {
+    _setTestVectorWorkerFactory(
+      factoryEmitting((w) => w.crash(new Error("crash boom"))),
+    );
+    const r = await checkReadOffload();
+    expect(r).toEqual({ status: "spawn-error", error: "crash boom" });
+  });
+
+  it("reports spawn-error when the worker exits before returning a result", async () => {
+    // Boots (ready) but dies when the read request arrives — no read-result.
+    _setTestVectorWorkerFactory(factoryReadProbe((w) => w.die(1)));
+    const r = await checkReadOffload();
+    expect(r.status).toBe("spawn-error");
+    expect(r.error).toContain("exited before returning a read result");
+  });
+
+  it("reports spawn-error when spawning throws synchronously", async () => {
+    _setTestVectorWorkerFactory((() => {
+      throw new Error("no worker");
+    }) as unknown as (d: VectorWorkerInitData) => never);
+    const r = await checkReadOffload();
+    expect(r).toEqual({ status: "spawn-error", error: "no worker" });
+  });
+
+  it("reports timeout when the worker never boots", async () => {
+    // Worker that never emits ready/init-error/exit (stays silent).
+    _setTestVectorWorkerFactory(factoryEmitting(() => {}));
+    const r = await checkReadOffload(20);
+    expect(r).toEqual({ status: "timeout" });
+    // The wedged probe worker is terminated so it can't leak a thread.
+    expect(FakeWorker.instances[0]?.terminated).toBe(true);
+  });
+
+  it("spawns directly, bypassing the poolEnabled kill switch", async () => {
+    // checkReadOffload must probe the worker seam even when the pool is disabled
+    // by config/env — otherwise a disabled ambient config would mask a broken
+    // SEA seam. With LORE_DISABLE_VEC_WORKER set (poolEnabled() → false), it
+    // still spawns and round-trips.
+    process.env.LORE_DISABLE_VEC_WORKER = "1";
+    _setTestVectorWorkerFactory(
+      factoryReadProbe((w, id) => w.replyRead(id, { one: 1 })),
+    );
+    const r = await checkReadOffload();
+    expect(r).toEqual({ status: "ok" });
     expect(FakeWorker.instances.length).toBe(1);
   });
 });

--- a/packages/gateway/src/cli/main.ts
+++ b/packages/gateway/src/cli/main.ts
@@ -139,6 +139,11 @@ const OPTIONS = {
   // JS brute-force path (`fallback ...`). Used by CI to confirm the SEA binary
   // embeds + loads the vec0 extension.
   "check-vec": { type: "boolean" as const },
+  // Hidden diagnostic: round-trips a trivial generic read job through the
+  // off-thread read-worker pool (prints `ok read-offload via worker`) to prove
+  // the embedded vector-worker asset + read-job seam works inside the SEA
+  // binary — the path recall/forSession fan-out rides on (#1029).
+  "check-read-offload": { type: "boolean" as const },
 } as const;
 
 // Populate the set used by extractAgentArgs to distinguish lore's own flags
@@ -317,6 +322,41 @@ export async function _cli(): Promise<void> {
     // Exit outside the try so a throw on the success path can't be mis-reported
     // as a check failure; safeExit (not process.exit) on both paths avoids the
     // Bun NAPI teardown hang.
+    safeExit(ok ? 0 : 1);
+    return;
+  }
+
+  // --check-read-offload (hidden). Proves the off-thread read-worker seam works
+  // end-to-end inside a built binary: spawns one read-pool worker exactly the
+  // way production does (embedded `vector-worker.cjs` asset), boots its reader
+  // connection, and round-trips a trivial `SELECT 1` read job back off the main
+  // thread. Unlike --check-vec (native sqlite-vec may legitimately be absent →
+  // JS fallback is OK), the read seam is pure JS + node:sqlite and MUST work on
+  // every platform, so anything but a worker round-trip is a hard failure. CI
+  // greps `^ok read-offload via worker` per platform AND checks the exit code.
+  if (values["check-read-offload"]) {
+    const { db, checkReadOffload } = await import("@loreai/core");
+    const { safeExit } = await import("./exit");
+    let ok = false;
+    try {
+      // Create/migrate the DB file so the worker's reader connection can open it.
+      db();
+      const r = await checkReadOffload();
+      if (r.status === "ok") {
+        console.log("ok read-offload via worker");
+        ok = true;
+      } else {
+        // Surface the failing status on stdout so the captured output shows why
+        // the assertion failed; the exit code is the gate.
+        console.log(
+          `read-offload failed: ${r.status}${r.error ? ` (${r.error})` : ""}`,
+        );
+      }
+    } catch (err: unknown) {
+      console.error(
+        `✗ check-read-offload failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
     safeExit(ok ? 0 : 1);
     return;
   }

--- a/packages/gateway/test/cli-check-read-offload.test.ts
+++ b/packages/gateway/test/cli-check-read-offload.test.ts
@@ -1,0 +1,137 @@
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from "vitest";
+import type { ReadOffloadCheck } from "@loreai/core";
+
+// Mutable state driving the @loreai/core mock so each test can steer the
+// `--check-read-offload` handler down a specific branch (ok / failure statuses
+// / db throw) without a real DB or a real worker thread. Hoisted alongside
+// vi.mock (lifted to the top of the file) so both the state and the safeExit
+// spy exist when the mock factories run.
+const { state, safeExit } = vi.hoisted(() => ({
+  state: {
+    dbThrows: false,
+    result: { status: "ok" } as ReadOffloadCheck,
+  },
+  safeExit: vi.fn(),
+}));
+
+// Partial mock: keep every real export (main.ts → start.ts → config.ts pulls
+// several at module load) and override only the two the handler calls.
+vi.mock("@loreai/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@loreai/core")>();
+  return {
+    ...actual,
+    db: () => {
+      if (state.dbThrows) throw new Error("db boom");
+      return { query: () => ({ get: () => ({}), all: () => [] }) };
+    },
+    checkReadOffload: async () => state.result,
+  };
+});
+
+// `safeExit` normally terminates the process; here it's a no-op so the handler
+// returns and the test runner survives. Resolves to the same module file that
+// main.ts imports via `./exit`.
+vi.mock("../src/cli/exit", () => ({ safeExit }));
+
+import { _cli } from "../src/cli/main";
+
+describe("--check-read-offload CLI diagnostic", () => {
+  const origArgv = process.argv;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    state.dbThrows = false;
+    state.result = { status: "ok" };
+    safeExit.mockClear();
+    process.argv = ["node", "lore", "--check-read-offload"];
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`__exit:${code}`);
+    }) as never);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    process.argv = origArgv;
+  });
+
+  test("worker round-trip ok: prints the worker line and exits 0", async () => {
+    state.result = { status: "ok" };
+
+    await _cli();
+
+    expect(logSpy).toHaveBeenCalledWith("ok read-offload via worker");
+    expect(safeExit).toHaveBeenCalledWith(0);
+    expect(errSpy).not.toHaveBeenCalled();
+  });
+
+  test("worker init-error: prints the failing status on stdout and exits 1", async () => {
+    state.result = { status: "init-error", error: "open boom" };
+
+    await _cli();
+
+    expect(logSpy).toHaveBeenCalledWith(
+      "read-offload failed: init-error (open boom)",
+    );
+    expect(logSpy).not.toHaveBeenCalledWith("ok read-offload via worker");
+    expect(safeExit).toHaveBeenCalledWith(1);
+  });
+
+  test("worker read-error: exits 1", async () => {
+    state.result = { status: "read-error", error: "scan boom" };
+
+    await _cli();
+
+    expect(logSpy).toHaveBeenCalledWith(
+      "read-offload failed: read-error (scan boom)",
+    );
+    expect(safeExit).toHaveBeenCalledWith(1);
+  });
+
+  test("worker timeout (no error detail): exits 1 without a trailing paren", async () => {
+    state.result = { status: "timeout" };
+
+    await _cli();
+
+    expect(logSpy).toHaveBeenCalledWith("read-offload failed: timeout");
+    expect(safeExit).toHaveBeenCalledWith(1);
+  });
+
+  test("spawn-error: exits 1", async () => {
+    state.result = { status: "spawn-error", error: "no worker" };
+
+    await _cli();
+
+    expect(logSpy).toHaveBeenCalledWith(
+      "read-offload failed: spawn-error (no worker)",
+    );
+    expect(safeExit).toHaveBeenCalledWith(1);
+  });
+
+  test("db error: prints failure via console.error and exits 1", async () => {
+    state.dbThrows = true;
+
+    await _cli();
+
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringContaining("✗ check-read-offload failed: db boom"),
+    );
+    expect(safeExit).toHaveBeenCalledWith(1);
+  });
+});


### PR DESCRIPTION
Closes #1029.

## Problem

The generic read-worker pool (`vector-pool.ts`) — off-thread vector search (#989), `forSession` packing (#1005), recall FTS fan-out (#1012), entity/hydration offload (#1019) — ships inside the SEA binary, but **nothing spawned it inside a built binary in CI**. It rode in on the existing `vector-worker.cjs` asset with zero SEA-build changes. That elegance is the risk: an asset-key mismatch, `eval:true`/`filename` breakage, a transitive `read-job.ts`/`vector-query.ts` bundling failure, or a worker init throw would silently degrade recall to the in-process fallback (re-blocking the event loop — the exact thing #966 fixed) with **no failing test**.

`--check-vec` (#1033) only proves the worker can **open** its connection (`ready`); it never runs a read job.

## Change

Add `checkReadOffload()` (core) + `--check-read-offload` (CLI), mirroring the reviewed `checkVecWorker` / `--check-vec`:

- Spawn **one** read-pool worker exactly the way production does (`spawnWorker` → embedded `__LORE_VECTOR_WORKER_SOURCE__` asset / npm sibling), wait for `ready`, then dispatch a trivial `{ sql: "SELECT 1 AS one", params: [], mode: "get" }` read job and assert the `read-result` round-trips back off the main thread.
- **Config-independent**: spawns directly, bypassing `poolEnabled()`, so neither `search.workerOffload` nor `LORE_DISABLE_VEC_WORKER` can mask a broken seam. Never touches the live `workers[]`, the `poolBroken` latch, or the structural-failure counter. Honors the test worker-factory seam; never throws; always terminates the probe worker.
- Fixed `SELECT 1` job needs no schema, so a `read-error`/`bad-result` means the worker's read path itself is broken, not the query.

Unlike `--check-vec` (native sqlite-vec may legitimately fall back to JS on e.g. darwin), the read seam is **pure JS + node:sqlite and must work on every platform**, so it is **fatal** on all three smoke jobs.

## CI wiring

`--check-read-offload` added to all three binary smokes, asserting `^ok read-offload via worker` (fatal everywhere):
- linux-x64 (in the `test` job),
- `binary-smoke-native` matrix (darwin-arm64 + windows-x64),
- the darwin-arm64 release/signing job.

## Tests

- **10** `checkReadOffload` unit cases (ok / init-error / read-error / bad-result / null-row / spawn-error on crash / exit-before-result / spawn-throw / timeout / kill-switch-bypass) via the `FakeWorker` seam.
- **6** CLI-handler cases (worker ok → exit 0; each failure status → exit 1; db throw → exit 1).
- Mutation-verified: dropping the `row.one === 1` assertion fails the bad-result tests; not posting the read job fails the round-trip tests.
- Full `@loreai/core` (2415) and `@loreai/gateway` (2494) suites green; typecheck + Biome clean; `ci.yml` parses.

## Non-goals

Native `sqlite-vec` stays intentionally stubbed in the SEA worker — this asserts the **off-thread round-trip**, not native-vec acceleration (that's `--check-vec`).