### PR TITLE
docs(website): frame Lore as continual learning in token space (#1124)

### DIFF
--- a/packages/website/src/pages/different.astro
+++ b/packages/website/src/pages/different.astro
@@ -387,6 +387,20 @@ const base = import.meta.env.BASE_URL;
       </div>
       <div class="bc bc-3 sr">
         <div>
+          <p class="bc-tag">Learning in token space</p>
+          <h3 class="bc-t">Knowledge that <em>outlives the model</em></h3>
+          <p class="bc-b">Fine-tuning bakes what an agent learns into weights you can't read, can't move,
+            and lose the moment you upgrade the model. Lore learns in <em>token space</em> instead — durable
+            knowledge in plain text, not parameter updates. That's why you can read every entry, carry the
+            same knowledge across providers and model generations, and roll back a line instead of retraining.
+            The model is the part you swap; your knowledge is the part that stays.</p>
+        </div>
+        <div class="code-block">
+          <code><span class="ck"># Learned once. Portable across</span><br><span class="ck"># every model and provider.</span><br><br><span class="cv">$</span> cat .lore.md<br><span class="ck">* **Auth**: refresh tokens in the</span><br><span class="ck">  middleware, never per route.</span></code>
+        </div>
+      </div>
+      <div class="bc bc-3 sr">
+        <div>
           <p class="bc-tag">Proven where it's hardest</p>
           <h3 class="bc-t">The advantage grows with the session</h3>
           <p class="bc-b">On a real 5-day, 2.3M-token coding session, Lore averaged 4.0/5 on recall versus 2.4/5

--- a/packages/website/src/pages/index.astro
+++ b/packages/website/src/pages/index.astro
@@ -324,7 +324,8 @@ const base = import.meta.env.BASE_URL;
           instruction capture, LLM-mediated curation, and adaptive calibration —
           compound across sessions. Patterns, gotchas, and decisions are automatically curated and exported to
           <code class="code-inline">.lore.md</code>,
-          git-portable and model-agnostic. What <a href="https://arxiv.org/abs/2605.27276"
+          git-portable and model-agnostic: knowledge learned in token space, not baked into weights you
+          lose at the next upgrade. What <a href="https://arxiv.org/abs/2605.27276"
           target="_blank" rel="noopener noreferrer" style="border-bottom:1px solid var(--g4)">researchers call</a>
           "harness self-improvement" — Lore does it automatically.</p>
       </div>


### PR DESCRIPTION
## Summary

Adopts the **"learning in token space"** framing on Lore's live positioning surfaces (part of #1124). Reframes the durability story: Lore learns in *token space* (durable text you own) rather than model weights — which is why its knowledge is inspectable, portable across model generations, and reversible.

## Changes

- **`different.astro`** (Why Lore page): new full-width card in the Ownership/Portability section — *"Learning in token space — Knowledge that outlives the model."* Contrasts weight-baked fine-tuning (unreadable, unmovable, lost on upgrade) with token-space knowledge, and illustrates with a plain `.lore.md` entry.
- **`index.astro`** (landing): sharpened the "Learning" bento to name the framing — *"git-portable and model-agnostic: knowledge learned in token space, not baked into weights you lose at the next upgrade."*

Grid stays balanced (12-col bento; new card is a `bc-3` full-width, idiomatic with the existing stacked `bc-3`s). `astro build` passes — all 20 pages, including `/` and `/different/`, render.

## Voice / guardrails

- Product-grounded; kept the grand-vision register ("machines that learn") out per the issue's non-goals.
- Third-person "Lore" voice to match the page; weight-vs-token contrasts kept to thesis-level only (no "you don't say X, you say Y" tic).
- Honest claims only — the `.lore.md` example and inspectable/portable/reversible properties are real.

## Follow-ups (kept open on #1124)

The formal artifacts #1124 also lists — the comparison page (#964) and technical note (#963) — don't exist yet; they should inherit this framing when built. Leaving #1124 open to track that.

Refs #1124
