### PR TITLE
feat(core): make the local-embedding stack an optional dependency (#1026)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,13 +25,15 @@
   },
   "dependencies": {
     "@huggingface/hub": "2.11.0",
-    "@huggingface/transformers": "^3.7.1",
     "micromark": "^4.0.0",
     "p-limit": "7",
     "remark": "^15.0.1",
     "sqlite-vec": "0.1.9",
     "uuidv7": "^1.1.0",
     "zod": "^4.3.6"
+  },
+  "optionalDependencies": {
+    "@huggingface/transformers": "^3.7.1"
   },
   "devDependencies": {
     "@types/mdast": "^4.0.4"

--- a/packages/core/src/embedding-worker-types.ts
+++ b/packages/core/src/embedding-worker-types.ts
@@ -161,6 +161,31 @@ export function isWasmFatalError(msg: string): boolean {
 }
 
 /**
+ * Detect that the OPTIONAL local-embedding stack is simply not installed, as
+ * opposed to installed-but-broken. `@huggingface/transformers` (and its native
+ * transitive deps `onnxruntime-node` / `onnxruntime-web` / `sharp`) is an
+ * `optionalDependency` of `@loreai/core` (#1026): a consumer on remote
+ * embeddings — or the SEA binary, which ships its own runtime — can install
+ * with `--omit=optional` and drop ~480 MB of ML runtime. When absent, the
+ * worker's `import("@huggingface/transformers")` (or, since transformers is
+ * bundled, its transitive `require("onnxruntime-node")`) throws a module-/
+ * package-not-found error rather than a runtime crash.
+ *
+ * We surface THIS as an expected, actionable degraded state (warn → FTS-only),
+ * distinct from a genuine init failure (error). Match requires BOTH a
+ * module-not-found signal AND a reference to one of the optional packages, so an
+ * unrelated resolution error (e.g. a missing model file) is never misclassified.
+ */
+export function isMissingLocalStackError(msg: string): boolean {
+  const moduleNotFound =
+    /ERR_MODULE_NOT_FOUND|Cannot find (?:module|package)|Could not locate the bindings file/i.test(
+      msg,
+    );
+  if (!moduleNotFound) return false;
+  return /@huggingface\/transformers|onnxruntime|\bsharp\b/i.test(msg);
+}
+
+/**
  * The two leading strings transformers.js' `sessionRun()` (models.js) passes to
  * `console.error` when `session.run` throws, before it re-throws: the error
  * message, and a dump of every input tensor's metadata AND `.data`. For our

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -53,6 +53,7 @@ import {
 } from "./embedding-cap";
 import {
   EMBED_OOM_EXIT_CODE,
+  isMissingLocalStackError,
   isWasmFatalError,
   type EmbedRequest,
   type WorkerInbound,
@@ -641,11 +642,25 @@ class LocalProvider implements EmbeddingProvider {
             localProviderKnownBroken = true;
             if (!localProviderErrorLogged) {
               localProviderErrorLogged = true;
-              log.error(
-                `local embedding provider failed to init: ${msg.error}. ` +
-                  `Set search.embeddings.provider in .lore.json to use a remote provider.`,
-                new Error(`embedding worker init failed: ${msg.error}`),
-              );
+              // Distinguish "optional local-embedding stack not installed"
+              // (#1026 — an expected, actionable degraded state) from a genuine
+              // init failure. Both latch the provider broken and degrade recall
+              // to FTS-only; only the log severity/message differs.
+              if (isMissingLocalStackError(msg.error)) {
+                log.warn(
+                  "local embedding dependencies not installed " +
+                    "(optional '@huggingface/transformers' / 'onnxruntime-node' absent) — " +
+                    "recall will use FTS-only search. Reinstall without --omit=optional to " +
+                    "enable local embeddings, or set search.embeddings.provider in .lore.json " +
+                    "to a remote provider (voyage/openai) with the matching API key.",
+                );
+              } else {
+                log.error(
+                  `local embedding provider failed to init: ${msg.error}. ` +
+                    `Set search.embeddings.provider in .lore.json to use a remote provider.`,
+                  new Error(`embedding worker init failed: ${msg.error}`),
+                );
+              }
             }
             for (const [, p] of this.pendingRequests) {
               p.reject(new LocalProviderUnavailableError(msg.error));
@@ -2175,7 +2190,22 @@ export interface BackfillOptions {
 export async function runStartupBackfill(
   opts: BackfillOptions = {},
 ): Promise<BackfillStats> {
-  if (!isAvailable()) return emptyBackfillStats();
+  if (!isAvailable()) {
+    // Make the degraded state visible in the startup path — this early return
+    // was previously silent, so a consumer who omitted the optional
+    // local-embedding stack (#1026), or is on a remote provider without a key,
+    // had no startup signal that backfill (and vector recall) is off. Gate on
+    // `enabled` so a deliberate `search.embeddings.enabled: false` stays quiet.
+    // `isAvailable()` already emits the local-broken FTS-only line once; this is
+    // the startup-scoped, backfill-specific companion.
+    if (config().search.embeddings.enabled !== false) {
+      log.info(
+        "startup embedding backfill skipped — embeddings unavailable " +
+          "(recall will use FTS-only search)",
+      );
+    }
+    return emptyBackfillStats();
+  }
 
   // Handle an embedding-config change, then attempt the one-time blob→vec0
   // cutover (both no-ops in the steady state). Order matters: a config change

--- a/packages/core/test/embedding-optional-stack.test.ts
+++ b/packages/core/test/embedding-optional-stack.test.ts
@@ -1,0 +1,273 @@
+import { readFileSync } from "node:fs";
+import { EventEmitter } from "node:events";
+import { fileURLToPath } from "node:url";
+import type { Worker } from "node:worker_threads";
+import { afterEach, beforeEach, describe, expect, it, test } from "vitest";
+import {
+  embed,
+  isAvailable,
+  runStartupBackfill,
+  LocalProviderUnavailableError,
+  _markLocalProviderUnavailable,
+  _resetLocalProviderProbe,
+  _restoreProvider,
+  _saveAndClearProvider,
+  _setTestWorkerFactory,
+} from "../src/embedding";
+import { isMissingLocalStackError } from "../src/embedding-worker-types";
+import { type LogSink, registerSink } from "../src/log";
+
+// #1026: `@huggingface/transformers` (+ its native transitive deps
+// onnxruntime-node/onnxruntime-web/sharp) is an OPTIONAL dependency of
+// @loreai/core. A consumer on remote embeddings — or the SEA binary, which
+// ships its own runtime — can `--omit=optional` and drop ~480 MB. When the
+// stack is absent the local provider must degrade to FTS-only recall, and the
+// degraded state must be VISIBLE and correctly classified (an expected "not
+// installed" warn, not an alarming "failed to init" error).
+
+// ---------------------------------------------------------------------------
+// Part A — isMissingLocalStackError classifier (pure)
+// ---------------------------------------------------------------------------
+
+describe("isMissingLocalStackError", () => {
+  test("true: ESM import of the absent optional package", () => {
+    expect(
+      isMissingLocalStackError(
+        "Cannot find package '@huggingface/transformers' imported from /app/worker.cjs",
+      ),
+    ).toBe(true);
+    expect(
+      isMissingLocalStackError(
+        "Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@huggingface/transformers'",
+      ),
+    ).toBe(true);
+  });
+
+  test("true: the native transitive deps are absent (--omit=optional)", () => {
+    // transformers is bundled into the worker, so with optionals omitted the
+    // failure surfaces from its transitive require("onnxruntime-node").
+    expect(
+      isMissingLocalStackError("Cannot find module 'onnxruntime-node'"),
+    ).toBe(true);
+    expect(
+      isMissingLocalStackError(
+        "Could not locate the bindings file for onnxruntime-node",
+      ),
+    ).toBe(true);
+    expect(isMissingLocalStackError("Cannot find module 'sharp'")).toBe(true);
+  });
+
+  test("false: module-not-found WITHOUT a known optional package (e.g. a model file)", () => {
+    // A missing model file must NOT be misread as "stack not installed".
+    expect(
+      isMissingLocalStackError(
+        "Cannot find module '/home/u/.cache/lore/model/model_quantized.onnx'",
+      ),
+    ).toBe(false);
+  });
+
+  test("false: a runtime failure that merely mentions onnxruntime (not a resolution error)", () => {
+    // OOM / allocation failures name onnxruntime but are NOT not-installed.
+    expect(
+      isMissingLocalStackError("onnxruntime allocation failed: 284792864"),
+    ).toBe(false);
+    expect(isMissingLocalStackError("pipeline is not a function")).toBe(false);
+    expect(isMissingLocalStackError("Aborted(). Build with -sASSERTIONS")).toBe(
+      false,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Part B — init-error classification: "not installed" (warn) vs genuine
+//          init failure (error). Both latch the provider broken.
+// ---------------------------------------------------------------------------
+
+/** Minimal stand-in for a node:worker_threads Worker (mirrors the seam used by
+ *  embedding-oom-recovery.test.ts) so we can emit "message" deterministically. */
+class FakeWorker extends EventEmitter {
+  postMessage(): void {}
+  ref(): void {}
+  unref(): void {}
+  terminate(): Promise<number> {
+    return Promise.resolve(0);
+  }
+}
+
+interface Captured {
+  level: "info" | "warn" | "error";
+  message: string;
+}
+
+function capturingSink(out: Captured[]): LogSink {
+  return {
+    info: (m) => out.push({ level: "info", message: m }),
+    warn: (m) => out.push({ level: "warn", message: m }),
+    error: (m) => out.push({ level: "error", message: m }),
+    captureException: () => {},
+  };
+}
+
+const passthroughSink: LogSink = {
+  info() {},
+  warn() {},
+  error() {},
+  captureException() {},
+};
+
+/** Attach handlers immediately so the LocalProviderUnavailableError rejection
+ *  that fires while we drive the worker is never flagged "unhandled". */
+function settle<T>(
+  p: Promise<T>,
+): Promise<{ ok: true; value: T } | { ok: false; err: unknown }> {
+  return p.then(
+    (value) => ({ ok: true as const, value }),
+    (err) => ({ ok: false as const, err }),
+  );
+}
+
+async function flush(): Promise<void> {
+  for (let i = 0; i < 5; i++) await Promise.resolve();
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+describe("init-error classification (worker-mock)", () => {
+  let savedProvider: unknown;
+  let savedVoyage: string | undefined;
+  let savedOpenAI: string | undefined;
+  let logs: Captured[];
+
+  beforeEach(() => {
+    // Force the local provider (no remote fallback) and a fresh instance.
+    savedVoyage = process.env.VOYAGE_API_KEY;
+    savedOpenAI = process.env.OPENAI_API_KEY;
+    delete process.env.VOYAGE_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    _resetLocalProviderProbe();
+    savedProvider = _saveAndClearProvider();
+    logs = [];
+    registerSink(capturingSink(logs));
+  });
+
+  afterEach(() => {
+    registerSink(passthroughSink);
+    _setTestWorkerFactory(null);
+    _resetLocalProviderProbe();
+    _restoreProvider(savedProvider);
+    if (savedVoyage !== undefined) process.env.VOYAGE_API_KEY = savedVoyage;
+    if (savedOpenAI !== undefined) process.env.OPENAI_API_KEY = savedOpenAI;
+  });
+
+  it("missing optional stack → WARN 'not installed', latches FTS-only (no error)", async () => {
+    const fakes: FakeWorker[] = [];
+    _setTestWorkerFactory(() => {
+      const f = new FakeWorker();
+      fakes.push(f);
+      return f as unknown as Worker;
+    });
+
+    const result = settle(embed(["hello"], "query"));
+    await flush();
+    expect(fakes).toHaveLength(1);
+
+    // The worker (or its bundled transformers) can't resolve the optional stack.
+    fakes[0].emit("message", {
+      type: "init-error",
+      error: "Cannot find module 'onnxruntime-node'",
+    });
+    await flush();
+
+    const r = await result;
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.err).toBeInstanceOf(LocalProviderUnavailableError);
+    expect(isAvailable()).toBe(false); // degraded to FTS-only
+
+    const warns = logs.filter((l) => l.level === "warn");
+    const errors = logs.filter((l) => l.level === "error");
+    expect(warns.some((l) => /not installed/i.test(l.message))).toBe(true);
+    // A deliberately-omitted optional dep must NOT be logged at error severity.
+    expect(errors).toHaveLength(0);
+  });
+
+  it("genuine init failure → ERROR 'failed to init', latches FTS-only", async () => {
+    const fakes: FakeWorker[] = [];
+    _setTestWorkerFactory(() => {
+      const f = new FakeWorker();
+      fakes.push(f);
+      return f as unknown as Worker;
+    });
+
+    const result = settle(embed(["hello"], "query"));
+    await flush();
+
+    fakes[0].emit("message", {
+      type: "init-error",
+      error: "model load failed: corrupt tokenizer.json",
+    });
+    await flush();
+
+    const r = await result;
+    expect(r.ok).toBe(false);
+    expect(isAvailable()).toBe(false);
+
+    const errors = logs.filter((l) => l.level === "error");
+    const warns = logs.filter((l) => l.level === "warn");
+    expect(errors.some((l) => /failed to init/i.test(l.message))).toBe(true);
+    // The install-guidance warn is reserved for the not-installed case.
+    expect(warns.some((l) => /not installed/i.test(l.message))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Part C — runStartupBackfill makes the degraded state visible
+// ---------------------------------------------------------------------------
+
+describe("runStartupBackfill degraded-state log", () => {
+  let savedProvider: unknown;
+  let logs: Captured[];
+
+  beforeEach(() => {
+    savedProvider = _saveAndClearProvider();
+    logs = [];
+    registerSink(capturingSink(logs));
+  });
+
+  afterEach(() => {
+    registerSink(passthroughSink);
+    _resetLocalProviderProbe();
+    _restoreProvider(savedProvider);
+  });
+
+  it("logs that backfill was skipped when embeddings are unavailable", async () => {
+    _markLocalProviderUnavailable();
+    const stats = await runStartupBackfill();
+    expect(stats.knowledgeEmbedded).toBe(0);
+    expect(
+      logs.some(
+        (l) => l.level === "info" && /backfill skipped/i.test(l.message),
+      ),
+    ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Part D — packaging invariant: the local stack is an OPTIONAL dependency
+// ---------------------------------------------------------------------------
+
+describe("packaging: @huggingface/transformers is optional (#1026)", () => {
+  const pkg = JSON.parse(
+    readFileSync(fileURLToPath(new URL("../package.json", import.meta.url)), {
+      encoding: "utf8",
+    }),
+  ) as {
+    dependencies?: Record<string, string>;
+    optionalDependencies?: Record<string, string>;
+  };
+
+  test("declared under optionalDependencies, not dependencies", () => {
+    expect(
+      pkg.optionalDependencies?.["@huggingface/transformers"],
+    ).toBeTruthy();
+    expect(pkg.dependencies?.["@huggingface/transformers"]).toBeUndefined();
+  });
+});

--- a/packages/website/src/content/docs/docs/install.md
+++ b/packages/website/src/content/docs/docs/install.md
@@ -27,6 +27,16 @@ You can also run the gateway directly with npm:
 npx @loreai/gateway
 ```
 
+## Slimmer installs (remote embeddings)
+
+Lore's on-device (local) embeddings run through `@huggingface/transformers` and the ONNX runtime — about 480 MB of ML runtime that's pulled in when you `npm install` a Lore package (`@loreai/core`, `@loreai/opencode`, `@loreai/pi`). It's an **optional dependency**, so if you use a remote embedding provider — or don't need vector recall — you can skip it:
+
+```bash
+npm install @loreai/opencode --omit=optional
+```
+
+With the stack absent, recall degrades gracefully to FTS-only keyword search. To keep semantic recall without the local runtime, set a remote provider in `.lore.json` (`search.embeddings.provider` = `voyage` or `openai`, with the matching API key). The hosted install script and the standalone binary are unaffected — they ship their own runtime and never read `node_modules`.
+
 ## Existing Conversations
 
 Lore can import previous coding conversations so a new project memory does not start from a blank slate:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,9 +71,6 @@ importers:
       '@huggingface/hub':
         specifier: 2.11.0
         version: 2.11.0
-      '@huggingface/transformers':
-        specifier: ^3.7.1
-        version: 3.8.1
       micromark:
         specifier: ^4.0.0
         version: 4.0.2
@@ -96,6 +93,10 @@ importers:
       '@types/mdast':
         specifier: ^4.0.4
         version: 4.0.4
+    optionalDependencies:
+      '@huggingface/transformers':
+        specifier: ^3.7.1
+        version: 3.8.1
 
   packages/gateway:
     dependencies:
@@ -5092,7 +5093,8 @@ snapshots:
     optionalDependencies:
       cli-progress: 3.12.0
 
-  '@huggingface/jinja@0.5.9': {}
+  '@huggingface/jinja@0.5.9':
+    optional: true
 
   '@huggingface/tasks@0.19.90': {}
 
@@ -5102,6 +5104,7 @@ snapshots:
       onnxruntime-node: 1.21.0
       onnxruntime-web: 1.22.0-dev.20250409-89f8206ba4
       sharp: 0.34.5
+    optional: true
 
   '@img/colour@1.1.0': {}
 
@@ -6230,7 +6233,8 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  boolean@3.2.0: {}
+  boolean@3.2.0:
+    optional: true
 
   bowser@2.14.1: {}
 
@@ -6393,12 +6397,14 @@ snapshots:
       es-define-property: 1.0.1
       es-errors: 1.3.0
       gopd: 1.2.0
+    optional: true
 
   define-properties@1.2.1:
     dependencies:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+    optional: true
 
   defu@6.1.7: {}
 
@@ -6413,7 +6419,8 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  detect-node@2.1.0: {}
+  detect-node@2.1.0:
+    optional: true
 
   devalue@5.8.1: {}
 
@@ -6484,7 +6491,8 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
 
-  es6-error@4.1.1: {}
+  es6-error@4.1.1:
+    optional: true
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -6533,7 +6541,8 @@ snapshots:
 
   escape-html@1.0.3: {}
 
-  escape-string-regexp@4.0.0: {}
+  escape-string-regexp@4.0.0:
+    optional: true
 
   escape-string-regexp@5.0.0: {}
 
@@ -6651,7 +6660,8 @@ snapshots:
     dependencies:
       is-unicode-supported: 2.1.0
 
-  flatbuffers@25.9.23: {}
+  flatbuffers@25.9.23:
+    optional: true
 
   flattie@1.1.1: {}
 
@@ -6755,11 +6765,13 @@ snapshots:
       roarr: 2.15.4
       semver: 7.8.4
       serialize-error: 7.0.1
+    optional: true
 
   globalthis@1.0.4:
     dependencies:
       define-properties: 1.2.1
       gopd: 1.2.0
+    optional: true
 
   google-auth-library@10.7.0:
     dependencies:
@@ -6789,7 +6801,8 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  guid-typescript@1.0.9: {}
+  guid-typescript@1.0.9:
+    optional: true
 
   h3@1.15.11:
     dependencies:
@@ -6808,6 +6821,7 @@ snapshots:
   has-property-descriptors@1.0.2:
     dependencies:
       es-define-property: 1.0.1
+    optional: true
 
   has-symbols@1.1.0: {}
 
@@ -7141,7 +7155,8 @@ snapshots:
 
   json-schema-traverse@1.0.0: {}
 
-  json-stringify-safe@5.0.1: {}
+  json-stringify-safe@5.0.1:
+    optional: true
 
   json5@2.2.3: {}
 
@@ -7221,6 +7236,7 @@ snapshots:
   matcher@3.0.0:
     dependencies:
       escape-string-regexp: 4.0.0
+    optional: true
 
   math-intrinsics@1.1.0: {}
 
@@ -7760,7 +7776,8 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
-  object-keys@1.1.1: {}
+  object-keys@1.1.1:
+    optional: true
 
   obug@2.1.2: {}
 
@@ -7782,15 +7799,18 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
-  onnxruntime-common@1.21.0: {}
+  onnxruntime-common@1.21.0:
+    optional: true
 
-  onnxruntime-common@1.22.0-dev.20250409-89f8206ba4: {}
+  onnxruntime-common@1.22.0-dev.20250409-89f8206ba4:
+    optional: true
 
   onnxruntime-node@1.21.0:
     dependencies:
       global-agent: 3.0.0
       onnxruntime-common: 1.21.0
       tar: 7.5.16
+    optional: true
 
   onnxruntime-web@1.22.0-dev.20250409-89f8206ba4:
     dependencies:
@@ -7800,6 +7820,7 @@ snapshots:
       onnxruntime-common: 1.22.0-dev.20250409-89f8206ba4
       platform: 1.3.6
       protobufjs: 8.6.3
+    optional: true
 
   openai@6.26.0(ws@8.21.0)(zod@4.4.3):
     optionalDependencies:
@@ -7925,7 +7946,8 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  platform@1.3.6: {}
+  platform@1.3.6:
+    optional: true
 
   portable-executable-signature@2.0.6: {}
 
@@ -8196,6 +8218,7 @@ snapshots:
       json-stringify-safe: 5.0.1
       semver-compare: 1.0.0
       sprintf-js: 1.1.3
+    optional: true
 
   rollup@4.62.0:
     dependencies:
@@ -8238,7 +8261,8 @@ snapshots:
 
   sax@1.6.0: {}
 
-  semver-compare@1.0.0: {}
+  semver-compare@1.0.0:
+    optional: true
 
   semver@6.3.1: {}
 
@@ -8253,6 +8277,7 @@ snapshots:
   serialize-error@7.0.1:
     dependencies:
       type-fest: 0.13.1
+    optional: true
 
   sharp@0.34.5:
     dependencies:
@@ -8355,7 +8380,8 @@ snapshots:
 
   split2@4.2.0: {}
 
-  sprintf-js@1.1.3: {}
+  sprintf-js@1.1.3:
+    optional: true
 
   sqlite-vec-darwin-arm64@0.1.9:
     optional: true
@@ -8513,7 +8539,8 @@ snapshots:
 
   tunnel@0.0.6: {}
 
-  type-fest@0.13.1: {}
+  type-fest@0.13.1:
+    optional: true
 
   typebox@1.1.38: {}
 


### PR DESCRIPTION
Closes #1026. Follow-up to #1027 (which removed core's ML tree from the raw-npm **gateway** path by inlining core into the Bun bundle); this covers the remaining runtime-dep paths.

## What

Move `@huggingface/transformers` from `dependencies` to `optionalDependencies` in `packages/core/package.json`. Its native tree (`onnxruntime-node` ~208 MB, `@huggingface/transformers` ~179 MB, `onnxruntime-web` ~90 MB — ≈480 MB) is only reachable through transformers, so this makes the whole subtree **optional-transitive**. A consumer of `@loreai/core` / `@loreai/opencode` / `@loreai/pi` on remote embeddings (or who doesn't need vector recall) can now:

```bash
npm install @loreai/opencode --omit=optional
```

and drop the ~480 MB.

## Why it's safe

Runtime degradation already existed and is unchanged: an absent stack makes the worker's `import("@huggingface/transformers")` (or, since transformers is bundled into the worker, its transitive `require("onnxruntime-node")`) throw → `init-error` → the `localProviderKnownBroken` latch → `isAvailable()` false → every vector read/write degrades to **FTS-only**. No exceptions bubble to callers.

Default installs (CI, dev) still get the stack — pnpm/npm install optionals unless `--omit=optional` — so the build (which inlines transformers into the worker) and every test are unaffected. Verified: `pnpm install --lockfile-only` produces a minimal diff (transformers → `optionalDependencies`, subtree marked `optional: true`), lockfile format matches the pinned pnpm 10.28.0, and `@loreai/core` build still bundles `embedding-worker.js` (1.9 MB, transformers inlined). The SEA binary and npm gateway bundle ship their own runtime and never read `node_modules`.

## Observability (the code change)

The absent-stack path was either alarming (logged at `error`) or silent. Two fixes so the degraded state reads correctly:

- **`isMissingLocalStackError()`** (new classifier in `embedding-worker-types.ts`) distinguishes "optional stack not installed" from a genuine init failure. Match requires **both** a module-not-found signal **and** a reference to one of the optional packages, so an unrelated resolution error (e.g. a missing model file) is never misclassified. The `init-error` handler now logs the not-installed case at **`warn`** with actionable guidance instead of **`error`**.
- **`runStartupBackfill()`**'s previously-silent unavailable early-return now logs an `info` line, gated on `search.embeddings.enabled` so a deliberate disable stays quiet.

## Deliberately NOT done

No implicit auto-switch to a remote provider when local is absent — that would mean surprising data egress to a third-party API. Degradation stays FTS-only (explicit); the warn tells users how to opt into a remote provider.

## Tests (`embedding-optional-stack.test.ts`, all mutation-verified)

- `isMissingLocalStackError` truth table (transformers/onnxruntime/sharp not-found → true; missing **model file** → false; OOM/`is not a function` → false).
- `init-error` → **warn** "not installed" (no error) vs **error** "failed to init", both latching FTS-only (worker-mock via `_setTestWorkerFactory`).
- `runStartupBackfill` emits the degraded-state log + zeroed stats when unavailable.
- Packaging invariant: transformers is under `optionalDependencies`, not `dependencies`.

Full `@loreai/core` (2442) and `@loreai/gateway` (2496) suites green; typecheck + Biome clean.

## Docs

`install.md` gains a "Slimmer installs (remote embeddings)" note documenting `--omit=optional` and the FTS-only fallback.