### PR TITLE
fix(core): drop pruned rows' vec0 chunks so orphans don't accumulate

### DIFF
--- a/packages/core/src/temporal.ts
+++ b/packages/core/src/temporal.ts
@@ -1,4 +1,5 @@
 import { db, ensureProject } from "./db";
+import { deleteEmbeddings } from "./db/vec-store";
 import { runRelaxedSearch, runRelaxedSearchAsync } from "./search";
 import { offloadAllOrTimeout, READ_JOB_TIMED_OUT } from "./read-offload";
 import { sanitizeSurrogates } from "./markdown";
@@ -730,21 +731,28 @@ export function prune(input: {
   // eligible rows before deletion to get the accurate number deleted.
   let ttlDeleted = 0;
   try {
-    const ttlEligible = (
+    // Select the ids first (instead of a bare COUNT) so we can also drop the
+    // messages' vec0 chunks: in vec0 mode the vectors live in the separate
+    // `temporal_vec` virtual table, so the base-row DELETE below leaves them
+    // dangling. `deleteEmbeddings` is a no-op in blob mode and when the list is
+    // empty. (The startup `gcVec0DanglingRows` sweep remains the catch-all
+    // backstop for orphans from other paths / a crash mid-delete.)
+    const ttlIds = (
       database
         .query(
-          "SELECT COUNT(*) as c FROM temporal_messages WHERE project_id = ? AND distilled = 1 AND created_at < ?",
+          "SELECT id FROM temporal_messages WHERE project_id = ? AND distilled = 1 AND created_at < ?",
         )
-        .get(pid, cutoff) as { c: number }
-    ).c;
-    if (ttlEligible > 0) {
+        .all(pid, cutoff) as { id: string }[]
+    ).map((r) => r.id);
+    if (ttlIds.length > 0) {
       database
         .query(
           "DELETE FROM temporal_messages WHERE project_id = ? AND distilled = 1 AND created_at < ?",
         )
         .run(pid, cutoff);
+      deleteEmbeddings(database, "temporal", ttlIds);
     }
-    ttlDeleted = ttlEligible;
+    ttlDeleted = ttlIds.length;
   } catch (e) {
     if (!isMissingObjectError(e)) throw e;
     sawMissingObject = true;
@@ -791,6 +799,8 @@ export function prune(input: {
         database
           .query(`DELETE FROM temporal_messages WHERE id IN (${placeholders})`)
           .run(...toDelete);
+        // Drop the evicted messages' vec0 chunks too (see Pass 1 rationale).
+        deleteEmbeddings(database, "temporal", toDelete);
         // toDelete.length is the accurate count — result.changes is inflated by FTS triggers.
         capDeleted = toDelete.length;
       }
@@ -808,11 +818,23 @@ export function prune(input: {
   // Archived gen-0 distillations are kept for recall search but don't need
   // to live forever — they follow the same retention policy as temporal messages.
   try {
-    database
-      .query(
-        "DELETE FROM distillations WHERE project_id = ? AND archived = 1 AND created_at < ?",
-      )
-      .run(pid, cutoff);
+    // Select ids first so the matching `distillation_vec` chunks can be dropped
+    // alongside the base rows (same vec0-orphan reasoning as Pass 1).
+    const archivedIds = (
+      database
+        .query(
+          "SELECT id FROM distillations WHERE project_id = ? AND archived = 1 AND created_at < ?",
+        )
+        .all(pid, cutoff) as { id: string }[]
+    ).map((r) => r.id);
+    if (archivedIds.length > 0) {
+      database
+        .query(
+          "DELETE FROM distillations WHERE project_id = ? AND archived = 1 AND created_at < ?",
+        )
+        .run(pid, cutoff);
+      deleteEmbeddings(database, "distillations", archivedIds);
+    }
   } catch (e) {
     if (!isMissingObjectError(e)) throw e;
     sawMissingObject = true;

--- a/packages/core/test/temporal-prune-race.test.ts
+++ b/packages/core/test/temporal-prune-race.test.ts
@@ -140,10 +140,10 @@ describe("temporal.prune resilience to a db()-swap missing-table race (#1001)", 
     seedDistilledMessage(10 * DAY);
     const arch = seedArchivedDistillation(10 * DAY);
 
-    // Pass 1's COUNT throws no-such-table; Passes 2-3 must still execute.
+    // Pass 1's id-select throws no-such-table; Passes 2-3 must still execute.
     registerSink(
       throwingSink(
-        /SELECT COUNT\(\*\) as c FROM temporal_messages/,
+        /SELECT id FROM temporal_messages/,
         new Error("no such table: temporal_messages"),
       ),
     );
@@ -205,7 +205,7 @@ describe("temporal.prune resilience to a db()-swap missing-table race (#1001)", 
     const warns: string[] = [];
     registerSink(
       recordingThrowingSink(
-        /DELETE FROM distillations/,
+        /SELECT id FROM distillations/,
         new Error("no such table: distillations"),
         warns,
       ),
@@ -228,7 +228,7 @@ describe("temporal.prune resilience to a db()-swap missing-table race (#1001)", 
     const warnsAfterRecovery: string[] = [];
     registerSink(
       recordingThrowingSink(
-        /DELETE FROM distillations/,
+        /SELECT id FROM distillations/,
         new Error("no such table: distillations"),
         warnsAfterRecovery,
       ),

--- a/packages/core/test/vec0-cutover.test.ts
+++ b/packages/core/test/vec0-cutover.test.ts
@@ -42,7 +42,7 @@ import {
 } from "../src/embedding";
 import * as log from "../src/log";
 import * as ltm from "../src/ltm";
-import { partsToText } from "../src/temporal";
+import { partsToText, prune } from "../src/temporal";
 import type { LorePart } from "../src/types";
 import {
   fromBlob,
@@ -1799,5 +1799,110 @@ describeVec("temporal re-chunk backfill (backfillTemporalEmbeddings)", () => {
     } finally {
       info.mockRestore();
     }
+  });
+});
+
+describeVec("prune drops the pruned rows' vec0 chunks (no orphans)", () => {
+  const DAY = 24 * 60 * 60 * 1000;
+
+  function insDistilledTemporal(id: string, ageDays: number, size = 100): void {
+    db()
+      .query(
+        "INSERT INTO temporal_messages (id, project_id, session_id, role, content, tokens, distilled, created_at) VALUES (?, ?, 's', 'user', ?, ?, 1, ?)",
+      )
+      .run(
+        id,
+        pid,
+        "x".repeat(size),
+        Math.ceil(size / 4),
+        Date.now() - ageDays * DAY,
+      );
+  }
+  function insArchivedDistillation(
+    id: string,
+    ageDays: number,
+    archived: 0 | 1,
+  ): void {
+    db()
+      .query(
+        "INSERT INTO distillations (id, project_id, session_id, narrative, facts, observations, source_ids, generation, token_count, created_at, archived) VALUES (?, ?, 's', '', '', 'obs', '', 0, 0, ?, ?)",
+      )
+      .run(id, pid, Date.now() - ageDays * DAY, archived);
+  }
+  const tvec = (id: string) =>
+    (
+      db()
+        .query("SELECT COUNT(*) n FROM temporal_vec WHERE message_id = ?")
+        .get(id) as { n: number }
+    ).n;
+  const dvec = (id: string) =>
+    (
+      db()
+        .query("SELECT COUNT(*) n FROM distillation_vec WHERE id = ?")
+        .get(id) as { n: number }
+    ).n;
+
+  test("TTL pass drops the pruned message's temporal_vec chunk, keeps survivors'", () => {
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    insDistilledTemporal("t_old", 130);
+    insDistilledTemporal("t_new", 10);
+    storeEmbedding(db(), "temporal", "t_old", v(1, 0, 0, 0));
+    storeEmbedding(db(), "temporal", "t_new", v(0, 1, 0, 0));
+    expect(tvec("t_old")).toBe(1);
+    expect(tvec("t_new")).toBe(1);
+
+    const res = prune({
+      projectPath: PROJECT,
+      retentionDays: 120,
+      maxStorageMB: 1024,
+    });
+    expect(res.ttlDeleted).toBe(1);
+
+    // The pruned message's chunk is gone — NOT left dangling in temporal_vec —
+    // while the survivor keeps its chunk.
+    expect(tvec("t_old")).toBe(0);
+    expect(tvec("t_new")).toBe(1);
+  });
+
+  test("size-cap pass drops the evicted messages' temporal_vec chunks", () => {
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    const size = 400 * 1024; // 3 × ~400 KB = ~1.2 MB, cap 1 MB → oldest evicted
+    insDistilledTemporal("c_old", 5, size);
+    insDistilledTemporal("c_mid", 3, size);
+    insDistilledTemporal("c_new", 1, size);
+    storeEmbedding(db(), "temporal", "c_old", v(1, 0, 0, 0));
+    storeEmbedding(db(), "temporal", "c_mid", v(0, 1, 0, 0));
+    storeEmbedding(db(), "temporal", "c_new", v(0, 0, 1, 0));
+
+    const res = prune({
+      projectPath: PROJECT,
+      retentionDays: 120,
+      maxStorageMB: 1,
+    });
+    expect(res.capDeleted).toBeGreaterThan(0);
+
+    // The oldest was evicted → its chunk must be gone too; the newest survives.
+    expect(tvec("c_old")).toBe(0);
+    expect(tvec("c_new")).toBe(1);
+  });
+
+  test("archived-distillation pass drops the pruned distillation_vec rows", () => {
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    insArchivedDistillation("d_old_arch", 130, 1); // old + archived → pruned
+    insArchivedDistillation("d_new_arch", 10, 1); // recent archived → kept
+    insArchivedDistillation("d_old_live", 130, 0); // old but not archived → kept
+    storeEmbedding(db(), "distillations", "d_old_arch", v(1, 0, 0, 0));
+    storeEmbedding(db(), "distillations", "d_new_arch", v(0, 1, 0, 0));
+    storeEmbedding(db(), "distillations", "d_old_live", v(0, 0, 1, 0));
+    expect(dvec("d_old_arch")).toBe(1);
+
+    prune({ projectPath: PROJECT, retentionDays: 120, maxStorageMB: 1024 });
+
+    expect(dvec("d_old_arch")).toBe(0); // pruned row's vec chunk dropped
+    expect(dvec("d_new_arch")).toBe(1); // recent archived kept
+    expect(dvec("d_old_live")).toBe(1); // non-archived kept
   });
 });


### PR DESCRIPTION
## Problem

In vec0 mode a message/distillation's vector lives in a **separate virtual table** (`temporal_vec` / `distillation_vec`), so `temporal.prune()` deleting a base row leaves the vector **dangling**. `gcVec0DanglingRows` only runs once per process (at startup), so on a long-running gateway — the intended steady state, where it should rarely restart — these orphans accumulate between restarts: wasted KNN candidate slots and disk.

They're harmless for correctness (recall hydration drops a hit whose base row is gone), which is why this was a latent bloat/quality issue rather than a bug.

## Fix

Clean them up at the source. Each `prune()` pass now drops the pruned ids' vec0 chunks via `deleteEmbeddings`:
- **O(deleted)**, not the O(corpus) anti-join sweep — cheap even on a 200k+ row corpus.
- **Mode-safe**: `deleteEmbeddings` is a no-op in blob mode (guarded on `readStorageMode`), so blob installs are unaffected.
- **Chunked** under SQLite's bound-variable ceiling (900/batch).

Passes 1 (TTL) and 3 (archived distillations) now `SELECT id` before deleting the base rows so the ids are available for `deleteEmbeddings`; Pass 2 (size cap) already had the id list. The startup `gcVec0DanglingRows` sweep stays as the catch-all backstop for orphans from other paths or a crash between the base-row delete and the chunk delete.

## Tests
- New vec0 prune tests (`vec0-cutover.test.ts`): assert the pruned rows' `temporal_vec` / `distillation_vec` chunks are gone while survivors' remain, across all three passes (TTL, size-cap, archived-distillation). **Mutation-verified** — reverting the three `deleteEmbeddings` calls leaves the orphans and fails all three tests.
- `#1001` race tests (`temporal-prune-race.test.ts`) retargeted to Pass 1/3's new *first* DB access (the id-select) — same assertions, faithful simulation of the missing-table swap window.
- Full `packages/core` suite: **2437 passed, 0 failed**.

## Scope note
Deliberately did **not** add completion telemetry or a chunk-policy self-heal mechanism (discussed and declined as overkill for the current user base); those are captured as code comments in a separate docs-only follow-up PR.