### PR TITLE
feat(gateway): tag cache-bust metric with idle_resume (separate avoidable warm rewrites from free cold ones)

### DIFF
--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -2426,6 +2426,14 @@ export function creditWarmupHit(
   // and warping the ROI analysis.
   if (cacheReadTokens <= 0) return noHit;
 
+  // `warmupHits` is a RETURN-FREQUENCY counter (binary +1), NOT a savings
+  // figure — it feeds the session ROI gate `warmupHits/totalWarmups >=
+  // MIN_SESSION_HIT_RATE`, which asks "did the user come back and read the
+  // warmed cache at all." Binary is correct there: a return is a return. Do NOT
+  // confuse this with the SAVINGS, which ARE pro-rata below (Bug B). An earlier
+  // note claimed a partial read "credits the full refreshTokens" — that was the
+  // pre-#1105 behavior and is no longer true: `creditedTokens` is the capped
+  // min() and is the only value booked as savings (pipeline recordWarmupHit).
   warmup.warmupHits++;
   // Pro-rata (Bug B): realized savings = what this turn actually read from the
   // warmed prefix, capped at what the warmup refreshed. See the docstring.

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -4667,6 +4667,10 @@ export function recordCacheTurnUsage(
       usage.cacheCreationInputTokens ?? 0,
       model,
       turnAnalysis.relocatable,
+      // Distinguish a free cold-boundary prefix-rewrite (rode along with an
+      // idle-resume write that was happening anyway) from an avoidable warm one
+      // (meta-distillation leaking onto a live cache) — see emitCacheBustMetric.
+      turnWasIdleResume,
     );
     // Persist a durable counter so the issue #791 "is system[0] dynamic
     // content a material cache-bust cause?" gate survives gateway restarts

--- a/packages/gateway/src/sentry.ts
+++ b/packages/gateway/src/sentry.ts
@@ -212,6 +212,19 @@ export function setCacheAnalyticsAttributes(
  * Emits a counter per cause category and a distribution of cache-write
  * token counts, both tagged by cause and model. Enables identifying which
  * bust causes dominate and tracking improvements over time.
+ *
+ * The `idle_resume` tag separates AVOIDABLE busts from FREE ones — critical for
+ * the `prefix-rewrite` cause in particular. `categorizeBust` labels ANY
+ * messages[0/1] divergence with cache creation as `prefix-rewrite` BEFORE it
+ * checks post-idle (cache-analytics.ts), so `cause=prefix-rewrite` alone
+ * conflates two very different events: a rewrite against a still-warm cache
+ * (a real, avoidable loss — meta-distillation should never run warm) versus a
+ * rewrite that merely rode along with an already-cold idle-resume boundary
+ * (free — that write was happening regardless). Tagging idle_resume lets a
+ * query isolate the leak: `lore.cache_bust_tokens{cause=prefix-rewrite,
+ * idle_resume=false}` is the avoidable spend and should stay ~0; a sustained
+ * non-zero value means meta-distillation is leaking onto warm caches. Multiply
+ * the token distribution by the model's cache_write price for the $ figure.
  */
 export function emitCacheBustMetric(
   cause: string,
@@ -219,16 +232,20 @@ export function emitCacheBustMetric(
   model: string,
   /** issue #791: whether a system[0] divergence looked relocatable. */
   relocatable = false,
+  /** True when this bust was a post-idle cold-cache re-warm (the write was
+   *  unavoidable). Distinguishes free cold-boundary rewrites from avoidable
+   *  warm ones — see the idle_resume note above. */
+  isIdleResume = false,
 ): void {
   if (!Sentry.isInitialized()) return;
 
   Sentry.metrics.count("lore.cache_bust", 1, {
-    attributes: { cause, model, relocatable },
+    attributes: { cause, model, relocatable, idle_resume: isIdleResume },
   });
 
   if (writeTokens > 0) {
     Sentry.metrics.distribution("lore.cache_bust_tokens", writeTokens, {
-      attributes: { cause, model, relocatable },
+      attributes: { cause, model, relocatable, idle_resume: isIdleResume },
       unit: "token",
     });
   }

--- a/packages/gateway/test/cache-bust-metric.test.ts
+++ b/packages/gateway/test/cache-bust-metric.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock @sentry/bun BEFORE importing the module under test (mirrors
+// readpath-capture.test.ts). A full factory replaces the shared instance for
+// both this test and src/sentry.ts, so we can drive isInitialized() and assert
+// the exact metric attributes emitted.
+vi.mock("@sentry/bun", () => ({
+  isInitialized: vi.fn(() => false),
+  metrics: {
+    distribution: vi.fn(),
+    count: vi.fn(),
+  },
+}));
+
+import * as Sentry from "@sentry/bun";
+import { emitCacheBustMetric } from "../src/sentry";
+
+type Attrs = Record<string, unknown>;
+
+function distAttrs(name: string): Attrs | undefined {
+  const call = vi
+    .mocked(Sentry.metrics.distribution)
+    .mock.calls.find((c) => c[0] === name);
+  return (call?.[2] as { attributes?: Attrs })?.attributes;
+}
+
+function countAttrs(name: string): Attrs | undefined {
+  const call = vi
+    .mocked(Sentry.metrics.count)
+    .mock.calls.find((c) => c[0] === name);
+  return (call?.[2] as { attributes?: Attrs })?.attributes;
+}
+
+describe("emitCacheBustMetric idle_resume dimension", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(Sentry.isInitialized).mockReturnValue(true);
+  });
+
+  it("tags a WARM prefix-rewrite (idle_resume=false) — the avoidable leak signal", () => {
+    emitCacheBustMetric(
+      "prefix-rewrite",
+      192878,
+      "claude-opus-4-8",
+      false,
+      false,
+    );
+
+    expect(distAttrs("lore.cache_bust_tokens")).toMatchObject({
+      cause: "prefix-rewrite",
+      idle_resume: false,
+    });
+    expect(countAttrs("lore.cache_bust")).toMatchObject({
+      cause: "prefix-rewrite",
+      idle_resume: false,
+    });
+  });
+
+  it("tags a COLD idle-resume prefix-rewrite (idle_resume=true) — free, distinct from the leak", () => {
+    emitCacheBustMetric(
+      "prefix-rewrite",
+      192878,
+      "claude-opus-4-8",
+      false,
+      true,
+    );
+
+    expect(distAttrs("lore.cache_bust_tokens")?.idle_resume).toBe(true);
+    expect(countAttrs("lore.cache_bust")?.idle_resume).toBe(true);
+  });
+
+  it("defaults idle_resume to false when the arg is omitted (back-compat)", () => {
+    emitCacheBustMetric("window-shift", 1000, "claude-opus-4-8");
+
+    expect(distAttrs("lore.cache_bust_tokens")?.idle_resume).toBe(false);
+    expect(countAttrs("lore.cache_bust")?.idle_resume).toBe(false);
+  });
+
+  it("emits nothing when Sentry is not initialized", () => {
+    vi.mocked(Sentry.isInitialized).mockReturnValue(false);
+    emitCacheBustMetric("prefix-rewrite", 500, "m", false, false);
+
+    expect(Sentry.metrics.distribution).not.toHaveBeenCalled();
+    expect(Sentry.metrics.count).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Why

Follow-up to the cache-warming / prefix-stability deep dive. Two small, **telemetry-only** changes (no behavior change).

### 1. `idle_resume` dimension on the cache-bust metric (the real change)

`categorizeBust` labels **any** `messages[0/1]` divergence with cache creation as `prefix-rewrite` **before** it checks post-idle (`cache-analytics.ts:756-758`). So the existing `lore.cache_bust_tokens{cause=prefix-rewrite}` metric conflates two very different events:

| | |
|---|---|
| rewrite vs a still-**WARM** cache | a real, **avoidable** loss — meta-distillation should never run warm |
| rewrite riding along with an already-**COLD** idle-resume boundary | **free** — that write was happening regardless |

**Production evidence (Jul 2026, current build):** every deep-turn ~185–193K "prefix rewrite" I traced was a cold idle-resume boundary (e.g. `0m89` turn 104: 9.5-min gap → `cool-bust` → `post-idle compact` → `idle-resume re-warm — not counted`). **Zero** were avoidable warm losses. But nothing surfaced the *aggregate* cost of these bust-exempt writes, and the metric couldn't tell warm from cold.

This adds an `idle_resume` attribute to both `lore.cache_bust` (counter) and `lore.cache_bust_tokens` (distribution), threaded from `turnWasIdleResume` at the `postResponse` call site. Now:

- `lore.cache_bust_tokens{cause=prefix-rewrite, idle_resume=false}` = **avoidable warm-rewrite spend** — should stay ~0; a sustained non-zero value means meta-distillation is leaking onto warm caches (a regression alarm).
- `{idle_resume=true}` = free cold-boundary rewrite.
- Multiply the token distribution by the model's `cache_write` price for the $ figure (kept token-native to avoid async pricing on the hot path).

### 2. Disambiguating comment at `creditWarmupHit`

The hit **count** (`warmupHits++`) is an intentional **binary return-frequency** signal for the ROI gate (`warmupHits/totalWarmups >= MIN_SESSION_HIT_RATE`), **not** a savings figure — savings are already pro-rata (`min(read, refresh)`, #1105). Adds a comment killing a stale "credits full refreshTokens" note that described pre-#1105 behavior, so it isn't re-derived.

## Tests
- `cache-bust-metric.test.ts` asserts warm (`idle_resume=false`) vs cold (`true`) tagging, back-compat default, and the not-initialized no-op. **Mutation-verified** (dropping the tag fails 3 tests).
- 311 tests green across cache-bust-metric / cache-analytics / readpath-capture / cache-warmer; typecheck + lint clean across all 4 packages.

No schema, no UI, no persistence, no behavior change.