### PR TITLE
docs(website): publish Lore memory-management principles post (#1125)

### DIFF
--- a/packages/website/src/content/blog/how-lore-remembers-and-forgets.md
+++ b/packages/website/src/content/blog/how-lore-remembers-and-forgets.md
@@ -1,0 +1,112 @@
+---
+title: "How Lore remembers, forgets, and changes its mind"
+subtitle: "The principles behind memory that manages itself"
+description: Most memory tools now ship a set of principles for how an agent should manage its context. Lore's principles work differently, because the layer enforces them instead of asking the agent to. Here are the rules Lore runs on.
+pubDate: 2026-07-02
+author: Lore Team
+tags:
+  - memory
+  - principles
+  - agents
+---
+
+The field is converging on an idea: agents should manage their own context. Give the
+model tools to edit its own instructions, let it decide what to keep and what to drop, teach
+it to notice when its own memory is going stale. It is a genuinely interesting bet, and the
+teams chasing it are doing real work. Writing those principles down, out in the open, is a
+good instinct too.
+
+Lore takes a different road to the same destination. You never have to manage memory, and
+neither does the agent. A fixed set of rules, enforced by the layer that sits in the request
+path, makes the call on every turn instead. That distinction matters more than it sounds. A
+set of principles written *for* an agent is guidance, and it holds only when the agent is
+paying attention. The same principles built *into* the layer are guarantees. They hold
+whether or not anyone is paying attention that turn.
+
+So here are the rules Lore runs on. Not aspirations we hope a cooperative model follows: the
+actual behavior of the layer that touches every token.
+
+## You never have to remember to remember
+
+Capture is automatic. Lore sits between your agent and the model, and it distills your work
+as it happens. You do not tag a message, save a decision, or file anything away for later.
+
+This is the whole reason capture lives in the layer. Memory you have to reach for is memory
+you will forget to reach for, right at the moment you are heads-down on the actual problem.
+The filing was never the hard part, and it should never be your job. If a rule for managing
+memory depends on you (or the agent) remembering to invoke it, it is already broken.
+
+## Being surfaced is not being right
+
+When Lore pulls a memory into your context, that is a bet about what might be relevant this
+turn. It is not a vote on whether the memory is true. Selecting an entry never raises its
+confidence.
+
+That separation keeps the store honest. A note that keeps getting surfaced but never actually
+helps does not get more entrenched just for being loud. Confidence is earned somewhere else,
+by whether the knowledge holds up in practice, and the act of showing it to the model is kept
+strictly out of that accounting.
+
+## Confidence is earned, and it decays
+
+Every entry carries a confidence score. It rises when the knowledge proves useful across
+sessions and drifts down when it sits untouched. Fall below the floor and the entry is
+evicted. The store stays bounded by usefulness rather than by a fixed timer that forgets
+things on a schedule, whether or not you still need them.
+
+There is one deliberate exception. The preferences you state outright, the ones that follow
+you across every project, are protected from that decay. Those are not guesses Lore made
+about you, so they are not subject to the same erosion as things Lore inferred.
+
+## When two things disagree, you get told, not overruled
+
+Opposing rules are never quietly merged. "Always use tabs" and "always use spaces" are not
+two versions of one fact, and collapsing them would be Lore deciding for you. Both are kept,
+ranked by confidence, and a genuine contradiction is meant to be surfaced for you to settle,
+not resolved behind your back.
+
+The layer's job here is narrow on purpose: notice the conflict, and hand it to you. Picking a
+winner silently is exactly the kind of decision a memory system should not be making on its
+own.
+
+## Nothing is really deleted
+
+Knowledge is append-only. An edit writes a new version and keeps the old one; a delete leaves
+a marker rather than erasing the trail. Because the history is intact, you can diff what your
+agent has learned and roll it back, the same way you already do with code.
+
+That is not an abstract property. Curated knowledge lands in a plain
+[`.lore.md`](/different/) file in your repo, so a change to your agent's memory shows up in a
+pull request and gets reviewed by the same people and the same process that review your code.
+Memory that changes without a diff is memory nobody can audit.
+
+## The live edge stays whole
+
+The most recent turns are always protected. Whatever gets distilled or dropped as older
+context is compressed, the active end of the conversation, where the work is actually
+happening right now, is never touched. Everything else is negotiable under pressure; the edge
+you are working on is not.
+
+## What's learned lives in tokens, not weights
+
+Lore learns by writing durable text, not by fine-tuning the model. That is a deliberate
+choice. Text is something you can read, carry across providers and across model generations,
+and undo a line at a time. Knowledge baked into weights is none of those things: you cannot
+inspect it, it does not move to the next model, and you lose it on the upgrade. The model is
+the part you replace. The knowledge is the part you keep.
+
+## Boring on purpose
+
+None of this says self-managing agents are the wrong idea. An agent that edits its own memory
+is an exciting direction, and we are glad people are pushing on it.
+
+Lore's bet is narrower, and honestly a little boring in the way infrastructure should be: the
+rules that decide what stays, what fades, and what gets surfaced ought to hold on every single
+turn, not only when the agent happens to be attending to them. A principle the layer enforces
+is one you never have to hope about.
+
+And because a layer that sees every token is a lot to ask you to trust, the rules above are
+not a description you take on faith. Lore is [Fair Source](https://fair.io)
+(FSL-1.1-Apache-2.0), so the code that decides what your agent remembers and forgets is right
+there for you to read, and it turns into Apache 2.0 on a timer. Principles you can enforce are
+better than principles you have to believe.

--- a/packages/website/src/content/blog/how-lore-remembers-and-forgets.md
+++ b/packages/website/src/content/blog/how-lore-remembers-and-forgets.md
@@ -84,12 +84,12 @@ Opposing rules are never quietly merged. "Always use tabs" and "always use space
 two versions of one fact, and collapsing them would be Lore deciding for you. Both are kept
 and ranked by confidence.
 
-A genuine contradiction still needs settling, so Lore looks for these in the background and
-flags the pair for you: on the knowledge dashboard, or from `lore data contradictions`. You
-pick the rule that still holds, or you keep both. Lore never merges them and never deletes the
-losing side on its own. The layer's job here is narrow on purpose: notice the conflict and hand
-it to you. Picking a winner silently is exactly the kind of decision a memory system should not
-be making.
+Genuine contradictions still need settling, so Lore looks for them in the background and flags
+each pair for you: on the knowledge dashboard, or from `lore data contradictions`. You pick the
+rule that still holds, or you keep both. Lore never merges them and never deletes the losing
+side on its own. The layer's job here is narrow on purpose: notice the conflict and hand it to
+you. Picking a winner silently is exactly the kind of decision a memory system should not be
+making.
 
 ## Nothing is really deleted
 

--- a/packages/website/src/content/blog/how-lore-remembers-and-forgets.md
+++ b/packages/website/src/content/blog/how-lore-remembers-and-forgets.md
@@ -10,11 +10,19 @@ tags:
   - agents
 ---
 
-The field is converging on an idea: agents should manage their own context. Give the
-model tools to edit its own instructions, let it decide what to keep and what to drop, teach
-it to notice when its own memory is going stale. It is a genuinely interesting bet, and the
-teams chasing it are doing real work. Writing those principles down, out in the open, is a
-good instinct too.
+Everywhere you look, agents are being taught to fix themselves. Self-healing loops,
+self-improving memory, a model that reads back its own transcript, rewrites its own
+instructions, and prunes whatever it decides has gone stale. There is real energy here, and
+some of it genuinely works.
+
+Here is the catch, and it is an old one. Self-correction is the hardest kind. Whatever made a
+mistake is usually the worst-placed thing to catch it, because from the inside the mistake
+still looks like a reasonable call. People hit this constantly, which is why we lean on
+outside help: an editor for the draft you have read too many times, a reviewer for the code
+you are sure is fine, a colleague who remembers you already tried that back in March. The
+whole value is that they are not you. A model sits in the same spot. Once it has written a
+shaky assumption into its own memory, it is not the thing you can count on to go back and
+find the error.
 
 Lore takes a different road to the same destination. You never have to manage memory, and
 neither does the agent. A fixed set of rules, enforced by the layer that sits in the request
@@ -22,6 +30,12 @@ path, makes the call on every turn instead. That distinction matters more than i
 set of principles written *for* an agent is guidance, and it holds only when the agent is
 paying attention. The same principles built *into* the layer are guarantees. They hold
 whether or not anyone is paying attention that turn.
+
+And because that layer sits outside the model, a model swap does not take your memory with
+it. A newer model arrives brilliant and completely unfamiliar with your work, the way a new
+hire does; the layer is the institutional memory already in the room, so the model is useful
+on the first turn instead of the fiftieth. Change the engine as often as you like. The
+assistant, and everything it has learned, stays.
 
 So here are the rules Lore runs on. Not aspirations we hope a cooperative model follows: the
 actual behavior of the layer that touches every token.
@@ -35,6 +49,12 @@ This is the whole reason capture lives in the layer. Memory you have to reach fo
 you will forget to reach for, right at the moment you are heads-down on the actual problem.
 The filing was never the hard part, and it should never be your job. If a rule for managing
 memory depends on you (or the agent) remembering to invoke it, it is already broken.
+
+Getting it back works the same way. When memory only returns because the agent thought to
+call a search tool, the knowledge can be sitting right there and never reach the model,
+because nobody went looking. Lore surfaces what is relevant on its own, and keeps a recall
+tool for when the agent wants to dig deeper, so recall does not hang on the agent's
+discipline on any given turn either.
 
 ## Being surfaced is not being right
 
@@ -97,8 +117,9 @@ the part you replace. The knowledge is the part you keep.
 
 ## Boring on purpose
 
-None of this says self-managing agents are the wrong idea. An agent that edits its own memory
-is an exciting direction, and we are glad people are pushing on it.
+Making a model better at checking itself is worth doing, and we hope it keeps improving. But
+the corrections you can lean on are the ones that do not wait for the model to notice, this
+turn, that it was wrong. Those come from outside it.
 
 Lore's bet is narrower, and honestly a little boring in the way infrastructure should be: the
 rules that decide what stays, what fades, and what gets surfaced ought to hold on every single

--- a/packages/website/src/content/blog/how-lore-remembers-and-forgets.md
+++ b/packages/website/src/content/blog/how-lore-remembers-and-forgets.md
@@ -81,13 +81,15 @@ about you, so they are not subject to the same erosion as things Lore inferred.
 ## When two things disagree, you get told, not overruled
 
 Opposing rules are never quietly merged. "Always use tabs" and "always use spaces" are not
-two versions of one fact, and collapsing them would be Lore deciding for you. Both are kept,
-ranked by confidence, and a genuine contradiction is meant to be surfaced for you to settle,
-not resolved behind your back.
+two versions of one fact, and collapsing them would be Lore deciding for you. Both are kept
+and ranked by confidence.
 
-The layer's job here is narrow on purpose: notice the conflict, and hand it to you. Picking a
-winner silently is exactly the kind of decision a memory system should not be making on its
-own.
+A genuine contradiction still needs settling, so Lore looks for these in the background and
+flags the pair for you: on the knowledge dashboard, or from `lore data contradictions`. You
+pick the rule that still holds, or you keep both. Lore never merges them and never deletes the
+losing side on its own. The layer's job here is narrow on purpose: notice the conflict and hand
+it to you. Picking a winner silently is exactly the kind of decision a memory system should not
+be making.
 
 ## Nothing is really deleted
 


### PR DESCRIPTION
## Summary

Publishes Lore's memory-management principles as a public blog post — the product-grounded answer to #1125 (and, implicitly, to the industry's "agents should manage their own memory" framing). The thesis: Lore's principles are **enforced by the layer**, not instructions a cooperating agent has to follow. A principle the infrastructure enforces is one you never have to hope about.

## The post

`content/blog/how-lore-remembers-and-forgets.md` — seven principles, each grounded in real behavior:

1. Automatic capture (you never have to remember to remember)
2. Injection ≠ certainty (surfacing a memory is a relevance bet, not a truth vote)
3. Confidence is earned and decays; explicit cross-project preferences are protected
4. Contradictions are surfaced, never silently merged (ties to #1123)
5. Append-only history, reviewable via `.lore.md` in a pull request (ties to #962)
6. The live edge is never compressed
7. Learning lives in tokens, not weights (consistent with #1124)

Close is deliberately generous: self-managing agents aren't the wrong idea; Lore's bet is just that the rules should hold every turn regardless. Fair Source ([fair.io](https://fair.io), FSL-1.1-Apache-2.0) is the trust close — principles you can read beat principles you take on faith.

## Voice / guardrails

- Blog voice: "we/you", **zero em-dashes** (verified), no emoji, no "not X, but Y" counterargument-first tic.
- Category-not-competitor: the agent-managed approach is acknowledged generously, never named or dunked on.
- Grand-vision register ("machines that learn") kept out per the issue's non-goals.

## Verification

- `astro build` passes (21 pages; new post renders at `/blog/how-lore-remembers-and-forgets/`).
- Internal `/different/` link validated against the build output.

Closes #1125

---

**Update (rework):** replaced the opening's faint-praise framing with a direct one — self-correction is the hard part for models and people alike, which is why external help exists; Lore is that outside layer, and it survives a model swap (a new model is a brilliant new hire; the layer is the institutional memory already in the room). The guidance-vs-guarantees paragraph is preserved verbatim.

This post also delivers the long-standing #662 thesis ("your agent shouldn't have to remember to remember"): the "You never have to remember to remember" principle now covers both automatic capture **and** automatic recall (manual save/search tools are fragile). Closing #662 as covered.

Closes #662
