### PR TITLE
docs(core): clarify blob-fallback recency caps; note chunk-policy re-arm for future migrations

### DIFF
--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -1941,6 +1941,20 @@ export async function vectorSearchTemporal(
  * Build a config fingerprint from provider + model + dimensions.
  * Used to detect when the embedding config changes (provider swap, model swap,
  * dimension change) so we can clear stale embeddings and re-embed.
+ *
+ * 🟡 Scope note for FUTURE chunk/text-policy migrations: this fingerprint keys
+ * ONLY on provider/model/dimensions — it deliberately does NOT include the
+ * embedding TEXT policy (how a message is split into units / which parts are
+ * embedded; see buildEmbeddingUnits). So changing that policy does NOT bump the
+ * fingerprint, and the stale-embedding clear + backfill triggered here will NOT
+ * fire for a pure policy change. Today the temporal re-chunk backfill re-embeds
+ * the whole corpus under a new policy only because it is armed by an explicit KV
+ * done-flag (see TEMPORAL_RECHUNK_DONE_KEY / resetTemporalRechunkProgress) that
+ * is reset on vec0 cutover — NOT by this fingerprint. If a future migration
+ * changes the chunk/text policy again WITHOUT a storage cutover, re-arm the walk
+ * deliberately — fold a policy-version token into the done-flag key, or call
+ * resetTemporalRechunkProgress() from the migration — because this fingerprint
+ * will stay silent.
  */
 function configFingerprint(): string {
   const cfg = config().search.embeddings;

--- a/packages/core/src/vector-query.ts
+++ b/packages/core/src/vector-query.ts
@@ -540,9 +540,11 @@ function runTemporal(
   if (readMode === "blob-native") {
     try {
       // Score only the most-recent MAX_TEMPORAL_VECTOR_ROWS rows (the same
-      // candidate window the JS path uses below). STOPGAP — see
-      // MAX_TEMPORAL_VECTOR_ROWS: drop the inner ORDER BY/LIMIT once an ANN
-      // index replaces brute-force scanning (#999).
+      // candidate window the JS path uses below). This recency cap is the
+      // BLOB-FALLBACK bound: the ANN replacement it once stood in for (#999,
+      // resolved) already shipped as the uncapped, whole-corpus FLAT-vec0 KNN
+      // path above — this branch runs only when sqlite-vec is unavailable and the
+      // DB stays in blob layout. See MAX_TEMPORAL_VECTOR_ROWS.
       const vsql = sessionId
         ? "SELECT id, 1 - vec_distance_cosine(embedding, ?) AS similarity FROM (SELECT id, embedding FROM temporal_messages WHERE embedding IS NOT NULL AND project_id = ? AND session_id = ? ORDER BY created_at DESC LIMIT ?) ORDER BY similarity DESC LIMIT ?"
         : "SELECT id, 1 - vec_distance_cosine(embedding, ?) AS similarity FROM (SELECT id, embedding FROM temporal_messages WHERE embedding IS NOT NULL AND project_id = ? ORDER BY created_at DESC LIMIT ?) ORDER BY similarity DESC LIMIT ?";
@@ -560,7 +562,8 @@ function runTemporal(
       // fall through to JS brute-force
     }
   }
-  // STOPGAP recency cap — see MAX_TEMPORAL_VECTOR_ROWS (#999).
+  // Blob-fallback recency cap (JS brute-force). The primary path is the uncapped
+  // whole-corpus vec0 KNN above (#999, resolved); see MAX_TEMPORAL_VECTOR_ROWS.
   const sql = sessionId
     ? "SELECT id, embedding FROM temporal_messages WHERE embedding IS NOT NULL AND project_id = ? AND session_id = ? ORDER BY created_at DESC LIMIT ?"
     : "SELECT id, embedding FROM temporal_messages WHERE embedding IS NOT NULL AND project_id = ? ORDER BY created_at DESC LIMIT ?";


### PR DESCRIPTION
Comment-only follow-up to the temporal-embedding workstream — **no behavior change** (diff is entirely comments; typecheck + lint clean).

Captures two things surfaced while reviewing the workstream for latent gaps.

### 1. `vector-query.ts` — recency-cap comments were stale
The `MAX_TEMPORAL_VECTOR_ROWS` / `MAX_DISTILLATION_VECTOR_ROWS` inline comments described themselves as a "STOPGAP … until an ANN index replaces brute-force scanning (#999)". That ANN replacement **already shipped**: the uncapped, whole-corpus FLAT-vec0 KNN path is the primary, and these capped `ORDER BY created_at DESC LIMIT` scans are the **blob-fallback** that runs only when sqlite-vec is unavailable. Reworded to say so; #999 is resolved, not pending. (The main `MAX_TEMPORAL_VECTOR_ROWS` doc block was already accurate — only the two inline comments drifted.)

### 2. `embedding.ts configFingerprint()` — chunk/text-policy self-heal note
Documented that the fingerprint keys **only** on provider/model/dimensions and deliberately excludes the embedding **text policy** (`buildEmbeddingUnits`), so a pure chunk/text-policy change does **not** auto-trigger the stale-clear + re-embed here. The temporal re-chunk walk is armed by the KV done-flag (reset on vec0 cutover), **not** this fingerprint — so a **future** policy migration *without* a storage cutover must re-arm the walk deliberately (fold a policy-version token into the done-flag key, or call `resetTemporalRechunkProgress()`).

This is the "cheap insurance" idea from the workstream review, captured as a comment rather than built (per direction — a policy change is unlikely to recur, so a durable note beats speculative machinery).

### Note
Deliberately did **not** cite issue #1072 here — verified #1072 was the per-message chunk fan-out OOM cap (closed by #1075), a different concern.