### PR TITLE
fix(core): bound embedding cap by the fixed WASM heap ceiling (#999)

### DIFF
--- a/packages/core/eval/measure-embed-ceiling.mjs
+++ b/packages/core/eval/measure-embed-ceiling.mjs
@@ -1,0 +1,140 @@
+// Measure the local-embedding OOM *ceiling* on the REAL bundled WASM worker
+// (the runtime users actually run, #999) by binary-searching the largest token
+// cap that completes vs the smallest that OOMs. Complements measure-embed-cap.mjs
+// (which fits the baseline + K·L² footprint model up to a safe length).
+//
+// WHY a separate ceiling matters: the bundled `ort-wasm-simd-threaded` build
+// declares `Memory({ initial: 256, maximum: 65536, shared: true })` → 65536
+// pages × 64 KiB = 4 GiB MAXIMUM_MEMORY. That cap is FIXED regardless of host
+// RAM, so a token cap sized purely from `os.freemem()` can exceed it on a
+// memory-rich box and OOM the WASM heap on every cold start. embedding-cap.ts
+// bounds the freemem-derived cap by WASM_SUSTAINABLE_MAX_TOKENS (derived from
+// this 4 GiB cap); this script is how you re-measure/verify that boundary.
+//
+// Each candidate gets a FRESH worker: WASM linear memory never shrinks, and an
+// OOM exits the worker with EMBED_OOM_EXIT_CODE (75). A candidate is:
+//   OK      → worker returned a result vector
+//   OOM     → worker exited 75 (exceeded the WASM heap)
+//   SLOW    → >90s with no result (host-memory thrashing, NOT a WASM OOM; only
+//             happens when free RAM is marginal — treated as inconclusive)
+//
+// Prereqs (same as measure-embed-cap.mjs):
+//   1. pnpm --filter @loreai/gateway run bundle
+//   2. LORE_MODEL_CACHE=<transformers cache root with nomic-ai/…> \
+//        node packages/core/eval/measure-embed-ceiling.mjs
+//   LORE_DIST_DIR overrides the gateway dist dir (defaults to packages/gateway/dist).
+//   LO/HI override the initial binary-search bounds (defaults 2048 / 8192).
+
+import { existsSync } from "node:fs";
+import { freemem, totalmem } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Worker } from "node:worker_threads";
+
+const EMBED_OOM_EXIT_CODE = 75;
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "../../..");
+const distDir =
+  process.env.LORE_DIST_DIR ?? path.join(repoRoot, "packages/gateway/dist");
+const modelCache = process.env.LORE_MODEL_CACHE;
+const wrapper = path.join(here, "measure-embed-cap-wrapper.cjs");
+
+for (const [label, p] of [
+  ["worker", path.join(distDir, "embedding-worker.cjs")],
+  ["wasm", path.join(distDir, "ort-wasm-simd-threaded.wasm")],
+  ["wrapper", wrapper],
+  [
+    "model",
+    path.join(modelCache ?? "", "nomic-ai/nomic-embed-text-v1.5/config.json"),
+  ],
+]) {
+  if (!existsSync(p)) {
+    console.error(
+      `missing ${label}: ${p}\n(build the bundle and set LORE_MODEL_CACHE — see header)`,
+    );
+    process.exit(1);
+  }
+}
+
+// Long enough that the worker's tokenizer truncates down to any target L.
+const longText = "lorem ipsum dolor sit amet consectetur ".repeat(2000);
+
+/** Run one candidate cap on a fresh worker. Resolves "OK" | "OOM" | "SLOW". */
+function testCap(N) {
+  return new Promise((resolve) => {
+    const w = new Worker(wrapper, {
+      workerData: {
+        _distDir: distDir,
+        modelId: "nomic-ai/nomic-embed-text-v1.5",
+        dimensions: 768,
+        vendorModel: { localModelPath: modelCache },
+        maxTokens: 8192,
+      },
+    });
+    let settled = false;
+    const finish = (v) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      w.terminate().catch(() => {});
+      resolve(v);
+    };
+    const timer = setTimeout(() => finish("SLOW"), 90_000);
+    w.on("message", (m) => {
+      if (m.type === "result") finish("OK");
+      else if (m.type === "error" || m.type === "init-error")
+        finish(`ERR:${String(m.error).slice(0, 48)}`);
+    });
+    w.on("exit", (code) => finish(code === EMBED_OOM_EXIT_CODE ? "OOM" : "OK"));
+    w.on("error", (e) => finish(`THREW:${String(e).slice(0, 48)}`));
+    w.postMessage({
+      type: "embed",
+      id: 1,
+      texts: [longText],
+      inputType: "document",
+      priority: "normal",
+      maxTokens: N,
+    });
+  });
+}
+
+console.log(
+  `free=${(freemem() / 2 ** 30).toFixed(1)}GiB total=${(totalmem() / 2 ** 30).toFixed(1)}GiB` +
+    ` — NOTE: SLOW results mean host-memory thrashing; run on a box with ≥6 GiB free for a clean WASM-OOM boundary.\n`,
+);
+
+let lo = Number(process.env.LO || 2048); // expected OK
+let hi = Number(process.env.HI || 8192); // expected OOM
+const rLo = await testCap(lo);
+const rHi = await testCap(hi);
+console.log(`probe lo=${lo} → ${rLo}`);
+console.log(`probe hi=${hi} → ${rHi}`);
+if (rLo !== "OK") {
+  console.log(`lo=${lo} not OK (${rLo}); lower LO or free up RAM.`);
+  process.exit(0);
+}
+if (rHi === "OK") {
+  console.log(`hi=${hi} is OK — ceiling ≥ model max on this host.`);
+  process.exit(0);
+}
+
+// Binary-search the OK/OOM boundary. SLOW is inconclusive (host pressure) — we
+// nudge the window down and keep the last confirmed OK as the reported floor.
+let bestOk = lo;
+let firstOom = hi;
+while (firstOom - bestOk > 128) {
+  const mid = (bestOk + firstOom) >> 1;
+  const r = await testCap(mid);
+  console.log(`  test ${mid} → ${r}`);
+  if (r === "OK") bestOk = mid;
+  else if (r === "OOM") firstOom = mid;
+  else firstOom = mid; // SLOW: treat as an upper bound; don't claim it OOMed
+}
+console.log(
+  `\n=== confirmed OK ≤ ${bestOk} tokens; OOM/inconclusive from ${firstOom} ===`,
+);
+console.log(
+  "The clean WASM-OOM boundary derives from the 4 GiB MAXIMUM_MEMORY and the\n" +
+    "measured baseline/K (footprint(L) ≈ 680 MB + 120·L²): 4 GiB ⇒ L ≈ 5460.",
+);
+process.exit(0);

--- a/packages/core/src/embedding-cap.ts
+++ b/packages/core/src/embedding-cap.ts
@@ -66,6 +66,10 @@ export const EMBED_CAP_TRUST_BAND = 0.25;
 export interface PersistedEmbedCap {
   cap: number;
   freeMemBytes: number;
+  /** Highest cap (tokens) known to have OOMed, persisted across restarts so a
+   *  memory-rich reboot never re-probes back up to a cap the WASM heap has
+   *  already rejected. Absent/0 = none learned yet. */
+  knownBadCap?: number;
 }
 
 /** Reference sequence length used to size the per-worker memory budget for pool
@@ -131,18 +135,54 @@ export function clampEmbedCap(n: number): number {
   return Math.max(MIN_EMBED_TOKENS, Math.min(MODEL_MAX_TOKENS, Math.round(n)));
 }
 
+/** ONNX WASM runtime linear-memory hard cap. The bundled
+ *  `ort-wasm-simd-threaded` build declares `Memory({ initial: 256,
+ *  maximum: 65536, shared: true })` → 65536 pages × 64 KiB = 4 GiB (measured on
+ *  the built worker, #999). Unlike host RAM this is FIXED regardless of how much
+ *  free memory the box has — so a cap sized purely from `os.freemem()` can exceed
+ *  it on a memory-rich host and OOM the WASM heap. */
+export const EMBED_WASM_HEAP_MAX_BYTES = 4 * 1024 * 1024 * 1024;
+
+/** Fraction of the WASM hard cap usable for the transient O(L²) attention
+ *  allocation (after the model/runtime baseline) before OOM. Headroom (0.85)
+ *  absorbs WASM heap fragmentation and ORT's non-attention intermediates — the
+ *  real OOM fires a bit below the theoretical 4 GiB. Combined with the measured
+ *  baseline/K this yields ~4950 tokens, matching the observed safe convergence
+ *  (≤4962) on a 4 GiB-WASM host (#999). */
+export const EMBED_WASM_HEAP_USABLE_FRACTION = 0.85;
+
+/** Hard token ceiling implied by the fixed WASM heap cap (host-RAM-independent):
+ *  `sqrt((MAX·fraction − baseline) / K)`. Every freemem-derived cap is bounded by
+ *  this, so a memory-rich host never *starts* above what the WASM heap can hold
+ *  (the OOM-backoff only corrects *downward*, so an over-sized start OOMs 1–2×
+ *  every boot until it re-converges — exactly the failure this prevents). */
+export const WASM_SUSTAINABLE_MAX_TOKENS = clampEmbedCap(
+  Math.sqrt(
+    (EMBED_WASM_HEAP_MAX_BYTES * EMBED_WASM_HEAP_USABLE_FRACTION -
+      EMBED_MODEL_BASELINE_BYTES) /
+      EMBED_ATTENTION_BYTES_PER_TOKEN_SQ,
+  ),
+);
+
 /** Lower the cap one backoff step, never below the floor. */
 export function backoffEmbedCap(cap: number): number {
   return Math.max(Math.round(cap * EMBED_BACKOFF_FACTOR), MIN_EMBED_TOKENS);
 }
 
-/** Size the token cap from free memory and the O(L²) attention model. */
+/** Size the token cap from free memory and the O(L²) attention model, bounded by
+ *  the fixed WASM heap ceiling ({@link WASM_SUSTAINABLE_MAX_TOKENS}). The freemem
+ *  term guards against host-memory thrashing (too big for RAM → swap); the WASM
+ *  bound guards against the fixed 4 GiB linear-memory cap (too big for the heap →
+ *  OOM) that host RAM says nothing about. */
 export function memoryModelEmbedCap(freeBytes: number): number {
   const budget = Math.max(
     freeBytes * EMBED_MEM_FRACTION - EMBED_MODEL_BASELINE_BYTES,
     0,
   );
-  return clampEmbedCap(Math.sqrt(budget / EMBED_ATTENTION_BYTES_PER_TOKEN_SQ));
+  return Math.min(
+    clampEmbedCap(Math.sqrt(budget / EMBED_ATTENTION_BYTES_PER_TOKEN_SQ)),
+    WASM_SUSTAINABLE_MAX_TOKENS,
+  );
 }
 
 /**
@@ -151,20 +191,42 @@ export function memoryModelEmbedCap(freeBytes: number): number {
  * cap (avoids re-walking the backoff every restart — the "recurs on every
  * restart" failure). When memory has materially grown, re-probe upward via the
  * model; when it has materially shrunk, take the safer of model vs learned.
+ *
+ * `knownBadCap` (a cap that has OOMed, persisted across restarts) is a hard
+ * ceiling on the result: a rising `os.freemem()` does NOT prove the fixed WASM
+ * heap can grow (see {@link reprobeEmbedCap}), so a memory-rich reboot must never
+ * re-probe back up to or past a cap the heap already rejected — the exact
+ * every-boot-OOM this guards against.
  */
 export function reconcileEmbedCap(
   freeBytes: number,
   stored: PersistedEmbedCap | null,
   modelCap: number,
+  knownBadCap = 0,
 ): number {
-  if (!stored) return modelCap;
-  const ratio = stored.freeMemBytes > 0 ? freeBytes / stored.freeMemBytes : 1;
-  if (ratio >= 1 - EMBED_CAP_TRUST_BAND && ratio <= 1 + EMBED_CAP_TRUST_BAND) {
-    return clampEmbedCap(stored.cap);
-  }
-  return freeBytes > stored.freeMemBytes
-    ? modelCap
-    : clampEmbedCap(Math.min(modelCap, stored.cap));
+  const reconciled = ((): number => {
+    if (!stored) return modelCap;
+    const ratio = stored.freeMemBytes > 0 ? freeBytes / stored.freeMemBytes : 1;
+    if (
+      ratio >= 1 - EMBED_CAP_TRUST_BAND &&
+      ratio <= 1 + EMBED_CAP_TRUST_BAND
+    ) {
+      return clampEmbedCap(stored.cap);
+    }
+    return freeBytes > stored.freeMemBytes
+      ? modelCap
+      : clampEmbedCap(Math.min(modelCap, stored.cap));
+  })();
+  // Bound EVERY path by the fixed WASM heap ceiling — not just the model-derived
+  // ones. The trust-band branch returns a persisted `stored.cap` verbatim, so a
+  // stale cap learned before this bound existed (e.g. an old 7000 read after an
+  // upgrade) would otherwise slip through and OOM once. knownBadCap (a
+  // per-host-learned OOM) tightens it further when present.
+  const ceiling =
+    knownBadCap > 0
+      ? Math.min(WASM_SUSTAINABLE_MAX_TOKENS, knownBadCap - 1)
+      : WASM_SUSTAINABLE_MAX_TOKENS;
+  return clampEmbedCap(Math.min(reconciled, ceiling));
 }
 
 /**
@@ -192,8 +254,13 @@ export function shouldReprobeEmbedCap(
  * `knownBadCap` (the highest cap that has OOMed in this process, 0 = none) is a
  * hard ceiling: a rising `os.freemem()` does not guarantee the WASM heap can
  * actually grow that far (fragmentation, racing allocations), so we never
- * re-probe *up to or past* a cap that already failed. A process restart
- * re-evaluates from scratch and can exceed it if memory genuinely grew.
+ * re-probe *up to or past* a cap that already failed.
+ *
+ * The result is also hard-bounded by {@link WASM_SUSTAINABLE_MAX_TOKENS} so this
+ * path can never yield a cap above the fixed WASM heap ceiling — even if handed
+ * an above-ceiling `cap` (the `Math.max(cap, …)` "never step down" clause would
+ * otherwise propagate it). This makes the "no cap exceeds the WASM ceiling"
+ * invariant locally enforced here, not merely inherited from a bounded input.
  */
 export function reprobeEmbedCap(
   cap: number,
@@ -203,5 +270,8 @@ export function reprobeEmbedCap(
   const stepped = Math.round(cap / EMBED_BACKOFF_FACTOR);
   let ceiling = memoryModelEmbedCap(freeBytes);
   if (knownBadCap > 0) ceiling = Math.min(ceiling, knownBadCap - 1);
-  return clampEmbedCap(Math.max(cap, Math.min(stepped, ceiling)));
+  return Math.min(
+    clampEmbedCap(Math.max(cap, Math.min(stepped, ceiling))),
+    WASM_SUSTAINABLE_MAX_TOKENS,
+  );
 }

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -118,17 +118,28 @@ function readPersistedEmbedCap(): PersistedEmbedCap | null {
     ) {
       return null;
     }
-    return { cap: parsed.cap, freeMemBytes: parsed.freeMemBytes };
+    return {
+      cap: parsed.cap,
+      freeMemBytes: parsed.freeMemBytes,
+      ...(typeof parsed.knownBadCap === "number" && parsed.knownBadCap > 0
+        ? { knownBadCap: parsed.knownBadCap }
+        : {}),
+    };
   } catch {
     return null;
   }
 }
 
-function persistEmbedCap(cap: number, freeMemBytes: number = freemem()): void {
+function persistEmbedCap(
+  cap: number,
+  freeMemBytes: number = freemem(),
+  knownBadCap = 0,
+): void {
   try {
     const value = JSON.stringify({
       cap,
       freeMemBytes,
+      ...(knownBadCap > 0 ? { knownBadCap } : {}),
     } satisfies PersistedEmbedCap);
     db()
       .query(
@@ -148,12 +159,15 @@ function persistEmbedCap(cap: number, freeMemBytes: number = freemem()): void {
  * current free memory; a materially larger free pool lets the cap re-probe
  * upward on restart (in lieu of continuous additive increase). Always clamped.
  */
-function computeInitialEmbedCap(): number {
+function computeInitialEmbedCap(
+  persisted: PersistedEmbedCap | null = readPersistedEmbedCap(),
+): number {
   const free = freemem();
   return reconcileEmbedCap(
     free,
-    readPersistedEmbedCap(),
+    persisted,
     memoryModelEmbedCap(free),
+    persisted?.knownBadCap ?? 0,
   );
 }
 
@@ -168,8 +182,12 @@ function computeInitialEmbedCap(): number {
  * construction (e.g. a CI box running the full suite in parallel) reconciles to
  * the freemem-derived model cap instead, making the start cap non-deterministic.
  */
-export function _persistEmbedCap(cap: number, freeMemBytes?: number): void {
-  persistEmbedCap(cap, freeMemBytes);
+export function _persistEmbedCap(
+  cap: number,
+  freeMemBytes?: number,
+  knownBadCap?: number,
+): void {
+  persistEmbedCap(cap, freeMemBytes, knownBadCap);
 }
 
 /** For tests: read the persisted embedding cap (or null when absent/corrupt). */
@@ -496,7 +514,13 @@ class LocalProvider implements EmbeddingProvider {
   constructor(modelId: string, dimensions: number) {
     this.modelId = modelId;
     this.dimensions = dimensions;
-    this.maxTokens = computeInitialEmbedCap();
+    // Seed lastOomCap from the persisted known-bad cap so an upward re-probe in
+    // THIS process still respects a ceiling the WASM heap rejected in a PRIOR
+    // one (a rising freemem doesn't prove the fixed heap grew). Read once and
+    // reuse for the initial cap to avoid a second kv_meta round-trip.
+    const persisted = readPersistedEmbedCap();
+    this.lastOomCap = persisted?.knownBadCap ?? 0;
+    this.maxTokens = computeInitialEmbedCap(persisted);
     this.capFreememAtLearn = freemem();
   }
 
@@ -745,7 +769,7 @@ class LocalProvider implements EmbeddingProvider {
     const prev = this.maxTokens;
     this.maxTokens = next;
     this.capFreememAtLearn = free;
-    persistEmbedCap(next, free);
+    persistEmbedCap(next, free, this.lastOomCap);
     log.info(
       `embedding cap re-probed up: ≤${prev} → ≤${next} tokens (free memory recovered)`,
     );
@@ -818,7 +842,9 @@ class LocalProvider implements EmbeddingProvider {
     // Anchor the re-probe baseline at OOM-time free memory: only climb back up
     // once memory has genuinely recovered (≥ EMBED_REPROBE_RATIO × this).
     this.capFreememAtLearn = free;
-    persistEmbedCap(capAfter, free);
+    // Persist the known-bad cap alongside the backed-off cap so the NEXT process
+    // start won't re-probe up to it even if the box reboots with more free RAM.
+    persistEmbedCap(capAfter, free, this.lastOomCap);
     log.info(
       `embedding worker OOM at ≤${capBefore} tokens — backing off to ≤${capAfter} ` +
         `and respawning on a fresh heap (${batchSize} in-flight, longest≈${longestChars} chars)`,

--- a/packages/core/test/embedding-cap-persistence.test.ts
+++ b/packages/core/test/embedding-cap-persistence.test.ts
@@ -46,4 +46,25 @@ describe("embedding cap persistence", () => {
     writeRaw(JSON.stringify({ cap: 1000 }));
     expect(_readPersistedEmbedCap()).toBeNull();
   });
+
+  it("round-trips a known-bad cap across the persistence boundary", () => {
+    _persistEmbedCap(1000, 4 * 1024 * 1024 * 1024, 3000);
+    const stored = _readPersistedEmbedCap();
+    expect(stored?.cap).toBe(1000);
+    expect(stored?.knownBadCap).toBe(3000);
+  });
+
+  it("omits knownBadCap when none is learned (0 / undefined)", () => {
+    _persistEmbedCap(1000);
+    expect(_readPersistedEmbedCap()?.knownBadCap).toBeUndefined();
+    _persistEmbedCap(1000, undefined, 0);
+    expect(_readPersistedEmbedCap()?.knownBadCap).toBeUndefined();
+  });
+
+  it("ignores a non-positive or non-numeric persisted knownBadCap", () => {
+    writeRaw(JSON.stringify({ cap: 1000, freeMemBytes: 1, knownBadCap: 0 }));
+    expect(_readPersistedEmbedCap()?.knownBadCap).toBeUndefined();
+    writeRaw(JSON.stringify({ cap: 1000, freeMemBytes: 1, knownBadCap: "x" }));
+    expect(_readPersistedEmbedCap()?.knownBadCap).toBeUndefined();
+  });
 });

--- a/packages/core/test/embedding-cap.test.ts
+++ b/packages/core/test/embedding-cap.test.ts
@@ -5,6 +5,7 @@ import {
   MIN_EMBED_TOKENS,
   MODEL_MAX_TOKENS,
   PER_WORKER_MEM_BUDGET_BYTES,
+  WASM_SUSTAINABLE_MAX_TOKENS,
   backoffEmbedCap,
   clampEmbedCap,
   desiredEmbedPoolSize,
@@ -75,8 +76,13 @@ describe("memoryModelEmbedCap", () => {
     expect(memoryModelEmbedCap(100 * 1024 * 1024)).toBe(MIN_EMBED_TOKENS);
   });
 
-  it("clamps to the model max on a large free pool", () => {
-    expect(memoryModelEmbedCap(64 * GB)).toBe(MODEL_MAX_TOKENS);
+  it("bounds a large free pool to the WASM heap ceiling, not the model max", () => {
+    // Host RAM says 8192 is affordable, but the fixed 4 GiB WASM heap can't hold
+    // the O(L²) attention at that length — so a memory-rich box is capped at the
+    // WASM-sustainable ceiling (~4948) rather than MODEL_MAX_TOKENS (8192). This
+    // is what prevents the OOM-on-every-boot on machines with lots of free RAM.
+    expect(memoryModelEmbedCap(64 * GB)).toBe(WASM_SUSTAINABLE_MAX_TOKENS);
+    expect(WASM_SUSTAINABLE_MAX_TOKENS).toBeLessThan(MODEL_MAX_TOKENS);
   });
 
   it("sizes a constrained host (~2.7 GB free, like Onur's box) well below 4096", () => {
@@ -101,6 +107,25 @@ describe("memoryModelEmbedCap", () => {
       const cap = memoryModelEmbedCap(free * GB);
       expect(cap).toBeGreaterThanOrEqual(MIN_EMBED_TOKENS);
       expect(cap).toBeLessThanOrEqual(MODEL_MAX_TOKENS);
+    }
+  });
+});
+
+describe("WASM_SUSTAINABLE_MAX_TOKENS", () => {
+  it("is a fixed ceiling below the model max, in the measured ~4900 range", () => {
+    // Derived from the 4 GiB WASM MAXIMUM_MEMORY (measured on the built worker)
+    // × 0.85 headroom, minus baseline, over K. Must sit below MODEL_MAX_TOKENS
+    // (that's the whole point) and near the observed safe convergence (≤4962).
+    expect(WASM_SUSTAINABLE_MAX_TOKENS).toBeLessThan(MODEL_MAX_TOKENS);
+    expect(WASM_SUSTAINABLE_MAX_TOKENS).toBeGreaterThan(4000);
+    expect(WASM_SUSTAINABLE_MAX_TOKENS).toBeLessThanOrEqual(5200);
+  });
+
+  it("is the binding ceiling once free RAM is large enough to hit it", () => {
+    // Below the crossover the freemem term binds; above it, the WASM ceiling
+    // does — and the result never exceeds the WASM ceiling regardless of RAM.
+    for (const free of [16, 32, 64, 256]) {
+      expect(memoryModelEmbedCap(free * GB)).toBe(WASM_SUSTAINABLE_MAX_TOKENS);
     }
   });
 });
@@ -144,6 +169,37 @@ describe("reconcileEmbedCap", () => {
       reconcileEmbedCap(1 * GB, { cap: 1500, freeMemBytes: 0 }, 2000),
     ).toBe(1500);
   });
+
+  it("never re-probes up to or past a persisted known-bad cap on a memory-rich reboot", () => {
+    // The every-boot-OOM: memory grew since learn time, so the freemem branch
+    // would jump back to the (larger) model cap — but 3000 already OOMed, so the
+    // result is hard-capped at knownBad − 1. Without persisting knownBad across
+    // restarts, this would climb to 4000 and OOM again on the very next boot.
+    const stored = { cap: 1500, freeMemBytes: 1 * GB };
+    expect(reconcileEmbedCap(4 * GB, stored, 4000, 3000)).toBe(2999);
+  });
+
+  it("still lowers below a known-bad cap when the reconciled value is already safe", () => {
+    // knownBad only *caps* — it never raises. A trusted learned cap below
+    // knownBad − 1 is returned unchanged.
+    const stored = { cap: 1500, freeMemBytes: 1 * GB };
+    expect(reconcileEmbedCap(1 * GB, stored, 2000, 3000)).toBe(1500);
+  });
+
+  it("ignores knownBad when it is 0 (none learned yet)", () => {
+    const stored = { cap: 1500, freeMemBytes: 1 * GB };
+    expect(reconcileEmbedCap(4 * GB, stored, 4000, 0)).toBe(4000);
+  });
+
+  it("bounds a stale trusted cap above the WASM ceiling (post-upgrade safety)", () => {
+    // A cap of 7000 learned BEFORE the WASM bound existed, trusted because
+    // free memory is stable — must be pulled down to the ceiling, not run at
+    // 7000 (which would OOM the 4 GiB heap once before the backoff re-converges).
+    const stale = { cap: 7000, freeMemBytes: 1 * GB };
+    expect(reconcileEmbedCap(1 * GB, stale, 8192)).toBe(
+      WASM_SUSTAINABLE_MAX_TOKENS,
+    );
+  });
 });
 
 describe("shouldReprobeEmbedCap", () => {
@@ -182,8 +238,15 @@ describe("reprobeEmbedCap", () => {
     expect(reprobeEmbedCap(3000, 1 * GB)).toBe(3000);
   });
 
-  it("stays clamped at the model max", () => {
-    expect(reprobeEmbedCap(MODEL_MAX_TOKENS, 64 * GB)).toBe(MODEL_MAX_TOKENS);
+  it("never re-probes above the WASM ceiling, even from an above-ceiling cap", () => {
+    // Defense-in-depth: the "never step down" Math.max(cap, …) clause must not
+    // propagate a stale above-ceiling cap. Handed 8192, reprobe self-bounds to
+    // the WASM ceiling rather than returning 8192 (which would OOM the 4 GiB heap).
+    expect(reprobeEmbedCap(MODEL_MAX_TOKENS, 64 * GB)).toBe(
+      WASM_SUSTAINABLE_MAX_TOKENS,
+    );
+    // A normal in-range cap still steps up as before (bound is a no-op here).
+    expect(reprobeEmbedCap(2000, 64 * GB)).toBe(Math.round(2000 / 0.7)); // 2857
   });
 
   it("never re-probes up to or past a known-bad cap", () => {

--- a/packages/core/test/embedding-oom-recovery.test.ts
+++ b/packages/core/test/embedding-oom-recovery.test.ts
@@ -12,7 +12,11 @@ import {
   _saveAndClearProvider,
   _setTestWorkerFactory,
 } from "../src/embedding";
-import { backoffEmbedCap, MIN_EMBED_TOKENS } from "../src/embedding-cap";
+import {
+  backoffEmbedCap,
+  MIN_EMBED_TOKENS,
+  WASM_SUSTAINABLE_MAX_TOKENS,
+} from "../src/embedding-cap";
 import { EMBED_OOM_EXIT_CODE } from "../src/embedding-worker-types";
 import { isStderrSilenced, silenceStderr } from "../src/log";
 
@@ -101,10 +105,11 @@ describe("embedding OOM recovery (worker-mock)", () => {
   });
 
   it("OOM exit lowers the cap ×0.7, persists it, respawns, and re-submits the in-flight request at the lowered cap", async () => {
-    // freeMemBytes=0 → reconcileEmbedCap trusts this cap as-is regardless of
-    // host free memory, so the provider deterministically starts at the model
-    // max (otherwise a freemem swing under parallel CI load reconciles down to
-    // the memory-model cap and this test flakes).
+    // freeMemBytes=0 → reconcileEmbedCap trusts this cap regardless of host free
+    // memory (otherwise a freemem swing under parallel CI load reconciles to the
+    // memory-model cap and this test flakes). The persisted 8192 is deliberately
+    // STALE (learned before the WASM bound) — the provider must start at the
+    // WASM ceiling, not 8192, exercising the trust-band bound in the live path.
     _persistEmbedCap(8192, 0);
     const fakes = installFakeWorkers();
 
@@ -114,7 +119,7 @@ describe("embedding OOM recovery (worker-mock)", () => {
     expect(fakes).toHaveLength(1);
     const first = fakes[0].lastPosted();
     expect(first.type).toBe("embed");
-    expect(first.maxTokens).toBe(8192);
+    expect(first.maxTokens).toBe(WASM_SUSTAINABLE_MAX_TOKENS);
 
     // The worker OOMs on the oversized input → exits with the OOM code.
     fakes[0].emit("exit", EMBED_OOM_EXIT_CODE);
@@ -124,7 +129,9 @@ describe("embedding OOM recovery (worker-mock)", () => {
     expect(fakes).toHaveLength(2);
     const resubmitted = fakes[1].lastPosted();
     expect(resubmitted.id).toBe(first.id);
-    expect(resubmitted.maxTokens).toBe(backoffEmbedCap(8192)); // 5734
+    expect(resubmitted.maxTokens).toBe(
+      backoffEmbedCap(WASM_SUSTAINABLE_MAX_TOKENS),
+    );
     expect(resubmitted.maxTokens).toBeLessThan(first.maxTokens);
     // The lowered cap was persisted so a restart doesn't re-walk the backoff.
     expect(_readPersistedEmbedCap()?.cap).toBe(resubmitted.maxTokens);


### PR DESCRIPTION
## Symptom

The local ONNX embedding worker OOMs 1–2× on (nearly) **every cold start** — worst on machines with *plenty* of free RAM. Recovery is correct (×0.7 backoff → fresh-heap respawn → resubmit), but it re-happens every boot.

## Root cause

The input token cap was sized purely from `os.freemem()`:

```
memoryModelEmbedCap = clamp( sqrt((free·0.5 − baseline) / K), [256, 8192] )
```

On a memory-rich boot (~13–15 GB free) that yields a **~7200–8192-token** cap. But the bundled `ort-wasm-simd-threaded` build has a **fixed** `Memory({ initial: 256, maximum: 65536, shared: true })` → **65536 pages × 64 KiB = 4 GiB `MAXIMUM_MEMORY`** (verified on the built worker). The O(L²) attention at ~7000+ tokens exceeds 4 GiB and OOMs; the backoff then walks the cap down to ~4962 — every boot. `os.freemem()` says nothing about the WASM heap cap, so **more host RAM made it worse, not better.**

## Fix

**(a) Bound the cap by the fixed WASM heap ceiling.** New `WASM_SUSTAINABLE_MAX_TOKENS`, derived from the 4 GiB `MAXIMUM_MEMORY` × 0.85 headroom and the measured `baseline`/`K` → **~4948 tokens** (matches the observed ≤4962 safe convergence). `memoryModelEmbedCap` is bounded by it, so every freemem-derived cap (initial, reconcile model cap, re-probe ceiling) can never *start* above what the heap can hold, regardless of host RAM. `reconcileEmbedCap` and `reprobeEmbedCap` also hard-bound their results by it — so even a **stale pre-fix persisted cap** (e.g. an old 7000 read after upgrade) is pulled down instead of OOMing once.

**(b) Persist the known-bad cap across restarts.** The highest cap that OOMed is now stored in the kv_meta cap record and used as a hard ceiling on restart. This applies the module's own principle — *"a rising `os.freemem()` does not prove the fixed WASM heap grew"* — to the restart path too: a memory-rich reboot no longer re-probes back up to a cap the heap already rejected.

## Measurement

Added `eval/measure-embed-ceiling.mjs`: binary-searches the OOM boundary on the **real bundled worker** (fresh worker per candidate; OOM = worker exit 75). Confirmed **8192 OOMs** (exit 75) while ≤4352 completes, and the 4 GiB `Memory` descriptor pins the clean boundary at `footprint(L)=680 MB+120·L² = 4 GiB ⇒ L ≈ 5460`. `footprint(4948) = 3.40 GiB` — ~15% below the boundary, and just under the ≤4962 real-world safe point.

## Scope / expectations

The goal is **no _recurring_ OOM**. On a host whose true boundary is marginally below the model's estimate, a single first-boot OOM could still occur — but (b)'s persisted known-bad cap ensures it doesn't recur. Host-memory *thrashing* at marginal free RAM is a separate concern (governed by `EMBED_MEM_FRACTION`) and out of scope here.

## Tests

- WASM ceiling bound + it being the binding ceiling on large free pools.
- `reconcileEmbedCap` known-bad hard-cap + stale-trusted-cap bounding (post-upgrade safety).
- `reprobeEmbedCap` self-bounds even from an above-ceiling input (defense-in-depth).
- `knownBadCap` persistence round-trip + backward-compat (old rows read cleanly).
- Updated the OOM-recovery test to assert the WASM ceiling as the start cap (also exercises the live-provider trust-band bound).

Typecheck + lint clean; all embedding suites green. Adversarial review: **no BLOCKERs**; the one flagged SHOULD-FIX (make `reprobeEmbedCap` self-bounding + fix the stale reprobe test) is included in this PR.