### PR TITLE
test(hermes): enforce the real ContextEngine ABC contract in CI (#1042)

### DIFF
--- a/packages/hermes/tests/conftest.py
+++ b/packages/hermes/tests/conftest.py
@@ -13,6 +13,7 @@ tested in isolation. This is test-only scaffolding — production runs against
 the real Hermes `ContextEngine`.
 """
 
+import abc
 import sys
 import types
 
@@ -20,11 +21,53 @@ if "agent.context_engine" not in sys.modules:
     agent_mod = types.ModuleType("agent")
     context_engine_mod = types.ModuleType("agent.context_engine")
 
-    class ContextEngine:
-        """Minimal stand-in for the Hermes ContextEngine ABC."""
+    class ContextEngine(abc.ABC):
+        """Minimal stand-in for the Hermes ``ContextEngine`` ABC.
 
-        def __init__(self, **kwargs):  # noqa: D401 - permissive base
+        The real base lives in the external ``hermes-agent`` package, which is
+        NOT vendored here. This stub is an ``abc.ABC`` that mirrors the real
+        ABC's *abstract-method set* so a missing or renamed override in
+        ``lore_hermes.engine.LoreContextEngine`` is caught at instantiation
+        (``TypeError: Can't instantiate abstract class ...``) instead of
+        silently passing — a plain-class stub would hide exactly that bug
+        (#1042, follow-up to the #1040 review).
+
+        The abstract set below is a snapshot of
+        ``hermes-agent==0.18.0``'s ``ContextEngine.__abstractmethods__``:
+        ``{name, should_compress, compress, update_from_response}``. Concrete
+        upstream hooks (e.g. ``should_compress_preflight``, ``get_status``) are
+        NOT abstract there, so they are intentionally omitted — marking them
+        abstract would make this stub *stricter* than reality.
+
+        Drift caveat: this is hand-maintained. Upstream Hermes adding a *new*
+        abstract method is only caught by the real-Hermes integration path
+        (``packages/hermes/test-integration.sh``), not by this unit suite.
+        """
+
+        def __init__(self, **kwargs):  # concrete upstream — permissive base
             pass
+
+        @property
+        @abc.abstractmethod
+        def name(self) -> str:  # noqa: D401
+            ...
+
+        @abc.abstractmethod
+        def should_compress(self, prompt_tokens: int = None) -> bool:
+            ...
+
+        @abc.abstractmethod
+        def compress(
+            self,
+            messages: list,
+            current_tokens: int = None,
+            focus_topic: str = None,
+        ) -> list:
+            ...
+
+        @abc.abstractmethod
+        def update_from_response(self, usage: dict) -> None:
+            ...
 
     context_engine_mod.ContextEngine = ContextEngine
     # Expose the submodule as an attribute so `import agent` + attribute access

--- a/packages/hermes/tests/test_contract.py
+++ b/packages/hermes/tests/test_contract.py
@@ -1,0 +1,68 @@
+"""ABC-conformance guard for the Hermes ``ContextEngine`` contract (#1042).
+
+The conftest stub (``agent.context_engine.ContextEngine``) is an ``abc.ABC``
+mirroring the real Hermes contract's abstract-method set. These tests prove:
+
+1. the stub actually *enforces* the contract — an implementation missing an
+   override cannot be instantiated. This guards against the stub silently
+   regressing to a plain class, which would re-hide the missing-override bug
+   that motivated #1042 (a plain-class stub makes ``TypeError`` impossible, so
+   the whole guard becomes vacuous); and
+2. ``LoreContextEngine`` *satisfies* the contract — it is concrete and
+   instantiable, so ``register()`` (``__init__.py``) won't raise
+   ``TypeError: Can't instantiate abstract class`` in production.
+
+Residual gap (documented, not fixed here): this checks our engine against a
+hand-maintained SNAPSHOT of the contract (hermes-agent==0.18.0), not live
+upstream Hermes. Upstream adding a *new* abstract method is only caught by
+``packages/hermes/test-integration.sh`` (needs a full Hermes install).
+"""
+
+import abc
+
+import pytest
+
+# The abstract-method set this repo mirrors, per hermes-agent==0.18.0.
+EXPECTED_ABSTRACT_METHODS = frozenset(
+    {"name", "should_compress", "compress", "update_from_response"}
+)
+
+
+def test_stub_context_engine_is_an_enforcing_abc():
+    from agent.context_engine import ContextEngine
+
+    assert issubclass(ContextEngine, abc.ABC)
+    # Exact set — flags any accidental add/remove of an abstract method in the
+    # stub (forcing an intentional, reviewed update when the snapshot changes).
+    assert ContextEngine.__abstractmethods__ == EXPECTED_ABSTRACT_METHODS
+
+
+def test_incomplete_implementation_cannot_be_instantiated():
+    """A subclass missing an override must raise TypeError.
+
+    This is the mutation guard: if the stub reverts to a plain (non-ABC) class,
+    ``Incomplete()`` would succeed and this test fails.
+    """
+    from agent.context_engine import ContextEngine
+
+    class Incomplete(ContextEngine):
+        # Overrides only ONE of the four abstract methods.
+        @property
+        def name(self) -> str:
+            return "incomplete"
+
+    with pytest.raises(TypeError):
+        Incomplete()
+
+
+def test_lore_engine_satisfies_the_contract():
+    from agent.context_engine import ContextEngine
+
+    from lore_hermes.engine import LoreContextEngine
+
+    assert issubclass(LoreContextEngine, ContextEngine)
+    # Instantiating proves every abstract method is overridden — this would
+    # raise ``TypeError`` otherwise. It is the conformance signal #1042 adds
+    # (previously a no-op, because the stub base enforced nothing).
+    engine = LoreContextEngine()
+    assert not type(engine).__abstractmethods__  # fully concrete

--- a/packages/hermes/tests/test_gateway.py
+++ b/packages/hermes/tests/test_gateway.py
@@ -60,11 +60,19 @@ class TestEnsureGateway:
     """Test gateway startup logic."""
 
     def test_returns_existing_gateway(self):
-        """If gateway is already running, returns its URL without starting."""
-        with patch("lore_hermes.gateway.find_gateway", return_value="http://127.0.0.1:3207"):
+        """If a gateway is already running, returns its URL without starting one.
+
+        Asserts the "without starting" claim explicitly: no subprocess is
+        spawned. Without the Popen assertion the mutation that always spawns a
+        process survives locally (it's only incidentally caught on CI runners
+        that have no ``lore`` binary on PATH) — see #1042 Finding 2.
+        """
+        with patch("lore_hermes.gateway.find_gateway", return_value="http://127.0.0.1:3207"), \
+             patch("subprocess.Popen") as popen:
             from lore_hermes.gateway import ensure_gateway
 
             assert ensure_gateway() == "http://127.0.0.1:3207"
+            popen.assert_not_called()
 
     def test_returns_none_when_no_binary(self):
         """No lore binary on PATH → None."""


### PR DESCRIPTION
Closes #1042. Follow-up to the #1040 adversarial review (Findings 3 + 2). Labeled `good first issue`.

## Problem

The `lore-hermes` pytest suite can't import the real Hermes `agent.context_engine` (not vendored), so `conftest.py` injects a stub. That stub's `ContextEngine` was a **plain class**, so `LoreContextEngine` subclassing it was never checked for ABC conformance. If it dropped/renamed an override the real Hermes ABC requires, production `LoreContextEngine()` (`register()`, `__init__.py`) would raise `TypeError: Can't instantiate abstract class …` — yet CI stayed green.

## Finding 3 — stub is now an enforcing `abc.ABC`

I introspected the **real** package to author a faithful stub rather than guessing. `hermes-agent==0.18.0`:

```
ContextEngine.__abstractmethods__ == {name, should_compress, compress, update_from_response}
```

The stub now declares exactly those four as abstract. `should_compress_preflight` and `get_status` are **concrete** upstream, so they're intentionally **not** marked abstract (that would make the stub stricter than reality). Also confirmed against the real 0.18.0 ABC that `LoreContextEngine` instantiates cleanly today — no drift.

New `test_contract.py` (3 tests):
1. the stub is an `abc.ABC` whose abstract set **equals** the 0.18.0 snapshot (flags any accidental add/remove of an abstract method);
2. an incomplete subclass raises `TypeError` — the **mutation guard** that fails if the stub ever reverts to a plain class (which would make the whole guard vacuous);
3. `LoreContextEngine` is concrete/instantiable — the conformance signal itself (previously a no-op against a plain base).

**Residual gap (documented, Option 2 not taken):** the stub is a hand-maintained snapshot, so upstream Hermes adding a *new* abstract method is only caught by `packages/hermes/test-integration.sh` (needs a full Hermes install). I deliberately did **not** add a CI job that `pip install`s real `hermes-agent`, to avoid making every code-touching PR's CI depend on an external package's installability/API stability. Happy to file that as a separate follow-up if you'd prefer the heavier signal.

## Finding 2 (NIT) — assert "without starting"

`test_returns_existing_gateway` now `patch("subprocess.Popen")` and asserts it was **not** called, proving the docstring's "without starting" claim. Previously the always-spawn mutation only died incidentally on CI runners with no `lore` binary on PATH; it survived locally.

## Verification

- **21 passed** (18 existing + 3 new), stable across 3 consecutive runs.
- Both fixes **mutation-checked**: reverting the stub to a plain class fails all 3 contract tests; an unconditional `subprocess.Popen` in `ensure_gateway` fails the gateway test.
- No production code touched — test scaffolding only.