### PR TITLE
fix(core): reclaim vec0 orphans on non-prune base-row deletes (#1132)

### DIFF
--- a/packages/core/src/data.ts
+++ b/packages/core/src/data.ts
@@ -29,6 +29,34 @@ import { getGitRemote } from "./git";
 import * as ltm from "./ltm";
 import * as agentsFile from "./agents-file";
 import { config as loreConfig } from "./config";
+import * as log from "./log";
+import {
+  deleteEmbeddings,
+  type EmbeddingTable,
+  gcVec0DanglingRows,
+  readStorageMode,
+} from "./db/vec-store";
+
+/**
+ * Reclaim the vec0 index rows orphaned by a bulk base-row delete. In vec0 mode a
+ * row's vector lives in a separate virtual table, so `DELETE FROM knowledge |
+ * temporal_messages | distillations` leaves it dangling; the once-per-startup
+ * sweep would otherwise not reclaim it until the next restart (issue #1132). We
+ * anti-join-sweep only the vec tables the caller actually deleted from — one
+ * scan each, which beats a per-id delete on the un-indexed `temporal_vec`
+ * message_id for large scopes, and correctly follows `knowledge_current`.
+ *
+ * Best-effort: a no-op in blob mode, and any failure is swallowed (the startup
+ * `gcVec0DanglingRows` + recall hydration-drop remain the backstop), so vec
+ * bookkeeping can never fail a user's delete.
+ */
+function reclaimVec0Orphans(tables: readonly EmbeddingTable[]): void {
+  try {
+    if (readStorageMode(db()) === "vec0") gcVec0DanglingRows(db(), tables);
+  } catch (e) {
+    log.warn("vec0 orphan reclaim after delete failed (harmless):", e);
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -662,6 +690,9 @@ export function clearProject(projectPath: string): ClearResult {
     throw e;
   }
 
+  // Base rows are gone (committed above) — reclaim their now-dangling vec0 chunks.
+  reclaimVec0Orphans(["knowledge", "temporal", "distillations"]);
+
   // Regenerate or delete .lore.md depending on toggle
   if (existsSync(projectPath)) {
     try {
@@ -804,6 +835,9 @@ export function deleteProject(projectId: string): ClearResult | null {
     throw e;
   }
 
+  // Base rows are gone (committed above) — reclaim their now-dangling vec0 chunks.
+  reclaimVec0Orphans(["knowledge", "temporal", "distillations"]);
+
   // Invalidate the .lore.md file cache for all known paths so that
   // shouldImportLoreFile() re-checks the file if this project path
   // is reused. Without this, the stale cache causes the import to be
@@ -864,6 +898,7 @@ export function clearKnowledge(projectPath: string): number {
     .query("DELETE FROM knowledge_session_injections WHERE project_id = ?")
     .run(pid);
   db().query("DELETE FROM knowledge WHERE project_id = ?").run(pid);
+  reclaimVec0Orphans(["knowledge"]);
 
   invalidateProjectsCache();
   invalidateGlobalStatsCache();
@@ -894,6 +929,7 @@ export function clearTemporal(projectPath: string): number {
   ).c;
 
   db().query("DELETE FROM temporal_messages WHERE project_id = ?").run(pid);
+  reclaimVec0Orphans(["temporal"]);
 
   invalidateProjectsCache();
   invalidateGlobalStatsCache();
@@ -911,6 +947,7 @@ export function clearDistillations(projectPath: string): number {
   ).c;
 
   db().query("DELETE FROM distillations WHERE project_id = ?").run(pid);
+  reclaimVec0Orphans(["distillations"]);
 
   invalidateProjectsCache();
   invalidateGlobalStatsCache();
@@ -935,6 +972,19 @@ export function deleteDistillation(id: string): boolean {
   const existing = getDistillation(id);
   if (!existing) return false;
   db().query("DELETE FROM distillations WHERE id = ?").run(id);
+  // Single known id → point-delete its vec0 chunk (indexed by the vec PK); no
+  // need for the whole-table anti-join sweep here. Best-effort like
+  // reclaimVec0Orphans: no-op in blob mode, and any failure is swallowed (the
+  // base row is already gone; the startup sweep + hydration-drop backstop it) so
+  // vec bookkeeping can never fail a delete that already succeeded.
+  try {
+    deleteEmbeddings(db(), "distillations", [id]);
+  } catch (e) {
+    log.warn(
+      "vec0 chunk delete after distillation delete failed (harmless):",
+      e,
+    );
+  }
   invalidateProjectsCache();
   invalidateGlobalStatsCache();
   return true;
@@ -991,6 +1041,9 @@ export function deleteSession(
   database
     .query("DELETE FROM knowledge_session_injections WHERE session_id = ?")
     .run(sessionId);
+
+  // Reclaim the session's now-dangling temporal/distillation vec0 chunks.
+  reclaimVec0Orphans(["temporal", "distillations"]);
 
   invalidateProjectsCache();
   invalidateGlobalStatsCache();

--- a/packages/core/src/db/vec-store.ts
+++ b/packages/core/src/db/vec-store.ts
@@ -533,35 +533,42 @@ export function dropEmbeddingColumn(
   }
 }
 
+/** The anti-join that reclaims one vec table's dangling rows. `knowledge_vec` is
+ *  pinned to CURRENT versions (the read path joins `knowledge_current`);
+ *  `temporal_vec` keys on the aux `message_id` (one message → many chunks). */
+const VEC0_DANGLING_SWEEP: Record<EmbeddingTable, string> = {
+  knowledge:
+    "DELETE FROM knowledge_vec WHERE id NOT IN (SELECT id FROM knowledge_current)",
+  entities: "DELETE FROM entity_vec WHERE id NOT IN (SELECT id FROM entities)",
+  distillations:
+    "DELETE FROM distillation_vec WHERE id NOT IN (SELECT id FROM distillations)",
+  temporal:
+    "DELETE FROM temporal_vec WHERE message_id NOT IN (SELECT id FROM temporal_messages)",
+};
+
+const ALL_EMBEDDING_TABLES: readonly EmbeddingTable[] = [
+  "knowledge",
+  "entities",
+  "distillations",
+  "temporal",
+];
+
 /**
  * Reclaim dangling `vec0` rows whose backing base row no longer exists — a bulk
  * project / session / prune delete removes base rows but not the separate vec0
  * rows. These rows are already HARMLESS for correctness (recall hydration drops
  * a hit whose base row is missing, and a deleted project's rows live in their
- * own partition), so this is a bloat / recall-quality backstop, not a fix. Run
- * once at startup in vec0 mode. `knowledge_vec` is pinned to CURRENT versions
- * (the read path joins `knowledge_current`); `temporal_vec` keys on the aux
- * `message_id`. One bounded pass per table.
+ * own partition), so this is a bloat / recall-quality backstop, not a fix. Runs
+ * at startup in vec0 mode (all tables) and after a bulk base-row delete (scoped
+ * to the tables that delete touched — see `data.ts`). One bounded anti-join pass
+ * per requested table; each is a single scan (cheaper than a per-id delete on
+ * the un-indexed `temporal_vec.message_id` aux column for large id sets).
  */
-export function gcVec0DanglingRows(conn: EmbeddingWriteConn): void {
-  conn
-    .query(
-      "DELETE FROM knowledge_vec WHERE id NOT IN (SELECT id FROM knowledge_current)",
-    )
-    .run();
-  conn
-    .query("DELETE FROM entity_vec WHERE id NOT IN (SELECT id FROM entities)")
-    .run();
-  conn
-    .query(
-      "DELETE FROM distillation_vec WHERE id NOT IN (SELECT id FROM distillations)",
-    )
-    .run();
-  conn
-    .query(
-      "DELETE FROM temporal_vec WHERE message_id NOT IN (SELECT id FROM temporal_messages)",
-    )
-    .run();
+export function gcVec0DanglingRows(
+  conn: EmbeddingWriteConn,
+  tables: readonly EmbeddingTable[] = ALL_EMBEDDING_TABLES,
+): void {
+  for (const t of tables) conn.query(VEC0_DANGLING_SWEEP[t]).run();
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/test/vec0-cutover.test.ts
+++ b/packages/core/test/vec0-cutover.test.ts
@@ -42,6 +42,14 @@ import {
 } from "../src/embedding";
 import * as log from "../src/log";
 import * as ltm from "../src/ltm";
+import {
+  clearDistillations,
+  clearKnowledge,
+  clearProject,
+  clearTemporal,
+  deleteDistillation,
+  deleteSession,
+} from "../src/data";
 import { partsToText, prune } from "../src/temporal";
 import type { LorePart } from "../src/types";
 import {
@@ -754,6 +762,36 @@ describeVec("delete maintenance + GC", () => {
     ).toEqual(["keepT"]);
   });
 
+  test("gcVec0DanglingRows sweeps ONLY the requested tables", () => {
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    // Orphan rows (no backing base row) in two different vec tables.
+    db()
+      .query(
+        "INSERT INTO temporal_vec(chunk_id, message_id, project_id, session_id, embedding) VALUES ('oT#0','oT',?,'s',?)",
+      )
+      .run(pid, toBlob(v(0, 1, 0, 0)));
+    db()
+      .query(
+        "INSERT INTO distillation_vec(id, project_id, session_id, embedding) VALUES ('oD',?,'s',?)",
+      )
+      .run(pid, toBlob(v(0, 1, 0, 0)));
+
+    gcVec0DanglingRows(db(), ["temporal"]); // filter: temporal only
+
+    expect(
+      (db().query("SELECT COUNT(*) n FROM temporal_vec").get() as { n: number })
+        .n,
+    ).toBe(0); // swept
+    expect(
+      (
+        db().query("SELECT COUNT(*) n FROM distillation_vec").get() as {
+          n: number;
+        }
+      ).n,
+    ).toBe(1); // NOT requested → left intact
+  });
+
   test("clearAllEmbeddings empties vec0 tables in vec0 mode", () => {
     setStorageMode(db(), "vec0");
     ensureVec0Store(db(), DIM);
@@ -767,6 +805,179 @@ describeVec("delete maintenance + GC", () => {
         }
       ).n,
     ).toBe(0);
+  });
+});
+
+describeVec("data.ts deletes reclaim vec0 orphans (#1132)", () => {
+  const tvec = () =>
+    (db().query("SELECT COUNT(*) n FROM temporal_vec").get() as { n: number })
+      .n;
+  const dvec = () =>
+    (
+      db().query("SELECT COUNT(*) n FROM distillation_vec").get() as {
+        n: number;
+      }
+    ).n;
+  const kvec = () =>
+    (db().query("SELECT COUNT(*) n FROM knowledge_vec").get() as { n: number })
+      .n;
+
+  test("clearTemporal reclaims temporal_vec chunks, leaves distillation_vec", () => {
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    insTemporal("t1", "s", 1);
+    insDistillation("d1", "s", 0);
+    storeEmbedding(db(), "temporal", "t1", v(1, 0, 0, 0));
+    storeEmbedding(db(), "distillations", "d1", v(1, 0, 0, 0));
+    expect(tvec()).toBe(1);
+
+    clearTemporal(PROJECT);
+
+    expect(tvec()).toBe(0); // reclaimed
+    expect(dvec()).toBe(1); // table filter left distillations alone
+  });
+
+  test("clearDistillations reclaims distillation_vec, leaves temporal_vec", () => {
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    insTemporal("t1", "s", 1);
+    insDistillation("d1", "s", 0);
+    storeEmbedding(db(), "temporal", "t1", v(1, 0, 0, 0));
+    storeEmbedding(db(), "distillations", "d1", v(1, 0, 0, 0));
+
+    clearDistillations(PROJECT);
+
+    expect(dvec()).toBe(0);
+    expect(tvec()).toBe(1);
+  });
+
+  test("clearKnowledge reclaims knowledge_vec", () => {
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    insKnowledge("k1");
+    storeEmbedding(db(), "knowledge", "k1", v(1, 0, 0, 0));
+    expect(kvec()).toBe(1);
+
+    clearKnowledge(PROJECT);
+
+    expect(kvec()).toBe(0);
+  });
+
+  test("deleteDistillation point-deletes its vec0 chunk, keeps others", () => {
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    insDistillation("d1", "s", 0);
+    insDistillation("d2", "s", 0);
+    storeEmbedding(db(), "distillations", "d1", v(1, 0, 0, 0));
+    storeEmbedding(db(), "distillations", "d2", v(0, 1, 0, 0));
+
+    deleteDistillation("d1");
+
+    expect(
+      db()
+        .query("SELECT id FROM distillation_vec ORDER BY id")
+        .all()
+        .map((r) => (r as { id: string }).id),
+    ).toEqual(["d2"]);
+  });
+
+  test("deleteSession reclaims that session's chunks, keeps other sessions'", () => {
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    insTemporal("t_s1", "s1", 1);
+    insDistillation("d_s1", "s1", 0);
+    insTemporal("t_s2", "s2", 1);
+    storeEmbedding(db(), "temporal", "t_s1", v(1, 0, 0, 0));
+    storeEmbedding(db(), "distillations", "d_s1", v(1, 0, 0, 0));
+    storeEmbedding(db(), "temporal", "t_s2", v(0, 1, 0, 0));
+
+    deleteSession(PROJECT, "s1");
+
+    expect(
+      db()
+        .query("SELECT message_id FROM temporal_vec ORDER BY message_id")
+        .all()
+        .map((r) => (r as { message_id: string }).message_id),
+    ).toEqual(["t_s2"]); // s1's temporal chunk gone, s2's kept
+    expect(dvec()).toBe(0); // s1's distillation chunk gone
+  });
+
+  test("clearProject reclaims all three vec tables", () => {
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    insKnowledge("k1");
+    insTemporal("t1", "s", 1);
+    insDistillation("d1", "s", 0);
+    storeEmbedding(db(), "knowledge", "k1", v(1, 0, 0, 0));
+    storeEmbedding(db(), "temporal", "t1", v(1, 0, 0, 0));
+    storeEmbedding(db(), "distillations", "d1", v(1, 0, 0, 0));
+
+    clearProject(PROJECT);
+
+    expect(kvec()).toBe(0);
+    expect(tvec()).toBe(0);
+    expect(dvec()).toBe(0);
+  });
+
+  test("clearing one project leaves ANOTHER project's vec0 rows intact", () => {
+    // The reclaim sweep is a GLOBAL anti-join, not project-scoped. This pins the
+    // load-bearing safety property: it only ever removes a vec row whose base row
+    // is gone, so a live sibling project is never touched.
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    const pidB = ensureProject("/test/vec0-cutover-other");
+    // Project A (the harness PROJECT/pid) — will be cleared.
+    insKnowledge("kA");
+    insTemporal("tA", "s", 1);
+    insDistillation("dA", "s", 0);
+    // Project B — inserted against pidB directly; must survive.
+    db()
+      .query(
+        "INSERT INTO knowledge (id, project_id, category, title, content, created_at, updated_at, logical_id) VALUES ('kB', ?, 'test', '', '', 0, 0, 'kB')",
+      )
+      .run(pidB);
+    db()
+      .query(
+        "INSERT INTO temporal_messages (id, project_id, session_id, role, content, tokens, distilled, created_at) VALUES ('tB', ?, 's', 'user', 'm', 0, 0, 1)",
+      )
+      .run(pidB);
+    db()
+      .query(
+        "INSERT INTO distillations (id, project_id, session_id, narrative, facts, observations, source_ids, generation, token_count, created_at, archived) VALUES ('dB', ?, 's', '', '', 'obs', '', 0, 0, 0, 0)",
+      )
+      .run(pidB);
+    for (const [t, id] of [
+      ["knowledge", "kA"],
+      ["temporal", "tA"],
+      ["distillations", "dA"],
+      ["knowledge", "kB"],
+      ["temporal", "tB"],
+      ["distillations", "dB"],
+    ] as const) {
+      storeEmbedding(db(), t, id, v(1, 0, 0, 0));
+    }
+
+    clearProject(PROJECT); // project A only
+
+    // A's chunks reclaimed; B's untouched because B's base rows still exist.
+    expect(
+      db()
+        .query("SELECT id FROM knowledge_vec ORDER BY id")
+        .all()
+        .map((r) => (r as { id: string }).id),
+    ).toEqual(["kB"]);
+    expect(
+      db()
+        .query("SELECT message_id FROM temporal_vec ORDER BY message_id")
+        .all()
+        .map((r) => (r as { message_id: string }).message_id),
+    ).toEqual(["tB"]);
+    expect(
+      db()
+        .query("SELECT id FROM distillation_vec ORDER BY id")
+        .all()
+        .map((r) => (r as { id: string }).id),
+    ).toEqual(["dB"]);
   });
 });
 


### PR DESCRIPTION
Follow-up to #1129, closes #1132.

## Problem
In vec0 mode a row's vector lives in a **separate virtual table**, so a base-row `DELETE` leaves the vector dangling until the next startup `gcVec0DanglingRows` sweep. #1129 closed the idle-`prune()` path; this closes the remaining `data.ts` admin deletes:
`clearProject`, `deleteProject`, `clearKnowledge`, `clearTemporal`, `clearDistillations`, `deleteSession`, `deleteDistillation`.

On a long-running gateway (the intended steady state) these orphans accumulate between restarts — wasted KNN candidate slots + disk. Harmless for correctness (recall hydration drops a hit whose base row is gone), so a bloat/quality fix.

## Fix
Two tools, picked by delete shape:

- **Bulk, scope-wide deletes → anti-join sweep.** `gcVec0DanglingRows` now takes an **optional table filter** so each caller sweeps only the vec tables it deleted from (default = all four → the startup caller is unchanged). One scan per vec table; it follows `knowledge_current` versioning, and avoids the per-id delete degrading to `ceil(N/900)` full scans of the **un-indexed** `temporal_vec.message_id` aux column on a large scope.
- **Single-row `deleteDistillation` → targeted `deleteEmbeddings`** point-delete (indexed by the vec PK).

`reclaimVec0Orphans(tables)` is **best-effort**: no-op in blob mode, and any failure is swallowed (startup sweep + hydration-drop remain the backstop) so vec bookkeeping can never fail a user's delete. For the transactional `clearProject`/`deleteProject` it runs **after commit** — off the atomic critical path.

## Tests
New vec0 delete-reclaim block (`vec0-cutover.test.ts`): each function drops exactly the deleted scope's chunks and leaves the rest — table-filter isolation (`clearTemporal` leaves `distillation_vec`), other-session survival (`deleteSession` keeps `s2`), point-delete (`deleteDistillation` keeps `d2`), and full-project reclaim. Plus a unit test that the `gcVec0DanglingRows` table filter sweeps **only** the requested tables.
**Mutation-verified** — neutering `reclaimVec0Orphans` / the `deleteDistillation` point-delete fails all six. Full `packages/core` suite: **2452 passed, 0 failed**.

## Not covered (by design)
`deleteKnowledge` routes through `ltm.remove` → `appendVersion`, which calls `deleteEmbeddings` for the superseded version (the death-cert version is inserted without an embedding, so no `knowledge_vec` orphan is created); `entities` are not deleted by any of these paths. The startup sweep remains the catch-all for any orphan from another source or a crash mid-delete.