### PR TITLE
fix(core): re-point vec0 partition keys when a session/project moves (#1138)

### DIFF
--- a/packages/core/src/data.ts
+++ b/packages/core/src/data.ts
@@ -35,6 +35,7 @@ import {
   type EmbeddingTable,
   gcVec0DanglingRows,
   readStorageMode,
+  repartitionVec0Project,
 } from "./db/vec-store";
 
 /**
@@ -1293,6 +1294,13 @@ export function moveSessions(
         `UPDATE distillations SET project_id = ? WHERE project_id = ? AND session_id IN (${placeholders})`,
       )
       .run(toId, fromProjectId, ...allIds);
+
+    // vec0: the base project_id UPDATEs above leave temporal_vec/distillation_vec
+    // partitioned under the OLD project. vec0 forbids UPDATE of a partition key,
+    // so re-point by DELETE+reINSERT — inside this transaction so a failure rolls
+    // the whole move back (a stale partition silently breaks scoped recall and
+    // has no orphan-sweep backstop). No-op in blob mode.
+    repartitionVec0Project(database, fromProjectId, toId, allIds);
 
     // Re-point the session rollup set-based: the project_id UPDATEs above do NOT
     // fire the rollup triggers (scoped to content/tokens/metadata + insert/delete),

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -4,6 +4,7 @@ import {
   ensureVec0Store,
   readStorageMode,
   readVecDimension,
+  repartitionVec0Project,
 } from "./db/vec-store";
 import { join, dirname } from "node:path";
 import { chmodSync, mkdirSync } from "node:fs";
@@ -2655,6 +2656,11 @@ export function mergeProjectInternal(sourceId: string, targetId: string): void {
       targetId,
       sourceId,
     );
+    // vec0: re-point temporal_vec/distillation_vec off the source partition (vec0
+    // forbids UPDATE of a partition key, so DELETE+reINSERT). Whole-project merge
+    // ⇒ no session filter. Inside the transaction so a failure rolls the merge
+    // back; no-op in blob mode. (knowledge_vec/entity_vec have no partition key.)
+    repartitionVec0Project(d, sourceId, targetId);
     // Re-point the session rollup set-based: the temporal/distillation project_id
     // UPDATEs above do NOT fire the rollup triggers (scoped to content/tokens/
     // metadata + insert/delete), so move the rows here. session_id is globally

--- a/packages/core/src/db/vec-store.ts
+++ b/packages/core/src/db/vec-store.ts
@@ -571,6 +571,103 @@ export function gcVec0DanglingRows(
   for (const t of tables) conn.query(VEC0_DANGLING_SWEEP[t]).run();
 }
 
+/** Rows re-pointed per pass — bounds memory when a whole-project merge moves a
+ *  large `temporal_vec` (each row carries a full embedding blob). */
+const REPARTITION_BATCH = 500;
+
+/**
+ * Re-point the `project_id` PARTITION KEY of a project's `temporal_vec` /
+ * `distillation_vec` rows when their base rows move to another project (a session
+ * move or a whole-project merge). vec0 rejects `UPDATE` on a PARTITION KEY column
+ * ("UPDATE on partition key columns are not supported yet"), so we DELETE each
+ * index row and re-INSERT it under `toProjectId`, preserving the stored embedding
+ * and the (unchanged) `session_id`. No-op outside vec0 mode.
+ *
+ * `sessionIds`: when provided, restricts to those sessions (session move); when
+ * omitted, moves EVERY row of `fromProjectId` (project merge).
+ *
+ * NOT best-effort — callers MUST run this inside the move transaction and let a
+ * failure roll the whole move back. A stale partition key silently breaks
+ * project-scoped vector recall for the moved rows and has no backstop: the row
+ * is mis-partitioned, not orphaned, so `gcVec0DanglingRows` never repairs it.
+ * (`knowledge_vec` / `entity_vec` have no partition key, so they need no move.)
+ */
+export function repartitionVec0Project(
+  conn: EmbeddingWriteConn,
+  fromProjectId: string,
+  toProjectId: string,
+  sessionIds?: string[],
+): void {
+  if (fromProjectId === toProjectId) return; // moving a row out of its own scope
+  if (sessionIds && sessionIds.length === 0) return;
+  if (readStorageMode(conn) !== "vec0") return;
+
+  // One scope for a merge; chunk the session `IN (…)` list under the bound-var
+  // ceiling for a session move. Draining `LIMIT`ed batches terminates because a
+  // moved row's `project_id` no longer matches `fromProjectId` (guarded above so
+  // from≠to keeps the working set shrinking).
+  const scopes: Array<{ where: string; params: unknown[] }> =
+    sessionIds === undefined
+      ? [{ where: "project_id = ?", params: [fromProjectId] }]
+      : chunkIds(sessionIds, 900).map((batch) => ({
+          where: `project_id = ? AND session_id IN (${batch.map(() => "?").join(",")})`,
+          params: [fromProjectId, ...batch],
+        }));
+
+  // Hoist the constant DELETE/INSERT statements (the SELECT's WHERE is dynamic).
+  const delT = conn.query("DELETE FROM temporal_vec WHERE chunk_id = ?");
+  const insT = conn.query(
+    "INSERT INTO temporal_vec(chunk_id, message_id, project_id, session_id, embedding) VALUES (?, ?, ?, ?, ?)",
+  );
+  const delD = conn.query("DELETE FROM distillation_vec WHERE id = ?");
+  const insD = conn.query(
+    "INSERT INTO distillation_vec(id, project_id, session_id, embedding) VALUES (?, ?, ?, ?)",
+  );
+
+  for (const { where, params } of scopes) {
+    // temporal_vec: chunk_id PK, +message_id aux, project_id + session_id PARTITION.
+    const selT = `SELECT chunk_id, message_id, session_id, embedding FROM temporal_vec WHERE ${where} LIMIT ${REPARTITION_BATCH}`;
+    for (;;) {
+      const rows = conn.query(selT).all(...params) as Array<{
+        chunk_id: string;
+        message_id: string;
+        session_id: string;
+        embedding: Uint8Array;
+      }>;
+      if (rows.length === 0) break;
+      for (const r of rows) delT.run(r.chunk_id);
+      for (const r of rows)
+        insT.run(
+          r.chunk_id,
+          r.message_id,
+          toProjectId,
+          r.session_id,
+          r.embedding,
+        );
+    }
+    // distillation_vec: id PK, project_id PARTITION, +session_id aux.
+    const selD = `SELECT id, session_id, embedding FROM distillation_vec WHERE ${where} LIMIT ${REPARTITION_BATCH}`;
+    for (;;) {
+      const rows = conn.query(selD).all(...params) as Array<{
+        id: string;
+        session_id: string;
+        embedding: Uint8Array;
+      }>;
+      if (rows.length === 0) break;
+      for (const r of rows) delD.run(r.id);
+      for (const r of rows)
+        insD.run(r.id, toProjectId, r.session_id, r.embedding);
+    }
+  }
+}
+
+/** Split `ids` into chunks of at most `size` (SQLite bound-variable ceiling). */
+function chunkIds(ids: string[], size: number): string[][] {
+  const out: string[][] = [];
+  for (let i = 0; i < ids.length; i += size) out.push(ids.slice(i, i + size));
+  return out;
+}
+
 // ---------------------------------------------------------------------------
 // Mode-aware "missing/has embedding" predicates for backfill detection
 // ---------------------------------------------------------------------------

--- a/packages/core/test/vec0-cutover.test.ts
+++ b/packages/core/test/vec0-cutover.test.ts
@@ -8,7 +8,14 @@
 // somehow unavailable so a vec-less CI lane stays green.
 import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
 import { config } from "../src/config";
-import { close, db, ensureProject, getKV, setKV } from "../src/db";
+import {
+  close,
+  db,
+  ensureProject,
+  getKV,
+  mergeProjectInternal,
+  setKV,
+} from "../src/db";
 import { isVecAvailable } from "../src/db/vec";
 import {
   VEC_DIMENSION_KEY,
@@ -25,6 +32,7 @@ import {
   missingEmbeddingSql,
   readStorageMode,
   readVecDimension,
+  repartitionVec0Project,
   setStorageMode,
   storeEmbedding,
   storeTemporalChunks,
@@ -49,6 +57,7 @@ import {
   clearTemporal,
   deleteDistillation,
   deleteSession,
+  moveSessions,
 } from "../src/data";
 import { partsToText, prune } from "../src/temporal";
 import type { LorePart } from "../src/types";
@@ -978,6 +987,142 @@ describeVec("data.ts deletes reclaim vec0 orphans (#1132)", () => {
         .all()
         .map((r) => (r as { id: string }).id),
     ).toEqual(["dB"]);
+  });
+});
+
+describeVec("moving a project re-points vec0 partition keys (#1138)", () => {
+  // Enumerate a partition directly (proves the partition-key VALUE was re-pointed).
+  const inT = (p: string) =>
+    db()
+      .query("SELECT message_id AS id FROM temporal_vec WHERE project_id = ?")
+      .all(p)
+      .map((r) => (r as { id: string }).id)
+      .sort();
+  const inD = (p: string) =>
+    db()
+      .query("SELECT id FROM distillation_vec WHERE project_id = ?")
+      .all(p)
+      .map((r) => (r as { id: string }).id)
+      .sort();
+  // Exercise the REAL read path (vector-query.ts:510): partition-filtered KNN.
+  const recallT = (p: string) =>
+    db()
+      .query(
+        "SELECT message_id AS id FROM temporal_vec WHERE embedding MATCH ? AND k = ? AND project_id = ? ORDER BY distance",
+      )
+      .all(toBlob(v(1, 0, 0, 0)), 10, p)
+      .map((r) => (r as { id: string }).id)
+      .sort();
+
+  test("repartitionVec0Project re-points a session's chunks; other sessions stay", () => {
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    const pidB = ensureProject("/test/vec0-move-B");
+    // sess1 (moved): two messages with DISTINCT vectors + a distillation.
+    insTemporal("t1", "sess1", 1);
+    insTemporal("t2", "sess1", 2);
+    insDistillation("d1", "sess1", 0);
+    // sess2 (same source project): a temporal AND a distillation that must STAY.
+    // The distillation sibling guards the aux-column session_id filter against
+    // over-moving (the inverse of the bug being fixed).
+    insTemporal("t_keep", "sess2", 1);
+    insDistillation("d_keep", "sess2", 0);
+    storeEmbedding(db(), "temporal", "t1", v(1, 0, 0, 0));
+    storeEmbedding(db(), "temporal", "t2", v(0, 1, 0, 0));
+    storeEmbedding(db(), "distillations", "d1", v(1, 0, 0, 0));
+    storeEmbedding(db(), "temporal", "t_keep", v(0, 0, 1, 0));
+    storeEmbedding(db(), "distillations", "d_keep", v(0, 0, 1, 0));
+
+    repartitionVec0Project(db(), pid, pidB, ["sess1"]);
+
+    expect(inT(pidB)).toEqual(["t1", "t2"]); // sess1 chunks now under B
+    expect(inT(pid)).toEqual(["t_keep"]); // sess2 temporal stays in A
+    expect(inD(pidB)).toEqual(["d1"]);
+    expect(inD(pid)).toEqual(["d_keep"]); // sess2 distillation stays in A
+    // Embedding fidelity: a KNN probe under B ranks the exact-match vector first
+    // (a corrupted/renormalized round-trip would scramble this ordering).
+    expect(
+      db()
+        .query(
+          "SELECT message_id AS id FROM temporal_vec WHERE embedding MATCH ? AND k = ? AND project_id = ? ORDER BY distance",
+        )
+        .all(toBlob(v(0, 1, 0, 0)), 2, pidB)
+        .map((r) => (r as { id: string }).id),
+    ).toEqual(["t2", "t1"]); // t2 (exact match) nearest, then t1
+    // And the moved chunk is recallable under B, not A.
+    expect(recallT(pid)).toEqual(["t_keep"]);
+  });
+
+  test("repartitionVec0Project with no sessionIds moves the WHOLE project (merge)", () => {
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    const pidB = ensureProject("/test/vec0-move-B2");
+    insTemporal("t1", "sess1", 1);
+    insTemporal("t2", "sess2", 1);
+    insDistillation("d1", "sess1", 0);
+    storeEmbedding(db(), "temporal", "t1", v(1, 0, 0, 0));
+    storeEmbedding(db(), "temporal", "t2", v(1, 0, 0, 0));
+    storeEmbedding(db(), "distillations", "d1", v(1, 0, 0, 0));
+
+    repartitionVec0Project(db(), pid, pidB); // no session filter
+
+    expect(inT(pidB)).toEqual(["t1", "t2"]);
+    expect(inT(pid)).toEqual([]);
+    expect(inD(pidB)).toEqual(["d1"]);
+  });
+
+  test("repartitionVec0Project is a no-op when from === to, on empty ids, and in blob mode", () => {
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    const pidB = ensureProject("/test/vec0-move-B3");
+    insTemporal("t1", "sess1", 1);
+    storeEmbedding(db(), "temporal", "t1", v(1, 0, 0, 0));
+
+    repartitionVec0Project(db(), pid, pid, ["sess1"]); // from === to
+    repartitionVec0Project(db(), pid, pidB, []); // empty session list
+    expect(inT(pid)).toEqual(["t1"]); // untouched by both
+
+    setStorageMode(db(), "blob");
+    expect(() =>
+      repartitionVec0Project(db(), pid, pidB, ["sess1"]),
+    ).not.toThrow(); // blob no-op
+  });
+
+  test("moveSessions makes the moved session recallable under the new project", () => {
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    insTemporal("m1", "moveSess", 1);
+    insDistillation("md1", "moveSess", 0);
+    storeEmbedding(db(), "temporal", "m1", v(1, 0, 0, 0));
+    storeEmbedding(db(), "distillations", "md1", v(1, 0, 0, 0));
+
+    const toPath = "/test/vec0-move-target";
+    moveSessions(["moveSess"], pid, toPath);
+    const pidTarget = ensureProject(toPath);
+
+    // Before this fix, these vec rows stayed under `pid` and were invisible to a
+    // search scoped to the new project.
+    expect(recallT(pidTarget)).toEqual(["m1"]);
+    expect(inD(pidTarget)).toEqual(["md1"]);
+    expect(inT(pid)).toEqual([]);
+    expect(inD(pid)).toEqual([]);
+  });
+
+  test("mergeProjectInternal re-points the source project's vec0 rows", () => {
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    const target = ensureProject("/test/vec0-merge-target");
+    insTemporal("s1", "sess1", 1);
+    insDistillation("sd1", "sess1", 0);
+    storeEmbedding(db(), "temporal", "s1", v(1, 0, 0, 0));
+    storeEmbedding(db(), "distillations", "sd1", v(1, 0, 0, 0));
+
+    mergeProjectInternal(pid, target);
+
+    expect(inT(target)).toEqual(["s1"]);
+    expect(inD(target)).toEqual(["sd1"]);
+    expect(inT(pid)).toEqual([]);
+    expect(inD(pid)).toEqual([]);
   });
 });
 


### PR DESCRIPTION
Closes #1138 (found in the #1137 review).

## Bug
`temporal_vec.project_id` (+`session_id`) and `distillation_vec.project_id` are vec0 **PARTITION KEYs**, and the read path filters on them **directly** (`vector-query.ts:510` / `:433`) — it does not join the base table for project scoping. But two paths updated `project_id` on the **base** rows only, leaving the vec0 partition keys stale:
- `moveSessions` (`data.ts`) — session move
- `mergeProjectInternal` (`db.ts`) — whole-project merge

After a move/merge the vectors stayed under the **old** project, so project-scoped semantic recall for the moved session silently missed them (and could still surface them under the source project). FTS / non-partitioned reads were unaffected.

## Fix
vec0 rejects `UPDATE` on a partition-key column — confirmed empirically: `UPDATE on partition key columns are not supported yet`. So `repartitionVec0Project()` (new, `vec-store.ts`) **DELETEs the affected index rows and re-INSERTs them** under the new `project_id`, preserving the stored embedding and the unchanged `session_id`.
- Drains in `LIMIT 500` batches → bounds memory on a whole-project merge (each row carries a full embedding blob); terminates because a moved row drops out of the `from`-project predicate (guarded `from===to`).
- `sessionIds` provided → session move; omitted → whole-project merge.
- `knowledge_vec` / `entity_vec` have **no** partition key, so knowledge/entity moves need no repointing.

Both callers run it **inside** their existing move transaction. This is **not** best-effort: a stale partition has no backstop (the row is mis-partitioned, not orphaned, so `gcVec0DanglingRows` never repairs it), so a failure must roll the whole move back. No-op in blob mode.

## Tests
- `repartitionVec0Project`: session-scoped + whole-project (merge) moves assert the partition key is re-pointed **and** the moved chunk is recallable under the new project via the **real KNN read path** (`MATCH … AND project_id = ?`), not the old one; sibling sessions stay; `from===to` / empty-ids / blob no-ops.
- End-to-end `moveSessions` + `mergeProjectInternal` regressions.
- **Mutation-verified** — neutering `repartitionVec0Project` fails all four positive tests. Full `packages/core` suite: **2467 passed, 0 failed**.