### PR TITLE
docs(gateway): document verified `HERMES_INFERENCE_PROVIDER` behavior (#649)

### DIFF
--- a/packages/gateway/src/cli/agents.ts
+++ b/packages/gateway/src/cli/agents.ts
@@ -238,8 +238,18 @@ export const AGENTS: AgentDef[] = [
     detect: () => whichSync("hermes"),
     envVars: (url, cwd) => {
       const env: Record<string, string> = {
-        // Hermes uses OPENAI_BASE_URL for custom OpenAI-compatible endpoints.
-        // Force provider to "custom" so Hermes picks up the base URL.
+        // Route Hermes through the gateway. Both keys are undocumented in the
+        // official env-vars reference but verified honored against hermes-agent
+        // 0.18.0 (see #649):
+        //   • OPENAI_BASE_URL — read as the custom OpenAI-compatible base URL
+        //     (auxiliary_client.py os.getenv("OPENAI_BASE_URL")).
+        //   • HERMES_INFERENCE_PROVIDER — selects the provider; resolution
+        //     order is CLI flag > config.yaml `model.provider` > this env var
+        //     > "auto" (cli.py). So "custom" makes a stock Hermes pick up
+        //     OPENAI_BASE_URL, but a named `model.provider` in
+        //     ~/.hermes/config.yaml takes precedence over it.
+        // `lore setup hermes` persists this same pair to ~/.hermes/.env for
+        // standalone (non-`lore run`) launches.
         OPENAI_BASE_URL: `${url}/v1`,
         HERMES_INFERENCE_PROVIDER: "custom",
       };


### PR DESCRIPTION
Closes #649 (the last actionable item from the triaged batch).

#649 asked whether `HERMES_INFERENCE_PROVIDER=custom` at `agents.ts` is a no-op (undocumented in Hermes's official env-vars reference). Introspecting the real `hermes-agent` 0.18.0 answers it — the env var **is honored**:

- **`HERMES_INFERENCE_PROVIDER` is read** — `cli.py`: provider resolution is `CLI flag > config.yaml model.provider > HERMES_INFERENCE_PROVIDER > "auto"`. Not a no-op. Caveat: a named `model.provider` in `~/.hermes/config.yaml` **overrides** it (matching the issue's verification scenario 3).
- **`OPENAI_BASE_URL` is read** as the custom OpenAI-compatible base URL — `auxiliary_client.py` `os.getenv("OPENAI_BASE_URL")`; Hermes even warns when it's set but `config.yaml` pins a named provider.
- `~/.hermes/.env` is loaded at startup via `load_hermes_dotenv` (python-dotenv).

This is the issue's **"supported but undocumented"** resolution branch: keep the env var, add a comment in `agents.ts` explaining it's verified-honored. This PR does exactly that (comment-only, no behavior change), and notes that `lore setup hermes` (#1141) now persists the same pair to `~/.hermes/.env` for standalone launches.

Typecheck + biome clean; `agents.test.ts` green (19 passed).