### PR TITLE
perf(gateway): run native onnxruntime-node (not WASM) in the SEA binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -665,6 +665,9 @@ jobs:
           - target: darwin-arm64
             runs-on: macos-14
             ext: ""
+          - target: linux-arm64
+            runs-on: ubuntu-24.04-arm
+            ext: ""
           - target: windows-x64
             runs-on: windows-latest
             ext: ".exe"

--- a/packages/core/src/embedding-worker.ts
+++ b/packages/core/src/embedding-worker.ts
@@ -249,20 +249,20 @@ async function ensurePipeline(): Promise<void> {
  * so it can be retried after a corrupt-model purge. Throws on any failure.
  */
 async function loadPipeline(): Promise<void> {
-  // npm/dev path: the bundled worker redirects onnxruntime-node →
-  // onnxruntime-web (WASM) and the gateway bundle ships the WASM runtime
-  // (ort-wasm-simd-threaded.{mjs,wasm}) next to this file in dist/. Point
-  // transformers.js' patched wasmPaths read at those sibling files so the
-  // WASM loads locally instead of from the jsdelivr CDN (wrong variant +
-  // requires network). The binary path sets __LORE_VENDOR_WASM_PATHS__ via
-  // native-loader.cjs instead, so we only act when neither global is set and
-  // we're not in vendored (binary) mode. Guarded by existsSync so dev/test
-  // (which run the raw .ts with the real native onnxruntime-node and have no
+  // npm dist-only path: the npm worker bundle redirects onnxruntime-node →
+  // onnxruntime-web (WASM) and ships the WASM runtime (ort-wasm-simd-threaded.
+  // {mjs,wasm}) next to this file in dist/ — this keeps `npm install`/AUR
+  // dist-only installs (no node_modules) self-contained (#763). Point
+  // transformers.js' patched wasmPaths at those sibling files so the WASM loads
+  // locally instead of from the jsdelivr CDN (wrong variant + requires network).
+  // The standalone SEA binary does NOT take this path: it bundles the native
+  // onnxruntime-node addon (extracted by native-loader.cjs) and runs in
+  // `vendorModel` mode, so `!vendorModel` short-circuits below. Guarded by
+  // existsSync so dev/test (raw .ts with the real native onnxruntime-node and no
   // sibling WASM) are unaffected — the block is simply inert there.
   const globals = globalThis as Record<string, unknown>;
   if (
     !vendorModel &&
-    !globals.__LORE_VENDOR_WASM_PATHS__ &&
     !globals.__LORE_NPM_WASM_PATHS__ &&
     typeof __filename === "string"
   ) {
@@ -293,18 +293,17 @@ async function loadPipeline(): Promise<void> {
     env.allowRemoteModels = false;
   }
 
-  // Force single-threaded WASM execution to avoid Bun's buggy
-  // shared-memory/pthread WASM paths. The threaded build uses
-  // `new WebAssembly.Memory({shared:true})` which triggers open Bun bugs:
+  // WASM-only tuning: force single-threaded WASM execution to avoid Bun's buggy
+  // shared-memory/pthread WASM paths (the npm dist path may run under Bun). The
+  // threaded build uses `new WebAssembly.Memory({shared:true})` which triggers
+  // open Bun bugs:
   //   - oven-sh/bun#25677: SharedArrayBuffer writes invisible to workers
   //   - oven-sh/bun#31158: SIGPWR storm with native threads + WASM
   //   - oven-sh/bun#18145: $bunfs + WASM Aborted() in --compile binaries
-  // Single-thread avoids all three. The ~2× batch speed advantage of
-  // threading is batch-only (single-text is identical) and lore's workload
-  // is incremental single-text embeds, so no practical throughput loss.
-  //
-  // Access the ONNX WASM config via the env object exposed by transformers.js.
-  // `env.backends.onnx.wasm` is the ORT WebAssemblyFlags interface.
+  // Single-thread avoids all three. This touches only `env.backends.onnx.wasm`,
+  // which the native onnxruntime-node backend (SEA binary + dev/test) ignores —
+  // native uses its own multi-threaded intra-op pool (a key reason the SEA
+  // switched to native: it scales with cores, #999). So this is a no-op there.
   const wasmEnv = (env as Record<string, unknown>).backends as
     | { onnx?: { wasm?: { numThreads?: number; proxy?: boolean } } }
     | undefined;
@@ -317,10 +316,10 @@ async function loadPipeline(): Promise<void> {
   // dtype: 'q8' selects the INT8 quantized ONNX variant (model_quantized.onnx)
   // which is ~137MB for Nomic v1.5 vs ~547MB for the full FP32 model.
   //
-  // device: "cpu" — in npm mode, transformers.js uses onnxruntime-node
-  // (native CPU). In the compiled binary, onnxruntime-node is redirected
-  // to onnxruntime-web by the build plugin, which handles "cpu" via its
-  // WASM+SIMD backend (API-compatible, ~2x faster on batch workloads).
+  // device: "cpu" — the SEA binary and dev/test use the native onnxruntime-node
+  // CPU backend (multi-threaded). The npm dist-only bundle redirects
+  // onnxruntime-node → onnxruntime-web, which serves "cpu" via its WASM+SIMD
+  // backend (API-compatible).
   pipe = (await pipeline("feature-extraction", modelId, {
     dtype: "q8",
     device: "cpu",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -74,6 +74,7 @@
     "@types/qrcode-terminal": "^0.12.2",
     "@types/semver": "^7.7.1",
     "fossilize": "^0.10.1",
+    "onnxruntime-node": "1.21.0",
     "tar": "^7.4.3",
     "undici": "^7.28.0"
   }

--- a/packages/gateway/script/build-binary-sea.ts
+++ b/packages/gateway/script/build-binary-sea.ts
@@ -46,8 +46,9 @@ import { dirname, join } from "node:path";
 import { parseArgs } from "node:util";
 import { PLACEHOLDER_DEBUG_ID, injectDebugId } from "./debug-id";
 import { MODEL_DIR_NAME, MODEL_FILES } from "./vendor-paths";
-import { findOrtWebDir, ortWebRedirectPlugin } from "./ort-web-plugin";
+import { ortNativePlugin } from "./ort-native-plugin";
 import { ensureVecBinaries, vecAssetKey } from "./vendor-sqlite-vec";
+import { ortNativeAssets } from "./vendor-ort-native";
 import { fossilize } from "fossilize";
 
 const require = createRequire(import.meta.url);
@@ -189,19 +190,17 @@ function prepareVendorModelCache(target: CompileTarget): string | null {
 }
 
 // ---------------------------------------------------------------------------
-// esbuild: onnxruntime-node → onnxruntime-web (WASM) redirect
+// esbuild: native onnxruntime-node (NOT WASM) for the SEA binary
 // ---------------------------------------------------------------------------
-// The onnxruntime-node → onnxruntime-web redirect + transformers.js wasmPaths
-// patch live in the shared ./ort-web-plugin module (also used by bundle.ts).
-// The binary path vendors the WASM as SEA assets and sets
-// __LORE_VENDOR_WASM_PATHS__ on globalThis (via native-loader.cjs) before the
-// worker evaluates, so the wasmPaths replacement reads from that global.
+// The SEA binary bundles the REAL native onnxruntime-node (2.7–4.1× faster than
+// single-threaded WASM, scales with cores, no 4 GiB WASM-heap cap — #999). The
+// native addon (.node) + its shared libs ride along as per-target SEA assets
+// (staged below via ortNativeAssets) and native-loader.cjs extracts them + sets
+// globalThis.__LORE_ORT_BINDING_PATH__ before any worker evaluates; the plugin
+// rewrites onnxruntime-node's binding.js to require that path. See
+// ort-native-plugin.ts / vendor-ort-native.ts.
 function binaryExternalsPlugin(): esbuild.Plugin {
-  return ortWebRedirectPlugin({
-    repoRoot,
-    wasmPathsExpr:
-      "globalThis.__LORE_VENDOR_WASM_PATHS__ || ONNX_ENV.wasm.wasmPaths",
-  });
+  return ortNativePlugin({ repoRoot });
 }
 
 // ---------------------------------------------------------------------------
@@ -492,8 +491,8 @@ async function buildBinary() {
       stubSqliteVecPlugin(),
     ],
     inject: [
-      // Runs FIRST: extracts WASM files from SEA assets and registers
-      // __LORE_VENDOR_WASM_PATHS__ on globalThis.
+      // Runs FIRST: extracts the native onnxruntime-node addon (+ sqlite-vec)
+      // from SEA assets and registers __LORE_ORT_BINDING_PATH__ on globalThis.
       join(here, "native-loader.cjs"),
     ],
     outfile: bundlePath,
@@ -511,8 +510,6 @@ async function buildBinary() {
       // doesn't reliably produce a stringified array in esbuild).
       __LORE_MODEL_FILES__: JSON.stringify(MODEL_FILES.join(",")),
       __LORE_MODEL_DIR_NAME__: JSON.stringify(MODEL_DIR_NAME),
-      __LORE_WASM_MJS_ASSET__: JSON.stringify("ort-wasm-simd-threaded.mjs"),
-      __LORE_WASM_BIN_ASSET__: JSON.stringify("ort-wasm-simd-threaded.wasm"),
       // (No __LORE_WORKER_PATH_ENV__ — the worker is now passed as
       // a source string at runtime via globalThis.__LORE_WORKER_SOURCE__,
       // not a file path. See packages/gateway/src/cli/sea-entry.ts.)
@@ -660,38 +657,6 @@ async function buildBinary() {
   // --asset-manifest. The manifest's `entry.file` field is the asset
   // key, and `entry.src` (or `file` path) is where fossilize reads
   // the bytes from.
-  const ortWebDir = findOrtWebDir(repoRoot);
-  const wasmMjsPath = join(ortWebDir, "dist", "ort-wasm-simd-threaded.mjs");
-  const wasmBinPath = join(ortWebDir, "dist", "ort-wasm-simd-threaded.wasm");
-
-  // Patch the WASM file to disable pthread Worker spawning. Node 24
-  // doesn't expose `Worker` as a global, so the WASM file's
-  // `new Worker(new URL(import.meta.url), ...)` call fails with
-  // "Received undefined" when used from a Node CJS bundle. Since
-  // lore's workload is single-text embedding and we already force
-  // `numThreads=1` via transformers.js, pthreads aren't needed.
-  // We replace the Qb function body with a no-op. The function
-  // body is single-line in the minified WASM bundle, so a regex
-  // anchored on its declaration and the trailing `}` works.
-  const originalWasmMjs = readFileSync(wasmMjsPath, "utf-8");
-  const patchedWasmMjs = originalWasmMjs.replace(
-    /function Qb\(\)\{var a=new Worker\(new URL\(import\.meta\.url\),\{type:"module",workerData:"em-pthread",name:"em-pthread"\}\);Q\.push\(a\)\}/,
-    "function Qb(){}",
-  );
-  // Verify the patch landed before writing to avoid leaving
-  // unpatched content on disk if the upstream WASM layout changes.
-  if (!patchedWasmMjs.includes("function Qb(){}")) {
-    throw new Error(
-      "Failed to patch WASM file (Qb() regex didn't match). " +
-        "The onnxruntime-web WASM layout may have changed.",
-    );
-  }
-  // Write patched WASM to a side path so we don't mutate the source.
-  const patchedWasmMjsPath = join(stagingDir, "ort-wasm-simd-threaded.mjs");
-  writeFileSync(patchedWasmMjsPath, patchedWasmMjs);
-  const patchedWasmBinPath = join(stagingDir, "ort-wasm-simd-threaded.wasm");
-  copyFileSync(wasmBinPath, patchedWasmBinPath);
-
   // Copy each asset into the staging dir under its final key name.
   // We use a hardlink (when possible) to avoid duplicating 132 MB of
   // model files. Falls back to copyFileSync on filesystems that don't
@@ -713,11 +678,8 @@ async function buildBinary() {
     return dest;
   };
 
-  // Patched files are already in stagingDir under their final keys.
-  // No need to stage again (stageAsset would no-op or fail on
-  // src == dest).
-  // worker.cjs was already moved to stagingDir/worker.cjs by the
-  // renameSync call above. No need to stage again.
+  // worker.cjs / vector-worker.cjs were already moved to stagingDir by the
+  // renameSync calls above. No need to stage again.
 
   if (vendorModelDir) {
     for (const rel of MODEL_FILES) {
@@ -735,6 +697,32 @@ async function buildBinary() {
     stageAsset(vecAssetKey(target), binPath);
   }
 
+  // Stage the native onnxruntime-node addon + its shared libraries for every
+  // target. Like vec0, fossilize embeds one shared asset set into each binary,
+  // so we key each file as `ort-<target>-<file>`; native-loader.cjs extracts
+  // only the set matching the running platform into one dir (replicating the
+  // package's sibling layout so the addon's $ORIGIN/@loader_path/DLL-search
+  // resolution finds libonnxruntime). ~22–37 MB per target — meaningful but
+  // dwarfed by the ~137 MB embedded model. See vendor-ort-native.ts.
+  const ortAssets = ortNativeAssets(targets);
+  for (const files of ortAssets.values()) {
+    for (const { assetKey, srcPath } of files) {
+      stageAsset(assetKey, srcPath);
+    }
+  }
+  // Runtime manifest of the ORT native file set per target. native-loader.cjs
+  // reads it to learn the (version-specific, e.g. libonnxruntime.1.21.0.dylib)
+  // filenames to extract for the running platform — so filenames live in ONE
+  // place (vendor-ort-native.ts) instead of being duplicated in the loader.
+  const ortFileManifest: Record<string, string[]> = {};
+  for (const [target, files] of ortAssets) {
+    ortFileManifest[target] = files.map((f) => f.file);
+  }
+  writeFileSync(
+    join(stagingDir, "ort-manifest.json"),
+    JSON.stringify(ortFileManifest),
+  );
+
   // Write a Vite-style manifest. Fossilize uses `entry.file` as the
   // SEA asset key and joins the manifest's dir to locate the file.
   interface ManifestEntry {
@@ -744,14 +732,6 @@ async function buildBinary() {
     name?: string;
   }
   const manifest: Record<string, ManifestEntry> = {
-    "ort-wasm-simd-threaded.mjs": {
-      file: "ort-wasm-simd-threaded.mjs",
-      src: "ort-wasm-simd-threaded.mjs",
-    },
-    "ort-wasm-simd-threaded.wasm": {
-      file: "ort-wasm-simd-threaded.wasm",
-      src: "ort-wasm-simd-threaded.wasm",
-    },
     "worker.cjs": { file: "worker.cjs", src: "worker.cjs" },
     "vector-worker.cjs": {
       file: "vector-worker.cjs",
@@ -768,6 +748,15 @@ async function buildBinary() {
     const key = vecAssetKey(target);
     manifest[key] = { file: key, src: key };
   }
+  for (const files of ortAssets.values()) {
+    for (const { assetKey } of files) {
+      manifest[assetKey] = { file: assetKey, src: assetKey };
+    }
+  }
+  manifest["ort-manifest.json"] = {
+    file: "ort-manifest.json",
+    src: "ort-manifest.json",
+  };
 
   const manifestPath = join(stagingDir, "asset-manifest.json");
   writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));

--- a/packages/gateway/script/build-binary-sea.ts
+++ b/packages/gateway/script/build-binary-sea.ts
@@ -482,8 +482,9 @@ async function buildBinary() {
     target: "node22",
     platform: "node",
     conditions: ["node"],
-    // sharp is for vision models, unused. onnxruntime-node is redirected
-    // to onnxruntime-web by the plugin. The WASM runtime is API-compatible.
+    // sharp is for vision models, unused (also stubbed by the plugin).
+    // onnxruntime-node is bundled natively; ort-native-plugin patches its
+    // binding.js to load the addon extracted by native-loader.cjs.
     external: ["sharp"],
     plugins: [
       binaryExternalsPlugin(),

--- a/packages/gateway/script/native-loader.cjs
+++ b/packages/gateway/script/native-loader.cjs
@@ -1,57 +1,54 @@
 /**
- * Runtime loader for fossilize-based standalone binary.
+ * Runtime loader for the fossilize-based standalone binary.
  *
  * This file is auto-injected at the top of the bundled CJS by esbuild's
- * `inject:` config. It runs before any other module evaluates, in both
- * the main process and any worker thread spawned by it.
+ * `inject:` config. It runs before any other module evaluates, in both the main
+ * process and any worker thread spawned by it.
  *
- * The standalone binary uses the WASM backend of `@huggingface/transformers`
- * (i.e. `onnxruntime-web`'s Node entry — same approach the prior Bun
- * `--compile` build used). This is the path of least resistance: WASM
- * runs correctly under Node's V8 engine (the bugs that forced this
- * migration were specific to Bun's WASM engine — see
- * `oven-sh/bun#18145`, `#25677`, `#31158`).
+ * The standalone binary runs the REAL native `onnxruntime-node` (not the WASM
+ * `onnxruntime-web`). Native ORT is multiple times faster than the
+ * single-threaded WASM backend, scales with cores, and has no fixed 4 GiB
+ * WASM-heap ceiling (#999). esbuild can't inline a `.node` addon, so the addon
+ * (+ its shared libraries) rides along as per-target SEA assets and is extracted
+ * here at startup — exactly how the native `sqlite-vec`/vec0 extension ships.
  *
- * Responsibilities:
+ * Responsibilities (only inside a Node SEA — a no-op otherwise):
  *
- * 1. If running inside a Node SEA (fossilize binary):
- *    a. Extract the two WASM runtime files
- *       (`ort-wasm-simd-threaded.mjs` and `ort-wasm-simd-threaded.wasm`)
- *       from SEA assets to a stable tmp dir on disk.
- *    b. Register their paths on `globalThis.__LORE_VENDOR_WASM_PATHS__`
- *       so the bundled `transformers.js` (patched via the shared
- *       `ortWebRedirectPlugin` in `ort-web-plugin.ts`) can load them
- *       without going to the CDN fallback.
+ *   1. Extract the native onnxruntime-node addon + its shared libraries for the
+ *      running platform into a per-pid tmp dir (replicating the package's
+ *      sibling layout so the addon's $ORIGIN/@loader_path/DLL-search resolution
+ *      finds `libonnxruntime`), and register the addon path on
+ *      `globalThis.__LORE_ORT_BINDING_PATH__`. The bundled onnxruntime-node's
+ *      `binding.js` is patched (see `ort-native-plugin.ts`) to `require` that
+ *      path instead of the node_modules-relative one that doesn't exist here.
  *
- * 2. If NOT running inside a SEA (npm CJS bundle, dev mode, tests):
- *    Do nothing. The npm CJS bundle handles WASM itself — it ships
- *    `ort-wasm-simd-threaded.{mjs,wasm}` in `dist/` and `embedding-worker.ts`
- *    registers `globalThis.__LORE_NPM_WASM_PATHS__` at runtime (also patched
- *    away from the CDN by `ortWebRedirectPlugin`). Dev/test use the real
- *    native `onnxruntime-node` from `node_modules`.
+ *   2. Extract the native `sqlite-vec` loadable extension and register it on
+ *      `globalThis.__LORE_VEC_EXTENSION_PATH__` (preferred by `db/vec.ts`).
  *
- * The extraction uses a per-pid tmp dir, so each process gets a
- * fresh copy. The OS reaps /tmp on reboot, so disk leaks are
- * bounded. The `--worker` argv flag causes the binary to run as a
- * worker thread (see sea-entry.ts); the shim is harmless in worker
- * mode — both threads need their own copy of the WASM files (cheap
- * at ~11 MB and avoids cross-thread fs races).
+ * Outside a SEA (npm CJS bundle, dev mode, tests): do nothing. The npm bundle
+ * uses the WASM backend and ships `ort-wasm-simd-threaded.{mjs,wasm}` in `dist/`
+ * (see `ort-web-plugin.ts` / `bundle.ts`); dev/test use the real native
+ * `onnxruntime-node` from `node_modules` directly.
  *
- * IMPORTANT: This file is intentionally CJS (not TS) so esbuild's
- * `inject:` mechanism treats it as the very first module in the bundle
- * without any transpilation or hoisting surprises. The corresponding
- * `node:sea` and `node:fs` requires are Node built-ins and resolve
- * at runtime.
+ * The extraction uses a per-pid tmp dir so concurrent worker threads don't race,
+ * and the OS reaps /tmp on reboot so disk leaks are bounded. NOTE: like the
+ * pre-existing vec0 extraction, the addon is `dlopen`ed from /tmp — a `noexec`
+ * /tmp mount makes both fall back (native ORT → FTS-only; vec0 → JS scan).
+ *
+ * IMPORTANT: This file is intentionally CJS (not TS) so esbuild's `inject:`
+ * mechanism treats it as the very first module in the bundle without any
+ * transpilation or hoisting surprises. The `node:*` requires are Node built-ins
+ * and resolve at runtime.
  */
 "use strict";
 
 // Idempotency guard: if the shim already ran in this process, exit.
-if (globalThis.__LORE_WASM_READY__) {
+if (globalThis.__LORE_NATIVE_READY__) {
   // No-op on second injection.
 } else {
-  // Detect SEA mode. `node:sea` is only available in Node 20+; the
-  // require itself is safe to attempt because Node throws synchronously
-  // if the module doesn't exist, which we catch and treat as "not SEA".
+  // Detect SEA mode. `node:sea` is only available in Node 20+; the require
+  // itself is safe to attempt because Node throws synchronously if the module
+  // doesn't exist, which we catch and treat as "not SEA".
   let isSea = false;
   try {
     isSea = require("node:sea").isSea();
@@ -64,65 +61,56 @@ if (globalThis.__LORE_WASM_READY__) {
     const path = require("node:path");
     const os = require("node:os");
     const sea = require("node:sea");
+    const { isMainThread } = require("node:worker_threads");
 
-    // Expose `Worker` as a global so the WASM runtime (loaded via
-    // dynamic `import()`) can spawn pthreads. Node doesn't ship
-    // `Worker` as a global — only via `require("node:worker_threads")`
-    // — but the WASM bundle references it as a free variable. Bun's
-    // runtime provides it natively; under Node we polyfill it here.
-    // (The original Bun-compiled binary worked for this same reason.)
-    if (typeof globalThis.Worker === "undefined") {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      globalThis.Worker = require("node:worker_threads").Worker;
-    }
-
-    // The WASM runtime's `new Worker(new URL(import.meta.url), ...)`
-    // call expects `import.meta.url` to be a string. When the WASM file
-    // is loaded as ESM in a CJS bundle, this works. But the Worker
-    // constructor in Node also needs the URL to be parseable as a
-    // file URL or string. We ensure the path is absolute so the URL
-    // conversion always succeeds.
-    // (No-op — handled by the WASM file's URL construction.)
-
-    // Per-pid tmp dir so concurrent worker threads don't race on file
-    // writes. The OS reaps /tmp on reboot, so leaks are bounded.
-    const targetDir = path.join(os.tmpdir(), "lore-wasm", `pid-${process.pid}`);
-
-    // The two WASM runtime files we need. The asset keys are the
-    // paths passed to fossilize's --assets flag (see build-binary-sea.ts).
-    const wasmMjsKey =
-      typeof __LORE_WASM_MJS_ASSET__ === "string"
-        ? __LORE_WASM_MJS_ASSET__
-        : "ort-wasm-simd-threaded.mjs";
-    const wasmBinKey =
-      typeof __LORE_WASM_BIN_ASSET__ === "string"
-        ? __LORE_WASM_BIN_ASSET__
-        : "ort-wasm-simd-threaded.wasm";
-
+    // Per-pid tmp dir so concurrent worker threads don't race on file writes.
+    const targetDir = path.join(
+      os.tmpdir(),
+      "lore-native",
+      `pid-${process.pid}`,
+    );
     fs.mkdirSync(targetDir, { recursive: true });
-    const mjsPath = path.join(targetDir, "ort-wasm-simd-threaded.mjs");
-    const wasmPath = path.join(targetDir, "ort-wasm-simd-threaded.wasm");
-    fs.writeFileSync(mjsPath, Buffer.from(sea.getRawAsset(wasmMjsKey)));
-    fs.writeFileSync(wasmPath, Buffer.from(sea.getRawAsset(wasmBinKey)));
 
-    // Register for the bundled transformers.js (patched via
-    // binaryExternalsPlugin to read wasmPaths from this global).
-    // On Windows, absolute paths (e.g. C:\...) passed to dynamic
-    // import() are rejected because 'C:' looks like a URL scheme.
-    // Convert the mjs path to a file:// URL so the ESM loader
-    // accepts it on all platforms. The wasm path is read via fs
-    // (not import()), so it stays as a plain file path.
-    globalThis.__LORE_VENDOR_WASM_PATHS__ = {
-      mjs: require("node:url").pathToFileURL(mjsPath).href,
-      wasm: wasmPath,
+    // The main thread runs first (at startup, before any worker spawns) and
+    // (re)writes unconditionally — overwriting any stale file from a reused pid.
+    // Worker threads share the pid/tmp dir, so they skip the write when the main
+    // thread already produced it: avoids a concurrent-write race on the shared
+    // path while still self-healing if it's somehow absent.
+    const writeAsset = (dest, key) => {
+      if (isMainThread || !fs.existsSync(dest)) {
+        fs.writeFileSync(dest, Buffer.from(sea.getRawAsset(key)));
+      }
     };
 
-    // sqlite-vec native loadable extension. The build embeds one binary per
-    // target as `vec0-<target>.<ext>` (see vendor-sqlite-vec.ts /
-    // build-binary-sea.ts). Extract only the one matching this platform and
-    // register its path; `db/vec.ts` prefers globalThis.__LORE_VEC_EXTENSION_PATH__
-    // over the (stubbed) npm wrapper. Runs in worker threads too (the vector
-    // pool's reader connections load it) — each thread has its own globalThis.
+    // 1. Native onnxruntime-node addon + shared libraries. The build embeds one
+    //    set per target as `ort-<target>-<file>` plus an `ort-manifest.json`
+    //    listing the (version-specific) filenames per target. Extract only the
+    //    running platform's set into `targetDir` and register the addon path.
+    try {
+      const ortTarget = `${process.platform === "win32" ? "windows" : process.platform}-${process.arch}`;
+      const ortManifest = JSON.parse(
+        Buffer.from(sea.getRawAsset("ort-manifest.json")).toString("utf8"),
+      );
+      const files = ortManifest[ortTarget];
+      if (Array.isArray(files) && files.length > 0) {
+        for (const f of files) {
+          writeAsset(path.join(targetDir, f), `ort-${ortTarget}-${f}`);
+        }
+        globalThis.__LORE_ORT_BINDING_PATH__ = path.join(
+          targetDir,
+          "onnxruntime_binding.node",
+        );
+      }
+    } catch {
+      // Asset missing / extraction failed — leave the global unset. The patched
+      // binding.js then throws a clear error, the embedding provider marks
+      // itself unavailable, and search degrades to FTS-only.
+    }
+
+    // 2. sqlite-vec native loadable extension. Extract the one matching this
+    //    platform and register its path; `db/vec.ts` prefers this global over
+    //    the (stubbed) npm wrapper. Runs in worker threads too (the vector
+    //    pool's reader connections load it) — each thread has its own globalThis.
     try {
       const vecOs = process.platform === "win32" ? "windows" : process.platform;
       const vecExt =
@@ -133,21 +121,13 @@ if (globalThis.__LORE_WASM_READY__) {
             : "so";
       const vecKey = `vec0-${vecOs}-${process.arch}.${vecExt}`;
       const vecPath = path.join(targetDir, `vec0.${vecExt}`);
-      // The main thread runs first (at startup, before any worker spawns) and
-      // (re)writes unconditionally — overwriting any stale file from a reused
-      // pid. Worker threads share the pid/tmp dir, so they skip the write when
-      // the main thread already produced it: this avoids a concurrent-write
-      // race on the shared path while still self-healing if it's somehow absent.
-      const { isMainThread } = require("node:worker_threads");
-      if (isMainThread || !fs.existsSync(vecPath)) {
-        fs.writeFileSync(vecPath, Buffer.from(sea.getRawAsset(vecKey)));
-      }
+      writeAsset(vecPath, vecKey);
       globalThis.__LORE_VEC_EXTENSION_PATH__ = vecPath;
     } catch {
       // Asset absent (build without vec staging) or extraction failed — leave
       // the global unset so db/vec.ts uses the JS brute-force fallback.
     }
 
-    globalThis.__LORE_WASM_READY__ = true;
+    globalThis.__LORE_NATIVE_READY__ = true;
   }
 }

--- a/packages/gateway/script/ort-native-plugin.ts
+++ b/packages/gateway/script/ort-native-plugin.ts
@@ -1,0 +1,89 @@
+/**
+ * esbuild plugin: bundle the REAL native `onnxruntime-node` (not the WASM
+ * `onnxruntime-web`) for the standalone SEA binary.
+ *
+ * Native ORT is 2.7–4.1× faster than the single-threaded WASM backend we shipped
+ * before, scales with cores, and has no fixed 4 GiB WASM-heap ceiling (#999).
+ * The WASM backend was only ever chosen because Bun's WASM engine had bugs
+ * (oven-sh/bun#18145/#25677/#31158) and esbuild can't inline a `.node` addon —
+ * both moot now: we're on Node SEA, and the addon rides along as a per-target
+ * SEA asset that `native-loader.cjs` extracts at runtime (exactly how the native
+ * `sqlite-vec`/vec0 extension already ships).
+ *
+ * What this plugin does (vs the WASM `ortWebRedirectPlugin`):
+ *   1. Stub `sharp` (vision models, unused for text embeddings) → empty module.
+ *   2. Stub `onnxruntime-web` → empty module. transformers.js unconditionally
+ *      `import * as ONNX_WEB from 'onnxruntime-web'`, but under Node
+ *      (`apis.IS_NODE_ENV`) it selects `ONNX_NODE` and only touches `ONNX_WEB`
+ *      in the unreachable browser branch — so stubbing it avoids bundling the
+ *      ~MBs of WASM glue (and shipping the `.wasm`) with zero behavioral change.
+ *   3. Rewrite `onnxruntime-node`'s `binding.js` native-addon `require(...)` —
+ *      which resolves `../bin/napi-v3/<platform>/<arch>/onnxruntime_binding.node`
+ *      relative to node_modules (absent in a SEA) — to require the path
+ *      `native-loader.cjs` exposes on `globalThis.__LORE_ORT_BINDING_PATH__`
+ *      after extracting the addon from a SEA asset.
+ *
+ * There is NO `onnxruntime-node` → web redirect and NO transformers CDN
+ * `wasmPaths` patch: native ORT never loads WASM, so the CDN assignment (which
+ * targets the selected backend's unused `env.wasm`) is dead and harmless.
+ */
+import { readFileSync } from "node:fs";
+import { dirname } from "node:path";
+import type * as esbuild from "esbuild";
+
+/** The exact native-addon `require` in onnxruntime-node@1.21's `dist/binding.js`
+ *  (a tagged-template path). Matching it precisely lets us fail loudly if a
+ *  future bump changes the shape, rather than silently shipping a broken addon
+ *  loader. */
+const ORT_BINDING_REQUIRE =
+  /require\(`\.\.\/bin\/napi-v3\/\$\{process\.platform\}\/\$\{process\.arch\}\/onnxruntime_binding\.node`\)/;
+
+/** Replacement: require the runtime-extracted addon path, throwing a clear error
+ *  if the loader shim didn't run (so a broken SEA fails loudly, not with a
+ *  cryptic "path must be a string, received undefined"). */
+const ORT_BINDING_REPLACEMENT =
+  'require((globalThis.__LORE_ORT_BINDING_PATH__ ?? (() => { throw new Error("lore: __LORE_ORT_BINDING_PATH__ is unset — the native onnxruntime-node addon was not extracted from SEA assets (native-loader.cjs did not run?)"); })()))';
+
+export interface OrtNativePluginOptions {
+  /** Monorepo root (reserved for symmetry with ortWebRedirectPlugin; unused). */
+  repoRoot?: string;
+}
+
+export function ortNativePlugin(
+  _opts: OrtNativePluginOptions = {},
+): esbuild.Plugin {
+  return {
+    name: "ort-native",
+    setup(build) {
+      // 1 + 2: stub sharp and onnxruntime-web as empty modules.
+      build.onResolve({ filter: /^(sharp|onnxruntime-web)$/ }, (args) => ({
+        path: args.path,
+        namespace: "ort-native-empty",
+      }));
+      build.onLoad({ filter: /.*/, namespace: "ort-native-empty" }, () => ({
+        contents: "module.exports = {};",
+        loader: "js",
+      }));
+
+      // 3: rewrite the native-addon require in onnxruntime-node's binding.js.
+      build.onLoad(
+        { filter: /onnxruntime-node[\\/]dist[\\/]binding\.js$/ },
+        (args) => {
+          const src = readFileSync(args.path, "utf8");
+          if (!ORT_BINDING_REQUIRE.test(src)) {
+            throw new Error(
+              `ort-native-plugin: expected native-addon require not found in ` +
+                `${args.path}. onnxruntime-node likely changed binding.js — ` +
+                `update ORT_BINDING_REQUIRE in ort-native-plugin.ts.`,
+            );
+          }
+          return {
+            contents: src.replace(ORT_BINDING_REQUIRE, ORT_BINDING_REPLACEMENT),
+            loader: "js",
+            resolveDir: dirname(args.path),
+          };
+        },
+      );
+    },
+  };
+}

--- a/packages/gateway/script/ort-web-plugin.ts
+++ b/packages/gateway/script/ort-web-plugin.ts
@@ -1,17 +1,17 @@
 /**
- * Shared esbuild plugin: redirect `onnxruntime-node` → `onnxruntime-web`
- * (WASM, Node entry) and patch transformers.js' CDN wasmPaths fallback.
+ * esbuild plugin: redirect `onnxruntime-node` → `onnxruntime-web` (WASM, Node
+ * entry) and patch transformers.js' CDN wasmPaths fallback.
  *
- * Used by both build pipelines:
- *   - `build-binary-sea.ts` (standalone binary): vendors WASM as SEA assets
- *     and sets `globalThis.__LORE_VENDOR_WASM_PATHS__` at runtime.
- *   - `bundle.ts` (npm package): ships the WASM files in `dist/` and sets
- *     `globalThis.__LORE_NPM_WASM_PATHS__` at runtime (see embedding-worker.ts).
- *
- * Without this redirect, the npm worker bundle leaves `onnxruntime-node`
- * (a native `.node` backend that esbuild can't bundle) as an external
- * `require`, which fails for dist-only installs (npm/AUR) with
+ * Used ONLY by `bundle.ts` (the npm package): it ships the WASM files in `dist/`
+ * and sets `globalThis.__LORE_NPM_WASM_PATHS__` at runtime (see
+ * embedding-worker.ts). Without this redirect, the npm worker bundle leaves
+ * `onnxruntime-node` (a native `.node` backend that esbuild can't bundle) as an
+ * external `require`, which fails for dist-only installs (npm/AUR) with
  * "Cannot find module 'onnxruntime-node'" (see GitHub issue #763).
+ *
+ * The standalone SEA binary does NOT use this: it bundles the native
+ * onnxruntime-node addon as a per-target SEA asset (see `ort-native-plugin.ts`),
+ * which is faster and has no 4 GiB WASM-heap cap (#999).
  */
 import { existsSync, readFileSync } from "node:fs";
 import { createRequire } from "node:module";
@@ -50,9 +50,8 @@ export interface OrtWebPluginOptions {
   repoRoot: string;
   /**
    * The replacement RHS for transformers.js' `ONNX_ENV.wasm.wasmPaths = <CDN>`
-   * assignment. The value is read at runtime to locate the local WASM files:
-   *   - binary: `globalThis.__LORE_VENDOR_WASM_PATHS__ || ONNX_ENV.wasm.wasmPaths`
-   *   - npm:    `globalThis.__LORE_NPM_WASM_PATHS__ || ONNX_ENV.wasm.wasmPaths`
+   * assignment. The value is read at runtime to locate the local WASM files
+   * (npm path): `globalThis.__LORE_NPM_WASM_PATHS__ || ONNX_ENV.wasm.wasmPaths`.
    */
   wasmPathsExpr: string;
 }

--- a/packages/gateway/script/vendor-ort-native.ts
+++ b/packages/gateway/script/vendor-ort-native.ts
@@ -1,0 +1,180 @@
+/**
+ * Vendor the native `onnxruntime-node` runtime for every build target.
+ *
+ * The SEA (fossilize) binary has no `node_modules`, so `onnxruntime-node`'s
+ * `binding.js` — which does `require("../bin/napi-v3/<platform>/<arch>/
+ * onnxruntime_binding.node")` — can't find its native addon inside the binary.
+ * Instead we embed the addon + its shared libraries as SEA assets (one set per
+ * target) and extract them at runtime (see `native-loader.cjs`, which sets
+ * `globalThis.__LORE_ORT_BINDING_PATH__`, the path the patched `binding.js`
+ * requires — see `ort-native-plugin.ts`).
+ *
+ * Unlike `sqlite-vec` (whose per-platform binaries live in separate npm
+ * packages), `onnxruntime-node` ships EVERY platform's binaries in one package
+ * under `bin/napi-v3/<platform>/<arch>/`. So there is no download step: we copy
+ * straight from the installed package. Lore's SEA builds are cross-platform (a
+ * single Linux host stages linux/windows and prepares darwin for the macOS
+ * `--from-staging` job), and every target's files are present in `node_modules`,
+ * so one host can stage all of them.
+ *
+ * The addon resolves its sibling `libonnxruntime.*` via `$ORIGIN` (linux
+ * RUNPATH), `@loader_path` (darwin), and same-directory DLL search (windows) —
+ * so extracting the whole set into ONE directory replicates the package's own
+ * sibling layout and resolution works by construction (it works in node_modules
+ * because they are siblings there too).
+ *
+ * Runs under Node (via tsx). Safe to import for its helpers — no side effects
+ * until `ortNativeAssets` / the CLI runs.
+ */
+import { existsSync, readdirSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseArgs } from "node:util";
+import { VENDOR_TARGETS, type VendorTarget } from "./vendor-paths";
+
+const require = createRequire(import.meta.url);
+
+const here = dirname(fileURLToPath(import.meta.url));
+const packageDir = dirname(here);
+const repoRoot = dirname(dirname(packageDir));
+
+/** Map a build target to onnxruntime-node's `bin/napi-v3/<platform>/<arch>`
+ *  subdirectory (Node's `process.platform`/`process.arch` naming). */
+const ORT_TARGET_SUBDIR: Record<VendorTarget, string> = {
+  "darwin-arm64": "darwin/arm64",
+  "linux-arm64": "linux/arm64",
+  "linux-x64": "linux/x64",
+  "windows-x64": "win32/x64",
+};
+
+/** The native addon file `binding.js` loads (constant across platforms). The
+ *  runtime loader points `__LORE_ORT_BINDING_PATH__` at the extracted copy. */
+export const ORT_BINDING_FILE = "onnxruntime_binding.node";
+
+/** The SEA asset key for one of a target's native files. `native-loader.cjs`
+ *  recomputes the same key from `process.platform`/`process.arch` at runtime,
+ *  so keep the two in sync. Filenames are flat (no path separators) so a simple
+ *  `ort-<target>-<file>` key is unambiguous. */
+export function ortAssetKey(target: VendorTarget, file: string): string {
+  return `ort-${target}-${file}`;
+}
+
+/** Resolve onnxruntime-node's package root (it's a transitive dep via
+ *  @huggingface/transformers, and a devDependency of the gateway/core). */
+function ortNodeDir(): string {
+  const pjPath = require.resolve("onnxruntime-node/package.json", {
+    paths: [packageDir, join(repoRoot, "packages/core")],
+  });
+  return dirname(pjPath);
+}
+
+/** onnxruntime-node's resolved version (keeps embedded libs ABI-matched to the
+ *  `binding.js` we bundle + patch). */
+export function ortNodeVersion(): string {
+  const pjPath = require.resolve("onnxruntime-node/package.json", {
+    paths: [packageDir, join(repoRoot, "packages/core")],
+  });
+  const v = JSON.parse(require("node:fs").readFileSync(pjPath, "utf8")).version;
+  if (typeof v !== "string" || v.length === 0) {
+    throw new Error(
+      "vendor-ort-native: could not determine onnxruntime-node version",
+    );
+  }
+  return v;
+}
+
+/**
+ * The set of files to embed for `target`: every file in the platform's bin dir,
+ * MINUS longer-versioned aliases of another file. e.g. linux ships both
+ * `libonnxruntime.so.1` (the SONAME the addon's NEEDED entry references) and
+ * `libonnxruntime.so.1.21.0` (identical bytes); we keep the SONAME and drop the
+ * duplicate to avoid embedding ~21 MB twice. darwin's `libonnxruntime.1.21.0.
+ * dylib` has no shorter alias so it's kept; windows' `onnxruntime.dll` /
+ * `DirectML.dll` are kept. Version-robust: no hard-coded library filenames.
+ */
+function targetFiles(dir: string): string[] {
+  const all = readdirSync(dir).filter((f) => !f.startsWith("."));
+  // Drop F when some other G is a strict prefix of F followed by "." — i.e. F is
+  // a longer-versioned alias (libX.so.1.21.0 vs the SONAME libX.so.1).
+  return all.filter((f) => !all.some((g) => g !== f && f.startsWith(`${g}.`)));
+}
+
+/** Absolute source path + asset key for every native file of every target.
+ *  Returns target → array of { assetKey, srcPath }. No caching/download needed:
+ *  onnxruntime-node ships all platforms in node_modules. */
+export function ortNativeAssets(
+  targets: readonly VendorTarget[],
+): Map<
+  VendorTarget,
+  Array<{ assetKey: string; srcPath: string; file: string }>
+> {
+  const binRoot = join(ortNodeDir(), "bin", "napi-v3");
+  const out = new Map<
+    VendorTarget,
+    Array<{ assetKey: string; srcPath: string; file: string }>
+  >();
+  for (const target of targets) {
+    const dir = join(binRoot, ORT_TARGET_SUBDIR[target]);
+    if (!existsSync(dir)) {
+      throw new Error(
+        `vendor-ort-native: onnxruntime-node bin dir missing for ${target}: ${dir}`,
+      );
+    }
+    const files = targetFiles(dir);
+    if (!files.includes(ORT_BINDING_FILE)) {
+      throw new Error(
+        `vendor-ort-native: ${ORT_BINDING_FILE} not found for ${target} in ${dir}`,
+      );
+    }
+    out.set(
+      target,
+      files.map((file) => ({
+        file,
+        assetKey: ortAssetKey(target, file),
+        srcPath: join(dir, file),
+      })),
+    );
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// CLI: `tsx script/vendor-ort-native.ts [--platforms a,b,c]`
+// ---------------------------------------------------------------------------
+async function main(): Promise<void> {
+  const { values } = parseArgs({
+    args: process.argv.slice(2),
+    options: { platforms: { type: "string" } },
+    allowPositionals: false,
+    strict: true,
+  });
+  const targets = (
+    values.platforms
+      ? values.platforms
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean)
+      : VENDOR_TARGETS
+  ) as VendorTarget[];
+  for (const t of targets) {
+    if (!VENDOR_TARGETS.includes(t)) {
+      console.error(`Invalid target: ${t}`);
+      console.error(`Valid targets: ${VENDOR_TARGETS.join(", ")}`);
+      process.exit(1);
+    }
+  }
+  console.log(
+    `→ vendor onnxruntime-node ${ortNodeVersion()}: ${targets.join(", ")}`,
+  );
+  const assets = ortNativeAssets(targets);
+  for (const [t, files] of assets) {
+    console.log(`✓ ${t}:`);
+    for (const { file, srcPath } of files)
+      console.log(`    ${file}  ←  ${srcPath}`);
+  }
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  await main();
+}

--- a/packages/gateway/src/cli/sea-entry.ts
+++ b/packages/gateway/src/cli/sea-entry.ts
@@ -5,8 +5,8 @@
  *
  * Architecture:
  * - The native loader shim (auto-injected by esbuild's `inject:`)
- *   runs FIRST and extracts the WASM runtime files to a per-pid
- *   tmp dir.
+ *   runs FIRST and extracts the native onnxruntime-node addon (+ the
+ *   sqlite-vec extension) to a per-pid tmp dir.
  * - This file (sea-entry.ts) reads the embedding worker source
  *   from a SEA asset and exposes it via
  *   `globalThis.__LORE_WORKER_SOURCE__` so `embedding.ts` can

--- a/packages/gateway/test/vendor-ort-native.test.ts
+++ b/packages/gateway/test/vendor-ort-native.test.ts
@@ -1,0 +1,109 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+import {
+  ORT_BINDING_FILE,
+  ortAssetKey,
+  ortNativeAssets,
+} from "../script/vendor-ort-native";
+import { VENDOR_TARGETS, type VendorTarget } from "../script/vendor-paths";
+
+// The SEA native-ORT path has THREE copies of the target→asset-key derivation
+// that MUST agree, or a platform silently loses local embeddings (getRawAsset
+// throws → FTS fallback) with no build-time error:
+//   1. build-binary-sea.ts stages assets as `ort-<target>-<file>` (ortAssetKey)
+//      and writes ort-manifest.json keyed by VendorTarget.
+//   2. native-loader.cjs (runtime) derives `ortTarget` from process.platform/
+//      arch and reads `ort-${ortTarget}-${f}` + `ortManifest[ortTarget]`.
+//   3. This test pins both to the (platform, arch) → VendorTarget mapping.
+// The Windows case is the trap: build target is "windows-x64" but
+// process.platform is "win32", so the loader MUST map win32→windows.
+
+/** The (process.platform, process.arch) each build target runs on. */
+const RUNTIME_PLATFORM: Record<
+  VendorTarget,
+  { platform: string; arch: string }
+> = {
+  "darwin-arm64": { platform: "darwin", arch: "arm64" },
+  "linux-arm64": { platform: "linux", arch: "arm64" },
+  "linux-x64": { platform: "linux", arch: "x64" },
+  "windows-x64": { platform: "win32", arch: "x64" },
+};
+
+/** EXACT replica of native-loader.cjs's runtime `ortTarget` derivation. If you
+ *  change this, change native-loader.cjs (and vice versa) — the source-level
+ *  assertions below guard that the loader still uses this shape. */
+function runtimeTarget(platform: string, arch: string): string {
+  return `${platform === "win32" ? "windows" : platform}-${arch}`;
+}
+
+const here = dirname(fileURLToPath(import.meta.url));
+const loaderSrc = readFileSync(
+  join(here, "..", "script", "native-loader.cjs"),
+  "utf8",
+);
+
+describe("vendor-ort-native ⇄ native-loader key contract", () => {
+  test("runtime (platform,arch) derivation reproduces the VendorTarget", () => {
+    for (const target of VENDOR_TARGETS) {
+      const { platform, arch } = RUNTIME_PLATFORM[target];
+      expect(runtimeTarget(platform, arch)).toBe(target);
+    }
+  });
+
+  test("windows maps win32→windows (the danger case)", () => {
+    expect(runtimeTarget("win32", "x64")).toBe("windows-x64");
+    // The asset key the loader computes on Windows must match the build's key.
+    expect(`ort-${runtimeTarget("win32", "x64")}-${ORT_BINDING_FILE}`).toBe(
+      ortAssetKey("windows-x64", ORT_BINDING_FILE),
+    );
+  });
+
+  test("build asset key === loader-derived asset key for every target", () => {
+    for (const target of VENDOR_TARGETS) {
+      const { platform, arch } = RUNTIME_PLATFORM[target];
+      const loaderKey = `ort-${runtimeTarget(platform, arch)}-${ORT_BINDING_FILE}`;
+      expect(ortAssetKey(target, ORT_BINDING_FILE)).toBe(loaderKey);
+    }
+  });
+
+  test("native-loader.cjs still uses the matching key shape + constants", () => {
+    // Binds the loader text so a divergent edit on either side fails here.
+    expect(loaderSrc).toContain('process.platform === "win32" ? "windows"');
+    expect(loaderSrc).toContain("`ort-${ortTarget}-${f}`");
+    expect(loaderSrc).toContain('"ort-manifest.json"');
+    expect(loaderSrc).toContain('"onnxruntime_binding.node"');
+    expect(loaderSrc).toContain("__LORE_ORT_BINDING_PATH__");
+  });
+});
+
+describe("vendor-ort-native asset selection (real package)", () => {
+  const assets = ortNativeAssets(VENDOR_TARGETS);
+
+  test("every target includes the addon and keys match ortAssetKey", () => {
+    for (const target of VENDOR_TARGETS) {
+      const files = assets.get(target);
+      expect(files, `${target} has staged files`).toBeTruthy();
+      const names = files!.map((f) => f.file);
+      expect(names).toContain(ORT_BINDING_FILE);
+      for (const { file, assetKey } of files!) {
+        expect(assetKey).toBe(ortAssetKey(target, file));
+      }
+    }
+  });
+
+  test("alias-drop keeps the linux SONAME and skips the versioned duplicate", () => {
+    const linux = assets.get("linux-x64")!.map((f) => f.file);
+    expect(linux).toContain("libonnxruntime.so.1");
+    // The identical, longer-versioned alias must NOT be embedded twice.
+    expect(linux).not.toContain("libonnxruntime.so.1.21.0");
+  });
+
+  test("darwin keeps its version-named dylib (no shorter alias to drop)", () => {
+    const darwin = assets.get("darwin-arm64")!.map((f) => f.file);
+    expect(darwin.some((f) => /^libonnxruntime\..*\.dylib$/.test(f))).toBe(
+      true,
+    );
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,6 +137,9 @@ importers:
       fossilize:
         specifier: ^0.10.1
         version: 0.10.1
+      onnxruntime-node:
+        specifier: 1.21.0
+        version: 1.21.0
       tar:
         specifier: ^7.4.3
         version: 7.5.16
@@ -6233,8 +6236,7 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  boolean@3.2.0:
-    optional: true
+  boolean@3.2.0: {}
 
   bowser@2.14.1: {}
 
@@ -6397,14 +6399,12 @@ snapshots:
       es-define-property: 1.0.1
       es-errors: 1.3.0
       gopd: 1.2.0
-    optional: true
 
   define-properties@1.2.1:
     dependencies:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
-    optional: true
 
   defu@6.1.7: {}
 
@@ -6419,8 +6419,7 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  detect-node@2.1.0:
-    optional: true
+  detect-node@2.1.0: {}
 
   devalue@5.8.1: {}
 
@@ -6491,8 +6490,7 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
 
-  es6-error@4.1.1:
-    optional: true
+  es6-error@4.1.1: {}
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -6541,8 +6539,7 @@ snapshots:
 
   escape-html@1.0.3: {}
 
-  escape-string-regexp@4.0.0:
-    optional: true
+  escape-string-regexp@4.0.0: {}
 
   escape-string-regexp@5.0.0: {}
 
@@ -6765,13 +6762,11 @@ snapshots:
       roarr: 2.15.4
       semver: 7.8.4
       serialize-error: 7.0.1
-    optional: true
 
   globalthis@1.0.4:
     dependencies:
       define-properties: 1.2.1
       gopd: 1.2.0
-    optional: true
 
   google-auth-library@10.7.0:
     dependencies:
@@ -6821,7 +6816,6 @@ snapshots:
   has-property-descriptors@1.0.2:
     dependencies:
       es-define-property: 1.0.1
-    optional: true
 
   has-symbols@1.1.0: {}
 
@@ -7155,8 +7149,7 @@ snapshots:
 
   json-schema-traverse@1.0.0: {}
 
-  json-stringify-safe@5.0.1:
-    optional: true
+  json-stringify-safe@5.0.1: {}
 
   json5@2.2.3: {}
 
@@ -7236,7 +7229,6 @@ snapshots:
   matcher@3.0.0:
     dependencies:
       escape-string-regexp: 4.0.0
-    optional: true
 
   math-intrinsics@1.1.0: {}
 
@@ -7776,8 +7768,7 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
-  object-keys@1.1.1:
-    optional: true
+  object-keys@1.1.1: {}
 
   obug@2.1.2: {}
 
@@ -7799,8 +7790,7 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
-  onnxruntime-common@1.21.0:
-    optional: true
+  onnxruntime-common@1.21.0: {}
 
   onnxruntime-common@1.22.0-dev.20250409-89f8206ba4:
     optional: true
@@ -7810,7 +7800,6 @@ snapshots:
       global-agent: 3.0.0
       onnxruntime-common: 1.21.0
       tar: 7.5.16
-    optional: true
 
   onnxruntime-web@1.22.0-dev.20250409-89f8206ba4:
     dependencies:
@@ -8218,7 +8207,6 @@ snapshots:
       json-stringify-safe: 5.0.1
       semver-compare: 1.0.0
       sprintf-js: 1.1.3
-    optional: true
 
   rollup@4.62.0:
     dependencies:
@@ -8261,8 +8249,7 @@ snapshots:
 
   sax@1.6.0: {}
 
-  semver-compare@1.0.0:
-    optional: true
+  semver-compare@1.0.0: {}
 
   semver@6.3.1: {}
 
@@ -8277,7 +8264,6 @@ snapshots:
   serialize-error@7.0.1:
     dependencies:
       type-fest: 0.13.1
-    optional: true
 
   sharp@0.34.5:
     dependencies:
@@ -8380,8 +8366,7 @@ snapshots:
 
   split2@4.2.0: {}
 
-  sprintf-js@1.1.3:
-    optional: true
+  sprintf-js@1.1.3: {}
 
   sqlite-vec-darwin-arm64@0.1.9:
     optional: true
@@ -8539,8 +8524,7 @@ snapshots:
 
   tunnel@0.0.6: {}
 
-  type-fest@0.13.1:
-    optional: true
+  type-fest@0.13.1: {}
 
   typebox@1.1.38: {}
 


### PR DESCRIPTION
## What

Switch the standalone SEA binary's embedding backend from the single-threaded WASM runtime (`onnxruntime-web`) to the **native `onnxruntime-node`** addon. The npm bundle is unchanged (still WASM — see below).

## Why

WASM was only ever chosen because Bun's WASM engine had bugs (oven-sh/bun#18145/#25677/#31158) and esbuild can't inline a `.node` addon. **Both are moot now:** we're on Node SEA, and the addon rides along as a per-target SEA asset — exactly how the native `sqlite-vec`/vec0 extension already ships.

Measured native vs the production WASM config (`numThreads=1`) on a 4-core box, same nomic q8 model:

| Input tokens | Native | WASM (numThreads=1) | Native speedup |
|---|---|---|---|
| 256 | 813 ms | 2,203 ms | **2.7×** |
| 512 | 1,058 ms | 4,358 ms | **4.1×** |

The gap widens with sequence length and core count (WASM stays single-threaded; native scales with cores). Native also has no fixed 4 GiB WASM-heap ceiling (the #999 OOM class).

## How (mirrors the existing vec0 native-extension staging)

- **`vendor-ort-native.ts`** — locate onnxruntime-node's per-target native files. The package ships every platform under `bin/napi-v3/<platform>/<arch>/`, so all 4 targets stage from one build host (no download). A *"drop longer-versioned alias"* rule keeps the SONAME the addon needs (`libonnxruntime.so.1`) and skips the identical `.so.1.21.0` duplicate — version-robust, no hard-coded lib names.
- **`ort-native-plugin.ts`** — esbuild plugin that (1) stubs `sharp` + `onnxruntime-web` (transformers imports `ONNX_WEB` unconditionally but only uses it in the unreachable browser branch under `IS_NODE_ENV`), and (2) rewrites `onnxruntime-node/binding.js`'s `require("../bin/.../onnxruntime_binding.node")` to require `globalThis.__LORE_ORT_BINDING_PATH__`, throwing loudly if unset.
- **`build-binary-sea.ts`** — use the native plugin; stage each target's addon + shared libs as `ort-<target>-<file>` assets + an `ort-manifest.json` (per-target file list). Drop all WASM staging (the `Qb` pthread patch, the `.mjs`/`.wasm` assets, the `__LORE_WASM_*_ASSET__` defines).
- **`native-loader.cjs`** — in SEA mode, extract the running platform's addon + libs into one per-pid tmp dir (replicating the package's sibling layout so `$ORIGIN`/`@loader_path`/DLL-search finds `libonnxruntime`) and set `__LORE_ORT_BINDING_PATH__`. Drop WASM extraction + the `Worker` pthread polyfill. vec0 extraction unchanged (now shares the tmp dir + a `writeAsset` helper).

## npm bundle keeps WASM (deliberate)

dist-only installs (AUR etc., no `node_modules`) can't resolve a native `onnxruntime-node` and rely on the self-contained WASM runtime (#763). `ort-web-plugin.ts` + the npm WASM shipping are untouched. `embedding-worker.ts` needs no functional change — in the SEA it runs `vendorModel` mode (WASM-path block skipped) and the `numThreads=1` WASM flag is a no-op for native (which uses its own intra-op pool); only stale comments were corrected.

## Verification

- Built the **linux-x64 binary** and ran `--check-embeddings` → `ok dim=768` in **1.33 s**, with the addon + `libonnxruntime.so.1` + `providers_shared.so` extracted to `/tmp/lore-native/pid-*/` and loaded via the patched binding. No `onnxruntime-web`/`ort-wasm` residual in the worker bundle. `--check-vec` still green.
- Typecheck + lint clean; embedding (138) and gateway (2529) test suites pass.
- **Cross-platform is covered by CI**: the `binary-smoke-native` matrix builds each target on its own runner and runs `--check-embeddings` end-to-end — validating native load on darwin-arm64 / windows-x64 / linux-arm64 (which the linux build host can't exercise). Merge gated on that going green.

## Size

~+22 MB per linux binary (native `libonnxruntime.so`), offset by dropping the 11 MB `.wasm`; dwarfed by the ~137 MB embedded model. Windows keeps `onnxruntime.dll` + `DirectML.dll`.

## Follow-up (not here)

Native has no 4 GiB cap, so the `WASM_SUSTAINABLE_MAX_TOKENS` bound (#1134) is now a conservative memory-prudence cap for the SEA rather than a hard limit; lifting it for native is a separate change (quality plateaus ~2048 tokens + chunking, so low priority).