### PR TITLE
test(hermes): detect real ContextEngine ABC drift against installed hermes-agent (#1136)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
     outputs:
       code: ${{ steps.force.outputs.code || steps.filter.outputs.code }}
       docs: ${{ steps.filter.outputs.docs }}
+      hermes: ${{ steps.force.outputs.hermes || steps.filter.outputs.hermes }}
     steps:
       - uses: actions/checkout@v6
 
@@ -60,13 +61,20 @@ jobs:
               - 'packages/core/src/config.ts'
               - 'packages/gateway/src/**/*.ts'
               - 'packages/core/src/**/*.ts'
+            # The real-hermes ABC check installs an external `hermes-agent`, so
+            # scope it to hermes changes only — it must never gate unrelated PRs.
+            hermes:
+              - 'packages/hermes/**'
+              - '.github/workflows/ci.yml'
 
       # Force code=true on main/release pushes — these always run full CI.
       # dorny/paths-filter only matters for PRs.
       - name: Force full CI on main/release push
         id: force
         if: github.event_name == 'push'
-        run: echo "code=true" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "code=true" >> "$GITHUB_OUTPUT"
+          echo "hermes=true" >> "$GITHUB_OUTPUT"
 
   # ---------------------------------------------------------------------------
   # Lint GitHub Actions workflow files (catches schema errors, empty `with:`
@@ -1403,10 +1411,50 @@ jobs:
       - name: Run hermes tests
         run: python -m pytest packages/hermes/tests/ -q
 
+  # ---------------------------------------------------------------------------
+  # Real-hermes ContextEngine ABC check (#1136).
+  #
+  # `hermes-test` runs the unit suite against a hand-maintained STUB of the
+  # Hermes `ContextEngine` ABC, so it can't catch *upstream* drift (a new/renamed
+  # abstract method would make `LoreContextEngine` un-instantiable in production
+  # while the stubbed suite stays green). This job installs the REAL, unpinned
+  # `hermes-agent` and runs a standalone script (outside pytest, so the stub is
+  # never injected) that (1) fails on snapshot drift and (2) fails if our engine
+  # no longer conforms.
+  #
+  # Scoped to `packages/hermes/**` changes so it never gates unrelated PRs, and
+  # the install step is `continue-on-error` so a transient/unsupported
+  # `hermes-agent` can't hard-block a hermes PR — the check self-skips and the
+  # job stays green (the stubbed contract test in `hermes-test` still ran).
+  # ---------------------------------------------------------------------------
+  hermes-real-abc:
+    name: Hermes real ContextEngine ABC (drift + conformance)
+    needs: [changes]
+    if: needs.changes.outputs.hermes == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install real hermes-agent + lore-hermes
+        id: install
+        continue-on-error: true
+        run: |
+          python -m pip install --upgrade pip
+          pip install hermes-agent
+          pip install -e packages/hermes
+      - name: Real ContextEngine ABC drift + conformance
+        if: steps.install.outcome == 'success'
+        run: python packages/hermes/scripts/check_real_context_engine.py
+      - name: Note skipped real-ABC check
+        if: steps.install.outcome != 'success'
+        run: echo "::warning::Skipped real-hermes ABC check — hermes-agent could not be installed (transient or unsupported runtime). The stubbed contract test still ran in hermes-test."
+
   ci-status:
     name: CI Status
     if: always()
-    needs: [changes, test, binary-smoke-native, check-docs, check-links, check-preview-links, check-social, check-patches, actionlint, sync-integration, hermes-test]
+    needs: [changes, test, binary-smoke-native, check-docs, check-links, check-preview-links, check-social, check-patches, actionlint, sync-integration, hermes-test, hermes-real-abc]
     runs-on: ubuntu-latest
     steps:
       - name: Check CI result
@@ -1476,6 +1524,19 @@ jobs:
             hermesResult="${{ needs.hermes-test.result }}"
             if [ "$hermesResult" != "success" ]; then
               echo "::error::hermes-test did not succeed (result: $hermesResult)"
+              exit 1
+            fi
+          fi
+          # hermes-real-abc is required only when packages/hermes changed (it
+          # self-gates on the hermes path filter); "skipped" otherwise is pass.
+          # It tolerates hermes-agent install failures (job stays green), so a
+          # genuine failure here means real upstream ABC drift or a conformance
+          # break — both actionable in-PR (update tests/contract_spec.py and/or
+          # LoreContextEngine).
+          if [ "${{ needs.changes.outputs.hermes }}" == "true" ]; then
+            hermesAbcResult="${{ needs.hermes-real-abc.result }}"
+            if [ "$hermesAbcResult" != "success" ]; then
+              echo "::error::hermes-real-abc did not succeed (result: $hermesAbcResult)"
               exit 1
             fi
           fi

--- a/packages/hermes/scripts/check_real_context_engine.py
+++ b/packages/hermes/scripts/check_real_context_engine.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Real-``hermes-agent`` ContextEngine ABC drift + conformance check (#1136).
+
+The unit suite (``packages/hermes/tests``) runs against a hand-maintained stub
+of ``agent.context_engine.ContextEngine`` injected by ``conftest.py``. That
+stub mirrors a SNAPSHOT of the real contract, so it cannot catch *upstream*
+drift: if a future ``hermes-agent`` adds/renames an abstract method,
+``LoreContextEngine`` would raise ``TypeError: Can't instantiate abstract
+class ...`` in production while the stubbed suite stays green.
+
+This script closes that gap. It runs OUTSIDE pytest (so ``conftest.py`` never
+injects the stub) against a real ``hermes-agent`` install and performs two
+checks:
+
+1. **Snapshot drift** — ``ContextEngine.__abstractmethods__`` must equal the
+   pinned ``EXPECTED_ABSTRACT_METHODS`` snapshot. A mismatch means upstream
+   changed the contract; update ``tests/contract_spec.py`` (and the stub /
+   engine) accordingly.
+2. **Conformance** — ``LoreContextEngine()`` must instantiate (every abstract
+   method overridden), proving ``register()`` won't raise in production.
+
+Exit codes:
+    0  OK — snapshot matches and the engine conforms.
+    1  FAIL — real drift or a conformance break (actionable, should fail CI).
+    2  SKIP — real ``hermes-agent`` is not importable (or only the test stub is
+       present). The CI wiring treats this as a non-fatal skip.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# packages/hermes — so ``tests.contract_spec`` (and an editable ``lore_hermes``)
+# resolve when this script is run directly (`python .../check_real_context_engine.py`).
+HERMES_ROOT = Path(__file__).resolve().parents[1]
+
+EXIT_OK = 0
+EXIT_FAIL = 1
+EXIT_SKIP = 2
+
+
+def diff_abstract_methods(
+    real: frozenset[str], expected: frozenset[str]
+) -> tuple[list[str], list[str]]:
+    """Return ``(added, removed)`` — abstract methods present upstream but not
+    in the snapshot, and vice-versa. Empty/empty means no drift."""
+    return sorted(real - expected), sorted(expected - real)
+
+
+def evaluate_engine(engine_factory) -> tuple[bool, str]:
+    """Instantiate the engine and confirm it is fully concrete.
+
+    Returns ``(ok, detail)``. ``ok`` is False (with a human-readable ``detail``)
+    when instantiation raises ``TypeError`` (an abstract method is unoverridden)
+    or the class still reports ``__abstractmethods__``.
+    """
+    try:
+        engine = engine_factory()
+    except TypeError as exc:
+        return False, f"instantiation raised TypeError: {exc}"
+    remaining = getattr(type(engine), "__abstractmethods__", frozenset())
+    if remaining:
+        return False, f"still abstract: {sorted(remaining)}"
+    return True, ""
+
+
+def _installed_version() -> str:
+    try:
+        from importlib.metadata import version
+
+        return version("hermes-agent")
+    except Exception:  # pragma: no cover - best-effort label only
+        return "unknown"
+
+
+def main() -> int:
+    if str(HERMES_ROOT) not in sys.path:
+        sys.path.insert(0, str(HERMES_ROOT))
+
+    # 1. Real ContextEngine must be importable. Missing → SKIP (env issue, not
+    #    a code failure).
+    try:
+        import agent.context_engine as ce
+    except ImportError as exc:
+        print(
+            f"SKIP: real hermes-agent not importable ({exc}). "
+            "Install it (`pip install hermes-agent`) to run this check.",
+            file=sys.stderr,
+        )
+        return EXIT_SKIP
+
+    # Guard: make sure we got the REAL module, not the conftest stub. The stub
+    # is a synthetic ``types.ModuleType`` with no ``__file__``; a real installed
+    # module always has one. Without this, running under pytest would compare
+    # the stub against its own snapshot (a vacuous pass).
+    if getattr(ce, "__file__", None) is None:
+        print(
+            "SKIP: agent.context_engine has no __file__ — this looks like the "
+            "test stub, not a real hermes-agent install.",
+            file=sys.stderr,
+        )
+        return EXIT_SKIP
+
+    from tests.contract_spec import EXPECTED_ABSTRACT_METHODS, HERMES_AGENT_VERSION
+
+    installed = _installed_version()
+    real_abstract = frozenset(ce.ContextEngine.__abstractmethods__)
+
+    # 2. Snapshot-drift check.
+    added, removed = diff_abstract_methods(real_abstract, EXPECTED_ABSTRACT_METHODS)
+    if added or removed:
+        print(
+            f"FAIL: ContextEngine abstract-method drift — installed "
+            f"hermes-agent=={installed} diverges from the pinned snapshot "
+            f"(hermes-agent=={HERMES_AGENT_VERSION}).",
+            file=sys.stderr,
+        )
+        if added:
+            print(f"  added upstream (need overrides): {added}", file=sys.stderr)
+        if removed:
+            print(f"  removed upstream (drop from snapshot): {removed}", file=sys.stderr)
+        print(
+            "  → update EXPECTED_ABSTRACT_METHODS in "
+            "packages/hermes/tests/contract_spec.py and, if new methods were "
+            "added, override them in lore_hermes.engine.LoreContextEngine.",
+            file=sys.stderr,
+        )
+        return EXIT_FAIL
+
+    # 3. Conformance check against the real ABC.
+    from lore_hermes.engine import LoreContextEngine
+
+    ok, detail = evaluate_engine(LoreContextEngine)
+    if not ok:
+        print(
+            f"FAIL: LoreContextEngine does not satisfy the real hermes-agent=="
+            f"{installed} ContextEngine ABC — {detail}.",
+            file=sys.stderr,
+        )
+        return EXIT_FAIL
+
+    print(
+        f"OK: LoreContextEngine satisfies the real ContextEngine ABC and the "
+        f"pinned snapshot matches (hermes-agent=={installed}, abstract methods: "
+        f"{sorted(real_abstract)})."
+    )
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/hermes/tests/conftest.py
+++ b/packages/hermes/tests/conftest.py
@@ -40,8 +40,10 @@ if "agent.context_engine" not in sys.modules:
         abstract would make this stub *stricter* than reality.
 
         Drift caveat: this is hand-maintained. Upstream Hermes adding a *new*
-        abstract method is only caught by the real-Hermes integration path
-        (``packages/hermes/test-integration.sh``), not by this unit suite.
+        abstract method is caught by the real-Hermes check
+        (``scripts/check_real_context_engine.py``, run by the CI
+        ``hermes-real-abc`` job — #1136), not by this stubbed unit suite. The
+        snapshot itself lives in ``tests/contract_spec.py``.
         """
 
         def __init__(self, **kwargs):  # concrete upstream — permissive base

--- a/packages/hermes/tests/contract_spec.py
+++ b/packages/hermes/tests/contract_spec.py
@@ -1,0 +1,25 @@
+"""Single source of truth for the Hermes ``ContextEngine`` ABC snapshot.
+
+Both the stubbed unit guard (``test_contract.py`` / ``conftest.py``) and the
+real-Hermes drift check (``scripts/check_real_context_engine.py``, wired into
+CI by #1136) compare against the values here, so there is exactly one place to
+update when upstream Hermes changes its abstract contract.
+
+``EXPECTED_ABSTRACT_METHODS`` is a snapshot of
+``agent.context_engine.ContextEngine.__abstractmethods__`` as of
+``hermes-agent==HERMES_AGENT_VERSION``. Concrete upstream hooks (e.g.
+``should_compress_preflight``, ``get_status``) are NOT abstract there and are
+intentionally excluded — listing them would make our stub stricter than
+reality.
+
+When the real-ABC CI check reports drift, update BOTH constants (and add/remove
+the corresponding override in ``lore_hermes.engine.LoreContextEngine``).
+"""
+
+# The hermes-agent release this repo's abstract-method snapshot mirrors.
+HERMES_AGENT_VERSION = "0.18.0"
+
+# Snapshot of ContextEngine.__abstractmethods__ at HERMES_AGENT_VERSION.
+EXPECTED_ABSTRACT_METHODS = frozenset(
+    {"name", "should_compress", "compress", "update_from_response"}
+)

--- a/packages/hermes/tests/test_contract.py
+++ b/packages/hermes/tests/test_contract.py
@@ -14,18 +14,17 @@ mirroring the real Hermes contract's abstract-method set. These tests prove:
 
 Residual gap (documented, not fixed here): this checks our engine against a
 hand-maintained SNAPSHOT of the contract (hermes-agent==0.18.0), not live
-upstream Hermes. Upstream adding a *new* abstract method is only caught by
-``packages/hermes/test-integration.sh`` (needs a full Hermes install).
+upstream Hermes. Upstream adding a *new* abstract method is caught separately
+by ``scripts/check_real_context_engine.py`` — the real-Hermes drift +
+conformance check wired into CI by #1136 (and by the full-install
+``packages/hermes/test-integration.sh``).
 """
 
 import abc
 
 import pytest
 
-# The abstract-method set this repo mirrors, per hermes-agent==0.18.0.
-EXPECTED_ABSTRACT_METHODS = frozenset(
-    {"name", "should_compress", "compress", "update_from_response"}
-)
+from tests.contract_spec import EXPECTED_ABSTRACT_METHODS
 
 
 def test_stub_context_engine_is_an_enforcing_abc():

--- a/packages/hermes/tests/test_real_abc_check.py
+++ b/packages/hermes/tests/test_real_abc_check.py
@@ -1,0 +1,66 @@
+"""Unit coverage for ``scripts/check_real_context_engine.py`` (#1136).
+
+These run under the normal (stubbed) pytest suite, so they exercise the pure
+diff/conformance helpers and — importantly — prove the stub-detection guard in
+``main()`` refuses to treat the conftest stub as a real hermes-agent install
+(which would make the whole real-ABC check a vacuous pass). The true
+integration path (real drift/conformance against an installed hermes-agent) is
+exercised by the CI ``hermes-real-abc`` job, not here.
+"""
+
+import sys
+from pathlib import Path
+
+# The check script lives outside the importable package (it's CI tooling, not
+# shipped), so load it by adding scripts/ to sys.path.
+_SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+import check_real_context_engine as chk  # noqa: E402
+
+
+def test_diff_abstract_methods_no_drift():
+    s = frozenset({"a", "b"})
+    assert chk.diff_abstract_methods(s, s) == ([], [])
+
+
+def test_diff_abstract_methods_reports_added_and_removed():
+    real = frozenset({"name", "compress", "brand_new"})
+    expected = frozenset({"name", "compress", "gone"})
+    added, removed = chk.diff_abstract_methods(real, expected)
+    assert added == ["brand_new"]
+    assert removed == ["gone"]
+
+
+def test_evaluate_engine_accepts_a_complete_subclass():
+    # LoreContextEngine overrides every abstract method of the (stub) ABC.
+    from lore_hermes.engine import LoreContextEngine
+
+    ok, detail = chk.evaluate_engine(LoreContextEngine)
+    assert ok is True
+    assert detail == ""
+
+
+def test_evaluate_engine_rejects_an_incomplete_subclass():
+    from agent.context_engine import ContextEngine
+
+    class Incomplete(ContextEngine):
+        # Overrides only ONE of the abstract methods.
+        @property
+        def name(self) -> str:
+            return "incomplete"
+
+    ok, detail = chk.evaluate_engine(Incomplete)
+    assert ok is False
+    assert "TypeError" in detail
+
+
+def test_main_skips_when_only_the_stub_is_present():
+    """The load-bearing guard: run under the conftest stub (no real
+    hermes-agent), ``main()`` must SKIP rather than compare the stub against
+    its own snapshot. If the ``__file__`` guard were removed, ``main()`` would
+    instead find no drift + a conforming engine and return ``EXIT_OK`` — a
+    false pass. Asserting SKIP kills that mutation.
+    """
+    assert chk.main() == chk.EXIT_SKIP


### PR DESCRIPTION
Closes #1136 (follow-up to #1042 / PR #1135).

## Problem

`hermes-test` runs the unit suite against a hand-maintained **stub** of Hermes's `ContextEngine` ABC (injected by `conftest.py`). That catches regressions in *our* code against the pinned snapshot, but **not upstream drift**: if a future `hermes-agent` adds/renames an abstract method, `LoreContextEngine` would raise `TypeError: Can't instantiate abstract class …` in production (`register()`) while the stubbed suite stays green. Until now this was only covered by `test-integration.sh` (full install, not run in CI).

## Fix (issue's Option 2)

A standalone real-hermes check that runs **outside pytest** (so the stub is never injected) against a real `hermes-agent` install:

- **`scripts/check_real_context_engine.py`** — imports the REAL `agent.context_engine` and:
  1. **snapshot-drift**: `ContextEngine.__abstractmethods__` must equal the pinned snapshot — else it prints the exact added/removed methods + installed version and exits `1`;
  2. **conformance**: `LoreContextEngine()` must instantiate against the real ABC (exit `1` on `TypeError`).
  A `__file__` guard makes it **SKIP** (exit `2`) rather than compare the stub against its own snapshot — the load-bearing anti-false-pass check.
- **`tests/contract_spec.py`** — single source of truth for `EXPECTED_ABSTRACT_METHODS` + `HERMES_AGENT_VERSION`, shared by the stubbed contract test and the real check (removes the duplicate that lived in `test_contract.py`).
- **CI `hermes-real-abc` job** — installs the REAL, unpinned `hermes-agent` and runs the script.
- **`tests/test_real_abc_check.py`** — unit-tests the diff/conformance helpers and proves the stub-skip guard is load-bearing.

## Won't hard-block unrelated PRs (issue's main concern)

- **Path-scoped**: the job self-gates on `packages/hermes/**` (added a `hermes` filter to the `changes` job), so it never runs on unrelated PRs.
- **Install-tolerant**: the `pip install hermes-agent` step is `continue-on-error`, so a transient/unsupported `hermes-agent` self-skips (`::warning::`) and the job stays green — the stubbed contract test in `hermes-test` still ran.
- **Unpinned on purpose**: installing latest (not pinned to the snapshot version) is what makes a new upstream release surface as drift; the script reports the installed version so the fix is actionable.
- Required by the `ci-status` gate **only when `hermes` changed**.

## Verification (against real hermes-agent==0.18.0)

| Scenario | Result |
|---|---|
| healthy | `OK` → exit 0 |
| snapshot drift (wrong `EXPECTED_ABSTRACT_METHODS`) | `FAIL` → exit 1, prints added `['compress','update_from_response']` / removed `['phantom_method']` |
| engine drops an override | `FAIL` → exit 1, `TypeError: … abstract method 'update_from_response'` |

Full hermes suite **26 passed** (stable ×3); stub-skip guard mutation-killed; `actionlint` clean. This PR touches `ci.yml`, so the new job runs on the PR itself (self-validating).