### PR TITLE
refactor(core): rename WASM_SUSTAINABLE_MAX_TOKENS → EMBED_TOKEN_CEILING

### DIFF
--- a/packages/core/src/embedding-cap.ts
+++ b/packages/core/src/embedding-cap.ts
@@ -151,12 +151,25 @@ export const EMBED_WASM_HEAP_MAX_BYTES = 4 * 1024 * 1024 * 1024;
  *  (≤4962) on a 4 GiB-WASM host (#999). */
 export const EMBED_WASM_HEAP_USABLE_FRACTION = 0.85;
 
-/** Hard token ceiling implied by the fixed WASM heap cap (host-RAM-independent):
- *  `sqrt((MAX·fraction − baseline) / K)`. Every freemem-derived cap is bounded by
- *  this, so a memory-rich host never *starts* above what the WASM heap can hold
- *  (the OOM-backoff only corrects *downward*, so an over-sized start OOMs 1–2×
- *  every boot until it re-converges — exactly the failure this prevents). */
-export const WASM_SUSTAINABLE_MAX_TOKENS = clampEmbedCap(
+/** Hard, host-RAM-independent token ceiling for a single embed:
+ *  `sqrt((MAX·fraction − baseline) / K)` ≈ 4962. Every freemem-derived cap is
+ *  bounded by this.
+ *
+ *  Its VALUE is sized to the WASM linear-memory cap because that is the binding
+ *  constraint on the **npm/WASM path** (onnxruntime-web): the fixed 4 GiB heap
+ *  can't hold more, and since the OOM-backoff only corrects *downward*, an
+ *  over-sized start OOMs 1–2× every boot until it re-converges — the exact
+ *  failure this prevents.
+ *
+ *  On the **native path** (the SEA binary — see #1143 — plus dev/test, which use
+ *  native onnxruntime-node) there is no WASM heap and no 4 GiB wall, so here this
+ *  same bound instead acts as a memory-prudence + quality cap: nomic-embed-v1.5's
+ *  effective context plateaus around ~2048 tokens, so capping at ~4962 sacrifices
+ *  negligible embedding quality while keeping the transient O(L²) attention
+ *  allocation bounded (and long inputs are chunked upstream anyway). Lifting it
+ *  for native would let it drift up toward {@link MODEL_MAX_TOKENS} on big-RAM
+ *  hosts for no quality gain, so we keep the single shared ceiling. */
+export const EMBED_TOKEN_CEILING = clampEmbedCap(
   Math.sqrt(
     (EMBED_WASM_HEAP_MAX_BYTES * EMBED_WASM_HEAP_USABLE_FRACTION -
       EMBED_MODEL_BASELINE_BYTES) /
@@ -170,10 +183,10 @@ export function backoffEmbedCap(cap: number): number {
 }
 
 /** Size the token cap from free memory and the O(L²) attention model, bounded by
- *  the fixed WASM heap ceiling ({@link WASM_SUSTAINABLE_MAX_TOKENS}). The freemem
- *  term guards against host-memory thrashing (too big for RAM → swap); the WASM
- *  bound guards against the fixed 4 GiB linear-memory cap (too big for the heap →
- *  OOM) that host RAM says nothing about. */
+ *  {@link EMBED_TOKEN_CEILING}. The freemem term guards against host-memory
+ *  thrashing (too big for RAM → swap); the ceiling guards the WASM path against
+ *  the fixed 4 GiB linear-memory cap (too big for the heap → OOM) that host RAM
+ *  says nothing about, and doubles as a memory-prudence/quality cap on native. */
 export function memoryModelEmbedCap(freeBytes: number): number {
   const budget = Math.max(
     freeBytes * EMBED_MEM_FRACTION - EMBED_MODEL_BASELINE_BYTES,
@@ -181,7 +194,7 @@ export function memoryModelEmbedCap(freeBytes: number): number {
   );
   return Math.min(
     clampEmbedCap(Math.sqrt(budget / EMBED_ATTENTION_BYTES_PER_TOKEN_SQ)),
-    WASM_SUSTAINABLE_MAX_TOKENS,
+    EMBED_TOKEN_CEILING,
   );
 }
 
@@ -217,15 +230,15 @@ export function reconcileEmbedCap(
       ? modelCap
       : clampEmbedCap(Math.min(modelCap, stored.cap));
   })();
-  // Bound EVERY path by the fixed WASM heap ceiling — not just the model-derived
+  // Bound EVERY path by EMBED_TOKEN_CEILING — not just the model-derived
   // ones. The trust-band branch returns a persisted `stored.cap` verbatim, so a
   // stale cap learned before this bound existed (e.g. an old 7000 read after an
   // upgrade) would otherwise slip through and OOM once. knownBadCap (a
   // per-host-learned OOM) tightens it further when present.
   const ceiling =
     knownBadCap > 0
-      ? Math.min(WASM_SUSTAINABLE_MAX_TOKENS, knownBadCap - 1)
-      : WASM_SUSTAINABLE_MAX_TOKENS;
+      ? Math.min(EMBED_TOKEN_CEILING, knownBadCap - 1)
+      : EMBED_TOKEN_CEILING;
   return clampEmbedCap(Math.min(reconciled, ceiling));
 }
 
@@ -256,11 +269,11 @@ export function shouldReprobeEmbedCap(
  * actually grow that far (fragmentation, racing allocations), so we never
  * re-probe *up to or past* a cap that already failed.
  *
- * The result is also hard-bounded by {@link WASM_SUSTAINABLE_MAX_TOKENS} so this
- * path can never yield a cap above the fixed WASM heap ceiling — even if handed
- * an above-ceiling `cap` (the `Math.max(cap, …)` "never step down" clause would
- * otherwise propagate it). This makes the "no cap exceeds the WASM ceiling"
- * invariant locally enforced here, not merely inherited from a bounded input.
+ * The result is also hard-bounded by {@link EMBED_TOKEN_CEILING} so this
+ * path can never yield a cap above it — even if handed an above-ceiling `cap`
+ * (the `Math.max(cap, …)` "never step down" clause would otherwise propagate it).
+ * This makes the "no cap exceeds EMBED_TOKEN_CEILING" invariant locally enforced
+ * here, not merely inherited from a bounded input.
  */
 export function reprobeEmbedCap(
   cap: number,
@@ -272,6 +285,6 @@ export function reprobeEmbedCap(
   if (knownBadCap > 0) ceiling = Math.min(ceiling, knownBadCap - 1);
   return Math.min(
     clampEmbedCap(Math.max(cap, Math.min(stepped, ceiling))),
-    WASM_SUSTAINABLE_MAX_TOKENS,
+    EMBED_TOKEN_CEILING,
   );
 }

--- a/packages/core/test/embedding-cap.test.ts
+++ b/packages/core/test/embedding-cap.test.ts
@@ -5,7 +5,7 @@ import {
   MIN_EMBED_TOKENS,
   MODEL_MAX_TOKENS,
   PER_WORKER_MEM_BUDGET_BYTES,
-  WASM_SUSTAINABLE_MAX_TOKENS,
+  EMBED_TOKEN_CEILING,
   backoffEmbedCap,
   clampEmbedCap,
   desiredEmbedPoolSize,
@@ -81,8 +81,8 @@ describe("memoryModelEmbedCap", () => {
     // the O(L²) attention at that length — so a memory-rich box is capped at the
     // WASM-sustainable ceiling (~4948) rather than MODEL_MAX_TOKENS (8192). This
     // is what prevents the OOM-on-every-boot on machines with lots of free RAM.
-    expect(memoryModelEmbedCap(64 * GB)).toBe(WASM_SUSTAINABLE_MAX_TOKENS);
-    expect(WASM_SUSTAINABLE_MAX_TOKENS).toBeLessThan(MODEL_MAX_TOKENS);
+    expect(memoryModelEmbedCap(64 * GB)).toBe(EMBED_TOKEN_CEILING);
+    expect(EMBED_TOKEN_CEILING).toBeLessThan(MODEL_MAX_TOKENS);
   });
 
   it("sizes a constrained host (~2.7 GB free, like Onur's box) well below 4096", () => {
@@ -111,21 +111,21 @@ describe("memoryModelEmbedCap", () => {
   });
 });
 
-describe("WASM_SUSTAINABLE_MAX_TOKENS", () => {
+describe("EMBED_TOKEN_CEILING", () => {
   it("is a fixed ceiling below the model max, in the measured ~4900 range", () => {
     // Derived from the 4 GiB WASM MAXIMUM_MEMORY (measured on the built worker)
     // × 0.85 headroom, minus baseline, over K. Must sit below MODEL_MAX_TOKENS
     // (that's the whole point) and near the observed safe convergence (≤4962).
-    expect(WASM_SUSTAINABLE_MAX_TOKENS).toBeLessThan(MODEL_MAX_TOKENS);
-    expect(WASM_SUSTAINABLE_MAX_TOKENS).toBeGreaterThan(4000);
-    expect(WASM_SUSTAINABLE_MAX_TOKENS).toBeLessThanOrEqual(5200);
+    expect(EMBED_TOKEN_CEILING).toBeLessThan(MODEL_MAX_TOKENS);
+    expect(EMBED_TOKEN_CEILING).toBeGreaterThan(4000);
+    expect(EMBED_TOKEN_CEILING).toBeLessThanOrEqual(5200);
   });
 
   it("is the binding ceiling once free RAM is large enough to hit it", () => {
     // Below the crossover the freemem term binds; above it, the WASM ceiling
     // does — and the result never exceeds the WASM ceiling regardless of RAM.
     for (const free of [16, 32, 64, 256]) {
-      expect(memoryModelEmbedCap(free * GB)).toBe(WASM_SUSTAINABLE_MAX_TOKENS);
+      expect(memoryModelEmbedCap(free * GB)).toBe(EMBED_TOKEN_CEILING);
     }
   });
 });
@@ -196,9 +196,7 @@ describe("reconcileEmbedCap", () => {
     // free memory is stable — must be pulled down to the ceiling, not run at
     // 7000 (which would OOM the 4 GiB heap once before the backoff re-converges).
     const stale = { cap: 7000, freeMemBytes: 1 * GB };
-    expect(reconcileEmbedCap(1 * GB, stale, 8192)).toBe(
-      WASM_SUSTAINABLE_MAX_TOKENS,
-    );
+    expect(reconcileEmbedCap(1 * GB, stale, 8192)).toBe(EMBED_TOKEN_CEILING);
   });
 });
 
@@ -243,7 +241,7 @@ describe("reprobeEmbedCap", () => {
     // propagate a stale above-ceiling cap. Handed 8192, reprobe self-bounds to
     // the WASM ceiling rather than returning 8192 (which would OOM the 4 GiB heap).
     expect(reprobeEmbedCap(MODEL_MAX_TOKENS, 64 * GB)).toBe(
-      WASM_SUSTAINABLE_MAX_TOKENS,
+      EMBED_TOKEN_CEILING,
     );
     // A normal in-range cap still steps up as before (bound is a no-op here).
     expect(reprobeEmbedCap(2000, 64 * GB)).toBe(Math.round(2000 / 0.7)); // 2857

--- a/packages/core/test/embedding-oom-recovery.test.ts
+++ b/packages/core/test/embedding-oom-recovery.test.ts
@@ -15,7 +15,7 @@ import {
 import {
   backoffEmbedCap,
   MIN_EMBED_TOKENS,
-  WASM_SUSTAINABLE_MAX_TOKENS,
+  EMBED_TOKEN_CEILING,
 } from "../src/embedding-cap";
 import { EMBED_OOM_EXIT_CODE } from "../src/embedding-worker-types";
 import { isStderrSilenced, silenceStderr } from "../src/log";
@@ -119,7 +119,7 @@ describe("embedding OOM recovery (worker-mock)", () => {
     expect(fakes).toHaveLength(1);
     const first = fakes[0].lastPosted();
     expect(first.type).toBe("embed");
-    expect(first.maxTokens).toBe(WASM_SUSTAINABLE_MAX_TOKENS);
+    expect(first.maxTokens).toBe(EMBED_TOKEN_CEILING);
 
     // The worker OOMs on the oversized input → exits with the OOM code.
     fakes[0].emit("exit", EMBED_OOM_EXIT_CODE);
@@ -129,9 +129,7 @@ describe("embedding OOM recovery (worker-mock)", () => {
     expect(fakes).toHaveLength(2);
     const resubmitted = fakes[1].lastPosted();
     expect(resubmitted.id).toBe(first.id);
-    expect(resubmitted.maxTokens).toBe(
-      backoffEmbedCap(WASM_SUSTAINABLE_MAX_TOKENS),
-    );
+    expect(resubmitted.maxTokens).toBe(backoffEmbedCap(EMBED_TOKEN_CEILING));
     expect(resubmitted.maxTokens).toBeLessThan(first.maxTokens);
     // The lowered cap was persisted so a restart doesn't re-walk the backoff.
     expect(_readPersistedEmbedCap()?.cap).toBe(resubmitted.maxTokens);


### PR DESCRIPTION
Follow-up to #1143. After the SEA binary switched to native onnxruntime-node (dev/test already used it), the embed-token cap governs **both** backends — but `WASM_SUSTAINABLE_MAX_TOKENS` and its comments implied a purely WASM-heap constraint. This renames it to `EMBED_TOKEN_CEILING` and documents the dual role.

- **npm/WASM path** — a hard requirement: the fixed 4 GiB WASM linear-memory heap can't hold more, and since OOM-backoff only corrects *downward*, an over-sized start OOMs every boot until it re-converges. The constant's VALUE stays sized to that heap.
- **native path** (SEA binary + dev/test) — no WASM heap, so the same bound acts as a **memory-prudence + quality cap**: nomic-embed-v1.5's effective context plateaus around ~2048 tokens, so capping at ~4962 sacrifices negligible embedding quality while bounding the transient O(L²) attention allocation (long inputs are chunked upstream anyway).

Pure rename + comment accuracy — **no value or behavior change** (~4962 unchanged). typecheck clean; the 51 embedding-cap / oom-recovery / persistence assertions pass untouched.