### PR TITLE
feat(core): detect & surface knowledge contradictions — engine + CLI (#1123)

### DIFF
--- a/packages/core/src/contradiction.ts
+++ b/packages/core/src/contradiction.ts
@@ -1,0 +1,250 @@
+/**
+ * Idle-time contradiction detection (#1123).
+ *
+ * Finds pairs of stored knowledge entries that genuinely OPPOSE each other and
+ * records them so they can be surfaced to the user for resolution (dashboard /
+ * CLI). This is the affirmative of the consolidation invariant "opposing rules
+ * (e.g. 'always use tabs' vs 'always use spaces') are NEVER duplicates — never
+ * merge them" (prompt.ts): consolidation must leave opposing entries alone; this
+ * worker is the one that notices them.
+ *
+ * Detection ONLY — never merges, never deletes. The user picks the survivor (or
+ * keeps both) on the dashboard.
+ *
+ * Pipeline (mirrors pattern-echo's embed -> cluster -> judge shape):
+ *   1. Enumerate the project's current knowledge entries (incl. cross-project).
+ *   2. Load their embeddings and form candidate pairs by cosine similarity —
+ *      opposing rules are TOPICALLY similar ("tabs vs spaces"), so high
+ *      similarity is a cheap prefilter.
+ *   3. For each not-yet-judged candidate (most-similar first, capped per pass),
+ *      ask the worker LLM "do these directly contradict?". Precision over
+ *      recall — a false alarm wastes the user's attention.
+ *   4. Record contradictions (status 'open', surfaced) and non-contradictions
+ *      (status 'cleared', never re-judged) so cost stays bounded.
+ */
+
+import { db, ensureProject } from "./db";
+import { embeddingByIdSource, readStorageMode } from "./db/vec-store";
+import * as embedding from "./embedding";
+import * as ltm from "./ltm";
+import type { KnowledgeEntry } from "./ltm";
+import * as log from "./log";
+import { CONTRADICTION_JUDGE_SYSTEM, contradictionJudgeUser } from "./prompt";
+import type { LLMClient } from "./types";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimum cosine similarity for a pair to be a contradiction CANDIDATE.
+ * Opposing rules about the same subject embed close together, so this is a
+ * permissive topical prefilter — the LLM judge supplies the precision. Kept low
+ * enough to catch reworded opposites, high enough to keep the pair count (and
+ * therefore judge calls) bounded.
+ */
+export const CANDIDATE_SIMILARITY = 0.6;
+
+/** Cap the pairwise scan to the top-N entries by confidence (forProject is
+ *  ordered confidence DESC) so a huge knowledge set can't make this O(N^2)
+ *  scan expensive. */
+const MAX_ENTRIES_SCAN = 300;
+
+/** Never consider more than this many candidate pairs in one pass. */
+const MAX_PAIRS_CONSIDER = 200;
+
+/** At most this many LLM judge calls per pass. New (unjudged) pairs are judged
+ *  most-similar first; the rest are picked up on later idle passes. */
+const MAX_JUDGE_CALLS_PER_PASS = 8;
+
+// ---------------------------------------------------------------------------
+// Candidate pairing (pure — unit tested directly)
+// ---------------------------------------------------------------------------
+
+export interface PairItem {
+  /** Current-version knowledge id (embedding key). */
+  id: string;
+  /** Stable logical id (persistence key). */
+  logicalId: string;
+  vec: Float32Array;
+}
+
+export interface CandidatePair {
+  aIdx: number;
+  bIdx: number;
+  similarity: number;
+}
+
+/**
+ * All index pairs whose cosine similarity is at least `threshold`, sorted
+ * most-similar first. Pure over the embedding math — deterministic.
+ */
+export function candidatePairs(
+  items: PairItem[],
+  threshold: number,
+): CandidatePair[] {
+  const pairs: CandidatePair[] = [];
+  for (let i = 0; i < items.length; i++) {
+    for (let j = i + 1; j < items.length; j++) {
+      const sim = embedding.cosineSimilarity(items[i].vec, items[j].vec);
+      if (sim >= threshold) pairs.push({ aIdx: i, bIdx: j, similarity: sim });
+    }
+  }
+  pairs.sort((a, b) => b.similarity - a.similarity);
+  return pairs;
+}
+
+// ---------------------------------------------------------------------------
+// Detection
+// ---------------------------------------------------------------------------
+
+export interface DetectResult {
+  /** Candidate pairs sent to the LLM judge this pass. */
+  judged: number;
+  /** New contradictions recorded (surfaced) this pass. */
+  found: number;
+}
+
+/**
+ * Run one contradiction-detection pass for a project. Bounded and idempotent:
+ * pairs already recorded (in any status) are skipped, so cost is capped and a
+ * user-dismissed/resolved pair is never re-surfaced. Errors are the caller's to
+ * catch (the idle handler wraps each step in try/catch).
+ */
+export async function detectContradictions(input: {
+  projectPath: string;
+  sessionID: string;
+  llm: LLMClient;
+  model?: { providerID: string; modelID: string };
+}): Promise<DetectResult> {
+  const entries = ltm.forProject(input.projectPath, true);
+  if (entries.length < 2) return { judged: 0, found: 0 };
+  const pid = ensureProject(input.projectPath);
+
+  // Cap the pairwise scan (entries are confidence DESC).
+  const scan = entries.slice(0, MAX_ENTRIES_SCAN);
+
+  // Load embeddings keyed by current-version id (same helper pattern-echo uses).
+  const ids = scan.map((e) => e.id);
+  const placeholders = ids.map(() => "?").join(",");
+  const src = embeddingByIdSource(
+    "knowledge",
+    readStorageMode(db()),
+    "knowledge_current",
+  );
+  const rows = db()
+    .query(
+      `SELECT id, embedding FROM ${src.table} WHERE id IN (${placeholders})${src.presenceFilter}`,
+    )
+    .all(...ids) as Array<{ id: string; embedding: Buffer }>;
+  const vecById = new Map<string, Float32Array>();
+  for (const r of rows) vecById.set(r.id, embedding.fromBlob(r.embedding));
+
+  const items: PairItem[] = [];
+  const byLogical = new Map<string, KnowledgeEntry>();
+  for (const e of scan) {
+    const vec = vecById.get(e.id);
+    if (!vec) continue; // not embedded yet — a later pass will pick it up
+    items.push({ id: e.id, logicalId: e.logical_id, vec });
+    byLogical.set(e.logical_id, e);
+  }
+  if (items.length < 2) return { judged: 0, found: 0 };
+
+  const pairs = candidatePairs(items, CANDIDATE_SIMILARITY).slice(
+    0,
+    MAX_PAIRS_CONSIDER,
+  );
+
+  let judged = 0;
+  let found = 0;
+  for (const pair of pairs) {
+    if (judged >= MAX_JUDGE_CALLS_PER_PASS) break;
+    const a = items[pair.aIdx];
+    const b = items[pair.bIdx];
+    // Judge each pair at most once ever — this also guarantees a pair the user
+    // already dismissed or resolved is never re-judged and re-surfaced.
+    if (ltm.contradictionExists(a.logicalId, b.logicalId)) continue;
+    const ea = byLogical.get(a.logicalId);
+    const eb = byLogical.get(b.logicalId);
+    if (!ea || !eb) continue;
+
+    judged++;
+    const responseText = await input.llm.prompt(
+      CONTRADICTION_JUDGE_SYSTEM,
+      contradictionJudgeUser({
+        a: { title: ea.title, content: ea.content },
+        b: { title: eb.title, content: eb.content },
+      }),
+      {
+        model: input.model,
+        workerID: "lore-contradiction",
+        thinking: false,
+        sessionID: input.sessionID,
+        maxTokens: 256,
+        temperature: 0,
+      },
+    );
+
+    const verdict = parseContradictionVerdict(responseText);
+    if (!verdict) continue; // unparseable — leave unrecorded, retry next pass
+
+    if (verdict.contradict) {
+      const inserted = ltm.recordContradiction({
+        logicalIdA: a.logicalId,
+        logicalIdB: b.logicalId,
+        projectId: ea.project_id ?? eb.project_id ?? pid,
+        similarity: pair.similarity,
+        rationale: verdict.reason,
+      });
+      if (inserted) {
+        found++;
+        log.info(
+          `contradiction: "${ea.title}" <> "${eb.title}" (sim=${pair.similarity.toFixed(3)})`,
+        );
+      }
+    } else {
+      ltm.recordContradictionCleared({
+        logicalIdA: a.logicalId,
+        logicalIdB: b.logicalId,
+        projectId: ea.project_id ?? eb.project_id ?? pid,
+        similarity: pair.similarity,
+      });
+    }
+  }
+
+  return { judged, found };
+}
+
+// ---------------------------------------------------------------------------
+// Response parsing
+// ---------------------------------------------------------------------------
+
+interface ContradictionVerdict {
+  contradict: boolean;
+  reason: string | null;
+}
+
+export function parseContradictionVerdict(
+  text: string | null,
+): ContradictionVerdict | null {
+  if (!text) return null;
+  const cleaned = text
+    .trim()
+    .replace(/^```json?\s*/i, "")
+    .replace(/\s*```$/i, "");
+  try {
+    const parsed = JSON.parse(cleaned);
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      typeof parsed.contradict === "boolean"
+    ) {
+      const reason =
+        typeof parsed.reason === "string" ? parsed.reason.slice(0, 400) : null;
+      return { contradict: parsed.contradict, reason };
+    }
+  } catch {
+    // not valid JSON
+  }
+  return null;
+}

--- a/packages/core/src/contradiction.ts
+++ b/packages/core/src/contradiction.ts
@@ -138,7 +138,17 @@ export async function detectContradictions(input: {
     )
     .all(...ids) as Array<{ id: string; embedding: Buffer }>;
   const vecById = new Map<string, Float32Array>();
-  for (const r of rows) vecById.set(r.id, embedding.fromBlob(r.embedding));
+  for (const r of rows) {
+    try {
+      vecById.set(r.id, embedding.fromBlob(r.embedding));
+    } catch {
+      // A corrupted/truncated embedding blob must not abort the whole pass:
+      // detectContradictions throwing here would exit with the cooldown already
+      // armed, silently disabling detection for this project for an hour. Skip
+      // the bad entry (a later pass re-embeds it) — mirrors the dedup guard.
+      log.info(`contradiction: skipping corrupted embedding for entry ${r.id}`);
+    }
+  }
 
   const items: PairItem[] = [];
   const byLogical = new Map<string, KnowledgeEntry>();

--- a/packages/core/src/data.ts
+++ b/packages/core/src/data.ts
@@ -679,6 +679,16 @@ export function clearProject(projectPath: string): ClearResult {
     database
       .query("DELETE FROM knowledge_session_injections WHERE project_id = ?")
       .run(pid);
+    // Contradiction pairs (#1123) reference TWO logical_ids, so they can't ride
+    // a single-column project sweep — purge any pair touching this project's
+    // entries BEFORE the knowledge rows go, while the subquery can still see them.
+    database
+      .query(
+        `DELETE FROM knowledge_contradictions
+         WHERE logical_id_a IN (SELECT logical_id FROM knowledge WHERE project_id = ?)
+            OR logical_id_b IN (SELECT logical_id FROM knowledge WHERE project_id = ?)`,
+      )
+      .run(pid, pid);
     database.query("DELETE FROM knowledge WHERE project_id = ?").run(pid);
     database
       .query("DELETE FROM temporal_messages WHERE project_id = ?")
@@ -811,6 +821,15 @@ export function deleteProject(projectId: string): ClearResult | null {
     database
       .query("DELETE FROM knowledge_session_injections WHERE project_id = ?")
       .run(projectId);
+    // Contradiction pairs (#1123): purge any pair touching this project's
+    // entries before the knowledge rows go (composite key, can't ride the loop).
+    database
+      .query(
+        `DELETE FROM knowledge_contradictions
+         WHERE logical_id_a IN (SELECT logical_id FROM knowledge WHERE project_id = ?)
+            OR logical_id_b IN (SELECT logical_id FROM knowledge WHERE project_id = ?)`,
+      )
+      .run(projectId, projectId);
     database.query("DELETE FROM knowledge WHERE project_id = ?").run(projectId);
     database
       .query("DELETE FROM temporal_messages WHERE project_id = ?")
@@ -898,6 +917,17 @@ export function clearKnowledge(projectPath: string): number {
   db()
     .query("DELETE FROM knowledge_session_injections WHERE project_id = ?")
     .run(pid);
+  // Contradiction pairs (#1123): purge any pair touching this project's entries
+  // before the knowledge rows go (composite key, can't ride the loop).
+  // Contradiction pairs (#1123): purge any pair touching this project's entries
+  // before the knowledge rows go (composite key, can't ride the loop).
+  db()
+    .query(
+      `DELETE FROM knowledge_contradictions
+       WHERE logical_id_a IN (SELECT logical_id FROM knowledge WHERE project_id = ?)
+          OR logical_id_b IN (SELECT logical_id FROM knowledge WHERE project_id = ?)`,
+    )
+    .run(pid, pid);
   db().query("DELETE FROM knowledge WHERE project_id = ?").run(pid);
   reclaimVec0Orphans(["knowledge"]);
 

--- a/packages/core/src/data.ts
+++ b/packages/core/src/data.ts
@@ -919,8 +919,6 @@ export function clearKnowledge(projectPath: string): number {
     .run(pid);
   // Contradiction pairs (#1123): purge any pair touching this project's entries
   // before the knowledge rows go (composite key, can't ride the loop).
-  // Contradiction pairs (#1123): purge any pair touching this project's entries
-  // before the knowledge rows go (composite key, can't ride the loop).
   db()
     .query(
       `DELETE FROM knowledge_contradictions

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1541,6 +1541,31 @@ const MIGRATIONS: string[] = [
   -- warmupNet = warmup_savings - warmup_cost.
   ALTER TABLE session_state ADD COLUMN warmup_cost REAL NOT NULL DEFAULT 0;
   `,
+
+  `
+  -- Version 62: knowledge_contradictions — idle-detected pairs of knowledge
+  -- entries that genuinely OPPOSE each other (the affirmative of the
+  -- consolidation "opposing rules are NEVER duplicates — never merge them"
+  -- invariant, prompt.ts). Detection ONLY: we surface the pair for the user to
+  -- resolve on the dashboard / CLI, never auto-merge or auto-delete (#1123).
+  -- Keyed by the two stable logical_ids in canonical (a <= b) order so a pair
+  -- is stored exactly once regardless of detection order. A sidecar table like
+  -- knowledge_meta / knowledge_symbol_presence — it never touches the frozen
+  -- append-only knowledge table.
+  CREATE TABLE IF NOT EXISTS knowledge_contradictions (
+    logical_id_a TEXT NOT NULL,
+    logical_id_b TEXT NOT NULL,
+    project_id   TEXT,
+    similarity   REAL NOT NULL DEFAULT 0,
+    rationale    TEXT,
+    status       TEXT NOT NULL DEFAULT 'open',
+    detected_at  INTEGER NOT NULL,
+    updated_at   INTEGER NOT NULL,
+    PRIMARY KEY (logical_id_a, logical_id_b)
+  );
+  CREATE INDEX IF NOT EXISTS idx_knowledge_contradictions_status
+    ON knowledge_contradictions (status);
+  `,
 ];
 
 // Index of the migration whose work is performed by a column-presence-aware JS
@@ -2405,6 +2430,19 @@ function recoverMissingObjects(database: Database) {
       last_present_at INTEGER NOT NULL DEFAULT 0,
       PRIMARY KEY (logical_id, symbol)
     );
+    CREATE TABLE IF NOT EXISTS knowledge_contradictions (
+      logical_id_a TEXT NOT NULL,
+      logical_id_b TEXT NOT NULL,
+      project_id   TEXT,
+      similarity   REAL NOT NULL DEFAULT 0,
+      rationale    TEXT,
+      status       TEXT NOT NULL DEFAULT 'open',
+      detected_at  INTEGER NOT NULL,
+      updated_at   INTEGER NOT NULL,
+      PRIMARY KEY (logical_id_a, logical_id_b)
+    );
+    CREATE INDEX IF NOT EXISTS idx_knowledge_contradictions_status
+      ON knowledge_contradictions (status);
     CREATE TABLE IF NOT EXISTS knowledge_transfers (
       knowledge_id           TEXT NOT NULL,
       recalled_in_project_id TEXT NOT NULL,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,6 +28,7 @@ export {
 export * as syncData from "./sync-data";
 export * as data from "./data";
 export * as distillation from "./distillation";
+export * as contradiction from "./contradiction";
 export * as curator from "./curator";
 export type { ChangedEntry } from "./curator";
 export * as embedding from "./embedding";

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -3561,7 +3561,9 @@ export function contradictionExists(a0: string, b0: string): boolean {
  * tombstoned) are excluded by the JOIN — a stale pair is never surfaced even if
  * the row lingers. Optionally scoped to a project (its own + cross-project).
  */
-export function listOpenContradictions(projectPath?: string): OpenContradiction[] {
+export function listOpenContradictions(
+  projectPath?: string,
+): OpenContradiction[] {
   const pid = projectPath ? ensureProject(projectPath) : null;
   const rows = db()
     .query(

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -617,6 +617,15 @@ export function remove(id: string, metadata?: KnowledgeMetadata) {
   db()
     .query("DELETE FROM knowledge_session_injections WHERE logical_id = ?")
     .run(logicalId);
+  // Contradiction pairs reference TWO logical_ids, so they can't ride the
+  // single-column LOGICAL_ID_BOOKKEEPING_TABLES loop. Purge any pair that
+  // touches this entry — a contradiction against a now-deleted entry is moot
+  // (the user resolved it by removing one side, or it was pruned). (#1123)
+  db()
+    .query(
+      "DELETE FROM knowledge_contradictions WHERE logical_id_a = ? OR logical_id_b = ?",
+    )
+    .run(logicalId, logicalId);
 }
 
 /** True when the entry for this logical_id was deleted (tombstoned). */
@@ -3449,6 +3458,160 @@ export function getDismissedKnowledgePairs(): Set<string> {
     dismissed.add(`${r.entry_b_title}\x1f${r.entry_a_title}`);
   }
   return dismissed;
+}
+
+// ---------------------------------------------------------------------------
+// Contradiction pairs (#1123)
+//
+// Idle-time detection records pairs of knowledge entries that genuinely OPPOSE
+// each other (see contradiction.ts). This is the affirmative of the
+// consolidation "never merge opposing rules" invariant: we NEVER auto-merge or
+// auto-delete — we only surface the pair for the user to resolve (dashboard /
+// CLI). Pairs are keyed by the two stable logical_ids in canonical (a <= b)
+// order so a pair maps to exactly one row regardless of detection order.
+// ---------------------------------------------------------------------------
+
+export type ContradictionStatus = "open" | "resolved" | "dismissed";
+
+export interface OpenContradiction {
+  logicalIdA: string;
+  logicalIdB: string;
+  titleA: string;
+  titleB: string;
+  similarity: number;
+  rationale: string | null;
+  detectedAt: number;
+}
+
+/** Canonical (a <= b) ordering so a pair maps to exactly one PK row. */
+export function contradictionPairKey(a: string, b: string): [string, string] {
+  return a <= b ? [a, b] : [b, a];
+}
+
+/**
+ * Record a detected contradiction pair. Canonicalizes order. Idempotent via
+ * INSERT OR IGNORE: a pair that already exists (in ANY status) is left
+ * untouched, so a previously resolved/dismissed pair is never re-opened and its
+ * detection timestamp never churns. Returns true when a NEW row was inserted.
+ */
+export function recordContradiction(input: {
+  logicalIdA: string;
+  logicalIdB: string;
+  projectId: string | null;
+  similarity: number;
+  rationale: string | null;
+}): boolean {
+  const [a, b] = contradictionPairKey(input.logicalIdA, input.logicalIdB);
+  if (a === b) return false; // never pair an entry with itself
+  const now = Date.now();
+  const res = db()
+    .query(
+      `INSERT OR IGNORE INTO knowledge_contradictions
+         (logical_id_a, logical_id_b, project_id, similarity, rationale, status, detected_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, 'open', ?, ?)`,
+    )
+    .run(a, b, input.projectId, input.similarity, input.rationale, now, now);
+  return res.changes > 0;
+}
+
+/**
+ * Record that a candidate pair was JUDGED and found NOT to contradict. Stored as
+ * status 'cleared' so the detector never re-judges it (bounds LLM cost and stops
+ * high-similarity non-contradicting pairs from starving the per-pass judge
+ * budget). Never surfaced. INSERT OR IGNORE so an already-recorded pair (open or
+ * otherwise) is left untouched.
+ */
+export function recordContradictionCleared(input: {
+  logicalIdA: string;
+  logicalIdB: string;
+  projectId: string | null;
+  similarity: number;
+}): void {
+  const [a, b] = contradictionPairKey(input.logicalIdA, input.logicalIdB);
+  if (a === b) return;
+  const now = Date.now();
+  db()
+    .query(
+      `INSERT OR IGNORE INTO knowledge_contradictions
+         (logical_id_a, logical_id_b, project_id, similarity, rationale, status, detected_at, updated_at)
+       VALUES (?, ?, ?, ?, NULL, 'cleared', ?, ?)`,
+    )
+    .run(a, b, input.projectId, input.similarity, now, now);
+}
+
+/**
+ * Has this pair already been recorded (in ANY status)? The detector uses this
+ * to judge each candidate pair at most once — bounding LLM cost and, crucially,
+ * never re-surfacing a pair the user already dismissed or resolved.
+ */
+export function contradictionExists(a0: string, b0: string): boolean {
+  const [a, b] = contradictionPairKey(a0, b0);
+  const row = db()
+    .query(
+      `SELECT COUNT(*) AS n FROM knowledge_contradictions
+       WHERE logical_id_a = ? AND logical_id_b = ?`,
+    )
+    .get(a, b) as { n: number };
+  return row.n > 0;
+}
+
+/**
+ * All OPEN contradictions, hydrated with both entries' current titles. Pairs
+ * where either entry no longer exists in `knowledge_current` (deleted /
+ * tombstoned) are excluded by the JOIN — a stale pair is never surfaced even if
+ * the row lingers. Optionally scoped to a project (its own + cross-project).
+ */
+export function listOpenContradictions(projectPath?: string): OpenContradiction[] {
+  const pid = projectPath ? ensureProject(projectPath) : null;
+  const rows = db()
+    .query(
+      `SELECT c.logical_id_a, c.logical_id_b, c.similarity, c.rationale, c.detected_at,
+              ka.title AS title_a, kb.title AS title_b
+         FROM knowledge_contradictions c
+         JOIN knowledge_current ka ON ka.logical_id = c.logical_id_a
+         JOIN knowledge_current kb ON kb.logical_id = c.logical_id_b
+        WHERE c.status = 'open'
+        ${pid ? "AND (c.project_id = ? OR c.project_id IS NULL)" : ""}
+        ORDER BY c.detected_at DESC`,
+    )
+    .all(...(pid ? [pid] : [])) as Array<{
+    logical_id_a: string;
+    logical_id_b: string;
+    similarity: number;
+    rationale: string | null;
+    detected_at: number;
+    title_a: string;
+    title_b: string;
+  }>;
+  return rows.map((r) => ({
+    logicalIdA: r.logical_id_a,
+    logicalIdB: r.logical_id_b,
+    titleA: r.title_a,
+    titleB: r.title_b,
+    similarity: r.similarity,
+    rationale: r.rationale,
+    detectedAt: r.detected_at,
+  }));
+}
+
+/**
+ * Set the status of a contradiction pair (canonicalized). Used by the dashboard
+ * resolve/dismiss endpoints and the CLI. A "resolved" pair usually accompanies
+ * a `remove()` of the losing entry (which also purges the row); "dismissed"
+ * keeps both entries but suppresses the pair from future surfacing.
+ */
+export function setContradictionStatus(
+  a0: string,
+  b0: string,
+  status: ContradictionStatus,
+): void {
+  const [a, b] = contradictionPairKey(a0, b0);
+  db()
+    .query(
+      `UPDATE knowledge_contradictions SET status = ?, updated_at = ?
+       WHERE logical_id_a = ? AND logical_id_b = ?`,
+    )
+    .run(status, Date.now(), a, b);
 }
 
 /**

--- a/packages/core/src/prompt.ts
+++ b/packages/core/src/prompt.ts
@@ -1147,3 +1147,41 @@ ${echoParts}
 
 Identify the common behavioral pattern the user is demonstrating across these ${input.echoCount + 1} instances.`;
 }
+
+// ---------------------------------------------------------------------------
+// Contradiction judge (#1123)
+// ---------------------------------------------------------------------------
+
+export const CONTRADICTION_JUDGE_SYSTEM = `You are a long-term memory auditor. You are given TWO knowledge entries that a user's AI coding assistant has stored about how to work in their project. Your ONLY job is to decide whether the two entries DIRECTLY CONTRADICT each other — such that a person could not follow BOTH at the same time.
+
+A contradiction means the entries give mutually exclusive instructions about the SAME subject at the SAME scope: same thing, opposite directive. Entries that DO contradict:
+- "Always use tabs for indentation" vs "Always use spaces for indentation"
+- "Never mock the database in tests" vs "Always mock the database in tests"
+- "Deploy from the main branch only" vs "Deploy from the release branch only"
+
+Entries that do NOT contradict (do not flag these):
+- Different scope/subject: "Use tabs in Go files" vs "Use spaces in Python files"
+- Complementary rules: "Add tests after implementing a feature" vs "Run the linter before committing"
+- A general rule and a coexisting specific exception: "Prefer async handlers" vs "Use a sync handler for the health check"
+- Two phrasings of the SAME rule (that is a duplicate, not a contradiction)
+- Merely sharing a topic or words without opposing directives
+
+Precision matters far more than recall. When in doubt, answer false. A false alarm wastes the user's attention; a missed contradiction is harmless and can be caught later.
+
+Respond with a single JSON object:
+{ "contradict": true | false, "reason": "one concise sentence naming the exact conflict, or why they do not conflict" }
+
+Output ONLY valid JSON. No markdown fences, no explanation, no preamble.`;
+
+export function contradictionJudgeUser(input: {
+  a: { title: string; content: string };
+  b: { title: string; content: string };
+}): string {
+  return `ENTRY A:
+${input.a.title}: ${input.a.content}
+
+ENTRY B:
+${input.b.title}: ${input.b.content}
+
+Do these two entries directly contradict each other?`;
+}

--- a/packages/core/test/contradiction.test.ts
+++ b/packages/core/test/contradiction.test.ts
@@ -136,7 +136,12 @@ describe("contradiction store", () => {
   it("never re-opens a dismissed pair; dismiss removes it from the open list", async () => {
     const P = "/test/contra/store-dismiss";
     const a = await seed(P, "Always use tabs", "tabs everywhere", v(1, 0, 0));
-    const b = await seed(P, "Always use spaces", "spaces everywhere", v(1, 0, 0));
+    const b = await seed(
+      P,
+      "Always use spaces",
+      "spaces everywhere",
+      v(1, 0, 0),
+    );
     ltm.recordContradiction({
       logicalIdA: a,
       logicalIdB: b,
@@ -170,9 +175,9 @@ describe("contradiction store", () => {
     });
     expect(ltm.contradictionExists("c1", "c2")).toBe(true);
     expect(
-      ltm.listOpenContradictions().some(
-        (c) => c.logicalIdA === "c1" || c.logicalIdB === "c1",
-      ),
+      ltm
+        .listOpenContradictions()
+        .some((c) => c.logicalIdA === "c1" || c.logicalIdB === "c1"),
     ).toBe(false);
   });
 
@@ -224,7 +229,11 @@ describe("detectContradictions", () => {
       JSON.stringify({ contradict: true, reason: "tabs vs spaces" }),
     );
 
-    const res = await detectContradictions({ projectPath: P, sessionID: "s", llm });
+    const res = await detectContradictions({
+      projectPath: P,
+      sessionID: "s",
+      llm,
+    });
 
     expect(prompt).toHaveBeenCalledTimes(1);
     expect(res).toEqual({ judged: 1, found: 1 });
@@ -239,13 +248,22 @@ describe("detectContradictions", () => {
 
   it("records NO contradiction (and clears the pair) when the judge says no conflict", async () => {
     const P = "/test/contra/detect-false";
-    const a = await seed(P, "Add tests after a feature", "write tests", v(1, 0, 0));
+    const a = await seed(
+      P,
+      "Add tests after a feature",
+      "write tests",
+      v(1, 0, 0),
+    );
     const b = await seed(P, "Run the linter before commit", "lint", v(1, 0, 0));
     const { llm, prompt } = stubLLM(
       JSON.stringify({ contradict: false, reason: "complementary" }),
     );
 
-    const res = await detectContradictions({ projectPath: P, sessionID: "s", llm });
+    const res = await detectContradictions({
+      projectPath: P,
+      sessionID: "s",
+      llm,
+    });
 
     expect(prompt).toHaveBeenCalledTimes(1);
     expect(res).toEqual({ judged: 1, found: 0 });
@@ -262,11 +280,19 @@ describe("detectContradictions", () => {
       JSON.stringify({ contradict: true, reason: "opposed" }),
     );
 
-    const first = await detectContradictions({ projectPath: P, sessionID: "s", llm });
+    const first = await detectContradictions({
+      projectPath: P,
+      sessionID: "s",
+      llm,
+    });
     expect(first).toEqual({ judged: 1, found: 1 });
 
     // Second pass: the pair is already recorded → skipped, no LLM call.
-    const second = await detectContradictions({ projectPath: P, sessionID: "s", llm });
+    const second = await detectContradictions({
+      projectPath: P,
+      sessionID: "s",
+      llm,
+    });
     expect(second).toEqual({ judged: 0, found: 0 });
     expect(prompt).toHaveBeenCalledTimes(1);
     expect(ltm.listOpenContradictions(P)).toHaveLength(1);
@@ -278,7 +304,11 @@ describe("detectContradictions", () => {
     const { llm, prompt } = stubLLM(
       JSON.stringify({ contradict: true, reason: "x" }),
     );
-    const res = await detectContradictions({ projectPath: P, sessionID: "s", llm });
+    const res = await detectContradictions({
+      projectPath: P,
+      sessionID: "s",
+      llm,
+    });
     expect(res).toEqual({ judged: 0, found: 0 });
     expect(prompt).not.toHaveBeenCalled();
   });
@@ -291,7 +321,11 @@ describe("detectContradictions", () => {
     const { llm, prompt } = stubLLM(
       JSON.stringify({ contradict: true, reason: "x" }),
     );
-    const res = await detectContradictions({ projectPath: P, sessionID: "s", llm });
+    const res = await detectContradictions({
+      projectPath: P,
+      sessionID: "s",
+      llm,
+    });
     expect(res).toEqual({ judged: 0, found: 0 });
     expect(prompt).not.toHaveBeenCalled();
   });

--- a/packages/core/test/contradiction.test.ts
+++ b/packages/core/test/contradiction.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as data from "../src/data";
 import { db, ensureProject } from "../src/db";
 import { storeEmbedding } from "../src/db/vec-store";
 import * as embedding from "../src/embedding";
@@ -217,6 +218,25 @@ describe("contradiction store", () => {
     // Row physically purged, not just hidden by the JOIN.
     expect(ltm.contradictionExists(a, b)).toBe(false);
     expect(ltm.listOpenContradictions(P)).toHaveLength(0);
+  });
+
+  it("bulk clearKnowledge() purges contradiction rows (no orphans)", async () => {
+    const P = "/test/contra/store-clear";
+    const a = await seed(P, "X is required", "always x", v(1, 0, 0));
+    const b = await seed(P, "X is forbidden", "never x", v(1, 0, 0));
+    ltm.recordContradiction({
+      logicalIdA: a,
+      logicalIdB: b,
+      projectId: ensureProject(P),
+      similarity: 0.95,
+      rationale: "r",
+    });
+    expect(ltm.contradictionExists(a, b)).toBe(true);
+
+    // Bulk delete goes straight to DELETE FROM knowledge (not through remove()),
+    // so it must clean up knowledge_contradictions itself or leave orphans.
+    data.clearKnowledge(P);
+    expect(ltm.contradictionExists(a, b)).toBe(false);
   });
 });
 

--- a/packages/core/test/contradiction.test.ts
+++ b/packages/core/test/contradiction.test.ts
@@ -1,0 +1,298 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { db, ensureProject } from "../src/db";
+import { storeEmbedding } from "../src/db/vec-store";
+import * as embedding from "../src/embedding";
+import * as ltm from "../src/ltm";
+import {
+  candidatePairs,
+  detectContradictions,
+  parseContradictionVerdict,
+  type PairItem,
+} from "../src/contradiction";
+import type { LLMClient } from "../src/types";
+
+function v(...xs: number[]): Float32Array {
+  return new Float32Array(xs);
+}
+
+/** Create an entry and force a deterministic stored embedding, bypassing ONNX.
+ *  settleDocumentEmbeds() drains the fire-and-forget embed from create() first,
+ *  so our explicit vector is the final one. */
+async function seed(
+  projectPath: string,
+  title: string,
+  content: string,
+  vec: Float32Array,
+): Promise<string> {
+  const id = ltm.create({
+    projectPath,
+    category: "preference",
+    title,
+    content,
+    scope: "project",
+    confidence: 0.9,
+  });
+  await embedding.settleDocumentEmbeds();
+  storeEmbedding(db(), "knowledge", id, vec);
+  return id;
+}
+
+function stubLLM(response: string | null): {
+  llm: LLMClient;
+  prompt: ReturnType<typeof vi.fn>;
+} {
+  const prompt = vi.fn().mockResolvedValue(response);
+  return { llm: { prompt } as unknown as LLMClient, prompt };
+}
+
+beforeEach(() => {
+  // Deterministic, ONNX-free embedding for create()'s fire-and-forget embed;
+  // seed() overwrites with an explicit vector afterwards.
+  vi.spyOn(embedding, "embed").mockResolvedValue([v(0, 0, 1)]);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+
+describe("candidatePairs", () => {
+  it("returns only pairs at/above the threshold, most-similar first", () => {
+    const items: PairItem[] = [
+      { id: "a", logicalId: "a", vec: v(1, 0, 0) },
+      { id: "b", logicalId: "b", vec: v(0.99, 0.01, 0) }, // ~1.0 sim with a
+      { id: "c", logicalId: "c", vec: v(0, 1, 0) }, // orthogonal to a/b
+    ];
+    const pairs = candidatePairs(items, 0.6);
+    // a-b are near-identical (kept); a-c and b-c are orthogonal (dropped).
+    expect(pairs).toHaveLength(1);
+    expect(pairs[0].aIdx).toBe(0);
+    expect(pairs[0].bIdx).toBe(1);
+    expect(pairs[0].similarity).toBeGreaterThan(0.6);
+  });
+
+  it("sorts multiple qualifying pairs by descending similarity", () => {
+    const items: PairItem[] = [
+      { id: "a", logicalId: "a", vec: v(1, 0) },
+      { id: "b", logicalId: "b", vec: v(1, 0) }, // sim 1.0 with a
+      { id: "c", logicalId: "c", vec: v(0.8, 0.6) }, // sim 0.8 with a/b
+    ];
+    const pairs = candidatePairs(items, 0.6);
+    expect(pairs.length).toBeGreaterThanOrEqual(2);
+    for (let i = 1; i < pairs.length; i++) {
+      expect(pairs[i - 1].similarity).toBeGreaterThanOrEqual(
+        pairs[i].similarity,
+      );
+    }
+  });
+});
+
+describe("parseContradictionVerdict", () => {
+  it("parses a plain JSON verdict", () => {
+    expect(
+      parseContradictionVerdict('{"contradict": true, "reason": "x"}'),
+    ).toEqual({ contradict: true, reason: "x" });
+  });
+  it("strips ```json fences", () => {
+    expect(
+      parseContradictionVerdict('```json\n{"contradict": false}\n```'),
+    ).toEqual({ contradict: false, reason: null });
+  });
+  it("returns null for junk / non-JSON / missing field", () => {
+    expect(parseContradictionVerdict(null)).toBeNull();
+    expect(parseContradictionVerdict("not json")).toBeNull();
+    expect(parseContradictionVerdict('{"reason":"no verdict"}')).toBeNull();
+  });
+});
+
+describe("contradiction store", () => {
+  it("canonicalizes pair order and is idempotent", () => {
+    const P = "/test/contra/store-canon";
+    ensureProject(P);
+    expect(
+      ltm.recordContradiction({
+        logicalIdA: "zzz",
+        logicalIdB: "aaa",
+        projectId: null,
+        similarity: 0.9,
+        rationale: "r",
+      }),
+    ).toBe(true);
+    // Same pair, opposite order → no new row.
+    expect(
+      ltm.recordContradiction({
+        logicalIdA: "aaa",
+        logicalIdB: "zzz",
+        projectId: null,
+        similarity: 0.9,
+        rationale: "r2",
+      }),
+    ).toBe(false);
+    expect(ltm.contradictionExists("aaa", "zzz")).toBe(true);
+    expect(ltm.contradictionExists("zzz", "aaa")).toBe(true);
+  });
+
+  it("never re-opens a dismissed pair; dismiss removes it from the open list", async () => {
+    const P = "/test/contra/store-dismiss";
+    const a = await seed(P, "Always use tabs", "tabs everywhere", v(1, 0, 0));
+    const b = await seed(P, "Always use spaces", "spaces everywhere", v(1, 0, 0));
+    ltm.recordContradiction({
+      logicalIdA: a,
+      logicalIdB: b,
+      projectId: ensureProject(P),
+      similarity: 0.99,
+      rationale: "tabs vs spaces",
+    });
+    expect(ltm.listOpenContradictions(P)).toHaveLength(1);
+
+    ltm.setContradictionStatus(a, b, "dismissed");
+    expect(ltm.listOpenContradictions(P)).toHaveLength(0);
+    // A dismissed pair still "exists" so the detector never re-judges/re-surfaces it.
+    expect(ltm.contradictionExists(a, b)).toBe(true);
+    // INSERT OR IGNORE must not resurrect it as 'open'.
+    ltm.recordContradiction({
+      logicalIdA: a,
+      logicalIdB: b,
+      projectId: ensureProject(P),
+      similarity: 0.99,
+      rationale: "again",
+    });
+    expect(ltm.listOpenContradictions(P)).toHaveLength(0);
+  });
+
+  it("cleared pairs are recorded but never surfaced", () => {
+    ltm.recordContradictionCleared({
+      logicalIdA: "c1",
+      logicalIdB: "c2",
+      projectId: null,
+      similarity: 0.7,
+    });
+    expect(ltm.contradictionExists("c1", "c2")).toBe(true);
+    expect(
+      ltm.listOpenContradictions().some(
+        (c) => c.logicalIdA === "c1" || c.logicalIdB === "c1",
+      ),
+    ).toBe(false);
+  });
+
+  it("excludes pairs whose entries no longer exist (stale JOIN guard)", () => {
+    // Record a pair referencing logical_ids that were never created.
+    ltm.recordContradiction({
+      logicalIdA: "ghost-1",
+      logicalIdB: "ghost-2",
+      projectId: null,
+      similarity: 0.9,
+      rationale: "stale",
+    });
+    expect(
+      ltm.listOpenContradictions().some((c) => c.logicalIdA === "ghost-1"),
+    ).toBe(false);
+  });
+
+  it("remove() purges any contradiction pair touching the deleted entry", async () => {
+    const P = "/test/contra/store-remove";
+    const a = await seed(P, "Deploy from main only", "main branch", v(1, 0, 0));
+    const b = await seed(
+      P,
+      "Deploy from release only",
+      "release branch",
+      v(1, 0, 0),
+    );
+    ltm.recordContradiction({
+      logicalIdA: a,
+      logicalIdB: b,
+      projectId: ensureProject(P),
+      similarity: 0.95,
+      rationale: "branch conflict",
+    });
+    expect(ltm.contradictionExists(a, b)).toBe(true);
+
+    ltm.remove(a);
+    // Row physically purged, not just hidden by the JOIN.
+    expect(ltm.contradictionExists(a, b)).toBe(false);
+    expect(ltm.listOpenContradictions(P)).toHaveLength(0);
+  });
+});
+
+describe("detectContradictions", () => {
+  it("records a contradiction when the judge says the pair conflicts", async () => {
+    const P = "/test/contra/detect-true";
+    await seed(P, "Always use tabs", "tabs for indentation", v(1, 0, 0));
+    await seed(P, "Always use spaces", "spaces for indentation", v(1, 0, 0));
+    const { llm, prompt } = stubLLM(
+      JSON.stringify({ contradict: true, reason: "tabs vs spaces" }),
+    );
+
+    const res = await detectContradictions({ projectPath: P, sessionID: "s", llm });
+
+    expect(prompt).toHaveBeenCalledTimes(1);
+    expect(res).toEqual({ judged: 1, found: 1 });
+    const open = ltm.listOpenContradictions(P);
+    expect(open).toHaveLength(1);
+    expect([open[0].titleA, open[0].titleB].sort()).toEqual([
+      "Always use spaces",
+      "Always use tabs",
+    ]);
+    expect(open[0].rationale).toBe("tabs vs spaces");
+  });
+
+  it("records NO contradiction (and clears the pair) when the judge says no conflict", async () => {
+    const P = "/test/contra/detect-false";
+    const a = await seed(P, "Add tests after a feature", "write tests", v(1, 0, 0));
+    const b = await seed(P, "Run the linter before commit", "lint", v(1, 0, 0));
+    const { llm, prompt } = stubLLM(
+      JSON.stringify({ contradict: false, reason: "complementary" }),
+    );
+
+    const res = await detectContradictions({ projectPath: P, sessionID: "s", llm });
+
+    expect(prompt).toHaveBeenCalledTimes(1);
+    expect(res).toEqual({ judged: 1, found: 0 });
+    expect(ltm.listOpenContradictions(P)).toHaveLength(0);
+    // The pair was recorded as 'cleared' so it is never judged again.
+    expect(ltm.contradictionExists(a, b)).toBe(true);
+  });
+
+  it("judges each candidate pair at most once across passes (cost bound)", async () => {
+    const P = "/test/contra/detect-once";
+    await seed(P, "Never force-push", "no force push", v(1, 0, 0));
+    await seed(P, "Always force-push your branch", "force push", v(1, 0, 0));
+    const { llm, prompt } = stubLLM(
+      JSON.stringify({ contradict: true, reason: "opposed" }),
+    );
+
+    const first = await detectContradictions({ projectPath: P, sessionID: "s", llm });
+    expect(first).toEqual({ judged: 1, found: 1 });
+
+    // Second pass: the pair is already recorded → skipped, no LLM call.
+    const second = await detectContradictions({ projectPath: P, sessionID: "s", llm });
+    expect(second).toEqual({ judged: 0, found: 0 });
+    expect(prompt).toHaveBeenCalledTimes(1);
+    expect(ltm.listOpenContradictions(P)).toHaveLength(1);
+  });
+
+  it("does nothing with fewer than two embedded entries", async () => {
+    const P = "/test/contra/detect-single";
+    await seed(P, "Only rule here", "solo", v(1, 0, 0));
+    const { llm, prompt } = stubLLM(
+      JSON.stringify({ contradict: true, reason: "x" }),
+    );
+    const res = await detectContradictions({ projectPath: P, sessionID: "s", llm });
+    expect(res).toEqual({ judged: 0, found: 0 });
+    expect(prompt).not.toHaveBeenCalled();
+  });
+
+  it("does not judge topically-unrelated pairs (below the similarity floor)", async () => {
+    const P = "/test/contra/detect-unrelated";
+    // Orthogonal embeddings → cosine 0 → never a candidate → judge never runs.
+    await seed(P, "Rule about auth", "auth stuff", v(1, 0, 0));
+    await seed(P, "Rule about styling", "css stuff", v(0, 1, 0));
+    const { llm, prompt } = stubLLM(
+      JSON.stringify({ contradict: true, reason: "x" }),
+    );
+    const res = await detectContradictions({ projectPath: P, sessionID: "s", llm });
+    expect(res).toEqual({ judged: 0, found: 0 });
+    expect(prompt).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/test/contradiction.test.ts
+++ b/packages/core/test/contradiction.test.ts
@@ -333,6 +333,38 @@ describe("detectContradictions", () => {
     expect(prompt).not.toHaveBeenCalled();
   });
 
+  it("skips a corrupted embedding blob instead of aborting the whole pass", async () => {
+    const P = "/test/contra/corrupt-blob";
+    // Two valid, contradicting entries + one whose embedding blob is corrupt.
+    await seed(P, "Always cache aggressively", "cache it", v(1, 0, 0));
+    await seed(P, "Never cache anything", "no caching", v(1, 0, 0));
+    const bad = await seed(P, "Unrelated corrupt entry", "x", v(0, 1, 0));
+    // Overwrite the bad entry with a truncated blob (3 bytes) and make fromBlob
+    // throw for it, delegating to the real impl for the two valid entries.
+    db()
+      .query("UPDATE knowledge SET embedding = ? WHERE id = ?")
+      .run(Buffer.from([9, 9, 9]), bad);
+    const realFromBlob = embedding.fromBlob;
+    vi.spyOn(embedding, "fromBlob").mockImplementation((blob) => {
+      if ((blob as Buffer).length === 3) throw new Error("corrupt blob");
+      return realFromBlob(blob);
+    });
+    const { llm, prompt } = stubLLM(
+      JSON.stringify({ contradict: true, reason: "opposed" }),
+    );
+
+    // Must NOT throw; the two valid entries are still judged and the
+    // contradiction is still found.
+    const res = await detectContradictions({
+      projectPath: P,
+      sessionID: "s",
+      llm,
+    });
+    expect(prompt).toHaveBeenCalledTimes(1);
+    expect(res).toEqual({ judged: 1, found: 1 });
+    expect(ltm.listOpenContradictions(P)).toHaveLength(1);
+  });
+
   it("does not judge topically-unrelated pairs (below the similarity floor)", async () => {
     const P = "/test/contra/detect-unrelated";
     // Orthogonal embeddings → cosine 0 → never a candidate → judge never runs.

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -59,7 +59,7 @@ describe("db", () => {
     const row = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(row.version).toBe(61);
+    expect(row.version).toBe(62);
   });
 
   test("v55: confidence/last_reinforced_at moved to knowledge_meta, exposed via view", () => {
@@ -116,7 +116,7 @@ describe("db", () => {
     const ver = fresh.query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(ver.version).toBe(61);
+    expect(ver.version).toBe(62);
     // Register + JOIN view were rebuilt and are queryable (confidence exposed).
     expect(
       fresh

--- a/packages/core/test/ltm-versioning.test.ts
+++ b/packages/core/test/ltm-versioning.test.ts
@@ -39,11 +39,11 @@ function ftsHits(token: string): number {
 }
 
 describe("A2 sub-PR 1: append-only knowledge scaffolding", () => {
-  test("schema version is 61", () => {
+  test("schema version is 62", () => {
     const v = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(v.version).toBe(61);
+    expect(v.version).toBe(62);
   });
 
   test("create() defaults logical_id = id, version 1, current, not deleted", () => {

--- a/packages/gateway/src/cli/data.ts
+++ b/packages/gateway/src/cli/data.ts
@@ -903,6 +903,44 @@ function promptChoice(
   });
 }
 
+/**
+ * `lore data contradictions` — list open contradictions detected between
+ * knowledge entries (#1123). Read-only surface; resolve them on the dashboard
+ * (/ui/knowledge) or by editing/removing one side of the pair.
+ */
+async function cmdContradictions(
+  args: string[],
+  flags: Record<string, unknown>,
+): Promise<void> {
+  const { ltm } = await import("@loreai/core");
+  const asJson = !!flags.json;
+  const projectPath = resolve((flags.project as string) ?? process.cwd());
+  const items = ltm.listOpenContradictions(projectPath);
+
+  if (asJson) {
+    console.log(JSON.stringify(items, null, 2));
+    return;
+  }
+  if (!items.length) {
+    console.log("No open contradictions.");
+    return;
+  }
+
+  console.log(`${items.length} open contradiction(s):\n`);
+  for (const c of items) {
+    console.log(`  "${c.titleA}"`);
+    console.log(`    vs "${c.titleB}"`);
+    if (c.rationale) console.log(`    reason: ${c.rationale}`);
+    console.log(
+      `    similarity ${c.similarity.toFixed(3)}   detected ${formatDate(c.detectedAt)}`,
+    );
+    console.log("");
+  }
+  console.log(
+    "Resolve in the dashboard (/ui/knowledge), or edit/remove one side to clear it.",
+  );
+}
+
 async function cmdDedup(
   _args: string[],
   flags: Record<string, unknown>,
@@ -2660,6 +2698,7 @@ Subcommands:
   recover               Re-import knowledge from .lore.md / AGENTS.md files
   reground-entities     Re-derive entities (people, tools, ...) from history (needs a running gateway)
   dedup                 Find and remove duplicate knowledge entries (all projects)
+  contradictions        List knowledge entries that contradict each other (#1123)
   reindex               Rebuild embedding vectors (after model/config change)
   rerank                Re-score preference confidence by directive strength
   cache-stats           Show cache-bust counters (system[0] cache-alignment gate)
@@ -3180,6 +3219,9 @@ export async function commandData(
       break;
     case "dedup":
       await cmdDedup(subArgs, values);
+      break;
+    case "contradictions":
+      await cmdContradictions(subArgs, values);
       break;
     case "reindex":
       await cmdReindex(values);

--- a/packages/gateway/src/cli/data.ts
+++ b/packages/gateway/src/cli/data.ts
@@ -909,7 +909,7 @@ function promptChoice(
  * (/ui/knowledge) or by editing/removing one side of the pair.
  */
 async function cmdContradictions(
-  args: string[],
+  _args: string[],
   flags: Record<string, unknown>,
 ): Promise<void> {
   const { ltm } = await import("@loreai/core");

--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -16,6 +16,7 @@ import { join } from "node:path";
 import {
   temporal,
   distillation,
+  contradiction,
   curator,
   ltm,
   DirectFsResolver,
@@ -212,6 +213,39 @@ export function consolidationCooldownActive(
     return false;
   if (topCategoryCount > cooldown.topCategoryCount) return false;
   return true;
+}
+
+// ---------------------------------------------------------------------------
+// Contradiction detection throttle (#1123)
+// ---------------------------------------------------------------------------
+
+/**
+ * Last time a contradiction-detection pass STARTED for a project (resolved
+ * project ID). Armed unconditionally the moment a pass begins so a
+ * "nothing found" outcome still throttles the next attempt — otherwise the full
+ * embed + judge scan would rerun every idle tick (the pattern-echo throttle
+ * gotcha). Keyed by canonical project ID like the consolidation cooldown so N
+ * worktrees of one repo share a single bucket.
+ */
+const contradictionCooldown = new Map<string, number>();
+
+/**
+ * Projects with an in-flight contradiction pass — thundering-herd guard across
+ * concurrent idle sessions for the same project (set before the await, cleared
+ * in a finally), mirroring consolidationInProgress.
+ */
+const contradictionInProgress = new Set<string>();
+
+/** Minimum interval between contradiction-detection passes per project. */
+export const CONTRADICTION_COOLDOWN_MS = 60 * 60 * 1000; // 1h
+
+/** Pure decision: is contradiction detection still on cooldown for this project? */
+export function contradictionCooldownActive(
+  lastAttemptAt: number | undefined,
+  now: number,
+): boolean {
+  if (lastAttemptAt === undefined) return false;
+  return now - lastAttemptAt < CONTRADICTION_COOLDOWN_MS;
 }
 
 /**
@@ -773,6 +807,8 @@ export function evictIdleSessions(
     if (!projectStillActive) {
       consolidationCooldown.delete(evictedProjectId);
       consolidationInProgress.delete(evictedProjectId);
+      contradictionCooldown.delete(evictedProjectId);
+      contradictionInProgress.delete(evictedProjectId);
     }
 
     // GC the shared quota cache only when no remaining session uses this
@@ -1192,6 +1228,50 @@ export function buildIdleWorkHandler(
         }
       } catch (e) {
         log.error("idle consolidation error:", e);
+      }
+    }
+
+    // 4.5 Contradiction detection (#1123). Idle-time, LLM-gated: find genuinely
+    // OPPOSING knowledge pairs and record them for the user to resolve on the
+    // dashboard / CLI. Never merges or deletes — the affirmative of the
+    // consolidation "opposing rules are never duplicates" invariant. Runs AFTER
+    // consolidation so it judges the post-merge entry set (paraphrase duplicates
+    // already collapsed), and is throttled / in-flight-guarded like it.
+    if (allowWorker && cfg.knowledge.enabled && model) {
+      try {
+        const now = Date.now();
+        if (
+          contradictionCooldownActive(
+            contradictionCooldown.get(projectId),
+            now,
+          ) ||
+          contradictionInProgress.has(projectId)
+        ) {
+          // Throttled or a pass is already in flight for this project — skip.
+        } else {
+          // Arm the cooldown UNCONDITIONALLY before the work: a "nothing found"
+          // pass must still throttle the next attempt (pattern-echo gotcha).
+          contradictionCooldown.set(projectId, now);
+          contradictionInProgress.add(projectId);
+          try {
+            const res = await contradiction.detectContradictions({
+              projectPath,
+              sessionID,
+              llm,
+              model,
+            });
+            if (res.found > 0) {
+              log.info(
+                `contradiction detection: ${res.found} new contradiction(s) surfaced ` +
+                  `(${res.judged} judged) in ${projectPath}`,
+              );
+            }
+          } finally {
+            contradictionInProgress.delete(projectId);
+          }
+        }
+      } catch (e) {
+        log.error("idle contradiction detection error:", e);
       }
     }
 

--- a/packages/gateway/test/contradiction-throttle.test.ts
+++ b/packages/gateway/test/contradiction-throttle.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import {
+  CONTRADICTION_COOLDOWN_MS,
+  contradictionCooldownActive,
+} from "../src/idle";
+
+// Pure decision guard for the idle contradiction-detection step (#1123).
+// Mirrors the consolidationCooldownActive unit tests: the cooldown is armed
+// unconditionally when a pass starts, so a "nothing found" pass still throttles
+// the next attempt (the pattern-echo throttle gotcha).
+describe("contradictionCooldownActive", () => {
+  it("allows the first pass when there is no prior attempt", () => {
+    expect(contradictionCooldownActive(undefined, Date.now())).toBe(false);
+  });
+
+  it("throttles a repeat pass inside the cooldown window", () => {
+    const now = 5_000_000;
+    expect(
+      contradictionCooldownActive(now - (CONTRADICTION_COOLDOWN_MS - 1), now),
+    ).toBe(true);
+  });
+
+  it("allows a new pass once the cooldown window has elapsed", () => {
+    const now = 5_000_000;
+    expect(contradictionCooldownActive(now - CONTRADICTION_COOLDOWN_MS, now)).toBe(
+      false,
+    );
+    expect(
+      contradictionCooldownActive(now - (CONTRADICTION_COOLDOWN_MS + 1), now),
+    ).toBe(false);
+  });
+});

--- a/packages/gateway/test/contradiction-throttle.test.ts
+++ b/packages/gateway/test/contradiction-throttle.test.ts
@@ -22,9 +22,9 @@ describe("contradictionCooldownActive", () => {
 
   it("allows a new pass once the cooldown window has elapsed", () => {
     const now = 5_000_000;
-    expect(contradictionCooldownActive(now - CONTRADICTION_COOLDOWN_MS, now)).toBe(
-      false,
-    );
+    expect(
+      contradictionCooldownActive(now - CONTRADICTION_COOLDOWN_MS, now),
+    ).toBe(false);
     expect(
       contradictionCooldownActive(now - (CONTRADICTION_COOLDOWN_MS + 1), now),
     ).toBe(false);

--- a/packages/gateway/test/idle-work.test.ts
+++ b/packages/gateway/test/idle-work.test.ts
@@ -29,6 +29,7 @@ import { resetPipelineState } from "../src/pipeline";
 import { compressBody } from "../src/cache-analytics";
 import {
   ltm,
+  embedding,
   loadSessionCosts,
   db,
   ensureProject,
@@ -881,5 +882,109 @@ describe("buildIdleWorkHandler", () => {
     const persisted = loadSessionCosts("idle-cost");
     expect(persisted).not.toBeNull();
     expect(persisted?.conversationTurns).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildIdleWorkHandler — contradiction detection wiring (#1123, idle step 4.5)
+// ---------------------------------------------------------------------------
+// The pure gate (contradictionCooldownActive) is unit-tested in
+// contradiction-throttle.test.ts; here we prove the handler actually runs the
+// detector AND that it is throttled per project — including the "arm the
+// cooldown even on a nothing-found pass" invariant (the pattern-echo gotcha).
+describe("buildIdleWorkHandler — contradiction detection (#1123)", () => {
+  const F32 = (xs: number[]) => Buffer.from(new Float32Array(xs).buffer);
+
+  // Create entries and force deterministic embedding blobs, draining the
+  // fire-and-forget embed from create() first so our vectors are final.
+  async function seedKnowledge(
+    projectPath: string,
+    rows: Array<{ title: string; vec: number[] }>,
+  ): Promise<void> {
+    const ids = rows.map((r) =>
+      ltm.create({
+        projectPath,
+        category: "preference",
+        title: r.title,
+        content: `${r.title} — body`,
+        scope: "project",
+        confidence: 0.9,
+      }),
+    );
+    await embedding.settleDocumentEmbeds();
+    for (let i = 0; i < ids.length; i++) {
+      db()
+        .query("UPDATE knowledge SET embedding = ? WHERE id = ?")
+        .run(F32(rows[i].vec), ids[i]);
+    }
+  }
+
+  function contradictLLM(): LLMClient {
+    return {
+      prompt: vi.fn(async () =>
+        JSON.stringify({ contradict: true, reason: "opposed" }),
+      ),
+    } as unknown as LLMClient;
+  }
+
+  async function runIdle(
+    sessionID: string,
+    projectPath: string,
+    llm: LLMClient,
+  ): Promise<void> {
+    // Force getWorkerModel() truthy so the model-gated step 4.5 runs.
+    const prev = process.env.LORE_WORKER_MODEL;
+    process.env.LORE_WORKER_MODEL = "anthropic/claude-haiku-4-5";
+    try {
+      await buildIdleWorkHandler(llm)(
+        sessionID,
+        makeSessionState({ sessionID, projectPath, turnsSinceCuration: 0 }),
+      );
+    } finally {
+      if (prev === undefined) delete process.env.LORE_WORKER_MODEL;
+      else process.env.LORE_WORKER_MODEL = prev;
+    }
+  }
+
+  test("step 4.5 detects and records a contradiction from the idle handler", async () => {
+    const projectPath = makeProjectDir();
+    await seedKnowledge(projectPath, [
+      { title: "Always use tabs", vec: [1, 0, 0] },
+      { title: "Always use spaces", vec: [1, 0, 0] }, // same topic → candidate
+    ]);
+
+    await runIdle("idle-contra-detect", projectPath, contradictLLM());
+
+    expect(ltm.listOpenContradictions(projectPath)).toHaveLength(1);
+  });
+
+  test("detection is throttled per project — cooldown armed even on a nothing-found pass", async () => {
+    const projectPath = makeProjectDir();
+    // Pass 1 sees only UNRELATED entries (orthogonal → no candidate pair): it
+    // finds nothing, but MUST still arm the per-project cooldown.
+    await seedKnowledge(projectPath, [
+      { title: "Rule about auth", vec: [1, 0, 0] },
+      { title: "Rule about css", vec: [0, 1, 0] },
+    ]);
+    await runIdle("idle-contra-pass1", projectPath, contradictLLM());
+    expect(ltm.listOpenContradictions(projectPath)).toHaveLength(0);
+
+    // Introduce a genuine contradiction (same topic as the auth rule).
+    await seedKnowledge(projectPath, [
+      { title: "Never force push", vec: [1, 0, 0] },
+      { title: "Always force push", vec: [1, 0, 0] },
+    ]);
+
+    // Pass 2 (different session, same project, within the window) is throttled,
+    // so the new contradiction is NOT detected. Without the unconditional arm in
+    // pass 1, this pass would run and record it.
+    await runIdle("idle-contra-pass2", projectPath, contradictLLM());
+    expect(ltm.listOpenContradictions(projectPath)).toHaveLength(0);
+
+    // Sanity: the contradicting entries really are present (so the pass-2 zero is
+    // due to the throttle, not because consolidation removed them).
+    const titles = ltm.forProject(projectPath, true).map((e) => e.title);
+    expect(titles).toContain("Never force push");
+    expect(titles).toContain("Always force push");
   });
 });


### PR DESCRIPTION
## Summary

Implements #1123 (PR 1 of 2): an idle-time worker that detects **contradictions** between stored knowledge entries and records them for the user to resolve. This is the affirmative of the consolidation invariant *"opposing rules (e.g. 'always use tabs' vs 'always use spaces') are NEVER duplicates — never merge them"* (`prompt.ts`): consolidation must leave opposing entries alone; this worker is the one that notices them.

**Detection only — never auto-merges or auto-deletes.** The user picks the survivor (or keeps both). PR 2 (#1147) adds the `/ui/knowledge` dashboard banner.

## How it works

1. **Candidate prefilter (cheap):** opposing rules are *topically* similar, so pairs are formed by cosine similarity over existing knowledge embeddings (`CANDIDATE_SIMILARITY = 0.6`), most-similar first. No new embeddings computed.
2. **LLM judge (precise):** each *new* candidate pair is judged by a worker-model call (`CONTRADICTION_JUDGE_SYSTEM`, `temperature:0`) — "could a person follow both at once?". **Precision over recall**: when in doubt, not a contradiction.
3. **Bounded + idempotent:** ≤ 8 judge calls per pass; every judged pair is recorded once — contradictions as `status='open'` (surfaced), non-contradictions as `status='cleared'` (never re-judged). A user-dismissed/resolved pair is never re-surfaced.
4. **Throttled** per project (1h cooldown armed *unconditionally* at pass start — the pattern-echo gotcha) with an in-flight guard, run as idle **step 4.5** after consolidation.

## Changes

- **Migration v62** — `knowledge_contradictions` sidecar table keyed by the two stable `logical_id`s in canonical `a <= b` order (`status`, `similarity`, `rationale`, timestamps), + `recoverMissingObjects` self-heal. Never alters the frozen append-only `knowledge` table.
- **`ltm` store** — `recordContradiction` / `recordContradictionCleared` / `contradictionExists` / `listOpenContradictions` / `setContradictionStatus`; `remove()` and the bulk-delete paths (`clearProject`/`deleteProject`/`clearKnowledge`) purge pairs touching a deleted entry.
- **`contradiction.ts`** — the detector (+ pure `candidatePairs`, `parseContradictionVerdict`).
- **`prompt.ts`** — `CONTRADICTION_JUDGE_SYSTEM` + `contradictionJudgeUser`.
- **`idle.ts`** — step 4.5 wiring + `contradictionCooldownActive` gate + eviction cleanup.
- **CLI** — `lore data contradictions`.

## Tests (all mutation-verified non-vacuous)

- `contradiction.test.ts` — pure `candidatePairs` + verdict parser; store (canonical order, dismiss, cleared, stale-JOIN, `remove()` + bulk-`clearKnowledge()` cleanup, corrupt-blob resilience); detector (records on conflict / clears on no-conflict / judges each pair at most once / `< 2` entries / below-similarity).
- `contradiction-throttle.test.ts` — pure cooldown gate.
- `idle-work.test.ts` — integration coverage for step 4.5: the handler detects+records a contradiction, and detection is throttled per project **including the "arm the cooldown even on a nothing-found pass" invariant**.
- Schema-version pins bumped to 62 (`db.test.ts`, `ltm-versioning.test.ts`). No regressions across the related core/gateway suites; `tsc --noEmit` + `biome check` clean.

## Post-review hardening (adversarial review round)

- **S1** — the detector's embedding load now wraps `fromBlob` in try/catch (mirrors the dedup guard): a single corrupted/stale blob is skipped instead of throwing out of the pass with the cooldown already armed (which would silently disable detection for the project for an hour).
- **S2** — added the idle-handler integration tests above (the throttle wiring was previously only covered at the pure-gate level).
- Bulk-delete orphan cleanup (Seer) + duplicate-comment cleanup.

Refs #1123
