### PR TITLE
feat(gateway): per-platform @loreai/onnxruntime-<os>-<arch> package generator (1/3)

### DIFF
--- a/packages/gateway/script/ort-platform-package.ts
+++ b/packages/gateway/script/ort-platform-package.ts
@@ -1,0 +1,212 @@
+/**
+ * Generate per-platform npm packages that carry the native `onnxruntime-node`
+ * addon + its shared libraries — the esbuild distribution model (see
+ * `@esbuild/<os>-<arch>`), replicated for ONNX Runtime.
+ *
+ * WHY: the `@loreai/gateway` npm bundle ships a self-contained WASM ONNX runtime
+ * so that dist-only installs (AUR, vendored `dist/`) work with zero
+ * `node_modules` (#763). But WASM is single-threaded and 2.7–4.1× slower than
+ * native (#999), and every normal `npm i` / plugin install DOES have a
+ * `node_modules`. We can't just depend on `onnxruntime-node` directly: its
+ * native binary arrives via a **postinstall download** from GitHub releases,
+ * which npm 12 will stop running automatically and which fails in offline / air-
+ * gapped / proxied installs.
+ *
+ * esbuild's answer — which we copy — is per-platform packages gated by npm's
+ * `os`/`cpu` fields and resolved at runtime with plain `require.resolve`:
+ *   - `@loreai/onnxruntime-<os>-<arch>` holds only that platform's ORT files.
+ *   - `os`/`cpu` make npm install ONLY the matching one (and, as an
+ *     optionalDependency, silently skip it when it can't — e.g. dist-only).
+ *   - `preferUnplugged: true` keeps the addon a real on-disk file under Yarn PnP.
+ *   - There is **no install script** — the addon is found at runtime via
+ *     `require.resolve("@loreai/onnxruntime-<target>/onnxruntime_binding.node")`
+ *     (see the runtime resolver), so this is fully npm-12-safe.
+ * When no platform package resolves (dist-only), the gateway falls back to its
+ * bundled WASM runtime — analogous to esbuild's `esbuild-wasm` fallback.
+ *
+ * Runs under Node (via tsx). Importing this module has no side effects.
+ */
+import {
+  copyFileSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseArgs } from "node:util";
+import {
+  ORT_BINDING_FILE,
+  collectOrtFiles,
+  ortNodeVersion,
+} from "./vendor-ort-native";
+
+/** A native-ORT npm target, keyed by `<process.platform>-<process.arch>` so the
+ *  runtime resolver can build the package name with no OS-name translation
+ *  (unlike the SEA's VendorTarget, which uses "windows"). */
+export interface OrtNpmPlatform {
+  /** `${process.platform}-${process.arch}`, e.g. "linux-x64", "win32-arm64". */
+  target: string;
+  /** onnxruntime-node `bin/napi-v3` subdir, e.g. "linux/x64". */
+  subdir: string;
+  /** npm `os` field value (== process.platform). */
+  os: string;
+  /** npm `cpu` field value (== process.arch). */
+  cpu: string;
+}
+
+/** The platforms onnxruntime-node@1.21 ships prebuilt binaries for. */
+export const ORT_NPM_PLATFORMS: readonly OrtNpmPlatform[] = [
+  { target: "linux-x64", subdir: "linux/x64", os: "linux", cpu: "x64" },
+  { target: "linux-arm64", subdir: "linux/arm64", os: "linux", cpu: "arm64" },
+  { target: "darwin-x64", subdir: "darwin/x64", os: "darwin", cpu: "x64" },
+  {
+    target: "darwin-arm64",
+    subdir: "darwin/arm64",
+    os: "darwin",
+    cpu: "arm64",
+  },
+  { target: "win32-x64", subdir: "win32/x64", os: "win32", cpu: "x64" },
+  { target: "win32-arm64", subdir: "win32/arm64", os: "win32", cpu: "arm64" },
+] as const;
+
+/** The scoped npm package name for a target, e.g. `@loreai/onnxruntime-linux-x64`. */
+export function ortPackageName(target: string): string {
+  return `@loreai/onnxruntime-${target}`;
+}
+
+/** The subpath within a platform package that resolves to the native addon —
+ *  what the runtime resolver passes to `require.resolve` and what the patched
+ *  onnxruntime-node binding.js ultimately loads. The addon's shared-library
+ *  siblings live in the same dir (package root), so $ORIGIN / @loader_path /
+ *  Windows DLL-search resolve them by construction. */
+export const ORT_PACKAGE_BINDING_SUBPATH = ORT_BINDING_FILE;
+
+/** Compute the platform target for the *running* process. Kept here (next to
+ *  ORT_NPM_PLATFORMS) so the build-time package names and the runtime
+ *  `require.resolve` key can never drift. */
+export function ortPlatformTarget(
+  platform: string = process.platform,
+  arch: string = process.arch,
+): string {
+  return `${platform}-${arch}`;
+}
+
+export interface BuiltOrtPackage {
+  target: string;
+  dir: string;
+  packageName: string;
+  files: string[];
+}
+
+/**
+ * Materialize each platform's npm package under `outDir/onnxruntime-<target>/`:
+ * a `package.json` (name/version/os/cpu/preferUnplugged/files) plus the native
+ * files copied flat into the package root. `version` is normally the gateway's
+ * version so the published packages stay version-locked with the
+ * `optionalDependencies` that reference them.
+ */
+export function buildOrtPlatformPackages(
+  outDir: string,
+  version: string,
+  platforms: readonly OrtNpmPlatform[] = ORT_NPM_PLATFORMS,
+): BuiltOrtPackage[] {
+  const built: BuiltOrtPackage[] = [];
+  for (const platform of platforms) {
+    const files = collectOrtFiles(platform.subdir);
+    const packageName = ortPackageName(platform.target);
+    const dir = join(outDir, `onnxruntime-${platform.target}`);
+    rmSync(dir, { recursive: true, force: true });
+    mkdirSync(dir, { recursive: true });
+
+    for (const { file, srcPath } of files) {
+      copyFileSync(srcPath, join(dir, file));
+    }
+
+    const fileNames = files.map((f) => f.file).sort();
+    const pkg = {
+      name: packageName,
+      version,
+      description: `Native ONNX Runtime (${platform.target}) for @loreai/gateway local embeddings. Auto-selected via os/cpu; not meant to be installed directly.`,
+      license: "FSL-1.1-Apache-2.0",
+      repository: {
+        type: "git",
+        url: "git+https://github.com/BYK/loreai.git",
+        directory: "packages/gateway",
+      },
+      // os/cpu gate install to the matching platform only; as an
+      // optionalDependency, npm silently skips the rest.
+      os: [platform.os],
+      cpu: [platform.cpu],
+      // Keep the addon a real on-disk file under Yarn PnP (it's dlopen'd, and
+      // its sibling libs must resolve next to it).
+      preferUnplugged: true,
+      // No "exports" field on purpose: the runtime resolver deep-imports the
+      // addon file via require.resolve("<pkg>/onnxruntime_binding.node"), which
+      // an "exports" map would block.
+      files: fileNames,
+      publishConfig: { access: "public" },
+    };
+    writeFileSync(
+      join(dir, "package.json"),
+      `${JSON.stringify(pkg, null, 2)}\n`,
+    );
+    writeFileSync(
+      join(dir, "README.md"),
+      `# ${packageName}\n\nThe ${platform.target} native ONNX Runtime for ` +
+        `[\`@loreai/gateway\`](https://www.npmjs.com/package/@loreai/gateway) ` +
+        `local embeddings.\n\nThis package is installed automatically (via ` +
+        `\`optionalDependencies\` + \`os\`/\`cpu\`) on matching platforms and ` +
+        `loaded at runtime. You should not depend on it directly.\n`,
+    );
+
+    built.push({ target: platform.target, dir, packageName, files: fileNames });
+  }
+  return built;
+}
+
+// ---------------------------------------------------------------------------
+// CLI: `tsx script/ort-platform-package.ts --out <dir> [--version x.y.z]`
+// ---------------------------------------------------------------------------
+async function main(): Promise<void> {
+  const { values } = parseArgs({
+    args: process.argv.slice(2),
+    options: {
+      out: { type: "string" },
+      version: { type: "string" },
+    },
+    allowPositionals: false,
+    strict: true,
+  });
+  if (!values.out) {
+    console.error(
+      "Usage: ort-platform-package.ts --out <dir> [--version x.y.z]",
+    );
+    process.exit(1);
+  }
+  // Default to the gateway's version so the packages stay version-locked with
+  // the optionalDependencies that reference them (publishing passes it anyway).
+  const gatewayPkg = JSON.parse(
+    readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), "..", "package.json"),
+      "utf8",
+    ),
+  ) as { version: string };
+  const version = values.version ?? gatewayPkg.version;
+  console.log(
+    `→ build ${ORT_NPM_PLATFORMS.length} @loreai/onnxruntime-* packages ` +
+      `@ ${version} (onnxruntime-node ${ortNodeVersion()}) → ${values.out}`,
+  );
+  const built = buildOrtPlatformPackages(values.out, version);
+  for (const b of built) {
+    console.log(`✓ ${b.packageName}  [${b.files.join(", ")}]  → ${b.dir}`);
+  }
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/packages/gateway/script/vendor-ort-native.ts
+++ b/packages/gateway/script/vendor-ort-native.ts
@@ -84,20 +84,44 @@ export function ortNodeVersion(): string {
   return v;
 }
 
+/** onnxruntime-node's `bin/napi-v3` root, under which each platform's files
+ *  live in `<process.platform>/<process.arch>/` subdirs. */
+export function ortNodeBinRoot(): string {
+  return join(ortNodeDir(), "bin", "napi-v3");
+}
+
 /**
- * The set of files to embed for `target`: every file in the platform's bin dir,
- * MINUS longer-versioned aliases of another file. e.g. linux ships both
+ * The native files for one onnxruntime-node platform, given its `bin/napi-v3`
+ * subdir (e.g. `"linux/x64"`, `"win32/arm64"`). Returns every file in the dir
+ * MINUS longer-versioned aliases of another file: linux ships both
  * `libonnxruntime.so.1` (the SONAME the addon's NEEDED entry references) and
- * `libonnxruntime.so.1.21.0` (identical bytes); we keep the SONAME and drop the
- * duplicate to avoid embedding ~21 MB twice. darwin's `libonnxruntime.1.21.0.
+ * `libonnxruntime.so.1.21.0` (identical bytes) — we keep the SONAME and drop the
+ * duplicate to avoid shipping ~21 MB twice. darwin's `libonnxruntime.1.21.0.
  * dylib` has no shorter alias so it's kept; windows' `onnxruntime.dll` /
  * `DirectML.dll` are kept. Version-robust: no hard-coded library filenames.
+ * Throws if the dir is missing or lacks the addon.
  */
-function targetFiles(dir: string): string[] {
+export function collectOrtFiles(
+  binSubdir: string,
+): Array<{ file: string; srcPath: string }> {
+  const dir = join(ortNodeBinRoot(), binSubdir);
+  if (!existsSync(dir)) {
+    throw new Error(
+      `vendor-ort-native: onnxruntime-node bin dir missing: ${dir}`,
+    );
+  }
   const all = readdirSync(dir).filter((f) => !f.startsWith("."));
   // Drop F when some other G is a strict prefix of F followed by "." — i.e. F is
   // a longer-versioned alias (libX.so.1.21.0 vs the SONAME libX.so.1).
-  return all.filter((f) => !all.some((g) => g !== f && f.startsWith(`${g}.`)));
+  const kept = all.filter(
+    (f) => !all.some((g) => g !== f && f.startsWith(`${g}.`)),
+  );
+  if (!kept.includes(ORT_BINDING_FILE)) {
+    throw new Error(
+      `vendor-ort-native: ${ORT_BINDING_FILE} not found in ${dir}`,
+    );
+  }
+  return kept.map((file) => ({ file, srcPath: join(dir, file) }));
 }
 
 /** Absolute source path + asset key for every native file of every target.
@@ -109,30 +133,17 @@ export function ortNativeAssets(
   VendorTarget,
   Array<{ assetKey: string; srcPath: string; file: string }>
 > {
-  const binRoot = join(ortNodeDir(), "bin", "napi-v3");
   const out = new Map<
     VendorTarget,
     Array<{ assetKey: string; srcPath: string; file: string }>
   >();
   for (const target of targets) {
-    const dir = join(binRoot, ORT_TARGET_SUBDIR[target]);
-    if (!existsSync(dir)) {
-      throw new Error(
-        `vendor-ort-native: onnxruntime-node bin dir missing for ${target}: ${dir}`,
-      );
-    }
-    const files = targetFiles(dir);
-    if (!files.includes(ORT_BINDING_FILE)) {
-      throw new Error(
-        `vendor-ort-native: ${ORT_BINDING_FILE} not found for ${target} in ${dir}`,
-      );
-    }
     out.set(
       target,
-      files.map((file) => ({
+      collectOrtFiles(ORT_TARGET_SUBDIR[target]).map(({ file, srcPath }) => ({
         file,
+        srcPath,
         assetKey: ortAssetKey(target, file),
-        srcPath: join(dir, file),
       })),
     );
   }

--- a/packages/gateway/test/ort-platform-package.test.ts
+++ b/packages/gateway/test/ort-platform-package.test.ts
@@ -1,0 +1,102 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, test } from "vitest";
+import {
+  buildOrtPlatformPackages,
+  ORT_NPM_PLATFORMS,
+  ORT_PACKAGE_BINDING_SUBPATH,
+  ortPackageName,
+  ortPlatformTarget,
+} from "../script/ort-platform-package";
+
+// The per-platform ORT packages are found at runtime via
+//   require.resolve(`${ortPackageName(ortPlatformTarget())}/${ORT_PACKAGE_BINDING_SUBPATH}`)
+// so the (process.platform, process.arch) → package-name derivation MUST match
+// the names/os/cpu the generator publishes, or a platform silently loses native
+// embeddings (resolve throws → WASM fallback). This binds both sides.
+
+describe("ORT_NPM_PLATFORMS ⇄ runtime resolution key", () => {
+  test("covers the 6 onnxruntime-node platforms, no dupes", () => {
+    expect(ORT_NPM_PLATFORMS.map((p) => p.target).sort()).toEqual([
+      "darwin-arm64",
+      "darwin-x64",
+      "linux-arm64",
+      "linux-x64",
+      "win32-arm64",
+      "win32-x64",
+    ]);
+  });
+
+  test("target === <os>-<cpu> === runtime key from those os/cpu", () => {
+    for (const p of ORT_NPM_PLATFORMS) {
+      // package identity: target is exactly os-cpu (npm os/cpu == process values)
+      expect(p.target).toBe(`${p.os}-${p.cpu}`);
+      // a process on this platform derives the same target → same package name
+      expect(ortPlatformTarget(p.os, p.cpu)).toBe(p.target);
+    }
+  });
+
+  test("package name mirrors @esbuild/<os>-<arch> shape", () => {
+    expect(ortPackageName("linux-x64")).toBe("@loreai/onnxruntime-linux-x64");
+    expect(ortPackageName("win32-arm64")).toBe(
+      "@loreai/onnxruntime-win32-arm64",
+    );
+  });
+
+  test("subdir is the onnxruntime-node bin layout (win32 stays win32)", () => {
+    const byTarget = Object.fromEntries(
+      ORT_NPM_PLATFORMS.map((p) => [p.target, p.subdir]),
+    );
+    expect(byTarget["linux-x64"]).toBe("linux/x64");
+    expect(byTarget["win32-x64"]).toBe("win32/x64");
+    expect(byTarget["darwin-arm64"]).toBe("darwin/arm64");
+  });
+});
+
+describe("buildOrtPlatformPackages (real onnxruntime-node)", () => {
+  const out = mkdtempSync(join(tmpdir(), "ort-pkgs-"));
+  const built = buildOrtPlatformPackages(out, "9.9.9");
+  afterAll(() => rmSync(out, { recursive: true, force: true }));
+
+  test("emits one package per platform with the addon present", () => {
+    expect(built).toHaveLength(ORT_NPM_PLATFORMS.length);
+    for (const b of built) {
+      expect(b.files).toContain(ORT_PACKAGE_BINDING_SUBPATH);
+      // the addon file physically exists at the resolve subpath
+      expect(existsSync(join(b.dir, ORT_PACKAGE_BINDING_SUBPATH))).toBe(true);
+    }
+  });
+
+  test("package.json: name/version/os/cpu/preferUnplugged, no exports", () => {
+    for (const p of ORT_NPM_PLATFORMS) {
+      const dir = join(out, `onnxruntime-${p.target}`);
+      const pkg = JSON.parse(readFileSync(join(dir, "package.json"), "utf8"));
+      expect(pkg.name).toBe(ortPackageName(p.target));
+      expect(pkg.version).toBe("9.9.9");
+      expect(pkg.os).toEqual([p.os]);
+      expect(pkg.cpu).toEqual([p.cpu]);
+      expect(pkg.preferUnplugged).toBe(true);
+      // no "exports" — the runtime deep-imports the .node file via require.resolve
+      expect(pkg.exports).toBeUndefined();
+      // every declared file exists on disk
+      for (const f of pkg.files) expect(existsSync(join(dir, f))).toBe(true);
+    }
+  });
+
+  test("alias-drop keeps the linux SONAME, drops the versioned duplicate", () => {
+    const linux = built.find((b) => b.target === "linux-x64")!;
+    expect(linux.files).toContain("libonnxruntime.so.1");
+    expect(linux.files).not.toContain("libonnxruntime.so.1.21.0");
+  });
+
+  test("darwin keeps its versioned dylib; win32 ships both DLLs", () => {
+    const darwin = built.find((b) => b.target === "darwin-arm64")!;
+    expect(
+      darwin.files.some((f) => /^libonnxruntime\..*\.dylib$/.test(f)),
+    ).toBe(true);
+    const win = built.find((b) => b.target === "win32-x64")!;
+    expect(win.files).toContain("onnxruntime.dll");
+    expect(win.files).toContain("DirectML.dll");
+  });
+});


### PR DESCRIPTION
First of 3 PRs giving the **npm** gateway — and the opencode/pi plugins that load it in-process — **native** ONNX Runtime instead of single-threaded WASM, by replicating esbuild's per-platform distribution model.

## Background

The `@loreai/gateway` npm bundle ships self-contained WASM so dist-only installs (AUR, vendored `dist/`) work with zero `node_modules` (#763). But WASM is 2.7–4.1× slower than native (#999), and normal `npm i` / plugin installs *do* have `node_modules`. We can't just depend on `onnxruntime-node`: its native binary arrives via a **postinstall download from GitHub releases**, which npm 12 will stop auto-running and which fails offline/air-gapped.

esbuild solves this with `@esbuild/<os>-<arch>` packages gated by npm `os`/`cpu`, found at runtime via plain `require.resolve` (postinstall is only a download *fallback*). Confirmed feasibility: **Bun loads the ORT `.node` addon fine** (18ms), so both plugins benefit.

## This PR (build-time only — no runtime behavior change yet)

- **`ort-platform-package.ts`** — `ORT_NPM_PLATFORMS` (the 6 platforms onnxruntime-node ships: linux/darwin/win32 × x64/arm64), `ortPackageName`, `ortPlatformTarget` (the `${process.platform}-${process.arch}` runtime key), and `buildOrtPlatformPackages(outDir, version)` emitting per-platform `@loreai/onnxruntime-<target>` packages: ORT addon + shared libs + a `package.json` with `os`/`cpu` (install-gating), `preferUnplugged` (keep the dlopen'd addon a real file under Yarn PnP), a `files` allowlist, and **no `exports`** (so the runtime can deep-import `.../onnxruntime_binding.node`).
- **`vendor-ort-native.ts`** — extracted the reusable `collectOrtFiles(binSubdir)` + `ortNodeBinRoot()` (shared with the SEA path); `ortNativeAssets` behavior unchanged.
- **Contract test** — binds the `(platform,arch)→package-name` derivation both ways (incl. win32 staying `win32`), asserts `os`/`cpu`/`preferUnplugged`/no-`exports`, the addon at the resolve subpath, and the alias-drop rule (keeps `libonnxruntime.so.1`, drops the `.so.1.21.0` dup; darwin keeps its versioned dylib; win32 ships `onnxruntime.dll` + `DirectML.dll`).

Verified: generator emits all 6 packages correctly from `node_modules`; 15 tests pass; typecheck + lint clean. The `0.0.0` placeholder packages are already reserved on npm.

## Next
- **PR 2:** npm bundle native-first resolver (`require.resolve` the platform package → `__LORE_ORT_BINDING_PATH__`, reusing #1143's binding patch) with WASM fallback via transformers' `Symbol.for('onnxruntime')` override.
- **PR 3:** `.craft.yml` + `bump-version.sh` publish the 6 packages version-locked with the gateway; inject `optionalDependencies` at publish time.