### PR TITLE
feat(gateway): npm bundle prefers native ONNX Runtime, falls back to WASM (2/3)

### DIFF
--- a/packages/core/src/embedding-worker.ts
+++ b/packages/core/src/embedding-worker.ts
@@ -249,34 +249,50 @@ async function ensurePipeline(): Promise<void> {
  * so it can be retried after a corrupt-model purge. Throws on any failure.
  */
 async function loadPipeline(): Promise<void> {
-  // npm dist-only path: the npm worker bundle redirects onnxruntime-node →
-  // onnxruntime-web (WASM) and ships the WASM runtime (ort-wasm-simd-threaded.
-  // {mjs,wasm}) next to this file in dist/ — this keeps `npm install`/AUR
-  // dist-only installs (no node_modules) self-contained (#763). Point
-  // transformers.js' patched wasmPaths at those sibling files so the WASM loads
-  // locally instead of from the jsdelivr CDN (wrong variant + requires network).
-  // The standalone SEA binary does NOT take this path: it bundles the native
-  // onnxruntime-node addon (extracted by native-loader.cjs) and runs in
-  // `vendorModel` mode, so `!vendorModel` short-circuits below. Guarded by
-  // existsSync so dev/test (raw .ts with the real native onnxruntime-node and no
-  // sibling WASM) are unaffected — the block is simply inert there.
+  // npm gateway bundle path: prefer NATIVE ONNX Runtime, fall back to the
+  // bundled WASM. This bundle ships the WASM runtime (ort-wasm-simd-threaded.
+  // {mjs,wasm}) next to this worker, so their presence is the "am I the npm
+  // bundle?" signal. dev/test (raw .ts, real native onnxruntime-node, no sibling
+  // WASM) and the SEA binary (vendorModel mode; native via
+  // __LORE_ORT_BINDING_PATH__ set by native-loader.cjs) don't match, so this
+  // block stays inert there.
+  //
+  // Native: if the per-platform `@loreai/onnxruntime-<target>` package is
+  // installed (optionalDependencies gated by os/cpu — npm-12-safe, no
+  // postinstall download), resolve its addon and set __LORE_ORT_BINDING_PATH__;
+  // the graceful-patched onnxruntime-node binding then loads it and
+  // transformers.js uses native (2.7–4.1× faster than WASM, #999).
+  //
+  // Fallback (dist-only / unsupported platform): point transformers' wasmPaths
+  // at the shipped WASM files (local, not the jsdelivr CDN). The bundle's
+  // onnxruntime-node shim (ort-npm-plugin.ts) sees no __LORE_ORT_BINDING_PATH__
+  // and resolves to onnxruntime-web, so transformers' IS_NODE_ENV branch (which
+  // registers the "cpu" device) drives WASM — keeping dist-only/AUR installs
+  // self-contained (#763).
   const globals = globalThis as Record<string, unknown>;
-  if (
-    !vendorModel &&
-    !globals.__LORE_NPM_WASM_PATHS__ &&
-    typeof __filename === "string"
-  ) {
+  if (!vendorModel && typeof __filename === "string") {
     const { dirname, join } = await import("node:path");
     const { pathToFileURL } = await import("node:url");
     const { existsSync } = await import("node:fs");
     const distDir = dirname(__filename);
     const wasmMjs = join(distDir, "ort-wasm-simd-threaded.mjs");
     const wasmBin = join(distDir, "ort-wasm-simd-threaded.wasm");
-    if (existsSync(wasmMjs) && existsSync(wasmBin)) {
-      globals.__LORE_NPM_WASM_PATHS__ = {
-        mjs: pathToFileURL(wasmMjs).href,
-        wasm: wasmBin,
-      };
+    const isNpmBundle = existsSync(wasmMjs) && existsSync(wasmBin);
+    if (
+      isNpmBundle &&
+      !globals.__LORE_ORT_BINDING_PATH__ &&
+      !globals.__LORE_NPM_WASM_PATHS__
+    ) {
+      const { resolveNativeOrtBindingPath } = await import("./ort-native");
+      const nativePath = resolveNativeOrtBindingPath(__filename);
+      if (nativePath) {
+        globals.__LORE_ORT_BINDING_PATH__ = nativePath;
+      } else {
+        globals.__LORE_NPM_WASM_PATHS__ = {
+          mjs: pathToFileURL(wasmMjs).href,
+          wasm: wasmBin,
+        };
+      }
     }
   }
 

--- a/packages/core/src/ort-native.ts
+++ b/packages/core/src/ort-native.ts
@@ -1,0 +1,56 @@
+/**
+ * Runtime resolution of the native ONNX Runtime addon shipped as a per-platform
+ * npm package (`@loreai/onnxruntime-<os>-<arch>`), the esbuild distribution
+ * model. See `packages/gateway/script/ort-platform-package.ts` for the build /
+ * publish side — the package name computed here MUST match the names published
+ * there (both are pinned to the literal `@loreai/onnxruntime-<os>-<arch>` shape
+ * by tests on each side).
+ *
+ * The npm gateway worker bundle uses this to prefer native ONNX Runtime over the
+ * bundled WASM fallback: if the platform package is installed (npm did so via
+ * `optionalDependencies` gated by `os`/`cpu`), `require.resolve` finds its
+ * addon at runtime — no postinstall, npm-12-safe — and the worker points
+ * transformers.js at it. When it isn't installed (dist-only / unsupported
+ * platform), resolution returns null and the worker falls back to WASM.
+ */
+import { createRequire } from "node:module";
+
+/** The npm target key for a platform: `<process.platform>-<process.arch>`
+ *  (e.g. "linux-x64", "darwin-arm64", "win32-arm64"). Matches the package name
+ *  suffix exactly — no OS-name translation (win32 stays win32). */
+export function ortPlatformTarget(
+  platform: string = process.platform,
+  arch: string = process.arch,
+): string {
+  return `${platform}-${arch}`;
+}
+
+/** The per-platform native-ORT package name, e.g. `@loreai/onnxruntime-linux-x64`. */
+export function ortNativePackageName(
+  target: string = ortPlatformTarget(),
+): string {
+  return `@loreai/onnxruntime-${target}`;
+}
+
+/** The addon file within a platform package (its shared-library siblings sit
+ *  next to it, resolved by $ORIGIN / @loader_path / Windows DLL search). */
+export const ORT_NATIVE_BINDING_FILE = "onnxruntime_binding.node";
+
+/**
+ * Resolve the absolute path to the native ONNX Runtime addon for the running
+ * platform, or `null` if the matching `@loreai/onnxruntime-<target>` package
+ * isn't installed / resolvable. `fromPath` is the resolving module's location
+ * (pass `__filename` from the worker — real in CJS, provided by Bun in ESM) so
+ * resolution walks up from the installed gateway's `node_modules`.
+ *
+ * Never throws: an unresolvable package is the expected dist-only case and must
+ * degrade to the WASM fallback, not crash embedding.
+ */
+export function resolveNativeOrtBindingPath(fromPath: string): string | null {
+  try {
+    const req = createRequire(fromPath);
+    return req.resolve(`${ortNativePackageName()}/${ORT_NATIVE_BINDING_FILE}`);
+  } catch {
+    return null;
+  }
+}

--- a/packages/core/test/ort-native.test.ts
+++ b/packages/core/test/ort-native.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "vitest";
+import {
+  ORT_NATIVE_BINDING_FILE,
+  ortNativePackageName,
+  ortPlatformTarget,
+  resolveNativeOrtBindingPath,
+} from "../src/ort-native";
+
+// These derivations MUST match the per-platform packages published by
+// packages/gateway/script/ort-platform-package.ts (asserted there too). The
+// literal `@loreai/onnxruntime-<os>-<arch>` shape is the contract binding the
+// build-time package names to this runtime require.resolve key.
+
+describe("ort-native runtime resolution", () => {
+  test("ortPlatformTarget = <platform>-<arch>; win32 is NOT translated", () => {
+    expect(ortPlatformTarget("linux", "x64")).toBe("linux-x64");
+    expect(ortPlatformTarget("linux", "arm64")).toBe("linux-arm64");
+    expect(ortPlatformTarget("darwin", "arm64")).toBe("darwin-arm64");
+    expect(ortPlatformTarget("darwin", "x64")).toBe("darwin-x64");
+    expect(ortPlatformTarget("win32", "x64")).toBe("win32-x64");
+    expect(ortPlatformTarget("win32", "arm64")).toBe("win32-arm64");
+  });
+
+  test("package name is the published @loreai/onnxruntime-<target> shape", () => {
+    expect(ortNativePackageName("linux-x64")).toBe(
+      "@loreai/onnxruntime-linux-x64",
+    );
+    expect(ortNativePackageName("win32-arm64")).toBe(
+      "@loreai/onnxruntime-win32-arm64",
+    );
+  });
+
+  test("ortNativePackageName() defaults to the running platform's target", () => {
+    expect(ortNativePackageName()).toBe(
+      `@loreai/onnxruntime-${ortPlatformTarget()}`,
+    );
+  });
+
+  test("binding file is the addon the shim/loader points at", () => {
+    expect(ORT_NATIVE_BINDING_FILE).toBe("onnxruntime_binding.node");
+  });
+
+  test("resolveNativeOrtBindingPath returns null (never throws) when the package is absent", () => {
+    // No @loreai/onnxruntime-* is installed above this isolated base path, so
+    // resolution must fail SOFTLY → null (the dist-only WASM-fallback signal).
+    expect(
+      resolveNativeOrtBindingPath("/nonexistent/lore-test/x.js"),
+    ).toBeNull();
+  });
+});

--- a/packages/gateway/script/bundle.ts
+++ b/packages/gateway/script/bundle.ts
@@ -30,7 +30,8 @@ import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { PLACEHOLDER_DEBUG_ID, injectDebugId } from "./debug-id";
-import { findOrtWebDir, ortWebRedirectPlugin } from "./ort-web-plugin";
+import { findOrtWebDir } from "./ort-web-plugin";
+import { ortNpmDualPlugin } from "./ort-npm-plugin";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const packageDir = dirname(here);
@@ -191,12 +192,13 @@ await esbuild.build({
   target: "node22",
   platform: "node",
   conditions: ["node"],
-  // onnxruntime-node is redirected to onnxruntime-web (WASM) by the plugin so
-  // the npm bundle has no native-module dependency. The WASM runtime files are
-  // copied into dist/ below and located at runtime via __LORE_NPM_WASM_PATHS__
-  // (set in embedding-worker.ts). sharp is stubbed by the plugin.
+  // Dual backend: bundle the real onnxruntime-node (graceful binding patch) AND
+  // onnxruntime-web (WASM). At runtime the worker prefers the native addon from
+  // the per-platform @loreai/onnxruntime-<target> optionalDependency, falling
+  // back to the shipped WASM (located via __LORE_NPM_WASM_PATHS__) for dist-only
+  // installs (#763). sharp is stubbed by the plugin. See ort-npm-plugin.ts.
   plugins: [
-    ortWebRedirectPlugin({
+    ortNpmDualPlugin({
       repoRoot,
       wasmPathsExpr:
         "globalThis.__LORE_NPM_WASM_PATHS__ || ONNX_ENV.wasm.wasmPaths",
@@ -227,18 +229,14 @@ await esbuild.build({
   platform: "node",
   conditions: ["bun"],
   external: ["bun:*", "node:*"],
-  // Same onnxruntime-node → onnxruntime-web redirect as the CJS worker, for
-  // consistency and defense-in-depth. NOTE: this is NOT the worker the
-  // opencode/pi (Bun) path actually loads — under Bun, the gateway bundle
-  // keeps @loreai/core external (see the index.bun.js build above), so
-  // LocalProvider runs from core's own dist and spawns core's
-  // dist/bun/embedding-worker.js (which still uses the native onnxruntime-node
-  // that ships as a non-optional dep of @huggingface/transformers in a
-  // raw-deps install). This gateway-side ESM worker only matters if the
-  // gateway's own Bun bundle is run as a standalone worker host. The bug
-  // (#763) is on the dist-only CJS path → embedding-worker.cjs (fixed above).
+  // Same dual-backend plugin as the CJS worker. @loreai/core is now INLINED
+  // into index.bun.js (see that build above, #1027), so the opencode (Bun) path
+  // spawns THIS worker (dist/embedding-worker.js), not core's — so it must also
+  // prefer native ORT with a WASM fallback. (Confirmed: Bun dlopens the ORT
+  // .node addon fine.) The dist-only WASM path (#763) is preserved by the
+  // fallback branch.
   plugins: [
-    ortWebRedirectPlugin({
+    ortNpmDualPlugin({
       repoRoot,
       wasmPathsExpr:
         "globalThis.__LORE_NPM_WASM_PATHS__ || ONNX_ENV.wasm.wasmPaths",

--- a/packages/gateway/script/ort-npm-plugin.ts
+++ b/packages/gateway/script/ort-npm-plugin.ts
@@ -1,0 +1,151 @@
+/**
+ * esbuild plugin for the npm gateway's embedding-worker bundles: ship BOTH ONNX
+ * Runtime backends and pick at runtime — native `onnxruntime-node` when the
+ * per-platform `@loreai/onnxruntime-<os>-<arch>` package is installed, else the
+ * bundled WASM `onnxruntime-web` (the dist-only fallback, #763).
+ *
+ * How: the bundled `onnxruntime-node` specifier is replaced with a tiny runtime
+ * SHIM that re-exports either the real native module or onnxruntime-web based on
+ * `globalThis.__LORE_ORT_BINDING_PATH__` (set by the worker before it imports
+ * transformers). This matters because transformers.js selects its backend as:
+ *   Symbol.for('onnxruntime') override → else IS_NODE_ENV → ONNX_NODE → else web
+ * Only the IS_NODE_ENV branch registers the "cpu" device, and it uses ONNX_NODE.
+ * So we keep transformers on that branch (as the old WASM-redirect did) but make
+ * ONNX_NODE runtime-switchable — native OR web — instead of hard-wiring web.
+ *
+ * A shim (vs the SEA's throwing binding patch) is required because transformers
+ * `import * as ONNX_NODE from 'onnxruntime-node'` eagerly, and onnxruntime-node's
+ * index.js calls `binding.listSupportedBackends()` at load. The shim only pulls
+ * in the real onnxruntime-node when the addon path is set, so binding.js never
+ * runs (and never crashes) on the WASM fallback path.
+ *
+ * Steps:
+ *   1. Stub `sharp` → empty module.
+ *   2. `onnxruntime-node` → runtime shim (native-or-web).
+ *   3. `onnxruntime-web` → its Node WASM entry (for transformers' own — unused
+ *      in Node — import, and the shim's web branch).
+ *   4. Patch the real onnxruntime-node binding.js addon require → the runtime
+ *      path (graceful; only reached when native is selected).
+ *   5. Patch transformers.js' CDN `wasmPaths` fallback to read from globalThis.
+ */
+import { createRequire } from "node:module";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import type * as esbuild from "esbuild";
+import { findOrtWebDir } from "./ort-web-plugin";
+
+/** onnxruntime-node@1.21's `dist/binding.js` native-addon require (tagged
+ *  template). Kept in sync with `ort-native-plugin.ts`; a bump that changes it
+ *  fails the build loudly rather than silently shipping a broken loader. */
+const ORT_BINDING_REQUIRE =
+  /require\(`\.\.\/bin\/napi-v3\/\$\{process\.platform\}\/\$\{process\.arch\}\/onnxruntime_binding\.node`\)/;
+
+/** Graceful replacement: native addon when the worker set the path, else a
+ *  dormant stub (index.js calls `binding.listSupportedBackends()` at load).
+ *  The shim below only requires this module when the path IS set, so the native
+ *  branch is the one actually exercised; the stub is pure defense-in-depth. */
+const ORT_BINDING_GRACEFUL =
+  "(globalThis.__LORE_ORT_BINDING_PATH__ ? require(globalThis.__LORE_ORT_BINDING_PATH__) : { listSupportedBackends: () => [] })";
+
+export interface OrtNpmPluginOptions {
+  repoRoot: string;
+  /** RHS for transformers.js' `ONNX_ENV.wasm.wasmPaths = <CDN>` — read at
+   *  runtime to locate the shipped WASM (e.g.
+   *  `globalThis.__LORE_NPM_WASM_PATHS__ || ONNX_ENV.wasm.wasmPaths`). */
+  wasmPathsExpr: string;
+}
+
+export function ortNpmDualPlugin(opts: OrtNpmPluginOptions): esbuild.Plugin {
+  const ortWebDir = findOrtWebDir(opts.repoRoot);
+  const ortWebNodeEntry = join(ortWebDir, "dist", "ort.node.min.mjs");
+  const ortWebPkg = JSON.parse(
+    readFileSync(join(ortWebDir, "package.json"), "utf8"),
+  ) as { main: string };
+  const ortWebMainEntry = join(ortWebDir, ortWebPkg.main);
+
+  // The real native onnxruntime-node entry (resolved from core, which has it
+  // transitively via @huggingface/transformers). The shim requires it by
+  // absolute path so it doesn't re-trigger the `^onnxruntime-node$` intercept.
+  const require2 = createRequire(join(opts.repoRoot, "packages/core/"));
+  const realOrtNodeEntry = require2.resolve("onnxruntime-node");
+
+  return {
+    name: "ort-npm-dual",
+    setup(build) {
+      // 1: stub sharp.
+      build.onResolve({ filter: /^sharp$/ }, (args) => ({
+        path: args.path,
+        namespace: "ort-npm-empty",
+      }));
+      build.onLoad({ filter: /.*/, namespace: "ort-npm-empty" }, () => ({
+        contents: "module.exports = {};",
+        loader: "js",
+      }));
+
+      // 2: onnxruntime-node → runtime shim. Selects native vs web by the addon
+      // path the worker set before importing transformers. Requiring the real
+      // native module lazily means its binding.js only loads when native is
+      // actually used (never on the WASM fallback path).
+      build.onResolve({ filter: /^onnxruntime-node$/ }, () => ({
+        path: "onnxruntime-node",
+        namespace: "ort-npm-shim",
+      }));
+      build.onLoad({ filter: /.*/, namespace: "ort-npm-shim" }, () => ({
+        contents:
+          `module.exports = globalThis.__LORE_ORT_BINDING_PATH__\n` +
+          `  ? require(${JSON.stringify(realOrtNodeEntry)})\n` +
+          `  : require(${JSON.stringify(ortWebNodeEntry)});\n`,
+        loader: "js",
+        resolveDir: dirname(realOrtNodeEntry),
+      }));
+
+      // 3: onnxruntime-web → its package main entry (transformers imports it but
+      // only uses it in the unreachable browser branch under Node).
+      build.onResolve({ filter: /^onnxruntime-web$/ }, () => ({
+        path: ortWebMainEntry,
+      }));
+
+      // 4: rewrite the real onnxruntime-node binding.js addon require.
+      build.onLoad(
+        { filter: /onnxruntime-node[\\/]dist[\\/]binding\.js$/ },
+        (args) => {
+          const src = readFileSync(args.path, "utf8");
+          if (!ORT_BINDING_REQUIRE.test(src)) {
+            throw new Error(
+              `ort-npm-plugin: expected native-addon require not found in ` +
+                `${args.path}. onnxruntime-node likely changed binding.js — ` +
+                `update ORT_BINDING_REQUIRE in ort-npm-plugin.ts.`,
+            );
+          }
+          return {
+            contents: src.replace(ORT_BINDING_REQUIRE, ORT_BINDING_GRACEFUL),
+            loader: "js",
+            resolveDir: dirname(args.path),
+          };
+        },
+      );
+
+      // 5: patch transformers.js' CDN wasmPaths fallback to read from globalThis.
+      build.onLoad({ filter: /transformers\.node\.(mjs|cjs)$/ }, (args) => {
+        const src = readFileSync(args.path, "utf8");
+        const cdnAssign =
+          /ONNX_ENV\.wasm\.wasmPaths\s*=\s*`https:\/\/cdn\.jsdelivr\.net[^`]*`;/;
+        if (!cdnAssign.test(src)) {
+          throw new Error(
+            `ort-npm-plugin: expected CDN wasmPaths assignment not found in ` +
+              `${args.path}. transformers.js likely changed its onnx.js — ` +
+              `update the regex in ort-npm-plugin.ts.`,
+          );
+        }
+        return {
+          contents: src.replace(
+            cdnAssign,
+            `ONNX_ENV.wasm.wasmPaths = ${opts.wasmPathsExpr};`,
+          ),
+          loader: "js",
+          resolveDir: dirname(args.path),
+        };
+      });
+    },
+  };
+}


### PR DESCRIPTION
PR 2 of 3. Makes the **npm** gateway worker bundles — loaded in-process by the **opencode/pi plugins** and the `npm i -g` CLI — prefer **native** ONNX Runtime (from the per-platform `@loreai/onnxruntime-<target>` package added in #1148), falling back to the bundled WASM only when it isn't installed. Builds on #1143 (native SEA) and #1148 (per-platform packages).

## Result (512-token embed, this box)

| | Node | Bun |
|---|---|---|
| Native (platform pkg present) | **1014ms** | **1267ms** |
| WASM fallback (no pkg) | 4293ms | 4386ms |

~3.4–4.2× faster; both paths verified under **Node and Bun** (opencode's runtime — confirmed Bun `dlopen`s the ORT addon).

## Mechanism (zero-regression — WASM path is byte-identical when no package resolves)

- **`ort-npm-plugin.ts`** replaces the WASM-only `ortWebRedirectPlugin` for the two worker bundles. The bundled `onnxruntime-node` specifier becomes a runtime **shim** that re-exports the real native module when `globalThis.__LORE_ORT_BINDING_PATH__` is set, else `onnxruntime-web`. This keeps transformers on its `IS_NODE_ENV` branch — the only one that registers the `"cpu"` device — while making the backend switchable. (`Symbol.for('onnxruntime')` can't be used: that branch registers no devices → `Unsupported device: "cpu"`.) The shim only pulls in the real onnxruntime-node when native is selected, so its `binding.js` — which calls `binding.listSupportedBackends()` at load — never runs on the WASM path.
- **`core/src/ort-native.ts`** — `resolveNativeOrtBindingPath()` does a plain `require.resolve("@loreai/onnxruntime-<target>/onnxruntime_binding.node")` (npm-12-safe: resolution, not postinstall; returns null, never throws, when absent). Plus `ortPlatformTarget`/`ortNativePackageName`, bound to the published names by tests on both sides.
- **`embedding-worker.ts`** — gated by the existing "sibling `.wasm` exists" npm-bundle signal, so **dev/test, core, and the SEA binary are untouched**: native → set `__LORE_ORT_BINDING_PATH__`; else set `__LORE_NPM_WASM_PATHS__`.
- **`bundle.ts`** — both worker builds use the dual plugin; fixed a stale NOTE (core is inlined into `index.bun.js` since #1027, so the opencode/Bun path spawns *this* worker, not core's).

## Verification
Spawned both worker bundles (CJS + ESM) under Node and Bun, with and without the platform package linked: native when present (~1s), correct 768-dim WASM result when absent (~4.3s). New resolver unit test + existing embedding/cap suites green; typecheck + lint clean.

## Next
- **PR 3:** `.craft.yml` + `bump-version.sh` publish the 6 packages version-locked with the gateway; inject `optionalDependencies` at publish time.