### PR TITLE
fix(gateway): don't re-anchor the durable delta on a warm idle resume (kills the #1 cache-bust)

### DIFF
--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -883,18 +883,52 @@ function parseDeltaMessage(raw: string): GatewayMessage | null {
  * steady layer-1 session resumes at layer 1. That movement is not a layer
  * change, so the layer comparison alone misses it and the frozen absolute
  * insertAt is replayed into a differently-shaped array, busting the prompt
- * cache. `outOfIdle` captures that case: any compressed-layer (>= 1) turn that
- * came out of idle also resets the delta.
+ * cache. `idleRecompacted` captures that case.
+ *
+ * 🔴 `idleRecompacted` must be TRUE only when the post-idle resume ACTUALLY
+ * recompacted (onIdleResume with `!cacheWarm`, which clears the byte-identity
+ * caches and rebuilds the raw window). A WARM idle resume (`cacheWarm` /
+ * skipCompact, PR #1102) PRESERVES the distilled prefix and raw-window pin
+ * byte-for-byte — the array does NOT reshuffle, so the delta's insertAt is
+ * still valid and re-anchoring it is pure harm: it moves the delta off its
+ * cached position and busts the very warm cache skipCompact was protecting.
+ * Passing raw `lastTurnWasIdle` here (the pre-fix behavior) re-anchored on
+ * every idle resume, which is what produced the observed 100%→9% "dramatic hit
+ * rate drop" busts on large sessions whose returning turn was warm-preserved
+ * (divergence at the delta's OLD index, e.g. messages[349].role, prefixMatch
+ * ~82% — the conversation was intact, only the delta had moved).
  *
  * @internal Exported for tests.
  */
 export function shouldResetDeltaOnCompression(
   prevLayer: number,
   curLayer: number,
-  outOfIdle = false,
+  idleRecompacted = false,
 ): boolean {
   if (curLayer < 1) return false;
-  return curLayer !== prevLayer || outOfIdle;
+  return curLayer !== prevLayer || idleRecompacted;
+}
+
+/**
+ * True when a post-idle resume ACTUALLY recompacted — i.e. reshuffled the
+ * gradient-transformed array — and therefore the durable delta must be
+ * re-anchored. This is the `idleRecompacted` input to
+ * {@link shouldResetDeltaOnCompression}.
+ *
+ * 🔴 A resume reshuffles ONLY when it was NOT cache-warm. When `cacheWarm` is
+ * true (skipCompact — PR #1102), onIdleResume PRESERVES the distilled prefix
+ * and raw-window pin byte-for-byte, so the array is unchanged and the delta's
+ * frozen insertAt is still valid; re-anchoring would move the delta off its
+ * cached position and bust the very warm cache skipCompact was protecting.
+ * Only a `!cacheWarm` resume clears those caches and rebuilds the raw window.
+ *
+ * @internal Exported for tests (guards the `&& !cacheWarm` fix against revert).
+ */
+export function idleResumeReshuffled(
+  lastTurnWasIdle: boolean,
+  cacheWarm: boolean,
+): boolean {
+  return lastTurnWasIdle && !cacheWarm;
 }
 
 /**
@@ -7478,13 +7512,24 @@ async function handleConversationTurn(
   // de-escalating compression), and (2) a POST-IDLE COMPACT, which rebuilds the
   // array (the distilled prefix grows, the raw window is rebuilt) while STAYING
   // at the same layer — a steady layer-1 session resumes at layer 1. The layer
-  // comparison alone misses (2), so `lastTurnWasIdle` covers that same-layer
-  // reshuffle (the false "unsustainable conversation" cache-bust on a tier-0
-  // post-idle session, which #786's layer-only check did not catch).
+  // comparison alone misses (2).
+  //
+  // 🔴 But (2) only reshuffles when the resume ACTUALLY recompacted. A WARM
+  // idle resume (`cacheWarm` / skipCompact — PR #1102) PRESERVES the distilled
+  // prefix and raw-window pin byte-for-byte, so the array does NOT reshuffle
+  // and the delta's insertAt stays valid. Gating on raw `lastTurnWasIdle`
+  // re-anchored the delta on those warm resumes too, moving it off its cached
+  // position and busting the very cache skipCompact was protecting (observed:
+  // 100%→9% drops at the delta's old index on large sessions). So a post-idle
+  // resume counts as a reshuffle ONLY when it was NOT cache-warm.
+  const idleRecompacted = idleResumeReshuffled(
+    sessionState.lastTurnWasIdle ?? false,
+    cacheWarm,
+  );
   const deltaCompressed = shouldResetDeltaOnCompression(
     sessionState.lastDeltaLayer ?? 0,
     result.layer,
-    sessionState.lastTurnWasIdle ?? false,
+    idleRecompacted,
   );
   // On a compressing turn the gradient reshuffled the array; re-anchor the
   // durable delta blocks (preserving content + `mut`) to a fresh tool-pair-safe

--- a/packages/gateway/test/delta-compress-reanchor.test.ts
+++ b/packages/gateway/test/delta-compress-reanchor.test.ts
@@ -36,6 +36,7 @@ import {
   applySessionPromptDeltas,
   removeOrphanedToolResults,
   shouldResetDeltaOnCompression,
+  idleResumeReshuffled,
   reanchorExistingDelta,
   reanchorDeltaOnCompression,
   appendKnowledgePromptDelta,
@@ -179,6 +180,40 @@ describe("shouldResetDeltaOnCompression — layer-transition predicate", () => {
   test("TRUE layer-4 refresh from layer 3 (3,4)", () => {
     expect(typeof shouldResetDeltaOnCompression).toBe("function");
     expect(shouldResetDeltaOnCompression(3, 4)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2b. idleResumeReshuffled — a WARM idle resume must NOT count as a reshuffle
+//     (regression guard for the delta-reanchor cache-bust fix). A warm resume
+//     (skipCompact, PR #1102) preserves the array byte-for-byte, so re-anchoring
+//     the delta there busts the very cache it was protecting (observed 100%→9%
+//     drops at the delta's old index on large sessions).
+// ---------------------------------------------------------------------------
+describe("idleResumeReshuffled — only a NON-warm post-idle resume reshuffles", () => {
+  test("cold recompacting resume (idle + !warm) => reshuffle => re-anchor", () => {
+    expect(idleResumeReshuffled(true, false)).toBe(true);
+  });
+
+  test("🔴 WARM resume (idle + cacheWarm) => NO reshuffle => NO re-anchor", () => {
+    // The fix: a warm/skipCompact resume preserves the caches, so the delta
+    // must stay put. If this ever returns true again, the delta re-anchors on
+    // warm resumes and busts the warm cache (the bug this guards).
+    expect(idleResumeReshuffled(true, true)).toBe(false);
+  });
+
+  test("not an idle resume => never a reshuffle (warm or cold)", () => {
+    expect(idleResumeReshuffled(false, false)).toBe(false);
+    expect(idleResumeReshuffled(false, true)).toBe(false);
+  });
+
+  test("wires into shouldResetDeltaOnCompression: warm same-layer resume does NOT reset", () => {
+    // layer unchanged (1→1) + warm idle resume => idleRecompacted false => no reset.
+    const warmResume = idleResumeReshuffled(true, true);
+    expect(shouldResetDeltaOnCompression(1, 1, warmResume)).toBe(false);
+    // Same session, but the resume actually recompacted => reset.
+    const coldResume = idleResumeReshuffled(true, false);
+    expect(shouldResetDeltaOnCompression(1, 1, coldResume)).toBe(true);
   });
 });
 


### PR DESCRIPTION
## The finding (from digging into the new-build logs)

After the prefix-stability work landed, **prefix rewrites are essentially gone** (1 in a 28-min window vs 619 historically). But warming was still net-negative, so I traced *why*. The real culprit isn't the warmer — it's Lore's **own durable knowledge-delta re-anchoring**.

**4 of 4 "dramatic hit-rate drops" in the window were each immediately preceded by a `re-anchored durable delta` event**, and the divergence lands exactly at the delta's *old* index:

```
19:43:16 re-anchor 0m89  349→409  →  19:43:30  100%→9%  at messages[349].role  (prefixMatch 81.7%)
20:00:29 re-anchor 0m89  409→451  →  20:00:47  100%→8%  at messages[409].role
```

`prefixMatch=81.7%` is the tell: the conversation barely changed — **the only reason turn 32 re-wrote ~473K tokens (~$2.98) was that the delta hopped from message 349 to 409.** These are real user turns, not warmups. 125 re-anchors in the logs; 82 on `layer 1→1` (no actual layer change).

## Root cause

`shouldResetDeltaOnCompression` re-anchors the delta whenever the turn "came out of idle" (raw `lastTurnWasIdle`). But a **warm** idle resume (`cacheWarm` / skipCompact — PR #1102) **preserves** the distilled prefix and raw-window pin byte-for-byte, so the array does **not** reshuffle and the delta's frozen `insertAt` is still valid. Re-anchoring there moves the delta off its cached position and busts the very warm cache skipCompact was protecting.

Confirmed on `0m89` turn 32:
```
session idle 6min — refreshing caches (cache warm — skipping compact)   ← preserved, no reshuffle
prompt-delta: re-anchored durable delta ... insertAt=409                 ← re-anchored anyway (bug)
dramatic hit rate drop: 100% → 9% at messages[349].role                  ← busted the warm cache
```

This also explains the warming losses: the warmup keeps *body-A* warm during idle; the return re-anchors to *body-B*, so the warm cache misses and both pay a full write. Warming couldn't win because the return turn mutated the body out from under it.

This is a gap left by **PR #1102**, which preserved the warm prefix/raw-window across idle but didn't update the delta gate to match.

## Fix

A post-idle resume counts as a reshuffle (and re-anchors the delta) **only when it was NOT cache-warm** — i.e. it actually recompacted and rebuilt the raw window. Layer changes still trigger re-anchor exactly as before.

- new pure seam `idleResumeReshuffled(lastTurnWasIdle, cacheWarm)` = `idle && !warm`
- call site (`handleConversationTurn`) passes it as `idleRecompacted`; `cacheWarm` is the same `decideSkipCompact` value already passed to `onIdleResume`
- `shouldResetDeltaOnCompression`: third param renamed `outOfIdle → idleRecompacted`, body unchanged, doc updated

## Safety

- When `cacheWarm`, `onIdleResume` provably preserves the byte-identity caches, so the delta's `insertAt` remains tool-pair-safe (it was safe when placed; a new tail message doesn't affect an earlier index). No new tool-pair-orphan risk (#747).
- The behavior this param was added for — a real post-idle **compact** at the same layer (#786) — still triggers: that path is `!cacheWarm`.
- Mid-session same-layer pin advances were never caught by this gate before and still aren't — no regression.

## Tests

- `idleResumeReshuffled`: warm resume → **no** reshuffle (🔴 the fix, **mutation-verified** — reverting to raw `lastTurnWasIdle` fails 2 tests); cold recompacting resume → reshuffle; non-idle → never.
- Existing `shouldResetDeltaOnCompression` predicate tests unchanged (body identical).
- 109 tests green across delta-reanchor / idle-work / prompt-delta / pipeline-cache-turn; typecheck + lint clean across all 4 packages.