### PR TITLE
feat(core): show cumulative temporal re-chunk progress in logs

### DIFF
--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -2738,6 +2738,25 @@ export function resetTemporalRechunkProgress(): void {
 }
 
 /**
+ * Cumulative-progress line for the temporal re-chunk walk. `done`/`total` count
+ * embeddable (>=50 char) messages across ALL runs, so the percentage keeps
+ * climbing over restarts — unlike the per-process counters, which reset to zero
+ * on every boot. `thisRun` is what the current invocation re-chunked. A zero
+ * `total` reads as 100% (nothing to do). The percentage is clamped to 100 and
+ * rendered to one decimal. Exported for testing. See {@link
+ * backfillTemporalEmbeddings} for how `done = baseDone + scanned` is derived.
+ */
+export function formatTemporalRechunkProgress(
+  done: number,
+  total: number,
+  thisRun: number,
+): string {
+  const pct =
+    total > 0 ? Math.min(100, Math.round((done / total) * 1000) / 10) : 100;
+  return `temporal re-chunk: ${pct}% complete (${done}/${total} messages) · +${thisRun} re-chunked this run`;
+}
+
+/**
  * Re-chunk existing temporal messages into the multi-vector vec0 layout.
  *
  * New messages are embedded part-aware at write time, but messages written
@@ -2814,9 +2833,29 @@ export async function backfillTemporalEmbeddings(
       )
       .get(cursor) as { n: number }
   ).n;
+  // Denominator for cumulative progress: ALL embeddable messages, not just the
+  // remaining backlog, so the heartbeat shows a percentage that keeps climbing
+  // across restarts instead of the per-process tally that resets to zero on every
+  // boot. `baseDone` is what prior runs already covered (rows at/below the resume
+  // cursor); the walk's SELECT is itself filtered to `length >= 50`, so `scanned`
+  // counts embeddable rows and `baseDone + scanned` reaches exactly `total` on a
+  // clean pass (→ 100%). Gated on `backlog > 0`: when nothing remains the loop
+  // latches done without iterating, so `total`/`baseDone` are never read — no
+  // point paying for a second full-table COUNT on that path.
+  let total = 0;
+  let baseDone = 0;
   if (backlog > 0) {
+    total = (
+      db()
+        .query(
+          `SELECT COUNT(*) AS n FROM temporal_messages WHERE length(content) >= 50`,
+        )
+        .get() as { n: number }
+    ).n;
+    baseDone = Math.max(0, total - backlog);
+    const basePct = total > 0 ? Math.round((baseDone / total) * 1000) / 10 : 0;
     log.info(
-      `temporal re-chunk: ${backlog} messages to scan${cursor ? " (resuming)" : ""}`,
+      `temporal re-chunk: ${backlog} messages to scan (${baseDone}/${total} already done, ${basePct}%)${cursor ? ", resuming" : ""}`,
     );
   }
 
@@ -2909,7 +2948,7 @@ export async function backfillTemporalEmbeddings(
 
       if (Date.now() - lastProgressAt >= PROGRESS_INTERVAL_MS) {
         log.info(
-          `re-chunking temporal messages: ${processed} re-chunked, ${scanned} scanned…`,
+          formatTemporalRechunkProgress(baseDone + scanned, total, processed),
         );
         lastProgressAt = Date.now();
       }
@@ -2919,7 +2958,9 @@ export async function backfillTemporalEmbeddings(
   }
 
   if (processed > 0) {
-    log.info(`re-chunked ${processed} temporal messages (${scanned} scanned)`);
+    log.info(
+      formatTemporalRechunkProgress(baseDone + scanned, total, processed),
+    );
   }
   return processed;
 }

--- a/packages/core/test/embedding.test.ts
+++ b/packages/core/test/embedding.test.ts
@@ -14,6 +14,7 @@ import {
   _saveAndClearProvider,
   _restoreProvider,
   embed,
+  formatTemporalRechunkProgress,
   recallEmbedsInFlight,
   _setRecallEmbedsInFlightForTest,
   runStartupBackfill,
@@ -112,6 +113,39 @@ describe("embed() enforces the L2-normalization invariant", () => {
     } finally {
       _restoreProvider(token);
     }
+  });
+});
+
+describe("formatTemporalRechunkProgress", () => {
+  test("reports a cumulative one-decimal percentage", () => {
+    expect(formatTemporalRechunkProgress(30688, 226527, 18)).toBe(
+      "temporal re-chunk: 13.5% complete (30688/226527 messages) · +18 re-chunked this run",
+    );
+  });
+
+  test("a clean, fully-scanned corpus reads as exactly 100%", () => {
+    // done === total is what `baseDone + scanned` reaches on a clean pass.
+    expect(formatTemporalRechunkProgress(2, 2, 2)).toContain(
+      "100% complete (2/2",
+    );
+  });
+
+  test("total === 0 reads as 100% (nothing to do), never NaN/Infinity", () => {
+    expect(formatTemporalRechunkProgress(0, 0, 0)).toContain(
+      "100% complete (0/0",
+    );
+  });
+
+  test("clamps to 100% if done somehow exceeds total", () => {
+    expect(formatTemporalRechunkProgress(5, 4, 1)).toContain(
+      "100% complete (5/4",
+    );
+  });
+
+  test("a fresh run (nothing done yet) reads as 0%", () => {
+    expect(formatTemporalRechunkProgress(0, 1000, 0)).toContain(
+      "0% complete (0/1000",
+    );
   });
 });
 

--- a/packages/core/test/vec0-cutover.test.ts
+++ b/packages/core/test/vec0-cutover.test.ts
@@ -2149,8 +2149,60 @@ describeVec("temporal re-chunk backfill (backfillTemporalEmbeddings)", () => {
       const lines = info.mock.calls.map((c: unknown[]) =>
         c.map(String).join(" "),
       );
+      // Startup line surfaces the backlog AND the cumulative baseline (fresh run
+      // ⇒ 0/2 done). `short` (<50 chars) is excluded from both counts.
       expect(
-        lines.some((l) => /temporal re-chunk: 2 messages to scan/.test(l)),
+        lines.some((l) =>
+          /temporal re-chunk: 2 messages to scan \(0\/2 already done, 0%\)/.test(
+            l,
+          ),
+        ),
+      ).toBe(true);
+      // On a clean completion `baseDone + scanned === total`, so the final line
+      // reads exactly 100% — the cumulative metric, not a per-process tally.
+      expect(
+        lines.some((l) =>
+          /temporal re-chunk: 100% complete \(2\/2 messages\)/.test(l),
+        ),
+      ).toBe(true);
+    } finally {
+      info.mockRestore();
+    }
+  });
+
+  test("cumulative progress counts prior runs (resuming), not just this process", async () => {
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    insTemporalContent("m1", MULTI);
+    insTemporalContent("m2", MULTI);
+    insTemporalContent("m3", MULTI);
+    insTemporalContent("m4", MULTI);
+    setKV(CURSOR_KEY, "m2"); // pretend m1,m2 were re-chunked in a prior run
+
+    const info = vi.spyOn(log, "info");
+    try {
+      await withProvider(async () => {
+        expect(await backfillTemporalEmbeddings()).toBe(2); // only m3,m4 this run
+      });
+      const lines = info.mock.calls.map((c: unknown[]) =>
+        c.map(String).join(" "),
+      );
+      // startup: 2 remain, but 2 of 4 are already done (50%) — resuming
+      expect(
+        lines.some((l) =>
+          /temporal re-chunk: 2 messages to scan \(2\/4 already done, 50%\), resuming/.test(
+            l,
+          ),
+        ),
+      ).toBe(true);
+      // completion: cumulative 4/4 (100%), NOT the per-process 2/4 — this is what
+      // distinguishes `baseDone + scanned` from `processed`.
+      expect(
+        lines.some((l) =>
+          /temporal re-chunk: 100% complete \(4\/4 messages\) · \+2 re-chunked this run/.test(
+            l,
+          ),
+        ),
       ).toBe(true);
     } finally {
       info.mockRestore();


### PR DESCRIPTION
## Why
The only per-run progress log — `re-chunking temporal messages: N re-chunked, N scanned…` — is **per-process**: it resets to zero on every gateway restart. On the current multi-day, restart-spanning re-chunk walk that means the logs never show how far through the whole corpus we are. Answering "are we making progress?" required cross-referencing the startup backlog line across restarts and querying the DB by hand.

## What
The heartbeat and the final summary now report a **cumulative** percentage that keeps climbing across restarts:

```
temporal re-chunk: 13.5% complete (30688/226527 messages) · +18 re-chunked this run
```

And the startup line now shows the baseline too:

```
temporal re-chunk: 2 messages to scan (2/4 already done, 50%), resuming
```

## How (the math)
- At startup we already `COUNT` the remaining `backlog` (embeddable rows above the resume cursor). One extra `COUNT` gives the embeddable `total`, so `baseDone = total - backlog` is what prior runs already covered.
- The walk's `SELECT` is itself filtered to `length(content) >= 50`, so `scanned` counts embeddable rows, and **`baseDone + scanned` reaches exactly `total` on a clean pass → 100%**.
- Both `COUNT`s run once per process, and only when work remains (the vec0-mode / done-flag guards already return early otherwise).

Percentage formatting is extracted into a pure, exported `formatTemporalRechunkProgress(done, total, thisRun)` — clamps to 100, one decimal, `total === 0` ⇒ 100% (never NaN/Infinity) — so it's unit-testable without waiting on the 30s heartbeat.

No behavior change to the walk itself; logs only.

## Tests
- Unit tests for the formatter: one-decimal rounding, 100% clamp when `done > total`, `0/0` ⇒ 100%, fresh `0%`.
- Integration: startup baseline line + exactly `100% complete` on a clean completion.
- **Resuming** test (cursor pre-seeded to `m2` of `m1..m4`) that a fresh run can't cover — proves the metric is cumulative (`4/4`), not per-process (`2/4`).
- **Mutation-verified**: swapping `baseDone + scanned` for `processed` fails the resuming test. Full `packages/core` suite: **2495 passed, 0 failed**.