### PR TITLE
fix(gateway): cache breakpoint at the distilled-prefix boundary (stop mid-conversation busts collapsing to the ~54K head)

### DIFF
--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -7650,6 +7650,14 @@ async function handleConversationTurn(
     cacheTools: true,
     cacheConversation: true,
     conversationTTL: resolvedConversationTTL,
+    // Lore's distilled prefix (buildPrefixMessages) is the first 2 messages
+    // (a [user, assistant] pair) whenever distillation is active
+    // (distilledTokens > 0), and always sits at the front of the transformed
+    // array ([...prefix, ...rawWindow]); the durable delta is inserted near the
+    // tail and orphan-removal never touches the front, so [0,1] stay the prefix.
+    // Passing 2 places an interior breakpoint on its boundary so a raw-window
+    // divergence falls back to the cached prefix instead of the ~54K head.
+    distilledPrefixLength: result.distilledTokens > 0 ? 2 : 0,
   };
 
   // --- Daily budget + OAuth quota throttle ---

--- a/packages/gateway/src/translate/anthropic.ts
+++ b/packages/gateway/src/translate/anthropic.ts
@@ -321,6 +321,29 @@ export type AnthropicCacheOptions = {
    * Only applies when `cacheConversation` is true.
    */
   conversationTTL?: "5m" | "1h";
+
+  /**
+   * Number of leading messages that form Lore's stable distilled prefix
+   * (`buildPrefixMessages` output: a [user, assistant] pair, so 0 or 2). When
+   * `> 0` AND there is a raw window beyond it, an EXTRA `cache_control`
+   * breakpoint is placed on the last block of `messages[distilledPrefixLength-1]`.
+   *
+   * Rationale: without it the conversation has ONE breakpoint (the moving tail),
+   * so ANY mid-conversation divergence (window shift, tool-result resolution,
+   * post-idle re-render) collapses the whole conversation block back to the
+   * system+tools head (~54K observed). The distilled prefix is Lore-generated
+   * and byte-stable between meta-distillations, so a breakpoint at its boundary
+   * gives a much closer fallback: a raw-window divergence keeps the prefix cached
+   * instead of re-writing it. Uses the 4th (and last) Anthropic breakpoint slot
+   * — the other three are system[1], tools, and the conversation tail.
+   *
+   * The breakpoint inherits the 1h `systemTTL` (like tools): the prefix is
+   * stable, so the longer eviction window is what lets it survive an idle gap
+   * and be read (not re-written) on the returning turn.
+   *
+   * Only applies when `cacheConversation` is true.
+   */
+  distilledPrefixLength?: number;
 };
 
 // ---------------------------------------------------------------------------
@@ -442,6 +465,26 @@ export function buildAnthropicRequest(
   // the last message. Anthropic's 20-block lookback finds the prior turn's
   // breakpoint, reads the cached prefix, and writes only the new tail.
   if (cache?.cacheConversation && messages.length > 0) {
+    // Interior breakpoint on the distilled-prefix boundary. The prefix is
+    // Lore-generated and byte-stable between meta-distillations; a breakpoint
+    // here means a mid-conversation divergence in the raw window falls back to
+    // the cached prefix (~124K) instead of collapsing to the system+tools head
+    // (~54K). Uses a 1h TTL (like tools) so it survives an idle gap and is read
+    // — not re-written — on the returning turn. Guarded to only fire when there
+    // is a raw window beyond the prefix (else the tail breakpoint below already
+    // covers it, and a second breakpoint on the same block is wasted).
+    const prefixLen = cache.distilledPrefixLength ?? 0;
+    if (prefixLen > 0 && prefixLen < messages.length) {
+      const prefixMsg = messages[prefixLen - 1];
+      const prefixBlock = prefixMsg?.content[prefixMsg.content.length - 1];
+      if (prefixBlock) {
+        (prefixBlock as Record<string, unknown>).cache_control =
+          cache.systemTTL === "1h"
+            ? { type: "ephemeral", ttl: "1h" }
+            : { type: "ephemeral" };
+      }
+    }
+
     const lastMsg = messages[messages.length - 1];
     const lastBlock = lastMsg?.content[lastMsg.content.length - 1];
     if (lastBlock) {

--- a/packages/gateway/test/anthropic-caching.test.ts
+++ b/packages/gateway/test/anthropic-caching.test.ts
@@ -307,6 +307,115 @@ describe("buildAnthropicRequest — conversation caching", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Distilled-prefix interior breakpoint (the 4th breakpoint). Prevents a
+// mid-conversation divergence from collapsing the whole conversation block
+// back to the ~54K system+tools head by caching the stable distilled prefix
+// separately.
+// ---------------------------------------------------------------------------
+
+describe("buildAnthropicRequest — distilled-prefix breakpoint", () => {
+  // [prefix-user, prefix-assistant, raw-user, raw-assistant]: prefixLen=2, tail=3
+  function prefixReq() {
+    return makeRequest({
+      messages: [
+        { role: "user", content: [{ type: "text", text: "<distilled user>" }] },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "<distilled assistant summary>" }],
+        },
+        { role: "user", content: [{ type: "text", text: "real question" }] },
+        { role: "assistant", content: [{ type: "text", text: "real answer" }] },
+      ],
+    });
+  }
+
+  test("places an interior breakpoint on the prefix boundary (messages[1])", () => {
+    const body = getBody(prefixReq(), {
+      cacheConversation: true,
+      distilledPrefixLength: 2,
+    });
+    const messages = body.messages as Array<{
+      content: Array<Record<string, unknown>>;
+    }>;
+    // messages[1] (end of distilled prefix) gets a breakpoint...
+    expect(messages[1].content[0].cache_control).toEqual({ type: "ephemeral" });
+    // ...and the tail (messages[3]) still gets one...
+    expect(messages[3].content[0].cache_control).toEqual({ type: "ephemeral" });
+    // ...but messages[0] and the mid-window message[2] do NOT.
+    expect(messages[0].content[0].cache_control).toBeUndefined();
+    expect(messages[2].content[0].cache_control).toBeUndefined();
+  });
+
+  test("inherits 1h TTL from systemTTL (stable prefix survives idle)", () => {
+    const body = getBody(prefixReq(), {
+      cacheConversation: true,
+      systemTTL: "1h",
+      distilledPrefixLength: 2,
+    });
+    const messages = body.messages as Array<{
+      content: Array<Record<string, unknown>>;
+    }>;
+    expect(messages[1].content[0].cache_control).toEqual({
+      type: "ephemeral",
+      ttl: "1h",
+    });
+  });
+
+  test("no interior breakpoint when distilledPrefixLength is 0/absent (back-compat)", () => {
+    for (const cache of [
+      { cacheConversation: true },
+      { cacheConversation: true, distilledPrefixLength: 0 },
+    ] as AnthropicCacheOptions[]) {
+      const body = getBody(prefixReq(), cache);
+      const messages = body.messages as Array<{
+        content: Array<Record<string, unknown>>;
+      }>;
+      // Only the tail carries a breakpoint; nothing interior.
+      expect(messages[0].content[0].cache_control).toBeUndefined();
+      expect(messages[1].content[0].cache_control).toBeUndefined();
+      expect(messages[2].content[0].cache_control).toBeUndefined();
+      expect(messages[3].content[0].cache_control).toEqual({
+        type: "ephemeral",
+      });
+    }
+  });
+
+  test("no interior breakpoint when the prefix IS the whole conversation (tail covers it)", () => {
+    // prefixLen == messages.length → guard (prefixLen < length) skips it, so we
+    // never double-place two breakpoints on the same (last) block.
+    const req = makeRequest({
+      messages: [
+        { role: "user", content: [{ type: "text", text: "<distilled user>" }] },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "<distilled assistant>" }],
+        },
+      ],
+    });
+    const body = getBody(req, {
+      cacheConversation: true,
+      distilledPrefixLength: 2,
+    });
+    const messages = body.messages as Array<{
+      content: Array<Record<string, unknown>>;
+    }>;
+    // messages[0] no breakpoint; only the tail (messages[1]) gets exactly one.
+    expect(messages[0].content[0].cache_control).toBeUndefined();
+    expect(messages[1].content[0].cache_control).toEqual({ type: "ephemeral" });
+  });
+
+  test("total conversation breakpoints never exceed 2 (interior + tail)", () => {
+    const body = getBody(prefixReq(), {
+      cacheConversation: true,
+      systemTTL: "1h",
+      distilledPrefixLength: 2,
+    });
+    const n = JSON.stringify(body.messages).match(/"cache_control"/g)?.length;
+    expect(n).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Combined: system + conversation caching (conversation turn config)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## The problem (from the warm-up deep dive)

Warm idle-resume turns on large sessions kept busting to `hit=9-15%` (read ≈54K, re-writing ~340K, ~\$2-3) **even though the body was 94% unchanged and the cache was warm**. After #1151 (which fixed the durable-delta re-anchor), this remained — and it's why warm-ups still showed pure overhead: every return only ever recovered the ~54K head.

## Root cause: one conversation breakpoint

`buildAnthropicRequest` places the conversation `cache_control` on **the last block of the last message** — a single breakpoint that moves to the tail every turn. The only other breakpoints are system[1] (1h) and tools (1h), which together are the ~54K head.

```
[system[1] ~54K, 1h] [tools, 1h] ............ ~340K conversation ............ [tail, 5m]
                                 ^^^^^ ONE cached block, nothing interior ^^^^^
```

Anthropic only serves a cached prefix that ends at a breakpoint. So:
- **Consecutive (append-only) turns** match to the previous tail breakpoint → ~99% hit. Fine.
- **Any mid-conversation divergence** (a window shift at e.g. `messages[331]`) breaks the match at ~93%, but the only breakpoint before the tail is the **54K head** → the entire conversation block collapses and re-writes. That's the `hit=14%, read=54228` we kept seeing.

## Fix: spend the 4th breakpoint on the stable prefix boundary

Anthropic allows **4** breakpoints; Lore used **3**. This adds the 4th at the **distilled-prefix boundary**. Lore's distilled prefix (`buildPrefixMessages`) is the first 2 messages — Lore-generated, byte-stable between meta-distillations, always at the front of the transformed array. A **1h** breakpoint on its last block means a raw-window divergence now falls back to the cached prefix (**~124K** = head + 70K prefix) instead of the ~54K head — and because it's 1h, the prefix **survives the idle gap and is read, not re-written**, on the returning turn.

- `AnthropicCacheOptions.distilledPrefixLength` (0 or 2)
- `buildAnthropicRequest` places an interior breakpoint on `messages[prefixLen-1]`'s last block, **guarded** to only fire when there's a raw window beyond it (never double-places with the tail breakpoint)
- pipeline passes `result.distilledTokens > 0 ? 2 : 0`

## Safety
- Backward-compatible: absent/0 `distilledPrefixLength` → no interior breakpoint (existing tests unchanged).
- Never exceeds Anthropic's 4-breakpoint limit (system[1] + tools + prefix + tail); the prefix-is-whole-conversation case is guarded so we never place two breakpoints on the same block.
- The prefix is stable (Approach C), so the 1h breakpoint is written once and read many times — net-positive even at 2× write cost.

## Tests
Placement on `messages[1]`; 1h TTL inheritance; back-compat (absent/0); prefix-is-whole-conversation guard; ≤2 conversation breakpoints. **Mutation-verified** (disabling placement fails 3 tests). 103 tests green across anthropic-caching / content-passthrough / vertex / pipeline-cache-turn; typecheck + lint clean.

## Scope
This is the **mitigation** (caps the damage of *every* mid-conversation bust, not just warm resumes). The **trigger** that shifts the array at ~message 331 on warm resumes is tracked separately — a follow-up adds targeted diagnostics to pin it down.