### PR TITLE
fix(gateway): stop mislabeling idle-resume tail growth as an "earlier message modified" edit

### DIFF
--- a/packages/gateway/src/cache-analytics.ts
+++ b/packages/gateway/src/cache-analytics.ts
@@ -560,6 +560,12 @@ export function analyzeCacheTurn(
       // breakpoint (addressed by the distilled-prefix breakpoint, PR #1155).
       if (
         divergenceReason.startsWith("earlier message modified") &&
+        // Bare top-level `messages[N]` only. The `]`→`,` transition also occurs
+        // when a nested `content` array grows (e.g. a tool_use block appended to
+        // an existing message) — there the path is `messages[N].content[M]`, a
+        // genuine content edit we must NOT relabel. A top-level element boundary
+        // maps to a bare `messages[N]`.
+        /^messages\[\d+\]$/.test(divergencePoint) &&
         prevBody[prefixMatchBytes] === "]" &&
         normalizedBody[prefixMatchBytes] === ","
       ) {

--- a/packages/gateway/src/cache-analytics.ts
+++ b/packages/gateway/src/cache-analytics.ts
@@ -548,6 +548,26 @@ export function analyzeCacheTurn(
         analytics.turnCount,
       );
 
+      // Refine the misleading "earlier message modified" verdict. When the
+      // previous body CLOSES the messages array (`]`) exactly where this body
+      // CONTINUES it (`,`), the previous turn's messages are a structural prefix
+      // of this turn's — the divergence is TAIL GROWTH (the returning turn
+      // appended messages), NOT a mid-conversation content edit. This is the
+      // signature of an idle-resume cache miss: the body is fine, but the
+      // returning turn can't reuse the cache and falls back to the nearest
+      // breakpoint. The generic label made these look like content edits at
+      // messages[N] and obscured that the real cost is the missing interior
+      // breakpoint (addressed by the distilled-prefix breakpoint, PR #1155).
+      if (
+        divergenceReason.startsWith("earlier message modified") &&
+        prevBody[prefixMatchBytes] === "]" &&
+        normalizedBody[prefixMatchBytes] === ","
+      ) {
+        divergenceReason =
+          "returning-turn tail growth (previous messages are a prefix — " +
+          "cache miss on resume, not a content edit)";
+      }
+
       // system[0] cache-alignment measurement (issue #791): when the first
       // divergence lands in the agent-owned host prompt, decide whether the
       // changed span is relocatable dynamic content (a date/timestamp/uuid)

--- a/packages/gateway/test/cache-analytics.test.ts
+++ b/packages/gateway/test/cache-analytics.test.ts
@@ -626,6 +626,54 @@ describe("analyzeCacheTurn", () => {
       /message at position 1 content changed/,
     );
   });
+
+  test("tail growth after idle is classified as returning-turn growth, NOT an edit", () => {
+    const analytics = makeCacheAnalytics();
+    // prev: the stored (pre-idle) body. curr: the returning turn — identical
+    // messages plus several NEW ones appended at the tail. prev's messages
+    // array CLOSES (`]`) exactly where curr CONTINUES (`,`). Because the
+    // divergence lands >2 messages back from curr's tail, the generic
+    // classifier calls it "earlier message modified"; the refinement must
+    // recognize the `]`→`,` signature and relabel it as tail growth.
+    const msg = (r: string, c: string) => ({ role: r, content: c });
+    const prev = JSON.stringify({
+      model: "opus",
+      messages: [
+        msg("user", "one"),
+        msg("assistant", "two"),
+        msg("user", "three"),
+        msg("assistant", "four"),
+      ],
+      tools: [],
+    });
+    const curr = JSON.stringify({
+      model: "opus",
+      messages: [
+        msg("user", "one"),
+        msg("assistant", "two"),
+        msg("user", "three"),
+        msg("assistant", "four"),
+        msg("user", "five"),
+        msg("assistant", "six"),
+        msg("user", "seven"),
+        msg("assistant", "eight"),
+      ],
+      tools: [],
+    });
+
+    analyzeCacheTurn(analytics, prev, makeUsage(), undefined, 4);
+    // messageCount=8 → the divergence at the append boundary (≈position 4) is
+    // >2 back from the tail, so the generic classifier says "earlier message
+    // modified" — exactly the misleading case the refinement must catch.
+    const result = analyzeCacheTurn(analytics, curr, makeUsage(), undefined, 8);
+
+    expect(result.divergenceReason).toBe(
+      "returning-turn tail growth (previous messages are a prefix — " +
+        "cache miss on resume, not a content edit)",
+    );
+    // Must NOT be the misleading "earlier message modified" verdict.
+    expect(result.divergenceReason).not.toMatch(/earlier message modified/);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/test/cache-analytics.test.ts
+++ b/packages/gateway/test/cache-analytics.test.ts
@@ -674,6 +674,61 @@ describe("analyzeCacheTurn", () => {
     // Must NOT be the misleading "earlier message modified" verdict.
     expect(result.divergenceReason).not.toMatch(/earlier message modified/);
   });
+
+  test("extending a message's content array is NOT relabeled as tail growth", () => {
+    // Sentry bot #15026759: the `]`→`,` transition also fires when a nested
+    // `content` array grows (e.g. a tool_use block appended to an existing
+    // assistant message). That is a genuine content edit at messages[N] — the
+    // path is `messages[N].content[M]`, so the bare-path guard must reject it.
+    const analytics = makeCacheAnalytics();
+    const t = (text: string) => ({
+      role: "user",
+      content: [{ type: "text", text }],
+    });
+    // message[2]'s content array gains a tool_use block. With 6 messages, idx=2
+    // is mid-conversation (not <=1, not within the last 2) → the classifier says
+    // "earlier message modified", so the outer guard passes and the bare-path
+    // guard is what must reject it (path is messages[2].content[1]).
+    const prev = JSON.stringify({
+      model: "opus",
+      messages: [
+        t("m0"),
+        t("m1"),
+        { role: "assistant", content: [{ type: "text", text: "look" }] },
+        t("m3"),
+        t("m4"),
+        t("m5"),
+      ],
+      tools: [],
+    });
+    const curr = JSON.stringify({
+      model: "opus",
+      messages: [
+        t("m0"),
+        t("m1"),
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "look" },
+            { type: "tool_use", id: "t1", name: "bash", input: {} },
+          ],
+        },
+        t("m3"),
+        t("m4"),
+        t("m5"),
+      ],
+      tools: [],
+    });
+
+    analyzeCacheTurn(analytics, prev, makeUsage(), undefined, 6);
+    const result = analyzeCacheTurn(analytics, curr, makeUsage(), undefined, 6);
+
+    // A real mid-message content edit — the path is nested (messages[2].content),
+    // so it must NOT be relabeled as tail growth.
+    expect(result.divergencePoint).toMatch(/^messages\[2\]\.content/);
+    expect(result.divergenceReason).not.toMatch(/returning-turn tail growth/);
+    expect(result.divergenceReason).toMatch(/earlier message modified/);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

While investigating the warm-up cache busts, the `messages[331]` divergences logged `reason="earlier message modified at position 331 (window shift or content change)"` — which reads like a mid-conversation content **edit**. That label sent the investigation chasing a phantom edit.

The byte-snippet diagnostic (already present) showed the real story:

```
prev: ...5bd35ef0b5826cc)"}]}],"tools":[{"name":"bash",...      ← messages array CLOSES
curr: ...5bd35ef0b5826cc)"}]},{"role":"assistant","content":[{"type":"tool_use",...  ← CONTINUES
```

The previous (stored, pre-idle) body **closes** the messages array (`]`) exactly where the returning turn **continues** it (`,{...}`). The previous turn's messages are a structural **prefix** of the returning turn's — this is **tail growth**, not an edit. The returning turn just failed to reuse the idle cache and fell back to the nearest breakpoint (the ~54K head — which #1155 addresses).

The generic classifier says "earlier message modified" whenever the divergence lands >2 messages back from the tail (true when several messages were appended during the gap), which is exactly this case.

## Change

Detect the `]`→`,` signature at the divergence and relabel:

> `returning-turn tail growth (previous messages are a prefix — cache miss on resume, not a content edit)`

**Diagnostic-only** — the reason string only feeds the `cache-analytics` INFO and `dramatic hit rate drop` WARN logs. No behavior change, no cache impact. The actual cache-alignment fix is the distilled-prefix breakpoint in **#1155**.

## Test
Drives `analyzeCacheTurn` prev(4 msgs) → curr(8 msgs) and asserts the relabel + that it's no longer "earlier message modified". **Mutation-verified** (without the `]`→`,` check it reverts to the old misleading label). Typecheck + lint clean.