### PR TITLE
feat: support GitHub Copilot CLI (`lore run` / `lore setup`)

### DIFF
--- a/packages/gateway/src/cli/agents.ts
+++ b/packages/gateway/src/cli/agents.ts
@@ -263,6 +263,36 @@ export const AGENTS: AgentDef[] = [
       return env;
     },
   },
+  {
+    name: "copilot",
+    displayName: "GitHub Copilot CLI",
+    binary: "copilot",
+    detect: () => whichSync("copilot"),
+    envVars: (url, cwd) => {
+      // GitHub Copilot CLI talks to the Copilot API (normally
+      // api.githubcopilot.com) in OpenAI wire format, performing its own GitHub→
+      // Copilot token exchange and setting a `Copilot-Integration-Id` header.
+      // `COPILOT_API_URL` overrides that API base — verified in the @github/copilot
+      // loader, which returns it verbatim as the Copilot API URL when set — so
+      // pointing it at the gateway makes Copilot's model calls flow through Lore.
+      // Copilot posts to the ORIGIN's bare `/chat/completions` (its API omits the
+      // /v1 segment), which the gateway accepts; the gateway recognizes the
+      // integration header and forwards to the github-copilot upstream (see
+      // forwardToUpstream). Use the bare origin (no /v1 suffix).
+      //
+      // This intercepts Copilot's DEFAULT (GitHub-hosted) models. BYOK users
+      // point COPILOT_PROVIDER_BASE_URL at the gateway themselves, so we leave
+      // the COPILOT_PROVIDER_* vars untouched.
+      const env: Record<string, string> = { COPILOT_API_URL: url };
+      // Project attribution. Copilot has no env→header mapping for model calls,
+      // so the gateway attributes the project from cwd / system-prompt inference;
+      // these are exported for consistency with other agents and future use.
+      env.LORE_PROJECT = cwd;
+      const remote = safeRemote(cwd);
+      if (remote) env.LORE_GIT_REMOTE = remote;
+      return env;
+    },
+  },
 ];
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/src/cli/help.ts
+++ b/packages/gateway/src/cli/help.ts
@@ -22,7 +22,7 @@ Commands:
   setup [app]         Configure an AI app to route through lore. Prefer \`lore run\`
                        for terminal agents; use setup for GUI/IDE agents lore can't
                        launch, paired with a background gateway (\`lore start --bg\`).
-                       Supported: codex, opencode, claude-code
+                       Supported: claude-code, codex, opencode, pi, hermes, copilot
                        \`setup undo [app]\` reverts a previous setup (restores
                        the backup lore saved before it changed your config)
                        \`setup status\` prints a read-only inventory of what

--- a/packages/gateway/src/cli/inventory.ts
+++ b/packages/gateway/src/cli/inventory.ts
@@ -267,6 +267,31 @@ export function collectHermesInventory(): AppInventory {
   return { app: "Hermes", file, fileExists, rows, hasBackup };
 }
 
+/**
+ * Collect inventory for GitHub Copilot CLI. Copilot has no config-file endpoint
+ * override — routing is controlled entirely by the `COPILOT_API_URL` env var —
+ * so this reports that env var rather than a file. A row is emitted only when
+ * the var is set, mirroring the "unconfigured → empty" shape of the file-based
+ * collectors (`fileExists` maps to "the env var is present").
+ */
+export function collectCopilotInventory(): AppInventory {
+  const file = "environment";
+  const value = process.env.COPILOT_API_URL;
+  const isSet = value !== undefined && value !== "";
+  const rows: InventoryRow[] = isSet
+    ? [
+        {
+          app: "Copilot",
+          file,
+          fileExists: true,
+          key: "COPILOT_API_URL",
+          routing: classifyRoutingValue(value),
+        },
+      ]
+    : [];
+  return { app: "Copilot", file, fileExists: isSet, rows, hasBackup: false };
+}
+
 /** Collect inventory for all supported apps. */
 export function collectInventory(): AppInventory[] {
   return [
@@ -275,6 +300,7 @@ export function collectInventory(): AppInventory[] {
     collectOpencodeInventory(),
     collectPiInventory(),
     collectHermesInventory(),
+    collectCopilotInventory(),
   ];
 }
 

--- a/packages/gateway/src/cli/run.ts
+++ b/packages/gateway/src/cli/run.ts
@@ -101,7 +101,7 @@ async function resolveLaunchTarget(
   if (detected.length === 0) {
     console.error("[lore] No known AI agents found on PATH.");
     console.error(
-      "[lore] Install one of: Claude Code (claude), Codex (codex), Pi (pi), OpenCode (opencode), Hermes (hermes)",
+      "[lore] Install one of: Claude Code (claude), Codex (codex), Pi (pi), OpenCode (opencode), Hermes (hermes), GitHub Copilot CLI (copilot)",
     );
     console.error(`[lore] Or run with an explicit command: lore run <command>`);
     console.error(

--- a/packages/gateway/src/cli/setup.ts
+++ b/packages/gateway/src/cli/setup.ts
@@ -137,6 +137,16 @@ const SUPPORTED_APPS: AppSetup[] = [
     // equivalent of opencode's `--no-plugin` fallback — which is all the
     // gateway can wire up without shelling out to `pi`.
   },
+  {
+    agentName: "copilot",
+    displayName: "GitHub Copilot CLI",
+    run: (baseUrl) => setupCopilot(baseUrl),
+    undo: undoCopilot,
+    // Copilot CLI has NO config-file endpoint override — interception is only
+    // via the COPILOT_API_URL env var. `run` prints the required `lore run
+    // copilot` / export guidance; there is nothing to persist, so `undo` is an
+    // informational no-op. Inventory reads COPILOT_API_URL from the environment.
+  },
 ];
 
 // ---------------------------------------------------------------------------
@@ -1042,6 +1052,57 @@ function setupHermes(baseUrl: string): void {
 }
 
 // ---------------------------------------------------------------------------
+// GitHub Copilot CLI setup
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive the value COPILOT_API_URL should hold from the setup base URL. Copilot
+ * CLI posts to the ORIGIN's bare `/chat/completions` (its API omits the /v1
+ * segment), so strip a trailing `/v1`. Pure.
+ */
+export function copilotApiUrlFromBaseUrl(baseUrl: string): string {
+  return baseUrl.endsWith("/v1") ? baseUrl.slice(0, -3) : baseUrl;
+}
+
+/**
+ * "Configure" GitHub Copilot CLI to route through Lore.
+ *
+ * Unlike every other supported agent, Copilot CLI exposes NO config-file field
+ * for its API endpoint — interception is only possible via the `COPILOT_API_URL`
+ * environment variable (verified against the @github/copilot binary: it returns
+ * that var verbatim as the Copilot API URL when set). There is therefore nothing
+ * to persist to a config file; instead we print the exact export the user needs
+ * and recommend `lore run copilot` for the zero-config path. `lore setup status`
+ * / `doctor` read COPILOT_API_URL to show the current routing.
+ */
+function setupCopilot(baseUrl: string): void {
+  const apiUrl = copilotApiUrlFromBaseUrl(baseUrl);
+  console.log(`[lore] GitHub Copilot CLI routes through Lore via an env var.`);
+  console.log(
+    `[lore] It has no config-file endpoint override, so either launch it with:`,
+  );
+  console.log(`[lore]`);
+  console.log(`[lore]     lore run copilot`);
+  console.log(`[lore]`);
+  console.log(
+    `[lore] (which sets COPILOT_API_URL for that session automatically), or add`,
+  );
+  console.log(
+    `[lore] this to your shell profile (~/.bashrc, ~/.zshrc, …) for standalone use:`,
+  );
+  console.log(`[lore]`);
+  console.log(`[lore]     export COPILOT_API_URL=${apiUrl}`);
+  console.log(`[lore]`);
+  console.log(
+    `[lore] This intercepts Copilot's default GitHub-hosted models. If you use a`,
+  );
+  console.log(
+    `[lore] BYOK provider instead, point COPILOT_PROVIDER_BASE_URL=${apiUrl}/v1`,
+  );
+  console.log(`[lore] at the gateway.`);
+}
+
+// ---------------------------------------------------------------------------
 // Undo (`lore setup undo [app]`)
 // ---------------------------------------------------------------------------
 
@@ -1081,6 +1142,20 @@ function undoHermes(): RestoreSummary {
   const { content: restored, summary } = restoreEnvBackup(content);
   if (summary.hadBackup) writeFileSync(configPath, restored, "utf8");
   return summary;
+}
+
+function undoCopilot(): RestoreSummary {
+  // `lore setup copilot` never persists anything (Copilot CLI has no config-file
+  // endpoint field), so there is nothing to restore. Tell the user how to stop
+  // routing and return an empty summary.
+  console.log(
+    `[lore] GitHub Copilot CLI setup is env-var based (COPILOT_API_URL); lore`,
+  );
+  console.log(
+    `[lore] wrote no config. Remove the COPILOT_API_URL export from your shell`,
+  );
+  console.log(`[lore] profile to stop routing through the gateway.`);
+  return { hadBackup: false, restored: [], skipped: [] };
 }
 
 function undoCodex(): RestoreSummary {

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -661,6 +661,25 @@ export function extractProviderHeader(
 }
 
 /**
+ * True when the request carries a non-empty `Copilot-Integration-Id` header —
+ * the marker GitHub Copilot CLI sets on every model-API call (in both its
+ * default GitHub-hosted mode and any mode where it exchanges a Copilot token).
+ *
+ * Copilot CLI's default mode is redirected at the gateway via `COPILOT_API_URL`,
+ * but the CLI has no way to set `X-Lore-Provider`, so this header is the only
+ * signal that a request should route to the `github-copilot` upstream
+ * (api.githubcopilot.com) rather than being sent to api.openai.com /
+ * api.anthropic.com by model-prefix routing. Any non-empty integration id
+ * counts (e.g. `copilot-cli`, `vscode-chat`).
+ */
+export function hasCopilotIntegrationHeader(
+  headers: Record<string, string>,
+): boolean {
+  const raw = headers["copilot-integration-id"];
+  return typeof raw === "string" && raw.trim().length > 0;
+}
+
+/**
  * Reverse map: normalized upstream base URL → provider id.
  *
  * Built once from PROVIDER_ROUTES at module load. Each route's `url` is run

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -109,6 +109,7 @@ import {
   extractUpstreamPathHeader,
   verbatimUpstreamUrl,
   extractProviderHeader,
+  hasCopilotIntegrationHeader,
   resolveLastSeenProvider,
   resolveProviderRoute,
   unattributedBucketPath,
@@ -3367,6 +3368,22 @@ async function forwardToUpstream(
   // Non-blocking — returns cached data or null (triggers background refresh).
   if (!providerRoute && providerID) {
     providerRoute = lookupProviderRoute(providerID);
+  }
+  // GitHub Copilot CLI (default GitHub-hosted mode) is redirected at the gateway
+  // via COPILOT_API_URL. It sends OpenAI-format requests with its own exchanged
+  // Copilot bearer token and a `Copilot-Integration-Id` header, but has no way to
+  // set X-Lore-Provider — so its model ids (gpt-*, claude-*, gemini-*) would route
+  // by model prefix to the WRONG upstream (api.openai.com / api.anthropic.com).
+  // Treat the integration header as the routing signal → github-copilot upstream
+  // (api.githubcopilot.com). Explicit X-Lore-Provider and X-Lore-Upstream-URL
+  // (incl. BYOK, where the user points COPILOT_PROVIDER_BASE_URL at the gateway)
+  // still win, since both set providerRoute / headerUpstream first.
+  if (
+    !providerRoute &&
+    !headerUpstream &&
+    hasCopilotIntegrationHeader(req.rawHeaders)
+  ) {
+    providerRoute = resolveProviderRoute("github-copilot");
   }
   const modelRoute = resolveUpstreamRoute(req.model);
 

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -422,8 +422,15 @@ export async function startServer(config: GatewayConfig): Promise<{
         return await handleAnthropicMessages(req, config);
       }
 
-      // POST /v1/chat/completions — OpenAI protocol
-      if (method === "POST" && pathname === "/v1/chat/completions") {
+      // POST /v1/chat/completions — OpenAI protocol.
+      // The bare `/chat/completions` (no /v1) form is accepted too: GitHub
+      // Copilot CLI redirected via COPILOT_API_URL posts to the origin's bare
+      // path (its API omits the /v1 segment, like api.githubcopilot.com).
+      if (
+        method === "POST" &&
+        (pathname === "/v1/chat/completions" ||
+          pathname === "/chat/completions")
+      ) {
         return await handleOpenAIChatCompletions(req, config);
       }
 
@@ -437,7 +444,12 @@ export async function startServer(config: GatewayConfig): Promise<{
         return await handleOpenAICodexResponses(req, config);
       }
 
-      // POST /v1/responses — OpenAI Responses API protocol
+      // POST /v1/responses — OpenAI Responses API protocol.
+      // NOTE: the bare `/responses` (no /v1) form used by GitHub Copilot CLI's
+      // Responses wire API (GPT-5 series) is intentionally NOT accepted yet — the
+      // responses upstream builder emits `${base}/v1/responses`, which would 404
+      // against api.githubcopilot.com (its endpoints omit /v1). Wiring that needs
+      // a host-aware responses path (like buildOpenAIChatCompletionsUrl) first.
       if (method === "POST" && pathname === "/v1/responses") {
         return await handleOpenAIResponses(req, config);
       }

--- a/packages/gateway/test/agents.test.ts
+++ b/packages/gateway/test/agents.test.ts
@@ -235,3 +235,43 @@ describe("Codex agent cliArgs", () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// GitHub Copilot CLI agent
+// ---------------------------------------------------------------------------
+
+describe("GitHub Copilot CLI agent envVars", () => {
+  const copilot = AGENTS.find((a) => a.name === "copilot");
+  if (!copilot) throw new Error("copilot agent not registered");
+
+  test("registered with the `copilot` binary", () => {
+    expect(copilot.binary).toBe("copilot");
+  });
+
+  test("sets COPILOT_API_URL to the bare gateway origin (no /v1)", () => {
+    // Copilot posts to the ORIGIN's bare /chat/completions, so COPILOT_API_URL
+    // must be the gateway origin without a /v1 suffix.
+    const env = copilot.envVars(
+      "http://127.0.0.1:3207",
+      "/home/user/my-project",
+    );
+    expect(env.COPILOT_API_URL).toBe("http://127.0.0.1:3207");
+  });
+
+  test("COPILOT_API_URL tracks the gateway URL", () => {
+    const env = copilot.envVars("http://192.168.1.50:5673", "/tmp/test");
+    expect(env.COPILOT_API_URL).toBe("http://192.168.1.50:5673");
+  });
+
+  test("sets LORE_PROJECT to cwd", () => {
+    const env = copilot.envVars("http://127.0.0.1:3207", "/home/user/proj");
+    expect(env.LORE_PROJECT).toBe("/home/user/proj");
+  });
+
+  test("does NOT set COPILOT_PROVIDER_* (leaves the user's BYOK config alone)", () => {
+    const env = copilot.envVars("http://127.0.0.1:3207", "/tmp/test");
+    expect(env.COPILOT_PROVIDER_BASE_URL).toBeUndefined();
+    expect(env.COPILOT_PROVIDER_TYPE).toBeUndefined();
+    expect(env.COPILOT_PROVIDER_API_KEY).toBeUndefined();
+  });
+});

--- a/packages/gateway/test/copilot-routing.e2e.test.ts
+++ b/packages/gateway/test/copilot-routing.e2e.test.ts
@@ -1,0 +1,160 @@
+/**
+ * End-to-end routing guard for GitHub Copilot CLI interception.
+ *
+ * The Copilot CLI's default (GitHub-hosted) mode is redirected at lore via the
+ * `COPILOT_API_URL` env var. Copilot then sends OpenAI-format requests carrying
+ * its own exchanged Copilot bearer token and a `Copilot-Integration-Id` header,
+ * but it has NO way to set `X-Lore-Provider`. Its model ids (`gpt-5.4`,
+ * `claude-sonnet-4.6`, …) would otherwise route via model-prefix to the WRONG
+ * upstream (api.openai.com / api.anthropic.com). This test pins the behavior:
+ * when a `Copilot-Integration-Id` header is present and there is no explicit
+ * provider / upstream override, the gateway forwards to the `github-copilot`
+ * upstream (api.githubcopilot.com). Explicit `X-Lore-Provider` /
+ * `X-Lore-Upstream-URL` (BYOK) still win.
+ *
+ * Mechanism mirrors github-copilot-url.e2e.test.ts: `upstreamFetch` is mocked to
+ * capture the resolved upstream URL, and the pipeline's upstream interceptor is
+ * overridden to invoke the real (mocked) request so the URL flows into the mock.
+ */
+import { describe, test, expect, afterEach, vi } from "vitest";
+
+vi.mock("../src/fetch", () => ({ upstreamFetch: vi.fn() }));
+
+import { upstreamFetch } from "../src/fetch";
+import type { Harness } from "./helpers/harness";
+import { createHarness } from "./helpers/harness";
+
+const mockFetch = vi.mocked(upstreamFetch);
+
+function openAIResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      id: "chatcmpl-x",
+      object: "chat.completion",
+      model: "gpt-5.4",
+      choices: [
+        {
+          index: 0,
+          message: { role: "assistant", content: "ok" },
+          finish_reason: "stop",
+        },
+      ],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+/**
+ * Send an OpenAI chat-completions request with the given model + headers and
+ * return the captured upstream URL the gateway forwarded to.
+ */
+async function captureUpstreamUrl(
+  harness: Harness,
+  model: string,
+  headers: Record<string, string>,
+  ingressPath = "/v1/chat/completions",
+): Promise<string> {
+  const { setUpstreamInterceptor } = await import("../src/pipeline");
+  setUpstreamInterceptor(async (_body, _model, _stream, makeReal) =>
+    makeReal(),
+  );
+  mockFetch.mockReset();
+  mockFetch.mockResolvedValue(openAIResponse());
+
+  const res = await fetch(`${harness.baseURL}${ingressPath}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: "Bearer tid=copilot-token",
+      "x-lore-project": "/tmp/copilot-routing-e2e",
+      ...headers,
+    },
+    body: JSON.stringify({
+      model,
+      stream: false,
+      messages: [{ role: "user", content: "hi" }],
+    }),
+  });
+  await res.text().catch(() => undefined);
+
+  expect(mockFetch).toHaveBeenCalled();
+  return String(mockFetch.mock.calls[0][0]);
+}
+
+describe("Copilot-Integration-Id → github-copilot upstream routing", () => {
+  let harness: Harness | undefined;
+
+  afterEach(async () => {
+    await harness?.teardown();
+    harness = undefined;
+  });
+
+  test("routes a gpt- model to api.githubcopilot.com (not api.openai.com)", async () => {
+    harness = await createHarness({ fixtures: [] });
+    const url = await captureUpstreamUrl(harness, "gpt-5.4", {
+      "copilot-integration-id": "copilot-cli",
+    });
+    expect(url).toContain("api.githubcopilot.com");
+    expect(url).not.toContain("api.openai.com");
+  });
+
+  test("routes a claude- model to api.githubcopilot.com (beats model-prefix anthropic route)", async () => {
+    harness = await createHarness({ fixtures: [] });
+    const url = await captureUpstreamUrl(harness, "claude-sonnet-4.6", {
+      "copilot-integration-id": "copilot-cli",
+    });
+    expect(url).toContain("api.githubcopilot.com");
+    expect(url).not.toContain("api.anthropic.com");
+  });
+
+  test("explicit X-Lore-Provider wins over the integration-id signal (BYOK/other)", async () => {
+    harness = await createHarness({ fixtures: [] });
+    const url = await captureUpstreamUrl(harness, "gpt-5.4", {
+      "copilot-integration-id": "copilot-cli",
+      "x-lore-provider": "openai",
+    });
+    // Explicit provider override must not be hijacked to github-copilot.
+    expect(url).not.toContain("api.githubcopilot.com");
+  });
+
+  test("explicit X-Lore-Upstream-URL (BYOK) wins over the integration-id signal", async () => {
+    harness = await createHarness({ fixtures: [] });
+    const url = await captureUpstreamUrl(harness, "gpt-5.4", {
+      "copilot-integration-id": "copilot-cli",
+      "x-lore-upstream-url": "https://api.openai.com",
+    });
+    expect(url).not.toContain("api.githubcopilot.com");
+    expect(url).toContain("api.openai.com");
+  });
+
+  test("without the integration-id header, model-prefix routing is unchanged", async () => {
+    harness = await createHarness({ fixtures: [] });
+    const url = await captureUpstreamUrl(harness, "gpt-5.4", {});
+    expect(url).toContain("api.openai.com");
+    expect(url).not.toContain("api.githubcopilot.com");
+  });
+});
+
+describe("Copilot bare (no /v1) ingress paths", () => {
+  let harness: Harness | undefined;
+
+  afterEach(async () => {
+    await harness?.teardown();
+    harness = undefined;
+  });
+
+  test("POST /chat/completions (no /v1) is accepted and routed", async () => {
+    // Copilot CLI redirected via COPILOT_API_URL hits the origin's bare
+    // /chat/completions (no /v1 segment). It must reach the OpenAI handler and,
+    // with the integration-id header, forward to github-copilot.
+    harness = await createHarness({ fixtures: [] });
+    const url = await captureUpstreamUrl(
+      harness,
+      "gpt-5.4",
+      { "copilot-integration-id": "copilot-cli" },
+      "/chat/completions",
+    );
+    expect(url).toContain("api.githubcopilot.com");
+  });
+});

--- a/packages/gateway/test/doctor.test.ts
+++ b/packages/gateway/test/doctor.test.ts
@@ -24,6 +24,7 @@ let origHome: string | undefined;
 let origXdg: string | undefined;
 let origPiDir: string | undefined;
 let origHermesHome: string | undefined;
+let origCopilotApiUrl: string | undefined;
 let logSpy: MockInstance;
 let errSpy: MockInstance;
 
@@ -38,6 +39,10 @@ beforeEach(() => {
   origXdg = process.env.XDG_DATA_HOME;
   origPiDir = process.env.PI_CODING_AGENT_DIR;
   origHermesHome = process.env.HERMES_HOME;
+  origCopilotApiUrl = process.env.COPILOT_API_URL;
+  // Copilot inventory reads COPILOT_API_URL from the environment; unset it so a
+  // stray value in the runner doesn't leak into the "clean" assertions.
+  delete process.env.COPILOT_API_URL;
   home = mkdtempSync(join(tmpdir(), "lore-doctor-"));
   process.env.HOME = home;
   process.env.XDG_DATA_HOME = join(home, "data");
@@ -61,6 +66,8 @@ afterEach(() => {
   else process.env.PI_CODING_AGENT_DIR = origPiDir;
   if (origHermesHome === undefined) delete process.env.HERMES_HOME;
   else process.env.HERMES_HOME = origHermesHome;
+  if (origCopilotApiUrl === undefined) delete process.env.COPILOT_API_URL;
+  else process.env.COPILOT_API_URL = origCopilotApiUrl;
   rmSync(home, { recursive: true, force: true });
 });
 
@@ -343,21 +350,42 @@ describe("formatFinding", () => {
 });
 
 describe("collectInventory (integration)", () => {
-  it("returns all-five-apps inventory with missing files on a clean HOME", () => {
+  it("returns all-six-apps inventory with missing files on a clean HOME", () => {
     const all = collectInventory();
-    expect(all).toHaveLength(5);
+    expect(all).toHaveLength(6);
     expect(all.map((i) => i.app)).toEqual([
       "Claude Code",
       "Codex",
       "OpenCode",
       "Pi",
       "Hermes",
+      "Copilot",
     ]);
     for (const inv of all) {
       expect(inv.fileExists).toBe(false);
       expect(inv.rows).toEqual([]);
       expect(inv.hasBackup).toBe(false);
     }
+  });
+
+  it("reports Copilot routing from the COPILOT_API_URL env var", () => {
+    process.env.COPILOT_API_URL = "http://127.0.0.1:3299";
+    const all = collectInventory();
+    const copilot = all.find((i) => i.app === "Copilot")!;
+    expect(copilot.fileExists).toBe(true);
+    const row = copilot.rows.find((r) => r.key === "COPILOT_API_URL")!;
+    expect(row.routing).toEqual({
+      kind: "lore",
+      value: "http://127.0.0.1:3299",
+    });
+  });
+
+  it("Copilot inventory is empty when COPILOT_API_URL is unset", () => {
+    delete process.env.COPILOT_API_URL;
+    const all = collectInventory();
+    const copilot = all.find((i) => i.app === "Copilot")!;
+    expect(copilot.fileExists).toBe(false);
+    expect(copilot.rows).toEqual([]);
   });
 
   it("collects lore-routed values after setup", async () => {

--- a/packages/gateway/test/setup-io.test.ts
+++ b/packages/gateway/test/setup-io.test.ts
@@ -296,3 +296,19 @@ describe("commandSetup — argument handling", () => {
     process.exitCode = 0;
   });
 });
+
+describe("commandSetup — GitHub Copilot CLI", () => {
+  it("prints COPILOT_API_URL guidance (no config file) and undoes cleanly", async () => {
+    // Copilot has no config-file endpoint field; setup is guidance-only. It must
+    // not throw and must surface the bare-origin export + the `lore run` path.
+    await commandSetup(["copilot"], { port: 3299 });
+    const out = logged();
+    expect(out).toContain("export COPILOT_API_URL=http://127.0.0.1:3299");
+    expect(out).toContain("lore run copilot");
+    // No config file is written for Copilot.
+
+    // Undo is an informational no-op (nothing was persisted).
+    await commandSetup(["undo", "copilot"], {});
+    expect(logged()).toContain("COPILOT_API_URL");
+  });
+});

--- a/packages/gateway/test/setup.test.ts
+++ b/packages/gateway/test/setup.test.ts
@@ -9,6 +9,7 @@ import {
   piModelsConfigPath,
   updateHermesEnv,
   hermesEnvPath,
+  copilotApiUrlFromBaseUrl,
   opencodePluginSpec,
 } from "../src/cli/setup";
 import { homedir } from "node:os";
@@ -769,5 +770,27 @@ describe("hermesEnvPath", () => {
       if (saved === undefined) delete process.env.HERMES_HOME;
       else process.env.HERMES_HOME = saved;
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// copilotApiUrlFromBaseUrl (GitHub Copilot CLI)
+// ---------------------------------------------------------------------------
+
+describe("copilotApiUrlFromBaseUrl", () => {
+  test("strips a trailing /v1 (Copilot posts to the bare origin)", () => {
+    expect(copilotApiUrlFromBaseUrl("http://127.0.0.1:3207/v1")).toBe(
+      "http://127.0.0.1:3207",
+    );
+  });
+
+  test("leaves a bare origin unchanged", () => {
+    expect(copilotApiUrlFromBaseUrl("http://127.0.0.1:3207")).toBe(
+      "http://127.0.0.1:3207",
+    );
+  });
+
+  test("does not strip a /v1 that is not a trailing segment", () => {
+    expect(copilotApiUrlFromBaseUrl("http://host/v1x")).toBe("http://host/v1x");
   });
 });


### PR DESCRIPTION
## What

Adds first-class support for **GitHub Copilot CLI** (`@github/copilot`, binary `copilot`) to `lore run` and `lore setup`, so its model calls flow through the Lore gateway for memory injection + distillation.

This is **PR 1 of 2** from the plan (Copilot first, Gemini CLI next as a separate PR).

## How Copilot is intercepted

Empirically verified against the `@github/copilot` binary: the CLI exposes an undocumented **`COPILOT_API_URL`** env var that overrides its default Copilot API base (normally `api.githubcopilot.com`). Copilot speaks OpenAI wire format, does its **own** GitHub→Copilot token exchange, and sets a `Copilot-Integration-Id` header. So Lore just needs to receive that traffic and forward it to the genuine `api.githubcopilot.com` — a pure transparent proxy, no token brokering.

This intercepts Copilot's **default GitHub-hosted models** (not just BYOK). BYOK users can alternatively point `COPILOT_PROVIDER_BASE_URL` at the gateway themselves; those vars are left untouched.

## Changes

**Gateway**
- `hasCopilotIntegrationHeader()` + routing in `forwardToUpstream`: when a `Copilot-Integration-Id` header is present and there's no explicit provider/upstream override, force the `github-copilot` upstream. Otherwise Copilot's model ids (`gpt-*`, `claude-*`, …) would route by model-prefix to the wrong host. Explicit `X-Lore-Provider` / `X-Lore-Upstream-URL` / BYOK still win.
- Accept the bare `/chat/completions` ingress path (no `/v1`) — Copilot posts to the origin of `COPILOT_API_URL`. (The bare `/responses` Responses-wire path is intentionally deferred: the responses upstream builder emits `/v1/responses`, which would 404 against `api.githubcopilot.com`; it needs a host-aware responses path first.)

**CLI**
- `lore run copilot` (+ `lore copilot` shorthand, auto-detect picker): sets `COPILOT_API_URL` to the gateway origin.
- `lore setup copilot`: Copilot has **no config-file endpoint field**, so setup is guidance-based — it prints the `lore run copilot` / `export COPILOT_API_URL=…` instructions + a BYOK note; `undo` is an informational no-op.
- Inventory collector reports `COPILOT_API_URL` from the environment so `lore setup status` / `doctor` show Copilot routing.

## Tests (TDD)
- `copilot-routing.e2e.test.ts` — full-pipeline routing guards: `gpt-`/`claude-` models → `api.githubcopilot.com`; explicit provider/upstream/BYOK override wins; no-header baseline unchanged; bare `/chat/completions` ingress reaches upstream. Core forcing logic verified non-vacuous (red→green) + mutation-checked (dropping the `!providerRoute` guard fails the explicit-provider test).
- `agents.test.ts`, `setup.test.ts`, `setup-io.test.ts`, `doctor.test.ts` — agent envVars, `copilotApiUrlFromBaseUrl`, setup round-trip, inventory (5→6 app fan-out).

Full gateway suite green; typecheck clean.