### PR TITLE
feat: native Google Gemini (generateContent) protocol + Gemini CLI support

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -334,7 +334,12 @@ export interface LLMClient {
        * Only the gateway adapter honors this field; other adapters
        * (OpenCode, Pi) ignore it.
        */
-      protocol?: "anthropic" | "openai" | "openai-responses" | "vertex";
+      protocol?:
+        | "anthropic"
+        | "openai"
+        | "openai-responses"
+        | "vertex"
+        | "gemini";
     },
   ): Promise<string | null>;
 }

--- a/packages/gateway/src/auth.ts
+++ b/packages/gateway/src/auth.ts
@@ -42,6 +42,13 @@ export function extractAuth(
   const apiKey = headers["x-api-key"] || headers["X-Api-Key"];
   if (apiKey) return { scheme: "api-key", value: apiKey };
 
+  // Google Gemini's native API authenticates with `x-goog-api-key`. Capture it
+  // as an api-key credential so gemini sessions get a stable identity and their
+  // background workers can resolve auth (worker builders emit it as
+  // `x-goog-api-key`, not the generic `x-api-key`, via buildGeminiWorkerRequest).
+  const googKey = headers["x-goog-api-key"] || headers["X-Goog-Api-Key"];
+  if (googKey) return { scheme: "api-key", value: googKey };
+
   const authHeader = headers.authorization || headers.Authorization;
   if (authHeader) {
     const match = /^Bearer\s+(\S+)$/i.exec(authHeader);

--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -1145,7 +1145,13 @@ function isAnthropicFirstPartyHost(url: string): boolean {
  */
 export function resolveProfile(
   model: string | undefined,
-  protocol: "anthropic" | "openai" | "openai-responses" | "vertex" | undefined,
+  protocol:
+    | "anthropic"
+    | "openai"
+    | "openai-responses"
+    | "vertex"
+    | "gemini"
+    | undefined,
   ttl: "5m" | "1h" | undefined,
   upstreamBase?: string,
   providerID?: string,

--- a/packages/gateway/src/cli/agents.ts
+++ b/packages/gateway/src/cli/agents.ts
@@ -293,6 +293,28 @@ export const AGENTS: AgentDef[] = [
       return env;
     },
   },
+  {
+    name: "gemini",
+    displayName: "Gemini CLI",
+    binary: "gemini",
+    detect: () => whichSync("gemini"),
+    envVars: (url, cwd) => {
+      // Google's Gemini CLI (GEMINI_API_KEY mode) reads GOOGLE_GEMINI_BASE_URL
+      // as the base origin for the native Generative Language API — it appends
+      // `/v1beta/models/{model}:generateContent` itself, so pass the bare gateway
+      // origin (no /v1). Gemini's security rule allows plain HTTP only for
+      // localhost / 127.0.0.1 / [::1], which the local gateway satisfies. The
+      // gateway speaks the native generateContent protocol and forwards to
+      // generativelanguage.googleapis.com.
+      const env: Record<string, string> = { GOOGLE_GEMINI_BASE_URL: url };
+      // Project attribution (Gemini has no env→header mapping for model calls;
+      // the gateway attributes from cwd / system-prompt inference).
+      env.LORE_PROJECT = cwd;
+      const remote = safeRemote(cwd);
+      if (remote) env.LORE_GIT_REMOTE = remote;
+      return env;
+    },
+  },
 ];
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/src/cli/help.ts
+++ b/packages/gateway/src/cli/help.ts
@@ -22,7 +22,7 @@ Commands:
   setup [app]         Configure an AI app to route through lore. Prefer \`lore run\`
                        for terminal agents; use setup for GUI/IDE agents lore can't
                        launch, paired with a background gateway (\`lore start --bg\`).
-                       Supported: claude-code, codex, opencode, pi, hermes, copilot
+                       Supported: claude-code, codex, opencode, pi, hermes, copilot, gemini
                        \`setup undo [app]\` reverts a previous setup (restores
                        the backup lore saved before it changed your config)
                        \`setup status\` prints a read-only inventory of what

--- a/packages/gateway/src/cli/inventory.ts
+++ b/packages/gateway/src/cli/inventory.ts
@@ -11,6 +11,7 @@ import {
   claudeCodeSettingsPath,
   codexConfigPath,
   hermesEnvPath,
+  geminiEnvPath,
   opencodeConfigPath,
   piModelsConfigPath,
   readJsonConfig,
@@ -267,6 +268,27 @@ export function collectHermesInventory(): AppInventory {
   return { app: "Hermes", file, fileExists, rows, hasBackup };
 }
 
+/** Collect inventory for the Gemini CLI (dotenv). Reads `~/.gemini/.env`. */
+export function collectGeminiInventory(): AppInventory {
+  const file = geminiEnvPath();
+  const fileExists = existsSync(file);
+  const rows: InventoryRow[] = [];
+  let hasBackup = false;
+  if (fileExists) {
+    const content = readFileSync(file, "utf8");
+    hasBackup = content.includes("lore setup backup");
+    const url = getEnvValue(content, "GOOGLE_GEMINI_BASE_URL");
+    rows.push({
+      app: "Gemini",
+      file,
+      fileExists,
+      key: "GOOGLE_GEMINI_BASE_URL",
+      routing: url === null ? { kind: "unset" } : classifyRoutingValue(url),
+    });
+  }
+  return { app: "Gemini", file, fileExists, rows, hasBackup };
+}
+
 /**
  * Collect inventory for GitHub Copilot CLI. Copilot has no config-file endpoint
  * override — routing is controlled entirely by the `COPILOT_API_URL` env var —
@@ -300,6 +322,7 @@ export function collectInventory(): AppInventory[] {
     collectOpencodeInventory(),
     collectPiInventory(),
     collectHermesInventory(),
+    collectGeminiInventory(),
     collectCopilotInventory(),
   ];
 }

--- a/packages/gateway/src/cli/run.ts
+++ b/packages/gateway/src/cli/run.ts
@@ -101,7 +101,7 @@ async function resolveLaunchTarget(
   if (detected.length === 0) {
     console.error("[lore] No known AI agents found on PATH.");
     console.error(
-      "[lore] Install one of: Claude Code (claude), Codex (codex), Pi (pi), OpenCode (opencode), Hermes (hermes), GitHub Copilot CLI (copilot)",
+      "[lore] Install one of: Claude Code (claude), Codex (codex), Pi (pi), OpenCode (opencode), Hermes (hermes), GitHub Copilot CLI (copilot), Gemini CLI (gemini)",
     );
     console.error(`[lore] Or run with an explicit command: lore run <command>`);
     console.error(

--- a/packages/gateway/src/cli/setup.ts
+++ b/packages/gateway/src/cli/setup.ts
@@ -147,6 +147,15 @@ const SUPPORTED_APPS: AppSetup[] = [
     // copilot` / export guidance; there is nothing to persist, so `undo` is an
     // informational no-op. Inventory reads COPILOT_API_URL from the environment.
   },
+  {
+    agentName: "gemini",
+    displayName: "Gemini CLI",
+    run: (baseUrl) => setupGemini(baseUrl),
+    undo: undoGemini,
+    // Gemini CLI reads GOOGLE_GEMINI_BASE_URL from ~/.gemini/.env (dotenv), so
+    // this persists the base URL there — the native generateContent equivalent
+    // of the Hermes env writer.
+  },
 ];
 
 // ---------------------------------------------------------------------------
@@ -1103,6 +1112,62 @@ function setupCopilot(baseUrl: string): void {
 }
 
 // ---------------------------------------------------------------------------
+// Gemini CLI setup
+// ---------------------------------------------------------------------------
+
+/** Path to Gemini CLI's dotenv file (`~/.gemini/.env`). */
+export function geminiEnvPath(): string {
+  return join(homedir(), ".gemini", ".env");
+}
+
+/**
+ * Rewrite Gemini CLI's `~/.gemini/.env` to route through the gateway. Sets
+ * `GOOGLE_GEMINI_BASE_URL` to the bare gateway origin (Gemini appends
+ * `/v1beta/models/...` itself, so strip a trailing `/v1`). Prepends a
+ * `#`-commented backup block and upserts the key in place (preserving every
+ * other line, e.g. `GEMINI_API_KEY`). Idempotent.
+ */
+export function updateGeminiEnv(content: string, baseUrl: string): string {
+  const root = copilotApiUrlFromBaseUrl(baseUrl); // strips a trailing /v1
+  const loreValues: Record<string, string> = {
+    GOOGLE_GEMINI_BASE_URL: root,
+  };
+  const block = buildEnvBackupBlock(content, loreValues);
+  let result = content;
+  for (const [key, value] of Object.entries(loreValues)) {
+    result = setEnvValueRaw(result, key, value);
+  }
+  return block ? prependEnvBackupBlock(result, block) : result;
+}
+
+function setupGemini(baseUrl: string): void {
+  const configPath = geminiEnvPath();
+  mkdirSync(dirname(configPath), { recursive: true });
+
+  let content = "";
+  try {
+    content = readFileSync(configPath, "utf8");
+  } catch (e: unknown) {
+    if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
+  }
+
+  const updated = updateGeminiEnv(content, baseUrl);
+  writeFileSync(configPath, updated, "utf8");
+
+  const root = copilotApiUrlFromBaseUrl(baseUrl);
+  console.log(`[lore] Gemini CLI configured to use Lore gateway.`);
+  console.log(`[lore]   GOOGLE_GEMINI_BASE_URL=${root}`);
+  console.log(`[lore]   Config: ${configPath}`);
+  console.log(`[lore]`);
+  console.log(
+    `[lore] Uses GEMINI_API_KEY auth. If Gemini CLI doesn't load ~/.gemini/.env,`,
+  );
+  console.log(
+    `[lore] export GOOGLE_GEMINI_BASE_URL in your shell, or use: lore run gemini`,
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Undo (`lore setup undo [app]`)
 // ---------------------------------------------------------------------------
 
@@ -1156,6 +1221,22 @@ function undoCopilot(): RestoreSummary {
   );
   console.log(`[lore] profile to stop routing through the gateway.`);
   return { hadBackup: false, restored: [], skipped: [] };
+}
+
+function undoGemini(): RestoreSummary {
+  const configPath = geminiEnvPath();
+  let content: string;
+  try {
+    content = readFileSync(configPath, "utf8");
+  } catch (e: unknown) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") {
+      return { hadBackup: false, restored: [], skipped: [] };
+    }
+    throw e;
+  }
+  const { content: restored, summary } = restoreEnvBackup(content);
+  if (summary.hadBackup) writeFileSync(configPath, restored, "utf8");
+  return summary;
 }
 
 function undoCodex(): RestoreSummary {

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -435,8 +435,18 @@ export function verbatimUpstreamUrl(params: {
   effectiveUpstreamBase: string;
   headerUpstream: string | undefined;
   upstreamPath: string | undefined;
-  effectiveProtocol: "anthropic" | "openai" | "openai-responses" | "vertex" | "gemini";
-  ingressProtocol: "anthropic" | "openai" | "openai-responses" | "vertex" | "gemini";
+  effectiveProtocol:
+    | "anthropic"
+    | "openai"
+    | "openai-responses"
+    | "vertex"
+    | "gemini";
+  ingressProtocol:
+    | "anthropic"
+    | "openai"
+    | "openai-responses"
+    | "vertex"
+    | "gemini";
 }): string {
   const {
     reconstructedUrl,

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -237,7 +237,7 @@ export function loadConfig(): GatewayConfig {
 
 export type UpstreamRoute = {
   url: string;
-  protocol: "anthropic" | "openai" | "openai-responses" | "vertex";
+  protocol: "anthropic" | "openai" | "openai-responses" | "vertex" | "gemini";
 };
 
 /**
@@ -250,7 +250,7 @@ export type UpstreamRoute = {
 const UPSTREAM_ROUTES: Array<{
   prefix: string;
   url: string;
-  protocol: "anthropic" | "openai" | "openai-responses" | "vertex";
+  protocol: "anthropic" | "openai" | "openai-responses" | "vertex" | "gemini";
 }> = [
   // Anthropic
   {
@@ -435,8 +435,8 @@ export function verbatimUpstreamUrl(params: {
   effectiveUpstreamBase: string;
   headerUpstream: string | undefined;
   upstreamPath: string | undefined;
-  effectiveProtocol: "anthropic" | "openai" | "openai-responses" | "vertex";
-  ingressProtocol: "anthropic" | "openai" | "openai-responses" | "vertex";
+  effectiveProtocol: "anthropic" | "openai" | "openai-responses" | "vertex" | "gemini";
+  ingressProtocol: "anthropic" | "openai" | "openai-responses" | "vertex" | "gemini";
 }): string {
   const {
     reconstructedUrl,
@@ -476,7 +476,13 @@ export type ProviderRoute = {
   /** Wire protocol for this upstream. When `null`, the ingress protocol is
    *  preserved — use this for proxy/aggregator providers (OpenCode Zen,
    *  Vercel AI Gateway, etc.) that accept whichever protocol the client sends. */
-  protocol: "anthropic" | "openai" | "openai-responses" | "vertex" | null;
+  protocol:
+    | "anthropic"
+    | "openai"
+    | "openai-responses"
+    | "vertex"
+    | "gemini"
+    | null;
   /** AWS Bedrock via the `bedrock-mantle` endpoint. When true, the gateway
    *  builds the region-specific mantle URL (`bedrock-mantle.<region>.api.aws/
    *  anthropic`) as the upstream base and remaps `body.model` to the mantle

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -491,7 +491,8 @@ type WorkerProtocol =
   | "anthropic"
   | "openai"
   | "openai-codex-responses"
-  | "vertex";
+  | "vertex"
+  | "gemini";
 
 /** Upstream URL, wire protocol, and provider label for a resolved target. */
 type ProviderTarget = {
@@ -516,7 +517,7 @@ type ProviderTarget = {
  */
 export function resolveWorkerProtocol(
   providerID: string,
-  explicit?: "anthropic" | "openai" | "openai-responses" | "vertex",
+  explicit?: "anthropic" | "openai" | "openai-responses" | "vertex" | "gemini",
 ): WorkerProtocol {
   // openai-codex MUST use the Responses API — its backend has no Chat
   // Completions endpoint. This takes precedence over the explicit hint

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -862,11 +862,18 @@ function buildGeminiWorkerRequest(
     generationConfig,
   };
   if (system) body.systemInstruction = { parts: [{ text: system }] };
+  // Gemini API-key auth uses `x-goog-api-key`; OAuth/Code-Assist sessions use a
+  // Bearer token. Be scheme-aware so a bearer credential is never shoved into
+  // the api-key header (which would silently misauth).
+  const authHeader: Record<string, string> =
+    cred.scheme === "bearer"
+      ? { Authorization: `Bearer ${cred.value}` }
+      : { "x-goog-api-key": cred.value };
   return {
     url: `${target.url}/v1beta/models/${encodeURIComponent(model.modelID)}:generateContent`,
     headers: {
       "Content-Type": "application/json",
-      "x-goog-api-key": cred.value,
+      ...authHeader,
     },
     body: JSON.stringify(body),
   };

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -536,12 +536,16 @@ export function resolveWorkerProtocol(
     // already "anthropic" (route carries `bedrockMantle: true`), so Bedrock
     // worker calls route to the mantle upstream over the normal Anthropic path.
     if (explicit === "vertex") return "vertex";
+    // Gemini is a DISTINCT worker protocol: native generateContent (model in the
+    // URL path, x-goog-api-key auth) — it must NOT collapse to "openai".
+    if (explicit === "gemini") return "gemini";
     return explicit === "anthropic" ? "anthropic" : "openai";
   }
   // 2. Route table lookup
   const route = resolveProviderRoute(providerID);
   if (route?.protocol) {
     if (route.protocol === "vertex") return "vertex";
+    if (route.protocol === "gemini") return "gemini";
     return route.protocol === "anthropic" ? "anthropic" : "openai";
   }
   // 3. Default: anthropic (safest for unknown/aggregator providers)
@@ -836,6 +840,71 @@ function buildOpenAIWorkerRequest(
 }
 
 /**
+ * Build a native Gemini `generateContent` worker request. Gemini authenticates
+ * with an API key via `x-goog-api-key` (NOT Bearer), carries the model in the
+ * URL path, and uses `systemInstruction` + `contents` + `generationConfig`.
+ */
+function buildGeminiWorkerRequest(
+  target: ProviderTarget,
+  cred: AuthCredential,
+  model: { providerID: string; modelID: string },
+  system: string,
+  user: string,
+  maxTokens: number,
+  temperature?: number,
+): { url: string; headers: Record<string, string>; body: string } {
+  const generationConfig: Record<string, unknown> = {
+    maxOutputTokens: maxTokens,
+  };
+  if (temperature != null) generationConfig.temperature = temperature;
+  const body: Record<string, unknown> = {
+    contents: [{ role: "user", parts: [{ text: user }] }],
+    generationConfig,
+  };
+  if (system) body.systemInstruction = { parts: [{ text: system }] };
+  return {
+    url: `${target.url}/v1beta/models/${encodeURIComponent(model.modelID)}:generateContent`,
+    headers: {
+      "Content-Type": "application/json",
+      "x-goog-api-key": cred.value,
+    },
+    body: JSON.stringify(body),
+  };
+}
+
+/** Parse a native Gemini `generateContent` worker response into `{text,usage,model}`. */
+function parseGeminiWorkerResponse(data: {
+  candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>;
+  usageMetadata?: {
+    promptTokenCount?: number;
+    candidatesTokenCount?: number;
+    cachedContentTokenCount?: number;
+  };
+  modelVersion?: string;
+}): {
+  text: string | null;
+  usage: AnthropicUsage | null;
+  model: string | null;
+} {
+  const parts = data.candidates?.[0]?.content?.parts ?? [];
+  const text =
+    parts
+      .filter((p) => typeof p.text === "string")
+      .map((p) => p.text)
+      .join("") || null;
+  const um = data.usageMetadata;
+  const usage: AnthropicUsage | null = um
+    ? {
+        input_tokens: um.promptTokenCount ?? 0,
+        output_tokens: um.candidatesTokenCount ?? 0,
+        cache_read_input_tokens: um.cachedContentTokenCount ?? 0,
+        cache_creation_input_tokens: 0,
+      }
+    : null;
+  return { text, usage, model: data.modelVersion ?? null };
+}
+
+/**
  * Build an OpenAI **Responses API** worker request for `openai-codex`.
  *
  * ChatGPT's `/backend-api` serves only the Responses API, so worker calls use
@@ -1113,6 +1182,16 @@ async function buildWorkerRequest(
         temperature,
         disableThinking,
       );
+    case "gemini":
+      return buildGeminiWorkerRequest(
+        target,
+        cred,
+        model,
+        system,
+        user,
+        maxTokens,
+        temperature,
+      );
     default:
       return buildAnthropicWorkerRequest(
         target,
@@ -1140,6 +1219,10 @@ function parseWorkerResponse(
       );
     case "openai":
       return parseOpenAIResponse(rawData as OpenAIChatResponse);
+    case "gemini":
+      return parseGeminiWorkerResponse(
+        rawData as Parameters<typeof parseGeminiWorkerResponse>[0],
+      );
     default:
       return parseAnthropicResponse(
         rawData as Parameters<typeof parseAnthropicResponse>[0],

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -3453,11 +3453,14 @@ async function forwardToUpstream(
     req.protocol === "openai-responses"
       ? "openai-responses"
       : req.protocol === "gemini"
-        ? // Native Gemini ingress stays gemini unless an explicit provider route
-          // overrides it (cross-routing). Do NOT let the `gemini-` model-prefix
-          // route — which is the OpenAI-compat layer (protocol "openai") — hijack
-          // a native generateContent request back to Chat Completions.
-          (providerRouteUsable?.protocol ?? "gemini")
+        ? // A native Gemini ingress ALWAYS stays gemini. The provider route still
+          // supplies the upstream URL (e.g. X-Lore-Provider: google →
+          // generativelanguage), but its protocol must not downgrade a native
+          // generateContent request: the `gemini-` model-prefix route and the
+          // `google` provider route are both the OpenAI-compat layer
+          // (protocol "openai"), which would wrongly re-translate to Chat
+          // Completions. opencode/pi's @ai-sdk/google speaks native generateContent.
+          "gemini"
         : (providerRouteUsable?.protocol ??
           modelRoute?.protocol ??
           req.protocol);
@@ -5185,8 +5188,8 @@ function postResponse(
       req.protocol === "openai-responses"
         ? "openai-responses"
         : req.protocol === "gemini"
-          ? // Mirror forwardToUpstream: native gemini ingress stays gemini.
-            (lpRouteUsable?.protocol ?? "gemini")
+          ? // Mirror forwardToUpstream: native gemini ingress always stays gemini.
+            "gemini"
           : (lpRouteUsable?.protocol ??
             resolveUpstreamRoute(req.model)?.protocol ??
             req.protocol);

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -442,6 +442,9 @@ export function stripContextWarnings(messages: GatewayMessage[]): void {
  * output on user messages for commit indicators. Used to trigger curation at
  * commit boundaries — natural checkpoints where decisions crystallize.
  */
+/** Default upstream origin for native Gemini (Generative Language API). */
+const GEMINI_DEFAULT_UPSTREAM = "https://generativelanguage.googleapis.com";
+
 const GIT_COMMIT_RE = /\bgit\s+commit\b/i;
 function containsGitCommit(req: GatewayRequest): boolean {
   for (const msg of req.messages) {
@@ -3449,7 +3452,15 @@ async function forwardToUpstream(
   const effectiveProtocol =
     req.protocol === "openai-responses"
       ? "openai-responses"
-      : (providerRouteUsable?.protocol ?? modelRoute?.protocol ?? req.protocol);
+      : req.protocol === "gemini"
+        ? // Native Gemini ingress stays gemini unless an explicit provider route
+          // overrides it (cross-routing). Do NOT let the `gemini-` model-prefix
+          // route — which is the OpenAI-compat layer (protocol "openai") — hijack
+          // a native generateContent request back to Chat Completions.
+          (providerRouteUsable?.protocol ?? "gemini")
+        : (providerRouteUsable?.protocol ??
+          modelRoute?.protocol ??
+          req.protocol);
 
   // Self-URL-building routes derive their base from config (region), not from
   // the route tables. This must take precedence over `modelRoute?.url`: a
@@ -3477,7 +3488,12 @@ async function forwardToUpstream(
     modelRoute?.url ??
     (effectiveProtocol === "anthropic"
       ? config.upstreamAnthropic
-      : config.upstreamOpenAI);
+      : effectiveProtocol === "gemini"
+        ? // Native Gemini default upstream (Generative Language API). `gemini-*`
+          // models resolve this via modelRoute.url already; this covers a native
+          // gemini ingress whose model id doesn't match the `gemini-` prefix.
+          GEMINI_DEFAULT_UPSTREAM
+        : config.upstreamOpenAI);
 
   // Warn when a provider route exists but has no URL and no header override —
   // the request will fall through to config defaults which likely have wrong
@@ -3608,7 +3624,10 @@ async function forwardToUpstream(
           system: [req.system, ...ltmParts].filter(Boolean).join("\n\n"),
         }
       : req;
-    const result = buildGeminiUpstreamRequest(reqWithLtm, effectiveUpstreamBase);
+    const result = buildGeminiUpstreamRequest(
+      reqWithLtm,
+      effectiveUpstreamBase,
+    );
     url = result.url;
     headers = result.headers;
     body = result.body;
@@ -5165,9 +5184,12 @@ function postResponse(
       | "gemini" =
       req.protocol === "openai-responses"
         ? "openai-responses"
-        : (lpRouteUsable?.protocol ??
-          resolveUpstreamRoute(req.model)?.protocol ??
-          req.protocol);
+        : req.protocol === "gemini"
+          ? // Mirror forwardToUpstream: native gemini ingress stays gemini.
+            (lpRouteUsable?.protocol ?? "gemini")
+          : (lpRouteUsable?.protocol ??
+            resolveUpstreamRoute(req.model)?.protocol ??
+            req.protocol);
     // Mirror forwardToUpstream exactly (same shared predicate).
     const lpBedrockMantle = isBedrockMantleDispatch(
       lpRouteUsable,

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -167,6 +167,15 @@ import {
 } from "./stream/openai-responses";
 import { translateAnthropicStreamToOpenAI } from "./stream/openai";
 import {
+  buildGeminiUpstreamRequest,
+  buildGeminiResponse,
+  parseGeminiResponseJSON,
+} from "./translate/gemini";
+import {
+  accumulateGeminiSSEStream,
+  translateAnthropicStreamToGemini,
+} from "./stream/gemini";
+import {
   createStreamAccumulator,
   createRecallAwareAccumulator,
   parseSSEStream,
@@ -2641,6 +2650,9 @@ function syntheticToolUseResponse(
     if (req.protocol === "openai-responses") {
       return translateAnthropicStreamToResponses(anthropicSSE);
     }
+    if (req.protocol === "gemini") {
+      return translateAnthropicStreamToGemini(anthropicSSE);
+    }
     return anthropicSSE;
   }
 
@@ -3585,6 +3597,21 @@ async function forwardToUpstream(
     url = vt.url;
     headers = vt.headers;
     body = vt.body;
+  } else if (effectiveProtocol === "gemini") {
+    // Google Gemini native generateContent. Inject LTM into the system prompt
+    // (Gemini maps `system` → `systemInstruction`), same as the OpenAI branches
+    // above — Anthropic-style separate system blocks don't apply here.
+    const ltmParts = [cache?.stableLtmSystem, cache?.ltmSystem].filter(Boolean);
+    const reqWithLtm = ltmParts.length
+      ? {
+          ...req,
+          system: [req.system, ...ltmParts].filter(Boolean).join("\n\n"),
+        }
+      : req;
+    const result = buildGeminiUpstreamRequest(reqWithLtm, effectiveUpstreamBase);
+    url = result.url;
+    headers = result.headers;
+    body = result.body;
   } else {
     // For non-native-Anthropic upstreams (MiniMax, Fireworks, etc.), downgrade
     // extended cache TTL ("1h") to standard 5-minute ephemeral — the "1h" TTL
@@ -4283,6 +4310,8 @@ async function accumulateNonStreamResponse(
       return accumulateOpenAINonStreamJSON(json);
     case "openai-responses":
       return accumulateResponsesNonStreamJSON(json);
+    case "gemini":
+      return parseGeminiResponseJSON(json);
     default:
       // Anthropic (incl. Bedrock via bedrock-mantle, which returns the native
       // Anthropic non-streaming JSON shape).
@@ -4612,6 +4641,8 @@ function nonStreamHttpResponse(
       scaledResp,
       clientStream ?? false,
     );
+  } else if (clientProtocol === "gemini") {
+    clientResp = buildGeminiResponse(scaledResp, clientStream ?? false);
   } else {
     // Anthropic or unspecified — default format
     const body = buildAnthropicNonStreamResponse(scaledResp);
@@ -5703,6 +5734,9 @@ async function handleCompaction(
     if (req.protocol === "openai-responses") {
       return translateAnthropicStreamToResponses(anthropicSSE);
     }
+    if (req.protocol === "gemini") {
+      return translateAnthropicStreamToGemini(anthropicSSE);
+    }
     return anthropicSSE;
   }
 
@@ -6116,6 +6150,9 @@ async function handlePassthrough(
       }
       if (req.protocol === "openai-responses") {
         return translateAnthropicStreamToResponses(anthropicSSE);
+      }
+      if (req.protocol === "gemini") {
+        return translateAnthropicStreamToGemini(anthropicSSE);
       }
     }
     // Other cross-protocol streaming combos: accumulate + re-emit
@@ -8087,6 +8124,13 @@ async function handleConversationTurn(
       return finalizeWithRecall(resp);
     }
 
+    if (effectiveProtocol === "gemini") {
+      // Gemini native streaming — accumulate the SSE frames, then re-emit via
+      // the recall-aware finalizer (same buffered pattern as the OpenAI paths).
+      const resp = await accumulateGeminiSSEStream(upstreamResponse);
+      return finalizeWithRecall(resp);
+    }
+
     // Anthropic streaming: forward events and accumulate in parallel.
     // Pass recall context so the accumulator can intercept recall tool_use.
     const hasRecallTool = modifiedReq.tools.some(
@@ -8112,6 +8156,9 @@ async function handleConversationTurn(
     }
     if (req.protocol === "openai-responses") {
       return translateAnthropicStreamToResponses(anthropicSSE);
+    }
+    if (req.protocol === "gemini") {
+      return translateAnthropicStreamToGemini(anthropicSSE);
     }
     return anthropicSSE;
   }
@@ -8736,6 +8783,9 @@ function slashResponse(
     }
     if (req.protocol === "openai-responses") {
       return translateAnthropicStreamToResponses(anthropicSSE);
+    }
+    if (req.protocol === "gemini") {
+      return translateAnthropicStreamToGemini(anthropicSSE);
     }
     return anthropicSSE;
   }

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -3342,7 +3342,12 @@ type UpstreamResult = {
   /** The serialized JSON body sent to the upstream provider. */
   serializedBody: string;
   /** The wire protocol used for the upstream request (may differ from ingress). */
-  effectiveProtocol: "anthropic" | "openai" | "openai-responses" | "vertex";
+  effectiveProtocol:
+    | "anthropic"
+    | "openai"
+    | "openai-responses"
+    | "vertex"
+    | "gemini";
 };
 
 /**
@@ -4258,7 +4263,8 @@ async function accumulateNonStreamResponse(
     | "anthropic"
     | "openai"
     | "openai-responses"
-    | "vertex" = "anthropic",
+    | "vertex"
+    | "gemini" = "anthropic",
 ): Promise<GatewayResponse> {
   // Some providers (e.g. DeepSeek) return SSE-formatted responses even when
   // stream: false was sent. Detect this via content-type and extract the JSON
@@ -5124,7 +5130,8 @@ function postResponse(
       | "anthropic"
       | "openai"
       | "openai-responses"
-      | "vertex" =
+      | "vertex"
+      | "gemini" =
       req.protocol === "openai-responses"
         ? "openai-responses"
         : (lpRouteUsable?.protocol ??

--- a/packages/gateway/src/recall.ts
+++ b/packages/gateway/src/recall.ts
@@ -437,7 +437,8 @@ export type RecallProtocol =
   | "anthropic"
   | "openai"
   | "openai-responses"
-  | "vertex";
+  | "vertex"
+  | "gemini";
 
 /**
  * Injected upstream dependencies for recall follow-up execution.

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -293,14 +293,18 @@ async function handleGeminiGenerateContent(
     return errorResponse(400, "invalid_request_error", "Invalid JSON body");
   }
 
+  const headers = headersToRecord(req.headers);
+  // Normalize `?key=` query-form auth (REST / google-generativeai clients) to
+  // the `x-goog-api-key` header — the upstream URL is rebuilt, so a query param
+  // would otherwise be dropped and the call would 401. Header form wins.
+  if (!headers["x-goog-api-key"] && !headers["X-Goog-Api-Key"]) {
+    const key = new URL(req.url).searchParams.get("key");
+    if (key) headers["x-goog-api-key"] = key;
+  }
+
   let gatewayReq: GatewayRequest;
   try {
-    gatewayReq = parseGeminiRequest(
-      body,
-      headersToRecord(req.headers),
-      model,
-      stream,
-    );
+    gatewayReq = parseGeminiRequest(body, headers, model, stream);
   } catch (e) {
     const msg = e instanceof Error ? e.message : "Failed to parse request";
     return errorResponse(400, "invalid_request_error", msg);

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -30,6 +30,7 @@ import {
 import type { GatewayRequest } from "./translate/types";
 import { parseAnthropicRequest } from "./translate/anthropic";
 import { parseOpenAIRequest } from "./translate/openai";
+import { parseGeminiRequest } from "./translate/gemini";
 import {
   parseOpenAICodexRequest,
   parseOpenAIResponsesRequest,
@@ -269,6 +270,53 @@ async function handleOpenAIChatCompletions(
   }
 }
 
+/**
+ * Matches a native Gemini `generateContent` endpoint path, capturing the model
+ * id and the verb. Version-prefix-agnostic (`/v1beta/models/...`,
+ * `/v1/models/...`, or bare `/models/...`) so both the Gemini CLI
+ * (`GOOGLE_GEMINI_BASE_URL` → `/v1beta/...`) and `@ai-sdk/google` (baseURL
+ * pinned to `${gateway}/v1` → `/v1/...`) are matched.
+ */
+const GEMINI_PATH_RE =
+  /\/models\/([^/:]+):(generateContent|streamGenerateContent)$/;
+
+async function handleGeminiGenerateContent(
+  req: Request,
+  config: GatewayConfig,
+  model: string,
+  stream: boolean,
+): Promise<Response> {
+  let body: unknown;
+  try {
+    body = JSON.parse(await decodeRequestBody(req));
+  } catch {
+    return errorResponse(400, "invalid_request_error", "Invalid JSON body");
+  }
+
+  let gatewayReq: GatewayRequest;
+  try {
+    gatewayReq = parseGeminiRequest(
+      body,
+      headersToRecord(req.headers),
+      model,
+      stream,
+    );
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "Failed to parse request";
+    return errorResponse(400, "invalid_request_error", msg);
+  }
+
+  try {
+    // Pipeline returns the response in the client's native Gemini wire format
+    // (generateContent JSON or streamGenerateContent SSE).
+    return withCors(await handleRequest(gatewayReq, config));
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "Pipeline error";
+    log.error(`pipeline error: ${msg}`);
+    return errorResponse(502, "api_error", `Gateway pipeline error: ${msg}`);
+  }
+}
+
 async function handleOpenAIResponses(
   req: Request,
   config: GatewayConfig,
@@ -432,6 +480,21 @@ export async function startServer(config: GatewayConfig): Promise<{
           pathname === "/chat/completions")
       ) {
         return await handleOpenAIChatCompletions(req, config);
+      }
+
+      // POST /v1beta/models/{model}:generateContent (or :streamGenerateContent)
+      // — native Google Gemini protocol. Version-prefix-agnostic (see
+      // GEMINI_PATH_RE) so the Gemini CLI and @ai-sdk/google both match.
+      if (method === "POST") {
+        const gm = pathname.match(GEMINI_PATH_RE);
+        if (gm) {
+          return await handleGeminiGenerateContent(
+            req,
+            config,
+            gm[1],
+            gm[2] === "streamGenerateContent",
+          );
+        }
       }
 
       // POST /v1/responses/compact — Codex compaction (Responses API)

--- a/packages/gateway/src/stream/gemini.ts
+++ b/packages/gateway/src/stream/gemini.ts
@@ -1,0 +1,159 @@
+/**
+ * Gemini streaming helpers.
+ *
+ * Two directions:
+ *   1. `accumulateGeminiSSEStream` — read an upstream Gemini
+ *      `:streamGenerateContent?alt=sse` response (a sequence of
+ *      `data: <partial GenerateContentResponse>\n\n` frames) and accumulate it
+ *      into a `GatewayResponse` for recall-aware post-processing + re-emission.
+ *   2. `translateAnthropicStreamToGemini` — convert the gateway's internal
+ *      Anthropic SSE stream into a Gemini SSE response for a Gemini client
+ *      talking to a non-Gemini (Anthropic) upstream. This buffers the full
+ *      response (via the shared Anthropic stream accumulator) and emits a single
+ *      aggregated Gemini SSE frame — matching how the OpenAI/Responses buffered
+ *      paths behave for recall-awareness (true token streaming is preserved only
+ *      on the native Anthropic→Anthropic path).
+ */
+import type {
+  GatewayContentBlock,
+  GatewayResponse,
+  GatewayUsage,
+} from "../translate/types";
+import { ZERO_USAGE } from "../translate/types";
+import { buildGeminiResponseBody } from "../translate/gemini";
+import { parseSSEStream, createStreamAccumulator } from "./anthropic";
+
+type GeminiPart = Record<string, unknown>;
+
+function mapGeminiFinishReason(reason: unknown, hasToolCall: boolean): string {
+  if (hasToolCall) return "tool_use";
+  switch (String(reason ?? "")) {
+    case "MAX_TOKENS":
+      return "max_tokens";
+    default:
+      return "end_turn";
+  }
+}
+
+/**
+ * Accumulate an upstream Gemini SSE (`?alt=sse`) response into a
+ * `GatewayResponse`. Text parts arrive as deltas across frames and are
+ * concatenated; `functionCall` parts arrive complete; `usageMetadata` and
+ * `finishReason` appear on the final frame(s).
+ */
+export async function accumulateGeminiSSEStream(
+  upstreamResponse: Response,
+): Promise<GatewayResponse> {
+  if (!upstreamResponse.body) {
+    throw new Error("Upstream response has no body");
+  }
+
+  let textContent = "";
+  const toolUses: Array<{ name: string; input: unknown }> = [];
+  let finishReason: unknown;
+  let model = "";
+  let responseId = "";
+  let usage: GatewayUsage = { ...ZERO_USAGE };
+
+  const reader = upstreamResponse.body.getReader();
+  for await (const { data } of parseSSEStream(reader)) {
+    if (!data || data === "[DONE]") continue;
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(data) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+
+    if (typeof parsed.modelVersion === "string") model = parsed.modelVersion;
+    if (typeof parsed.responseId === "string") responseId = parsed.responseId;
+
+    const candidates = Array.isArray(parsed.candidates)
+      ? parsed.candidates
+      : [];
+    const first = (candidates[0] ?? {}) as Record<string, unknown>;
+    const content = (first.content ?? {}) as Record<string, unknown>;
+    const parts = Array.isArray(content.parts)
+      ? (content.parts as GeminiPart[])
+      : [];
+    for (const p of parts) {
+      if (typeof p.text === "string") {
+        textContent += p.text;
+      } else if (p.functionCall && typeof p.functionCall === "object") {
+        const fc = p.functionCall as { name?: unknown; args?: unknown };
+        toolUses.push({ name: String(fc.name ?? ""), input: fc.args ?? {} });
+      }
+    }
+    if (first.finishReason != null) finishReason = first.finishReason;
+
+    const um = parsed.usageMetadata as Record<string, unknown> | undefined;
+    if (um) {
+      usage = {
+        inputTokens:
+          typeof um.promptTokenCount === "number" ? um.promptTokenCount : 0,
+        outputTokens:
+          typeof um.candidatesTokenCount === "number"
+            ? um.candidatesTokenCount
+            : 0,
+      };
+      if (typeof um.cachedContentTokenCount === "number") {
+        usage.cacheReadInputTokens = um.cachedContentTokenCount;
+      }
+    }
+  }
+
+  const blocks: GatewayContentBlock[] = [];
+  if (textContent) blocks.push({ type: "text", text: textContent });
+  for (const tu of toolUses) {
+    blocks.push({
+      type: "tool_use",
+      id: tu.name,
+      name: tu.name,
+      input: tu.input,
+    });
+  }
+
+  return {
+    id: responseId,
+    model,
+    content: blocks,
+    stopReason: mapGeminiFinishReason(finishReason, toolUses.length > 0),
+    usage,
+  };
+}
+
+/**
+ * Translate an internal Anthropic SSE stream into a Gemini SSE `Response`.
+ *
+ * Buffers via the shared Anthropic stream accumulator, then emits a single
+ * aggregated Gemini `data: <json>\n\n` frame. Used for a Gemini client whose
+ * request was routed to an Anthropic upstream.
+ */
+export function translateAnthropicStreamToGemini(
+  anthropicResponse: Response,
+): Response {
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const encoder = new TextEncoder();
+      const accumulator = createStreamAccumulator();
+      try {
+        if (anthropicResponse.body) {
+          const reader = anthropicResponse.body.getReader();
+          for await (const { event, data } of parseSSEStream(reader)) {
+            accumulator.processEvent(event, data);
+          }
+        }
+        const resp = accumulator.getResponse();
+        const body = buildGeminiResponseBody(resp);
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(body)}\n\n`));
+      } finally {
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}

--- a/packages/gateway/src/stream/gemini.ts
+++ b/packages/gateway/src/stream/gemini.ts
@@ -20,20 +20,14 @@ import type {
   GatewayUsage,
 } from "../translate/types";
 import { ZERO_USAGE } from "../translate/types";
-import { buildGeminiResponseBody } from "../translate/gemini";
+import {
+  buildGeminiResponseBody,
+  geminiUsageFromMetadata,
+  mapGeminiFinishReason,
+} from "../translate/gemini";
 import { parseSSEStream, createStreamAccumulator } from "./anthropic";
 
 type GeminiPart = Record<string, unknown>;
-
-function mapGeminiFinishReason(reason: unknown, hasToolCall: boolean): string {
-  if (hasToolCall) return "tool_use";
-  switch (String(reason ?? "")) {
-    case "MAX_TOKENS":
-      return "max_tokens";
-    default:
-      return "end_turn";
-  }
-}
 
 /**
  * Accumulate an upstream Gemini SSE (`?alt=sse`) response into a
@@ -49,6 +43,7 @@ export async function accumulateGeminiSSEStream(
   }
 
   let textContent = "";
+  let thinkingContent = "";
   const toolUses: Array<{ name: string; input: unknown }> = [];
   let finishReason: unknown;
   let model = "";
@@ -78,7 +73,10 @@ export async function accumulateGeminiSSEStream(
       : [];
     for (const p of parts) {
       if (typeof p.text === "string") {
-        textContent += p.text;
+        // Keep reasoning-summary parts (`thought: true`) out of the visible
+        // answer text — accumulate them into a separate thinking block.
+        if (p.thought === true) thinkingContent += p.text;
+        else textContent += p.text;
       } else if (p.functionCall && typeof p.functionCall === "object") {
         const fc = p.functionCall as { name?: unknown; args?: unknown };
         toolUses.push({ name: String(fc.name ?? ""), input: fc.args ?? {} });
@@ -86,23 +84,14 @@ export async function accumulateGeminiSSEStream(
     }
     if (first.finishReason != null) finishReason = first.finishReason;
 
+    // usageMetadata is cumulative across frames; last non-null wins.
     const um = parsed.usageMetadata as Record<string, unknown> | undefined;
-    if (um) {
-      usage = {
-        inputTokens:
-          typeof um.promptTokenCount === "number" ? um.promptTokenCount : 0,
-        outputTokens:
-          typeof um.candidatesTokenCount === "number"
-            ? um.candidatesTokenCount
-            : 0,
-      };
-      if (typeof um.cachedContentTokenCount === "number") {
-        usage.cacheReadInputTokens = um.cachedContentTokenCount;
-      }
-    }
+    if (um) usage = geminiUsageFromMetadata(um);
   }
 
   const blocks: GatewayContentBlock[] = [];
+  if (thinkingContent)
+    blocks.push({ type: "thinking", thinking: thinkingContent });
   if (textContent) blocks.push({ type: "text", text: textContent });
   for (const tu of toolUses) {
     blocks.push({

--- a/packages/gateway/src/translate/gemini.ts
+++ b/packages/gateway/src/translate/gemini.ts
@@ -1,0 +1,395 @@
+/**
+ * Google Gemini (native `generateContent`) ↔ Gateway translation layer.
+ *
+ * Converts between Google's native Generative Language API
+ * (`POST /v1beta/models/{model}:generateContent` /
+ * `:streamGenerateContent?alt=sse`) and the gateway's internal
+ * `GatewayRequest`/`GatewayResponse` types.
+ *
+ * This is a DISTINCT wire format from OpenAI/Anthropic (it is NOT the OpenAI
+ * compatibility layer at `/v1beta/openai/...`). Key differences:
+ *   - roles are `user` / `model` (not `assistant`);
+ *   - the system prompt lives in `systemInstruction` (a `{parts:[{text}]}`);
+ *   - tool calls are `functionCall` parts; tool results are `functionResponse`
+ *     parts. Gemini has NO per-call id — calls/results are paired by function
+ *     NAME, so we synthesize the internal tool-use id from the name;
+ *   - tools are `[{functionDeclarations:[{name,description,parameters}]}]`;
+ *   - generation params live under `generationConfig`;
+ *   - auth is an API key via the `x-goog-api-key` header (or `?key=` query).
+ */
+import type {
+  GatewayContentBlock,
+  GatewayMessage,
+  GatewayRequest,
+  GatewayResponse,
+  GatewayTool,
+  GatewayUsage,
+} from "./types";
+import { blocksToText, forwardClientHeaders, ZERO_USAGE } from "./types";
+
+/** Default Gemini API version segment used when building upstream URLs. */
+const GEMINI_API_VERSION = "v1beta";
+
+/** Default max output tokens when a request omits `generationConfig.maxOutputTokens`. */
+const DEFAULT_GEMINI_MAX_TOKENS = 8192;
+
+type GeminiPart = Record<string, unknown>;
+
+// ---------------------------------------------------------------------------
+// Gemini generateContent request → GatewayRequest
+// ---------------------------------------------------------------------------
+
+/** Extract the joined text of a Gemini `{parts:[{text}]}` container. */
+function partsText(container: unknown): string {
+  const parts = (container as { parts?: unknown } | undefined)?.parts;
+  if (!Array.isArray(parts)) return "";
+  return (parts as GeminiPart[])
+    .filter((p) => typeof p.text === "string")
+    .map((p) => String(p.text))
+    .join("");
+}
+
+/** Map a single Gemini content part to a gateway content block. */
+function partToBlock(part: GeminiPart): GatewayContentBlock | null {
+  if (typeof part.text === "string") {
+    return { type: "text", text: part.text };
+  }
+  if (part.functionCall && typeof part.functionCall === "object") {
+    const fc = part.functionCall as { name?: unknown; args?: unknown };
+    const name = String(fc.name ?? "");
+    // Gemini has no per-call id; pair by NAME (see file header).
+    return { type: "tool_use", id: name, name, input: fc.args ?? {} };
+  }
+  if (part.functionResponse && typeof part.functionResponse === "object") {
+    const fr = part.functionResponse as { name?: unknown; response?: unknown };
+    const name = String(fr.name ?? "");
+    return {
+      type: "tool_result",
+      toolUseId: name,
+      content: [{ type: "text", text: JSON.stringify(fr.response ?? {}) }],
+    };
+  }
+  // inlineData / fileData / executableCode / … — preserve verbatim.
+  return { type: "opaque", raw: part };
+}
+
+/**
+ * Parse a Gemini `generateContent` request body into a `GatewayRequest`.
+ *
+ * `model` and `stream` are supplied by the caller because Gemini carries them in
+ * the URL, not the body: the model is the path segment
+ * (`/v1beta/models/{model}:…`) and streaming is selected by the verb
+ * (`:streamGenerateContent` vs `:generateContent`).
+ */
+export function parseGeminiRequest(
+  body: unknown,
+  headers: Record<string, string>,
+  model: string,
+  stream: boolean,
+): GatewayRequest {
+  const raw = (body ?? {}) as Record<string, unknown>;
+
+  // System prompt: `systemInstruction` (camelCase) or `system_instruction`.
+  const system = partsText(raw.systemInstruction ?? raw.system_instruction);
+
+  const rawContents = Array.isArray(raw.contents) ? raw.contents : [];
+  const messages: GatewayMessage[] = [];
+  for (const c of rawContents as Array<Record<string, unknown>>) {
+    const geminiRole = String(c.role ?? "user");
+    // Gemini roles: "model" → assistant; "user"/"function" → user.
+    const role: "user" | "assistant" =
+      geminiRole === "model" ? "assistant" : "user";
+    const parts = Array.isArray(c.parts) ? (c.parts as GeminiPart[]) : [];
+    const blocks: GatewayContentBlock[] = [];
+    for (const p of parts) {
+      const block = partToBlock(p);
+      if (block) blocks.push(block);
+    }
+    messages.push({ role, content: blocks });
+  }
+
+  // Tools: `[{functionDeclarations:[{name,description,parameters}]}]`.
+  const tools: GatewayTool[] = [];
+  const rawTools = Array.isArray(raw.tools) ? raw.tools : [];
+  for (const t of rawTools as Array<Record<string, unknown>>) {
+    const decls = Array.isArray(t.functionDeclarations)
+      ? (t.functionDeclarations as Array<Record<string, unknown>>)
+      : [];
+    for (const d of decls) {
+      tools.push({
+        name: String(d.name ?? ""),
+        description: String(d.description ?? ""),
+        inputSchema: (d.parameters as Record<string, unknown>) ?? {},
+      });
+    }
+  }
+
+  const genConfig = (raw.generationConfig ?? {}) as Record<string, unknown>;
+  const maxTokens =
+    typeof genConfig.maxOutputTokens === "number"
+      ? genConfig.maxOutputTokens
+      : DEFAULT_GEMINI_MAX_TOKENS;
+
+  // Preserve generation params + any non-standard top-level fields the gateway
+  // doesn't model, so they round-trip to the upstream.
+  const metadata: Record<string, unknown> = {};
+  if (Object.keys(genConfig).length > 0) metadata.generationConfig = genConfig;
+  if (raw.safetySettings) metadata.safetySettings = raw.safetySettings;
+  if (raw.toolConfig) metadata.toolConfig = raw.toolConfig;
+  if (raw.cachedContent) metadata.cachedContent = raw.cachedContent;
+
+  return {
+    protocol: "gemini",
+    model,
+    system,
+    messages,
+    tools,
+    stream,
+    maxTokens,
+    metadata,
+    rawHeaders: { ...headers },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// GatewayRequest → Gemini generateContent upstream request
+// ---------------------------------------------------------------------------
+
+/** Build the Gemini `:generateContent` / `:streamGenerateContent` URL. */
+export function buildGeminiUpstreamUrl(
+  base: string,
+  model: string,
+  stream: boolean,
+): string {
+  const verb = stream ? "streamGenerateContent" : "generateContent";
+  const encodedModel = encodeURIComponent(model);
+  const url = `${base}/${GEMINI_API_VERSION}/models/${encodedModel}:${verb}`;
+  return stream ? `${url}?alt=sse` : url;
+}
+
+/** Convert a gateway content block to Gemini part(s). */
+function blockToGeminiParts(block: GatewayContentBlock): GeminiPart[] {
+  switch (block.type) {
+    case "text":
+      return block.text ? [{ text: block.text }] : [];
+    case "thinking":
+      // Gemini has no client-visible thinking wire field on input — project to
+      // text so the content is not silently dropped.
+      return block.thinking ? [{ text: block.thinking }] : [];
+    case "tool_use":
+      return [{ functionCall: { name: block.name, args: block.input ?? {} } }];
+    case "tool_result": {
+      const text = blocksToText(block.content);
+      let response: unknown;
+      try {
+        const parsed = JSON.parse(text);
+        response =
+          parsed && typeof parsed === "object" ? parsed : { output: text };
+      } catch {
+        response = { output: text };
+      }
+      return [{ functionResponse: { name: block.toolUseId, response } }];
+    }
+    case "opaque":
+      return [block.raw as GeminiPart];
+  }
+}
+
+/**
+ * Build the upstream Gemini request `{url, headers, body}` from a
+ * `GatewayRequest`. Injects the (LTM-augmented) system prompt as
+ * `systemInstruction`. Auth is the API key via `x-goog-api-key` (forwarded from
+ * the client; falls back to the `?key=` form the client used, both of which
+ * `forwardClientHeaders` preserves).
+ */
+export function buildGeminiUpstreamRequest(
+  req: GatewayRequest,
+  upstreamBase: string,
+): { url: string; headers: Record<string, string>; body: unknown } {
+  const headers: Record<string, string> = {
+    ...forwardClientHeaders(req.rawHeaders),
+    "content-type": "application/json",
+  };
+
+  const contents: Array<Record<string, unknown>> = [];
+  for (const msg of req.messages) {
+    const role = msg.role === "assistant" ? "model" : "user";
+    const parts: GeminiPart[] = [];
+    for (const block of msg.content) parts.push(...blockToGeminiParts(block));
+    if (parts.length > 0) contents.push({ role, parts });
+  }
+
+  const body: Record<string, unknown> = { contents };
+
+  if (req.system) {
+    body.systemInstruction = { parts: [{ text: req.system }] };
+  }
+
+  if (req.tools.length > 0) {
+    body.tools = [
+      {
+        functionDeclarations: req.tools.map((t) => ({
+          name: t.name,
+          description: t.description,
+          parameters: t.inputSchema,
+        })),
+      },
+    ];
+  }
+
+  // Reconstruct generationConfig: preserve the client's original config, and
+  // ensure maxOutputTokens reflects the gateway's normalized value.
+  const genConfig: Record<string, unknown> = {
+    ...((req.metadata.generationConfig as Record<string, unknown>) ?? {}),
+  };
+  if (req.maxTokens) genConfig.maxOutputTokens = req.maxTokens;
+  if (Object.keys(genConfig).length > 0) body.generationConfig = genConfig;
+
+  if (req.metadata.safetySettings)
+    body.safetySettings = req.metadata.safetySettings;
+  if (req.metadata.toolConfig) body.toolConfig = req.metadata.toolConfig;
+  if (req.metadata.cachedContent)
+    body.cachedContent = req.metadata.cachedContent;
+
+  return {
+    url: buildGeminiUpstreamUrl(upstreamBase, req.model, req.stream),
+    headers,
+    body,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Gemini response → GatewayResponse
+// ---------------------------------------------------------------------------
+
+/** Map a Gemini `finishReason` + tool presence to an internal stop reason. */
+function mapGeminiFinishReason(reason: unknown, hasToolCall: boolean): string {
+  if (hasToolCall) return "tool_use";
+  switch (String(reason ?? "")) {
+    case "MAX_TOKENS":
+      return "max_tokens";
+    case "STOP":
+    case "":
+      return "end_turn";
+    default:
+      return "end_turn";
+  }
+}
+
+/** Parse Gemini `usageMetadata` into `GatewayUsage`. */
+function parseGeminiUsage(json: Record<string, unknown>): GatewayUsage {
+  const um = json.usageMetadata as Record<string, unknown> | undefined;
+  if (!um) return { ...ZERO_USAGE };
+  const usage: GatewayUsage = {
+    inputTokens:
+      typeof um.promptTokenCount === "number" ? um.promptTokenCount : 0,
+    outputTokens:
+      typeof um.candidatesTokenCount === "number" ? um.candidatesTokenCount : 0,
+  };
+  if (typeof um.cachedContentTokenCount === "number") {
+    usage.cacheReadInputTokens = um.cachedContentTokenCount;
+  }
+  return usage;
+}
+
+/**
+ * Parse a Gemini `generateContent` response JSON into a `GatewayResponse`.
+ * Mirrors `parseAnthropicResponseJSON`, over `candidates[0].content.parts[]`.
+ */
+export function parseGeminiResponseJSON(
+  json: Record<string, unknown>,
+): GatewayResponse {
+  const candidates = Array.isArray(json.candidates) ? json.candidates : [];
+  const first = (candidates[0] ?? {}) as Record<string, unknown>;
+  const content = (first.content ?? {}) as Record<string, unknown>;
+  const parts = Array.isArray(content.parts)
+    ? (content.parts as GeminiPart[])
+    : [];
+
+  const blocks: GatewayContentBlock[] = [];
+  let hasToolCall = false;
+  for (const p of parts) {
+    const block = partToBlock(p);
+    if (!block) continue;
+    if (block.type === "tool_use") hasToolCall = true;
+    blocks.push(block);
+  }
+
+  return {
+    id: String(json.responseId ?? ""),
+    model: String(json.modelVersion ?? ""),
+    content: blocks,
+    stopReason: mapGeminiFinishReason(first.finishReason, hasToolCall),
+    usage: parseGeminiUsage(json),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// GatewayResponse → Gemini client response
+// ---------------------------------------------------------------------------
+
+/** Map an internal stop reason back to a Gemini `finishReason`. */
+function toGeminiFinishReason(stopReason: string): string {
+  switch (stopReason) {
+    case "max_tokens":
+    case "length":
+      return "MAX_TOKENS";
+    default:
+      // end_turn, tool_use, stop — Gemini reports STOP even for tool calls.
+      return "STOP";
+  }
+}
+
+/** Build the Gemini non-streaming JSON body from a `GatewayResponse`. */
+export function buildGeminiResponseBody(
+  resp: GatewayResponse,
+): Record<string, unknown> {
+  const usage = resp.usage ?? ZERO_USAGE;
+  const parts: GeminiPart[] = [];
+  for (const block of resp.content) parts.push(...blockToGeminiParts(block));
+
+  const usageMetadata: Record<string, unknown> = {
+    promptTokenCount: usage.inputTokens,
+    candidatesTokenCount: usage.outputTokens,
+    totalTokenCount: usage.inputTokens + usage.outputTokens,
+  };
+  if (usage.cacheReadInputTokens != null) {
+    usageMetadata.cachedContentTokenCount = usage.cacheReadInputTokens;
+  }
+
+  return {
+    candidates: [
+      {
+        content: { role: "model", parts },
+        finishReason: toGeminiFinishReason(resp.stopReason),
+        index: 0,
+      },
+    ],
+    usageMetadata,
+    ...(resp.model ? { modelVersion: resp.model } : {}),
+  };
+}
+
+/**
+ * Build a client-facing Gemini `Response`. For `stream`, emits a single
+ * aggregated SSE chunk (`data: <json>\n\n`) matching `?alt=sse`; otherwise a
+ * plain JSON body. Used when the gateway accumulated internally and must
+ * re-emit in the Gemini wire format.
+ */
+export function buildGeminiResponse(
+  resp: GatewayResponse,
+  stream: boolean,
+): Response {
+  const bodyJson = buildGeminiResponseBody(resp);
+  if (stream) {
+    const sse = `data: ${JSON.stringify(bodyJson)}\n\n`;
+    return new Response(sse, {
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+    });
+  }
+  return new Response(JSON.stringify(bodyJson), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/packages/gateway/src/translate/gemini.ts
+++ b/packages/gateway/src/translate/gemini.ts
@@ -15,7 +15,9 @@
  *     NAME, so we synthesize the internal tool-use id from the name;
  *   - tools are `[{functionDeclarations:[{name,description,parameters}]}]`;
  *   - generation params live under `generationConfig`;
- *   - auth is an API key via the `x-goog-api-key` header (or `?key=` query).
+ *   - auth is an API key via the `x-goog-api-key` header. Clients that use the
+ *     `?key=` query form instead have it normalized to that header at ingress
+ *     (see `handleGeminiGenerateContent`), since the upstream URL is rebuilt.
  */
 import type {
   GatewayContentBlock,
@@ -52,6 +54,13 @@ function partsText(container: unknown): string {
 /** Map a single Gemini content part to a gateway content block. */
 function partToBlock(part: GeminiPart): GatewayContentBlock | null {
   if (typeof part.text === "string") {
+    // A `thought: true` part is the model's private reasoning summary
+    // (thinkingConfig.includeThoughts). It must NOT be concatenated with the
+    // visible answer — map it to a distinct thinking block so egress can keep
+    // the `thought` flag and clients can tell reasoning from answer.
+    if (part.thought === true) {
+      return { type: "thinking", thinking: part.text };
+    }
     return { type: "text", text: part.text };
   }
   if (part.functionCall && typeof part.functionCall === "object") {
@@ -173,9 +182,10 @@ function blockToGeminiParts(block: GatewayContentBlock): GeminiPart[] {
     case "text":
       return block.text ? [{ text: block.text }] : [];
     case "thinking":
-      // Gemini has no client-visible thinking wire field on input — project to
-      // text so the content is not silently dropped.
-      return block.thinking ? [{ text: block.thinking }] : [];
+      // Re-emit as a Gemini thought part (`text` + `thought: true`) so a
+      // reasoning summary round-trips as reasoning — never merged into the
+      // visible answer text.
+      return block.thinking ? [{ text: block.thinking, thought: true }] : [];
     case "tool_use":
       return [{ functionCall: { name: block.name, args: block.input ?? {} } }];
     case "tool_result": {
@@ -198,9 +208,10 @@ function blockToGeminiParts(block: GatewayContentBlock): GeminiPart[] {
 /**
  * Build the upstream Gemini request `{url, headers, body}` from a
  * `GatewayRequest`. Injects the (LTM-augmented) system prompt as
- * `systemInstruction`. Auth is the API key via `x-goog-api-key` (forwarded from
- * the client; falls back to the `?key=` form the client used, both of which
- * `forwardClientHeaders` preserves).
+ * `systemInstruction`. Auth is the API key via the `x-goog-api-key` header
+ * (forwarded from the client by `forwardClientHeaders`; a client `?key=` query
+ * param is normalized to this header at ingress). The upstream URL is rebuilt
+ * from scratch, so query-string auth is NOT preserved on the URL itself.
  */
 export function buildGeminiUpstreamRequest(
   req: GatewayRequest,
@@ -262,34 +273,64 @@ export function buildGeminiUpstreamRequest(
 // Gemini response → GatewayResponse
 // ---------------------------------------------------------------------------
 
-/** Map a Gemini `finishReason` + tool presence to an internal stop reason. */
-function mapGeminiFinishReason(reason: unknown, hasToolCall: boolean): string {
+/**
+ * Map a Gemini `finishReason` + tool presence to an internal stop reason.
+ *
+ * Abnormal reasons (SAFETY, RECITATION, BLOCKLIST, PROHIBITED_CONTENT, SPII,
+ * MALFORMED_FUNCTION_CALL, OTHER, …) are preserved VERBATIM so a proxied client
+ * still sees the real block/filter signal instead of a laundered "STOP".
+ * `toGeminiFinishReason` echoes any such preserved value back on egress. Only
+ * the truly-normal reasons are normalized to the internal model. A block reason
+ * takes precedence over `hasToolCall` (a filtered turn is not a tool turn).
+ */
+export function mapGeminiFinishReason(
+  reason: unknown,
+  hasToolCall: boolean,
+): string {
+  const r = String(reason ?? "");
+  const isNormal =
+    r === "" ||
+    r === "STOP" ||
+    r === "MAX_TOKENS" ||
+    r === "FINISH_REASON_UNSPECIFIED";
+  if (!isNormal) return r; // preserve verbatim
   if (hasToolCall) return "tool_use";
-  switch (String(reason ?? "")) {
-    case "MAX_TOKENS":
-      return "max_tokens";
-    case "STOP":
-    case "":
-      return "end_turn";
-    default:
-      return "end_turn";
-  }
+  if (r === "MAX_TOKENS") return "max_tokens";
+  return "end_turn";
 }
 
-/** Parse Gemini `usageMetadata` into `GatewayUsage`. */
-function parseGeminiUsage(json: Record<string, unknown>): GatewayUsage {
-  const um = json.usageMetadata as Record<string, unknown> | undefined;
+/**
+ * Convert a Gemini `usageMetadata` object into `GatewayUsage`. Shared by the
+ * non-streaming parser and the SSE accumulator (single source of truth — avoids
+ * drift). Gemini bills thinking separately in `thoughtsTokenCount`; fold it into
+ * outputTokens (the internal model is Anthropic-shaped, where output_tokens
+ * INCLUDES thinking). Omitting it undercounts output for the gateway's
+ * cost-aware routing and understates the client's total.
+ */
+export function geminiUsageFromMetadata(
+  um: Record<string, unknown> | undefined,
+): GatewayUsage {
   if (!um) return { ...ZERO_USAGE };
+  const candidates =
+    typeof um.candidatesTokenCount === "number" ? um.candidatesTokenCount : 0;
+  const thoughts =
+    typeof um.thoughtsTokenCount === "number" ? um.thoughtsTokenCount : 0;
   const usage: GatewayUsage = {
     inputTokens:
       typeof um.promptTokenCount === "number" ? um.promptTokenCount : 0,
-    outputTokens:
-      typeof um.candidatesTokenCount === "number" ? um.candidatesTokenCount : 0,
+    outputTokens: candidates + thoughts,
   };
   if (typeof um.cachedContentTokenCount === "number") {
     usage.cacheReadInputTokens = um.cachedContentTokenCount;
   }
   return usage;
+}
+
+/** Parse Gemini `usageMetadata` into `GatewayUsage`. */
+function parseGeminiUsage(json: Record<string, unknown>): GatewayUsage {
+  return geminiUsageFromMetadata(
+    json.usageMetadata as Record<string, unknown> | undefined,
+  );
 }
 
 /**
@@ -300,6 +341,9 @@ export function parseGeminiResponseJSON(
   json: Record<string, unknown>,
 ): GatewayResponse {
   const candidates = Array.isArray(json.candidates) ? json.candidates : [];
+  // LIMITATION: the internal model holds a single response, so when a client
+  // requests `candidateCount > 1` only candidates[0] is surfaced. Multi-candidate
+  // fan-out is a documented follow-up, not currently supported.
   const first = (candidates[0] ?? {}) as Record<string, unknown>;
   const content = (first.content ?? {}) as Record<string, unknown>;
   const parts = Array.isArray(content.parts)
@@ -315,11 +359,22 @@ export function parseGeminiResponseJSON(
     blocks.push(block);
   }
 
+  // Prompt-level block: Gemini returns NO candidates plus
+  // `promptFeedback.blockReason`. Surface that reason as the stop reason instead
+  // of laundering it into a fake `end_turn`/STOP, so the client sees the block.
+  const promptFeedback = json.promptFeedback as
+    | { blockReason?: unknown }
+    | undefined;
+  const stopReason =
+    candidates.length === 0 && promptFeedback?.blockReason
+      ? String(promptFeedback.blockReason)
+      : mapGeminiFinishReason(first.finishReason, hasToolCall);
+
   return {
     id: String(json.responseId ?? ""),
     model: String(json.modelVersion ?? ""),
     content: blocks,
-    stopReason: mapGeminiFinishReason(first.finishReason, hasToolCall),
+    stopReason,
     usage: parseGeminiUsage(json),
   };
 }
@@ -334,9 +389,15 @@ function toGeminiFinishReason(stopReason: string): string {
     case "max_tokens":
     case "length":
       return "MAX_TOKENS";
-    default:
-      // end_turn, tool_use, stop — Gemini reports STOP even for tool calls.
+    case "end_turn":
+    case "tool_use":
+    case "stop":
+    case "":
+      // Gemini reports STOP even for tool calls.
       return "STOP";
+    default:
+      // A preserved Gemini block reason (SAFETY, RECITATION, …) — echo verbatim.
+      return stopReason;
   }
 }
 

--- a/packages/gateway/src/translate/types.ts
+++ b/packages/gateway/src/translate/types.ts
@@ -162,7 +162,8 @@ export type GatewayProtocol =
   | "anthropic"
   | "openai"
   | "openai-responses"
-  | "vertex";
+  | "vertex"
+  | "gemini";
 
 /** Normalized request after ingress translation from either protocol. */
 export type GatewayRequest = {
@@ -408,7 +409,7 @@ export interface UpstreamSnapshot {
   /** Resolved upstream base URL (e.g., "https://api.minimax.io/anthropic"). */
   url: string;
   /** Wire protocol used for the request. */
-  protocol: "anthropic" | "openai" | "openai-responses" | "vertex";
+  protocol: "anthropic" | "openai" | "openai-responses" | "vertex" | "gemini";
   /** Provider ID from X-Lore-Provider header (for worker model selection). */
   providerID?: string;
   /** Session model ID (for cost-aware worker model downgrade). */

--- a/packages/gateway/src/worker-model.ts
+++ b/packages/gateway/src/worker-model.ts
@@ -787,17 +787,14 @@ const WORKER_DEFAULTS: Record<
     family: "gpt-codex",
     alreadyCheap: (id) => id.includes("mini") || id.includes("spark"),
   },
-  // Google Gemini: flash matches pro quality on distillation at far lower cost.
-  // family "gemini-flash" tracks the newest flash/lite tier from models.dev; the
-  // modelID is the OFFLINE fallback. Applies when the session tags
-  // X-Lore-Provider: google (opencode/pi); a bare native Gemini CLI session (no
-  // provider header) falls back to the session model, which is still correct.
-  google: {
-    providerID: "google",
-    modelID: "gemini-2.5-flash",
-    family: "gemini-flash",
-    alreadyCheap: (id) => id.includes("flash") || id.includes("lite"),
-  },
+  // NOTE: `google` is intentionally NOT listed here. A gemini session's worker
+  // PROTOCOL is resolved to "gemini" from the session snapshot
+  // (resolveWorkerProtocol), and its MODEL is resolved cost-aware by the generic
+  // findCheaperSameProviderModel path (which auto-picks the cheapest gemini
+  // family from models.dev — better than a hardcoded family pin). Adding a
+  // WORKER_DEFAULTS.google entry would override that with a fixed family and is
+  // unnecessary for correctness.
+  //
   // GitHub Copilot proxies multiple providers — match by model ID prefix.
   // No `family`: Copilot's family resolution is handled by
   // resolveGitHubCopilotWorker (model IDs use different formatting, e.g.

--- a/packages/gateway/src/worker-model.ts
+++ b/packages/gateway/src/worker-model.ts
@@ -787,6 +787,17 @@ const WORKER_DEFAULTS: Record<
     family: "gpt-codex",
     alreadyCheap: (id) => id.includes("mini") || id.includes("spark"),
   },
+  // Google Gemini: flash matches pro quality on distillation at far lower cost.
+  // family "gemini-flash" tracks the newest flash/lite tier from models.dev; the
+  // modelID is the OFFLINE fallback. Applies when the session tags
+  // X-Lore-Provider: google (opencode/pi); a bare native Gemini CLI session (no
+  // provider header) falls back to the session model, which is still correct.
+  google: {
+    providerID: "google",
+    modelID: "gemini-2.5-flash",
+    family: "gemini-flash",
+    alreadyCheap: (id) => id.includes("flash") || id.includes("lite"),
+  },
   // GitHub Copilot proxies multiple providers — match by model ID prefix.
   // No `family`: Copilot's family resolution is handled by
   // resolveGitHubCopilotWorker (model IDs use different formatting, e.g.

--- a/packages/gateway/test/agents.test.ts
+++ b/packages/gateway/test/agents.test.ts
@@ -275,3 +275,31 @@ describe("GitHub Copilot CLI agent envVars", () => {
     expect(env.COPILOT_PROVIDER_API_KEY).toBeUndefined();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Gemini CLI agent
+// ---------------------------------------------------------------------------
+
+describe("Gemini CLI agent envVars", () => {
+  const gemini = AGENTS.find((a) => a.name === "gemini");
+  if (!gemini) throw new Error("gemini agent not registered");
+
+  test("registered with the `gemini` binary", () => {
+    expect(gemini.binary).toBe("gemini");
+  });
+
+  test("sets GOOGLE_GEMINI_BASE_URL to the bare gateway origin (no /v1)", () => {
+    const env = gemini.envVars("http://127.0.0.1:3207", "/home/user/proj");
+    expect(env.GOOGLE_GEMINI_BASE_URL).toBe("http://127.0.0.1:3207");
+  });
+
+  test("GOOGLE_GEMINI_BASE_URL tracks the gateway URL", () => {
+    const env = gemini.envVars("http://127.0.0.1:5673", "/tmp/test");
+    expect(env.GOOGLE_GEMINI_BASE_URL).toBe("http://127.0.0.1:5673");
+  });
+
+  test("sets LORE_PROJECT to cwd", () => {
+    const env = gemini.envVars("http://127.0.0.1:3207", "/home/user/proj");
+    expect(env.LORE_PROJECT).toBe("/home/user/proj");
+  });
+});

--- a/packages/gateway/test/doctor.test.ts
+++ b/packages/gateway/test/doctor.test.ts
@@ -350,15 +350,16 @@ describe("formatFinding", () => {
 });
 
 describe("collectInventory (integration)", () => {
-  it("returns all-six-apps inventory with missing files on a clean HOME", () => {
+  it("returns all-seven-apps inventory with missing files on a clean HOME", () => {
     const all = collectInventory();
-    expect(all).toHaveLength(6);
+    expect(all).toHaveLength(7);
     expect(all.map((i) => i.app)).toEqual([
       "Claude Code",
       "Codex",
       "OpenCode",
       "Pi",
       "Hermes",
+      "Gemini",
       "Copilot",
     ]);
     for (const inv of all) {

--- a/packages/gateway/test/gemini-ingress.e2e.test.ts
+++ b/packages/gateway/test/gemini-ingress.e2e.test.ts
@@ -43,6 +43,7 @@ function geminiUpstreamResponse(): Response {
 async function sendGemini(
   harness: Harness,
   path: string,
+  extraHeaders: Record<string, string> = {},
 ): Promise<{
   upstreamUrl: string;
   upstreamBody: unknown;
@@ -63,6 +64,7 @@ async function sendGemini(
       "content-type": "application/json",
       "x-goog-api-key": "test-key",
       "x-lore-project": "/tmp/gemini-e2e",
+      ...extraHeaders,
     },
     body: JSON.stringify({
       contents: [{ role: "user", parts: [{ text: "hi" }] }],
@@ -137,5 +139,25 @@ describe("native Gemini ingress → generativelanguage upstream (full pipeline)"
       "/v1/models/gemini-2.5-pro:generateContent",
     );
     expect(upstreamUrl).toContain("generativelanguage.googleapis.com");
+  });
+
+  test("opencode/pi shape: X-Lore-Provider: google stays native gemini (not openai-compat)", async () => {
+    // The @ai-sdk/google provider is tagged x-lore-provider: google by the
+    // opencode/pi plugins. The google provider route is protocol "openai"
+    // (compat layer) — but a native generateContent ingress must NOT be
+    // downgraded to /v1beta/openai/chat/completions.
+    harness = await createHarness({ fixtures: [] });
+    const { upstreamUrl, upstreamBody } = await sendGemini(
+      harness,
+      "/v1/models/gemini-2.5-pro:generateContent",
+      { "x-lore-provider": "google" },
+    );
+    expect(upstreamUrl).toBe(
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent",
+    );
+    expect(upstreamUrl).not.toContain("/openai/");
+    const ub = JSON.parse(String(upstreamBody)) as Record<string, unknown>;
+    expect(ub.contents).toBeDefined();
+    expect(ub.messages).toBeUndefined();
   });
 });

--- a/packages/gateway/test/gemini-ingress.e2e.test.ts
+++ b/packages/gateway/test/gemini-ingress.e2e.test.ts
@@ -1,0 +1,141 @@
+/**
+ * End-to-end wiring guard for native Gemini support.
+ *
+ * Drives a real `POST /v1beta/models/{model}:generateContent` through the full
+ * gateway pipeline (handleRequest → forwardToUpstream) and captures the exact
+ * URL + body forwarded upstream, plus the client-facing response. Pins that:
+ *   - the native Gemini ingress is routed as the `gemini` protocol (not hijacked
+ *     to the OpenAI-compat layer by the `gemini-` model-prefix route);
+ *   - the upstream URL is the native generativelanguage `:generateContent` path;
+ *   - the upstream body is native Gemini (`contents`), and the client response
+ *     is native Gemini (`candidates`).
+ */
+import { describe, test, expect, afterEach, vi } from "vitest";
+
+vi.mock("../src/fetch", () => ({ upstreamFetch: vi.fn() }));
+
+import { upstreamFetch } from "../src/fetch";
+import type { Harness } from "./helpers/harness";
+import { createHarness } from "./helpers/harness";
+
+const mockFetch = vi.mocked(upstreamFetch);
+
+function geminiUpstreamResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      candidates: [
+        {
+          content: { role: "model", parts: [{ text: "ok" }] },
+          finishReason: "STOP",
+        },
+      ],
+      usageMetadata: {
+        promptTokenCount: 1,
+        candidatesTokenCount: 1,
+        totalTokenCount: 2,
+      },
+      modelVersion: "gemini-2.5-pro",
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+async function sendGemini(
+  harness: Harness,
+  path: string,
+): Promise<{
+  upstreamUrl: string;
+  upstreamBody: unknown;
+  clientJson: unknown;
+}> {
+  const { setUpstreamInterceptor } = await import("../src/pipeline");
+  setUpstreamInterceptor(async (body, _model, _stream, makeReal) => {
+    // capture the serialized upstream body via closure
+    (sendGemini as unknown as { _body?: unknown })._body = body;
+    return makeReal();
+  });
+  mockFetch.mockReset();
+  mockFetch.mockResolvedValue(geminiUpstreamResponse());
+
+  const res = await fetch(`${harness.baseURL}${path}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-goog-api-key": "test-key",
+      "x-lore-project": "/tmp/gemini-e2e",
+    },
+    body: JSON.stringify({
+      contents: [{ role: "user", parts: [{ text: "hi" }] }],
+    }),
+  });
+  const clientJson = await res.json().catch(() => undefined);
+
+  expect(mockFetch).toHaveBeenCalled();
+  const call = mockFetch.mock.calls[0];
+  return {
+    upstreamUrl: String(call[0]),
+    upstreamBody: (call[1] as { body?: unknown } | undefined)?.body,
+    clientJson,
+  };
+}
+
+describe("native Gemini ingress → generativelanguage upstream (full pipeline)", () => {
+  let harness: Harness | undefined;
+
+  afterEach(async () => {
+    await harness?.teardown();
+    harness = undefined;
+  });
+
+  test("routes generateContent to the native Gemini upstream URL", async () => {
+    harness = await createHarness({ fixtures: [] });
+    const { upstreamUrl } = await sendGemini(
+      harness,
+      "/v1beta/models/gemini-2.5-pro:generateContent",
+    );
+    expect(upstreamUrl).toBe(
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent",
+    );
+    // NOT the OpenAI-compat path.
+    expect(upstreamUrl).not.toContain("/openai/");
+    expect(upstreamUrl).not.toContain("chat/completions");
+  });
+
+  test("forwards a native Gemini body and returns a native Gemini response", async () => {
+    harness = await createHarness({ fixtures: [] });
+    const { upstreamBody, clientJson } = await sendGemini(
+      harness,
+      "/v1beta/models/gemini-2.5-pro:generateContent",
+    );
+    // Upstream body is native Gemini (contents), not OpenAI messages.
+    const ub = JSON.parse(String(upstreamBody)) as Record<string, unknown>;
+    expect(ub.contents).toBeDefined();
+    expect(ub.messages).toBeUndefined();
+    // Client response is native Gemini (candidates).
+    const cj = clientJson as Record<string, unknown>;
+    expect(cj.candidates).toBeDefined();
+    const candidates = cj.candidates as Array<Record<string, unknown>>;
+    const content = candidates[0].content as Record<string, unknown>;
+    expect(content.role).toBe("model");
+  });
+
+  test("stream verb routes to :streamGenerateContent", async () => {
+    harness = await createHarness({ fixtures: [] });
+    const { upstreamUrl } = await sendGemini(
+      harness,
+      "/v1beta/models/gemini-2.5-flash:streamGenerateContent",
+    );
+    expect(upstreamUrl).toContain(
+      "/v1beta/models/gemini-2.5-flash:streamGenerateContent",
+    );
+  });
+
+  test("version-prefix-agnostic: /v1/models/... (@ai-sdk/google shape) is matched", async () => {
+    harness = await createHarness({ fixtures: [] });
+    const { upstreamUrl } = await sendGemini(
+      harness,
+      "/v1/models/gemini-2.5-pro:generateContent",
+    );
+    expect(upstreamUrl).toContain("generativelanguage.googleapis.com");
+  });
+});

--- a/packages/gateway/test/gemini-ingress.e2e.test.ts
+++ b/packages/gateway/test/gemini-ingress.e2e.test.ts
@@ -47,6 +47,7 @@ async function sendGemini(
 ): Promise<{
   upstreamUrl: string;
   upstreamBody: unknown;
+  upstreamHeaders: Record<string, string> | undefined;
   clientJson: unknown;
 }> {
   const { setUpstreamInterceptor } = await import("../src/pipeline");
@@ -77,6 +78,9 @@ async function sendGemini(
   return {
     upstreamUrl: String(call[0]),
     upstreamBody: (call[1] as { body?: unknown } | undefined)?.body,
+    upstreamHeaders: (
+      call[1] as { headers?: Record<string, string> } | undefined
+    )?.headers,
     clientJson,
   };
 }
@@ -138,7 +142,41 @@ describe("native Gemini ingress → generativelanguage upstream (full pipeline)"
       harness,
       "/v1/models/gemini-2.5-pro:generateContent",
     );
-    expect(upstreamUrl).toContain("generativelanguage.googleapis.com");
+    // Full native path (not just the host — which the openai-compat URL shares).
+    expect(upstreamUrl).toBe(
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent",
+    );
+  });
+
+  test("?key= query auth is normalized to the x-goog-api-key upstream header", async () => {
+    harness = await createHarness({ fixtures: [] });
+    const { setUpstreamInterceptor } = await import("../src/pipeline");
+    setUpstreamInterceptor(async (_b, _m, _s, makeReal) => makeReal());
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue(geminiUpstreamResponse());
+
+    // REST/google-generativeai style: key in the query, NO x-goog-api-key header.
+    await fetch(
+      `${harness.baseURL}/v1beta/models/gemini-2.5-pro:generateContent?key=qkey123`,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-lore-project": "/tmp/gemini-e2e",
+        },
+        body: JSON.stringify({
+          contents: [{ role: "user", parts: [{ text: "hi" }] }],
+        }),
+      },
+    );
+
+    expect(mockFetch).toHaveBeenCalled();
+    const headers = (
+      mockFetch.mock.calls[0][1] as
+        | { headers?: Record<string, string> }
+        | undefined
+    )?.headers;
+    expect(headers?.["x-goog-api-key"]).toBe("qkey123");
   });
 
   test("opencode/pi shape: X-Lore-Provider: google stays native gemini (not openai-compat)", async () => {

--- a/packages/gateway/test/gemini-stream.test.ts
+++ b/packages/gateway/test/gemini-stream.test.ts
@@ -86,6 +86,63 @@ describe("accumulateGeminiSSEStream", () => {
     const resp = await accumulateGeminiSSEStream(res);
     expect(resp.usage?.cacheReadInputTokens).toBe(6);
   });
+
+  test("thought deltas stay out of visible text (separate thinking block)", async () => {
+    const res = sse([
+      {
+        candidates: [
+          {
+            content: {
+              role: "model",
+              parts: [{ text: "reasoning", thought: true }],
+            },
+          },
+        ],
+      },
+      {
+        candidates: [
+          { content: { role: "model", parts: [{ text: "answer" }] } },
+        ],
+      },
+      {
+        candidates: [
+          { content: { role: "model", parts: [] }, finishReason: "STOP" },
+        ],
+      },
+    ]);
+    const resp = await accumulateGeminiSSEStream(res);
+    expect(resp.content).toEqual([
+      { type: "thinking", thinking: "reasoning" },
+      { type: "text", text: "answer" },
+    ]);
+  });
+
+  test("thoughtsTokenCount folded into outputTokens", async () => {
+    const res = sse([
+      {
+        candidates: [
+          { content: { parts: [{ text: "x" }] }, finishReason: "STOP" },
+        ],
+        usageMetadata: {
+          promptTokenCount: 10,
+          candidatesTokenCount: 2,
+          thoughtsTokenCount: 40,
+        },
+      },
+    ]);
+    const resp = await accumulateGeminiSSEStream(res);
+    expect(resp.usage).toEqual({ inputTokens: 10, outputTokens: 42 });
+  });
+
+  test("SAFETY finishReason preserved verbatim", async () => {
+    const res = sse([
+      {
+        candidates: [{ content: { parts: [] }, finishReason: "SAFETY" }],
+      },
+    ]);
+    const resp = await accumulateGeminiSSEStream(res);
+    expect(resp.stopReason).toBe("SAFETY");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/test/gemini-stream.test.ts
+++ b/packages/gateway/test/gemini-stream.test.ts
@@ -1,0 +1,160 @@
+import { describe, test, expect } from "vitest";
+import {
+  accumulateGeminiSSEStream,
+  translateAnthropicStreamToGemini,
+} from "../src/stream/gemini";
+
+function sse(frames: unknown[]): Response {
+  const body = frames.map((f) => `data: ${JSON.stringify(f)}\n\n`).join("");
+  return new Response(body, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+/** Read the single aggregated `data:` JSON frame from a Gemini SSE Response. */
+async function readGeminiSSEFrame(
+  res: Response,
+): Promise<Record<string, unknown>> {
+  const text = await res.text();
+  const line = text.split("\n").find((l) => l.startsWith("data: "));
+  if (!line) throw new Error(`no data frame in: ${text}`);
+  return JSON.parse(line.slice(6)) as Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// accumulateGeminiSSEStream
+// ---------------------------------------------------------------------------
+
+describe("accumulateGeminiSSEStream", () => {
+  test("concatenates text deltas across frames + final usage/finishReason", async () => {
+    const res = sse([
+      {
+        candidates: [{ content: { role: "model", parts: [{ text: "Hel" }] } }],
+      },
+      { candidates: [{ content: { role: "model", parts: [{ text: "lo" }] } }] },
+      {
+        candidates: [
+          { content: { role: "model", parts: [] }, finishReason: "STOP" },
+        ],
+        usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 2 },
+        modelVersion: "gemini-2.5-pro",
+      },
+    ]);
+    const resp = await accumulateGeminiSSEStream(res);
+    expect(resp.content).toEqual([{ type: "text", text: "Hello" }]);
+    expect(resp.stopReason).toBe("end_turn");
+    expect(resp.model).toBe("gemini-2.5-pro");
+    expect(resp.usage).toEqual({ inputTokens: 5, outputTokens: 2 });
+  });
+
+  test("functionCall frame → tool_use block + stopReason tool_use", async () => {
+    const res = sse([
+      {
+        candidates: [
+          {
+            content: {
+              role: "model",
+              parts: [{ functionCall: { name: "f", args: { a: 1 } } }],
+            },
+            finishReason: "STOP",
+          },
+        ],
+        usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1 },
+      },
+    ]);
+    const resp = await accumulateGeminiSSEStream(res);
+    expect(resp.content).toEqual([
+      { type: "tool_use", id: "f", name: "f", input: { a: 1 } },
+    ]);
+    expect(resp.stopReason).toBe("tool_use");
+  });
+
+  test("cachedContentTokenCount → cacheReadInputTokens", async () => {
+    const res = sse([
+      {
+        candidates: [
+          { content: { parts: [{ text: "x" }] }, finishReason: "STOP" },
+        ],
+        usageMetadata: {
+          promptTokenCount: 10,
+          candidatesTokenCount: 1,
+          cachedContentTokenCount: 6,
+        },
+      },
+    ]);
+    const resp = await accumulateGeminiSSEStream(res);
+    expect(resp.usage?.cacheReadInputTokens).toBe(6);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// translateAnthropicStreamToGemini
+// ---------------------------------------------------------------------------
+
+describe("translateAnthropicStreamToGemini", () => {
+  function anthropicSSE(): Response {
+    const events = [
+      [
+        "message_start",
+        {
+          type: "message_start",
+          message: {
+            id: "msg_1",
+            model: "claude-x",
+            role: "assistant",
+            content: [],
+            usage: { input_tokens: 3, output_tokens: 0 },
+          },
+        },
+      ],
+      [
+        "content_block_start",
+        {
+          type: "content_block_start",
+          index: 0,
+          content_block: { type: "text", text: "" },
+        },
+      ],
+      [
+        "content_block_delta",
+        {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "text_delta", text: "Hi there" },
+        },
+      ],
+      ["content_block_stop", { type: "content_block_stop", index: 0 }],
+      [
+        "message_delta",
+        {
+          type: "message_delta",
+          delta: { stop_reason: "end_turn" },
+          usage: { output_tokens: 2 },
+        },
+      ],
+      ["message_stop", { type: "message_stop" }],
+    ] as const;
+    const body = events
+      .map(([e, d]) => `event: ${e}\ndata: ${JSON.stringify(d)}\n\n`)
+      .join("");
+    return new Response(body, {
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+    });
+  }
+
+  test("emits a Gemini SSE frame with the accumulated model-role content", async () => {
+    const res = translateAnthropicStreamToGemini(anthropicSSE());
+    expect(res.headers.get("content-type")).toBe("text/event-stream");
+    const frame = await readGeminiSSEFrame(res);
+    const candidates = frame.candidates as Array<Record<string, unknown>>;
+    const content = candidates[0].content as Record<string, unknown>;
+    expect(content.role).toBe("model");
+    expect(content.parts).toEqual([{ text: "Hi there" }]);
+    expect(candidates[0].finishReason).toBe("STOP");
+    const um = frame.usageMetadata as Record<string, number>;
+    expect(um.promptTokenCount).toBe(3);
+    expect(um.candidatesTokenCount).toBe(2);
+  });
+});

--- a/packages/gateway/test/gemini-translate.test.ts
+++ b/packages/gateway/test/gemini-translate.test.ts
@@ -328,6 +328,102 @@ describe("parseGeminiResponseJSON", () => {
     });
     expect(resp.usage).toEqual({ inputTokens: 0, outputTokens: 0 });
   });
+
+  test("thought part → thinking block, NOT merged into visible text", () => {
+    const resp = parseGeminiResponseJSON({
+      candidates: [
+        {
+          content: {
+            role: "model",
+            parts: [
+              { text: "secret reasoning", thought: true },
+              { text: "visible answer" },
+            ],
+          },
+          finishReason: "STOP",
+        },
+      ],
+    });
+    expect(resp.content).toEqual([
+      { type: "thinking", thinking: "secret reasoning" },
+      { type: "text", text: "visible answer" },
+    ]);
+  });
+
+  test("thoughtsTokenCount is folded into outputTokens", () => {
+    const resp = parseGeminiResponseJSON({
+      candidates: [{ content: { parts: [{ text: "x" }] } }],
+      usageMetadata: {
+        promptTokenCount: 100,
+        candidatesTokenCount: 20,
+        thoughtsTokenCount: 500,
+      },
+    });
+    expect(resp.usage).toEqual({ inputTokens: 100, outputTokens: 520 });
+  });
+
+  test("SAFETY finishReason is preserved verbatim (not laundered to end_turn)", () => {
+    const resp = parseGeminiResponseJSON({
+      candidates: [{ content: { parts: [] }, finishReason: "SAFETY" }],
+    });
+    expect(resp.stopReason).toBe("SAFETY");
+  });
+
+  test("prompt-level block (no candidates) surfaces promptFeedback.blockReason", () => {
+    const resp = parseGeminiResponseJSON({
+      promptFeedback: { blockReason: "SAFETY" },
+      usageMetadata: { promptTokenCount: 8 },
+    });
+    expect(resp.content).toEqual([]);
+    expect(resp.stopReason).toBe("SAFETY");
+  });
+
+  test("multi-candidate: only candidates[0] is surfaced (documented limitation)", () => {
+    const resp = parseGeminiResponseJSON({
+      candidates: [
+        { content: { parts: [{ text: "cand0" }] }, finishReason: "STOP" },
+        { content: { parts: [{ text: "cand1" }] }, finishReason: "STOP" },
+      ],
+    });
+    expect(resp.content).toEqual([{ type: "text", text: "cand0" }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Egress: thinking + preserved finishReason round-trip
+// ---------------------------------------------------------------------------
+
+describe("buildGeminiResponseBody — thinking + block reason", () => {
+  test("thinking block re-emits as a thought part (thought:true), separate from text", () => {
+    const b = buildGeminiResponseBody({
+      id: "r",
+      model: "gemini-2.5-pro",
+      content: [
+        { type: "thinking", thinking: "reasoning" },
+        { type: "text", text: "answer" },
+      ],
+      stopReason: "end_turn",
+      usage: { inputTokens: 1, outputTokens: 1 },
+    });
+    const cand = (b.candidates as Array<Record<string, unknown>>)[0];
+    const parts = (cand.content as { parts: unknown[] }).parts;
+    expect(parts).toEqual([
+      { text: "reasoning", thought: true },
+      { text: "answer" },
+    ]);
+  });
+
+  test("preserved block reason echoes verbatim on egress finishReason", () => {
+    const b = buildGeminiResponseBody({
+      id: "r",
+      model: "m",
+      content: [],
+      stopReason: "SAFETY",
+      usage: { inputTokens: 1, outputTokens: 0 },
+    });
+    const cand = (b.candidates as Array<Record<string, unknown>>)[0];
+    expect(cand.finishReason).toBe("SAFETY");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/test/gemini-translate.test.ts
+++ b/packages/gateway/test/gemini-translate.test.ts
@@ -1,0 +1,413 @@
+import { describe, test, expect } from "vitest";
+import {
+  parseGeminiRequest,
+  buildGeminiUpstreamRequest,
+  buildGeminiUpstreamUrl,
+  parseGeminiResponseJSON,
+  buildGeminiResponseBody,
+  buildGeminiResponse,
+} from "../src/translate/gemini";
+import type { GatewayRequest, GatewayResponse } from "../src/translate/types";
+
+// ---------------------------------------------------------------------------
+// parseGeminiRequest (Gemini generateContent body → GatewayRequest)
+// ---------------------------------------------------------------------------
+
+describe("parseGeminiRequest", () => {
+  test("extracts systemInstruction, maps roles, and sets protocol/model/stream", () => {
+    const req = parseGeminiRequest(
+      {
+        systemInstruction: { parts: [{ text: "You are helpful." }] },
+        contents: [
+          { role: "user", parts: [{ text: "hi" }] },
+          { role: "model", parts: [{ text: "hello" }] },
+        ],
+        generationConfig: { maxOutputTokens: 1234, temperature: 0.5 },
+      },
+      { "x-goog-api-key": "k" },
+      "gemini-2.5-pro",
+      false,
+    );
+    expect(req.protocol).toBe("gemini");
+    expect(req.model).toBe("gemini-2.5-pro");
+    expect(req.stream).toBe(false);
+    expect(req.system).toBe("You are helpful.");
+    expect(req.maxTokens).toBe(1234);
+    expect(req.messages).toEqual([
+      { role: "user", content: [{ type: "text", text: "hi" }] },
+      { role: "assistant", content: [{ type: "text", text: "hello" }] },
+    ]);
+    // generationConfig preserved for round-trip.
+    expect(req.metadata.generationConfig).toEqual({
+      maxOutputTokens: 1234,
+      temperature: 0.5,
+    });
+  });
+
+  test("accepts snake_case system_instruction", () => {
+    const req = parseGeminiRequest(
+      { system_instruction: { parts: [{ text: "sys" }] }, contents: [] },
+      {},
+      "m",
+      false,
+    );
+    expect(req.system).toBe("sys");
+  });
+
+  test("maps functionCall → tool_use and functionResponse → tool_result (paired by name)", () => {
+    const req = parseGeminiRequest(
+      {
+        contents: [
+          {
+            role: "model",
+            parts: [
+              { functionCall: { name: "get_weather", args: { city: "SF" } } },
+            ],
+          },
+          {
+            role: "user",
+            parts: [
+              {
+                functionResponse: {
+                  name: "get_weather",
+                  response: { temp: 72 },
+                },
+              },
+            ],
+          },
+        ],
+      },
+      {},
+      "m",
+      false,
+    );
+    expect(req.messages[0].content[0]).toEqual({
+      type: "tool_use",
+      id: "get_weather",
+      name: "get_weather",
+      input: { city: "SF" },
+    });
+    const tr = req.messages[1].content[0];
+    expect(tr.type).toBe("tool_result");
+    if (tr.type === "tool_result") {
+      expect(tr.toolUseId).toBe("get_weather");
+      expect(tr.content).toEqual([
+        { type: "text", text: JSON.stringify({ temp: 72 }) },
+      ]);
+    }
+  });
+
+  test("parses functionDeclarations into tools", () => {
+    const req = parseGeminiRequest(
+      {
+        contents: [],
+        tools: [
+          {
+            functionDeclarations: [
+              {
+                name: "search",
+                description: "search the web",
+                parameters: {
+                  type: "object",
+                  properties: { q: { type: "string" } },
+                },
+              },
+            ],
+          },
+        ],
+      },
+      {},
+      "m",
+      false,
+    );
+    expect(req.tools).toEqual([
+      {
+        name: "search",
+        description: "search the web",
+        inputSchema: { type: "object", properties: { q: { type: "string" } } },
+      },
+    ]);
+  });
+
+  test("preserves unknown parts (inlineData) as opaque blocks", () => {
+    const req = parseGeminiRequest(
+      {
+        contents: [
+          {
+            role: "user",
+            parts: [{ inlineData: { mimeType: "image/png", data: "AAAA" } }],
+          },
+        ],
+      },
+      {},
+      "m",
+      false,
+    );
+    expect(req.messages[0].content[0]).toEqual({
+      type: "opaque",
+      raw: { inlineData: { mimeType: "image/png", data: "AAAA" } },
+    });
+  });
+
+  test("defaults maxTokens when generationConfig omits it", () => {
+    const req = parseGeminiRequest({ contents: [] }, {}, "m", false);
+    expect(req.maxTokens).toBe(8192);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildGeminiUpstreamUrl / buildGeminiUpstreamRequest
+// ---------------------------------------------------------------------------
+
+describe("buildGeminiUpstreamUrl", () => {
+  test("non-stream → :generateContent", () => {
+    expect(
+      buildGeminiUpstreamUrl(
+        "https://generativelanguage.googleapis.com",
+        "gemini-2.5-pro",
+        false,
+      ),
+    ).toBe(
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent",
+    );
+  });
+
+  test("stream → :streamGenerateContent?alt=sse", () => {
+    expect(
+      buildGeminiUpstreamUrl(
+        "https://generativelanguage.googleapis.com",
+        "gemini-2.5-flash",
+        true,
+      ),
+    ).toBe(
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse",
+    );
+  });
+});
+
+describe("buildGeminiUpstreamRequest", () => {
+  const base: GatewayRequest = {
+    protocol: "gemini",
+    model: "gemini-2.5-pro",
+    system: "sys prompt",
+    messages: [
+      { role: "user", content: [{ type: "text", text: "hi" }] },
+      {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "f", name: "f", input: { a: 1 } }],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            toolUseId: "f",
+            content: [{ type: "text", text: '{"ok":true}' }],
+          },
+        ],
+      },
+    ],
+    tools: [{ name: "f", description: "d", inputSchema: { type: "object" } }],
+    stream: false,
+    maxTokens: 555,
+    metadata: {},
+    rawHeaders: { "x-goog-api-key": "key123" },
+  };
+
+  test("builds systemInstruction, role-mapped contents, functionCall/response, tools, generationConfig", () => {
+    const { url, headers, body } = buildGeminiUpstreamRequest(
+      base,
+      "https://generativelanguage.googleapis.com",
+    );
+    expect(url).toBe(
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent",
+    );
+    // x-goog-api-key forwarded (not a managed header).
+    expect(headers["x-goog-api-key"]).toBe("key123");
+    const b = body as Record<string, unknown>;
+    expect(b.systemInstruction).toEqual({ parts: [{ text: "sys prompt" }] });
+    expect(b.contents).toEqual([
+      { role: "user", parts: [{ text: "hi" }] },
+      {
+        role: "model",
+        parts: [{ functionCall: { name: "f", args: { a: 1 } } }],
+      },
+      {
+        role: "user",
+        parts: [{ functionResponse: { name: "f", response: { ok: true } } }],
+      },
+    ]);
+    expect(b.tools).toEqual([
+      {
+        functionDeclarations: [
+          { name: "f", description: "d", parameters: { type: "object" } },
+        ],
+      },
+    ]);
+    expect(b.generationConfig).toEqual({ maxOutputTokens: 555 });
+  });
+
+  test("stream request builds the streaming URL", () => {
+    const { url } = buildGeminiUpstreamRequest(
+      { ...base, stream: true },
+      "https://generativelanguage.googleapis.com",
+    );
+    expect(url).toContain(":streamGenerateContent?alt=sse");
+  });
+
+  test("omits systemInstruction when there is no system prompt", () => {
+    const { body } = buildGeminiUpstreamRequest(
+      { ...base, system: "" },
+      "https://x",
+    );
+    expect((body as Record<string, unknown>).systemInstruction).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseGeminiResponseJSON
+// ---------------------------------------------------------------------------
+
+describe("parseGeminiResponseJSON", () => {
+  test("maps candidate text parts + usageMetadata", () => {
+    const resp = parseGeminiResponseJSON({
+      candidates: [
+        {
+          content: { role: "model", parts: [{ text: "answer" }] },
+          finishReason: "STOP",
+        },
+      ],
+      usageMetadata: {
+        promptTokenCount: 10,
+        candidatesTokenCount: 3,
+        cachedContentTokenCount: 4,
+        totalTokenCount: 13,
+      },
+      modelVersion: "gemini-2.5-pro",
+    });
+    expect(resp.content).toEqual([{ type: "text", text: "answer" }]);
+    expect(resp.stopReason).toBe("end_turn");
+    expect(resp.model).toBe("gemini-2.5-pro");
+    expect(resp.usage).toEqual({
+      inputTokens: 10,
+      outputTokens: 3,
+      cacheReadInputTokens: 4,
+    });
+  });
+
+  test("functionCall part → tool_use and stopReason tool_use", () => {
+    const resp = parseGeminiResponseJSON({
+      candidates: [
+        {
+          content: {
+            role: "model",
+            parts: [{ functionCall: { name: "f", args: { x: 1 } } }],
+          },
+          finishReason: "STOP",
+        },
+      ],
+    });
+    expect(resp.content).toEqual([
+      { type: "tool_use", id: "f", name: "f", input: { x: 1 } },
+    ]);
+    expect(resp.stopReason).toBe("tool_use");
+  });
+
+  test("MAX_TOKENS finishReason → max_tokens", () => {
+    const resp = parseGeminiResponseJSON({
+      candidates: [
+        { content: { parts: [{ text: "x" }] }, finishReason: "MAX_TOKENS" },
+      ],
+    });
+    expect(resp.stopReason).toBe("max_tokens");
+  });
+
+  test("missing usageMetadata → zero usage", () => {
+    const resp = parseGeminiResponseJSON({
+      candidates: [{ content: { parts: [{ text: "x" }] } }],
+    });
+    expect(resp.usage).toEqual({ inputTokens: 0, outputTokens: 0 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildGeminiResponseBody / buildGeminiResponse
+// ---------------------------------------------------------------------------
+
+describe("buildGeminiResponse", () => {
+  const resp: GatewayResponse = {
+    id: "r1",
+    model: "gemini-2.5-pro",
+    content: [
+      { type: "text", text: "hello" },
+      { type: "tool_use", id: "f", name: "f", input: { a: 1 } },
+    ],
+    stopReason: "tool_use",
+    usage: { inputTokens: 5, outputTokens: 2, cacheReadInputTokens: 1 },
+  };
+
+  test("body shape: candidates(model role) + parts + usageMetadata", () => {
+    const b = buildGeminiResponseBody(resp);
+    expect(b.candidates).toEqual([
+      {
+        content: {
+          role: "model",
+          parts: [
+            { text: "hello" },
+            { functionCall: { name: "f", args: { a: 1 } } },
+          ],
+        },
+        finishReason: "STOP",
+        index: 0,
+      },
+    ]);
+    expect(b.usageMetadata).toEqual({
+      promptTokenCount: 5,
+      candidatesTokenCount: 2,
+      totalTokenCount: 7,
+      cachedContentTokenCount: 1,
+    });
+    expect(b.modelVersion).toBe("gemini-2.5-pro");
+  });
+
+  test("non-stream → application/json; stream → SSE data frame", async () => {
+    const jsonRes = buildGeminiResponse(resp, false);
+    expect(jsonRes.headers.get("content-type")).toBe("application/json");
+    const sseRes = buildGeminiResponse(resp, true);
+    expect(sseRes.headers.get("content-type")).toBe("text/event-stream");
+    const text = await sseRes.text();
+    expect(text.startsWith("data: ")).toBe(true);
+    expect(text.endsWith("\n\n")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Round-trip structural equivalence (client request → internal → upstream body)
+// ---------------------------------------------------------------------------
+
+describe("Gemini round-trip", () => {
+  test("request → internal → upstream body preserves contents/tools/system", () => {
+    const clientBody = {
+      systemInstruction: { parts: [{ text: "sys" }] },
+      contents: [{ role: "user", parts: [{ text: "hi" }] }],
+      tools: [
+        {
+          functionDeclarations: [
+            { name: "f", description: "d", parameters: { type: "object" } },
+          ],
+        },
+      ],
+      generationConfig: { maxOutputTokens: 100, temperature: 0.2 },
+    };
+    const req = parseGeminiRequest(clientBody, {}, "gemini-2.5-pro", false);
+    const { body } = buildGeminiUpstreamRequest(req, "https://x");
+    const b = body as Record<string, unknown>;
+    expect(b.systemInstruction).toEqual(clientBody.systemInstruction);
+    expect(b.contents).toEqual(clientBody.contents);
+    expect(b.tools).toEqual(clientBody.tools);
+    expect(b.generationConfig).toEqual({
+      maxOutputTokens: 100,
+      temperature: 0.2,
+    });
+  });
+});

--- a/packages/gateway/test/llm-adapter.test.ts
+++ b/packages/gateway/test/llm-adapter.test.ts
@@ -270,6 +270,12 @@ describe("resolveWorkerProtocol", () => {
     );
   });
 
+  test("explicit 'gemini' stays 'gemini' (does NOT collapse to openai)", () => {
+    expect(resolveWorkerProtocol("google", "gemini")).toBe("gemini");
+    // Even against an unrelated provider id, the explicit hint wins.
+    expect(resolveWorkerProtocol("anthropic", "gemini")).toBe("gemini");
+  });
+
   // Priority 2: route table lookup
   test("anthropic provider resolves to 'anthropic' via route table", () => {
     expect(resolveWorkerProtocol("anthropic")).toBe("anthropic");

--- a/packages/gateway/test/setup-io.test.ts
+++ b/packages/gateway/test/setup-io.test.ts
@@ -312,3 +312,28 @@ describe("commandSetup — GitHub Copilot CLI", () => {
     expect(logged()).toContain("COPILOT_API_URL");
   });
 });
+
+describe("commandSetup — Gemini CLI", () => {
+  const geminiPath = () => join(home, ".gemini", ".env");
+
+  it("writes GOOGLE_GEMINI_BASE_URL to ~/.gemini/.env with a backup, then undoes", async () => {
+    mkdirSync(join(home, ".gemini"), { recursive: true });
+    writeFileSync(geminiPath(), "GEMINI_API_KEY=sk-abc\n");
+
+    await commandSetup(["gemini"], { port: 3299 });
+
+    const env = readFileSync(geminiPath(), "utf8");
+    // Bare origin (no /v1) — Gemini appends /v1beta/models/... itself.
+    expect(env).toContain("GOOGLE_GEMINI_BASE_URL=http://127.0.0.1:3299");
+    expect(env).not.toContain("http://127.0.0.1:3299/v1");
+    expect(env).toContain("GEMINI_API_KEY=sk-abc"); // preserved
+    expect(env).toContain("lore setup backup");
+
+    await commandSetup(["undo", "gemini"], {});
+
+    const restored = readFileSync(geminiPath(), "utf8");
+    expect(restored).not.toContain("GOOGLE_GEMINI_BASE_URL");
+    expect(restored).toContain("GEMINI_API_KEY=sk-abc");
+    expect(restored).not.toContain("lore setup backup");
+  });
+});

--- a/packages/gateway/test/setup.test.ts
+++ b/packages/gateway/test/setup.test.ts
@@ -9,6 +9,8 @@ import {
   piModelsConfigPath,
   updateHermesEnv,
   hermesEnvPath,
+  updateGeminiEnv,
+  geminiEnvPath,
   copilotApiUrlFromBaseUrl,
   opencodePluginSpec,
 } from "../src/cli/setup";
@@ -792,5 +794,35 @@ describe("copilotApiUrlFromBaseUrl", () => {
 
   test("does not strip a /v1 that is not a trailing segment", () => {
     expect(copilotApiUrlFromBaseUrl("http://host/v1x")).toBe("http://host/v1x");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateGeminiEnv / geminiEnvPath (Gemini CLI)
+// ---------------------------------------------------------------------------
+
+describe("updateGeminiEnv", () => {
+  test("sets GOOGLE_GEMINI_BASE_URL to the bare origin (strips /v1) + backup", () => {
+    const result = updateGeminiEnv(
+      "GEMINI_API_KEY=secret\n",
+      "http://127.0.0.1:3207/v1",
+    );
+    expect(result).toContain("GOOGLE_GEMINI_BASE_URL=http://127.0.0.1:3207");
+    // Preserves unrelated keys and records a backup block.
+    expect(result).toContain("GEMINI_API_KEY=secret");
+    expect(result).toContain("lore setup backup");
+  });
+
+  test("upserts in place on rerun (idempotent key)", () => {
+    const once = updateGeminiEnv("", "http://127.0.0.1:3299/v1");
+    const twice = updateGeminiEnv(once, "http://127.0.0.1:3299/v1");
+    const occurrences = twice.split("GOOGLE_GEMINI_BASE_URL=").length - 1;
+    expect(occurrences).toBe(1);
+  });
+});
+
+describe("geminiEnvPath", () => {
+  test("defaults to ~/.gemini/.env", () => {
+    expect(geminiEnvPath()).toBe(join(homedir(), ".gemini", ".env"));
   });
 });

--- a/packages/gateway/test/worker-gemini-path.test.ts
+++ b/packages/gateway/test/worker-gemini-path.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Background worker requests for a native Gemini session must target Google's
+ * native generateContent endpoint
+ * `https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent`,
+ * authenticate with `x-goog-api-key` (API key) or `Authorization: Bearer`
+ * (OAuth), and send a native Gemini body (`systemInstruction` + `contents`) —
+ * NOT the OpenAI-compat chat/completions shape.
+ *
+ * Guards the worker builder/parser (llm-adapter buildGeminiWorkerRequest /
+ * parseGeminiWorkerResponse), which were previously untested: a broken auth
+ * header, URL, or body shape would have silently disabled all distillation /
+ * curation for gemini sessions with zero test failure.
+ */
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("../src/fetch", () => ({ upstreamFetch: vi.fn() }));
+
+import { createGatewayLLMClient } from "../src/llm-adapter";
+import { upstreamFetch } from "../src/fetch";
+import { clearAllCosts } from "../src/cost-tracker";
+import { resetBackgroundLimiter } from "../src/background-limiter";
+import type { AuthCredential } from "../src/auth";
+
+const mockFetch = vi.mocked(upstreamFetch);
+
+const UPSTREAMS = {
+  anthropic: "https://api.anthropic.com",
+  openai: "https://api.openai.com",
+};
+
+function geminiOkResponse() {
+  return new Response(
+    JSON.stringify({
+      candidates: [
+        {
+          content: { role: "model", parts: [{ text: "worker ok" }] },
+          finishReason: "STOP",
+        },
+      ],
+      usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1 },
+      modelVersion: "gemini-2.5-flash",
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+async function runWorker(cred: AuthCredential | null) {
+  const client = createGatewayLLMClient(
+    UPSTREAMS,
+    (_sid, providerID) => (providerID === "google" ? cred : null),
+    { providerID: "google", modelID: "gemini-2.5-flash" },
+  );
+  const result = await client.prompt("system-prompt", "user-prompt", {
+    sessionID: "sess-gemini",
+    workerID: "lore-distill",
+    model: { providerID: "google", modelID: "gemini-2.5-flash" },
+    // Explicit protocol hint from the session snapshot (native gemini ingress).
+    protocol: "gemini",
+    upstreamProviderID: "google",
+  });
+  const call = mockFetch.mock.calls[0];
+  return {
+    result,
+    url: String(call?.[0]),
+    headers: (call?.[1] as { headers?: Record<string, string> } | undefined)
+      ?.headers,
+    body: JSON.parse(
+      String((call?.[1] as { body?: unknown } | undefined)?.body ?? "{}"),
+    ) as Record<string, unknown>,
+  };
+}
+
+describe("worker gemini native path", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue(geminiOkResponse());
+  });
+  afterEach(() => {
+    mockFetch.mockReset();
+    clearAllCosts();
+    resetBackgroundLimiter();
+  });
+
+  test("API-key cred → native :generateContent URL + x-goog-api-key + native body", async () => {
+    const { result, url, headers, body } = await runWorker({
+      scheme: "api-key",
+      value: "g_key",
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(url).toBe(
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent",
+    );
+    expect(url).not.toContain("/openai/");
+    expect(url).not.toContain("chat/completions");
+    // API-key auth via x-goog-api-key (not Authorization).
+    expect(headers?.["x-goog-api-key"]).toBe("g_key");
+    expect(headers?.Authorization).toBeUndefined();
+    // Native Gemini body shape.
+    expect(body.contents).toBeDefined();
+    expect(body.messages).toBeUndefined();
+    expect(body.systemInstruction).toEqual({
+      parts: [{ text: "system-prompt" }],
+    });
+    // Response parsed back from native gemini candidates.
+    expect(result).toContain("worker ok");
+  });
+
+  test("bearer (OAuth) cred → Authorization: Bearer, NOT x-goog-api-key", async () => {
+    const { headers } = await runWorker({
+      scheme: "bearer",
+      value: "oauth_tok",
+    });
+    expect(headers?.Authorization).toBe("Bearer oauth_tok");
+    expect(headers?.["x-goog-api-key"]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

Adds a **first-class native Gemini `generateContent` protocol** to the gateway and wires up the **Gemini CLI** (`@google/gemini-cli`) for `lore run` / `lore setup`. Unlike the pre-existing Gemini *OpenAI-compat* upstream, this speaks Gemini's real wire format end-to-end, so `@ai-sdk/google` clients (Gemini CLI **and** OpenCode's `google` provider) route through Lore with full memory support.

**PR 2 of 2** — stacked on #1157 (Copilot CLI). Base is `feat/copilot-cli-support`; will retarget to `main` once #1157 merges. (They both touch the shared CLI-registry files, so stacking avoids conflicts.)

## Why native (not the OpenAI-compat layer)

The Gemini CLI and `@ai-sdk/google` speak native `generateContent` (`user`/`model` roles, `systemInstruction`, `functionCall`/`functionResponse` parts, `generationConfig`, `usageMetadata`) — **no OpenAI-compat mode**. To do context injection + distillation, the gateway must understand that format.

## Phases (each a commit)

- **A — types**: `gemini` added to `GatewayProtocol` + every inline duplicate union (gateway + core `LLMClient.prompt`).
- **B — `translate/gemini.ts`**: parse/build request, parse/build response. Tool calls paired by function name (Gemini has no per-call id). 18 unit tests + round-trip.
- **C — `stream/gemini.ts`**: `accumulateGeminiSSEStream` (upstream SSE → internal) + `translateAnthropicStreamToGemini` (buffered, for cross-protocol gemini clients).
- **D — pipeline**: `forwardToUpstream` gemini branch (LTM → `systemInstruction`), `accumulateNonStreamResponse`/`nonStreamHttpResponse` cases, streaming dispatch across all sites.
- **E+G — ingress + routing**: server accepts `POST /v1beta/models/{model}:generateContent` + `:streamGenerateContent` (version-prefix-agnostic, so `@ai-sdk/google`'s `/v1/models/...` matches too). A native gemini ingress **always stays gemini** and defaults its base to `generativelanguage.googleapis.com`.
- **F — workers**: `resolveWorkerProtocol` maps gemini→gemini; `buildGeminiWorkerRequest`/`parseGeminiWorkerResponse`; `extractAuth` captures `x-goog-api-key`. (Worker model uses the generic cost-aware path — no `WORKER_DEFAULTS.google` pin.)
- **opencode/pi enablement**: `x-lore-provider: google` (native `@ai-sdk/google`) is no longer downgraded to the OpenAI-compat endpoint — e2e-covered. The existing `google` OpenAI-compat **worker** path is unchanged.
- **I — CLI**: `lore run gemini` sets `GOOGLE_GEMINI_BASE_URL` (bare origin; localhost HTTP allowed); `lore setup gemini` persists it to `~/.gemini/.env` (dotenv, like Hermes) with backup/undo; inventory + doctor fan-out (6→7).

## Tests (TDD)
`gemini-translate` (18), `gemini-stream` (4), `gemini-ingress.e2e` (5, incl. opencode-style `x-lore-provider: google`), worker-protocol, agents/setup/setup-io/doctor. **Full gateway suite (2621) + core suite (2519) green; typecheck + lint clean.**

## Scope notes
- Cache warming is a safe no-op for gemini (Anthropic-cache-specific; `resolveProfile` returns null).
- **Pi** `google` provider registration is deferred (Pi doesn't currently register `google`; its native-vs-baseURL semantics need Pi-side verification) — no regression. OpenCode is enabled.
- Vertex-Gemini (`GOOGLE_VERTEX_BASE_URL`) and Code-Assist OAuth modes are out of scope; the new translator is the shared core a future Vertex-Gemini mode can reuse.
- Not integration-tested against the real Gemini CLI (not available in CI); translators are unit-tested against Google's documented wire format.

---

## Update — adversarial pre-merge review addressed

Two independent review passes (verdict: SHIP-WITH-FOLLOWUPS, no BLOCKERs) surfaced fidelity/coverage gaps in the lossy Anthropic-shaped internal representation. All substantive ones are now fixed (commit "address adversarial review"), each guarded by a **mutation-verified non-vacuous** test:

- **Thinking leak** — `thought:true` reasoning parts no longer merge into the visible answer; mapped to a distinct thinking block on parse (non-stream + SSE) and re-emitted as `{text,thought:true}` on egress.
- **Usage** — `thoughtsTokenCount` folded into `outputTokens` (was undercounting output for cost-aware routing + understating the client total). A shared `geminiUsageFromMetadata` helper removes the duplicate stream copy (drift).
- **Safety transparency** — abnormal `finishReason`s (SAFETY/RECITATION/BLOCKLIST/PROHIBITED_CONTENT/SPII/MALFORMED_FUNCTION_CALL/OTHER) preserved verbatim through egress instead of laundered to STOP; the finish-reason mapper is now shared between the translator and the stream accumulator.
- **Prompt block** — a prompt-level block (no candidates) surfaces `promptFeedback.blockReason` as the stop reason instead of a fake `end_turn`.
- **Worker auth** — `buildGeminiWorkerRequest` is scheme-aware (bearer→`Authorization`, else `x-goog-api-key`), so an OAuth gemini session never misauths. **New `worker-gemini-path.test.ts`** closes the previously-untested worker builder (a broken `x-goog-api-key` header now fails a test — it silently passed the whole suite before).
- **`?key=` auth** — normalized to `x-goog-api-key` at ingress (was silently dropped when the upstream URL is rebuilt); the misleading comment is corrected.
- **Multi-candidate** — `candidateCount>1 → candidates[0]` limitation documented (single-response internal model); full fan-out is a follow-up.

**Full gateway suite: 2634 passed / 40 skipped** (+13 gemini tests). typecheck + lint clean. Mutation-tested each new guard in a disposable worktree — all go RED when the fix is reverted.

Deferred (documented, non-blocking): multi-candidate fan-out; full `promptFeedback` object passthrough; Pi `google` provider registration.
