### PR TITLE
feat(core): client-side encryption primitives (C-1, #825)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,7 +24,11 @@
     "build": "tsx script/build.ts"
   },
   "dependencies": {
+    "@hpke/core": "^1.9.0",
     "@huggingface/hub": "2.11.0",
+    "@noble/ciphers": "^2.2.0",
+    "@noble/curves": "^2.2.0",
+    "@noble/hashes": "^2.2.0",
     "micromark": "^4.0.0",
     "p-limit": "7",
     "remark": "^15.0.1",

--- a/packages/core/src/crypto/envelope.ts
+++ b/packages/core/src/crypto/envelope.ts
@@ -1,0 +1,173 @@
+/**
+ * Versioned encryption envelope for sync blob columns (A2/C, epic #821 decision #6).
+ *
+ * Every encrypted blob is self-describing: a fixed header names the AEAD scheme and
+ * the key epoch, so decryption dispatches on the stored `scheme_id` and MLS (RFC 9420)
+ * can later be added as an ADDITIVE scheme (scheme_id 2) — old ciphertext stays
+ * readable, NO re-encryption. The header's metadata is authenticated as additional
+ * data (AAD), so a scheme/epoch downgrade or a transplant across rows is detected as a
+ * tamper (tag mismatch), never silently accepted.
+ *
+ * We do NOT hand-roll crypto: scheme 1 is @noble/ciphers' audited XChaCha20-Poly1305
+ * (a 192-bit random nonce makes per-message random nonces collision-safe without a
+ * counter). See ./index.ts for the libsodium/HPKE→MLS rationale + threshold.
+ *
+ * Wire layout (scheme 1):
+ *   off size field
+ *   0   2    magic 0x4C 0x45 ("LE")
+ *   2   1    scheme_id
+ *   3   4    key_epoch (uint32 big-endian)
+ *   7   24   nonce (XChaCha20 24-byte nonce)
+ *   31  *    ciphertext || Poly1305 tag (16 bytes, appended by the AEAD)
+ * AEAD additional data = header[0..7) (magic|scheme_id|key_epoch) || callerAad.
+ */
+import { xchacha20poly1305 } from "@noble/ciphers/chacha.js";
+import { randomBytes } from "@noble/ciphers/utils.js";
+
+/** AEAD scheme identifiers. MLS/HPKE-rekeyed schemes are added here, additively. */
+export const SCHEME_XCHACHA20POLY1305 = 1 as const;
+
+const MAGIC0 = 0x4c; // 'L'
+const MAGIC1 = 0x45; // 'E'
+const META_LEN = 7; // magic(2) + scheme_id(1) + key_epoch(4)
+const NONCE_LEN = 24; // XChaCha20 nonce
+const HEADER_LEN = META_LEN + NONCE_LEN; // 31
+
+export interface EnvelopeHeader {
+  schemeId: number;
+  keyEpoch: number;
+  /** The AEAD nonce (scheme 1: 24 bytes). */
+  nonce: Uint8Array;
+  /** Ciphertext + tag (everything after the header). */
+  body: Uint8Array;
+  /** The authenticated metadata prefix (magic|scheme_id|key_epoch). */
+  meta: Uint8Array;
+}
+
+/**
+ * Concatenate the authenticated-metadata prefix with the caller's context AAD. An
+ * empty/absent callerAad carries no context, so it is treated as "no extra AAD".
+ */
+function aadFor(meta: Uint8Array, callerAad?: Uint8Array): Uint8Array {
+  if (!callerAad || callerAad.length === 0) return meta;
+  const out = new Uint8Array(meta.length + callerAad.length);
+  out.set(meta, 0);
+  out.set(callerAad, meta.length);
+  return out;
+}
+
+/**
+ * Build a context AAD from multiple parts UNAMBIGUOUSLY. Callers bind ciphertext to
+ * its row/column (e.g. `scope_id`, column name, `logical_id`); naive string concat is
+ * a footgun — `("ab","c")` and `("a","bc")` would collide. Each part is length-
+ * prefixed (4-byte big-endian) so distinct part boundaries always produce distinct
+ * AAD. ALWAYS build context AAD with this helper; never hand-concatenate.
+ */
+export function buildAad(...parts: Array<Uint8Array | string>): Uint8Array {
+  const te = new TextEncoder();
+  const bufs = parts.map((p) => (typeof p === "string" ? te.encode(p) : p));
+  const total = bufs.reduce((n, b) => n + 4 + b.length, 0);
+  const out = new Uint8Array(total);
+  let o = 0;
+  for (const b of bufs) {
+    out[o] = (b.length >>> 24) & 0xff;
+    out[o + 1] = (b.length >>> 16) & 0xff;
+    out[o + 2] = (b.length >>> 8) & 0xff;
+    out[o + 3] = b.length & 0xff;
+    o += 4;
+    out.set(b, o);
+    o += b.length;
+  }
+  return out;
+}
+
+/**
+ * Encrypt `plaintext` under `dek`, producing a versioned envelope. `aad` binds the
+ * ciphertext to its context (e.g. scope_id || column || logical_id) so it cannot be
+ * transplanted to another row/column. `keyEpoch` records which DEK version sealed it.
+ */
+export function seal(
+  dek: Uint8Array,
+  plaintext: Uint8Array,
+  aad?: Uint8Array,
+  opts: { keyEpoch?: number } = {},
+): Uint8Array {
+  const keyEpoch = opts.keyEpoch ?? 0;
+  if (dek.length !== 32) throw new Error("seal: DEK must be 32 bytes");
+  if (keyEpoch < 0 || keyEpoch > 0xffffffff || !Number.isInteger(keyEpoch)) {
+    throw new Error("seal: keyEpoch must be a uint32");
+  }
+  const nonce = randomBytes(NONCE_LEN);
+  const header = new Uint8Array(HEADER_LEN);
+  header[0] = MAGIC0;
+  header[1] = MAGIC1;
+  header[2] = SCHEME_XCHACHA20POLY1305;
+  // key_epoch, big-endian
+  header[3] = (keyEpoch >>> 24) & 0xff;
+  header[4] = (keyEpoch >>> 16) & 0xff;
+  header[5] = (keyEpoch >>> 8) & 0xff;
+  header[6] = keyEpoch & 0xff;
+  header.set(nonce, META_LEN);
+  const meta = header.subarray(0, META_LEN);
+  const ct = xchacha20poly1305(dek, nonce, aadFor(meta, aad)).encrypt(
+    plaintext,
+  );
+  const out = new Uint8Array(HEADER_LEN + ct.length);
+  out.set(header, 0);
+  out.set(ct, HEADER_LEN);
+  return out;
+}
+
+/** Parse (but do not decrypt) a versioned envelope's header. Throws on a bad frame. */
+export function parseHeader(envelope: Uint8Array): EnvelopeHeader {
+  if (envelope.length < HEADER_LEN) throw new Error("envelope: too short");
+  if (envelope[0] !== MAGIC0 || envelope[1] !== MAGIC1) {
+    throw new Error("envelope: bad magic");
+  }
+  const schemeId = envelope[2];
+  const keyEpoch =
+    ((envelope[3] << 24) |
+      (envelope[4] << 16) |
+      (envelope[5] << 8) |
+      envelope[6]) >>>
+    0;
+  return {
+    schemeId,
+    keyEpoch,
+    nonce: envelope.subarray(META_LEN, HEADER_LEN),
+    body: envelope.subarray(HEADER_LEN),
+    meta: envelope.subarray(0, META_LEN),
+  };
+}
+
+/**
+ * Decrypt a versioned envelope. Dispatches on the stored scheme_id. `aad` MUST match
+ * the value passed to `seal` (same context binding) or the AEAD tag check fails. A
+ * wrong DEK, a tampered header/body, or a mismatched AAD all throw.
+ */
+export function open(
+  dek: Uint8Array,
+  envelope: Uint8Array,
+  aad?: Uint8Array,
+): Uint8Array {
+  const h = parseHeader(envelope);
+  if (h.schemeId !== SCHEME_XCHACHA20POLY1305) {
+    throw new Error(`envelope: unsupported scheme_id ${h.schemeId}`);
+  }
+  if (dek.length !== 32) throw new Error("open: DEK must be 32 bytes");
+  return xchacha20poly1305(dek, h.nonce, aadFor(h.meta, aad)).decrypt(h.body);
+}
+
+/**
+ * True if `bytes` begins with a recognizable envelope frame (magic + known scheme).
+ * NOTE: the scheme check must be widened when a new scheme_id (e.g. MLS = 2) is added,
+ * or a valid future-scheme blob would be misreported as non-envelope.
+ */
+export function isEnvelope(bytes: Uint8Array): boolean {
+  return (
+    bytes.length >= HEADER_LEN &&
+    bytes[0] === MAGIC0 &&
+    bytes[1] === MAGIC1 &&
+    bytes[2] === SCHEME_XCHACHA20POLY1305
+  );
+}

--- a/packages/core/src/crypto/index.ts
+++ b/packages/core/src/crypto/index.ts
@@ -1,0 +1,62 @@
+/**
+ * Lore client-side encryption primitives (epic #821 "C", issue #825).
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * WHY libsodium/HPKE NOW, MLS LATER (epic decision #6 — 🔴 documented here at the seam)
+ * ─────────────────────────────────────────────────────────────────────────────
+ * Goal: Supabase stores CIPHERTEXT only for sensitive blobs (near-zero-knowledge).
+ * We do NOT need server-side search on those blobs — which is exactly what makes
+ * client-side encryption viable here.
+ *
+ * Scheme (v1): a per-scope symmetric **DEK** (XChaCha20-Poly1305) encrypts blob
+ * columns; the DEK is WRAPPED per member to their X25519 identity key with **HPKE**
+ * (RFC 9180). Every blob carries a **versioned envelope** (`scheme_id` + `key_epoch`),
+ * so a future scheme is ADDITIVE: old ciphertext keeps decrypting under its recorded
+ * scheme, with NO bulk re-encryption.
+ *
+ * We deliberately do NOT use Signal's Double Ratchet / Sender Keys: those buy FORWARD
+ * SECRECY for real-time chat, which actively FIGHTS a backup/sync product whose whole
+ * job is to let a freshly-paired device read OLD data. HPKE's KEM/DEM wrapping matches
+ * "wrap this durable key to these members" exactly.
+ *
+ * Threshold to add **MLS (RFC 9420)** as scheme_id 2 (additive, behind the same
+ * wrap interface): org-scale groups, high membership churn, or a requirement for
+ * forward secrecy / post-compromise security (PCS). Until then HPKE per-member
+ * wrapping is simpler and sufficient. Key-agreement is isolated behind
+ * `wrapDekForMember` / `unwrapDek` so that swap needs no change at call sites.
+ *
+ * 🔴 NEVER hand-roll crypto. Scheme 1 = @noble/ciphers (audited XChaCha20-Poly1305);
+ * DEK wrap = @hpke/core (RFC 9180); escrow KEK = @noble/hashes Argon2id. See also the
+ * architecture doc `docs/` (encryption section) which mirrors this rationale.
+ *
+ * Invariants (🔴): the server never sees plaintext of encrypted blobs; only blob
+ * columns are encrypted (ids/timestamps/scope_id/author_id/content_hash/cursors stay
+ * cleartext for sync mechanics); encrypted blobs are immutable ciphertext (new A2
+ * version = new blob, never re-encrypt in place).
+ *
+ * This module is PURE (no DB, no network). The keystore that persists identity keys +
+ * per-scope DEKs and drives escrow/unlock lives in C-2 (crypto/keystore.ts).
+ */
+export {
+  buildAad,
+  type EnvelopeHeader,
+  isEnvelope,
+  open,
+  parseHeader,
+  SCHEME_XCHACHA20POLY1305,
+  seal,
+} from "./envelope";
+export {
+  DEFAULT_KDF_PARAMS,
+  deriveKek,
+  generateDek,
+  generateIdentityKeypair,
+  generateKdfSalt,
+  identityPublicKey,
+  type KdfParams,
+  type Keypair,
+  unwrapDek,
+  unwrapWithKek,
+  wrapDekForMember,
+  wrapWithKek,
+} from "./keys";

--- a/packages/core/src/crypto/keys.ts
+++ b/packages/core/src/crypto/keys.ts
@@ -1,0 +1,201 @@
+/**
+ * Key material for the encryption seam (C, epic #821 decisions #6/#7).
+ *
+ * Layered model (v1 = personal; group wrapping is E):
+ *   - Per-account **identity keypair** (X25519). Its private key is the crown jewel;
+ *     at rest it is protected by the key-management model (escrow or client-only).
+ *   - Per-scope **DEK** (32 random bytes) encrypts blob columns via ./envelope.
+ *   - The DEK is WRAPPED to a recipient's identity public key with HPKE (RFC 9180,
+ *     DHKEM-X25519-HKDF-SHA256 + HKDF-SHA256 + AES-256-GCM) — a standard, vetted KEM/DEM,
+ *     never a hand-rolled sealed box. v1 wraps only to the user's own identity key.
+ *   - **Escrow:** the identity private key is wrapped by an Argon2id(passphrase) KEK
+ *     (XChaCha20-Poly1305 via ./envelope) and stored server-side, so any device with
+ *     the passphrase recovers it. A recovery code is a second, independent wrapping.
+ *
+ * Key-agreement lives behind this interface (wrapDekForMember / unwrapDek), so MLS can
+ * later replace HPKE additively. See ./index.ts for the full rationale + threshold.
+ */
+import { x25519 } from "@noble/curves/ed25519.js";
+import { randomBytes } from "@noble/ciphers/utils.js";
+import { argon2id } from "@noble/hashes/argon2.js";
+import {
+  Aes256Gcm,
+  CipherSuite,
+  DhkemX25519HkdfSha256,
+  HkdfSha256,
+} from "@hpke/core";
+import { open as envOpen, seal as envSeal } from "./envelope";
+
+export interface Keypair {
+  /** X25519 secret (private) key, 32 bytes. */
+  secretKey: Uint8Array;
+  /** X25519 public key, 32 bytes. */
+  publicKey: Uint8Array;
+}
+
+/** HPKE wrap-scheme identifiers (self-describing wrapped-DEK header). */
+const WRAP_HPKE_X25519 = 1 as const;
+/** DHKEM-X25519 encapsulated-key length (the ephemeral public key). */
+const HPKE_ENC_LEN = 32;
+/**
+ * HPKE `info` — domain-separates Lore's DEK wrapping from any other HPKE use of the
+ * same identity key, and binds the wrap to this scheme version. (Per-scope/epoch
+ * binding via `info` is a group-wrapping concern deferred to epic E; personal v1 is
+ * additionally protected because a mis-targeted DEK simply fails the blob open.)
+ */
+const HPKE_INFO_BYTES = new TextEncoder().encode("lore-dek-wrap-v1");
+function hpkeInfo(): ArrayBuffer {
+  const out = new ArrayBuffer(HPKE_INFO_BYTES.length);
+  new Uint8Array(out).set(HPKE_INFO_BYTES);
+  return out;
+}
+
+/** Argon2id parameters. Stored alongside the escrow blob so they can be reproduced. */
+export interface KdfParams {
+  /** Iterations (time cost). */
+  t: number;
+  /** Memory cost in KiB. */
+  m: number;
+  /** Parallelism. */
+  p: number;
+}
+
+/**
+ * OWASP-aligned defaults: 64 MiB memory, 3 passes, parallelism 1. `p=1` because the
+ * pure-JS Argon2id runs single-threaded — a higher lane count buys no defensive
+ * parallelism here, it only multiplies the legitimate user's unlock latency. Memory
+ * hardness (64 MiB) is the primary attacker cost. Tune to a target unlock latency on
+ * min-spec hardware if needed.
+ */
+export const DEFAULT_KDF_PARAMS: KdfParams = { t: 3, m: 65536, p: 1 };
+const KEK_LEN = 32;
+const SALT_LEN = 16;
+const DEK_LEN = 32;
+
+function hpkeSuite(): CipherSuite {
+  return new CipherSuite({
+    kem: new DhkemX25519HkdfSha256(),
+    kdf: new HkdfSha256(),
+    aead: new Aes256Gcm(),
+  });
+}
+
+/** A fresh, exact-length ArrayBuffer copy (the @hpke/core APIs take ArrayBuffer). */
+function ab(b: Uint8Array): ArrayBuffer {
+  const out = new ArrayBuffer(b.length);
+  new Uint8Array(out).set(b);
+  return out;
+}
+
+/** Generate a new X25519 identity keypair. */
+export function generateIdentityKeypair(): Keypair {
+  const secretKey = x25519.utils.randomSecretKey();
+  return { secretKey, publicKey: x25519.getPublicKey(secretKey) };
+}
+
+/** The X25519 public key for a given secret key. */
+export function identityPublicKey(secretKey: Uint8Array): Uint8Array {
+  if (secretKey.length !== 32)
+    throw new Error("identity secret key must be 32 bytes");
+  return x25519.getPublicKey(secretKey);
+}
+
+/** A fresh 32-byte data-encryption key (DEK). */
+export function generateDek(): Uint8Array {
+  return randomBytes(DEK_LEN);
+}
+
+/**
+ * Wrap `dek` to a recipient's identity public key with HPKE. Returns a self-describing
+ * blob: `[wrap_scheme(1)][enc(32)][hpke_ct]`. Only the holder of the matching identity
+ * secret key can unwrap it. Async: HPKE contexts use WebCrypto.
+ */
+export async function wrapDekForMember(
+  recipientPublicKey: Uint8Array,
+  dek: Uint8Array,
+): Promise<Uint8Array> {
+  if (recipientPublicKey.length !== 32)
+    throw new Error("recipient pubkey must be 32 bytes");
+  if (dek.length !== DEK_LEN) throw new Error("DEK must be 32 bytes");
+  const suite = hpkeSuite();
+  const rpk = await suite.kem.importKey("raw", ab(recipientPublicKey), true);
+  const sender = await suite.createSenderContext({
+    recipientPublicKey: rpk,
+    info: hpkeInfo(),
+  });
+  const ct = new Uint8Array(await sender.seal(ab(dek)));
+  const enc = new Uint8Array(sender.enc);
+  const out = new Uint8Array(1 + enc.length + ct.length);
+  out[0] = WRAP_HPKE_X25519;
+  out.set(enc, 1);
+  out.set(ct, 1 + enc.length);
+  return out;
+}
+
+/**
+ * Unwrap a DEK wrapped by {@link wrapDekForMember} using the recipient's identity
+ * secret key. Throws on an unknown wrap scheme, a wrong key, or a tampered blob.
+ */
+export async function unwrapDek(
+  recipientSecretKey: Uint8Array,
+  wrapped: Uint8Array,
+): Promise<Uint8Array> {
+  if (recipientSecretKey.length !== 32)
+    throw new Error("recipient secret key must be 32 bytes");
+  if (wrapped.length < 1 + HPKE_ENC_LEN)
+    throw new Error("wrapped DEK: too short");
+  if (wrapped[0] !== WRAP_HPKE_X25519) {
+    throw new Error(`wrapped DEK: unsupported wrap scheme ${wrapped[0]}`);
+  }
+  const enc = ab(wrapped.subarray(1, 1 + HPKE_ENC_LEN));
+  const ct = ab(wrapped.subarray(1 + HPKE_ENC_LEN));
+  const suite = hpkeSuite();
+  const rsk = await suite.kem.importKey("raw", ab(recipientSecretKey), false);
+  const recipient = await suite.createRecipientContext({
+    recipientKey: rsk,
+    enc,
+    info: hpkeInfo(),
+  });
+  return new Uint8Array(await recipient.open(ct));
+}
+
+/** A fresh random Argon2id salt. */
+export function generateKdfSalt(): Uint8Array {
+  return randomBytes(SALT_LEN);
+}
+
+/** Derive a 32-byte key-encryption key (KEK) from a passphrase via Argon2id. */
+export function deriveKek(
+  passphrase: string,
+  salt: Uint8Array,
+  params: KdfParams = DEFAULT_KDF_PARAMS,
+): Uint8Array {
+  const pw = new TextEncoder().encode(passphrase);
+  return argon2id(pw, salt, {
+    t: params.t,
+    m: params.m,
+    p: params.p,
+    dkLen: KEK_LEN,
+  });
+}
+
+const ESCROW_AAD = new TextEncoder().encode("lore-escrow-v1");
+
+/**
+ * Wrap a secret (e.g. the identity private key) under a passphrase-derived KEK, for
+ * server-side escrow. Reuses the audited XChaCha20-Poly1305 envelope; the escrow AAD
+ * domain-separates it from blob-column ciphertext.
+ */
+export function wrapWithKek(kek: Uint8Array, secret: Uint8Array): Uint8Array {
+  if (kek.length !== KEK_LEN) throw new Error("KEK must be 32 bytes");
+  return envSeal(kek, secret, ESCROW_AAD);
+}
+
+/** Unwrap a secret wrapped by {@link wrapWithKek}. Throws on a wrong KEK or tamper. */
+export function unwrapWithKek(
+  kek: Uint8Array,
+  wrapped: Uint8Array,
+): Uint8Array {
+  if (kek.length !== KEK_LEN) throw new Error("KEK must be 32 bytes");
+  return envOpen(kek, wrapped, ESCROW_AAD);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,10 @@
 
 export * as temporal from "./temporal";
 export * as ltm from "./ltm";
+// Client-side encryption primitives (C, #825). Namespaced `crypto` — consumers that
+// also need the WebCrypto/Node global should import that from `node:crypto` to avoid
+// shadowing this named import.
+export * as crypto from "./crypto";
 export * as references from "./references";
 export {
   DirectFsResolver,

--- a/packages/core/test/crypto.test.ts
+++ b/packages/core/test/crypto.test.ts
@@ -1,0 +1,310 @@
+import { describe, expect, it } from "vitest";
+import { crypto as lc } from "../src/index";
+
+const enc = (s: string) => new TextEncoder().encode(s);
+const dec = (b: Uint8Array) => new TextDecoder().decode(b);
+// Light Argon2id params for tests: correctness (determinism / round-trip) is
+// independent of the work factor, so keep CI fast. Production uses DEFAULT_KDF_PARAMS.
+const FAST = { t: 1, m: 256, p: 1 };
+
+describe("crypto/envelope — versioned AEAD", () => {
+  it("round-trips plaintext under a DEK with context AAD", () => {
+    const dek = lc.generateDek();
+    const aad = enc("scope|content|logical-1");
+    const blob = lc.seal(dek, enc("secret note"), aad);
+    expect(dec(lc.open(dek, blob, aad))).toBe("secret note");
+  });
+
+  it("is self-describing: header carries scheme_id + key_epoch", () => {
+    const dek = lc.generateDek();
+    const blob = lc.seal(dek, enc("x"), undefined, { keyEpoch: 7 });
+    const h = lc.parseHeader(blob);
+    expect(h.schemeId).toBe(lc.SCHEME_XCHACHA20POLY1305);
+    expect(h.keyEpoch).toBe(7);
+    expect(h.nonce.length).toBe(24);
+    expect(lc.isEnvelope(blob)).toBe(true);
+  });
+
+  it("round-trips a large uint32 key_epoch", () => {
+    const dek = lc.generateDek();
+    const blob = lc.seal(dek, enc("x"), undefined, { keyEpoch: 0xfffffffe });
+    expect(lc.parseHeader(blob).keyEpoch).toBe(0xfffffffe);
+    expect(dec(lc.open(dek, blob))).toBe("x");
+  });
+
+  it("fails to open under a wrong DEK", () => {
+    const blob = lc.seal(lc.generateDek(), enc("hi"));
+    expect(() => lc.open(lc.generateDek(), blob)).toThrow();
+  });
+
+  it("fails when the AAD does not match (context binding)", () => {
+    const dek = lc.generateDek();
+    const blob = lc.seal(dek, enc("hi"), enc("scope-A|content|l1"));
+    expect(() => lc.open(dek, blob, enc("scope-B|content|l1"))).toThrow();
+    // omitting the AAD entirely must also fail
+    expect(() => lc.open(dek, blob)).toThrow();
+  });
+
+  it("detects tampering in the body and in the authenticated header metadata", () => {
+    const dek = lc.generateDek();
+    const aad = enc("ctx");
+    const blob = lc.seal(dek, enc("payload"), aad);
+    // flip a ciphertext byte
+    const body = Uint8Array.from(blob);
+    body[body.length - 1] ^= 0xff;
+    expect(() => lc.open(dek, body, aad)).toThrow();
+    // flip the key_epoch (byte 3..6) — authenticated as AAD → tag mismatch
+    const meta = Uint8Array.from(blob);
+    meta[3] ^= 0x01;
+    expect(() => lc.open(dek, meta, aad)).toThrow();
+  });
+
+  it("rejects a frame with bad magic or an unsupported scheme", () => {
+    const dek = lc.generateDek();
+    const blob = lc.seal(dek, enc("x"));
+    const badMagic = Uint8Array.from(blob);
+    badMagic[0] ^= 0xff;
+    expect(() => lc.parseHeader(badMagic)).toThrow(/magic/);
+    const badScheme = Uint8Array.from(blob);
+    badScheme[2] = 99;
+    expect(() => lc.open(dek, badScheme)).toThrow(/scheme/);
+    expect(lc.isEnvelope(badScheme)).toBe(false);
+  });
+
+  it("rejects a non-32-byte DEK and a non-uint32 epoch", () => {
+    expect(() => lc.seal(new Uint8Array(16), enc("x"))).toThrow();
+    expect(() =>
+      lc.seal(lc.generateDek(), enc("x"), undefined, { keyEpoch: -1 }),
+    ).toThrow();
+  });
+
+  it("uses a fresh random nonce per seal (no nonce reuse across a batch)", () => {
+    const dek = lc.generateDek();
+    const seen = new Set<string>();
+    for (let i = 0; i < 200; i++) {
+      const n = Buffer.from(
+        lc.parseHeader(lc.seal(dek, enc("same"))).nonce,
+      ).toString("hex");
+      expect(seen.has(n)).toBe(false);
+      seen.add(n);
+    }
+  });
+
+  it("round-trips empty plaintext", () => {
+    const dek = lc.generateDek();
+    const aad = enc("ctx");
+    const blob = lc.seal(dek, new Uint8Array(0), aad);
+    expect(lc.open(dek, blob, aad).length).toBe(0);
+  });
+
+  it("round-trips the sign-bit key_epoch boundary (0x80000000, 0xffffffff)", () => {
+    const dek = lc.generateDek();
+    for (const epoch of [0x80000000, 0xffffffff]) {
+      const blob = lc.seal(dek, enc("x"), undefined, { keyEpoch: epoch });
+      expect(lc.parseHeader(blob).keyEpoch).toBe(epoch);
+      expect(dec(lc.open(dek, blob))).toBe("x");
+    }
+  });
+});
+
+describe("crypto/buildAad — unambiguous context binding", () => {
+  it("produces distinct AAD for distinct part boundaries (no concat collision)", () => {
+    const ab1 = lc.buildAad("ab", "c");
+    const ab2 = lc.buildAad("a", "bc");
+    expect(Buffer.from(ab1).equals(Buffer.from(ab2))).toBe(false);
+    // and a blob sealed with one boundary cannot be opened with the other
+    const dek = lc.generateDek();
+    const blob = lc.seal(dek, enc("secret"), ab1);
+    expect(() => lc.open(dek, blob, ab2)).toThrow();
+    expect(dec(lc.open(dek, blob, lc.buildAad("ab", "c")))).toBe("secret");
+  });
+
+  it("accepts string and byte parts interchangeably by value", () => {
+    const a = lc.buildAad("scope-1", "content", "logical-42");
+    const b = lc.buildAad(enc("scope-1"), enc("content"), enc("logical-42"));
+    expect(Buffer.from(a).equals(Buffer.from(b))).toBe(true);
+  });
+});
+
+describe("crypto/keys — identity, DEK wrapping (HPKE), escrow (Argon2id)", () => {
+  it("generates 32-byte X25519 identity keypairs; public key is derivable", () => {
+    const kp = lc.generateIdentityKeypair();
+    expect(kp.secretKey.length).toBe(32);
+    expect(kp.publicKey.length).toBe(32);
+    expect(Buffer.from(lc.identityPublicKey(kp.secretKey))).toEqual(
+      Buffer.from(kp.publicKey),
+    );
+  });
+
+  it("generates distinct 32-byte DEKs", () => {
+    const a = lc.generateDek();
+    const b = lc.generateDek();
+    expect(a.length).toBe(32);
+    expect(Buffer.from(a).equals(Buffer.from(b))).toBe(false);
+  });
+
+  it("wraps a DEK to an identity public key and unwraps with the secret key", async () => {
+    const kp = lc.generateIdentityKeypair();
+    const dek = lc.generateDek();
+    const wrapped = await lc.wrapDekForMember(kp.publicKey, dek);
+    const got = await lc.unwrapDek(kp.secretKey, wrapped);
+    expect(Buffer.from(got).equals(Buffer.from(dek))).toBe(true);
+  });
+
+  it("unwrapDek requires Lore's HPKE domain-separation info (rejects a foreign-info wrap)", async () => {
+    // Wrap the DEK with a DIFFERENT HPKE `info` than Lore's, in Lore's wrap layout
+    // [scheme(1)][enc(32)][ct]. unwrapDek pins info="lore-dek-wrap-v1", so it must
+    // reject this. Guards against a future both-sides drop of domain separation
+    // (which a symmetry-only round-trip test would miss).
+    const { Aes256Gcm, CipherSuite, DhkemX25519HkdfSha256, HkdfSha256 } =
+      await import("@hpke/core");
+    const kp = lc.generateIdentityKeypair();
+    const dek = lc.generateDek();
+    const suite = new CipherSuite({
+      kem: new DhkemX25519HkdfSha256(),
+      kdf: new HkdfSha256(),
+      aead: new Aes256Gcm(),
+    });
+    const rpk = await suite.kem.importKey(
+      "raw",
+      Uint8Array.from(kp.publicKey).buffer,
+      true,
+    );
+    // Wrap with EMPTY info (the HPKE default) — exactly what a dropped-domain-
+    // separation unwrapDek would use. If unwrapDek stopped passing Lore's info, this
+    // blob would open, so this test catches a both-sides drop of `info`.
+    const sender = await suite.createSenderContext({ recipientPublicKey: rpk });
+    const ct = new Uint8Array(await sender.seal(Uint8Array.from(dek).buffer));
+    const enc = new Uint8Array(sender.enc);
+    const wrapped = new Uint8Array(1 + enc.length + ct.length);
+    wrapped[0] = 1;
+    wrapped.set(enc, 1);
+    wrapped.set(ct, 1 + enc.length);
+    await expect(lc.unwrapDek(kp.secretKey, wrapped)).rejects.toThrow();
+  });
+
+  it("a different member cannot unwrap the DEK", async () => {
+    const alice = lc.generateIdentityKeypair();
+    const mallory = lc.generateIdentityKeypair();
+    const wrapped = await lc.wrapDekForMember(
+      alice.publicKey,
+      lc.generateDek(),
+    );
+    await expect(lc.unwrapDek(mallory.secretKey, wrapped)).rejects.toThrow();
+  });
+
+  it("detects tampering in the wrapped-DEK enc and ciphertext regions", async () => {
+    const kp = lc.generateIdentityKeypair();
+    const wrapped = await lc.wrapDekForMember(kp.publicKey, lc.generateDek());
+    // enc region is bytes [1, 33); ct region is [33, end)
+    const encTamper = Uint8Array.from(wrapped);
+    encTamper[5] ^= 0xff;
+    await expect(lc.unwrapDek(kp.secretKey, encTamper)).rejects.toThrow();
+    const ctTamper = Uint8Array.from(wrapped);
+    ctTamper[ctTamper.length - 1] ^= 0xff;
+    await expect(lc.unwrapDek(kp.secretKey, ctTamper)).rejects.toThrow();
+  });
+
+  it("escrow blobs and content blobs are domain-separated (AAD isolation)", () => {
+    const dek = lc.generateDek(); // reuse the 32-byte value as both a DEK and a KEK
+    const secret = lc.generateDek();
+    const escrow = lc.wrapWithKek(dek, secret);
+    // the escrow blob must NOT open as a plain content envelope (different AAD domain)
+    expect(() => lc.open(dek, escrow)).toThrow();
+    expect(() => lc.open(dek, escrow, enc("content"))).toThrow();
+    // and a content blob must NOT unwrap as escrow
+    const content = lc.seal(dek, enc("hi"), enc("content"));
+    expect(() => lc.unwrapWithKek(dek, content)).toThrow();
+  });
+
+  it("rejects a wrapped DEK with an unknown wrap scheme or truncated frame", async () => {
+    const kp = lc.generateIdentityKeypair();
+    const wrapped = await lc.wrapDekForMember(kp.publicKey, lc.generateDek());
+    const badScheme = Uint8Array.from(wrapped);
+    badScheme[0] = 99;
+    await expect(lc.unwrapDek(kp.secretKey, badScheme)).rejects.toThrow(
+      /wrap scheme/,
+    );
+    await expect(
+      lc.unwrapDek(kp.secretKey, wrapped.subarray(0, 4)),
+    ).rejects.toThrow();
+  });
+
+  it("wrapped DEK is a self-describing blob distinct from the plaintext DEK", async () => {
+    const kp = lc.generateIdentityKeypair();
+    const dek = lc.generateDek();
+    const wrapped = await lc.wrapDekForMember(kp.publicKey, dek);
+    expect(wrapped[0]).toBe(1); // WRAP_HPKE_X25519
+    expect(wrapped.length).toBeGreaterThan(dek.length);
+    expect(Buffer.from(wrapped).includes(Buffer.from(dek))).toBe(false);
+  });
+
+  it("derives a deterministic KEK for the same passphrase+salt+params", () => {
+    const salt = lc.generateKdfSalt();
+    const k1 = lc.deriveKek("correct horse", salt, FAST);
+    const k2 = lc.deriveKek("correct horse", salt, FAST);
+    expect(Buffer.from(k1).equals(Buffer.from(k2))).toBe(true);
+    expect(k1.length).toBe(32);
+  });
+
+  it("the production DEFAULT_KDF_PARAMS derive a valid 32-byte KEK", () => {
+    const kek = lc.deriveKek(
+      "prod",
+      lc.generateKdfSalt(),
+      lc.DEFAULT_KDF_PARAMS,
+    );
+    expect(kek.length).toBe(32);
+    expect(lc.DEFAULT_KDF_PARAMS.m).toBeGreaterThanOrEqual(19456); // OWASP floor (KiB)
+  });
+
+  it("derives different KEKs for a different passphrase or salt", () => {
+    const salt = lc.generateKdfSalt();
+    const base = lc.deriveKek("pw", salt, FAST);
+    expect(
+      Buffer.from(lc.deriveKek("PW", salt, FAST)).equals(Buffer.from(base)),
+    ).toBe(false);
+    expect(
+      Buffer.from(lc.deriveKek("pw", lc.generateKdfSalt(), FAST)).equals(
+        Buffer.from(base),
+      ),
+    ).toBe(false);
+  });
+
+  it("escrow: wraps/unwraps the identity secret key under a passphrase KEK", () => {
+    const kp = lc.generateIdentityKeypair();
+    const salt = lc.generateKdfSalt();
+    const kek = lc.deriveKek("master passphrase", salt, FAST);
+    const escrow = lc.wrapWithKek(kek, kp.secretKey);
+    const recovered = lc.unwrapWithKek(kek, escrow);
+    expect(Buffer.from(recovered).equals(Buffer.from(kp.secretKey))).toBe(true);
+    // a wrong passphrase → wrong KEK → cannot unwrap
+    const wrongKek = lc.deriveKek("WRONG passphrase", salt, FAST);
+    expect(() => lc.unwrapWithKek(wrongKek, escrow)).toThrow();
+  });
+});
+
+describe("crypto — end-to-end personal-scope flow", () => {
+  it("identity → DEK wrap → blob seal → recover on a 'fresh device' via escrow", async () => {
+    // Device 1: create identity, a scope DEK, wrap the DEK to itself, encrypt a blob.
+    const id = lc.generateIdentityKeypair();
+    const dek = lc.generateDek();
+    const wrappedDek = await lc.wrapDekForMember(id.publicKey, dek);
+    const aad = enc("scope-1|content|logical-42");
+    const blob = lc.seal(dek, enc("the raw conversation"), aad);
+
+    // Escrow the identity secret under a passphrase (what lands server-side).
+    const salt = lc.generateKdfSalt();
+    const escrow = lc.wrapWithKek(
+      lc.deriveKek("hunter2", salt, FAST),
+      id.secretKey,
+    );
+
+    // Device 2 (fresh): pulls escrow + wrapped DEK + blob, enters the passphrase.
+    const idSecret2 = lc.unwrapWithKek(
+      lc.deriveKek("hunter2", salt, FAST),
+      escrow,
+    );
+    const dek2 = await lc.unwrapDek(idSecret2, wrappedDek);
+    expect(dec(lc.open(dek2, blob, aad))).toBe("the raw conversation");
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,9 +68,21 @@ importers:
 
   packages/core:
     dependencies:
+      '@hpke/core':
+        specifier: ^1.9.0
+        version: 1.9.0
       '@huggingface/hub':
         specifier: 2.11.0
         version: 2.11.0
+      '@noble/ciphers':
+        specifier: ^2.2.0
+        version: 2.2.0
+      '@noble/curves':
+        specifier: ^2.2.0
+        version: 2.2.0
+      '@noble/hashes':
+        specifier: ^2.2.0
+        version: 2.2.0
       micromark:
         specifier: ^4.0.0
         version: 4.0.2
@@ -835,6 +847,14 @@ packages:
       '@modelcontextprotocol/sdk':
         optional: true
 
+  '@hpke/common@1.10.1':
+    resolution: {integrity: sha512-moJwhmtLtuxiUzzNp1jpfBfx8yefKoO9D/RCR9dmwrnc7qjJqId1rEtQz+lSlU5cabX8daToMSx/7HayXOiaFw==}
+    engines: {node: '>=16.0.0'}
+
+  '@hpke/core@1.9.0':
+    resolution: {integrity: sha512-pFxWl1nNJeQCSUFs7+GAblHvXBCjn9EPN65vdKlYQil2aURaRxfGMO6vBKGqm1YHTKwiAxJQNEI70PbSowMP9Q==}
+    engines: {node: '>=16.0.0'}
+
   '@huggingface/hub@2.11.0':
     resolution: {integrity: sha512-WS6QGaXYeBVFlaB4SOn6z4LGUpLB5kRZNL08uUni4izX353KxiwwZMK5+/AWX86MJh8SMZNa/JFcvFCcQsbszQ==}
     engines: {node: '>=18'}
@@ -1214,6 +1234,18 @@ packages:
     peerDependenciesMeta:
       '@opentelemetry/api':
         optional: true
+
+  '@noble/ciphers@2.2.0':
+    resolution: {integrity: sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==}
+    engines: {node: '>= 20.19.0'}
+
+  '@noble/curves@2.2.0':
+    resolution: {integrity: sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==}
+    engines: {node: '>= 20.19.0'}
+
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+    engines: {node: '>= 20.19.0'}
 
   '@nodable/entities@2.1.1':
     resolution: {integrity: sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==}
@@ -5090,6 +5122,12 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@hpke/common@1.10.1': {}
+
+  '@hpke/core@1.9.0':
+    dependencies:
+      '@hpke/common': 1.10.1
+
   '@huggingface/hub@2.11.0':
     dependencies:
       '@huggingface/tasks': 0.19.90
@@ -5432,6 +5470,14 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  '@noble/ciphers@2.2.0': {}
+
+  '@noble/curves@2.2.0':
+    dependencies:
+      '@noble/hashes': 2.2.0
+
+  '@noble/hashes@2.2.0': {}
 
   '@nodable/entities@2.1.1': {}
 


### PR DESCRIPTION
## Summary

First slice of the **encryption + key-management epic (#825)** — the **pure crypto primitives** (no DB, no network) that the rest of C builds on. Client-side encryption lets Supabase store ciphertext only for sensitive blobs (near-zero-knowledge); this PR lands the vetted, misuse-resistant building blocks.

Prerequisite for D (pro tables must be encrypted from day one). Decisions locked with @BYK: pure-JS crypto stack (no WASM), escrow-based key management as the v1 default, and `knowledge.content` as the first encrypted column (both in later sub-PRs).

## What lands (`packages/core/src/crypto/`)
- **`envelope.ts`** — versioned AEAD envelope: `[magic][scheme_id][key_epoch][nonce][ct+tag]`, XChaCha20-Poly1305 (`@noble/ciphers`). Header metadata is authenticated as AAD, so a scheme/epoch **downgrade** or a cross-row **transplant** fails the tag. MLS can later be an **additive** `scheme_id 2` — old ciphertext keeps decrypting, no bulk re-encryption. `buildAad(...parts)` length-prefixes context parts so caller bindings (`scope_id`/column/`logical_id`) can't collide.
- **`keys.ts`** — X25519 identity keypairs (`@noble/curves`), 32-byte DEK generation, **HPKE** DEK wrapping (`@hpke/core`, RFC 9180 DHKEM-X25519-HKDF-SHA256 + AES-256-GCM, with a domain-separation `info`), and **Argon2id** escrow (`@noble/hashes`): a passphrase-derived KEK wraps the identity secret key for server-side escrow.
- **`index.ts`** — stable key-agreement interface (`wrapDekForMember`/`unwrapDek`) so libsodium→MLS is a swap, plus the required inline **libsodium/HPKE→MLS rationale + threshold** doc. Barrel: `export * as crypto`.

## Why pure-JS (no WASM)
The SEA binary embeds WASM/native as assets (onnxruntime, sqlite-vec); a WASM crypto lib would inherit that build complexity. `@noble/*` + `@hpke/core` are audited, pure-JS/TS, and bundle cleanly through esbuild — verified the core bundle builds and the bundled crypto round-trips.

## Tests (27)
Envelope round-trip / body+header tamper / AAD mismatch / scheme dispatch / nonce-uniqueness (200×) / uint32 epoch boundaries; `buildAad` disambiguation; HPKE wrap/unwrap + wrong-recipient + enc/ct tamper + **`info` domain-separation** (discriminating — a both-sides `info` drop fails it); Argon2id determinism + escrow round-trip + escrow↔content domain isolation; and an **end-to-end fresh-device-via-escrow** flow. Argon2id uses light params in tests (correctness is work-factor-independent) with one run at production `DEFAULT_KDF_PARAMS`.

## Review
Two adversarial subagent reviews — **crypto-security** (~35 attack PoCs) and **correctness** (10 mutation probes) — both **SHIP, no blockers**. All flagged hardening applied in-PR: the length-prefixed AAD builder, HPKE `info` domain-separation, and Argon2id `p=4→p=1` (no parallelism benefit in single-threaded JS).

## Verification
27 crypto tests pass; full suite green (5163); typecheck 0 (all packages); Biome lint 0; core esbuild bundle builds and runs.

## Next (this epic)
- **C-2**: local key store (device identity + per-scope DEK, `scope_keys` local table, escrow derivation/unlock).
- **C-3**: `scope_keys` + escrow remote mirror (migration + RLS: a member pulls only DEKs wrapped for them).
- **C-4**: wire encrypt/decrypt into push/pull for `knowledge.content`.
