### PR TITLE
feat(core): auto-target CLAUDE.md for Claude Code, AGENTS.md otherwise

### DIFF
--- a/packages/core/src/agents-file.ts
+++ b/packages/core/src/agents-file.ts
@@ -60,6 +60,54 @@ const ALL_START_MARKERS = [
  */
 export const LORE_FILE = ".lore.md";
 
+/**
+ * Sentinel value for `agentsFile.path` that enables per-agent auto-selection of
+ * the host filename (see `resolveAgentsFileName`).
+ */
+export const AUTO_AGENTS_FILE = "auto";
+
+/** Candidate host filenames for the managed section when `path` is "auto". */
+export const AGENTS_FILE_CANDIDATES = ["AGENTS.md", "CLAUDE.md"] as const;
+
+/**
+ * Resolve the configured `agentsFile.path` to a concrete filename.
+ *
+ * A literal path (e.g. "AGENTS.md", "CLAUDE.md", ".cursor/rules/lore.md") is
+ * returned verbatim. The "auto" sentinel resolves per client:
+ *   - Claude Code sessions (`isClaudeCode === true`) → "CLAUDE.md" (Claude
+ *     Code's canonical memory file);
+ *   - other agents (`isClaudeCode === false`) → "AGENTS.md";
+ *   - no client hint (startup import / file watcher / CLI) → an existing
+ *     "CLAUDE.md" in the project if present, else "AGENTS.md".
+ *
+ * The idle exporter is the authoritative writer: it passes the session's client
+ * identity, so the first export creates the right file and the hint-less
+ * read/watch paths then discover it via existing-file detection.
+ */
+export function resolveAgentsFileName(
+  configuredPath: string,
+  opts: { isClaudeCode?: boolean; projectPath: string },
+): string {
+  if (configuredPath !== AUTO_AGENTS_FILE) return configuredPath;
+  if (opts.isClaudeCode === true) return "CLAUDE.md";
+  if (opts.isClaudeCode === false) return "AGENTS.md";
+  return existsSync(join(opts.projectPath, "CLAUDE.md"))
+    ? "CLAUDE.md"
+    : "AGENTS.md";
+}
+
+/**
+ * The other "auto"-mode candidate filename, used to strip a stale managed
+ * section after the resolved target flips between AGENTS.md and CLAUDE.md.
+ * Returns null for a custom (non-candidate) path, so an explicitly configured
+ * file's counterpart is never touched.
+ */
+export function otherAgentsFileCandidate(resolvedName: string): string | null {
+  if (resolvedName === "AGENTS.md") return "CLAUDE.md";
+  if (resolvedName === "CLAUDE.md") return "AGENTS.md";
+  return null;
+}
+
 const LORE_FILE_HEADER =
   "<!-- Managed by lore (https://github.com/BYK/loreai) — manual edits are imported on next session. -->";
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -742,16 +742,21 @@ export const LoreConfig = z.object({
         .describe(
           "Enable AGENTS.md export/import behaviour. Set to false to disable. Default: true.",
         ),
-      /** Path to the agents file, relative to the project root. */
+      /**
+       * Path to the agents file, relative to the project root, or the "auto"
+       * sentinel (default). "auto" writes CLAUDE.md for Claude Code sessions
+       * (its canonical memory file) and AGENTS.md for every other agent; an
+       * explicit path always overrides.
+       */
       path: z
         .string()
-        .default("AGENTS.md")
+        .default("auto")
         .describe(
-          "Path to the agents file, relative to the project root. Default: 'AGENTS.md'.",
+          "Path to the agents file, relative to the project root, or 'auto' (default) to write CLAUDE.md for Claude Code sessions and AGENTS.md otherwise. Set an explicit path (e.g. 'AGENTS.md' or 'CLAUDE.md') to override.",
         ),
     })
-    .default({ enabled: true, path: "AGENTS.md" })
-    .describe("AGENTS.md export/import configuration."),
+    .default({ enabled: true, path: "auto" })
+    .describe("AGENTS.md/CLAUDE.md export/import configuration."),
   loreFile: z
     .object({
       /** Set to false to disable `.lore.md` export/import. When disabled:

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -254,6 +254,10 @@ export {
   clearLoreFileCache,
   importLoreFileAs,
   LORE_FILE,
+  AUTO_AGENTS_FILE,
+  AGENTS_FILE_CANDIDATES,
+  resolveAgentsFileName,
+  otherAgentsFileCandidate,
 } from "./agents-file";
 export {
   discoverWorkspaceRoot,

--- a/packages/core/test/agents-file.test.ts
+++ b/packages/core/test/agents-file.test.ts
@@ -33,6 +33,10 @@ import {
   loreFileExists,
   clearLoreFileCache,
   parseEntriesFromSection,
+  resolveAgentsFileName,
+  otherAgentsFileCandidate,
+  AUTO_AGENTS_FILE,
+  AGENTS_FILE_CANDIDATES,
 } from "../src/agents-file";
 import { load } from "../src/config";
 
@@ -1836,5 +1840,97 @@ describe("loreFile.enabled toggle", () => {
   test("deleteLoreFile returns false when the file does not exist", () => {
     expect(existsSync(LORE_FILE_PATH)).toBe(false);
     expect(deleteLoreFile(PROJECT)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveAgentsFileName / otherAgentsFileCandidate — "auto" host selection
+// ---------------------------------------------------------------------------
+
+describe("resolveAgentsFileName", () => {
+  const RES_DIR = join(
+    fileURLToPath(new URL(".", import.meta.url)),
+    "__tmp_resolve_agents__",
+  );
+
+  beforeEach(() => {
+    rmSync(RES_DIR, { recursive: true, force: true });
+    mkdirSync(RES_DIR, { recursive: true });
+  });
+  afterAll(() => rmSync(RES_DIR, { recursive: true, force: true }));
+
+  test("an explicit path is returned verbatim (never auto-resolved)", () => {
+    expect(resolveAgentsFileName("AGENTS.md", { projectPath: RES_DIR })).toBe(
+      "AGENTS.md",
+    );
+    expect(
+      resolveAgentsFileName("CLAUDE.md", {
+        projectPath: RES_DIR,
+        isClaudeCode: false,
+      }),
+    ).toBe("CLAUDE.md");
+    expect(
+      resolveAgentsFileName(".cursor/rules/lore.md", { projectPath: RES_DIR }),
+    ).toBe(".cursor/rules/lore.md");
+  });
+
+  test("auto + Claude Code session → CLAUDE.md", () => {
+    expect(
+      resolveAgentsFileName(AUTO_AGENTS_FILE, {
+        projectPath: RES_DIR,
+        isClaudeCode: true,
+      }),
+    ).toBe("CLAUDE.md");
+  });
+
+  test("auto + non-Claude-Code session → AGENTS.md", () => {
+    expect(
+      resolveAgentsFileName(AUTO_AGENTS_FILE, {
+        projectPath: RES_DIR,
+        isClaudeCode: false,
+      }),
+    ).toBe("AGENTS.md");
+  });
+
+  test("auto + no hint + no existing file → AGENTS.md", () => {
+    expect(
+      resolveAgentsFileName(AUTO_AGENTS_FILE, { projectPath: RES_DIR }),
+    ).toBe("AGENTS.md");
+  });
+
+  test("auto + no hint + existing CLAUDE.md → CLAUDE.md", () => {
+    writeFileSync(join(RES_DIR, "CLAUDE.md"), "# hi\n", "utf8");
+    expect(
+      resolveAgentsFileName(AUTO_AGENTS_FILE, { projectPath: RES_DIR }),
+    ).toBe("CLAUDE.md");
+  });
+
+  test("auto + no hint + only AGENTS.md exists → AGENTS.md", () => {
+    writeFileSync(join(RES_DIR, "AGENTS.md"), "# hi\n", "utf8");
+    expect(
+      resolveAgentsFileName(AUTO_AGENTS_FILE, { projectPath: RES_DIR }),
+    ).toBe("AGENTS.md");
+  });
+
+  test("a client hint wins over existing-file detection", () => {
+    writeFileSync(join(RES_DIR, "CLAUDE.md"), "# hi\n", "utf8");
+    // Non-CC hint must not be overridden by a stray CLAUDE.md on disk.
+    expect(
+      resolveAgentsFileName(AUTO_AGENTS_FILE, {
+        projectPath: RES_DIR,
+        isClaudeCode: false,
+      }),
+    ).toBe("AGENTS.md");
+  });
+
+  test("otherAgentsFileCandidate flips the two auto candidates", () => {
+    expect(otherAgentsFileCandidate("AGENTS.md")).toBe("CLAUDE.md");
+    expect(otherAgentsFileCandidate("CLAUDE.md")).toBe("AGENTS.md");
+    // A custom path has no twin → never strips an unrelated file.
+    expect(otherAgentsFileCandidate(".cursor/rules/lore.md")).toBeNull();
+  });
+
+  test("AGENTS_FILE_CANDIDATES lists exactly the two auto host files", () => {
+    expect([...AGENTS_FILE_CANDIDATES]).toEqual(["AGENTS.md", "CLAUDE.md"]);
   });
 });

--- a/packages/core/test/config.test.ts
+++ b/packages/core/test/config.test.ts
@@ -14,16 +14,16 @@ afterEach(() => {
 });
 
 describe("LoreConfig — agentsFile schema", () => {
-  test("agentsFile defaults: enabled=true, path=AGENTS.md", () => {
+  test("agentsFile defaults: enabled=true, path=auto", () => {
     const cfg = LoreConfig.parse({});
     expect(cfg.agentsFile.enabled).toBe(true);
-    expect(cfg.agentsFile.path).toBe("AGENTS.md");
+    expect(cfg.agentsFile.path).toBe("auto");
   });
 
   test("agentsFile.enabled can be set to false", () => {
     const cfg = LoreConfig.parse({ agentsFile: { enabled: false } });
     expect(cfg.agentsFile.enabled).toBe(false);
-    expect(cfg.agentsFile.path).toBe("AGENTS.md"); // path still defaults
+    expect(cfg.agentsFile.path).toBe("auto"); // path still defaults
   });
 
   test("agentsFile.path can be customised", () => {
@@ -42,6 +42,11 @@ describe("LoreConfig — agentsFile schema", () => {
   test("agentsFile section is optional — omitting it uses defaults", () => {
     const cfg = LoreConfig.parse({ curator: { enabled: false } });
     expect(cfg.agentsFile.enabled).toBe(true);
+    expect(cfg.agentsFile.path).toBe("auto");
+  });
+
+  test("agentsFile.path can be pinned to an explicit AGENTS.md", () => {
+    const cfg = LoreConfig.parse({ agentsFile: { path: "AGENTS.md" } });
     expect(cfg.agentsFile.path).toBe("AGENTS.md");
   });
 });
@@ -257,6 +262,6 @@ describe("load — reads config from .lore.json", () => {
     mkdirSync(TMP, { recursive: true });
     const cfg = await load(TMP);
     expect(cfg.agentsFile.enabled).toBe(true);
-    expect(cfg.agentsFile.path).toBe("AGENTS.md");
+    expect(cfg.agentsFile.path).toBe("auto");
   });
 });

--- a/packages/gateway/src/cli/data.ts
+++ b/packages/gateway/src/cli/data.ts
@@ -2803,6 +2803,9 @@ async function cmdExport(
     exportInlineToAgentsFile,
     deleteLoreFile,
     removeLoreSectionFromFile,
+    resolveAgentsFileName,
+    otherAgentsFileCandidate,
+    AGENTS_FILE_CANDIDATES,
   } = await import("@loreai/core");
   const cfg = loreConfig();
 
@@ -2814,7 +2817,11 @@ async function cmdExport(
   }
 
   const entries = ltm.forProject(projectPath, false);
-  const agentsFilePath = join(projectPath, cfg.agentsFile.path);
+  // No live session here — resolve "auto" via existing-file detection.
+  const agentsFileName = resolveAgentsFileName(cfg.agentsFile.path, {
+    projectPath,
+  });
+  const agentsFilePath = join(projectPath, agentsFileName);
 
   if (entries.length === 0) {
     // No knowledge for this project — fully reconcile the on-disk files so no
@@ -2828,8 +2835,16 @@ async function cmdExport(
     }
     // Strip lore's section from the agents file (pointer in the default config,
     // inline knowledge in the agentsFile-only config). Preserves user content.
-    if (cfg.agentsFile.enabled && removeLoreSectionFromFile(agentsFilePath)) {
-      cleaned.push(agentsFilePath);
+    // Under "auto", clean BOTH candidates since either may hold a stale section.
+    if (cfg.agentsFile.enabled) {
+      const names =
+        cfg.agentsFile.path === "auto"
+          ? [...AGENTS_FILE_CANDIDATES]
+          : [agentsFileName];
+      for (const name of names) {
+        const p = join(projectPath, name);
+        if (removeLoreSectionFromFile(p)) cleaned.push(p);
+      }
     }
     if (cleaned.length) {
       console.log(`No knowledge for ${projectPath} — cleaned stale file(s):`);
@@ -2842,20 +2857,31 @@ async function cmdExport(
   }
 
   const written: string[] = [];
+  let wroteAgentsFile = false;
   if (cfg.loreFile.enabled && cfg.agentsFile.enabled) {
     exportToFile({ projectPath, filePath: agentsFilePath });
     written.push(join(projectPath, ".lore.md"), agentsFilePath);
+    wroteAgentsFile = true;
   } else if (cfg.loreFile.enabled) {
     exportLoreFile(projectPath);
     written.push(join(projectPath, ".lore.md"));
   } else if (cfg.agentsFile.enabled) {
     exportInlineToAgentsFile({ projectPath, filePath: agentsFilePath });
     written.push(agentsFilePath);
+    wroteAgentsFile = true;
   } else {
     console.log(
       "Both loreFile and agentsFile are disabled in config — nothing written.",
     );
     return;
+  }
+  // In "auto" mode, strip a stale managed section from the OTHER candidate so a
+  // target flip never leaves a duplicate (mirrors the idle exporter).
+  if (wroteAgentsFile && cfg.agentsFile.path === "auto") {
+    const other = otherAgentsFileCandidate(agentsFileName);
+    if (other && removeLoreSectionFromFile(join(projectPath, other))) {
+      console.log(`  (removed stale lore section from ${other})`);
+    }
   }
 
   console.log(

--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -27,6 +27,9 @@ import {
   exportToFile,
   exportLoreFile,
   exportInlineToAgentsFile,
+  removeLoreSectionFromFile,
+  resolveAgentsFileName,
+  otherAgentsFileCandidate,
   saveSessionCosts,
   saveSessionTracking,
   saveGradientState,
@@ -1296,19 +1299,38 @@ export function buildIdleWorkHandler(
     if (cfg.knowledge.enabled) {
       try {
         if (entries.length > 0) {
+          // Resolve the host filename. The idle exporter is the authoritative
+          // writer, so it feeds the session's client identity: an "auto" path
+          // writes CLAUDE.md for Claude Code sessions (its canonical memory
+          // file) and AGENTS.md otherwise. `header_name` is the persisted
+          // Tier-1 session header — `x-claude-code-session-id` iff Claude Code.
+          const isClaudeCode = state.headerName === "x-claude-code-session-id";
+          const agentsFileName = resolveAgentsFileName(cfg.agentsFile.path, {
+            isClaudeCode,
+            projectPath,
+          });
+          const filePath = join(projectPath, agentsFileName);
+          let wroteAgentsFile = false;
           if (cfg.loreFile.enabled && cfg.agentsFile.enabled) {
-            // Default: .lore.md + AGENTS.md pointer
-            const filePath = join(projectPath, cfg.agentsFile.path);
+            // Default: .lore.md + agents-file pointer
             exportToFile({ projectPath, filePath, entries });
+            wroteAgentsFile = true;
           } else if (cfg.loreFile.enabled) {
             // .lore.md only
             exportLoreFile(projectPath, entries);
           } else if (cfg.agentsFile.enabled) {
-            // Inline knowledge in AGENTS.md (no .lore.md)
-            const filePath = join(projectPath, cfg.agentsFile.path);
+            // Inline knowledge in the agents file (no .lore.md)
             exportInlineToAgentsFile({ projectPath, filePath, entries });
+            wroteAgentsFile = true;
           }
           // else: both disabled — no markdown file
+          // In "auto" mode, strip a stale managed section from the OTHER
+          // candidate so a target flip (AGENTS.md <-> CLAUDE.md) never leaves a
+          // duplicate. Never touches an explicitly configured file's twin.
+          if (wroteAgentsFile && cfg.agentsFile.path === "auto") {
+            const other = otherAgentsFileCandidate(agentsFileName);
+            if (other) removeLoreSectionFromFile(join(projectPath, other));
+          }
         }
       } catch (e) {
         log.error("idle knowledge export error:", e);

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -64,6 +64,8 @@ import {
   shouldImport,
   importFromFile,
   LORE_FILE,
+  AGENTS_FILE_CANDIDATES,
+  resolveAgentsFileName,
   latReader,
   embedding,
   saveSessionTracking,
@@ -1837,10 +1839,15 @@ function tryImportKnowledge(projectPath: string): boolean {
       }
     } else if (cfg.agentsFile.enabled) {
       const { join } = require("node:path") as typeof import("node:path");
-      const filePath = join(projectPath, cfg.agentsFile.path);
+      // No session hint here — resolve "auto" via existing-file detection
+      // (prefers a CLAUDE.md the idle exporter already wrote, else AGENTS.md).
+      const agentsFileName = resolveAgentsFileName(cfg.agentsFile.path, {
+        projectPath,
+      });
+      const filePath = join(projectPath, agentsFileName);
       if (shouldImport({ projectPath, filePath })) {
         importFromFile({ projectPath, filePath });
-        log.info("imported knowledge from", cfg.agentsFile.path);
+        log.info("imported knowledge from", agentsFileName);
         return true;
       }
     }
@@ -1899,16 +1906,24 @@ function startKnowledgeFileWatcher(projectPath: string): () => void {
     }
   }
 
-  // Watch agents file (AGENTS.md etc.) as fallback
+  // Watch the agents file(s) as fallback. Under "auto" we don't know which
+  // agent will run, so watch BOTH candidates (AGENTS.md + CLAUDE.md); an
+  // explicit path watches just that file.
   if (cfg.agentsFile.enabled) {
-    const agentsFilePath = join(projectPath, cfg.agentsFile.path);
-    if (existsSync(agentsFilePath)) {
-      try {
-        const w = watch(agentsFilePath, onFileChange);
-        w.on("error", () => {});
-        watchers.push(w);
-      } catch {
-        // watch not supported
+    const agentsFileNames =
+      cfg.agentsFile.path === "auto"
+        ? [...AGENTS_FILE_CANDIDATES]
+        : [cfg.agentsFile.path];
+    for (const name of agentsFileNames) {
+      const agentsFilePath = join(projectPath, name);
+      if (existsSync(agentsFilePath)) {
+        try {
+          const w = watch(agentsFilePath, onFileChange);
+          w.on("error", () => {});
+          watchers.push(w);
+        } catch {
+          // watch not supported
+        }
       }
     }
   }

--- a/packages/gateway/test/idle-work.test.ts
+++ b/packages/gateway/test/idle-work.test.ts
@@ -9,7 +9,14 @@
  * the batch queue; on an empty DB they are correctly skipped.
  */
 import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdtempSync, rmSync, readdirSync } from "node:fs";
+import {
+  mkdtempSync,
+  rmSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+  existsSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -779,6 +786,65 @@ describe("buildIdleWorkHandler", () => {
     // Default config enables loreFile + agentsFile → writes AGENTS.md (+ .lore.md).
     const files = readdirSync(projectPath);
     expect(files.some((f) => f === "AGENTS.md" || f === ".lore.md")).toBe(true);
+  });
+
+  test("auto: a Claude Code session writes CLAUDE.md and strips a stale AGENTS.md section", async () => {
+    const llm = makeLLM();
+    const handler = buildIdleWorkHandler(llm);
+    const projectPath = makeProjectDir();
+    ltm.create({
+      projectPath,
+      category: "gotcha",
+      title: "Auto target entry",
+      content: "Knowledge content for the auto-target export test.",
+      scope: "project",
+    });
+
+    // Phase 1: a non-Claude-Code session (no CC header) → "auto" resolves to
+    // AGENTS.md. This seeds a real lore-managed section on disk.
+    await handler(
+      "idle-auto-other",
+      makeSessionState({
+        sessionID: "idle-auto-other",
+        projectPath,
+        turnsSinceCuration: 0,
+      }),
+    );
+    const agentsPath = join(projectPath, "AGENTS.md");
+    expect(existsSync(agentsPath)).toBe(true);
+    // Add hand-written content OUTSIDE the managed markers — must be preserved
+    // when the section is later stripped on the target flip.
+    const USER_LINE = "# Hand-written heading kept across the flip";
+    writeFileSync(
+      agentsPath,
+      `${USER_LINE}\n\n${readFileSync(agentsPath, "utf8")}`,
+      "utf8",
+    );
+
+    // Phase 2: a Claude Code session (Tier-1 CC header) → "auto" resolves to
+    // CLAUDE.md, and the stale AGENTS.md managed section is stripped.
+    await handler(
+      "idle-auto-cc",
+      makeSessionState({
+        sessionID: "idle-auto-cc",
+        projectPath,
+        headerName: "x-claude-code-session-id",
+        turnsSinceCuration: 0,
+      }),
+    );
+
+    const claudePath = join(projectPath, "CLAUDE.md");
+    expect(existsSync(claudePath)).toBe(true);
+    // CLAUDE.md now carries the managed pointer section.
+    expect(readFileSync(claudePath, "utf8")).toContain(
+      "For long-term knowledge entries managed by",
+    );
+    // AGENTS.md still exists (user content preserved) but its lore section is gone.
+    const agentsAfter = readFileSync(agentsPath, "utf8");
+    expect(agentsAfter).toContain(USER_LINE);
+    expect(agentsAfter).not.toContain(
+      "For long-term knowledge entries managed by",
+    );
   });
 
   test("runs consolidation when a category is over threshold, then the cooldown skips the next tick", async () => {

--- a/packages/website/src/content/docs/docs/configuration.md
+++ b/packages/website/src/content/docs/docs/configuration.md
@@ -50,7 +50,7 @@ The cleanest way to override a single field is via env var if Lore reads it, or 
 - [`cache`](#cache) — Anthropic prompt cache TTL and speculative warming.
 - [`workspaces`](#workspaces) — Workspace sub-project paths or globs (relative to `.lore.json`). Imported into the root knowledge base on startup. Supports literal paths and single-level globs (e.g. "packages/*").
 - [`crossProject`](#crossProject) — Include cross-project knowledge in compaction summaries and auto-promote knowledge that recurs across 3+ projects. Default: true.
-- [`agentsFile`](#agentsFile) — AGENTS.md export/import configuration.
+- [`agentsFile`](#agentsFile) — AGENTS.md/CLAUDE.md export/import configuration.
 - [`loreFile`](#loreFile) — `.lore.md` export/import configuration.
 - [`user`](#user) — User identity for the self-entity. Falls back to git config user.name / user.email if omitted.
 
@@ -231,12 +231,12 @@ Include cross-project knowledge in compaction summaries and auto-promote knowled
 
 ## `agentsFile`
 
-AGENTS.md export/import configuration.
+AGENTS.md/CLAUDE.md export/import configuration.
 
 | Field | Type | Default | Constraints | Description |
 |---|---|---|---|---|
 | `enabled` | boolean | `true` |  | Enable AGENTS.md export/import behaviour. Set to false to disable. Default: true. |
-| `path` | string | `"AGENTS.md"` |  | Path to the agents file, relative to the project root. Default: 'AGENTS.md'. |
+| `path` | string | `"auto"` |  | Path to the agents file, relative to the project root, or 'auto' (default) to write CLAUDE.md for Claude Code sessions and AGENTS.md otherwise. Set an explicit path (e.g. 'AGENTS.md' or 'CLAUDE.md') to override. |
 
 
 ## `loreFile`


### PR DESCRIPTION
## Problem

Lore always wrote its managed knowledge section (and the `.lore.md` pointer) to **AGENTS.md**. But Claude Code's canonical memory file is **CLAUDE.md** — AGENTS.md support in the CC binary is negligible (215 `CLAUDE.md` refs vs 2 for `AGENTS.md`; most "AGENTS" tokens are the *subagents* feature). So Claude Code users didn't reliably pick up the pointer.

## Fix

Default `agentsFile.path` to a new **`"auto"`** sentinel that resolves the host filename per agent:

- Claude Code sessions (Tier-1 header `x-claude-code-session-id`) → **CLAUDE.md**
- every other agent → **AGENTS.md**
- an explicit `agentsFile.path` (e.g. `"AGENTS.md"`, `"CLAUDE.md"`, `".cursor/rules/lore.md"`) always overrides

The idle exporter is the authoritative writer and feeds the session's client identity (`state.headerName`). Hint-less read paths — startup import (`tryImportKnowledge`), the file watcher, and `lore data export` — resolve `"auto"` via existing-file detection (prefer an existing `CLAUDE.md`, else `AGENTS.md`); the watcher watches **both** candidates under `"auto"`.

On a target flip (AGENTS.md ⇄ CLAUDE.md), the **stale managed section is stripped** from the other candidate (via `removeLoreSectionFromFile`), preserving any hand-written content. A file the user configured explicitly never has a counterpart touched.

New core API: `resolveAgentsFileName`, `otherAgentsFileCandidate`, `AGENTS_FILE_CANDIDATES`, `AUTO_AGENTS_FILE`.

## Tests

- `config.test.ts`: default `agentsFile.path` is now `"auto"`; explicit paths preserved.
- `agents-file.test.ts`: `resolveAgentsFileName` matrix (explicit verbatim; auto+CC→CLAUDE.md; auto+non-CC→AGENTS.md; hint-less existing-file detection; hint beats detection) + `otherAgentsFileCandidate`.
- `idle-work.test.ts`: end-to-end flip — a non-CC session writes AGENTS.md, then a Claude Code session writes CLAUDE.md and strips the stale AGENTS.md section while preserving hand-written content. Mutation-verified (forcing `isClaudeCode=false` or removing the strip both fail the test).

No pointer-text change needed (it already references `.lore.md` generically). Typecheck + Biome clean; full core (2529) and gateway suites green except the pre-existing `bundle-exports` tests (require a built Bun bundle).

> [!NOTE]
> Intended migration: existing Claude Code users on the default move from AGENTS.md → CLAUDE.md on the next idle export, with the old AGENTS.md section removed. Mixed-agent projects (CC + another agent on the same repo) should pin an explicit `agentsFile.path`.