### PR TITLE
test(gateway): rebuild the npm bundle on demand instead of asserting against a stale one

### DIFF
--- a/packages/gateway/test/bundle-exports.test.ts
+++ b/packages/gateway/test/bundle-exports.test.ts
@@ -7,25 +7,108 @@
  * - The imported module exports the expected public API
  *
  * Requires the bundle (`pnpm --filter @loreai/gateway run bundle`) to have
- * been built. The root `pretest` script runs the bundle automatically before
- * `pnpm test`, so this test runs in every environment (local + CI). The
- * skipIf guard is defensive — it should never trigger in normal use, but
- * ensures a missing bundle is reported as a skip rather than a confusing
- * file-not-found assertion failure.
+ * been built AND to be up to date with its sources. The root `pretest` script
+ * rebuilds the bundle before `pnpm test`, so it is always fresh there (local +
+ * CI). The skip guard is defensive — it should never trigger under `pnpm test`.
+ *
+ * Two conditions cause a skip (a skip, never a confusing assertion failure):
+ *
+ *  1. MISSING bundle — a dev checkout that only ran `pnpm install` has the
+ *     `index.bun.js` dev shim but no `index.cjs`, so there is nothing to check.
+ *
+ *  2. STALE bundle — `dist/` is older than the sources it is built from. This
+ *     is the trap behind "bundle-export tests are failing on latest main":
+ *     `pretest` only runs for `pnpm test`, NOT for `vitest --watch`, IDE test
+ *     runners, or a direct `vitest run`. After pulling a change to the bundle's
+ *     inputs (e.g. #1027 inlining @loreai/core) WITHOUT rebuilding, those launch
+ *     paths assert against a stale artifact that no longer reflects source — a
+ *     false failure. Treat a stale bundle like a missing one and point the dev
+ *     at `pnpm --filter @loreai/gateway run bundle`.
+ *
+ * This never weakens CI: `pretest` writes the bundle AFTER checkout/build/
+ * typecheck/lint (the last write before vitest), so the artifact mtime is
+ * always newer than every source there — CI is never stale and always runs the
+ * checks strictly.
  */
 import { describe, test, expect } from "vitest";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const packageDir = join(fileURLToPath(import.meta.url), "..", "..");
 const distDir = join(packageDir, "dist");
+const coreSrcDir = join(packageDir, "..", "core", "src");
 const pkgJson = JSON.parse(
   readFileSync(join(packageDir, "package.json"), "utf8"),
 );
-const hasBundle = existsSync(join(distDir, "index.cjs"));
 
-describe.skipIf(!hasBundle)("bundle exports", () => {
+const cjsBundlePath = join(distDir, "index.cjs");
+const bunBundlePath = join(distDir, "index.bun.js");
+const hasBundle = existsSync(cjsBundlePath);
+
+/** Newest mtime (ms) across the given files/directories; dirs walk recursively.
+ *  Unreadable paths are skipped so a broken symlink can't crash the suite. */
+function newestMtimeMs(roots: string[]): number {
+  let newest = 0;
+  const stack = [...roots];
+  while (stack.length > 0) {
+    const p = stack.pop() as string;
+    let st: ReturnType<typeof statSync>;
+    try {
+      st = statSync(p);
+    } catch {
+      continue;
+    }
+    if (st.isDirectory()) {
+      for (const entry of readdirSync(p)) stack.push(join(p, entry));
+    } else if (st.mtimeMs > newest) {
+      newest = st.mtimeMs;
+    }
+  }
+  return newest;
+}
+
+/** Oldest mtime (ms) across the given files; a missing file counts as 0 (stale). */
+function oldestMtimeMs(files: string[]): number {
+  let oldest = Number.POSITIVE_INFINITY;
+  for (const f of files) {
+    try {
+      oldest = Math.min(oldest, statSync(f).mtimeMs);
+    } catch {
+      return 0;
+    }
+  }
+  return Number.isFinite(oldest) ? oldest : 0;
+}
+
+// The bundle inlines gateway/src + core/src; bundle.ts is its build config and
+// package.json drives the files/exports/deps assertions. If any of these is
+// newer than the built artifacts, the artifacts predate the current source.
+const newestSourceMtime = hasBundle
+  ? newestMtimeMs([
+      join(packageDir, "src"),
+      coreSrcDir,
+      join(packageDir, "script", "bundle.ts"),
+      join(packageDir, "package.json"),
+    ])
+  : 0;
+const oldestArtifactMtime = hasBundle
+  ? oldestMtimeMs([cjsBundlePath, bunBundlePath])
+  : 0;
+const bundleStale = hasBundle && newestSourceMtime > oldestArtifactMtime;
+
+if (bundleStale) {
+  console.warn(
+    "[bundle-exports] dist/ bundle is older than its sources — skipping " +
+      "bundle-content checks. Run `pnpm --filter @loreai/gateway run bundle` " +
+      "to refresh it (the root `pretest` hook does this automatically under " +
+      "`pnpm test`).",
+  );
+}
+
+const bundleReady = hasBundle && !bundleStale;
+
+describe.skipIf(!bundleReady)("bundle exports", () => {
   // -------------------------------------------------------------------------
   // Layer 1: Static content checks
   // -------------------------------------------------------------------------

--- a/packages/gateway/test/bundle-exports.test.ts
+++ b/packages/gateway/test/bundle-exports.test.ts
@@ -27,7 +27,7 @@
  */
 import { beforeAll, describe, test, expect } from "vitest";
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
-import { execFileSync } from "node:child_process";
+import { execSync } from "node:child_process";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -105,7 +105,10 @@ describe("bundle exports", () => {
         "(pnpm --filter @loreai/gateway run bundle)…\n",
     );
     try {
-      execFileSync("pnpm", ["--filter", "@loreai/gateway", "run", "bundle"], {
+      // execSync goes through the platform shell (a fixed literal command, no
+      // interpolation), so it resolves `pnpm.cmd` on Windows — execFile("pnpm")
+      // would ENOENT there because a .cmd is not directly executable.
+      execSync("pnpm --filter @loreai/gateway run bundle", {
         cwd: repoRoot,
         stdio: "pipe",
         encoding: "utf8",

--- a/packages/gateway/test/bundle-exports.test.ts
+++ b/packages/gateway/test/bundle-exports.test.ts
@@ -6,24 +6,30 @@
  * - The CJS Node bundle uses node:sqlite (not bun:sqlite)
  * - @loreai/core is inlined (not externalized) in the Bun bundle (#1027)
  *
- * These assert on the built `dist/` artifacts. The root `pretest` hook rebuilds
- * the bundle before `pnpm test`, but NOT for `vitest --watch`, IDE test
- * runners, or a direct `vitest run`. After pulling a change to the bundle's
- * inputs (e.g. #1027 inlining @loreai/core) WITHOUT rebuilding, those launch
- * paths would otherwise assert against a stale/missing artifact that no longer
- * reflects source — the "bundle-export tests are failing on latest main" trap.
+ * These assert on the built `dist/` artifacts. A bundle build runs immediately
+ * before vitest under `pnpm test` (root `pretest` hook) and `pnpm run
+ * test:coverage` (its own `bundle &&` chain, used by CI) — but NOT for
+ * `vitest --watch`, IDE test runners, or a direct `vitest run`. After pulling a
+ * change to the bundle's inputs (e.g. #1027 inlining @loreai/core) WITHOUT
+ * rebuilding, those launch paths would otherwise assert against a stale/missing
+ * artifact that no longer reflects source — the "bundle-export tests are
+ * failing on latest main" trap.
  *
  * Rather than SKIP when the artifact is stale/missing (which silently drops
  * these checks in the local dev loop — a footgun), the suite REBUILDS the
  * bundle on demand in `beforeAll`, so it always runs against a bundle built
  * from current source no matter how vitest was launched. The rebuild is gated
- * on freshness, so it is a no-op when the bundle is already current: in CI
- * `pretest` writes the bundle as the last step before vitest (after checkout/
- * build/typecheck/lint) and a manual `pnpm run bundle` leaves it newer than
- * every source — neither triggers a redundant rebuild.
+ * on freshness, so it is a no-op when the bundle is already current: CI builds
+ * the bundle as the last step before vitest (after checkout/build/typecheck/
+ * lint) and a manual `pnpm run bundle` leaves it newer than every source —
+ * neither triggers a redundant rebuild.
  *
- * Only this file reads `dist/`, and vitest runs with `pool: "forks"`, so the
- * rebuild (which wipes + recreates `dist/`) cannot race any other test file.
+ * The rebuild wipes + recreates `dist/`, but nothing else reads `dist/` during
+ * a test run: vitest's top-level `resolve.alias` (vitest.config.ts) redirects
+ * every `@loreai/*` import — including the variable dynamic imports in
+ * gateway-smoke and the opencode plugin — to `src`, and core's worker_threads
+ * resolve to their `.ts` siblings under vitest, never `dist/`. With
+ * `pool: "forks"` on top, the rebuild cannot race another test file.
  */
 import { beforeAll, describe, test, expect } from "vitest";
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
@@ -43,7 +49,7 @@ const cjsBundlePath = join(distDir, "index.cjs");
 const bunBundlePath = join(distDir, "index.bun.js");
 
 /** Newest mtime (ms) across the given files/directories; dirs walk recursively.
- *  Unreadable paths are skipped so a broken symlink can't crash the suite. */
+ *  Unreadable files/dirs are skipped rather than crashing the walk. */
 function newestMtimeMs(roots: string[]): number {
   let newest = 0;
   const stack = [...roots];
@@ -56,7 +62,11 @@ function newestMtimeMs(roots: string[]): number {
       continue;
     }
     if (st.isDirectory()) {
-      for (const entry of readdirSync(p)) stack.push(join(p, entry));
+      try {
+        for (const entry of readdirSync(p)) stack.push(join(p, entry));
+      } catch {
+        // Unreadable directory — skip it rather than crash the walk.
+      }
     } else if (st.mtimeMs > newest) {
       newest = st.mtimeMs;
     }
@@ -77,27 +87,36 @@ function oldestMtimeMs(files: string[]): number {
   return Number.isFinite(oldest) ? oldest : 0;
 }
 
-// The bundle is fresh iff both asserted artifacts exist and are at least as new
-// as every input the bundle is built from: gateway/src + core/src (both inlined
-// into the bundle), the build config (bundle.ts) and the manifest (package.json,
-// which drives the files/exports/deps assertions).
+// The bundle is fresh iff both asserted artifacts exist and are strictly newer
+// than every source the bundle is built from:
+//   - gateway/src + core/src — both inlined into the bundle;
+//   - script/ — the whole build-script dir, since bundle.ts imports siblings
+//     (the ORT plugins, debug-id, import-meta-url); tracking only bundle.ts
+//     would miss a build change made in one of those and falsely report fresh;
+//   - package.json — drives the files/exports/deps assertions.
+// Dependency upgrades (node_modules / the ORT wasm) are intentionally NOT
+// tracked here — those arrive via `pnpm install`, whose postinstall rebuilds the
+// bundle. Ties resolve toward rebuilding (strict `>`): a rebuild is cheap and
+// always correct, so err on that side rather than risk asserting against a
+// same-timestamp stale artifact.
 function isBundleFresh(): boolean {
   const newestSource = newestMtimeMs([
     join(packageDir, "src"),
     coreSrcDir,
-    join(packageDir, "script", "bundle.ts"),
+    join(packageDir, "script"),
     join(packageDir, "package.json"),
   ]);
   const oldestArtifact = oldestMtimeMs([cjsBundlePath, bunBundlePath]);
-  return oldestArtifact > 0 && oldestArtifact >= newestSource;
+  return oldestArtifact > 0 && oldestArtifact > newestSource;
 }
 
 describe("bundle exports", () => {
   // Build the bundle from current source when it is missing or stale, so the
   // assertions below never run against an artifact that predates source (see
   // the file header for why skipping would be a local footgun). No-op when the
-  // bundle is already fresh — CI's `pretest` and a manual `pnpm run bundle`
-  // both leave it newer than every source, so this never double-builds.
+  // bundle is already fresh — CI's pre-vitest bundle build and a manual
+  // `pnpm run bundle` both leave it newer than every source, so this never
+  // double-builds.
   beforeAll(() => {
     if (isBundleFresh()) return;
     process.stderr.write(
@@ -164,10 +183,10 @@ describe("bundle exports", () => {
     // external-core runtime dep and its ~480 MB ML tree (#1024/#1026).
     const content = readFileSync(join(distDir, "index.bun.js"), "utf8");
 
-    // Dev shim (`export * from "../src/index.ts";`) is not the real artifact,
-    // so there is nothing to assert. The real minified bundle is present under
-    // `pnpm test` because the root `pretest` runs
-    // `pnpm --filter @loreai/gateway run bundle`.
+    // Defensive: the `beforeAll` above guarantees a freshly-built (real,
+    // minified) bundle, so this dev-shim (`export * from "../src/index.ts"`)
+    // branch is normally unreachable. Kept so a hand-placed shim degrades to a
+    // no-op assert instead of scanning re-export syntax.
     if (content.trimStart().startsWith("export *")) return;
 
     // Match import CONTEXTS only — static `from "@loreai/x"` and dynamic

--- a/packages/gateway/test/bundle-exports.test.ts
+++ b/packages/gateway/test/bundle-exports.test.ts
@@ -4,38 +4,35 @@
  * Verifies that:
  * - Every file referenced by package.json `files` and `exports` exists
  * - The CJS Node bundle uses node:sqlite (not bun:sqlite)
- * - The imported module exports the expected public API
+ * - @loreai/core is inlined (not externalized) in the Bun bundle (#1027)
  *
- * Requires the bundle (`pnpm --filter @loreai/gateway run bundle`) to have
- * been built AND to be up to date with its sources. The root `pretest` script
- * rebuilds the bundle before `pnpm test`, so it is always fresh there (local +
- * CI). The skip guard is defensive — it should never trigger under `pnpm test`.
+ * These assert on the built `dist/` artifacts. The root `pretest` hook rebuilds
+ * the bundle before `pnpm test`, but NOT for `vitest --watch`, IDE test
+ * runners, or a direct `vitest run`. After pulling a change to the bundle's
+ * inputs (e.g. #1027 inlining @loreai/core) WITHOUT rebuilding, those launch
+ * paths would otherwise assert against a stale/missing artifact that no longer
+ * reflects source — the "bundle-export tests are failing on latest main" trap.
  *
- * Two conditions cause a skip (a skip, never a confusing assertion failure):
+ * Rather than SKIP when the artifact is stale/missing (which silently drops
+ * these checks in the local dev loop — a footgun), the suite REBUILDS the
+ * bundle on demand in `beforeAll`, so it always runs against a bundle built
+ * from current source no matter how vitest was launched. The rebuild is gated
+ * on freshness, so it is a no-op when the bundle is already current: in CI
+ * `pretest` writes the bundle as the last step before vitest (after checkout/
+ * build/typecheck/lint) and a manual `pnpm run bundle` leaves it newer than
+ * every source — neither triggers a redundant rebuild.
  *
- *  1. MISSING bundle — a dev checkout that only ran `pnpm install` has the
- *     `index.bun.js` dev shim but no `index.cjs`, so there is nothing to check.
- *
- *  2. STALE bundle — `dist/` is older than the sources it is built from. This
- *     is the trap behind "bundle-export tests are failing on latest main":
- *     `pretest` only runs for `pnpm test`, NOT for `vitest --watch`, IDE test
- *     runners, or a direct `vitest run`. After pulling a change to the bundle's
- *     inputs (e.g. #1027 inlining @loreai/core) WITHOUT rebuilding, those launch
- *     paths assert against a stale artifact that no longer reflects source — a
- *     false failure. Treat a stale bundle like a missing one and point the dev
- *     at `pnpm --filter @loreai/gateway run bundle`.
- *
- * This never weakens CI: `pretest` writes the bundle AFTER checkout/build/
- * typecheck/lint (the last write before vitest), so the artifact mtime is
- * always newer than every source there — CI is never stale and always runs the
- * checks strictly.
+ * Only this file reads `dist/`, and vitest runs with `pool: "forks"`, so the
+ * rebuild (which wipes + recreates `dist/`) cannot race any other test file.
  */
-import { describe, test, expect } from "vitest";
+import { beforeAll, describe, test, expect } from "vitest";
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const packageDir = join(fileURLToPath(import.meta.url), "..", "..");
+const repoRoot = join(packageDir, "..", "..");
 const distDir = join(packageDir, "dist");
 const coreSrcDir = join(packageDir, "..", "core", "src");
 const pkgJson = JSON.parse(
@@ -44,7 +41,6 @@ const pkgJson = JSON.parse(
 
 const cjsBundlePath = join(distDir, "index.cjs");
 const bunBundlePath = join(distDir, "index.bun.js");
-const hasBundle = existsSync(cjsBundlePath);
 
 /** Newest mtime (ms) across the given files/directories; dirs walk recursively.
  *  Unreadable paths are skipped so a broken symlink can't crash the suite. */
@@ -68,7 +64,7 @@ function newestMtimeMs(roots: string[]): number {
   return newest;
 }
 
-/** Oldest mtime (ms) across the given files; a missing file counts as 0 (stale). */
+/** Oldest mtime (ms) across the given files; a missing file counts as 0. */
 function oldestMtimeMs(files: string[]): number {
   let oldest = Number.POSITIVE_INFINITY;
   for (const f of files) {
@@ -81,34 +77,50 @@ function oldestMtimeMs(files: string[]): number {
   return Number.isFinite(oldest) ? oldest : 0;
 }
 
-// The bundle inlines gateway/src + core/src; bundle.ts is its build config and
-// package.json drives the files/exports/deps assertions. If any of these is
-// newer than the built artifacts, the artifacts predate the current source.
-const newestSourceMtime = hasBundle
-  ? newestMtimeMs([
-      join(packageDir, "src"),
-      coreSrcDir,
-      join(packageDir, "script", "bundle.ts"),
-      join(packageDir, "package.json"),
-    ])
-  : 0;
-const oldestArtifactMtime = hasBundle
-  ? oldestMtimeMs([cjsBundlePath, bunBundlePath])
-  : 0;
-const bundleStale = hasBundle && newestSourceMtime > oldestArtifactMtime;
-
-if (bundleStale) {
-  console.warn(
-    "[bundle-exports] dist/ bundle is older than its sources — skipping " +
-      "bundle-content checks. Run `pnpm --filter @loreai/gateway run bundle` " +
-      "to refresh it (the root `pretest` hook does this automatically under " +
-      "`pnpm test`).",
-  );
+// The bundle is fresh iff both asserted artifacts exist and are at least as new
+// as every input the bundle is built from: gateway/src + core/src (both inlined
+// into the bundle), the build config (bundle.ts) and the manifest (package.json,
+// which drives the files/exports/deps assertions).
+function isBundleFresh(): boolean {
+  const newestSource = newestMtimeMs([
+    join(packageDir, "src"),
+    coreSrcDir,
+    join(packageDir, "script", "bundle.ts"),
+    join(packageDir, "package.json"),
+  ]);
+  const oldestArtifact = oldestMtimeMs([cjsBundlePath, bunBundlePath]);
+  return oldestArtifact > 0 && oldestArtifact >= newestSource;
 }
 
-const bundleReady = hasBundle && !bundleStale;
+describe("bundle exports", () => {
+  // Build the bundle from current source when it is missing or stale, so the
+  // assertions below never run against an artifact that predates source (see
+  // the file header for why skipping would be a local footgun). No-op when the
+  // bundle is already fresh — CI's `pretest` and a manual `pnpm run bundle`
+  // both leave it newer than every source, so this never double-builds.
+  beforeAll(() => {
+    if (isBundleFresh()) return;
+    process.stderr.write(
+      "[bundle-exports] dist/ bundle missing or stale — building it " +
+        "(pnpm --filter @loreai/gateway run bundle)…\n",
+    );
+    try {
+      execFileSync("pnpm", ["--filter", "@loreai/gateway", "run", "bundle"], {
+        cwd: repoRoot,
+        stdio: "pipe",
+        encoding: "utf8",
+      });
+    } catch (err) {
+      const e = err as { stdout?: string; stderr?: string; message?: string };
+      throw new Error(
+        "Failed to build the @loreai/gateway bundle required by " +
+          "bundle-exports.test.ts. Run `pnpm --filter @loreai/gateway run " +
+          "bundle` to reproduce.\n" +
+          `${e.stderr ?? ""}${e.stdout ?? ""}${e.message ?? String(err)}`,
+      );
+    }
+  }, 300_000);
 
-describe.skipIf(!bundleReady)("bundle exports", () => {
   // -------------------------------------------------------------------------
   // Layer 1: Static content checks
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Root cause

The `bundle-exports` suite asserts on **pre-built `dist/` artifacts** — e.g. that `index.bun.js` inlines `@loreai/core` (#1027) and that `index.cjs` uses `node:sqlite`. Those artifacts are only kept in sync with source by a bundle build that runs immediately before vitest under `pnpm test` (root `pretest` hook) and `pnpm run test:coverage` (its own `bundle &&` chain, which CI uses).

That build does **not** run for `vitest --watch`, IDE / editor test runners, or a direct `vitest run packages/gateway/test/bundle-exports.test.ts`. So after pulling a change to the bundle's inputs (e.g. the #1027 inline-core change) **without rebuilding**, those launch paths assert against a stale `dist/` that still externalizes core, and fail:

```
× @loreai/core is inlined (not externalized) in the Bun bundle (#1027)
  AssertionError: expected true to be false
```

The **source and manifests are correct** — only the on-disk artifact is stale. `origin/main` CI is green precisely because it always rebuilds first. Reproduced exactly by dropping a pre-#1027 (externalized-core) `index.bun.js` into a fresh `main` checkout.

## Fix

Instead of **skipping** when the bundle is missing/stale (which silently drops these checks in the local dev loop — the same footgun that hid the stale artifact), the suite **rebuilds the bundle on demand** in `beforeAll`, so the assertions always run against a bundle built from current source no matter how vitest was launched.

The rebuild is gated on an mtime freshness check, so it is a **no-op when the bundle is already current**:
- CI builds the bundle as the **last** step before vitest (after checkout → `build` → `typecheck` → `lint`), so the artifact is always newer than every source → no rebuild, no double build.
- A manual `pnpm run bundle` likewise leaves it fresh.

Freshness compares the built artifacts against **all** the bundle's sources: `gateway/src` + `core/src` (inlined), the whole `script/` build-script dir (`bundle.ts` **and everything it imports** — the ORT plugins, debug-id, import-meta-url), and `package.json`. Ties resolve toward rebuilding.

**Race-freedom:** the rebuild wipes + recreates `dist/`, but nothing else reads `dist/` during a test run — vitest's top-level `resolve.alias` redirects every `@loreai/*` import (including the *variable* dynamic imports in gateway-smoke and the opencode plugin) to `src`, and core's `worker_threads` resolve to their `.ts` siblings under vitest, never `dist/`. With `pool: "forks"` on top, the rebuild can't collide with another test file. A build failure **throws** with guidance rather than skipping — loud, not silent. `execSync` (shell) resolves `pnpm.cmd` on Windows.

| State | Before | After |
|---|---|---|
| Fresh bundle (CI / `pnpm test` / after `pnpm run bundle`) | 7 pass | 7 pass, no rebuild (~670ms) |
| Missing bundle (`pnpm install` only) | block skipped | rebuilds → 7 pass |
| **Stale bundle** (watch / IDE / direct `vitest run`) | **1 false FAIL** | rebuilds → 7 pass |

## Review

Independently reviewed by an adversarial subagent (READ-ONLY, mutation/harness-verified): overall **SHIP-WITH-FOLLOWUPS, no blockers**. The one SHOULD-FIX (freshness set only tracked `bundle.ts`, so a change to another build script would falsely report fresh) and all NITs (mtime tie-break, `newestMtimeMs` readdir resilience, CI/`pretest` attribution, dead shim comment) are addressed in the final commits. Verified: touching `script/debug-id.ts` now triggers a rebuild; fresh/missing/stale all pass 7/7; `typecheck` + `biome` clean.