### PR TITLE
refactor(gateway): drop dead capitalized x-goog-api-key check

### DIFF
--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -293,11 +293,13 @@ async function handleGeminiGenerateContent(
     return errorResponse(400, "invalid_request_error", "Invalid JSON body");
   }
 
+  // headersToRecord lowercases every key (Web Headers API), so `x-goog-api-key`
+  // is the only case that can be present here.
   const headers = headersToRecord(req.headers);
   // Normalize `?key=` query-form auth (REST / google-generativeai clients) to
   // the `x-goog-api-key` header — the upstream URL is rebuilt, so a query param
   // would otherwise be dropped and the call would 401. Header form wins.
-  if (!headers["x-goog-api-key"] && !headers["X-Goog-Api-Key"]) {
+  if (!headers["x-goog-api-key"]) {
     const key = new URL(req.url).searchParams.get("key");
     if (key) headers["x-goog-api-key"] = key;
   }


### PR DESCRIPTION
Addresses the one Seer comment on #1159 (LOW).

`headersToRecord` lowercases every key (Web Headers API `forEach`), so the `X-Goog-Api-Key` branch in the `?key=` auth-normalization guard (`server.ts`) was unreachable dead code. The lowercase `x-goog-api-key` check is sufficient.

`auth.ts:49` intentionally keeps its dual-case (`x-goog-api-key || X-Goog-Api-Key`) to match the adjacent pre-existing `authorization || Authorization` defensive convention in the same function — left as-is for consistency.

The `?key=` ingress e2e (added in #1159) still passes and guards the behavior.