### PR TITLE
fix(core): clamp embedding memory sizing to the cgroup limit (container OOM)

### DIFF
--- a/packages/core/src/embedding-cap.ts
+++ b/packages/core/src/embedding-cap.ts
@@ -129,6 +129,33 @@ export function desiredEmbedPoolSize(
   return Math.min(ceiling, affordable);
 }
 
+/**
+ * Clamp host-reported free memory to the container's cgroup memory limit.
+ *
+ * `constrained` is `process.constrainedMemory()` — the cgroup memory limit in
+ * bytes, or `0` when the process is unconstrained (bare metal / VM) or the limit
+ * is unknown. Inside a memory-capped container `os.freemem()` reports the HOST's
+ * free memory (cgroup-blind), which can be many times larger than the container
+ * can actually allocate: the pool then spawns unbounded native-ONNX workers and
+ * sizes over-large token caps, and the cgroup OOM-killer SIGKILLs the process —
+ * uncatchable, so the ×0.7 OOM backoff never fires (the WASM path self-limited
+ * against its fixed 4 GiB heap; native has no such wall). Clamping to the limit
+ * caps every freemem-derived decision at what the container can actually provide.
+ *
+ * No-op whenever the process is unconstrained (`constrained <= 0`) or the limit
+ * is at least the host free figure (roomy container / bare metal): it returns
+ * `hostFree` unchanged, so sizing is byte-identical to the pre-cgroup behavior
+ * except on a container whose limit is below host-reported free. Monotonic — it
+ * can only lower the figure, never raise it, so it never increases memory use.
+ */
+export function clampFreeToContainerLimit(
+  hostFree: number,
+  constrained: number,
+): number {
+  if (!Number.isFinite(constrained) || constrained <= 0) return hostFree;
+  return Math.min(hostFree, constrained);
+}
+
 /** Clamp a raw cap estimate into the valid [MIN, MODEL_MAX] range. */
 export function clampEmbedCap(n: number): number {
   if (!Number.isFinite(n)) return MIN_EMBED_TOKENS;

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -44,6 +44,7 @@ import {
   PER_WORKER_MEM_BUDGET_BYTES,
   EMBED_POOL_ABS_MAX,
   backoffEmbedCap,
+  clampFreeToContainerLimit,
   desiredEmbedPoolSize,
   memoryModelEmbedCap,
   reconcileEmbedCap,
@@ -131,9 +132,40 @@ function readPersistedEmbedCap(): PersistedEmbedCap | null {
   }
 }
 
+/** Test seam: override `process.constrainedMemory()` for container-aware sizing
+ *  tests (null → use the real value). */
+let testConstrainedMemoryBytes: number | null = null;
+export function _setConstrainedMemoryForTest(bytes: number | null): void {
+  testConstrainedMemoryBytes = bytes;
+}
+
+/** The process's cgroup memory limit in bytes, or `0` if unconstrained / unknown
+ *  / unsupported by the runtime. `process.constrainedMemory()` is libuv-backed
+ *  (cgroup v1 + v2, no hard-coded paths) and returns `0` when unconstrained; it
+ *  is present in both Node (≥18.15) and Bun. Read live — the paths that consume
+ *  it (pool growth, cap init/re-probe) are infrequent, not per-embed. */
+function constrainedMemoryLimit(): number {
+  if (testConstrainedMemoryBytes != null) return testConstrainedMemoryBytes;
+  const fn = (process as { constrainedMemory?: () => number })
+    .constrainedMemory;
+  const v = typeof fn === "function" ? fn() : 0;
+  return Number.isFinite(v) && v > 0 ? v : 0;
+}
+
+/** Container-aware live free memory: `os.freemem()` clamped to the cgroup memory
+ *  limit ({@link clampFreeToContainerLimit}) so no sizing decision trusts
+ *  host-level free memory inside a memory-capped container. A no-op (returns
+ *  `freemem()` unchanged) when unconstrained or when the container limit exceeds
+ *  host-reported free — so behavior on non-containerized / roomy hosts is
+ *  identical to the pre-cgroup path. Use this for every memory-SIZING read;
+ *  telemetry keeps raw `freemem()` so host vs container stays diagnosable. */
+function containerFreeBytes(): number {
+  return clampFreeToContainerLimit(freemem(), constrainedMemoryLimit());
+}
+
 function persistEmbedCap(
   cap: number,
-  freeMemBytes: number = freemem(),
+  freeMemBytes: number = containerFreeBytes(),
   knownBadCap = 0,
 ): void {
   try {
@@ -163,7 +195,7 @@ function persistEmbedCap(
 function computeInitialEmbedCap(
   persisted: PersistedEmbedCap | null = readPersistedEmbedCap(),
 ): number {
-  const free = freemem();
+  const free = containerFreeBytes();
   return reconcileEmbedCap(
     free,
     persisted,
@@ -522,7 +554,7 @@ class LocalProvider implements EmbeddingProvider {
     const persisted = readPersistedEmbedCap();
     this.lastOomCap = persisted?.knownBadCap ?? 0;
     this.maxTokens = computeInitialEmbedCap(persisted);
-    this.capFreememAtLearn = freemem();
+    this.capFreememAtLearn = containerFreeBytes();
   }
 
   /**
@@ -777,7 +809,7 @@ class LocalProvider implements EmbeddingProvider {
     const now = Date.now();
     if (now - this.lastReprobeAt < EMBED_REPROBE_INTERVAL_MS) return;
     this.lastReprobeAt = now;
-    const free = freemem();
+    const free = containerFreeBytes();
     if (!shouldReprobeEmbedCap(free, this.capFreememAtLearn)) return;
     const next = reprobeEmbedCap(this.maxTokens, free, this.lastOomCap);
     if (next <= this.maxTokens) return;
@@ -847,7 +879,7 @@ class LocalProvider implements EmbeddingProvider {
       return;
     }
 
-    const free = freemem();
+    const free = containerFreeBytes();
     const capAfter = backoffEmbedCap(capBefore);
     this.maxTokens = capAfter;
     // Remember the cap that just OOMed so the upward re-probe never climbs back
@@ -1143,9 +1175,14 @@ class EmbeddingPool implements EmbeddingProvider {
     return best;
   }
 
-  /** Free memory for the live per-spawn gate; overridable in tests. */
+  /** Container-aware free memory for the live per-spawn gate: the injected test
+   *  value (or live `freemem()`) clamped to the cgroup limit, so a memory-capped
+   *  container never spawns a second native-ONNX worker off the host's (much
+   *  larger) free figure. Overridable in tests via {@link _setPoolFreememForTest}
+   *  (host free) and {@link _setConstrainedMemoryForTest} (the cgroup limit). */
   private liveFreemem(): number {
-    return testPoolFreememBytes != null ? testPoolFreememBytes : freemem();
+    const raw = testPoolFreememBytes != null ? testPoolFreememBytes : freemem();
+    return clampFreeToContainerLimit(raw, constrainedMemoryLimit());
   }
 
   private spawnSlot(): EmbedSlot {

--- a/packages/core/test/embedding-cap.test.ts
+++ b/packages/core/test/embedding-cap.test.ts
@@ -8,6 +8,7 @@ import {
   EMBED_TOKEN_CEILING,
   backoffEmbedCap,
   clampEmbedCap,
+  clampFreeToContainerLimit,
   desiredEmbedPoolSize,
   memoryModelEmbedCap,
   reconcileEmbedCap,
@@ -16,6 +17,74 @@ import {
 } from "../src/embedding-cap";
 
 const GB = 1024 * 1024 * 1024;
+const MB = 1024 * 1024;
+
+describe("clampFreeToContainerLimit", () => {
+  it("is a no-op when unconstrained (constrained <= 0)", () => {
+    // process.constrainedMemory() returns 0 on bare metal / VM without a cgroup
+    // limit → host freemem is authoritative, returned unchanged.
+    expect(clampFreeToContainerLimit(7 * GB, 0)).toBe(7 * GB);
+  });
+
+  it("is a no-op for an invalid/unknown limit (NaN, negative)", () => {
+    expect(clampFreeToContainerLimit(7 * GB, Number.NaN)).toBe(7 * GB);
+    expect(clampFreeToContainerLimit(7 * GB, -1)).toBe(7 * GB);
+  });
+
+  it("is a no-op when the container limit is >= host free (roomy container)", () => {
+    // Burak's box: freemem 6.72 GiB under a 12 GiB cgroup cap → returns freemem
+    // unchanged, so every downstream sizing decision is byte-identical.
+    const hostFree = Math.round(6.72 * GB);
+    expect(clampFreeToContainerLimit(hostFree, 12 * GB)).toBe(hostFree);
+  });
+
+  it("clamps to the limit when the container cap is below host free", () => {
+    // Railway: host reports 7 GiB free but the container is capped at 512 MiB.
+    expect(clampFreeToContainerLimit(7 * GB, 512 * MB)).toBe(512 * MB);
+  });
+
+  it("never raises the figure (monotonic — can only reduce memory use)", () => {
+    for (const limit of [0, 256 * MB, 4 * GB, 12 * GB, 128 * GB]) {
+      expect(clampFreeToContainerLimit(6 * GB, limit)).toBeLessThanOrEqual(
+        6 * GB,
+      );
+    }
+  });
+});
+
+describe("cgroup-aware sizing (clamp composed with pool + cap)", () => {
+  it("keeps the pool at 1 on a tiny container even when host free is huge", () => {
+    // Host lies (7 GiB free) but the cgroup cap is 512 MiB — can't fit even one
+    // full per-worker budget, so the pool must stay at the primary worker.
+    const clamped = clampFreeToContainerLimit(7 * GB, 512 * MB);
+    expect(desiredEmbedPoolSize(clamped)).toBe(1);
+    // Non-vacuous: WITHOUT the clamp the host figure would grow the pool to 2.
+    expect(desiredEmbedPoolSize(7 * GB)).toBe(DEFAULT_MAX_EMBED_POOL);
+  });
+
+  it("scales the per-embed token cap down to the floor on a tiny container", () => {
+    // 384 MiB cap: after the ~680 MB baseline there's no room for attention, so
+    // the memory model floors the token cap (bounds the O(L²) allocation) —
+    // the native primary worker self-limits instead of OOM-killing the cgroup.
+    const clamped = clampFreeToContainerLimit(7 * GB, 384 * MB);
+    expect(memoryModelEmbedCap(clamped)).toBe(MIN_EMBED_TOKENS);
+    // Non-vacuous: the unclamped host figure pins the cap at the ceiling.
+    expect(memoryModelEmbedCap(7 * GB)).toBe(EMBED_TOKEN_CEILING);
+  });
+
+  it("does not change sizing on a roomy/constrained host (Burak's box)", () => {
+    // constrainedMemory() = 12 GiB, freemem in the range this box actually sees.
+    // The clamp is the identity, so pool size AND token cap are unchanged.
+    for (const hostFree of [1 * GB, 3 * GB, Math.round(6.72 * GB), 7 * GB]) {
+      const clamped = clampFreeToContainerLimit(hostFree, 12 * GB);
+      expect(clamped).toBe(hostFree);
+      expect(desiredEmbedPoolSize(clamped)).toBe(
+        desiredEmbedPoolSize(hostFree),
+      );
+      expect(memoryModelEmbedCap(clamped)).toBe(memoryModelEmbedCap(hostFree));
+    }
+  });
+});
 
 describe("clampEmbedCap", () => {
   it("clamps below the floor up to MIN_EMBED_TOKENS", () => {

--- a/packages/core/test/embedding-pool.test.ts
+++ b/packages/core/test/embedding-pool.test.ts
@@ -9,6 +9,7 @@ import {
   _resetLocalProviderProbe,
   _restoreProvider,
   _saveAndClearProvider,
+  _setConstrainedMemoryForTest,
   _setEmbedPoolSizeForTest,
   _setPoolFreememForTest,
   _setRecallEmbedsInFlightForTest,
@@ -110,6 +111,10 @@ describe("EmbeddingPool dispatch (#999)", () => {
     delete process.env.VOYAGE_API_KEY;
     delete process.env.OPENAI_API_KEY;
     delete process.env.LORE_EMBED_POOL_SIZE;
+    // Neutralize any real cgroup limit on the CI box so the _setPoolFreememForTest
+    // injections drive the live gate deterministically (the clamp is a no-op at
+    // limit 0). The container-aware test below opts back in explicitly.
+    _setConstrainedMemoryForTest(0);
     _resetLocalProviderProbe();
     savedProvider = _saveAndClearProvider();
   });
@@ -118,6 +123,7 @@ describe("EmbeddingPool dispatch (#999)", () => {
     _setTestWorkerFactory(null);
     _setEmbedPoolSizeForTest(null);
     _setPoolFreememForTest(null);
+    _setConstrainedMemoryForTest(null);
     _setRecallEmbedsInFlightForTest(0); // defensive: don't leak a stuck count
     _resetLocalProviderProbe();
     _restoreProvider(savedProvider);
@@ -181,6 +187,29 @@ describe("EmbeddingPool dispatch (#999)", () => {
     await flush();
 
     // Both requests queue on the one worker rather than loading a second model.
+    expect(fakes).toHaveLength(1);
+    expect(fakes[0].embedIds).toHaveLength(2);
+
+    fakes[0].completeAll();
+    expect(await p1).toHaveLength(1);
+    expect(await p2).toHaveLength(1);
+  });
+
+  it("stays at a single worker when the cgroup limit can't fit a second (container-aware)", async () => {
+    // The regression that OOM-killed Aditya's Railway container: host freemem is
+    // huge (os.freemem() is cgroup-blind) so the old gate would spawn a second
+    // native-ONNX worker and blow past the container's memory.max → SIGKILL.
+    _setEmbedPoolSizeForTest(2); // ceiling allows 2...
+    _setPoolFreememForTest(64 * GB); // ...and the HOST reports ample free...
+    _setConstrainedMemoryForTest(256 * 1024 * 1024); // ...but the container cap is 256 MiB.
+    const fakes = installFakeWorkers();
+
+    const p1 = embed(["alpha"], "query");
+    const p2 = embed(["beta"], "query");
+    await flush();
+
+    // Clamped to 256 MiB (< one per-worker budget), the pool must NOT load a
+    // second model despite the ceiling and the host's 64 GiB free figure.
     expect(fakes).toHaveLength(1);
     expect(fakes[0].embedIds).toHaveLength(2);
 


### PR DESCRIPTION
## Problem

**0.35.0 crashes OpenCode ~2 min after a prompt on small Docker/Railway deployments** (reported by @MathurAditya724 running [`outpost`](https://github.com/MathurAditya724/outpost) on Railway; 0.34.0 works fine). The SIGKILL never reaches Sentry — there are **zero error events on release 0.35.0**, only N+1 perf issues.

## Root cause

`os.freemem()` is **cgroup-blind**: inside a memory-capped container it reports the *host's* free RAM (e.g. 7 GiB) rather than the container limit (e.g. 512 MiB). Two changes that both landed in 0.35.0 turn that into an OOM:

- **native ONNX Runtime** (#1143/#1149) — native RSS is unbounded; 0.34.0's WASM path self-capped against its fixed 4 GiB heap (`EMBED_WASM_HEAP_MAX_BYTES`).
- **memory-gated embedding worker pool** (#1115) — `EmbeddingPool` spawns extra native-ONNX workers (~1.13 GiB budget each) and `memoryModelEmbedCap` sizes token caps, all off `freemem()`.

Fed the host's huge free figure, the pool over-spawns and over-sizes, blows past the container's `memory.max`, and the cgroup OOM-killer **SIGKILLs the whole process** — uncatchable, so the ×0.7 OOM backoff never fires.

## Fix

Clamp every freemem-derived **sizing** read to `process.constrainedMemory()` — the cgroup memory limit, libuv-backed (cgroup v1 + v2, **no hard-coded `/sys/fs/cgroup` paths**), returning `0` when unconstrained. Present in both Node (≥18.15) and Bun (verified).

```ts
containerFreeBytes = min(os.freemem(), constrainedMemory() || Infinity)
```

Threaded through the pool ceiling + live spawn gate, initial cap, upward re-probe, and OOM-backoff baseline. Telemetry keeps raw `freemem()` so host-vs-container stays diagnosable.

### No behavior change on unconstrained / roomy hosts
The clamp is the **identity** whenever `constrainedMemory()` is `0` (bare metal / VM) or `>= host free` (roomy container). It's **monotonic** — it can only *lower* the figure, never raise it. Verified against a real box (12 GiB cgroup cap, 6.72 GiB freemem): every sizing decision is byte-identical. It only bites when the cgroup limit is *below* host-reported free — exactly the misleading-container case.

## Testing
- Pure `clampFreeToContainerLimit` unit tests (identity when unconstrained/roomy, clamp when tight, monotonic).
- Composition: tiny container ⇒ pool stays at 1 and token cap floors; roomy config ⇒ pool/cap unchanged.
- Pool wiring: ample host freemem (64 GiB) + 256 MiB cgroup limit ⇒ no second worker spawns.
- **Mutation-verified**: reverting the clamp reds exactly the tight-container cases while identity/no-op cases stay green.
- Full `embedding-*` suite (212 passed), `tsc --noEmit`, Biome all clean.

## Follow-up (separate PR)
ORT's intra-op thread pool is *also* cgroup-blind (sizes to host cores → per-thread arenas inflate RSS). Capping `intraOpNumThreads` via `os.availableParallelism()` (cgroup-CPU-aware) further bounds per-worker RSS — shipping separately since it changes thread counts and needs its own perf validation.