### PR TITLE
fix(core): cap native ONNX intra-op threads to the cgroup CPU quota

### DIFF
--- a/packages/core/src/embedding-worker-types.ts
+++ b/packages/core/src/embedding-worker-types.ts
@@ -324,6 +324,14 @@ export interface WorkerInitData {
    *  bounds the O(L²) attention allocation and keeps a constrained host out of
    *  swap. */
   maxTokens: number;
+  /** Intra-op thread count for native ONNX Runtime, or `undefined` to leave
+   *  ORT's own (host-core-sized) default in place. Computed on the main thread
+   *  via `nativeIntraOpThreads()` (the worker runs as raw .ts and can't
+   *  value-import `ort-native` — same constraint as the stderr-silence flag
+   *  below): caps intra-op threads to the cgroup CPU quota only when the process
+   *  is genuinely CPU-restricted, else `undefined` (a strict no-op). The worker
+   *  applies it on the native path only; WASM is already single-threaded. */
+  intraOpThreads?: number;
   /** Vendored model info for binary mode, or null for npm mode.
    *  In binary mode, model files are pre-extracted to a local dir
    *  and we point transformers.js at that path instead of downloading

--- a/packages/core/src/embedding-worker.ts
+++ b/packages/core/src/embedding-worker.ts
@@ -336,10 +336,30 @@ async function loadPipeline(): Promise<void> {
   // CPU backend (multi-threaded). The npm dist-only bundle redirects
   // onnxruntime-node → onnxruntime-web, which serves "cpu" via its WASM+SIMD
   // backend (API-compatible).
-  pipe = (await pipeline("feature-extraction", modelId, {
+  // Native ORT sizes its intra-op thread pool to the HOST core count, which is
+  // cgroup-CPU-blind — a CPU-quota'd container oversubscribes (one memory arena
+  // per thread → RSS inflation). Cap it to the cgroup-aware parallelism on the
+  // native path only (WASM is already forced single-thread via env above). A
+  // strict no-op on unconstrained hosts (see nativeIntraOpThreads). `globals`
+  // (captured above) only carries __LORE_NPM_WASM_PATHS__ when the npm bundle
+  // fell back to WASM; every other path (SEA vendorModel, native binding,
+  // dev/test) is native onnxruntime-node.
+  const pipelineOptions: Record<string, unknown> = {
     dtype: "q8",
     device: "cpu",
-  })) as unknown as FeatureExtractionPipeline;
+  };
+  if (!globals.__LORE_NPM_WASM_PATHS__) {
+    const { nativeIntraOpThreads } = await import("./ort-native");
+    const intraOpNumThreads = nativeIntraOpThreads();
+    if (intraOpNumThreads !== undefined) {
+      pipelineOptions.session_options = { intraOpNumThreads };
+    }
+  }
+  pipe = (await pipeline(
+    "feature-extraction",
+    modelId,
+    pipelineOptions,
+  )) as unknown as FeatureExtractionPipeline;
 
   // Guard against Callable pattern failure: @huggingface/transformers
   // uses Object.setPrototypeOf(closure, new.target.prototype) in the

--- a/packages/core/src/embedding-worker.ts
+++ b/packages/core/src/embedding-worker.ts
@@ -57,6 +57,15 @@ const stderrSilenced = init.stderrSilenced ?? false;
 const maxTokens = init.maxTokens ?? 2048;
 
 /**
+ * Cgroup-CPU-aware intra-op thread count for native ONNX Runtime, or `undefined`
+ * to leave ORT's own (host-core-sized) default. Computed on the main thread via
+ * `nativeIntraOpThreads()` and passed in — the worker runs as raw .ts and can't
+ * value-import `ort-native` (see the classifier note below). Applied on the
+ * native path only; WASM is already forced single-thread via env.
+ */
+const intraOpThreads = init.intraOpThreads;
+
+/**
  * Worker exit code signalling an input-size-driven ONNX OOM that the main
  * thread recovers from by respawning at a lower token cap (fresh WASM heap).
  * Inlined here — kept in sync with embedding-worker-types.ts — because the
@@ -338,22 +347,19 @@ async function loadPipeline(): Promise<void> {
   // backend (API-compatible).
   // Native ORT sizes its intra-op thread pool to the HOST core count, which is
   // cgroup-CPU-blind — a CPU-quota'd container oversubscribes (one memory arena
-  // per thread → RSS inflation). Cap it to the cgroup-aware parallelism on the
-  // native path only (WASM is already forced single-thread via env above). A
-  // strict no-op on unconstrained hosts (see nativeIntraOpThreads). `globals`
-  // (captured above) only carries __LORE_NPM_WASM_PATHS__ when the npm bundle
-  // fell back to WASM; every other path (SEA vendorModel, native binding,
-  // dev/test) is native onnxruntime-node.
+  // per thread → RSS inflation). The main thread computed the cgroup-aware cap
+  // (nativeIntraOpThreads() → WorkerInitData.intraOpThreads; the worker runs as
+  // raw .ts and can't value-import ort-native — see maxTokens above), a strict
+  // no-op on unconstrained hosts. Apply it on the native path only — WASM is
+  // already forced single-thread via env above; `globals` (captured above) only
+  // carries __LORE_NPM_WASM_PATHS__ when the npm bundle fell back to WASM, so
+  // every other path (SEA vendorModel, native binding, dev/test) is native.
   const pipelineOptions: Record<string, unknown> = {
     dtype: "q8",
     device: "cpu",
   };
-  if (!globals.__LORE_NPM_WASM_PATHS__) {
-    const { nativeIntraOpThreads } = await import("./ort-native");
-    const intraOpNumThreads = nativeIntraOpThreads();
-    if (intraOpNumThreads !== undefined) {
-      pipelineOptions.session_options = { intraOpNumThreads };
-    }
+  if (intraOpThreads !== undefined && !globals.__LORE_NPM_WASM_PATHS__) {
+    pipelineOptions.session_options = { intraOpNumThreads: intraOpThreads };
   }
   pipe = (await pipeline(
     "feature-extraction",

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -139,11 +139,13 @@ export function _setConstrainedMemoryForTest(bytes: number | null): void {
   testConstrainedMemoryBytes = bytes;
 }
 
-/** The process's cgroup memory limit in bytes, or `0` if unconstrained / unknown
- *  / unsupported by the runtime. `process.constrainedMemory()` is libuv-backed
- *  (cgroup v1 + v2, no hard-coded paths) and returns `0` when unconstrained; it
- *  is present in both Node (≥18.15) and Bun. Read live — the paths that consume
- *  it (pool growth, cap init/re-probe) are infrequent, not per-embed. */
+/** The process's cgroup memory LIMIT in bytes (not free-within-limit), or `0` if
+ *  unconstrained / unknown / unsupported by the runtime. `process.constrainedMemory()`
+ *  is libuv-backed (cgroup v1 + v2, no hard-coded paths) and returns `0` when
+ *  unconstrained; it is present in both Node (≥18.15) and Bun. Read live: it's
+ *  cheap and the consuming paths are cap init/re-probe (infrequent) plus the pool
+ *  growth gate (only while all workers are busy and below the ceiling — never in
+ *  the single-worker or at-ceiling steady state). */
 function constrainedMemoryLimit(): number {
   if (testConstrainedMemoryBytes != null) return testConstrainedMemoryBytes;
   const fn = (process as { constrainedMemory?: () => number })
@@ -158,7 +160,14 @@ function constrainedMemoryLimit(): number {
  *  `freemem()` unchanged) when unconstrained or when the container limit exceeds
  *  host-reported free — so behavior on non-containerized / roomy hosts is
  *  identical to the pre-cgroup path. Use this for every memory-SIZING read;
- *  telemetry keeps raw `freemem()` so host vs container stays diagnosable. */
+ *  telemetry keeps raw `freemem()` so host vs container stays diagnosable.
+ *
+ *  Note the clamp uses the cgroup LIMIT, not free-within-limit: `min(hostFree,
+ *  limit)` can slightly overestimate available memory in a mid-size container
+ *  already using part of its budget, but that's deliberate — it's strictly ≤ the
+ *  pre-fix host figure, and the per-worker budget already reserves the transient
+ *  attention peak as headroom. Using cgroup free (`availableMemory()`) instead
+ *  would break the no-op guarantee on constrained-but-roomy hosts. */
 function containerFreeBytes(): number {
   return clampFreeToContainerLimit(freemem(), constrainedMemoryLimit());
 }

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -38,6 +38,7 @@ import * as log from "./log";
 import { recordVecReadLatency } from "./vec-latency";
 import { buildEmbeddingText, buildEmbeddingUnits } from "./embedding-units";
 import { vendorModelInfo } from "./embedding-vendor";
+import { nativeIntraOpThreads } from "./ort-native";
 import {
   MIN_EMBED_TOKENS,
   MODEL_MAX_TOKENS,
@@ -605,6 +606,10 @@ class LocalProvider implements EmbeddingProvider {
         modelId: this.modelId,
         dimensions: this.dimensions,
         maxTokens: this.maxTokens,
+        // Cgroup-CPU-aware native ORT intra-op cap, computed here on the main
+        // thread (the worker can't value-import ort-native). undefined = no-op
+        // (unconstrained host); applied on the native path only in the worker.
+        intraOpThreads: nativeIntraOpThreads(),
         vendorModel: vendor ? { localModelPath: vendor.localModelPath } : null,
         // Snapshot the host's silence state — the worker's own `globalThis`
         // can't see the main thread's flag (re-read on every OOM respawn).

--- a/packages/core/src/ort-native.ts
+++ b/packages/core/src/ort-native.ts
@@ -14,6 +14,7 @@
  * platform), resolution returns null and the worker falls back to WASM.
  */
 import { createRequire } from "node:module";
+import { availableParallelism, cpus } from "node:os";
 
 /** The npm target key for a platform: `<process.platform>-<process.arch>`
  *  (e.g. "linux-x64", "darwin-arm64", "win32-arm64"). Matches the package name
@@ -53,4 +54,40 @@ export function resolveNativeOrtBindingPath(fromPath: string): string | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * Intra-op thread count to hand native ONNX Runtime, or `undefined` to leave
+ * ORT's own default in place.
+ *
+ * Native ORT sizes its intra-op pool to `std::thread::hardware_concurrency()`
+ * (the HOST physical-core count), which is cgroup-CPU-blind. In a CPU-quota'd
+ * container (Docker/Railway/K8s) it oversubscribes: each intra-op thread carries
+ * its own memory arena, so a 1-vCPU container on a 32-core host spawns ~32
+ * threads → wasted RSS (the axis PR #1168's memory clamp doesn't cover) plus
+ * context-switch thrash against the quota.
+ *
+ * `os.availableParallelism()` is cgroup-CPU-aware (libuv `uv_available_parallelism`:
+ * cgroup v2 `cpu.max`, v1 CFS quota, `sched_getaffinity`). We cap ONLY when the
+ * process is genuinely restricted — `availableParallelism() < os.cpus().length`
+ * (the logical-core count `os.cpus()` reports from the host). On an unconstrained
+ * host the two are equal, so we return `undefined` and never touch ORT's default;
+ * critically, this also avoids RAISING the thread count above ORT's physical-core
+ * default on a hyper-threaded host (where logical > physical). So this is a
+ * strict no-op except inside a CPU-limited container, where it returns the
+ * quota-sized count (floored at 1) to stop the oversubscription.
+ */
+export function nativeIntraOpThreads(
+  parallelism: number = availableParallelism(),
+  logicalCpus: number = cpus().length,
+): number | undefined {
+  const avail =
+    Number.isFinite(parallelism) && parallelism >= 1
+      ? Math.floor(parallelism)
+      : 1;
+  const total =
+    Number.isFinite(logicalCpus) && logicalCpus >= 1
+      ? Math.floor(logicalCpus)
+      : avail;
+  return avail < total ? avail : undefined;
 }

--- a/packages/core/test/ort-native.test.ts
+++ b/packages/core/test/ort-native.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import {
   ORT_NATIVE_BINDING_FILE,
+  nativeIntraOpThreads,
   ortNativePackageName,
   ortPlatformTarget,
   resolveNativeOrtBindingPath,
@@ -46,5 +47,39 @@ describe("ort-native runtime resolution", () => {
     expect(
       resolveNativeOrtBindingPath("/nonexistent/lore-test/x.js"),
     ).toBeNull();
+  });
+});
+
+describe("nativeIntraOpThreads", () => {
+  test("returns undefined on an unconstrained host (avail == logical) — no-op", () => {
+    // ORT keeps its own physical-core default; we must not touch it.
+    expect(nativeIntraOpThreads(4, 4)).toBeUndefined();
+    expect(nativeIntraOpThreads(8, 8)).toBeUndefined();
+    expect(nativeIntraOpThreads(1, 1)).toBeUndefined();
+  });
+
+  test("returns undefined when avail exceeds logical (never raises threads)", () => {
+    // Defensive: availableParallelism should never exceed cpus().length, but if
+    // it did we must not push ORT ABOVE its physical-core default (RSS regression
+    // on hyper-threaded hosts).
+    expect(nativeIntraOpThreads(8, 4)).toBeUndefined();
+  });
+
+  test("caps to the cgroup-limited parallelism inside a CPU-quota'd container", () => {
+    // 2 vCPU quota on an 8-core host → cap intra-op threads to 2, not 8.
+    expect(nativeIntraOpThreads(2, 8)).toBe(2);
+    expect(nativeIntraOpThreads(1, 16)).toBe(1);
+  });
+
+  test("floors fractional / invalid parallelism, never below 1", () => {
+    expect(nativeIntraOpThreads(2.9, 8)).toBe(2);
+    expect(nativeIntraOpThreads(0, 8)).toBe(1);
+    expect(nativeIntraOpThreads(Number.NaN, 8)).toBe(1);
+    expect(nativeIntraOpThreads(-4, 8)).toBe(1);
+  });
+
+  test("defaults reflect the live host (>=1 or undefined, never throws)", () => {
+    const v = nativeIntraOpThreads();
+    expect(v === undefined || (Number.isInteger(v) && v >= 1)).toBe(true);
   });
 });


### PR DESCRIPTION
Companion to #1168. That PR fixed the **memory** axis of container cgroup-blindness; this fixes the **CPU/thread** axis.

## Problem
Native ONNX Runtime sizes its intra-op thread pool to `std::thread::hardware_concurrency()` — the **host** core count — which is cgroup-CPU-blind. In a CPU-quota'd container (Docker/Railway/K8s), a 1–2 vCPU container on a many-core host spawns host-core-count intra-op threads. Each intra-op thread carries its own ORT memory **arena**, so this inflates per-worker RSS (the axis the #1168 memory clamp doesn't cover) and thrashes on context switches against the quota. The worker comment already noted native "scales with cores (#999)" — that's exactly the unbounded behavior in a container.

## Fix
Pass `session_options.intraOpNumThreads = os.availableParallelism()` to the transformers.js pipeline on the **native path only**. `availableParallelism()` is cgroup-CPU-aware (libuv `uv_available_parallelism`: cgroup v2 `cpu.max`, v1 CFS quota, `sched_getaffinity`).

**Only caps when genuinely CPU-restricted** — `availableParallelism() < os.cpus().length`. `nativeIntraOpThreads()` returns `undefined` (leave ORT's default untouched) when the two are equal:
- **No-op on unconstrained hosts** (same guarantee as #1168; e.g. a 4-core dev box: `avail 4 == cpus 4` → `undefined`).
- Avoids *raising* threads above ORT's physical-core default on a **hyper-threaded** host (where logical > physical would otherwise oversubscribe).

WASM is untouched — it's already forced single-thread via `env.backends.onnx.wasm` in the worker. Native-path detection reuses the existing `__LORE_NPM_WASM_PATHS__` signal (set only when the npm bundle falls back to WASM).

## Also
Folds in two review-comment nits from #1168 (doc-only): the `constrainedMemory()` JSDoc (clarify it's the cgroup *limit*, not free-within-limit; the pool-growth gate is per-embed only during the growth window) and a limit≠free note on `containerFreeBytes`.

## Testing
- `nativeIntraOpThreads` unit tests: undefined on unconstrained (`avail==cpus`) and on `avail>cpus` (never raises); caps to the quota when constrained; floors fractional/invalid at 1.
- **Mutation-verified**: forcing "always cap" reds the 2 no-op guards; forcing "never cap" reds the 2 cap guards.
- Full `ort-native` + `embedding-*` suites (222 passed), `tsc --noEmit`, Biome all clean.

## Scope
With #1168 (over-spawn + over-size) + this (thread/arena oversubscription), both cgroup-blind axes are bounded. A single native worker's baseline model RSS can still exceed a sub-GB container — for those, `search.embeddings.provider: "voyage"/"openai"` or `search.embeddings.enabled: false` remain the escape hatches.