### PR TITLE
fix(core): self-heal a transient local-embedding init failure instead of latching

### DIFF
--- a/packages/core/src/embedding-worker-types.ts
+++ b/packages/core/src/embedding-worker-types.ts
@@ -305,6 +305,30 @@ export function shouldHealCorruptModel(
   return !isVendored && isCorruptModelError(errorMessage);
 }
 
+/** Minimum plausible size for a real ONNX model file. A truncated/aborted
+ *  download, an empty file, or an HTML error page saved as the model is far
+ *  smaller (the nomic q8 model is ~137 MB). Used to distinguish a genuinely
+ *  corrupt/partial file (safe to purge + re-download) from a transient parse
+ *  failure of an INTACT file (must NOT be destroyed — a failed re-download,
+ *  e.g. offline, would leave us worse off). */
+export const MIN_ONNX_FILE_BYTES = 1024 * 1024; // 1 MiB
+
+/**
+ * True when an on-disk ONNX file looks structurally intact: plausibly sized AND
+ * beginning with the ONNX/protobuf header byte. A serialized ONNX ModelProto
+ * starts with field 1 (`ir_version`), whose protobuf wire tag is `0x08`; a
+ * truncated head, an empty file, or a non-protobuf payload (HTML error page)
+ * fails this. Pure predicate (the worker performs the fs read); extracted for
+ * testability. When this is true a parse failure was almost certainly transient,
+ * so the corrupt-model self-heal must NOT purge the file.
+ */
+export function looksLikeIntactOnnxFile(
+  sizeBytes: number,
+  firstByte: number | undefined,
+): boolean {
+  return sizeBytes >= MIN_ONNX_FILE_BYTES && firstByte === 0x08;
+}
+
 // ---------------------------------------------------------------------------
 // workerData contract
 // ---------------------------------------------------------------------------

--- a/packages/core/src/embedding-worker.ts
+++ b/packages/core/src/embedding-worker.ts
@@ -213,26 +213,41 @@ async function ensurePipeline(): Promise<void> {
         // (the model ships in the binary — re-downloading isn't appropriate and
         // the path is read-only).
         if (!vendorModel && isCorruptModelError(msg)) {
-          const healed = await purgeCachedModel();
-          if (healed) {
-            // Diagnostic only — do NOT post `init-error` here. The main thread
-            // treats `init-error` as a permanent break (sets
-            // localProviderKnownBroken=true), which would brick the provider
-            // even though we're about to retry successfully. Only the .catch
-            // below (a genuine final failure) may post init-error.
-            // Gate on the host's stderr-silence flag (see WorkerInitData) — in a
-            // host TUI any raw byte corrupts the render. The flag is inlined here
-            // because the worker runs as raw .ts and can't value-import siblings.
+          // Integrity-gate the DESTRUCTIVE purge: if the model files are present,
+          // correctly sized, and start with a valid ONNX header, the parse
+          // failure was almost certainly transient — e.g. the file was read
+          // while a concurrent process was still writing it during a
+          // multi-instance restart. Deleting a good ~137 MB model then would be
+          // strictly worse (a failed re-download, e.g. offline, bricks it). Retry
+          // the load once WITHOUT purging; a fresh-worker respawn on the main
+          // thread (the init-retry cooldown) is the next line of defense.
+          // Gate diagnostics on the host's stderr-silence flag (see
+          // WorkerInitData) — a raw byte corrupts a host TUI render. Inlined
+          // because the worker runs as raw .ts and can't value-import siblings.
+          const intact = await cachedModelLooksIntact();
+          if (intact) {
             if (!stderrSilenced) {
               console.warn(
-                `[embedding-worker] model corrupt (${msg}); purged cache, retrying download once`,
+                `[embedding-worker] model parse failed but on-disk files look intact (${msg}); retrying load without purging`,
               );
             }
-            // Retry once. If this throws, it propagates to the .catch below and
-            // marks the worker permanently failed.
+            // Retry once. If it still fails, it propagates to the .catch below.
             await loadPipeline();
           } else {
-            throw err;
+            const healed = await purgeCachedModel();
+            if (healed) {
+              // Diagnostic only — do NOT post `init-error` here; the main thread
+              // treats it as a break. Only the .catch below (a genuine final
+              // failure) may post init-error.
+              if (!stderrSilenced) {
+                console.warn(
+                  `[embedding-worker] model corrupt (${msg}); purged cache, retrying download once`,
+                );
+              }
+              await loadPipeline();
+            } else {
+              throw err;
+            }
           }
         } else {
           throw err;
@@ -416,6 +431,56 @@ async function purgeCachedModel(): Promise<boolean> {
   } catch {
     // If we can't resolve/remove the cache, retrying the download is pointless.
     return false;
+  }
+}
+
+/** Inlined copy of MIN_ONNX_FILE_BYTES from embedding-worker-types.ts — the
+ *  worker runs as raw .ts and can't value-import siblings (see the classifier
+ *  note above). Keep in sync with `looksLikeIntactOnnxFile`. */
+const MIN_ONNX_FILE_BYTES = 1024 * 1024;
+
+/**
+ * Best-effort integrity check of the cached model's ONNX file(s): present,
+ * plausibly sized (≥ 1 MiB), and starting with the ONNX/protobuf header byte
+ * (field 1 `ir_version`, wire tag 0x08). Returns true only when EVERY `.onnx`
+ * file passes — i.e. the on-disk model looks loadable, so a parse failure was
+ * likely transient and the corrupt-model self-heal must NOT purge it. Returns
+ * false on ANY uncertainty (missing dir / read error), so the caller falls back
+ * to the safe purge + re-download path. Never throws. Mirrors the pure
+ * `looksLikeIntactOnnxFile` predicate in embedding-worker-types.ts.
+ */
+async function cachedModelLooksIntact(): Promise<boolean> {
+  try {
+    const { env } = await import("@huggingface/transformers");
+    const cacheDir = (env as { cacheDir?: string }).cacheDir;
+    const modelDir = resolveModelCacheDir(cacheDir, modelId);
+    if (!modelDir) return false;
+    const { readdir, stat, open } = await import("node:fs/promises");
+    const { join } = await import("node:path");
+    const onnxDir = join(modelDir, "onnx");
+    let onnxFiles: string[];
+    try {
+      onnxFiles = (await readdir(onnxDir)).filter((f) => f.endsWith(".onnx"));
+    } catch {
+      return false; // no onnx dir → can't verify → allow the purge fallback
+    }
+    if (onnxFiles.length === 0) return false;
+    for (const name of onnxFiles) {
+      const file = join(onnxDir, name);
+      const { size } = await stat(file);
+      if (size < MIN_ONNX_FILE_BYTES) return false; // truncated / empty
+      const fh = await open(file, "r");
+      try {
+        const head = Buffer.alloc(1);
+        const { bytesRead } = await fh.read(head, 0, 1, 0);
+        if (bytesRead < 1 || head[0] !== 0x08) return false; // not an ONNX proto
+      } finally {
+        await fh.close();
+      }
+    }
+    return true;
+  } catch {
+    return false; // uncertain → safe fallback to purge
   }
 }
 

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -452,16 +452,42 @@ export class LocalProviderUnavailableError extends Error {
   }
 }
 
-/** Tracks whether the local provider has been probed and found unavailable.
- *  Set to true after the first worker init failure so subsequent calls
- *  to `isAvailable()` short-circuit. */
+/** PERMANENT break: the local provider is disabled for the rest of the process
+ *  lifetime (recall degrades to FTS-only). Set only for a non-self-healing cause
+ *  — the optional embedding stack is absent, a WASM-fatal abort, a floor OOM, or
+ *  the transient-init-retry budget below being exhausted. */
 let localProviderKnownBroken = false;
 let localProviderErrorLogged = false;
 
-/** For tests: reset the local provider probe state. */
+// --- Transient init-failure retry (self-heal a one-off worker init failure) ---
+// A single model-init failure used to latch the provider FTS-only for the whole
+// process lifetime. But a transient failure — e.g. the ONNX model file read
+// while a concurrent process was still writing it during a multi-instance
+// restart, or momentary memory pressure — should self-heal: reject the in-flight
+// requests, wait a cooldown, then respawn a FRESH worker (a new init attempt) on
+// the next embed. Only latch permanently after LOCAL_INIT_MAX_ATTEMPTS
+// consecutive failures, or immediately for a cause that will never self-heal
+// (the optional stack being absent).
+const LOCAL_INIT_MAX_ATTEMPTS = 3;
+let localInitFailures = 0;
+/** Epoch ms; `> 0` means "cooling down after a transient init failure — retry a
+ *  fresh worker once `Date.now()` reaches it". Reset to 0 on retry/recovery. */
+let localInitRetryAt = 0;
+let localInitCooldownMs = 30_000;
+
+/** Test seam: shorten the init-retry cooldown so the retry path is drivable
+ *  without real time (`0` → the next availability check retries immediately;
+ *  `null` restores the production default). */
+export function _setLocalInitCooldownMsForTest(ms: number | null): void {
+  localInitCooldownMs = ms ?? 30_000;
+}
+
+/** For tests: reset the local provider probe + transient-retry state. */
 export function _resetLocalProviderProbe(): void {
   localProviderKnownBroken = false;
   localProviderErrorLogged = false;
+  localInitFailures = 0;
+  localInitRetryAt = 0;
 }
 
 /** For tests: simulate the local provider being unavailable, without
@@ -678,6 +704,17 @@ class LocalProvider implements EmbeddingProvider {
             if (pending) {
               this.pendingRequests.delete(msg.id);
               this.updateWorkerRef();
+              // A successful embed means init succeeded — clear any transient
+              // init-failure debt so a future one-off blip gets the full retry
+              // budget again (and re-enables the one-time failure log).
+              if (localInitFailures > 0 || localInitRetryAt > 0) {
+                log.info(
+                  `local embedding provider recovered after ${localInitFailures} failed init attempt(s)`,
+                );
+                localInitFailures = 0;
+                localInitRetryAt = 0;
+                localProviderErrorLogged = false;
+              }
               pending.resolve(msg.vectors);
             }
             break;
@@ -709,14 +746,13 @@ class LocalProvider implements EmbeddingProvider {
             // LocalProviderUnavailableError on all pending + future requests.
             this.workerInitError = msg.error;
             this.workerReady = false;
-            localProviderKnownBroken = true;
-            if (!localProviderErrorLogged) {
-              localProviderErrorLogged = true;
-              // Distinguish "optional local-embedding stack not installed"
-              // (#1026 — an expected, actionable degraded state) from a genuine
-              // init failure. Both latch the provider broken and degrade recall
-              // to FTS-only; only the log severity/message differs.
-              if (isMissingLocalStackError(msg.error)) {
+            if (isMissingLocalStackError(msg.error)) {
+              // Optional local-embedding stack not installed (#1026 — an
+              // expected, actionable degraded state that will NOT self-heal on
+              // its own). Latch permanently; recall degrades to FTS-only.
+              localProviderKnownBroken = true;
+              if (!localProviderErrorLogged) {
+                localProviderErrorLogged = true;
                 log.warn(
                   "local embedding dependencies not installed " +
                     "(optional '@huggingface/transformers' / 'onnxruntime-node' absent) — " +
@@ -724,11 +760,30 @@ class LocalProvider implements EmbeddingProvider {
                     "enable local embeddings, or set search.embeddings.provider in .lore.json " +
                     "to a remote provider (voyage/openai) with the matching API key.",
                 );
+              }
+            } else {
+              // A potentially transient failure (e.g. a model read that raced a
+              // concurrent writer during a multi-instance restart, momentary
+              // memory pressure). Retry a FRESH worker after a cooldown rather
+              // than disabling local embeddings for the whole process lifetime;
+              // only give up (latch) once the retry budget is exhausted.
+              localInitFailures++;
+              if (localInitFailures >= LOCAL_INIT_MAX_ATTEMPTS) {
+                localProviderKnownBroken = true;
+                localInitRetryAt = 0;
+                if (!localProviderErrorLogged) {
+                  localProviderErrorLogged = true;
+                  log.error(
+                    `local embedding provider failed to init after ${localInitFailures} attempts: ${msg.error}. ` +
+                      `Set search.embeddings.provider in .lore.json to use a remote provider.`,
+                    new Error(`embedding worker init failed: ${msg.error}`),
+                  );
+                }
               } else {
-                log.error(
-                  `local embedding provider failed to init: ${msg.error}. ` +
-                    `Set search.embeddings.provider in .lore.json to use a remote provider.`,
-                  new Error(`embedding worker init failed: ${msg.error}`),
+                localInitRetryAt = Date.now() + localInitCooldownMs;
+                log.warn(
+                  `local embedding init failed (attempt ${localInitFailures}/${LOCAL_INIT_MAX_ATTEMPTS}): ${msg.error}. ` +
+                    `Retrying with a fresh worker after a cooldown; recall is FTS-only until then.`,
                 );
               }
             }
@@ -1471,16 +1526,27 @@ export function pickRemoteFallback(): {
 export function isAvailable(): boolean {
   const provider = getProvider();
   if (!provider) return false;
-  if (provider instanceof EmbeddingPool && localProviderKnownUnavailable()) {
-    // One-time log so the user knows why vector search is degraded.
-    if (!localProviderErrorLogged) {
-      localProviderErrorLogged = true;
-      log.info(
-        "local embedding provider unavailable — recall will use FTS-only search. " +
-          "To use a remote provider, set search.embeddings.provider in .lore.json.",
-      );
+  if (provider instanceof EmbeddingPool) {
+    if (localProviderKnownUnavailable()) {
+      // One-time log so the user knows why vector search is degraded.
+      if (!localProviderErrorLogged) {
+        localProviderErrorLogged = true;
+        log.info(
+          "local embedding provider unavailable — recall will use FTS-only search. " +
+            "To use a remote provider, set search.embeddings.provider in .lore.json.",
+        );
+      }
+      return false;
     }
-    return false;
+    if (localInitRetryAt > 0) {
+      // A transient init failure is cooling down before its next retry.
+      if (Date.now() < localInitRetryAt) return false; // FTS-only until then
+      // Cooldown elapsed → discard the failed pool (fire-and-forget shutdown of
+      // its dead worker) so getProvider() spawns a FRESH worker — a new init
+      // attempt — on the next embed.
+      localInitRetryAt = 0;
+      void resetProvider();
+    }
   }
   return true;
 }

--- a/packages/core/test/embedding-init-retry.test.ts
+++ b/packages/core/test/embedding-init-retry.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { EventEmitter } from "node:events";
+import type { Worker } from "node:worker_threads";
+import {
+  embed,
+  isAvailable,
+  LocalProviderUnavailableError,
+  _resetLocalProviderProbe,
+  _restoreProvider,
+  _saveAndClearProvider,
+  _setLocalInitCooldownMsForTest,
+  _setTestWorkerFactory,
+} from "../src/embedding";
+
+// Drives the LocalProvider init lifecycle via a fake worker to prove that a
+// TRANSIENT model-init failure (e.g. the ONNX model read while a concurrent
+// process was still writing it during a multi-instance restart) self-heals —
+// a fresh-worker retry after a cooldown — instead of latching the provider
+// FTS-only for the whole process lifetime. A persistent failure still latches
+// after the retry budget; a missing optional stack latches immediately.
+
+type PostedMsg = { type: string; id: number };
+
+class FakeWorker extends EventEmitter {
+  readonly posted: PostedMsg[] = [];
+  terminated = false;
+  postMessage(msg: unknown): void {
+    this.posted.push({ ...(msg as PostedMsg) });
+  }
+  ref(): void {}
+  unref(): void {}
+  terminate(): Promise<number> {
+    this.terminated = true;
+    return Promise.resolve(0);
+  }
+  lastPosted(): PostedMsg {
+    const m = this.posted.at(-1);
+    if (!m) throw new Error("fake worker received no message");
+    return m;
+  }
+}
+
+function installFakeWorkers(): FakeWorker[] {
+  const fakes: FakeWorker[] = [];
+  _setTestWorkerFactory(() => {
+    const f = new FakeWorker();
+    fakes.push(f);
+    return f as unknown as Worker;
+  });
+  return fakes;
+}
+
+async function flush(): Promise<void> {
+  for (let i = 0; i < 5; i++) await Promise.resolve();
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+function settle<T>(
+  p: Promise<T>,
+): Promise<{ ok: true; value: T } | { ok: false; err: unknown }> {
+  return p.then(
+    (value) => ({ ok: true as const, value }),
+    (err) => ({ ok: false as const, err }),
+  );
+}
+
+// A transient parse failure of an intact model (the reported production error).
+const TRANSIENT_ERR =
+  "Can't create a session. ERROR_CODE: 7, ERROR_MESSAGE: Failed to load model because protobuf parsing failed.";
+// A non-self-healing cause: the optional local-embedding stack isn't installed.
+const MISSING_STACK_ERR = "Cannot find package 'onnxruntime-node'";
+
+describe("local embedding init retry (transient self-heal)", () => {
+  let savedProvider: unknown;
+  let savedVoyage: string | undefined;
+  let savedOpenAI: string | undefined;
+
+  beforeEach(() => {
+    savedVoyage = process.env.VOYAGE_API_KEY;
+    savedOpenAI = process.env.OPENAI_API_KEY;
+    delete process.env.VOYAGE_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    _resetLocalProviderProbe();
+    savedProvider = _saveAndClearProvider();
+  });
+
+  afterEach(() => {
+    _setTestWorkerFactory(null);
+    _setLocalInitCooldownMsForTest(null);
+    _resetLocalProviderProbe();
+    _restoreProvider(savedProvider);
+    if (savedVoyage !== undefined) process.env.VOYAGE_API_KEY = savedVoyage;
+    if (savedOpenAI !== undefined) process.env.OPENAI_API_KEY = savedOpenAI;
+  });
+
+  /** Spawn the next worker, fail its init with `error`, and assert the in-flight
+   *  embed rejected with LocalProviderUnavailableError. */
+  async function failInit(fakes: FakeWorker[], error: string): Promise<void> {
+    const p = settle(embed(["q"], "query"));
+    await flush();
+    const worker = fakes.at(-1);
+    if (!worker) throw new Error("no worker spawned");
+    worker.emit("message", { type: "init-error", error });
+    await flush();
+    const r = await p;
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.err).toBeInstanceOf(LocalProviderUnavailableError);
+  }
+
+  it("stays FTS-only during the cooldown without prematurely retrying", async () => {
+    _setLocalInitCooldownMsForTest(60_000); // long → still cooling down
+    const fakes = installFakeWorkers();
+    await failInit(fakes, TRANSIENT_ERR);
+
+    // Cooling down → unavailable, and crucially NOT respawning a worker yet.
+    expect(isAvailable()).toBe(false);
+    expect(isAvailable()).toBe(false);
+    expect(fakes).toHaveLength(1);
+  });
+
+  it("retries a fresh worker after the cooldown and recovers on success", async () => {
+    _setLocalInitCooldownMsForTest(0); // retry on the next availability check
+    const fakes = installFakeWorkers();
+    await failInit(fakes, TRANSIENT_ERR);
+
+    // Cooldown elapsed → available again (this discards the dead pool).
+    expect(isAvailable()).toBe(true);
+
+    // The next embed spawns a FRESH worker; complete it → recovery.
+    const p2 = settle(embed(["q2"], "query"));
+    await flush();
+    expect(fakes.length).toBeGreaterThanOrEqual(2);
+    const worker = fakes.at(-1);
+    if (!worker) throw new Error("no fresh worker spawned");
+    worker.emit("message", {
+      type: "result",
+      id: worker.lastPosted().id,
+      vectors: [new Float32Array([1, 2, 3])],
+    });
+    const r2 = await p2;
+    expect(r2.ok).toBe(true);
+    expect(isAvailable()).toBe(true);
+  });
+
+  it("latches permanently only after the retry budget is exhausted", async () => {
+    _setLocalInitCooldownMsForTest(0);
+    const fakes = installFakeWorkers();
+
+    await failInit(fakes, TRANSIENT_ERR); // attempt 1
+    expect(isAvailable()).toBe(true); // retry armed
+    await failInit(fakes, TRANSIENT_ERR); // attempt 2
+    expect(isAvailable()).toBe(true); // retry armed
+    await failInit(fakes, TRANSIENT_ERR); // attempt 3 → give up
+
+    expect(isAvailable()).toBe(false); // permanently broken
+    expect(isAvailable()).toBe(false); // stays broken (no further retries)
+  });
+
+  it("latches immediately (no retry) when the optional stack is missing", async () => {
+    _setLocalInitCooldownMsForTest(0);
+    const fakes = installFakeWorkers();
+    await failInit(fakes, MISSING_STACK_ERR);
+
+    // A missing optional stack will not self-heal → broken on the first failure.
+    expect(isAvailable()).toBe(false);
+    expect(fakes).toHaveLength(1); // never respawned
+  });
+});

--- a/packages/core/test/embedding-optional-stack.test.ts
+++ b/packages/core/test/embedding-optional-stack.test.ts
@@ -12,6 +12,7 @@ import {
   _resetLocalProviderProbe,
   _restoreProvider,
   _saveAndClearProvider,
+  _setLocalInitCooldownMsForTest,
   _setTestWorkerFactory,
 } from "../src/embedding";
 import { isMissingLocalStackError } from "../src/embedding-worker-types";
@@ -152,6 +153,7 @@ describe("init-error classification (worker-mock)", () => {
   afterEach(() => {
     registerSink(passthroughSink);
     _setTestWorkerFactory(null);
+    _setLocalInitCooldownMsForTest(null);
     _resetLocalProviderProbe();
     _restoreProvider(savedProvider);
     if (savedVoyage !== undefined) process.env.VOYAGE_API_KEY = savedVoyage;
@@ -189,7 +191,8 @@ describe("init-error classification (worker-mock)", () => {
     expect(errors).toHaveLength(0);
   });
 
-  it("genuine init failure → ERROR 'failed to init', latches FTS-only", async () => {
+  it("genuine init failures retry, then ERROR 'failed to init' + latch after the budget", async () => {
+    _setLocalInitCooldownMsForTest(0); // drive the retries without waiting
     const fakes: FakeWorker[] = [];
     _setTestWorkerFactory(() => {
       const f = new FakeWorker();
@@ -197,21 +200,31 @@ describe("init-error classification (worker-mock)", () => {
       return f as unknown as Worker;
     });
 
-    const result = settle(embed(["hello"], "query"));
-    await flush();
+    // A genuine (non-missing-stack) init failure is now RETRIED with a fresh
+    // worker rather than latching on the first failure — only after the retry
+    // budget (3 attempts) is exhausted does it error + degrade permanently.
+    const GENUINE = "model load failed: corrupt tokenizer.json";
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      const result = settle(embed(["hello"], "query"));
+      await flush();
+      const worker = fakes.at(-1);
+      if (!worker) throw new Error("no worker spawned");
+      worker.emit("message", { type: "init-error", error: GENUINE });
+      await flush();
+      const r = await result;
+      expect(r.ok).toBe(false);
+      if (attempt < 3) expect(isAvailable()).toBe(true); // still retryable
+    }
 
-    fakes[0].emit("message", {
-      type: "init-error",
-      error: "model load failed: corrupt tokenizer.json",
-    });
-    await flush();
-
-    const r = await result;
-    expect(r.ok).toBe(false);
-    expect(isAvailable()).toBe(false);
+    expect(isAvailable()).toBe(false); // budget exhausted → permanently FTS-only
 
     const errors = logs.filter((l) => l.level === "error");
     const warns = logs.filter((l) => l.level === "warn");
+    // Intermediate attempts warn (retry, not the benign not-installed message);
+    // the terminal failure errors.
+    expect(warns.some((l) => /init failed \(attempt/i.test(l.message))).toBe(
+      true,
+    );
     expect(errors.some((l) => /failed to init/i.test(l.message))).toBe(true);
     // The install-guidance warn is reserved for the not-installed case.
     expect(warns.some((l) => /not installed/i.test(l.message))).toBe(false);

--- a/packages/core/test/embedding-worker-types.test.ts
+++ b/packages/core/test/embedding-worker-types.test.ts
@@ -6,6 +6,8 @@ import {
   isWasmFatalError,
   isCorruptModelError,
   isTransformersInferenceDumpLine,
+  looksLikeIntactOnnxFile,
+  MIN_ONNX_FILE_BYTES,
   resolveModelCacheDir,
   shouldHealCorruptModel,
   TRANSFORMERS_INFERENCE_DUMP_PREFIXES,
@@ -189,6 +191,28 @@ describe("TRANSFORMERS_INFERENCE_DUMP_PREFIXES inline copy stays in sync", () =>
     const workerBody = bodyOf(workerSrc);
     expect(workerBody.length).toBeGreaterThan(0);
     expect(workerBody).toBe(bodyOf(typesSrc));
+  });
+});
+
+describe("looksLikeIntactOnnxFile", () => {
+  const OK = MIN_ONNX_FILE_BYTES + 1;
+
+  test("true for a plausibly-sized file with the ONNX protobuf header (0x08)", () => {
+    // ~137 MB nomic q8 model, first byte 0x08 (field 1 = ir_version).
+    expect(looksLikeIntactOnnxFile(137_296_292, 0x08)).toBe(true);
+    expect(looksLikeIntactOnnxFile(OK, 0x08)).toBe(true);
+  });
+
+  test("false when the file is too small (truncated / empty / error page)", () => {
+    expect(looksLikeIntactOnnxFile(0, 0x08)).toBe(false);
+    expect(looksLikeIntactOnnxFile(MIN_ONNX_FILE_BYTES - 1, 0x08)).toBe(false);
+  });
+
+  test("false when the header byte is not the ONNX protobuf tag", () => {
+    // e.g. an HTML error page ('<' = 0x3c) saved as the model, or a bad head.
+    expect(looksLikeIntactOnnxFile(OK, 0x3c)).toBe(false);
+    expect(looksLikeIntactOnnxFile(OK, 0x00)).toBe(false);
+    expect(looksLikeIntactOnnxFile(OK, undefined)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Problem

A **single** model-init failure disabled local embeddings (FTS-only recall) for the **entire process lifetime** — the worker set `localProviderKnownBroken = true` on the first `init-error` and never retried until the next restart.

Observed in production: during a multi-instance restart (≥3 gateways starting within ~3 min while redeploying), one process hit a one-off `Can't create a session … protobuf parsing failed` and latched FTS-only — even though the on-disk model was **byte-identical to the known-good copy and loaded fine** (verified: valid ONNX header, checksum match, loads in 791 ms in the exact runtime). A transient blip (a model read racing a concurrent writer, or momentary memory pressure) permanently bricked vector recall for that process.

## Fix — two protections against the race

**1. Retry-with-cooldown** (`embedding.ts`). An `init-error` that isn't a non-self-healing cause no longer latches. It rejects the in-flight requests, cools down (`30s`), then respawns a **fresh worker** (a new init attempt) on the next `isAvailable()` check. Only after `LOCAL_INIT_MAX_ATTEMPTS` (3) consecutive failures does it latch permanently; a successful embed clears the debt. The optional-stack-absent case (`isMissingLocalStackError`) still latches immediately — it won't self-heal.

**2. Integrity-gated purge** (`embedding-worker.ts`). The corrupt-model self-heal now verifies the on-disk `.onnx` file(s) are present, plausibly sized (≥1 MiB), and start with the ONNX/protobuf header byte (`0x08`) **before** the destructive purge. If they look intact, the parse failure was transient → retry the load **without deleting a good ~137 MB model** (a failed re-download, e.g. offline, would be strictly worse). Only a genuinely bad file is purged + re-downloaded.

Together: a transient parse failure of an intact model no longer destroys the file *or* disables embeddings for the process — the worker retries in place, and if that still fails the main thread respawns a fresh worker after a cooldown, giving a concurrent writer time to finish.

## Testing
- `embedding-init-retry.test.ts` (new): stays FTS-only during cooldown without premature retry; retries a fresh worker after cooldown and recovers on success; latches only after the budget is exhausted; missing-stack latches immediately.
- `looksLikeIntactOnnxFile` predicate unit tests (size + header).
- Updated the optional-stack "genuine init failure" test for the new retry semantics (retries → errors + latches after the budget).
- **Mutation-verified**: shrinking the retry budget to 1 reds the 3 retry tests; making the integrity predicate always-true reds the 2 integrity tests.
- Full `embedding-*` suite (225, incl. real-worker via the vendored model), `tsc`, Biome all clean.

## Not a model-file problem
This is the resilience follow-up to the transient production incident — the model on disk was fine; the process just gave up too early. Diagnosed alongside the container-OOM fixes (#1168/#1170) but independent of them.