### PR TITLE
fix(core): bound embedding-pool memory to one pool-share of free RAM

### DIFF
--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -669,7 +669,10 @@ class LocalProvider implements EmbeddingProvider {
       const workerInitData: WorkerInitData = {
         modelId: this.modelId,
         dimensions: this.dimensions,
-        maxTokens: this.maxTokens,
+        // Only a fallback for a request that omits maxTokens (every embed()
+        // carries one) — but size it to current free memory too, so even that
+        // fallback path can't drive a native over-allocation.
+        maxTokens: this.effectiveMaxTokens(),
         // Cgroup-CPU-aware native ORT intra-op cap, computed here on the main
         // thread (the worker can't value-import ort-native). undefined = no-op
         // (unconstrained host); applied on the native path only in the worker.

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -140,6 +140,15 @@ export function _setConstrainedMemoryForTest(bytes: number | null): void {
   testConstrainedMemoryBytes = bytes;
 }
 
+/** Test seam: override the host free-memory read used by every cap-sizing
+ *  decision ({@link containerFreeBytes}), so the pool-aware divisor and the
+ *  per-request current-free clamp can be driven deterministically without
+ *  depending on the CI box's actual RAM (null → real `os.freemem()`). */
+let testHostFreememBytes: number | null = null;
+export function _setContainerFreeForTest(bytes: number | null): void {
+  testHostFreememBytes = bytes;
+}
+
 /** The process's cgroup memory LIMIT in bytes (not free-within-limit), or `0` if
  *  unconstrained / unknown / unsupported by the runtime. `process.constrainedMemory()`
  *  is libuv-backed (cgroup v1 + v2, no hard-coded paths) and returns `0` when
@@ -170,7 +179,8 @@ function constrainedMemoryLimit(): number {
  *  attention peak as headroom. Using cgroup free (`availableMemory()`) instead
  *  would break the no-op guarantee on constrained-but-roomy hosts. */
 function containerFreeBytes(): number {
-  return clampFreeToContainerLimit(freemem(), constrainedMemoryLimit());
+  const raw = testHostFreememBytes != null ? testHostFreememBytes : freemem();
+  return clampFreeToContainerLimit(raw, constrainedMemoryLimit());
 }
 
 function persistEmbedCap(
@@ -201,11 +211,20 @@ function persistEmbedCap(
  * every restart" failure). Otherwise it sizes from the memory model and
  * current free memory; a materially larger free pool lets the cap re-probe
  * upward on restart (in lieu of continuous additive increase). Always clamped.
+ *
+ * `memDivisor` is the number of pool workers this cap must share free memory
+ * with (the pool ceiling; 1 for a standalone provider). Each worker sizes its
+ * transient O(L²) attention budget from `free / memDivisor`, so `memDivisor`
+ * workers running concurrently collectively stay within one worker's worth of
+ * the `EMBED_MEM_FRACTION` budget — otherwise N independently-sized workers each
+ * claim half of free memory and their sum OOMs the host (the exact native
+ * SIGKILL the WASM heap wall used to prevent; see EmbeddingPool).
  */
 function computeInitialEmbedCap(
   persisted: PersistedEmbedCap | null = readPersistedEmbedCap(),
+  memDivisor = 1,
 ): number {
-  const free = containerFreeBytes();
+  const free = containerFreeBytes() / Math.max(1, memDivisor);
   return reconcileEmbedCap(
     free,
     persisted,
@@ -579,18 +598,37 @@ class LocalProvider implements EmbeddingProvider {
    *  upward re-probe never climbs to or past it — a rising os.freemem() does not
    *  prove the WASM heap can grow that far. Cleared only by a process restart. */
   private lastOomCap = 0;
+  /** Number of pool workers this provider shares free memory with (the pool
+   *  ceiling; 1 for a standalone provider). Every free-memory-derived cap is
+   *  sized from `free / memDivisor` so N concurrent workers can't each claim a
+   *  full `EMBED_MEM_FRACTION` share and sum past the host's RAM (BUG: native
+   *  OOM is an uncatchable SIGKILL, so this must be prevented, not recovered). */
+  private readonly memDivisor: number;
 
-  constructor(modelId: string, dimensions: number) {
+  constructor(modelId: string, dimensions: number, memDivisor = 1) {
     this.modelId = modelId;
     this.dimensions = dimensions;
+    this.memDivisor = Math.max(1, memDivisor);
     // Seed lastOomCap from the persisted known-bad cap so an upward re-probe in
     // THIS process still respects a ceiling the WASM heap rejected in a PRIOR
     // one (a rising freemem doesn't prove the fixed heap grew). Read once and
     // reuse for the initial cap to avoid a second kv_meta round-trip.
     const persisted = readPersistedEmbedCap();
     this.lastOomCap = persisted?.knownBadCap ?? 0;
-    this.maxTokens = computeInitialEmbedCap(persisted);
+    this.maxTokens = computeInitialEmbedCap(persisted, this.memDivisor);
     this.capFreememAtLearn = containerFreeBytes();
+  }
+
+  /** The token cap to send with the NEXT request: the learned `maxTokens`
+   *  clamped to what CURRENT free memory supports for this worker's share of
+   *  the pool. Re-evaluated per request (not just at construction) because free
+   *  memory drops as concurrent sessions and sibling workers allocate — and on
+   *  the native ONNX path a too-large allocation triggers the OS OOM-killer
+   *  (uncatchable SIGKILL) instead of a recoverable in-worker OOM. Clamping down
+   *  to live free memory avoids the allocation the ×0.7 backoff can't catch. */
+  private effectiveMaxTokens(): number {
+    const liveCap = memoryModelEmbedCap(containerFreeBytes() / this.memDivisor);
+    return Math.min(this.maxTokens, liveCap);
   }
 
   /**
@@ -880,7 +918,15 @@ class LocalProvider implements EmbeddingProvider {
     this.lastReprobeAt = now;
     const free = containerFreeBytes();
     if (!shouldReprobeEmbedCap(free, this.capFreememAtLearn)) return;
-    const next = reprobeEmbedCap(this.maxTokens, free, this.lastOomCap);
+    // The re-probe ceiling is the memory model over this worker's pool SHARE of
+    // free memory, so climbing back up never lets N workers sum past the host's
+    // RAM. The ratio check above stays on undivided free (it only compares
+    // now-vs-learn, both undivided).
+    const next = reprobeEmbedCap(
+      this.maxTokens,
+      free / this.memDivisor,
+      this.lastOomCap,
+    );
     if (next <= this.maxTokens) return;
     const prev = this.maxTokens;
     this.maxTokens = next;
@@ -1010,8 +1056,9 @@ class LocalProvider implements EmbeddingProvider {
     const worker = this.worker;
     if (!worker) return; // raced with another exit — that handler owns pending
     for (const [, p] of this.pendingRequests) {
-      // Re-submit at the lowered cap so the retry doesn't re-OOM at the old one.
-      p.payload.maxTokens = this.maxTokens;
+      // Re-submit at the lowered cap so the retry doesn't re-OOM at the old one,
+      // further clamped to live free memory for this worker's pool share.
+      p.payload.maxTokens = this.effectiveMaxTokens();
       try {
         worker.postMessage(p.payload satisfies WorkerInbound);
       } catch {
@@ -1051,7 +1098,11 @@ class LocalProvider implements EmbeddingProvider {
       texts: prefixed,
       inputType,
       priority,
-      maxTokens: this.maxTokens,
+      // Clamp to what CURRENT free memory allows for this worker's pool share,
+      // not just the construction-time learned cap — free memory drops as
+      // sibling workers and live sessions allocate, and a native over-allocation
+      // is an uncatchable SIGKILL rather than a recoverable in-worker OOM.
+      maxTokens: this.effectiveMaxTokens(),
     };
 
     return new Promise<Float32Array[]>((resolve, reject) => {
@@ -1256,7 +1307,12 @@ class EmbeddingPool implements EmbeddingProvider {
 
   private spawnSlot(): EmbedSlot {
     const slot: EmbedSlot = {
-      provider: new LocalProvider(this.modelId, this.dimensions),
+      // Pass the pool ceiling as the memory divisor so every worker sizes its
+      // token cap from `free / ceiling`. The ceiling is itself memory-gated
+      // (desiredEmbedPoolSize), so the workers the host is provisioned for
+      // collectively stay within one `EMBED_MEM_FRACTION` share of free memory
+      // instead of each independently claiming half and summing to an OOM.
+      provider: new LocalProvider(this.modelId, this.dimensions, this.ceiling),
       inflight: 0,
     };
     this.slots.push(slot);

--- a/packages/core/test/embedding-oom-recovery.test.ts
+++ b/packages/core/test/embedding-oom-recovery.test.ts
@@ -10,6 +10,8 @@ import {
   _resetLocalProviderProbe,
   _restoreProvider,
   _saveAndClearProvider,
+  _setConstrainedMemoryForTest,
+  _setContainerFreeForTest,
   _setTestWorkerFactory,
 } from "../src/embedding";
 import {
@@ -92,12 +94,21 @@ describe("embedding OOM recovery (worker-mock)", () => {
     savedOpenAI = process.env.OPENAI_API_KEY;
     delete process.env.VOYAGE_API_KEY;
     delete process.env.OPENAI_API_KEY;
+    // Pin free memory well above the WASM ceiling's crossover so the per-request
+    // current-free clamp is transparent (effective cap == learned cap). These
+    // tests exercise the OOM-backoff cap math, not the memory clamp, so the box's
+    // actual freemem must not shrink the posted cap (it otherwise flakes: the
+    // first post would be min(ceiling, memoryModelEmbedCap(realFree))).
+    _setConstrainedMemoryForTest(0);
+    _setContainerFreeForTest(16 * 1024 * 1024 * 1024);
     _resetLocalProviderProbe();
     savedProvider = _saveAndClearProvider();
   });
 
   afterEach(() => {
     _setTestWorkerFactory(null);
+    _setContainerFreeForTest(null);
+    _setConstrainedMemoryForTest(null);
     _resetLocalProviderProbe();
     _restoreProvider(savedProvider);
     if (savedVoyage !== undefined) process.env.VOYAGE_API_KEY = savedVoyage;

--- a/packages/core/test/embedding-pool-memory.test.ts
+++ b/packages/core/test/embedding-pool-memory.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { EventEmitter } from "node:events";
+import type { Worker } from "node:worker_threads";
+import {
+  embed,
+  _persistEmbedCap,
+  _resetLocalProviderProbe,
+  _restoreProvider,
+  _saveAndClearProvider,
+  _setConstrainedMemoryForTest,
+  _setContainerFreeForTest,
+  _setEmbedPoolSizeForTest,
+  _setPoolFreememForTest,
+  _setTestWorkerFactory,
+} from "../src/embedding";
+import { memoryModelEmbedCap } from "../src/embedding-cap";
+
+// Regression suite for the embedding-pool OOM that SIGKILLed the whole gateway
+// (Onur's report): the pool grew to N workers, each independently sized its
+// token cap to consume ~half of free memory, so the sum ran the host out of RAM.
+// On the native ONNX path that OOM is an uncatchable SIGKILL — the ×0.7 backoff
+// never fires — so the ONLY defense is never over-allocating in the first place.
+// These tests pin the two guards: (1) each worker sizes from free / ceiling, and
+// (2) the cap is re-clamped to CURRENT free memory on every request, not just at
+// construction.
+
+const GB = 1024 * 1024 * 1024;
+
+type EmbedMsg = { type: string; id: number; maxTokens: number };
+
+/** Minimal stand-in for a node:worker_threads Worker that captures the exact
+ *  per-request payload the provider posts (snapshotting, since the production
+ *  payload object is mutated in place on OOM re-submit). It never posts a
+ *  "result", so the embed promise stays pending — which is fine, we only assert
+ *  on what was sent to the worker. */
+class CapturingWorker extends EventEmitter {
+  readonly posted: EmbedMsg[] = [];
+  postMessage(msg: unknown): void {
+    this.posted.push({ ...(msg as EmbedMsg) });
+  }
+  ref(): void {}
+  unref(): void {}
+  terminate(): Promise<number> {
+    return Promise.resolve(0);
+  }
+  lastPosted(): EmbedMsg {
+    const m = this.posted.at(-1);
+    if (!m) throw new Error("fake worker received no message");
+    return m;
+  }
+}
+
+function installCapturingWorkers(): CapturingWorker[] {
+  const fakes: CapturingWorker[] = [];
+  _setTestWorkerFactory(() => {
+    const f = new CapturingWorker();
+    fakes.push(f);
+    return f as unknown as Worker;
+  });
+  return fakes;
+}
+
+async function flush(): Promise<void> {
+  for (let i = 0; i < 5; i++) await Promise.resolve();
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+/** Attach handlers immediately so the never-resolving embed promise is never
+ *  flagged as an unhandled rejection when the provider is torn down. */
+function settle<T>(p: Promise<T>): Promise<unknown> {
+  return p.then(
+    (v) => v,
+    (e) => e,
+  );
+}
+
+describe("embedding pool memory sizing (OOM regression)", () => {
+  let savedProvider: unknown;
+  let savedVoyage: string | undefined;
+  let savedOpenAI: string | undefined;
+
+  beforeEach(() => {
+    savedVoyage = process.env.VOYAGE_API_KEY;
+    savedOpenAI = process.env.OPENAI_API_KEY;
+    delete process.env.VOYAGE_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    // Neutralize any real cgroup limit on the CI box so _setContainerFreeForTest
+    // is the sole authority for free-memory sizing.
+    _setConstrainedMemoryForTest(0);
+    _resetLocalProviderProbe();
+    savedProvider = _saveAndClearProvider();
+  });
+
+  afterEach(() => {
+    _setTestWorkerFactory(null);
+    _setEmbedPoolSizeForTest(null);
+    _setPoolFreememForTest(null);
+    _setContainerFreeForTest(null);
+    _setConstrainedMemoryForTest(null);
+    _resetLocalProviderProbe();
+    _restoreProvider(savedProvider);
+    if (savedVoyage !== undefined) process.env.VOYAGE_API_KEY = savedVoyage;
+    if (savedOpenAI !== undefined) process.env.OPENAI_API_KEY = savedOpenAI;
+  });
+
+  it("sizes each pool worker's cap from free / ceiling, not full free memory", async () => {
+    // Pin the learned cap high (freeMemBytes=0 → trust band ignores host free),
+    // so the per-request cap is governed purely by the live free-memory model —
+    // isolating the divisor.
+    _persistEmbedCap(8192, 0);
+    _setEmbedPoolSizeForTest(2); // ceiling = 2 → memDivisor = 2
+    _setContainerFreeForTest(6 * GB);
+    const fakes = installCapturingWorkers();
+
+    void settle(embed(["some document text to embed"], "document"));
+    await flush();
+
+    expect(fakes).toHaveLength(1);
+    const posted = fakes[0].lastPosted();
+    const dividedCap = memoryModelEmbedCap((6 * GB) / 2);
+    const undividedCap = memoryModelEmbedCap(6 * GB);
+
+    // The cap must reflect this worker's SHARE (free / ceiling), so two such
+    // workers together stay within one memory-fraction budget instead of each
+    // claiming half and summing to an OOM.
+    expect(posted.maxTokens).toBe(dividedCap);
+    // Guard against the bug: sizing from full free (the pre-fix behavior) yields
+    // a strictly larger cap. If these were equal the test couldn't see the fix.
+    expect(dividedCap).toBeLessThan(undividedCap);
+    expect(posted.maxTokens).toBeLessThan(undividedCap);
+  });
+
+  it("re-clamps the cap to CURRENT free memory when it drops after construction", async () => {
+    // ceiling = 1 → divisor = 1, isolating the current-free clamp from the
+    // divisor. The learned cap is pinned high so only live free memory moves it.
+    _persistEmbedCap(8192, 0);
+    _setEmbedPoolSizeForTest(1);
+    const fakes = installCapturingWorkers();
+
+    // Construct + first request while free memory is ample.
+    _setContainerFreeForTest(6 * GB);
+    void settle(embed(["first request while memory is ample"], "document"));
+    await flush();
+    expect(fakes).toHaveLength(1);
+    const firstCap = fakes[0].lastPosted().maxTokens;
+
+    // Free memory collapses (sibling workers + live sessions allocate). The next
+    // request must be sized DOWN to what's now available — a construction-time
+    // cap would trigger the uncatchable native OOM here.
+    _setContainerFreeForTest(2 * GB);
+    void settle(embed(["second request after memory dropped"], "document"));
+    await flush();
+
+    // Same worker (pool never grew — ceiling 1), so we see two posts on it.
+    expect(fakes).toHaveLength(1);
+    const secondCap = fakes[0].lastPosted().maxTokens;
+
+    expect(firstCap).toBe(memoryModelEmbedCap(6 * GB));
+    expect(secondCap).toBe(memoryModelEmbedCap(2 * GB));
+    expect(secondCap).toBeLessThan(firstCap);
+  });
+});

--- a/packages/core/test/embedding-pool-memory.test.ts
+++ b/packages/core/test/embedding-pool-memory.test.ts
@@ -13,7 +13,8 @@ import {
   _setPoolFreememForTest,
   _setTestWorkerFactory,
 } from "../src/embedding";
-import { memoryModelEmbedCap } from "../src/embedding-cap";
+import { backoffEmbedCap, memoryModelEmbedCap } from "../src/embedding-cap";
+import { EMBED_OOM_EXIT_CODE } from "../src/embedding-worker-types";
 
 // Regression suite for the embedding-pool OOM that SIGKILLed the whole gateway
 // (Onur's report): the pool grew to N workers, each independently sized its
@@ -158,5 +159,37 @@ describe("embedding pool memory sizing (OOM regression)", () => {
     expect(firstCap).toBe(memoryModelEmbedCap(6 * GB));
     expect(secondCap).toBe(memoryModelEmbedCap(2 * GB));
     expect(secondCap).toBeLessThan(firstCap);
+  });
+
+  it("clamps the OOM-respawn resubmit to current free memory, not just the ×0.7 backoff", async () => {
+    // The OOM-respawn resubmit payload is posted directly (no later
+    // effectiveMaxTokens), so it is the ONLY cap on the native-SIGKILL retry
+    // path. Pin the learned cap high, embed while memory is ample, then DROP
+    // free BEFORE the worker OOMs: the resubmit must be sized to the dropped
+    // free, not merely the ×0.7 backoff of the (larger) construction-time cap.
+    _persistEmbedCap(8192, 0);
+    _setEmbedPoolSizeForTest(1); // divisor 1 → isolate the clamp
+    _setContainerFreeForTest(16 * GB);
+    const fakes = installCapturingWorkers();
+
+    void settle(embed(["a document to embed under ample memory"], "document"));
+    await flush();
+    expect(fakes).toHaveLength(1);
+    const first = fakes[0].lastPosted();
+
+    // Memory collapses, then the worker OOM-exits → respawn re-submits the same
+    // request on a fresh worker.
+    _setContainerFreeForTest(2 * GB);
+    fakes[0].emit("exit", EMBED_OOM_EXIT_CODE);
+    await flush();
+
+    expect(fakes.length).toBeGreaterThanOrEqual(2);
+    const resubmitted = fakes[1].lastPosted();
+    expect(resubmitted.id).toBe(first.id);
+    // min(backoff(first), memoryModelEmbedCap(2GB)) === memoryModelEmbedCap(2GB).
+    expect(resubmitted.maxTokens).toBe(memoryModelEmbedCap(2 * GB));
+    expect(resubmitted.maxTokens).toBeLessThan(
+      backoffEmbedCap(first.maxTokens),
+    );
   });
 });


### PR DESCRIPTION
## Problem (reported by Onur, `0.37.0-dev.1783205394` == `main` HEAD)

Symptoms on a bare-metal/VM host with native ONNX + local embeddings:
- ~4 cores pegged, RAM climbs to **~7.5 GB**, then suddenly crashes to **~1 GB**
- gateway goes **unresponsive** during the crash (clients get API errors)
- in-flight background work is **lost and retried** → 4 sessions barely progressed overnight

## Root cause

The memory-gated embedding pool (#1115) let each `LocalProvider` **independently** size its token cap to consume up to `freemem × EMBED_MEM_FRACTION (0.5)` for its transient O(L²) attention tensor. Grown to `DEFAULT_MAX_EMBED_POOL = 2` workers, the two workers each sized for ~50% of free RAM → combined ≈ 100% of free + 2× ~680 MB baselines. The spawn gate only reserves a 2048-ref-token budget (~1.16 GB) while the real cap reaches `EMBED_TOKEN_CEILING ≈ 4948` tokens ≈ 3.6 GB. 2 × 3.6 GB ≈ 7.2 GB → matches the observed climb.

On the **native** ONNX path there is no 4 GiB WASM heap wall, so physical-RAM exhaustion is an **uncatchable OS SIGKILL** on the whole gateway — the `process.exit(EMBED_OOM_EXIT_CODE)` → ×0.7 backoff → respawn machinery only fires for *catchable* WASM OOMs. So the gateway dies, auto-restarts (RAM → ~1 GB), clients see API errors, and in-flight distillation/curation is lost.

Sentry corroborates: Onur's exact release has **zero events** and isn't even in the release list (newer than anything that ever reported) — the signature of a process killed before it can flush. The only catchable embedding-OOM issue (`LOREAI-GATEWAY-2X`) is on older/WASM builds and a different user.

## Fix

Make over-allocation **impossible** rather than recoverable (we can't catch the native OOM):

1. **Pool-share sizing** — every worker sizes its cap from `free / ceiling` (via a `memDivisor` threaded from `EmbeddingPool.spawnSlot`). The ceiling is already memory-gated (`desiredEmbedPoolSize`), so the workers the host is provisioned for collectively stay within one `EMBED_MEM_FRACTION` share of free memory instead of each claiming half and summing to an OOM.
2. **Current-free clamp** — re-clamp the per-request cap (and the OOM-respawn resubmit) to **current** free memory via `effectiveMaxTokens()`, not just the construction-time learned cap. Free drops as sibling workers and live sessions allocate; a construction-time cap would trigger the uncatchable native OOM.

`computeInitialEmbedCap`, `effectiveMaxTokens()`, and `maybeReprobeCap` all divide free by the pool `memDivisor` before the memory model. The construction-time and re-probe divides are belt-and-suspenders — the per-request `effectiveMaxTokens()` clamp dominates on every real request.

## Tests
New `embedding-pool-memory.test.ts` with a `_setContainerFreeForTest` seam:
- worker cap sizes from `free / ceiling` (not full free)
- cap re-clamps down when free memory drops after construction
- the OOM-respawn resubmit is clamped to current free (the native-SIGKILL retry path)

Mutation-verified non-vacuous: reverting the per-request `effectiveMaxTokens` clamp, the `spawnSlot` ceiling divisor, or the resubmit clamp each turns a test red. (The `computeInitialEmbedCap`/`maybeReprobeCap` divides are equivalent mutants — safe because the per-request clamp dominates.) Updated `embedding-oom-recovery.test.ts` to pin free memory (removing a latent freemem dependency the new clamp exposed). Full `@loreai/core` suite (2612 tests), typecheck, and biome all green.

## Follow-ups (separate PRs)
- Temporal re-chunk backfill poison-row liveness — #1176.
- Immediate mitigation for Onur: `LORE_EMBED_POOL_SIZE=1` + restart.