### PR TITLE
fix(core): break the temporal re-chunk livelock on a row that crashes the process

### DIFF
--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -2801,6 +2801,25 @@ const TEMPORAL_RECHUNK_PAGE = 256;
  */
 const MAX_TEMPORAL_RECHUNK_RETRY_PASSES = 3;
 /**
+ * KV key: the id of the row currently being embedded, set just before the embed
+ * and cleared the instant it settles (success OR any catchable error). If it
+ * survives a process restart, the previous process died *inside* that row's
+ * embed — an uncatchable crash (the native ONNX OOM is an OS SIGKILL, so the
+ * ×0.7 in-worker backoff can't catch it) that the per-row cursor checkpoint
+ * cannot protect against: the cursor only advances AFTER a successful embed, so
+ * the same row is re-fetched and re-crashes on every restart, forever.
+ */
+const TEMPORAL_RECHUNK_INFLIGHT_KEY = "lore:temporal_rechunk.inflight";
+/** KV key: how many times the in-flight row above has taken the process down. */
+const TEMPORAL_RECHUNK_ROW_ATTEMPTS_KEY = "lore:temporal_rechunk.row_attempts";
+/**
+ * How many times a single row may crash the whole process before the walk skips
+ * it (advances the cursor past it) instead of retrying forever. The row keeps
+ * its legacy single vector + FTS, exactly like the transient-retry giveup — a
+ * bounded, self-healing liveness guard rather than a permanent wedge.
+ */
+const MAX_TEMPORAL_RECHUNK_ROW_CRASH_ATTEMPTS = 2;
+/**
  * Poll interval while the temporal walk is parked waiting for the host to go
  * idle. Short enough to resume promptly once traffic stops; a parked walk is
  * otherwise idle (one predicate call + one timer per tick).
@@ -2852,6 +2871,8 @@ export function resetTemporalRechunkProgress(): void {
   setKV(TEMPORAL_RECHUNK_DONE_KEY, "0");
   setKV(TEMPORAL_RECHUNK_CURSOR_KEY, "");
   setKV(TEMPORAL_RECHUNK_ATTEMPTS_KEY, "0");
+  setKV(TEMPORAL_RECHUNK_INFLIGHT_KEY, "");
+  setKV(TEMPORAL_RECHUNK_ROW_ATTEMPTS_KEY, "0");
 }
 
 /**
@@ -2928,6 +2949,41 @@ export async function backfillTemporalEmbeddings(
   if (getKV(TEMPORAL_RECHUNK_DONE_KEY) === "1") return 0;
 
   let cursor = getKV(TEMPORAL_RECHUNK_CURSOR_KEY) ?? "";
+
+  // Poison-row liveness guard. If the in-flight marker survived a restart, the
+  // previous process died mid-embed on that row — an uncatchable crash the
+  // per-row cursor checkpoint can't cover (the cursor advances only AFTER a
+  // successful embed, so a row that reliably OOM-SIGKILLs the process is
+  // re-fetched and re-crashes forever). Count the crash; once a row has taken
+  // the process down MAX_TEMPORAL_RECHUNK_ROW_CRASH_ATTEMPTS times, skip it by
+  // advancing the cursor past it so the walk makes progress. The skipped row
+  // keeps its legacy single vector + FTS, exactly like the transient giveup.
+  const crashedRow = getKV(TEMPORAL_RECHUNK_INFLIGHT_KEY) ?? "";
+  if (crashedRow) {
+    const rowAttempts =
+      Number(getKV(TEMPORAL_RECHUNK_ROW_ATTEMPTS_KEY) ?? "0") + 1;
+    // `crashedRow > cursor` guards against ever moving the cursor backwards: the
+    // in-flight row is always the one just past the checkpoint, but a stale
+    // marker (e.g. after a manual cursor rewind) must never rewind progress.
+    if (
+      rowAttempts >= MAX_TEMPORAL_RECHUNK_ROW_CRASH_ATTEMPTS &&
+      crashedRow > cursor
+    ) {
+      log.warn(
+        `temporal re-chunk: row ${crashedRow} crashed the process ` +
+          `${rowAttempts}× — skipping it (keeps its legacy vector + FTS)`,
+      );
+      cursor = crashedRow;
+      setKV(TEMPORAL_RECHUNK_CURSOR_KEY, cursor);
+      setKV(TEMPORAL_RECHUNK_ROW_ATTEMPTS_KEY, "0");
+    } else {
+      // Below the threshold: give the row another chance on this run, but
+      // remember the crash count so a repeat death eventually trips the skip.
+      setKV(TEMPORAL_RECHUNK_ROW_ATTEMPTS_KEY, String(rowAttempts));
+    }
+    setKV(TEMPORAL_RECHUNK_INFLIGHT_KEY, "");
+  }
+
   let processed = 0;
   let scanned = 0;
   // Resume point of the FIRST row that hit a transient error this pass. We keep
@@ -3028,6 +3084,11 @@ export async function backfillTemporalEmbeddings(
       // already checkpointed, so a park (or a crash while parked) resumes from
       // the last durable cursor.
       await awaitBackfillIdle(opts.shouldPause);
+      // Mark this row in-flight so an uncatchable crash mid-embed (native OOM
+      // SIGKILL) is detectable on the next startup and eventually skipped. It's
+      // cleared the moment the embed settles — success or catchable error — so
+      // only a hard process death ever leaves it set.
+      setKV(TEMPORAL_RECHUNK_INFLIGHT_KEY, row.id);
       try {
         // Count only messages that actually got a chunk set written. A row that
         // reduces to zero embeddable units (store() never persists one, but the
@@ -3038,7 +3099,10 @@ export async function backfillTemporalEmbeddings(
       } catch (err) {
         // Provider went away mid-run — stop WITHOUT advancing past this row or
         // latching done; the next startup resumes from the persisted cursor.
+        // Clear the in-flight marker: the provider being down is not this row's
+        // fault, so it must not count toward the poison-row skip.
         if (err instanceof LocalProviderUnavailableError) {
+          setKV(TEMPORAL_RECHUNK_INFLIGHT_KEY, "");
           log.info("temporal embedding backfill stopped: provider unavailable");
           stop = true;
           break;
@@ -3049,6 +3113,11 @@ export async function backfillTemporalEmbeddings(
         log.error("temporal embedding backfill row failed", row.id, ":", err);
         if (retryFrom === null) retryFrom = cursor;
       }
+      // The row settled without taking the process down: clear the in-flight
+      // marker and reset the per-row crash counter so it only ever reflects
+      // consecutive hard deaths on the row now at the cursor.
+      setKV(TEMPORAL_RECHUNK_INFLIGHT_KEY, "");
+      setKV(TEMPORAL_RECHUNK_ROW_ATTEMPTS_KEY, "0");
       cursor = row.id;
       scanned++;
 

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -2955,16 +2955,24 @@ export async function backfillTemporalEmbeddings(
   // per-row cursor checkpoint can't cover (the cursor advances only AFTER a
   // successful embed, so a row that reliably OOM-SIGKILLs the process is
   // re-fetched and re-crashes forever). Count the crash; once a row has taken
-  // the process down MAX_TEMPORAL_RECHUNK_ROW_CRASH_ATTEMPTS times, skip it by
-  // advancing the cursor past it so the walk makes progress. The skipped row
-  // keeps its legacy single vector + FTS, exactly like the transient giveup.
+  // the process down MAX_TEMPORAL_RECHUNK_ROW_CRASH_ATTEMPTS times, arm a
+  // one-shot skip so the walk steps over it (by id, when it reaches it) and
+  // makes progress. The skipped row keeps its legacy single vector + FTS,
+  // exactly like the transient-retry giveup.
+  //
+  // We skip by matching the row id in the loop rather than jumping the cursor:
+  // the persisted cursor may be pinned earlier than the poison row (at a
+  // transient failure's `retryFrom`), and jumping straight to the poison row
+  // would also skip those earlier, still-pending rows — abandoning their retries
+  // and any not-yet-embedded work between the pin and the poison row.
+  let poisonSkipId = "";
   const crashedRow = getKV(TEMPORAL_RECHUNK_INFLIGHT_KEY) ?? "";
   if (crashedRow) {
     const rowAttempts =
       Number(getKV(TEMPORAL_RECHUNK_ROW_ATTEMPTS_KEY) ?? "0") + 1;
-    // `crashedRow > cursor` guards against ever moving the cursor backwards: the
-    // in-flight row is always the one just past the checkpoint, but a stale
-    // marker (e.g. after a manual cursor rewind) must never rewind progress.
+    // `crashedRow > cursor` guards against a stale marker at/behind the resume
+    // point (e.g. after a manual cursor rewind): only a row still ahead of the
+    // cursor is a live poison-row candidate.
     if (
       rowAttempts >= MAX_TEMPORAL_RECHUNK_ROW_CRASH_ATTEMPTS &&
       crashedRow > cursor
@@ -2973,8 +2981,7 @@ export async function backfillTemporalEmbeddings(
         `temporal re-chunk: row ${crashedRow} crashed the process ` +
           `${rowAttempts}× — skipping it (keeps its legacy vector + FTS)`,
       );
-      cursor = crashedRow;
-      setKV(TEMPORAL_RECHUNK_CURSOR_KEY, cursor);
+      poisonSkipId = crashedRow;
       setKV(TEMPORAL_RECHUNK_ROW_ATTEMPTS_KEY, "0");
     } else {
       // Below the threshold: give the row another chance on this run, but
@@ -3079,6 +3086,17 @@ export async function backfillTemporalEmbeddings(
 
     let stop = false;
     for (const row of rows) {
+      // Poison row (armed above): step over it WITHOUT embedding — it keeps its
+      // legacy vector + FTS. One-shot: clear the sentinel so only this single
+      // row is skipped and the walk resumes normally. The cursor still advances
+      // here, so the poison row is durably passed.
+      if (poisonSkipId && row.id === poisonSkipId) {
+        poisonSkipId = "";
+        cursor = row.id;
+        scanned++;
+        setKV(TEMPORAL_RECHUNK_CURSOR_KEY, retryFrom ?? cursor);
+        continue;
+      }
       // Idle-gate before starting this row's embed so the walk yields the shared
       // embed pool to live traffic. Parking here is safe: the previous row is
       // already checkpointed, so a park (or a crash while parked) resumes from

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -2813,6 +2813,16 @@ const TEMPORAL_RECHUNK_INFLIGHT_KEY = "lore:temporal_rechunk.inflight";
 /** KV key: how many times the in-flight row above has taken the process down. */
 const TEMPORAL_RECHUNK_ROW_ATTEMPTS_KEY = "lore:temporal_rechunk.row_attempts";
 /**
+ * KV key: a poison row the walk has decided to permanently step over. DURABLE
+ * (unlike the in-memory `poisonSkipId`) so the skip survives restart even when
+ * the persisted cursor is pinned BEHIND the poison row — which happens when an
+ * earlier row hit a transient failure this pass (its `retryFrom` pins the cursor
+ * to its predecessor). Without a durable record the per-row checkpoint keeps
+ * writing that pinned cursor, so the poison row is re-fetched and re-crashes the
+ * process on every restart until the transient row's retry passes are exhausted.
+ */
+const TEMPORAL_RECHUNK_SKIP_KEY = "lore:temporal_rechunk.skip";
+/**
  * How many times a single row may crash the whole process before the walk skips
  * it (advances the cursor past it) instead of retrying forever. The row keeps
  * its legacy single vector + FTS, exactly like the transient-retry giveup — a
@@ -2873,6 +2883,7 @@ export function resetTemporalRechunkProgress(): void {
   setKV(TEMPORAL_RECHUNK_ATTEMPTS_KEY, "0");
   setKV(TEMPORAL_RECHUNK_INFLIGHT_KEY, "");
   setKV(TEMPORAL_RECHUNK_ROW_ATTEMPTS_KEY, "0");
+  setKV(TEMPORAL_RECHUNK_SKIP_KEY, "");
 }
 
 /**
@@ -2966,6 +2977,17 @@ export async function backfillTemporalEmbeddings(
   // would also skip those earlier, still-pending rows — abandoning their retries
   // and any not-yet-embedded work between the pin and the poison row.
   let poisonSkipId = "";
+
+  // Re-arm a previously-recorded durable skip. This is what makes the skip
+  // survive restarts when the cursor is pinned behind the poison row: the KV
+  // outlives the in-memory `poisonSkipId`, so the row is stepped over on every
+  // pass until the cursor durably moves past it (then the marker is retired).
+  const durableSkip = getKV(TEMPORAL_RECHUNK_SKIP_KEY) ?? "";
+  if (durableSkip) {
+    if (durableSkip > cursor) poisonSkipId = durableSkip;
+    else setKV(TEMPORAL_RECHUNK_SKIP_KEY, ""); // cursor passed it → retire
+  }
+
   const crashedRow = getKV(TEMPORAL_RECHUNK_INFLIGHT_KEY) ?? "";
   if (crashedRow) {
     // `crashedRow > cursor`: a genuine mid-embed crash always leaves the marker
@@ -2986,6 +3008,10 @@ export async function backfillTemporalEmbeddings(
             `${rowAttempts}× — skipping it (keeps its legacy vector + FTS)`,
         );
         poisonSkipId = crashedRow;
+        // Record the skip durably so a cursor pinned behind it (transient
+        // retryFrom) can't cause the row to be re-embedded — and re-crash — on
+        // the next restart.
+        setKV(TEMPORAL_RECHUNK_SKIP_KEY, crashedRow);
         setKV(TEMPORAL_RECHUNK_ROW_ATTEMPTS_KEY, "0");
       } else {
         // Below the threshold: give the row another chance on this run, but
@@ -3072,6 +3098,7 @@ export async function backfillTemporalEmbeddings(
         // Clean pass reached the end — latch done; subsequent startups skip it.
         setKV(TEMPORAL_RECHUNK_DONE_KEY, "1");
         setKV(TEMPORAL_RECHUNK_ATTEMPTS_KEY, "0");
+        setKV(TEMPORAL_RECHUNK_SKIP_KEY, "");
       } else {
         // Some rows failed this pass. Rewind to the first of them so the next
         // startup retries — up to a bounded number of passes, after which we
@@ -3084,6 +3111,7 @@ export async function backfillTemporalEmbeddings(
           );
           setKV(TEMPORAL_RECHUNK_DONE_KEY, "1");
           setKV(TEMPORAL_RECHUNK_ATTEMPTS_KEY, "0");
+          setKV(TEMPORAL_RECHUNK_SKIP_KEY, "");
         } else {
           setKV(TEMPORAL_RECHUNK_ATTEMPTS_KEY, String(attempts));
           setKV(TEMPORAL_RECHUNK_CURSOR_KEY, retryFrom);

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -2968,25 +2968,33 @@ export async function backfillTemporalEmbeddings(
   let poisonSkipId = "";
   const crashedRow = getKV(TEMPORAL_RECHUNK_INFLIGHT_KEY) ?? "";
   if (crashedRow) {
-    const rowAttempts =
-      Number(getKV(TEMPORAL_RECHUNK_ROW_ATTEMPTS_KEY) ?? "0") + 1;
-    // `crashedRow > cursor` guards against a stale marker at/behind the resume
-    // point (e.g. after a manual cursor rewind): only a row still ahead of the
-    // cursor is a live poison-row candidate.
-    if (
-      rowAttempts >= MAX_TEMPORAL_RECHUNK_ROW_CRASH_ATTEMPTS &&
-      crashedRow > cursor
-    ) {
-      log.warn(
-        `temporal re-chunk: row ${crashedRow} crashed the process ` +
-          `${rowAttempts}× — skipping it (keeps its legacy vector + FTS)`,
-      );
-      poisonSkipId = crashedRow;
-      setKV(TEMPORAL_RECHUNK_ROW_ATTEMPTS_KEY, "0");
+    // `crashedRow > cursor`: a genuine mid-embed crash always leaves the marker
+    // AHEAD of the persisted cursor (the cursor only advances after a row
+    // completes). A marker at/behind the cursor names an already-passed row —
+    // it can only arise from a manual cursor edit or a reset race, never a real
+    // crash — so treat it as stale: clear it WITHOUT counting a crash, otherwise
+    // a phantom count would bleed into the next genuine poison row. NOTE: this
+    // ordering compares in JS (string `>`) while the walk pages in SQLite
+    // (`id > ? ORDER BY id`, BINARY collation); the two agree for the ASCII ids
+    // temporal_messages uses (agent-supplied session/message ids).
+    if (crashedRow > cursor) {
+      const rowAttempts =
+        Number(getKV(TEMPORAL_RECHUNK_ROW_ATTEMPTS_KEY) ?? "0") + 1;
+      if (rowAttempts >= MAX_TEMPORAL_RECHUNK_ROW_CRASH_ATTEMPTS) {
+        log.warn(
+          `temporal re-chunk: row ${crashedRow} crashed the process ` +
+            `${rowAttempts}× — skipping it (keeps its legacy vector + FTS)`,
+        );
+        poisonSkipId = crashedRow;
+        setKV(TEMPORAL_RECHUNK_ROW_ATTEMPTS_KEY, "0");
+      } else {
+        // Below the threshold: give the row another chance on this run, but
+        // remember the crash count so a repeat death eventually trips the skip.
+        setKV(TEMPORAL_RECHUNK_ROW_ATTEMPTS_KEY, String(rowAttempts));
+      }
     } else {
-      // Below the threshold: give the row another chance on this run, but
-      // remember the crash count so a repeat death eventually trips the skip.
-      setKV(TEMPORAL_RECHUNK_ROW_ATTEMPTS_KEY, String(rowAttempts));
+      // Stale marker at/behind the cursor — not a live poison candidate.
+      setKV(TEMPORAL_RECHUNK_ROW_ATTEMPTS_KEY, "0");
     }
     setKV(TEMPORAL_RECHUNK_INFLIGHT_KEY, "");
   }
@@ -3132,8 +3140,11 @@ export async function backfillTemporalEmbeddings(
         if (retryFrom === null) retryFrom = cursor;
       }
       // The row settled without taking the process down: clear the in-flight
-      // marker and reset the per-row crash counter so it only ever reflects
-      // consecutive hard deaths on the row now at the cursor.
+      // marker and reset the crash counter. The counter is a single KV (not
+      // per-row), so this reset bounds it to deaths NOT separated by a clean
+      // row. A pinned cursor (transient retryFrom) plus adjacent crashes can
+      // still let one genuine poison row inherit a count of 1 and be skipped a
+      // crash early — always safe (the row keeps its legacy vector + FTS).
       setKV(TEMPORAL_RECHUNK_INFLIGHT_KEY, "");
       setKV(TEMPORAL_RECHUNK_ROW_ATTEMPTS_KEY, "0");
       cursor = row.id;

--- a/packages/core/test/embedding-temporal-poison-row.test.ts
+++ b/packages/core/test/embedding-temporal-poison-row.test.ts
@@ -23,6 +23,7 @@ const DIM = 4;
 const CURSOR = "lore:temporal_rechunk.cursor";
 const INFLIGHT = "lore:temporal_rechunk.inflight";
 const ROW_ATTEMPTS = "lore:temporal_rechunk.row_attempts";
+const SKIP = "lore:temporal_rechunk.skip";
 
 function vec(): Float32Array {
   const a = new Float32Array(DIM);
@@ -195,5 +196,62 @@ describe("temporal re-chunk poison-row liveness", () => {
     expect(ids).not.toContain("t1");
     expect(processed).toBe(0);
     expect(getKV(INFLIGHT)).toBe("");
+  });
+
+  it("re-arms a durable skip on restart even with no in-flight crash this run", async () => {
+    // The skip decision from a prior crash is persisted (SKIP), so it survives a
+    // restart where the in-flight marker is empty and the cursor is pinned behind
+    // the poison row — the row must still be stepped over, not re-embedded.
+    insertMsg("t1", pid);
+    insertMsg("t2", pid);
+    insertMsg("t3", pid);
+    setKV(SKIP, "t2"); // recorded on a prior crash
+    setKV(CURSOR, "t1"); // pinned behind the poison row
+    setKV(INFLIGHT, ""); // no crash this run
+
+    const processed = await backfillTemporalEmbeddings();
+
+    const ids = embeddedIds();
+    expect(ids).not.toContain("t2"); // durable skip honored
+    expect(ids).toContain("t3");
+    expect(processed).toBe(1);
+  });
+
+  it("keeps the durable skip when a transient failure pins the cursor behind the poison row", async () => {
+    // The exact crash-loop scenario: a transient failure on an earlier row pins
+    // the persisted cursor behind the poison row. The poison skip must be
+    // recorded DURABLY so the next restart steps over the row instead of
+    // re-embedding (and re-crashing on) it.
+    insertMsg("t0", pid);
+    insertMsg("t1", pid); // transient-fails → pins retryFrom at t0
+    insertMsg("t2", pid); // poison row, crash-armed this run
+    insertMsg("t3", pid);
+    setKV(CURSOR, ""); // walk from the start
+    setKV(INFLIGHT, "t2"); // crashed mid-embed on t2 last time
+    setKV(ROW_ATTEMPTS, "1"); // this run's detection reaches the skip threshold
+    _restoreProvider({
+      provider: {
+        maxBatchSize: 8,
+        async embed(texts: string[]) {
+          if (texts.some((t) => t.includes("message t1 "))) {
+            throw new Error("transient embed failure");
+          }
+          return texts.map(() => vec());
+        },
+      },
+    });
+
+    const processed = await backfillTemporalEmbeddings();
+
+    const ids = embeddedIds();
+    expect(ids).not.toContain("t2"); // poison row skipped
+    expect(ids).not.toContain("t1"); // transient row failed this pass
+    expect(ids).toContain("t0");
+    expect(ids).toContain("t3");
+    expect(processed).toBe(2); // t0 + t3
+    // The cursor is pinned behind t2 by the transient retryFrom...
+    expect(getKV(CURSOR)).toBe("t0");
+    // ...so the skip MUST persist durably, or the next restart re-crashes on t2.
+    expect(getKV(SKIP)).toBe("t2");
   });
 });

--- a/packages/core/test/embedding-temporal-poison-row.test.ts
+++ b/packages/core/test/embedding-temporal-poison-row.test.ts
@@ -140,6 +140,26 @@ describe("temporal re-chunk poison-row liveness", () => {
     expect(getKV(INFLIGHT)).toBe(""); // cleared after it settled
   });
 
+  it("skips only the poison row, still embedding earlier rows the cursor is pinned behind", async () => {
+    // The persisted cursor can sit earlier than the poison row (e.g. pinned at a
+    // transient failure's predecessor). Skipping must step over ONLY the poison
+    // row, not everything between the pin and it — otherwise a transient hiccup
+    // plus a later crash would silently abandon the rows in between.
+    insertMsg("t1", pid);
+    insertMsg("t2", pid);
+    insertMsg("t3", pid);
+    setKV(CURSOR, "t1"); // resume point is behind t2
+    setKV(INFLIGHT, "t3"); // ...but the poison row is t3, two rows ahead
+    setKV(ROW_ATTEMPTS, "1");
+
+    const processed = await backfillTemporalEmbeddings();
+
+    const ids = embeddedIds();
+    expect(ids).toContain("t2"); // the in-between row is still embedded
+    expect(ids).not.toContain("t3"); // only the poison row is skipped
+    expect(processed).toBe(1);
+  });
+
   it("never rewinds the cursor when a stale in-flight marker points at or behind it", async () => {
     insertMsg("t1", pid);
     insertMsg("t2", pid);

--- a/packages/core/test/embedding-temporal-poison-row.test.ts
+++ b/packages/core/test/embedding-temporal-poison-row.test.ts
@@ -160,6 +160,25 @@ describe("temporal re-chunk poison-row liveness", () => {
     expect(processed).toBe(1);
   });
 
+  it("treats a stale marker at/behind the cursor as resolved, without counting a crash", async () => {
+    // Only t1 exists and the cursor is already past it, so the walk fetches
+    // nothing and no later clean row can reset the counter for us — the final
+    // counter value is exactly what the entry-detection decided.
+    insertMsg("t1", pid);
+    setKV(CURSOR, "t5"); // resume point already past the marker
+    setKV(INFLIGHT, "t2"); // stale marker BEHIND the cursor
+    setKV(ROW_ATTEMPTS, "0");
+
+    const processed = await backfillTemporalEmbeddings();
+
+    // A stale-behind marker is not a live crash: the counter must stay 0, not be
+    // bumped to 1. (Dropping the `crashedRow > cursor` guard counts it as a
+    // crash and this becomes "1".)
+    expect(processed).toBe(0);
+    expect(getKV(ROW_ATTEMPTS)).toBe("0");
+    expect(getKV(INFLIGHT)).toBe("");
+  });
+
   it("never rewinds the cursor when a stale in-flight marker points at or behind it", async () => {
     insertMsg("t1", pid);
     insertMsg("t2", pid);

--- a/packages/core/test/embedding-temporal-poison-row.test.ts
+++ b/packages/core/test/embedding-temporal-poison-row.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { db, ensureProject, getKV, setKV } from "../src/db";
+import { ensureVec0Store, setStorageMode } from "../src/db/vec-store";
+import {
+  backfillTemporalEmbeddings,
+  resetTemporalRechunkProgress,
+  _restoreProvider,
+  _saveAndClearProvider,
+} from "../src/embedding";
+import * as log from "../src/log";
+
+// Regression suite for the temporal re-chunk backfill livelock: a single row
+// whose embed reliably OOM-SIGKILLs the whole gateway (native ONNX OOM is
+// uncatchable, so the ×0.7 backoff never fires) would be retried on every
+// restart forever, because the per-row cursor checkpoint only advances AFTER a
+// successful embed. An in-flight marker + bounded per-row crash counter lets the
+// walk detect such a row across restarts and skip past it (keeping its legacy
+// vector + FTS) so it makes progress.
+
+const PROJECT = "/test/poison-row";
+const DIM = 4;
+
+const CURSOR = "lore:temporal_rechunk.cursor";
+const INFLIGHT = "lore:temporal_rechunk.inflight";
+const ROW_ATTEMPTS = "lore:temporal_rechunk.row_attempts";
+
+function vec(): Float32Array {
+  const a = new Float32Array(DIM);
+  a[0] = 1;
+  return a;
+}
+
+function insertMsg(id: string, pid: string): void {
+  // >= 50 chars so the walk's `length(content) >= 50` filter embeds it.
+  const content = `temporal message ${id} with more than enough content to embed`;
+  expect(content.length).toBeGreaterThanOrEqual(50);
+  db()
+    .query(
+      "INSERT INTO temporal_messages (id, project_id, session_id, role, content, tokens, distilled, created_at) VALUES (?, ?, 's', 'user', ?, 0, 0, 0)",
+    )
+    .run(id, pid, content);
+}
+
+function embeddedIds(): string[] {
+  return (
+    db()
+      .query("SELECT DISTINCT message_id FROM temporal_vec ORDER BY message_id")
+      .all() as { message_id: string }[]
+  ).map((r) => r.message_id);
+}
+
+describe("temporal re-chunk poison-row liveness", () => {
+  let pid: string;
+  let providerToken: unknown;
+
+  beforeEach(() => {
+    pid = ensureProject(PROJECT);
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    db().query("DELETE FROM temporal_vec").run();
+    db().query("DELETE FROM temporal_messages").run();
+    resetTemporalRechunkProgress(); // done=0, cursor="", inflight="", attempts reset
+    providerToken = _saveAndClearProvider();
+    _restoreProvider({
+      provider: {
+        maxBatchSize: 8,
+        async embed(texts: string[]) {
+          return texts.map(() => vec());
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    _restoreProvider(providerToken);
+    vi.restoreAllMocks();
+  });
+
+  it("skips a row that has repeatedly crashed the process, and keeps walking", async () => {
+    insertMsg("t1", pid);
+    insertMsg("t2", pid);
+    insertMsg("t3", pid);
+    // Simulate a prior uncatchable crash mid-embed on t2: the in-flight marker
+    // survived, the cursor still sits at t2's predecessor, and t2 has already
+    // taken the process down once — so this run's detection reaches the cap.
+    setKV(CURSOR, "t1");
+    setKV(INFLIGHT, "t2");
+    setKV(ROW_ATTEMPTS, "1");
+    const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
+
+    const processed = await backfillTemporalEmbeddings();
+
+    const ids = embeddedIds();
+    expect(ids).not.toContain("t2"); // poison row skipped
+    expect(ids).toContain("t3"); // walk continued past it
+    expect(processed).toBe(1); // only t3 re-chunked
+    expect(getKV(INFLIGHT)).toBe(""); // marker cleared
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("t2"));
+  });
+
+  it("gives a row still below the crash threshold another chance instead of skipping", async () => {
+    insertMsg("t1", pid);
+    insertMsg("t2", pid);
+    insertMsg("t3", pid);
+    // In-flight marker present but the row has only crashed zero times so far:
+    // detection lifts it to 1 (< 2), so t2 must be retried, not skipped.
+    setKV(CURSOR, "t1");
+    setKV(INFLIGHT, "t2");
+    setKV(ROW_ATTEMPTS, "0");
+
+    const processed = await backfillTemporalEmbeddings();
+
+    const ids = embeddedIds();
+    expect(ids).toContain("t2"); // retried and succeeded
+    expect(ids).toContain("t3");
+    expect(processed).toBe(2);
+    expect(getKV(ROW_ATTEMPTS)).toBe("0"); // reset once t2 completed cleanly
+    expect(getKV(INFLIGHT)).toBe("");
+  });
+
+  it("marks the row in-flight during its embed and clears it once the row settles", async () => {
+    insertMsg("t1", pid);
+    const seenDuringEmbed: string[] = [];
+    _restoreProvider({
+      provider: {
+        maxBatchSize: 8,
+        async embed(texts: string[]) {
+          // The marker must be live exactly while this row is being embedded —
+          // that's the whole crash-detection signal.
+          seenDuringEmbed.push(getKV(INFLIGHT) ?? "");
+          return texts.map(() => vec());
+        },
+      },
+    });
+
+    const processed = await backfillTemporalEmbeddings();
+
+    expect(processed).toBe(1);
+    expect(seenDuringEmbed).toContain("t1"); // set before the embed ran
+    expect(getKV(INFLIGHT)).toBe(""); // cleared after it settled
+  });
+
+  it("never rewinds the cursor when a stale in-flight marker points at or behind it", async () => {
+    insertMsg("t1", pid);
+    insertMsg("t2", pid);
+    // A stale marker at t1 while the cursor has already advanced to t2 must not
+    // move the cursor backwards (the `crashedRow > cursor` guard).
+    setKV(CURSOR, "t2");
+    setKV(INFLIGHT, "t1");
+    setKV(ROW_ATTEMPTS, "1");
+
+    const processed = await backfillTemporalEmbeddings();
+
+    // Cursor stays at/after t2 → t1 is NOT revisited; nothing past t2 remains.
+    const ids = embeddedIds();
+    expect(ids).not.toContain("t1");
+    expect(processed).toBe(0);
+    expect(getKV(INFLIGHT)).toBe("");
+  });
+});


### PR DESCRIPTION
## Problem

The temporal re-chunk backfill (which walks the whole 220K+ corpus after a blob→vec0 cutover) checkpoints its cursor **only after** a row's embed succeeds (per-row checkpoint, #1104). That survives a clean restart, but **not** a row whose embed takes the whole process down: a native ONNX OOM is an **uncatchable OS SIGKILL**, so the `EMBED_OOM_EXIT_CODE` / ×0.7 backoff never runs and the cursor never advances. On restart the same row is re-fetched and re-crashes — the walk livelocks (Onur's report: 4 sessions barely progressed overnight, gateway RAM cycling 7.5GB→1GB).

This is the backfill-liveness half of the embedding-pool OOM investigation. #1175 fixes the OOM itself (so the crash shouldn't happen); this is defense-in-depth so a single pathological row can never wedge the walk again.

## Fix

An **in-flight marker** (KV `lore:temporal_rechunk.inflight`) set just before each row's embed and cleared the instant it settles (success **or** any catchable error). If it survives a restart, the previous process died *inside* that row's embed:

- count it (`lore:temporal_rechunk.row_attempts`),
- once a row has taken the process down `MAX_TEMPORAL_RECHUNK_ROW_CRASH_ATTEMPTS` (2) times, skip it (keeps its legacy single vector + FTS, like the existing transient-retry giveup).

Safety details:
- **Skip by id, not by cursor jump.** The persisted cursor may be pinned earlier than the poison row (at a transient failure's `retryFrom`); jumping the cursor straight to the poison row would also skip those earlier, still-pending rows. Matching the id in the loop skips only the poison row and still processes/retries everything before it.
- **Durable skip** (`lore:temporal_rechunk.skip`). The skip decision is persisted, not just held in memory. When a transient failure pins the cursor *behind* the poison row, an in-memory-only skip would be lost on restart → the poison row re-fetched and re-crashed (bounded at ~6 SIGKILLs by the retry-pass cap, but bad UX). The durable marker is re-armed on every startup while the row is still ahead of the cursor and retired once the cursor durably passes it (and on done-latch / reset), so the row is stepped over on every pass regardless of a pinned cursor.
- `crashedRow > cursor` guard so a stale marker at/behind the resume point is treated as resolved (cleared without counting a crash) rather than a live poison candidate.
- The `LocalProviderUnavailableError` path clears the marker — a provider being down is not the row's fault and must not count as a crash.

## Tests

New `embedding-temporal-poison-row.test.ts` (8 tests), including:
- skips a row that has repeatedly crashed the process, and keeps walking
- gives a row still below the threshold another chance instead of skipping
- marks the row in-flight during its embed and clears it once it settles
- skips only the poison row, still embedding earlier rows the cursor is pinned behind
- re-arms a durable skip on restart with no in-flight crash this run
- keeps the durable skip when a transient failure pins the cursor behind the poison row
- treats a stale marker at/behind the cursor as resolved, without counting a crash

Mutation-verified: reverting the skip branch, the marker set/clear, the by-id skip, the `crashedRow > cursor` handling, the durable re-arm, or the durable write each turns a test red. Full `@loreai/core` suite (2618 tests), typecheck, and biome all green.