### PR TITLE
fix(core): collapse per-entry outcomeImpact N+1 on the consolidation path

### DIFF
--- a/packages/core/src/curator.ts
+++ b/packages/core/src/curator.ts
@@ -8,7 +8,7 @@ import {
 import * as temporal from "./temporal";
 import * as distillation from "./distillation";
 import * as ltm from "./ltm";
-import type { KnowledgeMetadata } from "./ltm";
+import type { KnowledgeMetadata, OutcomeImpact } from "./ltm";
 import * as entities from "./entities";
 import * as embedding from "./embedding";
 import * as log from "./log";
@@ -1221,30 +1221,48 @@ type ConsolidationEntry = {
   outcome: { passes: number; fails: number };
 };
 
-/**
- * Project a knowledge entry into the consolidation-prompt shape, attaching its
- * value signal so the curator can keep proven-valuable entries when merging
- * duplicates or trimming (#497): current confidence (already folds in the
- * outcome reward/penalty) plus the raw verifier pass/fail co-occurrence record
- * (which discriminates within the confidence cluster). One indexed lookup per
- * entry — cheap, and only on the idle consolidation path.
- */
-function toConsolidationEntry(e: {
+type ConsolidationInput = {
   id: string;
   category: string;
   title: string;
   content: string;
   confidence: number;
   logical_id: string;
-}): ConsolidationEntry {
+};
+
+/**
+ * Project a knowledge entry into the consolidation-prompt shape, attaching its
+ * value signal so the curator can keep proven-valuable entries when merging
+ * duplicates or trimming (#497): current confidence (already folds in the
+ * outcome reward/penalty) plus the raw verifier pass/fail co-occurrence record
+ * (which discriminates within the confidence cluster). Takes a prefetched
+ * outcome map (see {@link toConsolidationEntries}) so a batch of entries costs
+ * one query, not one-per-entry (Sentry LOREAI-GATEWAY-3D N+1).
+ */
+function toConsolidationEntry(
+  e: ConsolidationInput,
+  outcomeByLogicalId: Map<string, OutcomeImpact>,
+): ConsolidationEntry {
   return {
     id: e.id,
     category: e.category,
     title: e.title,
     content: e.content,
     confidence: e.confidence,
-    outcome: ltm.outcomeImpact(e.logical_id),
+    outcome: outcomeByLogicalId.get(e.logical_id) ?? { passes: 0, fails: 0 },
   };
+}
+
+/**
+ * Batch-project entries for the consolidation prompt, fetching every entry's
+ * verifier outcome in a single query up front (instead of one per entry, which
+ * was an N+1 on the idle consolidation path — Sentry LOREAI-GATEWAY-3D).
+ */
+function toConsolidationEntries(
+  entries: ConsolidationInput[],
+): ConsolidationEntry[] {
+  const outcomes = ltm.outcomeImpactMany(entries.map((e) => e.logical_id));
+  return entries.map((e) => toConsolidationEntry(e, outcomes));
 }
 
 export async function consolidate(input: {
@@ -1302,14 +1320,14 @@ export async function consolidate(input: {
 
   if (entries.length <= CONSOLIDATION_BATCH_SIZE) {
     // Small overshoot — send all entries, target is maxEntries
-    entriesForPrompt = entries.map(toConsolidationEntry);
+    entriesForPrompt = toConsolidationEntries(entries);
     batchTarget = cfg.curator.maxEntries;
   } else {
     // Large overshoot — batched mode. Take the lowest-confidence entries.
     // The LLM evaluates this batch and deletes the least valuable ones.
     // Subsequent passes (on future idle ticks) handle the rest.
     const candidates = entries.slice(-CONSOLIDATION_BATCH_SIZE);
-    entriesForPrompt = candidates.map(toConsolidationEntry);
+    entriesForPrompt = toConsolidationEntries(candidates);
     // Target is relative to the batch (not the global total) because the
     // prompt only sees the batch entries. Keep at most half — delete the rest.
     // Each pass deletes ~25 entries, the idle scheduler re-triggers (cooldown
@@ -1342,7 +1360,7 @@ async function consolidateEntries(
     logical_id: string;
   }>,
 ): Promise<{ updated: number; deleted: number }> {
-  const entriesForPrompt = entries.map(toConsolidationEntry);
+  const entriesForPrompt = toConsolidationEntries(entries);
   log.info(
     `consolidation: category-focused — evaluating ${entries.length} "${entries[0]?.category}" entries for near-duplicate merge`,
   );

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -1609,31 +1609,65 @@ export type OutcomeImpact = {
 };
 
 /**
- * Aggregate the verifier outcomes a knowledge entry has co-occurred with, by its
- * stable `logical_id` (A2). Counts credited injection rows by verdict; 'none'
- * verdicts are not recorded (no signal), so only pass/fail are counted (the
- * `verdict IN ('pass','fail')` filter also excludes still-uncredited NULL rows).
- * Read-only — surfaced by `lore data show` so the reward loop's effect is
- * observable. (A recency / "last verdict" hint is intentionally omitted: the
- * only available timestamp is injection time, not credit time, so it would
- * misreport when an old session is credited late.)
+ * Batched form of {@link outcomeImpact}: aggregate the verifier outcomes for
+ * MANY entries (keyed by stable `logical_id`, A2) in a SINGLE query rather than
+ * one query per entry. The idle consolidation path evaluates dozens of entries
+ * per pass, so the per-entry form was an N+1 (Sentry LOREAI-GATEWAY-3D).
+ *
+ * Counts credited injection rows by verdict; 'none' verdicts are not recorded
+ * (no signal), so only pass/fail are counted (the `verdict IN ('pass','fail')`
+ * filter also excludes still-uncredited NULL rows). Backed by the
+ * `idx_ksi_logical_verdict (logical_id, verdict)` index. A recency / "last
+ * verdict" hint is intentionally omitted: the only available timestamp is
+ * injection time, not credit time, so it would misreport when an old session is
+ * credited late.
+ *
+ * Returns a Map keyed by `logical_id`. IDs with no pass/fail rows are ABSENT
+ * from the map (callers default to `{ passes: 0, fails: 0 }`). De-duplicates the
+ * input; empty input runs no query.
+ */
+export function outcomeImpactMany(
+  logicalIds: string[],
+): Map<string, OutcomeImpact> {
+  const out = new Map<string, OutcomeImpact>();
+  const unique = [...new Set(logicalIds)];
+  if (!unique.length) return out;
+  // SQLite caps host parameters (default 999); chunk well under that.
+  const CHUNK = 900;
+  for (let i = 0; i < unique.length; i += CHUNK) {
+    const batch = unique.slice(i, i + CHUNK);
+    const placeholders = batch.map(() => "?").join(",");
+    const rows = db()
+      .query(
+        `SELECT logical_id, verdict, COUNT(*) AS n
+         FROM knowledge_session_injections
+         WHERE logical_id IN (${placeholders}) AND verdict IN ('pass','fail')
+         GROUP BY logical_id, verdict`,
+      )
+      .all(...batch) as { logical_id: string; verdict: string; n: number }[];
+    for (const r of rows) {
+      let cur = out.get(r.logical_id);
+      if (!cur) {
+        cur = { passes: 0, fails: 0 };
+        out.set(r.logical_id, cur);
+      }
+      if (r.verdict === "pass") cur.passes = r.n;
+      else if (r.verdict === "fail") cur.fails = r.n;
+    }
+  }
+  return out;
+}
+
+/**
+ * Aggregate the verifier outcomes a single knowledge entry has co-occurred with,
+ * by its stable `logical_id`. Read-only — surfaced by `lore data show` so the
+ * reward loop's effect is observable. See {@link outcomeImpactMany} for the
+ * batched form (used on the consolidation path) and the counting semantics.
  */
 export function outcomeImpact(logicalId: string): OutcomeImpact {
-  const rows = db()
-    .query(
-      `SELECT verdict, COUNT(*) AS n
-       FROM knowledge_session_injections
-       WHERE logical_id = ? AND verdict IN ('pass','fail')
-       GROUP BY verdict`,
-    )
-    .all(logicalId) as { verdict: string; n: number }[];
-  let passes = 0;
-  let fails = 0;
-  for (const r of rows) {
-    if (r.verdict === "pass") passes = r.n;
-    else if (r.verdict === "fail") fails = r.n;
-  }
-  return { passes, fails };
+  return (
+    outcomeImpactMany([logicalId]).get(logicalId) ?? { passes: 0, fails: 0 }
+  );
 }
 
 /** Last observed reference-resolution counts for an entry (#627), or null if it

--- a/packages/core/test/ltm-outcome-reward.test.ts
+++ b/packages/core/test/ltm-outcome-reward.test.ts
@@ -499,3 +499,69 @@ describe("outcome-reward: outcomeImpact (observability, #497 follow-up)", () => 
     expect(ltm.outcomeImpact(lid)).toEqual({ passes: 0, fails: 0 });
   });
 });
+
+describe("outcome-reward: outcomeImpactMany (batched N+1 fix, LOREAI-GATEWAY-3D)", () => {
+  let pid: string;
+  beforeEach(() => {
+    pid = ensureProject(PROJECT);
+    db().query("DELETE FROM knowledge WHERE project_id = ?").run(pid);
+    db().query("DELETE FROM tool_calls WHERE project_id = ?").run(pid);
+    db()
+      .query("DELETE FROM knowledge_session_injections WHERE project_id = ?")
+      .run(pid);
+  });
+
+  function creditOnce(
+    logicalId: string,
+    session: string,
+    verdict: "pass" | "fail",
+  ): void {
+    db()
+      .query(
+        `INSERT INTO knowledge_session_injections (session_id, logical_id, project_id, created_at, credited)
+         VALUES (?, ?, ?, ?, 0)`,
+      )
+      .run(session, logicalId, pid, Date.now());
+    insertToolCall(pid, {
+      session,
+      status: verdict === "pass" ? "completed" : "error",
+      verifier: 1,
+    });
+    ltm.creditSessionOutcome(session, PROJECT);
+  }
+
+  test("aggregates per logical_id with no cross-entry bleed", () => {
+    // Distinct counts per entry so a missing `GROUP BY logical_id` (or map
+    // mis-keying) would visibly cross-contaminate the tallies.
+    const a = getEntry(makeProjectEntry("many-a", 0.5)).logical_id;
+    const b = getEntry(makeProjectEntry("many-b", 0.5)).logical_id;
+    const c = getEntry(makeProjectEntry("many-c", 0.5)).logical_id;
+    creditOnce(a, "m-a1", "pass");
+    creditOnce(a, "m-a2", "pass");
+    creditOnce(a, "m-a3", "fail");
+    creditOnce(b, "m-b1", "fail");
+    // c has no injections at all.
+
+    const map = ltm.outcomeImpactMany([a, b, c]);
+    expect(map.get(a)).toEqual({ passes: 2, fails: 1 });
+    expect(map.get(b)).toEqual({ passes: 0, fails: 1 });
+    // Entries with no pass/fail rows are absent (callers default to zeroes).
+    expect(map.has(c)).toBe(false);
+  });
+
+  test("matches the single-lookup outcomeImpact for the same id", () => {
+    const a = getEntry(makeProjectEntry("parity-a", 0.5)).logical_id;
+    creditOnce(a, "p-a1", "pass");
+    creditOnce(a, "p-a2", "fail");
+    expect(ltm.outcomeImpactMany([a]).get(a)).toEqual(ltm.outcomeImpact(a));
+  });
+
+  test("de-duplicates repeated ids and returns empty map for empty input", () => {
+    const a = getEntry(makeProjectEntry("dedup-a", 0.5)).logical_id;
+    creditOnce(a, "d-a1", "pass");
+    const map = ltm.outcomeImpactMany([a, a, a]);
+    expect(map.size).toBe(1);
+    expect(map.get(a)).toEqual({ passes: 1, fails: 0 });
+    expect(ltm.outcomeImpactMany([]).size).toBe(0);
+  });
+});

--- a/packages/core/test/ltm-outcome-reward.test.ts
+++ b/packages/core/test/ltm-outcome-reward.test.ts
@@ -556,12 +556,17 @@ describe("outcome-reward: outcomeImpactMany (batched N+1 fix, LOREAI-GATEWAY-3D)
     expect(ltm.outcomeImpactMany([a]).get(a)).toEqual(ltm.outcomeImpact(a));
   });
 
-  test("de-duplicates repeated ids and returns empty map for empty input", () => {
+  test("counts are not inflated by duplicate ids; empty input → empty map", () => {
     const a = getEntry(makeProjectEntry("dedup-a", 0.5)).logical_id;
     creditOnce(a, "d-a1", "pass");
+    // Requesting the same id repeatedly must not multiply its tally (the id is
+    // collapsed before the aggregate; `IN (a,a,a)` also never matches a row
+    // more than once). Dedup itself is a pure query-size optimization with no
+    // behavioral signature, so this asserts the observable contract only.
     const map = ltm.outcomeImpactMany([a, a, a]);
     expect(map.size).toBe(1);
     expect(map.get(a)).toEqual({ passes: 1, fails: 0 });
+    // Empty input returns an empty map (and issues no query).
     expect(ltm.outcomeImpactMany([]).size).toBe(0);
   });
 });


### PR DESCRIPTION
## What

The idle consolidation path (`curator.consolidate` / `consolidateEntries`) projects each knowledge entry into the curator-prompt shape via `toConsolidationEntry`, which called `ltm.outcomeImpact(logical_id)` **once per entry** — a separate `SELECT ... FROM knowledge_session_injections WHERE logical_id = ?` for every entry. With dozens of entries per pass this is an N+1.

Surfaced in Sentry as **LOREAI-GATEWAY-3D** (`N+1 Query`, culprit `lore.consolidation`):
```sql
SELECT verdict, COUNT(*) AS n
  FROM knowledge_session_injections
 WHERE logical_id = ? AND verdict IN ('pass','fail')
 GROUP BY verdict
```

## Fix

- Add `ltm.outcomeImpactMany(logicalIds)` — aggregates every entry's verifier outcome in a **single** query:
  ```sql
  ... WHERE logical_id IN (...) AND verdict IN ('pass','fail')
      GROUP BY logical_id, verdict
  ```
  Backed by the existing `idx_ksi_logical_verdict (logical_id, verdict)` index, de-dupes input, and chunks the `IN (...)` list under SQLite's host-parameter cap.
- Thread a prefetched outcome map through a new `toConsolidationEntries` helper, used at all three `.map(toConsolidationEntry)` call sites.
- `outcomeImpact` (still used by `lore data show`) now delegates to the batched form — single-lookup semantics unchanged.

Query count per consolidation pass drops from **N → 1** (the trim path is bounded by `CONSOLIDATION_BATCH_SIZE=50`, so exactly one query; the unbounded category path chunks under the parameter cap). Prompt output is unchanged (behavior-neutral).

## Tests

New `outcomeImpactMany` block in `ltm-outcome-reward.test.ts`:
- per-`logical_id` aggregation with **no cross-entry bleed** (mutation-verified: dropping `logical_id` from the `GROUP BY` fails exactly this test),
- parity with single `outcomeImpact` (mutation-verified: breaking the delegation fails this + the existing observability tests),
- duplicate-input correctness + empty-input → empty map.

> Note: dedup itself is a pure query-size optimization with no behavioral signature, so it is intentionally **not** asserted via a fragile internal query spy — the test asserts only observable contracts.

Full `ltm-outcome-reward` + curator/ltm suites pass; `tsc` + biome clean. Reviewed adversarially (mutation testing) before merge.

Part of a Sentry N+1 sweep since 0.34.0. The other new errors (3F temperature-batch, 3C dimension-mismatch, 3B blob vector scan) were already fixed post-0.34.0 (#1110/#1098/#1051) and resolved in 0.35.0. Lower-value N+1 follow-ups (3E per-candidate FTS, 3G per-tool-call insert) tracked in #1178.