### PR TITLE
fix(sync): eager-mint the scope DEK at `lore sync enable` (#1182)

### DIFF
--- a/packages/gateway/src/cli/sync-cmd.ts
+++ b/packages/gateway/src/cli/sync-cmd.ts
@@ -96,6 +96,24 @@ export async function cmdEnable(
     process.exitCode = 1;
     return;
   }
+
+  // Eager-mint the per-scope DEK now that encryption is "on", so scope_keys is enqueued
+  // and ships with the FIRST push. Otherwise it's minted lazily during the first knowledge
+  // encrypt (getScopeKey inside encryptColumns) and its capture lands a cycle later — a
+  // window where a fresh device pulls the ciphertext without the key and mints a DIVERGENT
+  // DEK, which under 0012 first-write-wins can orphan the data (#1182).
+  // Guard on user_id (mirrors the resolver's fail-closed contract) and swallow a transient
+  // mint failure: it degrades to the pre-fix lazy mint rather than aborting a valid enable.
+  if (user.user_id) {
+    try {
+      await keystore.getScopeKey(user.user_id);
+    } catch (e) {
+      console.error(
+        `sync: could not pre-provision the encryption key (will mint on first push): ${(e as Error).message}`,
+      );
+    }
+  }
+
   await runSync();
 }
 

--- a/packages/gateway/test/sync-cmd.test.ts
+++ b/packages/gateway/test/sync-cmd.test.ts
@@ -3,7 +3,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock the network + sync layers so cmdEnable is testable (bootstrapEncryption tests
 // inject their own syncKeys and never touch these).
-let mockUser: { github_login?: string } | null = { github_login: "octocat" };
+const TEST_UID = "11111111-1111-4111-8111-111111111111";
+let mockUser: { github_login?: string; user_id?: string } | null = {
+  github_login: "octocat",
+  user_id: TEST_UID,
+};
 let escrowRows: Array<{ id: number }> = [];
 let escrowError: { message: string } | null = null;
 const mockClient = {
@@ -48,11 +52,11 @@ const confirmed = () => Promise.resolve({ confirmed: true });
 
 beforeEach(() => {
   db().exec(
-    "DELETE FROM account_identity; DELETE FROM account_escrow; DELETE FROM scope_keys;",
+    "DELETE FROM account_identity; DELETE FROM account_escrow; DELETE FROM scope_keys; DELETE FROM sync_outbox;",
   );
   keystore.lock();
   if (syncData.isSyncEnabled()) syncData.disableSync();
-  mockUser = { github_login: "octocat" };
+  mockUser = { github_login: "octocat", user_id: TEST_UID };
   escrowRows = [];
   escrowError = null;
   pullOnceMock.mockClear();
@@ -221,6 +225,25 @@ describe("cmdEnable (C-4b activation)", () => {
     expect(syncData.isSyncEnabled()).toBe(true);
     expect(keystore.encryptionState()).toBe("on");
     expect(syncOnceMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("eager-mints the scope DEK so scope_keys ships with the first push (#1182)", async () => {
+    await cmdEnable(prompts({ newPassphrase: vi.fn(async () => "pw") }));
+    expect(keystore.encryptionState()).toBe("on");
+    // The DEK row is minted at enable-time (not lazily during the first encrypt), so it
+    // exists locally AND is enqueued in the outbox before the sync push runs.
+    const rows = (
+      db().query("SELECT COUNT(*) n FROM scope_keys").get() as { n: number }
+    ).n;
+    expect(rows).toBe(1);
+    const queued = (
+      db()
+        .query(
+          "SELECT COUNT(*) n FROM sync_outbox WHERE table_name='scope_keys'",
+        )
+        .get() as { n: number }
+    ).n;
+    expect(queued).toBeGreaterThanOrEqual(1);
   });
 
   it("refuses first-device setup when the escrow check is unreachable (clobber-safe)", async () => {

--- a/packages/gateway/test/sync-engine.integration.test.ts
+++ b/packages/gateway/test/sync-engine.integration.test.ts
@@ -422,13 +422,11 @@ describe.skipIf(SKIP)(
       insertKnowledge("ke", PLAIN);
       const push = await pushOnce(client);
       expect(push.pushed).toBeGreaterThanOrEqual(1);
-      // NOTE (real gap this e2e surfaced): the DEK row is minted lazily INSIDE the first
-      // push (getScopeKey during encrypt), so its capture lands too late for that cycle —
-      // the encrypted knowledge reaches the remote one cycle BEFORE scope_keys. A fresh
-      // device pulling in that window would mint a divergent DEK. The scheduler self-heals
-      // device-1 within a tick, but the window is a real risk (tracked in #1182: eager-
-      // mint the DEK at `lore sync enable` so scope_keys ships with the first push). Here
-      // a second push flushes it deterministically.
+      // NOTE: the DEK row is minted lazily INSIDE the first push (getScopeKey during
+      // encrypt), so its capture lands too late for that cycle. The real CLI path avoids
+      // this by eager-minting at `lore sync enable` (cmdEnable, #1182) so scope_keys ships
+      // with the first push; this engine-level test bypasses cmdEnable, so it flushes the
+      // DEK deterministically with a second push.
       await pushOnce(client);
       const rk = await h.asUser(uid, (c) =>
         c.query("select 1 from public.scope_keys").then((x) => x.rows),


### PR DESCRIPTION
## Problem
The per-scope DEK (`scope_keys`) was minted **lazily inside** the first encrypted knowledge push (`getScopeKey` within `encryptColumns`). That INSERT's outbox capture fires *after* the `scope_keys` table was already drained in the same cycle, so the ciphertext `knowledge` reaches the remote **one cycle before** `scope_keys`. A fresh device pulling in that window finds ciphertext + escrow but **no key**, and after unlocking mints a **divergent DEK** — which under migration 0012 (`wrapped_dek` first-write-wins) can **orphan** device-1's data or lock a device out.

Surfaced by the end-to-end encrypted round-trip test (#1181), which had to work around it with a second push.

## Fix
`cmdEnable` eager-mints the DEK (`keystore.getScopeKey(user.user_id)`) as soon as encryption reaches `"on"`, **before** `runSync` — so `scope_keys` is enqueued and ships in the **first** push (before/with the encrypted knowledge). Encryption is only ever armed via `lore sync enable`, so this single place closes the window for all paths (the gateway's later pushes always find `scope_keys` already established). `getScopeKey` is idempotent (`ON CONFLICT DO NOTHING`), so re-running `enable` is a no-op.

## Tests
- `sync-cmd.test.ts`: new test asserts `cmdEnable` mints `scope_keys` locally **and** enqueues it in the outbox before the sync push runs.
- Updated the engine e2e NOTE to point at the CLI eager-mint (that test bypasses `cmdEnable`, so it still flushes with a second push).

Typecheck + lint clean; 18 sync-cmd tests + 11 engine integration tests pass.