### PR TITLE
feat(core): throttle the temporal re-chunk backfill CPU on constrained hosts

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -578,6 +578,19 @@ export const LoreConfig = z.object({
             .describe(
               "Number of local embedding worker threads (each loads its own ~137MB model). Default: memory-gated (1–2). Override with LORE_EMBED_POOL_SIZE.",
             ),
+          /** Duty cycle (0.1–1.0) for the one-time temporal re-chunk backfill:
+           *  the fraction of wall-clock time it may spend embedding, sleeping the
+           *  rest so it doesn't peg a core on weak hosts. 1.0 = full speed (no
+           *  throttle). Omit to auto-scale by CPU count (full speed on roomy
+           *  hosts, gentler on small ones). Override with LORE_BACKFILL_CPU_DUTY. */
+          backfillCpuDuty: z
+            .number()
+            .min(0.1)
+            .max(1)
+            .optional()
+            .describe(
+              "Duty cycle (0.1–1.0) for the one-time temporal re-chunk backfill — the fraction of time it may spend embedding, sleeping the rest so it doesn't peg a core on weak hosts. 1.0 = full speed. Default: auto-scaled by CPU count. Override with LORE_BACKFILL_CPU_DUTY.",
+            ),
         })
         .default({
           enabled: true,

--- a/packages/core/src/embedding-cap.ts
+++ b/packages/core/src/embedding-cap.ts
@@ -315,3 +315,58 @@ export function reprobeEmbedCap(
     EMBED_TOKEN_CEILING,
   );
 }
+
+/** CPU-count at/above which the one-time temporal re-chunk backfill runs at full
+ *  speed (no throttle) by default. Below it, the auto duty cycle scales down so a
+ *  weak, few-core host isn't pegged by a background migration. */
+export const BACKFILL_FULLSPEED_CORES = 8;
+
+/** Floor for the auto-scaled duty cycle: even a 1-core host runs the backfill at
+ *  least this fraction of the time, so a large corpus still finishes in bounded
+ *  wall-clock rather than crawling forever. */
+export const BACKFILL_MIN_AUTO_DUTY = 0.4;
+
+/** Hard cap on a single inter-row throttle sleep. Keeps the walk responsive to
+ *  shutdown/reset even if one embed was an outlier (e.g. a huge merged tail),
+ *  and bounds the effect of a pathological duty value. */
+export const BACKFILL_THROTTLE_MAX_SLEEP_MS = 2_000;
+
+/**
+ * Resolve the duty cycle (0.1–1.0) for the temporal re-chunk backfill: the
+ * fraction of wall-clock time it may spend embedding, sleeping the rest so a
+ * background migration doesn't peg a core on a weak host.
+ *
+ * An explicit `configured` value (from `search.embeddings.backfillCpuDuty` or
+ * `LORE_BACKFILL_CPU_DUTY`) always wins, clamped to [0.1, 1]. Otherwise it
+ * auto-scales by logical CPU count: full speed (1.0) at
+ * {@link BACKFILL_FULLSPEED_CORES}+ cores, scaling down linearly to a
+ * {@link BACKFILL_MIN_AUTO_DUTY} floor on smaller hosts. Non-finite/≤0 core
+ * counts fall back to the floor (fail-safe: throttle rather than peg).
+ */
+export function resolveBackfillCpuDuty(
+  configured: number | undefined,
+  cores: number,
+): number {
+  if (configured != null && Number.isFinite(configured)) {
+    return Math.min(1, Math.max(0.1, configured));
+  }
+  if (!Number.isFinite(cores) || cores <= 0) return BACKFILL_MIN_AUTO_DUTY;
+  const scaled = cores / BACKFILL_FULLSPEED_CORES;
+  return Math.min(1, Math.max(BACKFILL_MIN_AUTO_DUTY, scaled));
+}
+
+/**
+ * Inter-row throttle sleep (ms) for a given embed duration and duty cycle. To
+ * hold the duty cycle `d = work / (work + sleep)`, sleep `elapsed·(1−d)/d`.
+ * `duty >= 1` (or non-positive elapsed) → 0 (no throttle). Bounded by
+ * {@link BACKFILL_THROTTLE_MAX_SLEEP_MS}.
+ */
+export function backfillThrottleSleepMs(
+  embedElapsedMs: number,
+  duty: number,
+): number {
+  if (!(duty < 1) || !(embedElapsedMs > 0)) return 0;
+  const d = Math.min(1, Math.max(0.1, duty));
+  const sleep = embedElapsedMs * ((1 - d) / d);
+  return Math.min(BACKFILL_THROTTLE_MAX_SLEEP_MS, Math.round(sleep));
+}

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -13,7 +13,7 @@
  * back silently to FTS-only when unavailable.
  */
 
-import { freemem } from "node:os";
+import { availableParallelism, freemem } from "node:os";
 import { performance } from "node:perf_hooks";
 import { db, getKV, setKV } from "./db";
 import { isVecAvailable } from "./db/vec";
@@ -44,12 +44,14 @@ import {
   MODEL_MAX_TOKENS,
   PER_WORKER_MEM_BUDGET_BYTES,
   EMBED_POOL_ABS_MAX,
+  backfillThrottleSleepMs,
   backoffEmbedCap,
   clampFreeToContainerLimit,
   desiredEmbedPoolSize,
   memoryModelEmbedCap,
   reconcileEmbedCap,
   reprobeEmbedCap,
+  resolveBackfillCpuDuty,
   shouldReprobeEmbedCap,
   type PersistedEmbedCap,
 } from "./embedding-cap";
@@ -1187,6 +1189,42 @@ function configuredEmbedPoolSize(): number | undefined {
  *  to `undefined`, never `NaN`) without spinning up a pool. */
 export function _configuredEmbedPoolSize(): number | undefined {
   return configuredEmbedPoolSize();
+}
+
+/** Resolve the configured backfill CPU duty cycle: `LORE_BACKFILL_CPU_DUTY`
+ *  wins, then `search.embeddings.backfillCpuDuty`, else `undefined` (auto-scaled
+ *  by CPU count — full speed on roomy hosts, gentler on small ones). Invalid
+ *  values are ignored (fall through). Read per-call so config reloads take
+ *  effect. */
+function configuredBackfillCpuDuty(): number | undefined {
+  const raw = process.env.LORE_BACKFILL_CPU_DUTY;
+  if (raw !== undefined) {
+    const n = Number(raw);
+    if (Number.isFinite(n) && n > 0) return n; // clamped in resolveBackfillCpuDuty
+    // invalid env → ignore, fall through to config
+  }
+  const cfg = config().search.embeddings.backfillCpuDuty;
+  if (typeof cfg === "number" && Number.isFinite(cfg) && cfg > 0) return cfg;
+  return undefined;
+}
+
+/** Test seam: exposes the env/config resolution for {@link backfillThrottleSleepMs}. */
+export function _configuredBackfillCpuDuty(): number | undefined {
+  return configuredBackfillCpuDuty();
+}
+
+/** The inter-row throttle sleep used by the temporal backfill. Indirected behind
+ *  a module variable so tests can observe it (and skip the real timer) without
+ *  wall-clock flakiness. */
+let backfillSleep: (ms: number) => Promise<void> = (ms) =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Test seam: replace the backfill throttle sleep (null restores the default). */
+export function _setBackfillSleepForTest(
+  fn: ((ms: number) => Promise<void>) | null,
+): void {
+  backfillSleep =
+    fn ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
 }
 
 /** Test-only override of the embedding-pool ceiling (null clears). Sets the
@@ -3138,6 +3176,14 @@ export async function backfillTemporalEmbeddings(
   const PROGRESS_INTERVAL_MS = 30_000;
   let lastProgressAt = Date.now();
 
+  // CPU duty cycle for this walk: after each row we sleep a fraction of the
+  // time the embed took so a one-time background migration doesn't peg a core on
+  // a weak host. Resolved once per walk (full speed on roomy hosts).
+  const backfillDuty = resolveBackfillCpuDuty(
+    configuredBackfillCpuDuty(),
+    availableParallelism(),
+  );
+
   for (;;) {
     // `length(content) >= 50` mirrors embedTemporalMessage's short-message skip,
     // so the walk never embeds a message the write path would have ignored.
@@ -3202,6 +3248,7 @@ export async function backfillTemporalEmbeddings(
       // cleared the moment the embed settles — success or catchable error — so
       // only a hard process death ever leaves it set.
       setKV(TEMPORAL_RECHUNK_INFLIGHT_KEY, row.id);
+      const embedStartedAt = Date.now();
       try {
         // Count only messages that actually got a chunk set written. A row that
         // reduces to zero embeddable units (store() never persists one, but the
@@ -3254,6 +3301,15 @@ export async function backfillTemporalEmbeddings(
         );
         lastProgressAt = Date.now();
       }
+
+      // CPU throttle: sleep a fraction of the embed time so this one-time
+      // migration doesn't peg a core on a weak host. After the checkpoint, so a
+      // crash while sleeping resumes cleanly. Skipped entirely at full duty.
+      const throttleMs = backfillThrottleSleepMs(
+        Date.now() - embedStartedAt,
+        backfillDuty,
+      );
+      if (throttleMs > 0) await backfillSleep(throttleMs);
     }
 
     if (stop) break;

--- a/packages/core/test/embedding-backfill-throttle.test.ts
+++ b/packages/core/test/embedding-backfill-throttle.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { db, ensureProject } from "../src/db";
+import { ensureVec0Store, setStorageMode } from "../src/db/vec-store";
+import {
+  backfillTemporalEmbeddings,
+  resetTemporalRechunkProgress,
+  _restoreProvider,
+  _saveAndClearProvider,
+  _setBackfillSleepForTest,
+} from "../src/embedding";
+
+// The temporal re-chunk backfill sleeps a fraction of each embed's duration so a
+// one-time background migration doesn't peg a core on a weak host. These tests
+// drive the loop through an injectable sleep seam so the wiring is asserted
+// without wall-clock flakiness.
+
+const PROJECT = "/test/backfill-throttle";
+const DIM = 4;
+
+function vec(): Float32Array {
+  const a = new Float32Array(DIM);
+  a[0] = 1;
+  return a;
+}
+
+/** Real timer (the seam replaces only the throttle sleep, not this). */
+function realDelay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function insertMsg(id: string, pid: string): void {
+  const content = `temporal message ${id} with more than enough content to embed`;
+  db()
+    .query(
+      "INSERT INTO temporal_messages (id, project_id, session_id, role, content, tokens, distilled, created_at) VALUES (?, ?, 's', 'user', ?, 0, 0, 0)",
+    )
+    .run(id, pid, content);
+}
+
+describe("temporal re-chunk backfill CPU throttle", () => {
+  let pid: string;
+  let providerToken: unknown;
+  const sleeps: number[] = [];
+
+  beforeEach(() => {
+    pid = ensureProject(PROJECT);
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    db().query("DELETE FROM temporal_vec").run();
+    db().query("DELETE FROM temporal_messages").run();
+    resetTemporalRechunkProgress();
+    sleeps.length = 0;
+    _setBackfillSleepForTest((ms) => {
+      sleeps.push(ms);
+      return Promise.resolve(); // record + skip the real timer
+    });
+    providerToken = _saveAndClearProvider();
+    _restoreProvider({
+      provider: {
+        maxBatchSize: 8,
+        async embed(texts: string[]) {
+          // A measurable embed duration so the duty-cycle sleep is non-zero.
+          await realDelay(15);
+          return texts.map(() => vec());
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    _restoreProvider(providerToken);
+    _setBackfillSleepForTest(null);
+    delete process.env.LORE_BACKFILL_CPU_DUTY;
+  });
+
+  it("throttles between rows when the duty cycle is below 1", async () => {
+    process.env.LORE_BACKFILL_CPU_DUTY = "0.5";
+    insertMsg("t1", pid);
+    insertMsg("t2", pid);
+
+    const processed = await backfillTemporalEmbeddings();
+
+    expect(processed).toBe(2);
+    // One throttle sleep per embedded row, each strictly positive (elapsed·1).
+    expect(sleeps).toHaveLength(2);
+    expect(sleeps.every((ms) => ms > 0)).toBe(true);
+  });
+
+  it("does not throttle at full duty (1.0)", async () => {
+    process.env.LORE_BACKFILL_CPU_DUTY = "1";
+    insertMsg("t1", pid);
+    insertMsg("t2", pid);
+
+    const processed = await backfillTemporalEmbeddings();
+
+    expect(processed).toBe(2);
+    expect(sleeps).toHaveLength(0);
+  });
+});

--- a/packages/core/test/embedding-cap.test.ts
+++ b/packages/core/test/embedding-cap.test.ts
@@ -1,11 +1,14 @@
 import { describe, it, expect } from "vitest";
 import {
+  BACKFILL_MIN_AUTO_DUTY,
+  BACKFILL_THROTTLE_MAX_SLEEP_MS,
   DEFAULT_MAX_EMBED_POOL,
   EMBED_POOL_ABS_MAX,
   MIN_EMBED_TOKENS,
   MODEL_MAX_TOKENS,
   PER_WORKER_MEM_BUDGET_BYTES,
   EMBED_TOKEN_CEILING,
+  backfillThrottleSleepMs,
   backoffEmbedCap,
   clampEmbedCap,
   clampFreeToContainerLimit,
@@ -13,6 +16,7 @@ import {
   memoryModelEmbedCap,
   reconcileEmbedCap,
   reprobeEmbedCap,
+  resolveBackfillCpuDuty,
   shouldReprobeEmbedCap,
 } from "../src/embedding-cap";
 
@@ -367,5 +371,61 @@ describe("desiredEmbedPoolSize", () => {
     expect(desiredEmbedPoolSize(Number.NaN)).toBe(1);
     expect(desiredEmbedPoolSize(-100)).toBe(1);
     expect(desiredEmbedPoolSize(0, 8)).toBe(1);
+  });
+});
+
+describe("resolveBackfillCpuDuty", () => {
+  it("honors an explicit configured value, clamped to [0.1, 1]", () => {
+    // Explicit config/env wins regardless of core count.
+    expect(resolveBackfillCpuDuty(0.5, 2)).toBe(0.5);
+    expect(resolveBackfillCpuDuty(0.5, 64)).toBe(0.5);
+    expect(resolveBackfillCpuDuty(1, 1)).toBe(1);
+    // Out-of-range values are clamped rather than rejected.
+    expect(resolveBackfillCpuDuty(2, 8)).toBe(1);
+    expect(resolveBackfillCpuDuty(0.01, 8)).toBe(0.1);
+  });
+
+  it("auto-scales by CPU count when unconfigured: full speed on roomy hosts", () => {
+    expect(resolveBackfillCpuDuty(undefined, 8)).toBe(1);
+    expect(resolveBackfillCpuDuty(undefined, 16)).toBe(1); // clamped at 1
+    expect(resolveBackfillCpuDuty(undefined, 4)).toBe(0.5); // 4/8
+    expect(resolveBackfillCpuDuty(undefined, 6)).toBe(0.75); // 6/8
+  });
+
+  it("floors the auto duty on small hosts so a large corpus still finishes", () => {
+    // 2/8 = 0.25 < floor → floor; 1 core likewise.
+    expect(resolveBackfillCpuDuty(undefined, 2)).toBe(BACKFILL_MIN_AUTO_DUTY);
+    expect(resolveBackfillCpuDuty(undefined, 1)).toBe(BACKFILL_MIN_AUTO_DUTY);
+  });
+
+  it("fails safe to the floor for a non-finite or non-positive core count", () => {
+    expect(resolveBackfillCpuDuty(undefined, 0)).toBe(BACKFILL_MIN_AUTO_DUTY);
+    expect(resolveBackfillCpuDuty(undefined, Number.NaN)).toBe(
+      BACKFILL_MIN_AUTO_DUTY,
+    );
+    // A non-finite configured value is ignored → auto path.
+    expect(resolveBackfillCpuDuty(Number.NaN, 8)).toBe(1);
+  });
+});
+
+describe("backfillThrottleSleepMs", () => {
+  it("holds the duty cycle: sleep = elapsed·(1−d)/d", () => {
+    expect(backfillThrottleSleepMs(100, 0.5)).toBe(100); // 100·0.5/0.5
+    expect(backfillThrottleSleepMs(100, 0.8)).toBe(25); // 100·0.2/0.8
+    expect(backfillThrottleSleepMs(300, 0.75)).toBe(100); // 300·0.25/0.75
+  });
+
+  it("never throttles at full duty or for a non-positive elapsed", () => {
+    expect(backfillThrottleSleepMs(100, 1)).toBe(0);
+    expect(backfillThrottleSleepMs(100, 1.5)).toBe(0); // duty > 1 guarded
+    expect(backfillThrottleSleepMs(0, 0.5)).toBe(0);
+    expect(backfillThrottleSleepMs(-5, 0.5)).toBe(0);
+  });
+
+  it("caps a single sleep so an outlier embed can't stall the walk", () => {
+    // duty 0.1 over a huge elapsed would ask for 9× elapsed → capped.
+    expect(backfillThrottleSleepMs(10 * 60_000, 0.1)).toBe(
+      BACKFILL_THROTTLE_MAX_SLEEP_MS,
+    );
   });
 });

--- a/packages/website/src/content/docs/docs/configuration.md
+++ b/packages/website/src/content/docs/docs/configuration.md
@@ -187,6 +187,7 @@ Vector embedding search provider, model, and dimensions.
 | `workerOffload` | boolean | `true` |  | Run vector searches on a read-worker pool off the main event loop. Kill switch (default true); set false to force the in-process path. |
 | `workerPoolSize` | number | `2` | min 1, max 16 | Number of read-worker threads for off-thread vector search. Default: 2. |
 | `embedPoolSize` | number | — | min 1, max 8 | Number of local embedding worker threads (each loads its own ~137MB model). Default: memory-gated (1–2). Override with LORE_EMBED_POOL_SIZE. |
+| `backfillCpuDuty` | number | — | min 0.1, max 1 | Duty cycle (0.1–1.0) for the one-time temporal re-chunk backfill — the fraction of time it may spend embedding, sleeping the rest so it doesn't peg a core on weak hosts. 1.0 = full speed. Default: auto-scaled by CPU count. Override with LORE_BACKFILL_CPU_DUTY. |
 
 ### `search.recall`
 

--- a/packages/website/src/content/docs/docs/environment.md
+++ b/packages/website/src/content/docs/docs/environment.md
@@ -70,6 +70,7 @@ Env vars override `.lore.json` for the same setting. To override a `.lore.json` 
 
 | Variable | Description |
 |---|---|
+| `LORE_BACKFILL_CPU_DUTY` | Resolve the configured backfill CPU duty cycle: `LORE_BACKFILL_CPU_DUTY` wins, then `search.embeddings.backfillCpuDuty`, else `undefined` (auto-scaled by CPU count — full speed on roomy hosts, gentler on small ones). Invalid values are ignored (fall through). Read per-call so config reloads take effect. |
 | `LORE_DB_PATH` | Resolved path of the SQLite database file. Reads `LORE_DB_PATH` first; falls back to `${dataDir}/lore.db` (typically `~/.local/share/lore/lore.db`). The test preload (`packages/core/test/setup.ts`) sets `LORE_DB_PATH` to a temp directory so tests never touch the production DB. Setting it to a non-existent path will create the file on first use. The gateway itself does not set this — it expects a stable location for the DB so the SQLite WAL and FTS5 indices persist across restarts. Env: `LORE_DB_PATH`. |
 | `LORE_DISABLE_VEC` | LORE_DISABLE_VEC=1 forces the JS brute-force vector-search path. Useful as a production kill-switch if the native extension causes issues, and as a test seam for the JS fallback. Set before the first `db()` call — once attempted=true is sticky for the connection lifetime, the env var won't be re-read until resetVecState() runs (in close()). |
 | `LORE_DISABLE_VEC_WORKER` | Kill switch: force the in-process vector-search path, disabling the off-thread read-worker pool. Default-on escape hatch, not opt-in. |


### PR DESCRIPTION
## Context

Follow-up to #1175 (embedding-pool OOM) and #1176 (backfill livelock). With those merged, Onur's box no longer OOMs — a fresh screenshot on his i5-7200U (2C/4T, 7.65 GiB) shows lore at **544 MB RSS, 82% RAM free, swap idle**. The memory bug is gone.

But he still read it as "not fixed" because lore was pegging ~one core (**56% CPU, 17 threads, load ~2**): the one-time blob→vec0 re-chunk backfill re-embedding his entire message history. It no longer crashes (so it genuinely progresses now), but on a weak few-core host it grinds a core continuously until the (potentially 220K-row) corpus is done — noisy, hot, and disruptive to everything else on the box.

## Fix

A **duty-cycle throttle** for the backfill walk: after each row it sleeps a fraction of the time that row's embed took, holding a target duty cycle so the migration leaves CPU headroom for the rest of the machine. Self-calibrating (proportional to real embed cost), portable (no hard-coded delays), and it only affects the one-time background backfill — never live recall.

- The sleep is placed **after** the per-row cursor checkpoint, so a crash while sleeping resumes cleanly; and it's skipped entirely at full duty.
- Configurable via `search.embeddings.backfillCpuDuty` / `LORE_BACKFILL_CPU_DUTY` (0.1–1.0; 1.0 = full speed).
- Unset, it **auto-scales by CPU count**: full speed at 8+ logical cores, scaling down linearly to a 0.4 floor on smaller hosts (so a large corpus still finishes in bounded wall-clock). Non-finite/≤0 core counts fail safe to the floor.
- A single sleep is capped (2s) so an outlier embed can't stall shutdown.

## Tests

- Pure `resolveBackfillCpuDuty` battery: explicit-value clamping, CPU auto-scaling, small-host floor, non-finite fail-safe.
- Pure `backfillThrottleSleepMs`: duty-cycle math, full-duty/non-positive no-op, outlier cap.
- Loop wiring via an injected sleep seam: throttles once per row below 1.0, no sleep at 1.0.

Mutation-verified: dropping the loop sleep, the auto floor, or the sleep cap each turns a test red. Full `@loreai/core` suite (2633), typecheck, biome, and `check:docs` all green.

## Immediate advice for Onur
Keep `LORE_EMBED_POOL_SIZE=1` (right for a 2-core box anyway); the backfill will finish and stop. Once on a nightly with this, the grind eases automatically; `LORE_BACKFILL_CPU_DUTY=0.3` throttles it further if desired.