### PR TITLE
feat(core): objective, justifier-free coding-agent degradation signals (#961)

### DIFF
--- a/packages/core/src/degradation-signals.ts
+++ b/packages/core/src/degradation-signals.ts
@@ -1,0 +1,539 @@
+/**
+ * Coding-agent degradation signals — a pure, no-LLM analysis engine.
+ *
+ * A faithful TypeScript port of the contextrot methodology
+ * (github.com/Priyanshu-byte-coder/contextrot, MIT), adapted for Lore's
+ * eval + benchmark suite (issue #961). It turns a normalized agent trace into
+ * per-step behavioral failure signals and a bucketed "rot curve", using only
+ * inspectable heuristics — no LLM judge, no "justifier" synthesis — so it can
+ * score an agent's *actual behavior* rather than a lenient re-narration of it.
+ *
+ * Five independent per-step signals (each reported separately AND combined, so
+ * one noisy signal can never silently dominate):
+ *   - tool_error:      any tool call in the step returned an error
+ *   - edit_failure:    an editing tool (edit/write/multiedit/…) errored — the
+ *                      clearest "agent lost track of file state" event
+ *   - retry:           the step repeats a (tool, target) pair that errored
+ *                      within the previous `RETRY_WINDOW` steps
+ *   - reread:          the step re-reads a file already read earlier in the
+ *                      session (a proxy for context scrolling out of attention)
+ *   - self_correction: assistant text contains apology/correction language
+ *
+ * Deliberate deviation from upstream contextrot: the rot curve supports an
+ * **absolute prompt-token** x-axis in addition to the fill-% axis. Lore keeps
+ * the context window deliberately low (compaction/distillation), so a fill-%
+ * axis is confounded when comparing Lore-on vs Lore-off; the absolute-token
+ * axis places both on the same scale and lets us locate the empirical
+ * degradation "knee" in token units — the input to Lore's context sweet-spot.
+ *
+ * Statistics are kept honest exactly as upstream: Wilson 95% score intervals,
+ * visible n-counts, low-confidence flags, and a conservative knee test.
+ * This module is intentionally free of DB and LLM dependencies so it can run
+ * over any source (eval transcripts, opencode.db, tool_calls) and under Bun.
+ */
+
+// ---------------------------------------------------------------------------
+// Signal definitions
+// ---------------------------------------------------------------------------
+
+export const SIGNAL_NAMES = [
+  "tool_error",
+  "edit_failure",
+  "retry",
+  "reread",
+  "self_correction",
+] as const;
+
+export type SignalName = (typeof SIGNAL_NAMES)[number];
+
+/**
+ * Editing tools whose failure is an `edit_failure`. Matched case-insensitively
+ * so both Claude Code (`Edit`, `Write`) and opencode/lore (`edit`, `write`)
+ * tool names resolve identically.
+ */
+export const EDIT_TOOLS: ReadonlySet<string> = new Set([
+  "edit",
+  "write",
+  "multiedit",
+  "notebookedit",
+  "str_replace_editor",
+  "apply_patch",
+  "patch",
+]);
+
+/** Reading tools tracked for the `reread` signal (case-insensitive). */
+export const READ_TOOLS: ReadonlySet<string> = new Set([
+  "read",
+  "notebookread",
+]);
+
+/**
+ * Apology / correction phrases marking a self-recognized error. Mirrors
+ * upstream contextrot's pattern; `\b` word boundaries keep it from matching
+ * inside larger words.
+ */
+const SELF_CORRECTION_RE =
+  /\b(i apologize|apologies|my mistake|my error|i made a mistake|i made an error|let me (?:fix|correct) (?:that|this|my)|that was (?:wrong|incorrect)|that's (?:wrong|incorrect)|i was wrong|oops|correcting my)\b/i;
+
+/** How many steps back an error stays "recent" for retry matching. */
+export const RETRY_WINDOW = 6;
+
+// ---------------------------------------------------------------------------
+// Normalized trace input contract
+// ---------------------------------------------------------------------------
+
+/**
+ * A single tool invocation within a step. `target` is the salient identity of
+ * the call used by the retry/reread heuristics — a file path for edit/read, a
+ * command string for bash, etc. When `target` is absent, retry/reread can not
+ * fire for that call (the safe, no-false-positive direction).
+ */
+export interface TraceToolCall {
+  name: string;
+  target?: string | null;
+  isError: boolean;
+}
+
+/**
+ * One model step (an assistant API call and the tool results it triggered).
+ * `promptTokens` is the prompt-side context size at that moment
+ * (`input + cache_read + cache_creation`); it drives the rot-curve x-axis and
+ * may be 0/absent for sources that don't carry real token accounting.
+ */
+export interface TraceStep {
+  role?: "user" | "assistant";
+  assistantText?: string;
+  toolCalls?: TraceToolCall[];
+  promptTokens?: number;
+  model?: string;
+}
+
+/** Per-step signal flags plus the `degraded` composite. */
+export interface StepSignals {
+  stepIndex: number;
+  promptTokens: number;
+  tool_error: boolean;
+  edit_failure: boolean;
+  retry: boolean;
+  reread: boolean;
+  self_correction: boolean;
+  /** True when ANY of the five signals fired. */
+  degraded: boolean;
+}
+
+const SEP = "\x1f";
+
+/**
+ * Extract per-step signals from an ordered list of trace steps.
+ *
+ * State carried across steps: `recentErrors` maps a `(tool, target)` pair to
+ * the index of the step where it last errored (for retry detection), and
+ * `filesRead` accumulates every file target seen (for reread detection).
+ * A repeat of a recently-errored `(tool, target)` counts as a retry whether or
+ * not the repeated attempt itself succeeds.
+ */
+export function extractSignals(steps: readonly TraceStep[]): StepSignals[] {
+  const out: StepSignals[] = [];
+  const recentErrors = new Map<string, number>();
+  const filesRead = new Set<string>();
+
+  for (let i = 0; i < steps.length; i++) {
+    const step = steps[i];
+    let toolError = false;
+    let editFailure = false;
+    let retry = false;
+    let reread = false;
+
+    for (const call of step.toolCalls ?? []) {
+      const name = call.name.toLowerCase();
+      const target = call.target ?? "";
+      const key = `${name}${SEP}${target}`;
+
+      if (READ_TOOLS.has(name) && target) {
+        if (filesRead.has(target)) reread = true;
+        filesRead.add(target);
+      }
+
+      // A repeat of a recently errored (tool, target) is a retry, whether or
+      // not this attempt succeeds. Requires a concrete target.
+      const errorStep = recentErrors.get(key);
+      if (errorStep !== undefined && target && i - errorStep <= RETRY_WINDOW) {
+        retry = true;
+      }
+
+      if (call.isError) {
+        toolError = true;
+        if (EDIT_TOOLS.has(name)) editFailure = true;
+        if (target) recentErrors.set(key, i);
+      }
+    }
+
+    const selfCorrection =
+      !!step.assistantText && SELF_CORRECTION_RE.test(step.assistantText);
+
+    out.push({
+      stepIndex: i,
+      promptTokens: step.promptTokens ?? 0,
+      tool_error: toolError,
+      edit_failure: editFailure,
+      retry,
+      reread,
+      self_correction: selfCorrection,
+      degraded: toolError || editFailure || retry || reread || selfCorrection,
+    });
+  }
+
+  return out;
+}
+
+/** Sum the per-signal totals across a set of step signals. */
+export function signalTotals(
+  steps: readonly StepSignals[],
+): Record<SignalName, number> {
+  const totals = Object.fromEntries(SIGNAL_NAMES.map((n) => [n, 0])) as Record<
+    SignalName,
+    number
+  >;
+  for (const s of steps) {
+    for (const name of SIGNAL_NAMES) {
+      if (s[name]) totals[name] += 1;
+    }
+  }
+  return totals;
+}
+
+// ---------------------------------------------------------------------------
+// Wilson score interval
+// ---------------------------------------------------------------------------
+
+/**
+ * Wilson 95% score interval for a binomial rate. Chosen over the normal
+ * approximation because bucket counts are often small and rates sit near 0.
+ * Returns `[0, 1]` for an empty sample.
+ */
+export function wilsonInterval(
+  successes: number,
+  n: number,
+  z = 1.96,
+): [number, number] {
+  if (n === 0) return [0, 1];
+  const p = successes / n;
+  const denom = 1 + (z * z) / n;
+  const center = (p + (z * z) / (2 * n)) / denom;
+  const margin =
+    (z / denom) * Math.sqrt((p * (1 - p)) / n + (z * z) / (4 * n * n));
+  return [Math.max(0, center - margin), Math.min(1, center + margin)];
+}
+
+// ---------------------------------------------------------------------------
+// Rot curve
+// ---------------------------------------------------------------------------
+
+export type RotAxis = "fill" | "tokens";
+
+export interface RotBucket {
+  /** Inclusive lower bound of the bucket, in axis units (% or tokens). */
+  lo: number;
+  /** Exclusive upper bound of the bucket, in axis units. */
+  hi: number;
+  n: number;
+  degraded: number;
+  bySignal: Record<SignalName, number>;
+  rate: number;
+  ci: [number, number];
+  lowConfidence: boolean;
+}
+
+export interface RotCurveOptions {
+  /** `"fill"` (prompt tokens ÷ window, default) or `"tokens"` (absolute). */
+  axis?: RotAxis;
+  /** Context window for the fill axis. Default 200_000. */
+  contextWindow?: number;
+  /** Bucket width in axis units. Default 10 (fill %) or 25_000 (tokens). */
+  bucketWidth?: number;
+  /** Upper edge of the "fresh" zone. Default 40 (fill) or 40_000 (tokens). */
+  freshMax?: number;
+  /** Lower edge of the "deep" zone. Default 60 (fill) or 100_000 (tokens). */
+  deepMin?: number;
+  /** Buckets below this many steps are flagged low-confidence. Default 15. */
+  minBucketN?: number;
+  /** Bucket-rate ÷ fresh-rate that marks the degradation knee. Default 1.5. */
+  kneeRatio?: number;
+}
+
+export interface RotCurve {
+  axis: RotAxis;
+  bucketWidth: number;
+  buckets: RotBucket[];
+  totalSteps: number;
+  totalDegraded: number;
+  overallRate: number;
+  /** Degraded rate below `freshMax`. Null when the fresh zone is empty. */
+  freshRate: number | null;
+  /** Degraded rate at/above `deepMin`. Null when the deep zone is empty. */
+  deepRate: number | null;
+  freshN: number;
+  deepN: number;
+  /** deepRate ÷ freshRate. `Infinity` when fresh is 0 but deep > 0. */
+  degradationRatio: number | null;
+  /** True only when the two zones' Wilson intervals do not overlap. */
+  ratioSignificant: boolean;
+  /** Lower bound (axis units) of the first bucket clearing the knee test. */
+  knee: number | null;
+  signalTotals: Record<SignalName, number>;
+}
+
+const AXIS_DEFAULTS: Record<
+  RotAxis,
+  { bucketWidth: number; freshMax: number; deepMin: number }
+> = {
+  fill: { bucketWidth: 10, freshMax: 40, deepMin: 60 },
+  tokens: { bucketWidth: 25_000, freshMax: 40_000, deepMin: 100_000 },
+};
+
+function emptySignalCounts(): Record<SignalName, number> {
+  return Object.fromEntries(SIGNAL_NAMES.map((n) => [n, 0])) as Record<
+    SignalName,
+    number
+  >;
+}
+
+/**
+ * Build a bucketed rot curve from per-step signals. Steps are bucketed by the
+ * chosen x-axis, and per bucket we report the degraded rate with a Wilson 95%
+ * interval. The "knee" is the lower bound of the first non-low-confidence
+ * bucket at/above `freshMax` whose point estimate is ≥ `kneeRatio` × the
+ * fresh-zone rate AND whose CI floor clears the fresh-zone rate — so a single
+ * noisy bucket can never declare a threshold.
+ *
+ * All statistics are observational: this is a diagnostic, not a controlled
+ * experiment. Association between context size and failure signals may partly
+ * reflect task difficulty rather than degradation.
+ */
+export function buildRotCurve(
+  steps: readonly StepSignals[],
+  options: RotCurveOptions = {},
+): RotCurve {
+  const axis = options.axis ?? "fill";
+  const defaults = AXIS_DEFAULTS[axis];
+  const bucketWidth = Math.max(1, options.bucketWidth ?? defaults.bucketWidth);
+  const freshMax = options.freshMax ?? defaults.freshMax;
+  const deepMin = options.deepMin ?? defaults.deepMin;
+  const minBucketN = options.minBucketN ?? 15;
+  const kneeRatio = options.kneeRatio ?? 1.5;
+  const contextWindow = Math.max(1, options.contextWindow ?? 200_000);
+
+  const axisValue = (s: StepSignals): number =>
+    axis === "fill"
+      ? Math.min(100, (100 * s.promptTokens) / contextWindow)
+      : Math.max(0, s.promptTokens);
+
+  // Fill has a fixed 0..100 domain; tokens grows to the observed maximum.
+  let maxAxis = 0;
+  for (const s of steps) maxAxis = Math.max(maxAxis, axisValue(s));
+  const domainTop = axis === "fill" ? 100 : maxAxis;
+  const bucketCount = Math.max(
+    1,
+    axis === "fill"
+      ? Math.ceil(100 / bucketWidth)
+      : Math.floor(domainTop / bucketWidth) + 1,
+  );
+
+  const buckets: RotBucket[] = Array.from({ length: bucketCount }, (_, i) => ({
+    lo: i * bucketWidth,
+    hi: (i + 1) * bucketWidth,
+    n: 0,
+    degraded: 0,
+    bySignal: emptySignalCounts(),
+    rate: 0,
+    ci: [0, 1] as [number, number],
+    lowConfidence: true,
+  }));
+
+  const totals = emptySignalCounts();
+  let totalDegraded = 0;
+  let freshN = 0;
+  let freshD = 0;
+  let deepN = 0;
+  let deepD = 0;
+
+  for (const s of steps) {
+    const value = axisValue(s);
+    const idx = Math.min(Math.floor(value / bucketWidth), buckets.length - 1);
+    const b = buckets[idx];
+    b.n += 1;
+    if (s.degraded) {
+      b.degraded += 1;
+      totalDegraded += 1;
+    }
+    for (const name of SIGNAL_NAMES) {
+      if (s[name]) {
+        b.bySignal[name] += 1;
+        totals[name] += 1;
+      }
+    }
+
+    if (value < freshMax) {
+      freshN += 1;
+      if (s.degraded) freshD += 1;
+    } else if (value >= deepMin) {
+      deepN += 1;
+      if (s.degraded) deepD += 1;
+    }
+  }
+
+  for (const b of buckets) {
+    b.rate = b.n ? b.degraded / b.n : 0;
+    b.ci = wilsonInterval(b.degraded, b.n);
+    b.lowConfidence = b.n < minBucketN;
+  }
+
+  const freshRate = freshN ? freshD / freshN : null;
+  const deepRate = deepN ? deepD / deepN : null;
+
+  let degradationRatio: number | null = null;
+  let ratioSignificant = false;
+  if (freshRate !== null && deepRate !== null) {
+    degradationRatio =
+      freshRate > 0 ? deepRate / freshRate : deepRate > 0 ? Infinity : 1;
+    const freshCi = wilsonInterval(freshD, freshN);
+    const deepCi = wilsonInterval(deepD, deepN);
+    ratioSignificant = deepCi[0] > freshCi[1];
+  }
+
+  let knee: number | null = null;
+  if (freshRate !== null && freshRate > 0) {
+    for (const b of buckets) {
+      if (b.lo < freshMax || b.lowConfidence) continue;
+      if (b.rate >= kneeRatio * freshRate && b.ci[0] > freshRate) {
+        knee = b.lo;
+        break;
+      }
+    }
+  }
+
+  return {
+    axis,
+    bucketWidth,
+    buckets,
+    totalSteps: steps.length,
+    totalDegraded,
+    overallRate: steps.length ? totalDegraded / steps.length : 0,
+    freshRate,
+    deepRate,
+    freshN,
+    deepN,
+    degradationRatio,
+    ratioSignificant,
+    knee,
+    signalTotals: totals,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Trace adapter: agent conversation turns → trace steps
+// ---------------------------------------------------------------------------
+
+/**
+ * Structural shape of an agent conversation content part. Deliberately matches
+ * the eval suite's `ContentPart` (and the Anthropic message shape) so callers
+ * can pass their turns directly without an import dependency on this module.
+ */
+export type AgentContentPart =
+  | { type: "text"; text: string }
+  | { type: "tool_use"; id: string; name: string; input: unknown }
+  | {
+      type: "tool_result";
+      tool_use_id: string;
+      content?: string;
+      is_error?: boolean;
+    };
+
+export interface AgentTurn {
+  role: "user" | "assistant";
+  content: AgentContentPart[];
+  /** Optional per-turn token estimate; used as the step's promptTokens. */
+  tokens?: number;
+}
+
+/**
+ * Best-effort extraction of the salient target string for a tool call, used by
+ * the retry/reread heuristics. File-oriented tools resolve to their path; other
+ * tools (bash/shell) resolve to their command. Returns null when nothing
+ * recoverable is present — which safely disables retry/reread for that call.
+ */
+export function toolTarget(name: string, input: unknown): string | null {
+  if (input == null) return null;
+  if (typeof input === "string") return input || null;
+  if (typeof input !== "object") return null;
+  const o = input as Record<string, unknown>;
+  const str = (v: unknown): string | null =>
+    typeof v === "string" && v.length > 0 ? v : null;
+  const n = name.toLowerCase();
+  if (EDIT_TOOLS.has(n) || READ_TOOLS.has(n)) {
+    return (
+      str(o.filePath) ??
+      str(o.file_path) ??
+      str(o.path) ??
+      str(o.notebookPath) ??
+      str(o.notebook_path)
+    );
+  }
+  return str(o.command) ?? str(o.cmd) ?? null;
+}
+
+/**
+ * Convert an ordered list of agent conversation turns into trace steps — one
+ * step per assistant turn. A tool call's error status is resolved from the
+ * `tool_result` (matched by `tool_use_id`) that appears in a later user turn,
+ * so callers may pass the full interleaved transcript.
+ */
+export function traceFromTurns(turns: readonly AgentTurn[]): TraceStep[] {
+  // First pass: map every tool_use_id to its error status.
+  const errorById = new Map<string, boolean>();
+  for (const turn of turns) {
+    for (const part of turn.content) {
+      if (part.type === "tool_result") {
+        errorById.set(part.tool_use_id, part.is_error === true);
+      }
+    }
+  }
+
+  const steps: TraceStep[] = [];
+  for (const turn of turns) {
+    if (turn.role !== "assistant") continue;
+    const textParts: string[] = [];
+    const toolCalls: TraceToolCall[] = [];
+    for (const part of turn.content) {
+      if (part.type === "text") {
+        textParts.push(part.text);
+      } else if (part.type === "tool_use") {
+        toolCalls.push({
+          name: part.name,
+          target: toolTarget(part.name, part.input),
+          isError: errorById.get(part.id) === true,
+        });
+      }
+    }
+    steps.push({
+      role: "assistant",
+      assistantText: textParts.join("\n"),
+      toolCalls,
+      promptTokens: turn.tokens ?? 0,
+    });
+  }
+
+  return steps;
+}
+
+/**
+ * Convenience: run the full pipeline (turns → steps → per-step signals) in one
+ * call. Returns both the raw step signals and the per-signal totals.
+ */
+export function analyzeTurns(turns: readonly AgentTurn[]): {
+  steps: StepSignals[];
+  totals: Record<SignalName, number>;
+} {
+  const steps = extractSignals(traceFromTurns(turns));
+  return { steps, totals: signalTotals(steps) };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -43,6 +43,7 @@ export * as latReader from "./lat-reader";
 export * as entities from "./entities";
 export * as entityRebuild from "./entity-rebuild";
 export * as patternExtract from "./pattern-extract";
+export * as degradationSignals from "./degradation-signals";
 export * as instructionDetect from "./instruction-detect";
 export * as log from "./log";
 export * as conversationImport from "./import";

--- a/packages/core/test/degradation-signals.test.ts
+++ b/packages/core/test/degradation-signals.test.ts
@@ -1,0 +1,405 @@
+import { describe, expect, test } from "vitest";
+import {
+  type AgentTurn,
+  type StepSignals,
+  type TraceStep,
+  analyzeTurns,
+  buildRotCurve,
+  extractSignals,
+  signalTotals,
+  toolTarget,
+  traceFromTurns,
+  wilsonInterval,
+} from "../src/degradation-signals";
+
+// Pure, no-LLM, no-DB engine — these tests exercise the exact heuristics and
+// are written to fail if the underlying logic is reverted (non-vacuous).
+
+// Convenience builder for a step with a single tool call.
+const step = (
+  name: string,
+  opts: { target?: string | null; isError?: boolean; text?: string } = {},
+): TraceStep => ({
+  role: "assistant",
+  assistantText: opts.text,
+  toolCalls: [
+    { name, target: opts.target ?? null, isError: opts.isError ?? false },
+  ],
+});
+
+const flags = (s: StepSignals) => ({
+  tool_error: s.tool_error,
+  edit_failure: s.edit_failure,
+  retry: s.retry,
+  reread: s.reread,
+  self_correction: s.self_correction,
+  degraded: s.degraded,
+});
+
+describe("extractSignals — per-step signals", () => {
+  test("tool_error fires on any errored tool call; not on success", () => {
+    const [ok, err] = extractSignals([
+      step("bash", { target: "ls", isError: false }),
+      step("bash", { target: "cat x", isError: true }),
+    ]);
+    expect(ok.tool_error).toBe(false);
+    expect(err.tool_error).toBe(true);
+    expect(err.degraded).toBe(true);
+  });
+
+  test("edit_failure fires only for editing tools, and implies tool_error", () => {
+    const [editErr, readErr] = extractSignals([
+      step("edit", { target: "/a.ts", isError: true }),
+      step("read", { target: "/b.ts", isError: true }),
+    ]);
+    expect(editErr.edit_failure).toBe(true);
+    expect(editErr.tool_error).toBe(true);
+    // read errors are tool errors but NOT edit failures
+    expect(readErr.edit_failure).toBe(false);
+    expect(readErr.tool_error).toBe(true);
+  });
+
+  test("edit tool name matching is case-insensitive", () => {
+    const [s] = extractSignals([
+      step("Edit", { target: "/a.ts", isError: true }),
+    ]);
+    expect(s.edit_failure).toBe(true);
+  });
+
+  test("retry fires when a recently-errored (tool,target) recurs — even if it now succeeds", () => {
+    const sig = extractSignals([
+      step("edit", { target: "/a.ts", isError: true }), // step 0 error
+      step("read", { target: "/other.ts", isError: false }), // step 1 filler
+      step("edit", { target: "/a.ts", isError: false }), // step 2 retry (success)
+    ]);
+    expect(sig[0].retry).toBe(false);
+    expect(sig[2].retry).toBe(true);
+  });
+
+  test("retry does NOT fire outside the retry window", () => {
+    // error at step 0, recurrence at step 7 (> RETRY_WINDOW = 6)
+    const steps: TraceStep[] = [
+      step("edit", { target: "/a.ts", isError: true }),
+    ];
+    for (let i = 0; i < 6; i++) steps.push(step("bash", { target: `f${i}` }));
+    steps.push(step("edit", { target: "/a.ts", isError: false })); // step 7
+    const sig = extractSignals(steps);
+    expect(sig[7].retry).toBe(false);
+  });
+
+  test("retry requires a concrete target (no target → no retry)", () => {
+    const sig = extractSignals([
+      step("bash", { target: null, isError: true }),
+      step("bash", { target: null, isError: true }),
+    ]);
+    expect(sig[1].retry).toBe(false);
+  });
+
+  test("retry keys on BOTH tool and target — different target does not retry", () => {
+    const sig = extractSignals([
+      step("edit", { target: "/a.ts", isError: true }),
+      step("edit", { target: "/b.ts", isError: false }),
+    ]);
+    expect(sig[1].retry).toBe(false);
+  });
+
+  test("reread fires on a second read of the same file, not the first", () => {
+    const sig = extractSignals([
+      step("read", { target: "/a.ts" }),
+      step("read", { target: "/b.ts" }),
+      step("read", { target: "/a.ts" }),
+    ]);
+    expect(sig[0].reread).toBe(false);
+    expect(sig[1].reread).toBe(false);
+    expect(sig[2].reread).toBe(true);
+  });
+
+  test("self_correction matches apology/correction phrases only", () => {
+    const [apology, plain, letMeFix] = extractSignals([
+      { toolCalls: [], assistantText: "I apologize, that was a mistake." },
+      {
+        toolCalls: [],
+        assistantText: "Here is the implementation you asked for.",
+      },
+      { toolCalls: [], assistantText: "Let me fix that now." },
+    ]);
+    expect(apology.self_correction).toBe(true);
+    expect(plain.self_correction).toBe(false);
+    expect(letMeFix.self_correction).toBe(true);
+  });
+
+  test("degraded is the OR of all five signals; a clean step is not degraded", () => {
+    const [clean] = extractSignals([
+      step("read", { target: "/a.ts", isError: false, text: "done" }),
+    ]);
+    expect(flags(clean)).toEqual({
+      tool_error: false,
+      edit_failure: false,
+      retry: false,
+      reread: false,
+      self_correction: false,
+      degraded: false,
+    });
+  });
+
+  test("multiple tool calls in one step aggregate signals", () => {
+    const s: TraceStep = {
+      toolCalls: [
+        { name: "read", target: "/a.ts", isError: false },
+        { name: "edit", target: "/a.ts", isError: true },
+      ],
+    };
+    const [sig] = extractSignals([s]);
+    expect(sig.tool_error).toBe(true);
+    expect(sig.edit_failure).toBe(true);
+  });
+});
+
+describe("signalTotals", () => {
+  test("counts each signal across steps", () => {
+    const sig = extractSignals([
+      step("edit", { target: "/a.ts", isError: true }),
+      step("edit", { target: "/a.ts", isError: false }), // retry
+      step("read", { target: "/a.ts" }), // first read of /a.ts here → not reread
+    ]);
+    const totals = signalTotals(sig);
+    expect(totals.tool_error).toBe(1);
+    expect(totals.edit_failure).toBe(1);
+    expect(totals.retry).toBe(1);
+  });
+});
+
+describe("wilsonInterval", () => {
+  test("empty sample returns the full [0,1] range", () => {
+    expect(wilsonInterval(0, 0)).toEqual([0, 1]);
+  });
+
+  test("interval brackets the point estimate and stays within [0,1]", () => {
+    const [lo, hi] = wilsonInterval(5, 10);
+    expect(lo).toBeGreaterThan(0);
+    expect(lo).toBeLessThan(0.5);
+    expect(hi).toBeGreaterThan(0.5);
+    expect(hi).toBeLessThan(1);
+  });
+
+  test("extremes are clamped: 0/n floor at 0, n/n ceil at 1", () => {
+    const [lo0] = wilsonInterval(0, 20);
+    const [, hi1] = wilsonInterval(20, 20);
+    expect(lo0).toBe(0);
+    expect(hi1).toBe(1);
+  });
+
+  test("larger n tightens the interval for the same rate", () => {
+    const wide = wilsonInterval(5, 10);
+    const narrow = wilsonInterval(50, 100);
+    expect(narrow[1] - narrow[0]).toBeLessThan(wide[1] - wide[0]);
+  });
+});
+
+// Build StepSignals directly (bypassing the trace) so the curve math is tested
+// in isolation from the signal heuristics.
+const degradedStep = (
+  promptTokens: number,
+  degraded: boolean,
+): StepSignals => ({
+  stepIndex: 0,
+  promptTokens,
+  tool_error: degraded,
+  edit_failure: false,
+  retry: false,
+  reread: false,
+  self_correction: false,
+  degraded,
+});
+
+describe("buildRotCurve — fill axis (default)", () => {
+  test("buckets by prompt-token fill percentage of the window", () => {
+    const steps = [
+      degradedStep(5_000, false), // 2.5% → bucket 0
+      degradedStep(130_000, true), // 65% → bucket 6 (deep)
+    ];
+    const curve = buildRotCurve(steps, { contextWindow: 200_000 });
+    expect(curve.axis).toBe("fill");
+    expect(curve.buckets[0].n).toBe(1);
+    expect(curve.buckets[6].n).toBe(1);
+    expect(curve.buckets[6].lo).toBe(60);
+  });
+});
+
+describe("buildRotCurve — tokens axis (absolute)", () => {
+  const opts = {
+    axis: "tokens" as const,
+    bucketWidth: 10_000,
+    freshMax: 20_000,
+    deepMin: 40_000,
+    minBucketN: 4,
+    kneeRatio: 1.5,
+  };
+
+  test("detects a degradation knee where the deep-zone rate climbs", () => {
+    const steps: StepSignals[] = [];
+    // Fresh zone: 20 steps at 5k tokens, 1 degraded → freshRate 0.05
+    for (let i = 0; i < 20; i++) steps.push(degradedStep(5_000, i === 0));
+    // Deep bucket [40k,50k): 20 steps, 12 degraded → rate 0.6
+    for (let i = 0; i < 20; i++) steps.push(degradedStep(45_000, i < 12));
+
+    const curve = buildRotCurve(steps, opts);
+    expect(curve.freshRate).toBeCloseTo(0.05, 5);
+    expect(curve.knee).toBe(40_000);
+    expect(curve.degradationRatio).toBeGreaterThan(1.5);
+    expect(curve.ratioSignificant).toBe(true);
+  });
+
+  test("a flat curve yields no knee and no significant ratio", () => {
+    const steps: StepSignals[] = [];
+    for (let i = 0; i < 20; i++) steps.push(degradedStep(5_000, i === 0)); // fresh 0.05
+    for (let i = 0; i < 20; i++) steps.push(degradedStep(45_000, i === 0)); // deep 0.05
+    const curve = buildRotCurve(steps, opts);
+    expect(curve.knee).toBeNull();
+    expect(curve.ratioSignificant).toBe(false);
+  });
+
+  test("an elevated point estimate with a wide CI (floor below fresh rate) is NOT a knee", () => {
+    // Guards the CI-floor requirement specifically: the deep bucket's rate
+    // exceeds kneeRatio × fresh, but its Wilson floor does not clear the fresh
+    // rate, so a single noisy-but-small bucket must not declare a threshold.
+    const steps: StepSignals[] = [];
+    for (let i = 0; i < 20; i++) steps.push(degradedStep(5_000, i < 9)); // fresh 0.45
+    for (let i = 0; i < 5; i++) steps.push(degradedStep(45_000, i < 4)); // deep 0.8, n=5
+    const curve = buildRotCurve(steps, opts);
+    const deep = curve.buckets.find((b) => b.lo === 40_000);
+    expect(deep?.rate).toBeGreaterThanOrEqual(1.5 * (curve.freshRate ?? 0));
+    expect(deep?.ci[0]).toBeLessThan(curve.freshRate ?? 0);
+    expect(curve.knee).toBeNull();
+  });
+
+  test("low-confidence buckets are flagged and never declare a knee", () => {
+    const steps: StepSignals[] = [];
+    for (let i = 0; i < 20; i++) steps.push(degradedStep(5_000, i === 0)); // fresh, high n
+    // Deep bucket with only 3 steps (< minBucketN=4) all degraded — must be
+    // flagged low-confidence and must NOT be chosen as the knee.
+    for (let i = 0; i < 3; i++) steps.push(degradedStep(45_000, true));
+    const curve = buildRotCurve(steps, opts);
+    const deep = curve.buckets.find((b) => b.lo === 40_000);
+    expect(deep?.lowConfidence).toBe(true);
+    expect(curve.knee).toBeNull();
+  });
+
+  test("infinite ratio when fresh zone is clean but deep zone degrades", () => {
+    const steps: StepSignals[] = [];
+    for (let i = 0; i < 20; i++) steps.push(degradedStep(5_000, false)); // fresh 0
+    for (let i = 0; i < 20; i++) steps.push(degradedStep(45_000, i < 10)); // deep 0.5
+    const curve = buildRotCurve(steps, opts);
+    expect(curve.freshRate).toBe(0);
+    expect(curve.degradationRatio).toBe(Infinity);
+  });
+});
+
+describe("buildRotCurve — edge cases", () => {
+  test("empty input yields a well-formed, empty curve", () => {
+    const curve = buildRotCurve([]);
+    expect(curve.totalSteps).toBe(0);
+    expect(curve.overallRate).toBe(0);
+    expect(curve.freshRate).toBeNull();
+    expect(curve.deepRate).toBeNull();
+    expect(curve.knee).toBeNull();
+  });
+});
+
+describe("toolTarget", () => {
+  test("file tools resolve to their path across key aliases", () => {
+    expect(toolTarget("edit", { filePath: "/a.ts" })).toBe("/a.ts");
+    expect(toolTarget("read", { file_path: "/b.ts" })).toBe("/b.ts");
+    expect(toolTarget("write", { path: "/c.ts" })).toBe("/c.ts");
+  });
+
+  test("shell tools resolve to their command", () => {
+    expect(toolTarget("bash", { command: "pnpm test" })).toBe("pnpm test");
+    expect(toolTarget("bash", { cmd: "ls" })).toBe("ls");
+  });
+
+  test("returns null when nothing recoverable is present", () => {
+    expect(toolTarget("edit", {})).toBeNull();
+    expect(toolTarget("bash", null)).toBeNull();
+    expect(toolTarget("read", 42)).toBeNull();
+  });
+});
+
+describe("traceFromTurns + analyzeTurns", () => {
+  const turns: AgentTurn[] = [
+    {
+      role: "assistant",
+      content: [
+        { type: "text", text: "Editing the file." },
+        {
+          type: "tool_use",
+          id: "t1",
+          name: "edit",
+          input: { filePath: "/a.ts" },
+        },
+      ],
+    },
+    {
+      role: "user",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: "t1",
+          content: "oldString not found",
+          is_error: true,
+        },
+      ],
+    },
+    {
+      role: "assistant",
+      content: [
+        { type: "text", text: "I apologize, let me fix that." },
+        {
+          type: "tool_use",
+          id: "t2",
+          name: "edit",
+          input: { filePath: "/a.ts" },
+        },
+      ],
+    },
+    {
+      role: "user",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: "t2",
+          content: "ok",
+          is_error: false,
+        },
+      ],
+    },
+  ];
+
+  test("builds one step per assistant turn and resolves tool errors from later results", () => {
+    const steps = traceFromTurns(turns);
+    expect(steps).toHaveLength(2);
+    expect(steps[0].toolCalls?.[0]).toMatchObject({
+      name: "edit",
+      target: "/a.ts",
+      isError: true,
+    });
+    expect(steps[1].toolCalls?.[0]).toMatchObject({
+      name: "edit",
+      target: "/a.ts",
+      isError: false,
+    });
+  });
+
+  test("end-to-end: an edit failure followed by a self-corrected retry lights up all expected signals", () => {
+    const { steps, totals } = analyzeTurns(turns);
+    // step 0: the failing edit
+    expect(steps[0].edit_failure).toBe(true);
+    expect(steps[0].tool_error).toBe(true);
+    // step 1: retry of same (edit,/a.ts) + apology text
+    expect(steps[1].retry).toBe(true);
+    expect(steps[1].self_correction).toBe(true);
+    expect(totals.edit_failure).toBe(1);
+    expect(totals.retry).toBe(1);
+    expect(totals.self_correction).toBe(1);
+  });
+});


### PR DESCRIPTION
## What

Adds `packages/core/src/degradation-signals.ts` — a pure, no-LLM engine that turns a normalized agent trace into per-step **behavioral failure signals** and a bucketed **rot curve**. It scores an agent's *actual behavior* instead of a lenient LLM re-narration, which is the anti-**"justifier"** scoring foundation the coding-agent memory benchmark (#961) explicitly calls for.

This is **PR1 of the contextrot-informed coding-eval plan** (checking whether [contextrot](https://github.com/Priyanshu-byte-coder/contextrot) can help us build a long + multi-session coding eval). It's the shared foundation every later workstream consumes; it has **no external dependency** and is safe in `core` (pure, DB/LLM-free, Bun-safe).

## Why contextrot

contextrot mines 5 transcript signals and correlates them with context fill. Those signals are exactly the objective, justifier-free degradation metric #961 wants (and 3 of the 5 we already compute in `tool-trace.ts` but never surface into scoring). This PR ports the methodology faithfully so our numbers are directly comparable to the independent tool, and adds the two things Lore needs.

## What it does

- **Five per-step signals** + a `degraded` composite, each reported separately so one noisy signal can't dominate:
  - `tool_error`, `edit_failure`, `retry` (a recently-errored `(tool,target)` recurs within 6 steps), `reread` (re-read of an already-read file), `self_correction` (apology/correction language).
- **Honest statistics**, identical to upstream: Wilson 95% score intervals, visible n-counts, low-confidence flags, and a conservative **knee** test (point estimate ≥ 1.5× fresh-zone rate **AND** CI floor clears the fresh rate).
- **Absolute prompt-token x-axis** for the rot curve, in addition to fill % — Lore keeps the window low by design, so the absolute-token axis is what puts Lore-on vs Lore-off on the same scale and locates the empirical degradation **knee** that will feed the context "sweet-spot" work.
- **`traceFromTurns`** adapter over the eval/Anthropic message shape (structural type, no import coupling) so the harness — and later the opencode.db adapter — can feed it directly.

Exported as `degradationSignals` from `@loreai/core`.

## Tests

`packages/core/test/degradation-signals.test.ts` — 28 unit tests covering signal heuristics, Wilson intervals, fill/token bucketing, knee detection, edge cases, and the trace adapter.

Two load-bearing guards are **mutation-verified** (temporarily reverted → the guarding test goes red, then restored byte-identical):
- retry-window bound (`i - errorStep <= RETRY_WINDOW`)
- knee CI-floor clearance (`b.ci[0] > freshRate`)

Full `packages/core` suite green (2652 passed, 6 skipped); typecheck + biome clean.

## Not in this PR (next steps in the plan)

- Wiring signals into the memory harness Q&A + separating retrieval-quality from end-task scoring.
- OpenCode adapter contributed **upstream** to contextrot (opencode.db has richer data than Claude Code JSONL).
- Controlled Lore-on/off A/B rot-curve run.
- Using the measured knee to tighten Lore's hard-coded context thresholds (the "sweet spot").

Refs #961, #916, #663