### PR TITLE
feat(eval): objective retrieval scoring, separated from the LLM judge (#961)

### DIFF
--- a/packages/core/eval/harness.ts
+++ b/packages/core/eval/harness.ts
@@ -40,6 +40,7 @@ import {
   estimateTokens,
 } from "./baselines";
 import { judge } from "./judge";
+import { scoreRetrieval } from "./recall-score";
 import type { EvalLLMClient } from "./llm-backend";
 import { createEvalLLMClient, resolveBackend } from "./llm-backend";
 
@@ -1012,8 +1013,22 @@ export async function runScenario(
           tokens = answer.tokens;
         }
 
-        // Score with the judge
+        // Score with the judge (end-task quality)
         const judgeResult = await judge(q, hypothesis, llm, { recallInvoked });
+
+        // Score retrieval quality objectively (justifier-free), independent of
+        // the judge. Present only when the question declares ground-truth
+        // anchors; omitted otherwise so it never dilutes into a vacuous zero.
+        // Skipped in fixture mode (hypothesis is a placeholder, not a real
+        // answer) — mirrors the judge's fixture-mode neutralization so a
+        // structural regression run doesn't look like a memory regression.
+        const retrieval =
+          config.mode === "fixture" || !llm
+            ? undefined
+            : scoreRetrieval(hypothesis, {
+                expectedFacts: q.expectedFacts,
+                forbiddenFacts: q.forbiddenFacts,
+              });
 
         const result: EvalResult = {
           timestamp: new Date().toISOString(),
@@ -1027,6 +1042,7 @@ export async function runScenario(
           scores: judgeResult.scores,
           compositeScore: judgeResult.compositeScore,
           judgeReasoning: judgeResult.reasoning,
+          ...(retrieval ? { retrieval } : {}),
           tokens,
           metadata: {
             difficulty: q.metadata.difficulty,
@@ -1197,7 +1213,35 @@ export function printSummary(results: EvalResult[]): string {
         const avg =
           modeResults.reduce((s, r) => s + r.compositeScore, 0) /
           modeResults.length;
-        parts.push(`${mode} ${avg.toFixed(1)}`);
+        // Objective retrieval metrics (justifier-free), shown separately from
+        // the judge's end-task composite. Only the subset of questions with
+        // ground-truth anchors contribute.
+        const scored = modeResults.filter((r) => r.retrieval !== undefined);
+        let retrievalPart = "";
+        if (scored.length > 0) {
+          const withRecall = scored.filter(
+            (r) => r.retrieval?.factRecall !== null,
+          );
+          const meanRecall =
+            withRecall.length > 0
+              ? withRecall.reduce(
+                  (s, r) => s + (r.retrieval?.factRecall ?? 0),
+                  0,
+                ) / withRecall.length
+              : null;
+          const passRate =
+            scored.filter((r) => r.retrieval?.pass).length / scored.length;
+          // `recall` averages over questions declaring expectedFacts; `pass`/`n`
+          // count all anchored questions. Denominators coincide unless a
+          // question is forbidden-only (a pure negative control).
+          const recallStr =
+            meanRecall !== null
+              ? `recall ${(meanRecall * 100).toFixed(0)}%`
+              : "";
+          const passStr = `pass ${(passRate * 100).toFixed(0)}% (n=${scored.length})`;
+          retrievalPart = ` [${[recallStr, passStr].filter(Boolean).join(", ")}]`;
+        }
+        parts.push(`${mode} ${avg.toFixed(1)}${retrievalPart}`);
       }
 
       lines.push(`  ${scenario}:  ${parts.join("  |  ")}`);

--- a/packages/core/eval/judge.ts
+++ b/packages/core/eval/judge.ts
@@ -319,6 +319,14 @@ function buildCriteriaDescription(rubric: ScoringRubric): string {
     .join("\n\n");
 }
 
+// The reference answer is the source of truth. The grader must judge fidelity
+// to it — NOT reward volume. An earlier version of this prompt told the judge
+// that "extra content should score 5" and that the reference was merely a
+// floor; that is the "justifier" inflation pattern #961 exists to avoid (a
+// fluent, padded answer scoring high without actually recalling the ground
+// truth). Retrieval correctness is now scored separately and deterministically
+// in `recall-score.ts`; this judge grades end-task quality only, grounded in
+// the reference.
 const JUDGE_SYSTEM = `You are evaluating an AI assistant's answer about a coding session.
 Score each criterion on a 1-5 integer scale. Return ONLY valid JSON:
 {
@@ -326,11 +334,13 @@ Score each criterion on a 1-5 integer scale. Return ONLY valid JSON:
   "reasoning": "<brief explanation of the scores, 2-3 sentences>"
 }
 
-IMPORTANT: The reference answer is a MINIMUM — the hypothesis may include additional
-correct information beyond the reference. Extra correct details should NOT be penalized.
-Only penalize facts that directly CONTRADICT the reference or are clearly fabricated.
-A hypothesis that covers all reference points PLUS additional accurate context should
-score 5 on factual_accuracy and completeness.
+Ground every score in the reference answer as the source of truth:
+- Credit only claims that the reference supports or that are verifiably
+  consistent with it.
+- Do NOT reward volume. Additional, unverifiable, or off-topic content is not
+  evidence of a better answer and must not raise a score on its own.
+- Penalize claims that contradict the reference or are fabricated, and penalize
+  missing key facts that the reference contains.
 
 Do NOT include any text outside the JSON object.`;
 

--- a/packages/core/eval/recall-score.test.ts
+++ b/packages/core/eval/recall-score.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "vitest";
+import { factPresent, normalizeForMatch, scoreRetrieval } from "./recall-score";
+
+describe("normalizeForMatch", () => {
+  test("lowercases, collapses whitespace, and trims", () => {
+    expect(normalizeForMatch("  The\tQuick   Brown\nFox ")).toBe(
+      "the quick brown fox",
+    );
+  });
+});
+
+describe("factPresent", () => {
+  const norm = normalizeForMatch("The migration bumps schema_version to 55.");
+  test("matches case-insensitively and whitespace-insensitively", () => {
+    expect(factPresent(norm, "SCHEMA_VERSION   to 55")).toBe(true);
+  });
+  test("does not match an absent fact", () => {
+    expect(factPresent(norm, "version 54")).toBe(false);
+  });
+  test("an empty fact never matches", () => {
+    expect(factPresent(norm, "   ")).toBe(false);
+  });
+});
+
+describe("scoreRetrieval — anchors gating", () => {
+  test("returns undefined when no anchors are declared", () => {
+    expect(scoreRetrieval("anything", {})).toBeUndefined();
+    expect(
+      scoreRetrieval("anything", { expectedFacts: [], forbiddenFacts: [] }),
+    ).toBeUndefined();
+  });
+
+  test("blank anchors are ignored (treated as no anchors)", () => {
+    expect(
+      scoreRetrieval("x", { expectedFacts: ["  "], forbiddenFacts: [""] }),
+    ).toBeUndefined();
+  });
+});
+
+describe("scoreRetrieval — expected facts (positive recall)", () => {
+  test("full recall passes with factRecall = 1", () => {
+    const s = scoreRetrieval(
+      "We chose event-sourcing with CQRS for the ledger.",
+      { expectedFacts: ["event-sourcing", "CQRS"] },
+    );
+    expect(s).toBeDefined();
+    expect(s?.factRecall).toBe(1);
+    expect(s?.matchedFacts).toEqual(["event-sourcing", "CQRS"]);
+    expect(s?.missedFacts).toEqual([]);
+    expect(s?.pass).toBe(true);
+  });
+
+  test("partial recall reports the fraction and fails the strict pass", () => {
+    const s = scoreRetrieval("We chose event-sourcing.", {
+      expectedFacts: ["event-sourcing", "CQRS"],
+    });
+    expect(s?.factRecall).toBe(0.5);
+    expect(s?.missedFacts).toEqual(["CQRS"]);
+    expect(s?.pass).toBe(false);
+  });
+
+  test("a fluent but fact-free answer scores zero recall (justifier-resistant)", () => {
+    // The kind of padded answer a lenient LLM judge might over-reward.
+    const s = scoreRetrieval(
+      "Great question! There were several important architectural considerations discussed at length.",
+      { expectedFacts: ["event-sourcing", "CQRS"] },
+    );
+    expect(s?.factRecall).toBe(0);
+    expect(s?.pass).toBe(false);
+  });
+});
+
+describe("scoreRetrieval — forbidden facts (negative controls)", () => {
+  test("a pure negative control passes when nothing stale surfaced", () => {
+    const s = scoreRetrieval("The timeout is now 30 seconds.", {
+      forbiddenFacts: ["10 seconds"],
+    });
+    expect(s?.factRecall).toBeNull();
+    expect(s?.expectedCount).toBe(0);
+    expect(s?.leakedStaleFacts).toEqual([]);
+    expect(s?.pass).toBe(true);
+  });
+
+  test("leaking a stale/superseded fact fails the pass", () => {
+    const s = scoreRetrieval("The timeout is 10 seconds.", {
+      forbiddenFacts: ["10 seconds"],
+    });
+    expect(s?.leakedStaleFacts).toEqual(["10 seconds"]);
+    expect(s?.pass).toBe(false);
+  });
+
+  test("a short/numeric forbidden anchor does not match inside a larger token", () => {
+    // "10 seconds" must NOT match inside "110 seconds" — a false leak would
+    // spuriously fail a correct answer (adversarial review finding #2).
+    const s = scoreRetrieval("The retry backoff is now 110 seconds.", {
+      forbiddenFacts: ["10 seconds"],
+    });
+    expect(s?.leakedStaleFacts).toEqual([]);
+    expect(s?.pass).toBe(true);
+  });
+
+  test("underscore counts as a word char (regex \\w semantics)", () => {
+    // forbidden "10" must NOT match inside "schema_10_version".
+    const s = scoreRetrieval("bumped to schema_10_version today.", {
+      forbiddenFacts: ["10"],
+    });
+    expect(s?.leakedStaleFacts).toEqual([]);
+    expect(s?.pass).toBe(true);
+  });
+
+  test("word-boundary matching still matches at punctuation edges", () => {
+    const s = scoreRetrieval("We chose event-sourcing with CQRS.", {
+      expectedFacts: ["event-sourcing", "CQRS"],
+    });
+    expect(s?.factRecall).toBe(1);
+    expect(s?.pass).toBe(true);
+  });
+
+  test("expected present but a forbidden fact also leaked → fail", () => {
+    const s = scoreRetrieval(
+      "The value was 5 seconds, previously it was 10 seconds.",
+      { expectedFacts: ["5 seconds"], forbiddenFacts: ["10 seconds"] },
+    );
+    expect(s?.factRecall).toBe(1);
+    expect(s?.matchedFacts).toEqual(["5 seconds"]);
+    expect(s?.leakedStaleFacts).toEqual(["10 seconds"]);
+    expect(s?.pass).toBe(false);
+  });
+});

--- a/packages/core/eval/recall-score.ts
+++ b/packages/core/eval/recall-score.ts
@@ -1,0 +1,116 @@
+/**
+ * Objective, justifier-free retrieval scoring for the memory eval.
+ *
+ * The LLM judge (`judge.ts`) grades *end-task* answer quality. That path is
+ * susceptible to the "justifier" inflation #961 warns about: a lenient grader
+ * can reward a fluent answer that never actually recalled the ground-truth
+ * fact. This module scores the *retrieval* dimension deterministically — no
+ * LLM, no synthesis — by checking, against the question's declared ground
+ * truth, whether the required fact(s) are present and whether any stale /
+ * superseded fact leaked in (negative controls).
+ *
+ * Reported separately from the judge's composite so the two axes never blur:
+ *   - retrieval quality  = did the right prior fact actually surface?  (here)
+ *   - end-task quality   = was the answer well-formed / well-reasoned?  (judge)
+ *
+ * Matching is intentionally simple and inspectable: case-insensitive,
+ * whitespace-normalized substring containment. False negatives (a paraphrased
+ * fact we fail to match) are acceptable and conservative; we never award credit
+ * an LLM might rationalize.
+ */
+
+import type { RetrievalScore } from "./types";
+
+/** Lowercase + collapse all whitespace runs to single spaces + trim. */
+export function normalizeForMatch(s: string): string {
+  return s.toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+/** Word-char test on already-lowercased text — matches regex `\w`
+ *  (`[a-z0-9_]`) so underscores are boundaries-internal, e.g. forbidden "10"
+ *  must not match inside "schema_10_version". */
+function isWordChar(ch: string): boolean {
+  return (ch >= "a" && ch <= "z") || (ch >= "0" && ch <= "9") || ch === "_";
+}
+
+/**
+ * True when `fact` appears in the already-normalized hypothesis, respecting
+ * word boundaries so a short/numeric anchor cannot match inside a larger token
+ * (e.g. forbidden "10 seconds" must NOT match "110 seconds" — a false leak
+ * would spuriously fail a correct answer). Boundaries follow regex `\b`
+ * semantics: they are only required where the needle's own edge is a word
+ * character, so anchors with non-word edges (paths, "/callback") still match.
+ * An empty fact never matches.
+ */
+export function factPresent(hypothesisNorm: string, fact: string): boolean {
+  const needle = normalizeForMatch(fact);
+  if (!needle) return false;
+  const leftEdgeIsWord = isWordChar(needle[0]);
+  const rightEdgeIsWord = isWordChar(needle[needle.length - 1]);
+  let from = 0;
+  for (;;) {
+    const idx = hypothesisNorm.indexOf(needle, from);
+    if (idx === -1) return false;
+    const end = idx + needle.length;
+    const leftOk =
+      !leftEdgeIsWord || idx === 0 || !isWordChar(hypothesisNorm[idx - 1]);
+    const rightOk =
+      !rightEdgeIsWord ||
+      end === hypothesisNorm.length ||
+      !isWordChar(hypothesisNorm[end]);
+    if (leftOk && rightOk) return true;
+    from = idx + 1;
+  }
+}
+
+export interface RetrievalAnchors {
+  /** Facts that MUST appear in a correct answer. */
+  expectedFacts?: string[];
+  /** Stale/superseded facts that must NOT appear (negative controls). */
+  forbiddenFacts?: string[];
+}
+
+/**
+ * Score a hypothesis against a question's ground-truth anchors.
+ *
+ * Returns `undefined` when the question declares no anchors — such questions
+ * are graded by the LLM judge alone, and callers should omit the retrieval
+ * block entirely rather than emit a vacuous zero.
+ *
+ * `pass` is the strict negative-control-aware verdict: every expected fact
+ * present AND no forbidden fact leaked. A question with only `forbiddenFacts`
+ * (a pure negative control) passes iff nothing stale surfaced.
+ */
+export function scoreRetrieval(
+  hypothesis: string,
+  anchors: RetrievalAnchors,
+): RetrievalScore | undefined {
+  const expected = (anchors.expectedFacts ?? []).filter((f) => f.trim());
+  const forbidden = (anchors.forbiddenFacts ?? []).filter((f) => f.trim());
+  if (expected.length === 0 && forbidden.length === 0) return undefined;
+
+  const norm = normalizeForMatch(hypothesis);
+  const matchedFacts: string[] = [];
+  const missedFacts: string[] = [];
+  for (const f of expected) {
+    if (factPresent(norm, f)) matchedFacts.push(f);
+    else missedFacts.push(f);
+  }
+  const leakedStaleFacts = forbidden.filter((f) => factPresent(norm, f));
+
+  const factRecall = expected.length
+    ? matchedFacts.length / expected.length
+    : null;
+  const pass =
+    (expected.length === 0 || matchedFacts.length === expected.length) &&
+    leakedStaleFacts.length === 0;
+
+  return {
+    factRecall,
+    expectedCount: expected.length,
+    matchedFacts,
+    missedFacts,
+    leakedStaleFacts,
+    pass,
+  };
+}

--- a/packages/core/eval/scenarios/multi-session-recall.ts
+++ b/packages/core/eval/scenarios/multi-session-recall.ts
@@ -477,6 +477,10 @@ const msr1Questions: EvalQuestion[] = [
     referenceAnswer:
       "Users were getting rate-limited when trying to log in with email/password after other users did OAuth logins. They received the error 'Too many login attempts, please try again in 15 minutes'.",
     rubric: RUBRICS.multiSessionRecall,
+    // Exact-phrase anchors: a faithful paraphrase (e.g. "too many failed login
+    // attempts") under-counts. Conservative by design — a false negative never
+    // awards unearned credit (see recall-score.ts).
+    expectedFacts: ["Too many login attempts", "15 minutes"],
     metadata: {
       turnIndex: 0,
       difficulty: "easy",
@@ -493,6 +497,7 @@ const msr1Questions: EvalQuestion[] = [
     referenceAnswer:
       "tests/auth/rate-limiter-oauth.test.ts — it has two test cases: one verifying OAuth callbacks don't count against login rate limits, and one verifying login attempts are still rate-limited by email.",
     rubric: RUBRICS.multiSessionRecall,
+    expectedFacts: ["tests/auth/rate-limiter-oauth.test.ts"],
     metadata: { turnIndex: 8, difficulty: "easy", tags: ["file-path", "test"] },
   },
   // Cross-session (session 1 → session 3) — medium
@@ -506,6 +511,7 @@ const msr1Questions: EvalQuestion[] = [
     referenceAnswer:
       "JWT was chosen because the API is consumed by both a React web frontend and a React Native mobile app. Stateless tokens avoid server-side session storage and work well with the existing CDN setup.",
     rubric: RUBRICS.multiSessionRecall,
+    expectedFacts: ["JWT", "React Native"],
     metadata: {
       turnIndex: 2,
       difficulty: "medium",
@@ -537,6 +543,7 @@ const msr1Questions: EvalQuestion[] = [
     referenceAnswer:
       "bcrypt with 12 salt rounds, implemented in src/auth/password.ts. Argon2 was considered but rejected due to better library support for bcrypt in the Node 20 setup.",
     rubric: RUBRICS.multiSessionRecall,
+    expectedFacts: ["bcrypt", "src/auth/password.ts"],
     metadata: {
       turnIndex: 3,
       difficulty: "medium",
@@ -553,6 +560,7 @@ const msr1Questions: EvalQuestion[] = [
     referenceAnswer:
       "PKCE was chosen for three reasons: (1) the mobile app is a public client where PKCE is mandatory, (2) implicit grant is deprecated in OAuth 2.1, and (3) using the same flow for both web and mobile simplifies the codebase.",
     rubric: RUBRICS.multiSessionRecall,
+    expectedFacts: ["PKCE", "public client"],
     metadata: {
       turnIndex: 4,
       difficulty: "medium",

--- a/packages/core/eval/types.ts
+++ b/packages/core/eval/types.ts
@@ -117,6 +117,14 @@ export interface EvalQuestion {
   question: string;
   referenceAnswer: string;
   rubric: ScoringRubric;
+  /**
+   * Ground-truth anchors for justifier-free retrieval scoring (see
+   * `recall-score.ts`). When present, the harness scores retrieval quality
+   * deterministically, separately from the LLM judge's end-task score.
+   */
+  expectedFacts?: string[];
+  /** Stale/superseded facts that must NOT appear (negative controls). */
+  forbiddenFacts?: string[];
   metadata: {
     turnIndex?: number;
     cumulativeTokens?: number;
@@ -144,6 +152,24 @@ export interface JudgeResult {
   tokensUsed: number;
 }
 
+/**
+ * Objective, LLM-free retrieval-quality score for a single question, kept
+ * separate from the judge's end-task composite. Produced by
+ * `recall-score.ts::scoreRetrieval` and present only when the question
+ * declares ground-truth anchors.
+ */
+export interface RetrievalScore {
+  /** matchedFacts / expectedCount; null when the question has no expectedFacts. */
+  factRecall: number | null;
+  expectedCount: number;
+  matchedFacts: string[];
+  missedFacts: string[];
+  /** forbiddenFacts that leaked into the answer (negative-control failures). */
+  leakedStaleFacts: string[];
+  /** All expected present AND nothing forbidden leaked. */
+  pass: boolean;
+}
+
 export interface EvalResult {
   timestamp: string;
   dimension: Dimension;
@@ -153,9 +179,17 @@ export interface EvalResult {
   question: string;
   referenceAnswer: string;
   hypothesis: string;
+  /** LLM judge (end-task quality) per-criterion scores. */
   scores: Record<string, number>;
+  /** LLM judge (end-task quality) weighted composite. */
   compositeScore: number;
   judgeReasoning: string;
+  /**
+   * Objective retrieval-quality score, independent of the judge. Present only
+   * when the question declares ground-truth anchors (`expectedFacts` /
+   * `forbiddenFacts`); omitted otherwise.
+   */
+  retrieval?: RetrievalScore;
   tokens: TokenUsage;
   metadata: Record<string, unknown>;
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,6 +17,10 @@ export default defineConfig({
     // Run all packages' tests
     include: [
       "packages/core/test/**/*.test.ts",
+      // Fast, pure unit tests for the eval suite's own logic (scorers,
+      // analysis). Heavy end-to-end evals live in *.eval.ts and run under
+      // vitest.evals.config.ts, not here.
+      "packages/core/eval/**/*.test.ts",
       "packages/gateway/test/**/*.test.ts",
       "packages/opencode/test/**/*.test.ts",
       "packages/pi/test/**/*.test.ts",


### PR DESCRIPTION
## What

**PR2** of the contextrot-informed coding-eval plan. Fixes the two "justifier"-inflation guardrails #961 calls for, directly in our eval scoring:

1. **Separate retrieval quality from end-task quality.**
2. **De-justify the grader.**

Builds on the degradation-signals engine from #1185.

## Why

Today the memory eval scores answers with an LLM judge whose system prompt *actively* encourages leniency — it told the grader the reference answer was a "MINIMUM" and that "a hypothesis that covers all reference points PLUS additional accurate context should score 5". That's exactly the justifier pattern #961 exists to avoid: a fluent, padded answer can score high without ever recalling the ground-truth fact.

## Changes

- **`recall-score.ts`** — a pure, LLM-free retrieval scorer. Given a question's ground-truth anchors it deterministically checks whether the required fact(s) surfaced (`expectedFacts`) and whether any stale/superseded fact leaked in (`forbiddenFacts` = negative controls). Matching is simple and inspectable (case/whitespace-insensitive substring); it's conservative — false negatives never award unearned credit.
- **Types** — `EvalQuestion` gains optional `expectedFacts`/`forbiddenFacts`; `EvalResult` gains an optional `retrieval` block reported **separately** from the judge's end-task `scores`/`compositeScore`.
- **Harness** — wires `scoreRetrieval` per question (omitted when a question declares no anchors, so it never dilutes into a vacuous zero); `printSummary` now shows mean fact-recall + negative-control pass-rate alongside the judge composite.
- **De-justify the judge** — `JUDGE_SYSTEM` no longer says extra content should score 5 / the reference is a floor. It now grades fidelity to the reference and must not reward volume. (Retrieval correctness is handled objectively above.)
- **Scenarios** — anchored five MSR-1 recall questions with real ground truth (error strings, file paths, decision keywords).
- **CI** — eval unit tests now run in the main suite (`packages/core/eval/**/*.test.ts` added to the vitest include; heavy `*.eval.ts` still run under `vitest.evals.config.ts`). Coverage already excludes `**/eval/**`.

## Tests

`packages/core/eval/recall-score.test.ts` — 12 unit tests: full/partial recall, a **fluent-but-fact-free answer scoring 0 recall** (justifier-resistant), pure negative controls passing, stale-fact leaks failing, and mixed expected+forbidden. Full local suite green except one **pre-existing, environment-only** failure (`gateway/test/agents.test.ts` needs a git remote, absent in a bare jj workspace; it passed in #1185's CI).

## Not in this PR

- Purpose-built superseded-fact **negative-control scenarios** (where the stale value isn't a substring of the current one) — follow-up.
- Surfacing degradation signals over **real agent traces** — lands with the opencode.db A/B (PR4), not over scripted scenario transcripts where it would mischaracterize planted history as agent behavior.

Refs #961