### PR TITLE
fix(sync): don't send a phantom content_hash on join-table deletes (PGRST204)

### DIFF
--- a/packages/gateway/src/sync.ts
+++ b/packages/gateway/src/sync.ts
@@ -298,15 +298,18 @@ async function pushEntry(
   }
 
   if (op === "delete") {
-    // Null the remote content_hash too, so the tombstone honors the
-    // "remoteHash is null for a tombstone" contract on the wire. The pull side
-    // (applyRemote) already treats is_deleted rows as hash-null, but this also
-    // protects un-upgraded readers during a rollout.
-    // Null the remote content_hash too (tombstone "remoteHash is null" contract).
     const tombstone: Record<string, unknown> = {
       is_deleted: true,
-      content_hash: null,
     };
+    // Only versioned tables have a content_hash column remotely; the join table
+    // (knowledge_entity_refs) does not, so sending it is a PGRST204 schema error that
+    // would wedge the table forever (PGRST204 classifies as transient → infinite retry).
+    // Mirror the upsert path's `meta.versioned` gate. Nulling it honors the tombstone's
+    // "remoteHash is null" contract on the wire (the pull side already treats is_deleted
+    // rows as hash-null, but this also protects un-upgraded readers during a rollout).
+    if (tableMeta(table).versioned !== false) {
+      tombstone.content_hash = null;
+    }
     // Erasure completeness (#823): scrub the deleted knowledge content-bearing
     // columns from the remote tombstone so the bytes don't linger server-side until
     // the sub-PR 4 reaper. The LOCAL death-cert preserves them, and

--- a/packages/gateway/test/sync-engine.integration.test.ts
+++ b/packages/gateway/test/sync-engine.integration.test.ts
@@ -215,6 +215,45 @@ describe.skipIf(SKIP)("sync engine ↔ real Postgres/PostgREST", () => {
     expect(ref).toHaveLength(1);
   });
 
+  it("pushes a DELETE for a join-table ref without a phantom content_hash (PGRST204 regression)", async () => {
+    insertKnowledge("k1", "x");
+    db()
+      .query(
+        "INSERT INTO entities (id, project_id, entity_type, canonical_name, created_at, updated_at) VALUES ('e1','p','tool','X',?,?)",
+      )
+      .run(Date.now(), Date.now());
+    syncData.enableSync("basic");
+    db()
+      .query(
+        "INSERT INTO knowledge_entity_refs (knowledge_id, entity_id) VALUES ('k1','e1')",
+      )
+      .run();
+    await pushOnce(clientFor(uid)); // ref upserted (is_deleted=false)
+
+    // Delete the ref locally → capture a delete op → push the tombstone. The join
+    // table is versioned:false (no content_hash column), so the delete payload must
+    // NOT include content_hash, or PostgREST rejects it (PGRST204) and — since that's
+    // not a 23514 — the table wedges on infinite transient retries.
+    db()
+      .query(
+        "DELETE FROM knowledge_entity_refs WHERE knowledge_id='k1' AND entity_id='e1'",
+      )
+      .run();
+    const r = await pushOnce(clientFor(uid));
+    expect(r.pushed).toBe(1); // exactly the ref delete pushed (no PGRST204 wedge)
+
+    // Remote ref is soft-deleted, not errored.
+    const ref = await h.asUser(uid, (c) =>
+      c
+        .query(
+          "select is_deleted from public.knowledge_entity_refs where knowledge_id='k1' and entity_id='e1'",
+        )
+        .then((x) => x.rows),
+    );
+    expect(ref).toHaveLength(1);
+    expect(ref[0].is_deleted).toBe(true);
+  });
+
   it("round-trips push → pull with a stable content hash (no ping-pong)", async () => {
     syncData.enableSync("basic");
     insertKnowledge("k1", "round-trip");


### PR DESCRIPTION
## Bug (observed on a live initial sync)
```
sync: push delete knowledge_entity_refs/…: Could not find the 'content_hash' column of 'knowledge_entity_refs' in the schema cache
```
The tombstone/DELETE push (`sync.ts:316`) **unconditionally** set `content_hash: null`. Join tables like `knowledge_entity_refs` are `versioned:false` and have **no `content_hash` column** remotely (only `is_deleted`), so PostgREST rejects the whole delete with **PGRST204**. Since that's not a `23514`, `classifyPushError` calls it **transient** → the delete retries every cycle forever → **`knowledge_entity_refs` sync wedges**.

The *upsert* path already gates this correctly (`if (tableMeta(table).versioned !== false)` at line 384); the delete path didn't.

## Fix
Gate `content_hash: null` on the tombstone behind `tableMeta(table).versioned !== false`, mirroring the upsert path. Versioned:false tables get a plain `{ is_deleted: true }` soft-delete — the column the join table actually has.

## Test
Tier-2 engine integration (real Postgres + PostgREST): push a ref, delete it locally, push the tombstone → assert it uploads (no PGRST204) and the remote row is `is_deleted=true`. **Verified discriminating** — fails with the gate removed.

12/12 engine integration + 47 unit sync tests pass; typecheck + lint clean.