### PR TITLE
feat(sync): show initial-sync progress — "Performing initial sync…" with a live bar

### DIFF
--- a/packages/gateway/src/cli/sync-cmd.ts
+++ b/packages/gateway/src/cli/sync-cmd.ts
@@ -13,6 +13,7 @@
 import { randomBytes } from "node:crypto";
 import { createInterface } from "node:readline";
 import { keystore, syncData, getKV } from "@loreai/core";
+import type { SyncProgressFn } from "../sync";
 
 export async function commandSync(
   positionals: string[],
@@ -114,7 +115,7 @@ export async function cmdEnable(
     }
   }
 
-  await runSync();
+  await runSync("Performing initial sync…");
 }
 
 /** Prompt callbacks for the encryption bootstrap (injectable for tests). */
@@ -399,9 +400,68 @@ async function cmdNow(): Promise<void> {
 }
 
 /** Run one sync cycle and print a human-readable summary. */
-async function runSync(): Promise<void> {
+interface ProgressOut {
+  write(s: string): void;
+  isTTY?: boolean;
+}
+
+/**
+ * A single-line progress reporter for one sync cycle. On a TTY it redraws a bar that
+ * names the current table (part) and moves as rows push/pull; off a TTY it prints the
+ * header once. The bar advances one step per (phase, table) visited — push every
+ * non-pull-only table, then pull every table.
+ */
+export function makeSyncProgress(
+  header: string,
+  out: ProgressOut = process.stdout,
+): { onProgress: SyncProgressFn; done: () => void } {
+  const tables = syncData.syncedTables("basic");
+  const total = tables.filter((t) => !t.pullOnly).length + tables.length;
+  const tty = !!out.isTTY;
+  const seen = new Set<string>();
+  let lastLen = 0;
+  let headerShown = false;
+
+  const bar = (frac: number, width = 16): string => {
+    const filled = Math.max(0, Math.min(width, Math.round(width * frac)));
+    return "█".repeat(filled) + "░".repeat(width - filled);
+  };
+
+  const onProgress: SyncProgressFn = (p) => {
+    // A rendering failure must NEVER abort the sync cycle (defense-in-depth).
+    try {
+      seen.add(`${p.phase}:${p.table}`);
+      if (!tty) {
+        if (!headerShown) {
+          out.write(`${header}\n`);
+          headerShown = true;
+        }
+        return;
+      }
+      const step = Math.min(seen.size, total);
+      const line =
+        `${header} [${bar(total ? step / total : 1)}] ${step}/${total}  ` +
+        `${p.phase} · ${p.table}   ↑${p.pushed} ↓${p.pulled}`;
+      lastLen = line.length;
+      out.write(`\r${line}`);
+    } catch {
+      // ignore — progress is cosmetic
+    }
+  };
+
+  const done = (): void => {
+    // Clear the progress line so the summary prints on a clean line.
+    if (tty && lastLen > 0) out.write(`\r${" ".repeat(lastLen)}\r`);
+  };
+
+  return { onProgress, done };
+}
+
+async function runSync(header = "Syncing…"): Promise<void> {
   const { syncOnce } = await import("../sync");
-  const r = await syncOnce();
+  const progress = makeSyncProgress(header);
+  const r = await syncOnce(progress.onProgress);
+  progress.done();
   if (r.notAuthed) {
     console.error('Session expired. Run "lore login" again.');
     process.exitCode = 1;

--- a/packages/gateway/src/sync.ts
+++ b/packages/gateway/src/sync.ts
@@ -49,6 +49,16 @@ export function __resetQuotaWarnedTables(): void {
   quotaWarnedTables.clear();
 }
 
+/** A live progress tick, emitted per table (on entry) and after each page. */
+export interface SyncProgress {
+  phase: "push" | "pull";
+  table: string;
+  /** Cumulative rows pushed/pulled so far this cycle. */
+  pushed: number;
+  pulled: number;
+}
+export type SyncProgressFn = (p: SyncProgress) => void;
+
 type PushErrorKind = "quota" | "poison" | "transient";
 
 /**
@@ -185,7 +195,10 @@ function decryptColumns(
  * independently: a quota or transient failure on one table never advances its
  * cursor past the unpushed row and never blocks another table.
  */
-export async function pushOnce(client: SupabaseClient): Promise<SyncResult> {
+export async function pushOnce(
+  client: SupabaseClient,
+  onProgress?: SyncProgressFn,
+): Promise<SyncResult> {
   const res: SyncResult = { pushed: 0, pulled: 0, conflicts: 0 };
   const enc = makeEncryptionResolver();
   for (const meta of syncData.syncedTables("basic")) {
@@ -193,7 +206,13 @@ export async function pushOnce(client: SupabaseClient): Promise<SyncResult> {
     // reads them. They have no outbox capture trigger, so this is belt-and-
     // suspenders, but it keeps the intent explicit and avoids a needless scan.
     if (meta.pullOnly) continue;
-    await pushTable(client, meta.table, res, enc);
+    onProgress?.({
+      phase: "push",
+      table: meta.table,
+      pushed: res.pushed,
+      pulled: res.pulled,
+    });
+    await pushTable(client, meta.table, res, enc, onProgress);
   }
   // Reclaim outbox rows fully pushed across all tables THAT HAVE ENTRIES (seq <=
   // the lowest such cursor) — the outbox is otherwise append-only. A table with
@@ -218,6 +237,7 @@ async function pushTable(
   table: string,
   res: SyncResult,
   enc: ReturnType<typeof makeEncryptionResolver>,
+  onProgress?: SyncProgressFn,
 ): Promise<void> {
   let cursor = Number(getKV(pushKey(table)) ?? "0");
 
@@ -253,6 +273,12 @@ async function pushTable(
 
     cursor = safeCursor;
     setKV(pushKey(table), String(cursor));
+    onProgress?.({
+      phase: "push",
+      table,
+      pushed: res.pushed,
+      pulled: res.pulled,
+    });
     if (stop || batch.length < PAGE) break;
   }
 }
@@ -465,11 +491,21 @@ function formatCursor(c: KeysetCursor): string {
  * keyset order), so rows that share a timestamp across a page boundary are never
  * dropped. Timestamps are compared as parsed instants, not lexical ISO strings.
  */
-export async function pullOnce(client: SupabaseClient): Promise<SyncResult> {
+export async function pullOnce(
+  client: SupabaseClient,
+  onProgress?: SyncProgressFn,
+): Promise<SyncResult> {
   const res: SyncResult = { pushed: 0, pulled: 0, conflicts: 0 };
   const encResolver = makeEncryptionResolver();
 
   for (const meta of syncData.syncedTables("basic")) {
+    // Emit BEFORE the locked/skip guards so a skipped table still advances the bar.
+    onProgress?.({
+      phase: "pull",
+      table: meta.table,
+      pushed: res.pushed,
+      pulled: res.pulled,
+    });
     const touchedFts = new Set<string>();
     let cursor = parseCursor(getKV(pullKey(meta.table)));
 
@@ -522,6 +558,12 @@ export async function pullOnce(client: SupabaseClient): Promise<SyncResult> {
           advanced = true;
         }
         setKV(pullKey(meta.table), formatCursor(cursor));
+        onProgress?.({
+          phase: "pull",
+          table: meta.table,
+          pushed: res.pushed,
+          pulled: res.pulled,
+        });
 
         if (rows.length < PAGE) break; // last page
 
@@ -760,15 +802,17 @@ function applyRemote(
 // syncOnce — push then pull
 // ---------------------------------------------------------------------------
 
-export async function syncOnce(): Promise<SyncResult> {
+export async function syncOnce(
+  onProgress?: SyncProgressFn,
+): Promise<SyncResult> {
   if (!syncData.isSyncEnabled()) {
     return { pushed: 0, pulled: 0, conflicts: 0 };
   }
   const client = await getAuthedClient();
   if (!client) return { pushed: 0, pulled: 0, conflicts: 0, notAuthed: true };
 
-  const push = await pushOnce(client);
-  const pull = await pullOnce(client);
+  const push = await pushOnce(client, onProgress);
+  const pull = await pullOnce(client, onProgress);
   return {
     pushed: push.pushed,
     pulled: pull.pulled,

--- a/packages/gateway/test/sync-cmd.test.ts
+++ b/packages/gateway/test/sync-cmd.test.ts
@@ -42,6 +42,7 @@ import {
   cmdEnable,
   type EncryptionPrompts,
   generateRecoveryCode,
+  makeSyncProgress,
   normalizeRecoveryCode,
 } from "../src/cli/sync-cmd";
 
@@ -261,6 +262,51 @@ describe("cmdEnable (C-4b activation)", () => {
     await cmdEnable(prompts());
     expect(syncData.isSyncEnabled()).toBe(false);
     expect(process.exitCode).toBe(1);
+  });
+});
+
+describe("makeSyncProgress (initial-sync progress UX)", () => {
+  it("renders a moving bar naming the current part (table) on a TTY", () => {
+    const writes: string[] = [];
+    const out = { write: (s: string) => writes.push(s), isTTY: true };
+    const { onProgress, done } = makeSyncProgress(
+      "Performing initial sync…",
+      out,
+    );
+    onProgress({ phase: "push", table: "knowledge", pushed: 100, pulled: 0 });
+    onProgress({ phase: "pull", table: "knowledge", pushed: 130, pulled: 40 });
+    const last = writes.at(-1) ?? "";
+    expect(last).toContain("pull · knowledge");
+    expect(last).toContain("↑130 ↓40");
+    expect(last).toMatch(/\[█+░*\]/); // a bar segment
+    done();
+    expect(writes.at(-1)).toMatch(/^\r +\r$/); // line cleared for the summary
+  });
+
+  it("advances the bar as new (phase, table) parts are seen", () => {
+    const writes: string[] = [];
+    const out = { write: (s: string) => writes.push(s), isTTY: true };
+    const { onProgress } = makeSyncProgress("Sync", out);
+    onProgress({ phase: "push", table: "knowledge", pushed: 0, pulled: 0 });
+    const first = Number((writes.at(-1) ?? "").match(/(\d+)\/\d+/)?.[1] ?? "0");
+    onProgress({ phase: "pull", table: "profiles", pushed: 0, pulled: 0 });
+    const second = Number(
+      (writes.at(-1) ?? "").match(/(\d+)\/\d+/)?.[1] ?? "0",
+    );
+    expect(second).toBeGreaterThan(first);
+  });
+
+  it("prints the header once with no bar on a non-TTY", () => {
+    const writes: string[] = [];
+    const out = { write: (s: string) => writes.push(s), isTTY: false };
+    const { onProgress, done } = makeSyncProgress(
+      "Performing initial sync…",
+      out,
+    );
+    onProgress({ phase: "push", table: "knowledge", pushed: 1, pulled: 0 });
+    onProgress({ phase: "push", table: "entities", pushed: 2, pulled: 0 });
+    done();
+    expect(writes).toEqual(["Performing initial sync…\n"]); // once, no bar
   });
 });
 

--- a/packages/gateway/test/sync.test.ts
+++ b/packages/gateway/test/sync.test.ts
@@ -289,6 +289,7 @@ import {
   __resetQuotaWarnedTables,
   pushOnce,
   pullOnce,
+  type SyncProgress,
   syncOnce,
 } from "../src/sync";
 
@@ -595,6 +596,43 @@ describe("BLOCKER regressions", () => {
     expect(tableRows("entities").find((x) => x.id === "e1")).toBeTruthy(); // synced!
     expect(Number(getKV("sync.push.knowledge"))).toBe(0); // knowledge cursor held
     expect(Number(getKV("sync.push.entities"))).toBeGreaterThan(0); // entities advanced
+  });
+
+  test("pushOnce emits progress per table (phase/table + cumulative counts)", async () => {
+    syncData.enableSync("basic");
+    insertKnowledge("k1", "hello");
+    const events: SyncProgress[] = [];
+    await pushOnce(makeClient() as never, (p) => events.push(p));
+    expect(events.every((e) => e.phase === "push")).toBe(true);
+    const kn = events.filter((e) => e.table === "knowledge");
+    expect(kn.length).toBeGreaterThanOrEqual(1);
+    expect(Math.max(...kn.map((e) => e.pushed))).toBeGreaterThanOrEqual(1);
+  });
+
+  test("pullOnce emits a progress event for every synced table (before skip guards)", async () => {
+    syncData.enableSync("basic");
+    const events: SyncProgress[] = [];
+    await pullOnce(makeClient() as never, (p) => events.push(p));
+    const tables = new Set(
+      events.filter((e) => e.phase === "pull").map((e) => e.table),
+    );
+    expect(tables.size).toBe(syncData.syncedTables("basic").length);
+  });
+
+  test("pullOnce still emits for a table SKIPPED while locked (emit precedes the skip guard)", async () => {
+    syncData.enableSync("basic");
+    keystore.setPassphrase("pw", { params: { t: 1, m: 256, p: 1 } });
+    db().exec("DELETE FROM account_identity"); // escrow remains → "locked"
+    keystore.lock();
+    expect(keystore.encryptionState()).toBe("locked");
+    const events: SyncProgress[] = [];
+    await pullOnce(makeClient() as never, (p) => events.push(p));
+    // knowledge is an encrypted table that is skipped while locked, yet its progress
+    // event must still fire — the emit is placed BEFORE the locked `continue` guard so
+    // a skipped table still advances the bar. (Moving the emit after the guard fails this.)
+    expect(
+      events.some((e) => e.phase === "pull" && e.table === "knowledge"),
+    ).toBe(true);
   });
 
   test("a persistent quota pause warns ONCE, not every cycle (log de-spam)", async () => {


### PR DESCRIPTION
## Why
`lore sync enable` printed "Encryption enabled" then went **silent** while the first push uploaded all existing knowledge (500+ rows, paged) — it looked frozen. Give live, per-part feedback.

## What
- **Engine**: thread an optional `onProgress` callback through `syncOnce`/`pushOnce`/`pullOnce`, emitted **per table** (on entry) and **after each page** (so counts move within a big table). No behavior change when absent — the background scheduler passes none.
- **CLI**: `makeSyncProgress` renders a single-line bar that names the current **part** (table) and moves as rows push/pull:
  ```
  Performing initial sync… [██████████░░░░░░] 6/16  pull · knowledge   ↑520 ↓140
  ```
  `runSync` drives it; `lore sync enable` labels it "Performing initial sync…", `lore sync now` "Syncing…". Non-TTY prints the header once (no bar). The bar is cleared before the "Synced: …" summary.

The bar advances one step per (phase, table) visited — push every non-pull-only table, then pull every table — and the ↑/↓ counts move per page for liveness.

## Tests
- `pushOnce`/`pullOnce` emit progress (per table, cumulative counts; one pull event per synced table, emitted **before** the locked/skip guards so a skipped table still advances).
- `makeSyncProgress`: renders + advances the bar on a TTY, names the current table + ↑/↓ counts, clears on `done()`, and prints just the header on a non-TTY.

72 gateway sync/cmd unit tests + 12 engine integration tests pass; typecheck + lint clean.

## Note
Determinate over the known table set (pull totals are unknown via keyset), with per-page ↑/↓ movement for liveness — an honest bar without faking a row total.