### PR TITLE
fix(gateway): tolerate mislabeled SSE when reading non-streaming completions

### DIFF
--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -40,7 +40,7 @@ import {
 } from "./sentry";
 import { recordWorkerCost } from "./cost-tracker";
 import { upstreamFetch } from "./fetch";
-import { extractJSONFromSSE } from "./translate/types";
+import { readCompletionJSON } from "./translate/types";
 import { buildOpenAIChatCompletionsUrl } from "./translate/openai";
 import { isBedrockMantleHost, toMantleModelId } from "./translate/bedrock";
 import {
@@ -1628,12 +1628,15 @@ export function createGatewayLLMClient(
                 // model.
                 if (thinkingStripped) markThinkingUnsupported(model);
 
-                // Guard: some providers return SSE even when stream: false
-                // was sent. Extract JSON from the data: lines instead.
+                // Guard: some providers (the ChatGPT/Codex backend, DeepSeek)
+                // return SSE even when stream: false was sent — sometimes
+                // WITHOUT the text/event-stream content-type. readCompletionJSON
+                // sniffs the body so a mislabeled SSE stream is never fed to
+                // JSON.parse (LOREAI-GATEWAY-38: `Unexpected token 'e', "event:
+                // res"...`) and the openai-responses terminal envelope is
+                // unwrapped to the bare response the parser expects.
                 const ct = response.headers.get("content-type") ?? "";
-                const rawData = ct.includes("text/event-stream")
-                  ? await extractJSONFromSSE(response)
-                  : await response.json();
+                const rawData = await readCompletionJSON(response);
 
                 // A 2xx whose body is a provider error envelope (e.g. OpenRouter
                 // surfacing an upstream timeout as HTTP 200 + {error:{code:504}})

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -97,7 +97,7 @@ import type {
 import {
   applyUpstreamExtraHeaders,
   blocksToText,
-  extractJSONFromSSE,
+  readCompletionJSON,
   forwardClientHeaders,
   ZERO_USAGE,
 } from "./translate/types";
@@ -4315,17 +4315,13 @@ async function accumulateNonStreamResponse(
     | "vertex"
     | "gemini" = "anthropic",
 ): Promise<GatewayResponse> {
-  // Some providers (e.g. DeepSeek) return SSE-formatted responses even when
-  // stream: false was sent. Detect this via content-type and extract the JSON
-  // payload from the SSE data lines instead of calling response.json() which
-  // would throw a SyntaxError on "data: {...}" prefixed text.
-  const ct = upstreamResponse.headers.get("content-type") ?? "";
-  let json: Record<string, unknown>;
-  if (ct.includes("text/event-stream")) {
-    json = await extractJSONFromSSE(upstreamResponse);
-  } else {
-    json = (await upstreamResponse.json()) as Record<string, unknown>;
-  }
+  // Some providers (the ChatGPT/Codex backend, DeepSeek) return SSE-formatted
+  // responses even when stream: false was sent — sometimes WITHOUT the
+  // text/event-stream content-type. readCompletionJSON sniffs the body so a
+  // mislabeled SSE stream is never fed to JSON.parse (which would throw a
+  // SyntaxError on "data: {...}" / "event: ..." prefixed text — LOREAI-GATEWAY-
+  // 38 / -1P).
+  const json = await readCompletionJSON(upstreamResponse);
 
   switch (protocol) {
     case "openai":

--- a/packages/gateway/src/translate/types.ts
+++ b/packages/gateway/src/translate/types.ts
@@ -258,29 +258,67 @@ export const ZERO_USAGE: GatewayUsage = Object.freeze({
 });
 
 /**
- * Extract a JSON payload from an SSE response body.
+ * True when a response body is Server-Sent Events rather than a JSON object —
+ * even if the provider mislabeled or omitted the `content-type`.
+ *
+ * Detected by the header OR by sniffing the body prefix: an SSE stream begins
+ * with an SSE field (`data:` / `event:` / `id:` / `retry:`) or a comment line
+ * (`:`), whereas a JSON body begins with `{` or `[`. Some providers (the
+ * ChatGPT/Codex backend, DeepSeek) return SSE even when a NON-streaming request
+ * was made — and sometimes WITHOUT the `text/event-stream` content-type — so a
+ * header-only check misses them and `JSON.parse`-ing the SSE body throws
+ * (`Unexpected token 'e', "event: res"...` — LOREAI-GATEWAY-38 / -1P).
+ */
+export function looksLikeSSE(contentType: string, body: string): boolean {
+  if (contentType.includes("text/event-stream")) return true;
+  const head = body.replace(/^\uFEFF/, "").trimStart();
+  return /^(?:data|event|id|retry):/.test(head) || head.startsWith(":");
+}
+
+/**
+ * An openai-responses SSE stream terminates with a `response.completed` (or
+ * `.incomplete` / `.failed`) event whose `response` field holds the FULL
+ * response object. `extractJSONFromSSEText` returns the last data line, which is
+ * that terminal event — but the non-streaming parsers expect the bare response
+ * object (`{output, output_text, usage, model}`). Unwrap the envelope so they
+ * read the right shape (otherwise: `text=null` → silent-empty worker output).
+ */
+function unwrapResponsesEnvelope(
+  obj: Record<string, unknown>,
+): Record<string, unknown> {
+  if (
+    typeof obj.type === "string" &&
+    obj.type.startsWith("response.") &&
+    obj.response &&
+    typeof obj.response === "object"
+  ) {
+    return obj.response as Record<string, unknown>;
+  }
+  return obj;
+}
+
+/**
+ * Extract a JSON payload from already-read SSE body text.
  *
  * Some providers (e.g. DeepSeek) return SSE-formatted responses even when
- * `stream: false` was sent. This function reads all `data: ` lines, ignores
- * the `data: [DONE]` sentinel, and returns the **last** non-sentinel data
- * payload as parsed JSON. The final `data:` line contains the full response
- * object in this scenario.
+ * `stream: false` was sent. This reads all `data:` lines, ignores the
+ * `data: [DONE]` sentinel, and returns the **last** non-sentinel data payload as
+ * parsed JSON (the final `data:` line carries the full response object in this
+ * scenario), unwrapping the openai-responses terminal envelope when present.
  *
- * NOTE: This does not handle the SSE spec's multiline `data:` continuation
- * (consecutive `data:` lines joined by `\n`). In practice, providers that
- * return a complete non-streaming response as SSE always send the JSON
- * object on a single `data:` line.
+ * NOTE: does not handle the SSE spec's multiline `data:` continuation
+ * (consecutive `data:` lines joined by `\n`). In practice, providers that return
+ * a complete non-streaming response as SSE send the JSON on a single `data:`
+ * line (or, for openai-responses, in the terminal `response.completed` event).
  */
-export async function extractJSONFromSSE(
-  response: Response,
-): Promise<Record<string, unknown>> {
-  const text = await response.text();
+export function extractJSONFromSSEText(text: string): Record<string, unknown> {
   const lines = text.split("\n");
   let lastPayload: string | null = null;
 
   for (const line of lines) {
-    if (line.startsWith("data: ")) {
-      const payload = line.slice(6).trim();
+    if (line.startsWith("data:")) {
+      // Tolerate both `data: x` and `data:x` (one optional leading space).
+      const payload = line.slice(line.indexOf(":") + 1).trim();
       if (payload && payload !== "[DONE]") {
         lastPayload = payload;
       }
@@ -293,7 +331,34 @@ export async function extractJSONFromSSE(
     );
   }
 
-  return JSON.parse(lastPayload) as Record<string, unknown>;
+  return unwrapResponsesEnvelope(
+    JSON.parse(lastPayload) as Record<string, unknown>,
+  );
+}
+
+/** Extract a JSON payload from an SSE `Response`. */
+export async function extractJSONFromSSE(
+  response: Response,
+): Promise<Record<string, unknown>> {
+  return extractJSONFromSSEText(await response.text());
+}
+
+/**
+ * Read an upstream LLM completion body as JSON, tolerant of providers that
+ * return SSE even for a non-streaming request — INCLUDING those that mislabel or
+ * omit the `content-type`. Reads the body once, sniffs for SSE, then either
+ * extracts the JSON from the data lines or parses the whole body as JSON. This
+ * is the single safe entry point for reading a non-streaming completion body;
+ * calling `response.json()` directly throws on a mislabeled SSE body.
+ */
+export async function readCompletionJSON(
+  response: Response,
+): Promise<Record<string, unknown>> {
+  const contentType = response.headers.get("content-type") ?? "";
+  const text = await response.text();
+  return looksLikeSSE(contentType, text)
+    ? extractJSONFromSSEText(text)
+    : (JSON.parse(text) as Record<string, unknown>);
 }
 
 /** Accumulated response from the upstream provider. */

--- a/packages/gateway/test/translate-types.test.ts
+++ b/packages/gateway/test/translate-types.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { ZERO_USAGE, extractJSONFromSSE } from "../src/translate/types";
+import {
+  ZERO_USAGE,
+  extractJSONFromSSE,
+  extractJSONFromSSEText,
+  looksLikeSSE,
+  readCompletionJSON,
+} from "../src/translate/types";
 
 // ---------------------------------------------------------------------------
 // ZERO_USAGE
@@ -92,5 +98,101 @@ describe("extractJSONFromSSE", () => {
     const body = 'data: {"id":"crlf"}\r\ndata: [DONE]\r\n\r\n';
     const json = await extractJSONFromSSE(sseResponse(body));
     expect(json).toEqual({ id: "crlf" });
+  });
+
+  it("tolerates `data:` with no space after the colon", async () => {
+    const json = await extractJSONFromSSE(
+      sseResponse('data:{"id":"nospace"}\n'),
+    );
+    expect(json).toEqual({ id: "nospace" });
+  });
+
+  it("unwraps the openai-responses `response.completed` envelope to the bare response", () => {
+    const body = [
+      "event: response.created",
+      'data: {"type":"response.created","response":{"id":"resp_1"}}',
+      "event: response.completed",
+      'data: {"type":"response.completed","response":{"output_text":"hi","usage":{"input_tokens":3,"output_tokens":1},"model":"gpt-5-codex"}}',
+      "data: [DONE]",
+      "",
+    ].join("\n");
+    // The terminal event's `.response` is returned, NOT the envelope — so the
+    // non-streaming parsers read `output_text`/`usage`/`model` at top level.
+    expect(extractJSONFromSSEText(body)).toEqual({
+      output_text: "hi",
+      usage: { input_tokens: 3, output_tokens: 1 },
+      model: "gpt-5-codex",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// looksLikeSSE — body-prefix sniffing (content-type may be mislabeled)
+// ---------------------------------------------------------------------------
+
+describe("looksLikeSSE", () => {
+  it("true for a text/event-stream content-type regardless of body", () => {
+    expect(looksLikeSSE("text/event-stream; charset=utf-8", "{}")).toBe(true);
+  });
+
+  it("sniffs SSE bodies even when the content-type is wrong or empty", () => {
+    for (const head of [
+      "data: {",
+      "event: response.created",
+      "id: 1",
+      "retry: 5",
+      ": keepalive",
+    ]) {
+      expect(looksLikeSSE("application/json", `${head}\n`)).toBe(true);
+      expect(looksLikeSSE("", `${head}\n`)).toBe(true);
+    }
+  });
+
+  it("false for a JSON body (object or array), tolerating BOM/leading whitespace", () => {
+    expect(looksLikeSSE("application/json", '{"a":1}')).toBe(false);
+    expect(looksLikeSSE("", "  \n [1,2]")).toBe(false);
+    expect(looksLikeSSE("", '\uFEFF{"a":1}')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readCompletionJSON — the single safe reader for non-streaming bodies
+// ---------------------------------------------------------------------------
+
+function response(body: string, contentType: string): Response {
+  return new Response(body, { headers: { "content-type": contentType } });
+}
+
+describe("readCompletionJSON", () => {
+  it("parses a normal JSON body", async () => {
+    const json = await readCompletionJSON(
+      response(
+        '{"choices":[{"message":{"content":"hi"}}]}',
+        "application/json",
+      ),
+    );
+    expect(json).toEqual({ choices: [{ message: { content: "hi" } }] });
+  });
+
+  it("does NOT throw on an SSE body that is mislabeled application/json (LOREAI-GATEWAY-38/-1P)", async () => {
+    // A chat/completions SSE stream with the WRONG content-type — calling
+    // response.json() on this throws `Unexpected token 'd', "data: {..."`.
+    const body =
+      'data: {"id":"1","choices":[{"delta":{"content":"hi"},"finish_reason":"stop"}]}\ndata: [DONE]\n\n';
+    const json = await readCompletionJSON(response(body, "application/json"));
+    expect(json).toEqual({
+      id: "1",
+      choices: [{ delta: { content: "hi" }, finish_reason: "stop" }],
+    });
+  });
+
+  it("handles an openai-responses SSE stream with NO content-type, unwrapping the envelope", async () => {
+    const body = [
+      "event: response.completed",
+      'data: {"type":"response.completed","response":{"output_text":"done","model":"gpt-5-codex"}}',
+      "",
+    ].join("\n");
+    const json = await readCompletionJSON(response(body, ""));
+    expect(json).toEqual({ output_text: "done", model: "gpt-5-codex" });
   });
 });

--- a/packages/gateway/test/worker-codex-sse-path.test.ts
+++ b/packages/gateway/test/worker-codex-sse-path.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Regression for LOREAI-GATEWAY-38 (Sergiy): a background worker for a Codex
+ * session hits the ChatGPT/Codex backend, which MANDATES streaming and returns
+ * an openai-responses SSE stream even for a non-streaming worker request.
+ *
+ * Two failure modes, both fixed here:
+ *   1. THROW — the SSE body arrives WITHOUT a `text/event-stream` content-type,
+ *      so the old header-only guard fed it to `response.json()` →
+ *      `SyntaxError: Unexpected token 'e', "event: res"... is not valid JSON`.
+ *   2. SILENT-EMPTY — even with the correct content-type, the last `data:` line
+ *      is the `response.completed` ENVELOPE (`{type, response:{...}}`), but the
+ *      worker parser reads `output`/`output_text` at top level → `text=null`.
+ *
+ * `readCompletionJSON` now sniffs the body prefix AND unwraps the responses
+ * envelope, so the worker extracts the real text in both cases.
+ */
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("../src/fetch", () => ({ upstreamFetch: vi.fn() }));
+
+import { createGatewayLLMClient } from "../src/llm-adapter";
+import { upstreamFetch } from "../src/fetch";
+import { clearAllCosts } from "../src/cost-tracker";
+import { resetBackgroundLimiter } from "../src/background-limiter";
+
+const mockFetch = vi.mocked(upstreamFetch);
+
+const UPSTREAMS = {
+  anthropic: "https://api.anthropic.com",
+  openai: "https://api.openai.com",
+};
+
+/** An openai-responses SSE stream whose terminal event carries the full text. */
+const CODEX_RESPONSES_SSE = [
+  "event: response.created",
+  'data: {"type":"response.created","response":{"id":"resp_1"}}',
+  "event: response.output_text.delta",
+  'data: {"type":"response.output_text.delta","delta":"worker "}',
+  "event: response.completed",
+  'data: {"type":"response.completed","response":{"output":[{"type":"message","content":[{"type":"output_text","text":"worker text"}]}],"usage":{"input_tokens":5,"output_tokens":2},"model":"gpt-5-codex"}}',
+  "data: [DONE]",
+  "",
+].join("\n");
+
+function sseResponse(contentType: string): Response {
+  return new Response(CODEX_RESPONSES_SSE, {
+    status: 200,
+    headers: { "content-type": contentType },
+  });
+}
+
+async function runCodexWorker(contentType: string): Promise<string | null> {
+  const client = createGatewayLLMClient(
+    UPSTREAMS,
+    (_sid, providerID) =>
+      providerID === "openai-codex"
+        ? { scheme: "bearer", value: "codex_tok" }
+        : null,
+    { providerID: "openai-codex", modelID: "gpt-5-codex" },
+  );
+  mockFetch.mockResolvedValue(sseResponse(contentType));
+  return client.prompt("system-prompt", "user-prompt", {
+    sessionID: "sess-codex",
+    workerID: "lore-distill",
+    model: { providerID: "openai-codex", modelID: "gpt-5-codex" },
+  });
+}
+
+describe("worker codex responses-SSE path", () => {
+  beforeEach(() => mockFetch.mockReset());
+  afterEach(() => {
+    mockFetch.mockReset();
+    clearAllCosts();
+    resetBackgroundLimiter();
+  });
+
+  test("mislabeled SSE (application/json) → extracts text, does NOT throw", async () => {
+    // Before the fix: response.json() on "event: res..." → SyntaxError → null.
+    const result = await runCodexWorker("application/json");
+    expect(result).toBe("worker text");
+  });
+
+  test("correct text/event-stream content-type → unwraps envelope → extracts text", async () => {
+    // Before the fix: extractJSONFromSSE returned the `response.completed`
+    // envelope, so the parser read output_text=undefined → null (silent-empty).
+    const result = await runCodexWorker("text/event-stream");
+    expect(result).toBe("worker text");
+  });
+});


### PR DESCRIPTION
## Problem

Reported via Sentry **LOREAI-GATEWAY-38** (Sergiy) — a Codex-session background worker throws:

```
SyntaxError: Unexpected token 'e', "event: res"... is not valid JSON
  at JSON.parse
```

The ChatGPT/Codex backend **mandates streaming** and returns an openai-responses SSE stream (`event: response.…`) even for a non-streaming worker request — and sometimes **without** a `text/event-stream` content-type. The existing guard only checked the content-type header, so a mislabeled SSE body was fed to `response.json()` → throw. The same class shows up on the conversation path (**LOREAI-GATEWAY-1P**, `POST /v1/chat/completions`, `Unexpected token 'd', "data: {..."`).

There's a **second, silent** failure hiding behind it: even when the content-type *is* `text/event-stream`, `extractJSONFromSSE` returns the SSE's last `data:` line — for openai-responses that's the `response.completed` **envelope** (`{type, response:{…}}`), but `parseResponsesWorkerResponse` reads `output`/`output_text` at the top level → `text=null` → the worker records a silent-empty completion (miscounted as an incapable model).

## Fix

One shared, body-sniffing reader used by **both** the worker (`llm-adapter`) and conversation (`pipeline.accumulateNonStreamResponse`) non-streaming paths — replacing the two duplicated content-type-only guards:

- **`looksLikeSSE(contentType, body)`** — detect SSE by the header **or** by sniffing the body prefix (`data:` / `event:` / `id:` / `retry:` / `:` comment), so a mislabeled stream never reaches `JSON.parse`.
- **`extractJSONFromSSEText()`** — unwrap the openai-responses terminal `response.*` envelope to the bare `response` object the parsers expect (also fixes the silent-empty case). Also tolerates `data:` with no leading space.
- **`readCompletionJSON(response)`** — read the body once, sniff, then extract-from-SSE or `JSON.parse`. The single safe entry point for a non-streaming completion body.

Only the two LLM-completion read sites are affected; every other `.json()` in the gateway is a real JSON API (GitHub / models.dev / batch / quota) and is left unchanged.

## Tests (mutation-verified non-vacuous)

- `translate-types.test.ts`: `looksLikeSSE` sniffing (header vs body, BOM/whitespace, JSON vs SSE), envelope unwrap, and `readCompletionJSON` **not** throwing on an SSE body mislabeled `application/json`.
- `worker-codex-sse-path.test.ts` (new, e2e): a codex responses SSE stream extracts the real text for **both** a mislabeled `application/json` content-type (throw case) and a correct `text/event-stream` content-type (silent-empty/unwrap case).
- Mutation checks: reverting the body-sniff → mislabeled-SSE tests RED; reverting the envelope-unwrap → unwrap tests RED.
- Full gateway suite: **2704 passed / 58 skipped**. typecheck + lint clean.

Fixes LOREAI-GATEWAY-38 (and the -1P class).