### PR TITLE
feat(gateway): env-gated warmup cache-divergence probe

### DIFF
--- a/packages/gateway/src/cache-analytics.ts
+++ b/packages/gateway/src/cache-analytics.ts
@@ -72,6 +72,39 @@ export type CacheSegmentDigest = {
 };
 
 /**
+ * Classify a warmup probe outcome from the head-hash comparison and the
+ * observed cache read. Pure (no I/O) so it can be unit-tested directly.
+ *
+ * - no baseline           → no real turn was analyzed yet this session.
+ * - head DIFFERS          → the warmup body genuinely diverges from the last
+ *                           real turn at the head (a real body bug).
+ * - head MATCH, read > 0  → the warmup read the cache (healthy).
+ * - head MATCH, read = 0, cacheLikelyAlive  → EVICTION: an identical, byte-
+ *                           stable head that should still have been live was
+ *                           nonetheless a full miss (Anthropic-side eviction —
+ *                           a stable head cannot diverge).
+ * - head MATCH, read = 0, !cacheLikelyAlive → expected TTL expiry, NOT
+ *                           eviction (mirrors the sibling `✗ UNCACHED` log,
+ *                           which excludes expiry from the circuit breaker).
+ */
+export function classifyWarmupProbe(args: {
+  hasBaseline: boolean;
+  headMatch: boolean;
+  cacheReadTokens: number;
+  cacheLikelyAlive: boolean;
+}): string {
+  const { hasBaseline, headMatch, cacheReadTokens, cacheLikelyAlive } = args;
+  if (!hasBaseline)
+    return "no baseline (no real turn analyzed yet this session)";
+  if (!headMatch)
+    return "HEAD DIVERGENCE (warmup body head != last real turn head)";
+  if (cacheReadTokens > 0) return "head identical to last real turn";
+  return cacheLikelyAlive
+    ? "EVICTION (head identical to last real turn, yet cacheRead=0 while cache should have been live)"
+    : "expected expiry (head identical; cache aged past TTL, not eviction)";
+}
+
+/**
  * Hash the cacheable segments of a serialized Anthropic request body. Returns
  * null on any parse error (never throws — must be safe on the request path).
  */
@@ -754,31 +787,40 @@ export function analyzeCacheTurn(
   // (a "stable" head/prefix that changes IS a divergence source), then store for
   // the next warmup to compare against. Parsing/hashing is skipped entirely when
   // the probe is off, so there is zero hot-path cost in production by default.
+  // Wrapped in try/catch: this is a diagnostic and must never break the request
+  // path (a throw here would propagate into the response stream's onComplete).
   if (isWarmupProbeEnabled()) {
-    const dg = cacheSegmentDigest(currentBody);
-    if (dg) {
-      const sidStr = sessionID ? ` session=${sessionID.slice(0, 16)}` : "";
-      const drift: string[] = [];
-      if (analytics.probeHeadSha && analytics.probeHeadSha !== dg.headSha)
-        drift.push(`head ${analytics.probeHeadSha}->${dg.headSha}`);
-      if (analytics.probeToolsSha && analytics.probeToolsSha !== dg.toolsSha)
-        drift.push(`tools ${analytics.probeToolsSha}->${dg.toolsSha}`);
-      if (analytics.probePrefixSha && analytics.probePrefixSha !== dg.prefixSha)
-        drift.push(`prefix ${analytics.probePrefixSha}->${dg.prefixSha}`);
-      if (drift.length > 0) {
+    try {
+      const dg = cacheSegmentDigest(currentBody);
+      if (dg) {
+        const sidStr = sessionID ? ` session=${sessionID.slice(0, 16)}` : "";
+        const drift: string[] = [];
+        if (analytics.probeHeadSha && analytics.probeHeadSha !== dg.headSha)
+          drift.push(`head ${analytics.probeHeadSha}->${dg.headSha}`);
+        if (analytics.probeToolsSha && analytics.probeToolsSha !== dg.toolsSha)
+          drift.push(`tools ${analytics.probeToolsSha}->${dg.toolsSha}`);
+        if (
+          analytics.probePrefixSha &&
+          analytics.probePrefixSha !== dg.prefixSha
+        )
+          drift.push(`prefix ${analytics.probePrefixSha}->${dg.prefixSha}`);
+        if (drift.length > 0) {
+          log.info(
+            `warmup-probe: turn${sidStr} SEGMENT DRIFT [${drift.join(", ")}] ` +
+              `(a stable-segment change busts the cached prefix)`,
+          );
+        }
         log.info(
-          `warmup-probe: turn${sidStr} SEGMENT DRIFT [${drift.join(", ")}] ` +
-            `(a stable-segment change busts the cached prefix)`,
+          `warmup-probe: turn${sidStr} head=${dg.headSha} tools=${dg.toolsSha} ` +
+            `prefix=${dg.prefixSha} bp=${dg.bpCount} sysBlocks=${dg.systemBlocks} ` +
+            `read=${cacheRead} create=${cacheCreation}`,
         );
+        analytics.probeHeadSha = dg.headSha;
+        analytics.probeToolsSha = dg.toolsSha;
+        analytics.probePrefixSha = dg.prefixSha;
       }
-      log.info(
-        `warmup-probe: turn${sidStr} head=${dg.headSha} tools=${dg.toolsSha} ` +
-          `prefix=${dg.prefixSha} bp=${dg.bpCount} sysBlocks=${dg.systemBlocks} ` +
-          `read=${cacheRead} create=${cacheCreation}`,
-      );
-      analytics.probeHeadSha = dg.headSha;
-      analytics.probeToolsSha = dg.toolsSha;
-      analytics.probePrefixSha = dg.prefixSha;
+    } catch (err) {
+      log.warn(`warmup-probe: turn probe failed (ignored): ${err}`);
     }
   }
 

--- a/packages/gateway/src/cache-analytics.ts
+++ b/packages/gateway/src/cache-analytics.ts
@@ -21,6 +21,7 @@ import type {
 } from "./translate/types.ts";
 import { log, type CacheBustCause, type CacheStrategy } from "@loreai/core";
 import { zstdCompressSync, zstdDecompressSync } from "node:zlib";
+import { createHash } from "node:crypto";
 
 // ---------------------------------------------------------------------------
 // Compression helpers (node:zlib zstd, available in Node.js >= 22.15)
@@ -32,6 +33,90 @@ export function compressBody(body: string): Uint8Array {
 
 export function decompressBody(compressed: Uint8Array): string {
   return zstdDecompressSync(compressed).toString();
+}
+
+// ---------------------------------------------------------------------------
+// Warmup cache-divergence probe (env-gated, OFF by default → zero hot-path cost)
+// ---------------------------------------------------------------------------
+//
+// Purpose: definitively distinguish an Anthropic-side cache EVICTION from a
+// warmup request-body DIVERGENCE. We proved (real builder + prepareWarmupBody +
+// zstd + upstream encoding, all byte-identical) that the warmup body's cacheable
+// content equals the last real turn's body — but that rests on the in-memory
+// `lastRequestBody` truly matching what Anthropic cached. This probe closes that
+// gap in production by hashing the cacheable SEGMENTS and:
+//   1. On each real turn: detecting drift of the stable head / distilled prefix
+//      across consecutive turns (a "stable" head that drifts IS a divergence).
+//   2. On each warmup: comparing the signed warmup body's segment hashes to the
+//      last real turn's. Then, with the response cacheRead:
+//        - head hash MATCHES + cacheRead=0  → identical head was evicted (EVICTION)
+//        - head hash DIFFERS               → real body divergence (and where)
+//
+// Enable with LORE_WARMUP_PROBE=1. When unset, callers skip all hashing/parsing.
+export function isWarmupProbeEnabled(): boolean {
+  return process.env.LORE_WARMUP_PROBE === "1";
+}
+
+export type CacheSegmentDigest = {
+  /** SHA (12 hex) of system blocks up to & including the 1h breakpoint — the
+   *  stable "head" (system[0] host prompt + system[1] LTM). system[2]
+   *  (context-bound LTM) is excluded: it rides the conversation cache, not the
+   *  head, so including it would produce false head-drift. */
+  headSha: string;
+  /** SHA (12 hex) of the tools array (1h breakpoint on the last tool). */
+  toolsSha: string;
+  /** SHA (12 hex) of messages[0..1] — Lore's distilled prefix, byte-stable
+   *  between meta-distillations and carrying the #1155 1h interior breakpoint. */
+  prefixSha: string;
+  /** Number of cache_control breakpoints in the serialized body. */
+  bpCount: number;
+  /** Count of system blocks (sanity: 2 or 3). */
+  systemBlocks: number;
+  /** Serialized byte length (uncompressed). */
+  bytes: number;
+};
+
+/**
+ * Hash the cacheable segments of a serialized Anthropic request body. Returns
+ * null on any parse error (never throws — must be safe on the request path).
+ */
+export function cacheSegmentDigest(
+  serializedBody: string,
+): CacheSegmentDigest | null {
+  try {
+    const body = JSON.parse(serializedBody) as Record<string, unknown>;
+    const sha = (v: unknown) =>
+      createHash("sha256")
+        .update(JSON.stringify(v ?? null))
+        .digest("hex")
+        .slice(0, 12);
+
+    const systemBlocks = Array.isArray(body.system)
+      ? (body.system as Array<Record<string, unknown>>)
+      : [];
+    // Head = blocks up to & including the first one carrying a cache_control
+    // (the 1h stable-LTM breakpoint). Falls back to the whole array if none.
+    let headEnd = systemBlocks.length;
+    for (let i = 0; i < systemBlocks.length; i++) {
+      if (systemBlocks[i]?.cache_control) {
+        headEnd = i + 1;
+        break;
+      }
+    }
+    const messages = Array.isArray(body.messages)
+      ? (body.messages as unknown[])
+      : [];
+    return {
+      headSha: sha(systemBlocks.slice(0, headEnd)),
+      toolsSha: sha(body.tools),
+      prefixSha: sha(messages.slice(0, 2)),
+      bpCount: (serializedBody.match(/"cache_control"/g) ?? []).length,
+      systemBlocks: systemBlocks.length,
+      bytes: serializedBody.length,
+    };
+  } catch {
+    return null;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -668,6 +753,39 @@ export function analyzeCacheTurn(
   analytics.lastRequestBodyLength = normalizedBody.length;
   analytics.lastCacheRead = cacheRead;
   analytics.lastCacheCreation = cacheCreation;
+
+  // --- Warmup cache-divergence probe (env-gated) ---
+  // Hash this real turn's cacheable segments; detect drift vs the previous turn
+  // (a "stable" head/prefix that changes IS a divergence source), then store for
+  // the next warmup to compare against. Parsing/hashing is skipped entirely when
+  // the probe is off, so there is zero hot-path cost in production by default.
+  if (isWarmupProbeEnabled()) {
+    const dg = cacheSegmentDigest(currentBody);
+    if (dg) {
+      const sidStr = sessionID ? ` session=${sessionID.slice(0, 16)}` : "";
+      const drift: string[] = [];
+      if (analytics.probeHeadSha && analytics.probeHeadSha !== dg.headSha)
+        drift.push(`head ${analytics.probeHeadSha}->${dg.headSha}`);
+      if (analytics.probeToolsSha && analytics.probeToolsSha !== dg.toolsSha)
+        drift.push(`tools ${analytics.probeToolsSha}->${dg.toolsSha}`);
+      if (analytics.probePrefixSha && analytics.probePrefixSha !== dg.prefixSha)
+        drift.push(`prefix ${analytics.probePrefixSha}->${dg.prefixSha}`);
+      if (drift.length > 0) {
+        log.info(
+          `warmup-probe: turn${sidStr} SEGMENT DRIFT [${drift.join(", ")}] ` +
+            `(a stable-segment change busts the cached prefix)`,
+        );
+      }
+      log.info(
+        `warmup-probe: turn${sidStr} head=${dg.headSha} tools=${dg.toolsSha} ` +
+          `prefix=${dg.prefixSha} bp=${dg.bpCount} sysBlocks=${dg.systemBlocks} ` +
+          `read=${cacheRead} create=${cacheCreation}`,
+      );
+      analytics.probeHeadSha = dg.headSha;
+      analytics.probeToolsSha = dg.toolsSha;
+      analytics.probePrefixSha = dg.prefixSha;
+    }
+  }
 
   const result: CacheTurnAnalysis = {
     turn: analytics.turnCount,

--- a/packages/gateway/src/cache-analytics.ts
+++ b/packages/gateway/src/cache-analytics.ts
@@ -38,21 +38,16 @@ export function decompressBody(compressed: Uint8Array): string {
 // ---------------------------------------------------------------------------
 // Warmup cache-divergence probe (env-gated, OFF by default → zero hot-path cost)
 // ---------------------------------------------------------------------------
-//
-// Purpose: definitively distinguish an Anthropic-side cache EVICTION from a
-// warmup request-body DIVERGENCE. We proved (real builder + prepareWarmupBody +
-// zstd + upstream encoding, all byte-identical) that the warmup body's cacheable
-// content equals the last real turn's body — but that rests on the in-memory
-// `lastRequestBody` truly matching what Anthropic cached. This probe closes that
-// gap in production by hashing the cacheable SEGMENTS and:
-//   1. On each real turn: detecting drift of the stable head / distilled prefix
-//      across consecutive turns (a "stable" head that drifts IS a divergence).
-//   2. On each warmup: comparing the signed warmup body's segment hashes to the
-//      last real turn's. Then, with the response cacheRead:
-//        - head hash MATCHES + cacheRead=0  → identical head was evicted (EVICTION)
-//        - head hash DIFFERS               → real body divergence (and where)
-//
-// Enable with LORE_WARMUP_PROBE=1. When unset, callers skip all hashing/parsing.
+
+/**
+ * Env var `LORE_WARMUP_PROBE`: when set to `1`, enables the warmup
+ * cache-divergence diagnostic. It logs SHA comparisons of the cacheable
+ * segments (the stable head `system[0..1]`, tools, and the distilled prefix
+ * `messages[0..1]`) on real turns and warmups to tell an Anthropic-side cache
+ * eviction (segments match, `cacheRead=0`) apart from a warmup request-body
+ * divergence (segments differ). A debugging aid only; off by default, with zero
+ * cost when unset (callers skip all parsing/hashing).
+ */
 export function isWarmupProbeEnabled(): boolean {
   return process.env.LORE_WARMUP_PROBE === "1";
 }

--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -47,6 +47,7 @@ import type {
 } from "./translate/types";
 import {
   cacheSegmentDigest,
+  classifyWarmupProbe,
   decompressBody,
   isWarmupProbeEnabled,
 } from "./cache-analytics";
@@ -2238,48 +2239,50 @@ export async function executeWarmup(
 
     // --- Warmup cache-divergence probe (env-gated) ---
     // The decisive tiebreaker between EVICTION and body DIVERGENCE. Hash the
-    // signed warmup body's cacheable segments and compare to the last real
-    // turn's (stored by analyzeCacheTurn). Interpretation, combined with the
-    // cacheRead outcome above:
-    //   head MATCH + cacheRead=0  → the identical stable head was evicted by
-    //                               Anthropic (a stable head cannot diverge) →
-    //                               EVICTION, not a body bug.
-    //   head DIFFERS              → the warmup body genuinely diverges from the
-    //                               last real turn at the head → body bug, and
-    //                               the changed segment is named explicitly.
-    // A matching head with a differing prefix/tail localizes the divergence to
-    // the distilled prefix (meta-distillation) or conversation tail.
+    // warmup body's cacheable segments and compare to the last real turn's
+    // (stored by analyzeCacheTurn). Combined with the cacheRead outcome, the
+    // classifier below distinguishes: HEAD DIVERGENCE (real body bug), plain
+    // read>0 (healthy), EVICTION (identical head yet full miss while the cache
+    // should have been live), and expected TTL expiry. A matching head with a
+    // differing prefix/tail localizes the divergence to the distilled prefix
+    // (meta-distillation) or conversation tail.
     //
-    // Hash `warmupBody` (PRE-resign), NOT `signedBody`: `resignBody` rewrites
-    // only the cch/cc_version billing token in system[0], which Anthropic strips
-    // before computing its cache key. Hashing the post-resign body would report a
-    // false HEAD DIVERGENCE for OAuth sessions (whose cch is re-signed to a new
-    // value each call). `warmupBody` still carries the real turn's cch verbatim
+    // Hash `warmupBody` (PRE-resign), NOT `signedBody`: `resignBody` recomputes
+    // the cch/cc_version billing token over the warmup body (which sets
+    // stream=false, max_tokens=0), so its cch differs from the real turn's even
+    // though Anthropic strips the cch before hashing its cache key. Hashing the
+    // post-resign body would therefore report a false HEAD DIVERGENCE for OAuth
+    // sessions. `warmupBody` carries the real turn's cch verbatim
     // (prepareWarmupBody never touches system[0]), so it compares symmetrically
     // against the real turn's stored body that analyzeCacheTurn hashed.
+    //
+    // Wrapped in try/catch: this is a diagnostic and must never break the warmup
+    // path (a throw here would run before cost/circuit-breaker accounting below).
     if (isWarmupProbeEnabled()) {
-      const ca = state.cacheAnalytics;
-      const dg = cacheSegmentDigest(warmupBody);
-      if (dg) {
-        const cmp = (name: string, warm: string, real: string | undefined) =>
-          `${name}=${warm}${real ? (warm === real ? "==" : `!=${real}`) : "(no-baseline)"}`;
-        log.info(
-          `warmup-probe: WARMUP session=${sid} ` +
-            `${cmp("head", dg.headSha, ca.probeHeadSha)} ` +
-            `${cmp("tools", dg.toolsSha, ca.probeToolsSha)} ` +
-            `${cmp("prefix", dg.prefixSha, ca.probePrefixSha)} ` +
-            `bp=${dg.bpCount} sysBlocks=${dg.systemBlocks} bytes=${dg.bytes} ` +
-            `cacheRead=${cacheReadTokens} cacheWrite=${cacheCreationTokens} ` +
-            `→ ${
-              ca.probeHeadSha && dg.headSha === ca.probeHeadSha
-                ? cacheReadTokens === 0
-                  ? "EVICTION (head identical to last real turn, yet cacheRead=0)"
-                  : "head identical to last real turn"
-                : ca.probeHeadSha
-                  ? "HEAD DIVERGENCE (warmup body head != last real turn head)"
-                  : "no baseline (no real turn analyzed yet this session)"
-            }`,
-        );
+      try {
+        const ca = state.cacheAnalytics;
+        const dg = cacheSegmentDigest(warmupBody);
+        if (dg) {
+          const cmp = (name: string, warm: string, real: string | undefined) =>
+            `${name}=${warm}${real ? (warm === real ? "==" : `!=${real}`) : "(no-baseline)"}`;
+          const verdict = classifyWarmupProbe({
+            hasBaseline: ca.probeHeadSha != null,
+            headMatch: dg.headSha === ca.probeHeadSha,
+            cacheReadTokens,
+            cacheLikelyAlive,
+          });
+          log.info(
+            `warmup-probe: WARMUP session=${sid} ` +
+              `${cmp("head", dg.headSha, ca.probeHeadSha)} ` +
+              `${cmp("tools", dg.toolsSha, ca.probeToolsSha)} ` +
+              `${cmp("prefix", dg.prefixSha, ca.probePrefixSha)} ` +
+              `bp=${dg.bpCount} sysBlocks=${dg.systemBlocks} bytes=${dg.bytes} ` +
+              `cacheRead=${cacheReadTokens} cacheWrite=${cacheCreationTokens} ` +
+              `→ ${verdict}`,
+          );
+        }
+      } catch (err) {
+        log.warn(`warmup-probe: probe failed (ignored): ${err}`);
       }
     }
 

--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -45,7 +45,11 @@ import type {
   SessionState,
   WarmupState,
 } from "./translate/types";
-import { decompressBody } from "./cache-analytics";
+import {
+  cacheSegmentDigest,
+  decompressBody,
+  isWarmupProbeEnabled,
+} from "./cache-analytics";
 import { resolveAuth, authHeaders, markAuthStale } from "./auth";
 import { recordWorkerFailure, recordWorkerSuccess } from "./worker-health";
 import { resignBody } from "./cch";
@@ -2231,6 +2235,45 @@ export async function executeWarmup(
     // bug. Correlating this with the outcome confirms the breakpoint-preserving
     // fix (raw stored body) is working: UNCACHED with breakpoints=1 was the bug.
     const breakpoints = (signedBody.match(/"cache_control"/g) ?? []).length;
+
+    // --- Warmup cache-divergence probe (env-gated) ---
+    // The decisive tiebreaker between EVICTION and body DIVERGENCE. Hash the
+    // signed warmup body's cacheable segments and compare to the last real
+    // turn's (stored by analyzeCacheTurn). Interpretation, combined with the
+    // cacheRead outcome above:
+    //   head MATCH + cacheRead=0  → the identical stable head was evicted by
+    //                               Anthropic (a stable head cannot diverge) →
+    //                               EVICTION, not a body bug.
+    //   head DIFFERS              → the warmup body genuinely diverges from the
+    //                               last real turn at the head → body bug, and
+    //                               the changed segment is named explicitly.
+    // A matching head with a differing prefix/tail localizes the divergence to
+    // the distilled prefix (meta-distillation) or conversation tail.
+    if (isWarmupProbeEnabled()) {
+      const ca = state.cacheAnalytics;
+      const dg = cacheSegmentDigest(signedBody);
+      if (dg) {
+        const cmp = (name: string, warm: string, real: string | undefined) =>
+          `${name}=${warm}${real ? (warm === real ? "==" : `!=${real}`) : "(no-baseline)"}`;
+        log.info(
+          `warmup-probe: WARMUP session=${sid} ` +
+            `${cmp("head", dg.headSha, ca.probeHeadSha)} ` +
+            `${cmp("tools", dg.toolsSha, ca.probeToolsSha)} ` +
+            `${cmp("prefix", dg.prefixSha, ca.probePrefixSha)} ` +
+            `bp=${dg.bpCount} sysBlocks=${dg.systemBlocks} bytes=${dg.bytes} ` +
+            `cacheRead=${cacheReadTokens} cacheWrite=${cacheCreationTokens} ` +
+            `→ ${
+              ca.probeHeadSha && dg.headSha === ca.probeHeadSha
+                ? cacheReadTokens === 0
+                  ? "EVICTION (head identical to last real turn, yet cacheRead=0)"
+                  : "head identical to last real turn"
+                : ca.probeHeadSha
+                  ? "HEAD DIVERGENCE (warmup body head != last real turn head)"
+                  : "no baseline (no real turn analyzed yet this session)"
+            }`,
+        );
+      }
+    }
 
     if (cacheReadTokens > 0 && cacheCreationTokens === 0) {
       log.info(

--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -2249,9 +2249,17 @@ export async function executeWarmup(
     //                               the changed segment is named explicitly.
     // A matching head with a differing prefix/tail localizes the divergence to
     // the distilled prefix (meta-distillation) or conversation tail.
+    //
+    // Hash `warmupBody` (PRE-resign), NOT `signedBody`: `resignBody` rewrites
+    // only the cch/cc_version billing token in system[0], which Anthropic strips
+    // before computing its cache key. Hashing the post-resign body would report a
+    // false HEAD DIVERGENCE for OAuth sessions (whose cch is re-signed to a new
+    // value each call). `warmupBody` still carries the real turn's cch verbatim
+    // (prepareWarmupBody never touches system[0]), so it compares symmetrically
+    // against the real turn's stored body that analyzeCacheTurn hashed.
     if (isWarmupProbeEnabled()) {
       const ca = state.cacheAnalytics;
-      const dg = cacheSegmentDigest(signedBody);
+      const dg = cacheSegmentDigest(warmupBody);
       if (dg) {
         const cmp = (name: string, warm: string, real: string | undefined) =>
           `${name}=${warm}${real ? (warm === real ? "==" : `!=${real}`) : "(no-baseline)"}`;

--- a/packages/gateway/src/translate/types.ts
+++ b/packages/gateway/src/translate/types.ts
@@ -398,6 +398,15 @@ export type CacheAnalytics = {
   turnCount: number;
   /** Confirmed busts (API returned cacheRead=0 with cacheCreation>0). */
   bustCount: number;
+  /**
+   * Warmup cache-divergence probe (LORE_WARMUP_PROBE=1 only): segment hashes of
+   * the last real turn's body, so a warmup can compare its own segments and
+   * distinguish eviction (segments match, cacheRead=0) from divergence (segments
+   * differ). Undefined when the probe is off. See {@link cacheSegmentDigest}.
+   */
+  probeHeadSha?: string;
+  probeToolsSha?: string;
+  probePrefixSha?: string;
 };
 
 /** Routing snapshot captured from the last successful session request.

--- a/packages/gateway/test/cache-segment-digest.test.ts
+++ b/packages/gateway/test/cache-segment-digest.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "vitest";
+import {
+  type AnthropicCacheOptions,
+  buildAnthropicRequest,
+} from "../src/translate/anthropic";
+import {
+  type CacheSegmentDigest,
+  cacheSegmentDigest,
+  isWarmupProbeEnabled,
+} from "../src/cache-analytics";
+import type { GatewayRequest } from "../src/translate/types";
+
+function req(prefixText: string, tailText: string): GatewayRequest {
+  return {
+    protocol: "anthropic",
+    model: "claude-opus-4-8",
+    system: "host prompt",
+    maxTokens: 1024,
+    stream: true,
+    rawHeaders: {},
+    metadata: {},
+    tools: [
+      { name: "bash", description: "run", inputSchema: { type: "object" } },
+    ],
+    messages: [
+      { role: "user", content: [{ type: "text", text: prefixText }] },
+      { role: "assistant", content: [{ type: "text", text: "ack" }] },
+      { role: "user", content: [{ type: "text", text: tailText }] },
+    ],
+  };
+}
+
+const opts: AnthropicCacheOptions = {
+  systemTTL: "1h",
+  stableLtmSystem: "STABLE LTM",
+  ltmSystem: "context LTM",
+  cacheTools: true,
+  cacheConversation: true,
+  conversationTTL: "5m",
+  distilledPrefixLength: 2,
+};
+
+function digest(prefixText: string, tailText: string): CacheSegmentDigest {
+  const body = JSON.stringify(
+    buildAnthropicRequest(req(prefixText, tailText), opts).body,
+  );
+  const d = cacheSegmentDigest(body);
+  if (!d) throw new Error("expected a non-null digest");
+  return d;
+}
+
+describe("cacheSegmentDigest", () => {
+  test("returns stable hashes and 4 breakpoints for a distilled body", () => {
+    const d = digest("prefix v1", "tail A");
+    expect(d.bpCount).toBe(4); // system[1], tools, distilled-prefix, tail
+    expect(d.systemBlocks).toBe(3); // host + stableLtm + contextLtm
+    expect(d.headSha).toMatch(/^[0-9a-f]{12}$/);
+  });
+
+  test("head/tools/prefix stay identical when only the conversation tail grows", () => {
+    const a = digest("prefix v1", "tail A");
+    const b = digest("prefix v1", "tail A then B");
+    expect(b.headSha).toBe(a.headSha); // head is byte-stable across tail growth
+    expect(b.toolsSha).toBe(a.toolsSha);
+    expect(b.prefixSha).toBe(a.prefixSha); // distilled prefix unchanged
+  });
+
+  test("prefix hash changes when the distilled prefix is rewritten (meta-distillation)", () => {
+    const a = digest("prefix v1", "tail A");
+    const b = digest("prefix v2 REWRITTEN", "tail A");
+    expect(b.prefixSha).not.toBe(a.prefixSha); // detects prefix drift
+    expect(b.headSha).toBe(a.headSha); // but the head is untouched
+  });
+
+  test("returns null on unparseable body (never throws on the request path)", () => {
+    expect(cacheSegmentDigest("not json{")).toBeNull();
+  });
+
+  test("probe is off by default", () => {
+    const prev = process.env.LORE_WARMUP_PROBE;
+    delete process.env.LORE_WARMUP_PROBE;
+    expect(isWarmupProbeEnabled()).toBe(false);
+    process.env.LORE_WARMUP_PROBE = "1";
+    expect(isWarmupProbeEnabled()).toBe(true);
+    if (prev === undefined) delete process.env.LORE_WARMUP_PROBE;
+    else process.env.LORE_WARMUP_PROBE = prev;
+  });
+});

--- a/packages/gateway/test/cache-segment-digest.test.ts
+++ b/packages/gateway/test/cache-segment-digest.test.ts
@@ -6,6 +6,7 @@ import {
 import {
   type CacheSegmentDigest,
   cacheSegmentDigest,
+  classifyWarmupProbe,
   isWarmupProbeEnabled,
 } from "../src/cache-analytics";
 import type { GatewayRequest } from "../src/translate/types";
@@ -84,5 +85,57 @@ describe("cacheSegmentDigest", () => {
     expect(isWarmupProbeEnabled()).toBe(true);
     if (prev === undefined) delete process.env.LORE_WARMUP_PROBE;
     else process.env.LORE_WARMUP_PROBE = prev;
+  });
+});
+
+describe("classifyWarmupProbe", () => {
+  const base = {
+    headMatch: true,
+    cacheReadTokens: 100,
+    cacheLikelyAlive: true,
+  };
+
+  test("no baseline before any real turn analyzed", () => {
+    expect(classifyWarmupProbe({ ...base, hasBaseline: false })).toMatch(
+      /no baseline/,
+    );
+  });
+
+  test("head mismatch => HEAD DIVERGENCE (the body-bug signal)", () => {
+    expect(
+      classifyWarmupProbe({ ...base, hasBaseline: true, headMatch: false }),
+    ).toMatch(/HEAD DIVERGENCE/);
+  });
+
+  test("head match with a read is healthy", () => {
+    expect(
+      classifyWarmupProbe({
+        ...base,
+        hasBaseline: true,
+        cacheReadTokens: 5000,
+      }),
+    ).toBe("head identical to last real turn");
+  });
+
+  test("head match + read=0 while cache should be live => EVICTION", () => {
+    expect(
+      classifyWarmupProbe({
+        hasBaseline: true,
+        headMatch: true,
+        cacheReadTokens: 0,
+        cacheLikelyAlive: true,
+      }),
+    ).toMatch(/EVICTION/);
+  });
+
+  test("head match + read=0 past TTL => expected expiry, NOT eviction", () => {
+    const v = classifyWarmupProbe({
+      hasBaseline: true,
+      headMatch: true,
+      cacheReadTokens: 0,
+      cacheLikelyAlive: false,
+    });
+    expect(v).toMatch(/expected expiry/);
+    expect(v).not.toMatch(/EVICTION/);
   });
 });

--- a/packages/website/src/content/docs/docs/environment.md
+++ b/packages/website/src/content/docs/docs/environment.md
@@ -17,6 +17,12 @@ Env vars override `.lore.json` for the same setting. To override a `.lore.json` 
 |---|---|
 | `LORE_BACKGROUND_CONCURRENCY` | Resolve the upper bound for background concurrency. `LORE_BACKGROUND_CONCURRENCY` is a hard ceiling override (escape hatch for large multi-tenant hosts); otherwise the built-in MAX applies. Clamped to a sane [1, 32]. |
 
+## cache-analytics
+
+| Variable | Description |
+|---|---|
+| `LORE_WARMUP_PROBE` | Env var `LORE_WARMUP_PROBE`: when set to `1`, enables the warmup cache-divergence diagnostic. It logs SHA comparisons of the cacheable segments (the stable head `system[0..1]`, tools, and the distilled prefix `messages[0..1]`) on real turns and warmups to tell an Anthropic-side cache eviction (segments match, `cacheRead=0`) apart from a warmup request-body divergence (segments differ). A debugging aid only; off by default, with zero cost when unset (callers skip all parsing/hashing). |
+
 ## Upstream + worker pipeline
 
 | Variable | Description |


### PR DESCRIPTION
## Why

Warmups on large sessions (>380K) keep cold-writing (~\$2-3 each) while the cache is provably alive — real turns hit ~100% at the same 180-300s gaps, warmups hit ~29%. I chased a **warmup request-body divergence** hard (BYK's strong suspicion), and proved the warmup body's *cacheable* content is **byte-identical** to the cached body across every layer:

- real `buildAnthropicRequest` → `JSON.stringify` → `compressBody`/`decompressBody` (zstd, lossless) → `prepareAnthropicWarmupBody` → `encodeUpstreamBody`: system/tools/messages all identical, 4=4 breakpoints, even with tool_use/tool_result/thinking/tool_choice/output_config.
- `resignBody` is a no-op for API-key sessions (no billing header), so nothing rewrites `system[0]`.
- Warmup format (`stream=false, max_tokens=0`) reads a real-format-written cache **7/7 at 180s**.
- Some production misses are `✗ UNCACHED read=0` — a miss on the **byte-stable 1h `system[0..1]` head**, which *cannot* diverge → that class is eviction, not a body bug.

That's strong but rests on one thing I can't verify statically: that the in-memory `lastRequestBody` truly equals what Anthropic cached. This probe closes that gap **in production**.

## What

`LORE_WARMUP_PROBE=1` (off by default → zero hot-path cost):

- **`cacheSegmentDigest()`**: SHA-12 of the stable head (`system[0..1]`, up to the 1h breakpoint), tools, and distilled prefix (`messages[0..1]`), + breakpoint count.
- **`analyzeCacheTurn`** (real turns): logs `SEGMENT DRIFT` when the "stable" head/tools/prefix change across consecutive turns (a stable segment that drifts *is* a divergence), and stores the baseline on `CacheAnalytics`.
- **`executeWarmup`**: hashes the **pre-resign `warmupBody`** and compares its segments to the last real turn's, then `classifyWarmupProbe()` labels the outcome:
  - head **matches** + `cacheRead=0` **while `cacheLikelyAlive`** → **EVICTION** (identical head, yet full miss when the cache should have been live)
  - head **matches** + `cacheRead=0` past TTL → **expected expiry** (not eviction)
  - head **differs** → **HEAD DIVERGENCE** (names the changed segment)
  - matching head + differing prefix/tail → localizes to distilled prefix (meta-distillation) or conversation tail

Why hash the **pre-resign** `warmupBody` (not the sent `signedBody`): `resignBody` recomputes the cch/cc_version billing token over the warmup body (`stream=false`, `max_tokens=0`), which Anthropic strips before hashing its cache key. Hashing the post-resign body would falsely flag HEAD DIVERGENCE for OAuth sessions; `warmupBody` carries the real turn's cch verbatim, so the comparison is symmetric with the body `analyzeCacheTurn` hashed. (Seer catch.)

## Tests

`cache-segment-digest.test.ts` (10): stable-across-tail-growth, prefix-drift detection, breakpoint/systemBlock counts, null-on-unparseable, probe-off-by-default, and the full `classifyWarmupProbe` truth table (no-baseline / divergence / healthy / eviction / expected-expiry). Mutation-verified (constant-prefix and head-includes-messages mutants both kill tests). Existing cache suites green (368 across cache-warmer/cache-analytics/anthropic-caching/pipeline-cache-turn/segment-digest). Typecheck + lint clean across all 5 workspaces.

## Safety

Log-only; no behavior change when the flag is unset (no parsing/hashing). `cacheSegmentDigest` returns `null` on parse error, and both probe blocks are wrapped in try/catch — a diagnostic throw can never break the request/warmup path or corrupt cost/circuit-breaker accounting.