### PR TITLE
fix(gateway): route all *.githubcopilot.com hosts to /chat/completions

### DIFF
--- a/packages/gateway/src/translate/openai.ts
+++ b/packages/gateway/src/translate/openai.ts
@@ -500,11 +500,24 @@ const DEFAULT_OPENAI_CHAT_COMPLETIONS_PATH = "/v1/chat/completions";
  * purely via its `X-Lore-Provider` route with no preserved endpoint path.
  */
 const OPENAI_HOST_CHAT_COMPLETIONS_PATHS: ReadonlyMap<string, string> = new Map(
-  [
-    ["api.githubcopilot.com", "/chat/completions"],
-    ["generativelanguage.googleapis.com", "/v1beta/openai/chat/completions"],
-  ],
+  [["generativelanguage.googleapis.com", "/v1beta/openai/chat/completions"]],
 );
+
+/**
+ * GitHub Copilot serves Chat Completions at `/chat/completions` (NO `/v1`) on
+ * ALL of its hosts, not just `api.githubcopilot.com`. Per-plan/regional hosts
+ * carry a subdomain segment — `api.individual.githubcopilot.com` (free/OSS
+ * quota), `api.business.githubcopilot.com`, `api.enterprise.githubcopilot.com`,
+ * and the `proxy.*` variants — and the token exchange (`copilot_internal/v2/
+ * token`) returns the account's specific host in `endpoints.api`. Matching the
+ * whole domain (not a single host) keeps individual/enterprise accounts from
+ * being reconstructed as `<host>/v1/chat/completions` → 404 (issue #1052).
+ */
+export function isGitHubCopilotHost(hostname: string): boolean {
+  return (
+    hostname === "githubcopilot.com" || hostname.endsWith(".githubcopilot.com")
+  );
+}
 
 /**
  * Build the OpenAI Chat Completions upstream URL for an upstream base.
@@ -513,10 +526,11 @@ const OPENAI_HOST_CHAT_COMPLETIONS_PATHS: ReadonlyMap<string, string> = new Map(
  * route tables store a bare origin and the gateway appends `/v1/...`. Two
  * exceptions are handled, in priority order:
  *
- *  1. Hosts in `OPENAI_HOST_CHAT_COMPLETIONS_PATHS` use a fixed non-`/v1`
- *     endpoint path (GitHub Copilot's `/chat/completions`, issue #1052; Google's
- *     `/v1beta/openai/...`, issue #1070). These hosts' route bases are bare
- *     origins, so the mapped path is simply appended.
+ *  1. GitHub Copilot hosts (any `*.githubcopilot.com`, issue #1052) serve at
+ *     `/chat/completions` with no `/v1`, and hosts in
+ *     `OPENAI_HOST_CHAT_COMPLETIONS_PATHS` use a fixed non-`/v1` endpoint path
+ *     (Google's `/v1beta/openai/...`, issue #1070). These hosts' route bases are
+ *     bare origins, so the mapped path is simply appended.
  *  2. A base whose pathname already ends in a version segment (e.g. Z.AI's
  *     user-configured `.../api/paas/v4`, issue #1093) serves Chat Completions at
  *     `<base>/chat/completions`; appending the default `/v1` would duplicate the
@@ -531,6 +545,11 @@ const OPENAI_HOST_CHAT_COMPLETIONS_PATHS: ReadonlyMap<string, string> = new Map(
 export function buildOpenAIChatCompletionsUrl(base: string): string {
   try {
     const { hostname, pathname } = new URL(base);
+    // GitHub Copilot (all hosts, incl. api.individual/business/enterprise.*)
+    // serves at /chat/completions with no /v1 prefix — issue #1052.
+    if (isGitHubCopilotHost(hostname)) {
+      return `${base}/chat/completions`;
+    }
     const hostPath = OPENAI_HOST_CHAT_COMPLETIONS_PATHS.get(hostname);
     if (hostPath !== undefined) {
       return `${base}${hostPath}`;

--- a/packages/gateway/test/github-copilot-url.test.ts
+++ b/packages/gateway/test/github-copilot-url.test.ts
@@ -16,6 +16,7 @@ import { extractUpstreamPathHeader, verbatimUpstreamUrl } from "../src/config";
 import {
   buildOpenAIChatCompletionsUrl,
   buildOpenAIUpstreamRequest,
+  isGitHubCopilotHost,
 } from "../src/translate/openai";
 import type { GatewayRequest } from "../src/translate/types";
 
@@ -187,6 +188,29 @@ describe("buildOpenAIChatCompletionsUrl", () => {
     );
   });
 
+  test("per-plan/regional Copilot hosts also omit /v1 (issue #1052 — individual/business/enterprise)", () => {
+    for (const host of [
+      "api.individual.githubcopilot.com",
+      "api.business.githubcopilot.com",
+      "api.enterprise.githubcopilot.com",
+      "proxy.individual.githubcopilot.com",
+    ]) {
+      expect(buildOpenAIChatCompletionsUrl(`https://${host}`)).toBe(
+        `https://${host}/chat/completions`,
+      );
+    }
+  });
+
+  test("a lookalike host that only CONTAINS the domain is NOT treated as Copilot", () => {
+    // Guards against a naive substring match: this host ends in `.evil.example`,
+    // so it must fall back to the standard /v1 form, not Copilot's root path.
+    expect(
+      buildOpenAIChatCompletionsUrl(
+        "https://api.githubcopilot.com.evil.example",
+      ),
+    ).toBe("https://api.githubcopilot.com.evil.example/v1/chat/completions");
+  });
+
   test("Google Gemini host uses the /v1beta/openai path (issue #1070)", () => {
     expect(
       buildOpenAIChatCompletionsUrl(
@@ -243,6 +267,32 @@ describe("buildOpenAIChatCompletionsUrl", () => {
     expect(buildOpenAIChatCompletionsUrl("not a url")).toBe(
       "not a url/v1/chat/completions",
     );
+  });
+});
+
+describe("isGitHubCopilotHost", () => {
+  test("matches the apex and every subdomain", () => {
+    for (const h of [
+      "githubcopilot.com",
+      "api.githubcopilot.com",
+      "api.individual.githubcopilot.com",
+      "api.business.githubcopilot.com",
+      "api.enterprise.githubcopilot.com",
+      "proxy.individual.githubcopilot.com",
+    ]) {
+      expect(isGitHubCopilotHost(h)).toBe(true);
+    }
+  });
+
+  test("does NOT match lookalikes or unrelated hosts", () => {
+    for (const h of [
+      "api.githubcopilot.com.evil.example",
+      "notgithubcopilot.com",
+      "api.openai.com",
+      "githubcopilot.com.attacker.net",
+    ]) {
+      expect(isGitHubCopilotHost(h)).toBe(false);
+    }
   });
 });
 


### PR DESCRIPTION
## Problem

GitHub Copilot serves chat completions at `/chat/completions` (no `/v1`), but the host→path map (`OPENAI_HOST_CHAT_COMPLETIONS_PATHS`) only listed the single host `api.githubcopilot.com`. Copilot actually uses **per-plan/regional hosts** — the token exchange (`copilot_internal/v2/token`) returns the account's specific host in `endpoints.api`:

- `api.individual.githubcopilot.com` — free / OSS quota (SKU `free_engaged_oss_quota`)
- `api.business.githubcopilot.com`, `api.enterprise.githubcopilot.com`
- `proxy.*.githubcopilot.com` variants

When the gateway **reconstructs** an upstream URL for one of these hosts (a background worker, or an `X-Lore-Upstream-URL` with no preserved path), it prepended `/v1` → `<host>/v1/chat/completions` → **`404 page not found`** (issue #1052) for those account types.

Verified live: this account's real endpoint is `api.individual.githubcopilot.com`; reconstructing it without a verbatim path 404s, while `api.githubcopilot.com` works.

## Fix

Match the whole `githubcopilot.com` domain via `isGitHubCopilotHost()` — the exact apex or any `.githubcopilot.com` subdomain (`endsWith`, so a lookalike like `api.githubcopilot.com.evil.example` correctly falls back to `/v1`). Copilot moves out of the static host map into this domain check.

The **foreground plugin path already worked** (the fetch interceptor preserves the verbatim `/chat/completions` path); this hardens the **reconstruction** path (workers, env-var / header-only routing), which is where the 404 bites.

## Tests (mutation-verified)

- `buildOpenAIChatCompletionsUrl`: individual/business/enterprise/proxy hosts → `/chat/completions`; lookalike host → `/v1`.
- `isGitHubCopilotHost`: apex + subdomain matrix → true; lookalikes/unrelated → false.
- Mutation: reverting to exact-`api.githubcopilot.com` match → individual-host tests RED.

Relates to issue #1052.