### PR TITLE
fix(gateway): accumulate mislabeled SSE completions through the stream accumulators

### DIFF
--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -40,8 +40,16 @@ import {
 } from "./sentry";
 import { recordWorkerCost } from "./cost-tracker";
 import { upstreamFetch } from "./fetch";
-import { readCompletionJSON } from "./translate/types";
+import {
+  looksLikeSSE,
+  type GatewayContentBlock,
+  type GatewayResponse,
+} from "./translate/types";
 import { buildOpenAIChatCompletionsUrl } from "./translate/openai";
+import { accumulateOpenAISSEStream } from "./stream/openai";
+import { accumulateResponsesSSEStream } from "./stream/openai-responses";
+import { accumulateGeminiSSEStream } from "./stream/gemini";
+import { accumulateSSEResponse } from "./stream/anthropic";
 import { isBedrockMantleHost, toMantleModelId } from "./translate/bedrock";
 import {
   toVertexBody,
@@ -1238,6 +1246,59 @@ function parseWorkerResponse(
 }
 
 /**
+ * Accumulate an SSE upstream worker response into a GatewayResponse using the
+ * protocol's stream accumulator. The ChatGPT/Copilot/Codex backend and some
+ * OpenAI-compatible providers stream even for a non-streaming worker request;
+ * merging every chunk here (rather than reading a single JSON body) makes the
+ * worker read multi-chunk safe and immune to a mislabeled/absent
+ * text/event-stream content-type (LOREAI-GATEWAY-38 / -1P).
+ */
+function accumulateWorkerSSE(
+  protocol: WorkerProtocol,
+  response: Response,
+): Promise<GatewayResponse> {
+  switch (protocol) {
+    case "openai-codex-responses":
+      return accumulateResponsesSSEStream(response);
+    case "gemini":
+      return accumulateGeminiSSEStream(response);
+    case "openai":
+      return accumulateOpenAISSEStream(response);
+    default:
+      // Anthropic wire (incl. Vertex/Bedrock-mantle) SSE.
+      return accumulateSSEResponse(response);
+  }
+}
+
+/**
+ * Project an accumulated GatewayResponse down to the worker result shape
+ * ({ text, usage, model }). Only the visible text blocks form the worker's
+ * text — a response that is purely tool_use (no text) is treated as empty,
+ * matching parseWorkerResponse (workers consume text, not tool calls).
+ */
+function gatewayResponseToWorkerResult(resp: GatewayResponse): {
+  text: string | null;
+  usage: AnthropicUsage | null;
+  model: string | null;
+} {
+  const text = resp.content
+    .filter(
+      (b): b is Extract<GatewayContentBlock, { type: "text" }> =>
+        b.type === "text",
+    )
+    .map((b) => b.text)
+    .join("");
+  const usage: AnthropicUsage | null = resp.usage
+    ? {
+        input_tokens: resp.usage.inputTokens,
+        output_tokens: resp.usage.outputTokens,
+        cache_read_input_tokens: resp.usage.cacheReadInputTokens,
+      }
+    : null;
+  return { text: text || null, usage, model: resp.model || null };
+}
+
+/**
  * Summarize an upstream worker response body for diagnostics when the parser
  * found no usable text. Reports which fields were present (content vs the
  * reasoning/thinking fallbacks), the finish_reason, and a truncated body
@@ -1628,15 +1689,21 @@ export function createGatewayLLMClient(
                 // model.
                 if (thinkingStripped) markThinkingUnsupported(model);
 
-                // Guard: some providers (the ChatGPT/Codex backend, DeepSeek)
-                // return SSE even when stream: false was sent — sometimes
-                // WITHOUT the text/event-stream content-type. readCompletionJSON
-                // sniffs the body so a mislabeled SSE stream is never fed to
-                // JSON.parse (LOREAI-GATEWAY-38: `Unexpected token 'e', "event:
-                // res"...`) and the openai-responses terminal envelope is
-                // unwrapped to the bare response the parser expects.
+                // Guard: some providers (the ChatGPT/Copilot/Codex backend,
+                // DeepSeek) return an SSE stream even when stream: false was
+                // sent — sometimes WITHOUT the text/event-stream content-type.
+                // Sniff the body: if it's SSE, accumulate the whole stream via
+                // the protocol's accumulator (multi-chunk safe) instead of
+                // JSON-parsing it (which would throw on "data: {...}" / "event:
+                // ..." text — LOREAI-GATEWAY-38 / -1P). A streamed body is a
+                // success, so the JSON error-envelope check below never applies
+                // to it (bodyErrCode stays null → the block is skipped).
                 const ct = response.headers.get("content-type") ?? "";
-                const rawData = await readCompletionJSON(response);
+                const bodyText = await response.text();
+                const isSSE = looksLikeSSE(ct, bodyText);
+                const rawData: Record<string, unknown> = isSSE
+                  ? {}
+                  : (JSON.parse(bodyText) as Record<string, unknown>);
 
                 // A 2xx whose body is a provider error envelope (e.g. OpenRouter
                 // surfacing an upstream timeout as HTTP 200 + {error:{code:504}})
@@ -1646,7 +1713,9 @@ export function createGatewayLLMClient(
                 // transient embedded code into the SAME retry/backoff ladder as a
                 // real HTTP-level transient. Non-transient embedded codes fall
                 // through to the normal empty-response handling (no regression). #899
-                const bodyErrCode = extractBodyErrorCode(rawData);
+                const bodyErrCode = isSSE
+                  ? null
+                  : extractBodyErrorCode(rawData);
                 if (bodyErrCode != null && TRANSIENT_CODES.has(bodyErrCode)) {
                   // Trip the breaker once on an embedded 429, matching the
                   // HTTP-level 429 path (background work to this provider pauses
@@ -1733,7 +1802,17 @@ export function createGatewayLLMClient(
                 }
 
                 // Parse response based on protocol
-                const parsed = parseWorkerResponse(target.protocol, rawData);
+                // SSE → accumulate the full stream; JSON → parse the body.
+                const parsed = isSSE
+                  ? gatewayResponseToWorkerResult(
+                      await accumulateWorkerSSE(
+                        target.protocol,
+                        new Response(bodyText, {
+                          headers: { "content-type": "text/event-stream" },
+                        }),
+                      ),
+                    )
+                  : parseWorkerResponse(target.protocol, rawData);
 
                 // Set usage attributes on the span
                 if (parsed.usage) {

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -97,7 +97,7 @@ import type {
 import {
   applyUpstreamExtraHeaders,
   blocksToText,
-  readCompletionJSON,
+  looksLikeSSE,
   forwardClientHeaders,
   ZERO_USAGE,
 } from "./translate/types";
@@ -165,7 +165,10 @@ import {
   accumulateResponsesSSEStream,
   translateAnthropicStreamToResponses,
 } from "./stream/openai-responses";
-import { translateAnthropicStreamToOpenAI } from "./stream/openai";
+import {
+  accumulateOpenAISSEStream,
+  translateAnthropicStreamToOpenAI,
+} from "./stream/openai";
 import {
   buildGeminiUpstreamRequest,
   buildGeminiResponse,
@@ -176,6 +179,7 @@ import {
   translateAnthropicStreamToGemini,
 } from "./stream/gemini";
 import {
+  accumulateSSEResponse,
   createStreamAccumulator,
   createRecallAwareAccumulator,
   parseSSEStream,
@@ -4315,14 +4319,34 @@ async function accumulateNonStreamResponse(
     | "vertex"
     | "gemini" = "anthropic",
 ): Promise<GatewayResponse> {
-  // Some providers (the ChatGPT/Codex backend, DeepSeek) return SSE-formatted
-  // responses even when stream: false was sent — sometimes WITHOUT the
-  // text/event-stream content-type. readCompletionJSON sniffs the body so a
-  // mislabeled SSE stream is never fed to JSON.parse (which would throw a
-  // SyntaxError on "data: {...}" / "event: ..." prefixed text — LOREAI-GATEWAY-
-  // 38 / -1P).
-  const json = await readCompletionJSON(upstreamResponse);
+  // Some providers (the ChatGPT/Copilot/Codex backend, DeepSeek) return an SSE
+  // stream even when stream: false was sent — sometimes WITHOUT the
+  // text/event-stream content-type. Sniff the body: if it's SSE, run it through
+  // the protocol's stream accumulator (merges EVERY chunk, so a multi-chunk
+  // stream is reconstructed faithfully — taking only the last data: line would
+  // drop all but the final delta, and JSON.parse-ing the body would throw on
+  // "data: {...}" / "event: ..." text — LOREAI-GATEWAY-38 / -1P). Otherwise
+  // parse the single JSON body.
+  const contentType = upstreamResponse.headers.get("content-type") ?? "";
+  const body = await upstreamResponse.text();
+  if (looksLikeSSE(contentType, body)) {
+    const sse = new Response(body, {
+      headers: { "content-type": "text/event-stream" },
+    });
+    switch (protocol) {
+      case "openai":
+        return accumulateOpenAISSEStream(sse);
+      case "openai-responses":
+        return accumulateResponsesSSEStream(sse);
+      case "gemini":
+        return accumulateGeminiSSEStream(sse);
+      default:
+        // Anthropic wire (incl. Vertex/Bedrock-mantle) SSE.
+        return accumulateSSEResponse(sse);
+    }
+  }
 
+  const json = JSON.parse(body) as Record<string, unknown>;
   switch (protocol) {
     case "openai":
       return accumulateOpenAINonStreamJSON(json);
@@ -4486,130 +4510,6 @@ async function _accumulateStreamResponse(
   }
 
   return accumulator.getResponse();
-}
-
-/**
- * Accumulate a streaming upstream OpenAI Chat Completions SSE response
- * into a GatewayResponse.
- *
- * OpenAI SSE chunks have a different format from Anthropic:
- *   data: {"id":"...","choices":[{"delta":{"content":"..."},"finish_reason":null}]}
- */
-async function accumulateNonStreamOpenAIStream(
-  upstreamResponse: Response,
-): Promise<GatewayResponse> {
-  let id = "";
-  let model = "";
-  let stopReason = "end_turn";
-  let textContent = "";
-  const toolCalls = new Map<
-    number,
-    { id: string; name: string; args: string }
-  >();
-  let inputTokens = 0;
-  let outputTokens = 0;
-  let cachedTokens: number | undefined;
-
-  if (!upstreamResponse.body) {
-    throw new Error("Upstream response has no body");
-  }
-  const reader = upstreamResponse.body.getReader();
-
-  for await (const { data } of parseSSEStream(reader)) {
-    if (data === "[DONE]") break;
-
-    let parsed: Record<string, unknown>;
-    try {
-      parsed = JSON.parse(data) as Record<string, unknown>;
-    } catch {
-      continue;
-    }
-
-    if (typeof parsed.id === "string") id = parsed.id;
-    if (typeof parsed.model === "string") model = parsed.model;
-
-    const choices = parsed.choices as
-      | Array<Record<string, unknown>>
-      | undefined;
-    const firstChoice = choices?.[0];
-    if (firstChoice) {
-      const delta = firstChoice.delta as Record<string, unknown> | undefined;
-      if (delta) {
-        if (typeof delta.content === "string") {
-          textContent += delta.content;
-        }
-        const tcs = delta.tool_calls as
-          | Array<Record<string, unknown>>
-          | undefined;
-        if (tcs) {
-          for (const tc of tcs) {
-            const idx = tc.index as number;
-            const fn = tc.function as Record<string, unknown> | undefined;
-            const existing = toolCalls.get(idx);
-            if (!existing) {
-              toolCalls.set(idx, {
-                id: String(tc.id ?? ""),
-                name: String(fn?.name ?? ""),
-                args: String(fn?.arguments ?? ""),
-              });
-            } else {
-              if (fn?.arguments) existing.args += fn.arguments;
-            }
-          }
-        }
-      }
-      if (typeof firstChoice.finish_reason === "string") {
-        const fr = firstChoice.finish_reason;
-        if (fr === "stop") stopReason = "end_turn";
-        else if (fr === "length") stopReason = "max_tokens";
-        else if (fr === "tool_calls") stopReason = "tool_use";
-      }
-    }
-
-    // Usage is typically in the final chunk
-    const usage = parsed.usage as Record<string, unknown> | undefined;
-    if (usage) {
-      if (typeof usage.prompt_tokens === "number")
-        inputTokens = usage.prompt_tokens as number;
-      if (typeof usage.completion_tokens === "number")
-        outputTokens = usage.completion_tokens as number;
-      const details = usage.prompt_tokens_details as
-        | Record<string, number>
-        | undefined;
-      if (details?.cached_tokens !== undefined)
-        cachedTokens = details.cached_tokens;
-    }
-  }
-
-  const content: GatewayContentBlock[] = [];
-  if (textContent) {
-    content.push({ type: "text", text: textContent });
-  }
-  for (const [, tc] of Array.from(toolCalls.entries()).sort(
-    ([a], [b]) => a - b,
-  )) {
-    let input: unknown = {};
-    if (tc.args) {
-      try {
-        input = JSON.parse(tc.args);
-      } catch {
-        input = tc.args;
-      }
-    }
-    content.push({ type: "tool_use", id: tc.id, name: tc.name, input });
-  }
-
-  return {
-    id,
-    model,
-    content,
-    stopReason,
-    usage: {
-      inputTokens,
-      outputTokens,
-      cacheReadInputTokens: cachedTokens,
-    },
-  };
 }
 
 /**
@@ -6124,11 +6024,11 @@ async function handlePassthrough(
   // Vertex speaks the native Anthropic wire format (Anthropic SSE for streaming
   // and the native Anthropic JSON shape for non-streaming), so for passthrough
   // routing it is wire-equivalent to "anthropic". Without this mapping a
-  // streaming meta request (title-gen/summary) on a Vertex session would take
-  // the cross-protocol branch below and get drained through extractJSONFromSSE,
-  // which returns only the last SSE data line ({"type":"message_stop"}) → an
-  // EMPTY response. Collapse vertex→anthropic here so a same-wire client
-  // (anthropic) streams through unchanged.
+  // streaming meta request (title-gen/summary) on a Vertex session would fail
+  // the same-wire fast path below and get buffered+re-emitted through the
+  // cross-protocol branch instead of streaming through raw. Collapse
+  // vertex→anthropic here so a same-wire client (anthropic) streams through
+  // unchanged.
   const wireProtocol: typeof effectiveProtocol =
     effectiveProtocol === "vertex" ? "anthropic" : effectiveProtocol;
 
@@ -8141,7 +8041,7 @@ async function handleConversationTurn(
     if (effectiveProtocol === "openai") {
       // OpenAI Chat Completions streaming — accumulate and return as
       // non-streaming Anthropic format (same pattern as non-stream path).
-      const resp = await accumulateNonStreamOpenAIStream(upstreamResponse);
+      const resp = await accumulateOpenAISSEStream(upstreamResponse);
       return finalizeWithRecall(resp);
     }
 

--- a/packages/gateway/src/stream/openai.ts
+++ b/packages/gateway/src/stream/openai.ts
@@ -18,7 +18,11 @@
  * (for pipeline post-processing that may read it).
  */
 import { log } from "@loreai/core";
-import { ZERO_USAGE } from "../translate/types";
+import {
+  ZERO_USAGE,
+  type GatewayContentBlock,
+  type GatewayResponse,
+} from "../translate/types";
 import { parseSSEStream, createStreamAccumulator } from "./anthropic";
 
 // ---------------------------------------------------------------------------
@@ -342,4 +346,135 @@ export function translateAnthropicStreamToOpenAI(
       connection: "keep-alive",
     },
   });
+}
+
+/**
+ * Accumulate a streaming OpenAI Chat Completions SSE response into a
+ * GatewayResponse.
+ *
+ * Reads EVERY `data:` chunk and merges the incremental `choices[0].delta`
+ * fields (text + tool-call fragments) into a single response — so a
+ * multi-chunk stream is reconstructed faithfully. This is the correct reader
+ * for a non-streaming request whose provider replied with SSE anyway (the
+ * ChatGPT/Copilot backend, DeepSeek): taking only the last `data:` line would
+ * drop all but the final delta.
+ *
+ * OpenAI SSE chunk shape:
+ *   data: {"id":"...","choices":[{"delta":{"content":"..."},"finish_reason":null}]}
+ */
+export async function accumulateOpenAISSEStream(
+  upstreamResponse: Response,
+): Promise<GatewayResponse> {
+  let id = "";
+  let model = "";
+  let stopReason = "end_turn";
+  let textContent = "";
+  const toolCalls = new Map<
+    number,
+    { id: string; name: string; args: string }
+  >();
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let cachedTokens: number | undefined;
+
+  if (!upstreamResponse.body) {
+    throw new Error("Upstream response has no body");
+  }
+  const reader = upstreamResponse.body.getReader();
+
+  for await (const { data } of parseSSEStream(reader)) {
+    if (data === "[DONE]") break;
+
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(data) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+
+    if (typeof parsed.id === "string") id = parsed.id;
+    if (typeof parsed.model === "string") model = parsed.model;
+
+    const choices = parsed.choices as
+      | Array<Record<string, unknown>>
+      | undefined;
+    const firstChoice = choices?.[0];
+    if (firstChoice) {
+      const delta = firstChoice.delta as Record<string, unknown> | undefined;
+      if (delta) {
+        if (typeof delta.content === "string") {
+          textContent += delta.content;
+        }
+        const tcs = delta.tool_calls as
+          | Array<Record<string, unknown>>
+          | undefined;
+        if (tcs) {
+          for (const tc of tcs) {
+            const idx = tc.index as number;
+            const fn = tc.function as Record<string, unknown> | undefined;
+            const existing = toolCalls.get(idx);
+            if (!existing) {
+              toolCalls.set(idx, {
+                id: String(tc.id ?? ""),
+                name: String(fn?.name ?? ""),
+                args: String(fn?.arguments ?? ""),
+              });
+            } else {
+              if (fn?.arguments) existing.args += fn.arguments;
+            }
+          }
+        }
+      }
+      if (typeof firstChoice.finish_reason === "string") {
+        const fr = firstChoice.finish_reason;
+        if (fr === "stop") stopReason = "end_turn";
+        else if (fr === "length") stopReason = "max_tokens";
+        else if (fr === "tool_calls") stopReason = "tool_use";
+      }
+    }
+
+    // Usage is typically in the final chunk
+    const usage = parsed.usage as Record<string, unknown> | undefined;
+    if (usage) {
+      if (typeof usage.prompt_tokens === "number")
+        inputTokens = usage.prompt_tokens as number;
+      if (typeof usage.completion_tokens === "number")
+        outputTokens = usage.completion_tokens as number;
+      const details = usage.prompt_tokens_details as
+        | Record<string, number>
+        | undefined;
+      if (details?.cached_tokens !== undefined)
+        cachedTokens = details.cached_tokens;
+    }
+  }
+
+  const content: GatewayContentBlock[] = [];
+  if (textContent) {
+    content.push({ type: "text", text: textContent });
+  }
+  for (const [, tc] of Array.from(toolCalls.entries()).sort(
+    ([a], [b]) => a - b,
+  )) {
+    let input: unknown = {};
+    if (tc.args) {
+      try {
+        input = JSON.parse(tc.args);
+      } catch {
+        input = tc.args;
+      }
+    }
+    content.push({ type: "tool_use", id: tc.id, name: tc.name, input });
+  }
+
+  return {
+    id,
+    model,
+    content,
+    stopReason,
+    usage: {
+      inputTokens,
+      outputTokens,
+      cacheReadInputTokens: cachedTokens,
+    },
+  };
 }

--- a/packages/gateway/src/translate/types.ts
+++ b/packages/gateway/src/translate/types.ts
@@ -261,104 +261,24 @@ export const ZERO_USAGE: GatewayUsage = Object.freeze({
  * True when a response body is Server-Sent Events rather than a JSON object —
  * even if the provider mislabeled or omitted the `content-type`.
  *
- * Detected by the header OR by sniffing the body prefix: an SSE stream begins
- * with an SSE field (`data:` / `event:` / `id:` / `retry:`) or a comment line
- * (`:`), whereas a JSON body begins with `{` or `[`. Some providers (the
- * ChatGPT/Codex backend, DeepSeek) return SSE even when a NON-streaming request
- * was made — and sometimes WITHOUT the `text/event-stream` content-type — so a
- * header-only check misses them and `JSON.parse`-ing the SSE body throws
+ * Detected by the header OR by sniffing the body prefix: an LLM-completion SSE
+ * stream always begins with a `data:` or `event:` field, whereas a JSON body
+ * begins with `{` or `[`. Some providers (the ChatGPT/Copilot/Codex backend,
+ * DeepSeek) return SSE even when a NON-streaming request was made — and
+ * sometimes WITHOUT the `text/event-stream` content-type — so a header-only
+ * check misses them and `JSON.parse`-ing the SSE body throws
  * (`Unexpected token 'e', "event: res"...` — LOREAI-GATEWAY-38 / -1P).
+ *
+ * Only `data:`/`event:` are sniffed (not `id:`/`retry:`/`:` comments): those two
+ * are the only prefixes a completion stream opens with, and the narrower set
+ * avoids false-positives on plaintext error bodies (e.g. a body starting with
+ * `retry: later`). The caller feeds a detected SSE body to a stream accumulator,
+ * which tolerates any subsequent field.
  */
 export function looksLikeSSE(contentType: string, body: string): boolean {
   if (contentType.includes("text/event-stream")) return true;
   const head = body.replace(/^\uFEFF/, "").trimStart();
-  return /^(?:data|event|id|retry):/.test(head) || head.startsWith(":");
-}
-
-/**
- * An openai-responses SSE stream terminates with a `response.completed` (or
- * `.incomplete` / `.failed`) event whose `response` field holds the FULL
- * response object. `extractJSONFromSSEText` returns the last data line, which is
- * that terminal event — but the non-streaming parsers expect the bare response
- * object (`{output, output_text, usage, model}`). Unwrap the envelope so they
- * read the right shape (otherwise: `text=null` → silent-empty worker output).
- */
-function unwrapResponsesEnvelope(
-  obj: Record<string, unknown>,
-): Record<string, unknown> {
-  if (
-    typeof obj.type === "string" &&
-    obj.type.startsWith("response.") &&
-    obj.response &&
-    typeof obj.response === "object"
-  ) {
-    return obj.response as Record<string, unknown>;
-  }
-  return obj;
-}
-
-/**
- * Extract a JSON payload from already-read SSE body text.
- *
- * Some providers (e.g. DeepSeek) return SSE-formatted responses even when
- * `stream: false` was sent. This reads all `data:` lines, ignores the
- * `data: [DONE]` sentinel, and returns the **last** non-sentinel data payload as
- * parsed JSON (the final `data:` line carries the full response object in this
- * scenario), unwrapping the openai-responses terminal envelope when present.
- *
- * NOTE: does not handle the SSE spec's multiline `data:` continuation
- * (consecutive `data:` lines joined by `\n`). In practice, providers that return
- * a complete non-streaming response as SSE send the JSON on a single `data:`
- * line (or, for openai-responses, in the terminal `response.completed` event).
- */
-export function extractJSONFromSSEText(text: string): Record<string, unknown> {
-  const lines = text.split("\n");
-  let lastPayload: string | null = null;
-
-  for (const line of lines) {
-    if (line.startsWith("data:")) {
-      // Tolerate both `data: x` and `data:x` (one optional leading space).
-      const payload = line.slice(line.indexOf(":") + 1).trim();
-      if (payload && payload !== "[DONE]") {
-        lastPayload = payload;
-      }
-    }
-  }
-
-  if (!lastPayload) {
-    throw new Error(
-      "upstream returned SSE but no data payload found — expected JSON in data: lines",
-    );
-  }
-
-  return unwrapResponsesEnvelope(
-    JSON.parse(lastPayload) as Record<string, unknown>,
-  );
-}
-
-/** Extract a JSON payload from an SSE `Response`. */
-export async function extractJSONFromSSE(
-  response: Response,
-): Promise<Record<string, unknown>> {
-  return extractJSONFromSSEText(await response.text());
-}
-
-/**
- * Read an upstream LLM completion body as JSON, tolerant of providers that
- * return SSE even for a non-streaming request — INCLUDING those that mislabel or
- * omit the `content-type`. Reads the body once, sniffs for SSE, then either
- * extracts the JSON from the data lines or parses the whole body as JSON. This
- * is the single safe entry point for reading a non-streaming completion body;
- * calling `response.json()` directly throws on a mislabeled SSE body.
- */
-export async function readCompletionJSON(
-  response: Response,
-): Promise<Record<string, unknown>> {
-  const contentType = response.headers.get("content-type") ?? "";
-  const text = await response.text();
-  return looksLikeSSE(contentType, text)
-    ? extractJSONFromSSEText(text)
-    : (JSON.parse(text) as Record<string, unknown>);
+  return /^(?:data|event):/.test(head);
 }
 
 /** Accumulated response from the upstream provider. */

--- a/packages/gateway/test/stream-openai.test.ts
+++ b/packages/gateway/test/stream-openai.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Unit tests for `accumulateOpenAISSEStream` — the OpenAI Chat Completions SSE
+ * reader used by the non-streaming conversation and worker paths when a provider
+ * streams even for a stream:false request (the ChatGPT/Copilot backend,
+ * DeepSeek). It must MERGE every chunk; a last-`data:`-line reader would drop all
+ * but the final delta (the silent-empty bug this guards — LOREAI-GATEWAY finding).
+ */
+import { describe, test, expect } from "vitest";
+import { accumulateOpenAISSEStream } from "../src/stream/openai";
+
+/** Each entry is one SSE event; events are blank-line delimited per the spec. */
+function sse(lines: string[]): Response {
+  return new Response(`${lines.join("\n\n")}\n\n`, {
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+describe("accumulateOpenAISSEStream", () => {
+  test("merges multi-chunk text deltas into the full string", async () => {
+    const resp = await accumulateOpenAISSEStream(
+      sse([
+        'data: {"id":"c1","model":"gpt-4o-mini","choices":[{"delta":{"role":"assistant"}}]}',
+        'data: {"id":"c1","choices":[{"delta":{"content":"Hel"}}]}',
+        'data: {"id":"c1","choices":[{"delta":{"content":"lo"}}]}',
+        'data: {"id":"c1","choices":[{"delta":{"content":", world"}}]}',
+        'data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":7,"completion_tokens":3}}',
+        "data: [DONE]",
+        "",
+      ]),
+    );
+    expect(resp.content).toEqual([{ type: "text", text: "Hello, world" }]);
+    expect(resp.stopReason).toBe("end_turn");
+    expect(resp.model).toBe("gpt-4o-mini");
+    expect(resp.usage?.inputTokens).toBe(7);
+    expect(resp.usage?.outputTokens).toBe(3);
+  });
+
+  test("merges streamed tool-call argument fragments", async () => {
+    const resp = await accumulateOpenAISSEStream(
+      sse([
+        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"get_weather","arguments":"{\\"ci"}}]}}]}',
+        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"ty\\":\\"Paris\\"}"}}]}}]}',
+        'data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}',
+        "data: [DONE]",
+        "",
+      ]),
+    );
+    expect(resp.stopReason).toBe("tool_use");
+    expect(resp.content).toEqual([
+      {
+        type: "tool_use",
+        id: "call_1",
+        name: "get_weather",
+        input: { city: "Paris" },
+      },
+    ]);
+  });
+
+  test("skips the empty-choices content-filter preamble (Azure/Copilot)", async () => {
+    // Copilot's first chunk is {"choices":[],"prompt_filter_results":[...]}.
+    const resp = await accumulateOpenAISSEStream(
+      sse([
+        'data: {"choices":[],"prompt_filter_results":[{"prompt_index":0}]}',
+        'data: {"choices":[{"delta":{"content":"ok"}}]}',
+        "data: [DONE]",
+        "",
+      ]),
+    );
+    expect(resp.content).toEqual([{ type: "text", text: "ok" }]);
+  });
+});

--- a/packages/gateway/test/translate-types.test.ts
+++ b/packages/gateway/test/translate-types.test.ts
@@ -1,11 +1,5 @@
 import { describe, it, expect } from "vitest";
-import {
-  ZERO_USAGE,
-  extractJSONFromSSE,
-  extractJSONFromSSEText,
-  looksLikeSSE,
-  readCompletionJSON,
-} from "../src/translate/types";
+import { ZERO_USAGE, looksLikeSSE } from "../src/translate/types";
 
 // ---------------------------------------------------------------------------
 // ZERO_USAGE
@@ -38,95 +32,6 @@ describe("ZERO_USAGE", () => {
 });
 
 // ---------------------------------------------------------------------------
-// extractJSONFromSSE
-// ---------------------------------------------------------------------------
-
-/** Helper: create a Response with the given body text and content-type. */
-function sseResponse(body: string): Response {
-  return new Response(body, {
-    headers: { "content-type": "text/event-stream" },
-  });
-}
-
-describe("extractJSONFromSSE", () => {
-  it("extracts JSON from a single data: line", async () => {
-    const resp = sseResponse('data: {"id":"abc","model":"gpt-4"}\n\n');
-    const json = await extractJSONFromSSE(resp);
-    expect(json).toEqual({ id: "abc", model: "gpt-4" });
-  });
-
-  it("returns the last non-[DONE] payload when multiple data: lines exist", async () => {
-    const body = [
-      'data: {"id":"1","choices":[]}',
-      'data: {"id":"2","choices":[{"finish_reason":"stop"}]}',
-      "data: [DONE]",
-      "",
-    ].join("\n");
-    const json = await extractJSONFromSSE(sseResponse(body));
-    expect(json).toEqual({
-      id: "2",
-      choices: [{ finish_reason: "stop" }],
-    });
-  });
-
-  it("ignores data: [DONE] sentinel", async () => {
-    const body = 'data: {"id":"x"}\ndata: [DONE]\n\n';
-    const json = await extractJSONFromSSE(sseResponse(body));
-    expect(json).toEqual({ id: "x" });
-  });
-
-  it("throws when body has no data: lines", async () => {
-    const resp = sseResponse("event: ping\n: comment\n\n");
-    await expect(extractJSONFromSSE(resp)).rejects.toThrow(
-      "no data payload found",
-    );
-  });
-
-  it("throws when body has only data: [DONE]", async () => {
-    const resp = sseResponse("data: [DONE]\n\n");
-    await expect(extractJSONFromSSE(resp)).rejects.toThrow(
-      "no data payload found",
-    );
-  });
-
-  it("throws on malformed JSON in data: line", async () => {
-    const resp = sseResponse("data: {broken json}\n\n");
-    await expect(extractJSONFromSSE(resp)).rejects.toThrow();
-  });
-
-  it("handles \\r\\n line endings", async () => {
-    const body = 'data: {"id":"crlf"}\r\ndata: [DONE]\r\n\r\n';
-    const json = await extractJSONFromSSE(sseResponse(body));
-    expect(json).toEqual({ id: "crlf" });
-  });
-
-  it("tolerates `data:` with no space after the colon", async () => {
-    const json = await extractJSONFromSSE(
-      sseResponse('data:{"id":"nospace"}\n'),
-    );
-    expect(json).toEqual({ id: "nospace" });
-  });
-
-  it("unwraps the openai-responses `response.completed` envelope to the bare response", () => {
-    const body = [
-      "event: response.created",
-      'data: {"type":"response.created","response":{"id":"resp_1"}}',
-      "event: response.completed",
-      'data: {"type":"response.completed","response":{"output_text":"hi","usage":{"input_tokens":3,"output_tokens":1},"model":"gpt-5-codex"}}',
-      "data: [DONE]",
-      "",
-    ].join("\n");
-    // The terminal event's `.response` is returned, NOT the envelope — so the
-    // non-streaming parsers read `output_text`/`usage`/`model` at top level.
-    expect(extractJSONFromSSEText(body)).toEqual({
-      output_text: "hi",
-      usage: { input_tokens: 3, output_tokens: 1 },
-      model: "gpt-5-codex",
-    });
-  });
-});
-
-// ---------------------------------------------------------------------------
 // looksLikeSSE — body-prefix sniffing (content-type may be mislabeled)
 // ---------------------------------------------------------------------------
 
@@ -135,17 +40,20 @@ describe("looksLikeSSE", () => {
     expect(looksLikeSSE("text/event-stream; charset=utf-8", "{}")).toBe(true);
   });
 
-  it("sniffs SSE bodies even when the content-type is wrong or empty", () => {
+  it("sniffs data:/event: bodies even when the content-type is wrong or empty", () => {
     for (const head of [
       "data: {",
+      "data:{", // no space after colon
       "event: response.created",
-      "id: 1",
-      "retry: 5",
-      ": keepalive",
     ]) {
       expect(looksLikeSSE("application/json", `${head}\n`)).toBe(true);
       expect(looksLikeSSE("", `${head}\n`)).toBe(true);
     }
+  });
+
+  it("tolerates a BOM / leading whitespace before the SSE field", () => {
+    expect(looksLikeSSE("", '\uFEFFdata: {"a":1}')).toBe(true);
+    expect(looksLikeSSE("", "  \n event: x")).toBe(true);
   });
 
   it("false for a JSON body (object or array), tolerating BOM/leading whitespace", () => {
@@ -153,46 +61,13 @@ describe("looksLikeSSE", () => {
     expect(looksLikeSSE("", "  \n [1,2]")).toBe(false);
     expect(looksLikeSSE("", '\uFEFF{"a":1}')).toBe(false);
   });
-});
 
-// ---------------------------------------------------------------------------
-// readCompletionJSON — the single safe reader for non-streaming bodies
-// ---------------------------------------------------------------------------
-
-function response(body: string, contentType: string): Response {
-  return new Response(body, { headers: { "content-type": contentType } });
-}
-
-describe("readCompletionJSON", () => {
-  it("parses a normal JSON body", async () => {
-    const json = await readCompletionJSON(
-      response(
-        '{"choices":[{"message":{"content":"hi"}}]}',
-        "application/json",
-      ),
-    );
-    expect(json).toEqual({ choices: [{ message: { content: "hi" } }] });
-  });
-
-  it("does NOT throw on an SSE body that is mislabeled application/json (LOREAI-GATEWAY-38/-1P)", async () => {
-    // A chat/completions SSE stream with the WRONG content-type — calling
-    // response.json() on this throws `Unexpected token 'd', "data: {..."`.
-    const body =
-      'data: {"id":"1","choices":[{"delta":{"content":"hi"},"finish_reason":"stop"}]}\ndata: [DONE]\n\n';
-    const json = await readCompletionJSON(response(body, "application/json"));
-    expect(json).toEqual({
-      id: "1",
-      choices: [{ delta: { content: "hi" }, finish_reason: "stop" }],
-    });
-  });
-
-  it("handles an openai-responses SSE stream with NO content-type, unwrapping the envelope", async () => {
-    const body = [
-      "event: response.completed",
-      'data: {"type":"response.completed","response":{"output_text":"done","model":"gpt-5-codex"}}',
-      "",
-    ].join("\n");
-    const json = await readCompletionJSON(response(body, ""));
-    expect(json).toEqual({ output_text: "done", model: "gpt-5-codex" });
+  it("does NOT false-positive on plaintext beginning with id:/retry:/`:` (only data:/event: count)", () => {
+    // A completion SSE stream always opens with data: or event:. Narrowing the
+    // sniff to those two avoids treating a plaintext error body as SSE.
+    expect(looksLikeSSE("text/plain", "retry: later please")).toBe(false);
+    expect(looksLikeSSE("text/plain", "id: 12345 not found")).toBe(false);
+    expect(looksLikeSSE("text/plain", ": a leading comment line")).toBe(false);
+    expect(looksLikeSSE("text/plain", "404 page not found")).toBe(false);
   });
 });

--- a/packages/gateway/test/worker-codex-sse-path.test.ts
+++ b/packages/gateway/test/worker-codex-sse-path.test.ts
@@ -7,12 +7,13 @@
  *   1. THROW — the SSE body arrives WITHOUT a `text/event-stream` content-type,
  *      so the old header-only guard fed it to `response.json()` →
  *      `SyntaxError: Unexpected token 'e', "event: res"... is not valid JSON`.
- *   2. SILENT-EMPTY — even with the correct content-type, the last `data:` line
- *      is the `response.completed` ENVELOPE (`{type, response:{...}}`), but the
- *      worker parser reads `output`/`output_text` at top level → `text=null`.
+ *   2. SILENT-EMPTY — a single-`data:`-line reader would return only the last
+ *      delta / terminal event, dropping the text streamed across the earlier
+ *      `output_text.delta` events → `text=null`.
  *
- * `readCompletionJSON` now sniffs the body prefix AND unwraps the responses
- * envelope, so the worker extracts the real text in both cases.
+ * The worker now sniffs the body prefix and runs a detected SSE stream through
+ * the protocol's stream accumulator (`accumulateResponsesSSEStream`), merging
+ * every delta into the full text — regardless of the content-type label.
  */
 import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
 
@@ -30,14 +31,28 @@ const UPSTREAMS = {
   openai: "https://api.openai.com",
 };
 
-/** An openai-responses SSE stream whose terminal event carries the full text. */
+/**
+ * A realistic multi-delta openai-responses SSE stream. The text arrives across
+ * TWO `output_text.delta` events ("worker " + "text") — a stream accumulator
+ * must merge them into "worker text"; a last-`data:`-line reader would drop all
+ * but the final delta.
+ */
 const CODEX_RESPONSES_SSE = [
   "event: response.created",
-  'data: {"type":"response.created","response":{"id":"resp_1"}}',
+  'data: {"type":"response.created","response":{"id":"resp_1","model":"gpt-5-codex"}}',
+  "",
+  "event: response.output_item.added",
+  'data: {"type":"response.output_item.added","output_index":0,"item":{"type":"message","role":"assistant"}}',
+  "",
   "event: response.output_text.delta",
-  'data: {"type":"response.output_text.delta","delta":"worker "}',
+  'data: {"type":"response.output_text.delta","output_index":0,"delta":"worker "}',
+  "",
+  "event: response.output_text.delta",
+  'data: {"type":"response.output_text.delta","output_index":0,"delta":"text"}',
+  "",
   "event: response.completed",
-  'data: {"type":"response.completed","response":{"output":[{"type":"message","content":[{"type":"output_text","text":"worker text"}]}],"usage":{"input_tokens":5,"output_tokens":2},"model":"gpt-5-codex"}}',
+  'data: {"type":"response.completed","response":{"id":"resp_1","status":"completed","usage":{"input_tokens":5,"output_tokens":2},"model":"gpt-5-codex"}}',
+  "",
   "data: [DONE]",
   "",
 ].join("\n");
@@ -74,15 +89,15 @@ describe("worker codex responses-SSE path", () => {
     resetBackgroundLimiter();
   });
 
-  test("mislabeled SSE (application/json) → extracts text, does NOT throw", async () => {
+  test("mislabeled SSE (application/json) → accumulates full text, does NOT throw", async () => {
     // Before the fix: response.json() on "event: res..." → SyntaxError → null.
     const result = await runCodexWorker("application/json");
     expect(result).toBe("worker text");
   });
 
-  test("correct text/event-stream content-type → unwraps envelope → extracts text", async () => {
-    // Before the fix: extractJSONFromSSE returned the `response.completed`
-    // envelope, so the parser read output_text=undefined → null (silent-empty).
+  test("correct text/event-stream content-type → merges multi-delta stream", async () => {
+    // The two output_text.delta events ("worker " + "text") must be merged; a
+    // last-data-line reader would only ever see the terminal event → empty.
     const result = await runCodexWorker("text/event-stream");
     expect(result).toBe("worker text");
   });

--- a/packages/gateway/test/worker-google-openai-path.test.ts
+++ b/packages/gateway/test/worker-google-openai-path.test.ts
@@ -67,4 +67,42 @@ describe("worker google URL (#1070)", () => {
     );
     expect(url).not.toContain("/v1/chat/completions");
   });
+
+  test("accumulates a MULTI-CHUNK SSE reply (mislabeled application/json) into the full text", async () => {
+    // An OpenAI-compat provider that streams even for a stream:false worker
+    // request, WITHOUT a text/event-stream content-type. The worker must sniff
+    // the body and merge every chunk — a last-data-line reader would return only
+    // the finish chunk (empty delta) → silent-empty (the finding-#1 gap).
+    // Blank-line-delimited SSE events (per the spec — parseSSEStream needs them).
+    const multichunk = `${[
+      'data: {"choices":[{"delta":{"role":"assistant"}}]}',
+      'data: {"choices":[{"delta":{"content":"Hel"}}]}',
+      'data: {"choices":[{"delta":{"content":"lo"}}]}',
+      'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}',
+      "data: [DONE]",
+    ].join("\n\n")}\n\n`;
+    mockFetch.mockResolvedValue(
+      new Response(multichunk, {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      (_sid, providerID) =>
+        providerID === "google"
+          ? { scheme: "bearer", value: "g_worker" }
+          : null,
+      { providerID: "google", modelID: "gemini-2.5-flash" },
+    );
+
+    const result = await client.prompt("system", "user", {
+      sessionID: "sess-google-mc",
+      workerID: "lore-distill",
+      model: { providerID: "google", modelID: "gemini-2.5-flash" },
+    });
+
+    expect(result).toBe("Hello");
+  });
 });


### PR DESCRIPTION
Follow-up to #1195 (merged), addressing its own post-merge adversarial-review findings.

## Finding 1 (SHOULD-FIX) — multi-chunk non-streaming SSE → silent-empty

A non-streaming request whose provider streams anyway was read by taking only the **last** `data:` line. For a **multi-chunk** stream that drops all but the final delta:
- openai chat → the finish chunk has an empty `delta` → **empty** completion
- truncated responses stream → loses the streamed text

#1195's last-line + envelope-unwrap reader fixed the reported *codex* case but not the general multi-chunk case (the review flagged this).

**Fix:** read the body once, sniff for SSE (`looksLikeSSE`), and run a detected SSE body through the protocol's **stream accumulator** — which already merges every chunk (text, tool-call fragments, usage) — instead of a bespoke last-line reader. Applied at both non-streaming read sites:
- **conversation** — `accumulateNonStreamResponse` (pipeline)
- **worker** — `llm-adapter` success path (SSE bodies are streamed successes, so the JSON error-envelope check is skipped for them; the 90-line embedded-error block is guarded by a null `bodyErrCode`, not re-indented)

The openai chat accumulator moved from pipeline (`accumulateNonStreamOpenAIStream`) to `stream/openai.ts` (`accumulateOpenAISSEStream`) so both call sites share one implementation; responses/gemini/anthropic reuse the existing `accumulateResponsesSSEStream` / `accumulateGeminiSSEStream` / `accumulateSSEResponse`.

## Finding 2 (NIT) — sniff false-positive

`looksLikeSSE` narrowed to `data:`/`event:` (dropped `id:`/`retry:`/`:` comment) — the only prefixes a completion stream opens with — so a plaintext error body (e.g. `retry: later`) is no longer misdetected as SSE.

## Cleanup

Removes the now-superseded `readCompletionJSON` / `extractJSONFromSSE` / `extractJSONFromSSEText` / `unwrapResponsesEnvelope` helpers (the #1195 stopgap). `looksLikeSSE` is retained (used by both read sites).

## Tests (mutation-verified non-vacuous)

- `stream-openai.test.ts` (new): `accumulateOpenAISSEStream` merges multi-chunk text + streamed tool-call fragments; skips the Copilot/Azure empty-choices content-filter preamble.
- `worker-codex-sse-path.test.ts`: realistic **multi-delta** responses stream (two `output_text.delta` events) extracted for both `application/json` (mislabeled) and `text/event-stream` content-types.
- `worker-google-openai-path.test.ts`: **multi-chunk** openai chat reply, mislabeled `application/json`, accumulated to the full text.
- `translate-types.test.ts`: `looksLikeSSE` narrowing — `data:`/`event:` sniffed; `id:`/`retry:`/`:`/plaintext are not.
- Mutations: overwrite-instead-of-merge → multi-chunk tests RED; worker skips SSE sniff → codex + chat tests RED; re-add `id:`/`retry:` → false-positive test RED.
- Full gateway suite: **2702 passed / 58 skipped**. typecheck + lint clean.