### PR TITLE
feat(gateway): telemetry for empty completions returned to the client

### DIFF
--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -97,6 +97,7 @@ import type {
 import {
   applyUpstreamExtraHeaders,
   blocksToText,
+  isEmptyCompletion,
   looksLikeSSE,
   forwardClientHeaders,
   ZERO_USAGE,
@@ -270,6 +271,7 @@ import {
   emitCurationMetrics,
   spanStartupBackfill,
   captureClientAbortUnderPressure,
+  captureEmptyCompletion,
   type AnthropicUsage,
 } from "./sentry";
 import {
@@ -8015,6 +8017,28 @@ async function handleConversationTurn(
       requestBody,
       genAiSpan,
     );
+    // Telemetry: flag a completion we're about to hand back with NO usable
+    // content (no text, no tool_use) — the "no response data" class
+    // (github-copilot #1052 follow-up). Checked on the model's response, before
+    // any lore context-warning banner is layered on. Never throws / never
+    // blocks the read path.
+    if (isEmptyCompletion(currentResp)) {
+      const emptyOutputTokens = currentResp.usage?.outputTokens ?? 0;
+      log.warn(
+        `empty completion → client: protocol=${effectiveProtocol} ` +
+          `model=${req.model} stopReason=${currentResp.stopReason} ` +
+          `outputTokens=${emptyOutputTokens} recallDepth=${recallDepth} ` +
+          `session=${sessionState.sessionID.slice(0, 16)}`,
+      );
+      captureEmptyCompletion({
+        protocol: effectiveProtocol,
+        model: req.model,
+        sessionID: sessionState.sessionID,
+        stopReason: currentResp.stopReason,
+        outputTokens: emptyOutputTokens,
+        recallDepth,
+      });
+    }
     const recallHeaders =
       recallDepth > 0 ? { "x-lore-recall-invoked": "true" } : undefined;
     return nonStreamHttpResponse(

--- a/packages/gateway/src/sentry.ts
+++ b/packages/gateway/src/sentry.ts
@@ -742,6 +742,46 @@ export function setupBustSpiralCapture(): void {
   });
 }
 
+/** Diagnostic context for an empty completion (see `captureEmptyCompletion`). */
+export interface EmptyCompletionInfo {
+  /** Upstream/client wire protocol (anthropic | openai | openai-responses | gemini). */
+  protocol: string;
+  /** Model id the request targeted. */
+  model: string;
+  /** Session id (for correlating with other events). */
+  sessionID: string;
+  /** Provider stop reason on the empty response (end_turn, length, …). */
+  stopReason: string;
+  /** Reported output tokens: >0 with empty content ⇒ parse/accumulate bug;
+   * 0 ⇒ the upstream genuinely returned nothing. */
+  outputTokens: number;
+  /** Recall continuation depth when the empty response was finalized. */
+  recallDepth: number;
+}
+
+/**
+ * Capture a warning when the gateway is about to hand the client a completion
+ * with ZERO usable content (no text, no tool_use) — the "no response data"
+ * class (github-copilot #1052 follow-up, and any future silent-empty parser or
+ * accumulator regression). Grouped by `protocol` so a provider-specific
+ * regression aggregates into one issue rather than one-per-session. No-op when
+ * Sentry is off; the caller guards it behind `isEmptyCompletion` and it never
+ * throws, so it is safe on the read path.
+ */
+export function captureEmptyCompletion(info: EmptyCompletionInfo): void {
+  if (!Sentry.isInitialized()) return;
+  Sentry.captureMessage(
+    "Empty completion returned to client (no content blocks)",
+    {
+      level: "warning",
+      fingerprint: ["empty-completion", info.protocol],
+      contexts: {
+        empty_completion: info as unknown as Record<string, unknown>,
+      },
+    },
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Process resource gauge + event-loop lag (periodic, from the idle tick)
 // ---------------------------------------------------------------------------

--- a/packages/gateway/src/translate/types.ts
+++ b/packages/gateway/src/translate/types.ts
@@ -110,6 +110,31 @@ export function blocksToText(blocks: GatewayContentBlock[], depth = 0): string {
 }
 
 /**
+ * True when a completion carries NO content the client can act on — no
+ * `tool_use`, no non-whitespace `text`, and no `thinking`/`opaque` block. This
+ * is the "no response data" shape (the client's agent turn ends with nothing):
+ * an empty `content` array, or one holding only whitespace text. `thinking` and
+ * `opaque` blocks count as content (the provider produced *something*), so a
+ * reasoning-only or passthrough response is NOT flagged — keeps the telemetry
+ * that consumes this predicate low-noise. Pure; safe to call on the hot path.
+ */
+export function isEmptyCompletion(resp: GatewayResponse): boolean {
+  for (const block of resp.content) {
+    switch (block.type) {
+      case "tool_use":
+      case "thinking":
+      case "opaque":
+        return false;
+      case "text":
+        if (block.text.trim() !== "") return false;
+        break;
+      // tool_result is not a completion output — ignore.
+    }
+  }
+  return true;
+}
+
+/**
  * Deterministic placeholder for an opaque block. Derives a compact descriptor
  * from common media fields (type, media_type, payload byte length) without
  * embedding the payload itself — so the placeholder is stable and cheap.

--- a/packages/gateway/test/empty-completion-telemetry.e2e.test.ts
+++ b/packages/gateway/test/empty-completion-telemetry.e2e.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Wiring test: when the finalize path is about to return a completion with no
+ * usable content, the gateway emits the empty-completion diagnostic
+ * (log.warn + captureEmptyCompletion). Drives a real in-process gateway over the
+ * openai conversation path with a canned EMPTY upstream reply (no network).
+ */
+import { describe, test, expect, afterEach, vi } from "vitest";
+import * as core from "@loreai/core";
+import { createHarness, type Harness } from "./helpers/harness";
+
+let harness: Harness | undefined;
+
+afterEach(() => {
+  harness?.teardown();
+  harness = undefined;
+  vi.restoreAllMocks();
+});
+
+/** Send a non-streaming openai chat request; `upstreamBody` is returned as-is. */
+async function runWithUpstream(
+  upstreamBody: string,
+  contentType = "application/json",
+): Promise<void> {
+  harness = await createHarness({ fixtures: [] });
+  const { setUpstreamInterceptor } = await import("../src/pipeline");
+  setUpstreamInterceptor(
+    async () =>
+      new Response(upstreamBody, {
+        status: 200,
+        headers: { "content-type": contentType },
+      }),
+  );
+  await fetch(`${harness.baseURL}/v1/chat/completions`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: "Bearer sk-test",
+      "x-lore-agent": "code", // force the conversation path (not meta)
+      "x-lore-session-id": "sess-empty",
+    },
+    body: JSON.stringify({
+      model: "gpt-4o-mini",
+      messages: [{ role: "user", content: "hi" }],
+      stream: false,
+      max_tokens: 50,
+    }),
+  });
+}
+
+const EMPTY_OPENAI = JSON.stringify({
+  id: "c1",
+  model: "gpt-4o-mini",
+  choices: [
+    {
+      index: 0,
+      message: { role: "assistant", content: "" },
+      finish_reason: "stop",
+    },
+  ],
+  usage: { prompt_tokens: 5, completion_tokens: 0 },
+});
+
+const NONEMPTY_OPENAI = JSON.stringify({
+  id: "c2",
+  model: "gpt-4o-mini",
+  choices: [
+    {
+      index: 0,
+      message: { role: "assistant", content: "hello" },
+      finish_reason: "stop",
+    },
+  ],
+  usage: { prompt_tokens: 5, completion_tokens: 1 },
+});
+
+describe("empty-completion telemetry wiring", () => {
+  test("logs the empty-completion diagnostic when the model returns no content", async () => {
+    const warn = vi.spyOn(core.log, "warn");
+    await runWithUpstream(EMPTY_OPENAI);
+    const emptyWarn = warn.mock.calls.find((c) =>
+      String(c[0]).includes("empty completion → client"),
+    );
+    expect(emptyWarn, "expected an 'empty completion' warning").toBeTruthy();
+    expect(String(emptyWarn?.[0])).toContain("protocol=openai");
+  });
+
+  test("does NOT log the diagnostic for a normal (non-empty) completion", async () => {
+    const warn = vi.spyOn(core.log, "warn");
+    await runWithUpstream(NONEMPTY_OPENAI);
+    const emptyWarn = warn.mock.calls.find((c) =>
+      String(c[0]).includes("empty completion → client"),
+    );
+    expect(emptyWarn).toBeUndefined();
+  });
+});

--- a/packages/gateway/test/sentry-empty-completion.test.ts
+++ b/packages/gateway/test/sentry-empty-completion.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Replace @sentry/bun with a complete mock so we can drive isInitialized() and
+// assert the exact captureMessage payload (see sentry-bust-spiral.test.ts).
+vi.mock("@sentry/bun", () => ({
+  isInitialized: vi.fn(() => true),
+  captureMessage: vi.fn(() => "event-id"),
+}));
+
+import { captureEmptyCompletion } from "../src/sentry";
+import * as Sentry from "@sentry/bun";
+
+const INFO = {
+  protocol: "openai",
+  model: "gpt-4o-mini",
+  sessionID: "sess-abc",
+  stopReason: "end_turn",
+  outputTokens: 0,
+  recallDepth: 0,
+};
+
+describe("captureEmptyCompletion", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(Sentry.isInitialized).mockReturnValue(true);
+  });
+
+  it("captures a warning grouped by protocol with the diagnostic context", () => {
+    captureEmptyCompletion({ ...INFO, protocol: "openai-responses" });
+    expect(Sentry.captureMessage).toHaveBeenCalledTimes(1);
+    const [message, opts] = vi.mocked(Sentry.captureMessage).mock.calls[0];
+    expect(message).toMatch(/empty completion/i);
+    expect(opts).toMatchObject({
+      level: "warning",
+      fingerprint: ["empty-completion", "openai-responses"],
+    });
+    // Full diagnostic payload is attached for triage.
+    expect(
+      (opts as { contexts: { empty_completion: Record<string, unknown> } })
+        .contexts.empty_completion,
+    ).toMatchObject({ protocol: "openai-responses", model: "gpt-4o-mini" });
+  });
+
+  it("is a no-op when Sentry is not initialized", () => {
+    vi.mocked(Sentry.isInitialized).mockReturnValue(false);
+    captureEmptyCompletion(INFO);
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it("groups distinct protocols into distinct fingerprints", () => {
+    captureEmptyCompletion({ ...INFO, protocol: "gemini" });
+    captureEmptyCompletion({ ...INFO, protocol: "openai" });
+    const fps = vi
+      .mocked(Sentry.captureMessage)
+      .mock.calls.map((c) => (c[1] as { fingerprint: string[] }).fingerprint);
+    expect(fps).toEqual([
+      ["empty-completion", "gemini"],
+      ["empty-completion", "openai"],
+    ]);
+  });
+});

--- a/packages/gateway/test/translate-types.test.ts
+++ b/packages/gateway/test/translate-types.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { ZERO_USAGE, looksLikeSSE } from "../src/translate/types";
+import {
+  ZERO_USAGE,
+  isEmptyCompletion,
+  looksLikeSSE,
+  type GatewayContentBlock,
+  type GatewayResponse,
+} from "../src/translate/types";
 
 // ---------------------------------------------------------------------------
 // ZERO_USAGE
@@ -69,5 +75,54 @@ describe("looksLikeSSE", () => {
     expect(looksLikeSSE("text/plain", "id: 12345 not found")).toBe(false);
     expect(looksLikeSSE("text/plain", ": a leading comment line")).toBe(false);
     expect(looksLikeSSE("text/plain", "404 page not found")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isEmptyCompletion — the "no response data" predicate
+// ---------------------------------------------------------------------------
+
+function resp(content: GatewayContentBlock[]): GatewayResponse {
+  return { id: "id", model: "m", content, stopReason: "end_turn" };
+}
+
+describe("isEmptyCompletion", () => {
+  it("true for an empty content array", () => {
+    expect(isEmptyCompletion(resp([]))).toBe(true);
+  });
+
+  it("true when the only text block is empty or whitespace", () => {
+    expect(isEmptyCompletion(resp([{ type: "text", text: "" }]))).toBe(true);
+    expect(isEmptyCompletion(resp([{ type: "text", text: "  \n\t " }]))).toBe(
+      true,
+    );
+  });
+
+  it("false when there is non-whitespace text", () => {
+    expect(isEmptyCompletion(resp([{ type: "text", text: "hi" }]))).toBe(false);
+  });
+
+  it("false when there is a tool_use block (even alongside empty text)", () => {
+    expect(
+      isEmptyCompletion(
+        resp([
+          { type: "text", text: "" },
+          { type: "tool_use", id: "1", name: "f", input: {} },
+        ]),
+      ),
+    ).toBe(false);
+  });
+
+  it("false for reasoning-only (thinking) or passthrough (opaque) content — not the no-data bug", () => {
+    expect(
+      isEmptyCompletion(
+        resp([{ type: "thinking" } as unknown as GatewayContentBlock]),
+      ),
+    ).toBe(false);
+    expect(
+      isEmptyCompletion(
+        resp([{ type: "opaque" } as unknown as GatewayContentBlock]),
+      ),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
Surfaces the **"no response data"** class (github-copilot #1052 follow-up, and any future silent-empty parser/accumulator regression) instead of letting it fail silently. When the finalize path is about to hand the client a completion with **no usable content** (no text, no tool_use), the gateway now logs a diagnostic and captures a Sentry warning.

Motivated by the copilot investigation: I couldn't reproduce the reporter's empty on current main (every path that reaches the provider returns content), so this closes the observability gap — if it recurs after the reporter upgrades, we'll have the signal.

## What

- **`isEmptyCompletion(resp)`** (`translate/types`) — pure predicate. `true` when `content` is empty or holds only whitespace text. `thinking` / `opaque` / `tool_use` / real text count as content (keeps it low-noise; targets the true no-data shape, not reasoning-only or passthrough responses).
- **`captureEmptyCompletion(info)`** (`sentry`) — `Sentry.captureMessage(level=warning, fingerprint=['empty-completion', protocol])` with a diagnostic context: `model`, `stopReason`, `outputTokens`, `recallDepth`, `session`. `outputTokens > 0` with empty content ⇒ a parse/accumulate bug; `0` ⇒ the upstream genuinely returned nothing. No-op when Sentry is off; never throws.
- **Wired into `finalizeWithRecall`** — the single chokepoint for openai / openai-responses / gemini conversation responses (streaming *and* non-streaming, including the reporter's github-copilot path). Checked on the **model's** response, before any lore context-warning banner. Also `log.warn`'d so it's visible in local `lore` logs even without Sentry (useful for the reporter's own debugging).

Read-path safety (🔴): the check is an O(n-blocks) scan that only fires on the already-degenerate empty case; the Sentry call is guarded + never throws. The common Anthropic *streaming* path (real-time forward, not buffered through `finalizeWithRecall`) is intentionally not covered — buffering it to test emptiness would defeat streaming, and Anthropic honors `stream` faithfully.

## Tests (mutation-verified non-vacuous)

- `translate-types`: `isEmptyCompletion` — empty / whitespace-only / text / tool_use / thinking / opaque.
- `sentry-empty-completion`: payload (level/fingerprint/context), no-op when Sentry off, per-protocol fingerprint grouping.
- `empty-completion-telemetry.e2e`: real in-process gateway + canned **empty** openai upstream → diagnostic logged; **non-empty** → not logged.
- Mutations: `isEmptyCompletion`→always-false → predicate + e2e RED; remove wiring → e2e RED; drop `isInitialized` guard → sentry no-op test RED.
- Full gateway suite: **2722 passed / 58 skipped**. typecheck + lint clean.