### PR TITLE
fix(gateway): point the worker-degradation warning at `lore doctor` (not the non-existent `lore status`)

### DIFF
--- a/packages/gateway/src/worker-health.ts
+++ b/packages/gateway/src/worker-health.ts
@@ -584,7 +584,7 @@ export function getDegradationWarning(sessionID: string): string | null {
     `[Lore: Background workers (distillation, curation, cache warming) for this session ` +
     `have been failing for ${formatDuration(sustainedMs)}. This is harmful — your ` +
     `context window is not being compressed and long-term knowledge is not being ` +
-    `captured. Likely cause: session authentication has gone stale. Run \`lore status\` ` +
+    `captured. Likely cause: session authentication has gone stale. Run \`lore doctor\` ` +
     `or check the dashboard for details.]`
   );
 }

--- a/packages/gateway/test/worker-health.test.ts
+++ b/packages/gateway/test/worker-health.test.ts
@@ -73,6 +73,25 @@ describe("worker-health", () => {
       expect(getDegradationWarning("s1")).not.toBeNull();
     });
 
+    test("degradation warning points at a REAL CLI command (lore doctor, not lore status)", () => {
+      // Regression (Sergiy's report, 2026-07-06): the warning told users to run
+      // `lore status`, which is not a command — the CLI has `doctor` for
+      // routing/env/auth diagnostics. A warning that hands the user a bogus
+      // command is worse than useless when their workers are already failing.
+      let t = 1_000_000;
+      _setNowForTest(() => t);
+      for (let i = 0; i < 3; i++) {
+        recordWorkerFailure("s1", "lore-distill", "no-auth");
+        t += 5 * 60 * 1000;
+      }
+      t = 1_000_000 + 31 * 60 * 1000;
+      _setNowForTest(() => t);
+      const warning = getDegradationWarning("s1");
+      expect(warning).not.toBeNull();
+      expect(warning).toContain("`lore doctor`");
+      expect(warning).not.toContain("lore status");
+    });
+
     test("sustained 60+ min: critical status", () => {
       let t = 1_000_000;
       _setNowForTest(() => t);


### PR DESCRIPTION
From Sergiy's Slack reports (2026-07-06). When background workers have been failing for a while, the gateway injects a context warning ending with:

> Likely cause: session authentication has gone stale. Run `lore status` or check the dashboard for details.

But **`lore status` is not a command**:

```
➜ lore status
Unknown command "status". Did you mean "lore start"?
```

Handing a user a bogus command — right when their workers are already down and they need to act — is worse than useless. The CLI's diagnostic command is **`lore doctor`** ("Diagnose routing/env conflicts: setup inventory, gateway health"), which is exactly what surfaces a stale-auth / routing problem.

Fix: reference `lore doctor`. Adds a regression test that the degradation warning contains `` `lore doctor` `` and never `lore status`.