### PR TITLE
fix(gateway): stream buffered non-Anthropic upstreams to Anthropic clients (#1052)

### DIFF
--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -184,7 +184,7 @@ import {
   createStreamAccumulator,
   createRecallAwareAccumulator,
   parseSSEStream,
-  buildSSETextResponse,
+  buildSSEResponse,
   buildSSEToolUseResponse,
   buildKeepaliveCompactionStream,
   formatSSEEvent,
@@ -4563,8 +4563,18 @@ function nonStreamHttpResponse(
     );
   } else if (clientProtocol === "gemini") {
     clientResp = buildGeminiResponse(scaledResp, clientStream ?? false);
+  } else if (clientStream) {
+    // Anthropic (or unspecified) client that requested `stream: true`. The
+    // upstream response was BUFFERED (non-Anthropic upstreams — OpenAI /
+    // Responses / Gemini — are accumulated, not streamed through), so we
+    // synthesize a complete Anthropic SSE stream from it. Returning the
+    // non-streaming JSON body below would leave the client's SDK waiting
+    // forever for an SSE stream it opened the request for — the github-copilot
+    // + Claude-model "response never reaches the UI" bug (#1052). The other
+    // client protocols already honor `clientStream` via their builders above.
+    clientResp = streamHttpResponse(scaledResp);
   } else {
-    // Anthropic or unspecified — default format
+    // Anthropic or unspecified — default non-streaming JSON format.
     const body = buildAnthropicNonStreamResponse(scaledResp);
     clientResp = new Response(JSON.stringify(body), {
       status: 200,
@@ -4584,19 +4594,13 @@ function nonStreamHttpResponse(
  * Convert a GatewayResponse to a streaming SSE HTTP Response.
  */
 function streamHttpResponse(resp: GatewayResponse): Response {
-  // Guard: resp.usage can be undefined at runtime for vLLM / partial responses.
-  const usage = resp.usage ?? ZERO_USAGE;
-
-  // Build the full SSE text for a text-only response
-  const textBlocks = resp.content.filter(
-    (b): b is { type: "text"; text: string } => b.type === "text",
-  );
-  const fullText = textBlocks.map((b) => b.text).join("");
-
-  const sseBody = buildSSETextResponse(resp.id, resp.model, fullText, {
-    inputTokens: usage.inputTokens,
-    outputTokens: usage.outputTokens,
-  });
+  // Synthesize a complete Anthropic SSE stream from the fully-accumulated
+  // response, preserving ALL blocks (text + tool_use + thinking + opaque). This
+  // is used both for synthetic responses (slash commands) and — critically —
+  // when re-emitting a BUFFERED non-Anthropic upstream (OpenAI/Responses/Gemini)
+  // to an Anthropic client that requested `stream: true`. A text-only synthesis
+  // would silently drop tool calls, breaking coding agents (#1052).
+  const sseBody = buildSSEResponse(resp);
 
   return new Response(sseBody, {
     status: 200,

--- a/packages/gateway/src/stream/anthropic.ts
+++ b/packages/gateway/src/stream/anthropic.ts
@@ -656,6 +656,118 @@ export function buildSSETextResponse(
 }
 
 /**
+ * Build a complete Anthropic SSE event sequence from a fully-accumulated
+ * `GatewayResponse`, preserving ALL content blocks — text, thinking, tool_use,
+ * and opaque (image/etc.) — not just text.
+ *
+ * Used when the gateway has BUFFERED a non-Anthropic upstream response
+ * (OpenAI / Responses / Gemini, which are accumulated rather than streamed
+ * through) for an Anthropic-protocol client that requested `stream: true`.
+ * The client's SDK opened the request expecting `text/event-stream`; handing it
+ * a non-streaming JSON body leaves it waiting forever with no output — exactly
+ * the "response reaches the gateway but never makes it to the UI" symptom for
+ * GitHub Copilot + a Claude model via OpenCode's Anthropic SDK (#1052).
+ *
+ * Emits the full lifecycle, one block at a time:
+ *   message_start
+ *   → (content_block_start → content_block_delta* → content_block_stop) per block
+ *   → message_delta → message_stop
+ *
+ * Unlike `buildSSETextResponse` (text-only, for synthetic single-string
+ * responses) this must not drop tool_use blocks — a coding agent whose turn is
+ * a tool call would otherwise receive an empty stream.
+ */
+export function buildSSEResponse(resp: GatewayResponse): string {
+  const events: string[] = [buildSSEMessageStart(resp)];
+
+  resp.content.forEach((block: GatewayContentBlock, index: number) => {
+    let contentBlock: Record<string, unknown>;
+    const deltas: Record<string, unknown>[] = [];
+
+    switch (block.type) {
+      case "text":
+        contentBlock = { type: "text", text: "" };
+        deltas.push({ type: "text_delta", text: block.text });
+        break;
+      case "thinking":
+        contentBlock = { type: "thinking", thinking: "" };
+        deltas.push({ type: "thinking_delta", thinking: block.thinking });
+        if (block.signature != null) {
+          deltas.push({ type: "signature_delta", signature: block.signature });
+        }
+        break;
+      case "tool_use":
+        contentBlock = {
+          type: "tool_use",
+          id: block.id,
+          name: block.name,
+          input: {},
+        };
+        // The full arguments object is delivered as one input_json_delta — the
+        // accumulator on the other side concatenates partial_json then parses.
+        deltas.push({
+          type: "input_json_delta",
+          partial_json: JSON.stringify(block.input ?? {}),
+        });
+        break;
+      case "opaque":
+        // Best-effort: re-emit the original block verbatim as a single-shot
+        // start (no delta). Rare in a response; better than dropping.
+        contentBlock = block.raw;
+        break;
+      default:
+        // tool_result never appears in an assistant response.
+        return;
+    }
+
+    events.push(
+      formatSSEEvent(
+        "content_block_start",
+        JSON.stringify({
+          type: "content_block_start",
+          index,
+          content_block: contentBlock,
+        }),
+      ),
+    );
+    for (const delta of deltas) {
+      events.push(
+        formatSSEEvent(
+          "content_block_delta",
+          JSON.stringify({ type: "content_block_delta", index, delta }),
+        ),
+      );
+    }
+    events.push(
+      formatSSEEvent(
+        "content_block_stop",
+        JSON.stringify({ type: "content_block_stop", index }),
+      ),
+    );
+  });
+
+  const u = resp.usage ?? ZERO_USAGE;
+  events.push(
+    formatSSEEvent(
+      "message_delta",
+      JSON.stringify({
+        type: "message_delta",
+        delta: {
+          stop_reason: resp.stopReason ?? "end_turn",
+          stop_sequence: null,
+        },
+        usage: { output_tokens: u.outputTokens },
+      }),
+    ),
+  );
+  events.push(
+    formatSSEEvent("message_stop", JSON.stringify({ type: "message_stop" })),
+  );
+
+  return events.join("");
+}
+
+/**
  * Build a *live* compaction SSE `Response` that emits keep-alive `ping` events
  * while `summaryPromise` is still pending, then streams the summary text once
  * it resolves.

--- a/packages/gateway/test/anthropic-client-openai-upstream-stream.test.ts
+++ b/packages/gateway/test/anthropic-client-openai-upstream-stream.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Integration test: an Anthropic-protocol client that requests `stream: true`
+ * whose UPSTREAM speaks OpenAI (e.g. GitHub Copilot serving a Claude model via
+ * OpenCode's Anthropic SDK, #1052).
+ *
+ * Non-Anthropic upstreams (OpenAI / Responses / Gemini) are BUFFERED — the
+ * gateway accumulates the full response, then re-emits it in the client's wire
+ * format. The bug: for an Anthropic client the re-emission returned a
+ * NON-STREAMING JSON body even when the client had opened the request with
+ * `stream: true`. The client's SDK sat waiting for an SSE stream it never got,
+ * so the response "reached the gateway but never made it to the UI".
+ *
+ * We drive an Anthropic `/v1/messages` request (stream:true) with a model
+ * (`gpt-4o`) that routes the upstream to the OpenAI protocol, and an upstream
+ * interceptor returning OpenAI SSE (with Copilot's empty-`choices` preamble
+ * chunk, plus a text delta AND a tool_call). We assert the CLIENT response is
+ * `text/event-stream` (not `application/json`) and preserves both the text and
+ * the tool_use.
+ */
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  existsSync,
+  mkdtempSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+function sseChunk(obj: unknown): string {
+  return `data: ${JSON.stringify(obj)}\n\n`;
+}
+
+// Copilot-style OpenAI chat-completions SSE: an Azure content-filter preamble
+// with EMPTY choices, a role chunk, a text delta, a tool_call, then a
+// finish chunk with usage.
+function openAICopilotStream(): Response {
+  const body =
+    sseChunk({
+      id: "chatcmpl-cop",
+      model: "gpt-4o",
+      choices: [],
+      prompt_filter_results: [],
+    }) +
+    sseChunk({
+      id: "chatcmpl-cop",
+      model: "gpt-4o",
+      choices: [
+        { index: 0, delta: { role: "assistant" }, finish_reason: null },
+      ],
+    }) +
+    sseChunk({
+      id: "chatcmpl-cop",
+      model: "gpt-4o",
+      choices: [
+        {
+          index: 0,
+          delta: { content: "Reading the file." },
+          finish_reason: null,
+        },
+      ],
+    }) +
+    sseChunk({
+      id: "chatcmpl-cop",
+      model: "gpt-4o",
+      choices: [
+        {
+          index: 0,
+          delta: {
+            tool_calls: [
+              {
+                index: 0,
+                id: "call_read1",
+                type: "function",
+                function: { name: "read", arguments: '{"path":"a.txt"}' },
+              },
+            ],
+          },
+          finish_reason: null,
+        },
+      ],
+    }) +
+    sseChunk({
+      id: "chatcmpl-cop",
+      model: "gpt-4o",
+      choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }],
+      usage: { prompt_tokens: 50, completion_tokens: 8 },
+    }) +
+    "data: [DONE]\n\n";
+  return new Response(body, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+let teardownFn: (() => void) | undefined;
+
+afterEach(() => {
+  teardownFn?.();
+  teardownFn = undefined;
+});
+
+describe("Anthropic client + OpenAI upstream (streaming re-emission, #1052)", () => {
+  test("re-emits a buffered OpenAI upstream as an Anthropic SSE stream (not JSON)", async () => {
+    const dbPath = `/tmp/lore-anthropic-openai-stream-${Date.now()}-${Math.random().toString(36).slice(2)}.db`;
+    process.env.LORE_DB_PATH = dbPath;
+    process.env.LORE_LISTEN_PORT = "0";
+    if (!process.env.LORE_DEBUG) process.env.LORE_DEBUG = "false";
+
+    // Query expansion off so recall never makes a real LLM call.
+    const projectDir = mkdtempSync(join(tmpdir(), "lore-ao-stream-proj-"));
+    writeFileSync(
+      join(projectDir, ".lore.json"),
+      JSON.stringify({ search: { queryExpansion: false } }),
+    );
+
+    const { setUpstreamInterceptor, resetPipelineState } = await import(
+      "../src/pipeline"
+    );
+    const { startServer } = await import("../src/server");
+    const { loadConfig } = await import("../src/config");
+    const { close: closeDB, load: loadLoreConfig } = await import(
+      "@loreai/core"
+    );
+
+    closeDB();
+    await resetPipelineState();
+    await loadLoreConfig(projectDir);
+
+    setUpstreamInterceptor(async () => openAICopilotStream());
+
+    const config = loadConfig();
+    const server = await startServer(config);
+    const baseURL = `http://127.0.0.1:${server.port}`;
+
+    teardownFn = () => {
+      server.stop();
+      closeDB();
+      setUpstreamInterceptor(undefined);
+      for (const suffix of ["", "-shm", "-wal"]) {
+        const f = `${dbPath}${suffix}`;
+        try {
+          if (existsSync(f)) unlinkSync(f);
+        } catch {
+          // best-effort
+        }
+      }
+      try {
+        rmSync(projectDir, { recursive: true, force: true });
+      } catch {
+        // best-effort
+      }
+    };
+
+    const resp = await fetch(`${baseURL}/v1/messages`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": "test-key",
+        "anthropic-version": "2023-06-01",
+        // Force a primary (conversation) turn — otherwise the small request is
+        // treated as a meta request and takes the passthrough path.
+        "x-lore-agent": "coder",
+        "x-lore-project": projectDir,
+      },
+      body: JSON.stringify({
+        model: "gpt-4o",
+        max_tokens: 1024,
+        stream: true,
+        tools: [
+          {
+            name: "read",
+            description: "read a file",
+            input_schema: { type: "object", properties: {} },
+          },
+        ],
+        messages: [{ role: "user", content: "read a.txt please" }],
+      }),
+    });
+
+    expect(resp.ok).toBe(true);
+
+    // THE FIX: a stream:true Anthropic client must get an SSE stream, never a
+    // non-streaming JSON body (which left OpenCode's SDK hanging with no output).
+    expect(resp.headers.get("content-type")).toContain("text/event-stream");
+
+    const sse = await resp.text();
+    // Well-formed Anthropic streaming lifecycle.
+    expect(sse).toContain("event: message_start");
+    expect(sse).toContain("event: message_stop");
+    // The assistant text survived the OpenAI→Anthropic re-emission…
+    expect(sse).toContain("Reading the file.");
+    // …and so did the tool_use (a text-only synthesis would have dropped it,
+    // breaking the coding agent's turn).
+    expect(sse).toContain('"name":"read"');
+    expect(sse).toContain("a.txt");
+  });
+});

--- a/packages/gateway/test/stream-anthropic.test.ts
+++ b/packages/gateway/test/stream-anthropic.test.ts
@@ -14,6 +14,7 @@ import {
   scaleMessageDeltaUsage,
   buildSSEMessageStart,
   buildSSETextResponse,
+  buildSSEResponse,
   accumulateSSEResponse,
 } from "../src/stream/anthropic";
 import {
@@ -479,5 +480,73 @@ describe("accumulateSSEResponse", () => {
     expect(resp.stopReason).toBe("end_turn");
     expect(resp.usage?.inputTokens).toBe(7);
     expect(resp.usage?.outputTokens).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildSSEResponse — full multi-block synthesis (text + tool_use)
+// ---------------------------------------------------------------------------
+
+describe("buildSSEResponse", () => {
+  test("round-trips a text + tool_use response, preserving the tool call", async () => {
+    const resp: GatewayResponse = {
+      id: "msg_multi",
+      model: "claude-x",
+      content: [
+        { type: "text", text: "Reading the file." },
+        {
+          type: "tool_use",
+          id: "toolu_1",
+          name: "read",
+          input: { path: "a.txt" },
+        },
+      ],
+      stopReason: "tool_use",
+      usage: {
+        inputTokens: 12,
+        outputTokens: 8,
+        cacheReadInputTokens: 0,
+        cacheCreationInputTokens: 0,
+      },
+    };
+
+    const sse = buildSSEResponse(resp);
+    // Well-formed lifecycle.
+    expect(sse).toContain("event: message_start");
+    expect(sse).toContain("event: message_stop");
+
+    const round = await accumulateSSEResponse(new Response(sse));
+    expect(round.id).toBe("msg_multi");
+    expect(round.stopReason).toBe("tool_use");
+    // BOTH blocks survive — a text-only synthesis would have dropped the tool.
+    expect(round.content).toEqual([
+      { type: "text", text: "Reading the file." },
+      {
+        type: "tool_use",
+        id: "toolu_1",
+        name: "read",
+        input: { path: "a.txt" },
+      },
+    ]);
+  });
+
+  test("emits a valid empty-content stream (no blocks)", async () => {
+    const resp: GatewayResponse = {
+      id: "msg_empty",
+      model: "claude-x",
+      content: [],
+      stopReason: "end_turn",
+      usage: {
+        inputTokens: 3,
+        outputTokens: 0,
+        cacheReadInputTokens: 0,
+        cacheCreationInputTokens: 0,
+      },
+    };
+    const round = await accumulateSSEResponse(
+      new Response(buildSSEResponse(resp)),
+    );
+    expect(round.content).toEqual([]);
+    expect(round.stopReason).toBe("end_turn");
   });
 });


### PR DESCRIPTION
Root cause of jonlong's follow-up on #1052: with an Anthropic-protocol client (OpenCode's Anthropic SDK) using the **github-copilot** provider + a **Claude model**, the response reaches the gateway (and shows up in Lore's dashboard) but **never makes it to the OpenCode UI**.

## Root cause

OpenCode's AI-SDK uses the Anthropic SDK for Claude models → it issues `/v1/messages` (`stream: true`). The github-copilot provider serves **OpenAI** (`api.githubcopilot.com/chat/completions`), so `effectiveProtocol = openai`. Non-Anthropic upstreams (OpenAI / Responses / Gemini) are **buffered** — the gateway accumulates the full response, then re-emits it in the client's wire format via `nonStreamHttpResponse`.

But `nonStreamHttpResponse`'s **Anthropic branch returned a non-streaming JSON body**, ignoring `clientStream`. The client's SDK had opened the request expecting `text/event-stream` and sat waiting for an SSE stream that never arrived → **no output**, and (correctly) **no empty-completion warning**, because the response wasn't empty — it just went out in the wrong shape.

The `openai` / `openai-responses` / `gemini` client branches already honored `clientStream` via their builders — only the Anthropic branch was broken. (This also affected any Anthropic client → OpenAI-backend streaming turn, e.g. Claude Code → DeepSeek; lenient clients tolerated the JSON, strict SDKs like OpenCode's did not.)

## Fix

- **`buildSSEResponse(resp)`** (new, `stream/anthropic.ts`): synthesizes a complete Anthropic SSE lifecycle from a fully-accumulated `GatewayResponse`, preserving **all** blocks — text + tool_use + thinking + opaque. `streamHttpResponse` now uses it instead of the text-only `buildSSETextResponse` (which silently dropped tool calls → would break a coding agent's turn).
- **`nonStreamHttpResponse`** honors `clientStream` for the Anthropic branch, returning the synthesized SSE stream.

## Tests

- **Integration** (`anthropic-client-openai-upstream-stream.test.ts`): drives an Anthropic `/v1/messages` `stream:true` request whose model routes the upstream to OpenAI; the interceptor returns Copilot-style OpenAI SSE (with the empty-`choices` Azure preamble chunk) carrying text **and** a tool_call. Asserts the client response is `text/event-stream` (not `application/json`) and preserves both the text and the tool_use. **Mutation-verified**: disabling the `clientStream` branch → `expected 'application/json' to contain 'text/event-stream'`.
- **Unit** (`stream-anthropic.test.ts`): `buildSSEResponse` round-trips a text + tool_use response through the accumulator; mutation-verified (breaking the `input_json_delta` → RED). Plus an empty-content case.
- Full gateway suite green (2726 passed), typecheck + lint clean.