### PR TITLE
fix(gateway): clamp client usage cap to 200K unless request enables context-1m

### DIFF
--- a/packages/gateway/src/compaction.ts
+++ b/packages/gateway/src/compaction.ts
@@ -92,6 +92,17 @@ export function estimateTokens(text: string): number {
  * window, not hardcoded. A hardcoded 200K cap (the old behavior) reports ~150K
  * for every model, which on a 1M-context model is wrong by ~6× and on smaller
  * models can trigger premature compaction.
+ *
+ * CRITICAL: "the model's context window" here means the window the CLIENT
+ * meters against, NOT the window models.dev reports. Claude Code only meters
+ * against a >200K window when the request opts into the long-context
+ * (`context-1m`) beta; for every other request — including a 1M-capable
+ * third-party model (e.g. MiniMax-M3 served over the Anthropic wire) that
+ * Claude Code has no metadata for — it meters against a 200K window and
+ * auto-compacts at ~167K. Deriving the cap from the model's real 1M window
+ * (→ 870_300) means the cap never trips, real usage sails past 167K, and the
+ * client auto-compacts anyway. Clamp with {@link clientMeteredContextWindow}
+ * before calling this. (Regression from #910; MiniMax-M3 confirmed via Sentry.)
  */
 export const AUTOCOMPACT_BUFFER_TOKENS = 13_000;
 /** Tokens Claude Code reserves for the compaction summary output. */
@@ -147,6 +158,53 @@ export const DEFAULT_MAX_REPORTED_USAGE = maxReportedUsageForModel(
   200_000,
   MAX_OUTPUT_RESERVE,
 );
+
+/**
+ * The context window a host client assumes for a model it does NOT recognise.
+ *
+ * Claude Code (the reference client for this anti-compaction feature) meters
+ * usage — and triggers auto-compaction — against a 200K window for any model
+ * it has no metadata for. That covers every anthropic-compat third party
+ * (MiniMax, GLM, vLLM, …) served over the Anthropic wire protocol, AND Claude's
+ * own 1M-capable models on requests that do NOT opt into the long-context
+ * (`context-1m`) beta. Only when the request enables that beta does the client
+ * meter against the model's real (larger) window.
+ */
+export const CLIENT_DEFAULT_CONTEXT_WINDOW = 200_000;
+
+/**
+ * The context window the host client actually meters against for a model, given
+ * whether the request opted into the extended (1M) window via the `context-1m`
+ * beta. Without the beta, clamp to {@link CLIENT_DEFAULT_CONTEXT_WINDOW} so the
+ * client-usage cap can never exceed what the client's own auto-compact
+ * threshold allows — otherwise a 1M-context model reported against a 200K-window
+ * client auto-compacts at ~167K despite having ~840K of real headroom left.
+ */
+export function clientMeteredContextWindow(
+  realContextWindow: number,
+  longContextEnabled: boolean,
+): number {
+  return longContextEnabled
+    ? realContextWindow
+    : Math.min(realContextWindow, CLIENT_DEFAULT_CONTEXT_WINDOW);
+}
+
+/**
+ * True when the request opts into the long-context (1M) window via the
+ * `context-1m` beta. This is the exact signal Claude Code uses to switch its
+ * own context meter / auto-compact threshold from the default 200K window to
+ * the model's larger (1M) window — so the client-usage cap must track it (feed
+ * the result into {@link clientMeteredContextWindow}). Case-insensitive;
+ * matches any `context-1m` token inside `anthropic-beta`.
+ */
+export function requestEnablesLongContext(req: GatewayRequest): boolean {
+  for (const [k, v] of Object.entries(req.rawHeaders)) {
+    if (k.toLowerCase() === "anthropic-beta" && /context-1m/i.test(v)) {
+      return true;
+    }
+  }
+  return false;
+}
 
 /**
  * Scale usage fields proportionally so the client's total

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -137,6 +137,8 @@ import {
   assembleOfflineCompaction,
   scaleUsageForClient,
   maxReportedUsageForModel,
+  clientMeteredContextWindow,
+  requestEnablesLongContext,
   MAX_OUTPUT_RESERVE,
   DEFAULT_MAX_REPORTED_USAGE,
 } from "./compaction";
@@ -3795,12 +3797,27 @@ async function forwardToUpstream(
  * `0.9 × (effectiveWindow − 13k)`. An empty/missing model id falls back to the
  * conservative default cap; unknown models use `getModelEntrySync`'s 200K-window
  * fallback entry (still well under a real 200K client's compaction threshold).
+ *
+ * `longContext` MUST reflect whether THIS request opted into the 1M window via
+ * the `context-1m` beta ({@link requestEnablesLongContext}). Without it, the
+ * effective window is clamped to 200K ({@link clientMeteredContextWindow}) so a
+ * 1M-capable third-party model (e.g. MiniMax-M3) the client meters against a
+ * 200K window can't sail past the client's ~167K auto-compact threshold — the
+ * whole point of scaling. Defaults to `false` (conservative) so any caller that
+ * can't determine the beta state gets the safe, compaction-proof cap.
  */
-function maxReportedUsageForModelID(modelID: string): number {
+function maxReportedUsageForModelID(
+  modelID: string,
+  longContext = false,
+): number {
   if (!modelID) return DEFAULT_MAX_REPORTED_USAGE;
   const entry = getModelEntrySync(modelID);
-  const contextWindow = entry.limit?.context ?? 200_000;
+  const realContextWindow = entry.limit?.context ?? 200_000;
   const maxOutput = entry.limit?.output ?? MAX_OUTPUT_RESERVE;
+  const contextWindow = clientMeteredContextWindow(
+    realContextWindow,
+    longContext,
+  );
   return maxReportedUsageForModel(contextWindow, maxOutput);
 }
 
@@ -4523,14 +4540,20 @@ function nonStreamHttpResponse(
   clientProtocol?: GatewayRequest["protocol"],
   clientStream?: boolean,
   extraHeaders?: Record<string, string>,
+  /** Whether the originating request opted into the 1M window via `context-1m`
+   *  beta. Defaults to `false` so the cap is clamped to the 200K-window value —
+   *  the safe, compaction-proof default for callers that don't thread it. */
+  longContext = false,
 ): Response {
   // Guard: resp.usage can be undefined at runtime for vLLM / partial responses.
   const usage = resp.usage ?? ZERO_USAGE;
 
   // Scale usage so the client's token total stays below auto-compact threshold.
   // postResponse() has already consumed the real values for calibration/bustRate.
-  // Cap is per-model (from the response's model), so a 1M-context model isn't
-  // throttled to the 200K cap.
+  // Cap is per-model AND per client-metered-window: a genuine 1M request (with
+  // the context-1m beta) isn't throttled to the 200K cap, but a 1M-capable model
+  // the client meters against 200K (no beta) IS clamped so it can't cross the
+  // client's ~167K auto-compact threshold (#910 regression; MiniMax-M3).
   const scaledUsage = scaleUsageForClient(
     {
       input_tokens: usage.inputTokens,
@@ -4538,7 +4561,7 @@ function nonStreamHttpResponse(
       cache_read_input_tokens: usage.cacheReadInputTokens,
       cache_creation_input_tokens: usage.cacheCreationInputTokens,
     },
-    maxReportedUsageForModelID(resp.model),
+    maxReportedUsageForModelID(resp.model, longContext),
   );
   const scaledResp: GatewayResponse = {
     ...resp,
@@ -6087,7 +6110,13 @@ async function handlePassthrough(
       upstreamResponse,
       wireProtocol,
     );
-    return nonStreamHttpResponse(resp, req.protocol, req.stream);
+    return nonStreamHttpResponse(
+      resp,
+      req.protocol,
+      req.stream,
+      undefined,
+      requestEnablesLongContext(req),
+    );
   }
 
   // Non-streaming cross-protocol: accumulate + re-emit
@@ -6095,7 +6124,13 @@ async function handlePassthrough(
     upstreamResponse,
     wireProtocol,
   );
-  return nonStreamHttpResponse(resp, req.protocol, req.stream);
+  return nonStreamHttpResponse(
+    resp,
+    req.protocol,
+    req.stream,
+    undefined,
+    requestEnablesLongContext(req),
+  );
 }
 
 /**
@@ -7822,6 +7857,10 @@ async function handleConversationTurn(
     let recallDepth = 0;
     let currentModifiedReq = modifiedReq;
     const cumulativeUsage = { ...(resp.usage ?? ZERO_USAGE) };
+    // Whether this request opted into the 1M window (context-1m beta); gates the
+    // client-usage cap so a 1M-capable model the client meters against 200K is
+    // clamped below its ~167K auto-compact threshold (#910 regression).
+    const longContext = requestEnablesLongContext(req);
 
     while (hasRecallToolUse(currentResp) && recallDepth < MAX_RECALL_DEPTH) {
       recallDepth++;
@@ -7876,6 +7915,7 @@ async function handleConversationTurn(
           req.protocol,
           req.stream,
           { "x-lore-recall-invoked": "true" },
+          longContext,
         );
       }
 
@@ -7944,6 +7984,7 @@ async function handleConversationTurn(
           req.protocol,
           req.stream,
           { "x-lore-recall-invoked": "true" },
+          longContext,
         );
       }
 
@@ -7979,6 +8020,7 @@ async function handleConversationTurn(
           req.protocol,
           req.stream,
           { "x-lore-recall-invoked": "true" },
+          longContext,
         );
       }
 
@@ -8052,6 +8094,7 @@ async function handleConversationTurn(
       req.protocol,
       req.stream,
       recallHeaders,
+      longContext,
     );
   };
 
@@ -8094,9 +8137,11 @@ async function handleConversationTurn(
         : undefined,
       warningText,
       sessionState.sessionID,
-      // Cap usage against the model the CLIENT meters against (its requested
-      // model), so a 1M-context model isn't throttled to the 200K cap.
-      maxReportedUsageForModelID(req.model),
+      // Cap usage against the window the CLIENT meters against: the model's real
+      // window only when this request opted into it via the context-1m beta,
+      // else 200K — so a 1M-capable model the client meters against 200K can't
+      // cross its ~167K auto-compact threshold (#910 regression; MiniMax-M3).
+      maxReportedUsageForModelID(req.model, requestEnablesLongContext(req)),
     );
     // Translate to client's wire format if needed. When the upstream is
     // Anthropic but the client speaks OpenAI, wrap the Anthropic SSE stream.

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -2667,8 +2667,16 @@ function syntheticToolUseResponse(
     return anthropicSSE;
   }
 
-  // Non-streaming: use the existing format builders.
-  return nonStreamHttpResponse(resp, req.protocol);
+  // Non-streaming: use the existing format builders. (Synthetic tool_use carries
+  // ZERO usage, so the cap never bites — thread longContext anyway for uniform
+  // behavior and to stay correct if this response ever carries real usage.)
+  return nonStreamHttpResponse(
+    resp,
+    req.protocol,
+    req.stream,
+    undefined,
+    requestEnablesLongContext(req),
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -5700,7 +5708,13 @@ async function handleCompaction(
     return await handlePassthrough(req, config);
   }
   const resp = buildCompactionResponse(sessionID, summary, req.model);
-  return nonStreamHttpResponse(resp, req.protocol, req.stream);
+  return nonStreamHttpResponse(
+    resp,
+    req.protocol,
+    req.stream,
+    undefined,
+    requestEnablesLongContext(req),
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -8784,7 +8798,13 @@ function slashResponse(
     return anthropicSSE;
   }
 
-  return nonStreamHttpResponse(resp, req.protocol, req.stream);
+  return nonStreamHttpResponse(
+    resp,
+    req.protocol,
+    req.stream,
+    undefined,
+    requestEnablesLongContext(req),
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/test/compaction.test.ts
+++ b/packages/gateway/test/compaction.test.ts
@@ -15,6 +15,8 @@ import {
   AUTOCOMPACT_THRESHOLD,
   DEFAULT_MAX_REPORTED_USAGE,
   scaleUsageForClient,
+  clientMeteredContextWindow,
+  CLIENT_DEFAULT_CONTEXT_WINDOW,
 } from "../src/compaction";
 import type { GatewayRequest } from "../src/translate/types";
 
@@ -961,5 +963,91 @@ describe("scaleUsageForClient", () => {
       maxReportedUsageForModel(200_000, 64_000),
     );
     expect(scaled.input_tokens).toBe(150_300);
+  });
+});
+
+describe("clientMeteredContextWindow", () => {
+  test("clamps a >200K window to 200K when long-context beta is absent", () => {
+    expect(clientMeteredContextWindow(1_000_000, false)).toBe(
+      CLIENT_DEFAULT_CONTEXT_WINDOW,
+    );
+    expect(clientMeteredContextWindow(524_288, false)).toBe(200_000);
+  });
+
+  test("uses the model's real window when long-context beta is present", () => {
+    expect(clientMeteredContextWindow(1_000_000, true)).toBe(1_000_000);
+    expect(clientMeteredContextWindow(524_288, true)).toBe(524_288);
+  });
+
+  test("never inflates a sub-200K window, beta or not", () => {
+    expect(clientMeteredContextWindow(128_000, false)).toBe(128_000);
+    expect(clientMeteredContextWindow(128_000, true)).toBe(128_000);
+  });
+
+  test("CLIENT_DEFAULT_CONTEXT_WINDOW matches the historical 200K default", () => {
+    expect(CLIENT_DEFAULT_CONTEXT_WINDOW).toBe(200_000);
+    // The clamped 1M cap must equal the historical 200K-model default cap.
+    expect(
+      maxReportedUsageForModel(
+        clientMeteredContextWindow(1_000_000, false),
+        20_000,
+      ),
+    ).toBe(DEFAULT_MAX_REPORTED_USAGE);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #910 regression: a 1M-capable model the client meters against a 200K window
+// (e.g. MiniMax-M3 over the Anthropic wire, no context-1m beta) must NOT report
+// usage above the client's ~167K auto-compact threshold. Confirmed via Sentry:
+// MiniMax-M3 real input_tokens topped out at ~163K and Claude Code auto-compacted
+// ("Context limit reached") because the cap resolved to the model's real 1M
+// window (870_300) and scaling never engaged.
+// ---------------------------------------------------------------------------
+describe("client usage cap for a 1M model metered against 200K (#910 / MiniMax-M3)", () => {
+  // Mirror models.dev's MiniMax-M3 entry (context 1M, output 128K).
+  const MINIMAX_M3_WINDOW = 1_000_000;
+  const MINIMAX_M3_OUTPUT = 128_000;
+
+  // This mirrors pipeline.ts `maxReportedUsageForModelID(model, longContext)`.
+  function capFor(realWindow: number, output: number, longContext: boolean) {
+    return maxReportedUsageForModel(
+      clientMeteredContextWindow(realWindow, longContext),
+      output,
+    );
+  }
+
+  test("without context-1m beta: cap stays strictly under the 200K auto-compact threshold", () => {
+    const cap = capFor(MINIMAX_M3_WINDOW, MINIMAX_M3_OUTPUT, false);
+    expect(cap).toBe(150_300);
+    // The whole point: the reported total can never reach the client's trigger.
+    expect(cap).toBeLessThan(AUTOCOMPACT_THRESHOLD); // 167_000
+  });
+
+  test("with context-1m beta: full 1M cap is preserved (no throttle back to 200K)", () => {
+    const cap = capFor(MINIMAX_M3_WINDOW, MINIMAX_M3_OUTPUT, true);
+    expect(cap).toBe(870_300);
+    expect(cap).toBeGreaterThan(DEFAULT_MAX_REPORTED_USAGE);
+  });
+
+  test("usage above the 200K-window threshold is scaled back below it without the beta", () => {
+    // A turn whose real usage (250K) exceeds the client's 167K trigger. Clamped
+    // cap (150_300) scales it down so the client never auto-compacts. Under the
+    // pre-fix behavior (cap 870_300) 250K passes through untouched and trips the
+    // client — this asserts the clamp, not just an already-safe number.
+    const cap = capFor(MINIMAX_M3_WINDOW, MINIMAX_M3_OUTPUT, false);
+    const scaled = scaleUsageForClient(
+      { input_tokens: 250_000, output_tokens: 0 },
+      cap,
+    );
+    const total = scaled.input_tokens + scaled.output_tokens;
+    expect(total).toBeLessThan(AUTOCOMPACT_THRESHOLD);
+  });
+
+  test("with the beta, the same ~163K usage passes through unscaled (well under the 1M cap)", () => {
+    const cap = capFor(MINIMAX_M3_WINDOW, MINIMAX_M3_OUTPUT, true);
+    const usage = { input_tokens: 163_211, output_tokens: 0 };
+    // total (163_211) < cap (870_300) → returned unchanged.
+    expect(scaleUsageForClient(usage, cap)).toBe(usage);
   });
 });

--- a/packages/gateway/test/long-context-beta.test.ts
+++ b/packages/gateway/test/long-context-beta.test.ts
@@ -1,0 +1,64 @@
+import { describe, test, expect } from "vitest";
+import { requestEnablesLongContext } from "../src/compaction";
+import type { GatewayRequest } from "../src/translate/types";
+
+/**
+ * `requestEnablesLongContext` gates the client-usage cap: only when the request
+ * opts into the 1M window via the `context-1m` beta does the gateway report
+ * usage against the model's real (1M) window instead of clamping to 200K. See
+ * the #910 / MiniMax-M3 regression in compaction.test.ts.
+ */
+function makeRequest(rawHeaders: Record<string, string>): GatewayRequest {
+  return {
+    protocol: "anthropic",
+    model: "MiniMax-M3",
+    system: "",
+    messages: [],
+    tools: [],
+    stream: true,
+    maxTokens: 32_000,
+    metadata: {},
+    rawHeaders,
+  };
+}
+
+describe("requestEnablesLongContext", () => {
+  test("false when there is no anthropic-beta header (the MiniMax-M3 case)", () => {
+    expect(requestEnablesLongContext(makeRequest({}))).toBe(false);
+  });
+
+  test("true when anthropic-beta carries a context-1m token", () => {
+    expect(
+      requestEnablesLongContext(
+        makeRequest({ "anthropic-beta": "context-1m-2025-08-07" }),
+      ),
+    ).toBe(true);
+  });
+
+  test("true when context-1m sits alongside other betas", () => {
+    expect(
+      requestEnablesLongContext(
+        makeRequest({
+          "anthropic-beta":
+            "oauth-2025-04-20,context-1m-2025-08-07,fine-grained-tool-streaming-2025-05-14",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  test("header name match is case-insensitive", () => {
+    expect(
+      requestEnablesLongContext(
+        makeRequest({ "Anthropic-Beta": "context-1m-2025-08-07" }),
+      ),
+    ).toBe(true);
+  });
+
+  test("false for an unrelated beta (must not over-enable the 1M window)", () => {
+    expect(
+      requestEnablesLongContext(
+        makeRequest({ "anthropic-beta": "prompt-caching-2024-07-31" }),
+      ),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Symptom (reported by Onur over WhatsApp)

Using **MiniMax-M3** (a 1M-context model, served over MiniMax's Anthropic-compatible endpoint `api.minimax.io/anthropic`) from **Claude Code**:
- The context meter drops far lower than in opencode for the same model (opencode never below ~75–80% remaining; Claude Code showed 35% / 50% / 52%).
- **"Context limit reached · /compact or /clear to continue"** fired mid-session (during parallel exploration subagents) despite the 1M window.

## Root cause

The client-usage cap (anti-compaction "fake token count") is derived from the model's **real** context window via models.dev. MiniMax-M3 resolves to a **1M** window → cap `maxReportedUsageForModel(1_000_000, 128_000) = 870_300`.

But Claude Code meters usage — and triggers auto-compaction — against a **200K** window for any model it doesn't recognise (it only meters against a larger window when the request carries the `context-1m` beta, which it never sends for a third-party model). So:

- Claude Code's auto-compact threshold ≈ `200_000 − 20_000 − 13_000 = 167_000`.
- The gateway caps reported usage at 870_300 → scaling **never engages** → real usage (~163K) sails right up to the client's 167K trigger.
- opencode uses the real 1M window as the meter denominator, so the same usage looks tiny there → the cross-client discrepancy Onur saw.

This is a regression from #910 (per-model cap): the previous flat `DEFAULT_MAX_REPORTED_USAGE = 150_300` cap kept third-party models safely under the 167K threshold. Per-model is correct only when the client meters against the same (real) window — true for opencode and native Claude models, false for third-party models via Claude Code.

### Confirmed with production telemetry (Sentry `byk/loreai-gateway`)

MiniMax-M3 `gen_ai.usage.input_tokens` cluster at **156K–163K with nothing above ~167K** — the exact signature of Claude Code auto-compacting at its 200K-window threshold. Max observed: 163,211.

## Fix

Derive the cap from the window the **client** meters against, not the model's real window:

- `clientMeteredContextWindow(realWindow, longContext)` clamps to `CLIENT_DEFAULT_CONTEXT_WINDOW` (200K) unless `longContext` is set.
- `requestEnablesLongContext(req)` detects the `context-1m` beta on `anthropic-beta` — the exact signal Claude Code uses to switch its own meter/threshold to the model's real window.
- `maxReportedUsageForModelID(model, longContext)` and `nonStreamHttpResponse(..., longContext)` thread the flag through every response path that carries real usage (streaming, recall follow-ups, cross-protocol passthrough).

Net effect:
- MiniMax-M3 without `context-1m` → cap `150_300` (< 167K threshold) → no premature compaction, restores pre-#910 behaviour.
- Genuine 1M request **with** `context-1m` → cap `870_300` preserved (no throttle) → keeps the #910 benefit.

## Tests

- `compaction.test.ts`: `clientMeteredContextWindow` clamping + the #910/MiniMax-M3 regression (cap 150_300 without beta, 870_300 with beta; usage above 167K scaled back under it). **Mutation-verified**: reverting the clamp turns 4 tests red.
- `long-context-beta.test.ts`: `requestEnablesLongContext` header detection (absent / present / mixed betas / case-insensitive / unrelated beta).
- Full gateway suite green (2739 passed), typecheck + Biome clean.