### PR TITLE
fix(gateway): make cost-tracker auto-compact threshold client-metered-window aware

### DIFF
--- a/packages/gateway/src/cost-tracker.ts
+++ b/packages/gateway/src/cost-tracker.ts
@@ -15,6 +15,7 @@ import {
   AUTOCOMPACT_THRESHOLD,
   MAX_OUTPUT_RESERVE,
   autocompactThresholdForModel,
+  clientMeteredContextWindow,
 } from "./compaction";
 import {
   log,
@@ -746,20 +747,39 @@ const POST_COMPACTION_CONTEXT = 30_000;
 
 /**
  * Per-model auto-compact threshold for the counterfactual estimate. Mirrors
- * pipeline.ts `maxReportedUsageForModelID`, but returns the UNSCALED auto-compact
- * trigger point (what a host like Claude Code compacts at) rather than the 0.9×
- * client-usage reporting cap. An empty/unknown model falls back to the historical
- * 200K-model value ({@link AUTOCOMPACT_THRESHOLD}), preserving prior behavior.
+ * pipeline.ts `maxReportedUsageForModelID` (same client-metered-window
+ * semantics), but returns the UNSCALED auto-compact trigger point (what a host
+ * like Claude Code compacts at) rather than the 0.9× client-usage reporting cap.
+ * An empty/unknown model falls back to the historical 200K-model value
+ * ({@link AUTOCOMPACT_THRESHOLD}).
  *
- * Fixes #983: the hardcoded 167K constant assumed a 200K-context model, so the
- * "avoided compactions" estimate was wrong for other windows — e.g. a 1M-context
- * model was counted as compacting ~5.8× too often.
+ * `longContext` MUST reflect whether the session opted into the 1M window via
+ * the `context-1m` beta ({@link clientMeteredContextWindow}). This is the same
+ * gate the client-usage cap uses (#1214): the counterfactual "would the client
+ * have compacted?" question only makes sense against the window the CLIENT
+ * actually meters — which is 200K unless the request enables long context, even
+ * for a 1M-capable model (e.g. MiniMax-M3 over the Anthropic wire). Defaults to
+ * `false` (conservative 200K) so callers without the signal — and the dominant
+ * third-party-via-Claude-Code case — stay accurate.
+ *
+ * #983 correctly made this per-model, but assumed the client always meters
+ * against the model's real window. That over-counts nothing for genuine
+ * long-context sessions yet UNDER-counts avoided compactions for a 1M model the
+ * client meters against 200K (it assumed the host compacts at ~967K when it
+ * really compacts at ~167K). Gating on the beta reconciles both.
  */
-export function autocompactThresholdForModelID(modelID?: string): number {
+export function autocompactThresholdForModelID(
+  modelID?: string,
+  longContext = false,
+): number {
   if (!modelID) return AUTOCOMPACT_THRESHOLD;
   const entry = getModelEntrySync(modelID);
-  const contextWindow = entry.limit?.context ?? 200_000;
+  const realContextWindow = entry.limit?.context ?? 200_000;
   const maxOutput = entry.limit?.output ?? MAX_OUTPUT_RESERVE;
+  const contextWindow = clientMeteredContextWindow(
+    realContextWindow,
+    longContext,
+  );
   return autocompactThresholdForModel(contextWindow, maxOutput);
 }
 
@@ -857,6 +877,11 @@ export function updateShadowContext(
   workerModel: string,
   conversationModel?: string,
   ttl?: "5m" | "1h",
+  /** Whether the request opted into the 1M window via `context-1m` beta. Gates
+   *  the per-model auto-compact threshold (#1214), matching the client-usage cap:
+   *  a 1M-capable model the client meters against 200K compacts at ~167K, not
+   *  ~967K. Defaults to `false` (conservative 200K). */
+  longContext = false,
 ): void {
   const costs = getOrCreate(sessionID);
 
@@ -889,7 +914,10 @@ export function updateShadowContext(
   // size), where a shadow compaction would immediately re-trigger every turn —
   // report 0 for those rather than a runaway count (matches the prior 167K
   // constant's effective 0 for tiny models, while fixing large-window overcount).
-  const threshold = autocompactThresholdForModelID(conversationModel);
+  const threshold = autocompactThresholdForModelID(
+    conversationModel,
+    longContext,
+  );
   if (
     threshold > POST_COMPACTION_CONTEXT &&
     costs._shadowContextTokens > threshold
@@ -1201,16 +1229,18 @@ export function computeHistoricalEstimates(
       // This is only a fallback — sessions with persisted snapshots (the common
       // case) use real data from live tracking.
       const sessionTokens = sess.total_tokens;
-      // Per-model auto-compact threshold (#983): the hardcoded 167K constant
-      // assumed a 200K-context model and over/under-counted for other windows.
-      // Pass the *extracted* model (`m`, null when the session has no usable
-      // metadata) — NOT the pricing-defaulted `model`. `model` falls back to
-      // DEFAULT_ESTIMATION_MODEL (a 1M-window model) purely to price the
-      // compaction cost; adopting its 967K trigger for metadata-less sessions
-      // would silently drop their historical "avoided compactions" ~7×. An
-      // unknown model must keep the historical 167K trigger, matching the live
-      // path (which passes `conversationModel`, undefined when unknown) and the
-      // documented `autocompactThresholdForModelID(undefined)` contract.
+      // Per-model auto-compact threshold (#983), client-metered-window aware
+      // (#1214). This batched historical path has no per-session `context-1m`
+      // signal, so it uses the conservative default (longContext=false → 200K
+      // clamp): the client-metered threshold for any model it can't confirm was
+      // in long-context mode. This matches the client-usage cap default and the
+      // dominant real case (1M-capable third parties metered against 200K via
+      // Claude Code). New sessions are tracked live with the real beta signal
+      // and prefer the persisted count below, so this coarse fallback only
+      // affects legacy sessions with no snapshot. Pass the *extracted* model
+      // (`m`, null when the session has no usable metadata) — NOT the
+      // pricing-defaulted `model` (which falls back to a 1M-window estimation
+      // model purely to price the compaction cost).
       const avoidedCompactions = estimateAvoidedCompactions(
         sessionTokens,
         autocompactThresholdForModelID(m ?? undefined),

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -5209,6 +5209,7 @@ function postResponse(
       getWorkerModel(sessionState.lastUpstream)?.modelID ?? "unknown",
       req.model,
       sessionState.resolvedConversationTTL,
+      requestEnablesLongContext(req),
     );
 
     // Mark session dirty for periodic flush (gradient + warming + costs).

--- a/packages/gateway/test/cost-tracker-historical.test.ts
+++ b/packages/gateway/test/cost-tracker-historical.test.ts
@@ -160,20 +160,27 @@ describe("computeHistoricalEstimates (session_rollup read path #981)", () => {
     expect(est.sessions[0].sessionId).toBe("sess-live");
   });
 
-  // --- #983: the batch "avoided compactions" estimate is per-model ---
+  // --- #983 + #1214: the batch estimate is per-model AND client-metered-window ---
   // The counterfactual host compacts once at the model's auto-compact trigger,
-  // then every (trigger − 30K post-compaction) tokens thereafter. A 600K-token
-  // session therefore yields a model-dependent count:
-  //   • 1M-window model  → trigger 967K  → 600K < 967K            ⇒ 0
+  // then every (trigger − 30K post-compaction) tokens thereafter. The batch path
+  // has no per-session `context-1m` signal, so it meters against the conservative
+  // client default (200K clamp) — the window Claude Code uses unless a session
+  // opted into long context. A 600K-token session therefore yields:
+  //   • 1M-window model, no long-context signal → clamped to 200K → trigger 167K
+  //       → 1 + ⌊433K/137K⌋ ⇒ 4   (#1214: was 0 under the old real-1M assumption)
   //   • 200K-window model → trigger 178808 → 1 + ⌊421192/148808⌋  ⇒ 3
   //   • no usable metadata → trigger 167K (AUTOCOMPACT_THRESHOLD) ⇒ 4
-  // The pre-#983 hardcoded 167K constant would have reported 4 for every one.
+  // The pre-#983 hardcoded 167K constant would report 4 for every one; the
+  // pre-#1214 real-1M assumption would wrongly report 0 for the 1M model — the
+  // MiniMax-M3-via-Claude-Code under-count this fix closes.
 
-  test("batch estimate: a 1M-window model under its trigger avoids 0 compactions", () => {
+  test("batch estimate: a 1M model with no long-context signal is metered at 200K (#1214)", () => {
     const pid = ensureProject("/test/cost-historical/1m", "hist-1m");
     const sid = "sess-1m";
     const now = Date.now();
-    // 600K tokens, model = Sonnet 4 (1M window ⇒ 967K trigger).
+    // 600K tokens, model = Sonnet 4 (real 1M window). With no context-1m signal
+    // the batch path clamps to the 200K client-metered window (trigger 167K), so
+    // 600K ⇒ 1 + ⌊(600K−167K)/137K⌋ = 4.
     insertMsg(
       pid,
       sid,
@@ -190,10 +197,9 @@ describe("computeHistoricalEstimates (session_rollup read path #981)", () => {
       (x) => x.sessionId === sid,
     );
     expect(s).toBeDefined();
-    // 600K is below the 967K trigger ⇒ the host would not have compacted at
-    // all. The old 167K constant would wrongly report 4. Kills the batch-site
-    // "revert to constant" mutation.
-    expect(s?.avoidedCompactions).toBe(0);
+    // #1214: reverting the client-metered clamp in the batch path lets the real
+    // 1M window (967K trigger) back in, dropping this to 0 — kills that mutation.
+    expect(s?.avoidedCompactions).toBe(4);
   });
 
   test("batch estimate: a 200K-window model over its trigger avoids several", () => {

--- a/packages/gateway/test/cost-tracker-per-model-compaction.test.ts
+++ b/packages/gateway/test/cost-tracker-per-model-compaction.test.ts
@@ -59,7 +59,7 @@ describe("estimateAvoidedCompactions (#983)", () => {
   });
 });
 
-describe("autocompactThresholdForModelID (#983)", () => {
+describe("autocompactThresholdForModelID (#983, #1214)", () => {
   test("empty / missing model falls back to the historical 200K value", () => {
     expect(autocompactThresholdForModelID(undefined)).toBe(
       AUTOCOMPACT_THRESHOLD,
@@ -68,27 +68,64 @@ describe("autocompactThresholdForModelID (#983)", () => {
     expect(AUTOCOMPACT_THRESHOLD).toBe(167_000);
   });
 
-  test("a 1M-context model resolves to its own (much higher) trigger point", () => {
+  test("a 1M-context model WITH the context-1m beta uses its real 967K trigger", () => {
     // claude-opus-4* fallback: context 1M, output 128K (capped at 20K reserve).
-    expect(autocompactThresholdForModelID("claude-opus-4-6")).toBe(967_000);
+    // longContext=true ⇒ client meters against the real 1M window.
+    expect(autocompactThresholdForModelID("claude-opus-4-6", true)).toBe(
+      967_000,
+    );
   });
 
-  test("an unknown named model uses the 200K/8K fallback limits", () => {
+  test("a 1M-context model WITHOUT the beta is clamped to the 200K trigger (#1214)", () => {
+    // The MiniMax-M3-via-Claude-Code case: the client meters a 1M-capable model
+    // it doesn't recognise against 200K, so it compacts at ~167K, not ~967K.
+    expect(autocompactThresholdForModelID("claude-opus-4-6")).toBe(167_000);
+    expect(autocompactThresholdForModelID("claude-opus-4-6", false)).toBe(
+      167_000,
+    );
+  });
+
+  test("an unknown named model uses the 200K/8K fallback limits (clamp is a no-op)", () => {
     // fallback entry: context 200K, output 8_192 → 200K − 8_192 − 13K.
+    // Already a 200K window, so the client-metered clamp changes nothing.
     expect(autocompactThresholdForModelID("totally-unknown-xyz")).toBe(178_808);
+    expect(autocompactThresholdForModelID("totally-unknown-xyz", true)).toBe(
+      178_808,
+    );
   });
 });
 
-describe("updateShadowContext uses the per-model threshold (#983)", () => {
+describe("updateShadowContext uses the client-metered threshold (#983, #1214)", () => {
   // Drive a session to ~600K uncompressed shadow tokens over two turns, then
   // read the counterfactual compaction count. 600K sits between the 200K-model
-  // trigger (167K) and the 1M-model trigger (967K), so the model identity flips
-  // the outcome — proving the threshold is actually per-model, not hardcoded.
-  function driveTo600K(sessionID: string, conversationModel?: string): void {
+  // trigger (167K) and the 1M-model trigger (967K), so the client-metered window
+  // flips the outcome — proving the threshold tracks the window the client
+  // actually meters, not just the model's real window.
+  function driveTo600K(
+    sessionID: string,
+    conversationModel?: string,
+    longContext = false,
+  ): void {
     recordConversationCost(sessionID, PRICING_MODEL, USAGE); // turns → 1
-    updateShadowContext(sessionID, 100_000, 500_000, WORKER, conversationModel);
+    updateShadowContext(
+      sessionID,
+      100_000,
+      500_000,
+      WORKER,
+      conversationModel,
+      undefined,
+      longContext,
+    );
     recordConversationCost(sessionID, PRICING_MODEL, USAGE); // turns → 2
-    updateShadowContext(sessionID, 120_000, 10_000, WORKER, conversationModel);
+    updateShadowContext(
+      sessionID,
+      120_000,
+      10_000,
+      WORKER,
+      conversationModel,
+      undefined,
+      longContext,
+    );
   }
 
   test("a 200K-class (default) model counts a shadow compaction at 600K", () => {
@@ -98,11 +135,23 @@ describe("updateShadowContext uses the per-model threshold (#983)", () => {
     ).toBe(1);
   });
 
-  test("a 1M-context model has NOT compacted at 600K", () => {
-    driveTo600K("s-opus", "claude-opus-4-6");
-    // The old hardcoded 167K constant would have wrongly counted 1 here.
+  test("a 1M-context model in long-context mode (beta) has NOT compacted at 600K", () => {
+    driveTo600K("s-opus", "claude-opus-4-6", true);
+    // With the context-1m beta the client meters against the real 1M window
+    // (967K trigger), so 600K has not compacted. The old hardcoded 167K constant
+    // would have wrongly counted 1 here.
     expect(getSessionCosts("s-opus")?.counterfactual.avoidedCompactions).toBe(
       0,
     );
+  });
+
+  test("a 1M-context model metered against 200K (no beta) DOES compact at 600K (#1214)", () => {
+    // MiniMax-M3-via-Claude-Code: the 1M model is metered against 200K, so it
+    // compacts at ~167K and 600K counts a shadow compaction. This is the case
+    // #983's real-window assumption silently under-counted to 0.
+    driveTo600K("s-minimax", "claude-opus-4-6", false);
+    expect(
+      getSessionCosts("s-minimax")?.counterfactual.avoidedCompactions,
+    ).toBe(1);
   });
 });


### PR DESCRIPTION
Follow-up to #1214 (the MiniMax-M3 "Context limit reached" fix). Closes the same regression class in the **cost dashboard's counterfactual estimate**.

## Problem

`autocompactThresholdForModelID` in `cost-tracker.ts` estimates *"how many times would the client have auto-compacted without Lore?"* — the "Avoided compactions" dashboard number. It derived the trigger from the model's **real** context window.

#983 correctly made this per-model, but assumed the client always meters against the model's real window. That holds for genuine long-context sessions, but **under-counts** for a 1M-capable model the client meters against 200K — e.g. MiniMax-M3 over the Anthropic wire with no `context-1m` beta. It assumed the host compacts at ~967K when Claude Code really compacts at ~167K, so avoided compactions were silently dropped (~7×). Same root cause as the #1214 client-usage cap.

## Fix

Gate the threshold on the **same signal** as the #1214 cap — the window the *client* meters against:

- `autocompactThresholdForModelID(modelID, longContext = false)` clamps the window via `clientMeteredContextWindow` (200K unless the request opts into `context-1m`).
- `updateShadowContext(..., longContext = false)` threads it; the live pipeline call passes `requestEnablesLongContext(req)` — the accurate, common path.
- The **batched historical** path has no per-session beta signal, so it uses the conservative 200K default. This matches the cap default and the dominant third-party-via-Claude-Code case. Live-tracked sessions persist their real, beta-aware counterfactual count, and the historical aggregation **prefers** that persisted count — so the coarse batch fallback only affects legacy sessions with no snapshot.

Net: consistent semantics with #1214 everywhere. A 1M model with the `context-1m` beta still uses its real 967K trigger; without it, 167K.

## Tests

- `cost-tracker-per-model-compaction.test.ts`: added beta-on (967K) vs beta-off (167K clamp) cases for both `autocompactThresholdForModelID` and `updateShadowContext` (incl. the MiniMax "1M metered at 200K DOES compact at 600K" case). Mutation-verified: reverting the clamp turns the two #1214 cases red.
- `cost-tracker-historical.test.ts`: updated the batch 1M-model case to the clamped semantics (4, was 0 under the real-1M assumption) with a comment explaining the reconciliation; reverting the clamp drops it back to 0 (kills that mutation).
- Full gateway suite green (2741 passed), typecheck + Biome clean.

## Note
This is the non-blocking follow-up NIT surfaced in #1214's adversarial review ("make cost-tracker client-metered-window + beta aware for consistency").