### PR TITLE
feat(cli): lore log / lore diff — surface knowledge version history (#962)

### DIFF
--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -2858,6 +2858,62 @@ export function logicalIdOf(id: string): string {
   return row?.logical_id ?? id;
 }
 
+/** A single stored version of a knowledge entry (for `lore log` / `lore diff`, #962). */
+export type KnowledgeVersion = {
+  id: string;
+  logical_id: string;
+  version: number;
+  /** 1 = the current live/deleted head; 0 = a superseded prior version. */
+  is_current: number;
+  /** 1 = a death-cert (deleted) version. */
+  is_deleted: number;
+  category: string;
+  title: string;
+  content: string;
+  created_at: number;
+  updated_at: number;
+  updated_by: string | null;
+};
+
+const VERSION_COLS =
+  "id, logical_id, version, is_current, is_deleted, category, title, content, created_at, updated_at, updated_by";
+
+/**
+ * All stored versions of a knowledge entry, oldest→newest, resolving any version
+ * id OR logical_id via {@link logicalIdOf}. Reads the BASE `knowledge` table (not
+ * `knowledge_current`) so it returns SUPERSEDED and deleted versions too — this is
+ * the append-only history surface (#962). Bounded by compaction (#909): superseded
+ * versions past the retention window are gone by design, so this is the kept window,
+ * not an unbounded log. Empty when the id is unknown.
+ */
+export function versionHistory(id: string): KnowledgeVersion[] {
+  const logicalId = logicalIdOf(id);
+  return db()
+    .query(
+      `SELECT ${VERSION_COLS} FROM knowledge WHERE logical_id = ? ORDER BY version ASC`,
+    )
+    .all(logicalId) as KnowledgeVersion[];
+}
+
+/**
+ * Recent knowledge version-writes for a project, newest first — one row per stored
+ * version (each version = a change). For `lore log --project` (#962). Reads the BASE
+ * table so superseded/deleted versions appear in the timeline. Scoped to the
+ * project's own rows (project_id = pid); global/cross-project entries are viewable
+ * per-entry via `lore log <id>`.
+ */
+export function recentKnowledgeChanges(
+  projectId: string,
+  limit = 20,
+): KnowledgeVersion[] {
+  return db()
+    .query(
+      `SELECT ${VERSION_COLS} FROM knowledge WHERE project_id = ?
+       ORDER BY updated_at DESC, version DESC LIMIT ?`,
+    )
+    .all(projectId, limit) as KnowledgeVersion[];
+}
+
 /**
  * Read the worker source attribution for a knowledge entry. Returns null for
  * legacy entries created before v35 (no attribution recorded) or for entries

--- a/packages/core/test/ltm-history.test.ts
+++ b/packages/core/test/ltm-history.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "vitest";
+import { projectId } from "../src/db";
+import * as ltm from "../src/ltm";
+
+const PROJECT = "/test/962/history";
+
+describe("knowledge version history (#962)", () => {
+  test("versionHistory returns every version oldest→newest, resolving a version id OR logical_id", () => {
+    const id = ltm.create({
+      projectPath: PROJECT,
+      scope: "project",
+      category: "pattern",
+      title: "T1",
+      content: "c1",
+    });
+    ltm.update(id, { content: "c2" }); // v2 (content-only: title/category carry forward)
+    ltm.update(id, { content: "c3" }); // v3
+
+    const h = ltm.versionHistory(id);
+    expect(h.map((v) => v.version)).toEqual([1, 2, 3]);
+    expect(h.map((v) => v.content)).toEqual(["c1", "c2", "c3"]);
+    expect(h[0].is_current).toBe(0); // superseded
+    expect(h[2].is_current).toBe(1); // head
+    expect(h.every((v) => v.title === "T1")).toBe(true); // carried forward
+
+    // Resolves by logical_id AND by any SUPERSEDED version id (logicalIdOf).
+    const logical = h[0].logical_id;
+    expect(ltm.versionHistory(logical).map((v) => v.version)).toEqual([
+      1, 2, 3,
+    ]);
+    expect(ltm.versionHistory(h[0].id).map((v) => v.version)).toEqual([
+      1, 2, 3,
+    ]);
+  });
+
+  test("versionHistory reflects a title/category change (appendVersion path)", () => {
+    const id = ltm.create({
+      projectPath: PROJECT,
+      scope: "project",
+      category: "pattern",
+      title: "Old",
+      content: "x1",
+    });
+    ltm.appendVersion(ltm.logicalIdOf(id), {
+      title: "New",
+      category: "gotcha",
+      content: "x2",
+    });
+    const h = ltm.versionHistory(id);
+    expect(h.map((v) => v.title)).toEqual(["Old", "New"]);
+    expect(h.map((v) => v.category)).toEqual(["pattern", "gotcha"]);
+  });
+
+  test("versionHistory includes the death-cert head after remove()", () => {
+    const id = ltm.create({
+      projectPath: PROJECT,
+      scope: "project",
+      category: "pattern",
+      title: "D",
+      content: "d1",
+    });
+    ltm.remove(id);
+    const h = ltm.versionHistory(id);
+    const head = h[h.length - 1];
+    expect(head.is_deleted).toBe(1);
+    expect(head.is_current).toBe(1);
+  });
+
+  test("versionHistory is empty for an unknown id", () => {
+    expect(ltm.versionHistory("does-not-exist")).toEqual([]);
+  });
+
+  test("recentKnowledgeChanges returns the project's version rows newest-first, limited", () => {
+    const pid = projectId(PROJECT);
+    expect(pid).toBeTruthy();
+    const rows = ltm.recentKnowledgeChanges(pid as string, 50);
+    expect(rows.length).toBeGreaterThan(0);
+    for (let i = 1; i < rows.length; i++)
+      expect(rows[i - 1].updated_at).toBeGreaterThanOrEqual(rows[i].updated_at);
+    expect(
+      ltm.recentKnowledgeChanges(pid as string, 1).length,
+    ).toBeLessThanOrEqual(1);
+  });
+});

--- a/packages/gateway/src/cli/help.ts
+++ b/packages/gateway/src/cli/help.ts
@@ -34,6 +34,9 @@ Commands:
   import              Import knowledge from prior AI agent conversations
   data <subcommand>   Manage stored data (list, show, clear, delete)
   recall <query>      Search project memory from the command line
+  log [<id>]          Show knowledge version history (an entry's timeline, or
+                       recent changes across the project)
+  diff <id>           Show what changed between two versions of a knowledge entry
   login               Sign in to your Folk Lore account (GitHub or --email)
   logout              Sign out and clear the local session
   whoami              Show the signed-in Folk Lore account
@@ -168,6 +171,9 @@ Examples:
   lore logs -n 100              # Show last 100 lines
   lore logs --path              # Print log file path
   lore recall "error handling"  # Search project memory from CLI
+  lore log                      # Recent knowledge changes in this project
+  lore log <id>                 # Version timeline for one knowledge entry
+  lore diff <id>                # What changed (latest superseded → current)
   lore login                    # Sign in to Folk Lore with GitHub (browser)
   lore login --no-browser       # Headless GitHub sign-in (SSH / remote box)
   lore login --email me@x.com   # Sign in with an email OTP code (needs SMTP)

--- a/packages/gateway/src/cli/history-cmd.ts
+++ b/packages/gateway/src/cli/history-cmd.ts
@@ -1,0 +1,225 @@
+/**
+ * CLI `lore log` / `lore diff` — a read-only view of the append-only knowledge
+ * version history (#962). We already store the full `logical_id + version`
+ * trajectory (A2, #823); these surface it. Runs WITHOUT the gateway — reads the
+ * local SQLite DB directly (like `lore data`), so no LLM client is needed.
+ *
+ *   lore log [<id>] [--project <path>] [--limit <n>] [--json]
+ *     <id>        show the version timeline for one entry (version id or logical_id)
+ *     (no id)     show recent knowledge changes across the project
+ *   lore diff <id> [<v1> <v2>] [--json]
+ *     default     latest superseded version → current
+ *     <v1> <v2>   diff two explicit version numbers
+ *
+ * The history is bounded by compaction (#909): superseded versions past the
+ * retention window are gone by design, so `log` shows the kept window.
+ */
+import { resolve } from "node:path";
+
+type KnowledgeVersion = import("@loreai/core").ltm.KnowledgeVersion;
+
+function fmtTs(ms: number): string {
+  // Local YYYY-MM-DD HH:MM — compact + sortable in the terminal.
+  const d = new Date(ms);
+  const p = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())} ${p(d.getHours())}:${p(d.getMinutes())}`;
+}
+
+function marker(v: KnowledgeVersion): string {
+  if (v.is_deleted) return "deleted";
+  return v.is_current ? "current" : "superseded";
+}
+
+const shortId = (id: string) => id.slice(0, 8);
+const author = (v: KnowledgeVersion) => v.updated_by || "—";
+
+/**
+ * A `--limit` → positive integer, defaulting for missing/garbage. Guards against a
+ * NaN/fractional value reaching a SQL `LIMIT ?` bind (node:sqlite rejects it with a
+ * raw "datatype mismatch" that would otherwise dump a stack).
+ */
+function parseLimit(v: unknown, def: number): number {
+  if (v === undefined) return def;
+  const n = Number(v);
+  if (Number.isInteger(n) && n > 0) return n;
+  console.error(`Ignoring invalid --limit "${v}" (using ${def}).`);
+  return def;
+}
+
+/** Minimal LCS line diff → unified-ish `-`/`+`/` ` prefixed lines. Exported for tests. */
+export type DiffLine = { kind: " " | "-" | "+"; text: string };
+export function lineDiff(a: string, b: string): DiffLine[] {
+  const x = a.split("\n");
+  const y = b.split("\n");
+  const n = x.length;
+  const m = y.length;
+  // dp[i][j] = LCS length of x[i:] and y[j:].
+  const dp: number[][] = Array.from({ length: n + 1 }, () =>
+    new Array(m + 1).fill(0),
+  );
+  for (let i = n - 1; i >= 0; i--)
+    for (let j = m - 1; j >= 0; j--)
+      dp[i][j] =
+        x[i] === y[j]
+          ? dp[i + 1][j + 1] + 1
+          : Math.max(dp[i + 1][j], dp[i][j + 1]);
+  const out: DiffLine[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < n && j < m) {
+    if (x[i] === y[j]) {
+      out.push({ kind: " ", text: x[i] });
+      i++;
+      j++;
+    } else if (dp[i + 1][j] >= dp[i][j + 1]) {
+      out.push({ kind: "-", text: x[i] });
+      i++;
+    } else {
+      out.push({ kind: "+", text: y[j] });
+      j++;
+    }
+  }
+  while (i < n) out.push({ kind: "-", text: x[i++] });
+  while (j < m) out.push({ kind: "+", text: y[j++] });
+  return out;
+}
+
+function renderTimeline(versions: KnowledgeVersion[]): void {
+  const current = versions[versions.length - 1];
+  console.log(current.title);
+  console.log(
+    `logical ${shortId(current.logical_id)} · ${versions.length} version${versions.length === 1 ? "" : "s"}\n`,
+  );
+  // Newest first.
+  for (const v of [...versions].reverse()) {
+    const retitled = v.title !== current.title ? `  "${v.title}"` : "";
+    console.log(
+      `  v${v.version}  ${fmtTs(v.updated_at)}  ${marker(v).padEnd(10)}  ${author(v).padEnd(12)}  ${v.category}${retitled}`,
+    );
+  }
+}
+
+function renderRecent(rows: KnowledgeVersion[], projectPath: string): void {
+  console.log(`Recent knowledge changes · ${projectPath}\n`);
+  if (rows.length === 0) {
+    console.log("  (none)");
+    return;
+  }
+  for (const v of rows) {
+    console.log(
+      `  ${fmtTs(v.updated_at)}  v${v.version}  ${marker(v).padEnd(10)}  ${v.title}  ·  ${author(v)}`,
+    );
+  }
+}
+
+export async function commandLog(
+  positionals: string[],
+  values: Record<string, unknown>,
+): Promise<void> {
+  const { ltm, projectId } = await import("@loreai/core");
+  const asJson = !!values.json;
+  const id = positionals[0];
+
+  // `lore log <id>` — the version timeline of one entry.
+  if (id) {
+    const versions = ltm.versionHistory(id);
+    if (versions.length === 0) {
+      console.error(`No knowledge entry found for id: ${id}`);
+      process.exit(1);
+    }
+    if (asJson) {
+      console.log(JSON.stringify(versions, null, 2));
+      return;
+    }
+    renderTimeline(versions);
+    return;
+  }
+
+  // `lore log [--project <path>]` — recent changes across the project.
+  const projectPath = resolve((values.project as string) ?? process.cwd());
+  const pid = projectId(projectPath);
+  if (!pid) {
+    console.error(
+      `No tracked project at ${projectPath} yet (nothing has been stored here).`,
+    );
+    process.exit(1);
+  }
+  const rows = ltm.recentKnowledgeChanges(pid, parseLimit(values.limit, 20));
+  if (asJson) {
+    console.log(JSON.stringify(rows, null, 2));
+    return;
+  }
+  renderRecent(rows, projectPath);
+}
+
+function renderDiff(a: KnowledgeVersion, b: KnowledgeVersion): void {
+  console.log(b.title);
+  console.log(
+    `logical ${shortId(b.logical_id)} · v${a.version} → v${b.version}   (${fmtTs(a.updated_at)} → ${fmtTs(b.updated_at)})\n`,
+  );
+  if (a.category !== b.category)
+    console.log(`category: ${a.category} → ${b.category}`);
+  if (a.title !== b.title) console.log(`title:    ${a.title} → ${b.title}`);
+  if (a.is_deleted !== b.is_deleted)
+    console.log(
+      b.is_deleted ? "(entry deleted in this version)" : "(entry restored)",
+    );
+  console.log();
+  for (const l of lineDiff(a.content, b.content))
+    console.log(`${l.kind} ${l.text}`);
+}
+
+export async function commandDiff(
+  positionals: string[],
+  values: Record<string, unknown>,
+): Promise<void> {
+  const { ltm } = await import("@loreai/core");
+  const id = positionals[0];
+  if (!id) {
+    console.error(`Usage: lore diff <id> [<v1> <v2>] [--json]
+
+  <id>        a knowledge entry (version id or logical_id)
+  <v1> <v2>   two version numbers to compare (default: latest superseded → current)`);
+    process.exit(1);
+  }
+  const versions = ltm.versionHistory(id);
+  if (versions.length === 0) {
+    console.error(`No knowledge entry found for id: ${id}`);
+    process.exit(1);
+  }
+
+  let a: KnowledgeVersion | undefined;
+  let b: KnowledgeVersion | undefined;
+  if (positionals[1] !== undefined && positionals[2] !== undefined) {
+    const v1 = Number(positionals[1]);
+    const v2 = Number(positionals[2]);
+    a = versions.find((v) => v.version === v1);
+    b = versions.find((v) => v.version === v2);
+    if (!a || !b) {
+      console.error(
+        `Version not found. Available: ${versions.map((v) => v.version).join(", ")}`,
+      );
+      process.exit(1);
+    }
+  } else {
+    if (versions.length < 2) {
+      console.log("Only one version — nothing to diff.");
+      return;
+    }
+    // Default: latest superseded → current (versions are sorted ascending).
+    a = versions[versions.length - 2];
+    b = versions[versions.length - 1];
+  }
+
+  if (values.json) {
+    console.log(
+      JSON.stringify(
+        { from: a, to: b, diff: lineDiff(a.content, b.content) },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+  renderDiff(a, b);
+}

--- a/packages/gateway/src/cli/main.ts
+++ b/packages/gateway/src/cli/main.ts
@@ -437,6 +437,18 @@ export async function _cli(): Promise<void> {
         break;
       }
 
+      case "log": {
+        const { commandLog } = await import("./history-cmd");
+        await commandLog(rest, values as Record<string, unknown>);
+        break;
+      }
+
+      case "diff": {
+        const { commandDiff } = await import("./history-cmd");
+        await commandDiff(rest, values as Record<string, unknown>);
+        break;
+      }
+
       case "login": {
         const { commandLogin } = await import("./login");
         await commandLogin(rest, values as Record<string, unknown>);
@@ -510,6 +522,8 @@ export async function _cli(): Promise<void> {
               "doctor",
               "data",
               "recall",
+              "log",
+              "diff",
               "login",
               "logout",
               "whoami",

--- a/packages/gateway/test/history-cmd.test.ts
+++ b/packages/gateway/test/history-cmd.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { ltm } from "@loreai/core";
+import { commandDiff, commandLog, lineDiff } from "../src/cli/history-cmd";
+
+describe("lore log / lore diff commands (#962)", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  function captureLog(): string[] {
+    const out: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((...a: unknown[]) => {
+      out.push(a.map(String).join(" "));
+    });
+    return out;
+  }
+
+  test("commandLog <id> renders the version timeline", async () => {
+    const id = ltm.create({
+      projectPath: "/test/962/cmd",
+      scope: "project",
+      category: "pattern",
+      title: "Cmd Entry",
+      content: "v1 body",
+    });
+    ltm.update(id, { content: "v2 body" });
+    const out = captureLog();
+    await commandLog([id], {});
+    const text = out.join("\n");
+    expect(text).toContain("Cmd Entry");
+    expect(text).toContain("v2");
+    expect(text).toContain("v1");
+    expect(text).toContain("current");
+  });
+
+  test("commandLog <id> --json emits the raw version array", async () => {
+    const id = ltm.create({
+      projectPath: "/test/962/cmd",
+      scope: "project",
+      category: "pattern",
+      title: "JSON Entry",
+      content: "only",
+    });
+    const out = captureLog();
+    await commandLog([id], { json: true });
+    const parsed = JSON.parse(out.join("\n"));
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed[0].title).toBe("JSON Entry");
+  });
+
+  test("commandDiff default picks latest superseded → current (not the first version)", async () => {
+    const id = ltm.create({
+      projectPath: "/test/962/cmd",
+      scope: "project",
+      category: "pattern",
+      title: "Multi",
+      content: "base",
+    });
+    ltm.update(id, { content: "second" }); // v2
+    ltm.update(id, { content: "third" }); // v3 (current)
+    const out = captureLog();
+    await commandDiff([id], {});
+    const text = out.join("\n");
+    expect(text).toContain("v2 → v3"); // default = latest superseded (v2) → current (v3)
+    expect(text).toContain("- second");
+    expect(text).toContain("+ third");
+    expect(text).not.toContain("base"); // v1 content is NOT involved
+  });
+
+  test("commandDiff <id> renders a content diff (default latest→current)", async () => {
+    const id = ltm.create({
+      projectPath: "/test/962/cmd",
+      scope: "project",
+      category: "pattern",
+      title: "Diffable",
+      content: "alpha\nbeta",
+    });
+    ltm.update(id, { content: "alpha\ngamma" });
+    const out = captureLog();
+    await commandDiff([id], {});
+    const text = out.join("\n");
+    expect(text).toContain("- beta");
+    expect(text).toContain("+ gamma");
+    expect(text).toContain(" alpha"); // context line retained
+  });
+});
+
+describe("lineDiff (lore diff, #962)", () => {
+  test("identical content → all context lines", () => {
+    const d = lineDiff("a\nb\nc", "a\nb\nc");
+    expect(d.every((l) => l.kind === " ")).toBe(true);
+    expect(d.map((l) => l.text)).toEqual(["a", "b", "c"]);
+  });
+
+  test("classifies added / removed / context lines", () => {
+    const d = lineDiff("a\nb\nc", "a\nB\nc\nd");
+    expect(d.filter((l) => l.kind === "-").map((l) => l.text)).toEqual(["b"]);
+    expect(d.filter((l) => l.kind === "+").map((l) => l.text)).toEqual([
+      "B",
+      "d",
+    ]);
+    expect(d.filter((l) => l.kind === " ").map((l) => l.text)).toEqual([
+      "a",
+      "c",
+    ]);
+  });
+
+  test("invariant: keeping context+additions reconstructs the target", () => {
+    const a = "one\ntwo\nthree";
+    const b = "one\ntwo point five\nthree\nfour";
+    const d = lineDiff(a, b);
+    expect(d.filter((l) => l.kind !== "-").map((l) => l.text)).toEqual(
+      b.split("\n"),
+    );
+    // …and keeping context+removals reconstructs the source.
+    expect(d.filter((l) => l.kind !== "+").map((l) => l.text)).toEqual(
+      a.split("\n"),
+    );
+  });
+});


### PR DESCRIPTION
Closes #962 (v0, read-only).

## What
We already store the full append-only `logical_id + version` trajectory (A2, #823), now bounded by compaction (#909) — but never exposed it. This surfaces it as a **read-only, gateway-free** version-control view:

```
lore log [<id>]              # <id>: version timeline for one entry
                             # (no id): recent knowledge changes across the project
lore diff <id> [<v1> <v2>]   # what changed between two versions
                             # (default: latest superseded → current)
  --project <path>  --limit <n>  --json
```

## Why
Per the issue: competitors (ByteRover, Letta) market **git-semantic / versioned memory** as a headline. We own the harder substrate (automatic, transparent capture) but never let you *look* at it. Near-zero new storage cost; closes the visibility gap. The `logical_id + version` history **is** the knowledge-evolution trajectory → subsumes #495.

## How
- **core** (`ltm.ts`): `versionHistory(id)` — resolves a version id **or** logical_id via `logicalIdOf`, reads the **base** `knowledge` table so **superseded + death-cert** versions appear; `recentKnowledgeChanges(projectId, limit)`; `KnowledgeVersion` type.
- **gateway**: `cli/history-cmd.ts` (`commandLog`/`commandDiff` + a small LCS `lineDiff`), wired into `main.ts` dispatch + `knownCommands`; `help.ts` entries. Reads the local SQLite DB directly (like `lore data`); flags reuse the already-declared `OPTIONS` (no undeclared-flag gotcha).
- **Respects compaction**: shows the KEPT window, not an unbounded log.

## Tests
- core: `versionHistory` ordering + superseded-id/logical_id resolution + death-cert head + unknown-id → []; `recentKnowledgeChanges` newest-first + limit; a title/category-change (`appendVersion`) case.
- gateway: `lineDiff` (context/add/remove classification + reconstruct-source/target invariant); command-level render smoke for `log` (+ `--json`) and `diff`.
- Full core suite (127 files, 2709) green; typecheck + lint clean.

## Non-goals (v0)
Branch/merge/conflict UX (sync convergence handles that), mutating history, web-dashboard timeline (stretch). Remote-gateway delegation (reads local DB) — follow-up if needed.