### PR TITLE
fix(gateway): don't flood WARN logs on expected orphan pull-skips

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist-vendor/
 .sea-staging/
 .node-cache/
 local_cache/
+.cache/
 *.tgz
 coverage/
 *.db

--- a/packages/gateway/src/cli/sync-cmd.ts
+++ b/packages/gateway/src/cli/sync-cmd.ts
@@ -471,6 +471,9 @@ async function runSync(header = "Syncing…"): Promise<void> {
     `Synced: pushed ${r.pushed}, pulled ${r.pulled}` +
       (r.conflicts
         ? `, ${r.conflicts} conflict(s) resolved (remote wins)`
+        : "") +
+      (r.skipped
+        ? `, ${r.skipped} skipped (couldn't apply locally — mostly records referencing data beyond your plan's sync cap)`
         : ""),
   );
   if (r.quotaHit) {

--- a/packages/gateway/src/sync.ts
+++ b/packages/gateway/src/sync.ts
@@ -33,6 +33,12 @@ export interface SyncResult {
   pushed: number;
   pulled: number;
   conflicts: number;
+  /**
+   * Pulled rows skipped because they violate a LOCAL constraint the FK-less
+   * remote doesn't enforce (mostly orphan refs/aliases whose entity wasn't synced
+   * under the plan cap). Recorded to `sync_conflicts`; surfaced in the CLI summary.
+   */
+  skipped: number;
   /** Tables whose upload was paused this cycle by a quota limit. */
   quotaHit?: { table: string; message: string };
   /** Set when not logged in / session invalid (caller should prompt login). */
@@ -105,6 +111,26 @@ export function isSqliteConstraintError(e: unknown): boolean {
     code.startsWith("SQLITE_CONSTRAINT") ||
     (code === "ERR_SQLITE_ERROR" &&
       /constraint/i.test(`${errstr} ${e.message}`))
+  );
+}
+
+/**
+ * The FK subset of {@link isSqliteConstraintError}: an orphan whose parent row
+ * wasn't synced (an entity beyond the free-tier cap). This is the EXPECTED,
+ * high-volume skip on a fresh device — so it's counted + recorded to
+ * `sync_conflicts` but NOT logged per row (a WARN-per-orphan flood would drown
+ * the console and inflate the Sentry warning stream). node:sqlite reports FK as
+ * errcode 787; bun:sqlite as `SQLITE_CONSTRAINT_FOREIGNKEY`. A rarer non-FK
+ * constraint skip (UNIQUE/CHECK/NOT NULL) stays visible — see the callers.
+ */
+function isForeignKeyError(e: unknown): boolean {
+  if (!(e instanceof Error)) return false;
+  const code = String((e as { code?: string }).code ?? "");
+  const errcode = (e as { errcode?: number }).errcode;
+  return (
+    code === "SQLITE_CONSTRAINT_FOREIGNKEY" ||
+    errcode === 787 ||
+    /FOREIGN KEY constraint failed/i.test(e.message)
   );
 }
 
@@ -227,7 +253,7 @@ export async function pushOnce(
   client: SupabaseClient,
   onProgress?: SyncProgressFn,
 ): Promise<SyncResult> {
-  const res: SyncResult = { pushed: 0, pulled: 0, conflicts: 0 };
+  const res: SyncResult = { pushed: 0, pulled: 0, conflicts: 0, skipped: 0 };
   const enc = makeEncryptionResolver();
   for (const meta of syncData.syncedTables("basic")) {
     // Pull-only tables (e.g. profiles) are server-authoritative: the client only
@@ -548,7 +574,7 @@ export async function pullOnce(
   client: SupabaseClient,
   onProgress?: SyncProgressFn,
 ): Promise<SyncResult> {
-  const res: SyncResult = { pushed: 0, pulled: 0, conflicts: 0 };
+  const res: SyncResult = { pushed: 0, pulled: 0, conflicts: 0, skipped: 0 };
   const encResolver = makeEncryptionResolver();
 
   for (const meta of syncData.syncedTables("basic")) {
@@ -579,6 +605,7 @@ export async function pullOnce(
     }
 
     const idc = meta.idColumns[0];
+    const skippedBefore = res.skipped;
     try {
       for (;;) {
         const sinceIso = new Date(cursor.ms).toISOString();
@@ -618,16 +645,22 @@ export async function pullOnce(
             // never apply as-is, so skip it — advancing the cursor past it so ONE poison
             // row can't abort the whole multi-table sync or wedge the cursor.
             if (!isSqliteConstraintError(e)) throw e;
-            res.conflicts++;
+            res.skipped++;
             syncData.recordConflict(
               meta.table,
               rid,
               "pull_constraint_skip",
               remote,
             );
-            log.notice(
-              `sync: pull ${meta.table} skipped orphan row ${rid}: ${(e as Error).message}`,
-            );
+            // FK orphans (parent beyond the plan cap) are EXPECTED + high-volume on
+            // a fresh device — count them (surfaced in the CLI summary + recorded to
+            // sync_conflicts) but DON'T log per row, or a WARN-per-orphan flood drowns
+            // the console and inflates the Sentry warning stream. A rarer non-FK skip
+            // (UNIQUE/CHECK/NOT NULL) is unexpected → keep it visible.
+            if (!isForeignKeyError(e))
+              log.notice(
+                `sync: pull ${meta.table} skipped a row (${rid}): ${(e as Error).message}`,
+              );
           }
           cursor = { ms, id: rid };
           advanced = true;
@@ -668,6 +701,14 @@ export async function pullOnce(
       // BEFORE any side effect, so no partial row was applied.)
       log.notice(`sync: pull ${meta.table} deferred — ${err.message}`);
     }
+
+    // One debug-gated summary per table for the (mostly FK-orphan) skips — the
+    // per-row detail is intentionally silent, so this is the diagnosable trace.
+    const skippedHere = res.skipped - skippedBefore;
+    if (skippedHere > 0)
+      log.info(
+        `sync: pull ${meta.table} skipped ${skippedHere} row(s) failing a local constraint (mostly orphans whose parent wasn't synced under the plan cap)`,
+      );
 
     for (const fts of touchedFts) syncData.rebuildFts(fts);
   }
@@ -741,16 +782,19 @@ async function drainTimestamp(
         // `last`/`cursor` still advance below so the drain can't wedge.
         if (!isSqliteConstraintError(e)) throw e;
         const rid = syncData.rowIdOf(meta.table, remote);
-        res.conflicts++;
+        res.skipped++;
         syncData.recordConflict(
           meta.table,
           rid,
           "pull_constraint_skip",
           remote,
         );
-        log.notice(
-          `sync: pull ${meta.table} skipped orphan row ${rid}: ${(e as Error).message}`,
-        );
+        // See the primary loop: FK orphans stay quiet (counted), rarer non-FK
+        // constraint skips stay visible.
+        if (!isForeignKeyError(e))
+          log.notice(
+            `sync: pull ${meta.table} skipped a row (${rid}): ${(e as Error).message}`,
+          );
       }
       cols.forEach((c, i) => {
         last[i] = String(remote[c]);
@@ -899,10 +943,11 @@ export async function syncOnce(
   onProgress?: SyncProgressFn,
 ): Promise<SyncResult> {
   if (!syncData.isSyncEnabled()) {
-    return { pushed: 0, pulled: 0, conflicts: 0 };
+    return { pushed: 0, pulled: 0, conflicts: 0, skipped: 0 };
   }
   const client = await getAuthedClient();
-  if (!client) return { pushed: 0, pulled: 0, conflicts: 0, notAuthed: true };
+  if (!client)
+    return { pushed: 0, pulled: 0, conflicts: 0, skipped: 0, notAuthed: true };
 
   const push = await pushOnce(client, onProgress);
   const pull = await pullOnce(client, onProgress);
@@ -910,6 +955,7 @@ export async function syncOnce(
     pushed: push.pushed,
     pulled: pull.pulled,
     conflicts: push.conflicts + pull.conflicts,
+    skipped: push.skipped + pull.skipped,
     quotaHit: push.quotaHit,
   };
 }

--- a/packages/gateway/test/sync-cmd.test.ts
+++ b/packages/gateway/test/sync-cmd.test.ts
@@ -21,11 +21,13 @@ const pullOnceMock = vi.fn(async () => ({
   pushed: 0,
   pulled: 0,
   conflicts: 0,
+  skipped: 0,
 }));
 const syncOnceMock = vi.fn(async () => ({
   pushed: 0,
   pulled: 0,
   conflicts: 0,
+  skipped: 0,
 }));
 
 vi.mock("../src/supabase", () => ({

--- a/packages/gateway/test/sync.test.ts
+++ b/packages/gateway/test/sync.test.ts
@@ -953,7 +953,13 @@ describe("pullOnce", () => {
     } as never);
 
     // Must NOT throw — one FK-failing row can't abort the whole multi-table sync.
+    const noticeSpy = vi.spyOn(log, "notice");
     const r = await pullOnce(makeClient() as never);
+
+    // FK orphans are EXPECTED (parent beyond the plan cap) + high-volume on a fresh
+    // device → they must NOT be logged per row (a WARN-per-orphan flood drowns the
+    // console + inflates the Sentry warning stream). Counted + recorded instead.
+    expect(noticeSpy.mock.calls.flat().join(" ")).not.toMatch(/skipped a row/);
 
     // Valid alias applied; orphan skipped (its FK parent is absent).
     expect(
@@ -963,7 +969,7 @@ describe("pullOnce", () => {
       db().query("SELECT 1 FROM entity_aliases WHERE id = ?").get("al-orphan"),
     ).toBeNull();
     // The skip is recorded as a conflict, not a crash — recoverable + diagnosable.
-    expect(r.conflicts).toBeGreaterThanOrEqual(1);
+    expect(r.skipped).toBeGreaterThanOrEqual(1);
     expect(
       db()
         .query(
@@ -971,6 +977,45 @@ describe("pullOnce", () => {
         )
         .get(),
     ).not.toBeNull();
+  });
+
+  test("a non-FK constraint skip (UNIQUE) stays VISIBLE (log.notice) and still counts as skipped", async () => {
+    syncData.enableSync("basic");
+    const entId = "55555555-5555-4555-8555-555555555555";
+    syncData.withApplying(() => {
+      db()
+        .query(
+          "INSERT INTO entities (id, entity_type, canonical_name, created_at, updated_at) VALUES (?, 'tool', 'U', 1, 1)",
+        )
+        .run(entId);
+      // A local alias already occupies UNIQUE(alias_type='name', alias_value='Dup').
+      db()
+        .query(
+          "INSERT INTO entity_aliases (id, entity_id, alias_type, alias_value, source, created_at) VALUES ('local-al', ?, 'name', 'Dup', NULL, 1)",
+        )
+        .run(entId);
+    });
+    // Remote alias: NEW id, entity present (FK passes), but SAME (alias_type, alias_value)
+    // → a local UNIQUE violation, NOT an FK error → the rarer, unexpected skip class.
+    tableRows("entity_aliases").push({
+      id: "remote-al",
+      entity_id: entId,
+      alias_type: "name",
+      alias_value: "Dup",
+      source: null,
+      created_at: 1,
+      updated_at: new Date(2_000_000).toISOString(),
+    } as never);
+
+    const noticeSpy = vi.spyOn(log, "notice");
+    const r = await pullOnce(makeClient() as never);
+
+    // Unexpected non-FK constraint → stays LOUD (visible notice) AND counts as skipped.
+    expect(noticeSpy.mock.calls.flat().join(" ")).toMatch(/skipped a row/);
+    expect(r.skipped).toBeGreaterThanOrEqual(1);
+    expect(
+      db().query("SELECT 1 FROM entity_aliases WHERE id = 'remote-al'").get(),
+    ).toBeNull();
   });
 
   test("drainTimestamp also skips an orphan row sharing one timestamp (does not abort the sync)", async () => {
@@ -1020,7 +1065,7 @@ describe("pullOnce", () => {
         .query("SELECT 1 FROM entity_aliases WHERE id = 'alias-zzzz-orphan'")
         .get(),
     ).toBeNull();
-    expect(r.conflicts).toBeGreaterThanOrEqual(1);
+    expect(r.skipped).toBeGreaterThanOrEqual(1);
     expect(
       db()
         .query(
@@ -1319,7 +1364,12 @@ describe("profiles (pull-only mirror)", () => {
 
 describe("syncOnce", () => {
   test("no-op when disabled; notAuthed when logged out", async () => {
-    expect(await syncOnce()).toEqual({ pushed: 0, pulled: 0, conflicts: 0 });
+    expect(await syncOnce()).toEqual({
+      pushed: 0,
+      pulled: 0,
+      conflicts: 0,
+      skipped: 0,
+    });
     syncData.enableSync("basic");
     authed = false;
     expect((await syncOnce()).notAuthed).toBe(true);


### PR DESCRIPTION
Follow-up to #1215. Reported after testing the nightly: sync no longer crashes (good!), but `sync now` produced a flood of:
```
[WARN ] sync: pull knowledge_entity_refs skipped orphan row <id>: FOREIGN KEY constraint failed
```
one per skipped row (hundreds, on a fresh device whose knowledge graph references entities beyond the free-tier 30-entity cap).

## Root cause
#1215's per-row skip logged via `log.notice`, which is **not** debug-gated, writes `[WARN]` to the log file, **and** reports to the Sentry sink at warning severity. So every expected orphan skip = a visible WARN + a Sentry warning event.

## Fix
FK orphans (parent entity not synced under the cap) are **expected + high-volume**, so:
- count them in a new `SyncResult.skipped` — surfaced once in the `lore sync now` summary ("…, N skipped (records not present locally — e.g. entities beyond your plan's sync cap)") — and still record each to `sync_conflicts` (diagnosable/recoverable);
- **don't log per row** for the FK case; emit **one debug-gated (`log.info`) summary per table** instead;
- a rarer **non-FK** constraint skip (UNIQUE/CHECK/NOT NULL) stays **visible** via `log.notice` — those are unexpected and low-volume.

## Also
- `.gitignore`: add `.cache/` — the transformers.js model-download cache lands in `packages/*/.cache` (a ~137MB onnx + tokenizer); this keeps it from being committed by accident.

## Tests
- New assertion: an FK-orphan pull-skip emits **no** per-row `log.notice`.
- The two existing orphan-skip tests now assert `res.skipped` (not `res.conflicts`) — orphan skips are semantically distinct from LWW conflicts.
- Full sync suites (63) green; typecheck + lint clean (the 2 lint errors on `references.ts`/`ltm-metadata.test.ts` are pre-existing on main, untouched here).

Note: the remote still *accumulates* these orphans (refs/aliases pushed for entities the cap rejected) — physically GC'ing them stays the server-side reaper's job (#909); convergent UNIQUE-conflict resolution is #1217.