### PR TITLE
fix(core): declare onnxruntime-node + sharp as optional deps so the plugin worker resolves the native ONNX backend

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,7 +37,9 @@
     "zod": "^4.3.6"
   },
   "optionalDependencies": {
-    "@huggingface/transformers": "^3.7.1"
+    "@huggingface/transformers": "^3.7.1",
+    "onnxruntime-node": "1.21.0",
+    "sharp": "^0.34.1"
   },
   "devDependencies": {
     "@types/mdast": "^4.0.4"

--- a/packages/core/test/embedding-optional-stack.test.ts
+++ b/packages/core/test/embedding-optional-stack.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 import { EventEmitter } from "node:events";
+import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 import type { Worker } from "node:worker_threads";
 import { afterEach, beforeEach, describe, expect, it, test } from "vitest";
@@ -283,4 +284,41 @@ describe("packaging: @huggingface/transformers is optional (#1026)", () => {
     ).toBeTruthy();
     expect(pkg.dependencies?.["@huggingface/transformers"]).toBeUndefined();
   });
+
+  // #1220: the native ONNX backend (onnxruntime-node) + image codec (sharp) are
+  // deps of @huggingface/transformers, but the worker in packages/core/dist/**
+  // must resolve them at runtime. As transitive-only deps they nest under
+  // .pnpm/@huggingface+transformers/… in a strict-pnpm layout and are
+  // unreachable from dist/ — transformers init throws and recall silently
+  // degrades to FTS-only. Declaring them directly (still optional) links them
+  // adjacent to core so the worker resolves them, without affecting the gateway
+  // bundle (which inlines core and externalizes onnxruntime-node) or a
+  // --omit=optional install.
+  test("onnxruntime-node and sharp are declared optional too (#1220)", () => {
+    for (const dep of ["onnxruntime-node", "sharp"]) {
+      expect(pkg.optionalDependencies?.[dep]).toBeTruthy();
+      expect(pkg.dependencies?.[dep]).toBeUndefined();
+    }
+  });
+
+  // The resolution invariant the bug violated: whenever the optional stack IS
+  // installed, its native peers must resolve from @loreai/core's location (the
+  // same node_modules the built worker walks). Skipped under --omit=optional /
+  // unsupported platforms where transformers itself isn't installed.
+  const require = createRequire(import.meta.url);
+  const stackInstalled = (() => {
+    try {
+      require.resolve("@huggingface/transformers");
+      return true;
+    } catch {
+      return false;
+    }
+  })();
+  test.runIf(stackInstalled)(
+    "native backend resolves from @loreai/core when the stack is installed (#1220)",
+    () => {
+      expect(() => require.resolve("onnxruntime-node")).not.toThrow();
+      expect(() => require.resolve("sharp")).not.toThrow();
+    },
+  );
 });

--- a/packages/core/test/embedding-optional-stack.test.ts
+++ b/packages/core/test/embedding-optional-stack.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { EventEmitter } from "node:events";
 import { createRequire } from "node:module";
@@ -293,7 +294,8 @@ describe("packaging: @huggingface/transformers is optional (#1026)", () => {
   // degrades to FTS-only. Declaring them directly (still optional) links them
   // adjacent to core so the worker resolves them, without affecting the gateway
   // bundle (which inlines core and externalizes onnxruntime-node) or a
-  // --omit=optional install.
+  // --omit=optional install. Pins must track @huggingface/transformers' own
+  // onnxruntime-node/sharp versions so pnpm dedupes to a single instance.
   test("onnxruntime-node and sharp are declared optional too (#1220)", () => {
     for (const dep of ["onnxruntime-node", "sharp"]) {
       expect(pkg.optionalDependencies?.[dep]).toBeTruthy();
@@ -301,24 +303,51 @@ describe("packaging: @huggingface/transformers is optional (#1026)", () => {
     }
   });
 
-  // The resolution invariant the bug violated: whenever the optional stack IS
-  // installed, its native peers must resolve from @loreai/core's location (the
-  // same node_modules the built worker walks). Skipped under --omit=optional /
-  // unsupported platforms where transformers itself isn't installed.
-  const require = createRequire(import.meta.url);
+  // The resolution invariant the bug violated: the built worker resolves the
+  // native backend from @loreai/core's OWN node_modules at runtime. This MUST
+  // run in a real Node subprocess based at the dist worker's path — NOT an
+  // in-process createRequire — because vitest's Vite resolver walks the .pnpm
+  // store directly and passes even with the fix fully reverted (a vacuous test,
+  // caught in the PR #1223 adversarial review). We also SCRUB NODE_PATH: pnpm
+  // points it at .pnpm/node_modules, and an inherited NODE_PATH would let the
+  // subprocess resolve the dep from the virtual store regardless of the fix
+  // (a published/plugin consumer has no such NODE_PATH). The worker file itself
+  // need not exist: Node resolves from its parent directory up through
+  // node_modules. Skipped under --omit=optional / unsupported platforms.
   const stackInstalled = (() => {
     try {
-      require.resolve("@huggingface/transformers");
+      createRequire(import.meta.url).resolve("@huggingface/transformers");
       return true;
     } catch {
       return false;
     }
   })();
+  const workerPath = fileURLToPath(
+    new URL("../dist/node/embedding-worker.js", import.meta.url),
+  );
+  function resolvesInRealNode(dep: string): boolean {
+    const env = { ...process.env };
+    delete env.NODE_PATH;
+    delete env.NODE_OPTIONS;
+    try {
+      execFileSync(
+        process.execPath,
+        [
+          "-e",
+          `require("module").createRequire(${JSON.stringify(workerPath)}).resolve(${JSON.stringify(dep)})`,
+        ],
+        { stdio: "pipe", env },
+      );
+      return true;
+    } catch {
+      return false;
+    }
+  }
   test.runIf(stackInstalled)(
-    "native backend resolves from @loreai/core when the stack is installed (#1220)",
+    "native backend resolves from @loreai/core's dist worker in a real Node process (#1220)",
     () => {
-      expect(() => require.resolve("onnxruntime-node")).not.toThrow();
-      expect(() => require.resolve("sharp")).not.toThrow();
+      expect(resolvesInRealNode("onnxruntime-node")).toBe(true);
+      expect(resolvesInRealNode("sharp")).toBe(true);
     },
   );
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,12 @@ importers:
       '@huggingface/transformers':
         specifier: ^3.7.1
         version: 3.8.1
+      onnxruntime-node:
+        specifier: 1.21.0
+        version: 1.21.0
+      sharp:
+        specifier: ^0.34.1
+        version: 0.34.5
 
   packages/gateway:
     dependencies:


### PR DESCRIPTION
Closes #1220.

## Problem

Self-hosted `opencode-lore` (the plugin path — raw TS → `@loreai/core`'s built `dist/`) silently degrades recall to **FTS-only** with a generic `'@huggingface/transformers' failed to initialize` warning, and stops generating embeddings.

Root cause is **module resolution, not runtime**: the worker at `packages/core/dist/**/embedding-worker.js` loads the native ONNX backend through `@huggingface/transformers`, which needs `onnxruntime-node` (and `sharp`) at runtime. Those were only **transitive** deps of the optional `@huggingface/transformers`, so a **strict-pnpm** layout nests them under `.pnpm/@huggingface+transformers/…` — unreachable from `dist/`:

```
# from packages/core/dist/bun/  (before)
@huggingface/transformers -> resolves
onnxruntime-node          -> Cannot find package 'onnxruntime-node' from …/dist/bun/embedding-worker.js
sharp                     -> Cannot find package 'sharp'
```

Flat-npm installs happened to hoist `onnxruntime-node` to the top level, so it resolved there and the bug was invisible — but any pnpm/monorepo consumer (and dev) hits it. The model file and the native addon are fine (loads under both Node and Bun); it's purely where the package lives.

## Fix

Declare `onnxruntime-node@1.21.0` and `sharp@^0.34.1` — the exact versions `@huggingface/transformers@3.8.1` resolves, so pnpm **dedupes to a single instance** — as `optionalDependencies` of `@loreai/core`. pnpm then links them adjacent to core, so the built worker resolves them in strict layouts too.

- Still **optional** → `--omit=optional` / unsupported platforms degrade to FTS-only exactly as before (the SEA binary and remote-provider users can still drop ~480 MB).
- **Gateway/SEA bundle unaffected:** it *inlines* `@loreai/core` and *externalizes* `onnxruntime-node`, shipping per-platform `@loreai/onnxruntime-*` + a bundled WASM fallback. Only the `@loreai/opencode` plugin path actually installs `@loreai/core`, which is the broken path this fixes.
- Lockfile change is minimal (two edges added to the core importer; deduped to versions already present).

## Verification

- Resolution from **`dist/bun`** and **`dist/node`** now succeeds for `onnxruntime-node`/`sharp` under strict pnpm.
- End-to-end (on the affected box): pipeline inits and returns a `[1, 768]` vector; provider recovers and embeds.

## Tests

Extended `embedding-optional-stack.test.ts` (Part D packaging invariant):
- `onnxruntime-node`/`sharp` are declared **optional** (not required) — mutation-verified (removing them turns the test red).
- **Resolution invariant:** when the optional stack is installed, its native peers resolve from `@loreai/core`'s location (the exact invariant the bug violated); auto-skips under `--omit=optional`.

Full `@loreai/core` suite (2714 passed / 6 skipped), typecheck, and biome all green.

## Follow-up (not in this PR)
The dev/test path has no WASM fallback (only the npm bundle does), so a genuinely missing native backend is fatal-to-embeddings rather than degrading to WASM. Tracked in #1220's discussion; can be a separate change.