### PR TITLE
fix(deps): override qs to >=6.15.2 to fix DoS (GHSA-q8mj-m7cp-5q26)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
       "yaml": ">=2.8.3",
       "esbuild": ">=0.28.1",
       "@opentelemetry/core": ">=2.8.0",
-      "protobufjs": ">=7.6.3"
+      "protobufjs": ">=7.6.3",
+      "qs": ">=6.15.2"
     },
     "patchedDependencies": {
       "@sentry/node@10.56.0": "patches/@sentry__node@10.56.0.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   esbuild: '>=0.28.1'
   '@opentelemetry/core': '>=2.8.0'
   protobufjs: '>=7.6.3'
+  qs: '>=6.15.2'
 
 patchedDependencies:
   '@sentry/node@10.56.0':
@@ -3331,8 +3332,8 @@ packages:
     resolution: {integrity: sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==}
     hasBin: true
 
-  qs@6.15.1:
-    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
     engines: {node: '>=0.6'}
 
   radix3@1.1.2:
@@ -8042,8 +8043,9 @@ snapshots:
 
   qrcode-terminal@0.12.0: {}
 
-  qs@6.15.1:
+  qs@6.15.3:
     dependencies:
+      es-define-property: 1.0.1
       side-channel: 1.1.1
 
   radix3@1.1.2: {}
@@ -8580,7 +8582,7 @@ snapshots:
     dependencies:
       des.js: 1.1.0
       js-md4: 0.3.2
-      qs: 6.15.1
+      qs: 6.15.3
       tunnel: 0.0.6
       underscore: 1.13.8
 


### PR DESCRIPTION
## Summary

Fixes the only open Dependabot alert (#14): [`qs` DoS — GHSA-q8mj-m7cp-5q26](https://github.com/BYK/loreai/security/dependabot/14) (CVE-2026-... medium).

`qs@6.15.1` is a **dev-only transitive** dependency, pulled in exclusively through the mutation-testing toolchain:

```
@stryker-mutator/core 9.6.1
└─ typed-rest-client 2.3.1
   └─ qs 6.15.1
```

The vulnerability: `qs.stringify` crashes with a `TypeError` on null/undefined entries in comma-format arrays when `encodeValuesOnly` is set (remotely triggerable DoS). Vulnerable range `>=6.11.1, <=6.15.1`; patched in **6.15.2**.

`typed-rest-client@2.3.1` has no newer release to bump into, so this adds a `pnpm.overrides` entry — the same pattern already used in this repo for `yaml`, `esbuild`, `@opentelemetry/core`, and `protobufjs`. The override resolves `qs` to the current `6.15.3`.

## Changes
- `package.json`: add `"qs": ">=6.15.2"` to `pnpm.overrides`.
- `pnpm-lock.yaml`: regenerated — `qs@6.15.1` → `qs@6.15.3` everywhere.

## Verification
- `pnpm why qs` shows only `6.15.3` in the tree; zero `6.15.1` entries remain in the lockfile.
- `pnpm install --frozen-lockfile` passes (lockfile consistent).
- Zero runtime impact — `qs` is only reached via dev-only mutation-testing tooling.

The GitHub Security advisories endpoint returned empty (`[]`); the other 12 Dependabot alerts are already `fixed`.