### PR TITLE
fix(core): checkpoint the SQLite WAL so it can't grow unbounded (#1221)

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -7,7 +7,7 @@ import {
   repartitionVec0Project,
 } from "./db/vec-store";
 import { join, dirname } from "node:path";
-import { chmodSync, mkdirSync } from "node:fs";
+import { chmodSync, mkdirSync, statSync } from "node:fs";
 import { getGitRemote } from "./git";
 import { isHostedMode } from "./hosted";
 import { dataDir } from "./data-dir";
@@ -2208,10 +2208,17 @@ export function db(): Database {
   // Retry for up to 5s when another connection holds the write lock (e.g.
   // backgroundDistill's BEGIN IMMEDIATE overlapping with a recall query).
   // Default is 0ms which throws SQLITE_BUSY immediately.
-  database.exec("PRAGMA busy_timeout = 5000");
+  database.exec(`PRAGMA busy_timeout = ${BUSY_TIMEOUT_MS}`);
   // Return freed pages to the OS incrementally on each transaction commit
   // instead of accumulating a free-page list that bloats the file.
   database.exec("PRAGMA auto_vacuum = INCREMENTAL");
+  // Bound the on-disk WAL (#1221). SQLite's default PASSIVE auto-checkpoint is
+  // starved by the persistent reader-pool connections (each recall query holds a
+  // WAL read-mark), so the WAL can grow unbounded (a 5.4 GB -wal was observed).
+  // journal_size_limit truncates the WAL back to this cap after any checkpoint
+  // that resets it — the backstop for the active TRUNCATE checkpoint the idle
+  // scheduler runs via checkpointWal(). Default is -1 (never truncate).
+  database.exec(`PRAGMA journal_size_limit = ${WAL_JOURNAL_SIZE_LIMIT_BYTES}`);
   migrate(database);
   installSyncCapture(database);
   // Load the sqlite-vec native extension (if available) on the RAW connection,
@@ -3058,12 +3065,76 @@ export function mergeProjectInternal(sourceId: string, targetId: string): void {
 
 export function close() {
   if (instance) {
+    // Reclaim the WAL on a graceful shutdown so the next open doesn't inherit a
+    // huge WAL to recover/checkpoint (#1221). Best-effort — we're closing anyway.
+    // busy_timeout=0 first so a reader mid-query can't make this busy-wait (~5s)
+    // and hang close(); an un-truncated WAL is simply recovered on next open.
+    try {
+      instance.exec("PRAGMA busy_timeout = 0");
+      instance.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+    } catch {
+      // ignore — a busy checkpoint or driver quirk must not block close()
+    }
     instance.close();
     instance = undefined;
   }
   // The sqlite-vec extension is loaded per-connection; reset loader state so a
   // subsequent db() on a fresh connection re-attempts the load.
   resetVecState();
+}
+
+/** Write-lock retry window for the writer connection (SQLITE_BUSY handling). */
+const BUSY_TIMEOUT_MS = 5000;
+
+/** Cap the on-disk WAL is truncated back to after a resetting checkpoint (#1221). */
+const WAL_JOURNAL_SIZE_LIMIT_BYTES = 64 * 1024 * 1024; // 64 MiB
+
+/** Bytes of the `-wal` sidecar (0 if absent / :memory:). Cheap stat for #1221 telemetry. */
+export function walSizeBytes(): number {
+  try {
+    return statSync(`${dbPath()}-wal`).size;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Reclaim the WAL with a TRUNCATE checkpoint on the writer connection (#1221).
+ * SQLite's PASSIVE auto-checkpoint is starved by the persistent reader-pool
+ * connections — each recall query holds a WAL read-mark, so the checkpoint can
+ * never obtain the "no reader below the mark" instant needed to reset the log and
+ * the WAL grows unbounded. TRUNCATE resets AND shrinks the file to zero when run
+ * in a quiet window (no reader pinning an older snapshot); when a reader is
+ * mid-query it checkpoints what it can and returns `busy` (a harmless no-op we
+ * retry on the next idle tick). It never blocks indefinitely.
+ */
+export function checkpointWal(): { busy: boolean; reclaimedBytes: number } {
+  // NOTE: for TRUNCATE mode the `log`/`checkpointed` result columns report the
+  // POST-truncation state (0/0) even on success — they can't tell you how much was
+  // reclaimed. Only `busy` is reliable there. So we measure the actual reclaim by
+  // the -wal file-size delta instead.
+  const conn = db();
+  const before = walSizeBytes();
+  // Drop the write-lock retry to 0 around the checkpoint: this runs synchronously on
+  // the gateway event loop, and a TRUNCATE blocked by a reader's read-mark would
+  // otherwise busy-wait the whole BUSY_TIMEOUT_MS (~5s stall) — precisely under the
+  // sustained-reader load that starves the WAL and makes this fire. With timeout 0 it
+  // returns `busy` in ~1ms when it can't reset, and still fully truncates in a quiet
+  // window. Restore the retry window afterward.
+  conn.exec("PRAGMA busy_timeout = 0");
+  let row: { busy: number } | undefined;
+  try {
+    row = conn.query("PRAGMA wal_checkpoint(TRUNCATE)").get() as
+      | { busy: number }
+      | undefined;
+  } finally {
+    conn.exec(`PRAGMA busy_timeout = ${BUSY_TIMEOUT_MS}`);
+  }
+  const after = walSizeBytes();
+  return {
+    busy: (row?.busy ?? 0) === 1,
+    reclaimedBytes: Math.max(0, before - after),
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -151,6 +151,8 @@ export {
   rebuildDirtySessionRollups,
   rebuildAllSessionRollups,
   close,
+  checkpointWal,
+  walSizeBytes,
 } from "./db";
 export {
   normalizeRemoteUrl,

--- a/packages/core/test/wal-checkpoint.test.ts
+++ b/packages/core/test/wal-checkpoint.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "vitest";
+import { checkpointWal, db, dbPath, walSizeBytes } from "../src/db";
+import { openReaderConnection } from "../src/db/reader";
+
+describe("WAL checkpointing (#1221)", () => {
+  test("journal_size_limit is bounded at open (not the -1 default)", () => {
+    const row = db().query("PRAGMA journal_size_limit").get() as {
+      journal_size_limit: number;
+    };
+    expect(row.journal_size_limit).toBe(64 * 1024 * 1024);
+  });
+
+  test("checkpointWal(TRUNCATE) reclaims the WAL when no reader pins a snapshot", () => {
+    // Disable the auto-checkpoint so the probe writes deterministically accumulate
+    // in the -wal (otherwise ~500 inserts land right at the 1000-page auto-reset
+    // boundary and the pre-checkpoint size is racy). Reset by the next open.
+    db().exec("PRAGMA wal_autocheckpoint = 0");
+    db().exec(
+      "CREATE TABLE IF NOT EXISTS wal_probe (id INTEGER PRIMARY KEY, blob TEXT)",
+    );
+    for (let i = 0; i < 500; i++)
+      db()
+        .query("INSERT INTO wal_probe (blob) VALUES (?)")
+        .run("x".repeat(2000));
+    const before = walSizeBytes();
+    expect(before).toBeGreaterThan(0);
+
+    const r = checkpointWal();
+    // Single connection in the test — no reader read-mark → TRUNCATE fully wraps.
+    expect(r.busy).toBe(false);
+    expect(r.reclaimedBytes).toBeGreaterThan(0);
+    // TRUNCATE shrinks the -wal file back to zero (well below the pre-size).
+    expect(walSizeBytes()).toBeLessThan(before);
+    expect(walSizeBytes()).toBe(0);
+  });
+
+  test("checkpointWal returns fast (no ~5s busy-wait) when a reader pins the WAL", () => {
+    db().exec("PRAGMA wal_autocheckpoint = 0");
+    db().exec(
+      "CREATE TABLE IF NOT EXISTS wal_probe2 (id INTEGER PRIMARY KEY, b TEXT)",
+    );
+    for (let i = 0; i < 200; i++)
+      db().query("INSERT INTO wal_probe2 (b) VALUES (?)").run("x".repeat(2000));
+
+    // A second connection with an OPEN read transaction pins a WAL snapshot, so
+    // the writer's TRUNCATE can't reset the log. Without the busy_timeout=0 guard
+    // the checkpoint would busy-wait the whole 5s window on the event loop (#1221).
+    const reader = openReaderConnection(dbPath());
+    try {
+      reader.db.exec("BEGIN");
+      reader.db.query("SELECT COUNT(*) FROM wal_probe2").get(); // take the snapshot
+      const t0 = Date.now();
+      const r = checkpointWal();
+      const elapsed = Date.now() - t0;
+      expect(r.busy).toBe(true); // reader pinning → couldn't fully reset
+      expect(elapsed).toBeLessThan(2000); // returned immediately, NOT ~5s
+    } finally {
+      try {
+        reader.db.exec("ROLLBACK");
+      } catch {
+        // no open txn to roll back
+      }
+      reader.db.close();
+    }
+  });
+});

--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -46,6 +46,8 @@ import {
   curatorLimiter,
   formatVecReadLatencyHeartbeat,
   vecReadLatencyTotalSamples,
+  checkpointWal,
+  walSizeBytes,
 } from "@loreai/core";
 import type { CacheStrategy, ChangedEntry, LLMClient } from "@loreai/core";
 import {
@@ -151,6 +153,14 @@ export const GLOBAL_DEAD_SWEEP_INTERVAL_MS = 60 * 60 * 1000; // 1h
  * next tick (every ~30s) instead of waiting the full interval.
  */
 const GLOBAL_DEAD_SWEEP_BATCH = 1000;
+
+// WAL checkpointing (#1221). Only bother attempting a TRUNCATE checkpoint once the
+// -wal has grown past this floor — below it SQLite's own auto-checkpoint suffices
+// and grabbing the lock every tick isn't worth it.
+const WAL_CHECKPOINT_FLOOR_BYTES = 8 * 1024 * 1024; // 8 MiB
+// A WAL this large that still won't reset means checkpointing is genuinely starved
+// (a reader is continuously pinning a snapshot) — surface it at notice level.
+const WAL_STARVED_NOTICE_BYTES = 512 * 1024 * 1024; // 512 MiB
 
 /**
  * Cooldown tracking for knowledge consolidation.
@@ -492,6 +502,30 @@ export function startIdleScheduler(
       } catch (e) {
         log.error("dead-ref cleanup error:", e);
       }
+    }
+
+    // WAL maintenance (#1221): SQLite's PASSIVE auto-checkpoint is starved by the
+    // persistent reader-pool connections (each recall query holds a WAL read-mark),
+    // so the WAL grows unbounded under load (a 5.4 GB -wal was observed). A TRUNCATE
+    // checkpoint on the writer connection resets AND shrinks it during a quiet
+    // window; when a reader is mid-query it returns busy and we retry next tick.
+    // Never throws out of the loop.
+    try {
+      const walBytes = walSizeBytes();
+      if (walBytes >= WAL_CHECKPOINT_FLOOR_BYTES) {
+        const r = checkpointWal();
+        if (r.busy && walBytes >= WAL_STARVED_NOTICE_BYTES) {
+          log.notice(
+            `wal ${Math.round(walBytes / 1e6)}MB not checkpointing — a reader is holding a snapshot; will retry when idle (#1221)`,
+          );
+        } else {
+          log.info(
+            `wal checkpoint: ${Math.round(walBytes / 1e6)}MB → reclaimed ${Math.round(r.reclaimedBytes / 1e6)}MB (busy=${r.busy})`,
+          );
+        }
+      }
+    } catch (e) {
+      log.info("wal checkpoint error:", e);
     }
 
     // --- Idle work (distillation, curation, etc.) ---


### PR DESCRIPTION
Closes #1221. Reported from a heavily-used self-hosted install: **10.8 GB `lore.db` with a 5.4 GB `lore.db-wal`** — the WAL was never truncating.

## Root cause: WAL checkpoint starvation
There was **no `wal_autocheckpoint` tuning, no `journal_size_limit`, no explicit `wal_checkpoint`, and no checkpoint on close** — the WAL relied entirely on SQLite's default **PASSIVE** auto-checkpoint. Lore's topology defeats it:
- **one writer** (the main connection) emits a continuous stream of small commits — live traffic **plus** the ~hour-long temporal-embedding backfill;
- **persistent reader-pool connections** (default 2, `db/reader.ts`) serve near-continuous recall, and each query holds a **WAL read-mark**.

A PASSIVE checkpoint can back-fill frames but can **never** get the "no reader below the mark" instant required to *reset* the WAL to frame 0 — so every commit appends past the high-water mark and the WAL grows without bound. Textbook checkpoint starvation.

## Fix
- **`db.ts`**:
  - `PRAGMA journal_size_limit = 64 MiB` at open — truncates the WAL back to the cap after any resetting checkpoint (backstop; default is `-1` = never).
  - `checkpointWal()` — a **TRUNCATE** checkpoint on the writer connection that resets **and** shrinks the file when no reader pins an older snapshot; when one does, it checkpoints what it can and returns `busy` (a harmless no-op retried next tick). Never blocks indefinitely.
  - `walSizeBytes()` — cheap `-wal` stat for telemetry.
  - a TRUNCATE checkpoint on **`close()`** so a graceful shutdown doesn't leave a huge WAL to recover.
- **`idle.ts`**: run `checkpointWal()` on the existing 30s idle tick once the WAL passes an 8 MiB floor — reclaims during the quiet windows between agent turns (when the reader pool is idle). Emits a **notice** if a >512 MiB WAL still won't checkpoint (a reader is continuously pinning), else a debug summary.

Subtlety handled: for `TRUNCATE` mode the `log`/`checkpointed` result columns report the *post-truncation* state (`0/0`) even on success, so the reclaim is measured by the `-wal` **file-size delta**, not those counters (verified empirically on node:sqlite).

## Scope note
The **10.8 GB main file** is a *separate* symptom: `PRAGMA auto_vacuum = INCREMENTAL` is a no-op on a pre-existing DB (SQLite bakes `auto_vacuum` at creation; changing it needs a one-off `VACUUM`), and `incremental_vacuum` only runs at the vec0 cutover. That's a heavier, separate fix — not in this PR.

## Tests
- `checkpointWal(TRUNCATE)` reclaims a deliberately-grown WAL to zero on a single connection (auto-checkpoint disabled for a deterministic pre-size); `reclaimedBytes` measured by file delta.
- `journal_size_limit` is set to 64 MiB at open.
- Full core suite (128 files, 2714) green; typecheck + lint clean.