### PR TITLE
feat(cli): `lore data vacuum` to reclaim the bloated DB file (#1221)

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -3137,6 +3137,42 @@ export function checkpointWal(): { busy: boolean; reclaimedBytes: number } {
   };
 }
 
+/** Bytes of the main DB file (0 if absent / :memory:). */
+export function dbFileSizeBytes(): number {
+  try {
+    return statSync(dbPath()).size;
+  } catch {
+    return 0;
+  }
+}
+
+/** Reclaimable free space right now: `freelist_count × page_size`. */
+export function freelistBytes(): number {
+  const fc = db().query("PRAGMA freelist_count").get() as
+    | { freelist_count: number }
+    | undefined;
+  const ps = db().query("PRAGMA page_size").get() as
+    | { page_size: number }
+    | undefined;
+  return (fc?.freelist_count ?? 0) * (ps?.page_size ?? 0);
+}
+
+/**
+ * Full VACUUM: rewrites the whole DB, reclaiming ALL free pages AND applying the
+ * current `auto_vacuum` mode — so a legacy DB created with `auto_vacuum=NONE`
+ * (freed pages never returned to the OS → #1221 main-file bloat) is converted to
+ * INCREMENTAL, after which the idle incremental-vacuum can keep it bounded. Heavy:
+ * takes an exclusive lock and needs ~2× the DB size in transient disk. Returns the
+ * file size before/after. Followed by a resetting WAL checkpoint so the VACUUM's
+ * churn doesn't linger in the -wal.
+ */
+export function vacuum(): { beforeBytes: number; afterBytes: number } {
+  const beforeBytes = dbFileSizeBytes();
+  db().exec("VACUUM");
+  checkpointWal();
+  return { beforeBytes, afterBytes: dbFileSizeBytes() };
+}
+
 // ---------------------------------------------------------------------------
 // Centralized query helpers
 //

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -153,6 +153,9 @@ export {
   close,
   checkpointWal,
   walSizeBytes,
+  vacuum,
+  dbFileSizeBytes,
+  freelistBytes,
 } from "./db";
 export {
   normalizeRemoteUrl,

--- a/packages/core/test/data-vacuum.test.ts
+++ b/packages/core/test/data-vacuum.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "vitest";
+import {
+  checkpointWal,
+  db,
+  dbFileSizeBytes,
+  freelistBytes,
+  vacuum,
+} from "../src/db";
+
+describe("VACUUM / free-page reclaim (#1221)", () => {
+  test("vacuum() clears the freelist and shrinks the file", () => {
+    db().exec(
+      "CREATE TABLE IF NOT EXISTS vac_probe (id INTEGER PRIMARY KEY, b TEXT)",
+    );
+    for (let i = 0; i < 1000; i++)
+      db().query("INSERT INTO vac_probe (b) VALUES (?)").run("x".repeat(2000));
+    checkpointWal(); // flush inserts into the main file so it actually grows
+    const grown = dbFileSizeBytes();
+
+    db().exec("DELETE FROM vac_probe");
+    checkpointWal(); // flush the deletes → freed pages land on the freelist
+    // auto_vacuum=INCREMENTAL keeps freed pages on the freelist until reclaimed.
+    expect(freelistBytes()).toBeGreaterThan(0);
+
+    const r = vacuum();
+    // VACUUM removes ALL free pages and returns the space to the OS.
+    expect(freelistBytes()).toBe(0);
+    expect(r.afterBytes).toBeLessThan(r.beforeBytes);
+    expect(dbFileSizeBytes()).toBeLessThan(grown);
+  });
+});

--- a/packages/gateway/src/cli/data.ts
+++ b/packages/gateway/src/cli/data.ts
@@ -1317,6 +1317,40 @@ async function cmdRerank(): Promise<void> {
   }
 }
 
+async function cmdVacuum(): Promise<void> {
+  const remote = getRemoteUrl();
+  if (remote) {
+    console.error(
+      "Error: vacuum is not supported in remote mode (requires local DB access).",
+    );
+    process.exit(1);
+  }
+
+  const { vacuum, dbFileSizeBytes, freelistBytes } = await import(
+    "@loreai/core"
+  );
+  const mb = (b: number) => `${(b / 1e6).toFixed(1)} MB`;
+
+  console.log(
+    `Database: ${mb(dbFileSizeBytes())} (${mb(freelistBytes())} reclaimable free pages)`,
+  );
+  console.log(
+    "Running VACUUM — this rewrites the whole database and can take a while (and ~2× the DB size in free disk) on a large DB…",
+  );
+  try {
+    const { beforeBytes, afterBytes } = vacuum();
+    console.log(
+      `Done — ${mb(beforeBytes)} → ${mb(afterBytes)} (reclaimed ${mb(Math.max(0, beforeBytes - afterBytes))}).`,
+    );
+  } catch (err) {
+    console.error("VACUUM failed:", err);
+    console.error(
+      "If a gateway/agent is running it holds the DB open — stop it and retry (VACUUM needs exclusive access).",
+    );
+    process.exit(1);
+  }
+}
+
 async function cmdReindex(flags?: Record<string, unknown>): Promise<void> {
   const remote = getRemoteUrl();
   if (remote) return cmdReindexRemote(remote, flags ?? {});
@@ -2701,6 +2735,7 @@ Subcommands:
   contradictions        List knowledge entries that contradict each other (#1123)
   reindex               Rebuild embedding vectors (after model/config change)
   rerank                Re-score preference confidence by directive strength
+  vacuum                Reclaim free space from the DB file (full VACUUM; #1221)
   cache-stats           Show cache-bust counters (system[0] cache-alignment gate)
 
 Options:
@@ -3254,6 +3289,9 @@ export async function commandData(
       break;
     case "rerank":
       await cmdRerank();
+      break;
+    case "vacuum":
+      await cmdVacuum();
       break;
     case "cache-stats":
       await cmdCacheStats(subArgs, values);


### PR DESCRIPTION
Companion to #1225 (which bounds the `-wal`). This is **(b)** of the #1221 follow-up; **(a)** automatic reclaim is a stacked follow-up.

## Why
The main `lore.db` stays bloated (10.8 GB observed) even after the WAL fix: `PRAGMA auto_vacuum = INCREMENTAL` is a **no-op on a DB created before it was set** (SQLite bakes `auto_vacuum` at creation; changing it needs a full `VACUUM`), so pages freed by prunes / knowledge compaction / eviction never return to the OS.

## What
```
lore data vacuum
```
Runs a full `VACUUM`: rewrites the DB, reclaims **all** free pages, and **converts a legacy `auto_vacuum=NONE` DB to INCREMENTAL** — so the follow-up idle incremental-vacuum can keep it bounded going forward.

Output:
```
Database: 10800.0 MB (9200.0 MB reclaimable free pages)
Running VACUUM — this rewrites the whole database and can take a while (and ~2× the DB size in free disk) on a large DB…
Done — 10800.0 MB → 1600.0 MB (reclaimed 9200.0 MB).
```

## How
- **`db.ts`**: `vacuum()` (full `VACUUM` + a resetting `checkpointWal()`; returns `{beforeBytes, afterBytes}`), `dbFileSizeBytes()`, `freelistBytes()` (`freelist_count × page_size`).
- **`cli/data.ts`**: `cmdVacuum` — local-only (clear error in remote mode); shows size + reclaimable up front and before→after + reclaimed on completion; on failure (DB busy) tells the user to stop the running agent, since `VACUUM` needs exclusive access.

## Scope
It's a **heavy** op (exclusive lock, ~2× transient disk), so it's explicit/manual by design. Automatic ongoing reclaim — idle `incremental_vacuum` for INCREMENTAL DBs + a one-time auto-conversion for *small* legacy DBs (large ones get a notice pointing here) — is the stacked **(a)** PR.

## Tests
- insert → delete → checkpoint leaves `freelistBytes() > 0`; `vacuum()` clears the freelist (`=== 0`) and shrinks the file (`afterBytes < beforeBytes`).
- Full core suite (129 files, 2718) green; typecheck + lint clean (the lone `data.ts:2143` noNonNullAssertion warning is pre-existing, not in this diff).