### PR TITLE
fix(core): fast-first-retry backoff for embedding init failures

### DIFF
--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -494,13 +494,41 @@ let localInitFailures = 0;
 /** Epoch ms; `> 0` means "cooling down after a transient init failure — retry a
  *  fresh worker once `Date.now()` reaches it". Reset to 0 on retry/recovery. */
 let localInitRetryAt = 0;
+// Ceiling for the init-retry cooldown; the first retries are much faster (see
+// computeInitRetryDelayMs). Also the test seam: 0 → retry immediately.
 let localInitCooldownMs = 30_000;
 
-/** Test seam: shorten the init-retry cooldown so the retry path is drivable
- *  without real time (`0` → the next availability check retries immediately;
- *  `null` restores the production default). */
+/** Base delay for the first init-retry, and the geometric backoff factor. A
+ *  transient init failure (e.g. a cold ORT "protobuf parsing failed" in the Bun
+ *  worker) reliably recovers on the NEXT fresh-worker respawn, so the first
+ *  retry should be fast; only a genuine failure (which fails the fast retry
+ *  too) needs to back off toward the ceiling to avoid a respawn storm. With
+ *  LOCAL_INIT_MAX_ATTEMPTS=3 the two retry waits are 2s then 8s. */
+const INIT_RETRY_BASE_MS = 2_000;
+const INIT_RETRY_BACKOFF_FACTOR = 4;
+
+/** Cooldown before the Nth fresh-worker init-retry: `base * factor^(N-1)`,
+ *  clamped to `ceilingMs`. Pure (no module state) so the schedule is unit
+ *  testable. `ceilingMs=0` (the test seam) collapses to 0 → retry immediately. */
+export function computeInitRetryDelayMs(
+  failures: number,
+  ceilingMs: number,
+): number {
+  const n = Math.max(1, failures);
+  const backoff = INIT_RETRY_BASE_MS * INIT_RETRY_BACKOFF_FACTOR ** (n - 1);
+  return Math.min(ceilingMs, backoff);
+}
+
+/** Test seam: shorten the init-retry cooldown ceiling so the retry path is
+ *  drivable without real time (`0` → the next availability check retries
+ *  immediately; `null` restores the production default). */
 export function _setLocalInitCooldownMsForTest(ms: number | null): void {
   localInitCooldownMs = ms ?? 30_000;
+}
+
+/** For tests: observe the pending init-retry deadline (epoch ms; 0 = none). */
+export function _getLocalInitRetryAtForTest(): number {
+  return localInitRetryAt;
 }
 
 /** For tests: reset the local provider probe + transient-retry state. */
@@ -823,10 +851,14 @@ class LocalProvider implements EmbeddingProvider {
                   );
                 }
               } else {
-                localInitRetryAt = Date.now() + localInitCooldownMs;
+                const retryDelayMs = computeInitRetryDelayMs(
+                  localInitFailures,
+                  localInitCooldownMs,
+                );
+                localInitRetryAt = Date.now() + retryDelayMs;
                 log.warn(
                   `local embedding init failed (attempt ${localInitFailures}/${LOCAL_INIT_MAX_ATTEMPTS}): ${msg.error}. ` +
-                    `Retrying with a fresh worker after a cooldown; recall is FTS-only until then.`,
+                    `Retrying with a fresh worker in ~${Math.round(retryDelayMs / 1000)}s; recall is FTS-only until then.`,
                 );
               }
             }

--- a/packages/core/test/embedding-init-retry.test.ts
+++ b/packages/core/test/embedding-init-retry.test.ts
@@ -108,7 +108,9 @@ describe("local embedding init retry (transient self-heal)", () => {
   }
 
   it("stays FTS-only during the cooldown without prematurely retrying", async () => {
-    _setLocalInitCooldownMsForTest(60_000); // long → still cooling down
+    // Ceiling well above the first-retry delay; the synchronous checks below
+    // run at t≈0, comfortably inside the (~2s) cooldown, so no premature respawn.
+    _setLocalInitCooldownMsForTest(60_000);
     const fakes = installFakeWorkers();
     await failInit(fakes, TRANSIENT_ERR);
 

--- a/packages/core/test/embedding-optional-stack.test.ts
+++ b/packages/core/test/embedding-optional-stack.test.ts
@@ -6,10 +6,12 @@ import { fileURLToPath } from "node:url";
 import type { Worker } from "node:worker_threads";
 import { afterEach, beforeEach, describe, expect, it, test } from "vitest";
 import {
+  computeInitRetryDelayMs,
   embed,
   isAvailable,
   runStartupBackfill,
   LocalProviderUnavailableError,
+  _getLocalInitRetryAtForTest,
   _markLocalProviderUnavailable,
   _resetLocalProviderProbe,
   _restoreProvider,
@@ -230,6 +232,60 @@ describe("init-error classification (worker-mock)", () => {
     expect(errors.some((l) => /failed to init/i.test(l.message))).toBe(true);
     // The install-guidance warn is reserved for the not-installed case.
     expect(warns.some((l) => /not installed/i.test(l.message))).toBe(false);
+  });
+
+  it("transient init failure arms a FAST first retry (~2s), not the 30s ceiling", async () => {
+    _setLocalInitCooldownMsForTest(null); // production ceiling (30s)
+    const fakes: FakeWorker[] = [];
+    _setTestWorkerFactory(() => {
+      const f = new FakeWorker();
+      fakes.push(f);
+      return f as unknown as Worker;
+    });
+
+    const result = settle(embed(["hello"], "query"));
+    await flush();
+    // A cold ORT parse failure — transient, recovers on the next fresh worker.
+    fakes[0].emit("message", {
+      type: "init-error",
+      error: "Can't create a session. ERROR_CODE: 7, protobuf parsing failed",
+    });
+    await flush();
+    await result;
+
+    // The first retry is armed ~2s out (INIT_RETRY_BASE_MS), NOT the flat 30s
+    // the provider used to wait — that flat wait was the entire startup
+    // FTS-only window for a self-healing blip. Fails if reverted to the
+    // fixed-cooldown behaviour (delay would be ~30_000).
+    const delayMs = _getLocalInitRetryAtForTest() - Date.now();
+    expect(delayMs).toBeGreaterThan(1_000);
+    expect(delayMs).toBeLessThanOrEqual(2_000);
+    expect(isAvailable()).toBe(false); // FTS-only during the (now short) cooldown
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Part B2 — init-retry backoff schedule (pure)
+// ---------------------------------------------------------------------------
+
+describe("computeInitRetryDelayMs (init-retry backoff)", () => {
+  test("fast first retry, geometric backoff, clamped to the ceiling", () => {
+    // Production ceiling 30s; LOCAL_INIT_MAX_ATTEMPTS=3 → two retry waits: 2s, 8s.
+    expect(computeInitRetryDelayMs(1, 30_000)).toBe(2_000);
+    expect(computeInitRetryDelayMs(2, 30_000)).toBe(8_000);
+    // 32s (attempt 3) would exceed the ceiling → clamped.
+    expect(computeInitRetryDelayMs(3, 30_000)).toBe(30_000);
+    // A lower ceiling clamps sooner.
+    expect(computeInitRetryDelayMs(2, 5_000)).toBe(5_000);
+  });
+
+  test("ceiling 0 (the test seam) collapses to immediate retry", () => {
+    expect(computeInitRetryDelayMs(1, 0)).toBe(0);
+    expect(computeInitRetryDelayMs(2, 0)).toBe(0);
+  });
+
+  test("guards failures < 1 (never a negative exponent)", () => {
+    expect(computeInitRetryDelayMs(0, 30_000)).toBe(2_000);
   });
 });
 

--- a/packages/core/test/embedding-optional-stack.test.ts
+++ b/packages/core/test/embedding-optional-stack.test.ts
@@ -4,7 +4,7 @@ import { EventEmitter } from "node:events";
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 import type { Worker } from "node:worker_threads";
-import { afterEach, beforeEach, describe, expect, it, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, test, vi } from "vitest";
 import {
   computeInitRetryDelayMs,
   embed,
@@ -155,6 +155,7 @@ describe("init-error classification (worker-mock)", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     registerSink(passthroughSink);
     _setTestWorkerFactory(null);
     _setLocalInitCooldownMsForTest(null);
@@ -234,8 +235,12 @@ describe("init-error classification (worker-mock)", () => {
     expect(warns.some((l) => /not installed/i.test(l.message))).toBe(false);
   });
 
-  it("transient init failure arms a FAST first retry (~2s), not the 30s ceiling", async () => {
+  it("transient init failure arms a FAST first retry (2s), not the 30s ceiling", async () => {
     _setLocalInitCooldownMsForTest(null); // production ceiling (30s)
+    // Freeze Date ONLY (keep real timers so flush()'s setTimeout still fires) so
+    // the armed deadline is deterministic — no wall-clock/monotonicity guessing.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(0);
     const fakes: FakeWorker[] = [];
     _setTestWorkerFactory(() => {
       const f = new FakeWorker();
@@ -253,13 +258,11 @@ describe("init-error classification (worker-mock)", () => {
     await flush();
     await result;
 
-    // The first retry is armed ~2s out (INIT_RETRY_BASE_MS), NOT the flat 30s
-    // the provider used to wait — that flat wait was the entire startup
-    // FTS-only window for a self-healing blip. Fails if reverted to the
-    // fixed-cooldown behaviour (delay would be ~30_000).
-    const delayMs = _getLocalInitRetryAtForTest() - Date.now();
-    expect(delayMs).toBeGreaterThan(1_000);
-    expect(delayMs).toBeLessThanOrEqual(2_000);
+    // Date frozen at 0 → the deadline IS the backoff delay: exactly 2s
+    // (INIT_RETRY_BASE_MS), NOT the flat 30s the provider used to wait — that
+    // flat wait was the entire startup FTS-only window for a self-healing blip.
+    // Fails if reverted to the fixed-cooldown behaviour (would be 30_000).
+    expect(_getLocalInitRetryAtForTest()).toBe(2_000);
     expect(isAvailable()).toBe(false); // FTS-only during the (now short) cooldown
   });
 });


### PR DESCRIPTION
## Background (the "flapping" investigation)

The embedding provider on a self-hosted install looked like it was "flapping". Deep dive: it wasn't. `protobuf parsing failed` (ORT `ERROR_CODE: 7` = `INVALID_PROTOBUF`) occurred **exactly twice ever**, each immediately after a cold gateway restart, and **self-healed** — the provider has since been stable for hours.

**Ruled out:** not a bad file (model is 137 MB, valid header, loads cleanly in isolation), not memory (12 Gi free), not in-process concurrency (serial *and* 6-way concurrent cold loads under both node and bun → 0 failures across trials).

**Root cause:** a cold-start transient in the Bun worker_thread's native ORT env. The decisive clue is the retry path: the model was intact, so the worker took its in-worker immediate retry (`embedding-worker.ts` "retrying load without purging") — and that *also* failed. Only a **fresh worker_thread** recovered. So the bad state is in that worker's ORT env, not the file; retrying in the same worker is futile, a fresh worker reliably recovers. Likely trigger: the model load racing heavy startup I/O.

## The actual problem this fixes

Recovery was gated behind a **flat 30s** init-retry cooldown (`localInitCooldownMs`, `LOCAL_INIT_MAX_ATTEMPTS=3`). Since the transient recovers on the *next* fresh-worker respawn, that flat 30s was the **entire** startup FTS-only window for a self-healing blip — pure waste.

## Change

Replace the flat cooldown with a **fast-first-retry geometric backoff**:

```
computeInitRetryDelayMs(failures, ceiling) = min(ceiling, 2_000 * 4^(failures-1))
```

With `LOCAL_INIT_MAX_ATTEMPTS=3`, the two retry waits become **~2s then ~8s** (was 30s, 30s) — shrinking the startup FTS-only window ~15x for the common case, while keeping respawn-storm backoff for genuine failures. The ceiling remains the test seam (`0` → retry immediately, unchanged for existing tests). The warn log now reports the actual delay (`Retrying with a fresh worker in ~2s`).

This is deliberately a proportionate fix — it makes recovery from the (rare, self-healing) transient fast rather than trying to eliminate an ORT cold-load flake I couldn't reproduce in isolation.

## Tests

- `computeInitRetryDelayMs` pure unit tests: schedule (2s, 8s), ceiling clamp, zero-ceiling seam, `failures < 1` guard.
- Worker-mock wiring test: a transient init failure arms the first retry **~2s out, not ~30s**.
- Both mutation-verified RED (revert wiring → flat 30s → wiring test fails; neuter the helper → schedule tests fail).
- Full `@loreai/core` suite: 2725 passed / 6 skipped. typecheck + biome clean.

## Note
Likely linked to the WAL size (#1221, now fixed): if the 5.4 GB WAL replay was the startup-I/O trigger, that fix should also reduce how often this transient fires.