### PR TITLE
feat(supabase): raise free-tier entity-graph caps (#1221 follow-up)

### DIFF
--- a/packages/core/src/sync-data.ts
+++ b/packages/core/src/sync-data.ts
@@ -621,7 +621,7 @@ function rowIdExpr(m: SyncTableMeta): string {
  * the MOST USEFUL rows (mirrors the knowledge seed; the push drains the outbox in seq
  * order and the server rejects once the cap is hit, so seed order = what survives):
  *  - entities: most-referenced first (by knowledge_entity_refs count), then recency —
- *    a heavily-referenced entity is more useful than a one-off, and the cap is small (30).
+ *    a heavily-referenced entity is more useful than a one-off when the free cap bites.
  *  - entity_relations: recency (updated_at, then created_at).
  *  - entity_aliases: recency (created_at — the table has no updated_at).
  *  - knowledge_meta: LIVE entries only (JOIN knowledge_current), same value order as

--- a/packages/gateway/test/sync-security.integration.test.ts
+++ b/packages/gateway/test/sync-security.integration.test.ts
@@ -15,10 +15,10 @@ import { type PgHarness, startPgHarness } from "./helpers/pg-harness";
 /** Free-tier defaults (mirror supabase/migrations/0003 + 0009) — restored after quota tests. */
 const FREE_LIMITS: Record<string, number> = {
   knowledge: 500,
-  entities: 30,
-  entity_aliases: 300,
-  entity_relations: 300,
-  knowledge_entity_refs: 2000,
+  entities: 300, // 0017: proportionate to knowledge=500 (was 30 — crippled the graph)
+  entity_aliases: 3000, // 0017: ~10x entities (was 300)
+  entity_relations: 1500, // 0017 (was 300)
+  knowledge_entity_refs: 5000, // 0017: ~10 refs/entity (was 2000)
   knowledge_meta: 5000, // 0016: headroom above knowledge so metas never bottleneck independently
   knowledge_meta_crdt: 5000,
   account_escrow: 2,
@@ -869,10 +869,10 @@ describe.skipIf(gate())("sync migrations — knowledge eviction (#1191b)", () =>
   }
   afterEach(async () => {
     if (gate()) return;
-    await setCap("knowledge", 500);
-    await setCap("entities", 30);
-    await setCap("entity_aliases", 300);
-    await setCap("entity_relations", 300);
+    await setCap("knowledge", FREE_LIMITS.knowledge);
+    await setCap("entities", FREE_LIMITS.entities);
+    await setCap("entity_aliases", FREE_LIMITS.entity_aliases);
+    await setCap("entity_relations", FREE_LIMITS.entity_relations);
     await setByteCap("knowledge", 12582912);
     await setEvictionBudget(200); // restore default so the low-budget test can't leak
   });

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -49,8 +49,9 @@ Migrations are plain SQL, applied in filename order:
   (RLS only governs ownership, not volume/size):
   - `profiles.tier` + a tunable `plan_limits(tier, table_name → max_rows)` table.
   - `BEFORE INSERT` quota trigger per table (free: knowledge ≤ 500, entities ≤
-    30, aliases ≤ 300, relations ≤ 300, refs ≤ 2000; pro generous; null =
-    unlimited). `SECURITY DEFINER` so it reads tier/limits past RLS.
+    300, aliases ≤ 3000, relations ≤ 1500, refs ≤ 5000; pro generous; null =
+    unlimited). `SECURITY DEFINER` so it reads tier/limits past RLS. (Entity-graph
+    caps raised in 0017 — the graph is cheap and makes knowledge navigable.)
   - `CHECK` constraints capping per-field size (title ≤ 512, content ≤ 8192, …).
   Per-request RATE limiting is intentionally deferred to an edge layer / hosted
   backend (paid tiers); these caps bound storage + cardinality + payload, which
@@ -63,7 +64,7 @@ Migrations are plain SQL, applied in filename order:
     could `PATCH /profiles {tier:'pro'}` and defeat all quotas.)
   - **Every user-controlled TEXT column is size-capped** (not just the obvious
     ones) — row-count caps alone don't bound storage; an uncapped column let a
-    30-row user store 30×~1GB blobs.
+    small-row-cap user store a handful of ~1GB blobs.
   - **DML `GRANT`s to `authenticated`** so PostgREST actually works (RLS is the
     2nd gate; without a table grant every call is denied). Landed in the SAME
     migration as the tier lock so write-access never precedes the guard.

--- a/supabase/migrations/0017_entity_graph_caps.sql
+++ b/supabase/migrations/0017_entity_graph_caps.sql
@@ -1,0 +1,28 @@
+-- Migration 0017: raise the free-tier entity-graph row caps
+--
+-- The original free caps (0003) sized the entity graph at entities=30 against
+-- knowledge=500 — far too tight. A real 500-entry knowledge base extracts ~100-300
+-- entities, so at 30 the graph that makes knowledge navigable is mostly evicted (a
+-- user with 115 entities synced only 30, and the refs/aliases to the other ~85 became
+-- orphans skipped on pull). Entities are cheap (~200 B/row), so keep the *content*
+-- cap (knowledge=500) as the real free-tier limit and let the graph be proportionate.
+--
+--   entities              30 ->  300   (~proportionate to knowledge=500)
+--   entity_aliases       300 -> 3000   (~10x entities)
+--   entity_relations     300 -> 1500
+--   knowledge_entity_refs 2000 -> 5000  (~10 refs/entity)
+--
+-- Row caps only. The free-tier byte caps (0007: entities 1 MB, aliases/relations 2 MB,
+-- refs 1 MB) already hold the new row counts with headroom (e.g. 3000 aliases ~= 450 KB
+-- << 2 MB), so they stay as the anti-abuse backstop and won't surprise-bind before the
+-- row cap. Pro tier unchanged. Idempotent (plain UPDATE of existing rows).
+
+update public.plan_limits set max_rows = v.max_rows
+  from (values
+    ('entities',               300),
+    ('entity_aliases',        3000),
+    ('entity_relations',      1500),
+    ('knowledge_entity_refs', 5000)
+  ) as v(table_name, max_rows)
+ where public.plan_limits.tier = 'free'
+   and public.plan_limits.table_name = v.table_name;


### PR DESCRIPTION
Follow-up to the #1221 work / the entity-cap concern surfaced during live sync testing (a user with **115 entities synced only 30**, and the refs/aliases to the other ~85 became orphans skipped on pull — #1215/#1222).

## Why
The original free caps (`0003_sync_limits.sql`) sized the entity graph at **entities=30** against **knowledge=500** — a 16× tighter cap on the *cheap, high-value* graph than on the content it indexes. A real 500-entry knowledge base extracts ~100–300 entities, so at 30 the graph that makes knowledge navigable is mostly evicted. Entities are ~200 B/row, so the content cap (knowledge=500) should be the real free-tier limit and the graph should be proportionate.

## Change (migration 0017, row caps only)
| table | before | after |
|---|---|---|
| entities | 30 | **300** |
| entity_aliases | 300 | **3000** |
| entity_relations | 300 | **1500** |
| knowledge_entity_refs | 2000 | **5000** |

knowledge (500) and **pro tier unchanged**. ~1 MB more per free user.

## Byte caps unchanged — on purpose
The free-tier `max_bytes` (0007: entities 1 MB, aliases/relations 2 MB, refs 1 MB) already hold the new row counts with headroom, so the **row cap binds first** and the byte caps stay as the anti-abuse backstop:
| table | new rows | ~bytes/row (user cols) | total | byte cap | per-row budget |
|---|---|---|---|---|---|
| entities | 300 | ~300 | ~90 KB | 1 MB | ~3.5 KB |
| entity_aliases | 3000 | ~122 | ~366 KB | 2 MB | ~699 B |
| entity_relations | 1500 | ~183 | ~275 KB | 2 MB | ~1.4 KB |
| knowledge_entity_refs | 5000 | ~72 | ~360 KB | 1 MB | ~210 B |

## Rollout
Server-side only — takes effect when the migration auto-deploys; **no client release needed** (the 0015 server-side eviction just raises its threshold). Existing users' next sync admits more of their graph.

## Validation
- Migration is a plain idempotent `UPDATE` of existing `plan_limits` rows.
- Updated the integration-test `afterEach` restore map (`FREE_LIMITS`) to match.
- **Full Tier-1 Postgres integration suite (60 tests) green** with 0017 applied (real Docker Postgres). Typecheck + lint clean.