### PR TITLE
feat(distill): retain exact literal/style values (hex, CSS, dimensions, version tags) in observations (#961)

### DIFF
--- a/packages/core/src/prompt.ts
+++ b/packages/core/src/prompt.ts
@@ -63,6 +63,7 @@ In coding sessions, the following must be recorded exactly as they appear:
 - Directory contents when enumerated: "src/auth/ contains: jwt.ts, password.ts, middleware.ts, rate-limiter.ts, routes.ts"
 - Test results: "47 tests passing, 3 failing in auth.test.ts"
 - Environment variables: DATABASE_URL, NEXT_PUBLIC_API_URL, CODECOV_TOKEN
+- Exact literal & style values — record the LITERAL token, never a paraphrase: hex colors (#1164a3, #0d2244), CSS declarations (border-radius: 10px, inset 0 8px 0 0, box-shadow: inset 0 8px 0 0, margin-left: 8px), pixel/size dimensions (18px, 8px), version/tag labels (v45), commit SHAs, and CSS/DOM selectors ([class*="ThreadList"], .virtual-list). "Styling", "visual", or "config" details are NOT low-value — they are exactly what the user asks to recall verbatim later.
 
 BAD: 🟡 Added password hashing to the auth module.
 GOOD: 🟡 Added bcrypt password hashing (12 salt rounds) in src/auth/password.ts. Argon2 was considered but rejected — better bcrypt library support for Node 20.
@@ -72,6 +73,9 @@ GOOD: 🟡 CI uses codecov/codecov-action@v4 with CODECOV_TOKEN secret. fail_ci_
 
 BAD: 🟡 Created database schema with several models.
 GOOD: 🟡 Prisma schema defines 4 models: User, Post, Comment, Tag. Migration 20250506_initial_schema creates all tables + Role enum + _PostToTag join table. Cascade delete on User → Post → Comment.
+
+BAD: 🟡 Adjusted the chat panel frame styling and rounded its corners.
+GOOD: 🟡 Chat panel frame (v45): border-top: 8px solid #1164a3; border-left: 8px solid #1164a3; box-shadow: inset 0 8px 0 0; outer container border-radius: 10px, inner .virtual-list border-radius: 8px; rounded top-left + bottom-left corners (18px). Dark-mode variant uses #0d2244.
 
 EXACT NUMBERS — NEVER APPROXIMATE:
 
@@ -248,7 +252,11 @@ This section answers: "Why did we choose approach X?" and "What alternatives wer
 
 ### Technical Changes
 Bugs found, root causes, fixes applied, files modified, tests added/fixed.
-Preserve exact file paths, line numbers, error messages, and commit references.
+Preserve exact file paths, line numbers, error messages, commit references, and
+literal values verbatim — hex colors (#1164a3), CSS/style declarations
+(border-radius: 10px, inset 0 8px 0 0), pixel dimensions (18px), version tags
+(v45), selectors ([class*="ThreadList"]), and exact counts. Never paraphrase a
+style/config value into prose ("rounded corners" loses "border-radius: 10px").
 This section answers: "What bugs were fixed?" and "What files were changed?"
 
 ### Session Timeline

--- a/packages/core/test/distillation-prompt-specifics.test.ts
+++ b/packages/core/test/distillation-prompt-specifics.test.ts
@@ -1,0 +1,32 @@
+import { describe, test, expect } from "vitest";
+import { DISTILLATION_SYSTEM, RECURSIVE_SYSTEM } from "../src/prompt";
+
+/**
+ * The retrieval diagnostic (#961) found the exact facts users ask to recall —
+ * hex colors, CSS declarations, pixel dimensions, version tags, selectors —
+ * were dropped from distillations as "styling/config" noise. These tests lock
+ * in the prompt guidance that those literal values must be retained verbatim,
+ * through both first-pass distillation and recursive consolidation.
+ */
+describe("distillation prompts — exact literal value preservation (#961)", () => {
+  test("DISTILLATION_SYSTEM instructs verbatim retention of hex/CSS/version literals", () => {
+    for (const token of [
+      "#1164a3",
+      "border-radius",
+      "inset 0 8px 0 0",
+      "v45",
+      "ThreadList",
+    ]) {
+      expect(DISTILLATION_SYSTEM).toContain(token);
+    }
+    // Frames styling/config as high-value, not skippable noise.
+    expect(DISTILLATION_SYSTEM.toLowerCase()).toContain("literal");
+  });
+
+  test("RECURSIVE_SYSTEM preserves literal style/config values through consolidation", () => {
+    for (const token of ["#1164a3", "border-radius", "v45"]) {
+      expect(RECURSIVE_SYSTEM).toContain(token);
+    }
+    expect(RECURSIVE_SYSTEM.toLowerCase()).toContain("never paraphrase");
+  });
+});


### PR DESCRIPTION
## Why

The retrieval diagnostic (#961, harness in #1211) found that the specific facts users ask to recall **verbatim** — hex colors (`#1164a3`), CSS declarations (`border-radius: 10px`, `inset 0 8px 0 0`), pixel dimensions (`18px`), version tags (`v45`), selectors (`[class*="ThreadList"]`) — were dropped from distillations as "styling/config" noise. Distillations held only **~6%** of expected facts vs **~90%** in raw temporal.

`DISTILLATION_SYSTEM` and `RECURSIVE_SYSTEM` already preserve file paths, function names, exact counts, and error codes — but never *named* literal style/config values, so a worker model treats them as skippable prose.

## What

- **`DISTILLATION_SYSTEM`**: new *"Exact literal & style values"* bullet + a worked BAD/GOOD example (chat-panel frame) that explicitly frames styling/config as high-value, not noise.
- **`RECURSIVE_SYSTEM`**: extends *Technical Changes* to carry those literals through meta-consolidation ("never paraphrase a style/config value into prose — 'rounded corners' loses 'border-radius: 10px'").

Complements #1228 (which surfaces these from raw temporal at injection time): richer distillations mean the specifics also survive compaction into the **durable** pool, so they're available even after raw messages age out.

## Tests
- `distillation-prompt-specifics.test.ts` locks in the guidance tokens so the intent can't silently regress.
- `distillation.test.ts` unaffected (121 pass); `tsc` clean.

Follow-up: validate lift via the eval harness (distillation-quality run) — expect the distillation-only passive share to rise from the ~6% floor.

Refs #961