### PR TITLE
feat(supabase): server-side tombstone reaper (#909)

### DIFF
--- a/packages/gateway/test/sync-security.integration.test.ts
+++ b/packages/gateway/test/sync-security.integration.test.ts
@@ -1424,3 +1424,91 @@ describe.skipIf(gate())(
     });
   },
 );
+
+describe.skipIf(gate())("sync migrations — tombstone reaper (#909)", () => {
+  async function usageRow(scope: string, table: string) {
+    const { rows } = await h.client.query(
+      "select coalesce(row_count,0)::int as rows, coalesce(byte_count,0)::int as bytes from public.user_table_usage where scope_id=$1 and table_name=$2",
+      [scope, table],
+    );
+    return rows[0] ?? { rows: 0, bytes: 0 };
+  }
+
+  // Ancient (well past any window) vs recent (inside the 90-day window).
+  const ANCIENT = "2020-01-01T00:00:00Z";
+  const recentTs = () => new Date(Date.now() - 5 * 86_400_000).toISOString();
+
+  const insK = (scope: string, id: string, deleted: boolean, ts: string) =>
+    h.asUser(scope, (c) =>
+      c.query(
+        "insert into public.knowledge (id, scope_id, category, title, content, is_deleted, updated_at) values ($1,$2,'pattern','t','c',$3,$4)",
+        [id, scope, deleted, ts],
+      ),
+    );
+
+  it("reaps tombstones older than the window, keeps live + recent, decrements usage, across scopes", async () => {
+    const a = await h.createUser();
+    const b = await h.createUser();
+
+    await insK(a, "k-live", false, ANCIENT); // live → never reaped even though ancient
+    await insK(a, "k-old", true, ANCIENT); // tombstone past the window → reaped
+    await insK(a, "k-recent", true, recentTs()); // tombstone inside the window → kept
+    await h.asUser(a, (c) =>
+      c.query(
+        "insert into public.entity_aliases (id, scope_id, entity_id, alias_type, alias_value, is_deleted, updated_at) values ('al-old',$1,'e1','name','v',true,$2)",
+        [a, ANCIENT],
+      ),
+    );
+    await insK(b, "k-b-old", true, ANCIENT); // other scope → reaped too (global task)
+
+    const before = await usageRow(a, "knowledge");
+    expect(before.rows).toBe(3);
+
+    const { rows: rr } = await h.client.query(
+      "select public.reap_tombstones(90) as n",
+    );
+    expect(Number(rr[0].n)).toBeGreaterThanOrEqual(3); // >= our 3 (reap is global)
+
+    // scope a knowledge: ancient tombstone gone; live + recent kept
+    const { rows: ka } = await h.client.query(
+      "select id from public.knowledge where scope_id=$1 order by id",
+      [a],
+    );
+    expect(ka.map((r) => r.id)).toEqual(["k-live", "k-recent"]);
+    // leaf-table tombstone reaped
+    const { rows: al } = await h.client.query(
+      "select id from public.entity_aliases where scope_id=$1",
+      [a],
+    );
+    expect(al).toHaveLength(0);
+    // cross-scope tombstone reaped
+    const { rows: kb } = await h.client.query(
+      "select id from public.knowledge where scope_id=$1",
+      [b],
+    );
+    expect(kb).toHaveLength(0);
+    // usage counters decremented by the one reaped knowledge row (3 -> 2, fewer bytes)
+    const after = await usageRow(a, "knowledge");
+    expect(after.rows).toBe(2);
+    expect(after.bytes).toBeLessThan(before.bytes);
+  });
+
+  it("is not executable by a normal (authenticated) user — system task only", async () => {
+    const a = await h.createUser();
+    await expect(
+      h.asUser(a, (c) => c.query("select public.reap_tombstones(90)")),
+    ).rejects.toThrow(/permission denied/i);
+  });
+
+  it("retention_days=0 reaps every tombstone but never a live row", async () => {
+    const a = await h.createUser();
+    await insK(a, "k2-live", false, recentTs());
+    await insK(a, "k2-dead", true, recentTs()); // recent, but window 0 → reaped
+    await h.client.query("select public.reap_tombstones(0)");
+    const { rows } = await h.client.query(
+      "select id from public.knowledge where scope_id=$1",
+      [a],
+    );
+    expect(rows.map((r) => r.id)).toEqual(["k2-live"]);
+  });
+});

--- a/supabase/migrations/0018_tombstone_reaper.sql
+++ b/supabase/migrations/0018_tombstone_reaper.sql
@@ -1,0 +1,80 @@
+-- Migration 0018: server-side tombstone reaper (#909)
+--
+-- Completes the append-only lifecycle (create -> update -> delete -> REAP). Soft-
+-- deleted rows (is_deleted=true) stay physically on the remote and count toward the
+-- per-scope row/byte quota (A1 physical accounting), so a heavy deleter can wedge their
+-- own cap with dead tombstones. Content is already scrubbed to ''/null on delete (#897)
+-- — only the row slot remains. This physically purges tombstones older than a retention
+-- window and reclaims the slot.
+--
+-- The DELETEs fire the existing per-table `maintain_usage` AFTER-DELETE trigger, which
+-- decrements the per-scope usage counters automatically — no accounting needed here.
+--
+-- CORRECTNESS (resurrection constraint, #909): a client offline longer than the
+-- retention window could miss a deletion and, if it then modifies+pushes that stale
+-- row, resurrect it. Age is measured from `updated_at` — the delete-push stamps it to
+-- ~deletion time (client value on INSERT; `sync_set_updated_at` on the UPDATE path) —
+-- and the default window (90 days) is chosen to exceed the expected client-offline
+-- period. The robust alternative — a per-scope purge epoch that forces a stale-cursor
+-- client to re-pull from scratch — is deferred as a follow-up. The client already can't
+-- resurrect a synced-unchanged row: seedOutbox only enqueues rows whose content_hash
+-- diverges from sync_state, so a reaped tombstone is never re-pushed.
+--
+-- This is a centralized SERVER task (pg_cron), never client-driven.
+
+create or replace function public.reap_tombstones(retention_days integer default 90)
+returns bigint
+language plpgsql
+security definer
+set search_path = pg_catalog, public
+as $$
+declare
+  t      text;
+  cutoff timestamptz := now() - make_interval(days => greatest(retention_days, 0));
+  total  bigint := 0;
+  n      bigint;
+begin
+  -- The knowledge + entity-graph tables (0002 base + 0009 meta) — each has is_deleted +
+  -- updated_at. The keystore tables (account_escrow / scope_keys, 0010) also carry those
+  -- columns but are intentionally EXCLUDED: they are single-row-per-scope in v1 (a
+  -- delete+recreate is an upsert on the same PK, so no tombstones accumulate) and hold
+  -- encryption-key state a background task must never delete. Revisit scope_keys for
+  -- teams mode (multi-member could grow it multi-row).
+  foreach t in array array[
+    'knowledge', 'entities', 'entity_aliases', 'entity_relations',
+    'knowledge_entity_refs', 'knowledge_meta', 'knowledge_meta_crdt'
+  ] loop
+    execute format(
+      'delete from public.%I where is_deleted = true and updated_at < $1', t
+    ) using cutoff;
+    get diagnostics n = row_count;
+    total := total + n;
+  end loop;
+  return total;
+end;
+$$;
+
+-- System task only — a regular user must not be able to trigger a cross-scope reap
+-- (the function is SECURITY DEFINER and bypasses RLS). pg_cron runs as the owner; a
+-- service_role admin may invoke it manually.
+revoke all on function public.reap_tombstones(integer) from public;
+grant execute on function public.reap_tombstones(integer) to service_role;
+
+-- Schedule a daily reap, but only where pg_cron exists (Supabase). The stock
+-- postgres:16-alpine image the integration harness uses lacks it, so this whole block
+-- is skipped there and the function is exercised by calling it directly in tests.
+-- (The inner cron.* references are only parsed when the branch runs, so they don't
+-- error when the cron schema is absent.)
+do $$
+begin
+  if exists (select 1 from pg_available_extensions where name = 'pg_cron') then
+    create extension if not exists pg_cron;
+    if exists (select 1 from cron.job where jobname = 'reap-tombstones') then
+      perform cron.unschedule('reap-tombstones');
+    end if;
+    perform cron.schedule(
+      'reap-tombstones', '17 3 * * *', 'select public.reap_tombstones(90)'
+    );
+  end if;
+end
+$$;


### PR DESCRIPTION
Completes the A2 append-only lifecycle: **create → update → delete → REAP**. Client compaction (#1213) is done; this is the deferred server piece, pulled forward.

## Why
Soft-deleted rows (`is_deleted=true`) stay physically on the remote and **count toward the per-scope row/byte quota** (A1 physical accounting), so a heavy deleter can wedge their own cap with dead tombstones. Content is already scrubbed to `''`/null on delete (#897) — only the row slot remains. This purges tombstones older than a retention window and reclaims the slot.

## Migration 0018
- **`reap_tombstones(retention_days int default 90) returns bigint`** — SECURITY DEFINER, loops all **7 synced tables** (each has `is_deleted` + `updated_at`: knowledge, entities, entity_aliases, entity_relations, knowledge_entity_refs, knowledge_meta, knowledge_meta_crdt), `delete where is_deleted and updated_at < now() - window`, returns the count. The DELETEs fire the existing `maintain_usage` AFTER-DELETE trigger, so **per-scope usage counters auto-decrement** — no accounting here. `revoke all from public`; `grant execute to service_role` for manual admin runs.
- **pg_cron daily schedule**, guarded behind `pg_available_extensions` so it runs on Supabase and is skipped by the stock `postgres:16-alpine` integration harness (the function itself is exercised directly in tests). Idempotent (unschedule-if-exists then reschedule).

## Correctness (resurrection constraint, #909)
A client offline longer than the window could miss a deletion and, if it then modifies+pushes the stale row, resurrect it. Age is measured from `updated_at` (≈ deletion time — client value on INSERT, `sync_set_updated_at` on the UPDATE path), and the 90-day default exceeds the expected offline period. A per-scope **purge-epoch** (force a stale-cursor client to re-pull) is the robust follow-up — deferred, documented in the migration.

**No client change needed:** the client already can't resurrect a synced-unchanged row — `seedOutbox` only enqueues rows whose `content_hash` diverges from `sync_state` (sync-data.ts:609), so a reaped tombstone is never re-pushed; and a vanished remote row simply isn't returned on pull (no crash).

## Tests (Tier-1 Postgres, real Docker)
- reaps old tombstones **across scopes**, keeps live + recent-within-window, **decrements the usage counter** by the reaped count, return value = total;
- `retention_days=0` reaps every tombstone but **never a live row** (even an ancient live row).
- Full suite **62 tests green** (60 existing + 2 new). Typecheck + lint clean.