### PR TITLE
fix(sync): converge pulled entity_alias UNIQUE collisions instead of skipping (#1217)

### DIFF
--- a/packages/core/src/sync-data.ts
+++ b/packages/core/src/sync-data.ts
@@ -1340,6 +1340,75 @@ export function recordConflict(
     );
 }
 
+/**
+ * Deterministic convergence for a pulled `entity_aliases` row that violates the local
+ * `UNIQUE(alias_type, alias_value)` the FK-less remote doesn't enforce (#1217). Two
+ * devices can independently mint an alias for the same (type, value) with DIFFERENT ids;
+ * without a rule each device keeps the OTHER's copy and they never converge. The tiebreak
+ * is symmetric — the LOWER alias id wins on EVERY device — so the outcome is identical
+ * regardless of pull order.
+ *
+ * `reapply` re-applies the winning remote row; it's invoked ONLY when the remote wins,
+ * after the losing local row is dropped so the collision is cleared. Returns true when
+ * the conflict is resolved (the caller advances the cursor + counts it), or false to fall
+ * back to the generic constraint skip — either because there is no local (type, value)
+ * collision, or because the remote alias is an FK orphan (its entity isn't admitted under
+ * the cap), in which case the valid local alias must stay.
+ *
+ * The losing local row is deleted WITHOUT sync-suppression, so its removal propagates via
+ * the outbox and the duplicate is cleaned off the remote too (then reaped, #909). The
+ * discarded row is recorded to `sync_conflicts`.
+ */
+export function resolveAliasUniqueConflict(
+  remote: Record<string, unknown>,
+  reapply: () => void,
+): boolean {
+  const at = remote.alias_type;
+  const av = remote.alias_value;
+  const remoteId = remote.id;
+  if (
+    typeof at !== "string" ||
+    typeof av !== "string" ||
+    typeof remoteId !== "string"
+  )
+    return false;
+  const local = db()
+    .query(
+      "SELECT id, entity_id, alias_type, alias_value FROM entity_aliases WHERE alias_type = ? AND alias_value = ?",
+    )
+    .get(at, av) as
+    | { id: string; entity_id: string; alias_type: string; alias_value: string }
+    | undefined;
+  // No local collision, or the very same row (an ordinary update, not a conflict) →
+  // let the caller apply/skip it normally.
+  if (!local || local.id === remoteId) return false;
+
+  if (remoteId < local.id) {
+    // Remote alias has the lower id → it wins. But only proceed if it can actually
+    // apply: its entity must be admitted locally, else it's an FK orphan and the valid
+    // local alias must stay (the caller skips the orphan remote row).
+    const entityId = remote.entity_id;
+    if (
+      typeof entityId !== "string" ||
+      !db().query("SELECT 1 FROM entities WHERE id = ?").get(entityId)
+    )
+      return false;
+    recordConflict(
+      "entity_aliases",
+      local.id,
+      "alias_unique_superseded",
+      local,
+    );
+    db().query("DELETE FROM entity_aliases WHERE id = ?").run(local.id);
+    reapply();
+    return true;
+  }
+
+  // Local alias has the lower id → it wins; discard the remote loser (recorded).
+  recordConflict("entity_aliases", remoteId, "alias_unique_superseded", remote);
+  return true;
+}
+
 // ---------------------------------------------------------------------------
 // Enable / disable
 // ---------------------------------------------------------------------------

--- a/packages/core/test/sync-alias-converge.test.ts
+++ b/packages/core/test/sync-alias-converge.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { db } from "../src/db";
+import { resolveAliasUniqueConflict } from "../src/sync-data";
+
+function insEntity(id: string) {
+  db()
+    .query(
+      "INSERT OR IGNORE INTO entities (id, entity_type, canonical_name, created_at, updated_at) VALUES (?,?,?,?,?)",
+    )
+    .run(id, "person", `n-${id}`, Date.now(), Date.now());
+}
+function insAlias(id: string, entityId: string, type: string, value: string) {
+  db()
+    .query(
+      "INSERT INTO entity_aliases (id, entity_id, alias_type, alias_value, created_at) VALUES (?,?,?,?,?)",
+    )
+    .run(id, entityId, type, value, Date.now());
+}
+function remoteAlias(
+  id: string,
+  entityId: string,
+  type: string,
+  value: string,
+) {
+  return { id, entity_id: entityId, alias_type: type, alias_value: value };
+}
+function conflicts(rowId: string) {
+  return db()
+    .query(
+      "SELECT resolution FROM sync_conflicts WHERE table_name='entity_aliases' AND row_id=?",
+    )
+    .all(rowId) as { resolution: string }[];
+}
+function aliasIds() {
+  return (
+    db().query("SELECT id FROM entity_aliases ORDER BY id").all() as {
+      id: string;
+    }[]
+  ).map((r) => r.id);
+}
+
+describe("resolveAliasUniqueConflict — alias UNIQUE convergence (#1217)", () => {
+  beforeEach(() => {
+    db().query("DELETE FROM entity_aliases").run();
+    db().query("DELETE FROM entities").run();
+    db().query("DELETE FROM sync_conflicts").run();
+  });
+
+  it("remote wins (lower id): drops local loser, runs reapply, records the discarded local", () => {
+    insEntity("e-lo");
+    insEntity("e-hi");
+    insAlias("al-bbb", "e-hi", "name", "Onur"); // local, higher id
+    let reapplied = false;
+    const ok = resolveAliasUniqueConflict(
+      remoteAlias("al-aaa", "e-lo", "name", "Onur"), // remote, lower id
+      () => {
+        reapplied = true;
+        insAlias("al-aaa", "e-lo", "name", "Onur"); // simulate applyRemote of the winner
+      },
+    );
+    expect(ok).toBe(true);
+    expect(reapplied).toBe(true);
+    expect(aliasIds()).toEqual(["al-aaa"]); // loser gone, winner present
+    expect(conflicts("al-bbb")).toHaveLength(1);
+  });
+
+  it("local wins (lower id): keeps local, no reapply, records the discarded remote", () => {
+    insEntity("e-lo");
+    insAlias("al-aaa", "e-lo", "name", "Onur"); // local, lower id
+    let reapplied = false;
+    const ok = resolveAliasUniqueConflict(
+      remoteAlias("al-bbb", "e-hi", "name", "Onur"), // remote, higher id
+      () => {
+        reapplied = true;
+      },
+    );
+    expect(ok).toBe(true);
+    expect(reapplied).toBe(false);
+    expect(aliasIds()).toEqual(["al-aaa"]);
+    expect(conflicts("al-bbb")).toHaveLength(1);
+  });
+
+  it("both pull orders converge to the same (lowest-id) winner", () => {
+    // Device X: local = lower id, remote = higher id → keeps the lower.
+    insEntity("e1");
+    insAlias("al-1", "e1", "name", "Dup");
+    resolveAliasUniqueConflict(remoteAlias("al-2", "e1", "name", "Dup"), () => {
+      throw new Error("must not reapply when local wins");
+    });
+    expect(aliasIds()).toEqual(["al-1"]);
+
+    // Device Y: local = higher id, remote = lower id → converges to the SAME winner.
+    db().query("DELETE FROM entity_aliases").run();
+    insAlias("al-2", "e1", "name", "Dup");
+    resolveAliasUniqueConflict(remoteAlias("al-1", "e1", "name", "Dup"), () => {
+      insAlias("al-1", "e1", "name", "Dup");
+    });
+    expect(aliasIds()).toEqual(["al-1"]);
+  });
+
+  it("falls through (false) when the remote alias's entity is not admitted (FK orphan)", () => {
+    insEntity("e-lo");
+    insAlias("al-bbb", "e-lo", "name", "Onur"); // valid local, higher id
+    const ok = resolveAliasUniqueConflict(
+      remoteAlias("al-aaa", "e-missing", "name", "Onur"), // lower id BUT orphan entity
+      () => {
+        throw new Error("must not reapply an FK-orphan remote");
+      },
+    );
+    expect(ok).toBe(false); // → caller does the generic skip, keeping the valid local
+    expect(aliasIds()).toEqual(["al-bbb"]);
+  });
+
+  it("falls through (false) when there is no local (type,value) collision", () => {
+    const ok = resolveAliasUniqueConflict(
+      remoteAlias("al-x", "e", "name", "Nobody"),
+      () => {
+        throw new Error("must not reapply");
+      },
+    );
+    expect(ok).toBe(false);
+  });
+});

--- a/packages/gateway/src/sync.ts
+++ b/packages/gateway/src/sync.ts
@@ -134,6 +134,23 @@ function isForeignKeyError(e: unknown): boolean {
   );
 }
 
+/**
+ * A UNIQUE (or PK) constraint violation. Used to route a pulled `entity_aliases` row that
+ * collides with a local row on `UNIQUE(alias_type, alias_value)` into the deterministic
+ * convergence resolver (#1217) instead of the generic skip. node:sqlite reports UNIQUE as
+ * errcode 2067; bun:sqlite as `SQLITE_CONSTRAINT_UNIQUE`.
+ */
+function isUniqueConstraintError(e: unknown): boolean {
+  if (!(e instanceof Error)) return false;
+  const code = String((e as { code?: string }).code ?? "");
+  const errcode = (e as { errcode?: number }).errcode;
+  return (
+    code === "SQLITE_CONSTRAINT_UNIQUE" ||
+    errcode === 2067 ||
+    /UNIQUE constraint failed/i.test(e.message)
+  );
+}
+
 // ---------------------------------------------------------------------------
 // C-4 (#825): wire encryption of knowledge content/title
 // ---------------------------------------------------------------------------
@@ -637,30 +654,18 @@ export async function pullOnce(
             applyRemote(meta, remote, res, touchedFts, enc);
           } catch (e) {
             // A ciphertext row we can't decrypt defers the WHOLE table (outer catch,
-            // no cursor advance) so it re-pulls once the key is available.
-            if (e instanceof EncryptedContentUnavailable) throw e;
-            // A pulled row that violates a LOCAL constraint the FK-less remote never
-            // enforces (e.g. an entity_aliases / knowledge_entity_refs row whose entity
-            // was never admitted under the entity cap → orphan on the remote). It can
-            // never apply as-is, so skip it — advancing the cursor past it so ONE poison
-            // row can't abort the whole multi-table sync or wedge the cursor.
-            if (!isSqliteConstraintError(e)) throw e;
-            res.skipped++;
-            syncData.recordConflict(
-              meta.table,
-              rid,
-              "pull_constraint_skip",
+            // no cursor advance) so it re-pulls once the key is available. Everything
+            // else (constraint) is resolved-or-skipped by the shared handler, then the
+            // cursor advances below so ONE poison row can't wedge the sync.
+            handlePulledRowConstraint(
+              meta,
               remote,
+              rid,
+              e,
+              res,
+              touchedFts,
+              enc,
             );
-            // FK orphans (parent beyond the plan cap) are EXPECTED + high-volume on
-            // a fresh device — count them (surfaced in the CLI summary + recorded to
-            // sync_conflicts) but DON'T log per row, or a WARN-per-orphan flood drowns
-            // the console and inflates the Sentry warning stream. A rarer non-FK skip
-            // (UNIQUE/CHECK/NOT NULL) is unexpected → keep it visible.
-            if (!isForeignKeyError(e))
-              log.notice(
-                `sync: pull ${meta.table} skipped a row (${rid}): ${(e as Error).message}`,
-              );
           }
           cursor = { ms, id: rid };
           advanced = true;
@@ -774,36 +779,65 @@ async function drainTimestamp(
     }
 
     for (const remote of rows) {
+      const rid = syncData.rowIdOf(meta.table, remote);
       try {
         applyRemote(meta, remote, res, touchedFts, enc);
       } catch (e) {
-        if (e instanceof EncryptedContentUnavailable) throw e;
-        // Orphan/poison pulled row (see the primary pull loop) — skip, don't abort;
-        // `last`/`cursor` still advance below so the drain can't wedge.
-        if (!isSqliteConstraintError(e)) throw e;
-        const rid = syncData.rowIdOf(meta.table, remote);
-        res.skipped++;
-        syncData.recordConflict(
-          meta.table,
-          rid,
-          "pull_constraint_skip",
-          remote,
-        );
-        // See the primary loop: FK orphans stay quiet (counted), rarer non-FK
-        // constraint skips stay visible.
-        if (!isForeignKeyError(e))
-          log.notice(
-            `sync: pull ${meta.table} skipped a row (${rid}): ${(e as Error).message}`,
-          );
+        // Same resolve-or-skip as the primary loop (incl. #1217 alias convergence) so
+        // the drain path — used when >PAGE rows share one exact ms — can't diverge or
+        // wedge; `last`/`cursor` still advance below.
+        handlePulledRowConstraint(meta, remote, rid, e, res, touchedFts, enc);
       }
       cols.forEach((c, i) => {
         last[i] = String(remote[c]);
       });
-      cursor = { ms: cursor.ms, id: syncData.rowIdOf(meta.table, remote) };
+      cursor = { ms: cursor.ms, id: rid };
     }
   }
   // Past this millisecond entirely; the next primary page resumes at ms+1.
   return { ms: cursor.ms + 1, id: "" };
+}
+
+/**
+ * Handle a constraint error thrown while applying a pulled row — shared by the primary
+ * pull loop and the `drainTimestamp` path so both converge identically. Rethrows
+ * encryption + non-constraint errors (the caller aborts the table). Otherwise: an
+ * entity_aliases UNIQUE(alias_type, alias_value) collision is resolved deterministically
+ * (#1217, the lower alias id wins on every device); anything else (FK orphan / CHECK /
+ * NOT NULL) is skipped so one poison row can't abort the whole multi-table sync or wedge
+ * the cursor. The caller advances the cursor after this returns.
+ */
+function handlePulledRowConstraint(
+  meta: syncData.SyncTableMeta,
+  remote: Record<string, unknown>,
+  rid: string,
+  e: unknown,
+  res: SyncResult,
+  touchedFts: Set<string>,
+  enc: EncSnapshot,
+): void {
+  if (e instanceof EncryptedContentUnavailable) throw e;
+  if (!isSqliteConstraintError(e)) throw e;
+  if (
+    meta.table === "entity_aliases" &&
+    isUniqueConstraintError(e) &&
+    syncData.resolveAliasUniqueConflict(remote, () =>
+      applyRemote(meta, remote, res, touchedFts, enc),
+    )
+  ) {
+    res.conflicts++;
+    return;
+  }
+  res.skipped++;
+  syncData.recordConflict(meta.table, rid, "pull_constraint_skip", remote);
+  // FK orphans (parent beyond the plan cap) are EXPECTED + high-volume on a fresh device
+  // — count them (surfaced in the CLI summary + recorded to sync_conflicts) but DON'T log
+  // per row, or a WARN-per-orphan flood drowns the console and inflates the Sentry
+  // warning stream. A rarer non-FK skip (CHECK/NOT NULL) is unexpected → keep it visible.
+  if (!isForeignKeyError(e))
+    log.notice(
+      `sync: pull ${meta.table} skipped a row (${rid}): ${(e as Error).message}`,
+    );
 }
 
 function applyRemote(

--- a/packages/gateway/test/sync.test.ts
+++ b/packages/gateway/test/sync.test.ts
@@ -979,7 +979,7 @@ describe("pullOnce", () => {
     ).not.toBeNull();
   });
 
-  test("a non-FK constraint skip (UNIQUE) stays VISIBLE (log.notice) and still counts as skipped", async () => {
+  test("resolves a pulled entity_alias UNIQUE collision deterministically — local (lower id) wins, not skipped (#1217)", async () => {
     syncData.enableSync("basic");
     const entId = "55555555-5555-4555-8555-555555555555";
     syncData.withApplying(() => {
@@ -988,17 +988,17 @@ describe("pullOnce", () => {
           "INSERT INTO entities (id, entity_type, canonical_name, created_at, updated_at) VALUES (?, 'tool', 'U', 1, 1)",
         )
         .run(entId);
-      // A local alias already occupies UNIQUE(alias_type='name', alias_value='Dup').
+      // Local alias with the LOWER id occupies UNIQUE(alias_type='name', alias_value='Dup').
       db()
         .query(
-          "INSERT INTO entity_aliases (id, entity_id, alias_type, alias_value, source, created_at) VALUES ('local-al', ?, 'name', 'Dup', NULL, 1)",
+          "INSERT INTO entity_aliases (id, entity_id, alias_type, alias_value, source, created_at) VALUES ('al-local', ?, 'name', 'Dup', NULL, 1)",
         )
         .run(entId);
     });
-    // Remote alias: NEW id, entity present (FK passes), but SAME (alias_type, alias_value)
-    // → a local UNIQUE violation, NOT an FK error → the rarer, unexpected skip class.
+    // Remote alias: HIGHER id, entity present (FK ok), SAME (alias_type, alias_value) →
+    // local UNIQUE collision. Deterministic tiebreak 'al-local' < 'al-remote' → LOCAL wins.
     tableRows("entity_aliases").push({
-      id: "remote-al",
+      id: "al-remote",
       entity_id: entId,
       alias_type: "name",
       alias_value: "Dup",
@@ -1010,12 +1010,68 @@ describe("pullOnce", () => {
     const noticeSpy = vi.spyOn(log, "notice");
     const r = await pullOnce(makeClient() as never);
 
-    // Unexpected non-FK constraint → stays LOUD (visible notice) AND counts as skipped.
-    expect(noticeSpy.mock.calls.flat().join(" ")).toMatch(/skipped a row/);
-    expect(r.skipped).toBeGreaterThanOrEqual(1);
+    // Converged, NOT skipped: no "skipped a row" notice; counted as a conflict.
+    expect(noticeSpy.mock.calls.flat().join(" ")).not.toMatch(/skipped a row/);
+    expect(r.conflicts).toBeGreaterThanOrEqual(1);
+    // Local (lower id) kept; remote loser discarded + recorded.
     expect(
-      db().query("SELECT 1 FROM entity_aliases WHERE id = 'remote-al'").get(),
+      db().query("SELECT 1 FROM entity_aliases WHERE id = 'al-local'").get(),
+    ).not.toBeNull();
+    expect(
+      db().query("SELECT 1 FROM entity_aliases WHERE id = 'al-remote'").get(),
     ).toBeNull();
+    expect(
+      db()
+        .query(
+          "SELECT 1 FROM sync_conflicts WHERE table_name='entity_aliases' AND row_id='al-remote' AND resolution='alias_unique_superseded'",
+        )
+        .get(),
+    ).not.toBeNull();
+  });
+
+  test("resolves a pulled entity_alias UNIQUE collision by applying the remote when it has the lower id (#1217)", async () => {
+    syncData.enableSync("basic");
+    const entId = "66666666-6666-4666-8666-666666666666";
+    syncData.withApplying(() => {
+      db()
+        .query(
+          "INSERT INTO entities (id, entity_type, canonical_name, created_at, updated_at) VALUES (?, 'tool', 'U2', 1, 1)",
+        )
+        .run(entId);
+      // Local alias with the HIGHER id occupies UNIQUE(name, 'Dup2').
+      db()
+        .query(
+          "INSERT INTO entity_aliases (id, entity_id, alias_type, alias_value, source, created_at) VALUES ('al-zzz', ?, 'name', 'Dup2', NULL, 1)",
+        )
+        .run(entId);
+    });
+    // Remote alias with the LOWER id → remote wins → local dropped, remote applied.
+    tableRows("entity_aliases").push({
+      id: "al-aaa",
+      entity_id: entId,
+      alias_type: "name",
+      alias_value: "Dup2",
+      source: null,
+      created_at: 1,
+      updated_at: new Date(2_000_000).toISOString(),
+    } as never);
+
+    const r = await pullOnce(makeClient() as never);
+
+    expect(r.conflicts).toBeGreaterThanOrEqual(1);
+    expect(
+      db().query("SELECT 1 FROM entity_aliases WHERE id = 'al-zzz'").get(),
+    ).toBeNull(); // local loser dropped
+    expect(
+      db().query("SELECT 1 FROM entity_aliases WHERE id = 'al-aaa'").get(),
+    ).not.toBeNull(); // remote winner applied
+    expect(
+      db()
+        .query(
+          "SELECT 1 FROM sync_conflicts WHERE table_name='entity_aliases' AND row_id='al-zzz' AND resolution='alias_unique_superseded'",
+        )
+        .get(),
+    ).not.toBeNull();
   });
 
   test("drainTimestamp also skips an orphan row sharing one timestamp (does not abort the sync)", async () => {
@@ -1070,6 +1126,72 @@ describe("pullOnce", () => {
       db()
         .query(
           "SELECT 1 FROM sync_conflicts WHERE row_id = 'alias-zzzz-orphan'",
+        )
+        .get(),
+    ).not.toBeNull();
+  });
+
+  test("drainTimestamp also converges an alias UNIQUE collision (not just the primary loop) (#1217)", async () => {
+    // The alias convergence must hold on the DRAIN path too (>PAGE rows sharing one ms),
+    // else the guarantee has a gap. Force the drain, land a collider in it, assert it
+    // resolves (converges) rather than skipping.
+    syncData.enableSync("basic");
+    const entId = "77777777-7777-4777-8777-777777777777";
+    syncData.withApplying(() => {
+      db()
+        .query(
+          "INSERT INTO entities (id, entity_type, canonical_name, created_at, updated_at) VALUES (?, 'tool', 'Bulk2', 1, 1)",
+        )
+        .run(entId);
+      // Local alias with a HIGH id occupies UNIQUE(name, 'collide-val').
+      db()
+        .query(
+          "INSERT INTO entity_aliases (id, entity_id, alias_type, alias_value, source, created_at) VALUES ('zzzzzzzz-local', ?, 'name', 'collide-val', NULL, 1)",
+        )
+        .run(entId);
+    });
+    const ts = new Date(2_000_000).toISOString(); // one exact ms for every remote row
+    for (let i = 0; i < 205; i++) {
+      tableRows("entity_aliases").push({
+        id: `alias-${String(i).padStart(4, "0")}`,
+        entity_id: entId,
+        alias_type: "name",
+        alias_value: `bulk-${i}`,
+        source: null,
+        created_at: 1,
+        updated_at: ts,
+      } as never);
+    }
+    // The collider sorts LAST (→ lands in the DRAIN batch) and has a LOWER id than the
+    // local alias ('alias-…' < 'zzzzzzzz-local') → remote wins, dropping the local loser.
+    tableRows("entity_aliases").push({
+      id: "alias-zzzz-collide",
+      entity_id: entId,
+      alias_type: "name",
+      alias_value: "collide-val",
+      source: null,
+      created_at: 1,
+      updated_at: ts,
+    } as never);
+
+    const r = await pullOnce(makeClient() as never); // must NOT throw (drain path)
+
+    expect(r.conflicts).toBeGreaterThanOrEqual(1);
+    // Remote (lower id) winner applied; local (higher id) loser dropped + recorded.
+    expect(
+      db()
+        .query("SELECT 1 FROM entity_aliases WHERE id = 'alias-zzzz-collide'")
+        .get(),
+    ).not.toBeNull();
+    expect(
+      db()
+        .query("SELECT 1 FROM entity_aliases WHERE id = 'zzzzzzzz-local'")
+        .get(),
+    ).toBeNull();
+    expect(
+      db()
+        .query(
+          "SELECT 1 FROM sync_conflicts WHERE row_id = 'zzzzzzzz-local' AND resolution = 'alias_unique_superseded'",
         )
         .get(),
     ).not.toBeNull();


### PR DESCRIPTION
Closes #1217 (split out from the #1215 orphan-resilience hotfix; Sentry MEDIUM).

## Problem
A pulled `entity_aliases` row that violates the **local** `UNIQUE(alias_type, alias_value)` — a constraint the FK-less remote doesn't enforce — was **skipped** (#1215) to avoid crashing the multi-table pull. But a skip leaves two devices **permanently divergent**: each keeps its own alias for the same (type, value) and neither ever converges. Two devices can independently mint an alias for the same (type, value) with different ids.

## Fix — deterministic, symmetric convergence
The **lower alias id wins on every device**, so the outcome is identical regardless of pull order:
- **remote id < local id** → remote wins: drop the losing **local** alias, apply the remote — *only if* the remote's entity is admitted locally; otherwise it's an FK orphan and the valid local alias stays (falls back to the generic skip).
- **local id < remote id** → local wins: discard the remote loser.

Why min-id and not "remote-wins": "remote always wins" does **not** converge (each device deletes its own and pulls the other's, ping-ponging). A symmetric deterministic tiebreak does.

The losing **local** row is deleted **without** sync-suppression, so its removal propagates via the outbox and the duplicate is cleaned off the remote too (then reaped by #909). The discarded row is recorded to `sync_conflicts` (`resolution=alias_unique_superseded`) so the lost alias is diagnosable, not silently destroyed. **Only** `entity_aliases` UNIQUE errors take this path — FK-orphan / CHECK / NOT NULL skips are unchanged.

## Changes
- `packages/core/src/sync-data.ts` — `resolveAliasUniqueConflict(remote, reapply)`: the tiebreak + FK-orphan guard + `sync_conflicts` recording + loser delete.
- `packages/gateway/src/sync.ts` — `isUniqueConstraintError` + route `entity_aliases` UNIQUE collisions through the resolver in the pull catch (falls back to the generic skip otherwise).

## Tests
- **core unit** (`sync-alias-converge.test.ts`): remote-wins, local-wins, **both pull orders converge to the same winner**, FK-orphan fall-through (valid local kept), no-collision fall-through.
- **gateway wiring** (through the real `pullOnce`): local-wins and remote-wins branches, asserting the winner present / loser gone / `sync_conflicts` recorded / no "skipped a row" notice. The obsolete "UNIQUE stays a visible skip" test is replaced by these.
- Full core+gateway suites green (one unrelated pre-existing flaky `session-rotation-merge` test passes in isolation). Typecheck + lint clean.