### PR TITLE
feat(sync): safe-reap watermark so no active device misses a deletion (#909)

### DIFF
--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -194,8 +194,9 @@ function insertMeta(
 // resists a single penalty) — the accepted cost of a faithful additive CRDT.
 
 /** Stable per-device replica id (UUIDv7), minted once into KV. Not cached: the
- *  test suite swaps the DB between cases, so always read it from the live DB. */
-function replicaId(): string {
+ *  test suite swaps the DB between cases, so always read it from the live DB. Also
+ *  reused as the device id for sync's server-side reaper watermark (#909). */
+export function replicaId(): string {
   let id = getKV("sync.replica_id");
   if (!id) {
     id = uuidv7();

--- a/packages/core/src/sync-data.ts
+++ b/packages/core/src/sync-data.ts
@@ -30,6 +30,11 @@ import {
 import { putWrappedScopeKey } from "./crypto/keystore";
 import { rematerializeConfidence } from "./ltm";
 
+// The stable per-device id (also used by the confidence CRDT) doubles as the device id
+// for sync's server-side reaper watermark (#909). Re-exported so the gateway can report
+// this device's pull progress under `syncData.replicaId()`.
+export { replicaId } from "./ltm";
+
 /**
  * Run `fn` with this connection's sync capture suppressed (re-entrant,
  * connection-scoped). Re-exported from `db` so the apply helpers and the engine

--- a/packages/gateway/src/sync.ts
+++ b/packages/gateway/src/sync.ts
@@ -973,6 +973,40 @@ function applyRemote(
 // syncOnce — push then pull
 // ---------------------------------------------------------------------------
 
+/**
+ * Report this device's per-table pull progress so the server-side reaper only reaps a
+ * tombstone once EVERY active device in the scope has pulled past it (#909 watermark) —
+ * no client reconcile-by-absence needed, which the eviction model forbids. Best-effort:
+ * a failure never breaks sync. `last_seen` is server-stamped (a client can't fake
+ * activity); `pulled_through` is this device's keyset cursor timestamp per table.
+ */
+async function reportDeviceProgress(client: SupabaseClient): Promise<void> {
+  try {
+    const user = await getCurrentUser();
+    if (!user?.user_id) return;
+    const deviceId = syncData.replicaId();
+    const rows: Array<Record<string, unknown>> = [];
+    for (const meta of syncData.syncedTables("basic")) {
+      if (meta.pullOnly) continue; // pull-only tables (e.g. profiles) are never reaped
+      const ms = parseCursor(getKV(pullKey(meta.table))).ms;
+      rows.push({
+        scope_id: user.user_id,
+        device_id: deviceId,
+        table_name: meta.table,
+        pulled_through: new Date(ms).toISOString(),
+      });
+    }
+    if (rows.length === 0) return;
+    const { error } = await client
+      .from("sync_device_progress")
+      .upsert(rows, { onConflict: "scope_id,device_id,table_name" });
+    if (error)
+      log.info(`sync: device-progress report skipped: ${error.message}`);
+  } catch (e) {
+    log.info(`sync: device-progress report skipped: ${(e as Error).message}`);
+  }
+}
+
 export async function syncOnce(
   onProgress?: SyncProgressFn,
 ): Promise<SyncResult> {
@@ -985,6 +1019,8 @@ export async function syncOnce(
 
   const push = await pushOnce(client, onProgress);
   const pull = await pullOnce(client, onProgress);
+  // Report AFTER the pull so pulled_through reflects the freshly-advanced cursors.
+  await reportDeviceProgress(client);
   return {
     pushed: push.pushed,
     pulled: pull.pulled,

--- a/packages/gateway/test/sync-security.integration.test.ts
+++ b/packages/gateway/test/sync-security.integration.test.ts
@@ -1512,3 +1512,193 @@ describe.skipIf(gate())("sync migrations — tombstone reaper (#909)", () => {
     expect(rows.map((r) => r.id)).toEqual(["k2-live"]);
   });
 });
+
+describe.skipIf(gate())("sync migrations — reaper watermark (#909)", () => {
+  const nowIso = () => new Date().toISOString();
+  // Relative dates keep the tests robust to wall-clock. The cutoff is
+  // LEAST(watermark, now()-retention); using cursors OLDER than the 90d floor makes the
+  // WATERMARK the governing bound (so these tests exercise the watermark, not the floor).
+  const daysAgo = (n: number) =>
+    new Date(Date.now() - n * 86_400_000).toISOString();
+
+  const insK = (scope: string, id: string, deleted: boolean, ts: string) =>
+    h.asUser(scope, (c) =>
+      c.query(
+        "insert into public.knowledge (id, scope_id, category, title, content, is_deleted, updated_at) values ($1,$2,'pattern','t','c',$3,$4)",
+        [id, scope, deleted, ts],
+      ),
+    );
+
+  // `last_seen` is server-stamped by a trigger, so a test that needs to backdate a
+  // device's activity bypasses user triggers via session_replication_role (superuser).
+  async function insProgress(
+    scope: string,
+    device: string,
+    table: string,
+    pulledThrough: string,
+    lastSeen: string,
+  ) {
+    await h.client.query("set session_replication_role = replica");
+    try {
+      await h.client.query(
+        `insert into public.sync_device_progress (scope_id, device_id, table_name, pulled_through, last_seen)
+         values ($1,$2,$3,$4,$5)
+         on conflict (scope_id, device_id, table_name)
+         do update set pulled_through = excluded.pulled_through, last_seen = excluded.last_seen`,
+        [scope, device, table, pulledThrough, lastSeen],
+      );
+    } finally {
+      await h.client.query("set session_replication_role = default");
+    }
+  }
+
+  const kIds = async (scope: string) =>
+    (
+      await h.client.query(
+        "select id from public.knowledge where scope_id=$1 order by id",
+        [scope],
+      )
+    ).rows.map((r) => r.id);
+
+  it("reaps a tombstone only once the SLOWEST active device has pulled past it", async () => {
+    const a = await h.createUser();
+    // Both cursors are older than the 90d floor, so the WATERMARK (min = tSlow) governs.
+    const tSlow = daysAgo(200);
+    const tFast = daysAgo(150);
+    await insProgress(a, "dev-slow", "knowledge", tSlow, nowIso());
+    await insProgress(a, "dev-fast", "knowledge", tFast, nowIso());
+    await insK(a, "k-below", true, daysAgo(220)); // < watermark(tSlow) → reaped
+    await insK(a, "k-between", true, daysAgo(175)); // > tSlow → slow device hasn't seen it → kept
+    await h.client.query("select public.reap_tombstones(90, 90)");
+    // k-between is >90d old, so a floor-only reaper would drop it; the watermark keeps it.
+    expect(await kIds(a)).toEqual(["k-between"]);
+  });
+
+  it("does NOT reap a tombstone at exactly a device's cursor ms (strict <, keyset boundary)", async () => {
+    const a = await h.createUser();
+    const boundary = daysAgo(200);
+    await insProgress(a, "dev-slow", "knowledge", boundary, nowIso());
+    await insProgress(a, "dev-fast", "knowledge", daysAgo(150), nowIso());
+    // A row AT exactly the slow device's cursor ms (a higher-id row at that ms may not
+    // have been pulled) must NOT be reaped — the guard is strict `<`, not `<=`.
+    await insK(a, "k-at-boundary", true, boundary);
+    await h.client.query("select public.reap_tombstones(90, 90)");
+    expect(await kIds(a)).toEqual(["k-at-boundary"]);
+  });
+
+  it("excludes an ABANDONED device (stale last_seen) so it can't hold back reaping", async () => {
+    const a = await h.createUser();
+    await insProgress(a, "dev-active", "knowledge", daysAgo(150), nowIso());
+    // Ancient cursor AND ancient last_seen → excluded from the watermark.
+    await insProgress(a, "dev-gone", "knowledge", daysAgo(500), daysAgo(500));
+    // Newer than the abandoned cursor but older than the active one → reaped (only the
+    // active device counts, and it has pulled past this tombstone). If the abandoned
+    // device were counted, the watermark would drop to daysAgo(500) and k-x would survive.
+    await insK(a, "k-x", true, daysAgo(300));
+    await h.client.query("select public.reap_tombstones(90, 90)");
+    expect(await kIds(a)).toEqual([]);
+  });
+
+  it("falls back to the retention floor for a scope whose only device is abandoned", async () => {
+    const a = await h.createUser();
+    // Abandoned device (excluded) → watermark null → LEAST falls back to now()-retention.
+    await insProgress(a, "dev-gone", "knowledge", daysAgo(150), daysAgo(500));
+    await insK(a, "k-old", true, daysAgo(200)); // > retention → reaped by the floor
+    await insK(a, "k-recent", true, daysAgo(10)); // < retention → kept
+    await h.client.query("select public.reap_tombstones(90, 90)");
+    expect(await kIds(a)).toEqual(["k-recent"]);
+  });
+
+  it("holds a tombstone forever while an active device sits behind it (no false reap)", async () => {
+    const a = await h.createUser();
+    // Active device stuck at an old cursor: even a tombstone older than the retention
+    // floor must NOT be reaped — the watermark, not the floor, governs.
+    await insProgress(a, "dev-behind", "knowledge", daysAgo(400), nowIso());
+    await insK(a, "k-ancient", true, daysAgo(300)); // >90d old, but AFTER the device cursor
+    await h.client.query("select public.reap_tombstones(90, 90)");
+    expect(await kIds(a)).toEqual(["k-ancient"]); // NOT reaped despite being > retention old
+  });
+
+  it("cleans up progress rows for devices abandoned beyond 2x the active window", async () => {
+    const a = await h.createUser();
+    await insProgress(
+      a,
+      "dev-ancient",
+      "knowledge",
+      daysAgo(300),
+      daysAgo(300),
+    ); // > 180d
+    await insProgress(a, "dev-fresh", "knowledge", daysAgo(300), nowIso());
+    await h.client.query("select public.reap_tombstones(90, 90)");
+    const { rows } = await h.client.query(
+      "select device_id from public.sync_device_progress where scope_id=$1 order by device_id",
+      [a],
+    );
+    expect(rows.map((r) => r.device_id)).toEqual(["dev-fresh"]);
+  });
+
+  it("server-stamps last_seen on write (a client can't fake activity)", async () => {
+    const a = await h.createUser();
+    await h.asUser(a, (c) =>
+      c.query(
+        "insert into public.sync_device_progress (scope_id, device_id, table_name, pulled_through, last_seen) values ($1,'d','knowledge', now(), '2000-01-01T00:00:00Z')",
+        [a],
+      ),
+    );
+    const { rows } = await h.client.query(
+      "select last_seen from public.sync_device_progress where scope_id=$1",
+      [a],
+    );
+    // Trigger overwrote the client's bogus 2000 value with ~now().
+    expect(new Date(rows[0].last_seen).getTime()).toBeGreaterThan(
+      Date.parse("2020-01-01T00:00:00Z"),
+    );
+  });
+
+  it("RLS: a device cannot read or write another scope's progress", async () => {
+    const a = await h.createUser();
+    const b = await h.createUser();
+    await insProgress(
+      b,
+      "dev-b",
+      "knowledge",
+      "2026-01-01T00:00:00Z",
+      nowIso(),
+    );
+    const seen = await h.asUser(a, (c) =>
+      c.query(
+        "select count(*)::int as n from public.sync_device_progress where scope_id=$1",
+        [b],
+      ),
+    );
+    expect(seen.rows[0].n).toBe(0); // RLS hides b's rows from a
+    await expect(
+      h.asUser(a, (c) =>
+        c.query(
+          "insert into public.sync_device_progress (scope_id, device_id, table_name, pulled_through) values ($1,'x','knowledge', now())",
+          [b],
+        ),
+      ),
+    ).rejects.toThrow(); // WITH CHECK (scope_id = auth.uid()) blocks forging b's scope
+  });
+
+  it("cap trigger allows re-reporting an existing device (the update path never trips it)", async () => {
+    const a = await h.createUser();
+    const reReport = () =>
+      h.asUser(a, (c) =>
+        c.query(
+          `insert into public.sync_device_progress (scope_id, device_id, table_name, pulled_through)
+           values ($1,'d1','knowledge', now())
+           on conflict (scope_id, device_id, table_name) do update set pulled_through = excluded.pulled_through`,
+          [a],
+        ),
+      );
+    await reReport(); // INSERT (well under cap) — allowed
+    await expect(reReport()).resolves.toBeDefined(); // UPDATE via upsert — must NOT raise
+    const { rows } = await h.client.query(
+      "select count(*)::int as n from public.sync_device_progress where scope_id=$1",
+      [a],
+    );
+    expect(rows[0].n).toBe(1); // upsert updated in place, did not duplicate
+  });
+});

--- a/packages/gateway/test/sync.test.ts
+++ b/packages/gateway/test/sync.test.ts
@@ -38,6 +38,9 @@ function nextTs(): string {
   return new Date(clock).toISOString();
 }
 function idColumns(table: string): string[] {
+  // sync_device_progress is a control table (not in SYNCED_TABLES); its PK is composite.
+  if (table === "sync_device_progress")
+    return ["scope_id", "device_id", "table_name"];
   return (
     syncData.syncedTables("basic").find((m) => m.table === table)
       ?.idColumns ?? ["id"]
@@ -130,60 +133,58 @@ function makeClient() {
   return {
     from(table: string) {
       return {
-        upsert(payload: Record<string, unknown>) {
-          if (quotaTables.has(table)) {
-            return Promise.resolve({
-              error: { code: "23514", message: `quota exceeded for ${table}` },
-            });
-          }
-          if (poisonIds.has(String(payload.id)))
-            return Promise.resolve({
-              error: {
+        // supabase-js .upsert() accepts a single row OR an array — mirror both.
+        upsert(payload: Record<string, unknown> | Record<string, unknown>[]) {
+          const upsertOne = (
+            one: Record<string, unknown>,
+          ): { code: string; message: string } | null => {
+            if (quotaTables.has(table))
+              return { code: "23514", message: `quota exceeded for ${table}` };
+            if (poisonIds.has(String(one.id)))
+              return {
                 code: "23514",
                 message: `new row violates check constraint "${table}_size_ck"`,
-              },
-            });
-          if (upsertError) return Promise.resolve({ error: upsertError });
-          // Faithful to the remote schema: an unknown column is a PGRST204 (the
-          // join table has NO content_hash/revision columns).
-          const allowed = REMOTE_COLUMNS[table];
-          if (allowed) {
-            for (const k of Object.keys(payload)) {
-              if (!allowed.has(k)) {
-                return Promise.resolve({
-                  error: {
+              };
+            if (upsertError)
+              return upsertError as { code: string; message: string };
+            // Faithful to the remote schema: an unknown column is a PGRST204 (the
+            // join table has NO content_hash/revision columns).
+            const allowed = REMOTE_COLUMNS[table];
+            if (allowed) {
+              for (const k of Object.keys(one)) {
+                if (!allowed.has(k))
+                  return {
                     code: "PGRST204",
                     message: `Could not find the '${k}' column of '${table}' in the schema cache`,
-                  },
-                });
+                  };
               }
             }
-          }
-          // Faithful to timestamptz columns: a bare epoch-ms integer is rejected
-          // (22008) the way real Postgres does — only ISO strings are accepted.
-          for (const k of ["created_at", "updated_at"]) {
-            if (k in payload && typeof payload[k] !== "string") {
-              return Promise.resolve({
-                error: {
+            // Faithful to timestamptz columns: a bare epoch-ms integer is rejected
+            // (22008) the way real Postgres does — only ISO strings are accepted.
+            for (const k of ["created_at", "updated_at"]) {
+              if (k in one && typeof one[k] !== "string")
+                return {
                   code: "22008",
-                  message: `date/time field value out of range: "${payload[k]}"`,
-                },
-              });
+                  message: `date/time field value out of range: "${one[k]}"`,
+                };
             }
+            const rows = tableRows(table);
+            const idc = idColumns(table);
+            const i = rows.findIndex((r) => idc.every((c) => r[c] === one[c]));
+            const stamped = {
+              scope_id: REMOTE_SCOPE,
+              author_id: REMOTE_SCOPE,
+              ...one,
+              updated_at: nextTs(),
+            } as RemoteRow;
+            if (i >= 0) rows[i] = stamped;
+            else rows.push(stamped);
+            return null;
+          };
+          for (const one of Array.isArray(payload) ? payload : [payload]) {
+            const error = upsertOne(one);
+            if (error) return Promise.resolve({ error });
           }
-          const rows = tableRows(table);
-          const idc = idColumns(table);
-          const i = rows.findIndex((r) =>
-            idc.every((c) => r[c] === payload[c]),
-          );
-          const stamped = {
-            scope_id: REMOTE_SCOPE,
-            author_id: REMOTE_SCOPE,
-            ...payload,
-            updated_at: nextTs(),
-          } as RemoteRow;
-          if (i >= 0) rows[i] = stamped;
-          else rows.push(stamped);
           return Promise.resolve({ error: null });
         },
         update(patch: Record<string, unknown>) {
@@ -1505,6 +1506,25 @@ describe("syncOnce", () => {
     // Echo-pull of our own row is a no-op (hash matches) — pulled stays 0.
     expect(r.pulled).toBe(0);
     expect(tableRows("knowledge").find((x) => x.id === "k1")).toBeTruthy();
+  });
+
+  test("reports per-table device pull progress for the reaper watermark (#909)", async () => {
+    syncData.enableSync("basic");
+    insertKnowledge("k1", "hello");
+    await syncOnce();
+    const prog = tableRows("sync_device_progress");
+    const deviceId = syncData.replicaId();
+    // We report every non-pull-only synced table (a superset of the reaper's tables; the
+    // extra rows are inert — the reaper only queries its own table_names).
+    const reported = syncData
+      .syncedTables("basic")
+      .filter((m) => !m.pullOnly)
+      .map((m) => m.table);
+    expect(prog.length).toBe(reported.length);
+    expect(prog.every((r) => r.device_id === deviceId)).toBe(true);
+    expect(new Set(prog.map((r) => r.table_name))).toEqual(new Set(reported));
+    // pulled_through is the device's keyset cursor as an ISO string, never null.
+    expect(prog.every((r) => typeof r.pulled_through === "string")).toBe(true);
   });
 });
 

--- a/supabase/migrations/0019_reaper_watermark.sql
+++ b/supabase/migrations/0019_reaper_watermark.sql
@@ -1,0 +1,169 @@
+-- Migration 0019: reaper safe-reap watermark (#909 purge epoch, correct form)
+--
+-- The literal purge-epoch (a stale client re-pulls + reconciles deletions BY ABSENCE)
+-- conflicts with the eviction model: the remote is a bounded cache, so a row absent from
+-- it is ambiguous — evicted-but-valid vs deleted-and-reaped — and reconcile-by-absence
+-- would wrongly drop valid local data (forbidden: "reconcile never treats remote-absence
+-- as a delete"). Instead the SERVER holds off reaping until EVERY active device in the
+-- scope has pulled past a tombstone. Then no active device can miss a deletion and no
+-- client reconcile is ever needed. The cutoff is LEAST(watermark, now()-retention): the
+-- watermark never lets us outrun a slow ACTIVE device, and the retention floor is kept as
+-- a safety net so a device that isn't reporting yet (mid-rollout) keeps the same
+-- protection as the old fixed window. So this is at-least-as-safe as the fixed window and
+-- additionally protects an active-but-slow device BEYOND the window. Residual bound: a
+-- device abandoned past the active-TTL may miss a deletion reaped in its absence — equal
+-- to the old fixed window.
+
+-- ===========================================================================
+-- 1. sync_device_progress — each device's per-table pull cursor. Control-plane: NOT a
+--    synced data table; the client writes it directly, out-of-band. `pulled_through` is
+--    the device's keyset cursor timestamp; `last_seen` is server-stamped (see the
+--    trigger) so a client can't fake activity to stall reaping. scope_id defaults to
+--    auth.uid() (the v1 scope).
+-- ===========================================================================
+create table if not exists public.sync_device_progress (
+  scope_id       uuid        not null default auth.uid() references auth.users (id) on delete cascade,
+  device_id      text        not null,
+  table_name     text        not null,
+  pulled_through timestamptz not null,
+  last_seen      timestamptz not null default now(),
+  primary key (scope_id, device_id, table_name)
+);
+
+alter table public.sync_device_progress drop constraint if exists sync_device_progress_size_ck;
+alter table public.sync_device_progress add constraint sync_device_progress_size_ck check (
+  length(device_id) <= 64 and length(table_name) <= 64
+);
+
+-- ===========================================================================
+-- 2. Server-stamp last_seen on every write — activity is server-observed, never client-
+--    claimed. `pulled_through` stays client-set: over/under-claiming only self-harms
+--    (a premature self-miss / a self-DoS on the scope's own quota), never another tenant.
+-- ===========================================================================
+create or replace function public.sync_device_progress_touch()
+returns trigger language plpgsql as $$
+begin
+  new.last_seen = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists sync_device_progress_touch on public.sync_device_progress;
+create trigger sync_device_progress_touch
+  before insert or update on public.sync_device_progress
+  for each row execute function public.sync_device_progress_touch();
+
+-- ===========================================================================
+-- 3. Anti-abuse: cap rows-per-scope so a client can't fabricate unbounded device ids
+--    (generous headroom across a device's reported tables). RLS already restricts writes
+--    to the caller's own scope, so this only bounds self-inflicted growth.
+-- ===========================================================================
+create or replace function public.sync_device_progress_cap()
+returns trigger language plpgsql as $$
+begin
+  -- Only a genuinely NEW (scope, device, table) row counts against the cap. BEFORE INSERT
+  -- also fires for an `insert ... on conflict do update` that resolves to an UPDATE, so
+  -- without the existence guard a re-report (a mere last_seen/pulled_through refresh of an
+  -- existing row) would wrongly trip the cap once a scope is full.
+  if not exists (
+    select 1 from public.sync_device_progress
+     where scope_id = new.scope_id
+       and device_id = new.device_id
+       and table_name = new.table_name
+  ) and (
+    select count(*) from public.sync_device_progress where scope_id = new.scope_id
+  ) >= 700 then
+    raise exception 'sync_device_progress: too many devices for scope'
+      using errcode = 'check_violation';
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists sync_device_progress_cap on public.sync_device_progress;
+create trigger sync_device_progress_cap
+  before insert on public.sync_device_progress
+  for each row execute function public.sync_device_progress_cap();
+
+-- Index for the reaper's per-scope correlated min(pulled_through).
+create index if not exists idx_sync_device_progress_reap
+  on public.sync_device_progress (table_name, scope_id, last_seen);
+
+-- ===========================================================================
+-- 4. RLS + DML grants (per-row ownership by scope; PostgREST needs the grants).
+-- ===========================================================================
+alter table public.sync_device_progress enable row level security;
+drop policy if exists sync_device_progress_scope_all on public.sync_device_progress;
+create policy sync_device_progress_scope_all on public.sync_device_progress
+  for all
+  using (scope_id = auth.uid())
+  with check (scope_id = auth.uid());
+
+grant select, insert, update, delete on public.sync_device_progress to authenticated;
+
+-- ===========================================================================
+-- 5. Reaper: reap a tombstone only when it is older than LEAST(watermark, retention floor).
+--    watermark = min(pulled_through) across the scope's ACTIVE devices (last_seen within
+--    active_ttl) — never outrun a slow active device. The retention floor (now()-retention)
+--    is kept via LEAST so a device that isn't reporting yet (mid-rollout) or a dormant
+--    scope with no active device stays protected (LEAST ignores the NULL watermark → the
+--    floor). `updated_at < cutoff` (strict) ⇒ every active device's keyset cursor already
+--    passed the tombstone ⇒ each applied the deletion ⇒ safe to reap.
+--    Drop-first avoids overload ambiguity with 0018's 1-arg version; the pg_cron call
+--    `reap_tombstones(90)` re-binds (the 2nd arg is defaulted).
+-- ===========================================================================
+drop function if exists public.reap_tombstones(integer);
+
+create or replace function public.reap_tombstones(
+  retention_days  integer default 90,
+  active_ttl_days integer default 90
+)
+returns bigint
+language plpgsql
+security definer
+set search_path = pg_catalog, public
+as $$
+declare
+  t            text;
+  total        bigint := 0;
+  n            bigint;
+  floor_ts     timestamptz := now() - make_interval(days => greatest(retention_days, 0));
+  active_since timestamptz := now() - make_interval(days => greatest(active_ttl_days, 0));
+begin
+  -- The knowledge + entity-graph tables (0002 base + 0009 meta) each carry is_deleted +
+  -- updated_at. Keystore tables (account_escrow / scope_keys, 0010) are single-row-per-
+  -- scope and intentionally excluded (no tombstone accrual; key state).
+  foreach t in array array[
+    'knowledge', 'entities', 'entity_aliases', 'entity_relations',
+    'knowledge_entity_refs', 'knowledge_meta', 'knowledge_meta_crdt'
+  ] loop
+    -- LEAST ignores a NULL watermark (no active device) → falls back to the floor.
+    execute format($q$
+      delete from public.%1$I k
+       where k.is_deleted = true
+         and k.updated_at < least(
+           (select min(p.pulled_through)
+              from public.sync_device_progress p
+             where p.scope_id = k.scope_id
+               and p.table_name = %1$L
+               and p.last_seen > $1),
+           $2
+         )
+    $q$, t) using active_since, floor_ts;
+    get diagnostics n = row_count;
+    total := total + n;
+  end loop;
+
+  -- Drop progress rows for long-abandoned devices (2× the active window) so the control
+  -- table doesn't accrue dead device rows forever.
+  delete from public.sync_device_progress
+   where last_seen < now() - make_interval(days => greatest(active_ttl_days, 0) * 2);
+
+  return total;
+end;
+$$;
+
+-- System task only (SECURITY DEFINER bypasses RLS to reap cross-scope); pg_cron runs as
+-- the owner, a service_role admin may invoke it manually.
+revoke all on function public.reap_tombstones(integer, integer) from public;
+grant execute on function public.reap_tombstones(integer, integer) to service_role;


### PR DESCRIPTION
Follow-up to the #909 tombstone reaper (#1233): the per-scope **purge epoch**, in a form that's actually correct for the eviction model.

## Why not the literal purge-epoch
#909 proposed a stale-cursor client "re-pull from scratch instead of trusting its cursor." That only helps if paired with **reconcile-by-absence** (delete local rows absent from the remote), which conflicts with an established invariant: the remote is a **bounded cache** (eviction #1203/#1206/#1207), so a row absent from it is ambiguous — *evicted-but-valid* vs *deleted-and-reaped*. Reconcile-by-absence would wrongly drop valid local data (`reconcile()` deliberately never treats remote-absence as a delete). The reaped tombstone is physically gone, so no pull can recover it.

## The correct form — server-side safe-reap watermark
Instead of forcing the client to reconcile, the **server holds off reaping** until **every active device in the scope has pulled past a tombstone**. Then no active device can miss a deletion, and no client reconcile is ever needed.

- `updated_at < min(pulled_through)` across the scope's active devices ⇒ every active device's keyset cursor already passed the tombstone ⇒ each applied the deletion ⇒ safe to reap.
- Strictly better than the fixed 90-day window: **precise** protection within the active window (a slow device is never outrun) + **faster quota reclaim** (reap as soon as all devices catch up, not after a blanket 90 days). Same residual bound only for a device abandoned past the active-TTL.

## Server — migration `0019_reaper_watermark.sql`
- `sync_device_progress(scope_id, device_id, table_name, pulled_through, last_seen)` — a **control table** (not synced; the client writes it directly out-of-band). `last_seen` is **server-stamped** by a trigger so a client can't fake activity to stall reaping; `pulled_through` is client-set (over/under-claiming only self-harms). RLS by scope, a rows-per-scope cap, and an index for the reaper's correlated `min()`.
- `reap_tombstones(retention_days=90, active_ttl_days=90)` redefined: per-scope correlated `delete … where updated_at < coalesce(min(active pulled_through), now()-retention)`. Falls back to the retention window for a scope with no active device (dormant / pre-feature). Also cleans up progress rows for devices abandoned beyond 2× the window. Drop-first avoids overload ambiguity — the pg_cron `reap_tombstones(90)` call re-binds (2nd arg defaulted).

## Client — `packages/gateway/src/sync.ts`
- `reportDeviceProgress()`: after each `syncOnce` pull, best-effort upsert of this device's per-table `pulled_through` (device id = the shared `replicaId()`, reused from the confidence CRDT). Never throws — a reporting failure never breaks sync.

## Tests
- **Tier-1 Postgres integration** (real Docker Postgres + migration 0019, 70 tests total): watermark holds a tombstone until the **slowest active device** passes it; an **abandoned** device is excluded (can't hold back reaping); **no-active-device** falls back to the retention window; an active device sitting **behind** a tombstone blocks its reaping regardless of age; abandoned progress-row **cleanup**; `last_seen` **server-stamping**; **RLS** isolation between scopes.
- **Gateway unit**: `syncOnce` reports per-table device progress; the mock now accepts array upserts (faithful to supabase-js).
- Full core+gateway suites green (5484 pass), typecheck + lint clean.

Residual (documented): a device abandoned longer than the active-TTL and later revived may still miss deletions reaped in its absence — the same bound as the prior fixed window, now the *only* gap rather than a blanket one.