### PR TITLE
fix(sync): converge pulled entity_relations UNIQUE collisions instead of skipping (#1217)

### DIFF
--- a/packages/core/src/sync-data.ts
+++ b/packages/core/src/sync-data.ts
@@ -1414,6 +1414,67 @@ export function resolveAliasUniqueConflict(
   return true;
 }
 
+/**
+ * #1217, mirror of resolveAliasUniqueConflict for entity_relations' local-only
+ * UNIQUE(entity_a, entity_b, relation): the FK-less remote keys only on `id`, so two
+ * devices can push the SAME relation triple under different ids. On pull, the second one
+ * violates the local triple UNIQUE and was skipped (→ divergence). Resolve it the same
+ * way: the lower `id` wins on EVERY device, so both converge regardless of pull order.
+ *
+ * Unlike aliases, NO FK-orphan guard is needed: the collision matches on entity_a AND
+ * entity_b, so the remote's endpoints are identical to the colliding local row's — which
+ * exist locally (that row's own FK) — so the winner can always apply. (And even if the
+ * reapply threw, the local loser is already gone, so the next pull re-applies cleanly.)
+ */
+export function resolveRelationUniqueConflict(
+  remote: Record<string, unknown>,
+  reapply: () => void,
+): boolean {
+  const ea = remote.entity_a;
+  const eb = remote.entity_b;
+  const rel = remote.relation;
+  const remoteId = remote.id;
+  if (
+    typeof ea !== "string" ||
+    typeof eb !== "string" ||
+    typeof rel !== "string" ||
+    typeof remoteId !== "string"
+  )
+    return false;
+  const local = db()
+    .query(
+      "SELECT id, entity_a, entity_b, relation FROM entity_relations WHERE entity_a = ? AND entity_b = ? AND relation = ?",
+    )
+    .get(ea, eb, rel) as
+    | { id: string; entity_a: string; entity_b: string; relation: string }
+    | undefined;
+  // No local collision, or the very same row (an ordinary update) → apply/skip normally.
+  if (!local || local.id === remoteId) return false;
+
+  if (remoteId < local.id) {
+    // Remote relation has the lower id → it wins: drop the local loser (recorded, and its
+    // unsuppressed delete propagates so the remote duplicate is cleaned up too) then apply.
+    recordConflict(
+      "entity_relations",
+      local.id,
+      "relation_unique_superseded",
+      local,
+    );
+    db().query("DELETE FROM entity_relations WHERE id = ?").run(local.id);
+    reapply();
+    return true;
+  }
+
+  // Local relation has the lower id → it wins; discard the remote loser (recorded).
+  recordConflict(
+    "entity_relations",
+    remoteId,
+    "relation_unique_superseded",
+    remote,
+  );
+  return true;
+}
+
 // ---------------------------------------------------------------------------
 // Enable / disable
 // ---------------------------------------------------------------------------

--- a/packages/core/test/sync-registry-contract.test.ts
+++ b/packages/core/test/sync-registry-contract.test.ts
@@ -107,3 +107,52 @@ describe("SYNCED_TABLES registry contract", () => {
     });
   }
 });
+
+describe("SYNCED_TABLES local-only secondary UNIQUE → convergence handling (#1217)", () => {
+  // A UNIQUE the FK-less remote doesn't enforce (keyed differently from the remote's
+  // upsert conflict target) means a pulled row can collide with a local row → without
+  // deterministic resolution it silently regresses to divergent-on-skip (#1215/#1217).
+  // This maps each such table to how it converges. A NEW table with such a UNIQUE fails
+  // here until it gets a resolver + routing in handlePulledRowConstraint (or is otherwise
+  // documented as handled) — the same fan-out hazard this battery exists to catch.
+  const HANDLED: Record<string, string> = {
+    entity_aliases: "resolveAliasUniqueConflict (#1234)",
+    entity_relations: "resolveRelationUniqueConflict (#1217)",
+    knowledge: "version-aware apply demotes is_current before insert (#897)",
+  };
+
+  const indexCols = (name: string) =>
+    (
+      db().query(`PRAGMA index_info("${name}")`).all() as { name: string }[]
+    ).map((r) => r.name);
+  const sameSet = (a: string[], b: string[]) =>
+    a.length === b.length &&
+    [...a].sort().join("\u0000") === [...b].sort().join("\u0000");
+
+  for (const m of SYNCED_TABLES.basic) {
+    test(`${m.table}: any local-only secondary UNIQUE has convergence handling`, () => {
+      const indexes = db().query(`PRAGMA index_list("${m.table}")`).all() as {
+        name: string;
+        unique: number;
+        origin: string;
+      }[];
+      // origin 'pk' is the remote's key too (ON CONFLICT handles it); a UNIQUE whose
+      // columns == idColumns is likewise the remote conflict target — neither diverges.
+      const localOnly = indexes.filter(
+        (i) =>
+          i.unique === 1 &&
+          i.origin !== "pk" &&
+          !sameSet(indexCols(i.name), m.idColumns),
+      );
+      if (localOnly.length > 0)
+        expect(
+          HANDLED[m.table],
+          `${m.table} has a local-only secondary UNIQUE (${localOnly
+            .map((i) => i.name)
+            .join(
+              ", ",
+            )}) with no convergence handling: a pulled collision would be skipped and leave devices divergent. Add a resolver + route it in handlePulledRowConstraint, then register it in HANDLED.`,
+        ).toBeDefined();
+    });
+  }
+});

--- a/packages/core/test/sync-relation-converge.test.ts
+++ b/packages/core/test/sync-relation-converge.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { db } from "../src/db";
+import { resolveRelationUniqueConflict } from "../src/sync-data";
+
+function insEntity(id: string) {
+  db()
+    .query(
+      "INSERT OR IGNORE INTO entities (id, entity_type, canonical_name, created_at, updated_at) VALUES (?,?,?,?,?)",
+    )
+    .run(id, "person", `n-${id}`, Date.now(), Date.now());
+}
+function insRelation(id: string, a: string, b: string, rel: string) {
+  db()
+    .query(
+      "INSERT INTO entity_relations (id, entity_a, entity_b, relation, created_at, updated_at) VALUES (?,?,?,?,?,?)",
+    )
+    .run(id, a, b, rel, Date.now(), Date.now());
+}
+function remoteRelation(id: string, a: string, b: string, rel: string) {
+  return { id, entity_a: a, entity_b: b, relation: rel };
+}
+function conflicts(rowId: string) {
+  return db()
+    .query(
+      "SELECT resolution FROM sync_conflicts WHERE table_name='entity_relations' AND row_id=?",
+    )
+    .all(rowId) as { resolution: string }[];
+}
+function relationIds() {
+  return (
+    db().query("SELECT id FROM entity_relations ORDER BY id").all() as {
+      id: string;
+    }[]
+  ).map((r) => r.id);
+}
+
+describe("resolveRelationUniqueConflict — relation UNIQUE convergence (#1217)", () => {
+  beforeEach(() => {
+    db().query("DELETE FROM entity_relations").run();
+    db().query("DELETE FROM entities").run();
+    db().query("DELETE FROM sync_conflicts").run();
+  });
+
+  it("remote wins (lower id): drops local loser, runs reapply, records the discarded local", () => {
+    insEntity("e1");
+    insEntity("e2");
+    insRelation("r-bbb", "e1", "e2", "knows"); // local, higher id
+    let reapplied = false;
+    const ok = resolveRelationUniqueConflict(
+      remoteRelation("r-aaa", "e1", "e2", "knows"), // remote, lower id
+      () => {
+        reapplied = true;
+        insRelation("r-aaa", "e1", "e2", "knows"); // simulate applyRemote of the winner
+      },
+    );
+    expect(ok).toBe(true);
+    expect(reapplied).toBe(true);
+    expect(relationIds()).toEqual(["r-aaa"]); // loser gone, winner present
+    expect(conflicts("r-bbb")).toHaveLength(1);
+  });
+
+  it("local wins (lower id): keeps local, no reapply, records the discarded remote", () => {
+    insEntity("e1");
+    insEntity("e2");
+    insRelation("r-aaa", "e1", "e2", "knows"); // local, lower id
+    let reapplied = false;
+    const ok = resolveRelationUniqueConflict(
+      remoteRelation("r-bbb", "e1", "e2", "knows"), // remote, higher id
+      () => {
+        reapplied = true;
+      },
+    );
+    expect(ok).toBe(true);
+    expect(reapplied).toBe(false);
+    expect(relationIds()).toEqual(["r-aaa"]);
+    expect(conflicts("r-bbb")).toHaveLength(1);
+  });
+
+  it("both pull orders converge to the same (lowest-id) winner", () => {
+    insEntity("e1");
+    insEntity("e2");
+    // Device X: local = lower id, remote = higher id → keeps the lower.
+    insRelation("r-1", "e1", "e2", "knows");
+    resolveRelationUniqueConflict(
+      remoteRelation("r-2", "e1", "e2", "knows"),
+      () => {
+        throw new Error("must not reapply when local wins");
+      },
+    );
+    expect(relationIds()).toEqual(["r-1"]);
+
+    // Device Y: local = higher id, remote = lower id → converges to the SAME winner.
+    db().query("DELETE FROM entity_relations").run();
+    insRelation("r-2", "e1", "e2", "knows");
+    resolveRelationUniqueConflict(
+      remoteRelation("r-1", "e1", "e2", "knows"),
+      () => {
+        insRelation("r-1", "e1", "e2", "knows");
+      },
+    );
+    expect(relationIds()).toEqual(["r-1"]);
+  });
+
+  it("falls through (false) when there is no local (a,b,relation) collision", () => {
+    insEntity("e1");
+    insEntity("e2");
+    insRelation("r-1", "e1", "e2", "knows");
+    const ok = resolveRelationUniqueConflict(
+      remoteRelation("r-x", "e1", "e2", "dislikes"), // same endpoints, DIFFERENT relation
+      () => {
+        throw new Error("must not reapply");
+      },
+    );
+    expect(ok).toBe(false);
+  });
+
+  it("falls through (false) for the same id (an ordinary update, not a conflict)", () => {
+    insEntity("e1");
+    insEntity("e2");
+    insRelation("r-1", "e1", "e2", "knows");
+    const ok = resolveRelationUniqueConflict(
+      remoteRelation("r-1", "e1", "e2", "knows"),
+      () => {
+        throw new Error("must not reapply on an ordinary update");
+      },
+    );
+    expect(ok).toBe(false);
+    expect(relationIds()).toEqual(["r-1"]);
+  });
+});

--- a/packages/gateway/src/sync.ts
+++ b/packages/gateway/src/sync.ts
@@ -818,15 +818,21 @@ function handlePulledRowConstraint(
 ): void {
   if (e instanceof EncryptedContentUnavailable) throw e;
   if (!isSqliteConstraintError(e)) throw e;
-  if (
-    meta.table === "entity_aliases" &&
-    isUniqueConstraintError(e) &&
-    syncData.resolveAliasUniqueConflict(remote, () =>
-      applyRemote(meta, remote, res, touchedFts, enc),
-    )
-  ) {
-    res.conflicts++;
-    return;
+  // Deterministic convergence for a local-only secondary UNIQUE the FK-less remote
+  // doesn't enforce (entity_aliases (type,value); entity_relations (a,b,relation)): the
+  // lower id wins on every device, so pull order can't leave devices divergent (#1217).
+  // Falls through to the generic skip when there's no local collision / it's an orphan.
+  if (isUniqueConstraintError(e)) {
+    const reapply = () => applyRemote(meta, remote, res, touchedFts, enc);
+    if (
+      (meta.table === "entity_aliases" &&
+        syncData.resolveAliasUniqueConflict(remote, reapply)) ||
+      (meta.table === "entity_relations" &&
+        syncData.resolveRelationUniqueConflict(remote, reapply))
+    ) {
+      res.conflicts++;
+      return;
+    }
   }
   res.skipped++;
   syncData.recordConflict(meta.table, rid, "pull_constraint_skip", remote);

--- a/packages/gateway/test/sync.test.ts
+++ b/packages/gateway/test/sync.test.ts
@@ -1075,6 +1075,108 @@ describe("pullOnce", () => {
     ).not.toBeNull();
   });
 
+  test("resolves a pulled entity_relations UNIQUE(a,b,relation) collision — local (lower id) wins (#1217)", async () => {
+    syncData.enableSync("basic");
+    const ea = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const eb = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    syncData.withApplying(() => {
+      for (const [id, n] of [
+        [ea, "A"],
+        [eb, "B"],
+      ] as const)
+        db()
+          .query(
+            "INSERT INTO entities (id, entity_type, canonical_name, created_at, updated_at) VALUES (?, 'tool', ?, 1, 1)",
+          )
+          .run(id, n);
+      // Local relation with the LOWER id occupies UNIQUE(entity_a, entity_b, 'knows').
+      db()
+        .query(
+          "INSERT INTO entity_relations (id, entity_a, entity_b, relation, created_at, updated_at) VALUES ('rl-local', ?, ?, 'knows', 1, 1)",
+        )
+        .run(ea, eb);
+    });
+    // Remote relation: HIGHER id, same triple → local UNIQUE collision → local wins.
+    tableRows("entity_relations").push({
+      id: "rl-remote",
+      entity_a: ea,
+      entity_b: eb,
+      relation: "knows",
+      source: null,
+      created_at: 1,
+      updated_at: new Date(2_000_000).toISOString(),
+    } as never);
+
+    const noticeSpy = vi.spyOn(log, "notice");
+    const r = await pullOnce(makeClient() as never);
+
+    expect(noticeSpy.mock.calls.flat().join(" ")).not.toMatch(/skipped a row/);
+    expect(r.conflicts).toBeGreaterThanOrEqual(1);
+    expect(
+      db().query("SELECT 1 FROM entity_relations WHERE id = 'rl-local'").get(),
+    ).not.toBeNull();
+    expect(
+      db().query("SELECT 1 FROM entity_relations WHERE id = 'rl-remote'").get(),
+    ).toBeNull();
+    expect(
+      db()
+        .query(
+          "SELECT 1 FROM sync_conflicts WHERE table_name='entity_relations' AND row_id='rl-remote' AND resolution='relation_unique_superseded'",
+        )
+        .get(),
+    ).not.toBeNull();
+  });
+
+  test("resolves a pulled entity_relations UNIQUE collision by applying the remote when it has the lower id (#1217)", async () => {
+    syncData.enableSync("basic");
+    const ea = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+    const eb = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+    syncData.withApplying(() => {
+      for (const [id, n] of [
+        [ea, "C"],
+        [eb, "D"],
+      ] as const)
+        db()
+          .query(
+            "INSERT INTO entities (id, entity_type, canonical_name, created_at, updated_at) VALUES (?, 'tool', ?, 1, 1)",
+          )
+          .run(id, n);
+      // Local relation with the HIGHER id.
+      db()
+        .query(
+          "INSERT INTO entity_relations (id, entity_a, entity_b, relation, created_at, updated_at) VALUES ('rl-zzz', ?, ?, 'knows', 1, 1)",
+        )
+        .run(ea, eb);
+    });
+    // Remote relation with the LOWER id → remote wins → local dropped, remote applied.
+    tableRows("entity_relations").push({
+      id: "rl-aaa",
+      entity_a: ea,
+      entity_b: eb,
+      relation: "knows",
+      source: null,
+      created_at: 1,
+      updated_at: new Date(2_000_000).toISOString(),
+    } as never);
+
+    const r = await pullOnce(makeClient() as never);
+
+    expect(r.conflicts).toBeGreaterThanOrEqual(1);
+    expect(
+      db().query("SELECT 1 FROM entity_relations WHERE id = 'rl-zzz'").get(),
+    ).toBeNull(); // local loser dropped
+    expect(
+      db().query("SELECT 1 FROM entity_relations WHERE id = 'rl-aaa'").get(),
+    ).not.toBeNull(); // remote winner applied
+    expect(
+      db()
+        .query(
+          "SELECT 1 FROM sync_conflicts WHERE table_name='entity_relations' AND row_id='rl-zzz' AND resolution='relation_unique_superseded'",
+        )
+        .get(),
+    ).not.toBeNull();
+  });
+
   test("drainTimestamp also skips an orphan row sharing one timestamp (does not abort the sync)", async () => {
     // > PAGE (200) rows on ONE exact updated_at force the primary page to stall and hand
     // off to drainTimestamp — guarding that the orphan-skip works on the drain path too.


### PR DESCRIPTION
Follow-up to #1234 (alias UNIQUE convergence). `entity_relations` has the **same** local-only secondary UNIQUE the FK-less remote doesn't enforce:

- **Local:** `UNIQUE(entity_a, entity_b, relation)` (db.ts:695)
- **Remote:** PK `(owner_user_id, id)`, no triple UNIQUE (0002); `idColumns: ["id"]` → `applyRemoteUpsert` keys `ON CONFLICT(id)`

So two devices can each mint the same relation triple under different `id`s → both live on the remote → a pulling device's second one violates its local triple UNIQUE → it was **skipped** (#1215), leaving the devices permanently divergent (each keeps its own id for the same edge).

## Fix
Deterministic convergence, mirroring the alias resolver: the **lower `id` wins on every device**, applied symmetrically, so both converge regardless of pull order. The loser is recorded to `sync_conflicts`; when the local row loses, its **unsuppressed** delete propagates so the remote duplicate is cleaned up (and reaped, #909).

Unlike aliases, **no FK-orphan guard is needed**: the collision matches on `entity_a` AND `entity_b`, so the remote's endpoints are identical to the colliding local row's — which exist locally (that row's own FK) — so the winner can always apply. The delete-then-reapply also self-heals on the next pull if the reapply ever threw (same property as aliases).

## Scope
- `packages/core/src/sync-data.ts`: `resolveRelationUniqueConflict`.
- `packages/gateway/src/sync.ts`: `handlePulledRowConstraint` routes `entity_relations` UNIQUE errors through it (both tables share one `isUniqueConstraintError` branch; the generic FK/CHECK/NOT-NULL skip is unchanged).
- **Tests:** core unit (`sync-relation-converge.test.ts`, 5: remote-wins, local-wins, both-orders-converge, no-collision, same-id) + gateway wiring through `pullOnce` (local-wins asserts no "skipped a row" notice; remote-wins asserts the local loser is dropped + the remote applied).

This closes the last table with a divergent-on-skip local-only UNIQUE. `knowledge` is version-aware (keyed by logical_id, no cross-device same-triple collision) and `knowledge_entity_refs` uses a composite PK resolved via `ON CONFLICT` — neither is subject to this pattern.

Full core+gateway suites green (the one `cache-stability.e2e` blip is pre-existing cross-test flakiness — passes 16/16 in isolation; this PR touches only sync). Typecheck + lint clean.