### PR TITLE
feat(sync): tier-aware synced-table selection (D-2, #826)

### DIFF
--- a/packages/core/src/sync-data.ts
+++ b/packages/core/src/sync-data.ts
@@ -318,12 +318,48 @@ export const SYNCED_TABLES: Record<SyncTier, SyncTableMeta[]> = {
   max: [],
 };
 
+// Every registered table across ALL tiers — so meta()/metaFor() resolve a table
+// regardless of the caller's current tier (a Pro table's shape is tier-independent;
+// tier only gates whether it is SYNCED, not whether its meta exists).
 const META_BY_TABLE = new Map<string, SyncTableMeta>();
-for (const t of SYNCED_TABLES.basic) META_BY_TABLE.set(t.table, t);
+for (const t of [
+  ...SYNCED_TABLES.basic,
+  ...SYNCED_TABLES.pro,
+  ...SYNCED_TABLES.max,
+])
+  META_BY_TABLE.set(t.table, t);
 
-/** The synced table set for a tier (only `basic` is populated today). */
+/** The tables registered for exactly one SyncTier (non-cumulative). */
 export function syncedTables(tier: SyncTier = "basic"): SyncTableMeta[] {
   return SYNCED_TABLES[tier];
+}
+
+/**
+ * The CUMULATIVE synced table set at a SyncTier: basic ⊆ pro ⊆ max. This is what
+ * the engine actually syncs — a Pro user gets the basic tables PLUS the pro ones.
+ * (pro/max are empty until #826/D populates them, so this equals `basic` today.)
+ */
+export function syncedTablesFor(tier: SyncTier): SyncTableMeta[] {
+  const out = [...SYNCED_TABLES.basic];
+  if (tier === "pro" || tier === "max") out.push(...SYNCED_TABLES.pro);
+  if (tier === "max") out.push(...SYNCED_TABLES.max);
+  return out;
+}
+
+/**
+ * Map the user's PLAN tier (currentTier(): 'free'|'pro'|'max') to the SyncTier
+ * whose cumulative table set should sync. free → basic; pro → pro; max → max.
+ */
+export function currentSyncTier(): SyncTier {
+  const plan = currentTier();
+  if (plan === "max") return "max";
+  if (plan === "pro") return "pro";
+  return "basic";
+}
+
+/** Resolve a table's meta regardless of tier (throws if not registered). */
+export function metaFor(table: string): SyncTableMeta {
+  return meta(table);
 }
 
 /**
@@ -675,7 +711,7 @@ function seedSelect(table: string): string {
   }
 }
 
-export function seedOutbox(tier: SyncTier = "basic"): void {
+export function seedOutbox(tier: SyncTier = currentSyncTier()): void {
   const now = Date.now();
   const enqueue = db().query(
     `INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
@@ -693,7 +729,7 @@ export function seedOutbox(tier: SyncTier = "basic"): void {
   // stall on `lore sync enable` for a large knowledge base. (Safe: seedOutbox is
   // only ever reached via enableSync, never from within another transaction.)
   withTransaction(() => {
-    for (const m of syncedTables(tier)) {
+    for (const m of syncedTablesFor(tier)) {
       // Pull-only tables are never pushed — enqueuing them would create outbox
       // entries that pushOnce skips forever, pinning their push cursor at 0 and
       // (via the prune floor) permanently disabling outbox pruning for ALL tables.
@@ -784,10 +820,10 @@ export function seedOutbox(tier: SyncTier = "basic"): void {
  * This is why enable does NOT just seed once: it reconciles, so changes made
  * while sync was disabled are not silently dropped from the push queue.
  */
-export function reconcile(tier: SyncTier = "basic"): void {
+export function reconcile(tier: SyncTier = currentSyncTier()): void {
   const now = Date.now();
   seedOutbox(tier);
-  for (const m of syncedTables(tier)) {
+  for (const m of syncedTablesFor(tier)) {
     // Pull-only tables are never pushed (see seedOutbox) — also skip the
     // delete-tombstone reconciliation so no `profiles` outbox entry is created.
     if (m.pullOnly) continue;
@@ -1494,7 +1530,7 @@ export function isSyncEnabled(): boolean {
  * row recreated after a pending delete still gets a trailing upsert; see
  * `seedOutbox`).
  */
-export function enableSync(tier: SyncTier = "basic"): void {
+export function enableSync(tier: SyncTier = currentSyncTier()): void {
   setTeamConfig(ENABLED_KEY, "1");
   reconcile(tier);
 }
@@ -1518,7 +1554,7 @@ export function disableSync(): void {
  */
 export function assertSyncInvariants(): void {
   const violations: string[] = [];
-  const tables = syncedTables();
+  const tables = syncedTablesFor(currentSyncTier());
 
   // 1. Pull-only tables are server-authoritative and never pushed, so an outbox
   //    entry for one can NEVER advance its push cursor — it pins the prune floor

--- a/packages/core/test/sync-data.test.ts
+++ b/packages/core/test/sync-data.test.ts
@@ -39,6 +39,10 @@ import {
   setSyncState,
   SYNCED_TABLES,
   syncedColumns,
+  syncedTables,
+  syncedTablesFor,
+  currentSyncTier,
+  metaFor,
   withApplying,
 } from "../src/sync-data";
 import * as ltm from "../src/ltm";
@@ -1356,5 +1360,51 @@ describe("applyRemoteMeta / applyRemoteMetaCrdt — convergent confidence (A2 3b
     ).last_reinforced_at;
     expect(lra).not.toBeNull();
     expect(lra as number).toBeGreaterThanOrEqual(before);
+  });
+});
+
+describe("tier-aware table selection (D-2, #826)", () => {
+  afterEach(() => db().exec("DELETE FROM profiles"));
+
+  test("syncedTablesFor is cumulative: basic ⊆ pro ⊆ max", () => {
+    const names = (t: "basic" | "pro" | "max") =>
+      syncedTablesFor(t).map((m) => m.table);
+    const basic = names("basic");
+    const pro = names("pro");
+    const max = names("max");
+    // basic equals the registered basic set exactly
+    expect(new Set(basic)).toEqual(
+      new Set(SYNCED_TABLES.basic.map((m) => m.table)),
+    );
+    // cumulative containment: every lower-tier table is present in the higher tier
+    for (const t of basic) expect(pro).toContain(t);
+    for (const t of pro) expect(max).toContain(t);
+    // no duplicate table within a tier's cumulative set
+    expect(new Set(pro).size).toBe(pro.length);
+    // non-cumulative accessor still returns exactly one tier's set
+    expect(syncedTables("basic")).toBe(SYNCED_TABLES.basic);
+  });
+
+  test("currentSyncTier maps the plan tier from the profiles mirror", () => {
+    const setPlan = (tier?: string) => {
+      db().exec("DELETE FROM profiles");
+      if (tier)
+        db().query("INSERT INTO profiles (id, tier) VALUES ('u', ?)").run(tier);
+    };
+    setPlan(); // no profile pulled yet → default
+    expect(currentSyncTier()).toBe("basic");
+    setPlan("free");
+    expect(currentSyncTier()).toBe("basic");
+    setPlan("pro");
+    expect(currentSyncTier()).toBe("pro");
+    setPlan("max");
+    expect(currentSyncTier()).toBe("max");
+    setPlan("enterprise"); // unknown plan → safe default, never throws
+    expect(currentSyncTier()).toBe("basic");
+  });
+
+  test("metaFor resolves any registered table regardless of tier; throws for unknown", () => {
+    expect(metaFor("knowledge").table).toBe("knowledge");
+    expect(() => metaFor("not_a_table")).toThrow(/not a synced table/);
   });
 });

--- a/packages/gateway/src/cli/sync-cmd.ts
+++ b/packages/gateway/src/cli/sync-cmd.ts
@@ -56,7 +56,7 @@ export async function cmdEnable(
   }
   const justEnabled = !syncData.isSyncEnabled();
   if (justEnabled) {
-    syncData.enableSync("basic");
+    syncData.enableSync(); // defaults to the current plan's SyncTier
     console.log(
       `Sync enabled for ${formatUser(user)}. Reconciling existing knowledge + entities…`,
     );
@@ -380,7 +380,7 @@ async function cmdStatus(): Promise<void> {
     // Pending = distinct (table,row_id) with an outbox seq beyond that table's
     // push cursor. Cursors are per table.
     const seen = new Set<string>();
-    for (const meta of syncData.syncedTables("basic")) {
+    for (const meta of syncData.syncedTablesFor(syncData.currentSyncTier())) {
       const cursor = Number(getKV(`sync.push.${meta.table}`) ?? "0");
       for (const e of syncData.readOutbox(cursor, 100_000, meta.table)) {
         seen.add(`${e.table_name}\x1f${e.row_id}`);
@@ -415,7 +415,7 @@ export function makeSyncProgress(
   header: string,
   out: ProgressOut = process.stdout,
 ): { onProgress: SyncProgressFn; done: () => void } {
-  const tables = syncData.syncedTables("basic");
+  const tables = syncData.syncedTablesFor(syncData.currentSyncTier());
   const total = tables.filter((t) => !t.pullOnly).length + tables.length;
   const tty = !!out.isTTY;
   const seen = new Set<string>();

--- a/packages/gateway/src/sync.ts
+++ b/packages/gateway/src/sync.ts
@@ -272,7 +272,7 @@ export async function pushOnce(
 ): Promise<SyncResult> {
   const res: SyncResult = { pushed: 0, pulled: 0, conflicts: 0, skipped: 0 };
   const enc = makeEncryptionResolver();
-  for (const meta of syncData.syncedTables("basic")) {
+  for (const meta of syncData.syncedTablesFor(syncData.currentSyncTier())) {
     // Pull-only tables (e.g. profiles) are server-authoritative: the client only
     // reads them. They have no outbox capture trigger, so this is belt-and-
     // suspenders, but it keeps the intent explicit and avoids a needless scan.
@@ -293,7 +293,7 @@ export async function pushOnce(
   // exclude them too (defense-in-depth: nothing should enqueue them, but if a
   // stray entry existed it must not wedge the prune floor at 0).
   const cursors = syncData
-    .syncedTables("basic")
+    .syncedTablesFor(syncData.currentSyncTier())
     .filter((m) => !m.pullOnly && syncData.hasOutboxEntries(m.table))
     .map((m) => Number(getKV(pushKey(m.table)) ?? "0"));
   if (cursors.length > 0) {
@@ -594,7 +594,7 @@ export async function pullOnce(
   const res: SyncResult = { pushed: 0, pulled: 0, conflicts: 0, skipped: 0 };
   const encResolver = makeEncryptionResolver();
 
-  for (const meta of syncData.syncedTables("basic")) {
+  for (const meta of syncData.syncedTablesFor(syncData.currentSyncTier())) {
     // Emit BEFORE the locked/skip guards so a skipped table still advances the bar.
     onProgress?.({
       phase: "pull",
@@ -992,7 +992,7 @@ async function reportDeviceProgress(client: SupabaseClient): Promise<void> {
     if (!user?.user_id) return;
     const deviceId = syncData.replicaId();
     const rows: Array<Record<string, unknown>> = [];
-    for (const meta of syncData.syncedTables("basic")) {
+    for (const meta of syncData.syncedTablesFor(syncData.currentSyncTier())) {
       if (meta.pullOnly) continue; // pull-only tables (e.g. profiles) are never reaped
       const ms = parseCursor(getKV(pullKey(meta.table))).ms;
       rows.push({
@@ -1145,9 +1145,10 @@ function toRemoteRow(
 }
 
 function tableMeta(table: string): syncData.SyncTableMeta {
-  const meta = syncData.syncedTables("basic").find((m) => m.table === table);
-  if (!meta) throw new Error(`not a synced table: ${table}`);
-  return meta;
+  // Tier-independent: a table's meta exists regardless of the current tier (tier
+  // only gates whether it's synced). Resolving via the registry avoids a
+  // tier-timing edge where a pro table is processed before the mirror flips.
+  return syncData.metaFor(table);
 }
 
 function idColumns(table: string): string[] {


### PR DESCRIPTION
Second PR of the **D** stack (#826). **Pure plumbing refactor** so the engine syncs the table set for the user's PLAN tier instead of a hardcoded `"basic"`. `SYNCED_TABLES.pro`/`max` are still empty → **behavior-identical today** (everyone gets basic); it just removes the hardcoded `"basic"` so D-3 can populate the pro set and have it sync automatically.

## core (`sync-data.ts`)
- **`META_BY_TABLE`** now indexes ALL tiers (basic ∪ pro ∪ max) → `meta()`/`metaFor()` resolve a table regardless of tier (a table's shape is tier-independent; tier only gates whether it's *synced*).
- **`syncedTablesFor(tier)`** — the CUMULATIVE set: basic ⊆ pro ⊆ max. This is what the engine actually syncs (a Pro user gets basic **plus** pro). `syncedTables(tier)` stays as the non-cumulative single-tier accessor.
- **`currentSyncTier()`** — maps the plan tier (`currentTier()`: free|pro|max) → SyncTier (free→basic, pro→pro, max→max); unknown plan → basic (safe default).
- **`metaFor(table)`** — tier-independent meta resolver.
- `seedOutbox`/`reconcile`/`enableSync` default to `currentSyncTier()` and iterate `syncedTablesFor(tier)`; `assertSyncInvariants` covers the cumulative set.

## gateway (`sync.ts`, `cli/sync-cmd.ts`)
- The 5 `sync.ts` + 2 CLI hardcoded `syncedTables("basic")` sites → `syncedTablesFor(currentSyncTier())`; `tableMeta()` resolves via tier-independent `metaFor()` (avoids a tier-timing edge for pro tables); `cmdEnable` calls `enableSync()` (defaults to the current plan's SyncTier).

## Tests
+3 unit tests: `syncedTablesFor` cumulative invariant (basic ⊆ pro ⊆ max), `currentSyncTier` plan mapping incl. unknown→basic, `metaFor` resolve/throw. **Full core+gateway suite green (5501 passed / 101 skipped, 0 fail)** — zero behavior change with pro/max empty.

Stack: D-1 (#1240, merged) → **D-2 (this)** → D-3 (pro metas + distillation-driven capture + subset seed + prune sync-suppression — arms it) → D-4 (Tier-2 encrypted round-trip).