### PR TITLE
feat(supabase): enforce append-only on temporal_messages (D-3a, #826)

### DIFF
--- a/packages/gateway/test/sync-security.integration.test.ts
+++ b/packages/gateway/test/sync-security.integration.test.ts
@@ -1944,5 +1944,81 @@ describe.skipIf(gate())(
       );
       expect(err.code).toBe("23514");
     });
+
+    it("temporal_messages is append-only: UPDATE is denied (42501); INSERT/SELECT/DELETE allowed (0021)", async () => {
+      const a = await h.createUser();
+      await makePro(a);
+      await h.asUser(a, (c) =>
+        c.query(
+          "insert into public.temporal_messages (id, scope_id, content) values ('t1',$1,'orig')",
+          [a],
+        ),
+      );
+      // UPDATE is revoked at the privilege level → hard 42501, not a silent no-op.
+      const err = await expectError(() =>
+        h.asUser(a, (c) =>
+          c.query(
+            "update public.temporal_messages set content='rewritten' where id='t1' and scope_id=$1",
+            [a],
+          ),
+        ),
+      );
+      expect(err.code).toBe("42501");
+      // Content is unchanged.
+      const row = await h.asUser(a, (c) =>
+        c.query("select content from public.temporal_messages where id='t1'"),
+      );
+      expect(row.rows[0].content).toBe("orig");
+      // Self-purge (DELETE) is still allowed.
+      await h.asUser(a, (c) =>
+        c.query(
+          "delete from public.temporal_messages where id='t1' and scope_id=$1",
+          [a],
+        ),
+      );
+      const after = await h.asUser(a, (c) =>
+        c.query(
+          "select count(*)::int as n from public.temporal_messages where scope_id=$1",
+          [a],
+        ),
+      );
+      expect(after.rows[0].n).toBe(0);
+    });
+
+    it("distillations still allows UPDATE (the archived flip re-pushes) (0021)", async () => {
+      const a = await h.createUser();
+      await makePro(a);
+      await h.asUser(a, (c) =>
+        c.query(
+          "insert into public.distillations (id, scope_id) values ('d1',$1)",
+          [a],
+        ),
+      );
+      await h.asUser(a, (c) =>
+        c.query(
+          "update public.distillations set archived=true where id='d1' and scope_id=$1",
+          [a],
+        ),
+      );
+      const row = await h.asUser(a, (c) =>
+        c.query("select archived from public.distillations where id='d1'"),
+      );
+      expect(row.rows[0].archived).toBe(true);
+    });
+
+    it("authenticated holds NO UPDATE grant on temporal_messages — guards against a future re-grant (0021)", async () => {
+      // The hard-error (42501) enforcement depends solely on the REVOKE; a careless
+      // future `grant update` would silently downgrade append-only to a 0-row no-op.
+      const grants = await h.client.query(
+        `select privilege_type from information_schema.role_table_grants
+          where grantee='authenticated' and table_schema='public'
+            and table_name='temporal_messages' order by privilege_type`,
+      );
+      expect(grants.rows.map((r) => r.privilege_type)).toEqual([
+        "DELETE",
+        "INSERT",
+        "SELECT",
+      ]); // no UPDATE
+    });
   },
 );

--- a/supabase/migrations/0021_temporal_append_only.sql
+++ b/supabase/migrations/0021_temporal_append_only.sql
@@ -1,0 +1,49 @@
+-- Migration 0021 — enforce append-only on temporal_messages at the DB layer (D, #826).
+--
+-- 0020 gave both pro tables a single `for all` RLS policy. temporal_messages is
+-- APPEND-ONLY by design (the client only ever inserts; a message's content is
+-- never rewritten in place), but `for all` still PERMITTED an UPDATE — so a
+-- direct-PostgREST client could rewrite its own stored conversation content
+-- (self-harm only, but it contradicts the documented model and the versioned:false
+-- + `(scope_id, updated_at)` pull-cursor assumptions). This closes that gap as
+-- defense-in-depth (Sentry finding on #1240).
+--
+-- Enforcement is belt-and-suspenders:
+--   1. REVOKE the UPDATE privilege from `authenticated` → a hard 42501 (not a
+--      silent 0-row no-op) if anyone tries.
+--   2. Replace the `for all` policy with explicit SELECT / INSERT / DELETE
+--      policies (no UPDATE), so the policy set itself reflects append-only.
+--
+-- distillations is UNTOUCHED: it is versioned and legitimately UPDATEs (the
+-- `archived` flip re-pushes), so it keeps its `for all` policy from 0020.
+-- DELETE stays allowed (a user may purge their own backup — self-scoped, no tier
+-- gate, matching 0020's behavior); the local prune is sync-invisible and the
+-- server reaper handles remote lifecycle.
+
+-- 1. Privilege-level hard deny of UPDATE.
+revoke update on public.temporal_messages from authenticated;
+
+-- 2. Policy set without UPDATE (idempotent: drop-then-create).
+drop policy if exists temporal_messages_scope_all on public.temporal_messages;
+drop policy if exists temporal_messages_scope_select on public.temporal_messages;
+drop policy if exists temporal_messages_scope_insert on public.temporal_messages;
+drop policy if exists temporal_messages_scope_delete on public.temporal_messages;
+
+-- Reads open (a downgraded ex-pro can still PULL their backup).
+create policy temporal_messages_scope_select on public.temporal_messages
+  for select
+  using (scope_id = auth.uid());
+
+-- Writes: scope + author pinned to the caller AND pro tier required.
+create policy temporal_messages_scope_insert on public.temporal_messages
+  for insert
+  with check (
+    scope_id = auth.uid()
+    and author_id = auth.uid()
+    and public.current_tier() = 'pro'
+  );
+
+-- Self-purge allowed regardless of tier (matches 0020; no in-place rewrite path).
+create policy temporal_messages_scope_delete on public.temporal_messages
+  for delete
+  using (scope_id = auth.uid());


### PR DESCRIPTION
Closes the D-1 Sentry MEDIUM: 0020 gave both pro tables a single `for all` RLS policy, but `temporal_messages` is **append-only** (the client only ever inserts; a message's content is never rewritten in place). `for all` still permitted UPDATE, letting a direct-PostgREST client rewrite its own stored conversation content (self-harm only, but contradicts the model + the `versioned:false` / `(scope_id, updated_at)` pull-cursor assumptions).

## `0021_temporal_append_only.sql` (belt-and-suspenders)
- **REVOKE UPDATE** on `temporal_messages` from `authenticated` → hard `42501`, not a silent 0-row no-op.
- Replace the `for all` policy with explicit **SELECT / INSERT(pro) / DELETE** policies (no UPDATE) so the policy set itself reflects append-only. Reads stay open (downgraded pull); DELETE stays allowed (self-purge, no tier gate — the local prune is sync-invisible, the server reaper handles remote lifecycle).
- **`distillations` untouched:** it's versioned and legitimately UPDATEs (the archived flip re-pushes), so it keeps its `for all` policy.

## Tier-1 tests (+2)
temporal UPDATE → `42501` with content unchanged + INSERT/SELECT/DELETE still work; distillations UPDATE (archived flip) still works. **85/85** pass against real Postgres.

Stack: D-1 (#1240) + D-2 (#1241) merged → **D-3a (this, small server follow-up)** → D-3b (client arming) → D-4 (Tier-2 round-trip).