### PR TITLE
feat(sync): arm Pro-tier distillation + temporal backup, client side (D-3b, #826)

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -2390,7 +2390,58 @@ function installSyncCapture(database: Database) {
       INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
       VALUES ('scope_keys', new.member_user_id, 'upsert', ${ts});
     END;`;
+  // D (#826): Pro-tier distillation-fanout capture. Installed ONLY when the plan
+  // tier (from the pulled profiles mirror) is pro/max — a free user creating
+  // distillations must not accrue un-pushable pro outbox entries that no push cursor
+  // ever drains. On a tier flip the gateway calls reinstallSyncCapture() to add/drop
+  // these (TEMP + IF NOT EXISTS is idempotent; the else-branch DROP removes them on
+  // downgrade).
+  const tierRow = database
+    .query("SELECT tier FROM profiles LIMIT 1")
+    .all()[0] as { tier?: string } | undefined;
+  const isProTier = tierRow?.tier === "pro" || tierRow?.tier === "max";
+  if (isProTier) {
+    // On INSERT: enqueue the distillation AND fan out one temporal_messages outbox
+    // row per referenced source id (json_each over source_ids). This REFERENCED
+    // SUBSET is the ONLY temporal that ever syncs — temporal_messages has NO capture
+    // trigger of its own (captureStrategy "none"), so an undistilled message is never
+    // enqueued. On UPDATE (the archived flip): re-enqueue the distillation only (its
+    // source set is immutable; a no-op non-archived UPDATE such as embedding backfill
+    // is deduped away by the push-side content_hash check). No DELETE: the local prune
+    // is sync-invisible (temporal.prune runs under capture-suppression + clears
+    // sync_state), so a pruned local row must NOT tombstone the remote backup.
+    sql += `
+      CREATE TEMP TRIGGER IF NOT EXISTS distillations_outbox_ins
+      AFTER INSERT ON distillations WHEN (${gate})
+      BEGIN
+        INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
+        VALUES ('distillations', new.id, 'upsert', ${ts});
+        INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
+        SELECT 'temporal_messages', value, 'upsert', ${ts} FROM json_each(new.source_ids);
+      END;
+      CREATE TEMP TRIGGER IF NOT EXISTS distillations_outbox_upd
+      AFTER UPDATE ON distillations WHEN (${gate})
+      BEGIN
+        INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
+        VALUES ('distillations', new.id, 'upsert', ${ts});
+      END;`;
+  } else {
+    sql += `
+      DROP TRIGGER IF EXISTS distillations_outbox_ins;
+      DROP TRIGGER IF EXISTS distillations_outbox_upd;`;
+  }
   database.exec(sql);
+}
+
+/**
+ * Re-run change-capture install on the current connection to reconcile the Pro
+ * distillation-fanout trigger set to the current plan tier (installSyncCapture reads
+ * it from the profiles mirror). Called after a profile pull may have flipped the
+ * tier: TEMP + IF NOT EXISTS makes the re-run idempotent, and the non-pro branch
+ * DROPs the Pro triggers on a downgrade.
+ */
+export function reinstallSyncCapture(database: Database = db()): void {
+  installSyncCapture(database);
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -145,6 +145,7 @@ export {
   setMeta,
   getInstanceId,
   runUpsert,
+  reinstallSyncCapture,
   withTransaction,
   withSavepoint,
   ensureSessionRollup,

--- a/packages/core/src/sync-data.ts
+++ b/packages/core/src/sync-data.ts
@@ -91,6 +91,29 @@ export interface SyncTableMeta {
    * `keystore.encryptionState() === "on"`; "off" leaves these plaintext (v1 default).
    */
   encryptedColumns?: string[];
+  /**
+   * How local change-capture is installed for this table (installSyncCapture, db.ts):
+   *   "row" (default) — a standard per-row INSERT/UPDATE/DELETE outbox trigger.
+   *   "distillation-fanout" — distillations only: on INSERT enqueue the distillation
+   *     AND fan out one temporal_messages outbox row per id in `source_ids`
+   *     (json_each); on UPDATE re-enqueue the distillation (the archived flip). Its
+   *     referenced temporal subset is the ONLY temporal that ever syncs. Pro-tier
+   *     gated (installed only when the plan tier is pro/max).
+   *   "none" — no own trigger; captured INDIRECTLY (temporal_messages, enqueued by
+   *     the distillation fanout). Distinct from pullOnly, which is never pushed.
+   */
+  captureStrategy?: "row" | "distillation-fanout" | "none";
+  /**
+   * Append-only table whose REMOTE schema has NO `is_deleted` column (temporal_messages,
+   * supabase/migrations/0020 — "no is_deleted reaper"). The push payload must therefore
+   * OMIT `is_deleted` (unlike every other table, where pushEntry sends `is_deleted:false`
+   * on upsert / `true` on delete) — sending it is a PGRST204 that poisons every row. The
+   * client also never deletes/tombstones it (reconcile skips it), so the delete branch is
+   * unreachable; the pull side already treats an absent `is_deleted` as not-deleted.
+   * Defaults to false. (Distinct from `versioned`: the join table is versioned:false yet
+   * HAS is_deleted, so `versioned` is the wrong discriminator here.)
+   */
+  appendOnly?: boolean;
 }
 
 /** ASCII Unit Separator — joins composite row ids (mirrors the SQL `char(31)`). */
@@ -314,7 +337,68 @@ export const SYNCED_TABLES: Record<SyncTier, SyncTableMeta[]> = {
       ],
     },
   ],
-  pro: [],
+  pro: [
+    {
+      // D (#826): the compressed conversation-memory backup. Encrypted on the wire
+      // (narrative/facts/observations sealed to the per-scope DEK). VERSIONED — the
+      // `archived` flip is a real UPDATE that re-pushes (content_hash changes).
+      // Captured via a distillation-fanout trigger that also enqueues the referenced
+      // temporal_messages subset. source_ids stays cleartext (id refs, like FKs).
+      table: "distillations",
+      idColumns: ["id"],
+      ftsTables: ["distillation_fts"],
+      captureStrategy: "distillation-fanout",
+      encryptedColumns: ["narrative", "facts", "observations"],
+      syncColumns: [
+        "id",
+        "project_id",
+        "session_id",
+        "narrative",
+        "facts",
+        "observations",
+        "source_ids",
+        "generation",
+        "token_count",
+        "r_compression",
+        "c_norm",
+        "call_type",
+        "worker_provider_id",
+        "worker_model_id",
+        "archived",
+        "created_at",
+        // No updated_at: the local table has none — the remote server-stamps it
+        // (0020 default now() + BEFORE UPDATE trigger), which is the pull cursor.
+      ],
+    },
+    {
+      // D (#826): ONLY the distillation-REFERENCED subset ever syncs (id ∈ ⋃
+      // distillations.source_ids) — enforced by the fanout capture + the subset-aware
+      // seed/reconcile; an undistilled message never leaves the device. Append-only
+      // (versioned:false); NO own capture trigger (captureStrategy "none" — enqueued
+      // by the distillation fanout). The local `distilled` residency flag is NOT
+      // synced (per-device cache state); a pulled row is marked distilled=1 on apply
+      // so the next prune won't evict a just-restored message. content/metadata are
+      // encrypted on the wire.
+      table: "temporal_messages",
+      idColumns: ["id"],
+      ftsTables: ["temporal_fts"],
+      versioned: false,
+      // Remote 0020 has no is_deleted column — the push payload must omit it.
+      appendOnly: true,
+      captureStrategy: "none",
+      encryptedColumns: ["content", "metadata"],
+      syncColumns: [
+        "id",
+        "project_id",
+        "session_id",
+        "role",
+        "content",
+        "tokens",
+        "metadata",
+        "created_at",
+      ],
+    },
+  ],
   max: [],
 };
 
@@ -706,6 +790,25 @@ function seedSelect(table: string): string {
                ORDER BY m.confidence DESC,
                         COALESCE(m.last_reinforced_at, m.updated_at) DESC,
                         m.logical_id`;
+    // D (#826): the compressed-memory backup. Recency order so the newest memory
+    // survives the (generous, rarely-binding) pro cap.
+    case "distillations":
+      return "SELECT * FROM distillations ORDER BY created_at DESC, id";
+    // D (#826): 🔴 ONLY the distillation-REFERENCED subset ever syncs — an
+    // undistilled message must NEVER be enqueued. Restrict to ids present in some
+    // distillation's source_ids (json_each), mirroring the fanout capture trigger.
+    // Recency order for cap survival; id tiebreak for determinism.
+    case "temporal_messages":
+      // json_valid guard: a single corrupt source_ids must not throw and abort the
+      // whole seed transaction (source_ids is always JSON.stringify'd, so this is
+      // belt-and-suspenders; filter BEFORE json_each so the bad row is skipped).
+      return `SELECT t.* FROM temporal_messages t
+                WHERE t.id IN (
+                  SELECT value FROM
+                    (SELECT source_ids FROM distillations WHERE json_valid(source_ids)) d,
+                    json_each(d.source_ids)
+                )
+               ORDER BY t.created_at DESC, t.id`;
     default:
       return `SELECT * FROM ${table}`;
   }
@@ -827,6 +930,14 @@ export function reconcile(tier: SyncTier = currentSyncTier()): void {
     // Pull-only tables are never pushed (see seedOutbox) — also skip the
     // delete-tombstone reconciliation so no `profiles` outbox entry is created.
     if (m.pullOnly) continue;
+    // D (#826): 🔴 the Pro backup tables (distillations, temporal_messages — any
+    // non-"row" capture strategy) are APPEND-ONLY and sync-invisible on local
+    // deletion. A local prune / project cleanup / cache eviction must NEVER tombstone
+    // the remote backup: the remote is permanent, bounded by the per-scope quota +
+    // server reaper, NOT by local residency (epic #821 decision). They also have no
+    // capture DELETE trigger, so the ONLY way they could tombstone is this pass —
+    // skip it. (Remote lifecycle is the server reaper's job, not the client's.)
+    if (m.captureStrategy && m.captureStrategy !== "row") continue;
     // Knowledge is keyed by logical_id and append-only: "live" means a CURRENT live
     // version exists (knowledge_current), NOT merely a physical row — a deleted
     // entry keeps its demoted/death-cert version rows, so an `id = logical_id`
@@ -1588,7 +1699,15 @@ export function assertSyncInvariants(): void {
 
   // 3. Every outbox / sync_state row references a registered synced table — a
   //    typo or registry drift would silently strand rows the engine can't route.
-  const known = new Set(tables.map((m) => m.table));
+  //    Use ALL registered tables (every tier), NOT the current tier's set: a
+  //    downgraded ex-pro (or a Pro user before the tier mirror loads) legitimately
+  //    holds sync_state/outbox rows for a Pro table while currentSyncTier() is
+  //    basic — that is registry-KNOWN, not drift (#826/D).
+  const known = new Set(
+    [...SYNCED_TABLES.basic, ...SYNCED_TABLES.pro, ...SYNCED_TABLES.max].map(
+      (m) => m.table,
+    ),
+  );
   for (const tbl of ["sync_outbox", "sync_state"] as const) {
     const names = db()
       .query(`SELECT DISTINCT table_name FROM ${tbl}`)

--- a/packages/core/src/temporal.ts
+++ b/packages/core/src/temporal.ts
@@ -1,4 +1,4 @@
-import { db, ensureProject } from "./db";
+import { db, ensureProject, withSyncApplying } from "./db";
 import { deleteEmbeddings } from "./db/vec-store";
 import { runRelaxedSearch, runRelaxedSearchAsync } from "./search";
 import { offloadAllOrTimeout, READ_JOB_TIMED_OUT } from "./read-offload";
@@ -699,6 +699,26 @@ export type PruneResult = {
  * at a real schema problem rather than a transient swap. Root-causing/serializing
  * the swap itself and recovering missing base tables are tracked follow-ups.
  */
+/**
+ * Clear sync_state for locally-pruned Pro-backup rows (#826/D). The prune is
+ * sync-INVISIBLE: the remote backup is bounded by the server reaper + per-scope
+ * quota, NOT by local residency, so a pruned row must never tombstone the remote
+ * (reconcile also skips these append-only tables). Dropping the now-dead sync_state
+ * keeps it from growing unbounded as messages are pruned over a device's lifetime.
+ * Harmless when sync is off (no rows) or the table is un-synced (basic tier).
+ */
+function clearPrunedSyncState(
+  database: ReturnType<typeof db>,
+  table: string,
+  ids: string[],
+): void {
+  if (ids.length === 0) return;
+  const ph = ids.map(() => "?").join(",");
+  database
+    .query(`DELETE FROM sync_state WHERE table_name = ? AND row_id IN (${ph})`)
+    .run(table, ...ids);
+}
+
 export function prune(input: {
   projectPath: string;
   retentionDays: number;
@@ -745,11 +765,16 @@ export function prune(input: {
         .all(pid, cutoff) as { id: string }[]
     ).map((r) => r.id);
     if (ttlIds.length > 0) {
-      database
-        .query(
-          "DELETE FROM temporal_messages WHERE project_id = ? AND distilled = 1 AND created_at < ?",
-        )
-        .run(pid, cutoff);
+      // Capture-suppressed (#826/D): defense-in-depth so a future sync DELETE
+      // trigger can't tombstone the remote backup; also drops the dead sync_state.
+      withSyncApplying(() => {
+        database
+          .query(
+            "DELETE FROM temporal_messages WHERE project_id = ? AND distilled = 1 AND created_at < ?",
+          )
+          .run(pid, cutoff);
+        clearPrunedSyncState(database, "temporal_messages", ttlIds);
+      });
       deleteEmbeddings(database, "temporal", ttlIds);
     }
     ttlDeleted = ttlIds.length;
@@ -796,9 +821,14 @@ export function prune(input: {
 
       if (toDelete.length) {
         const placeholders = toDelete.map(() => "?").join(",");
-        database
-          .query(`DELETE FROM temporal_messages WHERE id IN (${placeholders})`)
-          .run(...toDelete);
+        withSyncApplying(() => {
+          database
+            .query(
+              `DELETE FROM temporal_messages WHERE id IN (${placeholders})`,
+            )
+            .run(...toDelete);
+          clearPrunedSyncState(database, "temporal_messages", toDelete);
+        });
         // Drop the evicted messages' vec0 chunks too (see Pass 1 rationale).
         deleteEmbeddings(database, "temporal", toDelete);
         // toDelete.length is the accurate count — result.changes is inflated by FTS triggers.
@@ -828,11 +858,14 @@ export function prune(input: {
         .all(pid, cutoff) as { id: string }[]
     ).map((r) => r.id);
     if (archivedIds.length > 0) {
-      database
-        .query(
-          "DELETE FROM distillations WHERE project_id = ? AND archived = 1 AND created_at < ?",
-        )
-        .run(pid, cutoff);
+      withSyncApplying(() => {
+        database
+          .query(
+            "DELETE FROM distillations WHERE project_id = ? AND archived = 1 AND created_at < ?",
+          )
+          .run(pid, cutoff);
+        clearPrunedSyncState(database, "distillations", archivedIds);
+      });
       deleteEmbeddings(database, "distillations", archivedIds);
     }
   } catch (e) {

--- a/packages/core/test/sync-pro-tables.test.ts
+++ b/packages/core/test/sync-pro-tables.test.ts
@@ -1,0 +1,227 @@
+/**
+ * D (#826) — Pro-tier backup (distillations + the distillation-referenced subset
+ * of temporal_messages) push-side correctness: the distillation-fanout capture,
+ * tier-gating, subset-aware seed, the append-only no-tombstone reconcile, and the
+ * sync-invisible prune. The pull/restore side (residency exemption, encrypted
+ * round-trip) is covered by the Tier-2 integration suite (D-4).
+ */
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import {
+  db,
+  deleteTeamConfig,
+  ensureProject,
+  reinstallSyncCapture,
+} from "../src/db";
+import {
+  assertSyncInvariants,
+  enableSync,
+  getSyncState,
+  readOutbox,
+  reconcile,
+  seedOutbox,
+  setSyncState,
+} from "../src/sync-data";
+import * as temporal from "../src/temporal";
+
+const PROJECT = "/test/sync/pro";
+const now = () => Date.now();
+
+function setProTier() {
+  db()
+    .query(
+      "INSERT OR REPLACE INTO profiles (id, tier, created_at, updated_at) VALUES ('pro-u','pro',?,?)",
+    )
+    .run(now(), now());
+  reinstallSyncCapture(); // installs the tier-gated distillation-fanout trigger
+}
+
+function insertTemporal(id: string, distilled: 0 | 1 = 0, createdAt = now()) {
+  const pid = ensureProject(PROJECT);
+  db()
+    .query(
+      `INSERT OR REPLACE INTO temporal_messages
+         (id, project_id, session_id, role, content, tokens, distilled, created_at, metadata)
+       VALUES (?, ?, 's', 'user', 'hello', 1, ?, ?, '{}')`,
+    )
+    .run(id, pid, distilled, createdAt);
+}
+
+function insertDistillation(
+  id: string,
+  sourceIds: string[],
+  {
+    archived = 0,
+    createdAt = now(),
+  }: { archived?: 0 | 1; createdAt?: number } = {},
+) {
+  const pid = ensureProject(PROJECT);
+  db()
+    .query(
+      `INSERT OR REPLACE INTO distillations
+         (id, project_id, session_id, narrative, facts, observations, source_ids, generation, token_count, created_at, archived)
+       VALUES (?, ?, 's', 'n', 'f', 'o', ?, 0, 0, ?, ?)`,
+    )
+    .run(id, pid, JSON.stringify(sourceIds), createdAt, archived);
+}
+
+const clearOutbox = () => db().exec("DELETE FROM sync_outbox");
+const outbox = (table?: string, op?: string) =>
+  readOutbox(0).filter(
+    (e) => (!table || e.table_name === table) && (!op || e.op === op),
+  );
+const rowIds = (table: string, op?: string) =>
+  outbox(table, op)
+    .map((e) => e.row_id)
+    .sort();
+
+beforeEach(() => {
+  const pid = ensureProject(PROJECT);
+  deleteTeamConfig("sync.enabled");
+  db().exec("DELETE FROM temp._sync_applying");
+  db().exec("DELETE FROM sync_outbox");
+  db().exec("DELETE FROM sync_state");
+  db().exec("DELETE FROM profiles");
+  db().query("DELETE FROM temporal_messages WHERE project_id = ?").run(pid);
+  db().query("DELETE FROM distillations WHERE project_id = ?").run(pid);
+  reinstallSyncCapture(); // free-tier baseline (drops any Pro fanout trigger)
+});
+afterEach(() => {
+  db().exec("DELETE FROM profiles");
+  reinstallSyncCapture();
+});
+
+describe("distillation-fanout capture (#826/D)", () => {
+  test("a distillation INSERT enqueues the distillation + ONLY its referenced temporal subset", () => {
+    setProTier();
+    enableSync();
+    insertTemporal("t1");
+    insertTemporal("t2");
+    insertTemporal("t3"); // undistilled — must NEVER be enqueued
+    clearOutbox(); // temporal has no own trigger, so this is already empty
+    insertDistillation("d1", ["t1", "t2"]);
+
+    expect(rowIds("distillations")).toEqual(["d1"]);
+    expect(rowIds("temporal_messages")).toEqual(["t1", "t2"]); // t3 excluded
+  });
+
+  test("the fanout is TIER-GATED: a free-tier distillation INSERT enqueues nothing", () => {
+    // No profile row → free tier → reinstall drops the fanout trigger.
+    reinstallSyncCapture();
+    enableSync();
+    clearOutbox();
+    insertDistillation("d1", ["t1", "t2"]);
+    expect(outbox("distillations")).toHaveLength(0);
+    expect(outbox("temporal_messages")).toHaveLength(0);
+  });
+
+  test("the archived flip re-enqueues the distillation ONLY (not its temporal)", () => {
+    setProTier();
+    enableSync();
+    insertDistillation("d1", ["t1"]);
+    clearOutbox();
+    db().query("UPDATE distillations SET archived = 1 WHERE id = 'd1'").run();
+    expect(rowIds("distillations")).toEqual(["d1"]);
+    expect(outbox("temporal_messages")).toHaveLength(0);
+  });
+});
+
+describe("subset-aware seedOutbox (#826/D)", () => {
+  test("seeds distillations + ONLY the referenced temporal subset (never an undistilled message)", () => {
+    // Sync disabled → no capture; seed directly at the pro tier.
+    insertTemporal("t1");
+    insertTemporal("t2");
+    insertTemporal("t3"); // referenced by nothing
+    insertDistillation("d1", ["t1", "t2"]);
+    clearOutbox();
+
+    seedOutbox("pro");
+
+    expect(rowIds("distillations")).toEqual(["d1"]);
+    expect(rowIds("temporal_messages")).toEqual(["t1", "t2"]); // t3 never seeded
+  });
+});
+
+describe("reconcile never tombstones the append-only Pro backup (#826/D)", () => {
+  test("a locally-deleted synced distillation/temporal does NOT enqueue a delete", () => {
+    setProTier();
+    enableSync();
+    insertTemporal("t1");
+    insertDistillation("d1", ["t1"]);
+    // Pretend both were pushed (sync_state present), then vanish locally (prune /
+    // project cleanup). A basic table would tombstone here; a Pro table must not.
+    setSyncState("distillations", "d1", {
+      content_hash: "h",
+      revision: 0,
+      remote_updated_at: null,
+    });
+    setSyncState("temporal_messages", "t1", {
+      content_hash: "h",
+      revision: 0,
+      remote_updated_at: null,
+    });
+    db().exec("DELETE FROM distillations WHERE id = 'd1'");
+    db().exec("DELETE FROM temporal_messages WHERE id = 't1'");
+    clearOutbox();
+
+    reconcile("pro");
+
+    expect(outbox("distillations", "delete")).toHaveLength(0);
+    expect(outbox("temporal_messages", "delete")).toHaveLength(0);
+  });
+});
+
+describe("assertSyncInvariants spans all tiers (#826/D)", () => {
+  test("a Pro-table sync_state row at basic tier is NOT flagged as registry drift", () => {
+    // No profile row → basic tier. A distillations sync_state row lingers from when
+    // the user was pro (or before the tier mirror loaded). Invariant #3's known-set
+    // must span ALL tiers, else this false-throws "references unregistered table".
+    setSyncState("distillations", "d-old", {
+      content_hash: "h",
+      revision: 0,
+      remote_updated_at: null,
+    });
+    expect(() => assertSyncInvariants()).not.toThrow();
+  });
+});
+
+describe("prune is sync-invisible for Pro rows (#826/D)", () => {
+  test("clears the pruned rows' sync_state and enqueues NO tombstone", () => {
+    setProTier();
+    enableSync();
+    const old = now() - 200 * 24 * 60 * 60 * 1000; // 200 days old
+    insertTemporal("t1", 1, old); // distilled + old → TTL-pruned
+    insertDistillation("d1", ["t1"], { archived: 1, createdAt: old }); // archived + old → pruned
+    setSyncState("temporal_messages", "t1", {
+      content_hash: "h",
+      revision: 0,
+      remote_updated_at: null,
+    });
+    setSyncState("distillations", "d1", {
+      content_hash: "h",
+      revision: 0,
+      remote_updated_at: null,
+    });
+    clearOutbox();
+
+    temporal.prune({
+      projectPath: PROJECT,
+      retentionDays: 120,
+      maxStorageMB: 1024,
+    });
+
+    // Rows are gone locally...
+    expect(
+      (
+        db()
+          .query("SELECT COUNT(*) AS n FROM temporal_messages WHERE id = 't1'")
+          .get() as { n: number }
+      ).n,
+    ).toBe(0);
+    // ...their dead sync_state is cleared...
+    expect(getSyncState("temporal_messages", "t1")).toBeNull();
+    expect(getSyncState("distillations", "d1")).toBeNull();
+    // ...and NO tombstone was enqueued (sync-invisible prune).
+    expect(outbox("temporal_messages", "delete")).toHaveLength(0);
+    expect(outbox("distillations", "delete")).toHaveLength(0);
+  });
+});

--- a/packages/core/test/sync-registry-contract.test.ts
+++ b/packages/core/test/sync-registry-contract.test.ts
@@ -16,7 +16,7 @@
  * real push path.
  */
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
-import { db, deleteTeamConfig } from "../src/db";
+import { db, deleteTeamConfig, reinstallSyncCapture } from "../src/db";
 import {
   assertSyncInvariants,
   enableSync,
@@ -26,6 +26,20 @@ import {
 } from "../src/sync-data";
 
 const now = () => Date.now();
+
+// Every registered table across ALL tiers — the battery must cover Pro (#826/D)
+// tables too, not just basic, so a new tier's table inherits every contract.
+const ALL_REGISTERED = [
+  ...SYNCED_TABLES.basic,
+  ...SYNCED_TABLES.pro,
+  ...SYNCED_TABLES.max,
+];
+// Pro-tier tables: their capture triggers are tier-gated (installSyncCapture only
+// installs them when the plan tier is pro/max), so a check needing the trigger
+// present must set tier=pro + reinstall first.
+const PRO_TABLES = new Set(
+  [...SYNCED_TABLES.pro, ...SYNCED_TABLES.max].map((m) => m.table),
+);
 
 /**
  * Live-row factories used by the BEHAVIORAL pull-only checks. EVERY pull-only
@@ -58,15 +72,26 @@ beforeEach(() => {
   db().exec("DELETE FROM temp._sync_applying");
   db().exec("DELETE FROM sync_outbox");
   db().exec("DELETE FROM sync_state");
-  for (const m of SYNCED_TABLES.basic) {
+  for (const m of ALL_REGISTERED) {
     db().exec(`DELETE FROM ${m.table}`);
   }
+  // Reset change-capture to the free-tier baseline: with no profile row,
+  // reinstallSyncCapture() drops any Pro fanout triggers a prior test installed,
+  // so each test starts from the same trigger set.
+  reinstallSyncCapture();
 });
 
 afterEach(() => assertSyncInvariants()); // #834 — continuous invariant guard
 
 describe("SYNCED_TABLES registry contract", () => {
-  for (const m of SYNCED_TABLES.basic) {
+  test("no table is registered in more than one tier", () => {
+    // A table listed in two tiers would clobber META_BY_TABLE (last-wins) and
+    // duplicate it in every syncedTablesFor() cumulative set.
+    const names = ALL_REGISTERED.map((m) => m.table);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  for (const m of ALL_REGISTERED) {
     describe(`${m.table}${m.pullOnly ? " (pull-only)" : ""}`, () => {
       test("idColumns are non-empty and a subset of syncColumns", () => {
         // rowIdOf()/getRowById() read the id columns out of a syncColumns-only
@@ -75,13 +100,25 @@ describe("SYNCED_TABLES registry contract", () => {
         for (const c of m.idColumns) expect(m.syncColumns).toContain(c);
       });
 
-      test("has a change-capture trigger IFF it is not pull-only", () => {
-        // Pull-only tables are server-authoritative; capturing local writes
-        // would enqueue an entry that can never be pushed.
+      test("has its own change-capture trigger IFF not pull-only and captureStrategy != none", () => {
+        // Pull-only tables are server-authoritative; capturing local writes would
+        // enqueue an unpushable entry. captureStrategy "none" (temporal_messages) has
+        // NO own trigger either — it is captured indirectly by the distillation
+        // fanout, so its own trigger would double-enqueue.
+        if (PRO_TABLES.has(m.table)) {
+          // Pro capture is tier-gated — install it by setting the plan tier to pro.
+          db()
+            .query(
+              "INSERT OR REPLACE INTO profiles (id, tier, created_at, updated_at) VALUES ('rc-tier','pro',?,?)",
+            )
+            .run(now(), now());
+          reinstallSyncCapture();
+        }
+        const expectsOwnTrigger = !m.pullOnly && m.captureStrategy !== "none";
         const captured = tempTriggers().some((n) =>
           n.startsWith(`${m.table}_outbox_`),
         );
-        expect(captured).toBe(!m.pullOnly);
+        expect(captured).toBe(expectsOwnTrigger);
       });
 
       if (m.pullOnly) {
@@ -129,7 +166,7 @@ describe("SYNCED_TABLES local-only secondary UNIQUE → convergence handling (#1
     a.length === b.length &&
     [...a].sort().join("\u0000") === [...b].sort().join("\u0000");
 
-  for (const m of SYNCED_TABLES.basic) {
+  for (const m of ALL_REGISTERED) {
     test(`${m.table}: any local-only secondary UNIQUE has convergence handling`, () => {
       const indexes = db().query(`PRAGMA index_list("${m.table}")`).all() as {
         name: string;

--- a/packages/gateway/src/sync.ts
+++ b/packages/gateway/src/sync.ts
@@ -22,7 +22,15 @@
  *                          skipped).
  */
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { syncData, getKV, setKV, log, keystore, crypto } from "@loreai/core";
+import {
+  syncData,
+  getKV,
+  setKV,
+  log,
+  keystore,
+  crypto,
+  reinstallSyncCapture,
+} from "@loreai/core";
 import { getAuthedClient, getCurrentUser } from "./supabase";
 
 const PAGE = 200;
@@ -405,9 +413,11 @@ async function pushEntry(
   }
 
   if (op === "delete") {
-    const tombstone: Record<string, unknown> = {
-      is_deleted: true,
-    };
+    // Append-only tables (temporal_messages) never enqueue a delete — reconcile skips
+    // them and they have no capture DELETE trigger — so this branch is unreachable for
+    // them; guard defensively anyway (their remote has no is_deleted column).
+    const tombstone: Record<string, unknown> = {};
+    if (!tableMeta(table).appendOnly) tombstone.is_deleted = true;
     // Only versioned tables have a content_hash column remotely; the join table
     // (knowledge_entity_refs) does not, so sending it is a PGRST204 schema error. This
     // gate prevents that; and even a stray schema error is now classified as poison
@@ -487,8 +497,12 @@ async function pushEntry(
   // columns like knowledge.promoted_at, which the remote rejects (PGRST204).
   const payload: Record<string, unknown> = {
     ...toRemoteRow(table, syncData.pickSyncColumns(table, row)),
-    is_deleted: false,
   };
+  // Every table carries is_deleted EXCEPT append-only ones (temporal_messages), whose
+  // remote 0020 schema has no such column — sending it is a PGRST204 that poisons the
+  // whole table (#826/D). versioned is the wrong gate (the join table is versioned:false
+  // yet HAS is_deleted).
+  if (!tableMeta(table).appendOnly) payload.is_deleted = false;
   // C-4 (#825): encrypt the content-bearing columns for the wire (server stores only
   // ciphertext). content_hash above is over the PLAINTEXT row, so it stays cross-device
   // stable. "locked" means escrow is present but the device isn't unlocked — we can't
@@ -1023,8 +1037,22 @@ export async function syncOnce(
   if (!client)
     return { pushed: 0, pulled: 0, conflicts: 0, skipped: 0, notAuthed: true };
 
+  // A profile pull can flip the plan tier (e.g. free→pro after a Stripe upgrade,
+  // or the very first pull on a fresh Pro device). Snapshot before/after so we can
+  // arm/disarm the Pro capture + seed the newly-synced tier (#826/D).
+  const tierBefore = syncData.currentSyncTier();
   const push = await pushOnce(client, onProgress);
   const pull = await pullOnce(client, onProgress);
+  const tierAfter = syncData.currentSyncTier();
+  if (tierAfter !== tierBefore) {
+    // Reconcile the change-capture trigger set to the new tier (installs the Pro
+    // distillation-fanout on upgrade; drops it on downgrade), then reconcile the
+    // outbox so the newly-synced tier's PRE-EXISTING rows (distillations created
+    // before the upgrade) are seeded — capture only sees writes from now on. They
+    // push on the next cycle. reconcile is idempotent for the already-synced tables.
+    reinstallSyncCapture();
+    syncData.reconcile(tierAfter);
+  }
   // Report AFTER the pull so pulled_through reflects the freshly-advanced cursors.
   await reportDeviceProgress(client);
   return {

--- a/packages/gateway/test/sync.test.ts
+++ b/packages/gateway/test/sync.test.ts
@@ -5,6 +5,7 @@ import {
   getKV,
   setKV,
   deleteTeamConfig,
+  reinstallSyncCapture,
 } from "@loreai/core";
 import { ltm, log, keystore, crypto, syncData } from "@loreai/core";
 
@@ -121,6 +122,42 @@ const REMOTE_COLUMNS: Record<string, Set<string>> = {
     "created_at",
     "updated_at",
     ...SYNC_COLS,
+  ]),
+  // D (#826) pro tables — faithful to supabase/migrations/0020.
+  distillations: new Set([
+    "id",
+    "project_id",
+    "session_id",
+    "narrative",
+    "facts",
+    "observations",
+    "source_ids",
+    "generation",
+    "token_count",
+    "r_compression",
+    "c_norm",
+    "call_type",
+    "worker_provider_id",
+    "worker_model_id",
+    "archived",
+    "created_at",
+    "updated_at",
+    ...SYNC_COLS, // versioned + has is_deleted
+  ]),
+  // 🔴 temporal_messages is APPEND-ONLY: 0020 has NO is_deleted / content_hash /
+  // revision column. Registering it faithfully means a leaked is_deleted → PGRST204.
+  temporal_messages: new Set([
+    "id",
+    "project_id",
+    "session_id",
+    "role",
+    "content",
+    "tokens",
+    "metadata",
+    "created_at",
+    "updated_at",
+    "scope_id",
+    "author_id",
   ]),
 };
 
@@ -357,6 +394,8 @@ beforeEach(() => {
   db().exec("DELETE FROM account_identity");
   db().exec("DELETE FROM account_escrow");
   db().exec("DELETE FROM scope_keys");
+  db().exec("DELETE FROM distillations");
+  db().exec("DELETE FROM temporal_messages");
   keystore.lock();
   db().exec("DELETE FROM sync_outbox");
   db().exec("DELETE FROM sync_state");
@@ -370,10 +409,15 @@ beforeEach(() => {
     "profiles",
     "account_escrow",
     "scope_keys",
+    "distillations",
+    "temporal_messages",
   ]) {
     setKV(`sync.push.${t}`, "0");
     setKV(`sync.pull.${t}`, "0|");
   }
+  // Reset change-capture to the free-tier baseline (drops any Pro fanout trigger a
+  // prior test installed) so tier-gated capture doesn't leak across tests (#826/D).
+  reinstallSyncCapture();
   remote.clear();
   quotaTables = new Set();
   __resetQuotaWarnedTables(); // module-level dedupe state persists across tests
@@ -433,6 +477,46 @@ describe("pushOnce — happy path", () => {
     expect(r.pushed).toBe(1);
     const row = tableRows("knowledge").find((x) => x.id === "k1");
     expect("promoted_at" in (row ?? {})).toBe(false);
+  });
+
+  test("Pro backup: pushes a distillation + its referenced temporal subset; temporal carries NO is_deleted", async () => {
+    // The strict mock is faithful to 0020: temporal_messages has NO is_deleted column,
+    // so a leaked is_deleted:false → PGRST204 → poison. This test fails without the
+    // appendOnly gate in pushEntry.
+    db()
+      .query(
+        "INSERT OR REPLACE INTO profiles (id, tier, created_at, updated_at) VALUES (?, 'pro', ?, ?)",
+      )
+      .run(mockUserId, now(), now());
+    reinstallSyncCapture(); // arm the tier-gated distillation-fanout trigger
+    syncData.enableSync(); // pro tier → basic ∪ pro
+    const pid = ensureProject("/tmp/lore-sync-engine");
+    const insTemporal = (id: string) =>
+      db()
+        .query(
+          "INSERT INTO temporal_messages (id, project_id, session_id, role, content, tokens, distilled, created_at, metadata) VALUES (?, ?, 's', 'user', 'hi', 1, 1, ?, '{}')",
+        )
+        .run(id, pid, now());
+    insTemporal("t1");
+    insTemporal("t2"); // unreferenced — must NEVER sync
+    db()
+      .query(
+        "INSERT INTO distillations (id, project_id, session_id, narrative, facts, observations, source_ids, generation, token_count, created_at, archived) VALUES ('d1', ?, 's', 'n', 'f', 'o', ?, 0, 0, ?, 0)",
+      )
+      .run(pid, JSON.stringify(["t1"]), now()); // fanout enqueues d1 + t1 only
+
+    const r = await pushOnce(makeClient() as never);
+
+    expect(r.conflicts).toBe(0); // nothing poisoned
+    const d = tableRows("distillations").find((x) => x.id === "d1");
+    expect(d).toBeTruthy();
+    expect("is_deleted" in (d ?? {})).toBe(true); // versioned → carries is_deleted
+    const t = tableRows("temporal_messages").find((x) => x.id === "t1");
+    expect(t).toBeTruthy();
+    expect("is_deleted" in (t ?? {})).toBe(false); // append-only → NO is_deleted
+    expect(
+      tableRows("temporal_messages").find((x) => x.id === "t2"),
+    ).toBeUndefined(); // undistilled never synced
   });
 
   test("prunes the outbox even when another synced table has no entries", async () => {


### PR DESCRIPTION
Wires the **client half** of pro-tier sync: the compressed conversation memory (distillations + the distillation-referenced subset of `temporal_messages`) now syncs for pro users. **Free users are entirely unaffected** (tier stays basic, pro tables untouched). Pro sync is pre-GA. The pull/restore side (residency exemption, encrypted round-trip) lands in D-4.

## Registry (`sync-data.ts`)
- `SyncTableMeta` gains **`captureStrategy`** (`"row"` | `"distillation-fanout"` | `"none"`).
- `SYNCED_TABLES.pro` registers **distillations** (fanout capture, encrypted narrative/facts/observations) and **temporal_messages** (append-only `versioned:false`, `captureStrategy "none"`, encrypted content/metadata).

## Capture (`db.ts`)
- `installSyncCapture` installs a **tier-gated distillation-fanout trigger**: on INSERT enqueue the distillation AND fan out one `temporal_messages` outbox row per id in `source_ids` (`json_each`) — 🔴 this referenced subset is the ONLY temporal that ever syncs; an **undistilled message is never enqueued**. On UPDATE re-enqueue the distillation (archived flip). Pro-only; the else-branch DROPs it on downgrade.
- **`reinstallSyncCapture()`** exported to reconcile the trigger set on a tier flip.
- (`json_each`-in-trigger validated against node:sqlite before building on it.)

## Seed / reconcile (`sync-data.ts`)
- `seedSelect`: `temporal_messages` restricted to the `json_each`-referenced subset; distillations recency-ordered.
- `reconcile` **SKIPS the delete-tombstone pass** for the append-only Pro tables — a local prune / project cleanup / eviction must never wipe the remote backup (remote lifecycle is the server reaper's job, epic #821).

## Prune (`temporal.ts`)
- the 3 delete passes run under `withSyncApplying` + clear the pruned rows' `sync_state` (sync-invisible eviction; keeps `sync_state` bounded; no tombstone).

## Gateway (`sync.ts`)
- `syncOnce` detects a plan-tier flip across the pull → reinstalls capture + reconciles, so a free→pro upgrade (or a fresh Pro device) arms capture and seeds pre-existing distillations.

## D-2 follow-ups folded in
- registry-contract battery + `assertSyncInvariants` now cover the **cumulative all-tier set** (+ a cross-tier dedup guard); invariant #3's known-set spans all tiers (a downgraded ex-pro's Pro `sync_state` is not "drift").

## Tests
+6 unit tests (fanout capture / tier-gating / archived flip / subset seed / no-tombstone reconcile / sync-invisible prune) + registry-contract now exercises the pro tables. **Full core+gateway suite green (5517 passed / 104 skipped, 0 fail)**; typecheck + lint clean.

Stack: D-1 (#1240) + D-2 (#1241) + D-3a (#1243) merged → **D-3b (this)** → D-4 (pull/restore residency + Tier-2 encrypted round-trip).