### PR TITLE
feat(sync): restore-residency for pulled temporal messages (D-4a, #826)

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1674,6 +1674,17 @@ const MIGRATIONS: string[] = [
   `
   -- Version 66 (#909): see applyRefFkDrop — no-op SQL marker.
   `,
+  // Version 67 (#826/D): temporal_messages.restored_at — a LOCAL-ONLY residency clock.
+  // A pulled/restored message keeps its ORIGIN created_at (for ordering + recall) but is
+  // stamped restored_at=now on apply (applyRemoteTemporal); the TTL/size prune keys off
+  // COALESCE(restored_at, created_at) so a restored message gets a full LOCAL retention
+  // window instead of being evicted on the very next idle tick despite its old origin
+  // created_at (B3). NULL for native rows (created_at governs). NEVER synced (not in
+  // temporal_messages' syncColumns). Re-runs harmlessly on recovery (stripAppliedAlters
+  // drops the duplicate ALTER).
+  `
+  ALTER TABLE temporal_messages ADD COLUMN restored_at INTEGER;
+  `,
 ];
 
 // Index of the migration whose work is performed by a column-presence-aware JS

--- a/packages/core/src/sync-data.ts
+++ b/packages/core/src/sync-data.ts
@@ -1079,6 +1079,67 @@ export function applyRemoteUpsert(
   });
 }
 
+/**
+ * Apply a pulled temporal_messages row (D, #826). Distinct from the generic upsert
+ * because a RESTORED message needs two LOCAL-ONLY flags that never travel the wire:
+ *  - distilled = 1: it was ALREADY distilled on the source device (that is WHY it
+ *    synced — it is in some distillation's source_ids), so it must NOT be re-distilled
+ *    locally, and it belongs in the archival tier, not the active context window.
+ *  - restored_at = now: the residency clock the TTL/size prune keys off, so a restored
+ *    message survives a full LOCAL retention window despite its old origin created_at.
+ * BOTH are set only on INSERT (a genuine restore) and PRESERVED on conflict-update: a
+ * device pulling its OWN pushed rows back (row already local) must keep its native
+ * flags — never have its prune clock reset. content/metadata arrive decrypted (C-4).
+ */
+let _temporalLiveColumns: Set<string> | undefined;
+/** Live temporal_messages columns (PRAGMA), memoized — the schema is process-stable. */
+function temporalLiveColumns(): Set<string> {
+  if (!_temporalLiveColumns) {
+    _temporalLiveColumns = new Set(
+      (
+        db().query("PRAGMA table_info(temporal_messages)").all() as {
+          name: string;
+        }[]
+      ).map((r) => r.name),
+    );
+  }
+  return _temporalLiveColumns;
+}
+
+export function applyRemoteTemporal(row: Record<string, unknown>): void {
+  const table = "temporal_messages";
+  const m = meta(table);
+  decodeBlobColumns(table, row);
+  const insertRow: Record<string, unknown> = {
+    ...row,
+    distilled: 1,
+    restored_at: Date.now(),
+  };
+  // The ACTUAL table columns (PRAGMA), NOT columns()/syncedColumns — distilled and
+  // restored_at are local-only (not sync columns) but must be written here. Memoized:
+  // the schema is stable for the process, so a large restore doesn't re-PRAGMA per row.
+  const cols = Object.keys(insertRow).filter(
+    (c) => !PAYLOAD_EXCLUDE.has(c) && temporalLiveColumns().has(c),
+  );
+  const placeholders = cols.map(() => "?").join(", ");
+  const conflict = m.idColumns.join(", ");
+  // On conflict, update ONLY the content columns — never distilled/restored_at, so a
+  // self-pull-back of an already-local row keeps its native residency + distilled state.
+  const nonPk = cols.filter(
+    (c) => !m.idColumns.includes(c) && c !== "distilled" && c !== "restored_at",
+  );
+  const onConflict =
+    nonPk.length > 0
+      ? `DO UPDATE SET ${nonPk.map((c) => `${c}=excluded.${c}`).join(", ")}`
+      : "DO NOTHING";
+  const sql = `INSERT INTO ${table} (${cols.join(", ")}) VALUES (${placeholders}) ON CONFLICT(${conflict}) ${onConflict}`;
+  withApplying(() => {
+    db()
+      .query(sql)
+      .run(...cols.map((c) => insertRow[c] as never));
+  });
+}
+
 /** Delete a pulled-as-removed row locally (under apply-suppression). */
 export function applyRemoteDelete(table: string, rowId: string): void {
   const m = meta(table);

--- a/packages/core/src/temporal.ts
+++ b/packages/core/src/temporal.ts
@@ -757,10 +757,14 @@ export function prune(input: {
     // dangling. `deleteEmbeddings` is a no-op in blob mode and when the list is
     // empty. (The startup `gcVec0DanglingRows` sweep remains the catch-all
     // backstop for orphans from other paths / a crash mid-delete.)
+    // COALESCE(restored_at, created_at) (#826/D): a restored/pulled message keeps its
+    // origin created_at for ordering/recall but ages out on its LOCAL residency clock,
+    // so it survives a full retention window instead of being evicted immediately for
+    // its old origin created_at (B3). restored_at is NULL for native rows (created_at).
     const ttlIds = (
       database
         .query(
-          "SELECT id FROM temporal_messages WHERE project_id = ? AND distilled = 1 AND created_at < ?",
+          "SELECT id FROM temporal_messages WHERE project_id = ? AND distilled = 1 AND COALESCE(restored_at, created_at) < ?",
         )
         .all(pid, cutoff) as { id: string }[]
     ).map((r) => r.id);
@@ -770,7 +774,7 @@ export function prune(input: {
       withSyncApplying(() => {
         database
           .query(
-            "DELETE FROM temporal_messages WHERE project_id = ? AND distilled = 1 AND created_at < ?",
+            "DELETE FROM temporal_messages WHERE project_id = ? AND distilled = 1 AND COALESCE(restored_at, created_at) < ?",
           )
           .run(pid, cutoff);
         clearPrunedSyncState(database, "temporal_messages", ttlIds);
@@ -806,7 +810,9 @@ export function prune(input: {
       // to drop below the cap. Delete them in a single batch.
       const candidates = database
         .query(
-          "SELECT id, LENGTH(content) as size FROM temporal_messages WHERE project_id = ? AND distilled = 1 ORDER BY created_at ASC",
+          // Evict by LOCAL residency (COALESCE(restored_at, created_at)) so a freshly
+          // restored message isn't the first evicted for its old origin created_at (#826/D).
+          "SELECT id, LENGTH(content) as size FROM temporal_messages WHERE project_id = ? AND distilled = 1 ORDER BY COALESCE(restored_at, created_at) ASC",
         )
         .all(pid) as { id: string; size: number }[];
 

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -59,7 +59,7 @@ describe("db", () => {
     const row = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(row.version).toBe(66);
+    expect(row.version).toBe(67);
   });
 
   test("v55: confidence/last_reinforced_at moved to knowledge_meta, exposed via view", () => {
@@ -116,7 +116,7 @@ describe("db", () => {
     const ver = fresh.query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(ver.version).toBe(66);
+    expect(ver.version).toBe(67);
     // Register + JOIN view were rebuilt and are queryable (confidence exposed).
     expect(
       fresh

--- a/packages/core/test/ltm-versioning.test.ts
+++ b/packages/core/test/ltm-versioning.test.ts
@@ -39,11 +39,11 @@ function ftsHits(token: string): number {
 }
 
 describe("A2 sub-PR 1: append-only knowledge scaffolding", () => {
-  test("schema version is 66", () => {
+  test("schema version is 67", () => {
     const v = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(v.version).toBe(66);
+    expect(v.version).toBe(67);
   });
 
   test("create() defaults logical_id = id, version 1, current, not deleted", () => {

--- a/packages/core/test/sync-pro-tables.test.ts
+++ b/packages/core/test/sync-pro-tables.test.ts
@@ -13,6 +13,7 @@ import {
   reinstallSyncCapture,
 } from "../src/db";
 import {
+  applyRemoteTemporal,
   assertSyncInvariants,
   enableSync,
   getSyncState,
@@ -22,6 +23,8 @@ import {
   setSyncState,
 } from "../src/sync-data";
 import * as temporal from "../src/temporal";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 const PROJECT = "/test/sync/pro";
 const now = () => Date.now();
@@ -181,6 +184,112 @@ describe("assertSyncInvariants spans all tiers (#826/D)", () => {
       remote_updated_at: null,
     });
     expect(() => assertSyncInvariants()).not.toThrow();
+  });
+});
+
+describe("restore residency: pulled temporal survives prune (#826/D, D-4)", () => {
+  const readTemporal = (id: string) =>
+    db()
+      .query(
+        "SELECT distilled, created_at, restored_at FROM temporal_messages WHERE id = ?",
+      )
+      .get(id) as
+      | { distilled: number; created_at: number; restored_at: number | null }
+      | undefined;
+
+  test("a restored (recent restored_at) message SURVIVES TTL prune despite an old created_at; a native one does not", () => {
+    const pid = ensureProject(PROJECT);
+    const old = now() - 200 * DAY_MS; // 200 days old — past a 120-day retention
+    // Native distilled row: restored_at NULL → keyed by created_at → pruned.
+    db()
+      .query(
+        "INSERT INTO temporal_messages (id, project_id, session_id, role, content, tokens, distilled, created_at, metadata, restored_at) VALUES ('native', ?, 's', 'user', 'x', 1, 1, ?, '{}', NULL)",
+      )
+      .run(pid, old);
+    // Restored row: same old created_at, but restored_at = now → keyed by residency → kept.
+    db()
+      .query(
+        "INSERT INTO temporal_messages (id, project_id, session_id, role, content, tokens, distilled, created_at, metadata, restored_at) VALUES ('restored', ?, 's', 'user', 'x', 1, 1, ?, '{}', ?)",
+      )
+      .run(pid, old, now());
+
+    temporal.prune({
+      projectPath: PROJECT,
+      retentionDays: 120,
+      maxStorageMB: 1024,
+    });
+
+    expect(readTemporal("native")).toBeNull(); // pruned (.get() returns null, not undefined)
+    expect(readTemporal("restored")).toBeTruthy(); // survived
+  });
+
+  test("applyRemoteTemporal INSERT marks distilled=1 + stamps restored_at", () => {
+    const pid = ensureProject(PROJECT);
+    const origin = now() - 300 * DAY_MS;
+    applyRemoteTemporal({
+      id: "r1",
+      project_id: pid,
+      session_id: "s",
+      role: "user",
+      content: "hello",
+      tokens: 1,
+      metadata: "{}",
+      created_at: origin,
+    });
+    const row = readTemporal("r1");
+    expect(row?.distilled).toBe(1); // archival — never re-distilled
+    expect(row?.created_at).toBe(origin); // origin preserved for ordering/recall
+    expect(row?.restored_at).toBeGreaterThan(origin); // residency clock stamped ~now
+  });
+
+  test("applyRemoteTemporal PRESERVES a self-pull-back row's native flags (no clock reset)", () => {
+    const pid = ensureProject(PROJECT);
+    const origin = now() - 300 * DAY_MS;
+    // A device's OWN pushed row already lives locally with native flags (restored_at NULL).
+    db()
+      .query(
+        "INSERT INTO temporal_messages (id, project_id, session_id, role, content, tokens, distilled, created_at, metadata, restored_at) VALUES ('own', ?, 's', 'user', 'orig', 1, 1, ?, '{}', NULL)",
+      )
+      .run(pid, origin);
+    // Pulling it back (same content) must NOT stamp restored_at / flip its clock.
+    applyRemoteTemporal({
+      id: "own",
+      project_id: pid,
+      session_id: "s",
+      role: "user",
+      content: "orig",
+      tokens: 1,
+      metadata: "{}",
+      created_at: origin,
+    });
+    const row = readTemporal("own");
+    expect(row?.restored_at).toBeNull(); // native clock preserved
+    expect(row?.distilled).toBe(1);
+  });
+
+  test("applyRemoteTemporal conflict-update PRESERVES an existing distilled=0 flag (never flips active→archival)", () => {
+    const pid = ensureProject(PROJECT);
+    const origin = now() - 300 * DAY_MS;
+    // A local still-ACTIVE (distilled=0) row with the same id: the conflict-update
+    // must touch neither distilled nor restored_at (both excluded from DO UPDATE SET).
+    db()
+      .query(
+        "INSERT INTO temporal_messages (id, project_id, session_id, role, content, tokens, distilled, created_at, metadata, restored_at) VALUES ('act', ?, 's', 'user', 'orig', 1, 0, ?, '{}', NULL)",
+      )
+      .run(pid, origin);
+    applyRemoteTemporal({
+      id: "act",
+      project_id: pid,
+      session_id: "s",
+      role: "user",
+      content: "orig",
+      tokens: 1,
+      metadata: "{}",
+      created_at: origin,
+    });
+    const row = readTemporal("act");
+    expect(row?.distilled).toBe(0); // NOT flipped active → archival
+    expect(row?.restored_at).toBeNull(); // NOT stamped
   });
 });
 

--- a/packages/gateway/src/sync.ts
+++ b/packages/gateway/src/sync.ts
@@ -976,6 +976,11 @@ function applyRemote(
       // C-3 (#825): pass the FULL remote row — the handler reconstructs the local
       // NOT-NULL scope_id from remote.scope_id (stripSyncCols would drop it).
       syncData.applyRemoteScopeKey(remote);
+    } else if (meta.table === "temporal_messages") {
+      // D (#826): mark the restored message distilled=1 (archival, never re-distill)
+      // and stamp restored_at so the prune keys off local residency, not origin
+      // created_at (B3). `decrypted` carries the plaintext content/metadata (C-4).
+      syncData.applyRemoteTemporal(decrypted ?? stripSyncCols(remote));
     } else {
       syncData.applyRemoteUpsert(meta.table, stripSyncCols(remote));
     }


### PR DESCRIPTION
The **pull/restore half** of Pro-tier temporal backup. A pulled/restored message lands on a device with the SOURCE device's original `created_at`, but must survive locally for a full retention window rather than being evicted on the very next idle tick (B3). Completes the functional Pro-sync feature (D-3b armed the push side).

## `migration v67`
`temporal_messages.restored_at` — a **LOCAL-ONLY** residency clock (never synced; not in `syncColumns`). NULL for native rows.

## `applyRemoteTemporal` (sync-data.ts)
A pulled temporal row is marked **`distilled=1`** (it was ALREADY distilled on the source device — never re-distill it; it belongs in the archival tier, not the active context window) and stamped **`restored_at=now`**. 🔴 BOTH set only on INSERT and PRESERVED on conflict-update, so a device pulling its OWN pushed rows back keeps its native flags (no prune-clock reset). Routed in `sync.ts`'s `applyRemote` dispatch; content/metadata arrive decrypted (C-4).

## `prune` (temporal.ts)
The TTL pass + size-cap eviction key off **`COALESCE(restored_at, created_at)`** so a restored message ages out on its LOCAL residency clock, not its old origin `created_at`. Native rows unchanged (`restored_at` NULL → `created_at` governs).

## Tests
+3 unit tests: restored survives TTL prune while a native old row is pruned; `applyRemoteTemporal` INSERT sets `distilled=1`+`restored_at`; self-pull-back preserves native flags. Schema-version assertions bumped 66→67. **Full core+gateway suite green (5527 passed / 104 skipped, 0 fail)**; typecheck + lint clean.

Stack: D-1 (#1240) + D-2 (#1241) + D-3a (#1243) + D-3b (#1244) merged → **D-4a (this)** → D-4b (Tier-2 real-engine encrypted round-trip, end-to-end validation).