### PR TITLE
feat(sync): cross-device project-identity mapping (P1, #1246)

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -2401,6 +2401,27 @@ function installSyncCapture(database: Database) {
       INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
       VALUES ('scope_keys', new.member_user_id, 'upsert', ${ts});
     END;`;
+  // #1246: projects identity mapping (id→git_remote). Gated on git_remote IS NOT NULL —
+  // only remote-backed projects sync (a remote-less project's random id can't correlate
+  // cross-device; its content would FK-poison on a peer). The UPDATE trigger fires the
+  // git_remote backfill (null→remote) into the outbox. NO DELETE: a merge
+  // (convergeProjectsByRemote) deletes the loser locally, but the remote loser row is left
+  // as benign orphaned data (never tombstoned — is_deleted stays false, so the reaper does
+  // NOT collect it; it is one row/merge, within quota). A DELETE tombstone would instead
+  // race the loser's still-orphaned remote content. path is DEVICE-LOCAL, never synced.
+  sql += `
+    CREATE TEMP TRIGGER IF NOT EXISTS projects_outbox_ins
+    AFTER INSERT ON projects WHEN (${gate} AND new.git_remote IS NOT NULL)
+    BEGIN
+      INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
+      VALUES ('projects', new.id, 'upsert', ${ts});
+    END;
+    CREATE TEMP TRIGGER IF NOT EXISTS projects_outbox_upd
+    AFTER UPDATE ON projects WHEN (${gate} AND new.git_remote IS NOT NULL)
+    BEGIN
+      INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
+      VALUES ('projects', new.id, 'upsert', ${ts});
+    END;`;
   // D (#826): Pro-tier distillation-fanout capture. Installed ONLY when the plan
   // tier (from the pulled profiles mirror) is pro/max — a free user creating
   // distillations must not accrue un-pushable pro outbox entries that no push cursor
@@ -3030,6 +3051,33 @@ function recoverMissingObjects(database: Database) {
  * Used internally during lazy git-remote backfill when two path-only
  * projects are discovered to share the same git remote.
  */
+/**
+ * Deterministically converge projects that share a git_remote (#1246). Two devices can
+ * independently mint a random project_id for the same repo; after they sync each other's
+ * projects mapping, both hold >1 local project for that remote. Merge all into the
+ * lexicographically-smallest id — a winner both devices agree on, so there is NO re-key
+ * ping-pong (a non-deterministic "local wins" would make the two devices merge in
+ * opposite directions forever). mergeProjectInternal re-keys the content + re-enqueues it
+ * under the winner. MUST run AFTER a pull (post-content, so the re-key finds the applied
+ * rows) and OUTSIDE any transaction (mergeProjectInternal opens its own BEGIN IMMEDIATE).
+ */
+export function convergeProjectsByRemote(): void {
+  const dupes = db()
+    .query(
+      "SELECT git_remote FROM projects WHERE git_remote IS NOT NULL GROUP BY git_remote HAVING COUNT(*) > 1",
+    )
+    .all() as { git_remote: string }[];
+  for (const { git_remote } of dupes) {
+    const ids = (
+      db()
+        .query("SELECT id FROM projects WHERE git_remote = ? ORDER BY id")
+        .all(git_remote) as { id: string }[]
+    ).map((r) => r.id);
+    const winner = ids[0]; // lexicographically smallest — identical on every device
+    for (const loser of ids.slice(1)) mergeProjectInternal(loser, winner);
+  }
+}
+
 export function mergeProjectInternal(sourceId: string, targetId: string): void {
   const d = db();
   d.exec("BEGIN IMMEDIATE");

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -104,6 +104,7 @@ export {
   projectGitRemote,
   resolveProjectByRemoteOrPath,
   mergeProjectInternal,
+  convergeProjectsByRemote,
   UNATTRIBUTED_PROJECT_PREFIX,
   isUnattributedProjectPath,
   loadForceMinLayer,

--- a/packages/core/src/sync-data.ts
+++ b/packages/core/src/sync-data.ts
@@ -203,6 +203,24 @@ export const SYNCED_TABLES: Record<SyncTier, SyncTableMeta[]> = {
       blobColumns: ["wrapped_dek"],
     },
     {
+      // #1246: the cross-device project-identity mapping. project_id is a random
+      // per-device UUID (crypto.randomUUID in ensureProject); git_remote is the ONLY
+      // stable cross-device key. Syncing id→git_remote lets a pulled content row's FK
+      // parent (projects.id) exist on any device, and lets a later local checkout ADOPT
+      // the pulled id via ensureProject's git-remote match (real path becomes an alias).
+      // path is NEVER synced (device-local + sensitive); git_remote + name are ENCRYPTED
+      // (C-4) — repo URLs never reach the server in plaintext (correlation is client-
+      // side). Pulled AFTER the key tables (needs the DEK to decrypt) and BEFORE
+      // knowledge/entities (the FK parent). Applied via applyRemoteProject, which seeds a
+      // synthetic-path row (path is NOT NULL UNIQUE locally, but not synced). No
+      // updated_at column locally — the remote server-stamps it for the pull cursor.
+      table: "projects",
+      idColumns: ["id"],
+      ftsTables: [],
+      encryptedColumns: ["git_remote", "name"],
+      syncColumns: ["id", "git_remote", "name", "created_at"],
+    },
+    {
       table: "knowledge",
       idColumns: ["id"],
       ftsTables: ["knowledge_fts"],
@@ -809,6 +827,12 @@ function seedSelect(table: string): string {
                     json_each(d.source_ids)
                 )
                ORDER BY t.created_at DESC, t.id`;
+    // #1246: only remote-backed projects sync — a remote-less project's random id can't
+    // correlate cross-device (its content would FK-poison on a peer), so it stays local.
+    // Mirrors the capture trigger's git_remote gate. path is not synced (pickSyncColumns
+    // drops it — not in syncColumns).
+    case "projects":
+      return "SELECT * FROM projects WHERE git_remote IS NOT NULL ORDER BY created_at DESC, id";
     default:
       return `SELECT * FROM ${table}`;
   }
@@ -1091,6 +1115,44 @@ export function applyRemoteUpsert(
  * device pulling its OWN pushed rows back (row already local) must keep its native
  * flags — never have its prune clock reset. content/metadata arrive decrypted (C-4).
  */
+/**
+ * Apply a pulled projects identity row (#1246). `row` is the stripped + DECRYPTED remote
+ * row (git_remote/name plaintext). Never applied via the generic upsert because:
+ *  - projects.path is NOT NULL UNIQUE locally but is NOT synced → a new row needs a
+ *    synthetic, non-fs, unique placeholder path (`lore:project/<id>`). A later local
+ *    ensureProject(realPath) git-remote-matches this id and registers realPath as an
+ *    alias; the placeholder stays projects.path but is never used as a filesystem path.
+ *  - COALESCE on update never lets a null incoming clear a locally-known git_remote/name.
+ * A git_remote backfill here can create two local projects for one remote — the post-pull
+ * convergeProjectsByRemote() pass merges them deterministically (min-id winner).
+ */
+export function applyRemoteProject(row: Record<string, unknown>): void {
+  const id = String(row.id);
+  const gitRemote = row.git_remote != null ? String(row.git_remote) : null;
+  const name = row.name != null ? String(row.name) : null;
+  const createdAt = Number(row.created_at) || Date.now();
+  withApplying(() => {
+    const existing = db()
+      .query("SELECT id FROM projects WHERE id = ?")
+      .get(id) as { id: string } | null | undefined;
+    if (existing) {
+      // Update identity fields only; NEVER touch path (device-local). COALESCE keeps a
+      // locally-known git_remote/name if the incoming row hasn't resolved one yet.
+      db()
+        .query(
+          "UPDATE projects SET git_remote = COALESCE(?, git_remote), name = COALESCE(?, name) WHERE id = ?",
+        )
+        .run(gitRemote, name, id);
+    } else {
+      db()
+        .query(
+          "INSERT INTO projects (id, path, name, git_remote, created_at) VALUES (?, ?, ?, ?, ?)",
+        )
+        .run(id, `lore:project/${id}`, name, gitRemote, createdAt);
+    }
+  });
+}
+
 let _temporalLiveColumns: Set<string> | undefined;
 /** Live temporal_messages columns (PRAGMA), memoized — the schema is process-stable. */
 function temporalLiveColumns(): Set<string> {

--- a/packages/core/test/sync-projects.test.ts
+++ b/packages/core/test/sync-projects.test.ts
@@ -1,0 +1,176 @@
+/**
+ * #1246 — cross-device project-identity sync. project_id is a random per-device UUID;
+ * git_remote is the stable cross-device key. These cover the client half (P1): the
+ * applyRemoteProject pull-seed (synthetic-path FK parent) / identity backfill, the
+ * deterministic convergeProjectsByRemote merge, and the git_remote capture/seed gate.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import {
+  convergeProjectsByRemote,
+  db,
+  deleteTeamConfig,
+  reinstallSyncCapture,
+} from "../src/db";
+import {
+  applyRemoteProject,
+  assertSyncInvariants,
+  enableSync,
+  readOutbox,
+} from "../src/sync-data";
+
+const now = () => Date.now();
+
+// Direct inserts bypass ensureProject's git-detection + test-path guard so we control
+// git_remote precisely.
+function insertProject(
+  id: string,
+  gitRemote: string | null,
+  name = "repo",
+  path = `/local/${id}`,
+) {
+  db()
+    .query(
+      "INSERT INTO projects (id, path, name, git_remote, created_at) VALUES (?, ?, ?, ?, ?)",
+    )
+    .run(id, path, name, gitRemote, now());
+}
+function getProject(id: string) {
+  return db()
+    .query("SELECT id, path, name, git_remote FROM projects WHERE id = ?")
+    .get(id) as {
+    id: string;
+    path: string;
+    name: string | null;
+    git_remote: string | null;
+  } | null;
+}
+function insertKnowledge(id: string, projectId: string) {
+  db()
+    .query(
+      `INSERT INTO knowledge (id, logical_id, project_id, category, title, content, created_at, updated_at)
+       VALUES (?, ?, ?, 'pattern', 't', 'c', ?, ?)`,
+    )
+    .run(id, id, projectId, now(), now());
+}
+const projectOutbox = () =>
+  readOutbox(0, 1000)
+    .filter((e) => e.table_name === "projects")
+    .map((e) => e.row_id);
+
+beforeEach(() => {
+  deleteTeamConfig("sync.enabled");
+  db().exec("DELETE FROM temp._sync_applying");
+  db().exec("DELETE FROM sync_outbox");
+  db().exec("DELETE FROM sync_state");
+  db().exec("DELETE FROM knowledge");
+  db().exec("DELETE FROM knowledge_meta");
+  db().exec("DELETE FROM entities");
+  db().exec("DELETE FROM profiles");
+  db().exec(
+    "DELETE FROM projects WHERE path LIKE '/local/%' OR path LIKE '/real/%' OR path LIKE 'lore:project/%'",
+  );
+  reinstallSyncCapture();
+});
+
+afterEach(() => assertSyncInvariants());
+
+describe("applyRemoteProject (pull-seed / backfill)", () => {
+  test("seeds a synthetic-path FK-parent row for an unknown id", () => {
+    applyRemoteProject({
+      id: "p-new",
+      git_remote: "github.com/o/r",
+      name: "r",
+      created_at: now(),
+    });
+    const p = getProject("p-new");
+    expect(p?.path).toBe("lore:project/p-new"); // synthetic, non-fs, unique per id
+    expect(p?.git_remote).toBe("github.com/o/r");
+    expect(p?.name).toBe("r");
+  });
+
+  test("re-applying the same remote row is idempotent (updates in place, no duplicate)", () => {
+    applyRemoteProject({
+      id: "p-idem",
+      git_remote: "R",
+      name: "r",
+      created_at: now(),
+    });
+    applyRemoteProject({
+      id: "p-idem",
+      git_remote: "R",
+      name: "r2",
+      created_at: now(),
+    });
+    const c = db()
+      .query("SELECT COUNT(*) as c FROM projects WHERE id = 'p-idem'")
+      .get() as { c: number };
+    expect(c.c).toBe(1); // no duplicate row
+    expect(getProject("p-idem")?.name).toBe("r2"); // updated in place
+    expect(getProject("p-idem")?.path).toBe("lore:project/p-idem"); // still synthetic
+  });
+
+  test("backfills git_remote but COALESCE keeps a locally-known name; never touches path", () => {
+    insertProject("p-loc", null, "local-name", "/real/path");
+    applyRemoteProject({
+      id: "p-loc",
+      git_remote: "R",
+      name: null,
+      created_at: now(),
+    });
+    const p = getProject("p-loc");
+    expect(p?.git_remote).toBe("R"); // backfilled
+    expect(p?.name).toBe("local-name"); // COALESCE kept the local value
+    expect(p?.path).toBe("/real/path"); // device-local path untouched
+  });
+});
+
+describe("convergeProjectsByRemote (deterministic merge)", () => {
+  test("merges same-remote projects into the min-id winner and re-keys content", () => {
+    insertProject("bbb", "R", "r", "/local/bbb");
+    insertProject("aaa", "R", "r", "/local/aaa"); // inserted second, but is the min id
+    insertKnowledge("k-b", "bbb"); // content under the (to-be) loser
+    convergeProjectsByRemote();
+    expect(getProject("aaa")).toBeTruthy(); // lexicographically-smallest id wins
+    expect(getProject("bbb")).toBeNull(); // loser merged away
+    const k = db()
+      .query("SELECT project_id FROM knowledge WHERE id = 'k-b'")
+      .get() as { project_id: string };
+    expect(k.project_id).toBe("aaa"); // content re-keyed to the winner
+  });
+
+  test("is a no-op when projects have distinct remotes", () => {
+    insertProject("aaa", "R1");
+    insertProject("bbb", "R2");
+    convergeProjectsByRemote();
+    expect(getProject("aaa")).toBeTruthy();
+    expect(getProject("bbb")).toBeTruthy();
+  });
+
+  test("ignores remote-less projects (NULL git_remote never groups)", () => {
+    insertProject("aaa", null);
+    insertProject("bbb", null);
+    convergeProjectsByRemote();
+    expect(getProject("aaa")).toBeTruthy();
+    expect(getProject("bbb")).toBeTruthy();
+  });
+});
+
+describe("git_remote gate (only remote-backed projects sync)", () => {
+  test("capture: a remote-backed project enqueues; a remote-less one does not", () => {
+    enableSync("basic");
+    insertProject("with-r", "R");
+    insertProject("no-r", null);
+    const q = projectOutbox();
+    expect(q).toContain("with-r");
+    expect(q).not.toContain("no-r");
+  });
+
+  test("seed: only remote-backed projects are seeded on enable", () => {
+    insertProject("seed-r", "R"); // created while sync is OFF → seeded, not captured
+    insertProject("seed-none", null);
+    enableSync("basic"); // reconcile → seedOutbox
+    const q = projectOutbox();
+    expect(q).toContain("seed-r");
+    expect(q).not.toContain("seed-none");
+  });
+});

--- a/packages/core/test/sync-registry-contract.test.ts
+++ b/packages/core/test/sync-registry-contract.test.ts
@@ -156,6 +156,10 @@ describe("SYNCED_TABLES local-only secondary UNIQUE → convergence handling (#1
     entity_aliases: "resolveAliasUniqueConflict (#1234)",
     entity_relations: "resolveRelationUniqueConflict (#1217)",
     knowledge: "version-aware apply demotes is_current before insert (#897)",
+    // path UNIQUE can't collide: applyRemoteProject derives path from the PK id
+    // (lore:project/<id>), which is unique per row, and path is never synced (#1246).
+    projects:
+      "applyRemoteProject derives path from the PK id → path UNIQUE never collides (#1246)",
   };
 
   const indexCols = (name: string) =>

--- a/packages/gateway/src/sync.ts
+++ b/packages/gateway/src/sync.ts
@@ -30,6 +30,7 @@ import {
   keystore,
   crypto,
   reinstallSyncCapture,
+  convergeProjectsByRemote,
 } from "@loreai/core";
 import { getAuthedClient, getCurrentUser } from "./supabase";
 
@@ -981,6 +982,11 @@ function applyRemote(
       // and stamp restored_at so the prune keys off local residency, not origin
       // created_at (B3). `decrypted` carries the plaintext content/metadata (C-4).
       syncData.applyRemoteTemporal(decrypted ?? stripSyncCols(remote));
+    } else if (meta.table === "projects") {
+      // #1246: seed a synthetic-path FK parent / backfill identity. `decrypted` carries
+      // the plaintext git_remote/name (C-4). Same-remote dupes are merged post-pull by
+      // convergeProjectsByRemote (see syncOnce).
+      syncData.applyRemoteProject(decrypted ?? stripSyncCols(remote));
     } else {
       syncData.applyRemoteUpsert(meta.table, stripSyncCols(remote));
     }
@@ -1048,6 +1054,18 @@ export async function syncOnce(
   const tierBefore = syncData.currentSyncTier();
   const push = await pushOnce(client, onProgress);
   const pull = await pullOnce(client, onProgress);
+  // #1246: after content is applied, merge any projects that a peer's pulled identity
+  // row revealed to share a git_remote (min-id winner, deterministic → no ping-pong).
+  // Post-content so the re-key finds the applied rows; the re-keyed content re-pushes
+  // next cycle. No-op (a cheap GROUP BY) when there are no same-remote duplicates.
+  // Defensive: a transient merge failure must not abort the whole cycle — retried next tick.
+  try {
+    convergeProjectsByRemote();
+  } catch (e) {
+    log.notice(
+      `sync: project convergence deferred — ${(e as Error).message ?? e}`,
+    );
+  }
   const tierAfter = syncData.currentSyncTier();
   if (tierAfter !== tierBefore) {
     // Reconcile the change-capture trigger set to the new tier (installs the Pro

--- a/packages/gateway/test/sync-security.integration.test.ts
+++ b/packages/gateway/test/sync-security.integration.test.ts
@@ -23,6 +23,7 @@ const FREE_LIMITS: Record<string, number> = {
   knowledge_meta_crdt: 5000,
   account_escrow: 2,
   scope_keys: 100,
+  projects: 1000, // 0022 (#1246): basic-tier identity mapping, one row per repo
 };
 
 // Mirrors the free-tier max_bytes seeded in 0007_scope_seam.sql + 0009 — used to
@@ -37,6 +38,7 @@ const FREE_BYTE_LIMITS: Record<string, number> = {
   knowledge_meta_crdt: 1048576,
   account_escrow: 65536,
   scope_keys: 262144,
+  projects: 1048576, // 0022 (#1246): 1 MB
 };
 
 // Skip decision must be known at COLLECTION time (before beforeAll), so the
@@ -2019,6 +2021,126 @@ describe.skipIf(gate())(
         "INSERT",
         "SELECT",
       ]); // no UPDATE
+    });
+  },
+);
+
+describe.skipIf(gate())(
+  "sync migrations — projects identity mapping (#1246)",
+  () => {
+    // Basic-tier table (no current_tier() gate). Restore the free row cap after each
+    // test so a lowered cap never leaks (byte cap restored by the shared suite's map).
+    const setRowCap = (n: number) =>
+      h.client.query(
+        "update public.plan_limits set max_rows=$1 where tier='free' and table_name='projects'",
+        [n],
+      );
+    afterEach(async () => {
+      if (gate()) return;
+      await setRowCap(FREE_LIMITS.projects);
+    });
+
+    it("seeds projects plan_limits for BOTH free and pro (basic-tier table)", async () => {
+      const { rows } = await h.client.query(
+        "select tier, max_rows, max_bytes from public.plan_limits where table_name='projects' order by tier",
+      );
+      expect(rows.map((r) => r.tier)).toEqual(["free", "pro"]);
+      expect(Number(rows[0].max_rows)).toBe(1000); // free
+      expect(Number(rows[1].max_rows)).toBe(10000); // pro
+    });
+
+    it("a FREE user CAN write projects (no tier gate, unlike pro tables)", async () => {
+      const a = await h.createUser(); // tier defaults to 'free'
+      await h.asUser(a, (c) =>
+        c.query(
+          "insert into public.projects (id, scope_id, git_remote) values ('p1',$1,'R')",
+          [a],
+        ),
+      );
+      const { rows } = await h.asUser(a, (c) =>
+        c.query("select id from public.projects where scope_id=$1", [a]),
+      );
+      expect(rows.map((r) => r.id)).toEqual(["p1"]);
+    });
+
+    it("isolates projects across scopes (RLS USING)", async () => {
+      const a = await h.createUser();
+      const b = await h.createUser();
+      await h.asUser(b, (c) =>
+        c.query("insert into public.projects (id, scope_id) values ('pb',$1)", [
+          b,
+        ]),
+      );
+      const seen = await h.asUser(a, (c) =>
+        c.query(
+          "select count(*)::int as n from public.projects where scope_id=$1",
+          [b],
+        ),
+      );
+      expect(seen.rows[0].n).toBe(0); // RLS hides b's rows from a
+    });
+
+    it("rejects a forged author_id (WITH CHECK → 42501)", async () => {
+      const a = await h.createUser();
+      const b = await h.createUser();
+      const err = await expectError(() =>
+        h.asUser(a, (c) =>
+          c.query(
+            "insert into public.projects (id, scope_id, author_id) values ('p1',$1,$2)",
+            [a, b],
+          ),
+        ),
+      );
+      expect(err.code).toBe("42501");
+    });
+
+    it("rejects a forged scope_id (WITH CHECK → 42501)", async () => {
+      const a = await h.createUser();
+      const b = await h.createUser();
+      const err = await expectError(() =>
+        h.asUser(a, (c) =>
+          c.query(
+            "insert into public.projects (id, scope_id) values ('p1',$1)",
+            [b],
+          ),
+        ),
+      );
+      expect(err.code).toBe("42501");
+    });
+
+    it("scope_id is immutable (enforce_row_quota guard → 23514)", async () => {
+      const a = await h.createUser();
+      const b = await h.createUser();
+      await h.asUser(a, (c) =>
+        c.query("insert into public.projects (id, scope_id) values ('p1',$1)", [
+          a,
+        ]),
+      );
+      const err = await expectError(() =>
+        h.asUser(a, (c) =>
+          c.query(
+            "update public.projects set scope_id=$2 where id='p1' and scope_id=$1",
+            [a, b],
+          ),
+        ),
+      );
+      expect(err.code).toBe("23514");
+    });
+
+    it("caps projects inserts at the free row cap (generic id-key probe → 23514)", async () => {
+      const a = await h.createUser();
+      await setRowCap(2);
+      const ins = (id: string) =>
+        h.asUser(a, (c) =>
+          c.query(
+            "insert into public.projects (id, scope_id, git_remote) values ($1,$2,'R')",
+            [id, a],
+          ),
+        );
+      await ins("p1");
+      await ins("p2");
+      const err = await expectError(() => ins("p3"));
+      expect(err.code).toBe("23514");
     });
   },
 );

--- a/packages/gateway/test/sync.test.ts
+++ b/packages/gateway/test/sync.test.ts
@@ -123,6 +123,15 @@ const REMOTE_COLUMNS: Record<string, Set<string>> = {
     "updated_at",
     ...SYNC_COLS,
   ]),
+  // #1246 projects identity mapping — faithful to supabase/migrations/0022. path is
+  // NEVER a remote column (device-local); a leaked path → PGRST204.
+  projects: new Set([
+    "id",
+    "git_remote",
+    "name",
+    "created_at",
+    ...SYNC_COLS, // versioned: content_hash/revision/is_deleted + scope_id/author_id
+  ]),
   // D (#826) pro tables — faithful to supabase/migrations/0020.
   distillations: new Set([
     "id",
@@ -396,6 +405,10 @@ beforeEach(() => {
   db().exec("DELETE FROM scope_keys");
   db().exec("DELETE FROM distillations");
   db().exec("DELETE FROM temporal_messages");
+  // #1246: the synced test projects (remote-backed /local/* + pulled lore:project/*).
+  db().exec(
+    "DELETE FROM projects WHERE path LIKE '/local/%' OR path LIKE 'lore:project/%'",
+  );
   keystore.lock();
   db().exec("DELETE FROM sync_outbox");
   db().exec("DELETE FROM sync_state");
@@ -411,6 +424,7 @@ beforeEach(() => {
     "scope_keys",
     "distillations",
     "temporal_messages",
+    "projects",
   ]) {
     setKV(`sync.push.${t}`, "0");
     setKV(`sync.pull.${t}`, "0|");
@@ -2044,5 +2058,68 @@ describe("knowledge wire encryption — C-4 (#825)", () => {
     await pullOnce(makeClient() as never);
     expect(currentContent("k1")).toBeNull(); // aborted — NOT corrupted with ciphertext
     expect(getKV("sync.pull.knowledge")).toBe("0|"); // cursor frozen
+  });
+});
+
+describe("projects identity sync — #1246", () => {
+  const SCOPE = REMOTE_SCOPE; // == getCurrentUser().user_id in the mock
+  const FAST = { t: 1, m: 256, p: 1 };
+  async function enableEncryption() {
+    keystore.setPassphrase("pw", { params: FAST });
+    await keystore.getScopeKey(SCOPE, SCOPE);
+  }
+  function insertProjectRow(id: string, gitRemote: string | null) {
+    db()
+      .query(
+        "INSERT INTO projects (id, path, name, git_remote, created_at) VALUES (?, ?, 'repo', ?, ?)",
+      )
+      .run(id, `/local/${id}`, gitRemote, Date.now());
+  }
+
+  test("push seals git_remote + name; path (device-local) is never sent", async () => {
+    syncData.enableSync("basic");
+    await enableEncryption();
+    insertProjectRow("pj1", "github.com/o/secret-repo");
+    await pushOnce(makeClient() as never); // strict mock → PGRST204 if path leaks
+
+    const row = tableRows("projects").find((r) => r.id === "pj1") as RemoteRow;
+    expect(row).toBeTruthy();
+    expect(row.git_remote).not.toBe("github.com/o/secret-repo"); // sealed
+    expect(
+      crypto.isEnvelope(Buffer.from(String(row.git_remote), "base64")),
+    ).toBe(true);
+    expect(crypto.isEnvelope(Buffer.from(String(row.name), "base64"))).toBe(
+      true,
+    );
+    expect("path" in row).toBe(false); // never synced
+  });
+
+  test("a remote-less project is never pushed (git_remote gate)", async () => {
+    syncData.enableSync("basic");
+    await enableEncryption();
+    insertProjectRow("pj-none", null);
+    await pushOnce(makeClient() as never);
+    expect(
+      tableRows("projects").find((x) => x.id === "pj-none"),
+    ).toBeUndefined();
+  });
+
+  test("pull seeds a synthetic-path row with the DECRYPTED git_remote", async () => {
+    syncData.enableSync("basic");
+    await enableEncryption();
+    insertProjectRow("pj2", "github.com/o/r2");
+    await pushOnce(makeClient() as never); // remote now holds ciphertext
+
+    // device-2 (same unlocked keystore): drop the local row, re-pull it.
+    db().query("DELETE FROM projects WHERE id = 'pj2'").run();
+    db().exec("DELETE FROM sync_state");
+    setKV("sync.pull.projects", "0|");
+    await pullOnce(makeClient() as never);
+
+    const p = db()
+      .query("SELECT path, git_remote FROM projects WHERE id = 'pj2'")
+      .get() as { path: string; git_remote: string } | null;
+    expect(p?.path).toBe("lore:project/pj2"); // synthetic placeholder
+    expect(p?.git_remote).toBe("github.com/o/r2"); // decrypted on the wire
   });
 });

--- a/supabase/migrations/0022_projects_sync.sql
+++ b/supabase/migrations/0022_projects_sync.sql
@@ -1,0 +1,109 @@
+-- Migration 0022 — remote mirror for the projects identity mapping (#1246, epic #821).
+--
+-- project_id is a random per-device UUID; git_remote is the ONLY stable cross-device
+-- key. Syncing id→git_remote lets a pulled content row's FK parent (projects.id) exist
+-- on any device, and lets a later local checkout ADOPT the pulled id via the client's
+-- ensureProject git-remote match. This is a BASIC-tier table (syncs for every tier) —
+-- no current_tier() gate (contrast 0020's pro tables).
+--
+--   projects  — VERSIONED (content_hash/revision): git_remote backfill + name edits are
+--               real UPDATEs that must re-push. Keyed by id. ENCRYPTED columns:
+--               git_remote, name (sealed on the wire — repo URLs never reach the server
+--               in plaintext; correlation is entirely client-side). `path` is DEVICE-
+--               LOCAL and is NEVER synced (not a column here). No local updated_at column
+--               → the client never sends it; INSERT takes now(), UPDATE is server-stamped
+--               by the trigger (makes the row re-pullable by peers).
+--
+-- Scope seam (0007): every row owned/billed/isolated by scope_id, authored by author_id,
+-- both defaulted to auth.uid(); clients NEVER send them; RLS WITH CHECK pins both to the
+-- writer. Lifecycle: bounded by the per-scope quota counter (§4-§6), NOT a TTL reaper.
+-- The client never captures a projects DELETE (a local convergence merge deletes the
+-- loser locally; the remote loser row + its content are left for the reaper).
+
+-- ===========================================================================
+-- 1. Table.
+-- ===========================================================================
+create table if not exists public.projects (
+  scope_id     uuid not null default auth.uid() references auth.users (id) on delete cascade,
+  author_id    uuid not null default auth.uid(),
+  id           text not null,
+  git_remote   text,   -- encrypted on the wire (C-4); NULL for remote-less projects
+  name         text,   -- encrypted on the wire (C-4)
+  content_hash text,
+  revision     integer not null default 0,
+  is_deleted   boolean not null default false,
+  created_at   timestamptz not null default now(),
+  updated_at   timestamptz not null default now(),
+  primary key (scope_id, id)
+);
+
+-- ===========================================================================
+-- 2. Size CHECK (drop-then-add = idempotent). Anti-abuse backstop for a direct-
+--    PostgREST client bypassing the gateway. Encrypted-column caps carry envelope/
+--    base64 headroom over the short plaintext expectation (a git URL is < ~200 chars).
+-- ===========================================================================
+alter table public.projects drop constraint if exists projects_size_ck;
+alter table public.projects add constraint projects_size_ck check (
+  length(id) <= 64
+  and (content_hash is null or length(content_hash) <= 64)
+  and (git_remote is null or length(git_remote) <= 4096)
+  and (name is null or length(name) <= 2048)
+);
+
+-- ===========================================================================
+-- 3. updated_at trigger (the pull cursor), pull-cursor index, RLS. Basic tier: the
+--    WITH CHECK pins scope_id + author_id to the writer, with NO tier gate.
+-- ===========================================================================
+drop trigger if exists projects_set_updated_at on public.projects;
+create trigger projects_set_updated_at before update on public.projects
+  for each row execute function public.sync_set_updated_at();
+
+create index if not exists idx_projects_scope_updated
+  on public.projects (scope_id, updated_at);
+
+alter table public.projects enable row level security;
+drop policy if exists projects_scope_all on public.projects;
+create policy projects_scope_all on public.projects
+  for all
+  using (scope_id = auth.uid())
+  with check (scope_id = auth.uid() and author_id = auth.uid());
+
+-- ===========================================================================
+-- 4. DML grants so PostgREST works (RLS still enforces ownership).
+-- ===========================================================================
+grant select, insert, update, delete on public.projects to authenticated;
+
+-- ===========================================================================
+-- 5. plan_limits: BOTH free and pro (basic-tier table). Projects are low-volume (one
+--    per repo); caps are generous anti-abuse backstops.
+-- ===========================================================================
+insert into public.plan_limits (tier, table_name, max_rows, max_bytes) values
+  ('free', 'projects', 1000,  1048576),   -- 1 MB
+  ('pro',  'projects', 10000, 8388608)    -- 8 MB
+on conflict (tier, table_name) do update
+  set max_rows = excluded.max_rows, max_bytes = excluded.max_bytes;
+
+-- ===========================================================================
+-- 6. Attach the shared quota triggers. projects is (scope_id, id)-keyed, so the 0009
+--    enforce_row_quota GENERIC branch already fits — no new elsif. maintain_usage /
+--    usage_row_bytes (0007) are generic over scope_id + to_jsonb.
+-- ===========================================================================
+drop trigger if exists projects_row_quota on public.projects;
+create trigger projects_row_quota before insert or update on public.projects
+  for each row execute function public.enforce_row_quota();
+
+drop trigger if exists projects_maintain_usage on public.projects;
+create trigger projects_maintain_usage after insert or update or delete on public.projects
+  for each row execute function public.maintain_usage();
+
+-- ===========================================================================
+-- 7. Backfill the usage counter (none on first apply; kept for idempotent re-apply).
+-- ===========================================================================
+insert into public.user_table_usage (scope_id, table_name, row_count, byte_count)
+select scope_id, 'projects',
+       count(*),
+       coalesce(sum(public.usage_row_bytes(to_jsonb(x))), 0)
+  from public.projects x
+ group by scope_id
+on conflict (scope_id, table_name) do update
+  set row_count = excluded.row_count, byte_count = excluded.byte_count;


### PR DESCRIPTION
`project_id` is a random per-device `crypto.randomUUID()`; **`git_remote` is the ONLY stable cross-device key**. Content rows reference the source device's `project_id`, so on a device without that local `projects` row they FK-violate (dropped as poison post-#1215) AND, even seeded, sit orphaned under the wrong id. This syncs the `projects` id→git_remote mapping so the FK parent exists on any device and a later local checkout **adopts** the pulled id via the existing `ensureProject` git-remote match. Foundation that makes Pro-tier restore (D) actually correct.

## `migration 0022_projects_sync.sql`
`public.projects (scope_id, id, git_remote, name, versioned)`, RLS `scope_all` — **BASIC tier, no `current_tier()` gate** (contrast 0020) — quota via the generic `(scope_id, id)` `enforce_row_quota` branch, free+pro `plan_limits`.

## Client
- `projects` registered in `SYNCED_TABLES.basic` **after** the key tables (needs the DEK to decrypt) and **before** knowledge/entities (the FK parent). `git_remote` + `name` **encrypted** (C-4) — repo URLs never reach the server in plaintext (correlation is client-side). `path` is **never** synced (device-local).
- Gated on `git_remote IS NOT NULL` (capture trigger + `seedSelect`): only remote-backed projects sync.
- `applyRemoteProject`: seeds a synthetic-path FK parent (`lore:project/<id>`) for an unknown id, or backfills identity (COALESCE never clears a locally-known value); never touches `path`. INSERT/UPDATE capture, **no DELETE** (merge-deletes stay sync-invisible).
- `convergeProjectsByRemote` (post-pull, in `syncOnce`): merges projects that a peer's pulled identity revealed to share a git_remote into the **lexicographically-smallest id** — a deterministic winner both devices agree on, so there is **no re-key ping-pong**. Post-content (re-key finds applied rows), outside any txn.

## Tests
- `sync-projects.test.ts` (8): seed / backfill / idempotent; deterministic converge + re-key; git_remote capture+seed gate.
- gateway `sync.test.ts` (3): git_remote/name **sealed** + path never sent; remote-less not pushed; pull seeds synthetic-path **decrypted** row.
- `sync-security.integration.test.ts` (7, **real Postgres**): RLS isolation, forged author_id/scope_id → 42501, scope_id immutable → 23514, row cap → 23514, free+pro plan_limits.
- fan-out guard registers projects' `path UNIQUE` (can't collide — derived from PK id).

**Full suite green (5542 passed / 104 skipped); integration 93/93 with Docker; typecheck + lint clean.**

Stack: **P1 (this)** → P2 (gate content capture/seed on git_remote across the knowledge/entity families) → D-4b (Tier-2 encrypted round-trip, proves this end-to-end). Closes the core of #1246.
