### PR TITLE
fix(sync): make projects delete-invisible so reconcile never tombstones the mapping (#1246)

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -2404,11 +2404,12 @@ function installSyncCapture(database: Database) {
   // #1246: projects identity mapping (id→git_remote). Gated on git_remote IS NOT NULL —
   // only remote-backed projects sync (a remote-less project's random id can't correlate
   // cross-device; its content would FK-poison on a peer). The UPDATE trigger fires the
-  // git_remote backfill (null→remote) into the outbox. NO DELETE: a merge
-  // (convergeProjectsByRemote) deletes the loser locally, but the remote loser row is left
-  // as benign orphaned data (never tombstoned — is_deleted stays false, so the reaper does
-  // NOT collect it; it is one row/merge, within quota). A DELETE tombstone would instead
-  // race the loser's still-orphaned remote content. path is DEVICE-LOCAL, never synced.
+  // git_remote backfill (null→remote) into the outbox. NO DELETE trigger AND projects is
+  // deleteInvisible (reconcile skips its delete-tombstone pass), so a local deletion — a
+  // convergence merge loser OR a genuine project delete — is fully DELETE-INVISIBLE and
+  // never tombstones the shared remote mapping (a merge loser's content is
+  // re-keyed to the winner, not deleted; a genuine delete must not nuke another device's
+  // still-active project). Bounded by quota, not deletes. path is DEVICE-LOCAL, not synced.
   sql += `
     CREATE TEMP TRIGGER IF NOT EXISTS projects_outbox_ins
     AFTER INSERT ON projects WHEN (${gate} AND new.git_remote IS NOT NULL)

--- a/packages/core/src/sync-data.ts
+++ b/packages/core/src/sync-data.ts
@@ -114,6 +114,16 @@ export interface SyncTableMeta {
    * HAS is_deleted, so `versioned` is the wrong discriminator here.)
    */
   appendOnly?: boolean;
+  /**
+   * #1246: the reconcile() delete-tombstone pass SKIPS this table, so a local row deletion
+   * never propagates as a remote tombstone — even though the table HAS its own capture
+   * trigger and is updatable (unlike `appendOnly`, which is about omitting is_deleted for a
+   * remote table that lacks the column). Used by `projects`: a merge-loser's content is
+   * re-keyed (not deleted), and a genuine project delete must not nuke a peer's still-active
+   * project (id→git_remote is shared identity). Distinct from captureStrategy "none" (which
+   * means "no own trigger, enqueued via fanout"). Defaults to false.
+   */
+  deleteInvisible?: boolean;
 }
 
 /** ASCII Unit Separator — joins composite row ids (mirrors the SQL `char(31)`). */
@@ -214,9 +224,18 @@ export const SYNCED_TABLES: Record<SyncTier, SyncTableMeta[]> = {
       // knowledge/entities (the FK parent). Applied via applyRemoteProject, which seeds a
       // synthetic-path row (path is NOT NULL UNIQUE locally, but not synced). No
       // updated_at column locally — the remote server-stamps it for the pull cursor.
+      //
+      // deleteInvisible: projects has its OWN INSERT/UPDATE capture trigger (so it is a
+      // "row" table with a trigger — NOT "none"), but the reconcile() delete-tombstone
+      // pass SKIPS it. A local projects deletion must NEVER tombstone the shared remote
+      // mapping: (a) a convergence merge deletes the loser locally, but its content is
+      // RE-KEYED to the winner (not deleted) so a tombstone would race the re-key; (b) a
+      // genuine project delete on one device must not nuke another device's still-active
+      // project (id→git_remote is shared identity, not per-device state). Bounded by quota.
       table: "projects",
       idColumns: ["id"],
       ftsTables: [],
+      deleteInvisible: true,
       encryptedColumns: ["git_remote", "name"],
       syncColumns: ["id", "git_remote", "name", "created_at"],
     },
@@ -962,6 +981,10 @@ export function reconcile(tier: SyncTier = currentSyncTier()): void {
     // capture DELETE trigger, so the ONLY way they could tombstone is this pass —
     // skip it. (Remote lifecycle is the server reaper's job, not the client's.)
     if (m.captureStrategy && m.captureStrategy !== "row") continue;
+    // #1246: projects has its own trigger (so it is a "row" table) but is delete-invisible
+    // — a local deletion (merge loser or genuine delete) must never tombstone the shared
+    // remote id→git_remote mapping. Skip the delete-tombstone pass for it.
+    if (m.deleteInvisible) continue;
     // Knowledge is keyed by logical_id and append-only: "live" means a CURRENT live
     // version exists (knowledge_current), NOT merely a physical row — a deleted
     // entry keeps its demoted/death-cert version rows, so an `id = logical_id`

--- a/packages/core/test/sync-projects.test.ts
+++ b/packages/core/test/sync-projects.test.ts
@@ -16,6 +16,8 @@ import {
   assertSyncInvariants,
   enableSync,
   readOutbox,
+  reconcile,
+  setSyncState,
 } from "../src/sync-data";
 
 const now = () => Date.now();
@@ -136,6 +138,31 @@ describe("convergeProjectsByRemote (deterministic merge)", () => {
       .query("SELECT project_id FROM knowledge WHERE id = 'k-b'")
       .get() as { project_id: string };
     expect(k.project_id).toBe("aaa"); // content re-keyed to the winner
+  });
+
+  test("a merge-loser is NEVER tombstoned by reconcile (projects is delete-invisible)", () => {
+    insertProject("bbb", "R");
+    insertProject("aaa", "R");
+    // Both look previously-pushed (a sync_state row is the trigger for reconcile's
+    // delete-tombstone pass on a now-missing local row).
+    setSyncState("projects", "aaa", {
+      content_hash: "h",
+      revision: 0,
+      remote_updated_at: null,
+    });
+    setSyncState("projects", "bbb", {
+      content_hash: "h",
+      revision: 0,
+      remote_updated_at: null,
+    });
+    enableSync("basic");
+    convergeProjectsByRemote(); // merges bbb → aaa, deletes bbb locally
+    db().exec("DELETE FROM sync_outbox"); // ignore seed / re-key upserts
+    reconcile("basic"); // delete-tombstone pass — must SKIP projects (deleteInvisible)
+    const del = readOutbox(0, 1000).filter(
+      (e) => e.table_name === "projects" && e.op === "delete",
+    );
+    expect(del.map((e) => e.row_id)).not.toContain("bbb"); // loser NOT tombstoned
   });
 
   test("is a no-op when projects have distinct remotes", () => {

--- a/packages/core/test/sync-registry-contract.test.ts
+++ b/packages/core/test/sync-registry-contract.test.ts
@@ -121,6 +121,23 @@ describe("SYNCED_TABLES registry contract", () => {
         expect(captured).toBe(expectsOwnTrigger);
       });
 
+      if (m.deleteInvisible) {
+        test("a deleteInvisible table has NO DELETE capture trigger", () => {
+          // deleteInvisible suppresses reconcile's delete-tombstone pass, but a DELETE
+          // capture trigger would tombstone directly on local delete — bypassing the
+          // skip and defeating the flag. So such a table must never grow a *_outbox_del.
+          if (PRO_TABLES.has(m.table)) {
+            db()
+              .query(
+                "INSERT OR REPLACE INTO profiles (id, tier, created_at, updated_at) VALUES ('rc-tier','pro',?,?)",
+              )
+              .run(now(), now());
+            reinstallSyncCapture();
+          }
+          expect(tempTriggers()).not.toContain(`${m.table}_outbox_del`);
+        });
+      }
+
       if (m.pullOnly) {
         test("registers a SAMPLE_ROW (contract completeness)", () => {
           expect(SAMPLE_ROW[m.table]).toBeDefined();


### PR DESCRIPTION
Follow-up to #1247, addressing a Sentry `BUG_PREDICTION` (MEDIUM) posted right after that PR auto-merged.

## Bug
`projects` had no `captureStrategy`, so `reconcile()`'s delete-tombstone pass (sync-data.ts:964, which skips only `pullOnly` + `captureStrategy !== "row"` tables) **processed** it — enqueuing a `delete` for any `sync_state` row whose local row is gone. Two triggers:
- `convergeProjectsByRemote` merges a loser and deletes it locally; its `sync_state` lingers → reconcile tombstones it.
- a genuine `deleteProject`.

Either tombstones the **shared** remote id→git_remote mapping, which would **race a merge loser's re-keyed content** AND **nuke another device's still-active project** (id→git_remote is shared identity, not per-device state).

## Fix
A dedicated **`deleteInvisible`** flag on `SyncTableMeta` (projects sets it); `reconcile` skips the delete-tombstone pass for it.

Why not reuse existing flags:
- `captureStrategy: "none"` means *"no own trigger, enqueued via fanout"* — projects HAS its own INSERT/UPDATE trigger, so "none" would break the registry-contract `trigger IFF captureStrategy != none` test.
- `appendOnly` omits `is_deleted` for a remote table lacking the column — projects is versioned + updatable and has `is_deleted`.

`seedOutbox` gates only on `pullOnly`, so projects still seeds.

## Test
`sync-projects.test.ts`: a merged loser with a lingering `sync_state` row is NOT tombstoned by a subsequent `reconcile` — verified it FAILS without the flag (mutation-checked). Full suite **5543 green**; typecheck + lint clean.