### PR TITLE
test(sync): clean projects in the top-level engine beforeEach (#1246)

### DIFF
--- a/packages/gateway/test/sync-engine.integration.test.ts
+++ b/packages/gateway/test/sync-engine.integration.test.ts
@@ -119,6 +119,7 @@ beforeEach(async () => {
     "entity_aliases",
     "entity_relations",
     "entities",
+    "projects", // #1246: parent — after its content children above (local FK order)
     "profiles",
     "sync_outbox",
     "sync_state",
@@ -151,6 +152,7 @@ beforeEach(async () => {
     "entities",
     "entity_aliases",
     "entity_relations",
+    "projects", // #1246: no remote content→projects FK, so order-independent here
   ]) {
     await h.client.query(`DELETE FROM public.${t}`);
   }
@@ -446,12 +448,9 @@ describe.skipIf(SKIP)(
       db().exec(
         "DELETE FROM account_identity; DELETE FROM account_escrow; DELETE FROM scope_keys",
       );
-      // #1246: the synced test projects (remote-backed /dev1/* + pulled lore:project/*).
-      db().exec(
-        "DELETE FROM projects WHERE path LIKE '/dev1/%' OR path LIKE 'lore:project/%'",
-      );
+      // #1246: projects (local + remote) are cleaned by the top-level beforeEach.
       keystore.lock();
-      for (const t of ["account_escrow", "scope_keys", "projects"]) {
+      for (const t of ["account_escrow", "scope_keys"]) {
         await h.client.query(`DELETE FROM public.${t}`);
       }
     });


### PR DESCRIPTION
Sentry follow-up to #1249 (MEDIUM): the top-level engine-integration `beforeEach` cleaned every content table (local + remote) **except `projects`**, so a future main-describe test that pushes a remote-backed project would pollute later tests. Currently latent (only the encryption describe creates remote projects, and its own `beforeEach` cleaned them), but a real robustness gap.

**Centralize it:** add `projects` to the top-level `beforeEach` local cleanup (after its content children — local FK order) and remote cleanup (no remote content→projects FK, order-free), and drop the now-redundant projects cleanup from the encryption describe's `beforeEach`.

Test-only; **13/13** engine integration tests pass with Docker; typecheck + lint clean.