### PR TITLE
feat(sync): gate knowledge + entities content on git_remote (P2a, #1246)

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -30,6 +30,26 @@ function fireProjectMutation(): void {
 }
 
 /**
+ * #1246 (P2): fired when a project's git_remote flips NULL→set (ensureProject lazy
+ * backfill). Content created while the project was remote-less was NOT captured (the
+ * P2 git_remote gate), so it must be re-enqueued now that the project can correlate —
+ * otherwise it would silently stop being backed up until the next `lore sync enable`.
+ * The sync layer registers a handler (avoids a db.ts↔sync-data.ts circular import).
+ */
+let onProjectRemoteBackfilledCb: ((projectId: string) => void) | null = null;
+
+/** Register a handler for git_remote NULL→set backfill. Only one is supported. */
+export function onProjectRemoteBackfilled(
+  cb: ((projectId: string) => void) | null,
+): void {
+  onProjectRemoteBackfilledCb = cb;
+}
+
+function fireProjectRemoteBackfilled(projectId: string): void {
+  onProjectRemoteBackfilledCb?.(projectId);
+}
+
+/**
  * Extract the repository name from a normalized git remote URL.
  *
  * Examples:
@@ -2300,6 +2320,18 @@ function installSyncCapture(database: Database) {
     "entity_aliases",
     "entity_relations",
   ]) {
+    // P2a (#1246): only sync PROJECT-SCOPED content of a REMOTE-BACKED project — a
+    // remote-less project's random id can't correlate cross-device, so its private data
+    // must not upload. GLOBAL / cross-project entries (cross_project=1 or a NULL
+    // project_id) are NOT project-scoped and ALWAYS sync (they retain an origin
+    // project_id but aren't tied to its remote). Applies to the direct-project_id tables
+    // (knowledge, entities); the children (entity_aliases/entity_relations) gate through
+    // their parent entity in a follow-up (P2b), so they stay ungated here.
+    const projectGate =
+      t === "knowledge" || t === "entities"
+        ? " AND (%R.cross_project = 1 OR %R.project_id IS NULL OR " +
+          "EXISTS (SELECT 1 FROM projects p WHERE p.id = %R.project_id AND p.git_remote IS NOT NULL))"
+        : "";
     for (const [evt, suffix, ref, op] of ops) {
       // Knowledge is remote-keyed by logical_id (A2, #823), so capture the
       // logical_id for ALL ops (not the per-version row id). This makes the outbox
@@ -2313,7 +2345,7 @@ function installSyncCapture(database: Database) {
           : `${ref}.id`;
       sql += `
         CREATE TEMP TRIGGER IF NOT EXISTS ${t}_outbox_${suffix}
-        AFTER ${evt} ON ${t} WHEN (${gate})
+        AFTER ${evt} ON ${t} WHEN (${gate}${projectGate.replaceAll("%R", ref)})
         BEGIN
           INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
           VALUES ('${t}', ${rowExpr}, '${op}', ${ts});
@@ -3561,6 +3593,9 @@ export function ensureProject(
         db()
           .query("UPDATE projects SET git_remote = ? WHERE id = ?")
           .run(resolvedRemote, existing.id);
+        // #1246 (P2): the project just became remote-backed — re-seed the content that
+        // was gated out while it was remote-less (else it never gets backed up).
+        fireProjectRemoteBackfilled(existing.id);
       }
     }
     return existing.id;

--- a/packages/core/src/sync-data.ts
+++ b/packages/core/src/sync-data.ts
@@ -22,6 +22,7 @@ import {
   deleteTeamConfig,
   getKV,
   getTeamConfig,
+  onProjectRemoteBackfilled,
   setKV,
   setTeamConfig,
   withSyncApplying,
@@ -792,6 +793,19 @@ function rowIdExpr(m: SyncTableMeta): string {
  *  - any other table: unordered (no per-row value signal / high enough cap).
  * (knowledge is handled by its own logical_id-keyed branch in seedOutbox.)
  */
+// P2a (#1246): a PROJECT-SCOPED row (cross_project=0, non-NULL project_id) syncs only if
+// its project is remote-backed (git_remote set) — a remote-less project can't correlate
+// cross-device, so its private data must not upload. GLOBAL / cross-project rows always
+// sync (they retain an origin project_id but aren't tied to its remote). `prefix` qualifies
+// the columns for a joined query (e.g. "e." for the entities alias). Mirrors the capture
+// trigger gate (db.ts installSyncCapture) — the two MUST stay in lockstep.
+function remoteBackedGate(prefix = ""): string {
+  return (
+    `(${prefix}cross_project = 1 OR ${prefix}project_id IS NULL OR ` +
+    `${prefix}project_id IN (SELECT id FROM projects WHERE git_remote IS NOT NULL))`
+  );
+}
+
 function seedSelect(table: string): string {
   switch (table) {
     // The trailing id is a stable tiebreak so re-seeds are fully deterministic when
@@ -802,6 +816,7 @@ function seedSelect(table: string): string {
                   SELECT entity_id, COUNT(*) AS refs
                     FROM knowledge_entity_refs GROUP BY entity_id
                 ) r ON r.entity_id = e.id
+               WHERE ${remoteBackedGate("e.")}
                ORDER BY COALESCE(r.refs, 0) DESC, e.updated_at DESC, e.created_at DESC, e.id`;
     case "entity_relations":
       return "SELECT * FROM entity_relations ORDER BY updated_at DESC, created_at DESC, id";
@@ -905,6 +920,7 @@ export function seedOutbox(tier: SyncTier = currentSyncTier()): void {
         const lids = db()
           .query(
             `SELECT COALESCE(logical_id, id) AS lid FROM knowledge_current
+              WHERE ${remoteBackedGate()}
               ORDER BY confidence DESC,
                        COALESCE(last_reinforced_at, updated_at) DESC,
                        created_at DESC`,
@@ -1010,6 +1026,32 @@ export function reconcile(tier: SyncTier = currentSyncTier()): void {
       .run(now, m.table);
   }
 }
+
+// P2a (#1246): when a project gains a git_remote (ensureProject lazy backfill), re-enqueue
+// the project-scoped content the git_remote gate held back while it was remote-less — the
+// direct-project_id tables gated in P2a (knowledge + entities). Scoped to the one project;
+// NO transaction wrapper (ensureProject may run inside another transaction, and seedOutbox's
+// BEGIN IMMEDIATE would nest). cross_project=0 only: global/cross-project rows were never
+// gated (they always sync) so they're already queued/synced. Only fires when sync is on.
+export function reseedProjectContent(projectId: string): void {
+  if (getTeamConfig(ENABLED_KEY) !== "1") return;
+  const now = Date.now();
+  db()
+    .query(
+      `INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
+         SELECT 'knowledge', COALESCE(logical_id, id), 'upsert', ? FROM knowledge_current
+          WHERE project_id = ? AND cross_project = 0`,
+    )
+    .run(now, projectId);
+  db()
+    .query(
+      `INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
+         SELECT 'entities', id, 'upsert', ? FROM entities
+          WHERE project_id = ? AND cross_project = 0`,
+    )
+    .run(now, projectId);
+}
+onProjectRemoteBackfilled(reseedProjectContent);
 
 // ---------------------------------------------------------------------------
 // Per-row sync state

--- a/packages/core/test/sync-data.test.ts
+++ b/packages/core/test/sync-data.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import {
   db,
-  ensureProject,
+  ensureProject as ensureProjectDb,
   getKV,
   setKV,
   setTeamConfig,
@@ -48,6 +48,22 @@ import {
 import * as ltm from "../src/ltm";
 
 const now = () => Date.now();
+
+// P2a (#1246): these tests exercise content that must SYNC, so their projects must be
+// REMOTE-BACKED — the git_remote gate skips project-scoped content of a remote-less
+// project. Stamp a git_remote (under capture-suppression so it never enqueues a stray
+// projects/reseed entry). All call sites use this transparently.
+function ensureProject(path: string, name?: string): string {
+  const id = ensureProjectDb(path, name);
+  withApplying(() =>
+    db()
+      .query(
+        "UPDATE projects SET git_remote = 'test:remote' WHERE id = ? AND git_remote IS NULL",
+      )
+      .run(id),
+  );
+  return id;
+}
 
 describe("applyRemoteKnowledge — append-only pull apply (A2, #823)", () => {
   const PROJ = "/tmp/lore-apply-knowledge";
@@ -227,6 +243,7 @@ describe("knowledgePushPlan — append-only remote mapping keyed by logical_id (
   });
 
   test("capture triggers key the knowledge outbox by logical_id for every op (#909)", () => {
+    ensureProject("/tmp/lore-kpp-triggers"); // remote-backed → content passes the P2 gate
     setTeamConfig("sync.enabled", "1");
     db().exec("DELETE FROM sync_outbox");
     const id = ltm.create({
@@ -280,6 +297,7 @@ describe("knowledgePushPlan — append-only remote mapping keyed by logical_id (
   });
 
   test("seedOutbox enqueues knowledge by value (confidence, then recency) so the best entries win the cap", () => {
+    ensureProject("/tmp/lore-seed-rank"); // remote-backed → content passes the P2 gate
     setTeamConfig("sync.enabled", "1");
     const mk = (title: string) =>
       ltm.create({
@@ -309,6 +327,7 @@ describe("knowledgePushPlan — append-only remote mapping keyed by logical_id (
   });
 
   test("seedOutbox breaks confidence ties by recency (most recently reinforced first)", () => {
+    ensureProject("/tmp/lore-seed-tie"); // remote-backed → content passes the P2 gate
     setTeamConfig("sync.enabled", "1");
     const mk = (title: string) =>
       ltm.create({

--- a/packages/core/test/sync-projects.test.ts
+++ b/packages/core/test/sync-projects.test.ts
@@ -17,6 +17,7 @@ import {
   enableSync,
   readOutbox,
   reconcile,
+  reseedProjectContent,
   setSyncState,
 } from "../src/sync-data";
 
@@ -46,18 +47,31 @@ function getProject(id: string) {
     git_remote: string | null;
   } | null;
 }
-function insertKnowledge(id: string, projectId: string) {
+function insertKnowledge(
+  id: string,
+  projectId: string | null,
+  crossProject = 0,
+) {
   db()
     .query(
-      `INSERT INTO knowledge (id, logical_id, project_id, category, title, content, created_at, updated_at)
-       VALUES (?, ?, ?, 'pattern', 't', 'c', ?, ?)`,
+      `INSERT INTO knowledge (id, logical_id, project_id, category, title, content, cross_project, created_at, updated_at)
+       VALUES (?, ?, ?, 'pattern', 't', 'c', ?, ?, ?)`,
     )
-    .run(id, id, projectId, now(), now());
+    .run(id, id, projectId, crossProject, now(), now());
 }
-const projectOutbox = () =>
+function insertEntity(id: string, projectId: string | null, crossProject = 0) {
+  db()
+    .query(
+      `INSERT INTO entities (id, project_id, entity_type, canonical_name, cross_project, created_at, updated_at)
+       VALUES (?, ?, 'tool', 'n', ?, ?, ?)`,
+    )
+    .run(id, projectId, crossProject, now(), now());
+}
+const outboxRowIds = (table: string) =>
   readOutbox(0, 1000)
-    .filter((e) => e.table_name === "projects")
+    .filter((e) => e.table_name === table)
     .map((e) => e.row_id);
+const projectOutbox = () => outboxRowIds("projects");
 
 beforeEach(() => {
   deleteTeamConfig("sync.enabled");
@@ -199,5 +213,70 @@ describe("git_remote gate (only remote-backed projects sync)", () => {
     const q = projectOutbox();
     expect(q).toContain("seed-r");
     expect(q).not.toContain("seed-none");
+  });
+});
+
+describe("content git_remote gate — P2a (#1246)", () => {
+  test("capture: knowledge/entities of a remote-backed project enqueue; a remote-less one's do NOT", () => {
+    insertProject("p-remote", "R");
+    insertProject("p-local", null);
+    enableSync("basic");
+    insertKnowledge("k-remote", "p-remote");
+    insertKnowledge("k-local", "p-local");
+    insertEntity("e-remote", "p-remote");
+    insertEntity("e-local", "p-local");
+    expect(outboxRowIds("knowledge")).toEqual(["k-remote"]);
+    expect(outboxRowIds("entities")).toEqual(["e-remote"]);
+  });
+
+  test("capture: GLOBAL/cross-project content ALWAYS syncs, even under a remote-less project", () => {
+    insertProject("p-local", null);
+    enableSync("basic");
+    // cross_project=1 retains its origin project_id but is not tied to that remote.
+    insertKnowledge("k-cross", "p-local", 1);
+    insertEntity("e-cross", "p-local", 1);
+    insertKnowledge("k-global", null); // NULL project_id (global)
+    insertEntity("e-global", null);
+    expect(outboxRowIds("knowledge").sort()).toEqual(["k-cross", "k-global"]);
+    expect(outboxRowIds("entities").sort()).toEqual(["e-cross", "e-global"]);
+  });
+
+  test("seed: only remote-backed (+ global/cross) content is seeded on enable", () => {
+    // Created while sync is OFF → exercises the seedSelect gate, not the trigger.
+    insertProject("p-remote", "R");
+    insertProject("p-local", null);
+    insertKnowledge("k-remote", "p-remote");
+    insertKnowledge("k-local", "p-local"); // gated out
+    insertKnowledge("k-cross", "p-local", 1); // global → always seeded
+    insertEntity("e-remote", "p-remote");
+    insertEntity("e-local", "p-local"); // gated out
+    enableSync("basic"); // reconcile → seedOutbox
+    expect(outboxRowIds("knowledge").sort()).toEqual(["k-cross", "k-remote"]);
+    expect(outboxRowIds("entities")).toEqual(["e-remote"]);
+  });
+
+  test("reseedProjectContent: re-enqueues a project's project-scoped content after it gains a remote", () => {
+    // A project created remote-less: its content is NOT captured (gated out)…
+    insertProject("p", null);
+    enableSync("basic");
+    insertKnowledge("k1", "p");
+    insertKnowledge("k2", "p");
+    insertKnowledge("k-cross", "p", 1); // global → already captured
+    insertEntity("e1", "p");
+    expect(outboxRowIds("knowledge")).toEqual(["k-cross"]); // only the global one
+    expect(outboxRowIds("entities")).toEqual([]);
+    // …now the project gains a remote (backfill fires this) → its held-back
+    // project-scoped content is re-enqueued (the global one is NOT re-queued).
+    db().query("UPDATE projects SET git_remote='R' WHERE id='p'").run();
+    reseedProjectContent("p");
+    expect(outboxRowIds("knowledge").sort()).toEqual(["k-cross", "k1", "k2"]);
+    expect(outboxRowIds("entities")).toEqual(["e1"]);
+  });
+
+  test("reseedProjectContent: no-op when sync is disabled", () => {
+    insertProject("p", "R");
+    insertKnowledge("k1", "p");
+    reseedProjectContent("p"); // sync OFF → must not enqueue
+    expect(outboxRowIds("knowledge")).toEqual([]);
   });
 });

--- a/packages/gateway/test/sync-engine.integration.test.ts
+++ b/packages/gateway/test/sync-engine.integration.test.ts
@@ -16,7 +16,7 @@ import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import {
   crypto,
   db,
-  ensureProject,
+  ensureProject as ensureProjectCore,
   keystore,
   ltm,
   resolveProjectByRemoteOrPath,
@@ -162,6 +162,21 @@ beforeEach(async () => {
 afterEach(() => {
   if (!SKIP) syncData.assertSyncInvariants();
 });
+
+// P2a (#1246): content syncs only for REMOTE-BACKED projects. These engine tests exercise
+// content that must reach the real server, so their project must have a git_remote. Stamp
+// it under capture-suppression (raw UPDATE, not ensureProject → no reseed side-effect).
+function ensureProject(path: string, name?: string): string {
+  const id = ensureProjectCore(path, name);
+  syncData.withApplying(() =>
+    db()
+      .query(
+        "UPDATE projects SET git_remote = 'test:remote' WHERE id = ? AND git_remote IS NULL",
+      )
+      .run(id),
+  );
+  return id;
+}
 
 function insertKnowledge(id: string, content: string): void {
   const pid = ensureProject("/tmp/lore-engine-it");

--- a/packages/gateway/test/sync.property.test.ts
+++ b/packages/gateway/test/sync.property.test.ts
@@ -14,12 +14,27 @@ import fc from "fast-check";
 import {
   db,
   deleteTeamConfig,
-  ensureProject,
+  ensureProject as ensureProjectCore,
   ltm,
   setKV,
   syncData,
 } from "@loreai/core";
 import { describe, expect, test, vi } from "vitest";
+
+// P2a (#1246): content syncs only for REMOTE-BACKED projects (git_remote set). This
+// property test asserts the local live set converges with the remote, so its project
+// must be remote-backed. Stamp a git_remote under capture-suppression (no stray entry).
+function ensureProject(path: string, name?: string): string {
+  const id = ensureProjectCore(path, name);
+  syncData.withApplying(() =>
+    db()
+      .query(
+        "UPDATE projects SET git_remote = 'test:remote' WHERE id = ? AND git_remote IS NULL",
+      )
+      .run(id),
+  );
+  return id;
+}
 
 // --- Faithful in-memory Supabase (PostgREST surface the engine uses) ---------
 interface RemoteRow extends Record<string, unknown> {

--- a/packages/gateway/test/sync.test.ts
+++ b/packages/gateway/test/sync.test.ts
@@ -1,13 +1,28 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import {
   db,
-  ensureProject,
+  ensureProject as ensureProjectCore,
   getKV,
   setKV,
   deleteTeamConfig,
   reinstallSyncCapture,
 } from "@loreai/core";
 import { ltm, log, keystore, crypto, syncData } from "@loreai/core";
+
+// P2a (#1246): these tests exercise content that must SYNC, so their projects must be
+// REMOTE-BACKED — the git_remote gate skips project-scoped content of a remote-less
+// project. Stamp a git_remote (under capture-suppression → no stray outbox entry).
+function ensureProject(path: string, name?: string): string {
+  const id = ensureProjectCore(path, name);
+  syncData.withApplying(() =>
+    db()
+      .query(
+        "UPDATE projects SET git_remote = 'test:remote' WHERE id = ? AND git_remote IS NULL",
+      )
+      .run(id),
+  );
+  return id;
+}
 
 // --- Fake Supabase client ----------------------------------------------------
 // In-memory per-table store with the PostgREST surface the engine uses, PLUS
@@ -406,8 +421,11 @@ beforeEach(() => {
   db().exec("DELETE FROM distillations");
   db().exec("DELETE FROM temporal_messages");
   // #1246: the synced test projects (remote-backed /local/* + pulled lore:project/*).
+  // Also the /tmp/* content projects — P2a stamps them a git_remote, so a persisted one
+  // would be seeded+pushed at enableSync and skew exact push counts. Cleared here (content
+  // children already deleted above → FK-safe); each test recreates its project fresh.
   db().exec(
-    "DELETE FROM projects WHERE path LIKE '/local/%' OR path LIKE 'lore:project/%'",
+    "DELETE FROM projects WHERE path LIKE '/local/%' OR path LIKE 'lore:project/%' OR path LIKE '/tmp/%'",
   );
   keystore.lock();
   db().exec("DELETE FROM sync_outbox");
@@ -1452,6 +1470,7 @@ describe("pullOnce", () => {
     // (knowledge_current, keyed by logical_id), not the demoted v1 base row that
     // getRowById(id=logical_id) returns. Reverting that fix makes this fail with
     // conflicts=1 / pulled=1 and a stale (v1) sync_conflicts.local_content.
+    ensureProject("/tmp/lore-sync-engine"); // remote-backed → content passes the P2 gate
     syncData.enableSync("basic");
     const id = ltm.create({
       projectPath: "/tmp/lore-sync-engine",
@@ -1481,6 +1500,7 @@ describe("pullOnce", () => {
     // knowledge_current (current version), not getRowById (the demoted v1 row), so
     // the discarded edit recoverable from sync_conflicts.local_content is the real
     // superseded content. Reverting that branch to getRowById makes this fail.
+    ensureProject("/tmp/lore-sync-engine"); // remote-backed → content passes the P2 gate
     syncData.enableSync("basic");
     const id = ltm.create({
       projectPath: "/tmp/lore-sync-engine",
@@ -1512,6 +1532,7 @@ describe("pullOnce", () => {
     // The DELETE capture trigger must record the logical_id, not the version id —
     // otherwise a delete of a version whose id ≠ logical_id targets a remote row
     // that doesn't exist (remote is keyed by logical_id) and silently no-ops.
+    ensureProject("/tmp/lore-sync-engine"); // remote-backed → content passes the P2 gate
     syncData.enableSync("basic");
     const id = ltm.create({
       projectPath: "/tmp/lore-sync-engine",
@@ -1543,6 +1564,7 @@ describe("pullOnce", () => {
     // reconcile() must tombstone by knowledge_current liveness, not physical-row
     // existence — a deleted entry keeps its demoted/death-cert version rows, so an
     // id=logical_id existence check would never reconcile a delete made while OFF.
+    ensureProject("/tmp/lore-sync-engine"); // remote-backed → content passes the P2 gate
     syncData.enableSync("basic");
     const id = ltm.create({
       projectPath: "/tmp/lore-sync-engine",
@@ -1579,6 +1601,7 @@ describe("pullOnce", () => {
     // A physical delete of a non-current version fires op=delete keyed by logical_id.
     // The push delete branch must re-validate liveness: the entry still has a live
     // current version, so this is NOT a deletion — re-push current, don't tombstone.
+    ensureProject("/tmp/lore-sync-engine"); // remote-backed → content passes the P2 gate
     syncData.enableSync("basic");
     const id = ltm.create({
       projectPath: "/tmp/lore-sync-engine",


### PR DESCRIPTION
**P2** stops syncing PROJECT-SCOPED content of a REMOTE-LESS project — its random per-device id can't correlate cross-device, so uploading a local/scratch repo's private data is wasteful and a privacy leak (on a peer it just logical-orphans; for Pro tables it would FK-poison). **P2a** covers the direct-`project_id` basic tables (`knowledge`, `entities`); the indirect children (metas/refs/aliases/relations, **P2b**) and the Pro fanout (**P2c**) follow.

## Changes
- **Capture** (`db.ts` `installSyncCapture`): `knowledge` + `entities` triggers gain a git_remote gate — a row syncs iff its project is remote-backed **OR** it is GLOBAL/cross-project (`cross_project=1` or NULL `project_id`, which retain an origin project_id but aren't tied to its remote and must **always** sync). Children (`entity_aliases`/`entity_relations`) stay ungated here (P2b gates them through their parent entity).
- **Seed** (`sync-data.ts`): the `entities` seedSelect and the `knowledge_current` seed path get the same gate via a shared `remoteBackedGate()` fragment (kept in lockstep with the trigger).
- **Re-seed on backfill** (the novel mechanism): `ensureProject`'s git_remote NULL→set backfill fires a new `onProjectRemoteBackfilled` hook → `reseedProjectContent(projectId)`, re-enqueuing the project-scoped content the gate held back while it was remote-less. **Without this, a project that gains a remote later would silently STOP being backed up** until the next `lore sync enable` — a regression vs today. A registered hook avoids the `db.ts`↔`sync-data.ts` circular import; scoped, no transaction wrapper (`ensureProject` may run inside one).

## Tests
New `content git_remote gate — P2a` describe (capture/seed gating, global exemption, re-seed after backfill, no-op when disabled). Existing sync fixtures updated to remote-backed projects (they exercise content that must sync). **Full suite 5549 green**, typecheck + lint clean.

Part of the P2 stack (P2a here → P2b children → P2c Pro fanout). Design in `.opencode/plans/project-identity-sync.md`.