### PR TITLE
feat(sync): gate indirect child content on parent syncability (P2b, #1246)

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -2308,6 +2308,19 @@ function installSyncCapture(database: Database) {
     "(SELECT value FROM team_config WHERE key='sync.enabled')='1' " +
     "AND NOT EXISTS (SELECT 1 FROM temp._sync_applying)";
   const ts = "CAST(strftime('%s','now') AS INTEGER)*1000";
+  // P2 (#1246) content git_remote gates. A row syncs only if it is REMOTE-BACKED or
+  // GLOBAL — a remote-less project's random id can't correlate cross-device, so its
+  // private data must not upload. `directGate(c)` for a table WITH project_id/cross_project
+  // (knowledge, entities): cross_project=1 (promoted/global) OR NULL project_id OR the
+  // project has a git_remote. `knowledgeParentGate`/`entityParentGate` gate a CHILD (no
+  // project_id of its own) on whether its parent knowledge/entity is itself syncable.
+  const directGate = (c: string) =>
+    `(${c}.cross_project = 1 OR ${c}.project_id IS NULL OR ` +
+    `EXISTS (SELECT 1 FROM projects p WHERE p.id = ${c}.project_id AND p.git_remote IS NOT NULL))`;
+  const knowledgeParentGate = (idExpr: string) =>
+    `EXISTS (SELECT 1 FROM knowledge k WHERE COALESCE(k.logical_id, k.id) = ${idExpr} AND ${directGate("k")})`;
+  const entityParentGate = (idExpr: string) =>
+    `EXISTS (SELECT 1 FROM entities e WHERE e.id = ${idExpr} AND ${directGate("e")})`;
   const ops = [
     ["INSERT", "ins", "new", "upsert"],
     ["UPDATE", "upd", "new", "upsert"],
@@ -2320,19 +2333,21 @@ function installSyncCapture(database: Database) {
     "entity_aliases",
     "entity_relations",
   ]) {
-    // P2a (#1246): only sync PROJECT-SCOPED content of a REMOTE-BACKED project — a
-    // remote-less project's random id can't correlate cross-device, so its private data
-    // must not upload. GLOBAL / cross-project entries (cross_project=1 or a NULL
-    // project_id) are NOT project-scoped and ALWAYS sync (they retain an origin
-    // project_id but aren't tied to its remote). Applies to the direct-project_id tables
-    // (knowledge, entities); the children (entity_aliases/entity_relations) gate through
-    // their parent entity in a follow-up (P2b), so they stay ungated here.
-    const projectGate =
-      t === "knowledge" || t === "entities"
-        ? " AND (%R.cross_project = 1 OR %R.project_id IS NULL OR " +
-          "EXISTS (SELECT 1 FROM projects p WHERE p.id = %R.project_id AND p.git_remote IS NOT NULL))"
-        : "";
     for (const [evt, suffix, ref, op] of ops) {
+      // Direct-project_id tables (P2a): gate every op on the row's own project.
+      // Child tables (P2b): gate INSERT/UPDATE on the PARENT entity's syncability; a
+      // DELETE stays UNGATED — a delete of a never-synced child pushes as a harmless
+      // idempotent no-op, and gating it would depend on the parent still existing, but
+      // the parent (entity) is cascade-deleted FIRST (ON DELETE CASCADE), so an EXISTS
+      // check would spuriously drop a legitimate delete of a previously-synced child.
+      let contentGate = "";
+      if (t === "knowledge" || t === "entities")
+        contentGate = ` AND ${directGate(ref)}`;
+      else if (op !== "delete")
+        contentGate =
+          t === "entity_aliases"
+            ? ` AND ${entityParentGate(`${ref}.entity_id`)}`
+            : ` AND ${entityParentGate(`${ref}.entity_a`)} AND ${entityParentGate(`${ref}.entity_b`)}`;
       // Knowledge is remote-keyed by logical_id (A2, #823), so capture the
       // logical_id for ALL ops (not the per-version row id). This makes the outbox
       // uniformly logical_id-keyed: the push plan + pending checks read the row_id
@@ -2345,18 +2360,21 @@ function installSyncCapture(database: Database) {
           : `${ref}.id`;
       sql += `
         CREATE TEMP TRIGGER IF NOT EXISTS ${t}_outbox_${suffix}
-        AFTER ${evt} ON ${t} WHEN (${gate}${projectGate.replaceAll("%R", ref)})
+        AFTER ${evt} ON ${t} WHEN (${gate}${contentGate})
         BEGIN
           INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
           VALUES ('${t}', ${rowExpr}, '${op}', ${ts});
         END;`;
     }
   }
-  // Join table: composite row_id (knowledge_id || char(31) || entity_id),
-  // insert/delete only (no updatable columns).
+  // Join table: composite row_id (knowledge_id || char(31) || entity_id), insert/delete
+  // only (no updatable columns). P2b: gate INSERT on BOTH parents (the ref links a
+  // knowledge to an entity — both must be syncable); DELETE stays ungated (no-op if never
+  // synced; the parents may be gone by delete time).
   sql += `
     CREATE TEMP TRIGGER IF NOT EXISTS knowledge_entity_refs_outbox_ins
-    AFTER INSERT ON knowledge_entity_refs WHEN (${gate})
+    AFTER INSERT ON knowledge_entity_refs
+    WHEN (${gate} AND ${knowledgeParentGate("new.knowledge_id")} AND ${entityParentGate("new.entity_id")})
     BEGIN
       INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
       VALUES ('knowledge_entity_refs', new.knowledge_id || char(31) || new.entity_id, 'upsert', ${ts});
@@ -2372,16 +2390,17 @@ function installSyncCapture(database: Database) {
   // actually changes — the frequent per-op confidence re-materialization (which
   // only writes the local-derived confidence/updated_at) must NOT churn the outbox.
   // No DELETE (a register row outlives the knowledge entry's death-cert).
+  // P2b (#1246): gate on the parent knowledge's syncability.
   sql += `
     CREATE TEMP TRIGGER IF NOT EXISTS knowledge_meta_outbox_ins
-    AFTER INSERT ON knowledge_meta WHEN (${gate})
+    AFTER INSERT ON knowledge_meta WHEN (${gate} AND ${knowledgeParentGate("new.logical_id")})
     BEGIN
       INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
       VALUES ('knowledge_meta', new.logical_id, 'upsert', ${ts});
     END;
     CREATE TEMP TRIGGER IF NOT EXISTS knowledge_meta_outbox_upd
     AFTER UPDATE ON knowledge_meta
-    WHEN ((${gate}) AND new.base_confidence IS NOT old.base_confidence)
+    WHEN ((${gate}) AND new.base_confidence IS NOT old.base_confidence AND ${knowledgeParentGate("new.logical_id")})
     BEGIN
       INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
       VALUES ('knowledge_meta', new.logical_id, 'upsert', ${ts});
@@ -2391,16 +2410,17 @@ function installSyncCapture(database: Database) {
   // local applyConfidenceDelta only ever writes THIS device's replica row, and
   // pulled peer rows arrive under apply-suppression — so the outbox only carries
   // this device's counters. INSERT + UPDATE (pos/neg grow); no DELETE.
+  // P2b (#1246): gate on the parent knowledge's syncability.
   sql += `
     CREATE TEMP TRIGGER IF NOT EXISTS knowledge_meta_crdt_outbox_ins
-    AFTER INSERT ON knowledge_meta_crdt WHEN (${gate})
+    AFTER INSERT ON knowledge_meta_crdt WHEN (${gate} AND ${knowledgeParentGate("new.logical_id")})
     BEGIN
       INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
       VALUES ('knowledge_meta_crdt', new.logical_id || char(31) || new.replica_id, 'upsert', ${ts});
     END;
     CREATE TEMP TRIGGER IF NOT EXISTS knowledge_meta_crdt_outbox_upd
     AFTER UPDATE ON knowledge_meta_crdt
-    WHEN (${gate} AND (new.pos > old.pos OR new.neg > old.neg))
+    WHEN (${gate} AND (new.pos > old.pos OR new.neg > old.neg) AND ${knowledgeParentGate("new.logical_id")})
     BEGIN
       INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
       VALUES ('knowledge_meta_crdt', new.logical_id || char(31) || new.replica_id, 'upsert', ${ts});

--- a/packages/core/src/sync-data.ts
+++ b/packages/core/src/sync-data.ts
@@ -806,6 +806,16 @@ function remoteBackedGate(prefix = ""): string {
   );
 }
 
+// P2b (#1246): a CHILD row (no project_id of its own) syncs iff its PARENT knowledge/entity
+// is itself syncable. Mirrors the capture-trigger parent gates in db.ts installSyncCapture —
+// the two MUST stay in lockstep. `idExpr` is the child's FK column (e.g. "m.logical_id").
+function knowledgeParentGate(idExpr: string): string {
+  return `EXISTS (SELECT 1 FROM knowledge k WHERE COALESCE(k.logical_id, k.id) = ${idExpr} AND ${remoteBackedGate("k.")})`;
+}
+function entityParentGate(idExpr: string): string {
+  return `EXISTS (SELECT 1 FROM entities e WHERE e.id = ${idExpr} AND ${remoteBackedGate("e.")})`;
+}
+
 function seedSelect(table: string): string {
   switch (table) {
     // The trailing id is a stable tiebreak so re-seeds are fully deterministic when
@@ -818,10 +828,25 @@ function seedSelect(table: string): string {
                 ) r ON r.entity_id = e.id
                WHERE ${remoteBackedGate("e.")}
                ORDER BY COALESCE(r.refs, 0) DESC, e.updated_at DESC, e.created_at DESC, e.id`;
+    // P2b (#1246): a relation syncs only if BOTH endpoint entities are syncable (the
+    // relation FKs both; a peer would poison-skip it otherwise). Global/cross-project
+    // entities always qualify.
     case "entity_relations":
-      return "SELECT * FROM entity_relations ORDER BY updated_at DESC, created_at DESC, id";
+      return `SELECT * FROM entity_relations
+               WHERE ${entityParentGate("entity_a")} AND ${entityParentGate("entity_b")}
+               ORDER BY updated_at DESC, created_at DESC, id`;
+    // P2b (#1246): an alias syncs only if its parent entity is syncable.
     case "entity_aliases":
-      return "SELECT * FROM entity_aliases ORDER BY created_at DESC, id";
+      return `SELECT * FROM entity_aliases
+               WHERE ${entityParentGate("entity_id")}
+               ORDER BY created_at DESC, id`;
+    // P2b (#1246): a ref syncs only if BOTH its parents (knowledge + entity) are syncable.
+    case "knowledge_entity_refs":
+      return `SELECT * FROM knowledge_entity_refs
+               WHERE ${knowledgeParentGate("knowledge_id")} AND ${entityParentGate("entity_id")}`;
+    // P2b (#1246): a CRDT counter syncs only if its parent knowledge is syncable.
+    case "knowledge_meta_crdt":
+      return `SELECT c.* FROM knowledge_meta_crdt c WHERE ${knowledgeParentGate("c.logical_id")}`;
     // knowledge_meta shares knowledge's 500-row cap, so seed it in the SAME value order
     // (confidence, then recency) as the knowledge seed — otherwise the surviving meta set
     // wouldn't match the surviving knowledge set and synced entries would read as the
@@ -839,6 +864,7 @@ function seedSelect(table: string): string {
                   ON k.logical_id = m.logical_id
                  AND k.is_current = 1
                  AND k.is_deleted = 0
+               WHERE ${remoteBackedGate("k.")}
                ORDER BY m.confidence DESC,
                         COALESCE(m.last_reinforced_at, m.updated_at) DESC,
                         m.logical_id`;
@@ -1036,20 +1062,70 @@ export function reconcile(tier: SyncTier = currentSyncTier()): void {
 export function reseedProjectContent(projectId: string): void {
   if (getTeamConfig(ENABLED_KEY) !== "1") return;
   const now = Date.now();
-  db()
-    .query(
-      `INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
-         SELECT 'knowledge', COALESCE(logical_id, id), 'upsert', ? FROM knowledge_current
-          WHERE project_id = ? AND cross_project = 0`,
-    )
-    .run(now, projectId);
-  db()
-    .query(
-      `INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
-         SELECT 'entities', id, 'upsert', ? FROM entities
-          WHERE project_id = ? AND cross_project = 0`,
-    )
-    .run(now, projectId);
+  const enqueue = (sql: string, ...params: unknown[]) =>
+    db()
+      .query(
+        `INSERT INTO sync_outbox (table_name, row_id, op, changed_at) ${sql}`,
+      )
+      .run(...params);
+  // The project's own project-scoped rows (this project's cross_project=0 knowledge in
+  // one sub-select, reused for the children so they align 1:1 with the seeded knowledge).
+  // knowledge_current (live-only) so a deleted entry's lingering meta/refs aren't
+  // re-enqueued — matches seedSelect's live-only JOIN, not the any-version capture gate.
+  const projKnowledge =
+    "SELECT COALESCE(logical_id, id) FROM knowledge_current WHERE project_id = ? AND cross_project = 0";
+  const projEntities =
+    "SELECT id FROM entities WHERE project_id = ? AND cross_project = 0";
+  // P2a: the direct-project_id content.
+  enqueue(
+    `SELECT 'knowledge', COALESCE(logical_id, id), 'upsert', ? FROM knowledge_current
+      WHERE project_id = ? AND cross_project = 0`,
+    now,
+    projectId,
+  );
+  enqueue(
+    `SELECT 'entities', id, 'upsert', ? FROM (${projEntities})`,
+    now,
+    projectId,
+  );
+  // P2b: the children, now that their parents are syncable. Single-parent children key
+  // off this project's knowledge/entities; the two-parent children (relations, refs) also
+  // require the OTHER endpoint to be syncable (entity/knowledgeParentGate).
+  enqueue(
+    `SELECT 'knowledge_meta', logical_id, 'upsert', ? FROM knowledge_meta
+      WHERE logical_id IN (${projKnowledge})`,
+    now,
+    projectId,
+  );
+  enqueue(
+    `SELECT 'knowledge_meta_crdt', logical_id || char(31) || replica_id, 'upsert', ?
+       FROM knowledge_meta_crdt WHERE logical_id IN (${projKnowledge})`,
+    now,
+    projectId,
+  );
+  enqueue(
+    `SELECT 'entity_aliases', id, 'upsert', ? FROM entity_aliases
+      WHERE entity_id IN (${projEntities})`,
+    now,
+    projectId,
+  );
+  enqueue(
+    `SELECT 'entity_relations', id, 'upsert', ? FROM entity_relations r
+      WHERE (r.entity_a IN (${projEntities}) OR r.entity_b IN (${projEntities}))
+        AND ${entityParentGate("r.entity_a")} AND ${entityParentGate("r.entity_b")}`,
+    now,
+    projectId,
+    projectId,
+  );
+  enqueue(
+    `SELECT 'knowledge_entity_refs', knowledge_id || char(31) || entity_id, 'upsert', ?
+       FROM knowledge_entity_refs ref
+      WHERE (ref.knowledge_id IN (${projKnowledge}) OR ref.entity_id IN (${projEntities}))
+        AND ${knowledgeParentGate("ref.knowledge_id")} AND ${entityParentGate("ref.entity_id")}`,
+    now,
+    projectId,
+    projectId,
+  );
 }
 onProjectRemoteBackfilled(reseedProjectContent);
 

--- a/packages/core/test/sync-data.test.ts
+++ b/packages/core/test/sync-data.test.ts
@@ -430,6 +430,7 @@ describe("knowledgePushPlan — append-only remote mapping keyed by logical_id (
   });
 
   test("seedOutbox seeds knowledge_meta in the same value order as knowledge (confidence, recency)", () => {
+    ensureProject("/tmp/lore-meta-seed"); // remote-backed → meta passes the P2b parent gate
     setTeamConfig("sync.enabled", "1");
     const mk = (title: string) =>
       ltm.create({
@@ -462,6 +463,7 @@ describe("knowledgePushPlan — append-only remote mapping keyed by logical_id (
   });
 
   test("seedOutbox does NOT seed knowledge_meta for a DELETED entry (live-only JOIN)", () => {
+    ensureProject("/tmp/lore-meta-live"); // remote-backed → meta passes the P2b parent gate
     setTeamConfig("sync.enabled", "1");
     const mk = (title: string) =>
       ltm.create({

--- a/packages/core/test/sync-projects.test.ts
+++ b/packages/core/test/sync-projects.test.ts
@@ -67,6 +67,42 @@ function insertEntity(id: string, projectId: string | null, crossProject = 0) {
     )
     .run(id, projectId, crossProject, now(), now());
 }
+function insertMeta(logicalId: string) {
+  db()
+    .query(
+      "INSERT INTO knowledge_meta (logical_id, confidence, base_confidence, updated_at) VALUES (?, 1.0, 1.0, ?)",
+    )
+    .run(logicalId, now());
+}
+function insertMetaCrdt(logicalId: string, replica = "rA") {
+  db()
+    .query(
+      "INSERT INTO knowledge_meta_crdt (logical_id, replica_id, pos, neg, updated_at) VALUES (?, ?, 0.1, 0, ?)",
+    )
+    .run(logicalId, replica, now());
+}
+function insertAlias(id: string, entityId: string) {
+  db()
+    .query(
+      "INSERT INTO entity_aliases (id, entity_id, alias_type, alias_value, created_at) VALUES (?, ?, 'name', ?, ?)",
+    )
+    .run(id, entityId, id, now());
+}
+function insertRelation(id: string, a: string, b: string) {
+  db()
+    .query(
+      "INSERT INTO entity_relations (id, entity_a, entity_b, relation, created_at, updated_at) VALUES (?, ?, ?, 'rel', ?, ?)",
+    )
+    .run(id, a, b, now(), now());
+}
+function insertRef(knowledgeId: string, entityId: string) {
+  db()
+    .query(
+      "INSERT INTO knowledge_entity_refs (knowledge_id, entity_id) VALUES (?, ?)",
+    )
+    .run(knowledgeId, entityId);
+}
+const US = String.fromCharCode(31); // composite row_id separator (char(31))
 const outboxRowIds = (table: string) =>
   readOutbox(0, 1000)
     .filter((e) => e.table_name === table)
@@ -278,5 +314,113 @@ describe("content git_remote gate — P2a (#1246)", () => {
     insertKnowledge("k1", "p");
     reseedProjectContent("p"); // sync OFF → must not enqueue
     expect(outboxRowIds("knowledge")).toEqual([]);
+  });
+});
+
+describe("child content git_remote gate — P2b (#1246)", () => {
+  test("capture: children of a remote-backed parent enqueue; of a remote-less parent do NOT", () => {
+    insertProject("p-remote", "R");
+    insertProject("p-local", null);
+    enableSync("basic");
+    insertKnowledge("k-remote", "p-remote");
+    insertKnowledge("k-local", "p-local");
+    insertEntity("e-remote", "p-remote");
+    insertEntity("e-local", "p-local");
+    db().exec("DELETE FROM sync_outbox"); // isolate the children from the parent captures
+    insertMeta("k-remote");
+    insertMeta("k-local");
+    insertMetaCrdt("k-remote");
+    insertMetaCrdt("k-local");
+    insertAlias("a-remote", "e-remote");
+    insertAlias("a-local", "e-local");
+    insertRef("k-remote", "e-remote");
+    insertRef("k-local", "e-local");
+    expect(outboxRowIds("knowledge_meta")).toEqual(["k-remote"]);
+    expect(outboxRowIds("knowledge_meta_crdt")).toEqual([`k-remote${US}rA`]);
+    expect(outboxRowIds("entity_aliases")).toEqual(["a-remote"]);
+    expect(outboxRowIds("knowledge_entity_refs")).toEqual([
+      `k-remote${US}e-remote`,
+    ]);
+  });
+
+  test("capture: a relation syncs only when BOTH endpoints are syncable", () => {
+    insertProject("p-remote", "R");
+    insertProject("p-local", null);
+    enableSync("basic");
+    insertEntity("e1", "p-remote");
+    insertEntity("e2", "p-remote");
+    insertEntity("e3", "p-local"); // remote-less endpoint
+    insertEntity("e-global", "p-local", 1); // cross_project=1 → always syncable
+    db().exec("DELETE FROM sync_outbox");
+    insertRelation("r-both", "e1", "e2"); // both remote-backed → syncs
+    insertRelation("r-global", "e1", "e-global"); // remote-backed + global → syncs
+    insertRelation("r-mixed", "e1", "e3"); // one remote-less → does NOT sync
+    expect(outboxRowIds("entity_relations").sort()).toEqual([
+      "r-both",
+      "r-global",
+    ]);
+  });
+
+  test("capture: children of a GLOBAL parent always sync (even under a remote-less project)", () => {
+    insertProject("p-local", null);
+    enableSync("basic");
+    insertKnowledge("k-cross", "p-local", 1); // cross_project=1
+    insertEntity("e-cross", "p-local", 1);
+    db().exec("DELETE FROM sync_outbox");
+    insertMeta("k-cross");
+    insertAlias("a-cross", "e-cross");
+    expect(outboxRowIds("knowledge_meta")).toEqual(["k-cross"]);
+    expect(outboxRowIds("entity_aliases")).toEqual(["a-cross"]);
+  });
+
+  test("seed: children are gated by parent syncability on enable", () => {
+    insertProject("p-remote", "R");
+    insertProject("p-local", null);
+    insertKnowledge("k-remote", "p-remote");
+    insertKnowledge("k-local", "p-local");
+    insertEntity("e-remote", "p-remote");
+    insertEntity("e-local", "p-local");
+    insertMeta("k-remote");
+    insertMeta("k-local"); // gated out (parent remote-less)
+    insertAlias("a-remote", "e-remote");
+    insertAlias("a-local", "e-local"); // gated out
+    insertRef("k-remote", "e-remote");
+    insertRef("k-local", "e-local"); // gated out
+    enableSync("basic"); // reconcile → seedOutbox
+    expect(outboxRowIds("knowledge_meta")).toEqual(["k-remote"]);
+    expect(outboxRowIds("entity_aliases")).toEqual(["a-remote"]);
+    expect(outboxRowIds("knowledge_entity_refs")).toEqual([
+      `k-remote${US}e-remote`,
+    ]);
+  });
+
+  test("reseedProjectContent: re-enqueues the children after the project gains a remote", () => {
+    insertProject("p", null);
+    enableSync("basic");
+    insertKnowledge("k1", "p");
+    insertEntity("e1", "p");
+    insertEntity("e2", "p");
+    insertMeta("k1");
+    insertMetaCrdt("k1");
+    insertAlias("a1", "e1");
+    insertRelation("r1", "e1", "e2");
+    insertRef("k1", "e1");
+    // All gated out while remote-less.
+    for (const t of [
+      "knowledge_meta",
+      "knowledge_meta_crdt",
+      "entity_aliases",
+      "entity_relations",
+      "knowledge_entity_refs",
+    ])
+      expect(outboxRowIds(t)).toEqual([]);
+    // The project gains a remote → the children are re-enqueued.
+    db().query("UPDATE projects SET git_remote='R' WHERE id='p'").run();
+    reseedProjectContent("p");
+    expect(outboxRowIds("knowledge_meta")).toEqual(["k1"]);
+    expect(outboxRowIds("knowledge_meta_crdt")).toEqual([`k1${US}rA`]);
+    expect(outboxRowIds("entity_aliases")).toEqual(["a1"]);
+    expect(outboxRowIds("entity_relations")).toEqual(["r1"]);
+    expect(outboxRowIds("knowledge_entity_refs")).toEqual([`k1${US}e1`]);
   });
 });

--- a/packages/gateway/test/sync-engine.integration.test.ts
+++ b/packages/gateway/test/sync-engine.integration.test.ts
@@ -212,7 +212,7 @@ describe.skipIf(SKIP)("sync engine ↔ real Postgres/PostgREST", () => {
     insertKnowledge("k1", "x");
     db()
       .query(
-        "INSERT INTO entities (id, project_id, entity_type, canonical_name, created_at, updated_at) VALUES ('e1','p','tool','X',?,?)",
+        "INSERT INTO entities (id, project_id, entity_type, canonical_name, cross_project, created_at, updated_at) VALUES ('e1',NULL,'tool','X',1,?,?)",
       )
       .run(Date.now(), Date.now());
     syncData.enableSync("basic");
@@ -237,7 +237,7 @@ describe.skipIf(SKIP)("sync engine ↔ real Postgres/PostgREST", () => {
     insertKnowledge("k1", "x");
     db()
       .query(
-        "INSERT INTO entities (id, project_id, entity_type, canonical_name, created_at, updated_at) VALUES ('e1','p','tool','X',?,?)",
+        "INSERT INTO entities (id, project_id, entity_type, canonical_name, cross_project, created_at, updated_at) VALUES ('e1',NULL,'tool','X',1,?,?)",
       )
       .run(Date.now(), Date.now());
     syncData.enableSync("basic");
@@ -288,6 +288,7 @@ describe.skipIf(SKIP)("sync engine ↔ real Postgres/PostgREST", () => {
     // reinforce() records a PN-counter delta. Both must push cleanly through
     // supabase-js → PostgREST → Postgres (no 22008 timestamp / PGRST204 phantom-
     // column errors the docstring warns about), landing with the right values.
+    ensureProject("/tmp/lore-engine-it"); // remote-backed → content passes the P2 gate
     syncData.enableSync("basic");
     const id = ltm.create({
       projectPath: "/tmp/lore-engine-it",

--- a/packages/gateway/test/sync.test.ts
+++ b/packages/gateway/test/sync.test.ts
@@ -1754,6 +1754,7 @@ describe("syncOnce", () => {
 describe("knowledge_meta register sync (A2 3b-2)", () => {
   test("pushOnce uploads the base register row AND the CRDT counters", async () => {
     syncData.enableSync("basic");
+    insertKnowledge("k1", "body"); // parent knowledge (remote-backed) → meta passes the P2b gate
     // Capture triggers fire on these local writes (sync enabled) → outbox.
     db()
       .query(


### PR DESCRIPTION
Extends **P2a** (#1251) from the direct-`project_id` tables to the **CHILDREN** that have no `project_id` of their own — they sync iff their **parent** knowledge/entity is itself syncable (remote-backed OR global/cross-project). Closes the remaining privacy/efficiency gap: a remote-less project's confidence register, entity aliases, relations, and refs no longer upload.

## Changes
- **Capture** (`db.ts installSyncCapture`): new `knowledgeParentGate`/`entityParentGate` builders (reuse `directGate`). Gate **INSERT/UPDATE** of `knowledge_meta`, `knowledge_meta_crdt` (parent knowledge via logical_id), `entity_aliases` (parent entity), `entity_relations` (**both** endpoints), `knowledge_entity_refs` INSERT (**both** parents). **DELETE stays UNGATED** — a delete of a never-synced child pushes as an idempotent no-op, and gating it would depend on the parent still existing, but the parent (entity) is cascade-deleted FIRST (`ON DELETE CASCADE`), which would spuriously drop a legitimate delete of a *synced* child.
- **Seed** (`sync-data.ts`): mirror gates on the child seedSelects (`knowledge_meta` JOIN gains the git_remote condition; `entity_relations`/`entity_aliases`/`knowledge_entity_refs`/`knowledge_meta_crdt` get parent-gate WHEREs) via matching `knowledgeParentGate`/`entityParentGate` helpers — kept in lockstep with the triggers.
- **Re-seed on backfill**: `reseedProjectContent` extended to re-enqueue the project's children when it gains a remote — single-parent children keyed off the project's knowledge/entities; the two-parent children (relations, refs) additionally require the OTHER endpoint syncable.

## Tests
New `child content git_remote gate — P2b` describe (per-table capture gating, both-endpoints relation rule, global-parent exemption, seed gating, re-seed of all 5 child tables after backfill). Fixtures injecting metas/refs updated to have remote-backed parents. **Full suite 5554 + integration 106 green**, typecheck + lint clean.

P2 stack: P2a (#1251, merged) → **P2b (here)** → P2c (Pro fanout). Design in `.opencode/plans/project-identity-sync.md`.