### PR TITLE
feat(sync): gate Pro fanout (distillations + temporal) on git_remote (P2c, #1246)

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -2321,6 +2321,11 @@ function installSyncCapture(database: Database) {
     `EXISTS (SELECT 1 FROM knowledge k WHERE COALESCE(k.logical_id, k.id) = ${idExpr} AND ${directGate("k")})`;
   const entityParentGate = (idExpr: string) =>
     `EXISTS (SELECT 1 FROM entities e WHERE e.id = ${idExpr} AND ${directGate("e")})`;
+  // P2c (#1246): the Pro tables (distillations, temporal via the fanout) are ALWAYS
+  // project-scoped (project_id NOT NULL, no cross_project) — so they sync only when their
+  // project is remote-backed. No global/cross exemption applies.
+  const projectRemoteGate = (idExpr: string) =>
+    `EXISTS (SELECT 1 FROM projects p WHERE p.id = ${idExpr} AND p.git_remote IS NOT NULL)`;
   const ops = [
     ["INSERT", "ins", "new", "upsert"],
     ["UPDATE", "upd", "new", "upsert"],
@@ -2495,9 +2500,12 @@ function installSyncCapture(database: Database) {
     // is deduped away by the push-side content_hash check). No DELETE: the local prune
     // is sync-invisible (temporal.prune runs under capture-suppression + clears
     // sync_state), so a pruned local row must NOT tombstone the remote backup.
+    // P2c (#1246): gate on the distillation's project git_remote — gating the INSERT
+    // trigger's WHEN gates BOTH the distillation row AND the temporal fanout in one shot,
+    // so a remote-less project's compressed memory + its referenced messages never upload.
     sql += `
       CREATE TEMP TRIGGER IF NOT EXISTS distillations_outbox_ins
-      AFTER INSERT ON distillations WHEN (${gate})
+      AFTER INSERT ON distillations WHEN (${gate} AND ${projectRemoteGate("new.project_id")})
       BEGIN
         INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
         VALUES ('distillations', new.id, 'upsert', ${ts});
@@ -2505,7 +2513,7 @@ function installSyncCapture(database: Database) {
         SELECT 'temporal_messages', value, 'upsert', ${ts} FROM json_each(new.source_ids);
       END;
       CREATE TEMP TRIGGER IF NOT EXISTS distillations_outbox_upd
-      AFTER UPDATE ON distillations WHEN (${gate})
+      AFTER UPDATE ON distillations WHEN (${gate} AND ${projectRemoteGate("new.project_id")})
       BEGIN
         INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
         VALUES ('distillations', new.id, 'upsert', ${ts});

--- a/packages/core/src/sync-data.ts
+++ b/packages/core/src/sync-data.ts
@@ -815,6 +815,11 @@ function knowledgeParentGate(idExpr: string): string {
 function entityParentGate(idExpr: string): string {
   return `EXISTS (SELECT 1 FROM entities e WHERE e.id = ${idExpr} AND ${remoteBackedGate("e.")})`;
 }
+// P2c (#1246): the Pro tables are always project-scoped (project_id NOT NULL, no
+// cross_project) — they sync only when their project is remote-backed.
+function projectRemoteGate(idExpr: string): string {
+  return `EXISTS (SELECT 1 FROM projects p WHERE p.id = ${idExpr} AND p.git_remote IS NOT NULL)`;
+}
 
 function seedSelect(table: string): string {
   switch (table) {
@@ -871,7 +876,9 @@ function seedSelect(table: string): string {
     // D (#826): the compressed-memory backup. Recency order so the newest memory
     // survives the (generous, rarely-binding) pro cap.
     case "distillations":
-      return "SELECT * FROM distillations ORDER BY created_at DESC, id";
+      return `SELECT * FROM distillations
+               WHERE ${projectRemoteGate("project_id")}
+               ORDER BY created_at DESC, id`;
     // D (#826): 🔴 ONLY the distillation-REFERENCED subset ever syncs — an
     // undistilled message must NEVER be enqueued. Restrict to ids present in some
     // distillation's source_ids (json_each), mirroring the fanout capture trigger.
@@ -880,10 +887,12 @@ function seedSelect(table: string): string {
       // json_valid guard: a single corrupt source_ids must not throw and abort the
       // whole seed transaction (source_ids is always JSON.stringify'd, so this is
       // belt-and-suspenders; filter BEFORE json_each so the bad row is skipped).
+      // P2c (#1246): only the referenced subset of REMOTE-BACKED distillations.
       return `SELECT t.* FROM temporal_messages t
                 WHERE t.id IN (
                   SELECT value FROM
-                    (SELECT source_ids FROM distillations WHERE json_valid(source_ids)) d,
+                    (SELECT source_ids FROM distillations
+                      WHERE json_valid(source_ids) AND ${projectRemoteGate("project_id")}) d,
                     json_each(d.source_ids)
                 )
                ORDER BY t.created_at DESC, t.id`;
@@ -1126,6 +1135,26 @@ export function reseedProjectContent(projectId: string): void {
     projectId,
     projectId,
   );
+  // P2c: the Pro tables (distillations + their referenced temporal subset) — ONLY when the
+  // current tier syncs them, else the enqueued rows would be un-pushable orphans that pin
+  // the prune floor. distillations are always project-scoped, so all of this project's
+  // distillations qualify once it is remote-backed; the fanout mirrors the capture trigger.
+  if (
+    syncedTablesFor(currentSyncTier()).some((m) => m.table === "distillations")
+  ) {
+    enqueue(
+      "SELECT 'distillations', id, 'upsert', ? FROM distillations WHERE project_id = ?",
+      now,
+      projectId,
+    );
+    enqueue(
+      `SELECT 'temporal_messages', value, 'upsert', ? FROM
+         (SELECT source_ids FROM distillations WHERE project_id = ? AND json_valid(source_ids)) d,
+         json_each(d.source_ids)`,
+      now,
+      projectId,
+    );
+  }
 }
 onProjectRemoteBackfilled(reseedProjectContent);
 

--- a/packages/core/test/sync-pro-tables.test.ts
+++ b/packages/core/test/sync-pro-tables.test.ts
@@ -80,6 +80,13 @@ const rowIds = (table: string, op?: string) =>
 beforeEach(() => {
   const pid = ensureProject(PROJECT);
   deleteTeamConfig("sync.enabled");
+  // P2c (#1246): remote-backed → Pro content passes the git_remote gate. Set while sync is
+  // OFF (line above) so it fires no capture; every Pro test uses this same PROJECT.
+  db()
+    .query(
+      "UPDATE projects SET git_remote = 'test:remote' WHERE id = ? AND git_remote IS NULL",
+    )
+    .run(pid);
   db().exec("DELETE FROM temp._sync_applying");
   db().exec("DELETE FROM sync_outbox");
   db().exec("DELETE FROM sync_state");

--- a/packages/core/test/sync-projects.test.ts
+++ b/packages/core/test/sync-projects.test.ts
@@ -114,8 +114,15 @@ beforeEach(() => {
   db().exec("DELETE FROM temp._sync_applying");
   db().exec("DELETE FROM sync_outbox");
   db().exec("DELETE FROM sync_state");
-  db().exec("DELETE FROM knowledge");
+  // Children first (FK to entities/projects), then parents.
+  db().exec("DELETE FROM knowledge_entity_refs");
+  db().exec("DELETE FROM entity_aliases");
+  db().exec("DELETE FROM entity_relations");
+  db().exec("DELETE FROM knowledge_meta_crdt");
   db().exec("DELETE FROM knowledge_meta");
+  db().exec("DELETE FROM temporal_messages");
+  db().exec("DELETE FROM distillations");
+  db().exec("DELETE FROM knowledge");
   db().exec("DELETE FROM entities");
   db().exec("DELETE FROM profiles");
   db().exec(
@@ -422,5 +429,90 @@ describe("child content git_remote gate — P2b (#1246)", () => {
     expect(outboxRowIds("entity_aliases")).toEqual(["a1"]);
     expect(outboxRowIds("entity_relations")).toEqual(["r1"]);
     expect(outboxRowIds("knowledge_entity_refs")).toEqual([`k1${US}e1`]);
+  });
+});
+
+describe("Pro fanout git_remote gate — P2c (#1246)", () => {
+  function armPro() {
+    db()
+      .query(
+        "INSERT OR REPLACE INTO profiles (id, tier, created_at, updated_at) VALUES ('u','pro',?,?)",
+      )
+      .run(now(), now());
+    reinstallSyncCapture(); // arm the tier-gated distillation-fanout trigger
+  }
+  function insertTemporal(id: string, projectId: string) {
+    db()
+      .query(
+        `INSERT INTO temporal_messages (id, project_id, session_id, role, content, tokens, distilled, created_at, metadata)
+         VALUES (?, ?, 's', 'user', 'x', 1, 1, ?, '{}')`,
+      )
+      .run(id, projectId, now());
+  }
+  function insertDistillation(
+    id: string,
+    projectId: string,
+    sourceIds: string[],
+  ) {
+    db()
+      .query(
+        `INSERT INTO distillations (id, project_id, session_id, narrative, facts, observations, source_ids, generation, token_count, created_at, archived)
+         VALUES (?, ?, 's', 'n', 'f', 'o', ?, 0, 0, ?, 0)`,
+      )
+      .run(id, projectId, JSON.stringify(sourceIds), now());
+  }
+
+  test("capture: a distillation in a remote-backed project enqueues it + its temporal subset; a remote-less one syncs neither", () => {
+    insertProject("p-remote", "R");
+    insertProject("p-local", null);
+    insertTemporal("t-remote", "p-remote");
+    insertTemporal("t-local", "p-local");
+    armPro();
+    enableSync("pro");
+    db().exec("DELETE FROM sync_outbox");
+    insertDistillation("d-remote", "p-remote", ["t-remote"]);
+    insertDistillation("d-local", "p-local", ["t-local"]);
+    expect(outboxRowIds("distillations")).toEqual(["d-remote"]);
+    expect(outboxRowIds("temporal_messages")).toEqual(["t-remote"]);
+  });
+
+  test("seed: only remote-backed distillations + their temporal are seeded on enable", () => {
+    insertProject("p-remote", "R");
+    insertProject("p-local", null);
+    insertTemporal("t-remote", "p-remote");
+    insertTemporal("t-local", "p-local");
+    insertDistillation("d-remote", "p-remote", ["t-remote"]);
+    insertDistillation("d-local", "p-local", ["t-local"]); // gated out
+    armPro();
+    enableSync("pro"); // reconcile → seedOutbox
+    expect(outboxRowIds("distillations")).toEqual(["d-remote"]);
+    expect(outboxRowIds("temporal_messages")).toEqual(["t-remote"]);
+  });
+
+  test("reseedProjectContent (pro tier): re-enqueues distillations + temporal after the project gains a remote", () => {
+    insertProject("p", null);
+    insertTemporal("t1", "p");
+    armPro();
+    enableSync("pro");
+    insertDistillation("d1", "p", ["t1"]); // gated out (project remote-less)
+    expect(outboxRowIds("distillations")).toEqual([]);
+    expect(outboxRowIds("temporal_messages")).toEqual([]);
+    db().query("UPDATE projects SET git_remote='R' WHERE id='p'").run();
+    reseedProjectContent("p");
+    expect(outboxRowIds("distillations")).toEqual(["d1"]);
+    expect(outboxRowIds("temporal_messages")).toEqual(["t1"]);
+  });
+
+  test("reseedProjectContent (basic tier): does NOT enqueue Pro tables", () => {
+    insertProject("p", null);
+    insertTemporal("t1", "p");
+    // basic tier (no profiles/pro): the fanout trigger isn't armed and pro tables aren't synced.
+    enableSync("basic");
+    // A distillation written under basic never captures; simulate a pre-existing one.
+    insertDistillation("d1", "p", ["t1"]);
+    db().query("UPDATE projects SET git_remote='R' WHERE id='p'").run();
+    reseedProjectContent("p");
+    expect(outboxRowIds("distillations")).toEqual([]); // pro table, basic tier → not enqueued
+    expect(outboxRowIds("temporal_messages")).toEqual([]);
   });
 });


### PR DESCRIPTION
Completes the **P2** stack: the Pro-tier backup tables now honor the git_remote gate too, so a remote-less project's compressed memory (`distillations`) and its referenced raw messages (`temporal_messages`) never upload. These tables have `project_id NOT NULL` with **no `cross_project`** column, so they are always project-scoped — the gate is a plain git_remote check (no global/cross exemption). This also removes the last FK-poison vector: `distillations` + `temporal_messages` FK `projects(id)`, so a remote-less project's rows would poison-drop on a peer.

## Changes
- **Capture** (`db.ts`): new `projectRemoteGate` builder. Gating the distillation **INSERT** trigger's WHEN gates **both** the distillation row **and** the temporal fanout (`json_each`) in one shot; the archived-flip **UPDATE** trigger gets the same gate. Still tier-gated (installed only for pro/max).
- **Seed** (`sync-data.ts`): the `distillations` seedSelect and the `temporal_messages` subset-select (json_each over referenced distillations) gain the matching `projectRemoteGate`.
- **Re-seed on backfill**: `reseedProjectContent` re-enqueues the project's distillations + their referenced temporal when it gains a remote — but **only** when the current tier syncs those tables (else the rows would be un-pushable orphans pinning the prune floor).

## Tests
New `Pro fanout git_remote gate — P2c` describe: capture gates distillation + temporal by project remote; seed gating; reseed re-enqueues on backfill under **pro**; reseed does **not** enqueue Pro tables under **basic** tier. `sync-pro-tables` fixtures stamp git_remote in beforeEach. **Full suite 5558 + integration 106 green**, typecheck + lint clean.

**P2 complete**: P2a #1251 (knowledge+entities) → P2b #1252 (children) → **P2c (Pro fanout)**. Design in `.opencode/plans/project-identity-sync.md`.