### PR TITLE
fix(sync): dedupe reseed of temporal referenced by multiple distillations (#1253)

### DIFF
--- a/packages/core/src/sync-data.ts
+++ b/packages/core/src/sync-data.ts
@@ -1148,7 +1148,9 @@ export function reseedProjectContent(projectId: string): void {
       projectId,
     );
     enqueue(
-      `SELECT 'temporal_messages', value, 'upsert', ? FROM
+      // DISTINCT: a temporal id referenced by MULTIPLE distillations appears once per
+      // distillation in the json_each expansion — dedupe so it enqueues a single upsert.
+      `SELECT DISTINCT 'temporal_messages', value, 'upsert', ? FROM
          (SELECT source_ids FROM distillations WHERE project_id = ? AND json_valid(source_ids)) d,
          json_each(d.source_ids)`,
       now,

--- a/packages/core/test/sync-projects.test.ts
+++ b/packages/core/test/sync-projects.test.ts
@@ -503,6 +503,18 @@ describe("Pro fanout git_remote gate — P2c (#1246)", () => {
     expect(outboxRowIds("temporal_messages")).toEqual(["t1"]);
   });
 
+  test("reseedProjectContent: dedupes a temporal referenced by multiple distillations (#1253)", () => {
+    insertProject("p", null);
+    insertTemporal("t1", "p");
+    armPro();
+    enableSync("pro");
+    insertDistillation("d1", "p", ["t1"]);
+    insertDistillation("d2", "p", ["t1"]); // SAME t1 referenced by both
+    db().query("UPDATE projects SET git_remote='R' WHERE id='p'").run();
+    reseedProjectContent("p");
+    expect(outboxRowIds("temporal_messages")).toEqual(["t1"]); // once, not twice
+  });
+
   test("reseedProjectContent (basic tier): does NOT enqueue Pro tables", () => {
     insertProject("p", null);
     insertTemporal("t1", "p");


### PR DESCRIPTION
Sentry follow-up to #1253 (P2c). `reseedProjectContent`'s temporal re-enqueue expands `json_each(source_ids)` over **all** of a project's distillations, so a `temporal_messages` id referenced by more than one distillation was enqueued **once per referencing distillation** — redundant (idempotent no-op) upserts. Add `SELECT DISTINCT` so it enqueues a single upsert.

(The steady-state `seedSelect` already dedupes via `t.id IN (...)`; only the reseed's direct `json_each` SELECT could duplicate.)

Regression test: a temporal referenced by two distillations reseeds exactly once — fails without `DISTINCT`. 24/24 in sync-projects, typecheck + lint clean.