### PR TITLE
fix(sync): belt-and-suspenders gate on the temporal row's own project (#826)

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -2503,6 +2503,11 @@ function installSyncCapture(database: Database) {
     // P2c (#1246): gate on the distillation's project git_remote — gating the INSERT
     // trigger's WHEN gates BOTH the distillation row AND the temporal fanout in one shot,
     // so a remote-less project's compressed memory + its referenced messages never upload.
+    // Belt-and-suspenders (#826): the fanout ALSO re-checks each fanned-out temporal's OWN
+    // project git_remote. Normally redundant (a distillation's source_ids reference
+    // messages in the same session⇒same project as the distillation), but should that
+    // invariant ever break, a cross-project source id pointing at a remote-less project's
+    // message would otherwise upload it and FK-poison a peer (temporal FKs projects).
     sql += `
       CREATE TEMP TRIGGER IF NOT EXISTS distillations_outbox_ins
       AFTER INSERT ON distillations WHEN (${gate} AND ${projectRemoteGate("new.project_id")})
@@ -2510,7 +2515,9 @@ function installSyncCapture(database: Database) {
         INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
         VALUES ('distillations', new.id, 'upsert', ${ts});
         INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
-        SELECT 'temporal_messages', value, 'upsert', ${ts} FROM json_each(new.source_ids);
+        SELECT 'temporal_messages', value, 'upsert', ${ts} FROM json_each(new.source_ids)
+         WHERE EXISTS (SELECT 1 FROM temporal_messages t
+                        WHERE t.id = value AND ${projectRemoteGate("t.project_id")});
       END;
       CREATE TEMP TRIGGER IF NOT EXISTS distillations_outbox_upd
       AFTER UPDATE ON distillations WHEN (${gate} AND ${projectRemoteGate("new.project_id")})

--- a/packages/core/src/sync-data.ts
+++ b/packages/core/src/sync-data.ts
@@ -887,7 +887,11 @@ function seedSelect(table: string): string {
       // json_valid guard: a single corrupt source_ids must not throw and abort the
       // whole seed transaction (source_ids is always JSON.stringify'd, so this is
       // belt-and-suspenders; filter BEFORE json_each so the bad row is skipped).
-      // P2c (#1246): only the referenced subset of REMOTE-BACKED distillations.
+      // P2c (#1246): only the referenced subset of REMOTE-BACKED distillations. The
+      // trailing `${projectRemoteGate("t.project_id")}` is a belt-and-suspenders (#826):
+      // it re-checks the temporal's OWN project so a cross-project source id (should the
+      // session⇒one-project invariant ever break) can't seed a remote-less project's
+      // message and FK-poison a peer. Mirrors the fanout capture gate.
       return `SELECT t.* FROM temporal_messages t
                 WHERE t.id IN (
                   SELECT value FROM
@@ -895,6 +899,7 @@ function seedSelect(table: string): string {
                       WHERE json_valid(source_ids) AND ${projectRemoteGate("project_id")}) d,
                     json_each(d.source_ids)
                 )
+                  AND ${projectRemoteGate("t.project_id")}
                ORDER BY t.created_at DESC, t.id`;
     // #1246: only remote-backed projects sync — a remote-less project's random id can't
     // correlate cross-device (its content would FK-poison on a peer), so it stays local.
@@ -1150,9 +1155,12 @@ export function reseedProjectContent(projectId: string): void {
     enqueue(
       // DISTINCT: a temporal id referenced by MULTIPLE distillations appears once per
       // distillation in the json_each expansion — dedupe so it enqueues a single upsert.
+      // The EXISTS is the same belt-and-suspenders own-project gate as capture/seed (#826).
       `SELECT DISTINCT 'temporal_messages', value, 'upsert', ? FROM
          (SELECT source_ids FROM distillations WHERE project_id = ? AND json_valid(source_ids)) d,
-         json_each(d.source_ids)`,
+         json_each(d.source_ids)
+        WHERE EXISTS (SELECT 1 FROM temporal_messages t
+                       WHERE t.id = value AND ${projectRemoteGate("t.project_id")})`,
       now,
       projectId,
     );

--- a/packages/core/test/sync-projects.test.ts
+++ b/packages/core/test/sync-projects.test.ts
@@ -503,6 +503,32 @@ describe("Pro fanout git_remote gate — P2c (#1246)", () => {
     expect(outboxRowIds("temporal_messages")).toEqual(["t1"]);
   });
 
+  test("capture belt-and-suspenders: a foreign remote-less temporal referenced by a remote-backed distillation is NOT fanned out (#826)", () => {
+    insertProject("p-remote", "R");
+    insertProject("p-local", null);
+    insertTemporal("t-same", "p-remote");
+    insertTemporal("t-foreign", "p-local"); // lives in a remote-less project
+    armPro();
+    enableSync("pro");
+    db().exec("DELETE FROM sync_outbox");
+    // Invariant-violating: a remote-backed project's distillation referencing a foreign
+    // remote-less project's temporal. The distillation syncs; the foreign temporal must not.
+    insertDistillation("d1", "p-remote", ["t-same", "t-foreign"]);
+    expect(outboxRowIds("distillations")).toEqual(["d1"]);
+    expect(outboxRowIds("temporal_messages")).toEqual(["t-same"]);
+  });
+
+  test("seed belt-and-suspenders: a foreign remote-less temporal is not seeded (#826)", () => {
+    insertProject("p-remote", "R");
+    insertProject("p-local", null);
+    insertTemporal("t-same", "p-remote");
+    insertTemporal("t-foreign", "p-local");
+    insertDistillation("d1", "p-remote", ["t-same", "t-foreign"]);
+    armPro();
+    enableSync("pro"); // reconcile → seedOutbox
+    expect(outboxRowIds("temporal_messages")).toEqual(["t-same"]);
+  });
+
   test("reseedProjectContent: dedupes a temporal referenced by multiple distillations (#1253)", () => {
     insertProject("p", null);
     insertTemporal("t1", "p");


### PR DESCRIPTION
Follow-up to **P2c** (#1253 review concern **C1**). The distillation fanout + `temporal_messages` seedSelect gate on the **distillation's** project git_remote, relying on the session⇒one-project invariant (a distillation's `source_ids` reference messages in the same project). This adds a defensive gate on each fanned-out temporal's **own** project too: should that invariant ever break, a cross-project source id pointing at a remote-less project's message would otherwise upload it and **FK-poison** a peer (`temporal_messages` FKs `projects(id)`).

## Changes
- **Capture fanout** (`db.ts`): `WHERE EXISTS (temporal_messages t WHERE t.id = value AND projectRemoteGate(t.project_id))` on the `json_each` SELECT.
- **Seed** (`sync-data.ts`): `AND projectRemoteGate("t.project_id")` on the temporal seedSelect.
- **Reseed** (`sync-data.ts`): the same EXISTS gate on the temporal re-enqueue.

Normally a **no-op** (the temporal is in the same project as the already-gated distillation); protective only under an invariant violation.

## Tests
Capture + seed "belt-and-suspenders" cases: a remote-backed distillation referencing a *foreign remote-less* project's temporal syncs the distillation but **not** the foreign temporal. **Mutation-verified** (removing the gate → both temporals enqueue → test fails). Full suite **5561 + integration 106** green, typecheck + lint clean.