### PR TITLE
feat(supabase): identity_pub directory + member-aware scope_keys RLS (E-3a, #827)

### DIFF
--- a/packages/gateway/test/sync-identity-scopekeys.integration.test.ts
+++ b/packages/gateway/test/sync-identity-scopekeys.integration.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Integration tests for migration 0025 — identity_pub directory + member-aware scope_keys RLS
+ * (E-3, #827) against a real Postgres. Proves:
+ *  - identity_pub: publish/rotate OWN pubkey only; read own + co-members' (never a global
+ *    directory) — discriminated by a scope_members row flipping shares_scope();
+ *  - identity_pub size cap;
+ *  - scope_keys: a MEMBER reads only their own wrap; only a scope ADMIN may write wraps
+ *    (group wrapping) — an editor/non-member is rejected;
+ *  - behavior-preserving for a personal scope (owner reads/writes own self-wrap as before).
+ *
+ * Gated behind LORE_INTEGRATION=1 (needs Docker). Run:
+ *   LORE_INTEGRATION=1 pnpm exec vitest run packages/gateway/test/sync-identity-scopekeys.integration.test.ts
+ */
+import { execFileSync } from "node:child_process";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { type PgHarness, startPgHarness } from "./helpers/pg-harness";
+
+function dockerReady(): boolean {
+  try {
+    execFileSync("docker", ["info"], { stdio: "ignore", timeout: 10_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const RUN = process.env.LORE_INTEGRATION === "1";
+const SKIP = !RUN
+  ? "LORE_INTEGRATION!=1"
+  : !dockerReady()
+    ? "docker unavailable"
+    : false;
+
+let h: PgHarness;
+beforeAll(async () => {
+  if (!SKIP) h = await startPgHarness();
+}, 180_000);
+afterAll(async () => {
+  if (h) await h.stop();
+});
+const gate = () => SKIP;
+
+async function expectError(fn: () => Promise<unknown>): Promise<{
+  code?: string;
+  message: string;
+}> {
+  try {
+    await fn();
+  } catch (e) {
+    return {
+      code: (e as { code?: string }).code,
+      message: (e as Error).message,
+    };
+  }
+  throw new Error("expected the query to fail, but it succeeded");
+}
+
+const pubkey = (b: number) => Buffer.alloc(b, 7); // deterministic bytea of length b
+const publishPub = (uid: string, bytes = 32) =>
+  h.asUser(uid, (c) =>
+    c.query("insert into public.identity_pub (public_key) values ($1)", [
+      pubkey(bytes),
+    ]),
+  );
+// member reads via RLS how many identity_pub rows for a given target user.
+const canReadPub = (viewer: string, target: string) =>
+  h.asUser(viewer, (c) =>
+    c
+      .query("select 1 from public.identity_pub where user_id=$1", [target])
+      .then((r) => r.rowCount),
+  );
+const addMember = (scope: string, user: string, role: string) =>
+  h.client.query(
+    "insert into public.scope_members (scope_id, user_id, role) values ($1,$2,$3)",
+    [scope, user, role],
+  );
+
+describe.skipIf(gate())(
+  "0025 identity_pub + member-aware scope_keys RLS (E-3, #827)",
+  () => {
+    it("identity_pub: a user publishes their own pubkey; cannot write another user's", async () => {
+      const a = await h.createUser();
+      const b = await h.createUser();
+      await publishPub(a); // own row (user_id defaults to auth.uid())
+      expect(await canReadPub(a, a)).toBe(1);
+      // forging another user's row is rejected by RLS WITH CHECK user_id = auth.uid().
+      const err = await expectError(() =>
+        h.asUser(a, (c) =>
+          c.query(
+            "insert into public.identity_pub (user_id, public_key) values ($1,$2)",
+            [b, pubkey(32)],
+          ),
+        ),
+      );
+      expect(err.code).toBe("42501");
+    });
+
+    it("identity_pub read: co-membership grants pubkey visibility (discriminates shares_scope)", async () => {
+      const a = await h.createUser();
+      const b = await h.createUser();
+      await publishPub(a);
+      expect(await canReadPub(b, a)).toBe(0); // not sharing a scope → invisible (no global directory)
+      await addMember(a, b, "editor"); // now B co-inhabits A's scope
+      expect(await canReadPub(b, a)).toBe(1); // B can now read A's pubkey (to be wrapped to)
+    });
+
+    it("identity_pub: an oversized public key is rejected (anti-abuse cap)", async () => {
+      const a = await h.createUser();
+      const err = await expectError(() => publishPub(a, 257));
+      expect(err.code).toBe("23514"); // check_violation
+    });
+
+    it("scope_keys: a member reads only their OWN wrap", async () => {
+      const a = await h.createUser();
+      const b = await h.createUser();
+      await addMember(a, b, "editor");
+      // A (admin of own scope) writes its own self-wrap AND a wrap for B.
+      await h.asUser(a, (c) =>
+        c.query(
+          "insert into public.scope_keys (member_user_id, wrapped_dek) values ($1,'wa')",
+          [a],
+        ),
+      );
+      await h.asUser(a, (c) =>
+        c.query(
+          "insert into public.scope_keys (scope_id, author_id, member_user_id, wrapped_dek) values ($1,$1,$2,'wb')",
+          [a, b],
+        ),
+      );
+      // A sees only its own wrap (member_user_id = A), not B's.
+      const seenByA = await h.asUser(a, (c) =>
+        c
+          .query("select member_user_id from public.scope_keys")
+          .then((r) => r.rows.map((x) => x.member_user_id)),
+      );
+      expect(seenByA).toEqual([a]);
+      // B sees only its own wrap (member_user_id = B).
+      const seenByB = await h.asUser(b, (c) =>
+        c
+          .query("select member_user_id from public.scope_keys")
+          .then((r) => r.rows.map((x) => x.member_user_id)),
+      );
+      expect(seenByB).toEqual([b]);
+    });
+
+    it("scope_keys: only a scope admin may write wraps (editor + non-member rejected)", async () => {
+      const a = await h.createUser();
+      const b = await h.createUser();
+      const c = await h.createUser();
+      await addMember(a, b, "editor");
+      // editor B cannot write a wrap in A's scope (scope_role != 'admin').
+      const editorErr = await expectError(() =>
+        h.asUser(b, (cl) =>
+          cl.query(
+            "insert into public.scope_keys (scope_id, author_id, member_user_id, wrapped_dek) values ($1,$2,$3,'x')",
+            [a, b, b],
+          ),
+        ),
+      );
+      expect(editorErr.code).toBe("42501");
+      // non-member C cannot write a wrap in A's scope either.
+      const nonMemberErr = await expectError(() =>
+        h.asUser(c, (cl) =>
+          cl.query(
+            "insert into public.scope_keys (scope_id, author_id, member_user_id, wrapped_dek) values ($1,$2,$3,'x')",
+            [a, c, c],
+          ),
+        ),
+      );
+      expect(nonMemberErr.code).toBe("42501");
+      // admin A can (behavior-preserving: owner writes own scope's wraps).
+      await h.asUser(a, (cl) =>
+        cl.query(
+          "insert into public.scope_keys (member_user_id, wrapped_dek) values ($1,'ok')",
+          [a],
+        ),
+      );
+      const n = await h.asUser(a, (cl) =>
+        cl.query("select 1 from public.scope_keys").then((r) => r.rowCount),
+      );
+      expect(n).toBe(1);
+    });
+
+    it("scope_keys: an editor member cannot DELETE a wrap (delete gated to admin)", async () => {
+      const a = await h.createUser();
+      const b = await h.createUser();
+      await addMember(a, b, "editor");
+      await h.asUser(a, (cl) =>
+        cl.query(
+          "insert into public.scope_keys (member_user_id, wrapped_dek) values ($1,'w')",
+          [a],
+        ),
+      );
+      // editor B's DELETE matches no row under its USING (scope_role != 'admin') → no-op, wrap survives.
+      await h.asUser(b, (cl) =>
+        cl.query("delete from public.scope_keys where scope_id=$1", [a]),
+      );
+      const survived = await h.asUser(a, (cl) =>
+        cl.query("select 1 from public.scope_keys").then((r) => r.rowCount),
+      );
+      expect(survived).toBe(1);
+    });
+
+    it("identity_pub: a user cannot modify another user's pubkey row (update-forge is a no-op)", async () => {
+      const a = await h.createUser();
+      const b = await h.createUser();
+      await publishPub(a, 32); // A's key = 32 bytes of 0x07
+      await addMember(a, b, "editor"); // B can even READ A's key now, but still cannot write it
+      // B's UPDATE matches no row under the owner policy USING (user_id = auth.uid()) → no-op.
+      await h.asUser(b, (cl) =>
+        cl.query(
+          "update public.identity_pub set public_key=$1 where user_id=$2",
+          [Buffer.alloc(32, 9), a],
+        ),
+      );
+      const len = await h.client
+        .query(
+          "select octet_length(public_key) as l, public_key as k from public.identity_pub where user_id=$1",
+          [a],
+        )
+        .then((r) => r.rows[0]);
+      expect(len.l).toBe(32);
+      expect((len.k as Buffer)[0]).toBe(7); // unchanged (still A's original key, not B's 0x09)
+    });
+  },
+);

--- a/supabase/migrations/0025_identity_scope_keys_rls.sql
+++ b/supabase/migrations/0025_identity_scope_keys_rls.sql
@@ -1,0 +1,91 @@
+-- Migration 0025 — identity_pub directory + member-aware scope_keys RLS (E-3, #827).
+--
+-- WHY: group DEK wrapping needs (a) a place to look up a member's PUBLIC key so an admin can
+-- wrap the per-scope DEK to them, and (b) scope_keys RLS that lets a MEMBER read their own wrap
+-- (not just the scope owner) and an ADMIN write wraps for co-members. The identity PRIVATE key
+-- never leaves the device — only the public key is published here (client publish = E-3b).
+--
+-- BEHAVIOR-PRESERVING for personal scopes: is_member(personal,owner)=true and
+-- scope_role(personal,owner)='admin' (0023), and today member_user_id is always the owner's own
+-- id, so the split scope_keys policies are byte-identical to the old owner-only scope_all.
+-- identity_pub starts empty; shares_scope() is false for everyone until a shared (team) scope
+-- exists, so no global pubkey directory is exposed.
+
+-- ===========================================================================
+-- 1. shares_scope(other): do the caller and `other` co-inhabit ANY scope? SECURITY DEFINER
+--    (bypasses scope_members RLS → no recursion) with a pinned search_path.
+-- ===========================================================================
+create or replace function public.shares_scope(p_other uuid, p_uid uuid default auth.uid())
+returns boolean language sql stable security definer set search_path = pg_catalog, public
+as $$
+  select exists(
+    select 1
+      from public.scope_members a
+      join public.scope_members b on b.scope_id = a.scope_id
+     where a.user_id = p_uid and b.user_id = p_other);
+$$;
+grant execute on function public.shares_scope(uuid, uuid) to authenticated;
+
+-- ===========================================================================
+-- 2. identity_pub: one public key per user. Publish own (write self); read own + co-members'
+--    (so an admin can wrap the DEK to them). Public keys are not secret, but we still avoid a
+--    global directory — you only see the pubkeys of people you share a scope with.
+-- ===========================================================================
+create table if not exists public.identity_pub (
+  user_id    uuid primary key default auth.uid() references auth.users (id) on delete cascade,
+  public_key bytea not null,
+  updated_at timestamptz not null default now()
+);
+-- Anti-abuse: a real identity public key is tiny (X25519 = 32 bytes; leave HPKE headroom).
+alter table public.identity_pub drop constraint if exists identity_pub_size_ck;
+alter table public.identity_pub add constraint identity_pub_size_ck
+  check (octet_length(public_key) <= 256);
+
+create index if not exists idx_identity_pub_updated on public.identity_pub (updated_at);
+
+alter table public.identity_pub enable row level security;
+-- Full control of your OWN row (publish/rotate); this also covers select-own.
+drop policy if exists identity_pub_owner on public.identity_pub;
+create policy identity_pub_owner on public.identity_pub
+  for all using (user_id = auth.uid()) with check (user_id = auth.uid());
+-- Additionally READ the pubkeys of people you share a scope with (OR-ed with the owner policy).
+drop policy if exists identity_pub_read_comembers on public.identity_pub;
+create policy identity_pub_read_comembers on public.identity_pub
+  for select using (public.shares_scope(user_id));
+
+revoke all on public.identity_pub from anon, authenticated;
+grant select, insert, update on public.identity_pub to authenticated;
+
+drop trigger if exists identity_pub_set_updated_at on public.identity_pub;
+create trigger identity_pub_set_updated_at before update on public.identity_pub
+  for each row execute function public.sync_set_updated_at();
+
+-- ===========================================================================
+-- 3. scope_keys: owner-only scope_all → member-aware, split per verb.
+--    READ  — a member reads only THEIR OWN wrap (member_user_id = self) in scopes they belong to.
+--    WRITE — only a scope ADMIN may create/update/delete wraps (group wrapping + rotation);
+--            author still pinned to the writer. The 0012 first-write-wins guard still applies.
+-- ===========================================================================
+drop policy if exists scope_keys_scope_all on public.scope_keys;
+
+drop policy if exists scope_keys_read on public.scope_keys;
+create policy scope_keys_read on public.scope_keys
+  for select using (
+    public.is_member(scope_id) and member_user_id = auth.uid()::text
+  );
+
+drop policy if exists scope_keys_insert on public.scope_keys;
+create policy scope_keys_insert on public.scope_keys
+  for insert with check (
+    public.scope_role(scope_id) = 'admin' and author_id = auth.uid()
+  );
+
+drop policy if exists scope_keys_update on public.scope_keys;
+create policy scope_keys_update on public.scope_keys
+  for update
+  using (public.scope_role(scope_id) = 'admin')
+  with check (public.scope_role(scope_id) = 'admin' and author_id = auth.uid());
+
+drop policy if exists scope_keys_delete on public.scope_keys;
+create policy scope_keys_delete on public.scope_keys
+  for delete using (public.scope_role(scope_id) = 'admin');


### PR DESCRIPTION
Third slice of **E — teams & orgs** (#827), stacked on E-1 (#1256) + E-2 (#1257), both merged. Design: `.opencode/plans/sync-E-teams-orgs-impl.md`. This is the **remote half (E-3a)**; the client pubkey-publish is a stacked follow-up (E-3b).

## What
Crypto-directory groundwork for group DEK wrapping:

- **`identity_pub`** (`user_id` PK → auth.users, `public_key bytea`, `updated_at`) — the member public-key directory an admin uses to HPKE-wrap the per-scope DEK to co-members. The identity **private key never leaves the device**; only the public key is published (client publish = E-3b).
  - RLS: publish/rotate your **own** row only; **read own + co-members'** via a `shares_scope()` SECURITY DEFINER helper (no global pubkey directory — you only see people you share a scope with). 256-byte anti-abuse cap; `updated_at` trigger + cursor index; `user_id default auth.uid()`.
- **`scope_keys`** owner-only `scope_all` → **member-aware, split per verb**:
  - READ — a member reads only **their own** wrap: `is_member(scope_id) and member_user_id = auth.uid()::text`.
  - WRITE (insert/update/delete) — gated to `scope_role(scope_id)='admin'` (group wrapping + rotation), author pinned to writer. The 0012 first-write-wins guard still applies.

## Behavior-preserving
For a personal scope: `is_member(personal,owner)=true`, `scope_role='admin'`, and `member_user_id` is always the owner's own id — so the split `scope_keys` policies are byte-identical to the old owner-only `scope_all`. `identity_pub` starts empty and `shares_scope()` is false until a shared scope exists, so nothing is exposed.

## Verification (Tier-1, real Postgres)
`packages/gateway/test/sync-identity-scopekeys.integration.test.ts` (5): publish-own / forbid-others; **co-member pubkey visibility** (discriminates `shares_scope` — a `scope_members` row flips it); size cap (23514); scope_keys **member-reads-own-wrap** (A sees only A's, B sees only B's); **admin-only wrap writes** (editor + non-member → 42501, admin ok).

All integration suites green under the swap: **security 93 + engine 13 + orgs 9 + membership 7 = 122/122**. Gateway typecheck exit 0. Biome clean.

## Deferred
- **E-3b:** client publishes its local `account_identity` public key to `identity_pub` + pull co-members' keys (sync plumbing + keystore — kept isolated as crypto-adjacent).
- account_escrow RLS unchanged (per-user escrow, never shared).

Adversarial + SECURITY review to follow before merge.