### PR TITLE
feat(gateway): publish identity public key to the directory (E-3b, #827)

### DIFF
--- a/packages/gateway/src/sync.ts
+++ b/packages/gateway/src/sync.ts
@@ -1038,6 +1038,42 @@ async function reportDeviceProgress(client: SupabaseClient): Promise<void> {
   }
 }
 
+const IDENTITY_PUB_KV = "sync.identityPub"; // base64 of the last-published public key
+
+/**
+ * Publish this device's account identity PUBLIC key to the remote `identity_pub` directory
+ * (E-3, #827) so a scope admin can later HPKE-wrap the per-scope DEK to this member (E-4).
+ * The PRIVATE key never leaves the device. Best-effort: any failure is logged at info and
+ * never breaks sync. Only runs when encryption is "on" (an identity exists + is unlocked).
+ *
+ * `user_id` is filled by the remote column's `default auth.uid()` (like scope_id elsewhere),
+ * so the payload carries only the key. Gated on a KV hash of the published key so we upsert
+ * ONLY when it changes — re-publishing every cycle would bump the remote `updated_at` and
+ * churn co-members' pull cursors for no reason. The key is base64 (the wire convention for
+ * all key material — matches scope_keys.wrapped_dek so E-4 decodes it identically).
+ */
+export async function publishIdentityPub(
+  client: SupabaseClient,
+): Promise<void> {
+  try {
+    if (keystore.encryptionState() !== "on") return; // no unlocked identity to publish
+    const pub = Buffer.from(keystore.getAccountIdentity().publicKey).toString(
+      "base64",
+    );
+    if (getKV(IDENTITY_PUB_KV) === pub) return; // already published this exact key
+    const { error } = await client
+      .from("identity_pub")
+      .upsert({ public_key: pub }, { onConflict: "user_id" });
+    if (error) {
+      log.info(`sync: identity_pub publish skipped: ${error.message}`);
+      return;
+    }
+    setKV(IDENTITY_PUB_KV, pub);
+  } catch (e) {
+    log.info(`sync: identity_pub publish skipped: ${(e as Error).message}`);
+  }
+}
+
 export async function syncOnce(
   onProgress?: SyncProgressFn,
 ): Promise<SyncResult> {
@@ -1078,6 +1114,8 @@ export async function syncOnce(
   }
   // Report AFTER the pull so pulled_through reflects the freshly-advanced cursors.
   await reportDeviceProgress(client);
+  // Publish this device's identity public key so admins can wrap the DEK to it (E-3, #827).
+  await publishIdentityPub(client);
   return {
     pushed: push.pushed,
     pulled: pull.pulled,

--- a/packages/gateway/test/sync-engine.integration.test.ts
+++ b/packages/gateway/test/sync-engine.integration.test.ts
@@ -33,7 +33,7 @@ import {
   it,
   vi,
 } from "vitest";
-import { pullOnce, pushOnce } from "../src/sync";
+import { publishIdentityPub, pullOnce, pushOnce } from "../src/sync";
 import { type PgHarness, startPgHarness } from "./helpers/pg-harness";
 
 // The engine drives real supabase-js clients we pass in explicitly, but the encryption
@@ -466,9 +466,76 @@ describe.skipIf(SKIP)(
       );
       // #1246: projects (local + remote) are cleaned by the top-level beforeEach.
       keystore.lock();
-      for (const t of ["account_escrow", "scope_keys"]) {
+      setKV("sync.identityPub", ""); // reset the identity-publish gate
+      for (const t of ["account_escrow", "scope_keys", "identity_pub"]) {
         await h.client.query(`DELETE FROM public.${t}`);
       }
+    });
+
+    it("publishes this device's identity public key to the remote directory (E-3)", async () => {
+      const client = clientFor(uid);
+      keystore.setPassphrase("correct horse battery", { params: FAST }); // identity+escrow → "on"
+      syncData.enableSync("basic");
+      await publishIdentityPub(client);
+      const expected = Buffer.from(
+        keystore.getAccountIdentity().publicKey,
+      ).toString("base64");
+      const rows = await h.asUser(uid, (c) =>
+        c
+          .query("select user_id, public_key from public.identity_pub")
+          .then((x) => x.rows),
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0].user_id).toBe(uid); // user_id filled by default auth.uid()
+      expect(rows[0].public_key).toBe(expected); // base64 text (wire convention) == local pubkey
+      // Idempotent: a second publish is a no-op (KV-hash gated) — no updated_at churn.
+      const before = await h.asUser(uid, (c) =>
+        c
+          .query(
+            "select updated_at from public.identity_pub where user_id=$1",
+            [uid],
+          )
+          .then((x) => x.rows[0].updated_at),
+      );
+      await publishIdentityPub(client);
+      const after = await h.asUser(uid, (c) =>
+        c
+          .query(
+            "select updated_at from public.identity_pub where user_id=$1",
+            [uid],
+          )
+          .then((x) => x.rows[0].updated_at),
+      );
+      expect(after).toStrictEqual(before);
+    });
+
+    it("publishIdentityPub is a no-op when encryption is off/locked (never auto-mints or publishes)", async () => {
+      const client = clientFor(uid);
+      syncData.enableSync("basic");
+      setKV("sync.identityPub", "");
+      // OFF (beforeEach wiped identity+escrow and locked): must NOT auto-mint an identity as a
+      // side effect of getAccountIdentity (the keystore warns against escrow-less auto-mint), nor publish.
+      expect(keystore.encryptionState()).toBe("off");
+      await publishIdentityPub(client);
+      expect(keystore.hasAccountIdentity()).toBe(false); // no identity minted
+      expect(
+        await h.asUser(uid, (c) =>
+          c.query("select 1 from public.identity_pub").then((x) => x.rowCount),
+        ),
+      ).toBe(0);
+      // LOCKED (escrow exists but identity not installed — a fresh device that pulled the
+      // escrow but hasn't unlocked): still a no-op, and must not throw. Simulate by keeping the
+      // escrow row but dropping the local identity (which is otherwise stored in the clear).
+      keystore.setPassphrase("pw", { params: FAST });
+      db().exec("DELETE FROM account_identity");
+      keystore.lock();
+      expect(keystore.encryptionState()).toBe("locked");
+      await publishIdentityPub(client);
+      expect(
+        await h.asUser(uid, (c) =>
+          c.query("select 1 from public.identity_pub").then((x) => x.rowCount),
+        ),
+      ).toBe(0);
     });
 
     it("device-1 encrypts → remote stores CIPHERTEXT → device-2 unlocks + pulls plaintext", async () => {

--- a/packages/gateway/test/sync-identity-scopekeys.integration.test.ts
+++ b/packages/gateway/test/sync-identity-scopekeys.integration.test.ts
@@ -55,7 +55,9 @@ async function expectError(fn: () => Promise<unknown>): Promise<{
   throw new Error("expected the query to fail, but it succeeded");
 }
 
-const pubkey = (b: number) => Buffer.alloc(b, 7); // deterministic bytea of length b
+// A member's published key travels as base64 TEXT (0026 — the wire convention for all key
+// material). `raw` = the number of raw key bytes; the stored value is their base64.
+const pubkey = (raw = 32) => Buffer.alloc(raw, 7).toString("base64");
 const publishPub = (uid: string, bytes = 32) =>
   h.asUser(uid, (c) =>
     c.query("insert into public.identity_pub (public_key) values ($1)", [
@@ -106,7 +108,8 @@ describe.skipIf(gate())(
 
     it("identity_pub: an oversized public key is rejected (anti-abuse cap)", async () => {
       const a = await h.createUser();
-      const err = await expectError(() => publishPub(a, 257));
+      // base64 of 512 raw bytes is ~684 chars > the 512-char text cap → rejected.
+      const err = await expectError(() => publishPub(a, 512));
       expect(err.code).toBe("23514"); // check_violation
     });
 
@@ -204,23 +207,35 @@ describe.skipIf(gate())(
     it("identity_pub: a user cannot modify another user's pubkey row (update-forge is a no-op)", async () => {
       const a = await h.createUser();
       const b = await h.createUser();
-      await publishPub(a, 32); // A's key = 32 bytes of 0x07
+      await publishPub(a, 32); // A's key = base64 of 32×0x07
       await addMember(a, b, "editor"); // B can even READ A's key now, but still cannot write it
       // B's UPDATE matches no row under the owner policy USING (user_id = auth.uid()) → no-op.
       await h.asUser(b, (cl) =>
         cl.query(
           "update public.identity_pub set public_key=$1 where user_id=$2",
-          [Buffer.alloc(32, 9), a],
+          [Buffer.alloc(32, 9).toString("base64"), a],
         ),
       );
-      const len = await h.client
+      const k = await h.client
         .query(
-          "select octet_length(public_key) as l, public_key as k from public.identity_pub where user_id=$1",
+          "select public_key as k from public.identity_pub where user_id=$1",
           [a],
         )
-        .then((r) => r.rows[0]);
-      expect(len.l).toBe(32);
-      expect((len.k as Buffer)[0]).toBe(7); // unchanged (still A's original key, not B's 0x09)
+        .then((r) => r.rows[0].k);
+      expect(k).toBe(pubkey(32)); // unchanged — still A's original key, not B's 0x09
+    });
+
+    it("identity_pub: public_key is stored as base64 text (wire convention, not \\x-hex bytea)", async () => {
+      const a = await h.createUser();
+      await publishPub(a, 32);
+      const k = await h.client
+        .query(
+          "select public_key as k from public.identity_pub where user_id=$1",
+          [a],
+        )
+        .then((r) => r.rows[0].k);
+      expect(typeof k).toBe("string");
+      expect(k).toBe(Buffer.alloc(32, 7).toString("base64")); // decodes with Buffer.from(k,'base64')
     });
   },
 );

--- a/supabase/migrations/0026_identity_pub_text.sql
+++ b/supabase/migrations/0026_identity_pub_text.sql
@@ -1,0 +1,16 @@
+-- Migration 0026 — identity_pub.public_key is base64 TEXT, not bytea (E-3b, #827).
+--
+-- The wire convention for ALL key material is base64 text (scope_keys.wrapped_dek,
+-- account_escrow.wrapped_secret are text; the push base64-encodes local Uint8Array key
+-- blobs). A member's published public key must follow the same convention so E-4's group
+-- wrap reads it exactly like wrapped_dek (Buffer.from(value,'base64')) rather than as a
+-- \x-hex bytea string — a silent-wrong-bytes footgun. identity_pub is empty (E-3b is the
+-- first publisher), so the recast is trivial and lossless.
+alter table public.identity_pub drop constraint if exists identity_pub_size_ck;
+-- NOTE: the `type ... using` recast is single-run (a second apply would re-encode already-text
+-- data and fail); safe because Supabase applies each migration exactly once via the ledger.
+alter table public.identity_pub
+  alter column public_key type text using encode(public_key, 'base64');
+-- base64 of a ≤256-byte key is ≤344 chars; bound the text length with headroom (anti-abuse).
+alter table public.identity_pub add constraint identity_pub_size_ck
+  check (octet_length(public_key) <= 512);


### PR DESCRIPTION
Client half of **E-3** (#827), stacked on E-3a (#1259, merged). Design: `.opencode/plans/sync-E-teams-orgs-impl.md`.

## What
- **`publishIdentityPub(client)`** in `syncOnce` (best-effort, mirroring `reportDeviceProgress`): when encryption is `on`, upsert this device's account identity **public** key into remote `identity_pub` so an admin can later HPKE-wrap the per-scope DEK to this member (E-4). The **private key never leaves the device**.
  - `user_id` fills via the remote `default auth.uid()` (payload carries only the key, like `scope_id` elsewhere).
  - Gated on a **KV hash** of the published key → upserts only when it changes, so it never bumps the remote `updated_at` and churns co-members' pull cursors every cycle.
- **Migration 0026:** recast `identity_pub.public_key` **`bytea` → base64 `text`**. The wire convention for all key material is base64 text (`scope_keys.wrapped_dek`, `account_escrow.wrapped_secret`); publishing a pubkey as `bytea` would be a silent-wrong-bytes footgun for E-4 (which decodes wraps with `Buffer.from(v,'base64')`). The table is empty (E-3b is the first publisher), so the recast is trivial + lossless; size cap adjusted to `octet_length ≤ 512` (base64 of a ≤256-byte key).

## Deferred to E-4
Pulling/consuming **co-members'** pubkeys — E-4 fetches `identity_pub[M]` directly at wrap-time (no local mirror needed).

## Why bytea in 0025 → text now
0025 (E-3a) created the column as `bytea`; on review of the client path I found the whole crypto sync uses base64 text. Rather than let a single column diverge, 0026 aligns it before any client publishes (caught pre-consumption).

## Verification (Tier-1/2, real Postgres)
- New engine test: encryption on → `publishIdentityPub` → remote `identity_pub` holds exactly one row for the user, `public_key` == base64 of the local key; a second publish is a **no-op** (KV-gated, `updated_at` unchanged).
- 0025 identity_pub tests updated to the base64-text contract + a "stored as base64 text, not `\x`-hex" assertion.
- Integration **131/131** (security 93 + engine 14 + orgs 9 + membership 7 + identity-scopekeys 8); unit sync **144/144**; gateway typecheck exit 0; Biome clean.

Adversarial + SECURITY review to follow before merge.