### PR TITLE
feat(supabase): enforce_row_quota membership guard + effective_tier (E-4b, #827)

### DIFF
--- a/packages/gateway/test/sync-quota-membership.integration.test.ts
+++ b/packages/gateway/test/sync-quota-membership.integration.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Integration tests for migration 0028 — enforce_row_quota membership guard + effective_tier
+ * (E-4b, #827) against a real Postgres. Proves the two targeted changes:
+ *  - GUARD: a team member's write to a SHARED scope (scope_id ≠ auth.uid()) is now METERED.
+ *    Under the old `scope_id is distinct from auth.uid()` guard it was skipped (unmetered).
+ *  - TIER READ: a team scope's caps come from its ORG's tier via effective_tier (not from a
+ *    profiles lookup by the scope id, which for a team is null → 'free').
+ *  - Behavior-preserving: a personal scope is metered exactly as before.
+ *
+ * Gated behind LORE_INTEGRATION=1 (needs Docker). Run:
+ *   LORE_INTEGRATION=1 pnpm exec vitest run packages/gateway/test/sync-quota-membership.integration.test.ts
+ */
+import { execFileSync } from "node:child_process";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { type PgHarness, startPgHarness } from "./helpers/pg-harness";
+
+function dockerReady(): boolean {
+  try {
+    execFileSync("docker", ["info"], { stdio: "ignore", timeout: 10_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const RUN = process.env.LORE_INTEGRATION === "1";
+const SKIP = !RUN
+  ? "LORE_INTEGRATION!=1"
+  : !dockerReady()
+    ? "docker unavailable"
+    : false;
+
+let h: PgHarness;
+let origFreeMetaCap: number;
+beforeAll(async () => {
+  if (SKIP) return;
+  h = await startPgHarness();
+  origFreeMetaCap = await h.client
+    .query(
+      "select max_rows from public.plan_limits where tier='free' and table_name='knowledge_meta'",
+    )
+    .then((r) => Number(r.rows[0].max_rows));
+}, 180_000);
+afterAll(async () => {
+  if (h) await h.stop();
+});
+// Restore the mutated free cap so it never leaks across tests / files.
+afterEach(async () => {
+  if (!SKIP)
+    await h.client.query(
+      "update public.plan_limits set max_rows=$1 where tier='free' and table_name='knowledge_meta'",
+      [origFreeMetaCap],
+    );
+});
+const gate = () => SKIP;
+
+async function expectError(fn: () => Promise<unknown>): Promise<{
+  code?: string;
+  message: string;
+}> {
+  try {
+    await fn();
+  } catch (e) {
+    return {
+      code: (e as { code?: string }).code,
+      message: (e as Error).message,
+    };
+  }
+  throw new Error("expected the query to fail, but it succeeded");
+}
+
+// Manufacture a team org + team scope owned by `owner` at `tier` (service-role territory, so
+// inserted via the superuser client). Returns the team scope id.
+async function makeTeamScope(owner: string, tier: string): Promise<string> {
+  const org = await h.client
+    .query(
+      "insert into public.orgs (kind, owner_user_id, tier) values ('team',$1,$2) returning id",
+      [owner, tier],
+    )
+    .then((r) => r.rows[0].id as string);
+  return h.client
+    .query(
+      "insert into public.scopes (org_id, kind) values ($1,'team') returning id",
+      [org],
+    )
+    .then((r) => r.rows[0].id as string);
+}
+const addScopeMember = (scope: string, uid: string, role: string) =>
+  h.client.query(
+    "insert into public.scope_members (scope_id, user_id, role) values ($1,$2,$3)",
+    [scope, uid, role],
+  );
+const setFreeMetaCap = (n: number) =>
+  h.client.query(
+    "update public.plan_limits set max_rows=$1 where tier='free' and table_name='knowledge_meta'",
+    [n],
+  );
+// Insert a knowledge_meta row into `scope` AS `uid` (author defaults to auth.uid()).
+const insMeta = (uid: string, scope: string, lid: string) =>
+  h.asUser(uid, (c) =>
+    c.query(
+      "insert into public.knowledge_meta (logical_id, scope_id) values ($1,$2)",
+      [lid, scope],
+    ),
+  );
+
+describe.skipIf(gate())("0028 quota membership guard (E-4b, #827)", () => {
+  it("meters a team member's write to a shared scope (was skipped under the self-guard)", async () => {
+    const a = await h.createUser();
+    const b = await h.createUser();
+    const scope = await makeTeamScope(a, "free");
+    await addScopeMember(scope, a, "admin");
+    await addScopeMember(scope, b, "editor");
+    await setFreeMetaCap(1);
+    // First write fits under the cap.
+    await insMeta(b, scope, "lm1");
+    // Second write by the SAME team member is now METERED (is_member guard) → over cap → 23514.
+    // Under the old `scope_id distinct from auth.uid()` guard this would have been skipped.
+    const err = await expectError(() => insMeta(b, scope, "lm2"));
+    expect(err.code).toBe("23514");
+    expect(err.message).toMatch(/quota exceeded/i);
+  });
+
+  it("resolves a team scope's cap from its ORG tier via effective_tier (not a free default)", async () => {
+    const a = await h.createUser();
+    const b = await h.createUser();
+    const scope = await makeTeamScope(a, "pro"); // org tier = pro
+    await addScopeMember(scope, a, "admin");
+    await addScopeMember(scope, b, "editor");
+    await setFreeMetaCap(1); // tiny FREE cap — proves the free cap is NOT the one applied
+    // effective_tier(scope) = 'pro' → the (large) pro cap applies, so both writes succeed.
+    // Under the old profiles-by-scope-id read, tier would resolve null → 'free' → cap 1 → 23514.
+    await insMeta(b, scope, "lp1");
+    await insMeta(b, scope, "lp2");
+    expect(
+      await h.client
+        .query(
+          "select count(*)::int as n from public.knowledge_meta where scope_id=$1",
+          [scope],
+        )
+        .then((r) => r.rows[0].n),
+    ).toBe(2);
+  });
+
+  it("a non-member's forged write to a team scope is RLS-rejected and never counts against usage", async () => {
+    const a = await h.createUser();
+    const c = await h.createUser(); // NOT a member of the team scope
+    const scope = await makeTeamScope(a, "free");
+    await addScopeMember(scope, a, "admin");
+    // C forges a write to A's team scope. The BEFORE-trigger guard skips the quota read (not a
+    // member), then RLS WITH CHECK is_member rejects the row → 42501, never an actual write.
+    const err = await expectError(() => insMeta(c, scope, "forge"));
+    expect(err.code).toBe("42501");
+    // The scope's usage counter is untouched (maintain_usage never fired — the row never landed).
+    const usage = await h.client
+      .query(
+        "select row_count from public.user_table_usage where scope_id=$1 and table_name='knowledge_meta'",
+        [scope],
+      )
+      .then((r) => r.rows);
+    expect(usage).toHaveLength(0);
+  });
+
+  it("behavior-preserving: a personal scope is still metered (owner write over cap → 23514)", async () => {
+    const a = await h.createUser(); // auto-provisioned personal scope (id = a), free tier
+    await setFreeMetaCap(1);
+    await insMeta(a, a, "lo1"); // own scope (scope_id defaults auth.uid() = a)
+    const err = await expectError(() => insMeta(a, a, "lo2"));
+    expect(err.code).toBe("23514");
+  });
+});

--- a/supabase/migrations/0028_quota_membership_guard.sql
+++ b/supabase/migrations/0028_quota_membership_guard.sql
@@ -1,0 +1,270 @@
+-- Migration 0028 — enforce_row_quota: membership oracle-guard + effective_tier (E-4b, #827).
+--
+-- Two targeted changes to the quota trigger, reproduced VERBATIM from 0016 otherwise:
+--   1. Oracle-close guard: skip the quota read for a row this caller cannot own. Was keyed on
+--      `new.scope_id is distinct from auth.uid()` (self-only) — for a TEAM scope a member's
+--      write has scope_id ≠ auth.uid(), so that guard would SKIP quota entirely (unmetered
+--      team writes). Swap to `not public.is_member(new.scope_id)`: a member's write to a shared
+--      scope is now metered; only a row in a scope the caller does NOT belong to is skipped
+--      (still an at-cap existence-oracle we must not answer — RLS WITH CHECK rejects it anyway).
+--   2. Tier read: `profiles.tier where id = new.scope_id` (personal-only) → `effective_tier(
+--      new.scope_id)`, which resolves a team scope's tier via its org. Behavior-preserving for
+--      a personal scope (effective_tier personal → profiles.tier).
+--
+-- 🔴 Pairs with 0027 (the write-gate) as the second half of the deferred team gates: both MUST
+-- be in place BEFORE any cross-user scope_members row exists (E-4c). BEHAVIOR-PRESERVING today:
+-- every scope is personal, so is_member(own)=true (guard doesn't skip, same as before) and
+-- effective_tier(own)=profiles.tier.
+--
+-- KNOWN TEAM SEAM (unreachable until E-4c): continuous free-tier eviction selects the victim by
+-- scope_id, NOT author_id — a member's insert into a shared at-cap scope can evict the lowest-
+-- value row regardless of who authored it. That is intended for a shared per-scope quota (the
+-- quota is the team's, so the least-valuable row is shed team-wide), but revisit if per-author
+-- fairness is ever wanted.
+
+create or replace function public.enforce_row_quota()
+returns trigger
+language plpgsql
+security definer
+set search_path = pg_catalog, public
+as $$
+declare
+  user_tier text;
+  cap_rows  bigint;
+  cap_bytes bigint;
+  cur_rows  bigint;
+  cur_bytes bigint;
+  d_rows    int    := 0;
+  d_bytes   bigint := 0;
+  exists_pk boolean;
+  -- eviction locals
+  evb_start  timestamptz;
+  evb_count  int;
+  evb_cap    int;
+  victim     text;
+  floor_rank int;
+begin
+  if tg_op = 'UPDATE' and old.scope_id is distinct from new.scope_id then
+    raise exception 'scope_id is immutable'
+      using errcode = 'check_violation';
+  end if;
+
+  -- Do NOT read the victim's tier/usage for a row this caller cannot own (an at-cap
+  -- existence oracle via the quota exception). Such a row is ALWAYS rejected by RLS
+  -- WITH CHECK regardless, so skipping quota here changes NO legitimate outcome. E-4b:
+  -- keyed on membership (not self) so a team member's write to a shared scope is metered.
+  if auth.uid() is not null and not public.is_member(new.scope_id) then
+    return new;
+  end if;
+
+  perform pg_advisory_xact_lock(
+    hashtextextended(new.scope_id::text || '|' || tg_table_name, 0));
+
+  if tg_op = 'INSERT' then
+    if tg_table_name = 'knowledge_entity_refs' then
+      select exists(
+        select 1 from public.knowledge_entity_refs
+         where scope_id     = (to_jsonb(new)->>'scope_id')::uuid
+           and knowledge_id = to_jsonb(new)->>'knowledge_id'
+           and entity_id    = to_jsonb(new)->>'entity_id')
+        into exists_pk;
+    elsif tg_table_name = 'knowledge_meta' then
+      select exists(
+        select 1 from public.knowledge_meta
+         where scope_id   = (to_jsonb(new)->>'scope_id')::uuid
+           and logical_id = to_jsonb(new)->>'logical_id')
+        into exists_pk;
+    elsif tg_table_name = 'knowledge_meta_crdt' then
+      select exists(
+        select 1 from public.knowledge_meta_crdt
+         where scope_id   = (to_jsonb(new)->>'scope_id')::uuid
+           and logical_id = to_jsonb(new)->>'logical_id'
+           and replica_id = to_jsonb(new)->>'replica_id')
+        into exists_pk;
+    elsif tg_table_name = 'account_escrow' then
+      select exists(
+        select 1 from public.account_escrow
+         where scope_id = (to_jsonb(new)->>'scope_id')::uuid
+           and id       = (to_jsonb(new)->>'id')::int)
+        into exists_pk;
+    elsif tg_table_name = 'scope_keys' then
+      select exists(
+        select 1 from public.scope_keys
+         where scope_id       = (to_jsonb(new)->>'scope_id')::uuid
+           and member_user_id = to_jsonb(new)->>'member_user_id')
+        into exists_pk;
+    else
+      execute format(
+        'select exists(select 1 from public.%I where scope_id = $1 and id = $2)',
+        tg_table_name)
+        into exists_pk
+        using (to_jsonb(new)->>'scope_id')::uuid, to_jsonb(new)->>'id';
+    end if;
+    if exists_pk then
+      return new;
+    end if;
+    d_rows  := 1;
+    d_bytes := public.usage_row_bytes(to_jsonb(new));
+  else  -- UPDATE: row count unchanged; gate only byte growth.
+    d_bytes := public.usage_row_bytes(to_jsonb(new))
+             - public.usage_row_bytes(to_jsonb(old));
+  end if;
+
+  if d_rows <= 0 and d_bytes <= 0 then
+    return new;
+  end if;
+
+  user_tier := public.effective_tier(new.scope_id);
+  if user_tier is null then user_tier := 'free'; end if;
+
+  select max_rows, max_bytes into cap_rows, cap_bytes
+    from public.plan_limits
+   where tier = user_tier and table_name = tg_table_name;
+  if cap_rows is null and cap_bytes is null then
+    return new;
+  end if;
+
+  select row_count, byte_count into cur_rows, cur_bytes
+    from public.user_table_usage
+   where scope_id = new.scope_id and table_name = tg_table_name;
+  cur_rows  := coalesce(cur_rows, 0);
+  cur_bytes := coalesce(cur_bytes, 0);
+
+  -- ── Continuous top-N eviction (free tier, row cap) ──────────────────────────
+  -- On a genuine new row that would exceed the row cap, evict the lowest-value LIVE entry
+  -- for this scope instead of rejecting, then re-read usage so the checks below see the
+  -- freed slot. Per-table value: knowledge → knowledge_meta.base_confidence; entities →
+  -- sync_rank (ref-count) WITH an incoming-value guard; entity_aliases/entity_relations →
+  -- recency. Bounded by the per-scope hourly circuit breaker.
+  if tg_op = 'INSERT' and user_tier = 'free'
+     and tg_table_name in ('knowledge', 'entities', 'entity_aliases', 'entity_relations')
+     and cap_rows is not null and d_rows > 0 and cur_rows + d_rows > cap_rows then
+    select value into evb_cap from public.sync_config
+      where key = 'eviction_budget_per_hour';
+    evb_cap := coalesce(evb_cap, 200);
+    insert into public.sync_eviction_budget (scope_id) values (new.scope_id)
+      on conflict (scope_id) do nothing;
+    select window_start, evicted into evb_start, evb_count
+      from public.sync_eviction_budget
+     where scope_id = new.scope_id
+       for update;
+    if now() - evb_start > interval '1 hour' then
+      update public.sync_eviction_budget
+         set window_start = now(), evicted = 0
+       where scope_id = new.scope_id;
+      evb_count := 0;
+    end if;
+
+    if evb_count < evb_cap then
+      if tg_table_name = 'knowledge' then
+        -- COALESCE(base_confidence, 1.0): a meta-less knowledge row is treated as HIGH
+        -- value (protected). (1) matches knowledge_current's COALESCE(confidence, 1.0);
+        -- (2) meta-less is the NORMAL transient state during a push (knowledge pushes
+        -- before its meta), so 0.0 would evict a just-pushed fresh entry. Orphans are the
+        -- reaper's (#909) job.
+        select k.id into victim
+          from public.knowledge k
+          left join public.knowledge_meta m
+            on m.scope_id = k.scope_id and m.logical_id = k.id
+         where k.scope_id = new.scope_id and k.is_deleted = false
+         order by coalesce(m.base_confidence, 1.0) asc, k.updated_at asc, k.id asc
+         limit 1;
+        if victim is not null then
+          -- HARD delete + cascade (keeps knowledge/meta/crdt aligned; frees their slots).
+          delete from public.knowledge_meta_crdt
+           where scope_id = new.scope_id and logical_id = victim;
+          delete from public.knowledge_meta
+           where scope_id = new.scope_id and logical_id = victim;
+          delete from public.knowledge
+           where scope_id = new.scope_id and id = victim;
+        end if;
+      elsif tg_table_name = 'entities' then
+        -- Value = sync_rank (client-maintained ref-count). Incoming-value GUARD: only evict
+        -- when the incoming row strictly outranks the current floor. new.sync_rank is
+        -- self-contained on the incoming row, so the guard is exact even though the row's
+        -- refs aren't synced yet. A 0-ref newcomer that can't beat the floor PAUSES (never
+        -- displaces a well-referenced entity) until its rank rises.
+        select e.sync_rank into floor_rank
+          from public.entities e
+         where e.scope_id = new.scope_id and e.is_deleted = false
+         order by e.sync_rank asc, e.updated_at asc, e.id asc
+         limit 1;
+        if floor_rank is not null and new.sync_rank > floor_rank then
+          select e.id into victim
+            from public.entities e
+           where e.scope_id = new.scope_id and e.is_deleted = false
+           order by e.sync_rank asc, e.updated_at asc, e.id asc
+           limit 1;
+          if victim is not null then
+            -- entity_aliases / knowledge_entity_refs belong to the single evicted entity —
+            -- meaningless without it, so cascade unconditionally (frees their slots).
+            delete from public.entity_aliases
+             where scope_id = new.scope_id and entity_id = victim;
+            delete from public.knowledge_entity_refs
+             where scope_id = new.scope_id and entity_id = victim;
+            -- entity_relations connect TWO entities: delete a relation touching the victim
+            -- ONLY when its OTHER endpoint is also gone (not a live synced entity). A relation
+            -- to a surviving entity is that entity's edge — keep it (deleting it would be
+            -- permanent: the client marks it synced and never re-pushes). FIX 2 (#1191b).
+            delete from public.entity_relations r
+             where r.scope_id = new.scope_id
+               and (r.entity_a = victim or r.entity_b = victim)
+               and not exists (
+                 select 1 from public.entities e
+                  where e.scope_id = new.scope_id
+                    and e.is_deleted = false
+                    and e.id <> victim  -- victim is still live here; a self-relation's
+                                        -- "other endpoint" IS the victim → treat as gone
+                    and e.id = case when r.entity_a = victim
+                                    then r.entity_b else r.entity_a end);
+            delete from public.entities
+             where scope_id = new.scope_id and id = victim;
+          end if;
+        end if;
+      else
+        -- entity_aliases / entity_relations: evict the OLDEST (recency). Leaf tables → no
+        -- cascade. BEFORE INSERT ⇒ the incoming row isn't in the table yet, so it's never
+        -- its own victim and always survives (timing invariant, not a value one) — no guard.
+        execute format(
+          'select id from public.%I
+             where scope_id = $1 and is_deleted = false
+             order by updated_at asc, id asc
+             limit 1', tg_table_name)
+          into victim using new.scope_id;
+        if victim is not null then
+          execute format(
+            'delete from public.%I where scope_id = $1 and id = $2', tg_table_name)
+            using new.scope_id, victim;
+        end if;
+      end if;
+
+      if victim is not null then
+        update public.sync_eviction_budget
+           set evicted = evicted + 1
+         where scope_id = new.scope_id;
+        select row_count, byte_count into cur_rows, cur_bytes
+          from public.user_table_usage
+         where scope_id = new.scope_id and table_name = tg_table_name;
+        cur_rows  := coalesce(cur_rows, 0);
+        cur_bytes := coalesce(cur_bytes, 0);
+      end if;
+    end if;
+    -- breaker tripped, guard failed, or nothing to evict → fall through to the raise (pause).
+  end if;
+
+  if cap_rows is not null and d_rows > 0 and cur_rows + d_rows > cap_rows then
+    raise exception
+      'sync quota exceeded for % on tier %: % of % rows. Upgrade to sync more.',
+      tg_table_name, user_tier, cur_rows, cap_rows
+      using errcode = 'check_violation';
+  end if;
+  if cap_bytes is not null and d_bytes > 0 and cur_bytes + d_bytes > cap_bytes then
+    raise exception
+      'sync byte quota exceeded for % on tier %: % of % bytes. Upgrade to sync more.',
+      tg_table_name, user_tier, cur_bytes, cap_bytes
+      using errcode = 'check_violation';
+  end if;
+
+  return new;
+end;
+$$;


### PR DESCRIPTION
Second half of the deferred **E-4** team gates (stacked on E-4a #1262). Together with 0027 (the write-gate), this is the 🔴 prerequisite that must be in place *before* any cross-user `scope_members` row exists (E-4c).

## What (migration 0028)
`enforce_row_quota` reproduced **verbatim** from 0016 with exactly **two hunks** changed (the function diff is precisely these two + a guard comment):

1. **Oracle-close guard:** `scope_id is distinct from auth.uid()` → `not public.is_member(new.scope_id)`. The old self-guard skipped the quota read for *any* `scope_id ≠ auth.uid()` — so a team member's write to a **shared** scope was **unmetered**. Now a member's write is metered; only a row in a scope the caller does *not* belong to is skipped (that row is an at-cap existence oracle we must not answer — RLS `WITH CHECK` rejects it regardless).
2. **Tier read:** `profiles.tier where id = new.scope_id` → `effective_tier(new.scope_id)`, which resolves a **team** scope's caps via its org (a team scope id has no `profiles` row → the old read would misresolve to `'free'`).

`maintain_usage` has no self-guard (it always counts by `scope_id`), so the guard change alone is sufficient to meter team writes — no `maintain_usage` change needed.

## Behavior-preserving
Every scope today is personal: `is_member(own) = true` (guard never skips, exactly as before) and `effective_tier(own) = profiles.tier`. All 7 integration suites stay green.

## Verification (Tier-1, real Postgres, manufactured team scope)
`sync-quota-membership.integration.test.ts` (3):
- **Guard:** a team `editor`'s 2nd write over a cap of 1 → `23514` (was skipped/unmetered under the self-guard — the discriminating case).
- **Tier read:** a team scope under a **pro** org keeps writing past the tiny *free* cap → both succeed (proves the cap came from `effective_tier`=pro, not a `'free'` misread).
- **Behavior-preserving:** a personal owner's over-cap write still `23514`.

Suites: security 93 + engine 14 + orgs 9 + membership 7 + identity-scopekeys 8 + write-gate 6 + quota-membership 3 = **141/141**. Function diff vs 0016 = the 2 intended hunks only (verified). Gateway typecheck exit 0; Biome clean.

Adversarial + SECURITY review to follow before merge.