### PR TITLE
feat(supabase): team lifecycle RPCs — create/add/remove/set-role (E-4c-1, #827)

### DIFF
--- a/packages/gateway/test/sync-team-lifecycle.integration.test.ts
+++ b/packages/gateway/test/sync-team-lifecycle.integration.test.ts
@@ -1,0 +1,313 @@
+/**
+ * Integration tests for migration 0029 — team lifecycle RPCs (E-4c, #827) against a real
+ * Postgres. Proves the SECURITY DEFINER RPCs that create teams and manage membership:
+ *  - create_team makes the caller org owner + scope admin;
+ *  - a scope admin can add a member (who then READS the scope's content) and a non-member/editor
+ *    cannot add/remove (role-gated);
+ *  - removing a member revokes access and drops their DEK wrap;
+ *  - the last admin cannot be removed or demoted (no orphaned scope);
+ *  - invalid roles are rejected;
+ *  - the shares_scope oracle is pinned to the caller (no probing arbitrary user pairs).
+ *
+ * Gated behind LORE_INTEGRATION=1 (needs Docker). Run:
+ *   LORE_INTEGRATION=1 pnpm exec vitest run packages/gateway/test/sync-team-lifecycle.integration.test.ts
+ */
+import { execFileSync } from "node:child_process";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { type PgHarness, startPgHarness } from "./helpers/pg-harness";
+
+function dockerReady(): boolean {
+  try {
+    execFileSync("docker", ["info"], { stdio: "ignore", timeout: 10_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const RUN = process.env.LORE_INTEGRATION === "1";
+const SKIP = !RUN
+  ? "LORE_INTEGRATION!=1"
+  : !dockerReady()
+    ? "docker unavailable"
+    : false;
+
+let h: PgHarness;
+beforeAll(async () => {
+  if (!SKIP) h = await startPgHarness();
+}, 180_000);
+afterAll(async () => {
+  if (h) await h.stop();
+});
+const gate = () => SKIP;
+
+async function expectError(fn: () => Promise<unknown>): Promise<{
+  code?: string;
+  message: string;
+}> {
+  try {
+    await fn();
+  } catch (e) {
+    return {
+      code: (e as { code?: string }).code,
+      message: (e as Error).message,
+    };
+  }
+  throw new Error("expected the query to fail, but it succeeded");
+}
+
+const createTeam = (uid: string, name: string) =>
+  h.asUser(uid, (c) =>
+    c
+      .query("select public.create_team($1) as s", [name])
+      .then((r) => r.rows[0].s as string),
+  );
+const addMember = (
+  admin: string,
+  scope: string,
+  user: string,
+  role = "editor",
+) =>
+  h.asUser(admin, (c) =>
+    c.query("select public.add_scope_member($1,$2,$3)", [scope, user, role]),
+  );
+const removeMember = (admin: string, scope: string, user: string) =>
+  h.asUser(admin, (c) =>
+    c.query("select public.remove_scope_member($1,$2)", [scope, user]),
+  );
+const setRole = (admin: string, scope: string, user: string, role: string) =>
+  h.asUser(admin, (c) =>
+    c.query("select public.set_scope_role($1,$2,$3)", [scope, user, role]),
+  );
+const addKnowledge = (uid: string, scope: string, id: string) =>
+  h.asUser(uid, (c) =>
+    c.query(
+      "insert into public.knowledge (id, scope_id, category, title, content) values ($1,$2,'p','T','C')",
+      [id, scope],
+    ),
+  );
+const seesKnowledge = (uid: string) =>
+  h.asUser(uid, (c) =>
+    c.query("select id from public.knowledge").then((r) => r.rowCount),
+  );
+
+describe.skipIf(gate())("0029 team lifecycle RPCs (E-4c, #827)", () => {
+  it("create_team makes the caller org owner + scope admin", async () => {
+    const a = await h.createUser();
+    const scope = await createTeam(a, "Team A");
+    const [s, sm, om] = await Promise.all([
+      h.client
+        .query("select kind, org_id from public.scopes where id=$1", [scope])
+        .then((r) => r.rows[0]),
+      h.client
+        .query(
+          "select role from public.scope_members where scope_id=$1 and user_id=$2",
+          [scope, a],
+        )
+        .then((r) => r.rows[0]),
+      h.client
+        .query(
+          "select o.kind, o.owner_user_id, m.role from public.orgs o join public.org_members m on m.org_id=o.id where o.id=(select org_id from public.scopes where id=$1) and m.user_id=$2",
+          [scope, a],
+        )
+        .then((r) => r.rows[0]),
+    ]);
+    expect(s.kind).toBe("team");
+    expect(sm.role).toBe("admin"); // creator is the scope admin
+    expect(om.kind).toBe("team");
+    expect(om.owner_user_id).toBe(a);
+    expect(om.role).toBe("owner"); // creator is the org owner
+  });
+
+  it("an admin adds a member who can then read the scope's content; a non-member cannot", async () => {
+    const a = await h.createUser();
+    const b = await h.createUser();
+    const c = await h.createUser();
+    const scope = await createTeam(a, "Team B");
+    await addKnowledge(a, scope, "k1");
+    expect(await seesKnowledge(b)).toBe(0); // not a member yet
+    await addMember(a, scope, b, "editor");
+    expect(await seesKnowledge(b)).toBe(1); // membership grants FETCH (RLS is_member)
+    expect(await seesKnowledge(c)).toBe(0); // an unrelated user still sees nothing
+    // The new member is also an org member (plain 'member').
+    expect(
+      await h.client
+        .query(
+          "select role from public.org_members where org_id=(select org_id from public.scopes where id=$1) and user_id=$2",
+          [scope, b],
+        )
+        .then((r) => r.rows[0].role),
+    ).toBe("member");
+  });
+
+  it("only an admin can add or remove members", async () => {
+    const a = await h.createUser();
+    const b = await h.createUser();
+    const d = await h.createUser();
+    const scope = await createTeam(a, "Team C");
+    await addMember(a, scope, b, "editor");
+    // An editor cannot add or remove.
+    expect((await expectError(() => addMember(b, scope, d))).code).toBe(
+      "42501",
+    );
+    expect((await expectError(() => removeMember(b, scope, a))).code).toBe(
+      "42501",
+    );
+    // A total non-member cannot either (scope_role → null → not 'admin').
+    expect((await expectError(() => addMember(d, scope, b))).code).toBe(
+      "42501",
+    );
+  });
+
+  it("removing a member revokes access and drops their DEK wrap", async () => {
+    const a = await h.createUser();
+    const b = await h.createUser();
+    const scope = await createTeam(a, "Team D");
+    await addMember(a, scope, b, "editor");
+    await addKnowledge(a, scope, "k1");
+    // Admin group-wraps a DEK to B (cross-member insert, NO returning — the E-3a constraint).
+    await h.asUser(a, (cl) =>
+      cl.query(
+        "insert into public.scope_keys (scope_id, member_user_id, wrapped_dek) values ($1,$2,'ZGVr')",
+        [scope, b],
+      ),
+    );
+    expect(await seesKnowledge(b)).toBe(1);
+    await removeMember(a, scope, b);
+    expect(await seesKnowledge(b)).toBe(0); // access revoked
+    expect(
+      await h.client
+        .query(
+          "select 1 from public.scope_keys where scope_id=$1 and member_user_id=$2",
+          [scope, b],
+        )
+        .then((r) => r.rowCount),
+    ).toBe(0); // wrap dropped
+  });
+
+  it("dropping a member from their only scope removes their org membership, but not while they remain in another scope of the org", async () => {
+    const a = await h.createUser();
+    const b = await h.createUser();
+    const scope = await createTeam(a, "Team J");
+    const org = await h.client
+      .query("select org_id from public.scopes where id=$1", [scope])
+      .then((r) => r.rows[0].org_id as string);
+    // A second team scope under the SAME org (out-of-band via superuser), a=admin, b=editor.
+    const scope2 = await h.client
+      .query(
+        "insert into public.scopes (org_id, kind, name) values ($1,'team','J2') returning id",
+        [org],
+      )
+      .then((r) => r.rows[0].id as string);
+    await h.client.query(
+      "insert into public.scope_members (scope_id, user_id, role) values ($1,$2,'admin'),($1,$3,'editor')",
+      [scope2, a, b],
+    );
+    await addMember(a, scope, b, "editor"); // also makes b an org member
+    const orgRows = () =>
+      h.client
+        .query(
+          "select 1 from public.org_members where org_id=$1 and user_id=$2",
+          [org, b],
+        )
+        .then((r) => r.rowCount);
+    // Removed from scope 1 but still in scope 2 → keeps org membership.
+    await removeMember(a, scope, b);
+    expect(await orgRows()).toBe(1);
+    // Removed from the last remaining scope → org membership dropped.
+    await removeMember(a, scope2, b);
+    expect(await orgRows()).toBe(0);
+  });
+
+  it("cannot remove or demote the last admin of a scope", async () => {
+    const a = await h.createUser();
+    const scope = await createTeam(a, "Team E");
+    expect((await expectError(() => removeMember(a, scope, a))).code).toBe(
+      "23514",
+    );
+    expect((await expectError(() => setRole(a, scope, a, "editor"))).code).toBe(
+      "23514",
+    );
+    // With a second admin, demoting the first is allowed.
+    const b = await h.createUser();
+    await addMember(a, scope, b, "admin");
+    await setRole(a, scope, a, "editor"); // now b is the remaining admin
+    expect(
+      await h.client
+        .query(
+          "select role from public.scope_members where scope_id=$1 and user_id=$2",
+          [scope, a],
+        )
+        .then((r) => r.rows[0].role),
+    ).toBe("editor");
+  });
+
+  it("cannot demote the last admin via add_scope_member's re-role path (B1)", async () => {
+    const a = await h.createUser();
+    const scope = await createTeam(a, "Team H");
+    // add_scope_member upserts an existing member's role — demoting the sole admin here must be
+    // blocked exactly like set_scope_role, else the scope is left with 0 admins (unmanageable).
+    expect(
+      (await expectError(() => addMember(a, scope, a, "editor"))).code,
+    ).toBe("23514");
+  });
+
+  it("add_scope_member defaults a new member to editor", async () => {
+    const a = await h.createUser();
+    const b = await h.createUser();
+    const scope = await createTeam(a, "Team I");
+    // Call the 2-arg form so the SQL default ('editor') is exercised (guards against drift).
+    await h.asUser(a, (c) =>
+      c.query("select public.add_scope_member($1,$2)", [scope, b]),
+    );
+    expect(
+      await h.client
+        .query(
+          "select role from public.scope_members where scope_id=$1 and user_id=$2",
+          [scope, b],
+        )
+        .then((r) => r.rows[0].role),
+    ).toBe("editor");
+  });
+
+  it("rejects an invalid scope role", async () => {
+    const a = await h.createUser();
+    const b = await h.createUser();
+    const scope = await createTeam(a, "Team F");
+    expect(
+      (await expectError(() => addMember(a, scope, b, "superuser"))).code,
+    ).toBe("22023");
+  });
+
+  it("shares_scope is pinned to the caller (no probing arbitrary user pairs)", async () => {
+    const a = await h.createUser();
+    const b = await h.createUser();
+    const x = await h.createUser();
+    const scope = await createTeam(a, "Team G");
+    await addMember(a, scope, b, "editor");
+    // Self form (1-arg, p_uid defaults to auth.uid()) works for genuine co-members.
+    expect(
+      await h.asUser(b, (c) =>
+        c
+          .query("select public.shares_scope($1) as v", [a])
+          .then((r) => r.rows[0].v),
+      ),
+    ).toBe(true);
+    // An unrelated caller probing the a↔b pair (p_uid ≠ self) is pinned → false.
+    expect(
+      await h.asUser(x, (c) =>
+        c
+          .query("select public.shares_scope($1,$2) as v", [a, b])
+          .then((r) => r.rows[0].v),
+      ),
+    ).toBe(false);
+    // And a genuine non-co-member self query is honestly false.
+    expect(
+      await h.asUser(b, (c) =>
+        c
+          .query("select public.shares_scope($1) as v", [x])
+          .then((r) => r.rows[0].v),
+      ),
+    ).toBe(false);
+  });
+});

--- a/supabase/migrations/0029_team_lifecycle.sql
+++ b/supabase/migrations/0029_team_lifecycle.sql
@@ -1,0 +1,159 @@
+-- Migration 0029 — team lifecycle RPCs (E-4c, #827).
+--
+-- SECURITY DEFINER RPCs to create teams and manage scope membership + roles. These are the
+-- FIRST path by which a cross-user `scope_members` row can be created — safe ONLY because the
+-- deferred team gates already landed: 0027 (per-verb write-gate, viewer read-only, role-gated
+-- DELETE), 0028 (enforce_row_quota membership guard + effective_tier), and the
+-- sync_device_progress → is_member swap. Membership writes go through these role-checked,
+-- transactional RPCs — NEVER the generic client push (org/scope/member tables are pull-only
+-- mirrors on the client).
+--
+-- The per-scope DEK wrap is NOT done here: adding a member only grants FETCH (RLS is_member);
+-- the member cannot DECRYPT until an admin group-wraps the DEK to them (client-side, E-4c-2).
+-- Rotation on remove (bump key_epoch + re-wrap to remaining) is likewise client-side (E-4c-3);
+-- this RPC only deletes the removed member's row + their now-unreadable wrap.
+
+-- ---------------------------------------------------------------------------
+-- create_team: a new team org + team scope; the caller becomes org owner + scope admin.
+-- Returns the new team scope id. (Multi-team-per-org / standalone org creation: later.)
+-- ---------------------------------------------------------------------------
+create or replace function public.create_team(p_name text)
+returns uuid language plpgsql security definer set search_path = pg_catalog, public
+as $$
+declare
+  v_uid   uuid := auth.uid();
+  v_org   uuid;
+  v_scope uuid;
+begin
+  if v_uid is null then
+    raise exception 'not authenticated' using errcode = '28000';
+  end if;
+  insert into public.orgs (kind, owner_user_id, name) values ('team', v_uid, p_name)
+    returning id into v_org;
+  insert into public.org_members (org_id, user_id, role) values (v_org, v_uid, 'owner');
+  insert into public.scopes (org_id, kind, name) values (v_org, 'team', p_name)
+    returning id into v_scope;
+  insert into public.scope_members (scope_id, user_id, role) values (v_scope, v_uid, 'admin');
+  return v_scope;
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- add_scope_member: a scope ADMIN adds a user to the scope (and, implicitly, its org).
+-- role ∈ {admin, editor, viewer}. Idempotent (re-adding updates the role).
+-- ---------------------------------------------------------------------------
+create or replace function public.add_scope_member(
+  p_scope uuid, p_user uuid, p_role text default 'editor')
+returns void language plpgsql security definer set search_path = pg_catalog, public
+as $$
+declare
+  v_org      uuid;
+  v_existing text;
+begin
+  -- Serialize all membership mutations on this scope so the last-admin checks below can't race
+  -- (two concurrent demotions of distinct admins would each read count>1 and orphan the scope).
+  perform pg_advisory_xact_lock(hashtextextended(p_scope::text, 0));
+  -- scope_role() defaults to auth.uid() → this checks the CALLER is an admin of the scope.
+  if public.scope_role(p_scope) is distinct from 'admin' then
+    raise exception 'only a scope admin may add members' using errcode = '42501';
+  end if;
+  if p_role not in ('admin', 'editor', 'viewer') then
+    raise exception 'invalid scope role: %', p_role using errcode = '22023';
+  end if;
+  -- Last-admin guard: the upsert below can RE-ROLE an existing member, so demoting the sole
+  -- admin down to editor/viewer here must be blocked exactly like set_scope_role.
+  select role into v_existing from public.scope_members where scope_id = p_scope and user_id = p_user;
+  if v_existing = 'admin' and p_role <> 'admin'
+     and (select count(*) from public.scope_members where scope_id = p_scope and role = 'admin') <= 1
+  then
+    raise exception 'cannot demote the last admin of a scope' using errcode = '23514';
+  end if;
+  select org_id into v_org from public.scopes where id = p_scope;
+  if v_org is null then
+    raise exception 'no such scope' using errcode = '23503';
+  end if;
+  -- Org membership (plain member) so the new member can see the org; then the scope role.
+  insert into public.org_members (org_id, user_id, role) values (v_org, p_user, 'member')
+    on conflict (org_id, user_id) do nothing;
+  insert into public.scope_members (scope_id, user_id, role) values (p_scope, p_user, p_role)
+    on conflict (scope_id, user_id) do update set role = excluded.role;
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- remove_scope_member: a scope ADMIN removes a member. Refuses to orphan the last admin. Also
+-- drops the member's DEK wrap (server-side housekeeping; their local copy is inherently theirs).
+-- ---------------------------------------------------------------------------
+create or replace function public.remove_scope_member(p_scope uuid, p_user uuid)
+returns void language plpgsql security definer set search_path = pg_catalog, public
+as $$
+begin
+  perform pg_advisory_xact_lock(hashtextextended(p_scope::text, 0));
+  if public.scope_role(p_scope) is distinct from 'admin' then
+    raise exception 'only a scope admin may remove members' using errcode = '42501';
+  end if;
+  if (select role from public.scope_members where scope_id = p_scope and user_id = p_user) = 'admin'
+     and (select count(*) from public.scope_members where scope_id = p_scope and role = 'admin') <= 1
+  then
+    raise exception 'cannot remove the last admin of a scope' using errcode = '23514';
+  end if;
+  delete from public.scope_members where scope_id = p_scope and user_id = p_user;
+  delete from public.scope_keys where scope_id = p_scope and member_user_id = p_user::text;
+  -- Also drop the org membership IF the user no longer belongs to ANY scope of that org (and
+  -- isn't the org owner) — otherwise a removed member lingers as an org member with roster
+  -- visibility. A member of OTHER scopes in the same org keeps their org membership.
+  delete from public.org_members om
+   where om.user_id = p_user
+     and om.role <> 'owner'
+     and om.org_id = (select org_id from public.scopes where id = p_scope)
+     and not exists (
+       select 1 from public.scope_members sm
+         join public.scopes s on s.id = sm.scope_id
+        where sm.user_id = p_user and s.org_id = om.org_id);
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- set_scope_role: a scope ADMIN changes a member's role. Refuses to demote the last admin.
+-- ---------------------------------------------------------------------------
+create or replace function public.set_scope_role(p_scope uuid, p_user uuid, p_role text)
+returns void language plpgsql security definer set search_path = pg_catalog, public
+as $$
+begin
+  perform pg_advisory_xact_lock(hashtextextended(p_scope::text, 0));
+  if public.scope_role(p_scope) is distinct from 'admin' then
+    raise exception 'only a scope admin may change roles' using errcode = '42501';
+  end if;
+  if p_role not in ('admin', 'editor', 'viewer') then
+    raise exception 'invalid scope role: %', p_role using errcode = '22023';
+  end if;
+  if p_role <> 'admin'
+     and (select role from public.scope_members where scope_id = p_scope and user_id = p_user) = 'admin'
+     and (select count(*) from public.scope_members where scope_id = p_scope and role = 'admin') <= 1
+  then
+    raise exception 'cannot demote the last admin of a scope' using errcode = '23514';
+  end if;
+  update public.scope_members set role = p_role where scope_id = p_scope and user_id = p_user;
+end $$;
+
+grant execute on function public.create_team(text) to authenticated;
+grant execute on function public.add_scope_member(uuid, uuid, text) to authenticated;
+grant execute on function public.remove_scope_member(uuid, uuid) to authenticated;
+grant execute on function public.set_scope_role(uuid, uuid, text) to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- Harden the shares_scope oracle now that cross-user co-membership can exist. It is only ever
+-- called 1-arg (p_uid defaults to auth.uid()) by identity_pub_read_comembers, so pinning p_uid
+-- to the caller (or service_role) is transparent to every legitimate use while closing a
+-- co-membership social-graph oracle (an arbitrary caller probing "do A and B share a scope").
+-- ---------------------------------------------------------------------------
+create or replace function public.shares_scope(p_other uuid, p_uid uuid default auth.uid())
+returns boolean language sql stable security definer set search_path = pg_catalog, public
+as $$
+  select case
+    when p_uid is distinct from auth.uid() and coalesce(auth.role(), '') <> 'service_role'
+      then false
+    else exists(
+      select 1
+        from public.scope_members a
+        join public.scope_members b on b.scope_id = a.scope_id
+       where a.user_id = p_uid and b.user_id = p_other)
+  end;
+$$;


### PR DESCRIPTION
First slice of **E-4c** (#827), stacked on E-4a/E-4b (merged). The SECURITY DEFINER RPCs that create teams and manage scope membership — **the first path by which a cross-user `scope_members` row can be created**. Safe only because the deferred team gates already landed: 0027 (per-verb write-gate), 0028 (`enforce_row_quota` membership guard + `effective_tier`), and the `sync_device_progress`→`is_member` swap.

## RPCs (migration 0029)
| RPC | Authorization | Effect |
|---|---|---|
| `create_team(name)` | authenticated | new team org + team scope; caller → org **owner** + scope **admin**; returns scope id |
| `add_scope_member(scope, user, role)` | scope **admin** | org member (`member`) + scope role ∈ {admin,editor,viewer}; idempotent |
| `remove_scope_member(scope, user)` | scope **admin** | refuses to orphan the **last admin**; drops the member's DEK wrap |
| `set_scope_role(scope, user, role)` | scope **admin** | refuses to demote the **last admin** |

Membership writes go through these role-checked, transactional RPCs — **never** the generic client push (org/scope/member tables stay pull-only mirrors). Adding a member grants **FETCH only** (RLS `is_member`); **DECRYPT** requires an admin group-wrap of the DEK (client-side, **E-4c-2**), and rotation-on-remove is client-side (**E-4c-3**) — this RPC only deletes the removed member's row + their now-unreadable wrap.

## Also
Pins the `shares_scope` 2-arg oracle to the caller (or `service_role`) now that co-membership can exist — transparent to its only use (1-arg, in `identity_pub_read_comembers`), and closes a co-membership social-graph oracle (an arbitrary caller probing "do A and B share a scope").

## Verification (Tier-1, real Postgres)
`sync-team-lifecycle.integration.test.ts` (7): create_team owner/admin wiring; an admin-added member reads the scope's content while a non-member/editor cannot add/remove; remove revokes access + drops the wrap; last-admin remove/demote guard (23514); invalid role (22023); `shares_scope` caller-pinned (self works, arbitrary-pair probe → false). Cross-member `scope_keys` insert exercised WITHOUT `RETURNING` (the E-3a constraint).

Suites: security 93 + engine 14 + orgs 9 + membership 7 + identity-scopekeys 8 + write-gate 6 + quota-membership 4 + team-lifecycle 7 = **149/149**. Typecheck 0; Biome clean.

Adversarial + SECURITY review to follow before merge.