### PR TITLE
fix(core): batch instruction-detect cross-session FTS into one query

### DIFF
--- a/packages/core/src/instruction-detect.ts
+++ b/packages/core/src/instruction-detect.ts
@@ -182,6 +182,21 @@ export async function findRepeatedInstructions(input: {
 
   const results: RepeatedInstruction[] = [];
 
+  // Path B (FTS) pre-pass: build the per-candidate MATCH expressions and run
+  // them as ONE batched query instead of one query per candidate. The old
+  // per-candidate loop issued up to MAX_CANDIDATES identical-fingerprint FTS
+  // scans per curation run, which Sentry flagged as an N+1 under lore.curator.
+  const ftsMatchByIndex: Array<{ index: number; matchExpr: string }> = [];
+  for (let i = 0; i < input.candidates.length; i++) {
+    const terms = filterTerms(input.candidates[i].text);
+    // Need >= 2 meaningful terms; cap at 5 to keep queries focused.
+    if (terms.length < 2) continue;
+    const matchExpr = ftsQueryOr(terms.slice(0, 5).join(" "));
+    if (matchExpr === EMPTY_QUERY) continue;
+    ftsMatchByIndex.push({ index: i, matchExpr });
+  }
+  const ftsSessionsByIndex = searchDistillationsFTSBatch(pid, ftsMatchByIndex);
+
   for (let i = 0; i < input.candidates.length; i++) {
     const candidate = input.candidates[i];
     const sessionIDs = new Set<string>();
@@ -203,15 +218,13 @@ export async function findRepeatedInstructions(input: {
       }
     }
 
-    // Path B: FTS fallback (always runs to complement vector search)
-    const terms = filterTerms(candidate.text);
-    if (terms.length >= 2) {
-      // Cap at 5 terms to keep queries focused
-      const searchText = terms.slice(0, 5).join(" ");
-      const ftsHits = searchDistillationsFTS(pid, searchText);
-      for (const hit of ftsHits) {
-        if (hit.session_id !== input.currentSessionID) {
-          sessionIDs.add(hit.session_id);
+    // Path B: FTS fallback (always runs to complement vector search).
+    // Results were pre-computed above in a single batched query.
+    const ftsSessions = ftsSessionsByIndex.get(i);
+    if (ftsSessions) {
+      for (const sessionID of ftsSessions) {
+        if (sessionID !== input.currentSessionID) {
+          sessionIDs.add(sessionID);
         }
       }
     }
@@ -228,40 +241,75 @@ export async function findRepeatedInstructions(input: {
 }
 
 /**
- * Simple FTS5 search over distillation observations, returning session_id
- * for cross-session counting. Searches all distillations (including archived).
+ * Batched FTS5 search over distillation observations for MULTIPLE candidate
+ * instructions at once, returning the matching prior-session IDs grouped by
+ * candidate index. Searches all distillations (including archived).
  *
  * Uses OR semantics — we want to find any distillation mentioning any of
  * the instruction's key terms, since paraphrased instructions may share
  * only some terms. This is a recall-oriented search (find all possible
  * matches), not a precision-oriented one.
  *
+ * Each candidate contributes one `UNION ALL` branch tagged with its index and
+ * wrapped in a subquery so the per-candidate `ORDER BY rank LIMIT 30` bound is
+ * preserved exactly as the previous per-candidate query applied it. Collapsing
+ * these into a single statement avoids the N+1 query pattern (one FTS scan per
+ * candidate) that Sentry flagged under the `lore.curator` transaction.
+ *
+ * The candidate index is interpolated directly into the SQL — it is always a
+ * caller-supplied loop index (a trusted integer), never user input. The MATCH
+ * expression and project id are bound as parameters.
+ *
  * @param projectId  The resolved project ID (from ensureProject).
- * @param rawQuery   Raw search text — will be converted to OR-based FTS expression.
+ * @param queries    Per-candidate `{ index, matchExpr }` pairs. `matchExpr`
+ *                   must already be a sanitized FTS expression (from
+ *                   `ftsQueryOr`) and not `EMPTY_QUERY`.
+ * @returns          Map keyed by candidate index → set of matching session IDs.
  */
-function searchDistillationsFTS(
+function searchDistillationsFTSBatch(
   projectId: string,
-  rawQuery: string,
-): Array<{ id: string; session_id: string }> {
-  const matchExpr = ftsQueryOr(rawQuery);
-  if (matchExpr === EMPTY_QUERY) return [];
+  queries: ReadonlyArray<{ index: number; matchExpr: string }>,
+): Map<number, Set<string>> {
+  const out = new Map<number, Set<string>>();
+  if (!queries.length) return out;
 
-  const sql = `SELECT d.id, d.session_id
-     FROM distillation_fts f
-     CROSS JOIN distillations d ON d.rowid = f.rowid
-     WHERE distillation_fts MATCH ?
-     AND d.project_id = ?
-     ORDER BY rank LIMIT 30`;
+  const sql = queries
+    .map(
+      ({ index }) =>
+        `SELECT ${index | 0} AS cand, session_id FROM (
+           SELECT d.session_id AS session_id
+           FROM distillation_fts f
+           CROSS JOIN distillations d ON d.rowid = f.rowid
+           WHERE distillation_fts MATCH ? AND d.project_id = ?
+           ORDER BY rank LIMIT 30
+         )`,
+    )
+    .join("\nUNION ALL\n");
+
+  const params: string[] = [];
+  for (const { matchExpr } of queries) params.push(matchExpr, projectId);
 
   try {
-    return db().query(sql).all(matchExpr, projectId) as Array<{
-      id: string;
+    const rows = db()
+      .query(sql)
+      .all(...params) as Array<{
+      cand: number;
       session_id: string;
     }>;
+    for (const row of rows) {
+      let set = out.get(row.cand);
+      if (!set) {
+        set = new Set<string>();
+        out.set(row.cand, set);
+      }
+      set.add(row.session_id);
+    }
   } catch (err) {
-    log.warn("instruction-detect: FTS search failed:", err);
-    return [];
+    // Graceful degradation: the curator simply gets no cross-session FTS
+    // context this run (same outcome as the pre-batch per-candidate catch).
+    log.warn("instruction-detect: batched FTS search failed:", err);
   }
+  return out;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/test/instruction-detect.test.ts
+++ b/packages/core/test/instruction-detect.test.ts
@@ -530,6 +530,96 @@ describe("findRepeatedInstructions", () => {
     // Just verify it doesn't throw
     expect(Array.isArray(results)).toBe(true);
   });
+
+  test("attributes batched FTS hits to the correct candidate (no cross-contamination)", async () => {
+    // Two candidates with disjoint term sets are searched in a single batched
+    // query. Candidate 1 appears in 2 prior sessions; candidate 2 in only 1.
+    // The batched UNION ALL must keep each candidate's session set separate —
+    // if hits leaked across candidates, candidate 2 would be pushed over the
+    // threshold and candidate 1's count would be inflated.
+    insertDistillation({
+      projectId: pid,
+      sessionID: "pr-sess-1",
+      observations: "🔴 (14:30) User stated always create a PR for changes.",
+    });
+    insertDistillation({
+      projectId: pid,
+      sessionID: "pr-sess-2",
+      observations: "🔴 (10:00) User said create a PR before merging.",
+    });
+    // Only ONE prior session mentions running tests.
+    insertDistillation({
+      projectId: pid,
+      sessionID: "test-sess-1",
+      observations: "🟡 (09:00) Agent always run the tests before committing.",
+    });
+
+    const candidates: InstructionCandidate[] = [
+      { text: "create a PR for changes", sessionID: "current-sess" },
+      { text: "run the tests locally", sessionID: "current-sess" },
+    ];
+
+    const results = await findRepeatedInstructions({
+      projectPath: PROJECT,
+      currentSessionID: "current-sess",
+      candidates,
+      threshold: 2,
+    });
+
+    // Candidate 1 met the threshold (2 distinct sessions); candidate 2 did not
+    // (1 session) and must be absent — proving hits were not merged.
+    expect(results).toHaveLength(1);
+    expect(results[0].instruction).toBe("create a PR for changes");
+    expect(results[0].priorSessionCount).toBe(2);
+  });
+
+  test("returns a result per matching candidate in a multi-candidate batch", async () => {
+    // Both candidates independently clear the threshold. Verifies the batched
+    // query returns rows tagged for every candidate, not just the first.
+    // (Term sets are kept disjoint AND free of shared prefixes — FTS matches
+    // on prefixes, e.g. "pr"* would match "prefers".)
+    insertDistillation({
+      projectId: pid,
+      sessionID: "deploy-sess-1",
+      observations: "🔴 User stated always squash before merging.",
+    });
+    insertDistillation({
+      projectId: pid,
+      sessionID: "deploy-sess-2",
+      observations: "🔴 User said squash the commits before merging.",
+    });
+    insertDistillation({
+      projectId: pid,
+      sessionID: "fmt-sess-1",
+      observations: "🔴 User wants biome formatting everywhere.",
+    });
+    insertDistillation({
+      projectId: pid,
+      sessionID: "fmt-sess-2",
+      observations: "🔴 User likes biome formatting on save.",
+    });
+
+    const candidates: InstructionCandidate[] = [
+      { text: "squash before merging", sessionID: "current-sess" },
+      { text: "biome formatting everywhere", sessionID: "current-sess" },
+    ];
+
+    const results = await findRepeatedInstructions({
+      projectPath: PROJECT,
+      currentSessionID: "current-sess",
+      candidates,
+      threshold: 2,
+    });
+
+    // Both candidates must be returned — proving the batched UNION ALL emits
+    // rows for every candidate index, not just the first branch.
+    expect(results).toHaveLength(2);
+    const byText = new Map(
+      results.map((r) => [r.instruction, r.priorSessionCount]),
+    );
+    expect(byText.get("squash before merging")).toBeGreaterThanOrEqual(2);
+    expect(byText.get("biome formatting everywhere")).toBeGreaterThanOrEqual(2);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Fixes the N+1 query Sentry flagged under the `lore.curator` transaction — **LOREAI-GATEWAY-3E** (`N+1 Query`, 44 events, ongoing).

`findRepeatedInstructions` (`packages/core/src/instruction-detect.ts`) looped over up to `MAX_CANDIDATES = 5` instruction candidates and ran a **separate** `distillation_fts MATCH` scan for each one:

```
SELECT d.id, d.session_id
  FROM distillation_fts f
  CROSS JOIN distillations d ON d.rowid = f.rowid
  WHERE distillation_fts MATCH ? AND d.project_id = ?
  ORDER BY rank LIMIT 30
```

That's N identical-fingerprint FTS scans per curation run → the N+1 pattern.

## How

Collapse the per-candidate scans into a **single batched statement**. Each candidate contributes one `UNION ALL` branch tagged with its index and wrapped in a subquery, so the per-candidate `ORDER BY rank LIMIT 30` bound is preserved exactly as before (the `LIMIT` lives inside each subquery, not as a single top-level cap over the union). Rows are grouped back into a `Map<candidateIndex, Set<sessionId>>`.

- **Attribution is unchanged**: the resulting per-candidate session-id set is identical to the old code. (Only intra-candidate row ordering differs, and `d.id` — never used except as a dedup carrier — is no longer projected; dedup keys on `session_id` in both.)
- Candidate index is a trusted loop integer (interpolated as a number); the MATCH expr + project id remain bound params — no injection surface.
- `currentSessionID` exclusion, the `>= threshold` check, and the `< 2 terms` / `EMPTY_QUERY` skips are all preserved.
- The vector-search path (Path A) is byte-identical to `origin/main`.

### Error-handling note

The old code had a per-candidate `try/catch` (a failure isolated to one candidate). The new code has one `try/catch` for the whole batch, so a throw wipes the FTS path for **all** candidates that run. In practice this is not a behavioral regression: every branch is structurally identical and `matchExpr` is already sanitized by `ftsQueryOr`, so the only way to throw is a systemic failure (DB locked, schema missing) — which would have failed all N per-candidate queries in the old code too. Either way it degrades to "no cross-session FTS context this run".

## Tests

- Added a regression test asserting **per-candidate attribution isolation** (a candidate with only 1 matching session must stay below threshold even when another candidate matches 2+ — catches cross-contamination via an exact-count assertion).
- Added a test asserting **every** matching candidate is returned from the batch (not just index 0).
- Vacuity-checked: mutating the candidate-index tag (`SELECT 1 AS cand`) kills 6 tests including both new ones. (Fixtures use raw SQL inserts with no embeddings, so Path A is inert → the FTS tests are deterministic.)
- Full `packages/core` suite: 2714 passed / 6 skipped. Typecheck + Biome clean.

## Notes on the second N+1 (LOREAI-GATEWAY-3G)

The other N+1 (`INSERT INTO tool_calls … ON CONFLICT` in `recordToolCalls`) is a **write-side** loop: 1 event, last seen on release 0.34.0 (current 0.37.0). Those writes are already wrapped in a single savepoint (`storeTurnTemporal`), each row is a genuinely distinct tool call, and the loop reuses a prepared statement — the idiomatic SQLite pattern. Batching it into a multi-row insert is awkward (interleaved INSERT/UPDATE + `ON CONFLICT` CASE logic) for negligible gain. Left as-is; recommend archiving that issue rather than rewriting the write path.