### PR TITLE
fix(core): fail fast with an actionable error when SQLite lacks FTS5

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -2637,10 +2637,12 @@ function applyRefFkDrop(database: Database) {
  */
 export function assertFts5Available(database: Database): void {
   try {
+    // Table name deliberately omits the literal "fts5" so the classifier below
+    // can only match the module name in a real error, never our own probe SQL.
     database.exec(
-      "CREATE VIRTUAL TABLE IF NOT EXISTS temp.lore_fts5_probe USING fts5(x)",
+      "CREATE VIRTUAL TABLE IF NOT EXISTS temp.lore_fulltext_probe USING fts5(x)",
     );
-    database.exec("DROP TABLE IF EXISTS temp.lore_fts5_probe");
+    database.exec("DROP TABLE IF EXISTS temp.lore_fulltext_probe");
   } catch (e: unknown) {
     const detail = e instanceof Error ? e.message : String(e);
     if (!/fts5|no such module/i.test(detail)) throw e;

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -2250,6 +2250,10 @@ export function db(): Database {
   // that resets it — the backstop for the active TRUNCATE checkpoint the idle
   // scheduler runs via checkpointWal(). Default is -1 (never truncate).
   database.exec(`PRAGMA journal_size_limit = ${WAL_JOURNAL_SIZE_LIMIT_BYTES}`);
+  // Preflight: Lore's schema is built on FTS5 virtual tables. If this runtime's
+  // SQLite lacks the FTS5 module, fail fast with an actionable message instead
+  // of a cryptic mid-migration `no such module: fts5` crash-loop (#3M).
+  assertFts5Available(database);
   migrate(database);
   installSyncCapture(database);
   // Load the sqlite-vec native extension (if available) on the RAW connection,
@@ -2611,6 +2615,41 @@ function applyRefFkDrop(database: Database) {
     database.exec("ROLLBACK TO ref_fk_drop");
     database.exec("RELEASE ref_fk_drop");
     throw e;
+  }
+}
+
+/**
+ * Preflight check: verify the runtime's SQLite has the FTS5 full-text search
+ * extension compiled in.
+ *
+ * Every memory feature (temporal / knowledge / entity / distillation search)
+ * is built on FTS5 virtual tables, so a SQLite without it cannot function —
+ * this is a hard requirement, not a degradable one. Some system SQLite builds
+ * (notably on Windows) omit FTS5; without this probe the absence surfaced only
+ * mid-migration as a cryptic `no such module: fts5` that crash-looped on every
+ * request (Sentry LOREAI-GATEWAY-3M). Probing up front lets us fail with a
+ * clear, actionable message.
+ *
+ * The probe creates and drops a connection-scoped TEMP virtual table so it
+ * never touches the persistent schema. Only the absence of the module makes
+ * `CREATE VIRTUAL TABLE ... USING fts5` fail; any other (e.g. disk/IO) error is
+ * unexpected and is surfaced unchanged rather than mislabeled as "FTS5 missing".
+ */
+export function assertFts5Available(database: Database): void {
+  try {
+    database.exec(
+      "CREATE VIRTUAL TABLE IF NOT EXISTS temp.lore_fts5_probe USING fts5(x)",
+    );
+    database.exec("DROP TABLE IF EXISTS temp.lore_fts5_probe");
+  } catch (e: unknown) {
+    const detail = e instanceof Error ? e.message : String(e);
+    if (!/fts5|no such module/i.test(detail)) throw e;
+    throw new Error(
+      `Lore requires SQLite with the FTS5 full-text search extension, but this runtime's SQLite was built without it (${detail}). ` +
+        "FTS5 powers Lore's memory search and cannot be disabled. Use the standalone `lore` binary, or a Node.js/Bun build whose bundled SQLite includes FTS5. " +
+        "See https://www.sqlite.org/fts5.html",
+      { cause: e },
+    );
   }
 }
 

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -63,7 +63,7 @@ describe("db", () => {
       // The probe must clean up after itself — no stray temp table left behind.
       const leftover = database
         .query(
-          "SELECT name FROM sqlite_temp_master WHERE type='table' AND name='lore_fts5_probe'",
+          "SELECT name FROM sqlite_temp_master WHERE type='table' AND name='lore_fulltext_probe'",
         )
         .get() as { name: string } | null;
       expect(leftover).toBeNull();
@@ -101,8 +101,15 @@ describe("db", () => {
         },
       } as unknown as Parameters<typeof assertFts5Available>[0];
 
-      // Must NOT be mislabeled as an FTS5 problem — rethrown as-is.
-      expect(() => assertFts5Available(stub)).toThrow(cause);
+      // Must NOT be mislabeled as an FTS5 problem — rethrown as the SAME object
+      // (identity, not just message), so no wrapping occurred.
+      let thrown: unknown;
+      try {
+        assertFts5Available(stub);
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown).toBe(cause);
     });
   });
 

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -33,6 +33,7 @@ import {
   getDailyCostForDay,
   isUnattributedProjectPath,
   UNATTRIBUTED_PROJECT_PREFIX,
+  assertFts5Available,
 } from "../src/db";
 import { enableHostedMode, _resetHostedModeForTest } from "../src/hosted";
 
@@ -53,6 +54,56 @@ describe("db", () => {
     expect(names).toContain("metadata");
     expect(names).toContain("import_history");
     expect(names).toContain("tool_calls");
+  });
+
+  describe("assertFts5Available", () => {
+    test("passes on a runtime whose SQLite has FTS5 and leaves no temp table", () => {
+      const database = db();
+      expect(() => assertFts5Available(database)).not.toThrow();
+      // The probe must clean up after itself — no stray temp table left behind.
+      const leftover = database
+        .query(
+          "SELECT name FROM sqlite_temp_master WHERE type='table' AND name='lore_fts5_probe'",
+        )
+        .get() as { name: string } | null;
+      expect(leftover).toBeNull();
+    });
+
+    test("throws an actionable FTS5 error when the module is missing", () => {
+      // Stub a connection whose exec fails exactly as an FTS5-less SQLite does.
+      const cause = new Error("no such module: fts5");
+      const stub = {
+        exec: () => {
+          throw cause;
+        },
+      } as unknown as Parameters<typeof assertFts5Available>[0];
+
+      let thrown: unknown;
+      try {
+        assertFts5Available(stub);
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown).toBeInstanceOf(Error);
+      const msg = (thrown as Error).message;
+      expect(msg).toContain("FTS5");
+      expect(msg).toContain("no such module: fts5");
+      // Actionable guidance + preserved cause for debugging.
+      expect(msg).toMatch(/lore` binary|Node\.js\/Bun|sqlite\.org\/fts5/);
+      expect((thrown as Error).cause).toBe(cause);
+    });
+
+    test("surfaces an unexpected (non-FTS5) probe error unchanged", () => {
+      const cause = new Error("disk I/O error");
+      const stub = {
+        exec: () => {
+          throw cause;
+        },
+      } as unknown as Parameters<typeof assertFts5Available>[0];
+
+      // Must NOT be mislabeled as an FTS5 problem — rethrown as-is.
+      expect(() => assertFts5Available(stub)).toThrow(cause);
+    });
   });
 
   test("schema version is set", () => {


### PR DESCRIPTION
## What

Fixes **LOREAI-GATEWAY-3M** (`Error: no such module: fts5`, 23 events / 1 user, `db.ts` `migrate`, observed on Windows).

Lore's entire memory schema — `temporal_fts`, `knowledge_fts`, `distillation_fts`, `entities_fts`, `entity_aliases_fts`, `lat_sections_fts` — is built on FTS5 virtual tables. On a runtime whose SQLite was compiled **without** the FTS5 module, the absence only surfaced deep inside `migrate()` (`CREATE VIRTUAL TABLE … USING fts5`) as a cryptic `no such module: fts5`, which then crash-looped on every request (23 events in ~1h from one user).

## How

Add an `assertFts5Available()` preflight probe that runs on the `db()` init path, **before** `migrate()`:

- Creates and drops a connection-scoped `temp.lore_fulltext_probe` fts5 virtual table (never touches the persistent schema).
- On the module-missing error, throws a clear, actionable message: use the standalone `lore` binary, or a Node.js/Bun build whose bundled SQLite includes FTS5 (+ link to sqlite.org/fts5). The original error is preserved as `cause`.
- Any **other** (e.g. disk/IO) probe failure is surfaced unchanged rather than mislabeled as "FTS5 missing".

FTS5 is a hard requirement (every search path depends on it) and can't be degraded, so this **fails fast with a clear message** instead of a cryptic mid-migration crash. This doesn't make an FTS5-less runtime work — it turns an undiagnosable crash-loop into an actionable one.

## Tests

- **Pass path**: probe succeeds on the test runtime and leaves no stray temp table.
- **Missing-module path**: a stub `exec` throwing `no such module: fts5` produces an error whose message contains `FTS5` + the guidance, with `cause` preserved.
- **Unexpected-error path**: a non-FTS5 error (`disk I/O error`) is rethrown unchanged (asserted by object identity).

`packages/core/test/db.test.ts`: 112 passed. Typecheck + Biome clean.

## Review notes

Adversarial review verdict: **SHIP-WITH-FOLLOWUPS** (mutation-tested; three unit tests all mutation-killed). Applied follow-ups in this PR: renamed the probe table to drop the literal `fts5` substring (removes a theoretical classifier false-positive) and tightened the rethrow test to assert object identity.

**Known limitation:** the call-site wiring (the `assertFts5Available(database)` statement in `db()`) is not covered by an automated test — on an FTS5-capable CI runner the probe is a silent no-op, and there is no clean injection seam without a DI refactor of the hot `db()` init path. The probed function itself is fully unit-tested; the single unconditional call site is verified by inspection.