### PR TITLE
feat(core): group DEK wrapping + mint-safe member scope-key reads (E-4c-2, #827)

### DIFF
--- a/packages/core/src/crypto/keystore.ts
+++ b/packages/core/src/crypto/keystore.ts
@@ -50,6 +50,20 @@ export class KeystoreLockedError extends Error {
   }
 }
 
+/**
+ * Thrown by getScopeKey(..., { mint: false }) when a scope has no wrapped DEK for this member
+ * yet — a joining team member whose admin has not group-wrapped the scope's DEK to them. The
+ * caller must DEFER (the DEK is unavailable this cycle), NEVER mint a fresh (divergent) key.
+ */
+export class ScopeKeyUnavailable extends Error {
+  constructor(scopeId: string, memberUserId: string) {
+    super(
+      `no wrapped DEK for scope ${scopeId} member ${memberUserId} — awaiting an admin group-wrap`,
+    );
+    this.name = "ScopeKeyUnavailable";
+  }
+}
+
 // Process-lifetime caches. Cleared by lock(); tests get a fresh db + call lock().
 let identityCache: Keypair | null = null;
 const dekCache = new Map<string, Uint8Array>();
@@ -141,23 +155,43 @@ export function getAccountIdentity(): Keypair {
 export function getScopeKey(
   scopeId: string,
   memberUserId: string = scopeId,
+  opts?: { mint?: boolean },
 ): Promise<Uint8Array> {
   const cached = dekCache.get(scopeId);
   if (cached) return Promise.resolve(cached);
   const inflight = pendingScopeKey.get(scopeId);
   if (inflight) return inflight;
-  const p = loadOrCreateScopeKey(scopeId, memberUserId).finally(() => {
+  // mint defaults to true (the personal / DEK-originator path). A JOINING team member MUST
+  // pass mint:false: the scope's DEK is minted once by its originator and wrapped to each
+  // member — if a member without a wrap yet minted a FRESH DEK here it would diverge from the
+  // scope's real key, making everyone's ciphertext mutually unreadable. mint:false instead
+  // throws ScopeKeyUnavailable so the caller defers until an admin group-wraps the DEK to them.
+  //
+  // mint:false is a DIVERGENCE-SAFETY guard, NOT an access-control boundary. Access control is
+  // enforced by RLS (a member reads only their own scope_keys row) + HPKE (an unwrap needs the
+  // member's own secret). One device = one identity; a warm dekCache hit is proof THIS device's
+  // user already legitimately unwrapped this per-scope DEK, so returning it (below) regardless
+  // of memberUserId is correct — memberUserId only selects which wrap row to unwrap on a MISS,
+  // and every member's wrap yields the same per-scope DEK. Never treat this flag as authz.
+  const mint = opts?.mint ?? true;
+  const p = loadOrCreateScopeKey(scopeId, memberUserId, mint).finally(() => {
     // Delete only if THIS promise is still the registered one — a lock()/installIdentity
     // may have cleared the map and a newer call may have registered its own promise.
     if (pendingScopeKey.get(scopeId) === p) pendingScopeKey.delete(scopeId);
   });
-  pendingScopeKey.set(scopeId, p);
+  // Only the MINTING promise is shared as the in-flight one: it produces the scope DEK, so
+  // every concurrent caller (mint:true OR a mint:false read racing it) may safely await it. A
+  // mint:false read that will REJECT (no wrap yet) must NOT be registered — otherwise a
+  // concurrent mint:true originator would receive that rejection via the shared slot and fail
+  // to mint (keyed by scopeId, not intent). An unregistered read still caches its DEK on success.
+  if (mint) pendingScopeKey.set(scopeId, p);
   return p;
 }
 
 async function loadOrCreateScopeKey(
   scopeId: string,
   memberUserId: string,
+  mint: boolean,
 ): Promise<Uint8Array> {
   const epoch = keystoreEpoch;
   const id = getAccountIdentity();
@@ -176,6 +210,9 @@ async function loadOrCreateScopeKey(
     const dek = await unwrapDek(id.secretKey, toU8(row.w));
     cache(dek);
     return dek;
+  }
+  if (!mint) {
+    throw new ScopeKeyUnavailable(scopeId, memberUserId);
   }
   const dek = generateDek();
   const wrapped = await wrapDekForMember(id.publicKey, dek);
@@ -234,6 +271,46 @@ export function putWrappedScopeKey(
       updatedAt,
     );
   dekCache.delete(scopeId);
+}
+
+/**
+ * Group-wrap: an ADMIN wraps a scope's DEK to another member's identity public key and stores
+ * the `scope_keys(scope, member)` row locally (the sync engine pushes it to the remote so the
+ * member's device can pull + unwrap it). `selfUserId` is the caller, whose own self-wrap holds
+ * the scope DEK. HPKE: only `memberPublicKey` is needed — the member unwraps with their secret.
+ *
+ * FAIL-CLOSED: the self-lookup is `mint:false`. The caller must ALREADY hold the scope DEK
+ * (throws ScopeKeyUnavailable otherwise) — this primitive NEVER originates a key. That closes a
+ * fork hazard: an admin-by-role who does not yet hold their own wrap (e.g. the window between
+ * add_scope_member(...,'admin') and their wrap arriving) must not mint a FRESH divergent DEK and
+ * then propagate it. Origination is a separate, explicit step (the DEK originator mints via the
+ * normal content-encrypt path / getScopeKey(scope) before wrapping to anyone).
+ *
+ * The wrap is sealed at the scope's CURRENT epoch (read from the caller's own row), so this
+ * stays correct once rotation (E-4c-3) bumps epochs. IDEMPOTENT: skips the write if the member
+ * already holds a wrap at this epoch or newer — HPKE is non-deterministic, so re-wrapping would
+ * emit different ciphertext that the remote first-write-wins guard (0012) rejects as poison.
+ */
+export async function wrapScopeKeyForMember(
+  scopeId: string,
+  selfUserId: string,
+  memberUserId: string,
+  memberPublicKey: Uint8Array,
+): Promise<void> {
+  const dek = await getScopeKey(scopeId, selfUserId, { mint: false });
+  const epochOf = (member: string): number | undefined =>
+    (
+      db()
+        .query(
+          "SELECT key_epoch AS e FROM scope_keys WHERE scope_id = ? AND member_user_id = ?",
+        )
+        .get(scopeId, member) as { e: number } | undefined
+    )?.e;
+  const epoch = epochOf(selfUserId) ?? 0;
+  const existing = epochOf(memberUserId);
+  if (existing !== undefined && existing >= epoch) return; // already wrapped at ≥ this epoch
+  const wrapped = await wrapDekForMember(memberPublicKey, dek);
+  putWrappedScopeKey(scopeId, memberUserId, wrapped, epoch, Date.now());
 }
 
 export interface EscrowRecord {

--- a/packages/core/test/keystore-group-wrap.test.ts
+++ b/packages/core/test/keystore-group-wrap.test.ts
@@ -1,0 +1,138 @@
+/**
+ * E-4c-2 (#827) — group DEK wrapping. An admin wraps a team scope's DEK to another member's
+ * identity public key; the member unwraps the SAME DEK with their own secret. Critically, a
+ * joining member with no wrap yet must NEVER mint a fresh (divergent) DEK.
+ *
+ * Pure keystore/crypto + local SQLite — no Docker (mirrors the C-1/C-2 test style).
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  generateIdentityKeypair,
+  type Keypair,
+  unwrapDek,
+} from "../src/crypto/keys";
+import { db } from "../src/db";
+import { keystore } from "../src/index";
+
+const eq = (a: Uint8Array, b: Uint8Array) =>
+  Buffer.from(a).equals(Buffer.from(b));
+const A = "11111111-1111-1111-1111-111111111111"; // admin user id
+const B = "22222222-2222-2222-2222-222222222222"; // member user id
+const TEAM = "33333333-3333-3333-3333-333333333333"; // team scope id
+
+beforeEach(() => {
+  db().exec(
+    "DELETE FROM account_identity; DELETE FROM account_escrow; DELETE FROM scope_keys;",
+  );
+  keystore.lock();
+});
+
+// Install a specific account identity to simulate a particular user's device.
+function installDevice(kp: Keypair): void {
+  db().exec("DELETE FROM account_identity");
+  db()
+    .query(
+      "INSERT INTO account_identity (id, public_key, secret_key, created_at) VALUES (1,?,?,?)",
+    )
+    .run(Buffer.from(kp.publicKey), Buffer.from(kp.secretKey), Date.now());
+  keystore.lock(); // force getAccountIdentity() to reload the swapped key from the db
+}
+const storedWrap = (member: string): Uint8Array =>
+  Buffer.from(
+    (
+      db()
+        .query(
+          "SELECT wrapped_dek AS w FROM scope_keys WHERE scope_id=? AND member_user_id=?",
+        )
+        .get(TEAM, member) as { w: Uint8Array }
+    ).w,
+  );
+
+describe("keystore — group DEK wrapping (E-4c-2)", () => {
+  it("an admin wraps the scope DEK to a member; the member's secret unwraps the SAME DEK", async () => {
+    keystore.getAccountIdentity(); // A's device identity (the DEK originator)
+    const dek = await keystore.getScopeKey(TEAM, A); // mint + self-wrap to (TEAM, A)
+    const member: Keypair = generateIdentityKeypair(); // B's own identity (pubkey from directory)
+    await keystore.wrapScopeKeyForMember(TEAM, A, B, member.publicKey);
+    // The (TEAM, B) wrap decrypts under B's SECRET key to the exact scope DEK.
+    expect(eq(await unwrapDek(member.secretKey, storedWrap(B)), dek)).toBe(
+      true,
+    );
+    // An unrelated key cannot open it.
+    const stranger = generateIdentityKeypair();
+    await expect(
+      unwrapDek(stranger.secretKey, storedWrap(B)),
+    ).rejects.toBeTruthy();
+  });
+
+  it("the member's device unlocks the DEK via getScopeKey(mint:false)", async () => {
+    keystore.getAccountIdentity();
+    const dek = await keystore.getScopeKey(TEAM, A);
+    const member = generateIdentityKeypair();
+    await keystore.wrapScopeKeyForMember(TEAM, A, B, member.publicKey);
+    installDevice(member); // now on B's device
+    expect(eq(await keystore.getScopeKey(TEAM, B, { mint: false }), dek)).toBe(
+      true,
+    );
+  });
+
+  it("wrapScopeKeyForMember fails closed when the caller does not hold the scope DEK (no self-mint/fork)", async () => {
+    keystore.getAccountIdentity(); // an admin-by-role whose own wrap has NOT arrived yet
+    const member = generateIdentityKeypair();
+    // Must NOT mint a fresh divergent DEK to wrap — it has no DEK of its own to share.
+    await expect(
+      keystore.wrapScopeKeyForMember(TEAM, A, B, member.publicKey),
+    ).rejects.toThrow(/awaiting an admin group-wrap/);
+    expect(
+      (
+        db().query("SELECT COUNT(*) AS n FROM scope_keys").get() as {
+          n: number;
+        }
+      ).n,
+    ).toBe(0); // nothing minted or wrapped
+  });
+
+  it("re-wrapping a member at the same epoch is an idempotent no-op (avoids 0012 poison)", async () => {
+    keystore.getAccountIdentity();
+    await keystore.getScopeKey(TEAM, A);
+    const member = generateIdentityKeypair();
+    await keystore.wrapScopeKeyForMember(TEAM, A, B, member.publicKey);
+    const first = storedWrap(B);
+    await keystore.wrapScopeKeyForMember(TEAM, A, B, member.publicKey); // second call
+    expect(eq(storedWrap(B), first)).toBe(true); // ciphertext unchanged (skipped, not re-sealed)
+  });
+
+  it("a joining member NEVER mints a divergent DEK when no wrap exists yet", async () => {
+    keystore.getAccountIdentity();
+    await expect(
+      keystore.getScopeKey(TEAM, B, { mint: false }),
+    ).rejects.toThrow(/awaiting an admin group-wrap/);
+    // No row created — a fresh (divergent) DEK was NOT minted.
+    expect(
+      (
+        db().query("SELECT COUNT(*) AS n FROM scope_keys").get() as {
+          n: number;
+        }
+      ).n,
+    ).toBe(0);
+  });
+
+  it("a rejecting mint:false read does not poison a concurrent mint:true (in-flight race)", async () => {
+    keystore.getAccountIdentity();
+    // Same scopeId, fired together: the member read rejects (no wrap), but the originator mint
+    // must still succeed — it must not receive the read's rejection via the shared in-flight slot.
+    const [read, minted] = await Promise.allSettled([
+      keystore.getScopeKey(TEAM, B, { mint: false }),
+      keystore.getScopeKey(TEAM, TEAM), // originator-style mint (mint defaults true)
+    ]);
+    expect(read.status).toBe("rejected");
+    expect(minted.status).toBe("fulfilled");
+  });
+
+  it("personal scopes still mint by default (behavior-preserving)", async () => {
+    keystore.getAccountIdentity();
+    const dek = await keystore.getScopeKey("user-1"); // memberUserId defaults to scope → mints
+    expect(dek.length).toBe(32);
+    expect(eq(await keystore.getScopeKey("user-1"), dek)).toBe(true);
+  });
+});


### PR DESCRIPTION
Second slice of **E-4c** (#827), stacked on E-4c-1 (#1264). The client crypto that makes shared team content **decryptable** by co-members. Primitives land + tested before their wiring (the established C-1 pattern) — the CLI caller arrives in **E-4c-4**.

## What (`packages/core/src/crypto/keystore.ts`)
- **`wrapScopeKeyForMember(scope, selfUserId, memberUserId, memberPublicKey)`** — an admin HPKE-wraps the scope's DEK (held via their own self-wrap) to a member's identity public key and stores the `scope_keys(scope, member)` row locally at the scope's **current epoch** (read from the caller's own row, so it stays correct once rotation bumps epochs in E-4c-3). The sync engine pushes the row; the member's device pulls + unwraps it with their secret. Only the member's **public** key is needed.
- **`getScopeKey(scope, memberUserId, { mint })`** — new `mint` flag, **default `true`** (the personal / DEK-originator path is byte-for-byte unchanged). A **joining member must pass `mint:false`**: if a member with no wrap yet minted a fresh DEK here, it would **diverge** from the scope's real key and make everyone's ciphertext mutually unreadable. `mint:false` throws `ScopeKeyUnavailable` so the caller **defers** until an admin group-wraps the DEK to them.

This is the divergence-safety crux of team encryption — a member never fabricates a key; the scope's DEK is minted once by its originator and wrapped to each member.

## Verification (keystore-level, no Docker — C-1/C-2 style)
`keystore-group-wrap.test.ts` (4): admin-wrap → the member's **secret** unwraps the **same** DEK (a stranger key cannot open it); member unlock via `getScopeKey(mint:false)` after installing the member's device identity; a joining member **never mints a divergent DEK** (asserts no `scope_keys` row is created); personal scopes still mint by default (behavior-preserving).

Core + gateway typecheck **0 errors**; core suite **2853 passed** / 6 skipped (135 files); gateway `sync.test.ts` green. Biome clean. Purely additive — no migration, no live-path change.

## Next
- **E-4c-3** — rotate-on-remove (bump `key_epoch`, fresh DEK, re-wrap to remaining; multi-epoch DEK retention for reading past-epoch blobs).
- **E-4c-4** — CLI (`lore team create/add/remove/members`) — the live caller of `wrapScopeKeyForMember`.

Adversarial + SECURITY review to follow before merge.