### PR TITLE
feat(core,gateway): persist per-bucket worker cost breakdown for cost observability

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1705,6 +1705,19 @@ const MIGRATIONS: string[] = [
   `
   ALTER TABLE temporal_messages ADD COLUMN restored_at INTEGER;
   `,
+  // Version 68 (#961 follow-up): session_state.worker_breakdown — a LOCAL-ONLY JSON
+  // snapshot of per-bucket worker spend, shaped
+  // {distillation,curation,compaction,recall,warmup: {cost,calls}}. Until now only the
+  // AGGREGATE worker_cost was persisted, so once a session ended the split across
+  // background tasks was lost — you couldn't tell whether distillation, curation, or
+  // recall drove the worker overhead. This column captures the breakdown for cost
+  // observability (UI + `lore eval`). NULL for pre-migration / never-costed rows (readers
+  // fall back to the aggregate worker_cost). NEVER synced (not in session_state's sync
+  // surface — it's derived local telemetry). Re-runs harmlessly on recovery
+  // (stripAppliedAlters drops the duplicate ALTER).
+  `
+  ALTER TABLE session_state ADD COLUMN worker_breakdown TEXT;
+  `,
 ];
 
 // Index of the migration whose work is performed by a column-presence-aware JS
@@ -3816,6 +3829,20 @@ export function saveForceMinLayer(sessionID: string, layer: number): void {
 }
 
 /** Persisted cost snapshot for a session. */
+/**
+ * Per-bucket worker (background-task) spend. Mirrors the in-memory
+ * `SessionCosts["workers"]` shape in the gateway cost-tracker. Persisted as JSON
+ * in `session_state.worker_breakdown` so the split survives the session and can
+ * be inspected for cost observability. `cost` is USD; `calls` is the LLM call count.
+ */
+export type WorkerCostBreakdown = {
+  distillation: { cost: number; calls: number };
+  curation: { cost: number; calls: number };
+  compaction: { cost: number; calls: number };
+  recall: { cost: number; calls: number };
+  warmup: { cost: number; calls: number };
+};
+
 export type SessionCostSnapshot = {
   conversationCost: number;
   workerCost: number;
@@ -3831,6 +3858,12 @@ export type SessionCostSnapshot = {
   batchSavings: number;
   avoidedCompactions: number;
   avoidedCompactionCost: number;
+  /**
+   * Per-bucket worker spend split. Absent (undefined) when unavailable
+   * (pre-migration rows, or sessions written before this field existed) —
+   * readers fall back to the aggregate `workerCost`.
+   */
+  workerBreakdown?: WorkerCostBreakdown;
 };
 
 /**
@@ -3847,8 +3880,8 @@ export function saveSessionCosts(
          conversation_cost, worker_cost, conversation_turns,
          cache_read_tokens, cache_write_tokens,
          warmup_savings, warmup_cost, warmup_hits, ttl_savings, ttl_hits, batch_savings,
-         avoided_compactions, avoided_compaction_cost)
-       VALUES (?, COALESCE((SELECT force_min_layer FROM session_state WHERE session_id = ?), 0), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         avoided_compactions, avoided_compaction_cost, worker_breakdown)
+       VALUES (?, COALESCE((SELECT force_min_layer FROM session_state WHERE session_id = ?), 0), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT(session_id) DO UPDATE SET
          conversation_cost = excluded.conversation_cost,
          worker_cost = excluded.worker_cost,
@@ -3863,6 +3896,7 @@ export function saveSessionCosts(
          batch_savings = excluded.batch_savings,
          avoided_compactions = excluded.avoided_compactions,
          avoided_compaction_cost = excluded.avoided_compaction_cost,
+         worker_breakdown = excluded.worker_breakdown,
          updated_at = excluded.updated_at`,
     )
     .run(
@@ -3882,7 +3916,24 @@ export function saveSessionCosts(
       costs.batchSavings,
       costs.avoidedCompactions,
       costs.avoidedCompactionCost,
+      costs.workerBreakdown ? JSON.stringify(costs.workerBreakdown) : null,
     );
+}
+
+/**
+ * Parse a `worker_breakdown` JSON column value into a WorkerCostBreakdown.
+ * Returns null for missing/blank/invalid JSON so a corrupt or pre-migration
+ * value never throws on the read path — callers fall back to the aggregate.
+ */
+function parseWorkerBreakdown(raw: unknown): WorkerCostBreakdown | undefined {
+  if (typeof raw !== "string" || raw.length === 0) return undefined;
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return undefined;
+    return parsed as WorkerCostBreakdown;
+  } catch {
+    return undefined;
+  }
 }
 
 /**
@@ -3897,7 +3948,7 @@ export function loadSessionCosts(
       `SELECT conversation_cost, worker_cost, conversation_turns,
               cache_read_tokens, cache_write_tokens,
               warmup_savings, warmup_cost, warmup_hits, ttl_savings, ttl_hits, batch_savings,
-              avoided_compactions, avoided_compaction_cost
+              avoided_compactions, avoided_compaction_cost, worker_breakdown
        FROM session_state WHERE session_id = ?`,
     )
     .get(sessionID) as {
@@ -3914,6 +3965,7 @@ export function loadSessionCosts(
     batch_savings: number;
     avoided_compactions: number;
     avoided_compaction_cost: number;
+    worker_breakdown: string | null;
   } | null;
   if (!row) return null;
   return {
@@ -3930,6 +3982,7 @@ export function loadSessionCosts(
     batchSavings: row.batch_savings,
     avoidedCompactions: row.avoided_compactions,
     avoidedCompactionCost: row.avoided_compaction_cost,
+    workerBreakdown: parseWorkerBreakdown(row.worker_breakdown),
   };
 }
 
@@ -3943,7 +3996,7 @@ export function loadAllSessionCosts(): Map<string, SessionCostSnapshot> {
       `SELECT session_id, conversation_cost, worker_cost, conversation_turns,
               cache_read_tokens, cache_write_tokens,
               warmup_savings, warmup_cost, warmup_hits, ttl_savings, ttl_hits, batch_savings,
-              avoided_compactions, avoided_compaction_cost
+              avoided_compactions, avoided_compaction_cost, worker_breakdown
        FROM session_state
        WHERE conversation_turns > 0 OR warmup_savings > 0 OR warmup_cost > 0 OR ttl_savings > 0 OR batch_savings > 0`,
     )
@@ -3962,6 +4015,7 @@ export function loadAllSessionCosts(): Map<string, SessionCostSnapshot> {
     batch_savings: number;
     avoided_compactions: number;
     avoided_compaction_cost: number;
+    worker_breakdown: string | null;
   }>;
   const result = new Map<string, SessionCostSnapshot>();
   for (const row of rows) {
@@ -3979,6 +4033,7 @@ export function loadAllSessionCosts(): Map<string, SessionCostSnapshot> {
       batchSavings: row.batch_savings,
       avoidedCompactions: row.avoided_compactions,
       avoidedCompactionCost: row.avoided_compaction_cost,
+      workerBreakdown: parseWorkerBreakdown(row.worker_breakdown),
     });
   }
   return result;

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -59,7 +59,7 @@ describe("db", () => {
     const row = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(row.version).toBe(67);
+    expect(row.version).toBe(68);
   });
 
   test("v55: confidence/last_reinforced_at moved to knowledge_meta, exposed via view", () => {
@@ -116,7 +116,7 @@ describe("db", () => {
     const ver = fresh.query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(ver.version).toBe(67);
+    expect(ver.version).toBe(68);
     // Register + JOIN view were rebuilt and are queryable (confidence exposed).
     expect(
       fresh
@@ -888,6 +888,59 @@ describe("db", () => {
     saveSessionCosts(sid, snapshot);
     const loaded = loadSessionCosts(sid);
     expect(loaded).toEqual(snapshot);
+  });
+
+  test("saveSessionCosts round-trips the per-bucket worker breakdown", () => {
+    const sid = `test-costs-breakdown-${crypto.randomUUID()}`;
+    const workerBreakdown = {
+      distillation: { cost: 0.5, calls: 4 },
+      curation: { cost: 0.2, calls: 2 },
+      compaction: { cost: 0.05, calls: 1 },
+      recall: { cost: 0.05, calls: 3 },
+      warmup: { cost: 0.1, calls: 1 },
+    };
+    saveSessionCosts(sid, {
+      conversationCost: 2.0,
+      workerCost: 0.9,
+      conversationTurns: 12,
+      cacheReadTokens: 1000,
+      cacheWriteTokens: 100,
+      warmupSavings: 0,
+      warmupCost: 0.1,
+      warmupHits: 0,
+      ttlSavings: 0,
+      ttlHits: 0,
+      batchSavings: 0,
+      avoidedCompactions: 0,
+      avoidedCompactionCost: 0,
+      workerBreakdown,
+    });
+    // Survives both the single-session and bulk load paths.
+    expect(loadSessionCosts(sid)?.workerBreakdown).toEqual(workerBreakdown);
+    expect(loadAllSessionCosts().get(sid)?.workerBreakdown).toEqual(
+      workerBreakdown,
+    );
+  });
+
+  test("loadSessionCosts leaves workerBreakdown undefined for legacy rows (none stored)", () => {
+    const sid = `test-costs-nobreakdown-${crypto.randomUUID()}`;
+    saveSessionCosts(sid, {
+      conversationCost: 1.0,
+      workerCost: 0.2,
+      conversationTurns: 3,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      warmupSavings: 0,
+      warmupCost: 0,
+      warmupHits: 0,
+      ttlSavings: 0,
+      ttlHits: 0,
+      batchSavings: 0,
+      avoidedCompactions: 0,
+      avoidedCompactionCost: 0,
+      // workerBreakdown intentionally omitted → column stored NULL
+    });
+    expect(loadSessionCosts(sid)?.workerBreakdown).toBeUndefined();
   });
 
   test("saveSessionCosts overwrites existing data", () => {

--- a/packages/core/test/ltm-versioning.test.ts
+++ b/packages/core/test/ltm-versioning.test.ts
@@ -39,11 +39,11 @@ function ftsHits(token: string): number {
 }
 
 describe("A2 sub-PR 1: append-only knowledge scaffolding", () => {
-  test("schema version is 67", () => {
+  test("schema version is 68", () => {
     const v = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(v.version).toBe(67);
+    expect(v.version).toBe(68);
   });
 
   test("create() defaults logical_id = id, version 1, current, not deleted", () => {

--- a/packages/gateway/src/cost-tracker.ts
+++ b/packages/gateway/src/cost-tracker.ts
@@ -163,6 +163,22 @@ export type HistoricalEstimates = {
     totalWorkerCost: number;
     /** Persisted conversation cost (from sessions that went idle). */
     persistedConversationCost: number;
+    /**
+     * Per-bucket worker spend, accumulated from persisted
+     * `session_state.worker_breakdown` snapshots. Sessions written before this
+     * field existed (pre-migration) contribute to `totalWorkerCost` but not
+     * here, so this is a best-effort attribution view of where worker cost went.
+     * Warmup is intentionally EXCLUDED here — it is already aggregated in the
+     * dedicated `warmupCost` field, and duplicating it would risk a double-count
+     * if a caller ever summed both. (The per-session `worker_breakdown` JSON
+     * still carries all five buckets as a faithful snapshot.)
+     */
+    workerBreakdown: {
+      distillation: { cost: number; calls: number };
+      curation: { cost: number; calls: number };
+      compaction: { cost: number; calls: number };
+      recall: { cost: number; calls: number };
+    };
   };
 };
 
@@ -1145,6 +1161,12 @@ export function computeHistoricalEstimates(
     messageCount: 0,
     totalWorkerCost: 0,
     persistedConversationCost: 0,
+    workerBreakdown: {
+      distillation: { cost: 0, calls: 0 },
+      curation: { cost: 0, calls: 0 },
+      compaction: { cost: 0, calls: 0 },
+      recall: { cost: 0, calls: 0 },
+    },
   };
 
   const sessionEstimates: HistoricalEstimates["sessions"] = [];
@@ -1282,6 +1304,24 @@ export function computeHistoricalEstimates(
         // The persisted workerCost includes all 5 buckets (distillation, curation,
         // compaction, recall, warmup) from exact API-reported usage.
         totals.totalWorkerCost += persisted.workerCost;
+
+        // Attribute the aggregate to buckets when the split was persisted
+        // (session_state.worker_breakdown). Older rows lack it and contribute
+        // only to totalWorkerCost above. Warmup is deliberately omitted here —
+        // it is aggregated separately in totals.warmupCost, so summing it into
+        // the breakdown too would double-count.
+        const bd = persisted.workerBreakdown;
+        if (bd) {
+          for (const k of [
+            "distillation",
+            "curation",
+            "compaction",
+            "recall",
+          ] as const) {
+            totals.workerBreakdown[k].cost += bd[k]?.cost ?? 0;
+            totals.workerBreakdown[k].calls += bd[k]?.calls ?? 0;
+          }
+        }
 
         // Prefer persisted avoided compaction data over re-simulation.
         // Live tracking uses real API-reported total input tokens; the

--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -137,6 +137,9 @@ function persistSessionCosts(sessionID: string): void {
       batchSavings: costs.batchSavings,
       avoidedCompactions: costs.counterfactual.avoidedCompactions,
       avoidedCompactionCost: costs.counterfactual.avoidedCompactionCost,
+      // Per-bucket split so the worker overhead can be attributed to
+      // distillation / curation / compaction / recall / warmup after the fact.
+      workerBreakdown: costs.workers,
     });
   }
 }

--- a/packages/gateway/src/ui.ts
+++ b/packages/gateway/src/ui.ts
@@ -3002,6 +3002,22 @@ function pageCosts(): string {
       body += ` <span style="color:var(--fg3);font-size:0.85em">(distillation-only estimate: ${formatUSD(hist.distillationCost)})</span>`;
     }
     body += `</td></tr>`;
+    // Break out where the worker overhead actually went, by background task.
+    // Populated from persisted per-bucket snapshots (session_state.worker_breakdown);
+    // sessions recorded before that column existed contribute to the total above
+    // but not to these rows.
+    const wb = hist.workerBreakdown;
+    const bucketRow = (
+      label: string,
+      b: { cost: number; calls: number },
+    ): string =>
+      b.cost > 0
+        ? `<tr><td style="padding-left:1.4em;color:var(--fg3);font-size:0.9em">— ${label}</td><td style="color:var(--fg3);font-size:0.9em">${formatUSD(b.cost)} <span style="font-size:0.85em">(&times;${b.calls})</span></td></tr>`
+        : "";
+    body += bucketRow("distillation", wb.distillation);
+    body += bucketRow("curation", wb.curation);
+    body += bucketRow("compaction", wb.compaction);
+    body += bucketRow("recall", wb.recall);
     // Break out the cache-warmup cost as a visible component of worker overhead.
     // It is ALREADY included in totalWorkerCost above (so the net below is not
     // double-subtracted) — this row just surfaces how much of the overhead is


### PR DESCRIPTION
## Why

While scoping worker-cost reduction (#961 follow-up), I found we can't actually **see** where background/worker spend goes. `session_state` persists only the aggregate `worker_cost`; the per-bucket split (distillation / curation / compaction / recall / warmup) is computed in-memory by the cost tracker and lost when the session ends. So "is distillation or curation driving the ~$1.67/task overhead?" is unanswerable after the fact.

This is the measuring stick: persist the split so it survives the session, is SQL-queryable, and shows up in the cost UI. It also unblocks the eval's full cost accounting and doubles as a user-facing transparency feature.

## What

- **Migration v68**: `session_state.worker_breakdown TEXT` — a local-only JSON snapshot `{distillation,curation,compaction,recall,warmup: {cost,calls}}`. NULL for pre-migration rows (readers fall back to aggregate). Never synced. Re-runs harmlessly on recovery (`stripAppliedAlters`).
- **db.ts**: `WorkerCostBreakdown` type + `workerBreakdown?` on `SessionCostSnapshot`; threaded through `saveSessionCosts` / `loadSessionCosts` / `loadAllSessionCosts` with a defensive `parseWorkerBreakdown` (bad/blank JSON → `undefined`, never throws on the read path).
- **idle.ts** `persistSessionCosts`: feeds `costs.workers` into the snapshot.
- **cost-tracker.ts**: accumulates a per-bucket `workerBreakdown` in `HistoricalEstimates.totals` from persisted snapshots.
- **ui.ts**: breaks out distillation / curation / compaction / recall rows under "Lore Overhead" (cache warming row already existed).

## Notes

- Purely additive + local telemetry. No sync surface change, no hot-path impact (writes happen in the existing idle `persistSessionCosts`).
- `schema_version` assertions bumped 67→68 in two tests (migration count).
- Optional field is `undefined` when absent (not `null`) so existing `toEqual` round-trip assertions stay valid.

## Tests

- New round-trip test (single + bulk load) for the breakdown, and a legacy-row test (no breakdown → `undefined`).
- Mutation-verified: nulling the persist bind makes the round-trip test fail; reverting restores green.
- Full `db.test.ts`, `ltm-versioning`, and gateway cost-tracker/idle suites green. tsc clean (core + gateway).