### PR TITLE
fix(gateway): don't escalate credential-class worker failures to Sentry (3J)

### DIFF
--- a/packages/gateway/src/worker-health.ts
+++ b/packages/gateway/src/worker-health.ts
@@ -70,6 +70,29 @@ export type FailureReason =
   // visibility and cache the verdict so we stop calling that model.
   | "worker-incapable";
 
+/**
+ * Failure reasons that are credential/config conditions rather than upstream
+ * outages. On a self-hosted gateway (the common case), these mean the user
+ * hasn't provided a usable worker credential — NOT that lore or the upstream is
+ * broken — so they are not actionable bugs for the lore team and must never
+ * spawn a "Worker health degraded/critical" Sentry issue (LOREAI-GATEWAY-3J).
+ *
+ * They are NOT fully silenced (unlike `worker-incapable`, which early-returns):
+ * the local error log, the time-based degraded/critical STATUS, the user-facing
+ * `lore doctor` warning, and the circuit breaker are all preserved so the user
+ * still gets an actionable local signal. Only the Sentry escalation is
+ * suppressed, and only when EVERY failure in the current window is
+ * credential-class — a window mixing in any genuine outage reason still
+ * escalates. Both reasons also have dedicated handling elsewhere: `no-auth` is
+ * pre-guarded at scheduling (idle.ts / scheduleBackgroundWork) and self-limits
+ * once the session credential goes stale; `cross-provider` is soft-paused at
+ * the call site via {@link markWorkerPaused}.
+ */
+const CREDENTIAL_CLASS_REASONS: ReadonlySet<FailureReason> = new Set([
+  "no-auth",
+  "cross-provider",
+]);
+
 /** Snapshot of a session's worker health, suitable for the dashboard. */
 export type SessionHealth = {
   sessionID: string;
@@ -426,9 +449,23 @@ export function recordWorkerFailure(
     `[worker-health] ${workerID} degraded: ${entry.failureCount} failures in 5min for session=${sessionID.slice(0, 16)} (reasons: ${[...entry.reasons].join(", ")})`,
   );
 
-  // Debounce: don't re-alert within ALERT_COOLDOWN_MS.
+  // Suppress the Sentry escalation when EVERY failure in this window is a
+  // credential/config condition (see CREDENTIAL_CLASS_REASONS): those are the
+  // user's local setup, not a lore bug, and were the source of the
+  // LOREAI-GATEWAY-3J "Worker health degraded" noise. The local error log
+  // above, the degraded STATUS, and the `lore doctor` warning still fire — only
+  // the Sentry issue is withheld. A window with any genuine outage reason
+  // (`.reasons` is accumulated across the window) still escalates normally.
+  const allCredentialClass = [...entry.reasons].every((r) =>
+    CREDENTIAL_CLASS_REASONS.has(r),
+  );
+
+  // Debounce: don't re-alert within ALERT_COOLDOWN_MS. Skipping the alert when
+  // allCredentialClass ALSO leaves `alertSentAt` unset, so a later genuine
+  // outage reason in the same window can still fire the first real alert.
   const shouldAlert =
-    !entry.alertSentAt || t - entry.alertSentAt > ALERT_COOLDOWN_MS;
+    !allCredentialClass &&
+    (!entry.alertSentAt || t - entry.alertSentAt > ALERT_COOLDOWN_MS);
   if (shouldAlert) {
     entry.alertSentAt = t;
     // Stable message + fingerprint so Sentry groups all degradations of a
@@ -462,7 +499,8 @@ export function recordWorkerFailure(
   const sustainedMs = t - entry.firstFailureAt;
   if (sustainedMs >= CRITICAL_THRESHOLD_MS) {
     const shouldException =
-      !entry.exceptionSentAt || t - entry.exceptionSentAt > 60 * 60 * 1000;
+      !allCredentialClass &&
+      (!entry.exceptionSentAt || t - entry.exceptionSentAt > 60 * 60 * 1000);
     if (shouldException) {
       entry.exceptionSentAt = t;
       // Stable Error message + fingerprint so Sentry groups all critical

--- a/packages/gateway/test/worker-health.test.ts
+++ b/packages/gateway/test/worker-health.test.ts
@@ -259,6 +259,72 @@ describe("worker-health", () => {
     });
   });
 
+  // Regression (LOREAI-GATEWAY-3J): credential/config failures (no-auth,
+  // cross-provider) on a self-hosted gateway are the user's local setup, not a
+  // lore bug. They must NOT spawn a "Worker health degraded/critical" Sentry
+  // issue — but the local error log, degraded STATUS, and `lore doctor` warning
+  // are preserved. A window mixing in any genuine outage reason still escalates.
+  describe("credential-class reasons do not escalate to Sentry (#3J)", () => {
+    test("no-auth-only window: degrades locally but sends NO Sentry issue", () => {
+      // 3 rapid no-auth failures reach the degraded threshold in one window.
+      recordWorkerFailure("s1", "lore-contradiction", "no-auth");
+      recordWorkerFailure("s1", "lore-contradiction", "no-auth");
+      recordWorkerFailure("s1", "lore-contradiction", "no-auth");
+
+      // No "Worker health degraded" issue for a purely credential-class run.
+      expect(Sentry.captureMessage).not.toHaveBeenCalled();
+
+      // The local, user-facing signal is preserved: sustained 30+ min →
+      // degraded status + the actionable `lore doctor` warning.
+      _setNowForTest(() => 1_000_000 + 31 * 60 * 1000);
+      expect(getStatus("s1")).toBe("degraded");
+      expect(getDegradationWarning("s1")).not.toBeNull();
+    });
+
+    test("cross-provider-only window: sends NO Sentry issue", () => {
+      recordWorkerFailure("s1", "lore-distill", "cross-provider");
+      recordWorkerFailure("s1", "lore-distill", "cross-provider");
+      recordWorkerFailure("s1", "lore-distill", "cross-provider");
+      expect(Sentry.captureMessage).not.toHaveBeenCalled();
+    });
+
+    test("window mixing a genuine outage reason STILL escalates", () => {
+      recordWorkerFailure("s1", "lore-distill", "no-auth");
+      recordWorkerFailure("s1", "lore-distill", "no-auth");
+      recordWorkerFailure("s1", "lore-distill", "upstream-error"); // genuine
+      expect(Sentry.captureMessage).toHaveBeenCalledTimes(1);
+      const [msg] = (Sentry.captureMessage as ReturnType<typeof vi.fn>).mock
+        .calls[0];
+      expect(msg).toBe("Worker health degraded");
+    });
+
+    test("a genuine reason after a credential-class window still fires the first alert", () => {
+      // Two no-auth failures do not (and, being credential-class, would not)
+      // alert; alertSentAt must stay unset so the next genuine reason alerts.
+      recordWorkerFailure("s1", "lore-distill", "no-auth");
+      recordWorkerFailure("s1", "lore-distill", "no-auth");
+      expect(Sentry.captureMessage).not.toHaveBeenCalled();
+      // 3rd failure is a genuine outage → escalates (window not all-credential).
+      recordWorkerFailure("s1", "lore-distill", "upstream-error");
+      expect(Sentry.captureMessage).toHaveBeenCalledTimes(1);
+    });
+
+    test("sustained credential-class failure does NOT fire the critical exception", () => {
+      // Keep failures inside the 5-min window (no rotation) so firstFailureAt
+      // stays put while sustained duration crosses the 60-min critical mark.
+      let t = 1_000_000;
+      for (let i = 0; i <= 16; i++) {
+        _setNowForTest(() => t);
+        recordWorkerFailure("s1", "lore-contradiction", "no-auth");
+        t += 4 * 60 * 1000; // 4 min apart — inside the 5-min window
+      }
+      expect(Sentry.captureException).not.toHaveBeenCalled();
+      // Local critical status is still reflected.
+      _setNowForTest(() => 1_000_000 + 65 * 60 * 1000);
+      expect(getStatus("s1")).toBe("critical");
+    });
+  });
+
   describe("circuit breaker (allowWorkerProbe)", () => {
     test("healthy session is always allowed", () => {
       expect(allowWorkerProbe("s1")).toBe(true);

--- a/packages/gateway/test/worker-health.test.ts
+++ b/packages/gateway/test/worker-health.test.ts
@@ -298,13 +298,17 @@ describe("worker-health", () => {
       expect(msg).toBe("Worker health degraded");
     });
 
-    test("a genuine reason after a credential-class window still fires the first alert", () => {
-      // Two no-auth failures do not (and, being credential-class, would not)
-      // alert; alertSentAt must stay unset so the next genuine reason alerts.
+    test("a genuine reason after a suppressed window still fires the first alert", () => {
+      // Drive 3 credential-class failures so the escalation path actually RUNS
+      // (failureCount reaches DEGRADED_THRESHOLD) and is suppressed — this is
+      // the path that, if buggy, would wrongly stamp `alertSentAt`.
+      recordWorkerFailure("s1", "lore-distill", "no-auth");
       recordWorkerFailure("s1", "lore-distill", "no-auth");
       recordWorkerFailure("s1", "lore-distill", "no-auth");
       expect(Sentry.captureMessage).not.toHaveBeenCalled();
-      // 3rd failure is a genuine outage → escalates (window not all-credential).
+      // A genuine outage in the same window must still fire the FIRST alert:
+      // `alertSentAt` was left unset by the suppressed run, so the debounce
+      // does not swallow it.
       recordWorkerFailure("s1", "lore-distill", "upstream-error");
       expect(Sentry.captureMessage).toHaveBeenCalledTimes(1);
     });


### PR DESCRIPTION
## What

Fixes **LOREAI-GATEWAY-3J** (\`Worker health degraded\`, 12 events / 2 users, active through today).

The `lore-contradiction` idle worker (model `claude-opus-4-8`) recorded `no-auth` failures; after 3 in a 5-min window, `recordWorkerFailure` fired a **"Worker health degraded"** Sentry issue. Root-caused tag: `reason: no-auth`, `worker_id: lore-contradiction`, `failure_count: 3`.

## Why it happens

`no-auth` and `cross-provider` are **credential/config conditions, not upstream outages**. On a self-hosted gateway (all 3J events are `127.0.0.1`) they mean the user hasn't provided a usable worker credential — not a lore bug we can action. Both already have dedicated handling:

- `no-auth` is pre-guarded at scheduling (`idle.ts:651`, `pipeline.ts:5303`, both via `resolveAuth` — the same fn the adapter uses at `pipeline.ts:2195`) and **self-limits**: once the session credential goes stale, the next tick's guard skips scheduling entirely.
- `cross-provider` is soft-paused at the call site via `markWorkerPaused` (`llm-adapter.ts:1495`), which uses a separate map that never feeds the failure ladder.

The gap: `doIdleWork` is a long async chain (distill → meta → curate → consolidate → **contradiction #1123**). If auth goes stale *after* the scheduling guard passed (OAuth expiry, or an earlier step's 401 → `markAuthStale`), later steps still fire their LLM call and record `no-auth` — which tripped the degraded ladder and escalated to Sentry.

## How

Suppress the degraded/critical **Sentry escalation** when EVERY failure in the current window is credential-class (new `CREDENTIAL_CLASS_REASONS = {no-auth, cross-provider}`). Preserved: the local error log, the time-based degraded/critical **STATUS**, the user-facing **`lore doctor`** warning, and the circuit breaker. A window mixing in any genuine outage reason (`upstream-error`, `no-response`, `rate-limit`, …) still escalates normally. `alertSentAt` is left unset on a suppressed window so a later genuine reason can still fire the first alert.

This follows the existing precedent for non-actionable failures (`worker-incapable` early-returns; HTTP-402 credit pause uses a separate non-escalating map) but is deliberately more conservative — it keeps the helpful local signal and only withholds the Sentry issue.

## Tests

5 new regression tests (**mutation-verified**: removing the guard fails exactly the 3 suppression tests, the 2 escalation tests still pass):
- no-auth-only window → no Sentry issue, but still degrades locally (status + `lore doctor` warning).
- cross-provider-only window → no Sentry issue.
- window mixing a genuine outage reason → still escalates.
- genuine reason after a credential-class window → still fires the first alert.
- sustained credential-class failure → no critical exception (status still critical locally).

`packages/gateway/test/worker-health.test.ts`: 44 passed. Full gateway suite: 2769 passed / 0 failed. Typecheck + Biome clean.

## Review notes

Adversarial review verdict: **SHIP-WITH-FOLLOWUPS** (mutation-tested in a throwaway worktree; main tree verified byte-identical). Applied follow-up in this PR: strengthened the "genuine reason after a suppressed window" test to reach the degraded threshold first, so it actually exercises the suppression path (the prior version stopped at 2 failures and could not detect an `alertSentAt`-stamping bug — now mutation-verified to fail against that mutant).

**Accepted risk (tracked follow-up):** `no-auth`/`cross-provider` have no other Sentry path (they never reach upstream), so an all-credential-class window is now fully Sentry-invisible — only the local log, degraded status, dashboard, and `lore doctor` warning remain. This is exactly right for the self-hosted-first deployment model. If a **hosted** multi-tenant gateway ever ships, a lore-side credential-provisioning bug surfacing as `no-auth` would be silenced from Sentry and should get a distinct server-side signal then.