### PR TITLE
test(gateway): cover worker-cost-breakdown aggregation + UI rendering (#1268 follow-up)

### DIFF
--- a/packages/gateway/src/ui.ts
+++ b/packages/gateway/src/ui.ts
@@ -2625,6 +2625,31 @@ function pageWarming(): string {
 // Global Costs page
 // ---------------------------------------------------------------------------
 
+/**
+ * Render the per-background-task rows for the costs dashboard "Lore Overhead"
+ * section, attributing worker spend to distillation / curation / compaction /
+ * recall. Pure + exported so it can be unit-tested in isolation. Buckets with
+ * zero cost are omitted; warmup is surfaced by a separate row upstream (it is
+ * intentionally not part of this breakdown to avoid double-counting).
+ */
+export function renderWorkerBreakdownRows(wb: {
+  distillation: { cost: number; calls: number };
+  curation: { cost: number; calls: number };
+  compaction: { cost: number; calls: number };
+  recall: { cost: number; calls: number };
+}): string {
+  const row = (label: string, b: { cost: number; calls: number }): string =>
+    b.cost > 0
+      ? `<tr><td style="padding-left:1.4em;color:var(--fg3);font-size:0.9em">— ${label}</td><td style="color:var(--fg3);font-size:0.9em">${formatUSD(b.cost)} <span style="font-size:0.85em">(&times;${b.calls})</span></td></tr>`
+      : "";
+  return (
+    row("distillation", wb.distillation) +
+    row("curation", wb.curation) +
+    row("compaction", wb.compaction) +
+    row("recall", wb.recall)
+  );
+}
+
 function pageCosts(): string {
   let body = breadcrumb([
     { label: "Dashboard", href: "/ui" },
@@ -3006,18 +3031,7 @@ function pageCosts(): string {
     // Populated from persisted per-bucket snapshots (session_state.worker_breakdown);
     // sessions recorded before that column existed contribute to the total above
     // but not to these rows.
-    const wb = hist.workerBreakdown;
-    const bucketRow = (
-      label: string,
-      b: { cost: number; calls: number },
-    ): string =>
-      b.cost > 0
-        ? `<tr><td style="padding-left:1.4em;color:var(--fg3);font-size:0.9em">— ${label}</td><td style="color:var(--fg3);font-size:0.9em">${formatUSD(b.cost)} <span style="font-size:0.85em">(&times;${b.calls})</span></td></tr>`
-        : "";
-    body += bucketRow("distillation", wb.distillation);
-    body += bucketRow("curation", wb.curation);
-    body += bucketRow("compaction", wb.compaction);
-    body += bucketRow("recall", wb.recall);
+    body += renderWorkerBreakdownRows(hist.workerBreakdown);
     // Break out the cache-warmup cost as a visible component of worker overhead.
     // It is ALREADY included in totalWorkerCost above (so the net below is not
     // double-subtracted) — this row just surfaces how much of the overhead is

--- a/packages/gateway/test/cost-tracker-historical.test.ts
+++ b/packages/gateway/test/cost-tracker-historical.test.ts
@@ -258,6 +258,93 @@ describe("computeHistoricalEstimates (session_rollup read path #981)", () => {
     expect(totals.warmupSavings - totals.warmupCost).toBeCloseTo(-0.3);
   });
 
+  // A snapshot with all the non-breakdown fields zeroed, parameterized on the
+  // per-bucket breakdown. Cast to the saveSessionCosts param type so tests can
+  // pass an intentionally-partial breakdown (missing buckets) too.
+  function snap(workerBreakdown: unknown) {
+    return {
+      conversationCost: 1.0,
+      workerCost: 0.9,
+      conversationTurns: 5,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      warmupSavings: 0,
+      warmupCost: 0,
+      warmupHits: 0,
+      ttlSavings: 0,
+      ttlHits: 0,
+      batchSavings: 0,
+      avoidedCompactions: 0,
+      avoidedCompactionCost: 0,
+      workerBreakdown,
+    } as Parameters<typeof saveSessionCosts>[1];
+  }
+
+  test("attributes persisted worker cost to per-bucket breakdown (warmup excluded)", () => {
+    const pid = ensureProject("/test/cost-historical/breakdown", "hist-bd");
+    const sid = "sess-breakdown";
+    const now = Date.now();
+    insertMsg(pid, sid, "assistant", 100, now, null);
+    saveSessionCosts(
+      sid,
+      snap({
+        distillation: { cost: 0.5, calls: 4 },
+        curation: { cost: 0.2, calls: 2 },
+        compaction: { cost: 0.05, calls: 1 },
+        recall: { cost: 0.05, calls: 3 },
+        // Present in the persisted snapshot, but must NOT flow into the
+        // aggregated breakdown (it is tracked separately as warmupCost).
+        warmup: { cost: 0.1, calls: 1 },
+      }),
+    );
+
+    const totals = computeHistoricalEstimates().totals;
+    expect(totals.workerBreakdown.distillation.cost).toBeCloseTo(0.5);
+    expect(totals.workerBreakdown.distillation.calls).toBe(4);
+    expect(totals.workerBreakdown.curation.cost).toBeCloseTo(0.2);
+    expect(totals.workerBreakdown.compaction.cost).toBeCloseTo(0.05);
+    expect(totals.workerBreakdown.recall.cost).toBeCloseTo(0.05);
+    expect(totals.workerBreakdown.recall.calls).toBe(3);
+    // The aggregated breakdown carries no warmup entry — it can't double-count
+    // against the dedicated warmupCost total.
+    expect("warmup" in totals.workerBreakdown).toBe(false);
+  });
+
+  test("sums the breakdown across sessions and treats a missing bucket as zero", () => {
+    const pid = ensureProject("/test/cost-historical/breakdown2", "hist-bd2");
+    const now = Date.now();
+
+    insertMsg(pid, "sess-bd-a", "assistant", 100, now, null);
+    saveSessionCosts(
+      "sess-bd-a",
+      snap({
+        distillation: { cost: 0.3, calls: 2 },
+        curation: { cost: 0.1, calls: 1 },
+        compaction: { cost: 0, calls: 0 },
+        recall: { cost: 0.2, calls: 5 },
+        warmup: { cost: 0, calls: 0 },
+      }),
+    );
+
+    // Session B's breakdown omits `curation` entirely — a defensive path
+    // (bd[k]?.cost ?? 0) must treat the absent bucket as zero, not crash.
+    insertMsg(pid, "sess-bd-b", "assistant", 100, now, null);
+    saveSessionCosts(
+      "sess-bd-b",
+      snap({
+        distillation: { cost: 0.4, calls: 3 },
+        compaction: { cost: 0.1, calls: 1 },
+        recall: { cost: 0.1, calls: 2 },
+      }),
+    );
+
+    const totals = computeHistoricalEstimates().totals;
+    expect(totals.workerBreakdown.distillation.cost).toBeCloseTo(0.7); // 0.3 + 0.4
+    expect(totals.workerBreakdown.curation.cost).toBeCloseTo(0.1); // 0.1 + absent→0
+    expect(totals.workerBreakdown.compaction.cost).toBeCloseTo(0.1); // 0 + 0.1
+    expect(totals.workerBreakdown.recall.cost).toBeCloseTo(0.3); // 0.2 + 0.1
+  });
+
   test("batch estimate: a session with no usable model metadata keeps the 167K trigger", () => {
     const pid = ensureProject("/test/cost-historical/nomodel", "hist-nomodel");
     const sid = "sess-nomodel";

--- a/packages/gateway/test/ui-worker-breakdown.test.ts
+++ b/packages/gateway/test/ui-worker-breakdown.test.ts
@@ -1,0 +1,107 @@
+import { db, ensureProject, saveSessionCosts } from "@loreai/core";
+import { describe, expect, it } from "vitest";
+import { invalidateHistoricalCache } from "../src/cost-tracker";
+import { handleUIRequest, renderWorkerBreakdownRows } from "../src/ui";
+
+// Coverage for the costs-dashboard "Lore Overhead" per-bucket breakdown rows
+// (worker-cost-breakdown feature, #1268). The rows attribute worker spend to
+// distillation / curation / compaction / recall; buckets with zero cost are
+// omitted, and warmup is intentionally excluded (surfaced separately).
+
+describe("renderWorkerBreakdownRows", () => {
+  it("renders one row per non-zero bucket with its cost and call count", () => {
+    const html = renderWorkerBreakdownRows({
+      distillation: { cost: 0.5, calls: 4 },
+      curation: { cost: 0.2, calls: 2 },
+      compaction: { cost: 0.05, calls: 1 },
+      recall: { cost: 0.03, calls: 3 },
+    });
+    // All four labels present, in order.
+    for (const label of ["distillation", "curation", "compaction", "recall"]) {
+      expect(html).toContain(`— ${label}`);
+    }
+    // Exactly four <tr> rows.
+    expect(html.match(/<tr>/g) ?? []).toHaveLength(4);
+    // Formatted USD + call counts surfaced.
+    expect(html).toContain("$0.50");
+    expect(html).toContain("$0.20");
+    expect(html).toContain("&times;4");
+    expect(html).toContain("&times;3");
+  });
+
+  it("omits buckets whose cost is zero (the empty-row branch)", () => {
+    const html = renderWorkerBreakdownRows({
+      distillation: { cost: 0.5, calls: 4 },
+      curation: { cost: 0, calls: 0 },
+      compaction: { cost: 0, calls: 0 },
+      recall: { cost: 0.03, calls: 3 },
+    });
+    expect(html).toContain("— distillation");
+    expect(html).toContain("— recall");
+    expect(html).not.toContain("— curation");
+    expect(html).not.toContain("— compaction");
+    expect(html.match(/<tr>/g) ?? []).toHaveLength(2);
+  });
+
+  it("renders nothing when every bucket is zero", () => {
+    const html = renderWorkerBreakdownRows({
+      distillation: { cost: 0, calls: 0 },
+      curation: { cost: 0, calls: 0 },
+      compaction: { cost: 0, calls: 0 },
+      recall: { cost: 0, calls: 0 },
+    });
+    expect(html).toBe("");
+  });
+});
+
+describe("/ui/costs renders the worker breakdown end-to-end", () => {
+  it("includes per-bucket rows when a session has a persisted breakdown", async () => {
+    // Deterministic aggregate: wipe the rollup source + memoized estimate.
+    db().exec(
+      "DELETE FROM temporal_messages; DELETE FROM distillations; DELETE FROM session_rollup;",
+    );
+    const pid = ensureProject("/test/ui-costs-breakdown", "ui-bd");
+    const sid = "sess-ui-bd";
+    const now = Date.now();
+    // A message so the session shows up in the historical rollup iteration.
+    db()
+      .query(
+        `INSERT INTO temporal_messages
+           (id, project_id, session_id, role, content, tokens, distilled, created_at, metadata)
+         VALUES (?, ?, ?, 'assistant', 'c', 100, 0, ?, NULL)`,
+      )
+      .run("uim-bd-1", pid, sid, now);
+    saveSessionCosts(sid, {
+      conversationCost: 1.0,
+      workerCost: 0.75,
+      conversationTurns: 5,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      warmupSavings: 0,
+      warmupCost: 0,
+      warmupHits: 0,
+      ttlSavings: 0,
+      ttlHits: 0,
+      batchSavings: 0,
+      avoidedCompactions: 0,
+      avoidedCompactionCost: 0,
+      workerBreakdown: {
+        distillation: { cost: 0.5, calls: 4 },
+        curation: { cost: 0.2, calls: 2 },
+        compaction: { cost: 0.03, calls: 1 },
+        recall: { cost: 0.02, calls: 3 },
+        warmup: { cost: 0, calls: 0 },
+      },
+    });
+    invalidateHistoricalCache();
+
+    const url = new URL("http://localhost/ui/costs");
+    const res = await handleUIRequest(new Request(url), url);
+    const html = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(html).toContain("Lore Overhead");
+    expect(html).toContain("— distillation");
+    expect(html).toContain("— curation");
+  });
+});


### PR DESCRIPTION
## Why

Codecov flagged #1268's patch coverage at **33%** — the persistence/round-trip was tested in `db.test.ts`, but two new surfaces weren't:
- `packages/gateway/src/ui.ts` — the per-bucket "Lore Overhead" rows (7 lines, **0%**)
- `packages/gateway/src/cost-tracker.ts` — the `HistoricalEstimates.totals.workerBreakdown` aggregation loop (3 missing + 1 partial, **40%**)

## What

- **Refactor (behavior-preserving):** extracted the inline `bucketRow` block in `pageCosts()` into a pure, exported `renderWorkerBreakdownRows(wb)` so the rendering can be unit-tested in isolation (identical HTML output).
- **`ui-worker-breakdown.test.ts`** (new): covers `renderWorkerBreakdownRows` — a row per non-zero bucket with cost + call count, zero-cost buckets omitted (the empty-row branch), and the all-zero → `""` case.
- **`cost-tracker-historical.test.ts`** (added 2 tests): seed sessions via `saveSessionCosts` with a `workerBreakdown`, then assert `computeHistoricalEstimates().totals.workerBreakdown` sums distillation/curation/compaction/recall correctly; that warmup is **excluded** from the aggregated breakdown (guards the #1268 double-count fix); and that a breakdown missing a bucket is treated as zero (`bd[k]?.cost ?? 0`) rather than crashing.

## Verification

- Both files' new lines now exercised (ui rendering + aggregation loop incl. the `?? 0` partial branch).
- Mutation-checked: nulling the aggregation accumulator makes the breakdown test fail; reverting restores green.
- tsc clean (gateway); `biome check` clean; 12 tests pass across the two files.