### PR TITLE
feat(supabase): multi-epoch scope_keys + atomic rotate_scope_key (E-4c-3a, #827)

### DIFF
--- a/packages/core/src/crypto/keystore.ts
+++ b/packages/core/src/crypto/keystore.ts
@@ -203,7 +203,7 @@ async function loadOrCreateScopeKey(
   };
   const row = db()
     .query(
-      "SELECT wrapped_dek AS w FROM scope_keys WHERE scope_id = ? AND member_user_id = ?",
+      "SELECT wrapped_dek AS w FROM scope_keys WHERE scope_id = ? AND member_user_id = ? ORDER BY key_epoch DESC LIMIT 1",
     )
     .get(scopeId, memberUserId) as { w: unknown } | undefined;
   if (row) {
@@ -226,12 +226,12 @@ async function loadOrCreateScopeKey(
       `INSERT INTO scope_keys
          (scope_id, member_user_id, wrapped_dek, key_epoch, created_at, updated_at)
        VALUES (?, ?, ?, 0, ?, ?)
-       ON CONFLICT(scope_id, member_user_id) DO NOTHING`,
+       ON CONFLICT(scope_id, member_user_id, key_epoch) DO NOTHING`,
     )
     .run(scopeId, memberUserId, Buffer.from(wrapped), now, now);
   const stored = db()
     .query(
-      "SELECT wrapped_dek AS w FROM scope_keys WHERE scope_id = ? AND member_user_id = ?",
+      "SELECT wrapped_dek AS w FROM scope_keys WHERE scope_id = ? AND member_user_id = ? ORDER BY key_epoch DESC LIMIT 1",
     )
     .get(scopeId, memberUserId) as { w: unknown };
   const finalDek = await unwrapDek(id.secretKey, toU8(stored.w));
@@ -257,7 +257,7 @@ export function putWrappedScopeKey(
       `INSERT INTO scope_keys
          (scope_id, member_user_id, wrapped_dek, key_epoch, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?)
-       ON CONFLICT(scope_id, member_user_id) DO UPDATE SET
+       ON CONFLICT(scope_id, member_user_id, key_epoch) DO UPDATE SET
          wrapped_dek = excluded.wrapped_dek,
          key_epoch = excluded.key_epoch,
          updated_at = excluded.updated_at`,
@@ -302,7 +302,7 @@ export async function wrapScopeKeyForMember(
     (
       db()
         .query(
-          "SELECT key_epoch AS e FROM scope_keys WHERE scope_id = ? AND member_user_id = ?",
+          "SELECT key_epoch AS e FROM scope_keys WHERE scope_id = ? AND member_user_id = ? ORDER BY key_epoch DESC LIMIT 1",
         )
         .get(scopeId, member) as { e: number } | undefined
     )?.e;

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1718,6 +1718,15 @@ const MIGRATIONS: string[] = [
   `
   ALTER TABLE session_state ADD COLUMN worker_breakdown TEXT;
   `,
+  // Version 69 (#827 E-4c-3a): scope_keys PK gains key_epoch → (scope_id, member_user_id,
+  // key_epoch), so a member retains ONE wrapped DEK PER epoch (key rotation writes a new-epoch
+  // row; old epochs stay readable). SQLite can't ALTER a PK, so the table is RECREATED by a JS
+  // SAVEPOINT step (applyScopeKeyEpochPk), special-cased in migrate() by
+  // SCOPE_KEY_EPOCH_MIGRATION_INDEX so the recreate is all-or-nothing. This string is a no-op
+  // marker so MIGRATIONS.length still counts.
+  `
+  -- Version 69 (#827): see applyScopeKeyEpochPk — no-op SQL marker.
+  `,
 ];
 
 // Index of the migration whose work is performed by a column-presence-aware JS
@@ -1739,6 +1748,12 @@ const SESSION_ROLLUP_MIGRATION_INDEX = 59; // 0-based index of version-60
 // tables (plain exec() of CREATE/DROP/RENAME is NOT atomic). The MIGRATIONS entry at
 // this index is a no-op documentation marker.
 const REF_FK_DROP_MIGRATION_INDEX = 65; // 0-based index of version-66
+
+// Index of the scope_keys PK-widening migration (adds key_epoch to the PK). SQLite cannot
+// ALTER a primary key, so it recreates the table; done as a JS SAVEPOINT step so a crash
+// mid-recreate rolls back instead of boot-looping. Idempotent (skips if key_epoch already
+// in the PK). The MIGRATIONS entry at this index is a no-op documentation marker.
+const SCOPE_KEY_EPOCH_MIGRATION_INDEX = 68; // 0-based index of version-69
 
 /**
  * Idempotent, column-presence-aware application of the v55 knowledge_meta register
@@ -2448,8 +2463,9 @@ function installSyncCapture(database: Database) {
       VALUES ('knowledge_meta_crdt', new.logical_id || char(31) || new.replica_id, 'upsert', ${ts});
     END;`;
   // C-3 (#825): encryption key store. account_escrow is single-row (keyed by id=1);
-  // scope_keys is keyed by member_user_id (v1: one scope per user). INSERT + UPDATE
-  // (set/rotate the wrapping); no DELETE (keys/escrow are not deleted in v1).
+  // scope_keys is keyed by (member_user_id, key_epoch) — one wrap per member PER epoch since
+  // rotation (E-4c-3), so the outbox row_id is composite (member_user_id ⟳ char(31) ⟳ key_epoch),
+  // matching idColumns. INSERT + UPDATE (set/rotate the wrapping); no DELETE (v1).
   sql += `
     CREATE TEMP TRIGGER IF NOT EXISTS account_escrow_outbox_ins
     AFTER INSERT ON account_escrow WHEN (${gate})
@@ -2467,13 +2483,13 @@ function installSyncCapture(database: Database) {
     AFTER INSERT ON scope_keys WHEN (${gate})
     BEGIN
       INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
-      VALUES ('scope_keys', new.member_user_id, 'upsert', ${ts});
+      VALUES ('scope_keys', new.member_user_id || char(31) || new.key_epoch, 'upsert', ${ts});
     END;
     CREATE TEMP TRIGGER IF NOT EXISTS scope_keys_outbox_upd
     AFTER UPDATE ON scope_keys WHEN (${gate})
     BEGIN
       INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
-      VALUES ('scope_keys', new.member_user_id, 'upsert', ${ts});
+      VALUES ('scope_keys', new.member_user_id || char(31) || new.key_epoch, 'upsert', ${ts});
     END;`;
   // #1246: projects identity mapping (id→git_remote). Gated on git_remote IS NOT NULL —
   // only remote-backed projects sync (a remote-less project's random id can't correlate
@@ -2631,6 +2647,41 @@ function applyRefFkDrop(database: Database) {
   }
 }
 
+// v69 (#827 E-4c-3a): widen the scope_keys PK to include key_epoch so a member retains one
+// wrapped DEK per epoch (rotation writes a new-epoch row). SQLite can't ALTER a PK → recreate.
+// Idempotent: skips if key_epoch is already part of the PK (a re-run after recovery).
+function applyScopeKeyEpochPk(database: Database) {
+  const cols = database.query("PRAGMA table_info('scope_keys')").all() as {
+    name: string;
+    pk: number;
+  }[];
+  if (cols.some((c) => c.name === "key_epoch" && c.pk > 0)) return; // already widened
+  database.exec("SAVEPOINT scope_key_epoch_pk");
+  try {
+    database.exec(`
+      DROP TABLE IF EXISTS scope_keys_new;
+      CREATE TABLE scope_keys_new (
+        scope_id        TEXT NOT NULL,
+        member_user_id  TEXT NOT NULL,
+        wrapped_dek     BLOB NOT NULL,
+        key_epoch       INTEGER NOT NULL DEFAULT 0,
+        created_at      INTEGER NOT NULL,
+        updated_at      INTEGER NOT NULL DEFAULT 0,
+        PRIMARY KEY (scope_id, member_user_id, key_epoch)
+      );
+      INSERT INTO scope_keys_new (scope_id, member_user_id, wrapped_dek, key_epoch, created_at, updated_at)
+        SELECT scope_id, member_user_id, wrapped_dek, key_epoch, created_at, updated_at FROM scope_keys;
+      DROP TABLE scope_keys;
+      ALTER TABLE scope_keys_new RENAME TO scope_keys;
+    `);
+    database.exec("RELEASE scope_key_epoch_pk");
+  } catch (e) {
+    database.exec("ROLLBACK TO scope_key_epoch_pk");
+    database.exec("RELEASE scope_key_epoch_pk");
+    throw e;
+  }
+}
+
 /**
  * Preflight check: verify the runtime's SQLite has the FTS5 full-text search
  * extension compiled in.
@@ -2708,6 +2759,10 @@ function migrate(database: Database) {
       // Recreate the ref tables without their knowledge(id) FKs, atomically (SAVEPOINT)
       // so a crash mid-recreate rolls back instead of boot-looping the retry (#909).
       applyRefFkDrop(database);
+    } else if (i === SCOPE_KEY_EPOCH_MIGRATION_INDEX) {
+      // Recreate scope_keys with key_epoch in the PK, atomically (SAVEPOINT), idempotent
+      // (skips if already migrated) so a partial apply can't boot-loop (#827 E-4c-3a).
+      applyScopeKeyEpochPk(database);
     } else {
       try {
         database.exec(MIGRATIONS[i]);
@@ -3085,7 +3140,7 @@ function recoverMissingObjects(database: Database) {
     scope_id TEXT NOT NULL, member_user_id TEXT NOT NULL,
     wrapped_dek BLOB NOT NULL, key_epoch INTEGER NOT NULL DEFAULT 0,
     created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL DEFAULT 0,
-    PRIMARY KEY (scope_id, member_user_id)
+    PRIMARY KEY (scope_id, member_user_id, key_epoch)
   );`);
 
   // Version 36: session project binding. Recover each column independently in

--- a/packages/core/src/sync-data.ts
+++ b/packages/core/src/sync-data.ts
@@ -208,7 +208,10 @@ export const SYNCED_TABLES: Record<SyncTier, SyncTableMeta[]> = {
       // stripSyncCols would drop it, leaving the NOT-NULL local column unfilled).
       // wrapped_dek is ciphertext → base64 on the wire. Pulled BEFORE knowledge (C-4).
       table: "scope_keys",
-      idColumns: ["member_user_id"],
+      // key_epoch is part of the identity now (E-4c-3): a member holds one wrap PER epoch
+      // (rotation adds a new-epoch row; old epochs are retained so past blobs stay readable).
+      // The remote PK is (scope_id, member_user_id, key_epoch); onConflict prepends scope_id.
+      idColumns: ["member_user_id", "key_epoch"],
       ftsTables: [],
       syncColumns: ["member_user_id", "wrapped_dek", "key_epoch", "updated_at"],
       blobColumns: ["wrapped_dek"],

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -117,7 +117,7 @@ describe("db", () => {
     const row = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(row.version).toBe(68);
+    expect(row.version).toBe(69);
   });
 
   test("v55: confidence/last_reinforced_at moved to knowledge_meta, exposed via view", () => {
@@ -174,7 +174,7 @@ describe("db", () => {
     const ver = fresh.query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(ver.version).toBe(68);
+    expect(ver.version).toBe(69);
     // Register + JOIN view were rebuilt and are queryable (confidence exposed).
     expect(
       fresh

--- a/packages/core/test/keystore-sync.test.ts
+++ b/packages/core/test/keystore-sync.test.ts
@@ -87,7 +87,22 @@ describe("C-3 registry — encryption key-store tables", () => {
     expect(escrow.length).toBeGreaterThan(0);
     expect(escrow[0].row_id).toBe("1"); // single-row id
     expect(sk.length).toBeGreaterThan(0);
-    expect(sk[0].row_id).toBe(SCOPE); // keyed by member_user_id
+    expect(sk[0].row_id).toBe(`${SCOPE}\x1f0`); // composite: member_user_id ⟳ key_epoch (E-4c-3)
+  });
+
+  it("the captured scope_keys outbox row_id resolves back to its row (trigger ⇄ idColumns order)", async () => {
+    keystore.setPassphrase("pw", { params: FAST });
+    await keystore.getScopeKey(SCOPE, SCOPE); // captures a scope_keys row
+    const sk = syncData
+      .readOutbox(0)
+      .filter((e) => e.table_name === "scope_keys");
+    expect(sk.length).toBeGreaterThan(0);
+    // The trigger-produced row_id MUST decompose (via idColumns) back to the real row. An
+    // idColumns-order regression vs the capture trigger would return null here — catching the
+    // silent-corruption vector in the fast unit suite, not only the Docker round-trip (E-4c-3a).
+    const row = syncData.getRowById("scope_keys", sk[0].row_id);
+    expect(row?.member_user_id).toBe(SCOPE);
+    expect(Number(row?.key_epoch)).toBe(0);
   });
 });
 

--- a/packages/core/test/ltm-versioning.test.ts
+++ b/packages/core/test/ltm-versioning.test.ts
@@ -43,7 +43,7 @@ describe("A2 sub-PR 1: append-only knowledge scaffolding", () => {
     const v = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(v.version).toBe(68);
+    expect(v.version).toBe(69);
   });
 
   test("create() defaults logical_id = id, version 1, current, not deleted", () => {

--- a/packages/gateway/src/sync.ts
+++ b/packages/gateway/src/sync.ts
@@ -636,7 +636,6 @@ export async function pullOnce(
       }
     }
 
-    const idc = meta.idColumns[0];
     const skippedBefore = res.skipped;
     try {
       for (;;) {
@@ -644,13 +643,20 @@ export async function pullOnce(
         // Page by (updated_at, id). `gte` includes cursor.ms; the in-memory keyset
         // skip drops rows already applied. (timestamptz is compared by VALUE, so
         // Z vs +00:00 / fractional formats are equivalent.)
+        // Order by (updated_at, <FULL composite id>) — every id column, not just the first.
+        // The in-memory keyset skip (below) compares the FULL composite rowIdOf; if the page
+        // were ordered by only idColumns[0], two rows sharing (updated_at, idColumns[0]) but
+        // differing in a later id column could arrive in reverse-keyset order, and the one
+        // sorting earlier in the full keyset would be wrongly skipped (never applied) after the
+        // cursor advanced past the other. For scope_keys that means a member's lower-epoch wrap
+        // could be dropped when it shares updated_at with a higher epoch (E-4c-3). Matches
+        // drainTimestamp, which already keysets on the full composite.
         let q = client
           .from(meta.table)
           .select("*")
-          .order("updated_at", { ascending: true })
-          .order(idc, { ascending: true })
-          .limit(PAGE);
-        q = q.gte("updated_at", sinceIso);
+          .order("updated_at", { ascending: true });
+        for (const c of meta.idColumns) q = q.order(c, { ascending: true });
+        q = q.limit(PAGE).gte("updated_at", sinceIso);
         const { data, error } = await q;
         if (error) {
           log.notice(`sync: pull ${meta.table}: ${error.message}`);

--- a/packages/gateway/test/sync-scope-rotation.integration.test.ts
+++ b/packages/gateway/test/sync-scope-rotation.integration.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Integration tests for migration 0030 — key-rotation foundation (E-4c-3a, #827) against a real
+ * Postgres:
+ *  - rotate_scope_key atomically bumps scopes.key_epoch and is admin-only;
+ *  - the composite PK (scope_id, member_user_id, key_epoch) lets a member hold one wrap PER
+ *    epoch (a new-epoch row coexists with the old, so past blobs stay decryptable);
+ *  - the immutability guard blocks changing an existing epoch's wrapped_dek (rotation writes a
+ *    NEW epoch row, never re-wraps in place).
+ *
+ * Gated behind LORE_INTEGRATION=1 (needs Docker). Run:
+ *   LORE_INTEGRATION=1 pnpm exec vitest run packages/gateway/test/sync-scope-rotation.integration.test.ts
+ */
+import { execFileSync } from "node:child_process";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { type PgHarness, startPgHarness } from "./helpers/pg-harness";
+
+function dockerReady(): boolean {
+  try {
+    execFileSync("docker", ["info"], { stdio: "ignore", timeout: 10_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const RUN = process.env.LORE_INTEGRATION === "1";
+const SKIP = !RUN
+  ? "LORE_INTEGRATION!=1"
+  : !dockerReady()
+    ? "docker unavailable"
+    : false;
+
+let h: PgHarness;
+beforeAll(async () => {
+  if (!SKIP) h = await startPgHarness();
+}, 180_000);
+afterAll(async () => {
+  if (h) await h.stop();
+});
+const gate = () => SKIP;
+
+async function expectError(
+  fn: () => Promise<unknown>,
+): Promise<{ code?: string }> {
+  try {
+    await fn();
+  } catch (e) {
+    return { code: (e as { code?: string }).code };
+  }
+  throw new Error("expected the query to fail, but it succeeded");
+}
+
+const createTeam = (uid: string, name: string) =>
+  h.asUser(uid, (c) =>
+    c
+      .query("select public.create_team($1) as s", [name])
+      .then((r) => r.rows[0].s as string),
+  );
+const rotate = (uid: string, scope: string) =>
+  h.asUser(uid, (c) =>
+    c
+      .query("select public.rotate_scope_key($1) as e", [scope])
+      .then((r) => r.rows[0].e as number),
+  );
+// A scope admin writes a wrap row (author defaults to auth.uid()); RLS requires scope_role=admin.
+const putWrap = (
+  uid: string,
+  scope: string,
+  member: string,
+  epoch: number,
+  dek: string,
+) =>
+  h.asUser(uid, (c) =>
+    c.query(
+      "insert into public.scope_keys (scope_id, member_user_id, key_epoch, wrapped_dek) values ($1,$2,$3,$4)",
+      [scope, member, epoch, dek],
+    ),
+  );
+
+describe.skipIf(gate())("0030 key rotation foundation (E-4c-3a, #827)", () => {
+  it("rotate_scope_key bumps scopes.key_epoch and returns the new epoch; admin-only", async () => {
+    const a = await h.createUser();
+    const b = await h.createUser(); // not a member
+    const scope = await createTeam(a, "Rot A");
+    expect(await rotate(a, scope)).toBe(1); // 0 → 1
+    expect(await rotate(a, scope)).toBe(2); // 1 → 2
+    expect(
+      await h.client
+        .query("select key_epoch from public.scopes where id=$1", [scope])
+        .then((r) => r.rows[0].key_epoch),
+    ).toBe(2);
+    expect((await expectError(() => rotate(b, scope))).code).toBe("42501"); // non-admin
+  });
+
+  it("a member holds one wrap per epoch — new-epoch rows coexist with old (multi-epoch PK)", async () => {
+    const a = await h.createUser();
+    const scope = await createTeam(a, "Rot B");
+    await putWrap(a, scope, a, 0, "ZDA="); // epoch 0
+    await putWrap(a, scope, a, 1, "ZDE="); // epoch 1 — a NEW PK row, not a clobber
+    expect(
+      await h.client
+        .query(
+          "select key_epoch from public.scope_keys where scope_id=$1 and member_user_id=$2 order by key_epoch",
+          [scope, a],
+        )
+        .then((r) => r.rows.map((x) => x.key_epoch)),
+    ).toEqual([0, 1]); // both retained
+  });
+
+  it("an existing epoch's wrapped_dek is immutable (rotation writes a new row, never re-wraps)", async () => {
+    const a = await h.createUser();
+    const scope = await createTeam(a, "Rot C");
+    await putWrap(a, scope, a, 0, "ZDA=");
+    // In-place re-wrap of the SAME (scope, member, epoch) → blocked as poison.
+    const err = await expectError(() =>
+      h.asUser(a, (c) =>
+        c.query(
+          "update public.scope_keys set wrapped_dek=$1 where scope_id=$2 and member_user_id=$3 and key_epoch=0",
+          ["Y2xvYmJlcg==", scope, a],
+        ),
+      ),
+    );
+    expect(err.code).toBe("23514");
+    // A metadata-only UPDATE (same wrapped_dek) is still allowed.
+    await h.asUser(a, (c) =>
+      c.query(
+        "update public.scope_keys set revision=revision+1 where scope_id=$1 and member_user_id=$2 and key_epoch=0",
+        [scope, a],
+      ),
+    );
+  });
+});

--- a/packages/gateway/test/sync-security.integration.test.ts
+++ b/packages/gateway/test/sync-security.integration.test.ts
@@ -330,21 +330,33 @@ describe.skipIf(gate())(
       expect(rows[0].wrapped_dek).toBe("T1JJR0lOQUw=");
     });
 
-    it("allows changing wrapped_dek at a HIGHER key_epoch (rotation)", async () => {
+    it("rotation writes a NEW epoch row (coexists with epoch 0); an in-place re-wrap stays blocked", async () => {
       const a = await h.createUser();
-      await insKey(a, "ZXBvY2gw"); // "epoch0"
-      const r = await updKey(a, "wrapped_dek='ZXBvY2gx', key_epoch=1");
+      await insKey(a, "ZXBvY2gw"); // "epoch0" at key_epoch 0 (default)
+      // E-4c-3: rotation is an INSERT of a new-epoch row (the PK includes key_epoch), NOT an
+      // in-place re-wrap. The old epoch is retained so pre-rotation blobs stay decryptable.
+      const r = await h.asUser(a, (c) =>
+        c.query(
+          `insert into public.scope_keys (member_user_id, scope_id, author_id, wrapped_dek, key_epoch)
+           values ($1, $2, $2, 'ZXBvY2gx', 1)`,
+          [a, a],
+        ),
+      );
       expect(r.rowCount).toBe(1);
+      // In-place re-wrap of the existing epoch-0 row is still a poison clobber.
+      expect(
+        (await expectError(() => updKey(a, "wrapped_dek='Q0xPQkJFUg=='"))).code,
+      ).toBe("23514");
     });
 
     it("allows an idempotent upsert of the SAME wrapped_dek (production convergence)", async () => {
       const a = await h.createUser();
-      await insKey(a, "U0FNRQ=="); // "SAME"
+      await insKey(a, "U0FNRQ=="); // "SAME" at key_epoch 0
       const r = await h.asUser(a, (c) =>
         c.query(
           `insert into public.scope_keys (member_user_id, scope_id, author_id, wrapped_dek)
            values ($1, $2, $2, 'U0FNRQ==')
-           on conflict (scope_id, member_user_id)
+           on conflict (scope_id, member_user_id, key_epoch)
              do update set wrapped_dek = excluded.wrapped_dek, updated_at = now()`,
           [a, a],
         ),

--- a/supabase/migrations/0030_scope_key_rotation.sql
+++ b/supabase/migrations/0030_scope_key_rotation.sql
@@ -1,0 +1,63 @@
+-- Migration 0030 — key rotation foundation: multi-epoch scope_keys + atomic epoch (E-4c-3a, #827).
+--
+-- Rotate-on-remove needs the scope's DEK to change so a removed member cannot read FUTURE writes,
+-- while REMAINING members (and fresh devices / re-syncs) can still read PAST blobs. Each blob's
+-- envelope pins its key_epoch (crypto/envelope.ts), so every epoch's DEK must remain retrievable.
+--
+-- (A) MULTI-EPOCH scope_keys: the PK gains key_epoch, so a member accumulates one wrap PER epoch
+--     (the originator wraps the fresh DEK to each remaining member at N+1; old-epoch rows stay).
+-- (3) SERVER-ATOMIC epoch: scopes.key_epoch is the counter; rotate_scope_key() bumps it under a
+--     row lock so concurrent admins can never both mint the same N+1 with divergent DEKs.
+--
+-- 3a is the SCHEMA + atomic-counter + immutability foundation only. The client rotation crypto
+-- (mint fresh DEK, wrap to remaining members, epoch-aware seal/open) is E-4c-3b; no new-epoch row
+-- is created until then, so the enforce_row_quota per-epoch probe fix rides with 3b (unreachable
+-- here). rotate_scope_key exists now (Tier-1 testable) as the atomic primitive 3b/E-4c-4 call.
+
+-- Retain a wrap row per (scope, member, EPOCH) instead of one per (scope, member).
+alter table public.scope_keys
+  drop constraint scope_keys_pkey,
+  add primary key (scope_id, member_user_id, key_epoch);
+
+-- The scope's current key epoch — the atomic rotation counter (personal scopes stay at 0).
+alter table public.scopes add column if not exists key_epoch integer not null default 0;
+
+-- Atomically allocate the next epoch for a scope. Admin-only. The UPDATE takes a row lock, so two
+-- concurrent callers serialize and receive DISTINCT epochs — never a dueling N+1 with two DEKs.
+create or replace function public.rotate_scope_key(p_scope uuid)
+returns integer language plpgsql security definer set search_path = pg_catalog, public
+as $$
+declare v_epoch integer;
+begin
+  if public.scope_role(p_scope) is distinct from 'admin' then
+    raise exception 'only a scope admin may rotate the key' using errcode = '42501';
+  end if;
+  update public.scopes set key_epoch = key_epoch + 1 where id = p_scope
+    returning key_epoch into v_epoch;
+  if v_epoch is null then
+    raise exception 'no such scope' using errcode = '23503';
+  end if;
+  return v_epoch;
+end $$;
+
+grant execute on function public.rotate_scope_key(uuid) to authenticated;
+
+-- Immutability for the multi-epoch model: an existing (scope, member, epoch) row's wrapped_dek is
+-- IMMUTABLE — a rotation writes a NEW epoch row (INSERT), never an in-place re-wrap. Any UPDATE
+-- that changes wrapped_dek is therefore a clobber → 23514 poison (the client drops that push, the
+-- canonical wrap survives). Metadata-only UPDATEs (updated_at / revision / content_hash /
+-- is_deleted) are still allowed. Supersedes the pre-rotation epoch-comparison guard (0012), which
+-- assumed the single-row model where rotation was an in-place key_epoch bump.
+create or replace function public.guard_scope_key_immutable()
+returns trigger language plpgsql
+as $$
+begin
+  if new.wrapped_dek is distinct from old.wrapped_dek then
+    raise exception
+      'scope_keys.wrapped_dek is immutable for key_epoch % (rotation writes a new epoch row)',
+      old.key_epoch
+      using errcode = 'check_violation';
+  end if;
+  return new;
+end;
+$$;


### PR DESCRIPTION
Schema foundation for **key rotation** (rotate-on-remove), the first slice of E-4c-3. Decisions locked with the maintainer: **(A)** multi-epoch synced `scope_keys` + **server-atomic** epoch allocation.

**Why multi-epoch:** rotation must let a removed member no longer read *future* writes while remaining members (and fresh devices / re-syncs) still decrypt *past* blobs. Each blob's envelope pins its `key_epoch` (`crypto/envelope.ts`), so every epoch's DEK must stay retrievable → retain one wrap **per epoch**.

## Remote (migration 0030)
- `scope_keys` PK → **`(scope_id, member_user_id, key_epoch)`**: a member holds one wrap per epoch (rotation INSERTs a new-epoch row; old epochs retained).
- `scopes.key_epoch` counter + **`rotate_scope_key(scope)`** SECURITY DEFINER RPC (admin-only): atomically bumps under a row lock, so concurrent admins receive **distinct** epochs — never a dueling N+1 with two divergent DEKs.
- **`guard_scope_key_immutable` rewritten** for the multi-epoch model: an existing `(scope,member,epoch)` row's `wrapped_dek` is immutable (rotation is a new row, not an in-place re-wrap → 23514 poison); metadata-only UPDATEs still allowed. Supersedes 0012's epoch-compare guard.

## Local (schema v69)
- `applyScopeKeyEpochPk`: SQLite can't ALTER a PK, so an **idempotent SAVEPOINT table-recreate** (mirrors `applyRefFkDrop`).
- `scope_keys` outbox capture `row_id` → composite `member_user_id ⟳ char(31) ⟳ key_epoch`; `idColumns` → `[member_user_id, key_epoch]` (onConflict prepends `scope_id` → matches the remote PK).
- keystore ON CONFLICT / reads key on the 3-col PK (reads take the latest epoch, forward-safe).

## Scope
3a is **schema + atomic-counter + immutability only**. No new-epoch row is created until the client rotation crypto (mint fresh DEK, wrap to remaining members, epoch-aware seal/open) in **E-4c-3b** — so the `enforce_row_quota` per-epoch probe fix rides with 3b (unreachable here, documented in 0030).

## Verification
- Tier-1 `sync-scope-rotation.integration.test.ts` (3): `rotate_scope_key` bumps + admin-only (42501); new-epoch rows coexist with old (multi-epoch PK); in-place `wrapped_dek` change → 23514.
- Updated the two `0012` immutability tests that assumed the single-row rotation model (rotation is now a new-epoch INSERT; idempotent upsert uses the composite conflict target).
- Core **2789** passed / 6 skipped (134 files); integration **155** (security 93 + engine 14 + orgs 9 + membership 7 + identity-scopekeys 8 + write-gate 6 + quota 4 + team-lifecycle 10 + rotation 3 + …); `pnpm -r typecheck` **0**; Biome 0 errors.

Adversarial + SECURITY review to follow before merge. Next: **E-4c-3b** (client rotation crypto).