### PR TITLE
perf(core): memoize project path→id resolution per connection (3K)

### DIFF
--- a/packages/core/src/data.ts
+++ b/packages/core/src/data.ts
@@ -19,6 +19,7 @@ import {
   close,
   dbPath,
   mergeProjectInternal,
+  invalidateProjectIdCache,
   repoNameFromRemote,
   onProjectMutation,
   loadParentChildMap,
@@ -904,6 +905,9 @@ export function deleteProject(projectId: string): ClearResult | null {
 
   invalidateProjectsCache();
   invalidateGlobalStatsCache();
+  // The project row is gone — drop any memoized path→id entry pointing at it so
+  // a later ensureProject() can't return a dangling id and FK-violate (#3K).
+  invalidateProjectIdCache();
 
   return {
     knowledge_deleted: counts.knowledge,

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -26,6 +26,10 @@ export function onProjectMutation(cb: () => void): void {
 
 /** Fire the project mutation callback (if registered). */
 function fireProjectMutation(): void {
+  // Project creation and merge (mergeProjectInternal) both route through here,
+  // and a merge re-points a path to a different project id. Drop the memo so a
+  // stale path→id can never survive a mutation.
+  invalidateProjectIdCache();
   onProjectMutationCb?.();
 }
 
@@ -46,7 +50,53 @@ export function onProjectRemoteBackfilled(
 }
 
 function fireProjectRemoteBackfilled(projectId: string): void {
+  // git_remote just flipped NULL→set (possibly via a merge inside the backfill),
+  // so the project's identity may have changed — drop the memo to be safe.
+  invalidateProjectIdCache();
   onProjectRemoteBackfilledCb?.(projectId);
+}
+
+/**
+ * Per-connection memo of resolved project IDs keyed by the input `path`.
+ *
+ * The hot request path resolves the SAME session path many times per turn:
+ * `storeTurnTemporal` warms `ensureProject` once, then temporal.store /
+ * recordToolCalls each call `ensureProject`/`projectId` again (pipeline.ts,
+ * #1084 explicitly expects these to be "cheap cache hits"), and worktree/alias
+ * paths cost TWO lookups each (a `projects.path` miss + a `project_path_aliases`
+ * hit) — the sequential per-request DB churn Sentry flagged as a blocking
+ * operation (LOREAI-GATEWAY-3K).
+ *
+ * A path→id mapping is stable: it only changes when a project is created (new
+ * path, never rewrites an existing entry), merged, git_remote-backfilled, or
+ * deleted. The first three all fire {@link fireProjectMutation} /
+ * {@link fireProjectRemoteBackfilled}; deletion invalidates via
+ * {@link invalidateProjectIdCache} (called by data.ts `deleteProject`). Keyed by
+ * the live `db()` instance (WeakMap) so a test harness swapping the DB — or
+ * close() — starts from a fresh cache automatically, mirroring the column-list
+ * memo. Only STABLE resolutions are cached; the NULL-git_remote "existing"
+ * branch is intentionally left uncached so lazy backfill keeps retrying.
+ */
+const projectIdByPathCache = new WeakMap<Database, Map<string, string>>();
+
+function projectIdCacheFor(conn: Database): Map<string, string> {
+  let m = projectIdByPathCache.get(conn);
+  if (!m) {
+    m = new Map();
+    projectIdByPathCache.set(conn, m);
+  }
+  return m;
+}
+
+/**
+ * Drop the memoized path→id map for the current connection. Called on every
+ * project mutation (create/merge/backfill via the fire-hooks) and by data.ts
+ * after a project is deleted, so a stale mapping can never be served.
+ */
+export function invalidateProjectIdCache(): void {
+  // Read `instance` directly (not db()) so invalidation never forces a DB open.
+  if (!instance) return;
+  projectIdByPathCache.get(instance)?.clear();
 }
 
 /**
@@ -3660,12 +3710,21 @@ export function ensureProject(
     );
   }
 
+  // 0. Memoized fast path — the same session path is resolved many times per
+  // request (see projectIdByPathCache docs / LOREAI-GATEWAY-3K).
+  const cache = projectIdCacheFor(db());
+  const cached = cache.get(path);
+  if (cached !== undefined) return cached;
+
   // 1. Exact path match (fast path)
   const existing = db()
     .query("SELECT id, git_remote FROM projects WHERE path = ?")
     .get(path) as { id: string; git_remote: string | null } | null;
   if (existing) {
-    // Lazy backfill: populate git_remote on pre-v14 rows
+    // Lazy backfill: populate git_remote on pre-v14 rows. NOTE: this branch is
+    // intentionally left UNCACHED — git_remote is still NULL, so backfill must
+    // keep retrying on subsequent calls until it settles (at which point the
+    // `existing.git_remote` branch below caches the stable mapping).
     if (!existing.git_remote) {
       const resolvedRemote = resolveTrustedRemote(path, suppliedGitRemote);
       if (resolvedRemote) {
@@ -3686,15 +3745,22 @@ export function ensureProject(
         // was gated out while it was remote-less (else it never gets backed up).
         fireProjectRemoteBackfilled(existing.id);
       }
+      // Uncached: git_remote may still be NULL (no remote found) — keep retrying.
+      return existing.id;
     }
+    // Settled remote-backed row — stable mapping, safe to memoize.
+    cache.set(path, existing.id);
     return existing.id;
   }
 
-  // 2. Check path aliases (worktree/clone re-visits)
+  // 2. Check path aliases (worktree/clone re-visits) — the hot 3K path.
   const alias = db()
     .query("SELECT project_id FROM project_path_aliases WHERE path = ?")
     .get(path) as { project_id: string } | null;
-  if (alias) return alias.project_id;
+  if (alias) {
+    cache.set(path, alias.project_id);
+    return alias.project_id;
+  }
 
   // 3. Git remote identification
   const gitRemote = resolveTrustedRemote(path, suppliedGitRemote);
@@ -3709,6 +3775,7 @@ export function ensureProject(
           "INSERT OR IGNORE INTO project_path_aliases (path, project_id) VALUES (?, ?)",
         )
         .run(path, byRemote.id);
+      cache.set(path, byRemote.id);
       return byRemote.id;
     }
   }
@@ -3728,21 +3795,43 @@ export function ensureProject(
       "INSERT INTO projects (id, path, name, git_remote, created_at) VALUES (?, ?, ?, ?, ?)",
     )
     .run(id, path, derivedName, gitRemote, Date.now());
+  // fireProjectMutation() clears the memo (same map ref); populate AFTER it so
+  // the just-created mapping survives. Only memoize when the new project is
+  // already settled (has a remote): a remote-less project can still be
+  // git_remote-backfilled by a later ensureProject(path, suppliedGitRemote)
+  // call, so leave it uncached (mirrors the NULL-git_remote existing branch).
   fireProjectMutation();
+  if (gitRemote) cache.set(path, id);
   return id;
 }
 
 export function projectId(path: string): string | undefined {
-  const row = db()
-    .query("SELECT id FROM projects WHERE path = ?")
-    .get(path) as { id: string } | null;
-  if (row) return row.id;
+  // Shares ensureProject's per-connection memo (LOREAI-GATEWAY-3K).
+  const cache = projectIdCacheFor(db());
+  const cached = cache.get(path);
+  if (cached !== undefined) return cached;
 
-  // Check path aliases (worktree/clone paths registered by ensureProject)
+  const row = db()
+    .query("SELECT id, git_remote FROM projects WHERE path = ?")
+    .get(path) as { id: string; git_remote: string | null } | null;
+  if (row) {
+    // Mirror ensureProject: only memoize a settled (remote-backed) exact-path
+    // row so a NULL-git_remote project still gets its lazy backfill retried
+    // there. An unsettled row is returned but left uncached.
+    if (row.git_remote) cache.set(path, row.id);
+    return row.id;
+  }
+
+  // Check path aliases (worktree/clone paths registered by ensureProject). An
+  // alias only exists for an already-resolved project — safe to memoize.
   const alias = db()
     .query("SELECT project_id FROM project_path_aliases WHERE path = ?")
     .get(path) as { project_id: string } | null;
-  return alias?.project_id;
+  if (alias) {
+    cache.set(path, alias.project_id);
+    return alias.project_id;
+  }
+  return undefined;
 }
 
 /**

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -3744,8 +3744,15 @@ export function ensureProject(
         // #1246 (P2): the project just became remote-backed — re-seed the content that
         // was gated out while it was remote-less (else it never gets backed up).
         fireProjectRemoteBackfilled(existing.id);
+        // git_remote is now settled and existing.id survived any conflict merge
+        // above (it is the merge TARGET) — memoize so the next call for this
+        // path skips the exact-path lookup. fireProjectRemoteBackfilled cleared
+        // the map, so this set must come AFTER it.
+        cache.set(path, existing.id);
+        return existing.id;
       }
-      // Uncached: git_remote may still be NULL (no remote found) — keep retrying.
+      // Still remote-less (no remote resolved) — leave uncached so a later call
+      // with an on-disk/supplied remote can still lazily backfill.
       return existing.id;
     }
     // Settled remote-backed row — stable mapping, safe to memoize.

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -658,6 +658,27 @@ describe("db", () => {
         db().query("SELECT 1 AS n FROM projects WHERE id = ?").get(id2),
       ).toBeTruthy();
     });
+
+    test("mergeProjectInternal invalidates the memo (source path resolves to the winner, not the deleted source)", () => {
+      const loserPath = "/test/memo-merge/loser";
+      const winnerPath = "/test/memo-merge/winner";
+      const loser = ensureProject(loserPath);
+      const winner = ensureProject(winnerPath);
+      // Make the loser remote-backed so its settled exact-path row is memoized
+      // (a remote-less row is intentionally never cached).
+      db()
+        .query("UPDATE projects SET git_remote = ? WHERE id = ?")
+        .run("github.com/test/memo-merge", loser);
+      expect(ensureProject(loserPath)).toBe(loser); // primes the memo
+
+      // Merge deletes the loser row and re-points loserPath as an alias→winner.
+      // Without invalidation the memo would keep serving the DELETED loser id —
+      // a dangling FK target for the next temporal/knowledge write.
+      mergeProjectInternal(loser, winner);
+
+      expect(ensureProject(loserPath)).toBe(winner);
+      expect(projectId(loserPath)).toBe(winner);
+    });
   });
 
   test("ensureProject deduplicates via git_remote", () => {

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -4,6 +4,7 @@ import {
   close,
   ensureProject,
   projectId,
+  invalidateProjectIdCache,
   mergeProjectInternal,
   loadForceMinLayer,
   saveForceMinLayer,
@@ -36,6 +37,7 @@ import {
   assertFts5Available,
 } from "../src/db";
 import { enableHostedMode, _resetHostedModeForTest } from "../src/hosted";
+import { deleteProject } from "../src/data";
 
 describe("db", () => {
   test("initializes and creates tables", () => {
@@ -600,6 +602,62 @@ describe("db", () => {
 
     // projectId should resolve the alias
     expect(projectId("/test/alias/worktree")).toBe(id);
+  });
+
+  // Regression (LOREAI-GATEWAY-3K): the hot request path resolves the same
+  // worktree/alias path many times per turn. ensureProject/projectId memoize
+  // path→id per connection; the memo must be honored AND invalidated correctly.
+  describe("project id memoization (#3K)", () => {
+    test("serves a resolved alias path from the memo until it is invalidated", () => {
+      const canonical = "/test/memo/canonical";
+      const worktree = "/test/memo/worktree";
+      const id = ensureProject(canonical);
+      db()
+        .query(
+          "INSERT OR IGNORE INTO project_path_aliases (path, project_id) VALUES (?, ?)",
+        )
+        .run(worktree, id);
+
+      // First resolve caches worktree→id via the (stable) alias branch.
+      expect(ensureProject(worktree)).toBe(id);
+
+      // Remove the alias row WITHOUT invalidating the memo. If the memo is live,
+      // a cache HIT still returns the old id even though the DB no longer has
+      // the alias — this is what proves the lookups are actually memoized.
+      db()
+        .query("DELETE FROM project_path_aliases WHERE path = ?")
+        .run(worktree);
+      expect(ensureProject(worktree)).toBe(id); // served from memo
+      expect(projectId(worktree)).toBe(id); // shared memo
+
+      // After explicit invalidation the stale mapping is gone → the now-orphan
+      // worktree path resolves fresh (a brand-new project).
+      invalidateProjectIdCache();
+      expect(ensureProject(worktree)).not.toBe(id);
+    });
+
+    test("deleteProject invalidates the memo so a reused path is never a dangling id", () => {
+      const canonical = "/test/memo-del/canonical";
+      const worktree = "/test/memo-del/worktree";
+      const id1 = ensureProject(canonical);
+      db()
+        .query(
+          "INSERT OR IGNORE INTO project_path_aliases (path, project_id) VALUES (?, ?)",
+        )
+        .run(worktree, id1);
+      expect(ensureProject(worktree)).toBe(id1); // prime the memo
+
+      deleteProject(id1);
+
+      // The memo must have been cleared: the path resolves to a FRESH project,
+      // never the deleted id, and the returned id must actually exist (a stale
+      // memo would hand back id1 and FK-violate on the next temporal write).
+      const id2 = ensureProject(worktree);
+      expect(id2).not.toBe(id1);
+      expect(
+        db().query("SELECT 1 AS n FROM projects WHERE id = ?").get(id2),
+      ).toBeTruthy();
+    });
   });
 
   test("ensureProject deduplicates via git_remote", () => {

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -784,6 +784,22 @@ describe("db", () => {
         .get(id1) as { git_remote: string | null };
       expect(rowAfter.git_remote).toBe("github.com/test/backfill-repo");
     });
+
+    test("memoizes the mapping after a successful git_remote backfill (#3K)", () => {
+      const path = "/test/backfill-cache/original";
+      const id = ensureProject(path); // remote-less create → left uncached
+      // The backfill settles git_remote and, per the #3K memo, caches path→id.
+      expect(
+        ensureProject(path, undefined, "github.com/test/backfill-cache"),
+      ).toBe(id);
+      // Raw-delete the row WITHOUT invalidating: a cache HIT must still return
+      // id, proving the post-backfill mapping was memoized (so the next call
+      // skips the exact-path lookup — the extra lookup Seer flagged).
+      db().query("DELETE FROM projects WHERE id = ?").run(id);
+      expect(
+        ensureProject(path, undefined, "github.com/test/backfill-cache"),
+      ).toBe(id);
+    });
   });
 
   // Regression: the "git-remote magnet" bug. A non-repo path (e.g. a parent

--- a/packages/core/test/setup.ts
+++ b/packages/core/test/setup.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterAll, afterEach } from "vitest";
-import { close } from "../src/db";
+import { close, invalidateProjectIdCache } from "../src/db";
 import { silenceStderr } from "../src/log";
 
 // Create an isolated temporary database for the entire test run.
@@ -87,6 +87,11 @@ globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
 // Reset after every test so silenced state never crosses a test boundary.
 afterEach(() => {
   silenceStderr(false);
+  // The whole run shares one temp DB (single db() instance), so the per-
+  // connection project path→id memo persists across tests. Clear it after each
+  // test to make isolation explicit — a settled/alias mapping cached by one
+  // test must never be served to another test that reuses the same path.
+  invalidateProjectIdCache();
 });
 
 afterAll(() => {


### PR DESCRIPTION
## What

Addresses **LOREAI-GATEWAY-3K** (\`Blocking Operation\` on \`POST /v1/messages\`, 1 event, priority 50).

The event's span tree showed **no single slow query** (all 1–5ms) — the detector fired on the *cumulative* main-thread DB time in the post-response path, which resolves the **same** session path many times per turn. Worktree/alias paths (the user's common case) cost **two** lookups each — a \`projects.path\` **miss** then a \`project_path_aliases\` **hit** — so one request ran ~8 \`SELECT … FROM projects WHERE path\` + ~7 \`SELECT … FROM project_path_aliases WHERE path\`.

\`pipeline.ts\` (#1084) already documents the *intent*: warming \`ensureProject\` before the \`storeTurnTemporal\` savepoint should make "the \`ensureProject\` calls inside temporal.store / recordToolCalls cheap **cache hits**." But no cache existed, so every inner call re-queried.

## How

A per-connection **path→id memo** shared by \`ensureProject\` and \`projectId\`:
- Keyed on the live \`db()\` instance via \`WeakMap\` (mirrors the existing column-list memo) so a test DB swap / \`close()\` starts from a fresh cache automatically.
- Only **stable** resolutions are cached: a settled (remote-backed) exact-path row, an **alias hit** (the hot 3K path), a git-remote match, or a remote-backed freshly-created project.
- The **NULL-\`git_remote\` branches** (existing row and newly-created remote-less project) are intentionally left **uncached** so lazy \`git_remote\` backfill keeps retrying until it settles. (The existing "backfills existing project" test guards this — and caught a bug during development where the create branch cached a remote-less project.)

### Invalidation
- \`fireProjectMutation()\` (project **create** + **merge** via \`mergeProjectInternal\`) and \`fireProjectRemoteBackfilled()\` clear the memo.
- \`data.ts\` \`deleteProject\` clears it after removing the row, so a reused path can never resolve to a **dangling id** and FK-violate.
- \`renameProject\` only changes \`name\` (not \`path\`); \`clearProject\`/\`clearKnowledge\` keep the project row — neither needs invalidation.

## Tests (mutation-verified)

- **memo honored until invalidated**: after caching a worktree→id alias resolution, deleting the alias row directly still returns the cached id (proving lookups are memoized); after \`invalidateProjectIdCache()\` it resolves fresh. (Mutation: disabling the memo read fails this test.)
- **deleteProject invalidates**: a reused path resolves to a fresh project, never the deleted id, and the returned id exists. (Mutation: removing the delete-invalidation fails this test.)

\`packages/core/test/db.test.ts\`: 116 passed. Full core suite green except a pre-existing, unrelated dist-worker env test (\`embedding-optional-stack.test.ts #1220\`, fails identically on clean \`origin/main\` here). Typecheck + Biome clean.

## Review notes

Adversarial review verdict: **SHIP-WITH-FOLLOWUPS** (audited every projects/aliases mutation in db.ts/data.ts/sync-data.ts; mutation-tested in a throwaway worktree, main tree verified byte-identical). The caching logic was confirmed correct on all axes — cached-vs-uncached split, WeakMap keying (confined to the single main-thread writer connection; the read-worker pool runs only raw SQL and never populates the memo), staleness-within-mutation, and re-entrancy. The dangerous merge path (re-point + delete source) is correctly invalidated and was proven load-bearing.

Applied follow-ups in this PR:
- Added the missing **merge-invalidation regression test** (the one genuinely dangerous path — a mutation removing the invalidate in `fireProjectMutation` now fails it; verified).
- Reset the memo in the shared test `afterEach` so cross-test isolation is explicit (single shared temp DB / one `db()` instance).

Accepted NITs (not blocking): whole-map invalidation flushes all sessions on any create/merge/backfill (correctness-safe; creates are rare vs resolves on the intra-turn hot path), and `backfillGitRemotes`/`applyRemoteProject` are safe only because remote-less rows are never cached + post-pull converge invalidates — an implicit dependency on the caching rules (documented at the cache definition).