### PR TITLE
feat(core): client key rotation — epoch-aware DEKs + rotateScopeKey + seal/open (E-4c-3b, #827)

### DIFF
--- a/packages/core/src/crypto/keystore.ts
+++ b/packages/core/src/crypto/keystore.ts
@@ -147,19 +147,50 @@ export function getAccountIdentity(): Keypair {
   return kp;
 }
 
+/** dekCache / pendingScopeKey are keyed by (scope, epoch): each rotation epoch has its OWN DEK. */
+const dekKey = (scopeId: string, epoch: number): string =>
+  `${scopeId}\x1f${epoch}`;
+
+/** All rotation epochs this device holds a wrap for, for (scope, member), ascending. */
+export function scopeKeyEpochs(
+  scopeId: string,
+  memberUserId: string = scopeId,
+): number[] {
+  return (
+    db()
+      .query(
+        "SELECT key_epoch AS e FROM scope_keys WHERE scope_id = ? AND member_user_id = ? ORDER BY key_epoch",
+      )
+      .all(scopeId, memberUserId) as { e: number }[]
+  ).map((r) => r.e);
+}
+
+/** The scope's current (highest) epoch this device can encrypt at; 0 if it holds no wrap yet. */
+export function currentScopeEpoch(
+  scopeId: string,
+  memberUserId: string = scopeId,
+): number {
+  const eps = scopeKeyEpochs(scopeId, memberUserId);
+  return eps.length ? eps[eps.length - 1] : 0;
+}
+
 /**
- * The DEK for a scope. Generated + wrapped to the account key on first use (personal
- * v1: `memberUserId` defaults to `scopeId`, so `scope_id = member_user_id = user`).
- * Otherwise unwrapped from the stored `scope_keys` row. Cached in memory per scope.
+ * The DEK for a scope at a given epoch. Minted + wrapped to the account key on first use
+ * (personal v1: `memberUserId` defaults to `scopeId`). Otherwise unwrapped from the stored
+ * `scope_keys` row for that epoch. Cached in memory per (scope, epoch) — each rotation epoch has
+ * its own DEK. `epoch` defaults to the scope's CURRENT (highest) epoch (what encrypt seals at);
+ * decrypt passes the blob's pinned epoch to open past-rotation ciphertext.
  */
 export function getScopeKey(
   scopeId: string,
   memberUserId: string = scopeId,
-  opts?: { mint?: boolean },
+  opts?: { mint?: boolean; epoch?: number },
 ): Promise<Uint8Array> {
-  const cached = dekCache.get(scopeId);
+  const epoch = opts?.epoch ?? currentScopeEpoch(scopeId, memberUserId);
+  const ckey = dekKey(scopeId, epoch);
+  const cached = dekCache.get(ckey);
   if (cached) return Promise.resolve(cached);
-  const inflight = pendingScopeKey.get(scopeId);
+  const inflight = pendingScopeKey.get(ckey);
   if (inflight) return inflight;
   // mint defaults to true (the personal / DEK-originator path). A JOINING team member MUST
   // pass mint:false: the scope's DEK is minted once by its originator and wrapped to each
@@ -174,53 +205,58 @@ export function getScopeKey(
   // of memberUserId is correct — memberUserId only selects which wrap row to unwrap on a MISS,
   // and every member's wrap yields the same per-scope DEK. Never treat this flag as authz.
   const mint = opts?.mint ?? true;
-  const p = loadOrCreateScopeKey(scopeId, memberUserId, mint).finally(() => {
-    // Delete only if THIS promise is still the registered one — a lock()/installIdentity
-    // may have cleared the map and a newer call may have registered its own promise.
-    if (pendingScopeKey.get(scopeId) === p) pendingScopeKey.delete(scopeId);
-  });
+  const p = loadOrCreateScopeKey(scopeId, memberUserId, epoch, mint).finally(
+    () => {
+      // Delete only if THIS promise is still the registered one — a lock()/installIdentity
+      // may have cleared the map and a newer call may have registered its own promise.
+      if (pendingScopeKey.get(ckey) === p) pendingScopeKey.delete(ckey);
+    },
+  );
   // Only the MINTING promise is shared as the in-flight one: it produces the scope DEK, so
   // every concurrent caller (mint:true OR a mint:false read racing it) may safely await it. A
   // mint:false read that will REJECT (no wrap yet) must NOT be registered — otherwise a
   // concurrent mint:true originator would receive that rejection via the shared slot and fail
-  // to mint (keyed by scopeId, not intent). An unregistered read still caches its DEK on success.
-  if (mint) pendingScopeKey.set(scopeId, p);
+  // to mint (keyed by (scope,epoch), not intent). An unregistered read still caches on success.
+  if (mint) pendingScopeKey.set(ckey, p);
   return p;
 }
 
 async function loadOrCreateScopeKey(
   scopeId: string,
   memberUserId: string,
+  epoch: number,
   mint: boolean,
 ): Promise<Uint8Array> {
-  const epoch = keystoreEpoch;
+  const kEpoch = keystoreEpoch;
   const id = getAccountIdentity();
   // Only persist into the shared cache if no lock()/identity-swap happened while we
   // were awaiting — otherwise a stale key would leak back in after invalidation. The
   // caller that requested this DEK still receives it (it asked before the reset).
   const cache = (dek: Uint8Array): void => {
-    if (keystoreEpoch === epoch) dekCache.set(scopeId, dek);
+    if (keystoreEpoch === kEpoch) dekCache.set(dekKey(scopeId, epoch), dek);
   };
   const row = db()
     .query(
-      "SELECT wrapped_dek AS w FROM scope_keys WHERE scope_id = ? AND member_user_id = ? ORDER BY key_epoch DESC LIMIT 1",
+      "SELECT wrapped_dek AS w FROM scope_keys WHERE scope_id = ? AND member_user_id = ? AND key_epoch = ?",
     )
-    .get(scopeId, memberUserId) as { w: unknown } | undefined;
+    .get(scopeId, memberUserId, epoch) as { w: unknown } | undefined;
   if (row) {
     const dek = await unwrapDek(id.secretKey, toU8(row.w));
     cache(dek);
     return dek;
   }
-  if (!mint) {
+  // No wrap for this epoch. NEVER mint a ROTATED epoch (rotateScopeKey creates those) and never
+  // mint when the caller forbade it (a joining member awaiting a group-wrap). Only the DEK
+  // ORIGINATOR mints — always at epoch 0.
+  if (!mint || epoch !== 0) {
     throw new ScopeKeyUnavailable(scopeId, memberUserId);
   }
   const dek = generateDek();
   const wrapped = await wrapDekForMember(id.publicKey, dek);
   const now = Date.now();
-  // ON CONFLICT DO NOTHING: if a row already exists for this (scope, member) — a
-  // concurrent writer won the race — keep theirs and never clobber. Read the persisted
-  // row back and unwrap THAT so every caller converges on the one stored DEK; a lost
-  // insert can never leave earlier ciphertext unopenable.
+  // ON CONFLICT DO NOTHING: if an epoch-0 row already exists — a concurrent writer won the race —
+  // keep theirs and never clobber. Read the persisted row back and unwrap THAT so every caller
+  // converges on the one stored DEK; a lost insert can never leave earlier ciphertext unopenable.
   db()
     .query(
       `INSERT INTO scope_keys
@@ -231,7 +267,7 @@ async function loadOrCreateScopeKey(
     .run(scopeId, memberUserId, Buffer.from(wrapped), now, now);
   const stored = db()
     .query(
-      "SELECT wrapped_dek AS w FROM scope_keys WHERE scope_id = ? AND member_user_id = ? ORDER BY key_epoch DESC LIMIT 1",
+      "SELECT wrapped_dek AS w FROM scope_keys WHERE scope_id = ? AND member_user_id = ? AND key_epoch = 0",
     )
     .get(scopeId, memberUserId) as { w: unknown };
   const finalDek = await unwrapDek(id.secretKey, toU8(stored.w));
@@ -270,7 +306,45 @@ export function putWrappedScopeKey(
       now,
       updatedAt,
     );
-  dekCache.delete(scopeId);
+  // Invalidate only THIS epoch's cached DEK — a pulled canonical wrap may replace a device's
+  // divergent local mint at the same epoch (lost first-write-wins race), so the next
+  // getScopeKey for (scope, epoch) must re-unwrap the applied value. Other epochs are untouched.
+  dekCache.delete(dekKey(scopeId, keyEpoch));
+}
+
+/**
+ * Rotate the scope's DEK (E-4c-3): mint a FRESH DEK and wrap it to EACH remaining member at
+ * `newEpoch`, INSERTing new rows while OLD-epoch rows are retained (so past blobs stay
+ * decryptable). New content seals at `newEpoch` once it is the highest local epoch. `newEpoch`
+ * MUST be allocated server-atomically via the `rotate_scope_key(scope)` RPC so concurrent admins
+ * never mint the same epoch with divergent DEKs. `members` MUST include the caller (self) with
+ * their own public key, or the rotator locks itself out of the new epoch. Members + their
+ * identity public keys are supplied by the caller (CLI/registry).
+ */
+export async function rotateScopeKey(
+  scopeId: string,
+  newEpoch: number,
+  members: { userId: string; publicKey: Uint8Array }[],
+): Promise<void> {
+  const kEpoch = keystoreEpoch;
+  const dek = generateDek();
+  const now = Date.now();
+  // Wrap to ALL members FIRST (async HPKE), THEN persist — so a mid-wrap failure leaves NO
+  // partial epoch. Otherwise a half-written epoch + a retry (fresh DEK) would collide with the
+  // already-written members at the remote first-write-wins guard (23514 poison).
+  const wraps = await Promise.all(
+    members.map(async (m) => ({
+      userId: m.userId,
+      wrapped: await wrapDekForMember(m.publicKey, dek),
+    })),
+  );
+  for (const w of wraps) {
+    putWrappedScopeKey(scopeId, w.userId, w.wrapped, newEpoch, now);
+  }
+  // Cache the fresh DEK for (scope, newEpoch) so the encrypt path uses it immediately — unless a
+  // lock()/identity swap raced (then leave it for a fresh unwrap; putWrappedScopeKey already
+  // invalidated the slot).
+  if (keystoreEpoch === kEpoch) dekCache.set(dekKey(scopeId, newEpoch), dek);
 }
 
 /**

--- a/packages/core/test/keystore-group-wrap.test.ts
+++ b/packages/core/test/keystore-group-wrap.test.ts
@@ -47,6 +47,16 @@ const storedWrap = (member: string): Uint8Array =>
         .get(TEAM, member) as { w: Uint8Array }
     ).w,
   );
+const storedWrapAt = (member: string, epoch: number): Uint8Array =>
+  Buffer.from(
+    (
+      db()
+        .query(
+          "SELECT wrapped_dek AS w FROM scope_keys WHERE scope_id=? AND member_user_id=? AND key_epoch=?",
+        )
+        .get(TEAM, member, epoch) as { w: Uint8Array }
+    ).w,
+  );
 
 describe("keystore — group DEK wrapping (E-4c-2)", () => {
   it("an admin wraps the scope DEK to a member; the member's secret unwraps the SAME DEK", async () => {
@@ -127,6 +137,32 @@ describe("keystore — group DEK wrapping (E-4c-2)", () => {
     ]);
     expect(read.status).toBe("rejected");
     expect(minted.status).toBe("fulfilled");
+  });
+
+  it("rotateScopeKey mints a fresh epoch DEK, wraps to all members, and RETAINS old epochs", async () => {
+    const admin = keystore.getAccountIdentity(); // A (the DEK originator)
+    const dek0 = await keystore.getScopeKey(TEAM, A); // epoch 0
+    expect(keystore.currentScopeEpoch(TEAM, A)).toBe(0);
+    const member = generateIdentityKeypair(); // B, a remaining member
+    // A rotates to epoch 1, re-wrapping to the remaining members (incl. self).
+    await keystore.rotateScopeKey(TEAM, 1, [
+      { userId: A, publicKey: admin.publicKey },
+      { userId: B, publicKey: member.publicKey },
+    ]);
+    expect(keystore.currentScopeEpoch(TEAM, A)).toBe(1);
+    expect(keystore.scopeKeyEpochs(TEAM, A)).toEqual([0, 1]); // BOTH retained
+    const dek1 = await keystore.getScopeKey(TEAM, A, { epoch: 1 });
+    expect(eq(dek1, dek0)).toBe(false); // a genuinely fresh DEK
+    // The OLD epoch stays decryptable (past blobs remain readable).
+    expect(eq(await keystore.getScopeKey(TEAM, A, { epoch: 0 }), dek0)).toBe(
+      true,
+    );
+    // getScopeKey with no epoch now defaults to the CURRENT (highest) epoch.
+    expect(eq(await keystore.getScopeKey(TEAM, A), dek1)).toBe(true);
+    // Member B unwraps the epoch-1 wrap → the same new DEK.
+    expect(
+      eq(await unwrapDek(member.secretKey, storedWrapAt(B, 1)), dek1),
+    ).toBe(true);
   });
 
   it("personal scopes still mint by default (behavior-preserving)", async () => {

--- a/packages/gateway/src/sync.ts
+++ b/packages/gateway/src/sync.ts
@@ -168,7 +168,13 @@ function isUniqueConstraintError(e: unknown): boolean {
 class EncryptedContentUnavailable extends Error {}
 
 type EncMode = "off" | "locked" | "on";
-type EncCtx = { scope: string; dek: Uint8Array } | null;
+// Multi-epoch (E-4c-3): a scope has one DEK PER rotation epoch. `deks` holds every epoch this
+// device can decrypt; `currentEpoch` is the highest — what new content seals at.
+type EncCtx = {
+  scope: string;
+  currentEpoch: number;
+  deks: Map<number, Uint8Array>;
+} | null;
 /** A per-table snapshot of the encryption state handed to the (sync) apply path. */
 type EncSnapshot = { mode: EncMode; ctx: EncCtx };
 
@@ -192,9 +198,24 @@ function makeEncryptionResolver() {
       if (cached !== undefined) return cached;
       try {
         const scope = (await getCurrentUser())?.user_id;
-        cached = scope
-          ? { scope, dek: await keystore.getScopeKey(scope) }
-          : null;
+        if (!scope) {
+          cached = null;
+          return cached;
+        }
+        // Pre-resolve EVERY epoch's DEK once per cycle (few epochs; HPKE unwrap each, keystore-
+        // cached). Keeps encrypt/decrypt SYNC: decrypt looks up the blob's pinned epoch, encrypt
+        // seals at the current (highest) epoch. On first use the empty list resolves epoch 0,
+        // which MINTS the originator's DEK. An epoch we hold no wrap for is simply absent, so a
+        // blob sealed under it defers the table (EncryptedContentUnavailable) until it arrives.
+        // ONE read of the epoch set (ascending); derive currentEpoch from it — no TOCTOU window
+        // between a separate max-read and the enumeration if a rotate lands mid-cycle.
+        const epochs = keystore.scopeKeyEpochs(scope);
+        const currentEpoch = epochs.length ? epochs[epochs.length - 1] : 0;
+        const deks = new Map<number, Uint8Array>();
+        for (const e of epochs.length ? epochs : [currentEpoch]) {
+          deks.set(e, await keystore.getScopeKey(scope, scope, { epoch: e }));
+        }
+        cached = { scope, currentEpoch, deks };
       } catch (e) {
         log.notice(`sync: encryption key unavailable: ${(e as Error).message}`);
         cached = null;
@@ -214,14 +235,22 @@ function encryptColumns(
   table: string,
   logicalId: string,
   payload: Record<string, unknown>,
-  ctx: { scope: string; dek: Uint8Array },
+  ctx: NonNullable<EncCtx>,
 ): void {
+  // Seal new content at the scope's CURRENT epoch (the envelope pins it, so decrypt dispatches
+  // to the right DEK). ctx() guarantees the current-epoch DEK; its absence is a logic error —
+  // fail CLOSED (throw) rather than push plaintext.
+  const dek = ctx.deks.get(ctx.currentEpoch);
+  if (!dek)
+    throw new Error(
+      `encrypt: no DEK for ${ctx.scope} epoch ${ctx.currentEpoch}`,
+    );
   for (const col of tableMeta(table).encryptedColumns ?? []) {
     const v = payload[col];
     if (typeof v !== "string" || v.length === 0) continue;
     const aad = crypto.buildAad(ctx.scope, table, col, logicalId);
     payload[col] = Buffer.from(
-      crypto.seal(ctx.dek, utf8.encode(v), aad),
+      crypto.seal(dek, utf8.encode(v), aad, { keyEpoch: ctx.currentEpoch }),
     ).toString("base64");
   }
 }
@@ -251,9 +280,20 @@ function decryptColumns(
     if (enc.mode !== "on" || !enc.ctx) {
       throw new EncryptedContentUnavailable(`${table}: no key (locked/off)`);
     }
+    // Dispatch on the blob's PINNED epoch (E-4c-3): open with THAT epoch's DEK, not "current".
+    // A blob sealed under an epoch we hold no wrap for (a rotation we haven't received yet, or
+    // one we were removed before) defers the table until the wrap arrives — never stored as
+    // ciphertext, never crashes the cycle.
+    const blobEpoch = crypto.parseHeader(bytes).keyEpoch;
+    const dek = enc.ctx.deks.get(blobEpoch);
+    if (!dek) {
+      throw new EncryptedContentUnavailable(
+        `${table}: no key for epoch ${blobEpoch}`,
+      );
+    }
     const aad = crypto.buildAad(enc.ctx.scope, table, col, logicalId);
     try {
-      row[col] = fromUtf8.decode(crypto.open(enc.ctx.dek, bytes, aad));
+      row[col] = fromUtf8.decode(crypto.open(dek, bytes, aad));
     } catch (e) {
       // A valid envelope we hold a key for but still can't open (wrong key / tampered /
       // AAD mismatch) is an integrity failure. NEVER store the ciphertext and NEVER let

--- a/packages/gateway/test/sync-engine.integration.test.ts
+++ b/packages/gateway/test/sync-engine.integration.test.ts
@@ -641,6 +641,75 @@ describe.skipIf(SKIP)(
       expect(syncData.getRowById("knowledge", "kw")).toBeNull(); // never decrypted
     });
 
+    it("device-2 decrypts each blob at its PINNED epoch after a rotation (epoch dispatch, not 'current') (E-4c-3b)", async () => {
+      const client = clientFor(uid);
+      const P0 = "body sealed at epoch zero";
+      const P1 = "body sealed at epoch one";
+      const scope = uid; // v1 encryption scope = auth.uid()
+
+      // --- Device 1: arm encryption, push kr0 at epoch 0 (2nd push flushes the lazy DEK row). ---
+      keystore.setPassphrase("rotate me", { params: FAST });
+      syncData.enableSync("basic");
+      insertKnowledge("kr0", P0);
+      await pushOnce(client);
+      await pushOnce(client);
+      expect(keystore.currentScopeEpoch(scope)).toBe(0);
+
+      // Rotate to epoch 1 (mint a fresh DEK, re-wrap to self) → new content seals at epoch 1.
+      const self = keystore.getAccountIdentity();
+      await keystore.rotateScopeKey(scope, 1, [
+        { userId: scope, publicKey: self.publicKey },
+      ]);
+      expect(keystore.currentScopeEpoch(scope)).toBe(1);
+      insertKnowledge("kr1", P1);
+      await pushOnce(client); // kr1 (epoch 1) + the epoch-1 scope_keys row
+      await pushOnce(client);
+
+      // The remote blobs carry DISTINCT pinned epochs (kr1 sealed at CURRENT=1, kr0 stayed at 0).
+      const rows = await h.asUser(uid, (c) =>
+        c
+          .query(
+            "select id, content from public.knowledge where id in ('kr0','kr1') order by id",
+          )
+          .then((x) => x.rows),
+      );
+      const epochOf = (b64: string) =>
+        crypto.parseHeader(Buffer.from(b64 as string, "base64")).keyEpoch;
+      expect(epochOf(rows[0].content)).toBe(0); // kr0
+      expect(epochOf(rows[1].content)).toBe(1); // kr1 seals at the current epoch (kills the no-stamp mutant)
+      // Both epoch wraps must be on the remote for a fresh device to decrypt both.
+      expect(
+        await h.asUser(uid, (c) =>
+          c
+            .query("select count(*)::int n from public.scope_keys")
+            .then((x) => x.rows[0].n),
+        ),
+      ).toBe(2);
+
+      // --- Device 2: fresh device, same account. Pull escrow + BOTH epoch wraps, unlock, then
+      // pull knowledge: each blob MUST decrypt with ITS OWN epoch's DEK (kr0→epoch 0, kr1→epoch
+      // 1). Decrypting kr0 with the "current" (epoch-1) DEK would fail the AEAD tag. ---
+      db().exec(
+        "DELETE FROM account_identity; DELETE FROM account_escrow; DELETE FROM scope_keys; DELETE FROM knowledge; DELETE FROM knowledge_meta; DELETE FROM knowledge_meta_crdt; DELETE FROM sync_state; DELETE FROM sync_outbox",
+      );
+      keystore.lock();
+      for (const m of syncData.syncedTables("basic")) {
+        setKV(
+          `sync.pull.${m.table}`,
+          m.pullOnly ? `${Date.now() + 31_536_000_000}|` : "0|",
+        );
+        setKV(`sync.push.${m.table}`, "0");
+      }
+      await pullOnce(client); // escrow + both scope_keys epochs → locked
+      expect(keystore.encryptionState()).toBe("locked");
+      expect(keystore.unlockWithPassphrase("rotate me")).toBe(true);
+      expect(keystore.scopeKeyEpochs(scope)).toEqual([0, 1]); // both wraps pulled
+      const p = await pullOnce(client);
+      expect(p.conflicts).toBe(0);
+      expect(syncData.getRowById("knowledge", "kr0")?.content).toBe(P0);
+      expect(syncData.getRowById("knowledge", "kr1")?.content).toBe(P1);
+    });
+
     it("device-1 pushes a project + its content → device-2 restores under the seeded FK parent (P1, #1246)", async () => {
       const REMOTE_URL = "github.com/acme/secret-repo";
       const client = clientFor(uid);

--- a/packages/gateway/test/sync-scope-rotation.integration.test.ts
+++ b/packages/gateway/test/sync-scope-rotation.integration.test.ts
@@ -107,6 +107,28 @@ describe.skipIf(gate())("0030 key rotation foundation (E-4c-3a, #827)", () => {
     ).toEqual([0, 1]); // both retained
   });
 
+  it("a rotation's new-epoch wrap is COUNTED against the row cap (0031 per-epoch probe)", async () => {
+    const a = await h.createUser();
+    const scope = await createTeam(a, "Rot Quota");
+    const setCap = (n: number) =>
+      h.client.query(
+        "update public.plan_limits set max_rows=$1 where tier='free' and table_name='scope_keys'",
+        [n],
+      );
+    try {
+      await setCap(1);
+      await putWrap(a, scope, a, 0, "ZDA="); // epoch 0 → count 0→1 (ok)
+      // A rotation writes epoch 1 as a NEW physical row for the SAME member. The 0031 probe now
+      // matches key_epoch, so this row is counted → it trips the cap (before 0031 the probe
+      // matched only (scope,member), early-returned, and let the row escape the cap).
+      expect(
+        (await expectError(() => putWrap(a, scope, a, 1, "ZDE="))).code,
+      ).toBe("23514");
+    } finally {
+      await setCap(100); // restore the default free scope_keys cap
+    }
+  });
+
   it("an existing epoch's wrapped_dek is immutable (rotation writes a new row, never re-wraps)", async () => {
     const a = await h.createUser();
     const scope = await createTeam(a, "Rot C");

--- a/supabase/migrations/0031_scope_keys_epoch_quota.sql
+++ b/supabase/migrations/0031_scope_keys_epoch_quota.sql
@@ -1,0 +1,257 @@
+-- Migration 0031 — count scope_keys per epoch in the quota probe (E-4c-3b, #827).
+--
+-- Key rotation (E-4c-3) writes a NEW scope_keys row per epoch (PK now includes key_epoch, 0030).
+-- The 0028 enforce_row_quota INSERT probe keyed only on (scope_id, member_user_id), so a
+-- rotation's epoch-(N+1) row for an EXISTING member matched the member's epoch-0 row → exists_pk
+-- true → the new row was NOT counted, letting rotations accrue uncounted rows past the cap. This
+-- reproduces 0028's function VERBATIM except the scope_keys probe, which now also matches
+-- key_epoch so each epoch row is counted. (No new-epoch row existed before 3b, so this was
+-- unreachable until now — deferred from 0030 as documented.)
+
+create or replace function public.enforce_row_quota()
+returns trigger
+language plpgsql
+security definer
+set search_path = pg_catalog, public
+as $$
+declare
+  user_tier text;
+  cap_rows  bigint;
+  cap_bytes bigint;
+  cur_rows  bigint;
+  cur_bytes bigint;
+  d_rows    int    := 0;
+  d_bytes   bigint := 0;
+  exists_pk boolean;
+  -- eviction locals
+  evb_start  timestamptz;
+  evb_count  int;
+  evb_cap    int;
+  victim     text;
+  floor_rank int;
+begin
+  if tg_op = 'UPDATE' and old.scope_id is distinct from new.scope_id then
+    raise exception 'scope_id is immutable'
+      using errcode = 'check_violation';
+  end if;
+
+  -- Do NOT read the victim's tier/usage for a row this caller cannot own (an at-cap
+  -- existence oracle via the quota exception). Such a row is ALWAYS rejected by RLS
+  -- WITH CHECK regardless, so skipping quota here changes NO legitimate outcome. E-4b:
+  -- keyed on membership (not self) so a team member's write to a shared scope is metered.
+  if auth.uid() is not null and not public.is_member(new.scope_id) then
+    return new;
+  end if;
+
+  perform pg_advisory_xact_lock(
+    hashtextextended(new.scope_id::text || '|' || tg_table_name, 0));
+
+  if tg_op = 'INSERT' then
+    if tg_table_name = 'knowledge_entity_refs' then
+      select exists(
+        select 1 from public.knowledge_entity_refs
+         where scope_id     = (to_jsonb(new)->>'scope_id')::uuid
+           and knowledge_id = to_jsonb(new)->>'knowledge_id'
+           and entity_id    = to_jsonb(new)->>'entity_id')
+        into exists_pk;
+    elsif tg_table_name = 'knowledge_meta' then
+      select exists(
+        select 1 from public.knowledge_meta
+         where scope_id   = (to_jsonb(new)->>'scope_id')::uuid
+           and logical_id = to_jsonb(new)->>'logical_id')
+        into exists_pk;
+    elsif tg_table_name = 'knowledge_meta_crdt' then
+      select exists(
+        select 1 from public.knowledge_meta_crdt
+         where scope_id   = (to_jsonb(new)->>'scope_id')::uuid
+           and logical_id = to_jsonb(new)->>'logical_id'
+           and replica_id = to_jsonb(new)->>'replica_id')
+        into exists_pk;
+    elsif tg_table_name = 'account_escrow' then
+      select exists(
+        select 1 from public.account_escrow
+         where scope_id = (to_jsonb(new)->>'scope_id')::uuid
+           and id       = (to_jsonb(new)->>'id')::int)
+        into exists_pk;
+    elsif tg_table_name = 'scope_keys' then
+      select exists(
+        select 1 from public.scope_keys
+         where scope_id       = (to_jsonb(new)->>'scope_id')::uuid
+           and member_user_id = to_jsonb(new)->>'member_user_id'
+           and key_epoch       = (to_jsonb(new)->>'key_epoch')::int)
+        into exists_pk;
+    else
+      execute format(
+        'select exists(select 1 from public.%I where scope_id = $1 and id = $2)',
+        tg_table_name)
+        into exists_pk
+        using (to_jsonb(new)->>'scope_id')::uuid, to_jsonb(new)->>'id';
+    end if;
+    if exists_pk then
+      return new;
+    end if;
+    d_rows  := 1;
+    d_bytes := public.usage_row_bytes(to_jsonb(new));
+  else  -- UPDATE: row count unchanged; gate only byte growth.
+    d_bytes := public.usage_row_bytes(to_jsonb(new))
+             - public.usage_row_bytes(to_jsonb(old));
+  end if;
+
+  if d_rows <= 0 and d_bytes <= 0 then
+    return new;
+  end if;
+
+  user_tier := public.effective_tier(new.scope_id);
+  if user_tier is null then user_tier := 'free'; end if;
+
+  select max_rows, max_bytes into cap_rows, cap_bytes
+    from public.plan_limits
+   where tier = user_tier and table_name = tg_table_name;
+  if cap_rows is null and cap_bytes is null then
+    return new;
+  end if;
+
+  select row_count, byte_count into cur_rows, cur_bytes
+    from public.user_table_usage
+   where scope_id = new.scope_id and table_name = tg_table_name;
+  cur_rows  := coalesce(cur_rows, 0);
+  cur_bytes := coalesce(cur_bytes, 0);
+
+  -- ── Continuous top-N eviction (free tier, row cap) ──────────────────────────
+  -- On a genuine new row that would exceed the row cap, evict the lowest-value LIVE entry
+  -- for this scope instead of rejecting, then re-read usage so the checks below see the
+  -- freed slot. Per-table value: knowledge → knowledge_meta.base_confidence; entities →
+  -- sync_rank (ref-count) WITH an incoming-value guard; entity_aliases/entity_relations →
+  -- recency. Bounded by the per-scope hourly circuit breaker.
+  if tg_op = 'INSERT' and user_tier = 'free'
+     and tg_table_name in ('knowledge', 'entities', 'entity_aliases', 'entity_relations')
+     and cap_rows is not null and d_rows > 0 and cur_rows + d_rows > cap_rows then
+    select value into evb_cap from public.sync_config
+      where key = 'eviction_budget_per_hour';
+    evb_cap := coalesce(evb_cap, 200);
+    insert into public.sync_eviction_budget (scope_id) values (new.scope_id)
+      on conflict (scope_id) do nothing;
+    select window_start, evicted into evb_start, evb_count
+      from public.sync_eviction_budget
+     where scope_id = new.scope_id
+       for update;
+    if now() - evb_start > interval '1 hour' then
+      update public.sync_eviction_budget
+         set window_start = now(), evicted = 0
+       where scope_id = new.scope_id;
+      evb_count := 0;
+    end if;
+
+    if evb_count < evb_cap then
+      if tg_table_name = 'knowledge' then
+        -- COALESCE(base_confidence, 1.0): a meta-less knowledge row is treated as HIGH
+        -- value (protected). (1) matches knowledge_current's COALESCE(confidence, 1.0);
+        -- (2) meta-less is the NORMAL transient state during a push (knowledge pushes
+        -- before its meta), so 0.0 would evict a just-pushed fresh entry. Orphans are the
+        -- reaper's (#909) job.
+        select k.id into victim
+          from public.knowledge k
+          left join public.knowledge_meta m
+            on m.scope_id = k.scope_id and m.logical_id = k.id
+         where k.scope_id = new.scope_id and k.is_deleted = false
+         order by coalesce(m.base_confidence, 1.0) asc, k.updated_at asc, k.id asc
+         limit 1;
+        if victim is not null then
+          -- HARD delete + cascade (keeps knowledge/meta/crdt aligned; frees their slots).
+          delete from public.knowledge_meta_crdt
+           where scope_id = new.scope_id and logical_id = victim;
+          delete from public.knowledge_meta
+           where scope_id = new.scope_id and logical_id = victim;
+          delete from public.knowledge
+           where scope_id = new.scope_id and id = victim;
+        end if;
+      elsif tg_table_name = 'entities' then
+        -- Value = sync_rank (client-maintained ref-count). Incoming-value GUARD: only evict
+        -- when the incoming row strictly outranks the current floor. new.sync_rank is
+        -- self-contained on the incoming row, so the guard is exact even though the row's
+        -- refs aren't synced yet. A 0-ref newcomer that can't beat the floor PAUSES (never
+        -- displaces a well-referenced entity) until its rank rises.
+        select e.sync_rank into floor_rank
+          from public.entities e
+         where e.scope_id = new.scope_id and e.is_deleted = false
+         order by e.sync_rank asc, e.updated_at asc, e.id asc
+         limit 1;
+        if floor_rank is not null and new.sync_rank > floor_rank then
+          select e.id into victim
+            from public.entities e
+           where e.scope_id = new.scope_id and e.is_deleted = false
+           order by e.sync_rank asc, e.updated_at asc, e.id asc
+           limit 1;
+          if victim is not null then
+            -- entity_aliases / knowledge_entity_refs belong to the single evicted entity —
+            -- meaningless without it, so cascade unconditionally (frees their slots).
+            delete from public.entity_aliases
+             where scope_id = new.scope_id and entity_id = victim;
+            delete from public.knowledge_entity_refs
+             where scope_id = new.scope_id and entity_id = victim;
+            -- entity_relations connect TWO entities: delete a relation touching the victim
+            -- ONLY when its OTHER endpoint is also gone (not a live synced entity). A relation
+            -- to a surviving entity is that entity's edge — keep it (deleting it would be
+            -- permanent: the client marks it synced and never re-pushes). FIX 2 (#1191b).
+            delete from public.entity_relations r
+             where r.scope_id = new.scope_id
+               and (r.entity_a = victim or r.entity_b = victim)
+               and not exists (
+                 select 1 from public.entities e
+                  where e.scope_id = new.scope_id
+                    and e.is_deleted = false
+                    and e.id <> victim  -- victim is still live here; a self-relation's
+                                        -- "other endpoint" IS the victim → treat as gone
+                    and e.id = case when r.entity_a = victim
+                                    then r.entity_b else r.entity_a end);
+            delete from public.entities
+             where scope_id = new.scope_id and id = victim;
+          end if;
+        end if;
+      else
+        -- entity_aliases / entity_relations: evict the OLDEST (recency). Leaf tables → no
+        -- cascade. BEFORE INSERT ⇒ the incoming row isn't in the table yet, so it's never
+        -- its own victim and always survives (timing invariant, not a value one) — no guard.
+        execute format(
+          'select id from public.%I
+             where scope_id = $1 and is_deleted = false
+             order by updated_at asc, id asc
+             limit 1', tg_table_name)
+          into victim using new.scope_id;
+        if victim is not null then
+          execute format(
+            'delete from public.%I where scope_id = $1 and id = $2', tg_table_name)
+            using new.scope_id, victim;
+        end if;
+      end if;
+
+      if victim is not null then
+        update public.sync_eviction_budget
+           set evicted = evicted + 1
+         where scope_id = new.scope_id;
+        select row_count, byte_count into cur_rows, cur_bytes
+          from public.user_table_usage
+         where scope_id = new.scope_id and table_name = tg_table_name;
+        cur_rows  := coalesce(cur_rows, 0);
+        cur_bytes := coalesce(cur_bytes, 0);
+      end if;
+    end if;
+    -- breaker tripped, guard failed, or nothing to evict → fall through to the raise (pause).
+  end if;
+
+  if cap_rows is not null and d_rows > 0 and cur_rows + d_rows > cap_rows then
+    raise exception
+      'sync quota exceeded for % on tier %: % of % rows. Upgrade to sync more.',
+      tg_table_name, user_tier, cur_rows, cap_rows
+      using errcode = 'check_violation';
+  end if;
+  if cap_bytes is not null and d_bytes > 0 and cur_bytes + d_bytes > cap_bytes then
+    raise exception
+      'sync byte quota exceeded for % on tier %: % of % bytes. Upgrade to sync more.',
+      tg_table_name, user_tier, cur_bytes, cap_bytes
+      using errcode = 'check_violation';
+  end if;
+
+  return new;
+end;
+$$;


### PR DESCRIPTION
The client crypto that makes key **rotation function**, completing E-4c-3 (the schema landed in 3a, #1271). A rotation mints a fresh DEK, wraps it to the remaining members at a new epoch, seals new content at that epoch, and **still opens old-epoch blobs** (each blob's envelope pins its `key_epoch`).

## keystore (`crypto/keystore.ts`)
- **`dekCache` re-keyed by `(scope, epoch)`** — each rotation epoch has its own DEK.
- **`getScopeKey(scope, member, { mint?, epoch? })`** — `epoch` defaults to the scope's **current** (highest) epoch (what encrypt seals at); decrypt passes a blob's pinned epoch. Mints **only at epoch 0** (origination); a missing rotated epoch throws `ScopeKeyUnavailable` (only `rotateScopeKey` creates those).
- **`scopeKeyEpochs` / `currentScopeEpoch`** helpers drive the sync pre-resolve.
- **`rotateScopeKey(scope, newEpoch, members[{userId, pubKey}])`** — fresh `generateDek()`, wrap to each member (caller **must include self**) at `newEpoch`, INSERT (old epochs retained), cache the new DEK. `newEpoch` is server-atomically allocated by `rotate_scope_key(scope)` (0030).
- `putWrappedScopeKey` invalidates only **this** epoch's cache slot (so a pull-adopt of a canonical wrap after a lost mint race re-unwraps).

## sync.ts (epoch-aware — hot path stays SYNC)
- **`EncCtx` → `{ scope, currentEpoch, deks: Map<epoch, dek> }`**; `ctx()` pre-resolves **every** epoch's DEK once per cycle (few epochs; keystore-cached). This avoids propagating `await` through the pull loop.
- **encrypt** seals at `currentEpoch` (was hardcoded 0); fails **closed** (throws, never pushes plaintext) if the DEK is somehow absent.
- **decrypt** dispatches on the blob's `parseHeader().keyEpoch` → that epoch's DEK; a blob under an epoch we hold no wrap for **defers the table** (`EncryptedContentUnavailable`) — never stores ciphertext, never crashes the cycle.

## remote (migration 0031)
`enforce_row_quota`'s `scope_keys` probe now also matches `key_epoch` (reproduces 0028 **verbatim** + that one line — see the diff), so a rotation's new-epoch row is **counted** against the cap. Now reachable since 3b creates epoch>0 rows (deferred from 0030 as documented).

## Verification
- keystore rotation round-trip: fresh DEK ≠ old; **both** epochs readable; a remaining member unwraps the new epoch; `getScopeKey` with no epoch defaults to current.
- Tier-1: a rotation's new-epoch wrap trips the row cap (23514) under the 0031 probe.
- **Behavior-preserving at epoch 0**: core **2791** / 6 skipped; integration **156** (incl. the encrypted device-1→device-2 engine round-trip); `pnpm -r typecheck` **0**; Biome **0 errors**.

Adversarial + SECURITY review to follow. Next: **E-4c-4** (CLI) wires `rotate_scope_key` + `rotateScopeKey` into `lore team remove-member` (enumerating remaining members + their `identity_pub` keys) — the live caller.