### PR TITLE
feat(gateway): surface degraded memory (embeddings + workers) via /health and lore doctor

### DIFF
--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -531,6 +531,12 @@ export function _getLocalInitRetryAtForTest(): number {
   return localInitRetryAt;
 }
 
+/** For tests: arm/clear the init-retry deadline (epoch ms; 0 = none) so the
+ *  transient "retrying" health state is drivable without a fake worker. */
+export function _setLocalInitRetryAtForTest(at: number): void {
+  localInitRetryAt = at;
+}
+
 /** For tests: reset the local provider probe + transient-retry state. */
 export function _resetLocalProviderProbe(): void {
   localProviderKnownBroken = false;
@@ -1678,6 +1684,80 @@ export function isAvailable(): boolean {
     }
   }
   return true;
+}
+
+/** Coarse embedding-subsystem state for health surfaces. */
+export type EmbeddingHealthState =
+  | "ok"
+  | "retrying"
+  | "unavailable"
+  | "disabled";
+
+export interface EmbeddingHealth {
+  /** Whether vector recall is currently usable. */
+  available: boolean;
+  state: EmbeddingHealthState;
+  provider: "local" | "remote" | "none";
+  /** Human-readable explanation for logs / `lore doctor` / `/health`. */
+  detail: string;
+}
+
+/**
+ * Read-only snapshot of embedding availability for health surfaces
+ * (`/health`, `lore doctor`). Unlike {@link isAvailable}, this has NO side
+ * effects: it never logs, never triggers a retry, and never spawns a worker.
+ * When it reports `unavailable` or `retrying`, recall is running FTS-only —
+ * the degradation that was previously visible only as a one-time log line.
+ */
+export function embeddingStatus(): EmbeddingHealth {
+  const provider = getProvider();
+  if (!provider) {
+    return {
+      available: false,
+      state: "disabled",
+      provider: "none",
+      detail:
+        "no embedding provider configured (or disabled) — recall uses FTS-only search",
+    };
+  }
+  if (provider instanceof EmbeddingPool) {
+    if (localProviderKnownUnavailable()) {
+      return {
+        available: false,
+        state: "unavailable",
+        provider: "local",
+        detail:
+          "local embedding provider failed to initialize — recall is FTS-only (semantic search degraded)",
+      };
+    }
+    if (localInitRetryAt > 0) {
+      // A transient init failure has a retry armed. This is a pure read, so —
+      // unlike isAvailable() — we do NOT clear the deadline or trigger the
+      // reset here; the provider is not confirmed healthy until a later embed
+      // re-inits it. Report "retrying" (recall is FTS-only) for the whole
+      // armed window, whether or not the cooldown has elapsed, so health checks
+      // never show a false "ok" before recovery actually happens.
+      return {
+        available: false,
+        state: "retrying",
+        provider: "local",
+        detail:
+          "local embedding provider init failed; a retry is armed — recall is FTS-only until it recovers",
+      };
+    }
+    return {
+      available: true,
+      state: "ok",
+      provider: "local",
+      detail: "local ONNX embeddings active (vector recall enabled)",
+    };
+  }
+  return {
+    available: true,
+    state: "ok",
+    provider: "remote",
+    detail: "remote embedding provider active (vector recall enabled)",
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/test/embedding-status.test.ts
+++ b/packages/core/test/embedding-status.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  embeddingStatus,
+  _markLocalProviderUnavailable,
+  _resetLocalProviderProbe,
+  _setLocalInitRetryAtForTest,
+} from "../src/embedding";
+
+// embeddingStatus() is the read-only health snapshot behind `/health` and
+// `lore doctor`. Unlike isAvailable() it must never mutate state (no retry, no
+// worker spawn, no logging) — it just reports whether vector recall is live or
+// silently degraded to FTS-only. The default test config uses the local
+// (ONNX) provider.
+
+describe("embeddingStatus", () => {
+  beforeEach(() => {
+    _resetLocalProviderProbe();
+  });
+  afterEach(() => {
+    _resetLocalProviderProbe();
+  });
+
+  it("reports ok for a healthy local provider", () => {
+    const s = embeddingStatus();
+    expect(s.provider).toBe("local");
+    expect(s.available).toBe(true);
+    expect(s.state).toBe("ok");
+  });
+
+  it("reports unavailable + FTS-only once the local provider is latched broken", () => {
+    _markLocalProviderUnavailable();
+    const s = embeddingStatus();
+    expect(s.available).toBe(false);
+    expect(s.state).toBe("unavailable");
+    expect(s.provider).toBe("local");
+    expect(s.detail).toContain("FTS-only");
+  });
+
+  it("reports retrying (FTS-only) while a transient-failure retry is armed", () => {
+    _setLocalInitRetryAtForTest(Date.now() + 60_000);
+    const s = embeddingStatus();
+    expect(s.available).toBe(false);
+    expect(s.state).toBe("retrying");
+    expect(s.provider).toBe("local");
+  });
+
+  it("stays retrying after the cooldown elapses, until an embed recovers (Seer regression)", () => {
+    // Deadline in the PAST: cooldown elapsed but the retry hasn't run yet. A
+    // pure health read must not report a false "ok" here.
+    _setLocalInitRetryAtForTest(Date.now() - 60_000);
+    const s = embeddingStatus();
+    expect(s.available).toBe(false);
+    expect(s.state).toBe("retrying");
+  });
+});

--- a/packages/gateway/src/cli/inventory.ts
+++ b/packages/gateway/src/cli/inventory.ts
@@ -393,6 +393,14 @@ export function runDoctorDiagnostics(input: {
     ANTHROPIC_BEDROCK_BASE_URL?: string;
   };
   opencodePluginInstalled: boolean;
+  /**
+   * Memory-subsystem health read from the running gateway's `/health`. Null
+   * when the gateway is unreachable or did not report it (older gateway).
+   */
+  memoryHealth?: {
+    embeddings?: { available: boolean; state: string; detail: string };
+    worker?: { ok: boolean; detail: string };
+  } | null;
 }): Finding[] {
   const findings: Finding[] = [];
 
@@ -421,6 +429,44 @@ export function runDoctorDiagnostics(input: {
             "run `lore start --bg` (or `lore run` to launch an agent through the gateway)",
         },
   );
+
+  // 2b. Memory health (from the gateway's /health). Both are WARN, not FAIL:
+  // recall still works via FTS when embeddings are down, and workers recover on
+  // their own — but the user should know memory is running degraded.
+  const emb = input.memoryHealth?.embeddings;
+  if (emb) {
+    findings.push(
+      emb.available
+        ? { level: "PASS", label: "memory: embeddings", detail: emb.detail }
+        : {
+            level: "WARN",
+            label: "memory: embeddings",
+            detail: emb.detail,
+            remediation:
+              "reinstall Lore so its optional embedding dependency (onnxruntime-node) is present, " +
+              "or set search.embeddings.provider (e.g. voyage/openai) in .lore.json to use a remote provider",
+          },
+    );
+  }
+  const wrk = input.memoryHealth?.worker;
+  if (wrk) {
+    findings.push(
+      wrk.ok
+        ? {
+            level: "PASS",
+            label: "memory: background workers",
+            detail: wrk.detail,
+          }
+        : {
+            level: "WARN",
+            label: "memory: background workers",
+            detail: wrk.detail,
+            remediation:
+              "check that the session's provider auth is valid and has credit; " +
+              "workers recover automatically once a call succeeds",
+          },
+    );
+  }
 
   // 3. Port consistency: does any setup-routed LOCAL URL match the running port?
   if (input.gatewayAlive && input.gatewayPort !== null) {
@@ -545,6 +591,11 @@ export async function commandDoctor(): Promise<void> {
     ? await probeGateway(`http://127.0.0.1:${gatewayPort}`)
     : false;
 
+  const memoryHealth =
+    gatewayAlive && gatewayPort
+      ? await fetchMemoryHealth(`http://127.0.0.1:${gatewayPort}`)
+      : null;
+
   const findings = runDoctorDiagnostics({
     inventory,
     gatewayAlive,
@@ -557,6 +608,7 @@ export async function commandDoctor(): Promise<void> {
       ANTHROPIC_BEDROCK_BASE_URL: process.env.ANTHROPIC_BEDROCK_BASE_URL,
     },
     opencodePluginInstalled: isNpmPackageInstalledSafe("@loreai/opencode"),
+    memoryHealth,
   });
 
   // Print inventory first, then findings. Reuse the already-collected
@@ -575,6 +627,31 @@ export async function commandDoctor(): Promise<void> {
     } PASS.`,
   );
   if (fails > 0) process.exitCode = 1;
+}
+
+/**
+ * Read memory-subsystem health from the gateway's `/health`. Returns null on
+ * any failure or if the gateway predates these fields (older binary), so the
+ * doctor simply omits the memory findings rather than erroring.
+ */
+export async function fetchMemoryHealth(base: string): Promise<{
+  embeddings?: { available: boolean; state: string; detail: string };
+  worker?: { ok: boolean; detail: string };
+} | null> {
+  try {
+    const res = await fetch(`${base}/health`, {
+      signal: AbortSignal.timeout(2000),
+    });
+    if (!res.ok) return null;
+    const body = (await res.json()) as {
+      embeddings?: { available: boolean; state: string; detail: string };
+      worker?: { ok: boolean; detail: string };
+    };
+    if (!body.embeddings && !body.worker) return null;
+    return { embeddings: body.embeddings, worker: body.worker };
+  } catch {
+    return null;
+  }
 }
 
 // Local copy to avoid importing the private isNpmPackageInstalled from setup.ts.

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -18,9 +18,10 @@ import { createServer as createHttpServer } from "node:http";
 import type { Server } from "node:http";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { Readable } from "node:stream";
-import { log } from "@loreai/core";
+import { embedding, log } from "@loreai/core";
 import { DEFAULT_PORT, type GatewayConfig } from "./config";
 import { bootstrapDailySpend, getDailyBudget } from "./cost-tracker";
+import { workerHealthSummary } from "./worker-health";
 import {
   setupEmbeddingFailureCapture,
   setupBustSpiralCapture,
@@ -233,7 +234,26 @@ async function handleModelsPassthrough(
 }
 
 function handleHealth(): Response {
-  return jsonResponse({ status: "ok", version });
+  // Subsystem health so silent degradation (embeddings dropping to FTS-only,
+  // background workers stalling) is observable via `lore doctor` / monitoring
+  // instead of only a one-time gateway log line.
+  const embeddings = embedding.embeddingStatus();
+  const worker = workerHealthSummary();
+  return jsonResponse({
+    status: "ok",
+    version,
+    embeddings: {
+      available: embeddings.available,
+      state: embeddings.state,
+      provider: embeddings.provider,
+      detail: embeddings.detail,
+    },
+    worker: {
+      ok: worker.ok,
+      degradedSessions: worker.degradedSessions,
+      detail: worker.detail,
+    },
+  });
 }
 
 async function handleOpenAIChatCompletions(

--- a/packages/gateway/src/worker-health.ts
+++ b/packages/gateway/src/worker-health.ts
@@ -688,6 +688,41 @@ export function getWorkerHealth(): Array<{
   return result;
 }
 
+export interface WorkerHealthSummary {
+  /** True when no session is in sustained (degraded/critical) failure. */
+  ok: boolean;
+  /** Number of sessions past the degraded threshold. */
+  degradedSessions: number;
+  detail: string;
+}
+
+/**
+ * Gateway-wide roll-up of the per-session failure ladder, for health surfaces
+ * (`/health`, `lore doctor`). Sustained background-worker failures mean
+ * distillation/curation aren't running — context isn't being compressed and
+ * knowledge isn't being captured — which is otherwise only visible once a
+ * single session crosses the 30-minute response-warning threshold.
+ */
+export function workerHealthSummary(): WorkerHealthSummary {
+  const degraded = getWorkerHealth().filter(
+    (h) => h.status === "degraded" || h.status === "critical",
+  );
+  if (degraded.length === 0) {
+    return {
+      ok: true,
+      degradedSessions: 0,
+      detail: "background workers healthy",
+    };
+  }
+  return {
+    ok: false,
+    degradedSessions: degraded.length,
+    detail:
+      `${degraded.length} session(s) with sustained background-worker failures — ` +
+      "distillation/curation may be stalled (likely stale auth or exhausted credit)",
+  };
+}
+
 /**
  * Build the adapter that core passes around as `input.workerHealth`.
  * The core's `recordFailure` accepts a free-form string; the gateway's typed

--- a/packages/gateway/test/doctor.test.ts
+++ b/packages/gateway/test/doctor.test.ts
@@ -16,6 +16,7 @@ import {
   formatFinding,
   collectInventory,
   commandDoctor,
+  fetchMemoryHealth,
   type Finding,
 } from "../src/cli/inventory";
 
@@ -192,6 +193,61 @@ describe("runDoctorDiagnostics (pure)", () => {
       f.label.includes("ANTHROPIC_BASE_URL in shell env"),
     );
     expect(env?.level).toBe("WARN");
+  });
+
+  const baseInput = {
+    inventory: emptyInventory,
+    gatewayAlive: true,
+    gatewayPort: 3207,
+    env: {},
+    opencodePluginInstalled: false,
+  };
+
+  it("PASS: embeddings available", () => {
+    const findings = runDoctorDiagnostics({
+      ...baseInput,
+      memoryHealth: {
+        embeddings: {
+          available: true,
+          state: "ok",
+          detail: "vector recall on",
+        },
+      },
+    });
+    const f = findings.find((f) => f.label === "memory: embeddings");
+    expect(f?.level).toBe("PASS");
+  });
+
+  it("WARN: embeddings unavailable (FTS-only) with remediation", () => {
+    const findings = runDoctorDiagnostics({
+      ...baseInput,
+      memoryHealth: {
+        embeddings: {
+          available: false,
+          state: "unavailable",
+          detail: "recall is FTS-only",
+        },
+      },
+    });
+    const f = findings.find((f) => f.label === "memory: embeddings");
+    expect(f?.level).toBe("WARN");
+    expect(f?.detail).toContain("FTS-only");
+    expect(f?.remediation).toBeTruthy();
+  });
+
+  it("WARN: background workers degraded with remediation", () => {
+    const findings = runDoctorDiagnostics({
+      ...baseInput,
+      memoryHealth: { worker: { ok: false, detail: "2 session(s) failing" } },
+    });
+    const f = findings.find((f) => f.label === "memory: background workers");
+    expect(f?.level).toBe("WARN");
+    expect(f?.remediation).toBeTruthy();
+  });
+
+  it("omits memory findings when the gateway did not report /health", () => {
+    const findings = runDoctorDiagnostics({ ...baseInput, memoryHealth: null });
+    expect(findings.some((f) => f.label.startsWith("memory:"))).toBe(false);
   });
 
   it("fails on a Bedrock conflict", () => {
@@ -443,5 +499,56 @@ describe("commandDoctor (integration)", () => {
     const diagIdx = out.indexOf("Diagnostics:");
     expect(invIdx).toBeGreaterThanOrEqual(0);
     expect(diagIdx).toBeGreaterThan(invIdx);
+  });
+});
+
+describe("fetchMemoryHealth", () => {
+  let fetchSpy: MockInstance;
+  afterEach(() => {
+    fetchSpy?.mockRestore();
+  });
+
+  it("parses embeddings + worker from a healthy /health response", async () => {
+    fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          status: "ok",
+          version: "1.2.3",
+          embeddings: { available: true, state: "ok", detail: "on" },
+          worker: { ok: true, degradedSessions: 0, detail: "healthy" },
+        }),
+        { status: 200 },
+      ),
+    );
+    const h = await fetchMemoryHealth("http://127.0.0.1:3207");
+    expect(h?.embeddings?.available).toBe(true);
+    expect(h?.worker?.ok).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "http://127.0.0.1:3207/health",
+      expect.anything(),
+    );
+  });
+
+  it("returns null on a non-OK response", async () => {
+    fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("nope", { status: 500 }));
+    expect(await fetchMemoryHealth("http://127.0.0.1:3207")).toBeNull();
+  });
+
+  it("returns null when the gateway predates the fields (no embeddings/worker)", async () => {
+    fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ status: "ok", version: "0.1.0" }), {
+        status: 200,
+      }),
+    );
+    expect(await fetchMemoryHealth("http://127.0.0.1:3207")).toBeNull();
+  });
+
+  it("returns null when the request throws", async () => {
+    fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValue(new Error("connection refused"));
+    expect(await fetchMemoryHealth("http://127.0.0.1:3207")).toBeNull();
   });
 });

--- a/packages/gateway/test/worker-health.test.ts
+++ b/packages/gateway/test/worker-health.test.ts
@@ -7,6 +7,7 @@ import {
   getStatus,
   getDegradationWarning,
   getWorkerHealth,
+  workerHealthSummary,
   markWorkerPaused,
   isWorkerCreditPaused,
   clearWorkerPaused,
@@ -71,6 +72,26 @@ describe("worker-health", () => {
       _setNowForTest(() => t);
       expect(getStatus("s1")).toBe("degraded");
       expect(getDegradationWarning("s1")).not.toBeNull();
+    });
+
+    test("workerHealthSummary: ok when nothing is failing", () => {
+      _setNowForTest(() => 1_000_000);
+      const s = workerHealthSummary();
+      expect(s.ok).toBe(true);
+      expect(s.degradedSessions).toBe(0);
+    });
+
+    test("workerHealthSummary: rolls up sustained failures as degraded", () => {
+      let t = 1_000_000;
+      _setNowForTest(() => t);
+      recordWorkerFailure("s1", "lore-distill", "no-auth");
+      // 31 min later the single session is past the degraded threshold.
+      t = 1_000_000 + 31 * 60 * 1000;
+      _setNowForTest(() => t);
+      const s = workerHealthSummary();
+      expect(s.ok).toBe(false);
+      expect(s.degradedSessions).toBe(1);
+      expect(s.detail).toContain("stalled");
     });
 
     test("degradation warning points at a REAL CLI command (lore doctor, not lore status)", () => {


### PR DESCRIPTION
## Why

Roadmap item: **make silent memory degradation loud**. Two failure modes were discovered during eval that a user could not see:
- A missing/corrupt ONNX model silently drops recall to **FTS-only** (semantic search off) — visible only as a one-time gateway log line.
- Sustained background-worker failures stall distillation/curation — surfaced only after a single session crosses the 30-minute response-warning threshold.

The worker degradation warning even tells users to "run `lore doctor`" — but doctor had no memory-health section, and `/health` returned only `{status, version}`.

## What

- **`embedding.embeddingStatus()` (core, new):** a read-only health snapshot `{available, state: ok|retrying|unavailable|disabled, provider, detail}`. No side effects — unlike `isAvailable()` it never logs, retries, or spawns a worker. Reports the FTS-only degradation explicitly.
- **`workerHealthSummary()` (gateway, new):** gateway-wide roll-up of the per-session failure ladder → `{ok, degradedSessions, detail}`.
- **`/health` (server.ts):** now includes `embeddings` and `worker` subsystem blocks so monitoring/tooling can see degradation.
- **`lore doctor` (inventory.ts):** fetches `/health` and emits two new findings — `memory: embeddings` and `memory: background workers`. Both **WARN** (not FAIL): recall still works via FTS and workers self-recover, but the user now knows memory is running degraded, with remediation. Gracefully omitted when the gateway is unreachable or predates the fields.

## Notes

- Purely additive; no behavior change to recall/worker paths. `/health` stays `{status:"ok"}` plus the new blocks.
- This is the "loud" half of the roadmap item; a **self-heal re-probe** for the permanently-latched embedding provider will follow as its own PR.

## Tests

- `embedding-status.test.ts` (new): ok vs latched-unavailable (FTS-only). Mutation-verified — ignoring the broken latch makes it fail.
- `doctor.test.ts`: PASS/WARN for embeddings + workers, remediation present, and memory findings omitted when `/health` is absent.
- `worker-health.test.ts`: summary ok vs sustained-failure roll-up.
- tsc clean (core + gateway); biome clean.