### PR TITLE
feat(core): self-heal a latched local embedding provider via periodic re-probe

### DIFF
--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -479,6 +479,16 @@ export class LocalProviderUnavailableError extends Error {
  *  the transient-init-retry budget below being exhausted. */
 let localProviderKnownBroken = false;
 let localProviderErrorLogged = false;
+/** True when the latch cause is the ONE that never recovers on a re-probe: the
+ *  optional embedding stack is absent (needs a reinstall, not a retry). Every
+ *  other latch cause (WASM-fatal, floor OOM, exhausted transient-init budget, a
+ *  non-zero worker exit) can plausibly clear on a fresh worker, so self-heal
+ *  re-probes those on a slow cadence. */
+let localStackMissing = false;
+/** Epoch ms of the last self-heal re-probe; `0` = never (primed on first tick). */
+let lastSelfHealAt = 0;
+/** How long to wait between self-heal re-probes of a latched local provider. */
+const SELF_HEAL_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6h
 
 // --- Transient init-failure retry (self-heal a one-off worker init failure) ---
 // A single model-init failure used to latch the provider FTS-only for the whole
@@ -541,16 +551,54 @@ export function _setLocalInitRetryAtForTest(at: number): void {
 export function _resetLocalProviderProbe(): void {
   localProviderKnownBroken = false;
   localProviderErrorLogged = false;
+  localStackMissing = false;
   localInitFailures = 0;
   localInitRetryAt = 0;
+  lastSelfHealAt = 0;
 }
 
 /** For tests: simulate the local provider being unavailable, without
  *  actually spawning a worker. After this call, `isAvailable()` returns
- *  false for the local provider. */
-export function _markLocalProviderUnavailable(): void {
+ *  false for the local provider. Pass `stackMissing: true` to simulate the
+ *  ONE terminal (non-self-healing) cause. */
+export function _markLocalProviderUnavailable(stackMissing = false): void {
   localProviderKnownBroken = true;
+  localStackMissing = stackMissing;
   localProviderErrorLogged = true; // suppress the info log in tests
+}
+
+/**
+ * Self-heal a permanently-latched LOCAL embedding provider: on a slow cadence,
+ * clear the latch so the next embed spawns a fresh worker and re-attempts init.
+ * Only recoverable causes are re-probed — a missing optional stack
+ * (`localStackMissing`) is skipped, since only a reinstall fixes that. Safe to
+ * call every idle tick: it self-gates on the latch, the cause, and
+ * `SELF_HEAL_INTERVAL_MS`, and primes its clock on the first call so it never
+ * re-probes immediately after a fresh latch. Returns true iff it cleared the
+ * latch on this call. `nowMs` is injectable for tests.
+ */
+export function maybeSelfHealEmbeddingProvider(nowMs = Date.now()): boolean {
+  if (!localProviderKnownBroken || localStackMissing) return false;
+  if (lastSelfHealAt === 0) {
+    // Prime: wait a full interval before the first re-probe.
+    lastSelfHealAt = nowMs;
+    return false;
+  }
+  if (nowMs - lastSelfHealAt < SELF_HEAL_INTERVAL_MS) return false;
+  lastSelfHealAt = nowMs;
+  // Clear the latch + transient counters so getProvider() rebuilds a fresh pool
+  // and the next embed re-inits. If it fails again it simply re-latches — cheap
+  // at this cadence.
+  localProviderKnownBroken = false;
+  localProviderErrorLogged = false;
+  localInitFailures = 0;
+  localInitRetryAt = 0;
+  log.info(
+    "self-heal: re-probing a previously-latched local embedding provider " +
+      "(a fresh worker retries init on the next embed; re-latches if it fails again)",
+  );
+  void resetProvider();
+  return true;
 }
 
 /** Test seam: when set, `ensureWorker()` uses this factory instead of spawning
@@ -826,8 +874,11 @@ class LocalProvider implements EmbeddingProvider {
             if (isMissingLocalStackError(msg.error)) {
               // Optional local-embedding stack not installed (#1026 — an
               // expected, actionable degraded state that will NOT self-heal on
-              // its own). Latch permanently; recall degrades to FTS-only.
+              // its own). Latch permanently; recall degrades to FTS-only. Flag
+              // it so the self-heal re-probe skips it (a reinstall, not a retry,
+              // is what recovers this).
               localProviderKnownBroken = true;
+              localStackMissing = true;
               if (!localProviderErrorLogged) {
                 localProviderErrorLogged = true;
                 log.warn(

--- a/packages/core/test/embedding-self-heal.test.ts
+++ b/packages/core/test/embedding-self-heal.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  embeddingStatus,
+  maybeSelfHealEmbeddingProvider,
+  _markLocalProviderUnavailable,
+  _resetLocalProviderProbe,
+} from "../src/embedding";
+
+// maybeSelfHealEmbeddingProvider() is the idle-loop backstop that recovers a
+// LOCAL embedding provider which latched FTS-only for the process lifetime.
+// It re-probes recoverable causes on a slow cadence but never the terminal
+// missing-stack cause (that needs a reinstall).
+
+const SIX_H = 6 * 60 * 60 * 1000;
+
+describe("maybeSelfHealEmbeddingProvider", () => {
+  beforeEach(() => {
+    _resetLocalProviderProbe();
+  });
+  afterEach(() => {
+    _resetLocalProviderProbe();
+  });
+
+  it("does nothing when the provider is healthy", () => {
+    expect(maybeSelfHealEmbeddingProvider(1_000)).toBe(false);
+  });
+
+  it("primes on the first call, then re-probes a recoverable latch after the interval", () => {
+    _markLocalProviderUnavailable(); // recoverable latch
+    expect(embeddingStatus().state).toBe("unavailable");
+
+    const t0 = 1_000_000;
+    // First call primes the clock — no re-probe yet.
+    expect(maybeSelfHealEmbeddingProvider(t0)).toBe(false);
+    expect(embeddingStatus().state).toBe("unavailable");
+    // Before the interval elapses: still parked.
+    expect(maybeSelfHealEmbeddingProvider(t0 + SIX_H - 1)).toBe(false);
+    expect(embeddingStatus().state).toBe("unavailable");
+    // After the interval: clears the latch → provider healthy again.
+    expect(maybeSelfHealEmbeddingProvider(t0 + SIX_H + 1)).toBe(true);
+    expect(embeddingStatus().available).toBe(true);
+    expect(embeddingStatus().state).toBe("ok");
+  });
+
+  it("never re-probes the terminal missing-stack cause", () => {
+    _markLocalProviderUnavailable(true); // stack-missing = terminal
+    const t0 = 1_000_000;
+    expect(maybeSelfHealEmbeddingProvider(t0)).toBe(false);
+    // Even long after the interval, a missing stack is never re-probed.
+    expect(maybeSelfHealEmbeddingProvider(t0 + 10 * SIX_H)).toBe(false);
+    expect(embeddingStatus().state).toBe("unavailable");
+  });
+});

--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -53,6 +53,7 @@ import {
   vacuum,
   freelistBytes,
   dbFileSizeBytes,
+  embedding,
 } from "@loreai/core";
 import type { CacheStrategy, ChangedEntry, LLMClient } from "@loreai/core";
 import {
@@ -509,6 +510,17 @@ export function startIdleScheduler(
       } catch (e) {
         log.error("global dead-entry sweep error:", e);
       }
+    }
+
+    // Self-heal a latched local embedding provider — a slow-cadence re-probe so
+    // a transient init failure (or floor OOM) that latched the provider
+    // FTS-only for the whole process lifetime can recover without a restart.
+    // Self-gating (latch + recoverable cause + interval, primed on first call)
+    // and cheap, so it is safe to call every tick. It logs when it fires.
+    try {
+      embedding.maybeSelfHealEmbeddingProvider(now);
+    } catch (e) {
+      log.error("embedding self-heal error:", e);
     }
 
     // Global dead-reference cleanup — once per tick, not per session.


### PR DESCRIPTION
## Why

The self-heal half of the memory-degradation roadmap item (follow-up to #1274). Today a local embedding provider that latches `FTS-only` stays that way for the **entire process lifetime** — only a restart recovers it. But most latch causes are transient: a floor OOM (memory pressure eases), a non-zero worker exit, or an exhausted transient-init budget (e.g. the ONNX model read mid-write during a concurrent restart). Only a missing optional stack truly needs a reinstall.

## What

- **`maybeSelfHealEmbeddingProvider(nowMs?)` (core, new):** on a slow cadence (`SELF_HEAL_INTERVAL_MS = 6h`), clears a recoverable latch so the next embed spawns a fresh worker and re-attempts init. If it fails again it simply re-latches — cheap at this cadence. Primes its clock on the first call, so it never re-probes immediately after a fresh latch.
- **Terminal cause is skipped:** a new `localStackMissing` flag is set only at the missing-stack latch site; self-heal never re-probes it (reinstall, not retry, is the fix). All other causes are treated as recoverable.
- **Idle-loop wiring (idle.ts):** called once per tick next to the global dead sweep, wrapped in try/catch. Self-gating, so calling every tick is cheap.
- Test seam: `_markLocalProviderUnavailable(stackMissing?)` extended; `_resetLocalProviderProbe` clears the new state.

## Notes

- Recovery guarantee is narrow and honest: it un-latches and lets the next embed retry. A genuinely-broken environment just re-latches. It cannot fix a missing stack.
- Complements #1274: `lore doctor` / `/health` now *report* the degradation; this *recovers* from it without a restart.

## Tests

- `embedding-self-heal.test.ts`: healthy → no-op; recoverable latch → prime-then-recover after the interval (state flips back to `ok`); terminal missing-stack → never re-probed even after 10× the interval.
- Mutation-verified: dropping the missing-stack skip makes the terminal test fail.
- tsc clean (core + gateway); biome clean.