### PR TITLE
feat(core): high-salience 'Established facts' block in system[2] for reliable application on weaker models

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -305,6 +305,19 @@ export const LoreConfig = z.object({
         .describe(
           "Fold relevance-ranked distillation/temporal memory into the context-bound injection so facts are passively present (no recall tool needed). Empty = off. Default: [].",
         ),
+      /** Render short, concrete captured values (order status, region, hex,
+       *  dimensions) in a distinct, high-salience "Established facts" section at
+       *  the top of the context-bound (system[2]) block with an imperative
+       *  "use exactly" directive, so weaker models reliably APPLY surfaced
+       *  values instead of skimming past them. Pure reorganization of entries
+       *  already selected for system[2] — cache-stable, no new data. Default
+       *  true; kill-switch. */
+      establishedFacts: z
+        .boolean()
+        .default(true)
+        .describe(
+          "Surface short concrete captured values in a high-salience 'Established facts' section atop the context-bound injection so weaker models apply them verbatim. Cache-stable reorganization of already-selected entries. Default: true.",
+        ),
     })
     .default({
       enabled: true,
@@ -313,6 +326,7 @@ export const LoreConfig = z.object({
       outcomeReward: true,
       referenceValidation: true,
       contextSources: [],
+      establishedFacts: true,
     })
     .describe("Long-term knowledge (curator, entity injection) controls."),
   curator: z

--- a/packages/core/src/prompt.ts
+++ b/packages/core/src/prompt.ts
@@ -1,5 +1,5 @@
 import type { Root } from "mdast";
-import { serialize, inline, h, ul, liph, strong, t, root } from "./markdown";
+import { serialize, inline, h, p, ul, liph, strong, t, root } from "./markdown";
 
 // All prompts are locked down — they are our core value offering.
 // Do not make these configurable.
@@ -892,6 +892,38 @@ function estimateTokens(text: string): number {
   return Math.ceil(text.length / 3);
 }
 
+/** Max content length for an entry to be eligible for the high-salience
+ *  "Established facts" section — atomic captured values are short; long-form
+ *  decisions/architecture stay in the main list. */
+export const ESTABLISHED_FACT_MAX_CHARS = 160;
+
+/** A concrete-value signal: a digit, a hex color, a quoted literal, or a
+ *  `key: value` / `key = value` connector. Distinguishes an atomic captured
+ *  value ("region is eu-west-1", "primary color #3a7bd5", "status: shipped")
+ *  from vague prose ("prefer explicit over implicit"). Kept deliberately simple
+ *  and side-effect-free so it is trivially testable and byte-deterministic. */
+const CONCRETE_VALUE_SIGNAL = /[0-9]|["'`][^"'`]+["'`]|[:=]\s*\S/;
+
+/**
+ * True when an entry looks like a short, concrete captured fact worth elevating
+ * into the high-salience "Established facts" section so a weaker model applies
+ * the exact value instead of skimming past it. `"recalled"` entries (passive
+ * distillation/temporal snippets, #1228) are long-form context, not atomic
+ * facts, so they always stay in the main list.
+ */
+export function isEstablishedFact(entry: {
+  category: string;
+  title: string;
+  content: string;
+}): boolean {
+  if (entry.category === "recalled") return false;
+  if (entry.content.length > ESTABLISHED_FACT_MAX_CHARS) return false;
+  return (
+    CONCRETE_VALUE_SIGNAL.test(entry.content) ||
+    CONCRETE_VALUE_SIGNAL.test(entry.title)
+  );
+}
+
 export function formatKnowledge(
   entries: Array<{
     id?: string;
@@ -908,6 +940,16 @@ export function formatKnowledge(
    * busts the cache while a genuine selection change always re-pins.
    */
   outIncludedIds?: string[],
+  /**
+   * system[2]-only options. `establishedFacts` splits the SAME budget-packed
+   * `included` set into a leading "Established facts" section (short concrete
+   * values, rendered with an imperative "use exactly" directive) and the normal
+   * "Long-term Knowledge" list. It is a pure, deterministic reorganization of
+   * entries already selected — `outIncludedIds` (the pin key set) is unchanged,
+   * ordering stays byte-stable, and a fact-less set renders byte-identically to
+   * `establishedFacts` off. Default off, so the other callers are untouched.
+   */
+  opts?: { establishedFacts?: boolean },
 ): string {
   if (!entries.length) return "";
 
@@ -932,24 +974,52 @@ export function formatKnowledge(
     if (!included.length) return "";
   }
 
-  const grouped: Record<
-    string,
-    Array<{ title: string; content: string; id?: string }>
-  > = {};
-
+  // The pin key set covers EVERY rendered entry regardless of which section it
+  // lands in, so populate it from the full `included` set before partitioning.
   if (outIncludedIds) {
     for (const e of included) {
       if (e.id !== undefined) outIncludedIds.push(e.id);
     }
   }
 
-  for (const e of included) {
-    let group = grouped[e.category];
-    if (!group) {
-      group = [];
-      grouped[e.category] = group;
-    }
-    group.push(e);
+  // Deterministic tiebreak used everywhere below: title, then content. Keeps the
+  // rendered order a pure function of the selected set (byte-stable → no churn).
+  const byTitleThenContent = (
+    a: { title: string; content: string },
+    b: { title: string; content: string },
+  ): number => {
+    if (a.title !== b.title) return a.title < b.title ? -1 : 1;
+    return a.content < b.content ? -1 : a.content > b.content ? 1 : 0;
+  };
+
+  const renderEntry = (i: { id?: string; title: string; content: string }) => {
+    const titleText = i.id
+      ? `${inline(`[${shortId(i.id)}] `)}${inline(i.title)}`
+      : inline(i.title);
+    return liph(strong(titleText), t(`: ${inline(i.content)}`));
+  };
+
+  // system[2] only: elevate short, concrete captured values into a leading
+  // high-salience section so weaker models apply them verbatim. A pure split of
+  // the already-selected set — a fact-less set leaves `ltkEntries === included`,
+  // rendering byte-identically to the flag being off.
+  const emitFacts = opts?.establishedFacts === true;
+  const facts = emitFacts ? included.filter(isEstablishedFact) : [];
+  const factSet = new Set(facts);
+  const ltkEntries = emitFacts
+    ? included.filter((e) => !factSet.has(e))
+    : included;
+
+  const children: Root["children"] = [];
+
+  if (facts.length) {
+    children.push(h(2, "Established facts"));
+    children.push(
+      p(
+        "Values captured earlier in this project. Use them exactly — do not guess, approximate, or override them with assumptions.",
+      ),
+    );
+    children.push(ul([...facts].sort(byTitleThenContent).map(renderEntry)));
   }
 
   // Canonical layout: relevance ranking decides *selection* (which entries fit
@@ -957,27 +1027,26 @@ export function formatKnowledge(
   // entries alphabetically by title within each category. This makes the output
   // byte-stable for a stable selected set, so re-ranking the same entries does
   // not churn system[2] text and bust the prompt cache.
-  const children: Root["children"] = [h(2, "Long-term Knowledge")];
-  const categories = Object.keys(grouped).sort();
-  for (const category of categories) {
-    const items = grouped[category];
-    // Sort by title, then content as a deterministic tiebreak so two entries
-    // with identical titles don't render in input-dependent (churning) order.
-    items.sort((a, b) => {
-      if (a.title !== b.title) return a.title < b.title ? -1 : 1;
-      return a.content < b.content ? -1 : a.content > b.content ? 1 : 0;
-    });
-    children.push(h(3, category.charAt(0).toUpperCase() + category.slice(1)));
-    children.push(
-      ul(
-        items.map((i) => {
-          const titleText = i.id
-            ? `${inline(`[${shortId(i.id)}] `)}${inline(i.title)}`
-            : inline(i.title);
-          return liph(strong(titleText), t(`: ${inline(i.content)}`));
-        }),
-      ),
-    );
+  if (ltkEntries.length) {
+    const grouped: Record<
+      string,
+      Array<{ title: string; content: string; id?: string }>
+    > = {};
+    for (const e of ltkEntries) {
+      let group = grouped[e.category];
+      if (!group) {
+        group = [];
+        grouped[e.category] = group;
+      }
+      group.push(e);
+    }
+    children.push(h(2, "Long-term Knowledge"));
+    for (const category of Object.keys(grouped).sort()) {
+      const items = grouped[category];
+      items.sort(byTitleThenContent);
+      children.push(h(3, category.charAt(0).toUpperCase() + category.slice(1)));
+      children.push(ul(items.map(renderEntry)));
+    }
   }
 
   return serialize(root(...children));

--- a/packages/core/test/markdown.test.ts
+++ b/packages/core/test/markdown.test.ts
@@ -9,7 +9,12 @@ import {
   inline,
   renderMarkdown,
 } from "../src/markdown";
-import { formatDistillations, formatKnowledge } from "../src/prompt";
+import {
+  formatDistillations,
+  formatKnowledge,
+  isEstablishedFact,
+  ESTABLISHED_FACT_MAX_CHARS,
+} from "../src/prompt";
 
 const proc = remark();
 
@@ -372,6 +377,149 @@ describe("formatKnowledge", () => {
     );
     expect(included).toContain("s");
     expect(included).not.toContain("h");
+  });
+});
+
+describe("isEstablishedFact", () => {
+  const fact = (
+    over: Partial<{ category: string; title: string; content: string }>,
+  ) => ({
+    category: "decision",
+    title: "t",
+    content: "x",
+    ...over,
+  });
+
+  test("short entries with a concrete value signal are facts", () => {
+    expect(
+      isEstablishedFact(fact({ content: "the region is eu-west-1" })),
+    ).toBe(true); // digit
+    expect(isEstablishedFact(fact({ content: "primary color #3a7bd5" }))).toBe(
+      true,
+    ); // hex/quote via digit
+    expect(isEstablishedFact(fact({ content: "order status: shipped" }))).toBe(
+      true,
+    ); // connector
+    expect(isEstablishedFact(fact({ content: 'name = "acme"' }))).toBe(true); // connector + quote
+  });
+
+  test("vague prose with no concrete value is NOT a fact", () => {
+    expect(
+      isEstablishedFact(fact({ content: "prefer explicit over implicit" })),
+    ).toBe(false);
+  });
+
+  test("long-form entries are never facts, even with a value", () => {
+    expect(
+      isEstablishedFact(
+        fact({
+          content: `region eu-west-1. ${"x".repeat(ESTABLISHED_FACT_MAX_CHARS)}`,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  test("recalled (passive context) entries are never facts", () => {
+    expect(
+      isEstablishedFact(fact({ category: "recalled", content: "value = 42" })),
+    ).toBe(false);
+  });
+});
+
+describe("formatKnowledge — established facts section", () => {
+  const mixed = [
+    {
+      id: "f1",
+      category: "decision",
+      title: "Region",
+      content: "region is eu-west-1",
+    },
+    {
+      id: "f2",
+      category: "gotcha",
+      title: "Color",
+      content: "brand color #3a7bd5",
+    },
+    {
+      id: "k1",
+      category: "architecture",
+      title: "Overview",
+      content:
+        "The system uses a layered pipeline with distinct stages for parsing and planning.",
+    },
+  ];
+
+  test("off (default): no facts section, byte-identical to omitting the flag", () => {
+    const off = formatKnowledge(mixed, undefined, undefined);
+    expect(off).not.toContain("Established facts");
+    expect(
+      formatKnowledge(mixed, undefined, undefined, { establishedFacts: false }),
+    ).toBe(off);
+  });
+
+  test("on: concrete values render under a leading 'Established facts' section with an imperative directive", () => {
+    const out = formatKnowledge(mixed, undefined, undefined, {
+      establishedFacts: true,
+    });
+    expect(out).toContain("## Established facts");
+    expect(out).toContain("Use them exactly");
+    // Facts section comes before the main knowledge list.
+    expect(out.indexOf("Established facts")).toBeLessThan(
+      out.indexOf("Long-term Knowledge"),
+    );
+    // The two short values are elevated; the long-form entry stays in LTK.
+    expect(out.indexOf("Region")).toBeLessThan(
+      out.indexOf("## Long-term Knowledge"),
+    );
+    expect(out.indexOf("Overview")).toBeGreaterThan(
+      out.indexOf("## Long-term Knowledge"),
+    );
+  });
+
+  test("on: a fact-less set is byte-identical to the flag off (safe fallback)", () => {
+    const proseOnly = [
+      { id: "a", category: "pattern", title: "A", content: "prefer clarity" },
+      { id: "b", category: "decision", title: "B", content: "keep it simple" },
+    ];
+    expect(
+      formatKnowledge(proseOnly, undefined, undefined, {
+        establishedFacts: true,
+      }),
+    ).toBe(formatKnowledge(proseOnly, undefined, undefined));
+  });
+
+  test("on: output is byte-stable regardless of input order", () => {
+    const out = formatKnowledge(mixed, undefined, undefined, {
+      establishedFacts: true,
+    });
+    expect(
+      formatKnowledge([...mixed].reverse(), undefined, undefined, {
+        establishedFacts: true,
+      }),
+    ).toBe(out);
+  });
+
+  test("on: outIncludedIds still covers every rendered entry (facts + rest) for the pin key set", () => {
+    const ids: string[] = [];
+    formatKnowledge(mixed, undefined, ids, { establishedFacts: true });
+    expect(ids.sort()).toEqual(["f1", "f2", "k1"]);
+  });
+
+  test("on: an all-facts set renders no 'Long-term Knowledge' section", () => {
+    const allFacts = [
+      {
+        id: "f1",
+        category: "decision",
+        title: "Region",
+        content: "region is eu-west-1",
+      },
+      { id: "f2", category: "gotcha", title: "Port", content: "port = 3207" },
+    ];
+    const out = formatKnowledge(allFacts, undefined, undefined, {
+      establishedFacts: true,
+    });
+    expect(out).toContain("## Established facts");
+    expect(out).not.toContain("## Long-term Knowledge");
   });
 });
 

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -7003,6 +7003,7 @@ async function handleConversationTurn(
               })),
               contextBudget,
               renderedIds,
+              { establishedFacts: cfg.knowledge.establishedFacts },
             );
             if (formatted) {
               const tokenCount = Math.ceil(formatted.length / 3);
@@ -7265,6 +7266,7 @@ async function handleConversationTurn(
           })),
           contextBudget,
           renderedIds,
+          { establishedFacts: cfg.knowledge.establishedFacts },
         );
 
         if (formatted) {

--- a/packages/website/src/content/docs/docs/configuration.md
+++ b/packages/website/src/content/docs/docs/configuration.md
@@ -122,6 +122,7 @@ Long-term knowledge (curator, entity injection) controls.
 | `outcomeReward` | boolean | `true` |  | Adjust knowledge confidence by within-session verifier (test/build/typecheck/lint) outcomes. Default: true. |
 | `referenceValidation` | boolean | `true` |  | Lower confidence on entries whose file:line / command references no longer resolve against the repo. Unverifiable refs never penalize. Default: true. |
 | `contextSources` | array<enum> | `[]` |  | Fold relevance-ranked distillation/temporal memory into the context-bound injection so facts are passively present (no recall tool needed). Empty = off. Default: []. |
+| `establishedFacts` | boolean | `true` |  | Surface short concrete captured values in a high-salience 'Established facts' section atop the context-bound injection so weaker models apply them verbatim. Cache-stable reorganization of already-selected entries. Default: true. |
 
 
 ## `curator`


### PR DESCRIPTION
## Why

Roadmap item #1. The eval showed that on a cheaper model (MiniMax-M3), Lore *captures and surfaces* code-invisible values (order status, region, hex, dimensions) but the model doesn't always **apply** them — ~85%, one seed 1/4. Capture and passive injection already work; the missing lever is **salience**: a weaker model skims past a value buried in a ranked knowledge list.

## What

A distinct, high-salience **"Established facts"** section at the top of the context-bound `system[2]` block, with an imperative directive ("Use them exactly — do not guess, approximate, or override"). It's a **pure reorganization of the entries already selected for system[2]** — no new data, no new cache key, no new system block.

- **`formatKnowledge` (prompt.ts):** new opt-in `opts.establishedFacts`. When on, the budget-packed `included` set is split into short concrete facts (leading section) and the rest (normal "Long-term Knowledge"). Default off, so the other three callers (delta, doctor snapshot, system[1] preferences) are byte-unchanged.
- **`isEstablishedFact` heuristic:** short (`≤160` chars) + a concrete-value signal (a digit, a quoted literal, or a `key: value`/`key = value` connector). Deliberately simple/deterministic. `recalled` passive-context snippets are never elevated.
- **Config:** `knowledge.establishedFacts` (default **true**, kill-switch). Threaded to the two system[2] `formatKnowledge` renders only.

## Cache-stability (the load-bearing part)

- Rendered inside the single shared `formatKnowledge` chokepoint used by both live system[2] paths, so `ltmCacheText` can never diverge from `ltmPinText`.
- `outIncludedIds` (the pin key set) is populated from the full `included` set **before** partitioning — unchanged. `ltmEntryKeys`, the pin/delta decision, and `detectSurfacedMutations` are untouched.
- Ordering is a pure function of the selected set (title, then content) → byte-stable across re-ranking.
- **A fact-less set renders byte-identically to the flag being off** (safe fallback).
- Verified: `ltm-pin`, `cache-stability.e2e`, and `ltm-context-sources` all green with the flag default-on (36 tests).

## Tests

- `isEstablishedFact`: value-bearing vs prose vs long vs recalled.
- `formatKnowledge` established-facts: off byte-identical to omitting the flag; concrete values elevated above LTK with the directive; fact-less set == off; byte-stable regardless of input order; `outIncludedIds` still covers all entries; all-facts set emits no LTK section.
- Mutation-verified (neutering the heuristic fails the elevation tests). tsc + biome clean.

Next: I'll measure the actual application-rate lift in the final cost eval.