### PR TITLE
chore(lint): enforce no-unnecessary-type-assertion (−169 redundant casts)

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -19,7 +19,7 @@
     "typescript/await-thenable": "error",
     "typescript/no-for-in-array": "error",
     "typescript/no-misused-spread": "error",
-    "typescript/no-unnecessary-type-assertion": "warn",
+    "typescript/no-unnecessary-type-assertion": "error",
     "typescript/no-base-to-string": "warn",
     "typescript/unbound-method": "warn",
     "typescript/restrict-template-expressions": "warn",

--- a/packages/core/src/curator.ts
+++ b/packages/core/src/curator.ts
@@ -218,7 +218,7 @@ function filterRelations(arr: unknown[]): DetectedRelation[] {
         !Array.isArray(obj.metadata)
       ) {
         const filtered = Object.fromEntries(
-          Object.entries(obj.metadata as Record<string, unknown>).filter(
+          Object.entries(obj.metadata).filter(
             ([, v]) => typeof v === "string" && v.length > 0 && v.length <= 500,
           ),
         );

--- a/packages/core/src/db/traced.ts
+++ b/packages/core/src/db/traced.ts
@@ -64,7 +64,7 @@ type QueryableDatabase = { query(sql: string): unknown };
  * Intercepts only `query()`; all other members pass through bound to `db`.
  */
 export function tracedDatabase<T extends QueryableDatabase>(db: T): T {
-  const originalQuery = db.query.bind(db) as (sql: string) => unknown;
+  const originalQuery = db.query.bind(db);
   return new Proxy(db, {
     get(target, prop) {
       if (prop === "query") {
@@ -74,5 +74,5 @@ export function tracedDatabase<T extends QueryableDatabase>(db: T): T {
       const value = Reflect.get(target, prop);
       return typeof value === "function" ? value.bind(target) : value;
     },
-  }) as T;
+  });
 }

--- a/packages/core/src/db/vec-store.ts
+++ b/packages/core/src/db/vec-store.ts
@@ -101,7 +101,7 @@ export const VEC_TABLES = Object.freeze([
   "entity_vec",
   "distillation_vec",
   "temporal_vec",
-]) as readonly string[];
+]);
 
 /** Minimal connection shape for reading the stored storage mode. */
 export interface StorageModeConn {

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -2008,10 +2008,10 @@ export async function vectorSearch(
   limit = 10,
   excludeCategories?: string[],
 ): Promise<VectorHit[]> {
-  return (await poolOrInProcess(
+  return await poolOrInProcess(
     { kind: "knowledge", limit, excludeCategories },
     queryEmbedding,
-  )) as VectorHit[];
+  );
 }
 
 /**
@@ -2022,10 +2022,7 @@ export async function vectorSearchEntities(
   queryEmbedding: Float32Array,
   limit = 10,
 ): Promise<VectorHit[]> {
-  return (await poolOrInProcess(
-    { kind: "entities", limit },
-    queryEmbedding,
-  )) as VectorHit[];
+  return await poolOrInProcess({ kind: "entities", limit }, queryEmbedding);
 }
 
 // ---------------------------------------------------------------------------
@@ -2040,10 +2037,10 @@ export async function vectorSearchDistillations(
   queryEmbedding: Float32Array,
   limit = 10,
 ): Promise<VectorHit[]> {
-  return (await poolOrInProcess(
+  return await poolOrInProcess(
     { kind: "distillations", limit },
     queryEmbedding,
-  )) as VectorHit[];
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -2330,10 +2327,10 @@ export async function vectorSearchTemporal(
   limit = 10,
   sessionId?: string,
 ): Promise<VectorHit[]> {
-  return (await poolOrInProcess(
+  return await poolOrInProcess(
     { kind: "temporal", projectId, limit, sessionId },
     queryEmbedding,
-  )) as VectorHit[];
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/entities.ts
+++ b/packages/core/src/entities.ts
@@ -412,10 +412,7 @@ export function ensureSelfEntity(
     }
     // Merge config metadata into existing
     if (cfg?.metadata && Object.keys(cfg.metadata).length > 0) {
-      const merged = mergeMetadata(
-        existing.metadata,
-        cfg.metadata as Record<string, unknown>,
-      );
+      const merged = mergeMetadata(existing.metadata, cfg.metadata);
       if (merged) updates.metadata = merged;
     }
     let changed = Object.keys(updates).length > 0;
@@ -427,8 +424,7 @@ export function ensureSelfEntity(
     // Add config aliases
     if (cfg?.aliases) {
       for (const a of cfg.aliases) {
-        if (addAlias(existing.id, a.type as AliasType, a.value, "config"))
-          changed = true;
+        if (addAlias(existing.id, a.type, a.value, "config")) changed = true;
       }
     }
     // Only re-embed when the name or alias set actually changed.
@@ -443,7 +439,7 @@ export function ensureSelfEntity(
   if (cfg?.aliases) {
     for (const a of cfg.aliases) {
       aliases.push({
-        type: a.type as AliasType,
+        type: a.type,
         value: a.value,
         source: "config",
       });
@@ -456,7 +452,7 @@ export function ensureSelfEntity(
     entityType: "self",
     canonicalName: name,
     aliases,
-    metadata: cfg?.metadata as Record<string, unknown> | undefined,
+    metadata: cfg?.metadata,
     crossProject: true,
   });
 

--- a/packages/core/src/fetch-interceptor.ts
+++ b/packages/core/src/fetch-interceptor.ts
@@ -126,7 +126,7 @@ function extractBodyString(
   }
   if (ArrayBuffer.isView(body)) {
     try {
-      return new TextDecoder().decode(body as ArrayBufferView);
+      return new TextDecoder().decode(body);
     } catch {
       return undefined;
     }

--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -1847,7 +1847,7 @@ function cleanParts(parts: LorePart[]): LorePart[] {
     if (!isTextPart(part)) return part;
     const text = stripSystemReminders(part.text);
     if (text === part.text) return part;
-    return { ...part, text } as LorePart;
+    return { ...part, text };
   });
   // Filter out text parts that became empty after stripping
   const filtered = cleaned.filter(
@@ -1860,7 +1860,7 @@ function cleanParts(parts: LorePart[]): LorePart[] {
   if (filtered.length === 0 && parts.length > 0) {
     const first = parts[0];
     if (isTextPart(first)) {
-      return [{ ...first, text: "..." } as LorePart];
+      return [{ ...first, text: "..." }];
     }
   }
   return filtered.length > 0 ? filtered : parts;
@@ -2179,7 +2179,7 @@ export function deduplicateToolOutputs(
           output: dedupAnnotation(part.tool, readRange?.path, readRange),
           blocks: undefined,
         },
-      } as LorePart;
+      };
     });
 
     if (!partsChanged) return msg;
@@ -2228,7 +2228,7 @@ function sanitizeToolParts(messages: MessageWithParts[]): MessageWithParts[] {
             end: existingStart,
           },
         },
-      } as LorePart;
+      };
     });
 
     if (!partsChanged) return msg;
@@ -2251,7 +2251,7 @@ function stripToolOutputs(parts: LorePart[]): LorePart[] {
           output: toolStripAnnotation(part.tool, part.state.output),
           blocks: undefined,
         },
-      } as LorePart;
+      };
     }
     // Error outputs (e.g. large stack traces) must also be stripped under
     // aggressive (Layer 2) compression — otherwise failure-heavy turns evade
@@ -2264,7 +2264,7 @@ function stripToolOutputs(parts: LorePart[]): LorePart[] {
           error: toolStripAnnotation(part.tool, part.state.error),
           blocks: undefined,
         },
-      } as LorePart;
+      };
     }
     return part;
   });
@@ -2282,7 +2282,7 @@ function _stripToTextOnly(parts: LorePart[]): LorePart[] {
   // toModelMessages and the conversation doesn't end with an assistant message.
   if (stripped.length === 0 && parts.length > 0) {
     const first = parts.find(isTextPart);
-    if (first) return [{ ...first, text: "..." } as LorePart];
+    if (first) return [{ ...first, text: "..." }];
   }
   return stripped;
 }

--- a/packages/core/src/import/providers/claude-code.ts
+++ b/packages/core/src/import/providers/claude-code.ts
@@ -138,9 +138,7 @@ function lineToText(parsed: ClaudeCodeLine): string | null {
       return `[user] ${content}`;
     }
     // Array content — extract text blocks, tool_result blocks
-    const parts = (content as ContentBlock[])
-      .map(blockToText)
-      .filter(Boolean) as string[];
+    const parts = content.map(blockToText).filter(Boolean) as string[];
     return parts.length > 0 ? `[user] ${parts.join("\n")}` : null;
   }
 
@@ -303,7 +301,7 @@ const claudeCodeProvider: AgentHistoryProvider = {
 
         const ts =
           "timestamp" in line && line.timestamp
-            ? new Date(line.timestamp as string).getTime()
+            ? new Date(line.timestamp).getTime()
             : Date.now();
 
         messages.push({ text, timestamp: ts });

--- a/packages/core/src/import/providers/cline.ts
+++ b/packages/core/src/import/providers/cline.ts
@@ -238,9 +238,7 @@ function messageToText(msg: ClineMessage): string | null {
     return msg.content ? `[${msg.role}] ${msg.content}` : null;
   }
 
-  const parts = (msg.content as ContentBlock[])
-    .map(blockToText)
-    .filter(Boolean) as string[];
+  const parts = msg.content.map(blockToText).filter(Boolean) as string[];
   return parts.length > 0 ? `[${msg.role}] ${parts.join("\n")}` : null;
 }
 

--- a/packages/core/src/import/providers/opencode.ts
+++ b/packages/core/src/import/providers/opencode.ts
@@ -55,10 +55,7 @@ function openDB(): InstanceType<typeof Database> | null {
     // `readOnly`. Pass both via a structurally-typed options object that
     // covers either runtime's constructor signature.
     const options = { readonly: true, readOnly: true };
-    return new Database(
-      OPENCODE_DB_PATH,
-      options as ConstructorParameters<typeof Database>[1],
-    );
+    return new Database(OPENCODE_DB_PATH, options);
   } catch {
     return null;
   }

--- a/packages/core/src/lat-reader.ts
+++ b/packages/core/src/lat-reader.ts
@@ -12,7 +12,7 @@
 import { readdirSync, readFileSync, existsSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
 import { remark } from "remark";
-import type { Root, Heading, Paragraph, Text } from "mdast";
+import type { Heading, Paragraph, Text } from "mdast";
 import { db, ensureProject } from "./db";
 import { sha256 } from "#db/driver";
 import {
@@ -89,7 +89,7 @@ export function parseSections(
   content: string,
   projectRoot: string,
 ): ParsedSection[] {
-  const tree = processor.parse(content) as Root;
+  const tree = processor.parse(content);
   const fileRel = relative(projectRoot, filePath).replace(/\.md$/, "");
   const lines = content.split("\n");
 

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -2983,7 +2983,7 @@ export async function searchScoredOtherProjects(input: {
 export function get(id: string): KnowledgeEntry | null {
   const row = db()
     .query(`SELECT ${KNOWLEDGE_COLS} FROM knowledge_current WHERE id = ?`)
-    .get(id) as Record<string, unknown> | null;
+    .get(id);
   // Hydrate the `metadata` column like every `.all()` site does — without this
   // the single-row getters would return an unparsed JSON string, violating the
   // `KnowledgeEntry.metadata: KnowledgeMetadata | null` contract (#627 Phase 1).
@@ -3027,7 +3027,7 @@ export function getByLogical(logicalId: string): KnowledgeEntry | null {
     .query(
       `SELECT ${KNOWLEDGE_COLS} FROM knowledge_current WHERE logical_id = ?`,
     )
-    .get(logicalId) as Record<string, unknown> | null;
+    .get(logicalId);
   // Hydrate `metadata` (#627 Phase 1) — see get() above.
   return row ? (hydrateKnowledgeEntry(row) as KnowledgeEntry) : null;
 }

--- a/packages/core/src/read-offload.ts
+++ b/packages/core/src/read-offload.ts
@@ -42,7 +42,7 @@ export async function offloadAll(
   if (res) return res.rows as unknown[];
   return db()
     .query(sql)
-    .all(...params) as unknown[];
+    .all(...params);
 }
 
 /**
@@ -62,7 +62,7 @@ export async function offloadAllOrTimeout(
   if (res) return res.rows as unknown[];
   return db()
     .query(sql)
-    .all(...params) as unknown[];
+    .all(...params);
 }
 
 /**

--- a/packages/core/src/recall.ts
+++ b/packages/core/src/recall.ts
@@ -1111,7 +1111,7 @@ export async function searchRecall(
               source: "cross-knowledge" as const,
               item,
               projectLabel: label,
-            } as TaggedResult;
+            };
           }),
           key: (r) => `xk:${r.item.id}`,
         });
@@ -1306,7 +1306,7 @@ export async function searchRecall(
       for (const item of list.items) {
         if (item.source !== "distillation") continue;
         const key = `d:${item.item.id}`;
-        const d = item.item as ScoredDistillation;
+        const d = item.item;
         const cNorm = d.c_norm ?? 0; // NULL → treat as uniform (best case)
         // Quality score: lower c_norm is better. For high c_norm, recency
         // partially compensates. Age is normalized to days (capped at 90).

--- a/packages/core/src/references.ts
+++ b/packages/core/src/references.ts
@@ -234,7 +234,7 @@ export function extractReferences(text: string): Reference[] {
     out.push({
       kind: "file",
       path,
-      line: Number.isNaN(line as number) ? null : line,
+      line: Number.isNaN(line) ? null : line,
       raw,
     });
   }

--- a/packages/core/src/sync-data.ts
+++ b/packages/core/src/sync-data.ts
@@ -1012,10 +1012,7 @@ export function seedOutbox(tier: SyncTier = currentSyncTier()): void {
       // Resolve the synced columns ONCE per table (one PRAGMA table_info) — not
       // per row, which is what `contentHash` would do (an N+1 on large tables).
       const cols = columns(m.table);
-      const rows = db().query(seedSelect(m.table)).all() as Record<
-        string,
-        unknown
-      >[];
+      const rows = db().query(seedSelect(m.table)).all();
       for (const row of rows) {
         const rowId = rowIdOf(m.table, row);
         const pending =

--- a/packages/core/src/vector-pool.ts
+++ b/packages/core/src/vector-pool.ts
@@ -738,7 +738,7 @@ export async function checkReadOffload(
             type: "read",
             id: READ_OFFLOAD_PROBE_ID,
             spec: { sql: "SELECT 1 AS one", params: [], mode: "get" },
-          } as VectorWorkerInbound);
+          });
         } catch (err) {
           finish({
             status: "spawn-error",
@@ -787,7 +787,7 @@ export function shutdownVectorPool(): void {
   for (const pw of workers) {
     failAll(pw, new Error("vector pool shutting down"));
     try {
-      pw.worker.postMessage({ type: "shutdown" } as VectorWorkerInbound);
+      pw.worker.postMessage({ type: "shutdown" });
     } catch {
       // worker may already be gone
     }

--- a/packages/core/src/vector-worker.ts
+++ b/packages/core/src/vector-worker.ts
@@ -18,7 +18,7 @@
 import { parentPort, workerData } from "node:worker_threads";
 import { openReaderConnection, type ReaderConnection } from "./db/reader";
 import { resolveReadMode, readStorageMode } from "./db/vec-store";
-import { type ReadJobConn, runReadJob } from "./read-job";
+import { runReadJob } from "./read-job";
 import { runVectorQuery } from "./vector-query";
 import type {
   VectorWorkerInbound,
@@ -107,7 +107,7 @@ port.on("message", (msg: VectorWorkerInbound) => {
       }
       try {
         // The connection is query_only=TRUE, so a read job can only SELECT.
-        const rows = runReadJob(conn.db as unknown as ReadJobConn, msg.spec);
+        const rows = runReadJob(conn.db, msg.spec);
         post({ type: "read-result", id: msg.id, rows });
       } catch (err) {
         // Per-request failure — reject just this request, keep serving. The

--- a/packages/core/test/cache-economics.test.ts
+++ b/packages/core/test/cache-economics.test.ts
@@ -369,8 +369,8 @@ describe("decideCacheStrategy — meta-aware cost model (#947)", () => {
       pReturn: 0.8,
       expectedCycles: 1,
       expectedFutureTurns: 5,
-      metaThreshold: undefined as unknown as number,
-      metaDistillCostPerCall: undefined as unknown as number,
+      metaThreshold: undefined,
+      metaDistillCostPerCall: undefined,
     });
     expect(r.confident).toBe(true);
     // No meta adjustment → coolBustCost matches the no-meta formula.
@@ -410,7 +410,7 @@ describe("decideCacheStrategy — meta-aware cost model (#947)", () => {
 
 describe("decideCacheStrategy — non-finite inputs break confidence, not the contract", () => {
   test("undefined pricing (missing model) → confident:false, no NaN", () => {
-    const r = decide({ readPerToken: undefined as unknown as number });
+    const r = decide({ readPerToken: undefined });
     expect(r.confident).toBe(false);
     expect(Number.isNaN(r.holdWarmCost)).toBe(false);
   });

--- a/packages/core/test/contradiction.test.ts
+++ b/packages/core/test/contradiction.test.ts
@@ -43,7 +43,7 @@ function stubLLM(response: string | null): {
   prompt: ReturnType<typeof vi.fn>;
 } {
   const prompt = vi.fn().mockResolvedValue(response);
-  return { llm: { prompt } as unknown as LLMClient, prompt };
+  return { llm: { prompt }, prompt };
 }
 
 beforeEach(() => {

--- a/packages/core/test/distillation.test.ts
+++ b/packages/core/test/distillation.test.ts
@@ -368,17 +368,17 @@ describe("messagesToText", () => {
 // or trailing-text loss. This is the F3b correctness guarantee.
 
 function textPart(text: string): LorePart {
-  return { type: "text", text } as LorePart;
+  return { type: "text", text };
 }
 function reasoningPart(text: string): LorePart {
-  return { type: "reasoning", text } as LorePart;
+  return { type: "reasoning", text };
 }
 function toolPart(tool: string, output: string): LorePart {
   return {
     type: "tool",
     tool,
     state: { status: "completed", output },
-  } as unknown as LorePart;
+  };
 }
 
 describe("partsToText + truncateToolOutputsInContent round trip", () => {

--- a/packages/core/test/embedding-units.test.ts
+++ b/packages/core/test/embedding-units.test.ts
@@ -15,17 +15,17 @@ import {
 // Part fixtures — mirror the producers in temporal.partsToText (and the helpers
 // in distillation.test.ts) so content strings are byte-identical to production.
 function textPart(text: string): LorePart {
-  return { type: "text", text } as LorePart;
+  return { type: "text", text };
 }
 function reasoningPart(text: string): LorePart {
-  return { type: "reasoning", text } as LorePart;
+  return { type: "reasoning", text };
 }
 function toolPart(tool: string, output: string): LorePart {
   return {
     type: "tool",
     tool,
     state: { status: "completed", output },
-  } as unknown as LorePart;
+  };
 }
 
 describe("buildEmbeddingUnits", () => {

--- a/packages/core/test/fetch-interceptor-install.test.ts
+++ b/packages/core/test/fetch-interceptor-install.test.ts
@@ -30,7 +30,7 @@ describe("installFetchInterceptor — end-to-end routing", () => {
         init,
       };
       return new Response("ok", { status: 200 });
-    }) as unknown as typeof globalThis.fetch;
+    });
     globalThis.fetch = realFetch;
 
     cleanup = installFetchInterceptor({

--- a/packages/core/test/gradient-reasoning.test.ts
+++ b/packages/core/test/gradient-reasoning.test.ts
@@ -136,7 +136,7 @@ function makeAssistantMsgWithReasoning(
         metadata: {},
         time: { start: Date.now(), end: Date.now() },
       },
-    } as LorePart);
+    });
   }
   return { info, parts };
 }
@@ -323,7 +323,7 @@ describe("reasoning preservation — Layer 2/3 (tool-output stripping)", () => {
           metadata: {},
           time: { start: Date.now(), end: Date.now() },
         },
-      } as LorePart);
+      });
       messages.push(a);
     }
 

--- a/packages/core/test/gradient.test.ts
+++ b/packages/core/test/gradient.test.ts
@@ -77,7 +77,7 @@ function toolStateOf(part: LorePart | undefined): TestToolState {
   if (!part || !isToolPart(part)) {
     throw new Error("expected tool part");
   }
-  return part.state as unknown as TestToolState;
+  return part.state;
 }
 
 function makeMsg(
@@ -162,7 +162,7 @@ describe("gradient", () => {
       const role = i % 2 === 0 ? "user" : "assistant";
       return makeMsg(
         `bulk-${i}`,
-        role as "user" | "assistant",
+        role,
         `Message content number ${i} with some padding text to take up token space.`,
       );
     });
@@ -187,7 +187,7 @@ describe("gradient", () => {
     const messages = Array.from({ length: 10 }, (_, i) => {
       const role = i % 2 === 0 ? "user" : "assistant";
       const text = `Message ${i}: ${"detailed content about various topics and implementation details that span across multiple concerns ".repeat(40)}`;
-      return makeMsg(`nuclear-${i}`, role as "user" | "assistant", text);
+      return makeMsg(`nuclear-${i}`, role, text);
     });
     setModelLimits({ context: 2_000, output: 500 }); // 1500 usable, rawBudget ~600
     calibrate(0); // keep overhead at zero for this test
@@ -210,11 +210,7 @@ describe("gradient", () => {
     // Verify that more than the old fixed 3 are included.
     const messages = Array.from({ length: 20 }, (_, i) => {
       const role = i % 2 === 0 ? "user" : "assistant";
-      return makeMsg(
-        `tiny-${i}`,
-        role as "user" | "assistant",
-        `Msg ${i}: short`,
-      );
+      return makeMsg(`tiny-${i}`, role, `Msg ${i}: short`);
     });
     setModelLimits({ context: 12_000, output: 2_000 }); // usable ~10000
     calibrate(0);
@@ -259,12 +255,7 @@ describe("gradient", () => {
     const medMessages = Array.from({ length: 14 }, (_, i) => {
       const role = i % 2 === 0 ? "user" : "assistant";
       const text = `Message ${i}: ${"some content that fills the budget moderately well ".repeat(8)}`;
-      return makeMsg(
-        `ltm-flag-med-${i}`,
-        role as "user" | "assistant",
-        text,
-        "ltm-flag-med-sess",
-      );
+      return makeMsg(`ltm-flag-med-${i}`, role, text, "ltm-flag-med-sess");
     });
     const layerMidResult = transform({
       messages: medMessages,
@@ -281,12 +272,7 @@ describe("gradient", () => {
     const bigMessages = Array.from({ length: 10 }, (_, i) => {
       const role = i % 2 === 0 ? "user" : "assistant";
       const text = `Message ${i}: ${"detailed content about various topics and implementation details that span across multiple concerns ".repeat(40)}`;
-      return makeMsg(
-        `ltm-flag-big-${i}`,
-        role as "user" | "assistant",
-        text,
-        "ltm-flag-big-sess",
-      );
+      return makeMsg(`ltm-flag-big-${i}`, role, text, "ltm-flag-big-sess");
     });
     const layer4Result = transform({
       messages: bigMessages,
@@ -322,11 +308,7 @@ describe("gradient", () => {
     calibrate(0);
     const messages = Array.from({ length: 6 }, (_, i) => {
       const role = i % 2 === 0 ? "user" : "assistant";
-      return makeMsg(
-        `exhaust-${i}`,
-        role as "user" | "assistant",
-        "X".repeat(2_000),
-      );
+      return makeMsg(`exhaust-${i}`, role, "X".repeat(2_000));
     });
     const result = transform({
       messages,
@@ -1204,7 +1186,7 @@ function makeStepWithTool(
         sessionID,
         messageID: id,
         type: "step-start",
-      } as LorePart,
+      },
       {
         id: `tool-${id}`,
         sessionID,
@@ -1220,7 +1202,7 @@ function makeStepWithTool(
           metadata: {},
           time: { start: Date.now(), end: Date.now() },
         },
-      } as unknown as LorePart,
+      },
       {
         id: `step-finish-${id}`,
         sessionID,
@@ -1234,7 +1216,7 @@ function makeStepWithTool(
           reasoning: 0,
           cache: { read: 0, write: 0 },
         },
-      } as unknown as LorePart,
+      },
     ],
   };
 }
@@ -1279,7 +1261,7 @@ function makeStepWithPendingTool(
         sessionID,
         messageID: id,
         type: "step-start",
-      } as LorePart,
+      },
       {
         id: `tool-${id}`,
         sessionID,
@@ -1292,7 +1274,7 @@ function makeStepWithPendingTool(
           input: { command: "ls" },
           raw: '{"command": "ls"}',
         },
-      } as unknown as LorePart,
+      },
     ],
   };
 }
@@ -1330,7 +1312,7 @@ function makeStepWithRunningTool(
         sessionID,
         messageID: id,
         type: "step-start",
-      } as LorePart,
+      },
       {
         id: `tool-${id}`,
         sessionID,
@@ -1345,7 +1327,7 @@ function makeStepWithRunningTool(
           metadata: { cwd: "/test" },
           time: { start: startTime },
         },
-      } as unknown as LorePart,
+      },
     ],
   };
 }
@@ -2652,7 +2634,7 @@ function makeMsgWithTool(
           time: { start: Date.now(), end: Date.now() },
         },
         time: { start: Date.now(), end: Date.now() },
-      } as LorePart,
+      },
     ],
   };
 }
@@ -3622,7 +3604,7 @@ describe("reasoning preservation (F-REASONING-AUDIT mini-pin)", () => {
             type: "reasoning",
             text: "I should consider the trade-offs carefully here.",
             time: { start: Date.now(), end: Date.now() },
-          } as LorePart,
+          },
           {
             id: "rm-t1",
             sessionID: SID,
@@ -5725,9 +5707,7 @@ describe("gradient — free-write session compresses earlier than normal", () =>
       const msgs: ReturnType<typeof makeMsg>[] = [];
       for (let i = 0; i < 40; i++) {
         const role = i % 2 === 0 ? "user" : "assistant";
-        msgs.push(
-          makeMsg(`fw-${i}`, role as "user" | "assistant", bigText, sid),
-        );
+        msgs.push(makeMsg(`fw-${i}`, role, bigText, sid));
       }
       msgs.push(makeMsg("fw-final", "user", "do the fix", sid));
       return msgs;
@@ -5923,7 +5903,7 @@ describe("gradient — prefix/raw boundary role alternation (#424)", () => {
             output,
             time: { start: Date.now(), end: Date.now() },
           },
-        } as unknown as LorePart,
+        },
       ],
     };
   }
@@ -6166,7 +6146,7 @@ describe("gradient — error-state tool outputs are estimated (not flat 20)", ()
             error: bigError,
             time: { start: Date.now(), end: Date.now() },
           },
-        } as unknown as LorePart,
+        },
       ],
     };
     const estimate = estimateMessages([errorMsg]);
@@ -6219,7 +6199,7 @@ describe("gradient — atomic tool_use/tool_result pair (no orphan on eviction)"
             time: { start: Date.now(), end: Date.now() },
           },
           time: { start: Date.now(), end: Date.now() },
-        } as LorePart,
+        },
       ],
     };
   }
@@ -6252,7 +6232,7 @@ describe("gradient — atomic tool_use/tool_result pair (no orphan on eviction)"
             time: { start: Date.now(), end: Date.now() },
           },
           time: { start: Date.now(), end: Date.now() },
-        } as LorePart,
+        },
       ],
     };
   }

--- a/packages/core/test/markdown.test.ts
+++ b/packages/core/test/markdown.test.ts
@@ -26,7 +26,7 @@ function countListItems(md: string): number {
     for (const child of node.children ?? [])
       walk(child as { type: string; children?: unknown[] });
   }
-  walk(proc.parse(md) as { type: string; children?: unknown[] });
+  walk(proc.parse(md));
   return items;
 }
 

--- a/packages/core/test/pattern-echo.test.ts
+++ b/packages/core/test/pattern-echo.test.ts
@@ -27,7 +27,7 @@ function insertDistill(id: string, pid: string, session: string): void {
 }
 
 function stubLLM(): LLMClient {
-  return { prompt: vi.fn() } as unknown as LLMClient;
+  return { prompt: vi.fn() };
 }
 
 describe("pattern-echo cooldown", () => {

--- a/packages/core/test/setup.ts
+++ b/packages/core/test/setup.ts
@@ -62,7 +62,7 @@ const CANNED_MODELS_DEV = {
 };
 
 const realFetch = globalThis.fetch;
-globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+globalThis.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
   const url =
     typeof input === "string"
       ? input
@@ -78,7 +78,7 @@ globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
     );
   }
   return realFetch(input, init);
-}) as typeof globalThis.fetch;
+};
 
 // The Pi/OpenCode plugins flip `log.silenceStderr()` when they activate inside
 // their TUI host. A force-active plugin test (LORE_*_FORCE_ACTIVE=1) would

--- a/packages/core/test/temporal.test.ts
+++ b/packages/core/test/temporal.test.ts
@@ -68,7 +68,7 @@ function toolPart(
     tool,
     callID,
     state,
-  } as unknown as LorePart;
+  };
 }
 
 describe("temporal", () => {

--- a/packages/core/test/vec0-cutover.test.ts
+++ b/packages/core/test/vec0-cutover.test.ts
@@ -1380,17 +1380,17 @@ describe("mode-aware detection predicates", () => {
 // --- Phase 2 multi-vector temporal writes -----------------------------------
 // Part fixtures mirror temporal.partsToText so content is byte-identical to prod.
 function textPart(text: string): LorePart {
-  return { type: "text", text } as LorePart;
+  return { type: "text", text };
 }
 function reasoningPart(text: string): LorePart {
-  return { type: "reasoning", text } as LorePart;
+  return { type: "reasoning", text };
 }
 function toolPart(tool: string, output: string): LorePart {
   return {
     type: "tool",
     tool,
     state: { status: "completed", output },
-  } as unknown as LorePart;
+  };
 }
 function chunkIds(messageId: string): string[] {
   return (

--- a/packages/core/test/vector-pool.test.ts
+++ b/packages/core/test/vector-pool.test.ts
@@ -193,10 +193,10 @@ describe("vector-pool fallback paths (resolve null, never throw)", () => {
 
   it("returns null and latches broken when spawning throws (no retry)", async () => {
     let calls = 0;
-    _setTestVectorWorkerFactory((() => {
+    _setTestVectorWorkerFactory(() => {
       calls++;
       throw new Error("spawn failed");
-    }) as never);
+    });
     expect(await tryPoolVectorSearch(KNOWLEDGE, QUERY)).toBeNull();
     const afterFirst = calls;
     expect(afterFirst).toBeGreaterThan(0);
@@ -351,9 +351,9 @@ describe("vector-pool structural-failure latch (review #989)", () => {
     _setTestVectorWorkerFactory((() => {
       const w = new FakeWorker(() => {});
       // Simulate the worker dying between leastBusy() and postMessage().
-      w.postMessage = (() => {
+      w.postMessage = () => {
         throw new Error("dead pipe");
-      }) as never;
+      };
       return w;
     }) as never);
     expect(await tryPoolVectorSearch(KNOWLEDGE, QUERY)).toBeNull();
@@ -660,9 +660,9 @@ describe("checkVecWorker (off-thread read-pool vec probe, #1033)", () => {
   });
 
   it("reports spawn-error when spawning throws synchronously", async () => {
-    _setTestVectorWorkerFactory((() => {
+    _setTestVectorWorkerFactory(() => {
       throw new Error("no worker");
-    }) as unknown as (d: VectorWorkerInitData) => never);
+    });
     const r = await checkVecWorker();
     expect(r).toEqual({
       status: "spawn-error",
@@ -779,9 +779,9 @@ describe("checkReadOffload (off-thread read-job round-trip probe, #1029)", () =>
   });
 
   it("reports spawn-error when spawning throws synchronously", async () => {
-    _setTestVectorWorkerFactory((() => {
+    _setTestVectorWorkerFactory(() => {
       throw new Error("no worker");
-    }) as unknown as (d: VectorWorkerInitData) => never);
+    });
     const r = await checkReadOffload();
     expect(r).toEqual({ status: "spawn-error", error: "no worker" });
   });

--- a/packages/gateway/src/cli/entity.ts
+++ b/packages/gateway/src/cli/entity.ts
@@ -250,7 +250,7 @@ async function cmdEdit(
   const updates: Record<string, unknown> = {};
 
   if (flags.name) {
-    updates.canonicalName = flags.name as string;
+    updates.canonicalName = flags.name;
   }
 
   if (flags.cross !== undefined) {

--- a/packages/gateway/src/cli/lib/binary.ts
+++ b/packages/gateway/src/cli/lib/binary.ts
@@ -78,7 +78,7 @@ export function isNightlyVersion(version: string): boolean {
  * build is always less than the stable release it precedes.
  */
 export function compareVersions(a: string, b: string): -1 | 0 | 1 {
-  return semverCompare(a, b) as -1 | 0 | 1;
+  return semverCompare(a, b);
 }
 
 /**

--- a/packages/gateway/src/cli/lib/bspatch.ts
+++ b/packages/gateway/src/cli/lib/bspatch.ts
@@ -171,9 +171,7 @@ function createZstdStreamReader(compressed: Uint8Array): BufferedStreamReader {
   const webStream = Readable.toWeb(
     decompressor,
   ) as unknown as ReadableStream<Uint8Array>;
-  return new BufferedStreamReader(
-    webStream.getReader() as ReadableStreamDefaultReader<Uint8Array>,
-  );
+  return new BufferedStreamReader(webStream.getReader());
 }
 
 type OldFileHandle = {

--- a/packages/gateway/src/cli/main.ts
+++ b/packages/gateway/src/cli/main.ts
@@ -210,7 +210,7 @@ export async function _cli(): Promise<void> {
     });
     values = parsed.values;
     positionals = parsed.positionals;
-    tokens = parsed.tokens as ParseToken[];
+    tokens = parsed.tokens;
   } catch (e) {
     console.error(`Error: ${e instanceof Error ? e.message : e}`);
     printHelp();
@@ -371,17 +371,7 @@ export async function _cli(): Promise<void> {
   const command = positionals[0] ?? "run";
   const rest = positionals.slice(1);
 
-  const startOpts = buildStartOptions(
-    values as {
-      port?: string;
-      host?: string[];
-      debug?: boolean;
-      remote?: string;
-      local?: boolean;
-      bg?: boolean;
-      daemon?: boolean;
-    },
-  );
+  const startOpts = buildStartOptions(values);
 
   // Start background update check (non-blocking).
   // Suppressed for commands where the banner would be confusing or redundant.
@@ -415,7 +405,7 @@ export async function _cli(): Promise<void> {
 
       case "setup": {
         const { commandSetup } = await import("./setup");
-        await commandSetup(rest, values as Record<string, unknown>);
+        await commandSetup(rest, values);
         break;
       }
 
@@ -427,31 +417,31 @@ export async function _cli(): Promise<void> {
 
       case "data": {
         const { commandData } = await import("./data");
-        await commandData(rest, values as Record<string, unknown>);
+        await commandData(rest, values);
         break;
       }
 
       case "recall": {
         const { commandRecall } = await import("./recall-cmd");
-        await commandRecall(rest, values as Record<string, unknown>);
+        await commandRecall(rest, values);
         break;
       }
 
       case "log": {
         const { commandLog } = await import("./history-cmd");
-        await commandLog(rest, values as Record<string, unknown>);
+        await commandLog(rest, values);
         break;
       }
 
       case "diff": {
         const { commandDiff } = await import("./history-cmd");
-        await commandDiff(rest, values as Record<string, unknown>);
+        await commandDiff(rest, values);
         break;
       }
 
       case "login": {
         const { commandLogin } = await import("./login");
-        await commandLogin(rest, values as Record<string, unknown>);
+        await commandLogin(rest, values);
         break;
       }
 
@@ -463,37 +453,37 @@ export async function _cli(): Promise<void> {
 
       case "whoami": {
         const { commandWhoami } = await import("./login");
-        await commandWhoami(rest, values as Record<string, unknown>);
+        await commandWhoami(rest, values);
         break;
       }
 
       case "sync": {
         const { commandSync } = await import("./sync-cmd");
-        await commandSync(rest, values as Record<string, unknown>);
+        await commandSync(rest, values);
         break;
       }
 
       case "team": {
         const { commandTeam } = await import("./team-cmd");
-        await commandTeam(rest, values as Record<string, unknown>);
+        await commandTeam(rest, values);
         break;
       }
 
       case "logs": {
         const { commandLogs } = await import("./logs");
-        await commandLogs(rest, values as Record<string, unknown>);
+        await commandLogs(rest, values);
         break;
       }
 
       case "import": {
         const { commandImport } = await import("./import");
-        await commandImport(rest, values as Record<string, unknown>);
+        await commandImport(rest, values);
         break;
       }
 
       case "entity": {
         const { commandEntity } = await import("./entity");
-        await commandEntity(rest, values as Record<string, unknown>);
+        await commandEntity(rest, values);
         break;
       }
 

--- a/packages/gateway/src/compaction.ts
+++ b/packages/gateway/src/compaction.ts
@@ -61,7 +61,7 @@ function lastUserText(req: GatewayRequest): string {
     if (msg.role === "user") {
       return msg.content
         .filter((b) => b.type === "text")
-        .map((b) => (b as { type: "text"; text: string }).text)
+        .map((b) => b.text)
         .join("\n");
     }
   }

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -1455,9 +1455,7 @@ export function createGatewayLLMClient(
       // upstream (the vertex builder constructs its own headers and ignores it).
       const cred =
         getAuth(opts?.sessionID, model.providerID) ??
-        (protocol === "vertex"
-          ? ({ scheme: "bearer", value: "" } as AuthCredential)
-          : null);
+        (protocol === "vertex" ? { scheme: "bearer", value: "" } : null);
       if (!cred) {
         log.warn("no auth credentials available for worker call");
         recordWorkerFailure(

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -4413,7 +4413,7 @@ function accumulateOpenAINonStreamJSON(
         let input: unknown = {};
         if (typeof fn?.arguments === "string") {
           try {
-            input = JSON.parse(fn.arguments as string);
+            input = JSON.parse(fn.arguments);
           } catch {
             input = fn.arguments;
           }
@@ -4476,7 +4476,7 @@ export function accumulateResponsesNonStreamJSON(
         let input: unknown = {};
         if (typeof item.arguments === "string") {
           try {
-            input = JSON.parse(item.arguments as string);
+            input = JSON.parse(item.arguments);
           } catch {
             input = item.arguments;
           }
@@ -8344,7 +8344,7 @@ export function loreMessagesToGateway(
       }
     }
 
-    out.push({ role: msg.info.role as "user" | "assistant", content });
+    out.push({ role: msg.info.role, content });
   }
 
   return out;
@@ -8389,9 +8389,7 @@ export function removeOrphanedToolResults(
     // Remove tool_result blocks that reference missing tool_use IDs
     const before = msg.content.length;
     msg.content = msg.content.filter(
-      (b) =>
-        b.type !== "tool_result" ||
-        toolUseIds.has((b as GatewayToolResultBlock).toolUseId),
+      (b) => b.type !== "tool_result" || toolUseIds.has(b.toolUseId),
     );
     if (msg.content.length < before) {
       log.warn(
@@ -8428,9 +8426,7 @@ export function removeOrphanedToolResults(
     // Remove tool_use blocks that have no matching tool_result
     const before = msg.content.length;
     msg.content = msg.content.filter(
-      (b) =>
-        b.type !== "tool_use" ||
-        toolResultIds.has((b as GatewayToolUseBlock).id),
+      (b) => b.type !== "tool_use" || toolResultIds.has(b.id),
     );
     if (msg.content.length < before) {
       log.warn(
@@ -8458,7 +8454,7 @@ function lastUserTextTrimmed(req: GatewayRequest): string {
     if (msg.role !== "user") continue;
     const text = msg.content
       .filter((b) => b.type === "text")
-      .map((b) => (b as { type: "text"; text: string }).text)
+      .map((b) => b.text)
       .join("\n")
       .trim();
     return text;

--- a/packages/gateway/src/sentry.ts
+++ b/packages/gateway/src/sentry.ts
@@ -710,7 +710,7 @@ export function setupBustSpiralCapture(): void {
         level: "info",
         message:
           "Cold-start bust spiral observed (within grace window) — expected per #796/#804",
-        data: info as unknown as Record<string, unknown>,
+        data: info,
       });
     },
     onSpiral: (info: BustSpiralInfo) => {
@@ -736,7 +736,7 @@ export function setupBustSpiralCapture(): void {
         category: "lore.cache.bust_spiral",
         level: "info",
         message: "Bust spiral recovered",
-        data: info as unknown as Record<string, unknown>,
+        data: info,
       });
     },
   });

--- a/packages/gateway/src/stream/anthropic.ts
+++ b/packages/gateway/src/stream/anthropic.ts
@@ -1204,7 +1204,7 @@ export function createRecallAwareAccumulator(
         ) {
           const adjusted = {
             ...parsed,
-            index: (parsed.index as number) - suppressedCount + baseOffset,
+            index: parsed.index - suppressedCount + baseOffset,
           };
           return formatSSEEvent(eventType, JSON.stringify(adjusted));
         }

--- a/packages/gateway/src/stream/openai-responses.ts
+++ b/packages/gateway/src/stream/openai-responses.ts
@@ -175,7 +175,7 @@ export async function accumulateResponsesSSEStream(
               usage.inputTokens = respUsage.input_tokens;
             }
             if (typeof respUsage.output_tokens === "number") {
-              usage.outputTokens = respUsage.output_tokens as number;
+              usage.outputTokens = respUsage.output_tokens;
             }
             const promptDetails = respUsage.prompt_tokens_details as
               | Record<string, number>

--- a/packages/gateway/src/stream/openai.ts
+++ b/packages/gateway/src/stream/openai.ts
@@ -437,9 +437,9 @@ export async function accumulateOpenAISSEStream(
     const usage = parsed.usage as Record<string, unknown> | undefined;
     if (usage) {
       if (typeof usage.prompt_tokens === "number")
-        inputTokens = usage.prompt_tokens as number;
+        inputTokens = usage.prompt_tokens;
       if (typeof usage.completion_tokens === "number")
-        outputTokens = usage.completion_tokens as number;
+        outputTokens = usage.completion_tokens;
       const details = usage.prompt_tokens_details as
         | Record<string, number>
         | undefined;

--- a/packages/gateway/src/sync.ts
+++ b/packages/gateway/src/sync.ts
@@ -1283,7 +1283,7 @@ function toRemoteRow(
   const out: Record<string, unknown> = { ...row };
   for (const k of TS_COLS) {
     if (typeof out[k] === "number") {
-      out[k] = new Date(out[k] as number).toISOString();
+      out[k] = new Date(out[k]).toISOString();
     }
   }
   // Base64-encode BLOB columns for the PostgREST/JSON wire (remote stores `text`).

--- a/packages/gateway/src/translate/anthropic.ts
+++ b/packages/gateway/src/translate/anthropic.ts
@@ -478,7 +478,7 @@ export function buildAnthropicRequest(
       const prefixMsg = messages[prefixLen - 1];
       const prefixBlock = prefixMsg?.content[prefixMsg.content.length - 1];
       if (prefixBlock) {
-        (prefixBlock as Record<string, unknown>).cache_control =
+        prefixBlock.cache_control =
           cache.systemTTL === "1h"
             ? { type: "ephemeral", ttl: "1h" }
             : { type: "ephemeral" };
@@ -490,7 +490,7 @@ export function buildAnthropicRequest(
     if (lastBlock) {
       // Use configured TTL: "1h" for extended cache tier (2× write cost but
       // 12× longer eviction window), bare ephemeral (5m) otherwise.
-      (lastBlock as Record<string, unknown>).cache_control =
+      lastBlock.cache_control =
         cache.conversationTTL === "1h"
           ? { type: "ephemeral", ttl: "1h" }
           : { type: "ephemeral" };

--- a/packages/gateway/src/translate/gemini.ts
+++ b/packages/gateway/src/translate/gemini.ts
@@ -201,7 +201,7 @@ function blockToGeminiParts(block: GatewayContentBlock): GeminiPart[] {
       return [{ functionResponse: { name: block.toolUseId, response } }];
     }
     case "opaque":
-      return [block.raw as GeminiPart];
+      return [block.raw];
   }
 }
 

--- a/packages/gateway/src/ui.ts
+++ b/packages/gateway/src/ui.ts
@@ -3390,10 +3390,7 @@ function pageEntity(id: string): string | null {
       body += `<div class="field"><span class="key">Notes:</span> ${esc(parsedMeta.notes)}</div>`;
     }
     // Show any extra keys as raw JSON
-    const { role, description, notes, ...extra } = parsedMeta as Record<
-      string,
-      unknown
-    >;
+    const { role, description, notes, ...extra } = parsedMeta;
     if (Object.keys(extra).length > 0) {
       body += `<div class="field"><span class="key">Other:</span></div><pre>${esc(JSON.stringify(extra, null, 2))}</pre>`;
     }

--- a/packages/gateway/test/batch-queue.test.ts
+++ b/packages/gateway/test/batch-queue.test.ts
@@ -881,7 +881,7 @@ describe("BatchLLMClient", () => {
         url.includes("/v1/files") &&
         init?.body instanceof FormData
       ) {
-        const formData = init.body as FormData;
+        const formData = init.body;
         const file = formData.get("file") as Blob;
         if (file) {
           capturedJsonl = await file.text();
@@ -1435,7 +1435,7 @@ describe("BatchLLMClient temperature capability", () => {
         url.includes("/v1/files") &&
         init?.body instanceof FormData
       ) {
-        const file = (init.body as FormData).get("file") as Blob;
+        const file = init.body.get("file") as Blob;
         if (file) capturedJsonl = await file.text();
         return {
           ok: true,
@@ -1509,7 +1509,7 @@ describe("BatchLLMClient temperature capability", () => {
         url.includes("/v1/files") &&
         init?.body instanceof FormData
       ) {
-        const file = (init.body as FormData).get("file") as Blob;
+        const file = init.body.get("file") as Blob;
         if (file) capturedJsonl = await file.text();
         return {
           ok: true,

--- a/packages/gateway/test/cache-warmer.test.ts
+++ b/packages/gateway/test/cache-warmer.test.ts
@@ -457,10 +457,7 @@ describe("prepareAnthropicWarmupBody", () => {
     const breakpoints = (fromStore.messages as Array<{ content: unknown[] }>)
       .flatMap((m) => m.content)
       .filter(
-        (b) =>
-          typeof b === "object" &&
-          b !== null &&
-          "cache_control" in (b as object),
+        (b) => typeof b === "object" && b !== null && "cache_control" in b,
       );
     expect(breakpoints).toHaveLength(1);
     const lastMsg = fromStore.messages[fromStore.messages.length - 1];
@@ -486,10 +483,7 @@ describe("prepareAnthropicWarmupBody", () => {
     const breakpoints = (result.messages as Array<{ content: unknown[] }>)
       .flatMap((m) => m.content)
       .filter(
-        (b) =>
-          typeof b === "object" &&
-          b !== null &&
-          "cache_control" in (b as object),
+        (b) => typeof b === "object" && b !== null && "cache_control" in b,
       );
     expect(breakpoints).toHaveLength(1);
     expect(result.messages[0].content[0].cache_control).toEqual({

--- a/packages/gateway/test/cli-check-read-offload.test.ts
+++ b/packages/gateway/test/cli-check-read-offload.test.ts
@@ -17,6 +17,7 @@ import type { ReadOffloadCheck } from "@loreai/core";
 const { state, safeExit } = vi.hoisted(() => ({
   state: {
     dbThrows: false,
+    // oxlint-disable-next-line typescript/no-unnecessary-type-assertion -- widening for the mutable fixture; tests reassign error results below
     result: { status: "ok" } as ReadOffloadCheck,
   },
   safeExit: vi.fn(),

--- a/packages/gateway/test/cli-check-vec.test.ts
+++ b/packages/gateway/test/cli-check-vec.test.ts
@@ -17,12 +17,14 @@ const { state, safeExit } = vi.hoisted(() => ({
   state: {
     vecAvailable: true,
     // `undefined` simulates `SELECT vec_version()` returning a row with no `v`.
+    // oxlint-disable-next-line typescript/no-unnecessary-type-assertion -- widening for the mutable fixture; tests reassign undefined below
     vecVersion: "v0.1.9" as string | undefined,
     dbThrows: false,
     // Drives the off-thread read-pool probe (checkVecWorker). Defaults to a
     // healthy native worker so the main-thread assertions in existing tests
     // keep exiting 0.
     worker: {
+      // oxlint-disable-next-line typescript/no-unnecessary-type-assertion -- widening for the mutable fixture; tests reassign other statuses below
       status: "ready" as "ready" | "init-error" | "timeout" | "spawn-error",
       vecAvailable: true,
       error: undefined as string | undefined,

--- a/packages/gateway/test/codex-compression.test.ts
+++ b/packages/gateway/test/codex-compression.test.ts
@@ -139,7 +139,7 @@ describe("zstd-compressed request bodies (issue #1032)", () => {
         r.on("data", (c: Buffer) => chunks.push(c));
         r.on("end", () => {
           captured = {
-            encoding: r.headers["content-encoding"] as string | undefined,
+            encoding: r.headers["content-encoding"],
             raw: Buffer.concat(chunks),
           };
           res.writeHead(200, { "content-type": "application/json" });

--- a/packages/gateway/test/idle-work.test.ts
+++ b/packages/gateway/test/idle-work.test.ts
@@ -990,7 +990,7 @@ describe("buildIdleWorkHandler — contradiction detection (#1123)", () => {
       prompt: vi.fn(async () =>
         JSON.stringify({ contradict: true, reason: "opposed" }),
       ),
-    } as unknown as LLMClient;
+    };
   }
 
   async function runIdle(

--- a/packages/gateway/test/openai-responses.test.ts
+++ b/packages/gateway/test/openai-responses.test.ts
@@ -389,7 +389,7 @@ describe("parseOpenAIResponsesRequest", () => {
         m.content.some((b: GatewayContentBlock) => b.type === "tool_use"),
     );
     if (!assistant) throw new Error("expected assistant message");
-    const ids = (assistant.content as GatewayContentBlock[])
+    const ids = assistant.content
       .filter((b): b is GatewayToolUseBlock => b.type === "tool_use")
       .map((b) => b.id)
       .sort();

--- a/packages/gateway/test/readpath-capture.test.ts
+++ b/packages/gateway/test/readpath-capture.test.ts
@@ -43,9 +43,7 @@ const sample = (
 });
 
 function distNames(): string[] {
-  return vi
-    .mocked(Sentry.metrics.distribution)
-    .mock.calls.map((c) => c[0] as string);
+  return vi.mocked(Sentry.metrics.distribution).mock.calls.map((c) => c[0]);
 }
 
 describe("read-path timing Sentry capture (#999)", () => {

--- a/packages/gateway/test/recall-stream.test.ts
+++ b/packages/gateway/test/recall-stream.test.ts
@@ -919,8 +919,7 @@ describe("Case 2 integration — mixed tools end-to-end", () => {
     // No recall tool_use blocks remain
     expect(
       markerResp.content.every((b) => {
-        if (b.type === "tool_use")
-          return (b as GatewayToolUseBlock).name !== "recall";
+        if (b.type === "tool_use") return b.name !== "recall";
         return true;
       }),
     ).toBe(true);

--- a/packages/gateway/test/recall.test.ts
+++ b/packages/gateway/test/recall.test.ts
@@ -108,7 +108,7 @@ describe("RECALL_GATEWAY_TOOL", () => {
   test("has correct name and schema", () => {
     expect(RECALL_GATEWAY_TOOL.name).toBe("recall");
     expect(RECALL_GATEWAY_TOOL.description).toBeTruthy();
-    const schema = RECALL_GATEWAY_TOOL.inputSchema as Record<string, unknown>;
+    const schema = RECALL_GATEWAY_TOOL.inputSchema;
     expect(schema.type).toBe("object");
     const props = schema.properties as Record<string, unknown>;
     expect(props).toHaveProperty("query");

--- a/packages/gateway/test/shutdown.test.ts
+++ b/packages/gateway/test/shutdown.test.ts
@@ -45,7 +45,7 @@ describe("signalExitCode", () => {
   });
 
   test("falls back to 129 (128 + 1) for unknown signals", () => {
-    expect(signalExitCode("SIGUSR2" as NodeJS.Signals)).toBe(129);
+    expect(signalExitCode("SIGUSR2")).toBe(129);
   });
 });
 

--- a/packages/gateway/test/sync-engine.integration.test.ts
+++ b/packages/gateway/test/sync-engine.integration.test.ts
@@ -674,7 +674,7 @@ describe.skipIf(SKIP)(
           .then((x) => x.rows),
       );
       const epochOf = (b64: string) =>
-        crypto.parseHeader(Buffer.from(b64 as string, "base64")).keyEpoch;
+        crypto.parseHeader(Buffer.from(b64, "base64")).keyEpoch;
       expect(epochOf(rows[0].content)).toBe(0); // kr0
       expect(epochOf(rows[1].content)).toBe(1); // kr1 seals at the current epoch (kills the no-stamp mutant)
       // Both epoch wraps must be on the remote for a fresh device to decrypt both.

--- a/packages/gateway/test/sync.property.test.ts
+++ b/packages/gateway/test/sync.property.test.ts
@@ -72,7 +72,7 @@ function makeClient() {
           const i = rows.findIndex((r) =>
             idc.every((c) => r[c] === payload[c]),
           );
-          const stamped = { ...payload, updated_at: nextTs() } as RemoteRow;
+          const stamped = { ...payload, updated_at: nextTs() };
           if (i >= 0) rows[i] = stamped;
           else rows.push(stamped);
           return Promise.resolve({ error: null });
@@ -194,7 +194,7 @@ function seedCurrentProfile(): void {
       is_deleted: false,
       created_at: new Date(1000).toISOString(),
       updated_at: nextTs(),
-    } as RemoteRow,
+    },
   ]);
 }
 

--- a/packages/gateway/test/sync.test.ts
+++ b/packages/gateway/test/sync.test.ts
@@ -290,7 +290,7 @@ function makeClient() {
               author_id: REMOTE_SCOPE,
               ...one,
               updated_at: nextTs(),
-            } as RemoteRow);
+            });
             return null;
           };
           for (const one of Array.isArray(payload) ? payload : [payload]) {
@@ -1134,7 +1134,7 @@ describe("pullOnce", () => {
       content_hash: null,
       revision: 5,
       updated_at: new Date(3_000_000).toISOString(),
-    } as never);
+    });
     await pullOnce(makeClient() as never);
     expect(currentContent("kd")).toBeNull(); // death-cert applied → no live current
   });
@@ -1159,7 +1159,7 @@ describe("pullOnce", () => {
       source: null,
       created_at: 1,
       updated_at: new Date(2_000_000).toISOString(),
-    } as never);
+    });
     tableRows("entity_aliases").push({
       id: "al-orphan",
       entity_id: "22222222-2222-4222-8222-222222222222", // no such entity → local FK 787
@@ -1168,7 +1168,7 @@ describe("pullOnce", () => {
       source: null,
       created_at: 1,
       updated_at: new Date(2_000_001).toISOString(),
-    } as never);
+    });
 
     // Must NOT throw — one FK-failing row can't abort the whole multi-table sync.
     const noticeSpy = vi.spyOn(log, "notice");
@@ -1223,7 +1223,7 @@ describe("pullOnce", () => {
       source: null,
       created_at: 1,
       updated_at: new Date(2_000_000).toISOString(),
-    } as never);
+    });
 
     const noticeSpy = vi.spyOn(log, "notice");
     const r = await pullOnce(makeClient() as never);
@@ -1272,7 +1272,7 @@ describe("pullOnce", () => {
       source: null,
       created_at: 1,
       updated_at: new Date(2_000_000).toISOString(),
-    } as never);
+    });
 
     const r = await pullOnce(makeClient() as never);
 
@@ -1322,7 +1322,7 @@ describe("pullOnce", () => {
       source: null,
       created_at: 1,
       updated_at: new Date(2_000_000).toISOString(),
-    } as never);
+    });
 
     const noticeSpy = vi.spyOn(log, "notice");
     const r = await pullOnce(makeClient() as never);
@@ -1374,7 +1374,7 @@ describe("pullOnce", () => {
       source: null,
       created_at: 1,
       updated_at: new Date(2_000_000).toISOString(),
-    } as never);
+    });
 
     const r = await pullOnce(makeClient() as never);
 
@@ -1416,7 +1416,7 @@ describe("pullOnce", () => {
         source: null,
         created_at: 1,
         updated_at: ts,
-      } as never);
+      });
     }
     // Sorts LAST (so it lands in the DRAIN batch, not the first page) and its entity is absent.
     tableRows("entity_aliases").push({
@@ -1427,7 +1427,7 @@ describe("pullOnce", () => {
       source: null,
       created_at: 1,
       updated_at: ts,
-    } as never);
+    });
 
     const r = await pullOnce(makeClient() as never); // must NOT throw (drain path)
 
@@ -1480,7 +1480,7 @@ describe("pullOnce", () => {
         source: null,
         created_at: 1,
         updated_at: ts,
-      } as never);
+      });
     }
     // The collider sorts LAST (→ lands in the DRAIN batch) and has a LOWER id than the
     // local alias ('alias-…' < 'zzzzzzzz-local') → remote wins, dropping the local loser.
@@ -1492,7 +1492,7 @@ describe("pullOnce", () => {
       source: null,
       created_at: 1,
       updated_at: ts,
-    } as never);
+    });
 
     const r = await pullOnce(makeClient() as never); // must NOT throw (drain path)
 
@@ -1736,7 +1736,7 @@ describe("profiles (pull-only mirror)", () => {
       email: "octo@cat.dev",
       created_at: new Date(atMs).toISOString(),
       updated_at: new Date(atMs).toISOString(),
-    } as never);
+    });
   }
 
   test("pushOnce never uploads profiles (pull-only, no capture)", async () => {

--- a/packages/gateway/test/temporal-adapter.test.ts
+++ b/packages/gateway/test/temporal-adapter.test.ts
@@ -20,7 +20,7 @@ function toolStateOf(part: LorePart | undefined): TestToolState {
   if (!part || !isToolPart(part)) {
     throw new Error("expected tool part");
   }
-  return part.state as unknown as TestToolState;
+  return part.state;
 }
 
 /** Read the text of a text part, asserting it is one. */

--- a/packages/gateway/test/warmup-execute.test.ts
+++ b/packages/gateway/test/warmup-execute.test.ts
@@ -70,7 +70,7 @@ function makeState(): SessionState {
     upstreamByProvider: new Map(),
     resolvedConversationTTL: "5m",
     lastInputTokens: 100_000,
-  } as SessionState;
+  };
 }
 
 /** Build a fetch mock returning the given usage block as an Anthropic resp. */

--- a/packages/gateway/test/worker-model.test.ts
+++ b/packages/gateway/test/worker-model.test.ts
@@ -1695,7 +1695,7 @@ describe("worker-model resolution memoization", () => {
           },
         },
       },
-    } as unknown);
+    });
 
     const infoSpy = vi.spyOn(log, "info").mockImplementation(() => {});
 

--- a/packages/opencode/test/index.test.ts
+++ b/packages/opencode/test/index.test.ts
@@ -42,7 +42,7 @@ async function initPlugin() {
     worktree: tmpDir,
     serverUrl: new URL("http://localhost:0"),
     $: {} as unknown as PluginInput["$"],
-  } as PluginInput);
+  });
 
   return {
     hooks,

--- a/packages/opencode/test/routing.e2e.test.ts
+++ b/packages/opencode/test/routing.e2e.test.ts
@@ -130,7 +130,7 @@ describe("opencode plugin — e2e routing against a real gateway", () => {
       worktree: process.cwd(),
       serverUrl: new URL("http://localhost:0"),
       $: {} as unknown as PluginInput["$"],
-    } as PluginInput);
+    });
   });
 
   afterAll(async () => {
@@ -198,9 +198,8 @@ describe("opencode plugin — e2e routing against a real gateway", () => {
       provider: { id: "anthropic" },
       message: { id: "msg-1" },
     } as unknown as Parameters<NonNullable<Hooks["chat.headers"]>>[0];
-    const output = { headers: {} as Record<string, string> } as Parameters<
-      NonNullable<Hooks["chat.headers"]>
-    >[1];
+    // oxlint-disable-next-line typescript/no-unnecessary-type-assertion -- Record cast makes headers indexable for the assertions below
+    const output = { headers: {} as Record<string, string> };
 
     await hooks["chat.headers"]?.(input, output);
     expect(output.headers["x-lore-session-id"]).toBe("oc-sess-1");

--- a/packages/opencode/test/session-state.test.ts
+++ b/packages/opencode/test/session-state.test.ts
@@ -53,7 +53,7 @@ async function initPluginForProject(
     worktree: worktree ?? directory,
     serverUrl: new URL("http://localhost:0"),
     $: {} as unknown as PluginInput["$"],
-  } as PluginInput);
+  });
   return hooks;
 }
 
@@ -84,7 +84,7 @@ function buildChatHeadersInput(
     provider: providerID ? { id: providerID } : undefined,
     message: { id: "msg-1" },
   } as unknown as ChatHeadersInput;
-  const output = { headers: {} as Record<string, string> } as ChatHeadersOutput;
+  const output = { headers: {} };
   return { input, output };
 }
 

--- a/packages/opencode/test/tui-silence.test.ts
+++ b/packages/opencode/test/tui-silence.test.ts
@@ -43,7 +43,7 @@ describe("opencode plugin — TUI stderr silencing on activation", () => {
       worktree: process.cwd(),
       serverUrl: new URL("http://localhost:0"),
       $: {} as unknown as PluginInput["$"],
-    } as PluginInput);
+    });
 
     expect(log.isStderrSilenced()).toBe(true);
   });

--- a/packages/pi/test/extension.e2e.test.ts
+++ b/packages/pi/test/extension.e2e.test.ts
@@ -162,13 +162,13 @@ describe("pi extension — e2e against a real gateway", () => {
     const before = mock.registrations.length;
     const onStart = mock.handlers.get("session_start");
     await onStart?.(
-      {} as never,
+      {},
       {
         cwd: process.cwd(),
         sessionManager: {
           getSessionFile: () => "/tmp/lore-pi-e2e-session.json",
         },
-      } as never,
+      },
     );
     const after = mock.registrations.slice(before);
     expect(after.length).toBeGreaterThan(0);
@@ -186,8 +186,8 @@ describe("pi extension — e2e against a real gateway", () => {
           firstKeptEntryId: "e1",
           tokensBefore: 100,
         },
-      } as never,
-      {} as never,
+      },
+      {},
     );
     // The gateway returns 404 session_not_found for a session that never sent
     // a turn; the handler must return undefined (use Pi's default compaction).

--- a/packages/pi/test/no-tui-output.test.ts
+++ b/packages/pi/test/no-tui-output.test.ts
@@ -118,11 +118,11 @@ describe("pi extension — no TUI (stdout/stderr) output", () => {
 
       // session_start: updates the session id and re-registers providers.
       await onStart?.(
-        {} as never,
+        {},
         {
           cwd: process.cwd(),
           sessionManager: { getSessionFile: () => "/tmp/lore-pi-session" },
-        } as never,
+        },
       );
 
       // Compaction → gateway returns 404 session_not_found → graceful fallback.
@@ -133,8 +133,8 @@ describe("pi extension — no TUI (stdout/stderr) output", () => {
             firstKeptEntryId: "entry-1",
             tokensBefore: 100,
           },
-        } as never,
-        {} as never,
+        },
+        {},
       );
       expect(result).toBeUndefined();
 

--- a/packages/pi/test/real-runtime.e2e.test.ts
+++ b/packages/pi/test/real-runtime.e2e.test.ts
@@ -151,12 +151,7 @@ describe("pi extension — e2e against the real Pi runtime", () => {
     const resourceLoader = new DefaultResourceLoader({
       cwd,
       agentDir,
-      extensionFactories: [
-        (pi) =>
-          lorePiExtension(
-            pi as Parameters<typeof lorePiExtension>[0],
-          ) as void | Promise<void>,
-      ],
+      extensionFactories: [(pi) => lorePiExtension(pi)],
     });
 
     // Capture everything written to the terminal across the entire real


### PR DESCRIPTION
## What

First **warn-tail burn-down** PR after the oxc migration (#1277). Removes all 169 `no-unnecessary-type-assertion` findings and promotes the rule `warn` → `error`.

## How

`oxlint --type-aware --fix` removed 169 provably-redundant type assertions across 66 files (compile-time only — zero runtime change).

oxlint's type analysis diverges from tsc in **4 spots** (autofix false positives), handled manually:
- **`vector-worker.ts` / `lat-reader.ts`** — the removal was correct (tsc agreed the cast was redundant), but the autofix left a now-unused type import; dropped `ReadJobConn` / `Root`.
- **`cli-check-vec.test.ts`, `cli-check-read-offload.test.ts`, `opencode/routing.e2e.test.ts`** — restored 4 widening casts on mutable `vi.hoisted` fixtures that get reassigned to wider values elsewhere (oxlint can't see the later mutation), each with a targeted `oxlint-disable` + reason.

## Impact

- Warn tail: **385 → 216**.
- `no-unnecessary-type-assertion` now `error` (enforced).

## Verification

- `pnpm run lint` → 0 errors, 216 warns.
- `pnpm run typecheck` → green (all 5 packages).
- `pnpm test` → **5720 passed**, 0 failures.

---
Part of the warn-tail burn-down series. Remaining `warn` rules to follow (one PR each): `no-base-to-string` (102), `no-non-null-assertion` (55), `unbound-method` (30), `restrict-template-expressions` (15), `no-redundant-type-constituents` (10), `no-explicit-any` (4).
