### PR TITLE
chore(lint): enforce no-explicit-any + no-redundant-type-constituents

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -23,8 +23,8 @@
     "typescript/no-base-to-string": "warn",
     "typescript/unbound-method": "warn",
     "typescript/restrict-template-expressions": "warn",
-    "typescript/no-redundant-type-constituents": "warn",
-    "typescript/no-explicit-any": "warn",
+    "typescript/no-redundant-type-constituents": "error",
+    "typescript/no-explicit-any": "error",
     "typescript/no-non-null-assertion": "warn"
   },
   "ignorePatterns": [

--- a/packages/core/src/db/driver.node.ts
+++ b/packages/core/src/db/driver.node.ts
@@ -8,7 +8,7 @@
 // from this file must go through `#db/driver`. Never import `node:sqlite`
 // directly outside this file — it will break the test runner which runs against src.
 
-import { DatabaseSync } from "node:sqlite";
+import { DatabaseSync, type SQLInputValue } from "node:sqlite";
 import { createHash } from "node:crypto";
 
 const statementCache = new WeakMap<DatabaseSync, Map<string, unknown>>();
@@ -57,12 +57,13 @@ export class Database extends DatabaseSync {
     if (!entry) {
       const stmt = this.prepare(sql);
       entry = {
-        all: (...args: any[]) => stmt.all(...args) as Record<string, unknown>[],
-        get: (...args: any[]) => {
+        all: (...args: SQLInputValue[]) =>
+          stmt.all(...args) as Record<string, unknown>[],
+        get: (...args: SQLInputValue[]) => {
           const result = stmt.get(...args) as Record<string, unknown> | null;
           return result ?? null;
         },
-        run: (...args: any[]) =>
+        run: (...args: SQLInputValue[]) =>
           stmt.run(...args) as { changes: number; lastInsertRowid: bigint },
       };
       map.set(sql, entry);

--- a/packages/gateway/src/batch-queue.ts
+++ b/packages/gateway/src/batch-queue.ts
@@ -88,7 +88,7 @@ export interface BatchProvider {
       providerID: string;
       params: PendingRequest["params"];
     }>,
-  ): Promise<string | "auth-error" | "not-found" | null>;
+  ): Promise<(string & {}) | "auth-error" | "not-found" | null>;
   /** Poll a batch for completion. */
   poll(auth: AuthCredential, batchId: string): Promise<PollResult>;
 }
@@ -397,7 +397,7 @@ async function uploadOpenAIBatchFile(
   baseUrl: string,
   auth: AuthCredential,
   jsonlContent: string,
-): Promise<string | "auth-error" | "not-found" | null> {
+): Promise<(string & {}) | "auth-error" | "not-found" | null> {
   const formData = new FormData();
   formData.append("purpose", "batch");
   formData.append(

--- a/packages/gateway/src/worker-health.ts
+++ b/packages/gateway/src/worker-health.ts
@@ -100,7 +100,7 @@ export type SessionHealth = {
   lastFailureAt: number;
   failureCount: number; // in current sliding window
   reasons: Set<FailureReason>;
-  workerIDs: Set<WorkerID | string>;
+  workerIDs: Set<WorkerID | (string & {})>;
   alertSentAt?: number; // last Sentry message timestamp (debounce)
   exceptionSentAt?: number; // last Sentry exception timestamp (per-hour cap)
 };
@@ -366,7 +366,7 @@ export function clearWorkerPaused(sessionID: string): void {
  */
 export function recordWorkerFailure(
   sessionID: string,
-  workerID: WorkerID | string,
+  workerID: WorkerID | (string & {}),
   reason: FailureReason,
 ): void {
   const t = now();
@@ -651,7 +651,7 @@ export function getWorkerHealth(): Array<{
   lastFailureAt: number;
   sustainedMs: number;
   reasons: FailureReason[];
-  workerIDs: Array<WorkerID | string>;
+  workerIDs: Array<WorkerID | (string & {})>;
   warning: string | null;
 }> {
   const t = now();
@@ -663,7 +663,7 @@ export function getWorkerHealth(): Array<{
     lastFailureAt: number;
     sustainedMs: number;
     reasons: FailureReason[];
-    workerIDs: Array<WorkerID | string>;
+    workerIDs: Array<WorkerID | (string & {})>;
     warning: string | null;
   }> = [];
   for (const entry of state.values()) {
@@ -731,7 +731,7 @@ export function workerHealthSummary(): WorkerHealthSummary {
  */
 export function makeWorkerHealth(
   sessionID: string,
-  workerID: WorkerID | string,
+  workerID: WorkerID | (string & {}),
 ): {
   recordFailure(reason: string): void;
   recordSuccess(): void;

--- a/packages/gateway/test/helpers/harness.ts
+++ b/packages/gateway/test/helpers/harness.ts
@@ -11,7 +11,7 @@
  *   harness.teardown();
  */
 import { unlinkSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { DatabaseSync } from "node:sqlite";
+import { DatabaseSync, type SQLInputValue } from "node:sqlite";
 import type { FixtureEntry } from "../../src/recorder";
 import type { SimulatedCacheTurn } from "./simulated-cache";
 
@@ -178,7 +178,7 @@ export async function createHarness(opts: HarnessOptions): Promise<Harness> {
       const db = new DatabaseSync(dbPath, { readOnly: true });
       try {
         const stmt = db.prepare(sql);
-        return stmt.all(...((params ?? []) as any)) as T[];
+        return stmt.all(...((params ?? []) as SQLInputValue[])) as T[];
       } finally {
         db.close();
       }

--- a/scripts/generate-config-docs.ts
+++ b/scripts/generate-config-docs.ts
@@ -74,7 +74,7 @@ function getShape(schema: ZodTypeAny): Record<string, ZodTypeAny> | null {
  *  wrapper chain (default/optional) to find the most-specific description
  *  — outer wrappers override inner ones. */
 function getDescription(schema: ZodTypeAny): string | undefined {
-  let current: ZodTypeAny | undefined = schema;
+  let current: ZodTypeAny = schema;
   let lastSeen: string | undefined;
   while (current) {
     const desc = (current as { description?: string }).description;


### PR DESCRIPTION
## What

Burn-down PR #2. Fixes and enforces two small type-safety rules (fixed **properly**, no disables).

### `no-explicit-any` (4 → 0)
The node:sqlite variadic bind-param bridges used `any[]`. Typed them with node:sqlite's own exported **`SQLInputValue`** type:
- `packages/core/src/db/driver.node.ts` ×3 (the `all`/`get`/`run` wrappers)
- `packages/gateway/test/helpers/harness.ts` ×1

### `no-redundant-type-constituents` (10 → 0)
Each flagged union collapsed to its base type (e.g. `WorkerID | string` ≡ `string`, since `WorkerID` is a string-literal union). Preserved the documentary intent with the `T | (string & {})` idiom so literal autocomplete / sentinel values survive while the type is honest:
- `worker-health.ts` ×5 → `WorkerID | (string & {})`
- `batch-queue.ts` ×2 → `(string & {}) | "auth-error" | "not-found" | null`
- `generate-config-docs.ts` → dropped meaningless `| undefined` (`ZodTypeAny` acts as `any` and absorbed it)

Both rules promoted `warn` → `error`.

## Impact
- Warn tail: **216 → 202**.

## Verification
- `pnpm run lint` → 0 errors, 202 warns.
- `pnpm run typecheck` → green (all packages; `SQLInputValue` verified against the `StatementSync` API).
- `pnpm test` → **5720 passed**, 0 failures.

---
Warn-tail burn-down series (after #1277, #1281). Remaining: `no-base-to-string` (102), `no-non-null-assertion` (55), `unbound-method` (30), `restrict-template-expressions` (15).
