### PR TITLE
chore(lint): enforce restrict-template-expressions

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -22,7 +22,7 @@
     "typescript/no-unnecessary-type-assertion": "error",
     "typescript/no-base-to-string": "warn",
     "typescript/unbound-method": "warn",
-    "typescript/restrict-template-expressions": "warn",
+    "typescript/restrict-template-expressions": "error",
     "typescript/no-redundant-type-constituents": "error",
     "typescript/no-explicit-any": "error",
     "typescript/no-non-null-assertion": "warn"

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -887,7 +887,7 @@ export async function load(directory: string): Promise<LoreConfig> {
         return current;
       } catch (e) {
         warn(
-          `Failed to parse ${path}: ${e instanceof Error ? e.message : e}. Using defaults.`,
+          `Failed to parse ${path}: ${e instanceof Error ? e.message : String(e)}. Using defaults.`,
         );
       }
     }

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -1592,7 +1592,7 @@ function getProvider(): EmbeddingProvider | null {
       break;
     }
     default:
-      log.info(`unknown embedding provider: ${providerName}`);
+      log.info(`unknown embedding provider: ${String(providerName)}`);
       cachedProvider = null;
   }
 

--- a/packages/gateway/script/smoke-test.ts
+++ b/packages/gateway/script/smoke-test.ts
@@ -163,7 +163,10 @@ try {
     const resp = await fetch(`${BASE}/health`);
     assert(resp.status === 200, `Expected 200, got ${resp.status}`);
     const body = (await resp.json()) as Record<string, unknown>;
-    assert(body.status === "ok", `Expected status "ok", got "${body.status}"`);
+    assert(
+      body.status === "ok",
+      `Expected status "ok", got "${String(body.status)}"`,
+    );
   });
 
   // -----------------------------------------------------------------------
@@ -231,7 +234,7 @@ try {
     const markerBlock = content[0];
     assert(
       markerBlock.type === "text",
-      `First block type should be "text", got "${markerBlock.type}"`,
+      `First block type should be "text", got "${String(markerBlock.type)}"`,
     );
     const markerText = markerBlock.text as string;
     const parsedMarker = parseMarker(markerText);
@@ -245,7 +248,7 @@ try {
     const responseBlock = content[1];
     assert(
       responseBlock.type === "text",
-      `Second block type should be "text", got "${responseBlock.type}"`,
+      `Second block type should be "text", got "${String(responseBlock.type)}"`,
     );
     responseTextFromTest2 = responseBlock.text as string;
     assert(responseTextFromTest2.length > 0, "Response text block is empty");

--- a/packages/gateway/script/vendor-embeddings.ts
+++ b/packages/gateway/script/vendor-embeddings.ts
@@ -55,7 +55,7 @@ async function fetchWithRetry(url: string): Promise<Response> {
       // Network-level failure (DNS, TLS, connection reset)
       if (attempt === MAX_RETRIES) {
         console.error(
-          `✗ network error: ${url} → ${err}` +
+          `✗ network error: ${url} → ${String(err)}` +
             (attempt > 0 ? ` (after ${attempt + 1} attempts)` : ""),
         );
         process.exit(1);

--- a/packages/gateway/src/cache-analytics.ts
+++ b/packages/gateway/src/cache-analytics.ts
@@ -820,7 +820,7 @@ export function analyzeCacheTurn(
         analytics.probePrefixSha = dg.prefixSha;
       }
     } catch (err) {
-      log.warn(`warmup-probe: turn probe failed (ignored): ${err}`);
+      log.warn(`warmup-probe: turn probe failed (ignored): ${String(err)}`);
     }
   }
 

--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -2282,7 +2282,7 @@ export async function executeWarmup(
           );
         }
       } catch (err) {
-        log.warn(`warmup-probe: probe failed (ignored): ${err}`);
+        log.warn(`warmup-probe: probe failed (ignored): ${String(err)}`);
       }
     }
 

--- a/packages/gateway/src/cli/history-cmd.ts
+++ b/packages/gateway/src/cli/history-cmd.ts
@@ -42,7 +42,7 @@ function parseLimit(v: unknown, def: number): number {
   if (v === undefined) return def;
   const n = Number(v);
   if (Number.isInteger(n) && n > 0) return n;
-  console.error(`Ignoring invalid --limit "${v}" (using ${def}).`);
+  console.error(`Ignoring invalid --limit "${String(v)}" (using ${def}).`);
   return def;
 }
 

--- a/packages/gateway/src/cli/import.ts
+++ b/packages/gateway/src/cli/import.ts
@@ -393,7 +393,7 @@ async function importRemote(
       );
     } catch (err) {
       console.error(
-        `[lore] Extraction failed for ${result.agentDisplayName}: ${err instanceof Error ? err.message : err}`,
+        `[lore] Extraction failed for ${result.agentDisplayName}: ${err instanceof Error ? err.message : String(err)}`,
       );
       totalFailed += chunks.length;
       continue;
@@ -421,7 +421,7 @@ async function importRemote(
         });
       } catch (err) {
         console.error(
-          `[lore] Warning: failed to record import on remote: ${err instanceof Error ? err.message : err}`,
+          `[lore] Warning: failed to record import on remote: ${err instanceof Error ? err.message : String(err)}`,
         );
       }
       // Also record locally (belt-and-suspenders)

--- a/packages/gateway/src/cli/main.ts
+++ b/packages/gateway/src/cli/main.ts
@@ -212,7 +212,7 @@ export async function _cli(): Promise<void> {
     positionals = parsed.positionals;
     tokens = parsed.tokens;
   } catch (e) {
-    console.error(`Error: ${e instanceof Error ? e.message : e}`);
+    console.error(`Error: ${e instanceof Error ? e.message : String(e)}`);
     printHelp();
     process.exit(1);
   }

--- a/packages/gateway/src/cli/setup.ts
+++ b/packages/gateway/src/cli/setup.ts
@@ -1368,7 +1368,7 @@ export async function commandSetup(
       chooseSetupPort({ explicitPort, remoteUrl, livePort }),
     );
   } catch (e) {
-    console.error(`[lore] ${e instanceof Error ? e.message : e}`);
+    console.error(`[lore] ${e instanceof Error ? e.message : String(e)}`);
     process.exitCode = 1;
     return;
   }

--- a/packages/gateway/test/sync.test.ts
+++ b/packages/gateway/test/sync.test.ts
@@ -226,7 +226,7 @@ function makeClient() {
               if (k in one && typeof one[k] !== "string")
                 return {
                   code: "22008",
-                  message: `date/time field value out of range: "${one[k]}"`,
+                  message: `date/time field value out of range: "${String(one[k])}"`,
                 };
             }
             const rows = tableRows(table);
@@ -273,7 +273,7 @@ function makeClient() {
               if (k in one && typeof one[k] !== "string")
                 return {
                   code: "22008",
-                  message: `date/time field value out of range: "${one[k]}"`,
+                  message: `date/time field value out of range: "${String(one[k])}"`,
                 };
             }
             const rows = tableRows(table);


### PR DESCRIPTION
## What

Burn-down PR #3. Wraps 15 unsafe template-literal interpolations in `String(...)` and promotes `restrict-template-expressions` `warn` → `error`.

All flagged values were `unknown`/`any` — catch-clause errors used in ternary fallbacks (`e instanceof Error ? e.message : e`) or loosely-typed JSON/record properties. Template literals already `String`-coerce their interpolations, so this is a **type-safety annotation with zero runtime change** (output is byte-identical).

Sites:
- catch-var fallbacks: `config.ts`, `cli/setup.ts`, `cli/main.ts`, `cli/import.ts` ×2
- err/props: `embedding.ts`, `cache-analytics.ts`, `cache-warmer.ts`, `cli/history-cmd.ts`, `script/vendor-embeddings.ts`, `script/smoke-test.ts` ×3, `test/sync.test.ts` ×2

## Impact
- Warn tail: **202 → 187**.

## Verification
- `pnpm run lint` → 0 errors, 187 warns.
- `pnpm run typecheck` → green.
- `pnpm test` → **5720 passed**, 0 failures.

---
Warn-tail burn-down (after #1277, #1281, #1282). Remaining: `no-base-to-string` (102), `no-non-null-assertion` (55), `unbound-method` (30) — the two bug-class rules will get careful per-site review.
