### PR TITLE
fix(gateway): lore doctor treats intentionally-disabled embeddings as PASS, not WARN

### DIFF
--- a/packages/gateway/src/cli/inventory.ts
+++ b/packages/gateway/src/cli/inventory.ts
@@ -435,8 +435,12 @@ export function runDoctorDiagnostics(input: {
   // their own — but the user should know memory is running degraded.
   const emb = input.memoryHealth?.embeddings;
   if (emb) {
+    // `disabled` means the user turned embeddings off (or configured no provider)
+    // on purpose — recall runs FTS-only by design, so that is a PASS, not a
+    // degradation. Only a genuine failure (`unavailable`/`retrying`) is a WARN
+    // whose "reinstall / set a remote provider" remediation actually applies.
     findings.push(
-      emb.available
+      emb.available || emb.state === "disabled"
         ? { level: "PASS", label: "memory: embeddings", detail: emb.detail }
         : {
             level: "WARN",

--- a/packages/gateway/test/doctor.test.ts
+++ b/packages/gateway/test/doctor.test.ts
@@ -218,6 +218,24 @@ describe("runDoctorDiagnostics (pure)", () => {
     expect(f?.level).toBe("PASS");
   });
 
+  it("PASS: embeddings intentionally disabled — no misleading WARN/remediation", () => {
+    const findings = runDoctorDiagnostics({
+      ...baseInput,
+      memoryHealth: {
+        embeddings: {
+          available: false,
+          state: "disabled",
+          detail:
+            "no embedding provider configured (or disabled) — recall uses FTS-only search",
+        },
+      },
+    });
+    const f = findings.find((f) => f.label === "memory: embeddings");
+    expect(f?.level).toBe("PASS");
+    // Must NOT tell the user to reinstall/reconfigure something they turned off.
+    expect(f?.remediation).toBeUndefined();
+  });
+
   it("WARN: embeddings unavailable (FTS-only) with remediation", () => {
     const findings = runDoctorDiagnostics({
       ...baseInput,


### PR DESCRIPTION
## Why

Seer flagged this on the merged #1274 ([discussion r3565058605](https://github.com/BYK/loreai/pull/1274#discussion_r3565058605)). It's a real LOW bug.

When embeddings are turned off **on purpose** — `search.embeddings.enabled: false`, or simply no provider configured — `embeddingStatus()` returns `{ available: false, state: "disabled" }` (recall runs FTS-only by design). But `runDoctorDiagnostics` only branched on `emb.available`, so `lore doctor` showed:

```
WARN  memory: embeddings   ...
      remediation: reinstall Lore so its optional embedding dependency
      (onnxruntime-node) is present, or set search.embeddings.provider ...
```

— telling the user to fix something they intentionally configured.

## What

Treat `state === "disabled"` as **PASS** (with the informative FTS-only detail). Genuine failures (`"unavailable"` / `"retrying"`) still **WARN** with the valid reinstall/remote-provider remediation.

```ts
emb.available || emb.state === "disabled"
  ? { level: "PASS", ... }
  : { level: "WARN", ..., remediation: ... }
```

## Tests

Added a regression test: `disabled` → PASS with no remediation. Mutation-verified (reverting the guard fails the new test). Full `doctor.test.ts` green (30), tsc + biome clean.