### PR TITLE
fix(core): fire remote-backfill reseed event from backfillGitRemotes

### DIFF
--- a/packages/core/src/data.ts
+++ b/packages/core/src/data.ts
@@ -20,6 +20,7 @@ import {
   dbPath,
   mergeProjectInternal,
   invalidateProjectIdCache,
+  fireProjectRemoteBackfilled,
   repoNameFromRemote,
   onProjectMutation,
   loadParentChildMap,
@@ -1698,6 +1699,12 @@ export function backfillGitRemotes(): {
       db()
         .query("UPDATE projects SET git_remote = ? WHERE id = ?")
         .run(gitRemote, project.id);
+      // Mirror ensureProject's inline lazy backfill (db.ts): signal the NULL→set
+      // flip so the sync layer re-seeds content that was gated out while the
+      // project was remote-less (#1246). Without this, a project whose remote is
+      // backfilled through THIS path silently stops being pushed when sync is
+      // enabled. No-op when sync is disabled.
+      fireProjectRemoteBackfilled(project.id);
       updated++;
     }
 

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -49,7 +49,15 @@ export function onProjectRemoteBackfilled(
   onProjectRemoteBackfilledCb = cb;
 }
 
-function fireProjectRemoteBackfilled(projectId: string): void {
+/**
+ * Signal that a project's git_remote just flipped NULL→set. Exported so the
+ * `lore data`-triggered {@link backfillGitRemotes} path (data.ts) can fire the
+ * same reseed side-effect as {@link ensureProject}'s inline lazy backfill —
+ * both must notify the sync layer so content gated out while the project was
+ * remote-less gets re-enqueued (#1246). Safe to call when sync is disabled (the
+ * registered handler no-ops).
+ */
+export function fireProjectRemoteBackfilled(projectId: string): void {
   // git_remote just flipped NULL→set (possibly via a merge inside the backfill),
   // so the project's identity may have changed — drop the memo to be safe.
   invalidateProjectIdCache();

--- a/packages/core/test/backfill-git-remotes.test.ts
+++ b/packages/core/test/backfill-git-remotes.test.ts
@@ -1,0 +1,60 @@
+import { describe, test, expect, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { db, onProjectRemoteBackfilled } from "../src/db";
+import * as git from "../src/git";
+import { backfillGitRemotes } from "../src/data";
+
+// Regression (Seer, PR #1272 review): backfillGitRemotes flips a project
+// NULL→remote via a direct UPDATE. It must fire the remote-backfill event so
+// the sync layer re-seeds content gated out while the project was remote-less
+// (#1246) — exactly like ensureProject's inline lazy backfill does. Without it,
+// a project backfilled through this path silently stops being pushed.
+describe("backfillGitRemotes remote-backfill reseed event (#1246)", () => {
+  let repoDir: string | undefined;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    onProjectRemoteBackfilled(null);
+    if (repoDir) {
+      rmSync(repoDir, { recursive: true, force: true });
+      repoDir = undefined;
+    }
+  });
+
+  test("fires onProjectRemoteBackfilled when it backfills a remote via direct UPDATE", () => {
+    // A real, existing directory — backfillGitRemotes skips non-existent paths.
+    // Mock the on-disk remote so no real git repo is required.
+    repoDir = mkdtempSync(join(tmpdir(), "lore-backfill-evt-"));
+    const dir = repoDir;
+    const remote = "github.com/test/backfill-evt";
+    vi.spyOn(git, "getGitRemote").mockImplementation((p) =>
+      p === dir ? remote : null,
+    );
+
+    // Seed a remote-less project row directly: ensureProject would resolve the
+    // mocked remote immediately, so a raw INSERT reproduces the pre-v14 /
+    // remote-less row that backfillGitRemotes is meant to repair.
+    const id = crypto.randomUUID();
+    db()
+      .query(
+        "INSERT INTO projects (id, path, name, git_remote, created_at) VALUES (?, ?, ?, NULL, ?)",
+      )
+      .run(id, dir, "backfill-evt", Date.now());
+
+    const backfilled: string[] = [];
+    onProjectRemoteBackfilled((pid) => backfilled.push(pid));
+
+    const result = backfillGitRemotes();
+
+    // The remote was set via the direct-UPDATE branch...
+    expect(result.updated).toBe(1);
+    const row = db()
+      .query("SELECT git_remote FROM projects WHERE id = ?")
+      .get(id) as { git_remote: string | null };
+    expect(row.git_remote).toBe(remote);
+    // ...and the reseed event fired for that project (the bug: it did not).
+    expect(backfilled).toContain(id);
+  });
+});


### PR DESCRIPTION
## What

Fixes a **MEDIUM** bug [Seer flagged on PR #1272](https://github.com/BYK/loreai/pull/1272#discussion_r3564955746) (pre-existing, not introduced by #1272).

\`backfillGitRemotes()\` (data.ts) flips a project's \`git_remote\` from NULL→set via a direct \`UPDATE\`, but — unlike \`ensureProject\`'s inline lazy backfill (db.ts:3801) — it never called \`fireProjectRemoteBackfilled\`.

## Why it matters

The sync layer registers \`onProjectRemoteBackfilled(reseedProjectContent)\` (sync-data.ts:1172). That handler re-enqueues content that was **gated out of sync while the project was remote-less** (the P2 git_remote gate, #1246). \`backfillGitRemotes\` is reachable in the gateway process via the dashboard API (\`api.ts:415\`), so with sync enabled, a project whose remote is backfilled through this path would **silently stop being pushed** — its pre-existing knowledge/entities/etc. never get re-seeded.

The two backfill paths were inconsistent: \`ensureProject\` fired the event, \`backfillGitRemotes\` didn't.

## How

- Export \`fireProjectRemoteBackfilled\` from db.ts (it was private).
- Call it after the direct \`UPDATE\` in \`backfillGitRemotes\`, mirroring \`ensureProject\`.

\`reseedProjectContent\` early-returns when sync is disabled, so the call is always safe. It also clears the #1272 project-id memo, which is harmless here (a remote-less row is never cached, so there's nothing stale to serve).

The merge branch of \`backfillGitRemotes\` already fires the event correctly (via \`mergeProjects\` → \`mergeProjectInternal\` → \`fireProjectMutation\`); only the direct-UPDATE branch was missing it.

## Test (mutation-verified)

A dedicated test file (own vitest fork → clean DB, no accumulated projects) seeds a remote-less project row for a real temp dir, mocks \`getGitRemote\` to return a remote, and asserts \`backfillGitRemotes\` fires \`onProjectRemoteBackfilled\` with the project id (and sets the remote via the \`updated\` path). Reverting the fix fails the test.

Full core suite green (2839 passed); oxfmt + oxlint clean; typecheck clean.