### PR TITLE
chore(lint): enforce no-base-to-string (fix 102 unsafe stringifications)

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -20,7 +20,7 @@
     "typescript/no-for-in-array": "error",
     "typescript/no-misused-spread": "error",
     "typescript/no-unnecessary-type-assertion": "error",
-    "typescript/no-base-to-string": "warn",
+    "typescript/no-base-to-string": "error",
     "typescript/unbound-method": "warn",
     "typescript/restrict-template-expressions": "error",
     "typescript/no-redundant-type-constituents": "error",

--- a/packages/core/src/coerce.ts
+++ b/packages/core/src/coerce.ts
@@ -1,0 +1,13 @@
+/**
+ * Coerce a possibly-non-string value (e.g. a field read off parsed-JSON typed as
+ * `unknown`/`Record<string, unknown>`) to a string.
+ *
+ * Returns the value verbatim when it is already a string, otherwise `fallback`
+ * (default `""`). This is the safe replacement for `String(x ?? "")` on loosely
+ * typed protocol fields: identical output for the valid string case, but maps a
+ * malformed object value to `fallback` instead of the useless `"[object Object]"`
+ * (the bug `typescript/no-base-to-string` guards against).
+ */
+export function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -281,6 +281,7 @@ export {
   clearWorkspaceCache,
 } from "./workspace";
 export { workerSessionIDs, isWorkerSession } from "./worker";
+export { asString } from "./coerce";
 export { setReadPathTimingHook, type ReadPathTiming } from "./read-telemetry";
 export {
   recordVecReadLatency,

--- a/packages/core/src/sync-data.ts
+++ b/packages/core/src/sync-data.ts
@@ -17,6 +17,7 @@
  */
 import { createHash } from "node:crypto";
 import { uuidv7 } from "uuidv7";
+import { asString } from "./coerce";
 import {
   db,
   deleteTeamConfig,
@@ -629,6 +630,7 @@ function splitRowId(rowId: string): string[] {
 function serializeValue(v: unknown): string {
   if (v === null || v === undefined) return "\x00";
   if (v instanceof Uint8Array) return Buffer.from(v).toString("base64");
+  // oxlint-disable-next-line typescript/no-base-to-string -- v is a SQLite scalar (number/bigint/string) here; null/Uint8Array handled above
   return String(v);
 }
 
@@ -1333,8 +1335,8 @@ export function applyRemoteUpsert(
  */
 export function applyRemoteProject(row: Record<string, unknown>): void {
   const id = String(row.id);
-  const gitRemote = row.git_remote != null ? String(row.git_remote) : null;
-  const name = row.name != null ? String(row.name) : null;
+  const gitRemote = typeof row.git_remote === "string" ? row.git_remote : null;
+  const name = typeof row.name === "string" ? row.name : null;
   const createdAt = Number(row.created_at) || Date.now();
   withApplying(() => {
     const existing = db()
@@ -1459,7 +1461,7 @@ export function applyRemoteScopeKey(remote: Record<string, unknown>): void {
       ? new Uint8Array(Buffer.from(remote.wrapped_dek, "base64"))
       : new Uint8Array(remote.wrapped_dek as Uint8Array);
   const keyEpoch = Number(remote.key_epoch ?? 0);
-  const updatedAt = Date.parse(String(remote.updated_at ?? "")) || Date.now();
+  const updatedAt = Date.parse(asString(remote.updated_at)) || Date.now();
   withApplying(() =>
     putWrappedScopeKey(scopeId, memberUserId, wrapped, keyEpoch, updatedAt),
   );

--- a/packages/core/test/fetch-interceptor-install.test.ts
+++ b/packages/core/test/fetch-interceptor-install.test.ts
@@ -26,7 +26,12 @@ describe("installFetchInterceptor — end-to-end routing", () => {
     // Stub the underlying fetch so the interceptor calls into our capture.
     realFetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       captured = {
-        url: typeof input === "string" ? input : input.toString(),
+        url:
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.href
+              : input.url,
         init,
       };
       return new Response("ok", { status: 200 });

--- a/packages/gateway/src/cli/history-cmd.ts
+++ b/packages/gateway/src/cli/history-cmd.ts
@@ -15,6 +15,7 @@
  * retention window are gone by design, so `log` shows the kept window.
  */
 import { resolve } from "node:path";
+import { asString } from "@loreai/core";
 
 type KnowledgeVersion = import("@loreai/core").ltm.KnowledgeVersion;
 
@@ -42,7 +43,7 @@ function parseLimit(v: unknown, def: number): number {
   if (v === undefined) return def;
   const n = Number(v);
   if (Number.isInteger(n) && n > 0) return n;
-  console.error(`Ignoring invalid --limit "${String(v)}" (using ${def}).`);
+  console.error(`Ignoring invalid --limit "${asString(v)}" (using ${def}).`);
   return def;
 }
 

--- a/packages/gateway/src/cli/lib/errors.ts
+++ b/packages/gateway/src/cli/lib/errors.ts
@@ -41,6 +41,7 @@ export function stringifyUnknown(value: unknown): string {
     try {
       return JSON.stringify(value);
     } catch {
+      // oxlint-disable-next-line typescript/no-base-to-string -- last-resort fallback when JSON.stringify throws (e.g. circular refs)
       return String(value);
     }
   }

--- a/packages/gateway/src/cli/main.ts
+++ b/packages/gateway/src/cli/main.ts
@@ -13,6 +13,7 @@
  *   help           → print usage
  */
 import { parseArgs } from "node:util";
+import { stringifyUnknown } from "./lib/errors";
 import { printHelp, printVersion } from "./help";
 import { commandStart, type StartOptions } from "./start";
 import {
@@ -258,7 +259,7 @@ export async function _cli(): Promise<void> {
       );
       if (cause)
         console.error(
-          `  cause: ${cause instanceof Error ? (cause.stack ?? cause.message) : String(cause)}`,
+          `  cause: ${cause instanceof Error ? (cause.stack ?? cause.message) : stringifyUnknown(cause)}`,
         );
       process.exit(1);
     }

--- a/packages/gateway/src/fetch.ts
+++ b/packages/gateway/src/fetch.ts
@@ -94,7 +94,13 @@ function nodeHttpFetch(
   init?: RequestInit,
 ): Promise<Response> {
   return new Promise((resolve, reject) => {
-    const url = new URL(typeof input === "string" ? input : input.toString());
+    const url = new URL(
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url,
+    );
     const isHttps = url.protocol === "https:";
     const mod = isHttps ? https : http;
 

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -12,6 +12,7 @@
  *  3. Normal conversation turns → full pipeline.
  */
 import type { LoreMessageWithParts, LLMClient } from "@loreai/core";
+import { asString } from "@loreai/core";
 import {
   load,
   config as loreConfig,
@@ -4420,8 +4421,8 @@ function accumulateOpenAINonStreamJSON(
         }
         content.push({
           type: "tool_use",
-          id: String(tc.id ?? ""),
-          name: String(fn?.name ?? ""),
+          id: asString(tc.id),
+          name: asString(fn?.name),
           input,
         });
       }
@@ -4441,8 +4442,8 @@ function accumulateOpenAINonStreamJSON(
     | undefined;
 
   return {
-    id: String(json.id ?? ""),
-    model: String(json.model ?? ""),
+    id: asString(json.id),
+    model: asString(json.model),
     content,
     stopReason,
     usage: {
@@ -4468,7 +4469,7 @@ export function accumulateResponsesNonStreamJSON(
         if (msgContent) {
           for (const part of msgContent) {
             if (part.type === "output_text") {
-              content.push({ type: "text", text: String(part.text ?? "") });
+              content.push({ type: "text", text: asString(part.text) });
             }
           }
         }
@@ -4483,8 +4484,8 @@ export function accumulateResponsesNonStreamJSON(
         }
         content.push({
           type: "tool_use",
-          id: String(item.call_id ?? item.id ?? ""),
-          name: String(item.name ?? ""),
+          id: asString(item.call_id ?? item.id),
+          name: asString(item.name),
           input,
         });
       }
@@ -4505,8 +4506,8 @@ export function accumulateResponsesNonStreamJSON(
     | undefined;
 
   return {
-    id: String(json.id ?? ""),
-    model: String(json.model ?? ""),
+    id: asString(json.id),
+    model: asString(json.model),
     content,
     stopReason,
     usage: {

--- a/packages/gateway/src/stream/gemini.ts
+++ b/packages/gateway/src/stream/gemini.ts
@@ -20,6 +20,7 @@ import type {
   GatewayUsage,
 } from "../translate/types";
 import { ZERO_USAGE } from "../translate/types";
+import { asString } from "@loreai/core";
 import {
   buildGeminiResponseBody,
   geminiUsageFromMetadata,
@@ -79,7 +80,7 @@ export async function accumulateGeminiSSEStream(
         else textContent += p.text;
       } else if (p.functionCall && typeof p.functionCall === "object") {
         const fc = p.functionCall as { name?: unknown; args?: unknown };
-        toolUses.push({ name: String(fc.name ?? ""), input: fc.args ?? {} });
+        toolUses.push({ name: asString(fc.name), input: fc.args ?? {} });
       }
     }
     if (first.finishReason != null) finishReason = first.finishReason;

--- a/packages/gateway/src/stream/openai-responses.ts
+++ b/packages/gateway/src/stream/openai-responses.ts
@@ -14,7 +14,7 @@
  * Reuses `parseSSEStream` from the Anthropic stream module since the
  * underlying SSE wire format is the same.
  */
-import { log } from "@loreai/core";
+import { asString, log } from "@loreai/core";
 import {
   ZERO_USAGE,
   type GatewayContentBlock,
@@ -95,9 +95,9 @@ export async function accumulateResponsesSSEStream(
         } else if (item.type === "function_call") {
           items.set(outputIndex, {
             type: "tool_use",
-            id: String(item.id ?? ""),
-            callId: String(item.call_id ?? ""),
-            name: String(item.name ?? ""),
+            id: asString(item.id),
+            callId: asString(item.call_id),
+            name: asString(item.name),
             args: "",
           });
         }

--- a/packages/gateway/src/stream/openai.ts
+++ b/packages/gateway/src/stream/openai.ts
@@ -17,7 +17,7 @@
  * events, and `createStreamAccumulator` to build the internal GatewayResponse
  * (for pipeline post-processing that may read it).
  */
-import { log } from "@loreai/core";
+import { asString, log } from "@loreai/core";
 import {
   ZERO_USAGE,
   type GatewayContentBlock,
@@ -415,12 +415,12 @@ export async function accumulateOpenAISSEStream(
             const existing = toolCalls.get(idx);
             if (!existing) {
               toolCalls.set(idx, {
-                id: String(tc.id ?? ""),
-                name: String(fn?.name ?? ""),
-                args: String(fn?.arguments ?? ""),
+                id: asString(tc.id),
+                name: asString(fn?.name),
+                args: asString(fn?.arguments),
               });
             } else {
-              if (fn?.arguments) existing.args += fn.arguments;
+              if (fn?.arguments) existing.args += asString(fn.arguments);
             }
           }
         }

--- a/packages/gateway/src/sync.ts
+++ b/packages/gateway/src/sync.ts
@@ -22,6 +22,7 @@
  *                          skipped).
  */
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { asString } from "@loreai/core";
 import {
   syncData,
   getKV,
@@ -723,7 +724,7 @@ export async function pullOnce(
 
         let advanced = false;
         for (const remote of rows) {
-          const ms = Date.parse(String(remote.updated_at ?? "")) || 0;
+          const ms = Date.parse(asString(remote.updated_at)) || 0;
           const rid = syncData.rowIdOf(meta.table, remote);
           if (ms < cursor.ms || (ms === cursor.ms && rid <= cursor.id))
             continue;
@@ -946,7 +947,7 @@ function applyRemote(
         ? syncData.contentHash(meta.table, localRow)
         : null,
       revision: 0,
-      remote_updated_at: String(remote.updated_at ?? ""),
+      remote_updated_at: asString(remote.updated_at),
     });
     res.pulled++;
     return;
@@ -1055,7 +1056,7 @@ function applyRemote(
     syncData.setSyncState(meta.table, rowId, {
       content_hash: remoteHash,
       revision: typeof remote.revision === "number" ? remote.revision : 0,
-      remote_updated_at: String(remote.updated_at ?? ""),
+      remote_updated_at: asString(remote.updated_at),
     });
     for (const fts of meta.ftsTables) touchedFts.add(fts);
   }

--- a/packages/gateway/src/translate/anthropic.ts
+++ b/packages/gateway/src/translate/anthropic.ts
@@ -13,6 +13,7 @@ import type {
   GatewayTool,
 } from "./types";
 import { forwardClientHeaders, ZERO_USAGE } from "./types";
+import { asString } from "@loreai/core";
 import { extractAuth, authHeaders } from "../auth";
 
 // ---------------------------------------------------------------------------
@@ -47,22 +48,22 @@ const KNOWN_BODY_FIELDS = new Set([
 function toGatewayBlock(block: Record<string, unknown>): GatewayContentBlock {
   switch (block.type) {
     case "text":
-      return { type: "text", text: String(block.text ?? "") };
+      return { type: "text", text: asString(block.text) };
 
     case "thinking":
       return {
         type: "thinking",
-        thinking: String(block.thinking ?? ""),
+        thinking: asString(block.thinking),
         ...(block.signature != null
-          ? { signature: String(block.signature) }
+          ? { signature: asString(block.signature) }
           : undefined),
       };
 
     case "tool_use":
       return {
         type: "tool_use",
-        id: String(block.id ?? ""),
-        name: String(block.name ?? ""),
+        id: asString(block.id),
+        name: asString(block.name),
         input: block.input,
       };
 
@@ -83,7 +84,7 @@ function toGatewayBlock(block: Record<string, unknown>): GatewayContentBlock {
       }
       return {
         type: "tool_result",
-        toolUseId: String(block.tool_use_id ?? ""),
+        toolUseId: asString(block.tool_use_id),
         content,
         ...(block.is_error ? { isError: true } : undefined),
       };
@@ -129,11 +130,13 @@ function normalizeSystem(system: unknown): string {
   if (Array.isArray(system)) {
     return (system as Array<Record<string, unknown>>)
       .filter((block) => block.type === "text")
-      .map((block) => String(block.text ?? ""))
+      .map((block) => asString(block.text))
       .join("\n");
   }
 
-  return String(system);
+  // Unreachable for valid input (system is string | block[] | null per the
+  // Anthropic API); a malformed non-string/array shape normalizes to "".
+  return "";
 }
 
 // ---------------------------------------------------------------------------
@@ -199,7 +202,7 @@ export function parseAnthropicRequest(
   const raw = (body ?? {}) as Record<string, unknown>;
 
   // --- Extract known fields ---
-  const model = String(raw.model ?? "");
+  const model = asString(raw.model);
   const system = normalizeSystem(raw.system);
   const stream = raw.stream === true;
   const maxTokens = typeof raw.max_tokens === "number" ? raw.max_tokens : 4096;
@@ -216,8 +219,8 @@ export function parseAnthropicRequest(
   // --- Tools ---
   const rawTools = Array.isArray(raw.tools) ? raw.tools : [];
   const tools: GatewayTool[] = rawTools.map((t: Record<string, unknown>) => ({
-    name: String(t.name ?? ""),
-    description: String(t.description ?? ""),
+    name: asString(t.name),
+    description: asString(t.description),
     inputSchema: (t.input_schema as Record<string, unknown>) ?? {},
   }));
 
@@ -557,22 +560,22 @@ export function parseAnthropicResponseJSON(
     for (const block of rawContent) {
       switch (block.type) {
         case "text":
-          content.push({ type: "text", text: String(block.text ?? "") });
+          content.push({ type: "text", text: asString(block.text) });
           break;
         case "thinking":
           content.push({
             type: "thinking",
-            thinking: String(block.thinking ?? ""),
+            thinking: asString(block.thinking),
             ...(block.signature
-              ? { signature: String(block.signature) }
+              ? { signature: asString(block.signature) }
               : undefined),
           });
           break;
         case "tool_use":
           content.push({
             type: "tool_use",
-            id: String(block.id ?? ""),
-            name: String(block.name ?? ""),
+            id: asString(block.id),
+            name: asString(block.name),
             input: block.input,
           });
           break;
@@ -588,8 +591,8 @@ export function parseAnthropicResponseJSON(
   const usage = json.usage as Record<string, number> | undefined;
 
   return {
-    id: String(json.id ?? ""),
-    model: String(json.model ?? ""),
+    id: asString(json.id),
+    model: asString(json.model),
     content,
     stopReason: String((json.stop_reason as string) ?? "end_turn"),
     usage: {

--- a/packages/gateway/src/translate/gemini.ts
+++ b/packages/gateway/src/translate/gemini.ts
@@ -28,6 +28,7 @@ import type {
   GatewayUsage,
 } from "./types";
 import { blocksToText, forwardClientHeaders, ZERO_USAGE } from "./types";
+import { asString } from "@loreai/core";
 
 /** Default Gemini API version segment used when building upstream URLs. */
 const GEMINI_API_VERSION = "v1beta";
@@ -65,13 +66,13 @@ function partToBlock(part: GeminiPart): GatewayContentBlock | null {
   }
   if (part.functionCall && typeof part.functionCall === "object") {
     const fc = part.functionCall as { name?: unknown; args?: unknown };
-    const name = String(fc.name ?? "");
+    const name = asString(fc.name);
     // Gemini has no per-call id; pair by NAME (see file header).
     return { type: "tool_use", id: name, name, input: fc.args ?? {} };
   }
   if (part.functionResponse && typeof part.functionResponse === "object") {
     const fr = part.functionResponse as { name?: unknown; response?: unknown };
-    const name = String(fr.name ?? "");
+    const name = asString(fr.name);
     return {
       type: "tool_result",
       toolUseId: name,
@@ -104,7 +105,7 @@ export function parseGeminiRequest(
   const rawContents = Array.isArray(raw.contents) ? raw.contents : [];
   const messages: GatewayMessage[] = [];
   for (const c of rawContents as Array<Record<string, unknown>>) {
-    const geminiRole = String(c.role ?? "user");
+    const geminiRole = asString(c.role, "user");
     // Gemini roles: "model" → assistant; "user"/"function" → user.
     const role: "user" | "assistant" =
       geminiRole === "model" ? "assistant" : "user";
@@ -126,8 +127,8 @@ export function parseGeminiRequest(
       : [];
     for (const d of decls) {
       tools.push({
-        name: String(d.name ?? ""),
-        description: String(d.description ?? ""),
+        name: asString(d.name),
+        description: asString(d.description),
         inputSchema: (d.parameters as Record<string, unknown>) ?? {},
       });
     }
@@ -287,7 +288,7 @@ export function mapGeminiFinishReason(
   reason: unknown,
   hasToolCall: boolean,
 ): string {
-  const r = String(reason ?? "");
+  const r = asString(reason);
   const isNormal =
     r === "" ||
     r === "STOP" ||
@@ -367,12 +368,12 @@ export function parseGeminiResponseJSON(
     | undefined;
   const stopReason =
     candidates.length === 0 && promptFeedback?.blockReason
-      ? String(promptFeedback.blockReason)
+      ? asString(promptFeedback.blockReason)
       : mapGeminiFinishReason(first.finishReason, hasToolCall);
 
   return {
-    id: String(json.responseId ?? ""),
-    model: String(json.modelVersion ?? ""),
+    id: asString(json.responseId),
+    model: asString(json.modelVersion),
     content: blocks,
     stopReason,
     usage: parseGeminiUsage(json),

--- a/packages/gateway/src/translate/openai-responses.ts
+++ b/packages/gateway/src/translate/openai-responses.ts
@@ -10,7 +10,7 @@
  *   - System prompt is in the `instructions` field
  *   - Tools use `parameters` directly (not wrapped in `function`)
  */
-import { log } from "@loreai/core";
+import { asString, log } from "@loreai/core";
 import type {
   GatewayContentBlock,
   GatewayMessage,
@@ -31,7 +31,7 @@ export function parseOpenAIResponsesRequest(
 ): GatewayRequest {
   const raw = (body ?? {}) as Record<string, unknown>;
 
-  const model = String(raw.model ?? "");
+  const model = asString(raw.model);
   const stream = raw.stream === true;
 
   // max_output_tokens defaults to 4096 if not specified
@@ -49,8 +49,8 @@ export function parseOpenAIResponsesRequest(
   const tools: GatewayTool[] = rawTools
     .filter((t: Record<string, unknown>) => t.type === "function")
     .map((t: Record<string, unknown>) => ({
-      name: String(t.name ?? ""),
-      description: String(t.description ?? ""),
+      name: asString(t.name),
+      description: asString(t.description),
       inputSchema: (t.parameters as Record<string, unknown>) ?? {},
     }));
 
@@ -202,8 +202,8 @@ function parseInputItems(input: unknown): GatewayMessage[] {
       // together (and matched by the coalesced tool_result message below).
       const toolUseBlock: GatewayContentBlock = {
         type: "tool_use",
-        id: String(item.call_id ?? item.id ?? ""),
-        name: String(item.name ?? ""),
+        id: asString(item.call_id ?? item.id),
+        name: asString(item.name),
         input: parseArguments(item.arguments),
       };
       const last = messages[messages.length - 1];
@@ -224,10 +224,10 @@ function parseInputItems(input: unknown): GatewayMessage[] {
       // Function output — maps to tool_result. Coalesce consecutive outputs
       // into one user message (see the function_call comment above).
       // Normalize the output string to a block array for consistency.
-      const outputText = String(item.output ?? "");
+      const outputText = asString(item.output);
       const toolResultBlock: GatewayContentBlock = {
         type: "tool_result",
-        toolUseId: String(item.call_id ?? ""),
+        toolUseId: asString(item.call_id),
         content: outputText ? [{ type: "text", text: outputText }] : [],
       };
       const last = messages[messages.length - 1];
@@ -257,7 +257,7 @@ function parseInputItems(input: unknown): GatewayMessage[] {
     // and intentionally dropped — don't warn on those.)
     if (itemType === "item_reference") {
       log.warn(
-        `dropping unresolvable Responses API item_reference (id=${String(item.id ?? "?")}); ` +
+        `dropping unresolvable Responses API item_reference (id=${asString(item.id, "?")}); ` +
           `gateway is stateless full-history and cannot resolve server-side item references`,
       );
     }
@@ -280,7 +280,7 @@ function parseMessageContent(content: unknown): GatewayContentBlock[] {
       part.type === "output_text" ||
       part.type === "text"
     ) {
-      const text = String(part.text ?? "");
+      const text = asString(part.text);
       if (text) blocks.push({ type: "text", text });
     } else {
       // Unknown content part (input_image, input_audio, input_file, …) —

--- a/packages/gateway/src/translate/openai.ts
+++ b/packages/gateway/src/translate/openai.ts
@@ -12,6 +12,7 @@ import type {
   GatewayTool,
 } from "./types";
 import { blocksToText, forwardClientHeaders, ZERO_USAGE } from "./types";
+import { asString } from "@loreai/core";
 import { extractAuth } from "../auth";
 
 // ---------------------------------------------------------------------------
@@ -25,7 +26,7 @@ export function parseOpenAIRequest(
   const raw = (body ?? {}) as Record<string, unknown>;
 
   // Extract known fields
-  const model = String(raw.model ?? "");
+  const model = asString(raw.model);
   const stream = raw.stream === true;
 
   // max_tokens defaults to 4096 if not specified
@@ -74,7 +75,7 @@ export function parseOpenAIRequest(
       } else if (Array.isArray(content)) {
         text = (content as Array<Record<string, unknown>>)
           .filter((b) => b.type === "text")
-          .map((b) => String(b.text ?? ""))
+          .map((b) => asString(b.text))
           .join("\n");
       }
       if (system) {
@@ -135,8 +136,8 @@ export function parseOpenAIRequest(
   const tools: GatewayTool[] = rawTools.map((t: Record<string, unknown>) => {
     const func = t.function as Record<string, unknown> | undefined;
     return {
-      name: String(func?.name ?? t.name ?? ""),
-      description: String(func?.description ?? ""),
+      name: asString(func?.name ?? t.name),
+      description: asString(func?.description),
       inputSchema: (func?.parameters as Record<string, unknown>) ?? {},
     };
   });
@@ -169,12 +170,12 @@ function parseUserContent(
   } else if (Array.isArray(content)) {
     for (const item of content as Array<Record<string, unknown>>) {
       if (item.type === "text") {
-        blocks.push({ type: "text", text: String(item.text ?? "") });
+        blocks.push({ type: "text", text: asString(item.text) });
       } else if (item.type === "tool_use") {
         blocks.push({
           type: "tool_use",
-          id: String(item.id ?? ""),
-          name: String(item.name ?? ""),
+          id: asString(item.id),
+          name: asString(item.name),
           input: item.input ?? {},
         });
       } else {
@@ -199,8 +200,8 @@ function parseUserContent(
       }
       blocks.push({
         type: "tool_use",
-        id: String(tc.id ?? ""),
-        name: String(fn?.name ?? ""),
+        id: asString(tc.id),
+        name: asString(fn?.name),
         input,
       });
     }
@@ -220,12 +221,12 @@ function parseAssistantContent(
   } else if (Array.isArray(content)) {
     for (const item of content as Array<Record<string, unknown>>) {
       if (item.type === "text") {
-        blocks.push({ type: "text", text: String(item.text ?? "") });
+        blocks.push({ type: "text", text: asString(item.text) });
       } else if (item.type === "tool_use") {
         blocks.push({
           type: "tool_use",
-          id: String(item.id ?? ""),
-          name: String(item.name ?? ""),
+          id: asString(item.id),
+          name: asString(item.name),
           input: item.input ?? {},
         });
       } else {
@@ -249,8 +250,8 @@ function parseAssistantContent(
       }
       blocks.push({
         type: "tool_use",
-        id: String(tc.id ?? ""),
-        name: String(fn?.name ?? ""),
+        id: asString(tc.id),
+        name: asString(fn?.name),
         input,
       });
     }
@@ -260,7 +261,7 @@ function parseAssistantContent(
 }
 
 function parseToolResult(msg: Record<string, unknown>): GatewayContentBlock[] {
-  const toolCallId = String(msg.tool_call_id ?? "");
+  const toolCallId = asString(msg.tool_call_id);
   const content = msg.content;
 
   // Normalize tool-result content to a block array so non-text sub-blocks
@@ -271,7 +272,7 @@ function parseToolResult(msg: Record<string, unknown>): GatewayContentBlock[] {
   } else if (Array.isArray(content)) {
     innerBlocks = (content as Array<Record<string, unknown>>).map((item) => {
       if (item.type === "text") {
-        return { type: "text" as const, text: String(item.text ?? "") };
+        return { type: "text" as const, text: asString(item.text) };
       }
       // Unknown sub-block (image_url, …) — preserve as opaque.
       return { type: "opaque" as const, raw: item };
@@ -696,7 +697,7 @@ function buildOpenAIMessages(
           msgRecord.content = contentParts;
         } else {
           msgRecord.content = contentParts
-            .map((p) => String(p.text ?? ""))
+            .map((p) => asString(p.text))
             .join("");
         }
       }

--- a/packages/gateway/src/translate/types.ts
+++ b/packages/gateway/src/translate/types.ts
@@ -11,6 +11,8 @@
  * specific fields the gateway doesn't process live in `metadata`.
  */
 
+import { asString } from "@loreai/core";
+
 // ---------------------------------------------------------------------------
 // Content blocks — discriminated union on `type`
 // ---------------------------------------------------------------------------
@@ -140,7 +142,7 @@ export function isEmptyCompletion(resp: GatewayResponse): boolean {
  * embedding the payload itself — so the placeholder is stable and cheap.
  */
 export function opaquePlaceholder(raw: Record<string, unknown>): string {
-  const type = String(raw.type ?? "unknown");
+  const type = asString(raw.type, "unknown");
   const source = raw.source as Record<string, unknown> | undefined;
   const mediaType =
     (source?.media_type as string | undefined) ??

--- a/packages/gateway/src/ui.ts
+++ b/packages/gateway/src/ui.ts
@@ -40,6 +40,7 @@ import {
   type SessionCosts,
 } from "./cost-tracker";
 import { getActiveSessions, rebindActiveSession } from "./pipeline";
+import { asString } from "@loreai/core";
 import {
   computeWarmingSnapshot,
   getCircuitBreakerSummary,
@@ -3399,9 +3400,9 @@ function pageEntity(id: string): string | null {
   // Metadata edit form
   body += `<h2>Edit Metadata</h2>`;
   body += `<form method="POST" action="/ui/api/update/entity/${esc(entity.id)}/metadata" style="display:flex;flex-direction:column;gap:8px;max-width:500px;">`;
-  body += `<label>Role: <input name="role" value="${esc(String(parsedMeta.role ?? ""))}" style="width:100%;" /></label>`;
-  body += `<label>Description: <input name="description" value="${esc(String(parsedMeta.description ?? ""))}" style="width:100%;" /></label>`;
-  body += `<label>Notes: <textarea name="notes" rows="3" style="width:100%;">${esc(String(parsedMeta.notes ?? ""))}</textarea></label>`;
+  body += `<label>Role: <input name="role" value="${esc(asString(parsedMeta.role))}" style="width:100%;" /></label>`;
+  body += `<label>Description: <input name="description" value="${esc(asString(parsedMeta.description))}" style="width:100%;" /></label>`;
+  body += `<label>Notes: <textarea name="notes" rows="3" style="width:100%;">${esc(asString(parsedMeta.notes))}</textarea></label>`;
   body += `<button type="submit">Save Metadata</button>`;
   body += `</form>`;
 

--- a/packages/gateway/test/copilot-routing.e2e.test.ts
+++ b/packages/gateway/test/copilot-routing.e2e.test.ts
@@ -17,6 +17,7 @@
  * overridden to invoke the real (mocked) request so the URL flows into the mock.
  */
 import { describe, test, expect, afterEach, vi } from "vitest";
+import { fetchArgUrl } from "./helpers/fetch-url";
 
 vi.mock("../src/fetch", () => ({ upstreamFetch: vi.fn() }));
 
@@ -79,7 +80,7 @@ async function captureUpstreamUrl(
   await res.text().catch(() => undefined);
 
   expect(mockFetch).toHaveBeenCalled();
-  return String(mockFetch.mock.calls[0][0]);
+  return fetchArgUrl(mockFetch.mock.calls[0][0]);
 }
 
 describe("Copilot-Integration-Id → github-copilot upstream routing", () => {

--- a/packages/gateway/test/gemini-ingress.e2e.test.ts
+++ b/packages/gateway/test/gemini-ingress.e2e.test.ts
@@ -11,6 +11,7 @@
  *     is native Gemini (`candidates`).
  */
 import { describe, test, expect, afterEach, vi } from "vitest";
+import { fetchArgUrl } from "./helpers/fetch-url";
 
 vi.mock("../src/fetch", () => ({ upstreamFetch: vi.fn() }));
 
@@ -76,7 +77,7 @@ async function sendGemini(
   expect(mockFetch).toHaveBeenCalled();
   const call = mockFetch.mock.calls[0];
   return {
-    upstreamUrl: String(call[0]),
+    upstreamUrl: fetchArgUrl(call[0]),
     upstreamBody: (call[1] as { body?: unknown } | undefined)?.body,
     upstreamHeaders: (
       call[1] as { headers?: Record<string, string> } | undefined

--- a/packages/gateway/test/github-copilot-url.e2e.test.ts
+++ b/packages/gateway/test/github-copilot-url.e2e.test.ts
@@ -12,6 +12,7 @@
  * the resolved url) so the mocked fetch runs and records the destination.
  */
 import { describe, test, expect, afterEach, vi } from "vitest";
+import { fetchArgUrl } from "./helpers/fetch-url";
 
 vi.mock("../src/fetch", () => ({ upstreamFetch: vi.fn() }));
 
@@ -71,7 +72,7 @@ async function captureUpstreamUrl(
   await res.text().catch(() => undefined);
 
   expect(mockFetch).toHaveBeenCalled();
-  return String(mockFetch.mock.calls[0][0]);
+  return fetchArgUrl(mockFetch.mock.calls[0][0]);
 }
 
 describe("github-copilot upstream URL — full pipeline wiring (#1052)", () => {

--- a/packages/gateway/test/helpers/fetch-url.ts
+++ b/packages/gateway/test/helpers/fetch-url.ts
@@ -1,0 +1,14 @@
+/**
+ * Extract the URL string from a fetch mock's first argument.
+ *
+ * `fetch`'s first parameter is `string | URL | Request` (`RequestInfo | URL`).
+ * Stringifying it directly risks `"[object Request]"`, so narrow each case to a
+ * real string (mirrors the production logic in `src/fetch.ts`). Accepts
+ * `undefined` (e.g. `mockFetch.mock.calls[0]?.[0]`) and maps it to `""`.
+ */
+export function fetchArgUrl(input: RequestInfo | URL | undefined): string {
+  if (input == null) return "";
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.href;
+  return input.url;
+}

--- a/packages/gateway/test/llm-adapter.test.ts
+++ b/packages/gateway/test/llm-adapter.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import { fetchArgUrl } from "./helpers/fetch-url";
 
 // Mock the upstream fetch wrapper so the adapter's retry loop is driven by our
 // stubbed responses regardless of whether a fetch interceptor is installed on
@@ -1004,7 +1005,7 @@ describe("cross-provider collusion guard", () => {
     // The invariant: if any upstream call was made, it must NOT be to the
     // Anthropic direct endpoint with the minimax model.
     for (const call of mockFetch.mock.calls) {
-      const url = String(call[0]);
+      const url = fetchArgUrl(call[0]);
       expect(url).not.toContain("api.anthropic.com");
     }
   });
@@ -1066,7 +1067,7 @@ describe("cross-provider collusion guard", () => {
 
     expect(result).toBe("minimax reply");
     expect(mockFetch).toHaveBeenCalledTimes(1);
-    const url = String(mockFetch.mock.calls[0][0]);
+    const url = fetchArgUrl(mockFetch.mock.calls[0][0]);
     // minimax PROVIDER_ROUTES url is https://api.minimax.io/anthropic
     expect(url).toContain("api.minimax.io");
     expect(url).not.toContain("api.anthropic.com");
@@ -1154,7 +1155,7 @@ describe("cross-provider collusion guard", () => {
     });
 
     for (const call of mockFetch.mock.calls) {
-      expect(String(call[0])).not.toContain("api.anthropic.com");
+      expect(fetchArgUrl(call[0])).not.toContain("api.anthropic.com");
     }
   });
 });

--- a/packages/gateway/test/recompress-scope.test.ts
+++ b/packages/gateway/test/recompress-scope.test.ts
@@ -19,6 +19,7 @@
  * intercept it). Fully hermetic: no real network, DNS/hosts, or TLS.
  */
 import { describe, it, expect, afterEach } from "vitest";
+import { asString } from "@loreai/core";
 import { MockAgent } from "undici";
 import { zstdCompressSync, zstdDecompressSync } from "node:zlib";
 import type { Harness } from "./helpers/harness";
@@ -36,7 +37,7 @@ function toBuffer(body: unknown): Buffer {
   if (Buffer.isBuffer(body)) return body;
   if (typeof body === "string") return Buffer.from(body);
   if (body instanceof Uint8Array) return Buffer.from(body);
-  return Buffer.from(String(body ?? ""));
+  return Buffer.from(asString(body));
 }
 
 describe("upstream re-compression scoping (#1032 follow-up, wire-level)", () => {

--- a/packages/gateway/test/worker-cross-provider.test.ts
+++ b/packages/gateway/test/worker-cross-provider.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import { fetchArgUrl } from "./helpers/fetch-url";
 
 // Structural / property-based guard against CROSS-PROVIDER COLLUSION on worker
 // calls. This is the permanent regression net for the production incident where
@@ -143,7 +144,7 @@ describe("worker cross-provider routing matrix (structural guard)", () => {
         // THE INVARIANT: no request may go to a direct provider host that the
         // worker model does NOT belong to.
         for (const call of mockFetch.mock.calls) {
-          const url = String(call[0]);
+          const url = fetchArgUrl(call[0]);
           for (const host of DIRECT_HOSTS) {
             const belongsToWorker = wp.ownHost === host;
             if (!belongsToWorker) {
@@ -158,7 +159,7 @@ describe("worker cross-provider routing matrix (structural guard)", () => {
         // a foreign host, this fails. Unknown/unroutable providers fail closed.
         if (wp.ownHost) {
           expect(mockFetch).toHaveBeenCalledTimes(1);
-          expect(String(mockFetch.mock.calls[0][0])).toContain(wp.ownHost);
+          expect(fetchArgUrl(mockFetch.mock.calls[0][0])).toContain(wp.ownHost);
         } else {
           expect(mockFetch).not.toHaveBeenCalled();
         }

--- a/packages/gateway/test/worker-gemini-path.test.ts
+++ b/packages/gateway/test/worker-gemini-path.test.ts
@@ -12,6 +12,7 @@
  * curation for gemini sessions with zero test failure.
  */
 import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import { fetchArgUrl } from "./helpers/fetch-url";
 
 vi.mock("../src/fetch", () => ({ upstreamFetch: vi.fn() }));
 
@@ -61,11 +62,11 @@ async function runWorker(cred: AuthCredential | null) {
   const call = mockFetch.mock.calls[0];
   return {
     result,
-    url: String(call?.[0]),
+    url: fetchArgUrl(call?.[0]),
     headers: (call?.[1] as { headers?: Record<string, string> } | undefined)
       ?.headers,
     body: JSON.parse(
-      String((call?.[1] as { body?: unknown } | undefined)?.body ?? "{}"),
+      String((call?.[1] as { body?: string } | undefined)?.body ?? "{}"),
     ) as Record<string, unknown>,
   };
 }

--- a/packages/gateway/test/worker-github-copilot.test.ts
+++ b/packages/gateway/test/worker-github-copilot.test.ts
@@ -6,6 +6,7 @@
  * `buildOpenAIChatCompletionsUrl`.
  */
 import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import { fetchArgUrl } from "./helpers/fetch-url";
 
 vi.mock("../src/fetch", () => ({ upstreamFetch: vi.fn() }));
 
@@ -60,7 +61,7 @@ describe("worker github-copilot URL (#1052)", () => {
     });
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
-    const url = String(mockFetch.mock.calls[0][0]);
+    const url = fetchArgUrl(mockFetch.mock.calls[0][0]);
     expect(url).toBe("https://api.githubcopilot.com/chat/completions");
     expect(url).not.toContain("/v1/chat/completions");
   });

--- a/packages/gateway/test/worker-google-openai-path.test.ts
+++ b/packages/gateway/test/worker-google-openai-path.test.ts
@@ -7,6 +7,7 @@
  * reconstructed host-aware by `buildOpenAIChatCompletionsUrl`.
  */
 import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import { fetchArgUrl } from "./helpers/fetch-url";
 
 vi.mock("../src/fetch", () => ({ upstreamFetch: vi.fn() }));
 
@@ -61,7 +62,7 @@ describe("worker google URL (#1070)", () => {
     });
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
-    const url = String(mockFetch.mock.calls[0][0]);
+    const url = fetchArgUrl(mockFetch.mock.calls[0][0]);
     expect(url).toBe(
       "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions",
     );

--- a/packages/gateway/test/worker-zai-openai-path.test.ts
+++ b/packages/gateway/test/worker-zai-openai-path.test.ts
@@ -11,6 +11,7 @@
  * a version-suffixed base.
  */
 import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import { fetchArgUrl } from "./helpers/fetch-url";
 
 vi.mock("../src/fetch", () => ({ upstreamFetch: vi.fn() }));
 
@@ -68,7 +69,7 @@ describe("worker zai URL (#1093)", () => {
     });
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
-    const url = String(mockFetch.mock.calls[0][0]);
+    const url = fetchArgUrl(mockFetch.mock.calls[0][0]);
     expect(url).toBe(`${ZAI_BASE}/chat/completions`);
     expect(url).not.toContain("/v4/v1/chat/completions");
   });
@@ -90,7 +91,7 @@ describe("worker zai URL (#1093)", () => {
     });
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
-    const url = String(mockFetch.mock.calls[0][0]);
+    const url = fetchArgUrl(mockFetch.mock.calls[0][0]);
     expect(url).toBe(`${ZAI_BASE}/chat/completions`);
   });
 });

--- a/scripts/generate-config-docs.ts
+++ b/scripts/generate-config-docs.ts
@@ -199,6 +199,7 @@ function formatDefault(value: unknown): string {
   if (typeof value === "string") return `\`"${value}"\``;
   if (value === null) return "`null`";
   if (typeof value === "object") return `\`${JSON.stringify(value)}\``;
+  // oxlint-disable-next-line typescript/no-base-to-string -- value is a non-object primitive here (string/null/object handled above)
   return `\`${String(value)}\``;
 }
 


### PR DESCRIPTION
## What

Burn-down PR #4 — the **bug-class** rule. Promotes `no-base-to-string` `warn` → `error` after fixing all 102 sites (concentrated in the LLM protocol translation path).

## Core change: `asString` helper
Adds `asString(v, fallback = "")` to `@loreai/core` — the safe replacement for `String(x ?? "")` on loosely-typed (parsed-JSON `unknown`) protocol fields. **Identical output for the valid string case**; maps a malformed object to `fallback` instead of the useless `"[object Object]"`. Applied to ~85 string protocol fields across `translate/{anthropic,openai,openai-responses,gemini}`, `stream/*`, `pipeline.ts`, `ui.ts`, `sync.ts`, and `core/sync-data.ts`.

## Two real robustness bugs the rule surfaced
1. **`fetch.ts` `nodeHttpFetch()`** — a `Request` first-arg would stringify to `"[object Request]"` and **throw** in `new URL(...)`. Now narrows `string | URL | Request` via `.url`/`.href`. Mirrored in the fetch-interceptor test capture + a shared `fetchArgUrl` test helper used by the 9 fetch-assertion tests.
2. **`cli/main.ts`** — `String(cause)` → the existing `stringifyUnknown` helper.

## Judgment calls (behavior-preserving)
- `normalizeSystem()` unreachable non-string/array fallback → `""` (malformed input).
- `updated_at` (sync/sync-data): `asString` inside `Date.parse` — always a string on pull per the sync design; a numeric value would already yield the same `|| 0` / `|| Date.now()`.
- `serializeValue` (SQLite scalar), `errors.ts` last-resort `catch`, config-doc script primitive: targeted `oxlint-disable` with a reason.

## Impact
- Warn tail: **187 → 85**. Remaining `no-non-null-assertion` (55, test idiom) and `unbound-method` (30, oxlint `this`-analysis false positives) intentionally stay `warn`.

## Verification
- `pnpm run lint` → 0 errors, 85 warns.
- `pnpm run typecheck` → green (all packages).
- `pnpm test` → **5720 passed**, 0 failures.

> Given this touches the proxy translation hot path, I'm running an adversarial correctness review before merge.
