### PR TITLE
fix(responses): extract text from structured function_call_output.output

### DIFF
--- a/packages/gateway/src/translate/openai-responses.ts
+++ b/packages/gateway/src/translate/openai-responses.ts
@@ -223,12 +223,17 @@ function parseInputItems(input: unknown): GatewayMessage[] {
     if (itemType === "function_call_output") {
       // Function output — maps to tool_result. Coalesce consecutive outputs
       // into one user message (see the function_call comment above).
-      // Normalize the output string to a block array for consistency.
-      const outputText = asString(item.output);
+      //
+      // `output` is usually a plain string, but the Responses API also allows
+      // an array of content parts (e.g. `output_text`, plus multimodal parts
+      // for tool results). Reuse parseMessageContent so the string form yields
+      // a single text block (unchanged) while the array form extracts its text
+      // parts and preserves any non-text parts as opaque blocks — rather than
+      // flattening the whole array to "".
       const toolResultBlock: GatewayContentBlock = {
         type: "tool_result",
         toolUseId: asString(item.call_id),
-        content: outputText ? [{ type: "text", text: outputText }] : [],
+        content: parseMessageContent(item.output),
       };
       const last = messages[messages.length - 1];
       const lastIsToolResultMessage =

--- a/packages/gateway/test/openai-responses.test.ts
+++ b/packages/gateway/test/openai-responses.test.ts
@@ -127,6 +127,56 @@ describe("parseOpenAIResponsesRequest", () => {
     ]);
   });
 
+  test("extracts text from a structured (array) function_call_output.output", () => {
+    // The Responses API also allows `output` to be an array of content parts
+    // instead of a plain string. Its text must be extracted (not flattened to
+    // "") and any non-text parts preserved as opaque blocks.
+    const req = parseOpenAIResponsesRequest(
+      {
+        model: "gpt-4o",
+        input: [
+          { type: "message", role: "user", content: "read the chart" },
+          {
+            type: "function_call",
+            call_id: "call_img",
+            name: "read",
+            arguments: "{}",
+          },
+          {
+            type: "function_call_output",
+            call_id: "call_img",
+            output: [
+              { type: "output_text", text: "chart summary" },
+              {
+                type: "input_image",
+                image_url: "data:image/png;base64,AAA",
+              },
+            ],
+          },
+        ],
+      },
+      headers,
+    );
+
+    expect(req.messages[2].role).toBe("user");
+    expect(req.messages[2].content).toEqual([
+      {
+        type: "tool_result",
+        toolUseId: "call_img",
+        content: [
+          { type: "text", text: "chart summary" },
+          {
+            type: "opaque",
+            raw: {
+              type: "input_image",
+              image_url: "data:image/png;base64,AAA",
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
   test("coalesces parallel function_call items into one assistant message", () => {
     const req = parseOpenAIResponsesRequest(
       {


### PR DESCRIPTION
## What

Closes #1289 (follow-up from PR #1288 adversarial review, finding N1).

The OpenAI Responses API allows a `function_call_output`'s `output` to be an **array of content parts**, not just a plain string. The parse path used `asString(item.output)`, which flattened any array to `""` — silently dropping the tool result.

Fix: reuse the existing `parseMessageContent` helper:
- **string output** → single text block (identical to before)
- **`""` / null / non-array** → `[]` (identical to before)
- **array output** → extracts `output_text`/`text` parts and preserves non-text parts (e.g. images) as `opaque` blocks

This matches `GatewayToolResultBlock.content`'s documented lossless-round-trip design (non-text sub-blocks survive the gateway).

## Behavior
No change for the current string/empty/null cases (the common path, incl. Codex). The array case now round-trips instead of being dropped.

## Testing
- Added a regression test for the array-output case (text + multimodal opaque part).
- **Mutation-verified**: reverting to the old `asString` behavior fails the new test (non-vacuous).
- `pnpm run lint` → 0 errors; `pnpm run typecheck` → green; `pnpm test` → full suite passes, 0 failures.
