### PR TITLE
docs(lint): document why unbound-method and no-non-null-assertion stay warn

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -21,10 +21,19 @@
     "typescript/no-misused-spread": "error",
     "typescript/no-unnecessary-type-assertion": "error",
     "typescript/no-base-to-string": "error",
+    // warn (intentionally not error): oxlint's unbound-method has no this-usage
+    // analysis (unlike typescript-eslint), so every current hit is a false
+    // positive — pure node-builtin destructuring (`const { join } =
+    // require("node:path")`) and vitest spy inspections (`expect(obj.method)`).
+    // Enforcing would mean ~30 useless disables. Revisit if oxlint adds
+    // this-checking. See PR #1288 discussion.
     "typescript/unbound-method": "warn",
     "typescript/restrict-template-expressions": "error",
     "typescript/no-redundant-type-constituents": "error",
     "typescript/no-explicit-any": "error",
+    // warn (intentionally not error): 54/55 current hits are idiomatic `!` in
+    // tests where the value is known to exist. Enforcing would add churn/
+    // disables for ~zero real bug-catching. Kept visible as advisory.
     "typescript/no-non-null-assertion": "warn"
   },
   "ignorePatterns": [


### PR DESCRIPTION
## What

The two remaining `warn`-tier rules in `.oxlintrc.json` were left non-`error` deliberately, but the reasoning lived only in PR descriptions (#1288) — invisible to anyone reading or editing the config. This adds inline JSONC comments next to each rule so the rationale is discoverable at the point of decision:

- **`unbound-method`** — oxlint has no `this`-usage analysis (unlike typescript-eslint), so all current hits are false positives (node-builtin destructuring, vitest spy inspections). Revisit if oxlint adds `this`-checking.
- **`no-non-null-assertion`** — 54/55 hits are idiomatic `!` in tests where the value is known to exist.

## Safety
- oxlint tolerates JSONC comments — verified the config still parses with **0 lint errors**.
- Nothing parses `.oxlintrc.json` as strict JSON (only a `dorny/paths-filter` glob string references the filename).

Comment/config-only change; no source or behavior changes.
