### PR TITLE
feat(core): default knowledge.contextSources to ["distillation"] for reliable cross-session fact application

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -297,13 +297,21 @@ export const LoreConfig = z.object({
        *  the context-bound (system[2]) injection so in-session facts are "just
        *  there" without the model calling the recall tool. Scored on the same
        *  cosine scale as knowledge and packed under the same stickyIds
-       *  hysteresis so the prompt cache stays stable. Empty = off (default);
-       *  example: ["distillation","temporal"]. */
+       *  hysteresis so the prompt cache stays stable.
+       *
+       *  Default: ["distillation"]. Cross-session facts survive in gen-0
+       *  distillations the moment a session is distilled — well before the
+       *  slower curation path promotes them to durable knowledge. Folding
+       *  distillations in gives those facts a path into system[2] without
+       *  waiting on promotion, which is what actually makes offhand facts get
+       *  applied on cheaper models (application tracks presence in system[2],
+       *  not any salience treatment). Raw "temporal" stays opt-in — it is
+       *  larger and noisier. Empty = off. */
       contextSources: z
         .array(z.enum(["distillation", "temporal"]))
-        .default([])
+        .default(["distillation"])
         .describe(
-          "Fold relevance-ranked distillation/temporal memory into the context-bound injection so facts are passively present (no recall tool needed). Empty = off. Default: [].",
+          'Fold relevance-ranked distillation/temporal memory into the context-bound injection so facts are passively present (no recall tool needed). Default: ["distillation"]; add "temporal" for raw messages; [] = off.',
         ),
     })
     .default({
@@ -312,7 +320,7 @@ export const LoreConfig = z.object({
       autoToolFailureGotchas: false,
       outcomeReward: true,
       referenceValidation: true,
-      contextSources: [],
+      contextSources: ["distillation"],
     })
     .describe("Long-term knowledge (curator, entity injection) controls."),
   curator: z

--- a/packages/core/test/config.test.ts
+++ b/packages/core/test/config.test.ts
@@ -70,6 +70,24 @@ describe("LoreConfig — knowledge schema", () => {
     expect(cfg.knowledge.enabled).toBe(false);
   });
 
+  test("knowledge.contextSources defaults to ['distillation'] and is overridable", () => {
+    // Default-on so cross-session facts surface from gen-0 distillations (before
+    // curation promotes them to knowledge) without the model calling recall.
+    expect(LoreConfig.parse({}).knowledge.contextSources).toEqual([
+      "distillation",
+    ]);
+    // Opt into raw temporal too, or turn the whole thing off.
+    expect(
+      LoreConfig.parse({
+        knowledge: { contextSources: ["distillation", "temporal"] },
+      }).knowledge.contextSources,
+    ).toEqual(["distillation", "temporal"]);
+    expect(
+      LoreConfig.parse({ knowledge: { contextSources: [] } }).knowledge
+        .contextSources,
+    ).toEqual([]);
+  });
+
   test("knowledge section is optional — omitting it uses defaults", () => {
     const cfg = LoreConfig.parse({ curator: { enabled: false } });
     expect(cfg.knowledge.enabled).toBe(true);

--- a/packages/website/src/content/docs/docs/configuration.md
+++ b/packages/website/src/content/docs/docs/configuration.md
@@ -121,7 +121,7 @@ Long-term knowledge (curator, entity injection) controls.
 | `autoToolFailureGotchas` | boolean | `false` |  | Auto-create gotcha entries from recurring tool failures. Default false (noisy; can churn the LTM cache). |
 | `outcomeReward` | boolean | `true` |  | Adjust knowledge confidence by within-session verifier (test/build/typecheck/lint) outcomes. Default: true. |
 | `referenceValidation` | boolean | `true` |  | Lower confidence on entries whose file:line / command references no longer resolve against the repo. Unverifiable refs never penalize. Default: true. |
-| `contextSources` | array<enum> | `[]` |  | Fold relevance-ranked distillation/temporal memory into the context-bound injection so facts are passively present (no recall tool needed). Empty = off. Default: []. |
+| `contextSources` | array<enum> | `["distillation"]` |  | Fold relevance-ranked distillation/temporal memory into the context-bound injection so facts are passively present (no recall tool needed). Default: ["distillation"]; add "temporal" for raw messages; [] = off. |
 
 
 ## `curator`


### PR DESCRIPTION
## Why

This is the real fix for roadmap item #1 (offhand-fact application on cheaper models), replacing the reverted no-op salience block (#1276, reverted in #1287).

Live-eval root-cause (MiniMax-M3, `task-pref-combined`): fact **application tracks presence in `system[2]`** — when a code-invisible fact reaches the context-bound block, even a cheaper model applies it verbatim; when it doesn't, 0. The losing runs failed at **selection**: the offhand facts lived in gen-0 distillations but never reached `system[2]`, because curation hadn't yet promoted them to durable knowledge (e.g. one run had 27 distillations, **0 knowledge**).

#1228 already folds relevance-ranked distillation candidates into `system[2]` (cache-stable, bounded by `CONTEXT_SOURCE_LIMIT`, project-scoped) — but it defaulted **off**. Turning it on gives cross-session facts a path into context the moment a session is distilled, without waiting on the slower curation→knowledge→embed→rank pipeline.

## Change

One knob: `knowledge.contextSources` default `[]` → `["distillation"]`. Raw `"temporal"` stays opt-in (larger, noisier); `[]` fully disables.

## Evidence — controlled A/B (same build, same task/harness/model, only the flag differs)

M3, `task-pref-combined`, N=5, `--cap-context 200000`, hardened wait-for-curation settle:

| context-sources | probes | note |
|---|---|---|
| **ON (`["distillation"]`)** | **16/20 (80%)** | 4/4 ×4; one 0/4 where the model invented its own defaults despite the facts being in context (cheaper-model application variance, not selection) |
| OFF (`[]`) | 9/20 (45%) | facts reach context only via curation-promotion or an agent recall call — unreliable on M3 |

+35pp from the one flag. The residual gap to 100% is the model not honoring provided context (same failure mode RESULTS.md documents for Nemotron) — not something any memory layer fixes.

Config test locks the new default + overrides; core `tsc` + `vitest` green.

## Notes
- Cache stability, project-scoping, and overflow-exclusion are already covered by #1228's tests; this only flips the default.
- Eval harness hardening (wait-for-curation settle + `--context-sources` A/B flag) rides on the eval branch (#1211).