### PR TITLE
fix(setup): store JSON config backup in a sidecar file, not a _loreBackup key

### DIFF
--- a/packages/gateway/src/cli/inventory.ts
+++ b/packages/gateway/src/cli/inventory.ts
@@ -12,11 +12,12 @@ import {
   codexConfigPath,
   hermesEnvPath,
   geminiEnvPath,
+  loadJsonSetupBackup,
   opencodeConfigPath,
   piModelsConfigPath,
   readJsonConfig,
 } from "./setup";
-import { getPath, LORE_BACKUP_KEY } from "./setup-backup";
+import { getPath, readLegacyJsonBackup } from "./setup-backup";
 import { getEnvValue, getTomlTopLevelValue } from "./setup-backup";
 import { readPortFile } from "../portfile";
 import { probeGateway } from "./start";
@@ -128,16 +129,10 @@ export function collectClaudeCodeInventory(): AppInventory {
   let hasBackup = false;
   if (fileExists) {
     const cfg = readJsonConfig(file);
-    const backup = cfg[LORE_BACKUP_KEY] as
-      | {
-          entries?: {
-            path: string;
-            priorValue?: unknown;
-            hadPrior?: boolean;
-          }[];
-        }
-      | undefined;
-    hasBackup = backup !== undefined;
+    // Sidecar file is the current backup store; fall back to a legacy in-config
+    // key for installs written by older lore versions.
+    const backup = loadJsonSetupBackup(file) ?? readLegacyJsonBackup(cfg);
+    hasBackup = backup !== null;
     for (const key of ["env.ANTHROPIC_BASE_URL", "env.DISABLE_AUTO_COMPACT"]) {
       const v = getPath(cfg, key);
       const entry = backup?.entries?.find((e) => e.path === key);
@@ -197,7 +192,8 @@ export function collectOpencodeInventory(): AppInventory {
   let hasBackup = false;
   if (fileExists) {
     const cfg = readJsonConfig(file);
-    hasBackup = LORE_BACKUP_KEY in cfg;
+    hasBackup =
+      (loadJsonSetupBackup(file) ?? readLegacyJsonBackup(cfg)) !== null;
     const url = getPath(cfg, "provider.anthropic.options.baseURL");
     rows.push({
       app: "OpenCode",
@@ -231,7 +227,8 @@ export function collectPiInventory(): AppInventory {
   let hasBackup = false;
   if (fileExists) {
     const cfg = readJsonConfig(file);
-    hasBackup = LORE_BACKUP_KEY in cfg;
+    hasBackup =
+      (loadJsonSetupBackup(file) ?? readLegacyJsonBackup(cfg)) !== null;
     // `anthropic` is the representative provider (gateway root). If setup ran,
     // every gateway-routable provider carries a baseUrl; probing one is enough.
     const url = getPath(cfg, "providers.anthropic.baseUrl");

--- a/packages/gateway/src/cli/setup-backup.ts
+++ b/packages/gateway/src/cli/setup-backup.ts
@@ -4,9 +4,13 @@
  * `lore setup` rewrites third-party config files. To make the change
  * reversible (and visible) we record what was there before:
  *
- *  - JSON agents (Claude Code, OpenCode): a top-level `_loreBackup` sidecar
- *    key. We can't use literal `//` comments — the files are strict JSON and
- *    our own `readJsonConfig` does `JSON.parse`, which would throw on comments.
+ *  - JSON agents (Claude Code, OpenCode, Pi): a sidecar *file* next to the
+ *    config (`<config>.lore-backup`). Older versions stored this as a top-level
+ *    `_loreBackup` key *inside* the config, but OpenCode's schema is
+ *    `additionalProperties: false` and rejects unknown keys — that broke
+ *    OpenCode startup ("unknown field `_loreBackup`"), so the backup now lives
+ *    out-of-band. The sidecar file IO lives in setup.ts; the helpers here stay
+ *    pure so the revert logic is unit-testable without touching the filesystem.
  *  - TOML agent (Codex): a `#`-commented backup block at the top of the file
  *    (TOML supports native comments — this is the inline-visible backup).
  *
@@ -130,20 +134,6 @@ export function captureJsonBackup(
   return backup;
 }
 
-/**
- * Attach a backup to a config — but only if one isn't already present, so
- * re-running setup never overwrites the *true* original with lore's own
- * values. Mutates and returns `config`.
- */
-export function attachJsonBackup(
-  config: Record<string, unknown>,
-  backup: JsonBackup,
-): Record<string, unknown> {
-  if (LORE_BACKUP_KEY in config) return config;
-  config[LORE_BACKUP_KEY] = backup;
-  return config;
-}
-
 export interface RestoreSummary {
   hadBackup: boolean;
   restored: string[];
@@ -151,18 +141,38 @@ export interface RestoreSummary {
 }
 
 /**
- * Restore a JSON config from its `_loreBackup` sidecar. Revert-only-if-
- * unchanged: a path is reverted only when its current value still equals what
- * lore wrote. Removes the sidecar key on completion. Mutates `config`.
+ * Read a *legacy* in-config `_loreBackup` key, if present and valid.
+ *
+ * Older lore versions stored the JSON backup as a top-level key inside the
+ * config itself. OpenCode's config schema is `additionalProperties: false`, so
+ * that key makes newer OpenCode reject the whole file ("unknown field
+ * `_loreBackup`") and refuse to start. Backups now live in a sidecar *file*
+ * (see `loadJsonSetupBackup` in setup.ts); this reader exists only so `lore
+ * setup` / `lore setup undo` can migrate (and clean up) installs written by the
+ * old scheme. Pure — does not mutate `config`.
  */
-export function restoreJsonBackup(
+export function readLegacyJsonBackup(
   config: Record<string, unknown>,
-): RestoreSummary {
+): JsonBackup | null {
   const raw = config[LORE_BACKUP_KEY];
-  if (!isPlainObject(raw) || !Array.isArray(raw.entries)) {
-    return { hadBackup: false, restored: [], skipped: [] };
-  }
-  const backup = raw as unknown as JsonBackup;
+  if (!isPlainObject(raw) || !Array.isArray(raw.entries)) return null;
+  return raw as unknown as JsonBackup;
+}
+
+/**
+ * Apply a captured backup to a config, reverting lore's changes. Pure: mutates
+ * and reports on `config`, but never reads or removes any `_loreBackup` key
+ * (backups are stored out-of-band in a sidecar file, and the caller owns that).
+ *
+ * Revert-only-if-unchanged: a path is reverted only when its current value
+ * still equals what lore wrote, so a value the user changed after setup is left
+ * untouched and reported as skipped. `hadBackup` is always true — the caller
+ * supplies a real backup.
+ */
+export function applyJsonBackup(
+  config: Record<string, unknown>,
+  backup: JsonBackup,
+): RestoreSummary {
   const restored: string[] = [];
   const skipped: string[] = [];
 
@@ -192,12 +202,6 @@ export function restoreJsonBackup(
     }
   }
 
-  // Consume the backup only when everything was reverted. If some keys were
-  // skipped (the user changed them after setup), keep the sidecar so their
-  // original values remain recoverable — never silently drop that metadata.
-  if (skipped.length === 0) {
-    delete config[LORE_BACKUP_KEY];
-  }
   return { hadBackup: true, restored, skipped };
 }
 

--- a/packages/gateway/src/cli/setup.ts
+++ b/packages/gateway/src/cli/setup.ts
@@ -14,7 +14,13 @@
  * or accepts an explicit app name (e.g. `lore setup codex`).
  */
 import { execFileSync } from "node:child_process";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { dirname, join } from "node:path";
 import { homedir } from "node:os";
 import { CLAUDE_CODE_FIRST_PARTY_ENV } from "../cch";
@@ -23,8 +29,9 @@ import { detectAgents } from "./agents";
 import { probeGateway } from "./start";
 import {
   captureJsonBackup,
-  attachJsonBackup,
-  restoreJsonBackup,
+  applyJsonBackup,
+  readLegacyJsonBackup,
+  LORE_BACKUP_KEY,
   buildTomlBackupBlock,
   prependTomlBackupBlock,
   restoreTomlBackup,
@@ -33,6 +40,7 @@ import {
   restoreEnvBackup,
   setEnvValueRaw,
   type RestoreSummary,
+  type JsonBackup,
 } from "./setup-backup";
 
 // ---------------------------------------------------------------------------
@@ -616,6 +624,79 @@ function deepMerge(
 }
 
 // ---------------------------------------------------------------------------
+// JSON backup sidecar file (Claude Code, OpenCode, Pi)
+// ---------------------------------------------------------------------------
+//
+// The backup that makes `lore setup` reversible used to live as a top-level
+// `_loreBackup` key inside the JSON config. OpenCode's config schema is
+// `additionalProperties: false`, so that key made newer OpenCode reject the
+// whole file ("unknown field `_loreBackup`") and refuse to start. The backup
+// now lives in a sidecar file next to the config, so the config itself only
+// ever carries schema-valid keys.
+
+/** Path to the sidecar backup file for a JSON config (`<config>.lore-backup`). */
+export function jsonBackupPath(configPath: string): string {
+  return `${configPath}.lore-backup`;
+}
+
+/**
+ * Read + validate the sidecar backup for a JSON config, or null if it is
+ * absent or corrupt. A corrupt sidecar is treated as absent (rather than
+ * throwing) so undo degrades to a no-op and setup won't overwrite it.
+ */
+export function loadJsonSetupBackup(configPath: string): JsonBackup | null {
+  let raw: string;
+  try {
+    raw = readFileSync(jsonBackupPath(configPath), "utf8");
+  } catch (e: unknown) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw e;
+  }
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      parsed !== null &&
+      typeof parsed === "object" &&
+      Array.isArray((parsed as { entries?: unknown }).entries)
+    ) {
+      return parsed as JsonBackup;
+    }
+  } catch {
+    // Corrupt sidecar — fall through and report "no backup".
+  }
+  return null;
+}
+
+/** Remove the sidecar backup file (no-op if it doesn't exist). */
+function removeJsonSetupBackup(configPath: string): void {
+  try {
+    rmSync(jsonBackupPath(configPath));
+  } catch (e: unknown) {
+    if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
+  }
+}
+
+/**
+ * Persist the backup for a JSON config to its sidecar file. Preserves the TRUE
+ * original: if a sidecar already exists it is kept (re-running setup never
+ * overwrites the original with lore's own values); otherwise a migrated
+ * `legacyBackup` (from an old in-config `_loreBackup` key) is written, else the
+ * freshly-captured `freshBackup`.
+ */
+function persistJsonSetupBackup(
+  configPath: string,
+  legacyBackup: JsonBackup | null,
+  freshBackup: JsonBackup,
+): void {
+  if (existsSync(jsonBackupPath(configPath))) return;
+  writeFileSync(
+    jsonBackupPath(configPath),
+    `${JSON.stringify(legacyBackup ?? freshBackup, null, 2)}\n`,
+    "utf8",
+  );
+}
+
+// ---------------------------------------------------------------------------
 // opencode setup
 // ---------------------------------------------------------------------------
 
@@ -721,6 +802,12 @@ function setupOpencode(baseUrl: string, noPlugin: boolean): void {
   mkdirSync(configDir, { recursive: true });
 
   const existing = readJsonConfig(configPath);
+  // Migrate away from any legacy in-config `_loreBackup` key: capture it for the
+  // sidecar, then strip it so every config we write is schema-valid for
+  // OpenCode (its schema is `additionalProperties: false` and rejects unknown
+  // keys — the illegal key made OpenCode refuse to start).
+  const legacyBackup = readLegacyJsonBackup(existing);
+  delete existing[LORE_BACKUP_KEY];
 
   // Values lore is about to set (provider baseURLs + compaction), captured from
   // the ORIGINAL config for the backup's prior values.
@@ -769,10 +856,13 @@ function setupOpencode(baseUrl: string, noPlugin: boolean): void {
   // registration of the plugin in the config), so `pluginInstalled && !pluginAlreadyPresent`
   // accurately reflects whether lore actually added the plugin.
   const finalConfig = readJsonConfig(configPath);
+  // Defensive: never let the schema-invalid key reach OpenCode's config, even
+  // if some earlier write reintroduced it.
+  delete finalConfig[LORE_BACKUP_KEY];
   const backup = captureJsonBackup(existing, loreValues, {
     pluginAdded: pluginInstalled && !pluginAlreadyPresent,
   });
-  attachJsonBackup(finalConfig, backup);
+  persistJsonSetupBackup(configPath, legacyBackup, backup);
   writeFileSync(
     configPath,
     `${JSON.stringify(finalConfig, null, 2)}\n`,
@@ -835,13 +925,15 @@ function setupClaudeCode(baseUrl: string): void {
     : baseUrl;
 
   const existing = readJsonConfig(configPath);
+  const legacyBackup = readLegacyJsonBackup(existing);
+  delete existing[LORE_BACKUP_KEY];
   const backup = captureJsonBackup(existing, {
     "env.ANTHROPIC_BASE_URL": anthropicBaseUrl,
     "env.DISABLE_AUTO_COMPACT": "1",
     [`env.${CLAUDE_CODE_FIRST_PARTY_ENV}`]: "1",
   });
   const updated = updateClaudeCodeSettings(existing, anthropicBaseUrl);
-  attachJsonBackup(updated, backup);
+  persistJsonSetupBackup(configPath, legacyBackup, backup);
   writeFileSync(configPath, `${JSON.stringify(updated, null, 2)}\n`, "utf8");
 
   console.log(`[lore] Claude Code configured to use Lore gateway.`);
@@ -953,6 +1045,8 @@ function setupPi(baseUrl: string): void {
   const root = baseUrl.replace(/\/v1$/, "");
 
   const existing = readJsonConfig(configPath);
+  const legacyBackup = readLegacyJsonBackup(existing);
+  delete existing[LORE_BACKUP_KEY];
 
   // Record the exact values lore is about to set so undo reverts only if the
   // file still holds them (a value the user changed post-setup is left alone).
@@ -966,7 +1060,7 @@ function setupPi(baseUrl: string): void {
 
   const backup = captureJsonBackup(existing, loreValues);
   const updated = updatePiModelsConfig(existing, root);
-  attachJsonBackup(updated, backup);
+  persistJsonSetupBackup(configPath, legacyBackup, backup);
   writeFileSync(configPath, `${JSON.stringify(updated, null, 2)}\n`, "utf8");
 
   const total = PI_ANTHROPIC_PROVIDERS.length + PI_OPENAI_PROVIDERS.length;
@@ -1171,13 +1265,33 @@ function setupGemini(baseUrl: string): void {
 // Undo (`lore setup undo [app]`)
 // ---------------------------------------------------------------------------
 
-/** Restore a JSON-config app (Claude Code, OpenCode) from its `_loreBackup`. */
+/**
+ * Restore a JSON-config app (Claude Code, OpenCode, Pi) from its sidecar
+ * backup — falling back to a legacy in-config `_loreBackup` key, which is
+ * always stripped so a schema-invalid config never lingers. The sidecar is
+ * consumed only when everything was reverted; if the user changed a value
+ * after setup it is kept so their prior value stays recoverable.
+ */
 function undoJsonApp(configPath: string): RestoreSummary {
   const cfg = readJsonConfig(configPath);
-  const summary = restoreJsonBackup(cfg);
-  if (summary.hadBackup) {
-    writeFileSync(configPath, `${JSON.stringify(cfg, null, 2)}\n`, "utf8");
+  const backup = loadJsonSetupBackup(configPath) ?? readLegacyJsonBackup(cfg);
+  const hadLegacyKey = LORE_BACKUP_KEY in cfg;
+
+  if (!backup) {
+    // Nothing to restore. Still strip a stray/legacy key so a schema-invalid
+    // config can't linger (e.g. a corrupt sidecar with an in-config key).
+    if (hadLegacyKey) {
+      delete cfg[LORE_BACKUP_KEY];
+      writeFileSync(configPath, `${JSON.stringify(cfg, null, 2)}\n`, "utf8");
+    }
+    return { hadBackup: false, restored: [], skipped: [] };
   }
+
+  const summary = applyJsonBackup(cfg, backup);
+  // Always drop any legacy in-config backup key (migration cleanup).
+  delete cfg[LORE_BACKUP_KEY];
+  writeFileSync(configPath, `${JSON.stringify(cfg, null, 2)}\n`, "utf8");
+  if (summary.skipped.length === 0) removeJsonSetupBackup(configPath);
   return summary;
 }
 

--- a/packages/gateway/test/setup-backup.test.ts
+++ b/packages/gateway/test/setup-backup.test.ts
@@ -4,8 +4,8 @@ import {
   setPath,
   deletePath,
   captureJsonBackup,
-  attachJsonBackup,
-  restoreJsonBackup,
+  applyJsonBackup,
+  readLegacyJsonBackup,
   LORE_BACKUP_KEY,
   getTomlTopLevelValue,
   deleteTomlTopLevelKey,
@@ -84,31 +84,7 @@ describe("captureJsonBackup", () => {
   });
 });
 
-describe("attachJsonBackup", () => {
-  it("attaches when absent", () => {
-    const cfg: Record<string, unknown> = {};
-    attachJsonBackup(cfg, captureJsonBackup({}, CLAUDE_LORE_VALUES));
-    expect(cfg[LORE_BACKUP_KEY]).toBeDefined();
-  });
-
-  it("does NOT overwrite an existing backup (preserves the true original)", () => {
-    const original = captureJsonBackup(
-      { env: { ANTHROPIC_BASE_URL: "https://api.anthropic.com" } },
-      CLAUDE_LORE_VALUES,
-    );
-    const cfg: Record<string, unknown> = {};
-    attachJsonBackup(cfg, original);
-    // Second setup run: prior now looks like lore's own value — must be ignored.
-    const second = captureJsonBackup(
-      { env: { ANTHROPIC_BASE_URL: "http://127.0.0.1:3207" } },
-      CLAUDE_LORE_VALUES,
-    );
-    attachJsonBackup(cfg, second);
-    expect(cfg[LORE_BACKUP_KEY]).toBe(original);
-  });
-});
-
-describe("restoreJsonBackup", () => {
+describe("applyJsonBackup", () => {
   it("restores prior values and deletes keys that were originally unset", () => {
     // Simulate the post-setup config.
     const cfg: Record<string, unknown> = {
@@ -117,14 +93,11 @@ describe("restoreJsonBackup", () => {
         DISABLE_AUTO_COMPACT: "1",
       },
     };
-    attachJsonBackup(
-      cfg,
-      captureJsonBackup(
-        { env: { ANTHROPIC_BASE_URL: "https://api.anthropic.com" } },
-        CLAUDE_LORE_VALUES,
-      ),
+    const backup = captureJsonBackup(
+      { env: { ANTHROPIC_BASE_URL: "https://api.anthropic.com" } },
+      CLAUDE_LORE_VALUES,
     );
-    const summary = restoreJsonBackup(cfg);
+    const summary = applyJsonBackup(cfg, backup);
     expect(summary.hadBackup).toBe(true);
     expect(summary.restored.sort()).toEqual([
       "env.ANTHROPIC_BASE_URL",
@@ -142,35 +115,27 @@ describe("restoreJsonBackup", () => {
         DISABLE_AUTO_COMPACT: "1",
       },
     };
-    attachJsonBackup(
-      cfg,
-      captureJsonBackup(
-        { env: { ANTHROPIC_BASE_URL: "https://api.anthropic.com" } },
-        CLAUDE_LORE_VALUES,
-      ),
+    const backup = captureJsonBackup(
+      { env: { ANTHROPIC_BASE_URL: "https://api.anthropic.com" } },
+      CLAUDE_LORE_VALUES,
     );
-    const summary = restoreJsonBackup(cfg);
+    const summary = applyJsonBackup(cfg, backup);
     expect(summary.skipped).toContain("env.ANTHROPIC_BASE_URL");
     expect(summary.restored).toContain("env.DISABLE_AUTO_COMPACT");
     // The user's value is preserved.
     expect(getPath(cfg, "env.ANTHROPIC_BASE_URL")).toBe(
       "http://user-changed:9999",
     );
-    // A key was skipped → the sidecar is KEPT so its prior value stays
-    // recoverable (Seer #876 — no metadata loss).
-    expect(LORE_BACKUP_KEY in cfg).toBe(true);
-  });
-
-  it("reports no backup when the sidecar is missing", () => {
-    expect(restoreJsonBackup({ env: {} }).hadBackup).toBe(false);
   });
 
   it("removes a plugin lore appended (OpenCode)", () => {
     const cfg: Record<string, unknown> = {
       plugin: ["@other/plugin", "@loreai/opencode"],
     };
-    attachJsonBackup(cfg, captureJsonBackup({}, {}, { pluginAdded: true }));
-    const summary = restoreJsonBackup(cfg);
+    const summary = applyJsonBackup(
+      cfg,
+      captureJsonBackup({}, {}, { pluginAdded: true }),
+    );
     expect(summary.restored).toContain("plugin[@loreai/opencode]");
     expect(cfg.plugin).toEqual(["@other/plugin"]);
   });
@@ -179,21 +144,27 @@ describe("restoreJsonBackup", () => {
     const cfg: Record<string, unknown> = {
       plugin: ["@loreai/opencode"],
     };
-    attachJsonBackup(cfg, captureJsonBackup({}, {}, { pluginAdded: false }));
-    restoreJsonBackup(cfg);
+    applyJsonBackup(cfg, captureJsonBackup({}, {}, { pluginAdded: false }));
     expect(cfg.plugin).toEqual(["@loreai/opencode"]);
   });
+});
 
-  it("survives a full round-trip and leaves no _loreBackup key", () => {
-    const cfg: Record<string, unknown> = {
-      env: {
-        ANTHROPIC_BASE_URL: "http://127.0.0.1:3207",
-        DISABLE_AUTO_COMPACT: "1",
-      },
-    };
-    attachJsonBackup(cfg, captureJsonBackup({}, CLAUDE_LORE_VALUES));
-    restoreJsonBackup(cfg);
-    expect(LORE_BACKUP_KEY in cfg).toBe(false);
+describe("readLegacyJsonBackup", () => {
+  it("returns a valid legacy in-config backup", () => {
+    const backup = captureJsonBackup(
+      { env: { ANTHROPIC_BASE_URL: "https://api.anthropic.com" } },
+      CLAUDE_LORE_VALUES,
+    );
+    const cfg: Record<string, unknown> = { [LORE_BACKUP_KEY]: backup };
+    expect(readLegacyJsonBackup(cfg)).toEqual(backup);
+  });
+
+  it("returns null when the key is absent or malformed", () => {
+    expect(readLegacyJsonBackup({ env: {} })).toBeNull();
+    expect(readLegacyJsonBackup({ [LORE_BACKUP_KEY]: 42 })).toBeNull();
+    expect(
+      readLegacyJsonBackup({ [LORE_BACKUP_KEY]: { version: 1 } }),
+    ).toBeNull();
   });
 });
 

--- a/packages/gateway/test/setup-io.test.ts
+++ b/packages/gateway/test/setup-io.test.ts
@@ -231,6 +231,59 @@ describe("commandSetup — OpenCode", () => {
     expect(restored._loreBackup).toBeUndefined();
     expect(existsSync(`${ocPath()}.lore-backup`)).toBe(false);
   });
+
+  it("undo restores directly from a legacy in-config _loreBackup (no sidecar)", async () => {
+    // An install written by older lore that has NOT been re-run through setup:
+    // the backup still lives in the config, there is no sidecar. Undo must
+    // restore from it and strip the schema-invalid key.
+    mkdirSync(join(home, ".config", "opencode"), { recursive: true });
+    writeFileSync(
+      ocPath(),
+      JSON.stringify(
+        {
+          provider: {
+            anthropic: { options: { baseURL: "http://127.0.0.1:3207/v1" } },
+          },
+          compaction: { auto: false },
+          _loreBackup: {
+            version: 1,
+            savedAt: "2026-01-01T00:00:00.000Z",
+            entries: [
+              { path: "compaction.auto", loreValue: false, hadPrior: false },
+              {
+                path: "provider.anthropic.options.baseURL",
+                loreValue: "http://127.0.0.1:3207/v1",
+                hadPrior: true,
+                priorValue: "https://api.anthropic.com",
+              },
+            ],
+            pluginAdded: false,
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    await commandSetup(["undo", "opencode"], {});
+
+    const restored = JSON.parse(readFileSync(ocPath(), "utf8"));
+    expect(restored.provider.anthropic.options.baseURL).toBe(
+      "https://api.anthropic.com",
+    );
+    expect(restored._loreBackup).toBeUndefined();
+    // No sidecar was ever created for a legacy-only install.
+    expect(existsSync(`${ocPath()}.lore-backup`)).toBe(false);
+  });
+
+  it("tolerates a corrupt sidecar backup (nothing to undo, no throw)", async () => {
+    mkdirSync(join(home, ".config", "opencode"), { recursive: true });
+    writeFileSync(ocPath(), JSON.stringify({ provider: {} }, null, 2));
+    writeFileSync(`${ocPath()}.lore-backup`, "{ not valid json");
+
+    await commandSetup(["undo", "opencode"], {});
+    expect(logged().toLowerCase()).toContain("no lore backup");
+  });
 });
 
 describe("commandSetup — Pi", () => {

--- a/packages/gateway/test/setup-io.test.ts
+++ b/packages/gateway/test/setup-io.test.ts
@@ -13,6 +13,7 @@ import {
   mkdirSync,
   writeFileSync,
   readFileSync,
+  existsSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -74,7 +75,9 @@ describe("commandSetup — Claude Code", () => {
     const cfg = JSON.parse(readFileSync(claudePath(), "utf8"));
     expect(cfg.env.ANTHROPIC_BASE_URL).toBe("http://127.0.0.1:3299");
     expect(cfg.env.DISABLE_AUTO_COMPACT).toBe("1");
-    expect(cfg._loreBackup).toBeDefined();
+    // Backup lives in a sidecar file, NOT inside the config.
+    expect(cfg._loreBackup).toBeUndefined();
+    expect(existsSync(`${claudePath()}.lore-backup`)).toBe(true);
     // Liveness probe failed (no gateway) → WARN with remediation.
     expect(logged()).toContain("not reachable");
     expect(logged()).toContain("lore start --bg");
@@ -85,6 +88,8 @@ describe("commandSetup — Claude Code", () => {
     expect(restored.env.ANTHROPIC_BASE_URL).toBe("https://api.anthropic.com");
     expect(restored.env.DISABLE_AUTO_COMPACT).toBeUndefined();
     expect(restored._loreBackup).toBeUndefined();
+    // Sidecar consumed once everything was reverted.
+    expect(existsSync(`${claudePath()}.lore-backup`)).toBe(false);
   });
 
   it("detects the live gateway port from the port file (falls back when down)", async () => {
@@ -132,7 +137,11 @@ describe("commandSetup — OpenCode", () => {
       "http://127.0.0.1:3299/v1",
     );
     expect(cfg.compaction).toEqual({ auto: false });
-    expect(cfg._loreBackup).toBeDefined();
+    // The config must NOT carry a `_loreBackup` key — OpenCode's schema is
+    // `additionalProperties: false` and rejects unknown keys (Sergiy report).
+    expect(cfg._loreBackup).toBeUndefined();
+    expect(Object.keys(cfg)).not.toContain("_loreBackup");
+    expect(existsSync(`${ocPath()}.lore-backup`)).toBe(true);
 
     await commandSetup(["undo", "opencode"], {});
 
@@ -142,6 +151,7 @@ describe("commandSetup — OpenCode", () => {
     expect(restored.provider).toBeUndefined();
     expect(restored.compaction).toBeUndefined();
     expect(restored._loreBackup).toBeUndefined();
+    expect(existsSync(`${ocPath()}.lore-backup`)).toBe(false);
   });
 
   it("does NOT remove a plugin lore never added (Seer #876)", async () => {
@@ -149,10 +159,11 @@ describe("commandSetup — OpenCode", () => {
     // false in the backup. If the user adds it themselves afterwards, undo must
     // leave it alone.
     await commandSetup(["opencode"], { port: 3299, noPlugin: true });
-    const cfg = JSON.parse(readFileSync(ocPath(), "utf8"));
-    expect(cfg._loreBackup.pluginAdded).toBe(false);
+    const backup = JSON.parse(readFileSync(`${ocPath()}.lore-backup`, "utf8"));
+    expect(backup.pluginAdded).toBe(false);
 
     // User manually adds the plugin after setup.
+    const cfg = JSON.parse(readFileSync(ocPath(), "utf8"));
     cfg.plugin = ["@loreai/opencode"];
     writeFileSync(ocPath(), JSON.stringify(cfg, null, 2));
 
@@ -160,6 +171,65 @@ describe("commandSetup — OpenCode", () => {
 
     const restored = JSON.parse(readFileSync(ocPath(), "utf8"));
     expect(restored.plugin).toEqual(["@loreai/opencode"]); // preserved
+  });
+
+  it("migrates a legacy in-config _loreBackup out of opencode.json (Sergiy report)", async () => {
+    // Reproduce an install written by older lore: routing values PLUS the
+    // illegal top-level `_loreBackup` key that newer OpenCode rejects with
+    // "unknown field _loreBackup". Use port 3207 so the recorded lore-set
+    // value matches what this setup run writes (revert-only-if-unchanged).
+    mkdirSync(join(home, ".config", "opencode"), { recursive: true });
+    writeFileSync(
+      ocPath(),
+      JSON.stringify(
+        {
+          provider: {
+            anthropic: { options: { baseURL: "http://127.0.0.1:3207/v1" } },
+          },
+          compaction: { auto: false },
+          _loreBackup: {
+            version: 1,
+            savedAt: "2026-01-01T00:00:00.000Z",
+            entries: [
+              { path: "compaction.auto", loreValue: false, hadPrior: false },
+              {
+                path: "provider.anthropic.options.baseURL",
+                loreValue: "http://127.0.0.1:3207/v1",
+                hadPrior: true,
+                priorValue: "https://api.anthropic.com",
+              },
+            ],
+            pluginAdded: false,
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    await commandSetup(["opencode"], { port: 3207, noPlugin: true });
+
+    // The illegal key is stripped → config is schema-valid for OpenCode again.
+    const cfg = JSON.parse(readFileSync(ocPath(), "utf8"));
+    expect(cfg._loreBackup).toBeUndefined();
+    // The TRUE original was migrated to the sidecar (not overwritten by the
+    // fresh capture, which would have recorded lore's own value as the prior).
+    const migrated = JSON.parse(
+      readFileSync(`${ocPath()}.lore-backup`, "utf8"),
+    );
+    const entry = migrated.entries.find(
+      (e: { path: string }) => e.path === "provider.anthropic.options.baseURL",
+    );
+    expect(entry.priorValue).toBe("https://api.anthropic.com");
+
+    // Undo restores the true original and removes the sidecar.
+    await commandSetup(["undo", "opencode"], {});
+    const restored = JSON.parse(readFileSync(ocPath(), "utf8"));
+    expect(restored.provider.anthropic.options.baseURL).toBe(
+      "https://api.anthropic.com",
+    );
+    expect(restored._loreBackup).toBeUndefined();
+    expect(existsSync(`${ocPath()}.lore-backup`)).toBe(false);
   });
 });
 
@@ -200,7 +270,8 @@ describe("commandSetup — Pi", () => {
       baseUrl: "http://localhost:8000",
       models: [],
     });
-    expect(cfg._loreBackup).toBeDefined();
+    expect(cfg._loreBackup).toBeUndefined();
+    expect(existsSync(`${piPath()}.lore-backup`)).toBe(true);
 
     await commandSetup(["undo", "pi"], {});
 
@@ -214,6 +285,7 @@ describe("commandSetup — Pi", () => {
       models: [],
     });
     expect(restored._loreBackup).toBeUndefined();
+    expect(existsSync(`${piPath()}.lore-backup`)).toBe(false);
   });
 });
 

--- a/packages/gateway/test/setup-io.test.ts
+++ b/packages/gateway/test/setup-io.test.ts
@@ -284,6 +284,70 @@ describe("commandSetup — OpenCode", () => {
     await commandSetup(["undo", "opencode"], {});
     expect(logged().toLowerCase()).toContain("no lore backup");
   });
+
+  it("re-running setup never overwrites the TRUE original backup", async () => {
+    mkdirSync(join(home, ".config", "opencode"), { recursive: true });
+    writeFileSync(
+      ocPath(),
+      JSON.stringify(
+        {
+          provider: {
+            anthropic: { options: { baseURL: "https://api.anthropic.com" } },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    await commandSetup(["opencode"], { port: 3299, noPlugin: true });
+    const first = JSON.parse(readFileSync(`${ocPath()}.lore-backup`, "utf8"));
+    const firstEntry = first.entries.find(
+      (e: { path: string }) => e.path === "provider.anthropic.options.baseURL",
+    );
+    expect(firstEntry.priorValue).toBe("https://api.anthropic.com");
+
+    // Second run: the config now holds lore's own value. The sidecar must NOT
+    // be rewritten with lore's value recorded as the "prior".
+    await commandSetup(["opencode"], { port: 3299, noPlugin: true });
+    const second = JSON.parse(readFileSync(`${ocPath()}.lore-backup`, "utf8"));
+    expect(second).toEqual(first);
+  });
+
+  it("keeps the sidecar when the user changed a lore-set value (recoverable)", async () => {
+    mkdirSync(join(home, ".config", "opencode"), { recursive: true });
+    writeFileSync(
+      ocPath(),
+      JSON.stringify(
+        {
+          provider: {
+            anthropic: { options: { baseURL: "https://api.anthropic.com" } },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    await commandSetup(["opencode"], { port: 3299, noPlugin: true });
+
+    // User edits the lore-set anthropic baseURL after setup.
+    const cfg = JSON.parse(readFileSync(ocPath(), "utf8"));
+    cfg.provider.anthropic.options.baseURL = "http://user-changed:9999";
+    writeFileSync(ocPath(), JSON.stringify(cfg, null, 2));
+
+    await commandSetup(["undo", "opencode"], {});
+
+    const restored = JSON.parse(readFileSync(ocPath(), "utf8"));
+    // The user's change is preserved (revert-only-if-unchanged)...
+    expect(restored.provider.anthropic.options.baseURL).toBe(
+      "http://user-changed:9999",
+    );
+    // ...values the user did NOT touch were still reverted...
+    expect(restored.compaction).toBeUndefined();
+    // ...and the sidecar is KEPT so the untouched prior stays recoverable.
+    expect(existsSync(`${ocPath()}.lore-backup`)).toBe(true);
+  });
 });
 
 describe("commandSetup — Pi", () => {


### PR DESCRIPTION
## Problem

Sergiy reported OpenCode failing to start with `unknown field _loreBackup` (opencode `1.17.5`, lore `0.38.0-dev`).

Root cause: `lore setup` writes a top-level `_loreBackup` sidecar **key** into the JSON configs it manages (`setupOpencode` → `attachJsonBackup`). OpenCode's config schema (`https://opencode.ai/config.json`) declares **`"additionalProperties": false"`** on the top-level `Config` object, so newer OpenCode rejects the whole file and refuses to start. Older OpenCode silently ignored unknown keys, which is why this is newly visible. The same key is shared with Claude Code (`settings.json`) and Pi (`models.json`) — stashing a key inside a schema-validated config is fundamentally unsafe.

It is **not** the `@loreai/opencode` plugin — that only mutates the in-memory config at runtime and never writes `_loreBackup` to disk.

## Fix

Move the reversibility backup out of the config into a **sidecar file** next to it (`<config>.lore-backup`), for all JSON-config apps (one consistent mechanism). Every config `lore setup` writes now carries only schema-valid keys.

Migration / self-heal: any legacy in-config `_loreBackup` is migrated to the sidecar (preserving the **true original**, never overwritten by lore's own values) and stripped from the config on the next `lore setup` **or** `lore setup undo` — so a broken install (like Sergiy's) heals itself on the next run.

### Changes
- **`setup-backup.ts`** — remove `attachJsonBackup`/`restoreJsonBackup`; add pure, fs-free `applyJsonBackup` (revert-only-if-unchanged + plugin removal) and `readLegacyJsonBackup`.
- **`setup.ts`** — sidecar IO (`jsonBackupPath`, `loadJsonSetupBackup`, `persistJsonSetupBackup`, removal) + legacy migration in `setupOpencode` / `setupClaudeCode` / `setupPi` and `undoJsonApp`.
- **`inventory.ts`** — `hasBackup` / prior-value display read from sidecar-or-legacy.
- **tests** — sidecar assertions across all JSON apps; legacy-`_loreBackup` migration (the Sergiy scenario); schema-safe regression (written OpenCode config carries no `_loreBackup`); legacy-only undo; corrupt-sidecar tolerance; re-run never overwrites the true original; sidecar kept when a value was user-changed.

## Testing
- `pnpm run typecheck` (all packages), `pnpm run lint`, `pnpm run format:check` — clean
- Full setup / inventory / doctor suites: **169 passing**
- Mutation-verified (throwaway worktree, byte-identical restore): reintroducing the `_loreBackup` write, dropping the `existsSync` preserve-original guard, dropping the `skipped===0` sidecar-keep guard, dropping the undo key-strip, and weakening `applyJsonBackup`'s revert-only-if-unchanged guard are each caught by a dedicated test.

## Manual unblock (already shared with the reporter)
Delete the `_loreBackup` block from `~/.config/opencode/opencode.json` (leaves lore routing intact); don't re-run `lore setup opencode` on an unpatched build or it comes back.