### PR TITLE
fix(setup): don't crash lore doctor on an unreadable JSON backup sidecar

### DIFF
--- a/packages/gateway/src/cli/setup.ts
+++ b/packages/gateway/src/cli/setup.ts
@@ -641,16 +641,19 @@ export function jsonBackupPath(configPath: string): string {
 
 /**
  * Read + validate the sidecar backup for a JSON config, or null if it is
- * absent or corrupt. A corrupt sidecar is treated as absent (rather than
- * throwing) so undo degrades to a no-op and setup won't overwrite it.
+ * absent, unreadable, or corrupt. Any read failure (missing file, permission
+ * error, path-is-a-directory, etc.) or parse failure is treated as "no
+ * backup" — never thrown — so read-only callers (`lore doctor`, `lore setup
+ * status`) and `undo` degrade gracefully instead of crashing on a bad file.
  */
 export function loadJsonSetupBackup(configPath: string): JsonBackup | null {
   let raw: string;
   try {
     raw = readFileSync(jsonBackupPath(configPath), "utf8");
-  } catch (e: unknown) {
-    if ((e as NodeJS.ErrnoException).code === "ENOENT") return null;
-    throw e;
+  } catch {
+    // Absent (ENOENT) or unreadable (EACCES, EISDIR, ...) — report no backup
+    // rather than propagating an exception into a read-only command.
+    return null;
   }
   try {
     const parsed = JSON.parse(raw) as unknown;

--- a/packages/gateway/test/setup-io.test.ts
+++ b/packages/gateway/test/setup-io.test.ts
@@ -17,7 +17,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { commandSetup } from "../src/cli/setup";
+import { commandSetup, loadJsonSetupBackup } from "../src/cli/setup";
 import { writePortFile } from "../src/portfile";
 
 // Integration coverage for the setup.ts IO surface (backup capture on setup,
@@ -282,6 +282,27 @@ describe("commandSetup — OpenCode", () => {
     writeFileSync(`${ocPath()}.lore-backup`, "{ not valid json");
 
     await commandSetup(["undo", "opencode"], {});
+    expect(logged().toLowerCase()).toContain("no lore backup");
+  });
+
+  it("loadJsonSetupBackup returns null for an unreadable sidecar (never throws)", () => {
+    // A sidecar that exists but can't be read (permissions, or — as simulated
+    // here deterministically — the path is a directory → EISDIR) must be
+    // treated as "no backup", not crash read-only callers like `lore doctor`
+    // (Seer[bot] r3566840253).
+    mkdirSync(join(home, ".config", "opencode"), { recursive: true });
+    mkdirSync(`${ocPath()}.lore-backup`, { recursive: true });
+    expect(loadJsonSetupBackup(ocPath())).toBeNull();
+  });
+
+  it("undo tolerates an unreadable sidecar instead of crashing", async () => {
+    mkdirSync(join(home, ".config", "opencode"), { recursive: true });
+    writeFileSync(ocPath(), JSON.stringify({ provider: {} }, null, 2));
+    mkdirSync(`${ocPath()}.lore-backup`, { recursive: true });
+
+    await expect(
+      commandSetup(["undo", "opencode"], {}),
+    ).resolves.toBeUndefined();
     expect(logged().toLowerCase()).toContain("no lore backup");
   });
 


### PR DESCRIPTION
## Problem

Follow-up to #1297 — addresses Seer[bot] finding [r3566840253](https://github.com/BYK/loreai/pull/1297#discussion_r3566840253) (verified as a real MEDIUM issue).

`loadJsonSetupBackup` re-threw any read error other than `ENOENT` (e.g. `EACCES` on a permission-locked file, `EISDIR`). Its callers — the inventory collectors used by `lore doctor` / `lore setup status`, and `undoJsonApp` — don't wrap it, so an existing-but-unreadable `<config>.lore-backup` file would crash those read-only commands with an unhandled exception.

## Fix

Treat **any** read failure (not just `ENOENT`) as "no backup", the same way an already-handled corrupt/absent sidecar is. `loadJsonSetupBackup` is a read used by diagnostics and undo, so a single point-fix protects all four call sites and lets them degrade gracefully. Write paths (`persistJsonSetupBackup`) are unchanged — a failed write during `lore setup` still surfaces, as it should.

## Testing
- `loadJsonSetupBackup` returns `null` for an unreadable sidecar (simulated deterministically with a directory at the sidecar path → `EISDIR`, so it doesn't depend on running as non-root).
- `lore setup undo opencode` resolves gracefully ("no lore backup") instead of throwing when the sidecar is unreadable.
- Mutation-verified: reverting to the `ENOENT`-only guard makes both new tests fail (byte-identical restore confirmed via sha256).
- typecheck / lint / format clean; setup+inventory+doctor suites green (95 in the touched files).