### PR TITLE
fix(core): key project identity on origin, not upstream

### DIFF
--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -5,7 +5,8 @@
  * repository identity rather than filesystem path. This enables:
  *  - Worktree awareness: main checkout and worktrees share one project
  *  - Clone deduplication: same repo cloned to different paths is one project
- *  - Fork awareness: prefers `upstream` remote to unify forks with their source
+ *  - Fork safety: prefers `origin` over `upstream` so unrelated repos sharing a
+ *    common template's upstream are NOT collapsed into one project
  *
  * Remote URL normalization strips protocol, auth, and `.git` suffix to produce
  * a stable canonical identifier (e.g. "github.com/user/repo") regardless of
@@ -127,10 +128,17 @@ export function getGitRemote(path: string): string | null {
       return null;
     }
 
-    // Prefer upstream (fork source) > origin > any other
+    // Prefer origin (the canonical clone source) > upstream > any other.
+    // Origin-first (not upstream-first) is deliberate: two unrelated repos that
+    // were forked/bootstrapped from a common template each keep their own
+    // `origin` but may share an `upstream` pointing at that template. Keying on
+    // the shared upstream would collapse them into one project (a false merge),
+    // and an incorrect merge is far worse than failing to unify a genuine fork
+    // with its source. So we key on origin and fall back to upstream only when
+    // no origin is configured.
     const url =
-      remotes.get("upstream") ??
       remotes.get("origin") ??
+      remotes.get("upstream") ??
       remotes.values().next().value;
     if (!url) {
       gitRemoteCache.set(path, null);

--- a/packages/core/test/git.test.ts
+++ b/packages/core/test/git.test.ts
@@ -1,5 +1,9 @@
-import { describe, test, expect } from "vitest";
-import { normalizeRemoteUrl } from "../src/git";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+import { getGitRemote, normalizeRemoteUrl } from "../src/git";
 
 describe("normalizeRemoteUrl", () => {
   test("normalizes SSH shorthand", () => {
@@ -90,5 +94,68 @@ describe("normalizeRemoteUrl", () => {
     expect(normalizeRemoteUrl("  https://github.com/user/repo.git  ")).toBe(
       "github.com/user/repo",
     );
+  });
+});
+
+describe("getGitRemote remote preference", () => {
+  // Each repo lives at a unique temp path, so getGitRemote's per-path cache
+  // never bleeds between cases.
+  function makeRepo(remotes: Record<string, string>): string {
+    const dir = mkdtempSync(join(tmpdir(), "lore-git-remote-"));
+    const opts = { cwd: dir, stdio: "pipe" as const };
+    execFileSync("git", ["init", "-q"], opts);
+    for (const [name, url] of Object.entries(remotes)) {
+      execFileSync("git", ["remote", "add", name, url], opts);
+    }
+    return dir;
+  }
+
+  test("prefers origin over upstream when both exist", () => {
+    // The core of the fix (#1300 context): keying on the shared upstream would
+    // falsely merge two template-derived repos. origin must win.
+    const dir = makeRepo({
+      origin: "git@github.com:me/my-fork.git",
+      upstream: "https://github.com/template/starter.git",
+    });
+    expect(getGitRemote(dir)).toBe("github.com/me/my-fork");
+  });
+
+  test("falls back to upstream when no origin is configured", () => {
+    const dir = makeRepo({
+      upstream: "https://github.com/template/starter.git",
+    });
+    expect(getGitRemote(dir)).toBe("github.com/template/starter");
+  });
+
+  test("falls back to any remote when neither origin nor upstream exists", () => {
+    const dir = makeRepo({
+      fork: "git@github.com:someone/repo.git",
+    });
+    expect(getGitRemote(dir)).toBe("github.com/someone/repo");
+  });
+
+  test("two repos sharing an upstream but with distinct origins do NOT converge", () => {
+    // Regression guard for the false-merge that collapsed unrelated projects
+    // (e.g. nutri / figma-rn-bridge / uk-immigration-analyzer): both were
+    // bootstrapped from the same template (shared upstream) but are separate
+    // projects with their own origin. They must resolve to DIFFERENT keys.
+    const a = makeRepo({
+      origin: "git@github.com:me/project-a.git",
+      upstream: "https://github.com/template/starter.git",
+    });
+    const b = makeRepo({
+      origin: "git@github.com:me/project-b.git",
+      upstream: "https://github.com/template/starter.git",
+    });
+    const ra = getGitRemote(a);
+    const rb = getGitRemote(b);
+    expect(ra).toBe("github.com/me/project-a");
+    expect(rb).toBe("github.com/me/project-b");
+    expect(ra).not.toBe(rb);
+  });
+
+  test("returns null when no remotes are configured", () => {
+    const dir = makeRepo({});
+    expect(getGitRemote(dir)).toBeNull();
   });
 });


### PR DESCRIPTION
## Problem

Reported by Onur: a project (`nutri`) vanished from the dashboard — all its data merged under a different project, and even a new session in that directory mapped to the wrong project. Separately, while working in `figma-rn-bridge` the agent kept getting Lore knowledge injected from an unrelated project (`uk-immigration-analyzer`).

Both are the same root cause. `getGitRemote` (`packages/core/src/git.ts`) preferred `upstream` over `origin`:

```
const url = remotes.get("upstream") ?? remotes.get("origin") ?? …
```

Project identity converges on the normalized git remote. Two unrelated repos that were forked/bootstrapped from a common template each keep their own `origin` but share an `upstream` pointing at that template. Keying on the shared upstream collapses them into one `project_id`. Once merged the loser's path becomes a permanent `project_path_aliases` row and the alias lookup runs before git detection (`db.ts`), so even new sessions stay pinned to the wrong project. Cross-project knowledge injection follows directly: `ltm.forSession` only injects `project_id = ?` rows, so foreign knowledge can only appear once two projects share an id (i.e. after a false merge).

## Fix

Prefer `origin` over `upstream`; keep `upstream` only as a fallback when no `origin` is configured:

```
const url = remotes.get("origin") ?? remotes.get("upstream") ?? …
```

An incorrect merge is far worse than failing to unify a genuine fork with its source. Clones of the same `origin` still converge correctly (worktree/clone dedup is unaffected).

## Scope

Forward-only. Already-merged projects and existing path aliases are **not** auto-repaired (recovery/un-merge is a possible follow-up). Existing project rows keep their prior remote until re-resolved; new/unseen paths key on origin and diverge cleanly.

## Tests

Adds a `getGitRemote` preference suite (previously only `normalizeRemoteUrl` was covered) using real temp git repos:
- origin preferred over upstream when both exist
- upstream used only as a fallback
- fallback to any remote when neither origin nor upstream exists
- **regression guard**: two repos sharing an upstream but with distinct origins resolve to different project keys
- null when no remotes configured

Mutation-verified: reverting to upstream-first fails the origin-preference and distinct-origins tests. typecheck + oxlint + oxfmt clean.