### PR TITLE
fix(core): make LTM budget context-aware and sub-agent-aware

### DIFF
--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -114,6 +114,19 @@ const MIN_LAYER0_FLOOR = 40_000;
  *  models. */
 const LTM_BUDGET_STEP = 8_000;
 
+/** Hard ceiling on a single LTM budget as a fraction of `usable`, so the
+ *  quantization floor below (LTM_BUDGET_STEP) cannot turn a small requested
+ *  fraction into a large share of a small/short context window. Chosen well
+ *  above the default ltm (0.05) and preference (0.02) fractions, so on large
+ *  models it never binds and the budget is exactly the historical value; it
+ *  only clips the 8K floor on windows with less than ~40K usable tokens. */
+const MAX_LTM_BUDGET_FRACTION = 0.2;
+
+/** Tighter ceiling for short-lived sub-agent sessions (1-3 turns). Sub-agents
+ *  run a focused task and should keep their window for real work rather than
+ *  injected knowledge. */
+const SUBAGENT_MAX_LTM_BUDGET_FRACTION = 0.1;
+
 /** Consecutive zero-cache-write turns before treating the session as free-write. */
 const NO_CACHE_WRITE_THRESHOLD = 3;
 
@@ -1080,9 +1093,34 @@ export function getLtmTokens(sessionID?: string): number {
  * the configured ltm budget fraction. Call this from the system transform
  * hook to cap how many tokens formatKnowledge may use.
  */
-export function getLtmBudget(ltmFraction: number, sessionID?: string): number {
+export function getLtmBudget(
+  ltmFraction: number,
+  sessionID?: string,
+  opts?: { isSubagent?: boolean },
+): number {
   const overhead = getOverhead(sessionID);
   const usable = Math.max(0, contextLimit - outputReserved - overhead);
+  const raw = Math.floor(usable * ltmFraction);
+  if (raw <= 0) return 0;
+
+  // Context-aware ceiling: an LTM block must never swallow a large share of the
+  // window. On big models this never binds (ltmFraction << the ceiling
+  // fraction), so the budget is exactly the historical value; on small/short
+  // windows it stops the quantization floor below from ballooning a 5% request
+  // into 25-50% of the context. See #1300 context (subagent output crowding).
+  const ceiling = Math.floor(
+    usable *
+      (opts?.isSubagent
+        ? SUBAGENT_MAX_LTM_BUDGET_FRACTION
+        : MAX_LTM_BUDGET_FRACTION),
+  );
+
+  // Sub-agents are short-lived (1-3 turns), so cache-stability quantization and
+  // the "never disable LTM" floor matter little. Give them exactly the
+  // requested fraction (capped by the tighter ceiling) so a focused task keeps
+  // its window for real work instead of injected knowledge.
+  if (opts?.isSubagent) return Math.min(raw, ceiling);
+
   // Quantize to a coarse step so per-turn `usable` wobble (overhead EMA drift)
   // does not move the ltm.forSession() packing boundary and churn the pinned
   // LTM set every turn. See LTM_BUDGET_STEP.
@@ -1091,11 +1129,10 @@ export function getLtmBudget(ltmFraction: number, sessionID?: string): number {
   // when the raw budget is below one step (small-context models): a raw budget
   // under half a step rounds up to one full step rather than to zero, and the
   // common large-context case (raw >> step) is unaffected. This keeps the
-  // budget stable across wobble while never disabling LTM.
-  const raw = Math.floor(usable * ltmFraction);
-  if (raw <= 0) return 0;
+  // budget stable across wobble while never disabling LTM — but never above the
+  // context-aware ceiling.
   const quantized = Math.round(raw / LTM_BUDGET_STEP) * LTM_BUDGET_STEP;
-  return Math.max(LTM_BUDGET_STEP, quantized);
+  return Math.min(Math.max(LTM_BUDGET_STEP, quantized), ceiling);
 }
 
 /** Returns the token budget for stable LTM (preferences). Independent of context-bound LTM budget. */

--- a/packages/core/test/gradient.test.ts
+++ b/packages/core/test/gradient.test.ts
@@ -586,19 +586,26 @@ describe("gradient — LTM budget coordination", () => {
     calibrate(0); // zero overhead for these tests
   });
 
-  test("getLtmBudget returns fraction of usable context, quantized to LTM_BUDGET_STEP", () => {
-    // usable = 10_000 - 2_000 - 0 (overhead) = 8_000
-    // ltm fraction 0.10 → raw 800 → quantized to nearest 8_000 step, floored at
-    // one step so LTM is never disabled on small-context models → 8_000.
-    const budget = getLtmBudget(0.1);
-    expect(budget).toBe(8_000);
+  test("getLtmBudget clips to the context-aware ceiling on a small window", () => {
+    // usable = 10_000 - 2_000 - 0 (overhead) = 8_000. The 8K quantization floor
+    // alone would hand LTM the ENTIRE window; the context-aware ceiling caps a
+    // single LTM block at 20% of usable (1_600) so real work keeps its room.
+    expect(getLtmBudget(0.1)).toBe(1_600);
+
+    // On a large window the ceiling never binds and the historical floor still
+    // applies (raw below one step → quantized up to the 8K floor).
+    setModelLimits({ context: 200_000, output: 32_000 }); // usable = 168_000
+    calibrate(0);
+    expect(getLtmBudget(0.05)).toBe(8_000);
+    setModelLimits({ context: 10_000, output: 2_000 });
+    calibrate(0);
   });
 
-  test("getLtmBudget respects different fractions (quantized, never below one step)", () => {
-    // raw 2_000 → rounds to 0 step but floored to one step (8_000).
-    expect(getLtmBudget(0.25)).toBe(8_000);
-    // raw 400 → floored to one step (8_000).
-    expect(getLtmBudget(0.05)).toBe(8_000);
+  test("getLtmBudget ceiling dominates the floor for any fraction on a small window", () => {
+    // Both fractions would be floored to 8_000 (100% of an 8_000-token window);
+    // the ceiling clips both to 20% of usable = 1_600.
+    expect(getLtmBudget(0.25)).toBe(1_600);
+    expect(getLtmBudget(0.05)).toBe(1_600);
   });
 
   test("getLtmBudget returns 0 only when there is no usable budget", () => {

--- a/packages/core/test/ltm-budget.test.ts
+++ b/packages/core/test/ltm-budget.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import {
+  getLtmBudget,
+  getPreferenceLtmBudget,
+  setModelLimits,
+} from "../src/gradient";
+
+/**
+ * getLtmBudget: context-aware ceiling + sub-agent-aware sizing (#1300 context).
+ *
+ * These tests never call calibrate(), so getOverhead() falls back to the
+ * uncalibrated FIRST_TURN_OVERHEAD (15_000). With sessionID omitted, the budget
+ * is a pure function of the model limits set here:
+ *   usable = contextLimit - min(output, 32_000) - 15_000
+ */
+describe("getLtmBudget context-aware ceiling + sub-agent sizing", () => {
+  // Restore a large, generous default so a leaked small limit from one test
+  // can't silently change another. Each test still sets its own limits.
+  beforeEach(() => {
+    setModelLimits({ context: 200_000, output: 32_000 });
+  });
+
+  test("large context, main session: historical floor preserved", () => {
+    setModelLimits({ context: 200_000, output: 32_000 }); // usable = 153_000
+    // raw = 7_650 → quantized 8_000, ceiling 30_600 → 8_000 (unchanged).
+    expect(getLtmBudget(0.05)).toBe(8_000);
+  });
+
+  test("small context, main session: scaled BELOW the 8K floor", () => {
+    setModelLimits({ context: 30_000, output: 4_000 }); // usable = 11_000
+    // Historically this forced 8_000 (73% of usable). The ceiling clips it to
+    // 20% of usable = 2_200.
+    const budget = getLtmBudget(0.05);
+    expect(budget).toBe(2_200);
+    expect(budget).toBeLessThan(8_000);
+  });
+
+  test("sub-agent gets a smaller budget than a main session (large context)", () => {
+    setModelLimits({ context: 200_000, output: 32_000 }); // usable = 153_000
+    const main = getLtmBudget(0.05);
+    const sub = getLtmBudget(0.05, undefined, { isSubagent: true });
+    // Sub-agent skips the 8K floor and takes the exact fraction (7_650).
+    expect(sub).toBe(7_650);
+    expect(sub).toBeLessThan(main);
+  });
+
+  test("sub-agent budget is much smaller on a small context", () => {
+    setModelLimits({ context: 30_000, output: 4_000 }); // usable = 11_000
+    const main = getLtmBudget(0.05); // 2_200
+    const sub = getLtmBudget(0.05, undefined, { isSubagent: true }); // 550
+    expect(sub).toBe(550);
+    expect(sub).toBeLessThan(main);
+  });
+
+  test("ceilings bind for an oversized fraction (main 20%, sub-agent 10%)", () => {
+    setModelLimits({ context: 200_000, output: 32_000 }); // usable = 153_000
+    expect(getLtmBudget(0.5)).toBe(30_600); // 20% of usable
+    expect(getLtmBudget(0.5, undefined, { isSubagent: true })).toBe(15_300); // 10%
+  });
+
+  test("returns 0 when there is no usable context (both modes)", () => {
+    setModelLimits({ context: 15_000, output: 2_000 }); // usable = 0
+    expect(getLtmBudget(0.05)).toBe(0);
+    expect(getLtmBudget(0.05, undefined, { isSubagent: true })).toBe(0);
+  });
+
+  test("preference budget shares the same function and shrinks for sub-agents", () => {
+    setModelLimits({ context: 200_000, output: 32_000 }); // usable = 153_000
+    expect(getPreferenceLtmBudget).toBe(getLtmBudget);
+    const mainPref = getPreferenceLtmBudget(0.02); // floored to 8_000
+    const subPref = getPreferenceLtmBudget(0.02, undefined, {
+      isSubagent: true,
+    }); // exact fraction 3_060
+    expect(mainPref).toBe(8_000);
+    expect(subPref).toBe(3_060);
+    expect(subPref).toBeLessThan(mainPref);
+  });
+});

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -6799,10 +6799,18 @@ async function handleConversationTurn(
       const ltmFraction = cfg.budget.ltm;
       // Per-session overhead (Bug 1, lever 2): budget off this session's own
       // calibrated overhead, not a global EMA blended across sessions.
-      const ltmBudget = getLtmBudget(ltmFraction, sessionID ?? undefined);
+      // Sub-agent sessions get a smaller, needs-based LTM budget so injected
+      // knowledge doesn't crowd out a short focused task's own context/output.
+      const ltmBudgetOpts = { isSubagent: !!sessionState.isSubagent };
+      const ltmBudget = getLtmBudget(
+        ltmFraction,
+        sessionID ?? undefined,
+        ltmBudgetOpts,
+      );
       const prefBudget = getPreferenceLtmBudget(
         cfg.budget.preferenceLtm,
         sessionID ?? undefined,
+        ltmBudgetOpts,
       );
       const isFirstTurn =
         sessionID != null && !temporal.hasMessages(projectPath, sessionID);
@@ -7224,8 +7232,11 @@ async function handleConversationTurn(
   if (result.refreshLtm && cfg.knowledge.enabled) {
     try {
       const ltmFraction = cfg.budget.ltm;
-      // Per-session overhead (Bug 1, lever 2).
-      const ltmBudget = getLtmBudget(ltmFraction, sessionID);
+      // Per-session overhead (Bug 1, lever 2). Sub-agents keep the smaller
+      // needs-based budget on the emergency-refresh path too.
+      const ltmBudget = getLtmBudget(ltmFraction, sessionID, {
+        isSubagent: !!sessionState.isSubagent,
+      });
       // Full context-bound budget — preferences have their own dedicated budget.
       const contextBudget = ltmBudget;
       const stableTokens = stableLtmCache.get(sessionID)?.tokenCount ?? 0;


### PR DESCRIPTION
## Problem

Reported by Onur (Claude Code): sub-agents run and do work, but the result returned to the main session is dominated by injected Lore knowledge, so the parent reports "no result". His theory — the sub-agent's input/output budget is consumed by injected knowledge — is correct.

`getLtmBudget` (`packages/core/src/gradient.ts`) floored **every** budget at `LTM_BUDGET_STEP` (8K) for any positive usable context and never scaled with the real window:

```
const quantized = Math.round(raw / LTM_BUDGET_STEP) * LTM_BUDGET_STEP;
return Math.max(LTM_BUDGET_STEP, quantized);
```

Because `getPreferenceLtmBudget === getLtmBudget`, a knowledge-enabled session was eligible for ~8K (preferences+entities+catalog) + ~8K (context-bound) regardless of window size. On a small or short-lived context a 5% request silently became 25–50% of the window. And while `isSubagent` was already set for Claude Code (`x-parent-session-id`), it only drove cache-warming/eviction — it never sized LTM.

The result is the same failure surfaced in the project-merge report: with its window saturated and its output budget shrunk, the sub-agent spends its turn acknowledging the injected knowledge instead of returning task output.

## Fix

`getLtmBudget(ltmFraction, sessionID?, opts?)`:

- **Context-aware ceiling** (`MAX_LTM_BUDGET_FRACTION = 0.2`): the 8K floor can never exceed a safe share of `usable`. On large models the ceiling never binds — the budget is **byte-identical to before** (verified: 8K at default fractions on a 200K window). It only clips the floor on windows below ~40K usable.
- **`isSubagent` branch**: sub-agents are short-lived (1–3 turns), so cache-stability quantization and the "never disable LTM" floor matter little. They take the exact requested fraction, capped by a tighter ceiling (`SUBAGENT_MAX_LTM_BUDGET_FRACTION = 0.1`), so a focused task keeps its window for real work.
- Thread `sessionState.isSubagent` into all three `getLtmBudget`/`getPreferenceLtmBudget` call sites in `pipeline.ts` (main injection + preferences + emergency-refresh path).

The fractions are starting values (documented as tunable).

## Tests

- New `packages/core/test/ltm-budget.test.ts`: large-context floor preserved; small-context scaled below 8K; sub-agent < main (large and small contexts); both ceilings bind for an oversized fraction; zero-usable → 0; preferences shrink for sub-agents. **Mutation-verified** — reverting the ceiling fails 2 tests, disabling the sub-agent branch fails 3.
- Updated the two `gradient.test.ts` cases that asserted the *old* small-window floor (8K on an 8K-usable window) to the correct clipped values, plus a large-window assertion that the floor is still preserved. No assertions weakened — the behavior changed by design.
- typecheck (core + gateway) + oxlint + oxfmt clean; pipeline injection / cache-stability / ltm-pin / knowledge-delta suites pass.

## Follow-up

opencode/Pi plugins don't send `x-parent-session-id`, so their sub-agents aren't detected yet — tracked in #1300. This PR fully covers the Claude Code case.