### PR TITLE
feat(gateway): tell the agent Lore manages the context window

### DIFF
--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -356,6 +356,26 @@ export const LORE_COMMIT_REMINDER =
   "NEVER leave `.lore.md` modified or untracked after a commit. " +
   "`.lore.md` is shared project knowledge and must always be version-controlled.";
 
+/**
+ * A short, capability-framed note telling the agent that Lore is actively
+ * managing the context window, so it should not hedge or stop over
+ * context-length concerns. Prepended to the frozen system[1] block.
+ *
+ * MUST stay static — no token counts, no compression-layer names, no per-turn
+ * values. A per-turn "Context health" note that varied by layer used to live in
+ * system[2] and busted the conversation cache on every layer oscillation
+ * (issue #741). This note is safe precisely because it never changes: it is
+ * frozen with the system[1] baseline (1h cache) and present from turn 1, so it
+ * is a stable cache read on every turn.
+ *
+ * Exported for unit testing.
+ */
+export const LORE_CONTEXT_CAPABILITY_NOTE =
+  "Lore actively manages and compresses this session's context and preserves " +
+  "older turns as recall-able summaries, so your effective context is far " +
+  "larger than it looks. Don't hedge or stop over context limits; take on " +
+  "large, multi-step tasks directly.";
+
 // ---------------------------------------------------------------------------
 // Module state
 // ---------------------------------------------------------------------------
@@ -6887,22 +6907,27 @@ async function handleConversationTurn(
           log.warn("knowledge catalog injection failed (non-fatal):", err);
         }
 
-        const formatted = [prefText, entitiesText, knowledgeTocText]
+        // The context-capability note is a static preamble, always present so
+        // the agent knows from turn 1 that Lore manages the window (see
+        // LORE_CONTEXT_CAPABILITY_NOTE). Because it never varies and is frozen
+        // with this baseline, system[1] is now always present and byte-stable —
+        // which also means the "empty baseline" case below can no longer occur.
+        const formatted = [
+          LORE_CONTEXT_CAPABILITY_NOTE,
+          prefText,
+          entitiesText,
+          knowledgeTocText,
+        ]
           .filter(Boolean)
           .join("\n\n");
-        // Freeze this baseline durably (v45) — INCLUDING an empty result. The
-        // in-memory cache is lost on process restart / session eviction;
-        // persisting lets getOrCreateSession restore the exact bytes so system[1]
-        // is never recomputed from the live knowledge table mid-session (which is
-        // what let a consolidation delete bust the cached prefix — ses_14b9bf3d…
-        // incident). Caching even the EMPTY baseline matters: a session that
-        // starts with no preferences/entities must stay system[1]-absent for its
-        // life — otherwise a preference minted mid-session (curator/pattern-
-        // extract) would make system[1] appear, growing the array and busting the
-        // prefix once. An empty `formatted` is falsy at the assembly site
-        // (anthropic.ts `if (stableLtm)`), so freezing "" keeps system[1] absent
-        // rather than injecting an empty block; new preferences surface next
-        // session. This compute path only runs once per session (cache miss).
+        // Freeze this baseline durably (v45). The in-memory cache is lost on
+        // process restart / session eviction; persisting lets getOrCreateSession
+        // restore the exact bytes so system[1] is never recomputed from the live
+        // knowledge table mid-session (which is what let a consolidation delete
+        // bust the cached prefix — ses_14b9bf3d… incident). The freeze also pins
+        // preferences/entities minted mid-session (curator/pattern-extract) out
+        // of this block until the next session, so the prefix never grows
+        // mid-session. This compute path only runs once per session (cache miss).
         const tokenCount = formatted ? Math.ceil(formatted.length / 3) : 0;
         stable = { formatted, tokenCount };
         stableLtmCache.set(sessionID, stable);

--- a/packages/gateway/test/context-capability-note.test.ts
+++ b/packages/gateway/test/context-capability-note.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Pipeline context-capability note (system[1]).
+ *
+ * Verifies that Lore injects a short, STATIC capability note into the stable
+ * system block so the agent knows Lore manages the context window and needn't
+ * hedge over context-length concerns. The note must be present from turn 1 even
+ * with no knowledge/entities, and must be static (no token counts / layer names)
+ * so it never busts the cache the way the removed per-turn "Context health" note
+ * did (issue #741; see context-health-note.test.ts + cache-stability.e2e).
+ *
+ * The upstream interceptor captures the built Anthropic request body so the
+ * test can assert on the system blocks the gateway actually sends upstream.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { DEFAULT_MODEL, DEFAULT_SYSTEM } from "./helpers/fixtures";
+import type { Harness } from "./helpers/harness";
+import { createHarness } from "./helpers/harness";
+import {
+  LORE_CONTEXT_CAPABILITY_NOTE,
+  setUpstreamInterceptor,
+} from "../src/pipeline";
+
+function makeBody(userMessage: string): Record<string, unknown> {
+  return {
+    model: DEFAULT_MODEL,
+    max_tokens: 1024,
+    stream: false,
+    system: DEFAULT_SYSTEM,
+    messages: [{ role: "user", content: userMessage }],
+    tools: [],
+  };
+}
+
+interface Sink {
+  body?: Record<string, unknown>;
+}
+
+function captureInterceptor(sink: Sink) {
+  return async (requestBody: unknown): Promise<Response> => {
+    sink.body = requestBody as Record<string, unknown>;
+    return new Response(
+      JSON.stringify({
+        id: "msg_capture",
+        type: "message",
+        role: "assistant",
+        model: DEFAULT_MODEL,
+        content: [{ type: "text", text: "ok" }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 5, output_tokens: 2 },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  };
+}
+
+describe("context-capability note is static (#741 guardrail)", () => {
+  it("carries no per-layer adjective or token count", () => {
+    const n = LORE_CONTEXT_CAPABILITY_NOTE;
+    expect(n).not.toContain("aggressively compressed");
+    expect(n).not.toContain("emergency compressed");
+    expect(n).not.toContain("[Context health:");
+    // No digits — a token count / layer number would make it vary per turn and
+    // bust the frozen system[1] cache.
+    expect(/\d/.test(n)).toBe(false);
+  });
+});
+
+describe("Pipeline — context-capability note injection (system[1])", () => {
+  let harness: Harness;
+
+  afterEach(() => harness?.teardown());
+
+  it("injects the capability note into system[1] on turn 1 with no knowledge", async () => {
+    harness = await createHarness({ fixtures: [] });
+
+    const sink: Sink = {};
+    setUpstreamInterceptor(captureInterceptor(sink));
+
+    const resp = await harness.chat(makeBody("hello"));
+    expect(resp.status).toBe(200);
+    await resp.text();
+
+    const sys = JSON.stringify(sink.body?.system ?? "");
+    // Present even though no entities/preferences/knowledge were seeded — the
+    // note is always-present so the agent sees it from the first turn.
+    expect(sys).toContain("effective context is far larger than it looks");
+    expect(sys).toContain("take on large, multi-step tasks directly");
+  });
+});


### PR DESCRIPTION
## Problem

Suggested by Onur: coding agents over-hedge on large tasks — "I can't do this, we only have limited context", "this session is getting long, should we stop?" — forcing the user to repeat "we use Lore / auto-caching / don't worry about context" every session. Lore should proactively tell the agent the real situation so it knows the true scope it can take on.

## Fix

Prepend a short, **static** capability note (`LORE_CONTEXT_CAPABILITY_NOTE`) to the frozen `system[1]` block:

> Lore actively manages and compresses this session's context and preserves older turns as recall-able summaries, so your effective context is far larger than it looks. Don't hedge or stop over context limits; take on large, multi-step tasks directly.

### Why static / why system[1]

A per-turn "Context health" note whose wording varied by compression layer used to live in `system[2]` and busted the conversation cache on every layer oscillation (issue #741). This note is safe precisely because it **never changes**: no token counts, no layer names. It's frozen with the `system[1]` baseline (1h cache) and present from turn 1, so it's a stable cache read every turn. Because it's always present, `system[1]` no longer has an "empty baseline" edge case (the mid-session-appearance bust the freeze guarded against can't occur).

## Tests

- Static-content guard: the note contains none of the #741-forbidden strings (`aggressively compressed`, `emergency compressed`, `[Context health:`) and no digits (a token count/layer number would make it vary per turn).
- Harness test: the note lands in `system[1]` on turn 1 with **no** knowledge/entities seeded (proves always-present). **Mutation-verified** — removing the note from the assembly fails this test.
- `cache-stability.e2e` still asserts byte-identical system blocks across forced layer escalation (1→2→3); `context-health-note` guardrail still green. typecheck + oxlint + oxfmt clean.

Closes the loop on Onur's suggestion. (His related "say it 1–2× → auto-LTM" ask is the pattern-extract/curator path; this note makes the behavior work without depending on that capture.)