### PR TITLE
test(core): fix stale getGitRemote docstring + non-vacuous upstream fallback

### DIFF
--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -89,9 +89,11 @@ export function clearGitRemoteCache(): void {
 /**
  * Get the canonical git remote URL for a repository at the given path.
  *
- * Prefers `upstream` remote (for forks) over `origin`, then falls back
- * to any other remote. Returns null if the path is not in a git repo
- * or has no remotes configured.
+ * Prefers `origin` (the canonical clone source) over `upstream`, then falls
+ * back to any other remote. Origin-first is deliberate: unrelated repos
+ * bootstrapped from a common template share an `upstream` but keep distinct
+ * `origin`s, so keying on the shared upstream would falsely merge them into one
+ * project. Returns null if the path is not in a git repo or has no remotes.
  *
  * Results are cached in-memory for the process lifetime to avoid repeated
  * subprocess calls — `git remote -v` only runs once per unique path.

--- a/packages/core/test/git.test.ts
+++ b/packages/core/test/git.test.ts
@@ -121,7 +121,13 @@ describe("getGitRemote remote preference", () => {
   });
 
   test("falls back to upstream when no origin is configured", () => {
+    // Include a second, alphabetically-earlier remote ("backup" < "upstream").
+    // `git remote -v` lists remotes alphabetically, so the generic
+    // `remotes.values().next()` fallback would return "backup" — this asserts
+    // the upstream branch is actually preferred over that arbitrary fallback
+    // (guards against the upstream fallback being silently dropped).
     const dir = makeRepo({
+      backup: "git@github.com:mirror/backup.git",
       upstream: "https://github.com/template/starter.git",
     });
     expect(getGitRemote(dir)).toBe("github.com/template/starter");


### PR DESCRIPTION
Adversarial-review follow-ups for #1301 (both SHOULD-FIX, no runtime bug in the merged code).

1. **Stale docstring (reversion hazard).** The `getGitRemote` JSDoc still read *"Prefers `upstream` remote (for forks) over `origin`"* — the exact behavior #1301 reversed. The header/inline comments were updated but this one was missed. A future maintainer "restoring consistency" from it would reintroduce the false-merge bug. Corrected to origin-first with the rationale.

2. **Vacuous test.** `falls back to upstream when no origin is configured` used an upstream-*only* repo. Because the generic `remotes.values().next()` fallback returns that same single remote, deleting the `?? remotes.get("upstream")` branch entirely still passed the test (mutation survived in review). Fix: add a second, alphabetically-earlier remote (`backup`); `git remote -v` lists alphabetically, so the generic fallback would now return `backup` — the test genuinely fails if the upstream branch is dropped.

Verified: mutation deleting the upstream-fallback branch now fails this test (previously survived). 20/20 git tests pass; oxlint/oxfmt clean; `git.ts` restored byte-identical after mutation testing.