### PR TITLE
fix(core): getLtmBudget ceiling caps only the floor + stabilize small windows

### DIFF
--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -1100,39 +1100,45 @@ export function getLtmBudget(
 ): number {
   const overhead = getOverhead(sessionID);
   const usable = Math.max(0, contextLimit - outputReserved - overhead);
-  const raw = Math.floor(usable * ltmFraction);
+  // Snap usable DOWN to the LTM_BUDGET_STEP grid before deriving anything.
+  // Bucketing absorbs the per-turn overhead-EMA wobble so the budget — and thus
+  // the ltm.forSession() packing boundary and the pinned system[2] set — stays
+  // stable turn-to-turn. A wobbling boundary drops/re-adds the lowest-ranked
+  // entry every turn, appending a durable prompt-delta into the cached prefix (a
+  // cache bust). Floor (not round) so the ceiling below can never exceed its
+  // fraction of the REAL window. Driving BOTH the fraction budget and the
+  // ceiling off this one grid keeps the whole result stable, including the
+  // ceiling-bound small-window path.
+  const gridUsable = Math.floor(usable / LTM_BUDGET_STEP) * LTM_BUDGET_STEP;
+  const raw = Math.floor(gridUsable * ltmFraction);
   if (raw <= 0) return 0;
 
-  // Context-aware ceiling: an LTM block must never swallow a large share of the
-  // window. On big models this never binds (ltmFraction << the ceiling
-  // fraction), so the budget is exactly the historical value; on small/short
-  // windows it stops the quantization floor below from ballooning a 5% request
-  // into 25-50% of the context. See #1300 context (subagent output crowding).
+  // Context-aware ceiling: the safe share of the window a single LTM block may
+  // take. On large models it caps only the "never disable" floor below (the
+  // configured fraction is well under it); on small/short windows it stops that
+  // floor from ballooning a small request into a large share of the context.
+  // See #1300 context (sub-agent output crowding).
   const ceiling = Math.floor(
-    usable *
+    gridUsable *
       (opts?.isSubagent
         ? SUBAGENT_MAX_LTM_BUDGET_FRACTION
         : MAX_LTM_BUDGET_FRACTION),
   );
 
-  // Sub-agents are short-lived (1-3 turns), so cache-stability quantization and
-  // the "never disable LTM" floor matter little. Give them exactly the
-  // requested fraction (capped by the tighter ceiling) so a focused task keeps
-  // its window for real work instead of injected knowledge.
+  // Sub-agents are short-lived (1-3 turns): give them exactly the requested
+  // fraction, capped by the tighter ceiling, so a focused task keeps its window
+  // for real work instead of injected knowledge.
   if (opts?.isSubagent) return Math.min(raw, ceiling);
 
-  // Quantize to a coarse step so per-turn `usable` wobble (overhead EMA drift)
-  // does not move the ltm.forSession() packing boundary and churn the pinned
-  // LTM set every turn. See LTM_BUDGET_STEP.
-  //
-  // Round to the NEAREST step (not floor) so the budget never collapses to 0
-  // when the raw budget is below one step (small-context models): a raw budget
-  // under half a step rounds up to one full step rather than to zero, and the
-  // common large-context case (raw >> step) is unaffected. This keeps the
-  // budget stable across wobble while never disabling LTM — but never above the
-  // context-aware ceiling.
+  // Main sessions: quantize the fraction-derived budget to the step (so large
+  // windows are byte-identical to the historical value) and floor at one step
+  // so LTM is never disabled on small-context models — but cap ONLY that floor
+  // by the ceiling so a small window isn't flooded. The configured fraction
+  // itself is never clipped, so a large `budget.ltm` passes through on large
+  // models.
   const quantized = Math.round(raw / LTM_BUDGET_STEP) * LTM_BUDGET_STEP;
-  return Math.min(Math.max(LTM_BUDGET_STEP, quantized), ceiling);
+  const floor = Math.min(LTM_BUDGET_STEP, ceiling);
+  return Math.max(floor, quantized);
 }
 
 /** Returns the token budget for stable LTM (preferences). Independent of context-bound LTM budget. */

--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -1109,7 +1109,14 @@ export function getLtmBudget(
   // fraction of the REAL window. Driving BOTH the fraction budget and the
   // ceiling off this one grid keeps the whole result stable, including the
   // ceiling-bound small-window path.
-  const gridUsable = Math.floor(usable / LTM_BUDGET_STEP) * LTM_BUDGET_STEP;
+  //
+  // Guard the sub-one-step window (0 < usable < LTM_BUDGET_STEP): flooring would
+  // snap it to 0 and disable LTM entirely, which we never want on tiny-context
+  // models. There, fall back to the real `usable` — the grid can't stabilize a
+  // window smaller than one bucket anyway, and such a window is too small/cheap
+  // for cache churn to matter.
+  const bucketed = Math.floor(usable / LTM_BUDGET_STEP) * LTM_BUDGET_STEP;
+  const gridUsable = bucketed > 0 ? bucketed : usable;
   const raw = Math.floor(gridUsable * ltmFraction);
   if (raw <= 0) return 0;
 

--- a/packages/core/test/ltm-budget.test.ts
+++ b/packages/core/test/ltm-budget.test.ts
@@ -11,7 +11,10 @@ import {
  * These tests never call calibrate(), so getOverhead() falls back to the
  * uncalibrated FIRST_TURN_OVERHEAD (15_000). With sessionID omitted, the budget
  * is a pure function of the model limits set here:
- *   usable = contextLimit - min(output, 32_000) - 15_000
+ *   usable     = contextLimit - min(output, 32_000) - 15_000
+ *   gridUsable = floor(usable / 8_000) * 8_000   (LTM_BUDGET_STEP grid)
+ * The budget is derived from gridUsable (not raw usable) so it is stable under
+ * per-turn overhead wobble.
  */
 describe("getLtmBudget context-aware ceiling + sub-agent sizing", () => {
   // Restore a large, generous default so a leaked small limit from one test
@@ -20,42 +23,69 @@ describe("getLtmBudget context-aware ceiling + sub-agent sizing", () => {
     setModelLimits({ context: 200_000, output: 32_000 });
   });
 
-  test("large context, main session: historical floor preserved", () => {
-    setModelLimits({ context: 200_000, output: 32_000 }); // usable = 153_000
-    // raw = 7_650 → quantized 8_000, ceiling 30_600 → 8_000 (unchanged).
+  test("large context, main session: historical value preserved", () => {
+    setModelLimits({ context: 200_000, output: 32_000 }); // usable 153_000, grid 152_000
+    // raw 7_600 → quantized 8_000; ceiling 30_400 caps only the floor → 8_000.
     expect(getLtmBudget(0.05)).toBe(8_000);
   });
 
   test("small context, main session: scaled BELOW the 8K floor", () => {
-    setModelLimits({ context: 30_000, output: 4_000 }); // usable = 11_000
-    // Historically this forced 8_000 (73% of usable). The ceiling clips it to
-    // 20% of usable = 2_200.
+    setModelLimits({ context: 30_000, output: 4_000 }); // usable 11_000, grid 8_000
+    // Historically forced 8_000 (73% of usable). The ceiling caps the floor to
+    // 20% of gridUsable = 1_600.
     const budget = getLtmBudget(0.05);
-    expect(budget).toBe(2_200);
+    expect(budget).toBe(1_600);
     expect(budget).toBeLessThan(8_000);
   });
 
+  test("small-context main budget is STABLE across usable wobble (no churn)", () => {
+    // Regression guard for the ceiling-bound path being unquantized. Three
+    // context sizes whose usable (10_000 / 13_000 / 15_000) all floor-bucket to
+    // gridUsable 8_000 must yield the SAME budget. Pre-fix (ceiling = raw
+    // usable * 0.2) these produced 2_000 / 2_600 / 3_000 — a moving packing
+    // boundary that churns the pinned LTM set every turn.
+    const budgets = new Set<number>();
+    for (const context of [27_000, 30_000, 32_000]) {
+      setModelLimits({ context, output: 2_000 });
+      budgets.add(getLtmBudget(0.05));
+    }
+    expect(budgets.size).toBe(1);
+    expect([...budgets][0]).toBe(1_600);
+  });
+
   test("sub-agent gets a smaller budget than a main session (large context)", () => {
-    setModelLimits({ context: 200_000, output: 32_000 }); // usable = 153_000
+    setModelLimits({ context: 200_000, output: 32_000 }); // usable 153_000, grid 152_000
     const main = getLtmBudget(0.05);
     const sub = getLtmBudget(0.05, undefined, { isSubagent: true });
-    // Sub-agent skips the 8K floor and takes the exact fraction (7_650).
-    expect(sub).toBe(7_650);
+    // Sub-agent skips the 8K floor and takes the exact fraction (7_600).
+    expect(sub).toBe(7_600);
     expect(sub).toBeLessThan(main);
   });
 
   test("sub-agent budget is much smaller on a small context", () => {
-    setModelLimits({ context: 30_000, output: 4_000 }); // usable = 11_000
-    const main = getLtmBudget(0.05); // 2_200
-    const sub = getLtmBudget(0.05, undefined, { isSubagent: true }); // 550
-    expect(sub).toBe(550);
+    setModelLimits({ context: 30_000, output: 4_000 }); // usable 11_000, grid 8_000
+    const main = getLtmBudget(0.05); // 1_600
+    const sub = getLtmBudget(0.05, undefined, { isSubagent: true }); // 400
+    expect(sub).toBe(400);
     expect(sub).toBeLessThan(main);
   });
 
-  test("ceilings bind for an oversized fraction (main 20%, sub-agent 10%)", () => {
-    setModelLimits({ context: 200_000, output: 32_000 }); // usable = 153_000
-    expect(getLtmBudget(0.5)).toBe(30_600); // 20% of usable
-    expect(getLtmBudget(0.5, undefined, { isSubagent: true })).toBe(15_300); // 10%
+  test("main honors a large configured fraction — ceiling caps only the floor", () => {
+    setModelLimits({ context: 200_000, output: 32_000 }); // usable 153_000, grid 152_000
+    // budget.ltm can be configured up to 0.3. On a large window the fraction is
+    // NOT clipped by MAX_LTM_BUDGET_FRACTION (0.2): raw 45_600 → quantized
+    // 48_000, and the ceiling only bounds the never-disable floor. (Pre-fix this
+    // was wrongly clipped to 30_600.)
+    expect(getLtmBudget(0.3)).toBe(48_000);
+  });
+
+  test("sub-agent still caps at its tighter ceiling for an oversized fraction", () => {
+    setModelLimits({ context: 200_000, output: 32_000 }); // usable 153_000, grid 152_000
+    const main = getLtmBudget(0.5); // 80_000 (quantized fraction, uncapped)
+    const sub = getLtmBudget(0.5, undefined, { isSubagent: true }); // 15_200 (10% cap)
+    expect(main).toBe(80_000);
+    expect(sub).toBe(15_200);
+    expect(sub).toBeLessThan(main);
   });
 
   test("returns 0 when there is no usable context (both modes)", () => {
@@ -65,14 +95,14 @@ describe("getLtmBudget context-aware ceiling + sub-agent sizing", () => {
   });
 
   test("preference budget shares the same function and shrinks for sub-agents", () => {
-    setModelLimits({ context: 200_000, output: 32_000 }); // usable = 153_000
+    setModelLimits({ context: 200_000, output: 32_000 }); // usable 153_000, grid 152_000
     expect(getPreferenceLtmBudget).toBe(getLtmBudget);
     const mainPref = getPreferenceLtmBudget(0.02); // floored to 8_000
     const subPref = getPreferenceLtmBudget(0.02, undefined, {
       isSubagent: true,
-    }); // exact fraction 3_060
+    }); // exact fraction 3_040
     expect(mainPref).toBe(8_000);
-    expect(subPref).toBe(3_060);
+    expect(subPref).toBe(3_040);
     expect(subPref).toBeLessThan(mainPref);
   });
 });

--- a/packages/core/test/ltm-budget.test.ts
+++ b/packages/core/test/ltm-budget.test.ts
@@ -53,6 +53,15 @@ describe("getLtmBudget context-aware ceiling + sub-agent sizing", () => {
     expect([...budgets][0]).toBe(1_600);
   });
 
+  test("sub-one-step window still gets a non-zero (never-disabled) budget", () => {
+    setModelLimits({ context: 24_000, output: 2_000 }); // usable 7_000 (< 8K step)
+    // Flooring would snap gridUsable to 0 and disable LTM; instead we fall back
+    // to real usable so a tiny window keeps LTM. Main = 20% of 7_000 = 1_400;
+    // sub-agent takes the exact 5% fraction = 350.
+    expect(getLtmBudget(0.05)).toBe(1_400);
+    expect(getLtmBudget(0.05, undefined, { isSubagent: true })).toBe(350);
+  });
+
   test("sub-agent gets a smaller budget than a main session (large context)", () => {
     setModelLimits({ context: 200_000, output: 32_000 }); // usable 153_000, grid 152_000
     const main = getLtmBudget(0.05);


### PR DESCRIPTION
Adversarial-review follow-ups for #1302 (two SHOULD-FIX; no BLOCKER in the merged code).

## 1. Configured `budget.ltm` above 0.2 was silently clipped on large models
`budget.ltm` is configurable up to **0.3** (`config.ts`), but the ceiling was `MAX_LTM_BUDGET_FRACTION = 0.2` applied to the whole result: `min(max(8000, quantized), ceiling)`. So `ltm=0.3` on a 153K-usable window returned `min(48_000, 30_600) = 30_600` — a silent override of an explicit setting, and **not** byte-identical for non-default configs (the PR's "byte-identical on large models" claim only held for the default 0.05/0.02).

Fix: the ceiling now bounds **only the never-disable floor**, never the configured fraction. `ltm=0.3` → `48_000` (the honest quantized fraction). Default fractions are unchanged.

## 2. Ceiling-bound small-window budget was unquantized → per-turn churn
When the ceiling bound the result on a small (<40K usable) main session, the value was `floor(usable * 0.2)` — unquantized. `usable` wobbles every turn with the overhead EMA, so the `ltm.forSession` packing boundary moved turn-to-turn, dropping/re-adding the lowest-ranked entry and appending a durable prompt-delta into the cached prefix — the exact churn/cache-bust `LTM_BUDGET_STEP` exists to prevent. The existing wobble test uses a 1M context where the ceiling never binds, so nothing guarded this.

Fix: **floor-bucket `usable` to the `LTM_BUDGET_STEP` grid up front** and derive both the fraction budget and the ceiling from `gridUsable`. Now the whole result — including the ceiling-bound path — is stable within an 8K bucket. Flooring (not rounding) guarantees the ceiling never exceeds its fraction of the *real* window.

## Behavior
- Large-window default budgets: **byte-identical** (8_000). Verified across 153K/168K/1M.
- Large configured fraction (0.3): now passes through (48_000) instead of clipped (30_600).
- Small-window main: stable within each 8K `usable` bucket (was continuously drifting).
- Sub-agents unchanged in spirit (exact fraction capped by the tighter 0.1 ceiling), now also bucket-stable.

## Tests
- Added: small-context wobble-stability guard (3 contexts in one bucket → identical budget) and large-configured-fraction passthrough guard.
- Both **mutation-verified**: re-adding the upper clip fails the passthrough test; computing the ceiling off raw `usable` fails the stability test.
- Full `gradient.test.ts` + `ltm-budget.test.ts` (227) pass; gateway ltm-pin/entity-injection/knowledge-delta suites pass; typecheck + oxlint + oxfmt clean; `gradient.ts` restored byte-identical after mutation testing.