### PR TITLE
test(gateway): make context-note tests exercise a genuinely empty baseline

### DIFF
--- a/packages/gateway/test/cache-stability.e2e.test.ts
+++ b/packages/gateway/test/cache-stability.e2e.test.ts
@@ -1276,15 +1276,16 @@ describe("cache stability (e2e)", () => {
     ).toBe(sys1(bodies[0]));
   });
 
-  it("an EMPTY system[1] is frozen too: a preference minted mid-session does not appear (no array-grow bust)", async () => {
-    // Point-4 gap from the adversarial review: a session that starts with no
-    // preferences/entities has an empty system[1] (the cache breakpoint falls on
-    // the host block). Before the empty-baseline freeze, the compute path skipped
-    // caching when `formatted` was empty, so it recomputed every turn — and the
-    // moment the curator/pattern-extract minted a preference mid-session, system[1]
-    // appeared, growing the system array and busting the prefix once. Freezing the
-    // empty baseline keeps system[1] absent for the session's life (new prefs
-    // surface next session).
+  it("the note-only system[1] baseline is frozen: a preference minted mid-session does not appear (no array-grow bust)", async () => {
+    // A session that starts with no preferences/entities/knowledge still has a
+    // system[1] block: the static capability note (#1303) is always present, so
+    // the baseline is "note-only" rather than empty/absent. It is frozen on turn
+    // 1 and must never change mid-session. This guards that the moment the
+    // curator/pattern-extract mints a preference mid-session, system[1] does NOT
+    // grow/change (which would bust the prefix once); the new preference surfaces
+    // next session instead. (Historically, before the note, this same freeze kept
+    // an empty system[1] from appearing mid-session — the note now makes the
+    // block always-present, so the array can never grow at all.)
     const turns = Array.from({ length: 3 }, (_, i) => ({
       userMessage: `Empty-stable turn ${i}: continue the work.`,
       assistantText: `Empty-stable response ${i}.`,
@@ -1315,8 +1316,8 @@ describe("cache stability (e2e)", () => {
         content: [{ type: "text", text: turns[i].assistantText }],
       });
 
-      // After the empty baseline is frozen on turn 1, mint a project preference
-      // mid-session. With the freeze it must NOT appear as a new system[1] block.
+      // After the note-only baseline is frozen on turn 1, mint a project
+      // preference mid-session. With the freeze it must NOT change system[1].
       if (i === 0) {
         ltm.create({
           projectPath,
@@ -1340,7 +1341,7 @@ describe("cache stability (e2e)", () => {
       expect(
         systems[i],
         `system array changed on turn ${i + 1} after a mid-session preference ` +
-          `mint — the empty system[1] baseline was not frozen (array-grow bust)`,
+          `mint — the note-only system[1] baseline was not frozen (array-grow bust)`,
       ).toBe(systems[0]);
     }
     // And the minted preference's title must NOT have leaked into the prompt.

--- a/packages/gateway/test/context-capability-note.test.ts
+++ b/packages/gateway/test/context-capability-note.test.ts
@@ -11,6 +11,9 @@
  * The upstream interceptor captures the built Anthropic request body so the
  * test can assert on the system blocks the gateway actually sends upstream.
  */
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { DEFAULT_MODEL, DEFAULT_SYSTEM } from "./helpers/fixtures";
 import type { Harness } from "./helpers/harness";
@@ -70,8 +73,15 @@ describe("Pipeline — context-capability note injection (system[1])", () => {
 
   afterEach(() => harness?.teardown());
 
-  it("injects the capability note into system[1] on turn 1 with no knowledge", async () => {
-    harness = await createHarness({ fixtures: [] });
+  it("injects the note into an OTHERWISE-EMPTY system[1] on turn 1", async () => {
+    // Point the request at a fresh temp project dir with no `.lore.md`, so no
+    // preferences/entities/knowledge are imported and the stable baseline would
+    // be empty. (The default harness project is process.cwd(), whose `.lore.md`
+    // IS imported — that would not exercise the empty-baseline case this test
+    // claims to cover.) The note must still appear, proving it is always-present
+    // and makes system[1] non-empty even with zero knowledge.
+    const projectPath = mkdtempSync(join(tmpdir(), "lore-capnote-"));
+    harness = await createHarness({ fixtures: [], projectPath });
 
     const sink: Sink = {};
     setUpstreamInterceptor(captureInterceptor(sink));
@@ -81,9 +91,9 @@ describe("Pipeline — context-capability note injection (system[1])", () => {
     await resp.text();
 
     const sys = JSON.stringify(sink.body?.system ?? "");
-    // Present even though no entities/preferences/knowledge were seeded — the
-    // note is always-present so the agent sees it from the first turn.
     expect(sys).toContain("effective context is far larger than it looks");
     expect(sys).toContain("take on large, multi-step tasks directly");
+    // The baseline is genuinely empty: no imported knowledge block rode along.
+    expect(sys).not.toContain("Long-term Knowledge");
   });
 });


### PR DESCRIPTION
Adversarial-review follow-ups for #1303 (which was CLEAN — these are test-hygiene only, no behavior change).

1. **Injection test didn't test what it claimed.** It asserted the note appears "with no knowledge", but `createHarness` defaults `projectPath` to `process.cwd()`, whose `.lore.md` is imported into the test DB — so system[1] was actually full of real knowledge. Now it points at a fresh `mkdtemp` project dir (no `.lore.md`) and additionally asserts no `Long-term Knowledge` block rode along, so it genuinely proves the note makes an *otherwise-empty* system[1] appear.

2. **Stale premise in `cache-stability.e2e`.** The test `"an EMPTY system[1] is frozen too…"` and its comments described system[1] as empty/absent and the breakpoint on the host block — all false after #1303 (system[1] is now note-only, always present). Reworded the name, comments, and assertion message to describe the note-only frozen baseline. Assertions are unchanged and still pass — they now guard that a mid-session-minted preference can't grow/change the frozen note-only system[1].

Verified: note-removal mutation still fails the injection test; both suites pass (18); oxlint/oxfmt clean; `pipeline.ts` restored byte-identical after mutation testing.