### PR TITLE
feat(opencode): flag Task sub-agents to the gateway (x-parent-session-id)

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -1,4 +1,4 @@
-import type { Plugin, Hooks } from "@opencode-ai/plugin";
+import type { Hooks, Plugin, PluginInput } from "@opencode-ai/plugin";
 import {
   log,
   getGitRemote,
@@ -159,6 +159,58 @@ function reapStaleProjectState(): void {
   const cutoff = Date.now() - SESSION_STATE_TTL_MS;
   for (const [id, entry] of projectState) {
     if (entry.lastSeenAt < cutoff) projectState.delete(id);
+  }
+}
+
+/** session.id → { parentID (null = primary session), lastSeenAt }.
+ *  A session's parent never changes, so the result is cached for the process
+ *  lifetime (reaped by the same TTL as projectState) to avoid an SDK round-trip
+ *  on every turn. */
+const sessionParent = new Map<
+  string,
+  { parentID: string | null; lastSeenAt: number }
+>();
+
+function reapStaleSessionParent(): void {
+  const cutoff = Date.now() - SESSION_STATE_TTL_MS;
+  for (const [id, entry] of sessionParent) {
+    if (entry.lastSeenAt < cutoff) sessionParent.delete(id);
+  }
+}
+
+/**
+ * Resolve a session's parent session ID via the OpenCode SDK.
+ *
+ * OpenCode Task sub-agents run in a child session whose `parentID` points at
+ * the session that spawned them; primary sessions have no parent. We forward a
+ * non-null parent as the `x-parent-session-id` header so the gateway flags the
+ * session as a sub-agent and sizes its LTM injection accordingly (#1300) — the
+ * same signal Claude Code emits natively for its Task sub-agents.
+ *
+ * Cached per session (parentID is immutable). A successful lookup — including
+ * the common `null` for a primary session — is cached so we never re-query.
+ * Failures (gateway server unreachable, session not yet persisted) are NOT
+ * cached and never throw, so a transient error is retried on the next turn
+ * rather than permanently latching a real sub-agent as "not a sub-agent".
+ */
+async function resolveParentSession(
+  client: PluginInput["client"],
+  sessionID: string,
+): Promise<string | null> {
+  const cached = sessionParent.get(sessionID);
+  if (cached) {
+    cached.lastSeenAt = Date.now();
+    return cached.parentID;
+  }
+  try {
+    const res = await client.session.get({ path: { id: sessionID } });
+    const parentID = res.data?.parentID ?? null;
+    sessionParent.set(sessionID, { parentID, lastSeenAt: Date.now() });
+    reapStaleSessionParent();
+    return parentID;
+  } catch {
+    // Best-effort: never break or slow the request path on a lookup failure.
+    return null;
   }
 }
 
@@ -327,6 +379,18 @@ export const LorePlugin: Plugin = async (ctx) => {
         // unlike x-session-affinity (nanoid regenerated per process).
         output.headers["x-lore-session-id"] = input.sessionID;
         output.headers["x-lore-agent"] = input.agent;
+        // Flag OpenCode Task sub-agents so the gateway sizes their LTM
+        // injection (see #1300). A sub-agent runs in a child session carrying a
+        // parentID; forward it as the `x-parent-session-id` signal the gateway
+        // already understands (Claude Code sends this natively). Resolution is
+        // cached and never blocks or throws on failure.
+        const parentSessionID = await resolveParentSession(
+          ctx.client,
+          input.sessionID,
+        );
+        if (parentSessionID) {
+          output.headers["x-parent-session-id"] = parentSessionID;
+        }
         // Inject project path + git remote for THIS request based on the
         // current plugin's project. Setting it here (rather than relying on
         // the fetch interceptor's getHeaders() global) ensures that

--- a/packages/opencode/test/subagent-detection.test.ts
+++ b/packages/opencode/test/subagent-detection.test.ts
@@ -1,0 +1,160 @@
+/**
+ * OpenCode sub-agent detection (#1300).
+ *
+ * A Task sub-agent runs in a child session whose `parentID` points at the
+ * spawning session. The plugin's `chat.headers` hook resolves that parent via
+ * the SDK and forwards it as `x-parent-session-id` — the same signal Claude
+ * Code emits natively — so the gateway flags the session as a sub-agent and
+ * sizes its LTM injection (#1302). Primary sessions have no parent and emit no
+ * such header.
+ *
+ * The lookup is cached per session and must never block or break the request.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Hooks, PluginInput } from "@opencode-ai/plugin";
+import { afterEach, describe, expect, test } from "vitest";
+import { LorePlugin } from "../src/index";
+
+interface MockOpts {
+  /** session id → parentID it should report. Absent ⇒ primary (no parent). */
+  parents?: Record<string, string>;
+  /** Records every session.get(id) call. */
+  calls?: string[];
+  /** When true, session.get rejects (transient failure). */
+  fail?: () => boolean;
+}
+
+function createMockClient(opts: MockOpts): PluginInput["client"] {
+  return {
+    tui: { showToast: () => Promise.resolve() },
+    session: {
+      get: (args: { path: { id: string } }) => {
+        const id = args?.path?.id;
+        opts.calls?.push(id);
+        if (opts.fail?.()) return Promise.reject(new Error("server down"));
+        const parentID = opts.parents?.[id];
+        return Promise.resolve({
+          data: parentID ? { id, parentID } : { id },
+        });
+      },
+      list: () => Promise.resolve({ data: [] }),
+      create: () => Promise.resolve({ data: { id: "worker_1" } }),
+      messages: () => Promise.resolve({ data: [] }),
+      message: () => Promise.resolve({ data: null }),
+      prompt: () => Promise.resolve({ data: {} }),
+    },
+  } as unknown as PluginInput["client"];
+}
+
+async function initPlugin(directory: string, client: PluginInput["client"]) {
+  return LorePlugin({
+    client,
+    project: { id: `proj-${directory}` } as unknown as PluginInput["project"],
+    directory,
+    worktree: directory,
+    serverUrl: new URL("http://localhost:0"),
+    $: {} as unknown as PluginInput["$"],
+  });
+}
+
+type ChatHeadersHook = NonNullable<Hooks["chat.headers"]>;
+type ChatHeadersInput = Parameters<ChatHeadersHook>[0];
+
+function chatInput(sessionID: string): ChatHeadersInput {
+  return {
+    sessionID,
+    agent: "build",
+    model: { providerID: "anthropic", modelID: "claude-3-5-sonnet" },
+    provider: { id: "anthropic" },
+    message: { id: "msg-1" },
+  } as unknown as ChatHeadersInput;
+}
+
+async function headersFor(
+  hooks: Hooks,
+  sessionID: string,
+): Promise<Record<string, string>> {
+  const output = { headers: {} as Record<string, string> };
+  await hooks["chat.headers"]?.(chatInput(sessionID), output);
+  return output.headers;
+}
+
+describe("OpenCode plugin — sub-agent detection (#1300)", () => {
+  let tmpDirs: string[] = [];
+  function makeTmp(label: string): string {
+    const dir = mkdtempSync(join(tmpdir(), `lore-subagent-${label}-`));
+    tmpDirs.push(dir);
+    return dir;
+  }
+  afterEach(() => {
+    for (const dir of tmpDirs) {
+      try {
+        rmSync(dir, { recursive: true, force: true });
+      } catch {
+        // best-effort
+      }
+    }
+    tmpDirs = [];
+  });
+
+  test("sub-agent session forwards its parentID as x-parent-session-id", async () => {
+    const dir = makeTmp("sub");
+    const client = createMockClient({
+      parents: { "sa-child-1": "sa-parent-1" },
+    });
+    const hooks = await initPlugin(dir, client);
+
+    const headers = await headersFor(hooks, "sa-child-1");
+    expect(headers["x-parent-session-id"]).toBe("sa-parent-1");
+    // Sanity: the normal session header is still the child's own id.
+    expect(headers["x-lore-session-id"]).toBe("sa-child-1");
+  });
+
+  test("primary session (no parentID) emits no x-parent-session-id", async () => {
+    const dir = makeTmp("primary");
+    const client = createMockClient({ parents: {} });
+    const hooks = await initPlugin(dir, client);
+
+    const headers = await headersFor(hooks, "primary-1");
+    expect(headers["x-parent-session-id"]).toBeUndefined();
+    expect(headers["x-lore-session-id"]).toBe("primary-1");
+  });
+
+  test("parent lookup is cached — session.get runs once across turns", async () => {
+    const dir = makeTmp("cache");
+    const calls: string[] = [];
+    const client = createMockClient({
+      parents: { "cache-child": "cache-parent" },
+      calls,
+    });
+    const hooks = await initPlugin(dir, client);
+
+    for (let i = 0; i < 3; i++) {
+      const headers = await headersFor(hooks, "cache-child");
+      expect(headers["x-parent-session-id"]).toBe("cache-parent");
+    }
+    expect(calls.filter((id) => id === "cache-child")).toHaveLength(1);
+  });
+
+  test("a lookup failure is swallowed and NOT cached (retried next turn)", async () => {
+    const dir = makeTmp("retry");
+    let down = true; // first call fails, then recovers
+    const client = createMockClient({
+      parents: { "retry-child": "retry-parent" },
+      fail: () => down,
+    });
+    const hooks = await initPlugin(dir, client);
+
+    // Turn 1: lookup fails — no header, request not broken.
+    const h1 = await headersFor(hooks, "retry-child");
+    expect(h1["x-parent-session-id"]).toBeUndefined();
+    expect(h1["x-lore-session-id"]).toBe("retry-child");
+
+    // Turn 2: server recovers — the failure was not cached, so it resolves now.
+    down = false;
+    const h2 = await headersFor(hooks, "retry-child");
+    expect(h2["x-parent-session-id"]).toBe("retry-parent");
+  });
+});


### PR DESCRIPTION
Closes #1300.

## Problem
The gateway's only sub-agent signal is the `x-parent-session-id` request header. **Claude Code emits it natively** for its Task sub-agents, but the **opencode plugin never did** — it only set `x-lore-session-id`/`-agent`/`-project`/`-git-remote`. So opencode Task sub-agents were treated as ordinary first-class sessions and received the full, un-sized LTM injection. #1302 makes the budget sub-agent-aware but only helps sessions the gateway can *detect* — this closes that gap for opencode.

## Fix
An opencode Task sub-agent runs in a **child session whose `parentID`** points at the spawning session. The `chat.headers` hook now resolves that parent via the SDK (`client.session.get`) and forwards a non-null `parentID` as `x-parent-session-id`.

That value is the parent's opencode session id — the same value the parent session sends as its `x-lore-session-id` — so the gateway resolves it through the existing `headerSessionIndex` and flags the child `isSubagent` (→ sub-agent-aware LTM budget, cache-warming exemption, fast eviction, EMA isolation). Even if the parent isn't resolvable yet, `isSubagent` is still set (which is what sizes the budget).

### Safety
- **Cached per session** (parentID is immutable), including the common primary-session `null`, so it's one SDK round-trip per session, not per turn.
- **Never blocks or breaks the request**: lookup failures are swallowed and **not cached**, so a transient error (server unreachable, session not yet persisted) retries next turn instead of permanently latching a real sub-agent as "not a sub-agent".

### Pi
Pi has no exposed sub-agent/parent-session concept (a single session id derived from its session file), so there's nothing to mirror there yet. If Pi gains sub-agents, mirror this approach.

## Tests
`packages/opencode/test/subagent-detection.test.ts`: sub-agent forwards its parentID; primary emits nothing; lookup is cached (one `session.get` across 3 turns); a failure is swallowed and retried next turn. **Mutation-verified**: dropping the header emit fails 3 tests; caching failures fails the retry test. Full opencode suite (34) passes; typecheck + oxlint + oxfmt clean; `index.ts` restored byte-identical after mutation testing.

## Acceptance
- ✅ opencode Task sub-agents set `isSubagent` on their gateway session (via `x-parent-session-id`).
- ✅ Verified via a plugin test that a sub-agent request carries the parent signal.