### PR TITLE
feat(sync): re-enqueue the linked entity graph on team approval (#1307)

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -174,6 +174,9 @@
 <!-- lore:019f27e4-458e-7d6a-bdfc-5ab2f35c5354 -->
 * **Migrated to settings**: migrated to settings.
 
+<!-- lore:019f5b56-d717-7acf-82cd-ecfc75ca4871 -->
+* **Migrated to TG): test failed at sync**: migrating to TG): test failed at sync.
+
 <!-- lore:019f0103-15cb-708f-9cff-f5c8f060d37a -->
 * **Migrated to Vitest in May 2026 — 312ms vs 30s startup time cited as reason**: migrated from Mocha + Chai + ts-node to Vitest in May 2026 — 312ms vs 30s startup time cited as reason.
 
@@ -477,14 +480,11 @@
 <!-- lore:019ee535-02e6-7648-82b7-d6c68de1256a -->
 * **Always provide file:line inventory when researching codebase impact**: Always provide file:line inventory when researching codebase impact. Expected format: \`filename:line — description\`. Cover all SQL patterns, API surfaces, test assertions, and schema version checks. Research-only phases must not change code. This is a recurring directive across 42+ sessions.
 
-<!-- lore:019f5afa-3e9d-7eb0-b398-54529c7ada7e -->
-* **Always require read-only adversarial security/correctness PR reviews via throwaway worktree**: When user requests an adversarial correctness/security/logic review of a PR (in opencode-lore or similar sensitive repos), always: (1) treat it as a MANDATORY pre-merge gate, (2) operate strictly READ-ONLY — never modify tracked files, (3) if mutation testing is needed, create a throwaway git worktree under /tmp/opencode, run tests there, verify the main tree is byte-identical afterward via sha256sum, then delete the worktree, (4) use the exact diff command the user specifies (e.g., \`jj diff\` vs main) to scope the review to the stated changed files, (5) expect and address numbered scrutiny points requiring PASS/FAIL/CONCERN verdicts with file:line evidence, especially around security-critical logic like encryption, scoping, DEK handling, and privilege/authorization boundaries. Provide structured, evidence-backed verdicts rather than general commentary.
-
 <!-- lore:019ef947-5487-71bc-bbb9-7b03b4f768b0 -->
 * **Always run full CI on main/release push — dorny/paths-filter only for PRs**: 🔴 Directive (June 24 2026, seen 34+ prior sessions): always run full CI on main/release push events. \`dorny/paths-filter\` skip logic only applies to PRs. Workflow bugs 'should never slip through regardless of which files changed.' Enforced in \`ci.yml\` via a 'Force full CI on main/release push' step (id: \`force\`) that sets \`code=true\` unconditionally on \`push\` events via \`echo "code=true" >> "$GITHUB\_OUTPUT"\`. The \`actionlint\` job runs unconditionally (no \`needs\`/\`if\`) for the same reason.
 
-<!-- lore:019f5947-2ed5-7eba-9f8a-10e2a0db0db2 -->
-* **Always run tests, lint/format checks, then create a PR before merging**: The user consistently enforces a strict git/PR workflow: before committing, run all relevant tests and lint/format checks (e.g., oxfmt, oxlint, vitest) on changed files; treat pre-existing unrelated warnings as non-blocking. After tests pass, commit with a conventional commit message, push to a dedicated feature branch tracking origin, and always open a PR for review rather than merging directly. Each distinct fix/feature gets its own branch and PR (never bundle unrelated fixes). When reviewing PRs (including merged ones), use adversarial scrutiny with mutation testing performed only in throwaway /tmp worktrees, never touching tracked files directly. Maintain a todo list tracking PR status (in\_progress/completed) across multi-PR sessions. Apply this workflow automatically for every code change without being asked each time.
+<!-- lore:019f5b3f-b055-72cf-be6f-3c990de2723d -->
+* **Always run full test suite after changes before proceeding**: After making code changes (especially in packages/gateway or packages/core), always run the full test suite (not just a subset) and verify all tests pass with zero failures before concluding the work is solid or proceeding to commit/next steps. Report specific test counts, files passed/skipped, and duration. If test counts seem off from expectations, investigate discrepancies (e.g., missing test files, tests nested elsewhere) before moving on. This full-suite verification discipline applies even when changes appear scoped to a single file or package, and should be done prior to committing changes or declaring a refactor/fix complete.
 
 <!-- lore:019ef371-d1ab-791d-b04a-22f50f4e9013 -->
 * **Always scope fix tasks strictly to test fixtures, never touching src files**: When the user assigns a task to fix failing tests after a schema/API migration, they explicitly constrain the work to \`packages/\*/test/\` directories only, with an explicit prohibition on modifying \`packages/\*/src/\` files. The user expects the assistant to identify all broken raw SQL or fixture code in test files and update only those, leaving production source code untouched. This pattern applies whenever a schema change has already been implemented in src and the remaining work is purely test-side adaptation.
@@ -519,9 +519,6 @@
 <!-- lore:019eff04-9c94-773c-b2ed-dca9ee730f6f -->
 * **Blog tone: manual note-taking critique — respect skilled practitioners, highlight focus cost**: 🔴 Directive: when critiquing manual note-taking in Lore positioning copy, never imply incompetence ('you're bad at it anyway'). Acknowledge skilled practitioners exist; frame the cost as time and focus/context-switch overhead: 'The cost was never that you're bad at it. It's that the filing keeps pulling your focus off the thing you were actually trying to do.'
 
-<!-- lore:019f5ae9-30dd-7ece-b501-4d3d720e1045 -->
-* **Choose the recommended option when assistant presents choices**: When the assistant proposes multiple options for how to proceed (e.g., plan approvals, eval redesigns, bug fix approaches) and marks one as 'Recommended', the user consistently selects that recommended option, sometimes combining it with an additional follow-up action (e.g., 'do X (Recommended) AND finish Y later'). When presenting choices, clearly mark the recommended option, as the user is likely to defer to it and may add supplementary instructions rather than deviate from it entirely.
-
 <!-- lore:019ee673-63cb-7a6d-9b3b-844fdab3eaff -->
 * **Connection timeout: 10s is generous enough — do not increase; capture aborts instead of raw timeouts**: Connection timeout: 10s is generous — do not increase. Raw connect timeouts are not actionable for Sentry capture. Prefer capturing abort events with loop-lag/RSS context instead.
 
@@ -537,14 +534,14 @@
 <!-- lore:019f199d-06d5-7381-96fb-15d3d6d2fcd4 -->
 * **feat/persisted-prompt-deltas: investigate before discarding — contains unique commits**: 🔴 Directive (seen 23+ prior sessions): branch \`feat/persisted-prompt-deltas\` contains unique commits that have not been merged. Before deleting or discarding this branch, always investigate whether the work has been merged or superseded. Same applies to \`fix-resilient-dedup-scan-knowledge-merge-ui\`. Pattern: user consistently flags these branches for investigation rather than bulk deletion when cleaning up stale branches.
 
+<!-- lore:019f5b3c-f10c-7f0b-bc03-9eef9ebc85a4 -->
+* **Maintain a self-documenting sync engine via explicit code comments and consistent naming/design conventions**: When implementing or reviewing sync/outbox logic (db.ts, sync.ts, sync-data.ts), the user consistently: (1) writes detailed inline code comments explaining WHY a design choice was made (e.g., 'never lose a write', 'never admitted under the entity cap', 'a register row outlives the knowledge entry's death-cert'), citing issue/PR numbers (#909, #823, #1217) for traceability; (2) uses consistent composite-key patterns (char(31) unit-separator joins like logical\_id||US||replica\_id) across all sync tables; (3) gates triggers precisely — only firing UPDATE captures on semantically meaningful column changes, omitting DELETE triggers for append-only/non-deletable tables; (4) ensures error/failure paths never throw silently but fail closed (pause, defer, or fall back) rather than crash or leak data. When writing or reviewing this code, preserve/extend these conventions: composite key patterns, explicit conditional trigger gating, and always document design rationale with an issue reference in comments.
+
 <!-- lore:019ef69c-9430-7808-a25f-a20edeaf14f5 -->
 * **Make sure to address the seer comment there (re-emphasized via system-reminder directive — overrides prior state**: User stated make sure to address the seer comment there (re-emphasized via system-reminder directive — overrides prior state,
 
 <!-- lore:019eff03-77c0-7db3-ac9c-4cc105952816 -->
 * **Never evaluate alternatives in this project context**: 🔴 Directive (June 25 2026): never evaluate alternatives. Applies to assistant behavior when working on the loreai/opencode-lore project.
-
-<!-- lore:019f5b0f-5841-771e-9b5c-d6457c122166 -->
-* **Never let sync engine crash on partial failure; always fail closed or defer**: When designing/reviewing packages/gateway/src/sync.ts (and related sync logic), the user consistently enforces fail-safe degradation over crashing: encryption/context resolution functions must NEVER throw — any failure (missing user\_id, corrupt scope\_keys row, HPKE unwrap error, missing team wrap) returns null so callers degrade gracefully (push returns 'stop', pull defers just that table). Similarly, poison/unsyncable rows (CHECK violations, FK orphans, schema mismatches) must be recorded as conflicts and skipped/marked synced rather than retried forever or aborting the whole multi-table sync cycle. Transient errors (network/5xx/auth) are kept pending and retried ('never lose a write'). When implementing or reviewing sync code, always isolate failures to the single row/table/entry level, use explicit error classification (transient/poison/quota), and document these guarantees via clear code comments explaining the failure-mode rationale.
 
 <!-- lore:019ef029-6ac3-7605-bc76-fc627dc3f50a -->
 * **Never publish nightlies to npm — GHCR only**: 🔴 Directive (June 22 2026): nightlies are NEVER published to npm. Onur Temizkan uses \`lore upgrade nightly\` which pulls from GHCR (\`ghcr.io/byk/loreai:nightly\`). npm registry contains only stable releases (e.g. \`@loreai/gateway\`, \`@loreai/core\`, \`opencode-lore\`). Nightly version string is computed deterministically from commit timestamp. Publish pipeline: \`Publish Nightly to GHCR\` job in \`publish.yml\`; tagged as both \`nightly\` and \`nightly-\<version>\`.
@@ -554,6 +551,9 @@
 
 <!-- lore:019ef387-4b17-77d7-a76d-062269f0214b -->
 * **Never weaken assertions or change expected values to make a test pass**: 🔴 Directive (seen 23+ sessions): never weaken/delete an assertion or change an expected value to make a test pass. When a test fails due to a schema change, fix the test setup (INSERT helpers, raw SQL, helper functions) to match the new schema — never adjust the assertion target. Example: integrity.test.ts duplicate detection fixed by adding knowledge\_meta rows to raw INSERTs, not by changing \`duplicates.length >= 1\` assertion.
+
+<!-- lore:019f5b29-8f8c-784c-adaa-d4f85c0e4dc9 -->
+* **Perform read-only adversarial correctness/security PR reviews with worktree-isolated mutation testing**: When asked to review a PR (feat/827-\* series in opencode-lore), always: (1) treat the review as strictly READ-ONLY — never modify tracked files in the main working tree; (2) run any mutation testing in a throwaway git worktree under /tmp/opencode, checked out at the PR commit; (3) after mutation testing, verify the main tree is byte-identical to baseline via sha256sum before/after; (4) remove the throwaway worktree when finished; (5) run full baseline test suites (unit + integration, often via LORE\_INTEGRATION=1) before mutating; (6) work through a numbered checklist covering correctness points (no plaintext/private-key leaks, encryption-state gating, cross-scope/user isolation, KV-gate idempotency, migration safety, wire-convention consistency) plus targeted mutation kills to validate test coverage; (7) explicitly flag any SURVIVED mutation as a coverage gap in the final verdict (e.g., SHIP-WITH-FOLLOWUPS) rather than silently ignoring it.
 
 <!-- lore:019f22c5-89b8-7d9a-88a2-3c01c2685f20 -->
 * **Prefers a learned/persisted cap when current free memory is close over learn-time value (via reconcileEmbedCap)**: prefers a learned/persisted cap when current free memory is close to learn-time value (via reconcileEmbedCap),
@@ -600,8 +600,8 @@
 <!-- lore:019ef676-61ff-7594-83e1-e3e1a1ff7a26 -->
 * **replicaId() must always read from live DB (KV) each call**: replicaId() reads from KV on every invocation — never caches the value. Test suite swaps DB between cases so cached replicaId would return stale device identity. User assertion: 'always read it from the live DB' and 'always reads from live DB'. This ensures each test case gets a fresh replica ID matching its isolated database.
 
-<!-- lore:019f5aed-cc23-703f-9f30-c4a0dcfff405 -->
-* **Respect explicitly rejected approaches**: Behavioral pattern detected across 39 sessions (action: rejected-approach). The user consistently demonstrates this behavior.
+<!-- lore:019f5b3c-e91a-791e-bc22-de086f674b6b -->
+* **Review code before committing**: Behavioral pattern detected across 77 sessions (action: requested-review). The user consistently demonstrates this behavior.
 
 <!-- lore:019efb32-23de-7867-8e02-e5e57d2a734b -->
 * **Ship bug fixes as separate sequential PRs per bug**: User directive (June 24–25 2026): when fixing multiple bugs or shipping a feature series, ship them as separate sequential PRs — one logical change per PR. Do not combine fixes into a single PR even if related. Enforced across: Bug 1 (PR #974), Bug 2 (PR #976), Bug 3 (PR #979), regressions (PR #982), #627 Phase 0 (PR #939), Phase 1 (PR #977), Phase 2 (PR #986), #911 (PR #988). Follow-up PRs for regressions introduced by a fix are also shipped as separate PRs, not folded back into the original.
@@ -609,8 +609,11 @@
 <!-- lore:019f1a86-466f-7976-ba79-9481eea93805 -->
 * **Telemetry must never break or slow the read path**: 🔴 Directive (seen 29+ prior sessions): telemetry instrumentation must NEVER break or slow the read path. Applies to \`ReadPathTimer.await\`, \`setupReadPathTimingCapture()\`, and any future metric emission in \`sentry.ts\`. Acceptable pattern: O(1) \`===\` comparisons + \`+=\` in \`finally\` block; \`emit()\` and gateway hook both wrapped in try/catch. Rejecting promises must propagate untouched. Any telemetry that could throw or block on the hot read path is a BLOCKER.
 
+<!-- lore:019f5b4d-1c8c-7bfb-9cda-7128cbfd27a0 -->
+* **Use mutation testing to verify test suite effectiveness on PRs**: When reviewing or validating a PR/change, the user consistently expects systematic mutation testing: introduce deliberate code mutations (e.g., stubbing a function, corrupting a value, bypassing a guard, altering a comparison) into the implementation under test, then rerun the full relevant test suite to check whether tests fail (mutant killed) or pass (mutant survives, indicating a test gap). Report exact test run results (files/tests passed/failed, failure messages, timings). Explicitly reason about whether each mutation SHOULD have been caught given the code's intended behavior, and flag any surviving mutants as coverage gaps needing investigation or new tests. When results are surprising or contradictory (e.g., a mutation expected to fail silently succeeds), dig into the root cause before concluding. Always restore the original file after testing a mutation.
+
 <!-- lore:019f17c2-11df-731b-b7b9-747b0e03eeb0 -->
 * **Uses local ONNX embeddings (default for recall vector search via sqlite-vec) — not only on explicit local embeddings provider selection**: user uses local ONNX embeddings (default for recall vector search via sqlite-vec) — not only on explicit local embeddings provider selection.
 
-<!-- lore:019f5af0-1366-7b0e-b72f-f8fecbde4f47 -->
-* **Verify system health empirically before trusting automated gate/threshold logic**: When an automated system (orchestrator, CI, gate check) reports a negative or blocking status based on a threshold or heuristic, don't accept it at face value — independently verify the underlying condition with a direct manual probe or test before deciding whether to override the automated decision. If manual verification shows the system is actually healthy (e.g., probe succeeds despite transient errors, backfills complete despite temporary stalls, tests pass despite flaky history), intervene to bypass the overly strict automated gate rather than waiting out its conservative cooldown/retry logic. Also scrutinize whether the threshold or heuristic itself (e.g., error count, coverage floor, settle time) is well-calibrated, and flag/adjust it if it produces false negatives. Document the reasoning for overriding automation explicitly.
+<!-- lore:019f5b29-1f40-7d89-89bc-e0139b3aa834 -->
+* **Verify code claims against actual implementation before trusting comments/behavior**: When reviewing code (especially sync.ts, PR reviews, or refactors), always trace helper function implementations (e.g., asString, coercion utilities) to their actual source rather than trusting inline comments or apparent logic. Explicitly check whether fallback branches, error paths, or defensive code are dead code by verifying the real return values/behavior of called functions. Flag discrepancies between what comments claim and what code actually does (e.g., a \`?? fallback\` that never triggers because the underlying function never returns nullish). This pattern applies during adversarial PR reviews, refactor validation, and behavior-change audits — prioritize empirical verification (reading source, running tests) over assumed behavior, and explicitly call out dead code, behavior changes, or bugs found via this tracing, even if pre-existing and outside PR scope.

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -633,6 +633,18 @@ export function listPendingTeamPromotions(
   }));
 }
 
+// E-5-F3 (#1307): notified with a knowledge logical_id whenever its team-promotion status CHANGES
+// (approve OR reject), so the sync layer can re-enqueue the entry's linked entity graph and let the
+// push re-resolve each row's scope — migrating it INTO the team on approve and BACK to personal on
+// reject (symmetric). A hook (not a direct import) because sync-data.ts already imports ltm.ts — the
+// reverse import would be a cycle.
+let teamPromotionChangedCb: ((logicalId: string) => void) | null = null;
+export function onKnowledgeTeamPromotionChanged(
+  cb: (logicalId: string) => void,
+): void {
+  teamPromotionChangedCb = cb;
+}
+
 /**
  * Approve a knowledge entry for team promotion (manual review). Sets 'approved' + reviewer/time on
  * the current version, in place. Idempotent; returns false if no current row matched the id.
@@ -646,6 +658,9 @@ export function approveForTeam(
       "UPDATE knowledge SET approval_status = 'approved', approved_by = ?, approved_at = ? WHERE logical_id = ? AND is_current = 1",
     )
     .run(approvedBy ?? null, Date.now(), logicalId);
+  // The knowledge row's own migration rides its UPDATE (column-agnostic capture trigger); its linked
+  // entity graph has no such trigger from this UPDATE, so re-enqueue it explicitly (#1307).
+  if (res.changes > 0) teamPromotionChangedCb?.(logicalId);
   return res.changes > 0;
 }
 
@@ -659,6 +674,9 @@ export function rejectForTeam(logicalId: string): boolean {
       "UPDATE knowledge SET approval_status = 'rejected', approved_by = NULL, approved_at = NULL WHERE logical_id = ? AND is_current = 1",
     )
     .run(logicalId);
+  // Symmetric with approveForTeam: re-enqueue the linked graph so it migrates BACK to personal
+  // (unless an entity is still linked to OTHER team-approved knowledge — the resolver decides).
+  if (res.changes > 0) teamPromotionChangedCb?.(logicalId);
   return res.changes > 0;
 }
 

--- a/packages/core/src/sync-data.ts
+++ b/packages/core/src/sync-data.ts
@@ -30,7 +30,10 @@ import {
   withTransaction,
 } from "./db";
 import { putWrappedScopeKey } from "./crypto/keystore";
-import { rematerializeConfidence } from "./ltm";
+import {
+  onKnowledgeTeamPromotionChanged,
+  rematerializeConfidence,
+} from "./ltm";
 
 // The stable per-device id (also used by the confidence CRDT) doubles as the device id
 // for sync's server-side reaper watermark (#909). Re-exported so the gateway can report
@@ -1259,6 +1262,62 @@ export function reseedProjectContent(projectId: string): void {
   }
 }
 onProjectRemoteBackfilled(reseedProjectContent);
+
+/**
+ * E-5-F3 (#1307): when a knowledge entry is APPROVED into a team, re-enqueue its LINKED ENTITY GRAPH
+ * so the next push migrates those rows to the team scope too. The knowledge row itself is already
+ * re-enqueued by approveForTeam's UPDATE (column-agnostic capture trigger); its entities/aliases/
+ * relations/refs have no trigger from that UPDATE. The push's teamScopeForContent resolver decides
+ * each row's actual scope (e.g. a relation migrates only when BOTH endpoints share the team); here
+ * we just re-enqueue the candidates, gated on the same parent/remote gates as the capture triggers.
+ * Idempotent: an unchanged row short-circuits in the push (same content_hash AND scope).
+ */
+export function reenqueueKnowledgeTeamGraph(logicalId: string): void {
+  if (getTeamConfig(ENABLED_KEY) !== "1") return;
+  const now = Date.now();
+  const enqueue = (sql: string, ...params: unknown[]) =>
+    db()
+      .query(
+        `INSERT INTO sync_outbox (table_name, row_id, op, changed_at) ${sql}`,
+      )
+      .run(...params);
+  const linkedEntities =
+    "SELECT entity_id FROM knowledge_entity_refs WHERE knowledge_id = ?";
+  // The refs of this knowledge (they follow the knowledge → team).
+  enqueue(
+    `SELECT 'knowledge_entity_refs', knowledge_id || char(31) || entity_id, 'upsert', ?
+       FROM knowledge_entity_refs ref
+      WHERE ref.knowledge_id = ?
+        AND ${knowledgeParentGate("ref.knowledge_id")} AND ${entityParentGate("ref.entity_id")}`,
+    now,
+    logicalId,
+  );
+  // The linked entities (now referenced by team-approved knowledge).
+  enqueue(
+    `SELECT 'entities', e.id, 'upsert', ? FROM entities e
+      WHERE e.id IN (${linkedEntities}) AND ${remoteBackedGate("e.")}`,
+    now,
+    logicalId,
+  );
+  // Their aliases (follow the entity).
+  enqueue(
+    `SELECT 'entity_aliases', a.id, 'upsert', ? FROM entity_aliases a
+      WHERE a.entity_id IN (${linkedEntities}) AND ${entityParentGate("a.entity_id")}`,
+    now,
+    logicalId,
+  );
+  // Relations touching a linked entity (both endpoints gated; the push migrates only those whose
+  // BOTH endpoints resolve to the same team).
+  enqueue(
+    `SELECT 'entity_relations', r.id, 'upsert', ? FROM entity_relations r
+      WHERE (r.entity_a IN (${linkedEntities}) OR r.entity_b IN (${linkedEntities}))
+        AND ${entityParentGate("r.entity_a")} AND ${entityParentGate("r.entity_b")}`,
+    now,
+    logicalId,
+    logicalId,
+  );
+}
+onKnowledgeTeamPromotionChanged(reenqueueKnowledgeTeamGraph);
 
 // ---------------------------------------------------------------------------
 // Per-row sync state

--- a/packages/gateway/test/sync.test.ts
+++ b/packages/gateway/test/sync.test.ts
@@ -2371,6 +2371,93 @@ describe("pushOnce — team scope promotion + migration (E-5-F3-3)", () => {
     expect(rows).toHaveLength(1);
     expect(rows[0].scope_id).toBe(REMOTE_SCOPE); // personal — pending is not promoted
   });
+
+  test("approval migrates the linked entity graph too (#1307)", async () => {
+    const pid = ensureProjectCore("/tmp/lore-f3graph");
+    db()
+      .query("UPDATE projects SET git_remote='github.com/x/g' WHERE id=?")
+      .run(pid);
+    db()
+      .query(
+        "INSERT INTO scopes (id, org_id, kind, name, promotion_policy, created_at, updated_at) VALUES ('TG','o','team','TG','manual',0,0)",
+      )
+      .run();
+    setProjectScope(pid, "TG");
+    const kid = ltm.create({
+      projectPath: "/tmp/lore-f3graph",
+      category: "pattern",
+      title: "K",
+      content: "c",
+      scope: "project",
+    });
+    // Two entities in the project, both linked to K, with an alias + a relation between them.
+    for (const e of ["e1", "e2"])
+      db()
+        .query(
+          "INSERT INTO entities (id, project_id, entity_type, canonical_name, created_at, updated_at) VALUES (?,?,'tool',?,0,0)",
+        )
+        .run(e, pid, e);
+    for (const e of ["e1", "e2"])
+      db()
+        .query(
+          "INSERT INTO knowledge_entity_refs (knowledge_id, entity_id) VALUES (?, ?)",
+        )
+        .run(kid, e);
+    db()
+      .query(
+        "INSERT INTO entity_aliases (id, entity_id, alias_type, alias_value, created_at) VALUES ('a1','e1','name','X',0)",
+      )
+      .run();
+    db()
+      .query(
+        "INSERT INTO entity_relations (id, entity_a, entity_b, relation, created_at, updated_at) VALUES ('r1','e1','e2','rel',0,0)",
+      )
+      .run();
+
+    syncData.enableSync("basic");
+    await pushOnce(makeClient() as never);
+    const scopeOf = (t: string, pred: (r: RemoteRow) => boolean) =>
+      tableRows(t).find(pred)?.scope_id;
+    // While K is pending, the whole graph is personal.
+    expect(scopeOf("knowledge", (r) => r.id === kid)).toBe(REMOTE_SCOPE);
+    expect(scopeOf("entities", (r) => r.id === "e1")).toBe(REMOTE_SCOPE);
+    expect(scopeOf("entity_relations", (r) => r.id === "r1")).toBe(
+      REMOTE_SCOPE,
+    );
+
+    // Approve K → the next push migrates K AND its linked entity graph to the team scope.
+    expect(ltm.approveForTeam(kid, "u1")).toBe(true);
+    await pushOnce(makeClient() as never);
+    expect(scopeOf("knowledge", (r) => r.id === kid)).toBe("TG");
+    expect(scopeOf("entities", (r) => r.id === "e1")).toBe("TG");
+    expect(scopeOf("entities", (r) => r.id === "e2")).toBe("TG");
+    expect(scopeOf("entity_aliases", (r) => r.id === "a1")).toBe("TG");
+    expect(scopeOf("entity_relations", (r) => r.id === "r1")).toBe("TG"); // both endpoints team
+    expect(
+      scopeOf(
+        "knowledge_entity_refs",
+        (r) => r.knowledge_id === kid && r.entity_id === "e1",
+      ),
+    ).toBe("TG");
+    // No personal duplicate lingers after the migration.
+    expect(tableRows("entities").filter((r) => r.id === "e1")).toHaveLength(1);
+
+    // Symmetric: rejecting demotes K AND its linked graph BACK to personal (no team leftovers).
+    expect(ltm.rejectForTeam(kid)).toBe(true);
+    await pushOnce(makeClient() as never);
+    expect(scopeOf("knowledge", (r) => r.id === kid)).toBe(REMOTE_SCOPE);
+    expect(scopeOf("entities", (r) => r.id === "e1")).toBe(REMOTE_SCOPE);
+    expect(scopeOf("entity_relations", (r) => r.id === "r1")).toBe(
+      REMOTE_SCOPE,
+    );
+    expect(
+      scopeOf(
+        "knowledge_entity_refs",
+        (r) => r.knowledge_id === kid && r.entity_id === "e1",
+      ),
+    ).toBe(REMOTE_SCOPE);
+    expect(tableRows("entities").filter((r) => r.id === "e1")).toHaveLength(1);
+  });
 });
 
 describe("knowledge team-scope pull decrypt — E-5-F2 (#827)", () => {


### PR DESCRIPTION
Closes #1307. Completes the F3-3 entity-graph migration for the **manual-approval** flow.

## Gap
On `approveForTeam`, the knowledge row's own personal→team migration rides its `UPDATE` (the column-agnostic capture trigger). But its linked entity graph (`entities` / `entity_aliases` / `entity_relations` / `knowledge_entity_refs`) has **no** trigger from that UPDATE — so a manual-policy graph, pushed under the **personal** scope at creation, would stay personal while its knowledge moved to the team. (Auto-policy was already correct: the whole graph resolves to the team on first push, no migration.)

## Fix
- **`ltm.ts`**: `approveForTeam` notifies an `onKnowledgeApprovedForTeam` hook with the logical_id. A hook — not a direct import — because `sync-data.ts` already imports `ltm.ts`; the reverse would be a cycle (same pattern as `onProjectRemoteBackfilled`).
- **`sync-data.ts`**: `reenqueueKnowledgeTeamGraph(logicalId)` re-enqueues the approved entry's linked entities, their aliases, the relations touching them, and its refs — gated on the same parent/remote gates as the capture triggers (mirrors `reseedProjectContent`). The push's `teamScopeForContent` resolver decides each row's **actual** scope (a relation migrates only when **both** endpoints share the team); unchanged rows short-circuit (same content_hash AND scope). Registered at module load.

## Test (gateway, faithful mock)
Approving a manual-policy entry with two linked entities (+ an alias + a relation between them) migrates K **and** the full linked graph (entities, alias, relation, refs) from personal → team on the next push, with no personal duplicate left.

Full sync + core sync suites green, 0 TS errors, lint clean. Follow-up from the F3-3 (#1304) review.