### PR TITLE
fix(gateway): inject knowledge-delta as a user→assistant pair (stop M3 acknowledging it)

### DIFF
--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -1181,15 +1181,46 @@ export function coalesceAdjacentAssistants(
   for (const m of messages) {
     const last = merged[merged.length - 1];
     if (last && last.role === "assistant" && m.role === "assistant") {
+      // Anthropic (and the block-order-preserving egress) require any leading
+      // thinking / redacted_thinking blocks to stay FIRST in an assistant
+      // message when extended thinking is active — clients inspect content[0].
+      // The injected knowledge-delta payload lives in `last`; naively
+      // concatenating `[...last.content, ...m.content]` would push `m`'s leading
+      // reasoning blocks off index 0 and produce a wire-invalid message (hard
+      // 400 on every replay turn of an extended-thinking tool loop). Splice
+      // `last`'s blocks AFTER `m`'s leading reasoning run instead — mirrors the
+      // injectContextWarning insertion rule. `last` is the earlier message and
+      // never itself leads with reasoning (it is the synthetic delta payload),
+      // so only `m`'s leading run needs to be protected.
+      let lead = 0;
+      while (lead < m.content.length && isReasoningBlock(m.content[lead])) {
+        lead++;
+      }
       merged[merged.length - 1] = {
         role: "assistant",
-        content: [...last.content, ...m.content],
+        content: [
+          ...m.content.slice(0, lead),
+          ...last.content,
+          ...m.content.slice(lead),
+        ],
       };
     } else {
       merged.push(m);
     }
   }
   return merged;
+}
+
+/**
+ * True for a thinking block or a redacted_thinking block (the latter carried as
+ * an `opaque` passthrough — see requestHasThinking). Such blocks must remain at
+ * the head of an assistant message when extended thinking is active.
+ */
+function isReasoningBlock(block: GatewayContentBlock): boolean {
+  return (
+    block.type === "thinking" ||
+    (block.type === "opaque" && block.raw.type === "redacted_thinking")
+  );
 }
 
 /** @internal Exported for tests. */

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -865,14 +865,26 @@ function parseMessageInsertSelector(raw: string): MessageInsertSelector | null {
   }
 }
 
-function parseDeltaMessage(raw: string): GatewayMessage | null {
+function isGatewayMessage(v: unknown): v is GatewayMessage {
+  const m = v as Partial<GatewayMessage> | null;
+  return (
+    !!m &&
+    (m.role === "user" || m.role === "assistant") &&
+    Array.isArray(m.content)
+  );
+}
+
+// A delta block's content is now a user→assistant PAIR, stored as a JSON array.
+// Legacy blocks (persisted before the pair change, and single-message test
+// fixtures) stored ONE message object — accept both so already-persisted
+// sessions keep replaying and never crash. Returns [] on anything unparseable.
+function parseDeltaMessages(raw: string): GatewayMessage[] {
   try {
-    const parsed = JSON.parse(raw) as Partial<GatewayMessage>;
-    if (parsed.role !== "user" && parsed.role !== "assistant") return null;
-    if (!Array.isArray(parsed.content)) return null;
-    return parsed as GatewayMessage;
+    const parsed = JSON.parse(raw) as unknown;
+    if (Array.isArray(parsed)) return parsed.filter(isGatewayMessage);
+    return isGatewayMessage(parsed) ? [parsed] : [];
   } catch {
-    return null;
+    return [];
   }
 }
 
@@ -1151,6 +1163,35 @@ export function captureToolPairing400(input: {
   return true;
 }
 
+/**
+ * Merge runs of adjacent assistant messages into a single assistant message
+ * (content blocks concatenated in order). Used after knowledge-delta injection:
+ * the injected user→assistant pair can seat its trailing assistant right before
+ * a real assistant(tool_use) in a mid-tool-loop turn, which strict-alternation
+ * upstreams reject. Merging is a no-op unless such a run exists. user↔user
+ * adjacency is intentionally left alone (pre-existing behavior; providers accept
+ * it, and the delta-placement tests rely on distinct user blocks).
+ *
+ * @internal Exported for tests.
+ */
+export function coalesceAdjacentAssistants(
+  messages: GatewayMessage[],
+): GatewayMessage[] {
+  const merged: GatewayMessage[] = [];
+  for (const m of messages) {
+    const last = merged[merged.length - 1];
+    if (last && last.role === "assistant" && m.role === "assistant") {
+      merged[merged.length - 1] = {
+        role: "assistant",
+        content: [...last.content, ...m.content],
+      };
+    } else {
+      merged.push(m);
+    }
+  }
+  return merged;
+}
+
 /** @internal Exported for tests. */
 export function applySessionPromptDeltas(
   messages: GatewayMessage[],
@@ -1171,12 +1212,15 @@ export function applySessionPromptDeltas(
     rawSelector: string;
     clamped: number;
     safe: number;
-    message: GatewayMessage;
+    messages: GatewayMessage[];
   }> = [];
   for (const delta of deltas) {
     const selector = parseMessageInsertSelector(delta.selector);
-    const message = parseDeltaMessage(delta.content);
-    if (!selector || !message) {
+    // NB: name this `blockMessages`, NOT `messages` — the function parameter
+    // `messages` (the conversation array) must stay in scope below for
+    // clamped/safeDeltaInsertIndex, which are relative to the CONVERSATION.
+    const blockMessages = parseDeltaMessages(delta.content);
+    if (!selector || !blockMessages.length) {
       log.warn(
         `prompt-delta: skipping corrupt delta seq=${delta.seq} session=${sessionID.slice(0, 16)}`,
       );
@@ -1197,7 +1241,7 @@ export function applySessionPromptDeltas(
       rawSelector: delta.selector,
       clamped,
       safe,
-      message,
+      messages: blockMessages,
     });
   }
   // Sort by the (stable) safe position DESC, then seq DESC, so splicing
@@ -1216,7 +1260,7 @@ export function applySessionPromptDeltas(
   // `messages[0]` (production session 1GYu, k:019ece09). Batched at the end so
   // each drift = one DB write, not one per turn.
   const reanchored: Array<{ seq: number; selector: string }> = [];
-  for (const { seq, rawSelector, clamped, safe, message } of parsed) {
+  for (const { seq, rawSelector, clamped, safe, messages } of parsed) {
     // Selector positions are defined against the transformed upstream message
     // array at the time the delta is created (where they were already made
     // tool-pair-safe via safeDeltaInsertIndex). Re-inserting at the SAME index
@@ -1246,12 +1290,29 @@ export function applySessionPromptDeltas(
       rawSelectorObj.insertAt = safe;
       reanchored.push({ seq, selector: JSON.stringify(rawSelectorObj) });
     }
-    out.splice(safe, 0, message);
+    // Splice ALL of a block's messages at `safe`, contiguous and in order (the
+    // user→assistant pair; a legacy single-message block splices as one). Blocks
+    // are processed high-safe-first, so a block's pair is never split by a later
+    // (lower) splice, and stacked pairs alternate cleanly.
+    out.splice(safe, 0, ...messages);
   }
   for (const { seq, selector } of reanchored) {
     updateSessionPromptDeltaSelector(sessionID, seq, selector);
   }
-  return out;
+  // The knowledge delta is injected as a user→assistant PAIR. In a mid-tool-loop
+  // turn (tail = assistant(tool_use) → user(tool_result)) the tool-pair guard
+  // walks the insert index to BEFORE the assistant(tool_use), so the pair's
+  // trailing (injected) assistant lands immediately before that real assistant —
+  // producing two consecutive assistant messages. That index is frozen for the
+  // session, so a strict-alternation upstream (Anthropic maps messages 1:1, no
+  // merge) would reject it every turn. Collapse adjacent assistant messages into
+  // one (concatenated content blocks) — semantically identical on the wire and
+  // valid for every egress protocol. tool_use stays in the merged assistant,
+  // still immediately followed by its user(tool_result), so tool-pairing holds.
+  // Only assistant↔assistant runs are merged (they essentially only arise from
+  // this injection); user↔user adjacency — the pre-existing single-message
+  // behavior — is left untouched.
+  return coalesceAdjacentAssistants(out);
 }
 
 function ltmKeyMap(keys: string[] | undefined): Map<string, string> {
@@ -1413,7 +1474,7 @@ export function buildKnowledgeDeltaMessage(
     category: string;
     title: string;
   }>,
-): GatewayMessage | null {
+): GatewayMessage[] {
   // Emit ONLY when there is genuine new/changed knowledge to surface. A
   // removals-only diff (a pinned entry deleted/superseded by background
   // consolidation, or dropped from the selected set) no longer injects a
@@ -1423,7 +1484,7 @@ export function buildKnowledgeDeltaMessage(
   // every turn). The removal is still recorded in the block's `mut` signature
   // by the caller (advanceSurfacedKeys), so the surfaced set still advances;
   // the stale pin is simply left for the next session start to refresh.
-  if (!entries.length) return null;
+  if (!entries.length) return [];
   const renderedIds: string[] = [];
   let rendered = formatKnowledge(
     entries.map((entry) => ({
@@ -1476,18 +1537,45 @@ export function buildKnowledgeDeltaMessage(
           : ""
       }`
     : "";
-  return {
-    role: "user",
-    content: [
-      {
-        type: "text",
-        text:
-          "[Lore knowledge update: durable prompt delta. This message is inserted by Lore and replayed byte-identically on later turns until an intentional cache reset.]\n\n" +
-          rendered +
-          tocRendered,
-      },
-    ],
-  };
+  // Inject as a user→assistant PAIR (mirrors the distilled-prefix pattern in
+  // core/gradient.ts `buildPrefixMessages`), NOT a lone user message. A lone
+  // user block read as an open user turn, so instruction-literal models (e.g.
+  // MiniMax M3) prefaced every turn with "Acknowledged… none of this applies…
+  // I won't reference this knowledge." The pair closes the exchange: the tiny
+  // user note frames it as ambient context (and says not to reply), and the
+  // KNOWLEDGE PAYLOAD rides the ASSISTANT turn so the model treats it as its
+  // own settled prior note rather than a pending request.
+  //
+  // Placement is safe for role-alternation + tool-pairing: the block is spliced
+  // before the final message (a user turn / tool_result in an agent request via
+  // safeDeltaInsertIndex against len-1), so the injected assistant is always
+  // followed by a user turn. Stacked pairs alternate cleanly
+  // (…user,asst,user,asst,final-user). The only same-role adjacency possible is
+  // [user][inj-user] at the leading edge — identical to the prior single-user
+  // behavior. The pair carries no tool_use/tool_result.
+  //
+  // NOTE: keep the substring "Lore knowledge update" in the user note — the
+  // cache-stability e2e asserts on it.
+  return [
+    {
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text: "[Lore knowledge update — ambient context injected by Lore. Do not reference this format or reply to this message; silently use anything relevant and ignore the rest. Replayed byte-identically on later turns until an intentional cache reset.]",
+        },
+      ],
+    },
+    {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: rendered + tocRendered,
+        },
+      ],
+    },
+  ];
 }
 
 /**
@@ -1613,12 +1701,12 @@ export function appendKnowledgePromptDelta(input: {
   }
   const surfacedKeys = advanceSurfacedKeys(input.previousKeys, blocks);
   const { changed, removedIds } = detectSurfacedMutations(surfacedKeys);
-  const message = buildKnowledgeDeltaMessage(
+  const messages = buildKnowledgeDeltaMessage(
     changed,
     removedIds,
     input.overflow,
   );
-  if (!message) return false;
+  if (!messages.length) return false;
 
   // APPEND a fresh immutable block at the current tail (seq = MAX+1) instead of
   // rewriting one coalesced row in place. The insertAt is computed tool-pair-
@@ -1644,7 +1732,7 @@ export function appendKnowledgePromptDelta(input: {
       insertAt: input.insertAt,
       mut,
     }),
-    content: JSON.stringify(message),
+    content: JSON.stringify(messages),
   });
   log.info(
     `prompt-delta: appended knowledge block for session ${input.sessionID.slice(0, 16)} (${changed.length} changed, ${removedIds.length} removed, insertAt=${input.insertAt}, seq=${blocks.length})`,

--- a/packages/gateway/test/coalesce-adjacent-assistants.test.ts
+++ b/packages/gateway/test/coalesce-adjacent-assistants.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Unit tests for coalesceAdjacentAssistants (knowledge-delta pair injection,
+ * PR #1315). The delta is injected as a user→assistant PAIR; in a mid-tool-loop
+ * turn the tool-pair guard lands the injected assistant immediately before the
+ * real assistant(thinking, tool_use), producing two adjacent assistants that a
+ * strict-alternation upstream (Anthropic, 1:1 mapping) would reject. Coalescing
+ * merges them — but must preserve the invariant that leading thinking /
+ * redacted_thinking blocks stay FIRST (Anthropic 400s otherwise on every replay
+ * turn of an extended-thinking tool loop).
+ */
+import { describe, test, expect } from "vitest";
+import { coalesceAdjacentAssistants } from "../src/pipeline";
+import type { GatewayMessage } from "../src/translate/types";
+
+const asst = (content: GatewayMessage["content"]): GatewayMessage => ({
+  role: "assistant",
+  content,
+});
+const user = (text: string): GatewayMessage => ({
+  role: "user",
+  content: [{ type: "text", text }],
+});
+
+describe("coalesceAdjacentAssistants", () => {
+  test("merges the injected pair's assistant into a plain (text-only) assistant", () => {
+    const merged = coalesceAdjacentAssistants([
+      user("prev"),
+      asst([{ type: "text", text: "delta payload" }]),
+      asst([
+        { type: "text", text: "on it" },
+        { type: "tool_use", id: "t1", name: "X", input: {} },
+      ]),
+    ]);
+    expect(merged).toHaveLength(2); // user + one merged assistant
+    expect(merged[1].content.map((b) => b.type)).toEqual([
+      "text",
+      "text",
+      "tool_use",
+    ]);
+  });
+
+  test("keeps a leading thinking block FIRST when merging (Anthropic invariant)", () => {
+    const merged = coalesceAdjacentAssistants([
+      asst([{ type: "text", text: "delta payload" }]),
+      asst([
+        { type: "thinking", thinking: "reasoning", signature: "sig" },
+        { type: "tool_use", id: "t1", name: "X", input: {} },
+      ]),
+    ]);
+    expect(merged).toHaveLength(1);
+    const types = merged[0].content.map((b) => b.type);
+    // thinking MUST remain at index 0; payload spliced after the reasoning run.
+    expect(types).toEqual(["thinking", "text", "tool_use"]);
+  });
+
+  test("keeps a leading redacted_thinking (opaque) block FIRST when merging", () => {
+    const merged = coalesceAdjacentAssistants([
+      asst([{ type: "text", text: "delta payload" }]),
+      asst([
+        { type: "opaque", raw: { type: "redacted_thinking", data: "x" } },
+        { type: "tool_use", id: "t1", name: "X", input: {} },
+      ]),
+    ]);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].content.map((b) => b.type)).toEqual([
+      "opaque",
+      "text",
+      "tool_use",
+    ]);
+  });
+
+  test("preserves multiple leading reasoning blocks in order", () => {
+    const merged = coalesceAdjacentAssistants([
+      asst([{ type: "text", text: "payload" }]),
+      asst([
+        { type: "thinking", thinking: "step 1", signature: "s1" },
+        { type: "thinking", thinking: "step 2", signature: "s2" },
+        { type: "text", text: "answer" },
+      ]),
+    ]);
+    expect(merged[0].content.map((b) => b.type)).toEqual([
+      "thinking",
+      "thinking",
+      "text",
+      "text",
+    ]);
+  });
+
+  test("does not merge across a user boundary", () => {
+    const merged = coalesceAdjacentAssistants([
+      asst([{ type: "text", text: "a" }]),
+      user("boundary"),
+      asst([{ type: "text", text: "b" }]),
+    ]);
+    expect(merged.map((m) => m.role)).toEqual([
+      "assistant",
+      "user",
+      "assistant",
+    ]);
+  });
+});

--- a/packages/gateway/test/delta-compress-reanchor.test.ts
+++ b/packages/gateway/test/delta-compress-reanchor.test.ts
@@ -74,6 +74,17 @@ function text(t: string): GatewayContentBlock {
   return { type: "text", text: t };
 }
 
+// A delta block's stored content is a user→assistant PAIR (JSON array); legacy
+// blocks stored a single message object. Join the text across whichever shape.
+function deltaPayloadText(rawContent: string): string {
+  const parsed = JSON.parse(rawContent) as unknown;
+  const msgs = Array.isArray(parsed) ? parsed : [parsed];
+  return msgs
+    .flatMap((m) => (m as { content?: Array<{ text?: string }> }).content ?? [])
+    .map((b) => b.text ?? "")
+    .join("");
+}
+
 /**
  * Asserts every tool_use has an adjacent matching tool_result on the next
  * message, and every tool_result has an adjacent matching tool_use on the
@@ -1025,7 +1036,7 @@ describe("reanchorDeltaOnCompression — re-anchors (never deletes) on a compres
     expect(wrote1).toBe(true);
     expect(listSessionPromptDeltas(sessionID)).toHaveLength(1);
     expect(
-      JSON.parse(listSessionPromptDeltas(sessionID)[0].content).content[0].text,
+      deltaPayloadText(listSessionPromptDeltas(sessionID)[0].content),
     ).toContain("v2 materially changed.");
 
     // Turns 2..6: each is a COMPRESSION turn that ALSO carries a pending delta.
@@ -1138,9 +1149,7 @@ describe("reanchorDeltaOnCompression — re-anchors (never deletes) on a compres
     expect(rows).toHaveLength(2);
     // The newest block surfaces B's new content and only B in its mut.
     const newest = rows[rows.length - 1];
-    expect(JSON.parse(newest.content).content[0].text).toContain(
-      "b-v2 changed.",
-    );
+    expect(deltaPayloadText(newest.content)).toContain("b-v2 changed.");
     const newestMut = JSON.parse(newest.selector).mut as {
       changed: Array<{ id: string }>;
     };

--- a/packages/gateway/test/knowledge-delta-overflow.test.ts
+++ b/packages/gateway/test/knowledge-delta-overflow.test.ts
@@ -6,11 +6,13 @@ import {
 } from "../src/pipeline";
 import type { GatewayMessage } from "../src/translate/types";
 
-// Extract the single text part of a delta message.
-function text(msg: GatewayMessage | null): string {
-  if (!msg) return "";
-  const part = msg.content[0] as { type: string; text: string };
-  return part.text;
+// Join the text of every part across the delta's message pair (user framing +
+// assistant payload) so content assertions match regardless of which turn a
+// string lands on.
+function text(msgs: GatewayMessage[]): string {
+  return msgs
+    .flatMap((m) => m.content.map((b) => (b as { text?: string }).text ?? ""))
+    .join("\n");
 }
 
 const id = (prefix: string) => `${prefix}-1111-7111-8111-111111111111`;
@@ -50,7 +52,7 @@ describe("buildKnowledgeDeltaMessage — overflow ToC (#917)", () => {
     // Cache-stability invariant: a delta is only created on material change.
     // Overflow must never trigger one on its own, or it would add cache churn.
     const msg = buildKnowledgeDeltaMessage([], [], [toc("019bbbbb", "Lonely")]);
-    expect(msg).toBeNull();
+    expect(msg).toEqual([]);
   });
 
   test("overflow is id-sorted (byte-stable across per-turn relevance re-ranking)", () => {
@@ -200,5 +202,46 @@ describe("ToC ids are recall-resolvable (#917 round-trip)", () => {
     const detail = recallById(token as string);
     expect(detail).not.toMatch(/No entry found/);
     expect(detail).toContain("Round-trip overflow entry");
+  });
+});
+
+// The knowledge-delta block is injected mid-conversation. As a lone user-role
+// message it read as an open user turn, so instruction-literal models (e.g.
+// MiniMax M3) "Acknowledged… none of this applies… I won't reference it" on
+// every turn. Mirroring the distilled-prefix pattern (buildPrefixMessages), the
+// block is now a user→assistant PAIR: a tiny framing note on the user side and
+// the knowledge payload on the assistant side, so the exchange is already
+// closed and the model does not react to it.
+describe("buildKnowledgeDeltaMessage — non-eliciting user→assistant pair", () => {
+  test("returns a pair: user framing (non-ack) + assistant payload", () => {
+    const msgs = buildKnowledgeDeltaMessage(
+      [changed("019aaaaa", "Changed entry")],
+      [],
+      [toc("019bbbbb", "Overflow one")],
+    );
+    expect(Array.isArray(msgs)).toBe(true);
+    expect(msgs).toHaveLength(2);
+    const user = msgs[0];
+    const assistant = msgs[1];
+    expect(user.role).toBe("user");
+    expect(assistant.role).toBe("assistant");
+    const userText = (user.content[0] as { text: string }).text;
+    const asstText = (assistant.content[0] as { text: string }).text;
+    // Keeps the substring the cache-stability e2e assertions rely on.
+    expect(userText).toContain("Lore knowledge update");
+    // Explicit non-acknowledgment framing — the whole point of the fix.
+    expect(userText.toLowerCase()).toContain("do not");
+    // Payload rides the ASSISTANT turn so the model treats it as settled
+    // context (its own prior note), not a pending user request.
+    expect(asstText).toContain("Changed entry");
+    expect(asstText).toContain("## Long-term Knowledge");
+    // The framing note must NOT carry the payload.
+    expect(userText).not.toContain("## Long-term Knowledge");
+  });
+
+  test("no genuine change → empty array (no pair injected)", () => {
+    expect(
+      buildKnowledgeDeltaMessage([], [], [toc("019bbbbb", "Lonely")]),
+    ).toEqual([]);
   });
 });

--- a/packages/gateway/test/prompt-delta-append-only.test.ts
+++ b/packages/gateway/test/prompt-delta-append-only.test.ts
@@ -37,13 +37,21 @@ function keyOf(id: string, title: string, content: string): string {
   return `${id}:${fnv1a(`${title}\x1f${content}`)}`;
 }
 
+// A delta block's content is a user→assistant PAIR (JSON array); older blocks
+// stored a single message object. Join the text across whichever shape.
+function deltaText(raw: string): string {
+  const parsed = JSON.parse(raw) as unknown;
+  const msgs = Array.isArray(parsed) ? parsed : [parsed];
+  return msgs
+    .flatMap((m) => (m as { content?: Array<{ text?: string }> }).content ?? [])
+    .map((b) => b.text ?? "")
+    .join("");
+}
+
 function deltaContents(sessionID: string): string[] {
   return listSessionPromptDeltas(sessionID).map((r) => {
     try {
-      const msg = JSON.parse(r.content) as {
-        content: Array<{ text?: string }>;
-      };
-      return msg.content.map((b) => b.text ?? "").join("");
+      return deltaText(r.content);
     } catch {
       return "";
     }
@@ -325,10 +333,7 @@ describe("append-only durable knowledge deltas", () => {
     // After crossing the cap, the blocks coalesced to a single cumulative block.
     expect(lastLen).toBe(1);
     // That one block describes the full pin→DB delta (all 9 entries changed).
-    const text = JSON.parse(listSessionPromptDeltas(sessionID)[0].content) as {
-      content: Array<{ text?: string }>;
-    };
-    const body = text.content.map((b) => b.text ?? "").join("");
+    const body = deltaText(listSessionPromptDeltas(sessionID)[0].content);
     expect(body).toContain("cap v2 0.");
   });
 

--- a/packages/gateway/test/prompt-delta-mutation-trigger.test.ts
+++ b/packages/gateway/test/prompt-delta-mutation-trigger.test.ts
@@ -32,10 +32,16 @@ function deltaText(sessionID: string): string {
   return listSessionPromptDeltas(sessionID)
     .map((r) => {
       try {
-        const msg = JSON.parse(r.content) as {
-          content: Array<{ text?: string }>;
-        };
-        return msg.content.map((b) => b.text ?? "").join("");
+        // A delta block stores a user→assistant PAIR (JSON array); legacy blocks
+        // stored a single message object. Join text across whichever shape.
+        const parsed = JSON.parse(r.content) as unknown;
+        const msgs = Array.isArray(parsed) ? parsed : [parsed];
+        return msgs
+          .flatMap(
+            (m) => (m as { content?: Array<{ text?: string }> }).content ?? [],
+          )
+          .map((b) => b.text ?? "")
+          .join("");
       } catch {
         return "";
       }

--- a/packages/gateway/test/prompt-delta-tools.test.ts
+++ b/packages/gateway/test/prompt-delta-tools.test.ts
@@ -26,6 +26,7 @@ import {
   applySessionPromptDeltas,
   removeOrphanedToolResults,
   captureToolPairing400,
+  buildKnowledgeDeltaMessage,
 } from "../src/pipeline";
 import { appendSessionPromptDelta, ensureProject } from "@loreai/core";
 import type {
@@ -245,6 +246,91 @@ describe("captureToolPairing400 — detection", () => {
         sessionID: "abc",
       }),
     ).toBe(false);
+  });
+});
+
+// The knowledge delta is injected as a user→assistant PAIR. In a mid-tool-loop
+// turn the tool-pair guard seats it before the assistant(tool_use), which would
+// otherwise leave the pair's trailing assistant abutting that real assistant
+// (two consecutive assistant messages — a strict-alternation 400). The
+// assistant-coalesce pass in applySessionPromptDeltas must fold them into one.
+describe("knowledge-delta PAIR — no consecutive assistants, tool-pairing intact", () => {
+  const CHANGED = [
+    {
+      id: "019aaaaa-1111-7111-8111-111111111111",
+      category: "pattern",
+      title: "Card primitive",
+      content: "Use the shared Card component.",
+    },
+  ];
+
+  function assertNoConsecutiveAssistants(messages: GatewayMessage[]): void {
+    for (let i = 1; i < messages.length; i++) {
+      expect(
+        messages[i].role === "assistant" &&
+          messages[i - 1].role === "assistant",
+        `consecutive assistant messages at ${i - 1},${i}: ${messages
+          .map((m) => m.role)
+          .join(",")}`,
+      ).toBe(false);
+    }
+  }
+
+  function seedPair(sessionID: string, projectID: string, insertAt: number) {
+    const pair = buildKnowledgeDeltaMessage(CHANGED, []);
+    expect(pair).toHaveLength(2);
+    expect(pair[0].role).toBe("user");
+    expect(pair[1].role).toBe("assistant");
+    appendSessionPromptDelta({
+      sessionID,
+      projectID,
+      selector: JSON.stringify({ target: "messages", insertAt }),
+      content: JSON.stringify(pair),
+    });
+  }
+
+  test("mid-tool-loop tail: pair folds into the tool_use assistant, alternation preserved", () => {
+    const sessionID = `pair-toolloop-${Date.now()}`;
+    const projectID = ensureProject(`/tmp/lore-pair-toolloop-${Date.now()}`);
+    // Realistic agent turn: assistant plans + calls a tool in ONE message, then
+    // the tool_result comes back as the final (user) message.
+    const layout: GatewayMessage[] = [
+      user(text("migrate the card")),
+      assistant(text("on it"), toolUse("X")),
+      user(toolResult("X")),
+    ];
+    // insertAt = len-1 = 2 lands between tool_use and tool_result → guard walks
+    // it before the assistant, seating the injected assistant next to it.
+    seedPair(sessionID, projectID, layout.length - 1);
+    const out = applySessionPromptDeltas(layout, sessionID);
+    removeOrphanedToolResults(out);
+    assertNoOrphanedTools(out);
+    assertNoConsecutiveAssistants(out);
+    // The framing note (non-ack) survived as its own user turn…
+    const joined = out
+      .flatMap((m) => m.content.map((b) => (b as { text?: string }).text ?? ""))
+      .join("\n");
+    expect(joined).toContain("Lore knowledge update");
+    // …and the knowledge payload rode along (folded into the assistant).
+    expect(joined).toContain("Card primitive");
+    // Stable on replay (frozen position → byte-identical roles).
+    const out2 = applySessionPromptDeltas(layout, sessionID);
+    removeOrphanedToolResults(out2);
+    expect(out2.map((m) => m.role)).toEqual(out.map((m) => m.role));
+  });
+
+  test("plain tail (final user turn): pair sits cleanly before it", () => {
+    const sessionID = `pair-plain-${Date.now()}`;
+    const projectID = ensureProject(`/tmp/lore-pair-plain-${Date.now()}`);
+    const layout: GatewayMessage[] = [
+      user(text("hi")),
+      assistant(text("hello")),
+      user(text("do the thing")),
+    ];
+    seedPair(sessionID, projectID, layout.length - 1);
+    const out = applySessionPromptDeltas(layout, sessionID);
+    assertNoOrphanedTools(out);
+    assertNoConsecutiveAssistants(out);
   });
 });
 


### PR DESCRIPTION
## Problem
Onur reported his coding agent (running on **MiniMax M3**) floods its output with repeated blocks:

> ⏺ Acknowledged. None of the lore knowledge (deep-link guard on watchOS Swift, OCR/cluster/…, GDPR audit skill, …) applies to PR-10's React Native Card work. I won't reference this knowledge.

…repeated per turn and growing as the session lengthens.

## Root cause
Mid-session knowledge-delta ("information update") blocks were injected as a **lone `user`-role message** (`buildKnowledgeDeltaMessage`). Instruction-literal models like M3 read it as an open user turn and acknowledge/dismiss it every turn. The distilled-memory prefix (`core/gradient.ts` `buildPrefixMessages`) does **not** have this problem because it's a **user→assistant pair** — the assistant turn closes the exchange.

## Fix
- `buildKnowledgeDeltaMessage` now returns a **user→assistant pair**: a tiny user framing note ("ambient context… do not reply") + the knowledge payload on the **assistant** turn, so the model treats it as its own settled note.
- `parseDeltaMessages` accepts the pair (JSON array) and, for backward-compat, a legacy single-message object — already-persisted blocks and single-message test fixtures keep replaying.
- `applySessionPromptDeltas` splices all of a block's messages at the safe index.
- **Alternation fix (`coalesceAdjacentAssistants`):** in a mid-tool-loop turn the tool-pair guard seats the delta before the `assistant(tool_use)`, so the pair's trailing assistant would abut that real assistant — two consecutive assistant messages, frozen for the session, which a strict-alternation upstream (Anthropic maps 1:1) would reject every turn. We fold assistant runs into one message; `tool_use` stays adjacent to its `tool_result` so tool-pairing holds. `user↔user` adjacency (pre-existing behavior) is untouched.

## Notes
- Physical replay every turn is **unchanged** (required for conversation-cache stability); this removes the model's per-turn *reaction*, not the replay.
- A live session already polluted with old-format blocks needs a **fresh session** to shed them (the fix only affects newly-built blocks).

## Testing
- New: pair-structure test + non-ack framing assertion (`knowledge-delta-overflow.test.ts`); mid-tool-loop + plain-tail alternation/tool-pairing tests (`prompt-delta-tools.test.ts`).
- Mutation-verified: no-op'ing the coalesce → tool-loop test fails; removing the "do not" framing → pair test fails.
- Full suite green (5801 passed), typecheck + lint + format clean.

First of a 3-PR series (this = ack fix; next = relevance floor; then = materiality gate).