### PR TITLE
feat(core): relevance floor for session knowledge (stop off-task surfacing)

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -313,6 +313,21 @@ export const LoreConfig = z.object({
         .describe(
           'Fold relevance-ranked distillation/temporal memory into the context-bound injection so facts are passively present (no recall tool needed). Default: ["distillation"]; add "temporal" for raw messages; [] = off.',
         ),
+      /** Minimum cosine similarity for a vector-scored knowledge/context entry
+       *  to be surfaced into a session (system[2] + delta ToC + overflow). An
+       *  entry whose ONLY signal is a weak vector similarity below this floor is
+       *  dropped, so off-task project knowledge (e.g. watchOS entries during a
+       *  React Native task) isn't surfaced. FTS keyword matches are inherently
+       *  relevant and bypass the floor. Set to 0 to disable (surface any vector
+       *  hit, the pre-#1211 behavior). Default: 0.35. */
+      minRelevance: z
+        .number()
+        .min(0)
+        .max(1)
+        .default(0.35)
+        .describe(
+          "Minimum cosine similarity for a vector-only knowledge match to be surfaced into a session. FTS keyword matches bypass it. 0 disables. Default: 0.35.",
+        ),
     })
     .default({
       enabled: true,
@@ -321,6 +336,7 @@ export const LoreConfig = z.object({
       outcomeReward: true,
       referenceValidation: true,
       contextSources: ["distillation"],
+      minRelevance: 0.35,
     })
     .describe("Long-term knowledge (curator, entity injection) controls."),
   curator: z

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -2411,7 +2411,12 @@ export async function forSession(
       const minRelevance = config().knowledge.minRelevance;
       const isRelevant = (id: string): boolean => {
         const vecScore = vectorScores.get(id);
-        if (vecScore != null && vecScore >= minRelevance) return true;
+        // A vector match must be a POSITIVE cosine at or above the floor. The
+        // `> 0` clause preserves the pre-floor `score > 0` semantics when
+        // minRelevance is 0: an exactly-orthogonal (cosine 0) or negative entry
+        // is never surfaced on the vector signal alone.
+        if (vecScore != null && vecScore > 0 && vecScore >= minRelevance)
+          return true;
         return (ftsScores.get(id) ?? 0) > 0;
       };
       const scoreOf = (entry: KnowledgeEntry): number => {

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -2420,11 +2420,14 @@ export async function forSession(
         return (ftsScores.get(id) ?? 0) > 0;
       };
       const scoreOf = (entry: KnowledgeEntry): number => {
-        const vecScore = vectorScores.get(entry.id);
-        return (
-          (vecScore != null ? vecScore : (ftsScores.get(entry.id) ?? 0)) *
-          entry.confidence
-        );
+        // Rank by the STRONGER of the two normalized signals (both are 0–1:
+        // cosine, and BM25 min-max normalized). An entry that qualified via a
+        // high FTS keyword score but has a present-but-below-floor cosine must
+        // not be under-ranked by that weak cosine — take the max, not the
+        // vector-preferred value. (Seer #1318.)
+        const vecScore = vectorScores.get(entry.id) ?? 0;
+        const ftsScore = ftsScores.get(entry.id) ?? 0;
+        return Math.max(vecScore, ftsScore) * entry.confidence;
       };
 
       const matched = projectEntries

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -2763,7 +2763,11 @@ async function loadContextSourceCandidates(
         let added = 0;
         for (const h of hits) {
           if (added >= limit) break;
-          if (h.similarity < minRelevance) continue;
+          // Match the knowledge path's floor semantics: a context source must
+          // be a POSITIVE cosine at or above the floor. The `<= 0` clause keeps
+          // an exactly-orthogonal (or negative) hit out even when minRelevance
+          // is 0, so context sources and knowledge behave identically.
+          if (h.similarity <= 0 || h.similarity < minRelevance) continue;
           const r = byId.get(h.id);
           if (!r?.observations) continue;
           out.push({
@@ -2807,7 +2811,9 @@ async function loadContextSourceCandidates(
         const byId = new Map(rows.map((r) => [r.id, r]));
         const seen = new Set<string>();
         for (const h of hits) {
-          if (h.similarity < minRelevance) continue;
+          // Match the knowledge path's floor semantics (positive cosine at or
+          // above the floor); see the distillation source above.
+          if (h.similarity <= 0 || h.similarity < minRelevance) continue;
           const mid = h.id.split("#")[0];
           if (seen.has(mid)) continue;
           seen.add(mid);

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -2402,38 +2402,48 @@ export async function forSession(
       // fall back to FTS5 so they aren't invisible to scoring.
       const ftsScores = await scoreEntriesFTS(sessionContext);
 
-      // Score project entries: prefer vector similarity, fall back to FTS5
-      const rawScored: Scored[] = projectEntries.map((entry) => {
+      // Relevance floor: a VECTOR-ONLY signal must clear minRelevance to count
+      // as a match. Otherwise a near-orthogonal entry (e.g. a watchOS gotcha
+      // during a React Native task) scores a small positive cosine and pollutes
+      // the surfaced/overflow set — the "ranks but never filters" bug. An FTS
+      // keyword hit is inherently relevant, so it qualifies regardless of
+      // vecScore. Set knowledge.minRelevance to 0 to restore the old behavior.
+      const minRelevance = config().knowledge.minRelevance;
+      const isRelevant = (id: string): boolean => {
+        const vecScore = vectorScores.get(id);
+        if (vecScore != null && vecScore >= minRelevance) return true;
+        return (ftsScores.get(id) ?? 0) > 0;
+      };
+      const scoreOf = (entry: KnowledgeEntry): number => {
         const vecScore = vectorScores.get(entry.id);
-        const score =
-          vecScore != null
-            ? vecScore * entry.confidence
-            : (ftsScores.get(entry.id) ?? 0) * entry.confidence;
-        return { entry, score };
-      });
-      const matched = rawScored.filter((s) => s.score > 0);
-      const matchedIds = new Set(matched.map((s) => s.entry.id));
+        return (
+          (vecScore != null ? vecScore : (ftsScores.get(entry.id) ?? 0)) *
+          entry.confidence
+        );
+      };
 
-      // Safety net: top PROJECT_SAFETY_NET entries by confidence that weren't already matched.
-      // Given a tiny score (0.001 * confidence) so they sort below genuinely matched entries.
-      const safetyNet = projectEntries
-        .filter((e) => !matchedIds.has(e.id))
-        .slice(0, PROJECT_SAFETY_NET)
-        .map((e) => ({ entry: e, score: 0.001 * e.confidence }));
+      const matched = projectEntries
+        .filter((e) => isRelevant(e.id))
+        .map((entry) => ({ entry, score: scoreOf(entry) }));
+
+      // Safety net (fallback-only): when NOTHING clears the floor, keep the
+      // session useful with the top PROJECT_SAFETY_NET entries by confidence.
+      // When there ARE relevant matches, injecting unrelated top-confidence
+      // entries would re-pollute exactly what the floor removes, so skip it.
+      const safetyNet =
+        matched.length === 0
+          ? projectEntries
+              .slice(0, PROJECT_SAFETY_NET)
+              .map((e) => ({ entry: e, score: 0.001 * e.confidence }))
+          : [];
 
       scoredProject = [...matched, ...safetyNet];
 
-      // Cross-project: include entries matched by vector OR FTS5
+      // Cross-project: same relevance floor (vector-only must clear it; an FTS
+      // keyword hit qualifies).
       scoredCross = crossEntries
-        .filter((e) => vectorScores.has(e.id) || ftsScores.has(e.id))
-        .map((e) => {
-          const vecScore = vectorScores.get(e.id);
-          const score =
-            vecScore != null
-              ? vecScore * e.confidence
-              : (ftsScores.get(e.id) ?? 0) * e.confidence;
-          return { entry: e, score };
-        });
+        .filter((e) => isRelevant(e.id))
+        .map((e) => ({ entry: e, score: scoreOf(e) }));
     } else {
       // Vector failed — fall through to FTS5
       const ftsScores = await scoreEntriesFTS(sessionContext);
@@ -2677,6 +2687,10 @@ async function loadContextSourceCandidates(
   _sessionID?: string,
 ): Promise<Scored[]> {
   const out: Scored[] = [];
+  // Same relevance floor as knowledge: don't fold in a distillation/temporal
+  // chunk whose cosine to the session context is below the threshold (off-task
+  // noise). 0 disables.
+  const minRelevance = config().knowledge.minRelevance;
 
   const mkEntry = (
     id: string,
@@ -2741,6 +2755,7 @@ async function loadContextSourceCandidates(
         let added = 0;
         for (const h of hits) {
           if (added >= limit) break;
+          if (h.similarity < minRelevance) continue;
           const r = byId.get(h.id);
           if (!r?.observations) continue;
           out.push({
@@ -2784,6 +2799,7 @@ async function loadContextSourceCandidates(
         const byId = new Map(rows.map((r) => [r.id, r]));
         const seen = new Set<string>();
         for (const h of hits) {
+          if (h.similarity < minRelevance) continue;
           const mid = h.id.split("#")[0];
           if (seen.has(mid)) continue;
           seen.add(mid);
@@ -2823,12 +2839,16 @@ function scoreFTS(
     score: (ftsScores.get(entry.id) ?? 0) * entry.confidence,
   }));
   const matched = rawScored.filter((s) => s.score > 0);
-  const matchedIds = new Set(matched.map((s) => s.entry.id));
 
-  const safetyNet = projectEntries
-    .filter((e) => !matchedIds.has(e.id))
-    .slice(0, PROJECT_SAFETY_NET)
-    .map((e) => ({ entry: e, score: 0.001 * e.confidence }));
+  // Fallback-only safety net (mirrors the vector path): only inject top-
+  // confidence entries when NO keyword match exists, so a genuine match set is
+  // never diluted by unrelated project knowledge.
+  const safetyNet =
+    matched.length === 0
+      ? projectEntries
+          .slice(0, PROJECT_SAFETY_NET)
+          .map((e) => ({ entry: e, score: 0.001 * e.confidence }))
+      : [];
 
   const scoredProject = [...matched, ...safetyNet];
 

--- a/packages/core/test/ltm-context-sources.test.ts
+++ b/packages/core/test/ltm-context-sources.test.ts
@@ -3,6 +3,7 @@ import { uuidv7 } from "uuidv7";
 import { db, ensureProject } from "../src/db";
 import * as ltm from "../src/ltm";
 import * as embedding from "../src/embedding";
+import { config } from "../src/config";
 
 /**
  * forSession `includeContextSources`: relevance-ranked distillation + temporal
@@ -307,5 +308,32 @@ describe("ltm.forSession — context sources (distillation + temporal)", () => {
     expect(byId.has(`t:${tempId}`)).toBe(false);
     // Above-floor knowledge (0.6, from beforeEach) is unaffected.
     expect(byId.has(knowledgeId)).toBe(true);
+  });
+
+  test("minRelevance = 0 still excludes an exactly-orthogonal (cosine 0) context source", async () => {
+    // Consistency with the knowledge path's `vecScore > 0` clause (Seer #1318):
+    // when the floor is disabled, a cosine-0 (orthogonal) or negative hit must
+    // still be excluded from the context-source fold — `h.similarity < 0` alone
+    // would admit it. Guards the `<= 0` clause on both source guards.
+    const orig = config().knowledge.minRelevance;
+    config().knowledge.minRelevance = 0;
+    try {
+      vi.spyOn(embedding, "vectorSearchDistillations").mockResolvedValue([
+        { id: distId, similarity: 0 },
+      ]);
+      vi.spyOn(embedding, "vectorSearchTemporal").mockResolvedValue([
+        { id: `${tempId}#0`, similarity: 0 },
+      ]);
+      const result = await ltm.forSession(PROJ, undefined, 4000, {
+        excludeCategories: ["preference"],
+        contextHint: HINT,
+        includeContextSources: ["distillation", "temporal"],
+      });
+      const byId = new Set(result.map((e) => e.id));
+      expect(byId.has(`d:${distId}`)).toBe(false);
+      expect(byId.has(`t:${tempId}`)).toBe(false);
+    } finally {
+      config().knowledge.minRelevance = orig;
+    }
   });
 });

--- a/packages/core/test/ltm-context-sources.test.ts
+++ b/packages/core/test/ltm-context-sources.test.ts
@@ -284,4 +284,28 @@ describe("ltm.forSession — context sources (distillation + temporal)", () => {
       overflowSink.every((e) => e.category !== ltm.RECALLED_CONTEXT_CATEGORY),
     ).toBe(true);
   });
+
+  test("relevance floor: a below-floor distillation/temporal hit is NOT folded in", async () => {
+    // Seer #1318 coverage gap: the context-source floor guards
+    // (`h.similarity < minRelevance` in the distillation + temporal folds) had
+    // zero test coverage — a regression there would pass CI. Drive both hits
+    // BELOW the default floor (0.35) and assert neither synthetic surfaces,
+    // while knowledge (above floor) still does.
+    vi.spyOn(embedding, "vectorSearchDistillations").mockResolvedValue([
+      { id: distId, similarity: 0.1 },
+    ]);
+    vi.spyOn(embedding, "vectorSearchTemporal").mockResolvedValue([
+      { id: `${tempId}#0`, similarity: 0.1 },
+    ]);
+    const result = await ltm.forSession(PROJ, undefined, 4000, {
+      excludeCategories: ["preference"],
+      contextHint: HINT,
+      includeContextSources: ["distillation", "temporal"],
+    });
+    const byId = new Set(result.map((e) => e.id));
+    expect(byId.has(`d:${distId}`)).toBe(false);
+    expect(byId.has(`t:${tempId}`)).toBe(false);
+    // Above-floor knowledge (0.6, from beforeEach) is unaffected.
+    expect(byId.has(knowledgeId)).toBe(true);
+  });
 });

--- a/packages/core/test/ltm.test.ts
+++ b/packages/core/test/ltm.test.ts
@@ -1643,6 +1643,23 @@ describe("ltm.forSession — relevance floor", () => {
     expect(got.has(ids[1])).toBe(true);
     expect(got.has(ids[2])).toBe(true);
   });
+
+  test("minRelevance = 0 still excludes an exactly-orthogonal (cosine 0) entry", async () => {
+    // Seer #1318: with the floor at 0, `vecScore >= 0` would admit a cosine-0
+    // entry, diverging from the pre-floor `score > 0` semantics. A vector match
+    // must be a POSITIVE cosine. ids[1] has an exact-0 score and no FTS hit, so
+    // it must NOT surface; ids[0] (positive) still does.
+    config().knowledge.minRelevance = 0;
+    scores = new Map([
+      [ids[0], 0.5],
+      [ids[1], 0],
+    ]);
+    const got = new Set(
+      (await ltm.forSession(PROJ, SESSION, WIDE)).map((e) => e.id),
+    );
+    expect(got.has(ids[0])).toBe(true);
+    expect(got.has(ids[1])).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/test/ltm.test.ts
+++ b/packages/core/test/ltm.test.ts
@@ -12,6 +12,7 @@ import { uuidv7 } from "uuidv7";
 import { db, ensureProject } from "../src/db";
 import * as ltm from "../src/ltm";
 import * as embedding from "../src/embedding";
+import { config } from "../src/config";
 import {
   _resetVectorPoolForTest,
   _setTestVectorWorkerFactory,
@@ -1513,6 +1514,134 @@ describe("ltm.forSession — vector-path set stability (regression #727)", () =>
     );
     expect(got.has(ids[4])).toBe(true);
     expect(got.has(ids[3])).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ltm.forSession — relevance floor (off-task knowledge must not be surfaced)
+//
+// Ranks-but-never-filters was the bug: any positive cosine admitted an entry,
+// so a React Native session surfaced watchOS/OCR/GDPR entries from the same
+// (multi-task) project. A vector-only signal must now clear config().knowledge
+// .minRelevance; FTS keyword matches bypass it. Entry content below is chosen
+// to share NO tokens with the session context, so FTS never matches and the
+// mocked vector score is the sole signal.
+// ---------------------------------------------------------------------------
+
+describe("ltm.forSession — relevance floor", () => {
+  const PROJ = "/test/ltm/relevance-floor";
+  const SESSION = "relevance-floor-session";
+  let availableSpy: ReturnType<typeof vi.spyOn>;
+  let embedSpy: ReturnType<typeof vi.spyOn>;
+  let vectorSpy: ReturnType<typeof vi.spyOn>;
+  let scores: Map<string, number>;
+  let origMinRelevance: number;
+  const ids: string[] = [];
+
+  // Disjoint from the session context below → FTS never matches these.
+  const CONTENTS = [
+    "kubernetes ingress sidecar mesh rollout",
+    "protobuf schema registry backward wire",
+    "webassembly sandbox capability isolation",
+    "raytracing denoise kernel occupancy tuning",
+  ];
+
+  beforeEach(() => {
+    const pid = ensureProject(PROJ);
+    db().query("DELETE FROM knowledge WHERE project_id = ?").run(pid);
+    db().query("DELETE FROM temporal_messages WHERE project_id = ?").run(pid);
+    ids.length = 0;
+    for (let i = 0; i < CONTENTS.length; i++) {
+      ids.push(
+        ltm.create({
+          projectPath: PROJ,
+          category: "pattern",
+          title: `Floor entry ${i}`,
+          content: CONTENTS[i],
+          scope: "project",
+          crossProject: false,
+        }),
+      );
+    }
+    // Session context shares no tokens with any entry → pure vector signal.
+    db()
+      .query(
+        "INSERT INTO temporal_messages (id, project_id, session_id, role, content, tokens, distilled, created_at, metadata) VALUES (?, ?, ?, ?, ?, ?, 0, ?, '{}')",
+      )
+      .run(
+        "floor-msg-1",
+        pid,
+        SESSION,
+        "user",
+        "quarterly financial reconciliation ledger audit invoice",
+        20,
+        Date.now(),
+      );
+
+    scores = new Map();
+    availableSpy = vi.spyOn(embedding, "isAvailable").mockReturnValue(true);
+    embedSpy = vi
+      .spyOn(embedding, "embed")
+      .mockResolvedValue([new Float32Array([1, 0, 0])]);
+    vectorSpy = vi
+      .spyOn(embedding, "vectorSearch")
+      .mockImplementation(async () =>
+        [...scores.entries()].map(([id, similarity]) => ({ id, similarity })),
+      );
+    origMinRelevance = config().knowledge.minRelevance;
+  });
+
+  afterEach(() => {
+    availableSpy.mockRestore();
+    embedSpy.mockRestore();
+    vectorSpy.mockRestore();
+    config().knowledge.minRelevance = origMinRelevance;
+  });
+
+  // Budget large enough to fit ALL four entries, so any exclusion is due to the
+  // floor, not the token budget.
+  const WIDE = 8000;
+
+  test("drops vector-only entries below the floor, keeps those above", async () => {
+    config().knowledge.minRelevance = 0.35;
+    scores = new Map([
+      [ids[0], 0.62], // above
+      [ids[1], 0.4], // above
+      [ids[2], 0.2], // below → dropped
+      [ids[3], 0.1], // below → dropped
+    ]);
+    const got = new Set(
+      (await ltm.forSession(PROJ, SESSION, WIDE)).map((e) => e.id),
+    );
+    expect(got.has(ids[0])).toBe(true);
+    expect(got.has(ids[1])).toBe(true);
+    expect(got.has(ids[2])).toBe(false);
+    expect(got.has(ids[3])).toBe(false);
+  });
+
+  test("safety net is fallback-only: nothing clears the floor → top entries still surface", async () => {
+    config().knowledge.minRelevance = 0.35;
+    // Every entry is below the floor → no genuine match.
+    scores = new Map(ids.map((id) => [id, 0.1]));
+    const got = await ltm.forSession(PROJ, SESSION, WIDE);
+    // Fallback keeps the session useful rather than returning nothing.
+    expect(got.length).toBeGreaterThan(0);
+  });
+
+  test("minRelevance = 0 disables the floor (pre-#1211 behavior)", async () => {
+    config().knowledge.minRelevance = 0;
+    scores = new Map([
+      [ids[0], 0.62],
+      [ids[1], 0.2],
+      [ids[2], 0.1],
+      [ids[3], 0.05],
+    ]);
+    const got = new Set(
+      (await ltm.forSession(PROJ, SESSION, WIDE)).map((e) => e.id),
+    );
+    // With the floor disabled, low-similarity entries are surfaced again.
+    expect(got.has(ids[1])).toBe(true);
+    expect(got.has(ids[2])).toBe(true);
   });
 });
 

--- a/packages/core/test/ltm.test.ts
+++ b/packages/core/test/ltm.test.ts
@@ -1660,6 +1660,39 @@ describe("ltm.forSession — relevance floor", () => {
     expect(got.has(ids[0])).toBe(true);
     expect(got.has(ids[1])).toBe(false);
   });
+
+  test("applies the floor to the CROSS-PROJECT pool (below-floor cross entry dropped)", async () => {
+    // A cross-project entry lives in a DIFFERENT project so it enters the cross
+    // pool for this session. With only a below-floor vector score and no FTS
+    // hit, it must NOT surface. Guards the cross-pool isRelevant branch (Seer
+    // #1318 coverage gap: the base floor tests seed only crossProject:false).
+    config().knowledge.minRelevance = 0.35;
+    const crossId = ltm.create({
+      projectPath: "/test/ltm/relevance-floor-OTHER",
+      category: "pattern",
+      title: "Cross off-task",
+      content: "mainframe cobol batch job control language",
+      scope: "project",
+      crossProject: true,
+    });
+    // Above-floor local entry (so there IS a match set) + below-floor cross.
+    scores = new Map([
+      [ids[0], 0.6],
+      [crossId, 0.1],
+    ]);
+    const got = new Set(
+      (await ltm.forSession(PROJ, SESSION, WIDE)).map((e) => e.id),
+    );
+    expect(got.has(ids[0])).toBe(true);
+    expect(got.has(crossId)).toBe(false);
+    // Above the floor, the same cross entry DOES surface.
+    scores.set(crossId, 0.6);
+    const got2 = new Set(
+      (await ltm.forSession(PROJ, SESSION, WIDE)).map((e) => e.id),
+    );
+    expect(got2.has(crossId)).toBe(true);
+    db().query("DELETE FROM knowledge WHERE logical_id = ?").run(crossId);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/test/ltm.test.ts
+++ b/packages/core/test/ltm.test.ts
@@ -1619,6 +1619,37 @@ describe("ltm.forSession — relevance floor", () => {
     expect(got.has(ids[3])).toBe(false);
   });
 
+  test("FTS-qualified entry is ranked by its FTS score, not a weak below-floor cosine (Seer #1318)", async () => {
+    // An entry whose content shares keywords with the session context gets an
+    // FTS hit (qualifies past the floor) even with a below-floor cosine. scoreOf
+    // must rank it by the STRONGER signal (FTS), else a tight budget under-ranks
+    // and drops it below an above-floor-but-lower-combined competitor.
+    config().knowledge.minRelevance = 0.35;
+    // Matches the session context "quarterly financial reconciliation ledger
+    // audit invoice" on multiple tokens → strong FTS (BM25) score.
+    const ftsId = ltm.create({
+      projectPath: PROJ,
+      category: "pattern",
+      title: "Ledger entry",
+      content:
+        "quarterly financial reconciliation ledger audit invoice workflow",
+      scope: "project",
+      crossProject: false,
+    });
+    // ftsId has a present-but-below-floor cosine; a vector-only competitor sits
+    // just above the floor. Old scoreOf ranked ftsId by 0.1 (loses); the max()
+    // fix ranks it by its high FTS score (wins its slot).
+    scores = new Map([
+      [ftsId, 0.1], // below floor on the vector signal
+      [ids[0], 0.4], // above floor, but no FTS overlap
+    ]);
+    const ranked = (await ltm.forSession(PROJ, SESSION, WIDE)).map((e) => e.id);
+    expect(ranked).toContain(ftsId); // qualified via FTS, must be present
+    // Ranked ahead of the weak above-floor vector-only entry.
+    expect(ranked.indexOf(ftsId)).toBeLessThan(ranked.indexOf(ids[0]));
+    db().query("DELETE FROM knowledge WHERE logical_id = ?").run(ftsId);
+  });
+
   test("safety net is fallback-only: nothing clears the floor → top entries still surface", async () => {
     config().knowledge.minRelevance = 0.35;
     // Every entry is below the floor → no genuine match.

--- a/packages/gateway/test/cache-stability.e2e.test.ts
+++ b/packages/gateway/test/cache-stability.e2e.test.ts
@@ -14,8 +14,9 @@
  * the tail and these tests fail — turning whack-a-mole into a guardrail.
  */
 import { mkdirSync, writeFileSync } from "node:fs";
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import { log } from "@loreai/core";
+import * as embedding from "../../core/src/embedding";
 import type { Harness } from "./helpers/harness";
 import { createHarness } from "./helpers/harness";
 import {
@@ -310,6 +311,7 @@ async function seedMemory(projectPath: string, sessionID: string) {
 describe("cache stability (e2e)", () => {
   let harness: Harness;
   afterEach(async () => {
+    vi.restoreAllMocks();
     const { resetCalibration } = await import("../../core/src/gradient");
     resetCalibration();
     if (harness) await harness.teardown();
@@ -498,6 +500,20 @@ describe("cache stability (e2e)", () => {
     let contextID = "";
     let largeContextID = "";
 
+    // Deterministic relevance scoring: stub the knowledge vector search so both
+    // seeded entries score above the floor and pin (mirrors the vector-churn
+    // unit tests). Restored by afterEach's vi.restoreAllMocks(). Runs on the main
+    // thread — forSession's embedding.vectorSearch call is intercepted before any
+    // worker offload, so pinning no longer hinges on embedding-worker readiness.
+    let scoreableIds: string[] = [];
+    vi.spyOn(embedding, "isAvailable").mockReturnValue(true);
+    vi.spyOn(embedding, "embed").mockResolvedValue([
+      new Float32Array([1, 0, 0]),
+    ]);
+    vi.spyOn(embedding, "vectorSearch").mockImplementation(async () =>
+      scoreableIds.map((id) => ({ id, similarity: 0.9 })),
+    );
+
     for (let i = 0; i < turns.length; i++) {
       if (i === 2) setForceMinLayer(4, sessionID);
       const resp = await harness.chat(
@@ -539,6 +555,13 @@ describe("cache stability (e2e)", () => {
             "Initial filler. ".repeat(160),
           session: sessionID,
         });
+        // Relevance scoring is stubbed for this test (see the spy setup above the
+        // loop) so BOTH just-created entries score above the floor and pin
+        // deterministically. Without it, the relevance floor's fallback-only
+        // safety net makes 2-entry pinning depend on embedding-worker readiness
+        // and cosine asymmetry (flaky under load). The floor is covered in
+        // ltm.test.ts; this test targets durable-delta replay + system[2] stability.
+        scoreableIds = [contextID, largeContextID];
       }
 
       if (i === 1) {

--- a/packages/website/src/content/docs/docs/configuration.md
+++ b/packages/website/src/content/docs/docs/configuration.md
@@ -122,6 +122,7 @@ Long-term knowledge (curator, entity injection) controls.
 | `outcomeReward` | boolean | `true` |  | Adjust knowledge confidence by within-session verifier (test/build/typecheck/lint) outcomes. Default: true. |
 | `referenceValidation` | boolean | `true` |  | Lower confidence on entries whose file:line / command references no longer resolve against the repo. Unverifiable refs never penalize. Default: true. |
 | `contextSources` | array<enum> | `["distillation"]` |  | Fold relevance-ranked distillation/temporal memory into the context-bound injection so facts are passively present (no recall tool needed). Default: ["distillation"]; add "temporal" for raw messages; [] = off. |
+| `minRelevance` | number | `0.35` | min 0, max 1 | Minimum cosine similarity for a vector-only knowledge match to be surfaced into a session. FTS keyword matches bypass it. 0 disables. Default: 0.35. |
 
 
 ## `curator`


### PR DESCRIPTION
## Problem
Second of the 3-PR series from Onur's report. `forSession` **ranked** knowledge by relevance but never **filtered** by it: any positive cosine admitted an entry (top-50 vector hits all pass), and a 5-entry `PROJECT_SAFETY_NET` force-pinned top-confidence entries regardless of the task. So a React Native session surfaced unrelated same-project knowledge (watchOS deep-link guard, OCR/cluster, GDPR audit) into system[2], the delta ToC, and the overflow list — the absurd "none of this applies" lists in the report.

## Fix
- **Relevance floor:** a vector-only match must clear `knowledge.minRelevance` (default **0.35**) to count as relevant. An **FTS keyword hit bypasses the floor** (inherently relevant). `minRelevance: 0` disables it (pre-#1211 behavior).
- Applied to the **project pool**, the **cross-project pool**, and the **context-source** (distillation/temporal) fold — all on the same cosine scale.
- **`PROJECT_SAFETY_NET` is now fallback-only** (fires only when *nothing* clears the floor), in both the vector and FTS paths, so a genuine match set is never diluted by unrelated top-confidence entries.

## Config
`knowledge.minRelevance` (0–1, default 0.35) in `.lore.json`.

## Notes / findings
- Making the safety net fallback-only means the system[2] **pin composition is now relevance-gated**. That surfaced a genuine interaction with the durable-delta `cache-stability.e2e` test, which relied on the always-on net force-pinning an unrelated entry. That test targets **delta replay + system[2] stability**, not relevance, so it now stubs vector scoring (like the vector-churn unit tests) to pin its fixtures deterministically — the previous always-on-net path made 2-entry pinning depend on embedding-worker readiness + FTS min-max normalization (flaky under load).

## Testing
- New `ltm.test.ts` cases: below-floor vector-only entries dropped; above-floor kept; safety net fallback-only; `minRelevance=0` disables the floor. (Red-verified before implementing.)
- Full suite green (5800 passed) under full-suite load; typecheck + lint + format clean.

## Follow-up
- Tune `minRelevance` via the eval harness (recall@k / MRR) — 0.35 is a conservative starting default.

Stacked after #1315 (ack-pair fix); independent files (`ltm.ts`/`config.ts` vs #1315's `pipeline.ts`).