### PR TITLE
feat(website): add system-preference dark mode to marketing pages

### DIFF
--- a/packages/website/public/theme.css
+++ b/packages/website/public/theme.css
@@ -41,6 +41,11 @@
   --link-border: var(--g4);
   --link-hover: var(--g0);
 
+  /* Deep emphasis green — headline stats, "Lore" comparison cells, CTA
+   * vision line, blog links/blockquotes. Light value is --g1 (one step
+   * darker than the --g2 accent) to preserve the original design exactly. */
+  --emphasis: var(--g1);
+
   --highlight-bg: var(--g6);
   --highlight-border: var(--g5);
   --highlight-text: var(--g2);
@@ -76,6 +81,8 @@
     --link: #a6d6ae;
     --link-border: #4a7a55;
     --link-hover: #dcecdd;
+
+    --emphasis: #9ad3a4;
 
     --highlight-bg: #172c20;
     --highlight-border: #2a4634;
@@ -121,6 +128,8 @@
   --link: #a6d6ae;
   --link-border: #4a7a55;
   --link-hover: #dcecdd;
+
+  --emphasis: #9ad3a4;
 
   --highlight-bg: #172c20;
   --highlight-border: #2a4634;
@@ -477,7 +486,7 @@ h1 em::after {
   border-bottom: 1px solid var(--link-border);
   transition: color .2s;
 }
-.hero-folklore a:hover { color: var(--link-hover); }
+.hero-folklore a:hover { color: var(--emphasis); }
 
 .btn-fill {
   display: inline-flex;
@@ -632,7 +641,7 @@ h1 em::after {
 .stat-n {
   font-family: var(--serif);
   font-size: 2.2rem;
-  color: var(--heading-accent);
+  color: var(--emphasis);
   line-height: 1;
   margin-bottom: .3rem;
 }
@@ -907,7 +916,7 @@ h1 em::after {
 }
 
 .cmp thead th.cmp-lore {
-  color: var(--heading-accent);
+  color: var(--emphasis);
 }
 
 .cmp thead th .cmp-eyebrow {
@@ -948,7 +957,7 @@ h1 em::after {
 
 .cmp tbody td.cmp-lore {
   background: var(--highlight-bg);
-  color: var(--heading-accent);
+  color: var(--emphasis);
 }
 
 .cmp tbody tr:last-child th,
@@ -1046,7 +1055,7 @@ h1 em::after {
 .cta-vision {
   font-size: 1.05rem;
   line-height: 1.6;
-  color: var(--heading-accent);
+  color: var(--emphasis);
   text-align: center;
   max-width: 56ch;
   margin: 1.25rem auto 0;

--- a/packages/website/public/theme.css
+++ b/packages/website/public/theme.css
@@ -338,6 +338,12 @@ a.logo .logo-text {
   display: block;
 }
 
+/* "Get Started" CTA pill. It sits on the always-dark nav bar (--nav-bg,
+ * dark in both themes), so it is intentionally a cream pill with dark ink
+ * text in BOTH themes — a constant high-contrast accent, not a
+ * theme-switching surface. Raw --c0/--ink/--g5 are deliberate here (same
+ * rationale as the .logo rules above); routing them through --bg/--text
+ * would make it a dark pill on a dark bar. */
 .nav-btn {
   font-size: 1rem;
   font-family: var(--sans);

--- a/packages/website/public/theme.css
+++ b/packages/website/public/theme.css
@@ -1,6 +1,11 @@
 /* Lore.AI shared theme — used by index.html, different.html, etc. */
 
 :root {
+  color-scheme: light;
+
+  /* Raw brand palette. Fixed across themes — literal-cream / dark-block /
+   * logo / SVG uses rely on these staying put. Theme-dependent rules must
+   * use the semantic tokens below instead of these directly. */
   --c0: #f7f2e8;
   --c1: #ede5d0;
   --c2: #dfd5bb;
@@ -16,6 +21,123 @@
   --serif: 'Playfair Display', Georgia, serif;
   --sans: 'DM Sans', sans-serif;
   --ease: cubic-bezier(0.22, 1, 0.36, 1);
+
+  /* Semantic tokens — light values alias the raw palette 1:1, so light
+   * mode is visually unchanged. Dark values are defined below. */
+  --bg: var(--c0);
+  --bg-alt: var(--c1);
+  --surface: var(--c0);
+  --surface-alt: var(--c1);
+  --border: var(--c2);
+  --input-bg: var(--c0);
+
+  --text: var(--ink);
+  --text-muted: var(--mid);
+  --heading: var(--g0);
+  --heading-accent: var(--g2);
+  --eyebrow: var(--g3);
+
+  --link: var(--g2);
+  --link-border: var(--g4);
+  --link-hover: var(--g0);
+
+  --highlight-bg: var(--g6);
+  --highlight-border: var(--g5);
+  --highlight-text: var(--g2);
+
+  /* Dark blocks that keep LIGHT text in both themes (nav, footer, ticker,
+   * filled buttons, code blocks, install block). */
+  --nav-bg: var(--ink);
+  --inverse-bg: var(--g0);
+  --inverse-bg-hover: var(--g1);
+  --inverse-text: var(--c0);
+  --inverse-text-dim: var(--g5);
+
+  --error: #8b3a3a;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    color-scheme: dark;
+
+    --bg: #0d1913;
+    --bg-alt: #101f17;
+    --surface: #14251b;
+    --surface-alt: #1a3124;
+    --border: #26402f;
+    --input-bg: #14251b;
+
+    --text: #e8f1e6;
+    --text-muted: #9fbaa6;
+    --heading: #f2f7ee;
+    --heading-accent: #9ad3a4;
+    --eyebrow: #79ab84;
+
+    --link: #a6d6ae;
+    --link-border: #4a7a55;
+    --link-hover: #dcecdd;
+
+    --highlight-bg: #172c20;
+    --highlight-border: #2a4634;
+    --highlight-text: #bfe0c4;
+
+    --nav-bg: #0a140e;
+    --inverse-bg: #1e3a29;
+    --inverse-bg-hover: #26492f;
+    --inverse-text: #f2f7ee;
+    --inverse-text-dim: #c4ddc7;
+
+    --error: #e39393;
+
+    /* Remap raw accent vars so inline style="" accents in .astro pages
+     * adapt with no HTML changes. Safe because every *surface* rule below
+     * has been routed onto the semantic tokens above — these four raw vars
+     * now serve only small text/accent uses (inline styles, cursor dot,
+     * ticker diamond). --g4 stays put: its light-green already reads fine
+     * on the dark canvas. */
+    --mid: #9fbaa6;
+    --g1: #8fc79a;
+    --g2: #a6d6ae;
+    --g3: #79ab84;
+  }
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+
+  --bg: #0d1913;
+  --bg-alt: #101f17;
+  --surface: #14251b;
+  --surface-alt: #1a3124;
+  --border: #26402f;
+  --input-bg: #14251b;
+
+  --text: #e8f1e6;
+  --text-muted: #9fbaa6;
+  --heading: #f2f7ee;
+  --heading-accent: #9ad3a4;
+  --eyebrow: #79ab84;
+
+  --link: #a6d6ae;
+  --link-border: #4a7a55;
+  --link-hover: #dcecdd;
+
+  --highlight-bg: #172c20;
+  --highlight-border: #2a4634;
+  --highlight-text: #bfe0c4;
+
+  --nav-bg: #0a140e;
+  --inverse-bg: #1e3a29;
+  --inverse-bg-hover: #26492f;
+  --inverse-text: #f2f7ee;
+  --inverse-text-dim: #c4ddc7;
+
+  --error: #e39393;
+
+  --mid: #9fbaa6;
+  --g1: #8fc79a;
+  --g2: #a6d6ae;
+  --g3: #79ab84;
 }
 
 *,
@@ -31,8 +153,8 @@ html {
 }
 
 body {
-  background: var(--c0);
-  color: var(--ink);
+  background: var(--bg);
+  color: var(--text);
   font-family: var(--sans);
   font-weight: 300;
   font-size: 1.08rem;
@@ -45,7 +167,7 @@ body {
   position: fixed;
   width: 8px;
   height: 8px;
-  background: var(--g2);
+  background: var(--link);
   border-radius: 50%;
   pointer-events: none;
   z-index: 9999;
@@ -57,7 +179,7 @@ body {
   width: 36px;
   height: 36px;
   background: transparent;
-  border: 1px solid var(--g3);
+  border: 1px solid var(--eyebrow);
 }
 
 body::after {
@@ -85,9 +207,9 @@ a {
   align-items: center;
   justify-content: space-between;
   padding: .45rem 3rem;
-  background: var(--ink);
+  background: var(--nav-bg);
   border-bottom: 1px solid rgba(255, 255, 255, 0.05);
-  color: var(--c0);
+  color: var(--inverse-text);
 }
 
 .nav-left {
@@ -173,7 +295,7 @@ a.logo .logo-text {
 }
 
 .nav-links a:hover {
-  color: var(--c0);
+  color: var(--inverse-text);
 }
 
 .nav-socials {
@@ -197,7 +319,7 @@ a.logo .logo-text {
 .social-link:hover {
   background: rgba(247, 242, 232, .08);
   border-color: rgba(196, 221, 199, .5);
-  color: var(--c0);
+  color: var(--inverse-text);
 }
 
 .social-link svg {
@@ -257,7 +379,7 @@ a.logo .logo-text {
   font-size: .7rem;
   letter-spacing: .18em;
   text-transform: uppercase;
-  color: var(--g3);
+  color: var(--eyebrow);
   margin-bottom: 2rem;
 }
 
@@ -266,16 +388,16 @@ a.logo .logo-text {
   display: block;
   width: 28px;
   height: 1px;
-  background: var(--g4);
+  background: var(--link-border);
 }
 
 .badge-pill {
-  background: var(--g6);
-  border: 1px solid var(--g5);
+  background: var(--highlight-bg);
+  border: 1px solid var(--highlight-border);
   padding: .22rem .65rem;
   border-radius: 20px;
   font-size: .64rem;
-  color: var(--g2);
+  color: var(--highlight-text);
 }
 
 h1 {
@@ -283,13 +405,13 @@ h1 {
   font-size: clamp(2.8rem, 5.5vw, 5.5rem);
   font-weight: 400;
   line-height: 1.08;
-  color: var(--g0);
+  color: var(--heading);
   margin-bottom: 2rem;
 }
 
 h1 em {
   font-style: italic;
-  color: var(--g2);
+  color: var(--heading-accent);
   position: relative;
   display: inline-block;
 }
@@ -301,12 +423,12 @@ h1 em::after {
   left: 0;
   right: 0;
   height: 2px;
-  background: linear-gradient(90deg, var(--g4), transparent);
+  background: linear-gradient(90deg, var(--link-border), transparent);
 }
 
 .hero-desc {
   font-size: 1.1rem;
-  color: var(--mid);
+  color: var(--text-muted);
   max-width: 42ch;
   line-height: 1.9;
   margin-bottom: 3rem;
@@ -316,26 +438,26 @@ h1 em::after {
 .hero-install { margin-bottom: 2rem; }
 .install-block {
   display: inline-flex; align-items: center; gap: 1rem;
-  background: var(--g0); border-radius: 4px; padding: .9rem 1.4rem;
+  background: var(--inverse-bg); border-radius: 4px; padding: .9rem 1.4rem;
   cursor: pointer; position: relative; transition: background .2s;
 }
-.install-block:hover { background: var(--g1); }
+.install-block:hover { background: var(--inverse-bg-hover); }
 .install-block code {
-  font-family: monospace; font-size: .88rem; color: var(--g5); letter-spacing: .02em;
+  font-family: monospace; font-size: .88rem; color: var(--inverse-text-dim); letter-spacing: .02em;
 }
-.install-prompt { color: var(--g3); margin-right: .3rem; }
-.install-copy { color: var(--g4); opacity: .6; transition: opacity .2s; display: flex; }
+.install-prompt { color: var(--eyebrow); margin-right: .3rem; }
+.install-copy { color: var(--link-border); opacity: .6; transition: opacity .2s; display: flex; }
 .install-block:hover .install-copy { opacity: 1; }
 .install-copied {
   position: absolute; top: -1.8rem; right: 0;
-  font-size: .7rem; color: var(--g3); opacity: 0; transition: opacity .25s;
+  font-size: .7rem; color: var(--eyebrow); opacity: 0; transition: opacity .25s;
 }
 .install-copied.show { opacity: 1; }
 .install-alt {
-  margin-top: .7rem; font-size: .78rem; color: var(--mid);
+  margin-top: .7rem; font-size: .78rem; color: var(--text-muted);
 }
 .install-alt code {
-  font-size: .78rem; background: var(--g6); padding: .15em .45em; border-radius: 3px;
+  font-size: .78rem; background: var(--highlight-bg); padding: .15em .45em; border-radius: 3px;
 }
 
 .hero-actions {
@@ -348,21 +470,21 @@ h1 em::after {
 .hero-folklore {
   margin-top: 1.4rem;
   font-size: .8rem;
-  color: var(--mid);
+  color: var(--text-muted);
 }
 .hero-folklore a {
-  color: var(--mid);
-  border-bottom: 1px solid var(--g4);
+  color: var(--text-muted);
+  border-bottom: 1px solid var(--link-border);
   transition: color .2s;
 }
-.hero-folklore a:hover { color: var(--g1); }
+.hero-folklore a:hover { color: var(--link-hover); }
 
 .btn-fill {
   display: inline-flex;
   align-items: center;
   gap: .6rem;
-  background: var(--g0);
-  color: var(--c0);
+  background: var(--inverse-bg);
+  color: var(--inverse-text);
   padding: .9rem 2rem;
   font-size: .78rem;
   letter-spacing: .12em;
@@ -372,7 +494,7 @@ h1 em::after {
 }
 
 .btn-fill:hover {
-  background: var(--g1);
+  background: var(--inverse-bg-hover);
   transform: translateY(-2px);
 }
 
@@ -385,15 +507,15 @@ h1 em::after {
   font-size: .78rem;
   letter-spacing: .1em;
   text-transform: uppercase;
-  color: var(--g2);
-  border-bottom: 1px solid var(--g4);
+  color: var(--link);
+  border-bottom: 1px solid var(--link-border);
   padding-bottom: 2px;
   transition: color .25s, border-color .25s;
 }
 
 .btn-ghost:hover {
-  color: var(--g0);
-  border-color: var(--g2);
+  color: var(--link-hover);
+  border-color: var(--link);
 }
 
 /* graph visual */
@@ -467,13 +589,13 @@ h1 em::after {
 
 .g-chip {
   position: absolute;
-  background: var(--c0);
-  border: 1px solid var(--c2);
+  background: var(--surface);
+  border: 1px solid var(--border);
   border-radius: 3px;
   padding: .28rem .62rem;
   font-size: .62rem;
   letter-spacing: .07em;
-  color: var(--mid);
+  color: var(--text-muted);
   box-shadow: 0 4px 14px rgba(26, 51, 32, .06);
   white-space: nowrap;
   z-index: 2;
@@ -495,22 +617,22 @@ h1 em::after {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 1px;
-  background: var(--c2);
-  border: 1px solid var(--c2);
+  background: var(--border);
+  border: 1px solid var(--border);
   border-radius: 3px;
   overflow: hidden;
   margin-top: 1rem;
 }
 
 .stat-cell {
-  background: var(--c0);
+  background: var(--surface);
   padding: 1.6rem 2rem;
 }
 
 .stat-n {
   font-family: var(--serif);
   font-size: 2.2rem;
-  color: var(--g1);
+  color: var(--heading-accent);
   line-height: 1;
   margin-bottom: .3rem;
 }
@@ -519,13 +641,13 @@ h1 em::after {
   font-size: .72rem;
   letter-spacing: .1em;
   text-transform: uppercase;
-  color: var(--mid);
+  color: var(--text-muted);
 }
 
 /* TICKER */
 .ticker {
   overflow: hidden;
-  background: var(--g0);
+  background: var(--inverse-bg);
   padding: .9rem 0;
   white-space: nowrap;
 }
@@ -539,12 +661,12 @@ h1 em::after {
   font-family: var(--serif);
   font-size: 1rem;
   font-style: italic;
-  color: var(--g5);
+  color: var(--inverse-text-dim);
   padding: 0 2.5rem;
 }
 
 .td {
-  color: var(--g3);
+  color: var(--eyebrow);
   font-style: normal;
   font-family: var(--sans);
   font-size: .44rem;
@@ -561,7 +683,7 @@ h1 em::after {
 /* HOW / generic section */
 .how {
   padding: 8rem 3rem;
-  background: var(--c0);
+  background: var(--bg);
 }
 
 .sec-hd {
@@ -578,7 +700,7 @@ h1 em::after {
   font-size: .7rem;
   letter-spacing: .22em;
   text-transform: uppercase;
-  color: var(--g3);
+  color: var(--eyebrow);
   margin-bottom: 1rem;
 }
 
@@ -586,18 +708,18 @@ h1 em::after {
   font-family: var(--serif);
   font-size: clamp(2rem, 3.5vw, 3rem);
   font-weight: 400;
-  color: var(--g0);
+  color: var(--heading);
   line-height: 1.2;
 }
 
 .sec-title em {
   font-style: italic;
-  color: var(--g2);
+  color: var(--heading-accent);
 }
 
 .sec-sub {
   font-size: .9rem;
-  color: var(--mid);
+  color: var(--text-muted);
   max-width: 34ch;
   line-height: 1.8;
 }
@@ -607,14 +729,14 @@ h1 em::after {
   margin: 0 auto;
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  border: 1px solid var(--c2);
+  border: 1px solid var(--border);
   border-radius: 4px;
   overflow: hidden;
 }
 
 .step {
   padding: 3.5rem 2.5rem;
-  border-right: 1px solid var(--c2);
+  border-right: 1px solid var(--border);
   position: relative;
   transition: background .35s;
 }
@@ -624,40 +746,40 @@ h1 em::after {
 }
 
 .step:hover {
-  background: var(--g6);
+  background: var(--highlight-bg);
 }
 
 .step-n {
   font-family: var(--serif);
   font-size: .8rem;
-  color: var(--g4);
+  color: var(--link-border);
   margin-bottom: 2rem;
 }
 
 .step-icon {
   width: 40px;
   height: 40px;
-  color: var(--g2);
+  color: var(--heading-accent);
   margin-bottom: 1.5rem;
 }
 
 .step-t {
   font-family: var(--serif);
   font-size: 1.5rem;
-  color: var(--g0);
+  color: var(--heading);
   margin-bottom: .8rem;
 }
 
 .step-b {
   font-size: .92rem;
-  color: var(--mid);
+  color: var(--text-muted);
   line-height: 1.9;
 }
 
 /* FEATURES */
 .features {
   padding: 8rem 3rem;
-  background: var(--c1);
+  background: var(--bg-alt);
 }
 
 .bento {
@@ -669,8 +791,8 @@ h1 em::after {
 }
 
 .bc {
-  background: var(--c0);
-  border: 1px solid var(--c2);
+  background: var(--surface);
+  border: 1px solid var(--border);
   border-radius: 4px;
   padding: 2.5rem;
   overflow: hidden;
@@ -698,51 +820,51 @@ h1 em::after {
   font-size: .65rem;
   letter-spacing: .18em;
   text-transform: uppercase;
-  color: var(--g3);
+  color: var(--eyebrow);
   margin-bottom: 1.2rem;
 }
 
 .bc-t {
   font-family: var(--serif);
   font-size: 1.55rem;
-  color: var(--g0);
+  color: var(--heading);
   line-height: 1.25;
   margin-bottom: .8rem;
 }
 
 .bc-b {
   font-size: .92rem;
-  color: var(--mid);
+  color: var(--text-muted);
   line-height: 1.85;
 }
 
 /* code */
 .code-block {
   margin-top: 1.2rem;
-  background: var(--g0);
+  background: var(--inverse-bg);
   border-radius: 3px;
   padding: 1.5rem;
 }
 
 .code-block code {
   font-size: .78rem;
-  color: var(--g4);
+  color: var(--link-border);
   font-family: monospace;
   line-height: 1.6;
 }
 
 .code-block .ck {
-  color: var(--c0);
+  color: var(--inverse-text);
 }
 
 .code-block .cv {
-  color: var(--g5);
+  color: var(--inverse-text-dim);
 }
 
 /* Inline code highlight */
 .code-inline {
   font-size: .85em;
-  background: var(--g6);
+  background: var(--highlight-bg);
   padding: .15em .4em;
   border-radius: 3px;
 }
@@ -760,10 +882,10 @@ h1 em::after {
 .cmp-wrap {
   max-width: 1100px;
   margin: 0 auto;
-  border: 1px solid var(--c2);
+  border: 1px solid var(--border);
   border-radius: 4px;
   overflow: hidden;
-  background: var(--c0);
+  background: var(--surface);
 }
 
 .cmp {
@@ -776,16 +898,16 @@ h1 em::after {
   font-family: var(--serif);
   font-weight: 400;
   font-size: 1rem;
-  color: var(--g0);
+  color: var(--heading);
   text-align: left;
   padding: 1.4rem 1.6rem;
-  background: var(--g6);
-  border-bottom: 1px solid var(--c2);
+  background: var(--highlight-bg);
+  border-bottom: 1px solid var(--border);
   vertical-align: bottom;
 }
 
 .cmp thead th.cmp-lore {
-  color: var(--g1);
+  color: var(--heading-accent);
 }
 
 .cmp thead th .cmp-eyebrow {
@@ -794,7 +916,7 @@ h1 em::after {
   font-size: .62rem;
   letter-spacing: .16em;
   text-transform: uppercase;
-  color: var(--g3);
+  color: var(--eyebrow);
   margin-bottom: .3rem;
 }
 
@@ -802,20 +924,20 @@ h1 em::after {
   font-family: var(--sans);
   font-weight: 500;
   text-align: left;
-  color: var(--g0);
+  color: var(--heading);
   padding: 1.2rem 1.6rem;
   width: 26%;
-  border-bottom: 1px solid var(--c2);
-  border-right: 1px solid var(--c2);
-  background: var(--c1);
+  border-bottom: 1px solid var(--border);
+  border-right: 1px solid var(--border);
+  background: var(--surface-alt);
   vertical-align: top;
 }
 
 .cmp tbody td {
   padding: 1.2rem 1.6rem;
-  color: var(--mid);
-  border-bottom: 1px solid var(--c2);
-  border-right: 1px solid var(--c2);
+  color: var(--text-muted);
+  border-bottom: 1px solid var(--border);
+  border-right: 1px solid var(--border);
   vertical-align: top;
   line-height: 1.7;
 }
@@ -825,8 +947,8 @@ h1 em::after {
 }
 
 .cmp tbody td.cmp-lore {
-  background: var(--g6);
-  color: var(--g1);
+  background: var(--highlight-bg);
+  color: var(--heading-accent);
 }
 
 .cmp tbody tr:last-child th,
@@ -834,7 +956,7 @@ h1 em::after {
   border-bottom: none;
 }
 
-.cmp-yes { color: var(--g2); font-weight: 500; }
+.cmp-yes { color: var(--heading-accent); font-weight: 500; }
 
 /* SPECTRUM (used by different.html) */
 .spectrum-bar {
@@ -853,14 +975,14 @@ h1 em::after {
   font-family: var(--serif);
   font-size: 1.15rem;
   font-weight: 400;
-  color: var(--mid);
+  color: var(--text-muted);
   margin-bottom: .8rem;
 }
 
 .spectrum-list {
   list-style: none;
   font-size: .86rem;
-  color: var(--mid);
+  color: var(--text-muted);
   line-height: 2;
 }
 
@@ -883,7 +1005,7 @@ h1 em::after {
 /* CTA */
 .cta {
   padding: 9rem 3rem;
-  background: var(--c1);
+  background: var(--bg-alt);
   position: relative;
   text-align: center;
 }
@@ -898,14 +1020,14 @@ h1 em::after {
 .cta-inner h2 {
   font-family: var(--serif);
   font-size: clamp(2rem, 4vw, 3.4rem);
-  color: var(--g0);
+  color: var(--heading);
   line-height: 1.2;
   margin-bottom: 1.2rem;
 }
 
 .cta-sub {
   font-size: .92rem;
-  color: var(--mid);
+  color: var(--text-muted);
   line-height: 1.9;
   max-width: 42ch;
   margin: 0 auto 2.8rem;
@@ -916,7 +1038,7 @@ h1 em::after {
   font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.12em;
-  color: var(--g4);
+  color: var(--link-border);
   margin: 0 0 1rem 0;
   text-align: center;
 }
@@ -924,7 +1046,7 @@ h1 em::after {
 .cta-vision {
   font-size: 1.05rem;
   line-height: 1.6;
-  color: var(--g1);
+  color: var(--heading-accent);
   text-align: center;
   max-width: 56ch;
   margin: 1.25rem auto 0;
@@ -933,7 +1055,7 @@ h1 em::after {
 }
 
 .cta-vision em {
-  color: var(--g2);
+  color: var(--link);
   font-style: normal;
   font-weight: 500;
 }
@@ -941,16 +1063,16 @@ h1 em::after {
 .cta-input {
   width: 268px;
   padding: .85rem 1.3rem;
-  background: var(--c0);
-  border: 1px solid var(--c2);
+  background: var(--input-bg);
+  border: 1px solid var(--border);
   border-radius: 2px;
   outline: none;
 }
 
 .cta-submit {
   padding: .85rem 2rem;
-  background: var(--g0);
-  color: var(--c0);
+  background: var(--inverse-bg);
+  color: var(--inverse-text);
   border: none;
   border-radius: 2px;
   cursor: pointer;
@@ -959,13 +1081,13 @@ h1 em::after {
 }
 
 .cta-submit:hover {
-  background: var(--g1);
+  background: var(--inverse-bg-hover);
 }
 
 .cta-note {
   margin-top: 1.2rem;
   font-size: .72rem;
-  color: var(--mid);
+  color: var(--text-muted);
   opacity: .7;
 }
 
@@ -975,13 +1097,13 @@ h1 em::after {
 .cta-success {
   font-family: var(--serif);
   font-size: 1.3rem;
-  color: var(--g2);
+  color: var(--link);
   margin-top: 1rem;
 }
 
 .cta-error {
   font-size: .88rem;
-  color: #8b3a3a;
+  color: var(--error);
   margin-top: 1rem;
   line-height: 1.6;
 }
@@ -991,22 +1113,22 @@ h1 em::after {
   margin-top: 1rem;
   padding: .6rem 1.6rem;
   background: transparent;
-  border: 1px solid var(--c2);
+  border: 1px solid var(--border);
   border-radius: 2px;
-  color: var(--g0);
+  color: var(--heading);
   cursor: pointer;
   font-size: .82rem;
   text-transform: uppercase;
   letter-spacing: .08em;
 }
 
-.cta-back:hover { background: var(--c0); }
+.cta-back:hover { background: var(--surface); }
 .cta-submit:disabled { opacity: .7; cursor: not-allowed; }
 
 /* FOOTER */
 footer {
-  background: var(--g0);
-  color: var(--g5);
+  background: var(--inverse-bg);
+  color: var(--inverse-text-dim);
   padding: 4rem 3rem 2rem;
   text-align: center;
 }
@@ -1059,7 +1181,7 @@ footer {
   .sec-title { font-size: 2rem !important; word-wrap: break-word; }
 
   .steps { grid-template-columns: 1fr; max-width: 100%; }
-  .step { border-right: none; border-bottom: 1px solid var(--c2); padding: 2rem 1.2rem; text-align: center; min-width: 0; }
+  .step { border-right: none; border-bottom: 1px solid var(--border); padding: 2rem 1.2rem; text-align: center; min-width: 0; }
   .step-icon { margin: 0 auto 1.5rem; }
   .step:last-child { border-bottom: none; }
 

--- a/packages/website/src/pages/different.astro
+++ b/packages/website/src/pages/different.astro
@@ -359,7 +359,7 @@ const base = import.meta.env.BASE_URL;
   </section>
 
   <!-- PORTABILITY -->
-  <section class="features" id="portability" style="background:var(--c0);">
+  <section class="features" id="portability" style="background:var(--bg);">
     <div class="sec-hd" style="max-width:1100px;margin:0 auto 3rem;">
       <div>
         <p class="eyebrow sr">Ownership</p>

--- a/packages/website/src/styles/blog.css
+++ b/packages/website/src/styles/blog.css
@@ -202,7 +202,7 @@
 }
 
 .blog-prose a {
-  color: var(--link);
+  color: var(--emphasis);
   text-decoration: underline;
   text-decoration-thickness: 1px;
   text-underline-offset: 2px;
@@ -222,7 +222,7 @@
 .blog-prose blockquote {
   padding: .4rem 0 .4rem 1.3rem;
   border-left: 3px solid var(--eyebrow);
-  color: var(--heading-accent);
+  color: var(--emphasis);
   font-family: var(--serif);
   font-style: italic;
   font-size: 1.45rem;

--- a/packages/website/src/styles/blog.css
+++ b/packages/website/src/styles/blog.css
@@ -1,6 +1,6 @@
 .blog-body {
   min-height: 100svh;
-  background: var(--c0);
+  background: var(--bg);
   cursor: auto;
 }
 
@@ -17,8 +17,8 @@
   justify-content: space-between;
   gap: 2rem;
   padding: .6rem 3rem;
-  background: var(--ink);
-  color: var(--c0);
+  background: var(--nav-bg);
+  color: var(--inverse-text);
 }
 
 .blog-brand img {
@@ -49,7 +49,7 @@
 .blog-post h1 {
   font-family: var(--serif);
   font-weight: 400;
-  color: var(--g0);
+  color: var(--heading);
 }
 
 .blog-hero h1 {
@@ -62,26 +62,26 @@
 .blog-card p,
 .blog-post header p {
   max-width: 68ch;
-  color: var(--mid);
+  color: var(--text-muted);
 }
 
 .blog-list {
   display: grid;
   gap: 1px;
   padding-bottom: 6rem;
-  border: 1px solid var(--c2);
-  background: var(--c2);
+  border: 1px solid var(--border);
+  background: var(--border);
 }
 
 .blog-card {
-  background: var(--c0);
+  background: var(--surface);
   padding: 2rem;
 }
 
 .blog-card time,
 .blog-post time,
 .blog-back {
-  color: var(--g3);
+  color: var(--eyebrow);
   font-size: .78rem;
   letter-spacing: .1em;
   text-transform: uppercase;
@@ -103,10 +103,10 @@
 }
 
 .blog-card li {
-  border: 1px solid var(--c2);
+  border: 1px solid var(--border);
   border-radius: 3px;
   padding: .15rem .5rem;
-  color: var(--g2);
+  color: var(--link);
   font-size: .78rem;
 }
 
@@ -132,7 +132,7 @@
   font-weight: 400;
   font-size: clamp(1.3rem, 3vw, 1.9rem);
   line-height: 1.2;
-  color: var(--g2);
+  color: var(--heading-accent);
 }
 
 .blog-post time {
@@ -152,7 +152,7 @@
 
 .blog-prose p,
 .blog-prose li {
-  color: var(--ink);
+  color: var(--text);
   font-size: 1.05rem;
   line-height: 1.75;
 }
@@ -176,7 +176,7 @@
   font-weight: 500;
   font-size: 1.75rem;
   line-height: 1.2;
-  color: var(--g0);
+  color: var(--heading);
 }
 
 .blog-prose h3 {
@@ -185,7 +185,7 @@
   font-weight: 500;
   font-size: 1.3rem;
   line-height: 1.25;
-  color: var(--g0);
+  color: var(--heading);
 }
 
 .blog-prose ul,
@@ -202,27 +202,27 @@
 }
 
 .blog-prose a {
-  color: var(--g1);
+  color: var(--link);
   text-decoration: underline;
   text-decoration-thickness: 1px;
   text-underline-offset: 2px;
 }
 
 .blog-prose a:hover {
-  color: var(--g0);
+  color: var(--link-hover);
 }
 
 .blog-prose :not(pre) > code {
   padding: .12em .35em;
   border-radius: 3px;
-  background: var(--c1);
+  background: var(--bg-alt);
   font-size: .9em;
 }
 
 .blog-prose blockquote {
   padding: .4rem 0 .4rem 1.3rem;
-  border-left: 3px solid var(--g3);
-  color: var(--g1);
+  border-left: 3px solid var(--eyebrow);
+  color: var(--heading-accent);
   font-family: var(--serif);
   font-style: italic;
   font-size: 1.45rem;
@@ -242,28 +242,28 @@
 .blog-prose th,
 .blog-prose td {
   padding: .7rem .9rem;
-  border: 1px solid var(--c2);
+  border: 1px solid var(--border);
   text-align: left;
   vertical-align: top;
   line-height: 1.55;
 }
 
 .blog-prose thead th {
-  background: var(--c1);
-  color: var(--g0);
+  background: var(--surface-alt);
+  color: var(--heading);
   font-weight: 600;
 }
 
 .blog-prose tbody tr:nth-child(even) td {
-  background: var(--c1);
+  background: var(--surface-alt);
 }
 
 .blog-prose pre {
   overflow-x: auto;
   border-radius: 4px;
   padding: 1rem;
-  background: var(--g0);
-  color: var(--g5);
+  background: var(--inverse-bg);
+  color: var(--inverse-text-dim);
 }
 
 @media (max-width: 780px) {

--- a/packages/website/src/styles/starlight.css
+++ b/packages/website/src/styles/starlight.css
@@ -4,14 +4,20 @@
   --sl-color-accent-low: #c4ddc7;
   --sl-color-accent: #3d6644;
   --sl-color-accent-high: #8fba96;
-  --sl-color-white: #f7f2e8;
-  --sl-color-gray-1: #e8f2e9;
+  /* Dark theme (default). Aligned with the marketing dark palette in
+   * public/theme.css so docs, blog, and home share one dark surface scale:
+   *   black  → page bg (--bg #0d1913)
+   *   gray-6 → nav / sidebar / code surface (near --nav-bg / --surface)
+   *   gray-1 → primary text (--text)
+   * Text greys descend gray-1..gray-6 from light text to dark surface. */
+  --sl-color-white: #f2f7ee;
+  --sl-color-gray-1: #e8f1e6;
   --sl-color-gray-2: #c4ddc7;
-  --sl-color-gray-3: #8fba96;
-  --sl-color-gray-4: #5a8f63;
-  --sl-color-gray-5: #3d6644;
-  --sl-color-gray-6: #2a4d32;
-  --sl-color-black: #102015;
+  --sl-color-gray-3: #9fbaa6;
+  --sl-color-gray-4: #5a7a63;
+  --sl-color-gray-5: #26402f;
+  --sl-color-gray-6: #14251b;
+  --sl-color-black: #0d1913;
 }
 
 html[data-theme="light"] {


### PR DESCRIPTION
## What

Adds an automatic dark mode to the marketing pages (home, Why Lore, blog) that follows the OS `prefers-color-scheme` setting. Pure CSS — no JavaScript, no flash of wrong theme.

The Starlight docs already shipped a dark theme; this brings the rest of the site in line and unifies the dark surface scale so docs no longer look brighter than blog/home.

## How

- **`public/theme.css`** (main change): introduce a **semantic token layer** (`--bg`, `--surface`, `--border`, `--text`, `--heading`, `--link`, `--highlight-*`, `--inverse-*`, …) over the raw brand palette. The dual-role palette vars (`--c0` was page bg *and* light-text-on-dark; `--g0` was heading *and* dark-surface bg; `--ink` was body text *and* nav bg) are split across distinct tokens so a straight variable flip isn't needed.
  - Light-mode token values **alias the raw palette 1:1**, so light mode is byte-for-byte unchanged.
  - Dark values live in `@media (prefers-color-scheme: dark)` plus a `:root[data-theme="dark"]` escape hatch (wired for a future manual toggle; inert today).
  - Raw accent vars (`--g1/--g2/--g3/--mid`) are remapped in the dark block so the inline `style="…color:var(--g2)…"` accents in `index.astro` / `different.astro` adapt with **no HTML changes**.
- **`src/styles/blog.css`**: routed every color rule onto the same tokens.
- **`src/styles/starlight.css`**: darkened the docs dark-theme grayscale to match the marketing near-black-green surface scale (`--sl-color-black` → `#0d1913`, nav/sidebar/code surface → `#14251b`). Light docs theme untouched; accent vars untouched.

## Verification

- `astro build` succeeds; dark tokens present in built `theme.css` and inlined Starlight CSS.
- Manually reviewed home, Why Lore, blog index, and docs/install in both light and dark (system emulation) — nav, hero + graph, ticker, sections, bento + code blocks, comparison table, CTA form, footer, blog prose, and docs surfaces all render correctly.
- Raw palette values confirmed identical to `origin/main`; light mode renders unchanged.
- `pnpm run lint` passes.

Preview the branch locally with `astro preview` and toggle OS appearance (or DevTools → Rendering → *Emulate CSS prefers-color-scheme*).