### PR TITLE
feat(gateway): materiality gate for knowledge-delta emission

### DIFF
--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -825,6 +825,45 @@ export function sameEntryKeys(
   return true;
 }
 
+/** True when two id sets contain exactly the same ids. */
+export function sameIdSet(a: Set<string>, b: Set<string>): boolean {
+  if (a.size !== b.size) return false;
+  for (const id of a) {
+    if (!b.has(id)) return false;
+  }
+  return true;
+}
+
+/**
+ * Decide whether a persisted pin's `entryKeys` should be silently re-anchored
+ * to the freshly-computed `cachedKeys` WITHOUT counting as a change. This is the
+ * key-format migration guard for the surfaceSignature switch (#1320): a pin
+ * persisted with the old `id:fnv1a(title\x1f content)` keys mismatches the new
+ * normalized-signature keys on the first post-deploy turn even though the
+ * selection is identical. Re-anchoring costs zero cache bust when — and only
+ * when — it is provably the SAME selection:
+ *   1. the keys actually differ (nothing to do otherwise),
+ *   2. the freshly rendered text is byte-identical to the pinned text (so
+ *      system[2] would render the same bytes — no content change hides here),
+ *   3. the id SETS are identical (same entries, only the hash encoding moved).
+ * A genuine content edit fails (2); a set change fails (3). Both correctly fall
+ * through to the normal re-pin path.
+ *
+ * @internal Exported for tests.
+ */
+export function shouldReanchorPinKeys(
+  pinnedKeys: string[],
+  cachedKeys: string[],
+  cachedFormatted: string,
+  pinnedFormatted: string,
+): boolean {
+  return (
+    !sameEntryKeys(pinnedKeys, cachedKeys) &&
+    cachedFormatted === pinnedFormatted &&
+    sameIdSet(entryKeyIds(pinnedKeys), entryKeyIds(cachedKeys))
+  );
+}
+
 const KNOWLEDGE_DELTA_TOKEN_BUDGET = 400;
 
 /** Cap on appended durable-delta blocks before forcing a coalesce. Append-only
@@ -7238,6 +7277,26 @@ async function handleConversationTurn(
           // selected set changes, an entry's content changed (curator update),
           // or there is no pin yet. See ltmPinnedText docs.
           const pinned = ltmPinnedText.get(sessionID);
+          // Key-format migration guard (#1320): a persisted pin from before the
+          // surfaceSignature change stores entryKeys in the old
+          // `id:fnv1a(title\x1f content)` format. On the first post-deploy turn
+          // the recomputed `cachedKeys` use the new normalized signature, so a
+          // pure element-wise compare would spuriously mismatch and re-pin (one-
+          // time cache bust for every warm session). shouldReanchorPinKeys
+          // detects the SAME selection in a new key encoding (same id set +
+          // byte-identical rendered text) so we re-anchor with zero bust.
+          if (
+            pinned?.entryKeys &&
+            cachedKeys &&
+            shouldReanchorPinKeys(
+              pinned.entryKeys,
+              cachedKeys,
+              cached.formatted,
+              pinned.formatted,
+            )
+          ) {
+            pinned.entryKeys = cachedKeys;
+          }
           const setUnchanged = cachedKeys
             ? // Recompute path: compare entry-key sets.
               sameEntryKeys(pinned?.entryKeys, cachedKeys)

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -724,17 +724,26 @@ export function fnv1a(s: string): string {
  *     pinned text and never re-pins on a cosmetic edit.
  * Because the KEY itself is unchanged for an immaterial edit, the surfaced set
  * needs no advancing and the check never re-fires per turn (the 🔴 invariant).
- * A genuine content/title change, or a category change (folded in by callers
- * via the entry id + this sig), still changes the signature and fires normally.
+ * A genuine title or content change changes the signature and fires normally.
+ * NOTE: category is deliberately NOT part of the signature — a category-only
+ * edit keeps the same key, so the pin is reused and the model keeps the old
+ * `### Category` grouping until the next natural re-pin (consistent with the
+ * materiality intent; a bare re-grouping is not worth a mid-session cache bust).
  * The material (substantive) edit surfaces on the next natural re-pin.
  */
 export function surfaceSignature(title: string, content: string): string {
   const normalize = (s: string): string =>
     s
       .toLowerCase()
-      // Strip anything that isn't a letter, number, or whitespace (punctuation,
-      // markdown scaffolding) — Unicode-aware so non-ASCII letters are kept.
-      .replace(/[^\p{L}\p{N}\s]/gu, " ")
+      // Strip only COSMETIC punctuation: markdown scaffolding (*_`~#),
+      // quotes/brackets, and the sentence separators . , ; : … — Deliberately
+      // KEEP operator/comparator/boolean chars (= < > & | + / ^ % - ! ?) so a
+      // MATERIAL edit that changes only symbols is not collapsed to the same
+      // signature — e.g. `>= floor` vs `> floor`, `x == y` vs `x != y`,
+      // `a || b` vs `a && b`, `foo?.bar` vs `foo.bar` must remain distinct.
+      // `!`/`?` are kept (needed for `!=`, `?.`, ternary) at the cost of a cheap
+      // false-positive delta on an "excited!" reword — the safe failure mode.
+      .replace(/["'`*_~#()[\]{}.,;:…]/gu, " ")
       // Collapse all whitespace runs to a single space and trim.
       .replace(/\s+/g, " ")
       .trim();

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -711,14 +711,47 @@ export function fnv1a(s: string): string {
 }
 
 /**
+ * Materiality-aware surface signature for a knowledge entry, used as the hash
+ * half of every `id:hash` surfaced/pin key. Hashing a NORMALIZED form (title +
+ * content, lowercased, punctuation stripped, whitespace collapsed) means a
+ * cosmetic curator reword — reflow/whitespace, added/removed punctuation, a
+ * capitalization change — yields the SAME signature. Consequences, all flowing
+ * from the single definition:
+ *   - `detectSurfacedMutations`: `currentSig === surfacedSig` → no `changed`
+ *     entry → no mid-session delta block for a trivial reword.
+ *   - `ltmEntryKeys` (pin identity) + `hasMaterialLtmDelta`: the pin key is
+ *     unchanged, so `setUnchanged` stays true → system[2] keeps its byte-stable
+ *     pinned text and never re-pins on a cosmetic edit.
+ * Because the KEY itself is unchanged for an immaterial edit, the surfaced set
+ * needs no advancing and the check never re-fires per turn (the 🔴 invariant).
+ * A genuine content/title change, or a category change (folded in by callers
+ * via the entry id + this sig), still changes the signature and fires normally.
+ * The material (substantive) edit surfaces on the next natural re-pin.
+ */
+export function surfaceSignature(title: string, content: string): string {
+  const normalize = (s: string): string =>
+    s
+      .toLowerCase()
+      // Strip anything that isn't a letter, number, or whitespace (punctuation,
+      // markdown scaffolding) — Unicode-aware so non-ASCII letters are kept.
+      .replace(/[^\p{L}\p{N}\s]/gu, " ")
+      // Collapse all whitespace runs to a single space and trim.
+      .replace(/\s+/g, " ")
+      .trim();
+  return fnv1a(`${normalize(title)}\x1f${normalize(content)}`);
+}
+
+/**
  * Compute the sorted entry-key array for a set of context-bound LTM entries.
- * Each key is `"<id>:<hash(title+content)>"`. Sorted so order is canonical:
- * the same set of entries always produces the same key array regardless of
- * ranking order, which is exactly the property the reorder-tolerant pin needs.
+ * Each key is `"<id>:<surfaceSignature(title, content)>"` — a MATERIALITY-aware
+ * signature (normalized title+content), so a cosmetic reword keeps the key
+ * stable (see {@link surfaceSignature}). Sorted so order is canonical: the same
+ * set of entries always produces the same key array regardless of ranking
+ * order, which is exactly the property the reorder-tolerant pin needs.
  *
  * When `renderedIds` is provided, only those entries (the ones that survived
  * budget packing in formatKnowledge and are actually in the rendered text) are
- * keyed — so the key set always matches the rendered string byte-for-byte.
+ * keyed — so the key set tracks the rendered selection.
  */
 export function ltmEntryKeys(
   entries: Array<{ id: string; title: string; content: string }>,
@@ -730,7 +763,7 @@ export function ltmEntryKeys(
     source = entries.filter((e) => allow.has(e.id));
   }
   return source
-    .map((e) => `${e.id}:${fnv1a(`${e.title}\x1f${e.content}`)}`)
+    .map((e) => `${e.id}:${surfaceSignature(e.title, e.content)}`)
     .sort();
 }
 
@@ -1369,7 +1402,7 @@ function changedLtmEntries(
   const nextIDs = entryKeyIds(nextKeys);
   return entries.filter((entry) => {
     if (!nextIDs.has(entry.id)) return false;
-    const nextKey = `${entry.id}:${fnv1a(`${entry.title}\x1f${entry.content}`)}`;
+    const nextKey = `${entry.id}:${surfaceSignature(entry.title, entry.content)}`;
     return previous.get(entry.id) !== nextKey;
   });
 }
@@ -1412,15 +1445,17 @@ function hasMaterialLtmDelta(input: {
  * 1LYkXZ7jkiHHnqPl: read pinned at 41k, ~250k rewritten per turn).
  *
  * This trigger ignores ranking entirely. `surfacedKeys` is the set of
- * `id:fnv1a(title\x1f content)` keys the model has ALREADY been shown. Today
- * every call site passes the FROZEN system[2] pin keys (`pinned.entryKeys`),
- * so the result is the cumulative delta from the pinned baseline — preserving
- * the single-coalesced-row contract. (The append-only follow-up will widen
- * this to the pin ∪ already-appended blocks.) For each key we look up the
- * entry's CURRENT state in the DB and compare the content hash:
+ * `id:surfaceSignature(title, content)` keys the model has ALREADY been shown.
+ * Today every call site passes the FROZEN system[2] pin keys
+ * (`pinned.entryKeys`), so the result is the cumulative delta from the pinned
+ * baseline — preserving the single-coalesced-row contract. (The append-only
+ * follow-up will widen this to the pin ∪ already-appended blocks.) For each key
+ * we look up the entry's CURRENT state in the DB and compare the MATERIALITY
+ * signature:
  *   - missing  → the entry was deleted/superseded → `removedIds`
- *   - hash differs → genuine content edit (curator/consolidation) → `changed`
- *   - hash same → no signal (NOT in the result), no matter the ranking
+ *   - sig differs → MATERIAL content edit (curator/consolidation) → `changed`
+ *   - sig same → no signal (NOT in the result), whether ranking churned OR the
+ *     edit was cosmetic (whitespace/punctuation/case only — see surfaceSignature)
  *
  * A delta is emitted iff `changed ∪ removedIds` is non-empty, so a steady
  * session with no real knowledge change emits zero deltas and never busts.
@@ -1476,7 +1511,7 @@ export function detectSurfacedMutations(surfacedKeys: string[] | undefined): {
       if (ltm.isTombstoned(logicalId)) removedIds.push(id);
       continue;
     }
-    const currentHash = fnv1a(`${current.title}\x1f${current.content}`);
+    const currentHash = surfaceSignature(current.title, current.content);
     if (currentHash !== surfacedHash) {
       // Report under the id the model already knows (the surfaced id), so the
       // delta's recall tokens and any later supersession matching stay in the
@@ -1751,7 +1786,7 @@ export function appendKnowledgePromptDelta(input: {
   const mut: DeltaMutation = {
     changed: changed.map((c) => ({
       id: c.id,
-      h: fnv1a(`${c.title}\x1f${c.content}`),
+      h: surfaceSignature(c.title, c.content),
     })),
     removed: removedIds,
   };

--- a/packages/gateway/test/ltm-pin.test.ts
+++ b/packages/gateway/test/ltm-pin.test.ts
@@ -13,6 +13,9 @@ import {
   fnv1a,
   ltmEntryKeys,
   sameEntryKeys,
+  sameIdSet,
+  shouldReanchorPinKeys,
+  surfaceSignature,
 } from "../src/pipeline";
 
 type Entry = { id: string; title: string; content: string };
@@ -126,5 +129,76 @@ describe("reorder-tolerant pin decision", () => {
     // Turn 2: re-ranked to c,a,b but again only a,c fit — same rendered set.
     const next = decide(first.keys, [C, A, B], ["a", "c"]);
     expect(next.rePin).toBe(false);
+  });
+
+  test("cosmetic reword → same key → pin reused (materiality gate)", () => {
+    const first = decide(undefined, [A, B]);
+    // Curator rewrites B with whitespace/punctuation/case-only differences.
+    const reworded = decide(first.keys, [
+      A,
+      { ...B, content: "  SECOND.  " }, // was "second"
+    ]);
+    expect(reworded.rePin).toBe(false);
+  });
+});
+
+describe("sameIdSet", () => {
+  test("true when both sets contain the same ids", () => {
+    expect(sameIdSet(new Set(["a", "b"]), new Set(["b", "a"]))).toBe(true);
+  });
+  test("false when sizes differ", () => {
+    expect(sameIdSet(new Set(["a"]), new Set(["a", "b"]))).toBe(false);
+  });
+  test("false when an id differs", () => {
+    expect(sameIdSet(new Set(["a", "b"]), new Set(["a", "c"]))).toBe(false);
+  });
+});
+
+// Key-format migration (#1320 Seer HIGH): a pin persisted before the
+// surfaceSignature change stores keys as `id:fnv1a(title\x1f content)`. The
+// migration guard must recognize such a pin as the SAME selection (same id set
+// + byte-identical rendered text) so it re-anchors to the new-format keys with
+// zero cache bust, instead of treating every entry as "changed".
+describe("shouldReanchorPinKeys — surfaceSignature key-format migration", () => {
+  const legacyKey = (e: Entry) =>
+    `${e.id}:${fnv1a(`${e.title}\x1f${e.content}`)}`;
+  const legacy = [legacyKey(A), legacyKey(B)].sort();
+  const current = ltmEntryKeys([A, B]);
+  const rendered = "system[2] rendered bytes for A + B";
+
+  test("legacy and new keys differ but share the same id set", () => {
+    expect(sameEntryKeys(legacy, current)).toBe(false);
+    expect(sameIdSet(entryKeyIds(legacy), entryKeyIds(current))).toBe(true);
+  });
+
+  test("re-anchors when id set matches AND rendered text is byte-identical", () => {
+    expect(shouldReanchorPinKeys(legacy, current, rendered, rendered)).toBe(
+      true,
+    );
+  });
+
+  test("does NOT re-anchor when the rendered text differs (real content edit)", () => {
+    expect(
+      shouldReanchorPinKeys(legacy, current, rendered, `${rendered} EDITED`),
+    ).toBe(false);
+  });
+
+  test("does NOT re-anchor when the id set changed", () => {
+    const grownCurrent = ltmEntryKeys([A, B, C]);
+    expect(
+      shouldReanchorPinKeys(legacy, grownCurrent, rendered, rendered),
+    ).toBe(false);
+  });
+
+  test("does NOT re-anchor when keys are already identical (no migration needed)", () => {
+    expect(shouldReanchorPinKeys(current, current, rendered, rendered)).toBe(
+      false,
+    );
+  });
+
+  test("new signature is stable across a cosmetic reword (no legacy re-bust)", () => {
+    expect(surfaceSignature("Bravo", "second")).toBe(
+      surfaceSignature("Bravo", "  Second.  "),
+    );
   });
 });

--- a/packages/gateway/test/prompt-delta-mutation-trigger.test.ts
+++ b/packages/gateway/test/prompt-delta-mutation-trigger.test.ts
@@ -17,14 +17,14 @@ import { ltm, listSessionPromptDeltas } from "@loreai/core";
 import {
   appendKnowledgePromptDelta,
   detectSurfacedMutations,
-  fnv1a,
   ltmEntryKeys,
+  surfaceSignature,
 } from "../src/pipeline";
 
 const PROJECT = "/tmp/lore-delta-mutation-trigger";
 
 function keyOf(id: string, title: string, content: string): string {
-  return `${id}:${fnv1a(`${title}\x1f${content}`)}`;
+  return `${id}:${surfaceSignature(title, content)}`;
 }
 
 /** Parse the persisted delta row's rendered text (the GatewayMessage content). */
@@ -364,5 +364,58 @@ describe("detectSurfacedMutations — genuine DB mutation, not ranking churn", (
       changed: [],
       removedIds: [],
     });
+  });
+});
+
+// Materiality gate: a delta fires only on a MATERIAL change. A trivial reword
+// (whitespace / punctuation / capitalization only) produces the SAME surface
+// signature, so detectSurfacedMutations reports no change and no delta block is
+// appended — keeping the mid-session delta channel quiet on cosmetic curator
+// edits. A substantive content edit, a title change, or a category change all
+// change the signature and DO fire.
+describe("detectSurfacedMutations — materiality gate", () => {
+  const P = "/tmp/lore-delta-materiality";
+
+  it("trivial reword (whitespace/punctuation/case only) → NOT material, no change", () => {
+    const id = ltm.create({
+      projectPath: P,
+      scope: "project",
+      category: "gotcha",
+      title: "Prefer tabs",
+      content: "Always use tabs, not spaces.",
+    });
+    const surfaced = [keyOf(id, "Prefer tabs", "Always use tabs, not spaces.")];
+    // Curator rewrites with only cosmetic differences.
+    ltm.update(id, { content: "always   use tabs not spaces" });
+    expect(detectSurfacedMutations(surfaced).changed).toEqual([]);
+  });
+
+  it("substantive content edit → material, reported as changed", () => {
+    const id = ltm.create({
+      projectPath: P,
+      scope: "project",
+      category: "gotcha",
+      title: "Prefer tabs 2",
+      content: "Always use tabs, not spaces.",
+    });
+    const surfaced = [
+      keyOf(id, "Prefer tabs 2", "Always use tabs, not spaces."),
+    ];
+    ltm.update(id, { content: "Always use spaces, never tabs." });
+    expect(detectSurfacedMutations(surfaced).changed).toHaveLength(1);
+  });
+
+  it("surfaceSignature normalizes whitespace, punctuation, and case", () => {
+    expect(surfaceSignature("T", "Always use tabs, not spaces.")).toBe(
+      surfaceSignature("T", "always   use tabs  not  spaces"),
+    );
+    // A genuine word change must differ.
+    expect(surfaceSignature("T", "use tabs")).not.toBe(
+      surfaceSignature("T", "use spaces"),
+    );
+    // Title participates in the signature.
+    expect(surfaceSignature("Title A", "body")).not.toBe(
+      surfaceSignature("Title B", "body"),
+    );
   });
 });

--- a/packages/gateway/test/prompt-delta-mutation-trigger.test.ts
+++ b/packages/gateway/test/prompt-delta-mutation-trigger.test.ts
@@ -418,4 +418,28 @@ describe("detectSurfacedMutations — materiality gate", () => {
       surfaceSignature("Title B", "body"),
     );
   });
+
+  it("surfaceSignature preserves operators so symbol-only edits stay MATERIAL", () => {
+    // Regression for the operator-erasure gap (Seer #1320 review): stripping
+    // ALL non-alphanumerics collapsed comparator/boolean flips to the same
+    // signature, silently suppressing a material edit in code/config-heavy
+    // entries. Each pair below is a genuine semantic change and must differ.
+    const pairs: Array<[string, string]> = [
+      [">= floor", "> floor"], // comparator relaxed
+      ["x == y", "x != y"], // equality flipped
+      ["a || b", "a && b"], // boolean flipped
+      ["foo?.bar", "foo.bar"], // optional chain vs plain access
+      ["count + 1", "count - 1"], // arithmetic flipped
+      ["rate < 0.5", "rate > 0.5"], // direction flipped
+    ];
+    for (const [a, b] of pairs) {
+      expect(surfaceSignature("T", a), `${a} vs ${b}`).not.toBe(
+        surfaceSignature("T", b),
+      );
+    }
+    // But cosmetic markdown/quotes/sentence punctuation is still ignored.
+    expect(surfaceSignature("T", "*Use* `tabs`, not spaces!")).toBe(
+      surfaceSignature("T", "use tabs not spaces!"),
+    );
+  });
 });


### PR DESCRIPTION
## Problem
Third of the 3-PR series from Onur's report. A mid-session knowledge delta fired on **any** content-hash change to a pinned entry — so a cosmetic curator reword (whitespace reflow, punctuation, capitalization) minted a fresh delta block, accruing toward `MAX_DELTA_BLOCKS` and adding noise for no semantic gain.

## Fix
Gate at the source by hashing a **normalized** signature. New `surfaceSignature(title, content)` lowercases, strips punctuation (Unicode-aware — keeps non-ASCII letters), and collapses whitespace before `fnv1a`. It replaces the raw `title\x1f content` hash at **all four** surfaced/pin-key sites (`ltmEntryKeys`, `changedLtmEntries`, `detectSurfacedMutations`, and the block's `mut` signature), so the definition of "changed" is consistent everywhere.

Consequences, all from the single definition:
- **`detectSurfacedMutations`:** a trivial reword yields an identical signature → no `changed` entry → no delta block.
- **`ltmEntryKeys` (pin identity) + `hasMaterialLtmDelta`:** the pin key is unchanged → `setUnchanged` stays true → system[2] keeps its byte-stable pinned text and never re-pins on a cosmetic edit.
- Because the **key** is unchanged for an immaterial edit, the surfaced set needs no advancing and the check never re-fires per turn (the 🔴 invariant from the plan — satisfied structurally, not by special-casing).

## Scope
- `MAX_DELTA_BLOCKS` stays **8** (per decision): lowering it trades clutter for more frequent coalesce cache-busts on large sessions; the generator is the right lever.
- A substantive content edit still changes the signature and fires normally; the material edit surfaces on the next natural re-pin.

## Testing
- New `prompt-delta-mutation-trigger.test.ts` cases: trivial reword (whitespace/punctuation/case) → not material (no change); substantive edit → material; `surfaceSignature` normalization properties.
- **Mutation-verified:** reverting `surfaceSignature` to the raw hash makes both materiality tests fail.
- Full suite green (5804 passed); typecheck + lint + format clean.

**Stacked on #1315** (targets that branch for a clean diff). Merge #1315 first, then this retargets to main.