### PR TITLE
fix(gateway): emit cache_control on the OpenAI/OpenRouter request path

### DIFF
--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -3604,9 +3604,29 @@ async function forwardToUpstream(
           system: [req.system, ...ltmParts].filter(Boolean).join("\n\n"),
         }
       : req;
+    // Pass cache options through so OpenRouter (and other OpenAI-protocol
+    // Anthropic-compatible endpoints) receive `cache_control` breakpoints on
+    // the system prefix, the conversation tail, and the last tool. OpenRouter
+    // honors Anthropic-style ephemeral breakpoints on the OpenAI Chat
+    // Completions API for Anthropic models; providers that don't support
+    // caching ignore the annotation. Downgrade the extended "1h" TTL to bare
+    // ephemeral (5m) for non-native endpoints, mirroring the Anthropic-compat
+    // branch below — the "1h" ttl is an Anthropic beta that third parties may
+    // reject. The LTM now rides the single system-string breakpoint, so drop
+    // the (now-inlined) stableLtmSystem/ltmSystem fields.
+    const effectiveCache: AnthropicCacheOptions | undefined = cache
+      ? {
+          ...cache,
+          systemTTL: cache.systemTTL === false ? false : "5m",
+          conversationTTL: "5m",
+          stableLtmSystem: undefined,
+          ltmSystem: undefined,
+        }
+      : cache;
     const result = buildOpenAIUpstreamRequest(
       reqWithLtm,
       effectiveUpstreamBase,
+      effectiveCache,
     );
     url = result.url;
     headers = result.headers;

--- a/packages/gateway/src/translate/openai.ts
+++ b/packages/gateway/src/translate/openai.ts
@@ -12,6 +12,7 @@ import type {
   GatewayTool,
 } from "./types";
 import { blocksToText, forwardClientHeaders, ZERO_USAGE } from "./types";
+import type { AnthropicCacheOptions } from "./anthropic";
 import { asString } from "@loreai/core";
 import { extractAuth } from "../auth";
 
@@ -569,6 +570,7 @@ export function buildOpenAIChatCompletionsUrl(base: string): string {
 export function buildOpenAIUpstreamRequest(
   req: GatewayRequest,
   upstreamBase: string,
+  cache?: AnthropicCacheOptions,
 ): { url: string; headers: Record<string, string>; body: unknown } {
   // Forward non-managed client headers first, then overlay gateway-managed.
   const headers: Record<string, string> = {
@@ -585,7 +587,7 @@ export function buildOpenAIUpstreamRequest(
 
   const body: Record<string, unknown> = {
     model: req.model,
-    messages: buildOpenAIMessages(req.messages, req.system),
+    messages: buildOpenAIMessages(req.messages, req.system, cache),
     stream: req.stream,
   };
 
@@ -593,16 +595,24 @@ export function buildOpenAIUpstreamRequest(
     body.max_tokens = req.maxTokens;
   }
 
-  // Add tools in OpenAI format
+  // Add tools in OpenAI format. OpenRouter honors Anthropic-style
+  // `cache_control` on the last tool definition for Anthropic models, exactly
+  // like the native Anthropic path (see buildAnthropicRequest). Tool defs are
+  // stable across turns, so a breakpoint here keeps them as cache reads.
   if (req.tools.length > 0) {
-    body.tools = req.tools.map((t) => ({
-      type: "function",
+    const tools = req.tools.map((t) => ({
+      type: "function" as const,
       function: {
         name: t.name,
         description: t.description,
         parameters: t.inputSchema,
       },
     }));
+    if (cache?.cacheTools && tools.length > 0) {
+      const lastTool = tools[tools.length - 1] as Record<string, unknown>;
+      lastTool.cache_control = ephemeralCacheControl(cache.systemTTL);
+    }
+    body.tools = tools;
   }
 
   // Forward extras
@@ -637,15 +647,48 @@ export function buildOpenAIUpstreamRequest(
   };
 }
 
+/**
+ * Build the `cache_control` object for an ephemeral breakpoint. OpenRouter
+ * accepts Anthropic's `{ type: "ephemeral", ttl?: "1h" }` shape verbatim on the
+ * OpenAI Chat Completions API for Anthropic models. Non-Anthropic OpenRouter
+ * models (and other OpenAI-protocol providers) simply ignore the annotation, so
+ * emitting it is safe across the board.
+ */
+function ephemeralCacheControl(ttl?: "5m" | "1h" | false): {
+  type: "ephemeral";
+  ttl?: "1h";
+} {
+  return ttl === "1h"
+    ? { type: "ephemeral", ttl: "1h" }
+    : { type: "ephemeral" };
+}
+
 function buildOpenAIMessages(
   messages: GatewayMessage[],
   system: string,
+  cache?: AnthropicCacheOptions,
 ): Array<Record<string, unknown>> {
   const result: Array<Record<string, unknown>> = [];
 
-  // Add system prompt if present
+  // Add system prompt if present. When system caching is requested, emit the
+  // block-array form with a `cache_control` breakpoint so OpenRouter caches the
+  // (large, stable) system prefix. Otherwise keep the plain-string form for
+  // maximum compatibility and cache stability (byte-identical across turns).
   if (system) {
-    result.push({ role: "system", content: system });
+    if (cache?.systemTTL) {
+      result.push({
+        role: "system",
+        content: [
+          {
+            type: "text",
+            text: system,
+            cache_control: ephemeralCacheControl(cache.systemTTL),
+          },
+        ],
+      });
+    } else {
+      result.push({ role: "system", content: system });
+    }
   }
 
   for (const msg of messages) {
@@ -707,6 +750,35 @@ function buildOpenAIMessages(
       }
 
       result.push(msgRecord);
+    }
+  }
+
+  // Conversation caching: place a `cache_control` breakpoint on the final
+  // content block of the last cacheable message. OpenRouter's lookback finds
+  // the prior turn's breakpoint, reads the cached prefix, and writes only the
+  // new tail — the same strategy as the native Anthropic path. This requires
+  // the block-array content form, so promote a plain-string message body to a
+  // single text block before annotating it.
+  //
+  // Skip `role: "tool"` messages: the OpenAI Chat Completions API requires tool
+  // messages to carry STRING content, so we can't attach a block-level
+  // breakpoint there. Walk back to the most recent non-tool message instead —
+  // the cached prefix still covers the tool results in between (they precede
+  // the breakpoint), so no cache coverage is lost.
+  if (cache?.cacheConversation && result.length > 0) {
+    let idx = result.length - 1;
+    while (idx >= 0 && result[idx].role === "tool") idx--;
+    const target = idx >= 0 ? result[idx] : undefined;
+    if (target) {
+      const cc = ephemeralCacheControl(cache.conversationTTL);
+      if (typeof target.content === "string") {
+        target.content = [
+          { type: "text", text: target.content, cache_control: cc },
+        ];
+      } else if (Array.isArray(target.content) && target.content.length > 0) {
+        const parts = target.content as Array<Record<string, unknown>>;
+        parts[parts.length - 1].cache_control = cc;
+      }
     }
   }
 

--- a/packages/gateway/src/translate/openai.ts
+++ b/packages/gateway/src/translate/openai.ts
@@ -761,6 +761,9 @@ function buildOpenAIMessages(
   // single text block before annotating it.
   //
   // Walk back to the most recent message we can annotate, skipping:
+  //   - `role: "system"` messages — the system prefix owns its own breakpoint
+  //     (via `systemTTL`); the conversation breakpoint must never overwrite it,
+  //     which would clobber a distinct system TTL;
   //   - `role: "tool"` messages — the OpenAI Chat Completions API requires tool
   //     messages to carry STRING content, so we can't attach a block-level
   //     breakpoint there; and
@@ -770,7 +773,7 @@ function buildOpenAIMessages(
   // breakpoint), so no cache coverage is lost.
   if (cache?.cacheConversation && result.length > 0) {
     const isAnnotatable = (m: Record<string, unknown>): boolean => {
-      if (m.role === "tool") return false;
+      if (m.role === "system" || m.role === "tool") return false;
       return (
         (typeof m.content === "string" && m.content.length > 0) ||
         (Array.isArray(m.content) && m.content.length > 0)

--- a/packages/gateway/src/translate/openai.ts
+++ b/packages/gateway/src/translate/openai.ts
@@ -760,14 +760,24 @@ function buildOpenAIMessages(
   // the block-array content form, so promote a plain-string message body to a
   // single text block before annotating it.
   //
-  // Skip `role: "tool"` messages: the OpenAI Chat Completions API requires tool
-  // messages to carry STRING content, so we can't attach a block-level
-  // breakpoint there. Walk back to the most recent non-tool message instead —
-  // the cached prefix still covers the tool results in between (they precede
-  // the breakpoint), so no cache coverage is lost.
+  // Walk back to the most recent message we can annotate, skipping:
+  //   - `role: "tool"` messages — the OpenAI Chat Completions API requires tool
+  //     messages to carry STRING content, so we can't attach a block-level
+  //     breakpoint there; and
+  //   - assistant messages that carry only `tool_calls` (no `content`) — there
+  //     is no content block to hang the breakpoint on.
+  // The cached prefix still covers every skipped message (they precede the
+  // breakpoint), so no cache coverage is lost.
   if (cache?.cacheConversation && result.length > 0) {
+    const isAnnotatable = (m: Record<string, unknown>): boolean => {
+      if (m.role === "tool") return false;
+      return (
+        (typeof m.content === "string" && m.content.length > 0) ||
+        (Array.isArray(m.content) && m.content.length > 0)
+      );
+    };
     let idx = result.length - 1;
-    while (idx >= 0 && result[idx].role === "tool") idx--;
+    while (idx >= 0 && !isAnnotatable(result[idx])) idx--;
     const target = idx >= 0 ? result[idx] : undefined;
     if (target) {
       const cc = ephemeralCacheControl(cache.conversationTTL);
@@ -775,7 +785,7 @@ function buildOpenAIMessages(
         target.content = [
           { type: "text", text: target.content, cache_control: cc },
         ];
-      } else if (Array.isArray(target.content) && target.content.length > 0) {
+      } else {
         const parts = target.content as Array<Record<string, unknown>>;
         parts[parts.length - 1].cache_control = cc;
       }

--- a/packages/gateway/test/openai-caching.test.ts
+++ b/packages/gateway/test/openai-caching.test.ts
@@ -230,6 +230,45 @@ describe("buildOpenAIUpstreamRequest — conversation caching", () => {
     const toolMsg = msgs.find((m) => m.role === "tool");
     expect(typeof toolMsg?.content).toBe("string");
   });
+
+  test("never overwrites the system breakpoint when no message is annotatable", () => {
+    // All post-system messages are non-annotatable (tool_calls-only assistant +
+    // tool result), so the walk-back would otherwise reach the system message.
+    // The system keeps its own (1h) breakpoint; the conversation (5m) one is
+    // simply not placed rather than clobbering the system TTL.
+    const req = makeRequest({
+      messages: [
+        {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "t1", name: "recall", input: {} }],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              toolUseId: "t1",
+              content: [{ type: "text", text: "result" }],
+            },
+          ],
+        },
+      ],
+    });
+    const msgs = messagesOf(
+      getBody(req, {
+        systemTTL: "1h",
+        cacheConversation: true,
+        conversationTTL: "5m",
+      }),
+    );
+    const sys = msgs.find((m) => m.role === "system");
+    const sysBlock = (sys?.content as Array<Record<string, unknown>>)?.[0];
+    // system breakpoint intact at 1h — NOT downgraded to the 5m conversation TTL
+    expect(sysBlock.cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+    // exactly one breakpoint total (the system one)
+    const count = (JSON.stringify(msgs).match(/"cache_control"/g) ?? []).length;
+    expect(count).toBe(1);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/test/openai-caching.test.ts
+++ b/packages/gateway/test/openai-caching.test.ts
@@ -191,6 +191,45 @@ describe("buildOpenAIUpstreamRequest — conversation caching", () => {
     const count = (JSON.stringify(msgs).match(/"cache_control"/g) ?? []).length;
     expect(count).toBe(1);
   });
+
+  test("tool_calls-only assistant tail: breakpoint walks back to a message with content", () => {
+    // Regression for the case where the last non-tool message is an assistant
+    // message carrying ONLY tool_calls (no `content` field) — the breakpoint
+    // must not be silently dropped; it walks further back to the user message.
+    const req = makeRequest({
+      messages: [
+        { role: "user", content: [{ type: "text", text: "do it" }] },
+        {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "t1", name: "recall", input: {} }],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              toolUseId: "t1",
+              content: [{ type: "text", text: "result" }],
+            },
+          ],
+        },
+      ],
+    });
+    const msgs = messagesOf(getBody(req, { cacheConversation: true }));
+    // the assistant message has only tool_calls, no content to annotate
+    const assistant = msgs.find((m) => m.role === "assistant");
+    expect(assistant?.content).toBeUndefined();
+    // ...so the breakpoint lands on the first user message ("do it")
+    const firstUser = msgs.find(
+      (m) => m.role === "user" && JSON.stringify(m.content).includes("do it"),
+    );
+    expect(JSON.stringify(firstUser?.content)).toContain("cache_control");
+    // exactly one breakpoint total, and NOT on the tool message
+    const count = (JSON.stringify(msgs).match(/"cache_control"/g) ?? []).length;
+    expect(count).toBe(1);
+    const toolMsg = msgs.find((m) => m.role === "tool");
+    expect(typeof toolMsg?.content).toBe("string");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/test/openai-caching.test.ts
+++ b/packages/gateway/test/openai-caching.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Tests for OpenRouter/OpenAI-protocol prompt caching in
+ * buildOpenAIUpstreamRequest.
+ *
+ * Regression guard for the "cache hit rate = 0 on OpenRouter" bug: the OpenAI
+ * builder previously emitted ZERO `cache_control` breakpoints, so OpenRouter
+ * (which honors Anthropic-style ephemeral breakpoints on the Chat Completions
+ * API for Anthropic models) never cached anything. These tests pin the
+ * breakpoint placement on the system prefix, the conversation tail, and the
+ * last tool — and pin the no-cache passthrough shape (plain-string content)
+ * so the cache-stability invariant is preserved for meta requests.
+ */
+import { describe, expect, test } from "vitest";
+import type { AnthropicCacheOptions } from "../src/translate/anthropic";
+import { buildOpenAIUpstreamRequest } from "../src/translate/openai";
+import type { GatewayRequest } from "../src/translate/types";
+
+const BASE = "https://openrouter.ai/api";
+
+function makeRequest(overrides: Partial<GatewayRequest> = {}): GatewayRequest {
+  return {
+    protocol: "openai",
+    model: "anthropic/claude-opus-4.8",
+    system: "You are a helpful assistant.",
+    messages: [{ role: "user", content: [{ type: "text", text: "Hello" }] }],
+    tools: [],
+    stream: true,
+    maxTokens: 4096,
+    metadata: {},
+    rawHeaders: { "x-api-key": "test-key" },
+    extras: {},
+    ...overrides,
+  };
+}
+
+function getBody(req: GatewayRequest, cache?: AnthropicCacheOptions) {
+  return buildOpenAIUpstreamRequest(req, BASE, cache).body as Record<
+    string,
+    unknown
+  >;
+}
+
+type Msg = { role: string; content: unknown; tool_calls?: unknown };
+
+function messagesOf(body: Record<string, unknown>): Msg[] {
+  return body.messages as Msg[];
+}
+
+// ---------------------------------------------------------------------------
+// No caching (default / passthrough) — cache-stability invariant
+// ---------------------------------------------------------------------------
+
+describe("buildOpenAIUpstreamRequest — no caching", () => {
+  test("system is a plain string when no cache options", () => {
+    const msgs = messagesOf(getBody(makeRequest()));
+    const sys = msgs.find((m) => m.role === "system");
+    expect(sys?.content).toBe("You are a helpful assistant.");
+  });
+
+  test("text-only user content stays a plain string", () => {
+    const msgs = messagesOf(getBody(makeRequest()));
+    const user = msgs.find((m) => m.role === "user");
+    expect(user?.content).toBe("Hello");
+  });
+
+  test("no cache_control anywhere when cache is undefined", () => {
+    const json = JSON.stringify(getBody(makeRequest()));
+    expect(json).not.toContain("cache_control");
+  });
+
+  test("no cache_control when systemTTL is false and no conversation", () => {
+    const json = JSON.stringify(getBody(makeRequest(), { systemTTL: false }));
+    expect(json).not.toContain("cache_control");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// System caching
+// ---------------------------------------------------------------------------
+
+describe("buildOpenAIUpstreamRequest — system caching", () => {
+  test("system becomes a block array with an ephemeral breakpoint", () => {
+    const msgs = messagesOf(getBody(makeRequest(), { systemTTL: "5m" }));
+    const sys = msgs.find((m) => m.role === "system");
+    expect(Array.isArray(sys?.content)).toBe(true);
+    const block = (sys?.content as Array<Record<string, unknown>>)?.[0];
+    expect(block.text).toBe("You are a helpful assistant.");
+    expect(block.cache_control).toEqual({ type: "ephemeral" });
+  });
+
+  test("systemTTL 1h emits the extended ttl", () => {
+    const msgs = messagesOf(getBody(makeRequest(), { systemTTL: "1h" }));
+    const sys = msgs.find((m) => m.role === "system");
+    const block = (sys?.content as Array<Record<string, unknown>>)?.[0];
+    expect(block.cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+  });
+
+  test("no system block emitted when system is empty", () => {
+    const msgs = messagesOf(
+      getBody(makeRequest({ system: "" }), { systemTTL: "5m" }),
+    );
+    expect(msgs.find((m) => m.role === "system")).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Conversation caching
+// ---------------------------------------------------------------------------
+
+describe("buildOpenAIUpstreamRequest — conversation caching", () => {
+  test("breakpoint on the last block of the last message (string→array)", () => {
+    const msgs = messagesOf(
+      getBody(makeRequest(), { cacheConversation: true }),
+    );
+    const last = msgs[msgs.length - 1];
+    expect(Array.isArray(last.content)).toBe(true);
+    const parts = last.content as Array<Record<string, unknown>>;
+    expect(parts[parts.length - 1].cache_control).toEqual({
+      type: "ephemeral",
+    });
+  });
+
+  test("conversationTTL 1h emits the extended ttl on the tail", () => {
+    const msgs = messagesOf(
+      getBody(makeRequest(), {
+        cacheConversation: true,
+        conversationTTL: "1h",
+      }),
+    );
+    const last = msgs[msgs.length - 1];
+    const parts = last.content as Array<Record<string, unknown>>;
+    expect(parts[parts.length - 1].cache_control).toEqual({
+      type: "ephemeral",
+      ttl: "1h",
+    });
+  });
+
+  test("only the LAST message carries a conversation breakpoint", () => {
+    const req = makeRequest({
+      messages: [
+        { role: "user", content: [{ type: "text", text: "first" }] },
+        { role: "assistant", content: [{ type: "text", text: "reply" }] },
+        { role: "user", content: [{ type: "text", text: "second" }] },
+      ],
+    });
+    const msgs = messagesOf(getBody(req, { cacheConversation: true }));
+    // exactly one cache_control across all conversation messages
+    const count = msgs.filter((m) =>
+      JSON.stringify(m.content).includes("cache_control"),
+    ).length;
+    expect(count).toBe(1);
+    // ...and it's on the last one
+    expect(JSON.stringify(msgs[msgs.length - 1].content)).toContain(
+      "cache_control",
+    );
+  });
+
+  test("tool-role tail: breakpoint moves to prior non-tool message, tool content stays a string", () => {
+    // Agentic mid-turn shape: assistant tool_call, then a tool_result message.
+    const req = makeRequest({
+      messages: [
+        { role: "user", content: [{ type: "text", text: "do it" }] },
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "calling" },
+            { type: "tool_use", id: "t1", name: "recall", input: {} },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              toolUseId: "t1",
+              content: [{ type: "text", text: "result" }],
+            },
+          ],
+        },
+      ],
+    });
+    const msgs = messagesOf(getBody(req, { cacheConversation: true }));
+    const toolMsg = msgs.find((m) => m.role === "tool");
+    // tool message content MUST remain a string (OpenAI wire requirement)
+    expect(typeof toolMsg?.content).toBe("string");
+    expect(JSON.stringify(toolMsg?.content)).not.toContain("cache_control");
+    // breakpoint lands on the assistant message (last non-tool)
+    const assistant = msgs.find((m) => m.role === "assistant");
+    expect(JSON.stringify(assistant?.content)).toContain("cache_control");
+    // exactly one breakpoint total
+    const count = (JSON.stringify(msgs).match(/"cache_control"/g) ?? []).length;
+    expect(count).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tool caching
+// ---------------------------------------------------------------------------
+
+describe("buildOpenAIUpstreamRequest — tool caching", () => {
+  const withTools = makeRequest({
+    tools: [
+      { name: "a", description: "first", inputSchema: {} },
+      { name: "recall", description: "last", inputSchema: {} },
+    ],
+  });
+
+  test("breakpoint on the last tool when cacheTools is set", () => {
+    const body = getBody(withTools, { cacheTools: true, systemTTL: "5m" });
+    const tools = body.tools as Array<Record<string, unknown>>;
+    expect(tools[0].cache_control).toBeUndefined();
+    expect(tools[1].cache_control).toEqual({ type: "ephemeral" });
+  });
+
+  test("tool breakpoint uses 1h when systemTTL is 1h", () => {
+    const body = getBody(withTools, { cacheTools: true, systemTTL: "1h" });
+    const tools = body.tools as Array<Record<string, unknown>>;
+    expect(tools[1].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+  });
+
+  test("no tool breakpoint when cacheTools is falsy", () => {
+    const body = getBody(withTools, { systemTTL: "5m" });
+    const tools = body.tools as Array<Record<string, unknown>>;
+    for (const t of tools) expect(t.cache_control).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Full session config (what the pipeline actually sends) — end-to-end shape
+// ---------------------------------------------------------------------------
+
+describe("buildOpenAIUpstreamRequest — full session cache config", () => {
+  test("system + conversation + tool breakpoints all present", () => {
+    const req = makeRequest({
+      tools: [{ name: "recall", description: "search", inputSchema: {} }],
+    });
+    const body = getBody(req, {
+      systemTTL: "5m",
+      cacheTools: true,
+      cacheConversation: true,
+      conversationTTL: "5m",
+    });
+    // exactly 3 breakpoints: system, tool, conversation tail
+    const count = (JSON.stringify(body).match(/"cache_control"/g) ?? []).length;
+    expect(count).toBe(3);
+  });
+});


### PR DESCRIPTION
## Problem

Prompt caching was **never enabled** for the OpenAI-protocol upstream path. `buildOpenAIUpstreamRequest` emitted zero `cache_control` breakpoints, and the `openai` pipeline branch dropped the cache options entirely.

This stayed latent until an upstream switched from direct Anthropic to **OpenRouter** (`protocol=openai`). At that point every turn logged `read=0 create=0` despite 77–97% prefix matches — the content was cacheable, it was just never marked, so OpenRouter cached nothing. Diagnosis from the logs:

- Until the switch (`protocol=anthropic`, `api.anthropic.com`): **100% hit rate** (`read=275221`, `read=616682`).
- After (`protocol=openai`, `openrouter.ai/api`): **0/249 turns** had any cached read.

## Fix

OpenRouter honors Anthropic-style `cache_control: {type:"ephemeral"}` on content blocks **directly on the OpenAI Chat Completions API** for Anthropic models ([docs](https://openrouter.ai/docs/features/prompt-caching)). So we express caching there rather than routing the whole provider through the Anthropic wire (which would wrongly force non-Claude OpenRouter models onto `/v1/messages`).

- `buildOpenAIMessages` / `buildOpenAIUpstreamRequest` now accept an optional `AnthropicCacheOptions` and place ephemeral breakpoints on the **system prefix**, the **conversation tail**, and the **last tool definition** — mirroring the native Anthropic path.
- **Cache-stability invariant preserved**: plain-string content stays a string when no breakpoint applies (meta requests emit zero `cache_control`).
- **`role: "tool"` tail guard**: OpenAI requires string content on tool messages, so the conversation breakpoint walks back to the nearest non-tool message instead of corrupting the tool message.
- Threads session cache options into the `openai` pipeline branch, downgrading `"1h"` TTL to bare ephemeral (5m) for non-native endpoints (matching the existing Anthropic-compat branch).

## Tests

New `openai-caching.test.ts` (15 tests): no-cache passthrough shape, system/conversation/tool breakpoint placement + TTLs, the "only last message" invariant, the tool-role-tail guard, and a full-session 3-breakpoint end-to-end check.

- `typecheck`: clean
- `lint`: 0 errors
- `format:check`: clean
- Regression suites (pipeline-tools, anthropic-caching, content-passthrough, recall-openai-stream, openai-parse): all green

## Follow-up (not in this PR)

Cache-**write** accounting: the OpenAI parse paths read `usage.prompt_tokens_details.cached_tokens` (reads) but never `cache_write_tokens` (writes). Once this PR makes writes happen, that field should be parsed into `cacheCreationInputTokens` so the Costs UI write column and cache-warmer economics are accurate.