### PR TITLE
fix(gateway): parse cache-write tokens on the OpenAI/OpenRouter response path

### DIFF
--- a/packages/gateway/src/batch-queue.ts
+++ b/packages/gateway/src/batch-queue.ts
@@ -469,7 +469,10 @@ async function downloadOpenAIResults(
             usage?: {
               prompt_tokens?: number;
               completion_tokens?: number;
-              prompt_tokens_details?: { cached_tokens?: number };
+              prompt_tokens_details?: {
+                cached_tokens?: number;
+                cache_write_tokens?: number;
+              };
             };
             error?: { message?: string; type?: string; code?: string | null };
           };

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -458,7 +458,10 @@ type OpenAIChatResponse = {
   usage?: {
     prompt_tokens?: number;
     completion_tokens?: number;
-    prompt_tokens_details?: { cached_tokens?: number };
+    prompt_tokens_details?: {
+      cached_tokens?: number;
+      cache_write_tokens?: number;
+    };
   };
 };
 
@@ -466,10 +469,13 @@ type OpenAIChatResponse = {
  * Normalize OpenAI usage to the AnthropicUsage shape for unified cost tracking.
  *
  * Maps:
- *   prompt_tokens                          → input_tokens
- *   completion_tokens                      → output_tokens
- *   prompt_tokens_details.cached_tokens    → cache_read_input_tokens
- *   (not reported by OpenAI)               → cache_creation_input_tokens = 0
+ *   prompt_tokens                              → input_tokens
+ *   completion_tokens                          → output_tokens
+ *   prompt_tokens_details.cached_tokens        → cache_read_input_tokens
+ *   prompt_tokens_details.cache_write_tokens   → cache_creation_input_tokens
+ *
+ * OpenAI proper doesn't report cache writes (field absent → 0); OpenRouter does
+ * report them for Anthropic explicit caching.
  */
 export function normalizeOpenAIUsage(
   usage: OpenAIChatResponse["usage"],
@@ -478,7 +484,8 @@ export function normalizeOpenAIUsage(
     input_tokens: usage?.prompt_tokens ?? 0,
     output_tokens: usage?.completion_tokens ?? 0,
     cache_read_input_tokens: usage?.prompt_tokens_details?.cached_tokens ?? 0,
-    cache_creation_input_tokens: 0, // OpenAI doesn't report this separately
+    cache_creation_input_tokens:
+      usage?.prompt_tokens_details?.cache_write_tokens ?? 0,
   };
 }
 

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -466,26 +466,59 @@ type OpenAIChatResponse = {
 };
 
 /**
+ * OpenAI-protocol usage reports cache reads (`cached_tokens`) and writes
+ * (`cache_write_tokens`) as a SUBSET of `prompt_tokens` (inclusive accounting —
+ * confirmed by the OpenAI prompt-caching docs: `prompt_tokens: 2006` includes
+ * `cached_tokens: 1920`). The gateway's cost model and cache analytics treat
+ * input / cache-read / cache-write as DISJOINT buckets (the Anthropic-native
+ * convention, where `input_tokens` already EXCLUDES cache tokens). Feeding the
+ * raw inclusive `prompt_tokens` straight through double-bills the cached and
+ * written tokens (once at input rate, again at cache-read/write rate) and
+ * inflates the analytics denominator.
+ *
+ * Convert to the disjoint convention by subtracting the cache buckets from the
+ * reported input. Clamped at 0 so a provider that (incorrectly) reports cache
+ * tokens exceeding `prompt_tokens` can never yield a negative input count.
+ */
+export function disjointOpenAIInputTokens(
+  rawInputTokens: number | undefined,
+  cachedTokens: number | undefined,
+  cacheWriteTokens: number | undefined,
+): number {
+  return Math.max(
+    0,
+    (rawInputTokens ?? 0) - (cachedTokens ?? 0) - (cacheWriteTokens ?? 0),
+  );
+}
+
+/**
  * Normalize OpenAI usage to the AnthropicUsage shape for unified cost tracking.
  *
  * Maps:
- *   prompt_tokens                              → input_tokens
+ *   prompt_tokens − cached − written           → input_tokens (disjoint)
  *   completion_tokens                          → output_tokens
  *   prompt_tokens_details.cached_tokens        → cache_read_input_tokens
  *   prompt_tokens_details.cache_write_tokens   → cache_creation_input_tokens
  *
  * OpenAI proper doesn't report cache writes (field absent → 0); OpenRouter does
- * report them for Anthropic explicit caching.
+ * report them for Anthropic explicit caching. See `disjointOpenAIInputTokens`
+ * for why the cache buckets are subtracted from `prompt_tokens`.
  */
 export function normalizeOpenAIUsage(
   usage: OpenAIChatResponse["usage"],
 ): AnthropicUsage {
+  const cachedTokens = usage?.prompt_tokens_details?.cached_tokens ?? 0;
+  const cacheWriteTokens =
+    usage?.prompt_tokens_details?.cache_write_tokens ?? 0;
   return {
-    input_tokens: usage?.prompt_tokens ?? 0,
+    input_tokens: disjointOpenAIInputTokens(
+      usage?.prompt_tokens,
+      cachedTokens,
+      cacheWriteTokens,
+    ),
     output_tokens: usage?.completion_tokens ?? 0,
-    cache_read_input_tokens: usage?.prompt_tokens_details?.cached_tokens ?? 0,
-    cache_creation_input_tokens:
-      usage?.prompt_tokens_details?.cache_write_tokens ?? 0,
+    cache_read_input_tokens: cachedTokens,
+    cache_creation_input_tokens: cacheWriteTokens,
   };
 }
 

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -1316,7 +1316,7 @@ function accumulateWorkerSSE(
  * text — a response that is purely tool_use (no text) is treated as empty,
  * matching parseWorkerResponse (workers consume text, not tool calls).
  */
-function gatewayResponseToWorkerResult(resp: GatewayResponse): {
+export function gatewayResponseToWorkerResult(resp: GatewayResponse): {
   text: string | null;
   usage: AnthropicUsage | null;
   model: string | null;
@@ -1333,6 +1333,7 @@ function gatewayResponseToWorkerResult(resp: GatewayResponse): {
         input_tokens: resp.usage.inputTokens,
         output_tokens: resp.usage.outputTokens,
         cache_read_input_tokens: resp.usage.cacheReadInputTokens,
+        cache_creation_input_tokens: resp.usage.cacheCreationInputTokens,
       }
     : null;
   return { text: text || null, usage, model: resp.model || null };

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -200,7 +200,10 @@ import {
   resolveToolResults,
   deterministicID,
 } from "./temporal-adapter";
-import { createGatewayLLMClient } from "./llm-adapter";
+import {
+  createGatewayLLMClient,
+  disjointOpenAIInputTokens,
+} from "./llm-adapter";
 import { createBatchLLMClient } from "./batch-queue";
 import {
   runBackground,
@@ -4487,7 +4490,13 @@ export function accumulateOpenAINonStreamJSON(
     content,
     stopReason,
     usage: {
-      inputTokens: (usage?.prompt_tokens as number) ?? 0,
+      // prompt_tokens is inclusive of cache reads/writes; convert to the
+      // gateway's disjoint convention so cache tokens aren't double-counted.
+      inputTokens: disjointOpenAIInputTokens(
+        usage?.prompt_tokens as number | undefined,
+        promptTokensDetails?.cached_tokens,
+        promptTokensDetails?.cache_write_tokens,
+      ),
       outputTokens: (usage?.completion_tokens as number) ?? 0,
       cacheReadInputTokens: promptTokensDetails?.cached_tokens,
       // OpenRouter reports cache-write tokens (Anthropic explicit caching) in
@@ -4559,7 +4568,11 @@ export function accumulateResponsesNonStreamJSON(
     content,
     stopReason,
     usage: {
-      inputTokens: (usage?.input_tokens as number) ?? 0,
+      inputTokens: disjointOpenAIInputTokens(
+        usage?.input_tokens as number | undefined,
+        inputTokensDetails?.cached_tokens,
+        inputTokensDetails?.cache_write_tokens,
+      ),
       outputTokens: (usage?.output_tokens as number) ?? 0,
       cacheReadInputTokens: inputTokensDetails?.cached_tokens,
       cacheCreationInputTokens: inputTokensDetails?.cache_write_tokens,

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -4432,7 +4432,7 @@ async function accumulateNonStreamResponse(
 // Anthropic non-stream JSON → GatewayResponse: use shared parseAnthropicResponseJSON
 const accumulateAnthropicNonStreamJSON = parseAnthropicResponseJSON;
 
-function accumulateOpenAINonStreamJSON(
+export function accumulateOpenAINonStreamJSON(
   json: Record<string, unknown>,
 ): GatewayResponse {
   const content: GatewayContentBlock[] = [];
@@ -4490,6 +4490,12 @@ function accumulateOpenAINonStreamJSON(
       inputTokens: (usage?.prompt_tokens as number) ?? 0,
       outputTokens: (usage?.completion_tokens as number) ?? 0,
       cacheReadInputTokens: promptTokensDetails?.cached_tokens,
+      // OpenRouter reports cache-write tokens (Anthropic explicit caching) in
+      // prompt_tokens_details.cache_write_tokens. OpenAI proper doesn't report
+      // writes separately (leaves it undefined) — see the OpenRouter usage
+      // accounting docs. Left undefined when absent so it never masquerades
+      // as a real zero-write in analytics/cost tracking.
+      cacheCreationInputTokens: promptTokensDetails?.cache_write_tokens,
     },
   };
 }
@@ -4541,9 +4547,11 @@ export function accumulateResponsesNonStreamJSON(
   }
 
   const usage = json.usage as Record<string, unknown> | undefined;
-  const promptTokensDetails = usage?.prompt_tokens_details as
-    | Record<string, number>
-    | undefined;
+  // Responses API reports cache details under `input_tokens_details`; fall back
+  // to `prompt_tokens_details` (Chat Completions shape) for resilience across
+  // OpenAI-compatible providers.
+  const inputTokensDetails = (usage?.input_tokens_details ??
+    usage?.prompt_tokens_details) as Record<string, number> | undefined;
 
   return {
     id: asString(json.id),
@@ -4553,7 +4561,8 @@ export function accumulateResponsesNonStreamJSON(
     usage: {
       inputTokens: (usage?.input_tokens as number) ?? 0,
       outputTokens: (usage?.output_tokens as number) ?? 0,
-      cacheReadInputTokens: promptTokensDetails?.cached_tokens,
+      cacheReadInputTokens: inputTokensDetails?.cached_tokens,
+      cacheCreationInputTokens: inputTokensDetails?.cache_write_tokens,
     },
   };
 }

--- a/packages/gateway/src/stream/openai-responses.ts
+++ b/packages/gateway/src/stream/openai-responses.ts
@@ -171,9 +171,6 @@ export async function accumulateResponsesSSEStream(
 
           const respUsage = resp.usage as Record<string, unknown> | undefined;
           if (respUsage) {
-            if (typeof respUsage.input_tokens === "number") {
-              usage.inputTokens = respUsage.input_tokens;
-            }
             if (typeof respUsage.output_tokens === "number") {
               usage.outputTokens = respUsage.output_tokens;
             }
@@ -188,6 +185,16 @@ export async function accumulateResponsesSSEStream(
             }
             if (promptDetails?.cache_write_tokens !== undefined) {
               usage.cacheCreationInputTokens = promptDetails.cache_write_tokens;
+            }
+            if (typeof respUsage.input_tokens === "number") {
+              // input_tokens is inclusive of cache reads/writes; subtract them
+              // to match the gateway's disjoint token convention.
+              usage.inputTokens = Math.max(
+                0,
+                respUsage.input_tokens -
+                  (promptDetails?.cached_tokens ?? 0) -
+                  (promptDetails?.cache_write_tokens ?? 0),
+              );
             }
           }
         }

--- a/packages/gateway/src/stream/openai-responses.ts
+++ b/packages/gateway/src/stream/openai-responses.ts
@@ -177,11 +177,17 @@ export async function accumulateResponsesSSEStream(
             if (typeof respUsage.output_tokens === "number") {
               usage.outputTokens = respUsage.output_tokens;
             }
-            const promptDetails = respUsage.prompt_tokens_details as
+            // Responses API reports cache details under `input_tokens_details`;
+            // fall back to `prompt_tokens_details` for OpenAI-compatible providers.
+            const promptDetails = (respUsage.input_tokens_details ??
+              respUsage.prompt_tokens_details) as
               | Record<string, number>
               | undefined;
             if (promptDetails?.cached_tokens !== undefined) {
               usage.cacheReadInputTokens = promptDetails.cached_tokens;
+            }
+            if (promptDetails?.cache_write_tokens !== undefined) {
+              usage.cacheCreationInputTokens = promptDetails.cache_write_tokens;
             }
           }
         }

--- a/packages/gateway/src/stream/openai.ts
+++ b/packages/gateway/src/stream/openai.ts
@@ -376,6 +376,7 @@ export async function accumulateOpenAISSEStream(
   let inputTokens = 0;
   let outputTokens = 0;
   let cachedTokens: number | undefined;
+  let cacheWriteTokens: number | undefined;
 
   if (!upstreamResponse.body) {
     throw new Error("Upstream response has no body");
@@ -445,6 +446,8 @@ export async function accumulateOpenAISSEStream(
         | undefined;
       if (details?.cached_tokens !== undefined)
         cachedTokens = details.cached_tokens;
+      if (details?.cache_write_tokens !== undefined)
+        cacheWriteTokens = details.cache_write_tokens;
     }
   }
 
@@ -475,6 +478,7 @@ export async function accumulateOpenAISSEStream(
       inputTokens,
       outputTokens,
       cacheReadInputTokens: cachedTokens,
+      cacheCreationInputTokens: cacheWriteTokens,
     },
   };
 }

--- a/packages/gateway/src/stream/openai.ts
+++ b/packages/gateway/src/stream/openai.ts
@@ -475,7 +475,14 @@ export async function accumulateOpenAISSEStream(
     content,
     stopReason,
     usage: {
-      inputTokens,
+      // prompt_tokens is inclusive of cache reads/writes; subtract them to
+      // match the gateway's disjoint token convention (see
+      // disjointOpenAIInputTokens in llm-adapter.ts). Inlined here to keep this
+      // leaf stream module free of a cross-module import.
+      inputTokens: Math.max(
+        0,
+        inputTokens - (cachedTokens ?? 0) - (cacheWriteTokens ?? 0),
+      ),
       outputTokens,
       cacheReadInputTokens: cachedTokens,
       cacheCreationInputTokens: cacheWriteTokens,

--- a/packages/gateway/test/llm-adapter.test.ts
+++ b/packages/gateway/test/llm-adapter.test.ts
@@ -163,7 +163,9 @@ describe("normalizeOpenAIUsage", () => {
     });
 
     expect(result).toEqual({
-      input_tokens: 100,
+      // prompt_tokens (100) is inclusive of cached_tokens (30); the disjoint
+      // convention subtracts it → input_tokens = 70.
+      input_tokens: 70,
       output_tokens: 50,
       cache_read_input_tokens: 30,
       cache_creation_input_tokens: 0,

--- a/packages/gateway/test/openai-cache-write-accounting.test.ts
+++ b/packages/gateway/test/openai-cache-write-accounting.test.ts
@@ -23,6 +23,7 @@ import { accumulateResponsesSSEStream } from "../src/stream/openai-responses";
 import {
   normalizeOpenAIUsage,
   disjointOpenAIInputTokens,
+  gatewayResponseToWorkerResult,
 } from "../src/llm-adapter";
 
 /** One SSE event per entry; blank-line delimited per the spec. */
@@ -250,5 +251,31 @@ describe("disjointOpenAIInputTokens", () => {
 
   test("treats missing raw input as zero", () => {
     expect(disjointOpenAIInputTokens(undefined, 10, 10)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// gatewayResponseToWorkerResult — SSE worker path must forward cache writes
+// ---------------------------------------------------------------------------
+
+describe("gatewayResponseToWorkerResult cache-write forwarding", () => {
+  test("maps cacheCreationInputTokens to cache_creation_input_tokens", () => {
+    const result = gatewayResponseToWorkerResult({
+      id: "w1",
+      model: "anthropic/claude-opus-4.8",
+      content: [{ type: "text", text: "ok" }],
+      stopReason: "end_turn",
+      usage: {
+        inputTokens: 50,
+        outputTokens: 5,
+        cacheReadInputTokens: 20,
+        cacheCreationInputTokens: 100,
+      },
+    });
+    // The SSE worker path dropped cache_creation_input_tokens, under-reporting
+    // worker cache-creation cost. It must be forwarded verbatim.
+    expect(result.usage?.cache_creation_input_tokens).toBe(100);
+    expect(result.usage?.cache_read_input_tokens).toBe(20);
+    expect(result.usage?.input_tokens).toBe(50);
   });
 });

--- a/packages/gateway/test/openai-cache-write-accounting.test.ts
+++ b/packages/gateway/test/openai-cache-write-accounting.test.ts
@@ -20,7 +20,10 @@ import {
 } from "../src/pipeline";
 import { accumulateOpenAISSEStream } from "../src/stream/openai";
 import { accumulateResponsesSSEStream } from "../src/stream/openai-responses";
-import { normalizeOpenAIUsage } from "../src/llm-adapter";
+import {
+  normalizeOpenAIUsage,
+  disjointOpenAIInputTokens,
+} from "../src/llm-adapter";
 
 /** One SSE event per entry; blank-line delimited per the spec. */
 function sse(lines: string[]): Response {
@@ -58,6 +61,9 @@ describe("non-stream Chat Completions cache-write accounting", () => {
     });
     expect(resp.usage?.cacheReadInputTokens).toBe(50);
     expect(resp.usage?.cacheCreationInputTokens).toBe(100);
+    // prompt_tokens (200) is inclusive of cache read (50) + write (100);
+    // disjoint input = 200 − 50 − 100 = 50.
+    expect(resp.usage?.inputTokens).toBe(50);
   });
 
   test("leaves cacheCreationInputTokens undefined when the field is absent", () => {
@@ -101,6 +107,8 @@ describe("non-stream Responses API cache-write accounting", () => {
     });
     expect(resp.usage?.cacheReadInputTokens).toBe(20);
     expect(resp.usage?.cacheCreationInputTokens).toBe(250);
+    // input_tokens (300) inclusive of read (20) + write (250) → 300−20−250 = 30.
+    expect(resp.usage?.inputTokens).toBe(30);
   });
 
   test("falls back to prompt_tokens_details for OpenAI-compatible providers", () => {
@@ -117,6 +125,8 @@ describe("non-stream Responses API cache-write accounting", () => {
     });
     expect(resp.usage?.cacheReadInputTokens).toBe(10);
     expect(resp.usage?.cacheCreationInputTokens).toBe(90);
+    // input_tokens (100) inclusive of read (10) + write (90) → 100−10−90 = 0.
+    expect(resp.usage?.inputTokens).toBe(0);
   });
 });
 
@@ -136,6 +146,8 @@ describe("stream Chat Completions cache-write accounting", () => {
     );
     expect(resp.usage?.cacheReadInputTokens).toBe(50);
     expect(resp.usage?.cacheCreationInputTokens).toBe(100);
+    // prompt_tokens (200) inclusive of read (50) + write (100) → 200−50−100 = 50.
+    expect(resp.usage?.inputTokens).toBe(50);
   });
 
   test("leaves cacheCreationInputTokens undefined when absent", async () => {
@@ -183,6 +195,8 @@ describe("stream Responses API cache-write accounting", () => {
     );
     expect(resp.usage?.cacheReadInputTokens).toBe(20);
     expect(resp.usage?.cacheCreationInputTokens).toBe(250);
+    // input_tokens (300) inclusive of read (20) + write (250) → 300−20−250 = 30.
+    expect(resp.usage?.inputTokens).toBe(30);
   });
 });
 
@@ -199,6 +213,8 @@ describe("normalizeOpenAIUsage cache-write accounting", () => {
     });
     expect(result.cache_read_input_tokens).toBe(50);
     expect(result.cache_creation_input_tokens).toBe(100);
+    // prompt_tokens (200) inclusive of read (50) + write (100) → disjoint 50.
+    expect(result.input_tokens).toBe(50);
   });
 
   test("defaults cache_creation_input_tokens to 0 when absent (OpenAI proper)", () => {
@@ -208,5 +224,31 @@ describe("normalizeOpenAIUsage cache-write accounting", () => {
       prompt_tokens_details: { cached_tokens: 0 },
     });
     expect(result.cache_creation_input_tokens).toBe(0);
+    // no cache tokens → input_tokens unchanged.
+    expect(result.input_tokens).toBe(10);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// disjointOpenAIInputTokens — the shared inclusive→disjoint converter
+// ---------------------------------------------------------------------------
+
+describe("disjointOpenAIInputTokens", () => {
+  test("subtracts cache read + write from the raw input", () => {
+    expect(disjointOpenAIInputTokens(200, 50, 100)).toBe(50);
+  });
+
+  test("treats missing cache fields as zero", () => {
+    expect(disjointOpenAIInputTokens(200, undefined, undefined)).toBe(200);
+    expect(disjointOpenAIInputTokens(200, 30, undefined)).toBe(170);
+  });
+
+  test("clamps at 0 when cache tokens exceed the reported input", () => {
+    // Defensive: a provider must never drive input negative.
+    expect(disjointOpenAIInputTokens(100, 80, 90)).toBe(0);
+  });
+
+  test("treats missing raw input as zero", () => {
+    expect(disjointOpenAIInputTokens(undefined, 10, 10)).toBe(0);
   });
 });

--- a/packages/gateway/test/openai-cache-write-accounting.test.ts
+++ b/packages/gateway/test/openai-cache-write-accounting.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Tests for OpenRouter/OpenAI-protocol cache-WRITE accounting.
+ *
+ * Companion to `openai-caching.test.ts` (which emits `cache_control` on the
+ * request). Once OpenRouter starts writing to the cache it reports the write in
+ * `usage.prompt_tokens_details.cache_write_tokens` (Chat Completions) or
+ * `usage.input_tokens_details.cache_write_tokens` (Responses API). These tests
+ * pin that every OpenAI-protocol parse path maps that field to
+ * `cacheCreationInputTokens` so the cost tracker, cache analytics and warmer
+ * economics see real write tokens instead of a hard-coded 0.
+ *
+ * Regression guard for the second half of the "OpenRouter caching" fix: the
+ * request now marks content cacheable (PR #1321); this makes the reported
+ * writes actually count.
+ */
+import { describe, test, expect } from "vitest";
+import {
+  accumulateOpenAINonStreamJSON,
+  accumulateResponsesNonStreamJSON,
+} from "../src/pipeline";
+import { accumulateOpenAISSEStream } from "../src/stream/openai";
+import { accumulateResponsesSSEStream } from "../src/stream/openai-responses";
+import { normalizeOpenAIUsage } from "../src/llm-adapter";
+
+/** One SSE event per entry; blank-line delimited per the spec. */
+function sse(lines: string[]): Response {
+  return new Response(`${lines.join("\n\n")}\n\n`, {
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+function responsesSSE(
+  events: Array<{ event: string; data: Record<string, unknown> }>,
+): Response {
+  const chunks = events.map(
+    (e) => `event: ${e.event}\ndata: ${JSON.stringify(e.data)}\n\n`,
+  );
+  return new Response(chunks.join(""), {
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Non-streaming Chat Completions (accumulateOpenAINonStreamJSON)
+// ---------------------------------------------------------------------------
+
+describe("non-stream Chat Completions cache-write accounting", () => {
+  test("maps prompt_tokens_details.cache_write_tokens to cacheCreationInputTokens", () => {
+    const resp = accumulateOpenAINonStreamJSON({
+      id: "c1",
+      model: "anthropic/claude-opus-4.8",
+      choices: [{ message: { content: "hi" }, finish_reason: "stop" }],
+      usage: {
+        prompt_tokens: 200,
+        completion_tokens: 5,
+        prompt_tokens_details: { cached_tokens: 50, cache_write_tokens: 100 },
+      },
+    });
+    expect(resp.usage?.cacheReadInputTokens).toBe(50);
+    expect(resp.usage?.cacheCreationInputTokens).toBe(100);
+  });
+
+  test("leaves cacheCreationInputTokens undefined when the field is absent", () => {
+    const resp = accumulateOpenAINonStreamJSON({
+      id: "c1",
+      model: "gpt-4o",
+      choices: [{ message: { content: "hi" }, finish_reason: "stop" }],
+      usage: {
+        prompt_tokens: 10,
+        completion_tokens: 2,
+        prompt_tokens_details: { cached_tokens: 0 },
+      },
+    });
+    expect(resp.usage?.cacheReadInputTokens).toBe(0);
+    // undefined, NOT 0 — a real write of 0 and "no data" must stay distinct.
+    expect(resp.usage?.cacheCreationInputTokens).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Non-streaming Responses API (accumulateResponsesNonStreamJSON)
+// ---------------------------------------------------------------------------
+
+describe("non-stream Responses API cache-write accounting", () => {
+  test("reads cache_write_tokens from input_tokens_details", () => {
+    const resp = accumulateResponsesNonStreamJSON({
+      id: "resp_1",
+      model: "anthropic/claude-opus-4.8",
+      status: "completed",
+      output: [
+        {
+          type: "message",
+          content: [{ type: "output_text", text: "hi" }],
+        },
+      ],
+      usage: {
+        input_tokens: 300,
+        output_tokens: 8,
+        input_tokens_details: { cached_tokens: 20, cache_write_tokens: 250 },
+      },
+    });
+    expect(resp.usage?.cacheReadInputTokens).toBe(20);
+    expect(resp.usage?.cacheCreationInputTokens).toBe(250);
+  });
+
+  test("falls back to prompt_tokens_details for OpenAI-compatible providers", () => {
+    const resp = accumulateResponsesNonStreamJSON({
+      id: "resp_2",
+      model: "some/provider",
+      status: "completed",
+      output: [],
+      usage: {
+        input_tokens: 100,
+        output_tokens: 4,
+        prompt_tokens_details: { cached_tokens: 10, cache_write_tokens: 90 },
+      },
+    });
+    expect(resp.usage?.cacheReadInputTokens).toBe(10);
+    expect(resp.usage?.cacheCreationInputTokens).toBe(90);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Streaming Chat Completions (accumulateOpenAISSEStream)
+// ---------------------------------------------------------------------------
+
+describe("stream Chat Completions cache-write accounting", () => {
+  test("reads cache_write_tokens from the final usage chunk", async () => {
+    const resp = await accumulateOpenAISSEStream(
+      sse([
+        'data: {"id":"c1","model":"anthropic/claude-opus-4.8","choices":[{"delta":{"content":"ok"}}]}',
+        'data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":200,"completion_tokens":5,"prompt_tokens_details":{"cached_tokens":50,"cache_write_tokens":100}}}',
+        "data: [DONE]",
+        "",
+      ]),
+    );
+    expect(resp.usage?.cacheReadInputTokens).toBe(50);
+    expect(resp.usage?.cacheCreationInputTokens).toBe(100);
+  });
+
+  test("leaves cacheCreationInputTokens undefined when absent", async () => {
+    const resp = await accumulateOpenAISSEStream(
+      sse([
+        'data: {"id":"c1","choices":[{"delta":{"content":"ok"}}]}',
+        'data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":7,"completion_tokens":3}}',
+        "data: [DONE]",
+        "",
+      ]),
+    );
+    expect(resp.usage?.cacheCreationInputTokens).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Streaming Responses API (accumulateResponsesSSEStream)
+// ---------------------------------------------------------------------------
+
+describe("stream Responses API cache-write accounting", () => {
+  test("reads cache_write_tokens from input_tokens_details on response.completed", async () => {
+    const resp = await accumulateResponsesSSEStream(
+      responsesSSE([
+        {
+          event: "response.completed",
+          data: {
+            type: "response.completed",
+            response: {
+              id: "resp_1",
+              model: "anthropic/claude-opus-4.8",
+              status: "completed",
+              output: [],
+              usage: {
+                input_tokens: 300,
+                output_tokens: 8,
+                input_tokens_details: {
+                  cached_tokens: 20,
+                  cache_write_tokens: 250,
+                },
+              },
+            },
+          },
+        },
+      ]),
+    );
+    expect(resp.usage?.cacheReadInputTokens).toBe(20);
+    expect(resp.usage?.cacheCreationInputTokens).toBe(250);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Worker cost normalization (normalizeOpenAIUsage)
+// ---------------------------------------------------------------------------
+
+describe("normalizeOpenAIUsage cache-write accounting", () => {
+  test("maps cache_write_tokens to cache_creation_input_tokens", () => {
+    const result = normalizeOpenAIUsage({
+      prompt_tokens: 200,
+      completion_tokens: 5,
+      prompt_tokens_details: { cached_tokens: 50, cache_write_tokens: 100 },
+    });
+    expect(result.cache_read_input_tokens).toBe(50);
+    expect(result.cache_creation_input_tokens).toBe(100);
+  });
+
+  test("defaults cache_creation_input_tokens to 0 when absent (OpenAI proper)", () => {
+    const result = normalizeOpenAIUsage({
+      prompt_tokens: 10,
+      completion_tokens: 2,
+      prompt_tokens_details: { cached_tokens: 0 },
+    });
+    expect(result.cache_creation_input_tokens).toBe(0);
+  });
+});

--- a/packages/gateway/test/openai-responses-stream.test.ts
+++ b/packages/gateway/test/openai-responses-stream.test.ts
@@ -470,7 +470,9 @@ describe("accumulateResponsesSSEStream", () => {
     ]);
 
     const result = await accumulateResponsesSSEStream(response);
-    expect(result.usage?.inputTokens).toBe(100);
+    // input_tokens (100) is inclusive of cached_tokens (80); the gateway's
+    // disjoint convention subtracts it → 100 − 80 = 20.
+    expect(result.usage?.inputTokens).toBe(20);
     expect(result.usage?.outputTokens).toBe(10);
     expect(result.usage?.cacheReadInputTokens).toBe(80);
   });


### PR DESCRIPTION
## Context

Follow-up to #1321. That PR made the gateway mark content cacheable on the OpenAI/OpenRouter request path. This PR handles the accounting side of the cache activity OpenRouter now reports back.

## Problem 1 — writes were never counted

Every OpenAI-protocol response parse path read `usage.prompt_tokens_details.cached_tokens` (cache **reads**) but ignored cache **writes**. `cacheCreationInputTokens` was left unset — or hard-coded to `0` in `normalizeOpenAIUsage`. So once writes started happening (thanks to #1321), the Costs UI write column, cache analytics, and cache-warmer economics all under-reported them.

Per the [OpenRouter usage-accounting docs](https://openrouter.ai/docs/use-cases/usage-accounting), writes are reported in `prompt_tokens_details.cache_write_tokens` (Chat Completions) and `input_tokens_details.cache_write_tokens` (Responses API).

## Problem 2 — inclusive vs disjoint token accounting (double-count)

Surfaced by adversarial review. OpenAI-protocol usage reports cache reads/writes as a **subset of** `prompt_tokens` (inclusive) — confirmed by [OpenAI's prompt-caching docs](https://platform.openai.com/docs/guides/prompt-caching): `"prompt_tokens": 2006` **includes** `"cached_tokens": 1920`. But the gateway's cost model (`cost-tracker.ts`) and analytics (`cache-analytics.ts`, `sentry.ts`) treat input / cache-read / cache-write as **disjoint** buckets (the Anthropic-native convention, where `input_tokens` already excludes cache tokens).

Feeding the raw inclusive `prompt_tokens` straight through double-billed cached+written tokens (once at input rate, again at cache rate) and inflated the cache-hit-rate denominator. Activating the write mapping (Problem 1) would newly double-count writes; the read side was already affected before this PR.

## Fix

- Map `cache_write_tokens` → `cacheCreationInputTokens` at every inbound parse site: non-stream Chat Completions, non-stream Responses API (also corrected to read cache details from `input_tokens_details` with `prompt_tokens_details` fallback), streaming Chat Completions, streaming Responses API, and worker `normalizeOpenAIUsage`.
- Add `disjointOpenAIInputTokens(rawInput, cached, write)` (clamped at 0) and apply it at every site so `inputTokens` becomes disjoint. Fixes the newly-activated write double-count **and** the pre-existing read double-count on the OpenAI/OpenRouter path.

### Semantics
- Parse paths leave `cacheCreationInputTokens` **undefined** when absent (genuine 0 stays distinct from "not reported"); `normalizeOpenAIUsage` keeps its `0` default for the `AnthropicUsage` shape.
- Strictly inbound accounting — no change to the client-facing response shape.

## Tests

New `openai-cache-write-accounting.test.ts` (17 tests): all four parse paths, the `input_tokens_details`/`prompt_tokens_details` fallback, `normalizeOpenAIUsage`, the disjoint-input conversion + clamp, and the undefined-when-absent invariant. Two existing tests that encoded the old inclusive (double-counting) expectation were corrected with explanatory comments.

- `typecheck`: clean · `lint`: 0 errors · `format:check`: clean
- Full `@loreai/gateway` suite: **2892 passed, 168 skipped, 0 failing**