### PR TITLE
fix(sync): recover sync_conflicts.local_content + surface real errors

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -3121,6 +3121,19 @@ function recoverMissingObjects(database: Database) {
   if (!cols.some((c) => c.name === "call_type")) {
     database.exec("ALTER TABLE distillations ADD COLUMN call_type TEXT;");
   }
+  // sync_conflicts.local_content was added to the CREATE TABLE definition AFTER
+  // the first sync-engine release (#782) shipped the table without it. Because
+  // both the migration and the CREATE above use IF NOT EXISTS, an early sync
+  // adopter's table keeps the old 5-column shape forever — and recordConflict()'s
+  // INSERT ... local_content then throws "no such column" on EVERY sync cycle,
+  // escaping to the scheduler catch-all. There was no ALTER to add it, so recover
+  // it here (same self-heal pattern as call_type above).
+  const scCols = database
+    .query("PRAGMA table_info(sync_conflicts)")
+    .all() as Array<{ name: string }>;
+  if (!scCols.some((c) => c.name === "local_content")) {
+    database.exec("ALTER TABLE sync_conflicts ADD COLUMN local_content TEXT;");
+  }
   // Version 35: worker source attribution. The first ALTER may have applied
   // while a sibling ALTER in the same migration was skipped; recover each
   // column independently. Also recover the composite indexes which are

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -1915,6 +1915,34 @@ describe("db", () => {
       ).toBe(true);
     });
 
+    test("recoverMissingObjects re-adds sync_conflicts.local_content when missing", () => {
+      // Regression: the first sync-engine release (#782) shipped sync_conflicts
+      // WITHOUT local_content, then the column was added only to the CREATE TABLE
+      // IF NOT EXISTS definition (no ALTER). An early sync adopter's table keeps
+      // the old 5-column shape forever, so recordConflict()'s INSERT throws
+      // "no such column: local_content" on every sync cycle. Reproduce the old
+      // shape, reopen, and confirm recoverMissingObjects self-heals the column.
+      const d = db();
+      d.exec("ALTER TABLE sync_conflicts DROP COLUMN local_content");
+      expect(
+        (
+          d.query("PRAGMA table_info(sync_conflicts)").all() as Array<{
+            name: string;
+          }>
+        ).some((c) => c.name === "local_content"),
+      ).toBe(false);
+
+      close();
+      const fresh = db();
+      expect(
+        (
+          fresh.query("PRAGMA table_info(sync_conflicts)").all() as Array<{
+            name: string;
+          }>
+        ).some((c) => c.name === "local_content"),
+      ).toBe(true);
+    });
+
     test("recoverMissingObjects re-adds knowledge_session_injections.verdict without throwing on the index", () => {
       // Regression: the (logical_id, verdict) index must be created AFTER the
       // verdict column is ensured. Dropping the column (SQLite also drops the

--- a/packages/gateway/src/sync.ts
+++ b/packages/gateway/src/sync.ts
@@ -1249,6 +1249,24 @@ export async function publishIdentityPub(
   }
 }
 
+/**
+ * Tag an unexpected throw from a sync phase (push/pull) with which phase failed,
+ * preserving the original error (and its stack) as `cause` so the scheduler's
+ * captureException still gets the real trace. pushOnce/pullOnce classify all
+ * EXPECTED errors internally (quota/poison/transient); a throw reaching here is a
+ * genuine bug (e.g. a local schema mismatch), and knowing the phase narrows it fast.
+ */
+async function withPhase<T>(
+  phase: "push" | "pull",
+  fn: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await fn();
+  } catch (e) {
+    throw new Error(`${phase} phase: ${(e as Error).message}`, { cause: e });
+  }
+}
+
 export async function syncOnce(
   onProgress?: SyncProgressFn,
 ): Promise<SyncResult> {
@@ -1263,8 +1281,8 @@ export async function syncOnce(
   // or the very first pull on a fresh Pro device). Snapshot before/after so we can
   // arm/disarm the Pro capture + seed the newly-synced tier (#826/D).
   const tierBefore = syncData.currentSyncTier();
-  const push = await pushOnce(client, onProgress);
-  const pull = await pullOnce(client, onProgress);
+  const push = await withPhase("push", () => pushOnce(client, onProgress));
+  const pull = await withPhase("pull", () => pullOnce(client, onProgress));
   // #1246: after content is applied, merge any projects that a peer's pulled identity
   // row revealed to share a git_remote (min-id winner, deterministic → no ping-pong).
   // Post-content so the re-key finds the applied rows; the re-keyed content re-pushes
@@ -1322,9 +1340,12 @@ export function startSyncScheduler(
     inflight = syncOnce()
       // A quota pause is already reported once per table by pushEntry (deduped) — no
       // per-cycle scheduler summary, which would re-spam the same state every interval.
-      .catch((e) =>
-        log.error(`sync: background cycle failed: ${(e as Error).message}`),
-      )
+      // Pass the Error OBJECT (not a pre-formatted string) so log.error routes it through
+      // findError -> captureException: a pre-formatted `${e.message}` string drops the
+      // stack from the file AND never reaches Sentry, leaving an unexpected throw here
+      // (the "background cycle failed" case) undiagnosable — exactly what happened with
+      // the sync_conflicts.local_content column mismatch.
+      .catch((e) => log.error("sync: background cycle failed", e as Error))
       .finally(() => {
         inflight = null;
       });

--- a/packages/gateway/test/sync.test.ts
+++ b/packages/gateway/test/sync.test.ts
@@ -436,6 +436,7 @@ import {
   pullOnce,
   type SyncProgress,
   syncOnce,
+  startSyncScheduler,
 } from "../src/sync";
 
 const now = () => Date.now();
@@ -1876,6 +1877,62 @@ describe("syncOnce", () => {
     expect(new Set(prog.map((r) => r.table_name))).toEqual(new Set(reported));
     // pulled_through is the device's keyset cursor as an ISO string, never null.
     expect(prog.every((r) => typeof r.pulled_through === "string")).toBe(true);
+  });
+
+  test("an unexpected throw is tagged with its phase and preserves the original as cause", async () => {
+    // Regression: pushOnce/pullOnce classify EXPECTED errors internally (quota/poison/
+    // transient) and never throw; a throw reaching syncOnce is a genuine bug (e.g. the
+    // sync_conflicts.local_content schema mismatch that flooded logs). withPhase must tag
+    // WHICH phase threw and keep the original error (and its stack) as `cause` so the
+    // scheduler's log.error -> captureException reports the real trace.
+    syncData.enableSync("basic");
+    insertKnowledge("k1", "hello");
+    const raw = new Error("no such column: local_content");
+    const spy = vi.spyOn(syncData, "readOutbox").mockImplementation(() => {
+      throw raw;
+    });
+    try {
+      await expect(syncOnce()).rejects.toMatchObject({
+        message: expect.stringContaining("push phase:"),
+        cause: raw, // original error preserved for the stack trace
+      });
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("the background scheduler logs the Error OBJECT (not a string) so Sentry gets a stack", async () => {
+    // Regression: the scheduler previously logged `${e.message}`, a plain string, so
+    // log.error's findError -> captureException never fired (no Sentry stack). It must
+    // pass the Error object itself.
+    syncData.enableSync("basic");
+    insertKnowledge("k1", "hello");
+    const raw = new Error("boom");
+    const spy = vi.spyOn(syncData, "readOutbox").mockImplementation(() => {
+      throw raw;
+    });
+    const errSpy = vi.spyOn(log, "error").mockImplementation(() => {});
+    vi.useFakeTimers();
+    try {
+      const stop = startSyncScheduler(60_000);
+      // The scheduler runs its first cycle ~5s after start; drive it deterministically.
+      await vi.advanceTimersByTimeAsync(5_000);
+      await stop();
+      // Called with a message string AND the real Error object (arg 2), the shape
+      // log.error needs to route through findError -> captureException.
+      const call = errSpy.mock.calls.find(
+        (c) =>
+          typeof c[0] === "string" && c[0].includes("background cycle failed"),
+      );
+      expect(call).toBeTruthy();
+      const logged = (call as unknown[])[1];
+      expect(logged).toBeInstanceOf(Error);
+      expect((logged as Error).cause).toBe(raw);
+    } finally {
+      vi.useRealTimers();
+      spy.mockRestore();
+      errSpy.mockRestore();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
Fixes a flood of `sync: background cycle failed` errors on early sync-adopter DBs, and makes such failures diagnosable going forward.

## Root cause
The first sync-engine release (#782) created `sync_conflicts` **without** a `local_content` column. The column was later added only to the `CREATE TABLE IF NOT EXISTS` definition — with no `ALTER` migration. Because `IF NOT EXISTS` is a no-op on an existing table, any DB that created `sync_conflicts` before the column existed keeps the old 5-column shape forever. `recordConflict()` then `INSERT`s into `local_content`, which throws `no such column: local_content` on **every** sync cycle. The throw escapes `pushOnce`/`pullOnce` up to the scheduler's catch-all → repeating `background cycle failed` log lines (68 observed on my DB, schema v72).

The error was also undiagnosable: the scheduler logged a pre-formatted `${e.message}` string, so `log.error`'s `findError → captureException` path never fired (no Sentry stack) and the file log dropped the trace and phase.

## Changes
- **`db.ts`**: add a `local_content` self-heal step to `recoverMissingObjects` (`PRAGMA table_info` → `ALTER TABLE ... ADD COLUMN` if missing) — same pattern as the existing `call_type`/`verdict` recoveries. Affected DBs repair on next boot.
- **`sync.ts`**: pass the real `Error` object (not a formatted string) to `log.error` so `captureException` reports a stack to Sentry; wrap `pushOnce`/`pullOnce` in a `withPhase("push"|"pull", …)` helper that tags which phase threw, preserving the original error as `cause`.
- **`db.test.ts`**: regression test — drop `local_content`, reopen, assert `recoverMissingObjects` restores it. Verified discriminating (fails when the recovery step is removed).

## Impact
Affects all early sync adopters (schema created before `local_content` was added). The live-DB ALTER I applied locally stopped the flood immediately; this change makes the repair automatic for everyone else.

## Verification
- Core + gateway typecheck: clean.
- Sync suites (db, sync-data, sync, sync-cmd): 296/296 pass.
- Lint: 0 errors. Format: clean.