### PR TITLE
fix(gateway): cache accounting on the codex-worker Responses path

### DIFF
--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -1073,13 +1073,26 @@ export function parseOpenAIResponse(data: OpenAIChatResponse): {
  * the `openai-codex` worker path). Text lives in `output[].content[].text` for
  * `output_text` parts; usage uses `input_tokens`/`output_tokens`.
  */
-function parseResponsesWorkerResponse(data: {
+export function parseResponsesWorkerResponse(data: {
   output?: Array<{
     type?: string;
     content?: Array<{ type?: string; text?: string }>;
   }>;
   output_text?: string;
-  usage?: { input_tokens?: number; output_tokens?: number };
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    // Responses API reports cache details under `input_tokens_details`;
+    // OpenAI-compatible providers may use `prompt_tokens_details` instead.
+    input_tokens_details?: {
+      cached_tokens?: number;
+      cache_write_tokens?: number;
+    };
+    prompt_tokens_details?: {
+      cached_tokens?: number;
+      cache_write_tokens?: number;
+    };
+  };
   model?: string;
 }): {
   text: string | null;
@@ -1103,12 +1116,25 @@ function parseResponsesWorkerResponse(data: {
     if (parts.length > 0) text = parts.join("");
   }
 
-  const usage: AnthropicUsage | null = data.usage
-    ? {
-        input_tokens: data.usage.input_tokens ?? 0,
-        output_tokens: data.usage.output_tokens ?? 0,
-      }
-    : null;
+  let usage: AnthropicUsage | null = null;
+  if (data.usage) {
+    const details =
+      data.usage.input_tokens_details ?? data.usage.prompt_tokens_details;
+    const cachedTokens = details?.cached_tokens;
+    const cacheWriteTokens = details?.cache_write_tokens;
+    usage = {
+      // input_tokens is inclusive of cache reads/writes; convert to the
+      // gateway's disjoint convention so cache tokens aren't double-counted.
+      input_tokens: disjointOpenAIInputTokens(
+        data.usage.input_tokens,
+        cachedTokens,
+        cacheWriteTokens,
+      ),
+      output_tokens: data.usage.output_tokens ?? 0,
+      cache_read_input_tokens: cachedTokens ?? 0,
+      cache_creation_input_tokens: cacheWriteTokens ?? 0,
+    };
+  }
 
   return { text, usage, model: data.model ?? null };
 }

--- a/packages/gateway/test/codex-worker-cache-accounting.test.ts
+++ b/packages/gateway/test/codex-worker-cache-accounting.test.ts
@@ -1,0 +1,60 @@
+// Codex-worker Responses-path cache accounting.
+//
+// `parseResponsesWorkerResponse` parses the OpenAI Responses body returned to a
+// worker call (openai-codex background work). Before this fix it read only
+// input_tokens/output_tokens verbatim — it ignored cache reads/writes entirely
+// and passed the inclusive `input_tokens` straight through, so worker cache
+// cost was under-reported and (once cache tokens are present) input was double-
+// counted. This suite locks in: cache read + write mapping, and the disjoint
+// input conversion (matching the streaming/non-streaming accumulators).
+
+import { describe, test, expect } from "vitest";
+import { parseResponsesWorkerResponse } from "../src/llm-adapter";
+
+describe("parseResponsesWorkerResponse cache accounting", () => {
+  test("maps cache read + write from input_tokens_details and disjoins input", () => {
+    const { usage } = parseResponsesWorkerResponse({
+      output_text: "ok",
+      model: "anthropic/claude-opus-4.8",
+      usage: {
+        input_tokens: 300,
+        output_tokens: 8,
+        input_tokens_details: { cached_tokens: 20, cache_write_tokens: 250 },
+      },
+    });
+    expect(usage?.cache_read_input_tokens).toBe(20);
+    expect(usage?.cache_creation_input_tokens).toBe(250);
+    // input_tokens (300) inclusive of read (20) + write (250) → 300−20−250 = 30.
+    expect(usage?.input_tokens).toBe(30);
+  });
+
+  test("falls back to prompt_tokens_details for OpenAI-compatible providers", () => {
+    const { usage } = parseResponsesWorkerResponse({
+      output_text: "ok",
+      usage: {
+        input_tokens: 100,
+        output_tokens: 4,
+        prompt_tokens_details: { cached_tokens: 10, cache_write_tokens: 90 },
+      },
+    });
+    expect(usage?.cache_read_input_tokens).toBe(10);
+    expect(usage?.cache_creation_input_tokens).toBe(90);
+    // 100 − 10 − 90 = 0.
+    expect(usage?.input_tokens).toBe(0);
+  });
+
+  test("defaults cache buckets to 0 and leaves input unchanged when absent", () => {
+    const { usage } = parseResponsesWorkerResponse({
+      output_text: "ok",
+      usage: { input_tokens: 42, output_tokens: 3 },
+    });
+    expect(usage?.cache_read_input_tokens).toBe(0);
+    expect(usage?.cache_creation_input_tokens).toBe(0);
+    expect(usage?.input_tokens).toBe(42);
+  });
+
+  test("returns null usage when the response omits usage", () => {
+    const { usage } = parseResponsesWorkerResponse({ output_text: "ok" });
+    expect(usage).toBeNull();
+  });
+});


### PR DESCRIPTION
## Context

Follow-up NIT surfaced by the adversarial review of #1322. That PR fixed cache-write mapping + disjoint token accounting on all the *conversation* OpenAI-protocol parse paths, but the review noted one remaining site that was out of scope: the codex-worker Responses parser.

## Problem

`parseResponsesWorkerResponse` (parses the OpenAI Responses body returned to a **worker** call — openai-codex background work) read only `input_tokens`/`output_tokens`:

- It ignored cache reads/writes entirely — `cache_read_input_tokens` and `cache_creation_input_tokens` were never populated, so worker cache cost was under-reported.
- It passed the inclusive `input_tokens` straight through, so once cache tokens are present the input is double-counted — inconsistent with the disjoint convention established for the streaming/non-streaming accumulators in #1322.

## Fix

- Read cache details from `input_tokens_details` (fallback `prompt_tokens_details` for OpenAI-compatible providers).
- Map `cached_tokens` → `cache_read_input_tokens`, `cache_write_tokens` → `cache_creation_input_tokens`.
- Convert input to the gateway's disjoint convention via `disjointOpenAIInputTokens` (introduced in #1322).
- Defaults cache buckets to `0` (matching `normalizeOpenAIUsage`'s `AnthropicUsage`-shape convention, since this feeds worker cost tracking).

Exported the helper and added `codex-worker-cache-accounting.test.ts` (4 tests: read+write mapping + disjoint input, the `input_tokens_details`/`prompt_tokens_details` fallback, the zero-default when absent, and null-usage passthrough). Mutation-verified non-vacuous: reverting to the old verbatim mapping fails 3 of the 4 tests.

- `typecheck`: clean · `format:check`: clean · llm-adapter + worker + cache-write suites: 102 passing