### PR TITLE
fix(gateway): stabilize OpenAI content shape to stop per-turn cache busts

### DIFF
--- a/packages/gateway/src/translate/openai.ts
+++ b/packages/gateway/src/translate/openai.ts
@@ -734,9 +734,22 @@ function buildOpenAIMessages(
 
       if (contentParts.length > 0) {
         // Use array form when non-text (opaque) parts are present — OpenAI
-        // requires array content for multimodal messages. Use plain string
-        // when text-only for maximum compatibility and cache stability.
-        if (hasOpaque) {
+        // requires array content for multimodal messages.
+        //
+        // For text-only messages the shape choice must be STABLE across turns
+        // or it busts the prompt cache: the conversation breakpoint below is
+        // placed on the LAST message and promotes a plain string to a single
+        // text block to hang `cache_control` on it. That breakpoint moves
+        // forward every turn, so a message annotated on turn N (array form)
+        // would revert to string form on turn N+1 — flipping
+        //   "content":[{"type":"text","text":"…"}]  ⇄  "content":"…"
+        // for the SAME historical message and breaking the cached prefix at
+        // that point (observed as recurring `messages[N].content` divergences).
+        // When conversation caching is on, emit array form uniformly so only
+        // the single `cache_control` marker moves between turns (matching the
+        // always-array native Anthropic path); keep the plain-string form when
+        // caching is off, where it's simpler and there's no breakpoint to move.
+        if (hasOpaque || cache?.cacheConversation) {
           msgRecord.content = contentParts;
         } else {
           msgRecord.content = contentParts

--- a/packages/gateway/test/openai-caching.test.ts
+++ b/packages/gateway/test/openai-caching.test.ts
@@ -155,6 +155,53 @@ describe("buildOpenAIUpstreamRequest — conversation caching", () => {
     );
   });
 
+  test("all text messages use array content (no string↔array flip as the breakpoint moves)", () => {
+    // Regression (#cache-content-flip): the conversation breakpoint is placed on
+    // the LAST message and promotes a plain string to a [{type:text}] block to
+    // carry cache_control. Because that breakpoint moves forward every turn, a
+    // message emitted as an array on turn N would revert to a plain string on
+    // turn N+1 — flipping the SAME historical message's bytes and busting the
+    // cached prefix at that point. With caching on, EVERY text message must be
+    // array-form so only the single cache_control marker moves (matching the
+    // always-array native Anthropic path).
+    const req = makeRequest({
+      messages: [
+        { role: "user", content: [{ type: "text", text: "first" }] },
+        { role: "assistant", content: [{ type: "text", text: "reply" }] },
+        { role: "user", content: [{ type: "text", text: "second" }] },
+      ],
+    });
+    const msgs = messagesOf(getBody(req, { cacheConversation: true }));
+    const convo = msgs.filter((m) => m.role !== "system");
+    // Every conversation message is array-form — including the interior ones
+    // that do NOT carry the (moving) breakpoint.
+    expect(convo.every((m) => Array.isArray(m.content))).toBe(true);
+    // The interior messages carry NO cache_control (only the last does), so the
+    // only per-turn delta is the marker moving — the content bytes are stable.
+    const interior = convo.slice(0, -1);
+    expect(
+      interior.every(
+        (m) => !JSON.stringify(m.content).includes("cache_control"),
+      ),
+    ).toBe(true);
+  });
+
+  test("caching OFF keeps text-only content as a plain string (no breakpoint to move)", () => {
+    // The shape-stability promotion to array form only applies when conversation
+    // caching is on; without it, the simpler plain-string form is preserved
+    // (and there is no moving breakpoint, so no flip risk).
+    const req = makeRequest({
+      messages: [
+        { role: "user", content: [{ type: "text", text: "first" }] },
+        { role: "assistant", content: [{ type: "text", text: "reply" }] },
+        { role: "user", content: [{ type: "text", text: "second" }] },
+      ],
+    });
+    const msgs = messagesOf(getBody(req)); // no cache options
+    const convo = msgs.filter((m) => m.role !== "system");
+    expect(convo.every((m) => typeof m.content === "string")).toBe(true);
+  });
+
   test("tool-role tail: breakpoint moves to prior non-tool message, tool content stays a string", () => {
     // Agentic mid-turn shape: assistant tool_call, then a tool_result message.
     const req = makeRequest({


### PR DESCRIPTION
## Summary
Fixes a self-inflicted, every-turn prompt-cache bust on the OpenAI/OpenRouter upstream path caused by a message-content **shape flip** (array ⇄ string) for the same historical message across turns.

## Root cause
`buildOpenAIUpstreamRequest` serialized text-only messages as a plain string (`"content":"…"`). The conversation cache breakpoint (placed on the **last** message) promotes that string to a single `[{type:"text", cache_control}]` block so it can carry `cache_control`. Since the breakpoint moves forward every turn:

- **Turn N**: message P is the last message → emitted as **array** (with `cache_control`).
- **Turn N+1**: a new message is appended → message P is no longer last → emitted as a **plain string** again.

So the *same* historical message flips `"content":[{"type":"text",…}]` ⇄ `"content":"…"`, changing its bytes and breaking the cached prefix at that point. This showed up in the logs as recurring `messages[N].content` divergences with the position advancing each turn (356 → 359 → 362 …), and as avoidable cache-creation writes on OpenRouter.

## Fix
When conversation caching is on, emit **array content uniformly** for text-only messages, so only the single `cache_control` marker moves between turns — matching the always-array native Anthropic path, which is the reference for cache stability. The plain-string form is preserved when caching is off (no breakpoint to move, simpler wire shape).

## Tests
- `all text messages use array content (no string↔array flip as the breakpoint moves)` — asserts interior messages are array-form and carry no `cache_control`. Proven discriminating via revert.
- `caching OFF keeps text-only content as a plain string` — pins the no-cache passthrough shape.

## Scope note
The separate token double-count / cache-accounting issue on the OpenAI path (inflated spend + halved hit-rate gauge) was already fixed on `main` by #1322/#1326 (`disjointOpenAIInputTokens`); this PR is only the remaining content-shape stability fix.

## Verification
- Gateway typecheck: clean.
- openai-caching / openai-parse / openai-codex / recall-openai-stream / anthropic-client-openai-upstream-stream / pipeline-streaming: all pass.
- Format + lint clean.