### PR TITLE
refactor(gateway): clarify OpenAI conversation-breakpoint content branch

### DIFF
--- a/packages/gateway/src/translate/openai.ts
+++ b/packages/gateway/src/translate/openai.ts
@@ -797,13 +797,20 @@ function buildOpenAIMessages(
     const target = idx >= 0 ? result[idx] : undefined;
     if (target) {
       const cc = ephemeralCacheControl(cache.conversationTTL);
-      if (typeof target.content === "string") {
-        target.content = [
-          { type: "text", text: target.content, cache_control: cc },
-        ];
-      } else {
+      // Under `cacheConversation`, every text-only message is emitted in array
+      // form above (the shape-stability invariant that stops the string↔array
+      // flip from busting the cache), and `role:"tool"` string-content messages
+      // are excluded by `isAnnotatable`. So a targetable message's content is
+      // always a block array here — annotate its last block. The string case is
+      // handled defensively (single-block promotion) in case that invariant ever
+      // changes; today it is unreachable on this path.
+      if (Array.isArray(target.content)) {
         const parts = target.content as Array<Record<string, unknown>>;
         parts[parts.length - 1].cache_control = cc;
+      } else {
+        target.content = [
+          { type: "text", text: target.content as string, cache_control: cc },
+        ];
       }
     }
   }


### PR DESCRIPTION
## Summary
Follow-up NIT (F-1) from the #1327 adversarial review. No behavior change.

After #1327, when `cacheConversation` is on, every text-only message is emitted in array form (the shape-stability fix that stops the string↔array flip), and `role:"tool"` string-content messages are excluded by `isAnnotatable`. So the message this loop targets always has block-array content on this path — the `typeof target.content === "string"` branch in the conversation-breakpoint block was effectively dead.

## Change
- Reorder so the **array branch (the real path) is primary** and the string branch becomes a documented defensive fallback.
- Add a comment stating the invariant that makes the string branch unreachable today.

## Verification
- Gateway typecheck: clean.
- `openai-caching.test.ts`: 19/19 pass.
- Format + lint clean.