### PR TITLE
feat(core): persist raw input/output token buckets in session_state

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1843,6 +1843,17 @@ const MIGRATIONS: string[] = [
   `
    ALTER TABLE sync_state ADD COLUMN scope_id TEXT;
    `,
+  // Version 73: session_state.input_tokens / output_tokens — cumulative raw
+  // conversation token buckets. Previously only cache_read_tokens/cache_write_tokens
+  // were persisted; input/output were accumulated in memory but dropped on flush.
+  // Persisting them makes cost re-derivation possible after a future accounting
+  // bug (e.g. the OpenAI/OpenRouter inclusive→disjoint fix in #1322): given
+  // stored input + cache buckets, a corrected cost can be recomputed offline.
+  // LOCAL-ONLY telemetry — session_state is not synced.
+  `
+   ALTER TABLE session_state ADD COLUMN input_tokens INTEGER NOT NULL DEFAULT 0;
+   ALTER TABLE session_state ADD COLUMN output_tokens INTEGER NOT NULL DEFAULT 0;
+   `,
 ];
 
 // Index of the migration whose work is performed by a column-presence-aware JS
@@ -4252,6 +4263,8 @@ export type SessionCostSnapshot = {
   conversationCost: number;
   workerCost: number;
   conversationTurns: number;
+  inputTokens: number;
+  outputTokens: number;
   cacheReadTokens: number;
   cacheWriteTokens: number;
   warmupSavings: number;
@@ -4283,14 +4296,17 @@ export function saveSessionCosts(
     .query(
       `INSERT INTO session_state (session_id, force_min_layer, updated_at,
          conversation_cost, worker_cost, conversation_turns,
+         input_tokens, output_tokens,
          cache_read_tokens, cache_write_tokens,
          warmup_savings, warmup_cost, warmup_hits, ttl_savings, ttl_hits, batch_savings,
          avoided_compactions, avoided_compaction_cost, worker_breakdown)
-       VALUES (?, COALESCE((SELECT force_min_layer FROM session_state WHERE session_id = ?), 0), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       VALUES (?, COALESCE((SELECT force_min_layer FROM session_state WHERE session_id = ?), 0), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT(session_id) DO UPDATE SET
          conversation_cost = excluded.conversation_cost,
          worker_cost = excluded.worker_cost,
          conversation_turns = excluded.conversation_turns,
+         input_tokens = excluded.input_tokens,
+         output_tokens = excluded.output_tokens,
          cache_read_tokens = excluded.cache_read_tokens,
          cache_write_tokens = excluded.cache_write_tokens,
          warmup_savings = excluded.warmup_savings,
@@ -4311,6 +4327,8 @@ export function saveSessionCosts(
       costs.conversationCost,
       costs.workerCost,
       costs.conversationTurns,
+      costs.inputTokens,
+      costs.outputTokens,
       costs.cacheReadTokens,
       costs.cacheWriteTokens,
       costs.warmupSavings,
@@ -4351,6 +4369,7 @@ export function loadSessionCosts(
   const row = db()
     .query(
       `SELECT conversation_cost, worker_cost, conversation_turns,
+              input_tokens, output_tokens,
               cache_read_tokens, cache_write_tokens,
               warmup_savings, warmup_cost, warmup_hits, ttl_savings, ttl_hits, batch_savings,
               avoided_compactions, avoided_compaction_cost, worker_breakdown
@@ -4360,6 +4379,8 @@ export function loadSessionCosts(
     conversation_cost: number;
     worker_cost: number;
     conversation_turns: number;
+    input_tokens: number;
+    output_tokens: number;
     cache_read_tokens: number;
     cache_write_tokens: number;
     warmup_savings: number;
@@ -4377,6 +4398,8 @@ export function loadSessionCosts(
     conversationCost: row.conversation_cost,
     workerCost: row.worker_cost,
     conversationTurns: row.conversation_turns,
+    inputTokens: row.input_tokens,
+    outputTokens: row.output_tokens,
     cacheReadTokens: row.cache_read_tokens,
     cacheWriteTokens: row.cache_write_tokens,
     warmupSavings: row.warmup_savings,
@@ -4399,6 +4422,7 @@ export function loadAllSessionCosts(): Map<string, SessionCostSnapshot> {
   const rows = db()
     .query(
       `SELECT session_id, conversation_cost, worker_cost, conversation_turns,
+              input_tokens, output_tokens,
               cache_read_tokens, cache_write_tokens,
               warmup_savings, warmup_cost, warmup_hits, ttl_savings, ttl_hits, batch_savings,
               avoided_compactions, avoided_compaction_cost, worker_breakdown
@@ -4410,6 +4434,8 @@ export function loadAllSessionCosts(): Map<string, SessionCostSnapshot> {
     conversation_cost: number;
     worker_cost: number;
     conversation_turns: number;
+    input_tokens: number;
+    output_tokens: number;
     cache_read_tokens: number;
     cache_write_tokens: number;
     warmup_savings: number;
@@ -4428,6 +4454,8 @@ export function loadAllSessionCosts(): Map<string, SessionCostSnapshot> {
       conversationCost: row.conversation_cost,
       workerCost: row.worker_cost,
       conversationTurns: row.conversation_turns,
+      inputTokens: row.input_tokens,
+      outputTokens: row.output_tokens,
       cacheReadTokens: row.cache_read_tokens,
       cacheWriteTokens: row.cache_write_tokens,
       warmupSavings: row.warmup_savings,

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -1167,8 +1167,8 @@ describe("db", () => {
       conversationCost: 2.0,
       workerCost: 0.5,
       conversationTurns: 15,
-      inputTokens: 0,
-      outputTokens: 0,
+      inputTokens: 987654,
+      outputTokens: 54321,
       cacheReadTokens: 100000,
       cacheWriteTokens: 10000,
       warmupSavings: 0.5,
@@ -1186,6 +1186,12 @@ describe("db", () => {
     expect(loaded?.warmupSavings).toBe(0.5);
     expect(loaded?.avoidedCompactions).toBe(3);
     expect(loaded?.avoidedCompactionCost).toBe(1.5);
+    // Exercise the ON CONFLICT DO UPDATE path for the token columns: the
+    // second (updating) save must overwrite, not silently drop, these buckets.
+    expect(loaded?.inputTokens).toBe(987654);
+    expect(loaded?.outputTokens).toBe(54321);
+    expect(loaded?.cacheReadTokens).toBe(100000);
+    expect(loaded?.cacheWriteTokens).toBe(10000);
   });
 
   test("saveSessionCosts preserves existing forceMinLayer", () => {

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -119,7 +119,7 @@ describe("db", () => {
     const row = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(row.version).toBe(72);
+    expect(row.version).toBe(73);
   });
 
   test("v55: confidence/last_reinforced_at moved to knowledge_meta, exposed via view", () => {
@@ -176,7 +176,7 @@ describe("db", () => {
     const ver = fresh.query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(ver.version).toBe(72);
+    expect(ver.version).toBe(73);
     // Register + JOIN view were rebuilt and are queryable (confidence exposed).
     expect(
       fresh
@@ -1027,6 +1027,8 @@ describe("db", () => {
       conversationCost: 1.23,
       workerCost: 0.45,
       conversationTurns: 10,
+      inputTokens: 120000,
+      outputTokens: 8000,
       cacheReadTokens: 50000,
       cacheWriteTokens: 5000,
       warmupSavings: 0.12,
@@ -1043,6 +1045,48 @@ describe("db", () => {
     expect(loaded).toEqual(snapshot);
   });
 
+  test("saveSessionCosts round-trips input/output token buckets", () => {
+    const sid = `test-costs-io-${crypto.randomUUID()}`;
+    saveSessionCosts(sid, {
+      conversationCost: 1.0,
+      workerCost: 0,
+      conversationTurns: 3,
+      inputTokens: 123456,
+      outputTokens: 7890,
+      cacheReadTokens: 1000,
+      cacheWriteTokens: 200,
+      warmupSavings: 0,
+      warmupCost: 0,
+      warmupHits: 0,
+      ttlSavings: 0,
+      ttlHits: 0,
+      batchSavings: 0,
+      avoidedCompactions: 0,
+      avoidedCompactionCost: 0,
+    });
+    // Survives both the single-session and bulk load paths.
+    expect(loadSessionCosts(sid)?.inputTokens).toBe(123456);
+    expect(loadSessionCosts(sid)?.outputTokens).toBe(7890);
+    const all = loadAllSessionCosts().get(sid);
+    expect(all?.inputTokens).toBe(123456);
+    expect(all?.outputTokens).toBe(7890);
+  });
+
+  test("input/output tokens default to 0 for rows written without them", () => {
+    // Simulate a legacy row: insert directly without the token columns, relying
+    // on the NOT NULL DEFAULT 0 from the migration.
+    const sid = `test-costs-legacy-io-${crypto.randomUUID()}`;
+    db()
+      .query(
+        `INSERT INTO session_state (session_id, force_min_layer, updated_at, conversation_turns)
+         VALUES (?, 0, ?, 1)`,
+      )
+      .run(sid, Date.now());
+    const loaded = loadSessionCosts(sid);
+    expect(loaded?.inputTokens).toBe(0);
+    expect(loaded?.outputTokens).toBe(0);
+  });
+
   test("saveSessionCosts round-trips the per-bucket worker breakdown", () => {
     const sid = `test-costs-breakdown-${crypto.randomUUID()}`;
     const workerBreakdown = {
@@ -1056,6 +1100,8 @@ describe("db", () => {
       conversationCost: 2.0,
       workerCost: 0.9,
       conversationTurns: 12,
+      inputTokens: 0,
+      outputTokens: 0,
       cacheReadTokens: 1000,
       cacheWriteTokens: 100,
       warmupSavings: 0,
@@ -1081,6 +1127,8 @@ describe("db", () => {
       conversationCost: 1.0,
       workerCost: 0.2,
       conversationTurns: 3,
+      inputTokens: 0,
+      outputTokens: 0,
       cacheReadTokens: 0,
       cacheWriteTokens: 0,
       warmupSavings: 0,
@@ -1102,6 +1150,8 @@ describe("db", () => {
       conversationCost: 1.0,
       workerCost: 0,
       conversationTurns: 5,
+      inputTokens: 0,
+      outputTokens: 0,
       cacheReadTokens: 0,
       cacheWriteTokens: 0,
       warmupSavings: 0,
@@ -1117,6 +1167,8 @@ describe("db", () => {
       conversationCost: 2.0,
       workerCost: 0.5,
       conversationTurns: 15,
+      inputTokens: 0,
+      outputTokens: 0,
       cacheReadTokens: 100000,
       cacheWriteTokens: 10000,
       warmupSavings: 0.5,
@@ -1143,6 +1195,8 @@ describe("db", () => {
       conversationCost: 1.0,
       workerCost: 0,
       conversationTurns: 5,
+      inputTokens: 0,
+      outputTokens: 0,
       cacheReadTokens: 0,
       cacheWriteTokens: 0,
       warmupSavings: 0,
@@ -1200,6 +1254,8 @@ describe("db", () => {
       conversationCost: 1.0,
       workerCost: 0,
       conversationTurns: 5,
+      inputTokens: 0,
+      outputTokens: 0,
       cacheReadTokens: 0,
       cacheWriteTokens: 0,
       warmupSavings: 0.1,
@@ -1640,6 +1696,8 @@ describe("db", () => {
       conversationCost: 0.05,
       workerCost: 0.01,
       conversationTurns: 5,
+      inputTokens: 0,
+      outputTokens: 0,
       cacheReadTokens: 1000,
       cacheWriteTokens: 2000,
       warmupSavings: 0.02,

--- a/packages/core/test/ltm-versioning.test.ts
+++ b/packages/core/test/ltm-versioning.test.ts
@@ -39,11 +39,11 @@ function ftsHits(token: string): number {
 }
 
 describe("A2 sub-PR 1: append-only knowledge scaffolding", () => {
-  test("schema version is 72", () => {
+  test("schema version is 73", () => {
     const v = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(v.version).toBe(72);
+    expect(v.version).toBe(73);
   });
 
   test("create() defaults logical_id = id, version 1, current, not deleted", () => {

--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -128,6 +128,8 @@ function persistSessionCosts(sessionID: string): void {
       conversationCost: costs.conversation.cost,
       workerCost: totalWorkerCost(costs),
       conversationTurns: costs.conversation.turns,
+      inputTokens: costs.conversation.inputTokens,
+      outputTokens: costs.conversation.outputTokens,
       cacheReadTokens: costs.conversation.cacheReadTokens,
       cacheWriteTokens: costs.conversation.cacheWriteTokens,
       warmupSavings: costs.counterfactual.warmupSavings,

--- a/packages/gateway/test/cost-tracker-historical.test.ts
+++ b/packages/gateway/test/cost-tracker-historical.test.ts
@@ -238,6 +238,8 @@ describe("computeHistoricalEstimates (session_rollup read path #981)", () => {
       conversationCost: 1.0,
       workerCost: 0.5, // includes the warmup cost bucket
       conversationTurns: 4,
+      inputTokens: 0,
+      outputTokens: 0,
       cacheReadTokens: 1000,
       cacheWriteTokens: 500,
       warmupSavings: 0.2,
@@ -266,6 +268,8 @@ describe("computeHistoricalEstimates (session_rollup read path #981)", () => {
       conversationCost: 1.0,
       workerCost: 0.9,
       conversationTurns: 5,
+      inputTokens: 0,
+      outputTokens: 0,
       cacheReadTokens: 0,
       cacheWriteTokens: 0,
       warmupSavings: 0,

--- a/packages/gateway/test/cost-tracker.test.ts
+++ b/packages/gateway/test/cost-tracker.test.ts
@@ -1,5 +1,9 @@
 import { describe, test, expect } from "vitest";
-import { computeCallCost } from "../src/cost-tracker";
+import {
+  computeCallCost,
+  recordConversationCost,
+  getSessionCosts,
+} from "../src/cost-tracker";
 
 // Use a fake model name to guarantee we hit getPricingSync defaults:
 //   input: 3 $/MTok, output: 15 $/MTok,
@@ -78,5 +82,29 @@ describe("computeCallCost", () => {
     expect(cost.cacheReadCost).toBe(0);
     expect(cost.cacheWriteCost).toBe(0);
     expect(cost.outputCost).toBe(0);
+  });
+});
+
+describe("recordConversationCost token accumulation", () => {
+  // The raw input/output token buckets accumulated here are what
+  // persistSessionCosts flushes to session_state (migration v73), enabling
+  // offline cost re-derivation after a future accounting bug.
+  test("accumulates input and output tokens across turns", () => {
+    const sid = `test-io-accum-${crypto.randomUUID()}`;
+    recordConversationCost(sid, MODEL, {
+      input_tokens: 100,
+      output_tokens: 20,
+      cache_read_input_tokens: 30,
+      cache_creation_input_tokens: 10,
+    });
+    recordConversationCost(sid, MODEL, {
+      input_tokens: 200,
+      output_tokens: 40,
+    });
+    const costs = getSessionCosts(sid);
+    expect(costs?.conversation.inputTokens).toBe(300);
+    expect(costs?.conversation.outputTokens).toBe(60);
+    expect(costs?.conversation.cacheReadTokens).toBe(30);
+    expect(costs?.conversation.cacheWriteTokens).toBe(10);
   });
 });

--- a/packages/gateway/test/ui-worker-breakdown.test.ts
+++ b/packages/gateway/test/ui-worker-breakdown.test.ts
@@ -75,6 +75,8 @@ describe("/ui/costs renders the worker breakdown end-to-end", () => {
       conversationCost: 1.0,
       workerCost: 0.75,
       conversationTurns: 5,
+      inputTokens: 0,
+      outputTokens: 0,
       cacheReadTokens: 0,
       cacheWriteTokens: 0,
       warmupSavings: 0,


### PR DESCRIPTION
## Motivation

While diagnosing the OpenAI/OpenRouter cost double-count (fixed in #1322 / #1326), we found pre-fix inflated cost is **unrecoverable**: cost is persisted as pre-computed dollar totals, and of the raw token buckets only `cache_read_tokens`/`cache_write_tokens` were stored. `input_tokens`/`output_tokens` were accumulated in memory (`recordConversationCost`) but **dropped on flush** — so there was nothing to recompute a corrected cost from.

This PR makes future accounting bugs **backfillable** by persisting the raw input/output token buckets going forward. (It does **not** correct historical rows — pre-v73 data never had the source counts. Forward-looking only.)

## Change

- **Migration v73**: `ALTER TABLE session_state ADD COLUMN input_tokens / output_tokens` (`INTEGER NOT NULL DEFAULT 0`). LOCAL-ONLY telemetry — `session_state` is not in `SYNCED_TABLES`, consistent with the sibling cache-token columns and `worker_breakdown`.
- Thread `inputTokens`/`outputTokens` through `SessionCostSnapshot`, `saveSessionCosts` (INSERT + ON CONFLICT SET), `loadSessionCosts`, `loadAllSessionCosts`.
- `persistSessionCosts` (idle.ts) passes the in-memory `costs.conversation.inputTokens`/`outputTokens` that `recordConversationCost` already accumulates.

With this, a future corrective backfill can compute `disjoint_input = stored_input − cache_read − cache_write` (and re-derive cost) at session granularity.

### Scope decision
Session-aggregate columns (mirroring the existing `cache_read_tokens`/`cache_write_tokens`), not a per-turn ledger — minimal, low-risk, no hot-path table write. Per-turn fidelity (exact per-turn model/TTL) was considered and deferred as unnecessary for the backfill use case.

## Tests

- DB round-trip for the new buckets (single + bulk load) and legacy-row default-0.
- `recordConversationCost` accumulates input/output across turns.
- Schema-version assertions bumped 72→73 (db.test.ts ×2, ltm-versioning.test.ts).

Verification: core suite 2868 passing · gateway suite 2925 passing · typecheck/lint/format clean.