### PR TITLE
fix(supabase): wrap auth.<fn>() in RLS policies to fix initplan re-evaluation

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -396,6 +396,9 @@
 <!-- lore:019f6077-a7e9-76e2-8fd5-c999d1f57d28 -->
 * **Always Mandates Read-Only Reviews for Correctness and Security**: The user consistently requests adversarial, read-only correctness and/or security reviews for PRs in the opencode-lore repository. The user mandates that the review should not modify any tracked files and often requires mutation testing to be done in a throwaway git worktree. The user also specifies the commands to run for testing, such as typechecking, running tests, and mutation tests, to ensure the correctness and security of the changes.
 
+<!-- lore:019f6155-8e35-71d9-acb9-738b31c2f1b3 -->
+* **Always prefers specific content formats and array handling**: The user consistently expresses preferences for handling content in specific formats, particularly when it comes to arrays and their structure. They emphasize the importance of preserving the integrity of arrays, especially in the context of OpenAI conversation breakpoints and content translation. The user tends to specify how to handle arrays, such as always annotating the last block of a block array, and ensuring that non-text sub-blocks survive the gateway round-trip losslessly. They also express a preference for using array forms when caching is on or when non-text parts are present, and for keeping text-only content as plain strings when caching is off.
+
 <!-- lore:019f6149-35b5-792b-9ab6-d84d3ba7706a -->
 * **Always prefers to keep dead code with explanatory comments**: The user consistently chooses to keep dead code in the codebase, but with explanatory comments. This is observed in multiple instances where the user considered deleting dead code but decided to keep it with comments instead. This behavior indicates that the user values code readability and maintainability, and wants to preserve the history and context of the code, even if it's no longer actively used.
 

--- a/supabase/migrations/0036_rls_initplan.sql
+++ b/supabase/migrations/0036_rls_initplan.sql
@@ -1,0 +1,150 @@
+-- 0036_rls_initplan.sql
+-- Performance: wrap `auth.<function>()` calls in RLS policies as
+-- `(select auth.<function>())` so Postgres evaluates them ONCE per query (as an
+-- InitPlan) instead of re-evaluating per row. Fixes the 30 `auth_rls_initplan`
+-- performance-advisor warnings.
+--
+-- These are BEHAVIOR-PRESERVING recreations: each policy is byte-identical to
+-- its current definition except that a bare `auth.uid()` / `auth.role()` is
+-- replaced by `(select auth.uid())` / `(select auth.role())`. The membership
+-- helpers (`is_member`, `scope_role`, `effective_tier`, `shares_scope`) are NOT
+-- wrapped — they take no per-row-varying argument and call `auth.uid()`
+-- internally, so the planner already treats them as stable within the query
+-- (the advisor does not flag them).
+--
+-- Reproduced from: 0027 (content per-verb split), 0025 (identity_pub/scope_keys),
+-- 0023 (org_members/scope_members), 0010 (account_escrow scope_all), 0007
+-- (user_table_usage), 0003 (plan_limits), 0001 (profiles).
+
+-- ===========================================================================
+-- 1. Simple content tables + distillations/temporal (from 0027): the flagged
+--    `auth.uid()` is the `author_id = auth.uid()` clause in INSERT/UPDATE.
+-- ===========================================================================
+do $$
+declare t text;
+begin
+  foreach t in array array[
+    'knowledge', 'entities', 'entity_aliases', 'entity_relations', 'knowledge_entity_refs',
+    'knowledge_meta', 'knowledge_meta_crdt', 'projects'
+  ]
+  loop
+    execute format('drop policy if exists %1$s_scope_insert on public.%1$s', t);
+    execute format(
+      'create policy %1$s_scope_insert on public.%1$s
+         for insert with check (
+           public.is_member(scope_id)
+           and author_id = (select auth.uid())
+           and public.scope_role(scope_id) in (''editor'', ''admin''))', t);
+    execute format('drop policy if exists %1$s_scope_update on public.%1$s', t);
+    execute format(
+      'create policy %1$s_scope_update on public.%1$s
+         for update
+         using (public.is_member(scope_id) and public.scope_role(scope_id) in (''editor'', ''admin''))
+         with check (
+           public.is_member(scope_id)
+           and author_id = (select auth.uid())
+           and public.scope_role(scope_id) in (''editor'', ''admin''))', t);
+  end loop;
+end $$;
+
+-- distillations (pro, versioned)
+drop policy if exists distillations_scope_insert on public.distillations;
+create policy distillations_scope_insert on public.distillations
+  for insert with check (
+    public.is_member(scope_id)
+    and author_id = (select auth.uid())
+    and public.scope_role(scope_id) in ('editor', 'admin')
+    and public.effective_tier(scope_id) = 'pro');
+drop policy if exists distillations_scope_update on public.distillations;
+create policy distillations_scope_update on public.distillations
+  for update
+  using (public.is_member(scope_id) and public.scope_role(scope_id) in ('editor', 'admin'))
+  with check (
+    public.is_member(scope_id)
+    and author_id = (select auth.uid())
+    and public.scope_role(scope_id) in ('editor', 'admin')
+    and public.effective_tier(scope_id) = 'pro');
+
+-- temporal_messages (pro, append-only — no update policy)
+drop policy if exists temporal_messages_scope_insert on public.temporal_messages;
+create policy temporal_messages_scope_insert on public.temporal_messages
+  for insert with check (
+    public.is_member(scope_id)
+    and author_id = (select auth.uid())
+    and public.scope_role(scope_id) in ('editor', 'admin')
+    and public.effective_tier(scope_id) = 'pro');
+
+-- ===========================================================================
+-- 2. account_escrow (from 0010 scope_all loop).
+-- ===========================================================================
+drop policy if exists account_escrow_scope_all on public.account_escrow;
+create policy account_escrow_scope_all on public.account_escrow
+  for all
+  using (scope_id = (select auth.uid()))
+  with check (scope_id = (select auth.uid()) and author_id = (select auth.uid()));
+
+-- ===========================================================================
+-- 3. identity_pub owner + scope_keys (from 0025).
+-- ===========================================================================
+drop policy if exists identity_pub_owner on public.identity_pub;
+create policy identity_pub_owner on public.identity_pub
+  for all using (user_id = (select auth.uid())) with check (user_id = (select auth.uid()));
+
+drop policy if exists scope_keys_read on public.scope_keys;
+create policy scope_keys_read on public.scope_keys
+  for select using (
+    public.is_member(scope_id) and member_user_id = (select auth.uid())::text
+  );
+
+drop policy if exists scope_keys_insert on public.scope_keys;
+create policy scope_keys_insert on public.scope_keys
+  for insert with check (
+    public.scope_role(scope_id) = 'admin' and author_id = (select auth.uid())
+  );
+
+drop policy if exists scope_keys_update on public.scope_keys;
+create policy scope_keys_update on public.scope_keys
+  for update
+  using (public.scope_role(scope_id) = 'admin')
+  with check (public.scope_role(scope_id) = 'admin' and author_id = (select auth.uid()));
+
+-- ===========================================================================
+-- 4. org_members / scope_members registry reads (from 0023).
+-- ===========================================================================
+drop policy if exists org_members_read on public.org_members;
+create policy org_members_read on public.org_members
+  for select using (user_id = (select auth.uid()));
+
+drop policy if exists scope_members_read on public.scope_members;
+create policy scope_members_read on public.scope_members
+  for select using (user_id = (select auth.uid()) or public.is_member(scope_id));
+
+-- ===========================================================================
+-- 5. user_table_usage read (from 0007).
+-- ===========================================================================
+drop policy if exists user_table_usage_read on public.user_table_usage;
+create policy user_table_usage_read on public.user_table_usage
+  for select using (scope_id = (select auth.uid()));
+
+-- ===========================================================================
+-- 6. plan_limits read (from 0003) — the only auth.role() call.
+-- ===========================================================================
+drop policy if exists plan_limits_read on public.plan_limits;
+create policy plan_limits_read on public.plan_limits
+  for select using ((select auth.role()) = 'authenticated');
+
+-- ===========================================================================
+-- 7. profiles select/update own (from 0001).
+-- ===========================================================================
+drop policy if exists profiles_select_own on public.profiles;
+create policy profiles_select_own
+  on public.profiles
+  for select
+  using (id = (select auth.uid()));
+
+drop policy if exists profiles_update_own on public.profiles;
+create policy profiles_update_own
+  on public.profiles
+  for update
+  using (id = (select auth.uid()))
+  with check (id = (select auth.uid()));


### PR DESCRIPTION
## Summary
Fixes all 30 `auth_rls_initplan` **performance-advisor** warnings from Supabase. RLS policies that call `auth.uid()` / `auth.role()` directly re-evaluate them **once per row**; wrapping as `(select auth.uid())` lets Postgres hoist the call into an InitPlan (evaluated **once per query**) — a real win on the content tables at scale.

## Change
Migration `0036_rls_initplan.sql` recreates the 30 flagged policies **byte-identically except for the `(select …)` wrap**.

The membership helpers (`is_member` / `scope_role` / `effective_tier` / `shares_scope`) are intentionally **not** wrapped — they take no per-row-varying argument and call `auth.uid()` internally, so the planner already treats them as stable within a query (the advisor does not flag them).

### Policies recreated (source of each faithfully mirrored)
- 8-table content per-verb loop — `author_id = (select auth.uid())` in INSERT/UPDATE (from 0027)
- `distillations` + `temporal_messages` (pro tier) (0027)
- `account_escrow_scope_all` (0010)
- `identity_pub_owner`, `scope_keys` read/insert/update (0025)
- `org_members_read`, `scope_members_read` (0023)
- `user_table_usage_read` (0007)
- `plan_limits_read` — the only `auth.role()` call (0003)
- `profiles_select_own` / `profiles_update_own` (0001)

## Verification
Behavior-preserving. Against real Postgres 16 + PostgREST (Docker):
- `sync-write-gate`, `sync-membership-rls`, `sync-security`: 106 pass
- `sync-orgs`, `sync-identity-scopekeys`, `sync-quota-membership`, `team`: 25 pass

Post-merge the advisor should drop these 30 `auth_rls_initplan` warnings.

## Scope note
Part of a series addressing the Supabase advisor findings. Other groups (`function_search_path_mutable`, `multiple_permissive_policies`, `*_security_definer_function_executable`, info-level) are separate follow-up PRs.