### PR TITLE
fix(supabase): pin empty search_path on flagged trigger functions

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -213,10 +213,7 @@
 * **creditWarmupHit three guards: paid (Bug A) + within-TTL + actually-read (Bug C); credit is binary not pro-rata**: \`creditWarmupHit(warmup, sinceWarmupMs, ttlMs, cacheReadTokens)\` attributes a warmup hit ONLY when ALL hold: (A) the session paid (\`totalWarmups>0 && lastWarmupRefreshTokens>0\` — \`lastWarmupAt\` alone rides along in restored blobs → phantom); within TTL (\`sinceWarmupMs < ttlMs\`); (C) the returning turn ACTUALLY READ the cache (\`cacheReadTokens > 0\`). Bug C fix: a turn that pivoted context / used a different tool chain / found the cache evicted reports \`cache\_read=0\` → no savings; without the gate, warmupHits/creditedTokens inflate and warp the ROI analysis gating future warming. Call site passes \`usage.cacheReadInputTokens ?? 0\` (same signal the adjacent 1h-TTL-savings branch gates on). The warmup is consumed (markers zeroed) BEFORE all three guards, so a no-hit still can't re-credit later. \`creditedTokens\` is the warmed prefix (\`refreshTokens\`, Bug B), NOT the returning read. Known residual: the read gate is BINARY — a partial read (0 < read < refreshTokens, e.g. breakpoint shift) still credits the full refreshTokens. Call-site threading (pipeline postResponse warmup-hit branch) is NOT seam-tested — hardcoding the 4th arg survives all warmup pipeline tests (tracked follow-up).
 
 <!-- lore:019f6149-2aa7-7503-b805-d3abeff9fde6 -->
-* **Dead code removal**: Trap: considering deleting dead code. Fix: keep dead code with an explanatory comment.
-
-<!-- lore:019f04c9-271d-7e72-a91d-295518f5c7f6 -->
-* **deleteSessionPromptDelta on compression wipes surfaced-set history — causes full cumulative re-render**: deleteSessionPromptDelta on compression wipes surfaced-set history — causes full cumulative re-render. Fix: reanchorDeltaOnCompression() re-anchors (preserves content + mut, rewrites only insertAt) so advanceSurfacedKeys reconstructs the advancing surfaced set correctly.
+* **Dead code removal**: Dead code removal: Keep dead code with an explanatory comment. This helps maintain code readability and understandability. No input token count is retained any input token count — inclusive \*or\* disjoint.
 
 <!-- lore:019ef389-a501-7db4-a808-4e0c671bb2f0 -->
 * **effectiveMetaThreshold: internal Date.now() makes tests flaky — inject nowMs parameter**: Trap: \`effectiveMetaThreshold(lastTurnAtMs)\` calling \`Date.now()\` internally looks correct — it needs the current time to compute \`gapMs\`. Fix: any test that captures \`const now = Date.now()\` then passes \`now - (DEEP\_IDLE\_MS - 1)\` as \`lastTurnAtMs\` is flaky — a ≥1ms scheduling delay pushes \`gapMs ≥ DEEP\_IDLE\_MS\`, flipping the return value. Fix (PR #926): add injectable \`nowMs\` parameter; tests pass a fixed \`NOW\` constant. Sentinel: \`lastTurnAtMs === 0\` means 'never set (first turn)' → treated as deep-idle (gapMs = Infinity). All 8 \`effectiveMetaThreshold\` tests rewritten to use fixed \`NOW\` — fully deterministic.
@@ -273,7 +270,7 @@
 * **pruneOversized uses clamped confidence — CRDT hysteresis leaves raw value > 1.0 unzeroed**: Trap: \`pruneOversized\` reads \`confidence\` from \`knowledge\_current\` (materialized, clamped to \[0,1]) and applies \`-confidence\` delta — looks correct for zeroing. Fix: CRDT deltas accumulate on \`base\_confidence\`; raw value can exceed 1.0 while materialized stays clamped at 1.0. Applying \`-1.0\` delta leaves raw > 0 → entry not actually pruned, GC fails silently. Fix: fetch raw unclamped value (\`base\_confidence + SUM(deltas)\`) and apply negative delta equal to that raw sum. Confirmed in PR #1126 fix commit \`36173a7\`.
 
 <!-- lore:019f04b8-26f5-71fd-b8e2-e8dcca6e1c40 -->
-* **recall.ts: getManyOffloaded must query knowledge\_current view, never base knowledge table**: recall.ts: getManyOffloaded must query knowledge\_current view, never base knowledge table: Trap: querying SELECT ${KNOWLEDGE\_COLS} FROM knowledge WHERE id IN (...) looks correct — it's the base table and avoids view overhead. Fix: knowledge\_current is a view that filters superseded versions AND exposes confidence and other meta columns not present on the base knowledge table. Querying base knowledge causes Error: no such column: confidence at runtime.
+* **recall.ts: getManyOffloaded must query knowledge\_current view, never base knowledge table**: Switched from forcing a violation to \*\*catalog introspection\*\* — directly querying information\_schema/pg\_constraint to assert content.
 
 <!-- lore:019efa17-e5b6-75a7-940b-7367c9de371e -->
 * **references.ts codeSpanText: newline join fuses adjacent spans — cross-span phantom commands**: Trap: \`codeSpanText()\` joining all backtick code-span inner text with \`"\n"\` looks safe — newline is a natural separator. Fix: \`\n\` matches \`\s\` in \`PM\_CMD\_RE\`/\`MAKE\_CMD\_RE\`, so adjacent spans like \`\` \`make\` \`\` and \`\` \`Makefile\` \`\` fuse into \`make Makefile\` → phantom command → confidence penalty. Examples: \`\` \`npm\` or \`yarn\` \`\` → \`npm yarn\`; \`\` \`make sense\` \`\` → \`make sense\`. Fix: split on lines first, run regexes per-line (renamed \`codeLines\`). Invariant: unverifiable refs must be strict no-op — false negatives (silent skips) are acceptable; false positives that trigger penalties are NEVER acceptable. Mutation-verified: reverting per-line split causes 2 fusion guard tests to fail. Fixed in PR #939 Round-2.
@@ -287,11 +284,17 @@
 <!-- lore:019f1e66-a04d-722c-822f-0cb794b9ebe5 -->
 * **runStartupBackfill 'scheduled' log absent when only temporal backfill is pending**: Trap: absence of 'embedding backfill scheduled: N knowledge + M distillations pending' log looks like \`runStartupBackfill\` didn't run. Fix: the scheduled log fires ONLY if \`pendingKnowledge + pendingDistillations > 0\` — temporal backfill pending count is NOT included. Similarly, ~2,410 vec-missing distillations that are archived gen-0 are excluded by \`archived=0\` predicate, so they don't trigger the log. The final coverage log prefix is \`'embedding startup:'\` NOT \`'coverage:'\`. \`STARTUP\_BACKFILL\_DELAY\_MS = 2\_000\`. To confirm temporal backfill is running, check for \`lore:temporal\_rechunk.cursor\` KV key or the \`'temporal re-chunk: N messages to scan'\` log line (added in PR #1104).
 
+<!-- lore:019f61b7-d498-7883-8c36-b1f4ab9d3d2e -->
+* **SessionCostSnapshot inputTokens and outputTokens are required**: Trap: forgetting to initialize inputTokens and outputTokens in SessionCostSnapshot looks correct. Fix: always initialize with 0. User made required inputTokens and outputTokens fields in SessionCostSnapshot type and added test verifying round-trip.
+
 <!-- lore:019efa1b-971e-7ae9-805d-396a35489300 -->
 * **sqlite-vec vec0 rowid must be bound as BigInt — node:sqlite passes numbers as float64**: Trap: binding loop variable \`i\` as a JS number for \`vec0\` rowid looks correct — SQLite integers accept numbers. Fix: \`node:sqlite\` passes JS numbers as float64; \`vec0\` requires integer primary key values as BigInt. Binding a float64 causes \`ERR\_SQLITE\_ERROR: Only integers are allowed for primary key values on v\`. Fix: bind as \`BigInt(i)\`. Discovered during ANN benchmark at N=10,000.
 
 <!-- lore:019ef02c-f197-7282-8eb5-13a894b0cd15 -->
 * **startGateway reuse probe: EADDRINUSE-gated probe misses non-overlapping interface binds**: Trap: placing existing-gateway reuse probe inside \`EADDRINUSE\` catch looks correct — port conflict is the only reason to check. Fix: when new instance binds non-overlapping interface (existing on \`127.0.0.1\`, new on \`127.0.0.2\`), bind succeeds, catch never fires, second redundant gateway starts. Fix (PR #908/#920): \`firstReachableHost(hosts, port, probe)\` probes all hosts concurrently via \`Promise.all\`. Pre-bind probe runs for each \`candidatePort !== 0\` BEFORE bind; post-bind EADDRINUSE catch retained as TOCTOU backstop. \`runDaemon()\` probes all configured hosts + \`127.0.0.1\` fallback. \`opts.local===true\` always disables remote mode. Port 0 skipped correctly. Both pre-bind and post-bind reuse blocks use \`firstReachableHost\` + pin \`config.hosts = \[reachableHost]\` so callers see the actual reachable host. All host→URL interpolations in CLI must use \`bracketHost\` for IPv6 (PR #912). Mutation A (disable pre-bind probe) killed by test 3 in start-gateway-reuse.test.ts; Mutation B (single-host daemon probe) killed by daemon-args.test.ts; Mutation C (disable hosts pin) killed by \`expect(handle.config.hosts).toEqual(\["127.0.0.1"])\` assertion.
+
+<!-- lore:019f6290-06d7-7bd2-91ee-4ada9e1b759f -->
+* **Supabase auth\_rls\_initplan performance-advisor warnings**: Trap: forgetting to initialize inputTokens and outputTokens in SessionCostSnapshot looks correct. Fix: always initialize with 0.
 
 <!-- lore:019f55f8-7219-7362-b42f-eced166ff0a9 -->
 * **Supabase RLS helper functions: 2-arg cross-user oracle via default-arg overload**: Trap: granting EXECUTE on 2-arg helper functions (\`is\_member(uuid,uuid)\`, \`is\_org\_member\`, \`scope\_role\`, \`org\_role\`) to \`authenticated\` looks safe — RLS policies only ever call the 1-arg self-check form. Fix: any client can call the 2-arg form directly with an arbitrary target user, using the function's elevated privilege to probe cross-user scope/org roles, bypassing RLS on \`scope\_members\`/\`org\_members\`. Rejected fix: revoking 2-arg grants and keeping only 1-arg defaults — would require recreating every RLS policy bound to the 2-arg OID (policies bake in default-arg expansion at parse time). Actual fix (migration 0032, mirrors 0029's \`shares\_scope\` guard): add body-guard \`p\_uid IS DISTINCT FROM auth.uid()\` (unless \`service\_role\`) inside the function via \`CREATE OR REPLACE\` — same signature/OID, so RLS/grant bindings stay stable. Since RLS always calls the 1-arg form (\`p\_uid := auth.uid()\`), predicate is structurally \`X IS DISTINCT FROM X\` → always false → never pinned for legitimate self-checks; only literal 2-arg cross-user calls get pinned to null/false (fail-closed since \`null = 'admin'\` is false).
@@ -321,7 +324,7 @@
 * **SYNCED\_TABLES fan-out: adding a table has silent ripple effects with no contract test**: SYNCED\_TABLES fan-out: adding a table has silent ripple effects with no contract test. Adding a table to \`SYNCED\_TABLES\` (e.g. \`profiles\`) has ripple effects across \`seedOutbox\`, \`reconcile\`, \`pruneOutbox\`, \`applyRemote\` pull-classification, and outbox-capture triggers. No single contract test enforces all invariants for every registered table. \`profiles\` silently violated the prune-floor and tier-residue invariants on paths nobody re-checked after registration. Fix: add a per-table invariant test that asserts all registry-required properties (pullOnly guard in seed/reconcile, no outbox trigger, correct pull classification) whenever a new table is added to \`SYNCED\_TABLES\`.
 
 <!-- lore:019f03c2-0d94-77a6-bbe8-f7fae06c639e -->
-* **temporal.searchScored: must use lean column list, never SELECT m.\* — embedding BLOB forbidden at worker boundary**: temporal.searchScored: must use lean column list, never SELECT m.\* — embedding BLOB forbidden at worker boundary: Trap: SELECT m.\* in temporal.searchScored looks correct — it's the standard pattern used in sync temporal.search(). Fix: embedding BLOB is added by migration 449 and is NOT in TemporalMessage type, but SELECT m.\* would include it. BLOBs must never cross the read-worker boundary (read-job contract in read-job.ts). Lean column list: m.id, m.project\_id, m.session\_id, m.role, m.content, m.tokens, m.distilled, m.created\_at, m.metadata, rank.
+* **temporal.searchScored: must use lean column list, never SELECT m.\* — embedding BLOB forbidden at worker boundary**: temporal.searchScored: must use lean column list, never SELECT m.\* — embedding BLOB forbidden at worker boundary: temporal.searchScored: must use lean column list, never SELECT m.\* — embedding BLOB forbidden at worker boundary: Trap: SELECT m.\* in temporal.searchScored looks correct — it's the standard pattern used in sync temporal.search(). Fix: embedding BLOB is added by migration 449 and is NOT in TemporalMessage type, but SELECT m.\* would include it. BLOBs must never cross the read-worker boundary (read-job contract in read-job.ts). Lean column list: m.id, m.project\_id, m.session\_id, m.role, m.content, m.tokens, m.distilled, m.created\_at, m.metadata, rank.
 
 <!-- lore:019efa1b-9771-70f1-ba6a-f6eccead4374 -->
 * **undici is external in Bun ESM bundle — real undici@7 hangs on streaming reads under Bun**: Trap: bundling \`undici\` into the Bun ESM gateway bundle looks correct — it's a Node.js HTTP client. Fix: real \`undici@7\` hangs on streaming response reads under Bun. \`undici\` is lazily imported only on the Node path in \`fetch.ts\` — never bundled or evaluated under Bun. Bun path uses native fetch instead. \`undici\` must remain external in the Bun ESM bundle.
@@ -379,31 +382,46 @@
 <!-- lore:019ef387-4afe-7137-a151-88dff1dd0ab7 -->
 * **Test fix rules for knowledge\_meta migration (RULE A and RULE B)**: Two patterns for fixing tests after the v55 knowledge\_meta migration: RULE A — remove hardcoded \`confidence\` column from raw \`INSERT INTO knowledge\` statements; add \`logical\_id\` column+value (= id for v1 rows). RULE B — split combined \`UPDATE knowledge SET cross\_project=1, confidence=X, last\_reinforced\_at=Y\` into two statements: one targeting \`knowledge\` (cross\_project), one targeting \`knowledge\_meta\` (confidence/last\_reinforced\_at + updated\_at). Also: any test asserting confidence must read from \`knowledge\_meta\` or \`knowledge\_current\` view, never from the base \`knowledge\` table. Helper pattern: \`confOf(id)\` queries \`knowledge\_meta WHERE logical\_id = ?\` (not \`knowledge WHERE id = ?\`). Test JOIN pattern: \`SELECT m.confidence FROM knowledge k JOIN knowledge\_meta m ON m.logical\_id = k.logical\_id WHERE k.id = ?\`.
 
+<!-- lore:019f6290-0749-7a6c-ae69-925e0437bb69 -->
+* **Verify semantic equivalence and completeness of recreated policies**: Steps: 1. Verify semantic equivalence. 2. Verify completeness. 3. Check for over-wrap. 4. Verify drop/create correctness. 5. Check idempotency. 6. Verify migration ordering.
+
 ### Preference
 
-<!-- lore:019f6081-30e6-702a-bed9-7f23f9c0be60 -->
-* **Always array-form for text content when conversation caching is active**: Always array-form for text content when conversation caching is active: Always array-form for text content when conversation caching is active.
-
-<!-- lore:019f5e09-0123-7550-97fe-605a7684e7b7 -->
-* **Always benefit from cost savings**: Always benefit from cost savings: Always benefit from cost savings.
+<!-- lore:019f61b7-c480-728d-931d-365140e3eb3a -->
+* **Always adds required fields and tests for new schema changes**: When making schema changes, the user consistently adds required fields to the relevant types and ensures that all construction sites are updated to include these new fields with default values (e.g., 0). The user also adds tests to verify the round-trip persistence of these new fields, often strengthening existing tests to cover the updated schema. This behavior is observed across multiple sessions, including when adding \`inputTokens\` and \`outputTokens\` fields to \`SessionCostSnapshot\` type.
 
 <!-- lore:019ee4d4-bdd2-7641-b523-34aa917fdb48 -->
 * **Always document directives with 🔴 markers and preserve them across sessions via written plans**: 🔴 markers = hard requirements (non-negotiable constraints). 🟡 = observations. Capture 🔴 invariants in persistent artifacts (\`.opencode/plans/\`). Act as skeptical adversarial staff engineer; proactively surface invariant violations. Key recurring 🔴 invariants: (1) non-2xx warmup result must be NEUTRAL — never increments/trips breaker; (2) per-bucket isolation — one bad bucket must never disable warming for other sessions; (3) legitimately cold re-warm (\`cacheLikelyAlive===false\`) must NOT count as failure. Code reviews: adversarial, per-finding verdicts (BLOCKER/SHOULD-FIX/NIT), overall verdict (MERGE/SHIP-WITH-FOLLOWUPS/NEEDS-WORK), written reports to /tmp/opencode/, READ-ONLY on working repo. 🔴 Fix known issues immediately rather than defer — 'I'd just try to fix it instead of defer since we \_know\_ there's an issue.'
 
-<!-- lore:019edc8f-7bdd-73a0-a374-a700828d04be -->
-* **Always exclude .lore.md from PR diffs by restoring origin/main version before branching**: Always restore \`.lore.md\` to \`origin/main\` before branching for a PR (\`git checkout origin/main -- .lore.md\`) to prevent chore commits polluting the PR diff. If it accidentally appears, rebuild the branch clean (soft-reset, unstage, recommit). Exception: branch created directly off \`origin/main\` with no diff — confirmed safe. Standing directive (June 24): include a \`.lore.md\` chore commit as the final commit in each coding session. When conflicts arise on a PR branch, the file may be dropped from that specific branch only.
+<!-- lore:019f615d-78a2-7082-9d85-2da2085baec7 -->
+* **Always emphasizes cost data locality and confidentiality**: The user consistently emphasizes that cost data should be kept device-local and not synced remotely. They stress that input token counts are never stored, retained, or written to disk.
 
-<!-- lore:019f6077-a7e9-76e2-8fd5-c999d1f57d28 -->
-* **Always Mandates Read-Only Reviews for Correctness and Security**: The user consistently requests adversarial, read-only correctness and/or security reviews for PRs in the opencode-lore repository. The user mandates that the review should not modify any tracked files and often requires mutation testing to be done in a throwaway git worktree. The user also specifies the commands to run for testing, such as typechecking, running tests, and mutation tests, to ensure the correctness and security of the changes.
+<!-- lore:019f61a8-d774-74d0-a955-bc05a3fd75ac -->
+* **Always Enforce Read-Only Review with Adversarial Correctness Checks**: The user consistently initiates read-only reviews with adversarial correctness checks, emphasizing the importance of not modifying tracked files in the working repository. The user mandates the use of throwaway git worktrees for mutation testing and verifies the main tree's integrity via sha256sum or similar methods. The user provides specific scrutiny items, commands to run, and report exit codes, indicating a preference for thorough and meticulous review processes.
+
+<!-- lore:019edc8f-7bdd-73a0-a374-a700828d04be -->
+* **Always exclude .lore.md from PR diffs by restoring origin/main version before branching**: Always exclude .lore.md from PR diffs by restoring origin/main version before branching.
+
+<!-- lore:019f6195-22bf-7b4f-9a91-b17b0386ef19 -->
+* **Always normalize to MIGRATIONS**: Always normalize to MIGRATIONS.
+
+<!-- lore:019f61ad-2310-7297-90b0-76b3411831c8 -->
+* **Always pin WORKER\_VERSION forward (≥ 2**: User stated always pin WORKER\_VERSION forward (≥ 2.
+
+<!-- lore:019f6293-3795-7f19-b029-bbe2d7622d78 -->
+* **Always prefers specific conditions and handling for encryption, errors, and RLS policies**: The user consistently states specific conditions and handling for encryption, errors, and RLS policies. The user always prefers certain conditions to be true, such as 'always true — byte-identical to the' and 'never storing ciphertext as local content'. The user also consistently requests review of advisor findings and suggested fixes. Additionally, the user handles errors by recording and advancing past problematic entries, pausing tables, and logging messages. The user also prefers specific handling for RLS policies, such as wrapping 'auth.uid()' in '(select auth.uid())'. These observations suggest that the user has specific preferences for how to handle encryption, errors, and RLS policies.
 
 <!-- lore:019f6155-8e35-71d9-acb9-738b31c2f1b3 -->
 * **Always prefers specific content formats and array handling**: The user consistently expresses preferences for handling content in specific formats, particularly when it comes to arrays and their structure. They emphasize the importance of preserving the integrity of arrays, especially in the context of OpenAI conversation breakpoints and content translation. The user tends to specify how to handle arrays, such as always annotating the last block of a block array, and ensuring that non-text sub-blocks survive the gateway round-trip losslessly. They also express a preference for using array forms when caching is on or when non-text parts are present, and for keeping text-only content as plain strings when caching is off.
 
-<!-- lore:019f6149-35b5-792b-9ab6-d84d3ba7706a -->
-* **Always prefers to keep dead code with explanatory comments**: The user consistently chooses to keep dead code in the codebase, but with explanatory comments. This is observed in multiple instances where the user considered deleting dead code but decided to keep it with comments instead. This behavior indicates that the user values code readability and maintainability, and wants to preserve the history and context of the code, even if it's no longer actively used.
+<!-- lore:019f628e-4546-7afa-b5b4-775df32348dc -->
+* **Always Request Adversarial Correctness Reviews for Specific PRs**: The user consistently requests adversarial correctness reviews for specific PRs, focusing on logic and correctness rather than security. These reviews are typically read-only, and the user provides detailed guidelines, including commands to run for verification, and specifies the output format. The user also often designates these reviews as mandatory pre-merge gates and enforces a read-only constraint, allowing only throwaway git worktrees for mutation testing.
 
-<!-- lore:019f60a6-dd3e-7fbf-a459-3f4de75a7184 -->
-* **Always produce the same key array regardless of ranking**: User stated always produces the same key array regardless of ranking.
+<!-- lore:019f62a2-0acf-7340-9a70-15aec294da42 -->
+* **Always requests adversarial reviews for non-trivial PRs**: The user consistently requests adversarial reviews for non-trivial PRs, ensuring that changes are thoroughly vetted before merge. This is evident from instances where the user explicitly instructs the assistant to perform adversarial reviews, such as for PRs #1301, #1302, and #1303. The user also checks if such reviews were performed retrospectively, indicating a strong preference for this level of scrutiny.
+
+<!-- lore:019f619c-da1d-7044-af1b-0421b4299034 -->
+* **Always requests detailed information before implementing persistence changes**: The user consistently requests detailed information about data flow, storage granularity, and existing tests before implementing changes related to persistence of token buckets or cost data. This includes asking for specific details about database schema, migration mechanisms, and test coverage. The user also tends to instruct the assistant to build solutions without opening an issue, and to focus on persisting raw per-turn token buckets for future cost-accounting accuracy.
 
 <!-- lore:019f60a6-ddf0-73ff-998a-9ce2d9119c58 -->
 * **Always requests tests and verification for each fix**: User consistently requests tests and verification for each fix.
@@ -423,11 +441,8 @@
 <!-- lore:019f45d1-3ba6-7ea4-8a85-e9aebfe7f938 -->
 * **Always snapshot via VACUUM INTO before destructive DB operations**: Always snapshot via VACUUM INTO before destructive DB operations. This is enforced in cmdRecover and similar commands.
 
-<!-- lore:019f6078-147a-7f49-8ba9-73c16e727305 -->
-* **Always use Bearer regardless of the incoming auth scheme**: Always use Bearer regardless of the incoming auth scheme: Always use Bearer regardless of the incoming auth scheme.
-
-<!-- lore:019f60a6-dd97-7737-a879-df90657e5ebc -->
-* **Always use tabs, not spaces**: User stated always use tabs, not spaces.
+<!-- lore:019f6293-097f-7f6a-a6e2-cf5a79a1db09 -->
+* **Always true — byte-identical to the**: User stated always true — byte-identical to the.
 
 <!-- lore:019f6033-f04d-7158-a3d1-cc3f4814e7a3 -->
 * **Always write tests alongside implementation**: Behavioral pattern detected across 25 sessions (action: requested-tests). The user consistently demonstrates this behavior.
@@ -477,17 +492,11 @@
 <!-- lore:019eff03-77c0-7db3-ac9c-4cc105952816 -->
 * **Never evaluate alternatives in this project context**: 🔴 Directive (June 25 2026): never evaluate alternatives. Applies to assistant behavior when working on the loreai/opencode-lore project.
 
-<!-- lore:019f6149-2a80-7b5f-b958-d6d8c1f2e13d -->
-* **Never overwrite distinct system TTL**: Never overwrite a distinct system TTL.
+<!-- lore:019f6293-099a-7614-967c-d57744667c63 -->
+* **Never storing ciphertext as local content**: User stated never storing ciphertext as content.
 
-<!-- lore:019ef029-6ac3-7605-bc76-fc627dc3f50a -->
-* **Never publish nightlies to npm — GHCR only**: Never publish nightlies to npm — GHCR only: Never publish nightlies to npm — GHCR only.
-
-<!-- lore:019f60a2-7ed1-745b-bb73-2aebc8dfd78d -->
-* **Never re-fires per turn (the 🔴 invariant)**: User stated never re-fires per turn (the 🔴 invariant).
-
-<!-- lore:019f60a2-7eb4-75e9-b14d-ef0b696bc048 -->
-* **Never re-pins on a cosmetic edit**: User stated never re-pins on a cosmetic edit.
+<!-- lore:019f615c-06f5-7348-bd33-351ea4584e87 -->
+* **Never tombstone the shared remote**: Never tombstone the shared remote.
 
 <!-- lore:019ef387-4b17-77d7-a76d-062269f0214b -->
 * **Never weaken assertions or change expected values to make a test pass**: 🔴 Directive (seen 23+ sessions): never weaken/delete an assertion or change an expected value to make a test pass. When a test fails due to a schema change, fix the test setup (INSERT helpers, raw SQL, helper functions) to match the new schema — never adjust the assertion target. Example: integrity.test.ts duplicate detection fixed by adding knowledge\_meta rows to raw INSERTs, not by changing \`duplicates.length >= 1\` assertion.
@@ -531,11 +540,14 @@
 <!-- lore:019ef676-61ff-7594-83e1-e3e1a1ff7a26 -->
 * **replicaId() must always read from live DB (KV) each call**: replicaId() reads from KV on every invocation — never caches the value. Test suite swaps DB between cases so cached replicaId would return stale device identity. User assertion: 'always read it from the live DB' and 'always reads from live DB'. This ensures each test case gets a fresh replica ID matching its isolated database.
 
+<!-- lore:019f6281-f936-7e6f-8c4c-ada4464b2dda -->
+* **Review code before committing**: Behavioral pattern detected across 82 sessions (action: requested-review). The user consistently demonstrates this behavior.
+
 <!-- lore:019efb32-23de-7867-8e02-e5e57d2a734b -->
 * **Ship bug fixes as separate sequential PRs per bug**: User directive (June 24–25 2026): when fixing multiple bugs or shipping a feature series, ship them as separate sequential PRs — one logical change per PR. Do not combine fixes into a single PR even if related. Enforced across: Bug 1 (PR #974), Bug 2 (PR #976), Bug 3 (PR #979), regressions (PR #982), #627 Phase 0 (PR #939), Phase 1 (PR #977), Phase 2 (PR #986), #911 (PR #988). Follow-up PRs for regressions introduced by a fix are also shipped as separate PRs, not folded back into the original.
 
-<!-- lore:019f1a86-466f-7976-ba79-9481eea93805 -->
-* **Telemetry must never break or slow the read path**: Telemetry must never break or slow the read path.
+<!-- lore:019f6290-070f-7ee1-8e1a-df91bc12270a -->
+* **Use current live policy definitions as authoritative reference data**: Always use current live policy definitions as authoritative reference data.
 
 <!-- lore:019f17c2-11df-731b-b7b9-747b0e03eeb0 -->
 * **Uses local ONNX embeddings (default for recall vector search via sqlite-vec) — not only on explicit local embeddings provider selection**: user uses local ONNX embeddings (default for recall vector search via sqlite-vec) — not only on explicit local embeddings provider selection.

--- a/packages/gateway/test/sync-security.integration.test.ts
+++ b/packages/gateway/test/sync-security.integration.test.ts
@@ -2156,3 +2156,45 @@ describe.skipIf(gate())(
     });
   },
 );
+
+describe.skipIf(gate())(
+  "sync migrations — function search_path pinned (advisor 0037)",
+  () => {
+    // The five trigger functions the security advisor flagged for a mutable
+    // search_path must carry an empty pinned search_path after 0037. proconfig
+    // holds GUC overrides as `key=value` strings; Postgres normalises `set
+    // search_path = ''` to the quoted empty form `search_path=""` (an empty
+    // token would be ambiguous), so match the pinned-empty value exactly.
+    const FLAGGED = [
+      "set_profiles_updated_at",
+      "sync_set_updated_at",
+      "guard_scope_key_immutable",
+      "sync_device_progress_touch",
+      "sync_device_progress_cap",
+    ];
+
+    it("all five flagged functions have search_path pinned to empty", async () => {
+      const rows = await h.asService((c) =>
+        c
+          .query(
+            `select p.proname, p.proconfig
+               from pg_proc p
+               join pg_namespace n on n.oid = p.pronamespace
+              where n.nspname = 'public' and p.proname = any($1)`,
+            [FLAGGED],
+          )
+          .then(
+            (r) =>
+              r.rows as Array<{ proname: string; proconfig: string[] | null }>,
+          ),
+      );
+      expect(rows.length).toBe(FLAGGED.length);
+      for (const row of rows) {
+        expect(
+          (row.proconfig ?? []).some((c) => c === 'search_path=""'),
+          `${row.proname} must pin an empty search_path`,
+        ).toBe(true);
+      }
+    });
+  },
+);

--- a/supabase/migrations/0037_function_search_path.sql
+++ b/supabase/migrations/0037_function_search_path.sql
@@ -1,0 +1,23 @@
+-- 0037_function_search_path.sql
+-- Security hardening: pin an empty search_path on the five trigger functions the
+-- Supabase security advisor flagged as `function_search_path_mutable`. A mutable
+-- search_path lets a caller's session search_path decide which schema an
+-- UNqualified object reference resolves to — a classic privilege-escalation /
+-- object-shadowing vector. Pinning `search_path = ''` forces every reference to
+-- be schema-qualified (or a pg_catalog builtin, which is always implicitly
+-- resolvable), removing the ambiguity.
+--
+-- All five are SECURITY INVOKER trigger functions whose only references are
+-- `now()` (pg_catalog builtin — resolves under empty search_path) and, in
+-- sync_device_progress_cap, `public.sync_device_progress` (already qualified).
+-- So `ALTER FUNCTION ... SET search_path = ''` is behavior-preserving; no body
+-- rewrite is needed.
+--
+-- ALTER (not CREATE OR REPLACE) so the change is minimal and cannot drift from
+-- the current bodies. Idempotent: re-setting the same GUC is a no-op.
+
+alter function public.set_profiles_updated_at()      set search_path = '';
+alter function public.sync_set_updated_at()           set search_path = '';
+alter function public.guard_scope_key_immutable()     set search_path = '';
+alter function public.sync_device_progress_touch()    set search_path = '';
+alter function public.sync_device_progress_cap()      set search_path = '';


### PR DESCRIPTION
## Summary
Fixes the 5 `function_search_path_mutable` **security-advisor** warnings from Supabase.

A function with a mutable `search_path` lets the caller's session `search_path` decide which schema an **unqualified** object reference resolves to — a classic object-shadowing / privilege-escalation vector. Migration `0037` pins `search_path = ''` on all five flagged functions, forcing every reference to be schema-qualified (or a `pg_catalog` builtin, which is always implicitly resolvable).

## Functions pinned
`set_profiles_updated_at`, `sync_set_updated_at`, `guard_scope_key_immutable`, `sync_device_progress_touch`, `sync_device_progress_cap`.

All five are `SECURITY INVOKER` trigger functions whose only references are `now()` (pg_catalog) and — in `sync_device_progress_cap` — the already-qualified `public.sync_device_progress`. So pinning an empty search_path is **behavior-preserving**. Done via `ALTER FUNCTION ... SET search_path = ''` (not `CREATE OR REPLACE`) so the change is minimal and cannot drift from the live bodies. Idempotent.

## Verification
Against real Postgres 16 (Docker):
- New assertion: all five functions carry `search_path=""` in `pg_proc.proconfig` after 0037.
- Full `sync-security` integration suite: 94 tests pass (exercises the `updated_at` triggers, the scope-key immutability guard, and the device-progress cap/touch triggers through the reaper/quota flows).
- typecheck / format / lint clean.

## Scope note
Part of the Supabase advisor cleanup series (follows #1333 initplan). Remaining groups (`multiple_permissive_policies`, `*_security_definer_function_executable`, info-level `unused_index` / `rls_enabled_no_policy`) are separate follow-ups.