### PR TITLE
feat(gateway): log subagent flag + resolved LTM budget for one-grep triage

### DIFF
--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -6814,6 +6814,7 @@ async function handleConversationTurn(
   log.info(
     `turn: session=${sessionID.slice(0, 16)} messages=${req.messages.length} ` +
       `model=${req.model} stream=${req.stream} new=${isNew} tier=${tier} ` +
+      `subagent=${!!sessionState.isSubagent} ` +
       `source=${pathResult.source} ` +
       `hdrProject=${req.rawHeaders["x-lore-project"] ? "present" : "absent"} ` +
       `provisional=${sessionState.projectPathProvisional === true} ` +
@@ -7078,6 +7079,16 @@ async function handleConversationTurn(
         cfg.budget.preferenceLtm,
         sessionID ?? undefined,
         ltmBudgetOpts,
+      );
+      // Surface the resolved LTM budget so a "knowledge is crowding my
+      // sub-agent" report is a one-grep diagnosis (LORE_DEBUG=1) instead of an
+      // inference from window sizes: sub-agents are capped tighter
+      // (SUBAGENT_MAX_LTM_BUDGET_FRACTION) so a small ctxBound here is expected
+      // and NOT the crowding cause — see the Onur sub-agent triage, Jul 2026.
+      log.info(
+        `ltm-budget: session=${sessionID?.slice(0, 16) ?? "none"} ` +
+          `subagent=${!!sessionState.isSubagent} ` +
+          `ctxBound=${ltmBudget} pref=${prefBudget} fraction=${ltmFraction}`,
       );
       const isFirstTurn =
         sessionID != null && !temporal.hasMessages(projectPath, sessionID);


### PR DESCRIPTION
## Problem
When triaging Onur's recurring "sub-agent returns empty" report (Jul 2026), the gateway's per-turn `turn:` diagnostic line printed session identity/attribution but **not** whether the session was flagged as a sub-agent, nor the **resolved LTM budget**. So confirming whether LTM was crowding the sub-agent required inferring from `usable=`/`tokens=` across many `gradient:` lines and cross-referencing.

In that triage the real cause turned out to be upstream **MiniMax 429 rate-limiting** (window was 80%+ empty, running at layer 0 with ~32–39K of 174K used) — not LTM crowding. But proving that took a manual log autopsy.

## Change
Two `LORE_DEBUG=1` diagnostic additions, **no behavior change**:
- Add `subagent=<bool>` to the existing `turn:` attribution line.
- Add a new `ltm-budget:` line — `session`, `subagent`, `ctxBound` (resolved context-bound LTM budget), `pref` (preference budget), `fraction` — logged right after the budgets are resolved in the `knowledge.enabled` block.

Now "is knowledge crowding my sub-agent?" is a one-grep answer: `subagent=true` + a small `ctxBound` confirms the sub-agent cap is doing its job, ruling LTM out immediately.

## Testing
- Sub-agent detection behavior (`x-parent-session-id` → `isSubagent`) is already covered by `session.test.ts` (13 `isSubagent` assertions). These are pure diagnostic log strings on top of already-tested state, so no brittle log-scraping test was added.
- Full suite green (5879 passed); typecheck + lint + format clean.