### PR TITLE
fix(supabase): single SELECT policy on identity_pub (multiple_permissive_policies)

### DIFF
--- a/packages/gateway/test/sync-identity-scopekeys.integration.test.ts
+++ b/packages/gateway/test/sync-identity-scopekeys.integration.test.ts
@@ -106,6 +106,37 @@ describe.skipIf(gate())(
       expect(await canReadPub(b, a)).toBe(1); // B can now read A's pubkey (to be wrapped to)
     });
 
+    it("identity_pub: exactly one permissive SELECT policy (advisor 0038)", async () => {
+      // 0038 collapsed the FOR ALL owner policy + standalone co-member read into
+      // a single SELECT policy, so a read no longer evaluates two permissive
+      // policies (multiple_permissive_policies advisor). Writes stay owner-only.
+      const rows = await h.asService((c) =>
+        c
+          .query(
+            `select policyname, cmd
+               from pg_policies
+              where schemaname = 'public' and tablename = 'identity_pub'
+              order by policyname`,
+          )
+          .then((r) => r.rows as Array<{ policyname: string; cmd: string }>),
+      );
+      // A FOR ALL policy would count toward SELECT too; there must be none, and
+      // exactly ONE policy whose command applies to SELECT.
+      const selectApplicable = rows.filter(
+        (p) => p.cmd === "SELECT" || p.cmd === "ALL",
+      );
+      expect(selectApplicable.map((p) => p.policyname)).toEqual([
+        "identity_pub_read",
+      ]);
+      // Owner writes are split into dedicated INSERT + UPDATE policies.
+      const names = rows.map((p) => p.policyname).sort();
+      expect(names).toEqual([
+        "identity_pub_insert",
+        "identity_pub_read",
+        "identity_pub_update",
+      ]);
+    });
+
     it("identity_pub: an oversized public key is rejected (anti-abuse cap)", async () => {
       const a = await h.createUser();
       // base64 of 512 raw bytes is ~684 chars > the 512-char text cap → rejected.

--- a/supabase/migrations/0038_identity_pub_single_select_policy.sql
+++ b/supabase/migrations/0038_identity_pub_single_select_policy.sql
@@ -1,0 +1,49 @@
+-- 0038_identity_pub_single_select_policy.sql
+-- Performance: collapse the two permissive SELECT policies on identity_pub into
+-- one, fixing the 6 `multiple_permissive_policies` advisor warnings (one per
+-- role, all for SELECT on identity_pub).
+--
+-- Before (0025, initplan-wrapped in 0036):
+--   identity_pub_owner          FOR ALL    using (user_id = (select auth.uid()))
+--                                          with check (user_id = (select auth.uid()))
+--   identity_pub_read_comembers FOR SELECT using (public.shares_scope(user_id))
+-- A `FOR ALL` policy also applies to SELECT, so every SELECT evaluated BOTH
+-- permissive policies and OR-ed them: effective read = owner OR co-member.
+--
+-- After: a single SELECT policy carrying that exact OR, and the owner policy
+-- narrowed to the write verbs it actually needs (authenticated is granted only
+-- SELECT/INSERT/UPDATE on this table — 0025:57 — so no DELETE policy is needed).
+--
+-- Behavior-preserving:
+--  * READ — `user_id = (select auth.uid()) OR shares_scope(user_id)` is byte-
+--    equivalent to the prior OR of the owner + co-member policies. The explicit
+--    owner disjunct is retained (NOT folded into shares_scope alone) so a user
+--    can always read their OWN row even in the degenerate case where they have
+--    no scope_members row and shares_scope(self) would return false.
+--  * WRITE — INSERT/UPDATE keep the identical `user_id = (select auth.uid())`
+--    self-ownership gate the FOR ALL policy enforced.
+-- auth.uid() stays wrapped as (select …) to preserve the 0036 initplan fix.
+
+alter table public.identity_pub enable row level security;
+
+-- Drop the FOR ALL owner policy and the standalone co-member read policy.
+drop policy if exists identity_pub_owner on public.identity_pub;
+drop policy if exists identity_pub_read_comembers on public.identity_pub;
+
+-- Single SELECT policy: own row OR a co-member's row.
+drop policy if exists identity_pub_read on public.identity_pub;
+create policy identity_pub_read on public.identity_pub
+  for select
+  using (user_id = (select auth.uid()) or public.shares_scope(user_id));
+
+-- Owner-only write policies (self-ownership), matching the granted write verbs.
+drop policy if exists identity_pub_insert on public.identity_pub;
+create policy identity_pub_insert on public.identity_pub
+  for insert
+  with check (user_id = (select auth.uid()));
+
+drop policy if exists identity_pub_update on public.identity_pub;
+create policy identity_pub_update on public.identity_pub
+  for update
+  using (user_id = (select auth.uid()))
+  with check (user_id = (select auth.uid()));


### PR DESCRIPTION
## Summary
Fixes the 6 `multiple_permissive_policies` **performance-advisor** warnings (one per role) for SELECT on `identity_pub`.

### Before (0025, initplan-wrapped in 0036)
- `identity_pub_owner` — `FOR ALL using (user_id = (select auth.uid()))`
- `identity_pub_read_comembers` — `FOR SELECT using (public.shares_scope(user_id))`

A `FOR ALL` policy also applies to SELECT, so every read evaluated **both** permissive policies and OR-ed them → effective read = `owner OR co-member`.

### After
- `identity_pub_read` — single `FOR SELECT using (user_id = (select auth.uid()) or public.shares_scope(user_id))`
- `identity_pub_insert` / `identity_pub_update` — owner-only writes (self-ownership), matching the only write verbs granted to `authenticated` (SELECT/INSERT/UPDATE — 0025:57).

## Behavior-preserving
- **Read**: the single policy's `user_id = (select auth.uid()) OR shares_scope(user_id)` is byte-equivalent to the prior OR of the two policies. The explicit owner disjunct is **kept** (not folded into `shares_scope` alone) so a user can always read their own row even in the degenerate case where they have no `scope_members` row and `shares_scope(self)` would return false.
- **Write**: INSERT/UPDATE keep the identical `user_id = (select auth.uid())` gate the `FOR ALL` policy enforced.
- `auth.uid()` stays wrapped as `(select …)` to preserve the #1336/#1333 initplan fix.

## Verification (real Postgres 16, Docker)
- New assertion: exactly one policy applies to SELECT (`identity_pub_read`); writes are `identity_pub_insert` + `identity_pub_update`.
- `sync-identity-scopekeys` (incl. the co-member-read `shares_scope` discriminator + own-read/write-forge), `sync-scope-rotation`, `sync-team-lifecycle`: 23 tests pass.
- typecheck / format / lint clean.

## Scope note
Supabase advisor cleanup series (after #1333 initplan, #1335 search_path). Remaining: `*_security_definer_function_executable` (anon EXECUTE review) and info-level items.