### PR TITLE
fix(supabase): revoke default PUBLIC/anon EXECUTE on definer functions

### DIFF
--- a/packages/gateway/test/sync-security.integration.test.ts
+++ b/packages/gateway/test/sync-security.integration.test.ts
@@ -2198,3 +2198,105 @@ describe.skipIf(gate())(
     });
   },
 );
+
+describe.skipIf(gate())(
+  "sync migrations — definer function EXECUTE lockdown (advisor 0039)",
+  () => {
+    // 0039 revokes the default PUBLIC/anon EXECUTE grant on every SECURITY
+    // DEFINER function so PostgREST no longer exposes them to unauthenticated
+    // (or, for triggers, any) clients via /rpc. `authenticated` KEEPS EXECUTE on
+    // the five client RPCs (the CLI calls them) and on the RLS helpers (a policy
+    // expression runs AS the querying role, so it needs helper EXECUTE), and
+    // LOSES it on the trigger/internal functions.
+    const CLIENT_RPCS = [
+      "create_team",
+      "add_scope_member",
+      "remove_scope_member",
+      "set_scope_role",
+      "rotate_scope_key",
+    ];
+    const RLS_HELPERS = [
+      "is_member",
+      "is_org_member",
+      "scope_role",
+      "org_role",
+      "shares_scope",
+      "current_tier",
+      "effective_tier",
+    ];
+    const TRIGGERS = [
+      "enforce_row_quota",
+      "guard_org_tier",
+      "guard_profile_tier",
+      "handle_new_user",
+      "maintain_usage",
+      "on_auth_user_provision_scope",
+      "provision_personal_scope",
+    ];
+
+    // grantees holding EXECUTE on a given public function name. Read from
+    // pg_proc.proacl via aclexplode (information_schema.routine_privileges is
+    // role-filtered and unreliable here); PUBLIC surfaces as a NULL grantee oid.
+    async function execGrantees(fn: string): Promise<Set<string>> {
+      const rows = await h.asService((c) =>
+        c
+          .query(
+            `select coalesce(r.rolname, 'PUBLIC') as grantee
+               from pg_proc p
+               join pg_namespace n on n.oid = p.pronamespace
+               cross join lateral
+                 aclexplode(coalesce(p.proacl, acldefault('f', p.proowner))) a
+               left join pg_roles r on r.oid = a.grantee
+              where n.nspname = 'public'
+                and p.proname = $1
+                and a.privilege_type = 'EXECUTE'`,
+            [fn],
+          )
+          .then((r) => r.rows as Array<{ grantee: string }>),
+      );
+      return new Set(rows.map((r) => r.grantee));
+    }
+
+    it("PUBLIC and anon hold no EXECUTE on any locked-down definer function", async () => {
+      for (const fn of [...CLIENT_RPCS, ...RLS_HELPERS, ...TRIGGERS]) {
+        const g = await execGrantees(fn);
+        expect(g.has("PUBLIC"), `${fn}: PUBLIC must not EXECUTE`).toBe(false);
+        expect(g.has("anon"), `${fn}: anon must not EXECUTE`).toBe(false);
+      }
+    });
+
+    it("authenticated keeps EXECUTE on client RPCs and RLS helpers", async () => {
+      for (const fn of [...CLIENT_RPCS, ...RLS_HELPERS]) {
+        const g = await execGrantees(fn);
+        expect(
+          g.has("authenticated"),
+          `${fn}: authenticated must EXECUTE`,
+        ).toBe(true);
+      }
+    });
+
+    it("trigger/internal functions are executable only by postgres/service_role", async () => {
+      // Load-bearing form: the triggers' pre-0039 grantees were {PUBLIC, postgres},
+      // so authenticated only ever reached them THROUGH PUBLIC. Asserting merely
+      // that `authenticated` is absent would be vacuous (it never held a direct
+      // grant). Instead assert PUBLIC and anon are gone and the survivors are a
+      // subset of the admin roles — this actually guards the step-1 PUBLIC revoke.
+      const ADMIN = new Set(["postgres", "service_role"]);
+      for (const fn of TRIGGERS) {
+        const g = await execGrantees(fn);
+        expect(g.has("PUBLIC"), `${fn}: PUBLIC must not EXECUTE`).toBe(false);
+        expect(g.has("anon"), `${fn}: anon must not EXECUTE`).toBe(false);
+        expect(
+          g.has("authenticated"),
+          `${fn}: authenticated must not EXECUTE`,
+        ).toBe(false);
+        for (const grantee of g) {
+          expect(
+            ADMIN.has(grantee),
+            `${fn}: unexpected EXECUTE grantee ${grantee}`,
+          ).toBe(true);
+        }
+      }
+    });
+  },
+);

--- a/supabase/migrations/0039_definer_function_execute.sql
+++ b/supabase/migrations/0039_definer_function_execute.sql
@@ -1,0 +1,124 @@
+-- 0039_definer_function_execute.sql
+-- Security: lock down direct EXECUTE on the SECURITY DEFINER functions that
+-- Postgres granted to PUBLIC by default at CREATE time. PostgREST exposes ANY
+-- executable function at /rest/v1/rpc/<name>, so the blanket PUBLIC grant let
+-- `anon` and `authenticated` invoke every definer function directly — the 40
+-- `{anon,authenticated}_security_definer_function_executable` advisor warnings.
+--
+-- Correct posture:
+--   * PUBLIC + anon: revoke EXECUTE on ALL of them. No definer function here is
+--     meant to be called by an unauthenticated client.
+--   * authenticated: revoke on everything EXCEPT the five client-facing team
+--     RPCs the CLI actually calls (create_team, add_scope_member,
+--     remove_scope_member, set_scope_role, rotate_scope_key — the ONLY .rpc()
+--     names in src). NB: on today's schema the trigger/internal functions have
+--     no DIRECT authenticated grant (only PUBLIC), so authenticated loses them
+--     via the step-1 PUBLIC revoke; the explicit step-2 revoke is defensive.
+--
+-- `authenticated` KEEPS EXECUTE on the RLS helpers (is_member / is_org_member /
+--   scope_role / org_role / shares_scope / current_tier / effective_tier):
+--   an RLS policy expression is evaluated AS THE QUERYING ROLE, so Postgres
+--   checks function-call permission against `authenticated`, NOT the policy
+--   owner — even for a SECURITY DEFINER function. Revoking it breaks every
+--   membership-gated query with `permission denied for function is_member`.
+--   The helpers are already probe-hardened by the 2-arg oracle guard (0032),
+--   so keeping authenticated EXECUTE leaks nothing. Only PUBLIC + anon are
+--   revoked on them (anon never runs an authenticated RLS-gated query).
+--
+-- Why revoking the trigger functions from authenticated is SAFE:
+--   enforce_row_quota / guard_org_tier / guard_profile_tier / handle_new_user /
+--   maintain_usage / on_auth_user_provision_scope / rls_auto_enable /
+--   provision_personal_scope are fired by (event) triggers or called by other
+--   definer functions, never directly by a client. Triggers run the function in
+--   the definer context regardless of the caller's EXECUTE grant.
+--
+-- service_role / postgres keep EXECUTE throughout — the payment/admin/migration
+-- paths.
+--
+-- NOTE on existence guards: `rls_auto_enable()` is a platform-managed event-
+-- trigger function that exists on the hosted project but NOT in this migration
+-- set, so a bare `revoke ... on function public.rls_auto_enable()` would fail
+-- when applying migrations to a fresh DB (integration harness, preview branches).
+-- Each revoke is therefore guarded by `to_regprocedure(sig) is not null` so it
+-- silently skips a function absent from the target DB.
+
+-- ---------------------------------------------------------------------------
+-- 1. Revoke the blanket PUBLIC grant and anon on every flagged function.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  sig text;
+  all_sigs text[] := array[
+    -- client RPCs
+    'public.create_team(text)',
+    'public.add_scope_member(uuid, uuid, text)',
+    'public.remove_scope_member(uuid, uuid)',
+    'public.set_scope_role(uuid, uuid, text)',
+    'public.rotate_scope_key(uuid)',
+    -- RLS helpers
+    'public.is_member(uuid, uuid)',
+    'public.is_org_member(uuid, uuid)',
+    'public.scope_role(uuid, uuid)',
+    'public.org_role(uuid, uuid)',
+    'public.shares_scope(uuid, uuid)',
+    'public.current_tier()',
+    'public.effective_tier(uuid)',
+    -- trigger / internal definer functions
+    'public.enforce_row_quota()',
+    'public.guard_org_tier()',
+    'public.guard_profile_tier()',
+    'public.handle_new_user()',
+    'public.maintain_usage()',
+    'public.on_auth_user_provision_scope()',
+    'public.rls_auto_enable()',
+    'public.provision_personal_scope(uuid)'
+  ];
+begin
+  foreach sig in array all_sigs loop
+    if to_regprocedure(sig) is not null then
+      execute format('revoke all on function %s from public', sig);
+      execute format('revoke all on function %s from anon', sig);
+    end if;
+  end loop;
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 2. Belt-and-suspenders: explicitly revoke `authenticated` on the trigger /
+--    internal functions. On the current schema these have no DIRECT
+--    authenticated grant (authenticated only ever reached them via PUBLIC,
+--    already revoked in step 1), so this is a no-op today — it exists so a
+--    future accidental `grant ... to authenticated` on one of these cannot
+--    silently re-expose it via /rpc. (RLS helpers + client RPCs keep
+--    authenticated — see header.)
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  sig text;
+  trigger_sigs text[] := array[
+    'public.enforce_row_quota()',
+    'public.guard_org_tier()',
+    'public.guard_profile_tier()',
+    'public.handle_new_user()',
+    'public.maintain_usage()',
+    'public.on_auth_user_provision_scope()',
+    'public.rls_auto_enable()',
+    'public.provision_personal_scope(uuid)'
+  ];
+begin
+  foreach sig in array trigger_sigs loop
+    if to_regprocedure(sig) is not null then
+      execute format('revoke all on function %s from authenticated', sig);
+    end if;
+  end loop;
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 3. Re-affirm `authenticated` EXECUTE on the five client-facing team RPCs
+--    (idempotent — they already hold it; explicit so intent is self-evident
+--    and a future default-privilege change can't silently drop them).
+-- ---------------------------------------------------------------------------
+grant execute on function public.create_team(text)                        to authenticated;
+grant execute on function public.add_scope_member(uuid, uuid, text)       to authenticated;
+grant execute on function public.remove_scope_member(uuid, uuid)          to authenticated;
+grant execute on function public.set_scope_role(uuid, uuid, text)         to authenticated;
+grant execute on function public.rotate_scope_key(uuid)                   to authenticated;


### PR DESCRIPTION
## Summary
Fixes the 40 `{anon,authenticated}_security_definer_function_executable` **security-advisor** warnings.

**Root cause:** Postgres grants `EXECUTE` to `PUBLIC` by default at `CREATE FUNCTION`, and PostgREST exposes any executable function at `/rest/v1/rpc/<name>`. So `anon` and `authenticated` (inheriting from `PUBLIC`) could invoke **every** SECURITY DEFINER function directly.

## Change — migration 0039
Revokes the blanket grant, keeping only what's needed:
- **PUBLIC + anon**: revoked on all 20 functions.
- **authenticated**: **kept** on the 5 client RPCs the CLI calls (`create_team`, `add_scope_member`, `remove_scope_member`, `set_scope_role`, `rotate_scope_key`) and on the 7 RLS helpers (`is_member`, `is_org_member`, `scope_role`, `org_role`, `shares_scope`, `current_tier`, `effective_tier`); **revoked** on the 8 trigger/internal functions (`enforce_row_quota`, `guard_org_tier`, `guard_profile_tier`, `handle_new_user`, `maintain_usage`, `on_auth_user_provision_scope`, `rls_auto_enable`, `provision_personal_scope`).
- `service_role` / `postgres` keep EXECUTE (admin/payment/migration paths).

## ⚠️ Correctness note (caught by integration tests)
My first cut also revoked `authenticated` on the RLS helpers — **that broke RLS**: an RLS policy expression is evaluated **as the querying role**, so a SECURITY DEFINER helper referenced in a policy still requires the *caller* to hold EXECUTE. Revoking it produced `permission denied for function is_member` on every membership-gated query. The helpers therefore keep `authenticated` EXECUTE (already probe-hardened by the 2-arg oracle guard #1286/0032, so nothing leaks). Only functions never referenced in a policy and never called via `/rpc` lose `authenticated`.

## Robustness
Each revoke is guarded by `to_regprocedure(sig) is not null`, so a function absent from the migration set is silently skipped — `rls_auto_enable` is a platform-managed **event-trigger** function present only on the hosted project, not in `supabase/migrations`.

## Verification (real Postgres 16, Docker)
- New assertions (via `pg_proc.proacl`/`aclexplode`): PUBLIC+anon hold no EXECUTE on any of the 20; authenticated keeps it on RPCs+helpers; authenticated loses it on the triggers.
- Full regression across the RLS surface — `sync-security` (97), `sync-membership-rls` (7), `sync-write-gate` (6), `sync-orgs` (11), `sync-team-lifecycle` (10), `sync-quota-membership` (4), `sync-scope-rotation` (4), `sync-identity-scopekeys` (9), `team` (2): all pass. These exercise membership-gated reads (helpers), the team RPCs end-to-end, and trigger firing (quota/provisioning).
- typecheck / format / lint clean.

## Scope note
Supabase advisor cleanup series (after #1333 initplan, #1335 search_path, #1337 permissive-policy). Remaining: info-level `unused_index` (false positives — pro-table pull-cursor indexes, unused only pre-GA) and `rls_enabled_no_policy` on server-internal `sync_config`/`sync_eviction_budget` (RLS-on-no-policy = deny-all-to-clients, intentional) — to be documented, not code-changed. Plus the `auth_leaked_password_protection` toggle (dashboard setting, not a migration).