### PR TITLE
fix(supabase): drop unused idx_identity_pub_updated + document remaining advisors

### DIFF
--- a/packages/gateway/test/sync-identity-scopekeys.integration.test.ts
+++ b/packages/gateway/test/sync-identity-scopekeys.integration.test.ts
@@ -137,6 +137,21 @@ describe.skipIf(gate())(
       ]);
     });
 
+    it("identity_pub: the unused updated_at index is dropped (advisor 0040)", async () => {
+      // identity_pub is publish-only (upsert by user_id, read by exact user_id),
+      // never scanned by updated_at, so 0040 dropped idx_identity_pub_updated.
+      const rows = await h.asService((c) =>
+        c
+          .query(
+            `select indexname from pg_indexes
+              where schemaname = 'public' and tablename = 'identity_pub'`,
+          )
+          .then((r) => r.rows as Array<{ indexname: string }>),
+      );
+      const names = rows.map((r) => r.indexname);
+      expect(names).not.toContain("idx_identity_pub_updated");
+    });
+
     it("identity_pub: an oversized public key is rejected (anti-abuse cap)", async () => {
       const a = await h.createUser();
       // base64 of 512 raw bytes is ~684 chars > the 512-char text cap → rejected.

--- a/supabase/migrations/0040_drop_unused_identity_pub_index.sql
+++ b/supabase/migrations/0040_drop_unused_identity_pub_index.sql
@@ -1,0 +1,21 @@
+-- 0040_drop_unused_identity_pub_index.sql
+-- Performance advisor (unused_index): drop idx_identity_pub_updated.
+--
+-- identity_pub is a publish-only directory: rows are written via direct upsert
+-- keyed by user_id, and read only by exact user_id (own row + co-members'
+-- pubkeys via RLS). It is NOT a synced pull table — nothing scans it by
+-- updated_at, so the (updated_at) index added in 0025 has never been used and
+-- only costs write amplification. Drop it.
+--
+-- The three OTHER indexes the advisor flags are kept deliberately — they are
+-- load-bearing once the relevant feature sees traffic, and are "unused" only
+-- because those paths are pre-GA / low-volume:
+--   * idx_distillations_scope_updated, idx_temporal_messages_scope_updated —
+--     the (scope_id, updated_at) pull-cursor keyset indexes for the pro tables
+--     (sync isn't GA yet).
+--   * idx_scopes_org — the org_id FK-lookup index (teams just landed).
+--
+-- The updated_at BEFORE-UPDATE trigger on identity_pub is unaffected (it stamps
+-- the column; it does not need an index on it).
+
+drop index if exists public.idx_identity_pub_updated;


### PR DESCRIPTION
## Summary
Addresses the last actionable Supabase advisor item — the `unused_index` finding on `idx_identity_pub_updated` — and documents why the rest are intentional.

## Change — migration 0040
Drops `idx_identity_pub_updated`. `identity_pub` is a **publish-only** directory: rows are upserted by `user_id` and read only by exact `user_id` (own row + co-members' pubkeys via RLS). It is **not** a synced pull table, so nothing ever scans it by `updated_at` — the index from 0025 has never been used and only adds write amplification. The `updated_at` BEFORE-UPDATE trigger is unaffected (it stamps the column; it doesn't need an index).

## Deliberately NOT changed
- **The other 3 `unused_index` findings are kept** — load-bearing once their feature sees traffic, "unused" only because those paths are pre-GA/low-volume:
  - `idx_distillations_scope_updated`, `idx_temporal_messages_scope_updated` — `(scope_id, updated_at)` pull-cursor keyset indexes for the pro tables (sync not GA).
  - `idx_scopes_org` — org_id FK-lookup index (teams just landed).
- **`rls_enabled_no_policy` on `sync_config` / `sync_eviction_budget`** — intentional deny-all posture on server-internal tables (RLS-on-no-policy = clients can't touch them; grants also revoked at 0013:72; the security-definer trigger bypasses RLS). Adding a policy would be *less* safe.
- **`auth_leaked_password_protection` (HaveIBeenPwned)** — requires a Supabase **Pro** plan (Management API returns HTTP 402 on the free tier); not code-actionable. (This project primarily authenticates via email-OTP / GitHub OAuth; escrow passphrases use client-side Argon2id, separate from Supabase Auth passwords.)

## Verification (real Postgres 16, Docker)
- New assertion: `idx_identity_pub_updated` is absent after 0040.
- `sync-identity-scopekeys`: 10 tests pass (publish/read/co-member/cap/forge).
- typecheck / format / lint clean.

## Advisor cleanup series — status
This completes the actionable set: #1333 (initplan, 30), #1335 (search_path, 5), #1337 (permissive-policy, 6), #1338 (definer EXECUTE, 40), #1340 (this — unused index, 1). Remaining advisor entries are the intentional/plan-gated items documented above.