### PR TITLE
feat(sync): encrypt entity-graph content columns on the wire (C-4, #825)

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -387,167 +387,35 @@
 
 ### Preference
 
-<!-- lore:019f61b7-c480-728d-931d-365140e3eb3a -->
-* **Always adds required fields and tests for new schema changes**: When making schema changes, the user consistently adds required fields to the relevant types and ensures that all construction sites are updated to include these new fields with default values (e.g., 0). The user also adds tests to verify the round-trip persistence of these new fields, often strengthening existing tests to cover the updated schema. This behavior is observed across multiple sessions, including when adding \`inputTokens\` and \`outputTokens\` fields to \`SessionCostSnapshot\` type.
+<!-- lore:019f6526-fa79-7e51-8e5d-073c6d156bb9 -->
+* **Always decrypts ciphertext before passing to resolvers**: The user consistently decrypts ciphertext before passing it to resolvers, ensuring that sensitive data is handled securely and never stored or transmitted in its encrypted form. This pattern is observed across multiple coding sessions, where the user explicitly states their preference for decrypting content before passing it to resolvers, and the code changes reflect this behavior.
 
-<!-- lore:019ee4d4-bdd2-7641-b523-34aa917fdb48 -->
-* **Always document directives with 🔴 markers and preserve them across sessions via written plans**: 🔴 markers = hard requirements (non-negotiable constraints). 🟡 = observations. Capture 🔴 invariants in persistent artifacts (\`.opencode/plans/\`). Act as skeptical adversarial staff engineer; proactively surface invariant violations. Key recurring 🔴 invariants: (1) non-2xx warmup result must be NEUTRAL — never increments/trips breaker; (2) per-bucket isolation — one bad bucket must never disable warming for other sessions; (3) legitimately cold re-warm (\`cacheLikelyAlive===false\`) must NOT count as failure. Code reviews: adversarial, per-finding verdicts (BLOCKER/SHOULD-FIX/NIT), overall verdict (MERGE/SHIP-WITH-FOLLOWUPS/NEEDS-WORK), written reports to /tmp/opencode/, READ-ONLY on working repo. 🔴 Fix known issues immediately rather than defer — 'I'd just try to fix it instead of defer since we \_know\_ there's an issue.'
+<!-- lore:019f64f3-5674-7a81-8767-25e8f8e92cd8 -->
+* **Always evaluates competitor memory backends critically**: The user consistently expresses skepticism and criticism towards competitor memory backends, stating that they 'never actually work.' This pattern is observed in multiple sessions where the user discusses and evaluates various memory backend solutions, including ByteRover, Mem0, Zep, Hindsight, HonCho, and Chronos. The user appears to scrutinize these competitors' performance, often citing specific issues such as inflated accuracy scores or limited evaluation metrics. When exploring these competitors, the user focuses on their methodologies, architectures, and results, indicating a thorough and critical assessment of their capabilities.
 
-<!-- lore:019f615d-78a2-7082-9d85-2da2085baec7 -->
-* **Always emphasizes cost data locality and confidentiality**: The user consistently emphasizes that cost data should be kept device-local and not synced remotely. They stress that input token counts are never stored, retained, or written to disk.
+<!-- lore:019f62d0-62d8-795b-9117-4d96963b620f -->
+* **Always focus on sync and coordination problems**: The user consistently inquires about and addresses issues related to synchronization, coordination, and conflict resolution in the context of team-sync and data sharing. They explore features such as shared scope, review gates, and invariant-conflict detection to ensure data consistency and resolve coordination problems.
 
-<!-- lore:019f61a8-d774-74d0-a955-bc05a3fd75ac -->
-* **Always Enforce Read-Only Review with Adversarial Correctness Checks**: The user consistently initiates read-only reviews with adversarial correctness checks, emphasizing the importance of not modifying tracked files in the working repository. The user mandates the use of throwaway git worktrees for mutation testing and verifies the main tree's integrity via sha256sum or similar methods. The user provides specific scrutiny items, commands to run, and report exit codes, indicating a preference for thorough and meticulous review processes.
+<!-- lore:019f6507-4973-7c69-b851-a6b9e6670ad8 -->
+* **Always prioritize pull-side encryption mode and never store ciphertext as local content**: The user consistently emphasizes the importance of pull-side encryption and ensuring that ciphertext is never stored as local content. This is evident in their repeated statements and code reviews across multiple sessions, where they stress the need for a 'pull-side encryption mode' and the risk of storing ciphertext locally. The user also provides specific scrutiny points and code changes to implement this behavior, indicating a strong preference for this approach.
 
-<!-- lore:019edc8f-7bdd-73a0-a374-a700828d04be -->
-* **Always exclude .lore.md from PR diffs by restoring origin/main version before branching**: Always exclude .lore.md from PR diffs by restoring origin/main version before branching.
-
-<!-- lore:019f6195-22bf-7b4f-9a91-b17b0386ef19 -->
-* **Always normalize to MIGRATIONS**: Always normalize to MIGRATIONS.
-
-<!-- lore:019f61ad-2310-7297-90b0-76b3411831c8 -->
-* **Always pin WORKER\_VERSION forward (≥ 2**: User stated always pin WORKER\_VERSION forward (≥ 2.
-
-<!-- lore:019f6293-3795-7f19-b029-bbe2d7622d78 -->
-* **Always prefers specific conditions and handling for encryption, errors, and RLS policies**: The user consistently states specific conditions and handling for encryption, errors, and RLS policies. The user always prefers certain conditions to be true, such as 'always true — byte-identical to the' and 'never storing ciphertext as local content'. The user also consistently requests review of advisor findings and suggested fixes. Additionally, the user handles errors by recording and advancing past problematic entries, pausing tables, and logging messages. The user also prefers specific handling for RLS policies, such as wrapping 'auth.uid()' in '(select auth.uid())'. These observations suggest that the user has specific preferences for how to handle encryption, errors, and RLS policies.
-
-<!-- lore:019f6155-8e35-71d9-acb9-738b31c2f1b3 -->
-* **Always prefers specific content formats and array handling**: The user consistently expresses preferences for handling content in specific formats, particularly when it comes to arrays and their structure. They emphasize the importance of preserving the integrity of arrays, especially in the context of OpenAI conversation breakpoints and content translation. The user tends to specify how to handle arrays, such as always annotating the last block of a block array, and ensuring that non-text sub-blocks survive the gateway round-trip losslessly. They also express a preference for using array forms when caching is on or when non-text parts are present, and for keeping text-only content as plain strings when caching is off.
-
-<!-- lore:019f628e-4546-7afa-b5b4-775df32348dc -->
-* **Always Request Adversarial Correctness Reviews for Specific PRs**: The user consistently requests adversarial correctness reviews for specific PRs, focusing on logic and correctness rather than security. These reviews are typically read-only, and the user provides detailed guidelines, including commands to run for verification, and specifies the output format. The user also often designates these reviews as mandatory pre-merge gates and enforces a read-only constraint, allowing only throwaway git worktrees for mutation testing.
-
-<!-- lore:019f62a2-0acf-7340-9a70-15aec294da42 -->
-* **Always requests adversarial reviews for non-trivial PRs**: The user consistently requests adversarial reviews for non-trivial PRs, ensuring that changes are thoroughly vetted before merge. This is evident from instances where the user explicitly instructs the assistant to perform adversarial reviews, such as for PRs #1301, #1302, and #1303. The user also checks if such reviews were performed retrospectively, indicating a strong preference for this level of scrutiny.
-
-<!-- lore:019f619c-da1d-7044-af1b-0421b4299034 -->
-* **Always requests detailed information before implementing persistence changes**: The user consistently requests detailed information about data flow, storage granularity, and existing tests before implementing changes related to persistence of token buckets or cost data. This includes asking for specific details about database schema, migration mechanisms, and test coverage. The user also tends to instruct the assistant to build solutions without opening an issue, and to focus on persisting raw per-turn token buckets for future cost-accounting accuracy.
-
-<!-- lore:019f60a6-ddf0-73ff-998a-9ce2d9119c58 -->
-* **Always requests tests and verification for each fix**: User consistently requests tests and verification for each fix.
-
-<!-- lore:019f5dd5-5f6c-7c02-9aff-80126e624891 -->
-* **Always rides on the WHOLESALE channel out of the EMEA region**: User stated always rides on the WHOLESALE channel out of the EMEA region.
-
-<!-- lore:019ef947-5487-71bc-bbb9-7b03b4f768b0 -->
-* **Always run full CI on main/release push — dorny/paths-filter only for PRs**: 🔴 Directive (June 24 2026, seen 34+ prior sessions): always run full CI on main/release push events. \`dorny/paths-filter\` skip logic only applies to PRs. Workflow bugs 'should never slip through regardless of which files changed.' Enforced in \`ci.yml\` via a 'Force full CI on main/release push' step (id: \`force\`) that sets \`code=true\` unconditionally on \`push\` events via \`echo "code=true" >> "$GITHUB\_OUTPUT"\`. The \`actionlint\` job runs unconditionally (no \`needs\`/\`if\`) for the same reason.
-
-<!-- lore:019ef371-d1ab-791d-b04a-22f50f4e9013 -->
-* **Always scope fix tasks strictly to test fixtures, never touching src files**: When the user assigns a task to fix failing tests after a schema/API migration, they explicitly constrain the work to \`packages/\*/test/\` directories only, with an explicit prohibition on modifying \`packages/\*/src/\` files. The user expects the assistant to identify all broken raw SQL or fixture code in test files and update only those, leaving production source code untouched. This pattern applies whenever a schema change has already been implemented in src and the remaining work is purely test-side adaptation.
-
-<!-- lore:019f6081-05fc-7564-be77-a9820980d5bf -->
-* **Always scrutinize code changes for cache stability and content shape**: The user consistently scrutinizes code changes related to caching and content shape, particularly when working with OpenAI content. They examine changes to ensure stability across turns, verify test coverage, and check for correct serialization of message content. The user also reviews diffs, verifies type checks and test suites, and mutation-tests changes to ensure correctness.
-
-<!-- lore:019f45d1-3ba6-7ea4-8a85-e9aebfe7f938 -->
-* **Always snapshot via VACUUM INTO before destructive DB operations**: Always snapshot via VACUUM INTO before destructive DB operations. This is enforced in cmdRecover and similar commands.
-
-<!-- lore:019f6293-097f-7f6a-a6e2-cf5a79a1db09 -->
-* **Always true — byte-identical to the**: User stated always true — byte-identical to the.
-
-<!-- lore:019f6033-f04d-7158-a3d1-cc3f4814e7a3 -->
-* **Always write tests alongside implementation**: Behavioral pattern detected across 25 sessions (action: requested-tests). The user consistently demonstrates this behavior.
-
-<!-- lore:019ee640-0ad2-7a98-87f8-111898a4a84d -->
-* **ast-grep: always use stopBy: end for relational rules**: Always use \`stopBy: end\` for relational rules (\`inside\`, \`has\`) in ast-grep to ensure complete traversal. Stated as a firm rule unless there is a specific reason not to. ast-grep skill at \`/home/byk/.claude/skills/ast-grep\`. Key principles: start simple (pattern → kind → relational → composite); use \`--debug-query=cst\` to inspect AST; escape metavariables in inline rules with \`\\$VAR\`. Prefer \`ast-grep\` over \`rg\` for all structural/syntactic searches (🔴 directive, June 29 2026).
-
-<!-- lore:019ef63e-ffa5-740c-b8ab-ace77eae9232 -->
-* **Avoids execution yet**: user does not want execution yet,
-
-<!-- lore:019effdc-765b-7dc0-912f-69bb716352f4 -->
-* **Blog #663 voice: human but serious — no slang, emoji, or self-deprecating footnotes**: 🔴 Directive (June 25 2026): Lore.AI blog voice is human but serious, not cheeky. Contractions OK; rhetorical beats OK; direct address OK. No slang, emoji, self-deprecating footnotes, or cheeky headers. Use 'we' for Lore voice. Em-dashes are an AI tell — remove all (0 remaining in rev 9). Applies to blog post #663 and any future Lore positioning copy.
-
-<!-- lore:019eff04-9cff-74c1-a8d2-45d12e194d39 -->
-* **Blog copy: Fair Source named proudly with fair.io link**: 🔴 Directive: if licensing is mentioned in Lore blog/positioning copy, name Fair Source proudly by name and link to fair.io. Use it as a trust signal in the local-first paragraph, not a disclaimer. Consistent with \[\[019efe86-ad54-7ad3-868b-c3a76af9d306]] (FSL-1.1-Apache-2.0 license).
-
-<!-- lore:019eff04-9d31-7864-811d-39dbb8803da3 -->
-* **Blog copy: feature-dump bullets compressed to one consequences-framed sentence**: 🔴 Directive: compress platform feature-dump bullets (cache/extract/patterns/track-spend) to one sentence framed as consequences, not the argument. User confirmed: 'Like this.' — explicit agreement with reviewer suggestion to avoid the 'ah, the pitch' reaction from all three reader personas.
-
-<!-- lore:019eff04-9d5d-7934-b32b-fa411111b211 -->
-* **Blog copy: preferred vivid image is 'genius a minute ago' / amnesia — not chopping-block**: 🔴 Directive: the single keeper vivid image for Lore positioning copy is 'genius a minute ago, amnesic now' (or 'lobotomy' variant). The chopping-block scene is cut. Exact confirmed phrases: 'genius a minute ago,' / 'never decides what leaves it.' / 'never lift a finger.' / 'never the hard part.' / 'never gets a vote'.
+<!-- lore:019f62b8-fbc2-7c47-bfe1-486851ff478f -->
+* **Always Prioritizes Encryption and Security**: The user consistently emphasizes the importance of encryption and security in data handling. They prioritize ensuring that sensitive data, such as content and title columns in the knowledge table, are encrypted and protected from unauthorized access. The user also focuses on ensuring that content hashes are computed over plaintext, not ciphertext, to maintain data integrity and prevent misclassification. Additionally, the user requests reviews of advisor findings and suggested fixes to ensure the security and correctness of the code.
 
 <!-- lore:019eff04-9cca-712f-bdb7-535292cfc96b -->
 * **Blog tone: category-not-competitor thesis — gentle, not dunking**: 🔴 Directive: convey the 'new category being invented' thesis gently — acknowledge the existing category isn't enough and that something new is being built, without dunking on existing tools. Generous close required: 'a good store is genuinely worth having.'
 
-<!-- lore:019eff04-9c94-773c-b2ed-dca9ee730f6f -->
-* **Blog tone: manual note-taking critique — respect skilled practitioners, highlight focus cost**: 🔴 Directive: when critiquing manual note-taking in Lore positioning copy, never imply incompetence ('you're bad at it anyway'). Acknowledge skilled practitioners exist; frame the cost as time and focus/context-switch overhead: 'The cost was never that you're bad at it. It's that the filing keeps pulling your focus off the thing you were actually trying to do.'
-
-<!-- lore:019ee673-63cb-7a6d-9b3b-844fdab3eaff -->
-* **Connection timeout: 10s is generous enough — do not increase; capture aborts instead of raw timeouts**: Connection timeout: 10s is generous — do not increase. Raw connect timeouts are not actionable for Sentry capture. Prefer capturing abort events with loop-lag/RSS context instead.
-
-<!-- lore:019efae0-89c8-7ac9-a9ec-aba6ed3c2d33 -->
-* **Convention: X') + patterns in pattern-extract**: our convention is X') + patterns in pattern-extract.
-
-<!-- lore:019f5e6f-06c8-7996-a6df-00a6a3d77d2e -->
-* **Disjoint input tokens for OpenAI**: Always compute inputTokens = prompt\_tokens - cached\_tokens - cache\_write\_tokens (clamped at 0) for non-stream Chat Completions site.
-
-<!-- lore:019ee6ae-7cf6-7fdb-8959-36949bffa201 -->
-* **Embedding OOM adaptive cap: decrease factor ≥ 0.7, no additive increase**: Burak Yigit Kaya chose decrease factor ≥ 0.7 for embedding OOM adaptive cap — gentler than 0.5 (which quarters attention memory per step). No additive increase — upward adaptation handled by memory-aware initializer re-evaluating freemem on each respawn. 0.8 noted as a tuning option. Pre-truncation must use free-memory-adjusted value (e.g., \`adaptiveLocalMaxTokens()\` derived from \`os.freemem()\` + O(L²) attention model) — hard-coded token limits like \`LOCAL\_MAX\_CHARS = 16384\` explicitly rejected. Coverage stats in \`runStartupBackfill()\` must always log to stderr so the problem is visible. These are locked decisions for \`fix/embedding-oom-adaptive-cap\`.
-
 <!-- lore:019f60a4-db86-7ece-bc14-2d3c6d22502a -->
 * **Follow the established git workflow (branch, PR, review)**: Behavioral pattern detected across 119 sessions (action: enforced-workflow). The user consistently demonstrates this behavior.
 
-<!-- lore:019ef69c-9430-7808-a25f-a20edeaf14f5 -->
-* **Make sure to address the seer comment there (re-emphasized via system-reminder directive — overrides prior state**: User stated make sure to address the seer comment there (re-emphasized via system-reminder directive — overrides prior state,
+<!-- lore:019f650e-1593-72e3-8c34-fdbf17c32560 -->
+* **Never a skip/conflict**: Never a skip/conflict: User stated never a skip/conflict.
 
-<!-- lore:019eff03-77c0-7db3-ac9c-4cc105952816 -->
-* **Never evaluate alternatives in this project context**: 🔴 Directive (June 25 2026): never evaluate alternatives. Applies to assistant behavior when working on the loreai/opencode-lore project.
+<!-- lore:019f62dd-d5e1-72a7-aa48-c30e7c89a996 -->
+* **Never called via RPC**: Never call via RPC. This is a security restriction to prevent unauthorized access.
 
-<!-- lore:019f6293-099a-7614-967c-d57744667c63 -->
-* **Never storing ciphertext as local content**: User stated never storing ciphertext as content.
+<!-- lore:019f62e7-b68c-7a51-87d5-d0771009efc6 -->
+* **Never penalizes (neutral) 2ms**: Never penalize entries with latency over 2ms.
 
-<!-- lore:019f615c-06f5-7348-bd33-351ea4584e87 -->
-* **Never tombstone the shared remote**: Never tombstone the shared remote.
-
-<!-- lore:019ef387-4b17-77d7-a76d-062269f0214b -->
-* **Never weaken assertions or change expected values to make a test pass**: 🔴 Directive (seen 23+ sessions): never weaken/delete an assertion or change an expected value to make a test pass. When a test fails due to a schema change, fix the test setup (INSERT helpers, raw SQL, helper functions) to match the new schema — never adjust the assertion target. Example: integrity.test.ts duplicate detection fixed by adding knowledge\_meta rows to raw INSERTs, not by changing \`duplicates.length >= 1\` assertion.
-
-<!-- lore:019f22c5-89b8-7d9a-88a2-3c01c2685f20 -->
-* **Prefers a learned/persisted cap when current free memory is close over learn-time value (via reconcileEmbedCap)**: prefers a learned/persisted cap when current free memory is close to learn-time value (via reconcileEmbedCap),
-
-<!-- lore:019ef655-bc07-7aba-80c5-bb5ca9216d47 -->
-* **Prefers cool-bust only when compaction is STRICTLY cheaper — a tie means compaction buys nothing (e.g. compressed === full), so default over cool-full-write and never claim a pointless bust**: prefer cool-bust only when compaction is STRICTLY cheaper — a tie means compaction buys nothing (e.g. compressed === full), so default to cool-full-write and never claim a pointless bust.
-
-<!-- lore:019f03bd-7047-7c42-b440-2a59b788e769 -->
-* **Prefers durable pins over mid-session recomputation**: Prefer durable pins over mid-session recomputation.
-
-<!-- lore:019ef48a-ac2c-7800-a9dd-a771194a323b -->
-* **Prefers explicit over implicit**: prefer explicit over implicit.
-
-<!-- lore:019f13ff-bcfb-74d6-b29f-6dcdc2e39bc4 -->
-* **Prefers LORE\_REMOTE\_URL, prefers LORE\_GATEWAY\_URL over default ports**: prefers LORE\_REMOTE\_URL, prefers LORE\_GATEWAY\_URL over default ports,
-
-<!-- lore:019f29cc-c6ae-7a94-8376-3efd3090b7e3 -->
-* **Prefers minimum necessary, then use question tool for ambiguities), 2. Design (up over 1 agent**: prefer minimum necessary, then use question tool for ambiguities), 2. Design (up to 1 agent,
-
-<!-- lore:019f2031-a1b0-72cd-b70d-f68747812fd1 -->
-* **Prefers persisted.avoidedCompactions/avoidedCompactionCost over simulation fallback (sessionCompactionCost) when persisted**: prefers persisted.avoidedCompactions/avoidedCompactionCost over simulation fallback (sessionCompactionCost) when persisted.
-
-<!-- lore:019efad5-e983-7270-a61a-f0fca14983c6 -->
-* **Prefers pin over cache**: prefers pin over cache,
-
-<!-- lore:019f145e-ee7e-7832-86b1-36d87298bdbe -->
-* **Prefers recall over assuming you don't have the information**: prefer recall over assuming you don't have the information.
-
-<!-- lore:019ef4be-ac81-7964-bf08-f24d7c8e2ad5 -->
-* **Prefers UPDATES over CREATES section at line 390 of prompt**: PREFER UPDATES OVER CREATES section at line 390 of prompt.
-
-<!-- lore:019f0103-160f-77b8-8e3a-f84034642067 -->
-* **Prefers writing more tests over lowering the threshold or excluding files**: prefer writing more tests over lowering threshold or excluding files;
-
-<!-- lore:019eec4d-5e2b-7f16-8521-3ef10cc17d2d -->
-* **Protected content must never be stripped during context management**: 🔴 Directive (observed across 34+ sessions): content marked 'protected' must NEVER be stripped during compaction or context window management. Absolute invariant — no exceptions. Confirmed in architecture.md: 'The last 2 turns are always protected from stripping.' When implementing or modifying context compression, compaction, or eviction logic, always verify protected content survives all code paths. A stripping path that can remove protected content is a bug.
-
-<!-- lore:019ef676-61ff-7594-83e1-e3e1a1ff7a26 -->
-* **replicaId() must always read from live DB (KV) each call**: replicaId() reads from KV on every invocation — never caches the value. Test suite swaps DB between cases so cached replicaId would return stale device identity. User assertion: 'always read it from the live DB' and 'always reads from live DB'. This ensures each test case gets a fresh replica ID matching its isolated database.
-
-<!-- lore:019f6281-f936-7e6f-8c4c-ada4464b2dda -->
-* **Review code before committing**: Behavioral pattern detected across 82 sessions (action: requested-review). The user consistently demonstrates this behavior.
-
-<!-- lore:019efb32-23de-7867-8e02-e5e57d2a734b -->
-* **Ship bug fixes as separate sequential PRs per bug**: User directive (June 24–25 2026): when fixing multiple bugs or shipping a feature series, ship them as separate sequential PRs — one logical change per PR. Do not combine fixes into a single PR even if related. Enforced across: Bug 1 (PR #974), Bug 2 (PR #976), Bug 3 (PR #979), regressions (PR #982), #627 Phase 0 (PR #939), Phase 1 (PR #977), Phase 2 (PR #986), #911 (PR #988). Follow-up PRs for regressions introduced by a fix are also shipped as separate PRs, not folded back into the original.
-
-<!-- lore:019f6290-070f-7ee1-8e1a-df91bc12270a -->
-* **Use current live policy definitions as authoritative reference data**: Always use current live policy definitions as authoritative reference data.
-
-<!-- lore:019f17c2-11df-731b-b7b9-747b0e03eeb0 -->
-* **Uses local ONNX embeddings (default for recall vector search via sqlite-vec) — not only on explicit local embeddings provider selection**: user uses local ONNX embeddings (default for recall vector search via sqlite-vec) — not only on explicit local embeddings provider selection.
+<!-- lore:019f64f3-4326-79f4-88ff-b8bc01c50706 -->
+* **Never touch the user's real gateway/DB**: User stated never touch the user's real gateway/DB.

--- a/packages/core/src/sync-data.ts
+++ b/packages/core/src/sync-data.ts
@@ -338,6 +338,10 @@ export const SYNCED_TABLES: Record<SyncTier, SyncTableMeta[]> = {
       table: "entities",
       idColumns: ["id"],
       ftsTables: ["entities_fts"],
+      // C-4 (#825): the entity's human-readable name + metadata blob are PII
+      // (person/service/repo names, descriptions). Seal them on the wire like
+      // knowledge.content — decrypted locally so FTS + local reads are unchanged.
+      encryptedColumns: ["canonical_name", "metadata"],
       syncColumns: [
         "id",
         "project_id",
@@ -354,6 +358,12 @@ export const SYNCED_TABLES: Record<SyncTier, SyncTableMeta[]> = {
       table: "entity_aliases",
       idColumns: ["id"],
       ftsTables: ["entity_aliases_fts"],
+      // C-4 (#825): alias_value is PII (alternate names, emails, handles). Seal it.
+      // alias_type is a low-cardinality structural enum — left cleartext. The local
+      // UNIQUE(alias_type, alias_value) + convergence run on the DECRYPTED local
+      // row (applyRemote decrypts before upsert), and the remote has no UNIQUE on
+      // these columns, so encryption does not break dedup/convergence.
+      encryptedColumns: ["alias_value"],
       syncColumns: [
         "id",
         "entity_id",
@@ -367,6 +377,10 @@ export const SYNCED_TABLES: Record<SyncTier, SyncTableMeta[]> = {
       table: "entity_relations",
       idColumns: ["id"],
       ftsTables: [],
+      // C-4 (#825): relation label + metadata blob can carry PII. Seal them. The
+      // local UNIQUE(entity_a, entity_b, relation) + convergence run on the
+      // decrypted local row; the remote has no UNIQUE on relation.
+      encryptedColumns: ["relation", "metadata"],
       syncColumns: [
         "id",
         "entity_a",

--- a/packages/gateway/src/sync.ts
+++ b/packages/gateway/src/sync.ts
@@ -1004,12 +1004,25 @@ function handlePulledRowConstraint(
   // lower id wins on every device, so pull order can't leave devices divergent (#1217).
   // Falls through to the generic skip when there's no local collision / it's an orphan.
   if (isUniqueConstraintError(e)) {
+    // The resolver matches the remote row against LOCAL rows by their natural key
+    // (alias_type+alias_value / entity_a+entity_b+relation) — which is stored
+    // DECRYPTED locally. For an encrypted table the raw `remote` carries ciphertext
+    // in those columns, so we must decrypt a copy first or the lookup never matches
+    // and convergence silently fails (#1234/#1236 regression). `reapply` keeps using
+    // the raw `remote` (applyRemote re-decrypts internally). If decrypt can't proceed
+    // (locked / missing key), it throws EncryptedContentUnavailable → propagate so the
+    // whole table defers, exactly as the initial apply would have.
+    let resolveRow = remote;
+    if (meta.encryptedColumns?.length) {
+      resolveRow = stripSyncCols(remote);
+      decryptColumns(meta.table, rid, resolveRow, enc);
+    }
     const reapply = () => applyRemote(meta, remote, res, touchedFts, enc);
     if (
       (meta.table === "entity_aliases" &&
-        syncData.resolveAliasUniqueConflict(remote, reapply)) ||
+        syncData.resolveAliasUniqueConflict(resolveRow, reapply)) ||
       (meta.table === "entity_relations" &&
-        syncData.resolveRelationUniqueConflict(remote, reapply))
+        syncData.resolveRelationUniqueConflict(resolveRow, reapply))
     ) {
       res.conflicts++;
       return;
@@ -1163,7 +1176,14 @@ function applyRemote(
         stripSyncCols(remote, SCOPE_MEMBER_KEEP),
       );
     } else {
-      syncData.applyRemoteUpsert(meta.table, stripSyncCols(remote));
+      // Generic content tables (entities, entity_aliases, entity_relations, …).
+      // Use `decrypted` when the table has sealed columns (C-4) so the plaintext —
+      // not the pulled ciphertext — is stored locally; falls back to the stripped
+      // raw row for unencrypted tables.
+      syncData.applyRemoteUpsert(
+        meta.table,
+        decrypted ?? stripSyncCols(remote),
+      );
     }
     syncData.setSyncState(meta.table, rowId, {
       content_hash: remoteHash,

--- a/packages/gateway/test/sync-engine.integration.test.ts
+++ b/packages/gateway/test/sync-engine.integration.test.ts
@@ -678,6 +678,203 @@ describe.skipIf(SKIP)(
       expect((await pushOnce(client)).pushed).toBe(0);
     });
 
+    it("device-1 encrypts the entity graph → remote stores CIPHERTEXT → device-2 decrypts (C-4 entities)", async () => {
+      const NAME = "MiniMax Corp";
+      const META = JSON.stringify({ note: "a private description" });
+      const ALIAS = "founder@example.com";
+      const REL = "works_with";
+      const client = clientFor(uid);
+      const pid = ensureProject("/tmp/lore-engine-it");
+      const now = Date.now();
+
+      // --- Device 1: arm encryption, create an entity + alias + relation, push. ---
+      keystore.setPassphrase("correct horse battery", { params: FAST });
+      syncData.enableSync("basic");
+      db()
+        .query(
+          `INSERT INTO entities (id, project_id, entity_type, canonical_name, metadata, created_at, updated_at)
+           VALUES (?, ?, 'person', ?, ?, ?, ?)`,
+        )
+        .run("e1", pid, NAME, META, now, now);
+      db()
+        .query(
+          `INSERT INTO entities (id, project_id, entity_type, canonical_name, created_at, updated_at)
+           VALUES ('e2', ?, 'person', 'Other', ?, ?)`,
+        )
+        .run(pid, now, now);
+      db()
+        .query(
+          `INSERT INTO entity_aliases (id, entity_id, alias_type, alias_value, source, created_at)
+           VALUES ('a1', 'e1', 'email', ?, 'curator', ?)`,
+        )
+        .run(ALIAS, now);
+      db()
+        .query(
+          `INSERT INTO entity_relations (id, entity_a, entity_b, relation, metadata, source, created_at, updated_at)
+           VALUES ('r1', 'e1', 'e2', ?, ?, 'curator', ?, ?)`,
+        )
+        .run(REL, META, now, now);
+
+      await pushOnce(client);
+      await pushOnce(client); // flush the lazily-minted DEK (see knowledge test note)
+
+      // The remote MUST hold ciphertext for the sealed columns and CLEARTEXT for
+      // the structural ones (entity_type / alias_type / source).
+      const ent = await h.asUser(uid, (c) =>
+        c
+          .query(
+            "select entity_type, canonical_name, metadata from public.entities where id='e1'",
+          )
+          .then((x) => x.rows[0]),
+      );
+      expect(ent.entity_type).toBe("person"); // structural → cleartext
+      expect(ent.canonical_name).not.toBe(NAME);
+      expect(
+        crypto.isEnvelope(Buffer.from(ent.canonical_name as string, "base64")),
+      ).toBe(true);
+      expect(
+        crypto.isEnvelope(Buffer.from(ent.metadata as string, "base64")),
+      ).toBe(true);
+
+      const al = await h.asUser(uid, (c) =>
+        c
+          .query(
+            "select alias_type, alias_value, source from public.entity_aliases where id='a1'",
+          )
+          .then((x) => x.rows[0]),
+      );
+      expect(al.alias_type).toBe("email"); // structural → cleartext
+      expect(al.source).toBe("curator"); // provenance → cleartext
+      expect(al.alias_value).not.toBe(ALIAS);
+      expect(
+        crypto.isEnvelope(Buffer.from(al.alias_value as string, "base64")),
+      ).toBe(true);
+
+      const rel = await h.asUser(uid, (c) =>
+        c
+          .query(
+            "select relation, metadata, source from public.entity_relations where id='r1'",
+          )
+          .then((x) => x.rows[0]),
+      );
+      expect(rel.source).toBe("curator");
+      expect(rel.relation).not.toBe(REL);
+      expect(
+        crypto.isEnvelope(Buffer.from(rel.relation as string, "base64")),
+      ).toBe(true);
+      expect(
+        crypto.isEnvelope(Buffer.from(rel.metadata as string, "base64")),
+      ).toBe(true);
+
+      // --- Device 2: fresh device, same account. Wipe all local state. ---
+      db().exec(
+        "DELETE FROM account_identity; DELETE FROM account_escrow; DELETE FROM scope_keys; DELETE FROM entity_relations; DELETE FROM entity_aliases; DELETE FROM entities; DELETE FROM sync_state; DELETE FROM sync_outbox",
+      );
+      keystore.lock();
+      for (const m of syncData.syncedTables("basic")) {
+        setKV(
+          `sync.pull.${m.table}`,
+          m.pullOnly ? `${Date.now() + 31_536_000_000}|` : "0|",
+        );
+        setKV(`sync.push.${m.table}`, "0");
+      }
+
+      // First pull → escrow/scope_keys arrive first → "locked" → entity tables deferred.
+      await pullOnce(client);
+      expect(keystore.encryptionState()).toBe("locked");
+      expect(syncData.getRowById("entities", "e1")).toBeNull();
+
+      // Unlock → "on" → second pull decrypts the whole graph back to plaintext.
+      expect(keystore.unlockWithPassphrase("correct horse battery")).toBe(true);
+      await pullOnce(client);
+      expect(syncData.getRowById("entities", "e1")?.canonical_name).toBe(NAME);
+      expect(syncData.getRowById("entities", "e1")?.metadata).toBe(META);
+      expect(syncData.getRowById("entity_aliases", "a1")?.alias_value).toBe(
+        ALIAS,
+      );
+      expect(syncData.getRowById("entity_relations", "r1")?.relation).toBe(REL);
+      expect(syncData.getRowById("entity_relations", "r1")?.metadata).toBe(
+        META,
+      );
+
+      // No ping-pong: content_hash is over plaintext, pulled under capture-suppression.
+      expect((await pushOnce(client)).pushed).toBe(0);
+    });
+
+    it("converges an encrypted alias UNIQUE collision across devices (#1234 under C-4)", async () => {
+      // Two devices independently mint the SAME (alias_type, alias_value) under
+      // different ids; both reach the remote sealed (different ciphertext, same
+      // plaintext). On pull the second collides with the local UNIQUE(alias_type,
+      // alias_value) — the resolver must see the DECRYPTED value to match the local
+      // row and converge (lower id wins). Regression: it was fed the raw ciphertext,
+      // so the local lookup never matched and devices stayed divergent.
+      const VALUE = "shared@example.com";
+      const client = clientFor(uid);
+      const pid = ensureProject("/tmp/lore-engine-it");
+      const now = Date.now();
+      keystore.setPassphrase("correct horse battery", { params: FAST });
+      syncData.enableSync("basic");
+      db()
+        .query(
+          "INSERT INTO entities (id, project_id, entity_type, canonical_name, created_at, updated_at) VALUES ('e1', ?, 'person', 'E', ?, ?)",
+        )
+        .run(pid, now, now);
+
+      // Push the HIGHER-id alias ("a-2") FIRST so it gets the earlier server
+      // updated_at and is therefore PULLED first (applied cleanly). This forces the
+      // resolver's delete-and-reapply path: the lower-id winner ("a-1") arrives
+      // second, collides, and must DELETE the already-applied a-2 to converge. (If
+      // the resolver were fed ciphertext, its local lookup would miss, it would skip
+      // a-1, and the wrong row a-2 would survive — the discriminating case.)
+      db()
+        .query(
+          "INSERT INTO entity_aliases (id, entity_id, alias_type, alias_value, created_at) VALUES ('a-2', 'e1', 'email', ?, ?)",
+        )
+        .run(VALUE, now);
+      await pushOnce(client);
+      await pushOnce(client); // flush the lazily-minted DEK
+
+      // Swap in the LOWER-id row ("a-1") with the SAME (type,value); push it so BOTH
+      // exist on the remote (distinct ciphertext) with a-1's updated_at LATER.
+      syncData.withApplying(() =>
+        db().query("DELETE FROM entity_aliases WHERE id='a-2'").run(),
+      );
+      db()
+        .query(
+          "INSERT INTO entity_aliases (id, entity_id, alias_type, alias_value, created_at) VALUES ('a-1', 'e1', 'email', ?, ?)",
+        )
+        .run(VALUE, now + 1);
+      await pushOnce(client);
+      const remoteCount = await h.asUser(uid, (c) =>
+        c
+          .query("select count(*)::int as n from public.entity_aliases")
+          .then((x) => x.rows[0].n),
+      );
+      expect(remoteCount).toBe(2); // both a-lo and a-hi on the remote (sealed)
+
+      // Fresh device: pull BOTH. Whichever applies first, the second hits the local
+      // UNIQUE → resolver decrypts, matches on plaintext, converges to the lower id.
+      db().exec(
+        "DELETE FROM entity_aliases; DELETE FROM sync_state; DELETE FROM sync_outbox",
+      );
+      for (const m of syncData.syncedTables("basic")) {
+        setKV(
+          `sync.pull.${m.table}`,
+          m.pullOnly ? `${now + 31_536_000_000}|` : "0|",
+        );
+        setKV(`sync.push.${m.table}`, "0");
+      }
+      await pullOnce(client);
+
+      // Exactly ONE alias survives locally, and it's the lower id (a-1), decrypted.
+      const local = db()
+        .query("SELECT id, alias_value FROM entity_aliases ORDER BY id")
+        .all() as Array<{ id: string; alias_value: string }>;
+      expect(local).toHaveLength(1);
+      expect(local[0].id).toBe("a-1");
+      expect(local[0].alias_value).toBe(VALUE); // decrypted, not ciphertext
+    });
+
     it("a wrong passphrase does NOT unlock, and knowledge stays deferred", async () => {
       const client = clientFor(uid);
       keystore.setPassphrase("the-right-one", { params: FAST });

--- a/supabase/migrations/0041_encrypt_entities_caps.sql
+++ b/supabase/migrations/0041_encrypt_entities_caps.sql
@@ -1,0 +1,79 @@
+-- 0041_encrypt_entities_caps.sql
+-- Widen the entity-graph byte caps for wire encryption (C-4, #825).
+--
+-- Client-side encryption now seals the PII-bearing entity columns to a per-scope
+-- DEK and stores them as base64(envelope) on the wire (like knowledge.content in
+-- 0011):
+--   entities:         canonical_name, metadata
+--   entity_aliases:   alias_value
+--   entity_relations: relation, metadata
+--
+-- base64(envelope) inflates each sealed column: the envelope adds a fixed 47 bytes
+-- (31-byte header + 16-byte Poly1305 tag; XChaCha20 is a stream cipher so ciphertext
+-- length == plaintext length), then base64 expands ~4/3. CRUCIALLY, the old 0004 caps
+-- counted CHARACTERS (Postgres length() on text), but a UTF-8 char is up to 4 BYTES, so
+-- a value that fit the old char-limit could be up to 4× larger in bytes. To guarantee
+-- NO value that synced before gets poison-dropped now (a check_violation is classified
+-- "poison" and silently dropped from sync), size each sealed bound to the WORST CASE:
+--   ceil((old_chars * 4 + 47) / 3) * 4, rounded up.
+--     canonical_name  512  chars -> 2796  -> 3072
+--     alias_value     512  chars -> 2796  -> 3072
+--     relation        128  chars -> 748   -> 1024
+--     metadata        8192 chars -> 43756 -> 45056
+-- Generous per-row bounds are fine — the free-tier max_bytes AGGREGATE cap (below) is
+-- the real volume guard; these per-row CHECKs only reject pathological single values.
+--
+-- Only the SEALED columns' bounds change; every other bound is restated verbatim from
+-- 0004. Cleartext columns (entity_type, alias_type, source, ids, project_id,
+-- content_hash) are unchanged. Row caps are unchanged (encryption adds no rows).
+-- Idempotent.
+
+-- ---------------------------------------------------------------------------
+-- 1. Per-row size CHECK constraints (restated from 0004, sealed bounds widened
+--    to the worst-case ciphertext of the OLD character limit).
+-- ---------------------------------------------------------------------------
+alter table public.entities drop constraint if exists entities_size_ck;
+alter table public.entities add constraint entities_size_ck check (
+  length(canonical_name) <= 3072                                 -- 512 chars → 3072 (sealed)
+  and length(entity_type) <= 64
+  and (metadata is null or length(metadata) <= 45056)            -- 8192 chars → 45056 (sealed)
+  and (project_id is null or length(project_id) <= 1024)
+  and (content_hash is null or length(content_hash) <= 64)
+);
+
+alter table public.entity_aliases drop constraint if exists entity_aliases_size_ck;
+alter table public.entity_aliases add constraint entity_aliases_size_ck check (
+  length(alias_value) <= 3072                                    -- 512 chars → 3072 (sealed)
+  and length(alias_type) <= 64
+  and length(entity_id) <= 64
+  and (source is null or length(source) <= 256)
+  and (content_hash is null or length(content_hash) <= 64)
+);
+
+alter table public.entity_relations drop constraint if exists entity_relations_size_ck;
+alter table public.entity_relations add constraint entity_relations_size_ck check (
+  length(relation) <= 1024                                       -- 128 chars → 1024 (sealed)
+  and length(entity_a) <= 64
+  and length(entity_b) <= 64
+  and (source is null or length(source) <= 256)
+  and (metadata is null or length(metadata) <= 45056)            -- 8192 chars → 45056 (sealed)
+  and (content_hash is null or length(content_hash) <= 64)
+);
+
+-- ---------------------------------------------------------------------------
+-- 2. Free-tier max_bytes (per-scope AGGREGATE). Only the FREE tier carries byte
+--    caps (0007 set them for tier='free' only; pro's max_bytes is NULL =
+--    uncapped). Bump ~1.5× to preserve effective capacity for typical (mostly-
+--    ASCII) entity data post-encrypt. Unlike the per-row CHECK above, hitting
+--    this aggregate cap only PAUSES the table's sync (recoverable) — it is a
+--    volume guard, not a per-value correctness gate — so a 1.5× bump is the right
+--    tradeoff (a 4× worst-case bump would balloon the free storage allowance).
+-- ---------------------------------------------------------------------------
+update public.plan_limits set max_bytes = v.max_bytes
+  from (values
+    ('entities',          1572864::bigint),   -- 1 MB   → 1.5 MB
+    ('entity_aliases',    3145728::bigint),   -- 2 MB   → 3 MB
+    ('entity_relations',  3145728::bigint)    -- 2 MB   → 3 MB
+  ) as v(table_name, max_bytes)
+ where public.plan_limits.tier = 'free'
+   and public.plan_limits.table_name = v.table_name;


### PR DESCRIPTION
## Summary
Closes a real gap in the E2E-encryption guarantee: entity **names, aliases, and relation labels** were syncing to Supabase in **plaintext** while `knowledge.content` and the pro tables were already sealed. Confirmed live on the dev project (`entities.canonical_name = "MiniMax"`, `entity_aliases.alias_value = "Craft"` were plaintext while `knowledge.content` was a sealed envelope).

Seal the PII-bearing columns per-scope (same mechanism as `knowledge.content`):
| table | encrypted | left cleartext (why) |
|---|---|---|
| `entities` | `canonical_name`, `metadata` | `entity_type` (structural enum) |
| `entity_aliases` | `alias_value` | `alias_type` (enum), `source` (provenance) |
| `entity_relations` | `relation`, `metadata` | `entity_a`/`entity_b`/`source` (FK/provenance) |

## Why it's safe for convergence / FTS / hashing
- The remote has **no UNIQUE** on `(alias_type, alias_value)` / `(entity_a, entity_b, relation)` (PK is `(scope_id, id)`). Those UNIQUEs are **local-only**; cross-device convergence (#1234/#1236) runs on the **decrypted** local row.
- `content_hash` is computed over the **plaintext** row before encrypt (sync.ts), so hashes stay cross-device stable — no ping-pong.
- FTS indexes the decrypted local rows (encryption is push/pull-only).

## Two bugs caught in adversarial review (both fixed)
1. **Latent decrypt-drop**: `applyRemote`'s generic `applyRemoteUpsert` branch used `stripSyncCols(remote)` (ciphertext) instead of `decrypted ?? stripSyncCols(remote)` like every other encrypted table — it would have stored ciphertext locally. Harmless until a generic-path table got `encryptedColumns`.
2. **Convergence resolver fed ciphertext** (`handlePulledRowConstraint`): on a UNIQUE collision during pull the resolvers were passed the raw ciphertext `remote`, so their local lookup never matched → **devices stayed divergent** (silent #1234/#1236 regression). Fixed to decrypt the row before the resolver; `reapply` still passes the raw row (applyRemote re-decrypts). A throw here (locked/missing key) correctly propagates to the table-defer path.

## Migration 0041
Widens the sealed columns' per-row CHECK bounds to the **worst-case ciphertext of the old character limit** (UTF-8 up to 4 B/char; envelope +47 B; base64 ×4/3): `canonical_name`/`alias_value` 512→3072, `relation` 128→1024, both `metadata` 8192→45056 — so **no value that synced before gets poison-dropped**. Free-tier aggregate `max_bytes` bumped ~1.5× (entities 1→1.5 MB, aliases/relations 2→3 MB; a recoverable pause, not silent loss). Cleartext bounds + row caps unchanged.

## Verification (real Postgres 16, Docker)
- New engine test: device-1 encrypts the full entity graph → remote holds ciphertext for sealed cols + cleartext for structural cols → device-2 fresh-pull + unlock decrypts back to plaintext, no ping-pong.
- New **discriminating** test: two-device encrypted alias UNIQUE collision converges to the lower id (fails without the resolver-decrypt fix).
- Suites: engine 19, security 97, sync unit 163, alias/relation convergence 10 — all pass. typecheck (all packages) / format / lint clean.

## Post-merge deploy step (existing plaintext scrub)
~423 entity/alias rows are already on the remote in plaintext (`content_hash` is over plaintext → they won't re-push on their own). Per plan, scrub them with a one-time **remote wipe of the entity tables + client re-push** (local is source of truth) after this merges + migration 0041 deploys.